### PR TITLE
clean up and rename Initialization tags

### DIFF
--- a/docs/DevGuide/CreatingExecutables.md
+++ b/docs/DevGuide/CreatingExecutables.md
@@ -47,7 +47,7 @@ Parallel::GlobalCache (by specifying tags in the
 `const_global_cache_tags` type alias of the metavariables, component
 and action structs), to construct items in the db::DataBox of
 components during initialization (by specifying tags in the
-`initialization_tags` type alias of action struct), or be passed to
+`simple_tags_from_options` type alias of action struct), or be passed to
 the `allocate_array` function of an array component (by specifying
 tags in the `allocation_tags` type alias of the component).
 `SingletonHelloWorld` specifies a single option

--- a/docs/DevGuide/Parallelization.md
+++ b/docs/DevGuide/Parallelization.md
@@ -206,16 +206,16 @@ Each %Parallel Component struct must have the following type aliases:
    phase. If there are no iterable actions in a phase then a
    `PhaseAction` need not be specified for that phase. However, at
    least one `PhaseAction`, even if it is empty, must be specified.
-4. `using initialization_tags` which is a `tmpl::list` of all the tags
+4. `using simple_tags_from_options` which is a `tmpl::list` of all the tags
    that will be inserted into the initial `db::DataBox` of each component.
    These tags are db::SimpleTag%s that have have a `using option_tags`
    type alias and a static function `create_from_options` (see the
    example below).  This list can usually be constructed from the
    initialization actions of the component (i.e. the list of actions
    in the `PhaseAction` list for the `Initialization` phase) using the
-   helper function `Parallel::get_initialization_tags` (see the
+   helper function `Parallel::get_simple_tags_from_options` (see the
    examples of components below).  Each initialization action may
-   specify a type alias `using initialization_tags` which are a
+   specify a type alias `using simple_tags_from_options` which are a
    `tmpl::list` of tags that will be fetched from the db::DataBox by the
    action.
 5. `using const_global_cache_tags` is set to a `tmpl::list` of tags
@@ -257,7 +257,7 @@ signature of the `allocate_array` functions must be:
 \code
 static void allocate_array(
     Parallel::CProxy_GlobalCache<metavariables>& global_cache,
-    const tuples::tagged_tuple_from_typelist<initialization_tags>&
+    const tuples::tagged_tuple_from_typelist<simple_tags_from_options>&
     initialization_items,
     const std::unordered_set<size_t>& procs_to_ignore);
 \endcode
@@ -388,16 +388,16 @@ ResourceInfo:
 
 First is the `AvoidGlobalProc0` option. This will be available if any Array or
 Singleton component adds the `Parallel::Tags::AvoidGlobalProc0` tag to its
-`initialization_tags` type alias. This option will tell the program to not put
-*any* Array Elements or Singletons on the global zeroth charm-core. This core
-is sometimes used to write data to disk which is typically much slower than the
-program execution. The second is the `Singletons:` option. This will be
+`simple_tags_from_options` type alias. This option will tell the program to not
+put *any* Array Elements or Singletons on the global zeroth charm-core. This
+core is sometimes used to write data to disk which is typically much slower
+than the program execution. The second is the `Singletons:` option. This will be
 available for every Singleton that adds the `Parallel::Tags::SingletonInfo` tag
-to its `initialization_tags` type alias. `AhA` is the `pretty_type::name()` of
-a Singleton in the program and the user has a choice of which proc to place the
-Singleton on (`Auto` will let the program decide) and whether to exclude Array
-Elements or other Singletons from being put on this core. This is useful in
-case the Singleton does some expensive computation that shouldn't be slowed
+to its `simple_tags_from_options` type alias. `AhA` is the `pretty_type::name()`
+of a Singleton in the program and the user has a choice of which proc to place
+the Singleton on (`Auto` will let the program decide) and whether to exclude
+Array Elements or other Singletons from being put on this core. This is useful
+in case the Singleton does some expensive computation that shouldn't be slowed
 down by having lots of Array Elements on the same core. In the figure above,
 `AvoidGlobalProc0` is true, and `Sing. 2` requested to be exclusively on core
 `2`.

--- a/docs/DevGuide/Parallelization.md
+++ b/docs/DevGuide/Parallelization.md
@@ -223,10 +223,7 @@ Each %Parallel Component struct must have the following type aliases:
    component, or simple actions called on the parallel component.
    These tags correspond to const items that are stored in the
    Parallel::GlobalCache (of which there is one copy per Charm++
-   node).  The alias can be omitted if the list is empty.  (See
-   `array_allocation_tags` below for specifying tags needed for the
-   `allocate_array` function, but will not be added to the
-   Parallel::GlobalCache.)
+   node).  The alias can be omitted if the list is empty.
 6. `using mutable_global_cache_tags` is set to a `tmpl::list` of tags
    that correspond to mutable items that are stored in the
    Parallel::GlobalCache (of which there is one copy per Charm++
@@ -264,14 +261,16 @@ static void allocate_array(
 The `allocate_array` function is called by the Main parallel component
 when the execution starts and will typically insert elements into
 array parallel components. If the `allocate_array` function depends
-upon input options, the array component must specify a `using
-array_allocation_tags` type alias that is a `tmpl::list` of tags which
+upon input options that are not in the GlobalCache, the array component must
+include the appropriate tag in the `simple_tags_from_options` type alias.
+This type alias is a `tmpl::list` of tags which
 are db::SimpleTag%s that have have a `using option_tags` type alias
-and a static function `create_from_options`. If you want to ignore specific
+and a static function `create_from_options`. They only need to be explicitly
+added to the list if no initialization action has added them to its
+`simple_tags_from_options` type alias.  If you want to ignore specific
 processors when placing array elements, you can pass in a
 `std::unordered_set<size_t>` to `allocate_array` that contains all the
-processors that shouldn't have array elements on them. An example is:
-\snippet DistributedLinearSolverAlgorithmTestHelpers.hpp array_allocation_tag
+processors that shouldn't have array elements on them.
 
 The `allocate_array` functions of different
 array components are called in random order and so it is not safe to

--- a/docs/DevGuide/Parallelization.md
+++ b/docs/DevGuide/Parallelization.md
@@ -385,14 +385,13 @@ ResourceInfo:
       Exclusive: false
 ```
 
-First is the `AvoidGlobalProc0` option. This will be available if any Array or
-Singleton component adds the `Parallel::Tags::AvoidGlobalProc0` tag to its
-`simple_tags_from_options` type alias. This option will tell the program to not
+First is the `AvoidGlobalProc0` option. This option will tell the program to not
 put *any* Array Elements or Singletons on the global zeroth charm-core. This
 core is sometimes used to write data to disk which is typically much slower
-than the program execution. The second is the `Singletons:` option. This will be
-available for every Singleton that adds the `Parallel::Tags::SingletonInfo` tag
-to its `simple_tags_from_options` type alias. `AhA` is the `pretty_type::name()`
+than the program execution. The second is the `Singletons:` option. You can
+set the value to `Auto`, and then each singleton will have their proc be chosen
+automatically and they won't be exclusive.  Otherwise, you must specify options
+for each singleton as in the example above.  `AhA` is the `pretty_type::name()`
 of a Singleton in the program and the user has a choice of which proc to place
 the Singleton on (`Auto` will let the program decide) and whether to exclude
 Array Elements or other Singletons from being put on this core. This is useful
@@ -400,10 +399,6 @@ in case the Singleton does some expensive computation that shouldn't be slowed
 down by having lots of Array Elements on the same core. In the figure above,
 `AvoidGlobalProc0` is true, and `Sing. 2` requested to be exclusively on core
 `2`.
-
-\note If there are Singletons in your executable that don't have the
-`Parallel::Tags::SingletonInfo` tag, by default their proc will be chosen
-automatically and they won't be exclusive.
 
 # Actions {#dev_guide_parallelization_actions}
 

--- a/src/ControlSystem/Actions/Initialization.hpp
+++ b/src/ControlSystem/Actions/Initialization.hpp
@@ -49,7 +49,7 @@ template <typename Metavariables, typename ControlSystem>
 struct Initialize {
   static constexpr size_t deriv_order = ControlSystem::deriv_order;
 
-  using initialization_tags =
+  using simple_tags_from_options =
       tmpl::list<control_system::Tags::WriteDataToDisk,
                  control_system::Tags::Averager<ControlSystem>,
                  control_system::Tags::Controller<ControlSystem>,

--- a/src/ControlSystem/Component.hpp
+++ b/src/ControlSystem/Component.hpp
@@ -42,7 +42,7 @@ struct ControlComponent {
                                             Metavariables, ControlSystem>,
                                         Parallel::Actions::TerminatePhase>>>;
 
-  using initialization_tags = Parallel::get_initialization_tags<
+  using simple_tags_from_options = Parallel::get_simple_tags_from_options<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
 
   static void execute_next_phase(

--- a/src/Elliptic/DiscontinuousGalerkin/Actions/InitializeDomain.hpp
+++ b/src/Elliptic/DiscontinuousGalerkin/Actions/InitializeDomain.hpp
@@ -54,7 +54,7 @@ struct InitializeDomain {
   using InitializeGeometry = elliptic::dg::InitializeGeometry<Dim>;
 
  public:
-  using initialization_tags =
+  using simple_tags_from_options =
       tmpl::list<domain::Tags::InitialExtents<Dim>,
                  domain::Tags::InitialRefinementLevels<Dim>>;
   using simple_tags = typename InitializeGeometry::return_tags;

--- a/src/Elliptic/DiscontinuousGalerkin/DgElementArray.hpp
+++ b/src/Elliptic/DiscontinuousGalerkin/DgElementArray.hpp
@@ -25,7 +25,6 @@
 #include "Parallel/Phase.hpp"
 #include "Parallel/Printf.hpp"
 #include "Parallel/Protocols/ArrayElementsAllocator.hpp"
-#include "Parallel/Tags/ResourceInfo.hpp"
 #include "Utilities/Numeric.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/System/ParallelInfo.hpp"
@@ -138,9 +137,7 @@ struct DgElementArray {
   using phase_dependent_action_list = PhaseDepActionList;
   using array_index = ElementId<volume_dim>;
 
-  using const_global_cache_tags =
-      tmpl::list<domain::Tags::Domain<volume_dim>,
-                 Parallel::Tags::ResourceInfo<Metavariables>>;
+  using const_global_cache_tags = tmpl::list<domain::Tags::Domain<volume_dim>>;
 
   using array_allocation_tags =
       typename ElementsAllocator::template array_allocation_tags<
@@ -150,8 +147,7 @@ struct DgElementArray {
       tmpl::append<Parallel::get_simple_tags_from_options<
                        Parallel::get_initialization_actions_list<
                            phase_dependent_action_list>>,
-                   array_allocation_tags,
-                   tmpl::list<Parallel::Tags::AvoidGlobalProc0>>;
+                   array_allocation_tags>;
 
   static void allocate_array(
       Parallel::CProxy_GlobalCache<Metavariables>& global_cache,

--- a/src/Elliptic/DiscontinuousGalerkin/DgElementArray.hpp
+++ b/src/Elliptic/DiscontinuousGalerkin/DgElementArray.hpp
@@ -49,9 +49,7 @@ template <size_t Dim>
 struct DefaultElementsAllocator
     : tt::ConformsTo<Parallel::protocols::ArrayElementsAllocator> {
   template <typename ParallelComponent>
-  using array_allocation_tags =
-      tmpl::list<domain::Tags::InitialRefinementLevels<Dim>,
-                 domain::Tags::InitialExtents<Dim>>;
+  using array_allocation_tags = tmpl::list<>;
 
   template <typename ParallelComponent, typename Metavariables,
             typename... InitializationTags>
@@ -151,8 +149,8 @@ struct DgElementArray {
   using simple_tags_from_options =
       tmpl::append<Parallel::get_simple_tags_from_options<
                        Parallel::get_initialization_actions_list<
-                           phase_dependent_action_list>,
-                       array_allocation_tags>,
+                           phase_dependent_action_list>>,
+                   array_allocation_tags,
                    tmpl::list<Parallel::Tags::AvoidGlobalProc0>>;
 
   static void allocate_array(

--- a/src/Elliptic/DiscontinuousGalerkin/DgElementArray.hpp
+++ b/src/Elliptic/DiscontinuousGalerkin/DgElementArray.hpp
@@ -148,8 +148,8 @@ struct DgElementArray {
       typename ElementsAllocator::template array_allocation_tags<
           DgElementArray>;
 
-  using initialization_tags =
-      tmpl::append<Parallel::get_initialization_tags<
+  using simple_tags_from_options =
+      tmpl::append<Parallel::get_simple_tags_from_options<
                        Parallel::get_initialization_actions_list<
                            phase_dependent_action_list>,
                        array_allocation_tags>,
@@ -157,7 +157,7 @@ struct DgElementArray {
 
   static void allocate_array(
       Parallel::CProxy_GlobalCache<Metavariables>& global_cache,
-      const tuples::tagged_tuple_from_typelist<initialization_tags>&
+      const tuples::tagged_tuple_from_typelist<simple_tags_from_options>&
           initialization_items,
       const std::unordered_set<size_t>& procs_to_ignore = {}) {
     ElementsAllocator::template apply<DgElementArray>(

--- a/src/Elliptic/DiscontinuousGalerkin/SubdomainOperator/InitializeSubdomain.hpp
+++ b/src/Elliptic/DiscontinuousGalerkin/SubdomainOperator/InitializeSubdomain.hpp
@@ -148,7 +148,7 @@ struct InitializeSubdomain {
   using background_fields_external = typename System::background_fields;
 
  public:
-  using initialization_tags =
+  using simple_tags_from_options =
       tmpl::list<domain::Tags::InitialExtents<Dim>,
                  domain::Tags::InitialRefinementLevels<Dim>>;
   using const_global_cache_tags =

--- a/src/Evolution/Actions/RunEventsAndDenseTriggers.hpp
+++ b/src/Evolution/Actions/RunEventsAndDenseTriggers.hpp
@@ -290,7 +290,7 @@ struct RunEventsAndDenseTriggers {
 };
 
 struct InitializeRunEventsAndDenseTriggers {
-  using initialization_tags =
+  using simple_tags_from_options =
       tmpl::list<evolution::Tags::EventsAndDenseTriggers>;
   using simple_tags = tmpl::list<Tags::PreviousTriggerTime>;
 

--- a/src/Evolution/DiscontinuousGalerkin/DgElementArray.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/DgElementArray.hpp
@@ -23,7 +23,6 @@
 #include "Parallel/ParallelComponentHelpers.hpp"
 #include "Parallel/Phase.hpp"
 #include "Parallel/Printf.hpp"
-#include "Parallel/Tags/ResourceInfo.hpp"
 #include "Utilities/System/ParallelInfo.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TypeTraits/CreateHasStaticMemberVariable.hpp"
@@ -57,15 +56,10 @@ struct DgElementArray {
   using phase_dependent_action_list = PhaseDepActionList;
   using array_index = ElementId<volume_dim>;
 
-  using const_global_cache_tags =
-      tmpl::list<domain::Tags::Domain<volume_dim>,
-                 Parallel::Tags::ResourceInfo<Metavariables>>;
+  using const_global_cache_tags = tmpl::list<domain::Tags::Domain<volume_dim>>;
 
-  using simple_tags_from_options =
-      tmpl::append<Parallel::get_simple_tags_from_options<
-                       Parallel::get_initialization_actions_list<
-                           phase_dependent_action_list>>,
-                   tmpl::list<Parallel::Tags::AvoidGlobalProc0>>;
+  using simple_tags_from_options = Parallel::get_simple_tags_from_options<
+      Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
 
   static void allocate_array(
       Parallel::CProxy_GlobalCache<Metavariables>& global_cache,

--- a/src/Evolution/DiscontinuousGalerkin/DgElementArray.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/DgElementArray.hpp
@@ -61,15 +61,10 @@ struct DgElementArray {
       tmpl::list<domain::Tags::Domain<volume_dim>,
                  Parallel::Tags::ResourceInfo<Metavariables>>;
 
-  using array_allocation_tags =
-      tmpl::list<domain::Tags::InitialRefinementLevels<volume_dim>,
-                 domain::Tags::InitialExtents<volume_dim>>;
-
   using simple_tags_from_options =
       tmpl::append<Parallel::get_simple_tags_from_options<
                        Parallel::get_initialization_actions_list<
-                           phase_dependent_action_list>,
-                       array_allocation_tags>,
+                           phase_dependent_action_list>>,
                    tmpl::list<Parallel::Tags::AvoidGlobalProc0>>;
 
   static void allocate_array(

--- a/src/Evolution/DiscontinuousGalerkin/DgElementArray.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/DgElementArray.hpp
@@ -65,8 +65,8 @@ struct DgElementArray {
       tmpl::list<domain::Tags::InitialRefinementLevels<volume_dim>,
                  domain::Tags::InitialExtents<volume_dim>>;
 
-  using initialization_tags =
-      tmpl::append<Parallel::get_initialization_tags<
+  using simple_tags_from_options =
+      tmpl::append<Parallel::get_simple_tags_from_options<
                        Parallel::get_initialization_actions_list<
                            phase_dependent_action_list>,
                        array_allocation_tags>,
@@ -74,7 +74,7 @@ struct DgElementArray {
 
   static void allocate_array(
       Parallel::CProxy_GlobalCache<Metavariables>& global_cache,
-      const tuples::tagged_tuple_from_typelist<initialization_tags>&
+      const tuples::tagged_tuple_from_typelist<simple_tags_from_options>&
           initialization_items,
       const std::unordered_set<size_t>& procs_to_ignore = {});
 
@@ -90,7 +90,7 @@ struct DgElementArray {
 template <class Metavariables, class PhaseDepActionList>
 void DgElementArray<Metavariables, PhaseDepActionList>::allocate_array(
     Parallel::CProxy_GlobalCache<Metavariables>& global_cache,
-    const tuples::tagged_tuple_from_typelist<initialization_tags>&
+    const tuples::tagged_tuple_from_typelist<simple_tags_from_options>&
         initialization_items,
     const std::unordered_set<size_t>& procs_to_ignore) {
   auto& local_cache = *Parallel::local_branch(global_cache);

--- a/src/Evolution/DiscontinuousGalerkin/Initialization/Mortars.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Initialization/Mortars.hpp
@@ -94,8 +94,9 @@ struct Mortars {
   using MortarMap = std::unordered_map<Key, MappedType, boost::hash<Key>>;
 
  public:
-  using initialization_tags = tmpl::list<::domain::Tags::InitialExtents<Dim>,
-                                         evolution::dg::Tags::Quadrature>;
+  using simple_tags_from_options =
+      tmpl::list<::domain::Tags::InitialExtents<Dim>,
+                 evolution::dg::Tags::Quadrature>;
 
   using simple_tags = tmpl::list<
       Tags::MortarData<Dim>, Tags::MortarMesh<Dim>, Tags::MortarSize<Dim>,

--- a/src/Evolution/Initialization/DgDomain.hpp
+++ b/src/Evolution/Initialization/DgDomain.hpp
@@ -87,7 +87,7 @@ namespace Initialization {
  */
 template <size_t Dim, bool UseControlSystems = false>
 struct Domain {
-  using initialization_tags =
+  using simple_tags_from_options =
       tmpl::list<::domain::Tags::InitialExtents<Dim>,
                  ::domain::Tags::InitialRefinementLevels<Dim>,
                  evolution::dg::Tags::Quadrature>;

--- a/src/Evolution/Initialization/Evolution.hpp
+++ b/src/Evolution/Initialization/Evolution.hpp
@@ -80,7 +80,7 @@ namespace Actions {
 /// \note HistoryEvolvedVariables is allocated, but needs to be initialized
 template <typename Metavariables>
 struct TimeAndTimeStep {
-  using initialization_tags = tmpl::flatten<
+  using simple_tags_from_options = tmpl::flatten<
       tmpl::list<::Tags::Time, Tags::InitialTimeDelta,
                  Tags::InitialSlabSize<Metavariables::local_time_stepping>,
                  tmpl::conditional_t<

--- a/src/Evolution/Initialization/GrTagsForHydro.hpp
+++ b/src/Evolution/Initialization/GrTagsForHydro.hpp
@@ -62,7 +62,7 @@ namespace Actions {
 /// - Modifies: nothing
 template <typename System>
 struct GrTagsForHydro {
-  using initialization_tags = tmpl::list<::Tags::Time>;
+  using simple_tags_from_options = tmpl::list<::Tags::Time>;
 
   static constexpr size_t dim = System::volume_dim;
   using gr_tag = typename System::spacetime_variables_tag;

--- a/src/Evolution/Initialization/SetVariables.hpp
+++ b/src/Evolution/Initialization/SetVariables.hpp
@@ -56,7 +56,7 @@ namespace Actions {
 ///   * System::primitive_variables_tag (if system has primitive variables)
 template <typename LogicalCoordinatesTag>
 struct SetVariables {
-  using initialization_tags = tmpl::list<::Tags::Time>;
+  using simple_tags_from_options = tmpl::list<::Tags::Time>;
 
   template <typename DbTagsList, typename... InboxTags, typename Metavariables,
             typename ArrayIndex, typename ActionList,

--- a/src/Evolution/Systems/Cce/Actions/InitializeCharacteristicEvolutionScri.hpp
+++ b/src/Evolution/Systems/Cce/Actions/InitializeCharacteristicEvolutionScri.hpp
@@ -45,7 +45,7 @@ namespace Actions {
  */
 template <typename ScriValuesToObserve, typename BoundaryComponent>
 struct InitializeCharacteristicEvolutionScri {
-  using initialization_tags = tmpl::flatten<tmpl::list<
+  using simple_tags_from_options = tmpl::flatten<tmpl::list<
       InitializationTags::ScriInterpolationOrder,
       tmpl::conditional_t<
           tt::is_a_v<AnalyticWorldtubeBoundary, BoundaryComponent>,

--- a/src/Evolution/Systems/Cce/Actions/InitializeCharacteristicEvolutionTime.hpp
+++ b/src/Evolution/Systems/Cce/Actions/InitializeCharacteristicEvolutionTime.hpp
@@ -61,7 +61,7 @@ namespace Actions {
 template <typename EvolvedCoordinatesVariablesTag, typename EvolvedSwshTag,
           bool local_time_stepping>
 struct InitializeCharacteristicEvolutionTime {
-  using initialization_tags = tmpl::flatten<
+  using simple_tags_from_options = tmpl::flatten<
       tmpl::list<Initialization::Tags::InitialSlabSize<local_time_stepping>,
                  Tags::CceEvolutionPrefix<::Tags::TimeStepper<LtsTimeStepper>>,
                  Tags::CceEvolutionPrefix<::Tags::StepChoosers>,

--- a/src/Evolution/Systems/Cce/Actions/InitializeWorldtubeBoundary.hpp
+++ b/src/Evolution/Systems/Cce/Actions/InitializeWorldtubeBoundary.hpp
@@ -46,7 +46,7 @@ namespace detail {
 template <typename Initializer, typename ManagerTags,
           typename BoundaryCommunicationTagsList>
 struct InitializeWorldtubeBoundaryBase {
-  using initialization_tags = ManagerTags;
+  using simple_tags_from_options = ManagerTags;
   using const_global_cache_tags = tmpl::list<Tags::LMax>;
 
   using simple_tags =
@@ -127,7 +127,7 @@ struct InitializeWorldtubeBoundary<H5WorldtubeBoundary<Metavariables>>
   using typename base_type::simple_tags;
   using const_global_cache_tags =
       tmpl::list<Tags::LMax, Tags::EndTimeFromFile, Tags::StartTimeFromFile>;
-  using typename base_type::initialization_tags;
+  using typename base_type::simple_tags_from_options;
 };
 
 /*!
@@ -163,7 +163,7 @@ struct InitializeWorldtubeBoundary<GhWorldtubeBoundary<Metavariables>>
   using const_global_cache_tags =
       tmpl::list<Tags::LMax, InitializationTags::ExtractionRadius,
                  Tags::NoEndTime, Tags::SpecifiedStartTime>;
-  using typename base_type::initialization_tags;
+  using typename base_type::simple_tags_from_options;
 };
 
 /*!
@@ -203,7 +203,7 @@ struct InitializeWorldtubeBoundary<AnalyticWorldtubeBoundary<Metavariables>>
   using typename base_type::simple_tags;
   using const_global_cache_tags =
       tmpl::list<Tags::LMax, Tags::SpecifiedEndTime, Tags::SpecifiedStartTime>;
-  using typename base_type::initialization_tags;
+  using typename base_type::simple_tags_from_options;
 };
 }  // namespace Actions
 }  // namespace Cce

--- a/src/Evolution/Systems/Cce/Components/CharacteristicEvolution.hpp
+++ b/src/Evolution/Systems/Cce/Components/CharacteristicEvolution.hpp
@@ -29,7 +29,6 @@
 #include "Parallel/GlobalCache.hpp"
 #include "Parallel/Local.hpp"
 #include "Parallel/Phase.hpp"
-#include "Parallel/Tags/ResourceInfo.hpp"
 #include "ParallelAlgorithms/Actions/Goto.hpp"
 #include "ParallelAlgorithms/Actions/MutateApply.hpp"
 #include "ParallelAlgorithms/Actions/TerminatePhase.hpp"
@@ -111,9 +110,8 @@ struct CharacteristicEvolution {
           typename Metavariables::cce_boundary_component>,
       Parallel::Actions::TerminatePhase>;
 
-  using simple_tags_from_options = tmpl::push_back<
-      Parallel::get_simple_tags_from_options<initialize_action_list>,
-      Parallel::Tags::SingletonInfo<CharacteristicEvolution<Metavariables>>>;
+  using simple_tags_from_options =
+      Parallel::get_simple_tags_from_options<initialize_action_list>;
 
   // the list of actions that occur for each of the hypersurface-integrated
   // Bondi tags

--- a/src/Evolution/Systems/Cce/Components/CharacteristicEvolution.hpp
+++ b/src/Evolution/Systems/Cce/Components/CharacteristicEvolution.hpp
@@ -111,8 +111,8 @@ struct CharacteristicEvolution {
           typename Metavariables::cce_boundary_component>,
       Parallel::Actions::TerminatePhase>;
 
-  using initialization_tags = tmpl::push_back<
-      Parallel::get_initialization_tags<initialize_action_list>,
+  using simple_tags_from_options = tmpl::push_back<
+      Parallel::get_simple_tags_from_options<initialize_action_list>,
       Parallel::Tags::SingletonInfo<CharacteristicEvolution<Metavariables>>>;
 
   // the list of actions that occur for each of the hypersurface-integrated

--- a/src/Evolution/Systems/Cce/Components/WorldtubeBoundary.hpp
+++ b/src/Evolution/Systems/Cce/Components/WorldtubeBoundary.hpp
@@ -9,7 +9,6 @@
 #include "Parallel/Invoke.hpp"
 #include "Parallel/Local.hpp"
 #include "Parallel/Phase.hpp"
-#include "Parallel/Tags/ResourceInfo.hpp"
 #include "ParallelAlgorithms/Actions/TerminatePhase.hpp"
 
 namespace Cce {
@@ -26,9 +25,8 @@ struct WorldtubeComponentBase {
       tmpl::list<Actions::InitializeWorldtubeBoundary<WorldtubeComponent>,
                  Parallel::Actions::TerminatePhase>;
 
-  using simple_tags_from_options = tmpl::push_back<
-      Parallel::get_simple_tags_from_options<initialize_action_list>,
-      Parallel::Tags::SingletonInfo<WorldtubeComponent>>;
+  using simple_tags_from_options =
+      Parallel::get_simple_tags_from_options<initialize_action_list>;
 
   using worldtube_boundary_computation_steps = tmpl::list<>;
 

--- a/src/Evolution/Systems/Cce/Components/WorldtubeBoundary.hpp
+++ b/src/Evolution/Systems/Cce/Components/WorldtubeBoundary.hpp
@@ -26,9 +26,9 @@ struct WorldtubeComponentBase {
       tmpl::list<Actions::InitializeWorldtubeBoundary<WorldtubeComponent>,
                  Parallel::Actions::TerminatePhase>;
 
-  using initialization_tags =
-      tmpl::push_back<Parallel::get_initialization_tags<initialize_action_list>,
-                      Parallel::Tags::SingletonInfo<WorldtubeComponent>>;
+  using simple_tags_from_options = tmpl::push_back<
+      Parallel::get_simple_tags_from_options<initialize_action_list>,
+      Parallel::Tags::SingletonInfo<WorldtubeComponent>>;
 
   using worldtube_boundary_computation_steps = tmpl::list<>;
 
@@ -87,10 +87,10 @@ struct H5WorldtubeBoundary
   using typename base_type::chare_type;
   using const_global_cache_tags = tmpl::list<Tags::InitializeJ<
       Metavariables::uses_partially_flat_cartesian_coordinates>>;
-  using typename base_type::initialization_tags;
   using typename base_type::metavariables;
   using typename base_type::options;
   using typename base_type::phase_dependent_action_list;
+  using typename base_type::simple_tags_from_options;
   using end_time_tag = Tags::EndTimeFromFile;
 };
 
@@ -129,10 +129,10 @@ struct AnalyticWorldtubeBoundary
   using base_type::initialize;
   using typename base_type::chare_type;
   using const_global_cache_tags = tmpl::list<Tags::AnalyticInitializeJ>;
-  using typename base_type::initialization_tags;
   using typename base_type::metavariables;
   using typename base_type::options;
   using typename base_type::phase_dependent_action_list;
+  using typename base_type::simple_tags_from_options;
   using end_time_tag = Tags::SpecifiedEndTime;
 };
 
@@ -172,10 +172,10 @@ struct GhWorldtubeBoundary
   using typename base_type::chare_type;
   using const_global_cache_tags = tmpl::list<Tags::InitializeJ<
       Metavariables::uses_partially_flat_cartesian_coordinates>>;
-  using typename base_type::initialization_tags;
   using typename base_type::metavariables;
   using typename base_type::options;
   using typename base_type::phase_dependent_action_list;
+  using typename base_type::simple_tags_from_options;
   using end_time_tag = Tags::NoEndTime;
 };
 }  // namespace Cce

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/GrTagsForHydro.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/GrTagsForHydro.hpp
@@ -71,7 +71,7 @@ namespace subcell {
  */
 template <typename System, size_t Dim>
 struct GrTagsForHydro {
-  using initialization_tags = tmpl::list<::Tags::Time>;
+  using simple_tags_from_options = tmpl::list<::Tags::Time>;
 
   using gr_tag = typename System::spacetime_variables_tag;
   using subcell_gr_tag = evolution::dg::subcell::Tags::Inactive<gr_tag>;

--- a/src/Evolution/Systems/ScalarAdvection/Subcell/VelocityAtFace.hpp
+++ b/src/Evolution/Systems/ScalarAdvection/Subcell/VelocityAtFace.hpp
@@ -67,7 +67,7 @@ namespace ScalarAdvection::subcell {
  */
 template <size_t Dim>
 struct VelocityAtFace {
-  using initialization_tags = tmpl::list<::Tags::Time>;
+  using simple_tags_from_options = tmpl::list<::Tags::Time>;
 
   using velocity_field = ::ScalarAdvection::Tags::VelocityField<Dim>;
   using subcell_velocity_field =

--- a/src/Executables/Examples/HelloWorld/SingletonHelloWorld.hpp
+++ b/src/Executables/Examples/HelloWorld/SingletonHelloWorld.hpp
@@ -72,7 +72,7 @@ struct HelloWorld {
   using metavariables = Metavariables;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<Parallel::Phase::Execute, tmpl::list<>>>;
-  using initialization_tags = Parallel::get_initialization_tags<
+  using simple_tags_from_options = Parallel::get_simple_tags_from_options<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
   static void execute_next_phase(
       const Parallel::Phase next_phase,

--- a/src/IO/Importers/ElementDataReader.hpp
+++ b/src/IO/Importers/ElementDataReader.hpp
@@ -43,7 +43,7 @@ struct ElementDataReader {
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<Parallel::Phase::Initialization,
                              tmpl::list<detail::InitializeElementDataReader>>>;
-  using initialization_tags = Parallel::get_initialization_tags<
+  using simple_tags_from_options = Parallel::get_simple_tags_from_options<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
 
   static void initialize(

--- a/src/IO/Observer/ObserverComponent.hpp
+++ b/src/IO/Observer/ObserverComponent.hpp
@@ -34,7 +34,7 @@ struct Observer {
       Parallel::PhaseActions<Parallel::Phase::Initialization,
                              tmpl::list<Actions::Initialize<Metavariables>,
                                         Parallel::Actions::TerminatePhase>>>;
-  using initialization_tags = Parallel::get_initialization_tags<
+  using simple_tags_from_options = Parallel::get_simple_tags_from_options<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
 
   static void execute_next_phase(
@@ -58,7 +58,7 @@ struct ObserverWriter {
       Parallel::Phase::Initialization,
       tmpl::list<Actions::InitializeWriter<Metavariables>,
                  Parallel::Actions::TerminatePhase>>>;
-  using initialization_tags = Parallel::get_initialization_tags<
+  using simple_tags_from_options = Parallel::get_simple_tags_from_options<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
 
   static void execute_next_phase(

--- a/src/Parallel/Algorithms/AlgorithmArray.ci
+++ b/src/Parallel/Algorithms/AlgorithmArray.ci
@@ -26,7 +26,7 @@ module AlgorithmArray {
     entry AlgorithmArray(
         Parallel::CProxy_GlobalCache<typename ParallelComponent::metavariables>,
         tuples::tagged_tuple_from_typelist<
-            typename ParallelComponent::initialization_tags>
+            typename ParallelComponent::simple_tags_from_options>
             initialization_items);
 
     entry AlgorithmArray(

--- a/src/Parallel/Algorithms/AlgorithmGroup.ci
+++ b/src/Parallel/Algorithms/AlgorithmGroup.ci
@@ -12,7 +12,7 @@ module AlgorithmGroup {
     entry AlgorithmGroup(
         Parallel::CProxy_GlobalCache<typename ParallelComponent::metavariables>,
         tuples::tagged_tuple_from_typelist<
-            typename ParallelComponent::initialization_tags>
+            typename ParallelComponent::simple_tags_from_options>
             initialization_items);
 
     template <typename Action, typename... Args>

--- a/src/Parallel/Algorithms/AlgorithmNodegroup.ci
+++ b/src/Parallel/Algorithms/AlgorithmNodegroup.ci
@@ -12,7 +12,7 @@ module AlgorithmNodegroup {
     entry AlgorithmNodegroup(
         Parallel::CProxy_GlobalCache<typename ParallelComponent::metavariables>,
         tuples::tagged_tuple_from_typelist<
-            typename ParallelComponent::initialization_tags>
+            typename ParallelComponent::simple_tags_from_options>
             initialization_items);
 
     template <typename Action, typename... Args>

--- a/src/Parallel/Algorithms/AlgorithmSingleton.ci
+++ b/src/Parallel/Algorithms/AlgorithmSingleton.ci
@@ -13,7 +13,7 @@ module AlgorithmSingleton {
     entry AlgorithmSingleton(
         Parallel::CProxy_GlobalCache<typename ParallelComponent::metavariables>,
         tuples::tagged_tuple_from_typelist<
-            typename ParallelComponent::initialization_tags>
+            typename ParallelComponent::simple_tags_from_options>
             initialization_items);
 
     template <typename Action, typename... Args>

--- a/src/Parallel/DistributedObject.hpp
+++ b/src/Parallel/DistributedObject.hpp
@@ -200,6 +200,7 @@ class DistributedObject<ParallelComponent,
       Tags::GlobalCacheProxy<metavariables>,
       typename parallel_component::simple_tags_from_options,
       Tags::GlobalCacheImplCompute<metavariables>,
+      Tags::ResourceInfoReference<metavariables>,
       db::wrap_tags_in<Tags::FromGlobalCache, all_cache_tags>,
       Algorithm_detail::action_list_simple_tags<parallel_component>,
       Algorithm_detail::action_list_compute_tags<parallel_component>>>>;

--- a/src/Parallel/DistributedObject.hpp
+++ b/src/Parallel/DistributedObject.hpp
@@ -198,7 +198,7 @@ class DistributedObject<ParallelComponent,
   using databox_type = db::compute_databox_type<tmpl::flatten<tmpl::list<
       Tags::MetavariablesImpl<metavariables>,
       Tags::GlobalCacheProxy<metavariables>,
-      typename parallel_component::initialization_tags,
+      typename parallel_component::simple_tags_from_options,
       Tags::GlobalCacheImplCompute<metavariables>,
       db::wrap_tags_in<Tags::FromGlobalCache, all_cache_tags>,
       Algorithm_detail::action_list_simple_tags<parallel_component>,

--- a/src/Parallel/Main.hpp
+++ b/src/Parallel/Main.hpp
@@ -158,9 +158,8 @@ class Main : public CBase_Main<Metavariables> {
   void check_if_component_terminated_correctly();
 
   template <typename ParallelComponent>
-  using parallel_component_options =
-      Parallel::get_option_tags<typename ParallelComponent::initialization_tags,
-                                Metavariables>;
+  using parallel_component_options = Parallel::get_option_tags<
+      typename ParallelComponent::simple_tags_from_options, Metavariables>;
   using option_list = tmpl::remove_duplicates<tmpl::flatten<tmpl::list<
       Parallel::get_option_tags<const_global_cache_tags, Metavariables>,
       Parallel::get_option_tags<mutable_global_cache_tags, Metavariables>,
@@ -531,7 +530,8 @@ Main<Metavariables>::Main(CkArgMsg* msg) {
         ParallelComponentProxy::ckNew(
             global_cache_proxy_,
             Parallel::create_from_options<Metavariables>(
-                options_, typename parallel_component::initialization_tags{}),
+                options_,
+                typename parallel_component::simple_tags_from_options{}),
             &global_cache_dependency);
   });
 
@@ -653,7 +653,7 @@ void Main<Metavariables>::
     auto& singleton_proxy =
         Parallel::get_parallel_component<singleton_component>(local_cache);
     auto options = Parallel::create_from_options<Metavariables>(
-        options_, typename singleton_component::initialization_tags{});
+        options_, typename singleton_component::simple_tags_from_options{});
 
     const size_t proc = resource_info_.template proc_for<singleton_component>();
     singleton_proxy[0].insert(global_cache_proxy_, std::move(options), proc);
@@ -668,7 +668,7 @@ void Main<Metavariables>::
     parallel_component::allocate_array(
         global_cache_proxy_,
         Parallel::create_from_options<Metavariables>(
-            options_, typename parallel_component::initialization_tags{}),
+            options_, typename parallel_component::simple_tags_from_options{}),
         resource_info_.procs_to_ignore());
   });
 

--- a/src/Parallel/MemoryMonitor/MemoryMonitor.hpp
+++ b/src/Parallel/MemoryMonitor/MemoryMonitor.hpp
@@ -49,7 +49,7 @@ struct MemoryMonitor {
                      mem_monitor::detail::InitializeMutator>,
                  Parallel::Actions::TerminatePhase>>>;
 
-  using initialization_tags = Parallel::get_initialization_tags<
+  using simple_tags_from_options = Parallel::get_simple_tags_from_options<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
 
   static void execute_next_phase(

--- a/src/Parallel/ParallelComponentHelpers.hpp
+++ b/src/Parallel/ParallelComponentHelpers.hpp
@@ -251,55 +251,54 @@ using get_initialization_actions_list = tmpl::flatten<tmpl::transform<
 
 namespace detail {
 template <typename Action, typename = std::void_t<>>
-struct get_initialization_tags_from_action {
+struct get_simple_tags_from_options_from_action {
   using type = tmpl::list<>;
 };
 
 template <typename Action>
-struct get_initialization_tags_from_action<
-    Action, std::void_t<typename Action::initialization_tags>> {
-  using type = typename Action::initialization_tags;
+struct get_simple_tags_from_options_from_action<
+    Action, std::void_t<typename Action::simple_tags_from_options>> {
+  using type = typename Action::simple_tags_from_options;
 };
 }  // namespace detail
 
 /// \ingroup ParallelGroup
 /// \brief Given a list of initialization actions, and possibly a list of tags
 /// needed for allocation of an array component, returns a list of the
-/// unique initialization_tags for all the actions (and the allocate function).
+/// unique simple_tags_from_options for all the actions (and the allocate
+/// function).
 template <typename InitializationActionsList,
           typename AllocationTagsList = tmpl::list<>>
-using get_initialization_tags = tmpl::remove_duplicates<tmpl::flatten<
+using get_simple_tags_from_options = tmpl::remove_duplicates<tmpl::flatten<
     tmpl::list<AllocationTagsList,
-               tmpl::transform<
-                   InitializationActionsList,
-                   detail::get_initialization_tags_from_action<tmpl::_1>>>>>;
+               tmpl::transform<InitializationActionsList,
+                               detail::get_simple_tags_from_options_from_action<
+                                   tmpl::_1>>>>>;
 
 namespace detail {
-template <typename InitializationTag, typename Metavariables,
-          bool PassMetavariables = InitializationTag::pass_metavariables>
-struct get_option_tags_from_initialization_tag_impl {
-  using type = typename InitializationTag::option_tags;
+template <typename SimpleTag, typename Metavariables,
+          bool PassMetavariables = SimpleTag::pass_metavariables>
+struct get_option_tags_from_simple_tag_impl {
+  using type = typename SimpleTag::option_tags;
 };
-template <typename InitializationTag, typename Metavariables>
-struct get_option_tags_from_initialization_tag_impl<InitializationTag,
-                                                    Metavariables, true> {
-  using type = typename InitializationTag::template option_tags<Metavariables>;
+template <typename SimpleTag, typename Metavariables>
+struct get_option_tags_from_simple_tag_impl<SimpleTag, Metavariables, true> {
+  using type = typename SimpleTag::template option_tags<Metavariables>;
 };
 template <typename Metavariables>
-struct get_option_tags_from_initialization_tag {
-  template <typename InitializationTag>
-  using f = tmpl::type_from<get_option_tags_from_initialization_tag_impl<
-      InitializationTag, Metavariables>>;
+struct get_option_tags_from_simple_tag {
+  template <typename SimpleTag>
+  using f = tmpl::type_from<
+      get_option_tags_from_simple_tag_impl<SimpleTag, Metavariables>>;
 };
 }  // namespace detail
 
 /// \ingroup ParallelGroup
-/// \brief Given a list of initialization tags, returns a list of the
+/// \brief Given a list of simple tags, returns a list of the
 /// unique option tags required to construct them.
-template <typename InitializationTagsList, typename Metavariables>
-using get_option_tags = tmpl::remove_duplicates<tmpl::flatten<
-    tmpl::transform<InitializationTagsList,
-                    tmpl::bind<detail::get_option_tags_from_initialization_tag<
+template <typename SimpleTagsList, typename Metavariables>
+using get_option_tags = tmpl::remove_duplicates<tmpl::flatten<tmpl::transform<
+    SimpleTagsList, tmpl::bind<detail::get_option_tags_from_simple_tag<
                                    Metavariables>::template f,
                                tmpl::_1>>>>;
 

--- a/src/Parallel/ParallelComponentHelpers.hpp
+++ b/src/Parallel/ParallelComponentHelpers.hpp
@@ -263,17 +263,13 @@ struct get_simple_tags_from_options_from_action<
 }  // namespace detail
 
 /// \ingroup ParallelGroup
-/// \brief Given a list of initialization actions, and possibly a list of tags
-/// needed for allocation of an array component, returns a list of the
-/// unique simple_tags_from_options for all the actions (and the allocate
-/// function).
-template <typename InitializationActionsList,
-          typename AllocationTagsList = tmpl::list<>>
-using get_simple_tags_from_options = tmpl::remove_duplicates<tmpl::flatten<
-    tmpl::list<AllocationTagsList,
-               tmpl::transform<InitializationActionsList,
-                               detail::get_simple_tags_from_options_from_action<
-                                   tmpl::_1>>>>>;
+/// \brief Given a list of initialization actions, returns a list of the
+/// unique simple_tags_from_options for all the actions.
+template <typename InitializationActionsList>
+using get_simple_tags_from_options =
+    tmpl::remove_duplicates<tmpl::flatten<tmpl::transform<
+        InitializationActionsList,
+        detail::get_simple_tags_from_options_from_action<tmpl::_1>>>>;
 
 namespace detail {
 template <typename SimpleTag, typename Metavariables,

--- a/src/Parallel/ResourceInfo.hpp
+++ b/src/Parallel/ResourceInfo.hpp
@@ -249,24 +249,24 @@ bool operator!=(const SingletonPack<tmpl::list<Components...>>& lhs,
 namespace detail {
 // This whole gymnastics with type aliases is necessary because ResourceInfo is
 // inside the GlobalCache. There are a lot of places that use the GlobalCache
-// that haven't defined the initialization_tags type alias (like the testing
-// framework). And even though we don't call the entry method on the GlobalCache
-// related to ResourceInfo, all the type aliases inside ResourceInfo are still
-// constructed regardless. So rather than changing every mock component to have
-// an empty type alias, we just treat no type alias as not having the tag we are
-// looking for.
-CREATE_HAS_TYPE_ALIAS(initialization_tags)
-CREATE_HAS_TYPE_ALIAS_V(initialization_tags)
+// that haven't defined the simple_tags_from_options type alias (like the
+// testing framework). And even though we don't call the entry method on the
+// GlobalCache related to ResourceInfo, all the type aliases inside ResourceInfo
+// are still constructed regardless. So rather than changing every mock
+// component to have an empty type alias, we just treat no type alias as not
+// having the tag we are looking for.
+CREATE_HAS_TYPE_ALIAS(simple_tags_from_options)
+CREATE_HAS_TYPE_ALIAS_V(simple_tags_from_options)
 
 template <typename Component, typename Tag,
-          bool HasInitializationTags = has_initialization_tags_v<Component>>
+          bool HasInitializationTags =
+              has_simple_tags_from_options_v<Component>>
 struct has_tag : std::false_type {};
 
 template <typename Component, typename Tag>
 struct has_tag<Component, Tag, true>
-    : std::bool_constant<
-          tmpl::list_contains_v<typename Component::initialization_tags, Tag>> {
-};
+    : std::bool_constant<tmpl::list_contains_v<
+          typename Component::simple_tags_from_options, Tag>> {};
 
 template <typename Component>
 using component_has_singleton_info_tag =
@@ -312,13 +312,13 @@ constexpr bool using_resource_info =
  *
  * \details This can be used for placing all singletons in an executable. To
  * have a singleton specify resource information, add the
- * `Parallel::Tags::SingletonInfo` tag to the `initialization_tags` type alias
- * in the singleton. To specify whether to avoid placing array elements and
- * singletons on the global proc 0, add the `Parallel::Tags::AvoidGlobalProc0`
- * tag to the `initialization_tags` of the parallel components in your
- * executable. If you don't want either of these things and just want access to
- * the ResourceInfo, add the `Parallel::Tags::ResourceInfo` tag to the const
- * global cache tags.
+ * `Parallel::Tags::SingletonInfo` tag to the `simple_tags_from_options` type
+ * alias in the singleton. To specify whether to avoid placing array elements
+ * and singletons on the global proc 0, add the
+ * `Parallel::Tags::AvoidGlobalProc0` tag to the `simple_tags_from_options` of
+ * the parallel components in your executable. If you don't want either of these
+ * things and just want access to the ResourceInfo, add the
+ * `Parallel::Tags::ResourceInfo` tag to the const global cache tags.
  *
  * If you only add the `Parallel::Tags::ResourceInfo` tag to the const global
  * cache tags, you'll need the following block in the input file:

--- a/src/Parallel/Tags/ResourceInfo.hpp
+++ b/src/Parallel/Tags/ResourceInfo.hpp
@@ -7,12 +7,12 @@
 
 #include "DataStructures/DataBox/Tag.hpp"
 #include "Options/Options.hpp"
-#include "Parallel/ResourceInfo.hpp"
-#include "Utilities/PrettyType.hpp"
-#include "Utilities/System/ParallelInfo.hpp"
-#include "Utilities/TMPL.hpp"
 
 namespace Parallel {
+/// \cond
+template <typename Metavariables>
+struct ResourceInfo;
+/// \endcond
 namespace OptionTags {
 /// \ingroup ParallelGroup
 /// Options group for resource allocation
@@ -28,71 +28,10 @@ struct ResourceInfo {
 
 namespace Tags {
 /// \ingroup ParallelGroup
-/// Tag that tells whether to avoid placing Singleton and Array components
-/// on the global proc 0
-///
-/// We include this tag in addition to Parallel::Tags::ResourceInfo even though
-/// this tag's info is contained in Parallel::Tags::ResourceInfo because this
-/// tag will inform what the input file looks like
-struct AvoidGlobalProc0 : db::SimpleTag {
-  using type = bool;
-  template <typename Metavariables>
-  using option_tags =
-      tmpl::list<Parallel::OptionTags::ResourceInfo<Metavariables>>;
-
-  static constexpr bool pass_metavariables = true;
-  template <typename Metavariables>
-  static bool create_from_options(
-      const Parallel::ResourceInfo<Metavariables>& resource_info) {
-    return resource_info.avoid_global_proc_0();
-  }
-};
-
-/// \ingroup ParallelGroup
-/// Tag that holds resource info about a singleton.
-template <typename ParallelComponent>
-struct SingletonInfo : db::SimpleTag {
-  using type = Parallel::SingletonInfoHolder<ParallelComponent>;
-  static std::string name() { return pretty_type::name<ParallelComponent>(); }
-
-  static constexpr bool pass_metavariables = true;
-
-  template <typename Metavariables>
-  using option_tags =
-      tmpl::list<Parallel::OptionTags::ResourceInfo<Metavariables>>;
-
-  template <typename Metavariables>
-  static type create_from_options(
-      const Parallel::ResourceInfo<Metavariables>& resource_info) {
-    return resource_info.template get_singleton_info<ParallelComponent>();
-  }
-};
-
-/// \ingroup ParallelGroup
 /// Tag to retrieve the ResourceInfo.
-///
-/// \details This tag is meant to be used in the GlobalCache. It can be created
-/// from options, but since it must be specially created inside Main and
-/// assigned to the GlobalCache after all the global cache tags are created from
-/// options, the return of `create_from_options` is just a default constructed
-/// Parallel::ResourceInfo.
 template <typename Metavariables>
 struct ResourceInfo : db::SimpleTag {
   using type = Parallel::ResourceInfo<Metavariables>;
-
-  static constexpr bool pass_metavariables = true;
-
-  // The option tag is needed to force it's inclusion in the input file, but we
-  // don't actually use its value to create from options. See docs for this tag
-  // for an explanation.
-  template <typename Metavars>
-  using option_tags = tmpl::list<Parallel::OptionTags::ResourceInfo<Metavars>>;
-
-  template <typename Metavars>
-  static type create_from_options(
-      const Parallel::ResourceInfo<Metavars>& /*resource_info*/) {
-    return type{};
-  }
 };
 }  // namespace Tags
 }  // namespace Parallel

--- a/src/ParallelAlgorithms/Interpolation/InterpolationTarget.hpp
+++ b/src/ParallelAlgorithms/Interpolation/InterpolationTarget.hpp
@@ -12,7 +12,6 @@
 #include "Parallel/ParallelComponentHelpers.hpp"
 #include "Parallel/Phase.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
-#include "Parallel/Tags/ResourceInfo.hpp"
 #include "ParallelAlgorithms/Actions/TerminatePhase.hpp"
 #include "ParallelAlgorithms/Interpolation/Actions/InterpolationTargetSendPoints.hpp"
 #include "ParallelAlgorithms/Interpolation/Protocols/InterpolationTargetTag.hpp"
@@ -290,12 +289,8 @@ struct InterpolationTarget {
                           InterpolationTargetTag>>>,
               Parallel::Actions::TerminatePhase>>>;
 
-  using simple_tags_from_options =
-      tmpl::append<Parallel::get_simple_tags_from_options<
-                       Parallel::get_initialization_actions_list<
-                           phase_dependent_action_list>>,
-                   tmpl::list<Parallel::Tags::SingletonInfo<InterpolationTarget<
-                       Metavariables, InterpolationTargetTag>>>>;
+  using simple_tags_from_options = Parallel::get_simple_tags_from_options<
+      Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
 
   static void execute_next_phase(
       Parallel::Phase next_phase,

--- a/src/ParallelAlgorithms/Interpolation/InterpolationTarget.hpp
+++ b/src/ParallelAlgorithms/Interpolation/InterpolationTarget.hpp
@@ -290,8 +290,8 @@ struct InterpolationTarget {
                           InterpolationTargetTag>>>,
               Parallel::Actions::TerminatePhase>>>;
 
-  using initialization_tags =
-      tmpl::append<Parallel::get_initialization_tags<
+  using simple_tags_from_options =
+      tmpl::append<Parallel::get_simple_tags_from_options<
                        Parallel::get_initialization_actions_list<
                            phase_dependent_action_list>>,
                    tmpl::list<Parallel::Tags::SingletonInfo<InterpolationTarget<

--- a/src/ParallelAlgorithms/Interpolation/Interpolator.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Interpolator.hpp
@@ -52,7 +52,7 @@ struct Interpolator {
                                          tmpl::pin<Metavariables>, tmpl::_1>>,
               Tags::InterpolatedVarsHolders<Metavariables>>,
           Parallel::Actions::TerminatePhase>>>;
-  using initialization_tags = Parallel::get_initialization_tags<
+  using simple_tags_from_options = Parallel::get_simple_tags_from_options<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
   static void execute_next_phase(
       Parallel::Phase next_phase,

--- a/src/ParallelAlgorithms/LinearSolver/ConjugateGradient/ResidualMonitor.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/ConjugateGradient/ResidualMonitor.hpp
@@ -51,7 +51,7 @@ struct ResidualMonitor {
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
       Parallel::Phase::Initialization,
       tmpl::list<InitializeResidualMonitor<FieldsTag, OptionsGroup>>>>;
-  using initialization_tags = Parallel::get_initialization_tags<
+  using simple_tags_from_options = Parallel::get_simple_tags_from_options<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
 
   static void execute_next_phase(

--- a/src/ParallelAlgorithms/LinearSolver/Gmres/ResidualMonitor.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Gmres/ResidualMonitor.hpp
@@ -49,7 +49,7 @@ struct ResidualMonitor {
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
       Parallel::Phase::Initialization,
       tmpl::list<InitializeResidualMonitor<FieldsTag, OptionsGroup>>>>;
-  using initialization_tags = Parallel::get_initialization_tags<
+  using simple_tags_from_options = Parallel::get_simple_tags_from_options<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
 
   static void execute_next_phase(

--- a/src/ParallelAlgorithms/LinearSolver/Multigrid/ElementActions.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Multigrid/ElementActions.hpp
@@ -50,8 +50,9 @@ struct PostSmoothingBeginLabel {};
 template <size_t Dim, typename FieldsTag, typename OptionsGroup,
           typename SourceTag>
 struct InitializeElement {
-  using initialization_tags = tmpl::list<Tags::ChildrenRefinementLevels<Dim>,
-                                         Tags::ParentRefinementLevels<Dim>>;
+  using simple_tags_from_options =
+      tmpl::list<Tags::ChildrenRefinementLevels<Dim>,
+                 Tags::ParentRefinementLevels<Dim>>;
   using simple_tags =
       tmpl::list<Tags::ParentId<Dim>, Tags::ChildIds<Dim>,
                  Tags::ParentMesh<Dim>,

--- a/src/ParallelAlgorithms/LinearSolver/Multigrid/ElementsAllocator.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Multigrid/ElementsAllocator.hpp
@@ -72,10 +72,7 @@ struct ElementsAllocator
     : tt::ConformsTo<Parallel::protocols::ArrayElementsAllocator> {
   template <typename ElementArray>
   using array_allocation_tags =
-      tmpl::list<domain::Tags::InitialRefinementLevels<Dim>,
-                 Tags::ChildrenRefinementLevels<Dim>,
-                 Tags::ParentRefinementLevels<Dim>,
-                 Parallel::Tags::Section<ElementArray, Tags::MultigridLevel>,
+      tmpl::list<Parallel::Tags::Section<ElementArray, Tags::MultigridLevel>,
                  Parallel::Tags::Section<ElementArray, Tags::IsFinestGrid>>;
 
   template <typename ElementArray, typename Metavariables,

--- a/src/ParallelAlgorithms/LinearSolver/Schwarz/ElementActions.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Schwarz/ElementActions.hpp
@@ -206,7 +206,7 @@ struct InitializeElement {
       OptionsGroup>;
 
  public:
-  using initialization_tags =
+  using simple_tags_from_options =
       tmpl::list<domain::Tags::InitialExtents<Dim>, subdomain_solver_tag>;
 
   using const_global_cache_tags = tmpl::list<Tags::MaxOverlap<OptionsGroup>>;

--- a/src/ParallelAlgorithms/NonlinearSolver/NewtonRaphson/ResidualMonitor.hpp
+++ b/src/ParallelAlgorithms/NonlinearSolver/NewtonRaphson/ResidualMonitor.hpp
@@ -45,7 +45,7 @@ struct ResidualMonitor {
       Parallel::Phase::Initialization,
       tmpl::list<InitializeResidualMonitor<FieldsTag, OptionsGroup>>>>;
 
-  using initialization_tags = Parallel::get_initialization_tags<
+  using simple_tags_from_options = Parallel::get_simple_tags_from_options<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
 
   static void initialize(

--- a/tests/InputFiles/Cce/AnalyticTestBouncingBlackHole.yaml
+++ b/tests/InputFiles/Cce/AnalyticTestBouncingBlackHole.yaml
@@ -18,6 +18,7 @@ Evolution:
   InitialSlabSize: 0.8
 
 ResourceInfo:
+  AvoidGlobalProc0: false
   Singletons:
     CharacteristicEvolution:
       Proc: Auto

--- a/tests/InputFiles/Cce/AnalyticTestGaugeWave.yaml
+++ b/tests/InputFiles/Cce/AnalyticTestGaugeWave.yaml
@@ -18,6 +18,7 @@ Evolution:
   InitialSlabSize: 0.8
 
 ResourceInfo:
+  AvoidGlobalProc0: false
   Singletons:
     CharacteristicEvolution:
       Proc: Auto

--- a/tests/InputFiles/Cce/AnalyticTestLinearizedBondiSachs.yaml
+++ b/tests/InputFiles/Cce/AnalyticTestLinearizedBondiSachs.yaml
@@ -18,6 +18,7 @@ Evolution:
   InitialSlabSize: 0.8
 
 ResourceInfo:
+  AvoidGlobalProc0: false
   Singletons:
     CharacteristicEvolution:
       Proc: Auto

--- a/tests/InputFiles/Cce/AnalyticTestRobinsonTrautman.yaml
+++ b/tests/InputFiles/Cce/AnalyticTestRobinsonTrautman.yaml
@@ -18,6 +18,7 @@ Evolution:
   InitialSlabSize: 0.6
 
 ResourceInfo:
+  AvoidGlobalProc0: false
   Singletons:
     CharacteristicEvolution:
       Proc: Auto

--- a/tests/InputFiles/Cce/AnalyticTestRotatingSchwarzschild.yaml
+++ b/tests/InputFiles/Cce/AnalyticTestRotatingSchwarzschild.yaml
@@ -18,6 +18,7 @@ Evolution:
   InitialSlabSize: 0.8
 
 ResourceInfo:
+  AvoidGlobalProc0: false
   Singletons:
     CharacteristicEvolution:
       Proc: Auto

--- a/tests/InputFiles/Cce/AnalyticTestTeukolskyWave.yaml
+++ b/tests/InputFiles/Cce/AnalyticTestTeukolskyWave.yaml
@@ -18,6 +18,7 @@ Evolution:
   InitialSlabSize: 1.0
 
 ResourceInfo:
+  AvoidGlobalProc0: false
   Singletons:
     CharacteristicEvolution:
       Proc: Auto

--- a/tests/InputFiles/Cce/CharacteristicExtract.yaml
+++ b/tests/InputFiles/Cce/CharacteristicExtract.yaml
@@ -9,6 +9,7 @@ Evolution:
   InitialSlabSize: 10.0
 
 ResourceInfo:
+  AvoidGlobalProc0: false
   Singletons:
     CharacteristicEvolution:
       Proc: Auto

--- a/tests/InputFiles/Elasticity/BentBeam.yaml
+++ b/tests/InputFiles/Elasticity/BentBeam.yaml
@@ -15,6 +15,7 @@
 
 ResourceInfo:
   AvoidGlobalProc0: false
+  Singletons: Auto
 
 Background:
   BentBeam:

--- a/tests/InputFiles/Elasticity/HalfSpaceMirror.yaml
+++ b/tests/InputFiles/Elasticity/HalfSpaceMirror.yaml
@@ -16,6 +16,7 @@
 
 ResourceInfo:
   AvoidGlobalProc0: false
+  Singletons: Auto
 
 Background:
   HalfSpaceMirror:

--- a/tests/InputFiles/ExampleExecutables/SingletonHelloWorld.yaml
+++ b/tests/InputFiles/ExampleExecutables/SingletonHelloWorld.yaml
@@ -5,3 +5,7 @@
 # Check: parse;execute
 
 Name: Albert Einstein
+
+ResourceInfo:
+  AvoidGlobalProc0: false
+  Singletons: Auto

--- a/tests/InputFiles/GeneralizedHarmonic/BinaryBlackHole.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/BinaryBlackHole.yaml
@@ -19,6 +19,15 @@ ResourceInfo:
     ControlSystemAhB:
       Proc: Auto
       Exclusive: true
+    MemoryMonitor:
+      Proc: Auto
+      Exclusive: false
+    Rotation:
+      Proc: Auto
+      Exclusive: false
+    Expansion:
+      Proc: Auto
+      Exclusive: false
 
 Evolution:
   InitialTime: 0.0

--- a/tests/InputFiles/Poisson/ProductOfSinusoids1D.yaml
+++ b/tests/InputFiles/Poisson/ProductOfSinusoids1D.yaml
@@ -16,6 +16,7 @@
 
 ResourceInfo:
   AvoidGlobalProc0: false
+  Singletons: Auto
 
 Background:
   ProductOfSinusoids:

--- a/tests/InputFiles/Poisson/ProductOfSinusoids2D.yaml
+++ b/tests/InputFiles/Poisson/ProductOfSinusoids2D.yaml
@@ -16,6 +16,7 @@
 
 ResourceInfo:
   AvoidGlobalProc0: false
+  Singletons: Auto
 
 Background:
   ProductOfSinusoids:

--- a/tests/InputFiles/Poisson/ProductOfSinusoids3D.yaml
+++ b/tests/InputFiles/Poisson/ProductOfSinusoids3D.yaml
@@ -16,6 +16,7 @@
 
 ResourceInfo:
   AvoidGlobalProc0: false
+  Singletons: Auto
 
 Background:
   ProductOfSinusoids:

--- a/tests/InputFiles/Xcts/BinaryBlackHole.yaml
+++ b/tests/InputFiles/Xcts/BinaryBlackHole.yaml
@@ -7,6 +7,7 @@
 
 ResourceInfo:
   AvoidGlobalProc0: false
+  Singletons: Auto
 
 Background: &background
   Binary:

--- a/tests/InputFiles/Xcts/KerrSchild.yaml
+++ b/tests/InputFiles/Xcts/KerrSchild.yaml
@@ -16,6 +16,7 @@
 
 ResourceInfo:
   AvoidGlobalProc0: false
+  Singletons: Auto
 
 Background:
   KerrSchild:

--- a/tests/Unit/ControlSystem/Actions/Test_InitializeMeasurements.cpp
+++ b/tests/Unit/ControlSystem/Actions/Test_InitializeMeasurements.cpp
@@ -147,7 +147,7 @@ struct Component {
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = int;
 
-  using initialization_tags =
+  using simple_tags_from_options =
       tmpl::list<evolution::Tags::EventsAndDenseTriggers>;
 
   using simple_tags = tmpl::list<Tags::TimeStepId, Tags::Time>;

--- a/tests/Unit/ControlSystem/Test_Measurement.cpp
+++ b/tests/Unit/ControlSystem/Test_Measurement.cpp
@@ -44,7 +44,7 @@ struct MockControlSystemComponent {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockSingletonChare;
   using array_index = int;
-  using initialization_tags = tmpl::list<
+  using simple_tags_from_options = tmpl::list<
       control_system::TestHelpers::ExampleControlSystem::MeasurementQueue,
       control_system::TestHelpers::MeasurementResultTime,
       control_system::TestHelpers::MeasurementResultTag>;

--- a/tests/Unit/Domain/FunctionsOfTime/Test_FunctionsOfTimeAreReady.cpp
+++ b/tests/Unit/Domain/FunctionsOfTime/Test_FunctionsOfTimeAreReady.cpp
@@ -45,7 +45,7 @@ struct Component {
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = int;
 
-  using initialization_tags = tmpl::list<Tags::Time>;
+  using simple_tags_from_options = tmpl::list<Tags::Time>;
   using mutable_global_cache_tags =
       tmpl::list<domain::Tags::FunctionsOfTimeInitialize, OtherFunctionsOfTime>;
 

--- a/tests/Unit/Evolution/Actions/Test_RunEventsAndDenseTriggers.cpp
+++ b/tests/Unit/Evolution/Actions/Test_RunEventsAndDenseTriggers.cpp
@@ -249,7 +249,7 @@ struct Component {
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = int;
   using variables_tag = typename metavariables::system::variables_tag;
-  using initialization_tags =
+  using simple_tags_from_options =
       tmpl::push_front<extra_data, Tags::TimeStepId, Tags::TimeStep, Tags::Time,
                        evolution::Tags::PreviousTriggerTime, variables_tag,
                        Tags::HistoryEvolvedVariables<variables_tag>,

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_AnalyticBoundaryCommunication.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_AnalyticBoundaryCommunication.cpp
@@ -56,8 +56,8 @@ struct mock_analytic_worldtube_boundary {
       tmpl::list<Actions::InitializeWorldtubeBoundary<
                      AnalyticWorldtubeBoundary<Metavariables>>,
                  Parallel::Actions::TerminatePhase>;
-  using initialization_tags =
-      Parallel::get_initialization_tags<initialize_action_list>;
+  using simple_tags_from_options =
+      Parallel::get_simple_tags_from_options<initialize_action_list>;
 
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
@@ -86,8 +86,8 @@ struct mock_characteristic_evolution {
           typename Metavariables::scri_values_to_observe,
           typename Metavariables::cce_boundary_component>,
       Parallel::Actions::TerminatePhase>;
-  using initialization_tags =
-      Parallel::get_initialization_tags<initialize_action_list>;
+  using simple_tags_from_options =
+      Parallel::get_simple_tags_from_options<initialize_action_list>;
 
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_CharacteristicEvolutionBondiCalculations.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_CharacteristicEvolutionBondiCalculations.cpp
@@ -105,8 +105,8 @@ struct mock_characteristic_evolution {
           GaugeUpdateOmega<Tags::PartiallyFlatGaugeC, Tags::PartiallyFlatGaugeD,
                            Tags::PartiallyFlatGaugeOmega>>,
       Parallel::Actions::TerminatePhase>;
-  using initialization_tags =
-      Parallel::get_initialization_tags<initialize_action_list>;
+  using simple_tags_from_options =
+      Parallel::get_simple_tags_from_options<initialize_action_list>;
 
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_FilterSwshVolumeQuantity.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_FilterSwshVolumeQuantity.cpp
@@ -48,8 +48,8 @@ struct mock_characteristic_evolution {
 
   using initialize_action_list =
       tmpl::list<ActionTesting::InitializeDataBox<simple_tags, compute_tags>>;
-  using initialization_tags =
-      Parallel::get_initialization_tags<initialize_action_list>;
+  using simple_tags_from_options =
+      Parallel::get_simple_tags_from_options<initialize_action_list>;
 
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_GhBoundaryCommunication.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_GhBoundaryCommunication.cpp
@@ -67,8 +67,8 @@ struct mock_gh_worldtube_boundary : GhWorldtubeBoundary<Metavariables> {
 
   using initialize_action_list = tmpl::list<
       Actions::InitializeWorldtubeBoundary<GhWorldtubeBoundary<Metavariables>>>;
-  using initialization_tags =
-      Parallel::get_initialization_tags<initialize_action_list>;
+  using simple_tags_from_options =
+      Parallel::get_simple_tags_from_options<initialize_action_list>;
 
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
@@ -100,8 +100,8 @@ struct mock_characteristic_evolution {
       Actions::InitializeCharacteristicEvolutionScri<
           typename Metavariables::scri_values_to_observe,
           typename Metavariables::cce_boundary_component>>;
-  using initialization_tags =
-      Parallel::get_initialization_tags<initialize_action_list>;
+  using simple_tags_from_options =
+      Parallel::get_simple_tags_from_options<initialize_action_list>;
 
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_H5BoundaryCommunication.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_H5BoundaryCommunication.cpp
@@ -81,8 +81,8 @@ struct mock_h5_worldtube_boundary {
 
   using initialize_action_list = tmpl::list<
       Actions::InitializeWorldtubeBoundary<H5WorldtubeBoundary<Metavariables>>>;
-  using initialization_tags =
-      Parallel::get_initialization_tags<initialize_action_list>;
+  using simple_tags_from_options =
+      Parallel::get_simple_tags_from_options<initialize_action_list>;
 
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
@@ -112,8 +112,8 @@ struct mock_characteristic_evolution {
       // advance the time so that the current `TimeStepId` is valid without
       // having to perform self-start.
       ::Actions::AdvanceTime, Parallel::Actions::TerminatePhase>;
-  using initialization_tags =
-      Parallel::get_initialization_tags<initialize_action_list>;
+  using simple_tags_from_options =
+      Parallel::get_simple_tags_from_options<initialize_action_list>;
 
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_InitializeCharacteristicEvolution.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_InitializeCharacteristicEvolution.cpp
@@ -65,8 +65,8 @@ struct mock_characteristic_evolution {
       Actions::InitializeCharacteristicEvolutionScri<
           typename Metavariables::scri_values_to_observe, NoSuchType>,
       Parallel::Actions::TerminatePhase>;
-  using initialization_tags =
-      Parallel::get_initialization_tags<initialize_action_list>;
+  using simple_tags_from_options =
+      Parallel::get_simple_tags_from_options<initialize_action_list>;
 
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_InitializeWorldtubeBoundary.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_InitializeWorldtubeBoundary.cpp
@@ -45,8 +45,8 @@ struct mock_analytic_worldtube_boundary {
       tmpl::list<Actions::InitializeWorldtubeBoundary<
                      AnalyticWorldtubeBoundary<Metavariables>>,
                  Parallel::Actions::TerminatePhase>;
-  using initialization_tags =
-      Parallel::get_initialization_tags<initialize_action_list>;
+  using simple_tags_from_options =
+      Parallel::get_simple_tags_from_options<initialize_action_list>;
 
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_InsertInterpolationScriData.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_InsertInterpolationScriData.cpp
@@ -128,8 +128,8 @@ struct MockObserver {
   using const_global_cache_tags = tmpl::list<Tags::ObservationLMax>;
   using initialize_action_list =
       tmpl::list<observers::Actions::InitializeWriter<Metavariables>>;
-  using initialization_tags =
-      Parallel::get_initialization_tags<initialize_action_list>;
+  using simple_tags_from_options =
+      Parallel::get_simple_tags_from_options<initialize_action_list>;
 
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
@@ -159,8 +159,8 @@ struct MockCharacteristicEvolution {
           typename Metavariables::scri_values_to_observe,
           typename Metavariables::cce_boundary_component>,
       Parallel::Actions::TerminatePhase>;
-  using initialization_tags =
-      Parallel::get_initialization_tags<initialize_action_list>;
+  using simple_tags_from_options =
+      Parallel::get_simple_tags_from_options<initialize_action_list>;
 
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockSingletonChare;

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_RequestBoundaryData.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_RequestBoundaryData.cpp
@@ -79,8 +79,8 @@ struct mock_characteristic_evolution {
       // advance the time so that the current `TimeStepId` is valid without
       // having to perform self-start.
       ::Actions::AdvanceTime, Parallel::Actions::TerminatePhase>;
-  using initialization_tags =
-      Parallel::get_initialization_tags<initialize_action_list>;
+  using simple_tags_from_options =
+      Parallel::get_simple_tags_from_options<initialize_action_list>;
 
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_ScriObserveInterpolated.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_ScriObserveInterpolated.cpp
@@ -100,8 +100,8 @@ struct mock_observer {
       tmpl::list<observers::Tags::ReductionFileName, Tags::ObservationLMax>;
   using initialize_action_list =
       tmpl::list<observers::Actions::InitializeWriter<Metavariables>>;
-  using initialization_tags =
-      Parallel::get_initialization_tags<initialize_action_list>;
+  using simple_tags_from_options =
+      Parallel::get_simple_tags_from_options<initialize_action_list>;
 
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockGroupChare;
@@ -128,8 +128,8 @@ struct mock_characteristic_evolution {
           typename Metavariables::scri_values_to_observe,
           typename Metavariables::cce_boundary_component>,
       Parallel::Actions::TerminatePhase>;
-  using initialization_tags =
-      Parallel::get_initialization_tags<initialize_action_list>;
+  using simple_tags_from_options =
+      Parallel::get_simple_tags_from_options<initialize_action_list>;
 
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockSingletonChare;

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_TimeManagement.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_TimeManagement.cpp
@@ -40,8 +40,8 @@ struct mock_characteristic_evolution {
 
   using initialize_action_list =
       tmpl::list<ActionTesting::InitializeDataBox<simple_tags, compute_tags>>;
-  using initialization_tags =
-      Parallel::get_initialization_tags<initialize_action_list>;
+  using simple_tags_from_options =
+      Parallel::get_simple_tags_from_options<initialize_action_list>;
 
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;

--- a/tests/Unit/Framework/ActionTesting.hpp
+++ b/tests/Unit/Framework/ActionTesting.hpp
@@ -118,8 +118,8 @@ struct get_array_index;
  * All emplace functions optionally take a parameter pack of
  * additional arguments that are forwarded to the constructor of the component.
  * These additional arguments are how input options (set in the
- * `initialization_tags` type alias of the parallel component) get passed to
- * parallel components.
+ * `simple_tags_from_options` type alias of the parallel component) get passed
+ * to parallel components.
  *
  * With the ATF, everything is controlled explicitly, providing the ability to
  * perform full introspection into the state of the RTS at virtually any point

--- a/tests/Unit/Framework/MockDistributedObject.hpp
+++ b/tests/Unit/Framework/MockDistributedObject.hpp
@@ -73,14 +73,14 @@ ACTION_TESTING_CHECK_MOCK_ACTION_LIST(threaded_actions);
 #undef ACTION_TESTING_CHECK_MOCK_ACTION_LIST
 
 template <typename Component, typename = std::void_t<>>
-struct get_initialization_tags_from_component {
+struct get_simple_tags_from_options_from_component {
   using type = tmpl::list<>;
 };
 
 template <typename Component>
-struct get_initialization_tags_from_component<
-    Component, std::void_t<typename Component::initialization_tags>> {
-  using type = typename Component::initialization_tags;
+struct get_simple_tags_from_options_from_component<
+    Component, std::void_t<typename Component::simple_tags_from_options>> {
+  using type = typename Component::simple_tags_from_options;
 };
 
 // Returns the type of `Tag` (including const and reference-ness as would be
@@ -329,11 +329,12 @@ class MockDistributedObject {
   using parallel_component = Component;
 
   using all_cache_tags = Parallel::get_const_global_cache_tags<metavariables>;
-  using initialization_tags =
-      typename detail::get_initialization_tags_from_component<Component>::type;
+  using simple_tags_from_options =
+      typename detail::get_simple_tags_from_options_from_component<
+          Component>::type;
   using initial_tags = tmpl::flatten<tmpl::list<
       Parallel::Tags::MetavariablesImpl<metavariables>,
-      Parallel::Tags::GlobalCacheImpl<metavariables>, initialization_tags,
+      Parallel::Tags::GlobalCacheImpl<metavariables>, simple_tags_from_options,
       db::wrap_tags_in<Parallel::Tags::FromGlobalCache, all_cache_tags>,
       Parallel::Algorithm_detail::action_list_simple_tags<Component>,
       Parallel::Algorithm_detail::action_list_compute_tags<Component>>>;
@@ -359,8 +360,9 @@ class MockDistributedObject {
         array_index_(index),
         global_cache_(cache),
         inboxes_(inboxes) {
-    ::Initialization::mutate_assign<tmpl::push_front<
-        initialization_tags, Parallel::Tags::GlobalCacheImpl<metavariables>>>(
+    ::Initialization::mutate_assign<
+        tmpl::push_front<simple_tags_from_options,
+                         Parallel::Tags::GlobalCacheImpl<metavariables>>>(
         make_not_null(&box_), global_cache_, std::forward<Options>(opts)...);
   }
 

--- a/tests/Unit/Helpers/ControlSystem/SystemHelpers.hpp
+++ b/tests/Unit/Helpers/ControlSystem/SystemHelpers.hpp
@@ -202,7 +202,7 @@ struct MockObserverWriter {
   using const_global_cache_tags =
       tmpl::list<observers::Tags::ReductionFileName>;
 
-  using initialization_tags = tmpl::list<>;
+  using simple_tags_from_options = tmpl::list<>;
   using simple_tags = tmpl::list<observers::Tags::H5FileLock>;
 
   using metavariables = Metavars;

--- a/tests/Unit/Helpers/Evolution/Systems/Cce/Actions/WorldtubeBoundaryMocking.hpp
+++ b/tests/Unit/Helpers/Evolution/Systems/Cce/Actions/WorldtubeBoundaryMocking.hpp
@@ -46,8 +46,8 @@ struct mock_h5_worldtube_boundary {
   using initialize_action_list = tmpl::list<
       Actions::InitializeWorldtubeBoundary<H5WorldtubeBoundary<Metavariables>>,
       Parallel::Actions::TerminatePhase>;
-  using initialization_tags =
-      Parallel::get_initialization_tags<initialize_action_list>;
+  using simple_tags_from_options =
+      Parallel::get_simple_tags_from_options<initialize_action_list>;
 
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
@@ -75,8 +75,8 @@ struct mock_gh_worldtube_boundary {
   using initialize_action_list = tmpl::list<
       Actions::InitializeWorldtubeBoundary<GhWorldtubeBoundary<Metavariables>>,
       Parallel::Actions::TerminatePhase>;
-  using initialization_tags =
-      Parallel::get_initialization_tags<initialize_action_list>;
+  using simple_tags_from_options =
+      Parallel::get_simple_tags_from_options<initialize_action_list>;
 
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;

--- a/tests/Unit/Helpers/ParallelAlgorithms/LinearSolver/DistributedLinearSolverAlgorithmTestHelpers.hpp
+++ b/tests/Unit/Helpers/ParallelAlgorithms/LinearSolver/DistributedLinearSolverAlgorithmTestHelpers.hpp
@@ -81,7 +81,6 @@ struct ExpectedResult {
 };
 }  // namespace OptionTags
 
-// [array_allocation_tag]
 struct LinearOperator : db::SimpleTag {
   using type = std::vector<blaze::DynamicMatrix<double>>;
   using option_tags = tmpl::list<OptionTags::LinearOperator>;
@@ -91,7 +90,6 @@ struct LinearOperator : db::SimpleTag {
     return linear_operator;
   }
 };
-// [array_allocation_tag]
 
 struct Source : db::SimpleTag {
   using type = std::vector<blaze::DynamicVector<double>>;

--- a/tests/Unit/Helpers/ParallelAlgorithms/LinearSolver/DistributedLinearSolverAlgorithmTestHelpers.hpp
+++ b/tests/Unit/Helpers/ParallelAlgorithms/LinearSolver/DistributedLinearSolverAlgorithmTestHelpers.hpp
@@ -256,7 +256,7 @@ struct TestResult {
 };
 
 struct InitializeElement {
-  using initialization_tags =
+  using simple_tags_from_options =
       tmpl::list<domain::Tags::InitialExtents<1>,
                  domain::Tags::InitialRefinementLevels<1>>;
   using const_global_cache_tags = tmpl::list<Source>;

--- a/tests/Unit/Helpers/ParallelAlgorithms/LinearSolver/LinearSolverAlgorithmTestHelpers.hpp
+++ b/tests/Unit/Helpers/ParallelAlgorithms/LinearSolver/LinearSolverAlgorithmTestHelpers.hpp
@@ -294,14 +294,14 @@ struct ElementArray {
           Parallel::Phase::Testing,
           tmpl::list<TestResult<typename linear_solver::options_group>>>>;
   /// [action_list]
-  using initialization_tags = Parallel::get_initialization_tags<
+  using simple_tags_from_options = Parallel::get_simple_tags_from_options<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
   using const_global_cache_tags =
       tmpl::list<LinearOperator, Source, InitialGuess, ExpectedResult>;
 
   static void allocate_array(
       Parallel::CProxy_GlobalCache<Metavariables>& global_cache,
-      const tuples::tagged_tuple_from_typelist<initialization_tags>&
+      const tuples::tagged_tuple_from_typelist<simple_tags_from_options>&
           initialization_items,
       const std::unordered_set<size_t>& /*procs_to_ignore*/ = {}) {
     auto& local_component = Parallel::get_parallel_component<ElementArray>(
@@ -359,7 +359,7 @@ struct OutputCleaner {
 
                  Parallel::PhaseActions<Parallel::Phase::Cleanup,
                                         tmpl::list<CleanOutput<true>>>>;
-  using initialization_tags = Parallel::get_initialization_tags<
+  using simple_tags_from_options = Parallel::get_simple_tags_from_options<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
 
   static void execute_next_phase(

--- a/tests/Unit/Helpers/ParallelAlgorithms/LinearSolver/Multigrid/Helpers.hpp
+++ b/tests/Unit/Helpers/ParallelAlgorithms/LinearSolver/Multigrid/Helpers.hpp
@@ -78,7 +78,7 @@ using fields_tag = helpers_distributed::fields_tag;
 using sources_tag = helpers_distributed::sources_tag;
 
 struct InitializeElement {
-  using initialization_tags =
+  using simple_tags_from_options =
       tmpl::list<::domain::Tags::InitialExtents<1>,
                  ::domain::Tags::InitialRefinementLevels<1>>;
   using const_global_cache_tags =

--- a/tests/Unit/Helpers/ParallelAlgorithms/NonlinearSolver/Algorithm.hpp
+++ b/tests/Unit/Helpers/ParallelAlgorithms/NonlinearSolver/Algorithm.hpp
@@ -158,10 +158,8 @@ struct ElementArray {
           Parallel::Phase::Testing,
           tmpl::list<TestResult<typename nonlinear_solver::options_group>>>>;
 
-  using array_allocation_tags = tmpl::list<>;
   using simple_tags_from_options = Parallel::get_simple_tags_from_options<
-      Parallel::get_initialization_actions_list<phase_dependent_action_list>,
-      array_allocation_tags>;
+      Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
 
   static void allocate_array(
       Parallel::CProxy_GlobalCache<Metavariables>& global_cache,

--- a/tests/Unit/Helpers/ParallelAlgorithms/NonlinearSolver/Algorithm.hpp
+++ b/tests/Unit/Helpers/ParallelAlgorithms/NonlinearSolver/Algorithm.hpp
@@ -159,13 +159,13 @@ struct ElementArray {
           tmpl::list<TestResult<typename nonlinear_solver::options_group>>>>;
 
   using array_allocation_tags = tmpl::list<>;
-  using initialization_tags = Parallel::get_initialization_tags<
+  using simple_tags_from_options = Parallel::get_simple_tags_from_options<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>,
       array_allocation_tags>;
 
   static void allocate_array(
       Parallel::CProxy_GlobalCache<Metavariables>& global_cache,
-      const tuples::tagged_tuple_from_typelist<initialization_tags>&
+      const tuples::tagged_tuple_from_typelist<simple_tags_from_options>&
           initialization_items,
       const std::unordered_set<size_t>& /*procs_to_ignore*/ = {}) {
     auto& local_component = Parallel::get_parallel_component<ElementArray>(

--- a/tests/Unit/IO/Importers/Test_VolumeDataReaderAlgorithm.hpp
+++ b/tests/Unit/IO/Importers/Test_VolumeDataReaderAlgorithm.hpp
@@ -334,7 +334,6 @@ struct ElementArray {
   using array_index = ElementId<Dim>;
   using metavariables = Metavariables;
   using simple_tags_from_options = tmpl::list<>;
-  using array_allocation_tags = tmpl::list<>;
 
   using import_fields = tmpl::list<ScalarFieldTag, VectorFieldTag<Dim>>;
 

--- a/tests/Unit/IO/Importers/Test_VolumeDataReaderAlgorithm.hpp
+++ b/tests/Unit/IO/Importers/Test_VolumeDataReaderAlgorithm.hpp
@@ -261,7 +261,7 @@ struct TestDataWriter {
 
                  Parallel::PhaseActions<Parallel::Phase::Testing,
                                         tmpl::list<CleanTestData>>>;
-  using initialization_tags = tmpl::list<>;
+  using simple_tags_from_options = tmpl::list<>;
 
   static void initialize(
       Parallel::CProxy_GlobalCache<Metavariables>& /*global_cache*/) {}
@@ -333,7 +333,7 @@ struct ElementArray {
   using chare_type = Parallel::Algorithms::Array;
   using array_index = ElementId<Dim>;
   using metavariables = Metavariables;
-  using initialization_tags = tmpl::list<>;
+  using simple_tags_from_options = tmpl::list<>;
   using array_allocation_tags = tmpl::list<>;
 
   using import_fields = tmpl::list<ScalarFieldTag, VectorFieldTag<Dim>>;
@@ -359,7 +359,7 @@ struct ElementArray {
 
   static void allocate_array(
       Parallel::CProxy_GlobalCache<Metavariables>& global_cache,
-      const tuples::tagged_tuple_from_typelist<initialization_tags>&
+      const tuples::tagged_tuple_from_typelist<simple_tags_from_options>&
           initialization_items,
       const std::unordered_set<size_t>& procs_to_ignore = {}) {
     auto& array_proxy = Parallel::get_parallel_component<ElementArray>(

--- a/tests/Unit/IO/Importers/Test_VolumeDataReaderAlgorithm1D.yaml
+++ b/tests/Unit/IO/Importers/Test_VolumeDataReaderAlgorithm1D.yaml
@@ -10,3 +10,7 @@ Importers:
     FileGlob: "Test_DataImporterAlgorithm1D_coarse_data.h5"
     Subgroup: "test_data"
     ObservationValue: 2.
+
+ResourceInfo:
+  AvoidGlobalProc0: false
+  Singletons: Auto

--- a/tests/Unit/IO/Importers/Test_VolumeDataReaderAlgorithm2D.yaml
+++ b/tests/Unit/IO/Importers/Test_VolumeDataReaderAlgorithm2D.yaml
@@ -12,3 +12,7 @@ Importers:
     Subgroup: "coarse_data"
     ObservationValue: 2.
 # [importer_options]
+
+ResourceInfo:
+  AvoidGlobalProc0: false
+  Singletons: Auto

--- a/tests/Unit/IO/Importers/Test_VolumeDataReaderAlgorithm3D.yaml
+++ b/tests/Unit/IO/Importers/Test_VolumeDataReaderAlgorithm3D.yaml
@@ -10,3 +10,7 @@ Importers:
     FileGlob: "Test_DataImporterAlgorithm3D_shared.h5"
     Subgroup: "coarse_data"
     ObservationValue: 2.
+
+ResourceInfo:
+  AvoidGlobalProc0: false
+  Singletons: Auto

--- a/tests/Unit/Parallel/PhaseControl/Test_PhaseChange.cpp
+++ b/tests/Unit/Parallel/PhaseControl/Test_PhaseChange.cpp
@@ -50,7 +50,7 @@ struct TestComponentAlpha {
   using chare_type = Parallel::Algorithms::Array;
   using array_index = int;
   using metavariables = Metavariables;
-  using initialization_tags = tmpl::list<>;
+  using simple_tags_from_options = tmpl::list<>;
 };
 
 struct TestComponentBeta {
@@ -58,7 +58,7 @@ struct TestComponentBeta {
   using chare_type = Parallel::Algorithms::Array;
   using array_index = int;
   using metavariables = Metavariables;
-  using initialization_tags = tmpl::list<>;
+  using simple_tags_from_options = tmpl::list<>;
 };
 
 namespace TestGlobalStateRecord {

--- a/tests/Unit/Parallel/Test_AlgorithmCore.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmCore.cpp
@@ -197,7 +197,7 @@ struct NoOpsComponent {
                      Parallel::Phase::Register,
                      tmpl::list<no_op_test::increment_count_actions_called,
                                 no_op_test::no_op>>>;
-  using initialization_tags = Parallel::get_initialization_tags<
+  using simple_tags_from_options = Parallel::get_simple_tags_from_options<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
 
   static void execute_next_phase(
@@ -361,7 +361,7 @@ struct MutateComponent {
                              tmpl::list<add_remove_test::add_int_value_10,
                                         add_remove_test::increment_int0,
                                         add_remove_test::remove_int0>>>;
-  using initialization_tags = Parallel::get_initialization_tags<
+  using simple_tags_from_options = Parallel::get_simple_tags_from_options<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
 
   static void execute_next_phase(
@@ -531,7 +531,7 @@ struct ReceiveComponent {
                      add_remove_test::increment_int0,
                      add_remove_test::remove_int0,
                      receive_data_test::update_instance>>>;
-  using initialization_tags = Parallel::get_initialization_tags<
+  using simple_tags_from_options = Parallel::get_simple_tags_from_options<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
 
   static void execute_next_phase(
@@ -637,7 +637,7 @@ struct AnyOrderComponent {
                                         any_order::iterate_increment_int0,
                                         add_remove_test::remove_int0,
                                         receive_data_test::update_instance>>>;
-  using initialization_tags = Parallel::get_initialization_tags<
+  using simple_tags_from_options = Parallel::get_simple_tags_from_options<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
 
   static void execute_next_phase(

--- a/tests/Unit/Parallel/Test_AlgorithmGlobalCache.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmGlobalCache.cpp
@@ -239,7 +239,7 @@ struct MutateCacheComponent {
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<Parallel::Phase::Initialization,
                              tmpl::list<mutate_cache::Actions::initialize>>>;
-  using initialization_tags = Parallel::get_initialization_tags<
+  using simple_tags_from_options = Parallel::get_simple_tags_from_options<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
 
   static void execute_next_phase(
@@ -270,7 +270,7 @@ struct UseMutatedCacheComponent {
       Parallel::PhaseActions<
           Parallel::Phase::Solve,
           tmpl::list<mutate_cache::Actions::use_stored_double>>>;
-  using initialization_tags = Parallel::get_initialization_tags<
+  using simple_tags_from_options = Parallel::get_simple_tags_from_options<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
 
   static void execute_next_phase(
@@ -291,7 +291,7 @@ struct CheckAndUseMutatedCacheComponent {
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<Parallel::Phase::Initialization,
                              tmpl::list<mutate_cache::Actions::initialize>>>;
-  using initialization_tags = Parallel::get_initialization_tags<
+  using simple_tags_from_options = Parallel::get_simple_tags_from_options<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
 
   static void execute_next_phase(
@@ -316,7 +316,7 @@ struct CheckParallelInfo {
   using metavariables = Metavariables;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<Parallel::Phase::Initialization, tmpl::list<>>>;
-  using initialization_tags = Parallel::get_initialization_tags<
+  using simple_tags_from_options = Parallel::get_simple_tags_from_options<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
 
   static void execute_next_phase(
@@ -371,7 +371,7 @@ struct CheckMemoryMonitorRelatedMethods {
   using metavariables = Metavariables;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<Parallel::Phase::Initialization, tmpl::list<>>>;
-  using initialization_tags = Parallel::get_initialization_tags<
+  using simple_tags_from_options = Parallel::get_simple_tags_from_options<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
 
   static void execute_next_phase(

--- a/tests/Unit/Parallel/Test_AlgorithmGlobalCache.yaml
+++ b/tests/Unit/Parallel/Test_AlgorithmGlobalCache.yaml
@@ -7,3 +7,7 @@ VectorOfDoubles: []
 Observers:
   ReductionFileName: "Test_AlgorithmGlobalCacheReduction"
   VolumeFileName: "Test_AlgorithmGlobalCacheVolume"
+
+ResourceInfo:
+  AvoidGlobalProc0: false
+  Singletons: Auto

--- a/tests/Unit/Parallel/Test_AlgorithmLocalSyncAction.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmLocalSyncAction.cpp
@@ -188,7 +188,7 @@ struct NodegroupComponent {
   using phase_dependent_action_list =
       tmpl::list<Parallel::PhaseActions<Parallel::Phase::Initialization,
                                         tmpl::list<InitializeNodegroup>>>;
-  using initialization_tags = Parallel::get_initialization_tags<
+  using simple_tags_from_options = Parallel::get_simple_tags_from_options<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
 
   static void execute_next_phase(
@@ -209,12 +209,12 @@ struct ArrayComponent {
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
       Parallel::Phase::Evolve,
       tmpl::list<TestSyncActionIncrement, Parallel::Actions::TerminatePhase>>>;
-  using initialization_tags = Parallel::get_initialization_tags<
+  using simple_tags_from_options = Parallel::get_simple_tags_from_options<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
 
   static void allocate_array(
       Parallel::CProxy_GlobalCache<Metavariables>& global_cache,
-      const tuples::tagged_tuple_from_typelist<initialization_tags>&
+      const tuples::tagged_tuple_from_typelist<simple_tags_from_options>&
       /*initialization_items*/,
       const std::unordered_set<size_t>& /*procs_to_ignore*/ = {}) {
     auto& local_cache = *Parallel::local_branch(global_cache);

--- a/tests/Unit/Parallel/Test_AlgorithmNestedApply1.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmNestedApply1.cpp
@@ -47,7 +47,7 @@ struct Component {
   using metavariables = Metavariables;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<Parallel::Phase::Initialization, tmpl::list<>>>;
-  using initialization_tags = Parallel::get_initialization_tags<
+  using simple_tags_from_options = Parallel::get_simple_tags_from_options<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
 
   static void execute_next_phase(

--- a/tests/Unit/Parallel/Test_AlgorithmNestedApply2.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmNestedApply2.cpp
@@ -51,7 +51,7 @@ struct Component {
   using metavariables = Metavariables;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<Parallel::Phase::Initialization, tmpl::list<>>>;
-  using initialization_tags = Parallel::get_initialization_tags<
+  using simple_tags_from_options = Parallel::get_simple_tags_from_options<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
 
   static void execute_next_phase(

--- a/tests/Unit/Parallel/Test_AlgorithmNodelock.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmNodelock.cpp
@@ -242,12 +242,12 @@ struct ArrayParallelComponent {
       Parallel::PhaseActions<Parallel::Phase::Initialization, tmpl::list<>>,
       Parallel::PhaseActions<Parallel::Phase::Register, tmpl::list<>>,
       Parallel::PhaseActions<Parallel::Phase::Execute, tmpl::list<>>>;
-  using initialization_tags = Parallel::get_initialization_tags<
+  using simple_tags_from_options = Parallel::get_simple_tags_from_options<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
 
   static void allocate_array(
       Parallel::CProxy_GlobalCache<Metavariables>& global_cache,
-      const tuples::tagged_tuple_from_typelist<initialization_tags>&
+      const tuples::tagged_tuple_from_typelist<simple_tags_from_options>&
       /*initialization_items*/,
       const std::unordered_set<size_t>& procs_to_ignore = {}) {
     auto& local_cache = *Parallel::local_branch(global_cache);
@@ -288,7 +288,7 @@ struct NodegroupParallelComponent {
       Parallel::PhaseActions<Parallel::Phase::Solve, tmpl::list<>>,
       Parallel::PhaseActions<Parallel::Phase::Execute, tmpl::list<>>,
       Parallel::PhaseActions<Parallel::Phase::Testing, tmpl::list<>>>;
-  using initialization_tags = Parallel::get_initialization_tags<
+  using simple_tags_from_options = Parallel::get_simple_tags_from_options<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
 
   static void execute_next_phase(

--- a/tests/Unit/Parallel/Test_AlgorithmParallel.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmParallel.cpp
@@ -497,7 +497,7 @@ struct SingletonParallelComponent {
                              tmpl::list<SingletonActions::Initialize>>,
       Parallel::PhaseActions<Parallel::Phase::Solve,
                              tmpl::list<SingletonActions::CountReceives>>>;
-  using initialization_tags = Parallel::get_initialization_tags<
+  using simple_tags_from_options = Parallel::get_simple_tags_from_options<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
 
   static void execute_next_phase(
@@ -524,13 +524,13 @@ struct ArrayParallelComponent {
                      ArrayActions::RemoveInt0, ArrayActions::SendToSingleton>>,
       Parallel::PhaseActions<Parallel::Phase::Testing,
                              tmpl::list<ArrayActions::CheckWasUnpacked>>>;
-  using initialization_tags = Parallel::get_initialization_tags<
+  using simple_tags_from_options = Parallel::get_simple_tags_from_options<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
   using array_index = int;
 
   static void allocate_array(
       Parallel::CProxy_GlobalCache<Metavariables>& global_cache,
-      const tuples::tagged_tuple_from_typelist<initialization_tags>&
+      const tuples::tagged_tuple_from_typelist<simple_tags_from_options>&
       /*initialization_items*/,
       const std::unordered_set<size_t>& procs_to_ignore = {}) {
     auto& local_cache = *Parallel::local_branch(global_cache);
@@ -560,7 +560,7 @@ struct GroupParallelComponent {
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
       Parallel::Phase::Initialization,
       tmpl::list<GroupActions::Initialize, GroupActions::CheckComponentType>>>;
-  using initialization_tags = Parallel::get_initialization_tags<
+  using simple_tags_from_options = Parallel::get_simple_tags_from_options<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
 
   static void execute_next_phase(
@@ -576,7 +576,7 @@ struct NodegroupParallelComponent {
       Parallel::PhaseActions<Parallel::Phase::Initialization,
                              tmpl::list<NodegroupActions::Initialize,
                                         GroupActions::CheckComponentType>>>;
-  using initialization_tags = Parallel::get_initialization_tags<
+  using simple_tags_from_options = Parallel::get_simple_tags_from_options<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
 
   static void execute_next_phase(

--- a/tests/Unit/Parallel/Test_AlgorithmPhaseControl.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmPhaseControl.cpp
@@ -134,12 +134,12 @@ struct ComponentAlpha {
               Actions::TerminateAndRestart<ComponentBeta<Metavariables>, 2_st>,
               PhaseControl::Actions::ExecutePhaseChange>>>;
 
-  using initialization_tags = Parallel::get_initialization_tags<
+  using simple_tags_from_options = Parallel::get_simple_tags_from_options<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
 
   static void allocate_array(
       Parallel::CProxy_GlobalCache<Metavariables>& global_cache,
-      const tuples::tagged_tuple_from_typelist<initialization_tags>&
+      const tuples::tagged_tuple_from_typelist<simple_tags_from_options>&
       /*initialization_items*/,
       const std::unordered_set<size_t>& /*procs_to_ignore*/ = {}) {
     auto& local_cache = *Parallel::local_branch(global_cache);
@@ -191,7 +191,7 @@ struct ComponentBeta {
                      Actions::TerminateAndRestart<ComponentAlpha<Metavariables>,
                                                   3_st>>>>;
 
-  using initialization_tags = Parallel::get_initialization_tags<
+  using simple_tags_from_options = Parallel::get_simple_tags_from_options<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
 
   static void execute_next_phase(

--- a/tests/Unit/Parallel/Test_AlgorithmPhaseControl.yaml
+++ b/tests/Unit/Parallel/Test_AlgorithmPhaseControl.yaml
@@ -8,3 +8,6 @@ PhaseChangeAndTriggers:
     - - VisitAndReturn(Register)
   - - SolveTrigger:
     - - VisitAndReturn(Solve)
+
+ResourceInfo:
+  AvoidGlobalProc0: false

--- a/tests/Unit/Parallel/Test_AlgorithmReduction.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmReduction.cpp
@@ -112,7 +112,7 @@ struct SingletonParallelComponent {
   using metavariables = Metavariables;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<Parallel::Phase::Initialization, tmpl::list<>>>;
-  using initialization_tags = Parallel::get_initialization_tags<
+  using simple_tags_from_options = Parallel::get_simple_tags_from_options<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
 
   static void execute_next_phase(
@@ -230,12 +230,12 @@ struct ArrayParallelComponent {
   using array_index = int;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<Parallel::Phase::Initialization, tmpl::list<>>>;
-  using initialization_tags = Parallel::get_initialization_tags<
+  using simple_tags_from_options = Parallel::get_simple_tags_from_options<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
 
   static void allocate_array(
       Parallel::CProxy_GlobalCache<Metavariables>& global_cache,
-      const tuples::tagged_tuple_from_typelist<initialization_tags>&
+      const tuples::tagged_tuple_from_typelist<simple_tags_from_options>&
       /*initialization_items*/,
       const std::unordered_set<size_t>& procs_to_ignore = {}) {
     auto& local_cache = *Parallel::local_branch(global_cache);

--- a/tests/Unit/Parallel/Test_Callback.cpp
+++ b/tests/Unit/Parallel/Test_Callback.cpp
@@ -130,12 +130,12 @@ struct TestArray {
                                         tmpl::list<InitializeValue>>,
                  Parallel::PhaseActions<Parallel::Phase::Execute,
                                         tmpl::list<DoubleValueOfElement0>>>;
-  using initialization_tags = Parallel::get_initialization_tags<
+  using simple_tags_from_options = Parallel::get_simple_tags_from_options<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
 
   static void allocate_array(
       Parallel::CProxy_GlobalCache<Metavariables>& global_cache,
-      const tuples::tagged_tuple_from_typelist<initialization_tags>&
+      const tuples::tagged_tuple_from_typelist<simple_tags_from_options>&
       /*initialization_items*/,
       const std::unordered_set<size_t>& procs_to_ignore = {}) {
     auto& local_cache = *Parallel::local_branch(global_cache);
@@ -214,7 +214,7 @@ struct TestSingleton {
   using metavariables = Metavariables;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<Parallel::Phase::Initialization, tmpl::list<>>>;
-  using initialization_tags = Parallel::get_initialization_tags<
+  using simple_tags_from_options = Parallel::get_simple_tags_from_options<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
 
   static void execute_next_phase(

--- a/tests/Unit/Parallel/Test_CheckpointRestart.cpp
+++ b/tests/Unit/Parallel/Test_CheckpointRestart.cpp
@@ -123,12 +123,12 @@ struct ArrayComponent {
                              tmpl::list<InitializeLog>>,
       Parallel::PhaseActions<Parallel::Phase::Execute, tmpl::list<MutateLog>>,
       Parallel::PhaseActions<Parallel::Phase::Testing, tmpl::list<CheckLog>>>;
-  using initialization_tags = Parallel::get_initialization_tags<
+  using simple_tags_from_options = Parallel::get_simple_tags_from_options<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
 
   static void allocate_array(
       Parallel::CProxy_GlobalCache<Metavariables>& global_cache,
-      const tuples::tagged_tuple_from_typelist<initialization_tags>&
+      const tuples::tagged_tuple_from_typelist<simple_tags_from_options>&
       /*initialization_items*/,
       const std::unordered_set<size_t>& procs_to_ignore = {}) {
     auto& local_cache = *Parallel::local_branch(global_cache);
@@ -159,7 +159,7 @@ struct GroupComponent {
                              tmpl::list<InitializeLog>>,
       Parallel::PhaseActions<Parallel::Phase::Execute, tmpl::list<MutateLog>>,
       Parallel::PhaseActions<Parallel::Phase::Testing, tmpl::list<CheckLog>>>;
-  using initialization_tags = Parallel::get_initialization_tags<
+  using simple_tags_from_options = Parallel::get_simple_tags_from_options<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
 
   static void execute_next_phase(
@@ -181,7 +181,7 @@ struct NodegroupComponent {
                              tmpl::list<InitializeLog>>,
       Parallel::PhaseActions<Parallel::Phase::Execute, tmpl::list<MutateLog>>,
       Parallel::PhaseActions<Parallel::Phase::Testing, tmpl::list<CheckLog>>>;
-  using initialization_tags = Parallel::get_initialization_tags<
+  using simple_tags_from_options = Parallel::get_simple_tags_from_options<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
 
   static void execute_next_phase(
@@ -203,7 +203,7 @@ struct SingletonComponent {
                              tmpl::list<InitializeLog>>,
       Parallel::PhaseActions<Parallel::Phase::Execute, tmpl::list<MutateLog>>,
       Parallel::PhaseActions<Parallel::Phase::Testing, tmpl::list<CheckLog>>>;
-  using initialization_tags = Parallel::get_initialization_tags<
+  using simple_tags_from_options = Parallel::get_simple_tags_from_options<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
 
   static void execute_next_phase(

--- a/tests/Unit/Parallel/Test_DetectHangArray.cpp
+++ b/tests/Unit/Parallel/Test_DetectHangArray.cpp
@@ -98,7 +98,7 @@ struct NodegroupComponent {
 
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<Parallel::Phase::Evolve, tmpl::list<Hang>>>;
-  using initialization_tags = Parallel::get_initialization_tags<
+  using simple_tags_from_options = Parallel::get_simple_tags_from_options<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
 
   static void execute_next_phase(
@@ -117,7 +117,7 @@ struct GroupComponent {
 
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<Parallel::Phase::Evolve, tmpl::list<Hang>>>;
-  using initialization_tags = Parallel::get_initialization_tags<
+  using simple_tags_from_options = Parallel::get_simple_tags_from_options<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
 
   static void execute_next_phase(
@@ -136,7 +136,7 @@ struct SingletonComponent {
 
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<Parallel::Phase::Evolve, tmpl::list<Hang>>>;
-  using initialization_tags = Parallel::get_initialization_tags<
+  using simple_tags_from_options = Parallel::get_simple_tags_from_options<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
 
   static void execute_next_phase(
@@ -156,12 +156,12 @@ struct ArrayComponent {
 
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<Parallel::Phase::Evolve, tmpl::list<Hang>>>;
-  using initialization_tags = Parallel::get_initialization_tags<
+  using simple_tags_from_options = Parallel::get_simple_tags_from_options<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
 
   static void allocate_array(
       Parallel::CProxy_GlobalCache<Metavariables>& global_cache,
-      const tuples::tagged_tuple_from_typelist<initialization_tags>&
+      const tuples::tagged_tuple_from_typelist<simple_tags_from_options>&
       /*initialization_items*/,
       const std::unordered_set<size_t>& /*procs_to_ignore*/ = {}) {
     auto& local_cache = *Parallel::local_branch(global_cache);

--- a/tests/Unit/Parallel/Test_DynamicInsertion.cpp
+++ b/tests/Unit/Parallel/Test_DynamicInsertion.cpp
@@ -90,7 +90,7 @@ struct TestSingleton {
   using metavariables = Metavariables;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<Parallel::Phase::Initialization, tmpl::list<>>>;
-  using initialization_tags = Parallel::get_initialization_tags<
+  using simple_tags_from_options = Parallel::get_simple_tags_from_options<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
 
   static void execute_next_phase(
@@ -274,12 +274,12 @@ struct TestArray {
   using phase_dependent_action_list =
       tmpl::list<Parallel::PhaseActions<Parallel::Phase::Initialization,
                                         tmpl::list<InitializeValue>>>;
-  using initialization_tags = Parallel::get_initialization_tags<
+  using simple_tags_from_options = Parallel::get_simple_tags_from_options<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
 
   static void allocate_array(
       Parallel::CProxy_GlobalCache<Metavariables>& global_cache,
-      const tuples::tagged_tuple_from_typelist<initialization_tags>&
+      const tuples::tagged_tuple_from_typelist<simple_tags_from_options>&
       /*initialization_items*/,
       const std::unordered_set<size_t>& procs_to_ignore = {}) {
     auto& local_cache = *Parallel::local_branch(global_cache);

--- a/tests/Unit/Parallel/Test_GlobalCache.cpp
+++ b/tests/Unit/Parallel/Test_GlobalCache.cpp
@@ -161,7 +161,7 @@ struct SingletonParallelComponent {
   using metavariables = Metavariables;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<Parallel::Phase::Testing, tmpl::list<>>>;
-  using initialization_tags = Parallel::get_initialization_tags<
+  using simple_tags_from_options = Parallel::get_simple_tags_from_options<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
 };
 
@@ -174,7 +174,7 @@ struct ArrayParallelComponent {
   using metavariables = Metavariables;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<Parallel::Phase::Testing, tmpl::list<>>>;
-  using initialization_tags = Parallel::get_initialization_tags<
+  using simple_tags_from_options = Parallel::get_simple_tags_from_options<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
 };
 
@@ -186,7 +186,7 @@ struct GroupParallelComponent {
   using metavariables = Metavariables;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<Parallel::Phase::Testing, tmpl::list<>>>;
-  using initialization_tags = Parallel::get_initialization_tags<
+  using simple_tags_from_options = Parallel::get_simple_tags_from_options<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
 };
 
@@ -198,7 +198,7 @@ struct NodegroupParallelComponent {
   using metavariables = Metavariables;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<Parallel::Phase::Testing, tmpl::list<>>>;
-  using initialization_tags = Parallel::get_initialization_tags<
+  using simple_tags_from_options = Parallel::get_simple_tags_from_options<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
 };
 

--- a/tests/Unit/Parallel/Test_GlobalCache.cpp
+++ b/tests/Unit/Parallel/Test_GlobalCache.cpp
@@ -203,8 +203,7 @@ struct NodegroupParallelComponent {
 };
 
 struct TestMetavariables {
-  using const_global_cache_tags =
-      tmpl::list<Parallel::Tags::ResourceInfo<TestMetavariables>>;
+  using const_global_cache_tags = tmpl::list<>;
   using component_list =
       tmpl::list<SingletonParallelComponent<TestMetavariables>,
                  ArrayParallelComponent<TestMetavariables>,
@@ -386,11 +385,9 @@ template <typename Metavariables>
 void Test_GlobalCache<Metavariables>::run_single_core_test() {
   using const_tag_list =
       typename Parallel::get_const_global_cache_tags<TestMetavariables>;
-  static_assert(
-      std::is_same_v<const_tag_list,
-                     tmpl::list<Parallel::Tags::ResourceInfo<TestMetavariables>,
-                                name, age, height, shape_of_nametag>>,
-      "Wrong const_tag_list in GlobalCache test");
+  static_assert(std::is_same_v<const_tag_list,
+                               tmpl::list<name, age, height, shape_of_nametag>>,
+                "Wrong const_tag_list in GlobalCache test");
 
   using mutable_tag_list =
       typename Parallel::get_mutable_global_cache_tags<TestMetavariables>;
@@ -399,8 +396,7 @@ void Test_GlobalCache<Metavariables>::run_single_core_test() {
       "Wrong mutable_tag_list in GlobalCache test");
 
   tuples::tagged_tuple_from_typelist<const_tag_list> const_data_to_be_cached(
-      Parallel::ResourceInfo<Metavariables>{}, "Nobody", 178, 2.2,
-      std::make_unique<Square>());
+      "Nobody", 178, 2.2, std::make_unique<Square>());
   tuples::tagged_tuple_from_typelist<mutable_tag_list>
       mutable_data_to_be_cached(160, std::make_unique<Arthropod>(6),
                                 "joe@somewhere.com");
@@ -450,8 +446,7 @@ void Test_GlobalCache<Metavariables>::run_single_core_test() {
 
   Parallel::GlobalCache<TestMetavariables> cache_with_serialized_mutable_cache(
       tuples::tagged_tuple_from_typelist<const_tag_list>{
-          Parallel::ResourceInfo<Metavariables>{}, "Nobody", 178, 2.2,
-          std::make_unique<Square>()},
+          "Nobody", 178, 2.2, std::make_unique<Square>()},
       &serialized_and_deserialized_mutable_cache);
   SPECTRE_PARALLEL_REQUIRE(
       150 == Parallel::get<weight>(cache_with_serialized_mutable_cache));
@@ -509,11 +504,9 @@ Test_GlobalCache<Metavariables>::Test_GlobalCache(CkArgMsg*
 
   using const_tag_list =
       typename Parallel::get_const_global_cache_tags<TestMetavariables>;
-  static_assert(
-      std::is_same_v<const_tag_list,
-                     tmpl::list<Parallel::Tags::ResourceInfo<TestMetavariables>,
-                                name, age, height, shape_of_nametag>>,
-      "Wrong const_tag_list in GlobalCache test");
+  static_assert(std::is_same_v<const_tag_list,
+                               tmpl::list<name, age, height, shape_of_nametag>>,
+                "Wrong const_tag_list in GlobalCache test");
   static_assert(
       Parallel::is_in_const_global_cache<TestMetavariables, shape_of_nametag>);
   static_assert(
@@ -529,14 +522,12 @@ Test_GlobalCache<Metavariables>::Test_GlobalCache(CkArgMsg*
                                                shape_of_nametag_base>);
 
   tuples::tagged_tuple_from_typelist<const_tag_list> const_data_to_be_cached(
-      Parallel::ResourceInfo<Metavariables>{}, "Nobody", 178, 2.2,
-      std::make_unique<Square>());
+      "Nobody", 178, 2.2, std::make_unique<Square>());
   global_cache_proxy_ = Parallel::CProxy_GlobalCache<TestMetavariables>::ckNew(
       const_data_to_be_cached, mutable_global_cache_proxy_, std::nullopt,
       &mutable_global_cache_dependency);
 
-  Parallel::ResourceInfo<TestMetavariables> resource_info{
-      false, Parallel::SingletonPack<tmpl::list<>>{}};
+  Parallel::ResourceInfo<TestMetavariables> resource_info{false};
 
   const auto local_cache = Parallel::local_branch(global_cache_proxy_);
   auto mutable_global_cache_proxy = local_cache->mutable_global_cache_proxy();
@@ -547,8 +538,7 @@ Test_GlobalCache<Metavariables>::Test_GlobalCache(CkArgMsg*
 
   local_cache->set_resource_info(resource_info);
 
-  const auto& cache_resource_info =
-      Parallel::get<Parallel::Tags::ResourceInfo<Metavariables>>(*local_cache);
+  const auto& cache_resource_info = local_cache->get_resource_info();
 
   SPECTRE_PARALLEL_REQUIRE(cache_resource_info == resource_info);
 

--- a/tests/Unit/Parallel/Test_ParallelComponentHelpers.cpp
+++ b/tests/Unit/Parallel/Test_ParallelComponentHelpers.cpp
@@ -80,40 +80,6 @@ struct ComponentInitAndExecute {
       Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
 };
 
-struct ComponentInitWithAllocate {
-  using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
-      Parallel::Phase::Initialization,
-      tmpl::list<InitAction0, InitAction1, InitAction2>>>;
-  using array_allocation_tags = tmpl::list<InitTag4, InitTag5>;
-  using simple_tags_from_options = Parallel::get_simple_tags_from_options<
-      Parallel::get_initialization_actions_list<phase_dependent_action_list>,
-      array_allocation_tags>;
-  using const_global_cache_tags = tmpl::list<Tag1, Tag5, Tag7>;
-};
-
-struct ComponentExecuteWithAllocate {
-  using phase_dependent_action_list =
-      tmpl::list<Parallel::PhaseActions<Parallel::Phase::Execute,
-                                        tmpl::list<Action0, Action1>>>;
-  using array_allocation_tags = tmpl::list<InitTag6, InitTag7>;
-  using simple_tags_from_options = Parallel::get_simple_tags_from_options<
-      Parallel::get_initialization_actions_list<phase_dependent_action_list>,
-      array_allocation_tags>;
-};
-
-struct ComponentInitAndExecuteWithAllocate {
-  using phase_dependent_action_list = tmpl::list<
-      Parallel::PhaseActions<Parallel::Phase::Initialization,
-                             tmpl::list<InitAction3>>,
-      Parallel::PhaseActions<Parallel::Phase::Execute,
-                             tmpl::list<InitAction2, Action0, Action2>>>;
-  using array_allocation_tags = tmpl::list<InitTag3, InitTag4>;
-  using simple_tags_from_options = Parallel::get_simple_tags_from_options<
-      Parallel::get_initialization_actions_list<phase_dependent_action_list>,
-      array_allocation_tags>;
-  using const_global_cache_tags = tmpl::list<Tag2, Tag4>;
-};
-
 struct Metavariables0 {
   using component_list = tmpl::list<ComponentInit>;
 };
@@ -123,15 +89,6 @@ struct Metavariables1 {
   using component_list = tmpl::list<>;
 };
 
-struct Metavariables2 {
-  using component_list = tmpl::list<ComponentInitWithAllocate>;
-};
-
-struct Metavariables3 {
-  using const_global_cache_tags = tmpl::list<Tag0, Tag4>;
-  using component_list = tmpl::list<ComponentInitWithAllocate>;
-};
-
 struct Metavariables4 {
   using component_list = tmpl::list<ComponentInitAndExecute>;
 };
@@ -139,15 +96,6 @@ struct Metavariables4 {
 struct Metavariables5 {
   using const_global_cache_tags = tmpl::list<Tag0, Tag4>;
   using component_list = tmpl::list<ComponentInitAndExecute>;
-};
-
-struct Metavariables6 {
-  using component_list = tmpl::list<ComponentInitAndExecuteWithAllocate>;
-};
-
-struct Metavariables7 {
-  using const_global_cache_tags = tmpl::list<Tag0, Tag4>;
-  using component_list = tmpl::list<ComponentInitAndExecuteWithAllocate>;
 };
 
 static_assert(
@@ -167,16 +115,6 @@ static_assert(
     "Failed testing get_const_global_cache_tags");
 
 static_assert(
-    std::is_same_v<Parallel::get_const_global_cache_tags<Metavariables2>,
-                   tmpl::list<Tag1, Tag5, Tag7>>,
-    "Failed testing get_const_global_cache_tags");
-
-static_assert(
-    std::is_same_v<Parallel::get_const_global_cache_tags<Metavariables3>,
-                   tmpl::list<Tag0, Tag4, Tag1, Tag5, Tag7>>,
-    "Failed testing get_const_global_cache_tags");
-
-static_assert(
     std::is_same_v<Parallel::get_const_global_cache_tags<Metavariables4>,
                    tmpl::list<Tag6>>,
     "Failed testing get_const_global_cache_tags");
@@ -184,16 +122,6 @@ static_assert(
 static_assert(
     std::is_same_v<Parallel::get_const_global_cache_tags<Metavariables5>,
                    tmpl::list<Tag0, Tag4, Tag6>>,
-    "Failed testing get_const_global_cache_tags");
-
-static_assert(
-    std::is_same_v<Parallel::get_const_global_cache_tags<Metavariables6>,
-                   tmpl::list<Tag2, Tag4, Tag6>>,
-    "Failed testing get_const_global_cache_tags");
-
-static_assert(
-    std::is_same_v<Parallel::get_const_global_cache_tags<Metavariables7>,
-                   tmpl::list<Tag0, Tag4, Tag2, Tag6>>,
     "Failed testing get_const_global_cache_tags");
 
 static_assert(std::is_same_v<Parallel::get_initialization_actions_list<
@@ -222,21 +150,6 @@ static_assert(
 
 static_assert(std::is_same_v<ComponentInitAndExecute::simple_tags_from_options,
                              tmpl::list<InitTag0, InitTag1, InitTag3>>,
-              "Failed testing get_simple_tags_from_options");
-
-static_assert(std::is_same_v<
-                  ComponentInitWithAllocate::simple_tags_from_options,
-                  tmpl::list<InitTag4, InitTag5, InitTag0, InitTag1, InitTag2>>,
-              "Failed testing get_simple_tags_from_options");
-
-static_assert(
-    std::is_same_v<ComponentExecuteWithAllocate::simple_tags_from_options,
-                   tmpl::list<InitTag6, InitTag7>>,
-    "Failed testing get_simple_tags_from_options");
-
-static_assert(std::is_same_v<
-                  ComponentInitAndExecuteWithAllocate::simple_tags_from_options,
-                  tmpl::list<InitTag3, InitTag4, InitTag0, InitTag1>>,
               "Failed testing get_simple_tags_from_options");
 
 namespace OptionTags {

--- a/tests/Unit/Parallel/Test_ParallelComponentHelpers.cpp
+++ b/tests/Unit/Parallel/Test_ParallelComponentHelpers.cpp
@@ -43,21 +43,21 @@ struct InitTag6 {};
 struct InitTag7 {};
 
 struct InitAction0 {
-  using initialization_tags = tmpl::list<InitTag0>;
+  using simple_tags_from_options = tmpl::list<InitTag0>;
 };
 struct InitAction1 {};
 struct InitAction2 {
-  using initialization_tags = tmpl::list<InitTag1, InitTag2>;
+  using simple_tags_from_options = tmpl::list<InitTag1, InitTag2>;
 };
 struct InitAction3 {
-  using initialization_tags = tmpl::list<InitTag0, InitTag1, InitTag3>;
+  using simple_tags_from_options = tmpl::list<InitTag0, InitTag1, InitTag3>;
 };
 
 struct ComponentInit {
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
       Parallel::Phase::Initialization,
       tmpl::list<InitAction0, InitAction1, InitAction2>>>;
-  using initialization_tags = Parallel::get_initialization_tags<
+  using simple_tags_from_options = Parallel::get_simple_tags_from_options<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
 };
 
@@ -65,7 +65,7 @@ struct ComponentExecute {
   using phase_dependent_action_list =
       tmpl::list<Parallel::PhaseActions<Parallel::Phase::Execute,
                                         tmpl::list<Action0, Action1>>>;
-  using initialization_tags = Parallel::get_initialization_tags<
+  using simple_tags_from_options = Parallel::get_simple_tags_from_options<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
   using const_global_cache_tags = tmpl::list<Tag2, Tag4>;
 };
@@ -76,7 +76,7 @@ struct ComponentInitAndExecute {
                              tmpl::list<InitAction3>>,
       Parallel::PhaseActions<Parallel::Phase::Execute,
                              tmpl::list<InitAction2, Action0, Action2>>>;
-  using initialization_tags = Parallel::get_initialization_tags<
+  using simple_tags_from_options = Parallel::get_simple_tags_from_options<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
 };
 
@@ -85,7 +85,7 @@ struct ComponentInitWithAllocate {
       Parallel::Phase::Initialization,
       tmpl::list<InitAction0, InitAction1, InitAction2>>>;
   using array_allocation_tags = tmpl::list<InitTag4, InitTag5>;
-  using initialization_tags = Parallel::get_initialization_tags<
+  using simple_tags_from_options = Parallel::get_simple_tags_from_options<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>,
       array_allocation_tags>;
   using const_global_cache_tags = tmpl::list<Tag1, Tag5, Tag7>;
@@ -96,7 +96,7 @@ struct ComponentExecuteWithAllocate {
       tmpl::list<Parallel::PhaseActions<Parallel::Phase::Execute,
                                         tmpl::list<Action0, Action1>>>;
   using array_allocation_tags = tmpl::list<InitTag6, InitTag7>;
-  using initialization_tags = Parallel::get_initialization_tags<
+  using simple_tags_from_options = Parallel::get_simple_tags_from_options<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>,
       array_allocation_tags>;
 };
@@ -108,7 +108,7 @@ struct ComponentInitAndExecuteWithAllocate {
       Parallel::PhaseActions<Parallel::Phase::Execute,
                              tmpl::list<InitAction2, Action0, Action2>>>;
   using array_allocation_tags = tmpl::list<InitTag3, InitTag4>;
-  using initialization_tags = Parallel::get_initialization_tags<
+  using simple_tags_from_options = Parallel::get_simple_tags_from_options<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>,
       array_allocation_tags>;
   using const_global_cache_tags = tmpl::list<Tag2, Tag4>;
@@ -212,31 +212,32 @@ static_assert(
                    tmpl::list<InitAction3>>,
     "Failed testing get_intialization_actions_list");
 
-static_assert(std::is_same_v<ComponentInit::initialization_tags,
+static_assert(std::is_same_v<ComponentInit::simple_tags_from_options,
                              tmpl::list<InitTag0, InitTag1, InitTag2>>,
-              "Failed testing get_initialization_tags");
+              "Failed testing get_simple_tags_from_options");
 
 static_assert(
-    std::is_same_v<ComponentExecute::initialization_tags, tmpl::list<>>,
-    "Failed testing get_initialization_tags");
+    std::is_same_v<ComponentExecute::simple_tags_from_options, tmpl::list<>>,
+    "Failed testing get_simple_tags_from_options");
 
-static_assert(std::is_same_v<ComponentInitAndExecute::initialization_tags,
+static_assert(std::is_same_v<ComponentInitAndExecute::simple_tags_from_options,
                              tmpl::list<InitTag0, InitTag1, InitTag3>>,
-              "Failed testing get_initialization_tags");
+              "Failed testing get_simple_tags_from_options");
 
 static_assert(std::is_same_v<
-                  ComponentInitWithAllocate::initialization_tags,
+                  ComponentInitWithAllocate::simple_tags_from_options,
                   tmpl::list<InitTag4, InitTag5, InitTag0, InitTag1, InitTag2>>,
-              "Failed testing get_initialization_tags");
-
-static_assert(std::is_same_v<ComponentExecuteWithAllocate::initialization_tags,
-                             tmpl::list<InitTag6, InitTag7>>,
-              "Failed testing get_initialization_tags");
+              "Failed testing get_simple_tags_from_options");
 
 static_assert(
-    std::is_same_v<ComponentInitAndExecuteWithAllocate::initialization_tags,
-                   tmpl::list<InitTag3, InitTag4, InitTag0, InitTag1>>,
-    "Failed testing get_initialization_tags");
+    std::is_same_v<ComponentExecuteWithAllocate::simple_tags_from_options,
+                   tmpl::list<InitTag6, InitTag7>>,
+    "Failed testing get_simple_tags_from_options");
+
+static_assert(std::is_same_v<
+                  ComponentInitAndExecuteWithAllocate::simple_tags_from_options,
+                  tmpl::list<InitTag3, InitTag4, InitTag0, InitTag1>>,
+              "Failed testing get_simple_tags_from_options");
 
 namespace OptionTags {
 struct Yards {
@@ -304,29 +305,31 @@ struct FullGreeting {
 }  // namespace Tags
 }  // namespace Initialization
 
-using initialization_tags_0 = tmpl::list<>;
+using simple_tags_from_options_0 = tmpl::list<>;
 
-using initialization_tags_1 =
+using simple_tags_from_options_1 =
     tmpl::list<Initialization::Tags::Yards, Initialization::Tags::Feet,
                Initialization::Tags::Sides>;
 
-using initialization_tags_2 =
+using simple_tags_from_options_2 =
     tmpl::list<Initialization::Tags::Yards, Initialization::Tags::Feet,
                Initialization::Tags::FullGreeting>;
 
 static_assert(
-    std::is_same_v<Parallel::get_option_tags<initialization_tags_0, NoSuchType>,
-                   tmpl::list<>>,
-    "Failed testing get_option_tags");
-
-static_assert(
-    std::is_same_v<Parallel::get_option_tags<initialization_tags_1, NoSuchType>,
-                   tmpl::list<OptionTags::Yards, OptionTags::Dim>>,
+    std::is_same_v<
+        Parallel::get_option_tags<simple_tags_from_options_0, NoSuchType>,
+        tmpl::list<>>,
     "Failed testing get_option_tags");
 
 static_assert(
     std::is_same_v<
-        Parallel::get_option_tags<initialization_tags_2, NoSuchType>,
+        Parallel::get_option_tags<simple_tags_from_options_1, NoSuchType>,
+        tmpl::list<OptionTags::Yards, OptionTags::Dim>>,
+    "Failed testing get_option_tags");
+
+static_assert(
+    std::is_same_v<
+        Parallel::get_option_tags<simple_tags_from_options_2, NoSuchType>,
         tmpl::list<OptionTags::Yards, OptionTags::Greeting, OptionTags::Name>>,
     "Failed testing get_option_tags");
 
@@ -337,14 +340,14 @@ template <typename Metavariables, typename... InitializationTags>
 void check_initialization_items(
     const Options::Parser<all_option_tags>& all_options,
     const tuples::TaggedTuple<InitializationTags...>& expected_items) {
-  using initialization_tags = tmpl::list<InitializationTags...>;
+  using simple_tags_from_options = tmpl::list<InitializationTags...>;
   using option_tags =
-      Parallel::get_option_tags<initialization_tags, Metavariables>;
+      Parallel::get_option_tags<simple_tags_from_options, Metavariables>;
   const auto options = all_options.apply<option_tags>([](auto... args) {
     return tuples::tagged_tuple_from_typelist<option_tags>(std::move(args)...);
   });
   CHECK(Parallel::create_from_options<Metavariables>(
-            options, initialization_tags{}) == expected_items);
+            options, simple_tags_from_options{}) == expected_items);
 }
 }  // namespace
 

--- a/tests/Unit/Parallel/Test_PhaseChangeMain.cpp
+++ b/tests/Unit/Parallel/Test_PhaseChangeMain.cpp
@@ -145,7 +145,7 @@ struct GroupComponent {
       Parallel::PhaseActions<
           Parallel::Phase::Evolve,
           tmpl::list<IncrementStep, ReportGroupPhaseControlDataAndTerminate>>>;
-  using initialization_tags = Parallel::get_initialization_tags<
+  using simple_tags_from_options = Parallel::get_simple_tags_from_options<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
 
   static void execute_next_phase(
@@ -169,12 +169,12 @@ struct ArrayComponent {
       Parallel::PhaseActions<
           Parallel::Phase::Evolve,
           tmpl::list<IncrementStep, ReportArrayPhaseControlDataAndTerminate>>>;
-  using initialization_tags = Parallel::get_initialization_tags<
+  using simple_tags_from_options = Parallel::get_simple_tags_from_options<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
 
   static void allocate_array(
       Parallel::CProxy_GlobalCache<Metavariables>& global_cache,
-      const tuples::tagged_tuple_from_typelist<initialization_tags>&
+      const tuples::tagged_tuple_from_typelist<simple_tags_from_options>&
       /*initialization_items*/,
       const std::unordered_set<size_t>& procs_to_ignore = {}) {
     auto& local_cache = *Parallel::local_branch(global_cache);

--- a/tests/Unit/Parallel/Test_ResourceInfo.cpp
+++ b/tests/Unit/Parallel/Test_ResourceInfo.cpp
@@ -31,7 +31,7 @@ struct FakeSingleton {
   static std::string name() { return "FakeSingleton" + get_output(Index); }
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<Parallel::Phase::Initialization, tmpl::list<>>>;
-  using initialization_tags = tmpl::list<
+  using simple_tags_from_options = tmpl::list<
       Parallel::Tags::AvoidGlobalProc0,
       Parallel::Tags::SingletonInfo<FakeSingleton<Metavariables, Index>>>;
 };
@@ -43,7 +43,7 @@ struct FakeSingletonInfoOnly {
   static std::string name() { return "FakeSingleton" + get_output(Index); }
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<Parallel::Phase::Initialization, tmpl::list<>>>;
-  using initialization_tags = tmpl::list<Parallel::Tags::SingletonInfo<
+  using simple_tags_from_options = tmpl::list<Parallel::Tags::SingletonInfo<
       FakeSingletonInfoOnly<Metavariables, Index>>>;
 };
 template <typename Metavariables>
@@ -52,7 +52,7 @@ struct FakeSingletonAvoidGlobalProc0 {
   using metavariables = Metavariables;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<Parallel::Phase::Initialization, tmpl::list<>>>;
-  using initialization_tags = tmpl::list<Parallel::Tags::AvoidGlobalProc0>;
+  using simple_tags_from_options = tmpl::list<Parallel::Tags::AvoidGlobalProc0>;
 };
 
 template <size_t... Indices>

--- a/tests/Unit/Parallel/Test_SectionReductions.cpp
+++ b/tests/Unit/Parallel/Test_SectionReductions.cpp
@@ -143,9 +143,11 @@ struct ArrayComponent {
       // for convenient access
       Parallel::Tags::Section<ArrayComponent, EvenOrOddTag>,
       Parallel::Tags::Section<ArrayComponent, IsFirstElementTag>>;
-  using simple_tags_from_options = Parallel::get_simple_tags_from_options<
-      Parallel::get_initialization_actions_list<phase_dependent_action_list>,
-      array_allocation_tags>;
+  using simple_tags_from_options =
+      tmpl::append<Parallel::get_simple_tags_from_options<
+                       Parallel::get_initialization_actions_list<
+                           phase_dependent_action_list>>,
+                   array_allocation_tags>;
 
   static void allocate_array(
       Parallel::CProxy_GlobalCache<Metavariables>& global_cache,

--- a/tests/Unit/Parallel/Test_SectionReductions.cpp
+++ b/tests/Unit/Parallel/Test_SectionReductions.cpp
@@ -143,13 +143,13 @@ struct ArrayComponent {
       // for convenient access
       Parallel::Tags::Section<ArrayComponent, EvenOrOddTag>,
       Parallel::Tags::Section<ArrayComponent, IsFirstElementTag>>;
-  using initialization_tags = Parallel::get_initialization_tags<
+  using simple_tags_from_options = Parallel::get_simple_tags_from_options<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>,
       array_allocation_tags>;
 
   static void allocate_array(
       Parallel::CProxy_GlobalCache<Metavariables>& global_cache,
-      tuples::tagged_tuple_from_typelist<initialization_tags>
+      tuples::tagged_tuple_from_typelist<simple_tags_from_options>
           initialization_items,
       const std::unordered_set<size_t>& procs_to_ignore = {}) {
     auto& local_cache = *Parallel::local_branch(global_cache);

--- a/tests/Unit/Parallel/Test_TypeTraits.cpp
+++ b/tests/Unit/Parallel/Test_TypeTraits.cpp
@@ -28,23 +28,23 @@ struct Metavariables {
 
 struct SingletonParallelComponent {
   using metavariables = Metavariables;
-  using initialization_tags = tmpl::list<>;
+  using simple_tags_from_options = tmpl::list<>;
   using chare_type = Parallel::Algorithms::Singleton;
 };
 struct ArrayParallelComponent {
   using metavariables = Metavariables;
-  using initialization_tags = tmpl::list<>;
+  using simple_tags_from_options = tmpl::list<>;
   using chare_type = Parallel::Algorithms::Array;
   using array_index = int;
 };
 struct GroupParallelComponent {
   using metavariables = Metavariables;
-  using initialization_tags = tmpl::list<>;
+  using simple_tags_from_options = tmpl::list<>;
   using chare_type = Parallel::Algorithms::Group;
 };
 struct NodegroupParallelComponent {
   using metavariables = Metavariables;
-  using initialization_tags = tmpl::list<>;
+  using simple_tags_from_options = tmpl::list<>;
   using chare_type = Parallel::Algorithms::Nodegroup;
 };
 

--- a/tests/Unit/ParallelAlgorithms/Actions/Test_UpdateMessageQueue.cpp
+++ b/tests/Unit/ParallelAlgorithms/Actions/Test_UpdateMessageQueue.cpp
@@ -61,7 +61,8 @@ struct Component {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = int;
-  using initialization_tags = tmpl::list<LinkedMessageQueueTag, ProcessorCalls>;
+  using simple_tags_from_options =
+      tmpl::list<LinkedMessageQueueTag, ProcessorCalls>;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<Parallel::Phase::Initialization, tmpl::list<>>>;
 };

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/ConjugateGradient/Test_ConjugateGradientAlgorithm.yaml
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/ConjugateGradient/Test_ConjugateGradientAlgorithm.yaml
@@ -18,3 +18,7 @@ SerialCg:
   Verbosity: Verbose
 
 ConvergenceReason: AbsoluteResidual
+
+ResourceInfo:
+  AvoidGlobalProc0: false
+  Singletons: Auto

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/ConjugateGradient/Test_DistributedConjugateGradientAlgorithm.yaml
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/ConjugateGradient/Test_DistributedConjugateGradientAlgorithm.yaml
@@ -13,6 +13,7 @@
 
 ResourceInfo:
   AvoidGlobalProc0: false
+  Singletons: Auto
 
 DomainCreator:
   Interval:

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/Test_DistributedGmresAlgorithm.yaml
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/Test_DistributedGmresAlgorithm.yaml
@@ -14,6 +14,7 @@
 
 ResourceInfo:
   AvoidGlobalProc0: false
+  Singletons: Auto
 
 DomainCreator:
   Interval:

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/Test_DistributedGmresPreconditionedAlgorithm.yaml
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/Test_DistributedGmresPreconditionedAlgorithm.yaml
@@ -15,6 +15,7 @@
 
 ResourceInfo:
   AvoidGlobalProc0: false
+  Singletons: Auto
 
 DomainCreator:
   Interval:

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/Test_GmresAlgorithm.yaml
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/Test_GmresAlgorithm.yaml
@@ -18,3 +18,7 @@ SerialGmres:
   Verbosity: Verbose
 
 ConvergenceReason: AbsoluteResidual
+
+ResourceInfo:
+  AvoidGlobalProc0: false
+  Singletons: Auto

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/Test_GmresPreconditionedAlgorithm.yaml
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/Test_GmresPreconditionedAlgorithm.yaml
@@ -23,3 +23,7 @@ Preconditioner:
   Verbosity: Verbose
 
 ConvergenceReason: AbsoluteResidual
+
+ResourceInfo:
+  AvoidGlobalProc0: false
+  Singletons: Auto

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Multigrid/Test_MultigridAlgorithm.yaml
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Multigrid/Test_MultigridAlgorithm.yaml
@@ -16,6 +16,7 @@
 
 ResourceInfo:
   AvoidGlobalProc0: false
+  Singletons: Auto
 
 DomainCreator:
   Interval:

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Multigrid/Test_MultigridAlgorithmMassive.yaml
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Multigrid/Test_MultigridAlgorithmMassive.yaml
@@ -7,6 +7,7 @@
 
 ResourceInfo:
   AvoidGlobalProc0: false
+  Singletons: Auto
 
 DomainCreator:
   Interval:

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Multigrid/Test_MultigridPreconditionedGmresAlgorithm.yaml
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Multigrid/Test_MultigridPreconditionedGmresAlgorithm.yaml
@@ -6,6 +6,7 @@
 
 ResourceInfo:
   AvoidGlobalProc0: false
+  Singletons: Auto
 
 DomainCreator:
   Interval:

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Richardson/Test_DistributedRichardsonAlgorithm.yaml
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Richardson/Test_DistributedRichardsonAlgorithm.yaml
@@ -13,6 +13,7 @@
 
 ResourceInfo:
   AvoidGlobalProc0: false
+  Singletons: Auto
 
 DomainCreator:
   Interval:

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Richardson/Test_RichardsonAlgorithm.yaml
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Richardson/Test_RichardsonAlgorithm.yaml
@@ -16,3 +16,7 @@ SerialRichardson:
   Verbosity: Verbose
 
 ConvergenceReason: NumIterations
+
+ResourceInfo:
+  AvoidGlobalProc0: false
+  Singletons: Auto

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Schwarz/Test_SchwarzAlgorithm.yaml
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Schwarz/Test_SchwarzAlgorithm.yaml
@@ -14,6 +14,7 @@
 
 ResourceInfo:
   AvoidGlobalProc0: false
+  Singletons: Auto
 
 DomainCreator:
   Interval:

--- a/tests/Unit/ParallelAlgorithms/NonlinearSolver/NewtonRaphson/Test_NewtonRaphsonAlgorithm.yaml
+++ b/tests/Unit/ParallelAlgorithms/NonlinearSolver/NewtonRaphson/Test_NewtonRaphsonAlgorithm.yaml
@@ -26,3 +26,7 @@ LinearSolver:
 Observers:
   VolumeFileName: "Test_NewtonRaphsonAlgorithm_Volume"
   ReductionFileName: "Test_NewtonRaphsonAlgorithm_Reductions"
+
+ResourceInfo:
+  AvoidGlobalProc0: false
+  Singletons: Auto


### PR DESCRIPTION
## Proposed changes

- Rename initialization_tags to simple_tags_from_options (It makes it more clear what they are used for, i.e. adding simple tags to the DataBox for items initialized from input file options.)
- Get rid of array_allocation_tags in array components.  (In all cases, they end up being needed as simple tags in the DataBox; just make life simpler.)
- Decouple ResourceInfo from simple_tags_from_options (Makes life simpler.  Avoids using tag lists meant for DataBox initialization to initialize something in the GlobalCache.)
- Always add ResourceInfo to the GlobalCache and provide a reference item to fetch it from a Distributed Object's DataBox as well.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

- Do not add ResourceInfo, AvoidGlobalProc0, or Singletons tags to tag lists. 
- If you have an input file, you need to specify a ResourceInfo option, and if the executable has Singletons, you must specify the Singletons sub-option.  To keep prior behavior use:
```
ResourceInfo:
  AvoidGlobalProc0: false
  Singletons: Auto
```
- If you have specified explicit options for a singleton, you will need to do so for all singletons.

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
