### PR TITLE
Parallelize ExtractDatFromH5.py

### DIFF
--- a/src/IO/H5/Python/ExtractDatFromH5.py
+++ b/src/IO/H5/Python/ExtractDatFromH5.py
@@ -3,24 +3,44 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-from spectre.IO import H5 as spectre_h5
+from spectre.Visualization.ReadH5 import available_subfiles
+import h5py
 import click
-import spectre.DataStructures
+import multiprocessing as mp
 import numpy as np
 import os
 import shutil
 
 
-def extract_dat_files(filename, out_dir, list=False, force=False):
+def save_dat_data(dat_path, h5_filename, out_dir):
+    dat_dir = os.path.join(out_dir, os.path.dirname(dat_path))
+    os.makedirs(dat_dir, exist_ok=True)
+    dat_filename = os.path.join(out_dir, dat_path)
+
+    with h5py.File(h5_filename, "r") as h5file:
+        dat_file = h5file.get(dat_path)
+        legend = dat_file.attrs["Legend"]
+        dat_data = np.array(dat_file)
+
+    header = "\n".join(f"[{i}] " + "{}"
+                       for i in range(len(legend))).format(*legend)
+
+    np.savetxt(dat_filename,
+               dat_data,
+               delimiter=' ',
+               fmt="% .15e",
+               header=header)
+
+
+def extract_dat_files(filename, out_dir, num_cores, list=False, force=False):
     """Extract dat files from an H5 file
 
     Extract all Dat files inside a SpECTRE HDF5 file. The resulting files will
     be put into the 'OUT_DIR'. The directory structure will be identical to the
     group structure inside the HDF5 file.
     """
-    h5file = spectre_h5.H5File(filename, "r")
-
-    all_dat_files = h5file.all_dat_files()
+    with h5py.File(filename, "r") as h5file:
+        all_dat_files = available_subfiles(h5file, extension=".dat")
 
     if list:
         print_str = "\n ".join(all_dat_files)
@@ -40,28 +60,19 @@ def extract_dat_files(filename, out_dir, list=False, force=False):
             raise ValueError(
                 f"Could not make directory '{out_dir}'. Already exists.")
 
-    for dat_path in all_dat_files:
-        split_path = dat_path.split("/")
-        dat_dir = out_dir + "/".join(split_path[:-1])
-        dat_filename = out_dir + dat_path
+    num_dat_files = len(all_dat_files)
 
-        os.makedirs(dat_dir, exist_ok=True)
-
-        dat_file = h5file.get_dat(dat_path[:-4])
-
-        legend = dat_file.get_legend()
-        header = "\n".join(f"[{i}] " + "{}"
-                           for i in range(len(legend))).format(*legend)
-
-        dat_data = np.array(dat_file.get_data())
-
-        np.savetxt(dat_filename,
-                   dat_data,
-                   delimiter=' ',
-                   fmt="% .15e",
-                   header=header)
-
-        h5file.close()
+    # Only use multiprocessing if we are using more than one core. Otherwise
+    # avoid the overhead
+    if num_cores > 1:
+        with mp.Pool(processes=num_cores) as pool:
+            pool.starmap(
+                save_dat_data,
+                zip(all_dat_files, [filename] * num_dat_files,
+                    [out_dir] * num_dat_files))
+    else:
+        for dat_filename in all_dat_files:
+            save_dat_data(dat_filename, filename, out_dir)
 
     print(f"Successfully extracted all Dat files into '{out_dir}'")
 
@@ -75,6 +86,11 @@ def extract_dat_files(filename, out_dir, list=False, force=False):
 @click.argument("out_dir",
                 type=click.Path(file_okay=False, dir_okay=True, writable=True),
                 required=False)
+@click.option('--num-cores',
+              '-j',
+              default=1,
+              show_default=True,
+              help="Number of cores to run on.")
 @click.option('--force',
               '-f',
               is_flag=True,

--- a/src/IO/H5/Python/ExtractDatFromH5.py
+++ b/src/IO/H5/Python/ExtractDatFromH5.py
@@ -24,7 +24,7 @@ def extract_dat_files(filename, out_dir, list=False, force=False):
 
     if list:
         print_str = "\n ".join(all_dat_files)
-        print("Dat files within '{}':\n {}".format(filename, print_str))
+        print(f"Dat files within '{filename}':\n {print_str}")
         return
 
     if out_dir is None:
@@ -38,8 +38,7 @@ def extract_dat_files(filename, out_dir, list=False, force=False):
             os.mkdir(out_dir)
         else:
             raise ValueError(
-                "Could not make directory '{}'. Already exists.".format(
-                    out_dir))
+                f"Could not make directory '{out_dir}'. Already exists.")
 
     for dat_path in all_dat_files:
         split_path = dat_path.split("/")
@@ -51,7 +50,7 @@ def extract_dat_files(filename, out_dir, list=False, force=False):
         dat_file = h5file.get_dat(dat_path[:-4])
 
         legend = dat_file.get_legend()
-        header = "\n".join("[{}] ".format(i) + "{}"
+        header = "\n".join(f"[{i}] " + "{}"
                            for i in range(len(legend))).format(*legend)
 
         dat_data = np.array(dat_file.get_data())
@@ -64,7 +63,7 @@ def extract_dat_files(filename, out_dir, list=False, force=False):
 
         h5file.close()
 
-    print("Successfully extracted all Dat files into '{}'".format(out_dir))
+    print(f"Successfully extracted all Dat files into '{out_dir}'")
 
 
 @click.command(help=extract_dat_files.__doc__)


### PR DESCRIPTION
## Proposed changes

I noticed while trying to extract dat files from a run with CCE that if the files being extracted are fairly large (~1G or larger) this script runs pretty slow. Mostly due to writing large amounts of data to disk. Parallelizing the writing portion sped things up significantly.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
