### PR TITLE
Don't override functions of time in BBH

### DIFF
--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
@@ -174,7 +174,7 @@ struct EvolutionMetavars {
   // Set override_functions_of_time to true to override the
   // 2nd or 3rd order piecewise polynomial functions of time using
   // `read_spec_piecewise_polynomial()`
-  static constexpr bool override_functions_of_time = true;
+  static constexpr bool override_functions_of_time = false;
 
   using initialize_initial_data_dependent_quantities_actions =
       tmpl::list<GeneralizedHarmonic::gauges::Actions::InitializeDampedHarmonic<

--- a/tests/InputFiles/GeneralizedHarmonic/BinaryBlackHole.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/BinaryBlackHole.yaml
@@ -304,18 +304,3 @@ Importers:
       Shift: ShiftExcess
       SpatialMetric: SpatialMetric
       ExtrinsicCurvature: ExtrinsicCurvature
-
-# control.h5 should contain data for FunctionsOfTime that can be read by
-# ReadSpecPiecewisePolynomial. By default, this will override the spectre
-# control systems. To not replace any FunctionsOfTime, replace
-# "/path/to/control.h5" with None. To use spectre control systems, remove
-# Expansion or Rotation from the NameMap. Currently only Expansion and
-# Rotation control systems are supported in spectre.
-CubicFunctionOfTimeOverride:
-  FunctionOfTimeFile: "/path/to/control.h5"
-  # Note: SpEC calls the hole on the right hole A, but spectre calls hole A
-  # the hole on the left. So reverse the LambdaFactors used here
-  FunctionOfTimeNameMap: {ExpansionFactor: Expansion,
-                          RotationAngle: Rotation,
-                          LambdaFactorA0: SizeB,
-                          LambdaFactorB0: SizeA}


### PR DESCRIPTION
## Proposed changes

Now that I'm more confident that the control systems are working how I expect, we don't need to override them in the BBH executable.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
