### PR TITLE
Retrieve coordinate derivative of pressure from TOV star solution 

### DIFF
--- a/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/TovStar.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/TovStar.hpp
@@ -99,7 +99,10 @@ using TovVariablesCache = cached_temp_buffer_from_typelist<tmpl::list<
     hydro::Tags::SpecificEnthalpy<DataType>,
     hydro::Tags::RestMassDensity<DataType>,
     hydro::Tags::ElectronFraction<DataType>, hydro::Tags::Pressure<DataType>,
-    Tags::DrPressure<DataType>, hydro::Tags::SpecificInternalEnergy<DataType>,
+    Tags::DrPressure<DataType>,
+    ::Tags::deriv<hydro::Tags::Pressure<DataType>, tmpl::size_t<3>,
+                  Frame::Inertial>,
+    hydro::Tags::SpecificInternalEnergy<DataType>,
     Tags::MetricTimePotential<DataType>, Tags::DrMetricTimePotential<DataType>,
     Tags::MetricRadialPotential<DataType>,
     Tags::DrMetricRadialPotential<DataType>,
@@ -180,6 +183,11 @@ struct TovVariables {
   void operator()(gsl::not_null<Scalar<DataType>*> dr_pressure,
                   gsl::not_null<Cache*> cache,
                   Tags::DrPressure<DataType> /*meta*/) const;
+  void operator()(
+      gsl::not_null<tnsr::i<DataType, 3>*> deriv_pressure,
+      gsl::not_null<Cache*> cache,
+      ::Tags::deriv<hydro::Tags::Pressure<DataType>, tmpl::size_t<3>,
+                    Frame::Inertial> /*meta*/) const;
   void operator()(gsl::not_null<Scalar<DataType>*> specific_internal_energy,
                   gsl::not_null<Cache*> cache,
                   hydro::Tags::SpecificInternalEnergy<DataType> /*meta*/) const;


### PR DESCRIPTION
## Proposed changes

Add `()` operator returning dp/dx^i of TOV solution. This quantity is needed to compute initial magnetic fields.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

