### PR TITLE
Add abstract base class for GRMHD initial magnetic fields

### DIFF
--- a/src/PointwiseFunctions/AnalyticData/GrMhd/CMakeLists.txt
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/CMakeLists.txt
@@ -46,3 +46,5 @@ target_link_libraries(
   Options
   RelativisticEulerSolutions
   )
+
+add_subdirectory(InitialMagneticFields)

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/InitialMagneticFields/CMakeLists.txt
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/InitialMagneticFields/CMakeLists.txt
@@ -1,0 +1,9 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+spectre_target_headers(
+  ${LIBRARY}
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  InitialMagneticField.hpp
+  )

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/InitialMagneticFields/InitialMagneticField.hpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/InitialMagneticFields/InitialMagneticField.hpp
@@ -1,0 +1,57 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <memory>
+#include <pup.h>
+
+#include "Parallel/CharmPupable.hpp"
+
+namespace grmhd::AnalyticData {
+
+/*!
+ * \brief Things related to the initial (seed) magnetic field that can be
+ * superposed on GRMHD initial data.
+ *
+ * In many cases we assign magnetic fields in terms of the vector potential,
+ * which can be computed as
+ *
+ * \f{align*}{
+ *   B^i & = n_a\epsilon^{aijk}\partial_jA_k \\
+ *       & = \frac{1}{\sqrt{\gamma}}[ijk]\partial_j A_k,
+ * \f}
+ *
+ * where \f$[ijk]\f$ is the total anti-symmetric symbol.
+ *
+ * For example, in the Cartesian coordinates,
+ *
+ * \f{align*}{
+ *   B^x & = \frac{1}{\sqrt{\gamma}} (\partial_y A_z - \partial_z A_y), \\
+ *   B^y & = \frac{1}{\sqrt{\gamma}} (\partial_z A_x - \partial_x A_z), \\
+ *   B^z & = \frac{1}{\sqrt{\gamma}} (\partial_x A_y - \partial_y A_x).
+ * \f}
+ *
+ */
+namespace InitialMagneticFields {
+
+/*!
+ * \brief The abstract base class for initial magnetic field configurations.
+ */
+class InitialMagneticField : public PUP::able {
+ protected:
+  InitialMagneticField() = default;
+
+ public:
+  ~InitialMagneticField() override = default;
+
+  virtual auto get_clone() const -> std::unique_ptr<InitialMagneticField> = 0;
+
+  /// \cond
+  explicit InitialMagneticField(CkMigrateMessage* msg) : PUP::able(msg) {}
+  WRAPPED_PUPable_abstract(InitialMagneticField);
+  /// \endcond
+};
+
+}  // namespace InitialMagneticFields
+}  // namespace grmhd::AnalyticData


### PR DESCRIPTION
## Proposed changes

A base class that the initial magnetic fields (poloidal, toroidal, etc..) classes for GRMHD simulations should inherit.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
