### PR TITLE
Decouple metavariables and LTS in step chooser simple tags

### DIFF
--- a/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
+++ b/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
@@ -303,7 +303,8 @@ struct EvolutionMetavars {
           tmpl::list<>>,
 
       Initialization::Actions::AddComputeTags<
-          StepChoosers::step_chooser_compute_tags<EvolutionMetavars>>,
+          StepChoosers::step_chooser_compute_tags<EvolutionMetavars,
+                                                  local_time_stepping>>,
       ::evolution::dg::Initialization::Mortars<volume_dim, system>,
       Initialization::Actions::Minmod<1>,
       evolution::Actions::InitializeRunEventsAndDenseTriggers,

--- a/src/Evolution/Executables/CurvedScalarWave/EvolveCurvedScalarWave.hpp
+++ b/src/Evolution/Executables/CurvedScalarWave/EvolveCurvedScalarWave.hpp
@@ -289,8 +289,9 @@ struct EvolutionMetavars {
               volume_dim>,
           CurvedScalarWave::Initialization::InitializeEvolvedVariables<
               volume_dim>>,
-      Initialization::Actions::AddComputeTags<tmpl::flatten<tmpl::list<
-          StepChoosers::step_chooser_compute_tags<EvolutionMetavars>>>>,
+      Initialization::Actions::AddComputeTags<
+          tmpl::flatten<tmpl::list<StepChoosers::step_chooser_compute_tags<
+              EvolutionMetavars, local_time_stepping>>>>,
       ::evolution::dg::Initialization::Mortars<volume_dim, system>,
       intrp::Actions::ElementInitInterpPoints<
           intrp::Tags::InterpPointInfo<EvolutionMetavars>>,

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
@@ -438,8 +438,9 @@ struct EvolutionMetavars {
           typename system::gradient_variables>>,
       Initialization::Actions::TimeStepperHistory<EvolutionMetavars>,
       GeneralizedHarmonic::Actions::InitializeGhAnd3Plus1Variables<volume_dim>,
-      Initialization::Actions::AddComputeTags<tmpl::push_back<
-          StepChoosers::step_chooser_compute_tags<EvolutionMetavars>>>,
+      Initialization::Actions::AddComputeTags<
+          tmpl::push_back<StepChoosers::step_chooser_compute_tags<
+              EvolutionMetavars, local_time_stepping>>>,
       ::evolution::dg::Initialization::Mortars<volume_dim, system>,
       evolution::Actions::InitializeRunEventsAndDenseTriggers,
       control_system::Actions::InitializeMeasurements<control_systems>,

--- a/src/Evolution/Executables/GeneralizedHarmonic/GeneralizedHarmonicBase.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/GeneralizedHarmonicBase.hpp
@@ -365,7 +365,7 @@ struct GeneralizedHarmonicTemplateBase<
       GeneralizedHarmonic::Actions::InitializeGhAnd3Plus1Variables<volume_dim>,
       Initialization::Actions::AddComputeTags<
           tmpl::push_back<StepChoosers::step_chooser_compute_tags<
-              GeneralizedHarmonicTemplateBase>>>,
+              GeneralizedHarmonicTemplateBase, local_time_stepping>>>,
       ::evolution::dg::Initialization::Mortars<volume_dim, system>,
       evolution::Actions::InitializeRunEventsAndDenseTriggers,
       Parallel::Actions::TerminatePhase>;

--- a/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
+++ b/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
@@ -395,7 +395,7 @@ struct GhValenciaDivCleanTemplateBase<
       GeneralizedHarmonic::Actions::InitializeGhAnd3Plus1Variables<volume_dim>,
       Initialization::Actions::AddComputeTags<
           StepChoosers::step_chooser_compute_tags<
-              GhValenciaDivCleanTemplateBase>>,
+              GhValenciaDivCleanTemplateBase, local_time_stepping>>,
       ::evolution::dg::Initialization::Mortars<volume_dim, system>,
       Initialization::Actions::Minmod<3>,
       intrp::Actions::ElementInitInterpPoints<

--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
@@ -460,7 +460,8 @@ struct EvolutionMetavars {
           tmpl::list<>>,
 
       Initialization::Actions::AddComputeTags<
-          StepChoosers::step_chooser_compute_tags<EvolutionMetavars>>,
+          StepChoosers::step_chooser_compute_tags<EvolutionMetavars,
+                                                  local_time_stepping>>,
       ::evolution::dg::Initialization::Mortars<volume_dim, system>,
       Initialization::Actions::Minmod<3>,
       evolution::Actions::InitializeRunEventsAndDenseTriggers,

--- a/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
+++ b/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
@@ -267,7 +267,8 @@ struct EvolutionMetavars {
           tmpl::list<NewtonianEuler::Tags::SoundSpeedSquaredCompute<DataVector>,
                      NewtonianEuler::Tags::SoundSpeedCompute<DataVector>>>,
       Initialization::Actions::AddComputeTags<
-          StepChoosers::step_chooser_compute_tags<EvolutionMetavars>>,
+          StepChoosers::step_chooser_compute_tags<EvolutionMetavars,
+                                                  local_time_stepping>>,
       ::evolution::dg::Initialization::Mortars<volume_dim, system>,
       Initialization::Actions::Minmod<Dim>,
       evolution::Actions::InitializeRunEventsAndDenseTriggers,

--- a/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveM1Grey.hpp
+++ b/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveM1Grey.hpp
@@ -226,7 +226,8 @@ struct EvolutionMetavars {
       Actions::MutateApply<typename RadiationTransport::M1Grey::
                                ComputeM1HydroCoupling<neutrino_species>>,
       Initialization::Actions::AddComputeTags<
-          StepChoosers::step_chooser_compute_tags<EvolutionMetavars>>,
+          StepChoosers::step_chooser_compute_tags<EvolutionMetavars,
+                                                  local_time_stepping>>,
       ::evolution::dg::Initialization::Mortars<volume_dim, system>,
       Initialization::Actions::Minmod<3>,
       evolution::Actions::InitializeRunEventsAndDenseTriggers,

--- a/src/Evolution/Executables/RelativisticEuler/Valencia/EvolveValencia.hpp
+++ b/src/Evolution/Executables/RelativisticEuler/Valencia/EvolveValencia.hpp
@@ -245,7 +245,8 @@ struct EvolutionMetavars {
           tmpl::list<hydro::Tags::SoundSpeedSquaredCompute<DataVector>>>,
       Actions::UpdateConservatives,
       Initialization::Actions::AddComputeTags<
-          StepChoosers::step_chooser_compute_tags<EvolutionMetavars>>,
+          StepChoosers::step_chooser_compute_tags<EvolutionMetavars,
+                                                  local_time_stepping>>,
       ::evolution::dg::Initialization::Mortars<volume_dim, system>,
       Initialization::Actions::Minmod<Dim>,
       evolution::Actions::InitializeRunEventsAndDenseTriggers,

--- a/src/Evolution/Executables/ScalarAdvection/EvolveScalarAdvection.hpp
+++ b/src/Evolution/Executables/ScalarAdvection/EvolveScalarAdvection.hpp
@@ -311,7 +311,8 @@ struct EvolutionMetavars {
       Initialization::Actions::AddComputeTags<
           tmpl::list<ScalarAdvection::Tags::VelocityFieldCompute<Dim>>>,
       Initialization::Actions::AddComputeTags<
-          StepChoosers::step_chooser_compute_tags<EvolutionMetavars>>,
+          StepChoosers::step_chooser_compute_tags<EvolutionMetavars,
+                                                  local_time_stepping>>,
       ::evolution::dg::Initialization::Mortars<volume_dim, system>,
       Initialization::Actions::Minmod<Dim>,
       evolution::Actions::InitializeRunEventsAndDenseTriggers,

--- a/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
+++ b/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
@@ -240,19 +240,20 @@ struct EvolutionMetavars {
   using dg_registration_list =
       tmpl::list<observers::Actions::RegisterEventsWithObservers>;
 
-  using initialization_actions = tmpl::list<
-      Initialization::Actions::TimeAndTimeStep<EvolutionMetavars>,
-      evolution::dg::Initialization::Domain<volume_dim>,
-      Initialization::Actions::NonconservativeSystem<system>,
-      evolution::Initialization::Actions::SetVariables<
-          domain::Tags::Coordinates<Dim, Frame::ElementLogical>>,
-      Initialization::Actions::TimeStepperHistory<EvolutionMetavars>,
-      ScalarWave::Actions::InitializeConstraints<volume_dim>,
-      Initialization::Actions::AddComputeTags<
-          StepChoosers::step_chooser_compute_tags<EvolutionMetavars>>,
-      ::evolution::dg::Initialization::Mortars<volume_dim, system>,
-      evolution::Actions::InitializeRunEventsAndDenseTriggers,
-      Parallel::Actions::TerminatePhase>;
+  using initialization_actions =
+      tmpl::list<Initialization::Actions::TimeAndTimeStep<EvolutionMetavars>,
+                 evolution::dg::Initialization::Domain<volume_dim>,
+                 Initialization::Actions::NonconservativeSystem<system>,
+                 evolution::Initialization::Actions::SetVariables<
+                     domain::Tags::Coordinates<Dim, Frame::ElementLogical>>,
+                 Initialization::Actions::TimeStepperHistory<EvolutionMetavars>,
+                 ScalarWave::Actions::InitializeConstraints<volume_dim>,
+                 Initialization::Actions::AddComputeTags<
+                     StepChoosers::step_chooser_compute_tags<
+                         EvolutionMetavars, local_time_stepping>>,
+                 ::evolution::dg::Initialization::Mortars<volume_dim, system>,
+                 evolution::Actions::InitializeRunEventsAndDenseTriggers,
+                 Parallel::Actions::TerminatePhase>;
 
   using dg_element_array = DgElementArray<
       EvolutionMetavars,

--- a/src/Evolution/Initialization/Evolution.hpp
+++ b/src/Evolution/Initialization/Evolution.hpp
@@ -90,10 +90,10 @@ struct TimeAndTimeStep {
                      tmpl::list<::Tags::TimeStepper<TimeStepper>>>>>;
 
   using simple_tags =
-      tmpl::push_back<StepChoosers::step_chooser_simple_tags<Metavariables>,
+      tmpl::push_back<StepChoosers::step_chooser_simple_tags<
+                          Metavariables, Metavariables::local_time_stepping>,
                       ::Tags::TimeStepId, ::Tags::Next<::Tags::TimeStepId>,
-                      ::Tags::TimeStep,
-                      ::Tags::Next<::Tags::TimeStep>>;
+                      ::Tags::TimeStep, ::Tags::Next<::Tags::TimeStep>>;
   using compute_tags = tmpl::list<>;
 
   template <typename DbTagsList, typename... InboxTags, typename ArrayIndex,

--- a/src/Evolution/Systems/Cce/Actions/InitializeCharacteristicEvolutionVariables.hpp
+++ b/src/Evolution/Systems/Cce/Actions/InitializeCharacteristicEvolutionVariables.hpp
@@ -107,7 +107,7 @@ struct InitializeCharacteristicEvolutionVariables {
       Spectral::Swsh::Tags::SwshInterpolator<Tags::CauchyAngularCoords>,
       Spectral::Swsh::Tags::SwshInterpolator<Tags::PartiallyFlatAngularCoords>>;
   using simple_tags =
-      tmpl::append<StepChoosers::step_chooser_simple_tags<Metavariables>,
+      tmpl::append<StepChoosers::step_chooser_simple_tags<Metavariables, true>,
                    simple_tags_for_evolution>;
 
   using compute_tags = tmpl::remove_duplicates<tmpl::join<

--- a/src/Time/StepChoosers/StepChooser.hpp
+++ b/src/Time/StepChoosers/StepChooser.hpp
@@ -34,30 +34,30 @@ namespace detail {
 CREATE_GET_TYPE_ALIAS_OR_DEFAULT(compute_tags)
 CREATE_GET_TYPE_ALIAS_OR_DEFAULT(simple_tags)
 
-template <typename Metavariables>
+template <typename Metavariables, bool UsingLts>
 using all_step_choosers = tmpl::join<tmpl::remove<
     tmpl::list<
         tmpl::at<typename Metavariables::factory_creation::factory_classes,
                  StepChooser<StepChooserUse::Slab>>,
         tmpl::conditional_t<
-            Metavariables::local_time_stepping,
+            UsingLts,
             tmpl::at<typename Metavariables::factory_creation::factory_classes,
                      StepChooser<StepChooserUse::LtsStep>>,
             tmpl::no_such_type_>>,
     tmpl::no_such_type_>>;
 }  // namespace detail
 
-template <typename Metavariables>
-using step_chooser_compute_tags = tmpl::remove_duplicates<
-    tmpl::join<tmpl::transform<detail::all_step_choosers<Metavariables>,
-                               detail::get_compute_tags_or_default<
-                                   tmpl::_1, tmpl::pin<tmpl::list<>>>>>>;
+template <typename Metavariables, bool UsingLts>
+using step_chooser_compute_tags = tmpl::remove_duplicates<tmpl::join<
+    tmpl::transform<detail::all_step_choosers<Metavariables, UsingLts>,
+                    detail::get_compute_tags_or_default<
+                        tmpl::_1, tmpl::pin<tmpl::list<>>>>>>;
 
-template <typename Metavariables>
-using step_chooser_simple_tags = tmpl::remove_duplicates<
-    tmpl::join<tmpl::transform<detail::all_step_choosers<Metavariables>,
-                               detail::get_simple_tags_or_default<
-                                   tmpl::_1, tmpl::pin<tmpl::list<>>>>>>;
+template <typename Metavariables, bool UsingLts>
+using step_chooser_simple_tags = tmpl::remove_duplicates<tmpl::join<
+    tmpl::transform<detail::all_step_choosers<Metavariables, UsingLts>,
+                    detail::get_simple_tags_or_default<
+                        tmpl::_1, tmpl::pin<tmpl::list<>>>>>>;
 }  // namespace StepChoosers
 
 /// A placeholder type to indicate that all constructible step choosers should

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_CharacteristicEvolutionBondiCalculations.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_CharacteristicEvolutionBondiCalculations.cpp
@@ -126,7 +126,6 @@ struct mock_characteristic_evolution {
 };
 
 struct metavariables {
-  static constexpr bool local_time_stepping = false;
   using evolved_swsh_tag = Tags::BondiJ;
   using evolved_swsh_dt_tag = Tags::BondiH;
   using cce_step_choosers = tmpl::list<>;

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_GhBoundaryCommunication.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_GhBoundaryCommunication.cpp
@@ -126,7 +126,6 @@ struct mock_characteristic_evolution {
 };
 
 struct test_metavariables {
-  static constexpr bool local_time_stepping = false;
   using evolved_swsh_tag = Tags::BondiJ;
   using evolved_swsh_dt_tag = Tags::BondiH;
   using cce_step_choosers = tmpl::list<>;

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_H5BoundaryCommunication.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_H5BoundaryCommunication.cpp
@@ -138,7 +138,6 @@ struct mock_characteristic_evolution {
 };
 
 struct test_metavariables {
-  static constexpr bool local_time_stepping = false;
   using evolved_swsh_tag = Tags::BondiJ;
   using evolved_swsh_dt_tag = Tags::BondiH;
   using cce_step_choosers = tmpl::list<>;

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_InitializeCharacteristicEvolution.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_InitializeCharacteristicEvolution.cpp
@@ -83,7 +83,6 @@ struct mock_characteristic_evolution {
 };
 
 struct metavariables {
-  static constexpr bool local_time_stepping = false;
   using evolved_swsh_tag = Tags::BondiJ;
   using evolved_swsh_dt_tag = Tags::BondiH;
   using cce_step_choosers = tmpl::list<>;

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_RequestBoundaryData.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_RequestBoundaryData.cpp
@@ -104,7 +104,6 @@ struct mock_characteristic_evolution {
 };
 
 struct test_metavariables {
-  static constexpr bool local_time_stepping = false;
   using evolved_swsh_tag = Tags::BondiJ;
   using evolved_swsh_dt_tag = Tags::BondiH;
   using cce_step_choosers = tmpl::list<>;


### PR DESCRIPTION
## Proposed changes

I encountered this issue while helping @Sizheng-Ma rebase #4271 on the latest develop. The changes in #4358 made it so that LTS step choosers were added to the list of all step choosers only if the `local_time_stepping` type alias in the metavariables was true. However, in #4271, the GH evolution uses GTS, but the CCE evolution uses LTS. This caused the LTS step choosers to not be added to the list of all step choosers for CCE and as a result, some step chooser simple tags were missing from the CCE DataBox.

My solution was instead of using `Metavariables::local_time_stepping` in the `all_step_choosers` type alias in `src/Time/StepChoosers/StepChooser.hpp` to determine if the LTS choosers should be added, pass in a second template bool indicating if we are using LTS. That way different evolution systems can specify if they are using LTS or GTS.

I didn't run into this issue in #4109 because the GH evolution uses LTS there and so the LTS step choosers were added to all step choosers regardless.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
