### PR TITLE
Installation dox: refer to new docker containers.

### DIFF
--- a/docs/Installation/Installation.md
+++ b/docs/Installation/Installation.md
@@ -130,7 +130,7 @@ when you `cp` or `mv` the source files.
 ## Using Docker to obtain a SpECTRE environment {#docker_install}
 
 A [Docker](https://www.docker.com/) image is available from
-[DockerHub](https://hub.docker.com/r/sxscollaboration/spectrebuildenv/) and can
+[DockerHub](https://hub.docker.com/r/sxscollaboration/spectre/) and can
 be used to build SpECTRE on a personal machine.
 
 **Note**: The Docker image or the Singularity image (see below) are
@@ -243,12 +243,14 @@ To build SpECTRE with Singularity you must:
    (version 3.7. For other versions, see the [docs](https://sylabs.io/docs/)).
    Once inside the WORKDIR, clone SpECTRE into `WORKDIR/SPECTRE_ROOT`.
 3. Run `sudo singularity build spectre.img
-   docker://sxscollaboration/spectrebuildenv:latest`.
+   docker://sxscollaboration/spectre:dev`.
+   You can also use spectre:ci instead of spectre:dev if you want more
+   compilers installed.
 
    If you get the error message that `makesquashfs` did not have enough space to
    create the image you need to set a different `SINGULARITY_TMPDIR`. This can
    be done by running: `sudo SINGULARITY_TMPDIR=/path/to/new/tmp singularity
-   build spectre.img docker://sxscollaboration/spectrebuildenv:latest`. Normally
+   build spectre.img docker://sxscollaboration/spectre:dev`. Normally
    `SINGULARITY_TMPDIR` is `/tmp`, but building the image will temporarily need
    almost 8GB of space.
 


### PR DESCRIPTION
Currently it tells you to use the old ones that havent been updated in months.

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

