### PR TITLE
Add poloidal initial magnetic field to GRMHD

### DIFF
--- a/src/PointwiseFunctions/AnalyticData/GrMhd/InitialMagneticFields/CMakeLists.txt
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/InitialMagneticFields/CMakeLists.txt
@@ -1,9 +1,16 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
+spectre_target_sources(
+  ${LIBRARY}
+  PRIVATE
+  Poloidal.cpp
+  )
+
 spectre_target_headers(
   ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   InitialMagneticField.hpp
+  Poloidal.hpp
   )

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/InitialMagneticFields/Poloidal.cpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/InitialMagneticFields/Poloidal.cpp
@@ -1,0 +1,114 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "PointwiseFunctions/AnalyticData/GrMhd/InitialMagneticFields/Poloidal.hpp"
+
+#include <memory>
+
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "PointwiseFunctions/AnalyticData/GrMhd/InitialMagneticFields/InitialMagneticField.hpp"
+#include "PointwiseFunctions/Hydro/Tags.hpp"
+#include "Utilities/ContainerHelpers.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+
+namespace grmhd::AnalyticData::InitialMagneticFields {
+
+std::unique_ptr<InitialMagneticField> Poloidal::get_clone() const {
+  return std::make_unique<Poloidal>(*this);
+}
+
+Poloidal::Poloidal(CkMigrateMessage* msg) : InitialMagneticField(msg) {}
+
+void Poloidal::pup(PUP::er& p) {
+  InitialMagneticField::pup(p);
+  p | pressure_exponent_;
+  p | cutoff_pressure_;
+  p | vector_potential_amplitude_;
+}
+
+// NOLINTNEXTLINE
+PUP::able::PUP_ID Poloidal::my_PUP_ID = 0;
+
+Poloidal::Poloidal(const size_t pressure_exponent, const double cutoff_pressure,
+                   const double vector_potential_amplitude)
+    : pressure_exponent_(pressure_exponent),
+      cutoff_pressure_(cutoff_pressure),
+      vector_potential_amplitude_(vector_potential_amplitude) {}
+
+template <typename DataType>
+tuples::TaggedTuple<hydro::Tags::MagneticField<DataType, 3>>
+Poloidal::variables(const tnsr::I<DataType, 3>& coords,
+                    const Scalar<DataType>& pressure,
+                    const Scalar<DataType>& sqrt_det_spatial_metric,
+                    const tnsr::i<DataType, 3>& dcoords_pressure) const {
+  auto magnetic_field = make_with_value<tnsr::I<DataType, 3>>(coords, 0.0);
+  const size_t num_pts = get_size(get(pressure));
+
+  for (size_t i = 0; i < num_pts; ++i) {
+    const double pressure_i = get_element(get(pressure), i);
+    if (pressure_i < cutoff_pressure_) {
+      get_element(magnetic_field.get(0), i) = 0.0;
+      get_element(magnetic_field.get(1), i) = 0.0;
+      get_element(magnetic_field.get(2), i) = 0.0;
+      continue;
+    }
+
+    // (p - p_c)^{n_s}
+    const double pressure_term =
+        pow(pressure_i - cutoff_pressure_, pressure_exponent_);
+    // n_s * (p - p_c)^{n_s-1}
+    const double n_times_pressure_to_n_minus_1 =
+        pressure_exponent_ * pow(pressure_i - cutoff_pressure_,
+                                 static_cast<int>(pressure_exponent_) - 1);
+
+    const double x = get_element(coords.get(0), i);
+    const double y = get_element(coords.get(1), i);
+
+    const auto& dp_dx = get_element(dcoords_pressure.get(0), i);
+    const auto& dp_dy = get_element(dcoords_pressure.get(1), i);
+    const auto& dp_dz = get_element(dcoords_pressure.get(2), i);
+
+    // Assign Bx, By, Bz
+    get_element(magnetic_field.get(0), i) =
+        -n_times_pressure_to_n_minus_1 * x * dp_dz;
+    get_element(magnetic_field.get(1), i) =
+        -n_times_pressure_to_n_minus_1 * y * dp_dz;
+    get_element(magnetic_field.get(2), i) =
+        2.0 * pressure_term +
+        n_times_pressure_to_n_minus_1 * (x * dp_dx + y * dp_dy);
+  }
+
+  for (size_t d = 0; d < 3; ++d) {
+    magnetic_field.get(d) *=
+        vector_potential_amplitude_ / get(sqrt_det_spatial_metric);
+  }
+
+  return {std::move(magnetic_field)};
+}
+
+bool operator==(const Poloidal& lhs, const Poloidal& rhs) {
+  return lhs.pressure_exponent_ == rhs.pressure_exponent_ and
+         lhs.cutoff_pressure_ == rhs.cutoff_pressure_ and
+         lhs.vector_potential_amplitude_ == rhs.vector_potential_amplitude_;
+}
+
+bool operator!=(const Poloidal& lhs, const Poloidal& rhs) {
+  return not(lhs == rhs);
+}
+
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data)                                               \
+  template tuples::TaggedTuple<hydro::Tags::MagneticField<DTYPE(data), 3>> \
+  Poloidal::variables<DTYPE(data)>(                                        \
+      const tnsr::I<DTYPE(data), 3>& coords,                               \
+      const Scalar<DTYPE(data)>& pressure,                                 \
+      const Scalar<DTYPE(data)>& sqrt_det_spatial_metric,                  \
+      const tnsr::i<DTYPE(data), 3>& dcoords_pressure) const;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector))
+
+#undef INSTANTIATE
+#undef DTYPE
+
+}  // namespace grmhd::AnalyticData::InitialMagneticFields

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/InitialMagneticFields/Poloidal.hpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/InitialMagneticFields/Poloidal.hpp
@@ -1,0 +1,134 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <limits>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Options/Options.hpp"
+#include "PointwiseFunctions/AnalyticData/GrMhd/InitialMagneticFields/InitialMagneticField.hpp"
+#include "PointwiseFunctions/GeneralRelativity/TagsDeclarations.hpp"
+#include "PointwiseFunctions/Hydro/TagsDeclarations.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace grmhd::AnalyticData::InitialMagneticFields {
+
+/*!
+ * \brief %Poloidal magnetic field for GRMHD initial data.
+ *
+ * The vector potential has the form
+ *
+ * \f{align*}{
+ *  A_{\phi} = A_b \varpi^2 \max(p-p_{\mathrm{cut}}, 0)^{n_s} ,
+ * \f}
+ *
+ * where \f$A_b\f$ controls the amplitude of the magnetic field,
+ * \f$\varpi^2=x^2+y^2=r^2-z^2\f$ is the cylindrical radius,
+ * \f$n_s\f$ controls the degree of differentiability, and
+ * \f$p_{\mathrm{cut}}\f$ controls the pressure cutoff below which the magnetic
+ * field is zero.
+ *
+ * In Cartesian coordinates the vector potential is:
+ *
+ * \f{align*}{
+ *   A_x & = -\frac{y}{\varpi^2}A_\phi
+ *            = -y A_b\max(p-p_{\mathrm{cut}}, 0)^{n_s}, \\
+ *   A_y & = \frac{x}{\varpi^2}A_\phi
+ *            = x A_b\max(p-p_{\mathrm{cut}}, 0)^{n_s}, \\
+ *   A_z & = 0,
+ * \f}
+ *
+ * On the region where the field is non-zero, the magnetic field is given by:
+ *
+ * \f{align*}{
+ *   B^x & = -\frac{A_b n_s}{\sqrt{\gamma}}
+ *        (p-p_{\mathrm{cut}})^{n_s-1} x \partial_z p \\
+ *   B^x & = -\frac{A_b n_s}{\sqrt{\gamma}}
+ *        (p-p_{\mathrm{cut}})^{n_s-1} y \partial_z p \\
+ *   B^z & = \frac{A_b}{\sqrt{\gamma}}\left[
+ *        2(p-p_{\mathrm{cut}})^{n_s}
+ *        + n_s (p-p_{\mathrm{cut}})^{n_s-1} (x \partial_x p + y \partial_y p)
+ *        \right]
+ * \f}
+ *
+ * Taking the small-\f$r\f$ limit gives the magnetic field at the origin:
+ *
+ * \f{align*}{
+ *   B^x&=0, \\
+ *   B^y&=0, \\
+ *   B^z&=\frac{A_b}{\sqrt{\gamma}}
+ *        2(p-p_{\mathrm{cut}})^{n_s}.
+ * \f}
+ *
+ */
+class Poloidal : public InitialMagneticField {
+ public:
+  struct PressureExponent {
+    using type = size_t;
+    static constexpr Options::String help = {
+        "The exponent n_s controlling the smoothness of the field"};
+  };
+
+  struct CutoffPressure {
+    using type = double;
+    static constexpr Options::String help = {
+        "The pressure below which there is no magnetic field."};
+    static type lower_bound() { return 0.0; }
+  };
+
+  struct VectorPotentialAmplitude {
+    using type = double;
+    static constexpr Options::String help = {
+        "The amplitude A_b of the phi-component of the vector potential. This "
+        "controls the magnetic field strength."};
+    static type lower_bound() { return 0.0; }
+  };
+
+  using options =
+      tmpl::list<PressureExponent, CutoffPressure, VectorPotentialAmplitude>;
+
+  static constexpr Options::String help = {"Poloidal initial magnetic field"};
+
+  Poloidal() = default;
+  Poloidal(const Poloidal& /*rhs*/) = default;
+  Poloidal& operator=(const Poloidal& /*rhs*/) = default;
+  Poloidal(Poloidal&& /*rhs*/) = default;
+  Poloidal& operator=(Poloidal&& /*rhs*/) = default;
+  ~Poloidal() override = default;
+
+  Poloidal(size_t pressure_exponent, double cutoff_pressure,
+           double vector_potential_amplitude);
+
+  auto get_clone() const -> std::unique_ptr<InitialMagneticField> override;
+
+  /// \cond
+  explicit Poloidal(CkMigrateMessage* msg);
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(Poloidal);
+  /// \endcond
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& p) override;
+
+  /// Retrieve magnetic fields at `(x)`
+  template <typename DataType>
+  auto variables(const tnsr::I<DataType, 3>& coords,
+                 const Scalar<DataType>& pressure,
+                 const Scalar<DataType>& sqrt_det_spatial_metric,
+                 const tnsr::i<DataType, 3>& dcoords_pressure) const
+      -> tuples::TaggedTuple<hydro::Tags::MagneticField<DataType, 3>>;
+
+ private:
+  size_t pressure_exponent_ = std::numeric_limits<size_t>::max();
+  double cutoff_pressure_ = std::numeric_limits<double>::signaling_NaN();
+  double vector_potential_amplitude_ =
+      std::numeric_limits<double>::signaling_NaN();
+
+  friend bool operator==(const Poloidal& lhs, const Poloidal& rhs);
+  friend bool operator!=(const Poloidal& lhs, const Poloidal& rhs);
+};
+
+}  // namespace grmhd::AnalyticData::InitialMagneticFields

--- a/tests/Unit/PointwiseFunctions/AnalyticData/GrMhd/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/GrMhd/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY "Test_GrMhdAnalyticData")
 
 set(LIBRARY_SOURCES
+  InitialMagneticFields/Test_Poloidal.cpp
   Test_BlastWave.cpp
   Test_BondiHoyleAccretion.cpp
   Test_CcsnCollapse.cpp

--- a/tests/Unit/PointwiseFunctions/AnalyticData/GrMhd/InitialMagneticFields/Poloidal.py
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/GrMhd/InitialMagneticFields/Poloidal.py
@@ -1,0 +1,31 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+
+
+def magnetic_field(x, pressure, sqrt_det_spatial_metric, dcoords_pressure,
+                   pressure_exponent, cutoff_pressure,
+                   vector_potential_amplitude):
+    magnetic_field = np.zeros(x.shape)
+
+    magnetic_field[0] = -(
+        vector_potential_amplitude * pressure_exponent /
+        sqrt_det_spatial_metric) * (pressure - cutoff_pressure)**(
+            pressure_exponent - 1) * x[0] * dcoords_pressure[2]
+
+    magnetic_field[1] = -(
+        vector_potential_amplitude * pressure_exponent /
+        sqrt_det_spatial_metric) * (pressure - cutoff_pressure)**(
+            pressure_exponent - 1) * x[1] * dcoords_pressure[2]
+
+    magnetic_field[2] = (
+        vector_potential_amplitude / sqrt_det_spatial_metric
+    ) * (2 *
+         (pressure - cutoff_pressure)**pressure_exponent + pressure_exponent *
+         (pressure - cutoff_pressure)**(pressure_exponent - 1) *
+         (x[0] * dcoords_pressure[0] + x[1] * dcoords_pressure[1]))
+
+    magnetic_field = np.where(pressure < cutoff_pressure, 0.0, magnetic_field)
+
+    return magnetic_field

--- a/tests/Unit/PointwiseFunctions/AnalyticData/GrMhd/InitialMagneticFields/Test_Poloidal.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/GrMhd/InitialMagneticFields/Test_Poloidal.cpp
@@ -1,0 +1,159 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <memory>
+#include <utility>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Framework/CheckWithRandomValues.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "NumericalAlgorithms/LinearOperators/Divergence.hpp"
+#include "NumericalAlgorithms/Spectral/LogicalCoordinates.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "Parallel/RegisterDerivedClassesWithCharm.hpp"
+#include "PointwiseFunctions/AnalyticData/GrMhd/InitialMagneticFields/InitialMagneticField.hpp"
+#include "PointwiseFunctions/AnalyticData/GrMhd/InitialMagneticFields/Poloidal.hpp"
+#include "PointwiseFunctions/Hydro/Tags.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace grmhd::AnalyticData::InitialMagneticFields {
+namespace {
+
+struct PoloidalProxy : Poloidal {
+  using Poloidal::Poloidal;
+
+  template <typename DataType>
+  tuples::TaggedTuple<hydro::Tags::MagneticField<DataType, 3>> return_variables(
+      const tnsr::I<DataType, 3>& x, const Scalar<DataType>& pressure,
+      const Scalar<DataType>& sqrt_det_spatial_metric,
+      const tnsr::i<DataType, 3>& deriv_pressure) const {
+    return this->variables(x, pressure, sqrt_det_spatial_metric,
+                           deriv_pressure);
+  }
+};
+
+SPECTRE_TEST_CASE(
+    "Unit.PointwiseFunctions.AnalyticData.GrMhd.InitialMagneticFields.Poloidal",
+    "[Unit][PointwiseFunctions]") {
+  // test creation
+  const auto solution = TestHelpers::test_creation<Poloidal>(
+      "  PressureExponent: 2\n"
+      "  CutoffPressure: 1.0e-5\n"
+      "  VectorPotentialAmplitude: 2500.0\n");
+  CHECK(solution == Poloidal(2, 1.0e-5, 2500.0));
+
+  // test serialize
+  test_serialization(solution);
+
+  // test move
+  {
+    Poloidal poloidal_field{2, 1.0e-5, 2500.0};
+    Poloidal poloidal_field_copy{2, 1.0e-5, 2500.0};
+    test_move_semantics(std::move(poloidal_field), poloidal_field_copy);
+  }
+
+  // test derived
+  Parallel::register_classes_with_charm<Poloidal>();
+  const std::unique_ptr<InitialMagneticField> base_ptr =
+      std::make_unique<Poloidal>();
+  const std::unique_ptr<InitialMagneticField> deserialized_base_ptr =
+      serialize_and_deserialize(base_ptr)->get_clone();
+  CHECK(dynamic_cast<Poloidal*>(deserialized_base_ptr.get()) != nullptr);
+
+  // test equality
+  const Poloidal field_original{2, 1.0e-5, 2500.0};
+  const auto field = serialize_and_deserialize(field_original);
+  CHECK(field == Poloidal(2, 1.0e-5, 2500.0));
+  CHECK(field != Poloidal(3, 1.0e-5, 2500.0));
+  CHECK(field != Poloidal(2, 2.0e-5, 2500.0));
+  CHECK(field != Poloidal(2, 1.0e-5, 3500.0));
+
+  // test solution implementation
+  pypp::SetupLocalPythonEnvironment local_python_env{
+      "PointwiseFunctions/AnalyticData/GrMhd/InitialMagneticFields"};
+  const DataVector used_for_size{10};
+
+  const size_t pressure_exponent = 2;
+  const double cutoff_pressure = 1.0e-5;
+  const double vector_potential_amplitude = 2500.0;
+
+  pypp::check_with_random_values<1>(
+      &PoloidalProxy::return_variables<double>,
+      PoloidalProxy(pressure_exponent, cutoff_pressure,
+                    vector_potential_amplitude),
+      "Poloidal", {"magnetic_field"}, {{{-10.0, 10.0}}},
+      std::make_tuple(pressure_exponent, cutoff_pressure,
+                      vector_potential_amplitude),
+      used_for_size);
+
+  // test if the B field is divergence-free in the flat spacetime
+  const Mesh<3> mesh{5, Spectral::Basis::Legendre,
+                     Spectral::Quadrature::GaussLobatto};
+  const size_t num_grid_pts = mesh.number_of_grid_points();
+  const auto log_coords = logical_coordinates(mesh);
+  const double scale = 1.0e-2;
+  InverseJacobian<DataVector, 3, Frame::ElementLogical, Frame::Inertial>
+      inv_jac{mesh.number_of_grid_points(), 0.0};
+  for (size_t i = 0; i < 3; ++i) {
+    inv_jac.get(i, i) = 1.0 / scale;
+  }
+  const Scalar<DataVector> sqrt_det_spatial_metric{mesh.number_of_grid_points(),
+                                                   1.0};
+
+  const auto test_for_small_coords_patch =
+      [&inv_jac, &solution, &sqrt_det_spatial_metric, &mesh,
+       &num_grid_pts](const tnsr::I<DataVector, 3>& in_coords) {
+        const auto& x = in_coords.get(0);
+        const auto& y = in_coords.get(1);
+        const auto& z = in_coords.get(2);
+
+        // test with the pressure of a simple analytic form
+        Scalar<DataVector> pressure{num_grid_pts, 0.0};
+        get(pressure) = (x * x * x) + (y * y) + z +
+                        0.1;  // Add a small offset to set P > cutoff
+
+        tnsr::i<DataVector, 3, Frame::Inertial> d_pressure{num_grid_pts, 0.0};
+        d_pressure.get(0) = 3.0 * x * x;
+        d_pressure.get(1) = 2.0 * y;
+        d_pressure.get(2) = 1.0;
+
+        const auto b_field =
+            get<hydro::Tags::MagneticField<DataVector, 3>>(solution.variables(
+                in_coords, pressure, sqrt_det_spatial_metric, d_pressure));
+
+        Scalar<DataVector> mag_b_field{num_grid_pts, 0.0};
+        for (size_t i = 0; i < 3; ++i) {
+          get(mag_b_field) += square(b_field.get(i));
+        }
+        get(mag_b_field) = sqrt(get(mag_b_field));
+
+        CHECK(get(mag_b_field) != approx(0.));
+        const auto div_b_field = divergence(b_field, mesh, inv_jac);
+
+        const Scalar<DataVector> div_b_over_mag_b{get(div_b_field) /
+                                                  get(mag_b_field)};
+
+        CHECK(max(abs(get(div_b_over_mag_b))) < 1.0e-12);
+      };
+
+  // check a small region around the origin
+  tnsr::I<DataVector, 3, Frame::Inertial> inertial_coords{num_grid_pts, 0.0};
+  for (size_t i = 0; i < 3; ++i) {
+    inertial_coords.get(i) = scale * log_coords.get(i);
+  }
+  test_for_small_coords_patch(inertial_coords);
+
+  // check a small region off-origin
+  inertial_coords.get(0) += 0.5;
+  inertial_coords.get(1) += 1.0;
+  inertial_coords.get(2) += 2.0;
+  test_for_small_coords_patch(inertial_coords);
+}
+}  // namespace
+}  // namespace grmhd::AnalyticData::InitialMagneticFields


### PR DESCRIPTION
## Proposed changes

This is the same magnetic field currently used in MagnetizedTov initial data, but splitted as a separate class.

Dependent on
- [x] #4463 

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
