### PR TITLE
Add `GenerateXdmf.py` to Python CLI

### DIFF
--- a/src/Visualization/Python/CMakeLists.txt
+++ b/src/Visualization/Python/CMakeLists.txt
@@ -5,8 +5,9 @@ set(LIBRARY "PyVisualization")
 
 spectre_python_add_module(
   Visualization
-  PYTHON_EXECUTABLES
+  PYTHON_FILES
   GenerateXdmf.py
+  PYTHON_EXECUTABLES
   InterpolateVolumeData.py
   PlotDatFile.py
   Render1D.py

--- a/support/Python/__main__.py
+++ b/support/Python/__main__.py
@@ -13,12 +13,16 @@ SPECTRE_VERSION = "@SPECTRE_VERSION@"
 # invoked. This is important so the CLI responds quickly.
 class Cli(click.MultiCommand):
     def list_commands(self, ctx):
-        return ["clean-output"]
+        return ["clean-output", "generate-xdmf"]
 
     def get_command(self, ctx, name):
         if name == "clean-output":
             from spectre.tools.CleanOutput import clean_output_command
             return clean_output_command
+        elif name == "generate-xdmf":
+            from spectre.Visualization.GenerateXdmf import (
+                generate_xdmf_command)
+            return generate_xdmf_command
         raise NotImplementedError(f"The command '{name}' is not implemented.")
 
 

--- a/tests/Unit/Visualization/Python/Test_GenerateXdmf.py
+++ b/tests/Unit/Visualization/Python/Test_GenerateXdmf.py
@@ -1,24 +1,32 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-from spectre.Visualization.GenerateXdmf import generate_xdmf
+from spectre.Visualization.GenerateXdmf import (generate_xdmf,
+                                                generate_xdmf_command)
 
 import spectre.Informer as spectre_informer
 import unittest
+import logging
 import os
+import shutil
+from click.testing import CliRunner
 
 
 class TestGenerateXdmf(unittest.TestCase):
-    def test_generate_xdmf(self):
-        data_file_prefix = os.path.join(spectre_informer.unit_test_src_path(),
-                                        'Visualization/Python', 'VolTestData')
-        #write output file to same relative path in build directory
-        output_filename = os.path.join(spectre_informer.unit_test_build_path(),
-                                       'Visualization/Python',
-                                       'Test_GenerateXdmf_output')
-        if os.path.isfile(output_filename + '.xmf'):
-            os.remove(output_filename + '.xmf')
+    def setUp(self):
+        self.data_dir = os.path.join(spectre_informer.unit_test_src_path(),
+                                     'Visualization/Python')
+        self.test_dir = os.path.join(spectre_informer.unit_test_build_path(),
+                                     'Visualization/GenerateXdmf')
+        os.makedirs(self.test_dir, exist_ok=True)
 
+    def tearDown(self):
+        shutil.rmtree(self.test_dir)
+
+    def test_generate_xdmf(self):
+        data_file_prefix = os.path.join(self.data_dir, 'VolTestData')
+        output_filename = os.path.join(self.test_dir,
+                                       'Test_GenerateXdmf_output')
         generate_xdmf(file_prefix=data_file_prefix,
                       output=output_filename,
                       subfile_name="element_data",
@@ -31,19 +39,11 @@ class TestGenerateXdmf(unittest.TestCase):
         # it and it produces output without raising an error. To test more
         # details, we should refactor the script into smaller units.
         self.assertTrue(os.path.isfile(output_filename + '.xmf'))
-        os.remove(output_filename + '.xmf')
 
     def test_surface_generate_xdmf(self):
-        data_file_prefix = os.path.join(spectre_informer.unit_test_src_path(),
-                                        'Visualization/Python',
-                                        'SurfaceTestData')
-        #write output file to same relative path in build directory
-        output_filename = os.path.join(spectre_informer.unit_test_build_path(),
-                                       'Visualization/Python',
+        data_file_prefix = os.path.join(self.data_dir, 'SurfaceTestData')
+        output_filename = os.path.join(self.test_dir,
                                        'Test_SurfaceGenerateXdmf_output')
-        if os.path.isfile(output_filename + '.xmf'):
-            os.remove(output_filename + '.xmf')
-
         generate_xdmf(file_prefix=data_file_prefix,
                       output=output_filename,
                       subfile_name="AhA",
@@ -58,12 +58,9 @@ class TestGenerateXdmf(unittest.TestCase):
         self.assertTrue(os.path.isfile(output_filename + '.xmf'))
 
     def test_subfile_not_found(self):
-        data_file_prefix = os.path.join(spectre_informer.unit_test_src_path(),
-                                        'Visualization/Python', 'VolTestData')
-        output_filename = 'Test_GenerateXdmf_subfile_not_found'
-        if os.path.isfile(output_filename + '.xmf'):
-            os.remove(output_filename + '.xmf')
-
+        data_file_prefix = os.path.join(self.data_dir, 'VolTestData')
+        output_filename = os.path.join(self.test_dir,
+                                       'Test_GenerateXdmf_subfile_not_found')
         with self.assertRaisesRegex(ValueError, 'Could not open subfile'):
             generate_xdmf(file_prefix=data_file_prefix,
                           output=output_filename,
@@ -73,6 +70,23 @@ class TestGenerateXdmf(unittest.TestCase):
                           stride=1,
                           coordinates='InertialCoordinates')
 
+    def test_cli(self):
+        data_file_prefix = os.path.join(self.data_dir, 'VolTestData')
+        output_filename = os.path.join(self.test_dir,
+                                       'Test_GenerateXdmf_output')
+        runner = CliRunner()
+        result = runner.invoke(generate_xdmf_command, [
+            "--file-prefix",
+            data_file_prefix,
+            "-o",
+            output_filename,
+            "-d",
+            "element_data",
+        ],
+                               catch_exceptions=False)
+        self.assertEqual(result.exit_code, 0)
+
 
 if __name__ == '__main__':
+    logging.basicConfig(level=logging.DEBUG)
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Proposed changes

Expose GenerateXdmf to the Python CLI as `spectre generate-xdmf`. Note that the script isn't symlinked to bin/ anymore.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
Invoke `spectre generate-xdmf -h` to run the `GenerateXdmf.py` script.
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
