### PR TITLE
Eliminate remaining redundant computation from damped harmonic

### DIFF
--- a/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedHarmonic.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedHarmonic.hpp
@@ -173,6 +173,8 @@ void damped_harmonic_rollon(
     const Scalar<DataVector>& sqrt_det_spatial_metric,
     const tnsr::II<DataVector, SpatialDim, Frame>& inverse_spatial_metric,
     const tnsr::abb<DataVector, SpatialDim, Frame>& d4_spacetime_metric,
+    const Scalar<DataVector>& half_pi_two_normals,
+    const tnsr::i<DataVector, SpatialDim, Frame>& half_phi_two_normals,
     const tnsr::aa<DataVector, SpatialDim, Frame>& spacetime_metric,
     const tnsr::aa<DataVector, SpatialDim, Frame>& pi,
     const tnsr::iaa<DataVector, SpatialDim, Frame>& phi, double time,
@@ -195,6 +197,8 @@ void damped_harmonic(
     const Scalar<DataVector>& sqrt_det_spatial_metric,
     const tnsr::II<DataVector, SpatialDim, Frame>& inverse_spatial_metric,
     const tnsr::abb<DataVector, SpatialDim, Frame>& d4_spacetime_metric,
+    const Scalar<DataVector>& half_pi_two_normals,
+    const tnsr::i<DataVector, SpatialDim, Frame>& half_phi_two_normals,
     const tnsr::aa<DataVector, SpatialDim, Frame>& spacetime_metric,
     const tnsr::aa<DataVector, SpatialDim, Frame>& pi,
     const tnsr::iaa<DataVector, SpatialDim, Frame>& phi,
@@ -271,6 +275,9 @@ class DampedHarmonic final : public GaugeCondition {
           inverse_spatial_metric,
       const tnsr::abb<DataVector, SpatialDim, Frame::Inertial>&
           d4_spacetime_metric,
+      const Scalar<DataVector>& half_pi_two_normals,
+      const tnsr::i<DataVector, SpatialDim, Frame::Inertial>&
+          half_phi_two_normals,
       const tnsr::aa<DataVector, SpatialDim, Frame::Inertial>& spacetime_metric,
       const tnsr::aa<DataVector, SpatialDim, Frame::Inertial>& pi,
       const tnsr::iaa<DataVector, SpatialDim, Frame::Inertial>& phi,

--- a/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedHarmonic.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedHarmonic.hpp
@@ -172,6 +172,7 @@ void damped_harmonic_rollon(
     const tnsr::A<DataVector, SpatialDim, Frame>& spacetime_unit_normal,
     const Scalar<DataVector>& sqrt_det_spatial_metric,
     const tnsr::II<DataVector, SpatialDim, Frame>& inverse_spatial_metric,
+    const tnsr::abb<DataVector, SpatialDim, Frame>& d4_spacetime_metric,
     const tnsr::aa<DataVector, SpatialDim, Frame>& spacetime_metric,
     const tnsr::aa<DataVector, SpatialDim, Frame>& pi,
     const tnsr::iaa<DataVector, SpatialDim, Frame>& phi, double time,
@@ -193,6 +194,7 @@ void damped_harmonic(
     const tnsr::A<DataVector, SpatialDim, Frame>& spacetime_unit_normal,
     const Scalar<DataVector>& sqrt_det_spatial_metric,
     const tnsr::II<DataVector, SpatialDim, Frame>& inverse_spatial_metric,
+    const tnsr::abb<DataVector, SpatialDim, Frame>& d4_spacetime_metric,
     const tnsr::aa<DataVector, SpatialDim, Frame>& spacetime_metric,
     const tnsr::aa<DataVector, SpatialDim, Frame>& pi,
     const tnsr::iaa<DataVector, SpatialDim, Frame>& phi,
@@ -267,6 +269,8 @@ class DampedHarmonic final : public GaugeCondition {
       const Scalar<DataVector>& sqrt_det_spatial_metric,
       const tnsr::II<DataVector, SpatialDim, Frame::Inertial>&
           inverse_spatial_metric,
+      const tnsr::abb<DataVector, SpatialDim, Frame::Inertial>&
+          d4_spacetime_metric,
       const tnsr::aa<DataVector, SpatialDim, Frame::Inertial>& spacetime_metric,
       const tnsr::aa<DataVector, SpatialDim, Frame::Inertial>& pi,
       const tnsr::iaa<DataVector, SpatialDim, Frame::Inertial>& phi,

--- a/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedHarmonic.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedHarmonic.hpp
@@ -169,6 +169,7 @@ void damped_harmonic_rollon(
     const tnsr::I<DataVector, SpatialDim, Frame>& shift,
     const tnsr::a<DataVector, SpatialDim, Frame>&
         spacetime_unit_normal_one_form,
+    const tnsr::A<DataVector, SpatialDim, Frame>& spacetime_unit_normal,
     const Scalar<DataVector>& sqrt_det_spatial_metric,
     const tnsr::II<DataVector, SpatialDim, Frame>& inverse_spatial_metric,
     const tnsr::aa<DataVector, SpatialDim, Frame>& spacetime_metric,
@@ -189,6 +190,7 @@ void damped_harmonic(
     const tnsr::I<DataVector, SpatialDim, Frame>& shift,
     const tnsr::a<DataVector, SpatialDim, Frame>&
         spacetime_unit_normal_one_form,
+    const tnsr::A<DataVector, SpatialDim, Frame>& spacetime_unit_normal,
     const Scalar<DataVector>& sqrt_det_spatial_metric,
     const tnsr::II<DataVector, SpatialDim, Frame>& inverse_spatial_metric,
     const tnsr::aa<DataVector, SpatialDim, Frame>& spacetime_metric,
@@ -260,6 +262,8 @@ class DampedHarmonic final : public GaugeCondition {
       const tnsr::I<DataVector, SpatialDim, Frame::Inertial>& shift,
       const tnsr::a<DataVector, SpatialDim, Frame::Inertial>&
           spacetime_unit_normal_one_form,
+      const tnsr::A<DataVector, SpatialDim, Frame::Inertial>&
+          spacetime_unit_normal,
       const Scalar<DataVector>& sqrt_det_spatial_metric,
       const tnsr::II<DataVector, SpatialDim, Frame::Inertial>&
           inverse_spatial_metric,

--- a/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Dispatch.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Dispatch.cpp
@@ -26,6 +26,7 @@ void dispatch(
     const tnsr::A<DataVector, Dim, Frame::Inertial>& spacetime_unit_normal,
     const Scalar<DataVector>& sqrt_det_spatial_metric,
     const tnsr::II<DataVector, Dim, Frame::Inertial>& inverse_spatial_metric,
+    const tnsr::abb<DataVector, Dim, Frame::Inertial>& d4_spacetime_metric,
     const tnsr::aa<DataVector, Dim, Frame::Inertial>& spacetime_metric,
     const tnsr::aa<DataVector, Dim, Frame::Inertial>& pi,
     const tnsr::iaa<DataVector, Dim, Frame::Inertial>& phi,
@@ -45,7 +46,7 @@ void dispatch(
     damped_harmonic_gauge->gauge_and_spacetime_derivative(
         gauge_h, d4_gauge_h, lapse, shift, spacetime_unit_normal_one_form,
         spacetime_unit_normal, sqrt_det_spatial_metric, inverse_spatial_metric,
-        spacetime_metric, pi, phi, time, inertial_coords);
+        d4_spacetime_metric, spacetime_metric, pi, phi, time, inertial_coords);
   } else if (const auto* analytic_gauge =
                  dynamic_cast<const AnalyticChristoffel*>(&gauge_condition);
              analytic_gauge != nullptr) {
@@ -76,6 +77,8 @@ void dispatch(
       const Scalar<DataVector>& sqrt_det_spatial_metric,                       \
       const tnsr::II<DataVector, DIM(data), Frame::Inertial>&                  \
           inverse_spatial_metric,                                              \
+      const tnsr::abb<DataVector, DIM(data), Frame::Inertial>&                 \
+          d4_spacetime_metric,                                                 \
       const tnsr::aa<DataVector, DIM(data), Frame::Inertial>&                  \
           spacetime_metric,                                                    \
       const tnsr::aa<DataVector, DIM(data), Frame::Inertial>& pi,              \

--- a/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Dispatch.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Dispatch.cpp
@@ -27,6 +27,8 @@ void dispatch(
     const Scalar<DataVector>& sqrt_det_spatial_metric,
     const tnsr::II<DataVector, Dim, Frame::Inertial>& inverse_spatial_metric,
     const tnsr::abb<DataVector, Dim, Frame::Inertial>& d4_spacetime_metric,
+    const Scalar<DataVector>& half_pi_two_normals,
+    const tnsr::i<DataVector, Dim, Frame::Inertial>& half_phi_two_normals,
     const tnsr::aa<DataVector, Dim, Frame::Inertial>& spacetime_metric,
     const tnsr::aa<DataVector, Dim, Frame::Inertial>& pi,
     const tnsr::iaa<DataVector, Dim, Frame::Inertial>& phi,
@@ -46,7 +48,8 @@ void dispatch(
     damped_harmonic_gauge->gauge_and_spacetime_derivative(
         gauge_h, d4_gauge_h, lapse, shift, spacetime_unit_normal_one_form,
         spacetime_unit_normal, sqrt_det_spatial_metric, inverse_spatial_metric,
-        d4_spacetime_metric, spacetime_metric, pi, phi, time, inertial_coords);
+        d4_spacetime_metric, half_pi_two_normals, half_phi_two_normals,
+        spacetime_metric, pi, phi, time, inertial_coords);
   } else if (const auto* analytic_gauge =
                  dynamic_cast<const AnalyticChristoffel*>(&gauge_condition);
              analytic_gauge != nullptr) {
@@ -79,6 +82,9 @@ void dispatch(
           inverse_spatial_metric,                                              \
       const tnsr::abb<DataVector, DIM(data), Frame::Inertial>&                 \
           d4_spacetime_metric,                                                 \
+      const Scalar<DataVector>& half_pi_two_normals,                           \
+      const tnsr::i<DataVector, DIM(data), Frame::Inertial>&                   \
+          half_phi_two_normals,                                                \
       const tnsr::aa<DataVector, DIM(data), Frame::Inertial>&                  \
           spacetime_metric,                                                    \
       const tnsr::aa<DataVector, DIM(data), Frame::Inertial>& pi,              \

--- a/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Dispatch.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Dispatch.cpp
@@ -23,6 +23,7 @@ void dispatch(
     const tnsr::I<DataVector, Dim, Frame::Inertial>& shift,
     const tnsr::a<DataVector, Dim, Frame::Inertial>&
         spacetime_unit_normal_one_form,
+    const tnsr::A<DataVector, Dim, Frame::Inertial>& spacetime_unit_normal,
     const Scalar<DataVector>& sqrt_det_spatial_metric,
     const tnsr::II<DataVector, Dim, Frame::Inertial>& inverse_spatial_metric,
     const tnsr::aa<DataVector, Dim, Frame::Inertial>& spacetime_metric,
@@ -43,8 +44,8 @@ void dispatch(
              damped_harmonic_gauge != nullptr) {
     damped_harmonic_gauge->gauge_and_spacetime_derivative(
         gauge_h, d4_gauge_h, lapse, shift, spacetime_unit_normal_one_form,
-        sqrt_det_spatial_metric, inverse_spatial_metric, spacetime_metric, pi,
-        phi, time, inertial_coords);
+        spacetime_unit_normal, sqrt_det_spatial_metric, inverse_spatial_metric,
+        spacetime_metric, pi, phi, time, inertial_coords);
   } else if (const auto* analytic_gauge =
                  dynamic_cast<const AnalyticChristoffel*>(&gauge_condition);
              analytic_gauge != nullptr) {
@@ -70,6 +71,8 @@ void dispatch(
       const tnsr::I<DataVector, DIM(data), Frame::Inertial>& shift,            \
       const tnsr::a<DataVector, DIM(data), Frame::Inertial>&                   \
           spacetime_unit_normal_one_form,                                      \
+      const tnsr::A<DataVector, DIM(data), Frame::Inertial>&                   \
+          spacetime_unit_normal,                                               \
       const Scalar<DataVector>& sqrt_det_spatial_metric,                       \
       const tnsr::II<DataVector, DIM(data), Frame::Inertial>&                  \
           inverse_spatial_metric,                                              \

--- a/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Dispatch.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Dispatch.hpp
@@ -33,6 +33,8 @@ void dispatch(
     const Scalar<DataVector>& sqrt_det_spatial_metric,
     const tnsr::II<DataVector, Dim, Frame::Inertial>& inverse_spatial_metric,
     const tnsr::abb<DataVector, Dim, Frame::Inertial>& d4_spacetime_metric,
+    const Scalar<DataVector>& half_pi_two_normals,
+    const tnsr::i<DataVector, Dim, Frame::Inertial>& half_phi_two_normals,
     const tnsr::aa<DataVector, Dim, Frame::Inertial>& spacetime_metric,
     const tnsr::aa<DataVector, Dim, Frame::Inertial>& pi,
     const tnsr::iaa<DataVector, Dim, Frame::Inertial>& phi,

--- a/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Dispatch.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Dispatch.hpp
@@ -29,6 +29,7 @@ void dispatch(
     const tnsr::I<DataVector, Dim, Frame::Inertial>& shift,
     const tnsr::a<DataVector, Dim, Frame::Inertial>&
         spacetime_unit_normal_one_form,
+    const tnsr::A<DataVector, Dim, Frame::Inertial>& spacetime_unit_normal,
     const Scalar<DataVector>& sqrt_det_spatial_metric,
     const tnsr::II<DataVector, Dim, Frame::Inertial>& inverse_spatial_metric,
     const tnsr::aa<DataVector, Dim, Frame::Inertial>& spacetime_metric,

--- a/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Dispatch.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Dispatch.hpp
@@ -32,6 +32,7 @@ void dispatch(
     const tnsr::A<DataVector, Dim, Frame::Inertial>& spacetime_unit_normal,
     const Scalar<DataVector>& sqrt_det_spatial_metric,
     const tnsr::II<DataVector, Dim, Frame::Inertial>& inverse_spatial_metric,
+    const tnsr::abb<DataVector, Dim, Frame::Inertial>& d4_spacetime_metric,
     const tnsr::aa<DataVector, Dim, Frame::Inertial>& spacetime_metric,
     const tnsr::aa<DataVector, Dim, Frame::Inertial>& pi,
     const tnsr::iaa<DataVector, Dim, Frame::Inertial>& phi,

--- a/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/SetPiFromGauge.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/SetPiFromGauge.cpp
@@ -126,13 +126,19 @@ void SetPiFromGauge<Dim>::apply(
   trace_last_indices(make_not_null(&trace_spatial_christoffel_first),
                      spatial_christoffel_first, inverse_spatial_metric);
 
+  // Here we use `derivatives_of_spacetime_metric` to get \f$ \partial_a
+  // g_{bc}\f$ instead, and use only the derivatives of \f$ g_{bi}\f$.
+  tnsr::abb<DataVector, Dim, Frame::Inertial> d4_spacetime_metric{};
+  GeneralizedHarmonic::spacetime_derivative_of_spacetime_metric(
+      make_not_null(&d4_spacetime_metric), lapse, shift, *pi, phi);
+
   // Note: we pass in pi to compute d4_gauge_h, but we don't use d4_gauge_h. We
   // actually reset pi from gauge_h below.
   dispatch(make_not_null(&gauge_h), make_not_null(&d4_gauge_h), lapse, shift,
            spacetime_unit_normal_one_form, spacetime_unit_normal_vector,
-           sqrt_det_spatial_metric, inverse_spatial_metric, spacetime_metric,
-           *pi, phi, mesh, time, inertial_coords, inverse_jacobian,
-           gauge_condition);
+           sqrt_det_spatial_metric, inverse_spatial_metric, d4_spacetime_metric,
+           spacetime_metric, *pi, phi, mesh, time, inertial_coords,
+           inverse_jacobian, gauge_condition);
 
   // Compute lapse and shift time derivatives
   get(dt_lapse) =

--- a/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/SetPiFromGauge.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/SetPiFromGauge.cpp
@@ -129,9 +129,10 @@ void SetPiFromGauge<Dim>::apply(
   // Note: we pass in pi to compute d4_gauge_h, but we don't use d4_gauge_h. We
   // actually reset pi from gauge_h below.
   dispatch(make_not_null(&gauge_h), make_not_null(&d4_gauge_h), lapse, shift,
-           spacetime_unit_normal_one_form, sqrt_det_spatial_metric,
-           inverse_spatial_metric, spacetime_metric, *pi, phi, mesh, time,
-           inertial_coords, inverse_jacobian, gauge_condition);
+           spacetime_unit_normal_one_form, spacetime_unit_normal_vector,
+           sqrt_det_spatial_metric, inverse_spatial_metric, spacetime_metric,
+           *pi, phi, mesh, time, inertial_coords, inverse_jacobian,
+           gauge_condition);
 
   // Compute lapse and shift time derivatives
   get(dt_lapse) =

--- a/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Tags/GaugeCondition.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Tags/GaugeCondition.cpp
@@ -12,6 +12,7 @@
 #include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "Options/Options.hpp"
+#include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/SpacetimeDerivativeOfSpacetimeMetric.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
 
@@ -38,15 +39,21 @@ void GaugeAndDerivativeCompute<Dim>::function(
       UNLIKELY(gauge_and_deriv->number_of_grid_points() != num_points)) {
     gauge_and_deriv->initialize(num_points);
   }
+  // Just compute d4_spacetime_metric internally for now. Since compute tags
+  // are only used for observing, this should be fine.
+  tnsr::abb<DataVector, Dim, Frame::Inertial> d4_spacetime_metric{
+      get(lapse).size()};
+  GeneralizedHarmonic::spacetime_derivative_of_spacetime_metric(
+      make_not_null(&d4_spacetime_metric), lapse, shift, pi, phi);
   dispatch(make_not_null(
                &get<::GeneralizedHarmonic::Tags::GaugeH<Dim, Frame::Inertial>>(
                    *gauge_and_deriv)),
            make_not_null(&get<::GeneralizedHarmonic::Tags::SpacetimeDerivGaugeH<
                              Dim, Frame::Inertial>>(*gauge_and_deriv)),
            lapse, shift, spacetime_unit_normal_one_form, spacetime_unit_normal,
-           sqrt_det_spatial_metric, inverse_spatial_metric, spacetime_metric,
-           pi, phi, mesh, time, inertial_coords, inverse_jacobian,
-           gauge_condition);
+           sqrt_det_spatial_metric, inverse_spatial_metric, d4_spacetime_metric,
+           spacetime_metric, pi, phi, mesh, time, inertial_coords,
+           inverse_jacobian, gauge_condition);
 }
 
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)

--- a/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Tags/GaugeCondition.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Tags/GaugeCondition.cpp
@@ -23,6 +23,7 @@ void GaugeAndDerivativeCompute<Dim>::function(
     const tnsr::I<DataVector, Dim, Frame::Inertial>& shift,
     const tnsr::a<DataVector, Dim, Frame::Inertial>&
         spacetime_unit_normal_one_form,
+    const tnsr::A<DataVector, Dim, Frame::Inertial>& spacetime_unit_normal,
     const Scalar<DataVector>& sqrt_det_spatial_metric,
     const tnsr::II<DataVector, Dim, Frame::Inertial>& inverse_spatial_metric,
     const tnsr::aa<DataVector, Dim, Frame::Inertial>& spacetime_metric,
@@ -42,7 +43,7 @@ void GaugeAndDerivativeCompute<Dim>::function(
                    *gauge_and_deriv)),
            make_not_null(&get<::GeneralizedHarmonic::Tags::SpacetimeDerivGaugeH<
                              Dim, Frame::Inertial>>(*gauge_and_deriv)),
-           lapse, shift, spacetime_unit_normal_one_form,
+           lapse, shift, spacetime_unit_normal_one_form, spacetime_unit_normal,
            sqrt_det_spatial_metric, inverse_spatial_metric, spacetime_metric,
            pi, phi, mesh, time, inertial_coords, inverse_jacobian,
            gauge_condition);

--- a/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Tags/GaugeCondition.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Tags/GaugeCondition.hpp
@@ -65,7 +65,8 @@ struct GaugeAndDerivativeCompute
   using return_type = typename base::type;
   using argument_tags = tmpl::list<
       gr::Tags::Lapse<>, gr::Tags::Shift<Dim>,
-      gr::Tags::SpacetimeNormalOneForm<Dim>, gr::Tags::SqrtDetSpatialMetric<>,
+      gr::Tags::SpacetimeNormalOneForm<Dim>,
+      gr::Tags::SpacetimeNormalVector<Dim>, gr::Tags::SqrtDetSpatialMetric<>,
       gr::Tags::InverseSpatialMetric<Dim>, gr::Tags::SpacetimeMetric<Dim>,
       GeneralizedHarmonic::Tags::Pi<Dim>, GeneralizedHarmonic::Tags::Phi<Dim>,
       ::Events::Tags::ObserverMesh<Dim>, ::Tags::Time,
@@ -80,6 +81,7 @@ struct GaugeAndDerivativeCompute
       const tnsr::I<DataVector, Dim, Frame::Inertial>& shift,
       const tnsr::a<DataVector, Dim, Frame::Inertial>&
           spacetime_unit_normal_one_form,
+      const tnsr::A<DataVector, Dim, Frame::Inertial>& spacetime_unit_normal,
       const Scalar<DataVector>& sqrt_det_spatial_metric,
       const tnsr::II<DataVector, Dim, Frame::Inertial>& inverse_spatial_metric,
       const tnsr::aa<DataVector, Dim, Frame::Inertial>& spacetime_metric,

--- a/src/Evolution/Systems/GeneralizedHarmonic/TimeDerivative.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/TimeDerivative.cpp
@@ -228,11 +228,12 @@ void TimeDerivative<Dim>::apply(
   // Compute gauge condition.
   get(*sqrt_det_spatial_metric) = sqrt(get(*det_spatial_metric));
 
-  gauges::dispatch<Dim>(
-      gauge_function, spacetime_deriv_gauge_function, *lapse, *shift,
-      *normal_spacetime_one_form, *normal_spacetime_vector,
-      *sqrt_det_spatial_metric, *inverse_spatial_metric, spacetime_metric, pi,
-      phi, mesh, time, inertial_coords, inverse_jacobian, gauge_condition);
+  gauges::dispatch<Dim>(gauge_function, spacetime_deriv_gauge_function, *lapse,
+                        *shift, *normal_spacetime_one_form,
+                        *normal_spacetime_vector, *sqrt_det_spatial_metric,
+                        *inverse_spatial_metric, *da_spacetime_metric,
+                        spacetime_metric, pi, phi, mesh, time, inertial_coords,
+                        inverse_jacobian, gauge_condition);
 
   // Compute source function last so that we don't need to recompute any of the
   // other temporary tags.

--- a/src/Evolution/Systems/GeneralizedHarmonic/TimeDerivative.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/TimeDerivative.cpp
@@ -228,12 +228,12 @@ void TimeDerivative<Dim>::apply(
   // Compute gauge condition.
   get(*sqrt_det_spatial_metric) = sqrt(get(*det_spatial_metric));
 
-  gauges::dispatch<Dim>(gauge_function, spacetime_deriv_gauge_function, *lapse,
-                        *shift, *normal_spacetime_one_form,
-                        *normal_spacetime_vector, *sqrt_det_spatial_metric,
-                        *inverse_spatial_metric, *da_spacetime_metric,
-                        spacetime_metric, pi, phi, mesh, time, inertial_coords,
-                        inverse_jacobian, gauge_condition);
+  gauges::dispatch<Dim>(
+      gauge_function, spacetime_deriv_gauge_function, *lapse, *shift,
+      *normal_spacetime_one_form, *normal_spacetime_vector,
+      *sqrt_det_spatial_metric, *inverse_spatial_metric, *da_spacetime_metric,
+      *half_pi_two_normals, *half_phi_two_normals, spacetime_metric, pi, phi,
+      mesh, time, inertial_coords, inverse_jacobian, gauge_condition);
 
   // Compute source function last so that we don't need to recompute any of the
   // other temporary tags.

--- a/src/Evolution/Systems/GeneralizedHarmonic/TimeDerivative.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/TimeDerivative.cpp
@@ -228,11 +228,11 @@ void TimeDerivative<Dim>::apply(
   // Compute gauge condition.
   get(*sqrt_det_spatial_metric) = sqrt(get(*det_spatial_metric));
 
-  gauges::dispatch<Dim>(gauge_function, spacetime_deriv_gauge_function, *lapse,
-                        *shift, *normal_spacetime_one_form,
-                        *sqrt_det_spatial_metric, *inverse_spatial_metric,
-                        spacetime_metric, pi, phi, mesh, time, inertial_coords,
-                        inverse_jacobian, gauge_condition);
+  gauges::dispatch<Dim>(
+      gauge_function, spacetime_deriv_gauge_function, *lapse, *shift,
+      *normal_spacetime_one_form, *normal_spacetime_vector,
+      *sqrt_det_spatial_metric, *inverse_spatial_metric, spacetime_metric, pi,
+      phi, mesh, time, inertial_coords, inverse_jacobian, gauge_condition);
 
   // Compute source function last so that we don't need to recompute any of the
   // other temporary tags.

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Test_AnalyticChristoffel.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Test_AnalyticChristoffel.cpp
@@ -105,7 +105,7 @@ void test_gauge_wave(const Mesh<Dim>& mesh) {
   // gauge.
   GeneralizedHarmonic::gauges::dispatch(
       make_not_null(&gauge_h), make_not_null(&d4_gauge_h), {}, {}, {}, {}, {},
-      {}, {}, {}, {}, mesh, time, inertial_coords, inverse_jacobian,
+      {}, {}, {}, {}, {}, mesh, time, inertial_coords, inverse_jacobian,
       *gauge_condition);
 
   CHECK_ITERABLE_APPROX(
@@ -141,7 +141,7 @@ void test_ks(const Mesh<3>& mesh) {
   // gauge.
   GeneralizedHarmonic::gauges::dispatch(
       make_not_null(&gauge_h), make_not_null(&d4_gauge_h), {}, {}, {}, {}, {},
-      {}, {}, {}, {}, mesh, time, inertial_coords, inverse_jacobian,
+      {}, {}, {}, {}, {}, mesh, time, inertial_coords, inverse_jacobian,
       *gauge_condition);
 
   const GeneralizedHarmonic::Solutions::WrappedGr<gr::Solutions::KerrSchild>

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Test_AnalyticChristoffel.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Test_AnalyticChristoffel.cpp
@@ -105,7 +105,7 @@ void test_gauge_wave(const Mesh<Dim>& mesh) {
   // gauge.
   GeneralizedHarmonic::gauges::dispatch(
       make_not_null(&gauge_h), make_not_null(&d4_gauge_h), {}, {}, {}, {}, {},
-      {}, {}, {}, {}, {}, mesh, time, inertial_coords, inverse_jacobian,
+      {}, {}, {}, {}, {}, {}, {}, mesh, time, inertial_coords, inverse_jacobian,
       *gauge_condition);
 
   CHECK_ITERABLE_APPROX(
@@ -141,7 +141,7 @@ void test_ks(const Mesh<3>& mesh) {
   // gauge.
   GeneralizedHarmonic::gauges::dispatch(
       make_not_null(&gauge_h), make_not_null(&d4_gauge_h), {}, {}, {}, {}, {},
-      {}, {}, {}, {}, {}, mesh, time, inertial_coords, inverse_jacobian,
+      {}, {}, {}, {}, {}, {}, {}, mesh, time, inertial_coords, inverse_jacobian,
       *gauge_condition);
 
   const GeneralizedHarmonic::Solutions::WrappedGr<gr::Solutions::KerrSchild>

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Test_AnalyticChristoffel.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Test_AnalyticChristoffel.cpp
@@ -105,7 +105,7 @@ void test_gauge_wave(const Mesh<Dim>& mesh) {
   // gauge.
   GeneralizedHarmonic::gauges::dispatch(
       make_not_null(&gauge_h), make_not_null(&d4_gauge_h), {}, {}, {}, {}, {},
-      {}, {}, {}, mesh, time, inertial_coords, inverse_jacobian,
+      {}, {}, {}, {}, mesh, time, inertial_coords, inverse_jacobian,
       *gauge_condition);
 
   CHECK_ITERABLE_APPROX(
@@ -141,7 +141,7 @@ void test_ks(const Mesh<3>& mesh) {
   // gauge.
   GeneralizedHarmonic::gauges::dispatch(
       make_not_null(&gauge_h), make_not_null(&d4_gauge_h), {}, {}, {}, {}, {},
-      {}, {}, {}, mesh, time, inertial_coords, inverse_jacobian,
+      {}, {}, {}, {}, mesh, time, inertial_coords, inverse_jacobian,
       *gauge_condition);
 
   const GeneralizedHarmonic::Solutions::WrappedGr<gr::Solutions::KerrSchild>

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Test_DampedHarmonic.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Test_DampedHarmonic.cpp
@@ -31,6 +31,7 @@
 #include "PointwiseFunctions/GeneralRelativity/Lapse.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Shift.hpp"
 #include "PointwiseFunctions/GeneralRelativity/SpacetimeNormalOneForm.hpp"
+#include "PointwiseFunctions/GeneralRelativity/SpacetimeNormalVector.hpp"
 #include "PointwiseFunctions/GeneralRelativity/SpatialMetric.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
@@ -109,12 +110,14 @@ void wrap_damped_harmonic_rollon(
   const auto lapse = gr::lapse(shift, spacetime_metric);
   const auto spacetime_unit_normal_one_form =
       gr::spacetime_normal_one_form<SpatialDim, Frame>(lapse);
+  const auto spacetime_normal_vector =
+      gr::spacetime_normal_vector(lapse, shift);
   GeneralizedHarmonic::gauges::damped_harmonic_rollon(
       gauge_h, d4_gauge_h, gauge_h_init, dgauge_h_init, lapse, shift,
-      spacetime_unit_normal_one_form, sqrt_det_spatial_metric,
-      inverse_spatial_metric, spacetime_metric, pi, phi, time, coords,
-      amp_coef_L1, amp_coef_L2, amp_coef_S, 4, 4, 4, rollon_start_time,
-      rollon_width, sigma_r);
+      spacetime_unit_normal_one_form, spacetime_normal_vector,
+      sqrt_det_spatial_metric, inverse_spatial_metric, spacetime_metric, pi,
+      phi, time, coords, amp_coef_L1, amp_coef_L2, amp_coef_S, 4, 4, 4,
+      rollon_start_time, rollon_width, sigma_r);
 }
 
 template <size_t SpatialDim, typename Frame>
@@ -141,10 +144,13 @@ void wrap_damped_harmonic(
   const auto lapse = gr::lapse(shift, spacetime_metric);
   const auto spacetime_unit_normal_one_form =
       gr::spacetime_normal_one_form<SpatialDim, Frame>(lapse);
+  const auto spacetime_normal_vector =
+      gr::spacetime_normal_vector(lapse, shift);
   GeneralizedHarmonic::gauges::damped_harmonic(
       gauge_h, d4_gauge_h, lapse, shift, spacetime_unit_normal_one_form,
-      sqrt_det_spatial_metric, inverse_spatial_metric, spacetime_metric, pi,
-      phi, coords, amp_coef_L1, amp_coef_L2, amp_coef_S, 4, 4, 4, sigma_r);
+      spacetime_normal_vector, sqrt_det_spatial_metric, inverse_spatial_metric,
+      spacetime_metric, pi, phi, coords, amp_coef_L1, amp_coef_L2, amp_coef_S,
+      4, 4, 4, sigma_r);
 }
 
 // Compare with Python implementation
@@ -225,6 +231,8 @@ void test_derived_class(const Mesh<Dim>& mesh) {
       gr::spacetime_normal_one_form<Dim, Frame::Inertial>(lapse);
   const auto inverse_spacetime_metric =
       determinant_and_inverse(spacetime_metric).second;
+  const auto spacetime_normal_vector =
+      gr::spacetime_normal_vector(lapse, shift);
 
   std::uniform_real_distribution<> coords_dist(1.0, 100.0);
   const auto inertial_coords =
@@ -237,25 +245,25 @@ void test_derived_class(const Mesh<Dim>& mesh) {
       *gauge_condition)
       .gauge_and_spacetime_derivative(
           make_not_null(&gauge_h), make_not_null(&d4_gauge_h), lapse, shift,
-          spacetime_normal_one_form, sqrt_det_spatial_metric,
-          inverse_spatial_metric, spacetime_metric, pi, phi, time,
-          inertial_coords);
+          spacetime_normal_one_form, spacetime_normal_vector,
+          sqrt_det_spatial_metric, inverse_spatial_metric, spacetime_metric, pi,
+          phi, time, inertial_coords);
 
   // Used dispatch with defaulted arguments that we don't need for
   // DampedHarmonic gauge.
   GeneralizedHarmonic::gauges::dispatch(
       make_not_null(&gauge_h), make_not_null(&d4_gauge_h), lapse, shift,
-      spacetime_normal_one_form, sqrt_det_spatial_metric,
-      inverse_spatial_metric, spacetime_metric, pi, phi, mesh, time,
-      inertial_coords, {}, *gauge_condition);
+      spacetime_normal_one_form, spacetime_normal_vector,
+      sqrt_det_spatial_metric, inverse_spatial_metric, spacetime_metric, pi,
+      phi, mesh, time, inertial_coords, {}, *gauge_condition);
 
   tnsr::a<DataVector, Dim, Frame::Inertial> expected_gauge_h(num_points);
   tnsr::ab<DataVector, Dim, Frame::Inertial> expected_d4_gauge_h(num_points);
   GeneralizedHarmonic::gauges::damped_harmonic(
       make_not_null(&expected_gauge_h), make_not_null(&expected_d4_gauge_h),
-      lapse, shift, spacetime_normal_one_form, sqrt_det_spatial_metric,
-      inverse_spatial_metric, spacetime_metric, pi, phi, inertial_coords, 0.5,
-      1.5, 2.5, 2, 4, 6, 100.0);
+      lapse, shift, spacetime_normal_one_form, spacetime_normal_vector,
+      sqrt_det_spatial_metric, inverse_spatial_metric, spacetime_metric, pi,
+      phi, inertial_coords, 0.5, 1.5, 2.5, 2, 4, 6, 100.0);
 
   CHECK_ITERABLE_APPROX(gauge_h, expected_gauge_h);
   CHECK_ITERABLE_APPROX(d4_gauge_h, expected_d4_gauge_h);

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Test_Harmonic.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Test_Harmonic.cpp
@@ -49,7 +49,7 @@ void test() {
   // gauge.
   GeneralizedHarmonic::gauges::dispatch(
       make_not_null(&gauge_h), make_not_null(&d4_gauge_h), {}, {}, {}, {}, {},
-      {}, {}, {}, Mesh<Dim>{}, time, inertial_coords, {}, *gauge_condition);
+      {}, {}, {}, {}, Mesh<Dim>{}, time, inertial_coords, {}, *gauge_condition);
   CHECK(gauge_h == tnsr::a<DataVector, Dim, Frame::Inertial>(num_points, 0.0));
   CHECK(d4_gauge_h ==
         tnsr::ab<DataVector, Dim, Frame::Inertial>(num_points, 0.0));

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Test_Harmonic.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Test_Harmonic.cpp
@@ -49,7 +49,8 @@ void test() {
   // gauge.
   GeneralizedHarmonic::gauges::dispatch(
       make_not_null(&gauge_h), make_not_null(&d4_gauge_h), {}, {}, {}, {}, {},
-      {}, {}, {}, {}, Mesh<Dim>{}, time, inertial_coords, {}, *gauge_condition);
+      {}, {}, {}, {}, {}, Mesh<Dim>{}, time, inertial_coords, {},
+      *gauge_condition);
   CHECK(gauge_h == tnsr::a<DataVector, Dim, Frame::Inertial>(num_points, 0.0));
   CHECK(d4_gauge_h ==
         tnsr::ab<DataVector, Dim, Frame::Inertial>(num_points, 0.0));

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Test_Harmonic.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Test_Harmonic.cpp
@@ -49,7 +49,7 @@ void test() {
   // gauge.
   GeneralizedHarmonic::gauges::dispatch(
       make_not_null(&gauge_h), make_not_null(&d4_gauge_h), {}, {}, {}, {}, {},
-      {}, {}, {}, {}, {}, Mesh<Dim>{}, time, inertial_coords, {},
+      {}, {}, {}, {}, {}, {}, {}, Mesh<Dim>{}, time, inertial_coords, {},
       *gauge_condition);
   CHECK(gauge_h == tnsr::a<DataVector, Dim, Frame::Inertial>(num_points, 0.0));
   CHECK(d4_gauge_h ==

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Test_SetPiFromGauge.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Test_SetPiFromGauge.cpp
@@ -37,6 +37,7 @@
 #include "Helpers/DataStructures/MakeWithRandomValues.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/SpacetimeDerivativeOfSpacetimeMetric.hpp"
 #include "PointwiseFunctions/GeneralRelativity/InverseSpacetimeMetric.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Lapse.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Shift.hpp"
@@ -130,14 +131,17 @@ void test(const gsl::not_null<std::mt19937*> generator) {
       gr::spacetime_normal_one_form<Dim, Frame::Inertial>(lapse);
   const auto spacetime_normal_vector =
       gr::spacetime_normal_vector(lapse, shift);
+  tnsr::abb<DataVector, Dim, Frame::Inertial> d4_spacetime_metric{};
+  GeneralizedHarmonic::spacetime_derivative_of_spacetime_metric(
+      make_not_null(&d4_spacetime_metric), lapse, shift, pi, phi);
 
   tnsr::a<DataVector, Dim, Frame::Inertial> gauge_h(num_points);
   tnsr::ab<DataVector, Dim, Frame::Inertial> d4_gauge_h(num_points);
   GeneralizedHarmonic::gauges::dispatch(
       make_not_null(&gauge_h), make_not_null(&d4_gauge_h), lapse, shift,
       spacetime_normal_one_form, spacetime_normal_vector,
-      sqrt_det_spatial_metric, inverse_spatial_metric, spacetime_metric, pi,
-      phi, mesh, db::get<::Tags::Time>(box),
+      sqrt_det_spatial_metric, inverse_spatial_metric, d4_spacetime_metric,
+      spacetime_metric, pi, phi, mesh, db::get<::Tags::Time>(box),
       db::get<domain::CoordinateMaps::Tags::CoordinateMap<Dim, Frame::Grid,
                                                           Frame::Inertial>>(
           box)(db::get<domain::Tags::ElementMap<Dim, Frame::Grid>>(box)(

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Test_SetPiFromGauge.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Test_SetPiFromGauge.cpp
@@ -135,13 +135,37 @@ void test(const gsl::not_null<std::mt19937*> generator) {
   GeneralizedHarmonic::spacetime_derivative_of_spacetime_metric(
       make_not_null(&d4_spacetime_metric), lapse, shift, pi, phi);
 
+  Scalar<DataVector> half_pi_two_normals{get(lapse).size(), 0.0};
+  tnsr::i<DataVector, Dim, Frame::Inertial> half_phi_two_normals{
+      get(lapse).size(), 0.0};
+  for (size_t a = 0; a < Dim + 1; ++a) {
+    get(half_pi_two_normals) += spacetime_normal_vector.get(a) *
+                                spacetime_normal_vector.get(a) * pi.get(a, a);
+    for (size_t i = 0; i < Dim; ++i) {
+      half_phi_two_normals.get(i) += 0.5 * spacetime_normal_vector.get(a) *
+                                     spacetime_normal_vector.get(a) *
+                                     phi.get(i, a, a);
+    }
+    for (size_t b = a + 1; b < Dim + 1; ++b) {
+      get(half_pi_two_normals) += 2.0 * spacetime_normal_vector.get(a) *
+                                  spacetime_normal_vector.get(b) * pi.get(a, b);
+      for (size_t i = 0; i < Dim; ++i) {
+        half_phi_two_normals.get(i) += spacetime_normal_vector.get(a) *
+                                       spacetime_normal_vector.get(b) *
+                                       phi.get(i, a, b);
+      }
+    }
+  }
+  get(half_pi_two_normals) *= 0.5;
+
   tnsr::a<DataVector, Dim, Frame::Inertial> gauge_h(num_points);
   tnsr::ab<DataVector, Dim, Frame::Inertial> d4_gauge_h(num_points);
   GeneralizedHarmonic::gauges::dispatch(
       make_not_null(&gauge_h), make_not_null(&d4_gauge_h), lapse, shift,
       spacetime_normal_one_form, spacetime_normal_vector,
       sqrt_det_spatial_metric, inverse_spatial_metric, d4_spacetime_metric,
-      spacetime_metric, pi, phi, mesh, db::get<::Tags::Time>(box),
+      half_pi_two_normals, half_phi_two_normals, spacetime_metric, pi, phi,
+      mesh, db::get<::Tags::Time>(box),
       db::get<domain::CoordinateMaps::Tags::CoordinateMap<Dim, Frame::Grid,
                                                           Frame::Inertial>>(
           box)(db::get<domain::Tags::ElementMap<Dim, Frame::Grid>>(box)(

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Test_SetPiFromGauge.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Test_SetPiFromGauge.cpp
@@ -135,9 +135,9 @@ void test(const gsl::not_null<std::mt19937*> generator) {
   tnsr::ab<DataVector, Dim, Frame::Inertial> d4_gauge_h(num_points);
   GeneralizedHarmonic::gauges::dispatch(
       make_not_null(&gauge_h), make_not_null(&d4_gauge_h), lapse, shift,
-      spacetime_normal_one_form, sqrt_det_spatial_metric,
-      inverse_spatial_metric, spacetime_metric, pi, phi, mesh,
-      db::get<::Tags::Time>(box),
+      spacetime_normal_one_form, spacetime_normal_vector,
+      sqrt_det_spatial_metric, inverse_spatial_metric, spacetime_metric, pi,
+      phi, mesh, db::get<::Tags::Time>(box),
       db::get<domain::CoordinateMaps::Tags::CoordinateMap<Dim, Frame::Grid,
                                                           Frame::Inertial>>(
           box)(db::get<domain::Tags::ElementMap<Dim, Frame::Grid>>(box)(

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Test_Tags.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Test_Tags.cpp
@@ -34,6 +34,7 @@ void test() {
       db::AddSimpleTags<
           gr::Tags::Lapse<>, gr::Tags::Shift<Dim>,
           gr::Tags::SpacetimeNormalOneForm<Dim>,
+          gr::Tags::SpacetimeNormalVector<Dim>,
           gr::Tags::SqrtDetSpatialMetric<>, gr::Tags::InverseSpatialMetric<Dim>,
           gr::Tags::SpacetimeMetric<Dim>, GeneralizedHarmonic::Tags::Pi<Dim>,
           GeneralizedHarmonic::Tags::Phi<Dim>,
@@ -45,7 +46,8 @@ void test() {
       db::AddComputeTags<
           GeneralizedHarmonic::gauges::Tags::GaugeAndDerivativeCompute<Dim>>>(
       Scalar<DataVector>{}, tnsr::I<DataVector, Dim, Frame::Inertial>{},
-      tnsr::a<DataVector, Dim, Frame::Inertial>{}, Scalar<DataVector>{},
+      tnsr::a<DataVector, Dim, Frame::Inertial>{},
+      tnsr::A<DataVector, Dim, Frame::Inertial>{}, Scalar<DataVector>{},
       tnsr::II<DataVector, Dim, Frame::Inertial>{},
       tnsr::aa<DataVector, Dim, Frame::Inertial>{},
       tnsr::aa<DataVector, Dim, Frame::Inertial>{},

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_DuDt.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_DuDt.cpp
@@ -564,8 +564,8 @@ void test_compute_dudt(const gsl::not_null<Generator*> generator) {
   GeneralizedHarmonic::gauges::dispatch(
       make_not_null(&gauge_h), make_not_null(&d4_gauge_h), lapse, shift,
       normal_one_form, normal_vector, sqrt_det_spatial_metric,
-      inverse_spatial_metric, spacetime_metric, pi, phi, mesh, time,
-      inertial_coords, inv_jac, gauge_condition);
+      inverse_spatial_metric, da_spacetime_metric, spacetime_metric, pi, phi,
+      mesh, time, inertial_coords, inv_jac, gauge_condition);
 
   const auto [expected_dt_spacetime_metric, expected_dt_pi, expected_dt_phi] =
       gh_rhs_reference_impl(

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_DuDt.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_DuDt.cpp
@@ -563,9 +563,9 @@ void test_compute_dudt(const gsl::not_null<Generator*> generator) {
 
   GeneralizedHarmonic::gauges::dispatch(
       make_not_null(&gauge_h), make_not_null(&d4_gauge_h), lapse, shift,
-      normal_one_form, sqrt_det_spatial_metric, inverse_spatial_metric,
-      spacetime_metric, pi, phi, mesh, time, inertial_coords, inv_jac,
-      gauge_condition);
+      normal_one_form, normal_vector, sqrt_det_spatial_metric,
+      inverse_spatial_metric, spacetime_metric, pi, phi, mesh, time,
+      inertial_coords, inv_jac, gauge_condition);
 
   const auto [expected_dt_spacetime_metric, expected_dt_pi, expected_dt_phi] =
       gh_rhs_reference_impl(


### PR DESCRIPTION
## Proposed changes

Only `Pass Pi and Phi contracted with normals to DH` is new

I believe this eliminates the remaining redundant computations that the damped harmonic gauge ends up doing that are already done in the RHS. 

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
