### PR TITLE
Make Enthalpy EoS improvements

### DIFF
--- a/src/PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp
@@ -43,9 +43,11 @@ struct DerivedClasses {};
 
 template <>
 struct DerivedClasses<true, 1> {
-  using type =
-      tmpl::list<Spectral, Enthalpy<Spectral>, PiecewisePolytropicFluid<true>,
-                 PolytropicFluid<true>>;
+  using type = tmpl::list<Enthalpy<Enthalpy<Enthalpy<Spectral>>>,
+                          Enthalpy<Enthalpy<Spectral>>, Enthalpy<Spectral>,
+                          Enthalpy<PolytropicFluid<true>>,
+                          PiecewisePolytropicFluid<true>, PolytropicFluid<true>,
+                          Spectral>;
 };
 
 template <>

--- a/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_Enthalpy.cpp
+++ b/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_Enthalpy.cpp
@@ -25,7 +25,7 @@ void check_exact() {
   Parallel::register_derived_classes_with_charm<EquationOfState<true, 1>>();
   const auto eos_pointer = serialize_and_deserialize(
       TestHelpers::test_creation<std::unique_ptr<EquationOfState<true, 1>>>(
-          {"Enthalpy:\n"
+          {"Enthalpy(Spectral):\n"
            "  ReferenceDensity: 2.0\n"
            "  MinimumDensity: 4.0\n"
            "  MaximumDensity: 100.0\n"


### PR DESCRIPTION
## Proposed changes

This PR introduces some additional features to the Enthalpy EoS, allowing for example, Piecewise enthalpy EoSs (which will allow for modeling Piecewise polytropes). Most importantly, it introduces an optimization to the Enthalpy EoS evaluation of the function `pressure_from_rest_mass_density`, improving performance by typically 30 %

### Upgrade instructions

No upgrade instructions should be needed.

<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
