### PR TITLE
Add action to initialize DataBox items

### DIFF
--- a/src/ParallelAlgorithms/Actions/CMakeLists.txt
+++ b/src/ParallelAlgorithms/Actions/CMakeLists.txt
@@ -12,6 +12,7 @@ spectre_target_headers(
   AddComputeTags.hpp
   AddSimpleTags.hpp
   Goto.hpp
+  InitializeItems.hpp
   MutateApply.hpp
   RandomizeVariables.hpp
   SetData.hpp

--- a/src/ParallelAlgorithms/Actions/InitializeItems.hpp
+++ b/src/ParallelAlgorithms/Actions/InitializeItems.hpp
@@ -1,0 +1,75 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <optional>
+#include <utility>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "Parallel/AlgorithmExecution.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+/// \cond
+namespace Parallel {
+template <typename Metavariables>
+class GlobalCache;
+}  // namespace Parallel
+/// \endcond
+
+namespace Initialization {
+namespace Actions {
+/*!
+ * \ingroup ActionsGroup
+ * \brief Mutate DataBox items by calling db::mutate_apply on each Mutator in
+ *  the order they are specified
+ *
+ * There's a specialization for `InitializeItems<tmpl::list<Mutators...>>` that
+ * can also be used if a `tmpl::list` is available.
+ *
+ * \details In addition to the requirements specified by db::mutate_apply, each
+ * Mutator must define the type aliases of this action.
+ */
+template <typename... Mutators>
+struct InitializeItems {
+  /// Tags for constant items added to the GlobalCache.  These items are
+  /// initialized from input file options.
+  using const_global_cache_tags = tmpl::remove_duplicates<tmpl::flatten<
+      tmpl::append<typename Mutators::const_global_cache_tags...>>>;
+  /// Tags for mutable items added to the MutableGlobalCache.  These items are
+  /// initialized from input file options.
+  using mutable_global_cache_tags = tmpl::remove_duplicates<tmpl::flatten<
+      tmpl::append<typename Mutators::mutable_global_cache_tags...>>>;
+  /// Tags for simple DataBox items that are initialized from input file options
+  using simple_tags_from_options = tmpl::remove_duplicates<tmpl::flatten<
+      tmpl::append<typename Mutators::simple_tags_from_options...>>>;
+  /// Tags for simple DataBox items that are default initialized.  They may be
+  /// mutated by the Mutators.
+  using simple_tags = tmpl::remove_duplicates<
+      tmpl::flatten<tmpl::append<typename Mutators::simple_tags...>>>;
+  /// Tags for immutable DataBox items (compute items or reference items).
+  using compute_tags = tmpl::remove_duplicates<
+      tmpl::flatten<tmpl::append<typename Mutators::compute_tags...>>>;
+
+  template <typename DbTagsList, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent>
+  static Parallel::iterable_action_return_t apply(
+      db::DataBox<DbTagsList>& box,
+      const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+      const Parallel::GlobalCache<Metavariables>& /*cache*/,
+      const ArrayIndex& /*array_index*/, ActionList /*meta*/,
+      const ParallelComponent* const /*meta*/) {
+    EXPAND_PACK_LEFT_TO_RIGHT(db::mutate_apply<Mutators>(make_not_null(&box)));
+    return {Parallel::AlgorithmExecution::Continue, std::nullopt};
+  }
+};
+
+/// \cond
+template <typename... Mutators>
+struct InitializeItems<tmpl::list<Mutators...>>
+    : public InitializeItems<Mutators...> {};
+/// \endcond
+}  // namespace Actions
+}  // namespace Initialization

--- a/tests/Unit/ParallelAlgorithms/Actions/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/Actions/CMakeLists.txt
@@ -7,6 +7,7 @@ set(LIBRARY_SOURCES
   Test_AddComputeTags.cpp
   Test_AddSimpleTags.cpp
   Test_Goto.cpp
+  Test_InitializeItems.cpp
   Test_MutateApply.cpp
   Test_RandomizeVariables.cpp
   Test_SetData.cpp

--- a/tests/Unit/ParallelAlgorithms/Actions/Test_InitializeItems.cpp
+++ b/tests/Unit/ParallelAlgorithms/Actions/Test_InitializeItems.cpp
@@ -1,0 +1,170 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <string>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/Tag.hpp"
+#include "Framework/ActionTesting.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "Parallel/Phase.hpp"
+#include "Parallel/PhaseDependentActionList.hpp"
+#include "ParallelAlgorithms/Actions/InitializeItems.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+struct TagOne : db::SimpleTag {
+  using type = int;
+};
+
+struct TagTwo : db::SimpleTag {
+  using type = std::string;
+};
+
+struct TagThree : db::SimpleTag {
+  using type = double;
+};
+
+struct Two : db::SimpleTag {
+  using type = double;
+};
+
+struct Three : db::SimpleTag {
+  using type = double;
+};
+
+struct Five : db::SimpleTag {
+  using type = double;
+};
+
+struct Ten : db::SimpleTag {
+  using type = double;
+};
+
+struct FiveCompute : Five, db::ComputeTag {
+  using return_type = double;
+  using base = Five;
+  using argument_tags = tmpl::list<Two, Three>;
+  static void function(const gsl::not_null<double*> result, const double two,
+                       const double three) {
+    *result = two + three;
+  }
+};
+
+struct Duplicate : db::SimpleTag {
+  using type = int;
+};
+
+struct InitializeThree {
+  using const_global_cache_tags = tmpl::list<TagOne, Duplicate>;
+  using mutable_global_cache_tags = tmpl::list<TagTwo, Duplicate>;
+  using simple_tags_from_options = tmpl::list<>;
+  using simple_tags = tmpl::list<Three, Duplicate>;
+  using compute_tags = tmpl::list<>;
+  using return_tags = tmpl::list<Three>;
+  using argument_tags = tmpl::list<>;
+
+  static void apply(const gsl::not_null<double*> three) { *three = 3.; }
+};
+
+struct InitializeTwo {
+  using const_global_cache_tags = tmpl::list<TagThree, Duplicate>;
+  using mutable_global_cache_tags = tmpl::list<Duplicate>;
+  using simple_tags_from_options = tmpl::list<Two>;
+  using simple_tags = tmpl::list<Duplicate>;
+  using compute_tags = tmpl::list<FiveCompute>;
+  using return_tags = tmpl::list<>;
+  using argument_tags = tmpl::list<>;
+  static void apply() {}
+};
+
+struct InitializeTen {
+  using const_global_cache_tags = tmpl::list<Duplicate>;
+  using mutable_global_cache_tags = tmpl::list<Duplicate>;
+  using simple_tags_from_options = tmpl::list<Two>;
+  using simple_tags = tmpl::list<Ten, Duplicate>;
+  using compute_tags = tmpl::list<FiveCompute>;
+  using return_tags = tmpl::list<Ten>;
+  using argument_tags = tmpl::list<Two, Five>;
+
+  static void apply(const gsl::not_null<double*> ten, const double two,
+                    const double five) {
+    *ten = two * five;
+  }
+};
+
+template <typename Metavariables>
+struct Component {
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = int;
+
+  using initialization_action =
+      Initialization::Actions::InitializeItems<InitializeTwo, InitializeThree,
+                                               InitializeTen>;
+
+  using phase_dependent_action_list =
+      tmpl::list<Parallel::PhaseActions<Parallel::Phase::Initialization,
+                                        tmpl::list<initialization_action>>>;
+
+  static_assert(std::is_same_v<
+                tmpl::count_if<initialization_action::const_global_cache_tags,
+                               std::is_same<tmpl::_1, Duplicate>>,
+                tmpl::size_t<1>>);
+  static_assert(std::is_same_v<
+                tmpl::count_if<initialization_action::mutable_global_cache_tags,
+                               std::is_same<tmpl::_1, Duplicate>>,
+                tmpl::size_t<1>>);
+  static_assert(std::is_same_v<
+                tmpl::count_if<initialization_action::simple_tags_from_options,
+                               std::is_same<tmpl::_1, Two>>,
+                tmpl::size_t<1>>);
+  static_assert(
+      std::is_same_v<tmpl::count_if<initialization_action::simple_tags,
+                                    std::is_same<tmpl::_1, Duplicate>>,
+                     tmpl::size_t<1>>);
+  static_assert(
+      std::is_same_v<tmpl::count_if<initialization_action::compute_tags,
+                                    std::is_same<tmpl::_1, FiveCompute>>,
+                     tmpl::size_t<1>>);
+
+  using simple_tags_from_options = Parallel::get_simple_tags_from_options<
+      Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
+};
+
+struct Metavariables {
+  using component_list = tmpl::list<Component<Metavariables>>;
+};
+
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.ParallelAlgorithms.Actions.InitializeItems",
+
+                  "[Unit][ParallelAlgorithms]") {
+  using component = Component<Metavariables>;
+
+  tuples::TaggedTuple<TagOne, TagThree, Duplicate> const_cache_items{7, -4.,
+                                                                     8.};
+  tuples::TaggedTuple<TagTwo, Duplicate> mutable_cache_items{"bla", 9.};
+
+  ActionTesting::MockRuntimeSystem<Metavariables> runner{const_cache_items,
+                                                         mutable_cache_items};
+  ActionTesting::emplace_array_component<component>(make_not_null(&runner), {0},
+                                                    {0}, 0, 2.);
+
+  ActionTesting::set_phase(make_not_null(&runner),
+                           Parallel::Phase::Initialization);
+  for (size_t i = 0; i < 1; ++i) {
+    runner.template next_action<component>(0);
+  }
+
+  CHECK(ActionTesting::tag_is_retrievable<component, TagOne>(runner, 0));
+  CHECK(ActionTesting::tag_is_retrievable<component, TagThree>(runner, 0));
+  CHECK(ActionTesting::get_databox_tag<component, Two>(runner, 0) == 2.);
+  CHECK(ActionTesting::get_databox_tag<component, Three>(runner, 0) == 3.);
+  CHECK(ActionTesting::get_databox_tag<component, Ten>(runner, 0) == 10.);
+  CHECK(ActionTesting::get_databox_tag<component, Five>(runner, 0) == 5.);
+}


### PR DESCRIPTION
This allows multiple initialization actions to be converted into a mutators that are called by a single action.  This reduces charm++ overhead and makes testing easier as initialization mutators do not need to use the action testing framework.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
