### PR TITLE
Add post interp callback to dump metric data in Bondi-Sachs form

### DIFF
--- a/src/Evolution/Systems/Cce/CMakeLists.txt
+++ b/src/Evolution/Systems/Cce/CMakeLists.txt
@@ -66,6 +66,7 @@ target_link_libraries(
   LinearOperators
   Observer
   Options
+  ParallelInterpolation
   Spectral
   Utilities
   INTERFACE

--- a/src/Evolution/Systems/Cce/Callbacks/CMakeLists.txt
+++ b/src/Evolution/Systems/Cce/Callbacks/CMakeLists.txt
@@ -5,5 +5,6 @@ spectre_target_headers(
   ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
+  DumpBondiSachsOnWorldtube.hpp
   SendGhWorldtubeData.hpp
   )

--- a/src/Evolution/Systems/Cce/Callbacks/DumpBondiSachsOnWorldtube.hpp
+++ b/src/Evolution/Systems/Cce/Callbacks/DumpBondiSachsOnWorldtube.hpp
@@ -1,0 +1,294 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cmath>
+#include <cstddef>
+#include <iomanip>
+#include <iterator>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/TagName.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "DataStructures/Variables.hpp"
+#include "DataStructures/VariablesTag.hpp"
+#include "Evolution/Systems/Cce/BoundaryData.hpp"
+#include "Evolution/Systems/Cce/OptionTags.hpp"
+#include "Evolution/Systems/Cce/Tags.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
+#include "IO/Observer/ReductionActions.hpp"
+#include "NumericalAlgorithms/Spectral/SwshCoefficients.hpp"
+#include "NumericalAlgorithms/Spectral/SwshCollocation.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "Parallel/Invoke.hpp"
+#include "ParallelAlgorithms/Interpolation/InterpolationTargetDetail.hpp"
+#include "ParallelAlgorithms/Interpolation/Protocols/PostInterpolationCallback.hpp"
+#include "ParallelAlgorithms/Interpolation/Targets/AngularOrdering.hpp"
+#include "ParallelAlgorithms/Interpolation/Targets/Sphere.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeString.hpp"
+#include "Utilities/PrettyType.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace intrp {
+namespace callbacks {
+/*!
+ * \brief Post interpolation callback that dumps metric data in Bondi-Sachs form
+ * on a number of extraction radii given by the `intrp::TargetPoints::Sphere`
+ * target.
+ *
+ * To use this callback, the target must be the `intrp::TargetPoints::Sphere`
+ * target in the inertial frame. This callback also expects that the GH source
+ * vars on each of the target spheres are:
+ *
+ * - `gr::Tags::SpacetimeMetric`
+ * - `GeneralizedHarmonic::Tags::Pi`
+ * - `GeneralizedHarmonic::Tags::Phi`
+ *
+ * This callback will write a new `H5` file for each extraction radius in the
+ * Sphere target. The name of this file will be a file prefix specified by the
+ * Cce::Tags::FilePrefix prepended onto `CceRXXXX.h5` where the XXXX is the
+ * zero-padded extraction radius rounded to the nearest integer. The quantities
+ * that will be written are
+ *
+ * - `Cce::Tags::BondiBeta`
+ * - `Cce::Tags::Dr<Cce::Tags::BondiJ>`
+ * - `Cce::Tags::Du<Cce::Tags::BondiR>`
+ * - `Cce::Tags::BondiH`
+ * - `Cce::Tags::BondiJ`
+ * - `Cce::Tags::BondiQ`
+ * - `Cce::Tags::BondiR`
+ * - `Cce::Tags::BondiU`
+ * - `Cce::Tags::BondiW`
+ *
+ * \note For all real quantities (Beta, DuR, R, W) we omit writing the
+ * negative m modes, and the imaginary part of the m = 0 mode.
+ */
+template <typename InterpolationTargetTag>
+struct DumpBondiSachsOnWorldtube
+    : tt::ConformsTo<intrp::protocols::PostInterpolationCallback> {
+  static constexpr double fill_invalid_points_with =
+      std::numeric_limits<double>::quiet_NaN();
+
+  using const_global_cache_tags = tmpl::list<Cce::Tags::FilePrefix>;
+
+  using cce_boundary_tags = Cce::Tags::characteristic_worldtube_boundary_tags<
+      Cce::Tags::BoundaryValue>;
+
+  using cce_tags_to_dump = db::wrap_tags_in<
+      Cce::Tags::BoundaryValue,
+      tmpl::list<Cce::Tags::BondiBeta, Cce::Tags::Dr<Cce::Tags::BondiJ>,
+                 Cce::Tags::Du<Cce::Tags::BondiR>, Cce::Tags::BondiH,
+                 Cce::Tags::BondiJ, Cce::Tags::BondiQ, Cce::Tags::BondiR,
+                 Cce::Tags::BondiU, Cce::Tags::BondiW>>;
+
+  using gh_source_vars_for_cce =
+      tmpl::list<gr::Tags::SpacetimeMetric<3, ::Frame::Inertial>,
+                 GeneralizedHarmonic::Tags::Pi<3, ::Frame::Inertial>,
+                 GeneralizedHarmonic::Tags::Phi<3, ::Frame::Inertial>>;
+
+  using gh_source_vars_from_interpolation =
+      typename InterpolationTargetTag::vars_to_interpolate_to_target;
+
+  static_assert(
+      std::is_same_v<tmpl::list_difference<cce_tags_to_dump, cce_boundary_tags>,
+                     tmpl::list<>>,
+      "Cce tags to dump are not in the boundary tags.");
+
+  static_assert(
+      tmpl::and_<
+          std::is_same<tmpl::list_difference<gh_source_vars_from_interpolation,
+                                             gh_source_vars_for_cce>,
+                       tmpl::list<>>,
+          std::is_same<tmpl::list_difference<gh_source_vars_for_cce,
+                                             gh_source_vars_from_interpolation>,
+                       tmpl::list<>>>::type::value,
+      "To use DumpBondiSachsOnWorldtube, the GH source variables must be the "
+      "spacetime metric, pi, and phi.");
+
+  static_assert(
+      std::is_same_v<typename InterpolationTargetTag::compute_target_points,
+                     intrp::TargetPoints::Sphere<InterpolationTargetTag,
+                                                 ::Frame::Inertial>>,
+      "To use the DumpBondiSachsOnWorltube post interpolation callback, you "
+      "must use the intrp::TargetPoints::Sphere target in the inertial "
+      "frame");
+
+  template <typename DbTags, typename Metavariables, typename TemporalId>
+  static void apply(const db::DataBox<DbTags>& box,
+                    Parallel::GlobalCache<Metavariables>& cache,
+                    const TemporalId& temporal_id) {
+    const auto& sphere =
+        Parallel::get<Tags::Sphere<InterpolationTargetTag>>(cache);
+    const auto& filename_prefix = Parallel::get<Cce::Tags::FilePrefix>(cache);
+
+    if (sphere.angular_ordering != intrp::AngularOrdering::Cce) {
+      ERROR(
+          "To use the DumpBondiSachsOnWorldtube post interpolation callback, "
+          "the angular ordering of the Spheres must be Cce, not "
+          << sphere.angular_ordering);
+    }
+
+    const auto& radii = sphere.radii;
+    const size_t l_max = sphere.l_max;
+    const size_t num_points_single_sphere =
+        Spectral::Swsh::number_of_swsh_collocation_points(l_max);
+
+    const auto& all_gh_vars =
+        db::get<::Tags::Variables<gh_source_vars_from_interpolation>>(box);
+
+    const auto& all_spacetime_metric =
+        get<gr::Tags::SpacetimeMetric<3, ::Frame::Inertial>>(all_gh_vars);
+    const auto& all_pi =
+        get<GeneralizedHarmonic::Tags::Pi<3, ::Frame::Inertial>>(all_gh_vars);
+    const auto& all_phi =
+        get<GeneralizedHarmonic::Tags::Phi<3, ::Frame::Inertial>>(all_gh_vars);
+
+    const tnsr::aa<DataVector, 3, ::Frame::Inertial> spacetime_metric;
+    const tnsr::aa<DataVector, 3, ::Frame::Inertial> pi;
+    const tnsr::iaa<DataVector, 3, ::Frame::Inertial> phi;
+
+    // Bondi data
+    Variables<cce_boundary_tags> bondi_boundary_data{num_points_single_sphere};
+    ComplexModalVector goldberg_mode_buffer{square(l_max + 1)};
+    const std::vector<std::string> all_legend = build_legend(l_max, false);
+    const std::vector<std::string> real_legend = build_legend(l_max, true);
+
+    size_t offset = 0;
+    for (const auto& radius : radii) {
+      // Set data references so we don't copy data unnecessarily
+      for (size_t a = 0; a < 4; a++) {
+        for (size_t b = 0; b < 4; b++) {
+          make_const_view(make_not_null(&spacetime_metric.get(a, b)),
+                          all_spacetime_metric.get(a, b), offset,
+                          num_points_single_sphere);
+          make_const_view(make_not_null(&pi.get(a, b)), all_pi.get(a, b),
+                          offset, num_points_single_sphere);
+          for (size_t i = 0; i < 3; i++) {
+            make_const_view(make_not_null(&phi.get(i, a, b)),
+                            all_phi.get(i, a, b), offset,
+                            num_points_single_sphere);
+          }
+        }
+      }
+
+      offset += num_points_single_sphere;
+
+      Cce::create_bondi_boundary_data(make_not_null(&bondi_boundary_data), phi,
+                                      pi, spacetime_metric, radius, l_max);
+
+      const std::string filename =
+          MakeString{} << filename_prefix << "CceR" << std::setfill('0')
+                       << std::setw(4) << std::lround(radius);
+
+      tmpl::for_each<cce_tags_to_dump>(
+          [&temporal_id, &l_max, &all_legend, &real_legend, &filename,
+           &bondi_boundary_data, &goldberg_mode_buffer, &cache](auto tag_v) {
+            using tag = tmpl::type_from<std::decay_t<decltype(tag_v)>>;
+            constexpr int spin = tag::tag::type::type::spin;
+            // Spin = 0 does not imply a quantity is real. However, all the tags
+            // we want to print out that have spin = 0 happen to be real, so we
+            // use this as an indicator.
+            constexpr bool is_real = spin == 0;
+
+            const auto& legend = is_real ? real_legend : all_legend;
+
+            // `tag` is a BoundaryValue. We want the actual tag name
+            const std::string subfile_name{
+                "/" + replace_name(db::tag_name<typename tag::tag>())};
+
+            const auto& bondi_data = get(get<tag>(bondi_boundary_data));
+
+            // Convert our modal data to goldberg modes
+            SpinWeighted<ComplexModalVector, spin> goldberg_modes;
+            goldberg_modes.set_data_ref(make_not_null(&goldberg_mode_buffer));
+            Spectral::Swsh::libsharp_to_goldberg_modes(
+                make_not_null(&goldberg_modes),
+                Spectral::Swsh::swsh_transform(l_max, 1, bondi_data), l_max);
+
+            std::vector<double> data_to_write_buffer;
+            data_to_write_buffer.reserve(number_of_components(l_max, is_real));
+            data_to_write_buffer.emplace_back(
+                intrp::InterpolationTarget_detail::get_temporal_id_value(
+                    temporal_id));
+
+            // We loop over ell and m rather than just the total number of modes
+            // because we don't print negative m or the imaginary part of m=0
+            // for real quantities.
+            for (size_t ell = 0; ell <= l_max; ell++) {
+              for (int m = is_real ? 0 : -static_cast<int>(ell);
+                   m <= static_cast<int>(ell); m++) {
+                const size_t goldberg_index =
+                    Spectral::Swsh::goldberg_mode_index(l_max, ell, m);
+                data_to_write_buffer.push_back(
+                    real(goldberg_modes.data()[goldberg_index]));
+                if (not is_real or m != 0) {
+                  data_to_write_buffer.push_back(
+                      imag(goldberg_modes.data()[goldberg_index]));
+                }
+              }
+            }
+
+            ASSERT(legend.size() == data_to_write_buffer.size(),
+                   "Legend (" << legend.size()
+                              << ") does not have the same number of "
+                                 "components as data to write ("
+                              << data_to_write_buffer.size() << ") for tag "
+                              << db::tag_name<typename tag::tag>());
+
+            observers::ThreadedActions::ReductionActions_detail::write_data(
+                subfile_name, observers::input_source_from_cache(cache), legend,
+                std::make_tuple(data_to_write_buffer), filename,
+                std::index_sequence<0>{});
+          });
+    }
+  }
+
+ private:
+  // There are exactly half the number of modes for spin = 0 quantities as their
+  // are for spin != 0
+  static size_t number_of_components(const size_t l_max, const bool is_real) {
+    return 1 + square(l_max + 1) * (is_real ? 1 : 2);
+  }
+
+  static std::vector<std::string> build_legend(const size_t l_max,
+                                               const bool is_real) {
+    std::vector<std::string> legend;
+    legend.reserve(number_of_components(l_max, is_real));
+    legend.emplace_back("Time");
+    for (int ell = 0; ell <= static_cast<int>(l_max); ++ell) {
+      for (int m = is_real ? 0 : -ell; m <= ell; ++m) {
+        legend.push_back(MakeString{} << "Re(" << ell << "," << m << ")");
+        // For real quantities, don't include the imaginary m=0
+        if (not is_real or m != 0) {
+          legend.push_back(MakeString{} << "Im(" << ell << "," << m << ")");
+        }
+      }
+    }
+    return legend;
+  }
+
+  // These match names that CCE executable expects
+  static std::string replace_name(const std::string& db_tag_name) {
+    if (db_tag_name == "BondiBeta") {
+      return "Beta";
+    } else if (db_tag_name == "Dr(J)") {
+      return "DrJ";
+    } else if (db_tag_name == "Du(R)") {
+      return "DuR";
+    } else {
+      return db_tag_name;
+    }
+  }
+};
+}  // namespace callbacks
+}  // namespace intrp

--- a/src/Evolution/Systems/Cce/OptionTags.hpp
+++ b/src/Evolution/Systems/Cce/OptionTags.hpp
@@ -53,6 +53,15 @@ struct CceEvolutionPrefix {
   using group = Evolution;
 };
 
+struct BondiSachsOutputFilePrefix {
+  using type = std::string;
+  static constexpr Options::String help{
+      "Filename prefix for dumping Bondi-Sachs data on worltube radii. Files "
+      "will have this prefix prepended to 'CceRXXXX.h5' where XXXX will be the "
+      "zero-padded extraction radius to the nearest integer."};
+  using group = Cce;
+};
+
 struct LMax {
   using type = size_t;
   static constexpr Options::String help{
@@ -104,10 +113,10 @@ struct StandaloneExtractionRadius {
   using type = Options::Auto<double>;
 
   static constexpr Options::String help{
-    "Extraction radius of the CCE system for a standalone run. This may be "
-    "set to \"Auto\" to infer the radius from the filename (often used for "
-    "SpEC worldtube data). This option is unused if `H5IsBondiData` is "
-    "`true`, and should be \"Auto\" for such runs."};
+      "Extraction radius of the CCE system for a standalone run. This may be "
+      "set to \"Auto\" to infer the radius from the filename (often used for "
+      "SpEC worldtube data). This option is unused if `H5IsBondiData` is "
+      "`true`, and should be \"Auto\" for such runs."};
   using group = Cce;
 };
 
@@ -244,6 +253,13 @@ struct ScriOutputDensity : db::SimpleTag {
 }  // namespace InitializationTags
 
 namespace Tags {
+struct FilePrefix : db::SimpleTag {
+  using type = std::string;
+  using option_tags = tmpl::list<OptionTags::BondiSachsOutputFilePrefix>;
+  static constexpr bool pass_metavariables = false;
+  static type create_from_options(const type& option) { return option; }
+};
+
 /// Tag for duplicating functionality of another tag, but allows creation from
 /// options in the Cce::Evolution option group.
 template <typename Tag>
@@ -543,8 +559,7 @@ struct AnalyticBoundaryDataManager : db::SimpleTag {
 /// inertial-time news is difficult to compute.
 struct OutputNoninertialNews : db::SimpleTag {
   using type = bool;
-  using option_tags =
-      tmpl::list<OptionTags::AnalyticSolution>;
+  using option_tags = tmpl::list<OptionTags::AnalyticSolution>;
   static constexpr bool pass_metavariables = false;
   static bool create_from_options(
       const std::unique_ptr<Cce::Solutions::WorldtubeData>& worldtube_data) {

--- a/src/ParallelAlgorithms/Interpolation/Actions/TryToInterpolate.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Actions/TryToInterpolate.hpp
@@ -120,13 +120,24 @@ void interpolate_data(
             const auto& element_coord_holder = element_coord_pair.second;
             intrp::Irregular<Metavariables::volume_dim> interpolator(
                 volume_info.mesh, element_coord_holder.element_logical_coords);
-            if constexpr (InterpolationTarget_detail::
-                              has_compute_vars_to_interpolate_v<
-                                  InterpolationTargetTag>) {
+            // This first branch is used if compute_vars_to_interpolate exists
+            // or if the vars_to_interpolate_to_target is a subset of the
+            // interpolator_source_vars.
+            if constexpr (
+                InterpolationTarget_detail::has_compute_vars_to_interpolate_v<
+                    InterpolationTargetTag> or
+                not std::is_same_v<
+                    tmpl::list_difference<
+                        typename Metavariables::interpolator_source_vars,
+                        typename InterpolationTargetTag::
+                            vars_to_interpolate_to_target>,
+                    tmpl::list<>>) {
               interp_info.vars.emplace_back(
                   interpolator.interpolate(vars_to_interpolate));
             } else {
-              // If compute_vars_to_interpolate does not exist, then
+              // If compute_vars_to_interpolate does not exist and
+              // vars_to_interpolate_to_target isn't a subset of
+              // interpolator_source_vars, then
               // volume_info.source_vars_from_element is the same as
               // volume_info.vars_to_interpolate.
               interp_info.vars.emplace_back(interpolator.interpolate(

--- a/tests/Unit/Evolution/Systems/Cce/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/Cce/CMakeLists.txt
@@ -12,6 +12,7 @@ set(LIBRARY_SOURCES
   Test_AnalyticBoundaryDataManager.cpp
   Test_BoundaryData.cpp
   Test_BoundaryDataTags.cpp
+  Test_DumpBondiSachsOnWorldtube.cpp
   Test_Equations.cpp
   Test_GaugeTransformBoundaryData.cpp
   Test_InitializeCce.cpp

--- a/tests/Unit/Evolution/Systems/Cce/Test_DumpBondiSachsOnWorldtube.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_DumpBondiSachsOnWorldtube.cpp
@@ -1,0 +1,249 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cmath>
+#include <cstddef>
+#include <iomanip>
+#include <limits>
+#include <vector>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Matrix.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Evolution/Systems/Cce/BoundaryData.hpp"
+#include "Evolution/Systems/Cce/Callbacks/DumpBondiSachsOnWorldtube.hpp"
+#include "Evolution/Systems/Cce/Components/CharacteristicEvolution.hpp"
+#include "Evolution/Systems/Cce/OptionTags.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "IO/H5/AccessType.hpp"
+#include "IO/H5/Dat.hpp"
+#include "IO/H5/File.hpp"
+#include "NumericalAlgorithms/Spectral/SwshCoefficients.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "ParallelAlgorithms/Interpolation/Protocols/InterpolationTargetTag.hpp"
+#include "ParallelAlgorithms/Interpolation/Protocols/PostInterpolationCallback.hpp"
+#include "ParallelAlgorithms/Interpolation/Targets/Sphere.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Utilities/FileSystem.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+
+struct test_metavariables {
+  struct Target : tt::ConformsTo<intrp::protocols::InterpolationTargetTag> {
+    using temporal_id = ::Tags::Time;
+    using vars_to_interpolate_to_target =
+        tmpl::list<gr::Tags::SpacetimeMetric<3, ::Frame::Inertial>,
+                   GeneralizedHarmonic::Tags::Pi<3, ::Frame::Inertial>,
+                   GeneralizedHarmonic::Tags::Phi<3, ::Frame::Inertial>>;
+    using compute_target_points =
+        intrp::TargetPoints::Sphere<Target, ::Frame::Inertial>;
+    using post_interpolation_callback =
+        intrp::callbacks::DumpBondiSachsOnWorldtube<Target>;
+    using compute_items_on_target = tmpl::list<>;
+  };
+
+  using const_global_cache_tags =
+      tmpl::list<intrp::Tags::Sphere<Target>, Cce::Tags::FilePrefix>;
+  using component_list = tmpl::list<>;
+};
+
+std::string get_filename(const std::string& filename_prefix,
+                         const double radius) {
+  return MakeString{} << filename_prefix << "CceR" << std::setfill('0')
+                      << std::setw(4) << std::lround(radius) << ".h5";
+}
+
+std::string replace_name(const std::string& db_tag_name) {
+  if (db_tag_name == "BondiBeta") {
+    return "Beta";
+  } else if (db_tag_name == "Dr(J)") {
+    return "DrJ";
+  } else if (db_tag_name == "Du(R)") {
+    return "DuR";
+  } else {
+    return db_tag_name;
+  }
+}
+
+template <typename Tags>
+auto make_spacetime_variables(const size_t size) {
+  Variables<Tags> spacetime_variables{size, 0.0};
+  auto& spacetime_metric =
+      get<gr::Tags::SpacetimeMetric<3, ::Frame::Inertial>>(spacetime_variables);
+  get<0, 0>(spacetime_metric) = -1.0;
+  for (size_t i = 1; i < 4; i++) {
+    spacetime_metric.get(i, i) = 1.0;
+  }
+  return spacetime_variables;
+}
+
+void test(const std::string& filename_prefix,
+          const std::vector<double>& radii) {
+  using metavars = test_metavariables;
+  using target = typename metavars::Target;
+  using spacetime_tags = typename target::vars_to_interpolate_to_target;
+  using cce_tags =
+      typename target::post_interpolation_callback::cce_boundary_tags;
+  using written_cce_tags =
+      typename target::post_interpolation_callback::cce_tags_to_dump;
+
+  // Choose only l_max = 2 for two reasons:
+  //   1. Speed
+  //   2. So we can easily check the legend by hand
+  const size_t l_max = 2;
+  const size_t num_points_single_sphere =
+      Spectral::Swsh::number_of_swsh_collocation_points(l_max);
+  const std::vector<std::string> expected_all_legend{
+      "Time",     "Re(0,0)",  "Im(0,0)",  "Re(1,-1)", "Im(1,-1)",
+      "Re(1,0)",  "Im(1,0)",  "Re(1,1)",  "Im(1,1)",  "Re(2,-2)",
+      "Im(2,-2)", "Re(2,-1)", "Im(2,-1)", "Re(2,0)",  "Im(2,0)",
+      "Re(2,1)",  "Im(2,1)",  "Re(2,2)",  "Im(2,2)"};
+  const std::vector<std::string> expected_real_legend{
+      "Time",    "Re(0,0)", "Re(1,0)", "Re(1,1)", "Im(1,1)",
+      "Re(2,0)", "Re(2,1)", "Im(2,1)", "Re(2,2)", "Im(2,2)"};
+
+  // It doesn't really matter what the GH data is so long as we are able to
+  // calculate bondi data, because this is just testing that we can write the
+  // data. So choose Minkowski spacetime. This means pi, phi, and deriv phi are
+  // trivially 0.
+  Variables<spacetime_tags> spacetime_variables =
+      make_spacetime_variables<spacetime_tags>(radii.size() *
+                                               num_points_single_sphere);
+
+  // Options for Sphere
+  const intrp::AngularOrdering angular_ordering = intrp::AngularOrdering::Cce;
+  const std::array<double, 3> center = {{0.05, 0.06, 0.07}};
+  intrp::OptionHolders::Sphere sphere_opts(l_max, center, radii,
+                                           angular_ordering);
+
+  Parallel::MutableGlobalCache<metavars> mutable_cache{};
+  Parallel::GlobalCache<metavars> cache{
+      {std::move(sphere_opts), filename_prefix}, &mutable_cache};
+
+  // Only need variables in the box for this test
+  using db_tags = tmpl::list<::Tags::Variables<spacetime_tags>>;
+  const auto box = db::create<db_tags>(spacetime_variables);
+
+  // Check the error
+  CHECK_THROWS_WITH(
+      ([&box, &radii, &center, &filename_prefix, &mutable_cache]() {
+        const intrp::AngularOrdering local_angular_ordering =
+            intrp::AngularOrdering::Strahlkorper;
+        intrp::OptionHolders::Sphere local_sphere_opts(l_max, center, radii,
+                                                       local_angular_ordering);
+        Parallel::GlobalCache<metavars> local_cache{
+            {std::move(local_sphere_opts), filename_prefix}, &mutable_cache};
+
+        target::post_interpolation_callback::apply(box, local_cache, 0.1);
+      })(),
+      Catch::Contains(
+          "To use the DumpBondiSachsOnWorldtube post interpolation callback, "
+          "the angular ordering of the Spheres must be Cce"));
+
+  const std::vector<double> times{0.9, 1.3};
+
+  for (const double time : times) {
+    target::post_interpolation_callback::apply(box, cache, time);
+  }
+
+  Variables<spacetime_tags> single_spacetime_variables =
+      make_spacetime_variables<spacetime_tags>(num_points_single_sphere);
+  const auto& [spacetime_metric, pi, phi] = single_spacetime_variables;
+  Variables<cce_tags> bondi_boundary_data{num_points_single_sphere};
+
+  for (size_t i = 0; i < radii.size(); i++) {
+    const double radius = radii[i];
+    CAPTURE(radius);
+    // Have to create the bondi data for every radius individually
+    Cce::create_bondi_boundary_data(make_not_null(&bondi_boundary_data), phi,
+                                    pi, spacetime_metric, radius, l_max);
+    const auto file = h5::H5File<h5::AccessType::ReadOnly>(
+        get_filename(filename_prefix, radius));
+
+    tmpl::for_each<written_cce_tags>([&file, &bondi_boundary_data, &times,
+                                      &l_max, &expected_all_legend,
+                                      &expected_real_legend](auto tag_v) {
+      using tag = tmpl::type_from<std::decay_t<decltype(tag_v)>>;
+      const auto& bondi_data = get(get<tag>(bondi_boundary_data));
+      constexpr int spin = tag::tag::type::type::spin;
+      constexpr bool is_real = spin == 0;
+      const auto& expected_legend =
+          is_real ? expected_real_legend : expected_all_legend;
+
+      SpinWeighted<ComplexModalVector, spin> expected_data{square(l_max + 1)};
+      Spectral::Swsh::libsharp_to_goldberg_modes(
+          make_not_null(&expected_data),
+          Spectral::Swsh::swsh_transform(l_max, 1, bondi_data), l_max);
+
+      const std::string tag_path =
+          "/" + replace_name(db::tag_name<typename tag::tag>());
+      CAPTURE(tag_path);
+      const auto& dat_file = file.get<h5::Dat>(tag_path);
+      const Matrix written_data = dat_file.get_data();
+
+      CHECK(expected_legend == dat_file.get_legend());
+      CHECK(times.size() == written_data.rows());
+      const size_t expected_data_size = square(l_max + 1) * (is_real ? 1 : 2);
+      CHECK(expected_data_size == written_data.columns() - 1);
+
+      // Since the metric isn't changing it should be the same data on each
+      // row just with a different time
+      for (size_t j = 0; j < times.size(); j++) {
+        const double time = times[j];
+        CAPTURE(time);
+        CHECK(time == written_data(j, 0));
+        size_t counter = 1;
+        for (size_t ell = 0; ell <= l_max; ell++) {
+          for (size_t m = is_real ? 0 : -ell; m <= ell; m++) {
+            const size_t goldberg_index =
+                Spectral::Swsh::goldberg_mode_index(l_max, ell, m);
+            CHECK(written_data(j, counter) ==
+                  real(expected_data.data()[goldberg_index]));
+            counter++;
+            if (not is_real or m != 0) {
+              CHECK(written_data(j, counter) ==
+                    imag(expected_data.data()[goldberg_index]));
+              counter++;
+            }
+          }
+        }
+      }
+
+      file.close_current_object();
+    });
+  }
+}
+
+void delete_files(const std::string& filename_prefix,
+                  const std::vector<double>& radii_to_delete) {
+  for (const auto& radius : radii_to_delete) {
+    const std::string filename = get_filename(filename_prefix, radius);
+    if (file_system::check_if_file_exists(filename)) {
+      file_system::rm(filename, true);
+    }
+  }
+}
+
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.DumpBondiSachsOnWorldtube",
+                  "[Unit][Cce]") {
+  const std::string filename_prefix{"Shrek-the-Third"};
+  std::vector<double> radii{100.0};
+
+  delete_files(filename_prefix, radii);
+  test(filename_prefix, radii);
+
+  radii.push_back(150.0);
+  radii.push_back(200.0 - std::numeric_limits<double>::epsilon());
+
+  delete_files(filename_prefix, radii);
+  test(filename_prefix, radii);
+  delete_files(filename_prefix, radii);
+}
+}  // namespace

--- a/tests/Unit/Evolution/Systems/Cce/Test_OptionTags.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_OptionTags.cpp
@@ -48,6 +48,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.OptionTags", "[Unit][Cce]") {
       "ScriOutputDensity");
   TestHelpers::db::test_simple_tag<Cce::Tags::H5WorldtubeBoundaryDataManager>(
       "H5WorldtubeBoundaryDataManager");
+  TestHelpers::db::test_simple_tag<Cce::Tags::FilePrefix>("FilePrefix");
   TestHelpers::db::test_simple_tag<Cce::Tags::LMax>("LMax");
   TestHelpers::db::test_simple_tag<Cce::Tags::NumberOfRadialPoints>(
       "NumberOfRadialPoints");
@@ -82,6 +83,9 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.OptionTags", "[Unit][Cce]") {
       Cce::Tags::CceEvolutionPrefix<::Tags::TimeStepper<TimeStepper>>>(
       "TimeStepper");
 
+  CHECK(
+      TestHelpers::test_option_tag<Cce::OptionTags::BondiSachsOutputFilePrefix>(
+          "Shrek") == "Shrek");
   CHECK(TestHelpers::test_option_tag<Cce::OptionTags::LMax>("8") == 8_st);
   CHECK(TestHelpers::test_option_tag<Cce::OptionTags::FilterLMax>("7") == 7_st);
   CHECK(TestHelpers::test_option_tag<Cce::OptionTags::RadialFilterAlpha>(
@@ -176,6 +180,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.OptionTags", "[Unit][Cce]") {
             false, true, std::nullopt)
             ->get_l_max() == 8);
 
+  CHECK(Cce::Tags::FilePrefix::create_from_options("Shrek 2") == "Shrek 2");
   CHECK(Cce::Tags::LMax::create_from_options(8u) == 8u);
   CHECK(Cce::Tags::NumberOfRadialPoints::create_from_options(6u) == 6u);
 


### PR DESCRIPTION
## Proposed changes

This adds a new PostInterpolationCallback that will take metric data on concentric extraction spheres, convert it to the Bondi-Sachs form, and dump it to a separate file for each extraction radius. The format of the output data and the filenames are chosen so that it can be read in with the CCE executable.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments
~Depends on and includes #4460.~

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
