### PR TITLE
Cleanup gh execs and pass LTS bool in as template parameter

### DIFF
--- a/src/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivative.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivative.hpp
@@ -297,7 +297,8 @@ namespace evolution::dg::Actions {
  * - Modifies:
  *   - `evolution::dg::Tags::MortarData<Dim>`
  */
-template <size_t Dim, typename EvolutionSystem, typename DgStepChoosers>
+template <size_t Dim, typename EvolutionSystem, typename DgStepChoosers,
+          bool LocalTimeStepping>
 struct ComputeTimeDerivative {
   using inbox_tags = tmpl::list<
       evolution::dg::Tags::BoundaryCorrectionAndGhostCellsInbox<Dim>>;
@@ -324,17 +325,18 @@ struct ComputeTimeDerivative {
       gsl::not_null<db::DataBox<DbTagsList>*> box);
 };
 
-template <size_t Dim, typename EvolutionSystem, typename DgStepChoosers>
+template <size_t Dim, typename EvolutionSystem, typename DgStepChoosers,
+          bool LocalTimeStepping>
 template <typename DbTagsList, typename... InboxTags, typename ArrayIndex,
           typename ActionList, typename ParallelComponent,
           typename Metavariables>
 Parallel::iterable_action_return_t
-ComputeTimeDerivative<Dim, EvolutionSystem, DgStepChoosers>::apply(
-    db::DataBox<DbTagsList>& box,
-    tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
-    Parallel::GlobalCache<Metavariables>& cache,
-    const ArrayIndex& /*array_index*/, ActionList /*meta*/,
-    const ParallelComponent* const /*meta*/) {  // NOLINT const
+ComputeTimeDerivative<Dim, EvolutionSystem, DgStepChoosers, LocalTimeStepping>::
+    apply(db::DataBox<DbTagsList>& box,
+          tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+          Parallel::GlobalCache<Metavariables>& cache,
+          const ArrayIndex& /*array_index*/, ActionList /*meta*/,
+          const ParallelComponent* const /*meta*/) {  // NOLINT const
   using variables_tag = typename EvolutionSystem::variables_tag;
   using dt_variables_tag = db::add_tag_prefix<::Tags::dt, variables_tag>;
   using partial_derivative_tags = typename EvolutionSystem::gradient_variables;
@@ -488,7 +490,7 @@ ComputeTimeDerivative<Dim, EvolutionSystem, DgStepChoosers>::apply(
         }
       });
 
-  if constexpr (Metavariables::local_time_stepping) {
+  if constexpr (LocalTimeStepping) {
     take_step<DgStepChoosers>(make_not_null(&box));
   }
 
@@ -497,10 +499,12 @@ ComputeTimeDerivative<Dim, EvolutionSystem, DgStepChoosers>::apply(
   return {Parallel::AlgorithmExecution::Continue, std::nullopt};
 }
 
-template <size_t Dim, typename EvolutionSystem, typename DgStepChoosers>
+template <size_t Dim, typename EvolutionSystem, typename DgStepChoosers,
+          bool LocalTimeStepping>
 template <typename ParallelComponent, typename DbTagsList,
           typename Metavariables>
-void ComputeTimeDerivative<Dim, EvolutionSystem, DgStepChoosers>::
+void ComputeTimeDerivative<Dim, EvolutionSystem, DgStepChoosers,
+                           LocalTimeStepping>::
     send_data_for_fluxes(
         const gsl::not_null<Parallel::GlobalCache<Metavariables>*> cache,
         const gsl::not_null<db::DataBox<DbTagsList>*> box) {
@@ -565,7 +569,7 @@ void ComputeTimeDerivative<Dim, EvolutionSystem, DgStepChoosers>::
       }
 
       const TimeStepId& next_time_step_id = [&box]() {
-        if (Metavariables::local_time_stepping) {
+        if (LocalTimeStepping) {
           return db::get<::Tags::Next<::Tags::TimeStepId>>(*box);
         } else {
           return db::get<::Tags::TimeStepId>(*box);
@@ -602,7 +606,7 @@ void ComputeTimeDerivative<Dim, EvolutionSystem, DgStepChoosers>::
     }
   }
 
-  if constexpr (Metavariables::local_time_stepping) {
+  if constexpr (LocalTimeStepping) {
     using variables_tag = typename EvolutionSystem::variables_tag;
     using dt_variables_tag = db::add_tag_prefix<::Tags::dt, variables_tag>;
     // We assume isotropic quadrature, i.e. the quadrature is the same in

--- a/src/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivative.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivative.hpp
@@ -491,7 +491,8 @@ ComputeTimeDerivative<Dim, EvolutionSystem, DgStepChoosers, LocalTimeStepping>::
       });
 
   if constexpr (LocalTimeStepping) {
-    take_step<DgStepChoosers>(make_not_null(&box));
+    take_step<EvolutionSystem, LocalTimeStepping, DgStepChoosers>(
+        make_not_null(&box));
   }
 
   send_data_for_fluxes<ParallelComponent>(make_not_null(&cache),

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/LimiterActions.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/LimiterActions.hpp
@@ -72,10 +72,6 @@ template <typename Metavariables>
 struct Limit {
   using const_global_cache_tags = tmpl::list<typename Metavariables::limiter>;
 
-  static_assert(
-      not Metavariables::local_time_stepping,
-      "Limiter communication actions do not yet support local time stepping");
-
  public:
   using limiter_comm_tag =
       Limiters::Tags::LimiterCommunicationTag<Metavariables>;
@@ -88,6 +84,10 @@ struct Limit {
       const Parallel::GlobalCache<Metavariables>& cache,
       const ArrayIndex& /*array_index*/, const ActionList /*meta*/,
       const ParallelComponent* const /*meta*/) {
+    static_assert(
+        not Metavariables::local_time_stepping,
+        "Limiter communication actions do not yet support local time stepping");
+
     constexpr size_t volume_dim = Metavariables::system::volume_dim;
 
     const auto& local_temporal_id =
@@ -144,10 +144,6 @@ struct SendData {
   using const_global_cache_tags = tmpl::list<typename Metavariables::limiter>;
   using limiter_comm_tag =
       Limiters::Tags::LimiterCommunicationTag<Metavariables>;
-
-  static_assert(
-      not Metavariables::local_time_stepping,
-      "Limiter communication actions do not yet support local time stepping");
 
   template <typename DbTags, typename... InboxTags, typename ArrayIndex,
             typename ActionList, typename ParallelComponent>

--- a/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
+++ b/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
@@ -230,12 +230,12 @@ struct EvolutionMetavars {
           local_time_stepping,
           tmpl::list<evolution::Actions::RunEventsAndDenseTriggers<
                          tmpl::list<evolution::dg::ApplyBoundaryCorrections<
-                             EvolutionMetavars, true>>>,
+                             local_time_stepping, system, volume_dim, true>>>,
                      evolution::dg::Actions::ApplyLtsBoundaryCorrections<
-                         EvolutionMetavars>>,
+                         system, volume_dim>>,
           tmpl::list<
               evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
-                  EvolutionMetavars>,
+                  system, volume_dim>,
               Actions::RecordTimeStepperData<>,
               evolution::Actions::RunEventsAndDenseTriggers<tmpl::list<>>,
               Actions::UpdateU<>>>,
@@ -248,7 +248,7 @@ struct EvolutionMetavars {
       evolution::dg::Actions::ComputeTimeDerivative<volume_dim, system,
                                                     AllStepChoosers>,
       evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
-          EvolutionMetavars>,
+          system, volume_dim>,
       tmpl::conditional_t<
           local_time_stepping, tmpl::list<>,
           tmpl::list<

--- a/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
+++ b/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
@@ -224,8 +224,8 @@ struct EvolutionMetavars {
           tmpl::at<typename factory_creation::factory_classes, Event>>>>;
 
   using dg_step_actions = tmpl::flatten<tmpl::list<
-      evolution::dg::Actions::ComputeTimeDerivative<volume_dim, system,
-                                                    AllStepChoosers>,
+      evolution::dg::Actions::ComputeTimeDerivative<
+          volume_dim, system, AllStepChoosers, local_time_stepping>,
       tmpl::conditional_t<
           local_time_stepping,
           tmpl::list<evolution::Actions::RunEventsAndDenseTriggers<
@@ -245,8 +245,8 @@ struct EvolutionMetavars {
   using dg_subcell_step_actions = tmpl::flatten<tmpl::list<
       evolution::dg::subcell::Actions::SelectNumericalMethod,
       Actions::Label<evolution::dg::subcell::Actions::Labels::BeginDg>,
-      evolution::dg::Actions::ComputeTimeDerivative<volume_dim, system,
-                                                    AllStepChoosers>,
+      evolution::dg::Actions::ComputeTimeDerivative<
+          volume_dim, system, AllStepChoosers, local_time_stepping>,
       evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
           system, volume_dim>,
       tmpl::conditional_t<

--- a/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
+++ b/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
@@ -260,7 +260,7 @@ struct EvolutionMetavars {
       Actions::Goto<evolution::dg::subcell::Actions::Labels::EndOfSolvers>,
       Actions::Label<evolution::dg::subcell::Actions::Labels::BeginSubcell>,
       evolution::dg::subcell::Actions::SendDataForReconstruction<
-          volume_dim, Burgers::subcell::GhostVariables>,
+          volume_dim, Burgers::subcell::GhostVariables, local_time_stepping>,
       evolution::dg::subcell::Actions::ReceiveDataForReconstruction<volume_dim>,
       Actions::Label<
           evolution::dg::subcell::Actions::Labels::BeginSubcellAfterDgRollback>,

--- a/src/Evolution/Executables/CurvedScalarWave/EvolveCurvedScalarWave.hpp
+++ b/src/Evolution/Executables/CurvedScalarWave/EvolveCurvedScalarWave.hpp
@@ -254,12 +254,12 @@ struct EvolutionMetavars {
           local_time_stepping,
           tmpl::list<evolution::Actions::RunEventsAndDenseTriggers<
                          tmpl::list<evolution::dg::ApplyBoundaryCorrections<
-                             EvolutionMetavars, true>>>,
+                             local_time_stepping, system, volume_dim, true>>>,
                      evolution::dg::Actions::ApplyLtsBoundaryCorrections<
-                         EvolutionMetavars>>,
+                         system, volume_dim>>,
           tmpl::list<
               evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
-                  EvolutionMetavars>,
+                  system, volume_dim>,
               Actions::RecordTimeStepperData<>,
               evolution::Actions::RunEventsAndDenseTriggers<tmpl::list<>>,
               Actions::UpdateU<>>>,

--- a/src/Evolution/Executables/CurvedScalarWave/EvolveCurvedScalarWave.hpp
+++ b/src/Evolution/Executables/CurvedScalarWave/EvolveCurvedScalarWave.hpp
@@ -248,8 +248,8 @@ struct EvolutionMetavars {
       tmpl::conditional_t<domain::enable_time_dependent_maps,
                           CurvedScalarWave::Actions::CalculateGrVars<system>,
                           tmpl::list<>>,
-      evolution::dg::Actions::ComputeTimeDerivative<volume_dim, system,
-                                                    AllStepChoosers>,
+      evolution::dg::Actions::ComputeTimeDerivative<
+          volume_dim, system, AllStepChoosers, local_time_stepping>,
       tmpl::conditional_t<
           local_time_stepping,
           tmpl::list<evolution::Actions::RunEventsAndDenseTriggers<

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonicSingleBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonicSingleBlackHole.hpp
@@ -56,7 +56,6 @@ struct EvolutionMetavars
     : public GeneralizedHarmonicTemplateBase<
           EvolutionMetavars<VolumeDim, UseNumericalInitialData>> {
   using gh_base = GeneralizedHarmonicTemplateBase<EvolutionMetavars>;
-  using typename gh_base::frame;
   using typename gh_base::initialize_initial_data_dependent_quantities_actions;
   using typename gh_base::system;
   static constexpr size_t volume_dim = VolumeDim;
@@ -111,8 +110,6 @@ struct EvolutionMetavars
 
   using typename gh_base::step_actions;
 
-  // the dg element array needs to be re-declared to capture the new type
-  // aliases for the action lists.
   using gh_dg_element_array = DgElementArray<
       EvolutionMetavars,
       tmpl::flatten<tmpl::list<

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
@@ -437,12 +437,12 @@ struct EvolutionMetavars {
           tmpl::list<evolution::Actions::RunEventsAndDenseTriggers<tmpl::list<
                          ::domain::CheckFunctionsOfTimeAreReadyPostprocessor,
                          evolution::dg::ApplyBoundaryCorrections<
-                             EvolutionMetavars, true>>>,
+                             local_time_stepping, system, volume_dim, true>>>,
                      evolution::dg::Actions::ApplyLtsBoundaryCorrections<
-                         EvolutionMetavars>>,
+                         system, volume_dim>>,
           tmpl::list<
               evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
-                  EvolutionMetavars>,
+                  system, volume_dim>,
               Actions::RecordTimeStepperData<>,
               evolution::Actions::RunEventsAndDenseTriggers<tmpl::list<
                   ::domain::CheckFunctionsOfTimeAreReadyPostprocessor>>,

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
@@ -430,8 +430,8 @@ struct EvolutionMetavars {
        Parallel::Phase::Evolve, Parallel::Phase::Exit}};
 
   using step_actions = tmpl::list<
-      evolution::dg::Actions::ComputeTimeDerivative<volume_dim, system,
-                                                    AllStepChoosers>,
+      evolution::dg::Actions::ComputeTimeDerivative<
+          volume_dim, system, AllStepChoosers, local_time_stepping>,
       tmpl::conditional_t<
           local_time_stepping,
           tmpl::list<evolution::Actions::RunEventsAndDenseTriggers<tmpl::list<

--- a/src/Evolution/Executables/GeneralizedHarmonic/GeneralizedHarmonicBase.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/GeneralizedHarmonicBase.hpp
@@ -372,8 +372,8 @@ struct GeneralizedHarmonicTemplateBase<
       detail::make_default_phase_order<UseNumericalInitialData>();
 
   using step_actions = tmpl::list<
-      evolution::dg::Actions::ComputeTimeDerivative<volume_dim, system,
-                                                    AllStepChoosers>,
+      evolution::dg::Actions::ComputeTimeDerivative<
+          volume_dim, system, AllStepChoosers, local_time_stepping>,
       tmpl::conditional_t<
           local_time_stepping,
           tmpl::list<evolution::Actions::RunEventsAndDenseTriggers<

--- a/src/Evolution/Executables/GeneralizedHarmonic/GeneralizedHarmonicBase.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/GeneralizedHarmonicBase.hpp
@@ -169,31 +169,13 @@ constexpr auto make_default_phase_order() {
                       Parallel::Phase::Exit};
   }
 }
-}  // namespace detail
 
-template <template <size_t, bool> class EvolutionMetavarsDerived,
-          size_t VolumeDim, bool UseNumericalInitialData>
-struct GeneralizedHarmonicTemplateBase<
-    EvolutionMetavarsDerived<VolumeDim, UseNumericalInitialData>> {
-  using derived_metavars =
-      EvolutionMetavarsDerived<VolumeDim, UseNumericalInitialData>;
-  static constexpr size_t volume_dim = VolumeDim;
-  using frame = Frame::Inertial;
+template <size_t volume_dim>
+struct ObserverTags {
   using system = GeneralizedHarmonic::System<volume_dim>;
-  static constexpr dg::Formulation dg_formulation =
-      dg::Formulation::StrongInertial;
-  using temporal_id = Tags::TimeStepId;
-  static constexpr bool local_time_stepping = false;
 
-  using analytic_solution_fields = typename system::variables_tag::tags_list;
-
-  using initialize_initial_data_dependent_quantities_actions =
-      tmpl::list<Actions::MutateApply<
-                     GeneralizedHarmonic::gauges::SetPiFromGauge<volume_dim>>,
-                 Parallel::Actions::TerminatePhase>;
-
-  // NOLINTNEXTLINE(google-runtime-references)
-  void pup(PUP::er& /*p*/) {}
+  using variables_tag = typename system::variables_tag;
+  using analytic_solution_fields = typename variables_tag::tags_list;
 
   using initial_data_list =
       GeneralizedHarmonic::Solutions::all_solutions<volume_dim>;
@@ -201,7 +183,7 @@ struct GeneralizedHarmonicTemplateBase<
   using analytic_compute = evolution::Tags::AnalyticSolutionsCompute<
       volume_dim, analytic_solution_fields, false, initial_data_list>;
   using deriv_compute = ::Tags::DerivCompute<
-      typename system::variables_tag,
+      variables_tag,
       domain::Tags::InverseJacobian<volume_dim, Frame::ElementLogical,
                                     Frame::Inertial>,
       typename system::gradient_variables>;
@@ -214,23 +196,27 @@ struct GeneralizedHarmonicTemplateBase<
           GeneralizedHarmonic::Tags::GaugeH<volume_dim, Frame::Inertial>,
           GeneralizedHarmonic::Tags::SpacetimeDerivGaugeH<volume_dim,
                                                           Frame::Inertial>,
-          gr::Tags::SpatialMetric<volume_dim, frame, DataVector>,
+          gr::Tags::SpatialMetric<volume_dim, Frame::Inertial, DataVector>,
           gr::Tags::DetSpatialMetric<DataVector>,
-          gr::Tags::InverseSpatialMetric<volume_dim, frame, DataVector>,
-          gr::Tags::Shift<volume_dim, frame, DataVector>,
+          gr::Tags::InverseSpatialMetric<volume_dim, Frame::Inertial,
+                                         DataVector>,
+          gr::Tags::Shift<volume_dim, Frame::Inertial, DataVector>,
           gr::Tags::Lapse<DataVector>,
-          gr::Tags::SqrtDetSpatialMetricCompute<volume_dim, frame, DataVector>,
-          gr::Tags::SpacetimeNormalOneFormCompute<volume_dim, frame,
+          gr::Tags::SqrtDetSpatialMetricCompute<volume_dim, Frame::Inertial,
+                                                DataVector>,
+          gr::Tags::SpacetimeNormalOneFormCompute<volume_dim, Frame::Inertial,
                                                   DataVector>,
-          gr::Tags::SpacetimeNormalVectorCompute<volume_dim, frame, DataVector>,
-          gr::Tags::InverseSpacetimeMetricCompute<volume_dim, frame,
+          gr::Tags::SpacetimeNormalVectorCompute<volume_dim, Frame::Inertial,
+                                                 DataVector>,
+          gr::Tags::InverseSpacetimeMetricCompute<volume_dim, Frame::Inertial,
                                                   DataVector>,
 
-          GeneralizedHarmonic::Tags::GaugeConstraintCompute<volume_dim, frame>,
+          GeneralizedHarmonic::Tags::GaugeConstraintCompute<volume_dim,
+                                                            Frame::Inertial>,
           GeneralizedHarmonic::Tags::TwoIndexConstraintCompute<volume_dim,
-                                                               frame>,
-          GeneralizedHarmonic::Tags::ThreeIndexConstraintCompute<volume_dim,
-                                                                 frame>,
+                                                               Frame::Inertial>,
+          GeneralizedHarmonic::Tags::ThreeIndexConstraintCompute<
+              volume_dim, Frame::Inertial>,
           GeneralizedHarmonic::Tags::DerivSpatialMetricCompute<
               volume_dim, ::Frame::Inertial>,
           gr::Tags::SpatialChristoffelFirstKindCompute<
@@ -248,12 +234,14 @@ struct GeneralizedHarmonicTemplateBase<
                                               DataVector>,
           // following tags added to observe constraints
           ::Tags::PointwiseL2NormCompute<
-              GeneralizedHarmonic::Tags::GaugeConstraint<volume_dim, frame>>,
+              GeneralizedHarmonic::Tags::GaugeConstraint<volume_dim,
+                                                         Frame::Inertial>>,
           ::Tags::PointwiseL2NormCompute<
-              GeneralizedHarmonic::Tags::TwoIndexConstraint<volume_dim, frame>>,
+              GeneralizedHarmonic::Tags::TwoIndexConstraint<volume_dim,
+                                                            Frame::Inertial>>,
           ::Tags::PointwiseL2NormCompute<
               GeneralizedHarmonic::Tags::ThreeIndexConstraint<volume_dim,
-                                                              frame>>,
+                                                              Frame::Inertial>>,
           ::domain::Tags::Coordinates<volume_dim, Frame::Grid>,
           ::domain::Tags::Coordinates<volume_dim, Frame::Inertial>>,
       error_tags,
@@ -262,17 +250,19 @@ struct GeneralizedHarmonicTemplateBase<
           volume_dim == 3,
           tmpl::list<
               GeneralizedHarmonic::Tags::
-                  FourIndexConstraintCompute<3, frame>,
-              GeneralizedHarmonic::Tags::
-                  FConstraintCompute<3, frame>,
+                  FourIndexConstraintCompute<3, Frame::Inertial>,
+              GeneralizedHarmonic::Tags::FConstraintCompute<3, Frame::Inertial>,
               ::Tags::PointwiseL2NormCompute<
-                  GeneralizedHarmonic::Tags::FConstraint<3, frame>>,
+                  GeneralizedHarmonic::Tags::FConstraint<3, Frame::Inertial>>,
               ::Tags::PointwiseL2NormCompute<
-                  GeneralizedHarmonic::Tags::FourIndexConstraint<3, frame>>,
-              GeneralizedHarmonic::Tags::ConstraintEnergyCompute<3, frame>,
-              GeneralizedHarmonic::Tags::ExtrinsicCurvatureCompute<3, frame>,
+                  GeneralizedHarmonic::Tags::FourIndexConstraint<
+                      3, Frame::Inertial>>,
+              GeneralizedHarmonic::Tags::ConstraintEnergyCompute<
+                  3, Frame::Inertial>,
+              GeneralizedHarmonic::Tags::ExtrinsicCurvatureCompute<
+                  3, Frame::Inertial>,
               ::Tags::DerivTensorCompute<
-                  gr::Tags::ExtrinsicCurvature<3, frame>,
+                  gr::Tags::ExtrinsicCurvature<3, Frame::Inertial>,
                   ::domain::Tags::InverseJacobian<
                       volume_dim, Frame::ElementLogical, Frame::Inertial>>,
               gr::Tags::WeylElectricCompute<3, Frame::Inertial, DataVector>,
@@ -291,47 +281,77 @@ struct GeneralizedHarmonicTemplateBase<
       analytic_compute, error_compute,
       GeneralizedHarmonic::gauges::Tags::GaugeAndDerivativeCompute<volume_dim>>;
 
-  struct factory_creation
-      : tt::ConformsTo<Options::protocols::FactoryCreation> {
-    using factory_classes = tmpl::map<
-        tmpl::pair<DenseTrigger, DenseTriggers::standard_dense_triggers>,
-        tmpl::pair<DomainCreator<volume_dim>, domain_creators<volume_dim>>,
-        tmpl::pair<Event, tmpl::flatten<tmpl::list<
-                              Events::Completion,
-                              dg::Events::field_observations<
-                                  volume_dim, Tags::Time, observe_fields,
-                                  non_tensor_compute_tags>,
-                              Events::time_events<system>>>>,
-        tmpl::pair<GeneralizedHarmonic::BoundaryConditions::BoundaryCondition<
-                       volume_dim>,
-                   GeneralizedHarmonic::BoundaryConditions::
-                       standard_boundary_conditions<volume_dim>>,
-        tmpl::pair<GeneralizedHarmonic::gauges::GaugeCondition,
-                   GeneralizedHarmonic::gauges::all_gauges>,
-        tmpl::pair<evolution::initial_data::InitialData, initial_data_list>,
-        tmpl::pair<LtsTimeStepper, TimeSteppers::lts_time_steppers>,
-        tmpl::pair<PhaseChange,
-                   tmpl::list<PhaseControl::VisitAndReturn<
-                                  Parallel::Phase::LoadBalancing>,
-                              PhaseControl::CheckpointAndExitAfterWallclock>>,
-        tmpl::pair<StepChooser<StepChooserUse::LtsStep>,
-                   StepChoosers::standard_step_choosers<system>>,
-        tmpl::pair<
-            StepChooser<StepChooserUse::Slab>,
-            StepChoosers::standard_slab_choosers<system, local_time_stepping>>,
-        tmpl::pair<StepController, StepControllers::standard_step_controllers>,
-        tmpl::pair<TimeSequence<double>,
-                   TimeSequences::all_time_sequences<double>>,
-        tmpl::pair<TimeSequence<std::uint64_t>,
-                   TimeSequences::all_time_sequences<std::uint64_t>>,
-        tmpl::pair<TimeStepper, TimeSteppers::time_steppers>,
-        tmpl::pair<Trigger, tmpl::append<Triggers::logical_triggers,
-                                         Triggers::time_triggers>>>;
-  };
+  using field_observations =
+      dg::Events::field_observations<volume_dim, Tags::Time, observe_fields,
+                                     non_tensor_compute_tags>;
+};
+
+template <size_t volume_dim, bool LocalTimeStepping>
+struct FactoryCreation : tt::ConformsTo<Options::protocols::FactoryCreation> {
+  using system = GeneralizedHarmonic::System<volume_dim>;
+
+  using factory_classes = tmpl::map<
+      tmpl::pair<DenseTrigger, DenseTriggers::standard_dense_triggers>,
+      tmpl::pair<DomainCreator<volume_dim>, domain_creators<volume_dim>>,
+      tmpl::pair<Event,
+                 tmpl::flatten<tmpl::list<Events::Completion,
+                                          typename detail::ObserverTags<
+                                              volume_dim>::field_observations,
+                                          Events::time_events<system>>>>,
+      tmpl::pair<GeneralizedHarmonic::BoundaryConditions::BoundaryCondition<
+                     volume_dim>,
+                 GeneralizedHarmonic::BoundaryConditions::
+                     standard_boundary_conditions<volume_dim>>,
+      tmpl::pair<GeneralizedHarmonic::gauges::GaugeCondition,
+                 GeneralizedHarmonic::gauges::all_gauges>,
+      tmpl::pair<evolution::initial_data::InitialData,
+                 GeneralizedHarmonic::Solutions::all_solutions<volume_dim>>,
+      tmpl::pair<LtsTimeStepper, TimeSteppers::lts_time_steppers>,
+      tmpl::pair<PhaseChange,
+                 tmpl::list<PhaseControl::VisitAndReturn<
+                                Parallel::Phase::LoadBalancing>,
+                            PhaseControl::CheckpointAndExitAfterWallclock>>,
+      tmpl::pair<StepChooser<StepChooserUse::LtsStep>,
+                 StepChoosers::standard_step_choosers<system>>,
+      tmpl::pair<
+          StepChooser<StepChooserUse::Slab>,
+          StepChoosers::standard_slab_choosers<system, LocalTimeStepping>>,
+      tmpl::pair<StepController, StepControllers::standard_step_controllers>,
+      tmpl::pair<TimeSequence<double>,
+                 TimeSequences::all_time_sequences<double>>,
+      tmpl::pair<TimeSequence<std::uint64_t>,
+                 TimeSequences::all_time_sequences<std::uint64_t>>,
+      tmpl::pair<TimeStepper, TimeSteppers::time_steppers>,
+      tmpl::pair<Trigger, tmpl::append<Triggers::logical_triggers,
+                                       Triggers::time_triggers>>>;
+};
+}  // namespace detail
+
+template <template <size_t, bool> class EvolutionMetavarsDerived,
+          size_t VolumeDim, bool UseNumericalInitialData>
+struct GeneralizedHarmonicTemplateBase<
+    EvolutionMetavarsDerived<VolumeDim, UseNumericalInitialData>> {
+
+  using derived_metavars =
+      EvolutionMetavarsDerived<VolumeDim, UseNumericalInitialData>;
+  static constexpr size_t volume_dim = VolumeDim;
+  using system = GeneralizedHarmonic::System<volume_dim>;
+  static constexpr bool local_time_stepping = false;
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& /*p*/) {}
+
+  using factory_creation =
+      detail::FactoryCreation<volume_dim, local_time_stepping>;
 
   using observed_reduction_data_tags =
       observers::collect_reduction_data_tags<tmpl::push_back<
           tmpl::at<typename factory_creation::factory_classes, Event>>>;
+
+  using initialize_initial_data_dependent_quantities_actions =
+      tmpl::list<Actions::MutateApply<
+                     GeneralizedHarmonic::gauges::SetPiFromGauge<volume_dim>>,
+                 Parallel::Actions::TerminatePhase>;
 
   // A tmpl::list of tags to be added to the GlobalCache by the
   // metavariables
@@ -397,56 +417,4 @@ struct GeneralizedHarmonicTemplateBase<
       ::evolution::dg::Initialization::Mortars<volume_dim, system>,
       evolution::Actions::InitializeRunEventsAndDenseTriggers,
       Parallel::Actions::TerminatePhase>;
-
-  using gh_dg_element_array = DgElementArray<
-      derived_metavars,
-      tmpl::flatten<tmpl::list<
-          Parallel::PhaseActions<Parallel::Phase::Initialization,
-                                 initialization_actions>,
-          tmpl::conditional_t<
-              UseNumericalInitialData,
-              tmpl::list<
-                  Parallel::PhaseActions<
-                      Parallel::Phase::RegisterWithElementDataReader,
-                      tmpl::list<
-                          importers::Actions::RegisterWithElementDataReader,
-                          Parallel::Actions::TerminatePhase>>,
-                  Parallel::PhaseActions<
-                      Parallel::Phase::ImportInitialData,
-                      tmpl::list<
-                          GeneralizedHarmonic::Actions::ReadNumericInitialData<
-                              evolution::OptionTags::NumericInitialData>,
-                          GeneralizedHarmonic::Actions::SetNumericInitialData<
-                              evolution::OptionTags::NumericInitialData>,
-                          Parallel::Actions::TerminatePhase>>>,
-              tmpl::list<>>,
-          Parallel::PhaseActions<
-              Parallel::Phase::InitializeInitialDataDependentQuantities,
-              initialize_initial_data_dependent_quantities_actions>,
-          Parallel::PhaseActions<
-              Parallel::Phase::InitializeTimeStepperHistory,
-              SelfStart::self_start_procedure<step_actions, system>>,
-          Parallel::PhaseActions<Parallel::Phase::Register,
-                                 tmpl::list<dg_registration_list,
-                                            Parallel::Actions::TerminatePhase>>,
-          Parallel::PhaseActions<
-              Parallel::Phase::Evolve,
-              tmpl::list<Actions::RunEventsAndTriggers, Actions::ChangeSlabSize,
-                         step_actions, Actions::AdvanceTime,
-                         PhaseControl::Actions::ExecutePhaseChange>>>>>;
-
-  template <typename ParallelComponent>
-  struct registration_list {
-    using type = std::conditional_t<
-        std::is_same_v<ParallelComponent, gh_dg_element_array>,
-        dg_registration_list, tmpl::list<>>;
-  };
-
-  using component_list = tmpl::flatten<tmpl::list<
-      observers::Observer<derived_metavars>,
-      observers::ObserverWriter<derived_metavars>,
-      std::conditional_t<UseNumericalInitialData,
-                         importers::ElementDataReader<derived_metavars>,
-                         tmpl::list<>>,
-      gh_dg_element_array>>;
 };

--- a/src/Evolution/Executables/GeneralizedHarmonic/GeneralizedHarmonicBase.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/GeneralizedHarmonicBase.hpp
@@ -378,12 +378,12 @@ struct GeneralizedHarmonicTemplateBase<
           local_time_stepping,
           tmpl::list<evolution::Actions::RunEventsAndDenseTriggers<
                          tmpl::list<evolution::dg::ApplyBoundaryCorrections<
-                             derived_metavars, true>>>,
+                             local_time_stepping, system, volume_dim, true>>>,
                      evolution::dg::Actions::ApplyLtsBoundaryCorrections<
-                         derived_metavars>>,
+                         system, volume_dim>>,
           tmpl::list<
               evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
-                  derived_metavars>,
+                  system, volume_dim>,
               Actions::RecordTimeStepperData<>,
               evolution::Actions::RunEventsAndDenseTriggers<tmpl::list<>>,
               Actions::UpdateU<>,

--- a/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
+++ b/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
@@ -387,10 +387,10 @@ struct GhValenciaDivCleanTemplateBase<
       tmpl::conditional_t<
           local_time_stepping,
           tmpl::list<evolution::dg::Actions::ApplyLtsBoundaryCorrections<
-              derived_metavars>>,
+              system, volume_dim>>,
           tmpl::list<
               evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
-                  derived_metavars>,
+                  system, volume_dim>,
               Actions::RecordTimeStepperData<>, Actions::UpdateU<>>>,
       Limiters::Actions::SendData<derived_metavars>,
       Limiters::Actions::Limit<derived_metavars>,

--- a/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
+++ b/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
@@ -382,8 +382,8 @@ struct GhValenciaDivCleanTemplateBase<
       detail::make_default_phase_order<initial_data>();
 
   using step_actions = tmpl::flatten<tmpl::list<
-      evolution::dg::Actions::ComputeTimeDerivative<volume_dim, system,
-                                                    AllStepChoosers>,
+      evolution::dg::Actions::ComputeTimeDerivative<
+          volume_dim, system, AllStepChoosers, local_time_stepping>,
       tmpl::conditional_t<
           local_time_stepping,
           tmpl::list<evolution::dg::Actions::ApplyLtsBoundaryCorrections<

--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
@@ -346,14 +346,14 @@ struct EvolutionMetavars {
           local_time_stepping,
           tmpl::list<evolution::Actions::RunEventsAndDenseTriggers<tmpl::list<
                          evolution::dg::ApplyBoundaryCorrections<
-                             EvolutionMetavars, true>,
+                             local_time_stepping, system, volume_dim, true>,
                          system::primitive_from_conservative<
                              ordered_list_of_primitive_recovery_schemes>>>,
                      evolution::dg::Actions::ApplyLtsBoundaryCorrections<
-                         EvolutionMetavars>>,
+                         system, volume_dim>>,
           tmpl::list<
               evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
-                  EvolutionMetavars>,
+                  system, volume_dim>,
               Actions::RecordTimeStepperData<>,
               evolution::Actions::RunEventsAndDenseTriggers<
                   tmpl::list<system::primitive_from_conservative<
@@ -374,7 +374,7 @@ struct EvolutionMetavars {
       evolution::dg::Actions::ComputeTimeDerivative<volume_dim, system,
                                                     AllStepChoosers>,
       evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
-          EvolutionMetavars>,
+          system, volume_dim>,
       tmpl::conditional_t<
           local_time_stepping, tmpl::list<>,
           tmpl::list<Actions::RecordTimeStepperData<>,

--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
@@ -340,8 +340,8 @@ struct EvolutionMetavars {
               ordered_list_of_primitive_recovery_schemes>>>;
 
   using dg_step_actions = tmpl::flatten<tmpl::list<
-      evolution::dg::Actions::ComputeTimeDerivative<volume_dim, system,
-                                                    AllStepChoosers>,
+      evolution::dg::Actions::ComputeTimeDerivative<
+          volume_dim, system, AllStepChoosers, local_time_stepping>,
       tmpl::conditional_t<
           local_time_stepping,
           tmpl::list<evolution::Actions::RunEventsAndDenseTriggers<tmpl::list<
@@ -371,8 +371,8 @@ struct EvolutionMetavars {
       evolution::dg::subcell::Actions::SelectNumericalMethod,
 
       Actions::Label<evolution::dg::subcell::Actions::Labels::BeginDg>,
-      evolution::dg::Actions::ComputeTimeDerivative<volume_dim, system,
-                                                    AllStepChoosers>,
+      evolution::dg::Actions::ComputeTimeDerivative<
+          volume_dim, system, AllStepChoosers, local_time_stepping>,
       evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
           system, volume_dim>,
       tmpl::conditional_t<

--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
@@ -392,8 +392,8 @@ struct EvolutionMetavars {
 
       Actions::Label<evolution::dg::subcell::Actions::Labels::BeginSubcell>,
       evolution::dg::subcell::Actions::SendDataForReconstruction<
-          volume_dim,
-          grmhd::ValenciaDivClean::subcell::PrimitiveGhostVariables>,
+          volume_dim, grmhd::ValenciaDivClean::subcell::PrimitiveGhostVariables,
+          local_time_stepping>,
       evolution::dg::subcell::Actions::ReceiveDataForReconstruction<volume_dim>,
       Actions::Label<
           evolution::dg::subcell::Actions::Labels::BeginSubcellAfterDgRollback>,

--- a/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
+++ b/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
@@ -275,8 +275,8 @@ struct EvolutionMetavars {
       Parallel::Actions::TerminatePhase>>;
 
   using dg_step_actions = tmpl::flatten<tmpl::list<
-      evolution::dg::Actions::ComputeTimeDerivative<volume_dim, system,
-                                                    AllStepChoosers>,
+      evolution::dg::Actions::ComputeTimeDerivative<
+          volume_dim, system, AllStepChoosers, local_time_stepping>,
       tmpl::conditional_t<
           local_time_stepping,
           tmpl::list<evolution::Actions::RunEventsAndDenseTriggers<tmpl::list<
@@ -324,8 +324,8 @@ struct EvolutionMetavars {
       evolution::dg::subcell::Actions::SelectNumericalMethod,
 
       Actions::Label<evolution::dg::subcell::Actions::Labels::BeginDg>,
-      evolution::dg::Actions::ComputeTimeDerivative<volume_dim, system,
-                                                    AllStepChoosers>,
+      evolution::dg::Actions::ComputeTimeDerivative<
+          volume_dim, system, AllStepChoosers, local_time_stepping>,
       evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
           system, volume_dim>,
       tmpl::conditional_t<

--- a/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
+++ b/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
@@ -281,13 +281,13 @@ struct EvolutionMetavars {
           local_time_stepping,
           tmpl::list<evolution::Actions::RunEventsAndDenseTriggers<tmpl::list<
                          evolution::dg::ApplyBoundaryCorrections<
-                             EvolutionMetavars, true>,
+                             local_time_stepping, system, volume_dim, true>,
                          typename system::primitive_from_conservative>>,
                      evolution::dg::Actions::ApplyLtsBoundaryCorrections<
-                         EvolutionMetavars>>,
+                         system, volume_dim>>,
           tmpl::list<
               evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
-                  EvolutionMetavars>,
+                  system, volume_dim>,
               Actions::RecordTimeStepperData<>,
               evolution::Actions::RunEventsAndDenseTriggers<
                   tmpl::list<typename system::primitive_from_conservative>>,
@@ -327,7 +327,7 @@ struct EvolutionMetavars {
       evolution::dg::Actions::ComputeTimeDerivative<volume_dim, system,
                                                     AllStepChoosers>,
       evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
-          EvolutionMetavars>,
+          system, volume_dim>,
       tmpl::conditional_t<
           local_time_stepping, tmpl::list<>,
           tmpl::list<Actions::RecordTimeStepperData<>, Actions::UpdateU<>>>,

--- a/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
+++ b/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
@@ -340,7 +340,8 @@ struct EvolutionMetavars {
       Actions::Label<evolution::dg::subcell::Actions::Labels::BeginSubcell>,
       evolution::dg::subcell::Actions::SendDataForReconstruction<
           volume_dim,
-          NewtonianEuler::subcell::PrimitiveGhostVariables<volume_dim>>,
+          NewtonianEuler::subcell::PrimitiveGhostVariables<volume_dim>,
+          local_time_stepping>,
       evolution::dg::subcell::Actions::ReceiveDataForReconstruction<volume_dim>,
       Actions::Label<
           evolution::dg::subcell::Actions::Labels::BeginSubcellAfterDgRollback>,

--- a/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveM1Grey.hpp
+++ b/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveM1Grey.hpp
@@ -187,8 +187,8 @@ struct EvolutionMetavars {
           tmpl::at<typename factory_creation::factory_classes, Event>>>>;
 
   using step_actions = tmpl::flatten<tmpl::list<
-      evolution::dg::Actions::ComputeTimeDerivative<volume_dim, system,
-                                                    AllStepChoosers>,
+      evolution::dg::Actions::ComputeTimeDerivative<
+          volume_dim, system, AllStepChoosers, local_time_stepping>,
       tmpl::conditional_t<
           local_time_stepping,
           tmpl::list<evolution::Actions::RunEventsAndDenseTriggers<

--- a/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveM1Grey.hpp
+++ b/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveM1Grey.hpp
@@ -193,12 +193,12 @@ struct EvolutionMetavars {
           local_time_stepping,
           tmpl::list<evolution::Actions::RunEventsAndDenseTriggers<
                          tmpl::list<evolution::dg::ApplyBoundaryCorrections<
-                             EvolutionMetavars, true>>>,
+                             local_time_stepping, system, volume_dim, true>>>,
                      evolution::dg::Actions::ApplyLtsBoundaryCorrections<
-                         EvolutionMetavars>>,
+                         system, volume_dim>>,
           tmpl::list<
               evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
-                  EvolutionMetavars>,
+                  system, volume_dim>,
               Actions::RecordTimeStepperData<>,
               evolution::Actions::RunEventsAndDenseTriggers<tmpl::list<>>,
               Actions::UpdateU<>>>,

--- a/src/Evolution/Executables/RelativisticEuler/Valencia/EvolveValencia.hpp
+++ b/src/Evolution/Executables/RelativisticEuler/Valencia/EvolveValencia.hpp
@@ -201,8 +201,8 @@ struct EvolutionMetavars {
           tmpl::at<typename factory_creation::factory_classes, Event>>>>;
 
   using step_actions = tmpl::flatten<tmpl::list<
-      evolution::dg::Actions::ComputeTimeDerivative<volume_dim, system,
-                                                    AllStepChoosers>,
+      evolution::dg::Actions::ComputeTimeDerivative<
+          volume_dim, system, AllStepChoosers, local_time_stepping>,
       tmpl::conditional_t<
           local_time_stepping,
           tmpl::list<evolution::Actions::RunEventsAndDenseTriggers<tmpl::list<

--- a/src/Evolution/Executables/RelativisticEuler/Valencia/EvolveValencia.hpp
+++ b/src/Evolution/Executables/RelativisticEuler/Valencia/EvolveValencia.hpp
@@ -207,14 +207,14 @@ struct EvolutionMetavars {
           local_time_stepping,
           tmpl::list<evolution::Actions::RunEventsAndDenseTriggers<tmpl::list<
                          evolution::dg::ApplyBoundaryCorrections<
-                             EvolutionMetavars, true>,
+                             local_time_stepping, system, volume_dim, true>,
                          AlwaysReadyPostprocessor<
                              typename system::primitive_from_conservative>>>,
                      evolution::dg::Actions::ApplyLtsBoundaryCorrections<
-                         EvolutionMetavars>>,
+                         system, volume_dim>>,
           tmpl::list<
               evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
-                  EvolutionMetavars>,
+                  system, volume_dim>,
               Actions::RecordTimeStepperData<>,
               evolution::Actions::RunEventsAndDenseTriggers<
                   tmpl::list<AlwaysReadyPostprocessor<

--- a/src/Evolution/Executables/ScalarAdvection/EvolveScalarAdvection.hpp
+++ b/src/Evolution/Executables/ScalarAdvection/EvolveScalarAdvection.hpp
@@ -230,8 +230,8 @@ struct EvolutionMetavars {
           tmpl::at<typename factory_creation::factory_classes, Event>>>>;
 
   using dg_step_actions = tmpl::flatten<tmpl::list<
-      evolution::dg::Actions::ComputeTimeDerivative<volume_dim, system,
-                                                    AllStepChoosers>,
+      evolution::dg::Actions::ComputeTimeDerivative<
+          volume_dim, system, AllStepChoosers, local_time_stepping>,
       evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
           system, volume_dim>,
       tmpl::conditional_t<
@@ -247,8 +247,8 @@ struct EvolutionMetavars {
       evolution::dg::subcell::Actions::SelectNumericalMethod,
       Actions::Label<evolution::dg::subcell::Actions::Labels::BeginDg>,
 
-      evolution::dg::Actions::ComputeTimeDerivative<volume_dim, system,
-                                                    AllStepChoosers>,
+      evolution::dg::Actions::ComputeTimeDerivative<
+          volume_dim, system, AllStepChoosers, local_time_stepping>,
       evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
           system, volume_dim>,
       tmpl::conditional_t<

--- a/src/Evolution/Executables/ScalarAdvection/EvolveScalarAdvection.hpp
+++ b/src/Evolution/Executables/ScalarAdvection/EvolveScalarAdvection.hpp
@@ -262,7 +262,8 @@ struct EvolutionMetavars {
       Actions::Goto<evolution::dg::subcell::Actions::Labels::EndOfSolvers>,
       Actions::Label<evolution::dg::subcell::Actions::Labels::BeginSubcell>,
       evolution::dg::subcell::Actions::SendDataForReconstruction<
-          volume_dim, ScalarAdvection::subcell::GhostVariables>,
+          volume_dim, ScalarAdvection::subcell::GhostVariables,
+          local_time_stepping>,
       evolution::dg::subcell::Actions::ReceiveDataForReconstruction<volume_dim>,
       Actions::Label<
           evolution::dg::subcell::Actions::Labels::BeginSubcellAfterDgRollback>,

--- a/src/Evolution/Executables/ScalarAdvection/EvolveScalarAdvection.hpp
+++ b/src/Evolution/Executables/ScalarAdvection/EvolveScalarAdvection.hpp
@@ -233,7 +233,7 @@ struct EvolutionMetavars {
       evolution::dg::Actions::ComputeTimeDerivative<volume_dim, system,
                                                     AllStepChoosers>,
       evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
-          EvolutionMetavars>,
+          system, volume_dim>,
       tmpl::conditional_t<
           local_time_stepping, tmpl::list<>,
           tmpl::list<
@@ -250,7 +250,7 @@ struct EvolutionMetavars {
       evolution::dg::Actions::ComputeTimeDerivative<volume_dim, system,
                                                     AllStepChoosers>,
       evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
-          EvolutionMetavars>,
+          system, volume_dim>,
       tmpl::conditional_t<
           local_time_stepping, tmpl::list<>,
           tmpl::list<

--- a/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
+++ b/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
@@ -211,8 +211,8 @@ struct EvolutionMetavars {
   static constexpr bool use_filtering = (2 == volume_dim);
 
   using step_actions = tmpl::flatten<tmpl::list<
-      evolution::dg::Actions::ComputeTimeDerivative<volume_dim, system,
-                                                    AllStepChoosers>,
+      evolution::dg::Actions::ComputeTimeDerivative<
+          volume_dim, system, AllStepChoosers, local_time_stepping>,
       tmpl::conditional_t<
           local_time_stepping,
           tmpl::list<evolution::Actions::RunEventsAndDenseTriggers<

--- a/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
+++ b/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
@@ -217,12 +217,12 @@ struct EvolutionMetavars {
           local_time_stepping,
           tmpl::list<evolution::Actions::RunEventsAndDenseTriggers<
                          tmpl::list<evolution::dg::ApplyBoundaryCorrections<
-                             EvolutionMetavars, true>>>,
+                             local_time_stepping, system, volume_dim, true>>>,
                      evolution::dg::Actions::ApplyLtsBoundaryCorrections<
-                         EvolutionMetavars>>,
+                         system, volume_dim>>,
           tmpl::list<
               evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
-                  EvolutionMetavars>,
+                  system, volume_dim>,
               Actions::RecordTimeStepperData<>,
               evolution::Actions::RunEventsAndDenseTriggers<tmpl::list<>>,
               Actions::UpdateU<>>>,

--- a/tests/Unit/Evolution/DgSubcell/Actions/Test_ReconstructionCommunication.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Actions/Test_ReconstructionCommunication.cpp
@@ -84,14 +84,15 @@ struct component {
       tmpl::list<
           ActionTesting::InitializeDataBox<initial_tags>,
           evolution::dg::subcell::Actions::SendDataForReconstruction<
-              Dim, typename Metavariables::GhostDataMutator>,
+              Dim, typename Metavariables::GhostDataMutator,
+              // No local time stepping
+              false>,
           evolution::dg::subcell::Actions::ReceiveDataForReconstruction<Dim>>>>;
 };
 
 template <size_t Dim>
 struct Metavariables {
   static constexpr size_t volume_dim = Dim;
-  static constexpr bool local_time_stepping = false;
   using component_list = tmpl::list<component<Dim, Metavariables>>;
   using system = System<Dim>;
   using const_global_cache_tags = tmpl::list<>;

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Actions/Test_ApplyBoundaryCorrections.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Actions/Test_ApplyBoundaryCorrections.cpp
@@ -151,6 +151,7 @@ struct BoundaryTerms final : public BoundaryCorrection<Dim> {
 template <size_t Dim>
 PUP::able::PUP_ID BoundaryTerms<Dim>::my_PUP_ID = 0;  // NOLINT
 
+template <bool LocalTimeStepping>
 struct SetLocalMortarData {
   template <typename DbTagsList, typename... InboxTags, typename ArrayIndex,
             typename ActionList, typename ParallelComponent,
@@ -229,7 +230,7 @@ struct SetLocalMortarData {
                   std::move(type_erased_boundary_data_on_mortar));
             });
         ++count;
-        if (Metavariables::local_time_stepping) {
+        if (LocalTimeStepping) {
           const TimeStepId past_time_step_id{true, 3,
                                              Time{Slab{0.2, 3.4}, {1, 4}}};
           // When doing local time stepping we need a past history, starting an
@@ -379,6 +380,8 @@ struct component {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = ElementId<Metavariables::volume_dim>;
+  static constexpr bool local_time_stepping =
+      Metavariables::local_time_stepping;
 
   using internal_directions =
       domain::Tags::InternalDirections<Metavariables::volume_dim>;
@@ -411,15 +414,17 @@ struct component {
               ActionTesting::InitializeDataBox<simple_tags, compute_tags>,
               ::evolution::dg::Initialization::Mortars<
                   Metavariables::volume_dim, typename Metavariables::system>,
-              SetLocalMortarData>>,
+              SetLocalMortarData<local_time_stepping>>>,
       Parallel::PhaseActions<
           Parallel::Phase::Testing,
           tmpl::list<tmpl::conditional_t<
-              Metavariables::local_time_stepping,
+              local_time_stepping,
               ::evolution::dg::Actions::ApplyLtsBoundaryCorrections<
-                  Metavariables>,
+                  typename Metavariables::system, Metavariables::volume_dim>,
               ::evolution::dg::Actions::
-                  ApplyBoundaryCorrectionsToTimeDerivative<Metavariables>>>>>;
+                  ApplyBoundaryCorrectionsToTimeDerivative<
+                      typename Metavariables::system,
+                      Metavariables::volume_dim>>>>>;
 };
 
 template <size_t Dim, TestHelpers::SystemType SystemType,
@@ -452,6 +457,7 @@ void test_impl(const Spectral::Quadrature quadrature,
   CAPTURE(UseLocalTimeStepping);
   Parallel::register_derived_classes_with_charm<BoundaryCorrection<Dim>>();
   using metavars = Metavariables<Dim, SystemType, UseLocalTimeStepping>;
+  using comp = component<metavars>;
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<metavars>;
   using variables_tag = typename metavars::system::variables_tag;
   using variables_tags = typename variables_tag::tags_list;
@@ -565,7 +571,7 @@ void test_impl(const Spectral::Quadrature quadrature,
       {true, 3, Time{Slab{0.2, 3.4}, {6, 8}}},
       {true, 3, Time{Slab{0.2, 3.4}, {7, 8}}}};
 
-  ActionTesting::emplace_component_and_initialize<component<metavars>>(
+  ActionTesting::emplace_component_and_initialize<comp>(
       &runner, self_id,
       {time_step_id, local_next_time_step_id, time_step,
        std::make_unique<TimeSteppers::AdamsBashforthN>(time_stepper),
@@ -573,11 +579,9 @@ void test_impl(const Spectral::Quadrature quadrature,
        quadrature, typename evolution::dg::Tags::NeighborMesh<Dim>::type{}});
 
   // Initialize both the mortars
-  ActionTesting::next_action<component<metavars>>(make_not_null(&runner),
-                                                  self_id);
+  ActionTesting::next_action<comp>(make_not_null(&runner), self_id);
   // Set the local mortar data
-  ActionTesting::next_action<component<metavars>>(make_not_null(&runner),
-                                                  self_id);
+  ActionTesting::next_action<comp>(make_not_null(&runner), self_id);
 
   // Start testing the actual dg::ApplyBoundaryCorrections action
   ActionTesting::set_phase(make_not_null(&runner), Parallel::Phase::Testing);
@@ -654,7 +658,7 @@ void test_impl(const Spectral::Quadrature quadrature,
                  std::optional<std::vector<double>>, ::TimeStepId>
           data{mesh, face_mesh, {}, {flux_data}, {neighbor_next_time_step_id}};
 
-      runner.template mock_distributed_objects<component<metavars>>()
+      runner.template mock_distributed_objects<comp>()
           .at(self_id)
           .template receive_data<
               evolution::dg::Tags::BoundaryCorrectionAndGhostCellsInbox<Dim>>(
@@ -679,7 +683,7 @@ void test_impl(const Spectral::Quadrature quadrature,
            east_id_time_steps_index < east_id_next_time_steps.size();
            ++east_id_time_steps_index) {
         if (east_id_time_steps_index < east_id_next_time_steps.size() - 1) {
-          REQUIRE(not ActionTesting::next_action_if_ready<component<metavars>>(
+          REQUIRE(not ActionTesting::next_action_if_ready<comp>(
               make_not_null(&runner), self_id));
         }
         insert_neighbor_data(east_id_time_steps[east_id_time_steps_index],
@@ -688,7 +692,7 @@ void test_impl(const Spectral::Quadrature quadrature,
     } else {
       // Insert the mortar data (history) running at the same speed as the
       // self_id.
-      REQUIRE(not ActionTesting::next_action_if_ready<component<metavars>>(
+      REQUIRE(not ActionTesting::next_action_if_ready<comp>(
           make_not_null(&runner), self_id));
       if (UseLocalTimeStepping) {
         // Insert the past time, since we are using a 2nd order time stepper.
@@ -696,7 +700,7 @@ void test_impl(const Spectral::Quadrature quadrature,
         insert_neighbor_data(TimeStepId{time_step_id.time_runs_forward(),
                                         time_step_id.slab_number(), prev_time},
                              time_step_id);
-        REQUIRE(not ActionTesting::next_action_if_ready<component<metavars>>(
+        REQUIRE(not ActionTesting::next_action_if_ready<comp>(
             make_not_null(&runner), self_id));
       }
       insert_neighbor_data(time_step_id, UseLocalTimeStepping
@@ -708,28 +712,27 @@ void test_impl(const Spectral::Quadrature quadrature,
   REQUIRE(
       runner
           .template nonempty_inboxes<
-              component<metavars>,
+              comp,
               evolution::dg::Tags::BoundaryCorrectionAndGhostCellsInbox<Dim>>()
           .size() == 1);
 
-  ActionTesting::next_action<component<metavars>>(make_not_null(&runner),
-                                                  self_id);
+  ActionTesting::next_action<comp>(make_not_null(&runner), self_id);
 
   // Check the inboxes are empty when doing global time stepping
   if (not UseLocalTimeStepping) {
-    REQUIRE(runner
-                .template nonempty_inboxes<
-                    component<metavars>,
-                    evolution::dg::Tags::BoundaryCorrectionAndGhostCellsInbox<
-                        Dim>>()
-                .empty());
+    REQUIRE(
+        runner
+            .template nonempty_inboxes<
+                comp, evolution::dg::Tags::BoundaryCorrectionAndGhostCellsInbox<
+                          Dim>>()
+            .empty());
   } else {
-    CHECK(runner
-              .template nonempty_inboxes<
-                  component<metavars>,
-                  evolution::dg::Tags::BoundaryCorrectionAndGhostCellsInbox<
-                      Dim>>()
-              .size() == 1);
+    CHECK(
+        runner
+            .template nonempty_inboxes<
+                comp, evolution::dg::Tags::BoundaryCorrectionAndGhostCellsInbox<
+                          Dim>>()
+            .size() == 1);
   }
 
   // Now retrieve dt tag and check that values are correct

--- a/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivativeImpl.tpp
+++ b/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivativeImpl.tpp
@@ -826,7 +826,7 @@ struct component {
           Parallel::Phase::Testing,
           tmpl::list<::evolution::dg::Actions::ComputeTimeDerivative<
               Metavariables::volume_dim, typename Metavariables::system,
-              AllStepChoosers>>>>;
+              AllStepChoosers, Metavariables::local_time_stepping>>>>;
 };
 
 template <size_t Dim, SystemType SystemTypeIn, bool LocalTimeStepping,

--- a/tests/Unit/Time/Test_TakeStep.cpp
+++ b/tests/Unit/Time/Test_TakeStep.cpp
@@ -37,9 +37,7 @@ struct EvolvedVariable : db::SimpleTag {
   using type = DataVector;
 };
 
-template <bool LocalTimeStepping>
 struct Metavariables {
-  static constexpr bool local_time_stepping = LocalTimeStepping;
   struct system {
     static constexpr size_t volume_dim = 1;
     using variables_tag = EvolvedVariable;
@@ -96,13 +94,13 @@ void test_gts() {
       [](const auto y, const auto /*t*/) { return 1.0e-2 * y; }, time_step, 4);
 
   auto box = db::create<db::AddSimpleTags<
-      Parallel::Tags::MetavariablesImpl<Metavariables<false>>, Tags::TimeStepId,
+      Parallel::Tags::MetavariablesImpl<Metavariables>, Tags::TimeStepId,
       Tags::Next<Tags::TimeStepId>, Tags::TimeStep, Tags::Next<Tags::TimeStep>,
       EvolvedVariable, Tags::dt<EvolvedVariable>,
       Tags::HistoryEvolvedVariables<EvolvedVariable>,
       Tags::TimeStepper<LtsTimeStepper>,
       ::Tags::IsUsingTimeSteppingErrorControl>>(
-      Metavariables<false>{}, TimeStepId{true, 0_st, slab.start()},
+      Metavariables{}, TimeStepId{true, 0_st, slab.start()},
       TimeStepId{true, 0_st, Time{slab, {1, 4}}}, time_step, time_step,
       initial_values, DataVector{5, 0.0}, std::move(history),
       static_cast<std::unique_ptr<LtsTimeStepper>>(
@@ -111,7 +109,7 @@ void test_gts() {
   // update the rhs
   db::mutate<Tags::dt<EvolvedVariable>>(make_not_null(&box), update_rhs,
                                         db::get<EvolvedVariable>(box));
-  take_step(make_not_null(&box));
+  take_step<typename Metavariables::system, false>(make_not_null(&box));
   // check that the state is as expected
   CHECK(db::get<Tags::TimeStepId>(box).substep_time().value() == 0.0);
   CHECK(db::get<Tags::Next<Tags::TimeStepId>>(box).substep_time().value() ==
@@ -134,7 +132,7 @@ void test_lts() {
   step_choosers.emplace_back(
       std::make_unique<
           StepChoosers::Cfl<StepChooserUse::LtsStep, Frame::Inertial,
-                            typename Metavariables<true>::system>>(1.0));
+                            typename Metavariables::system>>(1.0));
 
   MAKE_GENERATOR(generator);
   std::uniform_real_distribution<> dist{-1.0, 1.0};
@@ -157,8 +155,8 @@ void test_lts() {
 
   auto box = db::create<
       db::AddSimpleTags<
-          Parallel::Tags::MetavariablesImpl<Metavariables<true>>,
-          Tags::TimeStepId, Tags::Next<Tags::TimeStepId>, Tags::TimeStep,
+          Parallel::Tags::MetavariablesImpl<Metavariables>, Tags::TimeStepId,
+          Tags::Next<Tags::TimeStepId>, Tags::TimeStep,
           Tags::Next<Tags::TimeStep>, EvolvedVariable,
           Tags::RollbackValue<EvolvedVariable>, Tags::dt<EvolvedVariable>,
           Tags::StepperError<EvolvedVariable>,
@@ -168,9 +166,9 @@ void test_lts() {
           domain::Tags::MinimumGridSpacing<1, Frame::Inertial>,
           Tags::StepController, ::Tags::IsUsingTimeSteppingErrorControl,
           Tags::StepperErrorUpdated>,
-      db::AddComputeTags<typename Metavariables<
-          true>::system::compute_largest_characteristic_speed>>(
-      Metavariables<true>{}, TimeStepId{true, 0_st, slab.start()},
+      db::AddComputeTags<typename Metavariables::system::
+                             compute_largest_characteristic_speed>>(
+      Metavariables{}, TimeStepId{true, 0_st, slab.start()},
       TimeStepId{true, 0_st, Time{slab, {1, 4}}}, time_step, time_step,
       initial_values, initial_values, DataVector{5, 0.0}, DataVector{},
       DataVector{}, std::move(history),
@@ -185,7 +183,7 @@ void test_lts() {
   // update the rhs
   db::mutate<Tags::dt<EvolvedVariable>>(make_not_null(&box), update_rhs,
                                          db::get<EvolvedVariable>(box));
-  take_step(make_not_null(&box));
+  take_step<typename Metavariables::system, true>(make_not_null(&box));
   // check that the state is as expected
   CHECK(db::get<Tags::TimeStepId>(box).substep_time().value() == 0.0);
   CHECK(db::get<Tags::Next<Tags::TimeStepId>>(box).substep_time().value() ==
@@ -223,7 +221,7 @@ void test_lts() {
       make_not_null(&box), [](const gsl::not_null<double*> grid_spacing) {
         *grid_spacing = 0.15 / TimeSteppers::AdamsBashforthN{5}.stable_step();
       });
-  take_step(make_not_null(&box));
+  take_step<typename Metavariables::system, true>(make_not_null(&box));
   // check that the state is as expected
   CHECK(db::get<Tags::TimeStepId>(box).substep_time().value() == approx(0.25));
   CHECK(db::get<Tags::TimeStep>(box) == TimeDelta{slab, {1, 8}});


### PR DESCRIPTION
## Proposed changes

- Refactors the single and no BH execs to make the metavariables easier to oversee.
- Several refactors to eliminate reaching up into the metavariables to get things out and instead pass them down through the actions.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
