### PR TITLE
Add `PlotDatFile.py` to Python CLI and refactor

### DIFF
--- a/docs/Tutorials/Visualization.md
+++ b/docs/Tutorials/Visualization.md
@@ -102,9 +102,9 @@ Make sure that `Scale Mode` is set to `vector`.
 ### Visualizing and Extracting Dat Files
 
 Global quantities such as error norms are stored in `h5::Dat` subfiles in the
-reduction/global HDF5 file. A python script named `PlotDatFile` in the `bin`
-directory (copied from `Visualization/Python`) can be used to plot quantities
-from Dat files and to extract them into space-separated text files. These text
+reduction/global HDF5 file. The command-line endpoint `spectre plot-dat`
+can be used to plot quantities, and `spectre extract-dat` can be used
+to extract them into space-separated text files. These text
 files can then be read with other plotting programs or viewed in an editor.
 
 ### Reproducibility of Results

--- a/src/Visualization/Python/CMakeLists.txt
+++ b/src/Visualization/Python/CMakeLists.txt
@@ -7,8 +7,8 @@ spectre_python_add_module(
   Visualization
   PYTHON_FILES
   GenerateXdmf.py
+  PlotDatFile.py
   PYTHON_EXECUTABLES
   InterpolateVolumeData.py
-  PlotDatFile.py
   Render1D.py
 )

--- a/src/Visualization/Python/PlotDatFile.py
+++ b/src/Visualization/Python/PlotDatFile.py
@@ -14,22 +14,20 @@ import rich
 logger = logging.getLogger(__name__)
 
 
-def available_subfiles(h5file, path='/'):
+def available_subfiles(h5file):
     """List all '.dat' subfiles in the 'h5file'.
 
     Parameters
     ----------
     h5file: Open h5py file
-    path: str
-      Root from where to list subfiles. Defaults to the file root.
     """
     subfiles = []
-    for member in h5file.keys():
-        if type(h5file[member]) is h5py._hl.group.Group:
-            subfiles = subfiles + available_subfiles(h5file[member],
-                                                     path + member + '/')
-        elif member.endswith('.dat'):
-            subfiles.append(path + member)
+
+    def visitor(name):
+        if name.endswith(".dat"):
+            subfiles.append(name)
+
+    h5file.visit(visitor)
     return subfiles
 
 

--- a/support/Python/__main__.py
+++ b/support/Python/__main__.py
@@ -16,6 +16,7 @@ class Cli(click.MultiCommand):
         return [
             "clean-output",
             "generate-xdmf",
+            "plot-dat",
             "simplify-traces",
         ]
 
@@ -27,6 +28,9 @@ class Cli(click.MultiCommand):
             from spectre.Visualization.GenerateXdmf import (
                 generate_xdmf_command)
             return generate_xdmf_command
+        elif name == "plot-dat":
+            from spectre.Visualization.PlotDatFile import plot_dat_command
+            return plot_dat_command
         elif name == "simplify-traces":
             from spectre.tools.CharmSimplifyTraces import (
                 simplify_traces_command)

--- a/tests/Unit/Visualization/Python/Test_PlotDatFile.py
+++ b/tests/Unit/Visualization/Python/Test_PlotDatFile.py
@@ -1,248 +1,94 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-import spectre.Visualization.PlotDatFile as plot_dat
+from spectre.Visualization.PlotDatFile import (available_subfiles,
+                                               plot_dat_command)
 
+import click
+import h5py
 import spectre.Informer as spectre_informer
 import numpy as np
 import os
 import unittest
+from click.testing import CliRunner
 
 
 class TestPlotDatFile(unittest.TestCase):
+    def setUp(self):
+        self.data_dir = os.path.join(spectre_informer.unit_test_src_path(),
+                                     'Visualization/Python')
+        self.filename = os.path.join(self.data_dir, 'DatTestData.h5')
+        self.stylesheet_filename = os.path.join(self.data_dir,
+                                                'teststyle.mplstyle')
+        self.test_dir = os.path.join(spectre_informer.unit_test_build_path(),
+                                     'Visualization/Python/PlotDatFile')
+        self.runner = CliRunner()
+
     def test_available_subfiles(self):
-        filename = os.path.join(spectre_informer.unit_test_src_path(),
-                                'Visualization/Python', 'DatTestData.h5')
-        available_subfiles = plot_dat.open_and_process_file(filename, None)
-        self.assertEqual(available_subfiles,
-                         ['/Group0/MemoryData.dat', '/TimeSteps2.dat'])
+        with h5py.File(self.filename, 'r') as open_file:
+            self.assertEqual(available_subfiles(open_file),
+                             ['/Group0/MemoryData.dat', '/TimeSteps2.dat'])
+
+    def test_list_subfiles(self):
+        result = self.runner.invoke(plot_dat_command, [self.filename],
+                                    catch_exceptions=False)
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("TimeSteps2.dat", result.output)
 
     def test_nonexistent_subfile(self):
-        filename = os.path.join(spectre_informer.unit_test_src_path(),
-                                'Visualization/Python', 'DatTestData.h5')
-        with self.assertRaisesRegex(
-                Exception, "Unable to open dat file 'TimeSteps.dat'."):
-            plot_dat.open_and_process_file(filename, 'TimeSteps')
+        result = self.runner.invoke(plot_dat_command,
+                                    [self.filename, "-d", "TimeSteps"],
+                                    catch_exceptions=False)
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("Unable to open dat file 'TimeSteps.dat'.",
+                      result.output)
 
     def test_legend_only(self):
-        filename = os.path.join(spectre_informer.unit_test_src_path(),
-                                'Visualization/Python', 'DatTestData.h5')
-        legend = plot_dat.open_and_process_file(filename,
-                                                'TimeSteps2',
-                                                legend_only=True,
-                                                write_dat=None)
-        self.assertEqual(legend, [
-            'Time', 'NumberOfPoints', 'Slab size', 'Minimum time step',
-            'Maximum time step', 'Effective time step', 'Minimum Walltime',
-            'Maximum Walltime'
-        ])
-
-    def test_write_dat(self):
-        filename = os.path.join(spectre_informer.unit_test_src_path(),
-                                'Visualization/Python', 'DatTestData.h5')
-        dat_filename = os.path.join(spectre_informer.unit_test_build_path(),
-                                    'Visualization/Python', 'DatTestData.dat')
-        plot_dat.open_and_process_file(filename,
-                                       'TimeSteps2',
-                                       legend_only=False,
-                                       write_dat=dat_filename)
-        # Load written out dat file and compare to expected values
-        self.assertTrue(os.path.exists(dat_filename))
-        dat_data = np.loadtxt(dat_filename)
-        self.assertTrue(
-            np.allclose(dat_data,
-                        np.asarray([[
-                            0.0, 20.0, 1.0e-2, 6.25e-4, 6.25e-4, 6.25e-4,
-                            3.3872221e-2, 3.3873593e-2
-                        ],
-                                    [
-                                        1.0e-2, 20.0, 1.0e-2, 5.0e-3, 5.0e-3,
-                                        5.0e-3, 2.75874901e-01,
-                                        2.7600519899999998e-01
-                                    ]]),
-                        rtol=1.0e-12,
-                        atol=1.0e-20))
-        if os.path.exists(dat_filename):
-            os.remove(dat_filename)
+        # Invoke with the subfile name but no functions to plot
+        result = self.runner.invoke(plot_dat_command,
+                                    [self.filename, "-d", "TimeSteps2"],
+                                    catch_exceptions=False)
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("Time", result.output)
+        self.assertIn("NumberOfPoints", result.output)
+        self.assertIn("Slab size", result.output)
+        # Invoke with the "-l" option and a couple of functions
+        result = self.runner.invoke(
+            plot_dat_command,
+            [self.filename, "-d", "TimeSteps2", "-l", "-y", "NumberOfPoints"],
+            catch_exceptions=False)
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("Time", result.output)
+        self.assertIn("NumberOfPoints", result.output)
+        self.assertIn("Slab size", result.output)
 
     def test_write_plot(self):
-        filename = os.path.join(spectre_informer.unit_test_src_path(),
-                                'Visualization/Python', 'DatTestData.h5')
-        plot_filename = os.path.join(spectre_informer.unit_test_build_path(),
-                                     'Visualization/Python', 'DatTestData')
-        plot_dat.open_and_process_file(filename,
-                                       'TimeSteps2',
-                                       legend_only=False,
-                                       write_dat=None,
-                                       x_axis=None,
-                                       functions=['Slab size'],
-                                       linestyles=['-'],
-                                       labels=None,
-                                       linewidth=1.0,
-                                       y_logscale=False,
-                                       x_label=None,
-                                       fontsize=16,
-                                       legend_ncols=1,
-                                       x_bounds=None,
-                                       y_bounds=None,
-                                       y_label="Blah",
-                                       title="DatTestdata",
-                                       output=plot_filename)
-        # We can't test that the plot is correct, so just make sure it at least
-        # gets written out.
-        self.assertTrue(os.path.exists(plot_filename + '.pdf'))
-        if os.path.exists(plot_filename + '.pdf'):
-            os.remove(plot_filename + '.pdf')
+        output_filename = os.path.join(self.test_dir, "output.pdf")
+        os.makedirs(self.test_dir, exist_ok=True)
 
-        # Test that no y-label doesn't error
-        plot_dat.open_and_process_file(filename,
-                                       'TimeSteps2',
-                                       legend_only=False,
-                                       write_dat=None,
-                                       x_axis=None,
-                                       functions=['Slab size'],
-                                       linestyles=['-'],
-                                       labels=None,
-                                       linewidth=1.0,
-                                       y_logscale=False,
-                                       x_label=None,
-                                       fontsize=16,
-                                       legend_ncols=1,
-                                       x_bounds=None,
-                                       y_bounds=None,
-                                       y_label=None,
-                                       title="DatTestdata",
-                                       output=plot_filename)
+        # Run with minimal options
+        result = self.runner.invoke(plot_dat_command, [
+            self.filename, "-d", "TimeSteps2", "-y", "Slab size", "-o",
+            output_filename
+        ],
+                                    catch_exceptions=False)
+        self.assertEqual(result.exit_code, 0)
         # We can't test that the plot is correct, so just make sure it at least
         # gets written out.
-        self.assertTrue(os.path.exists(plot_filename + '.pdf'))
-        if os.path.exists(plot_filename + '.pdf'):
-            os.remove(plot_filename + '.pdf')
+        self.assertTrue(os.path.exists(output_filename))
 
-        # Test that x and y bounds don't error
-        plot_dat.open_and_process_file(filename,
-                                       'TimeSteps2',
-                                       legend_only=False,
-                                       write_dat=None,
-                                       x_axis=None,
-                                       functions=['Slab size'],
-                                       linestyles=['-'],
-                                       labels=None,
-                                       linewidth=1.0,
-                                       y_logscale=False,
-                                       x_label=None,
-                                       fontsize=16,
-                                       legend_ncols=1,
-                                       x_bounds=[0.0, 1.0],
-                                       y_bounds=[0.0, 1.0],
-                                       y_label=None,
-                                       title="DatTestdata",
-                                       output=plot_filename)
-        # We can't test that the plot is correct, so just make sure it at least
-        # gets written out.
-        self.assertTrue(os.path.exists(plot_filename + '.pdf'))
-        if os.path.exists(plot_filename + '.pdf'):
-            os.remove(plot_filename + '.pdf')
+        # Run with all options
+        result = self.runner.invoke(plot_dat_command, [
+            self.filename, "-d", "Group0/MemoryData", "-x", "Time", "-y",
+            "Usage in MB", "-o", output_filename, "--x-label", "The time",
+            "--y-label", "The usage", "--x-logscale", "--y-logscale",
+            "--x-bounds", "0.1", "1", "--y-bounds", "0.1", "0.2", "-t",
+            "Memory Data", "-s", self.stylesheet_filename
+        ],
+                                    catch_exceptions=False)
+        self.assertEqual(result.exit_code, 0)
 
-        # Test that x-label doesn't error
-        plot_dat.open_and_process_file(filename,
-                                       'TimeSteps2',
-                                       legend_only=False,
-                                       write_dat=None,
-                                       x_axis=None,
-                                       functions=['Slab size'],
-                                       linestyles=['-'],
-                                       labels=None,
-                                       linewidth=1.0,
-                                       y_logscale=False,
-                                       x_label="X label",
-                                       fontsize=16,
-                                       legend_ncols=1,
-                                       x_bounds=None,
-                                       y_bounds=None,
-                                       y_label=None,
-                                       title="DatTestdata",
-                                       output=plot_filename)
-        # We can't test that the plot is correct, so just make sure it at least
-        # gets written out.
-        self.assertTrue(os.path.exists(plot_filename + '.pdf'))
-        if os.path.exists(plot_filename + '.pdf'):
-            os.remove(plot_filename + '.pdf')
-
-        # Test that y logscale doesn't error
-        plot_dat.open_and_process_file(filename,
-                                       'TimeSteps2',
-                                       legend_only=False,
-                                       write_dat=None,
-                                       x_axis=None,
-                                       functions=['Slab size'],
-                                       linestyles=['-'],
-                                       labels=None,
-                                       linewidth=1.0,
-                                       y_logscale=True,
-                                       x_label=None,
-                                       fontsize=16,
-                                       legend_ncols=1,
-                                       x_bounds=None,
-                                       y_bounds=None,
-                                       y_label=None,
-                                       title="DatTestdata",
-                                       output=plot_filename)
-        # We can't test that the plot is correct, so just make sure it at least
-        # gets written out.
-        self.assertTrue(os.path.exists(plot_filename + '.pdf'))
-        if os.path.exists(plot_filename + '.pdf'):
-            os.remove(plot_filename + '.pdf')
-
-        # Test that the x-axis can be set to something different without error
-        plot_dat.open_and_process_file(filename,
-                                       'TimeSteps2',
-                                       legend_only=False,
-                                       write_dat=None,
-                                       x_axis="NumberOfPoints",
-                                       functions=['Slab size'],
-                                       linestyles=['-'],
-                                       labels=None,
-                                       linewidth=1.0,
-                                       y_logscale=False,
-                                       x_label=None,
-                                       fontsize=16,
-                                       legend_ncols=1,
-                                       x_bounds=None,
-                                       y_bounds=None,
-                                       y_label=None,
-                                       title="DatTestdata",
-                                       output=plot_filename)
-        # We can't test that the plot is correct, so just make sure it at least
-        # gets written out.
-        self.assertTrue(os.path.exists(plot_filename + '.pdf'))
-        if os.path.exists(plot_filename + '.pdf'):
-            os.remove(plot_filename + '.pdf')
-
-        # Test that groups can be accessed without error
-        plot_dat.open_and_process_file(filename,
-                                       'Group0/MemoryData',
-                                       legend_only=False,
-                                       write_dat=None,
-                                       x_axis=None,
-                                       functions=['Usage in MB'],
-                                       linestyles=['-'],
-                                       labels=None,
-                                       linewidth=1.0,
-                                       y_logscale=False,
-                                       x_label=None,
-                                       fontsize=16,
-                                       legend_ncols=1,
-                                       x_bounds=None,
-                                       y_bounds=None,
-                                       y_label=None,
-                                       title="DatTestdata",
-                                       output=plot_filename)
-        # We can't test that the plot is correct, so just make sure it at least
-        # gets written out.
-        self.assertTrue(os.path.exists(plot_filename + '.pdf'))
-        if os.path.exists(plot_filename + '.pdf'):
-            os.remove(plot_filename + '.pdf')
+        os.remove(output_filename)
 
 
 if __name__ == '__main__':

--- a/tests/Unit/Visualization/Python/Test_PlotDatFile.py
+++ b/tests/Unit/Visualization/Python/Test_PlotDatFile.py
@@ -27,7 +27,7 @@ class TestPlotDatFile(unittest.TestCase):
     def test_available_subfiles(self):
         with h5py.File(self.filename, 'r') as open_file:
             self.assertEqual(available_subfiles(open_file),
-                             ['/Group0/MemoryData.dat', '/TimeSteps2.dat'])
+                             ['Group0/MemoryData.dat', 'TimeSteps2.dat'])
 
     def test_list_subfiles(self):
         result = self.runner.invoke(plot_dat_command, [self.filename],

--- a/tests/Unit/Visualization/Python/teststyle.mplstyle
+++ b/tests/Unit/Visualization/Python/teststyle.mplstyle
@@ -1,0 +1,7 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+lines.linewidth: 1
+font.size: 9
+legend.fontsize: 8
+axes.prop_cycle: cycler('linestyle', ['-', '--', '-.', 'dotted'])


### PR DESCRIPTION
## Proposed changes

- Print available subfiles and columns when options are unspecified, consistent with other CLIs.
- Remove `write_dat` option because `ExtractDatFromH5.py` does that now.
- Show plot interactively if 'output' is unspecified.
- Specify labels for plots as key-value pairs instead of JSON.
- Use a matplotlib stylesheet for any stylistic customization.

Tested on Wheeler.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
Invoke `spectre plot-dat -h` to run the `PlotDatFile.py` script.
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
