### PR TITLE
Fix a bug at roundoff error in block_logical_coords

### DIFF
--- a/src/Domain/BlockLogicalCoordinates.hpp
+++ b/src/Domain/BlockLogicalCoordinates.hpp
@@ -38,6 +38,13 @@ class IdPair;
 /// If a point is on a shared boundary of two or more `Block`s, it is
 /// returned only once, and is considered to belong to the `Block`
 /// with the smaller `BlockId`.
+///
+/// \warning Since map inverses can involve numerical roundoff error, care must
+/// be taken with points on shared block boundaries. They will be assigned to
+/// the first block (by block ID) that contains the point _within roundoff
+/// error_. Therefore, be advised to use the logical coordinates returned by
+/// this function, which are guaranteed to be in [-1, 1] and can be safely
+/// passed along to `element_logical_coordinates`.
 template <size_t Dim, typename Frame>
 auto block_logical_coordinates(
     const Domain<Dim>& domain, const tnsr::I<DataVector, Dim, Frame>& x,


### PR DESCRIPTION
This bug appeared when interpolating between two BBH domains with bulged frustums. Points at inner frustum edges were not mapped to the source domain because the frustum inverse reports logical coordinates outside [-1, 1] by roundoff error.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
