### PR TITLE
Update Test_FileSystem to pass on macOS

### DIFF
--- a/tests/Unit/Utilities/Test_FileSystem.cpp
+++ b/tests/Unit/Utilities/Test_FileSystem.cpp
@@ -146,18 +146,15 @@ void test_errors() {
       Catch::Contains("Failed to find a file in the given path: '/'"));
   CHECK_THROWS_WITH(file_system::get_file_name(""),
                     Catch::Contains("Received an empty path"));
-  CHECK_THROWS_WITH(
-      trigger_nonexistent_absolute_path(),
-      Catch::Contains(
-          "No such file or directory [./get_absolute_path_nonexistent/]"));
+  CHECK_THROWS_WITH(trigger_nonexistent_absolute_path(),
+                    Catch::Contains("No such file or directory"));
   CHECK_THROWS_WITH(
       file_system::file_size("./file_size_error.txt"),
       Catch::Contains("Cannot get size of file './file_size_error.txt' because "
                       "it cannot be accessed. Either it does not exist or you "
                       "do not have the appropriate permissions."));
-  CHECK_THROWS_WITH(
-      trigger_rm_error_not_empty(),
-      Catch::Contains("remove: Directory not empty [./rm_error_not_empty]"));
+  CHECK_THROWS_WITH(trigger_rm_error_not_empty(),
+                    Catch::Contains("remove: Directory not empty"));
   CHECK_THROWS_WITH(file_system::is_file("./is_file_error"),
                     Catch::Contains("Failed to check if path points to a file "
                                     "because the path is invalid"));


### PR DESCRIPTION
## Proposed changes

Fixes #4249 by adjusting the text in `Catch::Contains` for some of the tests, to account for differences in error messages on linux vs macOS.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
