### PR TITLE
Add ExcisionBoundaryA InterpolationTarget to EvolveGhSingleBlackHole

### DIFF
--- a/src/ApparentHorizons/CMakeLists.txt
+++ b/src/ApparentHorizons/CMakeLists.txt
@@ -19,6 +19,8 @@ spectre_target_headers(
   ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
+  ComputeExcisionBoundaryVolumeQuantities.hpp
+  ComputeExcisionBoundaryVolumeQuantities.tpp
   ComputeHorizonVolumeQuantities.hpp
   ComputeHorizonVolumeQuantities.tpp
   ComputeItems.hpp

--- a/src/ApparentHorizons/ComputeExcisionBoundaryVolumeQuantities.hpp
+++ b/src/ApparentHorizons/ComputeExcisionBoundaryVolumeQuantities.hpp
@@ -1,0 +1,97 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
+#include "ParallelAlgorithms/Interpolation/Protocols/ComputeVarsToInterpolate.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+class DataVector;
+template <size_t Dim>
+class Mesh;
+template <typename VariablesTags>
+class Variables;
+namespace gsl {
+template <typename T>
+class not_null;
+}  // namespace gsl
+/// \endcond
+
+namespace ah {
+
+/// Given the generalized harmonic variables in the volume, computes
+/// the quantities that will be interpolated onto an excision boundary.
+///
+/// This is meant to be the primary `compute_vars_to_interpolate`
+/// for the computation of the characteristic speeds on the
+/// excision boundary.
+///
+/// SrcTagList and DestTagList have limited flexibility, and their
+/// restrictions are static_asserted inside the apply functions.  The
+/// lack of complete flexibility is intentional, because most
+/// computations (e.g. for observers) should be done only on the
+/// horizon surface (i.e. after interpolation) as opposed to in the
+/// volume; only those computations that require data in the volume
+/// (e.g. volume numerical derivatives) should be done here.
+///
+/// For the dual-frame case, numerical derivatives of Jacobians are
+/// taken in order to avoid Hessians.
+///
+/// SrcTagList is usually `interpolator_source_vars` in the
+/// Metavariables, and the allowed and required tags in SrcTagList are
+/// given by the type aliases `allowed_src_tags` and `required_src_tags`
+/// below.
+///
+/// DestTagList is usually `vars_to_interpolate_to_target` in the
+/// `InterpolationTarget` that uses `ComputeExcisionBoundaryVolumeQuantities`.
+/// The allowed and required tags in DestTagList are given by
+/// the type aliases `allowed_dest_tags` and `required_dest_tags` below.
+struct ComputeExcisionBoundaryVolumeQuantities
+    : tt::ConformsTo<intrp::protocols::ComputeVarsToInterpolate> {
+  /// Single-frame case
+  template <typename SrcTagList, typename DestTagList>
+  static void apply(const gsl::not_null<Variables<DestTagList>*> target_vars,
+                    const Variables<SrcTagList>& src_vars, const Mesh<3>& mesh);
+  /// Dual-frame case
+  template <typename SrcTagList, typename DestTagList, typename TargetFrame>
+  static void apply(
+      const gsl::not_null<Variables<DestTagList>*> target_vars,
+      const Variables<SrcTagList>& src_vars, const Mesh<3>& mesh,
+      const Jacobian<DataVector, 3, TargetFrame, Frame::Inertial>& jacobian,
+      const InverseJacobian<DataVector, 3, Frame::ElementLogical, TargetFrame>&
+          inverse_jacobian);
+
+  using allowed_src_tags =
+      tmpl::list<gr::Tags::SpacetimeMetric<3, Frame::Inertial>,
+                 GeneralizedHarmonic::Tags::Pi<3, Frame::Inertial>,
+                 GeneralizedHarmonic::Tags::Phi<3, Frame::Inertial>,
+                 Tags::deriv<GeneralizedHarmonic::Tags::Phi<3, Frame::Inertial>,
+                             tmpl::size_t<3>, Frame::Inertial>>;
+
+  using required_src_tags =
+      tmpl::list<gr::Tags::SpacetimeMetric<3, Frame::Inertial>>;
+
+  template <typename TargetFrame>
+  using allowed_dest_tags_target_frame =
+      tmpl::list<gr::Tags::SpatialMetric<3, Frame::Inertial>,
+                 gr::Tags::SpacetimeMetric<3, Frame::Inertial>,
+                 gr::Tags::Lapse<DataVector>,
+                 gr::Tags::Shift<3, Frame::Inertial>>;
+
+  template <typename TargetFrame>
+  using allowed_dest_tags = tmpl::remove_duplicates<
+      tmpl::append<allowed_dest_tags_target_frame<TargetFrame>,
+                   allowed_dest_tags_target_frame<Frame::Inertial>>>;
+
+  template <typename TargetFrame>
+  using required_dest_tags =
+      tmpl::list<gr::Tags::SpacetimeMetric<3, Frame::Inertial>>;
+};
+
+}  // namespace ah

--- a/src/ApparentHorizons/ComputeExcisionBoundaryVolumeQuantities.tpp
+++ b/src/ApparentHorizons/ComputeExcisionBoundaryVolumeQuantities.tpp
@@ -1,0 +1,218 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "ApparentHorizons/ComputeExcisionBoundaryVolumeQuantities.hpp"
+
+#pragma once
+
+#include <cstdint>
+#include <type_traits>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/TaggedContainers.hpp"
+#include "DataStructures/Tags/TempTensor.hpp"
+#include "DataStructures/TempBuffer.hpp"
+#include "DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Christoffel.hpp"
+#include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/Christoffel.hpp"
+#include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/ExtrinsicCurvature.hpp"
+#include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/Ricci.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Lapse.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Shift.hpp"
+#include "PointwiseFunctions/GeneralRelativity/SpacetimeNormalVector.hpp"
+#include "PointwiseFunctions/GeneralRelativity/SpatialMetric.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Transform.hpp"
+#include "Utilities/ContainerHelpers.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace ah {
+
+/// Single frame case
+template <typename SrcTagList, typename DestTagList>
+void ComputeExcisionBoundaryVolumeQuantities::apply(
+    const gsl::not_null<Variables<DestTagList>*> target_vars,
+    const Variables<SrcTagList>& src_vars, const Mesh<3>& /*mesh*/) {
+  static_assert(
+      std::is_same_v<tmpl::list_difference<SrcTagList, allowed_src_tags>,
+                     tmpl::list<>>,
+      "Found a src tag that is not allowed");
+  static_assert(
+      std::is_same_v<tmpl::list_difference<required_src_tags, SrcTagList>,
+                     tmpl::list<>>,
+      "A required src tag is missing");
+
+  static_assert(
+      std::is_same_v<tmpl::list_difference<DestTagList,
+                                           allowed_dest_tags<Frame::Inertial>>,
+                     tmpl::list<>>,
+      "Found a dest tag that is not allowed");
+  static_assert(
+      std::is_same_v<tmpl::list_difference<required_dest_tags<Frame::Inertial>,
+                                           DestTagList>,
+                     tmpl::list<>>,
+      "A required dest tag is missing");
+
+  if (target_vars->number_of_grid_points() !=
+      src_vars.number_of_grid_points()) {
+    target_vars->initialize(src_vars.number_of_grid_points());
+  }
+
+  get<gr::Tags::SpacetimeMetric<3, Frame::Inertial>>(*target_vars) =
+    get<gr::Tags::SpacetimeMetric<3, Frame::Inertial>>(src_vars);
+
+  const auto& spacetime_metric =
+      get<gr::Tags::SpacetimeMetric<3, Frame::Inertial>>(src_vars);
+
+  using spatial_metric_tag = gr::Tags::SpatialMetric<3, Frame::Inertial>;
+  using inv_spatial_metric_tag =
+    gr::Tags::InverseSpatialMetric<3, Frame::Inertial>;
+  using lapse_tag = gr::Tags::Lapse<DataVector>;
+  using shift_tag = gr::Tags::Shift<3, Frame::Inertial>;
+
+  // All of the temporary tags, including some that may be repeated
+  // in the target_variables (for now).
+  using full_temp_tags_list =
+      tmpl::list<spatial_metric_tag, inv_spatial_metric_tag,
+                 lapse_tag, shift_tag>;
+
+  // temp tags without variables that are already in DestTagList.
+  using temp_tags_list =
+      tmpl::list_difference<full_temp_tags_list, DestTagList>;
+  TempBuffer<temp_tags_list> buffer(get<0, 0>(spacetime_metric).size());
+
+  // These may or may not be temporaries
+  auto& lapse = *(get<lapse_tag>(
+      target_vars, make_not_null(&buffer)));
+  auto& shift = *(get<shift_tag>(
+      target_vars, make_not_null(&buffer)));
+  auto& spatial_metric = *(get<spatial_metric_tag>(
+      target_vars, make_not_null(&buffer)));
+  auto& inv_spatial_metric = *(get<inv_spatial_metric_tag>(
+      target_vars, make_not_null(&buffer)));
+
+  // Actual computation starts here
+
+  gr::spatial_metric(make_not_null(&spatial_metric), spacetime_metric);
+  // put determinant of 3-metric temporarily into lapse to save memory.
+  determinant_and_inverse(make_not_null(&lapse),
+                          make_not_null(&inv_spatial_metric),
+                          spatial_metric);
+  gr::shift(make_not_null(&shift), spacetime_metric, inv_spatial_metric);
+  gr::lapse(make_not_null(&lapse), shift, spacetime_metric);
+}
+
+/// Dual frame case
+template <typename SrcTagList, typename DestTagList, typename TargetFrame>
+void ComputeExcisionBoundaryVolumeQuantities::apply(
+    const gsl::not_null<Variables<DestTagList>*> target_vars,
+    const Variables<SrcTagList>& src_vars, const Mesh<3>& /*mesh*/,
+    const Jacobian<DataVector, 3, TargetFrame, Frame::Inertial>& jacobian,
+    const InverseJacobian<DataVector, 3, Frame::ElementLogical, TargetFrame>&
+        /*inverse_jacobian*/) {
+
+  static_assert(
+      std::is_same_v<tmpl::list_difference<SrcTagList, allowed_src_tags>,
+                     tmpl::list<>>,
+      "Found a src tag that is not allowed");
+  static_assert(
+      std::is_same_v<tmpl::list_difference<required_src_tags, SrcTagList>,
+                     tmpl::list<>>,
+      "A required src tag is missing");
+
+  static_assert(
+      std::is_same_v<
+          tmpl::list_difference<DestTagList, allowed_dest_tags<TargetFrame>>,
+          tmpl::list<>>,
+      "Found a dest tag that is not allowed");
+  static_assert(
+      std::is_same_v<
+          tmpl::list_difference<required_dest_tags<TargetFrame>, DestTagList>,
+          tmpl::list<>>,
+      "A required dest tag is missing");
+
+  const auto& spacetime_metric =
+      get<gr::Tags::SpacetimeMetric<3, Frame::Inertial>>(src_vars);
+
+  if (target_vars->number_of_grid_points() !=
+      src_vars.number_of_grid_points()) {
+    target_vars->initialize(src_vars.number_of_grid_points());
+  }
+
+  using spatial_metric_tag = gr::Tags::SpatialMetric<3, TargetFrame>;
+  using inv_spatial_metric_tag = gr::Tags::InverseSpatialMetric<3, TargetFrame>;
+  using lapse_tag = gr::Tags::Lapse<DataVector>;
+  using inertial_shift_tag = gr::Tags::Shift<3, Frame::Inertial>;
+
+  // Additional temporary tags used for multiple frames
+  using inertial_spatial_metric_tag =
+      gr::Tags::SpatialMetric<3, Frame::Inertial>;
+  using inertial_inv_spatial_metric_tag =
+      gr::Tags::InverseSpatialMetric<3, Frame::Inertial>;
+
+  // All of the temporary tags, including some that may be repeated
+  // in the target_variables (for now).
+  using full_temp_tags_list =
+      tmpl::list<spatial_metric_tag, inv_spatial_metric_tag,
+                 lapse_tag, inertial_shift_tag,
+                 inertial_spatial_metric_tag,
+                 inertial_inv_spatial_metric_tag>;
+
+  // temp tags without variables that are already in DestTagList.
+  using temp_tags_list =
+      tmpl::list_difference<full_temp_tags_list, DestTagList>;
+  TempBuffer<temp_tags_list> buffer(get<0, 0>(spacetime_metric).size());
+
+  // These may or may not be temporaries, depending on if they are asked for
+  // in target_vars.
+  auto& lapse = *(get<lapse_tag>(
+      target_vars, make_not_null(&buffer)));
+  auto& inertial_shift = *(get<inertial_shift_tag>(
+      target_vars, make_not_null(&buffer)));
+  auto& inertial_spatial_metric = *(get<inertial_spatial_metric_tag>(
+      target_vars, make_not_null(&buffer)));
+  auto& inertial_inv_spatial_metric =
+      *(get<inertial_inv_spatial_metric_tag>(
+          target_vars, make_not_null(&buffer)));
+  auto& spatial_metric = *(get<spatial_metric_tag>(
+      target_vars, make_not_null(&buffer)));
+  auto& inv_spatial_metric = *(get<inv_spatial_metric_tag>(
+      target_vars, make_not_null(&buffer)));
+
+  // Actual computation starts here
+
+  gr::spatial_metric(make_not_null(&inertial_spatial_metric), spacetime_metric);
+  // put determinant of 3-metric temporarily into lapse to save memory.
+  determinant_and_inverse(make_not_null(&lapse),
+                          make_not_null(&inertial_inv_spatial_metric),
+                          inertial_spatial_metric);
+
+  // Transform spatial metric
+  transform::to_different_frame(make_not_null(&spatial_metric),
+                                inertial_spatial_metric,
+                                jacobian);
+
+  // Invert transformed 3-metric.
+  // put determinant of 3-metric temporarily into lapse to save memory.
+  determinant_and_inverse(make_not_null(&lapse),
+                          make_not_null(&inv_spatial_metric),
+                          spatial_metric);
+
+  // Only the inertial shift is computed at this time, so there is no
+  // transformation done.
+  gr::shift(make_not_null(&inertial_shift),
+                          spacetime_metric,
+                          inertial_inv_spatial_metric);
+  // We assume the lapse does note transform between the target and
+  // inertial frames.
+  gr::lapse(make_not_null(&lapse), inertial_shift, spacetime_metric);
+}
+
+}  // namespace ah

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonicSingleBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonicSingleBlackHole.hpp
@@ -6,6 +6,8 @@
 #include <cstdint>
 #include <vector>
 
+#include "ApparentHorizons/ComputeExcisionBoundaryVolumeQuantities.hpp"
+#include "ApparentHorizons/ComputeExcisionBoundaryVolumeQuantities.tpp"
 #include "ApparentHorizons/ComputeHorizonVolumeQuantities.hpp"
 #include "ApparentHorizons/ComputeHorizonVolumeQuantities.tpp"
 #include "ApparentHorizons/ComputeItems.hpp"
@@ -24,6 +26,7 @@
 #include "Parallel/PhaseControl/ExecutePhaseChange.hpp"
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 #include "ParallelAlgorithms/Interpolation/Actions/CleanUpInterpolator.hpp"
+#include "ParallelAlgorithms/Interpolation/Actions/ElementInitInterpPoints.hpp"
 #include "ParallelAlgorithms/Interpolation/Actions/InitializeInterpolationTarget.hpp"
 #include "ParallelAlgorithms/Interpolation/Actions/InterpolationTargetReceiveVars.hpp"
 #include "ParallelAlgorithms/Interpolation/Actions/InterpolatorReceivePoints.hpp"
@@ -36,11 +39,13 @@
 #include "ParallelAlgorithms/Interpolation/Callbacks/ObserveSurfaceData.hpp"
 #include "ParallelAlgorithms/Interpolation/Callbacks/ObserveTimeSeriesOnSurface.hpp"
 #include "ParallelAlgorithms/Interpolation/Events/Interpolate.hpp"
+#include "ParallelAlgorithms/Interpolation/Events/InterpolateWithoutInterpComponent.hpp"
 #include "ParallelAlgorithms/Interpolation/InterpolationTarget.hpp"
 #include "ParallelAlgorithms/Interpolation/Interpolator.hpp"
 #include "ParallelAlgorithms/Interpolation/Protocols/InterpolationTargetTag.hpp"
 #include "ParallelAlgorithms/Interpolation/Tags.hpp"
 #include "ParallelAlgorithms/Interpolation/Targets/ApparentHorizon.hpp"
+#include "ParallelAlgorithms/Interpolation/Targets/Sphere.hpp"
 #include "Time/Actions/ChangeSlabSize.hpp"
 #include "Time/Actions/SelfStartActions.hpp"
 #include "Time/StepChoosers/Factory.hpp"
@@ -86,29 +91,69 @@ struct EvolutionMetavars
                                              ::Frame::Inertial>>;
   };
 
-  using interpolation_target_tags = tmpl::list<AhA>;
+  struct ExcisionBoundaryA
+      : tt::ConformsTo<intrp::protocols::InterpolationTargetTag> {
+    using temporal_id = ::Tags::Time;
+    using tags_to_observe = tmpl::list<
+        gr::Tags::LapseCompute<volume_dim, ::Frame::Inertial, DataVector>>;
+    using compute_vars_to_interpolate =
+        ah::ComputeExcisionBoundaryVolumeQuantities;
+    using vars_to_interpolate_to_target =
+        tmpl::list<gr::Tags::SpacetimeMetric<volume_dim, Frame::Inertial>>;
+    using compute_items_on_source = tmpl::list<>;
+    using compute_items_on_target = tmpl::append<tmpl::list<
+        gr::Tags::SpatialMetricCompute<volume_dim, Frame::Inertial, DataVector>,
+        gr::Tags::DetAndInverseSpatialMetricCompute<volume_dim, Frame::Inertial,
+                                                    DataVector>,
+        gr::Tags::ShiftCompute<volume_dim, Frame::Inertial, DataVector>,
+        gr::Tags::LapseCompute<volume_dim, Frame::Inertial, DataVector>>>;
+    using compute_target_points =
+        intrp::TargetPoints::Sphere<ExcisionBoundaryA, ::Frame::Grid>;
+    using post_interpolation_callback =
+        intrp::callbacks::ObserveSurfaceData<tags_to_observe, ExcisionBoundaryA,
+                                             ::Frame::Grid>;
+    // run_callbacks
+    template <typename metavariables>
+    using interpolating_component = typename metavariables::gh_dg_element_array;
+  };
+
+  using interpolation_target_tags = tmpl::list<AhA, ExcisionBoundaryA>;
   using interpolator_source_vars = ::ah::source_vars<volume_dim>;
+  using interpolator_source_vars_excision_boundary =
+      tmpl::list<gr::Tags::SpacetimeMetric<volume_dim, Frame::Inertial>>;
 
   struct factory_creation
       : tt::ConformsTo<Options::protocols::FactoryCreation> {
     using factory_classes = Options::add_factory_classes<
         typename gh_base::factory_creation::factory_classes,
-        tmpl::pair<Event, tmpl::list<intrp::Events::Interpolate<
-                              3, AhA, interpolator_source_vars>>>>;
+        tmpl::pair<
+            Event,
+            tmpl::list<
+                intrp::Events::Interpolate<3, AhA, interpolator_source_vars>,
+                intrp::Events::InterpolateWithoutInterpComponent<
+                    3, ExcisionBoundaryA, EvolutionMetavars,
+                    interpolator_source_vars_excision_boundary>>>>;
   };
 
   using typename gh_base::const_global_cache_tags;
 
-  using observed_reduction_data_tags = observers::collect_reduction_data_tags<
-      tmpl::at<typename factory_creation::factory_classes, Event>>;
+  using observed_reduction_data_tags =
+      observers::collect_reduction_data_tags<tmpl::push_back<
+          tmpl::at<typename factory_creation::factory_classes, Event>,
+          typename AhA::post_horizon_find_callbacks,
+          typename ExcisionBoundaryA::post_interpolation_callback>>;
 
   using dg_registration_list =
       tmpl::push_back<typename gh_base::dg_registration_list,
                       intrp::Actions::RegisterElementWithInterpolator>;
 
-  using typename gh_base::initialization_actions;
-
   using typename gh_base::step_actions;
+
+  using initialization_actions =
+      tmpl::push_back<tmpl::pop_back<typename gh_base::initialization_actions>,
+                      intrp::Actions::ElementInitInterpPoints<
+                          intrp::Tags::InterpPointInfo<EvolutionMetavars>>,
+                      tmpl::back<typename gh_base::initialization_actions>>;
 
   using gh_dg_element_array = DgElementArray<
       EvolutionMetavars,
@@ -161,7 +206,8 @@ struct EvolutionMetavars
                          importers::ElementDataReader<EvolutionMetavars>,
                          tmpl::list<>>,
       gh_dg_element_array, intrp::Interpolator<EvolutionMetavars>,
-      intrp::InterpolationTarget<EvolutionMetavars, AhA>>>;
+      intrp::InterpolationTarget<EvolutionMetavars, AhA>,
+      intrp::InterpolationTarget<EvolutionMetavars, ExcisionBoundaryA>>>;
 };
 
 static const std::vector<void (*)()> charm_init_node_funcs{

--- a/src/ParallelAlgorithms/Interpolation/Callbacks/ObserveSurfaceData.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Callbacks/ObserveSurfaceData.hpp
@@ -62,19 +62,25 @@ struct ObserveSurfaceData
     const Strahlkorper<HorizonFrame>& strahlkorper =
         get<StrahlkorperTags::Strahlkorper<HorizonFrame>>(box);
     const YlmSpherepack& ylm = strahlkorper.ylm_spherepack();
-    const auto& inertial_strahlkorper_coords =
-        get<StrahlkorperTags::CartesianCoords<::Frame::Inertial>>(box);
 
     // Output the inertial-frame coordinates of the Stralhlkorper.
     // Note that these coordinates are not
     // Spherepack-evenly-distributed over the inertial-frame sphere
     // (they are Spherepack-evenly-distributed over the HorizonFrame
     // sphere).
-    std::vector<TensorComponent> tensor_components{
-        {"InertialCoordinates_x"s, get<0>(inertial_strahlkorper_coords)},
-        {"InertialCoordinates_y"s, get<1>(inertial_strahlkorper_coords)},
-        {"InertialCoordinates_z"s, get<2>(inertial_strahlkorper_coords)}};
-
+    std::vector<TensorComponent> tensor_components;
+    if constexpr (db::tag_is_retrievable_v<
+                      StrahlkorperTags::CartesianCoords<::Frame::Inertial>,
+                      db::DataBox<DbTags>>) {
+      const auto& inertial_strahlkorper_coords =
+          get<StrahlkorperTags::CartesianCoords<::Frame::Inertial>>(box);
+      tensor_components.push_back(
+          {"InertialCoordinates_x"s, get<0>(inertial_strahlkorper_coords)});
+      tensor_components.push_back(
+          {"InertialCoordinates_y"s, get<1>(inertial_strahlkorper_coords)});
+      tensor_components.push_back(
+          {"InertialCoordinates_z"s, get<2>(inertial_strahlkorper_coords)});
+    }
     // Output each tag if it is a scalar. Otherwise, throw a compile-time
     // error. This could be generalized to handle tensors of nonzero rank by
     // looping over the components, so each component could be visualized

--- a/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
@@ -20,6 +20,9 @@ ResourceInfo:
     AhA:
       Proc: Auto
       Exclusive: false
+    ExcisionBoundaryA:
+      Proc: Auto
+      Exclusive: false
 
 Evolution:
   InitialTime: 0.0
@@ -163,6 +166,11 @@ EventsAndTriggers:
           Offset: 2
     - - AhA
   - - Slabs:
+        EvenlySpaced:
+          Interval: 5
+          Offset: 2
+    - - ExcisionBoundaryA
+  - - Slabs:
         Specified:
           Values: [3]
     - - Completion
@@ -193,3 +201,10 @@ ApparentHorizons:
       DivergenceIter: 5
       MaxIts: 100
     Verbosity: Verbose
+
+InterpolationTargets:
+  ExcisionBoundaryA:
+    Lmax: 10
+    Center: [0., 0., 0.]
+    Radius: 2.0
+    AngularOrdering: "Strahlkorper"

--- a/tests/Unit/ApparentHorizons/CMakeLists.txt
+++ b/tests/Unit/ApparentHorizons/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY "Test_ApparentHorizons")
 
 set(LIBRARY_SOURCES
   Test_ApparentHorizonFinder.cpp
+  Test_ComputeExcisionBoundaryVolumeQuantities.cpp
   Test_ComputeHorizonVolumeQuantities.cpp
   Test_ComputeItems.cpp
   Test_FastFlow.cpp

--- a/tests/Unit/ApparentHorizons/Test_ComputeExcisionBoundaryVolumeQuantities.cpp
+++ b/tests/Unit/ApparentHorizons/Test_ComputeExcisionBoundaryVolumeQuantities.cpp
@@ -1,0 +1,382 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <memory>
+
+#include "ApparentHorizons/ComputeExcisionBoundaryVolumeQuantities.hpp"
+#include "ApparentHorizons/ComputeExcisionBoundaryVolumeQuantities.tpp"
+#include "Domain/Block.hpp"
+#include "Domain/Creators/Brick.hpp"
+#include "Domain/Domain.hpp"
+#include "Domain/ElementMap.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Domain/Structure/InitialElementIds.hpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.tpp"
+#include "NumericalAlgorithms/Spectral/LogicalCoordinates.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "ParallelAlgorithms/Interpolation/Protocols/ComputeVarsToInterpolate.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
+#include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/Phi.hpp"
+#include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/Pi.hpp"
+#include "PointwiseFunctions/GeneralRelativity/SpacetimeMetric.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Time/Slab.hpp"
+#include "Time/Time.hpp"
+#include "Time/TimeStepId.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace {
+template <typename IsTimeDependent, typename TargetFrame, typename SrcTags,
+          typename DestTags>
+void test_compute_excision_boundary_volume_quantities() {
+  const size_t number_of_grid_points = 8;
+
+  // slab and temporal_id used only in the TimeDependent version.
+  Slab slab(0.0, 1.0);
+  TimeStepId temporal_id{true, 0, Time(slab, Rational(13, 15))};
+
+  // Create a brick offset from the origin, so a KerrSchild solution
+  // doesn't have a singularity or excision_boundary in the domain.
+  std::unique_ptr<DomainCreator<3>> domain_creator;
+  if constexpr (IsTimeDependent::value) {
+    domain_creator = std::make_unique<domain::creators::Brick>(
+        std::array<double, 3>{3.1, 3.2, 3.3},
+        std::array<double, 3>{4.1, 4.2, 4.3}, std::array<size_t, 3>{0, 0, 0},
+        std::array<size_t, 3>{number_of_grid_points, number_of_grid_points,
+                              number_of_grid_points},
+        std::array<bool, 3>{false, false, false},
+        std::make_unique<
+            domain::creators::time_dependence::UniformTranslation<3>>(
+            0.0, std::array<double, 3>{0.01, 0.02, 0.03}));
+  } else {
+    domain_creator = std::make_unique<domain::creators::Brick>(
+        std::array<double, 3>{3.1, 3.2, 3.3},
+        std::array<double, 3>{4.1, 4.2, 4.3}, std::array<size_t, 3>{0, 0, 0},
+        std::array<size_t, 3>{number_of_grid_points, number_of_grid_points,
+                              number_of_grid_points});
+  }
+  const auto domain = domain_creator->create_domain();
+  ASSERT(domain.blocks().size() == 1, "Expected a Domain with one block");
+
+  const auto element_ids = initial_element_ids(
+      domain.blocks()[0].id(),
+      domain_creator->initial_refinement_levels()[domain.blocks()[0].id()]);
+  ASSERT(element_ids.size() == 1, "Expected a Domain with only one element");
+
+  // Set up target coordinates, and jacobians.
+  // We always compute our source quantities in the inertial frame.
+  // But we want our destination quantities in the target frame.
+  const Mesh mesh{domain_creator->initial_extents()[element_ids[0].block_id()],
+                  Spectral::Basis::Legendre,
+                  Spectral::Quadrature::GaussLobatto};
+  tnsr::I<DataVector, 3, TargetFrame> target_frame_coords{};
+  InverseJacobian<DataVector, 3, Frame::ElementLogical, Frame::Inertial>
+      inv_jacobian_logical_to_inertial{};
+  Jacobian<DataVector, 3, TargetFrame, Frame::Inertial>
+      jacobian_target_to_inertial{};
+  InverseJacobian<DataVector, 3, Frame::ElementLogical, TargetFrame>
+      inv_jacobian_logical_to_target{};
+  if constexpr (IsTimeDependent::value) {
+    ElementMap<3, Frame::Grid> map_logical_to_grid{
+        element_ids[0],
+        domain.blocks()[0].moving_mesh_logical_to_grid_map().get_clone()};
+    const auto inv_jacobian_logical_to_grid =
+        map_logical_to_grid.inv_jacobian(logical_coordinates(mesh));
+    const auto inv_jacobian_grid_to_inertial =
+        domain.blocks()[0].moving_mesh_grid_to_inertial_map().inv_jacobian(
+            map_logical_to_grid(logical_coordinates(mesh)),
+            temporal_id.step_time().value(),
+            domain_creator->functions_of_time());
+    inv_jacobian_logical_to_inertial =
+        InverseJacobian<DataVector, 3, Frame::ElementLogical, Frame::Inertial>(
+            mesh.number_of_grid_points(), 0.0);
+    for (size_t i = 0; i < 3; ++i) {
+      for (size_t j = 0; j < 3; ++j) {
+        for (size_t k = 0; k < 3; ++k) {
+          inv_jacobian_logical_to_inertial.get(i, j) +=
+              inv_jacobian_logical_to_grid.get(k, i) *
+              inv_jacobian_grid_to_inertial.get(j, k);
+        }
+      }
+    }
+    if constexpr (std::is_same_v<TargetFrame, Frame::Grid>) {
+      jacobian_target_to_inertial =
+          domain.blocks()[0].moving_mesh_grid_to_inertial_map().jacobian(
+              map_logical_to_grid(logical_coordinates(mesh)),
+              temporal_id.step_time().value(),
+              domain_creator->functions_of_time());
+      inv_jacobian_logical_to_target = inv_jacobian_logical_to_grid;
+      target_frame_coords = map_logical_to_grid(logical_coordinates(mesh));
+    } else {
+      static_assert(std::is_same_v<TargetFrame, Frame::Inertial>,
+                    "TargetFrame must be the Inertial frame");
+      inv_jacobian_logical_to_target = inv_jacobian_logical_to_inertial;
+      // jacobian_target_to_inertial is the identity in this case.
+      jacobian_target_to_inertial =
+          Jacobian<DataVector, 3, TargetFrame, Frame::Inertial>(
+              mesh.number_of_grid_points(), 0.0);
+      for (size_t i = 0; i < 3; ++i) {
+        jacobian_target_to_inertial.get(i, i) = 1.0;
+      }
+      target_frame_coords =
+          domain.blocks()[0].moving_mesh_grid_to_inertial_map()(
+              map_logical_to_grid(logical_coordinates(mesh)),
+              temporal_id.step_time().value(),
+              domain_creator->functions_of_time());
+    }
+  } else {
+    // time-independent.
+    static_assert(std::is_same_v<TargetFrame, Frame::Inertial>,
+                  "TargetFrame must be the Inertial frame");
+    // Don't need to define jacobian_target_to_inertial
+    ElementMap<3, Frame::Inertial> map_logical_to_inertial{
+        element_ids[0], domain.blocks()[0].stationary_map().get_clone()};
+    target_frame_coords = map_logical_to_inertial(logical_coordinates(mesh));
+    inv_jacobian_logical_to_inertial =
+        map_logical_to_inertial.inv_jacobian(logical_coordinates(mesh));
+    inv_jacobian_logical_to_target = inv_jacobian_logical_to_inertial;
+  }
+
+  // Set up analytic solution.
+  gr::Solutions::KerrSchild solution(1.0, {{0.1, 0.2, 0.3}},
+                                     {{0.03, 0.01, 0.02}});
+  const auto solution_vars_target_frame = solution.variables(
+      target_frame_coords, 0.0,
+      typename gr::Solutions::KerrSchild::tags<DataVector, TargetFrame>{});
+  const auto& lapse =
+      get<gr::Tags::Lapse<DataVector>>(solution_vars_target_frame);
+  const auto& shift = get<gr::Tags::Shift<3, TargetFrame, DataVector>>(
+      solution_vars_target_frame);
+  const auto& spatial_metric =
+      get<gr::Tags::SpatialMetric<3, TargetFrame, DataVector>>(
+          solution_vars_target_frame);
+
+  // Fill src vars with analytic solution.
+  Variables<SrcTags> src_vars(mesh.number_of_grid_points());
+
+  // Inertial metric variables. Needed only if TargetFrame is not Inertial.
+  // Set to zero size if TargetFrame is Inertial.
+  // Define them here, instead of inside the `if constexpr` below,
+  // because we might want to use them in later tests.
+  using inertial_metric_vars_tags =
+      tmpl::list<gr::Tags::Lapse<DataVector>,
+                 gr::Tags::Shift<3, Frame::Inertial, DataVector>,
+                 gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>>;
+  Variables<inertial_metric_vars_tags> inertial_metric_vars([&mesh]() {
+    if constexpr (std::is_same_v<TargetFrame, Frame::Inertial>) {
+      return 0;
+      // silence warning 'lambda capture mesh not used'.
+      (void)mesh;
+    } else {
+      return mesh.number_of_grid_points();
+    }
+  }());
+
+  if constexpr (std::is_same_v<TargetFrame, Frame::Inertial>) {
+    // Src vars are always in inertial frame. Here TargetFrame is inertial,
+    // so no frame transformation is needed.
+
+    get<::gr::Tags::SpacetimeMetric<3, TargetFrame>>(src_vars) =
+        gr::spacetime_metric(lapse, shift, spatial_metric);
+  } else {
+    static_assert(std::is_same_v<TargetFrame, Frame::Grid>,
+                  "TargetFrame must be the Grid frame");
+    // Src vars are always in inertial frame. Here TargetFrame is not
+    // inertial, so we need to transform to the inertial frame.
+
+    // First figure out jacobians
+    const auto coords_frame_velocity_jacobians =
+        domain.blocks()[0]
+            .moving_mesh_grid_to_inertial_map()
+            .coords_frame_velocity_jacobians(
+                target_frame_coords, temporal_id.step_time().value(),
+                domain_creator->functions_of_time());
+    const auto& inv_jacobian_grid_to_inertial =
+        std::get<1>(coords_frame_velocity_jacobians);
+    const auto& jacobian_grid_to_inertial =
+        std::get<2>(coords_frame_velocity_jacobians);
+    const auto& frame_velocity_grid_to_inertial =
+        std::get<3>(coords_frame_velocity_jacobians);
+
+    // Now compute metric variables and transform them into the
+    // inertial frame.  We transform lapse, shift, 3-metric.  Then we
+    // will numerically differentiate transformed 3-metric because we
+    // don't have Hessians and therefore we cannot transform the GH
+    // Phi variable directly.
+
+    // Just copy lapse, since it doesn't transform. Need it for derivs.
+    get<gr::Tags::Lapse<DataVector>>(inertial_metric_vars) = lapse;
+
+    // Transform shift
+    auto& shift_inertial =
+        get<::gr::Tags::Shift<3, Frame::Inertial>>(inertial_metric_vars);
+    for (size_t k = 0; k < 3; ++k) {
+      shift_inertial.get(k) = -frame_velocity_grid_to_inertial.get(k);
+      for (size_t j = 0; j < 3; ++j) {
+        shift_inertial.get(k) +=
+            jacobian_grid_to_inertial.get(k, j) * shift.get(j);
+      }
+    }
+
+    // Transform lower metric.
+    auto& lower_metric_inertial =
+        get<::gr::Tags::SpatialMetric<3, Frame::Inertial>>(
+            inertial_metric_vars);
+    transform::to_different_frame(make_not_null(&lower_metric_inertial),
+                                  spatial_metric,
+                                  inv_jacobian_grid_to_inertial);
+
+    // Now fill src_vars
+    get<::gr::Tags::SpacetimeMetric<3, Frame::Inertial>>(src_vars) =
+        gr::spacetime_metric(lapse, shift_inertial, lower_metric_inertial);
+  }
+
+  // Compute dest_vars
+  Variables<DestTags> dest_vars(mesh.number_of_grid_points());
+  if constexpr (IsTimeDependent::value) {
+    ah::ComputeExcisionBoundaryVolumeQuantities::apply(
+        make_not_null(&dest_vars), src_vars, mesh, jacobian_target_to_inertial,
+        inv_jacobian_logical_to_target);
+  } else {
+    // time-independent.
+    ah::ComputeExcisionBoundaryVolumeQuantities::apply(
+        make_not_null(&dest_vars), src_vars, mesh);
+  }
+
+  // Now make sure that dest vars are correct.
+  if constexpr (tmpl::list_contains_v<
+                    DestTags, gr::Tags::SpatialMetric<3, TargetFrame>>) {
+    const auto& numerical_spatial_metric =
+        get<gr::Tags::SpatialMetric<3, TargetFrame>>(dest_vars);
+    CHECK_ITERABLE_APPROX(spatial_metric, numerical_spatial_metric);
+  }
+
+  if constexpr (tmpl::list_contains_v<
+                    DestTags, gr::Tags::InverseSpatialMetric<3, TargetFrame>>) {
+    const auto& inv_spatial_metric =
+        get<gr::Tags::InverseSpatialMetric<3, TargetFrame>>(dest_vars);
+    CHECK_ITERABLE_APPROX(determinant_and_inverse(spatial_metric).second,
+                          inv_spatial_metric);
+  }
+
+  if constexpr (tmpl::list_contains_v<DestTags, gr::Tags::Lapse<DataVector>>) {
+    const auto& numerical_lapse = get<gr::Tags::Lapse<DataVector>>(dest_vars);
+    CHECK_ITERABLE_APPROX(lapse, numerical_lapse);
+  }
+
+  if constexpr (tmpl::list_contains_v<DestTags,
+                                      gr::Tags::Shift<3, TargetFrame>>) {
+    const auto& numerical_shift =
+        get<gr::Tags::Shift<3, TargetFrame>>(dest_vars);
+    CHECK_ITERABLE_APPROX(shift, numerical_shift);
+  }
+
+  // If TargetFrame is not the same as Inertial frame, we allow
+  // (optional) computation of destination quantities in the inertial frame.
+  // Test these here.
+  if constexpr (not std::is_same_v<TargetFrame, Frame::Inertial>) {
+    if constexpr (tmpl::list_contains_v<
+                      DestTags, gr::Tags::SpatialMetric<3, Frame::Inertial>>) {
+      const auto& expected_inertial_spatial_metric =
+          get<::gr::Tags::SpatialMetric<3, Frame::Inertial>>(
+              inertial_metric_vars);
+      const auto& inertial_spatial_metric =
+          get<gr::Tags::SpatialMetric<3, Frame::Inertial>>(dest_vars);
+      CHECK_ITERABLE_APPROX(expected_inertial_spatial_metric,
+                            inertial_spatial_metric);
+    }
+
+    if constexpr (tmpl::list_contains_v<
+                      DestTags,
+                      gr::Tags::InverseSpatialMetric<3, Frame::Inertial>>) {
+      const auto expected_inertial_inverse_spatial_metric =
+          determinant_and_inverse(
+              get<::gr::Tags::SpatialMetric<3, Frame::Inertial>>(
+                  inertial_metric_vars))
+              .second;
+      const auto& inertial_inverse_spatial_metric =
+          get<gr::Tags::InverseSpatialMetric<3, Frame::Inertial>>(dest_vars);
+      CHECK_ITERABLE_APPROX(expected_inertial_inverse_spatial_metric,
+                            inertial_inverse_spatial_metric);
+    }
+
+    if constexpr (tmpl::list_contains_v<DestTags,
+                                        gr::Tags::Shift<3, Frame::Inertial>>) {
+      const auto& expected_inertial_shift =
+          get<gr::Tags::Shift<3, Frame::Inertial>>(inertial_metric_vars);
+      const auto& inertial_shift =
+          get<gr::Tags::Shift<3, Frame::Inertial>>(dest_vars);
+      CHECK_ITERABLE_APPROX(expected_inertial_shift, inertial_shift);
+    }
+  }
+}
+
+SPECTRE_TEST_CASE(
+    "Unit.ApparentHorizons.ComputeExcisionBoundaryVolumeQuantities",
+    "[ApparentHorizons][Unit]") {
+  static_assert(
+      tt::assert_conforms_to_v<ah::ComputeExcisionBoundaryVolumeQuantities,
+                               intrp::protocols::ComputeVarsToInterpolate>);
+    // time-independent.
+    // All possible tags.
+  test_compute_excision_boundary_volume_quantities<
+      std::false_type, Frame::Inertial,
+      tmpl::list<gr::Tags::SpacetimeMetric<3, Frame::Inertial>,
+                 GeneralizedHarmonic::Tags::Pi<3, Frame::Inertial>,
+                 GeneralizedHarmonic::Tags::Phi<3, Frame::Inertial>,
+                 Tags::deriv<GeneralizedHarmonic::Tags::Phi<3, Frame::Inertial>,
+                             tmpl::size_t<3>, Frame::Inertial>>,
+      tmpl::list<gr::Tags::SpacetimeMetric<3, Frame::Inertial>,
+                 gr::Tags::SpatialMetric<3, Frame::Inertial>,
+                 gr::Tags::Lapse<DataVector>,
+                 gr::Tags::Shift<3, Frame::Inertial>>>();
+
+  // Leave out a few tags.
+  test_compute_excision_boundary_volume_quantities<
+      std::false_type, Frame::Inertial,
+      tmpl::list<gr::Tags::SpacetimeMetric<3, Frame::Inertial>,
+                 GeneralizedHarmonic::Tags::Pi<3, Frame::Inertial>,
+                 GeneralizedHarmonic::Tags::Phi<3, Frame::Inertial>>,
+      tmpl::list<gr::Tags::SpacetimeMetric<3, Frame::Inertial>,
+                 gr::Tags::SpatialMetric<3, Frame::Inertial>,
+                 gr::Tags::Lapse<DataVector>>>();
+
+  test_compute_excision_boundary_volume_quantities<
+      std::false_type, Frame::Inertial,
+      tmpl::list<gr::Tags::SpacetimeMetric<3, Frame::Inertial>,
+                 GeneralizedHarmonic::Tags::Pi<3, Frame::Inertial>,
+                 GeneralizedHarmonic::Tags::Phi<3, Frame::Inertial>>,
+      tmpl::list<gr::Tags::SpacetimeMetric<3, Frame::Inertial>,
+                 gr::Tags::SpatialMetric<3, Frame::Inertial>,
+                 gr::Tags::Shift<3, Frame::Inertial>>>();
+
+  // time-dependent.
+  // All possible tags.
+  test_compute_excision_boundary_volume_quantities<
+      std::true_type, Frame::Grid,
+      tmpl::list<gr::Tags::SpacetimeMetric<3, Frame::Inertial>,
+                 GeneralizedHarmonic::Tags::Pi<3, Frame::Inertial>,
+                 GeneralizedHarmonic::Tags::Phi<3, Frame::Inertial>,
+                 Tags::deriv<GeneralizedHarmonic::Tags::Phi<3, Frame::Inertial>,
+                             tmpl::size_t<3>, Frame::Inertial>>,
+      tmpl::list<gr::Tags::SpacetimeMetric<3, Frame::Inertial>,
+                 gr::Tags::SpatialMetric<3, Frame::Inertial>,
+                 gr::Tags::Lapse<DataVector>,
+                 gr::Tags::Shift<3, Frame::Inertial>>>();
+
+  // Leave out a few tags.
+  test_compute_excision_boundary_volume_quantities<
+      std::true_type, Frame::Grid,
+      tmpl::list<gr::Tags::SpacetimeMetric<3, Frame::Inertial>,
+                 GeneralizedHarmonic::Tags::Pi<3, Frame::Inertial>,
+                 GeneralizedHarmonic::Tags::Phi<3, Frame::Inertial>>,
+      tmpl::list<gr::Tags::SpacetimeMetric<3, Frame::Inertial>,
+                 gr::Tags::SpatialMetric<3, Frame::Inertial>>>();
+}
+}  // namespace


### PR DESCRIPTION
## Proposed changes

This is in the series of PRs that is working towards observing the char speeds on the excision surface.
This PR adds the ExcisionBoundaryA InterpolationTarget. The target points are given by a Sphere in
Frame::Grid. As the Shape maps do not change the angular locations of the collocation points on the surface, we
can use this target to interpolate Frame::Inertial quantities onto the excision boundary.

Addresses #4591 

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
