### PR TITLE
Print exception type

### DIFF
--- a/docs/DevGuide/DebuggingTips.md
+++ b/docs/DevGuide/DebuggingTips.md
@@ -1,0 +1,18 @@
+\cond NEVER
+Distributed under the MIT License.
+See LICENSE.txt for details.
+\endcond
+
+# Tips for debugging an executable {#runtime_errors}
+
+Learn how to use a debugger such as gdb.
+
+# Useful gdb commands
+
+- To break when an exception is thrown `catch throw`
+
+- To break on a specific exception type `catch throw std::out_of_range`
+  (This may not work on all compilers or older versions of gdb.  In this
+  case you also try setting a breakpoint on the constructor of the exception
+  type, `break std::out_of_range::out_of_range`)
+

--- a/docs/DevGuide/DevGuide.md
+++ b/docs/DevGuide/DevGuide.md
@@ -34,6 +34,7 @@ Methods for creating custom coordinate maps are discussed here.
 - \subpage static_analysis_tools "Static analysis tools"
 - \subpage build_profiling_and_optimization - Getting started with improving
   compilation time and memory use
+- \subpage runtime_errors "Tips for debugging an executable"
 
 ### Foundational Concepts in SpECTRE
 Designed to give the reader an introduction to SpECTRE's most recurring concepts

--- a/src/Parallel/DistributedObject.hpp
+++ b/src/Parallel/DistributedObject.hpp
@@ -1186,7 +1186,10 @@ void DistributedObject<ParallelComponent,
         "an issue.");
     sys::abort("");
   }
-  main_proxy.value().add_exception_message(std::string{exception.what()});
+  const std::string message = MakeString{}
+                              << "Message: " << exception.what() << "\nType: "
+                              << pretty_type::get_runtime_type_name(exception);
+  main_proxy.value().add_exception_message(message);
   set_terminate(true);
 }
 /// \endcond


### PR DESCRIPTION
## Proposed changes

When printing all exceptions caught by a DistributedObject, print the exception type in addition to the message.

This information can be used (with recent versions of gdb) to `catch throw <exception_type>` in order to set breakpoints
for only a certain exception type.

Also document some gdb tips.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
