### PR TITLE
Rename objects in BBH domains

### DIFF
--- a/src/ControlSystem/ControlErrors/Expansion.hpp
+++ b/src/ControlSystem/ControlErrors/Expansion.hpp
@@ -42,8 +42,8 @@ namespace ControlErrors {
  *   \delta a &= a\left( \frac{\vec{X}\cdot\vec{C}}{||\vec{C}||^2} - 1 \right)
  * \\ \delta a &= a\left( \frac{X_0}{C_0} - 1 \right) \f}
  *
- * where \f$\vec{X} = \vec{x}_B - \vec{x}_A\f$ and \f$\vec{C} = \vec{c}_B -
- * \vec{c}_A\f$. Here, object B is located on the positive x-axis and object A
+ * where \f$\vec{X} = \vec{x}_A - \vec{x}_B\f$ and \f$\vec{C} = \vec{c}_A -
+ * \vec{c}_B\f$. Here, object A is located on the positive x-axis and object B
  * is located on the negative x-axis, \f$\vec{X}\f$ is the difference in
  * positions of the centers of the mapped objects, and
  * \f$\vec{C}\f$ is the difference of the centers of the excision spheres, all
@@ -88,11 +88,11 @@ struct Expansion : tt::ConformsTo<protocols::ControlError> {
     const double current_position_of_B = get<center_B>(measurements)[0];
 
     // A is to the left of B in grid frame. To get positive differences,
-    // take B - A
+    // take A - B
     const double expected_expansion_factor =
         current_expansion_factor *
-        (current_position_of_B - current_position_of_A) /
-        (grid_position_of_B - grid_position_of_A);
+        (current_position_of_A - current_position_of_B) /
+        (grid_position_of_A - grid_position_of_B);
 
     return {expected_expansion_factor - current_expansion_factor};
   }

--- a/src/ControlSystem/ControlErrors/Expansion.hpp
+++ b/src/ControlSystem/ControlErrors/Expansion.hpp
@@ -83,17 +83,23 @@ struct Expansion : tt::ConformsTo<protocols::ControlError> {
     using center_A = control_system::QueueTags::Center<::ah::ObjectLabel::A>;
     using center_B = control_system::QueueTags::Center<::ah::ObjectLabel::B>;
 
-    ASSERT(domain.excision_spheres().count("ObjectAExcisionSphere") == 1,
+    ASSERT(domain.excision_spheres().count(
+               "PrimaryRightObjectAExcisionSphere") == 1,
            "Excision sphere for ObjectA not in the domain but is needed to "
            "compute Expansion control error.");
-    ASSERT(domain.excision_spheres().count("ObjectBExcisionSphere") == 1,
+    ASSERT(domain.excision_spheres().count(
+               "SecondaryLeftObjectBExcisionSphere") == 1,
            "Excision sphere for ObjectB not in the domain but is needed to "
            "compute Expansion control error.");
 
     const double grid_position_of_A =
-        domain.excision_spheres().at("ObjectAExcisionSphere").center()[0];
+        domain.excision_spheres()
+            .at("PrimaryRightObjectAExcisionSphere")
+            .center()[0];
     const double grid_position_of_B =
-        domain.excision_spheres().at("ObjectBExcisionSphere").center()[0];
+        domain.excision_spheres()
+            .at("SecondaryLeftObjectBExcisionSphere")
+            .center()[0];
     const double current_position_of_A = get<center_A>(measurements)[0];
     const double current_position_of_B = get<center_B>(measurements)[0];
 

--- a/src/ControlSystem/ControlErrors/Expansion.hpp
+++ b/src/ControlSystem/ControlErrors/Expansion.hpp
@@ -14,6 +14,7 @@
 #include "DataStructures/DataVector.hpp"
 #include "Options/Options.hpp"
 #include "Parallel/GlobalCache.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
@@ -59,6 +60,8 @@ namespace ControlErrors {
  *   control_system::Systems::Expansion Expansion \endlink control system
  */
 struct Expansion : tt::ConformsTo<protocols::ControlError> {
+  static constexpr size_t expected_number_of_excisions = 2;
+
   using options = tmpl::list<>;
   static constexpr Options::String help{
       "Computes the control error for expansion control. This should not "
@@ -79,6 +82,13 @@ struct Expansion : tt::ConformsTo<protocols::ControlError> {
 
     using center_A = control_system::QueueTags::Center<::ah::ObjectLabel::A>;
     using center_B = control_system::QueueTags::Center<::ah::ObjectLabel::B>;
+
+    ASSERT(domain.excision_spheres().count("ObjectAExcisionSphere") == 1,
+           "Excision sphere for ObjectA not in the domain but is needed to "
+           "compute Expansion control error.");
+    ASSERT(domain.excision_spheres().count("ObjectBExcisionSphere") == 1,
+           "Excision sphere for ObjectB not in the domain but is needed to "
+           "compute Expansion control error.");
 
     const double grid_position_of_A =
         domain.excision_spheres().at("ObjectAExcisionSphere").center()[0];

--- a/src/ControlSystem/ControlErrors/Rotation.hpp
+++ b/src/ControlSystem/ControlErrors/Rotation.hpp
@@ -74,17 +74,23 @@ struct Rotation : tt::ConformsTo<protocols::ControlError> {
     using center_A = control_system::QueueTags::Center<::ah::ObjectLabel::A>;
     using center_B = control_system::QueueTags::Center<::ah::ObjectLabel::B>;
 
-    ASSERT(domain.excision_spheres().count("ObjectAExcisionSphere") == 1,
+    ASSERT(domain.excision_spheres().count(
+               "PrimaryRightObjectAExcisionSphere") == 1,
            "Excision sphere for ObjectA not in the domain but is needed to "
            "compute Rotation control error.");
-    ASSERT(domain.excision_spheres().count("ObjectBExcisionSphere") == 1,
+    ASSERT(domain.excision_spheres().count(
+               "SecondaryLeftObjectBExcisionSphere") == 1,
            "Excision sphere for ObjectB not in the domain but is needed to "
            "compute Rotation control error.");
 
-    const DataVector grid_position_of_A = array_to_datavector(
-        domain.excision_spheres().at("ObjectAExcisionSphere").center());
-    const DataVector grid_position_of_B = array_to_datavector(
-        domain.excision_spheres().at("ObjectBExcisionSphere").center());
+    const DataVector grid_position_of_A =
+        array_to_datavector(domain.excision_spheres()
+                                .at("PrimaryRightObjectAExcisionSphere")
+                                .center());
+    const DataVector grid_position_of_B =
+        array_to_datavector(domain.excision_spheres()
+                                .at("SecondaryLeftObjectBExcisionSphere")
+                                .center());
     const DataVector& current_position_of_A = get<center_A>(measurements);
     const DataVector& current_position_of_B = get<center_B>(measurements);
 

--- a/src/ControlSystem/ControlErrors/Rotation.hpp
+++ b/src/ControlSystem/ControlErrors/Rotation.hpp
@@ -14,6 +14,7 @@
 #include "DataStructures/DataVector.hpp"
 #include "Options/Options.hpp"
 #include "Parallel/GlobalCache.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
@@ -54,6 +55,8 @@ namespace ControlErrors {
  *   control_system::Systems::Rotation Rotation \endlink control system
  */
 struct Rotation : tt::ConformsTo<protocols::ControlError> {
+  static constexpr size_t expected_number_of_excisions = 2;
+
   using options = tmpl::list<>;
   static constexpr Options::String help{
       "Computes the control error for rotation control. This should not "
@@ -70,6 +73,13 @@ struct Rotation : tt::ConformsTo<protocols::ControlError> {
 
     using center_A = control_system::QueueTags::Center<::ah::ObjectLabel::A>;
     using center_B = control_system::QueueTags::Center<::ah::ObjectLabel::B>;
+
+    ASSERT(domain.excision_spheres().count("ObjectAExcisionSphere") == 1,
+           "Excision sphere for ObjectA not in the domain but is needed to "
+           "compute Rotation control error.");
+    ASSERT(domain.excision_spheres().count("ObjectBExcisionSphere") == 1,
+           "Excision sphere for ObjectB not in the domain but is needed to "
+           "compute Rotation control error.");
 
     const DataVector grid_position_of_A = array_to_datavector(
         domain.excision_spheres().at("ObjectAExcisionSphere").center());

--- a/src/ControlSystem/ControlErrors/Rotation.hpp
+++ b/src/ControlSystem/ControlErrors/Rotation.hpp
@@ -39,8 +39,8 @@ namespace ControlErrors {
  *
  * \f[ \delta\vec{q} = \frac{\vec{C}\times\vec{X}}{\vec{C}\cdot\vec{X}} \f]
  *
- * where \f$\vec{X} = \vec{x}_B - \vec{x}_A\f$ and \f$\vec{C} = \vec{c}_B -
- * \vec{c}_A\f$. Here, object B is located on the positive x-axis and object A
+ * where \f$\vec{X} = \vec{x}_A - \vec{x}_B\f$ and \f$\vec{C} = \vec{c}_A -
+ * \vec{c}_B\f$. Here, object A is located on the positive x-axis and object B
  * is located on the negative x-axis, \f$\vec{X}\f$ is the difference in
  * positions of the centers of the mapped objects, and
  * \f$\vec{C}\f$ is the difference of the centers of the excision spheres, all
@@ -78,11 +78,11 @@ struct Rotation : tt::ConformsTo<protocols::ControlError> {
     const DataVector& current_position_of_A = get<center_A>(measurements);
     const DataVector& current_position_of_B = get<center_B>(measurements);
 
-    // A is to the left of B in grid frame. To get positive differences,
-    // take B - A
-    const DataVector grid_diff = grid_position_of_B - grid_position_of_A;
+    // B is to the left of A in grid frame. To get positive differences,
+    // take A - B
+    const DataVector grid_diff = grid_position_of_A - grid_position_of_B;
     const DataVector current_diff =
-        current_position_of_B - current_position_of_A;
+        current_position_of_A - current_position_of_B;
 
     const double grid_dot_current = dot(grid_diff, current_diff);
     const DataVector grid_cross_current = cross(grid_diff, current_diff);

--- a/src/ControlSystem/ControlErrors/Shape.hpp
+++ b/src/ControlSystem/ControlErrors/Shape.hpp
@@ -88,6 +88,8 @@ std::string size_name() {
  */
 template <::ah::ObjectLabel Horizon>
 struct Shape : tt::ConformsTo<protocols::ControlError> {
+  static constexpr size_t expected_number_of_excisions = 1;
+
   using options = tmpl::list<>;
   static constexpr Options::String help{
       "Computes the control error for shape control. This should not take any "
@@ -119,6 +121,13 @@ struct Shape : tt::ConformsTo<protocols::ControlError> {
                << ah_coefs.size() << ").");
 
     const auto& excision_spheres = domain.excision_spheres();
+
+    ASSERT(domain.excision_spheres().count(
+               detail::excision_sphere_name<Horizon>()) == 1,
+           "Excision sphere " << detail::excision_sphere_name<Horizon>()
+                              << " not in the domain but is needed to "
+                                 "compute Shape control error.");
+
     // See above docs for why we have the sqrt(pi/2)
     const double radius_excision_sphere_grid_frame =
         sqrt(0.5 * M_PI) *

--- a/src/ControlSystem/ControlErrors/Shape.hpp
+++ b/src/ControlSystem/ControlErrors/Shape.hpp
@@ -39,7 +39,8 @@ namespace ControlErrors {
 namespace detail {
 template <::ah::ObjectLabel Horizon>
 std::string excision_sphere_name() {
-  return "Object"s + ::ah::name(Horizon) + "ExcisionSphere"s;
+  return Horizon == ::ah::ObjectLabel::A ? "PrimaryRightObjectAExcisionSphere"
+                                         : "SecondaryLeftObjectBExcisionSphere";
 }
 
 template <::ah::ObjectLabel Horizon>

--- a/src/ControlSystem/ControlErrors/Translation.hpp
+++ b/src/ControlSystem/ControlErrors/Translation.hpp
@@ -95,12 +95,15 @@ struct Translation : tt::ConformsTo<protocols::ControlError> {
 
     using center_A = control_system::QueueTags::Center<::ah::ObjectLabel::A>;
 
-    ASSERT(domain.excision_spheres().count("ObjectAExcisionSphere") == 1,
+    ASSERT(domain.excision_spheres().count(
+               "PrimaryRightObjectAExcisionSphere") == 1,
            "Excision sphere for ObjectA not in the domain but is needed to "
            "compute Translation control error.");
 
-    const DataVector grid_position_of_A = array_to_datavector(
-        domain.excision_spheres().at("ObjectAExcisionSphere").center());
+    const DataVector grid_position_of_A =
+        array_to_datavector(domain.excision_spheres()
+                                .at("PrimaryRightObjectAExcisionSphere")
+                                .center());
     const DataVector& current_position_of_A = get<center_A>(measurements);
 
     const DataVector rotation_error =

--- a/src/ControlSystem/ControlErrors/Translation.hpp
+++ b/src/ControlSystem/ControlErrors/Translation.hpp
@@ -42,19 +42,19 @@ namespace ControlErrors {
  * \details Computes the error in how much the system has translated by using
  * Eq. (42) from \cite Ossokine2013zga. The equation is
  *
- * \f[ \left(0, \delta\vec{T}\right) = a\mathbf{q}\left(\mathbf{x}_B -
- * \mathbf{c}_B - \mathbf{\delta q}\wedge\mathbf{c}_B - \frac{\delta
- * a}{a}\mathbf{c}_B \right)\mathbf{q}^*
+ * \f[ \left(0, \delta\vec{T}\right) = a\mathbf{q}\left(\mathbf{x}_A -
+ * \mathbf{c}_A - \mathbf{\delta q}\wedge\mathbf{c}_A - \frac{\delta
+ * a}{a}\mathbf{c}_A \right)\mathbf{q}^*
  * \f]
  *
- * where object B is located on the positive x-axis, bold face letters are
+ * where object A is located on the positive x-axis, bold face letters are
  * quaternions, vectors are promoted to quaternions as \f$ \mathbf{v} = (0,
  * \vec{v}) \f$, \f$ \mathbf{q} \f$ is the quaternion from the \link
  * domain::CoordinateMaps::TimeDependent::Rotation Rotation \endlink map, \f$ a
  * \f$ is the function \f$ a(t) \f$ from the \link
  * domain::CoordinateMaps::TimeDependent::CubicScale CubicScale \endlink map,
- * \f$ \mathbf{\delta q}\wedge\mathbf{c}_B \equiv (0, \delta\vec{q} \times
- * \vec{c}_B) \f$, \f$ \delta\vec{q} \f$ is the \link
+ * \f$ \mathbf{\delta q}\wedge\mathbf{c}_A \equiv (0, \delta\vec{q} \times
+ * \vec{c}_A) \f$, \f$ \delta\vec{q} \f$ is the \link
  * control_system::ControlErrors::Rotation Rotation \endlink control error, and
  * \f$ \delta a\f$ is the \link control_system::ControlErrors::Expansion
  * Expansion \endlink control error.
@@ -91,27 +91,27 @@ struct Translation : tt::ConformsTo<protocols::ControlError> {
     const double expansion_factor =
         functions_of_time.at("Expansion")->func(time)[0][0];
 
-    using center_B = control_system::QueueTags::Center<::ah::ObjectLabel::B>;
+    using center_A = control_system::QueueTags::Center<::ah::ObjectLabel::A>;
 
-    const DataVector grid_position_of_B = array_to_datavector(
-        domain.excision_spheres().at("ObjectBExcisionSphere").center());
-    const DataVector& current_position_of_B = get<center_B>(measurements);
+    const DataVector grid_position_of_A = array_to_datavector(
+        domain.excision_spheres().at("ObjectAExcisionSphere").center());
+    const DataVector& current_position_of_A = get<center_A>(measurements);
 
     const DataVector rotation_error =
         rotation_control_error_(cache, time, "Rotation", measurements);
-    // Use B because it's on the positive x-axis, however, A would work as well.
+    // Use A because it's on the positive x-axis, however, B would work as well.
     // Just so long as we are consistent.
-    const DataVector rotation_error_cross_grid_pos_B =
-        cross(rotation_error, grid_position_of_B);
+    const DataVector rotation_error_cross_grid_pos_A =
+        cross(rotation_error, grid_position_of_A);
 
     const double expansion_error =
         expansion_control_error_(cache, time, "Expansion", measurements)[0];
 
     // From eq. 42 in 1304.3067
     const quat middle_expression = datavector_to_quaternion(
-        current_position_of_B -
-        (1.0 + expansion_error / expansion_factor) * grid_position_of_B -
-        rotation_error_cross_grid_pos_B);
+        current_position_of_A -
+        (1.0 + expansion_error / expansion_factor) * grid_position_of_A -
+        rotation_error_cross_grid_pos_A);
 
     // Because we are converting from a quaternion to a DataVector, there will
     // be four components in the DataVector. However, translation control only

--- a/src/ControlSystem/ControlErrors/Translation.hpp
+++ b/src/ControlSystem/ControlErrors/Translation.hpp
@@ -69,6 +69,8 @@ namespace ControlErrors {
  *   coordinate map with names "Expansion" and "Rotation", respectively.
  */
 struct Translation : tt::ConformsTo<protocols::ControlError> {
+  static constexpr size_t expected_number_of_excisions = 2;
+
   using options = tmpl::list<>;
   static constexpr Options::String help{
       "Computes the control error for translation control. This should not "
@@ -92,6 +94,10 @@ struct Translation : tt::ConformsTo<protocols::ControlError> {
         functions_of_time.at("Expansion")->func(time)[0][0];
 
     using center_A = control_system::QueueTags::Center<::ah::ObjectLabel::A>;
+
+    ASSERT(domain.excision_spheres().count("ObjectAExcisionSphere") == 1,
+           "Excision sphere for ObjectA not in the domain but is needed to "
+           "compute Translation control error.");
 
     const DataVector grid_position_of_A = array_to_datavector(
         domain.excision_spheres().at("ObjectAExcisionSphere").center());

--- a/src/ControlSystem/Protocols/ControlError.hpp
+++ b/src/ControlSystem/Protocols/ControlError.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include <string>
 #include <type_traits>
 
@@ -21,12 +22,18 @@ namespace control_system::protocols {
 ///
 /// - a call operator that returns a DataVector with a signature the same as in
 ///   the example shown here:
+/// - a `static constexpr size_t expected_number_of_excisions` which specifies
+///   the number of excisions necessary in order to compute the control error.
+///
 ///   \snippet Helpers/ControlSystem/Examples.hpp ControlError
 struct ControlError {
   template <typename ConformingType>
   struct test {
     struct DummyMetavariables;
     struct DummyTupleTags;
+
+    static constexpr size_t expected_number_of_excisions =
+        ConformingType::expected_number_of_excisions;
 
     static_assert(
         std::is_same_v<

--- a/src/ControlSystem/Tags.hpp
+++ b/src/ControlSystem/Tags.hpp
@@ -18,8 +18,10 @@
 #include "Domain/Creators/DomainCreator.hpp"
 #include "NumericalAlgorithms/SphericalHarmonics/Strahlkorper.hpp"
 #include "Options/Options.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
+#include "Utilities/StdHelpers.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TypeTraits/CreateHasStaticMemberVariable.hpp"
 
@@ -235,11 +237,53 @@ template <typename ControlSystem>
 struct ControlError : db::SimpleTag {
   using type = typename ControlSystem::control_error;
 
+  template <typename Metavariables>
   using option_tags =
-      tmpl::list<OptionTags::ControlSystemInputs<ControlSystem>>;
-  static constexpr bool pass_metavariables = false;
+      tmpl::list<OptionTags::ControlSystemInputs<ControlSystem>,
+                 domain::OptionTags::DomainCreator<Metavariables::volume_dim>>;
+  static constexpr bool pass_metavariables = true;
+
+  template <typename Metavariables>
   static type create_from_options(
-      const control_system::OptionHolder<ControlSystem>& option_holder) {
+      const control_system::OptionHolder<ControlSystem>& option_holder,
+      const std::unique_ptr<::DomainCreator<Metavariables::volume_dim>>&
+          domain_creator) {
+    const auto domain = domain_creator->create_domain();
+    const auto& excision_spheres = domain.excision_spheres();
+
+    constexpr size_t expected_number_of_excisions =
+        type::expected_number_of_excisions;
+
+    const auto print_error =
+        [&excision_spheres](const std::string& excision_sphere_name) {
+          ERROR_NO_TRACE(
+              "The control error for the"
+              << pretty_type::name<type>()
+              << " control system expected there to be at least one excision "
+                 "sphere named '"
+              << excision_sphere_name
+              << "' in the domain, but there wasn't. The existing excision "
+                 "spheres are: "
+              << keys_of(excision_spheres)
+              << ". Check that the domain you have chosen has excision spheres "
+                 "implemented.");
+        };
+
+    if constexpr (expected_number_of_excisions == 1) {
+      if (excision_spheres.count("ObjectAExcisionSphere") != 1 and
+          excision_spheres.count("ObjectBExcisionSphere") != 1) {
+        print_error("ObjectAExcisionSphere' or 'ObjectBExcisionSphere");
+      }
+    }
+    if constexpr (expected_number_of_excisions == 2) {
+      if (excision_spheres.count("ObjectAExcisionSphere") != 1) {
+        print_error("ObjectAExcisionSphere");
+      }
+      if (excision_spheres.count("ObjectBExcisionSphere") != 1) {
+        print_error("ObjectBExcisionSphere");
+      }
+    }
+
     return option_holder.control_error;
   }
 };

--- a/src/ControlSystem/Tags.hpp
+++ b/src/ControlSystem/Tags.hpp
@@ -270,17 +270,19 @@ struct ControlError : db::SimpleTag {
         };
 
     if constexpr (expected_number_of_excisions == 1) {
-      if (excision_spheres.count("ObjectAExcisionSphere") != 1 and
-          excision_spheres.count("ObjectBExcisionSphere") != 1) {
-        print_error("ObjectAExcisionSphere' or 'ObjectBExcisionSphere");
+      if (excision_spheres.count("PrimaryRightObjectAExcisionSphere") != 1 and
+          excision_spheres.count("SecondaryLeftObjectBExcisionSphere") != 1) {
+        print_error(
+            "PrimaryRightObjectAExcisionSphere' or "
+            "'SecondaryLeftObjectBExcisionSphere");
       }
     }
     if constexpr (expected_number_of_excisions == 2) {
-      if (excision_spheres.count("ObjectAExcisionSphere") != 1) {
-        print_error("ObjectAExcisionSphere");
+      if (excision_spheres.count("PrimaryRightObjectAExcisionSphere") != 1) {
+        print_error("PrimaryRightObjectAExcisionSphere");
       }
-      if (excision_spheres.count("ObjectBExcisionSphere") != 1) {
-        print_error("ObjectBExcisionSphere");
+      if (excision_spheres.count("SecondaryLeftObjectBExcisionSphere") != 1) {
+        print_error("SecondaryLeftObjectBExcisionSphere");
       }
     }
 

--- a/src/Domain/Creators/BinaryCompactObject.cpp
+++ b/src/Domain/Creators/BinaryCompactObject.cpp
@@ -106,6 +106,7 @@ BinaryCompactObject::BinaryCompactObject(
     number_of_blocks_++;
   }
 
+  // Parsing checks
   if (object_A_.x_coord <= 0.0) {
     PARSE_ERROR(
         context,
@@ -123,6 +124,27 @@ BinaryCompactObject::BinaryCompactObject(
         "The radius for the enveloping cube is too small! The Frustums will be "
         "malformed. A recommended radius is:\n"
             << suggested_value);
+  }
+  if (object_A_.inner_radius <= 0.0) {
+    PARSE_ERROR(context, "ObjectA's inner radius must be positive.");
+  }
+  if (object_B_.inner_radius <= 0.0) {
+    PARSE_ERROR(context, "ObjectB's inner radius must be positive.");
+  }
+  if (object_A_.is_excised() and object_B_.is_excised()) {
+    if (object_A_.inner_radius < object_B_.inner_radius) {
+      PARSE_ERROR(context,
+                  "ObjectA's inner radius should not be smaller than ObjectB's "
+                  "inner radius");
+    }
+    if (std::abs(object_A_.x_coord) > std::abs(object_B_.x_coord)) {
+      PARSE_ERROR(
+          context,
+          "When both objects are excised, we expect |x_A| <= |x_B|, the "
+          "x-coordinates of both objects.  We should roughly have "
+          "ObjectA.inner_radius * x_A + objectB.inner_radius * x_B = 0 (i.e. "
+          "for BBHs the center of mass should be about at the origin).");
+    }
   }
   if (object_A_.outer_radius < object_A_.inner_radius) {
     PARSE_ERROR(context,

--- a/src/Domain/Creators/BinaryCompactObject.cpp
+++ b/src/Domain/Creators/BinaryCompactObject.cpp
@@ -108,14 +108,14 @@ BinaryCompactObject::BinaryCompactObject(
 
   // Parsing checks
   if (object_A_.x_coord <= 0.0) {
-    PARSE_ERROR(
-        context,
-        "The x-coordinate of ObjectA's center is expected to be positive.");
+    PARSE_ERROR(context,
+                "The x-coordinate of PrimaryRightObjectA's center is expected "
+                "to be positive.");
   }
   if (object_B_.x_coord >= 0.0) {
-    PARSE_ERROR(
-        context,
-        "The x-coordinate of ObjectB's center is expected to be negative.");
+    PARSE_ERROR(context,
+                "The x-coordinate of SecondaryLeftObjectB's center is expected "
+                "to be negative.");
   }
   if (length_outer_cube_ <= 2.0 * length_inner_cube_) {
     const double suggested_value = 2.0 * length_inner_cube_ * sqrt(3.0);
@@ -148,11 +148,13 @@ BinaryCompactObject::BinaryCompactObject(
   }
   if (object_A_.outer_radius < object_A_.inner_radius) {
     PARSE_ERROR(context,
-                "ObjectA's inner radius must be less than its outer radius.");
+                "PrimaryRightObjectA's inner radius must be less than its "
+                "outer radius.");
   }
   if (object_B_.outer_radius < object_B_.inner_radius) {
     PARSE_ERROR(context,
-                "ObjectB's inner radius must be less than its outer radius.");
+                "SecondaryLeftObjectB's inner radius must be less than its "
+                "outer radius.");
   }
   if (object_A_.use_logarithmic_map and not object_A_.is_excised()) {
     PARSE_ERROR(
@@ -232,20 +234,20 @@ BinaryCompactObject::BinaryCompactObject(
       }
     }
   };
-  add_object_region("ObjectB", "Shell");  // 6 blocks
-  add_object_region("ObjectB", "Cube");   // 6 blocks
-  add_object_region("ObjectA", "Shell");  // 6 blocks
-  add_object_region("ObjectA", "Cube");   // 6 blocks
-  add_outer_region("EnvelopingCube");     // 10 blocks
+  add_object_region("SecondaryLeftObjectB", "Shell");  // 6 blocks
+  add_object_region("SecondaryLeftObjectB", "Cube");   // 6 blocks
+  add_object_region("PrimaryRightObjectA", "Shell");   // 6 blocks
+  add_object_region("PrimaryRightObjectA", "Cube");    // 6 blocks
+  add_outer_region("EnvelopingCube");                  // 10 blocks
   if (need_cube_to_sphere_transition_) {
     add_outer_region("CubedShell");  // 10 blocks
   }
   add_outer_region("OuterShell");  // 10 blocks
   if (not object_A_.is_excised()) {
-    add_object_interior("ObjectA");  // 1 block
+    add_object_interior("PrimaryRightObjectA");  // 1 block
   }
   if (not object_B_.is_excised()) {
-    add_object_interior("ObjectB");  // 1 block
+    add_object_interior("SecondaryLeftObjectB");  // 1 block
   }
   ASSERT(block_names_.size() == number_of_blocks_,
          "Number of block names (" << block_names_.size()
@@ -387,7 +389,7 @@ Domain<3> BinaryCompactObject::create_domain() const {
   // Each object is surrounded by 6 inner wedges that make a sphere, and another
   // 6 outer wedges that transition to a cube.
 
-  // ObjectA/B is on the right/left, respectively.
+  // PrimaryRightObjectA/B is on the right/left, respectively.
   const Translation translation_A{
       Affine{-1.0, 1.0, -1.0 + object_A_.x_coord, 1.0 + object_A_.x_coord},
       Identity2D{}};
@@ -528,7 +530,7 @@ Domain<3> BinaryCompactObject::create_domain() const {
   std::unordered_map<std::string, ExcisionSphere<3>> excision_spheres{};
   if (object_A_.is_excised()) {
     excision_spheres.emplace(
-        "ObjectAExcisionSphere",
+        "PrimaryRightObjectAExcisionSphere",
         ExcisionSphere<3>{object_A_.inner_radius,
                           {{object_A_.x_coord, 0.0, 0.0}},
                           {{12, Direction<3>::lower_zeta()},
@@ -540,7 +542,7 @@ Domain<3> BinaryCompactObject::create_domain() const {
   }
   if (object_B_.is_excised()) {
     excision_spheres.emplace(
-        "ObjectBExcisionSphere",
+        "SecondaryLeftObjectBExcisionSphere",
         ExcisionSphere<3>{object_B_.inner_radius,
                           {{object_B_.x_coord, 0.0, 0.0}},
                           {{0, Direction<3>::lower_zeta()},

--- a/src/Domain/Creators/BinaryCompactObject.hpp
+++ b/src/Domain/Creators/BinaryCompactObject.hpp
@@ -120,21 +120,23 @@ namespace creators {
  *      compact objects. This layer can be h-refined radially,
  *      creating a layer of multiple concentric spherical shells.
  *
- * In the code and options below, `ObjectA` and `ObjectB` refer to the two
- * compact objects, and by extension, also refer to the layers that immediately
- * surround each compact object. Note that `ObjectA` is located to the right of
- * the origin (along the positive x-axis) and `ObjectB` is located to the left
- * of the origin. If both objects are excised, then `ObjectA` must be the larger
- * object (larger inner radius and x-coord smaller in magnitude). `enveloping
- * cube` refers to the outer surface of Layer 3. `outer sphere` is the radius of
- * the spherical outer boundary, which is the outer boundary of Layer 5. The
- * `enveloping cube` and `outer sphere` are both centered at the origin.
- * `cutting plane` refers to the plane along which the domain divides into two
- * hemispheres. In the final coordinates, the cutting plane always intersects
- * the x-axis at the origin.
+ * In the code and options below, `PrimaryRightObjectA` and
+ * `SecondaryLeftObjectB` refer to the two compact objects, and by extension,
+ * also refer to the layers that immediately surround each compact object. Note
+ * that `PrimaryRightObjectA` is located to the right of the origin (along the
+ * positive x-axis) and `SecondaryLeftObjectB` is located to the left of the
+ * origin. If both objects are excised, then `PrimaryRightObjectA` must be the
+ * larger object (larger inner radius and x-coord smaller in magnitude).
+ * `enveloping cube` refers to the outer surface of Layer 3. `outer sphere` is
+ * the radius of the spherical outer boundary, which is the outer boundary of
+ * Layer 5. The `enveloping cube` and `outer sphere` are both centered at the
+ * origin. `cutting plane` refers to the plane along which the domain divides
+ * into two hemispheres. In the final coordinates, the cutting plane always
+ * intersects the x-axis at the origin.
  *
- * \note The x-coordinate locations of the `ObjectA` and `ObjectB` should be
- * chosen such that the center of mass is located at x=0.
+ * \note The x-coordinate locations of the `PrimaryRightObjectA` and
+ * `SecondaryLeftObjectB` should be chosen such that the center of mass is
+ * located at x=0.
  *
  * \note When using this domain, the
  * metavariables struct can contain a struct named `domain`
@@ -148,9 +150,10 @@ namespace creators {
  * the initial time for the FunctionsOfTime controlling the map. The
  * time-dependent map itself consists of a composition of a CubicScale expansion
  * map and a Rotation map everywhere except possibly in layer 1; in that case,
- * if `ObjectA` or `ObjectB` is excised, then the time-dependent map in the
- * corresponding blocks in layer 1 is a composition of a SphericalCompression
- * size map, a CubicScale expansion map, and a Rotation map.
+ * if `PrimaryRightObjectA` or `SecondaryLeftObjectB` is excised, then the
+ * time-dependent map in the corresponding blocks in layer 1 is a composition of
+ * a SphericalCompression size map, a CubicScale expansion map, and a Rotation
+ * map.
  */
 class BinaryCompactObject : public DomainCreator<3> {
  private:
@@ -297,14 +300,14 @@ class BinaryCompactObject : public DomainCreator<3> {
     bool use_logarithmic_map;
   };
 
-  struct ObjectA {
+  struct PrimaryRightObjectA {
     using type = Object;
     static constexpr Options::String help = {
         "Options for the object to the right of the origin (along the positive "
         "x-axis)."};
   };
 
-  struct ObjectB {
+  struct SecondaryLeftObjectB {
     using type = Object;
     static constexpr Options::String help = {
         "Options for the object to the left of the origin (along the negative "
@@ -533,10 +536,10 @@ class BinaryCompactObject : public DomainCreator<3> {
 
   template <typename Metavariables>
   using time_independent_options = tmpl::append<
-      tmpl::list<ObjectA, ObjectB, RadiusEnvelopingCube, OuterRadius,
-                 InitialRefinement, InitialGridPoints, UseProjectiveMap,
-                 FrustumSphericity, RadiusEnvelopingSphere,
-                 RadialDistributionOuterShell>,
+      tmpl::list<PrimaryRightObjectA, SecondaryLeftObjectB,
+                 RadiusEnvelopingCube, OuterRadius, InitialRefinement,
+                 InitialGridPoints, UseProjectiveMap, FrustumSphericity,
+                 RadiusEnvelopingSphere, RadialDistributionOuterShell>,
       tmpl::conditional_t<
           domain::BoundaryConditions::has_boundary_conditions_base_v<
               typename Metavariables::system>,
@@ -563,8 +566,9 @@ class BinaryCompactObject : public DomainCreator<3> {
       "The BinaryCompactObject domain is a general domain for two compact "
       "objects. The user must provide the inner and outer radii of the "
       "spherical shells surrounding each of the two compact objects A and B "
-      "(\"ObjectAShell\" and \"ObjectBShell\"). Each object is enveloped in "
-      "a cube (\"ObjectACube\" and \"ObjectBCube\")."
+      "(\"PrimaryRightObjectAShell\" and \"SecondaryLeftObjectBShell\"). Each "
+      "object is enveloped in "
+      "a cube (\"PrimaryRightObjectACube\" and \"SecondaryLeftObjectBCube\")."
       "The user must also provide the radius of the sphere that circumscribes "
       "the cube containing both compact objects (\"EnvelopingCube\"). "
       "A radial layer transitions from the enveloping cube to a sphere "
@@ -572,14 +576,16 @@ class BinaryCompactObject : public DomainCreator<3> {
       "boundary (\"OuterShell\"). The options Object{A,B}.Interior (or "
       "Object{A,B}.ExciseInterior if we're not working with boundary "
       "conditions) determine whether blocks are present inside each compact "
-      "object (\"ObjectAInterior\" and \"ObjectBInterior\"). If set to a "
+      "object (\"PrimaryRightObjectAInterior\" and "
+      "\"SecondaryLeftObjectBInterior\"). If set to a "
       "boundary condition or 'false', the region will be excised. The user "
       "specifies Object{A,B}.XCoord, the x-coordinates of the locations of the "
       "centers of each compact object. In these coordinates, the location for "
-      "the axis of rotation is x=0. ObjectA is located on the right and ObjectB"
-      "is located on the left. If both objects are excised, then ObjectA's "
-      "x-coordinates must be smaller in magnitude than ObjectB's. Please make "
-      "sure that your choices of "
+      "the axis of rotation is x=0. PrimaryRightObjectA is located on the "
+      "right and SecondaryLeftObjectB is located on the left. If both objects "
+      "are excised, then PrimaryRightObjectA's "
+      "x-coordinates must be smaller in magnitude than SecondaryLeftObjectB's. "
+      "Please make sure that your choices of "
       "x-coordinate locations are such that the resulting center of mass "
       "is located at zero.\n"
       "\n"

--- a/src/Domain/Creators/BinaryCompactObject.hpp
+++ b/src/Domain/Creators/BinaryCompactObject.hpp
@@ -124,12 +124,14 @@ namespace creators {
  * compact objects, and by extension, also refer to the layers that immediately
  * surround each compact object. Note that `ObjectA` is located to the right of
  * the origin (along the positive x-axis) and `ObjectB` is located to the left
- * of the origin. `enveloping cube` refers to the outer surface of Layer 3.
- * `outer sphere` is the radius of the spherical outer boundary, which is
- * the outer boundary of Layer 5. The `enveloping cube` and `outer sphere`
- * are both centered at the origin. `cutting plane` refers to the plane along
- * which the domain divides into two hemispheres. In the final coordinates, the
- * cutting plane always intersects the x-axis at the origin.
+ * of the origin. If both objects are excised, then `ObjectA` must be the larger
+ * object (larger inner radius and x-coord smaller in magnitude). `enveloping
+ * cube` refers to the outer surface of Layer 3. `outer sphere` is the radius of
+ * the spherical outer boundary, which is the outer boundary of Layer 5. The
+ * `enveloping cube` and `outer sphere` are both centered at the origin.
+ * `cutting plane` refers to the plane along which the domain divides into two
+ * hemispheres. In the final coordinates, the cutting plane always intersects
+ * the x-axis at the origin.
  *
  * \note The x-coordinate locations of the `ObjectA` and `ObjectB` should be
  * chosen such that the center of mass is located at x=0.
@@ -575,7 +577,9 @@ class BinaryCompactObject : public DomainCreator<3> {
       "specifies Object{A,B}.XCoord, the x-coordinates of the locations of the "
       "centers of each compact object. In these coordinates, the location for "
       "the axis of rotation is x=0. ObjectA is located on the right and ObjectB"
-      "is located on the left. Please make sure that your choices of "
+      "is located on the left. If both objects are excised, then ObjectA's "
+      "x-coordinates must be smaller in magnitude than ObjectB's. Please make "
+      "sure that your choices of "
       "x-coordinate locations are such that the resulting center of mass "
       "is located at zero.\n"
       "\n"

--- a/src/Domain/Creators/BinaryCompactObject.hpp
+++ b/src/Domain/Creators/BinaryCompactObject.hpp
@@ -122,8 +122,8 @@ namespace creators {
  *
  * In the code and options below, `ObjectA` and `ObjectB` refer to the two
  * compact objects, and by extension, also refer to the layers that immediately
- * surround each compact object. Note that `ObjectA` is located to the left of
- * the origin (along the negative x-axis) and `ObjectB` is located to the right
+ * surround each compact object. Note that `ObjectA` is located to the right of
+ * the origin (along the positive x-axis) and `ObjectB` is located to the left
  * of the origin. `enveloping cube` refers to the outer surface of Layer 3.
  * `outer sphere` is the radius of the spherical outer boundary, which is
  * the outer boundary of Layer 5. The `enveloping cube` and `outer sphere`
@@ -298,14 +298,14 @@ class BinaryCompactObject : public DomainCreator<3> {
   struct ObjectA {
     using type = Object;
     static constexpr Options::String help = {
-        "Options for the object to the left of the origin (along the negative "
+        "Options for the object to the right of the origin (along the positive "
         "x-axis)."};
   };
 
   struct ObjectB {
     using type = Object;
     static constexpr Options::String help = {
-        "Options for the object to the right of the origin (along the positive "
+        "Options for the object to the left of the origin (along the negative "
         "x-axis)."};
   };
 
@@ -338,7 +338,8 @@ class BinaryCompactObject : public DomainCreator<3> {
     static std::string name() { return "InnerRadius"; }
     using type = Options::Auto<double>;
     static constexpr Options::String help = {
-        "Inner radius of the outer spherical shell. Set to 'Auto' to compute a "
+        "Inner radius of the outer spherical shell. Set to 'Auto' to compute "
+        "a "
         "reasonable value automatically based on the "
         "'OuterShell.RadialDistribution', or to omit the layer of blocks "
         "altogether when EnvelopingCube.Sphericity is 1 and hence the "
@@ -383,7 +384,8 @@ class BinaryCompactObject : public DomainCreator<3> {
     static double lower_bound() { return 0.; }
     static double upper_bound() { return 1.; }
     // Suggest spherical frustums to encourage upgrading, but keep supporting
-    // cubical frustums until spherical frustums are sufficiently battle-tested
+    // cubical frustums until spherical frustums are sufficiently
+    // battle-tested
     static double suggested_value() { return 1.; }
   };
 
@@ -572,8 +574,8 @@ class BinaryCompactObject : public DomainCreator<3> {
       "boundary condition or 'false', the region will be excised. The user "
       "specifies Object{A,B}.XCoord, the x-coordinates of the locations of the "
       "centers of each compact object. In these coordinates, the location for "
-      "the axis of rotation is x=0. ObjectA is located on the left and ObjectB "
-      "is located on the right. Please make sure that your choices of "
+      "the axis of rotation is x=0. ObjectA is located on the right and ObjectB"
+      "is located on the left. Please make sure that your choices of "
       "x-coordinate locations are such that the resulting center of mass "
       "is located at zero.\n"
       "\n"

--- a/src/Domain/Creators/CylindricalBinaryCompactObject.hpp
+++ b/src/Domain/Creators/CylindricalBinaryCompactObject.hpp
@@ -66,14 +66,15 @@ namespace domain::creators {
  * \cite Buchman:2012dw, and is illustrated in Figure 20 of that
  * paper.
  *
- * In the code and options below, `ObjectA` and `ObjectB` refer to the
- * two compact objects. In the grid frame, `ObjectA` is located to the
- * right of (i.e. a more positive value of the x-coordinate than)
- * `ObjectB`.  The inner edge of the Blocks surrounding each of
- * `ObjectA` and `ObjectB` is spherical in grid coordinates; the
- * user must specify the center and radius of this surface for both
- * `ObjectA` and `ObjectB`, and the user must specify the outer boundary
- * radius.  The outer boundary is a sphere centered at the origin.
+ * In the code and options below, `PrimaryRightObjectA` and
+ * `SecondaryLeftObjectB` refer to the two compact objects. In the grid frame,
+ * `PrimaryRightObjectA` is located to the right of (i.e. a more positive value
+ * of the x-coordinate than) `SecondaryLeftObjectB`.  The inner edge of the
+ * Blocks surrounding each of `PrimaryRightObjectA` and `SecondaryLeftObjectB`
+ * is spherical in grid coordinates; the user must specify the center and radius
+ * of this surface for both `PrimaryRightObjectA` and `SecondaryLeftObjectB`,
+ * and the user must specify the outer boundary radius.  The outer boundary is a
+ * sphere centered at the origin.
  *
  * Note that Figure 20 of \cite Buchman:2012dw illustrates additional
  * spherical shells inside the "EA" and "EB" blocks, and the caption

--- a/src/PointwiseFunctions/AnalyticData/Xcts/Binary.hpp
+++ b/src/PointwiseFunctions/AnalyticData/Xcts/Binary.hpp
@@ -281,12 +281,12 @@ class Binary : public elliptic::analytic_data::Background,
         "The coordinates on the x-axis where the two objects are placed";
     using type = std::array<double, 2>;
   };
-  struct ObjectA {
+  struct PrimaryRightObjectA {
     static constexpr Options::String help =
         "The object placed on the negative x-axis";
     using type = std::unique_ptr<IsolatedObjectBase>;
   };
-  struct ObjectB {
+  struct SecondaryLeftObjectB {
     static constexpr Options::String help =
         "The object placed on the positive x-axis";
     using type = std::unique_ptr<IsolatedObjectBase>;
@@ -309,8 +309,8 @@ class Binary : public elliptic::analytic_data::Background,
         "to disable the Gaussian falloff.";
     using type = Options::Auto<std::array<double, 2>, Options::AutoLabel::None>;
   };
-  using options = tmpl::list<XCoords, ObjectA, ObjectB, AngularVelocity,
-                             Expansion, FalloffWidths>;
+  using options = tmpl::list<XCoords, PrimaryRightObjectA, SecondaryLeftObjectB,
+                             AngularVelocity, Expansion, FalloffWidths>;
   static constexpr Options::String help =
       "Binary compact-object data in general relativity, constructed from "
       "superpositions of two isolated objects.";

--- a/tests/InputFiles/ExportCoordinates/InputTimeDependent3D.yaml
+++ b/tests/InputFiles/ExportCoordinates/InputTimeDependent3D.yaml
@@ -17,16 +17,16 @@ DomainCreator:
   # Spectral Einstein Code (SpEC). The time-dependent maps are given
   # arbitrary time-dependence.
   BinaryCompactObject:
-    ObjectA:
-      InnerRadius: 0.45825
-      OuterRadius: 6.0
-      XCoord: -7.683
-      ExciseInterior: true
-      UseLogarithmicMap: true
-    ObjectB:
+    PrimaryRightObjectA:
       InnerRadius: 0.45825
       OuterRadius: 6.0
       XCoord: 7.683
+      ExciseInterior: true
+      UseLogarithmicMap: true
+    SecondaryLeftObjectB:
+      InnerRadius: 0.45825
+      OuterRadius: 6.0
+      XCoord: -7.683
       ExciseInterior: true
       UseLogarithmicMap: true
     EnvelopingCube:
@@ -38,10 +38,10 @@ DomainCreator:
       OuterRadius: 300.0
       RadialDistribution: Linear
     InitialRefinement:
-      ObjectAShell:   [1, 1, 1]
-      ObjectBShell:   [1, 1, 1]
-      ObjectACube:    [1, 1, 0]
-      ObjectBCube:    [1, 1, 0]
+      PrimaryRightObjectAShell:   [1, 1, 1]
+      SecondaryLeftObjectBShell:   [1, 1, 1]
+      PrimaryRightObjectACube:    [1, 1, 0]
+      SecondaryLeftObjectBCube:    [1, 1, 0]
       EnvelopingCube: [1, 1, 1]
       OuterShell:     [1, 1, 1]
     InitialGridPoints: 3

--- a/tests/InputFiles/GeneralizedHarmonic/BinaryBlackHole.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/BinaryBlackHole.yaml
@@ -45,18 +45,18 @@ Evolution:
 
 DomainCreator:
   BinaryCompactObject:
-    ObjectA:
+    PrimaryRightObjectA:
       InnerRadius: 0.7925
       OuterRadius: 6.683
-      XCoord: &XCoordA -7.683
+      XCoord: &XCoordA 7.683
       Interior:
         ExciseWithBoundaryCondition:
           DemandOutgoingCharSpeeds:
       UseLogarithmicMap: true
-    ObjectB:
+    SecondaryLeftObjectB:
       InnerRadius: 0.7925
       OuterRadius: 6.683
-      XCoord: &XCoordB 7.683
+      XCoord: &XCoordB -7.683
       Interior:
         ExciseWithBoundaryCondition:
           DemandOutgoingCharSpeeds:
@@ -73,10 +73,10 @@ DomainCreator:
         ConstraintPreservingBjorhus:
           Type: ConstraintPreservingPhysical
     InitialRefinement:
-      ObjectAShell:   [3, 3, 4]
-      ObjectACube:    [2, 2, 1]
-      ObjectBShell:   [3, 3, 4]
-      ObjectBCube:    [2, 2, 1]
+      PrimaryRightObjectAShell:   [3, 3, 4]
+      PrimaryRightObjectACube:    [2, 2, 1]
+      SecondaryLeftObjectBShell:   [3, 3, 4]
+      SecondaryLeftObjectBCube:    [2, 2, 1]
       EnvelopingCube: [2, 2, 3]
       CubedShell:     [2, 2, 2]
       OuterShell:     [2, 2, 5]

--- a/tests/InputFiles/Xcts/BinaryBlackHole.yaml
+++ b/tests/InputFiles/Xcts/BinaryBlackHole.yaml
@@ -12,12 +12,12 @@ ResourceInfo:
 Background: &background
   Binary:
     XCoords: [&x_left -8., &x_right 8.]
-    ObjectA: &kerr_left
+    PrimaryRightObjectA: &kerr_left
       KerrSchild:
         Mass: 0.4229
         Spin: [0., 0., 0.]
         Center: [0., 0., 0.]
-    ObjectB: &kerr_right
+    SecondaryLeftObjectB: &kerr_right
       KerrSchild:
         Mass: 0.4229
         Spin: [0., 0., 0.]
@@ -30,19 +30,7 @@ InitialGuess: *background
 
 DomainCreator:
   BinaryCompactObject:
-    ObjectA:
-      InnerRadius: 0.8
-      OuterRadius: 4.
-      XCoord: *x_left
-      Interior:
-        ExciseWithBoundaryCondition:
-          ApparentHorizon:
-            Center: [*x_left, 0., 0.]
-            Rotation: [0., 0., 0.]
-            Lapse: *kerr_left
-            NegativeExpansion: *kerr_left
-      UseLogarithmicMap: True
-    ObjectB:
+    PrimaryRightObjectA:
       InnerRadius: 0.8
       OuterRadius: 4.
       XCoord: *x_right
@@ -53,6 +41,18 @@ DomainCreator:
             Rotation: [0., 0., 0.]
             Lapse: *kerr_right
             NegativeExpansion: *kerr_right
+      UseLogarithmicMap: True
+    SecondaryLeftObjectB:
+      InnerRadius: 0.8
+      OuterRadius: 4.
+      XCoord: *x_left
+      Interior:
+        ExciseWithBoundaryCondition:
+          ApparentHorizon:
+            Center: [*x_left, 0., 0.]
+            Rotation: [0., 0., 0.]
+            Lapse: *kerr_left
+            NegativeExpansion: *kerr_left
       UseLogarithmicMap: True
     EnvelopingCube:
       Radius: 60.
@@ -67,10 +67,10 @@ DomainCreator:
     # Once the domain supports equatorial compression (or similar) this
     # h-refinement will simplify considerably.
     InitialRefinement:
-      ObjectAShell:               [1, 1, 1]
-      ObjectBShell:               [1, 1, 1]
-      ObjectACube:                [1, 1, 1]
-      ObjectBCube:                [1, 1, 1]
+      PrimaryRightObjectAShell:               [1, 1, 1]
+      SecondaryLeftObjectBShell:               [1, 1, 1]
+      PrimaryRightObjectACube:                [1, 1, 1]
+      SecondaryLeftObjectBCube:                [1, 1, 1]
       EnvelopingCubeUpperZLeft:   [1, 1, 1]
       EnvelopingCubeLowerZLeft:   [1, 1, 1]
       EnvelopingCubeUpperYLeft:   [1, 1, 1]
@@ -94,10 +94,10 @@ DomainCreator:
     # This p-refinement represents a crude manual optimization of the domain. We
     # will need AMR to optimize the domain further.
     InitialGridPoints:
-      ObjectAShell:   [6, 6, 10]
-      ObjectBShell:   [6, 6, 10]
-      ObjectACube:    [6, 6, 7]
-      ObjectBCube:    [6, 6, 7]
+      PrimaryRightObjectAShell:   [6, 6, 10]
+      SecondaryLeftObjectBShell:   [6, 6, 10]
+      PrimaryRightObjectACube:    [6, 6, 7]
+      SecondaryLeftObjectBCube:    [6, 6, 7]
       EnvelopingCube: [6, 6, 6]
       OuterShell:     [6, 6, 6]
 

--- a/tests/Unit/ControlSystem/Actions/Test_Initialization.cpp
+++ b/tests/Unit/ControlSystem/Actions/Test_Initialization.cpp
@@ -44,7 +44,7 @@ struct MockControlSystem
     return get_output(i);
   }
   using measurement = Measurement;
-  using control_error = control_system::TestHelpers::ControlError;
+  using control_error = control_system::TestHelpers::ControlError<0>;
   static constexpr size_t deriv_order = order;
   using simple_tags = tmpl::list<>;
 };
@@ -96,7 +96,7 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.Initialization",
       std::vector<double>{damping_time}, 10.0, 0.1, 2.0, 0.1, 1.01, 0.99};
   Controller<order> controller{0.3};
   bool write_data = false;
-  const control_system::TestHelpers::ControlError control_error{};
+  const control_system::TestHelpers::ControlError<0> control_error{};
 
   std::unordered_map<std::string,
                      std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>

--- a/tests/Unit/ControlSystem/Actions/Test_InitializeMeasurements.cpp
+++ b/tests/Unit/ControlSystem/Actions/Test_InitializeMeasurements.cpp
@@ -95,7 +95,7 @@ struct SystemA : tt::ConformsTo<control_system::protocols::ControlSystem> {
   }
   using simple_tags = tmpl::list<>;
   using measurement = Measurement<tmpl::list<SystemA, SystemB>>;
-  using control_error = control_system::TestHelpers::ControlError;
+  using control_error = control_system::TestHelpers::ControlError<1>;
   struct process_measurement {
     template <typename Submeasurement>
     using argument_tags = tmpl::list<>;
@@ -110,7 +110,7 @@ struct SystemB : tt::ConformsTo<control_system::protocols::ControlSystem> {
   }
   using simple_tags = tmpl::list<>;
   using measurement = Measurement<tmpl::list<SystemA, SystemB>>;
-  using control_error = control_system::TestHelpers::ControlError;
+  using control_error = control_system::TestHelpers::ControlError<1>;
   struct process_measurement {
     template <typename Submeasurement>
     using argument_tags = tmpl::list<>;
@@ -125,7 +125,7 @@ struct SystemC : tt::ConformsTo<control_system::protocols::ControlSystem> {
   }
   using simple_tags = tmpl::list<>;
   using measurement = Measurement<tmpl::list<SystemC>>;
-  using control_error = control_system::TestHelpers::ControlError;
+  using control_error = control_system::TestHelpers::ControlError<1>;
   struct process_measurement {
     template <typename Submeasurement>
     using argument_tags = tmpl::list<>;

--- a/tests/Unit/ControlSystem/ControlErrors/Test_Expansion.cpp
+++ b/tests/Unit/ControlSystem/ControlErrors/Test_Expansion.cpp
@@ -37,6 +37,7 @@ void test_expansion_control_error() {
       "  InitialTime: 0.0\n"
       "DomainCreator:\n"
       "  FakeCreator:\n"
+      "    NumberOfExcisions: 2\n"
       "    NumberOfComponents:\n"
       "      Expansion: 1\n"
       "ControlSystems:\n"

--- a/tests/Unit/ControlSystem/ControlErrors/Test_Expansion.cpp
+++ b/tests/Unit/ControlSystem/ControlErrors/Test_Expansion.cpp
@@ -92,10 +92,10 @@ void test_expansion_control_error() {
       control_system::QueueTags::Center<::ah::ObjectLabel::B>>;
 
   // Create fake measurements. For expansion we only care about the x component
-  // because that's all that is used. B is on the positive x-axis, A is on the
+  // because that's all that is used. A is on the positive x-axis, B is on the
   // negative x-axis
-  const double pos_A_x = -5.0;
-  const double pos_B_x = 10.0;
+  const double pos_A_x = 10.0;
+  const double pos_B_x = -5.0;
   QueueTuple fake_measurement_tuple{DataVector{pos_A_x, 0.0, 0.0},
                                     DataVector{pos_B_x, 0.0, 0.0}};
 
@@ -111,7 +111,7 @@ void test_expansion_control_error() {
           *functions_of_time.at(expansion_name));
   // Since we haven't updated, the expansion factor should just be 1.0
   const double exp_factor = expansion_f_of_t.func(check_time)[0][0];
-  const double pos_diff = pos_B_x - pos_A_x;
+  const double pos_diff = pos_A_x - pos_B_x;
   const double grid_diff = initial_separation;
 
   const DataVector expected_control_error{exp_factor *

--- a/tests/Unit/ControlSystem/ControlErrors/Test_Rotation.cpp
+++ b/tests/Unit/ControlSystem/ControlErrors/Test_Rotation.cpp
@@ -42,6 +42,7 @@ void test_rotation_control_error() {
       "  InitialTime: 0.0\n"
       "DomainCreator:\n"
       "  FakeCreator:\n"
+      "    NumberOfExcisions: 2\n"
       "    NumberOfComponents:\n"
       "      Rotation: 3\n"
       "ControlSystems:\n"

--- a/tests/Unit/ControlSystem/ControlErrors/Test_Rotation.cpp
+++ b/tests/Unit/ControlSystem/ControlErrors/Test_Rotation.cpp
@@ -95,8 +95,8 @@ void test_rotation_control_error() {
       control_system::QueueTags::Center<::ah::ObjectLabel::B>>;
 
   // Create fake measurements.
-  const DataVector pos_A{{-3.0, -4.0, 5.0}};
-  const DataVector pos_B{{2.0, 3.0, 6.0}};
+  const DataVector pos_A{{2.0, 3.0, 6.0}};
+  const DataVector pos_B{{-3.0, -4.0, 5.0}};
   QueueTuple fake_measurement_tuple{pos_A, pos_B};
 
   using ControlError = rotation_system::control_error;

--- a/tests/Unit/ControlSystem/ControlErrors/Test_Translation.cpp
+++ b/tests/Unit/ControlSystem/ControlErrors/Test_Translation.cpp
@@ -43,6 +43,7 @@ void test_translation_control_error() {
       "  InitialTime: 0.0\n"
       "DomainCreator:\n"
       "  FakeCreator:\n"
+      "    NumberOfExcisions: 2\n"
       "    NumberOfComponents:\n"
       "      Translation: 3\n"
       "ControlSystems:\n"

--- a/tests/Unit/ControlSystem/ControlErrors/Test_Translation.cpp
+++ b/tests/Unit/ControlSystem/ControlErrors/Test_Translation.cpp
@@ -97,9 +97,9 @@ void test_translation_control_error() {
       control_system::QueueTags::Center<::ah::ObjectLabel::B>>;
 
   // Create fake measurements.
-  const DataVector pos_A{{-3.0, -4.0, 5.0}};
-  const DataVector pos_B{{2.0, 3.0, 6.0}};
-  const DataVector grid_B{{initial_separation / 2.0, 0.0, 0.0}};
+  const DataVector pos_A{{2.0, 3.0, 6.0}};
+  const DataVector pos_B{{-3.0, -4.0, 5.0}};
+  const DataVector grid_A{{initial_separation / 2.0, 0.0, 0.0}};
   QueueTuple fake_measurement_tuple{pos_A, pos_B};
 
   using ControlError = translation_system::control_error;
@@ -113,19 +113,19 @@ void test_translation_control_error() {
   const DataVector rotation_control_error =
       DataVector{{0.0, -15.0, 105.0}} / 75.0;
   const double expansion_control_error =
-      (pos_B[0] - pos_A[0]) / initial_separation - 1.0;
+      (pos_A[0] - pos_B[0]) / initial_separation - 1.0;
 
   const DataVector rot_control_err_cross_grid =
-      cross(rotation_control_error, grid_B);
+      cross(rotation_control_error, grid_A);
 
   // The quaternion should be the unit quaternion (1,0,0,0) which means the
   // quaternion multiplication in the translation control error is the identity
   // so we avoid actually doing quaternion multiplication. Also the expansion
   // factor should be 1.0 so we don't have to multiply/divide by that where we
   // normally would have
-  const DataVector expected_control_error = pos_B - grid_B -
+  const DataVector expected_control_error = pos_A - grid_A -
                                             rot_control_err_cross_grid -
-                                            expansion_control_error * grid_B;
+                                            expansion_control_error * grid_A;
 
   Approx custom_approx = Approx::custom().epsilon(1.0e-14).scale(1.0);
   CHECK_ITERABLE_CUSTOM_APPROX(control_error, expected_control_error,

--- a/tests/Unit/ControlSystem/Systems/Test_Expansion.cpp
+++ b/tests/Unit/ControlSystem/Systems/Test_Expansion.cpp
@@ -134,7 +134,7 @@ void test_expansion_control_system() {
   const auto position_function = [&binary_trajectories](const double time) {
     const double separation = binary_trajectories.separation(time);
     return std::pair<std::array<double, 3>, std::array<double, 3>>{
-        {-0.5 * separation, 0.0, 0.0}, {0.5 * separation, 0.0, 0.0}};
+        {0.5 * separation, 0.0, 0.0}, {-0.5 * separation, 0.0, 0.0}};
   };
 
   const auto horizon_function = [&position_function, &runner,
@@ -156,9 +156,9 @@ void test_expansion_control_system() {
 
   // Our expected positions are just the initial positions
   const std::array<double, 3> expected_grid_position_of_a{
-      {-0.5 * initial_separation, 0.0, 0.0}};
-  const std::array<double, 3> expected_grid_position_of_b{
       {0.5 * initial_separation, 0.0, 0.0}};
+  const std::array<double, 3> expected_grid_position_of_b{
+      {-0.5 * initial_separation, 0.0, 0.0}};
 
   const auto& expansion_f_of_t =
       dynamic_cast<domain::FunctionsOfTime::PiecewisePolynomial<DerivOrder>&>(

--- a/tests/Unit/ControlSystem/Systems/Test_Expansion.cpp
+++ b/tests/Unit/ControlSystem/Systems/Test_Expansion.cpp
@@ -60,6 +60,7 @@ void test_expansion_control_system() {
       "  InitialTime: 0.0\n"
       "DomainCreator:\n"
       "  FakeCreator:\n"
+      "    NumberOfExcisions: 2\n"
       "    NumberOfComponents:\n"
       "      Expansion: 1\n"
       "ControlSystems:\n"

--- a/tests/Unit/ControlSystem/Systems/Test_RotScaleTrans.cpp
+++ b/tests/Unit/ControlSystem/Systems/Test_RotScaleTrans.cpp
@@ -107,6 +107,7 @@ void test_rotscaletrans_control_system(const double rotation_eps = 5.0e-5) {
       "  InitialTime: 0.0\n"
       "DomainCreator:\n"
       "  FakeCreator:\n"
+      "    NumberOfExcisions: 2\n"
       "    NumberOfComponents:\n"
       "      Translation: 3\n"
       "      Rotation: 3\n"

--- a/tests/Unit/ControlSystem/Systems/Test_RotScaleTrans.cpp
+++ b/tests/Unit/ControlSystem/Systems/Test_RotScaleTrans.cpp
@@ -217,9 +217,9 @@ void test_rotscaletrans_control_system(const double rotation_eps = 5.0e-5) {
 
   // Our expected positions are just the initial positions
   const std::array<double, 3> expected_grid_position_of_a{
-      {-0.5 * initial_separation, 0.0, 0.0}};
-  const std::array<double, 3> expected_grid_position_of_b{
       {0.5 * initial_separation, 0.0, 0.0}};
+  const std::array<double, 3> expected_grid_position_of_b{
+      {-0.5 * initial_separation, 0.0, 0.0}};
 
   const auto& rotation_f_of_t = dynamic_cast<
       domain::FunctionsOfTime::QuaternionFunctionOfTime<RotationDerivOrder>&>(

--- a/tests/Unit/ControlSystem/Systems/Test_Rotation.cpp
+++ b/tests/Unit/ControlSystem/Systems/Test_Rotation.cpp
@@ -61,6 +61,7 @@ void test_rotation_control_system(const bool newtonian) {
       "  InitialTime: 0.0\n"
       "DomainCreator:\n"
       "  FakeCreator:\n"
+      "    NumberOfExcisions: 2\n"
       "    NumberOfComponents:\n"
       "      Rotation: 3\n"
       "ControlSystems:\n"

--- a/tests/Unit/ControlSystem/Systems/Test_Rotation.cpp
+++ b/tests/Unit/ControlSystem/Systems/Test_Rotation.cpp
@@ -152,9 +152,9 @@ void test_rotation_control_system(const bool newtonian) {
 
   // Our expected positions are just the initial positions
   const std::array<double, 3> expected_grid_position_of_a{
-      {-0.5 * initial_separation, 0.0, 0.0}};
-  const std::array<double, 3> expected_grid_position_of_b{
       {0.5 * initial_separation, 0.0, 0.0}};
+  const std::array<double, 3> expected_grid_position_of_b{
+      {-0.5 * initial_separation, 0.0, 0.0}};
 
   const auto& rotation_f_of_t = dynamic_cast<
       domain::FunctionsOfTime::QuaternionFunctionOfTime<DerivOrder>&>(

--- a/tests/Unit/ControlSystem/Systems/Test_Shape.cpp
+++ b/tests/Unit/ControlSystem/Systems/Test_Shape.cpp
@@ -235,6 +235,7 @@ void test_suite(const gsl::not_null<Generator*> generator, const size_t l_max,
       "  InitialTime: 0.0\n"
       "DomainCreator:\n"
       "  FakeCreator:\n"
+      "    NumberOfExcisions: 1\n"
       "    NumberOfComponents:\n"
       "      ShapeA: " +
       num_ah_coeffs_str +

--- a/tests/Unit/ControlSystem/Systems/Test_Translation.cpp
+++ b/tests/Unit/ControlSystem/Systems/Test_Translation.cpp
@@ -138,7 +138,7 @@ void test_translation_control_system() {
                                   &velocity](const double time) {
     const std::array<double, 3> init_pos{{0.5 * initial_separation, 0.0, 0.0}};
     return std::pair<std::array<double, 3>, std::array<double, 3>>{
-        -init_pos + velocity * time, init_pos + velocity * time};
+        init_pos + velocity * time, -init_pos + velocity * time};
   };
 
   const auto horizon_function = [&position_function, &runner,
@@ -160,9 +160,9 @@ void test_translation_control_system() {
 
   // Our expected positions are just the initial positions
   const std::array<double, 3> expected_grid_position_of_a{
-      {-0.5 * initial_separation, 0.0, 0.0}};
-  const std::array<double, 3> expected_grid_position_of_b{
       {0.5 * initial_separation, 0.0, 0.0}};
+  const std::array<double, 3> expected_grid_position_of_b{
+      {-0.5 * initial_separation, 0.0, 0.0}};
 
   const auto& translation_f_of_t =
       dynamic_cast<domain::FunctionsOfTime::PiecewisePolynomial<DerivOrder>&>(

--- a/tests/Unit/ControlSystem/Systems/Test_Translation.cpp
+++ b/tests/Unit/ControlSystem/Systems/Test_Translation.cpp
@@ -67,6 +67,7 @@ void test_translation_control_system() {
       "  InitialTime: 0.0\n"
       "DomainCreator:\n"
       "  FakeCreator:\n"
+      "    NumberOfExcisions: 2\n"
       "    NumberOfComponents:\n"
       "      Translation: 3\n"
       "ControlSystems:\n"

--- a/tests/Unit/ControlSystem/Tags/Test_FunctionsOfTimeInitialize.cpp
+++ b/tests/Unit/ControlSystem/Tags/Test_FunctionsOfTimeInitialize.cpp
@@ -51,7 +51,7 @@ struct FakeControlSystem
   using measurement = control_system::TestHelpers::Measurement<
       control_system::TestHelpers::TestStructs_detail::LabelA>;
   using simple_tags = tmpl::list<>;
-  using control_error = control_system::TestHelpers::ControlError;
+  using control_error = control_system::TestHelpers::ControlError<1>;
   struct process_measurement {
     using argument_tags = tmpl::list<>;
   };
@@ -221,7 +221,7 @@ void test_functions_of_time_tag() {
   const Averager<1> averager(0.25, true);
   const double update_fraction = 0.3;
   const Controller<2> controller(update_fraction);
-  const control_system::TestHelpers::ControlError control_error{};
+  const control_system::TestHelpers::ControlError<1> control_error{};
 
   OptionHolder<1> option_holder1(false, averager, controller, tuner1,
                                  control_error);
@@ -427,7 +427,7 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.Tags.FunctionsOfTimeInitialize",
         const Averager<1> averager(0.25, true);
         const double update_fraction = 0.3;
         const Controller<2> controller(update_fraction);
-        const control_system::TestHelpers::ControlError control_error{};
+        const control_system::TestHelpers::ControlError<1> control_error{};
 
         OptionHolder<1> option_holder1(true, averager, controller, tuner,
                                        control_error);
@@ -459,7 +459,7 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.Tags.FunctionsOfTimeInitialize",
         const Averager<1> averager(0.25, true);
         const double update_fraction = 0.3;
         const Controller<2> controller(update_fraction);
-        const control_system::TestHelpers::ControlError control_error{};
+        const control_system::TestHelpers::ControlError<1> control_error{};
 
         OptionHolder<1> option_holder1(true, averager, controller, tuner,
                                        control_error);

--- a/tests/Unit/ControlSystem/Tags/Test_MeasurementTimescales.cpp
+++ b/tests/Unit/ControlSystem/Tags/Test_MeasurementTimescales.cpp
@@ -41,7 +41,7 @@ struct FakeControlSystem
   using measurement = control_system::TestHelpers::Measurement<
       control_system::TestHelpers::TestStructs_detail::LabelA>;
   using simple_tags = tmpl::list<>;
-  using control_error = control_system::TestHelpers::ControlError;
+  using control_error = control_system::TestHelpers::ControlError<1>;
   struct process_measurement {
     using argument_tags = tmpl::list<>;
   };
@@ -112,7 +112,7 @@ void test_measurement_tag() {
     const Averager<1> averager(averaging_fraction, true);
     const double update_fraction = 0.3;
     const Controller<2> controller(update_fraction);
-    const control_system::TestHelpers::ControlError control_error{};
+    const control_system::TestHelpers::ControlError<1> control_error{};
 
     OptionHolder<1> option_holder1(true, averager, controller, tuner1,
                                    control_error);
@@ -209,7 +209,7 @@ void test_measurement_tag() {
                                     1.0e-2, 1.0e-4, 1.01, 0.99);
         const Averager<1> averager(0.25, true);
         const Controller<2> controller(0.3);
-        const control_system::TestHelpers::ControlError control_error{};
+        const control_system::TestHelpers::ControlError<1> control_error{};
 
         OptionHolder<1> option_holder1(true, averager, controller, tuner1,
                                        control_error);

--- a/tests/Unit/ControlSystem/Test_ExpirationTimes.cpp
+++ b/tests/Unit/ControlSystem/Test_ExpirationTimes.cpp
@@ -34,7 +34,7 @@ struct FakeControlSystem
   using measurement = control_system::TestHelpers::Measurement<
       control_system::TestHelpers::TestStructs_detail::LabelA>;
   using simple_tags = tmpl::list<>;
-  using control_error = control_system::TestHelpers::ControlError;
+  using control_error = control_system::TestHelpers::ControlError<1>;
   struct process_measurement {
     using argument_tags = tmpl::list<>;
   };
@@ -70,7 +70,7 @@ void test_expiration_time_construction() {
   const Averager<1> averager(0.25, true);
   const double update_fraction = 0.3;
   const Controller<2> controller(update_fraction);
-  const control_system::TestHelpers::ControlError control_error{};
+  const control_system::TestHelpers::ControlError<1> control_error{};
 
   OptionHolder<1> option_holder1(true, averager, controller, tuner1,
                                  control_error);

--- a/tests/Unit/ControlSystem/Test_Tags.cpp
+++ b/tests/Unit/ControlSystem/Test_Tags.cpp
@@ -219,13 +219,13 @@ void test_individual_tags() {
       std::make_unique<FakeCreator>(std::unordered_map<std::string, size_t>{},
                                     1);
 
-  CHECK_THROWS_WITH(
-      control_error_tag::create_from_options<MetavarsEmpty>(holder,
-                                                            creator_error_0),
-      Catch::Contains("ObjectAExcisionSphere' or 'ObjectBExcisionSphere"));
+  CHECK_THROWS_WITH(control_error_tag::create_from_options<MetavarsEmpty>(
+                        holder, creator_error_0),
+                    Catch::Contains("PrimaryRightObjectAExcisionSphere' or "
+                                    "'SecondaryLeftObjectBExcisionSphere"));
   CHECK_THROWS_WITH(control_error_tag2::create_from_options<MetavarsEmpty>(
                         holder2, creator_error_1),
-                    Catch::Contains("'ObjectBExcisionSphere'"));
+                    Catch::Contains("'SecondaryLeftObjectBExcisionSphere'"));
 
   using controller_tag = control_system::Tags::Controller<system>;
 

--- a/tests/Unit/Domain/Creators/Test_BinaryCompactObject.cpp
+++ b/tests/Unit/Domain/Creators/Test_BinaryCompactObject.cpp
@@ -113,19 +113,21 @@ void test_connectivity() {
       for (const bool excise_interiorB : {true, false}) {
         CAPTURE(excise_interiorB);
         std::unordered_map<std::string, std::array<size_t, 3>> refinement{
-            {"ObjectAShell", {{1, 1, 1}}},
-            {"ObjectACube", {{1, 1, 1}}},
-            {"ObjectBShell", {{1, 1, 1}}},
-            {"ObjectBCube", {{1, 1, 1}}},
+            {"PrimaryRightObjectAShell", {{1, 1, 1}}},
+            {"PrimaryRightObjectACube", {{1, 1, 1}}},
+            {"SecondaryLeftObjectBShell", {{1, 1, 1}}},
+            {"SecondaryLeftObjectBCube", {{1, 1, 1}}},
             {"EnvelopingCube", {{1, 1, 1}}},
             {"CubedShell", {{1, 1, 1}}},
             // Add some radial refinement in outer shell
             {"OuterShell", {{1, 1, 4}}}};
         if (not excise_interiorA) {
-          refinement["ObjectAInterior"] = std::array<size_t, 3>{{1, 1, 1}};
+          refinement["PrimaryRightObjectAInterior"] =
+              std::array<size_t, 3>{{1, 1, 1}};
         }
         if (not excise_interiorB) {
-          refinement["ObjectBInterior"] = std::array<size_t, 3>{{1, 1, 1}};
+          refinement["SecondaryLeftObjectBInterior"] =
+              std::array<size_t, 3>{{1, 1, 1}};
         }
         for (const auto radial_distribution_outer_shell :
              {Distribution::Linear, Distribution::Logarithmic,
@@ -164,51 +166,90 @@ void test_connectivity() {
                   binary_compact_object, with_boundary_conditions);
 
           std::vector<std::string> expected_block_names{
-              "ObjectBShellUpperZ",       "ObjectBShellLowerZ",
-              "ObjectBShellUpperY",       "ObjectBShellLowerY",
-              "ObjectBShellUpperX",       "ObjectBShellLowerX",
-              "ObjectBCubeUpperZ",        "ObjectBCubeLowerZ",
-              "ObjectBCubeUpperY",        "ObjectBCubeLowerY",
-              "ObjectBCubeUpperX",        "ObjectBCubeLowerX",
-              "ObjectAShellUpperZ",       "ObjectAShellLowerZ",
-              "ObjectAShellUpperY",       "ObjectAShellLowerY",
-              "ObjectAShellUpperX",       "ObjectAShellLowerX",
-              "ObjectACubeUpperZ",        "ObjectACubeLowerZ",
-              "ObjectACubeUpperY",        "ObjectACubeLowerY",
-              "ObjectACubeUpperX",        "ObjectACubeLowerX",
-              "EnvelopingCubeUpperZLeft", "EnvelopingCubeUpperZRight",
-              "EnvelopingCubeLowerZLeft", "EnvelopingCubeLowerZRight",
-              "EnvelopingCubeUpperYLeft", "EnvelopingCubeUpperYRight",
-              "EnvelopingCubeLowerYLeft", "EnvelopingCubeLowerYRight",
-              "EnvelopingCubeUpperX",     "EnvelopingCubeLowerX",
-              "CubedShellUpperZLeft",     "CubedShellUpperZRight",
-              "CubedShellLowerZLeft",     "CubedShellLowerZRight",
-              "CubedShellUpperYLeft",     "CubedShellUpperYRight",
-              "CubedShellLowerYLeft",     "CubedShellLowerYRight",
-              "CubedShellUpperX",         "CubedShellLowerX",
-              "OuterShellUpperZLeft",     "OuterShellUpperZRight",
-              "OuterShellLowerZLeft",     "OuterShellLowerZRight",
-              "OuterShellUpperYLeft",     "OuterShellUpperYRight",
-              "OuterShellLowerYLeft",     "OuterShellLowerYRight",
-              "OuterShellUpperX",         "OuterShellLowerX"};
+              "SecondaryLeftObjectBShellUpperZ",
+              "SecondaryLeftObjectBShellLowerZ",
+              "SecondaryLeftObjectBShellUpperY",
+              "SecondaryLeftObjectBShellLowerY",
+              "SecondaryLeftObjectBShellUpperX",
+              "SecondaryLeftObjectBShellLowerX",
+              "SecondaryLeftObjectBCubeUpperZ",
+              "SecondaryLeftObjectBCubeLowerZ",
+              "SecondaryLeftObjectBCubeUpperY",
+              "SecondaryLeftObjectBCubeLowerY",
+              "SecondaryLeftObjectBCubeUpperX",
+              "SecondaryLeftObjectBCubeLowerX",
+              "PrimaryRightObjectAShellUpperZ",
+              "PrimaryRightObjectAShellLowerZ",
+              "PrimaryRightObjectAShellUpperY",
+              "PrimaryRightObjectAShellLowerY",
+              "PrimaryRightObjectAShellUpperX",
+              "PrimaryRightObjectAShellLowerX",
+              "PrimaryRightObjectACubeUpperZ",
+              "PrimaryRightObjectACubeLowerZ",
+              "PrimaryRightObjectACubeUpperY",
+              "PrimaryRightObjectACubeLowerY",
+              "PrimaryRightObjectACubeUpperX",
+              "PrimaryRightObjectACubeLowerX",
+              "EnvelopingCubeUpperZLeft",
+              "EnvelopingCubeUpperZRight",
+              "EnvelopingCubeLowerZLeft",
+              "EnvelopingCubeLowerZRight",
+              "EnvelopingCubeUpperYLeft",
+              "EnvelopingCubeUpperYRight",
+              "EnvelopingCubeLowerYLeft",
+              "EnvelopingCubeLowerYRight",
+              "EnvelopingCubeUpperX",
+              "EnvelopingCubeLowerX",
+              "CubedShellUpperZLeft",
+              "CubedShellUpperZRight",
+              "CubedShellLowerZLeft",
+              "CubedShellLowerZRight",
+              "CubedShellUpperYLeft",
+              "CubedShellUpperYRight",
+              "CubedShellLowerYLeft",
+              "CubedShellLowerYRight",
+              "CubedShellUpperX",
+              "CubedShellLowerX",
+              "OuterShellUpperZLeft",
+              "OuterShellUpperZRight",
+              "OuterShellLowerZLeft",
+              "OuterShellLowerZRight",
+              "OuterShellUpperYLeft",
+              "OuterShellUpperYRight",
+              "OuterShellLowerYLeft",
+              "OuterShellLowerYRight",
+              "OuterShellUpperX",
+              "OuterShellLowerX"};
           std::unordered_map<std::string, std::unordered_set<std::string>>
               expected_block_groups{
-                  {"ObjectAShell",
-                   {"ObjectAShellLowerZ", "ObjectAShellUpperX",
-                    "ObjectAShellLowerX", "ObjectAShellUpperY",
-                    "ObjectAShellUpperZ", "ObjectAShellLowerY"}},
-                  {"ObjectBShell",
-                   {"ObjectBShellLowerZ", "ObjectBShellUpperX",
-                    "ObjectBShellLowerX", "ObjectBShellUpperY",
-                    "ObjectBShellUpperZ", "ObjectBShellLowerY"}},
-                  {"ObjectACube",
-                   {"ObjectACubeLowerY", "ObjectACubeLowerZ",
-                    "ObjectACubeUpperY", "ObjectACubeUpperX",
-                    "ObjectACubeUpperZ", "ObjectACubeLowerX"}},
-                  {"ObjectBCube",
-                   {"ObjectBCubeLowerY", "ObjectBCubeLowerZ",
-                    "ObjectBCubeUpperY", "ObjectBCubeUpperX",
-                    "ObjectBCubeUpperZ", "ObjectBCubeLowerX"}},
+                  {"PrimaryRightObjectAShell",
+                   {"PrimaryRightObjectAShellLowerZ",
+                    "PrimaryRightObjectAShellUpperX",
+                    "PrimaryRightObjectAShellLowerX",
+                    "PrimaryRightObjectAShellUpperY",
+                    "PrimaryRightObjectAShellUpperZ",
+                    "PrimaryRightObjectAShellLowerY"}},
+                  {"SecondaryLeftObjectBShell",
+                   {"SecondaryLeftObjectBShellLowerZ",
+                    "SecondaryLeftObjectBShellUpperX",
+                    "SecondaryLeftObjectBShellLowerX",
+                    "SecondaryLeftObjectBShellUpperY",
+                    "SecondaryLeftObjectBShellUpperZ",
+                    "SecondaryLeftObjectBShellLowerY"}},
+                  {"PrimaryRightObjectACube",
+                   {"PrimaryRightObjectACubeLowerY",
+                    "PrimaryRightObjectACubeLowerZ",
+                    "PrimaryRightObjectACubeUpperY",
+                    "PrimaryRightObjectACubeUpperX",
+                    "PrimaryRightObjectACubeUpperZ",
+                    "PrimaryRightObjectACubeLowerX"}},
+                  {"SecondaryLeftObjectBCube",
+                   {"SecondaryLeftObjectBCubeLowerY",
+                    "SecondaryLeftObjectBCubeLowerZ",
+                    "SecondaryLeftObjectBCubeUpperY",
+                    "SecondaryLeftObjectBCubeUpperX",
+                    "SecondaryLeftObjectBCubeUpperZ",
+                    "SecondaryLeftObjectBCubeLowerX"}},
                   {"EnvelopingCube",
                    {"EnvelopingCubeUpperZRight", "EnvelopingCubeUpperX",
                     "EnvelopingCubeLowerZLeft", "EnvelopingCubeLowerZRight",
@@ -228,10 +269,10 @@ void test_connectivity() {
                     "OuterShellLowerYLeft", "OuterShellLowerYRight",
                     "OuterShellUpperX", "OuterShellLowerX"}}};
           if (not excise_interiorA) {
-            expected_block_names.emplace_back("ObjectAInterior");
+            expected_block_names.emplace_back("PrimaryRightObjectAInterior");
           }
           if (not excise_interiorB) {
-            expected_block_names.emplace_back("ObjectBInterior");
+            expected_block_names.emplace_back("SecondaryLeftObjectBInterior");
           }
           CHECK(binary_compact_object.block_names() == expected_block_names);
           CHECK(binary_compact_object.block_groups() == expected_block_groups);
@@ -239,7 +280,7 @@ void test_connectivity() {
               expected_excision_spheres{};
           if (excise_interiorA) {
             expected_excision_spheres.emplace(
-                "ObjectAExcisionSphere",
+                "PrimaryRightObjectAExcisionSphere",
                 ExcisionSphere<3>{inner_radius_objectA,
                                   {{xcoord_objectA, 0.0, 0.0}},
                                   {{12, Direction<3>::lower_zeta()},
@@ -251,7 +292,7 @@ void test_connectivity() {
           }
           if (excise_interiorB) {
             expected_excision_spheres.emplace(
-                "ObjectBExcisionSphere",
+                "SecondaryLeftObjectBExcisionSphere",
                 ExcisionSphere<3>{inner_radius_objectB,
                                   {{xcoord_objectB, 0.0, 0.0}},
                                   {{0, Direction<3>::lower_zeta()},
@@ -449,14 +490,14 @@ std::string create_option_string(const bool excise_A, const bool excise_B,
                                            "        BlockId: 50\n"}
                              : ""};
   return "BinaryCompactObject:\n"
-         "  ObjectA:\n"
+         "  PrimaryRightObjectA:\n"
          "    InnerRadius: 0.4\n"
          "    OuterRadius: 2.0\n"
          "    XCoord: 2.0\n" +
          interior_A +
          "    UseLogarithmicMap: " + stringize(use_logarithmic_map_AB) +
          "\n"
-         "  ObjectB:\n"
+         "  SecondaryLeftObjectB:\n"
          "    InnerRadius: 0.4\n"
          "    OuterRadius: 1.0\n"
          "    XCoord: -3.0\n" +
@@ -472,16 +513,16 @@ std::string create_option_string(const bool excise_A, const bool excise_B,
          "    OuterRadius: 25.0\n"
          "    RadialDistribution: Linear\n" +
          outer_boundary_condition + "  InitialRefinement:\n" +
-         (excise_A ? "" : "    ObjectAInterior: [1, 1, 1]\n") +
-         (excise_B ? "" : "    ObjectBInterior: [1, 1, 1]\n") +
-         "    ObjectAShell: [1, 1, " +
+         (excise_A ? "" : "    PrimaryRightObjectAInterior: [1, 1, 1]\n") +
+         (excise_B ? "" : "    SecondaryLeftObjectBInterior: [1, 1, 1]\n") +
+         "    PrimaryRightObjectAShell: [1, 1, " +
          std::to_string(1 + additional_refinement_A) +
          "]\n"
-         "    ObjectBShell: [1, 1, " +
+         "    SecondaryLeftObjectBShell: [1, 1, " +
          std::to_string(1 + additional_refinement_B) +
          "]\n"
-         "    ObjectACube: [1, 1, 1]\n"
-         "    ObjectBCube: [1, 1, 1]\n"
+         "    PrimaryRightObjectACube: [1, 1, 1]\n"
+         "    SecondaryLeftObjectBCube: [1, 1, 1]\n"
          "    EnvelopingCube: [1, 1, 1]\n"
          "    OuterShell: [1, 1, " +
          std::to_string(1 + additional_refinement_outer) +
@@ -663,16 +704,16 @@ void test_parse_errors() {
           {0.3, 1.0, -1.0, {{create_inner_boundary_condition()}}, false}, 25.5,
           32.4, 2_st, 6_st, true, 0.0, std::nullopt, Distribution::Linear,
           create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
-      Catch::Matchers::Contains(
-          "The x-coordinate of ObjectA's center is expected to be positive."));
+      Catch::Matchers::Contains("The x-coordinate of PrimaryRightObjectA's "
+                                "center is expected to be positive."));
   CHECK_THROWS_WITH(
       domain::creators::BinaryCompactObject(
           {0.5, 1.0, 1.0, {{create_inner_boundary_condition()}}, false},
           {0.3, 1.0, 1.0, {{create_inner_boundary_condition()}}, false}, 25.5,
           32.4, 2_st, 6_st, true, 0.0, std::nullopt, Distribution::Linear,
           create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
-      Catch::Matchers::Contains(
-          "The x-coordinate of ObjectB's center is expected to be negative."));
+      Catch::Matchers::Contains("The x-coordinate of SecondaryLeftObjectB's "
+                                "center is expected to be negative."));
   CHECK_THROWS_WITH(
       domain::creators::BinaryCompactObject(
           {0.3, 1.0, 1.0, {{create_inner_boundary_condition()}}, false},
@@ -720,16 +761,16 @@ void test_parse_errors() {
           {1.2, 1.1, -1.0, {{create_inner_boundary_condition()}}, false}, 25.5,
           32.4, 2_st, 6_st, true, 0.0, std::nullopt, Distribution::Linear,
           create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
-      Catch::Matchers::Contains(
-          "ObjectB's inner radius must be less than its outer radius."));
+      Catch::Matchers::Contains("SecondaryLeftObjectB's inner radius must be "
+                                "less than its outer radius."));
   CHECK_THROWS_WITH(
       domain::creators::BinaryCompactObject(
           {3.3, 1.0, 1.0, {{create_inner_boundary_condition()}}, false},
           {0.5, 1.0, -1.0, {{create_inner_boundary_condition()}}, false}, 25.5,
           32.4, 2_st, 6_st, true, 0.0, std::nullopt, Distribution::Linear,
           create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
-      Catch::Matchers::Contains(
-          "ObjectA's inner radius must be less than its outer radius."));
+      Catch::Matchers::Contains("PrimaryRightObjectA's inner radius must be "
+                                "less than its outer radius."));
   CHECK_THROWS_WITH(
       domain::creators::BinaryCompactObject(
           {0.3, 1.0, 1.0, {{create_inner_boundary_condition()}}, false},

--- a/tests/Unit/Domain/Creators/Test_BinaryCompactObject.cpp
+++ b/tests/Unit/Domain/Creators/Test_BinaryCompactObject.cpp
@@ -83,14 +83,14 @@ create_outer_boundary_condition() {
 
 void test_connectivity() {
   // ObjectA:
-  constexpr double inner_radius_objectA = 0.5;
+  constexpr double inner_radius_objectA = 0.3;
   constexpr double outer_radius_objectA = 1.0;
-  constexpr double xcoord_objectA = -3.0;
+  constexpr double xcoord_objectA = 3.0;
 
   // ObjectB:
-  constexpr double inner_radius_objectB = 0.3;
+  constexpr double inner_radius_objectB = 0.5;
   constexpr double outer_radius_objectB = 1.0;
-  constexpr double xcoord_objectB = 3.0;
+  constexpr double xcoord_objectB = -3.0;
 
   // Enveloping Cube:
   constexpr double radius_enveloping_cube = 25.5;
@@ -164,18 +164,18 @@ void test_connectivity() {
                   binary_compact_object, with_boundary_conditions);
 
           std::vector<std::string> expected_block_names{
-              "ObjectAShellUpperZ",       "ObjectAShellLowerZ",
-              "ObjectAShellUpperY",       "ObjectAShellLowerY",
-              "ObjectAShellUpperX",       "ObjectAShellLowerX",
-              "ObjectACubeUpperZ",        "ObjectACubeLowerZ",
-              "ObjectACubeUpperY",        "ObjectACubeLowerY",
-              "ObjectACubeUpperX",        "ObjectACubeLowerX",
               "ObjectBShellUpperZ",       "ObjectBShellLowerZ",
               "ObjectBShellUpperY",       "ObjectBShellLowerY",
               "ObjectBShellUpperX",       "ObjectBShellLowerX",
               "ObjectBCubeUpperZ",        "ObjectBCubeLowerZ",
               "ObjectBCubeUpperY",        "ObjectBCubeLowerY",
               "ObjectBCubeUpperX",        "ObjectBCubeLowerX",
+              "ObjectAShellUpperZ",       "ObjectAShellLowerZ",
+              "ObjectAShellUpperY",       "ObjectAShellLowerY",
+              "ObjectAShellUpperX",       "ObjectAShellLowerX",
+              "ObjectACubeUpperZ",        "ObjectACubeLowerZ",
+              "ObjectACubeUpperY",        "ObjectACubeLowerY",
+              "ObjectACubeUpperX",        "ObjectACubeLowerX",
               "EnvelopingCubeUpperZLeft", "EnvelopingCubeUpperZRight",
               "EnvelopingCubeLowerZLeft", "EnvelopingCubeLowerZRight",
               "EnvelopingCubeUpperYLeft", "EnvelopingCubeUpperYRight",
@@ -242,24 +242,24 @@ void test_connectivity() {
                 "ObjectAExcisionSphere",
                 ExcisionSphere<3>{inner_radius_objectA,
                                   {{xcoord_objectA, 0.0, 0.0}},
-                                  {{0, Direction<3>::lower_zeta()},
-                                   {1, Direction<3>::lower_zeta()},
-                                   {2, Direction<3>::lower_zeta()},
-                                   {3, Direction<3>::lower_zeta()},
-                                   {4, Direction<3>::lower_zeta()},
-                                   {5, Direction<3>::lower_zeta()}}});
-          }
-          if (excise_interiorB) {
-            expected_excision_spheres.emplace(
-                "ObjectBExcisionSphere",
-                ExcisionSphere<3>{inner_radius_objectB,
-                                  {{xcoord_objectB, 0.0, 0.0}},
                                   {{12, Direction<3>::lower_zeta()},
                                    {13, Direction<3>::lower_zeta()},
                                    {14, Direction<3>::lower_zeta()},
                                    {15, Direction<3>::lower_zeta()},
                                    {16, Direction<3>::lower_zeta()},
                                    {17, Direction<3>::lower_zeta()}}});
+          }
+          if (excise_interiorB) {
+            expected_excision_spheres.emplace(
+                "ObjectBExcisionSphere",
+                ExcisionSphere<3>{inner_radius_objectB,
+                                  {{xcoord_objectB, 0.0, 0.0}},
+                                  {{0, Direction<3>::lower_zeta()},
+                                   {1, Direction<3>::lower_zeta()},
+                                   {2, Direction<3>::lower_zeta()},
+                                   {3, Direction<3>::lower_zeta()},
+                                   {4, Direction<3>::lower_zeta()},
+                                   {5, Direction<3>::lower_zeta()}}});
           }
           CHECK(domain.excision_spheres() == expected_excision_spheres);
 
@@ -450,16 +450,16 @@ std::string create_option_string(const bool excise_A, const bool excise_B,
                              : ""};
   return "BinaryCompactObject:\n"
          "  ObjectA:\n"
-         "    InnerRadius: 0.2\n"
-         "    OuterRadius: 1.0\n"
-         "    XCoord: -2.0\n" +
+         "    InnerRadius: 1.0\n"
+         "    OuterRadius: 2.0\n"
+         "    XCoord: 3.0\n" +
          interior_A +
          "    UseLogarithmicMap: " + stringize(use_logarithmic_map_AB) +
          "\n"
          "  ObjectB:\n"
-         "    InnerRadius: 1.0\n"
-         "    OuterRadius: 2.0\n"
-         "    XCoord: 3.0\n" +
+         "    InnerRadius: 0.2\n"
+         "    OuterRadius: 1.0\n"
+         "    XCoord: -2.0\n" +
          interior_B +
          "    UseLogarithmicMap: " + stringize(use_logarithmic_map_AB) +
          "\n"
@@ -659,58 +659,48 @@ void test_binary_factory() {
 void test_parse_errors() {
   CHECK_THROWS_WITH(
       domain::creators::BinaryCompactObject(
-          {0.5, 1.0, 1.0, {{create_inner_boundary_condition()}}, false},
-          {0.3, 1.0, 1.0, {{create_inner_boundary_condition()}}, false}, 25.5,
-          32.4, 2_st, 6_st, true, 0.0, std::nullopt, Distribution::Linear,
-          create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
-      Catch::Matchers::Contains(
-          "The x-coordinate of ObjectA's center is expected to be negative."));
-  CHECK_THROWS_WITH(
-      domain::creators::BinaryCompactObject(
           {0.5, 1.0, -1.0, {{create_inner_boundary_condition()}}, false},
           {0.3, 1.0, -1.0, {{create_inner_boundary_condition()}}, false}, 25.5,
           32.4, 2_st, 6_st, true, 0.0, std::nullopt, Distribution::Linear,
           create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
       Catch::Matchers::Contains(
-          "The x-coordinate of ObjectB's center is expected to be positive."));
+          "The x-coordinate of ObjectA's center is expected to be positive."));
   CHECK_THROWS_WITH(
       domain::creators::BinaryCompactObject(
-          {0.5, 1.0, -7.0, {{create_inner_boundary_condition()}}, false},
-          {0.3, 1.0, 8.0, {{create_inner_boundary_condition()}}, false}, 25.5,
+          {0.5, 1.0, 1.0, {{create_inner_boundary_condition()}}, false},
+          {0.3, 1.0, 1.0, {{create_inner_boundary_condition()}}, false}, 25.5,
+          32.4, 2_st, 6_st, true, 0.0, std::nullopt, Distribution::Linear,
+          create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
+      Catch::Matchers::Contains(
+          "The x-coordinate of ObjectB's center is expected to be negative."));
+  CHECK_THROWS_WITH(
+      domain::creators::BinaryCompactObject(
+          {0.3, 1.0, 8.0, {{create_inner_boundary_condition()}}, false},
+          {0.5, 1.0, -7.0, {{create_inner_boundary_condition()}}, false}, 25.5,
           32.4, 2_st, 6_st, true, 0.0, std::nullopt, Distribution::Linear,
           create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
       Catch::Matchers::Contains("The radius for the enveloping cube is too "
                                 "small! The Frustums will be malformed."));
   CHECK_THROWS_WITH(
       domain::creators::BinaryCompactObject(
-          {1.5, 1.0, -1.0, {{create_inner_boundary_condition()}}, false},
-          {0.3, 1.0, 1.0, {{create_inner_boundary_condition()}}, false}, 25.5,
-          32.4, 2_st, 6_st, true, 0.0, std::nullopt, Distribution::Linear,
-          create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
-      Catch::Matchers::Contains(
-          "ObjectA's inner radius must be less than its outer radius."));
-  CHECK_THROWS_WITH(
-      domain::creators::BinaryCompactObject(
-          {0.5, 1.0, -1.0, {{create_inner_boundary_condition()}}, false},
-          {3.3, 1.0, 1.0, {{create_inner_boundary_condition()}}, false}, 25.5,
+          {0.3, 1.0, 1.0, {{create_inner_boundary_condition()}}, false},
+          {1.5, 1.0, -1.0, {{create_inner_boundary_condition()}}, false}, 25.5,
           32.4, 2_st, 6_st, true, 0.0, std::nullopt, Distribution::Linear,
           create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
       Catch::Matchers::Contains(
           "ObjectB's inner radius must be less than its outer radius."));
   CHECK_THROWS_WITH(
       domain::creators::BinaryCompactObject(
-          {0.5, 1.0, -1.0, std::nullopt, true},
-          {0.3, 1.0, 1.0, {{create_inner_boundary_condition()}}, false}, 25.5,
+          {3.3, 1.0, 1.0, {{create_inner_boundary_condition()}}, false},
+          {0.5, 1.0, -1.0, {{create_inner_boundary_condition()}}, false}, 25.5,
           32.4, 2_st, 6_st, true, 0.0, std::nullopt, Distribution::Linear,
           create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
       Catch::Matchers::Contains(
-          "Using a logarithmically spaced radial grid in the "
-          "part of Layer 1 enveloping Object A requires excising the interior "
-          "of Object A"));
+          "ObjectA's inner radius must be less than its outer radius."));
   CHECK_THROWS_WITH(
       domain::creators::BinaryCompactObject(
-          {0.5, 1.0, -1.0, {{create_inner_boundary_condition()}}, false},
-          {0.3, 1.0, 1.0, std::nullopt, true}, 25.5, 32.4, 2_st, 6_st, true,
+          {0.3, 1.0, 1.0, {{create_inner_boundary_condition()}}, false},
+          {0.5, 1.0, -1.0, std::nullopt, true}, 25.5, 32.4, 2_st, 6_st, true,
           0.0, std::nullopt, Distribution::Linear,
           create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
       Catch::Matchers::Contains(
@@ -719,24 +709,34 @@ void test_parse_errors() {
           "of Object B"));
   CHECK_THROWS_WITH(
       domain::creators::BinaryCompactObject(
-          {0.5, 1.0, -1.0, {{create_inner_boundary_condition()}}, false},
-          {0.3, 1.0, 1.0, {{create_inner_boundary_condition()}}, false}, 25.5,
+          {0.3, 1.0, 1.0, std::nullopt, true},
+          {0.5, 1.0, -1.0, {{create_inner_boundary_condition()}}, false}, 25.5,
+          32.4, 2_st, 6_st, true, 0.0, std::nullopt, Distribution::Linear,
+          create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
+      Catch::Matchers::Contains(
+          "Using a logarithmically spaced radial grid in the "
+          "part of Layer 1 enveloping Object A requires excising the interior "
+          "of Object A"));
+  CHECK_THROWS_WITH(
+      domain::creators::BinaryCompactObject(
+          {0.3, 1.0, 1.0, {{create_inner_boundary_condition()}}, false},
+          {0.5, 1.0, -1.0, {{create_inner_boundary_condition()}}, false}, 25.5,
           32.4, std::vector<std::array<size_t, 3>>{}, 6_st, true, 0.0,
           std::nullopt, Distribution::Linear, create_outer_boundary_condition(),
           Options::Context{false, {}, 1, 1}),
       Catch::Matchers::Contains("Invalid 'InitialRefinement'"));
   CHECK_THROWS_WITH(
       domain::creators::BinaryCompactObject(
-          {0.5, 1.0, -1.0, {{create_inner_boundary_condition()}}, false},
-          {0.3, 1.0, 1.0, {{create_inner_boundary_condition()}}, false}, 25.5,
+          {0.3, 1.0, 1.0, {{create_inner_boundary_condition()}}, false},
+          {0.5, 1.0, -1.0, {{create_inner_boundary_condition()}}, false}, 25.5,
           32.4, 2_st, std::vector<std::array<size_t, 3>>{}, true, 0.0,
           std::nullopt, Distribution::Linear, create_outer_boundary_condition(),
           Options::Context{false, {}, 1, 1}),
       Catch::Matchers::Contains("Invalid 'InitialGridPoints'"));
   CHECK_THROWS_WITH(
       domain::creators::BinaryCompactObject(
-          {0.5, 1.0, -1.0, {{create_inner_boundary_condition()}}, false},
-          {0.3, 1.0, 1.0, {{create_inner_boundary_condition()}}, false}, 25.5,
+          {0.3, 1.0, 1.0, {{create_inner_boundary_condition()}}, false},
+          {0.5, 1.0, -1.0, {{create_inner_boundary_condition()}}, false}, 25.5,
           32.4, 2_st, 6_st, true, 0.0, 35., Distribution::Linear,
           create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
       Catch::Matchers::Contains("The 'OuterShell.InnerRadius' must be within"));

--- a/tests/Unit/Domain/Creators/Test_CylindricalBinaryCompactObject.cpp
+++ b/tests/Unit/Domain/Creators/Test_CylindricalBinaryCompactObject.cpp
@@ -75,7 +75,7 @@ create_outer_boundary_condition() {
 }
 
 void test_connectivity() {
-  // ObjectA:
+  // PrimaryRightObjectA:
   constexpr double inner_radius_objectA = 1.0;
 
   // Misc.:
@@ -87,10 +87,10 @@ void test_connectivity() {
   // loop go over {true, false}
   for (const bool with_sphere_e : {false}) {
     CAPTURE(with_sphere_e);
-    // ObjectA:
+    // PrimaryRightObjectA:
     const std::array<double, 3> center_objectA = {with_sphere_e ? 2.0 : 3.0,
                                                   0.05, 0.0};
-    // ObjectB:
+    // SecondaryLeftObjectB:
     const double inner_radius_objectB = with_sphere_e ? 0.4 : 1.0;
     const std::array<double, 3> center_objectB = {with_sphere_e ? -5.0 : -3.0,
                                                   0.05, 0.0};

--- a/tests/Unit/Helpers/ControlSystem/Examples.hpp
+++ b/tests/Unit/Helpers/ControlSystem/Examples.hpp
@@ -98,6 +98,8 @@ struct ExampleMeasurement
 /// [ControlError]
 struct ExampleControlError
     : tt::ConformsTo<control_system::protocols::ControlError> {
+  static constexpr size_t expected_number_of_excisions = 1;
+
   void pup(PUP::er& /*p*/) {}
 
   template <typename Metavariables, typename... QueueTags>

--- a/tests/Unit/Helpers/ControlSystem/SystemHelpers.hpp
+++ b/tests/Unit/Helpers/ControlSystem/SystemHelpers.hpp
@@ -564,7 +564,7 @@ struct SystemHelper {
         std::unordered_map<std::string, ExcisionSphere<3>>{
             {"ObjectAExcisionSphere",
              ExcisionSphere<3>{excision_radius,
-                               {{-0.5 * initial_separation, 0.0, 0.0}},
+                               {{+0.5 * initial_separation, 0.0, 0.0}},
                                {{0, Direction<3>::lower_zeta()},
                                 {1, Direction<3>::lower_zeta()},
                                 {2, Direction<3>::lower_zeta()},
@@ -573,7 +573,7 @@ struct SystemHelper {
                                 {5, Direction<3>::lower_zeta()}}}},
             {"ObjectBExcisionSphere",
              ExcisionSphere<3>{excision_radius,
-                               {{+0.5 * initial_separation, 0.0, 0.0}},
+                               {{-0.5 * initial_separation, 0.0, 0.0}},
                                {{0, Direction<3>::lower_zeta()},
                                 {1, Direction<3>::lower_zeta()},
                                 {2, Direction<3>::lower_zeta()},

--- a/tests/Unit/Helpers/ControlSystem/SystemHelpers.hpp
+++ b/tests/Unit/Helpers/ControlSystem/SystemHelpers.hpp
@@ -116,7 +116,7 @@ class FakeCreator : public DomainCreator<3> {
     std::unordered_map<std::string, ExcisionSphere<3>> excision_spheres{};
     if (number_of_excisions_ > 0) {
       excision_spheres.insert(
-          {"ObjectAExcisionSphere",
+          {"PrimaryRightObjectAExcisionSphere",
            ExcisionSphere<3>{1.3,
                              {{+0.9, 0.0, 0.0}},
                              {{0, Direction<3>::lower_zeta()},
@@ -128,7 +128,7 @@ class FakeCreator : public DomainCreator<3> {
     }
     if (number_of_excisions_ > 1) {
       excision_spheres.insert(
-          {"ObjectBExcisionSphere",
+          {"SecondaryLeftObjectBExcisionSphere",
            ExcisionSphere<3>{0.8,
                              {{-1.1, 0.0, 0.0}},
                              {{0, Direction<3>::lower_zeta()},
@@ -597,7 +597,7 @@ struct SystemHelper {
     // have these specific names hard-coded into them.
     stored_excision_spheres_ =
         std::unordered_map<std::string, ExcisionSphere<3>>{
-            {"ObjectAExcisionSphere",
+            {"PrimaryRightObjectAExcisionSphere",
              ExcisionSphere<3>{excision_radius,
                                {{+0.5 * initial_separation, 0.0, 0.0}},
                                {{0, Direction<3>::lower_zeta()},
@@ -606,7 +606,7 @@ struct SystemHelper {
                                 {3, Direction<3>::lower_zeta()},
                                 {4, Direction<3>::lower_zeta()},
                                 {5, Direction<3>::lower_zeta()}}}},
-            {"ObjectBExcisionSphere",
+            {"SecondaryLeftObjectBExcisionSphere",
              ExcisionSphere<3>{excision_radius,
                                {{-0.5 * initial_separation, 0.0, 0.0}},
                                {{0, Direction<3>::lower_zeta()},

--- a/tests/Unit/Helpers/ControlSystem/TestStructs.hpp
+++ b/tests/Unit/Helpers/ControlSystem/TestStructs.hpp
@@ -30,7 +30,9 @@ struct Measurement : tt::ConformsTo<control_system::protocols::Measurement> {
   using submeasurements = tmpl::list<>;
 };
 
+template <size_t NumExcisions>
 struct ControlError : tt::ConformsTo<control_system::protocols::ControlError> {
+  static constexpr size_t expected_number_of_excisions = NumExcisions;
   void pup(PUP::er& /*p*/) {}
 
   using options = tmpl::list<>;
@@ -48,7 +50,8 @@ struct ControlError : tt::ConformsTo<control_system::protocols::ControlError> {
 static_assert(tt::assert_conforms_to_v<Measurement<TestStructs_detail::LabelA>,
                                        control_system::protocols::Measurement>);
 
-template <size_t DerivOrder, typename Label, typename Measurement>
+template <size_t DerivOrder, typename Label, typename Measurement,
+          size_t NumExcisions = 0>
 struct System : tt::ConformsTo<control_system::protocols::ControlSystem> {
   static std::string name() { return pretty_type::short_name<Label>(); }
   static std::optional<std::string> component_name(
@@ -57,7 +60,7 @@ struct System : tt::ConformsTo<control_system::protocols::ControlSystem> {
   }
   using measurement = Measurement;
   using simple_tags = tmpl::list<>;
-  using control_error = ControlError;
+  using control_error = ControlError<NumExcisions>;
   static constexpr size_t deriv_order = DerivOrder;
 };
 

--- a/tests/Unit/Helpers/PointwiseFunctions/PostNewtonian/BinaryTrajectories.cpp
+++ b/tests/Unit/Helpers/PointwiseFunctions/PostNewtonian/BinaryTrajectories.cpp
@@ -52,10 +52,10 @@ std::pair<std::array<double, 3>, std::array<double, 3>>
 BinaryTrajectories::position_impl(const double time,
                                   const double separation) const {
   const double orbital_freq = orbital_frequency(time);
-  double xB = 0.5 * separation * cos(orbital_freq * time);
-  double yB = 0.5 * separation * sin(orbital_freq * time);
-  double xA = -xB;
-  double yA = -yB;
+  double xA = 0.5 * separation * cos(orbital_freq * time);
+  double yA = 0.5 * separation * sin(orbital_freq * time);
+  double xB = -xA;
+  double yB = -yA;
   xB += velocity_[0] * time;
   xA += velocity_[0] * time;
   yB += velocity_[1] * time;

--- a/tests/Unit/Helpers/PointwiseFunctions/PostNewtonian/BinaryTrajectories.hpp
+++ b/tests/Unit/Helpers/PointwiseFunctions/PostNewtonian/BinaryTrajectories.hpp
@@ -19,10 +19,10 @@
  * \f}
  * In terms of these functions, the positions of objects 1 and 2 are
  * \f{align}{
- *   x_1(t) &= \frac{r(t)}{2}\cos\left[\Omega(t) t\right] + v_x t, \\
- *   y_1(t) &= \frac{r(t)}{2}\sin\left[\Omega(t) t\right], + v_y t\\
- *   x_2(t) &= -\frac{r(t)}{2}\cos\left[\Omega(t) t\right], + v_x t\\
- *   y_2(t) &= -\frac{r(t)}{2}\sin\left[\Omega(t) t\right], + v_y t\\
+ *   x_1(t) &= -\frac{r(t)}{2}\cos\left[\Omega(t) t\right] + v_x t, \\
+ *   y_1(t) &= -\frac{r(t)}{2}\sin\left[\Omega(t) t\right], + v_y t\\
+ *   x_2(t) &= \frac{r(t)}{2}\cos\left[\Omega(t) t\right], + v_x t\\
+ *   y_2(t) &= \frac{r(t)}{2}\sin\left[\Omega(t) t\right], + v_y t\\
  *   z_1(t) &= z_2(t) = v_z t.
  * \f} These trajectories are useful for, e.g., testing a horizon-tracking
  * control system.

--- a/tests/Unit/Helpers/Tests/PointwiseFunctions/PostNewtonian/BinaryTrajectories.py
+++ b/tests/Unit/Helpers/Tests/PointwiseFunctions/PostNewtonian/BinaryTrajectories.py
@@ -36,10 +36,10 @@ def position_helper(time, init_sep, newtonian, sign, no_expansion):
 def positions1(time, newtonian, no_expansion):
     newt = True if newtonian > 0.0 else False
     no_exp = True if no_expansion > 0.0 else False
-    return position_helper(time, initial_separation, newt, -1.0, no_exp)
+    return position_helper(time, initial_separation, newt, +1.0, no_exp)
 
 
 def positions2(time, newtonian, no_expansion):
     newt = True if newtonian > 0.0 else False
     no_exp = True if no_expansion > 0.0 else False
-    return position_helper(time, initial_separation, newt, +1.0, no_exp)
+    return position_helper(time, initial_separation, newt, -1.0, no_exp)

--- a/tests/Unit/PointwiseFunctions/AnalyticData/Xcts/Test_Binary.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/Xcts/Test_Binary.cpp
@@ -125,11 +125,11 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.AnalyticData.Xcts.Binary",
   test_data({{-5., 6.}}, 0.02, 0.01, {{7., 8.}}, {{1.1, 0.43}}, "bbh_isotropic",
             "Binary:\n"
             "  XCoords: [-5., 6.]\n"
-            "  ObjectA:\n"
+            "  PrimaryRightObjectA:\n"
             "    Schwarzschild:\n"
             "      Mass: 1.1\n"
             "      Coordinates: Isotropic\n"
-            "  ObjectB:\n"
+            "  SecondaryLeftObjectB:\n"
             "    Schwarzschild:\n"
             "      Mass: 0.43\n"
             "      Coordinates: Isotropic\n"


### PR DESCRIPTION
## Proposed changes

This PR does 4 things that are all related to each other:

1. Swaps the meaning of `ObjectA` and `ObjectB` in the BinaryCompactObject domain creator to match what is in the CylindricalBinaryCompactObject domain creator and what SpEC uses. Namely that `ObjectA` is on the postiive x-axis and `ObjectB` is on the negative x-axis.
2. Adds some additional restrictions on `ObjectA` and `ObjectB` in the BinaryCompactObject domain creator. Namely that if both objects are excised, then `ObjectA` must now be the larger of the two objects (larger inner radii and x-coord smaller in magnitude).
3. Adds some protections in the control system to error during option parsing if excision spheres aren't added to the domain.
4. Renames `ObjectA` to `PrimaryRightObjectA` and `ObjectB` to `SecondaryLeftObjectB` throughout the code to make it clear that the larger object is called `A` and is on the positive x-axis and the smaller object is called `B` and is on the negative x-axis.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
If you are using the `BinaryCompactObject` or `CylindricalBinaryCompactObject` domain creators, implement the follow name changes in your input files:
- `ObjectA` -> `PrimaryRightObjectA`
- `ObjectB` -> `SecondaryLeftObjectB`

Also, additional restrictions were added to the `BinaryCompactObject` domain creator so read the documentation to see what is allowed.
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
