### PR TITLE
Fix density and temperature bounds in Compose table reader

### DIFF
--- a/src/IO/ComposeTable.cpp
+++ b/src/IO/ComposeTable.cpp
@@ -134,19 +134,19 @@ void ComposeTable::parse_eos_parameters() {
       "tabulation scheme") {
     ERROR("Read unexpected comment line: '" << line_buffer << "'");
   }
-  parameters_file >> number_density_bounds_[0] >> temperature_bounds_[0] >>
+  parameters_file >> temperature_bounds_[0] >> number_density_bounds_[0] >>
       electron_fraction_bounds_[0];
   std::getline(parameters_file, line_buffer);  // Read rest of line (newline)
-  parameters_file >> number_density_bounds_[1] >> temperature_bounds_[1] >>
+  parameters_file >> temperature_bounds_[1] >> number_density_bounds_[1] >>
       electron_fraction_bounds_[1];
   std::getline(parameters_file, line_buffer);  // Read rest of line (newline)
-  parameters_file >> number_density_number_of_points_ >>
-      temperature_number_of_points_ >> electron_fraction_number_of_points_;
+  parameters_file >> temperature_number_of_points_ >>
+      number_density_number_of_points_ >> electron_fraction_number_of_points_;
   table_size_ = number_density_number_of_points_ *
                 temperature_number_of_points_ *
                 electron_fraction_number_of_points_;
   std::getline(parameters_file, line_buffer);  // Read rest of line (newline)
-  parameters_file >> number_density_log_spacing_ >> temperature_log_spacing_ >>
+  parameters_file >> temperature_log_spacing_ >> number_density_log_spacing_ >>
       electron_fraction_log_spacing_;
 }
 

--- a/tests/Unit/IO/Test_ComposeTable.cpp
+++ b/tests/Unit/IO/Test_ComposeTable.cpp
@@ -18,16 +18,16 @@
 
 namespace {
 void test_table(const io::ComposeTable& compose_table) {
-  CHECK(compose_table.number_density_bounds()[0] ==
-        approx(0.10000000000000001));
-  CHECK(compose_table.number_density_bounds()[1] == approx(158.0));
   CHECK(compose_table.temperature_bounds()[0] ==
+        approx(0.10000000000000001));
+  CHECK(compose_table.temperature_bounds()[1] == approx(158.0));
+  CHECK(compose_table.number_density_bounds()[0] ==
         approx(1.0000000000000000e-12));
-  CHECK(compose_table.temperature_bounds()[1] == approx(1.9));
+  CHECK(compose_table.number_density_bounds()[1] == approx(1.9));
   CHECK(compose_table.electron_fraction_bounds()[0] == approx(0.01));
   CHECK(compose_table.electron_fraction_bounds()[1] == approx(0.6));
-  CHECK(compose_table.number_density_number_of_points() == 2);
-  CHECK(compose_table.temperature_number_of_points() == 4);
+  CHECK(compose_table.number_density_number_of_points() == 4);
+  CHECK(compose_table.temperature_number_of_points() == 2);
   CHECK(compose_table.electron_fraction_number_of_points() == 3);
   CHECK(compose_table.beta_equilibrium() == false);
   CHECK(compose_table.number_density_log_spacing() == true);


### PR DESCRIPTION
The compose table reader was internally swapping density and temperature bounds when reading from the compose file eos.parameters.

With this change, compose tables converted to spectre format are read in correctly in PR #4468 .

