### PR TITLE
Swap meaning of objects A and B in BinaryCompactObject domain creator

### DIFF
--- a/src/ControlSystem/ControlErrors/Expansion.hpp
+++ b/src/ControlSystem/ControlErrors/Expansion.hpp
@@ -42,8 +42,8 @@ namespace ControlErrors {
  *   \delta a &= a\left( \frac{\vec{X}\cdot\vec{C}}{||\vec{C}||^2} - 1 \right)
  * \\ \delta a &= a\left( \frac{X_0}{C_0} - 1 \right) \f}
  *
- * where \f$\vec{X} = \vec{x}_B - \vec{x}_A\f$ and \f$\vec{C} = \vec{c}_B -
- * \vec{c}_A\f$. Here, object B is located on the positive x-axis and object A
+ * where \f$\vec{X} = \vec{x}_A - \vec{x}_B\f$ and \f$\vec{C} = \vec{c}_A -
+ * \vec{c}_B\f$. Here, object A is located on the positive x-axis and object B
  * is located on the negative x-axis, \f$\vec{X}\f$ is the difference in
  * positions of the centers of the mapped objects, and
  * \f$\vec{C}\f$ is the difference of the centers of the excision spheres, all
@@ -87,12 +87,12 @@ struct Expansion : tt::ConformsTo<protocols::ControlError> {
     const double current_position_of_A = get<center_A>(measurements)[0];
     const double current_position_of_B = get<center_B>(measurements)[0];
 
-    // A is to the left of B in grid frame. To get positive differences,
-    // take B - A
+    // A is to the right of B in grid frame. To get positive differences,
+    // take A - B
     const double expected_expansion_factor =
         current_expansion_factor *
-        (current_position_of_B - current_position_of_A) /
-        (grid_position_of_B - grid_position_of_A);
+        (current_position_of_A - current_position_of_B) /
+        (grid_position_of_A - grid_position_of_B);
 
     return {expected_expansion_factor - current_expansion_factor};
   }

--- a/src/ControlSystem/ControlErrors/Rotation.hpp
+++ b/src/ControlSystem/ControlErrors/Rotation.hpp
@@ -39,8 +39,8 @@ namespace ControlErrors {
  *
  * \f[ \delta\vec{q} = \frac{\vec{C}\times\vec{X}}{\vec{C}\cdot\vec{X}} \f]
  *
- * where \f$\vec{X} = \vec{x}_B - \vec{x}_A\f$ and \f$\vec{C} = \vec{c}_B -
- * \vec{c}_A\f$. Here, object B is located on the positive x-axis and object A
+ * where \f$\vec{X} = \vec{x}_A - \vec{x}_B\f$ and \f$\vec{C} = \vec{c}_A -
+ * \vec{c}_B\f$. Here, object A is located on the positive x-axis and object B
  * is located on the negative x-axis, \f$\vec{X}\f$ is the difference in
  * positions of the centers of the mapped objects, and
  * \f$\vec{C}\f$ is the difference of the centers of the excision spheres, all
@@ -78,11 +78,11 @@ struct Rotation : tt::ConformsTo<protocols::ControlError> {
     const DataVector& current_position_of_A = get<center_A>(measurements);
     const DataVector& current_position_of_B = get<center_B>(measurements);
 
-    // A is to the left of B in grid frame. To get positive differences,
-    // take B - A
-    const DataVector grid_diff = grid_position_of_B - grid_position_of_A;
+    // A is to the right of B in grid frame. To get positive differences,
+    // take A - B
+    const DataVector grid_diff = grid_position_of_A - grid_position_of_B;
     const DataVector current_diff =
-        current_position_of_B - current_position_of_A;
+        current_position_of_A - current_position_of_B;
 
     const double grid_dot_current = dot(grid_diff, current_diff);
     const DataVector grid_cross_current = cross(grid_diff, current_diff);

--- a/src/ControlSystem/ControlErrors/Translation.hpp
+++ b/src/ControlSystem/ControlErrors/Translation.hpp
@@ -42,19 +42,19 @@ namespace ControlErrors {
  * \details Computes the error in how much the system has translated by using
  * Eq. (42) from \cite Ossokine2013zga. The equation is
  *
- * \f[ \left(0, \delta\vec{T}\right) = a\mathbf{q}\left(\mathbf{x}_B -
- * \mathbf{c}_B - \mathbf{\delta q}\wedge\mathbf{c}_B - \frac{\delta
- * a}{a}\mathbf{c}_B \right)\mathbf{q}^*
+ * \f[ \left(0, \delta\vec{T}\right) = a\mathbf{q}\left(\mathbf{x}_A -
+ * \mathbf{c}_A - \mathbf{\delta q}\wedge\mathbf{c}_A - \frac{\delta
+ * a}{a}\mathbf{c}_A \right)\mathbf{q}^*
  * \f]
  *
- * where object B is located on the positive x-axis, bold face letters are
- * quaternions, vectors are promoted to quaternions as \f$ \mathbf{v} = (0,
- * \vec{v}) \f$, \f$ \mathbf{q} \f$ is the quaternion from the \link
- * domain::CoordinateMaps::TimeDependent::Rotation Rotation \endlink map, \f$ a
- * \f$ is the function \f$ a(t) \f$ from the \link
+ * where object A is located on the positive x-axis in the grid frame, bold face
+ * letters are quaternions, vectors are promoted to quaternions as \f$
+ * \mathbf{v} = (0, \vec{v}) \f$, \f$ \mathbf{q} \f$ is the quaternion from the
+ * \link domain::CoordinateMaps::TimeDependent::Rotation Rotation \endlink map,
+ * \f$ a \f$ is the function \f$ a(t) \f$ from the \link
  * domain::CoordinateMaps::TimeDependent::CubicScale CubicScale \endlink map,
- * \f$ \mathbf{\delta q}\wedge\mathbf{c}_B \equiv (0, \delta\vec{q} \times
- * \vec{c}_B) \f$, \f$ \delta\vec{q} \f$ is the \link
+ * \f$ \mathbf{\delta q}\wedge\mathbf{c}_A \equiv (0, \delta\vec{q} \times
+ * \vec{c}_A) \f$, \f$ \delta\vec{q} \f$ is the \link
  * control_system::ControlErrors::Rotation Rotation \endlink control error, and
  * \f$ \delta a\f$ is the \link control_system::ControlErrors::Expansion
  * Expansion \endlink control error.
@@ -91,27 +91,27 @@ struct Translation : tt::ConformsTo<protocols::ControlError> {
     const double expansion_factor =
         functions_of_time.at("Expansion")->func(time)[0][0];
 
-    using center_B = control_system::QueueTags::Center<::ah::ObjectLabel::B>;
+    using center_A = control_system::QueueTags::Center<::ah::ObjectLabel::A>;
 
-    const DataVector grid_position_of_B = array_to_datavector(
-        domain.excision_spheres().at("ObjectBExcisionSphere").center());
-    const DataVector& current_position_of_B = get<center_B>(measurements);
+    const DataVector grid_position_of_A = array_to_datavector(
+        domain.excision_spheres().at("ObjectAExcisionSphere").center());
+    const DataVector& current_position_of_A = get<center_A>(measurements);
 
     const DataVector rotation_error =
         rotation_control_error_(cache, time, "Rotation", measurements);
-    // Use B because it's on the positive x-axis, however, A would work as well.
+    // Use A because it's on the positive x-axis, however, B would work as well.
     // Just so long as we are consistent.
-    const DataVector rotation_error_cross_grid_pos_B =
-        cross(rotation_error, grid_position_of_B);
+    const DataVector rotation_error_cross_grid_pos_A =
+        cross(rotation_error, grid_position_of_A);
 
     const double expansion_error =
         expansion_control_error_(cache, time, "Expansion", measurements)[0];
 
     // From eq. 42 in 1304.3067
     const quat middle_expression = datavector_to_quaternion(
-        current_position_of_B -
-        (1.0 + expansion_error / expansion_factor) * grid_position_of_B -
-        rotation_error_cross_grid_pos_B);
+        current_position_of_A -
+        (1.0 + expansion_error / expansion_factor) * grid_position_of_A -
+        rotation_error_cross_grid_pos_A);
 
     // Because we are converting from a quaternion to a DataVector, there will
     // be four components in the DataVector. However, translation control only

--- a/src/Domain/Creators/BinaryCompactObject.cpp
+++ b/src/Domain/Creators/BinaryCompactObject.cpp
@@ -106,15 +106,15 @@ BinaryCompactObject::BinaryCompactObject(
     number_of_blocks_++;
   }
 
-  if (object_A_.x_coord >= 0.0) {
+  if (object_A_.x_coord <= 0.0) {
     PARSE_ERROR(
         context,
-        "The x-coordinate of ObjectA's center is expected to be negative.");
+        "The x-coordinate of ObjectA's center is expected to be positive.");
   }
-  if (object_B_.x_coord <= 0.0) {
+  if (object_B_.x_coord >= 0.0) {
     PARSE_ERROR(
         context,
-        "The x-coordinate of ObjectB's center is expected to be positive.");
+        "The x-coordinate of ObjectB's center is expected to be negative.");
   }
   if (length_outer_cube_ <= 2.0 * length_inner_cube_) {
     const double suggested_value = 2.0 * length_inner_cube_ * sqrt(3.0);
@@ -365,7 +365,7 @@ Domain<3> BinaryCompactObject::create_domain() const {
   // Each object is surrounded by 6 inner wedges that make a sphere, and another
   // 6 outer wedges that transition to a cube.
 
-  // ObjectA/B is on the left/right, respectively.
+  // ObjectA/B is on the right/left, respectively.
   const Translation translation_A{
       Affine{-1.0, 1.0, -1.0 + object_A_.x_coord, 1.0 + object_A_.x_coord},
       Identity2D{}};
@@ -529,13 +529,8 @@ Domain<3> BinaryCompactObject::create_domain() const {
                            {17, Direction<3>::lower_zeta()}}});
   }
 
-  const size_t num_biradial_layers = need_cube_to_sphere_transition_ ? 3 : 2;
-  Domain<3> domain{std::move(maps),
-                   corners_for_biradially_layered_domains(
-                       2, num_biradial_layers, not object_A_.is_excised(),
-                       not object_B_.is_excised()),
-                   {},
-                   std::move(excision_spheres)};
+  // Have corners determined automatically
+  Domain<3> domain{std::move(maps), std::move(excision_spheres)};
 
   // Inject the hard-coded time-dependence
   if (enable_time_dependence_) {

--- a/src/Domain/Creators/BinaryCompactObject.hpp
+++ b/src/Domain/Creators/BinaryCompactObject.hpp
@@ -122,8 +122,8 @@ namespace creators {
  *
  * In the code and options below, `ObjectA` and `ObjectB` refer to the two
  * compact objects, and by extension, also refer to the layers that immediately
- * surround each compact object. Note that `ObjectA` is located to the left of
- * the origin (along the negative x-axis) and `ObjectB` is located to the right
+ * surround each compact object. Note that `ObjectA` is located to the right of
+ * the origin (along the positive x-axis) and `ObjectB` is located to the left
  * of the origin. `enveloping cube` refers to the outer surface of Layer 3.
  * `outer sphere` is the radius of the spherical outer boundary, which is
  * the outer boundary of Layer 5. The `enveloping cube` and `outer sphere`
@@ -298,14 +298,14 @@ class BinaryCompactObject : public DomainCreator<3> {
   struct ObjectA {
     using type = Object;
     static constexpr Options::String help = {
-        "Options for the object to the left of the origin (along the negative "
+        "Options for the object to the right of the origin (along the positive "
         "x-axis)."};
   };
 
   struct ObjectB {
     using type = Object;
     static constexpr Options::String help = {
-        "Options for the object to the right of the origin (along the positive "
+        "Options for the object to the left of the origin (along the negative "
         "x-axis)."};
   };
 
@@ -572,8 +572,8 @@ class BinaryCompactObject : public DomainCreator<3> {
       "boundary condition or 'false', the region will be excised. The user "
       "specifies Object{A,B}.XCoord, the x-coordinates of the locations of the "
       "centers of each compact object. In these coordinates, the location for "
-      "the axis of rotation is x=0. ObjectA is located on the left and ObjectB "
-      "is located on the right. Please make sure that your choices of "
+      "the axis of rotation is x=0. ObjectA is located on the right and ObjectB"
+      "is located on the left. Please make sure that your choices of "
       "x-coordinate locations are such that the resulting center of mass "
       "is located at zero.\n"
       "\n"

--- a/tests/InputFiles/ExportCoordinates/InputTimeDependent3D.yaml
+++ b/tests/InputFiles/ExportCoordinates/InputTimeDependent3D.yaml
@@ -20,13 +20,13 @@ DomainCreator:
     ObjectA:
       InnerRadius: 0.45825
       OuterRadius: 6.0
-      XCoord: -7.683
+      XCoord: 7.683
       ExciseInterior: true
       UseLogarithmicMap: true
     ObjectB:
       InnerRadius: 0.45825
       OuterRadius: 6.0
-      XCoord: 7.683
+      XCoord: -7.683
       ExciseInterior: true
       UseLogarithmicMap: true
     EnvelopingCube:

--- a/tests/InputFiles/GeneralizedHarmonic/BinaryBlackHole.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/BinaryBlackHole.yaml
@@ -48,7 +48,7 @@ DomainCreator:
     ObjectA:
       InnerRadius: 0.7925
       OuterRadius: 6.683
-      XCoord: &XCoordA -7.683
+      XCoord: &XCoordA 7.683
       Interior:
         ExciseWithBoundaryCondition:
           DemandOutgoingCharSpeeds:
@@ -56,7 +56,7 @@ DomainCreator:
     ObjectB:
       InnerRadius: 0.7925
       OuterRadius: 6.683
-      XCoord: &XCoordB 7.683
+      XCoord: &XCoordB -7.683
       Interior:
         ExciseWithBoundaryCondition:
           DemandOutgoingCharSpeeds:

--- a/tests/InputFiles/Xcts/BinaryBlackHole.yaml
+++ b/tests/InputFiles/Xcts/BinaryBlackHole.yaml
@@ -12,12 +12,12 @@ ResourceInfo:
 Background: &background
   Binary:
     XCoords: [&x_left -8., &x_right 8.]
-    ObjectA: &kerr_left
+    ObjectA: &kerr_right
       KerrSchild:
         Mass: 0.4229
         Spin: [0., 0., 0.]
         Center: [0., 0., 0.]
-    ObjectB: &kerr_right
+    ObjectB: &kerr_left
       KerrSchild:
         Mass: 0.4229
         Spin: [0., 0., 0.]
@@ -33,18 +33,6 @@ DomainCreator:
     ObjectA:
       InnerRadius: 0.8
       OuterRadius: 4.
-      XCoord: *x_left
-      Interior:
-        ExciseWithBoundaryCondition:
-          ApparentHorizon:
-            Center: [*x_left, 0., 0.]
-            Rotation: [0., 0., 0.]
-            Lapse: *kerr_left
-            NegativeExpansion: *kerr_left
-      UseLogarithmicMap: True
-    ObjectB:
-      InnerRadius: 0.8
-      OuterRadius: 4.
       XCoord: *x_right
       Interior:
         ExciseWithBoundaryCondition:
@@ -53,6 +41,18 @@ DomainCreator:
             Rotation: [0., 0., 0.]
             Lapse: *kerr_right
             NegativeExpansion: *kerr_right
+      UseLogarithmicMap: True
+    ObjectB:
+      InnerRadius: 0.8
+      OuterRadius: 4.
+      XCoord: *x_left
+      Interior:
+        ExciseWithBoundaryCondition:
+          ApparentHorizon:
+            Center: [*x_left, 0., 0.]
+            Rotation: [0., 0., 0.]
+            Lapse: *kerr_left
+            NegativeExpansion: *kerr_left
       UseLogarithmicMap: True
     EnvelopingCube:
       Radius: 60.

--- a/tests/Unit/ControlSystem/ControlErrors/Test_Expansion.cpp
+++ b/tests/Unit/ControlSystem/ControlErrors/Test_Expansion.cpp
@@ -92,10 +92,10 @@ void test_expansion_control_error() {
       control_system::QueueTags::Center<::ah::ObjectLabel::B>>;
 
   // Create fake measurements. For expansion we only care about the x component
-  // because that's all that is used. B is on the positive x-axis, A is on the
+  // because that's all that is used. A is on the positive x-axis, B is on the
   // negative x-axis
-  const double pos_A_x = -5.0;
-  const double pos_B_x = 10.0;
+  const double pos_A_x = 10.0;
+  const double pos_B_x = -5.0;
   QueueTuple fake_measurement_tuple{DataVector{pos_A_x, 0.0, 0.0},
                                     DataVector{pos_B_x, 0.0, 0.0}};
 
@@ -111,7 +111,7 @@ void test_expansion_control_error() {
           *functions_of_time.at(expansion_name));
   // Since we haven't updated, the expansion factor should just be 1.0
   const double exp_factor = expansion_f_of_t.func(check_time)[0][0];
-  const double pos_diff = pos_B_x - pos_A_x;
+  const double pos_diff = pos_A_x - pos_B_x;
   const double grid_diff = initial_separation;
 
   const DataVector expected_control_error{exp_factor *

--- a/tests/Unit/ControlSystem/ControlErrors/Test_Rotation.cpp
+++ b/tests/Unit/ControlSystem/ControlErrors/Test_Rotation.cpp
@@ -95,8 +95,8 @@ void test_rotation_control_error() {
       control_system::QueueTags::Center<::ah::ObjectLabel::B>>;
 
   // Create fake measurements.
-  const DataVector pos_A{{-3.0, -4.0, 5.0}};
-  const DataVector pos_B{{2.0, 3.0, 6.0}};
+  const DataVector pos_A{{2.0, 3.0, 6.0}};
+  const DataVector pos_B{{-3.0, -4.0, 5.0}};
   QueueTuple fake_measurement_tuple{pos_A, pos_B};
 
   using ControlError = rotation_system::control_error;

--- a/tests/Unit/ControlSystem/ControlErrors/Test_Translation.cpp
+++ b/tests/Unit/ControlSystem/ControlErrors/Test_Translation.cpp
@@ -97,9 +97,9 @@ void test_translation_control_error() {
       control_system::QueueTags::Center<::ah::ObjectLabel::B>>;
 
   // Create fake measurements.
-  const DataVector pos_A{{-3.0, -4.0, 5.0}};
-  const DataVector pos_B{{2.0, 3.0, 6.0}};
-  const DataVector grid_B{{initial_separation / 2.0, 0.0, 0.0}};
+  const DataVector pos_A{{2.0, 3.0, 6.0}};
+  const DataVector pos_B{{-3.0, -4.0, 5.0}};
+  const DataVector grid_A{{initial_separation / 2.0, 0.0, 0.0}};
   QueueTuple fake_measurement_tuple{pos_A, pos_B};
 
   using ControlError = translation_system::control_error;
@@ -113,19 +113,19 @@ void test_translation_control_error() {
   const DataVector rotation_control_error =
       DataVector{{0.0, -15.0, 105.0}} / 75.0;
   const double expansion_control_error =
-      (pos_B[0] - pos_A[0]) / initial_separation - 1.0;
+      (pos_A[0] - pos_B[0]) / initial_separation - 1.0;
 
   const DataVector rot_control_err_cross_grid =
-      cross(rotation_control_error, grid_B);
+      cross(rotation_control_error, grid_A);
 
   // The quaternion should be the unit quaternion (1,0,0,0) which means the
   // quaternion multiplication in the translation control error is the identity
   // so we avoid actually doing quaternion multiplication. Also the expansion
   // factor should be 1.0 so we don't have to multiply/divide by that where we
   // normally would have
-  const DataVector expected_control_error = pos_B - grid_B -
+  const DataVector expected_control_error = pos_A - grid_A -
                                             rot_control_err_cross_grid -
-                                            expansion_control_error * grid_B;
+                                            expansion_control_error * grid_A;
 
   Approx custom_approx = Approx::custom().epsilon(1.0e-14).scale(1.0);
   CHECK_ITERABLE_CUSTOM_APPROX(control_error, expected_control_error,

--- a/tests/Unit/ControlSystem/Systems/Test_Expansion.cpp
+++ b/tests/Unit/ControlSystem/Systems/Test_Expansion.cpp
@@ -134,7 +134,7 @@ void test_expansion_control_system() {
   const auto position_function = [&binary_trajectories](const double time) {
     const double separation = binary_trajectories.separation(time);
     return std::pair<std::array<double, 3>, std::array<double, 3>>{
-        {-0.5 * separation, 0.0, 0.0}, {0.5 * separation, 0.0, 0.0}};
+        {0.5 * separation, 0.0, 0.0}, {-0.5 * separation, 0.0, 0.0}};
   };
 
   const auto horizon_function = [&position_function, &runner,
@@ -156,9 +156,9 @@ void test_expansion_control_system() {
 
   // Our expected positions are just the initial positions
   const std::array<double, 3> expected_grid_position_of_a{
-      {-0.5 * initial_separation, 0.0, 0.0}};
-  const std::array<double, 3> expected_grid_position_of_b{
       {0.5 * initial_separation, 0.0, 0.0}};
+  const std::array<double, 3> expected_grid_position_of_b{
+      {-0.5 * initial_separation, 0.0, 0.0}};
 
   const auto& expansion_f_of_t =
       dynamic_cast<domain::FunctionsOfTime::PiecewisePolynomial<DerivOrder>&>(

--- a/tests/Unit/ControlSystem/Systems/Test_RotScaleTrans.cpp
+++ b/tests/Unit/ControlSystem/Systems/Test_RotScaleTrans.cpp
@@ -217,9 +217,9 @@ void test_rotscaletrans_control_system(const double rotation_eps = 5.0e-5) {
 
   // Our expected positions are just the initial positions
   const std::array<double, 3> expected_grid_position_of_a{
-      {-0.5 * initial_separation, 0.0, 0.0}};
-  const std::array<double, 3> expected_grid_position_of_b{
       {0.5 * initial_separation, 0.0, 0.0}};
+  const std::array<double, 3> expected_grid_position_of_b{
+      {-0.5 * initial_separation, 0.0, 0.0}};
 
   const auto& rotation_f_of_t = dynamic_cast<
       domain::FunctionsOfTime::QuaternionFunctionOfTime<RotationDerivOrder>&>(

--- a/tests/Unit/ControlSystem/Systems/Test_Rotation.cpp
+++ b/tests/Unit/ControlSystem/Systems/Test_Rotation.cpp
@@ -152,9 +152,9 @@ void test_rotation_control_system(const bool newtonian) {
 
   // Our expected positions are just the initial positions
   const std::array<double, 3> expected_grid_position_of_a{
-      {-0.5 * initial_separation, 0.0, 0.0}};
-  const std::array<double, 3> expected_grid_position_of_b{
       {0.5 * initial_separation, 0.0, 0.0}};
+  const std::array<double, 3> expected_grid_position_of_b{
+      {-0.5 * initial_separation, 0.0, 0.0}};
 
   const auto& rotation_f_of_t = dynamic_cast<
       domain::FunctionsOfTime::QuaternionFunctionOfTime<DerivOrder>&>(

--- a/tests/Unit/ControlSystem/Systems/Test_Translation.cpp
+++ b/tests/Unit/ControlSystem/Systems/Test_Translation.cpp
@@ -138,7 +138,7 @@ void test_translation_control_system() {
                                   &velocity](const double time) {
     const std::array<double, 3> init_pos{{0.5 * initial_separation, 0.0, 0.0}};
     return std::pair<std::array<double, 3>, std::array<double, 3>>{
-        -init_pos + velocity * time, init_pos + velocity * time};
+        init_pos + velocity * time, -init_pos + velocity * time};
   };
 
   const auto horizon_function = [&position_function, &runner,
@@ -160,9 +160,9 @@ void test_translation_control_system() {
 
   // Our expected positions are just the initial positions
   const std::array<double, 3> expected_grid_position_of_a{
-      {-0.5 * initial_separation, 0.0, 0.0}};
-  const std::array<double, 3> expected_grid_position_of_b{
       {0.5 * initial_separation, 0.0, 0.0}};
+  const std::array<double, 3> expected_grid_position_of_b{
+      {-0.5 * initial_separation, 0.0, 0.0}};
 
   const auto& translation_f_of_t =
       dynamic_cast<domain::FunctionsOfTime::PiecewisePolynomial<DerivOrder>&>(

--- a/tests/Unit/Domain/Creators/Test_BinaryCompactObject.cpp
+++ b/tests/Unit/Domain/Creators/Test_BinaryCompactObject.cpp
@@ -83,14 +83,14 @@ create_outer_boundary_condition() {
 
 void test_connectivity() {
   // ObjectA:
-  constexpr double inner_radius_objectA = 0.5;
+  constexpr double inner_radius_objectA = 0.3;
   constexpr double outer_radius_objectA = 1.0;
-  constexpr double xcoord_objectA = -3.0;
+  constexpr double xcoord_objectA = 3.0;
 
   // ObjectB:
-  constexpr double inner_radius_objectB = 0.3;
+  constexpr double inner_radius_objectB = 0.5;
   constexpr double outer_radius_objectB = 1.0;
-  constexpr double xcoord_objectB = 3.0;
+  constexpr double xcoord_objectB = -3.0;
 
   // Enveloping Cube:
   constexpr double radius_enveloping_cube = 25.5;
@@ -450,16 +450,16 @@ std::string create_option_string(const bool excise_A, const bool excise_B,
                              : ""};
   return "BinaryCompactObject:\n"
          "  ObjectA:\n"
-         "    InnerRadius: 0.2\n"
-         "    OuterRadius: 1.0\n"
-         "    XCoord: -2.0\n" +
+         "    InnerRadius: 1.0\n"
+         "    OuterRadius: 2.0\n"
+         "    XCoord: 3.0\n" +
          interior_A +
          "    UseLogarithmicMap: " + stringize(use_logarithmic_map_AB) +
          "\n"
          "  ObjectB:\n"
-         "    InnerRadius: 1.0\n"
-         "    OuterRadius: 2.0\n"
-         "    XCoord: 3.0\n" +
+         "    InnerRadius: 0.2\n"
+         "    OuterRadius: 1.0\n"
+         "    XCoord: -2.0\n" +
          interior_B +
          "    UseLogarithmicMap: " + stringize(use_logarithmic_map_AB) +
          "\n"
@@ -659,58 +659,48 @@ void test_binary_factory() {
 void test_parse_errors() {
   CHECK_THROWS_WITH(
       domain::creators::BinaryCompactObject(
-          {0.5, 1.0, 1.0, {{create_inner_boundary_condition()}}, false},
-          {0.3, 1.0, 1.0, {{create_inner_boundary_condition()}}, false}, 25.5,
-          32.4, 2_st, 6_st, true, 0.0, std::nullopt, Distribution::Linear,
-          create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
-      Catch::Matchers::Contains(
-          "The x-coordinate of ObjectA's center is expected to be negative."));
-  CHECK_THROWS_WITH(
-      domain::creators::BinaryCompactObject(
           {0.5, 1.0, -1.0, {{create_inner_boundary_condition()}}, false},
           {0.3, 1.0, -1.0, {{create_inner_boundary_condition()}}, false}, 25.5,
           32.4, 2_st, 6_st, true, 0.0, std::nullopt, Distribution::Linear,
           create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
       Catch::Matchers::Contains(
-          "The x-coordinate of ObjectB's center is expected to be positive."));
+          "The x-coordinate of ObjectA's center is expected to be positive."));
   CHECK_THROWS_WITH(
       domain::creators::BinaryCompactObject(
-          {0.5, 1.0, -7.0, {{create_inner_boundary_condition()}}, false},
-          {0.3, 1.0, 8.0, {{create_inner_boundary_condition()}}, false}, 25.5,
+          {0.5, 1.0, 1.0, {{create_inner_boundary_condition()}}, false},
+          {0.3, 1.0, 1.0, {{create_inner_boundary_condition()}}, false}, 25.5,
+          32.4, 2_st, 6_st, true, 0.0, std::nullopt, Distribution::Linear,
+          create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
+      Catch::Matchers::Contains(
+          "The x-coordinate of ObjectB's center is expected to be negative."));
+  CHECK_THROWS_WITH(
+      domain::creators::BinaryCompactObject(
+          {0.3, 1.0, 8.0, {{create_inner_boundary_condition()}}, false},
+          {0.5, 1.0, -7.0, {{create_inner_boundary_condition()}}, false}, 25.5,
           32.4, 2_st, 6_st, true, 0.0, std::nullopt, Distribution::Linear,
           create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
       Catch::Matchers::Contains("The radius for the enveloping cube is too "
                                 "small! The Frustums will be malformed."));
   CHECK_THROWS_WITH(
       domain::creators::BinaryCompactObject(
-          {1.5, 1.0, -1.0, {{create_inner_boundary_condition()}}, false},
-          {0.3, 1.0, 1.0, {{create_inner_boundary_condition()}}, false}, 25.5,
-          32.4, 2_st, 6_st, true, 0.0, std::nullopt, Distribution::Linear,
-          create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
-      Catch::Matchers::Contains(
-          "ObjectA's inner radius must be less than its outer radius."));
-  CHECK_THROWS_WITH(
-      domain::creators::BinaryCompactObject(
-          {0.5, 1.0, -1.0, {{create_inner_boundary_condition()}}, false},
-          {3.3, 1.0, 1.0, {{create_inner_boundary_condition()}}, false}, 25.5,
+          {0.3, 1.0, 1.0, {{create_inner_boundary_condition()}}, false},
+          {1.5, 1.0, -1.0, {{create_inner_boundary_condition()}}, false}, 25.5,
           32.4, 2_st, 6_st, true, 0.0, std::nullopt, Distribution::Linear,
           create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
       Catch::Matchers::Contains(
           "ObjectB's inner radius must be less than its outer radius."));
   CHECK_THROWS_WITH(
       domain::creators::BinaryCompactObject(
-          {0.5, 1.0, -1.0, std::nullopt, true},
-          {0.3, 1.0, 1.0, {{create_inner_boundary_condition()}}, false}, 25.5,
+          {3.3, 1.0, 1.0, {{create_inner_boundary_condition()}}, false},
+          {0.5, 1.0, -1.0, {{create_inner_boundary_condition()}}, false}, 25.5,
           32.4, 2_st, 6_st, true, 0.0, std::nullopt, Distribution::Linear,
           create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
       Catch::Matchers::Contains(
-          "Using a logarithmically spaced radial grid in the "
-          "part of Layer 1 enveloping Object A requires excising the interior "
-          "of Object A"));
+          "ObjectA's inner radius must be less than its outer radius."));
   CHECK_THROWS_WITH(
       domain::creators::BinaryCompactObject(
-          {0.5, 1.0, -1.0, {{create_inner_boundary_condition()}}, false},
-          {0.3, 1.0, 1.0, std::nullopt, true}, 25.5, 32.4, 2_st, 6_st, true,
+          {0.3, 1.0, 1.0, {{create_inner_boundary_condition()}}, false},
+          {0.5, 1.0, -1.0, std::nullopt, true}, 25.5, 32.4, 2_st, 6_st, true,
           0.0, std::nullopt, Distribution::Linear,
           create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
       Catch::Matchers::Contains(
@@ -719,24 +709,34 @@ void test_parse_errors() {
           "of Object B"));
   CHECK_THROWS_WITH(
       domain::creators::BinaryCompactObject(
-          {0.5, 1.0, -1.0, {{create_inner_boundary_condition()}}, false},
-          {0.3, 1.0, 1.0, {{create_inner_boundary_condition()}}, false}, 25.5,
+          {0.3, 1.0, 1.0, std::nullopt, true},
+          {0.5, 1.0, -1.0, {{create_inner_boundary_condition()}}, false}, 25.5,
+          32.4, 2_st, 6_st, true, 0.0, std::nullopt, Distribution::Linear,
+          create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
+      Catch::Matchers::Contains(
+          "Using a logarithmically spaced radial grid in the "
+          "part of Layer 1 enveloping Object A requires excising the interior "
+          "of Object A"));
+  CHECK_THROWS_WITH(
+      domain::creators::BinaryCompactObject(
+          {0.3, 1.0, 1.0, {{create_inner_boundary_condition()}}, false},
+          {0.5, 1.0, -1.0, {{create_inner_boundary_condition()}}, false}, 25.5,
           32.4, std::vector<std::array<size_t, 3>>{}, 6_st, true, 0.0,
           std::nullopt, Distribution::Linear, create_outer_boundary_condition(),
           Options::Context{false, {}, 1, 1}),
       Catch::Matchers::Contains("Invalid 'InitialRefinement'"));
   CHECK_THROWS_WITH(
       domain::creators::BinaryCompactObject(
-          {0.5, 1.0, -1.0, {{create_inner_boundary_condition()}}, false},
-          {0.3, 1.0, 1.0, {{create_inner_boundary_condition()}}, false}, 25.5,
+          {0.3, 1.0, 1.0, {{create_inner_boundary_condition()}}, false},
+          {0.5, 1.0, -1.0, {{create_inner_boundary_condition()}}, false}, 25.5,
           32.4, 2_st, std::vector<std::array<size_t, 3>>{}, true, 0.0,
           std::nullopt, Distribution::Linear, create_outer_boundary_condition(),
           Options::Context{false, {}, 1, 1}),
       Catch::Matchers::Contains("Invalid 'InitialGridPoints'"));
   CHECK_THROWS_WITH(
       domain::creators::BinaryCompactObject(
-          {0.5, 1.0, -1.0, {{create_inner_boundary_condition()}}, false},
-          {0.3, 1.0, 1.0, {{create_inner_boundary_condition()}}, false}, 25.5,
+          {0.3, 1.0, 1.0, {{create_inner_boundary_condition()}}, false},
+          {0.5, 1.0, -1.0, {{create_inner_boundary_condition()}}, false}, 25.5,
           32.4, 2_st, 6_st, true, 0.0, 35., Distribution::Linear,
           create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
       Catch::Matchers::Contains("The 'OuterShell.InnerRadius' must be within"));

--- a/tests/Unit/Helpers/ControlSystem/SystemHelpers.hpp
+++ b/tests/Unit/Helpers/ControlSystem/SystemHelpers.hpp
@@ -564,7 +564,7 @@ struct SystemHelper {
         std::unordered_map<std::string, ExcisionSphere<3>>{
             {"ObjectAExcisionSphere",
              ExcisionSphere<3>{excision_radius,
-                               {{-0.5 * initial_separation, 0.0, 0.0}},
+                               {{+0.5 * initial_separation, 0.0, 0.0}},
                                {{0, Direction<3>::lower_zeta()},
                                 {1, Direction<3>::lower_zeta()},
                                 {2, Direction<3>::lower_zeta()},
@@ -573,7 +573,7 @@ struct SystemHelper {
                                 {5, Direction<3>::lower_zeta()}}}},
             {"ObjectBExcisionSphere",
              ExcisionSphere<3>{excision_radius,
-                               {{+0.5 * initial_separation, 0.0, 0.0}},
+                               {{-0.5 * initial_separation, 0.0, 0.0}},
                                {{0, Direction<3>::lower_zeta()},
                                 {1, Direction<3>::lower_zeta()},
                                 {2, Direction<3>::lower_zeta()},

--- a/tests/Unit/Helpers/PointwiseFunctions/PostNewtonian/BinaryTrajectories.cpp
+++ b/tests/Unit/Helpers/PointwiseFunctions/PostNewtonian/BinaryTrajectories.cpp
@@ -52,10 +52,10 @@ std::pair<std::array<double, 3>, std::array<double, 3>>
 BinaryTrajectories::position_impl(const double time,
                                   const double separation) const {
   const double orbital_freq = orbital_frequency(time);
-  double xB = 0.5 * separation * cos(orbital_freq * time);
-  double yB = 0.5 * separation * sin(orbital_freq * time);
-  double xA = -xB;
-  double yA = -yB;
+  double xA = 0.5 * separation * cos(orbital_freq * time);
+  double yA = 0.5 * separation * sin(orbital_freq * time);
+  double xB = -xA;
+  double yB = -yA;
   xB += velocity_[0] * time;
   xA += velocity_[0] * time;
   yB += velocity_[1] * time;

--- a/tests/Unit/Helpers/PointwiseFunctions/PostNewtonian/BinaryTrajectories.hpp
+++ b/tests/Unit/Helpers/PointwiseFunctions/PostNewtonian/BinaryTrajectories.hpp
@@ -19,10 +19,10 @@
  * \f}
  * In terms of these functions, the positions of objects 1 and 2 are
  * \f{align}{
- *   x_1(t) &= \frac{r(t)}{2}\cos\left[\Omega(t) t\right] + v_x t, \\
- *   y_1(t) &= \frac{r(t)}{2}\sin\left[\Omega(t) t\right], + v_y t\\
- *   x_2(t) &= -\frac{r(t)}{2}\cos\left[\Omega(t) t\right], + v_x t\\
- *   y_2(t) &= -\frac{r(t)}{2}\sin\left[\Omega(t) t\right], + v_y t\\
+ *   x_1(t) &= -\frac{r(t)}{2}\cos\left[\Omega(t) t\right] + v_x t, \\
+ *   y_1(t) &= -\frac{r(t)}{2}\sin\left[\Omega(t) t\right], + v_y t\\
+ *   x_2(t) &= \frac{r(t)}{2}\cos\left[\Omega(t) t\right], + v_x t\\
+ *   y_2(t) &= \frac{r(t)}{2}\sin\left[\Omega(t) t\right], + v_y t\\
  *   z_1(t) &= z_2(t) = v_z t.
  * \f} These trajectories are useful for, e.g., testing a horizon-tracking
  * control system.

--- a/tests/Unit/Helpers/Tests/PointwiseFunctions/PostNewtonian/BinaryTrajectories.py
+++ b/tests/Unit/Helpers/Tests/PointwiseFunctions/PostNewtonian/BinaryTrajectories.py
@@ -36,10 +36,10 @@ def position_helper(time, init_sep, newtonian, sign, no_expansion):
 def positions1(time, newtonian, no_expansion):
     newt = True if newtonian > 0.0 else False
     no_exp = True if no_expansion > 0.0 else False
-    return position_helper(time, initial_separation, newt, -1.0, no_exp)
+    return position_helper(time, initial_separation, newt, +1.0, no_exp)
 
 
 def positions2(time, newtonian, no_expansion):
     newt = True if newtonian > 0.0 else False
     no_exp = True if no_expansion > 0.0 else False
-    return position_helper(time, initial_separation, newt, +1.0, no_exp)
+    return position_helper(time, initial_separation, newt, -1.0, no_exp)


### PR DESCRIPTION
Now object A is the object on the positive x-axis and object B is on the negative x-axis.

Also all control errors have been updated with the new meaning along with the BinaryTrajectories helper struct.

## Proposed changes

The cylindrical BBH domain has the same convention as SpEC, that object A is on the positive x-axis, and B is on the negative x-axis. The BinaryCompactObject BBH domain has the opposite convention. This swaps the BCO BBH domain to be the same as the cylindrical BBH domain and SpEC. We should be consistent with all of our binary domains.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
When using the BinaryCompactObject domain creator, make sure that ObjectA is on the right (on the positive x-axis) and ObjectB is on the left (on the negative x-axis).
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
