### PR TITLE
Add protections against missing excision spheres in control system

### DIFF
--- a/src/ControlSystem/ControlErrors/Expansion.hpp
+++ b/src/ControlSystem/ControlErrors/Expansion.hpp
@@ -14,6 +14,7 @@
 #include "DataStructures/DataVector.hpp"
 #include "Options/Options.hpp"
 #include "Parallel/GlobalCache.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
@@ -59,6 +60,8 @@ namespace ControlErrors {
  *   control_system::Systems::Expansion Expansion \endlink control system
  */
 struct Expansion : tt::ConformsTo<protocols::ControlError> {
+  static constexpr size_t expected_number_of_excisions = 2;
+
   using options = tmpl::list<>;
   static constexpr Options::String help{
       "Computes the control error for expansion control. This should not "
@@ -79,6 +82,13 @@ struct Expansion : tt::ConformsTo<protocols::ControlError> {
 
     using center_A = control_system::QueueTags::Center<::ah::ObjectLabel::A>;
     using center_B = control_system::QueueTags::Center<::ah::ObjectLabel::B>;
+
+    ASSERT(domain.excision_spheres().count("ObjectAExcisionSphere") == 1,
+           "Excision sphere for ObjectA not in the domain but is needed to "
+           "compute Expansion control error.");
+    ASSERT(domain.excision_spheres().count("ObjectBExcisionSphere") == 1,
+           "Excision sphere for ObjectB not in the domain but is needed to "
+           "compute Expansion control error.");
 
     const double grid_position_of_A =
         domain.excision_spheres().at("ObjectAExcisionSphere").center()[0];

--- a/src/ControlSystem/ControlErrors/Rotation.hpp
+++ b/src/ControlSystem/ControlErrors/Rotation.hpp
@@ -14,6 +14,7 @@
 #include "DataStructures/DataVector.hpp"
 #include "Options/Options.hpp"
 #include "Parallel/GlobalCache.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
@@ -54,6 +55,8 @@ namespace ControlErrors {
  *   control_system::Systems::Rotation Rotation \endlink control system
  */
 struct Rotation : tt::ConformsTo<protocols::ControlError> {
+  static constexpr size_t expected_number_of_excisions = 2;
+
   using options = tmpl::list<>;
   static constexpr Options::String help{
       "Computes the control error for rotation control. This should not "
@@ -70,6 +73,13 @@ struct Rotation : tt::ConformsTo<protocols::ControlError> {
 
     using center_A = control_system::QueueTags::Center<::ah::ObjectLabel::A>;
     using center_B = control_system::QueueTags::Center<::ah::ObjectLabel::B>;
+
+    ASSERT(domain.excision_spheres().count("ObjectAExcisionSphere") == 1,
+           "Excision sphere for ObjectA not in the domain but is needed to "
+           "compute Rotation control error.");
+    ASSERT(domain.excision_spheres().count("ObjectBExcisionSphere") == 1,
+           "Excision sphere for ObjectB not in the domain but is needed to "
+           "compute Rotation control error.");
 
     const DataVector grid_position_of_A = array_to_datavector(
         domain.excision_spheres().at("ObjectAExcisionSphere").center());

--- a/src/ControlSystem/ControlErrors/Shape.hpp
+++ b/src/ControlSystem/ControlErrors/Shape.hpp
@@ -88,6 +88,8 @@ std::string size_name() {
  */
 template <::ah::ObjectLabel Horizon>
 struct Shape : tt::ConformsTo<protocols::ControlError> {
+  static constexpr size_t expected_number_of_excisions = 1;
+
   using options = tmpl::list<>;
   static constexpr Options::String help{
       "Computes the control error for shape control. This should not take any "
@@ -119,6 +121,13 @@ struct Shape : tt::ConformsTo<protocols::ControlError> {
                << ah_coefs.size() << ").");
 
     const auto& excision_spheres = domain.excision_spheres();
+
+    ASSERT(domain.excision_spheres().count(
+               detail::excision_sphere_name<Horizon>()) == 1,
+           "Excision sphere " << detail::excision_sphere_name<Horizon>()
+                              << " not in the domain but is needed to "
+                                 "compute Shape control error.");
+
     // See above docs for why we have the sqrt(pi/2)
     const double radius_excision_sphere_grid_frame =
         sqrt(0.5 * M_PI) *

--- a/src/ControlSystem/ControlErrors/Translation.hpp
+++ b/src/ControlSystem/ControlErrors/Translation.hpp
@@ -69,6 +69,8 @@ namespace ControlErrors {
  *   coordinate map with names "Expansion" and "Rotation", respectively.
  */
 struct Translation : tt::ConformsTo<protocols::ControlError> {
+  static constexpr size_t expected_number_of_excisions = 2;
+
   using options = tmpl::list<>;
   static constexpr Options::String help{
       "Computes the control error for translation control. This should not "
@@ -92,6 +94,10 @@ struct Translation : tt::ConformsTo<protocols::ControlError> {
         functions_of_time.at("Expansion")->func(time)[0][0];
 
     using center_A = control_system::QueueTags::Center<::ah::ObjectLabel::A>;
+
+    ASSERT(domain.excision_spheres().count("ObjectAExcisionSphere") == 1,
+           "Excision sphere for ObjectA not in the domain but is needed to "
+           "compute Translation control error.");
 
     const DataVector grid_position_of_A = array_to_datavector(
         domain.excision_spheres().at("ObjectAExcisionSphere").center());

--- a/src/ControlSystem/Protocols/ControlError.hpp
+++ b/src/ControlSystem/Protocols/ControlError.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include <string>
 #include <type_traits>
 
@@ -21,12 +22,18 @@ namespace control_system::protocols {
 ///
 /// - a call operator that returns a DataVector with a signature the same as in
 ///   the example shown here:
+/// - a `static constexpr size_t expected_number_of_excisions` which specifies
+///   the number of excisions necessary in order to compute the control error.
+///
 ///   \snippet Helpers/ControlSystem/Examples.hpp ControlError
 struct ControlError {
   template <typename ConformingType>
   struct test {
     struct DummyMetavariables;
     struct DummyTupleTags;
+
+    static constexpr size_t expected_number_of_excisions =
+        ConformingType::expected_number_of_excisions;
 
     static_assert(
         std::is_same_v<

--- a/src/ControlSystem/Tags.hpp
+++ b/src/ControlSystem/Tags.hpp
@@ -18,8 +18,10 @@
 #include "Domain/Creators/DomainCreator.hpp"
 #include "NumericalAlgorithms/SphericalHarmonics/Strahlkorper.hpp"
 #include "Options/Options.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
+#include "Utilities/StdHelpers.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TypeTraits/CreateHasStaticMemberVariable.hpp"
 
@@ -235,11 +237,53 @@ template <typename ControlSystem>
 struct ControlError : db::SimpleTag {
   using type = typename ControlSystem::control_error;
 
+  template <typename Metavariables>
   using option_tags =
-      tmpl::list<OptionTags::ControlSystemInputs<ControlSystem>>;
-  static constexpr bool pass_metavariables = false;
+      tmpl::list<OptionTags::ControlSystemInputs<ControlSystem>,
+                 domain::OptionTags::DomainCreator<Metavariables::volume_dim>>;
+  static constexpr bool pass_metavariables = true;
+
+  template <typename Metavariables>
   static type create_from_options(
-      const control_system::OptionHolder<ControlSystem>& option_holder) {
+      const control_system::OptionHolder<ControlSystem>& option_holder,
+      const std::unique_ptr<::DomainCreator<Metavariables::volume_dim>>&
+          domain_creator) {
+    const auto domain = domain_creator->create_domain();
+    const auto& excision_spheres = domain.excision_spheres();
+
+    constexpr size_t expected_number_of_excisions =
+        type::expected_number_of_excisions;
+
+    const auto print_error =
+        [&excision_spheres](const std::string& excision_sphere_name) {
+          ERROR_NO_TRACE(
+              "The control error for the"
+              << pretty_type::name<type>()
+              << " control system expected there to be at least one excision "
+                 "sphere named '"
+              << excision_sphere_name
+              << "' in the domain, but there wasn't. The existing excision "
+                 "spheres are: "
+              << keys_of(excision_spheres)
+              << ". Check that the domain you have chosen has excision spheres "
+                 "implemented.");
+        };
+
+    if constexpr (expected_number_of_excisions == 1) {
+      if (excision_spheres.count("ObjectAExcisionSphere") != 1 and
+          excision_spheres.count("ObjectBExcisionSphere") != 1) {
+        print_error("ObjectAExcisionSphere' or 'ObjectBExcisionSphere");
+      }
+    }
+    if constexpr (expected_number_of_excisions == 2) {
+      if (excision_spheres.count("ObjectAExcisionSphere") != 1) {
+        print_error("ObjectAExcisionSphere");
+      }
+      if (excision_spheres.count("ObjectBExcisionSphere") != 1) {
+        print_error("ObjectBExcisionSphere");
+      }
+    }
+
     return option_holder.control_error;
   }
 };

--- a/tests/Unit/ControlSystem/Actions/Test_Initialization.cpp
+++ b/tests/Unit/ControlSystem/Actions/Test_Initialization.cpp
@@ -44,7 +44,7 @@ struct MockControlSystem
     return get_output(i);
   }
   using measurement = Measurement;
-  using control_error = control_system::TestHelpers::ControlError;
+  using control_error = control_system::TestHelpers::ControlError<0>;
   static constexpr size_t deriv_order = order;
   using simple_tags = tmpl::list<>;
 };
@@ -96,7 +96,7 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.Initialization",
       std::vector<double>{damping_time}, 10.0, 0.1, 2.0, 0.1, 1.01, 0.99};
   Controller<order> controller{0.3};
   bool write_data = false;
-  const control_system::TestHelpers::ControlError control_error{};
+  const control_system::TestHelpers::ControlError<0> control_error{};
 
   std::unordered_map<std::string,
                      std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>

--- a/tests/Unit/ControlSystem/Actions/Test_InitializeMeasurements.cpp
+++ b/tests/Unit/ControlSystem/Actions/Test_InitializeMeasurements.cpp
@@ -95,7 +95,7 @@ struct SystemA : tt::ConformsTo<control_system::protocols::ControlSystem> {
   }
   using simple_tags = tmpl::list<>;
   using measurement = Measurement<tmpl::list<SystemA, SystemB>>;
-  using control_error = control_system::TestHelpers::ControlError;
+  using control_error = control_system::TestHelpers::ControlError<1>;
   struct process_measurement {
     template <typename Submeasurement>
     using argument_tags = tmpl::list<>;
@@ -110,7 +110,7 @@ struct SystemB : tt::ConformsTo<control_system::protocols::ControlSystem> {
   }
   using simple_tags = tmpl::list<>;
   using measurement = Measurement<tmpl::list<SystemA, SystemB>>;
-  using control_error = control_system::TestHelpers::ControlError;
+  using control_error = control_system::TestHelpers::ControlError<1>;
   struct process_measurement {
     template <typename Submeasurement>
     using argument_tags = tmpl::list<>;
@@ -125,7 +125,7 @@ struct SystemC : tt::ConformsTo<control_system::protocols::ControlSystem> {
   }
   using simple_tags = tmpl::list<>;
   using measurement = Measurement<tmpl::list<SystemC>>;
-  using control_error = control_system::TestHelpers::ControlError;
+  using control_error = control_system::TestHelpers::ControlError<1>;
   struct process_measurement {
     template <typename Submeasurement>
     using argument_tags = tmpl::list<>;

--- a/tests/Unit/ControlSystem/ControlErrors/Test_Expansion.cpp
+++ b/tests/Unit/ControlSystem/ControlErrors/Test_Expansion.cpp
@@ -37,6 +37,7 @@ void test_expansion_control_error() {
       "  InitialTime: 0.0\n"
       "DomainCreator:\n"
       "  FakeCreator:\n"
+      "    NumberOfExcisions: 2\n"
       "    NumberOfComponents:\n"
       "      Expansion: 1\n"
       "ControlSystems:\n"

--- a/tests/Unit/ControlSystem/ControlErrors/Test_Rotation.cpp
+++ b/tests/Unit/ControlSystem/ControlErrors/Test_Rotation.cpp
@@ -42,6 +42,7 @@ void test_rotation_control_error() {
       "  InitialTime: 0.0\n"
       "DomainCreator:\n"
       "  FakeCreator:\n"
+      "    NumberOfExcisions: 2\n"
       "    NumberOfComponents:\n"
       "      Rotation: 3\n"
       "ControlSystems:\n"

--- a/tests/Unit/ControlSystem/ControlErrors/Test_Translation.cpp
+++ b/tests/Unit/ControlSystem/ControlErrors/Test_Translation.cpp
@@ -43,6 +43,7 @@ void test_translation_control_error() {
       "  InitialTime: 0.0\n"
       "DomainCreator:\n"
       "  FakeCreator:\n"
+      "    NumberOfExcisions: 2\n"
       "    NumberOfComponents:\n"
       "      Translation: 3\n"
       "ControlSystems:\n"

--- a/tests/Unit/ControlSystem/Systems/Test_Expansion.cpp
+++ b/tests/Unit/ControlSystem/Systems/Test_Expansion.cpp
@@ -60,6 +60,7 @@ void test_expansion_control_system() {
       "  InitialTime: 0.0\n"
       "DomainCreator:\n"
       "  FakeCreator:\n"
+      "    NumberOfExcisions: 2\n"
       "    NumberOfComponents:\n"
       "      Expansion: 1\n"
       "ControlSystems:\n"

--- a/tests/Unit/ControlSystem/Systems/Test_RotScaleTrans.cpp
+++ b/tests/Unit/ControlSystem/Systems/Test_RotScaleTrans.cpp
@@ -107,6 +107,7 @@ void test_rotscaletrans_control_system(const double rotation_eps = 5.0e-5) {
       "  InitialTime: 0.0\n"
       "DomainCreator:\n"
       "  FakeCreator:\n"
+      "    NumberOfExcisions: 2\n"
       "    NumberOfComponents:\n"
       "      Translation: 3\n"
       "      Rotation: 3\n"

--- a/tests/Unit/ControlSystem/Systems/Test_Rotation.cpp
+++ b/tests/Unit/ControlSystem/Systems/Test_Rotation.cpp
@@ -61,6 +61,7 @@ void test_rotation_control_system(const bool newtonian) {
       "  InitialTime: 0.0\n"
       "DomainCreator:\n"
       "  FakeCreator:\n"
+      "    NumberOfExcisions: 2\n"
       "    NumberOfComponents:\n"
       "      Rotation: 3\n"
       "ControlSystems:\n"

--- a/tests/Unit/ControlSystem/Systems/Test_Shape.cpp
+++ b/tests/Unit/ControlSystem/Systems/Test_Shape.cpp
@@ -235,6 +235,7 @@ void test_suite(const gsl::not_null<Generator*> generator, const size_t l_max,
       "  InitialTime: 0.0\n"
       "DomainCreator:\n"
       "  FakeCreator:\n"
+      "    NumberOfExcisions: 1\n"
       "    NumberOfComponents:\n"
       "      ShapeA: " +
       num_ah_coeffs_str +

--- a/tests/Unit/ControlSystem/Systems/Test_Translation.cpp
+++ b/tests/Unit/ControlSystem/Systems/Test_Translation.cpp
@@ -67,6 +67,7 @@ void test_translation_control_system() {
       "  InitialTime: 0.0\n"
       "DomainCreator:\n"
       "  FakeCreator:\n"
+      "    NumberOfExcisions: 2\n"
       "    NumberOfComponents:\n"
       "      Translation: 3\n"
       "ControlSystems:\n"

--- a/tests/Unit/ControlSystem/Tags/Test_FunctionsOfTimeInitialize.cpp
+++ b/tests/Unit/ControlSystem/Tags/Test_FunctionsOfTimeInitialize.cpp
@@ -51,7 +51,7 @@ struct FakeControlSystem
   using measurement = control_system::TestHelpers::Measurement<
       control_system::TestHelpers::TestStructs_detail::LabelA>;
   using simple_tags = tmpl::list<>;
-  using control_error = control_system::TestHelpers::ControlError;
+  using control_error = control_system::TestHelpers::ControlError<1>;
   struct process_measurement {
     using argument_tags = tmpl::list<>;
   };
@@ -221,7 +221,7 @@ void test_functions_of_time_tag() {
   const Averager<1> averager(0.25, true);
   const double update_fraction = 0.3;
   const Controller<2> controller(update_fraction);
-  const control_system::TestHelpers::ControlError control_error{};
+  const control_system::TestHelpers::ControlError<1> control_error{};
 
   OptionHolder<1> option_holder1(false, averager, controller, tuner1,
                                  control_error);
@@ -427,7 +427,7 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.Tags.FunctionsOfTimeInitialize",
         const Averager<1> averager(0.25, true);
         const double update_fraction = 0.3;
         const Controller<2> controller(update_fraction);
-        const control_system::TestHelpers::ControlError control_error{};
+        const control_system::TestHelpers::ControlError<1> control_error{};
 
         OptionHolder<1> option_holder1(true, averager, controller, tuner,
                                        control_error);
@@ -459,7 +459,7 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.Tags.FunctionsOfTimeInitialize",
         const Averager<1> averager(0.25, true);
         const double update_fraction = 0.3;
         const Controller<2> controller(update_fraction);
-        const control_system::TestHelpers::ControlError control_error{};
+        const control_system::TestHelpers::ControlError<1> control_error{};
 
         OptionHolder<1> option_holder1(true, averager, controller, tuner,
                                        control_error);

--- a/tests/Unit/ControlSystem/Tags/Test_MeasurementTimescales.cpp
+++ b/tests/Unit/ControlSystem/Tags/Test_MeasurementTimescales.cpp
@@ -41,7 +41,7 @@ struct FakeControlSystem
   using measurement = control_system::TestHelpers::Measurement<
       control_system::TestHelpers::TestStructs_detail::LabelA>;
   using simple_tags = tmpl::list<>;
-  using control_error = control_system::TestHelpers::ControlError;
+  using control_error = control_system::TestHelpers::ControlError<1>;
   struct process_measurement {
     using argument_tags = tmpl::list<>;
   };
@@ -112,7 +112,7 @@ void test_measurement_tag() {
     const Averager<1> averager(averaging_fraction, true);
     const double update_fraction = 0.3;
     const Controller<2> controller(update_fraction);
-    const control_system::TestHelpers::ControlError control_error{};
+    const control_system::TestHelpers::ControlError<1> control_error{};
 
     OptionHolder<1> option_holder1(true, averager, controller, tuner1,
                                    control_error);
@@ -209,7 +209,7 @@ void test_measurement_tag() {
                                     1.0e-2, 1.0e-4, 1.01, 0.99);
         const Averager<1> averager(0.25, true);
         const Controller<2> controller(0.3);
-        const control_system::TestHelpers::ControlError control_error{};
+        const control_system::TestHelpers::ControlError<1> control_error{};
 
         OptionHolder<1> option_holder1(true, averager, controller, tuner1,
                                        control_error);

--- a/tests/Unit/ControlSystem/Test_ExpirationTimes.cpp
+++ b/tests/Unit/ControlSystem/Test_ExpirationTimes.cpp
@@ -34,7 +34,7 @@ struct FakeControlSystem
   using measurement = control_system::TestHelpers::Measurement<
       control_system::TestHelpers::TestStructs_detail::LabelA>;
   using simple_tags = tmpl::list<>;
-  using control_error = control_system::TestHelpers::ControlError;
+  using control_error = control_system::TestHelpers::ControlError<1>;
   struct process_measurement {
     using argument_tags = tmpl::list<>;
   };
@@ -70,7 +70,7 @@ void test_expiration_time_construction() {
   const Averager<1> averager(0.25, true);
   const double update_fraction = 0.3;
   const Controller<2> controller(update_fraction);
-  const control_system::TestHelpers::ControlError control_error{};
+  const control_system::TestHelpers::ControlError<1> control_error{};
 
   OptionHolder<1> option_holder1(true, averager, controller, tuner1,
                                  control_error);

--- a/tests/Unit/Helpers/ControlSystem/Examples.hpp
+++ b/tests/Unit/Helpers/ControlSystem/Examples.hpp
@@ -98,6 +98,8 @@ struct ExampleMeasurement
 /// [ControlError]
 struct ExampleControlError
     : tt::ConformsTo<control_system::protocols::ControlError> {
+  static constexpr size_t expected_number_of_excisions = 1;
+
   void pup(PUP::er& /*p*/) {}
 
   template <typename Metavariables, typename... QueueTags>

--- a/tests/Unit/Helpers/ControlSystem/TestStructs.hpp
+++ b/tests/Unit/Helpers/ControlSystem/TestStructs.hpp
@@ -30,7 +30,9 @@ struct Measurement : tt::ConformsTo<control_system::protocols::Measurement> {
   using submeasurements = tmpl::list<>;
 };
 
+template <size_t NumExcisions>
 struct ControlError : tt::ConformsTo<control_system::protocols::ControlError> {
+  static constexpr size_t expected_number_of_excisions = NumExcisions;
   void pup(PUP::er& /*p*/) {}
 
   using options = tmpl::list<>;
@@ -48,7 +50,8 @@ struct ControlError : tt::ConformsTo<control_system::protocols::ControlError> {
 static_assert(tt::assert_conforms_to_v<Measurement<TestStructs_detail::LabelA>,
                                        control_system::protocols::Measurement>);
 
-template <size_t DerivOrder, typename Label, typename Measurement>
+template <size_t DerivOrder, typename Label, typename Measurement,
+          size_t NumExcisions = 0>
 struct System : tt::ConformsTo<control_system::protocols::ControlSystem> {
   static std::string name() { return pretty_type::short_name<Label>(); }
   static std::optional<std::string> component_name(
@@ -57,7 +60,7 @@ struct System : tt::ConformsTo<control_system::protocols::ControlSystem> {
   }
   using measurement = Measurement;
   using simple_tags = tmpl::list<>;
-  using control_error = ControlError;
+  using control_error = ControlError<NumExcisions>;
   static constexpr size_t deriv_order = DerivOrder;
 };
 


### PR DESCRIPTION
## Proposed changes

This helps avoid a "hard to track down" map-based exception that happens if you domain doesn't have excision spheres.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments
~Depends on and includes #4532.~

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
