### PR TITLE
Add docs to ah::ObjectLabel

### DIFF
--- a/src/ApparentHorizons/ObjectLabel.hpp
+++ b/src/ApparentHorizons/ObjectLabel.hpp
@@ -8,7 +8,12 @@
 
 namespace ah {
 /// Labels for the objects in a binary system.
-enum class ObjectLabel { A, B };
+enum class ObjectLabel {
+  /// The object along the positive x-axis in the grid frame
+  A,
+  /// The object along the negative x-axis in the grid frame
+  B
+};
 
 std::string name(const ObjectLabel x);
 


### PR DESCRIPTION
## Proposed changes

Define that A should always be to the right of B in the grid frame. This is the SpEC convention. We make this assumption in the control systems (see also #4532). Discussion about potentially renaming A/B is in #4529.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
