### PR TITLE
Fix bug in rootfind for enthalpy parametrization

### DIFF
--- a/src/PointwiseFunctions/Hydro/EquationsOfState/Enthalpy.cpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/Enthalpy.cpp
@@ -501,7 +501,7 @@ double Enthalpy<LowDensityEoS>::rest_mass_density_from_enthalpy(
       const auto x = x_from_density(density);
       return evaluate_coefficients(coefficients_, x) - specific_enthalpy;
     };
-    return RootFinder::toms748(f, reference_density_, maximum_density_, 1.0e-14,
+    return RootFinder::toms748(f, minimum_density_, maximum_density_, 1.0e-14,
                                1.0e-15);
   }
 }


### PR DESCRIPTION
## Proposed changes

Change the limits for rootfind in computing density as a function of specific enthalpy

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
