### PR TITLE
Bind CubicSpline and BarycentricRational in Python, add accessors, fix default-constructed serialization

### DIFF
--- a/src/NumericalAlgorithms/Interpolation/BarycentricRational.hpp
+++ b/src/NumericalAlgorithms/Interpolation/BarycentricRational.hpp
@@ -49,6 +49,10 @@ class BarycentricRational {
 
   double operator()(double x_to_interp_to) const;
 
+  const std::vector<double>& x_values() const { return x_values_; }
+
+  const std::vector<double>& y_values() const { return y_values_; }
+
   size_t order() const;
 
   // NOLINTNEXTLINE(google-runtime-references)

--- a/src/NumericalAlgorithms/Interpolation/CubicSpline.cpp
+++ b/src/NumericalAlgorithms/Interpolation/CubicSpline.cpp
@@ -55,6 +55,10 @@ void CubicSpline::gsl_spline_deleter::operator()(
 }
 
 void CubicSpline::initialize_interpolant() {
+  if (x_values_.empty()) {
+    // Do nothing for default-initialized objects
+    return;
+  }
   const size_t num_points = x_values_.size();
   acc_ = std::unique_ptr<gsl_interp_accel, gsl_interp_accel_deleter>{
       gsl_interp_accel_alloc()};

--- a/src/NumericalAlgorithms/Interpolation/CubicSpline.hpp
+++ b/src/NumericalAlgorithms/Interpolation/CubicSpline.hpp
@@ -41,6 +41,10 @@ class CubicSpline {
 
   double operator()(double x_to_interp_to) const;
 
+  const std::vector<double>& x_values() const { return x_values_; }
+
+  const std::vector<double>& y_values() const { return y_values_; }
+
   // NOLINTNEXTLINE(google-runtime-references)
   void pup(PUP::er& p);
 

--- a/src/NumericalAlgorithms/Interpolation/Python/BarycentricRational.cpp
+++ b/src/NumericalAlgorithms/Interpolation/Python/BarycentricRational.cpp
@@ -1,0 +1,23 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "NumericalAlgorithms/Interpolation/Python/BarycentricRational.hpp"
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include "NumericalAlgorithms/Interpolation/BarycentricRational.hpp"
+
+namespace py = pybind11;
+
+namespace intrp::py_bindings {
+void bind_barycentric_rational(py::module& m) {  // NOLINT
+  py::class_<BarycentricRational>(m, "BarycentricRational")
+      .def(py::init<std::vector<double>, std::vector<double>, size_t>(),
+           py::arg("x_values"), py::arg("y_values"), py::arg("order"))
+      .def("x_values", &BarycentricRational::x_values)
+      .def("y_values", &BarycentricRational::y_values)
+      .def("order", &BarycentricRational::order)
+      .def("__call__", &BarycentricRational::operator());
+}
+}  // namespace intrp::py_bindings

--- a/src/NumericalAlgorithms/Interpolation/Python/BarycentricRational.hpp
+++ b/src/NumericalAlgorithms/Interpolation/Python/BarycentricRational.hpp
@@ -1,0 +1,11 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <pybind11/pybind11.h>
+
+namespace intrp::py_bindings {
+// NOLINTNEXTLINE(google-runtime-references)
+void bind_barycentric_rational(pybind11::module& m);
+}  // namespace intrp::py_bindings

--- a/src/NumericalAlgorithms/Interpolation/Python/Bindings.cpp
+++ b/src/NumericalAlgorithms/Interpolation/Python/Bindings.cpp
@@ -3,8 +3,16 @@
 
 #include <pybind11/pybind11.h>
 
+#include "NumericalAlgorithms/Interpolation/Python/BarycentricRational.hpp"
+#include "NumericalAlgorithms/Interpolation/Python/CubicSpline.hpp"
 #include "NumericalAlgorithms/Interpolation/Python/RegularGridInterpolant.hpp"
 
+namespace py = pybind11;
+
 PYBIND11_MODULE(_PyInterpolation, m) {  // NOLINT
+  py::module_::import("spectre.DataStructures");
+  py::module_::import("spectre.Spectral");
+  intrp::py_bindings::bind_barycentric_rational(m);
+  intrp::py_bindings::bind_cubic_spline(m);
   intrp::py_bindings::bind_regular_grid(m);
 }

--- a/src/NumericalAlgorithms/Interpolation/Python/CMakeLists.txt
+++ b/src/NumericalAlgorithms/Interpolation/Python/CMakeLists.txt
@@ -7,7 +7,9 @@ spectre_python_add_module(
   Interpolation
   LIBRARY_NAME ${LIBRARY}
   SOURCES
+  BarycentricRational.cpp
   Bindings.cpp
+  CubicSpline.cpp
   RegularGridInterpolant.cpp
 )
 
@@ -15,6 +17,8 @@ spectre_python_headers(
   ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
+  BarycentricRational.hpp
+  CubicSpline.hpp
   RegularGridInterpolant.hpp
   )
 

--- a/src/NumericalAlgorithms/Interpolation/Python/CubicSpline.cpp
+++ b/src/NumericalAlgorithms/Interpolation/Python/CubicSpline.cpp
@@ -1,0 +1,22 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "NumericalAlgorithms/Interpolation/Python/CubicSpline.hpp"
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include "NumericalAlgorithms/Interpolation/CubicSpline.hpp"
+
+namespace py = pybind11;
+
+namespace intrp::py_bindings {
+void bind_cubic_spline(py::module& m) {  // NOLINT
+  py::class_<CubicSpline>(m, "CubicSpline")
+      .def(py::init<std::vector<double>, std::vector<double>>(),
+           py::arg("x_values"), py::arg("y_values"))
+      .def("x_values", &CubicSpline::x_values)
+      .def("y_values", &CubicSpline::y_values)
+      .def("__call__", &CubicSpline::operator());
+}
+}  // namespace intrp::py_bindings

--- a/src/NumericalAlgorithms/Interpolation/Python/CubicSpline.hpp
+++ b/src/NumericalAlgorithms/Interpolation/Python/CubicSpline.hpp
@@ -1,0 +1,11 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <pybind11/pybind11.h>
+
+namespace intrp::py_bindings {
+// NOLINTNEXTLINE(google-runtime-references)
+void bind_cubic_spline(pybind11::module& m);
+}  // namespace intrp::py_bindings

--- a/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/TovStar.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/TovStar.hpp
@@ -443,6 +443,7 @@ class TovStar : public virtual evolution::initial_data::InitialData,
             get<tag>(vars)[component][point_index] = tensor[component];
           }
         } else {
+          (void)point_index;
           get<tag>(vars) = local_cache.get_var(local_computer, tag{});
         }
         return '0';

--- a/tests/Unit/Framework/TestHelpers.hpp
+++ b/tests/Unit/Framework/TestHelpers.hpp
@@ -65,6 +65,7 @@ void serialize_and_deserialize(const gsl::not_null<T*> result, const T& t) {
 /// \snippet Test_PupStlCpp11.cpp example_serialize_comparable
 template <typename T>
 void test_serialization(const T& t) {
+  INFO("Serialization");
   static_assert(tt::has_equivalence_v<T>, "No operator== for T");
   CHECK(t == serialize_and_deserialize(t));
 }
@@ -93,6 +94,7 @@ void test_serialization_via_base(Args&&... args) {
 /// Test for copy semantics assuming operator== is implement correctly
 template <typename T>
 void test_copy_semantics(const T& a) {
+  INFO("Copy semantics");
   static_assert(tt::has_equivalence_v<T>,
                 "Class has no operator== implemented");
   static_assert(std::is_copy_assignable<T>::value,
@@ -128,6 +130,7 @@ void test_copy_semantics(const T& a) {
 template <typename T, Requires<tt::has_equivalence<T>::value> = nullptr,
           typename... Args>
 void test_move_semantics(T&& a, const T& comparison, Args&&... args) {
+  INFO("Move semantics");
   static_assert(std::is_rvalue_reference<decltype(a)>::value,
                 "Must move into test_move_semantics");
   static_assert(std::is_move_assignable<T>::value);

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Python/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Python/CMakeLists.txt
@@ -2,7 +2,19 @@
 # See LICENSE.txt for details.
 
 spectre_add_python_bindings_test(
-        "Unit.Interpolation.Python.RegularGridInterpolant"
-        Test_RegularGridInterpolant.py
-        "Unit;Interpolation;Python"
-        PyInterpolation)
+  "Unit.Interpolation.Python.BarycentricRational"
+  Test_BarycentricRational.py
+  "Unit;Interpolation;Python"
+  PyInterpolation)
+
+spectre_add_python_bindings_test(
+  "Unit.Interpolation.Python.CubicSpline"
+  Test_CubicSpline.py
+  "Unit;Interpolation;Python"
+  PyInterpolation)
+
+spectre_add_python_bindings_test(
+  "Unit.Interpolation.Python.RegularGridInterpolant"
+  Test_RegularGridInterpolant.py
+  "Unit;Interpolation;Python"
+  PyInterpolation)

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Python/Test_BarycentricRational.py
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Python/Test_BarycentricRational.py
@@ -1,0 +1,29 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+from spectre.Interpolation import BarycentricRational
+
+import unittest
+import scipy.interpolate
+import numpy as np
+import numpy.testing as npt
+
+
+class TestBarycentricRational(unittest.TestCase):
+    def test_barycentric_rational(self):
+        x_values = np.linspace(0, 10, 5)
+        y_values = x_values**2
+        interpolant = BarycentricRational(x_values, y_values, order=3)
+        npt.assert_array_equal(interpolant.x_values(), x_values)
+        npt.assert_array_equal(interpolant.y_values(), y_values)
+        self.assertEqual(interpolant.order(), 3)
+        # Compare to scipy implementation
+        scipy_interpolant = scipy.interpolate.BarycentricInterpolator(
+            x_values, y_values)
+        sample_points = [0., 1.5, 9., 10.]
+        for x in sample_points:
+            self.assertAlmostEqual(interpolant(x), scipy_interpolant(x))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Python/Test_CubicSpline.py
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Python/Test_CubicSpline.py
@@ -1,0 +1,29 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+from spectre.Interpolation import CubicSpline
+
+import unittest
+import scipy.interpolate
+import numpy as np
+import numpy.testing as npt
+
+
+class TestCubicSpline(unittest.TestCase):
+    def test_cubic_spline(self):
+        x_values = np.linspace(0, 10, 5)
+        y_values = x_values**2
+        interpolant = CubicSpline(x_values, y_values)
+        npt.assert_array_equal(interpolant.x_values(), x_values)
+        npt.assert_array_equal(interpolant.y_values(), y_values)
+        # Compare to scipy implementation
+        scipy_interpolant = scipy.interpolate.CubicSpline(x_values,
+                                                          y_values,
+                                                          bc_type="natural")
+        sample_points = [0., 1.5, 9., 10.]
+        for x in sample_points:
+            self.assertAlmostEqual(interpolant(x), scipy_interpolant(x))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_BarycentricRational.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_BarycentricRational.cpp
@@ -26,6 +26,8 @@ void test_barycentric_rational(const F& function, const double lower_bound,
   }
 
   intrp::BarycentricRational interpolant{x_values, y_values, order};
+  CHECK(interpolant.x_values() == x_values);
+  CHECK(interpolant.y_values() == y_values);
 
   const auto deserialized_interpolant = serialize_and_deserialize(interpolant);
   Approx custom_approx = Approx::custom().epsilon(3.e-12).scale(1.0);

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_CubicSpline.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_CubicSpline.cpp
@@ -149,4 +149,10 @@ SPECTRE_TEST_CASE("Unit.Numerical.Interpolation.CubicSpline",
   test_with_natural_boundary(10, 1.e-1);
   test_with_natural_boundary(100, 1.e-5);
   test_with_natural_boundary(1000, 1.e-9);
+
+  {
+    INFO("Test default-construction");
+    const intrp::CubicSpline interpolant{};
+    test_serialization(interpolant);
+  }
 }

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_CubicSpline.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_CubicSpline.cpp
@@ -40,6 +40,8 @@ void test_cubic_spline(const F& function, const double lower_bound,
   // Construct the interpolant and give an example
   // [interpolate_example]
   intrp::CubicSpline interpolant{x_values, y_values};
+  CHECK(interpolant.x_values() == x_values);
+  CHECK(interpolant.y_values() == y_values);
   const double x_to_interpolate_to =
       lower_bound + (upper_bound - lower_bound) / 2.;
   CHECK(interpolant(x_to_interpolate_to) ==


### PR DESCRIPTION
## Proposed changes

Makes the `CubicSpline` and `BarycentricRational` interpolants available in Python. Mostly I used this to debug issues with the TOV solver interpolation.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
