### PR TITLE
Decrease initial step size in TOV integrator, switch conformal factor interpolant to CubicSpline

### DIFF
--- a/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/Python/Bindings.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/Python/Bindings.cpp
@@ -5,6 +5,10 @@
 
 #include "PointwiseFunctions/AnalyticSolutions/RelativisticEuler/Python/Tov.hpp"
 
+namespace py = pybind11;
+
 PYBIND11_MODULE(_PyRelativisticEulerSolutions, m) {  // NOLINT
+  py::module_::import("spectre.Interpolation");
+  py::module_::import("spectre.PointwiseFunctions.Hydro.EquationsOfState");
   RelativisticEuler::Solutions::py_bindings::bind_tov(m);
 }

--- a/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/Python/CMakeLists.txt
+++ b/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/Python/CMakeLists.txt
@@ -32,4 +32,5 @@ spectre_python_link_libraries(
 spectre_python_add_dependencies(
   ${LIBRARY}
   PyEquationsOfState
+  PyInterpolation
   )

--- a/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/Python/Tov.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/Python/Tov.cpp
@@ -5,6 +5,7 @@
 
 #include <pybind11/numpy.h>
 #include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
 #include <string>
 
 #include "PointwiseFunctions/AnalyticSolutions/RelativisticEuler/Tov.hpp"
@@ -19,8 +20,7 @@ void bind_tov(py::module& m) {
       .value("Schwarzschild", TovCoordinates::Schwarzschild)
       .value("Isotropic", TovCoordinates::Isotropic);
   py::class_<TovSolution>(m, "Tov")
-      .def(py::init<const EquationsOfState::EquationOfState<true, 1>&,
-      double,
+      .def(py::init<const EquationsOfState::EquationOfState<true, 1>&, double,
                     TovCoordinates, double, double, double>(),
            py::arg("equation_of_state"), py::arg("central_mass_density"),
            py::arg("coordinate_system") = TovCoordinates::Schwarzschild,
@@ -35,7 +35,13 @@ void bind_tov(py::module& m) {
       .def("log_specific_enthalpy",
            py::vectorize(&TovSolution::log_specific_enthalpy<double>))
       .def("conformal_factor",
-           py::vectorize(&TovSolution::conformal_factor<double>));
+           py::vectorize(&TovSolution::conformal_factor<double>))
+      .def_property_readonly("mass_over_radius_interpolant",
+                             &TovSolution::mass_over_radius_interpolant)
+      .def_property_readonly("log_specific_enthalpy_interpolant",
+                             &TovSolution::log_specific_enthalpy_interpolant)
+      .def_property_readonly("conformal_factor_interpolant",
+                             &TovSolution::conformal_factor_interpolant);
 }
 
 }  // namespace RelativisticEuler::Solutions::py_bindings

--- a/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/Tov.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/Tov.cpp
@@ -223,8 +223,8 @@ void TovSolution::integrate(
       // The interpolation is not safe otherwise
     }
     observer.radius.back() = outer_radius_;
-    conformal_factor_interpolant_ = intrp::BarycentricRational(
-        observer.radius, observer.conformal_factor, 5);
+    conformal_factor_interpolant_ =
+        intrp::CubicSpline(observer.radius, observer.conformal_factor);
   }
 
   mass_over_radius_interpolant_ =
@@ -300,7 +300,9 @@ void TovSolution::pup(PUP::er& p) {  // NOLINT
   p | injection_energy_;
   p | mass_over_radius_interpolant_;
   p | log_enthalpy_interpolant_;
-  p | conformal_factor_interpolant_;
+  if (coordinate_system_ == TovCoordinates::Isotropic) {
+    p | conformal_factor_interpolant_;
+  }
 }
 
 #define DTYPE(data) BOOST_PP_TUPLE_ELEM(0, data)

--- a/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/Tov.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/Tov.hpp
@@ -233,6 +233,16 @@ class TovSolution {
   template <typename DataType>
   DataType conformal_factor(const DataType& r) const;
 
+  const intrp::CubicSpline& mass_over_radius_interpolant() const {
+    return mass_over_radius_interpolant_;
+  }
+  const intrp::CubicSpline& log_specific_enthalpy_interpolant() const {
+    return log_enthalpy_interpolant_;
+  }
+  const intrp::CubicSpline& conformal_factor_interpolant() const {
+    return conformal_factor_interpolant_;
+  }
+
   // NOLINTNEXTLINE(google-runtime-references)
   void pup(PUP::er& p);
 

--- a/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/Tov.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/Tov.hpp
@@ -6,7 +6,6 @@
 #include <limits>
 #include <ostream>
 
-#include "NumericalAlgorithms/Interpolation/BarycentricRational.hpp"
 #include "NumericalAlgorithms/Interpolation/CubicSpline.hpp"
 #include "Options/Options.hpp"
 #include "Options/ParseOptions.hpp"
@@ -251,7 +250,7 @@ class TovSolution {
   double injection_energy_{std::numeric_limits<double>::signaling_NaN()};
   intrp::CubicSpline mass_over_radius_interpolant_;
   intrp::CubicSpline log_enthalpy_interpolant_;
-  intrp::BarycentricRational conformal_factor_interpolant_;
+  intrp::CubicSpline conformal_factor_interpolant_;
 };
 
 }  // namespace RelativisticEuler::Solutions

--- a/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/Tov.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/Tov.hpp
@@ -133,7 +133,7 @@ class TovSolution {
       double central_mass_density,
       const TovCoordinates coordinate_system = TovCoordinates::Schwarzschild,
       double log_enthalpy_at_outer_radius = 0.0,
-      double absolute_tolerance = 1.0e-14, double relative_tolerance = 1.0e-14);
+      double absolute_tolerance = 1.e-18, double relative_tolerance = 1.0e-14);
 
   TovSolution() = default;
   TovSolution(const TovSolution& /*rhs*/) = default;

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/Python/Test_Tov.py
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/Python/Test_Tov.py
@@ -39,6 +39,10 @@ class TestTov(unittest.TestCase):
                             np.array([0., 0.]),
                             atol=1e-14,
                             rtol=0.0)
+        # Test accessing interpolants
+        self.assertTrue(len(tov.mass_over_radius_interpolant.y_values()) > 0)
+        self.assertTrue(
+            len(tov.log_specific_enthalpy_interpolant.y_values()) > 0)
 
 
 if __name__ == '__main__':

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/Test_Tov.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/Test_Tov.cpp
@@ -39,6 +39,10 @@ void test_tov(
     const EquationsOfState::EquationOfState<true, 1>& equation_of_state,
     const double central_mass_density, const size_t num_pts,
     const size_t current_iteration, const bool newtonian_limit) {
+  CAPTURE(central_mass_density);
+  CAPTURE(num_pts);
+  CAPTURE(current_iteration);
+  CAPTURE(newtonian_limit);
   Approx custom_approx = Approx::custom().epsilon(1.0e-08).scale(1.0);
   const double initial_log_enthalpy =
       std::log(get(hydro::relativistic_specific_enthalpy(
@@ -122,6 +126,7 @@ void test_tov(
 }
 
 void test_tov_dp_dr(const EquationsOfState::EquationOfState<true, 1>& eos) {
+  INFO("dp/dr");
   const double central_rest_mass_density = 1.0e-3;
   const RelativisticEuler::Solutions::TovSolution radial_tov_solution{
       eos, central_rest_mass_density};
@@ -181,6 +186,7 @@ void test_tov_dp_dr(const EquationsOfState::EquationOfState<true, 1>& eos) {
 }
 
 void test_baumgarte_shapiro() {
+  INFO("BaumgarteShapiro");
   // Reproduces Fig. 1.2 in BaumgarteShapiro, as suggested in footnote 25 on p.
   // 18, and as listed in Table 14.1
   // We use the polytropic scaling relations to prevent
@@ -206,6 +212,7 @@ void test_baumgarte_shapiro() {
 
 void test_tov_isotropic(const EquationsOfState::EquationOfState<true, 1>& eos,
                         const double central_mass_density) {
+  INFO("Isotropic");
   const RelativisticEuler::Solutions::TovSolution tov_areal{
       eos, central_mass_density,
       RelativisticEuler::Solutions::TovCoordinates::Schwarzschild};
@@ -235,6 +242,7 @@ void test_tov_isotropic(const EquationsOfState::EquationOfState<true, 1>& eos,
 }
 
 void test_rueter() {
+  INFO("Rueter");
   // Reproduces the values in Sec. V.C and Fig. 8 in
   // https://arxiv.org/abs/1708.07358
   const EquationsOfState::PolytropicFluid<true> eos{123.6489, 2};


### PR DESCRIPTION
## Proposed changes

Rebasing on #4111 led to strong Hamiltonian constraint violations near the origin in #3903. I tracked this down to the switch from BarycentricRational to CubicSpline for the M(r) and ln(h) interpolators in the TOV solution. It looks like the initial step size in the TOV integrator was too large, leading to significant differences between the two interpolations at the start of the integration interval. Here's a quick plot that shows the large step size near r=0 (dots are integration steps, line is the interpolation):

<img width="315" alt="0c712d5b-bf32-4d92-80a7-2d928267ed37" src="https://user-images.githubusercontent.com/746230/208803290-e5ca1d88-7fb3-4541-9c43-d803b51c81b8.png">

Here's a plot of the adaptive step size in both r and ln(h):

<img width="268" alt="fe635671-3da3-4bd9-9339-16f3c701e2be" src="https://user-images.githubusercontent.com/746230/208803846-29b6437e-fd33-4298-a841-acf3b632f45e.png">

Therefore, I reduced the initial step size to `relative_tolerance * (ln(h_R) - ln(h_C))`. That seems to sample the origin densely enough so that the Hamiltonian constraint violations vanish. Here are the updated plots:

<img width="315" alt="7f14e704-887a-4a40-b12c-ee6a7dce700f" src="https://user-images.githubusercontent.com/746230/208803956-ba255a7e-faf6-448f-af28-196fe0b44710.png">

<img width="273" alt="ac49ea31-f936-4ce1-a707-1c387499bdb1" src="https://user-images.githubusercontent.com/746230/208803985-4211c4b4-92a8-482e-9848-a9c20fad2886.png">

Any other ideas would be welcome too.

With the dense sampling near the origin the BarycentricRational interpolation for the conformal factor (which wasn't switched in #4111) became unstable, so I switched it to CubicSpline too.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
