### PR TITLE
Configure Python init files

### DIFF
--- a/src/DataStructures/Python/CMakeLists.txt
+++ b/src/DataStructures/Python/CMakeLists.txt
@@ -10,6 +10,8 @@ spectre_python_add_module(
   Bindings.cpp
   DataVector.cpp
   Matrix.cpp
+  PYTHON_FILES
+  __init__.py
   )
 
 spectre_python_headers(

--- a/src/DataStructures/Python/__init__.py
+++ b/src/DataStructures/Python/__init__.py
@@ -1,0 +1,4 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+from ._PyDataStructures import *

--- a/src/Domain/Creators/Python/CMakeLists.txt
+++ b/src/Domain/Creators/Python/CMakeLists.txt
@@ -16,6 +16,8 @@ spectre_python_add_module(
   Rectangle.cpp
   Shell.cpp
   Sphere.cpp
+  PYTHON_FILES
+  __init__.py
   )
 
 spectre_python_headers(

--- a/src/Domain/Creators/Python/__init__.py
+++ b/src/Domain/Creators/Python/__init__.py
@@ -1,0 +1,4 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+from ._PyDomainCreators import *

--- a/src/Domain/Python/CMakeLists.txt
+++ b/src/Domain/Python/CMakeLists.txt
@@ -10,6 +10,8 @@ spectre_python_add_module(
   Bindings.cpp
   ElementId.cpp
   SegmentId.cpp
+  PYTHON_FILES
+  __init__.py
   )
 
 spectre_python_headers(

--- a/src/Domain/Python/__init__.py
+++ b/src/Domain/Python/__init__.py
@@ -2,3 +2,5 @@
 # See LICENSE.txt for details.
 
 from ._PyDomain import *
+
+ElementId = {1: ElementId1D, 2: ElementId2D, 3: ElementId3D}

--- a/src/Domain/Python/__init__.py
+++ b/src/Domain/Python/__init__.py
@@ -1,0 +1,4 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+from ._PyDomain import *

--- a/src/IO/H5/Python/CMakeLists.txt
+++ b/src/IO/H5/Python/CMakeLists.txt
@@ -13,6 +13,7 @@ spectre_python_add_module(
   TensorData.cpp
   VolumeData.cpp
   PYTHON_FILES
+  __init__.py
   ExtractDatFromH5.py
   ExtractInputSourceYamlFromH5.py
   MODULE_PATH "IO"

--- a/src/IO/H5/Python/__init__.py
+++ b/src/IO/H5/Python/__init__.py
@@ -1,0 +1,4 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+from ._PyH5 import *

--- a/src/Informer/Python/CMakeLists.txt
+++ b/src/Informer/Python/CMakeLists.txt
@@ -9,6 +9,8 @@ spectre_python_add_module(
   SOURCES
   Bindings.cpp
   InfoAtCompile.cpp
+  PYTHON_FILES
+  __init__.py
 )
 
 spectre_python_headers(

--- a/src/Informer/Python/__init__.py
+++ b/src/Informer/Python/__init__.py
@@ -1,0 +1,4 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+from ._PyInformer import *

--- a/src/NumericalAlgorithms/Interpolation/Python/CMakeLists.txt
+++ b/src/NumericalAlgorithms/Interpolation/Python/CMakeLists.txt
@@ -9,6 +9,8 @@ spectre_python_add_module(
   SOURCES
   Bindings.cpp
   RegularGridInterpolant.cpp
+  PYTHON_FILES
+  __init__.py
 )
 
 spectre_python_headers(

--- a/src/NumericalAlgorithms/Interpolation/Python/__init__.py
+++ b/src/NumericalAlgorithms/Interpolation/Python/__init__.py
@@ -2,3 +2,5 @@
 # See LICENSE.txt for details.
 
 from ._PyInterpolation import *
+
+RegularGrid = {1: RegularGrid1D, 2: RegularGrid2D, 3: RegularGrid3D}

--- a/src/NumericalAlgorithms/Interpolation/Python/__init__.py
+++ b/src/NumericalAlgorithms/Interpolation/Python/__init__.py
@@ -1,0 +1,4 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+from ._PyInterpolation import *

--- a/src/NumericalAlgorithms/Spectral/Python/CMakeLists.txt
+++ b/src/NumericalAlgorithms/Spectral/Python/CMakeLists.txt
@@ -10,6 +10,8 @@ spectre_python_add_module(
   Bindings.cpp
   Mesh.cpp
   Spectral.cpp
+  PYTHON_FILES
+  __init__.py
 )
 
 spectre_python_headers(

--- a/src/NumericalAlgorithms/Spectral/Python/__init__.py
+++ b/src/NumericalAlgorithms/Spectral/Python/__init__.py
@@ -1,0 +1,4 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+from ._PySpectral import *

--- a/src/NumericalAlgorithms/Spectral/Python/__init__.py
+++ b/src/NumericalAlgorithms/Spectral/Python/__init__.py
@@ -2,3 +2,5 @@
 # See LICENSE.txt for details.
 
 from ._PySpectral import *
+
+Mesh = {1: Mesh1D, 2: Mesh2D, 3: Mesh3D}

--- a/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/Python/CMakeLists.txt
+++ b/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/Python/CMakeLists.txt
@@ -10,6 +10,8 @@ spectre_python_add_module(
   SOURCES
   Bindings.cpp
   Tov.cpp
+  PYTHON_FILES
+  __init__.py
   )
 
 spectre_python_headers(

--- a/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/Python/__init__.py
+++ b/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/Python/__init__.py
@@ -1,0 +1,4 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+from ._PyRelativisticEulerSolutions import *

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/Python/CMakeLists.txt
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/Python/CMakeLists.txt
@@ -12,6 +12,8 @@ spectre_python_add_module(
   EquationOfState.cpp
   PiecewisePolytropicFluid.cpp
   PolytropicFluid.cpp
+  PYTHON_FILES
+  __init__.py
   )
 
 spectre_python_headers(

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/Python/__init__.py
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/Python/__init__.py
@@ -1,0 +1,4 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+from ._PyEquationsOfState import *

--- a/src/Visualization/Python/CMakeLists.txt
+++ b/src/Visualization/Python/CMakeLists.txt
@@ -6,6 +6,7 @@ set(LIBRARY "PyVisualization")
 spectre_python_add_module(
   Visualization
   PYTHON_FILES
+  __init__.py
   GenerateXdmf.py
   PlotDatFile.py
   ReadH5.py

--- a/src/Visualization/Python/InterpolateVolumeData.py
+++ b/src/Visualization/Python/InterpolateVolumeData.py
@@ -43,13 +43,6 @@ def forward_args(args):
     interpolate_h5_file(**args)
 
 
-RegularGrid = {
-    1: Interpolation.RegularGrid1D,
-    2: Interpolation.RegularGrid2D,
-    3: Interpolation.RegularGrid3D
-}
-
-
 def interpolate_h5_file(source_file_path,
                         target_mesh,
                         target_file_path,
@@ -155,7 +148,8 @@ def interpolate_h5_file(source_file_path,
                 extent, basis_from_string(basis),
                 quadrature_from_string(quadrature))
 
-            interpolant = RegularGrid[dim](source_mesh, target_mesh)
+            interpolant = Interpolation.RegularGrid[dim](source_mesh,
+                                                         target_mesh)
 
             tensor_comps = []
             offset, length = spectre_h5.offset_and_length_for_grid(

--- a/src/Visualization/Python/InterpolateVolumeData.py
+++ b/src/Visualization/Python/InterpolateVolumeData.py
@@ -43,8 +43,6 @@ def forward_args(args):
     interpolate_h5_file(**args)
 
 
-Mesh = {1: Spectral.Mesh1D, 2: Spectral.Mesh2D, 3: Spectral.Mesh3D}
-
 RegularGrid = {
     1: Interpolation.RegularGrid1D,
     2: Interpolation.RegularGrid2D,
@@ -153,8 +151,9 @@ def interpolate_h5_file(source_file_path,
         # iterate over elements
         for grid_name, extent, basis, quadrature in zip(
                 grid_names, extents, bases, quadratures):
-            source_mesh = Mesh[dim](extent, basis_from_string(basis),
-                                    quadrature_from_string(quadrature))
+            source_mesh = Spectral.Mesh[dim](
+                extent, basis_from_string(basis),
+                quadrature_from_string(quadrature))
 
             interpolant = RegularGrid[dim](source_mesh, target_mesh)
 
@@ -328,7 +327,8 @@ if __name__ == "__main__":
     source_vol = source_file.get_vol(parsed_args.source_subfile_name)
     dim = source_vol.get_dimension()
     source_file.close()
-    target_mesh = Mesh[dim](target_extents, target_basis, target_quadrature)
+    target_mesh = Spectral.Mesh[dim](target_extents, target_basis,
+                                     target_quadrature)
 
     interpolate_args = []
     logging.info("Source and target files/volumes are as follows:")

--- a/src/Visualization/Python/__init__.py
+++ b/src/Visualization/Python/__init__.py
@@ -1,0 +1,2 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.

--- a/tests/Unit/Domain/Python/Test_ElementId.py
+++ b/tests/Unit/Domain/Python/Test_ElementId.py
@@ -1,45 +1,44 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-from spectre.Domain import ElementId1D, ElementId2D, ElementId3D, SegmentId
+from spectre.Domain import ElementId, SegmentId
 import unittest
 
 
 class TestElementId(unittest.TestCase):
     def test_construction(self):
-        element_id = ElementId1D(block_id=1)
+        element_id = ElementId[1](block_id=1)
         self.assertEqual(element_id.block_id, 1)
         self.assertEqual(element_id.segment_ids, [SegmentId(0, 0)])
-        element_id = ElementId1D(block_id=1, segment_ids=[SegmentId(1, 0)])
+        element_id = ElementId[1](block_id=1, segment_ids=[SegmentId(1, 0)])
         self.assertEqual(element_id.block_id, 1)
         self.assertEqual(element_id.segment_ids, [SegmentId(1, 0)])
         self.assertEqual(
-            ElementId2D("[B2,(L0I0,L2I3)]"),
-            ElementId2D(block_id=2,
-                        segment_ids=[SegmentId(0, 0),
-                                     SegmentId(2, 3)]))
+            ElementId[2]("[B2,(L0I0,L2I3)]"),
+            ElementId[2](block_id=2,
+                         segment_ids=[SegmentId(0, 0),
+                                      SegmentId(2, 3)]))
 
     def test_repr(self):
-        self.assertEqual(repr(ElementId1D(0)), "[B0,(L0I0)]")
+        self.assertEqual(repr(ElementId[1](0)), "[B0,(L0I0)]")
         self.assertEqual(
-            repr(ElementId2D(
+            repr(ElementId[2](
                 2, [SegmentId(0, 0), SegmentId(1, 0)])), "[B2,(L0I0,L1I0)]")
         self.assertEqual(
-            repr(
-                ElementId3D(
-                    1, [SegmentId(1, 0),
-                        SegmentId(0, 0),
-                        SegmentId(1, 1)])), "[B1,(L1I0,L0I0,L1I1)]")
+            repr(ElementId[3](
+                1, [SegmentId(1, 0),
+                    SegmentId(0, 0),
+                    SegmentId(1, 1)])), "[B1,(L1I0,L0I0,L1I1)]")
 
     def test_equality(self):
-        self.assertEqual(ElementId1D(0, [SegmentId(1, 0)]),
-                         ElementId1D(0, [SegmentId(1, 0)]))
-        self.assertNotEqual(ElementId1D(0, [SegmentId(1, 0)]),
-                            ElementId1D(0, [SegmentId(1, 1)]))
+        self.assertEqual(ElementId[1](0, [SegmentId(1, 0)]),
+                         ElementId[1](0, [SegmentId(1, 0)]))
+        self.assertNotEqual(ElementId[1](0, [SegmentId(1, 0)]),
+                            ElementId[1](0, [SegmentId(1, 1)]))
 
     def test_external_boundary_id(self):
-        self.assertEqual(ElementId1D.external_boundary_id(),
-                         ElementId1D.external_boundary_id())
+        self.assertEqual(ElementId[1].external_boundary_id(),
+                         ElementId[1].external_boundary_id())
 
 
 if __name__ == '__main__':

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Python/Test_RegularGridInterpolant.py
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Python/Test_RegularGridInterpolant.py
@@ -4,7 +4,7 @@
 import unittest
 from spectre import Spectral
 from spectre import DataStructures
-from spectre import Interpolation
+from spectre.Interpolation import RegularGrid
 from numpy.polynomial.legendre import Legendre
 import numpy as np
 
@@ -58,10 +58,6 @@ class TestRegularGrid(unittest.TestCase):
     def test_regular_grid(self):
         for dim in range(1, 4):
             Mesh = [Spectral.Mesh1D, Spectral.Mesh2D, Spectral.Mesh3D][dim - 1]
-            RegularGrid = [
-                Interpolation.RegularGrid1D, Interpolation.RegularGrid2D,
-                Interpolation.RegularGrid3D
-            ][dim - 1]
             for quadrature in [
                     Spectral.Quadrature.Gauss, Spectral.Quadrature.GaussLobatto
             ]:
@@ -70,7 +66,7 @@ class TestRegularGrid(unittest.TestCase):
                                        quadrature)
                     target_mesh = Mesh(num_points + 2, Spectral.Basis.Legendre,
                                        quadrature)
-                    interpolant = RegularGrid(source_mesh, target_mesh)
+                    interpolant = RegularGrid[dim](source_mesh, target_mesh)
 
                     source_coords = self.logical_coordinates(source_mesh)
                     target_coords = self.logical_coordinates(target_mesh)

--- a/tests/Unit/NumericalAlgorithms/Spectral/Python/Test_Mesh.py
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Python/Test_Mesh.py
@@ -1,7 +1,7 @@
 #Distributed under the MIT License.
 #See LICENSE.txt for details.
 
-from spectre.Spectral import Mesh1D, Mesh2D, Mesh3D
+from spectre.Spectral import Mesh
 from spectre.Spectral import Basis, Quadrature
 
 import numpy as np
@@ -19,7 +19,6 @@ class TestMesh(unittest.TestCase):
             Quadrature.FaceCentered
         ]
         self.extents = range(12)
-        self.Mesh = [Mesh1D, Mesh2D, Mesh3D]
 
     def check_extents(self, mesh, extents):
         self.assertEqual(mesh.extents(0), extents[0])
@@ -35,81 +34,68 @@ class TestMesh(unittest.TestCase):
         self.assertEqual(mesh.quadrature(), quadratures)
 
     def test_uniform(self):
-        for dim in range(3):
+        for dim in [1, 2, 3]:
             for extent in range(12):
                 for basis in self.bases:
                     for quadrature in self.quadratures:
-                        # the mesh constructor of dimension dim + 1
-                        Mesh = self.Mesh[dim]
-                        mesh = Mesh(extent, basis, quadrature)
-                        self.assertEqual(mesh.dim, dim + 1)
-                        self.check_extents(mesh,
-                                           [extent for _ in range(dim + 1)])
-                        self.check_basis(mesh, [basis for _ in range(dim + 1)])
-                        self.check_quadrature(
-                            mesh, [quadrature for _ in range(dim + 1)])
+                        mesh = Mesh[dim](extent, basis, quadrature)
+                        self.assertEqual(mesh.dim, dim)
+                        self.check_extents(mesh, [extent for _ in range(dim)])
+                        self.check_basis(mesh, [basis for _ in range(dim)])
+                        self.check_quadrature(mesh,
+                                              [quadrature for _ in range(dim)])
 
     def test_nonuniform_extents(self):
-        for dim in range(3):
+        for dim in [1, 2, 3]:
             for basis in self.bases:
                 for quadrature in self.quadratures:
                     for i in range(100):
-                        # the mesh constructor of dimension dim + 1
-                        Mesh = self.Mesh[dim]
                         extents = [
-                            random.choice(self.extents) for _ in range(dim + 1)
+                            random.choice(self.extents) for _ in range(dim)
                         ]
-                        mesh = Mesh(extents, basis, quadrature)
+                        mesh = Mesh[dim](extents, basis, quadrature)
                         self.check_extents(mesh, extents)
 
     def test_nonuniform_all_with_pickle(self):
-        for dim in range(3):
+        for dim in [1, 2, 3]:
             for i in range(100):
-                # the mesh constructor of dimension dim + 1
-                Mesh = self.Mesh[dim]
-                extents = [random.choice(self.extents) for _ in range(dim + 1)]
-                bases = [random.choice(self.bases) for _ in range(dim + 1)]
+                extents = [random.choice(self.extents) for _ in range(dim)]
+                bases = [random.choice(self.bases) for _ in range(dim)]
                 quadratures = [
-                    random.choice(self.quadratures) for _ in range(dim + 1)
+                    random.choice(self.quadratures) for _ in range(dim)
                 ]
 
-                mesh = Mesh(extents, bases, quadratures)
+                mesh = Mesh[dim](extents, bases, quadratures)
                 mesh = pickle.loads(pickle.dumps(mesh))
                 self.check_extents(mesh, extents)
                 self.check_basis(mesh, bases)
                 self.check_quadrature(mesh, quadratures)
 
     def test_equality(self):
-        for dim in range(3):
+        for dim in [1, 2, 3]:
             for basis in self.bases:
                 for quadrature in self.quadratures:
-                    # the mesh constructor of dimension dim + 1
-                    Mesh = self.Mesh[dim]
-                    extents = [
-                        random.choice(self.extents) for _ in range(dim + 1)
-                    ]
-                    mesh = Mesh(extents, basis, quadrature)
-                    self.assertTrue(mesh == Mesh(extents, basis, quadrature))
-                    self.assertFalse(mesh != Mesh(extents, basis, quadrature))
+                    extents = [random.choice(self.extents) for _ in range(dim)]
+                    mesh = Mesh[dim](extents, basis, quadrature)
                     self.assertTrue(
-                        mesh != Mesh([ex + 1
-                                      for ex in extents], basis, quadrature))
+                        mesh == Mesh[dim](extents, basis, quadrature))
                     self.assertFalse(
-                        mesh == Mesh([ex + 1
+                        mesh != Mesh[dim](extents, basis, quadrature))
+                    self.assertTrue(mesh != Mesh[dim]
+                                    ([ex + 1
                                       for ex in extents], basis, quadrature))
+                    self.assertFalse(mesh == Mesh[dim](
+                        [ex + 1 for ex in extents], basis, quadrature))
 
     def test_slices(self):
-        for dim in range(3):
+        for dim in [1, 2, 3]:
             for basis in self.bases:
                 for quadrature in self.quadratures:
-                    # the mesh constructor of dimension dim + 1
-                    Mesh = self.Mesh[dim]
-                    extents = [
-                        random.choice(self.extents) for _ in range(dim + 1)
-                    ]
-                    mesh = Mesh(extents, basis, quadrature)
+                    extents = [random.choice(self.extents) for _ in range(dim)]
+                    mesh = Mesh[dim](extents, basis, quadrature)
                     self.assertEqual(mesh.slices(), [
-                        Mesh1D(extent, basis, quadrature) for extent in extents
+                        Mesh[1](extent, basis, quadrature)
+                        for extent in extents
                     ])
 
 


### PR DESCRIPTION
## Proposed changes

Add the `__init__.py` files for Python modules explicitly and remove the CMake code that writes/updates them automatically.

- This is easier to understand (in my opinion) than the autogeneration. Skipping the autogeneration also speeds up CMake.
- More importantly, it allows using the `__init__.py` files for what they are intended, which is documenting the module and importing Python code (see next commits).
- The autogenerated init files had code in `__all__` that was unnecessary (it doesn't have to list all submodules or files, that can actually slow down imports).

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
