### PR TITLE
Make ElementId hashable and comparable in Python

### DIFF
--- a/src/Domain/Python/ElementId.cpp
+++ b/src/Domain/Python/ElementId.cpp
@@ -38,7 +38,10 @@ void bind_element_id_impl(py::module& m) {  // NOLINT
       // NOLINTNEXTLINE(misc-redundant-expression)
       .def(py::self == py::self)
       // NOLINTNEXTLINE(misc-redundant-expression)
-      .def(py::self != py::self);
+      .def(py::self != py::self)
+      // NOLINTNEXTLINE(misc-redundant-expression)
+      .def(py::self < py::self)
+      .def(hash(py::self));
 }
 }  // namespace
 

--- a/tests/Unit/Domain/Python/Test_ElementId.py
+++ b/tests/Unit/Domain/Python/Test_ElementId.py
@@ -36,6 +36,17 @@ class TestElementId(unittest.TestCase):
         self.assertNotEqual(ElementId[1](0, [SegmentId(1, 0)]),
                             ElementId[1](0, [SegmentId(1, 1)]))
 
+    def test_comparison(self):
+        element1 = ElementId[1](0, [SegmentId(1, 0)])
+        element2 = ElementId[1](0, [SegmentId(1, 1)])
+        self.assertEqual(sorted([element2, element1]), [element1, element2])
+
+    def test_hash(self):
+        self.assertEqual(hash(ElementId[1](0, [SegmentId(1, 0)])),
+                         hash(ElementId[1](0, [SegmentId(1, 0)])))
+        self.assertNotEqual(hash(ElementId[1](0, [SegmentId(1, 0)])),
+                            hash(ElementId[1](0, [SegmentId(1, 1)])))
+
     def test_external_boundary_id(self):
         self.assertEqual(ElementId[1].external_boundary_id(),
                          ElementId[1].external_boundary_id())


### PR DESCRIPTION
## Proposed changes

Allows to use ElementId as key in dicts, and to order them.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
