### PR TITLE
Add DeleteSubfiles script

### DIFF
--- a/src/IO/H5/Python/CMakeLists.txt
+++ b/src/IO/H5/Python/CMakeLists.txt
@@ -14,6 +14,7 @@ spectre_python_add_module(
   VolumeData.cpp
   PYTHON_FILES
   __init__.py
+  DeleteSubfiles.py
   ExtractDatFromH5.py
   ExtractInputSourceYamlFromH5.py
   MODULE_PATH "IO"

--- a/src/IO/H5/Python/DeleteSubfiles.py
+++ b/src/IO/H5/Python/DeleteSubfiles.py
@@ -1,0 +1,34 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import click
+import h5py
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+@click.command()
+@click.argument("h5files",
+                type=click.Path(exists=True,
+                                file_okay=True,
+                                dir_okay=False,
+                                readable=True),
+                nargs=-1)
+@click.option("--subfile",
+              "-d",
+              "subfiles",
+              required=True,
+              multiple=True,
+              help="Subfile to delete")
+def delete_subfiles_command(h5files, subfiles):
+    """Delete subfiles from the 'H5FILES'"""
+    for h5file in h5files:
+        with h5py.File(h5file, "a") as open_h5_file:
+            for subfile in subfiles:
+                if subfile in open_h5_file:
+                    del open_h5_file[subfile]
+                    logger.debug(
+                        f"Deleted subfile '{subfile}' from file: {h5file}")
+                else:
+                    logger.warning(f"No subfile '{subfile}' in file: {h5file}")

--- a/support/Python/__main__.py
+++ b/support/Python/__main__.py
@@ -26,6 +26,9 @@ class Cli(click.MultiCommand):
         if name == "clean-output":
             from spectre.tools.CleanOutput import clean_output_command
             return clean_output_command
+        elif name == "delete-subfiles":
+            from spectre.IO.H5.DeleteSubfiles import delete_subfiles_command
+            return delete_subfiles_command
         elif name == "extract-dat":
             from spectre.IO.H5.ExtractDatFromH5 import extract_dat_command
             return extract_dat_command

--- a/tests/Unit/IO/H5/Python/CMakeLists.txt
+++ b/tests/Unit/IO/H5/Python/CMakeLists.txt
@@ -2,6 +2,12 @@
 # See LICENSE.txt for details.
 
 spectre_add_python_bindings_test(
+  "Unit.IO.H5.Python.DeleteSubfiles"
+  Test_DeleteSubfiles.py
+  "unit;IO;H5;python"
+  PyH5)
+
+spectre_add_python_bindings_test(
   "Unit.IO.H5.Python.ExtractDatFromH5"
   Test_ExtractDatFromH5.py
   "unit;IO;H5;python"

--- a/tests/Unit/IO/H5/Python/Test_DeleteSubfiles.py
+++ b/tests/Unit/IO/H5/Python/Test_DeleteSubfiles.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python
+
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+from spectre.IO.H5.DeleteSubfiles import delete_subfiles_command
+
+import h5py
+import os
+import shutil
+import unittest
+from click.testing import CliRunner
+from spectre.Informer import unit_test_src_path, unit_test_build_path
+
+
+class TestDeleteSubfiles(unittest.TestCase):
+    def setUp(self):
+        self.test_dir = os.path.join(unit_test_build_path(),
+                                     "IO/H5/Python/DeleteSubfile")
+        self.h5_filename = os.path.join(self.test_dir, "Test.h5")
+        os.makedirs(self.test_dir, exist_ok=True)
+        shutil.copyfile(
+            os.path.join(unit_test_src_path(), "Visualization/Python",
+                         "DatTestData.h5"), self.h5_filename)
+
+    def tearDown(self):
+        shutil.rmtree(self.test_dir)
+
+    def test_deletes_subfile(self):
+        runner = CliRunner()
+        result = runner.invoke(delete_subfiles_command,
+                               [self.h5_filename, "-d", "TimeSteps2.dat"],
+                               catch_exceptions=False)
+        self.assertEqual(result.exit_code, 0)
+        self.assertEqual(result.output, "")
+        with h5py.File(self.h5_filename, "r") as open_h5_file:
+            self.assertNotIn("TimeSteps2.dat", open_h5_file.keys())
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Proposed changes

Useful to delete unneeded data from H5 files. I always had to look up the syntax for this in Python. I needed this recently to delete the source archive from an H5 file before committing it to the repo.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
