### PR TITLE
Bind logical_coordinates, IrregularInterpolant in Python

### DIFF
--- a/src/NumericalAlgorithms/Interpolation/IrregularInterpolant.cpp
+++ b/src/NumericalAlgorithms/Interpolation/IrregularInterpolant.cpp
@@ -217,6 +217,31 @@ void Irregular<Dim>::pup(PUP::er& p) {
 }
 
 template <size_t Dim>
+void Irregular<Dim>::interpolate(const gsl::not_null<DataVector*> result,
+                                 const DataVector& input) const {
+  const size_t m = interpolation_matrix_.rows();
+  const size_t k = interpolation_matrix_.columns();
+  ASSERT(k == input.size(),
+         "Number of points in 'input', "
+             << input.size()
+             << ",\n disagrees with the size of the source_mesh, " << k
+             << ", that was passed into the constructor");
+  if (result->size() != m) {
+    result->destructive_resize(m);
+  }
+  dgemv_('n', m, k, 1.0, interpolation_matrix_.data(),
+         interpolation_matrix_.spacing(), input.data(), 1, 0.0, result->data(),
+         1);
+}
+
+template <size_t Dim>
+DataVector Irregular<Dim>::interpolate(const DataVector& input) const {
+  DataVector result{input.size()};
+  interpolate(make_not_null(&result), input);
+  return result;
+}
+
+template <size_t Dim>
 bool operator!=(const Irregular<Dim>& lhs, const Irregular<Dim>& rhs) {
   return not(lhs == rhs);
 }

--- a/src/NumericalAlgorithms/Interpolation/IrregularInterpolant.hpp
+++ b/src/NumericalAlgorithms/Interpolation/IrregularInterpolant.hpp
@@ -56,6 +56,18 @@ class Irregular {
   Variables<TagsList> interpolate(const Variables<TagsList>& vars) const;
   /// @}
 
+  /// @{
+  /// \brief Interpolate a DataVector onto the target points.
+  ///
+  /// \note When interpolating multiple tensors, the Variables interface is more
+  /// efficient. However, this DataVector interface is useful for applications
+  /// where only some components of a Tensor or Variables need to be
+  /// interpolated.
+  void interpolate(gsl::not_null<DataVector*> result,
+                   const DataVector& input) const;
+  DataVector interpolate(const DataVector& input) const;
+  /// @}
+
  private:
   friend bool operator==(const Irregular& lhs, const Irregular& rhs) {
     return lhs.interpolation_matrix_ == rhs.interpolation_matrix_;
@@ -101,4 +113,3 @@ template <size_t Dim>
 bool operator!=(const Irregular<Dim>& lhs, const Irregular<Dim>& rhs);
 
 }  // namespace intrp
-

--- a/src/NumericalAlgorithms/Interpolation/Python/Bindings.cpp
+++ b/src/NumericalAlgorithms/Interpolation/Python/Bindings.cpp
@@ -5,6 +5,7 @@
 
 #include "NumericalAlgorithms/Interpolation/Python/BarycentricRational.hpp"
 #include "NumericalAlgorithms/Interpolation/Python/CubicSpline.hpp"
+#include "NumericalAlgorithms/Interpolation/Python/IrregularInterpolant.hpp"
 #include "NumericalAlgorithms/Interpolation/Python/RegularGridInterpolant.hpp"
 
 namespace py = pybind11;
@@ -14,5 +15,6 @@ PYBIND11_MODULE(_PyInterpolation, m) {  // NOLINT
   py::module_::import("spectre.Spectral");
   intrp::py_bindings::bind_barycentric_rational(m);
   intrp::py_bindings::bind_cubic_spline(m);
+  intrp::py_bindings::bind_irregular(m);
   intrp::py_bindings::bind_regular_grid(m);
 }

--- a/src/NumericalAlgorithms/Interpolation/Python/CMakeLists.txt
+++ b/src/NumericalAlgorithms/Interpolation/Python/CMakeLists.txt
@@ -10,6 +10,7 @@ spectre_python_add_module(
   BarycentricRational.cpp
   Bindings.cpp
   CubicSpline.cpp
+  IrregularInterpolant.cpp
   RegularGridInterpolant.cpp
   PYTHON_FILES
   __init__.py
@@ -21,6 +22,7 @@ spectre_python_headers(
   HEADERS
   BarycentricRational.hpp
   CubicSpline.hpp
+  IrregularInterpolant.hpp
   RegularGridInterpolant.hpp
   )
 

--- a/src/NumericalAlgorithms/Interpolation/Python/IrregularInterpolant.cpp
+++ b/src/NumericalAlgorithms/Interpolation/Python/IrregularInterpolant.cpp
@@ -1,0 +1,45 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "NumericalAlgorithms/Interpolation/Python/IrregularInterpolant.hpp"
+
+#include <array>
+#include <cstddef>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include "DataStructures/DataVector.hpp"
+#include "NumericalAlgorithms/Interpolation/IrregularInterpolant.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+
+namespace py = pybind11;
+
+namespace intrp::py_bindings {
+namespace {
+template <size_t Dim>
+void bind_irregular_impl(py::module& m) {  // NOLINT
+  py::class_<Irregular<Dim>>(m,
+                             ("Irregular" + std::to_string(Dim) + "D").c_str())
+      .def(py::init(
+               [](const Mesh<Dim>& source_mesh,
+                  const std::array<DataVector, Dim>& target_logical_coords) {
+                 return Irregular<Dim>{
+                     source_mesh,
+                     tnsr::I<DataVector, Dim, Frame::ElementLogical>{
+                         target_logical_coords}};
+               }),
+           py::arg("source_mesh"), py::arg("target_logical_coords"))
+      .def("interpolate",
+           static_cast<DataVector (Irregular<Dim>::*)(const DataVector&) const>(
+               &Irregular<Dim>::interpolate),
+           py::arg("input"));
+}
+}  // namespace
+
+void bind_irregular(py::module& m) {
+  bind_irregular_impl<1>(m);
+  bind_irregular_impl<2>(m);
+  bind_irregular_impl<3>(m);
+}
+
+}  // namespace intrp::py_bindings

--- a/src/NumericalAlgorithms/Interpolation/Python/IrregularInterpolant.hpp
+++ b/src/NumericalAlgorithms/Interpolation/Python/IrregularInterpolant.hpp
@@ -1,0 +1,11 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <pybind11/pybind11.h>
+
+namespace intrp::py_bindings {
+// NOLINTNEXTLINE(google-runtime-references)
+void bind_irregular(pybind11::module& m);
+}  // namespace intrp::py_bindings

--- a/src/NumericalAlgorithms/Interpolation/Python/__init__.py
+++ b/src/NumericalAlgorithms/Interpolation/Python/__init__.py
@@ -3,4 +3,5 @@
 
 from ._PyInterpolation import *
 
+Irregular = {1: Irregular1D, 2: Irregular2D, 3: Irregular3D}
 RegularGrid = {1: RegularGrid1D, 2: RegularGrid2D, 3: RegularGrid3D}

--- a/src/NumericalAlgorithms/Spectral/Python/Bindings.cpp
+++ b/src/NumericalAlgorithms/Spectral/Python/Bindings.cpp
@@ -3,12 +3,14 @@
 
 #include <pybind11/pybind11.h>
 
+#include "NumericalAlgorithms/Spectral/Python/LogicalCoordinates.hpp"
 #include "NumericalAlgorithms/Spectral/Python/Mesh.hpp"
 #include "NumericalAlgorithms/Spectral/Python/Spectral.hpp"
 
 PYBIND11_MODULE(_PySpectral, m) {  // NOLINT
   Spectral::py_bindings::bind_basis(m);
   Spectral::py_bindings::bind_quadrature(m);
+  Spectral::py_bindings::bind_logical_coordinates(m);
   Spectral::py_bindings::bind_nodal_to_modal_matrix(m);
   Spectral::py_bindings::bind_modal_to_nodal_matrix(m);
   Spectral::py_bindings::bind_collocation_points(m);

--- a/src/NumericalAlgorithms/Spectral/Python/CMakeLists.txt
+++ b/src/NumericalAlgorithms/Spectral/Python/CMakeLists.txt
@@ -8,6 +8,7 @@ spectre_python_add_module(
   LIBRARY_NAME ${LIBRARY}
   SOURCES
   Bindings.cpp
+  LogicalCoordinates.cpp
   Mesh.cpp
   Spectral.cpp
   PYTHON_FILES
@@ -18,6 +19,7 @@ spectre_python_headers(
   ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
+  LogicalCoordinates.hpp
   Mesh.hpp
   Spectral.hpp
   )

--- a/src/NumericalAlgorithms/Spectral/Python/LogicalCoordinates.cpp
+++ b/src/NumericalAlgorithms/Spectral/Python/LogicalCoordinates.cpp
@@ -1,0 +1,36 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "NumericalAlgorithms/Spectral/Python/LogicalCoordinates.hpp"
+
+#include <array>
+#include <cstddef>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <string>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "NumericalAlgorithms/Spectral/LogicalCoordinates.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "Utilities/MakeArray.hpp"
+
+namespace py = pybind11;
+
+namespace Spectral::py_bindings {
+namespace {
+template <size_t Dim>
+void bind_logical_coordinates_impl(py::module& m) {  // NOLINT
+  m.def("logical_coordinates", [](const Mesh<Dim>& mesh) {
+    return make_array<DataVector, Dim>(logical_coordinates(mesh));
+  });
+}
+}  // namespace
+
+void bind_logical_coordinates(py::module& m) {
+  bind_logical_coordinates_impl<1>(m);
+  bind_logical_coordinates_impl<2>(m);
+  bind_logical_coordinates_impl<3>(m);
+}
+
+}  // namespace Spectral::py_bindings

--- a/src/NumericalAlgorithms/Spectral/Python/LogicalCoordinates.hpp
+++ b/src/NumericalAlgorithms/Spectral/Python/LogicalCoordinates.hpp
@@ -1,0 +1,11 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <pybind11/pybind11.h>
+
+namespace Spectral::py_bindings {
+// NOLINTNEXTLINE(google-runtime-references)
+void bind_logical_coordinates(pybind11::module& m);
+}  // namespace Spectral::py_bindings

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Python/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Python/CMakeLists.txt
@@ -18,3 +18,9 @@ spectre_add_python_bindings_test(
   Test_RegularGridInterpolant.py
   "Unit;Interpolation;Python"
   PyInterpolation)
+
+spectre_add_python_bindings_test(
+  "Unit.Interpolation.Python.IrregularInterpolant"
+  Test_IrregularInterpolant.py
+  "Unit;Interpolation;Python"
+  PyInterpolation)

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Python/Test_IrregularInterpolant.py
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Python/Test_IrregularInterpolant.py
@@ -1,0 +1,57 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import unittest
+import numpy as np
+import numpy.testing as npt
+import numpy.random
+from spectre.DataStructures import DataVector
+from spectre.Interpolation import Irregular
+from spectre.Spectral import Mesh, Basis, Quadrature, logical_coordinates
+
+
+class TestIrregular(unittest.TestCase):
+
+    # arbitrary polynomial functions of low order for exact interpolation
+    def polynomial(self, coords):
+        dim = len(coords)
+        if dim == 1:
+            x = coords[0]
+            return x**2 + x + 1.
+        elif dim == 2:
+            x, y = coords
+            return 2. * x**2 + y**2 + y + x + 2.
+        elif dim == 3:
+            x, y, z = coords
+            return 3. * x**2 + 2. * y**2 + z**2 + 2. * y + z + x + 2.
+        else:
+            raise ValueError("Coordinates must have shape (dim, N) where "
+                             "dim is 1, 2, or 3.")
+
+    def test_irregular(self):
+        for dim in [1, 2, 3]:
+            for quadrature in [Quadrature.Gauss, Quadrature.GaussLobatto]:
+                for num_points in range(3, 10):
+                    source_mesh = Mesh[dim](num_points, Basis.Legendre,
+                                            quadrature)
+                    target_logical_coords = numpy.random.rand(dim, 3) * 2. - 1.
+
+                    interpolant = Irregular[dim](
+                        source_mesh=source_mesh,
+                        target_logical_coords=[
+                            DataVector(xi) for xi in target_logical_coords
+                        ])
+
+                    source_logical_coords = np.array(
+                        logical_coordinates(source_mesh))
+
+                    source_data = self.polynomial(source_logical_coords)
+                    target_data = self.polynomial(target_logical_coords)
+
+                    interpolated_data = interpolant.interpolate(
+                        DataVector(source_data))
+                    npt.assert_allclose(interpolated_data, target_data, 1e-14)
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_IrregularInterpolant.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_IrregularInterpolant.cpp
@@ -201,6 +201,11 @@ void test_interpolate_to_points(const Mesh<Dim>& mesh) {
       using Tag = tmpl::type_from<decltype(tag)>;
       CHECK_ITERABLE_APPROX(get<Tag>(dest_vars), get<Tag>(expected_dest_vars));
     });
+
+    const DataVector result_dv = irregular_interpolant.interpolate(
+        get<0>(get<TestTags::Vector<Dim>>(src_vars)));
+    CHECK_ITERABLE_APPROX(
+        result_dv, get<0>(get<TestTags::Vector<Dim>>(expected_dest_vars)));
   }
 }
 

--- a/tests/Unit/NumericalAlgorithms/Spectral/Python/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Python/CMakeLists.txt
@@ -8,6 +8,12 @@ spectre_add_python_bindings_test(
         PySpectral)
 
 spectre_add_python_bindings_test(
+        "Unit.Spectral.Python.LogicalCoordinates"
+        Test_LogicalCoordinates.py
+        "Unit;Spectral;Python"
+        PySpectral)
+
+spectre_add_python_bindings_test(
         "Unit.Spectral.Python.Mesh"
         Test_Mesh.py
         "Unit;Spectral;Python"

--- a/tests/Unit/NumericalAlgorithms/Spectral/Python/Test_LogicalCoordinates.py
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Python/Test_LogicalCoordinates.py
@@ -1,0 +1,39 @@
+#Distributed under the MIT License.
+#See LICENSE.txt for details.
+
+from spectre.Spectral import (Mesh, Basis, Quadrature, collocation_points,
+                              logical_coordinates)
+
+import numpy as np
+import numpy.testing as npt
+import unittest
+from random import randint
+from spectre.DataStructures import DataVector
+
+
+class TestLogicalCoordinates(unittest.TestCase):
+    def test_logical_coordinates(self):
+        bases = [Basis.Legendre, Basis.Chebyshev]
+        quads = [Quadrature.Gauss, Quadrature.GaussLobatto]
+        for dim in [1, 2, 3]:
+            mesh = Mesh[dim](
+                [randint(3, 12) for i in range(dim)],
+                [bases[randint(0,
+                               len(bases) - 1)] for i in range(dim)],
+                [quads[randint(0,
+                               len(quads) - 1)] for i in range(dim)])
+
+            # Make sure we can convert to a Numpy array
+            logical_coords = np.array(logical_coordinates(mesh))
+            # Meshgrid is matrix-indexed, and flattened in Fortran order
+            expected = np.stack([
+                xyz.flatten(order="F") for xyz in np.meshgrid(*[
+                    collocation_points(mesh_1d) for mesh_1d in mesh.slices()
+                ],
+                                                              indexing="ij")
+            ])
+            npt.assert_equal(logical_coords, expected)
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Proposed changes

The DataVector overload commit is from #4438, doesn't really matter which PR merges it.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
