### PR TITLE
Observe the magnitude of comoving magnetic field in GRMHD

### DIFF
--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
@@ -54,6 +54,7 @@
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryConditions/Factory.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryCorrections/Factory.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryCorrections/RegisterDerived.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/ComovingMagneticFieldMagnitude.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/Factory.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/RegisterDerivedWithCharm.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/Tag.hpp"
@@ -239,6 +240,8 @@ struct EvolutionMetavars {
   using observe_fields = tmpl::push_back<
       tmpl::append<typename system::variables_tag::tags_list,
                    typename system::primitive_variables_tag::tags_list,
+                   tmpl::list<grmhd::ValenciaDivClean::Tags::
+                                  ComovingMagneticFieldMagnitudeCompute>,
                    error_tags,
                    tmpl::conditional_t<
                        use_dg_subcell,

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/CMakeLists.txt
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/CMakeLists.txt
@@ -9,6 +9,7 @@ spectre_target_sources(
   ${LIBRARY}
   PRIVATE
   Characteristics.cpp
+  ComovingMagneticFieldMagnitude.cpp
   ConservativeFromPrimitive.cpp
   FixConservatives.cpp
   Flattener.cpp
@@ -28,6 +29,7 @@ spectre_target_headers(
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   Characteristics.hpp
+  ComovingMagneticFieldMagnitude.hpp
   ConservativeFromPrimitive.hpp
   FixConservatives.hpp
   Flattener.hpp

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/ComovingMagneticFieldMagnitude.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/ComovingMagneticFieldMagnitude.cpp
@@ -1,0 +1,45 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/ComovingMagneticFieldMagnitude.hpp"
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace grmhd::ValenciaDivClean::Tags {
+
+void ComovingMagneticFieldMagnitudeCompute::function(
+    const gsl::not_null<Scalar<DataVector>*> comoving_magnetic_field_magnitude,
+    const tnsr::I<DataVector, 3>& magnetic_field,
+    const tnsr::I<DataVector, 3>& spatial_velocity,
+    const Scalar<DataVector>& lorentz_factor,
+    const tnsr::ii<DataVector, 3, Frame::Inertial>& spatial_metric) {
+  Variables<tmpl::list<hydro::Tags::MagneticFieldDotSpatialVelocity<DataVector>,
+                       hydro::Tags::MagneticFieldSquared<DataVector>>>
+      temp_tensors{get(lorentz_factor).size()};
+
+  const auto& magnetic_field_dot_spatial_velocity =
+      get<hydro::Tags::MagneticFieldDotSpatialVelocity<DataVector>>(
+          temp_tensors);
+  dot_product(
+      make_not_null(
+          &get<hydro::Tags::MagneticFieldDotSpatialVelocity<DataVector>>(
+              temp_tensors)),
+      magnetic_field, spatial_velocity, spatial_metric);
+
+  const auto& magnetic_field_squared =
+      get<hydro::Tags::MagneticFieldSquared<DataVector>>(temp_tensors);
+  dot_product(make_not_null(&get<hydro::Tags::MagneticFieldSquared<DataVector>>(
+                  temp_tensors)),
+              magnetic_field, magnetic_field, spatial_metric);
+
+  get(*comoving_magnetic_field_magnitude) =
+      sqrt(get(magnetic_field_squared) / square(get(lorentz_factor)) +
+           square(get(magnetic_field_dot_spatial_velocity)));
+}
+
+}  // namespace grmhd::ValenciaDivClean::Tags

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/ComovingMagneticFieldMagnitude.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/ComovingMagneticFieldMagnitude.hpp
@@ -1,0 +1,49 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "PointwiseFunctions/GeneralRelativity/TagsDeclarations.hpp"
+#include "PointwiseFunctions/Hydro/Tags.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+class DataVector;
+namespace gsl {
+template <typename T>
+class not_null;
+}  // namespace gsl
+/// \endcond
+
+namespace grmhd::ValenciaDivClean::Tags {
+/*!
+ * \brief Compute the magnitude of the comoving magnetic field.
+ *
+ * \f{align}
+ *  \sqrt{b^2} = \left( \frac{B^2}{W^2} + (B^iv_i)^2 \right)^{1/2}
+ * \f}
+ *
+ * \note This ComputeTag is for observation and monitoring purpose, not related
+ * to the actual time evolution.
+ *
+ */
+struct ComovingMagneticFieldMagnitudeCompute
+    : hydro::Tags::ComovingMagneticFieldMagnitude<DataVector>,
+      db::ComputeTag {
+  using argument_tags = tmpl::list<hydro::Tags::MagneticField<DataVector, 3>,
+                                   hydro::Tags::SpatialVelocity<DataVector, 3>,
+                                   hydro::Tags::LorentzFactor<DataVector>,
+                                   gr::Tags::SpatialMetric<3>>;
+  using return_type = Scalar<DataVector>;
+  using base = hydro::Tags::ComovingMagneticFieldMagnitude<DataVector>;
+
+  static void function(
+      gsl::not_null<Scalar<DataVector>*> comoving_magnetic_field_magnitude,
+      const tnsr::I<DataVector, 3>& magnetic_field,
+      const tnsr::I<DataVector, 3>& spatial_velocity,
+      const Scalar<DataVector>& lorentz_factor,
+      const tnsr::ii<DataVector, 3, Frame::Inertial>& spatial_metric);
+};
+}  // namespace grmhd::ValenciaDivClean::Tags

--- a/src/PointwiseFunctions/Hydro/Tags.hpp
+++ b/src/PointwiseFunctions/Hydro/Tags.hpp
@@ -45,6 +45,12 @@ struct ComovingMagneticFieldSquared : db::SimpleTag {
   using type = Scalar<DataType>;
 };
 
+/// The magnitude of the comoving magnetic field, \f$\sqrt{b^\mu b_\mu}\f$
+template <typename DataType>
+struct ComovingMagneticFieldMagnitude : db::SimpleTag {
+  using type = Scalar<DataType>;
+};
+
 /// The divergence-cleaning field \f$\Phi\f$.
 template <typename DataType>
 struct DivergenceCleaningField : db::SimpleTag {

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/CMakeLists.txt
@@ -30,6 +30,7 @@ set(LIBRARY_SOURCES
   Subcell/Test_TciOptions.cpp
   Subcell/Test_TimeDerivative.cpp
   Test_Characteristics.cpp
+  Test_ComovingMagneticFieldMagnitude.cpp
   Test_ConservativeFromPrimitive.cpp
   Test_FixConservatives.cpp
   Test_Flattener.cpp

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/TestFunctions.py
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/TestFunctions.py
@@ -114,3 +114,14 @@ def tilde_phi(rest_mass_density, electron_fraction, specific_internal_energy,
 
 
 # End functions for testing ConservativeFromPrimitive.cpp
+
+
+# Functions for testing ComovingMagneticFieldMagnitude.cpp
+def comoving_b_magnitude(magnetic_field, spatial_velocity, lorentz_factor,
+                         spatial_metric):
+    return np.sqrt(
+        b_squared(magnetic_field, spatial_metric) / lorentz_factor**2 +
+        b_dot_v(magnetic_field, spatial_velocity, spatial_metric)**2)
+
+
+# End functions for testing ComovingMagneticFieldMagnitude.cpp

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Test_ComovingMagneticFieldMagnitude.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Test_ComovingMagneticFieldMagnitude.cpp
@@ -1,0 +1,20 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include "DataStructures/DataVector.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/ComovingMagneticFieldMagnitude.hpp"
+#include "Framework/CheckWithRandomValues.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+
+SPECTRE_TEST_CASE("Unit.GrMhd.ValenciaDivClean.ComovingMagneticFieldMagnitude",
+                  "[Unit][Evolution]") {
+  pypp::SetupLocalPythonEnvironment local_python_env{
+      "Evolution/Systems/GrMhd/ValenciaDivClean"};
+
+  pypp::check_with_random_values<1>(
+      &grmhd::ValenciaDivClean::Tags::ComovingMagneticFieldMagnitudeCompute::
+          function,
+      "TestFunctions", {"comoving_b_magnitude"}, {{{0.0, 1.0}}}, DataVector{5});
+}


### PR DESCRIPTION
## Proposed changes

Add `mag(b)` as an observable field in GRMHD. This quantity is useful for computing or monitoring the max strength of comoving magnetic fields in fluid.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
