### PR TITLE
Add ApplyPointwise to Python CLI

### DIFF
--- a/src/IO/H5/Python/VolumeData.cpp
+++ b/src/IO/H5/Python/VolumeData.cpp
@@ -25,6 +25,11 @@ void bind_h5vol(py::module& m) {
            py::arg("observation_id"), py::arg("observation_value"),
            py::arg("elements"), py::arg("serialized_domain") = std::nullopt,
            py::arg("serialized_functions_of_time") = std::nullopt)
+      .def("write_tensor_component",
+           py::overload_cast<size_t, const std::string&, const DataVector&>(
+               &h5::VolumeData::write_tensor_component),
+           py::arg("observation_id"), py::arg("component_name"),
+           py::arg("contiguous_tensor_data"))
       .def("list_observation_ids", &h5::VolumeData::list_observation_ids)
       .def("get_observation_value", &h5::VolumeData::get_observation_value,
            py::arg("observation_id"))

--- a/src/IO/H5/VolumeData.cpp
+++ b/src/IO/H5/VolumeData.cpp
@@ -363,6 +363,26 @@ void VolumeData::write_volume_data(
   }
 }
 
+void VolumeData::write_tensor_component(
+    const size_t observation_id, const std::string& component_name,
+    const DataVector& contiguous_tensor_data) {
+  const std::string path = "ObservationId" + std::to_string(observation_id);
+  detail::OpenGroup observation_group(volume_data_group_.id(), path,
+                                      AccessType::ReadWrite);
+  h5::write_data(observation_group.id(), contiguous_tensor_data,
+                 component_name);
+}
+
+void VolumeData::write_tensor_component(
+    const size_t observation_id, const std::string& component_name,
+    const std::vector<float>& contiguous_tensor_data) {
+  const std::string path = "ObservationId" + std::to_string(observation_id);
+  detail::OpenGroup observation_group(volume_data_group_.id(), path,
+                                      AccessType::ReadWrite);
+  h5::write_data(observation_group.id(), contiguous_tensor_data,
+                 {contiguous_tensor_data.size()}, component_name);
+}
+
 std::vector<size_t> VolumeData::list_observation_ids() const {
   const auto names = get_group_names(volume_data_group_.id(), "");
   const auto helper = [](const std::string& s) {

--- a/src/IO/H5/VolumeData.hpp
+++ b/src/IO/H5/VolumeData.hpp
@@ -113,6 +113,14 @@ class VolumeData : public h5::Object {
       const std::optional<std::vector<char>>& serialized_functions_of_time =
           std::nullopt);
 
+  void write_tensor_component(const size_t observation_id,
+                              const std::string& component_name,
+                              const DataVector& contiguous_tensor_data);
+
+  void write_tensor_component(const size_t observation_id,
+                              const std::string& component_name,
+                              const std::vector<float>& contiguous_tensor_data);
+
   /// List all the integral observation ids in the subfile
   ///
   /// The list of observation IDs is sorted by their observation value, as

--- a/src/Visualization/Python/ApplyPointwise.py
+++ b/src/Visualization/Python/ApplyPointwise.py
@@ -1,0 +1,327 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import click
+import importlib
+import inspect
+import logging
+import numpy as np
+import re
+import spectre.IO.H5 as spectre_h5
+from pydoc import locate
+from typing import Union, Iterable, Dict, Optional, Sequence, List
+
+logger = logging.getLogger(__name__)
+
+
+def snake_case_to_camel_case(s: str) -> str:
+    """snake_case to CamelCase"""
+    return "".join([t.title() for t in s.split("_")])
+
+
+def parse_pybind11_signature(callable) -> inspect.Signature:
+    # Pybind11 functions don't currently expose a signature that's easily
+    # readable, see issue https://github.com/pybind/pybind11/issues/945.
+    # Therefore, we parse the docstring. Its first line is always the function
+    # signature.
+    match = re.match(callable.__name__ + r"\((.+)\) -> (.+)", callable.__doc__)
+    if not match:
+        raise ValueError(
+            f"Unable to extract signature for function '{callable.__name__}'. "
+            "Please make sure it is a pybind11 binding of a C++ function. "
+            "If it is, please file an issue and include the following first "
+            "line of its docstring:\n\n" + callable.__doc__.partition("\n")[0])
+    match_args, match_ret = match.groups()
+    parameters = []
+    for arg in match_args.split(","):
+        arg = arg.strip()
+        if " = " in arg:
+            arg, default_value = arg.split(" = ")
+        else:
+            default = inspect.Parameter.empty
+        name, annotation = arg.split(": ")
+        annotation = locate(annotation)
+        parameters.append(
+            inspect.Parameter(name=name,
+                              kind=inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                              default=default,
+                              annotation=annotation))
+    return inspect.Signature(parameters=parameters,
+                             return_annotation=locate(match_ret))
+
+
+def get_tensor_component_names(tensor_name: str,
+                               tensor_type: type) -> List[str]:
+    """Lists all independent components like 'Vector_x', 'Vector_y', etc."""
+    # Pybind11 doesn't support class methods, so `component_suffix` is a member
+    # function. Construct a proxy object to call it.
+    tensor_proxy = tensor_type()
+    return [
+        tensor_name + tensor_proxy.component_suffix(i)
+        for i in range(tensor_type.size)
+    ]
+
+
+class Kernel:
+    def __init__(self,
+                 callable,
+                 map_input_names: Dict[str, str] = {},
+                 output_name: Optional[str] = None):
+        """Specifies input and output tensor names for a pointwise function
+
+        Arguments:
+          callable: A Python function that takes and returns tensors
+            (from 'spectre.DataStructures.Tensor').
+          map_input_names: A map of argument names to dataset names (optional).
+            By default the argument name is transformed to CamelCase.
+          output_name: Name of the output dataset (optional). By default the
+            function name is transformed to CamelCase.
+        """
+        self.callable = callable
+        # Get input tensor names by transforming the function argument names to
+        # CamelCase, or look them up in 'map_input_names'
+        try:
+            signature = inspect.signature(callable)
+        except ValueError:
+            signature = parse_pybind11_signature(callable)
+        callable_args = signature.parameters
+        self.input_names = [
+            map_input_names.get(arg_name, snake_case_to_camel_case(arg_name))
+            for arg_name in callable_args
+        ]
+        # Look up tensor types for input arguments
+        self.input_types = []
+        for arg in callable_args.values():
+            tensor_type = arg.annotation
+            if tensor_type is inspect.Parameter.empty:
+                raise ValueError(
+                    "Please annotate all arguments in the kernel function "
+                    f"'{callable}'. Argument '{arg.name}' has no annotation.")
+            try:
+                tensor_type.rank
+            except AttributeError:
+                raise ValueError(
+                    "All annotations must be tensor types in the "
+                    f"kernel function '{callable}'. Argument '{arg.name}' has "
+                    f"type '{tensor_type}'.")
+            self.input_types.append(tensor_type)
+        # Use provided output name, or transform function name to CamelCase
+        self.output_name = (output_name
+                            or snake_case_to_camel_case(callable.__name__))
+        self.output_type = signature.return_annotation
+        try:
+            self.output_type.rank
+        except AttributeError:
+            raise ValueError(
+                "The return annotation must be a tensor type in the "
+                f"kernel function '{callable}'. Instead, it is "
+                f"'{self.output_type}'.")
+
+
+def apply_pointwise(volfiles: Union[spectre_h5.H5Vol,
+                                    Iterable[spectre_h5.H5Vol]],
+                    kernels: Sequence[Kernel]):
+    """Apply pointwise functions to data in the 'volfiles'
+
+    Arguments:
+      volfiles: Iterable of open H5 volume files, or a single H5 volume file.
+        Must be opened in writable mode, e.g. in mode "a". The transformed
+        data will be written back into these files. All observations in these
+        files will be transformed.
+      kernels: List of pointwise transformations to apply to the volume data
+        in the form of 'Kernel' objects.
+    """
+    # Collect all tensor components that we need to apply the kernels
+    all_tensors = {}
+    for kernel in kernels:
+        for tensor_name, tensor_type in zip(kernel.input_names,
+                                            kernel.input_types):
+            if tensor_name in all_tensors:
+                assert all_tensors[tensor_name][0] == tensor_type, (
+                    "Two tensor arguments with the same name "
+                    f"'{tensor_name}' have different types: "
+                    f"'{all_tensors[tensor_name][0]}' and '{tensor_type}'")
+            else:
+                all_tensors[tensor_name] = (tensor_type,
+                                            get_tensor_component_names(
+                                                tensor_name, tensor_type))
+    logger.debug("Input datasets: " + str(list(all_tensors.keys())))
+    logger.info("Output datasets: " +
+                str([kernel.output_name for kernel in kernels]))
+
+    if isinstance(volfiles, spectre_h5.H5Vol):
+        volfiles = [volfiles]
+    for volfile in volfiles:
+        for obs_id in volfile.list_observation_ids():
+            # Load tensor data for all kernels
+            all_tensor_data = {
+                tensor_name: tensor_type(
+                    np.array([
+                        volfile.get_tensor_component(obs_id,
+                                                     component_name).data
+                        for component_name in component_names
+                    ]))
+                for tensor_name, (tensor_type,
+                                  component_names) in all_tensors.items()
+            }
+
+            # Apply kernels
+            # We currently only apply strictly pointwise kernels that need no
+            # information about the element or mesh. To support derivatives we
+            # can slice the tensor data into elements and call those kernels
+            # that request it element-wise, passing them the mesh and Jacobian
+            # as well.
+            for kernel in kernels:
+                kernel_args = [
+                    all_tensor_data[input_name]
+                    for input_name in kernel.input_names
+                ]
+
+                transformed_tensor = kernel.callable(*kernel_args)
+
+                # Write result back into volfile
+                for i, component in enumerate(transformed_tensor):
+                    volfile.write_tensor_component(
+                        obs_id,
+                        component_name=(
+                            kernel.output_name +
+                            transformed_tensor.component_suffix(i)),
+                        contiguous_tensor_data=component)
+
+
+def parse_input_names(ctx, param, all_values):
+    if all_values is None:
+        return {}
+    input_names = {}
+    for value in all_values:
+        key, value = value.split('=')
+        input_names[key] = value
+    return input_names
+
+
+def parse_kernels(kernels, exec_files, map_input_names):
+    # Load kernels from 'exec_files'
+    for exec_file in exec_files:
+        exec(exec_file.read())
+    # Look up all kernels
+    for kernel in kernels:
+        if "." in kernel:
+            # A module path was specified. Import function from the module
+            kernel_module_path, kernel_function = kernel.rsplit(".",
+                                                                maxsplit=1)
+            kernel_module = importlib.import_module(kernel_module_path)
+            yield Kernel(getattr(kernel_module, kernel_function),
+                         map_input_names)
+        else:
+            # Only a function name was specified. Look up in 'locals()'.
+            yield Kernel(locals()[kernel], map_input_names)
+
+
+@click.command()
+@click.argument("h5files",
+                nargs=-1,
+                type=click.Path(exists=True,
+                                file_okay=True,
+                                dir_okay=False,
+                                readable=True))
+@click.option("--subfile-name",
+              "-d",
+              help="Name of volume data subfile within each h5 file.")
+@click.option("--kernel",
+              "-k",
+              "kernels",
+              multiple=True,
+              required=True,
+              help=("Python function(s) to apply to the volume data. "
+                    "Specify as 'path.to.module.function_name', where the "
+                    "module must be available to import. "
+                    "Alternatively, specify just 'function_name' if the "
+                    "function is defined in one of the '--exec' / '-e' "
+                    "files."))
+@click.option("--exec",
+              "-e",
+              "exec_files",
+              type=click.File("r"),
+              multiple=True,
+              help=("Python file(s) to execute before loading kernels. "
+                    "Load kernels from these files with the '--kernel' / '-k' "
+                    "option."))
+@click.option("--input-name",
+              "-i",
+              "map_input_names",
+              multiple=True,
+              callback=parse_input_names,
+              help=("Map of function argument names to dataset names "
+                    "in the volume data file. Specify key-value pairs "
+                    "like 'spatial_metric=SpatialMetric'. If unspecified, "
+                    "the argument name is transformed to CamelCase."))
+def apply_pointwise_command(h5files, subfile_name, kernels, exec_files,
+                            map_input_names, **kwargs):
+    """Apply pointwise functions to volume data
+
+    Run pointwise functions (kernels) over all volume data in the 'H5FILES' and
+    write the output data back into the same files. You can use any Python
+    function as kernel that takes tensors as input arguments and returns a
+    tensor (from 'spectre.DataStructures.Tensor'). The function must be
+    annotated with tensor types, like this:
+
+        def shift_magnitude(
+                shift: tnsr.I[DataVector, 3],
+                spatial_metric: tnsr.ii[DataVector, 3]) -> Scalar[DataVector]:
+            # ...
+
+    Any pybind11 binding of a C++ function will also work, as long as it takes
+    exclusively tensors as arguments. The kernels can be loaded from any
+    available Python module, such as 'spectre.PointwiseFunctions'. You can also
+    execute a Python file that defines kernels with the '--exec' / '-e' option.
+
+    By default, the data for the input arguments are read from datasets in the
+    volume files with the same names, transformed to CamelCase. For example, the
+    input dataset names for the 'shift_magnitude' function above would be
+    'Shift(_x,_y,_z)' and 'SpatialMetric(_xx,_yy,_zz,_xy,_xz,_yz)'.
+    That is, the code uses the name 'shift' from the function argument, changes
+    it to CamelCase, then reads the 'Shift(_x,_y,_z)' datasets into a
+    'tnsr.I[DataVector, 3]' before passing it to the function.
+    You can override the input names with the '--input-name' / '-i' option.
+    The output would be written to a dataset named 'ShiftMagnitude', which is
+    the function name transformed to CamelCase.
+    """
+    # Script should be a noop if input files are empty
+    if not h5files:
+        return
+
+    open_h5_files = [spectre_h5.H5File(filename, "a") for filename in h5files]
+
+    # Print available subfile names and exit
+    if not subfile_name:
+        import rich.columns
+        rich.print(rich.columns.Columns(open_h5_files[0].all_vol_files()))
+        return
+
+    if subfile_name.endswith(".vol"):
+        subfile_name = subfile_name.rstrip(".vol")
+    if not subfile_name.startswith("/"):
+        subfile_name = "/" + subfile_name
+
+    volfiles = [h5file.get_vol(subfile_name) for h5file in open_h5_files]
+
+    # Load kernels
+    kernels = list(parse_kernels(kernels, exec_files, map_input_names))
+
+    # Apply!
+    import rich.progress
+    progress = rich.progress.Progress(
+        rich.progress.TextColumn("[progress.description]{task.description}"),
+        rich.progress.BarColumn(),
+        rich.progress.MofNCompleteColumn(),
+        rich.progress.TimeRemainingColumn(),
+        disable=(len(volfiles) == 1))
+    task_id = progress.add_task("Applying to files")
+    volfiles_progress = progress.track(volfiles, task_id=task_id)
+    with progress:
+        apply_pointwise(volfiles_progress, kernels=kernels, **kwargs)
+        progress.update(task_id, completed=len(volfiles))
+
+
+if __name__ == "__main__":
+    apply_pointwise_command(help_option_names=["-h", "--help"])

--- a/src/Visualization/Python/CMakeLists.txt
+++ b/src/Visualization/Python/CMakeLists.txt
@@ -7,6 +7,7 @@ spectre_python_add_module(
   Visualization
   PYTHON_FILES
   __init__.py
+  ApplyPointwise.py
   GenerateXdmf.py
   InterpolateToCoords.py
   InterpolateToMesh.py

--- a/support/Python/__main__.py
+++ b/support/Python/__main__.py
@@ -14,6 +14,7 @@ SPECTRE_VERSION = "@SPECTRE_VERSION@"
 class Cli(click.MultiCommand):
     def list_commands(self, ctx):
         return [
+            "apply-pointwise",
             "clean-output",
             "extract-dat",
             "extract-input",
@@ -26,7 +27,11 @@ class Cli(click.MultiCommand):
         ]
 
     def get_command(self, ctx, name):
-        if name == "clean-output":
+        if name == "apply-pointwise":
+            from spectre.Visualization.ApplyPointwise import (
+                apply_pointwise_command)
+            return apply_pointwise_command
+        elif name == "clean-output":
             from spectre.tools.CleanOutput import clean_output_command
             return clean_output_command
         elif name == "delete-subfiles":

--- a/tests/Unit/Helpers/IO/VolumeData.cpp
+++ b/tests/Unit/Helpers/IO/VolumeData.cpp
@@ -71,9 +71,9 @@ void check_volume_data(
         volume_file.list_tensor_components(observation_id);
     CAPTURE(read_components);
     CAPTURE(expected_components);
-    CHECK(alg::all_of(read_components,
-                      [&expected_components](const std::string& id) {
-                        return alg::found(expected_components, id);
+    CHECK(alg::all_of(expected_components,
+                      [&read_components](const std::string& id) {
+                        return alg::found(read_components, id);
                       }));
   }
   // Helper Function to get number of points on a particular grid

--- a/tests/Unit/Visualization/Python/CMakeLists.txt
+++ b/tests/Unit/Visualization/Python/CMakeLists.txt
@@ -2,6 +2,12 @@
 # See LICENSE.txt for details.
 
 spectre_add_python_bindings_test(
+  "Unit.Visualization.Python.ApplyPointwise"
+  Test_ApplyPointwise.py
+  "unit;visualization;python"
+  None)
+
+spectre_add_python_bindings_test(
   "Unit.Visualization.Python.GenerateXdmf"
   Test_GenerateXdmf.py
   "unit;visualization;python"

--- a/tests/Unit/Visualization/Python/Test_ApplyPointwise.py
+++ b/tests/Unit/Visualization/Python/Test_ApplyPointwise.py
@@ -1,0 +1,74 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+from spectre.Visualization.ApplyPointwise import (snake_case_to_camel_case,
+                                                  Kernel, apply_pointwise,
+                                                  apply_pointwise_command)
+
+import numpy as np
+import numpy.testing as npt
+import os
+import shutil
+import spectre.IO.H5 as spectre_h5
+import unittest
+from click.testing import CliRunner
+from spectre.Informer import unit_test_src_path, unit_test_build_path
+from spectre.DataStructures import DataVector
+from spectre.DataStructures.Tensor import Scalar, tnsr
+
+
+def psi_squared(psi: Scalar[DataVector]) -> Scalar[DataVector]:
+    return Scalar[DataVector](np.array(psi)**2)
+
+
+def coordinate_radius(
+        inertial_coordinates: tnsr.I[DataVector, 3]) -> Scalar[DataVector]:
+    return Scalar[DataVector](np.expand_dims(
+        np.linalg.norm(np.array(inertial_coordinates), axis=0), 0))
+
+
+class TestApplyPointwise(unittest.TestCase):
+    def setUp(self):
+        self.test_dir = os.path.join(unit_test_build_path(),
+                                     'Visualization/ApplyPointwise')
+        self.h5_filename = os.path.join(self.test_dir, "Test.h5")
+        os.makedirs(self.test_dir, exist_ok=True)
+        shutil.copyfile(
+            os.path.join(unit_test_src_path(),
+                         'Visualization/Python/VolTestData0.h5'),
+            self.h5_filename)
+
+    def tearDown(self):
+        shutil.rmtree(self.test_dir)
+
+    def test_snake_case_to_camel_case(self):
+        self.assertEqual(snake_case_to_camel_case("hello_world"), "HelloWorld")
+
+    def test_apply_pointwise(self):
+        open_h5_files = [spectre_h5.H5File(self.h5_filename, "a")]
+        open_volfiles = [
+            h5file.get_vol("/element_data") for h5file in open_h5_files
+        ]
+
+        kernels = [Kernel(psi_squared), Kernel(coordinate_radius)]
+
+        apply_pointwise(volfiles=open_volfiles, kernels=kernels)
+
+        obs_id = open_volfiles[0].list_observation_ids()[0]
+        result_psisq = open_volfiles[0].get_tensor_component(
+            obs_id, "PsiSquared").data
+        result_radius = open_volfiles[0].get_tensor_component(
+            obs_id, "CoordinateRadius").data
+        psi = open_volfiles[0].get_tensor_component(obs_id, "Psi").data
+        x, y, z = [
+            np.array(open_volfiles[0].get_tensor_component(
+                obs_id, "InertialCoordinates" + xyz).data)
+            for xyz in ["_x", "_y", "_z"]
+        ]
+        npt.assert_allclose(np.array(result_psisq), np.array(psi)**2)
+        npt.assert_allclose(np.array(result_radius),
+                            np.sqrt(x**2 + y**2 + z**2))
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Proposed changes

Pointwise transformations of volume data. Allows to run any Python function over H5 vol data files. Doesn't yet do derivatives (need #4560 and a bit more for that) or parallelization (need to think a bit more about the best way to parallelize this). Should be functional enough to generate derived datasets from volume data though.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
