### PR TITLE
Add Charm++ message for boundary data

### DIFF
--- a/src/Evolution/DiscontinuousGalerkin/CMakeLists.txt
+++ b/src/Evolution/DiscontinuousGalerkin/CMakeLists.txt
@@ -27,4 +27,5 @@ spectre_target_sources(
 add_subdirectory(Actions)
 add_subdirectory(Initialization)
 add_subdirectory(Limiters)
+add_subdirectory(Messages)
 add_subdirectory(Tags)

--- a/src/Evolution/DiscontinuousGalerkin/Messages/BoundaryMessage.ci
+++ b/src/Evolution/DiscontinuousGalerkin/Messages/BoundaryMessage.ci
@@ -1,0 +1,12 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+module BoundaryMessage {
+  include "cstddef";
+
+  namespace evolution{ namespace dg {
+    template <size_t Dim>
+    message BoundaryMessage;
+  }
+  }
+}

--- a/src/Evolution/DiscontinuousGalerkin/Messages/BoundaryMessage.cpp
+++ b/src/Evolution/DiscontinuousGalerkin/Messages/BoundaryMessage.cpp
@@ -1,0 +1,234 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/DiscontinuousGalerkin/Messages/BoundaryMessage.hpp"
+
+#include <ios>
+#include <pup.h>
+
+#include "Parallel/Serialize.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+
+namespace evolution::dg {
+template <size_t Dim>
+BoundaryMessage<Dim>::BoundaryMessage(
+    const size_t subcell_ghost_data_size_in, const size_t dg_flux_data_size_in,
+    const bool sent_across_nodes_in, const size_t sender_node_in,
+    const size_t sender_core_in, const ::TimeStepId& current_time_step_id_in,
+    const ::TimeStepId& next_time_step_id_in,
+    const Mesh<Dim>& volume_or_ghost_mesh_in,
+    const Mesh<Dim - 1>& interface_mesh_in, double* subcell_ghost_data_in,
+    double* dg_flux_data_in)
+    : subcell_ghost_data_size(subcell_ghost_data_size_in),
+      dg_flux_data_size(dg_flux_data_size_in),
+      sent_across_nodes(sent_across_nodes_in),
+      sender_node(sender_node_in),
+      sender_core(sender_core_in),
+      current_time_step_id(current_time_step_id_in),
+      next_time_step_id(next_time_step_id_in),
+      volume_or_ghost_mesh(volume_or_ghost_mesh_in),
+      interface_mesh(interface_mesh_in),
+      subcell_ghost_data(subcell_ghost_data_in),
+      dg_flux_data(dg_flux_data_in) {}
+
+template <size_t Dim>
+size_t BoundaryMessage<Dim>::total_bytes_without_data() {
+  // subcell_ghost_data_size, dg_flux_data_size, sender_node, sender_core
+  size_t totalsize = 4 * detail::offset<size_t>();
+  // sent_across_nodes
+  totalsize += detail::offset<bool>();
+  // current_time_step_id, next_time_step_id
+  totalsize += 2 * detail::offset<TimeStepId>();
+  // volume_or_ghost_mesh
+  totalsize += detail::offset<Mesh<Dim>>();
+  // interface_mesh
+  totalsize += detail::offset<Mesh<Dim - 1>>();
+  // subcell_ghost_data, dg_flux_data
+  totalsize += 2 * detail::offset<double*>();
+
+  return totalsize;
+}
+
+template <size_t Dim>
+size_t BoundaryMessage<Dim>::total_bytes_with_data(const size_t subcell_size,
+                                                   const size_t dg_size) {
+  size_t totalsize = total_bytes_without_data();
+  totalsize += (subcell_size + dg_size) * sizeof(double);
+  return totalsize;
+}
+
+template <size_t Dim>
+void* BoundaryMessage<Dim>::pack(BoundaryMessage<Dim>* in_msg) {
+  const size_t subcell_size = in_msg->subcell_ghost_data_size;
+  const size_t dg_size = in_msg->dg_flux_data_size;
+
+  const size_t totalsize = total_bytes_with_data(subcell_size, dg_size);
+
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+  auto* out_msg = reinterpret_cast<BoundaryMessage<Dim>*>(
+      CkAllocBuffer(in_msg, static_cast<int>(totalsize)));
+
+  // We cast to char* here to avoid a GCC compiler error
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+  memcpy(reinterpret_cast<char*>(out_msg), &in_msg->subcell_ghost_data_size,
+         BoundaryMessage<Dim>::total_bytes_without_data());
+
+  if (subcell_size != 0) {
+    // double* + 1 == char* + 8 because double* is 8 bytes
+    // Place subcell data right after dg pointer
+    out_msg->subcell_ghost_data =
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+        reinterpret_cast<double*>(std::addressof(out_msg->dg_flux_data))
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+        + 1;
+    memcpy(out_msg->subcell_ghost_data, in_msg->subcell_ghost_data,
+           subcell_size * sizeof(double));
+  }
+  if (dg_size != 0) {
+    // Place dg data right after subcell data
+    out_msg->dg_flux_data =
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+        reinterpret_cast<double*>(std::addressof(out_msg->dg_flux_data))
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+        + 1 + subcell_size;
+    memcpy(out_msg->dg_flux_data, in_msg->dg_flux_data,
+           dg_size * sizeof(double));
+  }
+
+  // Gotta clean up
+  // A possible future optimization is if we know we have to send to another
+  // node that we define a BoundaryMessage::allocate function to immediately
+  // allocate a message of the right size. This will reduce the number of memory
+  // allocations when sending data internode from 3 (2 on send 1 on receive) to
+  // 2 (1 on send and 1 on receive).
+  delete in_msg;  // NOLINT
+  return static_cast<void*>(out_msg);
+}
+
+template <size_t Dim>
+BoundaryMessage<Dim>* BoundaryMessage<Dim>::unpack(void* in_buf) {
+  // We expect in_buf to be in a format where we can interpret it as a
+  // BoundaryMessage which is why we can immediately unpack the data as if it
+  // was a BoundaryMessage. All we have to do is set the pointers to the
+  // beginning of their respective data
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+  auto* buffer = reinterpret_cast<BoundaryMessage<Dim>*>(in_buf);
+
+  const size_t subcell_size = buffer->subcell_ghost_data_size;
+  const size_t dg_size = buffer->dg_flux_data_size;
+
+  if (subcell_size != 0) {
+    // double* + 1 == char* + 8 because double* is 8 bytes
+    // Subcell data is located right after dg pointer
+    buffer->subcell_ghost_data =
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+        reinterpret_cast<double*>(std::addressof(buffer->dg_flux_data))
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+        + 1;
+  } else {
+    buffer->subcell_ghost_data = nullptr;
+  }
+  if (dg_size != 0) {
+    // Dg data is located right after subcell data
+    buffer->dg_flux_data =
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+        reinterpret_cast<double*>(std::addressof(buffer->dg_flux_data))
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+        + 1 + subcell_size;
+  } else {
+    buffer->dg_flux_data = nullptr;
+  }
+
+  // We don't delete in_buf here because it is actually the data we want. We
+  // didn't do any new allocations/memcpy's so no need to clean up
+  return buffer;
+}
+
+template <size_t Dim>
+bool operator==(const BoundaryMessage<Dim>& lhs,
+                const BoundaryMessage<Dim>& rhs) {
+  return lhs.subcell_ghost_data_size == rhs.subcell_ghost_data_size and
+         lhs.dg_flux_data_size == rhs.dg_flux_data_size and
+         lhs.sent_across_nodes == rhs.sent_across_nodes and
+         lhs.sender_node == rhs.sender_node and
+         lhs.sender_core == rhs.sender_core and
+         lhs.current_time_step_id == rhs.current_time_step_id and
+         lhs.next_time_step_id == rhs.next_time_step_id and
+         lhs.volume_or_ghost_mesh == rhs.volume_or_ghost_mesh and
+         lhs.interface_mesh == rhs.interface_mesh and
+         // We are guaranteed that lhs.subcell_size == rhs.subcell_size and
+         // lhs.dg_size == rhs.dg_size at this point so it's safe to loop over
+         // everything
+         std::equal(
+             lhs.subcell_ghost_data,
+             // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+             lhs.subcell_ghost_data + lhs.subcell_ghost_data_size,
+             rhs.subcell_ghost_data) and
+         std::equal(
+             lhs.dg_flux_data,
+             // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+             lhs.dg_flux_data + lhs.dg_flux_data_size, rhs.dg_flux_data);
+}
+
+template <size_t Dim>
+bool operator!=(const BoundaryMessage<Dim>& lhs,
+                const BoundaryMessage<Dim>& rhs) {
+  return not(lhs == rhs);
+}
+
+template <size_t Dim>
+std::ostream& operator<<(std::ostream& os,
+                         const BoundaryMessage<Dim>& message) {
+  os << "subcell_ghost_data_size = " << message.subcell_ghost_data_size << "\n";
+  os << "dg_flux_data_size = " << message.dg_flux_data_size << "\n";
+  os << "sent_across_nodes = " << std::boolalpha << message.sent_across_nodes
+     << "\n";
+  os << "sender_node = " << message.sender_node << "\n";
+  os << "sender_core = " << message.sender_core << "\n";
+  os << "current_time_ste_id = " << message.current_time_step_id << "\n";
+  os << "next_time_ste_id = " << message.next_time_step_id << "\n";
+  os << "volume_or_ghost_mesh = " << message.volume_or_ghost_mesh << "\n";
+  os << "interface_mesh = " << message.interface_mesh << "\n";
+
+  os << "subcell_ghost_data = (";
+  if (message.subcell_ghost_data_size > 0) {
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+    os << message.subcell_ghost_data[0];
+    for (size_t i = 1; i < message.subcell_ghost_data_size; i++) {
+      // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+      os << "," << message.subcell_ghost_data[i];
+    }
+  }
+  os << ")\n";
+
+  os << "dg_flux_data = (";
+  if (message.dg_flux_data_size > 0) {
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+    os << message.dg_flux_data[0];
+    for (size_t i = 1; i < message.dg_flux_data_size; i++) {
+      // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+      os << "," << message.dg_flux_data[i];
+    }
+  }
+  os << ")";
+
+  return os;
+}
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data)                                       \
+  template struct BoundaryMessage<DIM(data)>;                      \
+  template bool operator==(const BoundaryMessage<DIM(data)>& lhs,  \
+                           const BoundaryMessage<DIM(data)>& rhs); \
+  template bool operator!=(const BoundaryMessage<DIM(data)>& lhs,  \
+                           const BoundaryMessage<DIM(data)>& rhs); \
+  template std::ostream& operator<<(                               \
+      std::ostream& os, const BoundaryMessage<DIM(data)>& message);
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
+
+#undef INSTANTIATE
+#undef DIM
+}  // namespace evolution::dg

--- a/src/Evolution/DiscontinuousGalerkin/Messages/BoundaryMessage.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Messages/BoundaryMessage.hpp
@@ -1,0 +1,121 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <ostream>
+#include <type_traits>
+
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "Time/TimeStepId.hpp"
+#include "Utilities/PrettyType.hpp"
+
+#include "Evolution/DiscontinuousGalerkin/Messages/BoundaryMessage.decl.h"
+
+namespace evolution::dg {
+/*!
+ * \brief [Charm++ Message]
+ * (https://charm.readthedocs.io/en/latest/charm%2B%2B/manual.html#messages)
+ * intended to be used in `receive_data` calls on the elements to send boundary
+ * data from one element on one node, to a different element on a (potentially)
+ * different node.
+ *
+ * If this message is to be sent across nodes, the `pack()` and `unpack()`
+ * methods will be called on the sending and receiving node, respectively.
+ */
+template <size_t Dim>
+struct BoundaryMessage : public CMessage_BoundaryMessage<Dim> {
+  using base = CMessage_BoundaryMessage<Dim>;
+
+  size_t subcell_ghost_data_size;
+  size_t dg_flux_data_size;
+  bool sent_across_nodes;
+  size_t sender_node;
+  size_t sender_core;
+  ::TimeStepId current_time_step_id;
+  ::TimeStepId next_time_step_id;
+  Mesh<Dim> volume_or_ghost_mesh;
+  Mesh<Dim - 1> interface_mesh;
+
+  // If set to nullptr then we aren't sending that type of data.
+  double* subcell_ghost_data;
+  double* dg_flux_data;
+
+  BoundaryMessage() = default;
+
+  BoundaryMessage(const size_t subcell_ghost_data_size_in,
+                  const size_t dg_flux_data_size_in,
+                  const bool sent_across_nodes_in, const size_t sender_node_in,
+                  const size_t sender_core_in,
+                  const ::TimeStepId& current_time_step_id_in,
+                  const ::TimeStepId& next_time_step_id_in,
+                  const Mesh<Dim>& volume_or_ghost_mesh_in,
+                  const Mesh<Dim - 1>& interface_mesh_in,
+                  double* subcell_ghost_data_in, double* dg_flux_data_in);
+
+  /*!
+   * \brief This is the size (in bytes) necessary to allocate a BoundaryMessage
+   * with only the member variables (no actual subcell/dg data, only pointers).
+   *
+   * This evaluates to 256 bytes for Dim == 1, 280 bytes for Dim == 2, and 312
+   * bytes for Dim == 3.
+   */
+  static size_t total_bytes_without_data();
+  /*!
+   * \brief This is the size (in bytes) necessary to allocate a BoundaryMessage
+   * including the arrays of data as well.
+   *
+   * This will add `(subcell_size + dg_size) * sizeof(double)` number of bytes
+   * to `total_bytes_without_data()`.
+   */
+  static size_t total_bytes_with_data(const size_t subcell_size,
+                                      const size_t dg_size);
+
+  static void* pack(BoundaryMessage*);
+  static BoundaryMessage* unpack(void*);
+};
+
+template <size_t Dim>
+bool operator==(const BoundaryMessage<Dim>& lhs,
+                const BoundaryMessage<Dim>& rhs);
+template <size_t Dim>
+bool operator!=(const BoundaryMessage<Dim>& lhs,
+                const BoundaryMessage<Dim>& rhs);
+
+template <size_t Dim>
+std::ostream& operator<<(std::ostream& os, const BoundaryMessage<Dim>& message);
+
+namespace detail {
+template <typename T>
+size_t offset() {
+  if constexpr (std::is_same_v<T, size_t>) {
+    return sizeof(size_t);
+  } else if constexpr (std::is_same_v<T, bool>) {
+    // BoundaryMessage is 8-byte aligned so a bool isn't 1 byte, it's actually 8
+    return 8;
+  } else if constexpr (std::is_same_v<T, TimeStepId>) {
+    return sizeof(TimeStepId);
+  } else if constexpr (std::is_same_v<T, Mesh<3>> or
+                       std::is_same_v<T, Mesh<2>> or
+                       std::is_same_v<T, Mesh<1>>) {
+    return sizeof(T);
+  } else if constexpr (std::is_same_v<T, Mesh<0>>) {
+    // Mesh<0> is only 3 bytes, but we need 8 for alignment
+    return 8;
+  } else if constexpr (std::is_same_v<T, double*>) {
+    return sizeof(double*);
+  } else {
+    ERROR("Cannot calculate offset for '"
+          << pretty_type::name<T>()
+          << "' in a BoundaryMessage. Offset is only known for size_t, bool, "
+             "TimeStepId, Mesh, double*.");
+    return 0;
+  }
+}
+}  // namespace detail
+}  // namespace evolution::dg
+
+#define CK_TEMPLATES_ONLY
+#include "Evolution/DiscontinuousGalerkin/Messages/BoundaryMessage.def.h"
+#undef CK_TEMPLATES_ONLY

--- a/src/Evolution/DiscontinuousGalerkin/Messages/CMakeLists.txt
+++ b/src/Evolution/DiscontinuousGalerkin/Messages/CMakeLists.txt
@@ -1,0 +1,22 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+add_charm_module(BoundaryMessage)
+
+spectre_target_headers(
+  ${LIBRARY}
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  BoundaryMessage.hpp
+  )
+
+spectre_target_sources(
+  ${LIBRARY}
+  PUBLIC
+  BoundaryMessage.cpp
+  )
+
+add_dependencies(
+  ${LIBRARY}
+  module_BoundaryMessage
+  )

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/CMakeLists.txt
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/CMakeLists.txt
@@ -12,6 +12,7 @@ set(LIBRARY_SOURCES
   Actions/Test_NormalCovectorAndMagnitude.cpp
   Initialization/Test_Mortars.cpp
   Initialization/Test_QuadratureTag.cpp
+  Messages/Test_BoundaryMessage.cpp
   Tags/Test_NeighborMesh.cpp
   Test_BoundaryCorrectionsHelper.cpp
   Test_InboxTags.cpp

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Messages/Test_BoundaryMessage.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Messages/Test_BoundaryMessage.cpp
@@ -1,0 +1,183 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <random>
+#include <sstream>
+#include <string>
+
+#include "Evolution/DiscontinuousGalerkin/Messages/BoundaryMessage.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "Time/Slab.hpp"
+#include "Time/Time.hpp"
+#include "Time/TimeStepId.hpp"
+#include "Utilities/GetOutput.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace evolution::dg {
+namespace {
+template <size_t Dim, typename Generator>
+void test_boundary_message(const gsl::not_null<Generator*> generator,
+                           const size_t subcell_size, const size_t dg_size) {
+  CAPTURE(Dim);
+  CAPTURE(subcell_size);
+  CAPTURE(dg_size);
+
+  const size_t total_size_without_data =
+      BoundaryMessage<Dim>::total_bytes_without_data();
+  // Mesh<0> == 8, Mesh<1> == 16, Mesh<2> == 32, Mesh<3> == 48
+  CHECK(total_size_without_data == (Dim == 1 ? 256 : (Dim == 2 ? 280 : 312)));
+  const size_t total_size_with_data =
+      BoundaryMessage<Dim>::total_bytes_with_data(subcell_size, dg_size);
+  CHECK(total_size_with_data ==
+        total_size_without_data + (subcell_size + dg_size) * sizeof(double));
+
+  const bool sent_across_nodes = true;
+  const size_t sender_node = 2;
+  const size_t sender_core = 15;
+
+  const Slab current_slab{0.1, 0.5};
+  const Time current_time{current_slab, {0, 1}};
+  const TimeStepId current_time_id{true, 0, current_time};
+  const Slab next_slab{0.5, 0.9};
+  const Time next_time{next_slab, {0, 1}};
+  const TimeStepId next_time_id{true, 0, next_time};
+
+  const size_t extents = 4;
+  const Mesh<Dim> volume_mesh{extents, Spectral::Basis::Legendre,
+                              Spectral::Quadrature::GaussLobatto};
+  const Mesh<Dim - 1> interface_mesh = volume_mesh.slice_away(0);
+
+  std::uniform_real_distribution<double> dist{-1.0, 1.0};
+  auto subcell_data = make_with_random_values<DataVector>(
+      generator, make_not_null(&dist), subcell_size);
+  auto dg_data = make_with_random_values<DataVector>(
+      generator, make_not_null(&dist), dg_size);
+  // Have to copy data so we have different pointers inside BoundaryMessage to
+  // different data that isn't deleted inside pack
+  DataVector copied_subcell_data = subcell_data;
+  DataVector copied_dg_data = dg_data;
+
+  BoundaryMessage<Dim>* boundary_message = new BoundaryMessage<Dim>(
+      subcell_size, dg_size, sent_across_nodes, sender_node, sender_core,
+      current_time_id, next_time_id, volume_mesh, interface_mesh,
+      subcell_size != 0 ? subcell_data.data() : nullptr,
+      dg_size != 0 ? dg_data.data() : nullptr);
+  BoundaryMessage<Dim>* copied_boundary_message = new BoundaryMessage<Dim>(
+      subcell_size, dg_size, sent_across_nodes, sender_node, sender_core,
+      current_time_id, next_time_id, volume_mesh, interface_mesh,
+      subcell_size != 0 ? copied_subcell_data.data() : nullptr,
+      dg_size != 0 ? copied_dg_data.data() : nullptr);
+
+  CHECK(subcell_data.size() == subcell_size);
+  CHECK(dg_data.size() == dg_size);
+
+  void* packed_message = boundary_message->pack(boundary_message);
+
+  BoundaryMessage<Dim>* unpacked_message =
+      boundary_message->unpack(packed_message);
+
+  CHECK(*copied_boundary_message == *unpacked_message);
+  CHECK_FALSE(*copied_boundary_message != *unpacked_message);
+}
+
+void test_output() {
+  const size_t subcell_size = 4;
+  const size_t dg_size = 3;
+
+  const bool sent_across_nodes = true;
+  const size_t sender_node = 2;
+  const size_t sender_core = 15;
+
+  const Slab current_slab{0.1, 0.5};
+  const Time current_time{current_slab, {0, 1}};
+  const TimeStepId current_time_id{true, 0, current_time};
+  const Slab next_slab{0.5, 0.9};
+  const Time next_time{next_slab, {0, 1}};
+  const TimeStepId next_time_id{true, 0, next_time};
+
+  const size_t extents = 4;
+  const Mesh<2> volume_mesh{extents, Spectral::Basis::Legendre,
+                            Spectral::Quadrature::GaussLobatto};
+  const Mesh<1> interface_mesh = volume_mesh.slice_away(0);
+
+  DataVector subcell_data{0.1, 0.2, 0.3, 0.4};
+  DataVector dg_data{-0.3, -0.2, -0.1};
+
+  BoundaryMessage<2> message{
+      subcell_size,        dg_size,       sent_across_nodes,
+      sender_node,         sender_core,   current_time_id,
+      next_time_id,        volume_mesh,   interface_mesh,
+      subcell_data.data(), dg_data.data()};
+
+  const std::string message_str = get_output(message);
+
+  std::stringstream ss;
+  ss << "subcell_ghost_data_size = 4\n"
+     << "dg_flux_data_size = 3\n"
+     << "sent_across_nodes = true\n"
+     << "sender_node = 2\n"
+     << "sender_core = 15\n"
+     // TimeStepIds have complicated output so don't try and hard code it, just
+     // use get_output
+     << "current_time_ste_id = " << get_output(current_time_id) << "\n"
+     << "next_time_ste_id = " << get_output(next_time_id) << "\n"
+     << "volume_or_ghost_mesh = "
+        "[(4,4),(Legendre,Legendre),(GaussLobatto,GaussLobatto)]\n"
+     << "interface_mesh = [(4),(Legendre),(GaussLobatto)]\n"
+     << "subcell_ghost_data = (0.1,0.2,0.3,0.4)\n"
+     << "dg_flux_data = (-0.3,-0.2,-0.1)";
+
+  CHECK(message_str == ss.str());
+}
+
+void test_offset() {
+  CHECK(detail::offset<size_t>() == 8);
+  CHECK(detail::offset<bool>() == 8);
+  CHECK(detail::offset<TimeStepId>() == 88);
+  CHECK(detail::offset<Mesh<0>>() == 8);
+  CHECK(detail::offset<Mesh<1>>() == 16);
+  CHECK(detail::offset<Mesh<2>>() == 32);
+  CHECK(detail::offset<Mesh<3>>() == 48);
+  CHECK(detail::offset<double*>() == 8);
+
+  CHECK_THROWS_WITH(
+      detail::offset<int>(),
+      Catch::Contains(
+          "Cannot calculate offset for 'int' in a BoundaryMessage"));
+}
+
+SPECTRE_TEST_CASE("Unit.Evolution.DG.BoundaryMessage", "[Unit][Evolution]") {
+  MAKE_GENERATOR(generator);
+
+  test_output();
+  test_offset();
+
+  std::uniform_int_distribution<size_t> size_dist{1, 10};
+  tmpl::for_each<tmpl::integral_list<size_t, 1, 2, 3>>(
+      [&generator, &size_dist](auto dim_t) {
+        constexpr size_t Dim =
+            tmpl::type_from<std::decay_t<decltype(dim_t)>>::value;
+        // Only subcell data
+        test_boundary_message<Dim>(make_not_null(&generator),
+                                   size_dist(generator), 0);
+        // Only dg data
+        test_boundary_message<Dim>(make_not_null(&generator), 0,
+                                   size_dist(generator));
+        // Both subcell and dg data
+        test_boundary_message<Dim>(make_not_null(&generator),
+                                   size_dist(generator), size_dist(generator));
+        // Neither subcell nor dg data. This isn't currently a use case, but we
+        // test it for completeness to ensure pack/unpack are doing the correct
+        // thing
+        test_boundary_message<Dim>(make_not_null(&generator), 0, 0);
+      });
+}
+}  // namespace
+}  // namespace evolution::dg


### PR DESCRIPTION
## Proposed changes

This is the first step in being able to use Charm++ messages so we don't have to `pup` data that's on the same node.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
