### PR TITLE
Add InterpolateToCoords script to Python CLI

### DIFF
--- a/src/DataStructures/Tensor/Python/Tensor.cpp
+++ b/src/DataStructures/Tensor/Python/Tensor.cpp
@@ -119,19 +119,29 @@ void bind_tensor_impl(py::module& m, const std::string& name) {  // NOLINT
                }
                const auto num_points = static_cast<size_t>(info.shape[1]);
                auto data = static_cast<double*>(info.ptr);
+               const std::array<size_t, 2> strides{
+                   {static_cast<size_t>(info.strides[0] / info.itemsize),
+                    static_cast<size_t>(info.strides[1] / info.itemsize)}};
                if (copy) {
                  TensorType result{num_points};
                  for (size_t i = 0; i < size; ++i) {
-                   // NOLINTNEXTLINE
-                   std::copy_n(data + i * num_points, num_points,
-                               result[i].data());
+                   for (size_t j = 0; j < num_points; ++j) {
+                     // NOLINTNEXTLINE
+                     result[i][j] = data[i * strides[0] + j * strides[1]];
+                   }
                  }
                  return result;
                } else {
+                 if (strides[1] != 1) {
+                   throw std::runtime_error(
+                       "Non-owning DataVectors only work with a stride of 1, "
+                       "but stride is " +
+                       std::to_string(strides[1]) + ".");
+                 }
                  TensorType result{};
                  for (size_t i = 0; i < size; ++i) {
                    // NOLINTNEXTLINE
-                   result[i].set_data_ref(data + i * num_points, num_points);
+                   result[i].set_data_ref(data + i * strides[0], num_points);
                  }
                  return result;
                }

--- a/src/Visualization/Python/CMakeLists.txt
+++ b/src/Visualization/Python/CMakeLists.txt
@@ -8,7 +8,7 @@ spectre_python_add_module(
   PYTHON_FILES
   __init__.py
   GenerateXdmf.py
-  InterpolateVolumeData.py
+  InterpolateToMesh.py
   PlotDatFile.py
   ReadH5.py
   Render1D.py

--- a/src/Visualization/Python/CMakeLists.txt
+++ b/src/Visualization/Python/CMakeLists.txt
@@ -8,6 +8,7 @@ spectre_python_add_module(
   PYTHON_FILES
   __init__.py
   GenerateXdmf.py
+  InterpolateToCoords.py
   InterpolateToMesh.py
   PlotDatFile.py
   ReadH5.py

--- a/src/Visualization/Python/InterpolateToCoords.py
+++ b/src/Visualization/Python/InterpolateToCoords.py
@@ -1,0 +1,274 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import click
+import logging
+import numpy as np
+import multiprocessing
+import rich
+import spectre.IO.H5 as spectre_h5
+from spectre.DataStructures import DataVector
+from spectre.DataStructures.Tensor import tnsr
+from spectre.Domain import (block_logical_coordinates,
+                            element_logical_coordinates, deserialize_domain,
+                            deserialize_functions_of_time, ElementId)
+from spectre.Interpolation import Irregular
+from spectre.Spectral import Mesh
+from typing import Iterable, Union, Sequence
+
+logger = logging.getLogger(__name__)
+
+
+def interpolate_to_coords(
+        volfiles: Union[spectre_h5.H5Vol, Iterable[spectre_h5.H5Vol]],
+        obs_id: int, tensor_components: Sequence[str],
+        target_coords: Union[np.ndarray, tnsr.I[DataVector, 3]]) -> np.ndarray:
+    """Interpolate volume data to target coordinates.
+
+    Arguments:
+      volfiles: Open volume data files.
+      obs_id: Observation ID present in all volume data files.
+      tensor_components: List of tensor components to interpolate. Each string
+        specified here must be a dataset name in the volume files.
+      target_coords: Coordinates to interpolate to. Must be an array of shape
+        (num_target_points, dim) or a 'tnsr.I[DataVector, 3]'.
+
+    Returns:
+      Array of shape (len(tensor_components), num_target_points) with the
+      interpolated data at all 'target_coords'.
+    """
+    if isinstance(target_coords, np.ndarray):
+        num_target_points, dim = target_coords.shape
+        target_coords = tnsr.I[DataVector, 3](target_coords.T)
+    else:
+        dim = target_coords.size
+        num_target_points = len(target_coords[0])
+    # We'll fill this array and return it
+    interpolated_data = np.empty((len(tensor_components), num_target_points))
+    interpolated_data.fill(np.nan)
+    # This is to keep track of completed target points to terminate early
+    filled_data = np.zeros(num_target_points, dtype=bool)
+    # We'll read these from the first volfile
+    domain = None
+    time = None
+    functions_of_time = None
+    block_logical_coords = None
+    if isinstance(volfiles, spectre_h5.H5Vol):
+        volfiles = [volfiles]
+    for volfile in volfiles:
+        assert dim == volfile.get_dimension(), (
+            f"'target_coords' has dimension {dim} but volume data has "
+            f"dimension {volfile.get_dimension()}.")
+        if domain is None:
+            domain = deserialize_domain[dim](volfile.get_domain(obs_id))
+            if domain.is_time_dependent():
+                time = volfile.get_observation_value(obs_id)
+                functions_of_time = deserialize_functions_of_time(
+                    volfile.get_functions_of_time(obs_id))
+            block_logical_coords = block_logical_coordinates(
+                domain=domain,
+                inertial_coords=target_coords,
+                time=time,
+                functions_of_time=functions_of_time)
+        all_grid_names = volfile.get_grid_names(obs_id)
+        all_element_ids = list(map(ElementId[dim], all_grid_names))
+        all_extents = volfile.get_extents(obs_id)
+        all_bases = volfile.get_bases(obs_id)
+        all_quadratures = volfile.get_quadratures(obs_id)
+        meshes = {
+            mesh_args[0]: Mesh[dim](*mesh_args[1:])
+            for mesh_args in zip(all_element_ids, all_extents, all_bases,
+                                 all_quadratures)
+        }
+        # Pre-load the tensor data because it's stored contiguously for all
+        # grids in the file
+        tensor_data = np.asarray([
+            volfile.get_tensor_component(obs_id, component).data
+            for component in tensor_components
+        ])
+        # Map the target points to element-logical coordinates
+        element_logical_coords = element_logical_coordinates(
+            all_element_ids, block_logical_coords)
+        for element_id, point in element_logical_coords.items():
+            offset, length = spectre_h5.offset_and_length_for_grid(
+                str(element_id), all_grid_names, all_extents)
+            element_data = tensor_data[:, offset:offset + length]
+            interpolant = Irregular[dim](
+                source_mesh=meshes[element_id],
+                target_logical_coords=point.element_logical_coords)
+            interpolated_data[:, point.offsets] = np.asarray([
+                interpolant.interpolate(DataVector(component))
+                for component in element_data
+            ])
+            filled_data[point.offsets] = True
+        # Terminate early if all data has been filled
+        if filled_data.all():
+            break
+    return interpolated_data
+
+
+def parse_points(ctx, param, values):
+    if not values:
+        return None
+    points = [list(map(float, value.split(','))) for value in values]
+    dim = len(points[0])
+    if any([len(point) != dim for point in points]):
+        raise click.BadParameter(
+            "All specified points must have the same dimension")
+    return np.array(points)
+
+
+@click.command()
+@click.argument("h5_files",
+                nargs=-1,
+                type=click.Path(exists=True,
+                                file_okay=True,
+                                dir_okay=False,
+                                readable=True))
+@click.option("--subfile-name",
+              "-d",
+              help=("Name of subfile within h5 file containing "
+                    "volume data to interpolate."))
+@click.option("--list-vars",
+              "-l",
+              is_flag=True,
+              help="Print available variables and exit.")
+@click.option("--var",
+              "-y",
+              "vars",
+              multiple=True,
+              help=("Variables to interpolate. List any tensor components "
+                    "in the volume data file, such as 'Shift_x'."))
+@click.option("--target-coords-file",
+              "-t",
+              type=click.Path(exists=True,
+                              file_okay=True,
+                              dir_okay=False,
+                              readable=True),
+              help=("Text file with target coordinates to interpolate to. "
+                    "Must have 'dim' columns with Cartesian coordinates. "
+                    "Rows enumerate points. "
+                    "Can be the output of 'numpy.savetxt'."))
+@click.option("--target-coords",
+              "-p",
+              multiple=True,
+              callback=parse_points,
+              help=("List target coordinates explicitly, e.g. '0,0,0'. "
+                    "Can be specified multiple times to quickly interpolate "
+                    "to a couple of target points."))
+@click.option("--step",
+              type=int,
+              help=("Observation step number. "
+                    "Specify '-1' for the last step in the file. "
+                    "Mutually exclusive with '--time'."))
+@click.option("--time",
+              type=float,
+              help=("Observation time. "
+                    "The observation step closest to the specified "
+                    "time is selected. "
+                    "Mutually exclusive with '--step'."))
+@click.option("--output",
+              "-o",
+              type=click.Path(writable=True),
+              help=("Output text file"))
+@click.option("--delimiter",
+              default=None,
+              show_default="whitespace",
+              help=("Delimiter separating columns for both the "
+                    "'--target-coords-file' and the '--output' file."))
+def interpolate_to_coords_command(h5_files, subfile_name, list_vars, vars,
+                                  target_coords, target_coords_file, output,
+                                  step, time, delimiter):
+    # Script should be a noop if input files are empty
+    if not h5_files:
+        return
+
+    open_h5_files = [spectre_h5.H5File(filename, "r") for filename in h5_files]
+
+    # Print available subfile names and exit
+    if not subfile_name:
+        import rich.columns
+        rich.print(rich.columns.Columns(open_h5_files[0].all_vol_files()))
+        return
+
+    if subfile_name.endswith(".vol"):
+        subfile_name = subfile_name.rstrip(".vol")
+    if not subfile_name.startswith("/"):
+        subfile_name = "/" + subfile_name
+
+    volfiles = [h5file.get_vol(subfile_name) for h5file in open_h5_files]
+    obs_ids = volfiles[0].list_observation_ids()
+    obs_values = list(map(volfiles[0].get_observation_value, obs_ids))
+    dim = volfiles[0].get_dimension()
+
+    # Select observation
+    if (step is None) == (time is None):
+        raise click.UsageError(
+            f"Specify either '--step' (in [0, {len(obs_ids) - 1}], or -1) or "
+            f"'--time' (in [{obs_values[0]:g}, {obs_values[-1]:g}]).")
+    if step is None:
+        # Find closest observation to specified time
+        step = np.argmin(np.abs(time - np.array(obs_values)))
+        obs_value = obs_values[step]
+        if obs_value != time:
+            logger.info(f"Selected closest observation to t = {time}: "
+                        f"step {step} at t = {obs_value:g}")
+    obs_id = obs_ids[step]
+
+    # Print available variables and exit
+    all_vars = volfiles[0].list_tensor_components(obs_id)
+    if list_vars or not vars:
+        import rich.columns
+        rich.print(rich.columns.Columns(all_vars))
+        return
+    for var in vars:
+        if var not in all_vars:
+            raise click.UsageError(f"Unknown variable '{var}'. "
+                                   f"Available variables are: {all_vars}")
+
+    # Load target coords from file
+    if (target_coords is None) == (target_coords_file is None):
+        raise click.UsageError("Specify either '--target-coords' / '-p' or "
+                               "'--target-coords-file' / '-t'.")
+    if target_coords_file:
+        target_coords = np.loadtxt(target_coords_file,
+                                   ndmin=2,
+                                   delimiter=delimiter)
+
+    # Interpolate!
+    import rich.progress
+    progress = rich.progress.Progress(
+        rich.progress.TextColumn("[progress.description]{task.description}"),
+        rich.progress.BarColumn(),
+        rich.progress.MofNCompleteColumn(),
+        rich.progress.TimeRemainingColumn(),
+        disable=(len(volfiles) == 1))
+    task_id = progress.add_task("Interpolating files")
+    volfiles_progress = progress.track(volfiles, task_id=task_id)
+    with progress:
+        interpolated_data = interpolate_to_coords(volfiles_progress,
+                                                  target_coords=target_coords,
+                                                  obs_id=obs_id,
+                                                  tensor_components=vars)
+        progress.update(task_id, completed=len(volfiles))
+
+    # Output result
+    column_names = ["X", "Y", "Z"][:dim] + list(vars)
+    column_data = np.hstack([target_coords, interpolated_data.T])
+    if output:
+        np.savetxt(output,
+                   column_data,
+                   delimiter=delimiter or " ",
+                   header=(f"t = {obs_values[step]:g}\n" +
+                           (delimiter or " ").join(column_names)))
+    else:
+        import rich.table
+        table = rich.table.Table(*column_names, box=None)
+        for row in column_data:
+            table.add_row(*list(map(str, row)))
+        rich.print(table)
+        rich.print(f"(t = {obs_values[step]:g})")
+
+
+if __name__ == "__main__":
+    interpolate_to_coords_command(help_option_names=["-h", "--help"])

--- a/src/Visualization/Python/InterpolateToMesh.py
+++ b/src/Visualization/Python/InterpolateToMesh.py
@@ -20,10 +20,10 @@ logger = logging.getLogger(__name__)
 # lambda because the function needs to be pickled. Note that `starmap` only
 # works with an iterable, not with a dict.
 def forward_kwargs(kwargs):
-    interpolate_h5_file(**kwargs)
+    interpolate_to_mesh(**kwargs)
 
 
-def interpolate_h5_file(source_file_path,
+def interpolate_to_mesh(source_file_path,
                         target_mesh,
                         target_file_path,
                         source_volume_data,
@@ -166,7 +166,7 @@ def interpolate_h5_file(source_file_path,
         target_file.close()
 
 
-@click.command(help=interpolate_h5_file.__doc__)
+@click.command(help=interpolate_to_mesh.__doc__)
 @click.option(
     "--source-file-prefix",
     required=True,
@@ -232,11 +232,11 @@ def interpolate_h5_file(source_file_path,
     default=None,
     help=("The maximum number of processes to be started. "
           "A process is spawned for each source file up to this number."))
-def interpolate_volume_data_command(source_file_prefix, source_subfile_name,
-                                    target_file_prefix, target_subfile_name,
-                                    target_extents, target_basis,
-                                    target_quadrature, tensor_component,
-                                    start_time, stop_time, stride, num_jobs):
+def interpolate_to_mesh_command(source_file_prefix, source_subfile_name,
+                                target_file_prefix, target_subfile_name,
+                                target_extents, target_basis,
+                                target_quadrature, tensor_component,
+                                start_time, stop_time, stride, num_jobs):
     _rich_traceback_guard = True  # Hide traceback until here
 
     source_files = glob.glob(source_file_prefix + "[0-9]*.h5")

--- a/support/Python/__main__.py
+++ b/support/Python/__main__.py
@@ -18,7 +18,7 @@ class Cli(click.MultiCommand):
             "extract-dat",
             "extract-input",
             "generate-xdmf",
-            "interpolate-vol",
+            "interpolate-to-mesh",
             "plot-dat",
             "render-1d",
             "simplify-traces",
@@ -42,10 +42,10 @@ class Cli(click.MultiCommand):
             from spectre.Visualization.GenerateXdmf import (
                 generate_xdmf_command)
             return generate_xdmf_command
-        elif name == "interpolate-vol":
-            from spectre.Visualization.InterpolateVolumeData import (
-                interpolate_volume_data_command)
-            return interpolate_volume_data_command
+        elif name == "interpolate-to-mesh":
+            from spectre.Visualization.InterpolateToMesh import (
+                interpolate_to_mesh_command)
+            return interpolate_to_mesh_command
         elif name == "plot-dat":
             from spectre.Visualization.PlotDatFile import plot_dat_command
             return plot_dat_command

--- a/support/Python/__main__.py
+++ b/support/Python/__main__.py
@@ -18,6 +18,7 @@ class Cli(click.MultiCommand):
             "extract-dat",
             "extract-input",
             "generate-xdmf",
+            "interpolate-to-coords",
             "interpolate-to-mesh",
             "plot-dat",
             "render-1d",
@@ -42,6 +43,10 @@ class Cli(click.MultiCommand):
             from spectre.Visualization.GenerateXdmf import (
                 generate_xdmf_command)
             return generate_xdmf_command
+        elif name == "interpolate-to-coords":
+            from spectre.Visualization.InterpolateToCoords import (
+                interpolate_to_coords_command)
+            return interpolate_to_coords_command
         elif name == "interpolate-to-mesh":
             from spectre.Visualization.InterpolateToMesh import (
                 interpolate_to_mesh_command)

--- a/tests/Unit/DataStructures/Tensor/Python/Test_Tensor.py
+++ b/tests/Unit/DataStructures/Tensor/Python/Test_Tensor.py
@@ -38,6 +38,18 @@ class TestTensor(unittest.TestCase):
                 npt.assert_equal(a, b, f"Mismatch at index {i}")
             npt.assert_equal(np.array(coords), data)
 
+    def test_buffer_strides(self):
+        # The transpose should set up data with non-unit strides
+        original_data = np.random.rand(4, 3)
+        data = original_data.T
+        coords = tnsr.I[DataVector, 3, Frame.Inertial](data)
+        for i, (a, b) in enumerate(zip(coords, data)):
+            npt.assert_equal(a, b, f"Mismatch at index {i}")
+        npt.assert_equal(np.array(coords), data)
+        # Non-owning DataVectors don't work with strides != 1
+        with self.assertRaisesRegex(RuntimeError, "Non-owning"):
+            coords = tnsr.I[DataVector, 3, Frame.Inertial](data, copy=False)
+
     def test_tensor_double(self):
         coords = tnsr.I[float, 3, Frame.Inertial](fill=0.)
         coords[0] = 1.

--- a/tests/Unit/Visualization/Python/CMakeLists.txt
+++ b/tests/Unit/Visualization/Python/CMakeLists.txt
@@ -36,6 +36,12 @@ spectre_add_python_test(
   None)
 
 spectre_add_python_bindings_test(
+  "Unit.Visualization.Python.InterpolateToCoords"
+  Test_InterpolateToCoords.py
+  "unit;visualization;python"
+  None)
+
+spectre_add_python_bindings_test(
   "Unit.Visualization.Python.InterpolateToMesh"
   Test_InterpolateToMesh.py
   "unit;visualization;python"

--- a/tests/Unit/Visualization/Python/CMakeLists.txt
+++ b/tests/Unit/Visualization/Python/CMakeLists.txt
@@ -36,7 +36,7 @@ spectre_add_python_test(
   None)
 
 spectre_add_python_bindings_test(
-  "Unit.Visualization.Python.InterpolateVolumeData"
-  Test_InterpolateVolumeData.py
+  "Unit.Visualization.Python.InterpolateToMesh"
+  Test_InterpolateToMesh.py
   "unit;visualization;python"
   None)

--- a/tests/Unit/Visualization/Python/Test_InterpolateToCoords.py
+++ b/tests/Unit/Visualization/Python/Test_InterpolateToCoords.py
@@ -1,0 +1,84 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+from spectre.Visualization.InterpolateToCoords import (
+    interpolate_to_coords, interpolate_to_coords_command)
+
+import numpy as np
+import numpy.testing as npt
+import os
+import shutil
+import spectre.IO.H5 as spectre_h5
+import unittest
+from click.testing import CliRunner
+from spectre.Informer import unit_test_build_path, unit_test_src_path
+
+
+class TestInterpolateToCoords(unittest.TestCase):
+    def setUp(self):
+        self.test_dir = os.path.join(unit_test_build_path(), "Visualization",
+                                     "InterpolateToCoords")
+        self.h5_filename = os.path.join(unit_test_src_path(),
+                                        "Visualization/Python",
+                                        "VolTestData0.h5")
+        os.makedirs(self.test_dir, exist_ok=True)
+
+    def tearDown(self):
+        shutil.rmtree(self.test_dir)
+
+    def test_interpolate_to_coords(self):
+        open_h5_file = spectre_h5.H5File(self.h5_filename, "r")
+        volfile = open_h5_file.get_vol("/element_data")
+        obs_id = volfile.list_observation_ids()[0]
+        # Domain is [0, 2 pi]^3, so we check the endpoints
+        coords = np.array([3 * [0.], 3 * [2 * np.pi]])
+        psi, = interpolate_to_coords(volfile,
+                                     obs_id=obs_id,
+                                     tensor_components=["Psi"],
+                                     target_coords=coords)
+        npt.assert_allclose(psi, [-0.07059807, -0.06781784])
+
+    def test_cli(self):
+        runner = CliRunner()
+        result = runner.invoke(interpolate_to_coords_command, [
+            self.h5_filename,
+            "-d",
+            "element_data",
+            "--step",
+            "0",
+            "-y",
+            "Psi",
+            "-p",
+            "0,0,0",
+        ],
+                               catch_exceptions=False)
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertIn("-0.0705980", result.output, result.output)
+
+        coords_file = os.path.join(self.test_dir, "coords.txt")
+        coords = np.array([3 * [0.], 3 * [2 * np.pi]])
+        np.savetxt(coords_file, coords)
+        result_file = os.path.join(self.test_dir, "result.txt")
+        result = runner.invoke(interpolate_to_coords_command, [
+            self.h5_filename,
+            "-d",
+            "element_data",
+            "--step",
+            "0",
+            "-y",
+            "Psi",
+            "-t",
+            coords_file,
+            "-o",
+            result_file,
+        ],
+                               catch_exceptions=False)
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        result_data = np.loadtxt(result_file)
+        npt.assert_allclose(
+            result_data, np.hstack((coords, [[-0.07059807], [-0.06781784]])))
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/tests/Unit/Visualization/Python/Test_InterpolateToMesh.py
+++ b/tests/Unit/Visualization/Python/Test_InterpolateToMesh.py
@@ -1,6 +1,9 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
+from spectre.Visualization.InterpolateToMesh import (
+    interpolate_to_mesh, interpolate_to_mesh_command)
+
 import unittest
 from click.testing import CliRunner
 from spectre.Informer import unit_test_build_path
@@ -8,14 +11,13 @@ import spectre.IO.H5 as spectre_h5
 from spectre.IO.H5 import TensorComponent, ElementVolumeData
 from spectre.DataStructures import DataVector
 from spectre import Spectral
-from spectre.Visualization import InterpolateVolumeData
 import os
 import numpy as np
 import logging
 import shutil
 
 
-class TestInterpolateH5(unittest.TestCase):
+class TestInterpolateToMesh(unittest.TestCase):
     def setUp(self):
         """
         Creates two files with 2 observations each with two elements each
@@ -23,7 +25,7 @@ class TestInterpolateH5(unittest.TestCase):
         """
 
         self.test_dir = os.path.join(unit_test_build_path(), "Visualization",
-                                     "InterpolateVolumeData")
+                                     "InterpolateToMesh")
         os.makedirs(self.test_dir, exist_ok=True)
 
         self.file_name = os.path.join(self.test_dir, "interpolation_1.h5")
@@ -136,10 +138,8 @@ class TestInterpolateH5(unittest.TestCase):
                                [Spectral.Quadrature.Gauss] * 3)
 
         target_volume_name = "/VolumeDataInterpolated"
-        InterpolateVolumeData.interpolate_h5_file(self.file_name, mesh,
-                                                  self.file_name,
-                                                  self.volume_name,
-                                                  target_volume_name)
+        interpolate_to_mesh(self.file_name, mesh, self.file_name,
+                            self.volume_name, target_volume_name)
 
         file = spectre_h5.H5File(self.file_name, "r")
 
@@ -191,7 +191,7 @@ class TestInterpolateH5(unittest.TestCase):
     def test_cli(self):
         runner = CliRunner()
         result = runner.invoke(
-            InterpolateVolumeData.interpolate_volume_data_command,
+            interpolate_to_mesh_command,
             [
                 "--source-file-prefix",
                 os.path.join(self.test_dir, "interpolation_"),


### PR DESCRIPTION
## Proposed changes

Allows to interpolate to any set of points in Python, or directly in the CLI:

```
$ spectre interpolate-to-coords tests/Unit/Visualization/Python/VolTestData0.h5 \
    -d element_data --step 0 -y Psi -p 0,0,0 -p 1,1,1
 X    Y    Z    Psi                 
 0.0  0.0  0.0  -0.0705980693254233 
 1.0  1.0  1.0  -0.4966680826867241 
(t = 0.04)
```

Can also save to files etc. I want to use this to interpolate initial data to any set of points, e.g. to compare to other codes or load data into other codes.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
