### PR TITLE
Add option to export FD coordinates in ExportCoords executable

### DIFF
--- a/src/Evolution/DgSubcell/ActiveGrid.hpp
+++ b/src/Evolution/DgSubcell/ActiveGrid.hpp
@@ -5,6 +5,10 @@
 
 #include <iosfwd>
 
+#include "Options/Options.hpp"
+#include "Options/ParseOptions.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
+
 namespace evolution::dg::subcell {
 /// \ingroup DgSubcellGroup
 /// The grid that is currently being used for the DG-subcell evolution.
@@ -12,3 +16,18 @@ enum class ActiveGrid { Dg, Subcell };
 
 std::ostream& operator<<(std::ostream& os, ActiveGrid active_grid);
 }  // namespace evolution::dg::subcell
+
+template <>
+struct Options::create_from_yaml<evolution::dg::subcell::ActiveGrid> {
+  template <typename Metavariables>
+  static evolution::dg::subcell::ActiveGrid create(
+      const Options::Option& options) {
+    const auto active_grid = options.parse_as<std::string>();
+    if (active_grid == "Dg") {
+      return evolution::dg::subcell::ActiveGrid::Dg;
+    } else if (active_grid == "Subcell") {
+      return evolution::dg::subcell::ActiveGrid::Subcell;
+    }
+    PARSE_ERROR(options.context(), "ActiveGrid must be 'Dg' or 'Subcell'.");
+  }
+};

--- a/src/Evolution/DgSubcell/Tags/ActiveGrid.hpp
+++ b/src/Evolution/DgSubcell/Tags/ActiveGrid.hpp
@@ -5,10 +5,28 @@
 
 #include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "Evolution/DgSubcell/ActiveGrid.hpp"
+#include "NumericalAlgorithms/SpatialDiscretization/OptionTags.hpp"
+#include "Options/Options.hpp"
 
-namespace evolution::dg::subcell::Tags {
+namespace evolution::dg::subcell {
+namespace OptionTags {
+struct ActiveGrid {
+  using type = evolution::dg::subcell::ActiveGrid;
+  static constexpr Options::String help = {
+      "The type of the active grid. Either 'Dg' or 'Subcell'."};
+  using group = SpatialDiscretization::OptionTags::SpatialDiscretizationGroup;
+};
+}  // namespace OptionTags
+namespace Tags {
+
 /// The grid currently used for the DG-subcell evolution on the element.
 struct ActiveGrid : db::SimpleTag {
   using type = evolution::dg::subcell::ActiveGrid;
+  using option_tags =
+      tmpl::list<evolution::dg::subcell::OptionTags::ActiveGrid>;
+
+  static constexpr bool pass_metavariables = false;
+  static type create_from_options(const type option) { return option; }
 };
-}  // namespace evolution::dg::subcell::Tags
+}  // namespace Tags
+}  // namespace evolution::dg::subcell

--- a/src/Executables/ExportCoordinates/CMakeLists.txt
+++ b/src/Executables/ExportCoordinates/CMakeLists.txt
@@ -3,6 +3,7 @@
 
 set(LIBS_TO_LINK
   CoordinateMaps
+  DgSubcell
   DomainCreators
   EventsAndTriggers
   Evolution

--- a/tests/InputFiles/ExportCoordinates/Input1D.yaml
+++ b/tests/InputFiles/ExportCoordinates/Input1D.yaml
@@ -23,6 +23,7 @@ DomainCreator:
         Velocity: [0.5]
 
 SpatialDiscretization:
+  ActiveGrid: Dg
   DiscontinuousGalerkin:
     Quadrature: GaussLobatto
 

--- a/tests/InputFiles/ExportCoordinates/Input2D.yaml
+++ b/tests/InputFiles/ExportCoordinates/Input2D.yaml
@@ -23,6 +23,7 @@ DomainCreator:
         Velocity: [0.5, 0.0]
 
 SpatialDiscretization:
+  ActiveGrid: Dg
   DiscontinuousGalerkin:
     Quadrature: GaussLobatto
 

--- a/tests/InputFiles/ExportCoordinates/Input3D.yaml
+++ b/tests/InputFiles/ExportCoordinates/Input3D.yaml
@@ -23,6 +23,7 @@ DomainCreator:
         Velocity: [0.5, 0.0, 0.0]
 
 SpatialDiscretization:
+  ActiveGrid: Dg
   DiscontinuousGalerkin:
     Quadrature: GaussLobatto
 

--- a/tests/InputFiles/ExportCoordinates/InputTimeDependent3D.yaml
+++ b/tests/InputFiles/ExportCoordinates/InputTimeDependent3D.yaml
@@ -61,6 +61,7 @@ DomainCreator:
         InitialAccelerations: [0.0, 0.0]
 
 SpatialDiscretization:
+  ActiveGrid: Dg
   DiscontinuousGalerkin:
     Quadrature: GaussLobatto
 

--- a/tests/Unit/Evolution/DgSubcell/Test_ActiveGrid.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Test_ActiveGrid.cpp
@@ -6,9 +6,24 @@
 #include <string>
 
 #include "Evolution/DgSubcell/ActiveGrid.hpp"
+#include "Evolution/DgSubcell/Tags/ActiveGrid.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
 #include "Utilities/GetOutput.hpp"
 
 SPECTRE_TEST_CASE("Unit.Evolution.Subcell.ActiveGrid", "[Evolution][Unit]") {
   CHECK("Dg" == get_output(evolution::dg::subcell::ActiveGrid::Dg));
   CHECK("Subcell" == get_output(evolution::dg::subcell::ActiveGrid::Subcell));
+  CHECK(TestHelpers::test_creation<evolution::dg::subcell::ActiveGrid>("Dg") ==
+        evolution::dg::subcell::ActiveGrid::Dg);
+  CHECK(TestHelpers::test_creation<evolution::dg::subcell::ActiveGrid>(
+            "Subcell") == evolution::dg::subcell::ActiveGrid::Subcell);
+  TestHelpers::db::test_simple_tag<evolution::dg::subcell::Tags::ActiveGrid>(
+      "ActiveGrid");
+  CHECK(TestHelpers::test_option_tag<
+            evolution::dg::subcell::OptionTags::ActiveGrid>("Dg") ==
+        evolution::dg::subcell::ActiveGrid::Dg);
+  CHECK(TestHelpers::test_option_tag<
+            evolution::dg::subcell::OptionTags::ActiveGrid>("Subcell") ==
+        evolution::dg::subcell::ActiveGrid::Subcell);
 }


### PR DESCRIPTION
## Proposed changes

Just allows you to export the coordinates of a domain with FD spacing or DG spacing. This will still actually work for curved/time dependent meshes because all we are doing are exporting coordinates. No evolution is actually happening.

Here is a 5x5x5 aligned lattice with a single refinement in the x direction on both a DG grid and a FD grid.

DG Grid:
![image](https://user-images.githubusercontent.com/31455476/212198623-1aa6f35d-ca25-40b1-aa3b-712fcbaeac1b.png)

FD Grid:
![image](https://user-images.githubusercontent.com/31455476/212198502-1868cc1c-3b92-4a63-8d55-56c3079259c6.png)


<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
Add an option called `ActiveGrid:` to the `SpatialDiscretization:` block of your ExportCoordinates input file. Choose either `Dg` or `Subcell` for the active grid.
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

A future optimization could be to add the ability to specify which blocks output FD and which output DG.

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
