### PR TITLE
Add Composition coord map

### DIFF
--- a/src/Domain/CMakeLists.txt
+++ b/src/Domain/CMakeLists.txt
@@ -16,6 +16,7 @@ spectre_target_sources(
   ElementDistribution.cpp
   ElementLogicalCoordinates.cpp
   ElementMap.cpp
+  ElementToBlockLogicalMap.cpp
   FaceNormal.cpp
   InterfaceLogicalCoordinates.cpp
   MinimumGridSpacing.cpp
@@ -37,6 +38,7 @@ spectre_target_headers(
   ElementDistribution.hpp
   ElementLogicalCoordinates.hpp
   ElementMap.hpp
+  ElementToBlockLogicalMap.hpp
   FaceNormal.hpp
   InterfaceComputeTags.hpp
   InterfaceHelpers.hpp

--- a/src/Domain/CoordinateMaps/CMakeLists.txt
+++ b/src/Domain/CoordinateMaps/CMakeLists.txt
@@ -10,6 +10,7 @@ spectre_target_sources(
   PRIVATE
   Affine.cpp
   BulgedCube.cpp
+  Composition.cpp
   CylindricalEndcap.cpp
   CylindricalEndcapHelpers.cpp
   CylindricalFlatEndcap.cpp
@@ -44,6 +45,7 @@ spectre_target_headers(
   HEADERS
   Affine.hpp
   BulgedCube.hpp
+  Composition.hpp
   CoordinateMap.hpp
   CoordinateMap.tpp
   CoordinateMapHelpers.hpp

--- a/src/Domain/CoordinateMaps/Composition.cpp
+++ b/src/Domain/CoordinateMaps/Composition.cpp
@@ -1,0 +1,375 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Domain/CoordinateMaps/Composition.hpp"
+
+#include <tuple>
+#include <type_traits>
+
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
+#include "Utilities/GenerateInstantiations.hpp"
+
+namespace domain::CoordinateMaps {
+
+template <typename Frames, size_t Dim, size_t... Is>
+Composition<Frames, Dim, std::index_sequence<Is...>>::Composition(
+    std::unique_ptr<
+        CoordinateMapBase<tmpl::at<frames, tmpl::size_t<Is>>,
+                          tmpl::at<frames, tmpl::size_t<Is + 1>>, Dim>>... maps)
+    : maps_{std::move(maps)...} {}
+
+template <typename Frames, size_t Dim, size_t... Is>
+Composition<Frames, Dim, std::index_sequence<Is...>>&
+Composition<Frames, Dim, std::index_sequence<Is...>>::operator=(
+    const Composition& rhs) {
+  expand_pack((get<Is>(maps_) = get<Is>(rhs.maps_)->get_clone())...);
+  return *this;
+}
+
+template <typename Frames, size_t Dim, size_t... Is>
+bool Composition<Frames, Dim, std::index_sequence<Is...>>::is_identity() const {
+  bool result = true;
+  EXPAND_PACK_LEFT_TO_RIGHT(
+      (result = result and get<Is>(maps_)->is_identity()));
+  return result;
+}
+
+template <typename Frames, size_t Dim, size_t... Is>
+bool Composition<Frames, Dim,
+                 std::index_sequence<Is...>>::inv_jacobian_is_time_dependent()
+    const {
+  bool result = false;
+  EXPAND_PACK_LEFT_TO_RIGHT(
+      (result = result or get<Is>(maps_)->inv_jacobian_is_time_dependent()));
+  return result;
+}
+
+template <typename Frames, size_t Dim, size_t... Is>
+bool Composition<Frames, Dim,
+                 std::index_sequence<Is...>>::jacobian_is_time_dependent()
+    const {
+  bool result = false;
+  EXPAND_PACK_LEFT_TO_RIGHT(
+      (result = result or get<Is>(maps_)->jacobian_is_time_dependent()));
+  return result;
+}
+
+template <typename Frames, size_t Dim, size_t... Is>
+tnsr::I<double, Dim, tmpl::back<Frames>>
+Composition<Frames, Dim, std::index_sequence<Is...>>::operator()(
+    tnsr::I<double, Dim, SourceFrame> source_point, const double time,
+    const FuncOfTimeMap& functions_of_time) const {
+  return call_impl(std::move(source_point), time, functions_of_time);
+}
+
+template <typename Frames, size_t Dim, size_t... Is>
+tnsr::I<DataVector, Dim, tmpl::back<Frames>>
+Composition<Frames, Dim, std::index_sequence<Is...>>::operator()(
+    tnsr::I<DataVector, Dim, SourceFrame> source_point, const double time,
+    const FuncOfTimeMap& functions_of_time) const {
+  return call_impl(std::move(source_point), time, functions_of_time);
+}
+
+template <typename Frames, size_t Dim, size_t... Is>
+std::optional<tnsr::I<double, Dim, tmpl::front<Frames>>>
+Composition<Frames, Dim, std::index_sequence<Is...>>::inverse(
+    tnsr::I<double, Dim, tmpl::back<Frames>> target_point, const double time,
+    const FuncOfTimeMap& functions_of_time) const {
+  return inverse_impl(std::move(target_point), time, functions_of_time);
+}
+
+template <typename Frames, size_t Dim, size_t... Is>
+InverseJacobian<double, Dim, tmpl::front<Frames>, tmpl::back<Frames>>
+Composition<Frames, Dim, std::index_sequence<Is...>>::inv_jacobian(
+    tnsr::I<double, Dim, SourceFrame> source_point, const double time,
+    const FuncOfTimeMap& functions_of_time) const {
+  return inv_jacobian_impl(std::move(source_point), time, functions_of_time);
+}
+
+template <typename Frames, size_t Dim, size_t... Is>
+InverseJacobian<DataVector, Dim, tmpl::front<Frames>, tmpl::back<Frames>>
+Composition<Frames, Dim, std::index_sequence<Is...>>::inv_jacobian(
+    tnsr::I<DataVector, Dim, SourceFrame> source_point, const double time,
+    const FuncOfTimeMap& functions_of_time) const {
+  return inv_jacobian_impl(std::move(source_point), time, functions_of_time);
+}
+
+template <typename Frames, size_t Dim, size_t... Is>
+Jacobian<double, Dim, tmpl::front<Frames>, tmpl::back<Frames>>
+Composition<Frames, Dim, std::index_sequence<Is...>>::jacobian(
+    tnsr::I<double, Dim, SourceFrame> source_point, const double time,
+    const FuncOfTimeMap& functions_of_time) const {
+  return jacobian_impl(std::move(source_point), time, functions_of_time);
+}
+
+template <typename Frames, size_t Dim, size_t... Is>
+Jacobian<DataVector, Dim, tmpl::front<Frames>, tmpl::back<Frames>>
+Composition<Frames, Dim, std::index_sequence<Is...>>::jacobian(
+    tnsr::I<DataVector, Dim, SourceFrame> source_point, const double time,
+    const FuncOfTimeMap& functions_of_time) const {
+  return jacobian_impl(std::move(source_point), time, functions_of_time);
+}
+
+template <typename Frames, size_t Dim, size_t... Is>
+[[noreturn]] std::tuple<
+    tnsr::I<double, Dim, tmpl::back<Frames>>,
+    InverseJacobian<double, Dim, tmpl::front<Frames>, tmpl::back<Frames>>,
+    Jacobian<double, Dim, tmpl::front<Frames>, tmpl::back<Frames>>,
+    tnsr::I<double, Dim, tmpl::back<Frames>>>
+Composition<Frames, Dim, std::index_sequence<Is...>>::
+    coords_frame_velocity_jacobians(
+        tnsr::I<double, Dim, SourceFrame> /*source_point*/,
+        const double /*time*/,
+        const FuncOfTimeMap& /*functions_of_time*/) const {
+  ERROR(
+      "coords_frame_velocity_jacobians is not yet implemented in "
+      "'Composition'. Please implement this function if you need it.");
+}
+
+template <typename Frames, size_t Dim, size_t... Is>
+[[noreturn]] std::tuple<
+    tnsr::I<DataVector, Dim, tmpl::back<Frames>>,
+    InverseJacobian<DataVector, Dim, tmpl::front<Frames>, tmpl::back<Frames>>,
+    Jacobian<DataVector, Dim, tmpl::front<Frames>, tmpl::back<Frames>>,
+    tnsr::I<DataVector, Dim, tmpl::back<Frames>>>
+Composition<Frames, Dim, std::index_sequence<Is...>>::
+    coords_frame_velocity_jacobians(
+        tnsr::I<DataVector, Dim, SourceFrame> /*source_point*/,
+        const double /*time*/,
+        const FuncOfTimeMap& /*functions_of_time*/) const {
+  ERROR(
+      "coords_frame_velocity_jacobians is not yet implemented in "
+      "'Composition'. Please implement this function if you need it.");
+}
+
+template <typename Frames, size_t Dim, size_t... Is>
+[[noreturn]] std::unique_ptr<
+    CoordinateMapBase<tmpl::front<Frames>, Frame::Grid, Dim>>
+Composition<Frames, Dim, std::index_sequence<Is...>>::get_to_grid_frame()
+    const {
+  // We probably don't need this.
+  ERROR(
+      "get_to_grid_frame is not implemented in 'Composition'. "
+      "Just create a composition to the grid frame, or implement this "
+      "function if you need it.");
+}
+
+// NOLINTNEXTLINE(google-runtime-references)
+template <typename Frames, size_t Dim, size_t... Is>
+void Composition<Frames, Dim, std::index_sequence<Is...>>::pup(PUP::er& p) {
+  Base::pup(p);
+  p | maps_;
+}
+
+template <typename Frames, size_t Dim, size_t... Is>
+template <typename DataType>
+tnsr::I<DataType, Dim, tmpl::back<Frames>>
+Composition<Frames, Dim, std::index_sequence<Is...>>::call_impl(
+    tnsr::I<DataType, Dim, SourceFrame> source_point, const double time,
+    const FuncOfTimeMap& functions_of_time) const {
+  std::tuple<tnsr::I<DataType, Dim, SourceFrame>,
+             tnsr::I<DataType, Dim, tmpl::at<frames, tmpl::size_t<Is + 1>>>...>
+      points{};
+  get<0>(points) = std::move(source_point);
+  const auto apply = [&points, &time, &functions_of_time,
+                      this](const auto index_v) {
+    constexpr size_t index = decltype(index_v)::value;
+    const auto& map = *get<index>(maps_);
+    if (UNLIKELY(map.is_identity())) {
+      for (size_t d = 0; d < Dim; ++d) {
+        get<index + 1>(points).get(d) = std::move(get<index>(points).get(d));
+      }
+    } else {
+      get<index + 1>(points) =
+          map(std::move(get<index>(points)), time, functions_of_time);
+    }
+    return '0';
+  };
+  EXPAND_PACK_LEFT_TO_RIGHT(apply(tmpl::size_t<Is>{}));
+  return get<tnsr::I<DataType, Dim, TargetFrame>>(points);
+}
+
+template <typename Frames, size_t Dim, size_t... Is>
+template <typename DataType>
+std::optional<tnsr::I<DataType, Dim, tmpl::front<Frames>>>
+Composition<Frames, Dim, std::index_sequence<Is...>>::inverse_impl(
+    tnsr::I<DataType, Dim, TargetFrame> target_point, const double time,
+    const FuncOfTimeMap& functions_of_time) const {
+  std::tuple<std::optional<tnsr::I<DataType, Dim, SourceFrame>>,
+             std::optional<tnsr::I<DataType, Dim,
+                                   tmpl::at<frames, tmpl::size_t<Is + 1>>>>...>
+      points{};
+  get<num_frames - 1>(points) = std::move(target_point);
+  const auto apply_inverse = [&points, &time, &functions_of_time,
+                              this](const auto index_v) {
+    constexpr size_t index = decltype(index_v)::value;
+    // index runs from 0 to num_frames - 2. We evaluate maps in reverse order.
+    auto& local_target_point = get<num_frames - index - 1>(points);
+    if (local_target_point.has_value()) {
+      auto& local_source_point = get<num_frames - index - 2>(points);
+      const auto& map = *get<num_frames - index - 2>(maps_);
+      if (UNLIKELY(map.is_identity())) {
+        local_source_point =
+            tnsr::I<DataType, Dim,
+                    tmpl::at<frames, tmpl::size_t<num_frames - index - 2>>>{};
+        for (size_t d = 0; d < Dim; ++d) {
+          local_source_point->get(d) = std::move(local_target_point->get(d));
+        }
+      } else {
+        local_source_point = map.inverse(std::move(local_target_point.value()),
+                                         time, functions_of_time);
+      }
+    }
+    return '0';
+  };
+  EXPAND_PACK_LEFT_TO_RIGHT(apply_inverse(tmpl::size_t<Is>{}));
+  return get<0>(points);
+}
+
+template <typename Frames, size_t Dim, size_t... Is>
+template <typename DataType>
+InverseJacobian<DataType, Dim, tmpl::front<Frames>, tmpl::back<Frames>>
+Composition<Frames, Dim, std::index_sequence<Is...>>::inv_jacobian_impl(
+    tnsr::I<DataType, Dim, SourceFrame> source_point, const double time,
+    const FuncOfTimeMap& functions_of_time) const {
+  std::tuple<tnsr::I<DataType, Dim, tmpl::at<frames, tmpl::size_t<Is>>>...>
+      source_points{};
+  std::tuple<InverseJacobian<DataType, Dim, SourceFrame,
+                             tmpl::at<frames, tmpl::size_t<Is + 1>>>...>
+      inv_jacobians{};
+  get<0>(source_points) = std::move(source_point);
+  const auto apply_inv_jacobian = [&source_points, &inv_jacobians, &time,
+                                   &functions_of_time,
+                                   this](const auto index_v) {
+    constexpr size_t index = decltype(index_v)::value;
+    const auto& map = *get<index>(maps_);
+    auto& local_source_point = get<index>(source_points);
+    if constexpr (index == 0) {
+      get<0>(inv_jacobians) =
+          map.inv_jacobian(local_source_point, time, functions_of_time);
+    } else {
+      auto& prev_inv_jacobian = get<index - 1>(inv_jacobians);
+      if (UNLIKELY(map.is_identity())) {
+        for (size_t i = 0; i < Dim; ++i) {
+          for (size_t j = 0; j <= i; ++j) {
+            get<index>(inv_jacobians).get(i, j) =
+                std::move(prev_inv_jacobian.get(i, j));
+          }
+        }
+      } else {
+        // Compose inverse Jacobians
+        const auto next_inv_jacobian =
+            map.inv_jacobian(local_source_point, time, functions_of_time);
+        get<index>(inv_jacobians) = tenex::evaluate<ti::I, ti::j>(
+            prev_inv_jacobian(ti::I, ti::k) * next_inv_jacobian(ti::K, ti::j));
+      }
+    }
+    // Map next source point
+    if constexpr (index < num_frames - 2) {
+      if (UNLIKELY(map.is_identity())) {
+        for (size_t d = 0; d < Dim; ++d) {
+          get<index + 1>(source_points).get(d) =
+              std::move(local_source_point.get(d));
+        }
+      } else {
+        get<index + 1>(source_points) =
+            map(std::move(local_source_point), time, functions_of_time);
+      }
+    }
+    return '0';
+  };
+  EXPAND_PACK_LEFT_TO_RIGHT(apply_inv_jacobian(tmpl::size_t<Is>{}));
+  return get<InverseJacobian<DataType, Dim, SourceFrame, TargetFrame>>(
+      inv_jacobians);
+}
+
+template <typename Frames, size_t Dim, size_t... Is>
+template <typename DataType>
+Jacobian<DataType, Dim, tmpl::front<Frames>, tmpl::back<Frames>>
+Composition<Frames, Dim, std::index_sequence<Is...>>::jacobian_impl(
+    tnsr::I<DataType, Dim, SourceFrame> source_point, const double time,
+    const FuncOfTimeMap& functions_of_time) const {
+  std::tuple<tnsr::I<DataType, Dim, tmpl::at<frames, tmpl::size_t<Is>>>...>
+      source_points{};
+  std::tuple<Jacobian<DataType, Dim, SourceFrame,
+                      tmpl::at<frames, tmpl::size_t<Is + 1>>>...>
+      jacobians{};
+  get<0>(source_points) = std::move(source_point);
+  const auto apply_jacobian = [&source_points, &jacobians, &time,
+                               &functions_of_time, this](const auto index_v) {
+    constexpr size_t index = decltype(index_v)::value;
+    const auto& map = *get<index>(maps_);
+    auto& local_source_point = get<index>(source_points);
+    if constexpr (index == 0) {
+      get<0>(jacobians) =
+          map.jacobian(local_source_point, time, functions_of_time);
+    } else {
+      auto& prev_jacobian = get<index - 1>(jacobians);
+      if (UNLIKELY(map.is_identity())) {
+        for (size_t i = 0; i < Dim; ++i) {
+          for (size_t j = 0; j <= i; ++j) {
+            get<index>(jacobians).get(i, j) =
+                std::move(prev_jacobian.get(i, j));
+          }
+        }
+      } else {
+        // Compose Jacobians
+        const auto next_jacobian =
+            map.jacobian(local_source_point, time, functions_of_time);
+        get<index>(jacobians) = tenex::evaluate<ti::I, ti::j>(
+            next_jacobian(ti::I, ti::k) * prev_jacobian(ti::K, ti::j));
+      }
+    }
+    // Map next source point
+    if constexpr (index < num_frames - 2) {
+      if (UNLIKELY(map.is_identity())) {
+        for (size_t d = 0; d < Dim; ++d) {
+          get<index + 1>(source_points).get(d) =
+              std::move(local_source_point.get(d));
+        }
+      } else {
+        get<index + 1>(source_points) =
+            map(std::move(local_source_point), time, functions_of_time);
+      }
+    }
+    return '0';
+  };
+  EXPAND_PACK_LEFT_TO_RIGHT(apply_jacobian(tmpl::size_t<Is>{}));
+  return get<Jacobian<DataType, Dim, SourceFrame, TargetFrame>>(jacobians);
+}
+
+template <typename Frames, size_t Dim, size_t... Is>
+bool Composition<Frames, Dim, std::index_sequence<Is...>>::is_equal_to(
+    const CoordinateMapBase<SourceFrame, TargetFrame, Dim>& other) const {
+  const auto& cast_of_other = dynamic_cast<const Composition&>(other);
+  bool result = true;
+  EXPAND_PACK_LEFT_TO_RIGHT(
+      (result = result and (*get<Is>(maps_) == *get<Is>(cast_of_other.maps_))));
+  return result;
+}
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data)                                                   \
+  template class Composition<                                                  \
+      tmpl::list<Frame::ElementLogical, Frame::BlockLogical, Frame::Inertial>, \
+      DIM(data)>;                                                              \
+  template class Composition<                                                  \
+      tmpl::list<Frame::ElementLogical, Frame::BlockLogical, Frame::Grid>,     \
+      DIM(data)>;                                                              \
+  template class Composition<                                                  \
+      tmpl::list<Frame::ElementLogical, Frame::BlockLogical, Frame::Grid,      \
+                 Frame::Inertial>,                                             \
+      DIM(data)>;                                                              \
+  template class Composition<                                                  \
+      tmpl::list<Frame::ElementLogical, Frame::BlockLogical, Frame::Grid,      \
+                 Frame::Distorted, Frame::Inertial>,                           \
+      DIM(data)>;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
+
+#undef DIM
+#undef INSTANTIATE
+
+}  // namespace domain::CoordinateMaps

--- a/src/Domain/CoordinateMaps/Composition.hpp
+++ b/src/Domain/CoordinateMaps/Composition.hpp
@@ -1,0 +1,227 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <memory>
+#include <pup.h>
+#include <tuple>
+#include <type_traits>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "Parallel/CharmPupable.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace domain::CoordinateMaps {
+
+/*!
+ * \brief A composition of coordinate maps at runtime
+ *
+ * Composes a sequence of `domain::CoordinateMapBase` that step through the
+ * `Frames`. The result is another `domain::CoordinateMapBase`. This is
+ * different to `domain::CoordinateMap`, which does the composition at compile
+ * time. The use cases are different:
+ *
+ * - Use `domain::CoordinateMap` to compose maps at compile time to go from one
+ *   (named) frame to another using any number of coordinate transformation. The
+ *   coordinate transformations are concatenated to effectively form a single
+ *   map, and intermediate frames have no meaning. This has the performance
+ *   benefit that looking up pointers and calling into virtual member functions
+ *   of intermediate maps is avoided, and it has the semantic benefit that
+ *   intermediate frames without meaning are not named or even accessible.
+ *   **Example:** A static BlockLogical -> Grid map that deforms the logical
+ *   cube to a wedge, applies a radial redistribution of grid points, and
+ *   translates + rotates the wedge.
+ * - Use `domain::CoordinateMaps::Composition` (this class) to compose maps at
+ *   runtime to step through a sequence of (named) frames.
+ *   **Example:** A time-dependent ElementLogical -> BlockLogical -> Grid ->
+ *   Inertial map that applies an affine transformation between the
+ *   ElementLogical and BlockLogical frames (see
+ *   domain::element_to_block_logical_map), then deforms the logical cube to a
+ *   wedge using the map described above (Grid frame), and then rotates the grid
+ *   with a time-dependent rotation map (Inertial frame).
+ *
+ * \warning Think about performance implications before using this Composition
+ * class. In an evolution it's usually advantageous to keep at least some of the
+ * maps separate, e.g. to avoid reevaluating the static maps in every time step.
+ * You can also access individual components of the composition in this class.
+ *
+ * \tparam Frames The list of frames in the composition, as a tmpl::list<>.
+ * The first entry in the list is the source frame, and the last entry is the
+ * target frame of the composition. Maps in the composition step through the
+ * `Frames`. For example, if `Frames = tmpl::list<Frame::ElementLogical,
+ * Frame::BlockLogical, Frame::Inertial>`, then the composition has two maps:
+ * ElementLogical -> BlockLogical and BlockLogical -> Inertial.
+ */
+template <typename Frames, size_t Dim,
+          typename Is = std::make_index_sequence<tmpl::size<Frames>::value - 1>>
+struct Composition;
+
+template <typename Frames, size_t Dim, size_t... Is>
+struct Composition<Frames, Dim, std::index_sequence<Is...>>
+    : public CoordinateMapBase<tmpl::front<Frames>, tmpl::back<Frames>, Dim> {
+  using frames = Frames;
+  using SourceFrame = tmpl::front<Frames>;
+  using TargetFrame = tmpl::back<Frames>;
+  static constexpr size_t num_frames = tmpl::size<Frames>::value;
+  using Base = CoordinateMapBase<SourceFrame, TargetFrame, Dim>;
+  using FuncOfTimeMap = std::unordered_map<
+      std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>;
+
+  Composition() = default;
+  Composition(const Composition& rhs) { *this = rhs; }
+  Composition& operator=(const Composition& rhs);
+  Composition(Composition&& /*rhs*/) = default;
+  Composition& operator=(Composition&& /*rhs*/) = default;
+  ~Composition() override = default;
+
+  std::unique_ptr<Base> get_clone() const override {
+    return std::make_unique<Composition>(*this);
+  }
+
+  /// \cond
+  explicit Composition(CkMigrateMessage* /*m*/) {}
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(Composition);  // NOLINT
+  /// \endcond
+
+  Composition(std::unique_ptr<CoordinateMapBase<
+                  tmpl::at<frames, tmpl::size_t<Is>>,
+                  tmpl::at<frames, tmpl::size_t<Is + 1>>, Dim>>... maps);
+
+  const std::tuple<std::unique_ptr<
+      CoordinateMapBase<tmpl::at<frames, tmpl::size_t<Is>>,
+                        tmpl::at<frames, tmpl::size_t<Is + 1>>, Dim>>...>&
+  maps() const {
+    return maps_;
+  }
+
+  template <typename LocalSourceFrame, typename LocalTargetFrame>
+  const CoordinateMapBase<LocalSourceFrame, LocalTargetFrame, Dim>&
+  get_component() const {
+    return *get<std::unique_ptr<
+        CoordinateMapBase<LocalSourceFrame, LocalTargetFrame, Dim>>>(maps_);
+  }
+
+  bool is_identity() const override;
+
+  bool inv_jacobian_is_time_dependent() const override;
+
+  bool jacobian_is_time_dependent() const override;
+
+  tnsr::I<double, Dim, TargetFrame> operator()(
+      tnsr::I<double, Dim, SourceFrame> source_point,
+      double time = std::numeric_limits<double>::signaling_NaN(),
+      const FuncOfTimeMap& functions_of_time = {}) const override;
+
+  tnsr::I<DataVector, Dim, TargetFrame> operator()(
+      tnsr::I<DataVector, Dim, SourceFrame> source_point,
+      double time = std::numeric_limits<double>::signaling_NaN(),
+      const FuncOfTimeMap& functions_of_time = {}) const override;
+
+  std::optional<tnsr::I<double, Dim, SourceFrame>> inverse(
+      tnsr::I<double, Dim, TargetFrame> target_point,
+      double time = std::numeric_limits<double>::signaling_NaN(),
+      const FuncOfTimeMap& functions_of_time = {}) const override;
+
+  InverseJacobian<double, Dim, SourceFrame, TargetFrame> inv_jacobian(
+      tnsr::I<double, Dim, SourceFrame> source_point,
+      double time = std::numeric_limits<double>::signaling_NaN(),
+      const FuncOfTimeMap& functions_of_time = {}) const override;
+
+  InverseJacobian<DataVector, Dim, SourceFrame, TargetFrame> inv_jacobian(
+      tnsr::I<DataVector, Dim, SourceFrame> source_point,
+      double time = std::numeric_limits<double>::signaling_NaN(),
+      const FuncOfTimeMap& functions_of_time = {}) const override;
+
+  Jacobian<double, Dim, SourceFrame, TargetFrame> jacobian(
+      tnsr::I<double, Dim, SourceFrame> source_point,
+      double time = std::numeric_limits<double>::signaling_NaN(),
+      const FuncOfTimeMap& functions_of_time = {}) const override;
+
+  Jacobian<DataVector, Dim, SourceFrame, TargetFrame> jacobian(
+      tnsr::I<DataVector, Dim, SourceFrame> source_point,
+      double time = std::numeric_limits<double>::signaling_NaN(),
+      const FuncOfTimeMap& functions_of_time = {}) const override;
+
+  [[noreturn]] std::tuple<
+      tnsr::I<double, Dim, TargetFrame>,
+      InverseJacobian<double, Dim, SourceFrame, TargetFrame>,
+      Jacobian<double, Dim, SourceFrame, TargetFrame>,
+      tnsr::I<double, Dim, TargetFrame>>
+  coords_frame_velocity_jacobians(
+      tnsr::I<double, Dim, SourceFrame> source_point,
+      double time = std::numeric_limits<double>::signaling_NaN(),
+      const FuncOfTimeMap& functions_of_time = {}) const override;
+
+  [[noreturn]] std::tuple<
+      tnsr::I<DataVector, Dim, TargetFrame>,
+      InverseJacobian<DataVector, Dim, SourceFrame, TargetFrame>,
+      Jacobian<DataVector, Dim, SourceFrame, TargetFrame>,
+      tnsr::I<DataVector, Dim, TargetFrame>>
+  coords_frame_velocity_jacobians(
+      tnsr::I<DataVector, Dim, SourceFrame> source_point,
+      double time = std::numeric_limits<double>::signaling_NaN(),
+      const FuncOfTimeMap& functions_of_time = {}) const override;
+
+  [[noreturn]] std::unique_ptr<CoordinateMapBase<SourceFrame, Frame::Grid, Dim>>
+  get_to_grid_frame() const override;
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& p) override;
+
+ private:
+  template <typename DataType>
+  tnsr::I<DataType, Dim, TargetFrame> call_impl(
+      tnsr::I<DataType, Dim, SourceFrame> source_point,
+      const double time = std::numeric_limits<double>::signaling_NaN(),
+      const FuncOfTimeMap& functions_of_time = {}) const;
+
+  template <typename DataType>
+  std::optional<tnsr::I<DataType, Dim, SourceFrame>> inverse_impl(
+      tnsr::I<DataType, Dim, TargetFrame> target_point,
+      const double time = std::numeric_limits<double>::signaling_NaN(),
+      const FuncOfTimeMap& functions_of_time = {}) const;
+
+  template <typename DataType>
+  InverseJacobian<DataType, Dim, SourceFrame, TargetFrame> inv_jacobian_impl(
+      tnsr::I<DataType, Dim, SourceFrame> source_point,
+      const double time = std::numeric_limits<double>::signaling_NaN(),
+      const FuncOfTimeMap& functions_of_time = {}) const;
+
+  template <typename DataType>
+  Jacobian<DataType, Dim, SourceFrame, TargetFrame> jacobian_impl(
+      tnsr::I<DataType, Dim, SourceFrame> source_point,
+      const double time = std::numeric_limits<double>::signaling_NaN(),
+      const FuncOfTimeMap& functions_of_time = {}) const;
+
+  bool is_equal_to(const CoordinateMapBase<SourceFrame, TargetFrame, Dim>&
+                       other) const override;
+
+  std::tuple<std::unique_ptr<
+      CoordinateMapBase<tmpl::at<frames, tmpl::size_t<Is>>,
+                        tmpl::at<frames, tmpl::size_t<Is + 1>>, Dim>>...>
+      maps_;
+};
+
+// Template deduction guide
+template <typename FirstMap, typename... Maps>
+Composition(std::unique_ptr<FirstMap>, std::unique_ptr<Maps>... maps)
+    -> Composition<tmpl::list<typename FirstMap::source_frame,
+                              typename FirstMap::target_frame,
+                              typename Maps::target_frame...>,
+                   FirstMap::dim>;
+
+/// \cond
+template <typename Frames, size_t Dim, size_t... Is>
+PUP::able::PUP_ID
+    Composition<Frames, Dim, std::index_sequence<Is...>>::my_PUP_ID = 0;
+/// \endcond
+
+}  // namespace domain::CoordinateMaps

--- a/src/Domain/ElementToBlockLogicalMap.cpp
+++ b/src/Domain/ElementToBlockLogicalMap.cpp
@@ -1,0 +1,58 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Domain/ElementToBlockLogicalMap.hpp"
+
+#include <cstddef>
+#include <memory>
+
+#include "Domain/CoordinateMaps/Affine.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
+#include "Domain/CoordinateMaps/ProductMaps.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.tpp"
+#include "Domain/Structure/Side.hpp"
+
+namespace domain {
+
+using AffineMap = CoordinateMaps::Affine;
+
+template <>
+std::unique_ptr<
+    CoordinateMapBase<Frame::ElementLogical, Frame::BlockLogical, 1>>
+element_to_block_logical_map(const ElementId<1>& element_id) {
+  return std::make_unique<
+      CoordinateMap<Frame::ElementLogical, Frame::BlockLogical, AffineMap>>(
+      AffineMap{-1., 1., element_id.segment_id(0).endpoint(Side::Lower),
+                element_id.segment_id(0).endpoint(Side::Upper)});
+}
+template <>
+std::unique_ptr<
+    CoordinateMapBase<Frame::ElementLogical, Frame::BlockLogical, 2>>
+element_to_block_logical_map(const ElementId<2>& element_id) {
+  using AffineMap2D = CoordinateMaps::ProductOf2Maps<AffineMap, AffineMap>;
+  return std::make_unique<
+      CoordinateMap<Frame::ElementLogical, Frame::BlockLogical, AffineMap2D>>(
+      AffineMap2D{{-1., 1., element_id.segment_id(0).endpoint(Side::Lower),
+                   element_id.segment_id(0).endpoint(Side::Upper)},
+                  {-1., 1., element_id.segment_id(1).endpoint(Side::Lower),
+                   element_id.segment_id(1).endpoint(Side::Upper)}});
+}
+
+template <>
+std::unique_ptr<
+    CoordinateMapBase<Frame::ElementLogical, Frame::BlockLogical, 3>>
+element_to_block_logical_map(const ElementId<3>& element_id) {
+  using AffineMap3D =
+      CoordinateMaps::ProductOf3Maps<AffineMap, AffineMap, AffineMap>;
+  return std::make_unique<
+      CoordinateMap<Frame::ElementLogical, Frame::BlockLogical, AffineMap3D>>(
+      AffineMap3D{{-1., 1., element_id.segment_id(0).endpoint(Side::Lower),
+                   element_id.segment_id(0).endpoint(Side::Upper)},
+                  {-1., 1., element_id.segment_id(1).endpoint(Side::Lower),
+                   element_id.segment_id(1).endpoint(Side::Upper)},
+                  {-1., 1., element_id.segment_id(2).endpoint(Side::Lower),
+                   element_id.segment_id(2).endpoint(Side::Upper)}});
+}
+
+}  // namespace domain

--- a/src/Domain/ElementToBlockLogicalMap.hpp
+++ b/src/Domain/ElementToBlockLogicalMap.hpp
@@ -1,0 +1,28 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <memory>
+
+#include "DataStructures/Tensor/IndexType.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/Structure/ElementId.hpp"
+
+namespace domain {
+/*!
+ * \brief Constructs the affine map from ElementLogical to BlockLogical
+ * coordinates
+ *
+ * An element is the result of repeatedly splitting a block in half along any of
+ * its logical axes. This map transforms from ElementLogical coordinates
+ * [-1, 1]^dim to the subset of BlockLogical coordinates [-1, 1]^dim that cover
+ * the element. For instance, the two elements at refinement level 1 in 1D
+ * cover [-1, 0] and [0, 1] in BlockLogical coordinates, respectively.
+ */
+template <size_t Dim>
+std::unique_ptr<
+    CoordinateMapBase<Frame::ElementLogical, Frame::BlockLogical, Dim>>
+element_to_block_logical_map(const ElementId<Dim>& element_id);
+}  // namespace domain

--- a/tests/Unit/Domain/CMakeLists.txt
+++ b/tests/Unit/Domain/CMakeLists.txt
@@ -18,6 +18,7 @@ set(LIBRARY_SOURCES
   Test_DomainTestHelpers.cpp
   Test_ElementDistribution.cpp
   Test_ElementMap.cpp
+  Test_ElementToBlockLogicalMap.cpp
   Test_FaceNormal.cpp
   Test_InterfaceHelpers.cpp
   Test_InterfaceItems.cpp

--- a/tests/Unit/Domain/CoordinateMaps/CMakeLists.txt
+++ b/tests/Unit/Domain/CoordinateMaps/CMakeLists.txt
@@ -6,6 +6,7 @@ set(LIBRARY "Test_CoordinateMaps")
 set(LIBRARY_SOURCES
   Test_Affine.cpp
   Test_BulgedCube.cpp
+  Test_Composition.cpp
   Test_CoordinateMap.cpp
   Test_CylindricalEndcap.cpp
   Test_CylindricalFlatEndcap.cpp

--- a/tests/Unit/Domain/CoordinateMaps/Test_Composition.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_Composition.cpp
@@ -1,0 +1,193 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <memory>
+#include <random>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/CoordinateMaps/Affine.hpp"
+#include "Domain/CoordinateMaps/Composition.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
+#include "Domain/CoordinateMaps/ProductMaps.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.tpp"
+#include "Domain/CoordinateMaps/Wedge.hpp"
+#include "Domain/ElementToBlockLogicalMap.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "Parallel/RegisterDerivedClassesWithCharm.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace domain::CoordinateMaps {
+
+namespace {
+void test_composition() {
+  INFO("Composition");
+
+  using Affine2D = ProductOf2Maps<Affine, Affine>;
+  Parallel::register_classes_with_charm<
+      CoordinateMap<Frame::ElementLogical, Frame::BlockLogical, Affine2D>,
+      CoordinateMap<Frame::BlockLogical, Frame::Inertial, Affine2D>>();
+
+  MAKE_GENERATOR(generator);
+  std::uniform_real_distribution<double> logical_dist{-1., 1.};
+
+  // Domain is [0, 1] x [1, 3], and first dim is split in half, so element is
+  // [0, 0.5] x [1, 3]
+  const ElementId<2> element_id{0, {{{1, 0}, {0, 0}}}};
+  // Testing template deduction here
+  const Composition map{
+      element_to_block_logical_map(element_id),
+      std::make_unique<
+          CoordinateMap<Frame::BlockLogical, Frame::Inertial, Affine2D>>(
+          Affine2D{{-1., 1., 0., 1.}, {-1., 1., 1., 3.}})};
+
+  {
+    INFO("Semantics");
+    test_serialization(map);
+    test_copy_semantics(map);
+    auto move_map = map;
+    test_move_semantics(std::move(move_map), map);
+  }
+
+  {
+    INFO("Properties");
+    const auto& maps = map.maps();
+    CHECK(*get<0>(maps) == *element_to_block_logical_map(element_id));
+    CHECK((map.get_component<Frame::ElementLogical, Frame::BlockLogical>() ==
+           *get<0>(maps)));
+  }
+
+  CHECK_FALSE(map.is_identity());
+  CHECK_FALSE(map.inv_jacobian_is_time_dependent());
+  CHECK_FALSE(map.jacobian_is_time_dependent());
+
+  const auto xi =
+      make_with_random_values<tnsr::I<DataVector, 2, Frame::ElementLogical>>(
+          make_not_null(&generator), make_not_null(&logical_dist),
+          DataVector(5));
+  const auto x = map(xi);
+  const auto jacobian = map.jacobian(xi);
+  const auto inv_jacobian = map.inv_jacobian(xi);
+  CHECK_ITERABLE_APPROX(get<0>(x), (get<0>(xi) + 1.) * 0.25);
+  CHECK_ITERABLE_APPROX(get<1>(x), (get<1>(xi) + 2.));
+  CHECK_ITERABLE_APPROX((get<0, 0>(jacobian)), DataVector(5, 0.25));
+  CHECK_ITERABLE_APPROX((get<0, 0>(inv_jacobian)), DataVector(5, 4.));
+  CHECK_ITERABLE_APPROX((get<1, 1>(jacobian)), DataVector(5, 1.));
+  CHECK_ITERABLE_APPROX((get<1, 1>(inv_jacobian)), DataVector(5, 1.));
+  CHECK_ITERABLE_APPROX((get<1, 0>(jacobian)), DataVector(5, 0.));
+  CHECK_ITERABLE_APPROX((get<1, 0>(inv_jacobian)), DataVector(5, 0.));
+  const auto x_target = tnsr::I<double, 2, Frame::Inertial>{{{0.5, 1.}}};
+  const auto inv = map.inverse(x_target);
+  REQUIRE(inv.has_value());
+  CHECK(get<0>(*inv) == approx(1.));
+  CHECK(get<1>(*inv) == approx(-1.));
+}
+
+void test_identity() {
+  INFO("Identity");
+
+  using Affine3D = ProductOf3Maps<Affine, Affine, Affine>;
+  Parallel::register_classes_with_charm<
+      CoordinateMap<Frame::ElementLogical, Frame::BlockLogical, Affine3D>,
+      CoordinateMap<Frame::BlockLogical, Frame::Inertial, Affine3D>>();
+
+  MAKE_GENERATOR(generator);
+  std::uniform_real_distribution<double> logical_dist{-1., 1.};
+
+  const ElementId<3> element_id{0, {{{0, 0}, {0, 0}, {0, 0}}}};
+  const Composition<
+      tmpl::list<Frame::ElementLogical, Frame::BlockLogical, Frame::Inertial>,
+      3>
+      map{element_to_block_logical_map(element_id),
+          std::make_unique<
+              CoordinateMap<Frame::BlockLogical, Frame::Inertial, Affine3D>>(
+              Affine3D{
+                  {-1., 1., -1., 1.}, {-1., 1., -1., 1.}, {-1., 1., -1., 1.}})};
+
+  CHECK(map.is_identity());
+
+  const auto xi =
+      make_with_random_values<tnsr::I<DataVector, 3, Frame::ElementLogical>>(
+          make_not_null(&generator), make_not_null(&logical_dist),
+          DataVector(5));
+  const auto x = map(xi);
+  const auto jacobian = map.jacobian(xi);
+  const auto inv_jacobian = map.inv_jacobian(xi);
+  CHECK_ITERABLE_APPROX(get<0>(x), get<0>(xi));
+  CHECK_ITERABLE_APPROX(get<1>(x), get<1>(xi));
+  CHECK_ITERABLE_APPROX(get<2>(x), get<2>(xi));
+  CHECK_ITERABLE_APPROX((get<0, 0>(jacobian)), DataVector(5, 1.));
+  CHECK_ITERABLE_APPROX((get<0, 0>(inv_jacobian)), DataVector(5, 1.));
+  CHECK_ITERABLE_APPROX((get<1, 1>(jacobian)), DataVector(5, 1.));
+  CHECK_ITERABLE_APPROX((get<1, 1>(inv_jacobian)), DataVector(5, 1.));
+  CHECK_ITERABLE_APPROX((get<2, 2>(jacobian)), DataVector(5, 1.));
+  CHECK_ITERABLE_APPROX((get<2, 2>(inv_jacobian)), DataVector(5, 1.));
+  CHECK_ITERABLE_APPROX((get<1, 0>(jacobian)), DataVector(5, 0.));
+  CHECK_ITERABLE_APPROX((get<1, 0>(inv_jacobian)), DataVector(5, 0.));
+  CHECK_ITERABLE_APPROX((get<2, 0>(jacobian)), DataVector(5, 0.));
+  CHECK_ITERABLE_APPROX((get<2, 0>(inv_jacobian)), DataVector(5, 0.));
+  CHECK_ITERABLE_APPROX((get<2, 1>(jacobian)), DataVector(5, 0.));
+  CHECK_ITERABLE_APPROX((get<2, 1>(inv_jacobian)), DataVector(5, 0.));
+  const auto x_target = tnsr::I<double, 3, Frame::Inertial>{{{0.5, 1., 0.}}};
+  const auto inv = map.inverse(x_target);
+  REQUIRE(inv.has_value());
+  CHECK(get<0>(*inv) == approx(0.5));
+  CHECK(get<1>(*inv) == approx(1.));
+  CHECK(get<2>(*inv) == approx(0.));
+}
+
+void test_3d() {
+  INFO("3D");
+
+  MAKE_GENERATOR(generator);
+  std::uniform_real_distribution<double> logical_dist{-1., 1.};
+
+  const ElementId<3> element_id{0, {{{1, 0}, {1, 0}, {2, 0}}}};
+  const Composition map{
+      element_to_block_logical_map(element_id),
+      std::make_unique<
+          CoordinateMap<Frame::BlockLogical, Frame::Inertial, Wedge<3>>>(
+          Wedge<3>{1., 3., 1., 1., {}, true})};
+
+  // Check some points that are easy to calculate
+  // - On inner boundary
+  CHECK(get(magnitude(map(tnsr::I<double, 3, Frame::ElementLogical>{
+            {logical_dist(generator), logical_dist(generator), -1.}}))) ==
+        approx(1.));
+  // - On outer boundary of first radial element
+  CHECK(get(magnitude(map(tnsr::I<double, 3, Frame::ElementLogical>{
+            {logical_dist(generator), logical_dist(generator), 1.}}))) ==
+        approx(1.5));
+
+  // Check Jacobian is consistent with inverse
+  const auto xi =
+      make_with_random_values<tnsr::I<DataVector, 3, Frame::ElementLogical>>(
+          make_not_null(&generator), make_not_null(&logical_dist),
+          DataVector(5));
+  const auto jacobian = map.jacobian(xi);
+  const auto inv_jacobian = map.inv_jacobian(xi);
+  const auto identity = tenex::evaluate<ti::I, ti::j>(
+      jacobian(ti::I, ti::k) * inv_jacobian(ti::K, ti::j));
+  CHECK_ITERABLE_APPROX((get<0, 0>(identity)), DataVector(5, 1.));
+  CHECK_ITERABLE_APPROX((get<1, 1>(identity)), DataVector(5, 1.));
+  CHECK_ITERABLE_APPROX((get<2, 2>(identity)), DataVector(5, 1.));
+  CHECK_ITERABLE_APPROX((get<1, 0>(identity)), DataVector(5, 0.));
+  CHECK_ITERABLE_APPROX((get<2, 0>(identity)), DataVector(5, 0.));
+  CHECK_ITERABLE_APPROX((get<2, 1>(identity)), DataVector(5, 0.));
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Composition", "[Domain][Unit]") {
+  test_composition();
+  test_identity();
+  test_3d();
+}
+
+}  // namespace domain::CoordinateMaps

--- a/tests/Unit/Domain/Test_ElementToBlockLogicalMap.cpp
+++ b/tests/Unit/Domain/Test_ElementToBlockLogicalMap.cpp
@@ -1,0 +1,108 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <random>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/ElementToBlockLogicalMap.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace domain {
+
+SPECTRE_TEST_CASE("Unit.Domain.ElementToBlockLogicalMap", "[Domain][Unit]") {
+  MAKE_GENERATOR(generator);
+  std::uniform_real_distribution<double> logical_dist{-1., 1.};
+
+  {
+    INFO("1D");
+    const ElementId<1> element_id{0, {{{1, 0}}}};
+    const auto map = element_to_block_logical_map(element_id);
+
+    const auto xi =
+        make_with_random_values<tnsr::I<DataVector, 1, Frame::ElementLogical>>(
+            make_not_null(&generator), make_not_null(&logical_dist),
+            DataVector(5));
+    const auto x = (*map)(xi);
+    const auto jacobian = map->jacobian(xi);
+    const auto inv_jacobian = map->inv_jacobian(xi);
+    CHECK_ITERABLE_APPROX(get<0>(x), get<0>(xi) * 0.5 - 0.5);
+    CHECK_ITERABLE_APPROX((get<0, 0>(jacobian)), DataVector(5, 0.5));
+    CHECK_ITERABLE_APPROX((get<0, 0>(inv_jacobian)), DataVector(5, 2.));
+    const auto x_target = tnsr::I<double, 1, Frame::BlockLogical>{{{0.}}};
+    const auto inv = map->inverse(x_target);
+    REQUIRE(inv.has_value());
+    CHECK(get<0>(*inv) == approx(1.));
+  }
+
+  {
+    INFO("2D");
+    const ElementId<2> element_id{0, {{{1, 0}, {0, 0}}}};
+    const auto map = element_to_block_logical_map(element_id);
+
+    const auto xi =
+        make_with_random_values<tnsr::I<DataVector, 2, Frame::ElementLogical>>(
+            make_not_null(&generator), make_not_null(&logical_dist),
+            DataVector(5));
+    const auto x = (*map)(xi);
+    const auto jacobian = map->jacobian(xi);
+    const auto inv_jacobian = map->inv_jacobian(xi);
+    CHECK_ITERABLE_APPROX(get<0>(x), get<0>(xi) * 0.5 - 0.5);
+    CHECK_ITERABLE_APPROX(get<1>(x), get<1>(xi));
+    CHECK_ITERABLE_APPROX((get<0, 0>(jacobian)), DataVector(5, 0.5));
+    CHECK_ITERABLE_APPROX((get<0, 0>(inv_jacobian)), DataVector(5, 2.));
+    CHECK_ITERABLE_APPROX((get<1, 1>(jacobian)), DataVector(5, 1.));
+    CHECK_ITERABLE_APPROX((get<1, 1>(inv_jacobian)), DataVector(5, 1.));
+    CHECK_ITERABLE_APPROX((get<1, 0>(jacobian)), DataVector(5, 0.));
+    CHECK_ITERABLE_APPROX((get<1, 0>(inv_jacobian)), DataVector(5, 0.));
+    const auto x_target = tnsr::I<double, 2, Frame::BlockLogical>{{{0., -1.}}};
+    const auto inv = map->inverse(x_target);
+    REQUIRE(inv.has_value());
+    CHECK(get<0>(*inv) == approx(1.));
+    CHECK(get<1>(*inv) == approx(-1.));
+  }
+
+  {
+    INFO("3D");
+    const ElementId<3> element_id{0, {{{1, 0}, {0, 0}, {2, 1}}}};
+    const auto map = element_to_block_logical_map(element_id);
+
+    const auto xi =
+        make_with_random_values<tnsr::I<DataVector, 3, Frame::ElementLogical>>(
+            make_not_null(&generator), make_not_null(&logical_dist),
+            DataVector(5));
+    const auto x = (*map)(xi);
+    const auto jacobian = map->jacobian(xi);
+    const auto inv_jacobian = map->inv_jacobian(xi);
+    CHECK_ITERABLE_APPROX(get<0>(x), get<0>(xi) * 0.5 - 0.5);
+    CHECK_ITERABLE_APPROX(get<1>(x), get<1>(xi));
+    CHECK_ITERABLE_APPROX(get<2>(x), get<2>(xi) * 0.25 - 0.25);
+    CHECK_ITERABLE_APPROX((get<0, 0>(jacobian)), DataVector(5, 0.5));
+    CHECK_ITERABLE_APPROX((get<0, 0>(inv_jacobian)), DataVector(5, 2.));
+    CHECK_ITERABLE_APPROX((get<1, 1>(jacobian)), DataVector(5, 1.));
+    CHECK_ITERABLE_APPROX((get<1, 1>(inv_jacobian)), DataVector(5, 1.));
+    CHECK_ITERABLE_APPROX((get<2, 2>(jacobian)), DataVector(5, 0.25));
+    CHECK_ITERABLE_APPROX((get<2, 2>(inv_jacobian)), DataVector(5, 4.));
+    CHECK_ITERABLE_APPROX((get<1, 0>(jacobian)), DataVector(5, 0.));
+    CHECK_ITERABLE_APPROX((get<1, 0>(inv_jacobian)), DataVector(5, 0.));
+    CHECK_ITERABLE_APPROX((get<2, 0>(jacobian)), DataVector(5, 0.));
+    CHECK_ITERABLE_APPROX((get<2, 0>(inv_jacobian)), DataVector(5, 0.));
+    CHECK_ITERABLE_APPROX((get<2, 1>(jacobian)), DataVector(5, 0.));
+    CHECK_ITERABLE_APPROX((get<2, 1>(inv_jacobian)), DataVector(5, 0.));
+    const auto x_target =
+        tnsr::I<double, 3, Frame::BlockLogical>{{{0., -1., -0.5}}};
+    const auto inv = map->inverse(x_target);
+    REQUIRE(inv.has_value());
+    CHECK(get<0>(*inv) == approx(1.));
+    CHECK(get<1>(*inv) == approx(-1.));
+    CHECK(get<2>(*inv) == approx(-1.));
+  }
+}
+}  // namespace domain


### PR DESCRIPTION
## Proposed changes

This makes Jacobians available in Python, which in turn will allow us to take derivatives and integrals over volume data (edit: deferred to next PR).

We can later consider replacing ElementMap with the Composition coordinate map that I'm adding here.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
