### PR TITLE
Pin macOS version on CI

### DIFF
--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -679,7 +679,7 @@ ${{ env.CACHE_KEY_SUFFIX }}"
   # Build all test executables and run unit tests on macOS
   unit_tests_macos:
     name: Unit tests on macOS
-    runs-on: macos-latest
+    runs-on: macos-11
     env:
       # We install some low-level dependencies with Homebrew. They get picked up
       # by `spack external find`.

--- a/src/Visualization/Python/InterpolateToCoords.py
+++ b/src/Visualization/Python/InterpolateToCoords.py
@@ -237,12 +237,26 @@ def interpolate_to_coords_command(h5_files, subfile_name, list_vars, vars,
 
     # Interpolate!
     import rich.progress
-    progress = rich.progress.Progress(
-        rich.progress.TextColumn("[progress.description]{task.description}"),
-        rich.progress.BarColumn(),
-        rich.progress.MofNCompleteColumn(),
-        rich.progress.TimeRemainingColumn(),
-        disable=(len(volfiles) == 1))
+    try:
+        progress_cols = (
+            rich.progress.TextColumn(
+                "[progress.description]{task.description}"),
+            rich.progress.BarColumn(),
+            # Added in rich v12.0
+            rich.progress.MofNCompleteColumn(),
+            rich.progress.TimeRemainingColumn(),
+        )
+    except AttributeError:
+        progress_cols = (
+            rich.progress.TextColumn(
+                "[progress.description]{task.description}"),
+            rich.progress.BarColumn(),
+            rich.progress.TextColumn(
+                "[progress.percentage]{task.percentage:>3.0f}%"),
+            rich.progress.TimeRemainingColumn(),
+        )
+    progress = rich.progress.Progress(*progress_cols,
+                                      disable=(len(volfiles) == 1))
     task_id = progress.add_task("Interpolating files")
     volfiles_progress = progress.track(volfiles, task_id=task_id)
     with progress:

--- a/support/Python/requirements.txt
+++ b/support/Python/requirements.txt
@@ -23,5 +23,5 @@ numpy < 1.22.0
 matplotlib
 pyyaml
 # Rich: to format CLI output and tracebacks
-rich
+rich >= 10.11.0
 scipy


### PR DESCRIPTION
Recently GitHub moved to macOS 12, which made all of our unit tests time out for some reason (maybe the switch to AppleClang 13 -> 14, though I'm building locally with AppleClang 14 just fine). Pin to macOS 11 until we can fix this.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
