### PR TITLE
Fix BoundaryMessage on macOS

### DIFF
--- a/src/Evolution/DiscontinuousGalerkin/Messages/BoundaryMessage.cpp
+++ b/src/Evolution/DiscontinuousGalerkin/Messages/BoundaryMessage.cpp
@@ -33,27 +33,9 @@ BoundaryMessage<Dim>::BoundaryMessage(
       dg_flux_data(dg_flux_data_in) {}
 
 template <size_t Dim>
-size_t BoundaryMessage<Dim>::total_bytes_without_data() {
-  // subcell_ghost_data_size, dg_flux_data_size, sender_node, sender_core
-  size_t totalsize = 4 * detail::offset<size_t>();
-  // sent_across_nodes
-  totalsize += detail::offset<bool>();
-  // current_time_step_id, next_time_step_id
-  totalsize += 2 * detail::offset<TimeStepId>();
-  // volume_or_ghost_mesh
-  totalsize += detail::offset<Mesh<Dim>>();
-  // interface_mesh
-  totalsize += detail::offset<Mesh<Dim - 1>>();
-  // subcell_ghost_data, dg_flux_data
-  totalsize += 2 * detail::offset<double*>();
-
-  return totalsize;
-}
-
-template <size_t Dim>
 size_t BoundaryMessage<Dim>::total_bytes_with_data(const size_t subcell_size,
                                                    const size_t dg_size) {
-  size_t totalsize = total_bytes_without_data();
+  size_t totalsize = sizeof(BoundaryMessage<Dim>);
   totalsize += (subcell_size + dg_size) * sizeof(double);
   return totalsize;
 }
@@ -72,7 +54,7 @@ void* BoundaryMessage<Dim>::pack(BoundaryMessage<Dim>* in_msg) {
   // We cast to char* here to avoid a GCC compiler error
   // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
   memcpy(reinterpret_cast<char*>(out_msg), &in_msg->subcell_ghost_data_size,
-         BoundaryMessage<Dim>::total_bytes_without_data());
+         sizeof(BoundaryMessage<Dim>));
 
   if (subcell_size != 0) {
     // double* + 1 == char* + 8 because double* is 8 bytes

--- a/src/Evolution/DiscontinuousGalerkin/Messages/BoundaryMessage.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Messages/BoundaryMessage.hpp
@@ -56,18 +56,10 @@ struct BoundaryMessage : public CMessage_BoundaryMessage<Dim> {
 
   /*!
    * \brief This is the size (in bytes) necessary to allocate a BoundaryMessage
-   * with only the member variables (no actual subcell/dg data, only pointers).
-   *
-   * This evaluates to 256 bytes for Dim == 1, 280 bytes for Dim == 2, and 312
-   * bytes for Dim == 3.
-   */
-  static size_t total_bytes_without_data();
-  /*!
-   * \brief This is the size (in bytes) necessary to allocate a BoundaryMessage
    * including the arrays of data as well.
    *
    * This will add `(subcell_size + dg_size) * sizeof(double)` number of bytes
-   * to `total_bytes_without_data()`.
+   * to `sizeof(BoundaryMessage<Dim>)`.
    */
   static size_t total_bytes_with_data(const size_t subcell_size,
                                       const size_t dg_size);
@@ -86,34 +78,6 @@ bool operator!=(const BoundaryMessage<Dim>& lhs,
 template <size_t Dim>
 std::ostream& operator<<(std::ostream& os, const BoundaryMessage<Dim>& message);
 
-namespace detail {
-template <typename T>
-size_t offset() {
-  if constexpr (std::is_same_v<T, size_t>) {
-    return sizeof(size_t);
-  } else if constexpr (std::is_same_v<T, bool>) {
-    // BoundaryMessage is 8-byte aligned so a bool isn't 1 byte, it's actually 8
-    return 8;
-  } else if constexpr (std::is_same_v<T, TimeStepId>) {
-    return sizeof(TimeStepId);
-  } else if constexpr (std::is_same_v<T, Mesh<3>> or
-                       std::is_same_v<T, Mesh<2>> or
-                       std::is_same_v<T, Mesh<1>>) {
-    return sizeof(T);
-  } else if constexpr (std::is_same_v<T, Mesh<0>>) {
-    // Mesh<0> is only 3 bytes, but we need 8 for alignment
-    return 8;
-  } else if constexpr (std::is_same_v<T, double*>) {
-    return sizeof(double*);
-  } else {
-    ERROR("Cannot calculate offset for '"
-          << pretty_type::name<T>()
-          << "' in a BoundaryMessage. Offset is only known for size_t, bool, "
-             "TimeStepId, Mesh, double*.");
-    return 0;
-  }
-}
-}  // namespace detail
 }  // namespace evolution::dg
 
 #define CK_TEMPLATES_ONLY

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Messages/Test_BoundaryMessage.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Messages/Test_BoundaryMessage.cpp
@@ -78,10 +78,10 @@ void test_boundary_message(const gsl::not_null<Generator*> generator,
   CHECK(subcell_data.size() == subcell_size);
   CHECK(dg_data.size() == dg_size);
 
-  void* packed_message = boundary_message->pack(boundary_message);
+  void* packed_message = BoundaryMessage<Dim>::pack(boundary_message);
 
   BoundaryMessage<Dim>* unpacked_message =
-      boundary_message->unpack(packed_message);
+      BoundaryMessage<Dim>::unpack(packed_message);
 
   CHECK(*copied_boundary_message == *unpacked_message);
   CHECK_FALSE(*copied_boundary_message != *unpacked_message);


### PR DESCRIPTION
## Proposed changes

For some reason sizeof(BoundaryMessage) is different on macOS than on
Linux. Just use sizeof instead of trying to
compute the size manually.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
