### PR TITLE
Run events on failure (added to GHMHD)

### DIFF
--- a/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
+++ b/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
@@ -127,6 +127,7 @@
 #include "ParallelAlgorithms/Actions/TerminatePhase.hpp"
 #include "ParallelAlgorithms/Events/Factory.hpp"
 #include "ParallelAlgorithms/EventsAndTriggers/Actions/RunEventsAndTriggers.hpp"
+#include "ParallelAlgorithms/EventsAndTriggers/Actions/RunEventsOnFailure.hpp"
 #include "ParallelAlgorithms/EventsAndTriggers/Completion.hpp"
 #include "ParallelAlgorithms/EventsAndTriggers/Event.hpp"
 #include "ParallelAlgorithms/EventsAndTriggers/EventsAndTriggers.hpp"
@@ -665,7 +666,11 @@ struct GhValenciaDivCleanTemplateBase<
                          Actions::UpdateConservatives,
                          Actions::RunEventsAndTriggers, Actions::ChangeSlabSize,
                          step_actions, Actions::AdvanceTime,
-                         PhaseControl::Actions::ExecutePhaseChange>>>>>;
+                         PhaseControl::Actions::ExecutePhaseChange>>,
+          Parallel::PhaseActions<
+              Parallel::Phase::PostFailureCleanup,
+              tmpl::list<Actions::RunEventsOnFailure,
+                         Parallel::Actions::TerminatePhase>>>>>;
 
   template <typename ParallelComponent>
   struct registration_list {

--- a/src/IO/Observer/Actions/RegisterEvents.hpp
+++ b/src/IO/Observer/Actions/RegisterEvents.hpp
@@ -156,6 +156,13 @@ struct RegisterEventsWithObservers {
       triggers_and_events.for_each_event(collect_observations);
     }
 
+    if constexpr (db::tag_is_retrievable_v<::Tags::EventsRunAtCleanup,
+                                           db::DataBox<DbTagList>>) {
+      for (const auto& event : db::get<::Tags::EventsRunAtCleanup>(box)) {
+        collect_observations(*event);
+      }
+    }
+
     for (const auto& [type_of_observation, observation_key] :
          type_of_observation_and_observation_key_pairs) {
       Parallel::simple_action<RegisterOrDeregisterAction>(

--- a/src/ParallelAlgorithms/EventsAndTriggers/Actions/CMakeLists.txt
+++ b/src/ParallelAlgorithms/EventsAndTriggers/Actions/CMakeLists.txt
@@ -6,4 +6,5 @@ spectre_target_headers(
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   RunEventsAndTriggers.hpp
+  RunEventsOnFailure.hpp
   )

--- a/src/ParallelAlgorithms/EventsAndTriggers/Actions/RunEventsOnFailure.hpp
+++ b/src/ParallelAlgorithms/EventsAndTriggers/Actions/RunEventsOnFailure.hpp
@@ -1,0 +1,80 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <optional>
+#include <tuple>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/ObservationBox.hpp"
+#include "Parallel/AlgorithmExecution.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "ParallelAlgorithms/EventsAndTriggers/Event.hpp"
+#include "ParallelAlgorithms/EventsAndTriggers/Tags.hpp"
+#include "Utilities/CloneUniquePtrs.hpp"
+#include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace Actions {
+/*!
+ * \brief Invokes all events specified in `Tags::EventsRunAtCleanup`.
+ *
+ * Before running the events, floating point exceptions are disabled. This is
+ * to allow manipulating data even if there are `NaN` or other problematic
+ * values. We ultimately just want to be able to see the state of the
+ * simulation at failure.
+ *
+ * This action is intended to be executed in the
+ * `Parallel::Phase::PostFailureCleanup` phase.
+ *
+ * \note When using local time stepping, the simulation will almost certainly
+ * fail with different elements at different times. This can also happen
+ * with global time stepping if some elements updated their current time
+ * before other elements hit an error. If an event requires consistent
+ * observation IDs, then an option should be added to that event that specifies
+ * what should be used instead of the received observation IDs. See
+ * the ObserveFields event for an example.
+ */
+struct RunEventsOnFailure {
+ private:
+  template <typename Event>
+  struct get_tags {
+    using type = typename Event::compute_tags_for_observation_box;
+  };
+
+ public:
+  using const_global_cache_tags = tmpl::list<::Tags::EventsRunAtCleanup>;
+
+  template <typename DbTags, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent>
+  static Parallel::iterable_action_return_t apply(
+      db::DataBox<DbTags>& box, tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+      Parallel::GlobalCache<Metavariables>& cache,
+      const ArrayIndex& array_index, const ActionList /*meta*/,
+      const ParallelComponent* const component) {
+    // We explicitly disable FPEs because we are dumping during a failure and
+    // so can't rely on the data being safe.
+    disable_floating_point_exceptions();
+
+    using compute_tags = tmpl::remove_duplicates<tmpl::filter<
+        tmpl::flatten<tmpl::transform<
+            tmpl::at<typename Metavariables::factory_creation::factory_classes,
+                     Event>,
+            get_tags<tmpl::_1>>>,
+        db::is_compute_tag<tmpl::_1>>>;
+    std::optional<decltype(make_observation_box<compute_tags>(box))>
+        observation_box{make_observation_box<compute_tags>(box)};
+
+    for (const auto& event : db::get<::Tags::EventsRunAtCleanup>(box)) {
+      event->run(observation_box.value(), cache, array_index, component);
+    }
+
+    // Do not re-enable FPEs because other parts of the pipeline might rely on
+    // them being disabled. We generally have them disabled during cleanup.
+    return {Parallel::AlgorithmExecution::Continue, std::nullopt};
+  }
+};
+}  // namespace Actions

--- a/tests/InputFiles/CurvedScalarWave/PlaneWaveMinkowski3D.yaml
+++ b/tests/InputFiles/CurvedScalarWave/PlaneWaveMinkowski3D.yaml
@@ -87,6 +87,7 @@ EventsAndTriggers:
           InterpolateToMesh: None
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double]
+          OverrideObservationValue: None
   - - Slabs:
         EvenlySpaced:
           Interval: 10
@@ -101,6 +102,7 @@ EventsAndTriggers:
           InterpolateToMesh: None
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double]
+          OverrideObservationValue: None
   - - Slabs:
         EvenlySpaced:
           Interval: 10

--- a/tests/InputFiles/Elasticity/BentBeam.yaml
+++ b/tests/InputFiles/Elasticity/BentBeam.yaml
@@ -91,3 +91,4 @@ EventsAndTriggers:
           InterpolateToMesh: None
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double]
+          OverrideObservationValue: None

--- a/tests/InputFiles/Elasticity/HalfSpaceMirror.yaml
+++ b/tests/InputFiles/Elasticity/HalfSpaceMirror.yaml
@@ -119,3 +119,4 @@ EventsAndTriggers:
           InterpolateToMesh: None
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double]
+          OverrideObservationValue: None

--- a/tests/InputFiles/GeneralizedHarmonic/BinaryBlackHole.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/BinaryBlackHole.yaml
@@ -203,6 +203,7 @@ EventsAndTriggers:
           InterpolateToMesh: None
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double]
+          OverrideObservationValue: None
   - - Slabs:
         EvenlySpaced:
           Interval: 1

--- a/tests/InputFiles/GeneralizedHarmonic/GaugeWave1D.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/GaugeWave1D.yaml
@@ -120,6 +120,7 @@ EventsAndTriggers:
           InterpolateToMesh: None
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double]
+          OverrideObservationValue: None
   - - Slabs:
         Specified:
           Values: [5]

--- a/tests/InputFiles/GeneralizedHarmonic/GaugeWave3D.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/GaugeWave3D.yaml
@@ -111,6 +111,7 @@ EventsAndTriggers:
           InterpolateToMesh: None
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double]
+          OverrideObservationValue: None
   - - Slabs:
         Specified:
           Values: [2]

--- a/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
@@ -156,6 +156,7 @@ EventsAndTriggers:
           InterpolateToMesh: None
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double]
+          OverrideObservationValue: None
   - - Slabs:
         EvenlySpaced:
           Interval: 5

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdBondiMichel.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdBondiMichel.yaml
@@ -184,6 +184,7 @@ EventsAndTriggers:
           InterpolateToMesh: None
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double, Double, Double, Double, Double]
+          OverrideObservationValue: None
   - - Slabs:
         EvenlySpaced:
           Interval: 5

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdBondiMichel.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdBondiMichel.yaml
@@ -219,3 +219,5 @@ Interpolator:
   DumpVolumeDataOnFailure: false
 
 EventsAndDenseTriggers:
+
+EventsRunAtCleanup:

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdTovStar.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdTovStar.yaml
@@ -193,6 +193,7 @@ EventsAndTriggers:
           InterpolateToMesh: None
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double, Double, Double, Double, Double]
+          OverrideObservationValue: None
   - - Slabs:
         Specified:
           Values: [3]

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdTovStar.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdTovStar.yaml
@@ -206,3 +206,5 @@ Interpolator:
   DumpVolumeDataOnFailure: false
 
 EventsAndDenseTriggers:
+
+EventsRunAtCleanup:

--- a/tests/InputFiles/Poisson/ProductOfSinusoids1D.yaml
+++ b/tests/InputFiles/Poisson/ProductOfSinusoids1D.yaml
@@ -87,3 +87,4 @@ EventsAndTriggers:
           InterpolateToMesh: None
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double]
+          OverrideObservationValue: None

--- a/tests/InputFiles/Poisson/ProductOfSinusoids2D.yaml
+++ b/tests/InputFiles/Poisson/ProductOfSinusoids2D.yaml
@@ -83,3 +83,4 @@ EventsAndTriggers:
           InterpolateToMesh: None
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double]
+          OverrideObservationValue: None

--- a/tests/InputFiles/Poisson/ProductOfSinusoids3D.yaml
+++ b/tests/InputFiles/Poisson/ProductOfSinusoids3D.yaml
@@ -83,3 +83,4 @@ EventsAndTriggers:
           InterpolateToMesh: None
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double]
+          OverrideObservationValue: None

--- a/tests/InputFiles/ScalarAdvection/Krivodonova1D.yaml
+++ b/tests/InputFiles/ScalarAdvection/Krivodonova1D.yaml
@@ -68,6 +68,7 @@ EventsAndTriggers:
           InterpolateToMesh: None
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Float, Float]
+          OverrideObservationValue: None
 
 EventsAndDenseTriggers:
 

--- a/tests/InputFiles/ScalarAdvection/Kuzmin2D.yaml
+++ b/tests/InputFiles/ScalarAdvection/Kuzmin2D.yaml
@@ -66,6 +66,7 @@ EventsAndTriggers:
           InterpolateToMesh: None
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Float, Float]
+          OverrideObservationValue: None
 
 EventsAndDenseTriggers:
 

--- a/tests/InputFiles/ScalarAdvection/Sinusoid1D.yaml
+++ b/tests/InputFiles/ScalarAdvection/Sinusoid1D.yaml
@@ -68,6 +68,7 @@ EventsAndTriggers:
           InterpolateToMesh: None
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Float, Float]
+          OverrideObservationValue: None
 
 EventsAndDenseTriggers:
 

--- a/tests/InputFiles/ScalarWave/PlaneWave1DEventsAndTriggersExample.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave1DEventsAndTriggersExample.yaml
@@ -64,6 +64,7 @@ EventsAndTriggers:
           InterpolateToMesh: None
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double]
+          OverrideObservationValue: None
       - ObserveNorms:
           SubfileName: Errors
           TensorsToObserve:

--- a/tests/InputFiles/ScalarWave/PlaneWave1DObserveExample.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave1DObserveExample.yaml
@@ -97,6 +97,7 @@ EventsAndTriggers:
           InterpolateToMesh: None
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double, Float, Float]
+          OverrideObservationValue: None
 # [observe_event_trigger]
 
 Observers:

--- a/tests/InputFiles/Xcts/BinaryBlackHole.yaml
+++ b/tests/InputFiles/Xcts/BinaryBlackHole.yaml
@@ -190,3 +190,4 @@ EventsAndTriggers:
           InterpolateToMesh: None
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double]
+          OverrideObservationValue: None

--- a/tests/InputFiles/Xcts/KerrSchild.yaml
+++ b/tests/InputFiles/Xcts/KerrSchild.yaml
@@ -153,3 +153,4 @@ EventsAndTriggers:
           InterpolateToMesh: None
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double]
+          OverrideObservationValue: None

--- a/tests/Unit/ParallelAlgorithms/EventsAndTriggers/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/EventsAndTriggers/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY "Test_EventsAndTriggers")
 
 set(LIBRARY_SOURCES
   Test_EventsAndTriggers.cpp
+  Test_RunEventsOnFailure.cpp
   Test_Tags.cpp
   )
 

--- a/tests/Unit/ParallelAlgorithms/EventsAndTriggers/Test_RunEventsOnFailure.cpp
+++ b/tests/Unit/ParallelAlgorithms/EventsAndTriggers/Test_RunEventsOnFailure.cpp
@@ -1,0 +1,63 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "Framework/ActionTesting.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Options/Protocols/FactoryCreation.hpp"
+#include "Parallel/Phase.hpp"
+#include "Parallel/PhaseDependentActionList.hpp"
+#include "Parallel/RegisterDerivedClassesWithCharm.hpp"
+#include "ParallelAlgorithms/EventsAndTriggers/Actions/RunEventsOnFailure.hpp"
+#include "ParallelAlgorithms/EventsAndTriggers/Completion.hpp"
+#include "ParallelAlgorithms/EventsAndTriggers/Event.hpp"
+#include "ParallelAlgorithms/EventsAndTriggers/Tags.hpp"
+#include "Utilities/MakeVector.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+template <typename Metavariables>
+struct Component {
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = int;
+  using const_global_cache_tags =
+      typename Actions::RunEventsOnFailure::const_global_cache_tags;
+  using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
+      Parallel::Phase::Testing, tmpl::list<Actions::RunEventsOnFailure>>>;
+};
+
+struct Metavariables {
+  using component_list = tmpl::list<Component<Metavariables>>;
+  struct factory_creation
+      : tt::ConformsTo<Options::protocols::FactoryCreation> {
+    using factory_classes =
+        tmpl::map<tmpl::pair<Event, tmpl::list<Events::Completion>>>;
+  };
+};
+
+SPECTRE_TEST_CASE("Unit.Evolution.EventsAndTriggers.RunEventsOnFailure",
+                  "[Unit][Evolution]") {
+  Parallel::register_factory_classes_with_charm<Metavariables>();
+
+  const std::vector<std::unique_ptr<Event>> events =
+      make_vector<std::unique_ptr<Event>>(
+          std::make_unique<Events::Completion>());
+
+  using my_component = Component<Metavariables>;
+  ActionTesting::MockRuntimeSystem<Metavariables> runner{
+      {serialize_and_deserialize(events)}};
+  ActionTesting::emplace_component<my_component>(&runner, 0);
+  ActionTesting::set_phase(make_not_null(&runner), Parallel::Phase::Testing);
+
+  ActionTesting::next_action<my_component>(make_not_null(&runner), 0);
+
+  CHECK(ActionTesting::get_terminate<my_component>(runner, 0) == true);
+}
+}  // namespace


### PR DESCRIPTION
## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
You need to specify the following in the input file:
```
EventsRunAtCleanup:
```
For example, if you want to dump volume data on failure use:
```
EventsRunAtCleanup:
  - ObserveFields:
      VariablesToObserve:
        [RestMassDensity, SpecificInternalEnergy, Pressure,
        SpecificEnthalpy, SpatialVelocity, LorentzFactor,
        MagneticField, DivergenceCleaningField,
        TildeD, TildeTau, TildeS,
        SpacetimeMetric, Pi, Phi,
        Error(RestMassDensity),
        Error(SpacetimeMetric),
        Error(Pi), Error(Phi),
        Error(SpatialVelocity),

        TciStatus
        ]
      SubfileName: FailureVolumeData
      InterpolateToMesh: None
      CoordinatesFloatingPointType: Double
      FloatingPointTypes: [Double]
      OverrideObservationValue: 0.0
```

ObserveFields now needs to specify an `OverrideObservationValue` which should be `None` except for in the `EventsRunAtCleanup` where it can be any value (`0.0` is a reasonable choice, or a value less than the start of an evolution, e.g. `-1.0`)
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
