### PR TITLE
Remove chained creation of distributed objects

### DIFF
--- a/src/Parallel/Algorithms/AlgorithmArray.ci
+++ b/src/Parallel/Algorithms/AlgorithmArray.ci
@@ -31,8 +31,7 @@ module AlgorithmArray {
 
     entry AlgorithmArray(
         Parallel::CProxy_GlobalCache<typename ParallelComponent::metavariables>,
-        Parallel::Phase, std::unique_ptr<Parallel::Callback>,
-        std::deque<typename ParallelComponent::array_index>);
+        Parallel::Phase, std::unique_ptr<Parallel::Callback>);
 
     // Ordinarily, indiscriminate use of [inline] has the danger of arbitrarily
     // deep recursive function calls, which then exceed the stack limits of the

--- a/src/ParallelAlgorithms/Amr/Actions/CMakeLists.txt
+++ b/src/ParallelAlgorithms/Amr/Actions/CMakeLists.txt
@@ -6,6 +6,7 @@ spectre_target_headers(
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   Actions.hpp
+  Component.hpp
   EvaluateRefinementCriteria.hpp
   Initialization.hpp
   Initialize.hpp

--- a/src/ParallelAlgorithms/Amr/Actions/Component.hpp
+++ b/src/ParallelAlgorithms/Amr/Actions/Component.hpp
@@ -1,0 +1,43 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "Parallel/Algorithms/AlgorithmSingleton.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "Parallel/Local.hpp"
+#include "Parallel/ParallelComponentHelpers.hpp"
+#include "Parallel/Phase.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \ingroup AmrGroup
+namespace amr {
+/// \brief A singleton parallel component to manage adaptive mesh refinement
+///
+/// \details This component can be used for:
+/// - Running actions that create new elements.  This may be necessary to
+///   work around Charm++ bugs, and may require the singleton to be placed
+///   on global processor 0.
+/// - As a reduction target to perform sanity checks after AMR, output
+///   AMR diagnostics, or determine when to trigger AMR.
+template <class Metavariables>
+struct Component {
+  using metavariables = Metavariables;
+
+  using chare_type = Parallel::Algorithms::Singleton;
+
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<Parallel::Phase::Initialization, tmpl::list<>>>;
+
+  using simple_tags_from_options = Parallel::get_simple_tags_from_options<
+      Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
+
+  static void execute_next_phase(
+      const Parallel::Phase next_phase,
+      Parallel::CProxy_GlobalCache<Metavariables>& global_cache_proxy) {
+    auto& local_cache = *Parallel::local_branch(global_cache_proxy);
+    Parallel::get_parallel_component<Component>(local_cache)
+        .start_phase(next_phase);
+  }
+};
+}  // namespace amr

--- a/tests/Unit/Parallel/Test_DynamicInsertion.cpp
+++ b/tests/Unit/Parallel/Test_DynamicInsertion.cpp
@@ -23,6 +23,7 @@
 #include "Parallel/Reduction.hpp"
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 #include "ParallelAlgorithms/Actions/TerminatePhase.hpp"
+#include "ParallelAlgorithms/Amr/Actions/Component.hpp"
 #include "ParallelAlgorithms/Initialization/MutateAssign.hpp"
 #include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
 #include "Utilities/MemoryHelpers.hpp"
@@ -83,21 +84,6 @@ struct Value : db::SimpleTag {
   using type = double;
 };
 
-template <class Metavariables>
-struct TestSingleton {
-  using chare_type = Parallel::Algorithms::Singleton;
-  using array_index = int;
-  using metavariables = Metavariables;
-  using phase_dependent_action_list = tmpl::list<
-      Parallel::PhaseActions<Parallel::Phase::Initialization, tmpl::list<>>>;
-  using simple_tags_from_options = Parallel::get_simple_tags_from_options<
-      Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
-
-  static void execute_next_phase(
-      const Parallel::Phase /*next_phase*/,
-      const Parallel::CProxy_GlobalCache<Metavariables>& /*global_cache*/) {}
-};
-
 struct InitializeValue {
   using simple_tags = tmpl::list<Value>;
   template <typename DbTagsList, typename... InboxTags, typename Metavariables,
@@ -124,7 +110,7 @@ struct ArrayReduce {
     const auto& my_proxy =
         Parallel::get_parallel_component<ParallelComponent>(cache)[array_index];
     const auto& singleton_proxy =
-        Parallel::get_parallel_component<TestSingleton<Metavariables>>(cache);
+        Parallel::get_parallel_component<amr::Component<Metavariables>>(cache);
     Parallel::ReductionData<Parallel::ReductionDatum<double, funcl::Plus<>>>
         reduction_data{db::get<Value>(box)};
     Parallel::contribute_to_reduction<CheckReduction>(reduction_data, my_proxy,
@@ -188,28 +174,61 @@ struct CollectDataFromChildren {
   }
 };
 
+struct CreateChild {
+  template <typename ParallelComponent, typename DbTagList,
+            typename Metavariables, typename ArrayIndex, typename ElementProxy,
+            typename ElementIndex>
+  static void apply(db::DataBox<DbTagList>& /*box*/,
+                    Parallel::GlobalCache<Metavariables>& cache,
+                    const ArrayIndex& /*array_index*/,
+                    ElementProxy element_proxy, ElementIndex parent_id,
+                    ElementIndex child_id,
+                    std::vector<ElementIndex> children_ids) {
+    auto my_proxy = Parallel::get_parallel_component<ParallelComponent>(cache);
+    ASSERT(
+        alg::count(children_ids, child_id) == 1,
+        "Child " << child_id << " does not exist uniquely in " << children_ids);
+    const auto child_it = alg::find(children_ids, child_id);
+    if (*child_it == children_ids.back()) {
+      auto parent_proxy = element_proxy(parent_id);
+      element_proxy(child_id).insert(
+          cache.thisProxy, Parallel::Phase::AdjustDomain,
+          std::make_unique<Parallel::SimpleActionCallback<
+              SendDataToChildren, decltype(parent_proxy),
+              std::vector<ElementIndex>>>(parent_proxy,
+                                          std::move(children_ids)));
+    } else {
+      const auto next_child_it = std::next(child_it);
+      auto next_child = *next_child_it;
+      element_proxy(child_id).insert(
+          cache.thisProxy, Parallel::Phase::AdjustDomain,
+          std::make_unique<Parallel::SimpleActionCallback<
+              CreateChild, decltype(my_proxy), ElementProxy, ElementIndex,
+              ElementIndex, std::vector<ElementIndex>>>(
+              my_proxy, std::move(element_proxy), std::move(parent_id),
+              std::move(next_child), std::move(children_ids)));
+    }
+  }
+};
+
 struct ChangeArray {
   template <typename ParallelComponent, typename DbTags, typename Metavariables,
             typename ArrayIndex>
   static void apply(const db::DataBox<DbTags>& /*box*/,
-                    const Parallel::GlobalCache<Metavariables>& cache,
+                    Parallel::GlobalCache<Metavariables>& cache,
                     const ArrayIndex& array_index) {
     auto& array_proxy =
         Parallel::get_parallel_component<ParallelComponent>(cache);
     auto my_proxy = array_proxy[array_index];
-    auto create_children = [&cache, &array_index, &array_proxy,
-                            &my_proxy](const size_t number_of_new_elements) {
+    auto create_children = [&cache, &array_index,
+                            &array_proxy](const size_t number_of_new_elements) {
       std::vector<int> new_ids(number_of_new_elements);
       std::iota(new_ids.begin(), new_ids.end(), 100 * array_index);
-      std::deque<int> other_ids_to_create(new_ids.begin(), new_ids.end());
-      other_ids_to_create.pop_front();
-      array_proxy(new_ids.front())
-          .insert(
-              cache.thisProxy, Parallel::Phase::Execute,
-              std::make_unique<Parallel::SimpleActionCallback<
-                  SendDataToChildren, decltype(my_proxy), std::vector<int>>>(
-                  my_proxy, std::move(new_ids)),
-              other_ids_to_create);
+      auto& singleton_proxy =
+          Parallel::get_parallel_component<amr::Component<Metavariables>>(
+              cache);
+      Parallel::simple_action<CreateChild>(
+          singleton_proxy, array_proxy, array_index, new_ids.front(), new_ids);
     };
 
     auto create_parent = [&cache, &array_proxy,
@@ -222,8 +241,7 @@ struct ChangeArray {
           std::make_unique<Parallel::SimpleActionCallback<
               CollectDataFromChildren, decltype(my_proxy), int, std::deque<int>,
               double>>(my_proxy, std::move(parent_id), std::move(ids_to_join),
-                       0.0),
-          std::deque<int>{});
+                       0.0));
     };
 
     std::vector<size_t> ids_to_split{2, 4, 8, 16, 32, 64};
@@ -308,7 +326,7 @@ struct TestArray {
 };
 
 struct TestMetavariables {
-  using component_list = tmpl::list<TestSingleton<TestMetavariables>,
+  using component_list = tmpl::list<amr::Component<TestMetavariables>,
                                     TestArray<TestMetavariables>>;
 
   static constexpr Options::String help =
@@ -326,6 +344,11 @@ struct TestMetavariables {
 void register_callback() {
   Parallel::register_classes_with_charm(
       tmpl::list<
+          Parallel::SimpleActionCallback<
+              CreateChild,
+              CProxy_AlgorithmSingleton<amr::Component<TestMetavariables>, int>,
+              CProxy_AlgorithmArray<TestArray<TestMetavariables>, int>, int,
+              int, std::vector<int>>,
           Parallel::SimpleActionCallback<
               SendDataToChildren,
               CProxyElement_AlgorithmArray<TestArray<TestMetavariables>, int>,

--- a/tools/CharmModulePatches/src/Parallel/Algorithms/AlgorithmArray_v7.0.0.decl.h.patch
+++ b/tools/CharmModulePatches/src/Parallel/Algorithms/AlgorithmArray_v7.0.0.decl.h.patch
@@ -4,10 +4,10 @@ index 7bc3d5c52..f10f24c9a 100644
 +++ b/src/Parallel/Algorithms/AlgorithmArray.decl.h
 @@ -498,7 +498,7 @@ template <class ParallelComponent, class SpectreArrayIndex>  class CProxyElement
  
- /* DECLS: void receive_data(const typename ReceiveTag::temporal_id &impl_noname_7, const ReceiveData_t &impl_noname_8, bool enable_if_disabled);
+ /* DECLS: void receive_data(const typename ReceiveTag::temporal_id &impl_noname_6, const ReceiveData_t &impl_noname_7, bool enable_if_disabled);
   */
 -    template <class ReceiveTag, class ReceiveData_t, typename Fwd1 = typename ReceiveTag::temporal_id, typename Fwd2 = ReceiveData_t>
 +    template <typename ReceiveTag, typename Fwd2, typename Fwd1 = typename ReceiveTag::temporal_id>
-     void receive_data(Fwd1 &&impl_noname_7, Fwd2 &&impl_noname_8, bool enable_if_disabled = false, const CkEntryOptions *impl_e_opts=NULL) ;
+     void receive_data(Fwd1 &&impl_noname_6, Fwd2 &&impl_noname_7, bool enable_if_disabled = false, const CkEntryOptions *impl_e_opts=NULL) ;
  
  /* DECLS: void set_terminate(const bool &impl_noname_9);

--- a/tools/CharmModulePatches/src/Parallel/Algorithms/AlgorithmArray_v7.0.0.def.h.patch
+++ b/tools/CharmModulePatches/src/Parallel/Algorithms/AlgorithmArray_v7.0.0.def.h.patch
@@ -3,12 +3,12 @@ index 541313a5d..7afe8f1b5 100644
 --- a/src/Parallel/Algorithms/AlgorithmArray.def.h
 +++ b/src/Parallel/Algorithms/AlgorithmArray.def.h
 @@ -518,16 +518,17 @@ void CProxyElement_AlgorithmArray <ParallelComponent, SpectreArrayIndex> ::start
- /* DEFS: void receive_data(const typename ReceiveTag::temporal_id &impl_noname_7, const ReceiveData_t &impl_noname_8, bool enable_if_disabled);
+ /* DEFS: void receive_data(const typename ReceiveTag::temporal_id &impl_noname_6, const ReceiveData_t &impl_noname_7, bool enable_if_disabled);
   */
  template <class ParallelComponent, class SpectreArrayIndex> 
 -template <class ReceiveTag, class ReceiveData_t, typename Fwd1, typename Fwd2>
 +template <typename ReceiveTag, typename Fwd2, typename Fwd1>
- void CProxyElement_AlgorithmArray <ParallelComponent, SpectreArrayIndex> ::receive_data(Fwd1 &&impl_noname_7, Fwd2 &&impl_noname_8, bool enable_if_disabled, const CkEntryOptions *impl_e_opts) 
+ void CProxyElement_AlgorithmArray <ParallelComponent, SpectreArrayIndex> ::receive_data(Fwd1 &&impl_noname_6, Fwd2 &&impl_noname_7, bool enable_if_disabled, const CkEntryOptions *impl_e_opts) 
  {
 +  using ReceiveData_t = Fwd2;
    ckCheck();


### PR DESCRIPTION
## Proposed changes

- Add singleton component for AMR
- Removed code to chain addition of new elements via a DistributedObject constructor

The singleton can be used as a reduction target for AMR sanity checks, diagnostic output, and maybe triggering when AMR occurs.

Instead of chaining element construction via the DistributedObject constructor, there will be separate actions to create new elements (in a forthcoming PR).  This change along with the added singleton is necessary (but not yet sufficient) to get AMR working on more than one proc with current Charm++ features/bugs.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
