### PR TITLE
Have MortarData store DataVectors rather than std::vector

### DIFF
--- a/src/Domain/Structure/OrientationMapHelpers.cpp
+++ b/src/Domain/Structure/OrientationMapHelpers.cpp
@@ -388,6 +388,16 @@ std::vector<double> orient_variables(
 }
 
 template <size_t VolumeDim>
+DataVector orient_variables(
+    const DataVector& variables, const Index<VolumeDim>& extents,
+    const OrientationMap<VolumeDim>& orientation_of_neighbor) {
+  DataVector oriented_variables{variables.size()};
+  orient_variables(make_not_null(&oriented_variables), variables, extents,
+                   orientation_of_neighbor);
+  return oriented_variables;
+}
+
+template <size_t VolumeDim>
 std::vector<double> orient_variables_on_slice(
     const std::vector<double>& variables_on_slice,
     const Index<VolumeDim - 1>& slice_extents, const size_t sliced_dim,
@@ -400,6 +410,18 @@ std::vector<double> orient_variables_on_slice(
       DataVector(const_cast<double*>(variables_on_slice.data()),
                  variables_on_slice.size()),
       slice_extents, sliced_dim, orientation_of_neighbor);
+  return oriented_variables;
+}
+
+template <size_t VolumeDim>
+DataVector orient_variables_on_slice(
+    const DataVector& variables_on_slice,
+    const Index<VolumeDim - 1>& slice_extents, const size_t sliced_dim,
+    const OrientationMap<VolumeDim>& orientation_of_neighbor) {
+  DataVector oriented_variables{variables_on_slice.size()};
+  orient_variables_on_slice(make_not_null(&oriented_variables),
+                            variables_on_slice, slice_extents, sliced_dim,
+                            orientation_of_neighbor);
   return oriented_variables;
 }
 
@@ -418,9 +440,16 @@ std::vector<double> orient_variables_on_slice(
   template std::vector<double> orient_variables<DIM(data)>(                  \
       const std::vector<double>& variables, const Index<DIM(data)>& extents, \
       const OrientationMap<DIM(data)>& orientation_of_neighbor);             \
+  template DataVector orient_variables<DIM(data)>(                           \
+      const DataVector& variables, const Index<DIM(data)>& extents,          \
+      const OrientationMap<DIM(data)>& orientation_of_neighbor);             \
   template std::vector<double> orient_variables_on_slice<DIM(data)>(         \
       const std::vector<double>& variables,                                  \
       const Index<DIM(data) - 1>& extents, size_t sliced_dim,                \
+      const OrientationMap<DIM(data)>& orientation_of_neighbor);             \
+  template DataVector orient_variables_on_slice<DIM(data)>(                  \
+      const DataVector& variables, const Index<DIM(data) - 1>& extents,      \
+      size_t sliced_dim,                                                     \
       const OrientationMap<DIM(data)>& orientation_of_neighbor);
 
 GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))

--- a/src/Domain/Structure/OrientationMapHelpers.hpp
+++ b/src/Domain/Structure/OrientationMapHelpers.hpp
@@ -102,8 +102,8 @@ Variables<TagsList> orient_variables_on_slice(
 
 /// @{
 /// \ingroup ComputationalDomainGroup
-/// Orient data in a `std::vector<double>` representing one or more tensor
-/// components.
+/// Orient data in a `std::vector<double>` or `DataVector` representing one or
+/// more tensor components.
 ///
 /// In most cases the `Variables` version of `orient_variables` should be
 /// called. However, in some cases the tags and thus the type of the data being
@@ -118,8 +118,19 @@ std::vector<double> orient_variables(
     const OrientationMap<VolumeDim>& orientation_of_neighbor);
 
 template <size_t VolumeDim>
+DataVector orient_variables(
+    const DataVector& variables, const Index<VolumeDim>& extents,
+    const OrientationMap<VolumeDim>& orientation_of_neighbor);
+
+template <size_t VolumeDim>
 std::vector<double> orient_variables_on_slice(
     const std::vector<double>& variables_on_slice,
+    const Index<VolumeDim - 1>& slice_extents, size_t sliced_dim,
+    const OrientationMap<VolumeDim>& orientation_of_neighbor);
+
+template <size_t VolumeDim>
+DataVector orient_variables_on_slice(
+    const DataVector& variables_on_slice,
     const Index<VolumeDim - 1>& slice_extents, size_t sliced_dim,
     const OrientationMap<VolumeDim>& orientation_of_neighbor);
 /// @}

--- a/src/Evolution/DgSubcell/Actions/TciAndRollback.hpp
+++ b/src/Evolution/DgSubcell/Actions/TciAndRollback.hpp
@@ -15,6 +15,7 @@
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataBox/PrefixHelpers.hpp"
 #include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataVector.hpp"
 #include "Domain/Structure/Element.hpp"
 #include "Domain/Tags.hpp"
 #include "Evolution/DgSubcell/Actions/Labels.hpp"
@@ -187,7 +188,7 @@ struct TciAndRollback {
             const gsl::not_null<bool*> did_rollback_ptr,
             const gsl::not_null<FixedHashMap<
                 maximum_number_of_neighbors(Dim),
-                std::pair<Direction<Dim>, ElementId<Dim>>, std::vector<double>,
+                std::pair<Direction<Dim>, ElementId<Dim>>, DataVector,
                 boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>*>
                 neighbor_data_ptr,
             const typename variables_tag::type& rollback_value,

--- a/src/Evolution/DgSubcell/CorrectPackagedData.hpp
+++ b/src/Evolution/DgSubcell/CorrectPackagedData.hpp
@@ -109,7 +109,7 @@ void correct_package_data(
           const gsl::not_null<Variables<DgPackageFieldTags>*>
               subcell_packaged_data,
           const size_t subcell_index, const Mesh<Dim - 1>& neighbor_face_mesh,
-          const std::vector<double>& neighbor_data) {
+          const DataVector& neighbor_data) {
         const size_t dg_variables_offset_size =
             variables_to_offset_in_dg_grid *
             neighbor_face_mesh.number_of_grid_points();
@@ -118,11 +118,11 @@ void correct_package_data(
             neighbor_data.data() + dg_variables_offset_size;
         // Warning: projected_data can't be inside the `if constexpr` since that
         // would lead to a dangling pointer.
-        std::vector<double> projected_data{};
+        DataVector projected_data{};
         if constexpr (Dim > 1) {
-          projected_data.resize(
+          projected_data = DataVector{
               Variables<DgPackageFieldTags>::number_of_independent_components *
-              subcell_face_mesh.number_of_grid_points());
+              subcell_face_mesh.number_of_grid_points()};
           evolution::dg::subcell::fd::detail::project_impl(
               gsl::make_span(projected_data.data(), projected_data.size()),
               gsl::make_span(

--- a/src/Evolution/DgSubcell/NeighborRdmpAndVolumeData.hpp
+++ b/src/Evolution/DgSubcell/NeighborRdmpAndVolumeData.hpp
@@ -6,8 +6,8 @@
 #include <boost/functional/hash.hpp>
 #include <cstddef>
 #include <utility>
-#include <vector>
 
+#include "DataStructures/DataVector.hpp"
 #include "DataStructures/FixedHashMap.hpp"
 #include "Domain/Structure/Direction.hpp"
 #include "Domain/Structure/ElementId.hpp"
@@ -33,12 +33,12 @@ namespace evolution::dg::subcell {
  */
 template <bool InsertIntoMap, size_t Dim>
 void insert_or_update_neighbor_volume_data(
-    gsl::not_null<FixedHashMap<
-        maximum_number_of_neighbors(Dim),
-        std::pair<Direction<Dim>, ElementId<Dim>>, std::vector<double>,
-        boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>*>
+    gsl::not_null<
+        FixedHashMap<maximum_number_of_neighbors(Dim),
+                     std::pair<Direction<Dim>, ElementId<Dim>>, DataVector,
+                     boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>*>
         neighbor_data_ptr,
-    const std::vector<double>& neighbor_subcell_data,
+    const DataVector& neighbor_subcell_data,
     const size_t number_of_rdmp_vars_in_buffer,
     const std::pair<Direction<Dim>, ElementId<Dim>>& directional_element_id,
     const Mesh<Dim>& neighbor_mesh, const Element<Dim>& element,
@@ -53,12 +53,12 @@ void insert_or_update_neighbor_volume_data(
 template <size_t Dim>
 void insert_neighbor_rdmp_and_volume_data(
     gsl::not_null<RdmpTciData*> rdmp_tci_data_ptr,
-    gsl::not_null<FixedHashMap<
-        maximum_number_of_neighbors(Dim),
-        std::pair<Direction<Dim>, ElementId<Dim>>, std::vector<double>,
-        boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>*>
+    gsl::not_null<
+        FixedHashMap<maximum_number_of_neighbors(Dim),
+                     std::pair<Direction<Dim>, ElementId<Dim>>, DataVector,
+                     boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>*>
         neighbor_data_ptr,
-    const std::vector<double>& received_neighbor_subcell_data,
+    const DataVector& received_neighbor_subcell_data,
     size_t number_of_rdmp_vars,
     const std::pair<Direction<Dim>, ElementId<Dim>>& directional_element_id,
     const Mesh<Dim>& neighbor_mesh, const Element<Dim>& element,

--- a/src/Evolution/DgSubcell/NeighborTciDecision.hpp
+++ b/src/Evolution/DgSubcell/NeighborTciDecision.hpp
@@ -8,9 +8,9 @@
 #include <optional>
 #include <tuple>
 #include <utility>
-#include <vector>
 
 #include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataVector.hpp"
 #include "DataStructures/FixedHashMap.hpp"
 #include "Domain/Structure/Direction.hpp"
 #include "Domain/Structure/ElementId.hpp"
@@ -34,9 +34,8 @@ void neighbor_tci_decision(
         FixedHashMap<
             maximum_number_of_neighbors(Dim),
             std::pair<Direction<Dim>, ElementId<Dim>>,
-            std::tuple<Mesh<Dim>, Mesh<Dim - 1>,
-                       std::optional<std::vector<double>>,
-                       std::optional<std::vector<double>>, ::TimeStepId, int>,
+            std::tuple<Mesh<Dim>, Mesh<Dim - 1>, std::optional<DataVector>,
+                       std::optional<DataVector>, ::TimeStepId, int>,
             boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>>&
         received_temporal_id_and_data) {
   db::mutate<subcell::Tags::NeighborTciDecisions<Dim>>(

--- a/src/Evolution/DgSubcell/RdmpTci.cpp
+++ b/src/Evolution/DgSubcell/RdmpTci.cpp
@@ -4,16 +4,16 @@
 #include "Evolution/DgSubcell/RdmpTci.hpp"
 
 #include <cstddef>
-#include <vector>
 
+#include "DataStructures/DataVector.hpp"
 #include "Utilities/ErrorHandling/Assert.hpp"
 
 namespace evolution::dg::subcell {
-int rdmp_tci(const std::vector<double>& max_of_current_variables,
-             const std::vector<double>& min_of_current_variables,
-             const std::vector<double>& max_of_past_variables,
-             const std::vector<double>& min_of_past_variables,
-             const double rdmp_delta0, const double rdmp_epsilon) {
+int rdmp_tci(const DataVector& max_of_current_variables,
+             const DataVector& min_of_current_variables,
+             const DataVector& max_of_past_variables,
+             const DataVector& min_of_past_variables, const double rdmp_delta0,
+             const double rdmp_epsilon) {
   const size_t number_of_vars = max_of_current_variables.size();
   ASSERT(min_of_current_variables.size() == number_of_vars and
              max_of_past_variables.size() == number_of_vars and

--- a/src/Evolution/DgSubcell/RdmpTci.hpp
+++ b/src/Evolution/DgSubcell/RdmpTci.hpp
@@ -5,7 +5,6 @@
 
 #include <algorithm>
 #include <cstddef>
-#include <vector>
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
@@ -80,9 +79,9 @@ int rdmp_tci(const Variables<tmpl::list<EvolvedVarsTags...>>&
                  active_grid_candidate_evolved_vars,
              const Variables<tmpl::list<Tags::Inactive<EvolvedVarsTags>...>>&
                  inactive_grid_candidate_evolved_vars,
-             const std::vector<double>& max_of_past_variables,
-             const std::vector<double>& min_of_past_variables,
-             const double rdmp_delta0, const double rdmp_epsilon) {
+             const DataVector& max_of_past_variables,
+             const DataVector& min_of_past_variables, const double rdmp_delta0,
+             const double rdmp_epsilon) {
   bool cell_is_troubled = false;
   int rdmp_tci_status = 0;
   size_t component_index = 0;
@@ -144,17 +143,17 @@ int rdmp_tci(const Variables<tmpl::list<EvolvedVarsTags...>>&
  * `active_grid_evolved_vars` for each component is returned.
  */
 template <typename... EvolvedVarsTags>
-std::pair<std::vector<double>, std::vector<double>> rdmp_max_min(
+std::pair<DataVector, DataVector> rdmp_max_min(
     const Variables<tmpl::list<EvolvedVarsTags...>>& active_grid_evolved_vars,
     const Variables<tmpl::list<Tags::Inactive<EvolvedVarsTags>...>>&
         inactive_grid_evolved_vars,
     const bool include_inactive_grid) {
-  std::vector<double> max_of_vars(
+  DataVector max_of_vars{
       active_grid_evolved_vars.number_of_independent_components,
-      std::numeric_limits<double>::min());
-  std::vector<double> min_of_vars(
+      std::numeric_limits<double>::min()};
+  DataVector min_of_vars{
       active_grid_evolved_vars.number_of_independent_components,
-      std::numeric_limits<double>::max());
+      std::numeric_limits<double>::max()};
   size_t component_index = 0;
   tmpl::for_each<tmpl::list<EvolvedVarsTags...>>(
       [&active_grid_evolved_vars, &component_index, &inactive_grid_evolved_vars,
@@ -234,7 +233,7 @@ std::pair<std::vector<double>, std::vector<double>> rdmp_max_min(
  *
  * If all checks are passed and cell is not troubled, returns an integer `0`.
  * Otherwise returns an 1-based index of the element in the input
- * `std::vector<double>` that fails the check.
+ * `DataVector` that fails the check.
  *
  * e.g. Suppose we have three variables to check RDMP so that
  * `max_of_current_variables.size() == 3`. If RDMP TCI flags
@@ -247,9 +246,9 @@ std::pair<std::vector<double>, std::vector<double>> rdmp_max_min(
  * `[2]` is skipped.
  *
  */
-int rdmp_tci(const std::vector<double>& max_of_current_variables,
-             const std::vector<double>& min_of_current_variables,
-             const std::vector<double>& max_of_past_variables,
-             const std::vector<double>& min_of_past_variables,
-             double rdmp_delta0, double rdmp_epsilon);
+int rdmp_tci(const DataVector& max_of_current_variables,
+             const DataVector& min_of_current_variables,
+             const DataVector& max_of_past_variables,
+             const DataVector& min_of_past_variables, double rdmp_delta0,
+             double rdmp_epsilon);
 }  // namespace evolution::dg::subcell

--- a/src/Evolution/DgSubcell/RdmpTciData.cpp
+++ b/src/Evolution/DgSubcell/RdmpTciData.cpp
@@ -7,8 +7,6 @@
 #include <pup.h>
 #include <pup_stl.h>
 
-#include "Utilities/StdHelpers.hpp"
-
 namespace evolution::dg::subcell {
 void pup(PUP::er& p, RdmpTciData& rdmp_tci_data) {  // NOLINT
   p | rdmp_tci_data.max_variables_values;

--- a/src/Evolution/DgSubcell/RdmpTciData.hpp
+++ b/src/Evolution/DgSubcell/RdmpTciData.hpp
@@ -5,8 +5,8 @@
 
 #include <cstddef>
 #include <iosfwd>
-#include <vector>
 
+#include "DataStructures/DataVector.hpp"
 #include "Domain/Structure/Direction.hpp"
 #include "Domain/Structure/ElementId.hpp"
 
@@ -20,8 +20,8 @@ namespace evolution::dg::subcell {
 /// Holds data needed for the relaxed discrete maximum principle
 /// troubled-cell indicator.
 struct RdmpTciData {
-  std::vector<double> max_variables_values{};
-  std::vector<double> min_variables_values{};
+  DataVector max_variables_values{};
+  DataVector min_variables_values{};
 };
 
 void pup(PUP::er& p, RdmpTciData& rdmp_tci_data);  // NOLINT

--- a/src/Evolution/DgSubcell/SliceData.hpp
+++ b/src/Evolution/DgSubcell/SliceData.hpp
@@ -4,12 +4,12 @@
 #pragma once
 
 #include <cstddef>
-#include <vector>
 
 #include "DataStructures/Variables.hpp"
 #include "Utilities/Gsl.hpp"
 
 /// \cond
+class DataVector;
 template <size_t Dim, typename T>
 class DirectionMap;
 template <size_t Dim>
@@ -19,7 +19,7 @@ class Index;
 namespace evolution::dg::subcell {
 namespace detail {
 template <size_t Dim>
-DirectionMap<Dim, std::vector<double>> slice_data_impl(
+DirectionMap<Dim, DataVector> slice_data_impl(
     const gsl::span<const double>& volume_subcell_vars,
     const Index<Dim>& subcell_extents, size_t number_of_ghost_points,
     const DirectionMap<Dim, bool>& directions_to_slice,
@@ -47,7 +47,7 @@ DirectionMap<Dim, std::vector<double>> slice_data_impl(
  * expensive data copying.
  */
 template <size_t Dim, typename TagList>
-DirectionMap<Dim, std::vector<double>> slice_data(
+DirectionMap<Dim, DataVector> slice_data(
     const Variables<TagList>& volume_subcell_vars,
     const Index<Dim>& subcell_extents, const size_t number_of_ghost_points,
     const DirectionMap<Dim, bool>& directions_to_slice,

--- a/src/Evolution/DgSubcell/SliceVariable.hpp
+++ b/src/Evolution/DgSubcell/SliceVariable.hpp
@@ -5,8 +5,8 @@
 
 #include <algorithm>
 #include <cstddef>
-#include <vector>
 
+#include "DataStructures/DataVector.hpp"
 #include "DataStructures/Index.hpp"
 #include "DataStructures/Variables.hpp"
 #include "Domain/Structure/Direction.hpp"
@@ -35,15 +35,15 @@ void slice_variable(
   }
 
   // Slice volume variables. Note that the return type of the
-  // `slice_data_impl()` function is std::vector<double>.
+  // `slice_data_impl()` function is DataVector.
   DirectionMap<Dim, bool> directions_to_slice{};
   directions_to_slice[direction] = true;
 
-  const std::vector<double> sliced_data{detail::slice_data_impl(
+  const DataVector sliced_data{detail::slice_data_impl(
       gsl::make_span(volume_subcell_vars.data(), volume_subcell_vars.size()),
       subcell_extents, ghost_zone_size, directions_to_slice, 0)[direction]};
 
-  // copy the returned std::vector<double> data into sliced variables
+  // copy the returned DataVector data into sliced variables
   std::copy(sliced_data.begin(), sliced_data.end(),
             sliced_subcell_vars->data());
 }

--- a/src/Evolution/DgSubcell/Tags/NeighborData.hpp
+++ b/src/Evolution/DgSubcell/Tags/NeighborData.hpp
@@ -6,9 +6,9 @@
 #include <boost/functional/hash.hpp>
 #include <cstddef>
 #include <utility>
-#include <vector>
 
 #include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/DataVector.hpp"
 #include "DataStructures/FixedHashMap.hpp"
 #include "Domain/Structure/Direction.hpp"
 #include "Domain/Structure/ElementId.hpp"
@@ -20,8 +20,7 @@ template <size_t Dim>
 struct NeighborDataForReconstruction : db::SimpleTag {
   using type =
       FixedHashMap<maximum_number_of_neighbors(Dim),
-                   std::pair<Direction<Dim>, ElementId<Dim>>,
-                   std::vector<double>,
+                   std::pair<Direction<Dim>, ElementId<Dim>>, DataVector,
                    boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>;
 };
 }  // namespace evolution::dg::subcell::Tags

--- a/src/Evolution/DiscontinuousGalerkin/Actions/ApplyBoundaryCorrections.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Actions/ApplyBoundaryCorrections.hpp
@@ -67,8 +67,8 @@ void neighbor_reconstructed_face_solution(
                       ElementId<Metavariables::volume_dim>>,
             std::tuple<Mesh<Metavariables::volume_dim>,
                        Mesh<Metavariables::volume_dim - 1>,
-                       std::optional<std::vector<double>>,
-                       std::optional<std::vector<double>>, ::TimeStepId, int>,
+                       std::optional<DataVector>, std::optional<DataVector>,
+                       ::TimeStepId, int>,
             boost::hash<std::pair<Direction<Metavariables::volume_dim>,
                                   ElementId<Metavariables::volume_dim>>>>>*>
         received_temporal_id_and_data);
@@ -80,9 +80,8 @@ void neighbor_tci_decision(
         FixedHashMap<
             maximum_number_of_neighbors(Dim),
             std::pair<Direction<Dim>, ElementId<Dim>>,
-            std::tuple<Mesh<Dim>, Mesh<Dim - 1>,
-                       std::optional<std::vector<double>>,
-                       std::optional<std::vector<double>>, ::TimeStepId, int>,
+            std::tuple<Mesh<Dim>, Mesh<Dim - 1>, std::optional<DataVector>,
+                       std::optional<DataVector>, ::TimeStepId, int>,
             boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>>&
         received_temporal_id_and_data);
 }  // namespace evolution::dg::subcell
@@ -99,13 +98,13 @@ bool receive_boundary_data_global_time_stepping(
 
   const TimeStepId& temporal_id = get<::Tags::TimeStepId>(*box);
   using Key = std::pair<Direction<volume_dim>, ElementId<volume_dim>>;
-  std::map<TimeStepId,
-           FixedHashMap<maximum_number_of_neighbors(volume_dim), Key,
-                        std::tuple<Mesh<volume_dim>, Mesh<volume_dim - 1>,
-                                   std::optional<std::vector<double>>,
-                                   std::optional<std::vector<double>>,
-                                   ::TimeStepId, int>,
-                        boost::hash<Key>>>& inbox =
+  std::map<
+      TimeStepId,
+      FixedHashMap<maximum_number_of_neighbors(volume_dim), Key,
+                   std::tuple<Mesh<volume_dim>, Mesh<volume_dim - 1>,
+                              std::optional<DataVector>,
+                              std::optional<DataVector>, ::TimeStepId, int>,
+                   boost::hash<Key>>>& inbox =
       tuples::get<evolution::dg::Tags::BoundaryCorrectionAndGhostCellsInbox<
           volume_dim>>(*inboxes);
   const auto received_temporal_id_and_data = inbox.find(temporal_id);
@@ -203,13 +202,13 @@ bool receive_boundary_data_local_time_stepping(
   // returned quantity is more a `dt` quantity than a
   // `NormalDotNormalDotFlux` since it's been lifted to the volume.
   using Key = std::pair<Direction<volume_dim>, ElementId<volume_dim>>;
-  std::map<TimeStepId,
-           FixedHashMap<maximum_number_of_neighbors(volume_dim), Key,
-                        std::tuple<Mesh<volume_dim>, Mesh<volume_dim - 1>,
-                                   std::optional<std::vector<double>>,
-                                   std::optional<std::vector<double>>,
-                                   ::TimeStepId, int>,
-                        boost::hash<Key>>>& inbox =
+  std::map<
+      TimeStepId,
+      FixedHashMap<maximum_number_of_neighbors(volume_dim), Key,
+                   std::tuple<Mesh<volume_dim>, Mesh<volume_dim - 1>,
+                              std::optional<DataVector>,
+                              std::optional<DataVector>, ::TimeStepId, int>,
+                   boost::hash<Key>>>& inbox =
       tuples::get<evolution::dg::Tags::BoundaryCorrectionAndGhostCellsInbox<
           volume_dim>>(*inboxes);
 
@@ -553,9 +552,9 @@ struct ApplyBoundaryCorrections {
 
               // Extract local and neighbor data, copy into Variables because
               // we store them in a std::vector for type erasure.
-              const std::pair<Mesh<volume_dim - 1>, std::vector<double>>&
+              const std::pair<Mesh<volume_dim - 1>, DataVector>&
                   local_mesh_and_data = *local_mortar_data.local_mortar_data();
-              const std::pair<Mesh<volume_dim - 1>, std::vector<double>>&
+              const std::pair<Mesh<volume_dim - 1>, DataVector>&
                   neighbor_mesh_and_data =
                       *neighbor_mortar_data.neighbor_mortar_data();
               local_data_on_mortar.set_data_ref(

--- a/src/Evolution/DiscontinuousGalerkin/Actions/InternalMortarDataImpl.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Actions/InternalMortarDataImpl.hpp
@@ -227,7 +227,7 @@ void internal_mortar_data_impl(
 
       Variables<mortar_tags_list> packaged_data{
           face_mesh.number_of_grid_points()};
-      // The DataBox is passed in for retrieving the `volume_tags`
+
       const double max_abs_char_speed_on_face = detail::dg_package_data<System>(
           make_not_null(&packaged_data), boundary_correction, fields_on_face,
           get<evolution::dg::Tags::NormalCovector<Dim>>(

--- a/src/Evolution/DiscontinuousGalerkin/Actions/InternalMortarDataImpl.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Actions/InternalMortarDataImpl.hpp
@@ -9,7 +9,6 @@
 #include <type_traits>
 #include <unordered_map>
 #include <utility>
-#include <vector>
 
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataBox/PrefixHelpers.hpp"
@@ -225,8 +224,13 @@ void internal_mortar_data_impl(
              "have been. Direction: "
                  << local_direction);
 
-      Variables<mortar_tags_list> packaged_data{
-          face_mesh.number_of_grid_points()};
+      // We point the Variables inside the DataVector because the DataVector
+      // will be moved later on so we want it owning its data
+      DataVector packaged_data_buffer{
+          face_mesh.number_of_grid_points() *
+          Variables<mortar_tags_list>::number_of_independent_components};
+      Variables<mortar_tags_list> packaged_data{packaged_data_buffer.data(),
+                                                packaged_data_buffer.size()};
 
       const double max_abs_char_speed_on_face = detail::dg_package_data<System>(
           make_not_null(&packaged_data), boundary_correction, fields_on_face,
@@ -244,33 +248,35 @@ void internal_mortar_data_impl(
         const auto& mortar_mesh = mortar_meshes.at(mortar_id);
         const auto& mortar_size = mortar_sizes.at(mortar_id);
 
-        // Project the data from the face to the mortar.
-        // Where no projection is necessary we `std::move` the data
-        // directly to avoid a copy. We can't move the data or modify it
-        // in-place when projecting, because in that case the face may
-        // touch two mortars so we need to keep the data around.
-        auto boundary_data_on_mortar =
-            Spectral::needs_projection(face_mesh, mortar_mesh, mortar_size)
-                // NOLINTNEXTLINE(bugprone-use-after-move)
-                ? ::dg::project_to_mortar(packaged_data, face_mesh, mortar_mesh,
-                                          mortar_size)
-                : std::move(packaged_data);
+        // Project the data from the face to the mortar if necessary.
+        // We can't move the data or modify it in-place when projecting, because
+        // in that case the face may touch two mortars so we need to keep the
+        // data around.
+        DataVector boundary_data_on_mortar{};
+        if (Spectral::needs_projection(face_mesh, mortar_mesh, mortar_size)) {
+          boundary_data_on_mortar = DataVector{
+              mortar_mesh.number_of_grid_points() *
+              Variables<mortar_tags_list>::number_of_independent_components};
+          Variables<mortar_tags_list> projected_packaged_data{
+              boundary_data_on_mortar.data(), boundary_data_on_mortar.size()};
+          // Since projected_packaged_data is non-owning, if we tried to
+          // move-assign it with the result of ::dg::project_to_mortar, it would
+          // then become owning and the buffer it previously pointed to wouldn't
+          // be filled (and we want it to be filled). So instead force a
+          // copy-assign by having an intermediary, data_to_copy.
+          const auto data_to_copy = ::dg::project_to_mortar(
+              packaged_data, face_mesh, mortar_mesh, mortar_size);
+          projected_packaged_data = data_to_copy;
 
-        // Store the boundary data on this side of the mortar in a way
-        // that is agnostic to the type of boundary correction used. This
-        // currently requires an additional allocation that could be
-        // eliminated either by:
-        //
-        // 1. Having non-owning Variables
-        //
-        // 2. Allow stealing the allocation out of a Variables (and
-        //    inserting an allocation).
-        std::vector<double> type_erased_boundary_data_on_mortar{
-            boundary_data_on_mortar.data(),
-            boundary_data_on_mortar.data() + boundary_data_on_mortar.size()};
+        } else {
+          ASSERT(neighbors_in_local_direction.size() == 1,
+                 "Expected only 1 neighbor in the local direction but got "
+                     << neighbors_in_local_direction.size() << "instead");
+          boundary_data_on_mortar = std::move(packaged_data_buffer);
+        }
+
         mortar_data_ptr->at(mortar_id).insert_local_mortar_data(
-            temporal_id, face_mesh,
-            std::move(type_erased_boundary_data_on_mortar));
+            temporal_id, face_mesh, std::move(boundary_data_on_mortar));
       }
     };
 

--- a/src/Evolution/DiscontinuousGalerkin/InboxTags.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/InboxTags.hpp
@@ -95,8 +95,8 @@ namespace evolution::dg::Tags {
 template <size_t Dim>
 struct BoundaryCorrectionAndGhostCellsInbox {
   using stored_type =
-      std::tuple<Mesh<Dim>, Mesh<Dim - 1>, std::optional<std::vector<double>>,
-                 std::optional<std::vector<double>>, ::TimeStepId, int>;
+      std::tuple<Mesh<Dim>, Mesh<Dim - 1>, std::optional<DataVector>,
+                 std::optional<DataVector>, ::TimeStepId, int>;
 
  public:
   using temporal_id = TimeStepId;

--- a/src/Evolution/DiscontinuousGalerkin/MortarData.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/MortarData.hpp
@@ -8,17 +8,13 @@
 #include <optional>
 #include <pup.h>
 #include <utility>
-#include <vector>
 
+#include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "Parallel/PupStlCpp17.hpp"
 #include "Time/TimeStepId.hpp"
 #include "Utilities/Gsl.hpp"
-
-/// \cond
-class DataVector;
-/// \endcond
 
 namespace evolution::dg {
 /*!
@@ -68,10 +64,10 @@ class MortarData {
   /// @{
   void insert_local_mortar_data(TimeStepId time_step_id,
                                 Mesh<Dim - 1> local_interface_mesh,
-                                std::vector<double> local_mortar_vars);
+                                DataVector local_mortar_vars);
   void insert_neighbor_mortar_data(TimeStepId time_step_id,
                                    Mesh<Dim - 1> neighbor_interface_mesh,
-                                   std::vector<double> neighbor_mortar_vars);
+                                   DataVector neighbor_mortar_vars);
   /// @}
 
   /*!
@@ -144,18 +140,18 @@ class MortarData {
   ///
   /// The first element is the local data while the second element is the
   /// neighbor data.
-  auto extract() -> std::pair<std::pair<Mesh<Dim - 1>, std::vector<double>>,
-                              std::pair<Mesh<Dim - 1>, std::vector<double>>>;
+  auto extract() -> std::pair<std::pair<Mesh<Dim - 1>, DataVector>,
+                              std::pair<Mesh<Dim - 1>, DataVector>>;
 
   const TimeStepId& time_step_id() const { return time_step_id_; }
 
   auto local_mortar_data() const
-      -> const std::optional<std::pair<Mesh<Dim - 1>, std::vector<double>>>& {
+      -> const std::optional<std::pair<Mesh<Dim - 1>, DataVector>>& {
     return local_mortar_data_;
   }
 
   auto neighbor_mortar_data() const
-      -> const std::optional<std::pair<Mesh<Dim - 1>, std::vector<double>>>& {
+      -> const std::optional<std::pair<Mesh<Dim - 1>, DataVector>>& {
     return neighbor_mortar_data_;
   }
 
@@ -169,11 +165,9 @@ class MortarData {
                          const MortarData<LocalDim>& rhs);
 
   TimeStepId time_step_id_{};
-  std::optional<std::pair<Mesh<Dim - 1>, std::vector<double>>>
-      local_mortar_data_{};
-  std::optional<std::pair<Mesh<Dim - 1>, std::vector<double>>>
-      neighbor_mortar_data_{};
-  std::vector<double> local_geometric_quantities_{};
+  std::optional<std::pair<Mesh<Dim - 1>, DataVector>> local_mortar_data_{};
+  std::optional<std::pair<Mesh<Dim - 1>, DataVector>> neighbor_mortar_data_{};
+  DataVector local_geometric_quantities_{};
   bool using_volume_and_face_jacobians_{false};
   bool using_only_face_normal_magnitude_{false};
 };

--- a/src/Evolution/Systems/Burgers/FiniteDifference/BoundaryConditionGhostData.hpp
+++ b/src/Evolution/Systems/Burgers/FiniteDifference/BoundaryConditionGhostData.hpp
@@ -7,9 +7,9 @@
 #include <optional>
 #include <type_traits>
 #include <utility>
-#include <vector>
 
 #include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataVector.hpp"
 #include "DataStructures/Index.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Variables.hpp"
@@ -192,9 +192,10 @@ void BoundaryConditionGhostData::apply(
 
     // Put the computed ghost data into neighbor data with {direction,
     // ElementId::external_boundary_id()} as the mortar_id key
-    std::vector<double> boundary_ghost_data{
-        ghost_data_vars.data(),
-        ghost_data_vars.data() + ghost_data_vars.size()};
+    DataVector boundary_ghost_data{ghost_data_vars.size()};
+    std::copy(get(get<Burgers::Tags::U>(ghost_data_vars)).begin(),
+              get(get<Burgers::Tags::U>(ghost_data_vars)).end(),
+              boundary_ghost_data.begin());
     const std::pair mortar_id{direction, ElementId<1>::external_boundary_id()};
 
     db::mutate<evolution::dg::subcell::Tags::NeighborDataForReconstruction<1>>(

--- a/src/Evolution/Systems/Burgers/FiniteDifference/MonotonisedCentral.cpp
+++ b/src/Evolution/Systems/Burgers/FiniteDifference/MonotonisedCentral.cpp
@@ -9,9 +9,9 @@
 #include <memory>
 #include <pup.h>
 #include <utility>
-#include <vector>
 
 #include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataVector.hpp"
 #include "DataStructures/FixedHashMap.hpp"
 #include "DataStructures/Index.hpp"
 #include "DataStructures/Tensor/IndexType.hpp"
@@ -49,10 +49,10 @@ void MonotonisedCentral::reconstruct(
         vars_on_upper_face,
     const Variables<tmpl::list<Burgers::Tags::U>>& volume_vars,
     const Element<1>& element,
-    const FixedHashMap<
-        maximum_number_of_neighbors(1), std::pair<Direction<1>, ElementId<1>>,
-        std::vector<double>,
-        boost::hash<std::pair<Direction<1>, ElementId<1>>>>& neighbor_data,
+    const FixedHashMap<maximum_number_of_neighbors(1),
+                       std::pair<Direction<1>, ElementId<1>>, DataVector,
+                       boost::hash<std::pair<Direction<1>, ElementId<1>>>>&
+        neighbor_data,
     const Mesh<1>& subcell_mesh) const {
   reconstruct_work(
       vars_on_lower_face, vars_on_upper_face,
@@ -69,10 +69,10 @@ void MonotonisedCentral::reconstruct(
 void MonotonisedCentral::reconstruct_fd_neighbor(
     const gsl::not_null<Variables<face_vars_tags>*> vars_on_face,
     const Variables<volume_vars_tags>& volume_vars, const Element<1>& element,
-    const FixedHashMap<
-        maximum_number_of_neighbors(1), std::pair<Direction<1>, ElementId<1>>,
-        std::vector<double>,
-        boost::hash<std::pair<Direction<1>, ElementId<1>>>>& neighbor_data,
+    const FixedHashMap<maximum_number_of_neighbors(1),
+                       std::pair<Direction<1>, ElementId<1>>, DataVector,
+                       boost::hash<std::pair<Direction<1>, ElementId<1>>>>&
+        neighbor_data,
     const Mesh<1>& subcell_mesh,
     const Direction<1> direction_to_reconstruct) const {
   reconstruct_fd_neighbor_work(

--- a/src/Evolution/Systems/Burgers/FiniteDifference/MonotonisedCentral.hpp
+++ b/src/Evolution/Systems/Burgers/FiniteDifference/MonotonisedCentral.hpp
@@ -8,7 +8,6 @@
 #include <cstddef>
 #include <memory>
 #include <utility>
-#include <vector>
 
 #include "DataStructures/DataBox/Prefixes.hpp"
 #include "DataStructures/FixedHashMap.hpp"
@@ -25,6 +24,7 @@
 #include "Utilities/TMPL.hpp"
 
 /// \cond
+class DataVector;
 template <size_t Dim>
 class Direction;
 template <size_t Dim>
@@ -91,19 +91,19 @@ class MonotonisedCentral : public Reconstructor {
           vars_on_upper_face,
       const Variables<tmpl::list<Burgers::Tags::U>>& volume_vars,
       const Element<1>& element,
-      const FixedHashMap<
-          maximum_number_of_neighbors(1), std::pair<Direction<1>, ElementId<1>>,
-          std::vector<double>,
-          boost::hash<std::pair<Direction<1>, ElementId<1>>>>& neighbor_data,
+      const FixedHashMap<maximum_number_of_neighbors(1),
+                         std::pair<Direction<1>, ElementId<1>>, DataVector,
+                         boost::hash<std::pair<Direction<1>, ElementId<1>>>>&
+          neighbor_data,
       const Mesh<1>& subcell_mesh) const;
 
   void reconstruct_fd_neighbor(
       gsl::not_null<Variables<face_vars_tags>*> vars_on_face,
       const Variables<volume_vars_tags>& volume_vars, const Element<1>& element,
-      const FixedHashMap<
-          maximum_number_of_neighbors(1), std::pair<Direction<1>, ElementId<1>>,
-          std::vector<double>,
-          boost::hash<std::pair<Direction<1>, ElementId<1>>>>& neighbor_data,
+      const FixedHashMap<maximum_number_of_neighbors(1),
+                         std::pair<Direction<1>, ElementId<1>>, DataVector,
+                         boost::hash<std::pair<Direction<1>, ElementId<1>>>>&
+          neighbor_data,
       const Mesh<1>& subcell_mesh,
       const Direction<1> direction_to_reconstruct) const;
 };

--- a/src/Evolution/Systems/Burgers/FiniteDifference/ReconstructWork.hpp
+++ b/src/Evolution/Systems/Burgers/FiniteDifference/ReconstructWork.hpp
@@ -7,7 +7,6 @@
 #include <boost/functional/hash.hpp>
 #include <cstddef>
 #include <utility>
-#include <vector>
 
 #include "DataStructures/FixedHashMap.hpp"
 #include "Domain/Structure/MaxNumberOfNeighbors.hpp"
@@ -15,6 +14,7 @@
 #include "Utilities/TMPL.hpp"
 
 /// \cond
+class DataVector;
 template <typename TagsList>
 class Variables;
 namespace gsl {
@@ -42,10 +42,10 @@ void reconstruct_work(
     gsl::not_null<std::array<Variables<TagsList>, 1>*> vars_on_upper_face,
     const Reconstructor& reconstruct,
     const Variables<tmpl::list<Tags::U>> volume_vars, const Element<1>& element,
-    const FixedHashMap<
-        maximum_number_of_neighbors(1), std::pair<Direction<1>, ElementId<1>>,
-        std::vector<double>,
-        boost::hash<std::pair<Direction<1>, ElementId<1>>>>& neighbor_data,
+    const FixedHashMap<maximum_number_of_neighbors(1),
+                       std::pair<Direction<1>, ElementId<1>>, DataVector,
+                       boost::hash<std::pair<Direction<1>, ElementId<1>>>>&
+        neighbor_data,
     const Mesh<1>& subcell_mesh, const size_t ghost_zone_size);
 
 /*!
@@ -62,10 +62,10 @@ void reconstruct_fd_neighbor_work(
     const ReconstructUpper& reconstruct_upper_neighbor,
     const Variables<tmpl::list<Tags::U>>& subcell_volume_vars,
     const Element<1>& element,
-    const FixedHashMap<
-        maximum_number_of_neighbors(1), std::pair<Direction<1>, ElementId<1>>,
-        std::vector<double>,
-        boost::hash<std::pair<Direction<1>, ElementId<1>>>>& neighbor_data,
+    const FixedHashMap<maximum_number_of_neighbors(1),
+                       std::pair<Direction<1>, ElementId<1>>, DataVector,
+                       boost::hash<std::pair<Direction<1>, ElementId<1>>>>&
+        neighbor_data,
     const Mesh<1>& subcell_mesh, const Direction<1>& direction_to_reconstruct,
     const size_t ghost_zone_size);
 }  // namespace Burgers::fd

--- a/src/Evolution/Systems/Burgers/FiniteDifference/ReconstructWork.tpp
+++ b/src/Evolution/Systems/Burgers/FiniteDifference/ReconstructWork.tpp
@@ -7,9 +7,9 @@
 #include <boost/functional/hash.hpp>
 #include <cstddef>
 #include <utility>
-#include <vector>
 
 #include "DataStructures/FixedHashMap.hpp"
+#include "DataStructures/DataVector.hpp"
 #include "DataStructures/Index.hpp"
 #include "DataStructures/Variables.hpp"
 #include "Domain/Structure/Direction.hpp"
@@ -32,7 +32,7 @@ void reconstruct_work(
     const Variables<tmpl::list<Tags::U>> volume_vars, const Element<1>& element,
     const FixedHashMap<
         maximum_number_of_neighbors(1), std::pair<Direction<1>, ElementId<1>>,
-        std::vector<double>,
+        DataVector,
         boost::hash<std::pair<Direction<1>, ElementId<1>>>>& neighbor_data,
     const Mesh<1>& subcell_mesh, const size_t ghost_zone_size) {
   const size_t volume_num_pts = subcell_mesh.number_of_grid_points();
@@ -67,9 +67,9 @@ void reconstruct_work(
              "got "
                  << neighbors_in_direction.size() << " in direction "
                  << direction);
-      ASSERT(not neighbor_data
+      ASSERT(neighbor_data
                      .at(std::pair{direction, *neighbors_in_direction.begin()})
-                     .empty(),
+                     .size() != 0,
              "The neighber data is empty in direction "
                  << direction << " on element id " << element.id());
 
@@ -106,7 +106,7 @@ void reconstruct_fd_neighbor_work(
     const Element<1>& element,
     const FixedHashMap<
         maximum_number_of_neighbors(1), std::pair<Direction<1>, ElementId<1>>,
-        std::vector<double>,
+        DataVector,
         boost::hash<std::pair<Direction<1>, ElementId<1>>>>& neighbor_data,
     const Mesh<1>& subcell_mesh, const Direction<1>& direction_to_reconstruct,
     const size_t ghost_zone_size) {

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/BoundaryConditionGhostData.hpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/BoundaryConditionGhostData.hpp
@@ -8,7 +8,6 @@
 #include <type_traits>
 #include <unordered_set>
 #include <utility>
-#include <vector>
 
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataVector.hpp"
@@ -122,8 +121,8 @@ void BoundaryConditionGhostData::apply(
 
     // Allocate a vector to store the computed FD ghost data and assign a
     // non-owning Variables on it.
-    std::vector<double> boundary_ghost_data(number_of_tensor_components *
-                                            ghost_zone_size * num_face_pts);
+    DataVector boundary_ghost_data{number_of_tensor_components *
+                                   ghost_zone_size * num_face_pts};
     Variables<reconstruction_tags> ghost_data_vars{boundary_ghost_data.data(),
                                                    boundary_ghost_data.size()};
 

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/Derivatives.cpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/Derivatives.cpp
@@ -34,8 +34,7 @@ void spacetime_derivatives(
         typename grmhd::GhValenciaDivClean::System::variables_tag::tags_list>&
         volume_evolved_variables,
     const FixedHashMap<maximum_number_of_neighbors(3),
-                       std::pair<Direction<3>, ElementId<3>>,
-                       std::vector<double>,
+                       std::pair<Direction<3>, ElementId<3>>, DataVector,
                        boost::hash<std::pair<Direction<3>, ElementId<3>>>>&
         neighbor_data_for_reconstruction,
     const Mesh<3>& volume_mesh,

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/Derivatives.hpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/Derivatives.hpp
@@ -49,8 +49,7 @@ void spacetime_derivatives(
         typename grmhd::GhValenciaDivClean::System::variables_tag::tags_list>&
         volume_evolved_variables,
     const FixedHashMap<maximum_number_of_neighbors(3),
-                       std::pair<Direction<3>, ElementId<3>>,
-                       std::vector<double>,
+                       std::pair<Direction<3>, ElementId<3>>, DataVector,
                        boost::hash<std::pair<Direction<3>, ElementId<3>>>>&
         neighbor_data_for_reconstruction,
     const Mesh<3>& volume_mesh,

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/Filters.cpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/Filters.cpp
@@ -31,8 +31,7 @@ void spacetime_kreiss_oliger_filter(
         typename grmhd::GhValenciaDivClean::System::variables_tag::tags_list>&
         volume_evolved_variables,
     const FixedHashMap<maximum_number_of_neighbors(3),
-                       std::pair<Direction<3>, ElementId<3>>,
-                       std::vector<double>,
+                       std::pair<Direction<3>, ElementId<3>>, DataVector,
                        boost::hash<std::pair<Direction<3>, ElementId<3>>>>&
         neighbor_data_for_reconstruction,
     const Mesh<3>& volume_mesh, const size_t order, const double epsilon) {

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/Filters.hpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/Filters.hpp
@@ -39,8 +39,7 @@ void spacetime_kreiss_oliger_filter(
         typename grmhd::GhValenciaDivClean::System::variables_tag::tags_list>&
         volume_evolved_variables,
     const FixedHashMap<maximum_number_of_neighbors(3),
-                       std::pair<Direction<3>, ElementId<3>>,
-                       std::vector<double>,
+                       std::pair<Direction<3>, ElementId<3>>, DataVector,
                        boost::hash<std::pair<Direction<3>, ElementId<3>>>>&
         neighbor_data_for_reconstruction,
     const Mesh<3>& volume_mesh, size_t order, double epsilon);

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/MonotonisedCentral.cpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/MonotonisedCentral.cpp
@@ -67,10 +67,10 @@ void MonotonisedCentralPrim::reconstruct(
         volume_spacetime_and_cons_vars,
     const EquationsOfState::EquationOfState<true, ThermodynamicDim>& eos,
     const Element<dim>& element,
-    const FixedHashMap<
-        maximum_number_of_neighbors(dim),
-        std::pair<Direction<dim>, ElementId<dim>>, std::vector<double>,
-        boost::hash<std::pair<Direction<dim>, ElementId<dim>>>>& neighbor_data,
+    const FixedHashMap<maximum_number_of_neighbors(dim),
+                       std::pair<Direction<dim>, ElementId<dim>>, DataVector,
+                       boost::hash<std::pair<Direction<dim>, ElementId<dim>>>>&
+        neighbor_data,
     const Mesh<dim>& subcell_mesh) const {
   using prim_tags_for_reconstruction =
       grmhd::GhValenciaDivClean::Tags::primitive_grmhd_reconstruction_tags;
@@ -138,10 +138,10 @@ void MonotonisedCentralPrim::reconstruct_fd_neighbor(
         subcell_volume_spacetime_metric,
     const EquationsOfState::EquationOfState<true, ThermodynamicDim>& eos,
     const Element<dim>& element,
-    const FixedHashMap<
-        maximum_number_of_neighbors(dim),
-        std::pair<Direction<dim>, ElementId<dim>>, std::vector<double>,
-        boost::hash<std::pair<Direction<dim>, ElementId<dim>>>>& neighbor_data,
+    const FixedHashMap<maximum_number_of_neighbors(dim),
+                       std::pair<Direction<dim>, ElementId<dim>>, DataVector,
+                       boost::hash<std::pair<Direction<dim>, ElementId<dim>>>>&
+        neighbor_data,
     const Mesh<dim>& subcell_mesh,
     const Direction<dim> direction_to_reconstruct) const {
   using prim_tags_for_reconstruction =
@@ -325,10 +325,10 @@ bool operator!=(const MonotonisedCentralPrim& lhs,
           volume_spacetime_and_cons_vars,                                      \
       const EquationsOfState::EquationOfState<true, THERMO_DIM(data)>& eos,    \
       const Element<3>& element,                                               \
-      const FixedHashMap<                                                      \
-          maximum_number_of_neighbors(3),                                      \
-          std::pair<Direction<3>, ElementId<3>>, std::vector<double>,          \
-          boost::hash<std::pair<Direction<3>, ElementId<3>>>>& neighbor_data,  \
+      const FixedHashMap<maximum_number_of_neighbors(3),                       \
+                         std::pair<Direction<3>, ElementId<3>>, DataVector,    \
+                         boost::hash<std::pair<Direction<3>, ElementId<3>>>>&  \
+          neighbor_data,                                                       \
       const Mesh<3>& subcell_mesh) const;                                      \
   template void MonotonisedCentralPrim::reconstruct_fd_neighbor(               \
       gsl::not_null<Variables<TAGS_LIST_DG_FD_INTERFACE(data)>*> vars_on_face, \
@@ -338,10 +338,10 @@ bool operator!=(const MonotonisedCentralPrim& lhs,
           subcell_volume_spacetime_metric,                                     \
       const EquationsOfState::EquationOfState<true, THERMO_DIM(data)>& eos,    \
       const Element<3>& element,                                               \
-      const FixedHashMap<                                                      \
-          maximum_number_of_neighbors(3),                                      \
-          std::pair<Direction<3>, ElementId<3>>, std::vector<double>,          \
-          boost::hash<std::pair<Direction<3>, ElementId<3>>>>& neighbor_data,  \
+      const FixedHashMap<maximum_number_of_neighbors(3),                       \
+                         std::pair<Direction<3>, ElementId<3>>, DataVector,    \
+                         boost::hash<std::pair<Direction<3>, ElementId<3>>>>&  \
+          neighbor_data,                                                       \
       const Mesh<3>& subcell_mesh,                                             \
       const Direction<3> direction_to_reconstruct) const;
 

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/MonotonisedCentral.hpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/MonotonisedCentral.hpp
@@ -111,7 +111,7 @@ class MonotonisedCentralPrim : public Reconstructor {
       const Element<dim>& element,
       const FixedHashMap<
           maximum_number_of_neighbors(dim),
-          std::pair<Direction<dim>, ElementId<dim>>, std::vector<double>,
+          std::pair<Direction<dim>, ElementId<dim>>, DataVector,
           boost::hash<std::pair<Direction<dim>, ElementId<dim>>>>&
           neighbor_data,
       const Mesh<dim>& subcell_mesh) const;
@@ -128,7 +128,7 @@ class MonotonisedCentralPrim : public Reconstructor {
       const Element<dim>& element,
       const FixedHashMap<
           maximum_number_of_neighbors(dim),
-          std::pair<Direction<dim>, ElementId<dim>>, std::vector<double>,
+          std::pair<Direction<dim>, ElementId<dim>>, DataVector,
           boost::hash<std::pair<Direction<dim>, ElementId<dim>>>>&
           neighbor_data,
       const Mesh<dim>& subcell_mesh,

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/ReconstructWork.hpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/ReconstructWork.hpp
@@ -14,6 +14,7 @@
 #include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
 
 /// \cond
+class DataVector;
 template <typename TagsList>
 class Variables;
 namespace gsl {
@@ -96,10 +97,10 @@ void reconstruct_fd_neighbor_work(
         subcell_volume_spacetime_vars,
     const EquationsOfState::EquationOfState<true, ThermodynamicDim>& eos,
     const Element<3>& element,
-    const FixedHashMap<
-        maximum_number_of_neighbors(3), std::pair<Direction<3>, ElementId<3>>,
-        std::vector<double>,
-        boost::hash<std::pair<Direction<3>, ElementId<3>>>>& neighbor_data,
+    const FixedHashMap<maximum_number_of_neighbors(3),
+                       std::pair<Direction<3>, ElementId<3>>, DataVector,
+                       boost::hash<std::pair<Direction<3>, ElementId<3>>>>&
+        neighbor_data,
     const Mesh<3>& subcell_mesh, const Direction<3>& direction_to_reconstruct,
     size_t ghost_zone_size, bool compute_conservatives);
 }  // namespace grmhd::GhValenciaDivClean::fd

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/ReconstructWork.tpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/ReconstructWork.tpp
@@ -255,7 +255,7 @@ void reconstruct_fd_neighbor_work(
     const Element<3>& element,
     const FixedHashMap<
         maximum_number_of_neighbors(3), std::pair<Direction<3>, ElementId<3>>,
-        std::vector<double>,
+        DataVector,
         boost::hash<std::pair<Direction<3>, ElementId<3>>>>& neighbor_data,
     const Mesh<3>& subcell_mesh, const Direction<3>& direction_to_reconstruct,
     const size_t ghost_zone_size, const bool compute_conservatives) {

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/NeighborPackagedData.hpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/NeighborPackagedData.hpp
@@ -69,9 +69,9 @@ namespace grmhd::GhValenciaDivClean::subcell {
  */
 struct NeighborPackagedData {
   template <typename DbTagsList>
-  static FixedHashMap<
-      maximum_number_of_neighbors(3), std::pair<Direction<3>, ElementId<3>>,
-      std::vector<double>, boost::hash<std::pair<Direction<3>, ElementId<3>>>>
+  static FixedHashMap<maximum_number_of_neighbors(3),
+                      std::pair<Direction<3>, ElementId<3>>, DataVector,
+                      boost::hash<std::pair<Direction<3>, ElementId<3>>>>
   apply(const db::DataBox<DbTagsList>& box,
         const std::vector<std::pair<Direction<3>, ElementId<3>>>&
             mortars_to_reconstruct_to) {
@@ -92,7 +92,7 @@ struct NeighborPackagedData {
            "re-slicing/projecting.");
 
     FixedHashMap<maximum_number_of_neighbors(3),
-                 std::pair<Direction<3>, ElementId<3>>, std::vector<double>,
+                 std::pair<Direction<3>, ElementId<3>>, DataVector,
                  boost::hash<std::pair<Direction<3>, ElementId<3>>>>
         neighbor_package_data{};
     if (mortars_to_reconstruct_to.empty()) {
@@ -133,8 +133,8 @@ struct NeighborPackagedData {
         db::get<grmhd::GhValenciaDivClean::fd::Tags::Reconstructor>(box);
     const auto& base_boundary_correction =
         db::get<evolution::Tags::BoundaryCorrection<System>>(box);
-    using derived_boundary_corrections = typename std::decay_t<
-        decltype(base_boundary_correction)>::creatable_classes;
+    using derived_boundary_corrections = typename std::decay_t<decltype(
+        base_boundary_correction)>::creatable_classes;
     call_with_dynamic_type<void, derived_boundary_corrections>(
         &base_boundary_correction,
         [&box, &dg_mesh, &mortars_to_reconstruct_to, &neighbor_package_data,
@@ -284,10 +284,10 @@ struct NeighborPackagedData {
             // Really we should be solving the boundary correction and
             // then reconstructing, but away from a shock this doesn't
             // matter.
-            std::vector<double> dg_data(
+            DataVector dg_data{
                 Variables<
                     dg_package_field_tags>::number_of_independent_components *
-                dg_face_mesh.number_of_grid_points());
+                dg_face_mesh.number_of_grid_points()};
             Variables<dg_package_field_tags> dg_packaged_data{dg_data.data(),
                                                               dg_data.size()};
             evolution::dg::subcell::fd::reconstruct(

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/BoundaryConditionGhostData.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/BoundaryConditionGhostData.hpp
@@ -8,7 +8,6 @@
 #include <type_traits>
 #include <unordered_set>
 #include <utility>
-#include <vector>
 
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataVector.hpp"
@@ -122,8 +121,8 @@ void BoundaryConditionGhostData::apply(
 
     // Allocate a vector to store the computed FD ghost data and assign a
     // non-owning Variables on it.
-    std::vector<double> boundary_ghost_data(num_prims_tensor_components *
-                                            ghost_zone_size * num_face_pts);
+    DataVector boundary_ghost_data{num_prims_tensor_components *
+                                   ghost_zone_size * num_face_pts};
     Variables<prims_for_reconstruction> ghost_data_vars{
         boundary_ghost_data.data(), boundary_ghost_data.size()};
 

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/MonotonicityPreserving5.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/MonotonicityPreserving5.cpp
@@ -9,7 +9,6 @@
 #include <memory>
 #include <pup.h>
 #include <utility>
-#include <vector>
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/FixedHashMap.hpp"
@@ -62,10 +61,10 @@ void MonotonicityPreserving5Prim::reconstruct(
     const Variables<hydro::grmhd_tags<DataVector>>& volume_prims,
     const EquationsOfState::EquationOfState<true, ThermodynamicDim>& eos,
     const Element<dim>& element,
-    const FixedHashMap<
-        maximum_number_of_neighbors(dim),
-        std::pair<Direction<dim>, ElementId<dim>>, std::vector<double>,
-        boost::hash<std::pair<Direction<dim>, ElementId<dim>>>>& neighbor_data,
+    const FixedHashMap<maximum_number_of_neighbors(dim),
+                       std::pair<Direction<dim>, ElementId<dim>>, DataVector,
+                       boost::hash<std::pair<Direction<dim>, ElementId<dim>>>>&
+        neighbor_data,
     const Mesh<dim>& subcell_mesh) const {
   FixedHashMap<maximum_number_of_neighbors(dim),
                std::pair<Direction<dim>, ElementId<dim>>,
@@ -96,10 +95,10 @@ void MonotonicityPreserving5Prim::reconstruct_fd_neighbor(
     const Variables<hydro::grmhd_tags<DataVector>>& subcell_volume_prims,
     const EquationsOfState::EquationOfState<true, ThermodynamicDim>& eos,
     const Element<dim>& element,
-    const FixedHashMap<
-        maximum_number_of_neighbors(dim),
-        std::pair<Direction<dim>, ElementId<dim>>, std::vector<double>,
-        boost::hash<std::pair<Direction<dim>, ElementId<dim>>>>& neighbor_data,
+    const FixedHashMap<maximum_number_of_neighbors(dim),
+                       std::pair<Direction<dim>, ElementId<dim>>, DataVector,
+                       boost::hash<std::pair<Direction<dim>, ElementId<dim>>>>&
+        neighbor_data,
     const Mesh<dim>& subcell_mesh,
     const Direction<dim> direction_to_reconstruct) const {
   reconstruct_fd_neighbor_work<prims_to_reconstruct_tags,
@@ -183,20 +182,20 @@ bool operator!=(const MonotonicityPreserving5Prim& lhs,
       const Variables<hydro::grmhd_tags<DataVector>>& volume_prims,           \
       const EquationsOfState::EquationOfState<true, THERMO_DIM(data)>& eos,   \
       const Element<3>& element,                                              \
-      const FixedHashMap<                                                     \
-          maximum_number_of_neighbors(3),                                     \
-          std::pair<Direction<3>, ElementId<3>>, std::vector<double>,         \
-          boost::hash<std::pair<Direction<3>, ElementId<3>>>>& neighbor_data, \
+      const FixedHashMap<maximum_number_of_neighbors(3),                      \
+                         std::pair<Direction<3>, ElementId<3>>, DataVector,   \
+                         boost::hash<std::pair<Direction<3>, ElementId<3>>>>& \
+          neighbor_data,                                                      \
       const Mesh<3>& subcell_mesh) const;                                     \
   template void MonotonicityPreserving5Prim::reconstruct_fd_neighbor(         \
       gsl::not_null<Variables<TAGS_LIST(data)>*> vars_on_face,                \
       const Variables<hydro::grmhd_tags<DataVector>>& subcell_volume_prims,   \
       const EquationsOfState::EquationOfState<true, THERMO_DIM(data)>& eos,   \
       const Element<3>& element,                                              \
-      const FixedHashMap<                                                     \
-          maximum_number_of_neighbors(3),                                     \
-          std::pair<Direction<3>, ElementId<3>>, std::vector<double>,         \
-          boost::hash<std::pair<Direction<3>, ElementId<3>>>>& neighbor_data, \
+      const FixedHashMap<maximum_number_of_neighbors(3),                      \
+                         std::pair<Direction<3>, ElementId<3>>, DataVector,   \
+                         boost::hash<std::pair<Direction<3>, ElementId<3>>>>& \
+          neighbor_data,                                                      \
       const Mesh<3>& subcell_mesh,                                            \
       const Direction<3> direction_to_reconstruct) const;
 

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/MonotonicityPreserving5.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/MonotonicityPreserving5.hpp
@@ -9,7 +9,6 @@
 #include <limits>
 #include <memory>
 #include <utility>
-#include <vector>
 
 #include "DataStructures/DataBox/PrefixHelpers.hpp"
 #include "DataStructures/DataBox/Prefixes.hpp"
@@ -129,7 +128,7 @@ class MonotonicityPreserving5Prim : public Reconstructor {
       const Element<dim>& element,
       const FixedHashMap<
           maximum_number_of_neighbors(dim),
-          std::pair<Direction<dim>, ElementId<dim>>, std::vector<double>,
+          std::pair<Direction<dim>, ElementId<dim>>, DataVector,
           boost::hash<std::pair<Direction<dim>, ElementId<dim>>>>&
           neighbor_data,
       const Mesh<dim>& subcell_mesh) const;
@@ -142,7 +141,7 @@ class MonotonicityPreserving5Prim : public Reconstructor {
       const Element<dim>& element,
       const FixedHashMap<
           maximum_number_of_neighbors(dim),
-          std::pair<Direction<dim>, ElementId<dim>>, std::vector<double>,
+          std::pair<Direction<dim>, ElementId<dim>>, DataVector,
           boost::hash<std::pair<Direction<dim>, ElementId<dim>>>>&
           neighbor_data,
       const Mesh<dim>& subcell_mesh,

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/MonotonisedCentral.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/MonotonisedCentral.cpp
@@ -9,7 +9,6 @@
 #include <memory>
 #include <pup.h>
 #include <utility>
-#include <vector>
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/FixedHashMap.hpp"
@@ -52,10 +51,10 @@ void MonotonisedCentralPrim::reconstruct(
     const Variables<hydro::grmhd_tags<DataVector>>& volume_prims,
     const EquationsOfState::EquationOfState<true, ThermodynamicDim>& eos,
     const Element<dim>& element,
-    const FixedHashMap<
-        maximum_number_of_neighbors(dim),
-        std::pair<Direction<dim>, ElementId<dim>>, std::vector<double>,
-        boost::hash<std::pair<Direction<dim>, ElementId<dim>>>>& neighbor_data,
+    const FixedHashMap<maximum_number_of_neighbors(dim),
+                       std::pair<Direction<dim>, ElementId<dim>>, DataVector,
+                       boost::hash<std::pair<Direction<dim>, ElementId<dim>>>>&
+        neighbor_data,
     const Mesh<dim>& subcell_mesh) const {
   FixedHashMap<maximum_number_of_neighbors(dim),
                std::pair<Direction<dim>, ElementId<dim>>,
@@ -84,10 +83,10 @@ void MonotonisedCentralPrim::reconstruct_fd_neighbor(
     const Variables<hydro::grmhd_tags<DataVector>>& subcell_volume_prims,
     const EquationsOfState::EquationOfState<true, ThermodynamicDim>& eos,
     const Element<dim>& element,
-    const FixedHashMap<
-        maximum_number_of_neighbors(dim),
-        std::pair<Direction<dim>, ElementId<dim>>, std::vector<double>,
-        boost::hash<std::pair<Direction<dim>, ElementId<dim>>>>& neighbor_data,
+    const FixedHashMap<maximum_number_of_neighbors(dim),
+                       std::pair<Direction<dim>, ElementId<dim>>, DataVector,
+                       boost::hash<std::pair<Direction<dim>, ElementId<dim>>>>&
+        neighbor_data,
     const Mesh<dim>& subcell_mesh,
     const Direction<dim> direction_to_reconstruct) const {
   reconstruct_fd_neighbor_work<prims_to_reconstruct_tags,
@@ -171,20 +170,20 @@ bool operator!=(const MonotonisedCentralPrim& lhs,
       const Variables<hydro::grmhd_tags<DataVector>>& volume_prims,           \
       const EquationsOfState::EquationOfState<true, THERMO_DIM(data)>& eos,   \
       const Element<3>& element,                                              \
-      const FixedHashMap<                                                     \
-          maximum_number_of_neighbors(3),                                     \
-          std::pair<Direction<3>, ElementId<3>>, std::vector<double>,         \
-          boost::hash<std::pair<Direction<3>, ElementId<3>>>>& neighbor_data, \
+      const FixedHashMap<maximum_number_of_neighbors(3),                      \
+                         std::pair<Direction<3>, ElementId<3>>, DataVector,   \
+                         boost::hash<std::pair<Direction<3>, ElementId<3>>>>& \
+          neighbor_data,                                                      \
       const Mesh<3>& subcell_mesh) const;                                     \
   template void MonotonisedCentralPrim::reconstruct_fd_neighbor(              \
       gsl::not_null<Variables<TAGS_LIST(data)>*> vars_on_face,                \
       const Variables<hydro::grmhd_tags<DataVector>>& subcell_volume_prims,   \
       const EquationsOfState::EquationOfState<true, THERMO_DIM(data)>& eos,   \
       const Element<3>& element,                                              \
-      const FixedHashMap<                                                     \
-          maximum_number_of_neighbors(3),                                     \
-          std::pair<Direction<3>, ElementId<3>>, std::vector<double>,         \
-          boost::hash<std::pair<Direction<3>, ElementId<3>>>>& neighbor_data, \
+      const FixedHashMap<maximum_number_of_neighbors(3),                      \
+                         std::pair<Direction<3>, ElementId<3>>, DataVector,   \
+                         boost::hash<std::pair<Direction<3>, ElementId<3>>>>& \
+          neighbor_data,                                                      \
       const Mesh<3>& subcell_mesh,                                            \
       const Direction<3> direction_to_reconstruct) const;
 

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/MonotonisedCentral.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/MonotonisedCentral.hpp
@@ -8,7 +8,6 @@
 #include <cstddef>
 #include <memory>
 #include <utility>
-#include <vector>
 
 #include "DataStructures/DataBox/PrefixHelpers.hpp"
 #include "DataStructures/DataBox/Prefixes.hpp"
@@ -105,7 +104,7 @@ class MonotonisedCentralPrim : public Reconstructor {
       const Element<dim>& element,
       const FixedHashMap<
           maximum_number_of_neighbors(dim),
-          std::pair<Direction<dim>, ElementId<dim>>, std::vector<double>,
+          std::pair<Direction<dim>, ElementId<dim>>, DataVector,
           boost::hash<std::pair<Direction<dim>, ElementId<dim>>>>&
           neighbor_data,
       const Mesh<dim>& subcell_mesh) const;
@@ -119,7 +118,7 @@ class MonotonisedCentralPrim : public Reconstructor {
       const Element<dim>& element,
       const FixedHashMap<
           maximum_number_of_neighbors(dim),
-          std::pair<Direction<dim>, ElementId<dim>>, std::vector<double>,
+          std::pair<Direction<dim>, ElementId<dim>>, DataVector,
           boost::hash<std::pair<Direction<dim>, ElementId<dim>>>>&
           neighbor_data,
       const Mesh<dim>& subcell_mesh,

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/PositivityPreservingAdaptiveOrder.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/PositivityPreservingAdaptiveOrder.cpp
@@ -10,7 +10,6 @@
 #include <pup.h>
 #include <tuple>
 #include <utility>
-#include <vector>
 
 #include "DataStructures/DataBox/Prefixes.hpp"
 #include "DataStructures/DataVector.hpp"
@@ -107,10 +106,10 @@ void PositivityPreservingAdaptiveOrderPrim::reconstruct(
     const Variables<hydro::grmhd_tags<DataVector>>& volume_prims,
     const EquationsOfState::EquationOfState<true, ThermodynamicDim>& eos,
     const Element<3>& element,
-    const FixedHashMap<
-        maximum_number_of_neighbors(3), std::pair<Direction<3>, ElementId<3>>,
-        std::vector<double>,
-        boost::hash<std::pair<Direction<3>, ElementId<3>>>>& neighbor_data,
+    const FixedHashMap<maximum_number_of_neighbors(3),
+                       std::pair<Direction<3>, ElementId<3>>, DataVector,
+                       boost::hash<std::pair<Direction<3>, ElementId<3>>>>&
+        neighbor_data,
     const Mesh<3>& subcell_mesh) const {
   FixedHashMap<maximum_number_of_neighbors(dim),
                std::pair<Direction<dim>, ElementId<dim>>,
@@ -159,10 +158,10 @@ void PositivityPreservingAdaptiveOrderPrim::reconstruct_fd_neighbor(
     const Variables<hydro::grmhd_tags<DataVector>>& subcell_volume_prims,
     const EquationsOfState::EquationOfState<true, ThermodynamicDim>& eos,
     const Element<3>& element,
-    const FixedHashMap<
-        maximum_number_of_neighbors(3), std::pair<Direction<3>, ElementId<3>>,
-        std::vector<double>,
-        boost::hash<std::pair<Direction<3>, ElementId<3>>>>& neighbor_data,
+    const FixedHashMap<maximum_number_of_neighbors(3),
+                       std::pair<Direction<3>, ElementId<3>>, DataVector,
+                       boost::hash<std::pair<Direction<3>, ElementId<3>>>>&
+        neighbor_data,
     const Mesh<3>& subcell_mesh,
     const Direction<3> direction_to_reconstruct) const {
   reconstruct_fd_neighbor_work<positivity_preserving_tags,
@@ -289,10 +288,10 @@ bool operator!=(const PositivityPreservingAdaptiveOrderPrim& lhs,
       const Variables<hydro::grmhd_tags<DataVector>>& volume_prims,           \
       const EquationsOfState::EquationOfState<true, THERMO_DIM(data)>& eos,   \
       const Element<3>& element,                                              \
-      const FixedHashMap<                                                     \
-          maximum_number_of_neighbors(3),                                     \
-          std::pair<Direction<3>, ElementId<3>>, std::vector<double>,         \
-          boost::hash<std::pair<Direction<3>, ElementId<3>>>>& neighbor_data, \
+      const FixedHashMap<maximum_number_of_neighbors(3),                      \
+                         std::pair<Direction<3>, ElementId<3>>, DataVector,   \
+                         boost::hash<std::pair<Direction<3>, ElementId<3>>>>& \
+          neighbor_data,                                                      \
       const Mesh<3>& subcell_mesh) const;                                     \
   template void                                                               \
   PositivityPreservingAdaptiveOrderPrim::reconstruct_fd_neighbor(             \
@@ -300,10 +299,10 @@ bool operator!=(const PositivityPreservingAdaptiveOrderPrim& lhs,
       const Variables<hydro::grmhd_tags<DataVector>>& subcell_volume_prims,   \
       const EquationsOfState::EquationOfState<true, THERMO_DIM(data)>& eos,   \
       const Element<3>& element,                                              \
-      const FixedHashMap<                                                     \
-          maximum_number_of_neighbors(3),                                     \
-          std::pair<Direction<3>, ElementId<3>>, std::vector<double>,         \
-          boost::hash<std::pair<Direction<3>, ElementId<3>>>>& neighbor_data, \
+      const FixedHashMap<maximum_number_of_neighbors(3),                      \
+                         std::pair<Direction<3>, ElementId<3>>, DataVector,   \
+                         boost::hash<std::pair<Direction<3>, ElementId<3>>>>& \
+          neighbor_data,                                                      \
       const Mesh<3>& subcell_mesh,                                            \
       const Direction<3> direction_to_reconstruct) const;
 

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/PositivityPreservingAdaptiveOrder.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/PositivityPreservingAdaptiveOrder.hpp
@@ -8,7 +8,6 @@
 #include <limits>
 #include <memory>
 #include <utility>
-#include <vector>
 
 #include "DataStructures/FixedHashMap.hpp"
 #include "DataStructures/VariablesTag.hpp"
@@ -162,7 +161,7 @@ class PositivityPreservingAdaptiveOrderPrim : public Reconstructor {
       const Element<dim>& element,
       const FixedHashMap<
           maximum_number_of_neighbors(dim),
-          std::pair<Direction<dim>, ElementId<dim>>, std::vector<double>,
+          std::pair<Direction<dim>, ElementId<dim>>, DataVector,
           boost::hash<std::pair<Direction<dim>, ElementId<dim>>>>&
           neighbor_data,
       const Mesh<dim>& subcell_mesh) const;
@@ -175,7 +174,7 @@ class PositivityPreservingAdaptiveOrderPrim : public Reconstructor {
       const Element<dim>& element,
       const FixedHashMap<
           maximum_number_of_neighbors(dim),
-          std::pair<Direction<dim>, ElementId<dim>>, std::vector<double>,
+          std::pair<Direction<dim>, ElementId<dim>>, DataVector,
           boost::hash<std::pair<Direction<dim>, ElementId<dim>>>>&
           neighbor_data,
       const Mesh<dim>& subcell_mesh,

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/ReconstructWork.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/ReconstructWork.hpp
@@ -7,13 +7,13 @@
 #include <boost/functional/hash.hpp>
 #include <cstddef>
 #include <utility>
-#include <vector>
 
 #include "DataStructures/FixedHashMap.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Domain/Structure/MaxNumberOfNeighbors.hpp"
 
 /// \cond
+class DataVector;
 template <typename TagsList>
 class Variables;
 namespace gsl {
@@ -87,10 +87,10 @@ void reconstruct_fd_neighbor_work(
     const Variables<PrimsTags>& subcell_volume_prims,
     const EquationsOfState::EquationOfState<true, ThermodynamicDim>& eos,
     const Element<3>& element,
-    const FixedHashMap<
-        maximum_number_of_neighbors(3), std::pair<Direction<3>, ElementId<3>>,
-        std::vector<double>,
-        boost::hash<std::pair<Direction<3>, ElementId<3>>>>& neighbor_data,
+    const FixedHashMap<maximum_number_of_neighbors(3),
+                       std::pair<Direction<3>, ElementId<3>>, DataVector,
+                       boost::hash<std::pair<Direction<3>, ElementId<3>>>>&
+        neighbor_data,
     const Mesh<3>& subcell_mesh, const Direction<3>& direction_to_reconstruct,
     const size_t ghost_zone_size, bool compute_conservatives);
 }  // namespace grmhd::ValenciaDivClean::fd

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/ReconstructWork.tpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/ReconstructWork.tpp
@@ -9,7 +9,6 @@
 #include <cstddef>
 #include <iterator>
 #include <utility>
-#include <vector>
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/FixedHashMap.hpp"
@@ -232,7 +231,7 @@ void reconstruct_fd_neighbor_work(
     const Element<3>& element,
     const FixedHashMap<
         maximum_number_of_neighbors(3), std::pair<Direction<3>, ElementId<3>>,
-        std::vector<double>,
+        DataVector,
         boost::hash<std::pair<Direction<3>, ElementId<3>>>>& neighbor_data,
     const Mesh<3>& subcell_mesh, const Direction<3>& direction_to_reconstruct,
     const size_t ghost_zone_size, const bool compute_conservatives) {

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/Wcns5z.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/Wcns5z.cpp
@@ -10,7 +10,6 @@
 #include <pup.h>
 #include <tuple>
 #include <utility>
-#include <vector>
 
 #include "DataStructures/DataBox/Prefixes.hpp"
 #include "DataStructures/DataVector.hpp"
@@ -83,10 +82,10 @@ void Wcns5zPrim::reconstruct(
     const Variables<hydro::grmhd_tags<DataVector>>& volume_prims,
     const EquationsOfState::EquationOfState<true, ThermodynamicDim>& eos,
     const Element<3>& element,
-    const FixedHashMap<
-        maximum_number_of_neighbors(3), std::pair<Direction<3>, ElementId<3>>,
-        std::vector<double>,
-        boost::hash<std::pair<Direction<3>, ElementId<3>>>>& neighbor_data,
+    const FixedHashMap<maximum_number_of_neighbors(3),
+                       std::pair<Direction<3>, ElementId<3>>, DataVector,
+                       boost::hash<std::pair<Direction<3>, ElementId<3>>>>&
+        neighbor_data,
     const Mesh<3>& subcell_mesh) const {
   FixedHashMap<maximum_number_of_neighbors(dim),
                std::pair<Direction<dim>, ElementId<dim>>,
@@ -116,10 +115,10 @@ void Wcns5zPrim::reconstruct_fd_neighbor(
     const Variables<hydro::grmhd_tags<DataVector>>& subcell_volume_prims,
     const EquationsOfState::EquationOfState<true, ThermodynamicDim>& eos,
     const Element<3>& element,
-    const FixedHashMap<
-        maximum_number_of_neighbors(3), std::pair<Direction<3>, ElementId<3>>,
-        std::vector<double>,
-        boost::hash<std::pair<Direction<3>, ElementId<3>>>>& neighbor_data,
+    const FixedHashMap<maximum_number_of_neighbors(3),
+                       std::pair<Direction<3>, ElementId<3>>, DataVector,
+                       boost::hash<std::pair<Direction<3>, ElementId<3>>>>&
+        neighbor_data,
     const Mesh<3>& subcell_mesh,
     const Direction<3> direction_to_reconstruct) const {
   reconstruct_fd_neighbor_work<prims_to_reconstruct_tags,
@@ -202,20 +201,20 @@ bool operator!=(const Wcns5zPrim& lhs, const Wcns5zPrim& rhs) {
       const Variables<hydro::grmhd_tags<DataVector>>& volume_prims,           \
       const EquationsOfState::EquationOfState<true, THERMO_DIM(data)>& eos,   \
       const Element<3>& element,                                              \
-      const FixedHashMap<                                                     \
-          maximum_number_of_neighbors(3),                                     \
-          std::pair<Direction<3>, ElementId<3>>, std::vector<double>,         \
-          boost::hash<std::pair<Direction<3>, ElementId<3>>>>& neighbor_data, \
+      const FixedHashMap<maximum_number_of_neighbors(3),                      \
+                         std::pair<Direction<3>, ElementId<3>>, DataVector,   \
+                         boost::hash<std::pair<Direction<3>, ElementId<3>>>>& \
+          neighbor_data,                                                      \
       const Mesh<3>& subcell_mesh) const;                                     \
   template void Wcns5zPrim::reconstruct_fd_neighbor(                          \
       gsl::not_null<Variables<TAGS_LIST(data)>*> vars_on_face,                \
       const Variables<hydro::grmhd_tags<DataVector>>& subcell_volume_prims,   \
       const EquationsOfState::EquationOfState<true, THERMO_DIM(data)>& eos,   \
       const Element<3>& element,                                              \
-      const FixedHashMap<                                                     \
-          maximum_number_of_neighbors(3),                                     \
-          std::pair<Direction<3>, ElementId<3>>, std::vector<double>,         \
-          boost::hash<std::pair<Direction<3>, ElementId<3>>>>& neighbor_data, \
+      const FixedHashMap<maximum_number_of_neighbors(3),                      \
+                         std::pair<Direction<3>, ElementId<3>>, DataVector,   \
+                         boost::hash<std::pair<Direction<3>, ElementId<3>>>>& \
+          neighbor_data,                                                      \
       const Mesh<3>& subcell_mesh,                                            \
       const Direction<3> direction_to_reconstruct) const;
 

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/Wcns5z.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/Wcns5z.hpp
@@ -8,7 +8,6 @@
 #include <limits>
 #include <memory>
 #include <utility>
-#include <vector>
 
 #include "DataStructures/FixedHashMap.hpp"
 #include "DataStructures/VariablesTag.hpp"
@@ -138,7 +137,7 @@ class Wcns5zPrim : public Reconstructor {
       const Element<dim>& element,
       const FixedHashMap<
           maximum_number_of_neighbors(dim),
-          std::pair<Direction<dim>, ElementId<dim>>, std::vector<double>,
+          std::pair<Direction<dim>, ElementId<dim>>, DataVector,
           boost::hash<std::pair<Direction<dim>, ElementId<dim>>>>&
           neighbor_data,
       const Mesh<dim>& subcell_mesh) const;
@@ -151,7 +150,7 @@ class Wcns5zPrim : public Reconstructor {
       const Element<dim>& element,
       const FixedHashMap<
           maximum_number_of_neighbors(dim),
-          std::pair<Direction<dim>, ElementId<dim>>, std::vector<double>,
+          std::pair<Direction<dim>, ElementId<dim>>, DataVector,
           boost::hash<std::pair<Direction<dim>, ElementId<dim>>>>&
           neighbor_data,
       const Mesh<dim>& subcell_mesh,

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/InitialDataTci.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/InitialDataTci.cpp
@@ -30,12 +30,12 @@ std::tuple<int, evolution::dg::subcell::RdmpTciData> initial_data_tci_work(
   evolution::dg::subcell::RdmpTciData rdmp_tci_data{};
   using std::max;
   using std::min;
-  rdmp_tci_data.max_variables_values = std::vector<double>{
+  rdmp_tci_data.max_variables_values = DataVector{
       max(max(get(dg_tilde_d)), max(get(subcell_tilde_d))),
       max(max(get(dg_tilde_ye)), max(get(subcell_tilde_ye))),
       max(max(get(dg_tilde_tau)), max(get(subcell_tilde_tau))),
       max(max(get(dg_tilde_b_magnitude)), max(get(subcell_tilde_b_magnitude)))};
-  rdmp_tci_data.min_variables_values = std::vector<double>{
+  rdmp_tci_data.min_variables_values = DataVector{
       min(min(get(dg_tilde_d)), min(get(subcell_tilde_d))),
       min(min(get(dg_tilde_ye)), min(get(subcell_tilde_ye))),
       min(min(get(dg_tilde_tau)), min(get(subcell_tilde_tau))),
@@ -122,10 +122,10 @@ void SetInitialRdmpData::apply(
     const Scalar<DataVector> subcell_tilde_b_magnitude =
         magnitude(subcell_tilde_b);
 
-    rdmp_tci_data->max_variables_values = std::vector<double>{
+    rdmp_tci_data->max_variables_values = DataVector{
         max(get(subcell_tilde_d)), max(get(subcell_tilde_ye)),
         max(get(subcell_tilde_tau)), max(get(subcell_tilde_b_magnitude))};
-    rdmp_tci_data->min_variables_values = std::vector<double>{
+    rdmp_tci_data->min_variables_values = DataVector{
         min(get(subcell_tilde_d)), min(get(subcell_tilde_ye)),
         min(get(subcell_tilde_tau)), min(get(subcell_tilde_b_magnitude))};
   }

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TciOnDgGrid.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TciOnDgGrid.cpp
@@ -92,15 +92,15 @@ TciOnDgGrid<RecoveryScheme>::apply(
   const double max_mag_tilde_b = max(get(mag_tilde_b));
 
   rdmp_tci_data.max_variables_values =
-      std::vector{max(max(get(subcell_tilde_d)), max(get(tilde_d))),
-                  max(max(get(subcell_tilde_ye)), max(get(tilde_ye))),
-                  max(max(get(subcell_tilde_tau)), max(get(tilde_tau))),
-                  max(max(get(subcell_mag_tilde_b)), max_mag_tilde_b)};
+      DataVector{max(max(get(subcell_tilde_d)), max(get(tilde_d))),
+                 max(max(get(subcell_tilde_ye)), max(get(tilde_ye))),
+                 max(max(get(subcell_tilde_tau)), max(get(tilde_tau))),
+                 max(max(get(subcell_mag_tilde_b)), max_mag_tilde_b)};
   rdmp_tci_data.min_variables_values =
-      std::vector{min(min(get(subcell_tilde_d)), min(get(tilde_d))),
-                  min(min(get(subcell_tilde_ye)), min(get(tilde_ye))),
-                  min(min(get(subcell_tilde_tau)), min(get(tilde_tau))),
-                  min(min(get(subcell_mag_tilde_b)), min(get(mag_tilde_b)))};
+      DataVector{min(min(get(subcell_tilde_d)), min(get(tilde_d))),
+                 min(min(get(subcell_tilde_ye)), min(get(tilde_ye))),
+                 min(min(get(subcell_tilde_tau)), min(get(tilde_tau))),
+                 min(min(get(subcell_mag_tilde_b)), min(get(mag_tilde_b)))};
 
   const double average_sqrt_det_spatial_metric =
       l1Norm(get(sqrt_det_spatial_metric));

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TciOnFdGrid.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TciOnFdGrid.cpp
@@ -48,11 +48,11 @@ std::tuple<int, evolution::dg::subcell::RdmpTciData> TciOnFdGrid::apply(
 
   evolution::dg::subcell::RdmpTciData rdmp_tci_data{};
   rdmp_tci_data.max_variables_values =
-      std::vector{max(get(subcell_tilde_d)), max(get(subcell_tilde_ye)),
-                  max(get(subcell_tilde_tau)), max(get(subcell_mag_tilde_b))};
+      DataVector{max(get(subcell_tilde_d)), max(get(subcell_tilde_ye)),
+                 max(get(subcell_tilde_tau)), max(get(subcell_mag_tilde_b))};
   rdmp_tci_data.min_variables_values =
-      std::vector{min(get(subcell_tilde_d)), min(get(subcell_tilde_ye)),
-                  min(get(subcell_tilde_tau)), min(get(subcell_mag_tilde_b))};
+      DataVector{min(get(subcell_tilde_d)), min(get(subcell_tilde_ye)),
+                 min(get(subcell_tilde_tau)), min(get(subcell_mag_tilde_b))};
 
   if (need_rdmp_data_only) {
     return {false, rdmp_tci_data};
@@ -128,12 +128,12 @@ std::tuple<int, evolution::dg::subcell::RdmpTciData> TciOnFdGrid::apply(
   using std::max;
   using std::min;
   evolution::dg::subcell::RdmpTciData rdmp_tci_data_for_check{};
-  rdmp_tci_data_for_check.max_variables_values = std::vector{
+  rdmp_tci_data_for_check.max_variables_values = DataVector{
       max(max(get(dg_tilde_d)), rdmp_tci_data.max_variables_values[0]),
       max(max(get(dg_tilde_ye)), rdmp_tci_data.max_variables_values[1]),
       max(max(get(dg_tilde_tau)), rdmp_tci_data.max_variables_values[2]),
       max(max(get(dg_mag_tilde_b)), rdmp_tci_data.max_variables_values[3])};
-  rdmp_tci_data_for_check.min_variables_values = std::vector{
+  rdmp_tci_data_for_check.min_variables_values = DataVector{
       min(min(get(dg_tilde_d)), rdmp_tci_data.min_variables_values[0]),
       min(min(get(dg_tilde_ye)), rdmp_tci_data.min_variables_values[1]),
       min(min(get(dg_tilde_tau)), rdmp_tci_data.min_variables_values[2]),

--- a/src/Evolution/Systems/NewtonianEuler/FiniteDifference/AoWeno.cpp
+++ b/src/Evolution/Systems/NewtonianEuler/FiniteDifference/AoWeno.cpp
@@ -6,7 +6,6 @@
 #include <array>
 #include <cstddef>
 #include <utility>
-#include <vector>
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/FixedHashMap.hpp"
@@ -80,10 +79,10 @@ void AoWeno53Prim<Dim>::reconstruct(
     const Variables<prims_tags>& volume_prims,
     const EquationsOfState::EquationOfState<false, ThermodynamicDim>& eos,
     const Element<Dim>& element,
-    const FixedHashMap<
-        maximum_number_of_neighbors(Dim),
-        std::pair<Direction<Dim>, ElementId<Dim>>, std::vector<double>,
-        boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>& neighbor_data,
+    const FixedHashMap<maximum_number_of_neighbors(Dim),
+                       std::pair<Direction<Dim>, ElementId<Dim>>, DataVector,
+                       boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>&
+        neighbor_data,
     const Mesh<Dim>& subcell_mesh) const {
   reconstruct_prims_work(
       vars_on_lower_face, vars_on_upper_face,
@@ -105,10 +104,10 @@ void AoWeno53Prim<Dim>::reconstruct_fd_neighbor(
     const Variables<prims_tags>& subcell_volume_prims,
     const EquationsOfState::EquationOfState<false, ThermodynamicDim>& eos,
     const Element<Dim>& element,
-    const FixedHashMap<
-        maximum_number_of_neighbors(Dim),
-        std::pair<Direction<Dim>, ElementId<Dim>>, std::vector<double>,
-        boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>& neighbor_data,
+    const FixedHashMap<maximum_number_of_neighbors(Dim),
+                       std::pair<Direction<Dim>, ElementId<Dim>>, DataVector,
+                       boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>&
+        neighbor_data,
     const Mesh<Dim>& subcell_mesh,
     const Direction<Dim> direction_to_reconstruct) const {
   reconstruct_fd_neighbor_work(
@@ -181,8 +180,7 @@ GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
       const Element<DIM(data)>& element,                                       \
       const FixedHashMap<                                                      \
           maximum_number_of_neighbors(DIM(data)),                              \
-          std::pair<Direction<DIM(data)>, ElementId<DIM(data)>>,               \
-          std::vector<double>,                                                 \
+          std::pair<Direction<DIM(data)>, ElementId<DIM(data)>>, DataVector,   \
           boost::hash<std::pair<Direction<DIM(data)>, ElementId<DIM(data)>>>>& \
           neighbor_data,                                                       \
       const Mesh<DIM(data)>& subcell_mesh) const;                              \
@@ -193,8 +191,7 @@ GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
       const Element<DIM(data)>& element,                                       \
       const FixedHashMap<                                                      \
           maximum_number_of_neighbors(DIM(data)),                              \
-          std::pair<Direction<DIM(data)>, ElementId<DIM(data)>>,               \
-          std::vector<double>,                                                 \
+          std::pair<Direction<DIM(data)>, ElementId<DIM(data)>>, DataVector,   \
           boost::hash<std::pair<Direction<DIM(data)>, ElementId<DIM(data)>>>>& \
           neighbor_data,                                                       \
       const Mesh<DIM(data)>& subcell_mesh,                                     \

--- a/src/Evolution/Systems/NewtonianEuler/FiniteDifference/AoWeno.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/FiniteDifference/AoWeno.hpp
@@ -8,10 +8,10 @@
 #include <cstddef>
 #include <limits>
 #include <memory>
-#include <vector>
 
 #include "DataStructures/DataBox/PrefixHelpers.hpp"
 #include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataVector.hpp"
 #include "DataStructures/FixedHashMap.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Domain/Structure/MaxNumberOfNeighbors.hpp"
@@ -115,7 +115,7 @@ class AoWeno53Prim : public Reconstructor<Dim> {
       const Element<Dim>& element,
       const FixedHashMap<
           maximum_number_of_neighbors(Dim),
-          std::pair<Direction<Dim>, ElementId<Dim>>, std::vector<double>,
+          std::pair<Direction<Dim>, ElementId<Dim>>, DataVector,
           boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>&
           neighbor_data,
       const Mesh<Dim>& subcell_mesh) const;
@@ -129,7 +129,7 @@ class AoWeno53Prim : public Reconstructor<Dim> {
       const Element<Dim>& element,
       const FixedHashMap<
           maximum_number_of_neighbors(Dim),
-          std::pair<Direction<Dim>, ElementId<Dim>>, std::vector<double>,
+          std::pair<Direction<Dim>, ElementId<Dim>>, DataVector,
           boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>&
           neighbor_data,
       const Mesh<Dim>& subcell_mesh,

--- a/src/Evolution/Systems/NewtonianEuler/FiniteDifference/MonotonisedCentral.cpp
+++ b/src/Evolution/Systems/NewtonianEuler/FiniteDifference/MonotonisedCentral.cpp
@@ -6,7 +6,6 @@
 #include <array>
 #include <cstddef>
 #include <utility>
-#include <vector>
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/FixedHashMap.hpp"
@@ -55,10 +54,10 @@ void MonotonisedCentralPrim<Dim>::reconstruct(
     const Variables<prims_tags>& volume_prims,
     const EquationsOfState::EquationOfState<false, ThermodynamicDim>& eos,
     const Element<Dim>& element,
-    const FixedHashMap<
-        maximum_number_of_neighbors(Dim),
-        std::pair<Direction<Dim>, ElementId<Dim>>, std::vector<double>,
-        boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>& neighbor_data,
+    const FixedHashMap<maximum_number_of_neighbors(Dim),
+                       std::pair<Direction<Dim>, ElementId<Dim>>, DataVector,
+                       boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>&
+        neighbor_data,
     const Mesh<Dim>& subcell_mesh) const {
   reconstruct_prims_work(
       vars_on_lower_face, vars_on_upper_face,
@@ -80,10 +79,10 @@ void MonotonisedCentralPrim<Dim>::reconstruct_fd_neighbor(
     const Variables<prims_tags>& subcell_volume_prims,
     const EquationsOfState::EquationOfState<false, ThermodynamicDim>& eos,
     const Element<Dim>& element,
-    const FixedHashMap<
-        maximum_number_of_neighbors(Dim),
-        std::pair<Direction<Dim>, ElementId<Dim>>, std::vector<double>,
-        boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>& neighbor_data,
+    const FixedHashMap<maximum_number_of_neighbors(Dim),
+                       std::pair<Direction<Dim>, ElementId<Dim>>, DataVector,
+                       boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>&
+        neighbor_data,
     const Mesh<Dim>& subcell_mesh,
     const Direction<Dim> direction_to_reconstruct) const {
   reconstruct_fd_neighbor_work(
@@ -148,8 +147,7 @@ GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
       const Element<DIM(data)>& element,                                       \
       const FixedHashMap<                                                      \
           maximum_number_of_neighbors(DIM(data)),                              \
-          std::pair<Direction<DIM(data)>, ElementId<DIM(data)>>,               \
-          std::vector<double>,                                                 \
+          std::pair<Direction<DIM(data)>, ElementId<DIM(data)>>, DataVector,   \
           boost::hash<std::pair<Direction<DIM(data)>, ElementId<DIM(data)>>>>& \
           neighbor_data,                                                       \
       const Mesh<DIM(data)>& subcell_mesh) const;                              \
@@ -160,8 +158,7 @@ GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
       const Element<DIM(data)>& element,                                       \
       const FixedHashMap<                                                      \
           maximum_number_of_neighbors(DIM(data)),                              \
-          std::pair<Direction<DIM(data)>, ElementId<DIM(data)>>,               \
-          std::vector<double>,                                                 \
+          std::pair<Direction<DIM(data)>, ElementId<DIM(data)>>, DataVector,   \
           boost::hash<std::pair<Direction<DIM(data)>, ElementId<DIM(data)>>>>& \
           neighbor_data,                                                       \
       const Mesh<DIM(data)>& subcell_mesh,                                     \

--- a/src/Evolution/Systems/NewtonianEuler/FiniteDifference/MonotonisedCentral.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/FiniteDifference/MonotonisedCentral.hpp
@@ -6,7 +6,6 @@
 #include <array>
 #include <cstddef>
 #include <utility>
-#include <vector>
 
 #include "DataStructures/DataBox/PrefixHelpers.hpp"
 #include "DataStructures/DataBox/Prefixes.hpp"
@@ -24,6 +23,7 @@
 #include "Utilities/TMPL.hpp"
 
 /// \cond
+class DataVector;
 template <size_t Dim>
 class Direction;
 template <size_t Dim>
@@ -110,7 +110,7 @@ class MonotonisedCentralPrim : public Reconstructor<Dim> {
       const Element<Dim>& element,
       const FixedHashMap<
           maximum_number_of_neighbors(Dim),
-          std::pair<Direction<Dim>, ElementId<Dim>>, std::vector<double>,
+          std::pair<Direction<Dim>, ElementId<Dim>>, DataVector,
           boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>&
           neighbor_data,
       const Mesh<Dim>& subcell_mesh) const;
@@ -129,7 +129,7 @@ class MonotonisedCentralPrim : public Reconstructor<Dim> {
       const Element<Dim>& element,
       const FixedHashMap<
           maximum_number_of_neighbors(Dim),
-          std::pair<Direction<Dim>, ElementId<Dim>>, std::vector<double>,
+          std::pair<Direction<Dim>, ElementId<Dim>>, DataVector,
           boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>&
           neighbor_data,
       const Mesh<Dim>& subcell_mesh,

--- a/src/Evolution/Systems/NewtonianEuler/FiniteDifference/ReconstructWork.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/FiniteDifference/ReconstructWork.hpp
@@ -7,12 +7,12 @@
 #include <boost/functional/hash.hpp>
 #include <cstddef>
 #include <utility>
-#include <vector>
 
 #include "DataStructures/FixedHashMap.hpp"
 #include "Domain/Structure/MaxNumberOfNeighbors.hpp"
 
 /// \cond
+class DataVector;
 template <typename TagsList>
 class Variables;
 namespace gsl {
@@ -47,10 +47,10 @@ void reconstruct_prims_work(
     const F& reconstruct, const Variables<PrimsTags>& volume_prims,
     const EquationsOfState::EquationOfState<false, ThermodynamicDim>& eos,
     const Element<Dim>& element,
-    const FixedHashMap<
-        maximum_number_of_neighbors(Dim),
-        std::pair<Direction<Dim>, ElementId<Dim>>, std::vector<double>,
-        boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>& neighbor_data,
+    const FixedHashMap<maximum_number_of_neighbors(Dim),
+                       std::pair<Direction<Dim>, ElementId<Dim>>, DataVector,
+                       boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>&
+        neighbor_data,
     const Mesh<Dim>& subcell_mesh, size_t ghost_zone_size);
 
 /*!
@@ -69,10 +69,10 @@ void reconstruct_fd_neighbor_work(
     const Variables<PrimsTags>& subcell_volume_prims,
     const EquationsOfState::EquationOfState<false, ThermodynamicDim>& eos,
     const Element<Dim>& element,
-    const FixedHashMap<
-        maximum_number_of_neighbors(Dim),
-        std::pair<Direction<Dim>, ElementId<Dim>>, std::vector<double>,
-        boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>& neighbor_data,
+    const FixedHashMap<maximum_number_of_neighbors(Dim),
+                       std::pair<Direction<Dim>, ElementId<Dim>>, DataVector,
+                       boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>&
+        neighbor_data,
     const Mesh<Dim>& subcell_mesh,
     const Direction<Dim>& direction_to_reconstruct, size_t ghost_zone_size);
 }  // namespace NewtonianEuler::fd

--- a/src/Evolution/Systems/NewtonianEuler/FiniteDifference/ReconstructWork.tpp
+++ b/src/Evolution/Systems/NewtonianEuler/FiniteDifference/ReconstructWork.tpp
@@ -7,7 +7,6 @@
 #include <boost/functional/hash.hpp>
 #include <cstddef>
 #include <utility>
-#include <vector>
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/FixedHashMap.hpp"
@@ -39,7 +38,7 @@ void reconstruct_prims_work(
     const Element<Dim>& element,
     const FixedHashMap<
         maximum_number_of_neighbors(Dim),
-        std::pair<Direction<Dim>, ElementId<Dim>>, std::vector<double>,
+        std::pair<Direction<Dim>, ElementId<Dim>>, DataVector,
         boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>& neighbor_data,
     const Mesh<Dim>& subcell_mesh, const size_t ghost_zone_size) {
   // Conservative vars tags
@@ -98,9 +97,9 @@ void reconstruct_prims_work(
                      << neighbors_in_direction.size() << " in direction "
                      << direction);
           ASSERT(
-              not neighbor_data
+              neighbor_data
                       .at(std::pair{direction, *neighbors_in_direction.begin()})
-                      .empty(),
+                      .size() != 0,
               "The neighber data is empty in direction "
                   << direction << " on element id " << element.id());
           ghost_cell_vars[direction] = gsl::make_span(
@@ -167,7 +166,7 @@ void reconstruct_fd_neighbor_work(
     const Element<Dim>& element,
     const FixedHashMap<
         maximum_number_of_neighbors(Dim),
-        std::pair<Direction<Dim>, ElementId<Dim>>, std::vector<double>,
+        std::pair<Direction<Dim>, ElementId<Dim>>, DataVector,
         boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>& neighbor_data,
     const Mesh<Dim>& subcell_mesh,
     const Direction<Dim>& direction_to_reconstruct,

--- a/src/Evolution/Systems/NewtonianEuler/Subcell/NeighborPackagedData.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/Subcell/NeighborPackagedData.hpp
@@ -68,15 +68,13 @@ namespace NewtonianEuler::subcell {
 struct NeighborPackagedData {
   template <size_t Dim, typename DbTagsList>
   static FixedHashMap<maximum_number_of_neighbors(Dim),
-                      std::pair<Direction<Dim>, ElementId<Dim>>,
-                      std::vector<double>,
+                      std::pair<Direction<Dim>, ElementId<Dim>>, DataVector,
                       boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>
   apply(const db::DataBox<DbTagsList>& box,
         const std::vector<std::pair<Direction<Dim>, ElementId<Dim>>>&
             mortars_to_reconstruct_to) {
-    using system =
-        typename std::decay_t<decltype(db::get<Parallel::Tags::Metavariables>(
-            box))>::system;
+    using system = typename std::decay_t<decltype(
+        db::get<Parallel::Tags::Metavariables>(box))>::system;
     using evolved_vars_tag = typename system::variables_tag;
     using evolved_vars_tags = typename evolved_vars_tag::tags_list;
     using prim_tags = typename system::primitive_variables_tag::tags_list;
@@ -90,7 +88,7 @@ struct NeighborPackagedData {
            "re-slicing/projecting.");
 
     FixedHashMap<maximum_number_of_neighbors(Dim),
-                 std::pair<Direction<Dim>, ElementId<Dim>>, std::vector<double>,
+                 std::pair<Direction<Dim>, ElementId<Dim>>, DataVector,
                  boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>
         neighbor_package_data{};
     if (mortars_to_reconstruct_to.empty()) {
@@ -203,9 +201,12 @@ struct NeighborPackagedData {
           if constexpr (Dim == 1) {
             (void)dg_mesh;
             (void)subcell_options;
-            neighbor_package_data[mortar_id] = std::vector<double>{
-                packaged_data.data(),
-                packaged_data.data() + packaged_data.size()};
+            // Make a view so we can use iterators with std::copy
+            DataVector packaged_data_view{packaged_data.data(),
+                                          packaged_data.size()};
+            neighbor_package_data[mortar_id] = DataVector{packaged_data.size()};
+            std::copy(packaged_data_view.begin(), packaged_data_view.end(),
+                      neighbor_package_data[mortar_id].begin());
           } else {
             // Reconstruct the DG solution.
             // Really we should be solving the boundary correction and
@@ -215,9 +216,14 @@ struct NeighborPackagedData {
                 packaged_data, dg_mesh.slice_away(mortar_id.first.dimension()),
                 subcell_mesh.extents().slice_away(mortar_id.first.dimension()),
                 subcell_options.reconstruction_method());
-            neighbor_package_data[mortar_id] = std::vector<double>{
-                dg_packaged_data.data(),
-                dg_packaged_data.data() + dg_packaged_data.size()};
+            // Make a view so we can use iterators with std::copy
+            DataVector dg_packaged_data_view{dg_packaged_data.data(),
+                                             dg_packaged_data.size()};
+            neighbor_package_data[mortar_id] =
+                DataVector{dg_packaged_data.size()};
+            std::copy(dg_packaged_data_view.begin(),
+                      dg_packaged_data_view.end(),
+                      neighbor_package_data[mortar_id].begin());
           }
         }
       }

--- a/src/Evolution/Systems/ScalarAdvection/FiniteDifference/AoWeno.cpp
+++ b/src/Evolution/Systems/ScalarAdvection/FiniteDifference/AoWeno.cpp
@@ -10,9 +10,9 @@
 #include <pup.h>
 #include <tuple>
 #include <utility>
-#include <vector>
 
 #include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataVector.hpp"
 #include "DataStructures/FixedHashMap.hpp"
 #include "DataStructures/Index.hpp"
 #include "DataStructures/Tensor/IndexType.hpp"
@@ -82,10 +82,10 @@ void AoWeno53<Dim>::reconstruct(
         vars_on_upper_face,
     const Variables<tmpl::list<Tags::U>>& volume_vars,
     const Element<Dim>& element,
-    const FixedHashMap<
-        maximum_number_of_neighbors(Dim),
-        std::pair<Direction<Dim>, ElementId<Dim>>, std::vector<double>,
-        boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>& neighbor_data,
+    const FixedHashMap<maximum_number_of_neighbors(Dim),
+                       std::pair<Direction<Dim>, ElementId<Dim>>, DataVector,
+                       boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>&
+        neighbor_data,
     const Mesh<Dim>& subcell_mesh) const {
   reconstruct_work(
       vars_on_lower_face, vars_on_upper_face,
@@ -105,10 +105,10 @@ void AoWeno53<Dim>::reconstruct_fd_neighbor(
     const gsl::not_null<Variables<TagsList>*> vars_on_face,
     const Variables<tmpl::list<Tags::U>>& volume_vars,
     const Element<Dim>& element,
-    const FixedHashMap<
-        maximum_number_of_neighbors(Dim),
-        std::pair<Direction<Dim>, ElementId<Dim>>, std::vector<double>,
-        boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>& neighbor_data,
+    const FixedHashMap<maximum_number_of_neighbors(Dim),
+                       std::pair<Direction<Dim>, ElementId<Dim>>, DataVector,
+                       boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>&
+        neighbor_data,
     const Mesh<Dim>& subcell_mesh,
     const Direction<Dim> direction_to_reconstruct) const {
   reconstruct_fd_neighbor_work(
@@ -177,8 +177,7 @@ GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2))
       const Element<DIM(data)>& element,                                       \
       const FixedHashMap<                                                      \
           maximum_number_of_neighbors(DIM(data)),                              \
-          std::pair<Direction<DIM(data)>, ElementId<DIM(data)>>,               \
-          std::vector<double>,                                                 \
+          std::pair<Direction<DIM(data)>, ElementId<DIM(data)>>, DataVector,   \
           boost::hash<std::pair<Direction<DIM(data)>, ElementId<DIM(data)>>>>& \
           neighbor_data,                                                       \
       const Mesh<DIM(data)>& subcell_mesh) const;                              \
@@ -188,8 +187,7 @@ GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2))
       const Element<DIM(data)>& element,                                       \
       const FixedHashMap<                                                      \
           maximum_number_of_neighbors(DIM(data)),                              \
-          std::pair<Direction<DIM(data)>, ElementId<DIM(data)>>,               \
-          std::vector<double>,                                                 \
+          std::pair<Direction<DIM(data)>, ElementId<DIM(data)>>, DataVector,   \
           boost::hash<std::pair<Direction<DIM(data)>, ElementId<DIM(data)>>>>& \
           neighbor_data,                                                       \
       const Mesh<DIM(data)>& subcell_mesh,                                     \

--- a/src/Evolution/Systems/ScalarAdvection/FiniteDifference/AoWeno.hpp
+++ b/src/Evolution/Systems/ScalarAdvection/FiniteDifference/AoWeno.hpp
@@ -9,7 +9,6 @@
 #include <limits>
 #include <memory>
 #include <utility>
-#include <vector>
 
 #include "DataStructures/DataBox/Prefixes.hpp"
 #include "DataStructures/FixedHashMap.hpp"
@@ -24,6 +23,7 @@
 #include "Utilities/TMPL.hpp"
 
 /// \cond
+class DataVector;
 template <size_t Dim>
 class Direction;
 template <size_t Dim>
@@ -121,7 +121,7 @@ class AoWeno53 : public Reconstructor<Dim> {
       const Element<Dim>& element,
       const FixedHashMap<
           maximum_number_of_neighbors(Dim),
-          std::pair<Direction<Dim>, ElementId<Dim>>, std::vector<double>,
+          std::pair<Direction<Dim>, ElementId<Dim>>, DataVector,
           boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>&
           neighbor_data,
       const Mesh<Dim>& subcell_mesh) const;
@@ -133,7 +133,7 @@ class AoWeno53 : public Reconstructor<Dim> {
       const Element<Dim>& element,
       const FixedHashMap<
           maximum_number_of_neighbors(Dim),
-          std::pair<Direction<Dim>, ElementId<Dim>>, std::vector<double>,
+          std::pair<Direction<Dim>, ElementId<Dim>>, DataVector,
           boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>&
           neighbor_data,
       const Mesh<Dim>& subcell_mesh,

--- a/src/Evolution/Systems/ScalarAdvection/FiniteDifference/MonotonisedCentral.cpp
+++ b/src/Evolution/Systems/ScalarAdvection/FiniteDifference/MonotonisedCentral.cpp
@@ -9,7 +9,6 @@
 #include <memory>
 #include <pup.h>
 #include <utility>
-#include <vector>
 
 #include "DataStructures/DataBox/Prefixes.hpp"
 #include "DataStructures/FixedHashMap.hpp"
@@ -57,10 +56,10 @@ void MonotonisedCentral<Dim>::reconstruct(
         vars_on_upper_face,
     const Variables<tmpl::list<Tags::U>>& volume_vars,
     const Element<Dim>& element,
-    const FixedHashMap<
-        maximum_number_of_neighbors(Dim),
-        std::pair<Direction<Dim>, ElementId<Dim>>, std::vector<double>,
-        boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>& neighbor_data,
+    const FixedHashMap<maximum_number_of_neighbors(Dim),
+                       std::pair<Direction<Dim>, ElementId<Dim>>, DataVector,
+                       boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>&
+        neighbor_data,
     const Mesh<Dim>& subcell_mesh) const {
   reconstruct_work(
       vars_on_lower_face, vars_on_upper_face,
@@ -80,10 +79,10 @@ void MonotonisedCentral<Dim>::reconstruct_fd_neighbor(
     const gsl::not_null<Variables<TagsList>*> vars_on_face,
     const Variables<tmpl::list<Tags::U>>& volume_vars,
     const Element<Dim>& element,
-    const FixedHashMap<
-        maximum_number_of_neighbors(Dim),
-        std::pair<Direction<Dim>, ElementId<Dim>>, std::vector<double>,
-        boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>& neighbor_data,
+    const FixedHashMap<maximum_number_of_neighbors(Dim),
+                       std::pair<Direction<Dim>, ElementId<Dim>>, DataVector,
+                       boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>&
+        neighbor_data,
     const Mesh<Dim>& subcell_mesh,
     const Direction<Dim> direction_to_reconstruct) const {
   reconstruct_fd_neighbor_work(
@@ -156,8 +155,7 @@ GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2))
       const Element<DIM(data)>& element,                                       \
       const FixedHashMap<                                                      \
           maximum_number_of_neighbors(DIM(data)),                              \
-          std::pair<Direction<DIM(data)>, ElementId<DIM(data)>>,               \
-          std::vector<double>,                                                 \
+          std::pair<Direction<DIM(data)>, ElementId<DIM(data)>>, DataVector,   \
           boost::hash<std::pair<Direction<DIM(data)>, ElementId<DIM(data)>>>>& \
           neighbor_data,                                                       \
       const Mesh<DIM(data)>& subcell_mesh) const;                              \
@@ -167,8 +165,7 @@ GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2))
       const Element<DIM(data)>& element,                                       \
       const FixedHashMap<                                                      \
           maximum_number_of_neighbors(DIM(data)),                              \
-          std::pair<Direction<DIM(data)>, ElementId<DIM(data)>>,               \
-          std::vector<double>,                                                 \
+          std::pair<Direction<DIM(data)>, ElementId<DIM(data)>>, DataVector,   \
           boost::hash<std::pair<Direction<DIM(data)>, ElementId<DIM(data)>>>>& \
           neighbor_data,                                                       \
       const Mesh<DIM(data)>& subcell_mesh,                                     \

--- a/src/Evolution/Systems/ScalarAdvection/FiniteDifference/MonotonisedCentral.hpp
+++ b/src/Evolution/Systems/ScalarAdvection/FiniteDifference/MonotonisedCentral.hpp
@@ -8,7 +8,6 @@
 #include <cstddef>
 #include <memory>
 #include <utility>
-#include <vector>
 
 #include "DataStructures/DataBox/Prefixes.hpp"
 #include "DataStructures/FixedHashMap.hpp"
@@ -25,6 +24,7 @@
 #include "Utilities/TMPL.hpp"
 
 /// \cond
+class DataVector;
 template <size_t Dim>
 class Direction;
 template <size_t Dim>
@@ -93,7 +93,7 @@ class MonotonisedCentral : public Reconstructor<Dim> {
       const Element<Dim>& element,
       const FixedHashMap<
           maximum_number_of_neighbors(Dim),
-          std::pair<Direction<Dim>, ElementId<Dim>>, std::vector<double>,
+          std::pair<Direction<Dim>, ElementId<Dim>>, DataVector,
           boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>&
           neighbor_data,
       const Mesh<Dim>& subcell_mesh) const;
@@ -105,7 +105,7 @@ class MonotonisedCentral : public Reconstructor<Dim> {
       const Element<Dim>& element,
       const FixedHashMap<
           maximum_number_of_neighbors(Dim),
-          std::pair<Direction<Dim>, ElementId<Dim>>, std::vector<double>,
+          std::pair<Direction<Dim>, ElementId<Dim>>, DataVector,
           boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>&
           neighbor_data,
       const Mesh<Dim>& subcell_mesh,

--- a/src/Evolution/Systems/ScalarAdvection/FiniteDifference/ReconstructWork.hpp
+++ b/src/Evolution/Systems/ScalarAdvection/FiniteDifference/ReconstructWork.hpp
@@ -7,7 +7,6 @@
 #include <boost/functional/hash.hpp>
 #include <cstddef>
 #include <utility>
-#include <vector>
 
 #include "DataStructures/FixedHashMap.hpp"
 #include "Domain/Structure/MaxNumberOfNeighbors.hpp"
@@ -15,6 +14,7 @@
 #include "Utilities/TMPL.hpp"
 
 /// \cond
+class DataVector;
 template <size_t Dim>
 class Direction;
 template <size_t Dim>
@@ -43,10 +43,10 @@ void reconstruct_work(
     const Reconstructor& reconstruct,
     const Variables<tmpl::list<Tags::U>> volume_vars,
     const Element<Dim>& element,
-    const FixedHashMap<
-        maximum_number_of_neighbors(Dim),
-        std::pair<Direction<Dim>, ElementId<Dim>>, std::vector<double>,
-        boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>& neighbor_data,
+    const FixedHashMap<maximum_number_of_neighbors(Dim),
+                       std::pair<Direction<Dim>, ElementId<Dim>>, DataVector,
+                       boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>&
+        neighbor_data,
     const Mesh<Dim>& subcell_mesh, const size_t ghost_zone_size);
 
 /*!
@@ -64,10 +64,10 @@ void reconstruct_fd_neighbor_work(
     const ReconstructUpper& reconstruct_upper_neighbor,
     const Variables<tmpl::list<Tags::U>>& subcell_volume_vars,
     const Element<Dim>& element,
-    const FixedHashMap<
-        maximum_number_of_neighbors(Dim),
-        std::pair<Direction<Dim>, ElementId<Dim>>, std::vector<double>,
-        boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>& neighbor_data,
+    const FixedHashMap<maximum_number_of_neighbors(Dim),
+                       std::pair<Direction<Dim>, ElementId<Dim>>, DataVector,
+                       boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>&
+        neighbor_data,
     const Mesh<Dim>& subcell_mesh,
     const Direction<Dim>& direction_to_reconstruct,
     const size_t ghost_zone_size);

--- a/src/Evolution/Systems/ScalarAdvection/FiniteDifference/ReconstructWork.tpp
+++ b/src/Evolution/Systems/ScalarAdvection/FiniteDifference/ReconstructWork.tpp
@@ -7,9 +7,9 @@
 #include <boost/functional/hash.hpp>
 #include <cstddef>
 #include <utility>
-#include <vector>
 
 #include "DataStructures/FixedHashMap.hpp"
+#include "DataStructures/DataVector.hpp"
 #include "DataStructures/Index.hpp"
 #include "DataStructures/Variables.hpp"
 #include "Domain/Structure/Direction.hpp"
@@ -35,7 +35,7 @@ void reconstruct_work(
     const Element<Dim>& element,
     const FixedHashMap<
         maximum_number_of_neighbors(Dim),
-        std::pair<Direction<Dim>, ElementId<Dim>>, std::vector<double>,
+        std::pair<Direction<Dim>, ElementId<Dim>>, DataVector,
         boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>& neighbor_data,
     const Mesh<Dim>& subcell_mesh, const size_t ghost_zone_size) {
   // check if subcell mesh is isotropic
@@ -78,9 +78,9 @@ void reconstruct_work(
            "got "
                << neighbors_in_direction.size() << " in direction "
                << direction);
-    ASSERT(not neighbor_data
+    ASSERT(neighbor_data
                    .at(std::pair{direction, *neighbors_in_direction.begin()})
-                   .empty(),
+                   .size() != 0,
            "The neighber data is empty in direction "
                << direction << " on element id " << element.id());
 
@@ -111,7 +111,7 @@ void reconstruct_fd_neighbor_work(
     const Element<Dim>& element,
     const FixedHashMap<
         maximum_number_of_neighbors(Dim),
-        std::pair<Direction<Dim>, ElementId<Dim>>, std::vector<double>,
+        std::pair<Direction<Dim>, ElementId<Dim>>, DataVector,
         boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>& neighbor_data,
     const Mesh<Dim>& subcell_mesh,
     const Direction<Dim>& direction_to_reconstruct,

--- a/src/NumericalAlgorithms/FiniteDifference/NeighborDataAsVariables.hpp
+++ b/src/NumericalAlgorithms/FiniteDifference/NeighborDataAsVariables.hpp
@@ -6,8 +6,8 @@
 #include <boost/functional/hash.hpp>
 #include <cstddef>
 #include <utility>
-#include <vector>
 
+#include "DataStructures/DataVector.hpp"
 #include "DataStructures/FixedHashMap.hpp"
 #include "DataStructures/Variables.hpp"
 #include "Domain/Structure/Direction.hpp"
@@ -20,7 +20,7 @@
 namespace fd {
 /*!
  * \brief Given the type-erased neighbor data for reconstruction stored in a
- * `std::vector<double>`, have `Variables` point into them.
+ * `DataVector`, have `Variables` point into them.
  *
  * This function is helpful for reconstruction, especially when wanting to apply
  * different reconstruction methods to different tags. This can happen, for
@@ -35,10 +35,10 @@ void neighbor_data_as_variables(
                      Variables<ReconstructionTags>,
                      boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>*>
         vars_neighbor_data,
-    const FixedHashMap<
-        maximum_number_of_neighbors(Dim),
-        std::pair<Direction<Dim>, ElementId<Dim>>, std::vector<double>,
-        boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>& neighbor_data,
+    const FixedHashMap<maximum_number_of_neighbors(Dim),
+                       std::pair<Direction<Dim>, ElementId<Dim>>, DataVector,
+                       boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>&
+        neighbor_data,
     const size_t ghost_zone_size, const Mesh<Dim>& subcell_mesh) {
   const size_t neighbor_num_pts =
       ghost_zone_size * subcell_mesh.extents().slice_away(0).product();

--- a/tests/Unit/Domain/Structure/Test_OrientationMap.cpp
+++ b/tests/Unit/Domain/Structure/Test_OrientationMap.cpp
@@ -317,7 +317,6 @@ void test_3d() {
         custom4.permute_from_neighbor(std::array<int, 3>{{4, -8, 12}}));
 }
 
-}  // namespace
 
 void test_errors() {
 #ifdef SPECTRE_DEBUG
@@ -451,6 +450,7 @@ void test_reference_wrapper() {
   CHECK(test_points[1] == y_points_proof);
   CHECK(test_points[2] == z_points_proof);
 }
+}  // namespace
 
 SPECTRE_TEST_CASE("Unit.Domain.Structure.OrientationMap", "[Domain][Unit]") {
   test_1d();

--- a/tests/Unit/Domain/Structure/Test_OrientationMap.cpp
+++ b/tests/Unit/Domain/Structure/Test_OrientationMap.cpp
@@ -319,64 +319,37 @@ void test_3d() {
 
 }  // namespace
 
-SPECTRE_TEST_CASE("Unit.Domain.Structure.OrientationMap", "[Domain][Unit]") {
-  test_1d();
-  test_2d();
-  test_3d();
-}
-
-// [[OutputRegex, This OrientationMap fails to map Directions one-to-one.]]
-[[noreturn]] SPECTRE_TEST_CASE("Unit.Domain.Structure.OrientationMap.Bijective",
-                               "[Domain][Unit]") {
-  ASSERTION_TEST();
+void test_errors() {
 #ifdef SPECTRE_DEBUG
-  auto failed_orientationmap = OrientationMap<2>{std::array<Direction<2>, 2>{
-      {Direction<2>::upper_xi(), Direction<2>::lower_xi()}}};
-  static_cast<void>(failed_orientationmap);
+  CHECK_THROWS_WITH(
+      OrientationMap<2>(std::array<Direction<2>, 2>{
+          {Direction<2>::upper_xi(), Direction<2>::lower_xi()}}),
+      Catch::Contains(
+          "This OrientationMap fails to map Directions one-to-one."));
 
-  ERROR("Failed to trigger ASSERT in an assertion test");
+  CHECK_THROWS_WITH(
+      OrientationMap<2>(
+          std::array<Direction<2>, 2>{
+              {Direction<2>::upper_xi(), Direction<2>::lower_xi()}},
+          std::array<Direction<2>, 2>{
+              {Direction<2>::upper_xi(), Direction<2>::upper_eta()}}),
+      Catch::Contains(
+          "This OrientationMap fails to map Directions one-to-one."));
+
+  CHECK_THROWS_WITH(
+      OrientationMap<3>(
+          std::array<Direction<3>, 3>{{Direction<3>::upper_xi(),
+                                       Direction<3>::lower_eta(),
+                                       Direction<3>::lower_zeta()}},
+          std::array<Direction<3>, 3>{{Direction<3>::upper_xi(),
+                                       Direction<3>::upper_eta(),
+                                       Direction<3>::lower_eta()}}),
+      Catch::Contains(
+          "This OrientationMap fails to map Directions one-to-one."));
 #endif
 }
 
-// [[OutputRegex, This OrientationMap fails to map Directions one-to-one.]]
-[[noreturn]] SPECTRE_TEST_CASE(
-    "Unit.Domain.Structure.OrientationMap.BijectiveHost", "[Domain][Unit]") {
-  ASSERTION_TEST();
-#ifdef SPECTRE_DEBUG
-  auto failed_orientationmap = OrientationMap<2>{
-      std::array<Direction<2>, 2>{
-          {Direction<2>::upper_xi(), Direction<2>::lower_xi()}},
-      std::array<Direction<2>, 2>{
-          {Direction<2>::upper_xi(), Direction<2>::upper_eta()}},
-  };
-  static_cast<void>(failed_orientationmap);
-
-  ERROR("Failed to trigger ASSERT in an assertion test");
-#endif
-}
-
-// [[OutputRegex, This OrientationMap fails to map Directions one-to-one.]]
-[[noreturn]] SPECTRE_TEST_CASE(
-    "Unit.Domain.Structure.OrientationMap.BijectiveNeighbor",
-    "[Domain][Unit]") {
-  ASSERTION_TEST();
-#ifdef SPECTRE_DEBUG
-  auto failed_orientationmap = OrientationMap<3>{
-      std::array<Direction<3>, 3>{{Direction<3>::upper_xi(),
-                                   Direction<3>::lower_eta(),
-                                   Direction<3>::lower_zeta()}},
-      std::array<Direction<3>, 3>{{Direction<3>::upper_xi(),
-                                   Direction<3>::upper_eta(),
-                                   Direction<3>::lower_eta()}},
-  };
-  static_cast<void>(failed_orientationmap);
-
-  ERROR("Failed to trigger ASSERT in an assertion test");
-#endif
-}
-
-SPECTRE_TEST_CASE("Unit.Domain.Structure.DiscreteRotation.AllOrientations",
-                  "[Domain][Unit]") {
+void test_all_orientations() {
   for (OrientationMapIterator<2> map_i{}; map_i; ++map_i) {
     const std::array<double, 2> original_point{{0.5, -2.0}};
     const std::array<double, 2> new_point =
@@ -401,8 +374,7 @@ SPECTRE_TEST_CASE("Unit.Domain.Structure.DiscreteRotation.AllOrientations",
   }
 }
 
-SPECTRE_TEST_CASE("Unit.Domain.Structure.DiscreteRotation.Rotation",
-                  "[Domain][Unit]") {
+void test_rotation() {
   const OrientationMap<1> rotation1(
       std::array<Direction<1>, 1>{{Direction<1>::lower_xi()}});
   const std::array<DataVector, 1> test_points1{
@@ -437,8 +409,7 @@ SPECTRE_TEST_CASE("Unit.Domain.Structure.DiscreteRotation.Rotation",
         std::array<double, 3>{{0.5, -1.0, 1.0}});
 }
 
-SPECTRE_TEST_CASE("Unit.Domain.Structure.DiscreteRotation.ReferenceWrapper",
-                  "[Domain][Unit]") {
+void test_reference_wrapper() {
   const OrientationMap<3> rotation(std::array<Direction<3>, 3>{
       {Direction<3>::upper_eta(), Direction<3>::lower_zeta(),
        Direction<3>::lower_xi()}});
@@ -479,4 +450,16 @@ SPECTRE_TEST_CASE("Unit.Domain.Structure.DiscreteRotation.ReferenceWrapper",
   CHECK(test_points[0] == x_points_proof);
   CHECK(test_points[1] == y_points_proof);
   CHECK(test_points[2] == z_points_proof);
+}
+
+SPECTRE_TEST_CASE("Unit.Domain.Structure.OrientationMap", "[Domain][Unit]") {
+  test_1d();
+  test_2d();
+  test_3d();
+
+  test_all_orientations();
+  test_rotation();
+  test_reference_wrapper();
+
+  test_errors();
 }

--- a/tests/Unit/Domain/Structure/Test_OrientationMapHelpers.cpp
+++ b/tests/Unit/Domain/Structure/Test_OrientationMapHelpers.cpp
@@ -145,6 +145,12 @@ void test_2d_orient_variables_simple_case_by_hand() {
   const std::vector<double> expected_vars_vector(
       expected_vars.data(), expected_vars.data() + expected_vars.size());
   CHECK(oriented_vars_vector == expected_vars_vector);
+
+  const DataVector vars_dv(vars.data(), vars.size());
+  const DataVector oriented_vars_dv =
+      orient_variables(vars_dv, extents, orientation_map);
+  const DataVector expected_vars_dv(expected_vars.data(), expected_vars.size());
+  CHECK(oriented_vars_dv == expected_vars_dv);
 }
 
 // Test orient_variables using a general orientation.
@@ -189,6 +195,12 @@ void test_2d_with_orientation(const OrientationMap<2>& orientation_map) {
   const std::vector<double> expected_vars_vector(
       expected_vars.data(), expected_vars.data() + expected_vars.size());
   CHECK(oriented_vars_vector == expected_vars_vector);
+
+  const DataVector vars_dv(vars.data(), vars.size());
+  const DataVector oriented_vars_dv =
+      orient_variables(vars_dv, extents, orientation_map);
+  const DataVector expected_vars_dv(expected_vars.data(), expected_vars.size());
+  CHECK(oriented_vars_dv == expected_vars_dv);
 
 #ifdef SPECTRE_DEBUG
   {
@@ -261,6 +273,12 @@ void test_3d_orient_variables_simple_case_by_hand() {
   const std::vector<double> expected_vars_vector(
       expected_vars.data(), expected_vars.data() + expected_vars.size());
   CHECK(oriented_vars_vector == expected_vars_vector);
+
+  const DataVector vars_dv(vars.data(), vars.size());
+  const DataVector oriented_vars_dv =
+      orient_variables(vars_dv, extents, orientation_map);
+  const DataVector expected_vars_dv(expected_vars.data(), expected_vars.size());
+  CHECK(oriented_vars_dv == expected_vars_dv);
 }
 
 // Test orient_variables using a general orientation.
@@ -361,6 +379,13 @@ void check_vector(const Variables<TagsList>& vars,
       // NOLINTNEXTLINE
       expected_vars.data(), expected_vars.data() + expected_vars.size()};
   CHECK(oriented_vars_vector == expected_vars_vector);
+
+  const DataVector vars_dv(const_cast<double*>(vars.data()), vars.size());
+  const DataVector oriented_vars_dv = orient_variables_on_slice(
+      vars_dv, slice_extents, sliced_dim, orientation_map);
+  const DataVector expected_vars_dv(const_cast<double*>(expected_vars.data()),
+                                    expected_vars.size());
+  CHECK(oriented_vars_dv == expected_vars_dv);
 }
 
 // Test 0D slice of a 1D element

--- a/tests/Unit/Evolution/DgSubcell/Actions/Test_Initialize.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Actions/Test_Initialize.cpp
@@ -156,11 +156,11 @@ struct Metavariables {
       using std::max;
       using std::min;
       rdmp_data.max_variables_values =
-          std::vector<double>{max(max(get(get<Var1>(dg_vars))),
-                                  max(get(get<Var1>(projected_dg_vars))))};
+          DataVector{max(max(get(get<Var1>(dg_vars))),
+                         max(get(get<Var1>(projected_dg_vars))))};
       rdmp_data.min_variables_values =
-          std::vector<double>{min(min(get(get<Var1>(dg_vars))),
-                                  min(get(get<Var1>(projected_dg_vars))))};
+          DataVector{min(min(get(get<Var1>(dg_vars))),
+                         min(get(get<Var1>(projected_dg_vars))))};
       invoked = true;
       return {static_cast<int>(TciFails), std::move(rdmp_data)};
     }

--- a/tests/Unit/Evolution/DgSubcell/Actions/Test_TakeTimeStep.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Actions/Test_TakeTimeStep.cpp
@@ -159,7 +159,7 @@ void test() {
   evolution::dg::MortarData<Dim> lower_xi_data{};
   lower_xi_data.insert_local_mortar_data(
       TimeStepId{true, 1, Time{Slab{1.2, 7.8}, {1, 10}}},
-      subcell_mesh.slice_away(0), std::vector<double>{1.1, 2.43, 7.8});
+      subcell_mesh.slice_away(0), DataVector{1.1, 2.43, 7.8});
   const std::pair lower_id{Direction<Dim>::lower_xi(), ElementId<Dim>{1}};
   mortar_data[lower_id] = lower_xi_data;
 

--- a/tests/Unit/Evolution/DgSubcell/Actions/Test_TciAndRollback.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Actions/Test_TciAndRollback.cpp
@@ -8,7 +8,6 @@
 #include <deque>
 #include <memory>
 #include <utility>
-#include <vector>
 
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataBox/PrefixHelpers.hpp"
@@ -169,9 +168,9 @@ struct Metavariables {
       using std::max;
       using std::min;
       evolution::dg::subcell::RdmpTciData rdmp_data{};
-      rdmp_data.max_variables_values = std::vector{max(
+      rdmp_data.max_variables_values = DataVector{max(
           max(get(get<Var1>(dg_vars))), max(get(get<Var1>(projected_vars))))};
-      rdmp_data.min_variables_values = std::vector{min(
+      rdmp_data.min_variables_values = DataVector{min(
           min(get(get<Var1>(dg_vars))), min(get(get<Var1>(projected_vars))))};
 
       CHECK(approx(persson_exponent) == 4.0);
@@ -273,7 +272,7 @@ void test_impl(const bool rdmp_fails, const bool tci_fails,
       evolution::dg::subcell::ActiveGrid::Dg;
 
   FixedHashMap<maximum_number_of_neighbors(Dim),
-               std::pair<Direction<Dim>, ElementId<Dim>>, std::vector<double>,
+               std::pair<Direction<Dim>, ElementId<Dim>>, DataVector,
                boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>
       neighbor_data{};
 
@@ -288,14 +287,14 @@ void test_impl(const bool rdmp_fails, const bool tci_fails,
         (direction.side() == Side::Lower and direction.dimension() % 2 != 0)) {
       neighbor_meshes[directional_element_id] = dg_mesh;
       neighbor_data[directional_element_id] =
-          std::vector<double>(dg_mesh.number_of_grid_points());
+          DataVector{dg_mesh.number_of_grid_points()};
       alg::iota(neighbor_data[directional_element_id],
                 subcell_mesh.number_of_grid_points() *
                     (2.0 * direction.dimension() + 1.0));
     } else {
       neighbor_meshes[directional_element_id] = subcell_mesh;
       neighbor_data[directional_element_id] =
-          std::vector<double>(dg_mesh.number_of_grid_points());
+          DataVector{dg_mesh.number_of_grid_points()};
       alg::iota(neighbor_data[directional_element_id],
                 subcell_mesh.number_of_grid_points() *
                     (2.0 * direction.dimension() + 1.0));
@@ -304,11 +303,9 @@ void test_impl(const bool rdmp_fails, const bool tci_fails,
 
   const int tci_decision{-1};
 
-  evolution::dg::subcell::RdmpTciData rdmp_tci_data{};
   // max and min of +-2 at last time level means reconstructed vars will be in
   // limit
-  rdmp_tci_data.max_variables_values.push_back(2.0);
-  rdmp_tci_data.min_variables_values.push_back(-2.0);
+  evolution::dg::subcell::RdmpTciData rdmp_tci_data{{2.0}, {-2.0}};
   // Make a copy of the RDMP data because in the case where the TCI fails the
   // RDMP TCI data in the DataBox shouldn't have changed.
   const evolution::dg::subcell::RdmpTciData initial_rdmp_tci_data =

--- a/tests/Unit/Evolution/DgSubcell/Actions/Test_TciAndSwitchToDg.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Actions/Test_TciAndSwitchToDg.cpp
@@ -9,7 +9,6 @@
 #include <deque>
 #include <memory>
 #include <utility>
-#include <vector>
 
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataBox/PrefixHelpers.hpp"
@@ -136,9 +135,9 @@ struct Metavariables {
 
       evolution::dg::subcell::RdmpTciData rdmp_data{};
       rdmp_data.max_variables_values =
-          std::vector<double>{max(get(get<Var1>(subcell_vars)))};
+          DataVector{max(get(get<Var1>(subcell_vars)))};
       rdmp_data.min_variables_values =
-          std::vector<double>{min(get(get<Var1>(subcell_vars)))};
+          DataVector{min(get(get<Var1>(subcell_vars)))};
 
       // Now do RDMP check, reconstruct to DG solution, then check.
       CHECK(evolution::dg::subcell::rdmp_tci(
@@ -256,17 +255,15 @@ void test_impl(
       make_time_stepper(multistep_time_stepper);
 
   FixedHashMap<maximum_number_of_neighbors(Dim),
-               std::pair<Direction<Dim>, ElementId<Dim>>, std::vector<double>,
+               std::pair<Direction<Dim>, ElementId<Dim>>, DataVector,
                boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>
       neighbor_data{};
 
   const int tci_decision{-1};  // default value
 
-  evolution::dg::subcell::RdmpTciData rdmp_tci_data{};
   // max and min of +-2 at last time level means reconstructed vars will be in
   // limit
-  rdmp_tci_data.max_variables_values.push_back(2.0);
-  rdmp_tci_data.min_variables_values.push_back(-2.0);
+  evolution::dg::subcell::RdmpTciData rdmp_tci_data{{2.0}, {-2.0}};
   std::deque<evolution::dg::subcell::ActiveGrid> tci_grid_history{};
   for (size_t i = 0; i < time_stepper->order(); ++i) {
     tci_grid_history.push_back(evolution::dg::subcell::ActiveGrid::Dg);

--- a/tests/Unit/Evolution/DgSubcell/Test_CorrectPackagedData.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Test_CorrectPackagedData.cpp
@@ -8,9 +8,9 @@
 #include <numeric>
 #include <unordered_map>
 #include <utility>
-#include <vector>
 
 #include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/DataVector.hpp"
 #include "DataStructures/Index.hpp"
 #include "DataStructures/SliceIterator.hpp"
 #include "DataStructures/Variables.hpp"
@@ -103,16 +103,16 @@ void test() {
     const size_t dg_number_of_independent_components =
         Vars::number_of_independent_components;
     const auto upper_neighbor_data = [&dg_face_mesh, &upper_packaged_data]() {
-      std::vector<double> result(dg_number_of_independent_components *
-                                 dg_face_mesh.number_of_grid_points());
+      DataVector result{dg_number_of_independent_components *
+                        dg_face_mesh.number_of_grid_points()};
       std::iota(result.begin(), result.end(),
                 1.0 + 2.0 * upper_packaged_data.size());
       return result;
     }();
     const auto lower_neighbor_data = [&dg_face_mesh, &upper_packaged_data,
                                       &upper_neighbor_data]() {
-      std::vector<double> result(dg_number_of_independent_components *
-                                 dg_face_mesh.number_of_grid_points());
+      DataVector result{dg_number_of_independent_components *
+                        dg_face_mesh.number_of_grid_points()};
       std::iota(
           result.begin(), result.end(),
           1.0 + 2.0 * upper_packaged_data.size() + upper_neighbor_data.size());
@@ -220,13 +220,11 @@ void test() {
     set_volume_data();
 
     {
-      std::vector<double> upper_local_data(
-          dg_number_of_independent_components *
-          dg_face_mesh.number_of_grid_points());
+      DataVector upper_local_data{dg_number_of_independent_components *
+                                  dg_face_mesh.number_of_grid_points()};
       std::iota(upper_local_data.begin(), upper_local_data.end(), 1.0e6);
-      std::vector<double> lower_local_data(
-          dg_number_of_independent_components *
-          dg_face_mesh.number_of_grid_points());
+      DataVector lower_local_data{dg_number_of_independent_components *
+                                  dg_face_mesh.number_of_grid_points()};
       std::iota(lower_local_data.begin(), lower_local_data.end(), 1.0e7);
       upper_mortar_data.insert_local_mortar_data(time_step_id, dg_face_mesh,
                                                  upper_local_data);

--- a/tests/Unit/Evolution/DgSubcell/Test_NeighborTciDecision.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Test_NeighborTciDecision.cpp
@@ -8,9 +8,9 @@
 #include <optional>
 #include <tuple>
 #include <utility>
-#include <vector>
 
 #include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataVector.hpp"
 #include "DataStructures/FixedHashMap.hpp"
 #include "Domain/Structure/Direction.hpp"
 #include "Domain/Structure/ElementId.hpp"
@@ -27,8 +27,8 @@ void test() {
   using Type = typename tag::type;
   auto box = db::create<db::AddSimpleTags<tag>>(Type{});
   using StorageType =
-      std::tuple<Mesh<Dim>, Mesh<Dim - 1>, std::optional<std::vector<double>>,
-                 std::optional<std::vector<double>>, ::TimeStepId, int>;
+      std::tuple<Mesh<Dim>, Mesh<Dim - 1>, std::optional<DataVector>,
+                 std::optional<DataVector>, ::TimeStepId, int>;
   std::pair<
       const TimeStepId,
       FixedHashMap<maximum_number_of_neighbors(Dim),

--- a/tests/Unit/Evolution/DgSubcell/Test_RdmpTci.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Test_RdmpTci.cpp
@@ -7,7 +7,6 @@
 #include <limits>
 #include <random>
 #include <utility>
-#include <vector>
 
 #include "DataStructures/DataBox/Tag.hpp"
 #include "DataStructures/DataVector.hpp"
@@ -49,11 +48,10 @@ DataVector soln(const tnsr::I<DataVector, Dim, Frame::ElementLogical>& coords) {
 }
 
 template <size_t Dim>
-void test_rdmp_impl(const std::vector<double>& past_max_values,
-                    const std::vector<double>& past_min_values,
-                    const double rdmp_delta0, const double rdmp_epsilon,
-                    const size_t num_pts_1d, const double rescale_dg_by,
-                    const double rescale_subcell_by,
+void test_rdmp_impl(const DataVector& past_max_values,
+                    const DataVector& past_min_values, const double rdmp_delta0,
+                    const double rdmp_epsilon, const size_t num_pts_1d,
+                    const double rescale_dg_by, const double rescale_subcell_by,
                     const int expected_tci_triggered) {
   CAPTURE(Dim);
   CAPTURE(num_pts_1d);
@@ -95,9 +93,9 @@ void test_rdmp_impl(const std::vector<double>& past_max_values,
             dg_vars, subcell_vars, past_max_values, past_min_values,
             rdmp_delta0, rdmp_epsilon) == expected_tci_triggered);
 
-  // Check with only std::vector implementation
-  std::vector<double> current_max_values(past_max_values.size());
-  std::vector<double> current_min_values(current_max_values.size());
+  // Check with only DataVector implementation
+  DataVector current_max_values{past_max_values.size()};
+  DataVector current_min_values{current_max_values.size()};
   size_t component_index = 0;
   tmpl::for_each<tmpl::list<Tags::Scalar, Tags::Vector<Dim>>>(
       [&component_index, &current_max_values, &current_min_values, &dg_vars,
@@ -130,8 +128,8 @@ void test_rdmp_impl(const std::vector<double>& past_max_values,
 
 template <size_t Dim>
 void test_rdmp() {
-  const std::vector<double> past_max_values(Dim + 1, static_cast<double>(Dim));
-  const std::vector<double> past_min_values(Dim + 1, -static_cast<double>(Dim));
+  const DataVector past_max_values{Dim + 1, static_cast<double>(Dim)};
+  const DataVector past_min_values{Dim + 1, -static_cast<double>(Dim)};
 
   // We lower the maximum number of 1d points in 3d in order to reduce total
   // test runtime.

--- a/tests/Unit/Evolution/DgSubcell/Test_RdmpTciData.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Test_RdmpTciData.cpp
@@ -6,7 +6,6 @@
 #include <cstddef>
 #include <random>
 #include <string>
-#include <vector>
 
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "Domain/Structure/ElementId.hpp"
@@ -21,8 +20,8 @@ namespace {
 void test() {
   MAKE_GENERATOR(gen);
   UniformCustomDistribution<double> dist{-100.0, 100.0};
-  std::vector<double> max_vars(10);
-  std::vector<double> min_vars(10);
+  DataVector max_vars{10};
+  DataVector min_vars{10};
   fill_with_random_values(make_not_null(&max_vars), make_not_null(&gen),
                           make_not_null(&dist));
   fill_with_random_values(make_not_null(&min_vars), make_not_null(&gen),

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Actions/Test_ApplyBoundaryCorrections.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Actions/Test_ApplyBoundaryCorrections.cpp
@@ -210,9 +210,10 @@ struct SetLocalMortarData {
         const Mesh<Metavariables::volume_dim - 1>& mortar_mesh =
             mortar_meshes.at(mortar_id);
 
-        std::vector<double> type_erased_boundary_data_on_mortar(
+        DataVector type_erased_boundary_data_on_mortar{
             mortar_mesh.number_of_grid_points() *
-            number_of_dg_package_tags_components);
+                number_of_dg_package_tags_components,
+            0.0};
         alg::iota(type_erased_boundary_data_on_mortar,
                   direction.dimension() +
                       10 * static_cast<unsigned long>(direction.side()) +
@@ -244,7 +245,7 @@ struct SetLocalMortarData {
               });
           // We also need to set the local history one step back to get to 2nd
           // order in time.
-          type_erased_boundary_data_on_mortar.resize(
+          type_erased_boundary_data_on_mortar.destructive_resize(
               mortar_mesh.number_of_grid_points() *
               number_of_dg_package_tags_components);
           alg::iota(type_erased_boundary_data_on_mortar,
@@ -653,14 +654,15 @@ void test_impl(const Spectral::Quadrature quadrature,
       std::pair mortar_id{direction, neighbor_id};
       const Mesh<Dim - 1>& mortar_mesh = mortar_meshes.at(mortar_id);
 
-      std::vector<double> flux_data(mortar_mesh.number_of_grid_points() *
-                                    number_of_dg_package_tags_components);
+      DataVector flux_data{mortar_mesh.number_of_grid_points() *
+                               number_of_dg_package_tags_components,
+                           0.0};
       alg::iota(flux_data,
                 direction.dimension() +
                     10 * static_cast<unsigned long>(direction.side()) +
                     100 * count);
-      std::tuple<Mesh<Dim>, Mesh<Dim - 1>, std::optional<std::vector<double>>,
-                 std::optional<std::vector<double>>, ::TimeStepId, int>
+      std::tuple<Mesh<Dim>, Mesh<Dim - 1>, std::optional<DataVector>,
+                 std::optional<DataVector>, ::TimeStepId, int>
           data{
               mesh,    face_mesh, {}, {flux_data}, {neighbor_next_time_step_id},
               decision};
@@ -781,10 +783,10 @@ void test_impl(const Spectral::Quadrature quadrature,
         mortar_mesh.number_of_grid_points()};
     Variables<mortar_tags_list> neighbor_data_on_mortar{
         mortar_mesh.number_of_grid_points()};
-    const std::pair<Mesh<Dim - 1>, std::vector<double>>& local_mesh_and_data =
+    const std::pair<Mesh<Dim - 1>, DataVector>& local_mesh_and_data =
         *local_mortar_data.local_mortar_data();
-    const std::pair<Mesh<Dim - 1>, std::vector<double>>&
-        neighbor_mesh_and_data = *neighbor_mortar_data.neighbor_mortar_data();
+    const std::pair<Mesh<Dim - 1>, DataVector>& neighbor_mesh_and_data =
+        *neighbor_mortar_data.neighbor_mortar_data();
     std::copy(std::get<1>(local_mesh_and_data).begin(),
               std::get<1>(local_mesh_and_data).end(),
               local_data_on_mortar.data());

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Actions/Test_ComputeTimeDerivative.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Actions/Test_ComputeTimeDerivative.cpp
@@ -202,13 +202,13 @@ SPECTRE_TEST_CASE("Unit.Evolution.DG.ComputeTimeDerivative",
   // - compute flux divergence and add to the time derivative.
   // - compute mortar data for internal boundaries.
   //
-  // The action supports conservative systems, and nonconservative systems
-  // (mixed conservative-nonconservative systems will be added in the future).
+  // The action supports conservative systems, nonconservative systems, and
+  // mixed conservative-nonconservative systems.
   //
   // To test the action thoroughly we need to test a lot of different
   // combinations:
   //
-  // - system type (conservative/nonconservative), using the enum SystemType
+  // - system type (conservative/nonconservative/mixed) with the enum SystemType
   // - 1d, 2d, 3d
   // - whether the mesh is moving or not
   //

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Test_InboxTags.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Test_InboxTags.cpp
@@ -27,9 +27,8 @@ template <size_t Dim>
 void test_no_ghost_cells() {
   static constexpr size_t number_of_components = 1 + Dim;
   using bc_tag = Tags::BoundaryCorrectionAndGhostCellsInbox<Dim>;
-  using Type =
-      std::tuple<Mesh<Dim>, Mesh<Dim - 1>, std::optional<std::vector<double>>,
-                 std::optional<std::vector<double>>, ::TimeStepId, int>;
+  using Type = std::tuple<Mesh<Dim>, Mesh<Dim - 1>, std::optional<DataVector>,
+                          std::optional<DataVector>, ::TimeStepId, int>;
   using Inbox = typename bc_tag::type;
 
   std::uniform_real_distribution<double> dist(-1.0, 2.3);
@@ -49,8 +48,8 @@ void test_no_ghost_cells() {
                              Spectral::Quadrature::GaussLobatto};
   get<0>(send_data_a) = volume_mesh_a;
   get<1>(send_data_a) = mesh_a;
-  get<3>(send_data_a) = std::vector<double>(mesh_a.number_of_grid_points() *
-                                            number_of_components);
+  get<3>(send_data_a) =
+      DataVector{mesh_a.number_of_grid_points() * number_of_components, 0.0};
   get<4>(send_data_a) = time_step_id_a;
   get<5>(send_data_a) = 5;
   fill_with_random_values(make_not_null(&*get<3>(send_data_a)),
@@ -69,8 +68,8 @@ void test_no_ghost_cells() {
   get<0>(send_data_b) = volume_mesh_b;
   get<1>(send_data_b) = mesh_b;
 
-  get<3>(send_data_b) = std::vector<double>(mesh_b.number_of_grid_points() *
-                                            number_of_components);
+  get<3>(send_data_b) =
+      DataVector{mesh_b.number_of_grid_points() * number_of_components, 0.0};
   // Set the future time step to make sure the implementation doesn't mix the
   // receive time ID and the validity range time ID
   get<4>(send_data_b) = time_step_id_c;
@@ -96,9 +95,8 @@ template <size_t Dim>
 void test_with_ghost_cells() {
   static constexpr size_t number_of_components = 1 + Dim;
   using bc_tag = Tags::BoundaryCorrectionAndGhostCellsInbox<Dim>;
-  using Type =
-      std::tuple<Mesh<Dim>, Mesh<Dim - 1>, std::optional<std::vector<double>>,
-                 std::optional<std::vector<double>>, ::TimeStepId, int>;
+  using Type = std::tuple<Mesh<Dim>, Mesh<Dim - 1>, std::optional<DataVector>,
+                          std::optional<DataVector>, ::TimeStepId, int>;
   using Inbox = typename bc_tag::type;
 
   std::uniform_real_distribution<double> dist(-1.0, 2.3);
@@ -119,8 +117,8 @@ void test_with_ghost_cells() {
                              Spectral::Quadrature::GaussLobatto};
   get<0>(send_data_a) = volume_mesh_a;
   get<1>(send_data_a) = mesh_a;
-  get<2>(send_data_a) = std::vector<double>(mesh_a.number_of_grid_points() *
-                                            number_of_components);
+  get<2>(send_data_a) =
+      DataVector{mesh_a.number_of_grid_points() * number_of_components, 0.0};
   get<4>(send_data_a) = time_step_id_a;
   get<5>(send_data_a) = 5;
   fill_with_random_values(make_not_null(&*get<2>(send_data_a)),
@@ -138,8 +136,8 @@ void test_with_ghost_cells() {
                              Spectral::Quadrature::GaussLobatto};
   get<0>(send_data_b) = volume_mesh_b;
   get<1>(send_data_b) = mesh_b;
-  get<2>(send_data_b) = std::vector<double>(
-      get<1>(send_data_b).number_of_grid_points() * number_of_components);
+  get<2>(send_data_b) = DataVector{
+      get<1>(send_data_b).number_of_grid_points() * number_of_components, 0.0};
   get<4>(send_data_b) = time_step_id_b;
   get<5>(send_data_b) = 6;
   fill_with_random_values(make_not_null(&*get<2>(send_data_b)),
@@ -164,8 +162,8 @@ void test_with_ghost_cells() {
   Type send_flux_data_a;
   get<0>(send_flux_data_a) = get<0>(send_data_a);
   get<1>(send_flux_data_a) = get<1>(send_data_a);
-  get<3>(send_flux_data_a) = std::vector<double>(
-      get<1>(send_data_a).number_of_grid_points() * number_of_components);
+  get<3>(send_flux_data_a) = DataVector{
+      get<1>(send_data_a).number_of_grid_points() * number_of_components, 0.0};
   // Verify that when we update the fluxes the validity of the fluxes is also
   // updated correctly
   get<4>(send_flux_data_a) = time_step_id_c;
@@ -185,8 +183,9 @@ void test_with_ghost_cells() {
   // Check sending both ghost and flux data at once
   Type send_all_data_b = send_data_b;
   get<3>(send_all_data_b) =
-      std::vector<double>(2 * get<1>(send_all_data_b).number_of_grid_points() *
-                          number_of_components);
+      DataVector{2 * get<1>(send_all_data_b).number_of_grid_points() *
+                     number_of_components,
+                 0.0};
   get<4>(send_all_data_b) = time_step_id_c;
   get<5>(send_data_a) = 6;
   fill_with_random_values(make_not_null(&*get<3>(send_all_data_b)),

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Test_MortarData.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Test_MortarData.cpp
@@ -39,15 +39,15 @@ void test_global_time_stepping_usage() {
 
   const Mesh<Dim - 1> local_mesh{4, Spectral::Basis::Legendre,
                                  Spectral::Quadrature::GaussLobatto};
-  std::vector<double> local_data(mortar_mesh.number_of_grid_points() *
-                                 number_of_components);
+  DataVector local_data{
+      mortar_mesh.number_of_grid_points() * number_of_components, 0.0};
   fill_with_random_values(make_not_null(&local_data), make_not_null(&gen),
                           make_not_null(&dist));
 
   const Mesh<Dim - 1> neighbor_mesh{3, Spectral::Basis::Legendre,
                                     Spectral::Quadrature::Gauss};
-  std::vector<double> neighbor_data(mortar_mesh.number_of_grid_points() *
-                                    number_of_components);
+  DataVector neighbor_data{
+      mortar_mesh.number_of_grid_points() * number_of_components, 0.0};
   fill_with_random_values(make_not_null(&local_data), make_not_null(&gen),
                           make_not_null(&dist));
 
@@ -104,8 +104,8 @@ void test_local_time_stepping_usage(const bool use_gauss_points) {
 
   const Mesh<Dim - 1> local_mesh{4, Spectral::Basis::Legendre,
                                  Spectral::Quadrature::GaussLobatto};
-  std::vector<double> local_data(mortar_mesh.number_of_grid_points() *
-                                 number_of_components);
+  DataVector local_data{
+      mortar_mesh.number_of_grid_points() * number_of_components, 0.0};
   fill_with_random_values(make_not_null(&local_data), make_not_null(&gen),
                           make_not_null(&dist));
 

--- a/tests/Unit/Evolution/Systems/Burgers/Subcell/Test_NeighborPackagedData.cpp
+++ b/tests/Unit/Evolution/Systems/Burgers/Subcell/Test_NeighborPackagedData.cpp
@@ -11,6 +11,7 @@
 #include <vector>
 
 #include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Variables.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
@@ -221,10 +222,9 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Burgers.Subcell.NeighborPackagedData",
         typename BoundaryCorrectionUsedForTest::dg_package_data_volume_tags{},
         dg_package_data_argument_tags{});
 
-    std::vector<double> vector_to_check{
+    const DataVector vector_to_check{
         expected_fd_packaged_data_on_mortar.data(),
-        expected_fd_packaged_data_on_mortar.data() +
-            expected_fd_packaged_data_on_mortar.size()};
+        expected_fd_packaged_data_on_mortar.size()};
 
     CHECK_ITERABLE_APPROX(vector_to_check, packaged_data.at(mortar_id));
   }

--- a/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/Test_BoundaryConditionGhostData.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/Test_BoundaryConditionGhostData.cpp
@@ -10,7 +10,6 @@
 #include <string>
 #include <unordered_map>
 #include <utility>
-#include <vector>
 
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Variables.hpp"
@@ -255,7 +254,7 @@ void test(const BoundaryConditionType& boundary_condition) {
                                         ReconstructorForTest{});
   const auto direction = Direction<3>::upper_xi();
   const std::pair mortar_id = {direction, ElementId<3>::external_boundary_id()};
-  const std::vector<double>& fd_ghost_data =
+  const DataVector& fd_ghost_data =
       get<evolution::dg::subcell::Tags::NeighborDataForReconstruction<3>>(box)
           .at(mortar_id);
 

--- a/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/Test_Derivatives.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/Test_Derivatives.cpp
@@ -5,7 +5,6 @@
 
 #include <cstddef>
 #include <utility>
-#include <vector>
 
 #include "DataStructures/DataBox/PrefixHelpers.hpp"
 #include "DataStructures/DataVector.hpp"
@@ -50,7 +49,7 @@ SPECTRE_TEST_CASE(
       TestHelpers::grmhd::GhValenciaDivClean::fd::detail::set_element();
 
   const FixedHashMap<maximum_number_of_neighbors(3),
-                     std::pair<Direction<3>, ElementId<3>>, std::vector<double>,
+                     std::pair<Direction<3>, ElementId<3>>, DataVector,
                      boost::hash<std::pair<Direction<3>, ElementId<3>>>>
       neighbor_data_for_reconstruction =
           TestHelpers::grmhd::GhValenciaDivClean::fd::detail::
@@ -158,12 +157,12 @@ SPECTRE_TEST_CASE(
     const std::pair directional_element_id{
         direction, *element.neighbors().at(direction).begin()};
     FixedHashMap<maximum_number_of_neighbors(3),
-                 std::pair<Direction<3>, ElementId<3>>, std::vector<double>,
+                 std::pair<Direction<3>, ElementId<3>>, DataVector,
                  boost::hash<std::pair<Direction<3>, ElementId<3>>>>
         bad_neighbor_data_for_reconstruction = neighbor_data_for_reconstruction;
     auto& neighbor_data =
         bad_neighbor_data_for_reconstruction.at(directional_element_id);
-    neighbor_data.resize(2);
+    neighbor_data = DataVector{2};
     const std::string match_string{
         MakeString{}
         << "Amount of reconstruction data sent (" << neighbor_data.size()

--- a/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/Test_Filters.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/Test_Filters.cpp
@@ -44,10 +44,9 @@ void set_solution(
     const gsl::not_null<Variables<
         typename grmhd::GhValenciaDivClean::System::variables_tag::tags_list>*>
         volume_vars,
-    const gsl::not_null<
-        FixedHashMap<maximum_number_of_neighbors(3),
-                     std::pair<Direction<3>, ElementId<3>>, std::vector<double>,
-                     boost::hash<std::pair<Direction<3>, ElementId<3>>>>*>
+    const gsl::not_null<FixedHashMap<
+        maximum_number_of_neighbors(3), std::pair<Direction<3>, ElementId<3>>,
+        DataVector, boost::hash<std::pair<Direction<3>, ElementId<3>>>>*>
         neighbor_data,
     const Mesh<3>& mesh,
     const tnsr::I<DataVector, 3, Frame::ElementLogical>& logical_coords,
@@ -114,7 +113,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.GrMhd.GhValenciaDivClean.Fd.Filters",
       volume_evolved_variables{subcell_mesh.number_of_grid_points()};
 
   FixedHashMap<maximum_number_of_neighbors(3),
-               std::pair<Direction<3>, ElementId<3>>, std::vector<double>,
+               std::pair<Direction<3>, ElementId<3>>, DataVector,
                boost::hash<std::pair<Direction<3>, ElementId<3>>>>
       neighbor_data_for_reconstruction{};
 

--- a/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/Test_InitialDataTci.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/Test_InitialDataTci.cpp
@@ -56,18 +56,18 @@ SPECTRE_TEST_CASE(
         get<grmhd::ValenciaDivClean::Tags::TildeTau>(subcell_vars);
     const auto subcell_tilde_b_magnitude =
         magnitude(get<grmhd::ValenciaDivClean::Tags::TildeB<>>(subcell_vars));
-    rdmp_tci_data.max_variables_values = std::vector<double>{
-        max(max(get(dg_tilde_d)), max(get(subcell_tilde_d))),
-        max(max(get(dg_tilde_ye)), max(get(subcell_tilde_ye))),
-        max(max(get(dg_tilde_tau)), max(get(subcell_tilde_tau))),
-        max(max(get(dg_tilde_b_magnitude)),
-            max(get(subcell_tilde_b_magnitude)))};
-    rdmp_tci_data.min_variables_values = std::vector<double>{
-        min(min(get(dg_tilde_d)), min(get(subcell_tilde_d))),
-        min(min(get(dg_tilde_ye)), min(get(subcell_tilde_ye))),
-        min(min(get(dg_tilde_tau)), min(get(subcell_tilde_tau))),
-        min(min(get(dg_tilde_b_magnitude)),
-            min(get(subcell_tilde_b_magnitude)))};
+    rdmp_tci_data.max_variables_values =
+        DataVector{max(max(get(dg_tilde_d)), max(get(subcell_tilde_d))),
+                   max(max(get(dg_tilde_ye)), max(get(subcell_tilde_ye))),
+                   max(max(get(dg_tilde_tau)), max(get(subcell_tilde_tau))),
+                   max(max(get(dg_tilde_b_magnitude)),
+                       max(get(subcell_tilde_b_magnitude)))};
+    rdmp_tci_data.min_variables_values =
+        DataVector{min(min(get(dg_tilde_d)), min(get(subcell_tilde_d))),
+                   min(min(get(dg_tilde_ye)), min(get(subcell_tilde_ye))),
+                   min(min(get(dg_tilde_tau)), min(get(subcell_tilde_tau))),
+                   min(min(get(dg_tilde_b_magnitude)),
+                       min(get(subcell_tilde_b_magnitude)))};
     return rdmp_tci_data;
   };
 

--- a/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/Test_NeighborPackagedData.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/Test_NeighborPackagedData.cpp
@@ -155,7 +155,7 @@ double test(const size_t num_dg_pts) {
     // Slice data so we can add it to the element's neighbor data
     DirectionMap<3, bool> directions_to_slice{};
     directions_to_slice[direction.opposite()] = true;
-    std::vector<double> neighbor_data_in_direction =
+    DataVector neighbor_data_in_direction =
         evolution::dg::subcell::slice_data(
             prims_to_reconstruct, subcell_mesh.extents(),
             grmhd::ValenciaDivClean::fd::MonotonisedCentralPrim{}

--- a/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/Test_TimeDerivative.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/Test_TimeDerivative.cpp
@@ -204,7 +204,7 @@ double test(const size_t num_dg_pts) {
     // Slice data so we can add it to the element's neighbor data
     DirectionMap<3, bool> directions_to_slice{};
     directions_to_slice[direction.opposite()] = true;
-    std::vector<double> neighbor_data_in_direction =
+    DataVector neighbor_data_in_direction =
         evolution::dg::subcell::slice_data(
             prims_to_reconstruct, subcell_mesh.extents(),
             grmhd::ValenciaDivClean::fd::MonotonisedCentralPrim{}
@@ -450,8 +450,8 @@ double test(const size_t num_dg_pts) {
         normal_covector, normal_vector, mesh_velocity,
         normal_dot_mesh_velocity);
 
-    std::vector<double> interface_data(
-        dg_packaged_data.size(), std::numeric_limits<double>::signaling_NaN());
+    DataVector interface_data{dg_packaged_data.size(),
+                              std::numeric_limits<double>::signaling_NaN()};
     std::copy(std::data(dg_packaged_data),
               std::next(std::data(dg_packaged_data),
                         static_cast<std::ptrdiff_t>(dg_packaged_data.size())),

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/Test_BoundaryConditionGhostData.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/Test_BoundaryConditionGhostData.cpp
@@ -10,7 +10,6 @@
 #include <string>
 #include <unordered_map>
 #include <utility>
-#include <vector>
 
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Variables.hpp"
@@ -259,7 +258,7 @@ void test(const BoundaryConditionType& boundary_condition) {
     const auto direction = Direction<3>::upper_xi();
     const std::pair mortar_id = {direction,
                                  ElementId<3>::external_boundary_id()};
-    const std::vector<double>& fd_ghost_data =
+    const DataVector& fd_ghost_data =
         get<evolution::dg::subcell::Tags::NeighborDataForReconstruction<3>>(box)
             .at(mortar_id);
 
@@ -441,7 +440,7 @@ void test(const BoundaryConditionType& boundary_condition) {
       fd::BoundaryConditionGhostData::apply(make_not_null(&box), element,
                                             ReconstructorForTest{});
 
-      const std::vector<double>& fd_ghost_data_velocity_inward =
+      const DataVector& fd_ghost_data_velocity_inward =
           get<evolution::dg::subcell::Tags::NeighborDataForReconstruction<3>>(
               box)
               .at(mortar_id);

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_InitialDataTci.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_InitialDataTci.cpp
@@ -56,18 +56,18 @@ SPECTRE_TEST_CASE(
         get<grmhd::ValenciaDivClean::Tags::TildeTau>(subcell_vars);
     const auto subcell_tilde_b_magnitude =
         magnitude(get<grmhd::ValenciaDivClean::Tags::TildeB<>>(subcell_vars));
-    rdmp_tci_data.max_variables_values = std::vector<double>{
-        max(max(get(dg_tilde_d)), max(get(subcell_tilde_d))),
-        max(max(get(dg_tilde_ye)), max(get(subcell_tilde_ye))),
-        max(max(get(dg_tilde_tau)), max(get(subcell_tilde_tau))),
-        max(max(get(dg_tilde_b_magnitude)),
-            max(get(subcell_tilde_b_magnitude)))};
-    rdmp_tci_data.min_variables_values = std::vector<double>{
-        min(min(get(dg_tilde_d)), min(get(subcell_tilde_d))),
-        min(min(get(dg_tilde_ye)), min(get(subcell_tilde_ye))),
-        min(min(get(dg_tilde_tau)), min(get(subcell_tilde_tau))),
-        min(min(get(dg_tilde_b_magnitude)),
-            min(get(subcell_tilde_b_magnitude)))};
+    rdmp_tci_data.max_variables_values =
+        DataVector{max(max(get(dg_tilde_d)), max(get(subcell_tilde_d))),
+                   max(max(get(dg_tilde_ye)), max(get(subcell_tilde_ye))),
+                   max(max(get(dg_tilde_tau)), max(get(subcell_tilde_tau))),
+                   max(max(get(dg_tilde_b_magnitude)),
+                       max(get(subcell_tilde_b_magnitude)))};
+    rdmp_tci_data.min_variables_values =
+        DataVector{min(min(get(dg_tilde_d)), min(get(subcell_tilde_d))),
+                   min(min(get(dg_tilde_ye)), min(get(subcell_tilde_ye))),
+                   min(min(get(dg_tilde_tau)), min(get(subcell_tilde_tau))),
+                   min(min(get(dg_tilde_b_magnitude)),
+                       min(get(subcell_tilde_b_magnitude)))};
     return rdmp_tci_data;
   };
 
@@ -216,12 +216,12 @@ SPECTRE_TEST_CASE(
         get<grmhd::ValenciaDivClean::Tags::TildeTau>(dg_vars);
     const auto dg_tilde_b_magnitude =
         magnitude(get<grmhd::ValenciaDivClean::Tags::TildeB<>>(dg_vars));
-    expected_rdmp_data.max_variables_values = std::vector<double>{
-        max(get(dg_tilde_d)), max(get(dg_tilde_ye)), max(get(dg_tilde_tau)),
-        max(get(dg_tilde_b_magnitude))};
-    expected_rdmp_data.min_variables_values = std::vector<double>{
-        min(get(dg_tilde_d)), min(get(dg_tilde_ye)), min(get(dg_tilde_tau)),
-        min(get(dg_tilde_b_magnitude))};
+    expected_rdmp_data.max_variables_values =
+        DataVector{max(get(dg_tilde_d)), max(get(dg_tilde_ye)),
+                   max(get(dg_tilde_tau)), max(get(dg_tilde_b_magnitude))};
+    expected_rdmp_data.min_variables_values =
+        DataVector{min(get(dg_tilde_d)), min(get(dg_tilde_ye)),
+                   min(get(dg_tilde_tau)), min(get(dg_tilde_b_magnitude))};
     CHECK(rdmp_data == expected_rdmp_data);
   }
 }

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_NeighborPackagedData.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_NeighborPackagedData.cpp
@@ -166,7 +166,7 @@ double test(const size_t num_dg_pts) {
     // Slice data so we can add it to the element's neighbor data
     DirectionMap<3, bool> directions_to_slice{};
     directions_to_slice[direction.opposite()] = true;
-    std::vector<double> neighbor_data_in_direction =
+    DataVector neighbor_data_in_direction =
         evolution::dg::subcell::slice_data(
             prims_to_reconstruct, subcell_mesh.extents(),
             grmhd::ValenciaDivClean::fd::MonotonisedCentralPrim{}

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_TciOnDgGrid.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_TciOnDgGrid.cpp
@@ -218,7 +218,7 @@ void test(const TestThis test_this, const int expected_tci_status) {
   const auto magnitude_tilde_b =
       magnitude(db::get<grmhd::ValenciaDivClean::Tags::TildeB<>>(box));
 
-  past_rdmp_tci_data.max_variables_values = std::vector<double>{
+  past_rdmp_tci_data.max_variables_values = DataVector{
       max(max(get(db::get<grmhd::ValenciaDivClean::Tags::TildeD>(box))),
           max(evolution::dg::subcell::fd::project(
               get(db::get<grmhd::ValenciaDivClean::Tags::TildeD>(box)), mesh,
@@ -234,7 +234,7 @@ void test(const TestThis test_this, const int expected_tci_status) {
       max(max(get(magnitude_tilde_b)),
           max(evolution::dg::subcell::fd::project(get(magnitude_tilde_b), mesh,
                                                   subcell_mesh.extents())))};
-  past_rdmp_tci_data.min_variables_values = std::vector<double>{
+  past_rdmp_tci_data.min_variables_values = DataVector{
       min(min(get(db::get<grmhd::ValenciaDivClean::Tags::TildeD>(box))),
           min(evolution::dg::subcell::fd::project(
               get(db::get<grmhd::ValenciaDivClean::Tags::TildeD>(box)), mesh,

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_TciOnFdGrid.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_TciOnFdGrid.cpp
@@ -146,7 +146,7 @@ void test(const TestThis test_this, const int expected_tci_status) {
   const auto magnitude_tilde_b =
       magnitude(db::get<grmhd::ValenciaDivClean::Tags::TildeB<>>(box));
 
-  past_rdmp_tci_data.max_variables_values = std::vector<double>{
+  past_rdmp_tci_data.max_variables_values = DataVector{
       max(max(get(db::get<grmhd::ValenciaDivClean::Tags::TildeD>(box))),
           max(evolution::dg::subcell::fd::reconstruct(
               get(db::get<grmhd::ValenciaDivClean::Tags::TildeD>(box)), mesh,
@@ -166,7 +166,7 @@ void test(const TestThis test_this, const int expected_tci_status) {
           max(evolution::dg::subcell::fd::reconstruct(
               get(magnitude_tilde_b), mesh, subcell_mesh.extents(),
               evolution::dg::subcell::fd::ReconstructionMethod::DimByDim)))};
-  past_rdmp_tci_data.min_variables_values = std::vector<double>{
+  past_rdmp_tci_data.min_variables_values = DataVector{
       min(min(get(db::get<grmhd::ValenciaDivClean::Tags::TildeD>(box))),
           min(evolution::dg::subcell::fd::reconstruct(
               get(db::get<grmhd::ValenciaDivClean::Tags::TildeD>(box)), mesh,
@@ -188,12 +188,12 @@ void test(const TestThis test_this, const int expected_tci_status) {
               evolution::dg::subcell::fd::ReconstructionMethod::DimByDim)))};
 
   evolution::dg::subcell::RdmpTciData expected_rdmp_tci_data{};
-  expected_rdmp_tci_data.max_variables_values = std::vector<double>{
+  expected_rdmp_tci_data.max_variables_values = DataVector{
       max(get(db::get<grmhd::ValenciaDivClean::Tags::TildeD>(box))),
       max(get(db::get<grmhd::ValenciaDivClean::Tags::TildeYe>(box))),
       max(get(db::get<grmhd::ValenciaDivClean::Tags::TildeTau>(box))),
       max(get(magnitude_tilde_b))};
-  expected_rdmp_tci_data.min_variables_values = std::vector<double>{
+  expected_rdmp_tci_data.min_variables_values = DataVector{
       min(get(db::get<grmhd::ValenciaDivClean::Tags::TildeD>(box))),
       min(get(db::get<grmhd::ValenciaDivClean::Tags::TildeYe>(box))),
       min(get(db::get<grmhd::ValenciaDivClean::Tags::TildeTau>(box))),

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_TimeDerivative.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_TimeDerivative.cpp
@@ -200,7 +200,7 @@ std::array<double, 5> test(const size_t num_dg_pts) {
     // Slice data so we can add it to the element's neighbor data
     DirectionMap<3, bool> directions_to_slice{};
     directions_to_slice[direction.opposite()] = true;
-    std::vector<double> neighbor_data_in_direction =
+    DataVector neighbor_data_in_direction =
         evolution::dg::subcell::slice_data(
             prims_to_reconstruct, subcell_mesh.extents(),
             grmhd::ValenciaDivClean::fd::MonotonisedCentralPrim{}

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/Subcell/Test_NeighborPackagedData.cpp
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/Subcell/Test_NeighborPackagedData.cpp
@@ -187,7 +187,7 @@ double test(const size_t num_dg_pts) {
     // Slice data so we can add it to the element's neighbor data
     DirectionMap<Dim, bool> directions_to_slice{};
     directions_to_slice[direction.opposite()] = true;
-    std::vector<double> neighbor_data_in_direction =
+    DataVector neighbor_data_in_direction =
         evolution::dg::subcell::slice_data(
             prims_to_reconstruct, subcell_mesh.extents(),
             NewtonianEuler::fd::MonotonisedCentralPrim<Dim>{}.ghost_zone_size(),

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/Subcell/Test_TciOnFdGrid.cpp
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/Subcell/Test_TciOnFdGrid.cpp
@@ -110,7 +110,7 @@ void test(const TestThis test_this) {
   using std::min;
   evolution::dg::subcell::RdmpTciData past_rdmp_tci_data{};
 
-  past_rdmp_tci_data.max_variables_values = std::vector<double>{
+  past_rdmp_tci_data.max_variables_values = DataVector{
       max(max(get(db::get<MassDensityCons>(box))),
           max(evolution::dg::subcell::fd::reconstruct(
               get(db::get<MassDensityCons>(box)), dg_mesh,
@@ -120,7 +120,7 @@ void test(const TestThis test_this) {
           max(evolution::dg::subcell::fd::reconstruct(
               get(db::get<EnergyDensity>(box)), dg_mesh, subcell_mesh.extents(),
               evolution::dg::subcell::fd::ReconstructionMethod::DimByDim)))};
-  past_rdmp_tci_data.min_variables_values = std::vector<double>{
+  past_rdmp_tci_data.min_variables_values = DataVector{
       min(min(get(db::get<MassDensityCons>(box))),
           min(evolution::dg::subcell::fd::reconstruct(
               get(db::get<MassDensityCons>(box)), dg_mesh,
@@ -133,11 +133,11 @@ void test(const TestThis test_this) {
 
   evolution::dg::subcell::RdmpTciData expected_rdmp_tci_data{};
   expected_rdmp_tci_data.max_variables_values =
-      std::vector<double>{max(get(db::get<MassDensityCons>(box))),
-                          max(get(db::get<EnergyDensity>(box)))};
+      DataVector{max(get(db::get<MassDensityCons>(box))),
+                 max(get(db::get<EnergyDensity>(box)))};
   expected_rdmp_tci_data.min_variables_values =
-      std::vector<double>{min(get(db::get<MassDensityCons>(box))),
-                          min(get(db::get<EnergyDensity>(box)))};
+      DataVector{min(get(db::get<MassDensityCons>(box))),
+                 min(get(db::get<EnergyDensity>(box)))};
 
   // Modify past data if we are expected an RDMP TCI failure.
   db::mutate<evolution::dg::subcell::Tags::DataForRdmpTci>(

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/Subcell/Test_TimeDerivative.cpp
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/Subcell/Test_TimeDerivative.cpp
@@ -201,7 +201,7 @@ std::array<double, 3> test(const size_t num_dg_pts) {
     // Slice data so we can add it to the element's neighbor data
     DirectionMap<dim, bool> directions_to_slice{};
     directions_to_slice[direction.opposite()] = true;
-    std::vector<double> neighbor_data_in_direction =
+    DataVector neighbor_data_in_direction =
         evolution::dg::subcell::slice_data(
             prims_to_reconstruct, subcell_mesh.extents(),
             NewtonianEuler::fd::MonotonisedCentralPrim<dim>{}.ghost_zone_size(),

--- a/tests/Unit/Evolution/Systems/ScalarAdvection/Subcell/Test_NeighborPackagedData.cpp
+++ b/tests/Unit/Evolution/Systems/ScalarAdvection/Subcell/Test_NeighborPackagedData.cpp
@@ -298,10 +298,9 @@ void test_neighbor_packaged_data(const size_t num_dg_pts_per_dimension,
 
     if constexpr (Dim == 1) {
       // no need to reconstruct back to DG grid for 1D
-      std::vector<double> vector_to_check{
+      const DataVector vector_to_check{
           expected_fd_packaged_data_on_mortar.data(),
-          expected_fd_packaged_data_on_mortar.data() +
-              expected_fd_packaged_data_on_mortar.size()};
+          expected_fd_packaged_data_on_mortar.size()};
 
       CHECK_ITERABLE_APPROX(vector_to_check, packaged_data.at(mortar_id));
     } else {
@@ -313,9 +312,9 @@ void test_neighbor_packaged_data(const size_t num_dg_pts_per_dimension,
               subcell_mesh.extents().slice_away(mortar_id.first.dimension()),
               evolution::dg::subcell::fd::ReconstructionMethod::AllDimsAtOnce);
 
-      std::vector<double> vector_to_check{
-          expected_dg_packaged_data.data(),
-          expected_dg_packaged_data.data() + expected_dg_packaged_data.size()};
+      const DataVector vector_to_check{
+          const_cast<double*>(expected_dg_packaged_data.data()),
+          expected_dg_packaged_data.size()};
 
       CHECK_ITERABLE_APPROX(vector_to_check, packaged_data.at(mortar_id));
     }

--- a/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivativeImpl.tpp
+++ b/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivativeImpl.tpp
@@ -1015,6 +1015,8 @@ void test_impl(const Spectral::Quadrature quadrature,
   CAPTURE(UseMovingMesh);
   CAPTURE(Dim);
   CAPTURE(system_type);
+  CAPTURE(HasPrims);
+  CAPTURE(PassVariables);
   CAPTURE(quadrature);
   CAPTURE(dg_formulation);
   using metavars = Metavariables<Dim, system_type, LocalTimeStepping,

--- a/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivativeImpl.tpp
+++ b/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivativeImpl.tpp
@@ -463,7 +463,6 @@ struct TimeDerivativeTermsWithVariables
   /// [dt_mp_variables]
 };
 
-
 template <size_t Dim>
 struct NonconservativeNormalDotFlux {
   using argument_tags = tmpl::list<>;
@@ -1727,8 +1726,11 @@ void test_impl(const Spectral::Quadrature quadrature,
         }
 
         // Compute the normal dot mesh velocity and then the packaged data
-        Variables<mortar_tags_list> packaged_data{
-            face_mesh.number_of_grid_points()};
+        DataVector packaged_data_buffer{
+            face_mesh.number_of_grid_points() *
+            Variables<mortar_tags_list>::number_of_independent_components};
+        Variables<mortar_tags_list> packaged_data{packaged_data_buffer.data(),
+                                                  packaged_data_buffer.size()};
         std::optional<Scalar<DataVector>> normal_dot_mesh_velocity{};
 
         if (face_mesh_velocity.has_value()) {
@@ -1750,17 +1752,31 @@ void test_impl(const Spectral::Quadrature quadrature,
             std::make_pair(local_direction, local_neighbor_id);
         const auto& mortar_mesh = mortar_meshes.at(mortar_id);
         const auto& mortar_size = mortar_sizes.at(mortar_id);
-        auto boundary_data_on_mortar =
-            Spectral::needs_projection(face_mesh, mortar_mesh, mortar_size)
-                ? ::dg::project_to_mortar(packaged_data, face_mesh, mortar_mesh,
-                                          mortar_size)
-                : std::move(packaged_data);
 
-        std::vector<double> expected_data{
-            boundary_data_on_mortar.data(),
-            boundary_data_on_mortar.data() + boundary_data_on_mortar.size()};
+        DataVector expected_data{};
+        if (Spectral::needs_projection(face_mesh, mortar_mesh, mortar_size)) {
+          expected_data = DataVector{
+              mortar_mesh.number_of_grid_points() *
+              Variables<mortar_tags_list>::number_of_independent_components};
+          Variables<mortar_tags_list> projected_packaged_data{
+              expected_data.data(), expected_data.size()};
+          // Since projected_packaged_data is non-owning, if we tried to
+          // move-assign it with the result of ::dg::project_to_mortar, it would
+          // then become owning and the buffer it previously pointed to wouldn't
+          // be filled (and we want it to be filled). So instead force a
+          // copy-assign by having an intermediary, data_to_copy.
+          const auto data_to_copy = ::dg::project_to_mortar(
+              packaged_data, face_mesh, mortar_mesh, mortar_size);
+          projected_packaged_data = data_to_copy;
+        } else {
+          expected_data = packaged_data_buffer;
+        }
+
         const auto& orientation =
             element.neighbors().at(local_direction).orientation();
+        DataVector oriented_variables =
+            orient_variables_on_slice(expected_data, mortar_mesh.extents(),
+                                      local_direction.dimension(), orientation);
         if (local_data or orientation.is_aligned()) {
           return expected_data;
         } else {
@@ -1992,8 +2008,8 @@ void test() {
             // Clang doesn't want moving mesh to be captured, but GCC requires
             // it. Silence the Clang warning by "using" it.
             (void)moving_mesh;
-            if constexpr (not(decltype(use_prims)::value and
-                              system_type == SystemType::Nonconservative)) {
+            if constexpr (not(decltype(use_prims)::value and system_type ==
+                              SystemType::Nonconservative)) {
               // PassVariables == false
               test_impl<false, std::decay_t<decltype(moving_mesh)>::value, Dim,
                         system_type, std::decay_t<decltype(use_prims)>::value,

--- a/tests/Unit/Helpers/Evolution/Systems/Burgers/FiniteDifference/TestHelpers.hpp
+++ b/tests/Unit/Helpers/Evolution/Systems/Burgers/FiniteDifference/TestHelpers.hpp
@@ -7,7 +7,6 @@
 #include <boost/functional/hash.hpp>
 #include <cstddef>
 #include <utility>
-#include <vector>
 
 #include "DataStructures/DataBox/Prefixes.hpp"
 #include "DataStructures/DataVector.hpp"
@@ -39,7 +38,7 @@ namespace TestHelpers {
 namespace Burgers::fd {
 template <typename F>
 FixedHashMap<maximum_number_of_neighbors(1),
-             std::pair<Direction<1>, ElementId<1>>, std::vector<double>,
+             std::pair<Direction<1>, ElementId<1>>, DataVector,
              boost::hash<std::pair<Direction<1>, ElementId<1>>>>
 compute_neighbor_data(
     const Mesh<1>& subcell_mesh,
@@ -47,7 +46,7 @@ compute_neighbor_data(
     const DirectionMap<1, Neighbors<1>>& neighbors,
     const size_t ghost_zone_size, const F& compute_variables_of_neighbor_data) {
   FixedHashMap<maximum_number_of_neighbors(1),
-               std::pair<Direction<1>, ElementId<1>>, std::vector<double>,
+               std::pair<Direction<1>, ElementId<1>>, DataVector,
                boost::hash<std::pair<Direction<1>, ElementId<1>>>>
       neighbor_data{};
   for (const auto& [direction, neighbors_in_direction] : neighbors) {
@@ -108,7 +107,7 @@ void test_reconstructor(const size_t num_pts,
                              Spectral::Quadrature::CellCentered};
   auto logical_coords = logical_coordinates(subcell_mesh);
   const FixedHashMap<maximum_number_of_neighbors(1),
-                     std::pair<Direction<1>, ElementId<1>>, std::vector<double>,
+                     std::pair<Direction<1>, ElementId<1>>, DataVector,
                      boost::hash<std::pair<Direction<1>, ElementId<1>>>>
       neighbor_data = compute_neighbor_data(
           subcell_mesh, logical_coords, element.neighbors(),

--- a/tests/Unit/Helpers/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/PrimReconstructor.hpp
+++ b/tests/Unit/Helpers/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/PrimReconstructor.hpp
@@ -48,7 +48,7 @@ namespace TestHelpers::grmhd::GhValenciaDivClean::fd {
 namespace detail {
 template <typename F>
 FixedHashMap<maximum_number_of_neighbors(3),
-             std::pair<Direction<3>, ElementId<3>>, std::vector<double>,
+             std::pair<Direction<3>, ElementId<3>>, DataVector,
              boost::hash<std::pair<Direction<3>, ElementId<3>>>>
 compute_neighbor_data(
     const Mesh<3>& subcell_mesh,
@@ -56,7 +56,7 @@ compute_neighbor_data(
     const DirectionMap<3, Neighbors<3>>& neighbors,
     const size_t ghost_zone_size, const F& compute_variables_of_neighbor_data) {
   FixedHashMap<maximum_number_of_neighbors(3),
-               std::pair<Direction<3>, ElementId<3>>, std::vector<double>,
+               std::pair<Direction<3>, ElementId<3>>, DataVector,
                boost::hash<std::pair<Direction<3>, ElementId<3>>>>
       neighbor_data{};
   for (const auto& [direction, neighbors_in_direction] : neighbors) {
@@ -219,7 +219,7 @@ void test_prim_reconstructor_impl(
   neighbors_for_data[gsl::at(Direction<3>::all_directions(), 5)] =
       Neighbors<3>{{ElementId<3>::external_boundary_id()}, {}};
   const FixedHashMap<maximum_number_of_neighbors(3),
-                     std::pair<Direction<3>, ElementId<3>>, std::vector<double>,
+                     std::pair<Direction<3>, ElementId<3>>, DataVector,
                      boost::hash<std::pair<Direction<3>, ElementId<3>>>>
       neighbor_data = compute_neighbor_data(
           subcell_mesh, logical_coords, neighbors_for_data,

--- a/tests/Unit/Helpers/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/PrimReconstructor.hpp
+++ b/tests/Unit/Helpers/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/PrimReconstructor.hpp
@@ -8,7 +8,6 @@
 #include <array>
 #include <cstddef>
 #include <utility>
-#include <vector>
 
 #include "DataStructures/DataBox/PrefixHelpers.hpp"
 #include "DataStructures/DataBox/Prefixes.hpp"
@@ -46,7 +45,7 @@ namespace TestHelpers::grmhd::ValenciaDivClean::fd {
 namespace detail {
 template <typename F>
 FixedHashMap<maximum_number_of_neighbors(3),
-             std::pair<Direction<3>, ElementId<3>>, std::vector<double>,
+             std::pair<Direction<3>, ElementId<3>>, DataVector,
              boost::hash<std::pair<Direction<3>, ElementId<3>>>>
 compute_neighbor_data(
     const Mesh<3>& subcell_mesh,
@@ -54,7 +53,7 @@ compute_neighbor_data(
     const DirectionMap<3, Neighbors<3>>& neighbors,
     const size_t ghost_zone_size, const F& compute_variables_of_neighbor_data) {
   FixedHashMap<maximum_number_of_neighbors(3),
-               std::pair<Direction<3>, ElementId<3>>, std::vector<double>,
+               std::pair<Direction<3>, ElementId<3>>, DataVector,
                boost::hash<std::pair<Direction<3>, ElementId<3>>>>
       neighbor_data{};
   for (const auto& [direction, neighbors_in_direction] : neighbors) {
@@ -153,7 +152,7 @@ void test_prim_reconstructor_impl(
   };
 
   const FixedHashMap<maximum_number_of_neighbors(3),
-                     std::pair<Direction<3>, ElementId<3>>, std::vector<double>,
+                     std::pair<Direction<3>, ElementId<3>>, DataVector,
                      boost::hash<std::pair<Direction<3>, ElementId<3>>>>
       neighbor_data = compute_neighbor_data(
           subcell_mesh, logical_coords, element.neighbors(),

--- a/tests/Unit/Helpers/Evolution/Systems/NewtonianEuler/FiniteDifference/PrimReconstructor.hpp
+++ b/tests/Unit/Helpers/Evolution/Systems/NewtonianEuler/FiniteDifference/PrimReconstructor.hpp
@@ -7,7 +7,6 @@
 
 #include <cstddef>
 #include <utility>
-#include <vector>
 
 #include "DataStructures/DataBox/PrefixHelpers.hpp"
 #include "DataStructures/DataBox/Prefixes.hpp"
@@ -37,7 +36,7 @@
 namespace TestHelpers::NewtonianEuler::fd {
 template <size_t Dim, typename F>
 FixedHashMap<maximum_number_of_neighbors(Dim),
-             std::pair<Direction<Dim>, ElementId<Dim>>, std::vector<double>,
+             std::pair<Direction<Dim>, ElementId<Dim>>, DataVector,
              boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>
 compute_neighbor_data(const Mesh<Dim>& subcell_mesh,
                       const tnsr::I<DataVector, Dim, Frame::ElementLogical>&
@@ -46,7 +45,7 @@ compute_neighbor_data(const Mesh<Dim>& subcell_mesh,
                       const size_t ghost_zone_size,
                       const F& compute_variables_of_neighbor_data) {
   FixedHashMap<maximum_number_of_neighbors(Dim),
-               std::pair<Direction<Dim>, ElementId<Dim>>, std::vector<double>,
+               std::pair<Direction<Dim>, ElementId<Dim>>, DataVector,
                boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>
       neighbor_data{};
   for (const auto& [direction, neighbors_in_direction] : neighbors) {
@@ -138,8 +137,7 @@ void test_prim_reconstructor_impl(
   };
 
   const FixedHashMap<maximum_number_of_neighbors(Dim),
-                     std::pair<Direction<Dim>, ElementId<Dim>>,
-                     std::vector<double>,
+                     std::pair<Direction<Dim>, ElementId<Dim>>, DataVector,
                      boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>
       neighbor_data = compute_neighbor_data(
           subcell_mesh, logical_coords, element.neighbors(),

--- a/tests/Unit/Helpers/Evolution/Systems/ScalarAdvection/FiniteDifference/TestHelpers.hpp
+++ b/tests/Unit/Helpers/Evolution/Systems/ScalarAdvection/FiniteDifference/TestHelpers.hpp
@@ -38,7 +38,7 @@ namespace TestHelpers {
 namespace ScalarAdvection::fd {
 template <size_t Dim, typename F>
 FixedHashMap<maximum_number_of_neighbors(Dim),
-             std::pair<Direction<Dim>, ElementId<Dim>>, std::vector<double>,
+             std::pair<Direction<Dim>, ElementId<Dim>>, DataVector,
              boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>
 compute_neighbor_data(const Mesh<Dim>& subcell_mesh,
                       const tnsr::I<DataVector, Dim, Frame::ElementLogical>&
@@ -47,7 +47,7 @@ compute_neighbor_data(const Mesh<Dim>& subcell_mesh,
                       const size_t ghost_zone_size,
                       const F& compute_variables_of_neighbor_data) {
   FixedHashMap<maximum_number_of_neighbors(Dim),
-               std::pair<Direction<Dim>, ElementId<Dim>>, std::vector<double>,
+               std::pair<Direction<Dim>, ElementId<Dim>>, DataVector,
                boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>
       neighbor_data{};
   for (const auto& [direction, neighbors_in_direction] : neighbors) {
@@ -116,8 +116,7 @@ void test_reconstructor(const size_t points_per_dimension,
                                Spectral::Quadrature::CellCentered};
   auto logical_coords = logical_coordinates(subcell_mesh);
   const FixedHashMap<maximum_number_of_neighbors(Dim),
-                     std::pair<Direction<Dim>, ElementId<Dim>>,
-                     std::vector<double>,
+                     std::pair<Direction<Dim>, ElementId<Dim>>, DataVector,
                      boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>
       neighbor_data = compute_neighbor_data(
           subcell_mesh, logical_coords, element.neighbors(),

--- a/tests/Unit/Helpers/NumericalAlgorithms/FiniteDifference/Exact.hpp
+++ b/tests/Unit/Helpers/NumericalAlgorithms/FiniteDifference/Exact.hpp
@@ -7,7 +7,6 @@
 
 #include <array>
 #include <cstddef>
-#include <vector>
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/SliceIterator.hpp"
@@ -72,8 +71,7 @@ void test_reconstruction_is_exact_if_in_basis(
       }
     }
   };
-  std::vector<double> volume_vars(mesh.number_of_grid_points() * number_of_vars,
-                                  0.0);
+  DataVector volume_vars{mesh.number_of_grid_points() * number_of_vars, 0.0};
   DataVector var1(volume_vars.data(), mesh.number_of_grid_points());
   DataVector var2(volume_vars.data() + mesh.number_of_grid_points(),  // NOLINT
                   mesh.number_of_grid_points());
@@ -84,13 +82,13 @@ void test_reconstruction_is_exact_if_in_basis(
   //
   // We do this by computing the solution in our entire neighbor, then using
   // slice_data to get the subset of points that are needed.
-  DirectionMap<Dim, std::vector<double>> neighbor_data{};
+  DirectionMap<Dim, DataVector> neighbor_data{};
   for (const auto& direction : Direction<Dim>::all_directions()) {
     auto neighbor_logical_coords = logical_coords;
     neighbor_logical_coords.get(direction.dimension()) +=
         direction.sign() * 2.0;
-    std::vector<double> neighbor_vars(
-        mesh.number_of_grid_points() * number_of_vars, 0.0);
+    DataVector neighbor_vars{mesh.number_of_grid_points() * number_of_vars,
+                             0.0};
     DataVector neighbor_var1(neighbor_vars.data(),
                              mesh.number_of_grid_points());
     DataVector neighbor_var2(
@@ -111,12 +109,10 @@ void test_reconstruction_is_exact_if_in_basis(
   // Note: reconstructed_num_pts assumes isotropic extents
   const size_t reconstructed_num_pts =
       (mesh.extents(0) + 1) * mesh.slice_away(0).number_of_grid_points();
-  std::array<std::vector<double>, Dim> reconstructed_upper_side_of_face_vars =
-      make_array<Dim>(
-          std::vector<double>(reconstructed_num_pts * number_of_vars));
-  std::array<std::vector<double>, Dim> reconstructed_lower_side_of_face_vars =
-      make_array<Dim>(
-          std::vector<double>(reconstructed_num_pts * number_of_vars));
+  std::array<DataVector, Dim> reconstructed_upper_side_of_face_vars =
+      make_array<Dim>(DataVector{reconstructed_num_pts * number_of_vars});
+  std::array<DataVector, Dim> reconstructed_lower_side_of_face_vars =
+      make_array<Dim>(DataVector{reconstructed_num_pts * number_of_vars});
 
   std::array<gsl::span<double>, Dim> recons_upper_side_of_face{};
   std::array<gsl::span<double>, Dim> recons_lower_side_of_face{};
@@ -161,8 +157,8 @@ void test_reconstruction_is_exact_if_in_basis(
           logical_coords_face_centered.get(i) + 4.0 * i;
     }
 
-    std::vector<double> expected_volume_vars(
-        face_centered_mesh.number_of_grid_points() * number_of_vars, 0.0);
+    DataVector expected_volume_vars{
+        face_centered_mesh.number_of_grid_points() * number_of_vars, 0.0};
     DataVector expected_var1(expected_volume_vars.data(),
                              face_centered_mesh.number_of_grid_points());
     DataVector expected_var2(

--- a/tests/Unit/NumericalAlgorithms/FiniteDifference/Test_NeighborDataAsVariables.cpp
+++ b/tests/Unit/NumericalAlgorithms/FiniteDifference/Test_NeighborDataAsVariables.cpp
@@ -6,7 +6,6 @@
 #include <boost/functional/hash.hpp>
 #include <cstddef>
 #include <utility>
-#include <vector>
 
 #include "DataStructures/DataBox/Tag.hpp"
 #include "DataStructures/DataVector.hpp"
@@ -44,15 +43,14 @@ void test() {
   const size_t neighbor_mesh_size =
       ghost_zone_size * subcell_mesh.extents().slice_away(0).product();
   FixedHashMap<maximum_number_of_neighbors(Dim),
-               std::pair<Direction<Dim>, ElementId<Dim>>, std::vector<double>,
+               std::pair<Direction<Dim>, ElementId<Dim>>, DataVector,
                boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>
       neighbor_data{};
   for (size_t i = 0; i < Direction<Dim>::all_directions().size(); ++i) {
     neighbor_data[std::pair{gsl::at(Direction<Dim>::all_directions(), i),
                             ElementId<Dim>{i}}] =
-        std::vector<double>(
-            Vars::number_of_independent_components * neighbor_mesh_size,
-            square(i + 1.0));
+        DataVector{Vars::number_of_independent_components * neighbor_mesh_size,
+                   square(i + 1.0)};
   }
   FixedHashMap<maximum_number_of_neighbors(Dim),
                std::pair<Direction<Dim>, ElementId<Dim>>, Vars,


### PR DESCRIPTION
## Proposed changes

This is a step towards #4580. Because we will eventually be using charm messages to send the boundary data and we want to avoid copies when we are on the same node, the MortarData needs to be able to store non-owning vectors and std::vector doesn't support this. That's why we make this switch to using DataVectors.

While making this change, I also had to change everything that uses the MortarData. This included ComputeTimeDerivaive, ApplyBoundaryCorrections, and all the subcell code because it previously expected the neighbor data to be a std::vector.

Basically all of the changes are in the last commit.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
