### PR TITLE
Store block names and groups in Domain/Block, bind in Python

### DIFF
--- a/src/DataStructures/Tensor/Python/Tensor.cpp
+++ b/src/DataStructures/Tensor/Python/Tensor.cpp
@@ -217,7 +217,8 @@ void bind_tensor(py::module& m) {
                    TensorKind::Jacobian>(m, "Jacobian");
 
   GENERATE_INSTANTIATIONS(INSTANTIATE_TNSR, (double, DataVector), (1, 2, 3),
-                          (Frame::ElementLogical, Frame::Inertial),
+                          (Frame::ElementLogical, Frame::BlockLogical,
+                           Frame::Grid, Frame::Distorted, Frame::Inertial),
                           (i, I, ij, iJ, ii, II, ijj))
   GENERATE_INSTANTIATIONS(INSTANTIATE_JAC, (double, DataVector), (1, 2, 3),
                           (Frame::Inertial))

--- a/src/DataStructures/Tensor/Python/__init__.py
+++ b/src/DataStructures/Tensor/Python/__init__.py
@@ -25,8 +25,10 @@ class TensorMeta:
             (dtype, dim, frame):
             globals()[f"Tensor{name}{_dtype_to_name(dtype)}{dim}{frame.name}"]
             for dtype, dim, frame in itertools.product(
-                [DataVector, float], [1, 2, 3],
-                [Frame.ElementLogical, Frame.Inertial])
+                [DataVector, float], [1, 2, 3], [
+                    Frame.ElementLogical, Frame.BlockLogical, Frame.Grid,
+                    Frame.Distorted, Frame.Inertial
+                ])
         }
 
     def _getitem(self, dtype: type, dim: int, frame: Frame = Frame.Inertial):

--- a/src/Domain/Block.hpp
+++ b/src/Domain/Block.hpp
@@ -9,6 +9,7 @@
 #include <cstddef>
 #include <iosfwd>
 #include <memory>
+#include <string>
 #include <unordered_set>
 
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
@@ -47,9 +48,11 @@ class Block {
   /// \param id a unique ID.
   /// \param neighbors info about the Blocks that share a codimension 1
   /// boundary with this Block.
+  /// \param name Human-readable name for the block
   Block(std::unique_ptr<domain::CoordinateMapBase<
             Frame::BlockLogical, Frame::Inertial, VolumeDim>>&& stationary_map,
-        size_t id, DirectionMap<VolumeDim, BlockNeighbor<VolumeDim>> neighbors);
+        size_t id, DirectionMap<VolumeDim, BlockNeighbor<VolumeDim>> neighbors,
+        std::string name = "");
 
   Block() = default;
   ~Block() = default;
@@ -135,6 +138,8 @@ class Block {
     return external_boundaries_;
   }
 
+  const std::string& name() const { return name_; }
+
   /// Serialization for Charm++
   // NOLINTNEXTLINE(google-runtime-references)
   void pup(PUP::er& p);
@@ -164,6 +169,7 @@ class Block {
   size_t id_{0};
   DirectionMap<VolumeDim, BlockNeighbor<VolumeDim>> neighbors_;
   std::unordered_set<Direction<VolumeDim>> external_boundaries_;
+  std::string name_;
 };
 
 template <size_t VolumeDim>

--- a/src/Domain/CoordinateMaps/Python/CoordinateMap.cpp
+++ b/src/Domain/CoordinateMaps/Python/CoordinateMap.cpp
@@ -17,6 +17,7 @@
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/GetOutput.hpp"
 
 namespace py = pybind11;
@@ -114,8 +115,23 @@ void bind_coordinate_map_impl(py::module& m) {  // NOLINT
 }  // namespace
 
 void bind_coordinate_map(py::module& m) {  // NOLINT
-  bind_coordinate_map_impl<Frame::ElementLogical, Frame::Inertial, 1>(m);
-  bind_coordinate_map_impl<Frame::ElementLogical, Frame::Inertial, 2>(m);
-  bind_coordinate_map_impl<Frame::ElementLogical, Frame::Inertial, 3>(m);
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data)                                                   \
+  bind_coordinate_map_impl<Frame::ElementLogical, Frame::BlockLogical,         \
+                           DIM(data)>(m);                                      \
+  bind_coordinate_map_impl<Frame::ElementLogical, Frame::Inertial, DIM(data)>( \
+      m);                                                                      \
+  bind_coordinate_map_impl<Frame::BlockLogical, Frame::Grid, DIM(data)>(m);    \
+  bind_coordinate_map_impl<Frame::BlockLogical, Frame::Inertial, DIM(data)>(   \
+      m);                                                                      \
+  bind_coordinate_map_impl<Frame::Grid, Frame::Distorted, DIM(data)>(m);       \
+  bind_coordinate_map_impl<Frame::Grid, Frame::Inertial, DIM(data)>(m);        \
+  bind_coordinate_map_impl<Frame::Distorted, Frame::Inertial, DIM(data)>(m);
+
+  GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
+
+#undef INSTANTIATE
+#undef DIM
 }
 }  // namespace domain::py_bindings

--- a/src/Domain/Creators/BinaryCompactObject.cpp
+++ b/src/Domain/Creators/BinaryCompactObject.cpp
@@ -530,7 +530,8 @@ Domain<3> BinaryCompactObject::create_domain() const {
   }
 
   // Have corners determined automatically
-  Domain<3> domain{std::move(maps), std::move(excision_spheres)};
+  Domain<3> domain{std::move(maps), std::move(excision_spheres), block_names_,
+                   block_groups_};
 
   // Inject the hard-coded time-dependence
   if (enable_time_dependence_) {

--- a/src/Domain/Creators/Cylinder.cpp
+++ b/src/Domain/Creators/Cylinder.cpp
@@ -300,7 +300,10 @@ Domain<3> Cylinder::create_domain() const {
           radial_distribution_, distribution_in_z_),
       corners_for_cylindrical_layered_domains(number_of_shells,
                                               number_of_layers),
-      pairs_of_faces};
+      pairs_of_faces,
+      {},
+      block_names_,
+      block_groups_};
 }
 
 std::vector<DirectionMap<

--- a/src/Domain/Creators/CylindricalBinaryCompactObject.cpp
+++ b/src/Domain/Creators/CylindricalBinaryCompactObject.cpp
@@ -801,7 +801,10 @@ Domain<3> CylindricalBinaryCompactObject::create_domain() const {
         CoordinateMaps::DiscreteRotation<3>(rotate_to_minus_x_axis));
   }
 
-  Domain<3> domain{std::move(coordinate_maps)};
+  std::unordered_map<std::string, ExcisionSphere<3>> excision_spheres{};
+
+  Domain<3> domain{std::move(coordinate_maps), std::move(excision_spheres),
+                   block_names_, block_groups_};
 
   if (is_time_dependent_) {
     // Same map for all the blocks for now.

--- a/src/Domain/Domain.hpp
+++ b/src/Domain/Domain.hpp
@@ -12,6 +12,7 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "Domain/Block.hpp"  // IWYU pragma: keep
@@ -61,11 +62,15 @@ class Domain {
    * determined. For more information on setting up domains, see the
    * [domain creation tutorial](\ref tutorial_domain_creation).
    */
-  explicit Domain(std::vector<std::unique_ptr<domain::CoordinateMapBase<
-                      Frame::BlockLogical, Frame::Inertial, VolumeDim>>>
-                      maps,
-                  std::unordered_map<std::string, ExcisionSphere<VolumeDim>>
-                      excision_spheres = {});
+  explicit Domain(
+      std::vector<std::unique_ptr<domain::CoordinateMapBase<
+          Frame::BlockLogical, Frame::Inertial, VolumeDim>>>
+          maps,
+      std::unordered_map<std::string, ExcisionSphere<VolumeDim>>
+          excision_spheres = {},
+      std::vector<std::string> block_names = {},
+      std::unordered_map<std::string, std::unordered_set<std::string>>
+          block_groups = {});
 
   /*!
    * Create a Domain using a corner numbering scheme to encode the Orientations,
@@ -91,7 +96,10 @@ class Domain {
              corners_of_all_blocks,
          const std::vector<PairOfFaces>& identifications = {},
          std::unordered_map<std::string, ExcisionSphere<VolumeDim>>
-             excision_spheres = {});
+             excision_spheres = {},
+         std::vector<std::string> block_names = {},
+         std::unordered_map<std::string, std::unordered_set<std::string>>
+             block_groups = {});
 
   Domain() = default;
   ~Domain() = default;
@@ -121,6 +129,11 @@ class Domain {
     return excision_spheres_;
   }
 
+  const std::unordered_map<std::string, std::unordered_set<std::string>>&
+  block_groups() const {
+    return block_groups_;
+  }
+
   // NOLINTNEXTLINE(google-runtime-references)
   void pup(PUP::er& p);
 
@@ -128,6 +141,8 @@ class Domain {
   std::vector<Block<VolumeDim>> blocks_{};
   std::unordered_map<std::string, ExcisionSphere<VolumeDim>>
       excision_spheres_{};
+  std::unordered_map<std::string, std::unordered_set<std::string>>
+      block_groups_{};
 };
 
 template <size_t VolumeDim>

--- a/src/Domain/Python/Bindings.cpp
+++ b/src/Domain/Python/Bindings.cpp
@@ -3,6 +3,7 @@
 
 #include <pybind11/pybind11.h>
 
+#include "Domain/Python/Block.hpp"
 #include "Domain/Python/BlockLogicalCoordinates.hpp"
 #include "Domain/Python/Domain.hpp"
 #include "Domain/Python/ElementId.hpp"
@@ -19,6 +20,7 @@ PYBIND11_MODULE(_PyDomain, m) {  // NOLINT
   py::module_::import("spectre.DataStructures");
   py::module_::import("spectre.DataStructures.Tensor");
   py::module_::import("spectre.Domain.CoordinateMaps");
+  py_bindings::bind_block(m);
   py_bindings::bind_block_logical_coordinates(m);
   py_bindings::bind_domain(m);
   py_bindings::bind_element_id(m);

--- a/src/Domain/Python/Block.cpp
+++ b/src/Domain/Python/Block.cpp
@@ -1,0 +1,46 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Domain/Python/Block.hpp"
+
+#include <cstddef>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <string>
+#include <vector>
+
+#include "Domain/Block.hpp"
+#include "Utilities/GetOutput.hpp"
+
+namespace py = pybind11;
+
+namespace domain::py_bindings {
+
+namespace {
+template <size_t Dim>
+void bind_block_impl(py::module& m) {  // NOLINT
+  py::class_<Block<Dim>>(m, ("Block" + get_output(Dim) + "D").c_str())
+      .def("is_time_dependent", &Block<Dim>::is_time_dependent)
+      .def("has_distorted_frame", &Block<Dim>::has_distorted_frame)
+      .def_property_readonly("id", &Block<Dim>::id)
+      .def_property_readonly("name", &Block<Dim>::name)
+      .def_property_readonly("stationary_map", &Block<Dim>::stationary_map)
+      .def_property_readonly("moving_mesh_logical_to_grid_map",
+                             &Block<Dim>::moving_mesh_logical_to_grid_map)
+      .def_property_readonly("moving_mesh_grid_to_inertial_map",
+                             &Block<Dim>::moving_mesh_grid_to_inertial_map)
+      .def_property_readonly("moving_mesh_grid_to_distorted_map",
+                             &Block<Dim>::moving_mesh_grid_to_distorted_map)
+      .def_property_readonly(
+          "moving_mesh_distorted_to_inertial_map",
+          &Block<Dim>::moving_mesh_distorted_to_inertial_map);
+}
+}  // namespace
+
+void bind_block(py::module& m) {  // NOLINT
+  bind_block_impl<1>(m);
+  bind_block_impl<2>(m);
+  bind_block_impl<3>(m);
+}
+
+}  // namespace domain::py_bindings

--- a/src/Domain/Python/Block.hpp
+++ b/src/Domain/Python/Block.hpp
@@ -1,0 +1,11 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <pybind11/pybind11.h>
+
+namespace domain::py_bindings {
+// NOLINTNEXTLINE(google-runtime-references)
+void bind_block(pybind11::module& m);
+}  // namespace domain::py_bindings

--- a/src/Domain/Python/CMakeLists.txt
+++ b/src/Domain/Python/CMakeLists.txt
@@ -8,6 +8,7 @@ spectre_python_add_module(
   LIBRARY_NAME ${LIBRARY}
   SOURCES
   Bindings.cpp
+  Block.cpp
   BlockLogicalCoordinates.cpp
   Domain.cpp
   ElementId.cpp
@@ -23,6 +24,7 @@ spectre_python_headers(
   ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
+  Block.hpp
   BlockLogicalCoordinates.hpp
   Domain.hpp
   ElementId.hpp

--- a/src/Domain/Python/Domain.cpp
+++ b/src/Domain/Python/Domain.cpp
@@ -23,7 +23,9 @@ namespace {
 template <size_t Dim>
 void bind_domain_impl(py::module& m) {  // NOLINT
   py::class_<Domain<Dim>>(m, ("Domain" + get_output(Dim) + "D").c_str())
-      .def("is_time_dependent", &Domain<Dim>::is_time_dependent);
+      .def("is_time_dependent", &Domain<Dim>::is_time_dependent)
+      .def_property_readonly("blocks", &Domain<Dim>::blocks)
+      .def_property_readonly("block_groups", &Domain<Dim>::block_groups);
   m.def(("deserialize_domain_" + get_output(Dim) + "d").c_str(),
         [](const std::vector<char>& serialized_domain) {
           return deserialize<Domain<Dim>>(serialized_domain.data());

--- a/src/Domain/Python/__init__.py
+++ b/src/Domain/Python/__init__.py
@@ -3,6 +3,7 @@
 
 from ._PyDomain import *
 
+Block = {1: Block1D, 2: Block2D, 3: Block3D}
 Domain = {1: Domain1D, 2: Domain2D, 3: Domain3D}
 ElementId = {1: ElementId1D, 2: ElementId2D, 3: ElementId3D}
 

--- a/tests/Unit/Domain/Python/Test_Domain.py
+++ b/tests/Unit/Domain/Python/Test_Domain.py
@@ -1,12 +1,16 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-from spectre.Domain import deserialize_domain
+from spectre.Domain import deserialize_domain, deserialize_functions_of_time
 
+import numpy as np
+import numpy.testing as npt
 import os
 import spectre.IO.H5 as spectre_h5
 import unittest
 from spectre.Informer import unit_test_src_path
+from spectre.DataStructures import DataVector
+from spectre.DataStructures.Tensor import Frame, tnsr
 
 
 class TestDomain(unittest.TestCase):
@@ -16,10 +20,29 @@ class TestDomain(unittest.TestCase):
         with spectre_h5.H5File(volfile_name, "r") as open_h5_file:
             volfile = open_h5_file.get_vol("/element_data")
             obs_id = volfile.list_observation_ids()[0]
+            time = volfile.get_observation_value(obs_id)
             serialized_domain = volfile.get_domain(obs_id)
+            serialized_fot = volfile.get_functions_of_time(obs_id)
 
         domain = deserialize_domain[3](serialized_domain)
         self.assertTrue(domain.is_time_dependent())
+        for block_id, block in enumerate(domain.blocks):
+            self.assertEqual(block.id, block_id)
+        domain.blocks[0].name == ""
+        self.assertEqual(len(domain.block_groups), 0)
+
+        # Check coordinate maps. The domain is [0, 2 pi]^3, so the block-logical
+        # coord (0, 0, 0) should map to (pi,) * 3
+        block = domain.blocks[0]
+        functions_of_time = deserialize_functions_of_time(serialized_fot)
+        logical_coord = tnsr.I[DataVector, 3, Frame.BlockLogical](num_points=1,
+                                                                  fill=0.)
+        self.assertTrue(block.is_time_dependent())
+        self.assertFalse(block.has_distorted_frame())
+        grid_coord = block.moving_mesh_logical_to_grid_map(logical_coord)
+        inertial_coord = block.moving_mesh_grid_to_inertial_map(
+            grid_coord, time, functions_of_time)
+        npt.assert_allclose(inertial_coord, [[np.pi]] * 3)
 
 
 if __name__ == '__main__':

--- a/tests/Unit/Domain/Test_Domain.cpp
+++ b/tests/Unit/Domain/Test_Domain.cpp
@@ -85,7 +85,12 @@ void test_1d_domains() {
                                            CoordinateMaps::Affine>>(
                 make_coordinate_map<Frame::BlockLogical, Frame::Inertial>(
                     CoordinateMaps::Affine{-1., 1., 0., 2.}))),
-        std::vector<std::array<size_t, 2>>{{{1, 2}}, {{3, 2}}});
+        std::vector<std::array<size_t, 2>>{{{1, 2}}, {{3, 2}}}, {}, {},
+        {"Left", "Right"}, {{"All", {"Left", "Right"}}});
+    CHECK(domain_from_corners.blocks()[0].name() == "Left");
+    CHECK(domain_from_corners.blocks()[1].name() == "Right");
+    CHECK(domain_from_corners.block_groups().at("All") ==
+          std::unordered_set<std::string>{"Left", "Right"});
 
     Domain<1> domain_no_corners(
         make_vector<std::unique_ptr<
@@ -97,8 +102,13 @@ void test_1d_domains() {
             std::make_unique<CoordinateMap<Frame::BlockLogical, Frame::Inertial,
                                            CoordinateMaps::Affine>>(
                 make_coordinate_map<Frame::BlockLogical, Frame::Inertial>(
-                    CoordinateMaps::Affine{-1., 1., 2., 0.}))));
+                    CoordinateMaps::Affine{-1., 1., 2., 0.}))),
+        {}, {"Left", "Right"}, {{"All", {"Left", "Right"}}});
     CHECK_FALSE(domain_no_corners.is_time_dependent());
+    CHECK(domain_no_corners.blocks()[0].name() == "Left");
+    CHECK(domain_no_corners.blocks()[1].name() == "Right");
+    CHECK(domain_no_corners.block_groups().at("All") ==
+          std::unordered_set<std::string>{"Left", "Right"});
 
     test_serialization(domain_no_corners);
 
@@ -413,6 +423,37 @@ void test_3d_rectilinear_domains() {
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Domain.Domain", "[Domain][Unit]") {
+  {
+    INFO("Equality operator");
+    Domain<1> lhs{
+        make_vector(
+            make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
+                CoordinateMaps::Affine{-1., 1., -2., 0.})),
+        {},
+        {"Block0"},
+        {{"All", {"Block0"}}}};
+    {
+      Domain<1> rhs{
+          make_vector(
+              make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
+                  CoordinateMaps::Affine{-1., 1., -2., 0.})),
+          {},
+          {"Block1"},
+          {{"All", {"Block0"}}}};
+      CHECK_FALSE(lhs == rhs);
+    }
+    {
+      Domain<1> rhs{
+          make_vector(
+              make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
+                  CoordinateMaps::Affine{-1., 1., -2., 0.})),
+          {},
+          {"Block0"},
+          {}};
+      CHECK_FALSE(lhs == rhs);
+    }
+  }
+
   test_1d_domains();
   test_1d_rectilinear_domains();
   test_2d_rectilinear_domains();

--- a/tests/Unit/Helpers/Domain/Creators/TestHelpers.hpp
+++ b/tests/Unit/Helpers/Domain/Creators/TestHelpers.hpp
@@ -43,6 +43,10 @@ Domain<Dim> test_domain_creator(const DomainCreator<Dim>& domain_creator,
   {
     CAPTURE(block_names);
     CHECK((block_names.empty() or (block_names.size() == blocks.size())));
+    for (size_t block_id = 0; block_id < block_names.size(); ++block_id) {
+      CHECK(blocks[block_id].name() == block_names[block_id]);
+    }
+    CHECK(domain.block_groups() == block_groups);
     {
       INFO("Test block names are unique");
       auto sorted_block_names = block_names;


### PR DESCRIPTION
## Proposed changes

Makes block names and groups accessible through the Domain. Also writes the names to H5 files (through serialization) so they are available in post-processing.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
