### PR TITLE
Add new inbox tag that uses BoundaryMessage

### DIFF
--- a/src/Evolution/DiscontinuousGalerkin/InboxTags.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/InboxTags.hpp
@@ -6,6 +6,7 @@
 #include <boost/functional/hash.hpp>
 #include <cstddef>
 #include <map>
+#include <memory>
 #include <optional>
 #include <tuple>
 #include <type_traits>
@@ -15,6 +16,7 @@
 #include "Domain/Structure/Direction.hpp"
 #include "Domain/Structure/ElementId.hpp"
 #include "Domain/Structure/MaxNumberOfNeighbors.hpp"
+#include "Evolution/DiscontinuousGalerkin/Messages/BoundaryMessage.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "Parallel/InboxInserters.hpp"
 #include "Time/TimeStepId.hpp"
@@ -171,6 +173,124 @@ struct BoundaryCorrectionAndGhostCellsInbox {
         ERROR("Failed to insert data to receive at instance '"
               << time_step_id
               << "' with tag 'BoundaryCorrectionAndGhostCellsInbox'.\n");
+      }
+    }
+  }
+};
+
+/*!
+ * \brief The inbox tag for boundary correction communication and DG-subcell
+ * ghost zone cells using a `BoundaryMessage` object
+ *
+ * To see what is stored within a `BoundaryMessage`, see its documentation.
+ *
+ * This inbox tag is very similar to `BoundaryCorrectionAndGhostCellsInbox` in
+ * that it stores subcell/DG data sent from neighboring elements. To see exactly
+ * when data is stored and how it's used, see the docs for
+ * `BoundaryCorrectionAndGhostCellsInbox`. This inbox tag is different than
+ * `BoundaryCorrectionAndGhostCellsInbox` in that it only takes a pointer to a
+ * `BoundaryMessage` as an argument to `insert_into_inbox` and stores a
+ * `std::unique_ptr<BoundaryMessage>` inside the inbox.
+ *
+ * This inbox tag is meant to be used to avoid unnecessary copies between
+ * elements on the same node which share a block of memory. If two elements
+ * aren't on the same node, then a copy/send is done regardless.
+ *
+ * \warning The `boundary_message` argument to `insert_into_inbox()` will be
+ * invalid after the function is called because a `std::unique_ptr` now controls
+ * the memory. Calling a method on the `boundary_message` pointer after the
+ * `insert_into_inbox()` function is called can result in undefined behaviour.
+ */
+template <size_t Dim>
+struct BoundaryMessageInbox {
+  using stored_type = std::unique_ptr<BoundaryMessage<Dim>>;
+
+ public:
+  using temporal_id = TimeStepId;
+  using type = std::map<
+      TimeStepId,
+      FixedHashMap<maximum_number_of_neighbors(Dim),
+                   std::pair<Direction<Dim>, ElementId<Dim>>, stored_type,
+                   boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>>;
+
+  template <typename Inbox>
+  static void insert_into_inbox(const gsl::not_null<Inbox*> inbox,
+                                BoundaryMessage<Dim>* boundary_message) {
+    const auto& time_step_id = boundary_message->current_time_step_id;
+    auto& current_inbox = (*inbox)[time_step_id];
+
+    const auto key = std::pair{boundary_message->neighbor_direction,
+                               boundary_message->element_id};
+
+    if (auto it = current_inbox.find(key); it != current_inbox.end()) {
+      auto& current_boundary_data = it->second;
+      // We have already received some data at this time. Receiving data twice
+      // at the same time should only occur when receiving fluxes after having
+      // previously received ghost cells. We sanity check that the data we
+      // already have is the ghost cells and that we have not yet received flux
+      // data.
+      //
+      // This is used if a 2-send implementation is used (which we don't right
+      // now!). We generally find that the number of communications is more
+      // important than the size of each communication, and so a single
+      // communication per time/sub step is preferred.
+      ASSERT(current_boundary_data->subcell_ghost_data != nullptr,
+             "Have not yet received ghost cells at time step "
+                 << time_step_id
+                 << " but the inbox entry already exists. This is a bug in the "
+                    "ordering of the actions.");
+      ASSERT(current_boundary_data->dg_flux_data == nullptr,
+             "The fluxes have already been received at time step "
+                 << time_step_id
+                 << ". They are either being received for a second time, there "
+                    "is a bug in the ordering of the actions (though a "
+                    "different ASSERT should've caught that), or the incorrect "
+                    "temporal ID is being sent.");
+      ASSERT(boundary_message->subcell_ghost_data == nullptr,
+             "Have already received ghost cells at time step "
+                 << time_step_id
+                 << ", but we are being sent ghost cells again. This data will "
+                    "not be cleaned up while the dg flux data is being "
+                    "inserted into the inbox which will cause a memory leak.");
+
+      ASSERT(current_boundary_data->interface_mesh ==
+                 boundary_message->interface_mesh,
+             "The mesh being received for the fluxes is different than the "
+             "mesh received for the ghost cells. Mesh for fluxes: "
+                 << boundary_message->interface_mesh << " mesh for ghost cells "
+                 << current_boundary_data->interface_mesh);
+      ASSERT(current_boundary_data->volume_or_ghost_mesh ==
+                 boundary_message->volume_or_ghost_mesh,
+             "The mesh being received for the ghost cell data is different "
+             "than the mesh received previously. Mesh for received when we got "
+             "fluxes: "
+                 << boundary_message->volume_or_ghost_mesh
+                 << " mesh received when we got ghost cells "
+                 << current_boundary_data->volume_or_ghost_mesh);
+
+      // Just need to set the pointer. No need to worry about the data being
+      // deleted upon destruction of boundary_message because the destructor of
+      // a BoundaryMessage will only delete the pointer stored inside the
+      // BoundaryMessage. It won't delete the actual data it points to. Now the
+      // unique_ptr owns the data that was previously pointed to by
+      // boundary_message
+      current_boundary_data->dg_flux_data_size =
+          boundary_message->dg_flux_data_size;
+      current_boundary_data->dg_flux_data = boundary_message->dg_flux_data;
+      current_boundary_data->next_time_step_id =
+          boundary_message->next_time_step_id;
+      current_boundary_data->tci_status = boundary_message->tci_status;
+    } else {
+      // We have not received ghost cells or fluxes at this time.
+      // Once we insert boundary_message into the unique_ptr we cannot use
+      // boundary_message anymore because it is invalidated. The unique_ptr now
+      // owns the memory.
+      if (not current_inbox
+                  .insert(std::pair{key, std::unique_ptr<BoundaryMessage<Dim>>(
+                                             boundary_message)})
+                  .second) {
+        ERROR("Failed to insert data to receive at instance '"
+              << time_step_id << "' with tag 'BoundaryMessageInbox'.\n");
       }
     }
   }

--- a/src/Evolution/DiscontinuousGalerkin/Messages/BoundaryMessage.cpp
+++ b/src/Evolution/DiscontinuousGalerkin/Messages/BoundaryMessage.cpp
@@ -14,19 +14,26 @@ namespace evolution::dg {
 template <size_t Dim>
 BoundaryMessage<Dim>::BoundaryMessage(
     const size_t subcell_ghost_data_size_in, const size_t dg_flux_data_size_in,
-    const bool sent_across_nodes_in, const size_t sender_node_in,
-    const size_t sender_core_in, const ::TimeStepId& current_time_step_id_in,
+    const bool sent_across_nodes_in, const bool enable_if_disabled_in,
+    const size_t sender_node_in, const size_t sender_core_in,
+    const int tci_status_in, const ::TimeStepId& current_time_step_id_in,
     const ::TimeStepId& next_time_step_id_in,
+    const Direction<Dim>& neighbor_direction_in,
+    const ElementId<Dim>& element_id_in,
     const Mesh<Dim>& volume_or_ghost_mesh_in,
     const Mesh<Dim - 1>& interface_mesh_in, double* subcell_ghost_data_in,
     double* dg_flux_data_in)
     : subcell_ghost_data_size(subcell_ghost_data_size_in),
       dg_flux_data_size(dg_flux_data_size_in),
       sent_across_nodes(sent_across_nodes_in),
+      enable_if_disabled(enable_if_disabled_in),
       sender_node(sender_node_in),
       sender_core(sender_core_in),
+      tci_status(tci_status_in),
       current_time_step_id(current_time_step_id_in),
       next_time_step_id(next_time_step_id_in),
+      neighbor_direction(neighbor_direction_in),
+      element_id(element_id_in),
       volume_or_ghost_mesh(volume_or_ghost_mesh_in),
       interface_mesh(interface_mesh_in),
       subcell_ghost_data(subcell_ghost_data_in),
@@ -133,10 +140,14 @@ bool operator==(const BoundaryMessage<Dim>& lhs,
   return lhs.subcell_ghost_data_size == rhs.subcell_ghost_data_size and
          lhs.dg_flux_data_size == rhs.dg_flux_data_size and
          lhs.sent_across_nodes == rhs.sent_across_nodes and
+         lhs.enable_if_disabled == rhs.enable_if_disabled and
          lhs.sender_node == rhs.sender_node and
          lhs.sender_core == rhs.sender_core and
+         lhs.tci_status == rhs.tci_status and
          lhs.current_time_step_id == rhs.current_time_step_id and
          lhs.next_time_step_id == rhs.next_time_step_id and
+         lhs.neighbor_direction == rhs.neighbor_direction and
+         lhs.element_id == rhs.element_id and
          lhs.volume_or_ghost_mesh == rhs.volume_or_ghost_mesh and
          lhs.interface_mesh == rhs.interface_mesh and
          // We are guaranteed that lhs.subcell_size == rhs.subcell_size and
@@ -166,10 +177,15 @@ std::ostream& operator<<(std::ostream& os,
   os << "dg_flux_data_size = " << message.dg_flux_data_size << "\n";
   os << "sent_across_nodes = " << std::boolalpha << message.sent_across_nodes
      << "\n";
+  os << "enable_if_disabled = " << std::boolalpha << message.enable_if_disabled
+     << "\n";
   os << "sender_node = " << message.sender_node << "\n";
   os << "sender_core = " << message.sender_core << "\n";
+  os << "tci_status = " << message.tci_status << "\n";
   os << "current_time_ste_id = " << message.current_time_step_id << "\n";
   os << "next_time_ste_id = " << message.next_time_step_id << "\n";
+  os << "neighbor_direction = " << message.neighbor_direction << "\n";
+  os << "element_id = " << message.element_id << "\n";
   os << "volume_or_ghost_mesh = " << message.volume_or_ghost_mesh << "\n";
   os << "interface_mesh = " << message.interface_mesh << "\n";
 

--- a/src/Evolution/DiscontinuousGalerkin/Messages/BoundaryMessage.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Messages/BoundaryMessage.hpp
@@ -7,6 +7,8 @@
 #include <ostream>
 #include <type_traits>
 
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/ElementId.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "Time/TimeStepId.hpp"
 #include "Utilities/PrettyType.hpp"
@@ -31,10 +33,14 @@ struct BoundaryMessage : public CMessage_BoundaryMessage<Dim> {
   size_t subcell_ghost_data_size;
   size_t dg_flux_data_size;
   bool sent_across_nodes;
+  bool enable_if_disabled;
   size_t sender_node;
   size_t sender_core;
+  int tci_status;
   ::TimeStepId current_time_step_id;
   ::TimeStepId next_time_step_id;
+  Direction<Dim> neighbor_direction;
+  ElementId<Dim> element_id;
   Mesh<Dim> volume_or_ghost_mesh;
   Mesh<Dim - 1> interface_mesh;
 
@@ -46,10 +52,13 @@ struct BoundaryMessage : public CMessage_BoundaryMessage<Dim> {
 
   BoundaryMessage(const size_t subcell_ghost_data_size_in,
                   const size_t dg_flux_data_size_in,
-                  const bool sent_across_nodes_in, const size_t sender_node_in,
-                  const size_t sender_core_in,
+                  const bool sent_across_nodes_in,
+                  const bool enable_if_disabled_in, const size_t sender_node_in,
+                  const size_t sender_core_in, const int tci_status_in,
                   const ::TimeStepId& current_time_step_id_in,
                   const ::TimeStepId& next_time_step_id_in,
+                  const Direction<Dim>& neighbor_direction_in,
+                  const ElementId<Dim>& element_id_in,
                   const Mesh<Dim>& volume_or_ghost_mesh_in,
                   const Mesh<Dim - 1>& interface_mesh_in,
                   double* subcell_ghost_data_in, double* dg_flux_data_in);

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Messages/Test_BoundaryMessage.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Messages/Test_BoundaryMessage.cpp
@@ -8,6 +8,9 @@
 #include <sstream>
 #include <string>
 
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Domain/Structure/Side.hpp"
 #include "Evolution/DiscontinuousGalerkin/Messages/BoundaryMessage.hpp"
 #include "Framework/TestHelpers.hpp"
 #include "Helpers/DataStructures/MakeWithRandomValues.hpp"
@@ -35,8 +38,10 @@ void test_boundary_message(const gsl::not_null<Generator*> generator,
                                     (subcell_size + dg_size) * sizeof(double));
 
   const bool sent_across_nodes = true;
+  const bool enable_if_disabled = false;
   const size_t sender_node = 2;
   const size_t sender_core = 15;
+  const int tci_status = -3;
 
   const Slab current_slab{0.1, 0.5};
   const Time current_time{current_slab, {0, 1}};
@@ -44,6 +49,8 @@ void test_boundary_message(const gsl::not_null<Generator*> generator,
   const Slab next_slab{0.5, 0.9};
   const Time next_time{next_slab, {0, 1}};
   const TimeStepId next_time_id{true, 0, next_time};
+  const Direction<Dim> neighbor_direction{0, Side::Upper};
+  const ElementId<Dim> element_id{0};
 
   const size_t extents = 4;
   const Mesh<Dim> volume_mesh{extents, Spectral::Basis::Legendre,
@@ -61,13 +68,15 @@ void test_boundary_message(const gsl::not_null<Generator*> generator,
   DataVector copied_dg_data = dg_data;
 
   BoundaryMessage<Dim>* boundary_message = new BoundaryMessage<Dim>(
-      subcell_size, dg_size, sent_across_nodes, sender_node, sender_core,
-      current_time_id, next_time_id, volume_mesh, interface_mesh,
+      subcell_size, dg_size, sent_across_nodes, enable_if_disabled, sender_node,
+      sender_core, tci_status, current_time_id, next_time_id,
+      neighbor_direction, element_id, volume_mesh, interface_mesh,
       subcell_size != 0 ? subcell_data.data() : nullptr,
       dg_size != 0 ? dg_data.data() : nullptr);
   BoundaryMessage<Dim>* copied_boundary_message = new BoundaryMessage<Dim>(
-      subcell_size, dg_size, sent_across_nodes, sender_node, sender_core,
-      current_time_id, next_time_id, volume_mesh, interface_mesh,
+      subcell_size, dg_size, sent_across_nodes, enable_if_disabled, sender_node,
+      sender_core, tci_status, current_time_id, next_time_id,
+      neighbor_direction, element_id, volume_mesh, interface_mesh,
       subcell_size != 0 ? copied_subcell_data.data() : nullptr,
       dg_size != 0 ? copied_dg_data.data() : nullptr);
 
@@ -88,8 +97,10 @@ void test_output() {
   const size_t dg_size = 3;
 
   const bool sent_across_nodes = true;
+  const bool enable_if_disabled = false;
   const size_t sender_node = 2;
   const size_t sender_core = 15;
+  const int tci_status = -3;
 
   const Slab current_slab{0.1, 0.5};
   const Time current_time{current_slab, {0, 1}};
@@ -97,6 +108,8 @@ void test_output() {
   const Slab next_slab{0.5, 0.9};
   const Time next_time{next_slab, {0, 1}};
   const TimeStepId next_time_id{true, 0, next_time};
+  const Direction<2> neighbor_direction{0, Side::Upper};
+  const ElementId<2> element_id{0};
 
   const size_t extents = 4;
   const Mesh<2> volume_mesh{extents, Spectral::Basis::Legendre,
@@ -106,11 +119,14 @@ void test_output() {
   DataVector subcell_data{0.1, 0.2, 0.3, 0.4};
   DataVector dg_data{-0.3, -0.2, -0.1};
 
-  BoundaryMessage<2> message{
-      subcell_size,        dg_size,       sent_across_nodes,
-      sender_node,         sender_core,   current_time_id,
-      next_time_id,        volume_mesh,   interface_mesh,
-      subcell_data.data(), dg_data.data()};
+  BoundaryMessage<2> message{subcell_size,      dg_size,
+                             sent_across_nodes, enable_if_disabled,
+                             sender_node,       sender_core,
+                             tci_status,        current_time_id,
+                             next_time_id,      neighbor_direction,
+                             element_id,        volume_mesh,
+                             interface_mesh,    subcell_data.data(),
+                             dg_data.data()};
 
   const std::string message_str = get_output(message);
 
@@ -118,12 +134,16 @@ void test_output() {
   ss << "subcell_ghost_data_size = 4\n"
      << "dg_flux_data_size = 3\n"
      << "sent_across_nodes = true\n"
+     << "enable_if_disabled = false\n"
      << "sender_node = 2\n"
      << "sender_core = 15\n"
+     << "tci_status = -3\n"
      // TimeStepIds have complicated output so don't try and hard code it, just
      // use get_output
      << "current_time_ste_id = " << get_output(current_time_id) << "\n"
      << "next_time_ste_id = " << get_output(next_time_id) << "\n"
+     << "neighbor_direction = +0\n"
+     << "element_id = [B0,(L0I0,L0I0)]\n"
      << "volume_or_ghost_mesh = "
         "[(4,4),(Legendre,Legendre),(GaussLobatto,GaussLobatto)]\n"
      << "interface_mesh = [(4),(Legendre),(GaussLobatto)]\n"

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Test_InboxTags.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Test_InboxTags.cpp
@@ -23,25 +23,57 @@
 
 namespace evolution::dg {
 namespace {
+
+template <size_t Dim>
+BoundaryMessage<Dim>* create_boundary_message(
+    const TimeStepId& current_time_step_id, const TimeStepId& next_time_step_id,
+    const std::pair<Direction<Dim>, ElementId<Dim>>& key,
+    const Mesh<Dim>& volume_mesh, const Mesh<Dim - 1>& interface_mesh,
+    std::optional<DataVector>& ghost_data, std::optional<DataVector>& dg_data,
+    const int tci_status) {
+  return new BoundaryMessage<Dim>(
+      ghost_data.value_or(DataVector{}).size(),  // subcell_ghost_data_size
+      dg_data.value_or(DataVector{}).size(),     // dg_flux_data_size
+      true,                                      // sent_across_nodes
+      false,                                     // enable_if_disabled
+      2,                                         // sender_node
+      12,                                        // sender_core
+      tci_status,                                // tci_status
+      current_time_step_id,                      // current_time_step_id
+      next_time_step_id,                         // next_time_step_id
+      key.first,                                 // neighbor_direction
+      key.second,                                // element_id
+      volume_mesh,                               // volume_or_ghost_mesh
+      interface_mesh,                            // interface_mesh
+      ghost_data.has_value() ? ghost_data.value().data()
+                             : nullptr,  // subcell_ghost_data
+      dg_data.has_value() ? dg_data.value().data() : nullptr  // dg_flux_data
+  );
+}
+
 template <size_t Dim>
 void test_no_ghost_cells() {
   static constexpr size_t number_of_components = 1 + Dim;
   using bc_tag = Tags::BoundaryCorrectionAndGhostCellsInbox<Dim>;
-  using Type = std::tuple<Mesh<Dim>, Mesh<Dim - 1>, std::optional<DataVector>,
-                          std::optional<DataVector>, ::TimeStepId, int>;
-  using Inbox = typename bc_tag::type;
+  using bm_tag = Tags::BoundaryMessageInbox<Dim>;
+  using BcType = std::tuple<Mesh<Dim>, Mesh<Dim - 1>, std::optional<DataVector>,
+                            std::optional<DataVector>, ::TimeStepId, int>;
+  using BcInbox = typename bc_tag::type;
+  using BmInbox = typename bm_tag::type;
 
   std::uniform_real_distribution<double> dist(-1.0, 2.3);
   MAKE_GENERATOR(gen);
+  std::optional<DataVector> nullopt = std::nullopt;
 
   const TimeStepId time_step_id_a{true, 3, Time{Slab{0.2, 3.4}, {3, 100}}};
   const TimeStepId time_step_id_b{true, 4, Time{Slab{3.4, 5.4}, {13, 100}}};
   const TimeStepId time_step_id_c{true, 5, Time{Slab{5.4, 6.4}, {17, 100}}};
   const std::pair nhbr_key{Direction<Dim>::lower_xi(), ElementId<Dim>{1}};
 
-  Inbox inbox{};
+  BcInbox bc_inbox{};
+  BmInbox bm_inbox{};
 
-  Type send_data_a{};
+  BcType send_data_a{};
   const Mesh<Dim> volume_mesh_a{5, Spectral::Basis::Legendre,
                                 Spectral::Quadrature::GaussLobatto};
   const Mesh<Dim - 1> mesh_a{5, Spectral::Basis::Legendre,
@@ -55,12 +87,21 @@ void test_no_ghost_cells() {
   fill_with_random_values(make_not_null(&*get<3>(send_data_a)),
                           make_not_null(&gen), make_not_null(&dist));
 
-  bc_tag::insert_into_inbox(make_not_null(&inbox), time_step_id_a,
+  BoundaryMessage<Dim>* boundary_message_a = create_boundary_message(
+      time_step_id_a, time_step_id_a, nhbr_key, volume_mesh_a, mesh_a, nullopt,
+      get<3>(send_data_a), get<5>(send_data_a));
+  BoundaryMessage<Dim>* boundary_message_a_compare = boundary_message_a;
+
+  bc_tag::insert_into_inbox(make_not_null(&bc_inbox), time_step_id_a,
                             std::make_pair(nhbr_key, send_data_a));
+  bm_tag::insert_into_inbox(make_not_null(&bm_inbox), boundary_message_a);
 
-  CHECK((inbox.at(time_step_id_a).at(nhbr_key) == send_data_a));
+  CHECK((bc_inbox.at(time_step_id_a).at(nhbr_key) == send_data_a));
+  // Check the values, not the pointers
+  CHECK(*(bm_inbox.at(time_step_id_a).at(nhbr_key).get()) ==
+        *boundary_message_a_compare);
 
-  Type send_data_b{};
+  BcType send_data_b{};
   const Mesh<Dim> volume_mesh_b{7, Spectral::Basis::Legendre,
                                 Spectral::Quadrature::GaussLobatto};
   const Mesh<Dim - 1> mesh_b{7, Spectral::Basis::Legendre,
@@ -77,40 +118,61 @@ void test_no_ghost_cells() {
   fill_with_random_values(make_not_null(&*get<3>(send_data_b)),
                           make_not_null(&gen), make_not_null(&dist));
 
-  bc_tag::insert_into_inbox(make_not_null(&inbox), time_step_id_b,
+  BoundaryMessage<Dim>* boundary_message_b = create_boundary_message(
+      time_step_id_b, time_step_id_c, nhbr_key, volume_mesh_b, mesh_b, nullopt,
+      get<3>(send_data_b), get<5>(send_data_b));
+  BoundaryMessage<Dim>* boundary_message_b_compare = boundary_message_b;
+
+  bc_tag::insert_into_inbox(make_not_null(&bc_inbox), time_step_id_b,
                             std::make_pair(nhbr_key, send_data_b));
+  bm_tag::insert_into_inbox(make_not_null(&bm_inbox),
+                            boundary_message_b_compare);
 
-  CHECK((inbox.at(time_step_id_a).at(nhbr_key) == send_data_a));
-  CHECK((inbox.at(time_step_id_b).at(nhbr_key) == send_data_b));
+  CHECK((bc_inbox.at(time_step_id_a).at(nhbr_key) == send_data_a));
+  CHECK((bc_inbox.at(time_step_id_b).at(nhbr_key) == send_data_b));
+  CHECK(*(bm_inbox.at(time_step_id_a).at(nhbr_key).get()) ==
+        *boundary_message_a_compare);
+  CHECK(*(bm_inbox.at(time_step_id_b).at(nhbr_key).get()) ==
+        *boundary_message_b_compare);
 
-  inbox.erase(time_step_id_a);
-  CHECK(inbox.count(time_step_id_a) == 0);
+  bc_inbox.erase(time_step_id_a);
+  bm_inbox.erase(time_step_id_a);
+  CHECK(bc_inbox.count(time_step_id_a) == 0);
+  CHECK(bm_inbox.count(time_step_id_a) == 0);
 
-  CHECK((inbox.at(time_step_id_b).at(nhbr_key) == send_data_b));
-  inbox.erase(time_step_id_b);
-  CHECK(inbox.count(time_step_id_b) == 0);
+  CHECK((bc_inbox.at(time_step_id_b).at(nhbr_key) == send_data_b));
+  CHECK(*(bm_inbox.at(time_step_id_b).at(nhbr_key).get()) ==
+        *boundary_message_b_compare);
+  bc_inbox.erase(time_step_id_b);
+  bm_inbox.erase(time_step_id_b);
+  CHECK(bc_inbox.count(time_step_id_b) == 0);
+  CHECK(bm_inbox.count(time_step_id_b) == 0);
 }
 
 template <size_t Dim>
 void test_with_ghost_cells() {
   static constexpr size_t number_of_components = 1 + Dim;
   using bc_tag = Tags::BoundaryCorrectionAndGhostCellsInbox<Dim>;
-  using Type = std::tuple<Mesh<Dim>, Mesh<Dim - 1>, std::optional<DataVector>,
-                          std::optional<DataVector>, ::TimeStepId, int>;
-  using Inbox = typename bc_tag::type;
+  using bm_tag = Tags::BoundaryMessageInbox<Dim>;
+  using BcType = std::tuple<Mesh<Dim>, Mesh<Dim - 1>, std::optional<DataVector>,
+                            std::optional<DataVector>, ::TimeStepId, int>;
+  using BcInbox = typename bc_tag::type;
+  using BmInbox = typename bm_tag::type;
 
   std::uniform_real_distribution<double> dist(-1.0, 2.3);
   MAKE_GENERATOR(gen);
+  std::optional<DataVector> nullopt = std::nullopt;
 
   const TimeStepId time_step_id_a{true, 3, Time{Slab{0.2, 3.4}, {3, 100}}};
   const TimeStepId time_step_id_b{true, 4, Time{Slab{3.4, 5.4}, {13, 100}}};
   const TimeStepId time_step_id_c{true, 5, Time{Slab{5.4, 6.4}, {17, 100}}};
   const std::pair nhbr_key{Direction<Dim>::lower_xi(), ElementId<Dim>{1}};
 
-  Inbox inbox{};
+  BcInbox bc_inbox{};
+  BmInbox bm_inbox{};
 
   // Send ghost cells first
-  Type send_data_a{};
+  BcType send_data_a{};
   const Mesh<Dim> volume_mesh_a{5, Spectral::Basis::Legendre,
                                 Spectral::Quadrature::GaussLobatto};
   const Mesh<Dim - 1> mesh_a{5, Spectral::Basis::Legendre,
@@ -124,12 +186,21 @@ void test_with_ghost_cells() {
   fill_with_random_values(make_not_null(&*get<2>(send_data_a)),
                           make_not_null(&gen), make_not_null(&dist));
 
-  bc_tag::insert_into_inbox(make_not_null(&inbox), time_step_id_a,
+  BoundaryMessage<Dim>* boundary_message_a = create_boundary_message(
+      time_step_id_a, time_step_id_a, nhbr_key, volume_mesh_a, mesh_a,
+      get<2>(send_data_a), nullopt, get<5>(send_data_a));
+  BoundaryMessage<Dim>* boundary_message_a_compare = boundary_message_a;
+
+  bc_tag::insert_into_inbox(make_not_null(&bc_inbox), time_step_id_a,
                             std::make_pair(nhbr_key, send_data_a));
+  bm_tag::insert_into_inbox(make_not_null(&bm_inbox), boundary_message_a);
 
-  CHECK((inbox.at(time_step_id_a).at(nhbr_key) == send_data_a));
+  CHECK((bc_inbox.at(time_step_id_a).at(nhbr_key) == send_data_a));
+  // Check the values, not the pointers
+  CHECK(*(bm_inbox.at(time_step_id_a).at(nhbr_key).get()) ==
+        *boundary_message_a_compare);
 
-  Type send_data_b{};
+  BcType send_data_b{};
   const Mesh<Dim> volume_mesh_b{7, Spectral::Basis::Legendre,
                                 Spectral::Quadrature::GaussLobatto};
   const Mesh<Dim - 1> mesh_b{7, Spectral::Basis::Legendre,
@@ -143,23 +214,45 @@ void test_with_ghost_cells() {
   fill_with_random_values(make_not_null(&*get<2>(send_data_b)),
                           make_not_null(&gen), make_not_null(&dist));
 
-  bc_tag::insert_into_inbox(make_not_null(&inbox), time_step_id_b,
+  BoundaryMessage<Dim>* boundary_message_b = create_boundary_message(
+      time_step_id_b, time_step_id_b, nhbr_key, volume_mesh_b, mesh_b,
+      get<2>(send_data_b), nullopt, get<5>(send_data_b));
+  BoundaryMessage<Dim>* boundary_message_b_compare = boundary_message_b;
+
+  bc_tag::insert_into_inbox(make_not_null(&bc_inbox), time_step_id_b,
                             std::make_pair(nhbr_key, send_data_b));
+  bm_tag::insert_into_inbox(make_not_null(&bm_inbox), boundary_message_b);
 
-  CHECK((inbox.at(time_step_id_a).at(nhbr_key) == send_data_a));
-  CHECK((inbox.at(time_step_id_b).at(nhbr_key) == send_data_b));
+  CHECK((bc_inbox.at(time_step_id_a).at(nhbr_key) == send_data_a));
+  CHECK((bc_inbox.at(time_step_id_b).at(nhbr_key) == send_data_b));
+  CHECK(*(bm_inbox.at(time_step_id_a).at(nhbr_key).get()) ==
+        *boundary_message_a_compare);
+  CHECK(*(bm_inbox.at(time_step_id_b).at(nhbr_key).get()) ==
+        *boundary_message_b_compare);
 
-  inbox.erase(time_step_id_a);
-  CHECK(inbox.count(time_step_id_a) == 0);
+  bc_inbox.erase(time_step_id_a);
+  bm_inbox.erase(time_step_id_a);
+  CHECK(bc_inbox.count(time_step_id_a) == 0);
+  CHECK(bm_inbox.count(time_step_id_a) == 0);
 
-  CHECK((inbox.at(time_step_id_b).at(nhbr_key) == send_data_b));
-  inbox.erase(time_step_id_b);
-  CHECK(inbox.count(time_step_id_b) == 0);
+  CHECK((bc_inbox.at(time_step_id_b).at(nhbr_key) == send_data_b));
+  CHECK(*(bm_inbox.at(time_step_id_b).at(nhbr_key).get()) ==
+        *boundary_message_b_compare);
+  bc_inbox.erase(time_step_id_b);
+  bm_inbox.erase(time_step_id_b);
+  CHECK(bc_inbox.count(time_step_id_b) == 0);
+  CHECK(bm_inbox.count(time_step_id_b) == 0);
 
   // Now send fluxes separately.
-  bc_tag::insert_into_inbox(make_not_null(&inbox), time_step_id_a,
+  bc_tag::insert_into_inbox(make_not_null(&bc_inbox), time_step_id_a,
                             std::make_pair(nhbr_key, send_data_a));
-  Type send_flux_data_a;
+
+  boundary_message_a = create_boundary_message(
+      time_step_id_a, time_step_id_a, nhbr_key, volume_mesh_a, mesh_a,
+      get<2>(send_data_a), nullopt, get<5>(send_data_a));
+  bm_tag::insert_into_inbox(make_not_null(&bm_inbox), boundary_message_a);
+
+  BcType send_flux_data_a;
   get<0>(send_flux_data_a) = get<0>(send_data_a);
   get<1>(send_flux_data_a) = get<1>(send_data_a);
   get<3>(send_flux_data_a) = DataVector{
@@ -170,18 +263,32 @@ void test_with_ghost_cells() {
   get<5>(send_flux_data_a) = 6;
   fill_with_random_values(make_not_null(&*get<3>(send_flux_data_a)),
                           make_not_null(&gen), make_not_null(&dist));
-  bc_tag::insert_into_inbox(make_not_null(&inbox), time_step_id_a,
-                            std::make_pair(nhbr_key, send_flux_data_a));
 
-  Type send_all_data_a = send_data_a;
+  BoundaryMessage<Dim>* flux_boundary_message_a = create_boundary_message(
+      time_step_id_a, time_step_id_c, nhbr_key, volume_mesh_a, mesh_a, nullopt,
+      get<3>(send_flux_data_a), get<5>(send_flux_data_a));
+
+  bc_tag::insert_into_inbox(make_not_null(&bc_inbox), time_step_id_a,
+                            std::make_pair(nhbr_key, send_flux_data_a));
+  bm_tag::insert_into_inbox(make_not_null(&bm_inbox), flux_boundary_message_a);
+
+  BcType send_all_data_a = send_data_a;
   get<3>(send_all_data_a) = get<3>(send_flux_data_a);
   get<4>(send_all_data_a) = get<4>(send_flux_data_a);
   get<5>(send_all_data_a) = get<5>(send_flux_data_a);
 
-  CHECK(inbox.at(time_step_id_a).at(nhbr_key) == send_all_data_a);
+  BoundaryMessage<Dim>* all_boundary_message_a =
+      create_boundary_message(time_step_id_a, time_step_id_c, nhbr_key,
+                              volume_mesh_a, mesh_a, get<2>(send_all_data_a),
+                              get<3>(send_all_data_a), get<5>(send_all_data_a));
+  BoundaryMessage<Dim>* all_boundary_message_a_compare = all_boundary_message_a;
+
+  CHECK(bc_inbox.at(time_step_id_a).at(nhbr_key) == send_all_data_a);
+  CHECK(*(bm_inbox.at(time_step_id_a).at(nhbr_key).get()) ==
+        *all_boundary_message_a_compare);
 
   // Check sending both ghost and flux data at once
-  Type send_all_data_b = send_data_b;
+  BcType send_all_data_b = send_data_b;
   get<3>(send_all_data_b) =
       DataVector{2 * get<1>(send_all_data_b).number_of_grid_points() *
                      number_of_components,
@@ -190,10 +297,20 @@ void test_with_ghost_cells() {
   get<5>(send_data_a) = 6;
   fill_with_random_values(make_not_null(&*get<3>(send_all_data_b)),
                           make_not_null(&gen), make_not_null(&dist));
-  bc_tag::insert_into_inbox(make_not_null(&inbox), time_step_id_b,
-                            std::make_pair(nhbr_key, send_all_data_b));
 
-  CHECK((inbox.at(time_step_id_b).at(nhbr_key) == send_all_data_b));
+  BoundaryMessage<Dim>* all_boundary_message_b =
+      create_boundary_message(time_step_id_b, time_step_id_c, nhbr_key,
+                              volume_mesh_b, mesh_b, get<2>(send_all_data_b),
+                              get<3>(send_all_data_b), get<5>(send_all_data_b));
+  BoundaryMessage<Dim>* all_boundary_message_b_compare = all_boundary_message_b;
+
+  bc_tag::insert_into_inbox(make_not_null(&bc_inbox), time_step_id_b,
+                            std::make_pair(nhbr_key, send_all_data_b));
+  bm_tag::insert_into_inbox(make_not_null(&bm_inbox), all_boundary_message_b);
+
+  CHECK((bc_inbox.at(time_step_id_b).at(nhbr_key) == send_all_data_b));
+  CHECK(*(bm_inbox.at(time_step_id_b).at(nhbr_key).get()) ==
+        *all_boundary_message_b_compare);
 }
 
 template <size_t Dim>


### PR DESCRIPTION
## Proposed changes

This effectively does the same thing as the current inbox tag
BoundaryCorrectionAndGhostCellsInbox, but with pointers.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
