### PR TITLE
Support derivatives and integrals in ApplyPointwise, rename to TransformVolumeData

### DIFF
--- a/src/DataStructures/Tensor/Python/__init__.py
+++ b/src/DataStructures/Tensor/Python/__init__.py
@@ -57,3 +57,10 @@ class JacobianMeta(TensorMeta):
 Scalar = {DataVector: ScalarDV, float: ScalarD}
 Jacobian = JacobianMeta(inverse=False)
 InverseJacobian = JacobianMeta(inverse=True)
+
+# Define a type annotation that means "any tensor". This should really be a
+# common superclass of all Tensor types, but we currently don't have that in C++
+# so we use a type alias to `typing.Any` as a workaround.
+from typing import Any
+
+Tensor = Any

--- a/src/Visualization/Python/ApplyPointwise.py
+++ b/src/Visualization/Python/ApplyPointwise.py
@@ -443,7 +443,6 @@ def parse_kernels(kernels, exec_files, map_input_names):
               "-k",
               "kernels",
               multiple=True,
-              required=True,
               help=("Python function(s) to apply to the volume data. "
                     "Specify as 'path.to.module.function_name', where the "
                     "module must be available to import. "
@@ -542,6 +541,8 @@ def apply_pointwise_command(h5files, subfile_name, kernels, exec_files,
     volfiles = [h5file.get_vol(subfile_name) for h5file in open_h5_files]
 
     # Load kernels
+    if not kernels:
+        raise click.UsageError("No '--kernel' / '-k' specified.")
     kernels = list(parse_kernels(kernels, exec_files, map_input_names))
 
     # Apply!

--- a/src/Visualization/Python/ApplyPointwise.py
+++ b/src/Visualization/Python/ApplyPointwise.py
@@ -9,7 +9,8 @@ import numpy as np
 import re
 import spectre.IO.H5 as spectre_h5
 from pydoc import locate
-from typing import Union, Iterable, Dict, Optional, Sequence, List
+from spectre.DataStructures.Tensor import Tensor
+from typing import Union, Iterable, Dict, Optional, Sequence, List, Type
 
 logger = logging.getLogger(__name__)
 
@@ -51,7 +52,7 @@ def parse_pybind11_signature(callable) -> inspect.Signature:
 
 
 def get_tensor_component_names(tensor_name: str,
-                               tensor_type: type) -> List[str]:
+                               tensor_type: Type[Tensor]) -> List[str]:
     """Lists all independent components like 'Vector_x', 'Vector_y', etc."""
     # Pybind11 doesn't support class methods, so `component_suffix` is a member
     # function. Construct a proxy object to call it.

--- a/src/Visualization/Python/ApplyPointwise.py
+++ b/src/Visualization/Python/ApplyPointwise.py
@@ -1,16 +1,29 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-import click
 import importlib
 import inspect
 import logging
-import numpy as np
 import re
-import spectre.IO.H5 as spectre_h5
+from dataclasses import dataclass
 from pydoc import locate
-from spectre.DataStructures.Tensor import Tensor
-from typing import Union, Iterable, Dict, Optional, Sequence, List, Type
+from typing import Dict, Iterable, List, Optional, Sequence, Type, Union
+
+import click
+import numpy as np
+import spectre.IO.H5 as spectre_h5
+from spectre.DataStructures import DataVector
+from spectre.DataStructures.Tensor import (Frame, InverseJacobian, Jacobian,
+                                           Tensor, tnsr)
+from spectre.IO.H5.IterElements import Element, iter_elements
+from spectre.Spectral import Mesh
+
+# functools.cached_property was added in Py 3.8. Fall back to a plain
+# `property` in Py 3.7.
+try:
+    from functools import cached_property
+except ImportError:
+    cached_property = property
 
 logger = logging.getLogger(__name__)
 
@@ -63,49 +76,182 @@ def get_tensor_component_names(tensor_name: str,
     ]
 
 
+class KernelArg:
+    """Subclasses provide data for a kernel function argument"""
+    def get(self, all_tensor_data: Dict[str, Tensor], element: Element):
+        """Get the data that will be passed to the kernel function"""
+        raise NotImplementedError
+
+
+@dataclass(frozen=True)
+class TensorArg(KernelArg):
+    """Kernel argument loaded from a volume file tensor dataset"""
+    tensor_type: Type[Tensor]
+    dataset_name: str
+
+    @cached_property
+    def component_names(self):
+        return get_tensor_component_names(self.dataset_name, self.tensor_type)
+
+    def get(self, all_tensor_data: Dict[str, Tensor],
+            element: Optional[Element]):
+        tensor_data = all_tensor_data[self.dataset_name]
+        if element:
+            components = np.asarray(tensor_data)[:, element.data_slice]
+            return self.tensor_type(components)
+        else:
+            return tensor_data
+
+
+@dataclass(frozen=True)
+class ElementArg(KernelArg):
+    """Kernel argument retrieved from an element in the computational domain"""
+    element_attr: str
+
+    def get(self, all_tensor_data: Dict[str, Tensor], element: Element):
+        return getattr(element, self.element_attr)
+
+
+def parse_kernel_arg(arg: inspect.Parameter,
+                     map_input_names: Dict[str, str]) -> KernelArg:
+    """Determine how data for a kernel function argument will be retrieved
+
+    Examines the name and type annotation of the argument. The following
+    arguments are supported:
+
+    - Mesh: Annotate the argument with a 'Mesh' type.
+    - Coordinates: Annotate the argument with a 'tnsr.I' type and name it
+        "logical_coords" / "logical_coordinates" or "inertial_coords" /
+        "inertial_coordinates" / "x".
+    - Jacobians: Annotate the argument with a 'Jacobian' or 'InverseJacobian'.
+    - Any tensor dataset: Annotate the argument with the tensor type. By
+        default, the argument name is transformed to CamelCase to determine the
+        dataset name in the volume data file. Specify a mapping in
+        'map_input_names' to override the default.
+
+    For example, the following function is a possible kernel:
+
+        def one_index_constraint(
+            psi: Scalar[DataVector],
+            mesh: Mesh[3],
+            inv_jacobian: InverseJacobian[DataVector, 3],
+        ) -> tnsr.i[DataVector, 3]:
+            # ...
+
+    The function can also be a binding of a C++ function, such as this:
+
+        tnsr::i<DataVector, 3> one_index_constraint(
+            const Scalar<DataVector>& psi,
+            const Mesh<3>& mesh,
+            const InverseJacobian<
+              DataVector, 3, Frame::ElementLogical, Frame::Inertial>&
+              inv_jacobian) {
+            // ...
+        }
+
+    Arguments:
+      arg: The function argument. Must have a type annotation.
+      map_input_names: A map of argument names to dataset names (optional).
+        By default the argument name is transformed to CamelCase.
+
+    Returns: A 'KernelArg' object that knows how to retrieve the data for the
+      argument.
+    """
+    if arg.annotation is inspect.Parameter.empty:
+        raise ValueError(
+            "Please annotate all arguments in the kernel function. "
+            f"Argument '{arg.name}' has no annotation.")
+
+    if arg.annotation in Mesh.values():
+        return ElementArg("mesh")
+    elif arg.name in ["logical_coords", "logical_coordinates"]:
+        assert arg.annotation in [
+            tnsr.I[DataVector, 1, Frame.ElementLogical],
+            tnsr.I[DataVector, 2, Frame.ElementLogical],
+            tnsr.I[DataVector, 3, Frame.ElementLogical],
+        ], (f"Argument '{arg.name}' has unexpected type "
+            f"'{arg.annotation}'. Expected a "
+            "'tnsr.I[DataVector, Dim, Frame.ElementLogical]' "
+            "for logical coordinates.")
+        return ElementArg("logical_coordinates")
+    elif arg.name in ["inertial_coords", "inertial_coordinates", "x"]:
+        assert arg.annotation in [
+            tnsr.I[DataVector, 1, Frame.Inertial],
+            tnsr.I[DataVector, 2, Frame.Inertial],
+            tnsr.I[DataVector, 3, Frame.Inertial],
+        ], (f"Argument '{arg.name}' has unexpected type "
+            f"'{arg.annotation}'. Expected a "
+            "'tnsr.I[DataVector, Dim, Frame.Inertial]' "
+            "for inertial coordinates.")
+        return ElementArg("inertial_coordinates")
+    elif arg.annotation in [
+            Jacobian[DataVector, 1],
+            Jacobian[DataVector, 2],
+            Jacobian[DataVector, 3],
+    ]:
+        return ElementArg("jacobian")
+    elif arg.annotation in [
+            InverseJacobian[DataVector, 1],
+            InverseJacobian[DataVector, 2],
+            InverseJacobian[DataVector, 3],
+    ]:
+        return ElementArg("inv_jacobian")
+    else:
+        try:
+            arg.annotation.rank
+        except AttributeError:
+            raise ValueError(
+                f"Unknown argument type '{arg.annotation}' for argument "
+                f"'{arg.name}'. It must be either a Tensor or one of "
+                "the supported structural types listed in "
+                "'ApplyPointwise.parse_kernel_arg'.")
+        return TensorArg(tensor_type=arg.annotation,
+                         dataset_name=map_input_names.get(
+                             arg.name, snake_case_to_camel_case(arg.name)))
+
+
 class Kernel:
     def __init__(self,
                  callable,
                  map_input_names: Dict[str, str] = {},
-                 output_name: Optional[str] = None):
+                 output_name: Optional[str] = None,
+                 elementwise: Optional[bool] = None):
         """Specifies input and output tensor names for a pointwise function
 
         Arguments:
           callable: A Python function that takes and returns tensors
-            (from 'spectre.DataStructures.Tensor').
+            (from 'spectre.DataStructures.Tensor') or a limited set of
+            structural information such as the mesh, coordinates, and Jacobians.
+            See the 'parse_kernel_arg' function for all supported argument
+            types.
           map_input_names: A map of argument names to dataset names (optional).
             By default the argument name is transformed to CamelCase.
           output_name: Name of the output dataset (optional). By default the
             function name is transformed to CamelCase.
+          elementwise: Call this kernel for each element. The default is to
+            call the kernel with all data in the volume file at once, unless
+            element-specific data such as a Mesh or Jacobian is requested.
         """
         self.callable = callable
-        # Get input tensor names by transforming the function argument names to
-        # CamelCase, or look them up in 'map_input_names'
         try:
             signature = inspect.signature(callable)
         except ValueError:
             signature = parse_pybind11_signature(callable)
-        callable_args = signature.parameters
-        self.input_names = [
-            map_input_names.get(arg_name, snake_case_to_camel_case(arg_name))
-            for arg_name in callable_args
+        # Parse function arguments
+        self.args = [
+            parse_kernel_arg(arg, map_input_names)
+            for arg in signature.parameters.values()
         ]
-        # Look up tensor types for input arguments
-        self.input_types = []
-        for arg in callable_args.values():
-            tensor_type = arg.annotation
-            if tensor_type is inspect.Parameter.empty:
-                raise ValueError(
-                    "Please annotate all arguments in the kernel function "
-                    f"'{callable}'. Argument '{arg.name}' has no annotation.")
-            try:
-                tensor_type.rank
-            except AttributeError:
-                raise ValueError(
-                    "All annotations must be tensor types in the "
-                    f"kernel function '{callable}'. Argument '{arg.name}' has "
-                    f"type '{tensor_type}'.")
-            self.input_types.append(tensor_type)
+        # If any argument is not a Tensor then we have to call the kernel
+        # elementwise
+        if elementwise:
+            self.elementwise = True
+        else:
+            self.elementwise = any(
+                isinstance(arg, ElementArg) for arg in self.args)
+            assert elementwise is None or elementwise == self.elementwise, (
+                f"Kernel '{callable.__name__}' must be called elementwise "
+                "because an argument is not a pointwise tensor.")
         # Use provided output name, or transform function name to CamelCase
         self.output_name = (output_name
                             or snake_case_to_camel_case(callable.__name__))
@@ -117,6 +263,12 @@ class Kernel:
                 "The return annotation must be a tensor type in the "
                 f"kernel function '{callable}'. Instead, it is "
                 f"'{self.output_type}'.")
+
+    def __call__(self, all_tensor_data: Dict[str, Tensor],
+                 element: Optional[Element]):
+        output = self.callable(*(arg.get(all_tensor_data, element)
+                                 for arg in self.args))
+        return output
 
 
 def apply_pointwise(volfiles: Union[spectre_h5.H5Vol,
@@ -133,19 +285,22 @@ def apply_pointwise(volfiles: Union[spectre_h5.H5Vol,
         in the form of 'Kernel' objects.
     """
     # Collect all tensor components that we need to apply the kernels
-    all_tensors = {}
+    all_tensors: Dict[str, TensorArg] = {}
     for kernel in kernels:
-        for tensor_name, tensor_type in zip(kernel.input_names,
-                                            kernel.input_types):
+        for tensor_arg in kernel.args:
+            # Skip non-tensors
+            if not isinstance(tensor_arg, TensorArg):
+                continue
+            tensor_name = tensor_arg.dataset_name
+            tensor_type = tensor_arg.tensor_type
             if tensor_name in all_tensors:
-                assert all_tensors[tensor_name][0] == tensor_type, (
+                assert all_tensors[tensor_name].tensor_type == tensor_type, (
                     "Two tensor arguments with the same name "
                     f"'{tensor_name}' have different types: "
-                    f"'{all_tensors[tensor_name][0]}' and '{tensor_type}'")
+                    f"'{all_tensors[tensor_name].tensor_type}' "
+                    f"and '{tensor_type}'")
             else:
-                all_tensors[tensor_name] = (tensor_type,
-                                            get_tensor_component_names(
-                                                tensor_name, tensor_type))
+                all_tensors[tensor_name] = tensor_arg
     logger.debug("Input datasets: " + str(list(all_tensors.keys())))
     logger.info("Output datasets: " +
                 str([kernel.output_name for kernel in kernels]))
@@ -153,32 +308,38 @@ def apply_pointwise(volfiles: Union[spectre_h5.H5Vol,
     if isinstance(volfiles, spectre_h5.H5Vol):
         volfiles = [volfiles]
     for volfile in volfiles:
-        for obs_id in volfile.list_observation_ids():
+        all_observation_ids = volfile.list_observation_ids()
+        num_obs = len(all_observation_ids)
+        for i_obs, obs_id in enumerate(all_observation_ids):
             # Load tensor data for all kernels
             all_tensor_data = {
-                tensor_name: tensor_type(
+                tensor_name: tensor_arg.tensor_type(
                     np.array([
                         volfile.get_tensor_component(obs_id,
                                                      component_name).data
-                        for component_name in component_names
+                        for component_name in tensor_arg.component_names
                     ]))
-                for tensor_name, (tensor_type,
-                                  component_names) in all_tensors.items()
+                for tensor_name, tensor_arg in all_tensors.items()
             }
+            total_num_points = np.sum(
+                np.prod(volfile.get_extents(obs_id), axis=1))
 
             # Apply kernels
-            # We currently only apply strictly pointwise kernels that need no
-            # information about the element or mesh. To support derivatives we
-            # can slice the tensor data into elements and call those kernels
-            # that request it element-wise, passing them the mesh and Jacobian
-            # as well.
             for kernel in kernels:
-                kernel_args = [
-                    all_tensor_data[input_name]
-                    for input_name in kernel.input_names
-                ]
-
-                transformed_tensor = kernel.callable(*kernel_args)
+                # Elementwise kernels need to slice the tensor data into
+                # elements, and reassemble the result into a contiguous dataset
+                if kernel.elementwise:
+                    transformed_tensor_data = np.zeros(
+                        (kernel.output_type.size, total_num_points))
+                    for element in iter_elements(volfile, obs_id):
+                        transformed_tensor = kernel(all_tensor_data, element)
+                        for i, component in enumerate(transformed_tensor):
+                            transformed_tensor_data[
+                                i, element.data_slice] = component
+                    transformed_tensor = kernel.output_type(
+                        transformed_tensor_data, copy=False)
+                else:
+                    transformed_tensor = kernel(all_tensor_data, None)
 
                 # Write result back into volfile
                 for i, component in enumerate(transformed_tensor):
@@ -272,9 +433,13 @@ def apply_pointwise_command(h5files, subfile_name, kernels, exec_files,
             # ...
 
     Any pybind11 binding of a C++ function will also work, as long as it takes
-    exclusively tensors as arguments. The kernels can be loaded from any
-    available Python module, such as 'spectre.PointwiseFunctions'. You can also
-    execute a Python file that defines kernels with the '--exec' / '-e' option.
+    only supported types as arguments. Supported types are tensors, as well
+    structural information such as the mesh, coordinates, and Jacobians. See the
+    'parse_kernel_arg' function for all supported argument types.
+
+    The kernels can be loaded from any available Python module, such as
+    'spectre.PointwiseFunctions'. You can also execute a Python file that
+    defines kernels with the '--exec' / '-e' option.
 
     By default, the data for the input arguments are read from datasets in the
     volume files with the same names, transformed to CamelCase. For example, the

--- a/src/Visualization/Python/ApplyPointwise.py
+++ b/src/Visualization/Python/ApplyPointwise.py
@@ -300,7 +300,7 @@ def apply_pointwise_command(h5files, subfile_name, kernels, exec_files,
         return
 
     if subfile_name.endswith(".vol"):
-        subfile_name = subfile_name.rstrip(".vol")
+        subfile_name = subfile_name[:-4]
     if not subfile_name.startswith("/"):
         subfile_name = "/" + subfile_name
 

--- a/src/Visualization/Python/CMakeLists.txt
+++ b/src/Visualization/Python/CMakeLists.txt
@@ -7,7 +7,6 @@ spectre_python_add_module(
   Visualization
   PYTHON_FILES
   __init__.py
-  ApplyPointwise.py
   GenerateXdmf.py
   InterpolateToCoords.py
   InterpolateToMesh.py
@@ -16,4 +15,5 @@ spectre_python_add_module(
   plots.mplstyle
   ReadH5.py
   Render1D.py
+  TransformVolumeData.py
 )

--- a/src/Visualization/Python/InterpolateToCoords.py
+++ b/src/Visualization/Python/InterpolateToCoords.py
@@ -193,7 +193,7 @@ def interpolate_to_coords_command(h5_files, subfile_name, list_vars, vars,
         return
 
     if subfile_name.endswith(".vol"):
-        subfile_name = subfile_name.rstrip(".vol")
+        subfile_name = subfile_name[:-4]
     if not subfile_name.startswith("/"):
         subfile_name = "/" + subfile_name
 

--- a/src/Visualization/Python/InterpolateToMesh.py
+++ b/src/Visualization/Python/InterpolateToMesh.py
@@ -71,8 +71,10 @@ def interpolate_to_mesh(source_file_path,
         will only take every `obs_stride` observation
     """
 
-    source_volume_data = source_volume_data.rstrip(".vol")
-    target_volume_data = target_volume_data.rstrip(".vol")
+    if source_volume_data.endswith(".vol"):
+        source_volume_data = source_volume_data[:-4]
+    if target_volume_data.endswith(".vol"):
+        target_volume_data = target_volume_data[:-4]
     if not source_volume_data.startswith("/"):
         source_volume_data = "/" + source_volume_data
     if not target_volume_data.startswith("/"):

--- a/support/Python/__main__.py
+++ b/support/Python/__main__.py
@@ -17,7 +17,6 @@ SPECTRE_VERSION = "@SPECTRE_VERSION@"
 class Cli(click.MultiCommand):
     def list_commands(self, ctx):
         return [
-            "apply-pointwise",
             "clean-output",
             "extract-dat",
             "extract-input",
@@ -28,14 +27,11 @@ class Cli(click.MultiCommand):
             "plot-power-monitors",
             "render-1d",
             "simplify-traces",
+            "transform-volume-data",
         ]
 
     def get_command(self, ctx, name):
-        if name == "apply-pointwise":
-            from spectre.Visualization.ApplyPointwise import (
-                apply_pointwise_command)
-            return apply_pointwise_command
-        elif name == "clean-output":
+        if name == "clean-output":
             from spectre.tools.CleanOutput import clean_output_command
             return clean_output_command
         elif name == "delete-subfiles":
@@ -74,6 +70,10 @@ class Cli(click.MultiCommand):
             from spectre.tools.CharmSimplifyTraces import (
                 simplify_traces_command)
             return simplify_traces_command
+        elif name in ["transform-volume-data", "transform-vol"]:
+            from spectre.Visualization.TransformVolumeData import (
+                transform_volume_data_command)
+            return transform_volume_data_command
         raise NotImplementedError(f"The command '{name}' is not implemented.")
 
 

--- a/tests/Unit/Visualization/Python/CMakeLists.txt
+++ b/tests/Unit/Visualization/Python/CMakeLists.txt
@@ -2,12 +2,6 @@
 # See LICENSE.txt for details.
 
 spectre_add_python_bindings_test(
-  "Unit.Visualization.Python.ApplyPointwise"
-  Test_ApplyPointwise.py
-  "unit;visualization;python"
-  None)
-
-spectre_add_python_bindings_test(
   "Unit.Visualization.Python.GenerateXdmf"
   Test_GenerateXdmf.py
   "unit;visualization;python"
@@ -61,5 +55,11 @@ spectre_add_python_bindings_test(
 spectre_add_python_bindings_test(
   "Unit.Visualization.Python.InterpolateToMesh"
   Test_InterpolateToMesh.py
+  "unit;visualization;python"
+  None)
+
+spectre_add_python_bindings_test(
+  "Unit.Visualization.Python.TransformVolumeData"
+  Test_TransformVolumeData.py
   "unit;visualization;python"
   None)

--- a/tests/Unit/Visualization/Python/Test_ApplyPointwise.py
+++ b/tests/Unit/Visualization/Python/Test_ApplyPointwise.py
@@ -2,7 +2,7 @@
 # See LICENSE.txt for details.
 
 from spectre.Visualization.ApplyPointwise import (snake_case_to_camel_case,
-                                                  parse_pybind11_signature,
+                                                  parse_pybind11_signatures,
                                                   Kernel, apply_pointwise,
                                                   apply_pointwise_command)
 
@@ -67,9 +67,9 @@ class TestApplyPointwise(unittest.TestCase):
     def tearDown(self):
         shutil.rmtree(self.test_dir)
 
-    def test_parse_pybind11_signature(self):
-        self.assertEqual(parse_pybind11_signature(adm_mass_integrand),
-                         inspect.signature(adm_mass_integrand_signature))
+    def test_parse_pybind11_signatures(self):
+        self.assertEqual(list(parse_pybind11_signatures(adm_mass_integrand)),
+                         [inspect.signature(adm_mass_integrand_signature)])
 
     def test_snake_case_to_camel_case(self):
         self.assertEqual(snake_case_to_camel_case("hello_world"), "HelloWorld")

--- a/tests/Unit/Visualization/Python/Test_ApplyPointwise.py
+++ b/tests/Unit/Visualization/Python/Test_ApplyPointwise.py
@@ -2,9 +2,11 @@
 # See LICENSE.txt for details.
 
 from spectre.Visualization.ApplyPointwise import (snake_case_to_camel_case,
+                                                  parse_pybind11_signature,
                                                   Kernel, apply_pointwise,
                                                   apply_pointwise_command)
 
+import inspect
 import numpy as np
 import numpy.testing as npt
 import os
@@ -15,6 +17,13 @@ from click.testing import CliRunner
 from spectre.Informer import unit_test_src_path, unit_test_build_path
 from spectre.DataStructures import DataVector
 from spectre.DataStructures.Tensor import Scalar, tnsr
+from spectre.PointwiseFunctions.Punctures import adm_mass_integrand
+
+
+def adm_mass_integrand_signature(
+        field: Scalar[DataVector], alpha: Scalar[DataVector],
+        beta: Scalar[DataVector]) -> Scalar[DataVector]:
+    pass
 
 
 def psi_squared(psi: Scalar[DataVector]) -> Scalar[DataVector]:
@@ -40,6 +49,10 @@ class TestApplyPointwise(unittest.TestCase):
 
     def tearDown(self):
         shutil.rmtree(self.test_dir)
+
+    def test_parse_pybind11_signature(self):
+        self.assertEqual(parse_pybind11_signature(adm_mass_integrand),
+                         inspect.signature(adm_mass_integrand_signature))
 
     def test_snake_case_to_camel_case(self):
         self.assertEqual(snake_case_to_camel_case("hello_world"), "HelloWorld")

--- a/tests/Unit/Visualization/Python/Test_ApplyPointwise.py
+++ b/tests/Unit/Visualization/Python/Test_ApplyPointwise.py
@@ -53,6 +53,10 @@ def sinusoid(x: tnsr.I[DataVector, 3]) -> Scalar[DataVector]:
                                              axis=0))
 
 
+def square_component(component: DataVector) -> Scalar[DataVector]:
+    return Scalar[DataVector]([component**2])
+
+
 class TestApplyPointwise(unittest.TestCase):
     def setUp(self):
         self.test_dir = os.path.join(unit_test_build_path(),
@@ -87,6 +91,8 @@ class TestApplyPointwise(unittest.TestCase):
                    elementwise=True,
                    output_name="CoordinateRadiusElementwise"),
             Kernel(deriv_coords),
+            Kernel(square_component,
+                   map_input_names={"component": "InertialCoordinates_x"}),
         ]
 
         apply_pointwise(volfiles=open_volfiles, kernels=kernels)
@@ -116,6 +122,9 @@ class TestApplyPointwise(unittest.TestCase):
                 result_deriv_coords = open_volfiles[0].get_tensor_component(
                     obs_id, "DerivCoords_" + "xyz"[i] + "xyz"[j]).data
                 npt.assert_allclose(result_deriv_coords, 0., atol=1e-14)
+        result_square_component = open_volfiles[0].get_tensor_component(
+            obs_id, "SquareComponent").data
+        npt.assert_allclose(np.array(result_square_component), x**2)
 
     def test_integrate(self):
         open_h5_files = [spectre_h5.H5File(self.h5_filename, "a")]


### PR DESCRIPTION
## Proposed changes

Apply python functions elementwise to all volume data in H5 files, including taking derivatives and volume integrals.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
`spectre apply-pointwise` is now `spectre transform-volume-data` (or `spectre transform-vol`).
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
