### PR TITLE
Psi4 Fix

### DIFF
--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Psi4.py
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Psi4.py
@@ -35,15 +35,24 @@ def psi_4(spatial_ricci, extrinsic_curvature, cov_deriv_extrinsic_curvature,
 
     x_coord = np.zeros((3))
     x_coord[0] = 1
-    magnitude_x = math.sqrt(
-        np.einsum("a,b,ab", x_coord, x_coord, spatial_metric))
-    x_hat = x_coord / magnitude_x
+    x_component = np.einsum("a,b,ab", x_coord, r_hat, spatial_metric)
+    x_hat = x_coord - (x_component * r_hat)
+    magnitude_x = math.sqrt(np.einsum("a,b,ab", x_hat, x_hat, spatial_metric))
+    if (magnitude_x != 0.0):
+        x_hat = np.einsum("a", x_hat / magnitude_x)
+    else:
+        x_hat = np.einsum("a", x_hat * 0.0)
     y_coord = np.zeros((3))
     y_coord[1] = 1
-    magnitude_y = math.sqrt(
-        np.einsum("a,b,ab", y_coord, y_coord, spatial_metric))
-    y_hat = y_coord / magnitude_y
-
+    y_component = np.einsum("a,b,ab", y_coord, r_hat, spatial_metric)
+    y_hat = y_coord - (y_component * r_hat)
+    y_component = np.einsum("a,b,ab", y_coord, x_hat, spatial_metric)
+    y_hat = y_hat - (y_component * x_hat)
+    magnitude_y = math.sqrt(np.einsum("a,b,ab", y_hat, y_hat, spatial_metric))
+    if (magnitude_y != 0.0):
+        y_hat = np.einsum("a", y_hat / magnitude_y)
+    else:
+        y_hat = np.einsum("a", y_hat * 0.0)
     m_bar = x_hat - (y_hat * complex(0.0, 1.0))
 
     return (-0.5 * np.einsum("ab,a,b", u8_plus, m_bar, m_bar))

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_Psi4.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_Psi4.cpp
@@ -96,9 +96,6 @@ void test_psi_4(const RealDataType& used_for_size_real,
   auto inertial_coords =
       make_with_random_values<tnsr::I<RealDataType, 3, Frame::Inertial>>(
           nn_generator, nn_distribution, used_for_size_real);
-  for (size_t i = 0; i < 3; ++i) {
-    inertial_coords.get(i)[0] = 0.0;
-  }
 
   const auto python_psi_4 = pypp::call<Scalar<ComplexDataType>>(
       "GeneralRelativity.Psi4", "psi_4", spatial_ricci, extrinsic_curvature,


### PR DESCRIPTION
## Proposed changes

This PR is to fix the visualization issues I've been seeing with Psi4. Made x_hat and y_hat orthonormal to r_hat at every point, was previously was not aware that this was required, I assumed x_hat and y_hat were the cartesian basis vectors. 

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.



