### PR TITLE
UniformTranslation: add distorted frame.

### DIFF
--- a/src/Domain/Creators/TimeDependence/UniformTranslation.hpp
+++ b/src/Domain/Creators/TimeDependence/UniformTranslation.hpp
@@ -57,6 +57,11 @@ namespace domain::creators::time_dependence {
  *
  * \p Index is used to distinguish multiple `UniformTranslation`s from each
  * other in CompositionUniformTranslation.
+ *
+ * See the documentation for the constructors below: one constructor
+ * takes two velocities, which correspond to two translations: one from
+ * Frame::Grid to Frame::Distorted, and the other from Frame::Distorted to
+ * Frame::Inertial.
  */
 template <size_t MeshDim, size_t Index>
 class UniformTranslation final : public TimeDependence<MeshDim> {
@@ -82,8 +87,19 @@ class UniformTranslation final : public TimeDependence<MeshDim> {
     static constexpr Options::String help = {"The velocity of the map."};
   };
 
-  using GridToInertialMap =
+  using GridToInertialMapSimple =
       detail::generate_coordinate_map_t<Frame::Grid, Frame::Inertial,
+                                        tmpl::list<TranslationMap>>;
+
+  using GridToInertialMapCombined = detail::generate_coordinate_map_t<
+      Frame::Grid, Frame::Inertial, tmpl::list<TranslationMap, TranslationMap>>;
+
+  using GridToDistortedMap =
+      detail::generate_coordinate_map_t<Frame::Grid, Frame::Distorted,
+                                        tmpl::list<TranslationMap>>;
+
+  using DistortedToInertialMap =
+      detail::generate_coordinate_map_t<Frame::Distorted, Frame::Inertial,
                                         tmpl::list<TranslationMap>>;
 
   using options = tmpl::list<InitialTime, Velocity>;
@@ -98,8 +114,26 @@ class UniformTranslation final : public TimeDependence<MeshDim> {
   UniformTranslation& operator=(const UniformTranslation&) = delete;
   UniformTranslation& operator=(UniformTranslation&&) = default;
 
+  /// If UniformTranslation is created using the constructor that
+  /// takes a single velocity, then there is no distorted frame (so
+  /// block_maps_grid_to_distorted() and
+  /// block_maps_distorted_to_inertial() contain nullptrs), and the
+  /// given velocity is the one that goes from Frame::Grid to
+  /// Frame::Inertial.
   UniformTranslation(double initial_time,
                      const std::array<double, MeshDim>& velocity);
+
+  /// If UniformTranslation is created using the constructor that
+  /// takes two velocities, then the first velocity is the one
+  /// describing a uniform translation that goes from Frame::Grid to
+  /// Frame::Distorted, and the second velocity is the one that
+  /// describes a uniform translation that goes from Frame::Distorted
+  /// to Frame::Inertial.  In this case there are also two
+  /// FunctionsOfTime, one for each of the two translation maps.
+  UniformTranslation(
+      double initial_time,
+      const std::array<double, MeshDim>& velocity_grid_to_distorted,
+      const std::array<double, MeshDim>& velocity_distorted_to_inertial);
 
   auto get_clone() const -> std::unique_ptr<TimeDependence<MeshDim>> override;
 
@@ -109,19 +143,11 @@ class UniformTranslation final : public TimeDependence<MeshDim> {
 
   auto block_maps_grid_to_distorted(size_t number_of_blocks) const
       -> std::vector<std::unique_ptr<domain::CoordinateMapBase<
-          Frame::Grid, Frame::Distorted, MeshDim>>> override {
-    using ptr_type =
-        domain::CoordinateMapBase<Frame::Grid, Frame::Distorted, MeshDim>;
-    return std::vector<std::unique_ptr<ptr_type>>(number_of_blocks);
-  }
+          Frame::Grid, Frame::Distorted, MeshDim>>> override;
 
   auto block_maps_distorted_to_inertial(size_t number_of_blocks) const
       -> std::vector<std::unique_ptr<domain::CoordinateMapBase<
-          Frame::Distorted, Frame::Inertial, MeshDim>>> override {
-    using ptr_type =
-        domain::CoordinateMapBase<Frame::Distorted, Frame::Inertial, MeshDim>;
-    return std::vector<std::unique_ptr<ptr_type>>(number_of_blocks);
-  }
+          Frame::Distorted, Frame::Inertial, MeshDim>>> override;
 
   auto functions_of_time(const std::unordered_map<std::string, double>&
                              initial_expiration_times = {}) const
@@ -139,12 +165,22 @@ class UniformTranslation final : public TimeDependence<MeshDim> {
   friend bool operator==(const UniformTranslation<LocalDim, LocalIndex>& lhs,
                          const UniformTranslation<LocalDim, LocalIndex>& rhs);
 
-  GridToInertialMap grid_to_inertial_map() const;
+  GridToInertialMapSimple grid_to_inertial_map_simple() const;
+  GridToInertialMapCombined grid_to_inertial_map_combined() const;
+  GridToDistortedMap grid_to_distorted_map() const;
+  DistortedToInertialMap distorted_to_inertial_map() const;
 
   double initial_time_{std::numeric_limits<double>::signaling_NaN()};
-  std::array<double, MeshDim> velocity_{};
-  inline static const std::string function_of_time_name_{
+  // If distorted and inertial frames are equal, then
+  // velocity_grid_to_distorted_ is the grid to inertial velocity, and
+  // velocity_distorted_to_inertial_ is unused.
+  std::array<double, MeshDim> velocity_grid_to_distorted_{};
+  std::array<double, MeshDim> velocity_distorted_to_inertial_{};
+  bool distorted_and_inertial_frames_are_equal_{true};
+  inline static const std::string function_of_time_name_grid_to_distorted_{
       "Translation" + (Index == 0 ? "" : get_output(Index))};
+  inline static const std::string function_of_time_name_distorted_to_inertial_{
+      "TranslationDistortedToInertial" + (Index == 0 ? "" : get_output(Index))};
 };
 
 template <size_t Dim, size_t Index>

--- a/tests/Unit/Domain/Creators/TimeDependence/Test_UniformTranslation.cpp
+++ b/tests/Unit/Domain/Creators/TimeDependence/Test_UniformTranslation.cpp
@@ -32,13 +32,133 @@ namespace {
 template <size_t MeshDim>
 using Translation = domain::CoordinateMaps::TimeDependent::Translation<MeshDim>;
 
-template <size_t MeshDim>
-using ConcreteMap =
-    domain::CoordinateMap<Frame::Grid, Frame::Inertial, Translation<MeshDim>>;
+template <size_t MeshDim, typename InputFrame = Frame::Grid,
+          typename OutputFrame = Frame::Inertial>
+using ConcreteMapSimple =
+    domain::CoordinateMap<InputFrame, OutputFrame, Translation<MeshDim>>;
 
 template <size_t MeshDim>
-ConcreteMap<MeshDim> create_coord_map(const std::string& f_of_t_name) {
-  return ConcreteMap<MeshDim>{Translation<MeshDim>{f_of_t_name}};
+using ConcreteMapCombined =
+    domain::CoordinateMap<Frame::Grid, Frame::Inertial, Translation<MeshDim>,
+                          Translation<MeshDim>>;
+
+template <size_t MeshDim, typename InputFrame = Frame::Grid,
+          typename OutputFrame = Frame::Inertial>
+ConcreteMapSimple<MeshDim, InputFrame, OutputFrame> create_coord_map(
+    const std::string& f_of_t_name) {
+  return ConcreteMapSimple<MeshDim, InputFrame, OutputFrame>{
+      Translation<MeshDim>{f_of_t_name}};
+}
+
+template <size_t MeshDim>
+ConcreteMapCombined<MeshDim> create_coord_map_grid_to_inertial(
+    const std::string& f_of_t_grid_to_distorted,
+    const std::string& f_of_t_distorted_to_inertial) {
+  return ConcreteMapCombined<MeshDim>{
+      Translation<MeshDim>{f_of_t_grid_to_distorted},
+      Translation<MeshDim>{f_of_t_distorted_to_inertial}};
+}
+
+template <size_t MeshDim, typename InputFrame, typename OutputFrame,
+          typename BlockMaps, typename BlockMap, typename Gen>
+void test_maps(
+    const std::unique_ptr<TimeDependence<MeshDim>>& time_dep_unique_ptr,
+    const double initial_time,
+    const tnsr::I<DataVector, MeshDim, InputFrame>& input_coords_dv,
+    const tnsr::I<double, MeshDim, InputFrame>& input_coords_double,
+    const tnsr::I<double, MeshDim, OutputFrame>& output_coords_double,
+    const BlockMaps& block_maps, const BlockMap& expected_block_map,
+    std::uniform_real_distribution<double>& dist, Gen& gen) {
+  const auto functions_of_time = time_dep_unique_ptr->functions_of_time();
+
+  for (const auto& block_map : block_maps) {
+    // We've checked equivalence above
+    // (CHECK(*black_map == expected_block_map);), but have sometimes been
+    // burned by incorrect operator== implementations so we check that the
+    // mappings behave as expected.
+    const double time_offset = dist(gen) + 1.2;
+    CHECK_ITERABLE_APPROX(
+        expected_block_map(input_coords_dv, initial_time + time_offset,
+                           functions_of_time),
+        (*block_map)(input_coords_dv, initial_time + time_offset,
+                     functions_of_time));
+    CHECK_ITERABLE_APPROX(
+        expected_block_map(input_coords_double, initial_time + time_offset,
+                           functions_of_time),
+        (*block_map)(input_coords_double, initial_time + time_offset,
+                     functions_of_time));
+
+    CHECK_ITERABLE_APPROX(
+        *expected_block_map.inverse(output_coords_double,
+                                    initial_time + time_offset,
+                                    functions_of_time),
+        *block_map->inverse(output_coords_double, initial_time + time_offset,
+                            functions_of_time));
+
+    CHECK_ITERABLE_APPROX(
+        expected_block_map.inv_jacobian(
+            input_coords_dv, initial_time + time_offset, functions_of_time),
+        block_map->inv_jacobian(input_coords_dv, initial_time + time_offset,
+                                functions_of_time));
+    CHECK_ITERABLE_APPROX(
+        expected_block_map.inv_jacobian(
+            input_coords_double, initial_time + time_offset, functions_of_time),
+        block_map->inv_jacobian(input_coords_double, initial_time + time_offset,
+                                functions_of_time));
+
+    CHECK_ITERABLE_APPROX(
+        expected_block_map.jacobian(input_coords_dv, initial_time + time_offset,
+                                    functions_of_time),
+        block_map->jacobian(input_coords_dv, initial_time + time_offset,
+                            functions_of_time));
+    CHECK_ITERABLE_APPROX(
+        expected_block_map.jacobian(
+            input_coords_double, initial_time + time_offset, functions_of_time),
+        block_map->jacobian(input_coords_double, initial_time + time_offset,
+                            functions_of_time));
+  }
+}
+
+template <size_t MeshDim>
+void test_common(
+    const std::unique_ptr<TimeDependence<MeshDim>>& time_dep_unique_ptr) {
+  CHECK_FALSE(time_dep_unique_ptr->is_none());
+
+  // We downcast to the expected derived class to make sure that factory
+  // creation worked correctly. In order to maximize code reuse this check is
+  // done here as opposed to separately elsewhere.
+  const auto* const time_dep = dynamic_cast<const UniformTranslation<MeshDim>*>(
+      time_dep_unique_ptr.get());
+  REQUIRE(time_dep != nullptr);
+}
+
+template <size_t MeshDim>
+void test_f_of_time(
+    const std::unique_ptr<TimeDependence<MeshDim>>& time_dep_unique_ptr,
+    const std::vector<std::string>& f_of_t_names) {
+  // Test without expiration times
+  const auto functions_of_time = time_dep_unique_ptr->functions_of_time();
+  REQUIRE(functions_of_time.size() == f_of_t_names.size());
+  for (const auto& f_of_t_name : f_of_t_names) {
+    CHECK(functions_of_time.count(f_of_t_name) == 1);
+    CHECK(functions_of_time.at(f_of_t_name)->time_bounds()[1] ==
+          std::numeric_limits<double>::infinity());
+  }
+
+  // Test with expiration times
+  const double init_expr_time = 5.0;
+  std::unordered_map<std::string, double> init_expr_times{};
+  for (const auto& f_of_t_name : f_of_t_names) {
+    init_expr_times[f_of_t_name] = init_expr_time;
+  }
+  const auto functions_of_time_with_expr_times =
+      time_dep_unique_ptr->functions_of_time(init_expr_times);
+  REQUIRE(functions_of_time_with_expr_times.size() == f_of_t_names.size());
+  for (const auto& f_of_t_name : f_of_t_names) {
+    CHECK(functions_of_time_with_expr_times.count(f_of_t_name) == 1);
+    CHECK(functions_of_time_with_expr_times.at(f_of_t_name)->time_bounds()[1] ==
+          init_expr_time);
+  }
 }
 
 template <size_t MeshDim>
@@ -48,14 +168,7 @@ void test(const std::unique_ptr<TimeDependence<MeshDim>>& time_dep_unique_ptr,
   CAPTURE(initial_time);
   CAPTURE(f_of_t_name);
 
-  CHECK_FALSE(time_dep_unique_ptr->is_none());
-
-  // We downcast to the expected derived class to make sure that factory
-  // creation worked correctly. In order to maximize code reuse this check is
-  // done here as opposed to separately elsewhere.
-  const auto* const time_dep = dynamic_cast<const UniformTranslation<MeshDim>*>(
-      time_dep_unique_ptr.get());
-  REQUIRE(time_dep != nullptr);
+  test_common(time_dep_unique_ptr);
 
   // Test coordinate maps
   UniformCustomDistribution<size_t> dist_size_t{1, 10};
@@ -68,7 +181,8 @@ void test(const std::unique_ptr<TimeDependence<MeshDim>>& time_dep_unique_ptr,
       time_dep_unique_ptr->block_maps_grid_to_inertial(num_blocks);
   for (const auto& block_map_unique_ptr : block_maps) {
     const auto* const block_map =
-        dynamic_cast<const ConcreteMap<MeshDim>*>(block_map_unique_ptr.get());
+        dynamic_cast<const ConcreteMapSimple<MeshDim>*>(
+            block_map_unique_ptr.get());
     REQUIRE(block_map != nullptr);
     CHECK(*block_map == expected_block_map);
   }
@@ -79,79 +193,96 @@ void test(const std::unique_ptr<TimeDependence<MeshDim>>& time_dep_unique_ptr,
   CHECK(time_dep_unique_ptr->block_maps_distorted_to_inertial(1)[0].get() ==
         nullptr);
 
-  // Test functions of time without expiration times
-  {
-    const auto functions_of_time = time_dep_unique_ptr->functions_of_time();
-    REQUIRE(functions_of_time.size() == 1);
-    CHECK(functions_of_time.count(f_of_t_name) == 1);
-    CHECK(functions_of_time.at(f_of_t_name)->time_bounds()[1] ==
-          std::numeric_limits<double>::infinity());
-  }
-  // Test functions of time with expiration times
-  {
-    const double init_expr_time = 5.0;
-    std::unordered_map<std::string, double> init_expr_times{};
-    init_expr_times[f_of_t_name] = init_expr_time;
-    const auto functions_of_time =
-        time_dep_unique_ptr->functions_of_time(init_expr_times);
-    REQUIRE(functions_of_time.size() == 1);
-    CHECK(functions_of_time.count(f_of_t_name) == 1);
-    CHECK(functions_of_time.at(f_of_t_name)->time_bounds()[1] ==
-          init_expr_time);
-  }
+  test_f_of_time(time_dep_unique_ptr, {f_of_t_name});
 
-  const auto functions_of_time = time_dep_unique_ptr->functions_of_time();
-
-  // For a random point at a random time check that the values agree. This is to
-  // check that the internals were assigned the correct function of times.
+  // For a random point at a random time check that the values agree. This is
+  // to check that the internals were assigned the correct function of times.
   TIME_DEPENDENCE_GENERATE_COORDS(make_not_null(&gen), MeshDim, -1.0, 1.0);
 
-  for (const auto& block_map : block_maps) {
-    // We've checked equivalence above
-    // (CHECK(*black_map == expected_block_map);), but have sometimes been
-    // burned by incorrect operator== implementations so we check that the
-    // mappings behave as expected.
-    const double time_offset = dist(gen) + 1.2;
-    CHECK_ITERABLE_APPROX(
-        expected_block_map(grid_coords_dv, initial_time + time_offset,
-                           functions_of_time),
-        (*block_map)(grid_coords_dv, initial_time + time_offset,
-                     functions_of_time));
-    CHECK_ITERABLE_APPROX(
-        expected_block_map(grid_coords_double, initial_time + time_offset,
-                           functions_of_time),
-        (*block_map)(grid_coords_double, initial_time + time_offset,
-                     functions_of_time));
+  test_maps(time_dep_unique_ptr, initial_time, grid_coords_dv,
+            grid_coords_double, inertial_coords_double, block_maps,
+            expected_block_map, dist, gen);
+}
 
-    CHECK_ITERABLE_APPROX(
-        *expected_block_map.inverse(inertial_coords_double,
-                                    initial_time + time_offset,
-                                    functions_of_time),
-        *block_map->inverse(inertial_coords_double, initial_time + time_offset,
-                            functions_of_time));
+template <size_t MeshDim>
+void test_with_distorted_frame(
+    const std::unique_ptr<TimeDependence<MeshDim>>& time_dep_unique_ptr,
+    const double initial_time, const std::string& f_of_t_grid_to_distorted,
+    const std::string& f_of_t_distorted_to_inertial) {
+  MAKE_GENERATOR(gen);
+  CAPTURE(initial_time);
+  CAPTURE(f_of_t_grid_to_distorted);
+  CAPTURE(f_of_t_distorted_to_inertial);
 
-    CHECK_ITERABLE_APPROX(
-        expected_block_map.inv_jacobian(
-            grid_coords_dv, initial_time + time_offset, functions_of_time),
-        block_map->inv_jacobian(grid_coords_dv, initial_time + time_offset,
-                                functions_of_time));
-    CHECK_ITERABLE_APPROX(
-        expected_block_map.inv_jacobian(
-            grid_coords_double, initial_time + time_offset, functions_of_time),
-        block_map->inv_jacobian(grid_coords_double, initial_time + time_offset,
-                                functions_of_time));
+  test_common(time_dep_unique_ptr);
 
-    CHECK_ITERABLE_APPROX(
-        expected_block_map.jacobian(grid_coords_dv, initial_time + time_offset,
-                                    functions_of_time),
-        block_map->jacobian(grid_coords_dv, initial_time + time_offset,
-                            functions_of_time));
-    CHECK_ITERABLE_APPROX(
-        expected_block_map.jacobian(
-            grid_coords_double, initial_time + time_offset, functions_of_time),
-        block_map->jacobian(grid_coords_double, initial_time + time_offset,
-                            functions_of_time));
+  // Test coordinate maps
+  UniformCustomDistribution<size_t> dist_size_t{1, 10};
+  const size_t num_blocks = dist_size_t(gen);
+  CAPTURE(num_blocks);
+
+  const auto expected_block_map_grid_to_inertial =
+      create_coord_map_grid_to_inertial<MeshDim>(f_of_t_grid_to_distorted,
+                                                 f_of_t_distorted_to_inertial);
+  const auto block_maps_grid_to_inertial =
+      time_dep_unique_ptr->block_maps_grid_to_inertial(num_blocks);
+  for (const auto& block_map_unique_ptr : block_maps_grid_to_inertial) {
+    const auto* const block_map =
+        dynamic_cast<const ConcreteMapCombined<MeshDim>*>(
+            block_map_unique_ptr.get());
+    REQUIRE(block_map != nullptr);
+    CHECK(*block_map == expected_block_map_grid_to_inertial);
   }
+
+  const auto expected_block_map_grid_to_distorted =
+      create_coord_map<MeshDim, Frame::Grid, Frame::Distorted>(
+          f_of_t_grid_to_distorted);
+  const auto block_maps_grid_to_distorted =
+      time_dep_unique_ptr->block_maps_grid_to_distorted(num_blocks);
+  for (const auto& block_map_unique_ptr : block_maps_grid_to_distorted) {
+    const auto* const block_map = dynamic_cast<
+        const ConcreteMapSimple<MeshDim, Frame::Grid, Frame::Distorted>*>(
+        block_map_unique_ptr.get());
+    REQUIRE(block_map != nullptr);
+    CHECK(*block_map == expected_block_map_grid_to_distorted);
+  }
+
+  const auto expected_block_map_distorted_to_inertial =
+      create_coord_map<MeshDim, Frame::Distorted, Frame::Inertial>(
+          f_of_t_distorted_to_inertial);
+  const auto block_maps_distorted_to_inertial =
+      time_dep_unique_ptr->block_maps_distorted_to_inertial(num_blocks);
+  for (const auto& block_map_unique_ptr : block_maps_distorted_to_inertial) {
+    const auto* const block_map = dynamic_cast<
+        const ConcreteMapSimple<MeshDim, Frame::Distorted, Frame::Inertial>*>(
+        block_map_unique_ptr.get());
+    REQUIRE(block_map != nullptr);
+    CHECK(*block_map == expected_block_map_distorted_to_inertial);
+  }
+
+  test_f_of_time(time_dep_unique_ptr,
+                 {f_of_t_grid_to_distorted, f_of_t_distorted_to_inertial});
+
+  // For a random point at a random time check that the values agree. This is
+  // to check that the internals were assigned the correct function of times.
+  TIME_DEPENDENCE_GENERATE_COORDS(make_not_null(&gen), MeshDim, -1.0, 1.0);
+
+  test_maps(time_dep_unique_ptr, initial_time, grid_coords_dv,
+            grid_coords_double, inertial_coords_double,
+            block_maps_grid_to_inertial, expected_block_map_grid_to_inertial,
+            dist, gen);
+
+  TIME_DEPENDENCE_GENERATE_DISTORTED_COORDS(make_not_null(&gen), dist, MeshDim);
+
+  test_maps(time_dep_unique_ptr, initial_time, grid_coords_dv,
+            grid_coords_double, distorted_coords_double,
+            block_maps_grid_to_distorted, expected_block_map_grid_to_distorted,
+            dist, gen);
+
+  test_maps(time_dep_unique_ptr, initial_time, distorted_coords_dv,
+            distorted_coords_double, inertial_coords_double,
+            block_maps_distorted_to_inertial,
+            expected_block_map_distorted_to_inertial, dist, gen);
 }
 
 void test_equivalence() {
@@ -197,6 +328,46 @@ void test_equivalence() {
     CHECK(ut0 != ut4);
     CHECK_FALSE(ut0 == ut4);
   }
+
+  // With distorted frame
+  {
+    UniformTranslation<3> ut0{1.0, {{2.0, 4.0, 6.0}}, {{1.0, 2.0, 3.0}}};
+    UniformTranslation<3> ut1{1.0, {{2.0, 4.0, 6.0}}};
+    UniformTranslation<3> ut2{1.0, {{3.0, 4.0, 6.0}}, {{1.0, 2.0, 3.0}}};
+    UniformTranslation<3> ut3{1.0, {{2.0, 5.0, 6.0}}, {{1.0, 2.0, 3.0}}};
+    UniformTranslation<3> ut4{1.0, {{2.0, 4.0, 6.0}}, {{1.0, 3.0, 2.0}}};
+    CHECK(ut0 == ut0);
+    CHECK_FALSE(ut0 != ut0);
+    CHECK(ut0 != ut1);
+    CHECK_FALSE(ut0 == ut1);
+    CHECK(ut0 != ut2);
+    CHECK_FALSE(ut0 == ut2);
+    CHECK(ut0 != ut3);
+    CHECK_FALSE(ut0 == ut3);
+    CHECK(ut0 != ut4);
+    CHECK_FALSE(ut0 == ut4);
+  }
+}
+
+template <size_t Dim>
+void test_with_distorted_frame_driver(
+    const std::array<double, Dim>& velocity_grid_to_distorted,
+    const std::array<double, Dim>& velocity_distorted_to_inertial) {
+  const double initial_time = 1.3;
+
+  // This name must match the hard coded one in UniformTranslation
+  const std::string f_of_t_grid_to_distorted = "Translation";
+  const std::string f_of_t_distorted_to_inertial =
+      "TranslationDistortedToInertial";
+  const std::unique_ptr<domain::creators::time_dependence::TimeDependence<Dim>>
+      time_dep = std::make_unique<UniformTranslation<Dim>>(
+          initial_time, velocity_grid_to_distorted,
+          velocity_distorted_to_inertial);
+  test_with_distorted_frame(time_dep, initial_time, f_of_t_grid_to_distorted,
+                            f_of_t_distorted_to_inertial);
+  test_with_distorted_frame(time_dep->get_clone(), initial_time,
+                            f_of_t_grid_to_distorted,
+                            f_of_t_distorted_to_inertial);
 }
 
 SPECTRE_TEST_CASE("Unit.Domain.Creators.TimeDependence.UniformTranslation",
@@ -257,6 +428,9 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.TimeDependence.UniformTranslation",
          initial_time, f_of_t_name);
   }
 
+  test_with_distorted_frame_driver<1>({{2.4}}, {{3.3}});
+  test_with_distorted_frame_driver<2>({{2.4, 3.1}}, {{3.3, 1.6}});
+  test_with_distorted_frame_driver<3>({{2.4, 3.1, 1.3}}, {{3.3, 1.6, -1.4}});
   test_equivalence();
 }
 }  // namespace

--- a/tests/Unit/Helpers/Domain/Creators/TimeDependence/TestHelpers.hpp
+++ b/tests/Unit/Helpers/Domain/Creators/TimeDependence/TestHelpers.hpp
@@ -37,3 +37,21 @@
   const auto inertial_coords_double =                                     \
       make_with_random_values<tnsr::I<double, DIM, Frame::Inertial>>(     \
           GENERATOR, make_not_null(&dist))
+
+/*!
+ * \brief Generates random coordinates of double and DataVector types.
+ *
+ * Same as TIME_DEPENDENCE_GENERATE_COORDS except:
+ * - It creates only distorted-frame coords.
+ * - It takes a DIST as an argument, since in typical usage one would
+ *   call TIME_DEPENDENCE_GENERATE_COORDS and then call
+ *   TIME_DEPENDENCE_GENERATE_DISTORTED_COORDS.
+ *
+ */
+#define TIME_DEPENDENCE_GENERATE_DISTORTED_COORDS(GENERATOR, DIST, DIM)    \
+  const auto distorted_coords_dv =                                         \
+      make_with_random_values<tnsr::I<DataVector, DIM, Frame::Distorted>>( \
+          GENERATOR, make_not_null(&dist), DataVector{5});                 \
+  const auto distorted_coords_double =                                     \
+      make_with_random_values<tnsr::I<double, DIM, Frame::Distorted>>(     \
+          GENERATOR, make_not_null(&dist));


### PR DESCRIPTION
## Proposed changes

Add distorted frame to UniformTranslation TimeDependence.

Also refactored tests in Test_UniformTranslation so as to re-use code for tests with and without
a distorted frame.

This is expected to be useful mostly for tests.
"Real" Domains with a distorted frame will not use a TimeDependence class.

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
