### PR TITLE
Add distorted frame to block_logical_coordinates

### DIFF
--- a/src/Domain/Block.hpp
+++ b/src/Domain/Block.hpp
@@ -105,6 +105,25 @@ class Block {
   bool is_time_dependent() const { return stationary_map_ == nullptr; }
 
   /// \brief Returns `true` if the block has a distorted frame.
+  ///
+  /// If a block has a distorted frame, then
+  ///   - moving_mesh_grid_to_distorted_map() is non-null
+  ///   - moving_mesh_distorted_to_inertial_map() is non-null
+  ///   - moving_mesh_grid_to_inertial_map() is non-null
+  /// Note in particular the last point above:  If the block is time-dependent,
+  /// then the block must have a grid_to_inertial map independent of whether
+  /// it has a distorted frame.  This allows us to write more efficient maps.
+  /// In particular, we often care only about the grid_to_inertial map, so we
+  /// can code that map directly instead of composing
+  /// grid_to_distorted + distorted_to_inertial maps at runtime.
+  ///
+  /// If a block does not have a distorted frame, then
+  ///   - moving_mesh_grid_to_distorted_map() is null
+  ///   - moving_mesh_distorted_to_inertial_map() is null
+  ///   - moving_mesh_grid_to_inertial_map() is non-null
+  ///   - If we ever find ourselves needing ::Frame::Distorted coordinates
+  ///     in that block, we can assume that ::Frame::Distorted and ::Frame::Grid
+  ///     are the same.  Usually this case will not occur.
   bool has_distorted_frame() const {
     return moving_mesh_grid_to_distorted_map_ != nullptr and
            moving_mesh_distorted_to_inertial_map_ != nullptr;

--- a/src/Domain/BlockLogicalCoordinates.hpp
+++ b/src/Domain/BlockLogicalCoordinates.hpp
@@ -42,6 +42,14 @@ class Domain;
 /// error_. Therefore, be advised to use the logical coordinates returned by
 /// this function, which are guaranteed to be in [-1, 1] and can be safely
 /// passed along to `element_logical_coordinates`.
+///
+/// \warning `block_logical_coordinates` with x in
+/// `::Frame::Distorted` ignores all `Block`s that lack a distorted
+/// frame, and it will return std::nullopt for points that lie outside
+/// all distorted-frame-endowed `Block`s. This is what is expected for
+/// typical use cases.  This means that `block_logical_coordinates`
+/// does not assume that grid and distorted frames are equal in
+/// `Block`s that lack a distorted frame.
 template <size_t Dim, typename Frame>
 auto block_logical_coordinates(
     const Domain<Dim>& domain, const tnsr::I<DataVector, Dim, Frame>& x,


### PR DESCRIPTION

block_logical_coordinates now understand the distorted frame.

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
