### PR TITLE
Add ScalarWaveWorldtube library

### DIFF
--- a/src/Evolution/Systems/CurvedScalarWave/CMakeLists.txt
+++ b/src/Evolution/Systems/CurvedScalarWave/CMakeLists.txt
@@ -44,3 +44,4 @@ target_link_libraries(
 
 add_subdirectory(BoundaryConditions)
 add_subdirectory(BoundaryCorrections)
+add_subdirectory(Worldtube)

--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/CMakeLists.txt
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/CMakeLists.txt
@@ -1,0 +1,26 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBRARY ScalarWaveWorldtube)
+
+add_spectre_library(${LIBRARY})
+
+spectre_target_sources(
+  ${LIBRARY}
+  PRIVATE
+  Tags.cpp
+  )
+
+spectre_target_headers(
+  ${LIBRARY}
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  Tags.hpp
+  Worldtube.hpp
+  )
+
+target_link_libraries(
+  ${LIBRARY}
+  PUBLIC
+  Options
+  )

--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/Tags.cpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/Tags.cpp
@@ -1,0 +1,5 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/CurvedScalarWave/Worldtube/Tags.hpp"
+

--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/Tags.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/Tags.hpp
@@ -1,0 +1,20 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "Options/Options.hpp"
+
+namespace CurvedScalarWave::Worldtube {
+/*!
+ * \brief Option tags for the worldtube
+ */
+namespace OptionTags {
+/*!
+ * \brief Options for the worldtube
+ */
+struct Worldtube {
+  static constexpr Options::String help = {"Options for the Worldtube"};
+};
+}  // namespace OptionTags
+}  // namespace CurvedScalarWave::Worldtube

--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/Worldtube.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/Worldtube.hpp
@@ -1,0 +1,30 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+/*!
+ * \brief The set of utilities for performing CurvedScalarWave evolution with a
+ * worldtube excision scheme.
+ *
+ * \details The worldtube excision scheme is a method that aims to enable NR
+ * evolutions of intermediate mass ratio binary black hole simulations. In
+ * standard BBH simulations two excision spheres are cut out from the domain
+ * within the apparent horizons of the respective black holes. For larger mass
+ * ratios, this introduces a scale disparity in the evolution system because the
+ * small grid spacing in the elements near the smaller black hole constrain the
+ * time step to be orders of magnitude smaller than near the larger black hole
+ * due to the CFL condition. The worldtube excision scheme avoids this by
+ * excising a much larger region (the worldtube) around the smaller black hole.
+ * Since the excision boundary no longer lies within the apparent horizon,
+ * boundary conditions are required. These are derived by approximating the
+ * solution inside the worldtube using a perturbative solution - a black hole
+ * perturbed by another black hole. The solution is calibrated by the evolved
+ * metric on the worldtube boundary and in turn provides boundary conditions to
+ * the evolution system.
+ *
+ * Here, we test this scheme using a toy problem of a scalar charge in
+ * circular orbit around a Schwarzschild black hole.
+ */
+namespace CurvedScalarWave::Worldtube {
+}  // namespace CurvedScalarWave::Worldtube


### PR DESCRIPTION
This adds the worldtube library. I think it is best to add it directly to `CurvedScalarWave` since it only works with this system.


