### PR TITLE
Add jacobian diagnostic to ExportCoordinates

### DIFF
--- a/src/Domain/JacobianDiagnostic.hpp
+++ b/src/Domain/JacobianDiagnostic.hpp
@@ -19,7 +19,7 @@ class DataVector;
 namespace domain {
 /*!
  * \ingroup ComputationalDomainGroup
- * \brief A diagonstic comparing the analytic and numerical Jacobians for a
+ * \brief A diagnostic comparing the analytic and numerical Jacobians for a
  * map.
  *
  * Specifically, returns
@@ -50,7 +50,7 @@ void jacobian_diagnostic(
 
 /*!
  * \ingroup ComputationalDomainGroup
- * \brief A diagonstic comparing the analytic and numerical Jacobians for a
+ * \brief A diagnostic comparing the analytic and numerical Jacobians for a
  * map.
  *
  * Specifically, returns
@@ -78,7 +78,7 @@ void jacobian_diagnostic(
 namespace Tags {
 /// \ingroup DataBoxTagsGroup
 /// \ingroup ComputationalDomainGroup
-/// \brief A diagonstic comparing the analytic and numerical Jacobians for a
+/// \brief A diagnostic comparing the analytic and numerical Jacobians for a
 /// map. See `domain::jacobian_diagnostic` for details.
 template <size_t Dim>
 struct JacobianDiagnostic : db::SimpleTag {


### PR DESCRIPTION
## Proposed changes

Output the jacobian diagnostic (comparing the analytic jacobian returned by the map to a numeric jacobian calculated via numerical differentiation) in ExportCoordinates. Also fixes a typo in the jacobian diagnostic documentation (misspelled "diagnostic").

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
