### PR TITLE
Allow transform to Distorted frame.

### DIFF
--- a/src/PointwiseFunctions/GeneralRelativity/Transform.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/Transform.cpp
@@ -346,11 +346,11 @@ auto first_index_to_different_frame(
       ->Scalar<DTYPE(data)>;
 GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3),
                         (Frame::BlockLogical, Frame::ElementLogical,
-                         Frame::Grid),
+                         Frame::Grid, Frame::Distorted),
                         (Frame::Inertial), (double, DataVector))
 GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (Frame::Inertial),
                         (Frame::BlockLogical, Frame::ElementLogical,
-                         Frame::Grid),
+                         Frame::Grid, Frame::Distorted),
                         (double, DataVector))
 #undef INSTANTIATE
 
@@ -377,12 +377,12 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (Frame::Inertial),
 
 GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3),
                         (Frame::BlockLogical, Frame::ElementLogical,
-                         Frame::Grid),
+                         Frame::Grid, Frame::Distorted),
                         (Frame::Inertial), (double, DataVector),
                         (I, i, iJ, ii, II, ijj))
 GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (Frame::Inertial),
                         (Frame::BlockLogical, Frame::ElementLogical,
-                         Frame::Grid),
+                         Frame::Grid, Frame::Distorted),
                         (double, DataVector), (I, i, iJ, ii, II, ijj))
 
 #undef INSTANTIATE
@@ -414,7 +414,7 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (Frame::Inertial),
       ->tnsr::ijj<DataVector, DIM(data), DESTFRAME(data)>;
 GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3),
                         (Frame::BlockLogical, Frame::ElementLogical),
-                        (Frame::Grid))
+                        (Frame::Grid, Frame::Distorted))
 
 #undef DIM
 #undef SRCFRAME

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_Transform.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_Transform.cpp
@@ -119,10 +119,25 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.GeneralRelativity.Transform",
   test_transform_to_different_frame<1, Frame::Grid, Frame::Inertial>(dv);
   test_transform_to_different_frame<2, Frame::Grid, Frame::Inertial>(dv);
   test_transform_to_different_frame<3, Frame::Grid, Frame::Inertial>(dv);
+  test_transform_to_different_frame<1, Frame::Inertial, Frame::Distorted>(
+      double{});
+  test_transform_to_different_frame<2, Frame::Inertial, Frame::Distorted>(
+      double{});
+  test_transform_to_different_frame<3, Frame::Inertial, Frame::Distorted>(
+      double{});
+  test_transform_to_different_frame<1, Frame::Inertial, Frame::Distorted>(dv);
+  test_transform_to_different_frame<2, Frame::Inertial, Frame::Distorted>(dv);
+  test_transform_to_different_frame<3, Frame::Inertial, Frame::Distorted>(dv);
   test_transform_first_index_to_different_frame<1, Frame::ElementLogical,
                                                 Frame::Grid>(dv);
   test_transform_first_index_to_different_frame<2, Frame::ElementLogical,
                                                 Frame::Grid>(dv);
   test_transform_first_index_to_different_frame<3, Frame::ElementLogical,
                                                 Frame::Grid>(dv);
+  test_transform_first_index_to_different_frame<1, Frame::ElementLogical,
+                                                Frame::Distorted>(dv);
+  test_transform_first_index_to_different_frame<2, Frame::ElementLogical,
+                                                Frame::Distorted>(dv);
+  test_transform_first_index_to_different_frame<3, Frame::ElementLogical,
+                                                Frame::Distorted>(dv);
 }


### PR DESCRIPTION
## Proposed changes

Allows functions in `namespace transform` to transform to Distorted frame.

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
