### PR TITLE
StrahlkorperCoords src can be Frame::Distorted.

### DIFF
--- a/src/ApparentHorizons/StrahlkorperCoordsInDifferentFrame.hpp
+++ b/src/ApparentHorizons/StrahlkorperCoordsInDifferentFrame.hpp
@@ -26,6 +26,14 @@ class not_null;
 /// \brief Maps (cartesian) collocation points of a Strahlkorper to
 /// a different frame.
 ///
+/// If SrcFrame is Frame::Distorted, strahlkorper_coords_in_different_frame
+/// will fail if src_strahlkorper intersects a Block that lacks a distorted
+/// frame.  Note that if such a Strahlkorper intersects
+/// such a Block, we have worse problems anyway (e.g. jacobians will usually
+/// be discontinuous at the boundaries of such a Block, and attempting to
+/// find such a Strahlkorper with an apparent-horizon finder will probably
+/// fail).
+///
 /// Note that because the Blocks inside the Domain allow access to
 /// maps only between a selected subset of frames, we cannot use
 /// strahlkorper_in_different_frame to map between arbitrary frames;

--- a/tests/Unit/ApparentHorizons/Test_StrahlkorperCoordsInDifferentFrame.cpp
+++ b/tests/Unit/ApparentHorizons/Test_StrahlkorperCoordsInDifferentFrame.cpp
@@ -23,17 +23,18 @@
 
 namespace {
 
+template<typename SrcFrame>
 void test_strahlkorper_coords_in_different_frame() {
   const size_t grid_points_each_dimension = 5;
 
   // Set up a Strahlkorper corresponding to a Schwarzschild hole of
-  // mass 1, in the grid frame.
+  // mass 1, in the source frame.
   // Center the Strahlkorper at (0.03,0.02,0.01) so that we test a
   // nonzero center.
-  const std::array<double, 3> strahlkorper_grid_center = {0.03, 0.02, 0.01};
+  const std::array<double, 3> strahlkorper_src_center = {0.03, 0.02, 0.01};
   const size_t l_max = 8;
-  const Strahlkorper<Frame::Grid> strahlkorper_grid(l_max, 2.0,
-                                                    strahlkorper_grid_center);
+  const Strahlkorper<SrcFrame> strahlkorper_src(l_max, 2.0,
+                                                strahlkorper_src_center);
 
   // Create a Domain.
   // We choose a spherical shell domain extending from radius 1.9M to
@@ -43,15 +44,32 @@ void test_strahlkorper_coords_in_different_frame() {
   std::vector<double> radial_partitioning{};
   std::vector<domain::CoordinateMaps::Distribution> radial_distribution{
       domain::CoordinateMaps::Distribution::Linear};
+
+  // In computing the time_dependence, make sure that src-to-inertial
+  // velocity is (0.01,0.02,0.03) to agree with the analytic checks
+  // below.  If src is distorted frame, then grid-to-distorted
+  // velocity doesn't matter for the value of the check (but does matter
+  // in terms of which points are in which blocks).
+  std::unique_ptr<domain::creators::time_dependence::TimeDependence<3>>
+      time_dependence;
+  if constexpr (std::is_same_v<SrcFrame, ::Frame::Grid>) {
+    time_dependence = std::make_unique<
+        domain::creators::time_dependence::UniformTranslation<3>>(
+        0.0, std::array<double, 3>({{0.01, 0.02, 0.03}}));
+  } else {
+    static_assert(std::is_same_v<SrcFrame, ::Frame::Distorted>,
+                  "Src frame must be Distorted if it is not Grid");
+    time_dependence = std::make_unique<
+        domain::creators::time_dependence::UniformTranslation<3>>(
+        0.0, std::array<double, 3>({{-0.02, -0.01, -0.01}}),
+        std::array<double, 3>({{0.01, 0.02, 0.03}}));
+  }
   domain::creators::Shell domain_creator(
       1.9, 2.9, 1,
       std::array<size_t, 2>{grid_points_each_dimension,
                             grid_points_each_dimension},
       false, {{1.0, 2}}, radial_partitioning, radial_distribution,
-      ShellWedges::All,
-      std::make_unique<
-          domain::creators::time_dependence::UniformTranslation<3>>(
-          0.0, std::array<double, 3>({{0.01, 0.02, 0.03}})));
+      ShellWedges::All, std::move(time_dependence));
   Domain<3> domain = domain_creator.create_domain();
   const auto functions_of_time = domain_creator.functions_of_time();
 
@@ -60,18 +78,18 @@ void test_strahlkorper_coords_in_different_frame() {
   tnsr::I<DataVector, 3, Frame::Inertial> inertial_coords{};
 
   strahlkorper_coords_in_different_frame(make_not_null(&inertial_coords),
-                                         strahlkorper_grid, domain,
+                                         strahlkorper_src, domain,
                                          functions_of_time, time);
 
-  // Now compare with expected result, which is the grid-frame coords of
+  // Now compare with expected result, which is the src-frame coords of
   // the Strahlkorper translated by (0.005,0.01,0.015).
-  const auto grid_coords = StrahlkorperFunctions::cartesian_coords(
-      strahlkorper_grid, StrahlkorperFunctions::radius(strahlkorper_grid),
+  const auto src_coords = StrahlkorperFunctions::cartesian_coords(
+      strahlkorper_src, StrahlkorperFunctions::radius(strahlkorper_src),
       StrahlkorperFunctions::rhat(
-          StrahlkorperFunctions::theta_phi(strahlkorper_grid)));
-  CHECK_ITERABLE_APPROX(get<0>(grid_coords) + 0.005, get<0>(inertial_coords));
-  CHECK_ITERABLE_APPROX(get<1>(grid_coords) + 0.01, get<1>(inertial_coords));
-  CHECK_ITERABLE_APPROX(get<2>(grid_coords) + 0.015, get<2>(inertial_coords));
+          StrahlkorperFunctions::theta_phi(strahlkorper_src)));
+  CHECK_ITERABLE_APPROX(get<0>(src_coords) + 0.005, get<0>(inertial_coords));
+  CHECK_ITERABLE_APPROX(get<1>(src_coords) + 0.01, get<1>(inertial_coords));
+  CHECK_ITERABLE_APPROX(get<2>(src_coords) + 0.015, get<2>(inertial_coords));
 }
 
 SPECTRE_TEST_CASE("Unit.ApparentHorizons.StrahlkorperCoordsInDifferentFrame",
@@ -79,7 +97,8 @@ SPECTRE_TEST_CASE("Unit.ApparentHorizons.StrahlkorperCoordsInDifferentFrame",
   domain::creators::register_derived_with_charm();
   domain::creators::time_dependence::register_derived_with_charm();
   domain::FunctionsOfTime::register_derived_with_charm();
-  test_strahlkorper_coords_in_different_frame();
+  test_strahlkorper_coords_in_different_frame<Frame::Grid>();
+  test_strahlkorper_coords_in_different_frame<Frame::Distorted>();
 }
 
 }  // namespace


### PR DESCRIPTION
StrahlkorperCoordsInDifferentFrame now can use distorted coords as its input.

Formerly only Frame::Grid was allowed as input.

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
