### PR TITLE
Change `ExcisionSphere::center()` return type to `tnsr::I<double, 3, Frame::Grid>`

### DIFF
--- a/src/ControlSystem/ControlErrors/Translation.hpp
+++ b/src/ControlSystem/ControlErrors/Translation.hpp
@@ -99,8 +99,11 @@ struct Translation : tt::ConformsTo<protocols::ControlError> {
            "Excision sphere for ObjectA not in the domain but is needed to "
            "compute Translation control error.");
 
-    const DataVector grid_position_of_A = array_to_datavector(
-        domain.excision_spheres().at("ObjectAExcisionSphere").center());
+    const tnsr::I<double, 3, Frame::Grid>& grid_position_of_A_tnsr =
+        domain.excision_spheres().at("ObjectAExcisionSphere").center();
+    const DataVector grid_position_of_A{{grid_position_of_A_tnsr[0],
+                                         grid_position_of_A_tnsr[1],
+                                         grid_position_of_A_tnsr[2]}};
     const DataVector& current_position_of_A = get<center_A>(measurements);
 
     const DataVector rotation_error =

--- a/src/Domain/Creators/BinaryCompactObject.cpp
+++ b/src/Domain/Creators/BinaryCompactObject.cpp
@@ -511,26 +511,28 @@ Domain<3> BinaryCompactObject::create_domain() const {
   if (object_A_.is_excised()) {
     excision_spheres.emplace(
         "ObjectAExcisionSphere",
-        ExcisionSphere<3>{object_A_.inner_radius,
-                          {{object_A_.x_coord, 0.0, 0.0}},
-                          {{0, Direction<3>::lower_zeta()},
-                           {1, Direction<3>::lower_zeta()},
-                           {2, Direction<3>::lower_zeta()},
-                           {3, Direction<3>::lower_zeta()},
-                           {4, Direction<3>::lower_zeta()},
-                           {5, Direction<3>::lower_zeta()}}});
+        ExcisionSphere<3>{
+            object_A_.inner_radius,
+            tnsr::I<double, 3, Frame::Grid>{{object_A_.x_coord, 0.0, 0.0}},
+            {{0, Direction<3>::lower_zeta()},
+             {1, Direction<3>::lower_zeta()},
+             {2, Direction<3>::lower_zeta()},
+             {3, Direction<3>::lower_zeta()},
+             {4, Direction<3>::lower_zeta()},
+             {5, Direction<3>::lower_zeta()}}});
   }
   if (object_B_.is_excised()) {
     excision_spheres.emplace(
         "ObjectBExcisionSphere",
-        ExcisionSphere<3>{object_B_.inner_radius,
-                          {{object_B_.x_coord, 0.0, 0.0}},
-                          {{12, Direction<3>::lower_zeta()},
-                           {13, Direction<3>::lower_zeta()},
-                           {14, Direction<3>::lower_zeta()},
-                           {15, Direction<3>::lower_zeta()},
-                           {16, Direction<3>::lower_zeta()},
-                           {17, Direction<3>::lower_zeta()}}});
+        ExcisionSphere<3>{
+            object_B_.inner_radius,
+            tnsr::I<double, 3, Frame::Grid>{{object_B_.x_coord, 0.0, 0.0}},
+            {{12, Direction<3>::lower_zeta()},
+             {13, Direction<3>::lower_zeta()},
+             {14, Direction<3>::lower_zeta()},
+             {15, Direction<3>::lower_zeta()},
+             {16, Direction<3>::lower_zeta()},
+             {17, Direction<3>::lower_zeta()}}});
   }
 
   // Have corners determined automatically

--- a/src/Domain/Creators/CylindricalBinaryCompactObject.cpp
+++ b/src/Domain/Creators/CylindricalBinaryCompactObject.cpp
@@ -842,8 +842,10 @@ Domain<3> CylindricalBinaryCompactObject::create_domain() const {
   }
   excision_spheres.emplace(
       "ObjectAExcisionSphere",
-      ExcisionSphere<3>{radius_A_, rotate_from_z_to_x_axis(center_A_),
-                        abutting_directions_A});
+      ExcisionSphere<3>{
+          radius_A_,
+          tnsr::I<double, 3, Frame::Grid>(rotate_from_z_to_x_axis(center_A_)),
+          abutting_directions_A});
 
   std::unordered_map<size_t, Direction<3>> abutting_directions_B;
   if (include_inner_sphere_B_) {
@@ -870,8 +872,10 @@ Domain<3> CylindricalBinaryCompactObject::create_domain() const {
   }
   excision_spheres.emplace(
       "ObjectBExcisionSphere",
-      ExcisionSphere<3>{radius_B_, rotate_from_z_to_x_axis(center_B_),
-                        abutting_directions_B});
+      ExcisionSphere<3>{
+          radius_B_,
+          tnsr::I<double, 3, Frame::Grid>(rotate_from_z_to_x_axis(center_B_)),
+          abutting_directions_B});
 
   Domain<3> domain{std::move(coordinate_maps), std::move(excision_spheres),
                    block_names_, block_groups_};

--- a/src/Domain/Creators/Shell.cpp
+++ b/src/Domain/Creators/Shell.cpp
@@ -162,7 +162,7 @@ Domain<3> Shell::create_domain() const {
     excision_spheres.emplace(
         "CentralExcisionSphere",
         ExcisionSphere<3>{inner_radius_,
-                          {{0.0, 0.0, 0.0}},
+                          tnsr::I<double, 3, Frame::Grid>{0.0},
                           {{0, Direction<3>::lower_zeta()},
                            {1, Direction<3>::lower_zeta()},
                            {2, Direction<3>::lower_zeta()},

--- a/src/Domain/Structure/ExcisionSphere.cpp
+++ b/src/Domain/Structure/ExcisionSphere.cpp
@@ -16,7 +16,7 @@
 
 template <size_t VolumeDim>
 ExcisionSphere<VolumeDim>::ExcisionSphere(
-    const double radius, const std::array<double, VolumeDim> center,
+    const double radius, const tnsr::I<double, VolumeDim, Frame::Grid> center,
     std::unordered_map<size_t, Direction<VolumeDim>> abutting_directions)
     : radius_(radius),
       center_(center),

--- a/src/Domain/Structure/ExcisionSphere.hpp
+++ b/src/Domain/Structure/ExcisionSphere.hpp
@@ -6,14 +6,13 @@
 
 #pragma once
 
-#include <array>
 #include <cstddef>
 #include <iosfwd>
 #include <limits>
 #include <unordered_map>
 
+#include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/Structure/Direction.hpp"
-#include "Utilities/MakeArray.hpp"
 
 /// \cond
 namespace PUP {
@@ -39,7 +38,7 @@ class ExcisionSphere {
   /// \param abutting_directions the set of blocks that touch the excision
   /// sphere, along with the direction in which they touch it.
   ExcisionSphere(
-      double radius, std::array<double, VolumeDim> center,
+      double radius, tnsr::I<double, VolumeDim, Frame::Grid> center,
       std::unordered_map<size_t, Direction<VolumeDim>> abutting_directions);
 
   /// Default constructor needed for Charm++ serialization.
@@ -56,7 +55,9 @@ class ExcisionSphere {
   double radius() const { return radius_; }
 
   /// The coodinate center of the ExcisionSphere.
-  const std::array<double, VolumeDim>& center() const { return center_; }
+  const tnsr::I<double, VolumeDim, Frame::Grid>& center() const {
+    return center_;
+  }
 
   /// The set of blocks that touch the excision sphere, along with the direction
   /// in which they touch it
@@ -70,8 +71,8 @@ class ExcisionSphere {
 
  private:
   double radius_{std::numeric_limits<double>::signaling_NaN()};
-  std::array<double, VolumeDim> center_{
-      make_array<VolumeDim>(std::numeric_limits<double>::signaling_NaN())};
+  tnsr::I<double, VolumeDim, Frame::Grid> center_{
+      std::numeric_limits<double>::signaling_NaN()};
   std::unordered_map<size_t, Direction<VolumeDim>> abutting_directions_{};
 };
 

--- a/tests/Unit/ControlSystem/ControlErrors/Test_Shape.cpp
+++ b/tests/Unit/ControlSystem/ControlErrors/Test_Shape.cpp
@@ -39,6 +39,7 @@
 #include "Parallel/Phase.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/MakeArray.hpp"
 #include "Utilities/StdArrayHelpers.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
@@ -64,10 +65,10 @@ void test_shape_control_error() {
   MAKE_GENERATOR(generator);
   domain::FunctionsOfTime::register_derived_with_charm();
 
-  const std::array<double, 3> origin{{0.0, 0.0, 0.0}};
+  const tnsr::I<double, 3, Frame::Grid> origin{0.0};
   const double ah_radius = 1.5;
   const double initial_time = 0.0;
-  Strahlkorper fake_ah{10, 10, origin};
+  Strahlkorper fake_ah{10, 10, make_array<double, 3>(origin)};
   auto& fake_ah_coefs = fake_ah.coefficients();
 
   // Setup initial shape map coefficients. In the map the coefficients are

--- a/tests/Unit/ControlSystem/Systems/Test_Shape.cpp
+++ b/tests/Unit/ControlSystem/Systems/Test_Shape.cpp
@@ -40,6 +40,7 @@
 #include "Parallel/Phase.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/MakeArray.hpp"
 #include "Utilities/MakeString.hpp"
 #include "Utilities/StdArrayHelpers.hpp"
 #include "Utilities/TMPL.hpp"
@@ -98,8 +99,9 @@ void test_shape_control(
   SpherepackIterator iter{l_max, l_max};
   const double ah_radius =
       ah_coefs_function_of_time.func(initial_time)[0][iter.set(0, 0)()];
-  const std::array<double, 3>& center = excision_sphere.center();
-  Strahlkorper horizon_a{l_max, l_max, ah_radius, center};
+  const tnsr::I<double, 3, Frame::Grid>& center = excision_sphere.center();
+  Strahlkorper horizon_a{l_max, l_max, ah_radius,
+                         make_array<double, 3>(center)};
   // B just needs to exist. Doesn't have to be valid
   const Strahlkorper horizon_b{};
 

--- a/tests/Unit/Domain/Creators/Test_BinaryCompactObject.cpp
+++ b/tests/Unit/Domain/Creators/Test_BinaryCompactObject.cpp
@@ -240,26 +240,28 @@ void test_connectivity() {
     if (excise_interiorA) {
       expected_excision_spheres.emplace(
           "ObjectAExcisionSphere",
-          ExcisionSphere<3>{inner_radius_objectA,
-                            {{xcoord_objectA, 0.0, 0.0}},
-                            {{0, Direction<3>::lower_zeta()},
-                             {1, Direction<3>::lower_zeta()},
-                             {2, Direction<3>::lower_zeta()},
-                             {3, Direction<3>::lower_zeta()},
-                             {4, Direction<3>::lower_zeta()},
-                             {5, Direction<3>::lower_zeta()}}});
+          ExcisionSphere<3>{
+              inner_radius_objectA,
+              tnsr::I<double, 3, Frame::Grid>{{xcoord_objectA, 0.0, 0.0}},
+              {{0, Direction<3>::lower_zeta()},
+               {1, Direction<3>::lower_zeta()},
+               {2, Direction<3>::lower_zeta()},
+               {3, Direction<3>::lower_zeta()},
+               {4, Direction<3>::lower_zeta()},
+               {5, Direction<3>::lower_zeta()}}});
     }
     if (excise_interiorB) {
       expected_excision_spheres.emplace(
           "ObjectBExcisionSphere",
-          ExcisionSphere<3>{inner_radius_objectB,
-                            {{xcoord_objectB, 0.0, 0.0}},
-                            {{12, Direction<3>::lower_zeta()},
-                             {13, Direction<3>::lower_zeta()},
-                             {14, Direction<3>::lower_zeta()},
-                             {15, Direction<3>::lower_zeta()},
-                             {16, Direction<3>::lower_zeta()},
-                             {17, Direction<3>::lower_zeta()}}});
+          ExcisionSphere<3>{
+              inner_radius_objectB,
+              tnsr::I<double, 3, Frame::Grid>{{xcoord_objectB, 0.0, 0.0}},
+              {{12, Direction<3>::lower_zeta()},
+               {13, Direction<3>::lower_zeta()},
+               {14, Direction<3>::lower_zeta()},
+               {15, Direction<3>::lower_zeta()},
+               {16, Direction<3>::lower_zeta()},
+               {17, Direction<3>::lower_zeta()}}});
     }
     CHECK(domain.excision_spheres() == expected_excision_spheres);
 

--- a/tests/Unit/Domain/Creators/Test_CylindricalBinaryCompactObject.cpp
+++ b/tests/Unit/Domain/Creators/Test_CylindricalBinaryCompactObject.cpp
@@ -291,11 +291,13 @@ void test_connectivity_once(const bool with_sphere_e,
     const auto& excision_sphere_a =
         domain.excision_spheres().at("ObjectAExcisionSphere");
     CHECK(excision_sphere_a.radius() == inner_radius_objectA);
-    CHECK(excision_sphere_a.center() == center_objectA);
     const auto& excision_sphere_b =
         domain.excision_spheres().at("ObjectBExcisionSphere");
     CHECK(excision_sphere_b.radius() == inner_radius_objectB);
-    CHECK(excision_sphere_b.center() == center_objectB);
+    for (size_t i = 0; i < 3; ++i) {
+      CHECK(excision_sphere_a.center().get(i) == center_objectA.at(i));
+      CHECK(excision_sphere_b.center().get(i) == center_objectB.at(i));
+    }
 
     // The Domain has no functions of time above, so make sure
     // that the functions_of_time function returns an empty map.

--- a/tests/Unit/Domain/Creators/Test_Shell.cpp
+++ b/tests/Unit/Domain/Creators/Test_Shell.cpp
@@ -347,7 +347,7 @@ void test_shell_construction(
           std::unordered_map<std::string, ExcisionSphere<3>>{
               {"CentralExcisionSphere",
                ExcisionSphere<3>{inner_radius,
-                                 {{0.0, 0.0, 0.0}},
+                                 tnsr::I<double, 3, Frame::Grid>{0.},
                                  {{0, Direction<3>::lower_zeta()},
                                   {1, Direction<3>::lower_zeta()},
                                   {2, Direction<3>::lower_zeta()},

--- a/tests/Unit/Domain/Structure/Test_ExcisionSphere.cpp
+++ b/tests/Unit/Domain/Structure/Test_ExcisionSphere.cpp
@@ -6,6 +6,7 @@
 #include <cstddef>
 #include <functional>
 
+#include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/Structure/Direction.hpp"
 #include "Domain/Structure/ExcisionSphere.hpp"
 #include "Framework/TestHelpers.hpp"
@@ -15,7 +16,7 @@
 namespace {
 template <size_t VolumeDim>
 void check_excision_sphere_work(
-    const double radius, const std::array<double, VolumeDim> center,
+    const double radius, const tnsr::I<double, VolumeDim, Frame::Grid> center,
     const std::unordered_map<size_t, Direction<VolumeDim>>&
         abutting_directions) {
   const ExcisionSphere<VolumeDim> excision_sphere(radius, center,
@@ -49,7 +50,7 @@ void check_excision_sphere_work(
 
 void check_excision_sphere_1d() {
   const double radius = 1.2;
-  const std::array<double, 1> center = {{5.4}};
+  const tnsr::I<double, 1, Frame::Grid> center{{5.4}};
   check_excision_sphere_work<1>(
       radius, center,
       {{0, Direction<1>::lower_xi()}, {2, Direction<1>::upper_xi()}});
@@ -57,7 +58,7 @@ void check_excision_sphere_1d() {
 
 void check_excision_sphere_2d() {
   const double radius = 4.2;
-  const std::array<double, 2> center = {{5.4, -2.3}};
+  const tnsr::I<double, 2, Frame::Grid> center{{5.4, -2.3}};
   check_excision_sphere_work<2>(
       radius, center,
       {{0, Direction<2>::lower_eta()}, {2, Direction<2>::upper_xi()}});
@@ -65,7 +66,7 @@ void check_excision_sphere_2d() {
 
 void check_excision_sphere_3d() {
   const double radius = 5.2;
-  const std::array<double, 3> center = {{5.4, -2.3, 9.0}};
+  const tnsr::I<double, 3, Frame::Grid> center{{5.4, -2.3, 9.0}};
   check_excision_sphere_work<3>(
       radius, center,
       {{0, Direction<3>::lower_xi()}, {2, Direction<3>::upper_zeta()}});
@@ -84,7 +85,8 @@ SPECTRE_TEST_CASE("Unit.Domain.Structure.ExcisionSphere", "[Domain][Unit]") {
                                "[Domain][Unit]") {
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
-  auto failed_excision_sphere = ExcisionSphere<3>(-2.0, {{3.4, 1.2, -0.9}}, {});
+  auto failed_excision_sphere = ExcisionSphere<3>(
+      -2.0, tnsr::I<double, 3, Frame::Grid>{{3.4, 1.2, -0.9}}, {});
   static_cast<void>(failed_excision_sphere);
   ERROR("Failed to trigger ASSERT in an assertion test");
 #endif

--- a/tests/Unit/Helpers/ControlSystem/SystemHelpers.hpp
+++ b/tests/Unit/Helpers/ControlSystem/SystemHelpers.hpp
@@ -118,7 +118,7 @@ class FakeCreator : public DomainCreator<3> {
       excision_spheres.insert(
           {"ObjectAExcisionSphere",
            ExcisionSphere<3>{1.3,
-                             {{+0.9, 0.0, 0.0}},
+                             tnsr::I<double, 3, Frame::Grid>{{+0.9, 0.0, 0.0}},
                              {{0, Direction<3>::lower_zeta()},
                               {1, Direction<3>::lower_zeta()},
                               {2, Direction<3>::lower_zeta()},
@@ -130,7 +130,7 @@ class FakeCreator : public DomainCreator<3> {
       excision_spheres.insert(
           {"ObjectBExcisionSphere",
            ExcisionSphere<3>{0.8,
-                             {{-1.1, 0.0, 0.0}},
+                             tnsr::I<double, 3, Frame::Grid>{{-1.1, 0.0, 0.0}},
                              {{0, Direction<3>::lower_zeta()},
                               {1, Direction<3>::lower_zeta()},
                               {2, Direction<3>::lower_zeta()},
@@ -599,7 +599,8 @@ struct SystemHelper {
         std::unordered_map<std::string, ExcisionSphere<3>>{
             {"ObjectAExcisionSphere",
              ExcisionSphere<3>{excision_radius,
-                               {{+0.5 * initial_separation, 0.0, 0.0}},
+                               tnsr::I<double, 3, Frame::Grid>{
+                                   {+0.5 * initial_separation, 0.0, 0.0}},
                                {{0, Direction<3>::lower_zeta()},
                                 {1, Direction<3>::lower_zeta()},
                                 {2, Direction<3>::lower_zeta()},
@@ -608,7 +609,8 @@ struct SystemHelper {
                                 {5, Direction<3>::lower_zeta()}}}},
             {"ObjectBExcisionSphere",
              ExcisionSphere<3>{excision_radius,
-                               {{-0.5 * initial_separation, 0.0, 0.0}},
+                               tnsr::I<double, 3, Frame::Grid>{
+                                   {-0.5 * initial_separation, 0.0, 0.0}},
                                {{0, Direction<3>::lower_zeta()},
                                 {1, Direction<3>::lower_zeta()},
                                 {2, Direction<3>::lower_zeta()},


### PR DESCRIPTION
The original return type was `std::array<double, 3>` but that makes it ambiguous in which coordinates the center is given.