### PR TITLE
Add tags related to electric current density terms in ForceFree system

### DIFF
--- a/src/Evolution/Systems/ForceFree/Tags.hpp
+++ b/src/Evolution/Systems/ForceFree/Tags.hpp
@@ -41,13 +41,6 @@ struct ChargeDensity : db::SimpleTag {
 };
 
 /*!
- * \brief The spatial electric current density \f$J^i\f$.
- */
-struct SpatialCurrentDensity : db::SimpleTag {
-  using type = tnsr::I<DataVector, 3>;
-};
-
-/*!
  * \brief The divergence cleaning scalar field \f$\psi\f$ coupled to the
  * electric field.
  */
@@ -99,6 +92,27 @@ struct TildePhi : db::SimpleTag {
  */
 struct TildeQ : db::SimpleTag {
   using type = Scalar<DataVector>;
+};
+
+/*!
+ * \brief The spatial electric current density \f$J^i\f$.
+ */
+struct CurrentDensity : db::SimpleTag {
+  using type = tnsr::I<DataVector, 3>;
+};
+
+/*!
+ * \brief The non-stff (i.e. drift current) part of \f$\tilde{J}^i\f$.
+ */
+struct DriftTildeJ : db::SimpleTag {
+  using type = tnsr::I<DataVector, 3>;
+};
+
+/*!
+ * \brief The stiff (i.e. parallel current) part of \f$\tilde{J}^i\f$.
+ */
+struct ParallelTildeJ : db::SimpleTag {
+  using type = tnsr::I<DataVector, 3>;
 };
 
 /*!
@@ -211,6 +225,21 @@ struct KappaPhi : db::SimpleTag {
     return kappa_phi;
   }
 };
+
+/*!
+ * \brief The damping parameter \f$\eta\f$ in the electric current density to
+ * impose force-free conditions. Physically, this parameter is the conductivity
+ * parallel to magnetic field lines.
+ */
+struct ParallelConductivity : db::SimpleTag {
+  using type = double;
+  using option_tags = tmpl::list<OptionTags::ParallelConductivity>;
+  static constexpr bool pass_metavariables = false;
+  static double create_from_options(const double parallel_conductivity) {
+    return parallel_conductivity;
+  }
+};
+
 }  // namespace Tags
 
 }  // namespace ForceFree

--- a/tests/Unit/Evolution/Systems/ForceFree/Test_Tags.cpp
+++ b/tests/Unit/Evolution/Systems/ForceFree/Test_Tags.cpp
@@ -29,9 +29,14 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.ForceFree.Tags",
   TestHelpers::db::test_simple_tag<ForceFree::Tags::TildePhi>("TildePhi");
   TestHelpers::db::test_simple_tag<ForceFree::Tags::TildeQ>("TildeQ");
 
+  // Tags related to electric current density
+  TestHelpers::db::test_simple_tag<ForceFree::Tags::CurrentDensity>(
+      "CurrentDensity");
+  TestHelpers::db::test_simple_tag<ForceFree::Tags::DriftTildeJ>("DriftTildeJ");
+  TestHelpers::db::test_simple_tag<ForceFree::Tags::ParallelTildeJ>(
+      "ParallelTildeJ");
+
   // etc.
-  TestHelpers::db::test_simple_tag<ForceFree::Tags::SpatialCurrentDensity>(
-      "SpatialCurrentDensity");
   TestHelpers::db::test_simple_tag<ForceFree::Tags::KappaPsi>("KappaPsi");
   TestHelpers::db::test_simple_tag<ForceFree::Tags::KappaPhi>("KappaPhi");
 }


### PR DESCRIPTION
- rename SpatialCurrentDensity to CurrentDensity
- Add two separate tags for TildeJ (J times lapse time sqrt det spatial metric) term. One is explicit and the other is implicit part.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
