### PR TITLE
Separate stiff and non-stiff terms for fluxes in ForceFree system.

### DIFF
--- a/src/Evolution/Systems/ForceFree/Fluxes.cpp
+++ b/src/Evolution/Systems/ForceFree/Fluxes.cpp
@@ -37,10 +37,10 @@ void fluxes_impl(
     const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_b,
     const Scalar<DataVector>& tilde_psi, const Scalar<DataVector>& tilde_phi,
     const Scalar<DataVector>& tilde_q,
-    const tnsr::I<DataVector, 3, Frame::Inertial>& spatial_current_density,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& drift_tilde_j,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& parallel_tilde_j,
     const Scalar<DataVector>& lapse,
     const tnsr::I<DataVector, 3, Frame::Inertial>& shift,
-    const Scalar<DataVector>& sqrt_det_spatial_metric,
     const tnsr::II<DataVector, 3, Frame::Inertial>& inv_spatial_metric) {
   for (size_t j = 0; j < 3; ++j) {
     tilde_psi_flux->get(j) =
@@ -49,8 +49,7 @@ void fluxes_impl(
     tilde_phi_flux->get(j) =
         -shift.get(j) * get(tilde_phi) + get(lapse) * tilde_b.get(j);
 
-    tilde_q_flux->get(j) = get(lapse) * get(sqrt_det_spatial_metric) *
-                               spatial_current_density.get(j) -
+    tilde_q_flux->get(j) = drift_tilde_j.get(j) + parallel_tilde_j.get(j) -
                            shift.get(j) * get(tilde_q);
 
     for (size_t i = 0; i < 3; ++i) {
@@ -89,7 +88,8 @@ void Fluxes::apply(
     const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_b,
     const Scalar<DataVector>& tilde_psi, const Scalar<DataVector>& tilde_phi,
     const Scalar<DataVector>& tilde_q,
-    const tnsr::I<DataVector, 3, Frame::Inertial>& spatial_current_density,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& drift_tilde_j,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& parallel_tilde_j,
     const Scalar<DataVector>& lapse,
     const tnsr::I<DataVector, 3, Frame::Inertial>& shift,
     const Scalar<DataVector>& sqrt_det_spatial_metric,
@@ -121,8 +121,8 @@ void Fluxes::apply(
       // temporaries
       lapse_times_electric_field_one_form, lapse_times_magnetic_field_one_form,
       // extra args
-      tilde_e, tilde_b, tilde_psi, tilde_phi, tilde_q, spatial_current_density,
-      lapse, shift, sqrt_det_spatial_metric, inv_spatial_metric);
+      tilde_e, tilde_b, tilde_psi, tilde_phi, tilde_q, drift_tilde_j,
+      parallel_tilde_j, lapse, shift, inv_spatial_metric);
 }
 
 }  // namespace ForceFree

--- a/src/Evolution/Systems/ForceFree/Fluxes.hpp
+++ b/src/Evolution/Systems/ForceFree/Fluxes.hpp
@@ -38,10 +38,10 @@ void fluxes_impl(
     const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_b,
     const Scalar<DataVector>& tilde_psi, const Scalar<DataVector>& tilde_phi,
     const Scalar<DataVector>& tilde_q,
-    const tnsr::I<DataVector, 3, Frame::Inertial>& spatial_current_density,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& drift_tilde_j,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& parallel_tilde_j,
     const Scalar<DataVector>& lapse,
     const tnsr::I<DataVector, 3, Frame::Inertial>& shift,
-    const Scalar<DataVector>& sqrt_det_spatial_metric,
     const tnsr::II<DataVector, 3, Frame::Inertial>& inv_spatial_metric);
 }  // namespace detail
 
@@ -55,13 +55,14 @@ void fluxes_impl(
  *      + \epsilon^{ijk}_{(3)}\tilde{E}_k) \\
  *  F^j(\tilde{\psi}) & = -\beta^j \tilde{\psi} + \alpha \tilde{E}^j \\
  *  F^j(\tilde{\phi}) & = -\beta^j \tilde{\phi} + \alpha \tilde{B}^j \\
- *  F^j(\tilde{q}) & = \alpha \sqrt{\gamma}J^j - \beta^j \tilde{q}
+ *  F^j(\tilde{q}) & = \tilde{J}^j - \beta^j \tilde{q}
  * \f}
  *
  * where the conserved variables \f$\tilde{E}^i, \tilde{B}^i, \tilde{\psi},
  * \tilde{\phi}, \tilde{q}\f$ are densitized electric field, magnetic field,
  * electric divergence cleaning field, magnetic divergence cleaning field, and
- * electric charge density. \f$J^i\f$ is the spatial electric current density.
+ * electric charge density. \f$\tilde{J}^i = \alpha\sqrt{\gamma}J^i\f$ is the
+ * generalized spatial electric current density.
  *
  * \f$\epsilon_{(3)}^{ijk}\f$ is the spatial Levi-Civita tensor defined as
  *
@@ -94,9 +95,10 @@ struct Fluxes {
 
   using argument_tags =
       tmpl::list<Tags::TildeE, Tags::TildeB, Tags::TildePsi, Tags::TildePhi,
-                 Tags::TildeQ, Tags::SpatialCurrentDensity, gr::Tags::Lapse<>,
-                 gr::Tags::Shift<3>, gr::Tags::SqrtDetSpatialMetric<>,
-                 gr::Tags::SpatialMetric<3>, gr::Tags::InverseSpatialMetric<3>>;
+                 Tags::TildeQ, Tags::DriftTildeJ, Tags::ParallelTildeJ,
+                 gr::Tags::Lapse<>, gr::Tags::Shift<3>,
+                 gr::Tags::SqrtDetSpatialMetric<>, gr::Tags::SpatialMetric<3>,
+                 gr::Tags::InverseSpatialMetric<3>>;
 
   static void apply(
       gsl::not_null<tnsr::IJ<DataVector, 3, Frame::Inertial>*> tilde_e_flux,
@@ -108,7 +110,8 @@ struct Fluxes {
       const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_b,
       const Scalar<DataVector>& tilde_psi, const Scalar<DataVector>& tilde_phi,
       const Scalar<DataVector>& tilde_q,
-      const tnsr::I<DataVector, 3, Frame::Inertial>& spatial_current_density,
+      const tnsr::I<DataVector, 3, Frame::Inertial>& drift_tilde_j,
+      const tnsr::I<DataVector, 3, Frame::Inertial>& parallel_tilde_j,
       const Scalar<DataVector>& lapse,
       const tnsr::I<DataVector, 3, Frame::Inertial>& shift,
       const Scalar<DataVector>& sqrt_det_spatial_metric,

--- a/src/Evolution/Systems/ForceFree/Tags.hpp
+++ b/src/Evolution/Systems/ForceFree/Tags.hpp
@@ -41,13 +41,6 @@ struct ChargeDensity : db::SimpleTag {
 };
 
 /*!
- * \brief The spatial electric current density \f$J^i\f$.
- */
-struct SpatialCurrentDensity : db::SimpleTag {
-  using type = tnsr::I<DataVector, 3>;
-};
-
-/*!
  * \brief The divergence cleaning scalar field \f$\psi\f$ coupled to the
  * electric field.
  */
@@ -99,6 +92,27 @@ struct TildePhi : db::SimpleTag {
  */
 struct TildeQ : db::SimpleTag {
   using type = Scalar<DataVector>;
+};
+
+/*!
+ * \brief The spatial electric current density \f$J^i\f$.
+ */
+struct CurrentDensity : db::SimpleTag {
+  using type = tnsr::I<DataVector, 3>;
+};
+
+/*!
+ * \brief The non-stff (i.e. drift current) part of \f$\tilde{J}^i\f$.
+ */
+struct DriftTildeJ : db::SimpleTag {
+  using type = tnsr::I<DataVector, 3>;
+};
+
+/*!
+ * \brief The stiff (i.e. parallel current) part of \f$\tilde{J}^i\f$.
+ */
+struct ParallelTildeJ : db::SimpleTag {
+  using type = tnsr::I<DataVector, 3>;
 };
 
 /*!
@@ -211,6 +225,21 @@ struct KappaPhi : db::SimpleTag {
     return kappa_phi;
   }
 };
+
+/*!
+ * \brief The damping parameter \f$\eta\f$ in the electric current density to
+ * impose force-free conditions. Physically, this parameter is the conductivity
+ * parallel to magnetic field lines.
+ */
+struct ParallelConductivity : db::SimpleTag {
+  using type = double;
+  using option_tags = tmpl::list<OptionTags::ParallelConductivity>;
+  static constexpr bool pass_metavariables = false;
+  static double create_from_options(const double parallel_conductivity) {
+    return parallel_conductivity;
+  }
+};
+
 }  // namespace Tags
 
 }  // namespace ForceFree

--- a/tests/Unit/Evolution/Systems/ForceFree/Fluxes.py
+++ b/tests/Unit/Evolution/Systems/ForceFree/Fluxes.py
@@ -9,8 +9,8 @@ def levi_civita_symbol(i, j, k):
 
 
 def tilde_e_flux(tilde_e, tilde_b, tilde_psi, tilde_phi, tilde_q,
-                 current_density, lapse, shift, sqrt_det_spatial_metric,
-                 spatial_metric, inv_spatial_metric):
+                 drift_tilde_j, parallel_tilde_j, lapse, shift,
+                 sqrt_det_spatial_metric, spatial_metric, inv_spatial_metric):
     magnetic_field_one_form = np.einsum(
         "a, ia", tilde_b, spatial_metric) / sqrt_det_spatial_metric
 
@@ -27,8 +27,8 @@ def tilde_e_flux(tilde_e, tilde_b, tilde_psi, tilde_phi, tilde_q,
 
 
 def tilde_b_flux(tilde_e, tilde_b, tilde_psi, tilde_phi, tilde_q,
-                 current_density, lapse, shift, sqrt_det_spatial_metric,
-                 spatial_metric, inv_spatial_metric):
+                 drift_tilde_j, parallel_tilde_j, lapse, shift,
+                 sqrt_det_spatial_metric, spatial_metric, inv_spatial_metric):
     electric_field_one_form = np.einsum(
         "a, ia", tilde_e, spatial_metric) / sqrt_det_spatial_metric
 
@@ -45,19 +45,20 @@ def tilde_b_flux(tilde_e, tilde_b, tilde_psi, tilde_phi, tilde_q,
 
 
 def tilde_psi_flux(tilde_e, tilde_b, tilde_psi, tilde_phi, tilde_q,
-                   current_density, lapse, shift, sqrt_det_spatial_metric,
-                   spatial_metric, inv_spatial_metric):
+                   drift_tilde_j, parallel_tilde_j, lapse, shift,
+                   sqrt_det_spatial_metric, spatial_metric,
+                   inv_spatial_metric):
     return -shift * tilde_psi + lapse * tilde_e
 
 
 def tilde_phi_flux(tilde_e, tilde_b, tilde_psi, tilde_phi, tilde_q,
-                   current_density, lapse, shift, sqrt_det_spatial_metric,
-                   spatial_metric, inv_spatial_metric):
+                   drift_tilde_j, parallel_tilde_j, lapse, shift,
+                   sqrt_det_spatial_metric, spatial_metric,
+                   inv_spatial_metric):
     return -shift * tilde_phi + lapse * tilde_b
 
 
 def tilde_q_flux(tilde_e, tilde_b, tilde_psi, tilde_phi, tilde_q,
-                 current_density, lapse, shift, sqrt_det_spatial_metric,
-                 spatial_metric, inv_spatial_metric):
-    return (lapse * sqrt_det_spatial_metric * current_density -
-            shift * tilde_q)
+                 drift_tilde_j, parallel_tilde_j, lapse, shift,
+                 sqrt_det_spatial_metric, spatial_metric, inv_spatial_metric):
+    return (drift_tilde_j + parallel_tilde_j - shift * tilde_q)

--- a/tests/Unit/Evolution/Systems/ForceFree/Test_Tags.cpp
+++ b/tests/Unit/Evolution/Systems/ForceFree/Test_Tags.cpp
@@ -29,9 +29,14 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.ForceFree.Tags",
   TestHelpers::db::test_simple_tag<ForceFree::Tags::TildePhi>("TildePhi");
   TestHelpers::db::test_simple_tag<ForceFree::Tags::TildeQ>("TildeQ");
 
+  // Tags related to electric current density
+  TestHelpers::db::test_simple_tag<ForceFree::Tags::CurrentDensity>(
+      "CurrentDensity");
+  TestHelpers::db::test_simple_tag<ForceFree::Tags::DriftTildeJ>("DriftTildeJ");
+  TestHelpers::db::test_simple_tag<ForceFree::Tags::ParallelTildeJ>(
+      "ParallelTildeJ");
+
   // etc.
-  TestHelpers::db::test_simple_tag<ForceFree::Tags::SpatialCurrentDensity>(
-      "SpatialCurrentDensity");
   TestHelpers::db::test_simple_tag<ForceFree::Tags::KappaPsi>("KappaPsi");
   TestHelpers::db::test_simple_tag<ForceFree::Tags::KappaPhi>("KappaPhi");
 }


### PR DESCRIPTION
## Proposed changes

Add two separate tags for TildeJ (J times lapse time sqrt det spatial metric) term. One is explicit and the other is implicit part.

Instead of using a single tag for electric current density J, take drift (non-stiff) and parallel (stiff) components of J as separate arguments for evaluating fluxes.

First commit is from
- [ ] #4668.


### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
