### PR TITLE
Split electric current density to stiff and non-stiff parts and update Fluxes and Sources in ForceFree system.

### DIFF
--- a/src/Evolution/Systems/ForceFree/Fluxes.cpp
+++ b/src/Evolution/Systems/ForceFree/Fluxes.cpp
@@ -37,10 +37,10 @@ void fluxes_impl(
     const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_b,
     const Scalar<DataVector>& tilde_psi, const Scalar<DataVector>& tilde_phi,
     const Scalar<DataVector>& tilde_q,
-    const tnsr::I<DataVector, 3, Frame::Inertial>& spatial_current_density,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& drift_tilde_j,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& parallel_tilde_j,
     const Scalar<DataVector>& lapse,
     const tnsr::I<DataVector, 3, Frame::Inertial>& shift,
-    const Scalar<DataVector>& sqrt_det_spatial_metric,
     const tnsr::II<DataVector, 3, Frame::Inertial>& inv_spatial_metric) {
   for (size_t j = 0; j < 3; ++j) {
     tilde_psi_flux->get(j) =
@@ -49,8 +49,7 @@ void fluxes_impl(
     tilde_phi_flux->get(j) =
         -shift.get(j) * get(tilde_phi) + get(lapse) * tilde_b.get(j);
 
-    tilde_q_flux->get(j) = get(lapse) * get(sqrt_det_spatial_metric) *
-                               spatial_current_density.get(j) -
+    tilde_q_flux->get(j) = drift_tilde_j.get(j) + parallel_tilde_j.get(j) -
                            shift.get(j) * get(tilde_q);
 
     for (size_t i = 0; i < 3; ++i) {
@@ -89,7 +88,8 @@ void Fluxes::apply(
     const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_b,
     const Scalar<DataVector>& tilde_psi, const Scalar<DataVector>& tilde_phi,
     const Scalar<DataVector>& tilde_q,
-    const tnsr::I<DataVector, 3, Frame::Inertial>& spatial_current_density,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& drift_tilde_j,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& parallel_tilde_j,
     const Scalar<DataVector>& lapse,
     const tnsr::I<DataVector, 3, Frame::Inertial>& shift,
     const Scalar<DataVector>& sqrt_det_spatial_metric,
@@ -121,8 +121,8 @@ void Fluxes::apply(
       // temporaries
       lapse_times_electric_field_one_form, lapse_times_magnetic_field_one_form,
       // extra args
-      tilde_e, tilde_b, tilde_psi, tilde_phi, tilde_q, spatial_current_density,
-      lapse, shift, sqrt_det_spatial_metric, inv_spatial_metric);
+      tilde_e, tilde_b, tilde_psi, tilde_phi, tilde_q, drift_tilde_j,
+      parallel_tilde_j, lapse, shift, inv_spatial_metric);
 }
 
 }  // namespace ForceFree

--- a/src/Evolution/Systems/ForceFree/Fluxes.hpp
+++ b/src/Evolution/Systems/ForceFree/Fluxes.hpp
@@ -38,10 +38,10 @@ void fluxes_impl(
     const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_b,
     const Scalar<DataVector>& tilde_psi, const Scalar<DataVector>& tilde_phi,
     const Scalar<DataVector>& tilde_q,
-    const tnsr::I<DataVector, 3, Frame::Inertial>& spatial_current_density,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& drift_tilde_j,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& parallel_tilde_j,
     const Scalar<DataVector>& lapse,
     const tnsr::I<DataVector, 3, Frame::Inertial>& shift,
-    const Scalar<DataVector>& sqrt_det_spatial_metric,
     const tnsr::II<DataVector, 3, Frame::Inertial>& inv_spatial_metric);
 }  // namespace detail
 
@@ -55,13 +55,14 @@ void fluxes_impl(
  *      + \epsilon^{ijk}_{(3)}\tilde{E}_k) \\
  *  F^j(\tilde{\psi}) & = -\beta^j \tilde{\psi} + \alpha \tilde{E}^j \\
  *  F^j(\tilde{\phi}) & = -\beta^j \tilde{\phi} + \alpha \tilde{B}^j \\
- *  F^j(\tilde{q}) & = \alpha \sqrt{\gamma}J^j - \beta^j \tilde{q}
+ *  F^j(\tilde{q}) & = \tilde{J}^j - \beta^j \tilde{q}
  * \f}
  *
  * where the conserved variables \f$\tilde{E}^i, \tilde{B}^i, \tilde{\psi},
  * \tilde{\phi}, \tilde{q}\f$ are densitized electric field, magnetic field,
  * electric divergence cleaning field, magnetic divergence cleaning field, and
- * electric charge density. \f$J^i\f$ is the spatial electric current density.
+ * electric charge density. \f$\tilde{J}^i = \alpha\sqrt{\gamma}J^i\f$ is the
+ * generalized spatial electric current density.
  *
  * \f$\epsilon_{(3)}^{ijk}\f$ is the spatial Levi-Civita tensor defined as
  *
@@ -94,9 +95,10 @@ struct Fluxes {
 
   using argument_tags =
       tmpl::list<Tags::TildeE, Tags::TildeB, Tags::TildePsi, Tags::TildePhi,
-                 Tags::TildeQ, Tags::SpatialCurrentDensity, gr::Tags::Lapse<>,
-                 gr::Tags::Shift<3>, gr::Tags::SqrtDetSpatialMetric<>,
-                 gr::Tags::SpatialMetric<3>, gr::Tags::InverseSpatialMetric<3>>;
+                 Tags::TildeQ, Tags::DriftTildeJ, Tags::ParallelTildeJ,
+                 gr::Tags::Lapse<>, gr::Tags::Shift<3>,
+                 gr::Tags::SqrtDetSpatialMetric<>, gr::Tags::SpatialMetric<3>,
+                 gr::Tags::InverseSpatialMetric<3>>;
 
   static void apply(
       gsl::not_null<tnsr::IJ<DataVector, 3, Frame::Inertial>*> tilde_e_flux,
@@ -108,7 +110,8 @@ struct Fluxes {
       const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_b,
       const Scalar<DataVector>& tilde_psi, const Scalar<DataVector>& tilde_phi,
       const Scalar<DataVector>& tilde_q,
-      const tnsr::I<DataVector, 3, Frame::Inertial>& spatial_current_density,
+      const tnsr::I<DataVector, 3, Frame::Inertial>& drift_tilde_j,
+      const tnsr::I<DataVector, 3, Frame::Inertial>& parallel_tilde_j,
       const Scalar<DataVector>& lapse,
       const tnsr::I<DataVector, 3, Frame::Inertial>& shift,
       const Scalar<DataVector>& sqrt_det_spatial_metric,

--- a/src/Evolution/Systems/ForceFree/Sources.cpp
+++ b/src/Evolution/Systems/ForceFree/Sources.cpp
@@ -32,14 +32,14 @@ void sources_impl(
     const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_b,
     const Scalar<DataVector>& tilde_psi, const Scalar<DataVector>& tilde_phi,
     const Scalar<DataVector>& tilde_q,
-    const tnsr::I<DataVector, 3, Frame::Inertial>& spatial_current_density,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& drift_tilde_j,
     const double kappa_psi, const double kappa_phi,
+
     // GR args
     const Scalar<DataVector>& lapse,
     const tnsr::i<DataVector, 3, Frame::Inertial>& d_lapse,
     const tnsr::iJ<DataVector, 3, Frame::Inertial>& d_shift,
     const tnsr::II<DataVector, 3, Frame::Inertial>& inv_spatial_metric,
-    const Scalar<DataVector>& sqrt_det_spatial_metric,
     const tnsr::ii<DataVector, 3, Frame::Inertial>& extrinsic_curvature) {
   // S(\tilde{E}^i)
   raise_or_lower_index(source_tilde_e, d_lapse, inv_spatial_metric);
@@ -47,8 +47,7 @@ void sources_impl(
     source_tilde_e->get(i) -=
         get(lapse) * trace_spatial_christoffel_second.get(i);
     source_tilde_e->get(i) *= get(tilde_psi);
-    source_tilde_e->get(i) -= get(lapse) * get(sqrt_det_spatial_metric) *
-                              spatial_current_density.get(i);
+    source_tilde_e->get(i) -= drift_tilde_j.get(i);
     for (size_t m = 0; m < 3; ++m) {
       source_tilde_e->get(i) -= tilde_e.get(m) * d_shift.get(m, i);
     }
@@ -97,7 +96,7 @@ void Sources::apply(
     const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_b,
     const Scalar<DataVector>& tilde_psi, const Scalar<DataVector>& tilde_phi,
     const Scalar<DataVector>& tilde_q,
-    const tnsr::I<DataVector, 3, Frame::Inertial>& spatial_current_density,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& drift_tilde_j,
     const double kappa_psi, const double kappa_phi,
     // GR variables
     const Scalar<DataVector>& lapse,
@@ -105,7 +104,6 @@ void Sources::apply(
     const tnsr::iJ<DataVector, 3, Frame::Inertial>& d_shift,
     const tnsr::ijj<DataVector, 3, Frame::Inertial>& d_spatial_metric,
     const tnsr::II<DataVector, 3, Frame::Inertial>& inv_spatial_metric,
-    const Scalar<DataVector>& sqrt_det_spatial_metric,
     const tnsr::ii<DataVector, 3, Frame::Inertial>& extrinsic_curvature) {
   // temp variable to store metric derivative quantities
   Variables<tmpl::list<
@@ -137,9 +135,8 @@ void Sources::apply(
   detail::sources_impl(source_tilde_e, source_tilde_b, source_tilde_psi,
                        source_tilde_phi, trace_spatial_christoffel_second,
                        tilde_e, tilde_b, tilde_psi, tilde_phi, tilde_q,
-                       spatial_current_density, kappa_psi, kappa_phi, lapse,
-                       d_lapse, d_shift, inv_spatial_metric,
-                       sqrt_det_spatial_metric, extrinsic_curvature);
+                       drift_tilde_j, kappa_psi, kappa_phi, lapse, d_lapse,
+                       d_shift, inv_spatial_metric, extrinsic_curvature);
 }
 
 }  // namespace ForceFree

--- a/src/Evolution/Systems/ForceFree/Sources.hpp
+++ b/src/Evolution/Systems/ForceFree/Sources.hpp
@@ -32,14 +32,14 @@ void sources_impl(
     const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_b,
     const Scalar<DataVector>& tilde_psi, const Scalar<DataVector>& tilde_phi,
     const Scalar<DataVector>& tilde_q,
-    const tnsr::I<DataVector, 3, Frame::Inertial>& spatial_current_density,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& drift_tilde_j,
     const double kappa_psi, const double kappa_phi,
+
     // GR args
     const Scalar<DataVector>& lapse,
     const tnsr::i<DataVector, 3, Frame::Inertial>& d_lapse,
     const tnsr::iJ<DataVector, 3, Frame::Inertial>& d_shift,
     const tnsr::II<DataVector, 3, Frame::Inertial>& inv_spatial_metric,
-    const Scalar<DataVector>& sqrt_det_spatial_metric,
     const tnsr::ii<DataVector, 3, Frame::Inertial>& extrinsic_curvature);
 }  // namespace detail
 
@@ -48,9 +48,9 @@ void sources_impl(
  * cleaning.
  *
  * \f{align*}
- *  S(\tilde{E}^i) &= -\alpha \sqrt{\gamma} J^i - \tilde{E}^j \partial_j \beta^i
- *    + \tilde{\psi} ( \gamma^{ij} \partial_j \alpha - \alpha \gamma^{jk}
- *    \Gamma^i_{jk} ) \\
+ *  S(\tilde{E}^i) &= - \tilde{J}^i_\mathrm{drift} - \tilde{E}^j \partial_j
+ *    \beta^i + \tilde{\psi} ( \gamma^{ij} \partial_j \alpha - \alpha
+ *    \gamma^{jk} \Gamma^i_{jk} ) \\
  *  S(\tilde{B}^i) &= -\tilde{B}^j \partial_j \beta^i + \tilde{\phi} (
  *    \gamma^{ij} \partial_j \alpha - \alpha \gamma^{jk} \Gamma^i_{jk} ) \\
  *  S(\tilde{\psi}) &= \tilde{E}^k \partial_k \alpha + \alpha \tilde{q} - \alpha
@@ -65,12 +65,17 @@ void sources_impl(
  * magnetic divergence cleaning field, electric divergence cleaning field, and
  * electric charge density.
  *
- * \f$J^i\f$ is the spatial electric current density, \f$\alpha\f$ is the lapse,
- * \f$\beta^i\f$ is the shift, \f$\gamma^{ij}\f$ is the spatial metric,
- * \f$\gamma\f$ is the determinant of spatial metric, \f$\Gamma^i_{jk}\f$ is the
- * spatial Christoffel symbol, \f$K\f$ is the trace of extrinsic curvature.
- * \f$\kappa_\phi\f$ and \f$\kappa_\psi\f$ are damping parameters associated
- * with divergence cleaning of magnetic and electric fields, respectively.
+ * \f$\alpha\f$ is the lapse, \f$\beta^i\f$ is the shift, \f$\gamma^{ij}\f$ is
+ * the spatial metric, \f$\gamma\f$ is the determinant of spatial metric,
+ * \f$\Gamma^i_{jk}\f$ is the spatial Christoffel symbol, \f$K\f$ is the trace
+ * of extrinsic curvature. \f$\kappa_\phi\f$ and \f$\kappa_\psi\f$ are damping
+ * parameters associated with divergence cleaning of magnetic and electric
+ * fields, respectively.
+ *
+ * \note We only include \f$\tilde{J}^i_\mathrm{drift}\f$ component of the
+ * current density here for \f$S(\tilde{E}^i)\f$. The remaining contribution,
+ * \f$-\tilde{J}^i_\mathrm{parallel}\f$, is stiff and evaluated separately
+ * within the IMEX framework.
  *
  */
 struct Sources {
@@ -82,7 +87,7 @@ struct Sources {
   using argument_tags = tmpl::list<
       // EM variables
       Tags::TildeE, Tags::TildeB, Tags::TildePsi, Tags::TildePhi, Tags::TildeQ,
-      Tags::SpatialCurrentDensity, Tags::KappaPsi, Tags::KappaPhi,
+      Tags::DriftTildeJ, Tags::KappaPsi, Tags::KappaPhi,
       // GR variables
       gr::Tags::Lapse<>,
       ::Tags::deriv<gr::Tags::Lapse<DataVector>, tmpl::size_t<3>,
@@ -91,7 +96,7 @@ struct Sources {
                     tmpl::size_t<3>, Frame::Inertial>,
       ::Tags::deriv<gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>,
                     tmpl::size_t<3>, Frame::Inertial>,
-      gr::Tags::InverseSpatialMetric<3>, gr::Tags::SqrtDetSpatialMetric<>,
+      gr::Tags::InverseSpatialMetric<3>,
       gr::Tags::ExtrinsicCurvature<3, Frame::Inertial, DataVector>>;
 
   static void apply(
@@ -104,7 +109,7 @@ struct Sources {
       const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_b,
       const Scalar<DataVector>& tilde_psi, const Scalar<DataVector>& tilde_phi,
       const Scalar<DataVector>& tilde_q,
-      const tnsr::I<DataVector, 3, Frame::Inertial>& spatial_current_density,
+      const tnsr::I<DataVector, 3, Frame::Inertial>& drift_tilde_j,
       const double kappa_psi, const double kappa_phi,
       // GR variables
       const Scalar<DataVector>& lapse,
@@ -112,7 +117,6 @@ struct Sources {
       const tnsr::iJ<DataVector, 3, Frame::Inertial>& d_shift,
       const tnsr::ijj<DataVector, 3, Frame::Inertial>& d_spatial_metric,
       const tnsr::II<DataVector, 3, Frame::Inertial>& inv_spatial_metric,
-      const Scalar<DataVector>& sqrt_det_spatial_metric,
       const tnsr::ii<DataVector, 3, Frame::Inertial>& extrinsic_curvature);
 };
 

--- a/src/Evolution/Systems/ForceFree/Tags.hpp
+++ b/src/Evolution/Systems/ForceFree/Tags.hpp
@@ -41,13 +41,6 @@ struct ChargeDensity : db::SimpleTag {
 };
 
 /*!
- * \brief The spatial electric current density \f$J^i\f$.
- */
-struct SpatialCurrentDensity : db::SimpleTag {
-  using type = tnsr::I<DataVector, 3>;
-};
-
-/*!
  * \brief The divergence cleaning scalar field \f$\psi\f$ coupled to the
  * electric field.
  */
@@ -99,6 +92,27 @@ struct TildePhi : db::SimpleTag {
  */
 struct TildeQ : db::SimpleTag {
   using type = Scalar<DataVector>;
+};
+
+/*!
+ * \brief The spatial electric current density \f$J^i\f$.
+ */
+struct CurrentDensity : db::SimpleTag {
+  using type = tnsr::I<DataVector, 3>;
+};
+
+/*!
+ * \brief The non-stff (i.e. drift current) part of \f$\tilde{J}^i\f$.
+ */
+struct DriftTildeJ : db::SimpleTag {
+  using type = tnsr::I<DataVector, 3>;
+};
+
+/*!
+ * \brief The stiff (i.e. parallel current) part of \f$\tilde{J}^i\f$.
+ */
+struct ParallelTildeJ : db::SimpleTag {
+  using type = tnsr::I<DataVector, 3>;
 };
 
 /*!
@@ -211,6 +225,21 @@ struct KappaPhi : db::SimpleTag {
     return kappa_phi;
   }
 };
+
+/*!
+ * \brief The damping parameter \f$\eta\f$ in the electric current density to
+ * impose force-free conditions. Physically, this parameter is the conductivity
+ * parallel to magnetic field lines.
+ */
+struct ParallelConductivity : db::SimpleTag {
+  using type = double;
+  using option_tags = tmpl::list<OptionTags::ParallelConductivity>;
+  static constexpr bool pass_metavariables = false;
+  static double create_from_options(const double parallel_conductivity) {
+    return parallel_conductivity;
+  }
+};
+
 }  // namespace Tags
 
 }  // namespace ForceFree

--- a/src/Evolution/Systems/ForceFree/TimeDerivativeTerms.cpp
+++ b/src/Evolution/Systems/ForceFree/TimeDerivativeTerms.cpp
@@ -51,7 +51,8 @@ void TimeDerivativeTerms::apply(
     const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_b,
     const Scalar<DataVector>& tilde_psi, const Scalar<DataVector>& tilde_phi,
     const Scalar<DataVector>& tilde_q,
-    const tnsr::I<DataVector, 3, Frame::Inertial>& spatial_current_density,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& drift_tilde_j,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& parallel_tilde_j,
     const double kappa_psi, const double kappa_phi,
 
     const Scalar<DataVector>& lapse,
@@ -80,12 +81,12 @@ void TimeDerivativeTerms::apply(
     (*lapse_times_magnetic_field_one_form).get(d) *=
         get(lapse) / get(sqrt_det_spatial_metric);
   }
-  detail::fluxes_impl(
-      tilde_e_flux, tilde_b_flux, tilde_psi_flux, tilde_phi_flux, tilde_q_flux,
-      *lapse_times_electric_field_one_form,
-      *lapse_times_magnetic_field_one_form, tilde_e, tilde_b, tilde_psi,
-      tilde_phi, tilde_q, spatial_current_density, lapse, shift,
-      sqrt_det_spatial_metric, inv_spatial_metric);
+  detail::fluxes_impl(tilde_e_flux, tilde_b_flux, tilde_psi_flux,
+                      tilde_phi_flux, tilde_q_flux,
+                      *lapse_times_electric_field_one_form,
+                      *lapse_times_magnetic_field_one_form, tilde_e, tilde_b,
+                      tilde_psi, tilde_phi, tilde_q, drift_tilde_j,
+                      parallel_tilde_j, lapse, shift, inv_spatial_metric);
 
   // Compute source terms
   gr::christoffel_first_kind(spatial_christoffel_first_kind, d_spatial_metric);
@@ -95,12 +96,13 @@ void TimeDerivativeTerms::apply(
   trace_last_indices(trace_spatial_christoffel_second,
                      *spatial_christoffel_second_kind, inv_spatial_metric);
 
+  // Note that here parallel_tilde_j is not used for source terms. This is
+  // handled in a separate IMEX routine.
   detail::sources_impl(non_flux_terms_dt_tilde_e, non_flux_terms_dt_tilde_b,
                        non_flux_terms_dt_tilde_psi, non_flux_terms_dt_tilde_phi,
                        *trace_spatial_christoffel_second, tilde_e, tilde_b,
-                       tilde_psi, tilde_phi, tilde_q, spatial_current_density,
-                       kappa_psi, kappa_phi, lapse, d_lapse, d_shift,
-                       inv_spatial_metric, sqrt_det_spatial_metric,
+                       tilde_psi, tilde_phi, tilde_q, drift_tilde_j, kappa_psi,
+                       kappa_phi, lapse, d_lapse, d_shift, inv_spatial_metric,
                        extrinsic_curvature);
 }
 

--- a/src/Evolution/Systems/ForceFree/TimeDerivativeTerms.hpp
+++ b/src/Evolution/Systems/ForceFree/TimeDerivativeTerms.hpp
@@ -49,7 +49,7 @@ struct TimeDerivativeTerms {
   using argument_tags = tmpl::list<
       // EM tags
       Tags::TildeE, Tags::TildeB, Tags::TildePsi, Tags::TildePhi, Tags::TildeQ,
-      Tags::SpatialCurrentDensity, Tags::KappaPsi, Tags::KappaPhi,
+      Tags::DriftTildeJ, Tags::ParallelTildeJ, Tags::KappaPsi, Tags::KappaPhi,
 
       // GR-related tags
       gr::Tags::Lapse<>, gr::Tags::Shift<3>, gr::Tags::SqrtDetSpatialMetric<>,
@@ -102,7 +102,8 @@ struct TimeDerivativeTerms {
       const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_b,
       const Scalar<DataVector>& tilde_psi, const Scalar<DataVector>& tilde_phi,
       const Scalar<DataVector>& tilde_q,
-      const tnsr::I<DataVector, 3, Frame::Inertial>& spatial_current_density,
+      const tnsr::I<DataVector, 3, Frame::Inertial>& drift_tilde_j,
+      const tnsr::I<DataVector, 3, Frame::Inertial>& parallel_tilde_j,
       const double kappa_psi, const double kappa_phi,
 
       const Scalar<DataVector>& lapse,

--- a/src/Evolution/Systems/ForceFree/VolumeTermsInstantiation.cpp
+++ b/src/Evolution/Systems/ForceFree/VolumeTermsInstantiation.cpp
@@ -46,7 +46,8 @@ template void volume_terms<::ForceFree::TimeDerivativeTerms>(
     const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_b,
     const Scalar<DataVector>& tilde_psi, const Scalar<DataVector>& tilde_phi,
     const Scalar<DataVector>& tilde_q,
-    const tnsr::I<DataVector, 3, Frame::Inertial>& spatial_current_density,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& drift_tilde_j,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& parallel_tilde_j,
     const double& kappa_psi, const double& kappa_phi,
 
     const Scalar<DataVector>& lapse,

--- a/tests/Unit/Evolution/Systems/ForceFree/Fluxes.py
+++ b/tests/Unit/Evolution/Systems/ForceFree/Fluxes.py
@@ -9,8 +9,8 @@ def levi_civita_symbol(i, j, k):
 
 
 def tilde_e_flux(tilde_e, tilde_b, tilde_psi, tilde_phi, tilde_q,
-                 current_density, lapse, shift, sqrt_det_spatial_metric,
-                 spatial_metric, inv_spatial_metric):
+                 drift_tilde_j, parallel_tilde_j, lapse, shift,
+                 sqrt_det_spatial_metric, spatial_metric, inv_spatial_metric):
     magnetic_field_one_form = np.einsum(
         "a, ia", tilde_b, spatial_metric) / sqrt_det_spatial_metric
 
@@ -27,8 +27,8 @@ def tilde_e_flux(tilde_e, tilde_b, tilde_psi, tilde_phi, tilde_q,
 
 
 def tilde_b_flux(tilde_e, tilde_b, tilde_psi, tilde_phi, tilde_q,
-                 current_density, lapse, shift, sqrt_det_spatial_metric,
-                 spatial_metric, inv_spatial_metric):
+                 drift_tilde_j, parallel_tilde_j, lapse, shift,
+                 sqrt_det_spatial_metric, spatial_metric, inv_spatial_metric):
     electric_field_one_form = np.einsum(
         "a, ia", tilde_e, spatial_metric) / sqrt_det_spatial_metric
 
@@ -45,19 +45,20 @@ def tilde_b_flux(tilde_e, tilde_b, tilde_psi, tilde_phi, tilde_q,
 
 
 def tilde_psi_flux(tilde_e, tilde_b, tilde_psi, tilde_phi, tilde_q,
-                   current_density, lapse, shift, sqrt_det_spatial_metric,
-                   spatial_metric, inv_spatial_metric):
+                   drift_tilde_j, parallel_tilde_j, lapse, shift,
+                   sqrt_det_spatial_metric, spatial_metric,
+                   inv_spatial_metric):
     return -shift * tilde_psi + lapse * tilde_e
 
 
 def tilde_phi_flux(tilde_e, tilde_b, tilde_psi, tilde_phi, tilde_q,
-                   current_density, lapse, shift, sqrt_det_spatial_metric,
-                   spatial_metric, inv_spatial_metric):
+                   drift_tilde_j, parallel_tilde_j, lapse, shift,
+                   sqrt_det_spatial_metric, spatial_metric,
+                   inv_spatial_metric):
     return -shift * tilde_phi + lapse * tilde_b
 
 
 def tilde_q_flux(tilde_e, tilde_b, tilde_psi, tilde_phi, tilde_q,
-                 current_density, lapse, shift, sqrt_det_spatial_metric,
-                 spatial_metric, inv_spatial_metric):
-    return (lapse * sqrt_det_spatial_metric * current_density -
-            shift * tilde_q)
+                 drift_tilde_j, parallel_tilde_j, lapse, shift,
+                 sqrt_det_spatial_metric, spatial_metric, inv_spatial_metric):
+    return (drift_tilde_j + parallel_tilde_j - shift * tilde_q)

--- a/tests/Unit/Evolution/Systems/ForceFree/Sources.py
+++ b/tests/Unit/Evolution/Systems/ForceFree/Sources.py
@@ -13,10 +13,10 @@ def trace_spatial_Gamma_second_kind(inv_spatial_metric, d_spatial_metric):
 
 
 def source_tilde_e(tilde_e, tilde_b, tilde_psi, tilde_phi, tilde_q,
-                   current_density, kappa_psi, kappa_phi, lapse, d_lapse,
+                   drift_tilde_j, kappa_psi, kappa_phi, lapse, d_lapse,
                    d_shift, d_spatial_metric, inv_spatial_metric,
-                   sqrt_det_spatial_metric, extrinsic_curvature):
-    return -lapse * sqrt_det_spatial_metric * current_density - np.einsum(
+                   extrinsic_curvature):
+    return -drift_tilde_j - np.einsum(
         "a, ai", tilde_e,
         d_shift) + tilde_psi * (np.einsum("a, ia", d_lapse, inv_spatial_metric)
                                 - lapse * trace_spatial_Gamma_second_kind(
@@ -24,18 +24,18 @@ def source_tilde_e(tilde_e, tilde_b, tilde_psi, tilde_phi, tilde_q,
 
 
 def source_tilde_b(tilde_e, tilde_b, tilde_psi, tilde_phi, tilde_q,
-                   current_density, kappa_psi, kappa_phi, lapse, d_lapse,
+                   drift_tilde_j, kappa_psi, kappa_phi, lapse, d_lapse,
                    d_shift, d_spatial_metric, inv_spatial_metric,
-                   sqrt_det_spatial_metric, extrinsic_curvature):
+                   extrinsic_curvature):
     return -np.einsum("a, ai", tilde_b, d_shift) + tilde_phi * (
         np.einsum("a, ia", d_lapse, inv_spatial_metric) - lapse *
         trace_spatial_Gamma_second_kind(inv_spatial_metric, d_spatial_metric))
 
 
 def source_tilde_phi(tilde_e, tilde_b, tilde_psi, tilde_phi, tilde_q,
-                     current_density, kappa_psi, kappa_phi, lapse, d_lapse,
+                     drift_tilde_j, kappa_psi, kappa_phi, lapse, d_lapse,
                      d_shift, d_spatial_metric, inv_spatial_metric,
-                     sqrt_det_spatial_metric, extrinsic_curvature):
+                     extrinsic_curvature):
 
     return np.einsum(
         "a, a", tilde_b, d_lapse) - lapse * tilde_phi * (np.einsum(
@@ -43,9 +43,9 @@ def source_tilde_phi(tilde_e, tilde_b, tilde_psi, tilde_phi, tilde_q,
 
 
 def source_tilde_psi(tilde_e, tilde_b, tilde_psi, tilde_phi, tilde_q,
-                     current_density, kappa_psi, kappa_phi, lapse, d_lapse,
+                     drift_tilde_j, kappa_psi, kappa_phi, lapse, d_lapse,
                      d_shift, d_spatial_metric, inv_spatial_metric,
-                     sqrt_det_spatial_metric, extrinsic_curvature):
+                     extrinsic_curvature):
     return np.einsum(
         "a, a", tilde_e,
         d_lapse) + lapse * tilde_q - lapse * tilde_psi * (np.einsum(

--- a/tests/Unit/Evolution/Systems/ForceFree/Test_Tags.cpp
+++ b/tests/Unit/Evolution/Systems/ForceFree/Test_Tags.cpp
@@ -29,9 +29,14 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.ForceFree.Tags",
   TestHelpers::db::test_simple_tag<ForceFree::Tags::TildePhi>("TildePhi");
   TestHelpers::db::test_simple_tag<ForceFree::Tags::TildeQ>("TildeQ");
 
+  // Tags related to electric current density
+  TestHelpers::db::test_simple_tag<ForceFree::Tags::CurrentDensity>(
+      "CurrentDensity");
+  TestHelpers::db::test_simple_tag<ForceFree::Tags::DriftTildeJ>("DriftTildeJ");
+  TestHelpers::db::test_simple_tag<ForceFree::Tags::ParallelTildeJ>(
+      "ParallelTildeJ");
+
   // etc.
-  TestHelpers::db::test_simple_tag<ForceFree::Tags::SpatialCurrentDensity>(
-      "SpatialCurrentDensity");
   TestHelpers::db::test_simple_tag<ForceFree::Tags::KappaPsi>("KappaPsi");
   TestHelpers::db::test_simple_tag<ForceFree::Tags::KappaPhi>("KappaPhi");
 }

--- a/tests/Unit/Evolution/Systems/ForceFree/Test_TimeDerivativeTerms.cpp
+++ b/tests/Unit/Evolution/Systems/ForceFree/Test_TimeDerivativeTerms.cpp
@@ -34,7 +34,8 @@ void forward_to_time_deriv(
     const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_b,
     const Scalar<DataVector>& tilde_psi, const Scalar<DataVector>& tilde_phi,
     const Scalar<DataVector>& tilde_q,
-    const tnsr::I<DataVector, 3, Frame::Inertial>& spatial_current_density,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& drift_tilde_j,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& parallel_tilde_j,
     const double kappa_psi, const double kappa_phi,
 
     const Scalar<DataVector>& lapse,
@@ -77,8 +78,8 @@ void forward_to_time_deriv(
       make_not_null(&get<gr::Tags::Shift<3>>(temp)),
       make_not_null(&get<gr::Tags::InverseSpatialMetric<3>>(temp)),
 
-      tilde_e, tilde_b, tilde_psi, tilde_phi, tilde_q, spatial_current_density,
-      kappa_psi, kappa_phi,
+      tilde_e, tilde_b, tilde_psi, tilde_phi, tilde_q, drift_tilde_j,
+      parallel_tilde_j, kappa_psi, kappa_phi,
 
       lapse, shift, sqrt_det_spatial_metric, spatial_metric, inv_spatial_metric,
       extrinsic_curvature, d_lapse, d_shift, d_spatial_metric);


### PR DESCRIPTION
## Proposed changes

- Add two tags `DriftTildeJ` and `ParallelTildeJ`, which corresponds to the drift component (non-stiff part) and parallel component (stiff part) of electric current density term. Sum of these two is the total electric current (TildeJ); please see equations in system documentation (https://spectre-code.org/structForceFree_1_1System.html). TildeJ = DriftTildeJ + ParallelTildeJ is in the source term of the variable TildeE, and also in the flux term of another evolved variable TildeQ.
- `DriftTildeJ` is explicit, therefore can be handled as a ComputeTag.
- `ParallelTildeJ` is implicit, and needs to be computed and stored after implicit solve (for TildeE) is completed using the IMEX framework. The reason why we want to store this quantity is we need the total `(DriftTildeJ + ParallelTildeJ)` for computing the flux for TildeQ at the next time step.
- The tag `CurrentDensity` is not used for evolution, just a tag for observation purpose only.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
