### PR TITLE
Fix unused variable warning in H5/File.cpp

### DIFF
--- a/src/IO/H5/File.cpp
+++ b/src/IO/H5/File.cpp
@@ -57,6 +57,8 @@ H5File<Access_t>::H5File(std::string file_name, bool append_to_file,
                // Ignore file locks when they are disabled on the file system
                true),
            "Failed to configure file locking.");
+#else
+  (void)use_file_locking;
 #endif
 
   file_id_ = file_exists


### PR DESCRIPTION
## Proposed changes

This happens because the variable is only used inside some header flags, so if the flag is false, then the variable never gets used.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
