### PR TITLE
Add new receive_data entry method to DistributedObject

### DIFF
--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -407,6 +407,13 @@ jobs:
         # We hash the content of the compiler rather than the location and mtime
         # to make sure the cache works across the different machines
         CCACHE_COMPILERCHECK: content
+        # These vars are to allow running charm with MPI as root inside the
+        # container which arises from using the "--privileged" flag just below.
+        OMPI_ALLOW_RUN_AS_ROOT: 1
+        OMPI_ALLOW_RUN_AS_ROOT_CONFIRM: 1
+      # See https://lists.cs.illinois.edu/lists/arc/charm/2018-10/msg00011.html
+      # for why we need this
+      options: --privileged
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3.0.1

--- a/cmake/FindCharm.cmake
+++ b/cmake/FindCharm.cmake
@@ -412,6 +412,7 @@ find_package_handle_standard_args(
 mark_as_advanced(
   CHARM_COMPILER
   CHARM_INCLUDE_DIR
+  CHARM_USE_MPI
   CHARM_VERSION_MAJOR
   CHARM_VERSION_MINOR
   CHARM_VERSION_PATCH

--- a/docs/DevGuide/Parallelization.md
+++ b/docs/DevGuide/Parallelization.md
@@ -593,6 +593,11 @@ inherit publicly off the inserters to gain the required insertion capabilities:
 
 \snippet Test_AlgorithmCore.cpp int receive tag insert
 
+Any inbox tag that uses Charm++ messages must also specify a `message_type` type
+alias which is the object that will be sent. An example is:
+
+\snippet Test_AlgorithmMessages.cpp charm message inbox tag
+
 The `inbox_tags` type alias for the action is:
 
 \snippet Test_AlgorithmParallel.cpp int_receive_tag_list

--- a/src/Evolution/DiscontinuousGalerkin/InboxTags.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/InboxTags.hpp
@@ -212,6 +212,7 @@ struct BoundaryMessageInbox {
       FixedHashMap<maximum_number_of_neighbors(Dim),
                    std::pair<Direction<Dim>, ElementId<Dim>>, stored_type,
                    boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>>;
+  using message_type = BoundaryMessage<Dim>;
 
   template <typename Inbox>
   static void insert_into_inbox(const gsl::not_null<Inbox*> inbox,

--- a/src/Evolution/DiscontinuousGalerkin/Messages/BoundaryMessage.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Messages/BoundaryMessage.hpp
@@ -11,6 +11,7 @@
 #include "Domain/Structure/ElementId.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "Time/TimeStepId.hpp"
+#include "Utilities/GetOutput.hpp"
 #include "Utilities/PrettyType.hpp"
 
 #include "Evolution/DiscontinuousGalerkin/Messages/BoundaryMessage.decl.h"
@@ -29,6 +30,11 @@ namespace evolution::dg {
 template <size_t Dim>
 struct BoundaryMessage : public CMessage_BoundaryMessage<Dim> {
   using base = CMessage_BoundaryMessage<Dim>;
+
+  // Needed for charm registration
+  static std::string name() {
+    return "BoundaryMessage<" + get_output(Dim) + ">";
+  };
 
   size_t subcell_ghost_data_size;
   size_t dg_flux_data_size;

--- a/src/Parallel/Algorithms/AlgorithmArray.ci
+++ b/src/Parallel/Algorithms/AlgorithmArray.ci
@@ -70,6 +70,9 @@ module AlgorithmArray {
 
     entry void start_phase(Parallel::Phase);
 
+    template <typename ReceiveTag, typename MessageType>
+    entry void receive_data(MessageType*);
+
     template <typename ReceiveTag, typename ReceiveData_t>
     entry [inline] void receive_data(typename ReceiveTag::temporal_id&,
                                      ReceiveData_t&,

--- a/src/Parallel/Invoke.hpp
+++ b/src/Parallel/Invoke.hpp
@@ -45,6 +45,38 @@ void receive_data(Proxy&& proxy, typename ReceiveTag::temporal_id temporal_id,
   }
 }
 
+/*!
+ * \ingroup ParallelGroup
+ * \brief Send a pointer `message` to the algorithm running on `proxy`.
+ *
+ * Here, `message` should hold all the information you need as member variables
+ * of the object. This includes, temporal ID identifiers, the data itself, and
+ * any auxilary information that needs to be communicated. The `ReceiveTag`
+ * associated with this `message` should be able unpack the information that was
+ * sent.
+ *
+ * If the component associated with the `proxy` you are calling this on is
+ * running on the same charm-node, the exact pointer `message` is sent to the
+ * receiving component. No copies of data are done. If the receiving component
+ * is on a different charm-node, then the data pointed to by `message` is
+ * copied, sent through charm, and unpacked on the receiving component. The
+ * pointer that is passed to the algorithm on the receiving component then
+ * points to the copied data on the receiving component.
+ *
+ * \warning You cannot use the `message` pointer after you call this function.
+ * Doing so will result in undefined behavior because something else may be
+ * controlling the pointer.
+ */
+template <typename ReceiveTag, typename Proxy, typename MessageType>
+void receive_data(Proxy&& proxy, MessageType* message) {
+  static_assert(is_array_proxy<std::decay_t<Proxy>>::value or
+                    is_array_element_proxy<std::decay_t<Proxy>>::value,
+                "Charm++ messages can only be used with Array[Element] chares "
+                "at the moment. If you want to use them with other types of "
+                "components, you will need to implement it.");
+  proxy.template receive_data<ReceiveTag, std::decay_t<MessageType>>(message);
+}
+
 /// @{
 /*!
  * \ingroup ParallelGroup

--- a/tests/Unit/Parallel/CMakeLists.txt
+++ b/tests/Unit/Parallel/CMakeLists.txt
@@ -9,7 +9,9 @@ set(ALGORITHM_TEST_LINK_LIBRARIES
   Actions
   Boost::program_options
   Charmxx::main
+  DomainStructure
   ErrorHandling
+  Evolution
   H5
   Informer
   Observer
@@ -17,7 +19,9 @@ set(ALGORITHM_TEST_LINK_LIBRARIES
   Parallel
   ParallelHelpers
   PhaseControl
+  Spectral
   SystemUtilities
+  Time
   Utilities
   )
 
@@ -61,6 +65,28 @@ function(add_algorithm_test_with_restart_from_checkpoint TEST_NAME)
   set_standalone_test_properties("Unit.Parallel.${TEST_NAME}")
 endfunction()
 
+function(add_algorithm_message_test TEST_NAME)
+  add_standalone_test_executable("Test_${TEST_NAME}")
+  target_link_libraries(
+    "Test_${TEST_NAME}"
+    PRIVATE
+    "${ALGORITHM_TEST_LINK_LIBRARIES}")
+  if (CHARM_USE_MPI)
+    set(CHARM_ARGS "+n2 +p2")
+  else()
+    set(CHARM_ARGS "")
+  endif()
+  add_test(
+    NAME "Unit.Parallel.${TEST_NAME}"
+    COMMAND
+    ${SHELL_EXECUTABLE}
+    -c
+    "${CMAKE_BINARY_DIR}/bin/charmrun ${CMAKE_BINARY_DIR}/bin/Test_${TEST_NAME} \
+        ${CHARM_ARGS} 2>&1"
+    )
+  set_standalone_test_properties("Unit.Parallel.${TEST_NAME}")
+endfunction()
+
 function(add_algorithm_test BASE_NAME)
   add_standalone_test("Unit.Parallel.${BASE_NAME}" ${ARGN})
   target_link_libraries(
@@ -83,6 +109,7 @@ add_dependencies(
   module_Test_GlobalCache
   )
 
+add_algorithm_message_test("AlgorithmMessages")
 add_algorithm_test("AlgorithmCore")
 add_algorithm_test("AlgorithmLocalSyncAction")
 add_algorithm_test(

--- a/tests/Unit/Parallel/Test_AlgorithmMessages.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmMessages.cpp
@@ -1,0 +1,435 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#define CATCH_CONFIG_RUNNER
+
+#include "Framework/TestingFramework.hpp"
+
+#include <map>
+#include <sstream>
+#include <string>
+#include <tuple>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Evolution/DiscontinuousGalerkin/Messages/BoundaryMessage.hpp"
+#include "Helpers/Parallel/RoundRobinArrayElements.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "Parallel/AlgorithmExecution.hpp"
+#include "Parallel/Algorithms/AlgorithmArray.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "Parallel/InboxInserters.hpp"
+#include "Parallel/InitializationFunctions.hpp"
+#include "Parallel/Invoke.hpp"
+#include "Parallel/Local.hpp"
+#include "Parallel/Main.hpp"
+#include "Parallel/ParallelComponentHelpers.hpp"
+#include "Parallel/Phase.hpp"
+#include "Parallel/PhaseDependentActionList.hpp"
+#include "ParallelAlgorithms/Actions/TerminatePhase.hpp"
+#include "ParallelAlgorithms/Initialization/MutateAssign.hpp"
+#include "Time/Slab.hpp"
+#include "Time/TimeStepId.hpp"
+#include "Utilities/Blas.hpp"
+#include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeString.hpp"
+#include "Utilities/System/ParallelInfo.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+static constexpr int total_number_of_array_elements = 12;
+
+namespace PUP {
+class er;
+}  // namespace PUP
+namespace db {
+template <typename TagsList>
+class DataBox;
+}  // namespace db
+
+namespace {
+template <size_t Dim>
+using BoundaryMessage = evolution::dg::BoundaryMessage<Dim>;
+
+int node_of(const int element, const bool using_two_nodes) {
+  return using_two_nodes
+             ? (element < total_number_of_array_elements / 2 ? 0 : 1)
+             : 0;
+}
+
+namespace Tags {
+// When we are running with two charm nodes, we want some elements to send to
+// the same node and some to send to a different node. Here's a chart:
+//
+// Element  MyNode  SendingTo  TheirNode  Inter/Intra-Communication
+//    0       0         1          0         Intra
+//    1       0         2          0         Intra
+//    2       0         3          0         Intra
+//    3       0         6          1         Inter
+//    4       0        11          1         Inter
+//    5       0        10          1         Inter
+//    6       1         7          1         Intra
+//    7       1         8          1         Intra
+//    8       1         9          1         Intra
+//    9       1         0          0         Inter
+//   10       1         4          0         Inter
+//   11       1         5          0         Inter
+//
+// Six elements will be doing inter-node communication, and six will be doing
+// intra-node communication
+//
+// When we are running with only one charm node, all twelve elements are on the
+// same node and will be doing intra-node communication
+struct SendMap : db::SimpleTag {
+  using type = std::map<int, int>;
+  using option_tags = tmpl::list<>;
+  static constexpr bool pass_metavariables = false;
+
+  static type create_from_options() {
+    return std::map<int, int>{{0, 1}, {1, 2}, {2, 3}, {3, 6}, {4, 11}, {5, 10},
+                              {6, 7}, {7, 8}, {8, 9}, {9, 0}, {10, 4}, {11, 5}};
+  }
+};
+
+// Inverse of SendMap. Simple way to have a bidirectional mapping
+struct ReceiveMap : db::SimpleTag {
+  using type = std::map<int, int>;
+  using option_tags = tmpl::list<>;
+  static constexpr bool pass_metavariables = false;
+
+  static type create_from_options() {
+    const std::map<int, int> send_map = SendMap::create_from_options();
+
+    std::map<int, int> receive_map{};
+
+    for (const auto& [sender_element, receiver_element] : send_map) {
+      receive_map[receiver_element] = sender_element;
+    }
+
+    return receive_map;
+  }
+};
+
+// We want to be able to compare Vector1.data() on the receiving element to the
+// Vector0.data() of the sending element. If the two elements are on the same
+// node, then those two addresses should be the same. If they are on different
+// nodes then they should be different. This is just a way to communicate
+// Vector0.data() from the sender to the receiver to compare.
+struct AddressOfVector0OnSender : db::SimpleTag {
+  using type = std::string;
+};
+
+// Even though some of these can be accessed with functions, we add them all
+// here to have a uniform interface
+// {
+struct MyElement : db::SimpleTag {
+  using type = int;
+};
+
+struct MyNode : db::SimpleTag {
+  using type = int;
+};
+
+struct ElementToSendTo : db::SimpleTag {
+  using type = int;
+};
+
+struct NodeOfElementToSendTo : db::SimpleTag {
+  using type = int;
+};
+
+struct ElementToReceiveFrom : db::SimpleTag {
+  using type = int;
+};
+
+struct NodeOfElementToReceiveFrom : db::SimpleTag {
+  using type = int;
+};
+// }
+
+struct Vector0 : db::SimpleTag {
+  using type = DataVector;
+};
+
+struct Vector1 : db::SimpleTag {
+  using type = DataVector;
+};
+
+// We hijack the tci_status argument to be the array index of the receiving
+// element. Also this comment is up here so the docs look pretty
+// [charm message inbox tag]
+struct BoundaryMessageReceiveTag {
+  using temporal_id = int;
+  using type =
+      std::unordered_map<temporal_id, std::unique_ptr<BoundaryMessage<3>>>;
+  using message_type = BoundaryMessage<3>;
+
+  template <typename Inbox>
+  static void insert_into_inbox(const gsl::not_null<Inbox*> inbox,
+                                BoundaryMessage<3>* message) {
+    const int receiver_element = message->tci_status;
+    (*inbox)[receiver_element] = std::unique_ptr<BoundaryMessage<3>>(message);
+  }
+};
+// [charm message inbox tag]
+}  // namespace Tags
+
+struct SendAddressOfVector0 {
+  template <typename ParallelComponent, typename DbTags, typename Metavariables,
+            typename ArrayIndex>
+  static void apply(db::DataBox<DbTags>& box,
+                    const Parallel::GlobalCache<Metavariables>& /*cache*/,
+                    const ArrayIndex& /*array_index*/,
+                    const std::string& sent_address) {
+    db::mutate<Tags::AddressOfVector0OnSender>(
+        make_not_null(&box),
+        [&sent_address](const gsl::not_null<std::string*> address) {
+          *address = sent_address;
+        });
+  }
+};
+
+struct Initialize {
+  using simple_tags =
+      tmpl::list<Tags::MyElement, Tags::MyNode, Tags::ElementToSendTo,
+                 Tags::NodeOfElementToSendTo, Tags::ElementToReceiveFrom,
+                 Tags::NodeOfElementToReceiveFrom, Tags::Vector0, Tags::Vector1,
+                 Tags::AddressOfVector0OnSender>;
+  using const_global_cache_tags = tmpl::list<Tags::SendMap, Tags::ReceiveMap>;
+  template <typename DbTagsList, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent>
+  static Parallel::iterable_action_return_t apply(
+      db::DataBox<DbTagsList>& box,
+      tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+      const Parallel::GlobalCache<Metavariables>& cache,
+      const ArrayIndex& array_index, const ActionList /*meta*/,
+      const ParallelComponent* const /*meta*/) {
+    const auto& send_map = Parallel::get<Tags::SendMap>(cache);
+    const auto& receive_map = Parallel::get<Tags::ReceiveMap>(cache);
+    const int element_to_send_to = send_map.at(array_index);
+    const int element_to_receive_from = receive_map.at(array_index);
+    const bool using_two_nodes = Parallel::number_of_nodes<int>(cache) == 2;
+
+    Initialization::mutate_assign<
+        tmpl::list<Tags::MyElement, Tags::MyNode, Tags::ElementToSendTo,
+                   Tags::NodeOfElementToSendTo, Tags::ElementToReceiveFrom,
+                   Tags::NodeOfElementToReceiveFrom, Tags::Vector0>>(
+        make_not_null(&box), array_index, node_of(array_index, using_two_nodes),
+        element_to_send_to, node_of(element_to_send_to, using_two_nodes),
+        element_to_receive_from,
+        node_of(element_to_receive_from, using_two_nodes),
+        DataVector{static_cast<size_t>(array_index) + 1, 1.0});
+
+    return {Parallel::AlgorithmExecution::Pause, std::nullopt};
+  }
+};
+
+struct SendMessage {
+  template <typename DbTags, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent>
+  static Parallel::iterable_action_return_t apply(
+      db::DataBox<DbTags>& box, tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+      Parallel::GlobalCache<Metavariables>& cache,
+      const ArrayIndex& array_index, const ActionList /*meta*/,
+      const ParallelComponent* const /*meta*/) {
+    const int my_node = db::get<Tags::MyNode>(box);
+    const int element_to_send_to = db::get<Tags::ElementToSendTo>(box);
+    const int node_of_element_to_send_to =
+        db::get<Tags::NodeOfElementToSendTo>(box);
+
+    auto& proxy = Parallel::get_parallel_component<ParallelComponent>(cache);
+
+    // We hijack the tci_status argument to be the array index of the element
+    // that we are sending data to which will be the temporal id for the inbox
+    // tag
+    BoundaryMessage<3>* message = new BoundaryMessage<3>(
+        0, static_cast<size_t>(array_index + 1),
+        my_node != node_of_element_to_send_to, true,
+        static_cast<size_t>(my_node), static_cast<size_t>(my_node),
+        element_to_send_to, {}, {}, {}, {}, {}, {}, nullptr,
+        const_cast<double*>(db::get<Tags::Vector0>(box).data()));
+
+    std::stringstream ss{};
+    ss << message;
+    const std::string message_address{ss.str()};
+    ss.str("");
+    ss << message->dg_flux_data;
+    const std::string data_address{ss.str()};
+
+    Parallel::receive_data<Tags::BoundaryMessageReceiveTag>(
+        proxy[element_to_send_to], message);
+
+    // Send the address of Vector0.data() to the receiver
+    Parallel::simple_action<SendAddressOfVector0>(proxy[element_to_send_to],
+                                                  data_address);
+
+    return {Parallel::AlgorithmExecution::Continue, std::nullopt};
+  }
+};
+
+struct ReceiveMessage {
+  using inbox_tags = tmpl::list<Tags::BoundaryMessageReceiveTag>;
+
+  template <typename DbTags, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent>
+  static Parallel::iterable_action_return_t apply(
+      db::DataBox<DbTags>& box, tuples::TaggedTuple<InboxTags...>& inboxes,
+      const Parallel::GlobalCache<Metavariables>& /*cache*/,
+      const ArrayIndex& array_index, const ActionList /*meta*/,
+      const ParallelComponent* const /*meta*/) {
+    auto& inbox = tuples::get<Tags::BoundaryMessageReceiveTag>(inboxes);
+
+    if (inbox.count(array_index) == 0) {
+      return {Parallel::AlgorithmExecution::Retry, std::nullopt};
+    }
+
+    // Scope this so we don't get a dangling reference
+    {
+      auto& boundary_message_ptr = inbox.at(array_index);
+
+      db::mutate<Tags::Vector1>(
+          make_not_null(&box),
+          [&boundary_message_ptr](const gsl::not_null<DataVector*> vector_1) {
+            vector_1->set_data_ref(boundary_message_ptr->dg_flux_data,
+                                   boundary_message_ptr->dg_flux_data_size);
+          });
+    }
+
+    inbox.erase(array_index);
+
+    return {Parallel::AlgorithmExecution::Continue, std::nullopt};
+  }
+};
+
+struct CheckMessage {
+  template <typename DbTags, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent>
+  static Parallel::iterable_action_return_t apply(
+      db::DataBox<DbTags>& box, tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+      const Parallel::GlobalCache<Metavariables>& /*cache*/,
+      const ArrayIndex& /*array_index*/, const ActionList /*meta*/,
+      const ParallelComponent* const /*meta*/) {
+    const int my_element = db::get<Tags::MyElement>(box);
+    const int my_node = db::get<Tags::MyNode>(box);
+    const int element_to_receive_from =
+        db::get<Tags::ElementToReceiveFrom>(box);
+    const int node_of_element_to_receive_from =
+        db::get<Tags::NodeOfElementToReceiveFrom>(box);
+
+    const auto& vector_0 = db::get<Tags::Vector0>(box);
+    const auto& vector_1 = db::get<Tags::Vector1>(box);
+
+    const auto& address_of_vector_0_on_sender =
+        db::get<Tags::AddressOfVector0OnSender>(box);
+    std::stringstream ss{};
+    ss << vector_1.data();
+    const std::string address_of_vector_1_on_receiver = ss.str();
+
+    // Regardless of whether we are on different nodes or not, this should be
+    // true
+    SPECTRE_PARALLEL_REQUIRE(vector_0.size() ==
+                             static_cast<size_t>(my_element) + 1);
+    SPECTRE_PARALLEL_REQUIRE(vector_1.size() ==
+                             static_cast<size_t>(element_to_receive_from) + 1);
+
+    // If we are on the same node, we should have the same memory address for
+    // our Vector1.data() and the senders Vector0.data(). But if we are on
+    // different nodes, they will be different.
+    if (node_of_element_to_receive_from == my_node) {
+      SPECTRE_PARALLEL_REQUIRE(address_of_vector_0_on_sender ==
+                               address_of_vector_1_on_receiver);
+    } else {
+      SPECTRE_PARALLEL_REQUIRE_FALSE(address_of_vector_0_on_sender ==
+                                     address_of_vector_1_on_receiver);
+    }
+
+    return {Parallel::AlgorithmExecution::Continue, std::nullopt};
+  }
+};
+
+template <class Metavariables>
+struct ArrayParallelComponent {
+  using chare_type = Parallel::Algorithms::Array;
+  using metavariables = Metavariables;
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<Parallel::Phase::Initialization,
+                             tmpl::list<Initialize>>,
+      Parallel::PhaseActions<Parallel::Phase::Solve,
+                             tmpl::list<SendMessage, ReceiveMessage,
+                                        Parallel::Actions::TerminatePhase>>,
+      Parallel::PhaseActions<
+          Parallel::Phase::Testing,
+          tmpl::list<CheckMessage, Parallel::Actions::TerminatePhase>>>;
+  using simple_tags_from_options = Parallel::get_simple_tags_from_options<
+      Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
+  using array_index = int;
+
+  static void allocate_array(
+      Parallel::CProxy_GlobalCache<Metavariables>& global_cache,
+      const tuples::tagged_tuple_from_typelist<simple_tags_from_options>&
+      /*initialization_items*/,
+      const std::unordered_set<size_t>& /*procs_to_ignore*/ = {}) {
+    auto& local_cache = *Parallel::local_branch(global_cache);
+    auto& array_proxy =
+        Parallel::get_parallel_component<ArrayParallelComponent>(local_cache);
+
+    if (sys::number_of_nodes() > 2) {
+      ERROR(
+          "The Test_AlgorithmMessages test must be run on one (1) or two (2) "
+          "charm-nodes. For one node, you don't need any extra options. For 2 "
+          "nodes, you'll need to add `+n2 +p2` to the submit command.");
+    }
+
+    for (int i = 0; i < total_number_of_array_elements; i++) {
+      const int node = node_of(i, sys::number_of_nodes() == 2);
+      array_proxy[i].insert(global_cache, {}, node);
+    }
+    array_proxy.doneInserting();
+  }
+
+  static void execute_next_phase(
+      const Parallel::Phase next_phase,
+      Parallel::CProxy_GlobalCache<Metavariables>& global_cache) {
+    auto& local_cache = *Parallel::local_branch(global_cache);
+    Parallel::get_parallel_component<ArrayParallelComponent>(local_cache)
+        .start_phase(next_phase);
+  }
+};
+
+struct TestMetavariables {
+  using component_list = tmpl::list<ArrayParallelComponent<TestMetavariables>>;
+
+  static constexpr const char* const help{
+      "Test the receive_data entry method that uses Charm++ messages"};
+  static constexpr bool ignore_unrecognized_command_line_options = false;
+
+  static constexpr std::array<Parallel::Phase, 5> default_phase_order{
+      {Parallel::Phase::Initialization, Parallel::Phase::Solve,
+       Parallel::Phase::Testing, Parallel::Phase::Cleanup,
+       Parallel::Phase::Exit}};
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& /*p*/) {}
+};
+}  // namespace
+
+static const std::vector<void (*)()> charm_init_node_funcs{
+    &setup_error_handling, &setup_memory_allocation_failure_reporting,
+    &disable_openblas_multithreading};
+static const std::vector<void (*)()> charm_init_proc_funcs{
+    &enable_floating_point_exceptions};
+
+using charmxx_main_component = Parallel::Main<TestMetavariables>;
+
+#include "Parallel/CharmMain.tpp"

--- a/tools/CharmModulePatches/src/Parallel/Algorithms/AlgorithmArray_v7.0.0.def.h.patch
+++ b/tools/CharmModulePatches/src/Parallel/Algorithms/AlgorithmArray_v7.0.0.def.h.patch
@@ -1,8 +1,8 @@
-diff --git a/src/Parallel/Algorithms/AlgorithmArray.def.h b/build_main/src/Parallel/Algorithms/AlgorithmArray.def.h
-index 541313a5d..7afe8f1b5 100644
+diff --git a/src/Parallel/Algorithms/AlgorithmArray.def.h b/src/Parallel/Algorithms/AlgorithmArray.def.h
+index 79de7a10b..ac9571c89 100644
 --- a/src/Parallel/Algorithms/AlgorithmArray.def.h
 +++ b/src/Parallel/Algorithms/AlgorithmArray.def.h
-@@ -518,16 +518,17 @@ void CProxyElement_AlgorithmArray <ParallelComponent, SpectreArrayIndex> ::start
+@@ -555,16 +555,17 @@ void CProxyElement_AlgorithmArray <ParallelComponent, SpectreArrayIndex> ::recei
  /* DEFS: void receive_data(const typename ReceiveTag::temporal_id &impl_noname_6, const ReceiveData_t &impl_noname_7, bool enable_if_disabled);
   */
  template <class ParallelComponent, class SpectreArrayIndex> 
@@ -18,12 +18,12 @@ index 541313a5d..7afe8f1b5 100644
    envelope env;
    env.setMsgtype(ForArrayEltMsg);
    env.setTotalsize(0);
--  _TRACE_CREATION_DETAILED(&env, CkIndex_AlgorithmArray <ParallelComponent, SpectreArrayIndex> ::template idx_receive_data_marshall9<ReceiveTag, ReceiveData_t>());
-+  _TRACE_CREATION_DETAILED(&env, (CkIndex_AlgorithmArray <ParallelComponent, SpectreArrayIndex> ::template idx_receive_data_marshall9<ReceiveTag, ReceiveData_t>()));
+-  _TRACE_CREATION_DETAILED(&env, CkIndex_AlgorithmArray <ParallelComponent, SpectreArrayIndex> ::template idx_receive_data_marshall10<ReceiveTag, ReceiveData_t>());
++  _TRACE_CREATION_DETAILED(&env, (CkIndex_AlgorithmArray <ParallelComponent, SpectreArrayIndex> ::template idx_receive_data_marshall10<ReceiveTag, ReceiveData_t>()));
    _TRACE_CREATION_DONE(1);
-   _TRACE_BEGIN_EXECUTE_DETAILED(CpvAccess(curPeEvent),ForArrayEltMsg,(CkIndex_AlgorithmArray <ParallelComponent, SpectreArrayIndex> ::template idx_receive_data_marshall9<ReceiveTag, ReceiveData_t>()),CkMyPe(), 0, ((CkArrayIndex&)ckGetIndex()).getProjectionID(), obj);
+   _TRACE_BEGIN_EXECUTE_DETAILED(CpvAccess(curPeEvent),ForArrayEltMsg,(CkIndex_AlgorithmArray <ParallelComponent, SpectreArrayIndex> ::template idx_receive_data_marshall10<ReceiveTag, ReceiveData_t>()),CkMyPe(), 0, ((CkArrayIndex&)ckGetIndex()).getProjectionID(), obj);
  #if CMK_LBDB_ON
-@@ -632,7 +632,7 @@ void CProxyElement_AlgorithmArray <ParallelComponent, SpectreArrayIndex> ::start
+@@ -669,7 +670,7 @@ bool CProxyElement_AlgorithmArray <ParallelComponent, SpectreArrayIndex> ::invok
    envelope env;
    env.setMsgtype(ForArrayEltMsg);
    env.setTotalsize(0);
@@ -32,3 +32,12 @@ index 541313a5d..7afe8f1b5 100644
    _TRACE_CREATION_DONE(1);
    _TRACE_BEGIN_EXECUTE_DETAILED(CpvAccess(curPeEvent),ForArrayEltMsg,(CkIndex_AlgorithmArray <ParallelComponent, SpectreArrayIndex> ::template idx_invoke_iterable_action_void<ThisAction, PhaseIndex, DataBoxIndex>()),CkMyPe(), 0, ((CkArrayIndex&)ckGetIndex()).getProjectionID(), obj);
  #if CMK_LBDB_ON
+@@ -1399,7 +1400,7 @@ template <class ParallelComponent, class SpectreArrayIndex>
+ template <class ReceiveTag, class MessageType>
+ int CkIndex_AlgorithmArray <ParallelComponent, SpectreArrayIndex> ::reg_receive_data_MessageType() {
+   int epidx = CkRegisterEp<ReceiveTag, MessageType>("receive_data(MessageType* impl_msg)",
+-      reinterpret_cast<CkCallFnPtr>(_call_receive_data_MessageType<ReceiveTag, MessageType>), CMessage_MessageType::__idx, __idx, 0);
++      reinterpret_cast<CkCallFnPtr>(_call_receive_data_MessageType<ReceiveTag, MessageType>), MessageType::base::__idx, __idx, 0);
+   CkRegisterMessagePupFn(epidx, (CkMessagePupFn)MessageType::ckDebugPup);
+   return epidx;
+ }


### PR DESCRIPTION
## Proposed changes

This one takes a Charm++ message (pointer) and inserts it into the inbox.

Also, a corresponding Parallel::receive_data function was added. This can only be used on Array components at the moment.

You also need to properly register messages with charm or you'll get incorrect behavior so there's also code added to handle that automatically.

The parallel test for this can be run on one or two charm nodes.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
