### PR TITLE
Enable equiangular maps in BBH domain

### DIFF
--- a/src/Domain/Creators/BinaryCompactObject.cpp
+++ b/src/Domain/Creators/BinaryCompactObject.cpp
@@ -64,7 +64,8 @@ BinaryCompactObject::BinaryCompactObject(
     const double outer_radius_domain,
     const typename InitialRefinement::type& initial_refinement,
     const typename InitialGridPoints::type& initial_number_of_grid_points,
-    const bool use_projective_map, const double frustum_sphericity,
+    const bool use_equiangular_map, const bool use_projective_map,
+    const double frustum_sphericity,
     const std::optional<double>& radius_enveloping_sphere,
     const CoordinateMaps::Distribution radial_distribution_outer_shell,
     std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
@@ -74,6 +75,7 @@ BinaryCompactObject::BinaryCompactObject(
       object_B_(std::move(object_B)),
       radius_enveloping_cube_(radius_enveloping_cube),
       outer_radius_domain_(outer_radius_domain),
+      use_equiangular_map_(use_equiangular_map),
       use_projective_map_(use_projective_map),
       frustum_sphericity_(frustum_sphericity),
       radial_distribution_outer_shell_(radial_distribution_outer_shell),
@@ -307,18 +309,20 @@ BinaryCompactObject::BinaryCompactObject(
     Object object_B, double radius_enveloping_cube, double outer_radius_domain,
     const typename InitialRefinement::type& initial_refinement,
     const typename InitialGridPoints::type& initial_number_of_grid_points,
-    bool use_projective_map, double frustum_sphericity,
+    const bool use_equiangular_map, bool use_projective_map,
+    double frustum_sphericity,
     const std::optional<double>& radius_enveloping_sphere,
     CoordinateMaps::Distribution radial_distribution_outer_shell,
     std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
         outer_boundary_condition,
     const Options::Context& context)
-    : BinaryCompactObject(
-          std::move(object_A), std::move(object_B), radius_enveloping_cube,
-          outer_radius_domain, initial_refinement,
-          initial_number_of_grid_points, use_projective_map, frustum_sphericity,
-          radius_enveloping_sphere, radial_distribution_outer_shell,
-          std::move(outer_boundary_condition), context) {
+    : BinaryCompactObject(std::move(object_A), std::move(object_B),
+                          radius_enveloping_cube, outer_radius_domain,
+                          initial_refinement, initial_number_of_grid_points,
+                          use_equiangular_map, use_projective_map,
+                          frustum_sphericity, radius_enveloping_sphere,
+                          radial_distribution_outer_shell,
+                          std::move(outer_boundary_condition), context) {
   enable_time_dependence_ = true;
   initial_time_ = initial_time;
   expansion_map_outer_boundary_ = expansion_map_outer_boundary;

--- a/src/Domain/Creators/BinaryCompactObject.hpp
+++ b/src/Domain/Creators/BinaryCompactObject.hpp
@@ -597,7 +597,7 @@ class BinaryCompactObject : public DomainCreator<3> {
       const typename InitialRefinement::type& initial_refinement,
       const typename InitialGridPoints::type& initial_number_of_grid_points,
       bool use_equiangular_map = true, bool use_projective_map = true,
-      double frustum_sphericity = 0.0,
+      double frustum_sphericity = 1.0,
       const std::optional<double>& radius_enveloping_sphere = std::nullopt,
       CoordinateMaps::Distribution radial_distribution_outer_shell =
           CoordinateMaps::Distribution::Linear,
@@ -623,7 +623,7 @@ class BinaryCompactObject : public DomainCreator<3> {
       const typename InitialRefinement::type& initial_refinement,
       const typename InitialGridPoints::type& initial_number_of_grid_points,
       bool use_equiangular_map = true, bool use_projective_map = true,
-      double frustum_sphericity = 0.0,
+      double frustum_sphericity = 1.0,
       const std::optional<double>& radius_enveloping_sphere = std::nullopt,
       CoordinateMaps::Distribution radial_distribution_outer_shell =
           CoordinateMaps::Distribution::Linear,

--- a/src/Domain/Creators/BinaryCompactObject.hpp
+++ b/src/Domain/Creators/BinaryCompactObject.hpp
@@ -349,6 +349,13 @@ class BinaryCompactObject : public DomainCreator<3> {
         "domain. See main help text for details."};
   };
 
+  struct UseEquiangularMap {
+    using type = bool;
+    static constexpr Options::String help = {
+        "Distribute grid points equiangularly."};
+    static bool suggested_value() { return true; }
+  };
+
   struct UseProjectiveMap {
     using group = EnvelopingCube;
     using type = bool;
@@ -514,8 +521,8 @@ class BinaryCompactObject : public DomainCreator<3> {
   template <typename Metavariables>
   using time_independent_options = tmpl::append<
       tmpl::list<ObjectA, ObjectB, RadiusEnvelopingCube, OuterRadius,
-                 InitialRefinement, InitialGridPoints, UseProjectiveMap,
-                 FrustumSphericity, RadiusEnvelopingSphere,
+                 InitialRefinement, InitialGridPoints, UseEquiangularMap,
+                 UseProjectiveMap, FrustumSphericity, RadiusEnvelopingSphere,
                  RadialDistributionOuterShell>,
       tmpl::conditional_t<
           domain::BoundaryConditions::has_boundary_conditions_base_v<
@@ -589,7 +596,8 @@ class BinaryCompactObject : public DomainCreator<3> {
       double outer_radius_domain,
       const typename InitialRefinement::type& initial_refinement,
       const typename InitialGridPoints::type& initial_number_of_grid_points,
-      bool use_projective_map = true, double frustum_sphericity = 0.0,
+      bool use_equiangular_map = true, bool use_projective_map = true,
+      double frustum_sphericity = 0.0,
       const std::optional<double>& radius_enveloping_sphere = std::nullopt,
       CoordinateMaps::Distribution radial_distribution_outer_shell =
           CoordinateMaps::Distribution::Linear,
@@ -614,7 +622,8 @@ class BinaryCompactObject : public DomainCreator<3> {
       double outer_radius_domain,
       const typename InitialRefinement::type& initial_refinement,
       const typename InitialGridPoints::type& initial_number_of_grid_points,
-      bool use_projective_map = true, double frustum_sphericity = 0.0,
+      bool use_equiangular_map = true, bool use_projective_map = true,
+      double frustum_sphericity = 0.0,
       const std::optional<double>& radius_enveloping_sphere = std::nullopt,
       CoordinateMaps::Distribution radial_distribution_outer_shell =
           CoordinateMaps::Distribution::Linear,
@@ -666,8 +675,7 @@ class BinaryCompactObject : public DomainCreator<3> {
   double outer_radius_domain_{};
   std::vector<std::array<size_t, 3>> initial_refinement_{};
   std::vector<std::array<size_t, 3>> initial_number_of_grid_points_{};
-  static constexpr bool use_equiangular_map_ =
-      false;  // Doesn't work properly yet
+  bool use_equiangular_map_ = true;
   bool use_projective_map_ = true;
   double frustum_sphericity_{};
   CoordinateMaps::Distribution radial_distribution_outer_shell_ =

--- a/src/Domain/DomainHelpers.cpp
+++ b/src/Domain/DomainHelpers.cpp
@@ -699,7 +699,10 @@ std::vector<domain::CoordinateMaps::Frustum> frustum_coordinate_maps(
 
   using FrustumMap = domain::CoordinateMaps::Frustum;
   // Binary compact object Domains use 10 Frustums, 4 around each Shell in the
-  //+z,-z,+y,-y directions, and 1 Frustum capping each end in +x, -x.
+  // +z,-z,+y,-y directions, and 1 Frustum capping each end in +x, -x.
+  // The frustums on the left are given a -1.0 indicating a lower half
+  // equiangular map while the frustums on the right are given a 1.0 indicating
+  // an upper half equiangular map
   std::vector<FrustumMap> frustums{};
   for (size_t i = 0; i < 4; i++) {
     // frustums on the left
@@ -717,7 +720,8 @@ std::vector<domain::CoordinateMaps::Frustum> frustum_coordinate_maps(
         use_equiangular_map,
         projective_scale_factor,
         false,
-        sphericity});
+        sphericity,
+        -1.0});
     // frustums on the right
     frustums.push_back(FrustumMap{{{{{-displacement_from_origin[0],
                                       -lower - displacement_from_origin[1]}},
@@ -731,7 +735,8 @@ std::vector<domain::CoordinateMaps::Frustum> frustum_coordinate_maps(
                                   use_equiangular_map,
                                   projective_scale_factor,
                                   false,
-                                  sphericity});
+                                  sphericity,
+                                  1.0});
   }
   // end cap frustum on the right
   std::array<double, 3> displacement_from_origin =

--- a/src/Utilities/CMakeLists.txt
+++ b/src/Utilities/CMakeLists.txt
@@ -27,6 +27,7 @@ spectre_target_headers(
   Blas.hpp
   CachedFunction.hpp
   CallWithDynamicType.hpp
+  CartesianProduct.hpp
   CleanupRoutine.hpp
   CloneUniquePtrs.hpp
   ConstantExpressions.hpp

--- a/src/Utilities/CartesianProduct.hpp
+++ b/src/Utilities/CartesianProduct.hpp
@@ -1,0 +1,69 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+// This implementation is from:
+// https://stackoverflow.com/questions/16686942/how-to-iterate-over-two-stl-like-containers-cartesian-product
+
+namespace detail {
+
+// the lambda is fully bound with one element from each of the ranges
+template <class Op>
+void insert_tuples(Op op) {
+  // evaluating the lambda will insert the currently bound tuple
+  op();
+}
+
+// "peel off" the first range from the remaining tuple of ranges
+template <class Op, class InputIterator1, class... InputIterator2>
+void insert_tuples(Op op, std::pair<InputIterator1, InputIterator1> head,
+                   std::pair<InputIterator2, InputIterator2>... tail) {
+  // "peel off" the elements from the first of the remaining ranges
+  // NOTE: the recursion will effectively generate the multiple nested for-loops
+  for (auto it = head.first; it != head.second; ++it) {
+    // bind the first free variable in the lambda, and
+    // keep one free variable for each of the remaining ranges
+    detail::insert_tuples(
+        [&op, &it](InputIterator2... elems) { op(it, elems...); }, tail...);
+  }
+}
+
+}  // namespace detail
+
+/*!
+ * \brief Fill the `result` iterator with the Cartesian product of a sequence of
+ * iterators
+ *
+ * The `result` will hold all possible combinations of the input iterators.
+ * The last dimension varies fastest.
+ */
+template <class OutputIterator, class... InputIterator>
+void cartesian_product(OutputIterator result,
+                       std::pair<InputIterator, InputIterator>... dimensions) {
+  detail::insert_tuples(
+      [&result](InputIterator... elems) {
+        *result++ = std::make_tuple(*elems...);
+      },
+      dimensions...);
+}
+
+/*!
+ * \brief The Cartesian product of a sequence arrays
+ *
+ * Returns a `std::array` with all possible combinations of the input arrays.
+ * The last dimension varies fastest.
+ */
+template <typename... Ts, size_t... Lens>
+std::array<std::tuple<Ts...>, (... * Lens)> cartesian_product(
+    const std::array<Ts, Lens>&... dimensions) {
+  std::array<std::tuple<Ts...>, (... * Lens)> result{};
+  cartesian_product(result.begin(),
+                    std::make_pair(dimensions.begin(), dimensions.end())...);
+  return result;
+}

--- a/tests/InputFiles/ExportCoordinates/InputTimeDependent3D.yaml
+++ b/tests/InputFiles/ExportCoordinates/InputTimeDependent3D.yaml
@@ -37,6 +37,7 @@ DomainCreator:
       InnerRadius: Auto
       OuterRadius: 300.0
       RadialDistribution: Linear
+    UseEquiangularMap: True
     InitialRefinement:
       ObjectAShell:   [1, 1, 1]
       ObjectBShell:   [1, 1, 1]

--- a/tests/InputFiles/GeneralizedHarmonic/BinaryBlackHole.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/BinaryBlackHole.yaml
@@ -71,6 +71,7 @@ DomainCreator:
       BoundaryCondition:
         ConstraintPreservingBjorhus:
           Type: ConstraintPreservingPhysical
+    UseEquiangularMap: True
     InitialRefinement:
       ObjectAShell:   [3, 3, 4]
       ObjectACube:    [2, 2, 1]

--- a/tests/InputFiles/Xcts/BinaryBlackHole.yaml
+++ b/tests/InputFiles/Xcts/BinaryBlackHole.yaml
@@ -63,6 +63,7 @@ DomainCreator:
       OuterRadius: 300.
       RadialDistribution: Inverse
       BoundaryCondition: Flatness
+    UseEquiangularMap: True
     # This h-refinement is set up so spherical wedges have equal angular size.
     # Once the domain supports equatorial compression (or similar) this
     # h-refinement will simplify considerably.

--- a/tests/Unit/Domain/CoordinateMaps/Test_Wedge3D.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_Wedge3D.cpp
@@ -13,7 +13,9 @@
 #include "Domain/Structure/OrientationMap.hpp"
 #include "Framework/TestHelpers.hpp"
 #include "Helpers/Domain/CoordinateMaps/TestMapHelpers.hpp"
+#include "Utilities/CartesianProduct.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/MakeArray.hpp"
 #include "Utilities/StdArrayHelpers.hpp"
 #include "Utilities/TypeTraits.hpp"
 
@@ -43,31 +45,28 @@ void test_wedge3d_all_directions() {
   using WedgeHalves = Wedge3D::WedgeHalves;
   const std::array<WedgeHalves, 3> halves_array = {
       {WedgeHalves::UpperOnly, WedgeHalves::LowerOnly, WedgeHalves::Both}};
-  for (const auto& halves : halves_array) {
+  for (const auto& [halves, orientation, with_equiangular_map,
+                    radial_distribution] :
+       cartesian_product(halves_array, all_wedge_directions(),
+                         make_array(true, false),
+                         make_array(CoordinateMaps::Distribution::Linear,
+                                    CoordinateMaps::Distribution::Logarithmic,
+                                    CoordinateMaps::Distribution::Inverse))) {
     CAPTURE(halves);
-    for (const auto& orientation : all_wedge_directions()) {
-      CAPTURE(orientation);
-      for (const auto& with_equiangular_map : {true, false}) {
-        CAPTURE(with_equiangular_map);
-        for (const auto radial_distribution :
-             {CoordinateMaps::Distribution::Linear,
-              CoordinateMaps::Distribution::Logarithmic,
-              CoordinateMaps::Distribution::Inverse}) {
-          CAPTURE(radial_distribution);
-          const Wedge3D wedge_map(
-              inner_radius, outer_radius,
-              radial_distribution == CoordinateMaps::Distribution::Linear
-                  ? inner_sphericity
-                  : 1.0,
-              radial_distribution == CoordinateMaps::Distribution::Linear
-                  ? outer_sphericity
-                  : 1.0,
-              orientation, with_equiangular_map, halves, radial_distribution,
-              with_equiangular_map ? half_opening_angle : M_PI_4);
-          test_suite_for_map_on_unit_cube(wedge_map);
-        }
-      }
-    }
+    CAPTURE(orientation);
+    CAPTURE(with_equiangular_map);
+    CAPTURE(radial_distribution);
+    const Wedge3D wedge_map(
+        inner_radius, outer_radius,
+        radial_distribution == CoordinateMaps::Distribution::Linear
+            ? inner_sphericity
+            : 1.0,
+        radial_distribution == CoordinateMaps::Distribution::Linear
+            ? outer_sphericity
+            : 1.0,
+        orientation, with_equiangular_map, halves, radial_distribution,
+        with_equiangular_map ? half_opening_angle : M_PI_4);
+    test_suite_for_map_on_unit_cube(wedge_map);
   }
 }
 

--- a/tests/Unit/Domain/Creators/Test_BinaryCompactObject.cpp
+++ b/tests/Unit/Domain/Creators/Test_BinaryCompactObject.cpp
@@ -36,7 +36,9 @@
 #include "Helpers/Domain/Creators/TestHelpers.hpp"
 #include "Helpers/Domain/DomainTestHelpers.hpp"
 #include "Options/Protocols/FactoryCreation.hpp"
+#include "Utilities/CartesianProduct.hpp"
 #include "Utilities/Literals.hpp"
+#include "Utilities/MakeArray.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -106,292 +108,276 @@ void test_connectivity() {
   // Misc.:
   constexpr size_t grid_points = 3;
 
-  for (const bool with_boundary_conditions : {true, false}) {
+  for (const auto& [with_boundary_conditions, excise_interiorA,
+                    excise_interiorB, use_equiangular_map,
+                    radial_distribution_outer_shell] :
+       cartesian_product(
+           make_array(true, false), make_array(true, false),
+           make_array(true, false), make_array(true, false),
+           make_array(Distribution::Linear, Distribution::Logarithmic,
+                      Distribution::Inverse))) {
     CAPTURE(with_boundary_conditions);
-    for (const bool excise_interiorA : {true, false}) {
-      CAPTURE(excise_interiorA);
-      for (const bool excise_interiorB : {true, false}) {
-        CAPTURE(excise_interiorB);
-        std::unordered_map<std::string, std::array<size_t, 3>> refinement{
-            {"ObjectAShell", {{1, 1, 1}}},
-            {"ObjectACube", {{1, 1, 1}}},
-            {"ObjectBShell", {{1, 1, 1}}},
-            {"ObjectBCube", {{1, 1, 1}}},
-            {"EnvelopingCube", {{1, 1, 1}}},
-            {"CubedShell", {{1, 1, 1}}},
-            // Add some radial refinement in outer shell
-            {"OuterShell", {{1, 1, 4}}}};
-        if (not excise_interiorA) {
-          refinement["ObjectAInterior"] = std::array<size_t, 3>{{1, 1, 1}};
-        }
-        if (not excise_interiorB) {
-          refinement["ObjectBInterior"] = std::array<size_t, 3>{{1, 1, 1}};
-        }
-        for (const auto radial_distribution_outer_shell :
-             {Distribution::Linear, Distribution::Logarithmic,
-              Distribution::Inverse}) {
-          CAPTURE(radial_distribution_outer_shell);
-          const domain::creators::BinaryCompactObject binary_compact_object{
-              Object{inner_radius_objectA, outer_radius_objectA, xcoord_objectA,
-                     excise_interiorA
-                         ? std::make_optional(
-                               Excision{with_boundary_conditions
-                                            ? create_inner_boundary_condition()
-                                            : nullptr})
-                         : std::nullopt,
-                     false},
-              Object{inner_radius_objectB, outer_radius_objectB, xcoord_objectB,
-                     excise_interiorB
-                         ? std::make_optional(
-                               Excision{with_boundary_conditions
-                                            ? create_inner_boundary_condition()
-                                            : nullptr})
-                         : std::nullopt,
-                     false},
-              radius_enveloping_cube,
-              outer_radius,
-              refinement,
-              grid_points,
-              use_projective_map,
-              sphericity_enveloping_cube,
-              radius_enveloping_sphere,
-              radial_distribution_outer_shell,
-              with_boundary_conditions ? create_outer_boundary_condition()
-                                       : nullptr};
+    CAPTURE(excise_interiorA);
+    CAPTURE(excise_interiorB);
+    std::unordered_map<std::string, std::array<size_t, 3>> refinement{
+        {"ObjectAShell", {{1, 1, 1}}},
+        {"ObjectACube", {{1, 1, 1}}},
+        {"ObjectBShell", {{1, 1, 1}}},
+        {"ObjectBCube", {{1, 1, 1}}},
+        {"EnvelopingCube", {{1, 1, 1}}},
+        {"CubedShell", {{1, 1, 1}}},
+        // Add some radial refinement in outer shell
+        {"OuterShell", {{1, 1, 4}}}};
+    if (not excise_interiorA) {
+      refinement["ObjectAInterior"] = std::array<size_t, 3>{{1, 1, 1}};
+    }
+    if (not excise_interiorB) {
+      refinement["ObjectBInterior"] = std::array<size_t, 3>{{1, 1, 1}};
+    }
+    CAPTURE(use_equiangular_map);
+    CAPTURE(radial_distribution_outer_shell);
+    const domain::creators::BinaryCompactObject binary_compact_object{
+        Object{inner_radius_objectA, outer_radius_objectA, xcoord_objectA,
+               excise_interiorA ? std::make_optional(Excision{
+                                      with_boundary_conditions
+                                          ? create_inner_boundary_condition()
+                                          : nullptr})
+                                : std::nullopt,
+               false},
+        Object{inner_radius_objectB, outer_radius_objectB, xcoord_objectB,
+               excise_interiorB ? std::make_optional(Excision{
+                                      with_boundary_conditions
+                                          ? create_inner_boundary_condition()
+                                          : nullptr})
+                                : std::nullopt,
+               false},
+        radius_enveloping_cube,
+        outer_radius,
+        refinement,
+        grid_points,
+        use_equiangular_map,
+        use_projective_map,
+        sphericity_enveloping_cube,
+        radius_enveloping_sphere,
+        radial_distribution_outer_shell,
+        with_boundary_conditions ? create_outer_boundary_condition() : nullptr};
 
-          const auto domain =
-              TestHelpers::domain::creators::test_domain_creator(
-                  binary_compact_object, with_boundary_conditions);
+    const auto domain = TestHelpers::domain::creators::test_domain_creator(
+        binary_compact_object, with_boundary_conditions);
 
-          std::vector<std::string> expected_block_names{
-              "ObjectAShellUpperZ",       "ObjectAShellLowerZ",
-              "ObjectAShellUpperY",       "ObjectAShellLowerY",
-              "ObjectAShellUpperX",       "ObjectAShellLowerX",
-              "ObjectACubeUpperZ",        "ObjectACubeLowerZ",
-              "ObjectACubeUpperY",        "ObjectACubeLowerY",
-              "ObjectACubeUpperX",        "ObjectACubeLowerX",
-              "ObjectBShellUpperZ",       "ObjectBShellLowerZ",
-              "ObjectBShellUpperY",       "ObjectBShellLowerY",
-              "ObjectBShellUpperX",       "ObjectBShellLowerX",
-              "ObjectBCubeUpperZ",        "ObjectBCubeLowerZ",
-              "ObjectBCubeUpperY",        "ObjectBCubeLowerY",
-              "ObjectBCubeUpperX",        "ObjectBCubeLowerX",
-              "EnvelopingCubeUpperZLeft", "EnvelopingCubeUpperZRight",
+    std::vector<std::string> expected_block_names{
+        "ObjectAShellUpperZ",       "ObjectAShellLowerZ",
+        "ObjectAShellUpperY",       "ObjectAShellLowerY",
+        "ObjectAShellUpperX",       "ObjectAShellLowerX",
+        "ObjectACubeUpperZ",        "ObjectACubeLowerZ",
+        "ObjectACubeUpperY",        "ObjectACubeLowerY",
+        "ObjectACubeUpperX",        "ObjectACubeLowerX",
+        "ObjectBShellUpperZ",       "ObjectBShellLowerZ",
+        "ObjectBShellUpperY",       "ObjectBShellLowerY",
+        "ObjectBShellUpperX",       "ObjectBShellLowerX",
+        "ObjectBCubeUpperZ",        "ObjectBCubeLowerZ",
+        "ObjectBCubeUpperY",        "ObjectBCubeLowerY",
+        "ObjectBCubeUpperX",        "ObjectBCubeLowerX",
+        "EnvelopingCubeUpperZLeft", "EnvelopingCubeUpperZRight",
+        "EnvelopingCubeLowerZLeft", "EnvelopingCubeLowerZRight",
+        "EnvelopingCubeUpperYLeft", "EnvelopingCubeUpperYRight",
+        "EnvelopingCubeLowerYLeft", "EnvelopingCubeLowerYRight",
+        "EnvelopingCubeUpperX",     "EnvelopingCubeLowerX",
+        "CubedShellUpperZLeft",     "CubedShellUpperZRight",
+        "CubedShellLowerZLeft",     "CubedShellLowerZRight",
+        "CubedShellUpperYLeft",     "CubedShellUpperYRight",
+        "CubedShellLowerYLeft",     "CubedShellLowerYRight",
+        "CubedShellUpperX",         "CubedShellLowerX",
+        "OuterShellUpperZLeft",     "OuterShellUpperZRight",
+        "OuterShellLowerZLeft",     "OuterShellLowerZRight",
+        "OuterShellUpperYLeft",     "OuterShellUpperYRight",
+        "OuterShellLowerYLeft",     "OuterShellLowerYRight",
+        "OuterShellUpperX",         "OuterShellLowerX"};
+    std::unordered_map<std::string, std::unordered_set<std::string>>
+        expected_block_groups{
+            {"ObjectAShell",
+             {"ObjectAShellLowerZ", "ObjectAShellUpperX", "ObjectAShellLowerX",
+              "ObjectAShellUpperY", "ObjectAShellUpperZ",
+              "ObjectAShellLowerY"}},
+            {"ObjectBShell",
+             {"ObjectBShellLowerZ", "ObjectBShellUpperX", "ObjectBShellLowerX",
+              "ObjectBShellUpperY", "ObjectBShellUpperZ",
+              "ObjectBShellLowerY"}},
+            {"ObjectACube",
+             {"ObjectACubeLowerY", "ObjectACubeLowerZ", "ObjectACubeUpperY",
+              "ObjectACubeUpperX", "ObjectACubeUpperZ", "ObjectACubeLowerX"}},
+            {"ObjectBCube",
+             {"ObjectBCubeLowerY", "ObjectBCubeLowerZ", "ObjectBCubeUpperY",
+              "ObjectBCubeUpperX", "ObjectBCubeUpperZ", "ObjectBCubeLowerX"}},
+            {"EnvelopingCube",
+             {"EnvelopingCubeUpperZRight", "EnvelopingCubeUpperX",
               "EnvelopingCubeLowerZLeft", "EnvelopingCubeLowerZRight",
-              "EnvelopingCubeUpperYLeft", "EnvelopingCubeUpperYRight",
-              "EnvelopingCubeLowerYLeft", "EnvelopingCubeLowerYRight",
-              "EnvelopingCubeUpperX",     "EnvelopingCubeLowerX",
-              "CubedShellUpperZLeft",     "CubedShellUpperZRight",
-              "CubedShellLowerZLeft",     "CubedShellLowerZRight",
-              "CubedShellUpperYLeft",     "CubedShellUpperYRight",
-              "CubedShellLowerYLeft",     "CubedShellLowerYRight",
-              "CubedShellUpperX",         "CubedShellLowerX",
-              "OuterShellUpperZLeft",     "OuterShellUpperZRight",
-              "OuterShellLowerZLeft",     "OuterShellLowerZRight",
-              "OuterShellUpperYLeft",     "OuterShellUpperYRight",
-              "OuterShellLowerYLeft",     "OuterShellLowerYRight",
-              "OuterShellUpperX",         "OuterShellLowerX"};
-          std::unordered_map<std::string, std::unordered_set<std::string>>
-              expected_block_groups{
-                  {"ObjectAShell",
-                   {"ObjectAShellLowerZ", "ObjectAShellUpperX",
-                    "ObjectAShellLowerX", "ObjectAShellUpperY",
-                    "ObjectAShellUpperZ", "ObjectAShellLowerY"}},
-                  {"ObjectBShell",
-                   {"ObjectBShellLowerZ", "ObjectBShellUpperX",
-                    "ObjectBShellLowerX", "ObjectBShellUpperY",
-                    "ObjectBShellUpperZ", "ObjectBShellLowerY"}},
-                  {"ObjectACube",
-                   {"ObjectACubeLowerY", "ObjectACubeLowerZ",
-                    "ObjectACubeUpperY", "ObjectACubeUpperX",
-                    "ObjectACubeUpperZ", "ObjectACubeLowerX"}},
-                  {"ObjectBCube",
-                   {"ObjectBCubeLowerY", "ObjectBCubeLowerZ",
-                    "ObjectBCubeUpperY", "ObjectBCubeUpperX",
-                    "ObjectBCubeUpperZ", "ObjectBCubeLowerX"}},
-                  {"EnvelopingCube",
-                   {"EnvelopingCubeUpperZRight", "EnvelopingCubeUpperX",
-                    "EnvelopingCubeLowerZLeft", "EnvelopingCubeLowerZRight",
-                    "EnvelopingCubeUpperYRight", "EnvelopingCubeLowerYRight",
-                    "EnvelopingCubeUpperYLeft", "EnvelopingCubeUpperZLeft",
-                    "EnvelopingCubeLowerYLeft", "EnvelopingCubeLowerX"}},
-                  {"CubedShell",
-                   {"CubedShellUpperZLeft", "CubedShellUpperZRight",
-                    "CubedShellLowerZLeft", "CubedShellLowerZRight",
-                    "CubedShellUpperYLeft", "CubedShellUpperYRight",
-                    "CubedShellLowerYLeft", "CubedShellLowerYRight",
-                    "CubedShellUpperX", "CubedShellLowerX"}},
-                  {"OuterShell",
-                   {"OuterShellUpperZLeft", "OuterShellUpperZRight",
-                    "OuterShellLowerZLeft", "OuterShellLowerZRight",
-                    "OuterShellUpperYLeft", "OuterShellUpperYRight",
-                    "OuterShellLowerYLeft", "OuterShellLowerYRight",
-                    "OuterShellUpperX", "OuterShellLowerX"}}};
-          if (not excise_interiorA) {
-            expected_block_names.emplace_back("ObjectAInterior");
-          }
-          if (not excise_interiorB) {
-            expected_block_names.emplace_back("ObjectBInterior");
-          }
-          CHECK(binary_compact_object.block_names() == expected_block_names);
-          CHECK(binary_compact_object.block_groups() == expected_block_groups);
-          std::unordered_map<std::string, ExcisionSphere<3>>
-              expected_excision_spheres{};
-          if (excise_interiorA) {
-            expected_excision_spheres.emplace(
-                "ObjectAExcisionSphere",
-                ExcisionSphere<3>{inner_radius_objectA,
-                                  {{xcoord_objectA, 0.0, 0.0}},
-                                  {{0, Direction<3>::lower_zeta()},
-                                   {1, Direction<3>::lower_zeta()},
-                                   {2, Direction<3>::lower_zeta()},
-                                   {3, Direction<3>::lower_zeta()},
-                                   {4, Direction<3>::lower_zeta()},
-                                   {5, Direction<3>::lower_zeta()}}});
-          }
-          if (excise_interiorB) {
-            expected_excision_spheres.emplace(
-                "ObjectBExcisionSphere",
-                ExcisionSphere<3>{inner_radius_objectB,
-                                  {{xcoord_objectB, 0.0, 0.0}},
-                                  {{12, Direction<3>::lower_zeta()},
-                                   {13, Direction<3>::lower_zeta()},
-                                   {14, Direction<3>::lower_zeta()},
-                                   {15, Direction<3>::lower_zeta()},
-                                   {16, Direction<3>::lower_zeta()},
-                                   {17, Direction<3>::lower_zeta()}}});
-          }
-          CHECK(domain.excision_spheres() == expected_excision_spheres);
+              "EnvelopingCubeUpperYRight", "EnvelopingCubeLowerYRight",
+              "EnvelopingCubeUpperYLeft", "EnvelopingCubeUpperZLeft",
+              "EnvelopingCubeLowerYLeft", "EnvelopingCubeLowerX"}},
+            {"CubedShell",
+             {"CubedShellUpperZLeft", "CubedShellUpperZRight",
+              "CubedShellLowerZLeft", "CubedShellLowerZRight",
+              "CubedShellUpperYLeft", "CubedShellUpperYRight",
+              "CubedShellLowerYLeft", "CubedShellLowerYRight",
+              "CubedShellUpperX", "CubedShellLowerX"}},
+            {"OuterShell",
+             {"OuterShellUpperZLeft", "OuterShellUpperZRight",
+              "OuterShellLowerZLeft", "OuterShellLowerZRight",
+              "OuterShellUpperYLeft", "OuterShellUpperYRight",
+              "OuterShellLowerYLeft", "OuterShellLowerYRight",
+              "OuterShellUpperX", "OuterShellLowerX"}}};
+    if (not excise_interiorA) {
+      expected_block_names.emplace_back("ObjectAInterior");
+    }
+    if (not excise_interiorB) {
+      expected_block_names.emplace_back("ObjectBInterior");
+    }
+    CHECK(binary_compact_object.block_names() == expected_block_names);
+    CHECK(binary_compact_object.block_groups() == expected_block_groups);
+    std::unordered_map<std::string, ExcisionSphere<3>>
+        expected_excision_spheres{};
+    if (excise_interiorA) {
+      expected_excision_spheres.emplace(
+          "ObjectAExcisionSphere",
+          ExcisionSphere<3>{inner_radius_objectA,
+                            {{xcoord_objectA, 0.0, 0.0}},
+                            {{0, Direction<3>::lower_zeta()},
+                             {1, Direction<3>::lower_zeta()},
+                             {2, Direction<3>::lower_zeta()},
+                             {3, Direction<3>::lower_zeta()},
+                             {4, Direction<3>::lower_zeta()},
+                             {5, Direction<3>::lower_zeta()}}});
+    }
+    if (excise_interiorB) {
+      expected_excision_spheres.emplace(
+          "ObjectBExcisionSphere",
+          ExcisionSphere<3>{inner_radius_objectB,
+                            {{xcoord_objectB, 0.0, 0.0}},
+                            {{12, Direction<3>::lower_zeta()},
+                             {13, Direction<3>::lower_zeta()},
+                             {14, Direction<3>::lower_zeta()},
+                             {15, Direction<3>::lower_zeta()},
+                             {16, Direction<3>::lower_zeta()},
+                             {17, Direction<3>::lower_zeta()}}});
+    }
+    CHECK(domain.excision_spheres() == expected_excision_spheres);
 
-          // Also check whether the radius of the inner boundary of Layer 5 is
-          // chosen correctly.
-          // Compute the radius of a point in the grid frame on this boundary.
-          // Block 44 is one block whose -zeta face is on this boundary.
-          const auto map{domain.blocks()[44].stationary_map().get_clone()};
-          tnsr::I<double, 3, Frame::BlockLogical> logical_point(
-              std::array<double, 3>{{0.0, 0.0, -1.0}});
-          const double layer_5_inner_radius =
-              get(magnitude(std::move(map)->operator()(logical_point)));
-          // The number of radial divisions in layers 4 and 5, excluding those
-          // resulting from InitialRefinement > 0.
-          const double radial_divisions_in_outer_layers = 9;
-          if (radial_distribution_outer_shell == Distribution::Logarithmic) {
-            CHECK(layer_5_inner_radius / radius_enveloping_cube ==
-                  approx(pow(outer_radius / radius_enveloping_cube,
-                             1.0 / radial_divisions_in_outer_layers)));
-          } else if (radial_distribution_outer_shell == Distribution::Inverse) {
-            CHECK(
-                layer_5_inner_radius / radius_enveloping_cube ==
-                approx(outer_radius /
-                       (outer_radius - (outer_radius - radius_enveloping_cube) /
-                                           radial_divisions_in_outer_layers)));
-          } else {
-            CHECK(layer_5_inner_radius - radius_enveloping_cube ==
-                  approx((outer_radius - radius_enveloping_cube) /
-                         radial_divisions_in_outer_layers));
-          }
-          if (with_boundary_conditions) {
-            using PeriodicBc = TestHelpers::domain::BoundaryConditions::
-                TestPeriodicBoundaryCondition<3>;
-            CHECK_THROWS_WITH(
-                domain::creators::BinaryCompactObject(
-                    Object{inner_radius_objectA, outer_radius_objectA,
-                           xcoord_objectA,
-                           excise_interiorA
-                               ? std::make_optional(Excision{
-                                     create_inner_boundary_condition()})
-                               : std::nullopt,
-                           false},
-                    domain::creators::BinaryCompactObject::Object{
-                        inner_radius_objectB, outer_radius_objectB,
-                        xcoord_objectB,
-                        excise_interiorB
-                            ? std::make_optional(
-                                  Excision{create_inner_boundary_condition()})
-                            : std::nullopt,
-                        false},
-                    radius_enveloping_cube, outer_radius, refinement,
-                    grid_points, use_projective_map, sphericity_enveloping_cube,
-                    radius_enveloping_sphere, radial_distribution_outer_shell,
-                    std::make_unique<PeriodicBc>(),
-                    Options::Context{false, {}, 1, 1}),
-                Catch::Matchers::Contains("Cannot have periodic boundary "
-                                          "conditions with a binary domain"));
-            if (excise_interiorA or excise_interiorB) {
-              CHECK_THROWS_WITH(
-                  domain::creators::BinaryCompactObject(
-                      Object{inner_radius_objectA, outer_radius_objectA,
-                             xcoord_objectA,
-                             excise_interiorA
-                                 ? std::make_optional(
-                                       Excision{std::make_unique<PeriodicBc>()})
-                                 : std::nullopt,
-                             false},
-                      Object{inner_radius_objectB, outer_radius_objectB,
-                             xcoord_objectB,
-                             excise_interiorB
-                                 ? std::make_optional(
-                                       Excision{std::make_unique<PeriodicBc>()})
-                                 : std::nullopt,
-                             false},
-                      radius_enveloping_cube, outer_radius, refinement,
-                      grid_points, use_projective_map,
-                      sphericity_enveloping_cube, radius_enveloping_sphere,
-                      radial_distribution_outer_shell,
-                      create_outer_boundary_condition(),
-                      Options::Context{false, {}, 1, 1}),
-                  Catch::Matchers::Contains("Cannot have periodic boundary "
-                                            "conditions with a binary domain"));
-              CHECK_THROWS_WITH(
-                  domain::creators::BinaryCompactObject(
-                      Object{inner_radius_objectA, outer_radius_objectA,
-                             xcoord_objectA,
-                             excise_interiorA
-                                 ? std::make_optional(Excision{
-                                       create_inner_boundary_condition()})
-                                 : std::nullopt,
-                             false},
-                      Object{inner_radius_objectB, outer_radius_objectB,
-                             xcoord_objectB,
-                             excise_interiorB
-                                 ? std::make_optional(Excision{
-                                       create_inner_boundary_condition()})
-                                 : std::nullopt,
-                             false},
-                      radius_enveloping_cube, outer_radius, refinement,
-                      grid_points, use_projective_map,
-                      sphericity_enveloping_cube, radius_enveloping_sphere,
-                      radial_distribution_outer_shell, nullptr,
-                      Options::Context{false, {}, 1, 1}),
-                  Catch::Matchers::Contains(
-                      "Must specify either both inner and outer boundary "
-                      "conditions or neither."));
-              CHECK_THROWS_WITH(
-                  domain::creators::BinaryCompactObject(
-                      Object{inner_radius_objectA, outer_radius_objectA,
-                             xcoord_objectA,
-                             excise_interiorA
-                                 ? std::make_optional(Excision{nullptr})
-                                 : std::nullopt,
-                             false},
-                      Object{inner_radius_objectB, outer_radius_objectB,
-                             xcoord_objectB,
-                             excise_interiorB
-                                 ? std::make_optional(Excision{nullptr})
-                                 : std::nullopt,
-                             false},
-                      radius_enveloping_cube, outer_radius, refinement,
-                      grid_points, use_projective_map,
-                      sphericity_enveloping_cube, radius_enveloping_sphere,
-                      radial_distribution_outer_shell,
-                      create_outer_boundary_condition(),
-                      Options::Context{false, {}, 1, 1}),
-                  Catch::Matchers::Contains(
-                      "Must specify either both inner and outer boundary "
-                      "conditions or neither."));
-            }
-          }
-        }
+    // Also check whether the radius of the inner boundary of Layer 5 is
+    // chosen correctly.
+    // Compute the radius of a point in the grid frame on this boundary.
+    // Block 44 is one block whose -zeta face is on this boundary.
+    const auto map{domain.blocks()[44].stationary_map().get_clone()};
+    tnsr::I<double, 3, Frame::BlockLogical> logical_point(
+        std::array<double, 3>{{0.0, 0.0, -1.0}});
+    const double layer_5_inner_radius =
+        get(magnitude(std::move(map)->operator()(logical_point)));
+    // The number of radial divisions in layers 4 and 5, excluding those
+    // resulting from InitialRefinement > 0.
+    const double radial_divisions_in_outer_layers = 9;
+    if (radial_distribution_outer_shell == Distribution::Logarithmic) {
+      CHECK(layer_5_inner_radius / radius_enveloping_cube ==
+            approx(pow(outer_radius / radius_enveloping_cube,
+                       1.0 / radial_divisions_in_outer_layers)));
+    } else if (radial_distribution_outer_shell == Distribution::Inverse) {
+      CHECK(layer_5_inner_radius / radius_enveloping_cube ==
+            approx(outer_radius /
+                   (outer_radius - (outer_radius - radius_enveloping_cube) /
+                                       radial_divisions_in_outer_layers)));
+    } else {
+      CHECK(layer_5_inner_radius - radius_enveloping_cube ==
+            approx((outer_radius - radius_enveloping_cube) /
+                   radial_divisions_in_outer_layers));
+    }
+    if (with_boundary_conditions) {
+      using PeriodicBc = TestHelpers::domain::BoundaryConditions::
+          TestPeriodicBoundaryCondition<3>;
+      CHECK_THROWS_WITH(
+          domain::creators::BinaryCompactObject(
+              Object{inner_radius_objectA, outer_radius_objectA, xcoord_objectA,
+                     excise_interiorA ? std::make_optional(Excision{
+                                            create_inner_boundary_condition()})
+                                      : std::nullopt,
+                     false},
+              domain::creators::BinaryCompactObject::Object{
+                  inner_radius_objectB, outer_radius_objectB, xcoord_objectB,
+                  excise_interiorB ? std::make_optional(Excision{
+                                         create_inner_boundary_condition()})
+                                   : std::nullopt,
+                  false},
+              radius_enveloping_cube, outer_radius, refinement, grid_points,
+              use_equiangular_map, use_projective_map,
+              sphericity_enveloping_cube, radius_enveloping_sphere,
+              radial_distribution_outer_shell, std::make_unique<PeriodicBc>(),
+              Options::Context{false, {}, 1, 1}),
+          Catch::Matchers::Contains("Cannot have periodic boundary "
+                                    "conditions with a binary domain"));
+      if (excise_interiorA or excise_interiorB) {
+        CHECK_THROWS_WITH(
+            domain::creators::BinaryCompactObject(
+                Object{inner_radius_objectA, outer_radius_objectA,
+                       xcoord_objectA,
+                       excise_interiorA ? std::make_optional(Excision{
+                                              std::make_unique<PeriodicBc>()})
+                                        : std::nullopt,
+                       false},
+                Object{inner_radius_objectB, outer_radius_objectB,
+                       xcoord_objectB,
+                       excise_interiorB ? std::make_optional(Excision{
+                                              std::make_unique<PeriodicBc>()})
+                                        : std::nullopt,
+                       false},
+                radius_enveloping_cube, outer_radius, refinement, grid_points,
+                use_equiangular_map, use_projective_map,
+                sphericity_enveloping_cube, radius_enveloping_sphere,
+                radial_distribution_outer_shell,
+                create_outer_boundary_condition(),
+                Options::Context{false, {}, 1, 1}),
+            Catch::Matchers::Contains("Cannot have periodic boundary "
+                                      "conditions with a binary domain"));
+        CHECK_THROWS_WITH(
+            domain::creators::BinaryCompactObject(
+                Object{
+                    inner_radius_objectA, outer_radius_objectA, xcoord_objectA,
+                    excise_interiorA ? std::make_optional(Excision{
+                                           create_inner_boundary_condition()})
+                                     : std::nullopt,
+                    false},
+                Object{
+                    inner_radius_objectB, outer_radius_objectB, xcoord_objectB,
+                    excise_interiorB ? std::make_optional(Excision{
+                                           create_inner_boundary_condition()})
+                                     : std::nullopt,
+                    false},
+                radius_enveloping_cube, outer_radius, refinement, grid_points,
+                use_equiangular_map, use_projective_map,
+                sphericity_enveloping_cube, radius_enveloping_sphere,
+                radial_distribution_outer_shell, nullptr,
+                Options::Context{false, {}, 1, 1}),
+            Catch::Matchers::Contains(
+                "Must specify either both inner and outer boundary "
+                "conditions or neither."));
+        CHECK_THROWS_WITH(
+            domain::creators::BinaryCompactObject(
+                Object{inner_radius_objectA, outer_radius_objectA,
+                       xcoord_objectA,
+                       excise_interiorA ? std::make_optional(Excision{nullptr})
+                                        : std::nullopt,
+                       false},
+                Object{inner_radius_objectB, outer_radius_objectB,
+                       xcoord_objectB,
+                       excise_interiorB ? std::make_optional(Excision{nullptr})
+                                        : std::nullopt,
+                       false},
+                radius_enveloping_cube, outer_radius, refinement, grid_points,
+                use_equiangular_map, use_projective_map,
+                sphericity_enveloping_cube, radius_enveloping_sphere,
+                radial_distribution_outer_shell,
+                create_outer_boundary_condition(),
+                Options::Context{false, {}, 1, 1}),
+            Catch::Matchers::Contains(
+                "Must specify either both inner and outer boundary "
+                "conditions or neither."));
       }
     }
   }
@@ -402,6 +388,7 @@ std::string stringize(const bool t) { return t ? "true" : "false"; }
 std::string create_option_string(const bool excise_A, const bool excise_B,
                                  const bool add_time_dependence,
                                  const bool use_logarithmic_map_AB,
+                                 const bool use_equiangular_map,
                                  const size_t additional_refinement_outer,
                                  const size_t additional_refinement_A,
                                  const size_t additional_refinement_B,
@@ -486,8 +473,9 @@ std::string create_option_string(const bool excise_A, const bool excise_B,
          "    OuterShell: [1, 1, " +
          std::to_string(1 + additional_refinement_outer) +
          "]\n"
-         "  InitialGridPoints: 3\n" +
-         time_dependence;
+         "  InitialGridPoints: 3\n"
+         "  UseEquiangularMap: " +
+         stringize(use_equiangular_map) + "\n" + time_dependence;
 }
 
 void test_bbh_time_dependent_factory(const bool with_boundary_conditions,
@@ -499,12 +487,12 @@ void test_bbh_time_dependent_factory(const bool with_boundary_conditions,
     if (with_boundary_conditions) {
       return TestHelpers::test_option_tag<domain::OptionTags::DomainCreator<3>,
                                           Metavariables<3, true, true>>(
-          create_option_string(true, true, true, false, 0, 0, 0,
+          create_option_string(true, true, true, false, true, 0, 0, 0,
                                with_boundary_conditions));
     } else {
       return TestHelpers::test_option_tag<domain::OptionTags::DomainCreator<3>,
                                           Metavariables<3, true, false>>(
-          create_option_string(true, true, true, false, 0, 0, 0,
+          create_option_string(true, true, true, false, true, 0, 0, 0,
                                with_boundary_conditions));
     }
   }();
@@ -635,22 +623,22 @@ void test_binary_factory() {
         *binary_compact_object, with_boundary_conditions);
   };
   for (const bool with_boundary_conds : {true, false}) {
-    check_impl(create_option_string(true, true, false, false, 2, 0, 2,
+    check_impl(create_option_string(true, true, false, false, true, 2, 0, 2,
                                     with_boundary_conds),
                with_boundary_conds);
-    check_impl(create_option_string(true, true, false, true, 3, 3, 0,
+    check_impl(create_option_string(true, true, false, true, true, 3, 3, 0,
                                     with_boundary_conds),
                with_boundary_conds);
-    check_impl(create_option_string(true, true, false, false, 0, 0, 0,
+    check_impl(create_option_string(true, true, false, false, true, 0, 0, 0,
                                     with_boundary_conds),
                with_boundary_conds);
-    check_impl(create_option_string(false, false, false, false, 0, 0, 0,
+    check_impl(create_option_string(false, false, false, false, true, 0, 0, 0,
                                     with_boundary_conds),
                with_boundary_conds);
-    check_impl(create_option_string(true, false, false, false, 0, 0, 0,
+    check_impl(create_option_string(true, false, false, false, true, 0, 0, 0,
                                     with_boundary_conds),
                with_boundary_conds);
-    check_impl(create_option_string(false, true, false, false, 0, 0, 0,
+    check_impl(create_option_string(false, true, false, false, true, 0, 0, 0,
                                     with_boundary_conds),
                with_boundary_conds);
   }
@@ -661,7 +649,7 @@ void test_parse_errors() {
       domain::creators::BinaryCompactObject(
           {0.5, 1.0, -1.0, {{create_inner_boundary_condition()}}, false},
           {0.3, 1.0, -1.0, {{create_inner_boundary_condition()}}, false}, 25.5,
-          32.4, 2_st, 6_st, true, 0.0, std::nullopt, Distribution::Linear,
+          32.4, 2_st, 6_st, true, true, 0.0, std::nullopt, Distribution::Linear,
           create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
       Catch::Matchers::Contains(
           "The x-coordinate of ObjectA's center is expected to be positive."));
@@ -669,7 +657,7 @@ void test_parse_errors() {
       domain::creators::BinaryCompactObject(
           {0.5, 1.0, 1.0, {{create_inner_boundary_condition()}}, false},
           {0.3, 1.0, 1.0, {{create_inner_boundary_condition()}}, false}, 25.5,
-          32.4, 2_st, 6_st, true, 0.0, std::nullopt, Distribution::Linear,
+          32.4, 2_st, 6_st, true, true, 0.0, std::nullopt, Distribution::Linear,
           create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
       Catch::Matchers::Contains(
           "The x-coordinate of ObjectB's center is expected to be negative."));
@@ -677,7 +665,7 @@ void test_parse_errors() {
       domain::creators::BinaryCompactObject(
           {0.3, 1.0, 8.0, {{create_inner_boundary_condition()}}, false},
           {0.5, 1.0, -7.0, {{create_inner_boundary_condition()}}, false}, 25.5,
-          32.4, 2_st, 6_st, true, 0.0, std::nullopt, Distribution::Linear,
+          32.4, 2_st, 6_st, true, true, 0.0, std::nullopt, Distribution::Linear,
           create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
       Catch::Matchers::Contains("The radius for the enveloping cube is too "
                                 "small! The Frustums will be malformed."));
@@ -685,7 +673,7 @@ void test_parse_errors() {
       domain::creators::BinaryCompactObject(
           {0.3, 1.0, 1.0, {{create_inner_boundary_condition()}}, false},
           {1.5, 1.0, -1.0, {{create_inner_boundary_condition()}}, false}, 25.5,
-          32.4, 2_st, 6_st, true, 0.0, std::nullopt, Distribution::Linear,
+          32.4, 2_st, 6_st, true, true, 0.0, std::nullopt, Distribution::Linear,
           create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
       Catch::Matchers::Contains(
           "ObjectB's inner radius must be less than its outer radius."));
@@ -693,7 +681,7 @@ void test_parse_errors() {
       domain::creators::BinaryCompactObject(
           {3.3, 1.0, 1.0, {{create_inner_boundary_condition()}}, false},
           {0.5, 1.0, -1.0, {{create_inner_boundary_condition()}}, false}, 25.5,
-          32.4, 2_st, 6_st, true, 0.0, std::nullopt, Distribution::Linear,
+          32.4, 2_st, 6_st, true, true, 0.0, std::nullopt, Distribution::Linear,
           create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
       Catch::Matchers::Contains(
           "ObjectA's inner radius must be less than its outer radius."));
@@ -701,7 +689,7 @@ void test_parse_errors() {
       domain::creators::BinaryCompactObject(
           {0.3, 1.0, 1.0, {{create_inner_boundary_condition()}}, false},
           {0.5, 1.0, -1.0, std::nullopt, true}, 25.5, 32.4, 2_st, 6_st, true,
-          0.0, std::nullopt, Distribution::Linear,
+          true, 0.0, std::nullopt, Distribution::Linear,
           create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
       Catch::Matchers::Contains(
           "Using a logarithmically spaced radial grid in the "
@@ -711,7 +699,7 @@ void test_parse_errors() {
       domain::creators::BinaryCompactObject(
           {0.3, 1.0, 1.0, std::nullopt, true},
           {0.5, 1.0, -1.0, {{create_inner_boundary_condition()}}, false}, 25.5,
-          32.4, 2_st, 6_st, true, 0.0, std::nullopt, Distribution::Linear,
+          32.4, 2_st, 6_st, true, true, 0.0, std::nullopt, Distribution::Linear,
           create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
       Catch::Matchers::Contains(
           "Using a logarithmically spaced radial grid in the "
@@ -721,7 +709,7 @@ void test_parse_errors() {
       domain::creators::BinaryCompactObject(
           {0.3, 1.0, 1.0, {{create_inner_boundary_condition()}}, false},
           {0.5, 1.0, -1.0, {{create_inner_boundary_condition()}}, false}, 25.5,
-          32.4, std::vector<std::array<size_t, 3>>{}, 6_st, true, 0.0,
+          32.4, std::vector<std::array<size_t, 3>>{}, 6_st, true, true, 0.0,
           std::nullopt, Distribution::Linear, create_outer_boundary_condition(),
           Options::Context{false, {}, 1, 1}),
       Catch::Matchers::Contains("Invalid 'InitialRefinement'"));
@@ -729,7 +717,7 @@ void test_parse_errors() {
       domain::creators::BinaryCompactObject(
           {0.3, 1.0, 1.0, {{create_inner_boundary_condition()}}, false},
           {0.5, 1.0, -1.0, {{create_inner_boundary_condition()}}, false}, 25.5,
-          32.4, 2_st, std::vector<std::array<size_t, 3>>{}, true, 0.0,
+          32.4, 2_st, std::vector<std::array<size_t, 3>>{}, true, true, 0.0,
           std::nullopt, Distribution::Linear, create_outer_boundary_condition(),
           Options::Context{false, {}, 1, 1}),
       Catch::Matchers::Contains("Invalid 'InitialGridPoints'"));
@@ -737,7 +725,7 @@ void test_parse_errors() {
       domain::creators::BinaryCompactObject(
           {0.3, 1.0, 1.0, {{create_inner_boundary_condition()}}, false},
           {0.5, 1.0, -1.0, {{create_inner_boundary_condition()}}, false}, 25.5,
-          32.4, 2_st, 6_st, true, 0.0, 35., Distribution::Linear,
+          32.4, 2_st, 6_st, true, true, 0.0, 35., Distribution::Linear,
           create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
       Catch::Matchers::Contains("The 'OuterShell.InnerRadius' must be within"));
   // Note: the boundary condition-related parse errors are checked in the

--- a/tests/Unit/Domain/Test_DomainHelpers.cpp
+++ b/tests/Unit/Domain/Test_DomainHelpers.cpp
@@ -374,6 +374,7 @@ void test_all_frustum_directions() {
       origin_preimage);
 
   const double projective_scale_factor = 0.3;
+  const double sphericity = 0.;
   for (const bool use_equiangular_map : {true, false}) {
     const auto expected_coord_maps = make_vector(
         FrustumMap{
@@ -385,7 +386,10 @@ void test_all_frustum_directions() {
             top,
             OrientationMap<3>{},
             use_equiangular_map,
-            projective_scale_factor},
+            projective_scale_factor,
+            false,
+            sphericity,
+            -1.},
         FrustumMap{
             {{{{-displacement2[0], -lower - displacement2[1]}},
               {{2.0 * lower - displacement2[0], lower - displacement2[1]}},
@@ -395,7 +399,10 @@ void test_all_frustum_directions() {
             top,
             OrientationMap<3>{},
             use_equiangular_map,
-            projective_scale_factor},
+            projective_scale_factor,
+            false,
+            sphericity,
+            1.},
         FrustumMap{
             {{{{-2.0 * lower - displacement3[0], -lower - displacement3[1]}},
               {{-displacement3[0], lower - displacement3[1]}},
@@ -407,7 +414,10 @@ void test_all_frustum_directions() {
                 {Direction<3>::upper_xi(), Direction<3>::lower_eta(),
                  Direction<3>::lower_zeta()}}},
             use_equiangular_map,
-            projective_scale_factor},
+            projective_scale_factor,
+            false,
+            sphericity,
+            -1.},
         FrustumMap{
             {{{{-displacement4[0], -lower - displacement4[1]}},
               {{2.0 * lower - displacement4[0], lower - displacement4[1]}},
@@ -419,7 +429,10 @@ void test_all_frustum_directions() {
                 {Direction<3>::upper_xi(), Direction<3>::lower_eta(),
                  Direction<3>::lower_zeta()}}},
             use_equiangular_map,
-            projective_scale_factor},
+            projective_scale_factor,
+            false,
+            sphericity,
+            1.},
         FrustumMap{
             {{{{-2.0 * lower - displacement5[0], -lower - displacement5[1]}},
               {{-displacement5[0], lower - displacement5[1]}},
@@ -431,7 +444,10 @@ void test_all_frustum_directions() {
                 {Direction<3>::upper_xi(), Direction<3>::upper_zeta(),
                  Direction<3>::lower_eta()}}},
             use_equiangular_map,
-            projective_scale_factor},
+            projective_scale_factor,
+            false,
+            sphericity,
+            -1.},
         FrustumMap{
             {{{{-displacement6[0], -lower - displacement6[1]}},
               {{2.0 * lower - displacement6[0], lower - displacement6[1]}},
@@ -443,7 +459,10 @@ void test_all_frustum_directions() {
                 {Direction<3>::upper_xi(), Direction<3>::upper_zeta(),
                  Direction<3>::lower_eta()}}},
             use_equiangular_map,
-            projective_scale_factor},
+            projective_scale_factor,
+            false,
+            sphericity,
+            1.},
         FrustumMap{
             {{{{-2.0 * lower - displacement7[0], -lower - displacement7[1]}},
               {{-displacement7[0], lower - displacement7[1]}},
@@ -455,7 +474,10 @@ void test_all_frustum_directions() {
                 {Direction<3>::upper_xi(), Direction<3>::lower_zeta(),
                  Direction<3>::upper_eta()}}},
             use_equiangular_map,
-            projective_scale_factor},
+            projective_scale_factor,
+            false,
+            sphericity,
+            -1.},
         FrustumMap{
             {{{{-displacement8[0], -lower - displacement8[1]}},
               {{2.0 * lower - displacement8[0], lower - displacement8[1]}},
@@ -467,7 +489,10 @@ void test_all_frustum_directions() {
                 {Direction<3>::upper_xi(), Direction<3>::lower_zeta(),
                  Direction<3>::upper_eta()}}},
             use_equiangular_map,
-            projective_scale_factor},
+            projective_scale_factor,
+            false,
+            sphericity,
+            1.},
         // Frustum on right half in the +x direction
         FrustumMap{{{{{-lower - displacement9[0], -lower - displacement9[1]}},
                      {{lower - displacement9[0], lower - displacement9[1]}},

--- a/tests/Unit/IO/Importers/Test_VolumeDataReaderAlgorithm3D.yaml
+++ b/tests/Unit/IO/Importers/Test_VolumeDataReaderAlgorithm3D.yaml
@@ -23,6 +23,7 @@ SourceDomainCreator:
       InnerRadius: Auto
       OuterRadius: 350.
       RadialDistribution: Inverse
+    UseEquiangularMap: True
     InitialRefinement: 1
     InitialGridPoints: 7
 
@@ -48,6 +49,7 @@ TargetDomainCreator:
       InnerRadius: Auto
       OuterRadius: 300.
       RadialDistribution: Linear
+    UseEquiangularMap: True
     InitialRefinement: 0
     InitialGridPoints: 3
 

--- a/tests/Unit/Utilities/CMakeLists.txt
+++ b/tests/Unit/Utilities/CMakeLists.txt
@@ -9,6 +9,7 @@ set(LIBRARY_SOURCES
   Test_Blas.cpp
   Test_CachedFunction.cpp
   Test_CallWithDynamicType.cpp
+  Test_CartesianProduct.cpp
   Test_CleanupRoutine.cpp
   Test_CloneUniquePtrs.cpp
   Test_ConstantExpressions.cpp

--- a/tests/Unit/Utilities/Test_CartesianProduct.cpp
+++ b/tests/Unit/Utilities/Test_CartesianProduct.cpp
@@ -1,0 +1,20 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <tuple>
+
+#include "Utilities/CartesianProduct.hpp"
+#include "Utilities/MakeArray.hpp"
+
+SPECTRE_TEST_CASE("Unit.Utilities.CartesianProduct", "[Unit][Utilities]") {
+  {
+    const auto result =
+        cartesian_product(make_array(true, false), make_array(1, 2, 3));
+    const std::array<std::tuple<bool, int>, 6> expected{
+        {{true, 1}, {true, 2}, {true, 3}, {false, 1}, {false, 2}, {false, 3}}};
+    CHECK(result == expected);
+  }
+}


### PR DESCRIPTION
## Proposed changes

Another step towards #3545.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
In input files using the `BinaryCompactObject` domain creator, add the `UseEquiangularMap: True` option.
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
