### PR TITLE
Only use charm built with gcc on CI

### DIFF
--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -225,7 +225,7 @@ jobs:
           -D CMAKE_C_COMPILER=clang
           -D CMAKE_CXX_COMPILER=clang++
           -D CMAKE_Fortran_COMPILER=gfortran-9
-          -D CHARM_ROOT=/work/charm_7_0_0/multicore-linux-x86_64-clang
+          -D CHARM_ROOT=${CHARM_ROOT}
           -D CMAKE_BUILD_TYPE=${{ matrix.build_type }}
           -D OVERRIDE_ARCH=x86-64
           -D USE_CCACHE=OFF
@@ -266,7 +266,7 @@ jobs:
           -D CMAKE_C_COMPILER=clang
           -D CMAKE_CXX_COMPILER=clang++
           -D CMAKE_Fortran_COMPILER=gfortran-9
-          -D CHARM_ROOT=/work/charm_7_0_0/multicore-linux-x86_64-clang
+          -D CHARM_ROOT=${CHARM_ROOT}
           -D CMAKE_BUILD_TYPE=Debug
           -D DEBUG_SYMBOLS=OFF
           -D BUILD_PYTHON_BINDINGS=ON
@@ -454,7 +454,6 @@ ${{ env.CACHE_KEY_SUFFIX }}"
 
           if [[ ${{ matrix.compiler }} =~ (gcc|clang)-([0-9\.]+) ]]; then
             CC=${BASH_REMATCH[1]}-${BASH_REMATCH[2]};
-            CHARM_CC=${BASH_REMATCH[1]};
             if [[ ${BASH_REMATCH[1]} = gcc ]]; then
               CXX=g++-${BASH_REMATCH[2]};
               FC=gfortran-${BASH_REMATCH[2]};
@@ -468,8 +467,6 @@ ${{ env.CACHE_KEY_SUFFIX }}"
           BUILD_SHARED_LIBS=${{ matrix.BUILD_SHARED_LIBS }}
           PYTHON_EXECUTABLE=${{ matrix.PYTHON_EXECUTABLE }}
           CMAKE_EXECUTABLE=${{ matrix.CMAKE_EXECUTABLE }}
-          CHARM_DIR_DEFAULT=/work/charm_7_0_0/multicore-linux-x86_64-
-          CHARM_DIR=${{ matrix.CHARM_DIR }}
           ASAN=${{ matrix.ASAN }}
           MEMORY_ALLOCATOR=${{ matrix.MEMORY_ALLOCATOR }}
           UBSAN_UNDEFINED=${{ matrix.UBSAN_UNDEFINED }}
@@ -485,7 +482,7 @@ ${{ env.CACHE_KEY_SUFFIX }}"
           -D CMAKE_Fortran_COMPILER=${FC}
           -D CMAKE_CXX_FLAGS="${CXXFLAGS} ${{ matrix.EXTRA_CXX_FLAGS }}"
           -D OVERRIDE_ARCH=x86-64
-          -D CHARM_ROOT=${CHARM_DIR:-${CHARM_DIR_DEFAULT}}${CHARM_CC}
+          -D CHARM_ROOT=${CHARM_ROOT}
           -D CMAKE_BUILD_TYPE=${{ matrix.build_type }}
           -D DEBUG_SYMBOLS=OFF
           -D UNIT_TESTS_IN_TEST_EXECUTABLES=OFF
@@ -620,7 +617,6 @@ ${{ env.CACHE_KEY_SUFFIX }}"
 
           if [[ ${{ matrix.compiler }} =~ (gcc|clang)-([0-9\.]+) ]]; then
             CC=${BASH_REMATCH[1]}-${BASH_REMATCH[2]};
-            CHARM_CC=${BASH_REMATCH[1]};
             if [[ ${BASH_REMATCH[1]} = gcc ]]; then
               CXX=g++-${BASH_REMATCH[2]};
               FC=gfortran-${BASH_REMATCH[2]};
@@ -640,7 +636,7 @@ ${{ env.CACHE_KEY_SUFFIX }}"
           -D CMAKE_CXX_FLAGS="${CXXFLAGS} ${{ matrix.EXTRA_CXX_FLAGS }}"
           -D OVERRIDE_ARCH=x86-64
           -D BUILD_SHARED_LIBS=ON
-          -D CHARM_ROOT=/work/charm_7_0_0/multicore-linux-x86_64-${CHARM_CC}
+          -D CHARM_ROOT=${CHARM_ROOT}
           -D CMAKE_BUILD_TYPE=${{ matrix.build_type }}
           -D DEBUG_SYMBOLS=OFF
           -D UNIT_TESTS_IN_TEST_EXECUTABLES=OFF
@@ -1030,7 +1026,6 @@ ${{ env.CACHE_KEY_SUFFIX }}"
             mkdir $BUILD_DIR && cd $BUILD_DIR
             if [[ ${{ matrix.compiler }} =~ (gcc|clang)-([0-9\.]+) ]]; then
               CC=${BASH_REMATCH[1]}-${BASH_REMATCH[2]};
-              CHARM_CC=${BASH_REMATCH[1]};
               if [[ ${BASH_REMATCH[1]} = gcc ]]; then
                 CXX=g++-${BASH_REMATCH[2]};
                 FC=gfortran-${BASH_REMATCH[2]};
@@ -1046,7 +1041,7 @@ ${{ env.CACHE_KEY_SUFFIX }}"
             -D CMAKE_Fortran_COMPILER=${FC}\
             -D CMAKE_CXX_FLAGS="${CXXFLAGS}"\
             -D OVERRIDE_ARCH=${OVERRIDE_ARCH}\
-            -D CHARM_ROOT=/work/charm_7_0_0/multicore-linux-x86_64-${CHARM_CC}\
+            -D CHARM_ROOT=${CHARM_ROOT}\
             -D CMAKE_BUILD_TYPE=Debug\
             -D DEBUG_SYMBOLS=OFF\
             -D STRIP_SYMBOLS=ON\


### PR DESCRIPTION
On both local and Wheeler, I've been using charm built with gcc but SpECTRE built with clang and I've had no issues

## Proposed changes

Separated from #4673 so we don't interrupt CI when we update the docker container.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
