### PR TITLE
Fix warnings from GNU grep 3.8

### DIFF
--- a/tools/CheckFiles.sh
+++ b/tools/CheckFiles.sh
@@ -17,7 +17,8 @@ staged_grep() {
     grep "$@";
 }
 pretty_grep() {
-    GREP_COLOR='1;37;41' grep --with-filename -n $color_option "$@"
+    GREP_COLOR='1;37;41' GREP_COLORS='mt=1;37;41' \
+        grep --with-filename -n $color_option "$@"
 }
 
 ##### CI checks #####

--- a/tools/FileTestDefs.sh
+++ b/tools/FileTestDefs.sh
@@ -82,7 +82,8 @@ pretty_grep() {
             file_prefix=${file}:
         fi
         git show ":./${file}" | \
-            GREP_COLOR='1;37;41' grep -n $color "${non_file_args[@]}" | \
+            GREP_COLOR='1;37;41' GREP_COLORS='mt=1;37;41' \
+            grep -n $color "${non_file_args[@]}" | \
             sed "s|^|${file_prefix}|"
     done
 }
@@ -483,11 +484,11 @@ standard_checks+=(catch_approx)
 
 # Check for Doxygen comments on the same line as a /*!
 doxygen_start_line() {
-    is_c++ "$1" && staged_grep -q '/\*\![^\n]' "$1"
+    is_c++ "$1" && staged_grep -q '/\*![^\n]' "$1"
 }
 doxygen_start_line_report() {
     echo "Found occurrences of bad Doxygen syntax: /*! STUFF:"
-    pretty_grep -E '\/\*\!.*' "$@"
+    pretty_grep -E '\/\*!.*' "$@"
 }
 doxygen_start_line_test() {
     test_check pass foo.cpp ''
@@ -727,11 +728,11 @@ standard_checks+=(prevent_cpp_includes)
 # Check for Doxygen-comments in cpp files. We don't parse cpp files with
 # Doxygen, so they shouldn't contain Doxygen-formatting.
 prevent_cpp_doxygen() {
-    [[ $1 =~ \.cpp$ ]] && staged_grep -q '/// \|/\*\!' "$1"
+    [[ $1 =~ \.cpp$ ]] && staged_grep -q '/// \|/\*!' "$1"
 }
 prevent_cpp_doxygen_report() {
     echo "Found Doxygen-formatting in cpp file:"
-    pretty_grep '/// \|/\*\!' "$@"
+    pretty_grep '/// \|/\*!' "$@"
     echo "Doxygen-formatting only has an effect in header files."
     echo "Use standard C++ comments in cpp files."
 }


### PR DESCRIPTION
* ! has no special meaning, so should not be escaped.
* GREP_COLOR is now deprecated and warns unless the replacement GREP_COLORS is also defined.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
