### PR TITLE
Fix order of objects in Binary initial data

### DIFF
--- a/tests/InputFiles/Xcts/BinaryBlackHole.yaml
+++ b/tests/InputFiles/Xcts/BinaryBlackHole.yaml
@@ -12,12 +12,12 @@ ResourceInfo:
 Background: &background
   Binary:
     XCoords: [&x_left -8., &x_right 8.]
-    ObjectA: &kerr_right
+    ObjectLeft: &kerr_left
       KerrSchild:
         Mass: 0.4229
         Spin: [0., 0., 0.]
         Center: [0., 0., 0.]
-    ObjectB: &kerr_left
+    ObjectRight: &kerr_right
       KerrSchild:
         Mass: 0.4229
         Spin: [0., 0., 0.]

--- a/tests/Unit/PointwiseFunctions/AnalyticData/Xcts/Test_Binary.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/Xcts/Test_Binary.cpp
@@ -125,11 +125,11 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.AnalyticData.Xcts.Binary",
   test_data({{-5., 6.}}, 0.02, 0.01, {{7., 8.}}, {{1.1, 0.43}}, "bbh_isotropic",
             "Binary:\n"
             "  XCoords: [-5., 6.]\n"
-            "  ObjectA:\n"
+            "  ObjectLeft:\n"
             "    Schwarzschild:\n"
             "      Mass: 1.1\n"
             "      Coordinates: Isotropic\n"
-            "  ObjectB:\n"
+            "  ObjectRight:\n"
             "    Schwarzschild:\n"
             "      Mass: 0.43\n"
             "      Coordinates: Isotropic\n"


### PR DESCRIPTION
## Proposed changes

#4532 made this inconsistent. The options in the `Xcts::Binary` class are named `ObjectLeft` and `ObjectRight` now to make them unambiguous and to prevent bugs like this.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
