### PR TITLE
Add action that does consistency/sanity checks on time stepper history

### DIFF
--- a/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
+++ b/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
@@ -325,6 +325,9 @@ struct EvolutionMetavars {
               Parallel::Phase::InitializeTimeStepperHistory,
               SelfStart::self_start_procedure<step_actions, system>>,
 
+          Parallel::PhaseActions<Parallel::Phase::CheckTimeStepperHistory,
+                                 SelfStart::check_self_start_actions>,
+
           Parallel::PhaseActions<
               Parallel::Phase::Evolve,
               tmpl::list<Actions::RunEventsAndTriggers, Actions::ChangeSlabSize,
@@ -348,10 +351,11 @@ struct EvolutionMetavars {
       "The analytic solution is: Linear\n"
       "The numerical flux is:    LocalLaxFriedrichs\n"};
 
-  static constexpr std::array<Parallel::Phase, 5> default_phase_order{
+  static constexpr std::array<Parallel::Phase, 6> default_phase_order{
       {Parallel::Phase::Initialization,
        Parallel::Phase::InitializeTimeStepperHistory, Parallel::Phase::Register,
-       Parallel::Phase::Evolve, Parallel::Phase::Exit}};
+       Parallel::Phase::CheckTimeStepperHistory, Parallel::Phase::Evolve,
+       Parallel::Phase::Exit}};
 
   // NOLINTNEXTLINE(google-runtime-references)
   void pup(PUP::er& /*p*/) {}

--- a/src/Evolution/Executables/Cce/CharacteristicExtract.hpp
+++ b/src/Evolution/Executables/Cce/CharacteristicExtract.hpp
@@ -81,9 +81,10 @@ struct EvolutionMetavars : CharacteristicExtractDefaults<false> {
       "Perform Cauchy Characteristic Extraction using .h5 input data.\n"
       "Uses regularity-preserving formulation."};
 
-  static constexpr std::array<Parallel::Phase, 4> default_phase_order{
+  static constexpr std::array<Parallel::Phase, 5> default_phase_order{
       {Parallel::Phase::Initialization,
-       Parallel::Phase::InitializeTimeStepperHistory, Parallel::Phase::Evolve,
+       Parallel::Phase::InitializeTimeStepperHistory,
+       Parallel::Phase::CheckTimeStepperHistory, Parallel::Phase::Evolve,
        Parallel::Phase::Exit}};
 
   // NOLINTNEXTLINE(google-runtime-references)

--- a/src/Evolution/Executables/CurvedScalarWave/EvolveCurvedScalarWave.hpp
+++ b/src/Evolution/Executables/CurvedScalarWave/EvolveCurvedScalarWave.hpp
@@ -304,6 +304,8 @@ struct EvolutionMetavars {
           Parallel::PhaseActions<
               Parallel::Phase::InitializeTimeStepperHistory,
               SelfStart::self_start_procedure<step_actions, system>>,
+          Parallel::PhaseActions<Parallel::Phase::CheckTimeStepperHistory,
+                                 SelfStart::check_self_start_actions>,
           Parallel::PhaseActions<Parallel::Phase::Register,
                                  tmpl::list<dg_registration_list,
                                             Parallel::Actions::TerminatePhase>>,
@@ -333,10 +335,11 @@ struct EvolutionMetavars {
       "Evolve a scalar wave in Dim spatial dimension on a curved background "
       "spacetime."};
 
-  static constexpr std::array<Parallel::Phase, 5> default_phase_order{
+  static constexpr std::array<Parallel::Phase, 6> default_phase_order{
       {Parallel::Phase::Initialization,
        Parallel::Phase::InitializeTimeStepperHistory, Parallel::Phase::Register,
-       Parallel::Phase::Evolve, Parallel::Phase::Exit}};
+       Parallel::Phase::CheckTimeStepperHistory, Parallel::Phase::Evolve,
+       Parallel::Phase::Exit}};
 
   // NOLINTNEXTLINE(google-runtime-references)
   void pup(PUP::er& /*p*/) {}

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
@@ -454,13 +454,14 @@ struct EvolutionMetavars {
       tmpl::list<observers::Actions::RegisterEventsWithObservers,
                  intrp::Actions::RegisterElementWithInterpolator>;
 
-  static constexpr std::array<Parallel::Phase, 8> default_phase_order{
+  static constexpr std::array<Parallel::Phase, 9> default_phase_order{
       {Parallel::Phase::Initialization,
        Parallel::Phase::RegisterWithElementDataReader,
        Parallel::Phase::ImportInitialData,
        Parallel::Phase::InitializeInitialDataDependentQuantities,
        Parallel::Phase::Register, Parallel::Phase::InitializeTimeStepperHistory,
-       Parallel::Phase::Evolve, Parallel::Phase::Exit}};
+       Parallel::Phase::CheckTimeStepperHistory, Parallel::Phase::Evolve,
+       Parallel::Phase::Exit}};
 
   using step_actions = tmpl::list<
       evolution::dg::Actions::ComputeTimeDerivative<
@@ -532,6 +533,8 @@ struct EvolutionMetavars {
           Parallel::PhaseActions<
               Parallel::Phase::InitializeTimeStepperHistory,
               SelfStart::self_start_procedure<step_actions, system>>,
+          Parallel::PhaseActions<Parallel::Phase::CheckTimeStepperHistory,
+                                 SelfStart::check_self_start_actions>,
           Parallel::PhaseActions<
               Parallel::Phase::Evolve,
               tmpl::list<::domain::Actions::CheckFunctionsOfTimeAreReady,

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhCce.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhCce.hpp
@@ -181,6 +181,8 @@ struct EvolutionMetavars : public GeneralizedHarmonicTemplateBase<VolumeDim>,
           Parallel::PhaseActions<
               Parallel::Phase::InitializeTimeStepperHistory,
               SelfStart::self_start_procedure<step_actions<true>, system>>,
+          Parallel::PhaseActions<Parallel::Phase::CheckTimeStepperHistory,
+                                 SelfStart::check_self_start_actions>,
           Parallel::PhaseActions<Parallel::Phase::Register,
                                  tmpl::list<dg_registration_list,
                                             Parallel::Actions::TerminatePhase>>,

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhNoBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhNoBlackHole.hpp
@@ -60,6 +60,8 @@ struct EvolutionMetavars : public GeneralizedHarmonicTemplateBase<VolumeDim> {
           Parallel::PhaseActions<
               Parallel::Phase::InitializeTimeStepperHistory,
               SelfStart::self_start_procedure<step_actions, system>>,
+          Parallel::PhaseActions<Parallel::Phase::CheckTimeStepperHistory,
+                                 SelfStart::check_self_start_actions>,
           Parallel::PhaseActions<Parallel::Phase::Register,
                                  tmpl::list<dg_registration_list,
                                             Parallel::Actions::TerminatePhase>>,

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhSingleBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhSingleBlackHole.hpp
@@ -212,6 +212,8 @@ struct EvolutionMetavars : public GeneralizedHarmonicTemplateBase<VolumeDim> {
           Parallel::PhaseActions<
               Parallel::Phase::InitializeTimeStepperHistory,
               SelfStart::self_start_procedure<step_actions, system>>,
+          Parallel::PhaseActions<Parallel::Phase::CheckTimeStepperHistory,
+                                 SelfStart::check_self_start_actions>,
           Parallel::PhaseActions<Parallel::Phase::Register,
                                  tmpl::list<dg_registration_list,
                                             Parallel::Actions::TerminatePhase>>,

--- a/src/Evolution/Executables/GeneralizedHarmonic/GeneralizedHarmonicBase.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/GeneralizedHarmonicBase.hpp
@@ -327,13 +327,14 @@ struct GeneralizedHarmonicTemplateBase {
 
   // Register needs to be before InitializeTimeStepperHistory so that CCE is
   // properly registered when the self-start happens
-  static constexpr std::array<Parallel::Phase, 8> default_phase_order{
+  static constexpr std::array<Parallel::Phase, 9> default_phase_order{
       {Parallel::Phase::Initialization,
        Parallel::Phase::RegisterWithElementDataReader,
        Parallel::Phase::ImportInitialData,
        Parallel::Phase::InitializeInitialDataDependentQuantities,
        Parallel::Phase::Register, Parallel::Phase::InitializeTimeStepperHistory,
-       Parallel::Phase::Evolve, Parallel::Phase::Exit}};
+       Parallel::Phase::CheckTimeStepperHistory, Parallel::Phase::Evolve,
+       Parallel::Phase::Exit}};
 
   using step_actions = tmpl::list<
       evolution::dg::Actions::ComputeTimeDerivative<

--- a/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
+++ b/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
@@ -324,21 +324,21 @@ namespace detail {
 template <typename InitialData>
 constexpr auto make_default_phase_order() {
   if constexpr (evolution::is_numeric_initial_data_v<InitialData>) {
-    return std::array<Parallel::Phase, 8>{
+    return std::array<Parallel::Phase, 9>{
         {Parallel::Phase::Initialization,
          Parallel::Phase::RegisterWithElementDataReader,
          Parallel::Phase::ImportInitialData,
          Parallel::Phase::InitializeInitialDataDependentQuantities,
          Parallel::Phase::InitializeTimeStepperHistory,
-         Parallel::Phase::Register, Parallel::Phase::Evolve,
-         Parallel::Phase::Exit}};
+         Parallel::Phase::CheckTimeStepperHistory, Parallel::Phase::Register,
+         Parallel::Phase::Evolve, Parallel::Phase::Exit}};
   } else {
-    return std::array<Parallel::Phase, 6>{
+    return std::array<Parallel::Phase, 7>{
         {Parallel::Phase::Initialization,
          Parallel::Phase::InitializeInitialDataDependentQuantities,
          Parallel::Phase::InitializeTimeStepperHistory,
-         Parallel::Phase::Register, Parallel::Phase::Evolve,
-         Parallel::Phase::Exit}};
+         Parallel::Phase::CheckTimeStepperHistory, Parallel::Phase::Register,
+         Parallel::Phase::Evolve, Parallel::Phase::Exit}};
   }
 }
 }  // namespace detail
@@ -723,6 +723,8 @@ struct GhValenciaDivCleanTemplateBase<
           Parallel::PhaseActions<
               Parallel::Phase::InitializeTimeStepperHistory,
               SelfStart::self_start_procedure<step_actions, system>>,
+          Parallel::PhaseActions<Parallel::Phase::CheckTimeStepperHistory,
+                                 SelfStart::check_self_start_actions>,
           Parallel::PhaseActions<Parallel::Phase::Register,
                                  tmpl::list<dg_registration_list,
                                             Parallel::Actions::TerminatePhase>>,

--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
@@ -492,6 +492,9 @@ struct EvolutionMetavars {
               Parallel::Phase::InitializeTimeStepperHistory,
               SelfStart::self_start_procedure<step_actions, system>>,
 
+          Parallel::PhaseActions<Parallel::Phase::CheckTimeStepperHistory,
+                                 SelfStart::check_self_start_actions>,
+
           Parallel::PhaseActions<
               Parallel::Phase::Register,
               tmpl::push_back<dg_registration_list,
@@ -536,10 +539,11 @@ struct EvolutionMetavars {
       "Evolve the Valencia formulation of the GRMHD system with divergence "
       "cleaning.\n\n"};
 
-  static constexpr std::array<Parallel::Phase, 5> default_phase_order{
+  static constexpr std::array<Parallel::Phase, 6> default_phase_order{
       {Parallel::Phase::Initialization,
        Parallel::Phase::InitializeTimeStepperHistory, Parallel::Phase::Register,
-       Parallel::Phase::Evolve, Parallel::Phase::Exit}};
+       Parallel::Phase::CheckTimeStepperHistory, Parallel::Phase::Evolve,
+       Parallel::Phase::Exit}};
 
   // NOLINTNEXTLINE(google-runtime-references)
   void pup(PUP::er& /*p*/) {}

--- a/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
+++ b/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
@@ -370,6 +370,9 @@ struct EvolutionMetavars {
               Parallel::Phase::InitializeTimeStepperHistory,
               SelfStart::self_start_procedure<step_actions, system>>,
 
+          Parallel::PhaseActions<Parallel::Phase::CheckTimeStepperHistory,
+                                 SelfStart::check_self_start_actions>,
+
           Parallel::PhaseActions<Parallel::Phase::Register,
                                  tmpl::list<dg_registration_list,
                                             Parallel::Actions::TerminatePhase>>,
@@ -403,10 +406,11 @@ struct EvolutionMetavars {
   static constexpr Options::String help{
       "Evolve the Newtonian Euler system in conservative form.\n\n"};
 
-  static constexpr std::array<Parallel::Phase, 5> default_phase_order{
+  static constexpr std::array<Parallel::Phase, 6> default_phase_order{
       {Parallel::Phase::Initialization,
        Parallel::Phase::InitializeTimeStepperHistory, Parallel::Phase::Register,
-       Parallel::Phase::Evolve, Parallel::Phase::Exit}};
+       Parallel::Phase::CheckTimeStepperHistory, Parallel::Phase::Evolve,
+       Parallel::Phase::Exit}};
 
   // NOLINTNEXTLINE(google-runtime-references)
   void pup(PUP::er& /*p*/) {}

--- a/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveM1Grey.hpp
+++ b/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveM1Grey.hpp
@@ -241,6 +241,9 @@ struct EvolutionMetavars {
               Parallel::Phase::InitializeTimeStepperHistory,
               SelfStart::self_start_procedure<step_actions, system>>,
 
+          Parallel::PhaseActions<Parallel::Phase::CheckTimeStepperHistory,
+                                 SelfStart::check_self_start_actions>,
+
           Parallel::PhaseActions<Parallel::Phase::Register,
                                  tmpl::list<dg_registration_list,
                                             Parallel::Actions::TerminatePhase>>,
@@ -268,10 +271,11 @@ struct EvolutionMetavars {
   static constexpr Options::String help{
       "Evolve the M1Grey system (without coupling to hydro).\n\n"};
 
-  static constexpr std::array<Parallel::Phase, 5> default_phase_order{
+  static constexpr std::array<Parallel::Phase, 6> default_phase_order{
       {Parallel::Phase::Initialization,
        Parallel::Phase::InitializeTimeStepperHistory, Parallel::Phase::Register,
-       Parallel::Phase::Evolve, Parallel::Phase::Exit}};
+       Parallel::Phase::CheckTimeStepperHistory, Parallel::Phase::Evolve,
+       Parallel::Phase::Exit}};
 
   // NOLINTNEXTLINE(google-runtime-references)
   void pup(PUP::er& /*p*/) {}

--- a/src/Evolution/Executables/RelativisticEuler/Valencia/EvolveValencia.hpp
+++ b/src/Evolution/Executables/RelativisticEuler/Valencia/EvolveValencia.hpp
@@ -260,6 +260,9 @@ struct EvolutionMetavars {
               Parallel::Phase::InitializeTimeStepperHistory,
               SelfStart::self_start_procedure<step_actions, system>>,
 
+          Parallel::PhaseActions<Parallel::Phase::CheckTimeStepperHistory,
+                                 SelfStart::check_self_start_actions>,
+
           Parallel::PhaseActions<Parallel::Phase::Register,
                                  tmpl::list<dg_registration_list,
                                             Parallel::Actions::TerminatePhase>>,
@@ -291,10 +294,11 @@ struct EvolutionMetavars {
   static constexpr Options::String help{
       "Evolve the Valencia formulation of RelativisticEuler system.\n\n"};
 
-  static constexpr std::array<Parallel::Phase, 5> default_phase_order{
+  static constexpr std::array<Parallel::Phase, 6> default_phase_order{
       {Parallel::Phase::Initialization,
        Parallel::Phase::InitializeTimeStepperHistory, Parallel::Phase::Register,
-       Parallel::Phase::Evolve, Parallel::Phase::Exit}};
+       Parallel::Phase::CheckTimeStepperHistory, Parallel::Phase::Evolve,
+       Parallel::Phase::Exit}};
 
   // NOLINTNEXTLINE(google-runtime-references)
   void pup(PUP::er& /*p*/) {}

--- a/src/Evolution/Executables/ScalarAdvection/EvolveScalarAdvection.hpp
+++ b/src/Evolution/Executables/ScalarAdvection/EvolveScalarAdvection.hpp
@@ -336,6 +336,9 @@ struct EvolutionMetavars {
               Parallel::Phase::InitializeTimeStepperHistory,
               SelfStart::self_start_procedure<step_actions, system>>,
 
+          Parallel::PhaseActions<Parallel::Phase::CheckTimeStepperHistory,
+                                 SelfStart::check_self_start_actions>,
+
           Parallel::PhaseActions<
               Parallel::Phase::Evolve,
               tmpl::list<Actions::RunEventsAndTriggers, Actions::ChangeSlabSize,
@@ -357,10 +360,11 @@ struct EvolutionMetavars {
   static constexpr Options::String help{
       "Evolve the scalar advection equation.\n\n"};
 
-  static constexpr std::array<Parallel::Phase, 5> default_phase_order{
+  static constexpr std::array<Parallel::Phase, 6> default_phase_order{
       {Parallel::Phase::Initialization,
        Parallel::Phase::InitializeTimeStepperHistory, Parallel::Phase::Register,
-       Parallel::Phase::Evolve, Parallel::Phase::Exit}};
+       Parallel::Phase::CheckTimeStepperHistory, Parallel::Phase::Evolve,
+       Parallel::Phase::Exit}};
 
   // NOLINTNEXTLINE(google-runtime-references)
   void pup(PUP::er& /*p*/) {}

--- a/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
+++ b/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
@@ -270,6 +270,9 @@ struct EvolutionMetavars {
                                  tmpl::list<dg_registration_list,
                                             Parallel::Actions::TerminatePhase>>,
 
+          Parallel::PhaseActions<Parallel::Phase::CheckTimeStepperHistory,
+                                 SelfStart::check_self_start_actions>,
+
           Parallel::PhaseActions<
               Parallel::Phase::Evolve,
               tmpl::list<Actions::RunEventsAndTriggers, Actions::ChangeSlabSize,
@@ -292,10 +295,11 @@ struct EvolutionMetavars {
       "Evolve a Scalar Wave in Dim spatial dimension.\n\n"
       "The numerical flux is:    UpwindFlux\n"};
 
-  static constexpr std::array<Parallel::Phase, 5> default_phase_order{
+  static constexpr std::array<Parallel::Phase, 6> default_phase_order{
       {Parallel::Phase::Initialization,
        Parallel::Phase::InitializeTimeStepperHistory, Parallel::Phase::Register,
-       Parallel::Phase::Evolve, Parallel::Phase::Exit}};
+       Parallel::Phase::CheckTimeStepperHistory, Parallel::Phase::Evolve,
+       Parallel::Phase::Exit}};
 
   // NOLINTNEXTLINE(google-runtime-references)
   void pup(PUP::er& /*p*/) {}

--- a/src/Evolution/Systems/Cce/Components/CharacteristicEvolution.hpp
+++ b/src/Evolution/Systems/Cce/Components/CharacteristicEvolution.hpp
@@ -236,6 +236,8 @@ struct CharacteristicEvolution {
       Parallel::PhaseActions<Parallel::Phase::InitializeTimeStepperHistory,
                              SelfStart::self_start_procedure<
                                  self_start_extract_action_list, cce_system>>,
+      Parallel::PhaseActions<Parallel::Phase::CheckTimeStepperHistory,
+                             SelfStart::check_self_start_actions>,
       Parallel::PhaseActions<Parallel::Phase::Evolve, extract_action_list>>;
 
   static void initialize(

--- a/src/Parallel/Phase.cpp
+++ b/src/Parallel/Phase.cpp
@@ -17,6 +17,7 @@ namespace Parallel {
 std::vector<Phase> known_phases() {
   return {Phase::AdjustDomain,
           Phase::CheckDomain,
+          Phase::CheckTimeStepperHistory,
           Phase::Cleanup,
           Phase::EvaluateAmrCriteria,
           Phase::Evolve,
@@ -41,6 +42,8 @@ std::ostream& operator<<(std::ostream& os, const Phase& phase) {
       return os << "AdjustDomain";
     case Parallel::Phase::CheckDomain:
       return os << "CheckDomain";
+    case Parallel::Phase::CheckTimeStepperHistory:
+      return os << "CheckTimeStepperHistory";
     case Parallel::Phase::Cleanup:
       return os << "Cleanup";
     case Parallel::Phase::EvaluateAmrCriteria:

--- a/src/Parallel/Phase.hpp
+++ b/src/Parallel/Phase.hpp
@@ -46,6 +46,9 @@ enum class Phase {
   AdjustDomain,
   ///  phase in which sanity checks are done after AMR
   CheckDomain,
+  ///  phase in which sanity checks on the history of the evolved variables are
+  ///  done. Intended to be after InitializeTimeStepperHistory but before Evolve
+  CheckTimeStepperHistory,
   ///  a cleanup phase
   Cleanup,
   ///  phase in which AMR criteria are evaluated

--- a/tests/Unit/Framework/MockDistributedObject.hpp
+++ b/tests/Unit/Framework/MockDistributedObject.hpp
@@ -373,6 +373,7 @@ class MockDistributedObject {
     phase_ = phase;
     algorithm_step_ = 0;
     terminate_ = number_of_actions_in_phase(phase) == 0;
+    performing_action_ = false;
     halt_algorithm_until_next_phase_ = false;
   }
   Parallel::Phase get_phase() const { return phase_; }


### PR DESCRIPTION
## Proposed changes

While working with CCM, I've been burned a couple times now by self-start not completing properly. There is nothing wrong with the self start code itself. However, if there is a deadlock in the `StepActions`, then because of quiescence detection, the self-start phase will finish (without error) and the algorithm continues to the evolution with incorrect time stepper history. This can cause all sorts of problems in the evolution and make things hard to debug.

This PR adds a new action that does some consistency/sanity checks on the history data so as to avoid this. Because quiescence can sometimes happen during self start (which we don't want), we can't put this action in the self-start phase itself because the action won't get run. We also don't want to put this in the Evolve phase because this check only needs to be done once. So I added a new phase `CheckTimeStepperHistory` that goes between self-start and evolve to do these checks.

I also added this new phase to most of our evolution executables.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
