### PR TITLE
Add an AMR refinement criterion useful for testing

### DIFF
--- a/src/Domain/Amr/Flag.hpp
+++ b/src/Domain/Amr/Flag.hpp
@@ -8,6 +8,14 @@
 
 #include <iosfwd>
 
+/// \cond
+namespace Options {
+class Option;
+template <typename T>
+struct create_from_yaml;
+}  // namespace Options
+/// \endcond
+
 namespace amr::domain {
 
 /// \ingroup AmrGroup
@@ -27,3 +35,15 @@ enum class Flag {
 /// Output operator for a Flag.
 std::ostream& operator<<(std::ostream& os, const Flag& flag);
 }  // namespace amr::domain
+
+template <>
+struct Options::create_from_yaml<amr::domain::Flag> {
+  template <typename Metavariables>
+  static amr::domain::Flag create(const Options::Option& options) {
+    return create<void>(options);
+  }
+};
+
+template <>
+amr::domain::Flag Options::create_from_yaml<amr::domain::Flag>::create<void>(
+    const Options::Option& options);

--- a/src/ParallelAlgorithms/Amr/Criteria/CMakeLists.txt
+++ b/src/ParallelAlgorithms/Amr/Criteria/CMakeLists.txt
@@ -8,6 +8,7 @@ add_spectre_library(${LIBRARY})
 spectre_target_sources(
   ${LIBRARY}
   PRIVATE
+  DriveToTarget.cpp
   Random.cpp
   )
 
@@ -17,6 +18,7 @@ spectre_target_headers(
   HEADERS
   Criteria.hpp
   Criterion.hpp
+  DriveToTarget.hpp
   Random.hpp
   )
 
@@ -32,6 +34,7 @@ target_link_libraries(
   DomainStructure
   Options
   Parallel
+  Spectral
   Utilities
   )
 

--- a/src/ParallelAlgorithms/Amr/Criteria/Criterion.hpp
+++ b/src/ParallelAlgorithms/Amr/Criteria/Criterion.hpp
@@ -21,7 +21,7 @@ namespace amr {
 /// be changed
 ///
 /// \details When AMR criteria are evaluated for each element, they should
-/// return a std::aray<amr::domain::Flag, Dim> containing the recommended
+/// return a std::array<amr::domain::Flag, Dim> containing the recommended
 /// refinement choice in each logical dimension of the Element.
 class Criterion : public PUP::able {
  protected:

--- a/src/ParallelAlgorithms/Amr/Criteria/DriveToTarget.cpp
+++ b/src/ParallelAlgorithms/Amr/Criteria/DriveToTarget.cpp
@@ -1,0 +1,74 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "ParallelAlgorithms/Amr/Criteria/DriveToTarget.hpp"
+
+#include <array>
+#include <cstddef>
+#include <pup.h>
+#include <pup_stl.h>
+
+#include "Domain/Amr/Flag.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace amr::Criteria {
+template <size_t Dim>
+DriveToTarget<Dim>::DriveToTarget(
+    const std::array<size_t, Dim>& target_number_of_grid_points,
+    const std::array<size_t, Dim>& target_refinement_levels,
+    const std::array<domain::Flag, Dim>& flags_at_target)
+    : target_number_of_grid_points_(target_number_of_grid_points),
+      target_refinement_levels_(target_refinement_levels),
+      flags_at_target_(flags_at_target) {}
+
+template <size_t Dim>
+DriveToTarget<Dim>::DriveToTarget(CkMigrateMessage* msg) : Criterion(msg) {}
+
+// NOLINTNEXTLINE(google-runtime-references)
+template <size_t Dim>
+void DriveToTarget<Dim>::pup(PUP::er& p) {
+  Criterion::pup(p);
+  p | target_number_of_grid_points_;
+  p | target_refinement_levels_;
+  p | flags_at_target_;
+}
+
+template <size_t Dim>
+std::array<domain::Flag, Dim> DriveToTarget<Dim>::impl(
+    const Mesh<Dim>& current_mesh, const ElementId<Dim>& element_id) const {
+  auto result = make_array<Dim>(domain::Flag::DoNothing);
+  const std::array<size_t, Dim> levels = element_id.refinement_levels();
+  bool is_at_target = true;
+  for (size_t d = 0; d < Dim; ++d) {
+    if (gsl::at(levels, d) < gsl::at(target_refinement_levels_, d)) {
+      gsl::at(result, d) = domain::Flag::Split;
+      is_at_target = false;
+    } else if (current_mesh.extents(d) <
+               gsl::at(target_number_of_grid_points_, d)) {
+      gsl::at(result, d) = domain::Flag::IncreaseResolution;
+      is_at_target = false;
+    } else if (current_mesh.extents(d) >
+               gsl::at(target_number_of_grid_points_, d)) {
+      gsl::at(result, d) = domain::Flag::DecreaseResolution;
+      is_at_target = false;
+    } else if (gsl::at(levels, d) > gsl::at(target_refinement_levels_, d)) {
+      gsl::at(result, d) = domain::Flag::Join;
+      is_at_target = false;
+    }
+  }
+  if (is_at_target) {
+    return flags_at_target_;
+  }
+
+  return result;
+}
+
+template <size_t Dim>
+PUP::able::PUP_ID DriveToTarget<Dim>::my_PUP_ID = 0;  // NOLINT
+
+template class DriveToTarget<1>;
+template class DriveToTarget<2>;
+template class DriveToTarget<3>;
+}  // namespace amr::Criteria

--- a/src/ParallelAlgorithms/Amr/Criteria/DriveToTarget.hpp
+++ b/src/ParallelAlgorithms/Amr/Criteria/DriveToTarget.hpp
@@ -1,0 +1,109 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <pup.h>
+
+#include "Domain/Amr/Flag.hpp"
+#include "Domain/Tags.hpp"
+#include "ParallelAlgorithms/Amr/Criteria/Criterion.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+template <size_t>
+class ElementId;
+template <size_t>
+class Mesh;
+/// \endcond
+
+namespace amr::Criteria {
+/*!
+ * \brief Refine the grid towards the target number of grid points and
+ * refinement levels in each dimension and then oscillate about the target.
+ *
+ * \details If the grid is at neither target in a given dimension, the
+ * flag chosen will be in the priority order Split,
+ * IncreaseResolution, DecreaseResolution, Join.
+ *
+ * \note To remain at the target, set the OscillationAtTarget Flags to
+ * DoNothing.
+ *
+ * \note This criterion is primarily for testing the mechanics of refinement.
+ */
+template <size_t Dim>
+class DriveToTarget : public Criterion {
+ public:
+  /// The target number of grid point in each dimension
+  struct TargetNumberOfGridPoints {
+    using type = std::array<size_t, Dim>;
+    static constexpr Options::String help = {
+        "The target number of grid points in each dimension."};
+  };
+
+  /// The target refinement level in each dimension
+  struct TargetRefinementLevels {
+    using type = std::array<size_t, Dim>;
+    static constexpr Options::String help = {
+        "The target refinement level in each dimension."};
+  };
+
+  /// The AMR flags chosen when the target number of grid points and refinement
+  /// levels are reached
+  struct OscillationAtTarget {
+    using type = std::array<domain::Flag, Dim>;
+    static constexpr Options::String help = {
+        "The flags returned when at the target."};
+  };
+
+  using options = tmpl::list<TargetNumberOfGridPoints, TargetRefinementLevels,
+                             OscillationAtTarget>;
+
+  static constexpr Options::String help = {
+      "Refine the grid towards the TargetNumberOfGridPoints and "
+      "TargetRefinementLevels, and then oscillate about them by applying "
+      "OscillationAtTarget."};
+
+  DriveToTarget() = default;
+
+  DriveToTarget(const std::array<size_t, Dim>& target_number_of_grid_points,
+                const std::array<size_t, Dim>& target_refinement_levels,
+                const std::array<domain::Flag, Dim>& flags_at_target);
+
+  /// \cond
+  explicit DriveToTarget(CkMigrateMessage* msg);
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(DriveToTarget);  // NOLINT
+  /// \endcond
+
+  using compute_tags_for_observation_box = tmpl::list<>;
+
+  using argument_tags = tmpl::list<::domain::Tags::Mesh<Dim>>;
+
+  template <typename Metavariables>
+  auto operator()(const Mesh<Dim>& current_mesh,
+                  Parallel::GlobalCache<Metavariables>& /*cache*/,
+                  const ElementId<Dim>& element_id) const;
+
+  void pup(PUP::er& p) override;
+
+ private:
+  std::array<domain::Flag, Dim> impl(const Mesh<Dim>& current_mesh,
+                                     const ElementId<Dim>& element_id) const;
+
+  std::array<size_t, Dim> target_number_of_grid_points_{};
+  std::array<size_t, Dim> target_refinement_levels_{};
+  std::array<domain::Flag, Dim> flags_at_target_{};
+};
+
+template <size_t Dim>
+template <typename Metavariables>
+auto DriveToTarget<Dim>::operator()(
+    const Mesh<Dim>& current_mesh,
+    Parallel::GlobalCache<Metavariables>& /*cache*/,
+    const ElementId<Dim>& element_id) const {
+  return impl(current_mesh, element_id);
+}
+}  // namespace amr::Criteria

--- a/tests/Unit/Domain/Amr/Test_Flag.cpp
+++ b/tests/Unit/Domain/Amr/Test_Flag.cpp
@@ -3,10 +3,12 @@
 
 #include "Framework/TestingFramework.hpp"
 
-#include <string>
+#include <vector>
 
 #include "Domain/Amr/Flag.hpp"
+#include "Framework/TestCreation.hpp"
 #include "Utilities/GetOutput.hpp"
+#include "Utilities/MakeString.hpp"
 
 SPECTRE_TEST_CASE("Unit.Domain.Amr.Flag", "[Domain][Unit]") {
   CHECK(get_output(amr::domain::Flag::Undefined) == "Undefined");
@@ -17,4 +19,22 @@ SPECTRE_TEST_CASE("Unit.Domain.Amr.Flag", "[Domain][Unit]") {
   CHECK(get_output(amr::domain::Flag::IncreaseResolution) ==
         "IncreaseResolution");
   CHECK(get_output(amr::domain::Flag::Split) == "Split");
+
+  const std::vector known_amr_flags{
+      amr::domain::Flag::Undefined,          amr::domain::Flag::Join,
+      amr::domain::Flag::DecreaseResolution, amr::domain::Flag::DoNothing,
+      amr::domain::Flag::IncreaseResolution, amr::domain::Flag::Split};
+
+  for (const auto flag : known_amr_flags) {
+    CHECK(flag ==
+          TestHelpers::test_creation<amr::domain::Flag>(get_output(flag)));
+  }
+
+  CHECK_THROWS_WITH(
+      ([]() {
+        TestHelpers::test_creation<amr::domain::Flag>("Bad flag name");
+      }()),
+      Catch::Contains(MakeString{} << "Failed to convert \"Bad flag name\" to "
+                                      "amr::domain::Flag.\nMust be one of "
+                                   << known_amr_flags << "."));
 }

--- a/tests/Unit/ParallelAlgorithms/Amr/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/Amr/CMakeLists.txt
@@ -7,6 +7,7 @@ set(LIBRARY_SOURCES
   Actions/Test_EvaluateRefinementCriteria.cpp
   Actions/Test_Initialize.cpp
   Actions/Test_UpdateAmrDecision.cpp
+  Criteria/Test_DriveToTarget.cpp
   Criteria/Test_Random.cpp
   Projectors/Test_Mesh.cpp
   )

--- a/tests/Unit/ParallelAlgorithms/Amr/Criteria/Test_DriveToTarget.cpp
+++ b/tests/Unit/ParallelAlgorithms/Amr/Criteria/Test_DriveToTarget.cpp
@@ -1,0 +1,176 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <memory>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/ObservationBox.hpp"
+#include "Domain/Amr/Flag.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Domain/Structure/SegmentId.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
+#include "Options/Protocols/FactoryCreation.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "Parallel/RegisterDerivedClassesWithCharm.hpp"
+#include "ParallelAlgorithms/Amr/Criteria/Criterion.hpp"
+#include "ParallelAlgorithms/Amr/Criteria/DriveToTarget.hpp"
+#include "ParallelAlgorithms/Amr/Criteria/Tags/Criteria.hpp"
+#include "Utilities/MakeArray.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+template <size_t VolumeDim>
+struct Metavariables {
+  static constexpr size_t volume_dim = VolumeDim;
+  using component_list = tmpl::list<>;
+  using const_global_cache_tags = tmpl::list<>;
+  struct factory_creation
+      : tt::ConformsTo<Options::protocols::FactoryCreation> {
+    using factory_classes = tmpl::map<tmpl::pair<
+        amr::Criterion, tmpl::list<amr::Criteria::DriveToTarget<VolumeDim>>>>;
+  };
+};
+struct TestComponent {};
+
+template <size_t VolumeDim>
+void test_criterion(
+    const amr::Criterion& criterion,
+    const std::array<size_t, VolumeDim> mesh_extents,
+    const std::array<size_t, VolumeDim>& element_refinement_levels,
+    const std::array<amr::domain::Flag, VolumeDim>& expected_flags) {
+  Parallel::GlobalCache<Metavariables<VolumeDim>> empty_cache{};
+  const auto databox = db::create<tmpl::list<::domain::Tags::Mesh<VolumeDim>>>(
+      Mesh<VolumeDim>{mesh_extents, Spectral::Basis::Legendre,
+                      Spectral::Quadrature::GaussLobatto});
+  ObservationBox<tmpl::list<>,
+                 db::DataBox<tmpl::list<::domain::Tags::Mesh<VolumeDim>>>>
+      box{databox};
+
+  std::array<SegmentId, VolumeDim> segment_ids;
+  alg::transform(element_refinement_levels, segment_ids.begin(),
+                 [](const size_t extent) {
+                   return SegmentId{extent, 0_st};
+                 });
+  ElementId<VolumeDim> element_id{0, segment_ids};
+  auto flags = criterion.evaluate(box, empty_cache, element_id);
+  CHECK(flags == expected_flags);
+}
+
+template <size_t VolumeDim>
+void test(
+    const std::array<size_t, VolumeDim>& target_extents,
+    const std::array<size_t, VolumeDim>& target_levels,
+    const std::array<amr::domain::Flag, VolumeDim>& flags_at_target,
+    const std::vector<
+        std::tuple<std::array<size_t, VolumeDim>, std::array<size_t, VolumeDim>,
+                   std::array<amr::domain::Flag, VolumeDim>>>& test_cases,
+    const std::string& option_string) {
+  Parallel::register_factory_classes_with_charm<Metavariables<VolumeDim>>();
+
+  const amr::Criteria::DriveToTarget criterion{target_extents, target_levels,
+                                               flags_at_target};
+  const auto criterion_from_option_string =
+      TestHelpers::test_creation<std::unique_ptr<amr::Criterion>,
+                                 Metavariables<VolumeDim>>(option_string);
+  for (const auto& [extents, levels, expected_flags] : test_cases) {
+    test_criterion(criterion, extents, levels, expected_flags);
+    test_criterion(*criterion_from_option_string, extents, levels,
+                   expected_flags);
+    test_criterion(*serialize_and_deserialize(criterion_from_option_string),
+                   extents, levels, expected_flags);
+  }
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Amr.Criteria.DriveToTarget",
+                  "[Unit][ParallelAlgorithms]") {
+  {
+    INFO("1D")
+    const std::array target_extents{4_st};
+    const std::array target_levels{3_st};
+    const std::array flags_at_target{amr::domain::Flag::Join};
+    const auto test_cases = std::vector{
+        std::tuple{std::array{4_st}, std::array{3_st},
+                   std::array{amr::domain::Flag::Join}},
+        std::tuple{std::array{3_st}, std::array{3_st},
+                   std::array{amr::domain::Flag::IncreaseResolution}},
+        std::tuple{std::array{5_st}, std::array{3_st},
+                   std::array{amr::domain::Flag::DecreaseResolution}},
+        std::tuple{std::array{4_st}, std::array{2_st},
+                   std::array{amr::domain::Flag::Split}},
+        std::tuple{std::array{3_st}, std::array{2_st},
+                   std::array{amr::domain::Flag::Split}},
+        std::tuple{std::array{5_st}, std::array{2_st},
+                   std::array{amr::domain::Flag::Split}},
+        std::tuple{std::array{4_st}, std::array{4_st},
+                   std::array{amr::domain::Flag::Join}},
+        std::tuple{std::array{3_st}, std::array{4_st},
+                   std::array{amr::domain::Flag::IncreaseResolution}},
+        std::tuple{std::array{5_st}, std::array{4_st},
+                   std::array{amr::domain::Flag::DecreaseResolution}}};
+    const std::string option =
+        "DriveToTarget:\n"
+        "  TargetNumberOfGridPoints: [4]\n"
+        "  TargetRefinementLevels: [3]\n"
+        "  OscillationAtTarget: [Join]\n";
+    test(target_extents, target_levels, flags_at_target, test_cases, option);
+  }
+  {
+    INFO("2D");
+    const std::array target_extents{4_st, 6_st};
+    const std::array target_levels{8_st, 3_st};
+    const std::array flags_at_target{amr::domain::Flag::IncreaseResolution,
+                                     amr::domain::Flag::Split};
+    const auto test_cases = std::vector{
+        std::tuple{std::array{4_st, 6_st}, std::array{8_st, 3_st},
+                   std::array{amr::domain::Flag::IncreaseResolution,
+                              amr::domain::Flag::Split}},
+        std::tuple{std::array{5_st, 6_st}, std::array{8_st, 3_st},
+                   std::array{amr::domain::Flag::DecreaseResolution,
+                              amr::domain::Flag::DoNothing}},
+        std::tuple{
+            std::array{3_st, 6_st}, std::array{7_st, 4_st},
+            std::array{amr::domain::Flag::Split, amr::domain::Flag::Join}},
+        std::tuple{std::array{4_st, 6_st}, std::array{8_st, 2_st},
+                   std::array{amr::domain::Flag::DoNothing,
+                              amr::domain::Flag::Split}}};
+    const std::string option =
+        "DriveToTarget:\n"
+        "  TargetNumberOfGridPoints: [4, 6]\n"
+        "  TargetRefinementLevels: [8, 3]\n"
+        "  OscillationAtTarget: [IncreaseResolution, Split]\n";
+    test(target_extents, target_levels, flags_at_target, test_cases, option);
+  }
+  {
+    INFO("3D");
+    const std::array target_extents{3_st, 9_st, 5_st};
+    const std::array target_levels{5_st, 2_st, 4_st};
+    const std::array flags_at_target{amr::domain::Flag::Split,
+                                     amr::domain::Flag::DecreaseResolution,
+                                     amr::domain::Flag::DoNothing};
+    const auto test_cases = std::vector{
+        std::tuple{std::array{3_st, 9_st, 5_st}, std::array{5_st, 2_st, 4_st},
+                   std::array{amr::domain::Flag::Split,
+                              amr::domain::Flag::DecreaseResolution,
+                              amr::domain::Flag::DoNothing}},
+        std::tuple{
+            std::array{3_st, 9_st, 5_st}, std::array{5_st, 5_st, 4_st},
+            std::array{amr::domain::Flag::DoNothing, amr::domain::Flag::Join,
+                       amr::domain::Flag::DoNothing}},
+        std::tuple{std::array{3_st, 9_st, 3_st}, std::array{5_st, 2_st, 4_st},
+                   std::array{amr::domain::Flag::DoNothing,
+                              amr::domain::Flag::DoNothing,
+                              amr::domain::Flag::IncreaseResolution}}};
+    const std::string option =
+        "DriveToTarget:\n"
+        "  TargetNumberOfGridPoints: [3, 9, 5]\n"
+        "  TargetRefinementLevels: [5, 2, 4]\n"
+        "  OscillationAtTarget: [Split, DecreaseResolution, DoNothing]\n";
+    test(target_extents, target_levels, flags_at_target, test_cases, option);
+  }
+}


### PR DESCRIPTION
## Proposed changes

The new criterion drives each Element in the Domain to a target resolution and refinement level.  Once it reaches the target, it will perform a given a decision that will cause the grid to oscillate between the target grid and a grid which differs by either one in resolution or refinement level.

This allows testing AMR actions in a controlled manner to make sure the mechanics of transferring data is correct.

In addition to testing, this criteria may be needed in order to drive the grid to desired initial refinement levels in order to bypass issues with Charm++

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
