### PR TITLE
Fix floating point bug in Test_Tov.cpp, ASSERT/ERROR print to full precision

### DIFF
--- a/src/Utilities/ErrorHandling/Assert.hpp
+++ b/src/Utilities/ErrorHandling/Assert.hpp
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <iomanip>
 #include <sstream>
 #include <string>
 
@@ -33,29 +34,31 @@
 // 20160415) can't figure out that the else branch and everything
 // after it is unreachable, causing warnings (and possibly suboptimal
 // code generation).
-#define ASSERT(a, m)                                                          \
-  do {                                                                        \
-    if (!(a)) {                                                               \
-      disable_floating_point_exceptions();                                    \
-      std::ostringstream avoid_name_collisions_ASSERT;                        \
-      /* clang-tidy: macro arg in parentheses */                              \
-      avoid_name_collisions_ASSERT << m; /* NOLINT */                         \
-      abort_with_error_message(#a, __FILE__, __LINE__,                        \
-                               static_cast<const char*>(__PRETTY_FUNCTION__), \
-                               avoid_name_collisions_ASSERT.str());           \
-    }                                                                         \
+#define ASSERT(a, m)                                                           \
+  do {                                                                         \
+    if (!(a)) {                                                                \
+      disable_floating_point_exceptions();                                     \
+      std::ostringstream avoid_name_collisions_ASSERT;                         \
+      /* clang-tidy: macro arg in parentheses */                               \
+      avoid_name_collisions_ASSERT << std::setprecision(18) << std::scientific \
+                                   << m; /* NOLINT */                          \
+      abort_with_error_message(#a, __FILE__, __LINE__,                         \
+                               static_cast<const char*>(__PRETTY_FUNCTION__),  \
+                               avoid_name_collisions_ASSERT.str());            \
+    }                                                                          \
   } while (false)
 #else
-#define ASSERT(a, m)                                   \
-  do {                                                 \
-    if (false) {                                       \
-      static_cast<void>(a);                            \
-      disable_floating_point_exceptions();             \
-      std::ostringstream avoid_name_collisions_ASSERT; \
-      /* clang-tidy: macro arg in parentheses */       \
-      avoid_name_collisions_ASSERT << m; /* NOLINT */  \
-      static_cast<void>(avoid_name_collisions_ASSERT); \
-      enable_floating_point_exceptions();              \
-    }                                                  \
+#define ASSERT(a, m)                                                           \
+  do {                                                                         \
+    if (false) {                                                               \
+      static_cast<void>(a);                                                    \
+      disable_floating_point_exceptions();                                     \
+      std::ostringstream avoid_name_collisions_ASSERT;                         \
+      /* clang-tidy: macro arg in parentheses */                               \
+      avoid_name_collisions_ASSERT << std::setprecision(18) << std::scientific \
+                                   << m; /* NOLINT */                          \
+      static_cast<void>(avoid_name_collisions_ASSERT);                         \
+      enable_floating_point_exceptions();                                      \
+    }                                                                          \
   } while (false)
 #endif

--- a/src/Utilities/ErrorHandling/Error.hpp
+++ b/src/Utilities/ErrorHandling/Error.hpp
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <iomanip>
 #include <string>
 
 #include "Utilities/ErrorHandling/AbortWithErrorMessage.hpp"
@@ -47,16 +48,16 @@
 // 20160415) can't figure out that the else branch and everything
 // after it is unreachable, causing warnings (and possibly suboptimal
 // code generation).
-#define ERROR(m)                                                              \
-  do {                                                                        \
-    if (__builtin_is_constant_evaluated()) {                                  \
-      throw std::runtime_error("Failed");                                     \
-    } else {                                                                  \
-      disable_floating_point_exceptions();                                    \
-      abort_with_error_message(__FILE__, __LINE__,                            \
-                               static_cast<const char*>(__PRETTY_FUNCTION__), \
-                               MakeString{} << m);                            \
-    }                                                                         \
+#define ERROR(m)                                                             \
+  do {                                                                       \
+    if (__builtin_is_constant_evaluated()) {                                 \
+      throw std::runtime_error("Failed");                                    \
+    } else {                                                                 \
+      disable_floating_point_exceptions();                                   \
+      abort_with_error_message(                                              \
+          __FILE__, __LINE__, static_cast<const char*>(__PRETTY_FUNCTION__), \
+          MakeString{} << std::setprecision(18) << std::scientific << m);    \
+    }                                                                        \
   } while (false)
 
 /*!
@@ -72,6 +73,6 @@
       disable_floating_point_exceptions();                                   \
       abort_with_error_message_no_trace(                                     \
           __FILE__, __LINE__, static_cast<const char*>(__PRETTY_FUNCTION__), \
-          MakeString{} << m);                                                \
+          MakeString{} << std::setprecision(18) << std::scientific << m);    \
     }                                                                        \
   } while (false)

--- a/tests/Unit/Domain/CoordinateMaps/Test_Frustum.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_Frustum.cpp
@@ -653,7 +653,7 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Frustum", "[Domain][Unit]") {
       Catch::Contains(
           "The sphericity must be set between 0.0, corresponding to a flat "
           "surface, and 1.0, corresponding to a spherical surface, inclusive. "
-          "It is currently set to 1.3."));
+          "It is currently set to 1.3"));
 #endif
 }
 }  // namespace domain

--- a/tests/Unit/Domain/FunctionsOfTime/Test_FunctionOfTimeHelpers.cpp
+++ b/tests/Unit/Domain/FunctionsOfTime/Test_FunctionOfTimeHelpers.cpp
@@ -100,9 +100,9 @@ SPECTRE_TEST_CASE("Unit.Domain.FunctionsOfTime.FunctionOfTimeHelpers",
         FunctionOfTimeHelpers::reset_expiration_time(make_not_null(&expr_time),
                                                      next_expr_time);
       }(),
-      Catch::Contains(
-          "Attempted to change expiration time to 3.5, which precedes "
-          "the previous expiration time of 4."));
+      Catch::Contains("Attempted to change expiration time to 3.5") and
+          Catch::Contains(
+              ", which precedes the previous expiration time of 4"));
 
   CHECK_THROWS_WITH(
       ([]() {
@@ -119,7 +119,8 @@ SPECTRE_TEST_CASE("Unit.Domain.FunctionsOfTime.FunctionOfTimeHelpers",
         (void)FunctionOfTimeHelpers::stored_info_from_upper_bound(
             -1.0, all_stored_info);
       }()),
-      Catch::Contains("requested time -1 precedes earliest time 0 of times."));
+      Catch::Contains("requested time -1") and
+          Catch::Contains(" precedes earliest time 0"));
 
 #ifdef SPECTRE_DEBUG
   CHECK_THROWS_WITH(

--- a/tests/Unit/Domain/FunctionsOfTime/Test_PiecewisePolynomial.cpp
+++ b/tests/Unit/Domain/FunctionsOfTime/Test_PiecewisePolynomial.cpp
@@ -325,7 +325,8 @@ SPECTRE_TEST_CASE("Unit.Domain.FunctionsOfTime.PiecewisePolynomial",
       }()),
       Catch::Contains(
           "t must be increasing from call to call. Attempted to update "
-          "at time 1, which precedes the previous update time of 2."));
+          "at time 1") and
+          Catch::Contains(", which precedes the previous update time of 2"));
 
   CHECK_THROWS_WITH(
       ([]() {
@@ -340,8 +341,9 @@ SPECTRE_TEST_CASE("Unit.Domain.FunctionsOfTime.PiecewisePolynomial",
       }()),
       Catch::Contains(
           "expiration_time must be nondecreasing from call to call. "
-          "Attempted to change expiration time to 1.1, which precedes "
-          "the previous expiration time of 2.1."));
+          "Attempted to change expiration time to 1.1") and
+          Catch::Contains(
+              ", which precedes the previous expiration time of 2.1"));
 
   CHECK_THROWS_WITH(
       ([]() {
@@ -353,9 +355,9 @@ SPECTRE_TEST_CASE("Unit.Domain.FunctionsOfTime.PiecewisePolynomial",
                                                                  2.0);
         f_of_t.update(1.0, {6.0, 0.0}, 2.1);
       }()),
-      Catch::Contains(
-          "Attempt to update PiecewisePolynomial at a time 1 that is "
-          "earlier than the previous expiration time of 2."));
+      Catch::Contains("Attempt to update PiecewisePolynomial at a time 1") and
+          Catch::Contains(
+              " that is earlier than the previous expiration time of 2"));
 
   CHECK_THROWS_WITH(
       ([]() {
@@ -369,7 +371,8 @@ SPECTRE_TEST_CASE("Unit.Domain.FunctionsOfTime.PiecewisePolynomial",
       }()),
       Catch::Contains(
           "Attempt to set the expiration time of PiecewisePolynomial to "
-          "a value 2.2 that is earlier than the current time 2.5."));
+          "a value 2.2") and
+          Catch::Contains(" that is earlier than the current time 2.5"));
 
   CHECK_THROWS_WITH(
       ([]() {
@@ -382,9 +385,9 @@ SPECTRE_TEST_CASE("Unit.Domain.FunctionsOfTime.PiecewisePolynomial",
         f_of_t.reset_expiration_time(1.5);
         f_of_t.update(2.5, {6.0, 0.0}, 2.2);
       }()),
-      Catch::Contains(
-          "Attempted to change expiration time to 1.5, which precedes "
-          "the previous expiration time of 2."));
+      Catch::Contains("Attempted to change expiration time to 1.5") and
+          Catch::Contains(
+              ", which precedes the previous expiration time of 2"));
 
   CHECK_THROWS_WITH(
       ([]() {
@@ -411,7 +414,8 @@ SPECTRE_TEST_CASE("Unit.Domain.FunctionsOfTime.PiecewisePolynomial",
         f_of_t.update(2.0, {6.0, 0.0}, 2.1);
         f_of_t.func(0.5);
       }()),
-      Catch::Contains("requested time 0.5 precedes earliest time 1 of times."));
+      Catch::Contains("requested time 5.0") and
+          Catch::Contains(" precedes earliest time 1"));
 
   CHECK_THROWS_WITH(
       ([]() {
@@ -424,7 +428,7 @@ SPECTRE_TEST_CASE("Unit.Domain.FunctionsOfTime.PiecewisePolynomial",
         f_of_t.func(2.2);
       }()),
       Catch::Contains(
-          "Attempt to evaluate PiecewisePolynomial at a time 2.2 that "
-          "is after the expiration time 2."));
+          "Attempt to evaluate PiecewisePolynomial at a time 2.2") and
+          Catch::Contains(" that is after the expiration time 2"));
 }
 }  // namespace domain

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/Test_Tov.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/Test_Tov.cpp
@@ -54,7 +54,9 @@ void test_tov(
   const double surface_log_enthalpy = 0.0;
   const double step = (surface_log_enthalpy - initial_log_enthalpy) / num_pts;
   const double final_log_enthalpy =
-      initial_log_enthalpy + (current_iteration + 1.0) * step;
+      num_pts == current_iteration + 1
+          ? surface_log_enthalpy
+          : initial_log_enthalpy + (current_iteration + 1.0) * step;
   const RelativisticEuler::Solutions::TovSolution tov_out_full(
       equation_of_state, central_mass_density,
       RelativisticEuler::Solutions::TovCoordinates::Schwarzschild,


### PR DESCRIPTION
## Proposed changes

- The `ASSERT` as it was basically said `1.0 == 1.0`, but it differed at roundoff. Printing to full precision in `ASSERT`/`ERROR` will help us debug these subtle issues more easily. I expect this will be especially useful to newer folks.
- Elide some floating point math that leads to slightly different solves in the TOV solver test.

Fixes #4657 

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
