### PR TITLE
Enable no-math-errno and reciprocal optimizations.

### DIFF
--- a/cmake/SetupCxxFlags.cmake
+++ b/cmake/SetupCxxFlags.cmake
@@ -59,6 +59,16 @@ set_property(TARGET SpectreFlags
   INTERFACE_COMPILE_OPTIONS
   $<$<COMPILE_LANGUAGE:CXX>:-ftemplate-backtrace-limit=0>)
 
+# Disable cmath setting the error flag. This allows the compiler to more
+# aggressively vectorize code since it doesn't need to respect some global
+# state.
+set_property(TARGET SpectreFlags
+  APPEND PROPERTY
+  INTERFACE_COMPILE_OPTIONS
+  $<$<COMPILE_LANGUAGE:C>:-fno-math-errno>
+  $<$<COMPILE_LANGUAGE:CXX>:-fno-math-errno>
+  $<$<COMPILE_LANGUAGE:Fortran>:-fno-math-errno>)
+
 # By default, the LLVM optimizer assumes floating point exceptions are ignored.
 create_cxx_flag_target("-ffp-exception-behavior=maytrap" SpectreFpExceptions)
 target_link_libraries(

--- a/cmake/SetupCxxFlags.cmake
+++ b/cmake/SetupCxxFlags.cmake
@@ -69,6 +69,15 @@ set_property(TARGET SpectreFlags
   $<$<COMPILE_LANGUAGE:CXX>:-fno-math-errno>
   $<$<COMPILE_LANGUAGE:Fortran>:-fno-math-errno>)
 
+# Allow the compiler to transform divisions into multiplication by the
+# reciprocal.
+set_property(TARGET SpectreFlags
+  APPEND PROPERTY
+  INTERFACE_COMPILE_OPTIONS
+  $<$<COMPILE_LANGUAGE:C>:-freciprocal-math>
+  $<$<COMPILE_LANGUAGE:CXX>:-freciprocal-math>
+  $<$<COMPILE_LANGUAGE:Fortran>:-freciprocal-math>)
+
 # By default, the LLVM optimizer assumes floating point exceptions are ignored.
 create_cxx_flag_target("-ffp-exception-behavior=maytrap" SpectreFpExceptions)
 target_link_libraries(


### PR DESCRIPTION
## Proposed changes

- `no-math-errno` allows the compiler to switch things like `sqrt` to vector intrinsics.
- Enable reciprocal math. We generally don't care about the difference between `a / b` and `a * one_over_b`.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
