### PR TITLE
CylBinaryCompactObject: add equiangular map.

### DIFF
--- a/src/Domain/Creators/CylindricalBinaryCompactObject.cpp
+++ b/src/Domain/Creators/CylindricalBinaryCompactObject.cpp
@@ -57,13 +57,10 @@ std::array<double, 3> flip_about_xy_plane(const std::array<double, 3> input) {
 
 namespace domain::creators {
 CylindricalBinaryCompactObject::CylindricalBinaryCompactObject(
-    typename CenterA::type center_A, typename CenterB::type center_B,
-    typename RadiusA::type radius_A, typename RadiusB::type radius_B,
-    typename IncludeInnerSphereA::type include_inner_sphere_A,
-    typename IncludeInnerSphereB::type include_inner_sphere_B,
-    typename IncludeOuterSphere::type include_outer_sphere,
-    typename OuterRadius::type outer_radius,
-    typename UseEquiangularMap::type use_equiangular_map,
+    std::array<double, 3> center_A, std::array<double, 3> center_B,
+    double radius_A, double radius_B, bool include_inner_sphere_A,
+    bool include_inner_sphere_B, bool include_outer_sphere, double outer_radius,
+    bool use_equiangular_map,
     const typename InitialRefinement::type& initial_refinement,
     const typename InitialGridPoints::type& initial_grid_points,
     std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
@@ -368,13 +365,10 @@ CylindricalBinaryCompactObject::CylindricalBinaryCompactObject(
 CylindricalBinaryCompactObject::CylindricalBinaryCompactObject(
     double initial_time, ExpansionMapOptions expansion_map_options,
     std::array<double, 3> initial_angular_velocity,
-    typename CenterA::type center_A, typename CenterB::type center_B,
-    typename RadiusA::type radius_A, typename RadiusB::type radius_B,
-    typename IncludeInnerSphereA::type include_inner_sphere_A,
-    typename IncludeInnerSphereB::type include_inner_sphere_B,
-    typename IncludeOuterSphere::type include_outer_sphere,
-    typename OuterRadius::type outer_radius,
-    typename UseEquiangularMap::type use_equiangular_map,
+    std::array<double, 3> center_A, std::array<double, 3> center_B,
+    double radius_A, double radius_B, bool include_inner_sphere_A,
+    bool include_inner_sphere_B, bool include_outer_sphere, double outer_radius,
+    bool use_equiangular_map,
     const typename InitialRefinement::type& initial_refinement,
     const typename InitialGridPoints::type& initial_grid_points,
     std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>

--- a/src/Domain/Creators/CylindricalBinaryCompactObject.cpp
+++ b/src/Domain/Creators/CylindricalBinaryCompactObject.cpp
@@ -63,6 +63,7 @@ CylindricalBinaryCompactObject::CylindricalBinaryCompactObject(
     typename IncludeInnerSphereB::type include_inner_sphere_B,
     typename IncludeOuterSphere::type include_outer_sphere,
     typename OuterRadius::type outer_radius,
+    typename UseEquiangularMap::type use_equiangular_map,
     const typename InitialRefinement::type& initial_refinement,
     const typename InitialGridPoints::type& initial_grid_points,
     std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
@@ -78,6 +79,7 @@ CylindricalBinaryCompactObject::CylindricalBinaryCompactObject(
       include_inner_sphere_B_(include_inner_sphere_B),
       include_outer_sphere_(include_outer_sphere),
       outer_radius_(outer_radius),
+      use_equiangular_map_(use_equiangular_map),
       inner_boundary_condition_(std::move(inner_boundary_condition)),
       outer_boundary_condition_(std::move(outer_boundary_condition)) {
   if (center_A_[2] <= 0.0) {
@@ -372,6 +374,7 @@ CylindricalBinaryCompactObject::CylindricalBinaryCompactObject(
     typename IncludeInnerSphereB::type include_inner_sphere_B,
     typename IncludeOuterSphere::type include_outer_sphere,
     typename OuterRadius::type outer_radius,
+    typename UseEquiangularMap::type use_equiangular_map,
     const typename InitialRefinement::type& initial_refinement,
     const typename InitialGridPoints::type& initial_grid_points,
     std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
@@ -382,7 +385,7 @@ CylindricalBinaryCompactObject::CylindricalBinaryCompactObject(
     : CylindricalBinaryCompactObject(
           center_A, center_B, radius_A, radius_B, include_inner_sphere_A,
           include_inner_sphere_B, include_outer_sphere, outer_radius,
-          initial_refinement, initial_grid_points,
+          use_equiangular_map, initial_refinement, initial_grid_points,
           std::move(inner_boundary_condition),
           std::move(outer_boundary_condition), context) {
   is_time_dependent_ = true;
@@ -442,13 +445,13 @@ Domain<3> CylindricalBinaryCompactObject::create_domain() const {
   const double cylinder_lower_bound_z = -1.0;
   const double cylinder_upper_bound_z = 1.0;
   const auto logical_to_cylinder_center_maps =
-      cyl_wedge_coord_map_center_blocks(cylinder_inner_radius,
-                                        cylinder_lower_bound_z,
-                                        cylinder_upper_bound_z, false);
+      cyl_wedge_coord_map_center_blocks(
+          cylinder_inner_radius, cylinder_lower_bound_z, cylinder_upper_bound_z,
+          use_equiangular_map_);
   const auto logical_to_cylinder_surrounding_maps =
       cyl_wedge_coord_map_surrounding_blocks(
           cylinder_inner_radius, cylinder_outer_radius, cylinder_lower_bound_z,
-          cylinder_upper_bound_z, false, 0.0);
+          cylinder_upper_bound_z, use_equiangular_map_, 0.0);
 
   // Lambda that takes a UniformCylindricalEndcap map and a
   // DiscreteRotation map, composes it with the logical-to-cylinder
@@ -526,7 +529,7 @@ Domain<3> CylindricalBinaryCompactObject::create_domain() const {
       cyl_wedge_coord_map_surrounding_blocks(
           cylindrical_shell_inner_radius, cylindrical_shell_outer_radius,
           cylindrical_shell_lower_bound_z, cylindrical_shell_upper_bound_z,
-          false, 1.0);
+          use_equiangular_map_, 1.0);
 
   // Lambda that takes a UniformCylindricalSide map and a DiscreteRotation
   // map, composes it with the logical-to-cylinder maps, and adds it

--- a/src/Domain/Creators/CylindricalBinaryCompactObject.hpp
+++ b/src/Domain/Creators/CylindricalBinaryCompactObject.hpp
@@ -219,6 +219,12 @@ class CylindricalBinaryCompactObject : public DomainCreator<3> {
     static constexpr Options::String help = {
         "Grid-coordinate radius of outer boundary."};
   };
+  struct UseEquiangularMap {
+    using type = bool;
+    static constexpr Options::String help = {
+        "Distribute grid points equiangularly in 2d wedges."};
+    static bool suggested_value() { return false; }
+  };
 
   struct InitialRefinement {
     using type =
@@ -334,6 +340,7 @@ class CylindricalBinaryCompactObject : public DomainCreator<3> {
   using time_independent_options =
       tmpl::list<CenterA, CenterB, RadiusA, RadiusB, IncludeInnerSphereA,
                  IncludeInnerSphereB, IncludeOuterSphere, OuterRadius,
+                 UseEquiangularMap,
                  InitialRefinement, InitialGridPoints>;
   using time_dependent_options =
       tmpl::list<InitialTime, ExpansionMap, InitialAngularVelocity>;
@@ -371,6 +378,7 @@ class CylindricalBinaryCompactObject : public DomainCreator<3> {
       typename IncludeInnerSphereB::type include_inner_sphere_B,
       typename IncludeOuterSphere::type include_outer_sphere,
       typename OuterRadius::type outer_radius,
+      typename UseEquiangularMap::type use_equiangular_map,
       const typename InitialRefinement::type& initial_refinement,
       const typename InitialGridPoints::type& initial_grid_points,
       std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
@@ -388,6 +396,7 @@ class CylindricalBinaryCompactObject : public DomainCreator<3> {
       typename IncludeInnerSphereB::type include_inner_sphere_B,
       typename IncludeOuterSphere::type include_outer_sphere,
       typename OuterRadius::type outer_radius,
+      typename UseEquiangularMap::type use_equiangular_map,
       const typename InitialRefinement::type& initial_refinement,
       const typename InitialGridPoints::type& initial_grid_points,
       std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
@@ -443,6 +452,7 @@ class CylindricalBinaryCompactObject : public DomainCreator<3> {
   typename IncludeInnerSphereB::type include_inner_sphere_B_{};
   typename IncludeOuterSphere::type include_outer_sphere_{};
   typename OuterRadius::type outer_radius_{};
+  bool use_equiangular_map_{false};
   typename std::vector<std::array<size_t, 3>> initial_refinement_{};
   typename std::vector<std::array<size_t, 3>> initial_grid_points_{};
   // cut_spheres_offset_factor_ is eta in Eq. (A.9) of

--- a/src/Domain/Creators/CylindricalBinaryCompactObject.hpp
+++ b/src/Domain/Creators/CylindricalBinaryCompactObject.hpp
@@ -372,13 +372,10 @@ class CylindricalBinaryCompactObject : public DomainCreator<3> {
       "each of the two compact objects A and B."};
 
   CylindricalBinaryCompactObject(
-      typename CenterA::type center_A, typename CenterB::type center_B,
-      typename RadiusA::type radius_A, typename RadiusB::type radius_B,
-      typename IncludeInnerSphereA::type include_inner_sphere_A,
-      typename IncludeInnerSphereB::type include_inner_sphere_B,
-      typename IncludeOuterSphere::type include_outer_sphere,
-      typename OuterRadius::type outer_radius,
-      typename UseEquiangularMap::type use_equiangular_map,
+      std::array<double, 3> center_A, std::array<double, 3> center_B,
+      double radius_A, double radius_B, bool include_inner_sphere_A,
+      bool include_inner_sphere_B, bool include_outer_sphere,
+      double outer_radius, bool use_equiangular_map,
       const typename InitialRefinement::type& initial_refinement,
       const typename InitialGridPoints::type& initial_grid_points,
       std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
@@ -390,13 +387,10 @@ class CylindricalBinaryCompactObject : public DomainCreator<3> {
   CylindricalBinaryCompactObject(
       double initial_time, ExpansionMapOptions expansion_map_options,
       std::array<double, 3> initial_angular_velocity,
-      typename CenterA::type center_A, typename CenterB::type center_B,
-      typename RadiusA::type radius_A, typename RadiusB::type radius_B,
-      typename IncludeInnerSphereA::type include_inner_sphere_A,
-      typename IncludeInnerSphereB::type include_inner_sphere_B,
-      typename IncludeOuterSphere::type include_outer_sphere,
-      typename OuterRadius::type outer_radius,
-      typename UseEquiangularMap::type use_equiangular_map,
+      std::array<double, 3> center_A, std::array<double, 3> center_B,
+      double radius_A, double radius_B, bool include_inner_sphere_A,
+      bool include_inner_sphere_B, bool include_outer_sphere,
+      double outer_radius, bool use_equiangular_map,
       const typename InitialRefinement::type& initial_refinement,
       const typename InitialGridPoints::type& initial_grid_points,
       std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
@@ -444,14 +438,14 @@ class CylindricalBinaryCompactObject : public DomainCreator<3> {
   // construct the map in a frame where the centers are offset in the
   // z direction.  At the end, there will be another rotation back to
   // the grid frame (where the centers are offset in the x direction).
-  typename CenterA::type center_A_{};
-  typename CenterB::type center_B_{};
-  typename RadiusA::type radius_A_{};
-  typename RadiusB::type radius_B_{};
-  typename IncludeInnerSphereA::type include_inner_sphere_A_{};
-  typename IncludeInnerSphereB::type include_inner_sphere_B_{};
-  typename IncludeOuterSphere::type include_outer_sphere_{};
-  typename OuterRadius::type outer_radius_{};
+  std::array<double, 3> center_A_{};
+  std::array<double, 3> center_B_{};
+  double radius_A_{};
+  double radius_B_{};
+  bool include_inner_sphere_A_{};
+  bool include_inner_sphere_B_{};
+  bool include_outer_sphere_{};
+  double outer_radius_{};
   bool use_equiangular_map_{false};
   typename std::vector<std::array<size_t, 3>> initial_refinement_{};
   typename std::vector<std::array<size_t, 3>> initial_grid_points_{};

--- a/tests/Unit/Domain/Creators/Test_BinaryCompactObject.cpp
+++ b/tests/Unit/Domain/Creators/Test_BinaryCompactObject.cpp
@@ -11,6 +11,7 @@
 #include <memory>
 #include <optional>
 #include <pup.h>
+#include <random>
 #include <string>
 #include <tuple>
 #include <unordered_map>
@@ -84,6 +85,9 @@ create_outer_boundary_condition() {
 }
 
 void test_connectivity() {
+  MAKE_GENERATOR(gen);
+  std::uniform_real_distribution<> unit_dis(0.0, 1.0);
+
   // ObjectA:
   constexpr double inner_radius_objectA = 0.3;
   constexpr double outer_radius_objectA = 1.0;
@@ -116,6 +120,11 @@ void test_connectivity() {
            make_array(true, false), make_array(true, false),
            make_array(Distribution::Linear, Distribution::Logarithmic,
                       Distribution::Inverse))) {
+    // To speed up this test, don't run every case in the above loop.
+    // Instead, ignore some of them at random.
+    if (unit_dis(gen) > 0.5) {
+      continue;
+    }
     CAPTURE(with_boundary_conditions);
     CAPTURE(excise_interiorA);
     CAPTURE(excise_interiorB);


### PR DESCRIPTION
## Proposed changes

Adds an equiangular map option to CylindricalBinaryCompactObject.

### Upgrade instructions

<!-- UPGRADE INSTRUCTIONS -->
When using the `CylindricalBinaryCompactObject` domain creator one must now specify `UseEquiangularMap`.  Setting this option to false gives the previous behavior.
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

