### PR TITLE
Add weights for FD integration

### DIFF
--- a/src/NumericalAlgorithms/Spectral/FiniteDifference.cpp
+++ b/src/NumericalAlgorithms/Spectral/FiniteDifference.cpp
@@ -16,10 +16,12 @@ std::pair<DataVector, DataVector> compute_collocation_points_and_weights<
     Basis::FiniteDifference, Quadrature::CellCentered>(
     const size_t num_points) {
   DataVector x{num_points};
-  DataVector w{num_points, std::numeric_limits<double>::signaling_NaN()};
   // The finite difference grid cells cover the interval [-1, 1]
-  constexpr double lower_bound = -1.0, upper_bound = 1.0;
+  constexpr double lower_bound = -1.0;
+  constexpr double upper_bound = 1.0;
   const double delta_x = (upper_bound - lower_bound) / num_points;
+  // Weights for integration using midpoint method
+  DataVector w{num_points, delta_x};
   for (size_t i = 0; i < num_points; ++i) {
     x[i] = lower_bound + 0.5 * delta_x + i * delta_x;
   }
@@ -31,14 +33,23 @@ std::pair<DataVector, DataVector> compute_collocation_points_and_weights<
     Basis::FiniteDifference, Quadrature::FaceCentered>(
     const size_t num_points) {
   DataVector x{num_points};
-  DataVector w{num_points, std::numeric_limits<double>::signaling_NaN()};
   // The finite difference grid cells cover the interval [-1, 1]
-  constexpr double lower_bound = -1.0, upper_bound = 1.0;
-  const double delta_x = (upper_bound - lower_bound) / (num_points - 1);
+  constexpr double lower_bound = -1.0;
+  constexpr double upper_bound = 1.0;
+  const double delta_x = (upper_bound - lower_bound) / (num_points - 1.0);
+  // Weights for integration using midpoint method
+  DataVector w{num_points, delta_x};
   for (size_t i = 0; i < num_points; ++i) {
     x[i] = lower_bound + i * delta_x;
   }
   return std::make_pair(std::move(x), std::move(w));
+}
+
+template <>
+DataVector compute_inverse_weight_function_values<Basis::FiniteDifference>(
+    const DataVector& x) {
+  DataVector iw{x.size(),1.0};
+  return iw;
 }
 
 // The below definitions are necessary to successfully link with some compilers.
@@ -67,11 +78,6 @@ double compute_basis_function_value<Basis::FiniteDifference>(
   ERROR("No basis functions to compute.\n");
 }
 
-template <>
-DataVector compute_inverse_weight_function_values<Basis::FiniteDifference>(
-    const DataVector& /*x*/) {
-  ERROR("No no inverse weight function to compute.\n");
-}
 #if defined(__GNUC__) && !defined(__clang__)
 #pragma GCC diagnostic pop
 #endif  // defined(__GNUC__) && !defined(__clang__)

--- a/src/ParallelAlgorithms/Events/ObserveNorms.hpp
+++ b/src/ParallelAlgorithms/Events/ObserveNorms.hpp
@@ -75,10 +75,6 @@ namespace Events {
  * where $V=\int_\Omega$ is the volume of the entire domain in inertial
  * coordinates.
  *
- * \note The integral norm does not currently work with a
- * Spectral::Basis::FiniteDifference mesh because ::definite_integral does not
- * support it.
- *
  * Here is an example of an input file:
  *
  * \snippet Test_ObserveNorms.cpp input_file_examples
@@ -192,7 +188,8 @@ class ObserveNorms<ObservationValueTag, tmpl::list<ObservableTensorTags...>,
       "domain with large volume. Choose wisely! When in doubt, try the\n"
       "'L2Norm' first.\n"
       "The 'L2IntegralNorm' does not currently work with finite difference\n"
-      "(subcell) meshes.\n"
+      "(subcell) meshes. [We need to figure out how to provide the proper \n"
+      "determinant of the Jacobian]\n"
       "\n"
       "Writes reduction quantities:\n"
       " * ObservationValueTag (e.g. Time or IterationId)\n"
@@ -346,8 +343,8 @@ operator()(const typename ObservationValueTag::type& observation_value,
       norm_values_and_names{};
   const auto& mesh = get<::Events::Tags::ObserverMesh<VolumeDim>>(box);
   const DataVector det_jacobian =
-      1. / get(get<domain::Tags::DetInvJacobian<Frame::ElementLogical,
-                                                Frame::Inertial>>(box));
+    1. / get(get<domain::Tags::DetInvJacobian<Frame::ElementLogical,
+                                              Frame::Inertial>>(box));
   const size_t number_of_points = mesh.number_of_grid_points();
   const double local_volume = [&mesh, &det_jacobian]() {
     if (mesh.basis(0) == Spectral::Basis::FiniteDifference) {
@@ -398,7 +395,7 @@ operator()(const typename ObservationValueTag::type& observation_value,
               values.push_back(
                   alg::accumulate(square(components[storage_index]), 0.0));
             } else if (tensor_norm_types_[i] == "L2IntegralNorm") {
-              if (mesh.basis(0) == Spectral::Basis::FiniteDifference) {
+             if (mesh.basis(0) == Spectral::Basis::FiniteDifference) {
                 ERROR(
                     "The 'L2IntegralNorm' is currently not supported on finite "
                     "difference (subcell) meshes.");


### PR DESCRIPTION
## Proposed changes

Add weights for low-order integration on a finite difference grid 

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.