### PR TITLE
Fix cartesian_product dox

### DIFF
--- a/src/Utilities/CartesianProduct.hpp
+++ b/src/Utilities/CartesianProduct.hpp
@@ -37,6 +37,7 @@ void insert_tuples(Op op, std::pair<InputIterator1, InputIterator1> head,
 }  // namespace detail
 
 /*!
+ * \ingroup UtilitiesGroup
  * \brief Fill the `result` iterator with the Cartesian product of a sequence of
  * iterators
  *
@@ -54,10 +55,15 @@ void cartesian_product(OutputIterator result,
 }
 
 /*!
+ * \ingroup UtilitiesGroup
  * \brief The Cartesian product of a sequence arrays
  *
  * Returns a `std::array` with all possible combinations of the input arrays.
  * The last dimension varies fastest.
+ *
+ * \example
+ * Here's an example using this function to replace a nested for loop:
+ * \snippet Test_Wedge3D.cpp cartesian_product_loop
  */
 template <typename... Ts, size_t... Lens>
 std::array<std::tuple<Ts...>, (... * Lens)> cartesian_product(

--- a/tests/Unit/Domain/CoordinateMaps/Test_Wedge3D.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_Wedge3D.cpp
@@ -45,6 +45,7 @@ void test_wedge3d_all_directions() {
   using WedgeHalves = Wedge3D::WedgeHalves;
   const std::array<WedgeHalves, 3> halves_array = {
       {WedgeHalves::UpperOnly, WedgeHalves::LowerOnly, WedgeHalves::Both}};
+  // [cartesian_product_loop]
   for (const auto& [halves, orientation, with_equiangular_map,
                     radial_distribution] :
        cartesian_product(halves_array, all_wedge_directions(),
@@ -52,6 +53,7 @@ void test_wedge3d_all_directions() {
                          make_array(CoordinateMaps::Distribution::Linear,
                                     CoordinateMaps::Distribution::Logarithmic,
                                     CoordinateMaps::Distribution::Inverse))) {
+    // [cartesian_product_loop]
     CAPTURE(halves);
     CAPTURE(orientation);
     CAPTURE(with_equiangular_map);

--- a/tests/Unit/Domain/Creators/Test_CylindricalBinaryCompactObject.cpp
+++ b/tests/Unit/Domain/Creators/Test_CylindricalBinaryCompactObject.cpp
@@ -34,6 +34,8 @@
 #include "Helpers/Domain/BoundaryConditions/BoundaryCondition.hpp"
 #include "Helpers/Domain/Creators/TestHelpers.hpp"
 #include "Helpers/Domain/DomainTestHelpers.hpp"
+#include "Utilities/CartesianProduct.hpp"
+#include "Utilities/MakeArray.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -356,19 +358,17 @@ void test_connectivity_once(const bool with_sphere_e,
 void test_connectivity() {
   // When we add sphere_e support we will make the following
   // loop go over {true, false}
-  for (const bool with_sphere_e : {false}) {
+  const bool with_sphere_e = false;
+  for (const auto& [include_outer_sphere, include_inner_sphere_A,
+                    include_inner_sphere_B] :
+       cartesian_product(make_array(true, false), make_array(true, false),
+                         make_array(true, false))) {
     CAPTURE(with_sphere_e);
-    for (const bool include_outer_sphere : {true, false}) {
-      CAPTURE(include_outer_sphere);
-      for (const bool include_inner_sphere_A : {true, false}) {
-        CAPTURE(include_inner_sphere_A);
-        for (const bool include_inner_sphere_B : {true, false}) {
-          CAPTURE(include_inner_sphere_B);
-          test_connectivity_once(with_sphere_e, include_inner_sphere_A,
-                                 include_inner_sphere_B, include_outer_sphere);
-        }
-      }
-    }
+    CAPTURE(include_outer_sphere);
+    CAPTURE(include_inner_sphere_A);
+    CAPTURE(include_inner_sphere_B);
+    test_connectivity_once(with_sphere_e, include_inner_sphere_A,
+                           include_inner_sphere_B, include_outer_sphere);
   }
 }
 
@@ -543,15 +543,15 @@ void test_binary_factory() {
     TestHelpers::domain::creators::test_domain_creator(
         *binary_compact_object, with_boundary_conditions);
   };
-  for (const bool with_boundary_conds : {true, false}) {
-    for (const bool with_additional_outer_radial_refinement : {false, true}) {
-      for (const bool with_additional_grid_points : {false, true}) {
-        check_impl(create_option_string(
-                       false, with_additional_outer_radial_refinement,
-                       with_additional_grid_points, with_boundary_conds),
-                   with_boundary_conds);
-      }
-    }
+  for (const auto& [with_boundary_conds,
+                    with_additional_outer_radial_refinement,
+                    with_additional_grid_points] :
+       cartesian_product(make_array(true, false), make_array(true, false),
+                         make_array(true, false))) {
+    check_impl(
+        create_option_string(false, with_additional_outer_radial_refinement,
+                             with_additional_grid_points, with_boundary_conds),
+        with_boundary_conds);
   }
 }
 

--- a/tests/Unit/Domain/Creators/Test_FrustalCloak.cpp
+++ b/tests/Unit/Domain/Creators/Test_FrustalCloak.cpp
@@ -25,6 +25,8 @@
 #include "Helpers/Domain/Creators/TestHelpers.hpp"
 #include "Helpers/Domain/DomainTestHelpers.hpp"
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
+#include "Utilities/CartesianProduct.hpp"
+#include "Utilities/MakeArray.hpp"
 
 namespace {
 std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
@@ -83,20 +85,21 @@ void test_connectivity() {
   const double length_outer_cube = 42.4;
   const std::array<double, 3> origin_preimage = {{1.3, 0.2, -3.1}};
 
-  for (const bool with_boundary_conditions : {true, false}) {
-    for (const bool use_equiangular_map : {true, false}) {
-      const domain::creators::FrustalCloak frustal_cloak{
-          refinement,
-          grid_points,
-          use_equiangular_map,
-          projective_scale_factor,
-          length_inner_cube,
-          length_outer_cube,
-          origin_preimage,
-          with_boundary_conditions ? create_boundary_condition() : nullptr};
-      TestHelpers::domain::creators::test_domain_creator(
-          frustal_cloak, with_boundary_conditions);
-    }
+  for (const auto& [with_boundary_conditions, use_equiangular_map] :
+       cartesian_product(make_array(true, false), make_array(true, false))) {
+    CAPTURE(with_boundary_conditions);
+    CAPTURE(use_equiangular_map);
+    const domain::creators::FrustalCloak frustal_cloak{
+        refinement,
+        grid_points,
+        use_equiangular_map,
+        projective_scale_factor,
+        length_inner_cube,
+        length_outer_cube,
+        origin_preimage,
+        with_boundary_conditions ? create_boundary_condition() : nullptr};
+    TestHelpers::domain::creators::test_domain_creator(
+        frustal_cloak, with_boundary_conditions);
   }
 
   CHECK_THROWS_WITH(


### PR DESCRIPTION
Functions without a namespace don't show up in the dox by default.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
