### PR TITLE
Add Bondi Sachs interpolation to BBH

### DIFF
--- a/src/Evolution/Executables/GeneralizedHarmonic/CMakeLists.txt
+++ b/src/Evolution/Executables/GeneralizedHarmonic/CMakeLists.txt
@@ -82,7 +82,7 @@ add_spectre_parallel_executable(
   EvolveGhBinaryBlackHole
   Evolution/Executables/GeneralizedHarmonic
   "EvolutionMetavars"
-  "${LIBS_TO_LINK};ControlSystem;GeneralRelativitySolutions;Importers"
+  "${LIBS_TO_LINK};Cce;ControlSystem;GeneralRelativitySolutions;Importers"
 )
 
 add_generalized_harmonic_cce_executable_without_horizon(

--- a/tests/InputFiles/GeneralizedHarmonic/BinaryBlackHole.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/BinaryBlackHole.yaml
@@ -22,6 +22,7 @@ ResourceInfo:
     MemoryMonitor: Auto
     Rotation: Auto
     Expansion: Auto
+    BondiSachsInterpolation: Auto
 
 Evolution:
   InitialTime: 0.0
@@ -254,6 +255,16 @@ ApparentHorizons:
     Verbosity: Verbose
   ControlSystemAhA: *AhA
   ControlSystemAhB: *AhB
+
+InterpolationTargets:
+  BondiSachsInterpolation:
+    Lmax: 16
+    Radius: [100, 150, 200]
+    Center: [0, 0, 0]
+    AngularOrdering: Cce
+
+Cce:
+  BondiSachsOutputFilePrefix: "BondiSachs"
 
 ControlSystems:
   WriteDataToDisk: true


### PR DESCRIPTION
## Proposed changes

Adds #4489 to the BBH executable.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
In your BBH input files, you'll need two new blocks:
```yaml
InterpolationTargets:
  BondiSachsInterpolation:
    Lmax: 16
    Radius: [100, 150, 200]
    Center: [0, 0, 0]
    AngularOrdering: Cce
```
and
```yaml
Cce:
  BondiSachsOutputFilePrefix: "BondiSachs"
```

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
