### PR TITLE
Work around version bug in Blaze 3.8.2

### DIFF
--- a/cmake/SetupBlaze.cmake
+++ b/cmake/SetupBlaze.cmake
@@ -21,8 +21,10 @@ endif()
 
 # Every time we've upgraded blaze compatibility in the past, we've had to change
 # vector code, so we should expect to need changes again on each subsequent
-# release, so we specify an exact version requirement.
-find_package(Blaze 3.8 EXACT REQUIRED)
+# release, so we should specify an exact version requirement. However, Blaze
+# hasn't been consistent in naming releases (version 3.8.2 has 3.9.0 written
+# in Version.h).
+find_package(Blaze 3.8 REQUIRED)
 
 message(STATUS "Blaze incl: ${BLAZE_INCLUDE_DIR}")
 message(STATUS "Blaze vers: ${BLAZE_VERSION}")


### PR DESCRIPTION
## Proposed changes

If we merge this before #4673 then I can push the container with Blaze 3.8.2 installed, in addition to MPI Charm.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
