### PR TITLE
Add more Jacobians to Compute VolumeQuantities files

### DIFF
--- a/src/ApparentHorizons/ComputeExcisionBoundaryVolumeQuantities.hpp
+++ b/src/ApparentHorizons/ComputeExcisionBoundaryVolumeQuantities.hpp
@@ -63,9 +63,15 @@ struct ComputeExcisionBoundaryVolumeQuantities
   static void apply(
       const gsl::not_null<Variables<DestTagList>*> target_vars,
       const Variables<SrcTagList>& src_vars, const Mesh<3>& mesh,
-      const Jacobian<DataVector, 3, TargetFrame, Frame::Inertial>& jacobian,
+      const Jacobian<DataVector, 3, TargetFrame, Frame::Inertial>&
+          jac_target_to_inertial,
+      const InverseJacobian<DataVector, 3, TargetFrame, Frame::Inertial>&
+          invjac_target_to_inertial,
+      const Jacobian<DataVector, 3, Frame::ElementLogical, TargetFrame>&
+          jac_logical_to_target,
       const InverseJacobian<DataVector, 3, Frame::ElementLogical, TargetFrame>&
-          inverse_jacobian);
+          invjac_logical_to_target,
+      const tnsr::I<DataVector, 3, Frame::Inertial>& inertial_mesh_velocity);
 
   using allowed_src_tags =
       tmpl::list<gr::Tags::SpacetimeMetric<3, Frame::Inertial>,

--- a/src/ApparentHorizons/ComputeExcisionBoundaryVolumeQuantities.tpp
+++ b/src/ApparentHorizons/ComputeExcisionBoundaryVolumeQuantities.tpp
@@ -114,9 +114,15 @@ template <typename SrcTagList, typename DestTagList, typename TargetFrame>
 void ComputeExcisionBoundaryVolumeQuantities::apply(
     const gsl::not_null<Variables<DestTagList>*> target_vars,
     const Variables<SrcTagList>& src_vars, const Mesh<3>& /*mesh*/,
-    const Jacobian<DataVector, 3, TargetFrame, Frame::Inertial>& jacobian,
+    const Jacobian<DataVector, 3, TargetFrame, Frame::Inertial>&
+      jac_target_to_inertial,
+    const InverseJacobian<DataVector, 3, TargetFrame, Frame::Inertial>&
+      /*invjac_target_to_inertial*/,
+    const Jacobian<DataVector, 3, Frame::ElementLogical, TargetFrame>&
+      /*jac_logical_to_target*/,
     const InverseJacobian<DataVector, 3, Frame::ElementLogical, TargetFrame>&
-        /*inverse_jacobian*/) {
+      /*invjac_logical_to_target*/,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& /*inertial_mesh_velocity*/) {
 
   static_assert(
       std::is_same_v<tmpl::list_difference<SrcTagList, allowed_src_tags>,
@@ -197,7 +203,8 @@ void ComputeExcisionBoundaryVolumeQuantities::apply(
   // Transform spatial metric
   transform::to_different_frame(make_not_null(&spatial_metric),
                                 inertial_spatial_metric,
-                                jacobian);
+                                jac_target_to_inertial
+);
 
   // Invert transformed 3-metric.
   // put determinant of 3-metric temporarily into lapse to save memory.

--- a/src/ApparentHorizons/ComputeHorizonVolumeQuantities.hpp
+++ b/src/ApparentHorizons/ComputeHorizonVolumeQuantities.hpp
@@ -64,9 +64,15 @@ struct ComputeHorizonVolumeQuantities
   static void apply(
       const gsl::not_null<Variables<DestTagList>*> target_vars,
       const Variables<SrcTagList>& src_vars, const Mesh<3>& mesh,
-      const Jacobian<DataVector, 3, TargetFrame, Frame::Inertial>& jacobian,
+      const Jacobian<DataVector, 3, TargetFrame, Frame::Inertial>&
+          jac_target_to_inertial,
+      const InverseJacobian<DataVector, 3, TargetFrame, Frame::Inertial>&
+          invjac_target_to_inertial,
+      const Jacobian<DataVector, 3, Frame::ElementLogical, TargetFrame>&
+          jac_logical_to_target,
       const InverseJacobian<DataVector, 3, Frame::ElementLogical, TargetFrame>&
-          inverse_jacobian);
+          invjac_logical_to_target,
+      const tnsr::I<DataVector, 3, Frame::Inertial>& inertial_mesh_velocity);
 
   using allowed_src_tags = tmpl::list<
       gr::Tags::SpacetimeMetric<3, Frame::Inertial>,

--- a/tests/Unit/ApparentHorizons/Test_ComputeExcisionBoundaryVolumeQuantities.cpp
+++ b/tests/Unit/ApparentHorizons/Test_ComputeExcisionBoundaryVolumeQuantities.cpp
@@ -76,12 +76,19 @@ void test_compute_excision_boundary_volume_quantities() {
                   Spectral::Basis::Legendre,
                   Spectral::Quadrature::GaussLobatto};
   tnsr::I<DataVector, 3, TargetFrame> target_frame_coords{};
+  Jacobian<DataVector, 3, Frame::ElementLogical, Frame::Inertial>
+      jacobian_logical_to_inertial{};
   InverseJacobian<DataVector, 3, Frame::ElementLogical, Frame::Inertial>
       inv_jacobian_logical_to_inertial{};
   Jacobian<DataVector, 3, TargetFrame, Frame::Inertial>
       jacobian_target_to_inertial{};
+  InverseJacobian<DataVector, 3, TargetFrame, Frame::Inertial>
+      inv_jacobian_target_to_inertial{};
+  Jacobian<DataVector, 3, Frame::ElementLogical, TargetFrame>
+      jacobian_logical_to_target{};
   InverseJacobian<DataVector, 3, Frame::ElementLogical, TargetFrame>
       inv_jacobian_logical_to_target{};
+  tnsr::I<DataVector, 3, Frame::Inertial> inertial_mesh_velocity{};
   if constexpr (IsTimeDependent::value) {
     ElementMap<3, Frame::Grid> map_logical_to_grid{
         element_ids[0],
@@ -242,7 +249,8 @@ void test_compute_excision_boundary_volume_quantities() {
   if constexpr (IsTimeDependent::value) {
     ah::ComputeExcisionBoundaryVolumeQuantities::apply(
         make_not_null(&dest_vars), src_vars, mesh, jacobian_target_to_inertial,
-        inv_jacobian_logical_to_target);
+        inv_jacobian_target_to_inertial, jacobian_logical_to_target,
+        inv_jacobian_logical_to_target, inertial_mesh_velocity);
   } else {
     // time-independent.
     ah::ComputeExcisionBoundaryVolumeQuantities::apply(

--- a/tests/Unit/ApparentHorizons/Test_ComputeHorizonVolumeQuantities.cpp
+++ b/tests/Unit/ApparentHorizons/Test_ComputeHorizonVolumeQuantities.cpp
@@ -85,8 +85,13 @@ void test_compute_horizon_volume_quantities() {
       inv_jacobian_logical_to_inertial{};
   Jacobian<DataVector, 3, TargetFrame, Frame::Inertial>
       jacobian_target_to_inertial{};
+  InverseJacobian<DataVector, 3, TargetFrame, Frame::Inertial>
+      inv_jacobian_target_to_inertial{};
+  Jacobian<DataVector, 3, Frame::ElementLogical, TargetFrame>
+      jacobian_logical_to_target{};
   InverseJacobian<DataVector, 3, Frame::ElementLogical, TargetFrame>
       inv_jacobian_logical_to_target{};
+  tnsr::I<DataVector, 3, Frame::Inertial> inertial_mesh_velocity{};
   if constexpr (IsTimeDependent::value) {
     ElementMap<3, Frame::Grid> map_logical_to_grid{
         element_ids[0],
@@ -358,7 +363,8 @@ void test_compute_horizon_volume_quantities() {
   if constexpr (IsTimeDependent::value) {
     ah::ComputeHorizonVolumeQuantities::apply(
         make_not_null(&dest_vars), src_vars, mesh, jacobian_target_to_inertial,
-        inv_jacobian_logical_to_target);
+        inv_jacobian_target_to_inertial, jacobian_logical_to_target,
+        inv_jacobian_logical_to_target, inertial_mesh_velocity);
   } else {
     // time-independent.
     ah::ComputeHorizonVolumeQuantities::apply(make_not_null(&dest_vars),


### PR DESCRIPTION
## Proposed changes

<!--
At a high level, describe what this PR does.
-->

Follows up PR #4518 towards the computation of char speeds on the excision surface.
This PR adds the necessary jacobians to the signatures of the apply functions of Compute*VolumeQuantities.
A follow-up PR will use this update to transform the Shift to the Grid frame for the computation of the char speeds (using the grid frame normal to the target and other quantities).

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
