### PR TITLE
Add electric current density (Ohm's law) to ForceFree system

### DIFF
--- a/src/Evolution/Systems/ForceFree/CMakeLists.txt
+++ b/src/Evolution/Systems/ForceFree/CMakeLists.txt
@@ -9,6 +9,7 @@ spectre_target_sources(
   ${LIBRARY}
   PRIVATE
   Characteristics.cpp
+  ElectricCurrentDensity.cpp
   Fluxes.cpp
   Sources.cpp
   TimeDerivativeTerms.cpp
@@ -20,6 +21,7 @@ spectre_target_headers(
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   Characteristics.hpp
+  ElectricCurrentDensity.hpp
   Fluxes.hpp
   Sources.hpp
   System.hpp

--- a/src/Evolution/Systems/ForceFree/ElectricCurrentDensity.cpp
+++ b/src/Evolution/Systems/ForceFree/ElectricCurrentDensity.cpp
@@ -1,0 +1,144 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/ForceFree/ElectricCurrentDensity.hpp"
+
+#include <cstddef>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/LeviCivitaIterator.hpp"
+#include "DataStructures/Tags/TempTensor.hpp"
+#include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "PointwiseFunctions/GeneralRelativity/IndexManipulation.hpp"
+#include "Utilities/ContainerHelpers.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace ForceFree {
+
+namespace {
+
+template <bool IncludeDriftCurrent, bool IncludeParallelCurrent>
+void tilde_j_impl(
+    const gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> tilde_j,
+    const Scalar<DataVector>& tilde_q,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_e,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_b,
+    const double parallel_conductivity, const Scalar<DataVector>& lapse,
+    const Scalar<DataVector>& sqrt_det_spatial_metric,
+    const tnsr::ii<DataVector, 3, Frame::Inertial>& spatial_metric) {
+  static_assert(IncludeDriftCurrent or IncludeParallelCurrent);
+
+  Variables<tmpl::list<::Tags::Tempi<0, 3>, ::Tags::Tempi<1, 3>,
+                       ::Tags::TempScalar<0>, ::Tags::TempScalar<1>,
+                       ::Tags::TempScalar<2>>>
+      buffer{get(lapse).size()};
+
+  // compute one-forms of TildeE and TildeB in advance to reduce the number of
+  // dot products using spatial metric (which are slower than dot products
+  // without using spatial metric)
+  auto& tilde_e_one_form = get<::Tags::Tempi<0, 3>>(buffer);
+  auto& tilde_b_one_form = get<::Tags::Tempi<1, 3>>(buffer);
+  raise_or_lower_index(make_not_null(&tilde_e_one_form), tilde_e,
+                       spatial_metric);
+  raise_or_lower_index(make_not_null(&tilde_b_one_form), tilde_b,
+                       spatial_metric);
+
+  // Compute \tilde{B}^2 = \tilde{B}^j \tilde{B}_j. We need this quantity for
+  // both drift (explicit, non-stiff) and parallel (implicit, stiff) components
+  // of J^i.
+  auto& tilde_b_squared = get<::Tags::TempScalar<0>>(buffer);
+  dot_product(make_not_null(&tilde_b_squared), tilde_b, tilde_b_one_form);
+
+  if constexpr (IncludeParallelCurrent) {
+    (void)tilde_q;                  // avoid compiler warnings
+    (void)sqrt_det_spatial_metric;  // avoid compiler warnings
+
+    auto& tilde_e_squared = get<::Tags::TempScalar<1>>(buffer);
+    auto& tilde_e_dot_tilde_b = get<::Tags::TempScalar<2>>(buffer);
+    dot_product(make_not_null(&tilde_e_squared), tilde_e, tilde_e_one_form);
+    dot_product(make_not_null(&tilde_e_dot_tilde_b), tilde_e, tilde_b_one_form);
+
+    for (size_t i = 0; i < 3; ++i) {
+      (*tilde_j).get(i) =
+          parallel_conductivity *
+          (get(tilde_e_dot_tilde_b) * tilde_b.get(i) +
+           max(get(tilde_e_squared) - get(tilde_b_squared), 0.0) *
+               tilde_e.get(i));
+    }
+  } else {
+    // tilde_j should be initialized to zero before the summation performed in
+    // the next `if constexpr` block
+    for (size_t i = 0; i < 3; ++i) {
+      (*tilde_j).get(i) = 0;
+    }
+  }
+
+  if constexpr (IncludeDriftCurrent) {
+    (void)parallel_conductivity;  // avoid compiler warnings
+
+    for (LeviCivitaIterator<3> it; it; ++it) {
+      const auto& i = it[0];
+      const auto& j = it[1];
+      const auto& k = it[2];
+      (*tilde_j).get(i) +=
+          it.sign() * get(tilde_q) * tilde_e_one_form.get(j) *
+          tilde_b_one_form.get(k) /
+          get(sqrt_det_spatial_metric);  // the extra 1/sqrt{gamma} factor comes
+                                         // from the spatial Levi-Civita tensor
+    }
+  }
+
+  // overall factor
+  for (size_t i = 0; i < 3; ++i) {
+    (*tilde_j).get(i) *= get(lapse) / get(tilde_b_squared);
+  }
+}
+
+}  // namespace
+
+void ComputeDriftTildeJ::apply(
+    const gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> drift_tilde_j,
+    const Scalar<DataVector>& tilde_q,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_e,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_b,
+    const double parallel_conductivity, const Scalar<DataVector>& lapse,
+    const Scalar<DataVector>& sqrt_det_spatial_metric,
+    const tnsr::ii<DataVector, 3, Frame::Inertial>& spatial_metric) {
+  tilde_j_impl<true, false>(drift_tilde_j, tilde_q, tilde_e, tilde_b,
+                            parallel_conductivity, lapse,
+                            sqrt_det_spatial_metric, spatial_metric);
+}
+
+void ComputeParallelTildeJ::apply(
+    const gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*>
+        parallel_tilde_j,
+    const Scalar<DataVector>& tilde_q,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_e,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_b,
+    const double parallel_conductivity, const Scalar<DataVector>& lapse,
+    const Scalar<DataVector>& sqrt_det_spatial_metric,
+    const tnsr::ii<DataVector, 3, Frame::Inertial>& spatial_metric) {
+  tilde_j_impl<false, true>(parallel_tilde_j, tilde_q, tilde_e, tilde_b,
+                            parallel_conductivity, lapse,
+                            sqrt_det_spatial_metric, spatial_metric);
+}
+
+namespace Tags {
+void ComputeTildeJ::function(
+    const gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> tilde_j,
+    const Scalar<DataVector>& tilde_q,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_e,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_b,
+    const double parallel_conductivity, const Scalar<DataVector>& lapse,
+    const Scalar<DataVector>& sqrt_det_spatial_metric,
+    const tnsr::ii<DataVector, 3, Frame::Inertial>& spatial_metric) {
+  tilde_j_impl<true, true>(tilde_j, tilde_q, tilde_e, tilde_b,
+                           parallel_conductivity, lapse,
+                           sqrt_det_spatial_metric, spatial_metric);
+}
+}  // namespace Tags
+
+}  // namespace ForceFree

--- a/src/Evolution/Systems/ForceFree/ElectricCurrentDensity.hpp
+++ b/src/Evolution/Systems/ForceFree/ElectricCurrentDensity.hpp
@@ -1,0 +1,129 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Evolution/Systems/ForceFree/Tags.hpp"
+#include "PointwiseFunctions/GeneralRelativity/TagsDeclarations.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+class DataVector;
+namespace gsl {
+template <typename T>
+class not_null;
+}  // namespace gsl
+/// \endcond
+
+namespace ForceFree {
+
+/*!
+ * \brief Computes the non-stiff part \f$\tilde{J}^i_\mathrm{drift}\f$ of the
+ * generalized electric current density \f$\tilde{J}^i\f$.
+ *
+ * \f{align}
+ *  \tilde{J}^i_\mathrm{drift}
+ *    = \alpha \sqrt{\gamma} q \frac{\epsilon^{ijk}_{(3)}E_jB_k}{B_lB^l}
+ * \f}
+ *
+ * where \f$\alpha\f$ is lapse, \f$\gamma\f$ is the determinant of the spatial
+ * metric, \f$q\f$ is charge density, \f$\epsilon^{ijk}_{(3)}\f$ is the spatial
+ * Levi-Civita tensor, \f$E^i\f$ is the electric field, and \f$B^i\f$ is the
+ * magnetic field.
+ *
+ */
+struct ComputeDriftTildeJ {
+  using argument_tags =
+      tmpl::list<Tags::TildeQ, Tags::TildeE, Tags::TildeB,
+                 Tags::ParallelConductivity, gr::Tags::Lapse<>,
+                 gr::Tags::SqrtDetSpatialMetric<>, gr::Tags::SpatialMetric<3>>;
+  using return_type = tnsr::I<DataVector, 3>;
+
+  static void apply(
+      gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> drift_tilde_j,
+      const Scalar<DataVector>& tilde_q,
+      const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_e,
+      const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_b,
+      double parallel_conductivity, const Scalar<DataVector>& lapse,
+      const Scalar<DataVector>& sqrt_det_spatial_metric,
+      const tnsr::ii<DataVector, 3, Frame::Inertial>& spatial_metric);
+};
+
+/*!
+ * \brief Computes the stiff part \f$\tilde{J}^i_\mathrm{parallel}\f$ of the
+ * generalized electric current density \f$\tilde{J}^i\f$.
+ *
+ * \f{align*}
+ *  \tilde{J}^i_\mathrm{parallel}
+ *    & = \alpha \sqrt{\gamma} \eta \left[
+ *        \frac{(E_lB^l)B^i}{B^2} + \frac{\mathcal{R}(E^2-B^2)}{B^2} E^i
+ *      \right]
+ * \f}
+ *
+ * where \f$\alpha\f$ is lapse, \f$\gamma\f$ is the determinant of the spatial
+ * metric, \f$E^i\f$ is the electric field, \f$B^i\f$ is the magnetic field,
+ * \f$\eta\f$ is the parallel conductivity, and \f$\mathcal{R}(x) = \max
+ * (x,0)\f$ is the rectifier function.
+ *
+ */
+struct ComputeParallelTildeJ {
+  using argument_tags =
+      tmpl::list<Tags::TildeQ, Tags::TildeE, Tags::TildeB,
+                 Tags::ParallelConductivity, gr::Tags::Lapse<>,
+                 gr::Tags::SqrtDetSpatialMetric<>, gr::Tags::SpatialMetric<3>>;
+  using return_type = tnsr::I<DataVector, 3>;
+
+  static void apply(
+      gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> parallel_tilde_j,
+      const Scalar<DataVector>& tilde_q,
+      const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_e,
+      const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_b,
+      double parallel_conductivity, const Scalar<DataVector>& lapse,
+      const Scalar<DataVector>& sqrt_det_spatial_metric,
+      const tnsr::ii<DataVector, 3, Frame::Inertial>& spatial_metric);
+};
+
+namespace Tags {
+/*!
+ * \brief Computes the densitized electric current density \f$\tilde{J}^i\f$.
+ *
+ * \f{align}
+ *  \tilde{J}^i = \tilde{J}^i_\mathrm{drift} + \tilde{J}^i_\mathrm{parallel}
+ *   = \alpha \left[
+ *      \tilde{q} \frac{\epsilon^{ijk}_{(3)}\tilde{E}_j \tilde{B}_k}
+ *                     {\tilde{B}_l \tilde{B}^l}
+ *      + \eta \left\{
+ *        \frac{(\tilde{E}_l\tilde{B}^l)\tilde{B}^i}{\tilde{B}^2}
+ *      + \frac{\mathcal{R}(\tilde{E}^2-\tilde{B}^2)}{\tilde{B}^2} \tilde{E}^i
+ *      \right\}
+ * \right]
+ * \f}
+ *
+ * See ComputeDriftTildeJ and ComputeParallelTildeJ for the details of each
+ * terms.
+ *
+ */
+struct ComputeTildeJ : TildeJ, db::ComputeTag {
+  using argument_tags =
+      tmpl::list<Tags::TildeQ, Tags::TildeE, Tags::TildeB,
+                 Tags::ParallelConductivity, gr::Tags::Lapse<>,
+                 gr::Tags::SqrtDetSpatialMetric<>, gr::Tags::SpatialMetric<3>>;
+  using return_type = tnsr::I<DataVector, 3>;
+  using base = TildeJ;
+
+  static void function(
+      gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> tilde_j,
+      const Scalar<DataVector>& tilde_q,
+      const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_e,
+      const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_b,
+      double parallel_conductivity, const Scalar<DataVector>& lapse,
+      const Scalar<DataVector>& sqrt_det_spatial_metric,
+      const tnsr::ii<DataVector, 3, Frame::Inertial>& spatial_metric);
+};
+}  // namespace Tags
+
+}  // namespace ForceFree

--- a/src/Evolution/Systems/ForceFree/Fluxes.cpp
+++ b/src/Evolution/Systems/ForceFree/Fluxes.cpp
@@ -37,10 +37,9 @@ void fluxes_impl(
     const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_b,
     const Scalar<DataVector>& tilde_psi, const Scalar<DataVector>& tilde_phi,
     const Scalar<DataVector>& tilde_q,
-    const tnsr::I<DataVector, 3, Frame::Inertial>& spatial_current_density,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_j,
     const Scalar<DataVector>& lapse,
     const tnsr::I<DataVector, 3, Frame::Inertial>& shift,
-    const Scalar<DataVector>& sqrt_det_spatial_metric,
     const tnsr::II<DataVector, 3, Frame::Inertial>& inv_spatial_metric) {
   for (size_t j = 0; j < 3; ++j) {
     tilde_psi_flux->get(j) =
@@ -49,9 +48,7 @@ void fluxes_impl(
     tilde_phi_flux->get(j) =
         -shift.get(j) * get(tilde_phi) + get(lapse) * tilde_b.get(j);
 
-    tilde_q_flux->get(j) = get(lapse) * get(sqrt_det_spatial_metric) *
-                               spatial_current_density.get(j) -
-                           shift.get(j) * get(tilde_q);
+    tilde_q_flux->get(j) = tilde_j.get(j) - shift.get(j) * get(tilde_q);
 
     for (size_t i = 0; i < 3; ++i) {
       tilde_e_flux->get(j, i) =
@@ -89,7 +86,7 @@ void Fluxes::apply(
     const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_b,
     const Scalar<DataVector>& tilde_psi, const Scalar<DataVector>& tilde_phi,
     const Scalar<DataVector>& tilde_q,
-    const tnsr::I<DataVector, 3, Frame::Inertial>& spatial_current_density,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_j,
     const Scalar<DataVector>& lapse,
     const tnsr::I<DataVector, 3, Frame::Inertial>& shift,
     const Scalar<DataVector>& sqrt_det_spatial_metric,
@@ -121,8 +118,8 @@ void Fluxes::apply(
       // temporaries
       lapse_times_electric_field_one_form, lapse_times_magnetic_field_one_form,
       // extra args
-      tilde_e, tilde_b, tilde_psi, tilde_phi, tilde_q, spatial_current_density,
-      lapse, shift, sqrt_det_spatial_metric, inv_spatial_metric);
+      tilde_e, tilde_b, tilde_psi, tilde_phi, tilde_q, tilde_j, lapse, shift,
+      inv_spatial_metric);
 }
 
 }  // namespace ForceFree

--- a/src/Evolution/Systems/ForceFree/Fluxes.hpp
+++ b/src/Evolution/Systems/ForceFree/Fluxes.hpp
@@ -38,10 +38,9 @@ void fluxes_impl(
     const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_b,
     const Scalar<DataVector>& tilde_psi, const Scalar<DataVector>& tilde_phi,
     const Scalar<DataVector>& tilde_q,
-    const tnsr::I<DataVector, 3, Frame::Inertial>& spatial_current_density,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_j,
     const Scalar<DataVector>& lapse,
     const tnsr::I<DataVector, 3, Frame::Inertial>& shift,
-    const Scalar<DataVector>& sqrt_det_spatial_metric,
     const tnsr::II<DataVector, 3, Frame::Inertial>& inv_spatial_metric);
 }  // namespace detail
 
@@ -94,7 +93,7 @@ struct Fluxes {
 
   using argument_tags =
       tmpl::list<Tags::TildeE, Tags::TildeB, Tags::TildePsi, Tags::TildePhi,
-                 Tags::TildeQ, Tags::SpatialCurrentDensity, gr::Tags::Lapse<>,
+                 Tags::TildeQ, Tags::TildeJ, gr::Tags::Lapse<>,
                  gr::Tags::Shift<3>, gr::Tags::SqrtDetSpatialMetric<>,
                  gr::Tags::SpatialMetric<3>, gr::Tags::InverseSpatialMetric<3>>;
 
@@ -108,7 +107,7 @@ struct Fluxes {
       const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_b,
       const Scalar<DataVector>& tilde_psi, const Scalar<DataVector>& tilde_phi,
       const Scalar<DataVector>& tilde_q,
-      const tnsr::I<DataVector, 3, Frame::Inertial>& spatial_current_density,
+      const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_j,
       const Scalar<DataVector>& lapse,
       const tnsr::I<DataVector, 3, Frame::Inertial>& shift,
       const Scalar<DataVector>& sqrt_det_spatial_metric,

--- a/src/Evolution/Systems/ForceFree/Sources.hpp
+++ b/src/Evolution/Systems/ForceFree/Sources.hpp
@@ -32,14 +32,13 @@ void sources_impl(
     const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_b,
     const Scalar<DataVector>& tilde_psi, const Scalar<DataVector>& tilde_phi,
     const Scalar<DataVector>& tilde_q,
-    const tnsr::I<DataVector, 3, Frame::Inertial>& spatial_current_density,
-    const double kappa_psi, const double kappa_phi,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_j_drift,
+    double kappa_psi, double kappa_phi,
     // GR args
     const Scalar<DataVector>& lapse,
     const tnsr::i<DataVector, 3, Frame::Inertial>& d_lapse,
     const tnsr::iJ<DataVector, 3, Frame::Inertial>& d_shift,
     const tnsr::II<DataVector, 3, Frame::Inertial>& inv_spatial_metric,
-    const Scalar<DataVector>& sqrt_det_spatial_metric,
     const tnsr::ii<DataVector, 3, Frame::Inertial>& extrinsic_curvature);
 }  // namespace detail
 
@@ -82,7 +81,7 @@ struct Sources {
   using argument_tags = tmpl::list<
       // EM variables
       Tags::TildeE, Tags::TildeB, Tags::TildePsi, Tags::TildePhi, Tags::TildeQ,
-      Tags::SpatialCurrentDensity, Tags::KappaPsi, Tags::KappaPhi,
+      Tags::KappaPsi, Tags::KappaPhi, Tags::ParallelConductivity,
       // GR variables
       gr::Tags::Lapse<>,
       ::Tags::deriv<gr::Tags::Lapse<DataVector>, tmpl::size_t<3>,
@@ -91,7 +90,8 @@ struct Sources {
                     tmpl::size_t<3>, Frame::Inertial>,
       ::Tags::deriv<gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>,
                     tmpl::size_t<3>, Frame::Inertial>,
-      gr::Tags::InverseSpatialMetric<3>, gr::Tags::SqrtDetSpatialMetric<>,
+      gr::Tags::SpatialMetric<3>, gr::Tags::InverseSpatialMetric<3>,
+      gr::Tags::SqrtDetSpatialMetric<>,
       gr::Tags::ExtrinsicCurvature<3, Frame::Inertial, DataVector>>;
 
   static void apply(
@@ -103,14 +103,14 @@ struct Sources {
       const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_e,
       const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_b,
       const Scalar<DataVector>& tilde_psi, const Scalar<DataVector>& tilde_phi,
-      const Scalar<DataVector>& tilde_q,
-      const tnsr::I<DataVector, 3, Frame::Inertial>& spatial_current_density,
-      const double kappa_psi, const double kappa_phi,
+      const Scalar<DataVector>& tilde_q, double kappa_psi, double kappa_phi,
+      double parallel_conductivity,
       // GR variables
       const Scalar<DataVector>& lapse,
       const tnsr::i<DataVector, 3, Frame::Inertial>& d_lapse,
       const tnsr::iJ<DataVector, 3, Frame::Inertial>& d_shift,
       const tnsr::ijj<DataVector, 3, Frame::Inertial>& d_spatial_metric,
+      const tnsr::ii<DataVector, 3, Frame::Inertial>& spatial_metric,
       const tnsr::II<DataVector, 3, Frame::Inertial>& inv_spatial_metric,
       const Scalar<DataVector>& sqrt_det_spatial_metric,
       const tnsr::ii<DataVector, 3, Frame::Inertial>& extrinsic_curvature);

--- a/src/Evolution/Systems/ForceFree/Tags.hpp
+++ b/src/Evolution/Systems/ForceFree/Tags.hpp
@@ -43,7 +43,7 @@ struct ChargeDensity : db::SimpleTag {
 /*!
  * \brief The spatial electric current density \f$J^i\f$.
  */
-struct SpatialCurrentDensity : db::SimpleTag {
+struct ElectricCurrentDensity : db::SimpleTag {
   using type = tnsr::I<DataVector, 3>;
 };
 
@@ -99,6 +99,14 @@ struct TildePhi : db::SimpleTag {
  */
 struct TildeQ : db::SimpleTag {
   using type = Scalar<DataVector>;
+};
+
+/*!
+ * \brief The densitized electric current density \f$\tilde{J}^i =
+ * \alpha\sqrt{\gamma}J^i\f$.
+ */
+struct TildeJ : db::SimpleTag {
+  using type = tnsr::I<DataVector, 3>;
 };
 
 /*!
@@ -211,6 +219,21 @@ struct KappaPhi : db::SimpleTag {
     return kappa_phi;
   }
 };
+
+/*!
+ * \brief The damping parameter \f$\eta\f$ in the electric current density to
+ * impose force-free conditions. Physically, this parameter is the conductivity
+ * parallel to magnetic field lines.
+ */
+struct ParallelConductivity : db::SimpleTag {
+  using type = double;
+  using option_tags = tmpl::list<OptionTags::ParallelConductivity>;
+  static constexpr bool pass_metavariables = false;
+  static double create_from_options(const double parallel_conductivity) {
+    return parallel_conductivity;
+  }
+};
+
 }  // namespace Tags
 
 }  // namespace ForceFree

--- a/src/Evolution/Systems/ForceFree/TimeDerivativeTerms.cpp
+++ b/src/Evolution/Systems/ForceFree/TimeDerivativeTerms.cpp
@@ -5,6 +5,7 @@
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "Evolution/Systems/ForceFree/ElectricCurrentDensity.hpp"
 #include "Evolution/Systems/ForceFree/Fluxes.hpp"
 #include "Evolution/Systems/ForceFree/Sources.hpp"
 #include "Evolution/Systems/ForceFree/TimeDerivativeTerms.hpp"
@@ -35,6 +36,7 @@ void TimeDerivativeTerms::apply(
         lapse_times_electric_field_one_form,
     const gsl::not_null<tnsr::i<DataVector, 3, Frame::Inertial>*>
         lapse_times_magnetic_field_one_form,
+    const gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> tilde_j_drift,
     const gsl::not_null<tnsr::ijj<DataVector, 3, Frame::Inertial>*>
         spatial_christoffel_first_kind,
     const gsl::not_null<tnsr::Ijj<DataVector, 3, Frame::Inertial>*>
@@ -51,8 +53,9 @@ void TimeDerivativeTerms::apply(
     const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_b,
     const Scalar<DataVector>& tilde_psi, const Scalar<DataVector>& tilde_phi,
     const Scalar<DataVector>& tilde_q,
-    const tnsr::I<DataVector, 3, Frame::Inertial>& spatial_current_density,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_j,
     const double kappa_psi, const double kappa_phi,
+    const double parallel_conductivity,
 
     const Scalar<DataVector>& lapse,
     const tnsr::I<DataVector, 3, Frame::Inertial>& shift,
@@ -84,10 +87,12 @@ void TimeDerivativeTerms::apply(
       tilde_e_flux, tilde_b_flux, tilde_psi_flux, tilde_phi_flux, tilde_q_flux,
       *lapse_times_electric_field_one_form,
       *lapse_times_magnetic_field_one_form, tilde_e, tilde_b, tilde_psi,
-      tilde_phi, tilde_q, spatial_current_density, lapse, shift,
-      sqrt_det_spatial_metric, inv_spatial_metric);
+      tilde_phi, tilde_q, tilde_j, lapse, shift, inv_spatial_metric);
 
   // Compute source terms
+  ComputeDriftTildeJ::apply(tilde_j_drift, tilde_q, tilde_e, tilde_b,
+                            parallel_conductivity, lapse,
+                            sqrt_det_spatial_metric, spatial_metric);
   gr::christoffel_first_kind(spatial_christoffel_first_kind, d_spatial_metric);
   raise_or_lower_first_index(spatial_christoffel_second_kind,
                              *spatial_christoffel_first_kind,
@@ -98,9 +103,8 @@ void TimeDerivativeTerms::apply(
   detail::sources_impl(non_flux_terms_dt_tilde_e, non_flux_terms_dt_tilde_b,
                        non_flux_terms_dt_tilde_psi, non_flux_terms_dt_tilde_phi,
                        *trace_spatial_christoffel_second, tilde_e, tilde_b,
-                       tilde_psi, tilde_phi, tilde_q, spatial_current_density,
-                       kappa_psi, kappa_phi, lapse, d_lapse, d_shift,
-                       inv_spatial_metric, sqrt_det_spatial_metric,
+                       tilde_psi, tilde_phi, tilde_q, *tilde_j_drift, kappa_psi,
+                       kappa_phi, lapse, d_lapse, d_shift, inv_spatial_metric,
                        extrinsic_curvature);
 }
 

--- a/src/Evolution/Systems/ForceFree/TimeDerivativeTerms.hpp
+++ b/src/Evolution/Systems/ForceFree/TimeDerivativeTerms.hpp
@@ -31,12 +31,16 @@ struct TimeDerivativeTerms {
   struct LapseTimesMagneticFieldOneForm : db::SimpleTag {
     using type = tnsr::i<DataVector, 3, Frame::Inertial>;
   };
+  struct TildeJDrift : db::SimpleTag {
+    using type = tnsr::I<DataVector, 3, Frame::Inertial>;
+  };
 
   using temporary_tags = tmpl::list<
       // Flux terms
       LapseTimesElectricFieldOneForm, LapseTimesMagneticFieldOneForm,
 
       // Source terms
+      TildeJDrift,
       gr::Tags::SpatialChristoffelFirstKind<3, Frame::Inertial, DataVector>,
       gr::Tags::SpatialChristoffelSecondKind<3, Frame::Inertial, DataVector>,
       gr::Tags::TraceSpatialChristoffelSecondKind<3, Frame::Inertial,
@@ -49,7 +53,7 @@ struct TimeDerivativeTerms {
   using argument_tags = tmpl::list<
       // EM tags
       Tags::TildeE, Tags::TildeB, Tags::TildePsi, Tags::TildePhi, Tags::TildeQ,
-      Tags::SpatialCurrentDensity, Tags::KappaPsi, Tags::KappaPhi,
+      Tags::TildeJ, Tags::KappaPsi, Tags::KappaPhi, Tags::ParallelConductivity,
 
       // GR-related tags
       gr::Tags::Lapse<>, gr::Tags::Shift<3>, gr::Tags::SqrtDetSpatialMetric<>,
@@ -85,6 +89,7 @@ struct TimeDerivativeTerms {
           lapse_times_electric_field_one_form,
       gsl::not_null<tnsr::i<DataVector, 3, Frame::Inertial>*>
           lapse_times_magnetic_field_one_form,
+      gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> tilde_j_drift,
       gsl::not_null<tnsr::ijj<DataVector, 3, Frame::Inertial>*>
           spatial_christoffel_first_kind,
       gsl::not_null<tnsr::Ijj<DataVector, 3, Frame::Inertial>*>
@@ -102,8 +107,9 @@ struct TimeDerivativeTerms {
       const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_b,
       const Scalar<DataVector>& tilde_psi, const Scalar<DataVector>& tilde_phi,
       const Scalar<DataVector>& tilde_q,
-      const tnsr::I<DataVector, 3, Frame::Inertial>& spatial_current_density,
+      const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_j,
       const double kappa_psi, const double kappa_phi,
+      const double parallel_conductivity,
 
       const Scalar<DataVector>& lapse,
       const tnsr::I<DataVector, 3, Frame::Inertial>& shift,

--- a/src/Evolution/Systems/ForceFree/VolumeTermsInstantiation.cpp
+++ b/src/Evolution/Systems/ForceFree/VolumeTermsInstantiation.cpp
@@ -46,8 +46,9 @@ template void volume_terms<::ForceFree::TimeDerivativeTerms>(
     const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_b,
     const Scalar<DataVector>& tilde_psi, const Scalar<DataVector>& tilde_phi,
     const Scalar<DataVector>& tilde_q,
-    const tnsr::I<DataVector, 3, Frame::Inertial>& spatial_current_density,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_j_drift,
     const double& kappa_psi, const double& kappa_phi,
+    const double& parallel_conductivity,
 
     const Scalar<DataVector>& lapse,
     const tnsr::I<DataVector, 3, Frame::Inertial>& shift,

--- a/tests/Unit/Evolution/Systems/ForceFree/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/ForceFree/CMakeLists.txt
@@ -7,6 +7,7 @@ set(LIBRARY_SOURCES
   BoundaryConditions/Test_Periodic.cpp
   BoundaryCorrections/Test_Rusanov.cpp
   Test_Characteristics.cpp
+  Test_ElectricCurrentDensity.cpp
   Test_Fluxes.cpp
   Test_Sources.cpp
   Test_Tags.cpp

--- a/tests/Unit/Evolution/Systems/ForceFree/ElectricCurrentDensity.py
+++ b/tests/Unit/Evolution/Systems/ForceFree/ElectricCurrentDensity.py
@@ -1,0 +1,51 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+
+
+def levi_civita_symbol(i, j, k):
+    return np.sign(j - i) * np.sign(k - i) * np.sign(k - j)
+
+
+def tilde_j_drift(tilde_q, tilde_e, tilde_b, parallel_conductivity, lapse,
+                  sqrt_det_spatial_metric, spatial_metric):
+    tilde_e_one_form = np.einsum("a, ia", tilde_e, spatial_metric)
+    tilde_b_one_form = np.einsum("a, ia", tilde_b, spatial_metric)
+    tilde_b_squared = np.einsum("a, a", tilde_b_one_form, tilde_b)
+
+    result = tilde_e * 0.0
+
+    for i in range(3):
+        for j in range(3):
+            for k in range(3):
+                e_ijk = levi_civita_symbol(i, j, k) / sqrt_det_spatial_metric
+                result[i] += e_ijk * tilde_e_one_form[j] * tilde_b_one_form[k]
+
+    # overall scaling
+    result = result * lapse * tilde_q / tilde_b_squared
+
+    return result
+
+
+def tilde_j_parallel(tilde_q, tilde_e, tilde_b, parallel_conductivity, lapse,
+                     sqrt_det_spatial_metric, spatial_metric):
+    tilde_e_one_form = np.einsum("a, ia", tilde_e, spatial_metric)
+    tilde_b_one_form = np.einsum("a, ia", tilde_b, spatial_metric)
+
+    tilde_e_squared = np.einsum("a, a", tilde_e_one_form, tilde_e)
+    tilde_b_squared = np.einsum("a, a", tilde_b_one_form, tilde_b)
+    tilde_e_dot_tilde_b = np.einsum("a, a", tilde_e_one_form, tilde_b)
+
+    return parallel_conductivity * lapse * (
+        tilde_e_dot_tilde_b * tilde_b + max(tilde_e_squared - tilde_b_squared,
+                                            0.0) * tilde_e) / tilde_b_squared
+
+
+def tilde_j(tilde_q, tilde_e, tilde_b, parallel_conductivity, lapse,
+            sqrt_det_spatial_metric, spatial_metric):
+    return tilde_j_drift(
+        tilde_q, tilde_e, tilde_b, parallel_conductivity, lapse,
+        sqrt_det_spatial_metric, spatial_metric) + tilde_j_parallel(
+            tilde_q, tilde_e, tilde_b, parallel_conductivity, lapse,
+            sqrt_det_spatial_metric, spatial_metric)

--- a/tests/Unit/Evolution/Systems/ForceFree/Fluxes.py
+++ b/tests/Unit/Evolution/Systems/ForceFree/Fluxes.py
@@ -8,9 +8,9 @@ def levi_civita_symbol(i, j, k):
     return np.sign(j - i) * np.sign(k - i) * np.sign(k - j)
 
 
-def tilde_e_flux(tilde_e, tilde_b, tilde_psi, tilde_phi, tilde_q,
-                 current_density, lapse, shift, sqrt_det_spatial_metric,
-                 spatial_metric, inv_spatial_metric):
+def tilde_e_flux(tilde_e, tilde_b, tilde_psi, tilde_phi, tilde_q, tilde_j,
+                 lapse, shift, sqrt_det_spatial_metric, spatial_metric,
+                 inv_spatial_metric):
     magnetic_field_one_form = np.einsum(
         "a, ia", tilde_b, spatial_metric) / sqrt_det_spatial_metric
 
@@ -26,9 +26,9 @@ def tilde_e_flux(tilde_e, tilde_b, tilde_psi, tilde_phi, tilde_q,
     return result
 
 
-def tilde_b_flux(tilde_e, tilde_b, tilde_psi, tilde_phi, tilde_q,
-                 current_density, lapse, shift, sqrt_det_spatial_metric,
-                 spatial_metric, inv_spatial_metric):
+def tilde_b_flux(tilde_e, tilde_b, tilde_psi, tilde_phi, tilde_q, tilde_j,
+                 lapse, shift, sqrt_det_spatial_metric, spatial_metric,
+                 inv_spatial_metric):
     electric_field_one_form = np.einsum(
         "a, ia", tilde_e, spatial_metric) / sqrt_det_spatial_metric
 
@@ -44,20 +44,19 @@ def tilde_b_flux(tilde_e, tilde_b, tilde_psi, tilde_phi, tilde_q,
     return result
 
 
-def tilde_psi_flux(tilde_e, tilde_b, tilde_psi, tilde_phi, tilde_q,
-                   current_density, lapse, shift, sqrt_det_spatial_metric,
-                   spatial_metric, inv_spatial_metric):
+def tilde_psi_flux(tilde_e, tilde_b, tilde_psi, tilde_phi, tilde_q, tilde_j,
+                   lapse, shift, sqrt_det_spatial_metric, spatial_metric,
+                   inv_spatial_metric):
     return -shift * tilde_psi + lapse * tilde_e
 
 
-def tilde_phi_flux(tilde_e, tilde_b, tilde_psi, tilde_phi, tilde_q,
-                   current_density, lapse, shift, sqrt_det_spatial_metric,
-                   spatial_metric, inv_spatial_metric):
+def tilde_phi_flux(tilde_e, tilde_b, tilde_psi, tilde_phi, tilde_q, tilde_j,
+                   lapse, shift, sqrt_det_spatial_metric, spatial_metric,
+                   inv_spatial_metric):
     return -shift * tilde_phi + lapse * tilde_b
 
 
-def tilde_q_flux(tilde_e, tilde_b, tilde_psi, tilde_phi, tilde_q,
-                 current_density, lapse, shift, sqrt_det_spatial_metric,
-                 spatial_metric, inv_spatial_metric):
-    return (lapse * sqrt_det_spatial_metric * current_density -
-            shift * tilde_q)
+def tilde_q_flux(tilde_e, tilde_b, tilde_psi, tilde_phi, tilde_q, tilde_j,
+                 lapse, shift, sqrt_det_spatial_metric, spatial_metric,
+                 inv_spatial_metric):
+    return (tilde_j - shift * tilde_q)

--- a/tests/Unit/Evolution/Systems/ForceFree/Sources.py
+++ b/tests/Unit/Evolution/Systems/ForceFree/Sources.py
@@ -2,6 +2,7 @@
 # See LICENSE.txt for details.
 
 import numpy as np
+from ElectricCurrentDensity import tilde_j_drift
 
 
 def trace_spatial_Gamma_second_kind(inv_spatial_metric, d_spatial_metric):
@@ -12,20 +13,20 @@ def trace_spatial_Gamma_second_kind(inv_spatial_metric, d_spatial_metric):
         "ia, a", inv_spatial_metric, term_two)
 
 
-def source_tilde_e(tilde_e, tilde_b, tilde_psi, tilde_phi, tilde_q,
-                   current_density, kappa_psi, kappa_phi, lapse, d_lapse,
-                   d_shift, d_spatial_metric, inv_spatial_metric,
+def source_tilde_e(tilde_e, tilde_b, tilde_psi, tilde_phi, tilde_q, kappa_psi,
+                   kappa_phi, parallel_conductivity, lapse, d_lapse, d_shift,
+                   d_spatial_metric, spatial_metric, inv_spatial_metric,
                    sqrt_det_spatial_metric, extrinsic_curvature):
-    return -lapse * sqrt_det_spatial_metric * current_density - np.einsum(
-        "a, ai", tilde_e,
-        d_shift) + tilde_psi * (np.einsum("a, ia", d_lapse, inv_spatial_metric)
-                                - lapse * trace_spatial_Gamma_second_kind(
-                                    inv_spatial_metric, d_spatial_metric))
+    tilde_j = tilde_j_drift(tilde_q, tilde_e, tilde_b, parallel_conductivity,
+                            lapse, sqrt_det_spatial_metric, spatial_metric)
+    return -tilde_j - np.einsum("a, ai", tilde_e, d_shift) + tilde_psi * (
+        np.einsum("a, ia", d_lapse, inv_spatial_metric) - lapse *
+        trace_spatial_Gamma_second_kind(inv_spatial_metric, d_spatial_metric))
 
 
-def source_tilde_b(tilde_e, tilde_b, tilde_psi, tilde_phi, tilde_q,
-                   current_density, kappa_psi, kappa_phi, lapse, d_lapse,
-                   d_shift, d_spatial_metric, inv_spatial_metric,
+def source_tilde_b(tilde_e, tilde_b, tilde_psi, tilde_phi, tilde_q, kappa_psi,
+                   kappa_phi, parallel_conductivity, lapse, d_lapse, d_shift,
+                   d_spatial_metric, spatial_metric, inv_spatial_metric,
                    sqrt_det_spatial_metric, extrinsic_curvature):
     return -np.einsum("a, ai", tilde_b, d_shift) + tilde_phi * (
         np.einsum("a, ia", d_lapse, inv_spatial_metric) - lapse *
@@ -33,9 +34,10 @@ def source_tilde_b(tilde_e, tilde_b, tilde_psi, tilde_phi, tilde_q,
 
 
 def source_tilde_phi(tilde_e, tilde_b, tilde_psi, tilde_phi, tilde_q,
-                     current_density, kappa_psi, kappa_phi, lapse, d_lapse,
-                     d_shift, d_spatial_metric, inv_spatial_metric,
-                     sqrt_det_spatial_metric, extrinsic_curvature):
+                     kappa_psi, kappa_phi, parallel_conductivity, lapse,
+                     d_lapse, d_shift, d_spatial_metric, spatial_metric,
+                     inv_spatial_metric, sqrt_det_spatial_metric,
+                     extrinsic_curvature):
 
     return np.einsum(
         "a, a", tilde_b, d_lapse) - lapse * tilde_phi * (np.einsum(
@@ -43,9 +45,10 @@ def source_tilde_phi(tilde_e, tilde_b, tilde_psi, tilde_phi, tilde_q,
 
 
 def source_tilde_psi(tilde_e, tilde_b, tilde_psi, tilde_phi, tilde_q,
-                     current_density, kappa_psi, kappa_phi, lapse, d_lapse,
-                     d_shift, d_spatial_metric, inv_spatial_metric,
-                     sqrt_det_spatial_metric, extrinsic_curvature):
+                     kappa_psi, kappa_phi, parallel_conductivity, lapse,
+                     d_lapse, d_shift, d_spatial_metric, spatial_metric,
+                     inv_spatial_metric, sqrt_det_spatial_metric,
+                     extrinsic_curvature):
     return np.einsum(
         "a, a", tilde_e,
         d_lapse) + lapse * tilde_q - lapse * tilde_psi * (np.einsum(

--- a/tests/Unit/Evolution/Systems/ForceFree/Test_ElectricCurrentDensity.cpp
+++ b/tests/Unit/Evolution/Systems/ForceFree/Test_ElectricCurrentDensity.cpp
@@ -1,0 +1,27 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include "DataStructures/DataVector.hpp"
+#include "Evolution/Systems/ForceFree/ElectricCurrentDensity.hpp"
+#include "Framework/CheckWithRandomValues.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.ForceFree.ElectricCurrentDensity",
+                  "[Unit][Evolution]") {
+  pypp::SetupLocalPythonEnvironment local_python_env{
+      "Evolution/Systems/ForceFree"};
+
+  pypp::check_with_random_values<1>(&ForceFree::ComputeDriftTildeJ::apply,
+                                    "ElectricCurrentDensity", {"tilde_j_drift"},
+                                    {{{-1.0, 1.0}}}, DataVector{5});
+
+  pypp::check_with_random_values<1>(
+      &ForceFree::ComputeParallelTildeJ::apply, "ElectricCurrentDensity",
+      {"tilde_j_parallel"}, {{{-1.0, 1.0}}}, DataVector{5});
+
+  pypp::check_with_random_values<1>(&ForceFree::Tags::ComputeTildeJ::function,
+                                    "ElectricCurrentDensity", {"tilde_j"},
+                                    {{{-1.0, 1.0}}}, DataVector{5});
+}

--- a/tests/Unit/Evolution/Systems/ForceFree/Test_Tags.cpp
+++ b/tests/Unit/Evolution/Systems/ForceFree/Test_Tags.cpp
@@ -30,8 +30,8 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.ForceFree.Tags",
   TestHelpers::db::test_simple_tag<ForceFree::Tags::TildeQ>("TildeQ");
 
   // etc.
-  TestHelpers::db::test_simple_tag<ForceFree::Tags::SpatialCurrentDensity>(
-      "SpatialCurrentDensity");
+  TestHelpers::db::test_simple_tag<ForceFree::Tags::ElectricCurrentDensity>(
+      "ElectricCurrentDensity");
   TestHelpers::db::test_simple_tag<ForceFree::Tags::KappaPsi>("KappaPsi");
   TestHelpers::db::test_simple_tag<ForceFree::Tags::KappaPhi>("KappaPhi");
 }

--- a/tests/Unit/Evolution/Systems/ForceFree/Test_TimeDerivativeTerms.cpp
+++ b/tests/Unit/Evolution/Systems/ForceFree/Test_TimeDerivativeTerms.cpp
@@ -34,8 +34,9 @@ void forward_to_time_deriv(
     const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_b,
     const Scalar<DataVector>& tilde_psi, const Scalar<DataVector>& tilde_phi,
     const Scalar<DataVector>& tilde_q,
-    const tnsr::I<DataVector, 3, Frame::Inertial>& spatial_current_density,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_j_drift,
     const double kappa_psi, const double kappa_phi,
+    const double parallel_conductivity,
 
     const Scalar<DataVector>& lapse,
     const tnsr::I<DataVector, 3, Frame::Inertial>& shift,
@@ -62,6 +63,8 @@ void forward_to_time_deriv(
                              LapseTimesElectricFieldOneForm>(temp)),
       make_not_null(&get<typename ForceFree::TimeDerivativeTerms::
                              LapseTimesMagneticFieldOneForm>(temp)),
+      make_not_null(
+          &get<typename ForceFree::TimeDerivativeTerms::TildeJDrift>(temp)),
 
       make_not_null(
           &get<gr::Tags::SpatialChristoffelFirstKind<3, Frame::Inertial,
@@ -77,8 +80,8 @@ void forward_to_time_deriv(
       make_not_null(&get<gr::Tags::Shift<3>>(temp)),
       make_not_null(&get<gr::Tags::InverseSpatialMetric<3>>(temp)),
 
-      tilde_e, tilde_b, tilde_psi, tilde_phi, tilde_q, spatial_current_density,
-      kappa_psi, kappa_phi,
+      tilde_e, tilde_b, tilde_psi, tilde_phi, tilde_q, tilde_j_drift, kappa_psi,
+      kappa_phi, parallel_conductivity,
 
       lapse, shift, sqrt_det_spatial_metric, spatial_metric, inv_spatial_metric,
       extrinsic_curvature, d_lapse, d_shift, d_spatial_metric);

--- a/tests/Unit/Evolution/Systems/ForceFree/TimeDerivative.py
+++ b/tests/Unit/Evolution/Systems/ForceFree/TimeDerivative.py
@@ -5,106 +5,103 @@ import numpy as np
 import Fluxes, Sources
 
 
-def tilde_e_flux(tilde_e, tilde_b, tilde_psi, tilde_phi, tilde_q,
-                 current_density, kappa_psi, kappa_phi, lapse, shift,
+def tilde_e_flux(tilde_e, tilde_b, tilde_psi, tilde_phi, tilde_q, tilde_j,
+                 kappa_psi, kappa_phi, parallel_conductivity, lapse, shift,
                  sqrt_det_spatial_metric, spatial_metric, inv_spatial_metric,
                  extrinsic_curvature, d_lapse, d_shift, d_spatial_metric):
     return Fluxes.tilde_e_flux(tilde_e, tilde_b, tilde_psi, tilde_phi, tilde_q,
-                               current_density, lapse, shift,
-                               sqrt_det_spatial_metric, spatial_metric,
-                               inv_spatial_metric)
+                               tilde_j, lapse, shift, sqrt_det_spatial_metric,
+                               spatial_metric, inv_spatial_metric)
 
 
-def tilde_b_flux(tilde_e, tilde_b, tilde_psi, tilde_phi, tilde_q,
-                 current_density, kappa_psi, kappa_phi, lapse, shift,
+def tilde_b_flux(tilde_e, tilde_b, tilde_psi, tilde_phi, tilde_q, tilde_j,
+                 kappa_psi, kappa_phi, parallel_conductivity, lapse, shift,
                  sqrt_det_spatial_metric, spatial_metric, inv_spatial_metric,
                  extrinsic_curvature, d_lapse, d_shift, d_spatial_metric):
     return Fluxes.tilde_b_flux(tilde_e, tilde_b, tilde_psi, tilde_phi, tilde_q,
-                               current_density, lapse, shift,
-                               sqrt_det_spatial_metric, spatial_metric,
-                               inv_spatial_metric)
+                               tilde_j, lapse, shift, sqrt_det_spatial_metric,
+                               spatial_metric, inv_spatial_metric)
 
 
-def tilde_psi_flux(tilde_e, tilde_b, tilde_psi, tilde_phi, tilde_q,
-                   current_density, kappa_psi, kappa_phi, lapse, shift,
+def tilde_psi_flux(tilde_e, tilde_b, tilde_psi, tilde_phi, tilde_q, tilde_j,
+                   kappa_psi, kappa_phi, parallel_conductivity, lapse, shift,
                    sqrt_det_spatial_metric, spatial_metric, inv_spatial_metric,
                    extrinsic_curvature, d_lapse, d_shift, d_spatial_metric):
     return Fluxes.tilde_psi_flux(tilde_e, tilde_b, tilde_psi, tilde_phi,
-                                 tilde_q, current_density, lapse, shift,
+                                 tilde_q, tilde_j, lapse, shift,
                                  sqrt_det_spatial_metric, spatial_metric,
                                  inv_spatial_metric)
 
 
-def tilde_phi_flux(tilde_e, tilde_b, tilde_psi, tilde_phi, tilde_q,
-                   current_density, kappa_psi, kappa_phi, lapse, shift,
+def tilde_phi_flux(tilde_e, tilde_b, tilde_psi, tilde_phi, tilde_q, tilde_j,
+                   kappa_psi, kappa_phi, parallel_conductivity, lapse, shift,
                    sqrt_det_spatial_metric, spatial_metric, inv_spatial_metric,
                    extrinsic_curvature, d_lapse, d_shift, d_spatial_metric):
     return Fluxes.tilde_phi_flux(tilde_e, tilde_b, tilde_psi, tilde_phi,
-                                 tilde_q, current_density, lapse, shift,
+                                 tilde_q, tilde_j, lapse, shift,
                                  sqrt_det_spatial_metric, spatial_metric,
                                  inv_spatial_metric)
 
 
-def tilde_q_flux(tilde_e, tilde_b, tilde_psi, tilde_phi, tilde_q,
-                 current_density, kappa_psi, kappa_phi, lapse, shift,
+def tilde_q_flux(tilde_e, tilde_b, tilde_psi, tilde_phi, tilde_q, tilde_j,
+                 kappa_psi, kappa_phi, parallel_conductivity, lapse, shift,
                  sqrt_det_spatial_metric, spatial_metric, inv_spatial_metric,
                  extrinsic_curvature, d_lapse, d_shift, d_spatial_metric):
     return Fluxes.tilde_q_flux(tilde_e, tilde_b, tilde_psi, tilde_phi, tilde_q,
-                               current_density, lapse, shift,
-                               sqrt_det_spatial_metric, spatial_metric,
-                               inv_spatial_metric)
+                               tilde_j, lapse, shift, sqrt_det_spatial_metric,
+                               spatial_metric, inv_spatial_metric)
 
 
-def source_tilde_e(tilde_e, tilde_b, tilde_psi, tilde_phi, tilde_q,
-                   current_density, kappa_psi, kappa_phi, lapse, shift,
+def source_tilde_e(tilde_e, tilde_b, tilde_psi, tilde_phi, tilde_q, tilde_j,
+                   kappa_psi, kappa_phi, parallel_conductivity, lapse, shift,
                    sqrt_det_spatial_metric, spatial_metric, inv_spatial_metric,
                    extrinsic_curvature, d_lapse, d_shift, d_spatial_metric):
     return Sources.source_tilde_e(tilde_e, tilde_b, tilde_psi, tilde_phi,
-                                  tilde_q, current_density, kappa_psi,
-                                  kappa_phi, lapse, d_lapse, d_shift,
-                                  d_spatial_metric, inv_spatial_metric,
-                                  sqrt_det_spatial_metric, extrinsic_curvature)
+                                  tilde_q, kappa_psi, kappa_phi,
+                                  parallel_conductivity, lapse, d_lapse,
+                                  d_shift, d_spatial_metric, spatial_metric,
+                                  inv_spatial_metric, sqrt_det_spatial_metric,
+                                  extrinsic_curvature)
 
 
-def source_tilde_b(tilde_e, tilde_b, tilde_psi, tilde_phi, tilde_q,
-                   current_density, kappa_psi, kappa_phi, lapse, shift,
+def source_tilde_b(tilde_e, tilde_b, tilde_psi, tilde_phi, tilde_q, tilde_j,
+                   kappa_psi, kappa_phi, parallel_conductivity, lapse, shift,
                    sqrt_det_spatial_metric, spatial_metric, inv_spatial_metric,
                    extrinsic_curvature, d_lapse, d_shift, d_spatial_metric):
     return Sources.source_tilde_b(tilde_e, tilde_b, tilde_psi, tilde_phi,
-                                  tilde_q, current_density, kappa_psi,
-                                  kappa_phi, lapse, d_lapse, d_shift,
-                                  d_spatial_metric, inv_spatial_metric,
-                                  sqrt_det_spatial_metric, extrinsic_curvature)
+                                  tilde_q, kappa_psi, kappa_phi,
+                                  parallel_conductivity, lapse, d_lapse,
+                                  d_shift, d_spatial_metric, spatial_metric,
+                                  inv_spatial_metric, sqrt_det_spatial_metric,
+                                  extrinsic_curvature)
 
 
-def source_tilde_psi(tilde_e, tilde_b, tilde_psi, tilde_phi, tilde_q,
-                     current_density, kappa_psi, kappa_phi, lapse, shift,
+def source_tilde_psi(tilde_e, tilde_b, tilde_psi, tilde_phi, tilde_q, tilde_j,
+                     kappa_psi, kappa_phi, parallel_conductivity, lapse, shift,
                      sqrt_det_spatial_metric, spatial_metric,
                      inv_spatial_metric, extrinsic_curvature, d_lapse, d_shift,
                      d_spatial_metric):
-    return Sources.source_tilde_psi(tilde_e, tilde_b, tilde_psi, tilde_phi,
-                                    tilde_q, current_density, kappa_psi,
-                                    kappa_phi, lapse, d_lapse, d_shift,
-                                    d_spatial_metric, inv_spatial_metric,
-                                    sqrt_det_spatial_metric,
-                                    extrinsic_curvature)
+    return Sources.source_tilde_psi(
+        tilde_e, tilde_b, tilde_psi, tilde_phi, tilde_q, kappa_psi, kappa_phi,
+        parallel_conductivity, lapse, d_lapse, d_shift, d_spatial_metric,
+        spatial_metric, inv_spatial_metric, sqrt_det_spatial_metric,
+        extrinsic_curvature)
 
 
-def source_tilde_phi(tilde_e, tilde_b, tilde_psi, tilde_phi, tilde_q,
-                     current_density, kappa_psi, kappa_phi, lapse, shift,
+def source_tilde_phi(tilde_e, tilde_b, tilde_psi, tilde_phi, tilde_q, tilde_j,
+                     kappa_psi, kappa_phi, parallel_conductivity, lapse, shift,
                      sqrt_det_spatial_metric, spatial_metric,
                      inv_spatial_metric, extrinsic_curvature, d_lapse, d_shift,
                      d_spatial_metric):
-    return Sources.source_tilde_phi(tilde_e, tilde_b, tilde_psi, tilde_phi,
-                                    tilde_q, current_density, kappa_psi,
-                                    kappa_phi, lapse, d_lapse, d_shift,
-                                    d_spatial_metric, inv_spatial_metric,
-                                    sqrt_det_spatial_metric,
-                                    extrinsic_curvature)
+    return Sources.source_tilde_phi(
+        tilde_e, tilde_b, tilde_psi, tilde_phi, tilde_q, kappa_psi, kappa_phi,
+        parallel_conductivity, lapse, d_lapse, d_shift, d_spatial_metric,
+        spatial_metric, inv_spatial_metric, sqrt_det_spatial_metric,
+        extrinsic_curvature)
 
 
-def source_tilde_q(tilde_e, tilde_b, tilde_psi, tilde_phi, tilde_q,
-                   current_density, kappa_psi, kappa_phi, lapse, shift,
+def source_tilde_q(tilde_e, tilde_b, tilde_psi, tilde_phi, tilde_q, tilde_j,
+                   kappa_psi, kappa_phi, parallel_conductivity, lapse, shift,
                    sqrt_det_spatial_metric, spatial_metric, inv_spatial_metric,
                    extrinsic_curvature, d_lapse, d_shift, d_spatial_metric):
     return 0.0 * lapse


### PR DESCRIPTION
## Proposed changes

* Rename `SpatialCurrentDensity` to `ElectricCurrentDensity`.
* Add free functions that evaluate J_drift (explicit) and J_parallel (implicit) part of electric current density J.
* Add a compute tag which evaluates the total J (`TildeJ`)

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
