### PR TITLE
Extend Xcts::WrappedGr to GRMHD

### DIFF
--- a/docs/References.bib
+++ b/docs/References.bib
@@ -2062,6 +2062,23 @@ archivePrefix = {arXiv},
     year = "2014"
 }
 
+@article{Tacik2016zal,
+  author        = {Tacik, Nick and Foucart, Francois and Pfeiffer, Harald P.
+                   and Muhlberger, Curran and Kidder, Lawrence E. and Scheel,
+                   Mark A. and Szil\'agyi, B.},
+  title         = {Initial data for black hole-neutron star binaries, with
+                   rotating stars},
+  eprint        = {1607.07962},
+  archiveprefix = {arXiv},
+  primaryclass  = {gr-qc},
+  doi           = {10.1088/0264-9381/33/22/225012},
+  journal       = {Class. Quant. Grav.},
+  volume        = {33},
+  number        = {22},
+  pages         = {225012},
+  year          = {2016}
+}
+
 @article{Teukolsky2015ega,
   author         = "Teukolsky, Saul A.",
   title          = "Formulation of discontinuous {Galerkin} methods for

--- a/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/RotatingStar.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/RotatingStar.hpp
@@ -413,6 +413,10 @@ class RotatingStar : public virtual evolution::initial_data::InitialData,
     return equation_of_state_;
   }
 
+  double equatorial_radius() const {
+    return cst_solution_.equatorial_radius();
+  }
+
  protected:
   template <typename DataType>
   using DerivLapse = ::Tags::deriv<gr::Tags::Lapse<DataType>, tmpl::size_t<3>,

--- a/src/PointwiseFunctions/AnalyticSolutions/Xcts/CMakeLists.txt
+++ b/src/PointwiseFunctions/AnalyticSolutions/Xcts/CMakeLists.txt
@@ -37,6 +37,7 @@ target_link_libraries(
   ErrorHandling
   GeneralRelativity
   GeneralRelativitySolutions
+  GrMhdAnalyticData
   InitialDataUtilities
   Options
   Parallel

--- a/src/PointwiseFunctions/AnalyticSolutions/Xcts/Factory.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Xcts/Factory.hpp
@@ -3,9 +3,12 @@
 
 #pragma once
 
+#include "PointwiseFunctions/AnalyticData/GrMhd/CcsnCollapse.hpp"
+#include "PointwiseFunctions/AnalyticData/GrMhd/MagnetizedTovStar.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/HarmonicSchwarzschild.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/SphericalKerrSchild.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/RelativisticEuler/RotatingStar.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/Xcts/Flatness.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/Xcts/Schwarzschild.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/Xcts/TovStar.hpp"
@@ -18,6 +21,15 @@ namespace Solutions {
 using all_analytic_solutions =
     tmpl::list<Flatness, WrappedGr<gr::Solutions::KerrSchild>,
                WrappedGr<gr::Solutions::SphericalKerrSchild>, Schwarzschild,
-               WrappedGr<gr::Solutions::HarmonicSchwarzschild>, TovStar>;
+               WrappedGr<gr::Solutions::HarmonicSchwarzschild>, TovStar,
+               WrappedGrMhd<RelativisticEuler::Solutions::RotatingStar>,
+               // The following are only approximate solutions to the XCTS
+               // equations. We list them here (as opposed to AnalyticData) to
+               // avoid a cyclic dependency with the `WrappedGr` class, and also
+               // for convenience: by treating them as analytic solutions we can
+               // easily measure the difference between the approximate
+               // (analytic) solution and the numerical solution.
+               WrappedGrMhd<grmhd::AnalyticData::CcsnCollapse>,
+               WrappedGrMhd<grmhd::AnalyticData::MagnetizedTovStar>>;
 }  // namespace Solutions
 }  // namespace Xcts

--- a/src/PointwiseFunctions/AnalyticSolutions/Xcts/TovStar.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Xcts/TovStar.hpp
@@ -188,7 +188,6 @@ class TovStar : public elliptic::analytic_data::AnalyticSolution {
   TovStar& operator=(TovStar&&) = default;
   ~TovStar() = default;
 
-  template <typename... OptionTypes>
   TovStar(double central_rest_mass_density,
           std::unique_ptr<EquationsOfState::EquationOfState<true, 1>>
               equation_of_state,

--- a/src/PointwiseFunctions/AnalyticSolutions/Xcts/WrappedGr.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Xcts/WrappedGr.cpp
@@ -12,14 +12,19 @@
 #include "Elliptic/Systems/Xcts/Tags.hpp"
 #include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
 #include "Options/Options.hpp"
+#include "PointwiseFunctions/AnalyticData/GrMhd/CcsnCollapse.hpp"
+#include "PointwiseFunctions/AnalyticData/GrMhd/MagnetizedTovStar.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/HarmonicSchwarzschild.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/SphericalKerrSchild.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/RelativisticEuler/RotatingStar.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/Xcts/CommonVariables.tpp"
 #include "PointwiseFunctions/Elasticity/Strain.hpp"
 #include "PointwiseFunctions/GeneralRelativity/IndexManipulation.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags/Conformal.hpp"
+#include "PointwiseFunctions/Hydro/ComovingMagneticField.hpp"
+#include "PointwiseFunctions/Hydro/StressEnergy.hpp"
 #include "PointwiseFunctions/Xcts/LongitudinalOperator.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
@@ -28,8 +33,8 @@
 namespace Xcts::Solutions {
 namespace detail {
 
-template <typename DataType>
-void WrappedGrVariables<DataType>::operator()(
+template <typename DataType, bool HasMhd>
+void WrappedGrVariables<DataType, HasMhd>::operator()(
     const gsl::not_null<tnsr::ii<DataType, Dim>*> spatial_metric,
     const gsl::not_null<Cache*> /*cache*/,
     gr::Tags::SpatialMetric<Dim, Frame::Inertial, DataType> /*meta*/) const {
@@ -37,8 +42,8 @@ void WrappedGrVariables<DataType>::operator()(
       get<gr::Tags::SpatialMetric<Dim, Frame::Inertial, DataType>>(gr_solution);
 }
 
-template <typename DataType>
-void WrappedGrVariables<DataType>::operator()(
+template <typename DataType, bool HasMhd>
+void WrappedGrVariables<DataType, HasMhd>::operator()(
     const gsl::not_null<tnsr::II<DataType, Dim>*> inv_spatial_metric,
     const gsl::not_null<Cache*> /*cache*/,
     gr::Tags::InverseSpatialMetric<Dim, Frame::Inertial, DataType> /*meta*/)
@@ -48,8 +53,8 @@ void WrappedGrVariables<DataType>::operator()(
           gr_solution);
 }
 
-template <typename DataType>
-void WrappedGrVariables<DataType>::operator()(
+template <typename DataType, bool HasMhd>
+void WrappedGrVariables<DataType, HasMhd>::operator()(
     const gsl::not_null<tnsr::ijj<DataType, Dim>*> deriv_spatial_metric,
     const gsl::not_null<Cache*> /*cache*/,
     ::Tags::deriv<gr::Tags::SpatialMetric<Dim, Frame::Inertial, DataType>,
@@ -59,8 +64,8 @@ void WrappedGrVariables<DataType>::operator()(
                         tmpl::size_t<Dim>, Frame::Inertial>>(gr_solution);
 }
 
-template <typename DataType>
-void WrappedGrVariables<DataType>::operator()(
+template <typename DataType, bool HasMhd>
+void WrappedGrVariables<DataType, HasMhd>::operator()(
     const gsl::not_null<tnsr::ii<DataType, Dim>*> conformal_metric,
     const gsl::not_null<Cache*> cache,
     Xcts::Tags::ConformalMetric<DataType, Dim, Frame::Inertial> /*meta*/)
@@ -76,8 +81,8 @@ void WrappedGrVariables<DataType>::operator()(
   }
 }
 
-template <typename DataType>
-void WrappedGrVariables<DataType>::operator()(
+template <typename DataType, bool HasMhd>
+void WrappedGrVariables<DataType, HasMhd>::operator()(
     const gsl::not_null<tnsr::II<DataType, Dim>*> inv_conformal_metric,
     const gsl::not_null<Cache*> cache,
     Xcts::Tags::InverseConformalMetric<DataType, Dim, Frame::Inertial> /*meta*/)
@@ -94,8 +99,8 @@ void WrappedGrVariables<DataType>::operator()(
   }
 }
 
-template <typename DataType>
-void WrappedGrVariables<DataType>::operator()(
+template <typename DataType, bool HasMhd>
+void WrappedGrVariables<DataType, HasMhd>::operator()(
     const gsl::not_null<tnsr::ijj<DataType, Dim>*> deriv_conformal_metric,
     const gsl::not_null<Cache*> cache,
     ::Tags::deriv<Xcts::Tags::ConformalMetric<DataType, Dim, Frame::Inertial>,
@@ -122,8 +127,8 @@ void WrappedGrVariables<DataType>::operator()(
   }
 }
 
-template <typename DataType>
-void WrappedGrVariables<DataType>::operator()(
+template <typename DataType, bool HasMhd>
+void WrappedGrVariables<DataType, HasMhd>::operator()(
     const gsl::not_null<Scalar<DataType>*> trace_extrinsic_curvature,
     const gsl::not_null<Cache*> /*cache*/,
     gr::Tags::TraceExtrinsicCurvature<DataType> /*meta*/) const {
@@ -136,24 +141,24 @@ void WrappedGrVariables<DataType>::operator()(
   trace(trace_extrinsic_curvature, extrinsic_curvature, inv_spatial_metric);
 }
 
-template <typename DataType>
-void WrappedGrVariables<DataType>::operator()(
+template <typename DataType, bool HasMhd>
+void WrappedGrVariables<DataType, HasMhd>::operator()(
     const gsl::not_null<Scalar<DataType>*> dt_trace_extrinsic_curvature,
     const gsl::not_null<Cache*> /*cache*/,
     ::Tags::dt<gr::Tags::TraceExtrinsicCurvature<DataType>> /*meta*/) const {
   get(*dt_trace_extrinsic_curvature) = 0.;
 }
 
-template <typename DataType>
-void WrappedGrVariables<DataType>::operator()(
+template <typename DataType, bool HasMhd>
+void WrappedGrVariables<DataType, HasMhd>::operator()(
     const gsl::not_null<Scalar<DataType>*> conformal_factor,
     const gsl::not_null<Cache*> /*cache*/,
     Xcts::Tags::ConformalFactor<DataType> /*meta*/) const {
   get(*conformal_factor) = 1.;
 }
 
-template <typename DataType>
-void WrappedGrVariables<DataType>::operator()(
+template <typename DataType, bool HasMhd>
+void WrappedGrVariables<DataType, HasMhd>::operator()(
     const gsl::not_null<tnsr::i<DataType, Dim>*> conformal_factor_gradient,
     const gsl::not_null<Cache*> /*cache*/,
     ::Tags::deriv<Xcts::Tags::ConformalFactor<DataType>, tmpl::size_t<Dim>,
@@ -162,16 +167,16 @@ void WrappedGrVariables<DataType>::operator()(
             conformal_factor_gradient->end(), 0.);
 }
 
-template <typename DataType>
-void WrappedGrVariables<DataType>::operator()(
+template <typename DataType, bool HasMhd>
+void WrappedGrVariables<DataType, HasMhd>::operator()(
     const gsl::not_null<Scalar<DataType>*> lapse,
     const gsl::not_null<Cache*> /*cache*/,
     gr::Tags::Lapse<DataType> /*meta*/) const {
   *lapse = get<gr::Tags::Lapse<DataType>>(gr_solution);
 }
 
-template <typename DataType>
-void WrappedGrVariables<DataType>::operator()(
+template <typename DataType, bool HasMhd>
+void WrappedGrVariables<DataType, HasMhd>::operator()(
     const gsl::not_null<Scalar<DataType>*> lapse_times_conformal_factor,
     const gsl::not_null<Cache*> cache,
     Xcts::Tags::LapseTimesConformalFactor<DataType> /*meta*/) const {
@@ -182,8 +187,8 @@ void WrappedGrVariables<DataType>::operator()(
   get(*lapse_times_conformal_factor) *= get(conformal_factor);
 }
 
-template <typename DataType>
-void WrappedGrVariables<DataType>::operator()(
+template <typename DataType, bool HasMhd>
+void WrappedGrVariables<DataType, HasMhd>::operator()(
     const gsl::not_null<tnsr::i<DataType, Dim>*>
         lapse_times_conformal_factor_gradient,
     const gsl::not_null<Cache*> cache,
@@ -205,8 +210,8 @@ void WrappedGrVariables<DataType>::operator()(
   }
 }
 
-template <typename DataType>
-void WrappedGrVariables<DataType>::operator()(
+template <typename DataType, bool HasMhd>
+void WrappedGrVariables<DataType, HasMhd>::operator()(
     const gsl::not_null<tnsr::I<DataType, Dim>*> shift_background,
     const gsl::not_null<Cache*> /*cache*/,
     Xcts::Tags::ShiftBackground<DataType, Dim, Frame::Inertial> /*meta*/)
@@ -214,8 +219,8 @@ void WrappedGrVariables<DataType>::operator()(
   std::fill(shift_background->begin(), shift_background->end(), 0.);
 }
 
-template <typename DataType>
-void WrappedGrVariables<DataType>::operator()(
+template <typename DataType, bool HasMhd>
+void WrappedGrVariables<DataType, HasMhd>::operator()(
     const gsl::not_null<tnsr::II<DataType, Dim, Frame::Inertial>*>
         longitudinal_shift_background_minus_dt_conformal_metric,
     const gsl::not_null<Cache*> /*cache*/,
@@ -225,8 +230,8 @@ void WrappedGrVariables<DataType>::operator()(
             longitudinal_shift_background_minus_dt_conformal_metric->end(), 0.);
 }
 
-template <typename DataType>
-void WrappedGrVariables<DataType>::operator()(
+template <typename DataType, bool HasMhd>
+void WrappedGrVariables<DataType, HasMhd>::operator()(
     const gsl::not_null<tnsr::I<DataType, Dim>*> shift_excess,
     const gsl::not_null<Cache*> /*cache*/,
     Xcts::Tags::ShiftExcess<DataType, Dim, Frame::Inertial> /*meta*/) const {
@@ -234,8 +239,8 @@ void WrappedGrVariables<DataType>::operator()(
       get<gr::Tags::Shift<Dim, Frame::Inertial, DataType>>(gr_solution);
 }
 
-template <typename DataType>
-void WrappedGrVariables<DataType>::operator()(
+template <typename DataType, bool HasMhd>
+void WrappedGrVariables<DataType, HasMhd>::operator()(
     const gsl::not_null<tnsr::ii<DataType, Dim>*> shift_strain,
     const gsl::not_null<Cache*> cache,
     Xcts::Tags::ShiftStrain<DataType, Dim, Frame::Inertial> /*meta*/) const {
@@ -258,8 +263,8 @@ void WrappedGrVariables<DataType>::operator()(
                      shift);
 }
 
-template <typename DataType>
-void WrappedGrVariables<DataType>::operator()(
+template <typename DataType, bool HasMhd>
+void WrappedGrVariables<DataType, HasMhd>::operator()(
     const gsl::not_null<tnsr::ii<DataType, 3>*> extrinsic_curvature,
     const gsl::not_null<Cache*> /*cache*/,
     gr::Tags::ExtrinsicCurvature<3, Frame::Inertial, DataType> /*meta*/) const {
@@ -268,40 +273,175 @@ void WrappedGrVariables<DataType>::operator()(
           gr_solution);
 }
 
-template <typename DataType>
-void WrappedGrVariables<DataType>::operator()(
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsuggest-attribute=noreturn"
+#endif  // defined(__GNUC__) && !defined(__clang__)
+
+template <typename DataType, bool HasMhd>
+void WrappedGrVariables<DataType, HasMhd>::operator()(
+    [[maybe_unused]] const gsl::not_null<Scalar<DataType>*>
+        magnetic_field_dot_spatial_velocity,
+    const gsl::not_null<Cache*> /*cache*/,
+    hydro::Tags::MagneticFieldDotSpatialVelocity<DataType> /*meta*/) const {
+  if constexpr (HasMhd) {
+    const auto& spatial_velocity =
+        get<hydro::Tags::SpatialVelocity<DataType, Dim, Frame::Inertial>>(
+            hydro_solution);
+    const auto& magnetic_field =
+        get<hydro::Tags::MagneticField<DataType, Dim, Frame::Inertial>>(
+            hydro_solution);
+    const auto& spatial_metric =
+        get<gr::Tags::SpatialMetric<Dim, Frame::Inertial, DataType>>(
+            gr_solution);
+    tenex::evaluate(magnetic_field_dot_spatial_velocity,
+                    magnetic_field(ti::I) * spatial_velocity(ti::J) *
+                        spatial_metric(ti::i, ti::j));
+  } else {
+    ERROR(
+        "The 'MagneticFieldDotSpatialVelocity' should not be needed in vacuum "
+        "GR.");
+  }
+}
+
+template <typename DataType, bool HasMhd>
+void WrappedGrVariables<DataType, HasMhd>::operator()(
+    [[maybe_unused]] const gsl::not_null<Scalar<DataType>*>
+        comoving_magnetic_field_squared,
+    [[maybe_unused]] const gsl::not_null<Cache*> cache,
+    hydro::Tags::ComovingMagneticFieldSquared<DataType> /*meta*/) const {
+  if constexpr (HasMhd) {
+    const auto& lorentz_factor =
+        get<hydro::Tags::LorentzFactor<DataType>>(hydro_solution);
+    const auto& magnetic_field =
+        get<hydro::Tags::MagneticField<DataType, Dim, Frame::Inertial>>(
+            hydro_solution);
+    const auto& spatial_metric =
+        get<gr::Tags::SpatialMetric<Dim, Frame::Inertial, DataType>>(
+            gr_solution);
+    const auto magnetic_field_squared =
+        tenex::evaluate(magnetic_field(ti::I) * magnetic_field(ti::J) *
+                        spatial_metric(ti::i, ti::j));
+    const auto& magnetic_field_dot_spatial_velocity = cache->get_var(
+        *this, hydro::Tags::MagneticFieldDotSpatialVelocity<DataType>{});
+    hydro::comoving_magnetic_field_squared(
+        comoving_magnetic_field_squared, magnetic_field_squared,
+        magnetic_field_dot_spatial_velocity, lorentz_factor);
+  } else {
+    ERROR(
+        "The 'ComovingMagneticFieldSquared' should not be needed in vacuum "
+        "GR.");
+  }
+}
+
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif  // defined(__GNUC__) && !defined(__clang__)
+
+template <typename DataType, bool HasMhd>
+void WrappedGrVariables<DataType, HasMhd>::operator()(
     const gsl::not_null<Scalar<DataType>*> energy_density,
-    const gsl::not_null<Cache*> /*cache*/,
+    [[maybe_unused]] const gsl::not_null<Cache*> cache,
     gr::Tags::Conformal<gr::Tags::EnergyDensity<DataType>, 0> /*meta*/) const {
-  std::fill(energy_density->begin(), energy_density->end(), 0.);
+  if constexpr (HasMhd) {
+    const auto& rest_mass_density =
+        get<hydro::Tags::RestMassDensity<DataType>>(hydro_solution);
+    const auto& specific_enthalpy =
+        get<hydro::Tags::SpecificEnthalpy<DataType>>(hydro_solution);
+    const auto& pressure = get<hydro::Tags::Pressure<DataType>>(hydro_solution);
+    const auto& lorentz_factor =
+        get<hydro::Tags::LorentzFactor<DataType>>(hydro_solution);
+    const auto& magnetic_field_dot_spatial_velocity = cache->get_var(
+        *this, hydro::Tags::MagneticFieldDotSpatialVelocity<DataType>{});
+    const auto& comoving_magnetic_field_squared = cache->get_var(
+        *this, hydro::Tags::ComovingMagneticFieldSquared<DataType>{});
+    hydro::energy_density(energy_density, rest_mass_density, specific_enthalpy,
+                          pressure, lorentz_factor,
+                          magnetic_field_dot_spatial_velocity,
+                          comoving_magnetic_field_squared);
+  } else {
+    std::fill(energy_density->begin(), energy_density->end(), 0.);
+  }
 }
 
-template <typename DataType>
-void WrappedGrVariables<DataType>::operator()(
+template <typename DataType, bool HasMhd>
+void WrappedGrVariables<DataType, HasMhd>::operator()(
     const gsl::not_null<Scalar<DataType>*> stress_trace,
-    const gsl::not_null<Cache*> /*cache*/,
+    [[maybe_unused]] const gsl::not_null<Cache*> cache,
     gr::Tags::Conformal<gr::Tags::StressTrace<DataType>, 0> /*meta*/) const {
-  std::fill(stress_trace->begin(), stress_trace->end(), 0.);
+  if constexpr (HasMhd) {
+    const auto& rest_mass_density =
+        get<hydro::Tags::RestMassDensity<DataType>>(hydro_solution);
+    const auto& specific_enthalpy =
+        get<hydro::Tags::SpecificEnthalpy<DataType>>(hydro_solution);
+    const auto& pressure = get<hydro::Tags::Pressure<DataType>>(hydro_solution);
+    const auto& spatial_velocity =
+        get<hydro::Tags::SpatialVelocity<DataType, Dim, Frame::Inertial>>(
+            hydro_solution);
+    const auto& spatial_metric =
+        get<gr::Tags::SpatialMetric<Dim, Frame::Inertial, DataType>>(
+            gr_solution);
+    const auto spatial_velocity_squared =
+        tenex::evaluate(spatial_velocity(ti::I) * spatial_velocity(ti::J) *
+                        spatial_metric(ti::i, ti::j));
+    const auto& lorentz_factor =
+        get<hydro::Tags::LorentzFactor<DataType>>(hydro_solution);
+    const auto& magnetic_field_dot_spatial_velocity = cache->get_var(
+        *this, hydro::Tags::MagneticFieldDotSpatialVelocity<DataType>{});
+    const auto& comoving_magnetic_field_squared = cache->get_var(
+        *this, hydro::Tags::ComovingMagneticFieldSquared<DataType>{});
+    hydro::stress_trace(stress_trace, rest_mass_density, specific_enthalpy,
+                        pressure, spatial_velocity_squared, lorentz_factor,
+                        magnetic_field_dot_spatial_velocity,
+                        comoving_magnetic_field_squared);
+  } else {
+    std::fill(stress_trace->begin(), stress_trace->end(), 0.);
+  }
 }
 
-template <typename DataType>
-void WrappedGrVariables<DataType>::operator()(
+template <typename DataType, bool HasMhd>
+void WrappedGrVariables<DataType, HasMhd>::operator()(
     const gsl::not_null<tnsr::I<DataType, Dim>*> momentum_density,
-    const gsl::not_null<Cache*> /*cache*/,
+    [[maybe_unused]] const gsl::not_null<Cache*> cache,
     gr::Tags::Conformal<
         gr::Tags::MomentumDensity<Dim, Frame::Inertial, DataType>, 0> /*meta*/)
     const {
-  std::fill(momentum_density->begin(), momentum_density->end(), 0.);
+  if constexpr (HasMhd) {
+    const auto& rest_mass_density =
+        get<hydro::Tags::RestMassDensity<DataType>>(hydro_solution);
+    const auto& specific_enthalpy =
+        get<hydro::Tags::SpecificEnthalpy<DataType>>(hydro_solution);
+    const auto& spatial_velocity =
+        get<hydro::Tags::SpatialVelocity<DataType, Dim, Frame::Inertial>>(
+            hydro_solution);
+    const auto& lorentz_factor =
+        get<hydro::Tags::LorentzFactor<DataType>>(hydro_solution);
+    const auto& magnetic_field =
+        get<hydro::Tags::MagneticField<DataType, Dim, Frame::Inertial>>(
+            hydro_solution);
+    const auto& magnetic_field_dot_spatial_velocity = cache->get_var(
+        *this, hydro::Tags::MagneticFieldDotSpatialVelocity<DataType>{});
+    const auto& comoving_magnetic_field_squared = cache->get_var(
+        *this, hydro::Tags::ComovingMagneticFieldSquared<DataType>{});
+    hydro::momentum_density(momentum_density, rest_mass_density,
+                            specific_enthalpy, spatial_velocity, lorentz_factor,
+                            magnetic_field, magnetic_field_dot_spatial_velocity,
+                            comoving_magnetic_field_squared);
+  } else {
+    std::fill(momentum_density->begin(), momentum_density->end(), 0.);
+  }
 }
 
-template class WrappedGrVariables<double>;
-template class WrappedGrVariables<DataVector>;
+template class WrappedGrVariables<double, false>;
+template class WrappedGrVariables<DataVector, false>;
+template class WrappedGrVariables<double, true>;
+template class WrappedGrVariables<DataVector, true>;
 
 }  // namespace detail
 
-template <typename GrSolution, typename... GrSolutionOptions>
+template <typename GrSolution, bool HasMhd, typename... GrSolutionOptions>
 PUP::able::PUP_ID
-    WrappedGr<GrSolution, tmpl::list<GrSolutionOptions...>>::my_PUP_ID =
+    WrappedGr<GrSolution, HasMhd, tmpl::list<GrSolutionOptions...>>::my_PUP_ID =
         0;  // NOLINT
 
 }  // namespace Xcts::Solutions
@@ -309,25 +449,32 @@ PUP::able::PUP_ID
 // Instantiate implementations for common variables
 template class Xcts::Solutions::CommonVariables<
     double,
-    typename Xcts::Solutions::detail::WrappedGrVariables<double>::Cache>;
+    typename Xcts::Solutions::detail::WrappedGrVariables<double, false>::Cache>;
 template class Xcts::Solutions::CommonVariables<
-    DataVector,
-    typename Xcts::Solutions::detail::WrappedGrVariables<DataVector>::Cache>;
+    DataVector, typename Xcts::Solutions::detail::WrappedGrVariables<
+                    DataVector, false>::Cache>;
 template class Xcts::AnalyticData::CommonVariables<
     double,
-    typename Xcts::Solutions::detail::WrappedGrVariables<double>::Cache>;
+    typename Xcts::Solutions::detail::WrappedGrVariables<double, false>::Cache>;
 template class Xcts::AnalyticData::CommonVariables<
-    DataVector,
-    typename Xcts::Solutions::detail::WrappedGrVariables<DataVector>::Cache>;
+    DataVector, typename Xcts::Solutions::detail::WrappedGrVariables<
+                    DataVector, false>::Cache>;
 
 #define STYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
 
-#define INSTANTIATE(_, data) \
-  template class Xcts::Solutions::WrappedGr<STYPE(data)>;
+#define INSTANTIATE_GR(_, data) \
+  template class Xcts::Solutions::WrappedGr<STYPE(data), false>;
+#define INSTANTIATE_GRMHD(_, data) \
+  template class Xcts::Solutions::WrappedGr<STYPE(data), true>;
 
-GENERATE_INSTANTIATIONS(INSTANTIATE, (gr::Solutions::KerrSchild,
-                                      gr::Solutions::SphericalKerrSchild,
-                                      gr::Solutions::HarmonicSchwarzschild))
+GENERATE_INSTANTIATIONS(INSTANTIATE_GR, (gr::Solutions::KerrSchild,
+                                         gr::Solutions::SphericalKerrSchild,
+                                         gr::Solutions::HarmonicSchwarzschild))
+GENERATE_INSTANTIATIONS(INSTANTIATE_GRMHD,
+                        (grmhd::AnalyticData::CcsnCollapse,
+                         grmhd::AnalyticData::MagnetizedTovStar,
+                         RelativisticEuler::Solutions::RotatingStar))
 
 #undef STYPE
-#undef INSTANTIATE
+#undef INSTANTIATE_GR
+#undef INSTANTIATE_GRMHD

--- a/src/PointwiseFunctions/AnalyticSolutions/Xcts/WrappedGr.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Xcts/WrappedGr.cpp
@@ -299,8 +299,10 @@ template class WrappedGrVariables<DataVector>;
 
 }  // namespace detail
 
-template <typename GrSolution>
-PUP::able::PUP_ID WrappedGr<GrSolution>::my_PUP_ID = 0;  // NOLINT
+template <typename GrSolution, typename... GrSolutionOptions>
+PUP::able::PUP_ID
+    WrappedGr<GrSolution, tmpl::list<GrSolutionOptions...>>::my_PUP_ID =
+        0;  // NOLINT
 
 }  // namespace Xcts::Solutions
 

--- a/src/PointwiseFunctions/AnalyticSolutions/Xcts/WrappedGr.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Xcts/WrappedGr.hpp
@@ -20,6 +20,7 @@
 #include "PointwiseFunctions/AnalyticSolutions/Xcts/CommonVariables.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags/Conformal.hpp"
+#include "PointwiseFunctions/Hydro/Tags.hpp"
 #include "PointwiseFunctions/InitialDataUtilities/AnalyticSolution.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/PrettyType.hpp"
@@ -43,16 +44,27 @@ using gr_solution_vars = tmpl::list<
                   tmpl::size_t<Dim>, Frame::Inertial>,
     gr::Tags::ExtrinsicCurvature<Dim, Frame::Inertial, DataType>>;
 
+template <typename DataType, size_t Dim>
+using hydro_solution_vars =
+    tmpl::list<hydro::Tags::RestMassDensity<DataType>,
+               hydro::Tags::SpecificEnthalpy<DataType>,
+               hydro::Tags::Pressure<DataType>,
+               hydro::Tags::SpatialVelocity<DataType, Dim>,
+               hydro::Tags::LorentzFactor<DataType>,
+               hydro::Tags::MagneticField<DataType, Dim>>;
+
 template <typename DataType>
 using WrappedGrVariablesCache =
     cached_temp_buffer_from_typelist<tmpl::push_back<
         common_tags<DataType>,
+        hydro::Tags::MagneticFieldDotSpatialVelocity<DataType>,
+        hydro::Tags::ComovingMagneticFieldSquared<DataType>,
         gr::Tags::Conformal<gr::Tags::EnergyDensity<DataType>, 0>,
         gr::Tags::Conformal<gr::Tags::StressTrace<DataType>, 0>,
         gr::Tags::Conformal<
             gr::Tags::MomentumDensity<3, Frame::Inertial, DataType>, 0>>>;
 
-template <typename DataType>
+template <typename DataType, bool HasMhd>
 struct WrappedGrVariables
     : CommonVariables<DataType, WrappedGrVariablesCache<DataType>> {
   static constexpr size_t Dim = 3;
@@ -67,14 +79,19 @@ struct WrappedGrVariables
           local_inv_jacobian,
       const tnsr::I<DataType, 3>& local_x,
       const tuples::tagged_tuple_from_typelist<gr_solution_vars<DataType, Dim>>&
-          local_gr_solution)
+          local_gr_solution,
+      const tuples::tagged_tuple_from_typelist<
+          hydro_solution_vars<DataType, Dim>>& local_hydro_solution)
       : Base(std::move(local_mesh), std::move(local_inv_jacobian)),
         x(local_x),
-        gr_solution(local_gr_solution) {}
+        gr_solution(local_gr_solution),
+        hydro_solution(local_hydro_solution) {}
 
   const tnsr::I<DataType, Dim>& x;
   const tuples::tagged_tuple_from_typelist<gr_solution_vars<DataType, Dim>>&
       gr_solution;
+  const tuples::tagged_tuple_from_typelist<hydro_solution_vars<DataType, Dim>>&
+      hydro_solution;
 
   void operator()(
       gsl::not_null<tnsr::ii<DataType, Dim>*> conformal_metric,
@@ -163,6 +180,14 @@ struct WrappedGrVariables
       gr::Tags::ExtrinsicCurvature<3, Frame::Inertial, DataType> /*meta*/)
       const override;
   void operator()(
+      gsl::not_null<Scalar<DataType>*> magnetic_field_dot_spatial_velocity,
+      gsl::not_null<Cache*> cache,
+      hydro::Tags::MagneticFieldDotSpatialVelocity<DataType> /*meta*/) const;
+  void operator()(
+      gsl::not_null<Scalar<DataType>*> comoving_magnetic_field_squared,
+      gsl::not_null<Cache*> cache,
+      hydro::Tags::ComovingMagneticFieldSquared<DataType> /*meta*/) const;
+  void operator()(
       gsl::not_null<Scalar<DataType>*> energy_density,
       gsl::not_null<Cache*> cache,
       gr::Tags::Conformal<gr::Tags::EnergyDensity<DataType>, 0> /*meta*/) const;
@@ -211,13 +236,38 @@ struct WrappedGrVariables
  * production solves this is not an issue because we choose a much better
  * initial guess than flatness, such as a superposition of Kerr solutions for
  * black-hole binary initial data.
+ *
+ * \warning
+ * The computation of the XCTS matter source terms (energy density $\rho$,
+ * momentum density $S^i$, stress trace $S$) uses GR quantities (lapse $\alpha$,
+ * shift $\beta^i$, spatial metric $\gamma_{ij}$), which means these GR
+ * quantities are not treated dynamically in the source terms when solving the
+ * XCTS equations. If the GR quantities satisfy the Einstein constraints (as is
+ * the case if the `GrSolution` is actually a solution to the Einstein
+ * equations), then the XCTS solve will reproduce the GR quantities given the
+ * fixed sources computed here. However, if the GR quantities don't satisfy the
+ * Einstein constraints (e.g. because a magnetic field was added to the solution
+ * but ignored in the gravity sector, or because it is a hydrodynamic solution
+ * on a fixed background metric) then the XCTS solution will depend on our
+ * treatment of the source terms: fixing the source terms (the simple approach
+ * taken here) means we're making a choice of $W$ and $u^i$. This is what
+ * initial data codes usually do when they iterate back and forth between a
+ * hydro solve and an XCTS solve (e.g. see \cite Tacik2016zal). Alternatively,
+ * we could fix $v^i$ and compute $W$ and $u^i$ from $v^i$ and the dynamic
+ * metric variables at every step in the XCTS solver algorithm. This requires
+ * adding the source terms and their linearization to the XCTS equations, and
+ * could be interesting to explore.
+ *
+ * \tparam GrSolution Any solution to the Einstein constraint equations
+ * \tparam HasMhd Enable to compute matter source terms. Disable to set matter
+ * source terms to zero.
  */
-template <typename GrSolution,
+template <typename GrSolution, bool HasMhd = false,
           typename GrSolutionOptions = typename GrSolution::options>
 class WrappedGr;
 
-template <typename GrSolution, typename... GrSolutionOptions>
-class WrappedGr<GrSolution, tmpl::list<GrSolutionOptions...>>
+template <typename GrSolution, bool HasMhd, typename... GrSolutionOptions>
+class WrappedGr<GrSolution, HasMhd, tmpl::list<GrSolutionOptions...>>
     : public elliptic::analytic_data::AnalyticSolution {
  public:
   static constexpr size_t Dim = 3;
@@ -263,10 +313,24 @@ class WrappedGr<GrSolution, tmpl::list<GrSolutionOptions...>>
       gr_solution =
           gr_solution_.variables(x, detail::gr_solution_vars<DataType, Dim>{});
     }
-    using VarsComputer = detail::WrappedGrVariables<DataType>;
+    tuples::tagged_tuple_from_typelist<
+        detail::hydro_solution_vars<DataType, Dim>>
+        hydro_solution;
+    if constexpr (HasMhd) {
+      if constexpr (is_analytic_solution_v<GrSolution>) {
+        hydro_solution = gr_solution_.variables(
+            x, std::numeric_limits<double>::signaling_NaN(),
+            detail::hydro_solution_vars<DataType, Dim>{});
+      } else {
+        hydro_solution = gr_solution_.variables(
+            x, detail::hydro_solution_vars<DataType, Dim>{});
+      }
+    }
+    using VarsComputer = detail::WrappedGrVariables<DataType, HasMhd>;
     const size_t num_points = get_size(*x.begin());
     typename VarsComputer::Cache cache{num_points};
-    const VarsComputer computer{std::nullopt, std::nullopt, x, gr_solution};
+    const VarsComputer computer{std::nullopt, std::nullopt, x, gr_solution,
+                                hydro_solution};
     return {cache.get_var(computer, RequestedTags{})...};
   }
 
@@ -286,10 +350,23 @@ class WrappedGr<GrSolution, tmpl::list<GrSolutionOptions...>>
       gr_solution =
           gr_solution_.variables(x, detail::gr_solution_vars<DataType, Dim>{});
     }
-    using VarsComputer = detail::WrappedGrVariables<DataType>;
+    tuples::tagged_tuple_from_typelist<
+        detail::hydro_solution_vars<DataType, Dim>>
+        hydro_solution;
+    if constexpr (HasMhd) {
+      if constexpr (is_analytic_solution_v<GrSolution>) {
+        hydro_solution = gr_solution_.variables(
+            x, std::numeric_limits<double>::signaling_NaN(),
+            detail::hydro_solution_vars<DataType, Dim>{});
+      } else {
+        hydro_solution = gr_solution_.variables(
+            x, detail::hydro_solution_vars<DataType, Dim>{});
+      }
+    }
+    using VarsComputer = detail::WrappedGrVariables<DataType, HasMhd>;
     const size_t num_points = get_size(*x.begin());
     typename VarsComputer::Cache cache{num_points};
-    VarsComputer computer{mesh, inv_jacobian, x, gr_solution};
+    VarsComputer computer{mesh, inv_jacobian, x, gr_solution, hydro_solution};
     return {cache.get_var(computer, RequestedTags{})...};
   }
 
@@ -299,7 +376,21 @@ class WrappedGr<GrSolution, tmpl::list<GrSolutionOptions...>>
   }
 
  private:
+  friend bool operator==(const WrappedGr<GrSolution, HasMhd>& lhs,
+                         const WrappedGr<GrSolution, HasMhd>& rhs) {
+    return lhs.gr_solution_ == rhs.gr_solution_;
+  }
+
   GrSolution gr_solution_;
 };
+
+template <typename GrSolution, bool HasMhd>
+inline bool operator!=(const WrappedGr<GrSolution, HasMhd>& lhs,
+                       const WrappedGr<GrSolution, HasMhd>& rhs) {
+  return not(lhs == rhs);
+}
+
+template <typename GrMhdSolution>
+using WrappedGrMhd = WrappedGr<GrMhdSolution, true>;
 
 }  // namespace Xcts::Solutions

--- a/src/PointwiseFunctions/AnalyticSolutions/Xcts/WrappedGr.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Xcts/WrappedGr.hpp
@@ -16,6 +16,7 @@
 #include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
 #include "Options/Options.hpp"
 #include "Parallel/CharmPupable.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/AnalyticSolution.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/Xcts/CommonVariables.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags/Conformal.hpp"
@@ -252,9 +253,16 @@ class WrappedGr<GrSolution, tmpl::list<GrSolutionOptions...>>
   tuples::TaggedTuple<RequestedTags...> variables(
       const tnsr::I<DataType, 3, Frame::Inertial>& x,
       tmpl::list<RequestedTags...> /*meta*/) const {
-    const auto gr_solution =
-        gr_solution_.variables(x, std::numeric_limits<double>::signaling_NaN(),
-                               detail::gr_solution_vars<DataType, Dim>{});
+    tuples::tagged_tuple_from_typelist<detail::gr_solution_vars<DataType, Dim>>
+        gr_solution;
+    if constexpr (is_analytic_solution_v<GrSolution>) {
+      gr_solution = gr_solution_.variables(
+          x, std::numeric_limits<double>::signaling_NaN(),
+          detail::gr_solution_vars<DataType, Dim>{});
+    } else {
+      gr_solution =
+          gr_solution_.variables(x, detail::gr_solution_vars<DataType, Dim>{});
+    }
     using VarsComputer = detail::WrappedGrVariables<DataType>;
     const size_t num_points = get_size(*x.begin());
     typename VarsComputer::Cache cache{num_points};
@@ -268,9 +276,16 @@ class WrappedGr<GrSolution, tmpl::list<GrSolutionOptions...>>
       const InverseJacobian<DataVector, 3, Frame::ElementLogical,
                             Frame::Inertial>& inv_jacobian,
       tmpl::list<RequestedTags...> /*meta*/) const {
-    const auto gr_solution =
-        gr_solution_.variables(x, std::numeric_limits<double>::signaling_NaN(),
-                               detail::gr_solution_vars<DataType, Dim>{});
+    tuples::tagged_tuple_from_typelist<detail::gr_solution_vars<DataType, Dim>>
+        gr_solution;
+    if constexpr (is_analytic_solution_v<GrSolution>) {
+      gr_solution = gr_solution_.variables(
+          x, std::numeric_limits<double>::signaling_NaN(),
+          detail::gr_solution_vars<DataType, Dim>{});
+    } else {
+      gr_solution =
+          gr_solution_.variables(x, detail::gr_solution_vars<DataType, Dim>{});
+    }
     using VarsComputer = detail::WrappedGrVariables<DataType>;
     const size_t num_points = get_size(*x.begin());
     typename VarsComputer::Cache cache{num_points};

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/Test_RotatingStar.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/Test_RotatingStar.cpp
@@ -59,6 +59,8 @@ SPECTRE_TEST_CASE(
                   100)
                   .get_clone())));
 
+  CHECK(solution.equatorial_radius() == approx(7.155891353887));
+
   // Near the center the finite difference derivatives cause "large" errors
   // (1e-8) and so the check fails.
   verify_solution(solution, {{1., 0., 0.}}, error_tolerance);

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Xcts/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Xcts/CMakeLists.txt
@@ -8,6 +8,7 @@ set(LIBRARY_SOURCES
   Test_Flatness.cpp
   Test_HarmonicSchwarzschild.cpp
   Test_Kerr.cpp
+  Test_RotatingStar.cpp
   Test_Schwarzschild.cpp
   Test_SphericalKerr.cpp
   Test_TovStar.cpp
@@ -26,6 +27,7 @@ target_link_libraries(
   CoordinateMaps
   DataStructures
   Domain
+  RelativisticEulerSolutions
   Spectral
   Utilities
   Xcts

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Xcts/Test_HarmonicSchwarzschild.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Xcts/Test_HarmonicSchwarzschild.cpp
@@ -31,8 +31,8 @@ void test_solution(const double mass, const std::array<double, 3>& center,
   const auto& solution = dynamic_cast<const HarmonicSchwarzschild&>(*created);
   {
     INFO("Properties");
-    CHECK(solution.mass() == mass);
-    CHECK(solution.center() == center);
+    CHECK(solution.gr_solution().mass() == mass);
+    CHECK(solution.gr_solution().center() == center);
   }
   {
     INFO("Semantics");

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Xcts/Test_Kerr.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Xcts/Test_Kerr.cpp
@@ -33,9 +33,9 @@ void test_solution(const double mass, const std::array<double, 3> spin,
   const auto& solution = dynamic_cast<const Kerr&>(*created);
   {
     INFO("Properties");
-    CHECK(solution.mass() == mass);
-    CHECK(solution.dimensionless_spin() == spin);
-    CHECK(solution.center() == center);
+    CHECK(solution.gr_solution().mass() == mass);
+    CHECK(solution.gr_solution().dimensionless_spin() == spin);
+    CHECK(solution.gr_solution().center() == center);
   }
   {
     INFO("Semantics");

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Xcts/Test_RotatingStar.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Xcts/Test_RotatingStar.cpp
@@ -1,0 +1,58 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <string>
+
+#include "Elliptic/Systems/Xcts/Geometry.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/PointwiseFunctions/AnalyticSolutions/Xcts/VerifySolution.hpp"
+#include "Informer/InfoFromBuild.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/RelativisticEuler/RotatingStar.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/Xcts/WrappedGr.hpp"
+
+namespace Xcts::Solutions {
+
+// [[Timeout, 20]]
+SPECTRE_TEST_CASE("Unit.PointwiseFunctions.AnalyticSolutions.Xcts.RotatingStar",
+                  "[PointwiseFunctions][Unit]") {
+  using RotatingStar = WrappedGrMhd<RelativisticEuler::Solutions::RotatingStar>;
+  const std::string rotns_filename = unit_test_src_path() +
+                                     "/PointwiseFunctions/AnalyticSolutions/"
+                                     "RelativisticEuler/RotatingStarId.dat";
+  const auto created = TestHelpers::test_factory_creation<
+      elliptic::analytic_data::AnalyticSolution, RotatingStar>(
+      "RotatingStar:\n"
+      "  RotNsFilename: " +
+      rotns_filename +
+      "\n"
+      "  PolytropicConstant: 100.\n");
+  REQUIRE(dynamic_cast<const RotatingStar*>(created.get()) != nullptr);
+  const auto& solution = dynamic_cast<const RotatingStar&>(*created);
+  {
+    INFO("Semantics");
+    test_serialization(solution);
+    test_copy_semantics(solution);
+    auto move_solution = solution;
+    test_move_semantics(std::move(move_solution), solution);
+  }
+  {
+    INFO("Verify the solution solves the XCTS equations");
+    const auto& equatorial_radius = solution.gr_solution().equatorial_radius();
+    CAPTURE(equatorial_radius);
+    for (const double fraction_of_star_radius : {0.2, 1., 1.5}) {
+      CAPTURE(fraction_of_star_radius);
+      const double inner_radius = fraction_of_star_radius * equatorial_radius;
+      const double outer_radius =
+          (fraction_of_star_radius + 0.01) * equatorial_radius;
+      CAPTURE(inner_radius);
+      CAPTURE(outer_radius);
+      TestHelpers::Xcts::Solutions::verify_solution<Xcts::Geometry::Curved, 0>(
+          solution, {{0., 0., 0.}}, inner_radius, outer_radius, 2.e-3);
+    }
+  }
+}
+
+}  // namespace Xcts::Solutions

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Xcts/Test_SphericalKerr.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Xcts/Test_SphericalKerr.cpp
@@ -33,9 +33,9 @@ void test_solution(const double mass, const std::array<double, 3> spin,
   const auto& solution = dynamic_cast<const SphericalKerr&>(*created);
   {
     INFO("Properties");
-    CHECK(solution.mass() == mass);
-    CHECK(solution.dimensionless_spin() == spin);
-    CHECK(solution.center() == center);
+    CHECK(solution.gr_solution().mass() == mass);
+    CHECK(solution.gr_solution().dimensionless_spin() == spin);
+    CHECK(solution.gr_solution().center() == center);
   }
   {
     INFO("Semantics");


### PR DESCRIPTION
## Proposed changes

Allows to solve the Einstein constraints for any fixed GRMHD profile, such as a magnetized TOV star or a CCSN profile.
Note that this does _not_ solve for the hydro sector, only the gravity sector given the matter content.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
