### PR TITLE
Add and use weighted element distributions

### DIFF
--- a/src/Domain/ElementDistribution.cpp
+++ b/src/Domain/ElementDistribution.cpp
@@ -3,77 +3,287 @@
 
 #include "Domain/ElementDistribution.hpp"
 
-#include <algorithm>
 #include <array>
+#include <cmath>
 #include <cstddef>
-#include <numeric>
+#include <functional>
+#include <optional>
+#include <unordered_map>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/IndexType.hpp"
+#include "Domain/Block.hpp"
+#include "Domain/CreateInitialElement.hpp"
+#include "Domain/ElementMap.hpp"
+#include "Domain/MinimumGridSpacing.hpp"
+#include "Domain/Structure/CreateInitialMesh.hpp"
+#include "Domain/Structure/Element.hpp"
 #include "Domain/Structure/ElementId.hpp"
+#include "Domain/Structure/InitialElementIds.hpp"
 #include "Domain/Structure/ZCurve.hpp"
+#include "NumericalAlgorithms/Spectral/LogicalCoordinates.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "Utilities/Algorithm.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Literals.hpp"
+#include "Utilities/Numeric.hpp"
 
 namespace domain {
+namespace {
+// \brief Get the cost of an `Element` computed as
+// `(number of grid points) / sqrt(minimum grid spacing in Frame::Grid)`
+//
+// \details As grid points in an `Element` increase, we expect the
+// computational cost of an `Element` to scale proportionally (if the minimum
+// grid spacing is held constant). In addition, the minimum grid spacing
+// between two points in an `Element` informs the time step that we take, where
+// the smaller the minimum spacing, the smaller time step we must take, which
+// means we expect computational work to scale inversely with the minimum grid
+// spacing.
+//
+// The reason that we use the square root of the spacing as opposed to just the
+// spacing in the denominator of the cost is that it was found experimentally
+// that using the square root yielded faster BBH simulation runtimes when using
+// local time stepping.
+template <size_t Dim>
+double get_num_points_and_grid_spacing_cost(
+    const ElementId<Dim>& element_id, const Block<Dim>& block,
+    const std::vector<std::array<size_t, Dim>>& initial_refinement_levels,
+    const std::vector<std::array<size_t, Dim>>& initial_extents,
+    const Spectral::Quadrature quadrature) {
+  Mesh<Dim> mesh = ::domain::Initialization::create_initial_mesh(
+      initial_extents, element_id, quadrature);
+  Element<Dim> element = ::domain::Initialization::create_initial_element(
+      element_id, block, initial_refinement_levels);
+  ElementMap<Dim, Frame::Grid> element_map{
+      element_id, block.is_time_dependent()
+                      ? block.moving_mesh_logical_to_grid_map().get_clone()
+                      : block.stationary_map().get_to_grid_frame()};
+  const tnsr::I<DataVector, Dim, Frame::ElementLogical> logical_coords =
+      logical_coordinates(mesh);
+  const tnsr::I<DataVector, Dim, Frame::Grid> grid_coords =
+      element_map(logical_coords);
+  const double min_grid_spacing =
+      minimum_grid_spacing(mesh.extents(), grid_coords);
+
+  return mesh.number_of_grid_points() / sqrt(min_grid_spacing);
+}
+}  //  namespace
+
+template <size_t Dim>
+std::unordered_map<ElementId<Dim>, double> get_element_costs(
+    const std::vector<Block<Dim>>& blocks,
+    const std::vector<std::array<size_t, Dim>>& initial_refinement_levels,
+    const std::vector<std::array<size_t, Dim>>& initial_extents,
+    const ElementWeight element_weight,
+    const std::optional<Spectral::Quadrature>& quadrature) {
+  std::unordered_map<ElementId<Dim>, double> element_costs{};
+
+  for (size_t block_number = 0; block_number < blocks.size(); block_number++) {
+    const auto& block = blocks[block_number];
+    const auto initial_ref_levs = initial_refinement_levels[block_number];
+    const std::vector<ElementId<Dim>> element_ids =
+        initial_element_ids(block.id(), initial_ref_levs);
+    const size_t grid_points_per_element = alg::accumulate(
+        initial_extents[block_number], 1_st, std::multiplies<size_t>());
+
+    for (const auto& element_id : element_ids) {
+      if (element_weight == ElementWeight::Uniform) {
+        element_costs.insert({element_id, 1.0});
+      } else if (element_weight == ElementWeight::NumGridPoints) {
+        element_costs.insert({element_id, grid_points_per_element});
+      } else {
+        ASSERT(element_weight == ElementWeight::NumGridPointsAndGridSpacing,
+               "Unknown element_weight");
+        ASSERT(quadrature.has_value(),
+               "Since element_weight is "
+               "ElementWeight::NumGridPointsAndGridSpacing, quadrature must "
+               "have a value");
+
+        element_costs.insert(
+            {element_id, get_num_points_and_grid_spacing_cost(
+                             element_id, block, initial_refinement_levels,
+                             initial_extents, quadrature.value())});
+      }
+    }
+  }
+
+  return element_costs;
+}
+
 template <size_t Dim>
 BlockZCurveProcDistribution<Dim>::BlockZCurveProcDistribution(
-    size_t number_of_procs_with_elements,
-    const std::vector<std::array<size_t, Dim>>& refinements_by_block,
+    const std::unordered_map<ElementId<Dim>, double>& element_costs,
+    const size_t number_of_procs_with_elements,
+    const std::vector<Block<Dim>>& blocks,
+    const std::vector<std::array<size_t, Dim>>& initial_refinement_levels,
+    const std::vector<std::array<size_t, Dim>>& initial_extents,
     const std::unordered_set<size_t>& global_procs_to_ignore) {
+  const size_t num_blocks = blocks.size();
+
+  ASSERT(
+      number_of_procs_with_elements > 0,
+      "Must have a non-zero number of processors to distribute elements to.");
+  ASSERT(num_blocks > 0, "Must have a non-zero number of blocks.");
+  ASSERT(
+      initial_refinement_levels.size() == num_blocks,
+      "`initial_refinement_levels` is not the same size as number of blocks");
+  ASSERT(initial_extents.size() == num_blocks,
+         "`initial_extents` is not the same size as number of blocks");
+
+  size_t num_elements = 0;
+  std::vector<size_t> num_elements_by_block(num_blocks);
+  for (size_t i = 0; i < num_blocks; i++) {
+    const size_t num_elements_current_block = two_to_the(alg::accumulate(
+        initial_refinement_levels[i], 0_st, std::plus<size_t>()));
+    num_elements_by_block[i] = num_elements_current_block;
+    num_elements += num_elements_current_block;
+  }
+
+  ASSERT(element_costs.size() == num_elements,
+         "`element_costs` is not the same size as the total number of elements "
+         "computed from `initial_refinement_levels`");
+
   block_element_distribution_ =
-      std::vector<std::vector<std::pair<size_t, size_t>>>(
-          refinements_by_block.size());
-  auto add_number_of_elements_for_refinement =
-      [](size_t lhs, const std::array<size_t, Dim>& rhs) {
-        size_t value = 1;
-        for (size_t i = 0; i < Dim; ++i) {
-          value *= two_to_the(gsl::at(rhs, i));
-        }
-        return lhs + value;
-      };
-  const size_t number_of_elements =
-      std::accumulate(refinements_by_block.begin(), refinements_by_block.end(),
-                      0_st, add_number_of_elements_for_refinement);
-  ASSERT(not refinements_by_block.empty(),
-         "`refinements_by_block` must be non-empty.");
-  // currently, we just assign uniform weight to elements. In future, it will
-  // probably be better to take into account p-refinement, but then the z-curve
-  // method will also require weighting.
-  size_t remaining_elements_in_block =
-      add_number_of_elements_for_refinement(0_st, refinements_by_block[0]);
-  size_t current_block = 0;
-  // This variable will keep track of how many global procs we've skipped over
-  // so far. This bookkeeping is necessary so the element gets placed on the
-  // correct global proc. The loop variable `i` does not correspond to global
-  // proc number. It's just an index
+      std::vector<std::vector<std::pair<size_t, size_t>>>(num_blocks);
+
+  std::vector<std::vector<ElementId<Dim>>> initial_element_ids_by_block(
+      num_blocks);
+  for (size_t i = 0; i < num_blocks; i++) {
+    initial_element_ids_by_block[i].reserve(num_elements_by_block[i]);
+    initial_element_ids_by_block[i] =
+        initial_element_ids(blocks[i].id(), initial_refinement_levels[i]);
+    alg::sort(initial_element_ids_by_block[i],
+              [](const ElementId<Dim>& lhs, const ElementId<Dim>& rhs) {
+                return z_curve_index(lhs) < z_curve_index(rhs);
+              });
+  }
+
+  double total_cost = 0.0;
+  for (const auto& element_id_and_cost : element_costs) {
+    total_cost += element_id_and_cost.second;
+  }
+
+  size_t current_block_num = 0;
+  size_t element_num_of_block = 0;
+  double cost_remaining = total_cost;
   size_t number_of_ignored_procs_so_far = 0;
-  for (size_t i = 0; i < number_of_procs_with_elements; ++i) {
+  // distribute Elements to all but the final proc
+  for (size_t i = 0; i < number_of_procs_with_elements - 1; ++i) {
     size_t global_proc_number = i + number_of_ignored_procs_so_far;
     while (global_procs_to_ignore.find(global_proc_number) !=
            global_procs_to_ignore.end()) {
       ++number_of_ignored_procs_so_far;
       ++global_proc_number;
     }
-    size_t remaining_elements_on_proc =
-        (number_of_elements / number_of_procs_with_elements) +
-        (i < (number_of_elements % number_of_procs_with_elements) ? 1 : 0);
-    while (remaining_elements_on_proc > 0) {
-      block_element_distribution_.at(current_block)
-          .emplace_back(std::make_pair(global_proc_number,
-                                       std::min(remaining_elements_in_block,
-                                                remaining_elements_on_proc)));
-      if (remaining_elements_in_block <= remaining_elements_on_proc) {
-        remaining_elements_on_proc -= remaining_elements_in_block;
-        ++current_block;
-        if (current_block < refinements_by_block.size()) {
-          remaining_elements_in_block = add_number_of_elements_for_refinement(
-              0_st, gsl::at(refinements_by_block, current_block));
+
+    // The target cost per proc is updated as we distribute to each proc since
+    // the total cost on a proc will nearly never be exactly the target average.
+    // If we don't adjust the target cost, then we risk either not using all
+    // procs (from overshooting the average too much on multiple procs) or
+    // piling up cost on the last proc (from undershooting the average on
+    // multiple procs). Updating the target cost per proc keeps the total cost
+    // spread somewhat evenly to each proc.
+    double target_cost_per_proc =
+        cost_remaining / static_cast<double>(number_of_procs_with_elements - i);
+    double cost_spent_on_proc = 0.0;
+    size_t total_elements_distributed_to_proc = 0;
+    bool add_more_elements_to_proc = true;
+    // while we haven't yet distributed all blocks and we still have cost
+    // allowed on the proc
+    while (add_more_elements_to_proc and (current_block_num < num_blocks)) {
+      const size_t num_elements_current_block =
+          num_elements_by_block[current_block_num];
+      size_t num_elements_distributed_to_proc = 0;
+      // while we still have elements left on the block to distribute and we
+      // still have cost allowed on the proc
+      while (add_more_elements_to_proc and
+             (element_num_of_block < num_elements_current_block)) {
+        const ElementId<Dim>& element_id =
+            initial_element_ids_by_block[current_block_num]
+                                        [element_num_of_block];
+        const double element_cost = element_costs.at(element_id);
+
+        if (total_elements_distributed_to_proc == 0) {
+          // if we haven't yet assigned any elements to this proc, assign the
+          // current element to the current proc to ensure it gets at least one
+          // element
+          cost_remaining -= element_cost;
+          cost_spent_on_proc = element_cost;
+          num_elements_distributed_to_proc = 1;
+          total_elements_distributed_to_proc = 1;
+          element_num_of_block++;
+        } else {
+          const double current_cost_diff =
+              abs(target_cost_per_proc - cost_spent_on_proc);
+          const double next_cost_diff =
+              abs(target_cost_per_proc - (cost_spent_on_proc + element_cost));
+
+          if (current_cost_diff <= next_cost_diff) {
+            // if the current proc cost is closer to the target cost than if we
+            // were to add one more element, then we're done adding elements to
+            // this proc and don't add the current one
+            add_more_elements_to_proc = false;
+          } else {
+            // otherwise, the current proc cost is farther from the target then
+            // if we were to add one more element, so we add the current element
+            // to the current proc
+            cost_spent_on_proc += element_cost;
+            cost_remaining -= element_cost;
+            num_elements_distributed_to_proc++;
+            total_elements_distributed_to_proc++;
+            element_num_of_block++;
+          }
         }
-      } else {
-        remaining_elements_in_block -= remaining_elements_on_proc;
-        remaining_elements_on_proc = 0;
+      }
+
+      // add a proc and its element allowance for the current block
+      block_element_distribution_.at(current_block_num)
+          .emplace_back(std::make_pair(global_proc_number,
+                                       num_elements_distributed_to_proc));
+      if (element_num_of_block >= num_elements_current_block) {
+        // if we're done assigning elements from the current block, move on to
+        // the elements in the next block
+        ++current_block_num;
+        element_num_of_block = 0;
       }
     }
+  }
+
+  // distribute all remaining Elements on the final proc
+
+  size_t global_proc_number =
+      number_of_procs_with_elements - 1 + number_of_ignored_procs_so_far;
+  while (global_procs_to_ignore.find(global_proc_number) !=
+         global_procs_to_ignore.end()) {
+    ++global_proc_number;
+  }
+
+  // distribute remaining Elements of Block we left off on
+  if (current_block_num < num_blocks) {
+    block_element_distribution_.at(current_block_num)
+        .emplace_back(std::make_pair(
+            global_proc_number,
+            num_elements_by_block[current_block_num] - element_num_of_block));
+  }
+
+  // distribute any Blocks that still remain after the Block we left off on
+  current_block_num++;
+  while (current_block_num < num_blocks) {
+    const size_t num_elements_current_block =
+        num_elements_by_block[current_block_num];
+    block_element_distribution_.at(current_block_num)
+        .emplace_back(
+            std::make_pair(global_proc_number, num_elements_current_block));
+    current_block_num++;
   }
 }
 
@@ -94,10 +304,26 @@ size_t BlockZCurveProcDistribution<Dim>::get_proc_for_element(
       "Processor not successfully chosen. This indicates a flaw in the logic "
       "of BlockZCurveProcDistribution.");
 }
+
 #define GET_DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 
-#define INSTANTIATION(r, data) \
-  template class BlockZCurveProcDistribution<GET_DIM(data)>;
+#define INSTANTIATION(r, data)                                               \
+  template class BlockZCurveProcDistribution<GET_DIM(data)>;                 \
+  double get_num_points_and_grid_spacing_cost(                               \
+      const ElementId<GET_DIM(data)>& element_id,                            \
+      const Block<GET_DIM(data)>& block,                                     \
+      const std::vector<std::array<size_t, GET_DIM(data)>>&                  \
+          initial_refinement_levels,                                         \
+      const std::vector<std::array<size_t, GET_DIM(data)>>& initial_extents, \
+      Spectral::Quadrature quadrature);                                      \
+  template std::unordered_map<ElementId<GET_DIM(data)>, double>              \
+  get_element_costs(                                                         \
+      const std::vector<Block<GET_DIM(data)>>& blocks,                       \
+      const std::vector<std::array<size_t, GET_DIM(data)>>&                  \
+          initial_refinement_levels,                                         \
+      const std::vector<std::array<size_t, GET_DIM(data)>>& initial_extents, \
+      ElementWeight element_weight,                                          \
+      const std::optional<Spectral::Quadrature>& quadrature);
 
 GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
 

--- a/src/Domain/ElementDistribution.cpp
+++ b/src/Domain/ElementDistribution.cpp
@@ -11,86 +11,10 @@
 #include <vector>
 
 #include "Domain/Structure/ElementId.hpp"
-#include "Utilities/Algorithm.hpp"
+#include "Domain/Structure/ZCurve.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 
 namespace domain {
-
-namespace {
-// This interleaves the bits of the element index.
-// A sketch of a 2D block with 4x2 elements, with bit indices and resulting
-// z-curve
-//
-//        x-->
-//        00  01  10  11
-// y  0 |  0   2   4   6
-// |    |
-// v  1 |  1   3   5   7
-template <size_t Dim>
-size_t z_curve_index(const ElementId<Dim>& element_id) {
-  // for the bit manipulation of the element index, we need to interleave the
-  // indices in each dimension in order according to how many bits are in the
-  // index representation. This variable stores the refinement level and
-  // dimension index in ascending order of refinement level, representing a
-  // permutation of the dimensions
-  std::array<std::pair<size_t, size_t>, Dim>
-      dimension_by_highest_refinement_level;
-  for (size_t i = 0; i < Dim; ++i) {
-    dimension_by_highest_refinement_level.at(i) =
-        std::make_pair(element_id.segment_id(i).refinement_level(), i);
-  }
-  alg::sort(dimension_by_highest_refinement_level,
-            [](const std::pair<size_t, size_t>& lhs,
-               const std::pair<size_t, size_t>& rhs) {
-              return lhs.first < rhs.first;
-            });
-
-  size_t element_order_index = 0;
-
-  // 'gap' the lowest refinement direction bits as:
-  // ... x1 x0 -> ... x1 0 0 x0,
-  // then bitwise or in 'gap'ed and shifted next-lowest refinement direction
-  // bits as:
-  // ... y2 y1 y0 -> ... y2 0 y1 x1 0 y0 x0
-  // then bitwise or in 'gap'ed and shifted highest-refinement direction bits
-  // as:
-  // ... z3 z2 z1 z0 -> z3 z2 y2 z1 y1 x1 z0 y0 x0
-  // note that we must skip refinement-level 0 dimensions as though they are
-  // not present
-  size_t leading_gap = 0;
-  for (size_t i = 0; i < Dim; ++i) {
-    const size_t id_to_gap_and_shift =
-        element_id
-            .segment_id(
-                gsl::at(dimension_by_highest_refinement_level, i).second)
-            .index();
-    size_t total_gap = leading_gap;
-    if (gsl::at(dimension_by_highest_refinement_level, i).first > 0) {
-      ++leading_gap;
-    }
-    for (size_t bit_index = 0;
-         bit_index < gsl::at(dimension_by_highest_refinement_level, i).first;
-         ++bit_index) {
-      // This operation will not overflow for our present use of `ElementId`s.
-      // This technique densely assigns an ElementID a unique size_t identifier
-      // determining the Morton curve order, and `ElementId` supports refinement
-      // levels such that a global index within a block will fit in a 64-bit
-      // unsigned integer.
-      element_order_index |=
-          ((id_to_gap_and_shift & two_to_the(bit_index)) << total_gap);
-      for (size_t j = 0; j < Dim; ++j) {
-        if (i != j and
-            bit_index + 1 <
-                gsl::at(dimension_by_highest_refinement_level, j).first) {
-          ++total_gap;
-        }
-      }
-    }
-  }
-  return element_order_index;
-}
-}  // namespace
-
 template <size_t Dim>
 BlockZCurveProcDistribution<Dim>::BlockZCurveProcDistribution(
     size_t number_of_procs_with_elements,

--- a/src/Domain/Structure/CMakeLists.txt
+++ b/src/Domain/Structure/CMakeLists.txt
@@ -23,6 +23,7 @@ spectre_target_sources(
   OrientationMapHelpers.cpp
   SegmentId.cpp
   Side.cpp
+  ZCurve.cpp
   )
 
 spectre_target_headers(
@@ -49,6 +50,7 @@ spectre_target_headers(
   SegmentId.hpp
   Side.hpp
   TrimMap.hpp
+  ZCurve.hpp
   )
 
 target_link_libraries(

--- a/src/Domain/Structure/ZCurve.cpp
+++ b/src/Domain/Structure/ZCurve.cpp
@@ -1,0 +1,86 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Domain/Structure/ZCurve.hpp"
+
+#include <array>
+#include <cstddef>
+#include <utility>
+
+#include "Domain/Structure/ElementId.hpp"
+#include "Domain/Structure/SegmentId.hpp"
+#include "Utilities/Algorithm.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace domain {
+
+template <size_t Dim>
+size_t z_curve_index(const ElementId<Dim>& element_id) {
+  // for the bit manipulation of the element index, we need to interleave the
+  // indices in each dimension in order according to how many bits are in the
+  // index representation. This variable stores the refinement level and
+  // dimension index in ascending order of refinement level, representing a
+  // permutation of the dimensions
+  // pair<refinement level, dim index> in order of ascending refinement
+  std::array<std::pair<size_t, size_t>, Dim>
+      dimension_by_highest_refinement_level;
+  for (size_t i = 0; i < Dim; ++i) {
+    dimension_by_highest_refinement_level.at(i) =
+        std::make_pair(element_id.segment_id(i).refinement_level(), i);
+  }
+  alg::sort(dimension_by_highest_refinement_level);
+
+  size_t element_order_index = 0;
+
+  // 'gap' the lowest refinement direction bits as:
+  // ... x1 x0 -> ... x1 0 0 x0,
+  // then bitwise or in 'gap'ed and shifted next-lowest refinement direction
+  // bits as:
+  // ... y2 y1 y0 -> ... y2 0 y1 x1 0 y0 x0
+  // then bitwise or in 'gap'ed and shifted highest-refinement direction bits
+  // as:
+  // ... z3 z2 z1 z0 -> z3 z2 y2 z1 y1 x1 z0 y0 x0
+  // note that we must skip refinement-level 0 dimensions as though they are
+  // not present
+  size_t leading_gap = 0;
+  for (size_t i = 0; i < Dim; ++i) {
+    const size_t id_to_gap_and_shift =
+        element_id
+            .segment_id(
+                gsl::at(dimension_by_highest_refinement_level, i).second)
+            .index();
+    size_t total_gap = leading_gap;
+    if (gsl::at(dimension_by_highest_refinement_level, i).first > 0) {
+      ++leading_gap;
+    }
+    for (size_t bit_index = 0;
+         bit_index < gsl::at(dimension_by_highest_refinement_level, i).first;
+         ++bit_index) {
+      // This operation will not overflow for our present use of `ElementId`s.
+      // This technique densely assigns an ElementID a unique size_t identifier
+      // determining the Morton curve order, and `ElementId` supports refinement
+      // levels such that a global index within a block will fit in a 64-bit
+      // unsigned integer.
+      element_order_index |=
+          ((id_to_gap_and_shift & two_to_the(bit_index)) << total_gap);
+      for (size_t j = 0; j < Dim; ++j) {
+        if (i != j and
+            bit_index + 1 <
+                gsl::at(dimension_by_highest_refinement_level, j).first) {
+          ++total_gap;
+        }
+      }
+    }
+  }
+  return element_order_index;
+}
+
+#define GET_DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATION(r, data) \
+  template size_t z_curve_index(const ElementId<GET_DIM(data)>& element_id);
+
+GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
+}  // namespace domain

--- a/src/Domain/Structure/ZCurve.hpp
+++ b/src/Domain/Structure/ZCurve.hpp
@@ -1,0 +1,29 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+template <size_t Dim>
+class ElementId;
+
+namespace domain {
+/// \brief Computes the Z-curve index of a given `ElementId`
+///
+/// \details The Z-curve index is computed by interleaving the bits of the
+/// `ElementId`'s `Segment` indices. Here is a sketch of a 2D block with 4x2
+/// elements, with bit indices and the resulting z-curve:
+///
+/// \code
+///        x-->
+///        00  01  10  11
+/// y  0 |  0   2   4   6
+/// |    |
+/// v  1 |  1   3   5   7
+/// \endcode
+///
+/// \param element_id the `ElementId` for which to compute the Z-curve index
+template <size_t Dim>
+size_t z_curve_index(const ElementId<Dim>& element_id);
+}  // namespace domain

--- a/tests/Unit/Domain/Structure/CMakeLists.txt
+++ b/tests/Unit/Domain/Structure/CMakeLists.txt
@@ -22,6 +22,7 @@ set(LIBRARY_SOURCES
   Test_SegmentId.cpp
   Test_Side.cpp
   Test_TrimMap.cpp
+  Test_ZCurve.cpp
   )
 
 add_test_library(

--- a/tests/Unit/Domain/Structure/Test_ZCurve.cpp
+++ b/tests/Unit/Domain/Structure/Test_ZCurve.cpp
@@ -1,0 +1,387 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+
+#include "Domain/Structure/ElementId.hpp"
+#include "Domain/Structure/SegmentId.hpp"
+#include "Domain/Structure/ZCurve.hpp"
+#include "Utilities/MakeArray.hpp"
+
+namespace {
+// Test the Z-curve index computed for ElementIds in 1D. Tests
+// domain::z_curve_index.
+void test_z_curve_index_1d() {
+  // The Z-curve does not depend on the block ID or grid index, so the choice of
+  // these two values for this test is arbitrary
+  const size_t block_id = 0;
+  const size_t grid_index = 0;
+
+  // Create SegmentIds from refinement 0 to 2
+  // l0i0 refers to refinement 0, at index 0
+  SegmentId l0i0(0, 0);
+
+  SegmentId l1i0(1, 0);
+  SegmentId l1i1(1, 1);
+
+  SegmentId l2i0(2, 0);
+  SegmentId l2i1(2, 1);
+  SegmentId l2i2(2, 2);
+  SegmentId l2i3(2, 3);
+
+  // Create ElementIds with 1D SegmentIds from refinement 0 to 2
+  const ElementId<1> e_l0x0(block_id, make_array<1>(l0i0), grid_index);
+
+  const ElementId<1> e_l1x0(block_id, make_array<1>(l1i0), grid_index);
+  const ElementId<1> e_l1x1(block_id, make_array<1>(l1i1), grid_index);
+
+  const ElementId<1> e_l2x0(block_id, make_array<1>(l2i0), grid_index);
+  const ElementId<1> e_l2x1(block_id, make_array<1>(l2i1), grid_index);
+  const ElementId<1> e_l2x2(block_id, make_array<1>(l2i2), grid_index);
+  const ElementId<1> e_l2x3(block_id, make_array<1>(l2i3), grid_index);
+
+  // Check that ElementIds are mapped to their correct Z-curve index
+  CHECK(domain::z_curve_index(e_l0x0) == 0);
+
+  CHECK(domain::z_curve_index(e_l1x0) == 0);
+  CHECK(domain::z_curve_index(e_l1x1) == 1);
+
+  CHECK(domain::z_curve_index(e_l2x0) == 0);
+  CHECK(domain::z_curve_index(e_l2x1) == 1);
+  CHECK(domain::z_curve_index(e_l2x2) == 2);
+  CHECK(domain::z_curve_index(e_l2x3) == 3);
+}
+
+// Test the Z-curve index computed for ElementIds in 2D. Tests
+// domain::z_curve_index.
+void test_z_curve_index_2d() {
+  // The Z-curve does not depend on the block ID or grid index, so the choice of
+  // these two values for this test is arbitrary
+  const size_t block_id = 0;
+  const size_t grid_index = 0;
+
+  // Create SegmentIds from refinement 0 to 2
+  // l0i0 refers to refinement 0, at index 0
+  SegmentId l0i0(0, 0);
+
+  SegmentId l1i0(1, 0);
+  SegmentId l1i1(1, 1);
+
+  SegmentId l2i0(2, 0);
+  SegmentId l2i1(2, 1);
+  SegmentId l2i2(2, 2);
+  SegmentId l2i3(2, 3);
+
+  // Create ElementIds with 2D SegmentIds from refinement 0 to 2 and check that
+  // ElementIds are mapped to their correct Z-curve index
+  const ElementId<2> e_l0x0_l0y0(block_id, make_array(l0i0, l0i0), grid_index);
+  CHECK(domain::z_curve_index(e_l0x0_l0y0) == 0);
+
+  const ElementId<2> e_l1x0_l0y0(block_id, make_array(l1i0, l0i0), grid_index);
+  const ElementId<2> e_l1x1_l0y0(block_id, make_array(l1i1, l0i0), grid_index);
+  CHECK(domain::z_curve_index(e_l1x0_l0y0) == 0);
+  CHECK(domain::z_curve_index(e_l1x1_l0y0) == 1);
+
+  const ElementId<2> e_l0x0_l1y0(block_id, make_array(l0i0, l1i0), grid_index);
+  const ElementId<2> e_l0x0_l1y1(block_id, make_array(l0i0, l1i1), grid_index);
+  CHECK(domain::z_curve_index(e_l0x0_l1y0) == 0);
+  CHECK(domain::z_curve_index(e_l0x0_l1y1) == 1);
+
+  const ElementId<2> e_l1x0_l1y0(block_id, make_array(l1i0, l1i0), grid_index);
+  const ElementId<2> e_l1x1_l1y0(block_id, make_array(l1i1, l1i0), grid_index);
+  const ElementId<2> e_l1x0_l1y1(block_id, make_array(l1i0, l1i1), grid_index);
+  CHECK(domain::z_curve_index(e_l1x0_l1y0) == 0);
+  CHECK(domain::z_curve_index(e_l1x1_l1y0) == 1);
+  CHECK(domain::z_curve_index(e_l1x0_l1y1) == 2);
+
+  const ElementId<2> e_l2x0_l0y0(block_id, make_array(l2i0, l0i0), grid_index);
+  const ElementId<2> e_l2x1_l0y0(block_id, make_array(l2i1, l0i0), grid_index);
+  const ElementId<2> e_l2x2_l0y0(block_id, make_array(l2i2, l0i0), grid_index);
+  const ElementId<2> e_l2x3_l0y0(block_id, make_array(l2i3, l0i0), grid_index);
+  CHECK(domain::z_curve_index(e_l2x0_l0y0) == 0);
+  CHECK(domain::z_curve_index(e_l2x1_l0y0) == 1);
+  CHECK(domain::z_curve_index(e_l2x2_l0y0) == 2);
+  CHECK(domain::z_curve_index(e_l2x3_l0y0) == 3);
+
+  const ElementId<2> e_l2x0_l1y0(block_id, make_array(l2i0, l1i0), grid_index);
+  const ElementId<2> e_l2x1_l1y0(block_id, make_array(l2i1, l1i0), grid_index);
+  const ElementId<2> e_l2x2_l1y0(block_id, make_array(l2i2, l1i0), grid_index);
+  const ElementId<2> e_l2x3_l1y0(block_id, make_array(l2i3, l1i0), grid_index);
+  CHECK(domain::z_curve_index(e_l2x0_l1y0) == 0);
+  CHECK(domain::z_curve_index(e_l2x1_l1y0) == 2);
+  CHECK(domain::z_curve_index(e_l2x2_l1y0) == 4);
+  CHECK(domain::z_curve_index(e_l2x3_l1y0) == 6);
+
+  const ElementId<2> e_l2x0_l1y1(block_id, make_array(l2i0, l1i1), grid_index);
+  const ElementId<2> e_l2x1_l1y1(block_id, make_array(l2i1, l1i1), grid_index);
+  const ElementId<2> e_l2x2_l1y1(block_id, make_array(l2i2, l1i1), grid_index);
+  const ElementId<2> e_l2x3_l1y1(block_id, make_array(l2i3, l1i1), grid_index);
+  CHECK(domain::z_curve_index(e_l2x0_l1y1) == 1);
+  CHECK(domain::z_curve_index(e_l2x1_l1y1) == 3);
+  CHECK(domain::z_curve_index(e_l2x2_l1y1) == 5);
+  CHECK(domain::z_curve_index(e_l2x3_l1y1) == 7);
+
+  const ElementId<2> e_l0x0_l2y0(block_id, make_array(l0i0, l2i0), grid_index);
+  const ElementId<2> e_l0x0_l2y1(block_id, make_array(l0i0, l2i1), grid_index);
+  const ElementId<2> e_l0x0_l2y2(block_id, make_array(l0i0, l2i2), grid_index);
+  const ElementId<2> e_l0x0_l2y3(block_id, make_array(l0i0, l2i3), grid_index);
+  CHECK(domain::z_curve_index(e_l0x0_l2y0) == 0);
+  CHECK(domain::z_curve_index(e_l0x0_l2y1) == 1);
+  CHECK(domain::z_curve_index(e_l0x0_l2y2) == 2);
+  CHECK(domain::z_curve_index(e_l0x0_l2y3) == 3);
+
+  const ElementId<2> e_l1x0_l2y0(block_id, make_array(l1i0, l2i0), grid_index);
+  const ElementId<2> e_l1x0_l2y1(block_id, make_array(l1i0, l2i1), grid_index);
+  const ElementId<2> e_l1x0_l2y2(block_id, make_array(l1i0, l2i2), grid_index);
+  const ElementId<2> e_l1x0_l2y3(block_id, make_array(l1i0, l2i3), grid_index);
+  CHECK(domain::z_curve_index(e_l1x0_l2y0) == 0);
+  CHECK(domain::z_curve_index(e_l1x0_l2y1) == 2);
+  CHECK(domain::z_curve_index(e_l1x0_l2y2) == 4);
+  CHECK(domain::z_curve_index(e_l1x0_l2y3) == 6);
+
+  const ElementId<2> e_l1x1_l2y0(block_id, make_array(l1i1, l2i0), grid_index);
+  const ElementId<2> e_l1x1_l2y1(block_id, make_array(l1i1, l2i1), grid_index);
+  const ElementId<2> e_l1x1_l2y2(block_id, make_array(l1i1, l2i2), grid_index);
+  const ElementId<2> e_l1x1_l2y3(block_id, make_array(l1i1, l2i3), grid_index);
+  CHECK(domain::z_curve_index(e_l1x1_l2y0) == 1);
+  CHECK(domain::z_curve_index(e_l1x1_l2y1) == 3);
+  CHECK(domain::z_curve_index(e_l1x1_l2y2) == 5);
+  CHECK(domain::z_curve_index(e_l1x1_l2y3) == 7);
+
+  const ElementId<2> e_l2x0_l2y0(block_id, make_array(l2i0, l2i0), grid_index);
+  const ElementId<2> e_l2x1_l2y0(block_id, make_array(l2i1, l2i0), grid_index);
+  const ElementId<2> e_l2x2_l2y0(block_id, make_array(l2i2, l2i0), grid_index);
+  const ElementId<2> e_l2x3_l2y0(block_id, make_array(l2i3, l2i0), grid_index);
+  const ElementId<2> e_l2x0_l2y1(block_id, make_array(l2i0, l2i1), grid_index);
+  const ElementId<2> e_l2x1_l2y1(block_id, make_array(l2i1, l2i1), grid_index);
+  const ElementId<2> e_l2x2_l2y1(block_id, make_array(l2i2, l2i1), grid_index);
+  const ElementId<2> e_l2x3_l2y1(block_id, make_array(l2i3, l2i1), grid_index);
+  const ElementId<2> e_l2x0_l2y2(block_id, make_array(l2i0, l2i2), grid_index);
+  const ElementId<2> e_l2x1_l2y2(block_id, make_array(l2i1, l2i2), grid_index);
+  const ElementId<2> e_l2x2_l2y2(block_id, make_array(l2i2, l2i2), grid_index);
+  const ElementId<2> e_l2x3_l2y2(block_id, make_array(l2i3, l2i2), grid_index);
+  const ElementId<2> e_l2x0_l2y3(block_id, make_array(l2i0, l2i3), grid_index);
+  const ElementId<2> e_l2x1_l2y3(block_id, make_array(l2i1, l2i3), grid_index);
+  const ElementId<2> e_l2x2_l2y3(block_id, make_array(l2i2, l2i3), grid_index);
+  const ElementId<2> e_l2x3_l2y3(block_id, make_array(l2i3, l2i3), grid_index);
+  CHECK(domain::z_curve_index(e_l2x0_l2y0) == 0);
+  CHECK(domain::z_curve_index(e_l2x1_l2y0) == 1);
+  CHECK(domain::z_curve_index(e_l2x2_l2y0) == 4);
+  CHECK(domain::z_curve_index(e_l2x3_l2y0) == 5);
+  CHECK(domain::z_curve_index(e_l2x0_l2y1) == 2);
+  CHECK(domain::z_curve_index(e_l2x1_l2y1) == 3);
+  CHECK(domain::z_curve_index(e_l2x2_l2y1) == 6);
+  CHECK(domain::z_curve_index(e_l2x3_l2y1) == 7);
+  CHECK(domain::z_curve_index(e_l2x0_l2y2) == 8);
+  CHECK(domain::z_curve_index(e_l2x1_l2y2) == 9);
+  CHECK(domain::z_curve_index(e_l2x2_l2y2) == 12);
+  CHECK(domain::z_curve_index(e_l2x3_l2y2) == 13);
+  CHECK(domain::z_curve_index(e_l2x0_l2y3) == 10);
+  CHECK(domain::z_curve_index(e_l2x1_l2y3) == 11);
+  CHECK(domain::z_curve_index(e_l2x2_l2y3) == 14);
+  CHECK(domain::z_curve_index(e_l2x3_l2y3) == 15);
+}
+
+// Test the Z-curve index computed for ElementIds in 3D. Tests
+// domain::z_curve_index.
+void test_z_curve_index_3d() {
+  // The Z-curve does not depend on the block ID or grid index, so the choice of
+  // these two values for this test is arbitrary
+  const size_t block_id = 0;
+  const size_t grid_index = 0;
+
+  // Create SegmentIds for 3D test case. Since the 1D and 2D test cases are
+  // exhaustive and exhaustively testing 3D in the same way is a lot to hard
+  // code, we instead test one interesting 3D case. Having the highest
+  // refinement (z ref = 4) at least 2 levels higher than the next highest
+  // refinement (x ref = 2) is an important test case where the highest bits
+  // of the Z-curve index come from one dimension, not an interleaving of more
+  // than one dimension's segment index bits. More concretely, the bits for the
+  // Z-curve index will be z3 z2 z1 x1 z0 x0, where the z3 z2 bits are not
+  // interleaved with another dimension's segment index.
+  const size_t x_refinement = 2;
+  const size_t y_refinement = 0;
+  const size_t z_refinement = 4;
+
+  SegmentId x0(x_refinement, 0);
+  SegmentId x1(x_refinement, 1);
+  SegmentId x2(x_refinement, 2);
+  SegmentId x3(x_refinement, 3);
+
+  SegmentId y0(y_refinement, 0);
+
+  SegmentId z0(z_refinement, 0);
+  SegmentId z1(z_refinement, 1);
+  SegmentId z2(z_refinement, 2);
+  SegmentId z3(z_refinement, 3);
+  SegmentId z4(z_refinement, 4);
+  SegmentId z5(z_refinement, 5);
+  SegmentId z6(z_refinement, 6);
+  SegmentId z7(z_refinement, 7);
+  SegmentId z8(z_refinement, 8);
+  SegmentId z9(z_refinement, 9);
+  SegmentId z10(z_refinement, 10);
+  SegmentId z11(z_refinement, 11);
+  SegmentId z12(z_refinement, 12);
+  SegmentId z13(z_refinement, 13);
+  SegmentId z14(z_refinement, 14);
+  SegmentId z15(z_refinement, 15);
+
+  // Create ElementIds with 3D SegmentIds from refinement 0 to 2 and check that
+  // ElementIds are mapped to their correct Z-curve index
+  // e_000 denotes segment indices x=0, y=0, z=0
+  const ElementId<3> e_000(block_id, make_array(x0, y0, z0), grid_index);
+  CHECK(domain::z_curve_index(e_000) == 0);
+  const ElementId<3> e_100(block_id, make_array(x1, y0, z0), grid_index);
+  CHECK(domain::z_curve_index(e_100) == 1);
+  const ElementId<3> e_200(block_id, make_array(x2, y0, z0), grid_index);
+  CHECK(domain::z_curve_index(e_200) == 4);
+  const ElementId<3> e_300(block_id, make_array(x3, y0, z0), grid_index);
+  CHECK(domain::z_curve_index(e_300) == 5);
+
+  const ElementId<3> e_001(block_id, make_array(x0, y0, z1), grid_index);
+  CHECK(domain::z_curve_index(e_001) == 2);
+  const ElementId<3> e_101(block_id, make_array(x1, y0, z1), grid_index);
+  CHECK(domain::z_curve_index(e_101) == 3);
+  const ElementId<3> e_201(block_id, make_array(x2, y0, z1), grid_index);
+  CHECK(domain::z_curve_index(e_201) == 6);
+  const ElementId<3> e_301(block_id, make_array(x3, y0, z1), grid_index);
+  CHECK(domain::z_curve_index(e_301) == 7);
+
+  const ElementId<3> e_002(block_id, make_array(x0, y0, z2), grid_index);
+  CHECK(domain::z_curve_index(e_002) == 8);
+  const ElementId<3> e_102(block_id, make_array(x1, y0, z2), grid_index);
+  CHECK(domain::z_curve_index(e_102) == 9);
+  const ElementId<3> e_202(block_id, make_array(x2, y0, z2), grid_index);
+  CHECK(domain::z_curve_index(e_202) == 12);
+  const ElementId<3> e_302(block_id, make_array(x3, y0, z2), grid_index);
+  CHECK(domain::z_curve_index(e_302) == 13);
+
+  const ElementId<3> e_003(block_id, make_array(x0, y0, z3), grid_index);
+  CHECK(domain::z_curve_index(e_003) == 10);
+  const ElementId<3> e_103(block_id, make_array(x1, y0, z3), grid_index);
+  CHECK(domain::z_curve_index(e_103) == 11);
+  const ElementId<3> e_203(block_id, make_array(x2, y0, z3), grid_index);
+  CHECK(domain::z_curve_index(e_203) == 14);
+  const ElementId<3> e_303(block_id, make_array(x3, y0, z3), grid_index);
+  CHECK(domain::z_curve_index(e_303) == 15);
+
+  const ElementId<3> e_004(block_id, make_array(x0, y0, z4), grid_index);
+  CHECK(domain::z_curve_index(e_004) == 16);
+  const ElementId<3> e_104(block_id, make_array(x1, y0, z4), grid_index);
+  CHECK(domain::z_curve_index(e_104) == 17);
+  const ElementId<3> e_204(block_id, make_array(x2, y0, z4), grid_index);
+  CHECK(domain::z_curve_index(e_204) == 20);
+  const ElementId<3> e_304(block_id, make_array(x3, y0, z4), grid_index);
+  CHECK(domain::z_curve_index(e_304) == 21);
+
+  const ElementId<3> e_005(block_id, make_array(x0, y0, z5), grid_index);
+  CHECK(domain::z_curve_index(e_005) == 18);
+  const ElementId<3> e_105(block_id, make_array(x1, y0, z5), grid_index);
+  CHECK(domain::z_curve_index(e_105) == 19);
+  const ElementId<3> e_205(block_id, make_array(x2, y0, z5), grid_index);
+  CHECK(domain::z_curve_index(e_205) == 22);
+  const ElementId<3> e_305(block_id, make_array(x3, y0, z5), grid_index);
+  CHECK(domain::z_curve_index(e_305) == 23);
+
+  const ElementId<3> e_006(block_id, make_array(x0, y0, z6), grid_index);
+  CHECK(domain::z_curve_index(e_006) == 24);
+  const ElementId<3> e_106(block_id, make_array(x1, y0, z6), grid_index);
+  CHECK(domain::z_curve_index(e_106) == 25);
+  const ElementId<3> e_206(block_id, make_array(x2, y0, z6), grid_index);
+  CHECK(domain::z_curve_index(e_206) == 28);
+  const ElementId<3> e_306(block_id, make_array(x3, y0, z6), grid_index);
+  CHECK(domain::z_curve_index(e_306) == 29);
+
+  const ElementId<3> e_007(block_id, make_array(x0, y0, z7), grid_index);
+  CHECK(domain::z_curve_index(e_007) == 26);
+  const ElementId<3> e_107(block_id, make_array(x1, y0, z7), grid_index);
+  CHECK(domain::z_curve_index(e_107) == 27);
+  const ElementId<3> e_207(block_id, make_array(x2, y0, z7), grid_index);
+  CHECK(domain::z_curve_index(e_207) == 30);
+  const ElementId<3> e_307(block_id, make_array(x3, y0, z7), grid_index);
+  CHECK(domain::z_curve_index(e_307) == 31);
+
+  const ElementId<3> e_008(block_id, make_array(x0, y0, z8), grid_index);
+  CHECK(domain::z_curve_index(e_008) == 32);
+  const ElementId<3> e_108(block_id, make_array(x1, y0, z8), grid_index);
+  CHECK(domain::z_curve_index(e_108) == 33);
+  const ElementId<3> e_208(block_id, make_array(x2, y0, z8), grid_index);
+  CHECK(domain::z_curve_index(e_208) == 36);
+  const ElementId<3> e_308(block_id, make_array(x3, y0, z8), grid_index);
+  CHECK(domain::z_curve_index(e_308) == 37);
+
+  const ElementId<3> e_009(block_id, make_array(x0, y0, z9), grid_index);
+  CHECK(domain::z_curve_index(e_009) == 34);
+  const ElementId<3> e_109(block_id, make_array(x1, y0, z9), grid_index);
+  CHECK(domain::z_curve_index(e_109) == 35);
+  const ElementId<3> e_209(block_id, make_array(x2, y0, z9), grid_index);
+  CHECK(domain::z_curve_index(e_209) == 38);
+  const ElementId<3> e_309(block_id, make_array(x3, y0, z9), grid_index);
+  CHECK(domain::z_curve_index(e_309) == 39);
+
+  const ElementId<3> e_0010(block_id, make_array(x0, y0, z10), grid_index);
+  CHECK(domain::z_curve_index(e_0010) == 40);
+  const ElementId<3> e_1010(block_id, make_array(x1, y0, z10), grid_index);
+  CHECK(domain::z_curve_index(e_1010) == 41);
+  const ElementId<3> e_2010(block_id, make_array(x2, y0, z10), grid_index);
+  CHECK(domain::z_curve_index(e_2010) == 44);
+  const ElementId<3> e_3010(block_id, make_array(x3, y0, z10), grid_index);
+  CHECK(domain::z_curve_index(e_3010) == 45);
+
+  const ElementId<3> e_0011(block_id, make_array(x0, y0, z11), grid_index);
+  CHECK(domain::z_curve_index(e_0011) == 42);
+  const ElementId<3> e_1011(block_id, make_array(x1, y0, z11), grid_index);
+  CHECK(domain::z_curve_index(e_1011) == 43);
+  const ElementId<3> e_2011(block_id, make_array(x2, y0, z11), grid_index);
+  CHECK(domain::z_curve_index(e_2011) == 46);
+  const ElementId<3> e_3011(block_id, make_array(x3, y0, z11), grid_index);
+  CHECK(domain::z_curve_index(e_3011) == 47);
+
+  const ElementId<3> e_0012(block_id, make_array(x0, y0, z12), grid_index);
+  CHECK(domain::z_curve_index(e_0012) == 48);
+  const ElementId<3> e_1012(block_id, make_array(x1, y0, z12), grid_index);
+  CHECK(domain::z_curve_index(e_1012) == 49);
+  const ElementId<3> e_2012(block_id, make_array(x2, y0, z12), grid_index);
+  CHECK(domain::z_curve_index(e_2012) == 52);
+  const ElementId<3> e_3012(block_id, make_array(x3, y0, z12), grid_index);
+  CHECK(domain::z_curve_index(e_3012) == 53);
+
+  const ElementId<3> e_0013(block_id, make_array(x0, y0, z13), grid_index);
+  CHECK(domain::z_curve_index(e_0013) == 50);
+  const ElementId<3> e_1013(block_id, make_array(x1, y0, z13), grid_index);
+  CHECK(domain::z_curve_index(e_1013) == 51);
+  const ElementId<3> e_2013(block_id, make_array(x2, y0, z13), grid_index);
+  CHECK(domain::z_curve_index(e_2013) == 54);
+  const ElementId<3> e_3013(block_id, make_array(x3, y0, z13), grid_index);
+  CHECK(domain::z_curve_index(e_3013) == 55);
+
+  const ElementId<3> e_0014(block_id, make_array(x0, y0, z14), grid_index);
+  CHECK(domain::z_curve_index(e_0014) == 56);
+  const ElementId<3> e_1014(block_id, make_array(x1, y0, z14), grid_index);
+  CHECK(domain::z_curve_index(e_1014) == 57);
+  const ElementId<3> e_2014(block_id, make_array(x2, y0, z14), grid_index);
+  CHECK(domain::z_curve_index(e_2014) == 60);
+  const ElementId<3> e_3014(block_id, make_array(x3, y0, z14), grid_index);
+  CHECK(domain::z_curve_index(e_3014) == 61);
+
+  const ElementId<3> e_0015(block_id, make_array(x0, y0, z15), grid_index);
+  CHECK(domain::z_curve_index(e_0015) == 58);
+  const ElementId<3> e_1015(block_id, make_array(x1, y0, z15), grid_index);
+  CHECK(domain::z_curve_index(e_1015) == 59);
+  const ElementId<3> e_2015(block_id, make_array(x2, y0, z15), grid_index);
+  CHECK(domain::z_curve_index(e_2015) == 62);
+  const ElementId<3> e_3015(block_id, make_array(x3, y0, z15), grid_index);
+  CHECK(domain::z_curve_index(e_3015) == 63);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Domain.ZCurve", "[Domain][Unit]") {
+  // Test transforming ElementId to Z-curve index
+  test_z_curve_index_1d();
+  test_z_curve_index_2d();
+  test_z_curve_index_3d();
+}

--- a/tests/Unit/Domain/Test_ElementDistribution.cpp
+++ b/tests/Unit/Domain/Test_ElementDistribution.cpp
@@ -3,306 +3,544 @@
 
 #include "Framework/TestingFramework.hpp"
 
-#include <algorithm>
 #include <array>
+#include <cmath>
 #include <cstddef>
-#include <set>
+#include <functional>
+#include <optional>
+#include <unordered_map>
 #include <unordered_set>
+#include <utility>
 #include <vector>
 
+#include "Domain/Block.hpp"
+#include "Domain/Creators/AlignedLattice.hpp"
+#include "Domain/Creators/DomainCreator.hpp"
+#include "Domain/Domain.hpp"
 #include "Domain/ElementDistribution.hpp"
 #include "Domain/Structure/ElementId.hpp"
-#include "Domain/Structure/SegmentId.hpp"
-#include "Utilities/Literals.hpp"
+#include "Domain/Structure/InitialElementIds.hpp"
+#include "Domain/Structure/ZCurve.hpp"
+#include "Utilities/Algorithm.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/Gsl.hpp"
 
 namespace {
+// Test the weighting done by `domain::get_element_costs` for a uniform cost
+// function
+void test_uniform_cost_function() {
+  // AlignedLattice with differently-refined Elements
+  const auto domain_creator = domain::creators::AlignedLattice<2>(
+      {{{{70, 71, 72, 73}}, {{90, 92, 95, 99}}}}, {{2, 5}}, {{3, 3}},
+      {{{{{1, 0}}, {{3, 2}}, {{3, 5}}}, {{{2, 1}}, {{3, 3}}, {{4, 6}}}}},
+      {{{{{1, 0}}, {{3, 2}}, {{4, 5}}}, {{{2, 1}}, {{3, 3}}, {{6, 7}}}}}, {});
 
-// a global indexing to help aggregating the processor maps in the tests
-template <size_t Dim>
-std::array<SegmentId, Dim> element_index_to_segment_id(
-    const std::array<size_t, Dim>& refinement_levels,
-    const size_t element_index) {
-  std::array<SegmentId, Dim> segment_ids{};
-  size_t stride = 1;
-  for (size_t i = 0; i < Dim; ++i) {
-    const size_t element_index_in_dim =
-        (element_index / stride) % two_to_the(gsl::at(refinement_levels, i));
-    segment_ids.at(i) =
-        SegmentId{gsl::at(refinement_levels, i), element_index_in_dim};
-    stride *= two_to_the(gsl::at(refinement_levels, i));
+  const auto domain = domain_creator.create_domain();
+  const auto& blocks = domain.blocks();
+
+  const auto costs = domain::get_element_costs(
+      blocks, domain_creator.initial_refinement_levels(),
+      domain_creator.initial_extents(), domain::ElementWeight::Uniform,
+      std::nullopt);
+
+  for (const auto& element_id_and_cost : costs) {
+    CHECK(element_id_and_cost.second == 1.0);
   }
-  return segment_ids;
 }
 
-template <size_t Dim>
-size_t segment_id_to_element_index(
-    const std::array<SegmentId, Dim>& segment_ids) {
-  size_t element_index = 0;
-  size_t stride = 1;
-  for (size_t i = 0; i < Dim; ++i) {
-    element_index += stride * gsl::at(segment_ids, i).index();
-    stride *= two_to_the(gsl::at(segment_ids, i).refinement_level());
+// Test the weighting done by `domain::get_element_costs` for weighted cost
+// functions
+void test_weighted_cost_function(const domain::ElementWeight element_weight) {
+  const auto domain_creator1 = domain::creators::AlignedLattice<3>(
+      {{{{0.0, 1.0, 2.0}}, {{0.0, 1.0}}, {{0.0, 1.0}}}}, {{2, 1, 0}},
+      {{4, 4, 4}}, {}, {}, {});
+  const auto domain1 = domain_creator1.create_domain();
+  const auto& blocks1 = domain1.blocks();
+
+  // Block size and grid points are the same as blocks in `domain1`, but
+  // refinement levels are different
+  const auto domain_creator2 = domain::creators::AlignedLattice<3>(
+      {{{{0.0, 1.0}}, {{0.0, 1.0}}, {{0.0, 1.0}}}}, {{2, 3, 2}}, {{4, 4, 4}},
+      {}, {}, {});
+  const auto domain2 = domain_creator2.create_domain();
+  const auto& blocks2 = domain2.blocks();
+
+  // Block size and refinement levels are the same as blocks in `domain1`, but
+  // grid points are different
+  const auto domain_creator3 = domain::creators::AlignedLattice<3>(
+      {{{{0.0, 1.0}}, {{0.0, 1.0}}, {{0.0, 1.0}}}}, {{2, 1, 0}}, {{4, 3, 2}},
+      {}, {}, {});
+  const auto domain3 = domain_creator3.create_domain();
+  const auto& blocks3 = domain2.blocks();
+
+  const auto costs1 = domain::get_element_costs(
+      blocks1, domain_creator1.initial_refinement_levels(),
+      domain_creator1.initial_extents(), element_weight,
+      Spectral::Quadrature::GaussLobatto);
+
+  const auto costs2 = domain::get_element_costs(
+      blocks2, domain_creator2.initial_refinement_levels(),
+      domain_creator2.initial_extents(), element_weight,
+      Spectral::Quadrature::GaussLobatto);
+
+  const auto costs3 = domain::get_element_costs(
+      blocks3, domain_creator3.initial_refinement_levels(),
+      domain_creator3.initial_extents(), element_weight,
+      Spectral::Quadrature::GaussLobatto);
+
+  // check that all elements in each domain have the same cost
+
+  auto elemental_cost_it1 = costs1.begin();
+  const double elemental_cost1 = elemental_cost_it1->second;
+  elemental_cost_it1++;
+  while (elemental_cost_it1 != costs1.end()) {
+    CHECK(elemental_cost1 == approx(elemental_cost_it1->second));
+    elemental_cost_it1++;
   }
-  return element_index;
+
+  auto elemental_cost_it2 = costs2.begin();
+  const double elemental_cost2 = elemental_cost_it2->second;
+  elemental_cost_it2++;
+  while (elemental_cost_it2 != costs1.end()) {
+    CHECK(elemental_cost2 == approx(elemental_cost_it2->second));
+    elemental_cost_it2++;
+  }
+
+  auto elemental_cost_it3 = costs3.begin();
+  const double elemental_cost3 = elemental_cost_it3->second;
+  elemental_cost_it3++;
+  while (elemental_cost_it3 != costs3.end()) {
+    CHECK(elemental_cost3 == approx(elemental_cost_it3->second));
+    elemental_cost_it3++;
+  }
+
+  if (element_weight == domain::ElementWeight::NumGridPoints) {
+    // check that varying refinement doesn't affect the cost
+    CHECK(elemental_cost2 == elemental_cost1);
+  } else {
+    // element_weight == domain::ElementWeight::NumGridPointsAndGridSpacing
+
+    // The highest refinement for the first test domain is 2 while the highest
+    // refinement for the second test domain is 3, grid points held constant.
+    // Since the minimum grid spacing of the second domain is half the minimum
+    // grid spacing of the first and since
+    // elemental cost = (# of grid points) / sqrt(min grid spacing), the
+    // elemental cost of the second domain should be a factor of sqrt(2) the
+    // cost.
+    CHECK(elemental_cost2 == approx(sqrt(2.0) * elemental_cost1));
+  }
+
+  // The minimum grid spacing for the first and third domain are equal, but the
+  // number of grid points in an element in the first is 64 while the number of
+  // grid points in an element in the third is 24. Since elemental cost for
+  // either domain::Elementweight::NumGridPoints or
+  // domain::Elementweight::NumGridPointsAndGridSpacing should only scale by
+  // the # of grid points, the elemental cost of the third domain should be a
+  // factor of 24/64 = 3/8 the cost of the first domain.
+  CHECK(elemental_cost3 == elemental_cost1 * 3.0 / 8.0);
 }
 
+// Test the processor distribution logic of the
+// `domain::BlockZCurveProcDistribution` constructor for an unweighted element
+// distribution
 template <size_t Dim>
-size_t number_of_elements_in_block(
-    const std::array<size_t, Dim>& refinement_levels) {
-  size_t number_of_elements = 1;
-  for (size_t i = 0; i < Dim; ++i) {
-    number_of_elements *= two_to_the(gsl::at(refinement_levels, i));
+void test_uniform_element_distribution_construction(
+    const DomainCreator<Dim>& domain_creator,
+    const size_t number_of_procs_with_elements,
+    const std::unordered_set<size_t>& global_procs_to_ignore = {}) {
+  const auto domain = domain_creator.create_domain();
+  const auto& blocks = domain.blocks();
+  const auto initial_refinement_levels =
+      domain_creator.initial_refinement_levels();
+  const auto initial_extents = domain_creator.initial_extents();
+
+  const size_t num_blocks = blocks.size();
+  size_t num_elements = 0;
+  std::vector<size_t> num_elements_by_block(num_blocks, 0);
+  for (size_t i = 0; i < num_blocks; i++) {
+    size_t num_elements_this_block =
+        two_to_the(gsl::at(initial_refinement_levels[i], 0));
+    for (size_t j = 1; j < Dim; j++) {
+      num_elements_this_block *=
+          two_to_the(gsl::at(initial_refinement_levels[i], j));
+    }
+    num_elements_by_block[i] = num_elements_this_block;
+    num_elements += num_elements_this_block;
   }
-  return number_of_elements;
+
+  const auto costs = domain::get_element_costs(
+      blocks, initial_refinement_levels, initial_extents,
+      domain::ElementWeight::Uniform, std::nullopt);
+
+  const domain::BlockZCurveProcDistribution<Dim> element_distribution(
+      costs, number_of_procs_with_elements, blocks, initial_refinement_levels,
+      initial_extents, global_procs_to_ignore);
+  const auto proc_map = element_distribution.block_element_distribution();
+
+  const size_t total_procs =
+      number_of_procs_with_elements + global_procs_to_ignore.size();
+  std::vector<size_t> num_elements_by_proc(total_procs, 0);
+  std::vector<size_t> actual_num_elements_by_block_in_dist(num_blocks, 0);
+  size_t actual_num_elements_in_dist = 0;
+  for (size_t block_number = 0; block_number < proc_map.size();
+       block_number++) {
+    for (const auto& proc_allowance : proc_map[block_number]) {
+      const size_t proc_number = proc_allowance.first;
+      const size_t element_allowance = proc_allowance.second;
+      num_elements_by_proc[proc_number] += element_allowance;
+      actual_num_elements_by_block_in_dist[block_number] += element_allowance;
+    }
+    // check that the number of elements in this block accounted for in the
+    // distribution matches the expected number of total elements for this block
+    CHECK(actual_num_elements_by_block_in_dist[block_number] ==
+          num_elements_by_block[block_number]);
+    actual_num_elements_in_dist +=
+        actual_num_elements_by_block_in_dist[block_number];
+  }
+  // check that the number of elements accounted for in the distribution matches
+  // the expected number of total elements
+  CHECK(actual_num_elements_in_dist == num_elements);
+
+  size_t lowest_proc_with_elements = 0;
+  while (global_procs_to_ignore.count(lowest_proc_with_elements) == 1) {
+    lowest_proc_with_elements++;
+  }
+  const size_t num_elements_on_lowest_proc =
+      num_elements_by_proc[lowest_proc_with_elements];
+
+  size_t num_elements_so_far = num_elements_on_lowest_proc;
+  size_t proc_num = lowest_proc_with_elements + 1;
+  while (proc_num < total_procs and num_elements_so_far < num_elements) {
+    const size_t num_elements_this_proc = num_elements_by_proc[proc_num];
+    if (global_procs_to_ignore.count(proc_num) == 1) {
+      CHECK(num_elements_this_proc == 0);
+    } else {
+      // check that the distribution is near-uniform
+      CHECK((num_elements_this_proc == num_elements_on_lowest_proc or
+             num_elements_this_proc == num_elements_on_lowest_proc + 1 or
+             num_elements_this_proc == num_elements_on_lowest_proc - 1));
+    }
+    num_elements_so_far += num_elements_this_proc;
+    proc_num++;
+  }
+
+  // check that any remainder of processors we didn't need do indeed have 0
+  // elements assigned to them
+  while (proc_num < total_procs) {
+    CHECK(num_elements_by_proc[proc_num] == 0);
+    proc_num++;
+  }
 }
 
+// Test the processor distribution logic of the
+// `domain::BlockZCurveProcDistribution` constructor for weighted element
+// distributions
 template <size_t Dim>
-std::vector<std::vector<size_t>> make_proc_map_for_domain(
-    const size_t number_of_blocks, const size_t number_of_procs,
-    const std::vector<std::array<size_t, Dim>>& refinement_levels_by_block,
-    const std::unordered_set<size_t>& procs_to_ignore) {
-  std::vector<std::vector<size_t>> proc_map(number_of_blocks);
-  const domain::BlockZCurveProcDistribution distribution{
-      number_of_procs, refinement_levels_by_block, procs_to_ignore};
-  for (size_t block = 0; block < number_of_blocks; ++block) {
-    const size_t number_of_elements =
-        number_of_elements_in_block(gsl::at(refinement_levels_by_block, block));
-    proc_map.at(block) = std::vector<size_t>(number_of_elements);
-    for (size_t element_index = 0; element_index < number_of_elements;
-         ++element_index) {
-      const ElementId<Dim> element_id{
-          block,
-          element_index_to_segment_id(
-              gsl::at(refinement_levels_by_block, block), element_index)};
-      proc_map.at(block).at(element_index) =
-          distribution.get_proc_for_element(element_id);
-      // Check that we ignored the correct proc
-      CHECK(not procs_to_ignore.count(proc_map.at(block).at(element_index)));
+void test_weighted_element_distribution_construction(
+    const domain::ElementWeight element_weight,
+    const DomainCreator<Dim>& domain_creator,
+    const size_t number_of_procs_with_elements,
+    const std::unordered_set<size_t>& global_procs_to_ignore = {}) {
+  const auto domain = domain_creator.create_domain();
+  const auto& blocks = domain.blocks();
+  const auto initial_refinement_levels =
+      domain_creator.initial_refinement_levels();
+  const auto initial_extents = domain_creator.initial_extents();
+
+  const size_t num_blocks = blocks.size();
+  size_t num_elements = 0;
+  std::vector<size_t> num_elements_by_block(num_blocks, 0);
+  for (size_t i = 0; i < num_blocks; i++) {
+    size_t num_elements_this_block =
+        two_to_the(gsl::at(initial_refinement_levels[i], 0));
+    for (size_t j = 1; j < Dim; j++) {
+      num_elements_this_block *=
+          two_to_the(gsl::at(initial_refinement_levels[i], j));
+    }
+    num_elements_by_block[i] = num_elements_this_block;
+    num_elements += num_elements_this_block;
+  }
+
+  const auto costs = domain::get_element_costs(
+      blocks, initial_refinement_levels, initial_extents, element_weight,
+      Spectral::Quadrature::GaussLobatto);
+
+  const domain::BlockZCurveProcDistribution<Dim> element_distribution(
+      costs, number_of_procs_with_elements, blocks, initial_refinement_levels,
+      initial_extents, global_procs_to_ignore);
+  const auto proc_map = element_distribution.block_element_distribution();
+
+  const size_t total_procs =
+      number_of_procs_with_elements + global_procs_to_ignore.size();
+  std::vector<size_t> num_elements_by_proc(total_procs, 0);
+  std::vector<size_t> actual_num_elements_by_block_in_dist(num_blocks, 0);
+  size_t actual_num_elements_in_dist = 0;
+  for (size_t block_number = 0; block_number < proc_map.size();
+       block_number++) {
+    for (const auto& proc_allowance : proc_map[block_number]) {
+      const size_t proc_number = proc_allowance.first;
+      const size_t element_allowance = proc_allowance.second;
+      num_elements_by_proc[proc_number] += element_allowance;
+      actual_num_elements_by_block_in_dist[block_number] += element_allowance;
+    }
+    // check that the number of elements in this block accounted for in the
+    // distribution matches the expected number of total elements for this block
+    CHECK(actual_num_elements_by_block_in_dist[block_number] ==
+          num_elements_by_block[block_number]);
+    actual_num_elements_in_dist +=
+        actual_num_elements_by_block_in_dist[block_number];
+  }
+  // check that the number of elements accounted for in the distribution matches
+  // the expected number of total elements
+  CHECK(actual_num_elements_in_dist == num_elements);
+
+  std::vector<std::vector<ElementId<Dim>>> initial_element_ids_by_block(
+      num_blocks);
+  for (size_t i = 0; i < num_blocks; i++) {
+    const size_t num_elements_this_block = two_to_the(alg::accumulate(
+        initial_refinement_levels[i], 0_st, std::plus<size_t>()));
+    initial_element_ids_by_block[i].reserve(num_elements_this_block);
+    initial_element_ids_by_block[i] =
+        initial_element_ids(blocks[i].id(), initial_refinement_levels[i]);
+    alg::sort(initial_element_ids_by_block[i],
+              [](const ElementId<Dim>& lhs, const ElementId<Dim>& rhs) {
+                return domain::z_curve_index(lhs) < domain::z_curve_index(rhs);
+              });
+  }
+
+  double total_cost = 0.0;
+  for (const auto& element_id_and_cost : costs) {
+    total_cost += element_id_and_cost.second;
+  }
+
+  // one flattened vector instead of vectors by Block
+  std::vector<double> costs_flattened(num_elements);
+  size_t cost_index = 0;
+  for (size_t i = 0; i < num_blocks; i++) {
+    const size_t num_elements_this_block =
+        initial_element_ids_by_block[i].size();
+    for (size_t j = 0; j < num_elements_this_block; j++) {
+      const ElementId<Dim>& element_id = initial_element_ids_by_block[i][j];
+      costs_flattened[cost_index] = costs.at(element_id);
+      cost_index++;
     }
   }
-  return proc_map;
+
+  cost_index = 0;
+  double cost_remaining = total_cost;
+  size_t procs_skipped = 0;
+  size_t proc_num = 0;
+  // check that we distributed the right number of elements to each proc based
+  // on the sum of their costs in Z-curve index order
+  while (proc_num < total_procs) {
+    if (global_procs_to_ignore.count(proc_num)) {
+      procs_skipped++;
+      proc_num++;
+      continue;
+    }
+
+    if (cost_index < num_elements) {
+      // if we haven't accounted for all elements yet, we should still have cost
+      // left to account for
+      CHECK(cost_remaining <= total_cost);
+    } else {
+      // if we've already accounted for all the elements, we shouldn't have any
+      // cost left to account for, and it's the case that more procs were
+      // requested than could be used, e.g. in the case of less elements than
+      // procs
+      Approx custom_approx = Approx::custom().epsilon(1.0e-9).scale(1.0);
+      CHECK(cost_remaining == custom_approx(0.0));
+      break;
+    }
+
+    // the average cost per proc that we're aiming for
+    const double target_proc_cost =
+        cost_remaining /
+        (number_of_procs_with_elements - proc_num + procs_skipped);
+
+    // total cost on the processor before adding the cost of the final element
+    // assigned to this proc
+    double proc_cost_without_final_element = 0.0;
+    const size_t num_elements_this_proc = num_elements_by_proc[proc_num];
+    // add up costs of all elements but the final one to add
+    for (size_t j = 0; j < num_elements_this_proc - 1; j++) {
+      const double this_cost = costs_flattened[cost_index + j];
+      proc_cost_without_final_element += this_cost;
+    }
+
+    // the cost of all of the elements assigned to this proc
+    const double proc_cost_with_final_element =
+        proc_cost_without_final_element +
+        costs_flattened[cost_index + num_elements_this_proc - 1];
+
+    const double diff_without_final_element =
+        abs(proc_cost_without_final_element - target_proc_cost);
+
+    const double diff_with_final_element =
+        abs(proc_cost_with_final_element - target_proc_cost);
+
+    // if the elements assigned to this proc have a cost that is over the target
+    // cost per proc, make sure that either it's because only one element is
+    // being assigned to the proc or this cost is closer to the target than if
+    // we omitted the final element, i.e. check that it's better to keep the
+    // final element than to not
+    if (proc_cost_with_final_element > target_proc_cost) {
+      CHECK((num_elements_this_proc == 1 or
+             diff_with_final_element == approx(diff_without_final_element) or
+             diff_with_final_element < diff_without_final_element));
+    }
+
+    if (cost_index + num_elements_this_proc < num_elements) {
+      // total cost on the processor if we were to add the cost of the next
+      // element (one additional than the number chosen)
+      const double proc_cost_with_extra_element =
+          proc_cost_with_final_element +
+          costs_flattened[cost_index + num_elements_this_proc];
+      const double diff_with_extra_element =
+          abs(proc_cost_with_extra_element - target_proc_cost);
+
+      // if it appears better to add one more element, check that it's because
+      // the distance from the target cost with or without the additional
+      // element is about the same
+      if (diff_with_extra_element < diff_with_final_element) {
+        Approx custom_approx = Approx::custom().epsilon(1.0e-12).scale(1.0);
+        CHECK(diff_with_extra_element ==
+              custom_approx(diff_with_final_element));
+      }
+    }
+
+    cost_index += num_elements_this_proc;
+    cost_remaining -= proc_cost_with_final_element;
+    proc_num++;
+  }
+
+  // check that any remainder of processors we didn't need do indeed have 0
+  // elements assigned to them
+  while (proc_num < total_procs) {
+    CHECK(num_elements_by_proc[proc_num] == 0);
+    proc_num++;
+  }
 }
 
-// check that the distribution portions out the number of elements approximately
-// evenly (within 1 element) to each processor
+// Test the retrieval of the assigned processor that is done by
+// `domain::BlockZCurveProcDistribution::get_proc_for_element`
 template <size_t Dim>
-void check_element_distribution_uniformity(
-    const std::vector<std::vector<size_t>>& proc_map,
-    const size_t number_of_procs,
-    const std::vector<std::array<size_t, Dim>>& refinement_levels_by_block) {
-  // size_t, size_t = proc, number of elements
-  std::unordered_map<size_t, size_t> elements_per_proc{};
-  for (const auto& block_proc_map : proc_map) {
-    for (const size_t proc : block_proc_map) {
-      ++elements_per_proc[proc];
-    }
-  }
-  const size_t number_of_elements = std::accumulate(
-      refinement_levels_by_block.begin(), refinement_levels_by_block.end(),
-      0_st, [](const size_t lhs, const std::array<size_t, Dim>& rhs) {
-        return lhs + number_of_elements_in_block(rhs);
-      });
-  for (const auto& [proc, element_count] : elements_per_proc) {
-    (void)proc;
-    CHECK((element_count == number_of_elements / number_of_procs or
-           element_count == number_of_elements / number_of_procs + 1));
-  }
-}
+void test_proc_retrieval(
+    const domain::ElementWeight element_weight,
+    const DomainCreator<Dim>& domain_creator,
+    const size_t number_of_procs_with_elements,
+    const std::unordered_set<size_t>& global_procs_to_ignore = {}) {
+  const auto domain = domain_creator.create_domain();
+  const auto& blocks = domain.blocks();
+  const auto initial_refinement_levels =
+      domain_creator.initial_refinement_levels();
+  const auto initial_extents = domain_creator.initial_extents();
 
-// check that, for each block, no processor appears in more than two connected
-// groups, and that each processor does not appear in too many blocks.
-template <size_t Dim>
-void check_element_distribution_cohesion(
-    const std::vector<std::vector<size_t>>& proc_map,
-    const size_t number_of_procs,
-    const std::vector<std::array<size_t, Dim>>& refinement_levels_by_block,
-    const bool nonuniform_block = false) {
-  // size_t, std::set<size_t> = proc, block set
-  std::unordered_map<size_t, std::set<size_t>> block_set_per_proc{};
-  for (size_t block = 0; block < proc_map.size(); ++block) {
-    std::array<size_t, Dim> strides{};
-    strides[0] = 1;
-    for (size_t i = 1; i < Dim; ++i) {
-      strides.at(i) = gsl::at(strides, i - 1) *
-                      two_to_the(gsl::at(
-                          gsl::at(refinement_levels_by_block, block), i - 1));
-    }
-    // size_t, size_t = proc, number of clusters of elements
-    std::unordered_map<size_t, size_t> number_of_clusters_per_proc{};
-    std::vector<bool> seen(gsl::at(proc_map, block).size(), false);
-    for (size_t start_element = 0;
-         start_element < gsl::at(proc_map, block).size(); ++start_element) {
-      if (not seen.at(start_element)) {
-        const size_t current_proc =
-            gsl::at(gsl::at(proc_map, block), start_element);
-        block_set_per_proc[current_proc].insert(block);
-        ++number_of_clusters_per_proc[current_proc];
-        seen.at(start_element) = true;
-        // perform a bredth-first search to get all elements in the cluster that
-        // share a proc and mark them seen
-        std::deque<size_t> next_elements;
-        auto insert_adjacent_unseen = [&next_elements, &current_proc, &proc_map,
-                                       &refinement_levels_by_block, &strides,
-                                       &seen, &block](const size_t index) {
-          for (size_t i = 0; i < Dim; ++i) {
-            const size_t index_in_dim =
-                (index / gsl::at(strides, i)) %
-                two_to_the(
-                    gsl::at(gsl::at(refinement_levels_by_block, block), i));
-            if (index_in_dim > 0 and
-                not seen.at(index - gsl::at(strides, i)) and
-                gsl::at(gsl::at(proc_map, block),
-                        index - gsl::at(strides, i)) == current_proc) {
-              next_elements.push_back(index - gsl::at(strides, i));
-              seen.at(index - gsl::at(strides, i)) = true;
-            }
-            if (index_in_dim + 1 <
-                    two_to_the(gsl::at(
-                        gsl::at(refinement_levels_by_block, block), i)) and
-                not seen.at(index + gsl::at(strides, i)) and
-                gsl::at(gsl::at(proc_map, block),
-                        index + gsl::at(strides, i)) == current_proc) {
-              next_elements.push_back(index + gsl::at(strides, i));
-              seen.at(index + gsl::at(strides, i)) = true;
-            }
-          }
-        };
-        insert_adjacent_unseen(start_element);
-        // note that this loop cannot be converted to an STL iterator algorithm
-        // because `insert_adjacent_unseen` violates iterator stability via the
-        // insertions.
-        while (not next_elements.empty()) {
-          const size_t front = next_elements.front();
-          next_elements.pop_front();
-          insert_adjacent_unseen(front);
+  const size_t num_blocks = blocks.size();
+  std::vector<std::vector<ElementId<Dim>>> element_ids_in_z_curve_order(
+      num_blocks);
+  for (size_t i = 0; i < num_blocks; i++) {
+    element_ids_in_z_curve_order[i] =
+        initial_element_ids(i, gsl::at(initial_refinement_levels, i), 0);
+    alg::sort(element_ids_in_z_curve_order[i],
+              [](const ElementId<Dim>& lhs, const ElementId<Dim>& rhs) {
+                return domain::z_curve_index(lhs) < domain::z_curve_index(rhs);
+              });
+  }
+
+  const auto costs = domain::get_element_costs(
+      blocks, initial_refinement_levels, initial_extents, element_weight,
+      Spectral::Quadrature::GaussLobatto);
+
+  const domain::BlockZCurveProcDistribution<Dim> element_distribution(
+      costs, number_of_procs_with_elements, blocks, initial_refinement_levels,
+      initial_extents, global_procs_to_ignore);
+  const auto proc_map = element_distribution.block_element_distribution();
+
+  const size_t total_number_of_procs =
+      number_of_procs_with_elements + global_procs_to_ignore.size();
+
+  // whether or not we've assigned elements to a proc
+  std::vector<bool> proc_hit(total_number_of_procs, false);
+
+  size_t highest_proc_assigned = 0;
+  for (size_t i = 0; i < num_blocks; i++) {
+    size_t element_index = 0;
+    const std::vector<std::pair<size_t, size_t>>& proc_map_this_block =
+        proc_map[i];
+    const size_t num_procs_this_block = proc_map_this_block.size();
+
+    for (size_t j = 0; j < num_procs_this_block; j++) {
+      const size_t expected_proc = proc_map_this_block[j].first;
+      const size_t proc_allowance = proc_map_this_block[j].second;
+
+      for (size_t k = 0; k < proc_allowance; k++) {
+        const size_t actual_proc = element_distribution.get_proc_for_element(
+            element_ids_in_z_curve_order[i][element_index]);
+        // check that the correct processor is returned for the `ElementId`
+        CHECK(actual_proc == expected_proc);
+        proc_hit[actual_proc] = true;
+        if (highest_proc_assigned < actual_proc) {
+          highest_proc_assigned = actual_proc;
         }
       }
-    }
-    // verify that the distribution is well-clustered -- the Z-curve should
-    // ensure no more than 2 clusters for each core
-    for (const auto& [proc, number_of_clusters] : number_of_clusters_per_proc) {
-      (void)proc;
-      CHECK(number_of_clusters < 3);
-    }
-  }
-  // verify that each processor has not been assigned to too many blocks -- the
-  // greedy algorithm will let extras 'overflow' into the next block, but that
-  // shouldn't give more than one extra block in the count.
-  // this check assumes that only one block is a different size to make the
-  // upper bound calculation simple -- the algorithm still works to keep the
-  // number of blocks in which a given processor participates low for more
-  // intricate cases, but the upper bound becomes more complicated to write out.
-  for (const auto& [proc, blocks] : block_set_per_proc) {
-    (void)proc;
-    CHECK(blocks.size() <=
-          static_cast<size_t>(
-              std::ceil(static_cast<double>(refinement_levels_by_block.size()) /
-                        number_of_procs) +
-              (nonuniform_block ? 2 : 1)));
-  }
-}
-
-template <size_t Dim>
-void test_single_block_domain() {
-  std::vector<std::array<size_t, Dim>> refinement_levels_by_block;
-  refinement_levels_by_block.emplace_back();
-  for (size_t i = 0; i < Dim; ++i) {
-    refinement_levels_by_block.at(0).at(i) = 3;
-  }
-  // Ignore the Dim'th proc (this proc is guaranteed to always exist)
-  std::unordered_set<size_t> procs_to_ignore = {Dim};
-
-  std::vector<std::vector<size_t>> proc_map = make_proc_map_for_domain(
-      1, two_to_the(Dim), refinement_levels_by_block, procs_to_ignore);
-  // check that the domain is segmented into 4x4x4 cubes
-  std::set<size_t> procs_seen;
-  for (size_t cube_index = 0; cube_index < two_to_the(Dim); ++cube_index) {
-    std::array<SegmentId, Dim> reference_segment_id{};
-    size_t stride = 1;
-    for (size_t i = 0; i < Dim; ++i) {
-      reference_segment_id.at(i) =
-          SegmentId{gsl::at(gsl::at(refinement_levels_by_block, 0), i),
-                    (cube_index / stride) % 2 == 0_st ? 0_st : 4_st};
-      stride *= 2;
-    }
-    const size_t global_reference_id =
-        segment_id_to_element_index(reference_segment_id);
-    // check that the 2^Dim lower corners of the large cubes have unique procs
-    CHECK(procs_seen.count(
-              gsl::at(gsl::at(proc_map, 0), global_reference_id)) == 0);
-    procs_seen.insert(gsl::at(gsl::at(proc_map, 0), global_reference_id));
-    for (size_t element_within_cube = 0;
-         element_within_cube <
-         number_of_elements_in_block(gsl::at(refinement_levels_by_block, 0)) /
-             two_to_the(Dim);
-         ++element_within_cube) {
-      std::array<SegmentId, Dim> segment_id = reference_segment_id;
-      stride = 1;
-      for (size_t i = 0; i < Dim; ++i) {
-        segment_id.at(i) = SegmentId{gsl::at(segment_id, i).refinement_level(),
-                                     gsl::at(segment_id, i).index() +
-                                         (element_within_cube / stride) % 4};
-        stride *= 4_st;
-      }
-      // check that each element in the large cubes have the same processor as
-      // the corner elements.
-      size_t global_element_id = segment_id_to_element_index(segment_id);
-      CHECK(gsl::at(gsl::at(proc_map, 0), global_element_id) ==
-            gsl::at(gsl::at(proc_map, 0), global_reference_id));
+      element_index += proc_allowance;
     }
   }
 
-  // Ignore another proc common to all Dims for this upcoming case
-  procs_to_ignore.insert(4);
-  // test a more scattered distribution because of the prime number of procs
-  proc_map = make_proc_map_for_domain(1, 5, refinement_levels_by_block,
-                                      procs_to_ignore);
-  check_element_distribution_uniformity(proc_map, 5,
-                                        refinement_levels_by_block);
-  check_element_distribution_cohesion(proc_map, 5, refinement_levels_by_block);
-}
-
-template <size_t Dim>
-void general_test(const size_t number_of_blocks, const size_t number_of_procs,
-                  const bool uneven_domain) {
-  std::vector<std::array<size_t, Dim>> refinement_levels_by_block;
-  for (size_t i = 0; i < number_of_blocks; ++i) {
-    refinement_levels_by_block.emplace_back();
-    for (size_t j = 0; j < Dim; ++j) {
-      refinement_levels_by_block.at(i).at(j) = uneven_domain ? j : 1;
-    }
-  }
-  if (uneven_domain) {
-    for (size_t j = 0; j < Dim; ++j) {
-      refinement_levels_by_block.at(0).at(j) = j % 2 == 0 ? 1 : 2;
-    }
-  }
-  // Ignore only one proc
-  const std::unordered_set<size_t> procs_to_ignore = {1};
-  const std::vector<std::vector<size_t>> proc_map =
-      make_proc_map_for_domain(number_of_blocks, number_of_procs,
-                               refinement_levels_by_block, procs_to_ignore);
-  check_element_distribution_uniformity(proc_map, number_of_procs,
-                                        refinement_levels_by_block);
-  check_element_distribution_cohesion(
-      proc_map, number_of_procs, refinement_levels_by_block, uneven_domain);
-}
-
-SPECTRE_TEST_CASE("Unit.Domain.ElementDistribution", "[Domain][Unit]") {
-  {
-    INFO("Single block domain");
-    test_single_block_domain<1>();
-    test_single_block_domain<2>();
-    test_single_block_domain<3>();
-  }
-  for (const size_t number_of_blocks : {2_st, 6_st}) {
-    for (const size_t number_of_procs : {2_st, 7_st}) {
-      for (const bool uneven_domain : {true, false}) {
-        general_test<1>(number_of_blocks, number_of_procs, uneven_domain);
-        general_test<2>(number_of_blocks, number_of_procs, uneven_domain);
-        general_test<3>(number_of_blocks, number_of_procs, uneven_domain);
-      }
+  // check that ignored procs were indeed skipped and that all other procs
+  // up to the highest one assigned were hit
+  for (size_t i = 0; i < highest_proc_assigned + 1; i++) {
+    if (global_procs_to_ignore.count(i) == 0) {
+      CHECK(proc_hit[i]);
+    } else {
+      CHECK(not proc_hit[i]);
     }
   }
 }
 }  // namespace
+
+SPECTRE_TEST_CASE("Unit.Domain.ElementDistribution", "[Domain][Unit]") {
+  // Test cost functions
+  test_uniform_cost_function();
+  test_weighted_cost_function(domain::ElementWeight::NumGridPoints);
+  test_weighted_cost_function(
+      domain::ElementWeight::NumGridPointsAndGridSpacing);
+
+  // Inputs for testing `BlockZCurveProcDistribution`
+
+  // 1D, single block
+  const auto lattice_1d = domain::creators::AlignedLattice<1>(
+      {{{{0.0, 1.0}}}}, {{4}}, {{6}}, {}, {}, {});
+  // 2D
+  const auto lattice_2d = domain::creators::AlignedLattice<2>(
+      {{{{0.0, 0.3}}, {{0.0, 0.8, 2.5, 4.9}}}}, {{2, 3}}, {{4, 5}}, {}, {}, {});
+  // 3D
+  const auto lattice_3d = domain::creators::AlignedLattice<3>(
+      {{{{0.0, 0.6}}, {{0.0, 0.4, 0.7}}, {{0.0, 0.3}}}}, {{2, 1, 3}},
+      {{5, 4, 5}}, {}, {}, {});
+
+  // Test element distribution construction logic
+
+  // uniform distribution, single proc, single block
+  test_uniform_element_distribution_construction(lattice_1d, 1);
+  // uniform distribution, multiple procs, multiple blocks
+  test_uniform_element_distribution_construction(
+      lattice_2d, 20, std::unordered_set<size_t>{4, 20});
+  // weighted distribution, multiple procs
+  test_weighted_element_distribution_construction(
+      domain::ElementWeight::NumGridPointsAndGridSpacing, lattice_3d, 22,
+      std::unordered_set<size_t>{3, 4});
+  // weighted distribution, more procs than elements to distribute
+  test_weighted_element_distribution_construction(
+      domain::ElementWeight::NumGridPoints, lattice_2d, 100,
+      std::unordered_set<size_t>{0, 9});
+
+  // Test processor retrieval with ignored processors
+  test_proc_retrieval(domain::ElementWeight::NumGridPointsAndGridSpacing,
+                      lattice_2d, 19, std::unordered_set<size_t>{0, 8, 9, 21});
+  // Test processor retrieval when there are more processors requested than
+  // `Element`s in the domain
+  test_proc_retrieval(domain::ElementWeight::NumGridPointsAndGridSpacing,
+                      lattice_2d, 100, std::unordered_set<size_t>{17});
+}


### PR DESCRIPTION
Addresses #4582

## Proposed changes

This PR:
- Adds a weighted element distribution that weights elemental costs and attempts to spread costs evenly across processors, which is opposed to our current unweighted distribution (`BlockZCurveProcDistribution`), which assigns an even number of elements to each processor
- Updates `Evolution/DiscontinuousGalerkin/DgElementArray.hpp` to use this new weighted distribution as opposed to its current usage of the unweighted distribution (`BlockZCurveProcDistribution`)

The cost of each element is computed as `(number of grid points) / sqrt(minimum grid spacing in Frame::Grid)`.

To test the speedup of these changes, `EvolveGhBinaryBlackHole` was run for equal mass, non-spinning black holes to time 100M with initial time step 0.0002 on 4 of ocean's orca-1 nodes with 20 tasks per node and using blocks with p-refinements 9 and 10 and h-refinements 1 and 2 (different blocks with different refinements, the exact yaml used can be provided). Before these changes, this simulation took ~15.75 hours and after these changes, this simulation took ~9 hours, yielding a 75% speedup improvement for this particular simulation to get to 100M.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
