### PR TITLE
Add abutting direction per element to `ExcisionSphere`

### DIFF
--- a/src/Domain/Structure/ExcisionSphere.hpp
+++ b/src/Domain/Structure/ExcisionSphere.hpp
@@ -9,10 +9,12 @@
 #include <cstddef>
 #include <iosfwd>
 #include <limits>
+#include <optional>
 #include <unordered_map>
 
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/ElementId.hpp"
 
 /// \cond
 namespace PUP {
@@ -65,6 +67,10 @@ class ExcisionSphere {
       const {
     return abutting_directions_;
   }
+  /// Checks whether an element abuts the excision sphere. If it does, returns
+  /// the corresponding direction. Else, `nullopt` is returned.
+  std::optional<Direction<VolumeDim>> abutting_direction(
+      const ElementId<VolumeDim>& element_id) const;
 
   // NOLINTNEXTLINE(google-runtime-references)
   void pup(PUP::er& p);

--- a/tests/Unit/Domain/Structure/Test_ExcisionSphere.cpp
+++ b/tests/Unit/Domain/Structure/Test_ExcisionSphere.cpp
@@ -3,13 +3,25 @@
 
 #include "Framework/TestingFramework.hpp"
 
+#include <array>
 #include <cstddef>
 #include <functional>
+#include <optional>
+#include <utility>
+#include <vector>
 
+#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/CreateInitialElement.hpp"
+#include "Domain/Creators/Shell.hpp"
+#include "Domain/ElementMap.hpp"
+#include "Domain/InterfaceLogicalCoordinates.hpp"
 #include "Domain/Structure/Direction.hpp"
 #include "Domain/Structure/ExcisionSphere.hpp"
+#include "Domain/Structure/InitialElementIds.hpp"
 #include "Framework/TestHelpers.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
 #include "Utilities/GetOutput.hpp"
 #include "Utilities/StdHelpers.hpp"  // IWYU pragma: keep
 
@@ -72,12 +84,71 @@ void check_excision_sphere_3d() {
       {{0, Direction<3>::lower_xi()}, {2, Direction<3>::upper_zeta()}});
 }
 
+void test_abutting_direction_shell() {
+  const double inner_radius = 1.3;
+  for (const auto& ref_level : std::array<size_t, 3>{{0, 1, 2}}) {
+    // shell without radial partition (blocks have 2 outer boundaries)
+    domain::creators::Shell shell_plain{
+        inner_radius, 3.,
+        ref_level,    {4, 4},
+        true,         {},
+        {},           {domain::CoordinateMaps::Distribution::Linear}};
+    // shell with radial partition (blocks have 1 outer boundary)
+    domain::creators::Shell shell_partitioned{
+        inner_radius,
+        3.,
+        ref_level,
+        {4, 4},
+        true,
+        {},
+        {2.},
+        {domain::CoordinateMaps::Distribution::Linear,
+         domain::CoordinateMaps::Distribution::Linear}};
+    std::vector<domain::creators::Shell> shells{};
+    shells.push_back(std::move(shell_plain));
+    shells.push_back(std::move(shell_partitioned));
+    for (const auto& shell : shells) {
+      const auto shell_domain = shell.create_domain();
+      const auto& blocks = shell_domain.blocks();
+      const auto& initial_ref_levels = shell.initial_refinement_levels();
+      const auto element_ids = initial_element_ids(initial_ref_levels);
+      const auto excision_sphere =
+          shell_domain.excision_spheres().at("CentralExcisionSphere");
+      const auto& abutting_directions = excision_sphere.abutting_directions();
+      size_t num_excision_neighbors = 0;
+      const Mesh<2> face_mesh{10, Spectral::Basis::Legendre,
+                              Spectral::Quadrature::GaussLobatto};
+      for (const auto& element_id : element_ids) {
+        const auto& current_block = blocks.at(element_id.block_id());
+        const auto element_abutting_direction =
+            excision_sphere.abutting_direction(element_id);
+        if (element_abutting_direction.has_value()) {
+          CHECK(abutting_directions.count(element_id.block_id()));
+          CHECK(element_abutting_direction.value() ==
+                abutting_directions.at(element_id.block_id()));
+          const auto face_logical_coords = interface_logical_coordinates(
+              face_mesh, element_abutting_direction.value());
+          const auto logical_to_grid_map = ElementMap(
+              element_id, current_block.stationary_map().get_clone());
+          const auto grid_coords = logical_to_grid_map(face_logical_coords);
+          const auto radii = magnitude(grid_coords);
+          CHECK_ITERABLE_APPROX(radii.get(),
+                                DataVector(radii.get().size(), inner_radius));
+          num_excision_neighbors++;
+        }
+      }
+      CHECK(num_excision_neighbors == 6 * pow(4, ref_level));
+    }
+  }
+}
+
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Domain.Structure.ExcisionSphere", "[Domain][Unit]") {
   check_excision_sphere_1d();
   check_excision_sphere_2d();
   check_excision_sphere_3d();
+  test_abutting_direction_shell();
 }
 
 // [[OutputRegex, The ExcisionSphere must have a radius greater than zero.]]


### PR DESCRIPTION
## Proposed changes

Adds a method to check whether an element abuts an excision sphere and returns an optional direction. This can be called by each element to e.g. identify the surfaces of the excision sphere in order to do face integrals.

~~@nilsvu can this be done with `ElementId` rather than `Element` by checking whether the segment is at the boundary of the given direction? I am worried that this assumes that the blocks have a certain orientation w.r.t. the excision sphere.~~

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
