### PR TITLE
Find apparent horizon in distorted frame

### DIFF
--- a/src/ApparentHorizons/FastFlow.cpp
+++ b/src/ApparentHorizons/FastFlow.cpp
@@ -366,6 +366,7 @@ FastFlow::FlowType Options::create_from_yaml<FastFlow::FlowType>::create<void>(
       const tnsr::II<DataVector, 3, FRAME(data)>& upper_spatial_metric,     \
       const tnsr::ii<DataVector, 3, FRAME(data)>& extrinsic_curvature,      \
       const tnsr::Ijj<DataVector, 3, FRAME(data)>& christoffel_2nd_kind);
-GENERATE_INSTANTIATIONS(INSTANTIATE, (Frame::Grid, Frame::Inertial))
+GENERATE_INSTANTIATIONS(INSTANTIATE,
+                        (Frame::Grid, Frame::Distorted, Frame::Inertial))
 #undef INSTANTIATE
 #undef FRAME

--- a/src/ApparentHorizons/StrahlkorperGr.cpp
+++ b/src/ApparentHorizons/StrahlkorperGr.cpp
@@ -1062,7 +1062,8 @@ void radial_distance(const gsl::not_null<Scalar<DataVector>*> radial_distance,
       const gsl::not_null<Scalar<DataVector>*> radial_distance,             \
       const Strahlkorper<FRAME(data)>& strahlkorper_a,                      \
       const Strahlkorper<FRAME(data)>& strahlkorper_b);
-GENERATE_INSTANTIATIONS(INSTANTIATE, (Frame::Grid, Frame::Inertial))
+GENERATE_INSTANTIATIONS(INSTANTIATE,
+                        (Frame::Grid, Frame::Distorted, Frame::Inertial))
 #undef INSTANTIATE
 #undef FRAME
 

--- a/src/Domain/CoordinateMaps/Composition.cpp
+++ b/src/Domain/CoordinateMaps/Composition.cpp
@@ -364,6 +364,10 @@ bool Composition<Frames, Dim, std::index_sequence<Is...>>::is_equal_to(
       DIM(data)>;                                                              \
   template class Composition<                                                  \
       tmpl::list<Frame::ElementLogical, Frame::BlockLogical, Frame::Grid,      \
+                 Frame::Distorted>,                                            \
+      DIM(data)>;                                                              \
+  template class Composition<                                                  \
+      tmpl::list<Frame::ElementLogical, Frame::BlockLogical, Frame::Grid,      \
                  Frame::Distorted, Frame::Inertial>,                           \
       DIM(data)>;
 

--- a/src/Domain/Creators/TimeDependence/UniformTranslation.cpp
+++ b/src/Domain/Creators/TimeDependence/UniformTranslation.cpp
@@ -253,7 +253,11 @@ using Translation = CoordinateMaps::TimeDependent::Translation<MeshDim>;
 
 INSTANTIATE_MAPS_FUNCTIONS(((Translation<1>), (Translation<2>),
                             (Translation<3>)),
-                           (Frame::Grid), (Frame::Inertial),
+                           (Frame::Grid), (Frame::Distorted, Frame::Inertial),
+                           (double, DataVector))
+INSTANTIATE_MAPS_FUNCTIONS(((Translation<1>), (Translation<2>),
+                            (Translation<3>)),
+                           (Frame::Distorted), (Frame::Inertial),
                            (double, DataVector))
 
 }  // namespace domain

--- a/src/Domain/Creators/TimeDependence/UniformTranslation.hpp
+++ b/src/Domain/Creators/TimeDependence/UniformTranslation.hpp
@@ -71,7 +71,11 @@ class UniformTranslation final : public TimeDependence<MeshDim> {
 
  public:
   using maps_list = tmpl::list<
-      domain::CoordinateMap<Frame::Grid, Frame::Inertial, TranslationMap>>;
+      domain::CoordinateMap<Frame::Grid, Frame::Inertial, TranslationMap>,
+      domain::CoordinateMap<Frame::Grid, Frame::Distorted, TranslationMap>,
+      domain::CoordinateMap<Frame::Distorted, Frame::Inertial, TranslationMap>,
+      domain::CoordinateMap<Frame::Grid, Frame::Inertial, TranslationMap,
+                            TranslationMap>>;
 
   static constexpr size_t mesh_dim = MeshDim;
 

--- a/src/NumericalAlgorithms/LinearOperators/PartialDerivatives.cpp
+++ b/src/NumericalAlgorithms/LinearOperators/PartialDerivatives.cpp
@@ -262,7 +262,7 @@ auto partial_derivative(
                   inverse_jacobian);
 
 GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3),
-                        (Frame::Inertial, Frame::Grid),
+                        (Frame::Grid, Frame::Distorted, Frame::Inertial),
                         (tnsr::a, tnsr::A, tnsr::i, tnsr::I, tnsr::ab, tnsr::Ab,
                          tnsr::aB, tnsr::AB, tnsr::ij, tnsr::iJ, tnsr::Ij,
                          tnsr::IJ, tnsr::iA, tnsr::ia, tnsr::aa, tnsr::AA,
@@ -314,7 +314,7 @@ GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
                             GET_FRAME(data)>& inverse_jacobian);
 
 GENERATE_INSTANTIATIONS(INSTANTIATE_SCALAR, (1, 2, 3),
-                        (Frame::Inertial, Frame::Grid))
+                        (Frame::Grid, Frame::Distorted, Frame::Inertial))
 
 #undef INSTANTIATE_SCALAR
 #undef GET_FRAME

--- a/src/ParallelAlgorithms/Interpolation/Actions/VerifyTemporalIdsAndSendPoints.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Actions/VerifyTemporalIdsAndSendPoints.hpp
@@ -101,9 +101,8 @@ void verify_temporal_ids_and_send_points_time_dependent(
                                  })
                     ->second->time_bounds()[1];
             for (const auto& pending_id : pending_temporal_ids) {
-              if (InterpolationTarget_detail::
-                      evaluate_temporal_id_for_expiration(pending_id) <=
-                  min_expiration_time) {
+              if (InterpolationTarget_detail::get_temporal_id_value(
+                      pending_id) <= min_expiration_time) {
                 // Success: at least one pending_temporal_id is ok.
                 return std::unique_ptr<Parallel::Callback>{};
               }
@@ -134,8 +133,8 @@ void verify_temporal_ids_and_send_points_time_dependent(
           const gsl::not_null<std::deque<TemporalId>*> pending_ids,
           const std::deque<TemporalId>& completed_ids) {
         for (auto it = pending_ids->begin(); it != pending_ids->end();) {
-          if (InterpolationTarget_detail::evaluate_temporal_id_for_expiration(
-                  *it) <= min_expiration_time and
+          if (InterpolationTarget_detail::get_temporal_id_value(*it) <=
+                  min_expiration_time and
               std::find(completed_ids.begin(), completed_ids.end(), *it) ==
                   completed_ids.end() and
               std::find(ids->begin(), ids->end(), *it) == ids->end()) {

--- a/src/ParallelAlgorithms/Interpolation/InterpolationTargetDetail.cpp
+++ b/src/ParallelAlgorithms/Interpolation/InterpolationTargetDetail.cpp
@@ -14,11 +14,4 @@ double get_temporal_id_value(const LinkedMessageId<double>& id) {
 double get_temporal_id_value(const TimeStepId& time_id) {
   return time_id.substep_time().value();
 }
-double evaluate_temporal_id_for_expiration(const double time) { return time; }
-double evaluate_temporal_id_for_expiration(const LinkedMessageId<double>& id) {
-  return id.id;
-}
-double evaluate_temporal_id_for_expiration(const TimeStepId& time_id) {
-  return time_id.step_time().value();
-}
 }  // namespace intrp::InterpolationTarget_detail

--- a/src/ParallelAlgorithms/Interpolation/InterpolationTargetDetail.hpp
+++ b/src/ParallelAlgorithms/Interpolation/InterpolationTargetDetail.hpp
@@ -71,9 +71,6 @@ namespace InterpolationTarget_detail {
 double get_temporal_id_value(double time);
 double get_temporal_id_value(const LinkedMessageId<double>& id);
 double get_temporal_id_value(const TimeStepId& time_id);
-double evaluate_temporal_id_for_expiration(double time);
-double evaluate_temporal_id_for_expiration(const LinkedMessageId<double>& id);
-double evaluate_temporal_id_for_expiration(const TimeStepId& time_id);
 
 // apply_callback accomplishes the overload for the
 // two signatures of callback functions.
@@ -491,8 +488,7 @@ auto block_logical_coords(
       const auto& functions_of_time = get<domain::Tags::FunctionsOfTime>(cache);
       return ::block_logical_coordinates(
           domain, coords,
-          InterpolationTarget_detail::evaluate_temporal_id_for_expiration(
-              temporal_id),
+          InterpolationTarget_detail::get_temporal_id_value(temporal_id),
           functions_of_time);
     } else {
       // We error here because the maps are time-dependent, yet
@@ -657,8 +653,7 @@ void compute_dest_vars_from_source_vars(
         element_id, block.moving_mesh_logical_to_grid_map().get_clone()};
     const auto logical_coords = logical_coordinates(mesh);
     const auto time =
-        InterpolationTarget_detail::evaluate_temporal_id_for_expiration(
-            temporal_id);
+        InterpolationTarget_detail::get_temporal_id_value(temporal_id);
     const auto jac_logical_to_grid =
         map_logical_to_grid.jacobian(logical_coords);
     const auto invjac_logical_to_grid =
@@ -688,8 +683,7 @@ void compute_dest_vars_from_source_vars(
         block.moving_mesh_grid_to_distorted_map().get_clone()};
     const auto logical_coords = logical_coordinates(mesh);
     const auto time =
-        InterpolationTarget_detail::evaluate_temporal_id_for_expiration(
-            temporal_id);
+        InterpolationTarget_detail::get_temporal_id_value(temporal_id);
     const auto [inertial_coords, invjac_distorted_to_inertial,
                 jac_distorted_to_inertial,
                 distorted_to_inertial_mesh_velocity] =

--- a/src/ParallelAlgorithms/Interpolation/InterpolationTargetDetail.hpp
+++ b/src/ParallelAlgorithms/Interpolation/InterpolationTargetDetail.hpp
@@ -14,7 +14,9 @@
 #include "DataStructures/Tensor/Metafunctions.hpp"
 #include "DataStructures/VariablesTag.hpp"
 #include "Domain/BlockLogicalCoordinates.hpp"
+#include "Domain/CoordinateMaps/Composition.hpp"
 #include "Domain/Creators/Tags/Domain.hpp"
+#include "Domain/ElementToBlockLogicalMap.hpp"
 #include "Domain/TagsTimeDependent.hpp"
 #include "Parallel/GlobalCache.hpp"
 #include "Parallel/Invoke.hpp"
@@ -636,40 +638,74 @@ void compute_dest_vars_from_source_vars(
     const Mesh<Metavariables::volume_dim>& mesh, const ElementId& element_id,
     const Parallel::GlobalCache<Metavariables>& cache,
     const typename InterpolationTargetTag::temporal_id::type& temporal_id) {
+  // The functions of time are always guaranteed to be
+  // up-to-date here.
+  // For interpolation without an Interpolator ParallelComponent,
+  // this is because the InterpWithoutInterpComponent event will be called
+  // after the Action that keeps functions of time up to date.
+  // For interpolation with an Interpolator ParallelCompoent,
+  // this is because the functions of time are made up to date before
+  // calling SendPointsToInterpolator.
   if constexpr (any_index_in_frame_v<SourceTags, Frame::Inertial> and
                 any_index_in_frame_v<typename InterpolationTargetTag::
                                          vars_to_interpolate_to_target,
                                      Frame::Grid>) {
-    // Need to do frame transformations.
-
-    // The functions of time are always guaranteed to be
-    // up-to-date here.
-    // For interpolation without an Interpolator ParallelComponent,
-    // this is because the InterpWithoutInterpComponent event will be called
-    // after the Action that keeps functions of time up to date.
-    // For interpolation with an Interpolator ParallelCompoent,
-    // this is because the functions of time are made up to date before
-    // calling SendPointsToInterpolator.
+    // Need to do frame transformations to Grid frame.
     const auto& functions_of_time = get<domain::Tags::FunctionsOfTime>(cache);
     const auto& block = domain.blocks().at(element_id.block_id());
     ElementMap<3, ::Frame::Grid> map_logical_to_grid{
         element_id, block.moving_mesh_logical_to_grid_map().get_clone()};
+    const auto logical_coords = logical_coordinates(mesh);
+    const auto time =
+        InterpolationTarget_detail::evaluate_temporal_id_for_expiration(
+            temporal_id);
     const auto jac_logical_to_grid =
-        map_logical_to_grid.jacobian(logical_coordinates(mesh));
+        map_logical_to_grid.jacobian(logical_coords);
     const auto invjac_logical_to_grid =
-        map_logical_to_grid.inv_jacobian(logical_coordinates(mesh));
-    const auto[inertial_coords, invjac_grid_to_inertial, jac_grid_to_inertial,
-               inertial_mesh_velocity] =
+        map_logical_to_grid.inv_jacobian(logical_coords);
+    const auto [inertial_coords, invjac_grid_to_inertial, jac_grid_to_inertial,
+                inertial_mesh_velocity] =
         block.moving_mesh_grid_to_inertial_map()
             .coords_frame_velocity_jacobians(
-                map_logical_to_grid(logical_coordinates(mesh)),
-                InterpolationTarget_detail::evaluate_temporal_id_for_expiration(
-                    temporal_id),
-                functions_of_time);
+                map_logical_to_grid(logical_coords), time, functions_of_time);
     InterpolationTargetTag::compute_vars_to_interpolate::apply(
         dest_vars, source_vars, mesh, jac_grid_to_inertial,
         invjac_grid_to_inertial, jac_logical_to_grid, invjac_logical_to_grid,
         inertial_mesh_velocity);
+  } else if constexpr (any_index_in_frame_v<SourceTags, Frame::Inertial> and
+                       any_index_in_frame_v<typename InterpolationTargetTag::
+                                                vars_to_interpolate_to_target,
+                                            Frame::Distorted>) {
+    // Need to do frame transformations to Distorted frame.
+    const auto& functions_of_time = get<domain::Tags::FunctionsOfTime>(cache);
+    const auto& block = domain.blocks().at(element_id.block_id());
+    ASSERT(block.has_distorted_frame(),
+           "Cannot interpolate to distorted frame in a block that does not "
+           "have a distorted frame");
+    const domain::CoordinateMaps::Composition element_logical_to_distorted_map{
+        domain::element_to_block_logical_map(element_id),
+        block.moving_mesh_logical_to_grid_map().get_clone(),
+        block.moving_mesh_grid_to_distorted_map().get_clone()};
+    const auto logical_coords = logical_coordinates(mesh);
+    const auto time =
+        InterpolationTarget_detail::evaluate_temporal_id_for_expiration(
+            temporal_id);
+    const auto [inertial_coords, invjac_distorted_to_inertial,
+                jac_distorted_to_inertial,
+                distorted_to_inertial_mesh_velocity] =
+        block.moving_mesh_distorted_to_inertial_map()
+            .coords_frame_velocity_jacobians(
+                element_logical_to_distorted_map(logical_coords, time,
+                                                 functions_of_time),
+                time, functions_of_time);
+    InterpolationTargetTag::compute_vars_to_interpolate::apply(
+        dest_vars, source_vars, mesh, jac_distorted_to_inertial,
+        invjac_distorted_to_inertial,
+        element_logical_to_distorted_map.jacobian(logical_coords, time,
+                                                  functions_of_time),
+        element_logical_to_distorted_map.inv_jacobian(logical_coords, time,
+                                                      functions_of_time),
+        distorted_to_inertial_mesh_velocity);
   } else {
     // No frame transformations needed.
     InterpolationTargetTag::compute_vars_to_interpolate::apply(

--- a/src/ParallelAlgorithms/Interpolation/Targets/ApparentHorizon.cpp
+++ b/src/ParallelAlgorithms/Interpolation/Targets/ApparentHorizon.cpp
@@ -51,7 +51,8 @@ bool operator!=(const ApparentHorizon<Frame>& lhs,
                            const ApparentHorizon<FRAME(data)>& rhs); \
   template bool operator!=(const ApparentHorizon<FRAME(data)>& lhs,  \
                            const ApparentHorizon<FRAME(data)>& rhs);
-GENERATE_INSTANTIATIONS(INSTANTIATE, (::Frame::Inertial, ::Frame::Grid))
+GENERATE_INSTANTIATIONS(INSTANTIATE,
+                        (::Frame::Grid, ::Frame::Distorted, ::Frame::Inertial))
 
 #undef FRAME
 #undef INSTANTIATE

--- a/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.cpp
@@ -761,7 +761,7 @@ KerrSchild::IntermediateVars<DataType, Frame>::get_var(
   template class KerrSchild::IntermediateVars<DTYPE(data), FRAME(data)>; \
   template class KerrSchild::IntermediateComputer<DTYPE(data), FRAME(data)>;
 GENERATE_INSTANTIATIONS(INSTANTIATE, (DataVector, double),
-                        (::Frame::Inertial, ::Frame::Grid))
+                        (::Frame::Grid, ::Frame::Inertial, ::Frame::Distorted))
 #undef INSTANTIATE
 #undef DTYPE
 #undef FRAME

--- a/src/PointwiseFunctions/GeneralRelativity/Christoffel.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/Christoffel.cpp
@@ -109,8 +109,9 @@ auto christoffel_second_kind(
           inverse_metric);
 
 GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (double, DataVector),
-                        (Frame::Grid, Frame::Inertial,
+                        (Frame::Grid, Frame::Distorted, Frame::Inertial,
                          Frame::Spherical<Frame::Inertial>,
+                         Frame::Spherical<Frame::Distorted>,
                          Frame::Spherical<Frame::Grid>),
                         (IndexType::Spatial, IndexType::Spacetime))
 

--- a/src/PointwiseFunctions/GeneralRelativity/ExtrinsicCurvature.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/ExtrinsicCurvature.cpp
@@ -80,7 +80,7 @@ tnsr::ii<DataType, SpatialDim, Frame> extrinsic_curvature(
           deriv_spatial_metric);
 
 GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (double, DataVector),
-                        (Frame::Grid, Frame::Inertial))
+                        (Frame::Grid, Frame::Distorted, Frame::Inertial))
 
 #undef DIM
 #undef DTYPE

--- a/src/PointwiseFunctions/GeneralRelativity/IndexManipulation.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/IndexManipulation.cpp
@@ -136,8 +136,9 @@ void trace(
                               change_index_up_lo<INDEX1(data)>>>& metric);
 
 GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (double, DataVector),
-                        (Frame::Grid, Frame::Inertial,
+                        (Frame::Grid, Frame::Distorted, Frame::Inertial,
                          Frame::Spherical<Frame::Inertial>,
+                         Frame::Spherical<Frame::Distorted>,
                          Frame::Spherical<Frame::Grid>),
                         (SpatialIndex, SpacetimeIndex), (UpLo::Lo, UpLo::Up),
                         (UpLo::Lo, UpLo::Up))
@@ -168,7 +169,7 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (double, DataVector),
                               change_index_up_lo<INDEX0(data)>>>& metric);
 
 GENERATE_INSTANTIATIONS(INSTANTIATE2, (1, 2, 3), (double, DataVector),
-                        (Frame::Grid, Frame::Inertial),
+                        (Frame::Grid, Frame::Distorted, Frame::Inertial),
                         (SpatialIndex, SpacetimeIndex), (UpLo::Lo, UpLo::Up))
 
 #undef DIM


### PR DESCRIPTION
## Proposed changes

Two main changes:
 * compute_dest_vars_from_src_vars now recognizes distorted frame, so interpolation can be done in that frame.
 * Test_ApparentHorizonFinder now has a test where it finds the horizon in the distorted frame.

Other necessary changes are fixing a bug in UniformTranslation and adding instantiations of the distorted frame in many places.

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
