### PR TITLE
Add truncation error estimate

### DIFF
--- a/src/NumericalAlgorithms/LinearOperators/PowerMonitors.hpp
+++ b/src/NumericalAlgorithms/LinearOperators/PowerMonitors.hpp
@@ -38,11 +38,69 @@ namespace PowerMonitors {
  */
 template <size_t Dim>
 void power_monitors(gsl::not_null<std::array<DataVector, Dim>*> result,
-                    const DataVector& input_data_vector, const Mesh<Dim>& mesh);
+                    const DataVector& u, const Mesh<Dim>& mesh);
 
 template <size_t Dim>
-std::array<DataVector, Dim> power_monitors(const DataVector& input_data_vector,
+std::array<DataVector, Dim> power_monitors(const DataVector& u,
                                            const Mesh<Dim>& mesh);
 /// @}
 
+/// @{
+/*!
+ * \ingroup SpectralGroup
+ * \brief Compute the negative log10 of the relative truncation error.
+ *
+ * Truncation error according to Eqs. (57) and (58) of Ref.
+ * \cite Szilagyi2014fna, i.e.,
+ *
+ * \f{align*}{
+ *  \mathcal{T}\left[P_k\right] = \log_{10} \max \left(P_0, P_1\right)
+ *   - \dfrac{\sum_{j=0}^{j_{\text{max}, k}} \log_{10} \left(P_j\right) w_j}
+ *   {\sum_{j=0}^{j_{\text{max}, k}} w_j} , \f}
+ *
+ * with weights
+ *
+ * \f{align*}{
+ *  w_j = \exp\left[ - \left(j - j_{\text{max}, k}
+ *          + \dfrac{1}{2}\right)^2 \right] .
+ * \f}
+ *
+ * where \f$ j_{\text{max}, k}  = N_k - 1 \f$ and  \f$ N_k \f$ is the number of
+ * modes or gridpoints in dimension k. Here the second term is a weighted
+ * average with larger weights toward the highest modes. This number should
+ * correspond to the number of digits resolved by the spectral expansion.
+ *
+ * \details The number of modes (`num_modes_to_use`) argument needs to be less
+ * or equal than the total number of power monitors (`power_monitor.size()`).
+ * In contrast with Ref. \cite Szilagyi2014fna, here we index the modes starting
+ * from zero.
+ *
+ */
+double relative_truncation_error(const DataVector& power_monitor,
+                                 const size_t num_modes_to_use);
+/// @}
+
+/// @{
+/*!
+ * \ingroup SpectralGroup
+ * \brief Returns an estimate of the absolute truncation error in each
+ * dimension.
+ *
+ * The estimate of the numerical error is given by
+ *
+ * \f{align*}{
+ *  \mathcal{E}\left[P_k\right] = u_\mathrm{max} \times 10^{- \mathcal{T}[P_k]},
+ * \f}
+ *
+ * where \f$ u_\mathrm{max} = \mathrm{max} |u|\f$ in the corresponding element
+ * and \f$ \mathcal{T}[P_k] \f$ is the relative error estimate
+ * computed from the power monitors \f$ P_k \f$.
+ *
+ * \warning This estimate is intended for visualization purposes only.
+ */
+template <size_t Dim>
+std::array<double, Dim> truncation_error(
+    const std::array<DataVector, Dim>& power_monitors_of_u,
+    const DataVector& u);
+/// @}
 }  // namespace PowerMonitors

--- a/src/NumericalAlgorithms/LinearOperators/Python/PowerMonitors.cpp
+++ b/src/NumericalAlgorithms/LinearOperators/Python/PowerMonitors.cpp
@@ -20,7 +20,12 @@ void bind_power_monitors_impl(py::module& m) {  // NOLINT
   m.def("power_monitors",
         py::overload_cast<const DataVector&, const Mesh<Dim>&> (
           &power_monitors<Dim>),
-        py::arg("input_data_vector"), py::arg("mesh"));
+        py::arg("data_vector"), py::arg("mesh"));
+  m.def(
+      "truncation_error",
+      py::overload_cast<const std::array<DataVector, Dim>&, const DataVector&>(
+          &truncation_error<Dim>),
+      py::arg("power_monitors_of_u"), py::arg("data_vector"));
 }
 }  // namespace
 
@@ -28,6 +33,10 @@ void bind_power_monitors(py::module& m) {
   bind_power_monitors_impl<1>(m);
   bind_power_monitors_impl<2>(m);
   bind_power_monitors_impl<3>(m);
+  m.def("relative_truncation_error",
+        py::overload_cast<const DataVector&, const size_t>(
+            &relative_truncation_error),
+        py::arg("power_monitor"), py::arg("num_modes_to_use"));
 }
 
 }  // namespace PowerMonitors::py_bindings

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/Python/Test_PowerMonitors.py
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/Python/Test_PowerMonitors.py
@@ -6,8 +6,18 @@ import unittest
 import numpy as np
 
 from spectre.DataStructures import DataVector
-from spectre.NumericalAlgorithms.LinearOperators import power_monitors
-from spectre.Spectral import Basis, Mesh2D, Quadrature
+from spectre.NumericalAlgorithms.LinearOperators import (
+    power_monitors,
+    relative_truncation_error,
+    truncation_error,
+)
+from spectre.Spectral import (
+    Basis,
+    Mesh1D,
+    Mesh2D,
+    Quadrature,
+    logical_coordinates,
+)
 
 
 class TestPowerMonitors(unittest.TestCase):
@@ -21,8 +31,7 @@ class TestPowerMonitors(unittest.TestCase):
         quadrature = Quadrature.GaussLobatto
         mesh = Mesh2D(extent, basis, quadrature)
 
-        np_vec = np.ones(mesh.number_of_grid_points())
-        test_vec = DataVector(np_vec)
+        test_vec = np.ones(mesh.number_of_grid_points())
 
         test_array = power_monitors(test_vec, mesh)
         np_test_array = np.asarray(test_array)
@@ -36,6 +45,61 @@ class TestPowerMonitors(unittest.TestCase):
         np_check_array = np.array([check_vec_0, check_vec_1])
 
         np.testing.assert_allclose(np_test_array, np_check_array, 1e-12, 1e-12)
+
+    # Check that the truncation error for a straight line is consistent with the
+    # analytic expectation
+    def test_relative_truncation_error(self):
+        num_points_per_dimension = 2
+
+        extent = num_points_per_dimension
+        basis = Basis.Legendre
+        quadrature = Quadrature.GaussLobatto
+        mesh = Mesh1D(extent, basis, quadrature)
+        logical_coords = np.array(logical_coordinates(mesh))[0]
+
+        # Define the test function
+        slope, offset = 0.1, 1.0
+        test_vec = slope * logical_coords + offset
+
+        modes_all_dim = power_monitors(test_vec, mesh)
+        modes = modes_all_dim[0]
+
+        test_relative_truncation_error_exponent = relative_truncation_error(
+            modes, extent
+        )
+
+        test_relative_truncation_error = np.power(
+            10.0, -1.0 * test_relative_truncation_error_exponent
+        )
+
+        # For a linear function the slope and offset correspond to the power
+        # monitor values
+        # The weighted average of the highest modes is
+        avg = np.log10(np.abs(slope)) * np.exp(-0.25) + np.log10(
+            np.abs(offset)
+        ) * np.exp(-0.25)
+        avg = avg / (np.exp(-0.25) + np.exp(-0.25))
+        expected_relative_truncation_error = np.power(10.0, avg)
+
+        np.testing.assert_allclose(
+            test_relative_truncation_error,
+            expected_relative_truncation_error,
+            1e-12,
+            1e-12,
+        )
+
+        # Test absolute truncation_error
+        test_truncation_error = np.asarray(
+            truncation_error(modes_all_dim, test_vec)
+        )
+
+        expected_truncation_error = (
+            np.max(np.abs(test_vec)) * expected_relative_truncation_error
+        )
+
+        np.testing.assert_allclose(
+            test_truncation_error, expected_truncation_error, 1e-12, 1e-12
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Proposed changes

<!--
At a high level, describe what this PR does.
-->

Add truncation error estimate functions and pybindings. Change output of power monitors to return the log10 value of them.
#4585
### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
Corrected script for new log factor #4663

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
