### PR TITLE
Add Single horizon measurement

### DIFF
--- a/src/ControlSystem/ControlErrors/Shape.hpp
+++ b/src/ControlSystem/ControlErrors/Shape.hpp
@@ -8,7 +8,6 @@
 #include <pup.h>
 #include <string>
 
-#include "ControlSystem/Measurements/BothHorizons.hpp"
 #include "ControlSystem/Protocols/ControlError.hpp"
 #include "ControlSystem/Tags.hpp"
 #include "DataStructures/DataVector.hpp"

--- a/src/ControlSystem/Measurements/BothHorizons.hpp
+++ b/src/ControlSystem/Measurements/BothHorizons.hpp
@@ -43,7 +43,16 @@ struct Mesh;
 /// \endcond
 
 namespace control_system::measurements {
+/*!
+ * \brief A `control_system::protocols::Measurement` that relies on two apparent
+ * horizons.
+ */
 struct BothHorizons : tt::ConformsTo<protocols::Measurement> {
+  /*!
+   * \brief A `control_system::protocols::Submeasurement` that starts the
+   * interpolation to the interpolation target in order to find the apparent
+   * horizon given by the template parameter `Horizon`.
+   */
   template <::domain::ObjectLabel Horizon>
   struct FindHorizon : tt::ConformsTo<protocols::Submeasurement> {
    private:

--- a/src/ControlSystem/Measurements/CMakeLists.txt
+++ b/src/ControlSystem/Measurements/CMakeLists.txt
@@ -10,6 +10,7 @@ spectre_target_headers(
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   BothHorizons.hpp
+  SingleHorizon.hpp
   )
 
 target_link_libraries(

--- a/src/ControlSystem/Measurements/SingleHorizon.hpp
+++ b/src/ControlSystem/Measurements/SingleHorizon.hpp
@@ -1,0 +1,113 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <string>
+
+#include "ApparentHorizons/ComputeHorizonVolumeQuantities.hpp"
+#include "ApparentHorizons/HorizonAliases.hpp"
+#include "ApparentHorizons/ObserveCenters.hpp"
+#include "ApparentHorizons/Tags.hpp"
+#include "ControlSystem/Protocols/Measurement.hpp"
+#include "ControlSystem/Protocols/Submeasurement.hpp"
+#include "ControlSystem/RunCallbacks.hpp"
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/LinkedMessageId.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Domain/ObjectLabel.hpp"
+#include "ParallelAlgorithms/Interpolation/Callbacks/ErrorOnFailedApparentHorizon.hpp"
+#include "ParallelAlgorithms/Interpolation/Callbacks/FindApparentHorizon.hpp"
+#include "ParallelAlgorithms/Interpolation/Interpolate.hpp"
+#include "ParallelAlgorithms/Interpolation/Protocols/InterpolationTargetTag.hpp"
+#include "ParallelAlgorithms/Interpolation/Targets/ApparentHorizon.hpp"
+#include "Time/Tags.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+class DataVector;
+template <size_t VolumeDim>
+class ElementId;
+template <size_t Dim>
+class Mesh;
+namespace Parallel {
+template <typename Metavariables>
+class GlobalCache;
+}  // namespace Parallel
+namespace domain::Tags {
+template <size_t Dim>
+struct Mesh;
+}  // namespace domain::Tags
+/// \endcond
+
+namespace control_system::measurements {
+/*!
+ * \brief A `control_system::protocols::Measurement` that relies on only one
+ * apparent horizon; the template parameter `Horizon`.
+ */
+template <::domain::ObjectLabel Horizon>
+struct SingleHorizon : tt::ConformsTo<protocols::Measurement> {
+  /*!
+   * \brief A `control_system::protocols::Submeasurement` that starts the
+   * interpolation to the interpolation target in order to find the apparent
+   * horizon.
+   */
+  struct Submeasurement : tt::ConformsTo<protocols::Submeasurement> {
+   private:
+    template <typename ControlSystems>
+    struct InterpolationTarget
+        : tt::ConformsTo<intrp::protocols::InterpolationTargetTag> {
+      static std::string name() {
+        return "ControlSystemSingleAh" + ::domain::name(Horizon);
+      }
+
+      using temporal_id = ::Tags::TimeAndPrevious;
+
+      using vars_to_interpolate_to_target =
+          ::ah::vars_to_interpolate_to_target<3, ::Frame::Grid>;
+      using compute_vars_to_interpolate = ::ah::ComputeHorizonVolumeQuantities;
+      using tags_to_observe = ::ah::tags_for_observing<Frame::Grid>;
+      using compute_items_on_target =
+          ::ah::compute_items_on_target<3, Frame::Grid>;
+      using compute_target_points =
+          intrp::TargetPoints::ApparentHorizon<InterpolationTarget,
+                                               ::Frame::Grid>;
+      using post_interpolation_callback =
+          intrp::callbacks::FindApparentHorizon<InterpolationTarget,
+                                                ::Frame::Grid>;
+      using horizon_find_failure_callback =
+          intrp::callbacks::ErrorOnFailedApparentHorizon;
+      using post_horizon_find_callbacks = tmpl::list<
+          control_system::RunCallbacks<Submeasurement, ControlSystems>>;
+    };
+
+   public:
+    template <typename ControlSystems>
+    using interpolation_target_tag = InterpolationTarget<ControlSystems>;
+
+    using argument_tags =
+        tmpl::push_front<::ah::source_vars<3>, domain::Tags::Mesh<3>>;
+
+    template <typename Metavariables, typename ParallelComponent,
+              typename ControlSystems>
+    static void apply(
+        const Mesh<3>& mesh,
+        const tnsr::aa<DataVector, 3, ::Frame::Inertial>& spacetime_metric,
+        const tnsr::aa<DataVector, 3, ::Frame::Inertial>& pi,
+        const tnsr::iaa<DataVector, 3, ::Frame::Inertial>& phi,
+        const tnsr::ijaa<DataVector, 3, ::Frame::Inertial>& deriv_phi,
+        const LinkedMessageId<double>& measurement_id,
+        Parallel::GlobalCache<Metavariables>& cache,
+        const ElementId<3>& array_index,
+        const ParallelComponent* const /*meta*/, ControlSystems /*meta*/) {
+      intrp::interpolate<interpolation_target_tag<ControlSystems>>(
+          measurement_id, mesh, cache, array_index, spacetime_metric, pi, phi,
+          deriv_phi);
+    }
+  };
+
+  using submeasurements = tmpl::list<Submeasurement>;
+};
+}  // namespace control_system::measurements

--- a/tests/Unit/ControlSystem/Systems/Test_Expansion.cpp
+++ b/tests/Unit/ControlSystem/Systems/Test_Expansion.cpp
@@ -152,7 +152,7 @@ void test_expansion_control_system() {
 
   // Run the actual control system test.
   system_helper.run_control_system_test(runner, final_time, make_not_null(&gen),
-                                        horizon_function, 2);
+                                        horizon_function);
 
   // Grab results
   std::array<double, 3> grid_position_of_a;

--- a/tests/Unit/ControlSystem/Systems/Test_RotScaleTrans.cpp
+++ b/tests/Unit/ControlSystem/Systems/Test_RotScaleTrans.cpp
@@ -210,7 +210,7 @@ void test_rotscaletrans_control_system(const double rotation_eps = 5.0e-5) {
 
   // Run the actual control system test.
   system_helper.run_control_system_test(runner, final_time, make_not_null(&gen),
-                                        horizon_function, 2);
+                                        horizon_function);
 
   // Grab results
   std::array<double, 3> grid_position_of_a;

--- a/tests/Unit/ControlSystem/Systems/Test_Rotation.cpp
+++ b/tests/Unit/ControlSystem/Systems/Test_Rotation.cpp
@@ -148,7 +148,7 @@ void test_rotation_control_system(const bool newtonian) {
 
   // Run the actual control system test.
   system_helper.run_control_system_test(runner, final_time, make_not_null(&gen),
-                                        horizon_function, 2);
+                                        horizon_function);
 
   // Grab results
   std::array<double, 3> grid_position_of_a;

--- a/tests/Unit/ControlSystem/Systems/Test_Shape.cpp
+++ b/tests/Unit/ControlSystem/Systems/Test_Shape.cpp
@@ -123,7 +123,7 @@ void test_shape_control(
 
   // Run the test, specifying that we are only using 1 horizon
   system_helper->run_control_system_test(runner, final_time, generator,
-                                         horizon_measurement, 1);
+                                         horizon_measurement);
 
   const auto& functions_of_time =
       Parallel::get<domain::Tags::FunctionsOfTime>(cache);

--- a/tests/Unit/ControlSystem/Systems/Test_Translation.cpp
+++ b/tests/Unit/ControlSystem/Systems/Test_Translation.cpp
@@ -156,7 +156,7 @@ void test_translation_control_system() {
 
   // Run the actual control system test.
   system_helper.run_control_system_test(runner, final_time, make_not_null(&gen),
-                                        horizon_function, 2);
+                                        horizon_function);
 
   // Grab results
   std::array<double, 3> grid_position_of_a;

--- a/tests/Unit/ControlSystem/Test_Measurements.cpp
+++ b/tests/Unit/ControlSystem/Test_Measurements.cpp
@@ -4,6 +4,7 @@
 #include "Framework/TestingFramework.hpp"
 
 #include "ControlSystem/Measurements/BothHorizons.hpp"
+#include "ControlSystem/Measurements/SingleHorizon.hpp"
 #include "Domain/ObjectLabel.hpp"
 #include "Helpers/ControlSystem/Examples.hpp"
 #include "ParallelAlgorithms/Interpolation/Protocols/InterpolationTargetTag.hpp"
@@ -13,5 +14,12 @@ static_assert(
     tt::assert_conforms_to_v<
         control_system::measurements::BothHorizons::
             FindHorizon<::domain::ObjectLabel::A>::interpolation_target_tag<
+                tmpl::list<control_system::TestHelpers::ExampleControlSystem>>,
+        intrp::protocols::InterpolationTargetTag>);
+
+static_assert(
+    tt::assert_conforms_to_v<
+        control_system::measurements::SingleHorizon<::domain::ObjectLabel::B>::
+            Submeasurement::interpolation_target_tag<
                 tmpl::list<control_system::TestHelpers::ExampleControlSystem>>,
         intrp::protocols::InterpolationTargetTag>);


### PR DESCRIPTION
## Proposed changes

And use it in the shape control system. This is similar to the BothHorizons measurement, except it is only for one horizon.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

Depends on and includes #4728.

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
