### PR TITLE
Add Transformed Shift with Mesh Velocity

### DIFF
--- a/src/ApparentHorizons/ComputeExcisionBoundaryVolumeQuantities.hpp
+++ b/src/ApparentHorizons/ComputeExcisionBoundaryVolumeQuantities.hpp
@@ -88,7 +88,8 @@ struct ComputeExcisionBoundaryVolumeQuantities
       tmpl::list<gr::Tags::SpatialMetric<3, Frame::Inertial>,
                  gr::Tags::SpacetimeMetric<3, Frame::Inertial>,
                  gr::Tags::Lapse<DataVector>,
-                 gr::Tags::Shift<3, Frame::Inertial>>;
+                 gr::Tags::Shift<3, Frame::Inertial>,
+                 gr::Tags::Shift<3, Frame::Grid>>;
 
   template <typename TargetFrame>
   using allowed_dest_tags = tmpl::remove_duplicates<

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonicSingleBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonicSingleBlackHole.hpp
@@ -105,7 +105,9 @@ struct EvolutionMetavars
         gr::Tags::DetAndInverseSpatialMetricCompute<volume_dim, Frame::Inertial,
                                                     DataVector>,
         gr::Tags::ShiftCompute<volume_dim, Frame::Inertial, DataVector>,
-        gr::Tags::LapseCompute<volume_dim, Frame::Inertial, DataVector>>>;
+        gr::Tags::LapseCompute<volume_dim, Frame::Inertial, DataVector>,
+        GeneralizedHarmonic::ConstraintDamping::Tags::ConstraintGamma1>>;
+
     using compute_target_points =
         intrp::TargetPoints::Sphere<ExcisionBoundaryA, ::Frame::Grid>;
     using post_interpolation_callback =

--- a/tests/Unit/ApparentHorizons/Test_ComputeExcisionBoundaryVolumeQuantities.cpp
+++ b/tests/Unit/ApparentHorizons/Test_ComputeExcisionBoundaryVolumeQuantities.cpp
@@ -88,7 +88,7 @@ void test_compute_excision_boundary_volume_quantities() {
       jacobian_logical_to_target{};
   InverseJacobian<DataVector, 3, Frame::ElementLogical, TargetFrame>
       inv_jacobian_logical_to_target{};
-  tnsr::I<DataVector, 3, Frame::Inertial> inertial_mesh_velocity{};
+  tnsr::I<DataVector, 3, Frame::Inertial> frame_velocity_grid_to_inertial{};
   if constexpr (IsTimeDependent::value) {
     ElementMap<3, Frame::Grid> map_logical_to_grid{
         element_ids[0],
@@ -208,8 +208,12 @@ void test_compute_excision_boundary_volume_quantities() {
         std::get<1>(coords_frame_velocity_jacobians);
     const auto& jacobian_grid_to_inertial =
         std::get<2>(coords_frame_velocity_jacobians);
-    const auto& frame_velocity_grid_to_inertial =
+    frame_velocity_grid_to_inertial =
         std::get<3>(coords_frame_velocity_jacobians);
+    inv_jacobian_target_to_inertial =
+        std::get<1>(coords_frame_velocity_jacobians);
+    jacobian_target_to_inertial =
+        std::get<2>(coords_frame_velocity_jacobians);
 
     // Now compute metric variables and transform them into the
     // inertial frame.  We transform lapse, shift, 3-metric.  Then we
@@ -250,7 +254,7 @@ void test_compute_excision_boundary_volume_quantities() {
     ah::ComputeExcisionBoundaryVolumeQuantities::apply(
         make_not_null(&dest_vars), src_vars, mesh, jacobian_target_to_inertial,
         inv_jacobian_target_to_inertial, jacobian_logical_to_target,
-        inv_jacobian_logical_to_target, inertial_mesh_velocity);
+        inv_jacobian_logical_to_target, frame_velocity_grid_to_inertial);
   } else {
     // time-independent.
     ah::ComputeExcisionBoundaryVolumeQuantities::apply(
@@ -376,7 +380,8 @@ SPECTRE_TEST_CASE(
       tmpl::list<gr::Tags::SpacetimeMetric<3, Frame::Inertial>,
                  gr::Tags::SpatialMetric<3, Frame::Inertial>,
                  gr::Tags::Lapse<DataVector>,
-                 gr::Tags::Shift<3, Frame::Inertial>>>();
+                 gr::Tags::Shift<3, Frame::Inertial>,
+                 gr::Tags::Shift<3, Frame::Grid>>>();
 
   // Leave out a few tags.
   test_compute_excision_boundary_volume_quantities<


### PR DESCRIPTION
## Proposed changes

Another small PR that adds the grid shift which includes the frame velocity in the transformation so that
the computed value corresponds with the value computed using the KerrSchild solution in `Test_ComputeExcisionBoundaryVolumeQuantities.cpp`. The next PR will compute the characteristic speeds on the excision surface from these ingredients.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
