### PR TITLE
Only include object centers tags if needed

### DIFF
--- a/src/ControlSystem/Actions/Initialization.hpp
+++ b/src/ControlSystem/Actions/Initialization.hpp
@@ -19,6 +19,21 @@
 
 namespace control_system {
 namespace Actions {
+namespace detail {
+template <typename Objects>
+struct get_center_tags;
+
+template <domain::ObjectLabel... Object>
+struct get_center_tags<domain::object_list<Object...>> {
+  using type = tmpl::list<domain::Tags::ExcisionCenter<Object>...>;
+};
+
+template <>
+struct get_center_tags<domain::object_list<>> {
+  using type = tmpl::list<>;
+};
+}  // namespace detail
+
 /*!
  * \ingroup ControlSystemGroup
  * \ingroup InitializationGroup
@@ -60,10 +75,10 @@ struct Initialize {
       tmpl::push_back<typename ControlSystem::simple_tags,
                       control_system::Tags::CurrentNumberOfMeasurements>;
 
-  using const_global_cache_tags =
-      tmpl::list<control_system::Tags::MeasurementsPerUpdate,
-                 domain::Tags::ExcisionCenter<domain::ObjectLabel::A>,
-                 domain::Tags::ExcisionCenter<domain::ObjectLabel::B>>;
+  using const_global_cache_tags = tmpl::flatten<tmpl::list<
+      control_system::Tags::MeasurementsPerUpdate,
+      typename detail::get_center_tags<
+          typename ControlSystem::control_error::object_centers>::type>>;
 
   using mutable_global_cache_tags =
       tmpl::list<control_system::Tags::MeasurementTimescales>;

--- a/src/ControlSystem/ControlErrors/Expansion.hpp
+++ b/src/ControlSystem/ControlErrors/Expansion.hpp
@@ -63,6 +63,9 @@ namespace ControlErrors {
 struct Expansion : tt::ConformsTo<protocols::ControlError> {
   static constexpr size_t expected_number_of_excisions = 2;
 
+  using object_centers =
+      domain::object_list<domain::ObjectLabel::A, domain::ObjectLabel::B>;
+
   using options = tmpl::list<>;
   static constexpr Options::String help{
       "Computes the control error for expansion control. This should not "

--- a/src/ControlSystem/ControlErrors/Rotation.hpp
+++ b/src/ControlSystem/ControlErrors/Rotation.hpp
@@ -59,6 +59,9 @@ namespace ControlErrors {
 struct Rotation : tt::ConformsTo<protocols::ControlError> {
   static constexpr size_t expected_number_of_excisions = 2;
 
+  using object_centers =
+      domain::object_list<domain::ObjectLabel::A, domain::ObjectLabel::B>;
+
   using options = tmpl::list<>;
   static constexpr Options::String help{
       "Computes the control error for rotation control. This should not "

--- a/src/ControlSystem/ControlErrors/Shape.hpp
+++ b/src/ControlSystem/ControlErrors/Shape.hpp
@@ -90,6 +90,9 @@ template <::domain::ObjectLabel Horizon>
 struct Shape : tt::ConformsTo<protocols::ControlError> {
   static constexpr size_t expected_number_of_excisions = 1;
 
+  // Shape doesn't need the center tags
+  using object_centers = domain::object_list<>;
+
   using options = tmpl::list<>;
   static constexpr Options::String help{
       "Computes the control error for shape control. This should not take any "

--- a/src/ControlSystem/ControlErrors/Translation.hpp
+++ b/src/ControlSystem/ControlErrors/Translation.hpp
@@ -72,6 +72,9 @@ namespace ControlErrors {
 struct Translation : tt::ConformsTo<protocols::ControlError> {
   static constexpr size_t expected_number_of_excisions = 2;
 
+  using object_centers =
+      domain::object_list<domain::ObjectLabel::A, domain::ObjectLabel::B>;
+
   using options = tmpl::list<>;
   static constexpr Options::String help{
       "Computes the control error for translation control. This should not "

--- a/src/ControlSystem/Protocols/ControlError.hpp
+++ b/src/ControlSystem/Protocols/ControlError.hpp
@@ -24,6 +24,11 @@ namespace control_system::protocols {
 ///   the example shown here:
 /// - a `static constexpr size_t expected_number_of_excisions` which specifies
 ///   the number of excisions necessary in order to compute the control error.
+/// - a type alias `object_centers` to a `domain::object_list` of
+///   `domain::ObjectLabel`s. These are the objects that will require the
+///   `domain::Tags::ObjectCenter`s tags to be in the GlobalCache for this
+///   control system to work.
+///
 ///
 ///   \snippet Helpers/ControlSystem/Examples.hpp ControlError
 struct ControlError {
@@ -34,6 +39,8 @@ struct ControlError {
 
     static constexpr size_t expected_number_of_excisions =
         ConformingType::expected_number_of_excisions;
+
+    using object_centers = typename ConformingType::object_centers;
 
     static_assert(
         std::is_same_v<

--- a/src/Domain/ObjectLabel.hpp
+++ b/src/Domain/ObjectLabel.hpp
@@ -18,4 +18,8 @@ enum class ObjectLabel {
 std::string name(const ObjectLabel x);
 
 std::ostream& operator<<(std::ostream& s, const ObjectLabel x);
+
+/// \brief Similar to a `tmpl::list` but for `ObjectLabel`s.
+template <ObjectLabel... Objects>
+struct object_list {};
 }  // namespace domain

--- a/tests/Unit/Helpers/ControlSystem/Examples.hpp
+++ b/tests/Unit/Helpers/ControlSystem/Examples.hpp
@@ -17,6 +17,7 @@
 #include "DataStructures/LinkedMessageId.hpp"
 #include "DataStructures/LinkedMessageQueue.hpp"
 #include "Domain/FunctionsOfTime/Tags.hpp"
+#include "Domain/ObjectLabel.hpp"
 #include "Parallel/GlobalCache.hpp"
 #include "Parallel/Invoke.hpp"
 #include "ParallelAlgorithms/Actions/UpdateMessageQueue.hpp"
@@ -99,6 +100,8 @@ struct ExampleMeasurement
 struct ExampleControlError
     : tt::ConformsTo<control_system::protocols::ControlError> {
   static constexpr size_t expected_number_of_excisions = 1;
+
+  using object_centers = domain::object_list<domain::ObjectLabel::A>;
 
   void pup(PUP::er& /*p*/) {}
 

--- a/tests/Unit/Helpers/ControlSystem/TestStructs.hpp
+++ b/tests/Unit/Helpers/ControlSystem/TestStructs.hpp
@@ -12,6 +12,7 @@
 #include "ControlSystem/Protocols/ControlSystem.hpp"
 #include "ControlSystem/Protocols/Measurement.hpp"
 #include "DataStructures/DataVector.hpp"
+#include "Domain/ObjectLabel.hpp"
 #include "Options/Options.hpp"
 #include "Parallel/GlobalCache.hpp"
 #include "Utilities/GetOutput.hpp"
@@ -33,6 +34,7 @@ struct Measurement : tt::ConformsTo<control_system::protocols::Measurement> {
 template <size_t NumExcisions>
 struct ControlError : tt::ConformsTo<control_system::protocols::ControlError> {
   static constexpr size_t expected_number_of_excisions = NumExcisions;
+  using object_centers = domain::object_list<>;
   void pup(PUP::er& /*p*/) {}
 
   using options = tmpl::list<>;


### PR DESCRIPTION
## Proposed changes

Some control systems don't need centers to compute their control errors (like shape). This allows control errors to specify if they need center tags, and if so, they'll be added to the `const_global_cache_tags` type alias in the control system initialization action.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
