### PR TITLE
Add distorted frame to shape time dependence

### DIFF
--- a/src/Domain/Creators/TimeDependence/CMakeLists.txt
+++ b/src/Domain/Creators/TimeDependence/CMakeLists.txt
@@ -39,6 +39,7 @@ target_link_libraries(
   PUBLIC
   CoordinateMaps
   DataStructures
+  DomainStructure
   FunctionsOfTime
   Options
   Utilities

--- a/src/Domain/Creators/TimeDependence/Shape.cpp
+++ b/src/Domain/Creators/TimeDependence/Shape.cpp
@@ -148,6 +148,20 @@ Shape::functions_of_time(const std::unordered_map<std::string, double>&
           std::array<DataVector, 4>{
               {radial_distortion_coefs, zeros, zeros, zeros}},
           expiration_time);
+  // This adds a size function of time that is the l=0 component of the radial
+  // distortion coefficients. We do this so that this time dependence can be
+  // used with the Shape control system. The control error for the shape control
+  // system requires there to be two functions of time in the cache: one for
+  // shape and one for size. This size function of time isn't controlling any
+  // maps so it never expires and is constant the entire time. If we want this
+  // time dependence to work with size control as well, we'll have to add in the
+  // size map as well.
+  const DataVector zeros_size{1, 0.0};
+  result["Size"] = std::make_unique<FunctionsOfTime::PiecewisePolynomial<3>>(
+      initial_time_,
+      std::array<DataVector, 4>{
+          {{radial_distortion_coefs[0]}, zeros_size, zeros_size, zeros_size}},
+      std::numeric_limits<double>::infinity());
   return result;
 }
 

--- a/src/Domain/Creators/TimeDependence/Shape.cpp
+++ b/src/Domain/Creators/TimeDependence/Shape.cpp
@@ -70,8 +70,7 @@ std::unique_ptr<TimeDependence<3>> Shape::get_clone() const {
 
 std::vector<
     std::unique_ptr<domain::CoordinateMapBase<Frame::Grid, Frame::Inertial, 3>>>
-Shape::block_maps_grid_to_inertial(
-    const size_t number_of_blocks) const {
+Shape::block_maps_grid_to_inertial(const size_t number_of_blocks) const {
   ASSERT(number_of_blocks > 0,
          "Must have at least one block on which to create a map.");
 
@@ -87,9 +86,8 @@ Shape::block_maps_grid_to_inertial(
 
 std::unordered_map<std::string,
                    std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
-Shape::functions_of_time(
-    const std::unordered_map<std::string, double>& initial_expiration_times)
-    const {
+Shape::functions_of_time(const std::unordered_map<std::string, double>&
+                             initial_expiration_times) const {
   std::unordered_map<std::string,
                      std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
       result{};
@@ -110,12 +108,12 @@ Shape::functions_of_time(
                 inner_radius_;
   const auto radial_distortion_coefs = ylm.phys_to_spec(radial_distortion);
   const DataVector zeros =
-    make_with_value<DataVector>(radial_distortion_coefs, 0.0);
+      make_with_value<DataVector>(radial_distortion_coefs, 0.0);
   result[function_of_time_name_] =
       std::make_unique<FunctionsOfTime::PiecewisePolynomial<3>>(
           initial_time_,
-          std::array<DataVector, 4>{{
-            radial_distortion_coefs, zeros, zeros, zeros}},
+          std::array<DataVector, 4>{
+              {radial_distortion_coefs, zeros, zeros, zeros}},
           expiration_time);
   return result;
 }
@@ -126,8 +124,7 @@ auto Shape::grid_to_inertial_map() const -> GridToInertialMap {
                                     function_of_time_name_}};
 }
 
-bool operator==(const Shape& lhs,
-                const Shape& rhs) {
+bool operator==(const Shape& lhs, const Shape& rhs) {
   return lhs.initial_time_ == rhs.initial_time_ and lhs.l_max_ == rhs.l_max_ and
          lhs.mass_ == rhs.mass_ and lhs.spin_ == rhs.spin_ and
          lhs.center_ == rhs.center_ and
@@ -135,15 +132,12 @@ bool operator==(const Shape& lhs,
          lhs.outer_radius_ == rhs.outer_radius_;
 }
 
-bool operator!=(const Shape& lhs,
-                const Shape& rhs) {
-  return not(lhs == rhs);
-}
+bool operator!=(const Shape& lhs, const Shape& rhs) { return not(lhs == rhs); }
 }  // namespace creators::time_dependence
 
 using ShapeMap3d = CoordinateMaps::TimeDependent::Shape;
 
-INSTANTIATE_MAPS_FUNCTIONS(((ShapeMap3d)), (Frame::Grid),
-                           (Frame::Inertial), (double, DataVector))
+INSTANTIATE_MAPS_FUNCTIONS(((ShapeMap3d)), (Frame::Grid), (Frame::Inertial),
+                           (double, DataVector))
 
 }  // namespace domain

--- a/src/Domain/Creators/TimeDependence/Shape.hpp
+++ b/src/Domain/Creators/TimeDependence/Shape.hpp
@@ -56,13 +56,11 @@ namespace domain::creators::time_dependence {
  */
 class Shape final : public TimeDependence<3> {
  private:
-  using ShapeMap =
-      domain::CoordinateMaps::TimeDependent::Shape;
+  using ShapeMap = domain::CoordinateMaps::TimeDependent::Shape;
 
  public:
   using maps_list =
-      tmpl::list<domain::CoordinateMap<Frame::Grid, Frame::Inertial,
-                                       ShapeMap>>;
+      tmpl::list<domain::CoordinateMap<Frame::Grid, Frame::Inertial, ShapeMap>>;
 
   static constexpr size_t mesh_dim = 3;
 
@@ -81,10 +79,9 @@ class Shape final : public TimeDependence<3> {
   /// \brief The mass of the Kerr black hole.
   struct Mass {
     using type = double;
-    static constexpr Options::String help = {
-        "The mass of the Kerr BH."};
+    static constexpr Options::String help = {"The mass of the Kerr BH."};
   };
-   /// \brief The dimensionless spin of the Kerr black hole.
+  /// \brief The dimensionless spin of the Kerr black hole.
   struct Spin {
     using type = std::array<double, 3>;
     static constexpr Options::String help = {
@@ -93,8 +90,7 @@ class Shape final : public TimeDependence<3> {
   /// \brief Center for the Shape map
   struct Center {
     using type = std::array<double, 3>;
-    static constexpr Options::String help = {
-        "Center for the Shape map."};
+    static constexpr Options::String help = {"Center for the Shape map."};
   };
   /// \brief The inner radius of the Shape map, the radius at which
   /// to begin applying the map.
@@ -112,8 +108,8 @@ class Shape final : public TimeDependence<3> {
   };
 
   using GridToInertialMap =
-        detail::generate_coordinate_map_t<Frame::Grid, Frame::Inertial,
-                                          tmpl::list<ShapeMap>>;
+      detail::generate_coordinate_map_t<Frame::Grid, Frame::Inertial,
+                                        tmpl::list<ShapeMap>>;
 
   using options = tmpl::list<InitialTime, LMax, Mass, Spin, Center, InnerRadius,
                              OuterRadius>;
@@ -164,8 +160,7 @@ class Shape final : public TimeDependence<3> {
 
  private:
   // NOLINTNEXTLINE(readability-redundant-declaration)
-  friend bool operator==(const Shape& lhs,
-                         const Shape& rhs);
+  friend bool operator==(const Shape& lhs, const Shape& rhs);
 
   using TransitionFunction = domain::CoordinateMaps::
       ShapeMapTransitionFunctions::ShapeMapTransitionFunction;
@@ -184,6 +179,5 @@ class Shape final : public TimeDependence<3> {
   std::unique_ptr<TransitionFunction> transition_func_;
 };
 
-bool operator!=(const Shape& lhs,
-                const Shape& rhs);
+bool operator!=(const Shape& lhs, const Shape& rhs);
 }  // namespace domain::creators::time_dependence

--- a/src/Domain/Creators/TimeDependence/TimeDependence.hpp
+++ b/src/Domain/Creators/TimeDependence/TimeDependence.hpp
@@ -9,6 +9,7 @@
 #include <unordered_map>
 #include <vector>
 
+#include "Domain/Structure/ObjectLabel.hpp"
 #include "Utilities/TMPL.hpp"
 
 /// \cond
@@ -32,6 +33,7 @@ template <size_t MeshDim>
 class None;
 template <size_t MeshDim>
 class ScalingAndZRotation;
+template <domain::ObjectLabel Label>
 class Shape;
 class SphericalCompression;
 template <size_t MeshDim>
@@ -60,8 +62,9 @@ struct TimeDependence {
   using creatable_classes_2d =
       tmpl::list<RotationAboutZAxis<2>, ScalingAndZRotation<2>>;
   using creatable_classes_3d =
-      tmpl::list<Shape, SphericalCompression, RotationAboutZAxis<3>,
-                 ScalingAndZRotation<3>>;
+      tmpl::list<Shape<domain::ObjectLabel::A>, Shape<domain::ObjectLabel::B>,
+                 Shape<domain::ObjectLabel::None>, SphericalCompression,
+                 RotationAboutZAxis<3>, ScalingAndZRotation<3>>;
   using creatable_classes_any_dim =
       tmpl::list<CubicScale<MeshDim>, None<MeshDim>,
                  UniformTranslation<MeshDim>>;

--- a/tests/Unit/Domain/Creators/TimeDependence/Test_Shape.cpp
+++ b/tests/Unit/Domain/Creators/TimeDependence/Test_Shape.cpp
@@ -309,8 +309,9 @@ void test(const std::unique_ptr<TimeDependence<3>>& time_dep_unique_ptr,
   // Test functions of time without expiration times
   {
     const auto functions_of_time = time_dep_unique_ptr->functions_of_time();
-    REQUIRE(functions_of_time.size() == 1);
+    REQUIRE(functions_of_time.size() == 2);
     CHECK(functions_of_time.count(f_of_t_name) == 1);
+    CHECK(functions_of_time.count("Size") == 1);
     CHECK(functions_of_time.at(f_of_t_name)->time_bounds()[1] ==
           std::numeric_limits<double>::infinity());
   }
@@ -321,8 +322,9 @@ void test(const std::unique_ptr<TimeDependence<3>>& time_dep_unique_ptr,
     init_expr_times[f_of_t_name] = init_expr_time;
     const auto functions_of_time =
         time_dep_unique_ptr->functions_of_time(init_expr_times);
-    REQUIRE(functions_of_time.size() == 1);
+    REQUIRE(functions_of_time.size() == 2);
     CHECK(functions_of_time.count(f_of_t_name) == 1);
+    CHECK(functions_of_time.count("Size") == 1);
     CHECK(functions_of_time.at(f_of_t_name)->time_bounds()[1] ==
           init_expr_time);
   }

--- a/tests/Unit/Domain/Creators/TimeDependence/Test_Shape.cpp
+++ b/tests/Unit/Domain/Creators/TimeDependence/Test_Shape.cpp
@@ -28,27 +28,54 @@
 #include "Helpers/Domain/Creators/TimeDependence/TestHelpers.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrHorizon.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/PrettyType.hpp"
 #include "Utilities/TMPL.hpp"
 
 namespace domain::creators::time_dependence {
 
 namespace {
 using ShapeMap = domain::CoordinateMaps::TimeDependent::Shape;
+using Identity = domain::CoordinateMaps::Identity<3>;
 
-using ConcreteMap =
+template <typename SourceFrame, typename TargetFrame>
+using ConcreteMapSimple = domain::CoordinateMap<
+    SourceFrame, TargetFrame,
+    tmpl::conditional_t<std::is_same_v<SourceFrame, Frame::Grid>, ShapeMap,
+                        Identity>>;
+
+using ConcreteMapCombined =
     domain::CoordinateMap<Frame::Grid, Frame::Inertial, ShapeMap>;
 
 using Transition =
     domain::CoordinateMaps::ShapeMapTransitionFunctions::SphereTransition;
 
-ConcreteMap create_coord_map(
+template <typename SourceFrame, typename TargetFrame>
+ConcreteMapSimple<SourceFrame, TargetFrame> create_coord_map(
     const std::string& f_of_t_name, const size_t l_max,
     const std::array<double, 3>& center,
     std::unique_ptr<domain::CoordinateMaps::ShapeMapTransitionFunctions::
                         ShapeMapTransitionFunction>
         transition_func) {
-  return ConcreteMap{{ShapeMap{center, l_max, l_max,
-                               transition_func->get_clone(), f_of_t_name}}};
+  if constexpr (std::is_same_v<SourceFrame, Frame::Grid>) {
+    return ConcreteMapSimple<SourceFrame, TargetFrame>{{ShapeMap{
+        center, l_max, l_max, transition_func->get_clone(), f_of_t_name}}};
+  } else {
+    (void)f_of_t_name;
+    (void)l_max;
+    (void)center;
+    (void)transition_func;
+    return ConcreteMapSimple<SourceFrame, TargetFrame>{Identity{}};
+  }
+}
+
+ConcreteMapCombined create_coord_map_combined(
+    const std::string& f_of_t_name, const size_t l_max,
+    const std::array<double, 3>& center,
+    std::unique_ptr<domain::CoordinateMaps::ShapeMapTransitionFunctions::
+                        ShapeMapTransitionFunction>
+        transition_func) {
+  return ConcreteMapCombined{ShapeMap{
+      center, l_max, l_max, transition_func->get_clone(), f_of_t_name}};
 }
 
 template <typename Frame>
@@ -64,15 +91,16 @@ std::array<double, 3> r_theta_phi(const tnsr::I<double, 3, Frame>& input) {
 // used instead of an expansion over spherical harmonics, as is used by the
 // Shape map. For an `l_max` of 16, this test can be expected to pass for any
 // random point mapped for a Shape map with dim'less spin magnitude < 0.65.
-void test_r_theta_phi(const tnsr::I<double, 3, Frame::Grid>& input,
-                      const tnsr::I<double, 3, Frame::Inertial>& output,
+template <typename SourceFrame, typename TargetFrame>
+void test_r_theta_phi(const tnsr::I<double, 3, SourceFrame>& input,
+                      const tnsr::I<double, 3, TargetFrame>& output,
                       const double inner_radius, const double outer_radius,
                       const double mass, const std::array<double, 3>& spin,
                       const std::array<double, 3>& center) {
   auto input_centered =
-      make_with_value<tnsr::I<double, 3, Frame::Grid>>(input, 0.0);
+      make_with_value<tnsr::I<double, 3, SourceFrame>>(input, 0.0);
   auto output_centered =
-      make_with_value<tnsr::I<double, 3, Frame::Inertial>>(output, 0.0);
+      make_with_value<tnsr::I<double, 3, TargetFrame>>(output, 0.0);
   for (size_t i = 0; i < 3; i++) {
     input_centered.get(i) = input.get(i) - gsl::at(center, i);
     output_centered.get(i) = output.get(i) - gsl::at(center, i);
@@ -97,6 +125,104 @@ void test_r_theta_phi(const tnsr::I<double, 3, Frame::Grid>& input,
        transition_factor * (kerr_schild_radius - inner_radius) / inner_radius);
   CHECK(output_centered_spherical[0] ==
         approx(expected_output_centered_spherical));
+}
+
+template <typename SourceFrame, typename TargetFrame, typename Generator,
+          typename BlockMaps, typename ExpectedBlockMap>
+void test_maps(const gsl::not_null<Generator*> gen,
+               const std::unique_ptr<TimeDependence<3>>& time_dep_unique_ptr,
+               const double initial_time, const double inner_radius,
+               const double outer_radius, const double mass,
+               const std::array<double, 3>& spin,
+               const std::array<double, 3>& center, const BlockMaps& block_maps,
+               const ExpectedBlockMap& expected_block_map) {
+  // These are just so we can capture the frames
+  const std::string source_frame = pretty_type::name<SourceFrame>();
+  const std::string target_frame = pretty_type::name<TargetFrame>();
+  CAPTURE(source_frame);
+  CAPTURE(target_frame);
+  const auto functions_of_time = time_dep_unique_ptr->functions_of_time();
+
+  // For a random point at a random time check that the values agree. This is
+  // to check that the internals were assigned the correct function of times.
+  // The points are are drawn from the positive x/y/z quadrant such that their
+  // radii lie between inner_radius and outer_radius.
+  TIME_DEPENDENCE_GENERATE_COORDS(gen, 3, inner_radius / sqrt(3.0),
+                                  outer_radius / sqrt(3.0));
+  TIME_DEPENDENCE_GENERATE_DISTORTED_COORDS(gen, dist, 3);
+
+  tnsr::I<DataVector, 3, SourceFrame> source_coords_dv;
+  tnsr::I<double, 3, SourceFrame> source_coords_double;
+  if constexpr (std::is_same_v<SourceFrame, Frame::Grid>) {
+    source_coords_dv = grid_coords_dv;
+    source_coords_double = grid_coords_double;
+  } else {
+    source_coords_dv = distorted_coords_dv;
+    source_coords_double = distorted_coords_double;
+  }
+
+  tnsr::I<double, 3, TargetFrame> target_coords_double;
+  if constexpr (std::is_same_v<TargetFrame, Frame::Inertial>) {
+    target_coords_double = inertial_coords_double;
+  } else {
+    target_coords_double = distorted_coords_double;
+  }
+
+  for (const auto& block_map : block_maps) {
+    // We've checked equivalence above
+    // (CHECK(*block_map == expected_block_map);), but have sometimes been
+    // burned by incorrect operator== implementations so we check that the
+    // mappings behave as expected.
+    const double check_time = initial_time + dist(*gen) + 1.2;
+    CHECK_ITERABLE_APPROX(
+        expected_block_map(source_coords_dv, check_time, functions_of_time),
+        (*block_map)(source_coords_dv, check_time, functions_of_time));
+    CHECK_ITERABLE_APPROX(
+        expected_block_map(source_coords_double, check_time, functions_of_time),
+        (*block_map)(source_coords_double, check_time, functions_of_time));
+
+    CHECK_ITERABLE_APPROX(
+        *expected_block_map.inverse(target_coords_double, check_time,
+                                    functions_of_time),
+        *block_map->inverse(target_coords_double, check_time,
+                            functions_of_time));
+
+    CHECK_ITERABLE_APPROX(expected_block_map.inv_jacobian(
+                              source_coords_dv, check_time, functions_of_time),
+                          block_map->inv_jacobian(source_coords_dv, check_time,
+                                                  functions_of_time));
+    CHECK_ITERABLE_APPROX(
+        expected_block_map.inv_jacobian(source_coords_double, check_time,
+                                        functions_of_time),
+        block_map->inv_jacobian(source_coords_double, check_time,
+                                functions_of_time));
+
+    CHECK_ITERABLE_APPROX(
+        expected_block_map.jacobian(source_coords_dv, check_time,
+                                    functions_of_time),
+        block_map->jacobian(source_coords_dv, check_time, functions_of_time));
+    CHECK_ITERABLE_APPROX(
+        expected_block_map.jacobian(source_coords_double, check_time,
+                                    functions_of_time),
+        block_map->jacobian(source_coords_double, check_time,
+                            functions_of_time));
+    // If this is the case, then the map is the identity so we don't need to
+    // test this
+    if constexpr (not std::is_same_v<SourceFrame, Frame::Distorted>) {
+      // Initialize a non spherical shape and make sure the values match
+      // kerr map takes mass and spin, gives radius at different theta phis
+      // get modal coefficients from SPHEREPACK (ylms corresponding to r(theta,
+      // phi) keep in mind how this interacts with r==0, consider an assert.
+      const auto output_point =
+          (*block_map)(source_coords_double, check_time, functions_of_time);
+      test_r_theta_phi(source_coords_double, output_point, inner_radius,
+                       outer_radius, mass, spin, center);
+    }
+    // Avoid compiler warnings
+    (void)mass;
+    (void)spin;
+    (void)center;
+  }
 }
 
 void test(const std::unique_ptr<TimeDependence<3>>& time_dep_unique_ptr,
@@ -128,22 +254,57 @@ void test(const std::unique_ptr<TimeDependence<3>>& time_dep_unique_ptr,
   UniformCustomDistribution<size_t> dist_size_t{1, 10};
   const size_t num_blocks = dist_size_t(gen);
   CAPTURE(num_blocks);
-  const auto expected_block_map = create_coord_map(
+  const auto expected_block_map_grid_to_inertial = create_coord_map_combined(
       f_of_t_name, l_max, center, transition_func->get_clone());
-  const auto block_maps =
+  const auto block_maps_grid_to_inertial =
       time_dep_unique_ptr->block_maps_grid_to_inertial(num_blocks);
-  for (const auto& block_map_unique_ptr : block_maps) {
+  for (const auto& block_map_unique_ptr : block_maps_grid_to_inertial) {
     const auto* const block_map =
-        dynamic_cast<const ConcreteMap*>(block_map_unique_ptr.get());
+        dynamic_cast<const ConcreteMapCombined*>(block_map_unique_ptr.get());
     REQUIRE(block_map != nullptr);
-    CHECK(*block_map == expected_block_map);
+    CHECK(*block_map == expected_block_map_grid_to_inertial);
   }
 
-  // Check that maps involving distorted frame are empty.
-  CHECK(time_dep_unique_ptr->block_maps_grid_to_distorted(1)[0].get() ==
-        nullptr);
-  CHECK(time_dep_unique_ptr->block_maps_distorted_to_inertial(1)[0].get() ==
-        nullptr);
+  test_maps<Frame::Grid, Frame::Inertial>(
+      make_not_null(&gen), time_dep_unique_ptr, initial_time, inner_radius,
+      outer_radius, mass, spin, center, block_maps_grid_to_inertial,
+      expected_block_map_grid_to_inertial);
+
+  const auto expected_block_map_grid_to_distorted =
+      create_coord_map<Frame::Grid, Frame::Distorted>(
+          f_of_t_name, l_max, center, transition_func->get_clone());
+  const auto block_maps_grid_to_distorted =
+      time_dep_unique_ptr->block_maps_grid_to_distorted(num_blocks);
+  for (const auto& block_map_unique_ptr : block_maps_grid_to_distorted) {
+    const auto* const block_map =
+        dynamic_cast<const ConcreteMapSimple<Frame::Grid, Frame::Distorted>*>(
+            block_map_unique_ptr.get());
+    REQUIRE(block_map != nullptr);
+    CHECK(*block_map == expected_block_map_grid_to_distorted);
+  }
+
+  test_maps<Frame::Grid, Frame::Distorted>(
+      make_not_null(&gen), time_dep_unique_ptr, initial_time, inner_radius,
+      outer_radius, mass, spin, center, block_maps_grid_to_distorted,
+      expected_block_map_grid_to_distorted);
+
+  const auto expected_block_map_distorted_to_inertial =
+      create_coord_map<Frame::Distorted, Frame::Inertial>(
+          f_of_t_name, l_max, center, transition_func->get_clone());
+  const auto block_maps_distorted_to_inertial =
+      time_dep_unique_ptr->block_maps_distorted_to_inertial(num_blocks);
+  for (const auto& block_map_unique_ptr : block_maps_distorted_to_inertial) {
+    const auto* const block_map = dynamic_cast<
+        const ConcreteMapSimple<Frame::Distorted, Frame::Inertial>*>(
+        block_map_unique_ptr.get());
+    REQUIRE(block_map != nullptr);
+    CHECK(*block_map == expected_block_map_distorted_to_inertial);
+  }
+
+  test_maps<Frame::Distorted, Frame::Inertial>(
+      make_not_null(&gen), time_dep_unique_ptr, initial_time, inner_radius,
+      outer_radius, mass, spin, center, block_maps_distorted_to_inertial,
+      expected_block_map_distorted_to_inertial);
 
   // Test functions of time without expiration times
   {
@@ -165,63 +326,44 @@ void test(const std::unique_ptr<TimeDependence<3>>& time_dep_unique_ptr,
     CHECK(functions_of_time.at(f_of_t_name)->time_bounds()[1] ==
           init_expr_time);
   }
+}
 
-  const auto functions_of_time = time_dep_unique_ptr->functions_of_time();
+void test_all() {
+  constexpr double initial_time{1.3};
+  // l_max of 16 needed to pass tests using `approx` as tests
+  // compare ylm output with analytic solution.
+  constexpr size_t l_max{16};
+  constexpr double mass{1.0};
+  const std::array<double, 3> spin{{0.1, 0.4, -0.5}};
+  const std::array<double, 3> center{{-0.02, 0.013, 0.024}};
+  const double inner_radius = 2.0;
+  const double outer_radius = 100;
+  const Transition sphere_transition{inner_radius, outer_radius};
+  // This name must match the hard coded one in Shape
+  const std::string f_of_t_name = "Shape";
 
-  // For a random point at a random time check that the values agree. This is
-  // to check that the internals were assigned the correct function of times.
-  // The points are are drawn from the positive x/y/z quadrant such that their
-  // radii lie between inner_radius and outer_radius.
-  TIME_DEPENDENCE_GENERATE_COORDS(make_not_null(&gen), 3,
-                                  inner_radius / sqrt(3.0),
-                                  outer_radius / sqrt(3.0));
+  const std::unique_ptr<domain::creators::time_dependence::TimeDependence<3>>
+      time_dep = std::make_unique<Shape>(initial_time, l_max, mass, spin,
+                                         center, inner_radius, outer_radius);
+  test(time_dep, initial_time, f_of_t_name, l_max,
+       std::make_unique<Transition>(sphere_transition), inner_radius,
+       outer_radius, mass, spin, center);
+  test(time_dep->get_clone(), initial_time, f_of_t_name, l_max,
+       std::make_unique<Transition>(sphere_transition), inner_radius,
+       outer_radius, mass, spin, center);
 
-  for (const auto& block_map : block_maps) {
-    // We've checked equivalence above
-    // (CHECK(*block_map == expected_block_map);), but have sometimes been
-    // burned by incorrect operator== implementations so we check that the
-    // mappings behave as expected.
-    const double check_time = initial_time + dist(gen) + 1.2;
-    CHECK_ITERABLE_APPROX(
-        expected_block_map(grid_coords_dv, check_time, functions_of_time),
-        (*block_map)(grid_coords_dv, check_time, functions_of_time));
-    CHECK_ITERABLE_APPROX(
-        expected_block_map(grid_coords_double, check_time, functions_of_time),
-        (*block_map)(grid_coords_double, check_time, functions_of_time));
-
-    CHECK_ITERABLE_APPROX(
-        *expected_block_map.inverse(inertial_coords_double, check_time,
-                                    functions_of_time),
-        *block_map->inverse(inertial_coords_double, check_time,
-                            functions_of_time));
-
-    CHECK_ITERABLE_APPROX(
-        expected_block_map.inv_jacobian(grid_coords_dv, check_time,
-                                        functions_of_time),
-        block_map->inv_jacobian(grid_coords_dv, check_time, functions_of_time));
-    CHECK_ITERABLE_APPROX(
-        expected_block_map.inv_jacobian(grid_coords_double, check_time,
-                                        functions_of_time),
-        block_map->inv_jacobian(grid_coords_double, check_time,
-                                functions_of_time));
-
-    CHECK_ITERABLE_APPROX(
-        expected_block_map.jacobian(grid_coords_dv, check_time,
-                                    functions_of_time),
-        block_map->jacobian(grid_coords_dv, check_time, functions_of_time));
-    CHECK_ITERABLE_APPROX(
-        expected_block_map.jacobian(grid_coords_double, check_time,
-                                    functions_of_time),
-        block_map->jacobian(grid_coords_double, check_time, functions_of_time));
-    // Initialize a non spherical shape and make sure the values match
-    // kerr map takes mass and spin, gives radius at different theta phis
-    // get modal coefficients from SPHEREPACK (ylms corresponding to r(theta,
-    // phi) keep in mind how this interacts with r==0, consider an assert.
-    const auto output_point =
-        (*block_map)(grid_coords_double, check_time, functions_of_time);
-    test_r_theta_phi(grid_coords_double, output_point, inner_radius,
-                     outer_radius, mass, spin, center);
-  }
+  test(TestHelpers::test_creation<std::unique_ptr<TimeDependence<3>>>(
+           "Shape:\n"
+           "  InitialTime: 1.3\n"
+           "  LMax: 16\n"
+           "  Mass: 1.0\n"
+           "  Spin: [0.1, 0.4, -0.5]\n"
+           "  Center: [-0.02, 0.013, 0.024]\n"
+           "  InnerRadius: 2.0\n"
+           "  OuterRadius: 100.0\n"),
+       initial_time, f_of_t_name, l_max,
+       std::make_unique<Transition>(sphere_transition), inner_radius,
+       outer_radius, mass, spin, center);
 }
 
 void test_equivalence() {
@@ -261,45 +403,7 @@ void test_equivalence() {
   CHECK_FALSE(sc0 == sc7);
 }
 
-SPECTRE_TEST_CASE("Unit.Domain.Creators.TimeDependence.Shape",
-                  "[Domain][Unit]") {
-  constexpr double initial_time{1.3};
-  // l_max of 16 needed to pass tests using `approx` as tests
-  // compare ylm output with analytic solution.
-  constexpr size_t l_max{16};
-  constexpr double mass{1.0};
-  const std::array<double, 3> spin{{0.1, 0.4, -0.5}};
-  const std::array<double, 3> center{{-0.02, 0.013, 0.024}};
-  const double inner_radius = 2.0;
-  const double outer_radius = 100;
-  const Transition sphere_transition{inner_radius, outer_radius};
-  // This name must match the hard coded one in Shape
-  const std::string f_of_t_name = "Shape";
-
-  const std::unique_ptr<domain::creators::time_dependence::TimeDependence<3>>
-      time_dep = std::make_unique<Shape>(initial_time, l_max, mass, spin,
-                                         center, inner_radius, outer_radius);
-  test(time_dep, initial_time, f_of_t_name, l_max,
-       std::make_unique<Transition>(sphere_transition), inner_radius,
-       outer_radius, mass, spin, center);
-  test(time_dep->get_clone(), initial_time, f_of_t_name, l_max,
-       std::make_unique<Transition>(sphere_transition), inner_radius,
-       outer_radius, mass, spin, center);
-
-  test(TestHelpers::test_creation<std::unique_ptr<TimeDependence<3>>>(
-           "Shape:\n"
-           "  InitialTime: 1.3\n"
-           "  LMax: 16\n"
-           "  Mass: 1.0\n"
-           "  Spin: [0.1, 0.4, -0.5]\n"
-           "  Center: [-0.02, 0.013, 0.024]\n"
-           "  InnerRadius: 2.0\n"
-           "  OuterRadius: 100.0\n"),
-       initial_time, f_of_t_name, l_max,
-       std::make_unique<Transition>(sphere_transition), inner_radius,
-       outer_radius, mass, spin, center);
-  test_equivalence();
-
+void test_errors() {
   CHECK_THROWS_WITH(
       TestHelpers::test_creation<std::unique_ptr<TimeDependence<3>>>(
           "Shape:\n"
@@ -337,6 +441,14 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.TimeDependence.Shape",
           "  InnerRadius: 1.0\n"
           "  OuterRadius: 10.0\n"),
       Catch::Contains("Tried to create a Shape TimeDependence, but the mass"));
+}
+
+SPECTRE_TEST_CASE("Unit.Domain.Creators.TimeDependence.Shape",
+                  "[Domain][Unit]") {
+  test_equivalence();
+  test_errors();
+
+  test_all();
 }
 
 }  // namespace

--- a/tests/Unit/Domain/Creators/TimeDependence/Test_Shape.cpp
+++ b/tests/Unit/Domain/Creators/TimeDependence/Test_Shape.cpp
@@ -22,11 +22,13 @@
 #include "Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/SphereTransition.hpp"
 #include "Domain/Creators/TimeDependence/Shape.hpp"
 #include "Domain/Creators/TimeDependence/TimeDependence.hpp"
+#include "Domain/Structure/ObjectLabel.hpp"
 #include "Framework/TestCreation.hpp"
 #include "Framework/TestHelpers.hpp"
 #include "Helpers/DataStructures/MakeWithRandomValues.hpp"
 #include "Helpers/Domain/Creators/TimeDependence/TestHelpers.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrHorizon.hpp"
+#include "Utilities/GetOutput.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/PrettyType.hpp"
 #include "Utilities/TMPL.hpp"
@@ -34,6 +36,8 @@
 namespace domain::creators::time_dependence {
 
 namespace {
+using Shape = Shape<domain::ObjectLabel::None>;
+
 using ShapeMap = domain::CoordinateMaps::TimeDependent::Shape;
 using Identity = domain::CoordinateMaps::Identity<3>;
 


### PR DESCRIPTION
## Proposed changes

This is in preparation for using this time dependence with the shape control system.

Also
- Adds a size function of time in the shape time dependence. This function of time doesn't control any maps, but is necessary if we want to use this time dependence with the shape control system (because the shape control error requires there to be a size function of time)
- Templates the shape time dependence on an `ObjectLabel` so we know which function of time name to use.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
