### PR TITLE
Revert "Find NumPy with CMake's built-in FindPython"

### DIFF
--- a/cmake/SetupPypp.cmake
+++ b/cmake/SetupPypp.cmake
@@ -8,8 +8,10 @@
 # variable set by the user.
 find_package(Python REQUIRED COMPONENTS Interpreter Development)
 
-# We can't rely on CMake 3.14 quite yet so we backport the `Python::NumPy`
-# imported target that FindPython in CMake 3.14+ could also provide.
+# CMake's FindPython has trouble finding NumPy when it isn't installed in the
+# Python executable's directory, and can't be given hints either (as of CMake
+# version 3.25). So we find NumPy ourselves (which isn't much different to
+# what FindPython does internally anyway).
 find_package(NumPy 1.10 REQUIRED)
 
 message(STATUS "NumPy incl: " ${NUMPY_INCLUDE_DIRS})

--- a/cmake/SetupPypp.cmake
+++ b/cmake/SetupPypp.cmake
@@ -6,11 +6,27 @@
 # component as well to make sure the find is consistent with earlier finds that
 # only looked for the interpreter, possibly guided by the Python_EXECUTABLE
 # variable set by the user.
-find_package(Python REQUIRED COMPONENTS Interpreter Development NumPy)
+find_package(Python REQUIRED COMPONENTS Interpreter Development)
+
+# We can't rely on CMake 3.14 quite yet so we backport the `Python::NumPy`
+# imported target that FindPython in CMake 3.14+ could also provide.
+find_package(NumPy 1.10 REQUIRED)
+
+message(STATUS "NumPy incl: " ${NUMPY_INCLUDE_DIRS})
+message(STATUS "NumPy vers: " ${NUMPY_VERSION})
+
+file(APPEND
+  "${CMAKE_BINARY_DIR}/BuildInfo.txt"
+  "NumPy version: ${NUMPY_VERSION}\n"
+  )
 
 # Also check that SciPy is installed
 include(FindPythonModule)
 find_python_module(scipy TRUE)
+
+add_library(Python::NumPy INTERFACE IMPORTED)
+set_property(TARGET Python::NumPy PROPERTY
+  INTERFACE_INCLUDE_DIRECTORIES ${NUMPY_INCLUDE_DIRS})
 
 set_property(
   GLOBAL APPEND PROPERTY SPECTRE_THIRD_PARTY_LIBS


### PR DESCRIPTION
## Proposed changes

Reverts part of #4731 because it led to build issues on Wheeler. Turns out CMake's built-in code to find NumPy isn't as great as I hoped it would be.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
