### PR TITLE
Upgrade HDF5 on Wheeler

### DIFF
--- a/support/Environments/wheeler_clang.sh
+++ b/support/Environments/wheeler_clang.sh
@@ -29,7 +29,7 @@ spectre_unload_modules() {
     module unload charm/7.0.0-intelmpi-smp
     module unload python/miniconda-3.9.7
     module unload pybind11/2.6.1
-    module unload hdf5/1.12.0
+    module unload hdf5/1.12.2
 }
 
 spectre_load_modules() {
@@ -54,7 +54,7 @@ spectre_load_modules() {
     module load charm/7.0.0-intelmpi-smp
     module load python/miniconda-3.9.7
     module load pybind11/2.6.1
-    module load hdf5/1.12.0
+    module load hdf5/1.12.2
 }
 
 spectre_run_cmake() {

--- a/support/Environments/wheeler_gcc.sh
+++ b/support/Environments/wheeler_gcc.sh
@@ -29,7 +29,7 @@ spectre_unload_modules() {
     module unload charm/7.0.0-intelmpi-smp
     module unload python/miniconda-3.9.7
     module unload pybind11/2.6.1
-    module unload hdf5/1.12.0
+    module unload hdf5/1.12.2
 }
 
 spectre_load_modules() {
@@ -54,7 +54,7 @@ spectre_load_modules() {
     module load charm/7.0.0-intelmpi-smp
     module load python/miniconda-3.9.7
     module load pybind11/2.6.1
-    module load hdf5/1.12.0
+    module load hdf5/1.12.2
 }
 
 spectre_run_cmake() {


### PR DESCRIPTION
## Proposed changes

Use HDF5 1.12.2 because it supports the file locking API (see #4633).

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
