### PR TITLE
Control when we ObserveCenters from input file in BBH

### DIFF
--- a/src/ApparentHorizons/ObserveCenters.hpp
+++ b/src/ApparentHorizons/ObserveCenters.hpp
@@ -57,6 +57,11 @@ namespace callbacks {
  */
 template <typename InterpolationTargetTag>
 struct ObserveCenters {
+  // Note that we don't add a const_global_cache_tags type alias here with
+  // ah::Tags::ObserveCenters because we want to use the base tag and so must be
+  // agnostic to how the tag was added to the cache. We do this so anything that
+  // uses ObserveCenters can control when it gets printed.
+
   template <typename DbTags, typename Metavariables, typename TemporalId>
   static void apply(const db::DataBox<DbTags>& box,
                     Parallel::GlobalCache<Metavariables>& cache,
@@ -75,6 +80,11 @@ struct ObserveCenters {
         db::tag_is_retrievable_v<EuclideanAreaElementTag, db::DataBox<DbTags>>,
         "DataBox must contain "
         "StrahlkorperTags::EuclideanAreaElement<Frame::Grid>");
+
+    // Only print the centers if we want to.
+    if (not Parallel::get<ah::Tags::ObserveCentersBase>(cache)) {
+      return;
+    }
 
     const auto& grid_horizon = db::get<GridTag>(box);
     const std::array<double, 3> grid_center = grid_horizon.physical_center();

--- a/src/ApparentHorizons/Tags.hpp
+++ b/src/ApparentHorizons/Tags.hpp
@@ -41,6 +41,18 @@ struct PreviousStrahlkorpers : db::SimpleTag {
   using type = std::deque<std::pair<double, ::Strahlkorper<Frame>>>;
 };
 
+/// Base tag for whether or not to write the centers of the horizons to disk.
+/// Most likely to be used in the `ObserveCenters` post horizon find callback
+///
+/// Other things can control whether the horizon centers are output by defining
+/// their own simple tag from this base tag.
+struct ObserveCentersBase : db::BaseTag {};
+
+/// Simple tag for whether to write the centers of the horizons to disk.
+/// Currently this tag is not creatable by options
+struct ObserveCenters : ObserveCentersBase, db::SimpleTag {
+  using type = bool;
+};
 }  // namespace ah::Tags
 
 /// \ingroup SurfacesGroup

--- a/src/ControlSystem/Actions/Initialization.hpp
+++ b/src/ControlSystem/Actions/Initialization.hpp
@@ -7,6 +7,7 @@
 #include <memory>
 #include <unordered_map>
 
+#include "ApparentHorizons/Tags.hpp"
 #include "ControlSystem/Averager.hpp"
 #include "ControlSystem/Tags.hpp"
 #include "ControlSystem/Tags/MeasurementTimescales.hpp"
@@ -43,6 +44,7 @@ struct get_center_tags<domain::object_list<>> {
  * - Uses:
  *   - `control_system::Tags::MeasurementTimescales`
  *   - `control_system::Tags::WriteDataToDisk`
+ *   - `control_system::Tags::ObserveCenters`
  *   - `domain::Tags::ExcisionCenter<domain::ObjectLabel::A>`
  *   - `domain::Tags::ExcisionCenter<domain::ObjectLabel::B>`
  *
@@ -77,6 +79,7 @@ struct Initialize {
   using const_global_cache_tags = tmpl::flatten<tmpl::list<
       control_system::Tags::MeasurementsPerUpdate,
       control_system::Tags::WriteDataToDisk,
+      control_system::Tags::ObserveCenters,
       typename detail::get_center_tags<
           typename ControlSystem::control_error::object_centers>::type>>;
 

--- a/src/ControlSystem/Actions/Initialization.hpp
+++ b/src/ControlSystem/Actions/Initialization.hpp
@@ -42,6 +42,7 @@ struct get_center_tags<domain::object_list<>> {
  * GlobalCache:
  * - Uses:
  *   - `control_system::Tags::MeasurementTimescales`
+ *   - `control_system::Tags::WriteDataToDisk`
  *   - `domain::Tags::ExcisionCenter<domain::ObjectLabel::A>`
  *   - `domain::Tags::ExcisionCenter<domain::ObjectLabel::B>`
  *
@@ -52,7 +53,6 @@ struct get_center_tags<domain::object_list<>> {
  *   - `control_system::Tags::Controller<ControlSystem>`
  *   - `control_system::Tags::TimescaleTuner<ControlSystem>`
  *   - `control_system::Tags::ControlError<ControlSystem>`
- *   - `control_system::Tags::WriteDataToDisk`
  *   - `control_system::Tags::IsActive<ControlSystem>`
  * - Removes: Nothing
  * - Modifies:
@@ -64,8 +64,7 @@ struct Initialize {
   static constexpr size_t deriv_order = ControlSystem::deriv_order;
 
   using simple_tags_from_options =
-      tmpl::list<control_system::Tags::WriteDataToDisk,
-                 control_system::Tags::Averager<ControlSystem>,
+      tmpl::list<control_system::Tags::Averager<ControlSystem>,
                  control_system::Tags::Controller<ControlSystem>,
                  control_system::Tags::TimescaleTuner<ControlSystem>,
                  control_system::Tags::ControlError<ControlSystem>,
@@ -77,6 +76,7 @@ struct Initialize {
 
   using const_global_cache_tags = tmpl::flatten<tmpl::list<
       control_system::Tags::MeasurementsPerUpdate,
+      control_system::Tags::WriteDataToDisk,
       typename detail::get_center_tags<
           typename ControlSystem::control_error::object_centers>::type>>;
 

--- a/src/ControlSystem/Tags.hpp
+++ b/src/ControlSystem/Tags.hpp
@@ -10,6 +10,7 @@
 #include <string>
 #include <utility>
 
+#include "ApparentHorizons/Tags.hpp"
 #include "ControlSystem/Averager.hpp"
 #include "ControlSystem/Controller.hpp"
 #include "ControlSystem/Protocols/ControlSystem.hpp"
@@ -135,6 +136,20 @@ namespace Tags {
 /// \ingroup ControlSystemGroup
 /// DataBox tag for writing control system data to disk
 struct WriteDataToDisk : db::SimpleTag {
+  using type = bool;
+  using option_tags = tmpl::list<OptionTags::WriteDataToDisk>;
+
+  static constexpr bool pass_metavariables = false;
+  static type create_from_options(const type& option) { return option; }
+};
+
+/// \ingroup DataBoxTagsGroup
+/// \ingroup ControlSystemGroup
+/// DataBox tag for writing the centers of the horizons to disk.
+///
+/// This is controlled by the `control_system::OptionTags::WriteDataToDisk`
+/// option in the input file.
+struct ObserveCenters : ::ah::Tags::ObserveCentersBase, db::SimpleTag {
   using type = bool;
   using option_tags = tmpl::list<OptionTags::WriteDataToDisk>;
 

--- a/src/ControlSystem/UpdateControlSystem.hpp
+++ b/src/ControlSystem/UpdateControlSystem.hpp
@@ -142,7 +142,7 @@ struct UpdateControlSystem {
       q_and_dtq[1] = (*opt_avg_values)[1];
     }
 
-    if (db::get<control_system::Tags::WriteDataToDisk>(*box)) {
+    if (Parallel::get<control_system::Tags::WriteDataToDisk>(cache)) {
       // LCOV_EXCL_START
       write_components_to_disk<ControlSystem>(time, cache, function_of_time,
                                               q_and_dtq);

--- a/tests/Unit/ApparentHorizons/Test_ObserveCenters.cpp
+++ b/tests/Unit/ApparentHorizons/Test_ObserveCenters.cpp
@@ -9,6 +9,7 @@
 #include <string>
 
 #include "ApparentHorizons/ObserveCenters.hpp"
+#include "ApparentHorizons/Tags.hpp"
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/Matrix.hpp"
 #include "Framework/ActionTesting.hpp"
@@ -29,6 +30,7 @@ namespace {
 struct AhA {};
 
 struct TestMetavars {
+  using const_global_cache_tags = tmpl::list<ah::Tags::ObserveCenters>;
   using component_list =
       tmpl::list<TestHelpers::observers::MockObserverWriter<TestMetavars>>;
 };
@@ -43,7 +45,7 @@ SPECTRE_TEST_CASE("Unit.ApparentHorizons.ObserveCenters",
   std::uniform_real_distribution<double> center_dist{-10.0, 10.0};
 
   // set up runner and stuff
-  ActionTesting::MockRuntimeSystem<TestMetavars> runner{{}};
+  ActionTesting::MockRuntimeSystem<TestMetavars> runner{{true}};
   runner.set_phase(Parallel::Phase::Initialization);
   ActionTesting::emplace_nodegroup_component_and_initialize<observer_writer>(
       make_not_null(&runner), {});

--- a/tests/Unit/ApparentHorizons/Test_Tags.cpp
+++ b/tests/Unit/ApparentHorizons/Test_Tags.cpp
@@ -213,6 +213,9 @@ SPECTRE_TEST_CASE("Unit.ApparentHorizons.StrahlkorperDataBox",
   test_dimensionful_spin_vector_compute_tag();
   test_dimensionless_spin_magnitude_compute_tag();
   TestHelpers::db::test_simple_tag<ah::Tags::FastFlow>("FastFlow");
+  TestHelpers::db::test_base_tag<ah::Tags::ObserveCentersBase>(
+      "ObserveCentersBase");
+  TestHelpers::db::test_simple_tag<ah::Tags::ObserveCenters>("ObserveCenters");
   TestHelpers::db::test_simple_tag<StrahlkorperGr::Tags::Area>("Area");
   TestHelpers::db::test_simple_tag<StrahlkorperGr::Tags::IrreducibleMass>(
       "IrreducibleMass");

--- a/tests/Unit/ControlSystem/ControlErrors/Test_Expansion.cpp
+++ b/tests/Unit/ControlSystem/ControlErrors/Test_Expansion.cpp
@@ -83,7 +83,7 @@ void test_expansion_control_error() {
   // Setup runner and element component because it's the easiest way to get the
   // global cache
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<metavars>;
-  MockRuntimeSystem runner{{"DummyFileName", std::move(domain), 4,
+  MockRuntimeSystem runner{{"DummyFileName", std::move(domain), 4, false,
                             std::move(grid_center_A), std::move(grid_center_B)},
                            {std::move(initial_functions_of_time),
                             std::move(initial_measurement_timescales)}};

--- a/tests/Unit/ControlSystem/ControlErrors/Test_Rotation.cpp
+++ b/tests/Unit/ControlSystem/ControlErrors/Test_Rotation.cpp
@@ -88,7 +88,7 @@ void test_rotation_control_error() {
   // Setup runner and element component because it's the easiest way to get the
   // global cache
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<metavars>;
-  MockRuntimeSystem runner{{"DummyFileName", std::move(domain), 4,
+  MockRuntimeSystem runner{{"DummyFileName", std::move(domain), 4, false,
                             std::move(grid_center_A), std::move(grid_center_B)},
                            {std::move(initial_functions_of_time),
                             std::move(initial_measurement_timescales)}};

--- a/tests/Unit/ControlSystem/ControlErrors/Test_Shape.cpp
+++ b/tests/Unit/ControlSystem/ControlErrors/Test_Shape.cpp
@@ -149,7 +149,7 @@ void test_shape_control_error() {
 
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<metavars>;
   // Excision centers aren't used so their values can be anything
-  MockRuntimeSystem runner{{"DummyFilename", std::move(fake_domain), 4,
+  MockRuntimeSystem runner{{"DummyFilename", std::move(fake_domain), 4, false,
                             std::move(grid_center_A), std::move(grid_center_B)},
                            {std::move(initial_functions_of_time),
                             std::move(initial_measurement_timescales)}};

--- a/tests/Unit/ControlSystem/ControlErrors/Test_Translation.cpp
+++ b/tests/Unit/ControlSystem/ControlErrors/Test_Translation.cpp
@@ -90,7 +90,7 @@ void test_translation_control_error() {
   // Setup runner and element component because it's the easiest way to get the
   // global cache
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<metavars>;
-  MockRuntimeSystem runner{{"DummyFileName", std::move(domain), 4,
+  MockRuntimeSystem runner{{"DummyFileName", std::move(domain), 4, false,
                             std::move(grid_center_A), std::move(grid_center_B)},
                            {std::move(initial_functions_of_time),
                             std::move(initial_measurement_timescales)}};

--- a/tests/Unit/ControlSystem/Systems/Test_Expansion.cpp
+++ b/tests/Unit/ControlSystem/Systems/Test_Expansion.cpp
@@ -105,7 +105,7 @@ void test_expansion_control_system() {
 
   // Setup runner and all components
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<metavars>;
-  MockRuntimeSystem runner{{"DummyFileName", std::move(domain), 4,
+  MockRuntimeSystem runner{{"DummyFileName", std::move(domain), 4, false,
                             std::move(grid_center_A), std::move(grid_center_B)},
                            {std::move(initial_functions_of_time),
                             std::move(initial_measurement_timescales)}};

--- a/tests/Unit/ControlSystem/Systems/Test_RotScaleTrans.cpp
+++ b/tests/Unit/ControlSystem/Systems/Test_RotScaleTrans.cpp
@@ -158,7 +158,7 @@ void test_rotscaletrans_control_system(const double rotation_eps = 5.0e-5) {
   // Setup runner and all components
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<metavars>;
   MockRuntimeSystem runner{
-      {"DummyFileName", std::move(domain), 4,
+      {"DummyFileName", std::move(domain), 4, false,
        tnsr::I<double, 3, Frame::Grid>{{0.5 * initial_separation, 0.0, 0.0}},
        tnsr::I<double, 3, Frame::Grid>{{-0.5 * initial_separation, 0.0, 0.0}}},
       {std::move(initial_functions_of_time),

--- a/tests/Unit/ControlSystem/Systems/Test_Rotation.cpp
+++ b/tests/Unit/ControlSystem/Systems/Test_Rotation.cpp
@@ -106,7 +106,7 @@ void test_rotation_control_system(const bool newtonian) {
 
   // Setup runner and all components
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<metavars>;
-  MockRuntimeSystem runner{{"DummyFileName", std::move(domain), 4,
+  MockRuntimeSystem runner{{"DummyFileName", std::move(domain), 4, false,
                             std::move(grid_center_A), std::move(grid_center_B)},
                            {std::move(initial_functions_of_time),
                             std::move(initial_measurement_timescales)}};

--- a/tests/Unit/ControlSystem/Systems/Test_Shape.cpp
+++ b/tests/Unit/ControlSystem/Systems/Test_Shape.cpp
@@ -84,7 +84,7 @@ void test_shape_control(
 
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<Metavars>;
   // Excision centers aren't used so their values can be anything
-  MockRuntimeSystem runner{{"DummyFileName", std::move(domain), 4,
+  MockRuntimeSystem runner{{"DummyFileName", std::move(domain), 4, false,
                             std::move(grid_center_A), std::move(grid_center_B)},
                            {std::move(initial_functions_of_time),
                             std::move(initial_measurement_timescales)}};

--- a/tests/Unit/ControlSystem/Systems/Test_Translation.cpp
+++ b/tests/Unit/ControlSystem/Systems/Test_Translation.cpp
@@ -115,7 +115,7 @@ void test_translation_control_system() {
 
   // Setup runner and all components
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<metavars>;
-  MockRuntimeSystem runner{{"DummyFileName", std::move(domain), 4,
+  MockRuntimeSystem runner{{"DummyFileName", std::move(domain), 4, false,
                             std::move(grid_center_A), std::move(grid_center_B)},
                            {std::move(initial_functions_of_time),
                             std::move(initial_measurement_timescales)}};

--- a/tests/Unit/ControlSystem/Test_Tags.cpp
+++ b/tests/Unit/ControlSystem/Test_Tags.cpp
@@ -46,6 +46,8 @@ void test_all_tags() {
   INFO("Test all tags");
   using write_tag = control_system::Tags::WriteDataToDisk;
   TestHelpers::db::test_simple_tag<write_tag>("WriteDataToDisk");
+  using observe_tag = control_system::Tags::ObserveCenters;
+  TestHelpers::db::test_simple_tag<observe_tag>("ObserveCenters");
   using averager_tag = control_system::Tags::Averager<system>;
   TestHelpers::db::test_simple_tag<averager_tag>("Averager");
   using timescaletuner_tag = control_system::Tags::TimescaleTuner<system>;

--- a/tests/Unit/Helpers/ControlSystem/SystemHelpers.hpp
+++ b/tests/Unit/Helpers/ControlSystem/SystemHelpers.hpp
@@ -85,7 +85,6 @@ using init_simple_tags =
                control_system::Tags::TimescaleTuner<ControlSystem>,
                control_system::Tags::Controller<ControlSystem>,
                control_system::Tags::ControlError<ControlSystem>,
-               control_system::Tags::WriteDataToDisk,
                control_system::Tags::IsActive<ControlSystem>,
                control_system::Tags::CurrentNumberOfMeasurements,
                typename ControlSystem::MeasurementQueue>;
@@ -204,6 +203,7 @@ struct MockControlComponent {
 
   using const_global_cache_tags =
       tmpl::list<control_system::Tags::MeasurementsPerUpdate,
+                 control_system::Tags::WriteDataToDisk,
                  domain::Tags::ExcisionCenter<domain::ObjectLabel::A>,
                  domain::Tags::ExcisionCenter<domain::ObjectLabel::B>>;
 
@@ -790,7 +790,7 @@ struct SystemHelper {
               get<control_system::Tags::TimescaleTuner<system>>(created_tags),
               get<control_system::Tags::Controller<system>>(created_tags),
               get<control_system::Tags::ControlError<system>>(created_tags),
-              get<control_system::Tags::WriteDataToDisk>(created_tags), true, 0,
+              true, 0,
               // Just need an empty queue. It will get filled in as the control
               // system is updated
               LinkedMessageQueue<


### PR DESCRIPTION
## Proposed changes

Now for the BBH executable, specifying
```yaml
ControlSystems:
  WriteDataToDisk: false
```

will also turn off writing the centers of the horizons to disk. Before it only stopped the control system diagnostics from being written and the centers were always written.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
