### PR TITLE
Unify naming pattern of excision spheres

### DIFF
--- a/src/ControlSystem/ControlErrors/Shape.hpp
+++ b/src/ControlSystem/ControlErrors/Shape.hpp
@@ -38,7 +38,7 @@ namespace ControlErrors {
 namespace detail {
 template <::domain::ObjectLabel Horizon>
 std::string excision_sphere_name() {
-  return "Object"s + ::domain::name(Horizon) + "ExcisionSphere"s;
+  return "ExcisionSphere"s + ::domain::name(Horizon);
 }
 
 template <::domain::ObjectLabel Horizon>

--- a/src/ControlSystem/Tags.hpp
+++ b/src/ControlSystem/Tags.hpp
@@ -268,17 +268,17 @@ struct ControlError : db::SimpleTag {
         };
 
     if constexpr (expected_number_of_excisions == 1) {
-      if (excision_spheres.count("ObjectAExcisionSphere") != 1 and
-          excision_spheres.count("ObjectBExcisionSphere") != 1) {
-        print_error("ObjectAExcisionSphere' or 'ObjectBExcisionSphere");
+      if (excision_spheres.count("ExcisionSphereA") != 1 and
+          excision_spheres.count("ExcisionSphereB") != 1) {
+        print_error("ExcisionSphereA' or 'ExcisionSphereB");
       }
     }
     if constexpr (expected_number_of_excisions == 2) {
-      if (excision_spheres.count("ObjectAExcisionSphere") != 1) {
-        print_error("ObjectAExcisionSphere");
+      if (excision_spheres.count("ExcisionSphereA") != 1) {
+        print_error("ExcisionSphereA");
       }
-      if (excision_spheres.count("ObjectBExcisionSphere") != 1) {
-        print_error("ObjectBExcisionSphere");
+      if (excision_spheres.count("ExcisionSphereB") != 1) {
+        print_error("ExcisionSphereB");
       }
     }
 

--- a/src/Domain/Creators/BinaryCompactObject.cpp
+++ b/src/Domain/Creators/BinaryCompactObject.cpp
@@ -510,7 +510,7 @@ Domain<3> BinaryCompactObject::create_domain() const {
   std::unordered_map<std::string, ExcisionSphere<3>> excision_spheres{};
   if (object_A_.is_excised()) {
     excision_spheres.emplace(
-        "ObjectAExcisionSphere",
+        "ExcisionSphereA",
         ExcisionSphere<3>{
             object_A_.inner_radius,
             tnsr::I<double, 3, Frame::Grid>{{object_A_.x_coord, 0.0, 0.0}},
@@ -523,7 +523,7 @@ Domain<3> BinaryCompactObject::create_domain() const {
   }
   if (object_B_.is_excised()) {
     excision_spheres.emplace(
-        "ObjectBExcisionSphere",
+        "ExcisionSphereB",
         ExcisionSphere<3>{
             object_B_.inner_radius,
             tnsr::I<double, 3, Frame::Grid>{{object_B_.x_coord, 0.0, 0.0}},

--- a/src/Domain/Creators/CylindricalBinaryCompactObject.cpp
+++ b/src/Domain/Creators/CylindricalBinaryCompactObject.cpp
@@ -838,7 +838,7 @@ Domain<3> CylindricalBinaryCompactObject::create_domain() const {
     }
   }
   excision_spheres.emplace(
-      "ObjectAExcisionSphere",
+      "ExcisionSphereA",
       ExcisionSphere<3>{
           radius_A_,
           tnsr::I<double, 3, Frame::Grid>(rotate_from_z_to_x_axis(center_A_)),
@@ -868,7 +868,7 @@ Domain<3> CylindricalBinaryCompactObject::create_domain() const {
     }
   }
   excision_spheres.emplace(
-      "ObjectBExcisionSphere",
+      "ExcisionSphereB",
       ExcisionSphere<3>{
           radius_B_,
           tnsr::I<double, 3, Frame::Grid>(rotate_from_z_to_x_axis(center_B_)),

--- a/src/Domain/Creators/Shell.cpp
+++ b/src/Domain/Creators/Shell.cpp
@@ -160,7 +160,7 @@ Domain<3> Shell::create_domain() const {
   std::unordered_map<std::string, ExcisionSphere<3>> excision_spheres;
   if (which_wedges_ == ShellWedges::All) {
     excision_spheres.emplace(
-        "CentralExcisionSphere",
+        "ExcisionSphere",
         ExcisionSphere<3>{inner_radius_,
                           tnsr::I<double, 3, Frame::Grid>{0.0},
                           {{0, Direction<3>::lower_zeta()},

--- a/src/Domain/Tags/ObjectCenter.cpp
+++ b/src/Domain/Tags/ObjectCenter.cpp
@@ -19,7 +19,7 @@ template <ObjectLabel Label>
 tnsr::I<double, 3, Frame::Grid> ExcisionCenter<Label>::create_from_options(
     const std::unique_ptr<::DomainCreator<3>>& domain_creator) {
   const auto domain = domain_creator->create_domain();
-  const std::string name = "Object"s + get_output(Label) + "ExcisionSphere"s;
+  const std::string name = "ExcisionSphere"s + get_output(Label);
   if (domain.excision_spheres().count(name) != 1) {
     ERROR(name << " is not in the domains excision spheres but is needed to "
                   "generate the ExcisionCenter<"

--- a/tests/Unit/ControlSystem/ControlErrors/Test_Expansion.cpp
+++ b/tests/Unit/ControlSystem/ControlErrors/Test_Expansion.cpp
@@ -75,10 +75,8 @@ void test_expansion_control_error() {
   const std::string expansion_name =
       system_helper.template name<expansion_system>();
 
-  auto grid_center_A =
-      domain.excision_spheres().at("ObjectAExcisionSphere").center();
-  auto grid_center_B =
-      domain.excision_spheres().at("ObjectBExcisionSphere").center();
+  auto grid_center_A = domain.excision_spheres().at("ExcisionSphereA").center();
+  auto grid_center_B = domain.excision_spheres().at("ExcisionSphereB").center();
 
   // Setup runner and element component because it's the easiest way to get the
   // global cache

--- a/tests/Unit/ControlSystem/ControlErrors/Test_Rotation.cpp
+++ b/tests/Unit/ControlSystem/ControlErrors/Test_Rotation.cpp
@@ -80,10 +80,8 @@ void test_rotation_control_error() {
   const std::string rotation_name =
       system_helper.template name<rotation_system>();
 
-  auto grid_center_A =
-      domain.excision_spheres().at("ObjectAExcisionSphere").center();
-  auto grid_center_B =
-      domain.excision_spheres().at("ObjectBExcisionSphere").center();
+  auto grid_center_A = domain.excision_spheres().at("ExcisionSphereA").center();
+  auto grid_center_B = domain.excision_spheres().at("ExcisionSphereB").center();
 
   // Setup runner and element component because it's the easiest way to get the
   // global cache

--- a/tests/Unit/ControlSystem/ControlErrors/Test_Shape.cpp
+++ b/tests/Unit/ControlSystem/ControlErrors/Test_Shape.cpp
@@ -143,9 +143,9 @@ void test_shape_control_error() {
                            {5, Direction<3>::lower_zeta()}}}}}};
 
   auto grid_center_A =
-      fake_domain.excision_spheres().at("ObjectAExcisionSphere").center();
+      fake_domain.excision_spheres().at("ExcisionSphereA").center();
   auto grid_center_B =
-      fake_domain.excision_spheres().at("ObjectAExcisionSphere").center();
+      fake_domain.excision_spheres().at("ExcisionSphereA").center();
 
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<metavars>;
   // Excision centers aren't used so their values can be anything

--- a/tests/Unit/ControlSystem/ControlErrors/Test_Translation.cpp
+++ b/tests/Unit/ControlSystem/ControlErrors/Test_Translation.cpp
@@ -82,10 +82,8 @@ void test_translation_control_error() {
   const std::string translation_name =
       system_helper.template name<translation_system>();
 
-  auto grid_center_A =
-      domain.excision_spheres().at("ObjectAExcisionSphere").center();
-  auto grid_center_B =
-      domain.excision_spheres().at("ObjectBExcisionSphere").center();
+  auto grid_center_A = domain.excision_spheres().at("ExcisionSphereA").center();
+  auto grid_center_B = domain.excision_spheres().at("ExcisionSphereB").center();
 
   // Setup runner and element component because it's the easiest way to get the
   // global cache

--- a/tests/Unit/ControlSystem/Systems/Test_Expansion.cpp
+++ b/tests/Unit/ControlSystem/Systems/Test_Expansion.cpp
@@ -98,10 +98,8 @@ void test_expansion_control_system() {
   const auto& init_exp_tuple =
       system_helper.template init_tuple<expansion_system>();
 
-  auto grid_center_A =
-      domain.excision_spheres().at("ObjectAExcisionSphere").center();
-  auto grid_center_B =
-      domain.excision_spheres().at("ObjectBExcisionSphere").center();
+  auto grid_center_A = domain.excision_spheres().at("ExcisionSphereA").center();
+  auto grid_center_B = domain.excision_spheres().at("ExcisionSphereB").center();
 
   // Setup runner and all components
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<metavars>;

--- a/tests/Unit/ControlSystem/Systems/Test_Rotation.cpp
+++ b/tests/Unit/ControlSystem/Systems/Test_Rotation.cpp
@@ -99,10 +99,8 @@ void test_rotation_control_system(const bool newtonian) {
   const auto& init_rot_tuple =
       system_helper.template init_tuple<rotation_system>();
 
-  auto grid_center_A =
-      domain.excision_spheres().at("ObjectAExcisionSphere").center();
-  auto grid_center_B =
-      domain.excision_spheres().at("ObjectBExcisionSphere").center();
+  auto grid_center_A = domain.excision_spheres().at("ExcisionSphereA").center();
+  auto grid_center_B = domain.excision_spheres().at("ExcisionSphereB").center();
 
   // Setup runner and all components
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<metavars>;

--- a/tests/Unit/ControlSystem/Systems/Test_Shape.cpp
+++ b/tests/Unit/ControlSystem/Systems/Test_Shape.cpp
@@ -75,10 +75,8 @@ void test_shape_control(
   auto& initial_measurement_timescales =
       system_helper->initial_measurement_timescales();
 
-  auto grid_center_A =
-      domain.excision_spheres().at("ObjectAExcisionSphere").center();
-  auto grid_center_B =
-      domain.excision_spheres().at("ObjectBExcisionSphere").center();
+  auto grid_center_A = domain.excision_spheres().at("ExcisionSphereA").center();
+  auto grid_center_B = domain.excision_spheres().at("ExcisionSphereB").center();
 
   const auto& init_shape_tuple = system_helper->template init_tuple<system>();
 

--- a/tests/Unit/ControlSystem/Systems/Test_Translation.cpp
+++ b/tests/Unit/ControlSystem/Systems/Test_Translation.cpp
@@ -108,10 +108,8 @@ void test_translation_control_system() {
   const std::string translation_name =
       system_helper.template name<translation_system>();
 
-  auto grid_center_A =
-      domain.excision_spheres().at("ObjectAExcisionSphere").center();
-  auto grid_center_B =
-      domain.excision_spheres().at("ObjectBExcisionSphere").center();
+  auto grid_center_A = domain.excision_spheres().at("ExcisionSphereA").center();
+  auto grid_center_B = domain.excision_spheres().at("ExcisionSphereB").center();
 
   // Setup runner and all components
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<metavars>;

--- a/tests/Unit/ControlSystem/Test_Tags.cpp
+++ b/tests/Unit/ControlSystem/Test_Tags.cpp
@@ -219,13 +219,12 @@ void test_individual_tags() {
       std::make_unique<FakeCreator>(std::unordered_map<std::string, size_t>{},
                                     1);
 
-  CHECK_THROWS_WITH(
-      control_error_tag::create_from_options<MetavarsEmpty>(holder,
-                                                            creator_error_0),
-      Catch::Contains("ObjectAExcisionSphere' or 'ObjectBExcisionSphere"));
+  CHECK_THROWS_WITH(control_error_tag::create_from_options<MetavarsEmpty>(
+                        holder, creator_error_0),
+                    Catch::Contains("ExcisionSphereA' or 'ExcisionSphereB"));
   CHECK_THROWS_WITH(control_error_tag2::create_from_options<MetavarsEmpty>(
                         holder2, creator_error_1),
-                    Catch::Contains("'ObjectBExcisionSphere'"));
+                    Catch::Contains("'ExcisionSphereB'"));
 
   using controller_tag = control_system::Tags::Controller<system>;
 

--- a/tests/Unit/Domain/Creators/Test_BinaryCompactObject.cpp
+++ b/tests/Unit/Domain/Creators/Test_BinaryCompactObject.cpp
@@ -248,7 +248,7 @@ void test_connectivity() {
         expected_excision_spheres{};
     if (excise_interiorA) {
       expected_excision_spheres.emplace(
-          "ObjectAExcisionSphere",
+          "ExcisionSphereA",
           ExcisionSphere<3>{
               inner_radius_objectA,
               tnsr::I<double, 3, Frame::Grid>{{xcoord_objectA, 0.0, 0.0}},
@@ -261,7 +261,7 @@ void test_connectivity() {
     }
     if (excise_interiorB) {
       expected_excision_spheres.emplace(
-          "ObjectBExcisionSphere",
+          "ExcisionSphereB",
           ExcisionSphere<3>{
               inner_radius_objectB,
               tnsr::I<double, 3, Frame::Grid>{{xcoord_objectB, 0.0, 0.0}},

--- a/tests/Unit/Domain/Creators/Test_CylindricalBinaryCompactObject.cpp
+++ b/tests/Unit/Domain/Creators/Test_CylindricalBinaryCompactObject.cpp
@@ -294,10 +294,10 @@ void test_connectivity_once(const bool with_sphere_e,
 
     CHECK(domain.excision_spheres().size() == 2);
     const auto& excision_sphere_a =
-        domain.excision_spheres().at("ObjectAExcisionSphere");
+        domain.excision_spheres().at("ExcisionSphereA");
     CHECK(excision_sphere_a.radius() == inner_radius_objectA);
     const auto& excision_sphere_b =
-        domain.excision_spheres().at("ObjectBExcisionSphere");
+        domain.excision_spheres().at("ExcisionSphereB");
     CHECK(excision_sphere_b.radius() == inner_radius_objectB);
     for (size_t i = 0; i < 3; ++i) {
       CHECK(excision_sphere_a.center().get(i) == center_objectA.at(i));

--- a/tests/Unit/Domain/Creators/Test_Shell.cpp
+++ b/tests/Unit/Domain/Creators/Test_Shell.cpp
@@ -345,7 +345,7 @@ void test_shell_construction(
   if (which_wedges == ShellWedges::All) {
     CHECK(domain.excision_spheres() ==
           std::unordered_map<std::string, ExcisionSphere<3>>{
-              {"CentralExcisionSphere",
+              {"ExcisionSphere",
                ExcisionSphere<3>{inner_radius,
                                  tnsr::I<double, 3, Frame::Grid>{0.},
                                  {{0, Direction<3>::lower_zeta()},

--- a/tests/Unit/Domain/Structure/Test_ExcisionSphere.cpp
+++ b/tests/Unit/Domain/Structure/Test_ExcisionSphere.cpp
@@ -113,7 +113,7 @@ void test_abutting_direction_shell() {
       const auto& initial_ref_levels = shell.initial_refinement_levels();
       const auto element_ids = initial_element_ids(initial_ref_levels);
       const auto excision_sphere =
-          shell_domain.excision_spheres().at("CentralExcisionSphere");
+          shell_domain.excision_spheres().at("ExcisionSphere");
       const auto& abutting_directions = excision_sphere.abutting_directions();
       size_t num_excision_neighbors = 0;
       const Mesh<2> face_mesh{10, Spectral::Basis::Legendre,

--- a/tests/Unit/Domain/Test_SurfaceJacobian.cpp
+++ b/tests/Unit/Domain/Test_SurfaceJacobian.cpp
@@ -85,7 +85,7 @@ void test_sphere_integral() {
     const auto& initial_ref_levels = shell.initial_refinement_levels();
     const auto element_ids = initial_element_ids(initial_ref_levels);
     const auto excision_sphere =
-        shell_domain.excision_spheres().at("CentralExcisionSphere");
+        shell_domain.excision_spheres().at("ExcisionSphere");
     const Mesh<2> face_mesh{10, Spectral::Basis::Legendre,
                             Spectral::Quadrature::GaussLobatto};
     double sphere_surface = 0.;

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/Test_Tags.cpp
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/Test_Tags.cpp
@@ -19,17 +19,17 @@ void test_excision_sphere_tag() {
       std::make_unique<domain::creators::Shell>(
           1., 2., 2, std::array<size_t, 2>{{4, 4}}, true);
   const auto shell_excision_sphere =
-      shell->create_domain().excision_spheres().at("CentralExcisionSphere");
+      shell->create_domain().excision_spheres().at("ExcisionSphere");
 
   CHECK(
       CurvedScalarWave::Worldtube::Tags::ExcisionSphere<3>::create_from_options(
-          shell, "CentralExcisionSphere") == shell_excision_sphere);
+          shell, "ExcisionSphere") == shell_excision_sphere);
   CHECK_THROWS_WITH(
       CurvedScalarWave::Worldtube::Tags::ExcisionSphere<3>::create_from_options(
           shell, "OtherExcisionSphere"),
       Catch::Matchers::Contains(
           "Specified excision sphere 'OtherExcisionSphere' not available. "
-          "Available excision spheres are: (CentralExcisionSphere)"));
+          "Available excision spheres are: (ExcisionSphere)"));
 }
 }  // namespace
 

--- a/tests/Unit/Helpers/ControlSystem/SystemHelpers.hpp
+++ b/tests/Unit/Helpers/ControlSystem/SystemHelpers.hpp
@@ -118,7 +118,7 @@ class FakeCreator : public DomainCreator<3> {
     std::unordered_map<std::string, ExcisionSphere<3>> excision_spheres{};
     if (number_of_excisions_ > 0) {
       excision_spheres.insert(
-          {"ObjectAExcisionSphere",
+          {"ExcisionSphereA",
            ExcisionSphere<3>{1.3,
                              tnsr::I<double, 3, Frame::Grid>{{+0.9, 0.0, 0.0}},
                              {{0, Direction<3>::lower_zeta()},
@@ -130,7 +130,7 @@ class FakeCreator : public DomainCreator<3> {
     }
     if (number_of_excisions_ > 1) {
       excision_spheres.insert(
-          {"ObjectBExcisionSphere",
+          {"ExcisionSphereB",
            ExcisionSphere<3>{0.8,
                              tnsr::I<double, 3, Frame::Grid>{{-1.1, 0.0, 0.0}},
                              {{0, Direction<3>::lower_zeta()},
@@ -601,7 +601,7 @@ struct SystemHelper {
     // have these specific names hard-coded into them.
     stored_excision_spheres_ =
         std::unordered_map<std::string, ExcisionSphere<3>>{
-            {"ObjectAExcisionSphere",
+            {"ExcisionSphereA",
              ExcisionSphere<3>{excision_radius,
                                tnsr::I<double, 3, Frame::Grid>{
                                    {+0.5 * initial_separation, 0.0, 0.0}},
@@ -611,7 +611,7 @@ struct SystemHelper {
                                 {3, Direction<3>::lower_zeta()},
                                 {4, Direction<3>::lower_zeta()},
                                 {5, Direction<3>::lower_zeta()}}}},
-            {"ObjectBExcisionSphere",
+            {"ExcisionSphereB",
              ExcisionSphere<3>{excision_radius,
                                tnsr::I<double, 3, Frame::Grid>{
                                    {-0.5 * initial_separation, 0.0, 0.0}},


### PR DESCRIPTION
## Proposed changes

Most other things have the convention ThingLabel, but the excision spheres were named ObjectLabelThing. This changes all occurrences of Object{A,B}ExcisionSphere to ExcisionSphere{A,B} and CentralExcisionSphere to just ExcisionSphere

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
