### PR TITLE
Have time steppers overwrite in update_u again

### DIFF
--- a/src/Evolution/Actions/RunEventsAndDenseTriggers.hpp
+++ b/src/Evolution/Actions/RunEventsAndDenseTriggers.hpp
@@ -247,12 +247,6 @@ struct RunEventsAndDenseTriggers {
 
             using history_tag = ::Tags::HistoryEvolvedVariables<variables_tag>;
             bool dense_output_succeeded = false;
-            // Restore the evolved variables if they have been
-            // previously altered so the time stepper starts in the
-            // correct state, then save them if they have not been
-            // previously altered.  (So one of these two lines is a
-            // no-op.)
-            variables_restorer.restore();
             variables_restorer.save();
             db::mutate<variables_tag>(
                 make_not_null(&box),

--- a/src/Time/TimeSteppers/AdamsBashforth.cpp
+++ b/src/Time/TimeSteppers/AdamsBashforth.cpp
@@ -198,7 +198,9 @@ void clean_history(const MutableUntypedHistory<T>& history) {
   while (history.size() > history.integration_order()) {
     history.pop_front();
   }
-  history.discard_value(history.back().time_step_id);
+  if (history.size() > 1) {
+    history.discard_value(history[history.size() - 2].time_step_id);
+  }
 }
 }  // namespace
 
@@ -257,7 +259,6 @@ bool AdamsBashforth::update_u_impl(
     const gsl::not_null<T*> u, const gsl::not_null<T*> u_error,
     const MutableUntypedHistory<T>& history, const TimeDelta& time_step) const {
   clean_history(history);
-  *u_error = *u;
   update_u_common(u, history, time_step, history.integration_order());
   // the error estimate is only useful once the history has enough elements to
   // do more than one order of step
@@ -294,6 +295,7 @@ void AdamsBashforth::update_u_common(const gsl::not_null<T*> u,
       get_coefficients(history_time_iterator(history_start),
                        history_time_iterator(history.end()), time_step);
 
+  *u = *history.back().value;
   auto coefficient = coefficients.rbegin();
   for (auto history_entry = history_start;
        history_entry != history.end();

--- a/src/Time/TimeSteppers/AdamsBashforth.cpp
+++ b/src/Time/TimeSteppers/AdamsBashforth.cpp
@@ -366,6 +366,11 @@ void AdamsBashforth::boundary_dense_output_impl(
     const gsl::not_null<T*> result,
     const TimeSteppers::BoundaryHistoryEvaluator<T>& coupling,
     const double time) const {
+  if ((coupling.local_end() - 1)->value() == time) {
+    // Nothing to do.  The requested time is the start of the step,
+    // which is the input value of `result`.
+    return;
+  }
   return boundary_impl(result, coupling, ApproximateTime{time});
 }
 

--- a/src/Time/TimeSteppers/RungeKutta.cpp
+++ b/src/Time/TimeSteppers/RungeKutta.cpp
@@ -110,9 +110,11 @@ void update_u_impl_with_tableau(const gsl::not_null<T*> u,
     if (history.size() > 1) {
       history.pop_front();
     }
-    history.discard_value(history.back().time_step_id);
+  } else if (history.substeps().size() == 1) {
+    history.discard_value(history.front().time_step_id);
   } else {
-    history.discard_value(history.substeps().back().time_step_id);
+    history.discard_value(
+        history.substeps()[history.substeps().size() - 2].time_step_id);
   }
   ASSERT(history.size() == 1, "Have more than one step after cleanup.");
 
@@ -125,12 +127,15 @@ void update_u_impl_with_tableau(const gsl::not_null<T*> u,
   if (substep == 0) {
     ASSERT(tableau.substep_coefficients[0].size() == 1,
            "First substep should use one derivative.");
-    *u += tableau.substep_coefficients[0][0] * dt * history.front().derivative;
+    *u = *history.front().value +
+         tableau.substep_coefficients[0][0] * dt * history.front().derivative;
   } else if (substep == number_of_substeps - 1) {
+    *u = *history.substeps().back().value;
     update_between_substeps(u, history, dt,
                             tableau.substep_coefficients[substep - 1],
                             tableau.result_coefficients);
   } else if (substep < number_of_substeps - 1) {
+    *u = *history.substeps().back().value;
     update_between_substeps(u, history, dt,
                             tableau.substep_coefficients[substep - 1],
                             tableau.substep_coefficients[substep]);
@@ -192,6 +197,7 @@ bool RungeKutta::dense_update_u_impl(const gsl::not_null<T*> u,
   if (time == step_end) {
     // Special case necessary for dense output at the initial time,
     // before taking a step.
+    *u = *history.back().value;
     return true;
   }
   const evolution_less<double> before{step_end > step_start};
@@ -206,6 +212,7 @@ bool RungeKutta::dense_update_u_impl(const gsl::not_null<T*> u,
 
   const auto& tableau = butcher_tableau();
 
+  *u = *history.back().value;
   // The Butcher dense output coefficients are given in terms of the
   // start of the step, but we are passed the value at the end of the
   // step, so we have to undo the step first.

--- a/src/Time/TimeSteppers/TimeStepper.hpp
+++ b/src/Time/TimeSteppers/TimeStepper.hpp
@@ -72,7 +72,7 @@ class TimeStepper : public PUP::able {
 #undef TIME_STEPPER_DECLARE_VIRTUALS_IMPL
   /// \endcond
 
-  /// Add the change for the current substep to u.
+  /// Set \p u to the value at the end of the current substep.
   ///
   /// Derived classes must implement this as a function with signature
   ///
@@ -90,8 +90,8 @@ class TimeStepper : public PUP::able {
                             time_step);
   }
 
-  /// Add the change for the current substep to u; report the error measure when
-  /// available.
+  /// Set \p u to the value at the end of the current substep; report the error
+  /// measure when available.
   ///
   /// For a substep method, the error measure will only be available on full
   /// steps. For a multistep method, the error measure will only be available

--- a/tests/Unit/Helpers/Time/TimeSteppers/TimeStepperTestUtils.cpp
+++ b/tests/Unit/Helpers/Time/TimeSteppers/TimeStepperTestUtils.cpp
@@ -42,6 +42,7 @@ void take_step(
        ++substep) {
     CHECK(time_id.substep() == substep);
     history->insert(time_id, *y, rhs(*y, time_id.substep_time().value()));
+    *y = std::numeric_limits<double>::signaling_NaN();
     stepper.update_u(y, history, step_size);
     time_id = stepper.next_time_id(time_id, step_size);
   }
@@ -60,6 +61,7 @@ void take_step_and_check_error(
        ++substep) {
     CHECK(time_id.substep() == substep);
     history->insert(time_id, *y, rhs(*y, time_id.substep_time().value()));
+    *y = std::numeric_limits<double>::signaling_NaN();
     bool error_updated = stepper.update_u(y, y_error, history, step_size);
     CAPTURE(substep);
     REQUIRE((substep == stepper.number_of_substeps_for_error() - 1) ==
@@ -454,6 +456,7 @@ void check_dense_output(const TimeStepper& stepper,
       auto step = step_size;
       for (;;) {
         history.insert(time_id, y, y);
+        y = std::numeric_limits<double>::signaling_NaN();
         if (not before((time_id.step_time() + step).value(), time)) {
           if (stepper.dense_update_u(make_not_null(&y), history, time)) {
             return y;


### PR DESCRIPTION
It turns out that it is sometimes difficult for the caller to determine the correct value to pass into the function.

This largely reverts bf4fd0a409c76996a104cb8750b4b9fb8e190c58.

Fixes #4399 

@geoffrey4444 This should remove the need for the dense output hack.  Can you test this and verify that your results look good?

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
