### PR TITLE
Add CharacteristicSpeedsOnStrahlkorper to ExcisionBoundary in EvolveGeneralizedHarmonicSingleBlackHole

### DIFF
--- a/src/ApparentHorizons/ComputeExcisionBoundaryVolumeQuantities.hpp
+++ b/src/ApparentHorizons/ComputeExcisionBoundaryVolumeQuantities.hpp
@@ -6,6 +6,7 @@
 #include <cstddef>
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/Tags.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
 #include "ParallelAlgorithms/Interpolation/Protocols/ComputeVarsToInterpolate.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
@@ -73,23 +74,25 @@ struct ComputeExcisionBoundaryVolumeQuantities
           invjac_logical_to_target,
       const tnsr::I<DataVector, 3, Frame::Inertial>& inertial_mesh_velocity);
 
-  using allowed_src_tags =
-      tmpl::list<gr::Tags::SpacetimeMetric<3, Frame::Inertial>,
-                 GeneralizedHarmonic::Tags::Pi<3, Frame::Inertial>,
-                 GeneralizedHarmonic::Tags::Phi<3, Frame::Inertial>,
-                 Tags::deriv<GeneralizedHarmonic::Tags::Phi<3, Frame::Inertial>,
-                             tmpl::size_t<3>, Frame::Inertial>>;
+  using allowed_src_tags = tmpl::list<
+      gr::Tags::SpacetimeMetric<3, Frame::Inertial>,
+      GeneralizedHarmonic::Tags::Pi<3, Frame::Inertial>,
+      GeneralizedHarmonic::Tags::Phi<3, Frame::Inertial>,
+      Tags::deriv<GeneralizedHarmonic::Tags::Phi<3, Frame::Inertial>,
+                  tmpl::size_t<3>, Frame::Inertial>,
+      GeneralizedHarmonic::ConstraintDamping::Tags::ConstraintGamma1>;
 
   using required_src_tags =
       tmpl::list<gr::Tags::SpacetimeMetric<3, Frame::Inertial>>;
 
   template <typename TargetFrame>
-  using allowed_dest_tags_target_frame =
-      tmpl::list<gr::Tags::SpatialMetric<3, Frame::Inertial>,
-                 gr::Tags::SpacetimeMetric<3, Frame::Inertial>,
-                 gr::Tags::Lapse<DataVector>,
-                 gr::Tags::Shift<3, Frame::Inertial>,
-                 gr::Tags::Shift<3, Frame::Grid>>;
+  using allowed_dest_tags_target_frame = tmpl::list<
+      gr::Tags::SpatialMetric<3, Frame::Inertial>,
+      gr::Tags::SpatialMetric<3, Frame::Grid>,
+      gr::Tags::SpacetimeMetric<3, Frame::Inertial>,
+      gr::Tags::Lapse<DataVector>, gr::Tags::Shift<3, Frame::Inertial>,
+      gr::Tags::Shift<3, Frame::Grid>,
+      GeneralizedHarmonic::ConstraintDamping::Tags::ConstraintGamma1>;
 
   template <typename TargetFrame>
   using allowed_dest_tags = tmpl::remove_duplicates<
@@ -97,8 +100,7 @@ struct ComputeExcisionBoundaryVolumeQuantities
                    allowed_dest_tags_target_frame<Frame::Inertial>>>;
 
   template <typename TargetFrame>
-  using required_dest_tags =
-      tmpl::list<gr::Tags::SpacetimeMetric<3, Frame::Inertial>>;
+  using required_dest_tags = tmpl::list<>;
 };
 
 }  // namespace ah

--- a/src/ApparentHorizons/ComputeExcisionBoundaryVolumeQuantities.tpp
+++ b/src/ApparentHorizons/ComputeExcisionBoundaryVolumeQuantities.tpp
@@ -76,12 +76,14 @@ void ComputeExcisionBoundaryVolumeQuantities::apply(
     gr::Tags::InverseSpatialMetric<3, Frame::Inertial>;
   using lapse_tag = gr::Tags::Lapse<DataVector>;
   using shift_tag = gr::Tags::Shift<3, Frame::Inertial>;
+  using constraint_gamma1_tag =
+    GeneralizedHarmonic::ConstraintDamping::Tags::ConstraintGamma1;
 
   // All of the temporary tags, including some that may be repeated
   // in the target_variables (for now).
   using full_temp_tags_list =
       tmpl::list<spatial_metric_tag, inv_spatial_metric_tag,
-                 lapse_tag, shift_tag>;
+                 lapse_tag, shift_tag, constraint_gamma1_tag>;
 
   // temp tags without variables that are already in DestTagList.
   using temp_tags_list =
@@ -97,6 +99,8 @@ void ComputeExcisionBoundaryVolumeQuantities::apply(
       target_vars, make_not_null(&buffer)));
   auto& inv_spatial_metric = *(get<inv_spatial_metric_tag>(
       target_vars, make_not_null(&buffer)));
+  auto& constraint_gamma1 = *(get<constraint_gamma1_tag>(
+      target_vars, make_not_null(&buffer)));
 
   // Actual computation starts here
 
@@ -107,6 +111,8 @@ void ComputeExcisionBoundaryVolumeQuantities::apply(
                           spatial_metric);
   gr::shift(make_not_null(&shift), spacetime_metric, inv_spatial_metric);
   gr::lapse(make_not_null(&lapse), shift, spacetime_metric);
+  constraint_gamma1 =
+  get<GeneralizedHarmonic::ConstraintDamping::Tags::ConstraintGamma1>(src_vars);
 }
 
 /// Dual frame case
@@ -123,7 +129,6 @@ void ComputeExcisionBoundaryVolumeQuantities::apply(
     const InverseJacobian<DataVector, 3, Frame::ElementLogical, TargetFrame>&
       /*invjac_logical_to_target*/,
     const tnsr::I<DataVector, 3, Frame::Inertial>& inertial_mesh_velocity) {
-
   static_assert(
       std::is_same_v<tmpl::list_difference<SrcTagList, allowed_src_tags>,
                      tmpl::list<>>,
@@ -157,6 +162,8 @@ void ComputeExcisionBoundaryVolumeQuantities::apply(
   using lapse_tag = gr::Tags::Lapse<DataVector>;
   using shift_tag = gr::Tags::Shift<3, TargetFrame>;
   using inertial_shift_tag = gr::Tags::Shift<3, Frame::Inertial>;
+  using constraint_gamma1_tag =
+    GeneralizedHarmonic::ConstraintDamping::Tags::ConstraintGamma1;
 
   // Additional temporary tags used for multiple frames
   using inertial_spatial_metric_tag =
@@ -170,7 +177,7 @@ void ComputeExcisionBoundaryVolumeQuantities::apply(
       tmpl::list<spatial_metric_tag, inv_spatial_metric_tag,
                  lapse_tag, shift_tag, inertial_shift_tag,
                  inertial_spatial_metric_tag,
-                 inertial_inv_spatial_metric_tag>;
+                 inertial_inv_spatial_metric_tag, constraint_gamma1_tag>;
 
   // temp tags without variables that are already in DestTagList.
   using temp_tags_list =
@@ -193,6 +200,8 @@ void ComputeExcisionBoundaryVolumeQuantities::apply(
   auto& spatial_metric = *(get<spatial_metric_tag>(
       target_vars, make_not_null(&buffer)));
   auto& inv_spatial_metric = *(get<inv_spatial_metric_tag>(
+      target_vars, make_not_null(&buffer)));
+  auto& constraint_gamma1 = *(get<constraint_gamma1_tag>(
       target_vars, make_not_null(&buffer)));
 
   // Actual computation starts here
@@ -236,6 +245,8 @@ void ComputeExcisionBoundaryVolumeQuantities::apply(
           (src.get(j) + inertial_mesh_velocity.get(j));
     }
   }
+  constraint_gamma1 =
+  get<GeneralizedHarmonic::ConstraintDamping::Tags::ConstraintGamma1>(src_vars);
 }
 
 }  // namespace ah

--- a/src/ApparentHorizons/ComputeHorizonVolumeQuantities.hpp
+++ b/src/ApparentHorizons/ComputeHorizonVolumeQuantities.hpp
@@ -6,6 +6,7 @@
 #include <cstddef>
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/Tags.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
 #include "ParallelAlgorithms/Interpolation/Protocols/ComputeVarsToInterpolate.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
@@ -79,7 +80,9 @@ struct ComputeHorizonVolumeQuantities
       GeneralizedHarmonic::Tags::Pi<3, Frame::Inertial>,
       GeneralizedHarmonic::Tags::Phi<3, Frame::Inertial>,
       ::Tags::deriv<GeneralizedHarmonic::Tags::Phi<3, Frame::Inertial>,
-                    tmpl::size_t<3>, Frame::Inertial>>;
+                    tmpl::size_t<3>, Frame::Inertial>,
+      GeneralizedHarmonic::ConstraintDamping::Tags::ConstraintGamma1>;
+
   using required_src_tags =
       tmpl::list<gr::Tags::SpacetimeMetric<3, Frame::Inertial>,
                  GeneralizedHarmonic::Tags::Pi<3, Frame::Inertial>,

--- a/src/Evolution/Systems/GeneralizedHarmonic/Characteristics.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Characteristics.cpp
@@ -214,6 +214,8 @@ void Tags::ComputeLargestCharacteristicSpeed<Dim, Frame>::function(
           mesh_velocity);                                                      \
   template struct GeneralizedHarmonic::CharacteristicSpeedsCompute<            \
       DIM(data), FRAME(data)>;                                                 \
+  template struct GeneralizedHarmonic::                                        \
+      CharacteristicSpeedsOnStrahlkorperCompute<DIM(data), FRAME(data)>;       \
   template void GeneralizedHarmonic::characteristic_fields(                    \
       const gsl::not_null<                                                     \
           typename GeneralizedHarmonic::Tags::CharacteristicFields<            \

--- a/src/ParallelAlgorithms/Interpolation/Callbacks/ObserveSurfaceData.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Callbacks/ObserveSurfaceData.hpp
@@ -90,11 +90,12 @@ struct ObserveSurfaceData
     // points on the surface).
     tmpl::for_each<TagsToObserve>([&box, &tensor_components](auto tag_v) {
       using Tag = tmpl::type_from<decltype(tag_v)>;
-      static_assert(std::is_same_v<typename Tag::type, Scalar<DataVector>>,
-                    "Each tag in TagsToObserve must be a Scalar<DataVector>. "
-                    "This could be generalized if needed; see the code comment "
-                    "above the static_assert.");
-      tensor_components.push_back({db::tag_name<Tag>(), get(get<Tag>(box))});
+      const auto tag_name = db::tag_name<Tag>();
+      const auto& tensor = get<Tag>(box);
+      for (size_t i = 0; i < tensor.size(); ++i) {
+        tensor_components.emplace_back(tag_name + tensor.component_suffix(i),
+                                       tensor[i]);
+      }
     });
 
     const std::string& surface_name =

--- a/tests/Unit/ApparentHorizons/Test_ComputeExcisionBoundaryVolumeQuantities.cpp
+++ b/tests/Unit/ApparentHorizons/Test_ComputeExcisionBoundaryVolumeQuantities.cpp
@@ -339,11 +339,13 @@ SPECTRE_TEST_CASE(
     // All possible tags.
   test_compute_excision_boundary_volume_quantities<
       std::false_type, Frame::Inertial,
-      tmpl::list<gr::Tags::SpacetimeMetric<3, Frame::Inertial>,
-                 GeneralizedHarmonic::Tags::Pi<3, Frame::Inertial>,
-                 GeneralizedHarmonic::Tags::Phi<3, Frame::Inertial>,
-                 Tags::deriv<GeneralizedHarmonic::Tags::Phi<3, Frame::Inertial>,
-                             tmpl::size_t<3>, Frame::Inertial>>,
+      tmpl::list<
+          gr::Tags::SpacetimeMetric<3, Frame::Inertial>,
+          GeneralizedHarmonic::Tags::Pi<3, Frame::Inertial>,
+          GeneralizedHarmonic::Tags::Phi<3, Frame::Inertial>,
+          Tags::deriv<GeneralizedHarmonic::Tags::Phi<3, Frame::Inertial>,
+                      tmpl::size_t<3>, Frame::Inertial>,
+          GeneralizedHarmonic::ConstraintDamping::Tags::ConstraintGamma1>,
       tmpl::list<gr::Tags::SpacetimeMetric<3, Frame::Inertial>,
                  gr::Tags::SpatialMetric<3, Frame::Inertial>,
                  gr::Tags::Lapse<DataVector>,
@@ -352,18 +354,22 @@ SPECTRE_TEST_CASE(
   // Leave out a few tags.
   test_compute_excision_boundary_volume_quantities<
       std::false_type, Frame::Inertial,
-      tmpl::list<gr::Tags::SpacetimeMetric<3, Frame::Inertial>,
-                 GeneralizedHarmonic::Tags::Pi<3, Frame::Inertial>,
-                 GeneralizedHarmonic::Tags::Phi<3, Frame::Inertial>>,
+      tmpl::list<
+          gr::Tags::SpacetimeMetric<3, Frame::Inertial>,
+          GeneralizedHarmonic::Tags::Pi<3, Frame::Inertial>,
+          GeneralizedHarmonic::Tags::Phi<3, Frame::Inertial>,
+          GeneralizedHarmonic::ConstraintDamping::Tags::ConstraintGamma1>,
       tmpl::list<gr::Tags::SpacetimeMetric<3, Frame::Inertial>,
                  gr::Tags::SpatialMetric<3, Frame::Inertial>,
                  gr::Tags::Lapse<DataVector>>>();
 
   test_compute_excision_boundary_volume_quantities<
       std::false_type, Frame::Inertial,
-      tmpl::list<gr::Tags::SpacetimeMetric<3, Frame::Inertial>,
-                 GeneralizedHarmonic::Tags::Pi<3, Frame::Inertial>,
-                 GeneralizedHarmonic::Tags::Phi<3, Frame::Inertial>>,
+      tmpl::list<
+          gr::Tags::SpacetimeMetric<3, Frame::Inertial>,
+          GeneralizedHarmonic::Tags::Pi<3, Frame::Inertial>,
+          GeneralizedHarmonic::Tags::Phi<3, Frame::Inertial>,
+          GeneralizedHarmonic::ConstraintDamping::Tags::ConstraintGamma1>,
       tmpl::list<gr::Tags::SpacetimeMetric<3, Frame::Inertial>,
                  gr::Tags::SpatialMetric<3, Frame::Inertial>,
                  gr::Tags::Shift<3, Frame::Inertial>>>();
@@ -372,11 +378,13 @@ SPECTRE_TEST_CASE(
   // All possible tags.
   test_compute_excision_boundary_volume_quantities<
       std::true_type, Frame::Grid,
-      tmpl::list<gr::Tags::SpacetimeMetric<3, Frame::Inertial>,
-                 GeneralizedHarmonic::Tags::Pi<3, Frame::Inertial>,
-                 GeneralizedHarmonic::Tags::Phi<3, Frame::Inertial>,
-                 Tags::deriv<GeneralizedHarmonic::Tags::Phi<3, Frame::Inertial>,
-                             tmpl::size_t<3>, Frame::Inertial>>,
+      tmpl::list<
+          gr::Tags::SpacetimeMetric<3, Frame::Inertial>,
+          GeneralizedHarmonic::Tags::Pi<3, Frame::Inertial>,
+          GeneralizedHarmonic::Tags::Phi<3, Frame::Inertial>,
+          Tags::deriv<GeneralizedHarmonic::Tags::Phi<3, Frame::Inertial>,
+                      tmpl::size_t<3>, Frame::Inertial>,
+          GeneralizedHarmonic::ConstraintDamping::Tags::ConstraintGamma1>,
       tmpl::list<gr::Tags::SpacetimeMetric<3, Frame::Inertial>,
                  gr::Tags::SpatialMetric<3, Frame::Inertial>,
                  gr::Tags::Lapse<DataVector>,
@@ -386,9 +394,11 @@ SPECTRE_TEST_CASE(
   // Leave out a few tags.
   test_compute_excision_boundary_volume_quantities<
       std::true_type, Frame::Grid,
-      tmpl::list<gr::Tags::SpacetimeMetric<3, Frame::Inertial>,
-                 GeneralizedHarmonic::Tags::Pi<3, Frame::Inertial>,
-                 GeneralizedHarmonic::Tags::Phi<3, Frame::Inertial>>,
+      tmpl::list<
+          gr::Tags::SpacetimeMetric<3, Frame::Inertial>,
+          GeneralizedHarmonic::Tags::Pi<3, Frame::Inertial>,
+          GeneralizedHarmonic::Tags::Phi<3, Frame::Inertial>,
+          GeneralizedHarmonic::ConstraintDamping::Tags::ConstraintGamma1>,
       tmpl::list<gr::Tags::SpacetimeMetric<3, Frame::Inertial>,
                  gr::Tags::SpatialMetric<3, Frame::Inertial>>>();
 }


### PR DESCRIPTION
## Proposed changes

Adds the CharacteristicSpeedsCompute tag to the `compute_items_on_target` list of tags to compute on the Target (ExcisionBoundary). Also changes the Lapse, shift, and spatial metric to being computed in the volume in the grid frame before interpolating to the target, instead of interpolating the Frame::Inertial quantities to the target and changing frames there.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
