### PR TITLE
CSW: Add `evolved_from_characteristic_fields` overload

### DIFF
--- a/src/Evolution/Systems/CurvedScalarWave/Characteristics.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Characteristics.hpp
@@ -213,6 +213,17 @@ void evolved_fields_from_characteristic_fields(
         unit_normal_one_form);
 
 template <size_t SpatialDim>
+void evolved_fields_from_characteristic_fields(
+    gsl::not_null<Scalar<DataVector>*> psi,
+    gsl::not_null<Scalar<DataVector>*> pi,
+    gsl::not_null<tnsr::i<DataVector, SpatialDim, Frame::Inertial>*> phi,
+    const Scalar<DataVector>& gamma_2, const Scalar<DataVector>& v_psi,
+    const tnsr::i<DataVector, SpatialDim, Frame::Inertial>& v_zero,
+    const Scalar<DataVector>& v_plus, const Scalar<DataVector>& v_minus,
+    const tnsr::i<DataVector, SpatialDim, Frame::Inertial>&
+        unit_normal_one_form);
+
+template <size_t SpatialDim>
 struct EvolvedFieldsFromCharacteristicFieldsCompute
     : Tags::EvolvedFieldsFromCharacteristicFields<SpatialDim>,
       db::ComputeTag {


### PR DESCRIPTION
Currently there are only overloads that return `Variables`. However, in the BoundaryConditions and many other places, you might want to compute the evolved fields from characteristic fields directly into the references that have been sliced in for you and this requires creating an extra `Variables`.
AFAIK there is no way to use references to avoid copies/allocations when using this function unless the allocations you have are contiguous.

This adds an overload that returns the evolved fields directly by reference.