### PR TITLE
Support grid point distributions in Interval domain creator, refactor tests

### DIFF
--- a/src/Domain/CoordinateMaps/Python/Bindings.cpp
+++ b/src/Domain/CoordinateMaps/Python/Bindings.cpp
@@ -3,6 +3,7 @@
 
 #include <pybind11/pybind11.h>
 
+#include "Domain/CoordinateMaps/Distribution.hpp"
 #include "Domain/CoordinateMaps/Python/CoordinateMap.hpp"
 
 namespace py = pybind11;
@@ -12,6 +13,11 @@ namespace domain {
 PYBIND11_MODULE(_PyCoordinateMaps, m) {  // NOLINT
   py::module_::import("spectre.DataStructures");
   py::module_::import("spectre.DataStructures.Tensor");
+  py::enum_<CoordinateMaps::Distribution>(m, "Distribution")
+      .value("Linear", CoordinateMaps::Distribution::Linear)
+      .value("Equiangular", CoordinateMaps::Distribution::Equiangular)
+      .value("Logarithmic", CoordinateMaps::Distribution::Logarithmic)
+      .value("Inverse", CoordinateMaps::Distribution::Inverse);
   // Order is important: The base class `CoordinateMap` needs to have its
   // bindings set up before the derived classes
   py_bindings::bind_coordinate_map(m);

--- a/src/Domain/Creators/Interval.cpp
+++ b/src/Domain/Creators/Interval.cpp
@@ -106,7 +106,9 @@ Domain<1> Interval::create_domain() const {
           CoordinateMaps::Affine{-1., 1., lower_x_[0], upper_x_[0]}),
       std::vector<std::array<size_t, 2>>{{{1, 2}}},
       is_periodic_in_x_[0] ? std::vector<PairOfFaces>{{{1}, {2}}}
-                           : std::vector<PairOfFaces>{}};
+                           : std::vector<PairOfFaces>{},
+      {},
+      block_names_};
   if (not time_dependence_->is_none()) {
     domain.inject_time_dependent_map_for_block(
         0, std::move(time_dependence_->block_maps_grid_to_inertial(1)[0]),

--- a/src/Domain/Creators/Interval.cpp
+++ b/src/Domain/Creators/Interval.cpp
@@ -8,18 +8,18 @@
 #include <utility>
 #include <vector>
 
-#include "Domain/Block.hpp"  // IWYU pragma: keep
+#include "Domain/Block.hpp"
 #include "Domain/BoundaryConditions/None.hpp"
 #include "Domain/BoundaryConditions/Periodic.hpp"
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.tpp"
-#include "Domain/Creators/DomainCreator.hpp"  // IWYU pragma: keep
+#include "Domain/Creators/DomainCreator.hpp"
 #include "Domain/Creators/TimeDependence/None.hpp"
 #include "Domain/Creators/TimeDependence/TimeDependence.hpp"
 #include "Domain/Domain.hpp"
 #include "Domain/DomainHelpers.hpp"
-#include "Domain/Structure/BlockNeighbor.hpp"  // IWYU pragma: keep
+#include "Domain/Structure/BlockNeighbor.hpp"
 #include "Domain/Structure/Direction.hpp"
 #include "Domain/Structure/DirectionMap.hpp"
 

--- a/src/Domain/Creators/Interval.hpp
+++ b/src/Domain/Creators/Interval.hpp
@@ -156,6 +156,8 @@ class Interval : public DomainCreator<1> {
           std::string,
           std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>> override;
 
+  std::vector<std::string> block_names() const override { return block_names_; }
+
  private:
   typename LowerBound::type lower_x_{};
   typename UpperBound::type upper_x_{};
@@ -168,6 +170,7 @@ class Interval : public DomainCreator<1> {
       upper_boundary_condition_;
   std::unique_ptr<domain::creators::time_dependence::TimeDependence<1>>
       time_dependence_;
+  inline static std::vector<std::string> block_names_{"Interval"};
 };
 }  // namespace creators
 }  // namespace domain

--- a/src/Domain/Creators/Interval.hpp
+++ b/src/Domain/Creators/Interval.hpp
@@ -118,9 +118,9 @@ class Interval : public DomainCreator<1> {
   Interval(std::array<double, 1> lower_x, std::array<double, 1> upper_x,
            std::array<size_t, 1> initial_refinement_level_x,
            std::array<size_t, 1> initial_number_of_grid_points_in_x,
-           std::array<bool, 1> is_periodic_in_x,
+           std::array<bool, 1> is_periodic_in_x = {{false}},
            std::unique_ptr<domain::creators::time_dependence::TimeDependence<1>>
-               time_dependence);
+               time_dependence = nullptr);
 
   Interval(std::array<double, 1> lower_x, std::array<double, 1> upper_x,
            std::array<size_t, 1> initial_refinement_level_x,
@@ -130,7 +130,7 @@ class Interval : public DomainCreator<1> {
            std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
                upper_boundary_condition,
            std::unique_ptr<domain::creators::time_dependence::TimeDependence<1>>
-               time_dependence,
+               time_dependence = nullptr,
            const Options::Context& context = {});
 
   Interval() = default;

--- a/src/Domain/Creators/Interval.hpp
+++ b/src/Domain/Creators/Interval.hpp
@@ -13,7 +13,7 @@
 
 #include "Domain/BoundaryConditions/BoundaryCondition.hpp"
 #include "Domain/BoundaryConditions/GetBoundaryConditionsBase.hpp"
-#include "Domain/Creators/DomainCreator.hpp"  // IWYU pragma: keep
+#include "Domain/Creators/DomainCreator.hpp"
 #include "Domain/Creators/TimeDependence/TimeDependence.hpp"
 #include "Domain/Domain.hpp"
 #include "Domain/Structure/DirectionMap.hpp"

--- a/src/Domain/Creators/Interval.hpp
+++ b/src/Domain/Creators/Interval.hpp
@@ -9,14 +9,20 @@
 #include <array>
 #include <cstddef>
 #include <memory>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "Domain/BoundaryConditions/BoundaryCondition.hpp"
 #include "Domain/BoundaryConditions/GetBoundaryConditionsBase.hpp"
+#include "Domain/CoordinateMaps/Distribution.hpp"
 #include "Domain/Creators/DomainCreator.hpp"
 #include "Domain/Creators/TimeDependence/TimeDependence.hpp"
 #include "Domain/Domain.hpp"
 #include "Domain/Structure/DirectionMap.hpp"
+#include "Options/Auto.hpp"
 #include "Options/Options.hpp"
 #include "Utilities/MakeArray.hpp"
 #include "Utilities/TMPL.hpp"
@@ -24,7 +30,7 @@
 /// \cond
 namespace domain {
 namespace CoordinateMaps {
-class Affine;
+class Interval;
 }  // namespace CoordinateMaps
 
 template <typename SourceFrame, typename TargetFrame, typename... Maps>
@@ -39,7 +45,7 @@ class Interval : public DomainCreator<1> {
  public:
   using maps_list =
       tmpl::list<domain::CoordinateMap<Frame::BlockLogical, Frame::Inertial,
-                                       CoordinateMaps::Affine>>;
+                                       CoordinateMaps::Interval>>;
 
   struct LowerBound {
     using type = std::array<double, 1>;
@@ -50,6 +56,22 @@ class Interval : public DomainCreator<1> {
     using type = std::array<double, 1>;
     static constexpr Options::String help = {
         "Sequence of [x] for upper bounds."};
+  };
+  struct Distribution {
+    using type = CoordinateMaps::Distribution;
+    static constexpr Options::String help = {"Distribution of grid points"};
+  };
+  struct Singularity {
+    using type = Options::Auto<double, Options::AutoLabel::None>;
+    static constexpr Options::String help = {
+        "Position of coordinate singularity. Must be outside the domain. "
+        "Required for 'Logarithmic' and 'Inverse' grid point distributions. "
+        "Set to 'None' otherwise. "
+        "A singularity position close to the lower or upper bound of the "
+        "interval leads to very small grid spacing near that end, and "
+        "placing the singularity further away from the domain increases the "
+        "grid spacing. See the documentation of "
+        "'domain::CoordinateMap::Distribution' for details."};
   };
   struct IsPeriodicIn {
     using type = std::array<bool, 1>;
@@ -111,7 +133,7 @@ class Interval : public DomainCreator<1> {
               typename Metavariables::system>,
           options_boundary_conditions<typename Metavariables::system>,
           options_periodic>,
-      tmpl::list<TimeDependence>>;
+      tmpl::list<Distribution, Singularity, TimeDependence>>;
 
   static constexpr Options::String help = {"Creates a 1D interval."};
 
@@ -119,8 +141,12 @@ class Interval : public DomainCreator<1> {
            std::array<size_t, 1> initial_refinement_level_x,
            std::array<size_t, 1> initial_number_of_grid_points_in_x,
            std::array<bool, 1> is_periodic_in_x = {{false}},
+           CoordinateMaps::Distribution distribution =
+               CoordinateMaps::Distribution::Linear,
+           std::optional<double> singularity = std::nullopt,
            std::unique_ptr<domain::creators::time_dependence::TimeDependence<1>>
-               time_dependence = nullptr);
+               time_dependence = nullptr,
+           const Options::Context& context = {});
 
   Interval(std::array<double, 1> lower_x, std::array<double, 1> upper_x,
            std::array<size_t, 1> initial_refinement_level_x,
@@ -129,6 +155,9 @@ class Interval : public DomainCreator<1> {
                lower_boundary_condition,
            std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
                upper_boundary_condition,
+           CoordinateMaps::Distribution distribution =
+               CoordinateMaps::Distribution::Linear,
+           std::optional<double> singularity = std::nullopt,
            std::unique_ptr<domain::creators::time_dependence::TimeDependence<1>>
                time_dependence = nullptr,
            const Options::Context& context = {});
@@ -161,6 +190,8 @@ class Interval : public DomainCreator<1> {
  private:
   typename LowerBound::type lower_x_{};
   typename UpperBound::type upper_x_{};
+  CoordinateMaps::Distribution distribution_{};
+  std::optional<double> singularity_{};
   typename IsPeriodicIn::type is_periodic_in_x_{};
   typename InitialRefinement::type initial_refinement_level_x_{};
   typename InitialGridPoints::type initial_number_of_grid_points_in_x_{};

--- a/src/Domain/Creators/Python/Bindings.cpp
+++ b/src/Domain/Creators/Python/Bindings.cpp
@@ -19,6 +19,7 @@ namespace domain::creators {
 
 PYBIND11_MODULE(_PyDomainCreators, m) {  // NOLINT
   py::module_::import("spectre.Domain");
+  py::module_::import("spectre.Domain.CoordinateMaps");
   domain::creators::register_derived_with_charm();
   domain::creators::time_dependence::register_derived_with_charm();
   // Order is important: The base class `DomainCreator` needs to have its

--- a/src/Domain/Creators/Python/CMakeLists.txt
+++ b/src/Domain/Creators/Python/CMakeLists.txt
@@ -42,5 +42,6 @@ spectre_python_link_libraries(
 
 spectre_python_add_dependencies(
   ${LIBRARY}
+  PyCoordinateMaps
   PyDomain
   )

--- a/src/Domain/Creators/Python/Interval.cpp
+++ b/src/Domain/Creators/Python/Interval.cpp
@@ -5,10 +5,12 @@
 
 #include <array>
 #include <cstddef>
+#include <optional>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 #include <string>
 
+#include "Domain/CoordinateMaps/Distribution.hpp"
 #include "Domain/Creators/DomainCreator.hpp"
 #include "Domain/Creators/Interval.hpp"
 
@@ -17,24 +19,16 @@ namespace py = pybind11;
 namespace domain::creators::py_bindings {
 void bind_interval(py::module& m) {
   py::class_<Interval, DomainCreator<1>>(m, "Interval")
-      .def(
-          py::init(
-              [](const std::array<double, 1> lower_x,
-                 const std::array<double, 1> upper_x,
-                 const std::array<size_t, 1> initial_refinement_level_x,
-                 const std::array<size_t, 1> initial_number_of_grid_points_in_x,
-                 const std::array<bool, 1> is_periodic_in_x) {
-                return domain::creators::Interval{
-                    lower_x,
-                    upper_x,
-                    initial_refinement_level_x,
-                    initial_number_of_grid_points_in_x,
-                    is_periodic_in_x,
-                    nullptr};
-              }),
-          py::arg("lower_x"), py::arg("upper_x"),
-          py::arg("initial_refinement_level_x"),
-          py::arg("initial_number_of_grid_points_in_x"),
-          py::arg("is_periodic_in_x"));
+      .def(py::init<std::array<double, 1>, std::array<double, 1>,
+                    std::array<size_t, 1>, std::array<size_t, 1>,
+                    std::array<bool, 1>, domain::CoordinateMaps::Distribution,
+                    std::optional<double>>(),
+           py::arg("lower_x"), py::arg("upper_x"),
+           py::arg("initial_refinement_level_x"),
+           py::arg("initial_number_of_grid_points_in_x"),
+           py::arg("is_periodic_in_x") = std::array<bool, 1>{{false}},
+           py::arg("distribution") =
+               domain::CoordinateMaps::Distribution::Linear,
+           py::arg("singularity") = std::nullopt);
 }
 }  // namespace domain::creators::py_bindings

--- a/tests/InputFiles/Burgers/Step.yaml
+++ b/tests/InputFiles/Burgers/Step.yaml
@@ -33,6 +33,8 @@ DomainCreator:
   Interval:
     LowerBound: [-1.0]
     UpperBound: [1.0]
+    Distribution: Linear
+    Singularity: None
     InitialRefinement: [2]
     InitialGridPoints: [7]
     TimeDependence: None

--- a/tests/InputFiles/CurvedScalarWave/PlaneWaveMinkowski1D.yaml
+++ b/tests/InputFiles/CurvedScalarWave/PlaneWaveMinkowski1D.yaml
@@ -40,6 +40,8 @@ DomainCreator:
   Interval:
     LowerBound: [0.0]
     UpperBound: [6.283185307179586]
+    Distribution: Linear
+    Singularity: None
     InitialRefinement: [1]
     InitialGridPoints: [5]
     TimeDependence: None

--- a/tests/InputFiles/ExampleExecutables/RandomAmr1D.yaml
+++ b/tests/InputFiles/ExampleExecutables/RandomAmr1D.yaml
@@ -8,6 +8,8 @@ DomainCreator:
   Interval:
     LowerBound: [-0.5]
     UpperBound: [6.5]
+    Distribution: Linear
+    Singularity: None
     InitialRefinement: [2]
     InitialGridPoints: [2]
     TimeDependence: None

--- a/tests/InputFiles/ExportCoordinates/Input1D.yaml
+++ b/tests/InputFiles/ExportCoordinates/Input1D.yaml
@@ -14,6 +14,8 @@ DomainCreator:
   Interval:
     LowerBound: [0]
     UpperBound: [1]
+    Distribution: Linear
+    Singularity: None
     IsPeriodicIn: [false]
     InitialRefinement: [1]
     InitialGridPoints: [3]

--- a/tests/InputFiles/NewtonianEuler/RiemannProblem1D.yaml
+++ b/tests/InputFiles/NewtonianEuler/RiemannProblem1D.yaml
@@ -19,6 +19,8 @@ DomainCreator:
   Interval:
     LowerBound: [-0.25]
     UpperBound: [0.75]
+    Distribution: Linear
+    Singularity: None
     InitialRefinement: [1]
     InitialGridPoints: [2]
     TimeDependence: None

--- a/tests/InputFiles/Poisson/ProductOfSinusoids1D.yaml
+++ b/tests/InputFiles/Poisson/ProductOfSinusoids1D.yaml
@@ -31,6 +31,8 @@ DomainCreator:
   Interval:
     LowerBound: [-1.570796326794896]
     UpperBound: [3.141592653589793]
+    Distribution: Linear
+    Singularity: None
     InitialRefinement: [1]
     InitialGridPoints: [4]
     TimeDependence: None

--- a/tests/InputFiles/RelativisticEuler/Valencia/SmoothFlow1D.yaml
+++ b/tests/InputFiles/RelativisticEuler/Valencia/SmoothFlow1D.yaml
@@ -19,6 +19,8 @@ DomainCreator:
   Interval:
     LowerBound: [0.0]
     UpperBound: [0.1]
+    Distribution: Linear
+    Singularity: None
     InitialRefinement: [1]
     InitialGridPoints: [4]
     TimeDependence: None

--- a/tests/InputFiles/ScalarAdvection/Krivodonova1D.yaml
+++ b/tests/InputFiles/ScalarAdvection/Krivodonova1D.yaml
@@ -20,6 +20,8 @@ DomainCreator:
   Interval:
     LowerBound: [-1.0]
     UpperBound: [1.0]
+    Distribution: Linear
+    Singularity: None
     InitialRefinement: [2]
     InitialGridPoints: [5]
     TimeDependence: None

--- a/tests/InputFiles/ScalarAdvection/Sinusoid1D.yaml
+++ b/tests/InputFiles/ScalarAdvection/Sinusoid1D.yaml
@@ -20,6 +20,8 @@ DomainCreator:
   Interval:
     LowerBound: [-1.0]
     UpperBound: [1.0]
+    Distribution: Linear
+    Singularity: None
     InitialRefinement: [2]
     InitialGridPoints: [5]
     TimeDependence: None

--- a/tests/InputFiles/ScalarWave/PlaneWave1DEventsAndTriggersExample.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave1DEventsAndTriggersExample.yaml
@@ -35,6 +35,8 @@ DomainCreator:
   Interval:
     LowerBound: [0.0]
     UpperBound: [6.283185307179586]
+    Distribution: Linear
+    Singularity: None
     InitialRefinement: [0]
     InitialGridPoints: [2]
     TimeDependence: None

--- a/tests/InputFiles/ScalarWave/PlaneWave1DObserveExample.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave1DObserveExample.yaml
@@ -41,6 +41,8 @@ DomainCreator:
   Interval:
     LowerBound: [0.0]
     UpperBound: [6.283185307179586]
+    Distribution: Linear
+    Singularity: None
     InitialRefinement: [2]
     InitialGridPoints: [7]
     TimeDependence:

--- a/tests/Unit/Domain/Creators/Python/Test_Interval.py
+++ b/tests/Unit/Domain/Creators/Python/Test_Interval.py
@@ -2,6 +2,7 @@
 # See LICENSE.txt for details.
 
 from spectre.Domain.Creators import Interval, DomainCreator1D
+from spectre.Domain.CoordinateMaps import Distribution
 import unittest
 
 
@@ -9,6 +10,8 @@ class TestInterval(unittest.TestCase):
     def test_construction(self):
         interval = Interval(lower_x=[1.],
                             upper_x=[2.],
+                            distribution=Distribution.Linear,
+                            singularity=None,
                             is_periodic_in_x=[False],
                             initial_refinement_level_x=[1],
                             initial_number_of_grid_points_in_x=[3])

--- a/tests/Unit/Domain/Creators/Test_BinaryCompactObject.cpp
+++ b/tests/Unit/Domain/Creators/Test_BinaryCompactObject.cpp
@@ -452,9 +452,7 @@ void test_bbh_time_dependent_factory(const bool with_boundary_conditions,
                                with_boundary_conditions));
     }
   }();
-  const std::array<double, 3> times_to_check{{0.0, 0.7, 1.6}};
 
-  constexpr double initial_time = 0.0;
   constexpr double expected_time = 1.0;  // matches InitialTime: 1.0 above
   constexpr double expected_initial_function_value =
       1.0;  // hard-coded in BinaryCompactObject.cpp
@@ -523,37 +521,12 @@ void test_bbh_time_dependent_factory(const bool with_boundary_conditions,
               rotation_name,
               {expected_time, quaternion_coefs, rotation_angle_coefs,
                initial_expiration_times[rotation_name]}});
-  std::unordered_map<std::string,
-                     std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
-      functions_of_time{};
-  functions_of_time[expansion_name] =
-      std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<2>>(
-          initial_time, expansion_factor_coefs,
-          initial_expiration_times[expansion_name]);
-  functions_of_time["ExpansionOuterBoundary"] =
-      std::make_unique<domain::FunctionsOfTime::FixedSpeedCubic>(
-          expected_initial_function_value, initial_time,
-          expected_asymptotic_velocity_outer_boundary,
-          expected_decay_timescale_outer_boundary_velocity);
-  functions_of_time[rotation_name] =
-      std::make_unique<domain::FunctionsOfTime::QuaternionFunctionOfTime<3>>(
-          initial_time, quaternion_coefs, rotation_angle_coefs,
-          initial_expiration_times[rotation_name]);
-  functions_of_time[size_a_name] =
-      std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<3>>(
-          initial_time, lambda_factor_a0_coefs,
-          initial_expiration_times[size_a_name]);
-  functions_of_time[size_b_name] =
-      std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<3>>(
-          initial_time, lambda_factor_b0_coefs,
-          initial_expiration_times[size_b_name]);
 
+  const std::vector<double> times_to_check{{1., 10.}};
   const auto domain = TestHelpers::domain::creators::test_domain_creator(
-      *binary_compact_object, with_boundary_conditions);
+      *binary_compact_object, with_boundary_conditions, false, times_to_check);
   for (const double time : times_to_check) {
     CAPTURE(time);
-    test_det_jac_positive(domain.blocks(), time, functions_of_time);
-    test_physical_separation(domain.blocks(), time, functions_of_time);
     TestHelpers::domain::creators::test_functions_of_time(
         *binary_compact_object, expected_functions_of_time,
         with_control_systems ? initial_expiration_times : ExpirationTimeMap{});

--- a/tests/Unit/Domain/Creators/Test_CylindricalBinaryCompactObject.cpp
+++ b/tests/Unit/Domain/Creators/Test_CylindricalBinaryCompactObject.cpp
@@ -448,12 +448,10 @@ void test_bbh_time_dependent_factory(const bool with_boundary_conditions,
           create_option_string(true, false, false, with_boundary_conditions));
     }
   }();
+  const std::vector<double> times_to_check{{1., 10.}};
   const auto domain = TestHelpers::domain::creators::test_domain_creator(
-      *binary_compact_object, with_boundary_conditions);
+      *binary_compact_object, with_boundary_conditions, false, times_to_check);
 
-  const std::array<double, 3> times_to_check{{0.0, 0.7, 1.6}};
-
-  constexpr double initial_time = 0.0;
   constexpr double expected_time = 1.0;  // matches InitialTime: 1.0 above
 
   constexpr double expected_initial_outer_boundary_function_value =
@@ -511,28 +509,8 @@ void test_bbh_time_dependent_factory(const bool with_boundary_conditions,
                initial_rotation_angle_coefs,
                initial_expiration_times[rotation_name]}});
 
-  // Initial functions of time, evaluated at initial_time.
-  std::unordered_map<std::string,
-                     std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
-      functions_of_time{};
-  functions_of_time[expansion_name] =
-      std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<2>>(
-          initial_time, initial_expansion_factor_coefs,
-          initial_expiration_times[expansion_name]);
-  functions_of_time[expansion_name + "OuterBoundary"] =
-      std::make_unique<domain::FunctionsOfTime::FixedSpeedCubic>(
-          expected_initial_outer_boundary_function_value, initial_time,
-          expected_asymptotic_velocity_outer_boundary,
-          expected_decay_timescale_outer_boundary_velocity);
-  functions_of_time[rotation_name] =
-      std::make_unique<domain::FunctionsOfTime::QuaternionFunctionOfTime<3>>(
-          initial_time, initial_quaternion_coefs, initial_rotation_angle_coefs,
-          initial_expiration_times[rotation_name]);
-
   for (const double time : times_to_check) {
     CAPTURE(time);
-    test_det_jac_positive(domain.blocks(), time, functions_of_time);
-    test_physical_separation(domain.blocks(), time, functions_of_time);
     TestHelpers::domain::creators::test_functions_of_time(
         *binary_compact_object, expected_functions_of_time,
         with_control_systems ? initial_expiration_times : ExpirationTimeMap{});

--- a/tests/Unit/Domain/Creators/Test_Interval.cpp
+++ b/tests/Unit/Domain/Creators/Test_Interval.cpp
@@ -11,7 +11,7 @@
 #include <vector>
 
 #include "DataStructures/Tensor/Tensor.hpp"
-#include "Domain/Block.hpp"  // IWYU pragma: keep
+#include "Domain/Block.hpp"
 #include "Domain/BoundaryConditions/BoundaryCondition.hpp"
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
@@ -25,7 +25,7 @@
 #include "Domain/Creators/TimeDependence/RegisterDerivedWithCharm.hpp"
 #include "Domain/Domain.hpp"
 #include "Domain/FunctionsOfTime/PiecewisePolynomial.hpp"
-#include "Domain/Structure/BlockNeighbor.hpp"  // IWYU pragma: keep
+#include "Domain/Structure/BlockNeighbor.hpp"
 #include "Domain/Structure/Direction.hpp"
 #include "Domain/Structure/DirectionMap.hpp"
 #include "Domain/Structure/OrientationMap.hpp"

--- a/tests/Unit/Domain/Creators/Test_Interval.cpp
+++ b/tests/Unit/Domain/Creators/Test_Interval.cpp
@@ -58,8 +58,9 @@ void test_interval_construction(
     const bool expect_boundary_conditions = false,
     const std::unordered_map<std::string, double>& initial_expiration_times =
         {}) {
+  const std::vector<double> times{1.};
   const auto domain = TestHelpers::domain::creators::test_domain_creator(
-      interval, expect_boundary_conditions);
+      interval, expect_boundary_conditions, false, times);
 
   CHECK(interval.initial_extents() == expected_extents);
   CHECK(interval.initial_refinement_levels() == expected_refinement_level);

--- a/tests/Unit/Domain/Creators/Test_Interval.cpp
+++ b/tests/Unit/Domain/Creators/Test_Interval.cpp
@@ -49,6 +49,7 @@ void test_interval_construction(const creators::Interval& domain_creator,
   CHECK(domain.excision_spheres().empty());
 
   const auto& block = blocks[0];
+  CHECK(block.name() == "Interval");
   const auto& external_boundaries = block.external_boundaries();
   CHECK(external_boundaries.size() == (is_periodic ? 0 : 2));
 

--- a/tests/Unit/Domain/Creators/Test_RotatedIntervals.cpp
+++ b/tests/Unit/Domain/Creators/Test_RotatedIntervals.cpp
@@ -59,8 +59,9 @@ void test_rotated_intervals_construction(
     const bool is_periodic = false,
     const std::unordered_map<std::string, double>& initial_expiration_times =
         {}) {
+  const std::vector<double> times{1.};
   const auto domain = TestHelpers::domain::creators::test_domain_creator(
-      rotated_intervals, expect_boundary_conditions, is_periodic);
+      rotated_intervals, expect_boundary_conditions, is_periodic, times);
 
   CHECK(rotated_intervals.initial_extents() == expected_extents);
   CHECK(rotated_intervals.initial_refinement_levels() ==

--- a/tests/Unit/Domain/Creators/Test_Shell.cpp
+++ b/tests/Unit/Domain/Creators/Test_Shell.cpp
@@ -98,8 +98,9 @@ void test_shell_construction(
     const bool expect_boundary_conditions = false,
     const std::unordered_map<std::string, double>& initial_expiration_times =
         {}) {
+  const std::vector<double> times{1.};
   const auto domain = TestHelpers::domain::creators::test_domain_creator(
-      shell, expect_boundary_conditions);
+      shell, expect_boundary_conditions, false, times);
   TestHelpers::domain::creators::test_functions_of_time(
       shell, expected_functions_of_time, initial_expiration_times);
 

--- a/tests/Unit/Elliptic/Actions/Test_InitializeBackgroundFields.cpp
+++ b/tests/Unit/Elliptic/Actions/Test_InitializeBackgroundFields.cpp
@@ -83,8 +83,8 @@ SPECTRE_TEST_CASE("Unit.Elliptic.Actions.InitializeBackgroundFields",
   domain::creators::register_derived_with_charm();
   // Which element we work with does not matter for this test
   const ElementId<1> element_id{0, {{SegmentId{2, 1}}}};
-  const domain::creators::Interval domain_creator{{{-0.5}}, {{1.5}},   {{2}},
-                                                  {{4}},    {{false}}, nullptr};
+  const domain::creators::Interval domain_creator{
+      {{-0.5}}, {{1.5}}, {{2}}, {{4}}};
 
   using element_array = ElementArray<Metavariables>;
   ActionTesting::MockRuntimeSystem<Metavariables> runner{

--- a/tests/Unit/Elliptic/Actions/Test_InitializeFields.cpp
+++ b/tests/Unit/Elliptic/Actions/Test_InitializeFields.cpp
@@ -111,8 +111,8 @@ SPECTRE_TEST_CASE("Unit.Elliptic.Actions.InitializeFields",
   Parallel::register_factory_classes_with_charm<Metavariables>();
   // Which element we work with does not matter for this test
   const ElementId<1> element_id{0, {{SegmentId{2, 1}}}};
-  const domain::creators::Interval domain_creator{{{-0.5}}, {{1.5}},   {{2}},
-                                                  {{4}},    {{false}}, nullptr};
+  const domain::creators::Interval domain_creator{
+      {{-0.5}}, {{1.5}}, {{2}}, {{4}}};
 
   using element_array = ElementArray<Metavariables>;
   ActionTesting::MockRuntimeSystem<Metavariables> runner{

--- a/tests/Unit/Elliptic/Actions/Test_InitializeFixedSources.cpp
+++ b/tests/Unit/Elliptic/Actions/Test_InitializeFixedSources.cpp
@@ -108,8 +108,8 @@ SPECTRE_TEST_CASE("Unit.Elliptic.Actions.InitializeFixedSources",
   Parallel::register_factory_classes_with_charm<Metavariables>();
   // Which element we work with does not matter for this test
   const ElementId<1> element_id{0, {{SegmentId{2, 1}}}};
-  const domain::creators::Interval domain_creator{{{-0.5}}, {{1.5}},   {{2}},
-                                                  {{4}},    {{false}}, nullptr};
+  const domain::creators::Interval domain_creator{
+      {{-0.5}}, {{1.5}}, {{2}}, {{4}}};
 
   using element_array = ElementArray<Metavariables>;
   ActionTesting::MockRuntimeSystem<Metavariables> runner{tuples::TaggedTuple<

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/Actions/Test_InitializeDomain.cpp
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/Actions/Test_InitializeDomain.cpp
@@ -67,7 +67,7 @@ SPECTRE_TEST_CASE("Unit.ParallelDG.InitializeDomain", "[Unit][Actions]") {
     // [ |X| | ]-> xi
     const ElementId<1> element_id{0, {{SegmentId{2, 1}}}};
     const domain::creators::Interval domain_creator{
-        {{-0.5}}, {{1.5}}, {{2}}, {{4}}, {{false}}, nullptr};
+        {{-0.5}}, {{1.5}}, {{2}}, {{4}}};
     // Register the coordinate map for serialization
     PUPable_reg(
         SINGLE_ARG(domain::CoordinateMap<Frame::BlockLogical, Frame::Inertial,

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/Actions/Test_InitializeDomain.cpp
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/Actions/Test_InitializeDomain.cpp
@@ -16,6 +16,7 @@
 #include "Domain/Creators/Brick.hpp"
 #include "Domain/Creators/Interval.hpp"
 #include "Domain/Creators/Rectangle.hpp"
+#include "Domain/Creators/RegisterDerivedWithCharm.hpp"
 #include "Domain/Creators/Tags/Domain.hpp"
 #include "Domain/Creators/Tags/InitialExtents.hpp"
 #include "Domain/Creators/Tags/InitialRefinementLevels.hpp"
@@ -69,9 +70,7 @@ SPECTRE_TEST_CASE("Unit.ParallelDG.InitializeDomain", "[Unit][Actions]") {
     const domain::creators::Interval domain_creator{
         {{-0.5}}, {{1.5}}, {{2}}, {{4}}};
     // Register the coordinate map for serialization
-    PUPable_reg(
-        SINGLE_ARG(domain::CoordinateMap<Frame::BlockLogical, Frame::Inertial,
-                                         domain::CoordinateMaps::Affine>));
+    domain::creators::register_derived_with_charm();
 
     using metavariables = Metavariables<1>;
     using element_array = ElementArray<1, metavariables>;

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/SubdomainOperator/Test_SubdomainOperator.cpp
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/SubdomainOperator/Test_SubdomainOperator.cpp
@@ -689,8 +689,7 @@ SPECTRE_TEST_CASE("Unit.Elliptic.DG.SubdomainOperator", "[Unit][Elliptic]") {
           make_boundary_condition<system>(
               elliptic::BoundaryConditionType::Dirichlet),
           make_boundary_condition<system>(
-              elliptic::BoundaryConditionType::Neumann),
-          nullptr};
+              elliptic::BoundaryConditionType::Neumann)};
       for (const bool use_massive_dg_operator : {false, true}) {
         test_subdomain_operator<system>(domain_creator,
                                         use_massive_dg_operator);

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_DgOperator.cpp
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_DgOperator.cpp
@@ -445,8 +445,7 @@ SPECTRE_TEST_CASE("Unit.Elliptic.DG.Operator", "[Unit][Elliptic]") {
               elliptic::BoundaryConditionType::Dirichlet),
           std::make_unique<
               elliptic::BoundaryConditions::AnalyticSolution<system>>(
-              elliptic::BoundaryConditionType::Neumann),
-          nullptr};
+              elliptic::BoundaryConditionType::Neumann)};
       const ElementId<1> left_id{0, {{{2, 0}}}};
       const ElementId<1> midleft_id{0, {{{2, 1}}}};
       const ElementId<1> midright_id{0, {{{2, 2}}}};
@@ -527,8 +526,7 @@ SPECTRE_TEST_CASE("Unit.Elliptic.DG.Operator", "[Unit][Elliptic]") {
               elliptic::BoundaryConditionType::Dirichlet),
           std::make_unique<
               elliptic::BoundaryConditions::AnalyticSolution<system>>(
-              elliptic::BoundaryConditionType::Neumann),
-          nullptr};
+              elliptic::BoundaryConditionType::Neumann)};
       Approx analytic_solution_aux_approx =
           Approx::custom().epsilon(1.e-8).scale(M_PI);
       Approx analytic_solution_operator_approx =

--- a/tests/Unit/Evolution/Systems/Burgers/FiniteDifference/Test_BoundaryConditionGhostData.cpp
+++ b/tests/Unit/Evolution/Systems/Burgers/FiniteDifference/Test_BoundaryConditionGhostData.cpp
@@ -90,7 +90,7 @@ void test(const BoundaryConditionType& boundary_condition) {
   const auto interval = domain::creators::Interval(
       lower_x, upper_x, refinement_level_x, number_of_grid_points_in_x,
       std::make_unique<BoundaryConditionType>(boundary_condition),
-      std::make_unique<BoundaryConditionType>(boundary_condition), nullptr);
+      std::make_unique<BoundaryConditionType>(boundary_condition));
   auto domain = interval.create_domain();
   auto boundary_conditions = interval.external_boundary_conditions();
   const auto element = domain::Initialization::create_initial_element(

--- a/tests/Unit/Helpers/Domain/BoundaryConditions/BoundaryCondition.cpp
+++ b/tests/Unit/Helpers/Domain/BoundaryConditions/BoundaryCondition.cpp
@@ -1,12 +1,16 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
+#include "Framework/TestingFramework.hpp"
+
 #include "Helpers/Domain/BoundaryConditions/BoundaryCondition.hpp"
 
 #include <cstddef>
 #include <memory>
 #include <pup.h>
+#include <vector>
 
+#include "Domain/Structure/DirectionMap.hpp"
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
@@ -90,6 +94,27 @@ bool operator!=(const TestBoundaryCondition<Dim>& lhs,
 template <size_t Dim>
 PUP::able::PUP_ID TestBoundaryCondition<Dim>::my_PUP_ID = 0;  // NOLINT
 
+template <size_t Dim>
+void test_boundary_conditions(
+    const std::vector<DirectionMap<
+        Dim, std::unique_ptr<::domain::BoundaryConditions::BoundaryCondition>>>&
+        all_boundary_conditions) {
+  for (size_t block_id = 0; block_id < all_boundary_conditions.size();
+       ++block_id) {
+    const auto& boundary_conditions = all_boundary_conditions[block_id];
+    for (const auto& [direction, boundary_condition] : boundary_conditions) {
+      CAPTURE(direction);
+      const auto test_bc =
+          dynamic_cast<const TestHelpers::domain::BoundaryConditions::
+                           TestBoundaryCondition<Dim>*>(
+              boundary_condition.get());
+      REQUIRE(test_bc != nullptr);
+      CHECK(test_bc->direction() == direction);
+      CHECK(test_bc->block_id() == block_id);
+    }
+  }
+}
+
 void register_derived_with_charm() {
   Parallel::register_derived_classes_with_charm<BoundaryConditionBase<1>>();
   Parallel::register_derived_classes_with_charm<BoundaryConditionBase<2>>();
@@ -104,7 +129,11 @@ void register_derived_with_charm() {
   template bool operator==(const TestBoundaryCondition<DIM(data)>& lhs,  \
                            const TestBoundaryCondition<DIM(data)>& rhs); \
   template bool operator!=(const TestBoundaryCondition<DIM(data)>& lhs,  \
-                           const TestBoundaryCondition<DIM(data)>& rhs);
+                           const TestBoundaryCondition<DIM(data)>& rhs); \
+  template void test_boundary_conditions(                                \
+      const std::vector<DirectionMap<                                    \
+          DIM(data), std::unique_ptr<                                    \
+                         ::domain::BoundaryConditions::BoundaryCondition>>>&);
 
 GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
 

--- a/tests/Unit/Helpers/Domain/BoundaryConditions/CMakeLists.txt
+++ b/tests/Unit/Helpers/Domain/BoundaryConditions/CMakeLists.txt
@@ -3,7 +3,7 @@
 
 set(LIBRARY "DomainBoundaryConditionsHelpers")
 
-add_spectre_library(${LIBRARY})
+add_spectre_library(${LIBRARY} ${SPECTRE_TEST_LIBS_TYPE})
 
 spectre_target_sources(
   ${LIBRARY}
@@ -21,9 +21,13 @@ spectre_target_headers(
 target_link_libraries(
   ${LIBRARY}
   PUBLIC
+  Domain
   DomainBoundaryConditions
+  DomainCreators
   DomainStructure
   Options
   Parallel
   Utilities
+  PRIVATE
+  Framework
   )

--- a/tests/Unit/IO/Importers/Test_VolumeDataReaderAlgorithm1D.yaml
+++ b/tests/Unit/IO/Importers/Test_VolumeDataReaderAlgorithm1D.yaml
@@ -5,6 +5,8 @@ SourceDomainCreator:
   Interval:
     LowerBound: [0]
     UpperBound: [4]
+    Distribution: Linear
+    Singularity: None
     IsPeriodicIn: [False]
     InitialRefinement: [2]
     InitialGridPoints: [8]
@@ -15,6 +17,8 @@ TargetDomainCreator:
   Interval:
     LowerBound: [-1]
     UpperBound: [3]
+    Distribution: Linear
+    Singularity: None
     IsPeriodicIn: [False]
     InitialRefinement: [1]
     InitialGridPoints: [6]

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_IrregularInterpolant.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_IrregularInterpolant.cpp
@@ -272,8 +272,7 @@ Domain<2> create_domain<2>(const double length,
 template <>
 Domain<1> create_domain<1>(const double length,
                            const std::array<size_t, 1>& extents) {
-  const domain::creators::Interval creator{{{0.0}}, {{length}}, {{0}},
-                                           extents, {{false}},  nullptr};
+  const domain::creators::Interval creator{{{0.0}}, {{length}}, {{0}}, extents};
   return creator.create_domain();
 }
 

--- a/tests/Unit/ParallelAlgorithms/Events/Test_ObserveVolumeIntegrals.cpp
+++ b/tests/Unit/ParallelAlgorithms/Events/Test_ObserveVolumeIntegrals.cpp
@@ -187,8 +187,7 @@ std::unique_ptr<DomainCreator<SpatialDim>> domain_creator();
 template <>
 std::unique_ptr<DomainCreator<1>> domain_creator() {
   return std::make_unique<domain::creators::Interval>(
-      domain::creators::Interval({{-0.5}}, {{0.5}}, {{0}}, {{4}}, {{false}},
-                                 nullptr));
+      domain::creators::Interval({{-0.5}}, {{0.5}}, {{0}}, {{4}}));
 }
 
 template <>

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolationTargetSpecifiedPoints.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolationTargetSpecifiedPoints.cpp
@@ -65,8 +65,8 @@ void test_1d() {
           "Points: [[1.0], [0.3]]");
   CHECK(created_opts == points_opts);
 
-  const auto domain_creator = domain::creators::Interval(
-      {{-1.0}}, {{1.0}}, {{1}}, {{3}}, {{false}}, nullptr);
+  const auto domain_creator =
+      domain::creators::Interval({{-1.0}}, {{1.0}}, {{1}}, {{3}});
 
   const auto expected_block_coord_holders = [&domain_creator]() {
     tnsr::I<DataVector, 1, Frame::Inertial> points;

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_ObserveLineSegment.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_ObserveLineSegment.cpp
@@ -484,8 +484,8 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.ObserveLineSegment",
   domain::creators::register_derived_with_charm();
   MAKE_GENERATOR(generator);
 
-  const auto interval = domain::creators::Interval({{0.}}, {{4.}}, {{1}},
-                                                   {{12}}, {{true}}, nullptr);
+  const auto interval =
+      domain::creators::Interval({{0.}}, {{4.}}, {{1}}, {{12}}, {{true}});
   const auto disk = domain::creators::Disk(0.9, 4.9, 1, {{12, 12}}, false);
   const auto shell = domain::creators::Shell(0.9, 4.9, 1, {{12, 12}}, false);
 

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/ConjugateGradient/Test_DistributedConjugateGradientAlgorithm.yaml
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/ConjugateGradient/Test_DistributedConjugateGradientAlgorithm.yaml
@@ -19,6 +19,8 @@ DomainCreator:
   Interval:
     LowerBound: [0]
     UpperBound: [3.141592653589793]
+    Distribution: Linear
+    Singularity: None
     IsPeriodicIn: [false]
     InitialRefinement: [1]
     InitialGridPoints: [3]

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/Test_DistributedGmresAlgorithm.yaml
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/Test_DistributedGmresAlgorithm.yaml
@@ -20,6 +20,8 @@ DomainCreator:
   Interval:
     LowerBound: [0]
     UpperBound: [3.141592653589793]
+    Distribution: Linear
+    Singularity: None
     IsPeriodicIn: [false]
     InitialRefinement: [1]
     InitialGridPoints: [3]

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/Test_DistributedGmresPreconditionedAlgorithm.yaml
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/Test_DistributedGmresPreconditionedAlgorithm.yaml
@@ -21,6 +21,8 @@ DomainCreator:
   Interval:
     LowerBound: [0]
     UpperBound: [3.141592653589793]
+    Distribution: Linear
+    Singularity: None
     IsPeriodicIn: [false]
     InitialRefinement: [1]
     InitialGridPoints: [3]

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Multigrid/Test_MultigridAlgorithm.yaml
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Multigrid/Test_MultigridAlgorithm.yaml
@@ -22,6 +22,8 @@ DomainCreator:
   Interval:
     LowerBound: [0]
     UpperBound: [3.141592653589793]
+    Distribution: Linear
+    Singularity: None
     IsPeriodicIn: [false]
     InitialRefinement: [1]
     InitialGridPoints: [3]

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Multigrid/Test_MultigridAlgorithmMassive.yaml
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Multigrid/Test_MultigridAlgorithmMassive.yaml
@@ -13,6 +13,8 @@ DomainCreator:
   Interval:
     LowerBound: [0]
     UpperBound: [3.141592653589793]
+    Distribution: Linear
+    Singularity: None
     IsPeriodicIn: [false]
     InitialRefinement: [1]
     InitialGridPoints: [3]

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Multigrid/Test_MultigridPreconditionedGmresAlgorithm.yaml
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Multigrid/Test_MultigridPreconditionedGmresAlgorithm.yaml
@@ -12,6 +12,8 @@ DomainCreator:
   Interval:
     LowerBound: [0]
     UpperBound: [3.141592653589793]
+    Distribution: Linear
+    Singularity: None
     IsPeriodicIn: [false]
     InitialRefinement: [1]
     InitialGridPoints: [3]

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Richardson/Test_DistributedRichardsonAlgorithm.yaml
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Richardson/Test_DistributedRichardsonAlgorithm.yaml
@@ -19,6 +19,8 @@ DomainCreator:
   Interval:
     LowerBound: [0]
     UpperBound: [3.141592653589793]
+    Distribution: Linear
+    Singularity: None
     IsPeriodicIn: [false]
     InitialRefinement: [1]
     InitialGridPoints: [3]

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Schwarz/Test_SchwarzAlgorithm.yaml
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Schwarz/Test_SchwarzAlgorithm.yaml
@@ -20,6 +20,8 @@ DomainCreator:
   Interval:
     LowerBound: [0]
     UpperBound: [3.141592653589793]
+    Distribution: Linear
+    Singularity: None
     IsPeriodicIn: [false]
     InitialRefinement: [1]
     InitialGridPoints: [3]


### PR DESCRIPTION
## Proposed changes

Add logarithmic and inverse grid point distributions to the `Interval` domain creator. I'm using this to debug the elliptic DG operator at large outer radii.

Also refactor tests in the spirit of #4408.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
If you use the 1D `Interval` domain creator, add the `Distribution: Linear` and `Singularity: None` options to keep the previous behavior. The `Interval` domain creator now supports logarithmic and inverse grid point distributions as well.
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
