### PR TITLE
Remove intermediate cubed shell in BBH domain

### DIFF
--- a/tests/InputFiles/ExportCoordinates/InputTimeDependent3D.yaml
+++ b/tests/InputFiles/ExportCoordinates/InputTimeDependent3D.yaml
@@ -29,13 +29,11 @@ DomainCreator:
       XCoord: -7.683
       ExciseInterior: true
       UseLogarithmicMap: true
-    EnvelopingCube:
+    Envelope:
       Radius: 100.0
       UseProjectiveMap: false
-      Sphericity: 1.0
     OuterShell:
-      InnerRadius: Auto
-      OuterRadius: 300.0
+      Radius: 300.0
       RadialDistribution: Linear
     UseEquiangularMap: True
     InitialRefinement:
@@ -43,7 +41,7 @@ DomainCreator:
       ObjectBShell:   [1, 1, 1]
       ObjectACube:    [1, 1, 0]
       ObjectBCube:    [1, 1, 0]
-      EnvelopingCube: [1, 1, 1]
+      Envelope: [1, 1, 1]
       OuterShell:     [1, 1, 1]
     InitialGridPoints: 3
     TimeDependentMaps:

--- a/tests/InputFiles/GeneralizedHarmonic/BinaryBlackHole.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/BinaryBlackHole.yaml
@@ -61,13 +61,11 @@ DomainCreator:
         ExciseWithBoundaryCondition:
           DemandOutgoingCharSpeeds:
       UseLogarithmicMap: true
-    EnvelopingCube:
+    Envelope:
       Radius: 100.0
       UseProjectiveMap: true
-      Sphericity: 0.0
     OuterShell:
-      InnerRadius: Auto
-      OuterRadius: 1493.0
+      Radius: 1493.0
       RadialDistribution: Logarithmic
       BoundaryCondition:
         ConstraintPreservingBjorhus:
@@ -78,8 +76,7 @@ DomainCreator:
       ObjectACube:    [2, 2, 1]
       ObjectBShell:   [3, 3, 4]
       ObjectBCube:    [2, 2, 1]
-      EnvelopingCube: [2, 2, 3]
-      CubedShell:     [2, 2, 2]
+      Envelope:       [2, 2, 3]
       OuterShell:     [2, 2, 5]
     InitialGridPoints: 5
     TimeDependentMaps:

--- a/tests/InputFiles/Xcts/BinaryBlackHole.yaml
+++ b/tests/InputFiles/Xcts/BinaryBlackHole.yaml
@@ -54,13 +54,11 @@ DomainCreator:
             Lapse: *kerr_left
             NegativeExpansion: *kerr_left
       UseLogarithmicMap: True
-    EnvelopingCube:
+    Envelope:
       Radius: 60.
       UseProjectiveMap: True
-      Sphericity: 1.
     OuterShell:
-      InnerRadius: Auto
-      OuterRadius: 300.
+      Radius: 300.
       RadialDistribution: Inverse
       BoundaryCondition: Flatness
     UseEquiangularMap: True
@@ -72,16 +70,16 @@ DomainCreator:
       ObjectBShell:               [1, 1, 1]
       ObjectACube:                [1, 1, 1]
       ObjectBCube:                [1, 1, 1]
-      EnvelopingCubeUpperZLeft:   [1, 1, 1]
-      EnvelopingCubeLowerZLeft:   [1, 1, 1]
-      EnvelopingCubeUpperYLeft:   [1, 1, 1]
-      EnvelopingCubeLowerYLeft:   [1, 1, 1]
-      EnvelopingCubeLowerX:       [1, 1, 1]
-      EnvelopingCubeUpperZRight:  [1, 1, 1]
-      EnvelopingCubeLowerZRight:  [1, 1, 1]
-      EnvelopingCubeUpperYRight:  [1, 1, 1]
-      EnvelopingCubeLowerYRight:  [1, 1, 1]
-      EnvelopingCubeUpperX:       [1, 1, 1]
+      EnvelopeUpperZLeft:         [1, 1, 1]
+      EnvelopeLowerZLeft:         [1, 1, 1]
+      EnvelopeUpperYLeft:         [1, 1, 1]
+      EnvelopeLowerYLeft:         [1, 1, 1]
+      EnvelopeLowerX:             [1, 1, 1]
+      EnvelopeUpperZRight:        [1, 1, 1]
+      EnvelopeLowerZRight:        [1, 1, 1]
+      EnvelopeUpperYRight:        [1, 1, 1]
+      EnvelopeLowerYRight:        [1, 1, 1]
+      EnvelopeUpperX:             [1, 1, 1]
       OuterShellUpperZLeft:       [0, 1, 0]
       OuterShellLowerZLeft:       [0, 1, 0]
       OuterShellUpperYLeft:       [0, 1, 0]
@@ -99,7 +97,7 @@ DomainCreator:
       ObjectBShell:   [6, 6, 10]
       ObjectACube:    [6, 6, 7]
       ObjectBCube:    [6, 6, 7]
-      EnvelopingCube: [6, 6, 6]
+      Envelope:       [6, 6, 6]
       OuterShell:     [6, 6, 6]
 
 Discretization:

--- a/tests/InputFiles/Xcts/HeadOnBns.yaml
+++ b/tests/InputFiles/Xcts/HeadOnBns.yaml
@@ -44,13 +44,11 @@ DomainCreator:
       XCoord: *x_left
       Interior: Auto
       UseLogarithmicMap: False
-    EnvelopingCube:
+    Envelope:
       Radius: 120.
       UseProjectiveMap: True
-      Sphericity: 1.
     OuterShell:
-      InnerRadius: Auto
-      OuterRadius: 600.
+      Radius: 600.
       RadialDistribution: Inverse
       BoundaryCondition: Flatness
     UseEquiangularMap: True
@@ -64,16 +62,16 @@ DomainCreator:
       ObjectBShell:               [1, 1, 1]
       ObjectACube:                [1, 1, 1]
       ObjectBCube:                [1, 1, 1]
-      EnvelopingCubeUpperZLeft:   [1, 1, 0]
-      EnvelopingCubeLowerZLeft:   [1, 1, 0]
-      EnvelopingCubeUpperYLeft:   [1, 1, 0]
-      EnvelopingCubeLowerYLeft:   [1, 1, 0]
-      EnvelopingCubeLowerX:       [1, 1, 0]
-      EnvelopingCubeUpperZRight:  [1, 1, 0]
-      EnvelopingCubeLowerZRight:  [1, 1, 0]
-      EnvelopingCubeUpperYRight:  [1, 1, 0]
-      EnvelopingCubeLowerYRight:  [1, 1, 0]
-      EnvelopingCubeUpperX:       [1, 1, 0]
+      EnvelopeUpperZLeft:         [1, 1, 0]
+      EnvelopeLowerZLeft:         [1, 1, 0]
+      EnvelopeUpperYLeft:         [1, 1, 0]
+      EnvelopeLowerYLeft:         [1, 1, 0]
+      EnvelopeLowerX:             [1, 1, 0]
+      EnvelopeUpperZRight:        [1, 1, 0]
+      EnvelopeLowerZRight:        [1, 1, 0]
+      EnvelopeUpperYRight:        [1, 1, 0]
+      EnvelopeLowerYRight:        [1, 1, 0]
+      EnvelopeUpperX:             [1, 1, 0]
       OuterShellUpperZLeft:       [0, 1, 0]
       OuterShellLowerZLeft:       [0, 1, 0]
       OuterShellUpperYLeft:       [0, 1, 0]
@@ -93,7 +91,7 @@ DomainCreator:
       ObjectBShell:    [4, 4, 5]
       ObjectACube:     [4, 4, 5]
       ObjectBCube:     [4, 4, 5]
-      EnvelopingCube:  [4, 4, 4]
+      Envelope:        [4, 4, 4]
       OuterShell:      [4, 4, 3]
 
 Discretization:

--- a/tests/Unit/Domain/Creators/Test_BinaryCompactObject.cpp
+++ b/tests/Unit/Domain/Creators/Test_BinaryCompactObject.cpp
@@ -97,13 +97,9 @@ void test_connectivity() {
   constexpr double outer_radius_objectB = 1.0;
   constexpr double xcoord_objectB = -3.0;
 
-  // Enveloping Cube:
-  constexpr double radius_enveloping_cube = 25.5;
+  // Envelope:
+  constexpr double envelope_radius = 25.5;
   constexpr bool use_projective_map = true;
-  constexpr double sphericity_enveloping_cube = 0.5;
-
-  // Enveloping sphere:
-  const std::optional<double> radius_enveloping_sphere = std::nullopt;
 
   // Outer shell:
   constexpr double outer_radius = 32.4;
@@ -129,8 +125,7 @@ void test_connectivity() {
         {"ObjectACube", {{1, 1, 1}}},
         {"ObjectBShell", {{1, 1, 1}}},
         {"ObjectBCube", {{1, 1, 1}}},
-        {"EnvelopingCube", {{1, 1, 1}}},
-        {"CubedShell", {{1, 1, 1}}},
+        {"Envelope", {{1, 1, 1}}},
         // Add some radial refinement in outer shell
         {"OuterShell", {{1, 1, 4}}}};
     if (not excise_interiorA) {
@@ -156,14 +151,12 @@ void test_connectivity() {
                                           : nullptr})
                                 : std::nullopt,
                false},
-        radius_enveloping_cube,
+        envelope_radius,
         outer_radius,
         refinement,
         grid_points,
         use_equiangular_map,
         use_projective_map,
-        sphericity_enveloping_cube,
-        radius_enveloping_sphere,
         radial_distribution_outer_shell,
         with_boundary_conditions ? create_outer_boundary_condition() : nullptr};
 
@@ -171,33 +164,28 @@ void test_connectivity() {
         binary_compact_object, with_boundary_conditions);
 
     std::vector<std::string> expected_block_names{
-        "ObjectAShellUpperZ",       "ObjectAShellLowerZ",
-        "ObjectAShellUpperY",       "ObjectAShellLowerY",
-        "ObjectAShellUpperX",       "ObjectAShellLowerX",
-        "ObjectACubeUpperZ",        "ObjectACubeLowerZ",
-        "ObjectACubeUpperY",        "ObjectACubeLowerY",
-        "ObjectACubeUpperX",        "ObjectACubeLowerX",
-        "ObjectBShellUpperZ",       "ObjectBShellLowerZ",
-        "ObjectBShellUpperY",       "ObjectBShellLowerY",
-        "ObjectBShellUpperX",       "ObjectBShellLowerX",
-        "ObjectBCubeUpperZ",        "ObjectBCubeLowerZ",
-        "ObjectBCubeUpperY",        "ObjectBCubeLowerY",
-        "ObjectBCubeUpperX",        "ObjectBCubeLowerX",
-        "EnvelopingCubeUpperZLeft", "EnvelopingCubeUpperZRight",
-        "EnvelopingCubeLowerZLeft", "EnvelopingCubeLowerZRight",
-        "EnvelopingCubeUpperYLeft", "EnvelopingCubeUpperYRight",
-        "EnvelopingCubeLowerYLeft", "EnvelopingCubeLowerYRight",
-        "EnvelopingCubeUpperX",     "EnvelopingCubeLowerX",
-        "CubedShellUpperZLeft",     "CubedShellUpperZRight",
-        "CubedShellLowerZLeft",     "CubedShellLowerZRight",
-        "CubedShellUpperYLeft",     "CubedShellUpperYRight",
-        "CubedShellLowerYLeft",     "CubedShellLowerYRight",
-        "CubedShellUpperX",         "CubedShellLowerX",
-        "OuterShellUpperZLeft",     "OuterShellUpperZRight",
-        "OuterShellLowerZLeft",     "OuterShellLowerZRight",
-        "OuterShellUpperYLeft",     "OuterShellUpperYRight",
-        "OuterShellLowerYLeft",     "OuterShellLowerYRight",
-        "OuterShellUpperX",         "OuterShellLowerX"};
+        "ObjectAShellUpperZ",   "ObjectAShellLowerZ",
+        "ObjectAShellUpperY",   "ObjectAShellLowerY",
+        "ObjectAShellUpperX",   "ObjectAShellLowerX",
+        "ObjectACubeUpperZ",    "ObjectACubeLowerZ",
+        "ObjectACubeUpperY",    "ObjectACubeLowerY",
+        "ObjectACubeUpperX",    "ObjectACubeLowerX",
+        "ObjectBShellUpperZ",   "ObjectBShellLowerZ",
+        "ObjectBShellUpperY",   "ObjectBShellLowerY",
+        "ObjectBShellUpperX",   "ObjectBShellLowerX",
+        "ObjectBCubeUpperZ",    "ObjectBCubeLowerZ",
+        "ObjectBCubeUpperY",    "ObjectBCubeLowerY",
+        "ObjectBCubeUpperX",    "ObjectBCubeLowerX",
+        "EnvelopeUpperZLeft",   "EnvelopeUpperZRight",
+        "EnvelopeLowerZLeft",   "EnvelopeLowerZRight",
+        "EnvelopeUpperYLeft",   "EnvelopeUpperYRight",
+        "EnvelopeLowerYLeft",   "EnvelopeLowerYRight",
+        "EnvelopeUpperX",       "EnvelopeLowerX",
+        "OuterShellUpperZLeft", "OuterShellUpperZRight",
+        "OuterShellLowerZLeft", "OuterShellLowerZRight",
+        "OuterShellUpperYLeft", "OuterShellUpperYRight",
+        "OuterShellLowerYLeft", "OuterShellLowerYRight",
+        "OuterShellUpperX",     "OuterShellLowerX"};
     std::unordered_map<std::string, std::unordered_set<std::string>>
         expected_block_groups{
             {"ObjectAShell",
@@ -214,18 +202,11 @@ void test_connectivity() {
             {"ObjectBCube",
              {"ObjectBCubeLowerY", "ObjectBCubeLowerZ", "ObjectBCubeUpperY",
               "ObjectBCubeUpperX", "ObjectBCubeUpperZ", "ObjectBCubeLowerX"}},
-            {"EnvelopingCube",
-             {"EnvelopingCubeUpperZRight", "EnvelopingCubeUpperX",
-              "EnvelopingCubeLowerZLeft", "EnvelopingCubeLowerZRight",
-              "EnvelopingCubeUpperYRight", "EnvelopingCubeLowerYRight",
-              "EnvelopingCubeUpperYLeft", "EnvelopingCubeUpperZLeft",
-              "EnvelopingCubeLowerYLeft", "EnvelopingCubeLowerX"}},
-            {"CubedShell",
-             {"CubedShellUpperZLeft", "CubedShellUpperZRight",
-              "CubedShellLowerZLeft", "CubedShellLowerZRight",
-              "CubedShellUpperYLeft", "CubedShellUpperYRight",
-              "CubedShellLowerYLeft", "CubedShellLowerYRight",
-              "CubedShellUpperX", "CubedShellLowerX"}},
+            {"Envelope",
+             {"EnvelopeUpperZRight", "EnvelopeUpperX", "EnvelopeLowerZLeft",
+              "EnvelopeLowerZRight", "EnvelopeUpperYRight",
+              "EnvelopeLowerYRight", "EnvelopeUpperYLeft", "EnvelopeUpperZLeft",
+              "EnvelopeLowerYLeft", "EnvelopeLowerX"}},
             {"OuterShell",
              {"OuterShellUpperZLeft", "OuterShellUpperZRight",
               "OuterShellLowerZLeft", "OuterShellLowerZRight",
@@ -270,32 +251,6 @@ void test_connectivity() {
     }
     CHECK(domain.excision_spheres() == expected_excision_spheres);
 
-    // Also check whether the radius of the inner boundary of Layer 5 is
-    // chosen correctly.
-    // Compute the radius of a point in the grid frame on this boundary.
-    // Block 44 is one block whose -zeta face is on this boundary.
-    const auto map{domain.blocks()[44].stationary_map().get_clone()};
-    tnsr::I<double, 3, Frame::BlockLogical> logical_point(
-        std::array<double, 3>{{0.0, 0.0, -1.0}});
-    const double layer_5_inner_radius =
-        get(magnitude(std::move(map)->operator()(logical_point)));
-    // The number of radial divisions in layers 4 and 5, excluding those
-    // resulting from InitialRefinement > 0.
-    const double radial_divisions_in_outer_layers = 9;
-    if (radial_distribution_outer_shell == Distribution::Logarithmic) {
-      CHECK(layer_5_inner_radius / radius_enveloping_cube ==
-            approx(pow(outer_radius / radius_enveloping_cube,
-                       1.0 / radial_divisions_in_outer_layers)));
-    } else if (radial_distribution_outer_shell == Distribution::Inverse) {
-      CHECK(layer_5_inner_radius / radius_enveloping_cube ==
-            approx(outer_radius /
-                   (outer_radius - (outer_radius - radius_enveloping_cube) /
-                                       radial_divisions_in_outer_layers)));
-    } else {
-      CHECK(layer_5_inner_radius - radius_enveloping_cube ==
-            approx((outer_radius - radius_enveloping_cube) /
-                   radial_divisions_in_outer_layers));
-    }
     if (with_boundary_conditions) {
       using PeriodicBc = TestHelpers::domain::BoundaryConditions::
           TestPeriodicBoundaryCondition<3>;
@@ -312,9 +267,8 @@ void test_connectivity() {
                                          create_inner_boundary_condition()})
                                    : std::nullopt,
                   false},
-              radius_enveloping_cube, outer_radius, refinement, grid_points,
+              envelope_radius, outer_radius, refinement, grid_points,
               use_equiangular_map, use_projective_map,
-              sphericity_enveloping_cube, radius_enveloping_sphere,
               radial_distribution_outer_shell, std::make_unique<PeriodicBc>(),
               Options::Context{false, {}, 1, 1}),
           Catch::Matchers::Contains("Cannot have periodic boundary "
@@ -334,9 +288,8 @@ void test_connectivity() {
                                               std::make_unique<PeriodicBc>()})
                                         : std::nullopt,
                        false},
-                radius_enveloping_cube, outer_radius, refinement, grid_points,
+                envelope_radius, outer_radius, refinement, grid_points,
                 use_equiangular_map, use_projective_map,
-                sphericity_enveloping_cube, radius_enveloping_sphere,
                 radial_distribution_outer_shell,
                 create_outer_boundary_condition(),
                 Options::Context{false, {}, 1, 1}),
@@ -356,9 +309,8 @@ void test_connectivity() {
                                            create_inner_boundary_condition()})
                                      : std::nullopt,
                     false},
-                radius_enveloping_cube, outer_radius, refinement, grid_points,
+                envelope_radius, outer_radius, refinement, grid_points,
                 use_equiangular_map, use_projective_map,
-                sphericity_enveloping_cube, radius_enveloping_sphere,
                 radial_distribution_outer_shell, nullptr,
                 Options::Context{false, {}, 1, 1}),
             Catch::Matchers::Contains(
@@ -376,9 +328,8 @@ void test_connectivity() {
                        excise_interiorB ? std::make_optional(Excision{nullptr})
                                         : std::nullopt,
                        false},
-                radius_enveloping_cube, outer_radius, refinement, grid_points,
+                envelope_radius, outer_radius, refinement, grid_points,
                 use_equiangular_map, use_projective_map,
-                sphericity_enveloping_cube, radius_enveloping_sphere,
                 radial_distribution_outer_shell,
                 create_outer_boundary_condition(),
                 Options::Context{false, {}, 1, 1}),
@@ -457,13 +408,11 @@ std::string create_option_string(const bool excise_A, const bool excise_B,
          interior_B +
          "    UseLogarithmicMap: " + stringize(use_logarithmic_map_AB) +
          "\n"
-         "  EnvelopingCube:\n"
+         "  Envelope:\n"
          "    Radius: 22.0\n"
          "    UseProjectiveMap: true\n"
-         "    Sphericity: 1.0\n"
          "  OuterShell:\n"
-         "    InnerRadius: Auto\n"
-         "    OuterRadius: 25.0\n"
+         "    Radius: 25.0\n"
          "    RadialDistribution: Linear\n" +
          outer_boundary_condition + "  InitialRefinement:\n" +
          (excise_A ? "" : "    ObjectAInterior: [1, 1, 1]\n") +
@@ -476,7 +425,7 @@ std::string create_option_string(const bool excise_A, const bool excise_B,
          "]\n"
          "    ObjectACube: [1, 1, 1]\n"
          "    ObjectBCube: [1, 1, 1]\n"
-         "    EnvelopingCube: [1, 1, 1]\n"
+         "    Envelope: [1, 1, 1]\n"
          "    OuterShell: [1, 1, " +
          std::to_string(1 + additional_refinement_outer) +
          "]\n"
@@ -658,7 +607,7 @@ void test_parse_errors() {
       domain::creators::BinaryCompactObject(
           {0.5, 1.0, -1.0, {{create_inner_boundary_condition()}}, false},
           {0.3, 1.0, -1.0, {{create_inner_boundary_condition()}}, false}, 25.5,
-          32.4, 2_st, 6_st, true, true, 0.0, std::nullopt, Distribution::Linear,
+          32.4, 2_st, 6_st, true, true, Distribution::Linear,
           create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
       Catch::Matchers::Contains(
           "The x-coordinate of ObjectA's center is expected to be positive."));
@@ -666,7 +615,7 @@ void test_parse_errors() {
       domain::creators::BinaryCompactObject(
           {0.5, 1.0, 1.0, {{create_inner_boundary_condition()}}, false},
           {0.3, 1.0, 1.0, {{create_inner_boundary_condition()}}, false}, 25.5,
-          32.4, 2_st, 6_st, true, true, 0.0, std::nullopt, Distribution::Linear,
+          32.4, 2_st, 6_st, true, true, Distribution::Linear,
           create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
       Catch::Matchers::Contains(
           "The x-coordinate of ObjectB's center is expected to be negative."));
@@ -674,7 +623,7 @@ void test_parse_errors() {
       domain::creators::BinaryCompactObject(
           {0.3, 1.0, 8.0, {{create_inner_boundary_condition()}}, false},
           {0.5, 1.0, -7.0, {{create_inner_boundary_condition()}}, false}, 25.5,
-          32.4, 2_st, 6_st, true, true, 0.0, std::nullopt, Distribution::Linear,
+          32.4, 2_st, 6_st, true, true, Distribution::Linear,
           create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
       Catch::Matchers::Contains("The radius for the enveloping cube is too "
                                 "small! The Frustums will be malformed."));
@@ -682,7 +631,7 @@ void test_parse_errors() {
       domain::creators::BinaryCompactObject(
           {0.3, 1.0, 1.0, {{create_inner_boundary_condition()}}, false},
           {1.5, 1.0, -1.0, {{create_inner_boundary_condition()}}, false}, 25.5,
-          32.4, 2_st, 6_st, true, true, 0.0, std::nullopt, Distribution::Linear,
+          32.4, 2_st, 6_st, true, true, Distribution::Linear,
           create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
       Catch::Matchers::Contains(
           "ObjectB's inner radius must be less than its outer radius."));
@@ -690,7 +639,7 @@ void test_parse_errors() {
       domain::creators::BinaryCompactObject(
           {3.3, 1.0, 1.0, {{create_inner_boundary_condition()}}, false},
           {0.5, 1.0, -1.0, {{create_inner_boundary_condition()}}, false}, 25.5,
-          32.4, 2_st, 6_st, true, true, 0.0, std::nullopt, Distribution::Linear,
+          32.4, 2_st, 6_st, true, true, Distribution::Linear,
           create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
       Catch::Matchers::Contains(
           "ObjectA's inner radius must be less than its outer radius."));
@@ -698,8 +647,8 @@ void test_parse_errors() {
       domain::creators::BinaryCompactObject(
           {0.3, 1.0, 1.0, {{create_inner_boundary_condition()}}, false},
           {0.5, 1.0, -1.0, std::nullopt, true}, 25.5, 32.4, 2_st, 6_st, true,
-          true, 0.0, std::nullopt, Distribution::Linear,
-          create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
+          true, Distribution::Linear, create_outer_boundary_condition(),
+          Options::Context{false, {}, 1, 1}),
       Catch::Matchers::Contains(
           "Using a logarithmically spaced radial grid in the "
           "part of Layer 1 enveloping Object B requires excising the interior "
@@ -708,7 +657,7 @@ void test_parse_errors() {
       domain::creators::BinaryCompactObject(
           {0.3, 1.0, 1.0, std::nullopt, true},
           {0.5, 1.0, -1.0, {{create_inner_boundary_condition()}}, false}, 25.5,
-          32.4, 2_st, 6_st, true, true, 0.0, std::nullopt, Distribution::Linear,
+          32.4, 2_st, 6_st, true, true, Distribution::Linear,
           create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
       Catch::Matchers::Contains(
           "Using a logarithmically spaced radial grid in the "
@@ -718,25 +667,18 @@ void test_parse_errors() {
       domain::creators::BinaryCompactObject(
           {0.3, 1.0, 1.0, {{create_inner_boundary_condition()}}, false},
           {0.5, 1.0, -1.0, {{create_inner_boundary_condition()}}, false}, 25.5,
-          32.4, std::vector<std::array<size_t, 3>>{}, 6_st, true, true, 0.0,
-          std::nullopt, Distribution::Linear, create_outer_boundary_condition(),
+          32.4, std::vector<std::array<size_t, 3>>{}, 6_st, true, true,
+          Distribution::Linear, create_outer_boundary_condition(),
           Options::Context{false, {}, 1, 1}),
       Catch::Matchers::Contains("Invalid 'InitialRefinement'"));
   CHECK_THROWS_WITH(
       domain::creators::BinaryCompactObject(
           {0.3, 1.0, 1.0, {{create_inner_boundary_condition()}}, false},
           {0.5, 1.0, -1.0, {{create_inner_boundary_condition()}}, false}, 25.5,
-          32.4, 2_st, std::vector<std::array<size_t, 3>>{}, true, true, 0.0,
-          std::nullopt, Distribution::Linear, create_outer_boundary_condition(),
+          32.4, 2_st, std::vector<std::array<size_t, 3>>{}, true, true,
+          Distribution::Linear, create_outer_boundary_condition(),
           Options::Context{false, {}, 1, 1}),
       Catch::Matchers::Contains("Invalid 'InitialGridPoints'"));
-  CHECK_THROWS_WITH(
-      domain::creators::BinaryCompactObject(
-          {0.3, 1.0, 1.0, {{create_inner_boundary_condition()}}, false},
-          {0.5, 1.0, -1.0, {{create_inner_boundary_condition()}}, false}, 25.5,
-          32.4, 2_st, 6_st, true, true, 0.0, 35., Distribution::Linear,
-          create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
-      Catch::Matchers::Contains("The 'OuterShell.InnerRadius' must be within"));
   // Note: the boundary condition-related parse errors are checked in the
   // test_connectivity function.
 }

--- a/tests/Unit/IO/Importers/Test_VolumeDataReaderAlgorithm3D.yaml
+++ b/tests/Unit/IO/Importers/Test_VolumeDataReaderAlgorithm3D.yaml
@@ -15,13 +15,11 @@ SourceDomainCreator:
       XCoord: &x_left -7.683
       ExciseInterior: True
       UseLogarithmicMap: True
-    EnvelopingCube:
+    Envelope:
       Radius: 60.
       UseProjectiveMap: True
-      Sphericity: 1.
     OuterShell:
-      InnerRadius: Auto
-      OuterRadius: 350.
+      Radius: 350.
       RadialDistribution: Inverse
     UseEquiangularMap: True
     InitialRefinement: 1
@@ -41,13 +39,11 @@ TargetDomainCreator:
       XCoord: *x_left
       ExciseInterior: True
       UseLogarithmicMap: true
-    EnvelopingCube:
+    Envelope:
       Radius: 100.
       UseProjectiveMap: true
-      Sphericity: 1.
     OuterShell:
-      InnerRadius: Auto
-      OuterRadius: 300.
+      Radius: 300.
       RadialDistribution: Linear
     UseEquiangularMap: True
     InitialRefinement: 0


### PR DESCRIPTION
## Proposed changes

The spherical enveloping frustums are working well, so we don't need this intermediate cube anymore.
Also simplify the documentation a bit.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
In input files using the `BinaryCompactObject` domain, remove the `EnvelopingCube.Sphericity` option and the `OuterShell.InnerRadius` option. `EnvelopingCube` is now just `Envelope`, and `OuterShell.OuterRadius` is now `OuterShell.Radius`.
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
