### PR TITLE
Use preinstalled Py env on Wheeler

### DIFF
--- a/support/Environments/wheeler_clang.sh
+++ b/support/Environments/wheeler_clang.sh
@@ -27,7 +27,7 @@ spectre_unload_modules() {
     module unload git/2.8.4
     module unload llvm/13.0.1
     module unload charm/7.0.0-intelmpi-smp
-    module unload python/miniconda-3.9.7
+    module unload envs/spectre-python
     module unload pybind11/2.6.1
     module unload hdf5/1.12.2
 }
@@ -52,7 +52,7 @@ spectre_load_modules() {
     module load git/2.8.4
     module load llvm/13.0.1
     module load charm/7.0.0-intelmpi-smp
-    module load python/miniconda-3.9.7
+    module load envs/spectre-python
     module load pybind11/2.6.1
     module load hdf5/1.12.2
 }
@@ -63,12 +63,6 @@ spectre_run_cmake() {
         return 1
     fi
     spectre_load_modules
-    # Notes:
-    # - Set CMAKE_PREFIX_PATH to pick up packages consistent with the anaconda
-    #   module, such as zlib. The anaconda module on Wheeler does not set this
-    #   automatically.
-    # - Bootstrap Python dependencies in the build directory so users don't have
-    #   to install them.
     cmake -D CHARM_ROOT=$CHARM_ROOT \
           -D CMAKE_BUILD_TYPE=Release \
           -D CMAKE_C_COMPILER=clang \
@@ -76,8 +70,6 @@ spectre_run_cmake() {
           -D CMAKE_Fortran_COMPILER=gfortran \
           -D MEMORY_ALLOCATOR=SYSTEM \
           -D BUILD_PYTHON_BINDINGS=ON \
-          -D CMAKE_PREFIX_PATH="$PYTHON_HOME" \
-          -D BOOTSTRAP_PY_DEPS=ON \
           -D MACHINE=Wheeler \
           "$@" \
           $SPECTRE_HOME

--- a/support/Environments/wheeler_gcc.sh
+++ b/support/Environments/wheeler_gcc.sh
@@ -27,7 +27,7 @@ spectre_unload_modules() {
     module unload git/2.8.4
     module unload lcov/1.13
     module unload charm/7.0.0-intelmpi-smp
-    module unload python/miniconda-3.9.7
+    module unload envs/spectre-python
     module unload pybind11/2.6.1
     module unload hdf5/1.12.2
 }
@@ -52,7 +52,7 @@ spectre_load_modules() {
     module load git/2.8.4
     module load lcov/1.13
     module load charm/7.0.0-intelmpi-smp
-    module load python/miniconda-3.9.7
+    module load envs/spectre-python
     module load pybind11/2.6.1
     module load hdf5/1.12.2
 }
@@ -63,19 +63,11 @@ spectre_run_cmake() {
         return 1
     fi
     spectre_load_modules
-    # Notes:
-    # - Set CMAKE_PREFIX_PATH to pick up packages consistent with the anaconda
-    #   module, such as zlib. The anaconda module on Wheeler does not set this
-    #   automatically.
-    # - Bootstrap Python dependencies in the build directory so users don't have
-    #   to install them.
     cmake -D CHARM_ROOT=$CHARM_ROOT \
           -D CMAKE_BUILD_TYPE=Release \
           -D CMAKE_Fortran_COMPILER=gfortran \
           -D MEMORY_ALLOCATOR=SYSTEM \
           -D BUILD_PYTHON_BINDINGS=ON \
-          -D CMAKE_PREFIX_PATH="$PYTHON_HOME" \
-          -D BOOTSTRAP_PY_DEPS=ON \
           -D MACHINE=Wheeler \
           "$@" \
           $SPECTRE_HOME


### PR DESCRIPTION
## Proposed changes

Speeds up CMake config because bootstrapping Py packages is avoided.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
