### PR TITLE
Allow the control system to use NS centers of mass as measurements

### DIFF
--- a/src/ControlSystem/Measurements/BNSCenterOfMass.cpp
+++ b/src/ControlSystem/Measurements/BNSCenterOfMass.cpp
@@ -1,0 +1,35 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "BNSCenterOfMass.hpp"
+
+namespace control_system::measurements {
+
+void center_of_mass_integral_on_element(
+    const gsl::not_null<double*> mass_a, const gsl::not_null<double*> mass_b,
+    const gsl::not_null<std::array<double, 3>*> first_moment_a,
+    const gsl::not_null<std::array<double, 3>*> first_moment_b,
+    const Mesh<3>& mesh, const Scalar<DataVector>& inv_det_jacobian,
+    const Scalar<DataVector>& tilde_d,
+    const tnsr::I<DataVector, 3, Frame::Grid>& x_grid) {
+  // Get Jacobian and mask for left/right stars
+  const DataVector det_jacobian = 1. / get(inv_det_jacobian);
+  const DataVector positive_x = step_function(get<0>(x_grid));
+  const DataVector negative_x = (1.0 - positive_x);
+
+  // Integrals of the density and its first moment (on local element).
+  // Suffix A/B for positive/negative x-coordinate (proxy for stars A and B)
+  const DataVector integrand_a = det_jacobian * positive_x * get(tilde_d);
+  const DataVector integrand_b = det_jacobian * negative_x * get(tilde_d);
+
+  (*mass_a) = definite_integral(integrand_a, mesh);
+  (*mass_b) = definite_integral(integrand_b, mesh);
+  for (size_t i = 0; i < 3; i++) {
+    gsl::at(*first_moment_a, i) =
+        definite_integral(integrand_a * x_grid.get(i), mesh);
+    gsl::at(*first_moment_b, i) =
+        definite_integral(integrand_b * x_grid.get(i), mesh);
+  }
+}
+
+}  // namespace control_system::measurements

--- a/src/ControlSystem/Measurements/BNSCenterOfMass.hpp
+++ b/src/ControlSystem/Measurements/BNSCenterOfMass.hpp
@@ -1,0 +1,179 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <string>
+
+#include "ControlSystem/Component.hpp"
+#include "ControlSystem/Protocols/Measurement.hpp"
+#include "ControlSystem/Protocols/Submeasurement.hpp"
+#include "ControlSystem/RunCallbacks.hpp"
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/LinkedMessageId.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Domain/Structure/ObjectLabel.hpp"
+#include "NumericalAlgorithms/LinearOperators/DefiniteIntegral.hpp"
+#include "Parallel/Reduction.hpp"
+#include "Time/Tags.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
+#include "Utilities/StdArrayHelpers.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+class DataVector;
+template <size_t VolumeDim>
+class ElementId;
+template <size_t Dim>
+class Mesh;
+namespace Parallel {
+template <typename Metavariables>
+class GlobalCache;
+}  // namespace Parallel
+namespace domain::Tags {
+template <size_t Dim>
+struct Mesh;
+template <size_t Dim, typename Frame>
+struct Coordinates;
+}  // namespace domain::Tags
+namespace Events::Tags {
+template <typename InputFrame, typename OutputFrame>
+struct ObserverDetInvJacobian;
+}
+namespace grmhd::ValenciaDivClean {
+struct TildeD;
+}
+/// \endcond
+
+namespace control_system::measurements {
+
+template <typename ControlSystems>
+struct PostReductionSendBNSStarCentersToControlSystem;
+
+namespace Tags {
+/// \ingroup DataBoxTagsGroup
+/// \ingroup ControlSystemGroup
+/// DataBox tag for location of neutron star center
+/// (or more accurately, center of mass of the matter
+/// in the x>0 (label A) or x<0 (label B) region, in grid
+/// coordinates.
+template <::domain::ObjectLabel Center>
+struct NeutronStarCenter : db::SimpleTag {
+  using type = std::array<double, 3>;
+};
+}  // namespace Tags
+
+/// Factored Center of Mass calculation (for easier testing)
+/// This function computes the integral of tildeD (assumed to be the
+/// conservative baryon density in the inertial frame), as well as
+/// its first moment in the grid frame. The integrals are limited to
+/// \f$x>0\f$ (label A) or \f$x<0\f$ (label B).
+/// inv_det_jacobian is the inverse determinant of the jacobian of the
+///                  map between logical and inertial coordinates
+/// xGrid contains the coordinates in the grid frame
+void center_of_mass_integral_on_element(
+    const gsl::not_null<double*> mass_a, const gsl::not_null<double*> mass_b,
+    const gsl::not_null<std::array<double, 3>*> first_moment_A,
+    const gsl::not_null<std::array<double, 3>*> first_moment_B,
+    const Mesh<3>& mesh, const Scalar<DataVector>& inv_det_jacobian,
+    const Scalar<DataVector>& tilde_d,
+    const tnsr::I<DataVector, 3, Frame::Grid>& x_grid);
+
+/// Measurement providing the location of the center of mass of the
+/// matter in the \f$x>0\f$ and \f$x<0\f$ regions (assumed to correspond to the
+/// center of mass of the two neutron stars in a BNS merger).
+struct BothNSCenters : tt::ConformsTo<protocols::Measurement> {
+  struct FindTwoCenters : tt::ConformsTo<protocols::Submeasurement> {
+    /// Unused tag needed to conform to the submeasurement protocol.
+    template <typename ControlSystems>
+    using interpolation_target_tag = void;
+
+    /// Tags for the arguments to the apply function.
+    using argument_tags =
+        tmpl::list<domain::Tags::Mesh<3>,
+                   Events::Tags::ObserverDetInvJacobian<Frame::ElementLogical,
+                                                        Frame::Inertial>,
+                   grmhd::ValenciaDivClean::TildeD,
+                   domain::Tags::Coordinates<3, Frame::Grid>>;
+
+    /// Calculate integrals needed for CoM computation on each element,
+    /// then reduce the data.
+    template <typename Metavariables, typename ParallelComponent,
+              typename ControlSystems>
+    static void apply(const Mesh<3>& mesh,
+                      const Scalar<DataVector>& inv_det_jacobian,
+                      const Scalar<DataVector>& tilde_d,
+                      const tnsr::I<DataVector, 3, Frame::Grid> x_grid,
+                      const LinkedMessageId<double>& measurement_id,
+                      Parallel::GlobalCache<Metavariables>& cache,
+                      const ElementId<3>& /*array_index*/,
+                      const ParallelComponent* const /*meta*/,
+                      ControlSystems /*meta*/) {
+      // Initialize integrals and perform local calculations
+      double mass_a = 0.;
+      double mass_b = 0.;
+      std::array<double, 3> first_moment_a = {0., 0., 0.};
+      std::array<double, 3> first_moment_b = {0., 0., 0.};
+      center_of_mass_integral_on_element(&mass_a, &mass_b, &first_moment_a,
+                                         &first_moment_b, mesh,
+                                         inv_det_jacobian, tilde_d, x_grid);
+
+      // Reduction
+      auto& my_proxy =
+          Parallel::get_parallel_component<ParallelComponent>(cache);
+      // We need a place to run RunCallback on... this does not need to be
+      // the control system using the CoM data.
+      auto& reduction_target_proxy = Parallel::get_parallel_component<
+          ControlComponent<Metavariables, tmpl::front<ControlSystems>>>(cache);
+      Parallel::ReductionData<
+          Parallel::ReductionDatum<LinkedMessageId<double>,
+                                   funcl::AssertEqual<>>,
+          Parallel::ReductionDatum<double, funcl::Plus<>>,
+          Parallel::ReductionDatum<double, funcl::Plus<>>,
+          Parallel::ReductionDatum<std::array<double, 3>, funcl::Plus<>>,
+          Parallel::ReductionDatum<std::array<double, 3>, funcl::Plus<>>>
+          reduction_data{measurement_id, mass_a, mass_b, first_moment_a,
+                         first_moment_b};
+      Parallel::contribute_to_reduction<
+          PostReductionSendBNSStarCentersToControlSystem<ControlSystems>>(
+          std::move(reduction_data), my_proxy, reduction_target_proxy);
+    }
+  };
+  /// List of submeasurements used by this measurement -- only FindTwoCenters
+  /// here.
+  using submeasurements = tmpl::list<FindTwoCenters>;
+};
+
+/// Action called after reduction of the center of mass data.
+/// mass_a, mass_b, first_moment_a, first_moment_b will contain the reduced data
+/// for the integral of the density (and its first moment) in the x>=0 (A label)
+/// and x<0 (B label) regions.
+/// This action calculates the center of mass in each region, and sends the
+/// result to the control system.
+template <typename ControlSystems>
+struct PostReductionSendBNSStarCentersToControlSystem {
+  template <typename ParallelComponent, typename DbTags, typename Metavariables,
+            typename ArrayIndex>
+  static void apply(db::DataBox<DbTags>& /*box*/,
+                    Parallel::GlobalCache<Metavariables>& cache,
+                    const ArrayIndex& /*array_index*/,
+                    const LinkedMessageId<double>& measurement_id,
+                    const double& mass_a, const double& mass_b,
+                    const std::array<double, 3>& first_moment_a,
+                    const std::array<double, 3>& first_moment_b) {
+    // Function called after reduction of the CoM data.
+    // 1. Calculate CoM from integrals
+    std::array<double, 3> center_a = first_moment_a / mass_a;
+    std::array<double, 3> center_b = first_moment_b / mass_b;
+    const auto center_databox = db::create<
+        db::AddSimpleTags<Tags::NeutronStarCenter<::domain::ObjectLabel::A>,
+                          Tags::NeutronStarCenter<::domain::ObjectLabel::B>>>(
+        center_a, center_b);
+    // Send results to the control system(s)
+    RunCallbacks<BothNSCenters::FindTwoCenters, ControlSystems>::apply(
+        center_databox, cache, measurement_id);
+  }
+};
+
+}  // namespace control_system::measurements

--- a/src/ControlSystem/Measurements/CMakeLists.txt
+++ b/src/ControlSystem/Measurements/CMakeLists.txt
@@ -3,19 +3,26 @@
 
 set(LIBRARY ControlSystemMeasurements)
 
-add_spectre_library(${LIBRARY} INTERFACE)
+add_spectre_library(${LIBRARY})
+
+spectre_target_sources(
+  ${LIBRARY}
+  PRIVATE
+  BNSCenterOfMass.cpp
+  )
 
 spectre_target_headers(
   ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
+  BNSCenterOfMass.hpp
   BothHorizons.hpp
   SingleHorizon.hpp
   )
 
 target_link_libraries(
   ${LIBRARY}
-  INTERFACE
+  PUBLIC
   ApparentHorizons
   ControlSystem
   DataStructures

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
@@ -15,6 +15,7 @@
 #include "ControlSystem/Actions/InitializeMeasurements.hpp"
 #include "ControlSystem/Component.hpp"
 #include "ControlSystem/Event.hpp"
+#include "ControlSystem/Measurements/BothHorizons.hpp"
 #include "ControlSystem/Systems/Expansion.hpp"
 #include "ControlSystem/Systems/Rotation.hpp"
 #include "ControlSystem/Trigger.hpp"
@@ -238,8 +239,11 @@ struct EvolutionMetavars {
         intrp::callbacks::ObserveTimeSeriesOnSurface<tags_to_observe, AhB>>;
   };
 
-  using control_systems = tmpl::list<control_system::Systems::Rotation<3>,
-                                     control_system::Systems::Expansion<2>>;
+  using control_systems =
+      tmpl::list<control_system::Systems::Rotation<
+                     3, control_system::measurements::BothHorizons>,
+                 control_system::Systems::Expansion<
+                     2, control_system::measurements::BothHorizons>>;
 
   static constexpr bool use_control_systems =
       tmpl::size<control_systems>::value > 0;

--- a/tests/Unit/ControlSystem/CMakeLists.txt
+++ b/tests/Unit/ControlSystem/CMakeLists.txt
@@ -37,6 +37,7 @@ target_link_libraries(
   PRIVATE
   ApparentHorizons
   ControlSystem
+  ControlSystemMeasurements
   EventsAndDenseTriggers
   FunctionsOfTime
   H5

--- a/tests/Unit/ControlSystem/Systems/Test_Expansion.cpp
+++ b/tests/Unit/ControlSystem/Systems/Test_Expansion.cpp
@@ -185,7 +185,8 @@ void test_expansion_control_system() {
 }
 
 void test_names() {
-  using expansion = control_system::Systems::Expansion<2>;
+  using expansion = control_system::Systems::Expansion<
+      2, control_system::measurements::BothHorizons>;
 
   CHECK(pretty_type::name<expansion>() == "Expansion");
   CHECK(*expansion::component_name(0, 1) == "Expansion");

--- a/tests/Unit/ControlSystem/Systems/Test_Rotation.cpp
+++ b/tests/Unit/ControlSystem/Systems/Test_Rotation.cpp
@@ -28,6 +28,10 @@ struct Grid;
 struct Inertial;
 }  // namespace Frame
 
+namespace control_system::measurements {
+struct BothHorizons;
+}  // namespace control_system::measurements
+
 namespace control_system {
 namespace {
 using RotationMap = domain::CoordinateMaps::TimeDependent::Rotation<3>;
@@ -189,7 +193,8 @@ void test_rotation_control_system(const bool newtonian) {
 }
 
 void test_names() {
-  using rotation = control_system::Systems::Rotation<2>;
+  using rotation = control_system::Systems::Rotation<
+      2, control_system::measurements::BothHorizons>;
 
   CHECK(pretty_type::name<rotation>() == "Rotation");
   CHECK(*rotation::component_name(0, 3) == "x");

--- a/tests/Unit/ControlSystem/Systems/Test_Translation.cpp
+++ b/tests/Unit/ControlSystem/Systems/Test_Translation.cpp
@@ -195,7 +195,8 @@ void test_translation_control_system() {
 }
 
 void test_names() {
-  using translation = control_system::Systems::Translation<2>;
+  using translation = control_system::Systems::Translation<
+      2, control_system::measurements::BothHorizons>;
 
   CHECK(pretty_type::name<translation>() == "Translation");
   CHECK(*translation::component_name(0, 3) == "x");

--- a/tests/Unit/ControlSystem/Test_Measurements.cpp
+++ b/tests/Unit/ControlSystem/Test_Measurements.cpp
@@ -3,12 +3,24 @@
 
 #include "Framework/TestingFramework.hpp"
 
+#include "ControlSystem/Measurements/BNSCenterOfMass.hpp"
 #include "ControlSystem/Measurements/BothHorizons.hpp"
 #include "ControlSystem/Measurements/SingleHorizon.hpp"
+#include "DataStructures/DataVector.hpp"
 #include "Domain/Structure/ObjectLabel.hpp"
+#include "Framework/ActionTesting.hpp"
 #include "Helpers/ControlSystem/Examples.hpp"
 #include "ParallelAlgorithms/Interpolation/Protocols/InterpolationTargetTag.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
+
+static_assert(
+    tt::assert_conforms_to_v<control_system::measurements::BothHorizons::
+                                 FindHorizon<::domain::ObjectLabel::A>,
+                             control_system::protocols::Submeasurement>);
+
+static_assert(
+    tt::assert_conforms_to_v<control_system::measurements::BothHorizons,
+                             control_system::protocols::Measurement>);
 
 static_assert(
     tt::assert_conforms_to_v<
@@ -23,3 +35,134 @@ static_assert(
             Submeasurement::interpolation_target_tag<
                 tmpl::list<control_system::TestHelpers::ExampleControlSystem>>,
         intrp::protocols::InterpolationTargetTag>);
+
+static_assert(tt::assert_conforms_to_v<
+              control_system::measurements::BothNSCenters::FindTwoCenters,
+              control_system::protocols::Submeasurement>);
+
+static_assert(
+    tt::assert_conforms_to_v<control_system::measurements::BothNSCenters,
+                             control_system::protocols::Measurement>);
+
+namespace {
+
+struct MockControlSystem
+    : tt::ConformsTo<control_system::protocols::ControlSystem> {
+  static std::string name() { return "MockControlSystem"; }
+  static std::optional<std::string> component_name(
+      const size_t /*i*/, const size_t num_components) {
+    ASSERT(num_components == 1,
+           "This control system expected 1 component but there are "
+               << num_components << " instead.");
+    return "Phi";
+  }
+  using measurement = control_system::measurements::BothNSCenters;
+  using simple_tags = tmpl::list<
+      control_system::TestHelpers::ExampleControlSystem::MeasurementQueue>;
+  static constexpr size_t deriv_order = 2;
+  using control_error = control_system::TestHelpers::ExampleControlError;
+  struct process_measurement {
+    template <typename Submeasurement>
+    using argument_tags =
+        tmpl::list<control_system::measurements::Tags::NeutronStarCenter<
+                       ::domain::ObjectLabel::A>,
+                   control_system::measurements::Tags::NeutronStarCenter<
+                       ::domain::ObjectLabel::B>>;
+    using submeasurement =
+        control_system::measurements::BothNSCenters::FindTwoCenters;
+
+    template <typename Metavariables>
+    static void apply(submeasurement /*meta*/,
+                      const std::array<double, 3> center_a,
+                      const std::array<double, 3> center_b,
+                      Parallel::GlobalCache<Metavariables>& /*cache*/,
+                      const LinkedMessageId<double>& /*measurement_id*/) {
+      // Check that the center of mass is at the expected location for this
+      // test.
+      CHECK(center_a[0] == 1.0);
+      CHECK(center_a[1] == 4.5 / 8.0);
+      CHECK(center_a[2] == 3.0 / 8.0);
+      CHECK(center_b[0] == -1.0);
+      CHECK(center_b[1] == 1.0);
+      CHECK(center_b[2] == 0.0);
+      // Avoid unused variable warning for deriv_order, which is required
+      // as part of the control_system protocol.
+      CHECK(2 == deriv_order);
+    }
+  };
+};
+
+template <typename Metavariables>
+struct MockControlSystemComponent {
+  using component_being_mocked =
+      ControlComponent<Metavariables, MockControlSystem>;
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockSingletonChare;
+  using array_index = int;
+  using simple_tags_from_options = tmpl::list<>;
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<Parallel::Phase::Testing, tmpl::list<>>>;
+};
+
+struct Metavariables {
+  using component_list = tmpl::list<MockControlSystemComponent<Metavariables>>;
+};
+
+}  // namespace
+
+// This test tests the calculation of the center of mass of a star
+// in the FindTwoCenters submeasurement
+SPECTRE_TEST_CASE("Unit.ControlSystem.FindTwoCenters",
+                  "[ControlSystem][Unit]") {
+  // Part 1 of the test: calculation of the relevant integrals
+  // within a (mock) element.
+  const Mesh<3> mesh(2, Spectral::Basis::FiniteDifference,
+                     Spectral::Quadrature::CellCentered);
+  const Scalar<DataVector> tilde_d{
+      DataVector{0.0, 0.5, 1.0, 1.0, 0.5, 0.0, 1.0, 1.0}};
+  const Scalar<DataVector> inv_det_jacobian{
+      DataVector{0.2, 0.2, 0.4, 0.4, 0.5, 0.5, 1.0, 1.0}};
+  const DataVector x_coord{-1.0, 1.0, -1.0, 1.0, 1.0, 2.0, 0.0, 2.0};
+  const DataVector y_coord{0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 1.0, 1.0};
+  const DataVector z_coord{0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0};
+  const tnsr::I<DataVector, 3, Frame::Grid> x_grid{{x_coord, y_coord, z_coord}};
+
+  // mass_a and mass_b: Integral of tilde_d/inv_det_jacobian for x>=0 and x<0
+  // first_moment_a, first_moment_b : Same as masses, but multiplying the
+  //                              integrand by x_grid
+  double mass_a = 0.;
+  double mass_b = 0.;
+  std::array<double, 3> first_moment_a = {0., 0., 0.};
+  std::array<double, 3> first_moment_b = {0., 0., 0.};
+  control_system::measurements::center_of_mass_integral_on_element(
+      &mass_a, &mass_b, &first_moment_a, &first_moment_b, mesh,
+      inv_det_jacobian, tilde_d, x_grid);
+  // Comparison with expected answer
+  CHECK(mass_a == 8.0);
+  CHECK(mass_b == 2.5);
+  CHECK(first_moment_a == std::array<double, 3>{8.0, 4.5, 3.0});
+  CHECK(first_moment_b == std::array<double, 3>{-2.5, 2.5, 0.0});
+
+  using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<Metavariables>;
+  using control_system_component = MockControlSystemComponent<Metavariables>;
+
+  MockRuntimeSystem runner{{}};
+  ActionTesting::emplace_singleton_component<control_system_component>(
+      make_not_null(&runner), ActionTesting::NodeId{0},
+      ActionTesting::LocalCoreId{0});
+  ActionTesting::set_phase(make_not_null(&runner), Parallel::Phase::Testing);
+  auto& cache = ActionTesting::cache<control_system_component>(runner, 0);
+
+  LinkedMessageId<double> measurement_id{1.0, 0.0};
+  ElementId<3> unused_element_id;
+
+  using ControlSystems = tmpl::list<MockControlSystem>;
+  auto box = db::create<db::AddSimpleTags<Tags::Time>>(1.0);
+
+  // Test post-reduction action
+  control_system::measurements::PostReductionSendBNSStarCentersToControlSystem<
+      ControlSystems>::
+      template apply<control_system_component>(box, cache, unused_element_id,
+                                               measurement_id, mass_a, mass_b,
+                                               first_moment_a, first_moment_b);
+}

--- a/tests/Unit/Helpers/ControlSystem/SystemHelpers.hpp
+++ b/tests/Unit/Helpers/ControlSystem/SystemHelpers.hpp
@@ -289,10 +289,12 @@ struct MockMetavars {
 
   using element_component = MockElementComponent<metavars>;
 
-  using expansion_system = control_system::Systems::Expansion<exp_deriv_order>;
-  using rotation_system = control_system::Systems::Rotation<rot_deriv_order>;
-  using translation_system =
-      control_system::Systems::Translation<trans_deriv_order>;
+  using expansion_system = control_system::Systems::Expansion<
+      exp_deriv_order, control_system::measurements::BothHorizons>;
+  using rotation_system = control_system::Systems::Rotation<
+      rot_deriv_order, control_system::measurements::BothHorizons>;
+  using translation_system = control_system::Systems::Translation<
+      trans_deriv_order, control_system::measurements::BothHorizons>;
   using shape_system = control_system::Systems::Shape<::domain::ObjectLabel::A,
                                                       shape_deriv_order>;
 


### PR DESCRIPTION
Include test of the center of mass calculation.
The new measurement can be used by the Rotation, Expansion and Translation systems.

## Proposed changes

This PR adds the BothBNSCenters measurements and associated submeasurement, 
to be used to calculate the center of mass of neutron stars in BNS simulations and
drive the BNS control system. In this PR, the measurement is made compatible with
the Expansion, Translation, and Rotation components of the control system.

### Upgrade instructions

Any executable using the Expansion, Translation, or Rotation control system now
needs to template those systems on the Measurement used to get the location
of the compact objects (this is done for tested executables in this PR).

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.