### PR TITLE
Add `CenteredFaceCoordinates` compute tag

### DIFF
--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/Tags.cpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/Tags.cpp
@@ -1,5 +1,49 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
+#include <cstddef>
+#include <optional>
+
 #include "Evolution/Systems/CurvedScalarWave/Worldtube/Tags.hpp"
 
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/Structure/Element.hpp"
+#include "Domain/Structure/ExcisionSphere.hpp"
+#include "Evolution/DiscontinuousGalerkin/ProjectToBoundary.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "Utilities/ContainerHelpers.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace CurvedScalarWave::Worldtube::Tags {
+template <size_t Dim>
+void CenteredFaceCoordinatesCompute<Dim>::function(
+    const gsl::not_null<std::optional<tnsr::I<DataVector, Dim, Frame::Grid>>*>
+        result,
+    const ::ExcisionSphere<Dim>& excision_sphere, const Element<Dim>& element,
+    const tnsr::I<DataVector, Dim, Frame::Grid>& grid_coords,
+    const Mesh<Dim>& mesh) {
+  const auto direction = excision_sphere.abutting_direction(element.id());
+  if (direction.has_value()) {
+    const size_t grid_size =
+        mesh.slice_away(direction->dimension()).number_of_grid_points();
+    if (result->has_value()) {
+      destructive_resize_components(make_not_null(&(result->value())),
+                                    grid_size);
+    } else {
+      result->emplace(grid_size);
+    }
+    evolution::dg::project_tensor_to_boundary(make_not_null(&(result->value())),
+                                              grid_coords, mesh,
+                                              direction.value());
+    for (size_t i = 0; i < Dim; ++i) {
+      result->value().get(i) -= excision_sphere.center().get(i);
+    }
+
+  } else {
+    result->reset();
+  }
+}
+
+template struct CenteredFaceCoordinatesCompute<3>;
+}  // namespace CurvedScalarWave::Worldtube::Tags

--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/Tags.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/Tags.hpp
@@ -69,6 +69,17 @@ struct ExcisionSphere : db::SimpleTag {
 };
 
 /*!
+ * \brief An optional that holds the grid coordinates, centered on the
+ * worldtube, of an element face abutting the worldtube excision sphere. If the
+ * element does not abut the worldtube, this holds std::nullopt. This tag should
+ * be in the databox of element chares.
+ */
+template <size_t Dim>
+struct CenteredFaceCoordinates : db::SimpleTag {
+  using type = std::optional<tnsr::I<DataVector, Dim, Frame::Grid>>;
+};
+
+/*!
  * \brief A map that holds the grid coordinates centered on the worldtube of
  * all element faces abutting the worldtube with the corresponding ElementIds.
  */

--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/Tags.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/Tags.hpp
@@ -5,17 +5,22 @@
 
 #include <cstddef>
 #include <memory>
+#include <optional>
 #include <string>
 #include <unordered_map>
 
 #include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/Creators/DomainCreator.hpp"
 #include "Domain/Creators/OptionTags.hpp"
 #include "Domain/Domain.hpp"
+#include "Domain/Structure/Element.hpp"
 #include "Domain/Structure/ElementId.hpp"
 #include "Domain/Structure/ExcisionSphere.hpp"
+#include "Domain/Tags.hpp"
 #include "Evolution/Systems/CurvedScalarWave/Tags.hpp"
 #include "Options/Options.hpp"
+#include "Utilities/Gsl.hpp"
 
 namespace CurvedScalarWave::Worldtube {
 /*!
@@ -77,6 +82,23 @@ struct ExcisionSphere : db::SimpleTag {
 template <size_t Dim>
 struct CenteredFaceCoordinates : db::SimpleTag {
   using type = std::optional<tnsr::I<DataVector, Dim, Frame::Grid>>;
+};
+
+template <size_t Dim>
+struct CenteredFaceCoordinatesCompute : CenteredFaceCoordinates<Dim>,
+                                        db::ComputeTag {
+  using base = CenteredFaceCoordinates<Dim>;
+  using argument_tags =
+      tmpl::list<ExcisionSphere<Dim>, domain::Tags::Element<Dim>,
+                 domain::Tags::Coordinates<Dim, Frame::Grid>,
+                 domain::Tags::Mesh<Dim>>;
+  using return_type = std::optional<tnsr::I<DataVector, Dim, Frame::Grid>>;
+  static void function(
+      const gsl::not_null<std::optional<tnsr::I<DataVector, Dim, Frame::Grid>>*>
+          res,
+      const ::ExcisionSphere<Dim>& excision_sphere, const Element<Dim>& element,
+      const tnsr::I<DataVector, Dim, Frame::Grid>& grid_coords,
+      const Mesh<Dim>& mesh);
 };
 
 /*!

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/CMakeLists.txt
@@ -39,7 +39,7 @@ target_link_libraries(
   GeneralRelativityHelpers
   GeneralRelativitySolutions
   MathFunctions
-  GeneralRelativitySolutions
+  ScalarWaveWorldtube
   Utilities
   WaveEquationSolutions
 )

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/Test_Tags.cpp
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/Test_Tags.cpp
@@ -13,6 +13,7 @@
 #include "Framework/TestCreation.hpp"
 #include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
 
+namespace CurvedScalarWave::Worldtube {
 namespace {
 void test_excision_sphere_tag() {
   const std::unique_ptr<DomainCreator<3>> shell =
@@ -21,12 +22,11 @@ void test_excision_sphere_tag() {
   const auto shell_excision_sphere =
       shell->create_domain().excision_spheres().at("ExcisionSphere");
 
-  CHECK(
-      CurvedScalarWave::Worldtube::Tags::ExcisionSphere<3>::create_from_options(
-          shell, "ExcisionSphere") == shell_excision_sphere);
+  CHECK(Tags::ExcisionSphere<3>::create_from_options(shell, "ExcisionSphere") ==
+        shell_excision_sphere);
   CHECK_THROWS_WITH(
-      CurvedScalarWave::Worldtube::Tags::ExcisionSphere<3>::create_from_options(
-          shell, "OtherExcisionSphere"),
+      Tags::ExcisionSphere<3>::create_from_options(shell,
+                                                   "OtherExcisionSphere"),
       Catch::Matchers::Contains(
           "Specified excision sphere 'OtherExcisionSphere' not available. "
           "Available excision spheres are: (ExcisionSphere)"));
@@ -35,13 +35,11 @@ void test_excision_sphere_tag() {
 
 SPECTRE_TEST_CASE("Unit.Evolution.Systems.CurvedScalarWave.Worldtube.Tags",
                   "[Unit][Evolution]") {
-  CHECK(TestHelpers::test_option_tag<
-            CurvedScalarWave::Worldtube::OptionTags::ExcisionSphere>(
-            "Worldtube") == "Worldtube");
-  TestHelpers::db::test_simple_tag<
-      CurvedScalarWave::Worldtube::Tags::ExcisionSphere<3>>("ExcisionSphere");
-  TestHelpers::db::test_simple_tag<
-      CurvedScalarWave::Worldtube::Tags::ElementFacesGridCoordinates<3>>(
+  CHECK(TestHelpers::test_option_tag<OptionTags::ExcisionSphere>("Worldtube") ==
+        "Worldtube");
+  TestHelpers::db::test_simple_tag<Tags::ExcisionSphere<3>>("ExcisionSphere");
+  TestHelpers::db::test_simple_tag<Tags::ElementFacesGridCoordinates<3>>(
       "ElementFacesGridCoordinates");
   test_excision_sphere_tag();
 }
+}  // namespace CurvedScalarWave::Worldtube

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/Test_Tags.cpp
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/Test_Tags.cpp
@@ -40,6 +40,8 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.CurvedScalarWave.Worldtube.Tags",
   TestHelpers::db::test_simple_tag<Tags::ExcisionSphere<3>>("ExcisionSphere");
   TestHelpers::db::test_simple_tag<Tags::ElementFacesGridCoordinates<3>>(
       "ElementFacesGridCoordinates");
+  TestHelpers::db::test_simple_tag<Tags::CenteredFaceCoordinates<3>>(
+      "CenteredFaceCoordinates");
   test_excision_sphere_tag();
 }
 }  // namespace CurvedScalarWave::Worldtube


### PR DESCRIPTION
## Proposed changes
Adds a convenient compute tag that computes the grid coordinates of each element face abutting the worldtube