### PR TITLE
Enable AMR for ScalarWave

### DIFF
--- a/src/Evolution/Executables/ScalarWave/CMakeLists.txt
+++ b/src/Evolution/Executables/ScalarWave/CMakeLists.txt
@@ -2,6 +2,9 @@
 # See LICENSE.txt for details.
 
 set(LIBS_TO_LINK
+  Amr
+  AmrCriteria
+  AmrProjectors
   CoordinateMaps
   DiscontinuousGalerkin
   DomainCreators

--- a/src/Evolution/Executables/ScalarWave/Projector.hpp
+++ b/src/Evolution/Executables/ScalarWave/Projector.hpp
@@ -1,0 +1,107 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <unordered_map>
+#include <utility>
+
+#include "DataStructures/DataBox/PrefixHelpers.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/FixedHashMap.hpp"
+#include "DataStructures/Index.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "DataStructures/VariablesTag.hpp"
+#include "Domain/Amr/Flag.hpp"
+#include "Domain/Amr/Tags/Flags.hpp"
+#include "Domain/Amr/Tags/NeighborFlags.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Domain/Tags.hpp"
+#include "Evolution/DiscontinuousGalerkin/Tags/NeighborMesh.hpp"
+#include "Evolution/Systems/ScalarWave/Tags.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Projection.hpp"
+#include "ParallelAlgorithms/Amr/Projectors/Mesh.hpp"
+#include "Time/History.hpp"
+#include "Time/Tags.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+#include "Parallel/Printf.hpp"
+
+namespace amr {
+
+template <size_t Dim, typename System>
+struct Projector {
+  using MortarKey = std::pair<Direction<Dim>, ElementId<Dim>>;
+  template <typename MappedType>
+  using MortarMap =
+      std::unordered_map<MortarKey, MappedType, boost::hash<MortarKey>>;
+
+  using variables_tag = typename System::variables_tag;
+  using variables_t = typename variables_tag::type;
+
+  using argument_tags = tmpl::list<::domain::Tags::Element<Dim>>;
+  using return_tags =
+      tmpl::list<::domain::Tags::Mesh<Dim>,
+                 ::evolution::dg::Tags::NeighborMesh<Dim>, Tags::Flags<Dim>,
+                 variables_tag, ::ScalarWave::Tags::ConstraintGamma2,
+                 ::Tags::HistoryEvolvedVariables<variables_tag>,
+                 ::evolution::dg::Tags::MortarMesh<Dim>,
+                 ::evolution::dg::Tags::NormalCovectorAndMagnitude<Dim>>;
+
+  static void apply(
+      const gsl::not_null<Mesh<Dim>*> mesh,
+      const gsl::not_null<
+          typename ::evolution::dg::Tags::NeighborMesh<Dim>::type*>
+          neighbor_meshes,
+      const gsl::not_null<std::array<Flag, Dim>*> amr_flags,
+      const gsl::not_null<variables_t*> vars,
+      const gsl::not_null<Scalar<DataVector>*> gamma_2,
+      const gsl::not_null<TimeSteppers::History<variables_t>*> history,
+      const gsl::not_null<MortarMap<Mesh<Dim - 1>>*> mortar_meshes,
+      const gsl::not_null<
+          DirectionMap<Dim, std::optional<Variables<tmpl::list<
+                                evolution::dg::Tags::MagnitudeOfNormal,
+                                evolution::dg::Tags::NormalCovector<Dim>>>>>*>
+          normal_covector_quantities,
+      const Element<Dim>& element) {
+    const Mesh<Dim> old_mesh = *mesh;
+    *mesh = amr::projectors::mesh(old_mesh, *amr_flags);
+
+    const auto projection_matrices =
+        Spectral::p_projection_matrices(old_mesh, *mesh);
+
+    auto projected_vars =
+        apply_matrices(projection_matrices, *vars, old_mesh.extents());
+    *vars = std::move(projected_vars);
+
+    auto projected_gamma_2 =
+        apply_matrices(projection_matrices, get(*gamma_2), old_mesh.extents());
+    get(*gamma_2) = std::move(projected_gamma_2);
+
+    history->map_entries([&projection_matrices, &old_mesh](const auto entry) {
+      *entry = apply_matrices(projection_matrices, *entry, old_mesh.extents());
+    });
+
+    for (const auto& [direction, neighbors] : element.neighbors()) {
+      (*normal_covector_quantities)[direction] = std::nullopt;
+      for (const auto& neighbor : neighbors) {
+        const auto mortar_id = std::make_pair(direction, neighbor);
+        (*mortar_meshes)[mortar_id] = ::dg::mortar_mesh(
+            mesh->slice_away(direction.dimension()),
+            neighbor_meshes->at(mortar_id).slice_away(direction.dimension()));
+      }
+    }
+    for (const auto& direction : element.external_boundaries()) {
+      (*normal_covector_quantities)[direction] = std::nullopt;
+    }
+  }
+};
+
+}  // namespace amr

--- a/src/NumericalAlgorithms/Spectral/Projection.hpp
+++ b/src/NumericalAlgorithms/Spectral/Projection.hpp
@@ -101,4 +101,10 @@ projection_matrix_parent_to_child(
     const Mesh<Dim>& parent_mesh, const Mesh<Dim>& child_mesh,
     const std::array<ChildSize, Dim>& child_sizes);
 
+/// The projection matrices from a source mesh to a target mesh where the
+/// meshes cover the same physical volume
+template <size_t Dim>
+std::array<std::reference_wrapper<const Matrix>, Dim> p_projection_matrices(
+    const Mesh<Dim>& source_mesh, const Mesh<Dim>& target_mesh);
+
 }  // namespace Spectral

--- a/src/ParallelAlgorithms/Amr/Actions/AdjustDomain.hpp
+++ b/src/ParallelAlgorithms/Amr/Actions/AdjustDomain.hpp
@@ -1,0 +1,66 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "Domain/Amr/Flag.hpp"
+#include "Domain/Amr/Tags/Flags.hpp"
+#include "Domain/Amr/Tags/NeighborFlags.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "Utilities/Algorithm.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
+
+// #include "Parallel/Printf.hpp"
+
+namespace amr {
+template <size_t Dim, typename System>
+struct Projector;
+}
+
+namespace amr::Actions {
+struct AdjustDomain {
+  template <typename ParallelComponent, typename DbTagList,
+            typename Metavariables, typename ArrayIndex>
+  static void apply(db::DataBox<DbTagList>& box,
+                    Parallel::GlobalCache<Metavariables>& cache,
+                    const ArrayIndex& array_index) {
+    constexpr size_t volume_dim = Metavariables::volume_dim;
+    const auto& my_amr_flags = db::get<amr::Tags::Flags<volume_dim>>(box);
+    auto& element_array =
+        Parallel::get_parallel_component<ParallelComponent>(cache);
+    auto my_proxy = element_array[array_index];
+
+    if (alg::any_of(my_amr_flags,
+                    [](amr::Flag flag) { return flag == amr::Flag::Split; })) {
+      ERROR("h-refinement not supported yet\n");
+    } else if (alg::any_of(my_amr_flags, [](amr::Flag flag) {
+                 return flag == amr::Flag::Join;
+               })) {
+      ERROR("h-refinement not supported yet\n");
+    } else if (alg::any_of(my_amr_flags, [](amr::Flag flag) {
+                 return (flag == amr::Flag::IncreaseResolution or
+                         flag == amr::Flag::DecreaseResolution);
+               })) {
+      db::mutate_apply<
+          amr::Projector<volume_dim, typename Metavariables::system>>(
+          make_not_null(&box));
+    }
+    db::mutate<amr::Tags::Flags<volume_dim>,
+               amr::Tags::NeighborFlags<volume_dim>>(
+        make_not_null(&box),
+        [](const gsl::not_null<std::array<amr::Flag, volume_dim>*> amr_flags,
+           const gsl::not_null<std::unordered_map<
+               ElementId<volume_dim>, std::array<amr::Flag, volume_dim>>*>
+               amr_flags_of_neighbors) {
+          amr_flags_of_neighbors->clear();
+          for (size_t d = 0; d < volume_dim; ++d) {
+            (*amr_flags)[d] = amr::Flag::Undefined;
+          }
+        });
+  }
+};
+}  // namespace amr::Actions

--- a/tests/InputFiles/ScalarWave/PlaneWave1D.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave1D.yaml
@@ -6,6 +6,7 @@
 
 ResourceInfo:
   AvoidGlobalProc0: false
+  Singletons: Auto
 
 InitialData: &InitialData
   PlaneWave:
@@ -17,25 +18,16 @@ InitialData: &InitialData
         Wavenumber: 1.0
         Phase: 0.0
 
+Criteria:
+
 PhaseChangeAndTriggers:
 
 Evolution:
   InitialTime: 0.0
   InitialTimeStep: 0.001
-  InitialSlabSize: 0.1
   TimeStepper:
     AdamsBashforth:
       Order: 3
-  StepChoosers:
-    - PreventRapidIncrease
-    - Increase:
-        Factor: 2
-    - ErrorControl:
-        AbsoluteTolerance: 1.0e-5
-        RelativeTolerance: 1.0e-5
-        MaxFactor: 10000.0
-        MinFactor: 0.0
-        SafetyFactor: 0.9
 
 DomainCreator:
   RotatedIntervals:

--- a/tests/InputFiles/ScalarWave/PlaneWave1DEventsAndTriggersExample.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave1DEventsAndTriggersExample.yaml
@@ -8,6 +8,7 @@
 
 ResourceInfo:
   AvoidGlobalProc0: false
+  Singletons: Auto
 
 InitialData:
   PlaneWave:
@@ -19,17 +20,16 @@ InitialData:
         Wavenumber: 1.0
         Phase: 0.0
 
+Criteria:
+
 PhaseChangeAndTriggers:
 
 Evolution:
   InitialTime: 0.0
   InitialTimeStep: 0.001
-  InitialSlabSize: 0.01
   TimeStepper:
     AdamsBashforth:
       Order: 3
-  StepChoosers:
-    - Constant: 0.001
 
 DomainCreator:
   Interval:

--- a/tests/InputFiles/ScalarWave/PlaneWave1DObserveExample.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave1DObserveExample.yaml
@@ -9,6 +9,7 @@
 
 ResourceInfo:
   AvoidGlobalProc0: false
+  Singletons: Auto
 
 InitialData:
   PlaneWave:
@@ -20,22 +21,28 @@ InitialData:
         Wavenumber: 1.0
         Phase: 0.0
 
+Criteria:
+  - DriveToTarget:
+      TargetNumberOfGridPoints: [7]
+      TargetRefinementLevels: [2]
+      OscillationAtTarget: [IncreaseResolution]
+
 PhaseChangeAndTriggers:
+  - - Slabs:
+        EvenlySpaced:
+          Interval: 100
+          Offset: 0
+    - - VisitAndReturn(EvaluateAmrCriteria)
+      - VisitAndReturn(AdjustDomain)
+      - VisitAndReturn(CheckDomain)
 
 Evolution:
   InitialTime: &InitialTime
     0.0
   InitialTimeStep: 0.001
-  InitialSlabSize: 0.01
   TimeStepper:
     AdamsBashforth:
       Order: 3
-  StepChoosers:
-    - Constant: 0.05
-    - Increase:
-        Factor: 2
-    - Cfl:
-        SafetyFactor: 0.2
 
 DomainCreator:
   Interval:
@@ -84,7 +91,7 @@ EventsAndDenseTriggers:
 EventsAndTriggers:
   - - Slabs:
         Specified:
-          Values: [100]
+          Values: [1000]
     - - Completion
   - - Slabs:
         EvenlySpaced:

--- a/tests/InputFiles/ScalarWave/PlaneWave2D.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave2D.yaml
@@ -8,6 +8,7 @@
 
 ResourceInfo:
   AvoidGlobalProc0: false
+  Singletons: Auto
 
 InitialData:
   PlaneWave:
@@ -19,28 +20,16 @@ InitialData:
         Wavenumber: 1.0
         Phase: 0.0
 
+Criteria:
+
 PhaseChangeAndTriggers:
 
 Evolution:
   InitialTime: &initial_time 0.0
   InitialTimeStep: 0.001
-  InitialSlabSize: 0.01
   TimeStepper:
     AdamsBashforth:
       Order: 3
-  StepChoosers:
-    - Constant: 0.05
-    - Increase:
-        Factor: 2
-    - ElementSizeCfl:
-        SafetyFactor: 0.5
-    - ErrorControl:
-        AbsoluteTolerance: 1e-6
-        RelativeTolerance: 1e-4
-        MaxFactor: 2
-        MinFactor: 0.25
-        SafetyFactor: 0.95
-
 
 DomainCreator:
   Rectangle:

--- a/tests/InputFiles/ScalarWave/PlaneWave3D.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave3D.yaml
@@ -6,6 +6,7 @@
 
 ResourceInfo:
   AvoidGlobalProc0: false
+  Singletons: Auto
 
 InitialData:
   PlaneWave:
@@ -17,21 +18,16 @@ InitialData:
         Wavenumber: 1.0
         Phase: 0.0
 
+Criteria:
+
 PhaseChangeAndTriggers:
 
 Evolution:
   InitialTime: 0.0
   InitialTimeStep: 0.001
-  InitialSlabSize: 0.01
   TimeStepper:
     AdamsBashforth:
       Order: 3
-  StepChoosers:
-    - Constant: 0.05
-    - Increase:
-        Factor: 2
-    - Cfl:
-        SafetyFactor: 0.2
 
 DomainCreator:
   Brick:


### PR DESCRIPTION
In case anyone wants to test a p-refinement criteria, this adds the code necessary to do p-refinement for a scalar wave.

The input file:  `PlaneWave1DObserveExample.yaml` demonstrates this by oscillating between two resolutions during the evolution.

The `amr::Projector` mutator will need to be factored/generalized/rewritten to handle other evolution systems, local time-stepping, ...


## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
