### PR TITLE
Add Worldtube ExpansionOrder tag

### DIFF
--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/Tags.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/Tags.hpp
@@ -33,6 +33,7 @@ namespace OptionTags {
 struct Worldtube {
   static constexpr Options::String help = {"Options for the Worldtube"};
 };
+
 /*!
  * \brief Name of the excision sphere designated to act as a worldtube
  */
@@ -43,6 +44,17 @@ struct ExcisionSphere {
   using group = Worldtube;
 };
 
+/*!
+ * \brief The internal expansion order of the worldtube solution.
+ */
+struct ExpansionOrder {
+  using type = size_t;
+  static constexpr Options::String help{
+      "The internal expansion order of the worldtube solution. Currently only "
+      "order 0 is implemented"};
+  static size_t upper_bound() { return 0; }
+  using group = Worldtube;
+};
 }  // namespace OptionTags
 
 /*!
@@ -99,6 +111,15 @@ struct CenteredFaceCoordinatesCompute : CenteredFaceCoordinates<Dim>,
       const ::ExcisionSphere<Dim>& excision_sphere, const Element<Dim>& element,
       const tnsr::I<DataVector, Dim, Frame::Grid>& grid_coords,
       const Mesh<Dim>& mesh);
+};
+
+/*!
+ * \brief The internal expansion order of the worldtube solution.
+ */
+struct ExpansionOrder : db::SimpleTag {
+  using type = size_t;
+  using options_tag = tmpl::list<OptionTags::ExpansionOrder>;
+  static size_t create_from_options(const size_t order) { return order; }
 };
 
 /*!

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/Test_Tags.cpp
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/Test_Tags.cpp
@@ -143,7 +143,11 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.CurvedScalarWave.Worldtube.Tags",
                   "[Unit][Evolution]") {
   CHECK(TestHelpers::test_option_tag<OptionTags::ExcisionSphere>("Worldtube") ==
         "Worldtube");
+  CHECK(TestHelpers::test_option_tag<
+            CurvedScalarWave::Worldtube::OptionTags::ExpansionOrder>("0") == 0);
   TestHelpers::db::test_simple_tag<Tags::ExcisionSphere<3>>("ExcisionSphere");
+  TestHelpers::db::test_simple_tag<
+      CurvedScalarWave::Worldtube::Tags::ExpansionOrder>("ExpansionOrder");
   TestHelpers::db::test_simple_tag<Tags::ElementFacesGridCoordinates<3>>(
       "ElementFacesGridCoordinates");
   TestHelpers::db::test_simple_tag<Tags::CenteredFaceCoordinates<3>>(


### PR DESCRIPTION
## Proposed changes
Adds an option tag that sets the expansion order of the internal worldtube solution.