### PR TITLE
Add `InertialParticlePosition` compute tag

### DIFF
--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/Tags.cpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/Tags.cpp
@@ -7,11 +7,13 @@
 #include "Evolution/Systems/CurvedScalarWave/Worldtube/Tags.hpp"
 
 #include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/Structure/Element.hpp"
 #include "Domain/Structure/ExcisionSphere.hpp"
 #include "Evolution/DiscontinuousGalerkin/ProjectToBoundary.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "Time/Tags.hpp"
 #include "Utilities/ContainerHelpers.hpp"
 #include "Utilities/Gsl.hpp"
 
@@ -45,5 +47,23 @@ void CenteredFaceCoordinatesCompute<Dim>::function(
   }
 }
 
+template <size_t Dim>
+void InertialParticlePositionCompute<Dim>::function(
+    gsl::not_null<tnsr::I<double, Dim, Frame::Inertial>*> inertial_position,
+    const ::ExcisionSphere<Dim>& excision_sphere, const double time) {
+  const auto& grid_position = excision_sphere.center();
+  const double orbital_radius = get(magnitude(grid_position));
+
+  // assume circular orbit around black hole with mass 1
+  const double angular_velocity = 1. / (sqrt(orbital_radius) * orbital_radius);
+  const double angle = angular_velocity * time;
+  inertial_position->get(0) =
+      cos(angle) * grid_position.get(0) - sin(angle) * grid_position.get(1);
+  inertial_position->get(1) =
+      sin(angle) * grid_position.get(0) + cos(angle) * grid_position.get(1);
+  inertial_position->get(2) = grid_position.get(2);
+}
+
 template struct CenteredFaceCoordinatesCompute<3>;
+template struct InertialParticlePositionCompute<3>;
 }  // namespace CurvedScalarWave::Worldtube::Tags

--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/Tags.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/Tags.hpp
@@ -73,6 +73,22 @@ struct ExcisionSphere : db::SimpleTag {
   }
 };
 
+/// @{
+/*!
+ * \brief The position of the scalar charge particle orbiting a central black
+ * hole given in inertial coordinates. We currently assume a circular orbit in
+ * the xy-plane with radius \f$R\f$ and angular velocity \f$\omega =
+ * R^{-3/2}\f$, where grid and inertial coordinates are equal at t = 0.
+ *
+ * Coordinate maps are only saved in Blocks at the moment. More generic
+ * orbits will probably require injecting the grid-to-inertial coordinate map
+ * into the ExcisionSpheres as well.
+ */
+template <size_t Dim>
+struct InertialParticlePosition : db::SimpleTag {
+  using type = tnsr::I<double, Dim, Frame::Inertial>;
+};
+
 /*!
  * \brief An optional that holds the grid coordinates, centered on the
  * worldtube, of an element face abutting the worldtube excision sphere. If the

--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/Tags.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/Tags.hpp
@@ -102,6 +102,7 @@ struct InertialParticlePositionCompute : InertialParticlePosition<Dim>,
 };
 /// @}
 
+/// @{
 /*!
  * \brief An optional that holds the grid coordinates, centered on the
  * worldtube, of an element face abutting the worldtube excision sphere. If the
@@ -129,6 +130,7 @@ struct CenteredFaceCoordinatesCompute : CenteredFaceCoordinates<Dim>,
       const tnsr::I<DataVector, Dim, Frame::Grid>& grid_coords,
       const Mesh<Dim>& mesh);
 };
+/// @}
 
 /*!
  * \brief A map that holds the grid coordinates centered on the worldtube of

--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/Tags.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/Tags.hpp
@@ -20,6 +20,7 @@
 #include "Domain/Tags.hpp"
 #include "Evolution/Systems/CurvedScalarWave/Tags.hpp"
 #include "Options/Options.hpp"
+#include "Time/Tags.hpp"
 #include "Utilities/Gsl.hpp"
 
 namespace CurvedScalarWave::Worldtube {
@@ -88,6 +89,18 @@ template <size_t Dim>
 struct InertialParticlePosition : db::SimpleTag {
   using type = tnsr::I<double, Dim, Frame::Inertial>;
 };
+
+template <size_t Dim>
+struct InertialParticlePositionCompute : InertialParticlePosition<Dim>,
+                                         db::ComputeTag {
+  using base = InertialParticlePosition<Dim>;
+  using return_type = tnsr::I<double, Dim, Frame::Inertial>;
+  using argument_tags = tmpl::list<ExcisionSphere<Dim>, ::Tags::Time>;
+  static void function(
+      gsl::not_null<tnsr::I<double, Dim, Frame::Inertial>*> position,
+      const ::ExcisionSphere<Dim>& excision_sphere, const double time);
+};
+/// @}
 
 /*!
  * \brief An optional that holds the grid coordinates, centered on the

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/Test_Tags.cpp
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/Test_Tags.cpp
@@ -148,6 +148,9 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.CurvedScalarWave.Worldtube.Tags",
       "ElementFacesGridCoordinates");
   TestHelpers::db::test_simple_tag<Tags::CenteredFaceCoordinates<3>>(
       "CenteredFaceCoordinates");
+  TestHelpers::db::test_simple_tag<Tags::InertialParticlePosition<3>>(
+      "InertialParticlePosition");
+
   test_excision_sphere_tag();
   test_compute_centered_face_coordinates();
 }

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/Test_Tags.cpp
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/Test_Tags.cpp
@@ -7,8 +7,14 @@
 #include <cstddef>
 #include <memory>
 #include <optional>
+#include <random>
 
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/Block.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/Rotation.hpp"
 #include "Domain/CreateInitialElement.hpp"
 #include "Domain/Creators/DomainCreator.hpp"
 #include "Domain/Creators/Shell.hpp"
@@ -18,6 +24,7 @@
 #include "Evolution/Systems/CurvedScalarWave/Worldtube/SingletonActions/InitializeElementFacesGridCoordinates.hpp"
 #include "Evolution/Systems/CurvedScalarWave/Worldtube/Tags.hpp"
 #include "Framework/TestCreation.hpp"
+#include "Framework/TestHelpers.hpp"
 #include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
 #include "NumericalAlgorithms/Spectral/LogicalCoordinates.hpp"
 #include "ParallelAlgorithms/Initialization/MutateAssign.hpp"
@@ -137,6 +144,34 @@ void test_compute_centered_face_coordinates() {
     }
   }
 }
+
+void test_inertial_particle_position_compute() {
+  static constexpr size_t Dim = 3;
+  MAKE_GENERATOR(gen);
+  std::uniform_real_distribution<> dist(-10., 10.);
+  const tnsr::I<double, Dim, Frame::Grid> grid_coords_center{
+      {dist(gen), dist(gen), 0.}};
+  const double orbit_radius = get(magnitude(grid_coords_center));
+  const double angular_velocity = 1. / (sqrt(orbit_radius) * orbit_radius);
+  const ::ExcisionSphere<Dim> excision_sphere{2., grid_coords_center, {}};
+  const double initial_time = 0.;
+  auto box = db::create<
+      db::AddSimpleTags<Tags::ExcisionSphere<Dim>, ::Tags::Time>,
+      db::AddComputeTags<Tags::InertialParticlePositionCompute<Dim>>>(
+      excision_sphere, initial_time);
+  for (size_t i = 0; i < 100; ++i) {
+    const double random_time = dist(gen);
+    ::Initialization::mutate_assign<tmpl::list<::Tags::Time>>(
+        make_not_null(&box), random_time);
+    const auto coordinate_map =
+        domain::make_coordinate_map<Frame::Grid, Frame::Inertial>(
+            domain::CoordinateMaps::Rotation<Dim>(
+                angular_velocity * random_time, 0., 0.));
+    const auto& inertial_pos =
+        db::get<Tags::InertialParticlePosition<Dim>>(box);
+    CHECK_ITERABLE_APPROX(inertial_pos, coordinate_map(grid_coords_center));
+  }
+}
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Evolution.Systems.CurvedScalarWave.Worldtube.Tags",
@@ -153,5 +188,6 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.CurvedScalarWave.Worldtube.Tags",
 
   test_excision_sphere_tag();
   test_compute_centered_face_coordinates();
+  test_inertial_particle_position_compute();
 }
 }  // namespace CurvedScalarWave::Worldtube


### PR DESCRIPTION
## Proposed changes
Adds a compute tag that calculates the inertial position of the scalar charge particle assumed to be on a circular orbit. For generic orbits, we should probably inject block maps into `ExcisionSphere`.

~for convenience this depends on #4771~