### PR TITLE
Generalize FaceCenteredCoordinates to Frame and Centered

### DIFF
--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/CMakeLists.txt
@@ -36,6 +36,8 @@ target_link_libraries(
   CurvedWaveEquationAnalyticData
   CurvedScalarWaveHelpers
   DataStructures
+  DomainBoundaryConditions
+  DomainBoundaryConditionsHelpers
   DomainCreators
   GeneralRelativityHelpers
   GeneralRelativitySolutions

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/Test_Tags.cpp
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/Test_Tags.cpp
@@ -16,19 +16,26 @@
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/Rotation.hpp"
 #include "Domain/CreateInitialElement.hpp"
+#include "Domain/Creators/BinaryCompactObject.hpp"
 #include "Domain/Creators/DomainCreator.hpp"
 #include "Domain/Creators/Shell.hpp"
+#include "Domain/Creators/Tags/FunctionsOfTime.hpp"
 #include "Domain/ElementMap.hpp"
 #include "Domain/Structure/CreateInitialMesh.hpp"
 #include "Domain/Structure/InitialElementIds.hpp"
+#include "Domain/TagsTimeDependent.hpp"
 #include "Evolution/Systems/CurvedScalarWave/Worldtube/SingletonActions/InitializeElementFacesGridCoordinates.hpp"
 #include "Evolution/Systems/CurvedScalarWave/Worldtube/Tags.hpp"
 #include "Framework/TestCreation.hpp"
 #include "Framework/TestHelpers.hpp"
 #include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
+#include "Helpers/Domain/Creators/TestHelpers.hpp"
+#include "Helpers/Domain/DomainTestHelpers.hpp"
+#include "Helpers/Evolution/Systems/CurvedScalarWave/Worldtube/TestHelpers.hpp"
 #include "NumericalAlgorithms/Spectral/LogicalCoordinates.hpp"
 #include "ParallelAlgorithms/Initialization/MutateAssign.hpp"
 #include "Utilities/CartesianProduct.hpp"
+#include "Utilities/TMPL.hpp"
 
 namespace CurvedScalarWave::Worldtube {
 namespace {
@@ -111,11 +118,11 @@ void test_compute_face_coordinates_grid() {
       auto box =
           db::create<db::AddSimpleTags<
                          Tags::ExcisionSphere<Dim>, domain::Tags::Element<Dim>,
-                            domain::Tags::Coordinates<Dim, Frame::Grid>,
-                            domain::Tags::Mesh<Dim>>,
+                         domain::Tags::Coordinates<Dim, Frame::Grid>,
+                         domain::Tags::Mesh<Dim>>,
                      db::AddComputeTags<
                          Tags::FaceCoordinatesCompute<Dim, Frame::Grid, true>>>(
-          excision_sphere, element, grid_coords_1, mesh_1);
+              excision_sphere, element, grid_coords_1, mesh_1);
 
       const auto centered_face_coordinates_1 =
           db::get<Tags::FaceCoordinates<Dim, Frame::Grid, true>>(box);
@@ -150,6 +157,133 @@ void test_compute_face_coordinates_grid() {
   }
 }
 
+void test_compute_face_coordinates() {
+  static constexpr size_t Dim = 3;
+  const auto domain_creator =
+      TestHelpers::CurvedScalarWave::Worldtube::worldtube_binary_compact_object(
+          7., 0.2);
+  const double initial_time = 0.;
+  auto domain = domain_creator->create_domain();
+  const auto excision_sphere = domain.excision_spheres().at("ExcisionSphereA");
+  const auto& blocks = domain.blocks();
+  const auto initial_extents = domain_creator->initial_extents();
+  const auto initial_refinements = domain_creator->initial_refinement_levels();
+  const auto element_ids = initial_element_ids(initial_refinements);
+  const auto quadrature = Spectral::Quadrature::GaussLobatto;
+  std::unordered_map<ElementId<Dim>, tnsr::I<DataVector, Dim, Frame::Grid>>
+      all_faces_grid_coords{};
+  Initialization::InitializeElementFacesGridCoordinates<Dim>::apply(
+      make_not_null(&all_faces_grid_coords), domain, initial_extents,
+      initial_refinements, quadrature, excision_sphere);
+  for (const auto& element_id : element_ids) {
+    const auto& my_block = blocks.at(element_id.block_id());
+    const auto element = domain::Initialization::create_initial_element(
+        element_id, my_block, initial_refinements);
+    const auto mesh = domain::Initialization::create_initial_mesh(
+        initial_extents, element_id, quadrature);
+    const ElementMap element_map(
+        element_id,
+        my_block.moving_mesh_logical_to_grid_map().get_to_grid_frame());
+    const auto grid_coords = element_map(logical_coordinates(mesh));
+
+    auto box = db::create<
+        db::AddSimpleTags<::domain::Tags::Domain<3>, ::Tags::Time,
+                          Tags::ExcisionSphere<3>,
+                          domain::Tags::FunctionsOfTimeInitialize,
+                          domain::Tags::Element<Dim>, domain::Tags::Mesh<Dim>,
+                          domain::Tags::Coordinates<Dim, Frame::Grid>,
+                          ::domain::CoordinateMaps::Tags::CoordinateMap<
+                              Dim, Frame::Grid, Frame::Inertial>>,
+        db::AddComputeTags<
+            Tags::InertialParticlePositionCompute<3>,
+            ::domain::Tags::CoordinatesMeshVelocityAndJacobiansCompute<
+                ::domain::CoordinateMaps::Tags::CoordinateMap<Dim, Frame::Grid,
+                                                              Frame::Inertial>>,
+            ::domain::Tags::InertialFromGridCoordinatesCompute<Dim>,
+            Tags::FaceCoordinatesCompute<3, Frame::Grid, true>,
+            Tags::FaceCoordinatesCompute<3, Frame::Grid, false>,
+            Tags::FaceCoordinatesCompute<3, Frame::Inertial, true>,
+            Tags::FaceCoordinatesCompute<3, Frame::Inertial, false>>>(
+        domain_creator->create_domain(), initial_time, excision_sphere,
+        domain_creator->functions_of_time(), element, mesh, grid_coords,
+        my_block.moving_mesh_grid_to_inertial_map().get_clone());
+    const auto centered_grid_1 =
+        db::get<Tags::FaceCoordinatesCompute<3, Frame::Grid, true>>(box);
+    const auto uncentered_grid_1 =
+        db::get<Tags::FaceCoordinatesCompute<3, Frame::Grid, false>>(box);
+    const auto centered_inertial_1 =
+        db::get<Tags::FaceCoordinatesCompute<3, Frame::Inertial, true>>(box);
+    const auto uncentered_inertial_1 =
+        db::get<Tags::FaceCoordinatesCompute<3, Frame::Inertial, false>>(box);
+    if (all_faces_grid_coords.count(element_id)) {
+      CHECK(centered_grid_1.has_value());
+      CHECK(uncentered_grid_1.has_value());
+      CHECK(centered_inertial_1.has_value());
+      CHECK(uncentered_inertial_1.has_value());
+
+      CHECK_ITERABLE_APPROX(centered_grid_1.value(),
+                            all_faces_grid_coords.at(element_id));
+      for (size_t i = 0; i < 3; ++i) {
+        CHECK_ITERABLE_APPROX(centered_grid_1->get(i),
+                              centered_inertial_1->get(i));
+        CHECK_ITERABLE_APPROX(uncentered_grid_1->get(i),
+                              uncentered_inertial_1->get(i));
+        CHECK_ITERABLE_APPROX(
+            centered_grid_1->get(i),
+            uncentered_grid_1->get(i) - excision_sphere.center().get(i));
+      }
+    } else {
+      CHECK(not centered_grid_1.has_value());
+      CHECK(not uncentered_grid_1.has_value());
+      CHECK(not centered_inertial_1.has_value());
+      CHECK(not uncentered_inertial_1.has_value());
+    }
+
+    const double new_time = 5.;
+    ::Initialization::mutate_assign<tmpl::list<::Tags::Time>>(
+        make_not_null(&box), new_time);
+
+    const auto centered_grid_2 =
+        db::get<Tags::FaceCoordinatesCompute<3, Frame::Grid, true>>(box);
+    const auto uncentered_grid_2 =
+        db::get<Tags::FaceCoordinatesCompute<3, Frame::Grid, false>>(box);
+    const auto centered_inertial_2 =
+        db::get<Tags::FaceCoordinatesCompute<3, Frame::Inertial, true>>(box);
+    const auto uncentered_inertial_2 =
+        db::get<Tags::FaceCoordinatesCompute<3, Frame::Inertial, false>>(box);
+    if (all_faces_grid_coords.count(element_id)) {
+      CHECK(centered_grid_2.has_value());
+      CHECK(uncentered_grid_2.has_value());
+      CHECK(centered_inertial_2.has_value());
+      CHECK(uncentered_grid_2.has_value());
+
+      CHECK_ITERABLE_APPROX(centered_grid_2.value(), centered_grid_1.value());
+      CHECK_ITERABLE_APPROX(uncentered_grid_2.value(),
+                            uncentered_grid_1.value());
+      const auto& inertial_particle_position =
+          db::get<Tags::InertialParticlePosition<Dim>>(box);
+      const auto& grid_to_inertial_map =
+          db::get<::domain::CoordinateMaps::Tags::CoordinateMap<
+              Dim, Frame::Grid, Frame::Inertial>>(box);
+      const auto& functions_of_time =
+          db::get<domain::Tags::FunctionsOfTimeInitialize>(box);
+      CHECK_ITERABLE_APPROX(uncentered_inertial_2.value(),
+                            grid_to_inertial_map(uncentered_grid_2.value(),
+                                                 new_time, functions_of_time));
+      for (size_t i = 0; i < Dim; ++i) {
+        CHECK_ITERABLE_APPROX(
+            centered_inertial_2->get(i),
+            uncentered_inertial_2->get(i) - inertial_particle_position.get(i));
+      }
+    } else {
+      CHECK(not centered_grid_2.has_value());
+      CHECK(not uncentered_grid_2.has_value());
+      CHECK(not centered_inertial_2.has_value());
+      CHECK(not uncentered_inertial_2.has_value());
+    }
+  }
+}
+
 void test_inertial_particle_position_compute() {
   static constexpr size_t Dim = 3;
   MAKE_GENERATOR(gen);
@@ -179,6 +313,7 @@ void test_inertial_particle_position_compute() {
 }
 }  // namespace
 
+// [[TimeOut, 15]]
 SPECTRE_TEST_CASE("Unit.Evolution.Systems.CurvedScalarWave.Worldtube.Tags",
                   "[Unit][Evolution]") {
   CHECK(TestHelpers::test_option_tag<OptionTags::ExcisionSphere>("Worldtube") ==
@@ -203,6 +338,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.CurvedScalarWave.Worldtube.Tags",
 
   test_excision_sphere_tag();
   test_compute_face_coordinates_grid();
+  test_compute_face_coordinates();
   test_inertial_particle_position_compute();
 }
 }  // namespace CurvedScalarWave::Worldtube

--- a/tests/Unit/Helpers/Evolution/Systems/CurvedScalarWave/CMakeLists.txt
+++ b/tests/Unit/Helpers/Evolution/Systems/CurvedScalarWave/CMakeLists.txt
@@ -5,15 +5,17 @@ set(LIBRARY "CurvedScalarWaveHelpers")
 
 set(LIBRARY_SOURCES
   TestHelpers.cpp
+  Worldtube/TestHelpers.cpp
   )
 
-add_spectre_library(${LIBRARY} ${LIBRARY_SOURCES})
+add_spectre_library(${LIBRARY} ${SPECTRE_TEST_LIBS_TYPE} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}
-  PRIVATE
-  Utilities
-
   PUBLIC
   DataStructures
+  DomainBoundaryConditions
+  DomainBoundaryConditionsHelpers
+  DomainCreators
+  Framework
   )

--- a/tests/Unit/Helpers/Evolution/Systems/CurvedScalarWave/Worldtube/TestHelpers.cpp
+++ b/tests/Unit/Helpers/Evolution/Systems/CurvedScalarWave/Worldtube/TestHelpers.cpp
@@ -1,0 +1,76 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Helpers/Evolution/Systems/CurvedScalarWave/Worldtube/TestHelpers.hpp"
+
+#include <cstddef>
+#include <string>
+
+#include "Domain/Creators/BinaryCompactObject.hpp"
+#include "Domain/Creators/DomainCreator.hpp"
+#include "Domain/Creators/OptionTags.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Helpers/Domain/BoundaryConditions/BoundaryCondition.hpp"
+
+namespace TestHelpers::CurvedScalarWave::Worldtube {
+std::unique_ptr<DomainCreator<3>> worldtube_binary_compact_object(
+    const double orbit_radius, const double worldtube_radius) {
+  ASSERT(orbit_radius > 4. * worldtube_radius,
+         "Can't construct a domain with these parameters");
+  const double angular_velocity = 1. / (orbit_radius * sqrt(orbit_radius));
+  std::string binary_compact_object_options =
+      "BinaryCompactObject:\n"
+      "  ObjectA:\n"
+      "    InnerRadius: " +
+      std::to_string(worldtube_radius) +
+      "\n"
+      "    OuterRadius: " +
+      std::to_string(2. * worldtube_radius) +
+      "\n"
+      "    XCoord: " +
+      std::to_string(orbit_radius) +
+      "\n"
+      "    Interior:\n"
+      "      ExciseWithBoundaryCondition:\n"
+      "        None:\n"
+      "    UseLogarithmicMap: false\n"
+      "  ObjectB:\n"
+      "    InnerRadius: 1.9\n"
+      "    OuterRadius: 3.0\n"
+      "    XCoord: -1e-99\n"
+      "    Interior:\n"
+      "      ExciseWithBoundaryCondition:\n"
+      "        None\n"
+      "    UseLogarithmicMap: false\n"
+      "  Envelope:\n"
+      "    Radius: 30.0\n"
+      "    UseProjectiveMap: false\n"
+      "  OuterShell:\n"
+      "    Radius: 50.0\n"
+      "    RadialDistribution: Linear\n"
+      "    BoundaryCondition:\n"
+      "      None\n"
+      "  InitialRefinement: 0\n"
+      "  InitialGridPoints: 3\n"
+      "  UseEquiangularMap: true\n"
+      "  TimeDependentMaps:\n"
+      "    InitialTime: 0.0\n"
+      "    ExpansionMap: \n"
+      "      OuterBoundary: 1.0\n"
+      "      InitialExpansion: 1.0\n"
+      "      InitialExpansionVelocity: 0.0\n"
+      "      AsymptoticVelocityOuterBoundary: 0.0\n"
+      "      DecayTimescaleOuterBoundaryVelocity: 1.0\n"
+      "    RotationMap:\n"
+      "      InitialAngularVelocity: [0.0, 0.0," +
+      std::to_string(angular_velocity) +
+      "]\n"
+      "    SizeMap:\n"
+      "      InitialValues: [0.0, 0.0]\n"
+      "      InitialVelocities: [0.0, 0.0]\n"
+      "      InitialAccelerations: [0.0, 0.0]";
+  return ::TestHelpers::test_option_tag<::domain::OptionTags::DomainCreator<3>,
+                                        Metavariables>(
+      binary_compact_object_options);
+}
+}  // namespace TestHelpers::CurvedScalarWave::Worldtube

--- a/tests/Unit/Helpers/Evolution/Systems/CurvedScalarWave/Worldtube/TestHelpers.hpp
+++ b/tests/Unit/Helpers/Evolution/Systems/CurvedScalarWave/Worldtube/TestHelpers.hpp
@@ -1,0 +1,40 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <string>
+
+#include "Domain/Creators/BinaryCompactObject.hpp"
+#include "Domain/Creators/DomainCreator.hpp"
+#include "Domain/Protocols/Metavariables.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/Domain/BoundaryConditions/BoundaryCondition.hpp"
+#include "Helpers/Domain/Creators/TestHelpers.hpp"
+#include "Helpers/Domain/DomainTestHelpers.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace TestHelpers::CurvedScalarWave::Worldtube {
+struct Metavariables {
+  struct domain : tt::ConformsTo<::domain::protocols::Metavariables> {
+    static constexpr bool enable_time_dependent_maps = true;
+  };
+  using system =
+      TestHelpers::domain::BoundaryConditions::SystemWithBoundaryConditions<3>;
+  struct factory_creation
+      : tt::ConformsTo<Options::protocols::FactoryCreation> {
+    using factory_classes = tmpl::map<tmpl::pair<
+        DomainCreator<3>, tmpl::list<::domain::creators::BinaryCompactObject>>>;
+  };
+};
+
+// returns a binary compact object domain creator with the excision spheres
+// corresponding to the circular worldtube setup: a central excision sphere
+// (the central black hole) and a worldtube excision sphere in circular orbit
+// around it with angular velocity R^{-3/2}, where R is the orbital radius.
+std::unique_ptr<DomainCreator<3>> worldtube_binary_compact_object(
+    const double orbit_radius, const double worldtube_radius);
+
+}  // namespace TestHelpers::CurvedScalarWave::Worldtube


### PR DESCRIPTION
Generalizes the `FaceCenteredCoordinates` compute tag to Grid and Inertial frames as well as centered and un-centered.