### PR TITLE
Use iterable approx in control error tests

### DIFF
--- a/tests/Unit/ControlSystem/ControlErrors/Test_Expansion.cpp
+++ b/tests/Unit/ControlSystem/ControlErrors/Test_Expansion.cpp
@@ -122,7 +122,7 @@ void test_expansion_control_error() {
   const DataVector expected_control_error{exp_factor *
                                           (pos_diff / grid_diff - 1.0)};
 
-  CHECK(control_error == expected_control_error);
+  CHECK_ITERABLE_APPROX(control_error, expected_control_error);
 }
 
 SPECTRE_TEST_CASE("Unit.ControlSystem.ControlErrors.Expansion",

--- a/tests/Unit/ControlSystem/ControlErrors/Test_Rotation.cpp
+++ b/tests/Unit/ControlSystem/ControlErrors/Test_Rotation.cpp
@@ -116,7 +116,7 @@ void test_rotation_control_error() {
   const DataVector expected_control_error =
       DataVector{{0.0, -15.0, 105.0}} / 75.0;
 
-  CHECK(control_error == expected_control_error);
+  CHECK_ITERABLE_APPROX(control_error, expected_control_error);
 }
 
 SPECTRE_TEST_CASE("Unit.ControlSystem.ControlErrors.Rotation",

--- a/tests/Unit/ControlSystem/ControlErrors/Test_Shape.cpp
+++ b/tests/Unit/ControlSystem/ControlErrors/Test_Shape.cpp
@@ -191,7 +191,7 @@ void test_shape_control_error() {
     }
   }
 
-  CHECK(control_error == expected_control_error);
+  CHECK_ITERABLE_APPROX(control_error, expected_control_error);
 }
 
 SPECTRE_TEST_CASE("Unit.ControlSystem.ControlErrors.Shape",


### PR DESCRIPTION
## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
