### PR TITLE
Add distorted frame to BBH domains

### DIFF
--- a/src/Domain/Creators/CylindricalBinaryCompactObject.cpp
+++ b/src/Domain/Creators/CylindricalBinaryCompactObject.cpp
@@ -382,6 +382,17 @@ CylindricalBinaryCompactObject::CylindricalBinaryCompactObject(
           use_equiangular_map, initial_refinement, initial_grid_points,
           std::move(inner_boundary_condition),
           std::move(outer_boundary_condition), context) {
+  // The size map, which is applied from the grid to distorted frame, currently
+  // needs to start and stop at certain radii around each excision. If the inner
+  // spheres aren't included, the outer radii would have to be in the middle of
+  // a block. With the inner spheres, the outer radii can be at block
+  // boundaries.
+  if (not (include_inner_sphere_A and include_inner_sphere_B)) {
+    PARSE_ERROR(context,
+                "To use the CylindricalBBH domain with time-dependent maps, "
+                "you must include the inner spheres for both objects. "
+                "Currently, one or both objects is missing the inner spheres.");
+  }
   is_time_dependent_ = true;
   initial_time_ = initial_time;
   expansion_map_options_ = expansion_map_options;

--- a/tests/Unit/Domain/Creators/Test_CylindricalBinaryCompactObject.cpp
+++ b/tests/Unit/Domain/Creators/Test_CylindricalBinaryCompactObject.cpp
@@ -101,7 +101,8 @@ void test_connectivity_once(const bool with_sphere_e,
                             const bool include_inner_sphere_A,
                             const bool include_inner_sphere_B,
                             const bool include_outer_sphere,
-                            const bool use_equiangular_map) {
+                            const bool use_equiangular_map,
+                            const bool with_boundary_conditions) {
   // Misc.:
   constexpr size_t refinement = 1;
   constexpr size_t grid_points = 3;
@@ -122,243 +123,209 @@ void test_connectivity_once(const bool with_sphere_e,
   const double inner_radius_objectA = 2.0 * mass_ratio / (1.0 + mass_ratio);
   const double inner_radius_objectB = 2.0 / (1.0 + mass_ratio);
 
-  for (const bool with_boundary_conditions : {true, false}) {
-    CAPTURE(with_boundary_conditions);
-    const domain::creators::CylindricalBinaryCompactObject
-        binary_compact_object{
-            center_objectA,
-            center_objectB,
-            inner_radius_objectA,
-            inner_radius_objectB,
-            include_inner_sphere_A,
-            include_inner_sphere_B,
-            include_outer_sphere,
-            outer_radius,
-            use_equiangular_map,
-            refinement,
-            grid_points,
-            with_boundary_conditions ? create_inner_boundary_condition()
-                                     : nullptr,
-            with_boundary_conditions ? create_outer_boundary_condition()
-                                     : nullptr};
+  const domain::creators::CylindricalBinaryCompactObject binary_compact_object{
+      center_objectA,
+      center_objectB,
+      inner_radius_objectA,
+      inner_radius_objectB,
+      include_inner_sphere_A,
+      include_inner_sphere_B,
+      include_outer_sphere,
+      outer_radius,
+      use_equiangular_map,
+      refinement,
+      grid_points,
+      with_boundary_conditions ? create_inner_boundary_condition() : nullptr,
+      with_boundary_conditions ? create_outer_boundary_condition() : nullptr};
 
-    std::vector<std::string> block_names{
-        "CAFilledCylinderCenter", "CAFilledCylinderEast",
-        "CAFilledCylinderNorth",  "CAFilledCylinderWest",
-        "CAFilledCylinderSouth",  "CACylinderEast",
-        "CACylinderNorth",        "CACylinderWest",
-        "CACylinderSouth",        "EAFilledCylinderCenter",
-        "EAFilledCylinderEast",   "EAFilledCylinderNorth",
-        "EAFilledCylinderWest",   "EAFilledCylinderSouth",
-        "EACylinderEast",         "EACylinderNorth",
-        "EACylinderWest",         "EACylinderSouth",
-        "EBFilledCylinderCenter", "EBFilledCylinderEast",
-        "EBFilledCylinderNorth",  "EBFilledCylinderWest",
-        "EBFilledCylinderSouth",  "EBCylinderEast",
-        "EBCylinderNorth",        "EBCylinderWest",
-        "EBCylinderSouth",        "MAFilledCylinderCenter",
-        "MAFilledCylinderEast",   "MAFilledCylinderNorth",
-        "MAFilledCylinderWest",   "MAFilledCylinderSouth",
-        "MBFilledCylinderCenter", "MBFilledCylinderEast",
-        "MBFilledCylinderNorth",  "MBFilledCylinderWest",
-        "MBFilledCylinderSouth",  "CBFilledCylinderCenter",
-        "CBFilledCylinderEast",   "CBFilledCylinderNorth",
-        "CBFilledCylinderWest",   "CBFilledCylinderSouth",
-        "CBCylinderEast",         "CBCylinderNorth",
-        "CBCylinderWest",         "CBCylinderSouth"};
-    std::unordered_map<std::string, std::unordered_set<std::string>>
-        block_groups{
-            {"Outer",
-             {{"CAFilledCylinderCenter", "CBCylinderEast",
-               "CAFilledCylinderEast", "CAFilledCylinderNorth",
-               "CBFilledCylinderNorth", "CACylinderEast",
-               "CBFilledCylinderEast", "CAFilledCylinderSouth",
-               "CACylinderNorth", "CAFilledCylinderWest", "CACylinderWest",
-               "CACylinderSouth", "CBFilledCylinderCenter",
-               "CBFilledCylinderWest", "CBFilledCylinderSouth",
-               "CBCylinderNorth", "CBCylinderWest", "CBCylinderSouth"}}},
-            {"InnerA",
-             {"EAFilledCylinderCenter", "MAFilledCylinderNorth",
-              "EACylinderSouth", "EAFilledCylinderSouth", "EACylinderNorth",
-              "EACylinderWest", "MAFilledCylinderCenter",
-              "EAFilledCylinderNorth", "EAFilledCylinderWest",
-              "MAFilledCylinderSouth", "EACylinderEast", "MAFilledCylinderEast",
-              "EAFilledCylinderEast", "MAFilledCylinderWest"}},
-            {"InnerB",
-             {"EBFilledCylinderEast", "MBFilledCylinderEast",
-              "EBFilledCylinderSouth", "EBFilledCylinderNorth",
-              "EBFilledCylinderWest", "EBCylinderEast", "MBFilledCylinderWest",
-              "EBCylinderNorth", "EBCylinderSouth", "EBCylinderWest",
-              "MBFilledCylinderCenter", "EBFilledCylinderCenter",
-              "MBFilledCylinderNorth", "MBFilledCylinderSouth"}}};
+  std::vector<std::string> block_names{
+      "CAFilledCylinderCenter", "CAFilledCylinderEast",
+      "CAFilledCylinderNorth",  "CAFilledCylinderWest",
+      "CAFilledCylinderSouth",  "CACylinderEast",
+      "CACylinderNorth",        "CACylinderWest",
+      "CACylinderSouth",        "EAFilledCylinderCenter",
+      "EAFilledCylinderEast",   "EAFilledCylinderNorth",
+      "EAFilledCylinderWest",   "EAFilledCylinderSouth",
+      "EACylinderEast",         "EACylinderNorth",
+      "EACylinderWest",         "EACylinderSouth",
+      "EBFilledCylinderCenter", "EBFilledCylinderEast",
+      "EBFilledCylinderNorth",  "EBFilledCylinderWest",
+      "EBFilledCylinderSouth",  "EBCylinderEast",
+      "EBCylinderNorth",        "EBCylinderWest",
+      "EBCylinderSouth",        "MAFilledCylinderCenter",
+      "MAFilledCylinderEast",   "MAFilledCylinderNorth",
+      "MAFilledCylinderWest",   "MAFilledCylinderSouth",
+      "MBFilledCylinderCenter", "MBFilledCylinderEast",
+      "MBFilledCylinderNorth",  "MBFilledCylinderWest",
+      "MBFilledCylinderSouth",  "CBFilledCylinderCenter",
+      "CBFilledCylinderEast",   "CBFilledCylinderNorth",
+      "CBFilledCylinderWest",   "CBFilledCylinderSouth",
+      "CBCylinderEast",         "CBCylinderNorth",
+      "CBCylinderWest",         "CBCylinderSouth"};
+  std::unordered_map<std::string, std::unordered_set<std::string>> block_groups{
+      {"Outer",
+       {{"CAFilledCylinderCenter", "CBCylinderEast", "CAFilledCylinderEast",
+         "CAFilledCylinderNorth", "CBFilledCylinderNorth", "CACylinderEast",
+         "CBFilledCylinderEast", "CAFilledCylinderSouth", "CACylinderNorth",
+         "CAFilledCylinderWest", "CACylinderWest", "CACylinderSouth",
+         "CBFilledCylinderCenter", "CBFilledCylinderWest",
+         "CBFilledCylinderSouth", "CBCylinderNorth", "CBCylinderWest",
+         "CBCylinderSouth"}}},
+      {"InnerA",
+       {"EAFilledCylinderCenter", "MAFilledCylinderNorth", "EACylinderSouth",
+        "EAFilledCylinderSouth", "EACylinderNorth", "EACylinderWest",
+        "MAFilledCylinderCenter", "EAFilledCylinderNorth",
+        "EAFilledCylinderWest", "MAFilledCylinderSouth", "EACylinderEast",
+        "MAFilledCylinderEast", "EAFilledCylinderEast",
+        "MAFilledCylinderWest"}},
+      {"InnerB",
+       {"EBFilledCylinderEast", "MBFilledCylinderEast", "EBFilledCylinderSouth",
+        "EBFilledCylinderNorth", "EBFilledCylinderWest", "EBCylinderEast",
+        "MBFilledCylinderWest", "EBCylinderNorth", "EBCylinderSouth",
+        "EBCylinderWest", "MBFilledCylinderCenter", "EBFilledCylinderCenter",
+        "MBFilledCylinderNorth", "MBFilledCylinderSouth"}}};
 
-    if (include_inner_sphere_A) {
-      block_names.insert(
-          block_names.end(),
-          {"InnerSphereEAFilledCylinderCenter",
-           "InnerSphereEAFilledCylinderEast",
-           "InnerSphereEAFilledCylinderNorth",
-           "InnerSphereEAFilledCylinderWest",
-           "InnerSphereEAFilledCylinderSouth",
-           "InnerSphereMAFilledCylinderCenter",
-           "InnerSphereMAFilledCylinderEast",
-           "InnerSphereMAFilledCylinderNorth",
-           "InnerSphereMAFilledCylinderWest",
-           "InnerSphereMAFilledCylinderSouth", "InnerSphereEACylinderEast",
-           "InnerSphereEACylinderNorth", "InnerSphereEACylinderWest",
-           "InnerSphereEACylinderSouth"});
-      block_groups.insert(
-          {"InnerSphereA",
-           {"InnerSphereEAFilledCylinderCenter",
-            "InnerSphereEAFilledCylinderEast",
-            "InnerSphereEAFilledCylinderNorth",
-            "InnerSphereEAFilledCylinderWest",
-            "InnerSphereEAFilledCylinderSouth",
-            "InnerSphereMAFilledCylinderCenter",
-            "InnerSphereMAFilledCylinderEast",
-            "InnerSphereMAFilledCylinderNorth",
-            "InnerSphereMAFilledCylinderWest",
-            "InnerSphereMAFilledCylinderSouth", "InnerSphereEACylinderEast",
-            "InnerSphereEACylinderNorth", "InnerSphereEACylinderWest",
-            "InnerSphereEACylinderSouth"}});
-    }
-    if (include_inner_sphere_B) {
-      block_names.insert(
-          block_names.end(),
-          {"InnerSphereEBFilledCylinderCenter",
-           "InnerSphereEBFilledCylinderEast",
-           "InnerSphereEBFilledCylinderNorth",
-           "InnerSphereEBFilledCylinderWest",
-           "InnerSphereEBFilledCylinderSouth",
-           "InnerSphereMBFilledCylinderCenter",
-           "InnerSphereMBFilledCylinderEast",
-           "InnerSphereMBFilledCylinderNorth",
-           "InnerSphereMBFilledCylinderWest",
-           "InnerSphereMBFilledCylinderSouth", "InnerSphereEBCylinderEast",
-           "InnerSphereEBCylinderNorth", "InnerSphereEBCylinderWest",
-           "InnerSphereEBCylinderSouth"});
-      block_groups.insert(
-          {"InnerSphereB",
-           {"InnerSphereEBFilledCylinderCenter",
-            "InnerSphereEBFilledCylinderEast",
-            "InnerSphereEBFilledCylinderNorth",
-            "InnerSphereEBFilledCylinderWest",
-            "InnerSphereEBFilledCylinderSouth",
-            "InnerSphereMBFilledCylinderCenter",
-            "InnerSphereMBFilledCylinderEast",
-            "InnerSphereMBFilledCylinderNorth",
-            "InnerSphereMBFilledCylinderWest",
-            "InnerSphereMBFilledCylinderSouth", "InnerSphereEBCylinderEast",
-            "InnerSphereEBCylinderNorth", "InnerSphereEBCylinderWest",
-            "InnerSphereEBCylinderSouth"}});
-    }
-    if (include_outer_sphere) {
-      block_names.insert(
-          block_names.end(),
-          {"OuterSphereCAFilledCylinderCenter",
-           "OuterSphereCAFilledCylinderEast",
-           "OuterSphereCAFilledCylinderNorth",
-           "OuterSphereCAFilledCylinderWest",
-           "OuterSphereCAFilledCylinderSouth",
-           "OuterSphereCBFilledCylinderCenter",
-           "OuterSphereCBFilledCylinderEast",
-           "OuterSphereCBFilledCylinderNorth",
-           "OuterSphereCBFilledCylinderWest",
-           "OuterSphereCBFilledCylinderSouth", "OuterSphereCACylinderEast",
-           "OuterSphereCACylinderNorth", "OuterSphereCACylinderWest",
-           "OuterSphereCACylinderSouth", "OuterSphereCBCylinderEast",
-           "OuterSphereCBCylinderNorth", "OuterSphereCBCylinderWest",
-           "OuterSphereCBCylinderSouth"});
-      block_groups.insert(
-          {"OuterSphere",
-           {"OuterSphereCAFilledCylinderCenter",
-            "OuterSphereCAFilledCylinderEast",
-            "OuterSphereCAFilledCylinderNorth",
-            "OuterSphereCAFilledCylinderWest",
-            "OuterSphereCAFilledCylinderSouth",
-            "OuterSphereCBFilledCylinderCenter",
-            "OuterSphereCBFilledCylinderEast",
-            "OuterSphereCBFilledCylinderNorth",
-            "OuterSphereCBFilledCylinderWest",
-            "OuterSphereCBFilledCylinderSouth", "OuterSphereCACylinderEast",
-            "OuterSphereCACylinderNorth", "OuterSphereCACylinderWest",
-            "OuterSphereCACylinderSouth", "OuterSphereCBCylinderEast",
-            "OuterSphereCBCylinderNorth", "OuterSphereCBCylinderWest",
-            "OuterSphereCBCylinderSouth"}});
-    }
-    CHECK(binary_compact_object.block_names() == block_names);
-    CHECK(binary_compact_object.block_groups() == block_groups);
+  if (include_inner_sphere_A) {
+    block_names.insert(
+        block_names.end(),
+        {"InnerSphereEAFilledCylinderCenter", "InnerSphereEAFilledCylinderEast",
+         "InnerSphereEAFilledCylinderNorth", "InnerSphereEAFilledCylinderWest",
+         "InnerSphereEAFilledCylinderSouth",
+         "InnerSphereMAFilledCylinderCenter", "InnerSphereMAFilledCylinderEast",
+         "InnerSphereMAFilledCylinderNorth", "InnerSphereMAFilledCylinderWest",
+         "InnerSphereMAFilledCylinderSouth", "InnerSphereEACylinderEast",
+         "InnerSphereEACylinderNorth", "InnerSphereEACylinderWest",
+         "InnerSphereEACylinderSouth"});
+    block_groups.insert(
+        {"InnerSphereA",
+         {"InnerSphereEAFilledCylinderCenter",
+          "InnerSphereEAFilledCylinderEast", "InnerSphereEAFilledCylinderNorth",
+          "InnerSphereEAFilledCylinderWest", "InnerSphereEAFilledCylinderSouth",
+          "InnerSphereMAFilledCylinderCenter",
+          "InnerSphereMAFilledCylinderEast", "InnerSphereMAFilledCylinderNorth",
+          "InnerSphereMAFilledCylinderWest", "InnerSphereMAFilledCylinderSouth",
+          "InnerSphereEACylinderEast", "InnerSphereEACylinderNorth",
+          "InnerSphereEACylinderWest", "InnerSphereEACylinderSouth"}});
+  }
+  if (include_inner_sphere_B) {
+    block_names.insert(
+        block_names.end(),
+        {"InnerSphereEBFilledCylinderCenter", "InnerSphereEBFilledCylinderEast",
+         "InnerSphereEBFilledCylinderNorth", "InnerSphereEBFilledCylinderWest",
+         "InnerSphereEBFilledCylinderSouth",
+         "InnerSphereMBFilledCylinderCenter", "InnerSphereMBFilledCylinderEast",
+         "InnerSphereMBFilledCylinderNorth", "InnerSphereMBFilledCylinderWest",
+         "InnerSphereMBFilledCylinderSouth", "InnerSphereEBCylinderEast",
+         "InnerSphereEBCylinderNorth", "InnerSphereEBCylinderWest",
+         "InnerSphereEBCylinderSouth"});
+    block_groups.insert(
+        {"InnerSphereB",
+         {"InnerSphereEBFilledCylinderCenter",
+          "InnerSphereEBFilledCylinderEast", "InnerSphereEBFilledCylinderNorth",
+          "InnerSphereEBFilledCylinderWest", "InnerSphereEBFilledCylinderSouth",
+          "InnerSphereMBFilledCylinderCenter",
+          "InnerSphereMBFilledCylinderEast", "InnerSphereMBFilledCylinderNorth",
+          "InnerSphereMBFilledCylinderWest", "InnerSphereMBFilledCylinderSouth",
+          "InnerSphereEBCylinderEast", "InnerSphereEBCylinderNorth",
+          "InnerSphereEBCylinderWest", "InnerSphereEBCylinderSouth"}});
+  }
+  if (include_outer_sphere) {
+    block_names.insert(
+        block_names.end(),
+        {"OuterSphereCAFilledCylinderCenter", "OuterSphereCAFilledCylinderEast",
+         "OuterSphereCAFilledCylinderNorth", "OuterSphereCAFilledCylinderWest",
+         "OuterSphereCAFilledCylinderSouth",
+         "OuterSphereCBFilledCylinderCenter", "OuterSphereCBFilledCylinderEast",
+         "OuterSphereCBFilledCylinderNorth", "OuterSphereCBFilledCylinderWest",
+         "OuterSphereCBFilledCylinderSouth", "OuterSphereCACylinderEast",
+         "OuterSphereCACylinderNorth", "OuterSphereCACylinderWest",
+         "OuterSphereCACylinderSouth", "OuterSphereCBCylinderEast",
+         "OuterSphereCBCylinderNorth", "OuterSphereCBCylinderWest",
+         "OuterSphereCBCylinderSouth"});
+    block_groups.insert(
+        {"OuterSphere",
+         {"OuterSphereCAFilledCylinderCenter",
+          "OuterSphereCAFilledCylinderEast", "OuterSphereCAFilledCylinderNorth",
+          "OuterSphereCAFilledCylinderWest", "OuterSphereCAFilledCylinderSouth",
+          "OuterSphereCBFilledCylinderCenter",
+          "OuterSphereCBFilledCylinderEast", "OuterSphereCBFilledCylinderNorth",
+          "OuterSphereCBFilledCylinderWest", "OuterSphereCBFilledCylinderSouth",
+          "OuterSphereCACylinderEast", "OuterSphereCACylinderNorth",
+          "OuterSphereCACylinderWest", "OuterSphereCACylinderSouth",
+          "OuterSphereCBCylinderEast", "OuterSphereCBCylinderNorth",
+          "OuterSphereCBCylinderWest", "OuterSphereCBCylinderSouth"}});
+  }
+  CHECK(binary_compact_object.block_names() == block_names);
+  CHECK(binary_compact_object.block_groups() == block_groups);
 
-    const auto domain = TestHelpers::domain::creators::test_domain_creator(
-        binary_compact_object, with_boundary_conditions);
+  const auto domain = TestHelpers::domain::creators::test_domain_creator(
+      binary_compact_object, with_boundary_conditions);
 
-    CHECK(domain.excision_spheres().size() == 2);
-    const auto& excision_sphere_a =
-        domain.excision_spheres().at("ExcisionSphereA");
-    CHECK(excision_sphere_a.radius() == inner_radius_objectA);
-    const auto& excision_sphere_b =
-        domain.excision_spheres().at("ExcisionSphereB");
-    CHECK(excision_sphere_b.radius() == inner_radius_objectB);
-    for (size_t i = 0; i < 3; ++i) {
-      CHECK(excision_sphere_a.center().get(i) == center_objectA.at(i));
-      CHECK(excision_sphere_b.center().get(i) == center_objectB.at(i));
-    }
+  CHECK(domain.excision_spheres().size() == 2);
+  const auto& excision_sphere_a =
+      domain.excision_spheres().at("ExcisionSphereA");
+  CHECK(excision_sphere_a.radius() == inner_radius_objectA);
+  const auto& excision_sphere_b =
+      domain.excision_spheres().at("ExcisionSphereB");
+  CHECK(excision_sphere_b.radius() == inner_radius_objectB);
+  for (size_t i = 0; i < 3; ++i) {
+    CHECK(excision_sphere_a.center().get(i) == center_objectA.at(i));
+    CHECK(excision_sphere_b.center().get(i) == center_objectB.at(i));
+  }
 
-    // The Domain has no functions of time above, so make sure
-    // that the functions_of_time function returns an empty map.
-    CHECK(binary_compact_object.functions_of_time() ==
-          std::unordered_map<
-              std::string,
-              std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>{});
+  // The Domain has no functions of time above, so make sure
+  // that the functions_of_time function returns an empty map.
+  CHECK(binary_compact_object.functions_of_time() ==
+        std::unordered_map<
+            std::string,
+            std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>{});
 
-    if (with_boundary_conditions) {
-      CHECK_THROWS_WITH(
-          domain::creators::CylindricalBinaryCompactObject(
-              center_objectA, center_objectB, inner_radius_objectA,
-              inner_radius_objectB, include_inner_sphere_A,
-              include_inner_sphere_B, include_outer_sphere, outer_radius,
-              use_equiangular_map, refinement, grid_points,
-              create_inner_boundary_condition(),
-              std::make_unique<TestHelpers::domain::BoundaryConditions::
-                                   TestPeriodicBoundaryCondition<3>>(),
-              Options::Context{false, {}, 1, 1}),
-          Catch::Matchers::Contains("Cannot have periodic boundary "
-                                    "conditions with a binary domain"));
-      CHECK_THROWS_WITH(
-          domain::creators::CylindricalBinaryCompactObject(
-              center_objectA, center_objectB, inner_radius_objectA,
-              inner_radius_objectB, include_inner_sphere_A,
-              include_inner_sphere_B, include_outer_sphere, outer_radius,
-              use_equiangular_map, refinement, grid_points,
-              std::make_unique<TestHelpers::domain::BoundaryConditions::
-                                   TestPeriodicBoundaryCondition<3>>(),
-              create_outer_boundary_condition(),
-              Options::Context{false, {}, 1, 1}),
-          Catch::Matchers::Contains("Cannot have periodic boundary "
-                                    "conditions with a binary domain"));
-      CHECK_THROWS_WITH(
-          domain::creators::CylindricalBinaryCompactObject(
-              center_objectA, center_objectB, inner_radius_objectA,
-              inner_radius_objectB, include_inner_sphere_A,
-              include_inner_sphere_B, include_outer_sphere, outer_radius,
-              use_equiangular_map, refinement, grid_points, nullptr,
-              create_outer_boundary_condition(),
-              Options::Context{false, {}, 1, 1}),
-          Catch::Matchers::Contains(
-              "Must specify either both inner and outer boundary "
-              "conditions or neither."));
-      CHECK_THROWS_WITH(
-          domain::creators::CylindricalBinaryCompactObject(
-              center_objectA, center_objectB, inner_radius_objectA,
-              inner_radius_objectB, include_inner_sphere_A,
-              include_inner_sphere_B, include_outer_sphere, outer_radius,
-              use_equiangular_map, refinement, grid_points,
-              create_inner_boundary_condition(), nullptr,
-              Options::Context{false, {}, 1, 1}),
-          Catch::Matchers::Contains(
-              "Must specify either both inner and outer boundary "
-              "conditions or neither."));
-    }
+  if (with_boundary_conditions) {
+    CHECK_THROWS_WITH(
+        domain::creators::CylindricalBinaryCompactObject(
+            center_objectA, center_objectB, inner_radius_objectA,
+            inner_radius_objectB, include_inner_sphere_A,
+            include_inner_sphere_B, include_outer_sphere, outer_radius,
+            use_equiangular_map, refinement, grid_points,
+            create_inner_boundary_condition(),
+            std::make_unique<TestHelpers::domain::BoundaryConditions::
+                                 TestPeriodicBoundaryCondition<3>>(),
+            Options::Context{false, {}, 1, 1}),
+        Catch::Matchers::Contains("Cannot have periodic boundary "
+                                  "conditions with a binary domain"));
+    CHECK_THROWS_WITH(
+        domain::creators::CylindricalBinaryCompactObject(
+            center_objectA, center_objectB, inner_radius_objectA,
+            inner_radius_objectB, include_inner_sphere_A,
+            include_inner_sphere_B, include_outer_sphere, outer_radius,
+            use_equiangular_map, refinement, grid_points,
+            std::make_unique<TestHelpers::domain::BoundaryConditions::
+                                 TestPeriodicBoundaryCondition<3>>(),
+            create_outer_boundary_condition(),
+            Options::Context{false, {}, 1, 1}),
+        Catch::Matchers::Contains("Cannot have periodic boundary "
+                                  "conditions with a binary domain"));
+    CHECK_THROWS_WITH(
+        domain::creators::CylindricalBinaryCompactObject(
+            center_objectA, center_objectB, inner_radius_objectA,
+            inner_radius_objectB, include_inner_sphere_A,
+            include_inner_sphere_B, include_outer_sphere, outer_radius,
+            use_equiangular_map, refinement, grid_points, nullptr,
+            create_outer_boundary_condition(),
+            Options::Context{false, {}, 1, 1}),
+        Catch::Matchers::Contains(
+            "Must specify either both inner and outer boundary "
+            "conditions or neither."));
+    CHECK_THROWS_WITH(domain::creators::CylindricalBinaryCompactObject(
+                          center_objectA, center_objectB, inner_radius_objectA,
+                          inner_radius_objectB, include_inner_sphere_A,
+                          include_inner_sphere_B, include_outer_sphere,
+                          outer_radius, use_equiangular_map, refinement,
+                          grid_points, create_inner_boundary_condition(),
+                          nullptr, Options::Context{false, {}, 1, 1}),
+                      Catch::Matchers::Contains(
+                          "Must specify either both inner and outer boundary "
+                          "conditions or neither."));
   }
 }
 
@@ -369,19 +336,22 @@ void test_connectivity() {
   // loop go over {true, false}
   const bool with_sphere_e = false;
   for (const auto& [include_outer_sphere, include_inner_sphere_A,
-                    include_inner_sphere_B, use_equiangular_map] :
+                    include_inner_sphere_B, use_equiangular_map,
+                    with_boundary_conditions] :
        random_sample<5>(
            cartesian_product(make_array(true, false), make_array(true, false),
-                             make_array(true, false), make_array(true, false)),
+                             make_array(true, false), make_array(true, false),
+                             make_array(true, false)),
            make_not_null(&gen))) {
     CAPTURE(with_sphere_e);
     CAPTURE(include_outer_sphere);
     CAPTURE(include_inner_sphere_A);
     CAPTURE(include_inner_sphere_B);
     CAPTURE(use_equiangular_map);
+    CAPTURE(with_boundary_conditions);
     test_connectivity_once(with_sphere_e, include_inner_sphere_A,
                            include_inner_sphere_B, include_outer_sphere,
-                           use_equiangular_map);
+                           use_equiangular_map, with_boundary_conditions);
   }
 }
 

--- a/tests/Unit/Domain/Creators/Test_CylindricalBinaryCompactObject.cpp
+++ b/tests/Unit/Domain/Creators/Test_CylindricalBinaryCompactObject.cpp
@@ -394,24 +394,24 @@ std::string create_option_string(
          "  IncludeOuterSphere: False\n"
          "  InitialRefinement:" +
          (with_additional_outer_radial_refinement
-              ? std::string(" 1\n")
-              : (add_time_dependence
+              ? (add_time_dependence
                      ? std::string("\n    InnerSphereA: [1, 1, 1]"
                                    "\n    InnerSphereB: [1, 1, 1]")
                      : "") +
                     std::string("\n    Outer: [2, 1, 1]"
                                 "\n    InnerA: [1, 1, 1]"
-                                "\n    InnerB: [2, 1, 1]\n")) +
+                                "\n    InnerB: [2, 1, 1]\n")
+              : std::string(" 1\n")) +
          "  InitialGridPoints:" +
          (with_additional_grid_points
-              ? std::string(" 3\n")
-              : (add_time_dependence
+              ? (add_time_dependence
                      ? std::string("\n    InnerSphereA: [3, 3, 3]"
                                    "\n    InnerSphereB: [3, 3, 3]")
                      : "") +
                     std::string("\n    Outer: [4, 3, 3]"
                                 "\n    InnerA: [3, 3, 3]"
-                                "\n    InnerB: [5, 3, 3]\n")) +
+                                "\n    InnerB: [5, 3, 3]\n")
+              : std::string(" 3\n")) +
          time_dependence + boundary_conditions;
 }
 


### PR DESCRIPTION
## Proposed changes

Also adds the size map to the CylBBH domain so it has the same time dependent maps as the regular BBH domains.

Part of #4764.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
