### PR TITLE
Add radially compressed coordinates

### DIFF
--- a/src/Domain/CMakeLists.txt
+++ b/src/Domain/CMakeLists.txt
@@ -21,6 +21,7 @@ spectre_target_sources(
   InterfaceLogicalCoordinates.cpp
   JacobianDiagnostic.cpp
   MinimumGridSpacing.cpp
+  RadiallyCompressedCoordinates.cpp
   SizeOfElement.cpp
   SurfaceJacobian.cpp
   TagsTimeDependent.cpp
@@ -46,6 +47,7 @@ spectre_target_headers(
   InterfaceLogicalCoordinates.hpp
   JacobianDiagnostic.hpp
   MinimumGridSpacing.hpp
+  RadiallyCompressedCoordinates.hpp
   SizeOfElement.hpp
   SurfaceJacobian.hpp
   Tags.hpp

--- a/src/Domain/CoordinateMaps/Python/Bindings.cpp
+++ b/src/Domain/CoordinateMaps/Python/Bindings.cpp
@@ -3,6 +3,7 @@
 
 #include <pybind11/pybind11.h>
 
+#include "Domain/CoordinateMaps/Distribution.hpp"
 #include "Domain/CoordinateMaps/Python/CoordinateMap.hpp"
 
 namespace py = pybind11;
@@ -12,6 +13,11 @@ namespace domain {
 PYBIND11_MODULE(_PyCoordinateMaps, m) {  // NOLINT
   py::module_::import("spectre.DataStructures");
   py::module_::import("spectre.DataStructures.Tensor");
+  py::enum_<CoordinateMaps::Distribution>(m, "Distribution")
+      .value("Linear", CoordinateMaps::Distribution::Linear)
+      .value("Equiangular", CoordinateMaps::Distribution::Equiangular)
+      .value("Logarithmic", CoordinateMaps::Distribution::Logarithmic)
+      .value("Inverse", CoordinateMaps::Distribution::Inverse);
   // Order is important: The base class `CoordinateMap` needs to have its
   // bindings set up before the derived classes
   py_bindings::bind_coordinate_map(m);

--- a/src/Domain/Python/Bindings.cpp
+++ b/src/Domain/Python/Bindings.cpp
@@ -11,6 +11,7 @@
 #include "Domain/Python/ElementMap.hpp"
 #include "Domain/Python/FunctionsOfTime.hpp"
 #include "Domain/Python/JacobianDiagnostic.hpp"
+#include "Domain/Python/RadiallyCompressedCoordinates.hpp"
 #include "Domain/Python/SegmentId.hpp"
 
 namespace py = pybind11;
@@ -29,6 +30,7 @@ PYBIND11_MODULE(_PyDomain, m) {  // NOLINT
   py_bindings::bind_element_map(m);
   py_bindings::bind_functions_of_time(m);
   py_bindings::bind_jacobian_diagnostic(m);
+  py_bindings::bind_radially_compressed_coordinates(m);
   py_bindings::bind_segment_id(m);
 }
 

--- a/src/Domain/Python/CMakeLists.txt
+++ b/src/Domain/Python/CMakeLists.txt
@@ -16,6 +16,7 @@ spectre_python_add_module(
   ElementMap.cpp
   FunctionsOfTime.cpp
   JacobianDiagnostic.cpp
+  RadiallyCompressedCoordinates.cpp
   SegmentId.cpp
   PYTHON_FILES
   __init__.py
@@ -33,6 +34,7 @@ spectre_python_headers(
   ElementMap.hpp
   FunctionsOfTime.hpp
   JacobianDiagnostic.hpp
+  RadiallyCompressedCoordinates.hpp
   SegmentId.hpp
 )
 

--- a/src/Domain/Python/RadiallyCompressedCoordinates.cpp
+++ b/src/Domain/Python/RadiallyCompressedCoordinates.cpp
@@ -1,0 +1,41 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Domain/Python/RadiallyCompressedCoordinates.hpp"
+
+#include <cstddef>
+#include <pybind11/pybind11.h>
+#include <string>
+#include <type_traits>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Domain/CoordinateMaps/Distribution.hpp"
+#include "Domain/RadiallyCompressedCoordinates.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace py = pybind11;
+
+namespace domain::py_bindings {
+
+namespace {
+template <size_t Dim, typename CoordsFrame>
+void bind_radially_compressed_coordinates_impl(py::module& m) {  // NOLINT
+  m.def("radially_compressed_coordinates",
+        static_cast<tnsr::I<DataVector, Dim, CoordsFrame> (*)(
+            const tnsr::I<DataVector, Dim, CoordsFrame>&, double, double,
+            CoordinateMaps::Distribution)>(
+            &radially_compressed_coordinates<DataVector, Dim, CoordsFrame>),
+        py::arg(std::is_same_v<CoordsFrame, Frame::Inertial> ? "inertial_coords"
+                                                             : "grid_coords"),
+        py::arg("inner_radius"), py::arg("outer_radius"),
+        py::arg("compression"));
+}
+}  // namespace
+
+void bind_radially_compressed_coordinates(py::module& m) {  // NOLINT
+  bind_radially_compressed_coordinates_impl<1, Frame::Inertial>(m);
+  bind_radially_compressed_coordinates_impl<2, Frame::Inertial>(m);
+  bind_radially_compressed_coordinates_impl<3, Frame::Inertial>(m);
+}
+
+}  // namespace domain::py_bindings

--- a/src/Domain/Python/RadiallyCompressedCoordinates.hpp
+++ b/src/Domain/Python/RadiallyCompressedCoordinates.hpp
@@ -1,0 +1,11 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <pybind11/pybind11.h>
+
+namespace domain::py_bindings {
+// NOLINTNEXTLINE(google-runtime-references)
+void bind_radially_compressed_coordinates(pybind11::module& m);
+}  // namespace domain::py_bindings

--- a/src/Domain/RadiallyCompressedCoordinates.cpp
+++ b/src/Domain/RadiallyCompressedCoordinates.cpp
@@ -1,0 +1,94 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Domain/RadiallyCompressedCoordinates.hpp"
+
+#include <cstddef>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/CoordinateMaps/Distribution.hpp"
+#include "Domain/CoordinateMaps/Interval.hpp"
+#include "Utilities/ContainerHelpers.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeWithValue.hpp"
+
+namespace domain {
+
+template <typename DataType, size_t Dim, typename CoordsFrame>
+void radially_compressed_coordinates(
+    const gsl::not_null<tnsr::I<DataType, Dim, CoordsFrame>*> result,
+    const tnsr::I<DataType, Dim, CoordsFrame>& coordinates,
+    const double inner_radius, const double outer_radius,
+    const CoordinateMaps::Distribution compression) {
+  const DataType radius = get(magnitude(coordinates));
+  // Return early if all radii are within the inner radius
+  if (max(radius) <= inner_radius + 1.e-14) {
+    *result = coordinates;
+    return;
+  }
+  // The compressed outer radius is chosen so it increases with both the inner
+  // and the outer radius but exponentials are tamed
+  const double compressed_outer_radius = inner_radius * log10(outer_radius);
+  // We use the inverse of the Interval map, which is also used to distribute
+  // grid points radially
+  CoordinateMaps::Interval interval{inner_radius, compressed_outer_radius,
+                                    inner_radius, outer_radius,
+                                    compression,  0.};
+  DataType compressed_radius = radius;
+  for (size_t i = 0; i < get_size(radius); ++i) {
+    if (get_element(radius, i) > inner_radius + 1.e-14) {
+      get_element(compressed_radius, i) =
+          interval.inverse({{get_element(radius, i)}}).value()[0];
+    }
+  }
+  *result = coordinates;
+  for (size_t d = 0; d < Dim; ++d) {
+    result->get(d) *= compressed_radius / radius;
+  }
+}
+
+void RadiallyCompressedCoordinatesOptions::pup(PUP::er& p) {
+  p | inner_radius;
+  p | outer_radius;
+  p | compression;
+}
+
+template <typename DataType, size_t Dim, typename CoordsFrame>
+tnsr::I<DataType, Dim, CoordsFrame> radially_compressed_coordinates(
+    const tnsr::I<DataType, Dim, CoordsFrame>& coordinates,
+    const double inner_radius, const double outer_radius,
+    const CoordinateMaps::Distribution compression) {
+  tnsr::I<DataType, Dim, CoordsFrame> result{};
+  radially_compressed_coordinates(make_not_null(&result), coordinates,
+                                  inner_radius, outer_radius, compression);
+  return result;
+}
+
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define DIM(data) BOOST_PP_TUPLE_ELEM(1, data)
+#define FRAME(data) BOOST_PP_TUPLE_ELEM(2, data)
+
+#define INSTANTIATE(_, data)                                               \
+  template void radially_compressed_coordinates(                           \
+      gsl::not_null<tnsr::I<DTYPE(data), DIM(data), FRAME(data)>*> result, \
+      const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& coordinates,     \
+      double inner_radius, double outer_radius,                            \
+      CoordinateMaps::Distribution compression);                           \
+  template tnsr::I<DTYPE(data), DIM(data), FRAME(data)>                    \
+  radially_compressed_coordinates(                                         \
+      const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& coordinates,     \
+      double inner_radius, double outer_radius,                            \
+      CoordinateMaps::Distribution compression);
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector), (1, 2, 3),
+                        (Frame::Inertial))
+
+#undef DTYPE
+#undef DIM
+#undef FRAME
+#undef INSTANTIATE
+
+}  // namespace domain

--- a/src/Domain/RadiallyCompressedCoordinates.hpp
+++ b/src/Domain/RadiallyCompressedCoordinates.hpp
@@ -1,0 +1,169 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <string>
+
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/CoordinateMaps/Distribution.hpp"
+#include "Domain/Tags.hpp"
+#include "Options/Auto.hpp"
+#include "Options/Options.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+class DataVector;
+/// \endcond
+
+namespace domain {
+
+/// @{
+/*!
+ * \ingroup ComputationalDomainGroup
+ * \brief Coordinates suitable for visualizing large radii by compressing them
+ * logarithmically or inversely.
+ *
+ * Rescales the coordinates $\boldsymbol{x}$ as
+ *
+ * \begin{equation}
+ * \hat{\boldsymbol{x}} = \frac{\hat{r}}{r} \boldsymbol{x}
+ * \text{,}
+ * \end{equation}
+ *
+ * for $r > r_0$, where $r=\sqrt{x^2+y^2+z^2}$ is the Euclidean coordinate
+ * radius and $r_0$ is the `inner_radius`.
+ * The coordinates are compressed from $r \in [r_0, r_1]$ to $\hat{r} \in [r_0,
+ * \hat{r}_1]$, where the `outer_radius` $r_1$ can be incomprehensibly large
+ * like $10^9$ and the compressed outer radius $\hat{r}_1$ is reasonably small
+ * so it can be visualized well. We choose
+ *
+ * \begin{equation}
+ * \hat{r}_1 = r_0 \log_{10}(r_1)
+ * \end{equation}
+ *
+ * so the compressed outer radius is a multiple of the inner radius and
+ * increases with the outer radius as well, but exponentials are tamed.
+ *
+ * The radial compression map $\hat{r}(r)$ is just the inverse of the
+ * `domain::CoordinateMaps::Interval` map, which is also used to distribute grid
+ * points radially. Therefore, radial grid points will be distributed linearly
+ * in the radially compressed coordinates if you use the same `compression`
+ * distribution that you used to distribute radial grid points in the
+ * `CoordsFrame`.
+ *
+ * \see domain::CoordinateMaps::Interval
+ */
+template <typename DataType, size_t Dim, typename CoordsFrame>
+void radially_compressed_coordinates(
+    gsl::not_null<tnsr::I<DataType, Dim, CoordsFrame>*> result,
+    const tnsr::I<DataType, Dim, CoordsFrame>& coordinates, double inner_radius,
+    double outer_radius, CoordinateMaps::Distribution compression);
+template <typename DataType, size_t Dim, typename CoordsFrame>
+tnsr::I<DataType, Dim, CoordsFrame> radially_compressed_coordinates(
+    const tnsr::I<DataType, Dim, CoordsFrame>& coordinates, double inner_radius,
+    double outer_radius, CoordinateMaps::Distribution compression);
+/// @}
+
+/// Options for radially compressed coordinates
+///
+/// \see radially_compressed_coordinates
+struct RadiallyCompressedCoordinatesOptions {
+  static constexpr Options::String help =
+      "Define radially compressed coordinates for visualizing large outer "
+      "radii.";
+  struct InnerRadius {
+    using type = double;
+    static constexpr Options::String help =
+        "Radially compressed coordinates begin at this radius, and coincide "
+        "with the original coordinates for smaller radii.";
+  };
+  struct OuterRadius {
+    using type = double;
+    static constexpr Options::String help =
+        "Outer radius of the domain which will be compressed down to a "
+        "comprehensible radius, namely to r_inner * log10(r_outer).";
+  };
+  struct Compression {
+    using type = CoordinateMaps::Distribution;
+    static constexpr Options::String help =
+        "Compression mode: 'Logarithmic' or 'Inverse'. If you use the same "
+        "mode that you used to distribute radial grid points then the "
+        "grid points will be distributed linearly in the radially compressed "
+        "coordinates.";
+  };
+  using options = tmpl::list<InnerRadius, OuterRadius, Compression>;
+  void pup(PUP::er& p);
+  double inner_radius;
+  double outer_radius;
+  CoordinateMaps::Distribution compression;
+};
+
+namespace OptionTags {
+
+struct RadiallyCompressedCoordinates {
+  using type = Options::Auto<domain::RadiallyCompressedCoordinatesOptions,
+                             Options::AutoLabel::None>;
+  static constexpr Options::String help =
+      "Define radially compressed coordinates for visualizing large outer "
+      "radii.";
+};
+
+}  // namespace OptionTags
+
+namespace Tags {
+
+/// Options for radially compressed coordinates, or `std::nullopt` if none
+/// were specified in the input file
+///
+/// \see radially_compressed_coordinates
+struct RadiallyCompressedCoordinatesOptions : db::SimpleTag {
+  using type = std::optional<domain::RadiallyCompressedCoordinatesOptions>;
+  static constexpr bool pass_metavariables = false;
+  using option_tags = tmpl::list<OptionTags::RadiallyCompressedCoordinates>;
+  static type create_from_options(type value) { return value; };
+};
+
+/// @{
+/*!
+ * \brief Coordinates suitable for visualizing large radii by compressing them
+ * logarithmically or inversely.
+ *
+ * The coordinate map reduces to the identity if no options for radially
+ * compressed coordinates were specified in the input file.
+ *
+ * \see radially_compressed_coordinates
+ */
+template <size_t Dim, typename CoordsFrame>
+struct RadiallyCompressedCoordinates : db::SimpleTag {
+  using type = tnsr::I<DataVector, Dim, CoordsFrame>;
+};
+
+template <size_t Dim, typename CoordsFrame>
+struct RadiallyCompressedCoordinatesCompute
+    : RadiallyCompressedCoordinates<Dim, CoordsFrame>,
+      db::ComputeTag {
+  using base = RadiallyCompressedCoordinates<Dim, CoordsFrame>;
+  using return_type = tnsr::I<DataVector, Dim, CoordsFrame>;
+  using argument_tags = tmpl::list<Tags::Coordinates<Dim, CoordsFrame>,
+                                   Tags::RadiallyCompressedCoordinatesOptions>;
+  static void function(
+      const gsl::not_null<tnsr::I<DataVector, Dim, CoordsFrame>*> result,
+      const tnsr::I<DataVector, Dim, CoordsFrame>& coords,
+      const std::optional<domain::RadiallyCompressedCoordinatesOptions>&
+          options) {
+    if (options.has_value()) {
+      radially_compressed_coordinates(result, coords, options->inner_radius,
+                                      options->outer_radius,
+                                      options->compression);
+    } else {
+      *result = coords;
+    }
+  }
+};
+/// @}
+
+}  // namespace Tags
+}  // namespace domain

--- a/src/Elliptic/Executables/Poisson/SolvePoisson.hpp
+++ b/src/Elliptic/Executables/Poisson/SolvePoisson.hpp
@@ -10,6 +10,7 @@
 #include "Domain/Creators/Factory2D.hpp"
 #include "Domain/Creators/Factory3D.hpp"
 #include "Domain/Creators/RegisterDerivedWithCharm.hpp"
+#include "Domain/RadiallyCompressedCoordinates.hpp"
 #include "Domain/Tags.hpp"
 #include "Elliptic/Actions/InitializeAnalyticSolution.hpp"
 #include "Elliptic/Actions/InitializeFields.hpp"
@@ -155,13 +156,17 @@ struct Metavariables {
   using error_tags = db::wrap_tags_in<Tags::Error, analytic_solution_fields>;
   using observe_fields = tmpl::append<
       analytic_solution_fields, error_tags,
-      tmpl::list<domain::Tags::Coordinates<volume_dim, Frame::Inertial>>>;
+      tmpl::list<domain::Tags::Coordinates<volume_dim, Frame::Inertial>,
+                 domain::Tags::RadiallyCompressedCoordinatesCompute<
+                     volume_dim, Frame::Inertial>>>;
   using observer_compute_tags =
       tmpl::list<::Events::Tags::ObserverMeshCompute<volume_dim>,
                  error_compute>;
 
   // Collect all items to store in the cache.
-  using const_global_cache_tags = tmpl::list<background_tag, initial_guess_tag>;
+  using const_global_cache_tags =
+      tmpl::list<background_tag, initial_guess_tag,
+                 domain::Tags::RadiallyCompressedCoordinatesOptions>;
 
   struct factory_creation
       : tt::ConformsTo<Options::protocols::FactoryCreation> {

--- a/src/Elliptic/Executables/Xcts/SolveXcts.hpp
+++ b/src/Elliptic/Executables/Xcts/SolveXcts.hpp
@@ -9,6 +9,7 @@
 #include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
 #include "Domain/Creators/Factory3D.hpp"
 #include "Domain/Creators/RegisterDerivedWithCharm.hpp"
+#include "Domain/RadiallyCompressedCoordinates.hpp"
 #include "Domain/Tags.hpp"
 #include "Elliptic/BoundaryConditions/BoundaryCondition.hpp"
 #include "Elliptic/DiscontinuousGalerkin/DgElementArray.hpp"
@@ -78,6 +79,8 @@ struct Metavariables {
       analytic_solution_fields, typename system::background_fields,
       typename spacetime_quantities_compute::tags_list, error_tags,
       tmpl::list<domain::Tags::Coordinates<volume_dim, Frame::Inertial>,
+                 domain::Tags::RadiallyCompressedCoordinatesCompute<
+                     volume_dim, Frame::Inertial>,
                  ::Tags::NonEuclideanMagnitude<
                      Xcts::Tags::ShiftExcess<DataVector, 3, Frame::Inertial>,
                      gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>>>>;
@@ -86,7 +89,8 @@ struct Metavariables {
                  spacetime_quantities_compute, error_compute>;
 
   // Collect all items to store in the cache.
-  using const_global_cache_tags = tmpl::list<>;
+  using const_global_cache_tags =
+      tmpl::list<domain::Tags::RadiallyCompressedCoordinatesOptions>;
 
   struct factory_creation
       : tt::ConformsTo<Options::protocols::FactoryCreation> {

--- a/tests/InputFiles/Poisson/ProductOfSinusoids1D.yaml
+++ b/tests/InputFiles/Poisson/ProductOfSinusoids1D.yaml
@@ -73,6 +73,8 @@ LinearSolver:
     SubdomainSolver: ExplicitInverse
     ObservePerCoreReductions: False
 
+RadiallyCompressedCoordinates: None
+
 EventsAndTriggers:
   - - HasConverged
     - - ObserveNorms:

--- a/tests/InputFiles/Poisson/ProductOfSinusoids2D.yaml
+++ b/tests/InputFiles/Poisson/ProductOfSinusoids2D.yaml
@@ -69,6 +69,8 @@ LinearSolver:
     SubdomainSolver: ExplicitInverse
     ObservePerCoreReductions: False
 
+RadiallyCompressedCoordinates: None
+
 EventsAndTriggers:
   - - HasConverged
     - - ObserveNorms:

--- a/tests/InputFiles/Poisson/ProductOfSinusoids3D.yaml
+++ b/tests/InputFiles/Poisson/ProductOfSinusoids3D.yaml
@@ -69,6 +69,8 @@ LinearSolver:
     SubdomainSolver: ExplicitInverse
     ObservePerCoreReductions: False
 
+RadiallyCompressedCoordinates: None
+
 EventsAndTriggers:
   - - HasConverged
     - - ObserveNorms:

--- a/tests/InputFiles/Xcts/BinaryBlackHole.yaml
+++ b/tests/InputFiles/Xcts/BinaryBlackHole.yaml
@@ -55,11 +55,11 @@ DomainCreator:
             NegativeExpansion: *kerr_left
       UseLogarithmicMap: True
     Envelope:
-      Radius: 60.
+      Radius: &outer_shell_inner_radius 60.
       UseProjectiveMap: True
     OuterShell:
-      Radius: 300.
-      RadialDistribution: Inverse
+      Radius: &outer_radius 300.
+      RadialDistribution: &outer_shell_distribution Inverse
       BoundaryCondition: Flatness
     UseEquiangularMap: True
     # This h-refinement is set up so spherical wedges have equal angular size.
@@ -155,6 +155,11 @@ LinearSolver:
     SkipResets: True
     ObservePerCoreReductions: False
 
+RadiallyCompressedCoordinates:
+  InnerRadius: *outer_shell_inner_radius
+  OuterRadius: *outer_radius
+  Compression: *outer_shell_distribution
+
 EventsAndTriggers:
   - - HasConverged
     - - ObserveNorms:
@@ -186,6 +191,7 @@ EventsAndTriggers:
             - ExtrinsicCurvature
             - HamiltonianConstraint
             - MomentumConstraint
+            - RadiallyCompressedCoordinates
           InterpolateToMesh: None
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double]

--- a/tests/InputFiles/Xcts/HeadOnBns.yaml
+++ b/tests/InputFiles/Xcts/HeadOnBns.yaml
@@ -45,11 +45,11 @@ DomainCreator:
       Interior: Auto
       UseLogarithmicMap: False
     Envelope:
-      Radius: 120.
+      Radius: &outer_shell_inner_radius 120.
       UseProjectiveMap: True
     OuterShell:
-      Radius: 600.
-      RadialDistribution: Inverse
+      Radius: &outer_radius 600.
+      RadialDistribution: &outer_shell_distribution Inverse
       BoundaryCondition: Flatness
     UseEquiangularMap: True
     # This h-refinement is set up so spherical wedges have equal angular size.
@@ -149,6 +149,11 @@ LinearSolver:
     SkipResets: True
     ObservePerCoreReductions: False
 
+RadiallyCompressedCoordinates:
+  InnerRadius: *outer_shell_inner_radius
+  OuterRadius: *outer_radius
+  Compression: *outer_shell_distribution
+
 EventsAndTriggers:
   - - HasConverged
     - - ObserveNorms:
@@ -188,6 +193,7 @@ EventsAndTriggers:
             - MomentumConstraint
             - Conformal(EnergyDensity)
             - Conformal(StressTrace)
+            - RadiallyCompressedCoordinates
           InterpolateToMesh: None
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double]

--- a/tests/InputFiles/Xcts/KerrSchild.yaml
+++ b/tests/InputFiles/Xcts/KerrSchild.yaml
@@ -108,6 +108,8 @@ LinearSolver:
     SkipResets: True
     ObservePerCoreReductions: False
 
+RadiallyCompressedCoordinates: None
+
 EventsAndTriggers:
   - - HasConverged
     - - ObserveNorms:

--- a/tests/InputFiles/Xcts/TovStar.yaml
+++ b/tests/InputFiles/Xcts/TovStar.yaml
@@ -101,6 +101,8 @@ LinearSolver:
     SkipResets: True
     ObservePerCoreReductions: False
 
+RadiallyCompressedCoordinates: None
+
 EventsAndTriggers:
   - - HasConverged
     - - ObserveNorms:

--- a/tests/Unit/Domain/CMakeLists.txt
+++ b/tests/Unit/Domain/CMakeLists.txt
@@ -26,6 +26,7 @@ set(LIBRARY_SOURCES
   Test_JacobianDiagnostic.cpp
   Test_MinimumGridSpacing.cpp
   Test_Protocols.cpp
+  Test_RadiallyCompressedCoordinates.cpp
   Test_SizeOfElement.cpp
   Test_SurfaceJacobian.cpp
   Test_Tags.cpp

--- a/tests/Unit/Domain/Python/CMakeLists.txt
+++ b/tests/Unit/Domain/Python/CMakeLists.txt
@@ -38,6 +38,12 @@ spectre_add_python_bindings_test(
   PyDomain)
 
 spectre_add_python_bindings_test(
+  "Unit.Domain.Python.RadiallyCompressedCoordinates"
+  Test_RadiallyCompressedCoordinates.py
+  "Unit;Domain"
+  PyDomain)
+
+spectre_add_python_bindings_test(
   "Unit.Domain.Python.SegmentId"
   Test_SegmentId.py
   "Unit;Domain"

--- a/tests/Unit/Domain/Python/Test_RadiallyCompressedCoordinates.py
+++ b/tests/Unit/Domain/Python/Test_RadiallyCompressedCoordinates.py
@@ -1,0 +1,30 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import unittest
+
+import numpy as np
+import numpy.testing as npt
+from spectre.DataStructures import DataVector
+from spectre.DataStructures.Tensor import tnsr
+from spectre.Domain import radially_compressed_coordinates
+from spectre.Domain.CoordinateMaps import Distribution
+
+
+class TestRadiallyCompressedCoordinates(unittest.TestCase):
+    def test_radially_compressed_coordinates(self):
+        inner_radius = 1.
+        outer_radius = 1.e6
+        expected_compressed_outer_radius = 6.
+        x = np.array([[inner_radius, outer_radius], [0., 0.], [0., 0.]])
+        x_compressed = radially_compressed_coordinates(
+            x,
+            inner_radius=1.,
+            outer_radius=1.e6,
+            compression=Distribution.Logarithmic)
+        npt.assert_allclose(x_compressed[0],
+                            [inner_radius, expected_compressed_outer_radius])
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/tests/Unit/Domain/Test_RadiallyCompressedCoordinates.cpp
+++ b/tests/Unit/Domain/Test_RadiallyCompressedCoordinates.cpp
@@ -1,0 +1,136 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cmath>
+#include <cstddef>
+#include <random>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/CoordinateMaps/Wedge.hpp"
+#include "Domain/RadiallyCompressedCoordinates.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+
+namespace domain {
+namespace {
+
+void test_radially_compressed_coordinates(
+    const CoordinateMaps::Distribution radial_distribution) {
+  CAPTURE(radial_distribution);
+  MAKE_GENERATOR(gen);
+  const double inner_radius = 10.;
+  const double outer_radius = 1.e9;
+  const double expected_compressed_outer_radius = 90.;
+  // Helper function that maps inertial to compressed radius for a single point
+  const auto compressed_radius =
+      [&inner_radius, &outer_radius,
+       &radial_distribution](const double inertial_radius) -> double {
+    return get<0>(radially_compressed_coordinates(
+        tnsr::I<double, 3, Frame::Inertial>{{{inertial_radius, 0., 0.}}},
+        inner_radius, outer_radius, radial_distribution));
+  };
+  {
+    INFO("Inner radius is identical");
+    CHECK(compressed_radius(inner_radius) == approx(inner_radius));
+  }
+  {
+    INFO("Interior is identical");
+    CHECK(compressed_radius(inner_radius / 2.) == approx(inner_radius / 2.));
+  }
+  {
+    INFO("Outer radius is compressed");
+    CHECK(compressed_radius(outer_radius) ==
+          approx(expected_compressed_outer_radius));
+  }
+  {
+    INFO("Consistency with Wedge map");
+    // Check that grid points are distributed linearly in radially compressed
+    // coordinates if the compression is consistent with the Wedge map
+    const auto wedge_map =
+        CoordinateMaps::Wedge<3>{inner_radius,
+                                 outer_radius,
+                                 1.0,
+                                 1.0,
+                                 {},
+                                 true,
+                                 CoordinateMaps::Wedge<3>::WedgeHalves::Both,
+                                 radial_distribution};
+    // Set up a point at a fraction of the radial distance covered by the wedge
+    std::uniform_real_distribution<double> dist_fraction(0., 1.);
+    const double radial_fraction = dist_fraction(gen);
+    const double r_logical = -1. + radial_fraction * 2.;
+    const double r_inertial =
+        wedge_map(std::array<double, 3>{{0., 0., r_logical}})[2];
+    const double r_compressed = compressed_radius(r_inertial);
+    const double expected_r_compressed =
+        inner_radius +
+        radial_fraction * (expected_compressed_outer_radius - inner_radius);
+    CHECK(r_compressed == approx(expected_r_compressed));
+  }
+  {
+    INFO("Coordinates preserve angles");
+    const size_t num_angles = 6;
+    // extend below inner radius to check identity there
+    std::uniform_real_distribution<double> dist_r(inner_radius / 2.,
+                                                  outer_radius);
+    std::uniform_real_distribution<double> dist_theta(0., M_PI);
+    std::uniform_real_distribution<double> dist_phi(-M_PI, M_PI);
+    const auto r = make_with_random_values<DataVector>(
+        make_not_null(&gen), make_not_null(&dist_r), DataVector(5));
+    const auto theta = make_with_random_values<DataVector>(
+        make_not_null(&gen), make_not_null(&dist_theta),
+        DataVector(num_angles));
+    const auto phi = make_with_random_values<DataVector>(
+        make_not_null(&gen), make_not_null(&dist_phi), DataVector(num_angles));
+    for (size_t i = 0; i < r.size(); ++i) {
+      tnsr::I<DataVector, 3, Frame::Inertial> x{num_angles};
+      get<0>(x) = r[i] * cos(phi) * sin(theta);
+      get<1>(x) = r[i] * sin(phi) * sin(theta);
+      get<2>(x) = r[i] * cos(theta);
+      const auto x_compressed = radially_compressed_coordinates(
+          x, inner_radius, outer_radius, radial_distribution);
+      const auto r_compressed = get(magnitude(x_compressed));
+      // Check all compressed radii are the same
+      CHECK_ITERABLE_APPROX(r_compressed,
+                            DataVector(num_angles, compressed_radius(r[i])));
+      // Check the angles didn't change
+      const auto theta_compressed =
+          atan2(hypot(get<0>(x_compressed), get<1>(x_compressed)),
+                get<2>(x_compressed));
+      const auto phi_compressed =
+          atan2(get<1>(x_compressed), get<0>(x_compressed));
+      CHECK_ITERABLE_APPROX(theta_compressed, theta);
+      CHECK_ITERABLE_APPROX(phi_compressed, phi);
+      // Also check some more consistency
+      if (r[i] <= inner_radius) {
+        CHECK(r_compressed[i] == approx(r[i]));
+      } else {
+        CHECK(r_compressed[i] < r[i]);
+        CHECK(r_compressed[i] <= expected_compressed_outer_radius + 1.e-14);
+      }
+    }
+  }
+}
+
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Domain.RadiallyCompressedCoordinates",
+                  "[Domain][Unit]") {
+  TestHelpers::db::test_simple_tag<
+      Tags::RadiallyCompressedCoordinates<3, Frame::Inertial>>(
+      "RadiallyCompressedCoordinates");
+  TestHelpers::db::test_compute_tag<
+      Tags::RadiallyCompressedCoordinatesCompute<3, Frame::Inertial>>(
+      "RadiallyCompressedCoordinates");
+  test_radially_compressed_coordinates(
+      CoordinateMaps::Distribution::Logarithmic);
+  test_radially_compressed_coordinates(CoordinateMaps::Distribution::Inverse);
+}
+
+}  // namespace domain


### PR DESCRIPTION
## Proposed changes

Coordinates suitable for visualizing large radii by compressing them logarithmically or inversely.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
