### PR TITLE
Plot power monitors over time, filter by element

### DIFF
--- a/src/IO/H5/Python/IterElements.py
+++ b/src/IO/H5/Python/IterElements.py
@@ -1,18 +1,19 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
+from dataclasses import dataclass
+from typing import Dict, Iterable, Optional, Sequence, Union
+
 import numpy as np
 import spectre.IO.H5 as spectre_h5
-from dataclasses import dataclass
 from spectre.DataStructures.Tensor.EagerMath import determinant
-from spectre.Domain import (ElementId, ElementMap, deserialize_domain,
-                            deserialize_functions_of_time, FunctionOfTime)
+from spectre.Domain import (ElementId, ElementMap, FunctionOfTime,
+                            deserialize_domain, deserialize_functions_of_time)
 from spectre.Domain.CoordinateMaps import (
     CoordinateMapElementLogicalToInertial1D,
     CoordinateMapElementLogicalToInertial2D,
     CoordinateMapElementLogicalToInertial3D)
 from spectre.Spectral import Mesh, logical_coordinates
-from typing import Union, Iterable, Optional, Dict
 
 # functools.cached_property was added in Py 3.8. Fall back to a plain
 # `property` in Py 3.7.
@@ -64,14 +65,15 @@ class Element:
 
 def iter_elements(volfiles: Union[spectre_h5.H5Vol,
                                   Iterable[spectre_h5.H5Vol]],
-                  obs_id: int,
+                  obs_ids: Optional[Union[int, Sequence[int]]],
                   tensor_components: Optional[Iterable[str]] = None):
     """Return volume data by element
 
     Arguments:
       volfiles: Open spectre H5 volume files. Can be a single volfile or a list,
         but can also be an iterator that opens and closes the files on demand.
-      obs_id: Observation ID
+      obs_id: An observation ID, a list of observation IDs, or None to iterate
+        over all observation IDs.
       tensor_components: Tensor components to retrieve. Can be empty.
 
     Returns: Iterator over all elements in all 'volfiles'. Yields either just
@@ -82,46 +84,60 @@ def iter_elements(volfiles: Union[spectre_h5.H5Vol,
     """
     if isinstance(volfiles, spectre_h5.H5Vol):
         volfiles = [volfiles]
+    if isinstance(obs_ids, int):
+        obs_ids = [obs_ids]
+    # Assuming the domain is the same in all volfiles at all observations to
+    # speed up the script
+    domain = None
     for volfile in volfiles:
-        dim = volfile.get_dimension()
-        domain = deserialize_domain[dim](volfile.get_domain(obs_id))
-        if domain.is_time_dependent():
-            time = volfile.get_observation_value(obs_id)
-            functions_of_time = deserialize_functions_of_time(
-                volfile.get_functions_of_time(obs_id))
+        all_obs_ids = volfile.list_observation_ids()
+        if obs_ids:
+            selected_obs_ids = [
+                obs_id for obs_id in obs_ids if obs_id in all_obs_ids
+            ]
         else:
-            time = None
-            functions_of_time = None
-        all_grid_names = volfile.get_grid_names(obs_id)
-        all_element_ids = [ElementId[dim](name) for name in all_grid_names]
-        all_extents = volfile.get_extents(obs_id)
-        all_bases = volfile.get_bases(obs_id)
-        all_quadratures = volfile.get_quadratures(obs_id)
-        all_meshes = [
-            Mesh[dim](*mesh_args)
-            for mesh_args in zip(all_extents, all_bases, all_quadratures)
-        ]
-        # Pre-load the tensor data because it's stored contiguously for all
-        # grids in the file
-        if tensor_components:
-            tensor_data = np.asarray([
-                volfile.get_tensor_component(obs_id, component).data
-                for component in tensor_components
-            ])
-        # Iterate elements in this file
-        for grid_name, element_id, mesh in zip(all_grid_names, all_element_ids,
-                                               all_meshes):
-            offset, length = spectre_h5.offset_and_length_for_grid(
-                grid_name, all_grid_names, all_extents)
-            data_slice = slice(offset, offset + length)
-            element_map = ElementMap(element_id, domain)
-            element = Element(element_id,
-                              mesh=mesh,
-                              map=element_map,
-                              time=time,
-                              functions_of_time=functions_of_time,
-                              data_slice=data_slice)
-            if tensor_components:
-                yield element, tensor_data[:, offset:offset + length]
+            selected_obs_ids = all_obs_ids
+        dim = volfile.get_dimension()
+        for obs_id in selected_obs_ids:
+            if not domain:
+                domain = deserialize_domain[dim](volfile.get_domain(obs_id))
+            time = volfile.get_observation_value(obs_id)
+            if domain.is_time_dependent():
+                functions_of_time = deserialize_functions_of_time(
+                    volfile.get_functions_of_time(obs_id))
             else:
-                yield element
+                functions_of_time = None
+            all_grid_names = volfile.get_grid_names(obs_id)
+            all_element_ids = [ElementId[dim](name) for name in all_grid_names]
+            all_extents = volfile.get_extents(obs_id)
+            all_bases = volfile.get_bases(obs_id)
+            all_quadratures = volfile.get_quadratures(obs_id)
+            all_meshes = [
+                Mesh[dim](*mesh_args)
+                for mesh_args in zip(all_extents, all_bases, all_quadratures)
+            ]
+            # Pre-load the tensor data because it's stored contiguously for all
+            # grids in the file
+            if tensor_components:
+                tensor_data = np.asarray([
+                    volfile.get_tensor_component(obs_id, component).data
+                    for component in tensor_components
+                ])
+            # Iterate elements in this file
+            for grid_name, element_id, mesh in zip(all_grid_names,
+                                                   all_element_ids,
+                                                   all_meshes):
+                offset, length = spectre_h5.offset_and_length_for_grid(
+                    grid_name, all_grid_names, all_extents)
+                data_slice = slice(offset, offset + length)
+                element_map = ElementMap(element_id, domain)
+                element = Element(element_id,
+                                  mesh=mesh,
+                                  map=element_map,
+                                  time=time,
+                                  functions_of_time=functions_of_time,
+                                  data_slice=data_slice)
+                if tensor_components:
+                    yield element, tensor_data[:, offset:offset + length]
+                else:
+                    yield element

--- a/src/Visualization/Python/PlotPowerMonitors.py
+++ b/src/Visualization/Python/PlotPowerMonitors.py
@@ -11,11 +11,12 @@ import click
 import matplotlib.pyplot as plt
 import numpy as np
 import spectre.IO.H5 as spectre_h5
-from spectre.Spectral import Basis
+from matplotlib.colors import LinearSegmentedColormap
 from spectre.DataStructures import DataVector
 from spectre.Domain import Domain, deserialize_domain
 from spectre.IO.H5.IterElements import iter_elements, stripped_element_name
 from spectre.NumericalAlgorithms.LinearOperators import power_monitors
+from spectre.Spectral import Basis
 
 logger = logging.getLogger(__name__)
 
@@ -35,17 +36,22 @@ def find_block_or_group(
     return None
 
 
-def plot_power_monitors(volfiles: Union[spectre_h5.H5Vol,
-                                        Iterable[spectre_h5.H5Vol]],
-                        obs_id: int, tensor_components: Sequence[str],
-                        block_or_group_names: Sequence[str],
-                        domain: Union[Domain[1], Domain[2], Domain[3]],
-                        element_patterns: Optional[Sequence[str]] = None):
-    # One subplot per block or group
-    num_plots = len(block_or_group_names)
-    fig, axes = plt.subplots(nrows=1,
-                             ncols=num_plots,
-                             figsize=(num_plots * 4, 4),
+def plot_power_monitors(
+    volfiles: Union[spectre_h5.H5Vol, Iterable[spectre_h5.H5Vol]],
+    obs_id: Optional[int],
+    tensor_components: Sequence[str],
+    block_or_group_names: Sequence[str],
+    domain: Union[Domain[1], Domain[2], Domain[3]],
+    dimension_labels: Sequence[str] = [r"$\xi$", r"$\eta$", r"$\zeta$"],
+    element_patterns: Optional[Sequence[str]] = None):
+    plot_over_time = obs_id is None
+    # One column per block or group
+    num_cols = len(block_or_group_names)
+    # One row per dimension if plotted over time to declutter the plots
+    num_rows = domain.dim if plot_over_time else 1
+    fig, axes = plt.subplots(nrows=num_rows,
+                             ncols=num_cols,
+                             figsize=(num_cols * 4, num_rows * 4),
                              sharey=True,
                              sharex=True,
                              squeeze=False)
@@ -63,9 +69,15 @@ def plot_power_monitors(volfiles: Union[spectre_h5.H5Vol,
         for d in range(domain.dim)
     }
 
-    # Collect some reduction data for each subplot
-    num_elements = np.zeros(num_plots, dtype=int)
-    max_error = np.zeros((num_plots, domain.dim))
+    # Collect data for each subplot
+    if plot_over_time:
+        all_mode_time_series = {
+            subplot_index: dict()
+            for subplot_index in range(num_cols)
+        }
+    else:
+        num_elements = np.zeros(num_cols, dtype=int)
+        max_error = np.zeros((num_cols, domain.dim))
 
     for element, tensor_data in iter_elements(
             volfiles, obs_id, tensor_components,
@@ -81,8 +93,7 @@ def plot_power_monitors(volfiles: Union[spectre_h5.H5Vol,
                                             block_or_group_names, domain)
         if subplot_index is None:
             continue
-        num_elements[subplot_index] += 1
-        ax = axes[0][subplot_index]
+
         # Compute power monitors and take L2 norm over tensor components
         all_modes = [
             np.zeros(element.mesh.extents(d)) for d in range(element.dim)
@@ -93,42 +104,103 @@ def plot_power_monitors(volfiles: Union[spectre_h5.H5Vol,
                 all_modes[d] += modes_dim**2
         for d in range(element.dim):
             all_modes[d] = np.sqrt(all_modes[d])
-            # Collect reduction data
-            # - We estimate the truncation error by just taking the highest
-            #   mode. This won't work well with filtering and should be improved
-            #   on the C++ side.
-            max_error[subplot_index][d] = max(max_error[subplot_index][d],
-                                              all_modes[d][-1])
-        # Plot
-        for d, modes_dim in enumerate(all_modes):
-            ax.semilogy(modes_dim, **props_dim[d], zorder=30 + d)
-            ax.scatter(len(modes_dim) - 1,
-                       modes_dim[-1],
-                       marker=".",
-                       color=props_dim[d].get("color", "black"),
-                       zorder=30 + d)
 
+        if plot_over_time:
+            # Collect time series of modes
+            all_mode_time_series[subplot_index].setdefault(element.id,
+                                                           []).append(
+                                                               (element.time,
+                                                                all_modes))
+        else:
+            # Plot modes directly
+            ax = axes[0][subplot_index]
+            for d, modes_dim in enumerate(all_modes):
+                ax.semilogy(modes_dim, **props_dim[d], zorder=30 + d)
+                ax.scatter(len(modes_dim) - 1,
+                           modes_dim[-1],
+                           marker=".",
+                           color=props_dim[d].get("color", "black"),
+                           zorder=30 + d)
+                # Collect reduction data
+                # - We estimate the truncation error by just taking the highest
+                #   mode. This won't work well with filtering and should be
+                #   improved on the C++ side.
+                max_error[subplot_index][d] = max(max_error[subplot_index][d],
+                                                  all_modes[d][-1])
+            num_elements[subplot_index] += 1
+
+    if plot_over_time:
+        # Plot mode timeseries
+        max_num_modes = np.max(np.array(
+            [[len(modes) for modes in all_modes]
+             for subplot_index in range(num_cols) for mode_time_series in
+             all_mode_time_series[subplot_index].values()
+             for _, all_modes in mode_time_series]),
+                               axis=0)
+        mode_cmap = [
+            LinearSegmentedColormap.from_list(
+                "Modes", ["black", props_dim[d].get("color", "black")],
+                N=max_num_modes[d]) for d in range(domain.dim)
+        ]
+        for subplot_index in range(num_cols):
+            for element_id, mode_time_series in all_mode_time_series[
+                    subplot_index].items():
+                times = np.array([time for time, _ in mode_time_series])
+                for d in range(domain.dim):
+                    ax = axes[d][subplot_index]
+                    for mode in range(max_num_modes[d]):
+                        mode_time_series_i = np.array([
+                            (all_modes[d][mode]
+                             if len(all_modes[d]) > mode else np.nan)
+                            for _, all_modes in mode_time_series
+                        ])
+                        color = mode_cmap[d](mode / (max_num_modes[d] - 1))
+                        ax.semilogy(times,
+                                    mode_time_series_i,
+                                    color=color,
+                                    zorder=30 + d)
+        # Plot colorbars as legend
+        import matplotlib.cm
+        import matplotlib.colors
+        for d in range(domain.dim):
+            colorbar = plt.colorbar(matplotlib.cm.ScalarMappable(
+                norm=matplotlib.colors.Normalize(0, max_num_modes[d]),
+                cmap=mode_cmap[d]),
+                                    ax=axes[d],
+                                    ticks=list(range(max_num_modes[d])),
+                                    label=dimension_labels[d] + " Mode")
+            colorbar.ax.invert_yaxis()
+    else:
+        # Annotate the max truncation error. Also serves as a legend.
+        for subplot_index, ax in enumerate(axes[0]):
+            for d in range(domain.dim):
+                ax.axhline(max_error[subplot_index][d],
+                           **props_dim[d],
+                           zorder=20 + d)
+                ax.annotate(dimension_labels[d],
+                            xy=(0, max_error[subplot_index][d]),
+                            xytext=((2 * d + 0.5) * plt.rcParams["font.size"],
+                                    0),
+                            textcoords='offset points',
+                            ha='left',
+                            va='center',
+                            bbox=dict(fc="white",
+                                      ec=props_dim[d].get("color", "black"),
+                                      pad=2.),
+                            zorder=40 + d)
+
+    # Set plot titles
     for subplot_index, ax in enumerate(axes[0]):
         ax.set_title(block_or_group_names[subplot_index], loc="left")
-        ax.set_title(f"{num_elements[subplot_index]} element" +
-                     "s"[:num_elements[subplot_index] != 1],
+        num_elements_i = (len(all_mode_time_series[subplot_index])
+                          if plot_over_time else num_elements[subplot_index])
+        ax.set_title(f"{num_elements_i} element" + "s"[:num_elements_i != 1],
                      loc="right")
-        ax.grid(which='both', zorder=0)
-        # Annotate the max truncation error. Also serves as a legend.
-        for d in range(domain.dim):
-            ax.axhline(max_error[subplot_index][d],
-                       **props_dim[d],
-                       zorder=20 + d)
-            ax.annotate([r"$\xi$", r"$\eta$", r"$\zeta$"][d],
-                        xy=(0, max_error[subplot_index][d]),
-                        xytext=((2 * d + 0.5) * plt.rcParams["font.size"], 0),
-                        textcoords='offset points',
-                        ha='left',
-                        va='center',
-                        bbox=dict(fc="white",
-                                  ec=props_dim[d].get("color", "black"),
-                                  pad=2.),
-                        zorder=40 + d)
+
+    # Draw grid lines
+    for axes_row in axes:
+        for ax in axes_row:
+            ax.grid(which='both', zorder=0)
 
     # Add x-label spanning all subplots
     ax_colspan = fig.add_subplot(111, frameon=False)
@@ -138,7 +210,7 @@ def plot_power_monitors(volfiles: Union[spectre_h5.H5Vol,
                            left=False,
                            right=False)
     ax_colspan.grid(False)
-    ax_colspan.set_xlabel("Mode number")
+    ax_colspan.set_xlabel("Time" if plot_over_time else "Mode number")
 
 
 def parse_step(ctx, param, value):
@@ -265,22 +337,28 @@ def plot_power_monitors_command(h5_files, subfile_name, step, time,
 
     # Select observation
     if step is None and time is None:
-        step = -1
+        # Plot power monitors over time
+        obs_id = None
     elif step is not None and time is not None:
         raise click.UsageError(
             f"Specify either '--step' (in [0, {len(obs_ids) - 1}], or -1) or "
-            f"'--time' (in [{obs_values[0]:g}, {obs_values[-1]:g}]).")
-    if step is None:
+            f"'--time' (in [{obs_values[0]:g}, {obs_values[-1]:g}]), "
+            "or neither.")
+    elif step is None:
         # Find closest observation to specified time
         step = np.argmin(np.abs(time - np.array(obs_values)))
         obs_value = obs_values[step]
         if obs_value != time:
             logger.info(f"Selected closest observation to t = {time}: "
                         f"step {step} at t = {obs_value:g}")
-    obs_id = obs_ids[step]
+        obs_id = obs_ids[step]
+    else:
+        # Select the specified observation
+        obs_id = obs_ids[step]
 
     # Print available blocks and groups
-    domain = deserialize_domain[dim](volfiles[0].get_domain(obs_id))
+    any_obs_id = obs_id if obs_id is not None else obs_ids[0]
+    domain = deserialize_domain[dim](volfiles[0].get_domain(any_obs_id))
     all_block_groups = list(domain.block_groups.keys())
     all_block_names = [block.name for block in domain.blocks]
     if list_blocks or not block_or_group_names:
@@ -317,7 +395,7 @@ def plot_power_monitors_command(h5_files, subfile_name, step, time,
         return
 
     # Print available variables and exit
-    all_vars = volfiles[0].list_tensor_components(obs_id)
+    all_vars = volfiles[0].list_tensor_components(any_obs_id)
     if list_vars or not vars_patterns:
         import rich.columns
         rich.print(rich.columns.Columns(all_vars))

--- a/tests/Unit/Visualization/Python/Test_PlotPowerMonitors.py
+++ b/tests/Unit/Visualization/Python/Test_PlotPowerMonitors.py
@@ -43,6 +43,7 @@ class TestPlotPowerMonitors(unittest.TestCase):
 
     def test_cli(self):
         runner = CliRunner()
+        # Test plotting a single step
         result = runner.invoke(plot_power_monitors_command, [
             self.h5_filename,
             "-d",
@@ -62,6 +63,27 @@ class TestPlotPowerMonitors(unittest.TestCase):
         self.assertEqual(result.exit_code, 0, result.output)
         # Can't easily test the plot itself, so just check that it was created
         self.assertTrue(os.path.exists(self.plot_filename))
+        os.remove(self.plot_filename)
+
+        # Test plotting over time
+        result = runner.invoke(plot_power_monitors_command, [
+            self.h5_filename,
+            "-d",
+            "element_data",
+            "-b",
+            "Brick",
+            "-e",
+            "B*",
+            "-y",
+            "Psi",
+            "-o",
+            self.plot_filename,
+        ],
+                               catch_exceptions=False)
+        self.assertEqual(result.exit_code, 0, result.output)
+        # Can't easily test the plot itself, so just check that it was created
+        self.assertTrue(os.path.exists(self.plot_filename))
+        os.remove(self.plot_filename)
 
 
 if __name__ == '__main__':

--- a/tests/Unit/Visualization/Python/Test_PlotPowerMonitors.py
+++ b/tests/Unit/Visualization/Python/Test_PlotPowerMonitors.py
@@ -51,6 +51,8 @@ class TestPlotPowerMonitors(unittest.TestCase):
             "-1",
             "-b",
             "Brick",
+            "-e",
+            "B*",
             "-y",
             "Psi",
             "-o",


### PR DESCRIPTION
## Proposed changes

Allows plotting power monitors over time, as well as filtering by element name.

Try this:

```sh
$ spectre plot-power-monitors H5FILES -d VolumeData -b Shell1 -b Shell2 -y Field -e "B*,(L1I1,L1I1,L1I1)"
```

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
