### PR TITLE
Add integrands for BNS observers

### DIFF
--- a/src/PointwiseFunctions/Hydro/CMakeLists.txt
+++ b/src/PointwiseFunctions/Hydro/CMakeLists.txt
@@ -11,6 +11,7 @@ spectre_target_sources(
   ComovingMagneticField.cpp
   LorentzFactor.cpp
   MassFlux.cpp
+  MassWeightedFluidItems.cpp
   SoundSpeedSquared.cpp
   SpecificEnthalpy.cpp
   StressEnergy.cpp
@@ -23,6 +24,7 @@ spectre_target_headers(
   ComovingMagneticField.hpp
   LorentzFactor.hpp
   MassFlux.hpp
+  MassWeightedFluidItems.hpp
   SoundSpeedSquared.hpp
   SpecificEnthalpy.hpp
   StressEnergy.hpp

--- a/src/PointwiseFunctions/Hydro/MassWeightedFluidItems.cpp
+++ b/src/PointwiseFunctions/Hydro/MassWeightedFluidItems.cpp
@@ -1,0 +1,83 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "MassWeightedFluidItems.hpp"
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/ContainerHelpers.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace hydro {
+
+template <typename DataType, size_t Dim, typename Frame>
+void u_lower_t(const gsl::not_null<Scalar<DataType>*> result,
+               const Scalar<DataType>& lorentz_factor,
+               const tnsr::i<DataType, Dim, Frame>& spatial_velocity_one_form,
+               const Scalar<DataType>& lapse,
+               const tnsr::I<DataType, Dim, Frame>& shift) {
+  dot_product(result, spatial_velocity_one_form, shift);
+  result->get() = get(lorentz_factor) * (get(lapse) * (-1.0) + result->get());
+}
+
+template <typename DataType>
+void mass_weighted_internal_energy(
+    const gsl::not_null<Scalar<DataType>*> result,
+    const Scalar<DataType>& tilde_d,
+    const Scalar<DataType>& specific_internal_energy) {
+  result->get() = get(tilde_d) * get(specific_internal_energy);
+}
+
+template <typename DataType>
+void mass_weighted_kinetic_energy(const gsl::not_null<Scalar<DataType>*> result,
+                                  const Scalar<DataType>& tilde_d,
+                                  const Scalar<DataType>& lorentz_factor) {
+  result->get() = get(tilde_d) * (get(lorentz_factor) - 1.0);
+}
+
+template <typename DataType, size_t Dim, typename Fr>
+void tilde_d_unbound_ut_criterion(
+    const gsl::not_null<Scalar<DataType>*> result,
+    const Scalar<DataType>& tilde_d, const Scalar<DataType>& lorentz_factor,
+    const tnsr::i<DataType, Dim, Fr>& spatial_velocity_one_form,
+    const Scalar<DataType>& lapse, const tnsr::I<DataType, Dim, Fr>& shift) {
+  u_lower_t(result, lorentz_factor, spatial_velocity_one_form, lapse, shift);
+  result->get() = get(tilde_d) * step_function(-1.0 - result->get());
+}
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data)                                         \
+  template void u_lower_t(                                           \
+      const gsl::not_null<Scalar<DataVector>*> result,               \
+      const Scalar<DataVector>& lorentz_factor,                      \
+      const tnsr::i<DataVector, DIM(data), Frame::Inertial>&         \
+          spatial_velocity_one_form,                                 \
+      const Scalar<DataVector>& lapse,                               \
+      const tnsr::I<DataVector, DIM(data), Frame::Inertial>& shift); \
+  template void tilde_d_unbound_ut_criterion(                        \
+      const gsl::not_null<Scalar<DataVector>*> result,               \
+      const Scalar<DataVector>& tilde_d,                             \
+      const Scalar<DataVector>& lorentz_factor,                      \
+      const tnsr::i<DataVector, DIM(data), Frame::Inertial>&         \
+          spatial_velocity_one_form,                                 \
+      const Scalar<DataVector>& lapse,                               \
+      const tnsr::I<DataVector, DIM(data), Frame::Inertial>& shift);
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
+
+#undef DIM
+#undef INSTANTIATE
+
+template void mass_weighted_internal_energy(
+    const gsl::not_null<Scalar<DataVector>*> result,
+    const Scalar<DataVector>& tilde_d,
+    const Scalar<DataVector>& specific_internal_energy);
+template void mass_weighted_kinetic_energy(
+    const gsl::not_null<Scalar<DataVector>*> result,
+    const Scalar<DataVector>& tilde_d,
+    const Scalar<DataVector>& lorentz_factor);
+
+}  // namespace hydro

--- a/src/PointwiseFunctions/Hydro/MassWeightedFluidItems.hpp
+++ b/src/PointwiseFunctions/Hydro/MassWeightedFluidItems.hpp
@@ -1,0 +1,138 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/TagsDeclarations.hpp"  // IWYU pragma: keep
+#include "PointwiseFunctions/GeneralRelativity/TagsDeclarations.hpp"  // IWYU pragma: keep
+#include "PointwiseFunctions/Hydro/TagsDeclarations.hpp"  // IWYU pragma: keep
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+namespace gsl {
+template <typename>
+struct not_null;
+}  // namespace gsl
+/// \endcond
+
+namespace hydro {
+
+/// Tag containing TildeD * SpecificInternalEnergy
+/// Useful as a diagnostics tool, as input to volume
+/// integral.
+namespace Tags {
+template <typename DataType>
+struct MassWeightedInternalEnergy : db::SimpleTag {
+  using type = Scalar<DataType>;
+};
+
+/// Tag containing TildeD * (LorentzFactor - 1.0)
+/// Useful as a diagnostics tool, as input to volume
+/// integral.
+template <typename DataType>
+struct MassWeightedKineticEnergy : db::SimpleTag {
+  using type = Scalar<DataType>;
+};
+
+/// Contains TildeD restricted to regions marked as
+/// unbound, using the u_t < -1 criterion.
+template <typename DataType>
+struct TildeDUnboundUtCriterion : db::SimpleTag {
+  using type = Scalar<DataType>;
+};
+}  // namespace Tags
+
+/// Compute tilde_d * specific_internal_energy
+/// Result of the calculation stored in result.
+template <typename DataType>
+void mass_weighted_internal_energy(
+    const gsl::not_null<Scalar<DataType>*> result,
+    const Scalar<DataType>& tilde_d,
+    const Scalar<DataType>& specific_internal_energy);
+
+/// Compute tilde_d * (lorentz_factor - 1.0)
+/// Result of the calculation stored in result.
+template <typename DataType>
+void mass_weighted_kinetic_energy(const gsl::not_null<Scalar<DataType>*> result,
+                                  const Scalar<DataType>& tilde_d,
+                                  const Scalar<DataType>& lorentz_factor);
+
+/// Returns tilde_d in regions where u_t < -1 and 0 in regions where
+/// u_t > -1 (approximate criteria for unbound matter, theoretically
+/// valid for particles following geodesics of a time-independent metric).
+template <typename DataType, size_t Dim, typename Fr = Frame::Inertial>
+void tilde_d_unbound_ut_criterion(
+    const gsl::not_null<Scalar<DataType>*> result,
+    const Scalar<DataType>& tilde_d, const Scalar<DataType>& lorentz_factor,
+    const tnsr::i<DataType, Dim, Fr>& spatial_velocity_one_form,
+    const Scalar<DataType>& lapse, const tnsr::I<DataType, Dim, Fr>& shift);
+
+namespace Tags {
+/// Compute item for mass-weighted internal energy
+///
+/// Can be retrieved using `hydro::Tags::MassWeightedInternalEnergy'
+template <typename DataType>
+struct MassWeightedInternalEnergyCompute : MassWeightedInternalEnergy<DataType>,
+                                           db::ComputeTag {
+  using argument_tags = tmpl::list<grmhd::ValenciaDivClean::Tags::TildeD,
+                                   SpecificInternalEnergy<DataType>>;
+
+  using return_type = Scalar<DataType>;
+
+  using base = MassWeightedInternalEnergy<DataType>;
+
+  static constexpr auto function =
+      static_cast<void (*)(const gsl::not_null<Scalar<DataType>*> result,
+                           const Scalar<DataType>& tilde_d,
+                           const Scalar<DataType>& specific_internal_energy)>(
+          &mass_weighted_internal_energy<DataType>);
+};
+
+/// Compute item for mass-weighted internal energy
+///
+/// Can be retrieved using `hydro::Tags::MassWeightedKineticEnergy'
+template <typename DataType>
+struct MassWeightedKineticEnergyCompute : MassWeightedKineticEnergy<DataType>,
+                                          db::ComputeTag {
+  using argument_tags = tmpl::list<grmhd::ValenciaDivClean::Tags::TildeD,
+                                   LorentzFactor<DataType>>;
+
+  using return_type = Scalar<DataType>;
+
+  using base = MassWeightedKineticEnergy<DataType>;
+
+  static constexpr auto function = static_cast<void (*)(
+      const gsl::not_null<Scalar<DataType>*> result,
+      const Scalar<DataType>& tilde_d, const Scalar<DataType>& lorentz_factor)>(
+      &mass_weighted_kinetic_energy<DataType>);
+};
+
+/// Compute item for TildeD limited to unbound material (u_t<-1 criteria)
+///
+/// Can be retrieved using `hydro::Tags::TildeDUnboundUtCriterion'
+template <typename DataType, size_t Dim, typename Fr = Frame::Inertial>
+struct TildeDUnboundUtCriterionCompute : TildeDUnboundUtCriterion<DataType>,
+                                         db::ComputeTag {
+  using argument_tags =
+      tmpl::list<grmhd::ValenciaDivClean::Tags::TildeD, LorentzFactor<DataType>,
+                 SpatialVelocityOneForm<DataType, Dim, Fr>,
+                 gr::Tags::Lapse<DataType>, gr::Tags::Shift<Dim, Fr, DataType>>;
+
+  using return_type = Scalar<DataType>;
+
+  using base = TildeDUnboundUtCriterion<DataType>;
+
+  static constexpr auto function = static_cast<void (*)(
+      const gsl::not_null<Scalar<DataType>*> result,
+      const Scalar<DataType>& tilde_d, const Scalar<DataType>& lorentz_factor,
+      const tnsr::i<DataType, Dim, Fr>& spatial_velocity_one_form,
+      const Scalar<DataType>& lapse, const tnsr::I<DataType, Dim, Fr>& shift)>(
+      &tilde_d_unbound_ut_criterion<DataType, Dim, Fr>);
+};
+
+}  // namespace Tags
+}  // namespace hydro

--- a/tests/Unit/PointwiseFunctions/Hydro/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/Hydro/CMakeLists.txt
@@ -9,6 +9,7 @@ set(LIBRARY_SOURCES
   Test_ComovingMagneticField.cpp
   Test_LorentzFactor.cpp
   Test_MassFlux.cpp
+  Test_MassWeightedFluidItems.cpp
   Test_SoundSpeedSquared.cpp
   Test_SpecificEnthalpy.cpp
   Test_StressEnergy.cpp

--- a/tests/Unit/PointwiseFunctions/Hydro/TestFunctions.py
+++ b/tests/Unit/PointwiseFunctions/Hydro/TestFunctions.py
@@ -3,6 +3,26 @@
 
 import numpy as np
 
+# Functions testing the MassWeightedFluidItems
+
+
+def mass_weighted_internal_energy(tilde_d, specific_internal_energy):
+    return tilde_d * specific_internal_energy
+
+
+def mass_weighted_kinetic_energy(tilde_d, lorentz_factor):
+    return tilde_d * (lorentz_factor - 1.0)
+
+
+def tilde_d_unbound_ut_criterion(tilde_d, lorentz_factor,
+                                 spatial_velocity_one_form, lapse, shift):
+    shift_dot_velocity = np.dot(spatial_velocity_one_form, shift)
+    u_t = lorentz_factor * (-lapse + shift_dot_velocity)
+    return tilde_d * (u_t < -1.0)
+
+
+# Functions testing the MassWeightedFluidItems
+
 
 def comoving_magnetic_field_one_form(spatial_velocity_one_form,
                                      magnetic_field_one_form,

--- a/tests/Unit/PointwiseFunctions/Hydro/Test_MassWeightedFluidItems.cpp
+++ b/tests/Unit/PointwiseFunctions/Hydro/Test_MassWeightedFluidItems.cpp
@@ -1,0 +1,35 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <string>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Framework/CheckWithRandomValues.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
+#include "PointwiseFunctions/Hydro/MassWeightedFluidItems.hpp"
+
+namespace hydro {
+
+SPECTRE_TEST_CASE("Unit.PointwiseFunctions.Hydro.MassWeightedFluidItems",
+                  "[Unit][Hydro]") {
+  pypp::SetupLocalPythonEnvironment local_python_env(
+      "PointwiseFunctions/Hydro/");
+  const DataVector used_for_size(5);
+  pypp::check_with_random_values<1>(
+      &mass_weighted_internal_energy<DataVector>, "TestFunctions",
+      {"mass_weighted_internal_energy"}, {{{0.0, 1.0}}}, used_for_size);
+  pypp::check_with_random_values<1>(
+      &mass_weighted_kinetic_energy<DataVector>, "TestFunctions",
+      {"mass_weighted_kinetic_energy"}, {{{0.0, 1.0}}}, used_for_size);
+  pypp::check_with_random_values<1>(
+      &tilde_d_unbound_ut_criterion<DataVector, 1, Frame::Inertial>,
+      "TestFunctions", {"tilde_d_unbound_ut_criterion"}, {{{0.0, 1.0}}},
+      used_for_size);
+}
+
+}  // namespace hydro


### PR DESCRIPTION
## Proposed changes

Add a few db::ComputeTag that can be used as integrand to diagnose BNS simulations.

NOTE: Because the TildeD tag is currently hard-coded to be a Scalar<DataVector> in Frame::Inertial, it could make sense to avoid using templates. On the other hand, we might want to use TildeD in a different frame in the future, or test calculations on doubles instead of DataVectors, in which case having the templates would be useful. I'm happy to remove the templates if that's the preferred choice.

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.