### PR TITLE
Add actions to send data from worldtube to abutting elements

### DIFF
--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/ElementActions/CMakeLists.txt
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/ElementActions/CMakeLists.txt
@@ -5,5 +5,6 @@ spectre_target_headers(
   ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
+  ReceiveWorldtubeData.hpp
   SendToWorldtube.hpp
 )

--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/ElementActions/ReceiveWorldtubeData.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/ElementActions/ReceiveWorldtubeData.hpp
@@ -1,0 +1,144 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <optional>
+#include <tuple>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/PrefixHelpers.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Slice.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/IndexToSliceAt.hpp"
+#include "Domain/Tags.hpp"
+#include "Evolution/Systems/CurvedScalarWave/System.hpp"
+#include "Evolution/Systems/CurvedScalarWave/Tags.hpp"
+#include "Evolution/Systems/CurvedScalarWave/Worldtube/Inboxes.hpp"
+#include "Evolution/Systems/CurvedScalarWave/Worldtube/PunctureField.hpp"
+#include "Evolution/Systems/CurvedScalarWave/Worldtube/Tags.hpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "Parallel/AlgorithmExecution.hpp"
+#include "Parallel/AlgorithmMetafunctions.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "Parallel/Invoke.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace CurvedScalarWave::Worldtube::Actions {
+
+/*!
+ * \brief Checks if the regular field has been received from the worldtube and
+ * computes the retarded field for boundary conditions.
+ *
+ *  \details This action checks whether values for the regular field have been
+ * send by the worldtube. If so, the spatial derivative is converted from the
+ * grid to inertial frame and the puncture field is added to it to obtain the
+ * retarded field. This is stored in \ref Tags::WorldtubeSolution which is used
+ * to formulate boundary conditions in
+ * \ref CurvedScalarWave::BoundaryConditions::Worldtube.
+ */
+struct ReceiveWorldtubeData {
+  static constexpr size_t Dim = 3;
+  using psi_tag = CurvedScalarWave::Tags::Psi;
+  using dt_psi_tag = ::Tags::dt<CurvedScalarWave::Tags::Psi>;
+  template <typename Frame>
+  using di_psi_tag =
+      ::Tags::deriv<CurvedScalarWave::Tags::Psi, tmpl::size_t<Dim>, Frame>;
+  using received_tags =
+      tmpl::list<psi_tag, dt_psi_tag, di_psi_tag<Frame::Grid>>;
+  using evolved_tags_list =
+      typename CurvedScalarWave::System<Dim>::variables_tag::tags_list;
+  using simple_tags = tmpl::list<Tags::WorldtubeSolution<Dim>>;
+  using inbox_tags = tmpl::list<Tags::RegularFieldInbox<Dim>>;
+  using tags_to_slice_to_face = tmpl::list<
+      domain::Tags::InverseJacobian<Dim, Frame::Grid, Frame::Inertial>,
+      gr::Tags::Shift<Dim, Frame::Inertial, DataVector>,
+      gr::Tags::Lapse<DataVector>>;
+
+  template <typename DbTagsList, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent>
+  static Parallel::iterable_action_return_t apply(
+      db::DataBox<DbTagsList>& box, tuples::TaggedTuple<InboxTags...>& inboxes,
+      const Parallel::GlobalCache<Metavariables>& /*cache*/,
+      const ArrayIndex& /*array_index*/, const ActionList /*meta*/,
+      const ParallelComponent* const /*meta*/) {
+    const auto& puncture_field = db::get<Tags::PunctureField<Dim>>(box);
+    if (puncture_field.has_value()) {
+      const auto& time_step_id = db::get<::Tags::TimeStepId>(box);
+      auto& inbox = get<Tags::RegularFieldInbox<Dim>>(inboxes);
+      if (not inbox.count(time_step_id)) {
+        return {Parallel::AlgorithmExecution::Retry, std::nullopt};
+      }
+      const auto& element_id = db::get<domain::Tags::Element<Dim>>(box).id();
+      const auto& excision_sphere = db::get<Tags::ExcisionSphere<Dim>>(box);
+      const auto direction = excision_sphere.abutting_direction(element_id);
+      ASSERT(direction.has_value(), "This element should abut the worldtube!");
+
+      const auto& mesh = db::get<domain::Tags::Mesh<Dim>>(box);
+      const auto face_mesh = mesh.slice_away(direction->dimension());
+      const size_t face_size = face_mesh.number_of_grid_points();
+      Variables<tags_to_slice_to_face> vars_on_face(face_size);
+      tmpl::for_each<tags_to_slice_to_face>(
+          [&box, &vars_on_face, &mesh, &direction](auto tag_to_slice_v) {
+            using tag_to_slice = typename decltype(tag_to_slice_v)::type;
+            data_on_slice(make_not_null(&get<tag_to_slice>(vars_on_face)),
+                          db::get<tag_to_slice>(box), mesh.extents(),
+                          direction.value().dimension(),
+                          index_to_slice_at(mesh.extents(), direction.value()));
+          });
+
+      auto& received_data = inbox.at(time_step_id);
+      get(get<psi_tag>(received_data)) +=
+          get(get<psi_tag>(puncture_field.value()));
+      get(get<dt_psi_tag>(received_data)) +=
+          get(get<dt_psi_tag>(puncture_field.value()));
+
+      db::mutate<Tags::WorldtubeSolution<Dim>>(
+          make_not_null(&box),
+          [&received_data, &puncture_field,
+           &vars_on_face](const gsl::not_null<Variables<evolved_tags_list>*>
+                              worldtube_solution) {
+            const auto& inv_jacobian = get<domain::Tags::InverseJacobian<
+                Dim, Frame::Grid, Frame::Inertial>>(vars_on_face);
+            auto& phi_inertial =
+                get<CurvedScalarWave::Tags::Phi<Dim>>(*worldtube_solution);
+            for (size_t i = 0; i < Dim; ++i) {
+              phi_inertial.get(i) =
+                  get<0>(get<di_psi_tag<Frame::Grid>>(received_data)) *
+                      inv_jacobian.get(0, i) +
+                  get<1>(get<di_psi_tag<Frame::Grid>>(received_data)) *
+                      inv_jacobian.get(1, i) +
+                  get<2>(get<di_psi_tag<Frame::Grid>>(received_data)) *
+                      inv_jacobian.get(2, i);
+              phi_inertial.get(i) +=
+                  get<di_psi_tag<Frame::Inertial>>(puncture_field.value())
+                      .get(i);
+            }
+
+            get<CurvedScalarWave::Tags::Psi>(*worldtube_solution) =
+                get<psi_tag>(received_data);
+            const auto& shift =
+                get<gr::Tags::Shift<Dim, Frame::Inertial, DataVector>>(
+                    vars_on_face);
+
+            const auto& lapse = get<gr::Tags::Lapse<DataVector>>(vars_on_face);
+            auto& pi = get<CurvedScalarWave::Tags::Pi>(*worldtube_solution);
+            get(pi) = (-get(get<dt_psi_tag>(received_data)) +
+                       get(dot_product(shift, phi_inertial))) /
+                      get(lapse);
+          });
+      inbox.erase(time_step_id);
+    }
+    return {Parallel::AlgorithmExecution::Continue, std::nullopt};
+  }
+};
+}  // namespace CurvedScalarWave::Worldtube::Actions

--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/Inboxes.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/Inboxes.hpp
@@ -32,4 +32,21 @@ struct SphericalHarmonicsInbox
       std::map<temporal_id,
                std::unordered_map<ElementId<Dim>, Variables<tags_list>>>;
 };
+
+/*!
+ * \brief Inbox of the element chares that contains the regular field $\Psi^R$
+ * as well as its time and spatial derivative evaluated at the grid points of
+ * abutting element faces.
+ */
+template <size_t Dim>
+struct RegularFieldInbox
+    : Parallel::InboxInserters::Value<RegularFieldInbox<Dim>> {
+  using tags_to_send =
+      tmpl::list<CurvedScalarWave::Tags::Psi,
+                 ::Tags::dt<CurvedScalarWave::Tags::Psi>,
+                 ::Tags::deriv<CurvedScalarWave::Tags::Psi, tmpl::size_t<Dim>,
+                               Frame::Grid>>;
+  using temporal_id = TimeStepId;
+  using type = std::map<temporal_id, Variables<tags_to_send>>;
+};
 }  // namespace CurvedScalarWave::Worldtube::Tags

--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonActions/CMakeLists.txt
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonActions/CMakeLists.txt
@@ -7,4 +7,5 @@ spectre_target_headers(
   HEADERS
   InitializeElementFacesGridCoordinates.hpp
   ReceiveElementData.hpp
+  SendToElements.hpp
 )

--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonActions/SendToElements.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonActions/SendToElements.hpp
@@ -1,0 +1,74 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <optional>
+#include <tuple>
+#include <unordered_map>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Domain/Tags.hpp"
+#include "Evolution/Systems/CurvedScalarWave/Worldtube/Inboxes.hpp"
+#include "Evolution/Systems/CurvedScalarWave/Worldtube/Tags.hpp"
+#include "Parallel/AlgorithmExecution.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "ParallelAlgorithms/Initialization/MutateAssign.hpp"
+#include "Time/Tags.hpp"
+#include "Time/TimeStepId.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace CurvedScalarWave::Worldtube::Actions {
+/*!
+ * \brief Sends the regular field to each element abutting the worldtube,
+ * evaluated at the grid coordinates of each face
+ *
+ * \details h-refinement could be accounted for by sending the
+ * coefficients of the internal solution directly and have each element evaluate
+ * it for themselves.
+ */
+template <typename Metavariables>
+struct SendToElements {
+  static constexpr size_t Dim = Metavariables::volume_dim;
+  using psi_tag = CurvedScalarWave::Tags::Psi;
+  using dt_psi_tag = ::Tags::dt<CurvedScalarWave::Tags::Psi>;
+  using di_psi_tag = ::Tags::deriv<CurvedScalarWave::Tags::Psi,
+                                   tmpl::size_t<Dim>, Frame::Grid>;
+  using tags_to_send = tmpl::list<psi_tag, dt_psi_tag, di_psi_tag>;
+
+  template <typename DbTagsList, typename... InboxTags, typename ArrayIndex,
+            typename ActionList, typename ParallelComponent>
+  static Parallel::iterable_action_return_t apply(
+      db::DataBox<DbTagsList>& box,
+      tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+      Parallel::GlobalCache<Metavariables>& cache,
+      const ArrayIndex& /*array_index*/, const ActionList /*meta*/,
+      const ParallelComponent* const /*meta*/) {
+    auto& element_proxies = Parallel::get_parallel_component<
+        typename Metavariables::dg_element_array>(cache);
+    const auto& faces_grid_coords =
+        get<Tags::ElementFacesGridCoordinates<Dim>>(box);
+
+    for (const auto& [element_id, grid_coords] : faces_grid_coords) {
+      const size_t grid_size = get<0>(grid_coords).size();
+      Variables<tags_to_send> vars_to_send(grid_size);
+      get(get<psi_tag>(vars_to_send)) = get<Tags::Psi0>(box);
+      get(get<dt_psi_tag>(vars_to_send)) = get<::Tags::dt<Tags::Psi0>>(box);
+      for (size_t i = 0; i < Dim; ++i) {
+        // at 0th order the spatial derivative is just zero
+        get<di_psi_tag>(vars_to_send).get(i) = 0.;
+      }
+      Parallel::receive_data<Tags::RegularFieldInbox<Dim>>(
+          element_proxies[element_id], db::get<::Tags::TimeStepId>(box),
+          std::move(vars_to_send));
+    }
+    return {Parallel::AlgorithmExecution::Continue, std::nullopt};
+  }
+};
+}  // namespace CurvedScalarWave::Worldtube::Actions

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/CMakeLists.txt
@@ -20,6 +20,7 @@ set(LIBRARY_SOURCES
   Worldtube/Test_PunctureField.cpp
   Worldtube/Test_Tags.cpp
   Worldtube/ElementActions/Test_SendToWorldtube.cpp
+  Worldtube/ElementActions/Test_ReceiveWorldtubeData.cpp
   Worldtube/SingletonActions/Test_InitializeElementFacesGridCoordinates.cpp
   )
 

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/ElementActions/Test_ReceiveWorldtubeData.cpp
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/ElementActions/Test_ReceiveWorldtubeData.cpp
@@ -1,0 +1,248 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <limits>
+#include <random>
+#include <unordered_map>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/Block.hpp"
+#include "Domain/CreateInitialElement.hpp"
+#include "Domain/Creators/RegisterDerivedWithCharm.hpp"
+#include "Domain/Creators/Shell.hpp"
+#include "Domain/Creators/Tags/Domain.hpp"
+#include "Domain/Domain.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Domain/Structure/InitialElementIds.hpp"
+#include "Domain/Tags.hpp"
+#include "Evolution/Systems/CurvedScalarWave/System.hpp"
+#include "Evolution/Systems/CurvedScalarWave/Worldtube/ElementActions/ReceiveWorldtubeData.hpp"
+#include "Evolution/Systems/CurvedScalarWave/Worldtube/Inboxes.hpp"
+#include "Evolution/Systems/CurvedScalarWave/Worldtube/SingletonActions/InitializeElementFacesGridCoordinates.hpp"
+#include "Evolution/Systems/CurvedScalarWave/Worldtube/SingletonActions/SendToElements.hpp"
+#include "Evolution/Systems/CurvedScalarWave/Worldtube/SingletonChare.hpp"
+#include "Framework/ActionTesting.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "Parallel/ParallelComponentHelpers.hpp"
+#include "Parallel/Phase.hpp"
+#include "Parallel/PhaseDependentActionList.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Time/Tags.hpp"
+#include "Time/Time.hpp"
+#include "Time/TimeStepId.hpp"
+#include "Utilities/CartesianProduct.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace CurvedScalarWave::Worldtube {
+namespace {
+
+template <typename Metavariables>
+struct MockElementArray {
+  using metavariables = Metavariables;
+  static constexpr size_t Dim = metavariables::volume_dim;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = ElementId<Dim>;
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<
+          Parallel::Phase::Initialization,
+          tmpl::list<ActionTesting::InitializeDataBox<
+              db::AddSimpleTags<
+                  domain::Tags::Element<Dim>, domain::Tags::Mesh<Dim>,
+                  Tags::PunctureField<Dim>,
+                  gr::Tags::Shift<Dim, Frame::Inertial, DataVector>,
+                  gr::Tags::Lapse<DataVector>,
+                  domain::Tags::InverseJacobian<Dim, Frame::Grid,
+                                                Frame::Inertial>,
+                  ::Tags::TimeStepId, Tags::WorldtubeSolution<Dim>>,
+              db::AddComputeTags<>>>>,
+      Parallel::PhaseActions<Parallel::Phase::Testing,
+                             tmpl::list<Actions::ReceiveWorldtubeData>>>;
+};
+template <typename Metavariables>
+struct MockWorldtubeSingleton {
+  using metavariables = Metavariables;
+  static constexpr size_t Dim = metavariables::volume_dim;
+  using chare_type = ActionTesting::MockSingletonChare;
+  using array_index = int;
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<
+          Parallel::Phase::Initialization,
+          tmpl::list<ActionTesting::InitializeDataBox<
+              db::AddSimpleTags<Tags::ElementFacesGridCoordinates<Dim>,
+                                ::Tags::TimeStepId, Tags::Psi0,
+                                ::Tags::dt<Tags::Psi0>>,
+              db::AddComputeTags<>>>>,
+      Parallel::PhaseActions<
+          Parallel::Phase::Testing,
+          tmpl::list<Actions::SendToElements<Metavariables>>>>;
+  using component_being_mocked = WorldtubeSingleton<Metavariables>;
+};
+
+template <size_t Dim>
+struct MockMetavariables {
+  static constexpr size_t volume_dim = Dim;
+  using dg_element_array = MockElementArray<MockMetavariables>;
+  using component_list = tmpl::list<MockWorldtubeSingleton<MockMetavariables>,
+                                    MockElementArray<MockMetavariables>>;
+  using const_global_cache_tags =
+      tmpl::list<Tags::ExcisionSphere<Dim>, Tags::ExpansionOrder>;
+};
+
+SPECTRE_TEST_CASE("Unit.CurvedScalarWave.Worldtube.ReceiveWorldtubeData",
+                  "[Unit]") {
+  static constexpr size_t Dim = 3;
+  MAKE_GENERATOR(generator);
+  std::uniform_real_distribution<> dist(-10., 10.);
+  using metavars = MockMetavariables<Dim>;
+  domain::creators::register_derived_with_charm();
+  using element_chare = MockElementArray<metavars>;
+  using worldtube_chare = MockWorldtubeSingleton<metavars>;
+  const size_t initial_extent = 8;
+  const size_t face_size = initial_extent * initial_extent;
+  const auto quadrature = Spectral::Quadrature::GaussLobatto;
+  const size_t expansion_order = 0;
+  // we create several differently refined shells so a different number of
+  // elements sends data
+  for (const auto& [initial_refinement, worldtube_radius] : cartesian_product(
+           std::array<size_t, 3>{0, 1, 2}, make_array(0.07, 1., 2.8))) {
+    const domain::creators::Shell shell{worldtube_radius,
+                                        3.,
+                                        initial_refinement,
+                                        {initial_extent, initial_extent}};
+    const auto shell_domain = shell.create_domain();
+    const auto excision_sphere =
+        shell_domain.excision_spheres().at("ExcisionSphere");
+
+    const auto& initial_refinements = shell.initial_refinement_levels();
+    const auto& initial_extents = shell.initial_extents();
+    ActionTesting::MockRuntimeSystem<metavars> runner{
+        {excision_sphere, expansion_order}};
+    const auto element_ids = initial_element_ids(initial_refinements);
+    const auto& blocks = shell_domain.blocks();
+
+    using puncture_field_type =
+        Variables<tmpl::list<CurvedScalarWave::Tags::Psi,
+                             ::Tags::dt<CurvedScalarWave::Tags::Psi>,
+                             ::Tags::deriv<CurvedScalarWave::Tags::Psi,
+                                           tmpl::size_t<3>, Frame::Inertial>>>;
+
+    // The puncture field will get subtracted from the DG field. Here, we set
+    // the puncture field to 0, so psi and dt_psi are passed on directly
+    // and we can check the analytical result.
+    const puncture_field_type puncture_field{face_size, 0.};
+    const double psi_value = dist(generator);
+    const double dt_psi_value = dist(generator);
+    const Time dummy_time{{1., 2.}, {1, 2}};
+    const TimeStepId dummy_time_step_id{true, 123, dummy_time};
+
+    for (const auto& element_id : element_ids) {
+      auto mesh = domain::Initialization::create_initial_mesh(
+          initial_extents, element_id, quadrature);
+      const size_t grid_size = mesh.number_of_grid_points();
+      const auto& my_block = blocks.at(element_id.block_id());
+      auto element = domain::Initialization::create_initial_element(
+          element_id, my_block, initial_refinements);
+      // since the spatial derivative is zero at zeroth order this will not be
+      // used
+      auto grid_inv_jacobian =
+          InverseJacobian<DataVector, Dim, Frame::Grid, Frame::Inertial>(
+              grid_size, 1.);
+      // we set lapse and shift to Minkowski so dt Psi = - Pi
+      Scalar<DataVector> lapse(grid_size, 1.);
+      tnsr::I<DataVector, Dim, Frame::Inertial> shift(grid_size, 0.);
+      // not initialized, the action does that for us
+      typename CurvedScalarWave::System<Dim>::variables_tag::type
+          worldtube_solution{};
+      std::optional<puncture_field_type> optional_puncture_field =
+          excision_sphere.abutting_direction(element_id).has_value()
+              ? std::make_optional<puncture_field_type>(puncture_field)
+              : std::nullopt;
+      ActionTesting::emplace_array_component_and_initialize<element_chare>(
+          &runner, ActionTesting::NodeId{0}, ActionTesting::LocalCoreId{0},
+          element_id,
+          {std::move(element), std::move(mesh),
+           std::move(optional_puncture_field), std::move(shift),
+           std::move(lapse), std::move(grid_inv_jacobian), dummy_time_step_id,
+           worldtube_solution});
+    }
+
+    std::unordered_map<ElementId<Dim>, tnsr::I<DataVector, Dim, Frame::Grid>>
+        element_faces_grid_coords{};
+    Initialization::InitializeElementFacesGridCoordinates<Dim>::apply(
+        make_not_null(&element_faces_grid_coords), shell_domain,
+        initial_extents, initial_refinements, quadrature, excision_sphere);
+
+    ActionTesting::emplace_singleton_component_and_initialize<worldtube_chare>(
+        &runner, ActionTesting::NodeId{0}, ActionTesting::LocalCoreId{0},
+        {element_faces_grid_coords, dummy_time_step_id, psi_value,
+         dt_psi_value});
+
+    ActionTesting::set_phase(make_not_null(&runner), Parallel::Phase::Testing);
+
+    // If it is an abutting element, we don't have data yet and should not be
+    // ready. Else, there is nothing to do so it's ready.
+    for (const auto& element_id : element_ids) {
+      if (element_faces_grid_coords.count(element_id)) {
+        CHECK(not ActionTesting::next_action_if_ready<element_chare>(
+            make_not_null(&runner), element_id));
+      } else {
+        CHECK(ActionTesting::next_action_if_ready<element_chare>(
+            make_not_null(&runner), element_id));
+      }
+    }
+    // SendToElements
+    ActionTesting::next_action<worldtube_chare>(make_not_null(&runner), 0);
+
+    for (const auto& element_id : element_ids) {
+      using inbox_tag = Tags::RegularFieldInbox<Dim>;
+      const auto& element_inbox =
+          ActionTesting::get_inbox_tag<element_chare, inbox_tag>(runner,
+                                                                 element_id);
+      if (element_faces_grid_coords.count(element_id)) {
+        CHECK(element_inbox.count(dummy_time_step_id));
+        const auto& inbox_data = element_inbox.at(dummy_time_step_id);
+        CHECK_ITERABLE_APPROX(get(get<CurvedScalarWave::Tags::Psi>(inbox_data)),
+                              DataVector(face_size, psi_value));
+        CHECK_ITERABLE_APPROX(
+            get(get<::Tags::dt<CurvedScalarWave::Tags::Psi>>(inbox_data)),
+            DataVector(face_size, dt_psi_value));
+
+        // ReceiveWorldtubeData
+        CHECK(ActionTesting::next_action_if_ready<element_chare>(
+            make_not_null(&runner), element_id));
+        CHECK(element_inbox.empty());
+        const auto& worldtube_solution =
+            ActionTesting::get_databox_tag<element_chare,
+                                           Tags::WorldtubeSolution<Dim>>(
+                runner, element_id);
+        CHECK_ITERABLE_APPROX(
+            get(get<CurvedScalarWave::Tags::Psi>(worldtube_solution)),
+            DataVector(face_size, psi_value));
+        CHECK_ITERABLE_APPROX(
+            get(get<CurvedScalarWave::Tags::Pi>(worldtube_solution)),
+            DataVector(face_size, -dt_psi_value));
+        for (size_t i = 0; i < Dim; ++i) {
+          CHECK_ITERABLE_APPROX(
+              get<CurvedScalarWave::Tags::Phi<Dim>>(worldtube_solution).get(i),
+              DataVector(face_size, 0.));
+        }
+      } else {
+        CHECK(element_inbox.empty());
+      }
+    }
+  }
+}
+}  // namespace
+}  // namespace CurvedScalarWave::Worldtube


### PR DESCRIPTION
## Proposed changes
Adds the final piece of the 0th order worldtube scheme:

-  an action `SendToElements` in which the worldtube sends the regular field it calculated to the abutting elements 
-  an action `ReceiveWorldtubeData` in which the elements process the sent data into boundary conditions

~depends on #4798~