### PR TITLE
Allow con2prim after tci fail with DG clamp

### DIFF
--- a/src/Evolution/Systems/Burgers/Subcell/TciOnDgGrid.cpp
+++ b/src/Evolution/Systems/Burgers/Subcell/TciOnDgGrid.cpp
@@ -17,7 +17,7 @@ std::tuple<bool, evolution::dg::subcell::RdmpTciData> TciOnDgGrid::apply(
     const Mesh<1>& subcell_mesh,
     const evolution::dg::subcell::RdmpTciData& past_rdmp_tci_data,
     const evolution::dg::subcell::SubcellOptions& subcell_options,
-    double persson_exponent) {
+    double persson_exponent, [[maybe_unused]] const bool element_stays_on_dg) {
   // Don't use buffer since we have only one memory allocation right now (until
   // persson_tci can use a buffer)
   const Scalar<DataVector> subcell_u{::evolution::dg::subcell::fd::project(
@@ -30,12 +30,12 @@ std::tuple<bool, evolution::dg::subcell::RdmpTciData> TciOnDgGrid::apply(
       {min(min(get(dg_u)), min(get(subcell_u)))}};
 
   const bool cell_is_troubled =
-      evolution::dg::subcell::rdmp_tci(rdmp_tci_data.max_variables_values,
-                                       rdmp_tci_data.min_variables_values,
-                                       past_rdmp_tci_data.max_variables_values,
-                                       past_rdmp_tci_data.min_variables_values,
-                                       subcell_options.rdmp_delta0(),
-                                       subcell_options.rdmp_epsilon()) or
+      static_cast<bool>(evolution::dg::subcell::rdmp_tci(
+          rdmp_tci_data.max_variables_values,
+          rdmp_tci_data.min_variables_values,
+          past_rdmp_tci_data.max_variables_values,
+          past_rdmp_tci_data.min_variables_values,
+          subcell_options.rdmp_delta0(), subcell_options.rdmp_epsilon())) or
       ::evolution::dg::subcell::persson_tci(dg_u, dg_mesh, persson_exponent);
 
   return {cell_is_troubled, std::move(rdmp_tci_data)};

--- a/src/Evolution/Systems/Burgers/Subcell/TciOnDgGrid.hpp
+++ b/src/Evolution/Systems/Burgers/Subcell/TciOnDgGrid.hpp
@@ -42,6 +42,6 @@ struct TciOnDgGrid {
       const Mesh<1>& subcell_mesh,
       const evolution::dg::subcell::RdmpTciData& past_rdmp_tci_data,
       const evolution::dg::subcell::SubcellOptions& subcell_options,
-      double persson_exponent);
+      double persson_exponent, bool element_stays_on_dg);
 };
 }  // namespace Burgers::subcell

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TciOnDgGrid.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TciOnDgGrid.hpp
@@ -164,6 +164,6 @@ class TciOnDgGrid {
       const evolution::dg::subcell::RdmpTciData& past_rdmp_tci_data,
       const TciOptions& tci_options,
       const evolution::dg::subcell::SubcellOptions& subcell_options,
-      double persson_exponent);
+      double persson_exponent, bool element_stays_on_dg);
 };
 }  // namespace grmhd::ValenciaDivClean::subcell

--- a/src/Evolution/Systems/NewtonianEuler/Subcell/TciOnDgGrid.cpp
+++ b/src/Evolution/Systems/NewtonianEuler/Subcell/TciOnDgGrid.cpp
@@ -32,7 +32,8 @@ std::tuple<bool, evolution::dg::subcell::RdmpTciData> TciOnDgGrid<Dim>::apply(
     const Mesh<Dim>& dg_mesh, const Mesh<Dim>& subcell_mesh,
     const evolution::dg::subcell::RdmpTciData& past_rdmp_tci_data,
     const evolution::dg::subcell::SubcellOptions& subcell_options,
-    const double persson_exponent) {
+    const double persson_exponent,
+    [[maybe_unused]] const bool element_stays_on_dg) {
   const Variables<tmpl::list<MassDensityCons, MomentumDensity, EnergyDensity>>
       subcell_vars = evolution::dg::subcell::fd::project(
           dg_vars, dg_mesh, subcell_mesh.extents());
@@ -97,7 +98,7 @@ GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
       const Mesh<DIM(data)>& dg_mesh, const Mesh<DIM(data)>& subcell_mesh,    \
       const evolution::dg::subcell::RdmpTciData& past_rdmp_tci_data,          \
       const evolution::dg::subcell::SubcellOptions& subcell_options,          \
-      double persson_exponent);
+      double persson_exponent, const bool element_stays_on_dg);
 GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3), (1, 2))
 #undef INSTANTIATION
 #undef THERMO_DIM

--- a/src/Evolution/Systems/NewtonianEuler/Subcell/TciOnDgGrid.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/Subcell/TciOnDgGrid.hpp
@@ -86,6 +86,6 @@ class TciOnDgGrid {
       const Mesh<Dim>& dg_mesh, const Mesh<Dim>& subcell_mesh,
       const evolution::dg::subcell::RdmpTciData& past_rdmp_tci_data,
       const evolution::dg::subcell::SubcellOptions& subcell_options,
-      double persson_exponent);
+      double persson_exponent, bool element_stays_on_dg);
 };
 }  // namespace NewtonianEuler::subcell

--- a/src/Evolution/Systems/ScalarAdvection/Subcell/TciOnDgGrid.cpp
+++ b/src/Evolution/Systems/ScalarAdvection/Subcell/TciOnDgGrid.cpp
@@ -20,7 +20,8 @@ std::tuple<bool, evolution::dg::subcell::RdmpTciData> TciOnDgGrid<Dim>::apply(
     const Mesh<Dim>& subcell_mesh,
     const evolution::dg::subcell::RdmpTciData& past_rdmp_tci_data,
     const evolution::dg::subcell::SubcellOptions& subcell_options,
-    const TciOptions& tci_options, const double persson_exponent) {
+    const TciOptions& tci_options, const double persson_exponent,
+    [[maybe_unused]] const bool element_stays_on_dg) {
   // Don't use buffer since we have only one memory allocation right now (until
   // persson_tci can use a buffer)
   const Scalar<DataVector> subcell_u{::evolution::dg::subcell::fd::project(

--- a/src/Evolution/Systems/ScalarAdvection/Subcell/TciOnDgGrid.hpp
+++ b/src/Evolution/Systems/ScalarAdvection/Subcell/TciOnDgGrid.hpp
@@ -46,6 +46,7 @@ struct TciOnDgGrid {
       const Mesh<Dim>& subcell_mesh,
       const evolution::dg::subcell::RdmpTciData& past_rdmp_tci_data,
       const evolution::dg::subcell::SubcellOptions& subcell_options,
-      const TciOptions& tci_options, double persson_exponent);
+      const TciOptions& tci_options, double persson_exponent,
+      bool element_stays_on_dg);
 };
 }  // namespace ScalarAdvection::subcell

--- a/tests/Unit/Evolution/Systems/Burgers/Subcell/Test_TciOnDgGrid.cpp
+++ b/tests/Unit/Evolution/Systems/Burgers/Subcell/Test_TciOnDgGrid.cpp
@@ -62,10 +62,11 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Burgers.Subcell.TciOnDgGrid",
         std::nullopt,
         std::nullopt};
 
+    const bool element_stays_on_dg = false;
     const std::tuple<bool, evolution::dg::subcell::RdmpTciData> result =
-        Burgers::subcell::TciOnDgGrid::apply(u, dg_mesh, subcell_mesh,
-                                             past_rdmp_tci_data,
-                                             subcell_options, persson_exponent);
+        Burgers::subcell::TciOnDgGrid::apply(
+            u, dg_mesh, subcell_mesh, past_rdmp_tci_data, subcell_options,
+            persson_exponent, element_stays_on_dg);
 
     CHECK(std::get<1>(result) == expected_rdmp_data);
 

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/Subcell/Test_TciOnDgGrid.cpp
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/Subcell/Test_TciOnDgGrid.cpp
@@ -142,9 +142,10 @@ void test(const TestThis test_this) {
         }
       });
 
+  const bool element_stays_on_dg = false;
   const std::tuple<bool, evolution::dg::subcell::RdmpTciData> result =
       db::mutate_apply<NewtonianEuler::subcell::TciOnDgGrid<Dim>>(
-          make_not_null(&box), persson_exponent);
+          make_not_null(&box), persson_exponent, element_stays_on_dg);
 
   CHECK_ITERABLE_APPROX(get<1>(result).max_variables_values,
                         expected_rdmp_tci_data.max_variables_values);

--- a/tests/Unit/Evolution/Systems/ScalarAdvection/Subcell/Test_TciOnDgGrid.cpp
+++ b/tests/Unit/Evolution/Systems/ScalarAdvection/Subcell/Test_TciOnDgGrid.cpp
@@ -71,10 +71,11 @@ void test(const TestThis& test_this) {
       std::nullopt,
       std::nullopt};
 
+  const bool element_stays_on_dg = false;
   const std::tuple<bool, evolution::dg::subcell::RdmpTciData> result =
       ScalarAdvection::subcell::TciOnDgGrid<Dim>::apply(
           u, dg_mesh, subcell_mesh, past_rdmp_tci_data, subcell_options,
-          tci_options, persson_exponent);
+          tci_options, persson_exponent, element_stays_on_dg);
 
   CHECK(std::get<1>(result) == expected_rdmp_data);
 


### PR DESCRIPTION
## Proposed changes

If a cell is DG clamped, allow con2prim transformation to occur with hydro variables, even if cell is troubled. Also the check for # neighbors > 1 (found in PrepareNeighborData) now only occurs if an element uses subcell.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

Currently a draft PR to check code coverage & CI.

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
