### PR TITLE
Add `GridtoInertialInverseJacobian` compute tag

### DIFF
--- a/src/Domain/TagsTimeDependent.hpp
+++ b/src/Domain/TagsTimeDependent.hpp
@@ -103,6 +103,30 @@ struct InertialFromGridCoordinatesCompute
                                    CoordinatesMeshVelocityAndJacobians<Dim>>;
 };
 
+/// Computes the Grid to Inertial inverse Jacobian from
+/// `CoordinatesVelocityAndJacobians`. If the mesh is not moving, requesting
+/// this tag will throw an error because the Jacobian is just the identity.
+template <size_t Dim>
+struct GridToInertialInverseJacobian
+    : Tags::InverseJacobian<Dim, Frame::Grid, Frame::Inertial>,
+      db::ComputeTag {
+  using base = Tags::InverseJacobian<Dim, Frame::Grid, Frame::Inertial>;
+  using return_type = typename base::type;
+
+  static void function(
+      gsl::not_null<
+          ::InverseJacobian<DataVector, Dim, Frame::Grid, Frame::Inertial>*>
+          inv_jac_grid_to_inertial,
+      const std::optional<std::tuple<
+          tnsr::I<DataVector, Dim, Frame::Inertial>,
+          ::InverseJacobian<DataVector, Dim, Frame::Grid, Frame::Inertial>,
+          ::Jacobian<DataVector, Dim, Frame::Grid, Frame::Inertial>,
+          tnsr::I<DataVector, Dim, Frame::Inertial>>>&
+          grid_to_inertial_quantities);
+
+  using argument_tags = tmpl::list<CoordinatesMeshVelocityAndJacobians<Dim>>;
+};
+
 /// Computes the Logical to Inertial inverse Jacobian from
 /// `CoordinatesVelocityAndJacobians`
 template <size_t Dim>


### PR DESCRIPTION
## Proposed changes

Adds a compute tag that computes the grid to inertial inverse jacobian. If the mesh is moving it is be a data reference into `CoordinatesMeshVelocityAndJacobians`. Otherwise it throws an error if it is requested.