### PR TITLE
Add AO derivs support

### DIFF
--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TimeDerivative.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TimeDerivative.hpp
@@ -39,6 +39,7 @@
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/Sources.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/ComputeFluxes.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/System.hpp"
+#include "NumericalAlgorithms/FiniteDifference/DerivativeOrder.hpp"
 #include "NumericalAlgorithms/FiniteDifference/HighOrderFluxCorrection.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "Parallel/Tags/Metavariables.hpp"
@@ -324,7 +325,8 @@ struct TimeDerivative {
 
         db::get<evolution::dg::subcell::Tags::CellCenteredFlux<
             evolved_vars_tags, 3>>(*box),
-        boundary_corrections, fd_derivative_order,
+        boundary_corrections,
+        static_cast<::fd::DerivativeOrder>(fd_derivative_order.value_or(2)),
         db::get<evolution::dg::subcell::Tags::NeighborDataForReconstruction<3>>(
             *box),
         subcell_mesh, recons.ghost_zone_size());

--- a/src/NumericalAlgorithms/FiniteDifference/HighOrderFluxCorrection.hpp
+++ b/src/NumericalAlgorithms/FiniteDifference/HighOrderFluxCorrection.hpp
@@ -261,7 +261,6 @@ void cartesian_high_order_fluxes_using_nodes(
                   collapsed_index(upper_n, reconstruction_extents);
             }
 
-            // Only do 4th-order correction for now...
             if (static_cast<int>(DerivOrder) >= 10 or
                 (static_cast<int>(DerivOrder) < 0 and
                  min(recons_order[lower_neighbor_index],

--- a/src/NumericalAlgorithms/FiniteDifference/HighOrderFluxCorrection.hpp
+++ b/src/NumericalAlgorithms/FiniteDifference/HighOrderFluxCorrection.hpp
@@ -321,37 +321,37 @@ void cartesian_high_order_fluxes_using_nodes(
                  EvolvedVarsTags, tmpl::size_t<Dim>, Frame::Inertial>...>>>&
         ghost_cell_inertial_flux,
     const Mesh<Dim>& subcell_mesh, const size_t number_of_ghost_cells,
-    const size_t correction_order) {
-  switch (correction_order) {
-    case 2:
+    const DerivativeOrder derivative_order) {
+  switch (derivative_order) {
+    case DerivativeOrder::Two:
       cartesian_high_order_fluxes_using_nodes<DerivativeOrder::Two>(
           high_order_boundary_corrections_in_logical_direction,
           second_order_boundary_corrections_in_logical_direction,
           cell_centered_inertial_flux, ghost_cell_inertial_flux, subcell_mesh,
           number_of_ghost_cells);
       break;
-    case 4:
+    case DerivativeOrder::Four:
       cartesian_high_order_fluxes_using_nodes<DerivativeOrder::Four>(
           high_order_boundary_corrections_in_logical_direction,
           second_order_boundary_corrections_in_logical_direction,
           cell_centered_inertial_flux, ghost_cell_inertial_flux, subcell_mesh,
           number_of_ghost_cells);
       break;
-    case 6:
+    case DerivativeOrder::Six:
       cartesian_high_order_fluxes_using_nodes<DerivativeOrder::Six>(
           high_order_boundary_corrections_in_logical_direction,
           second_order_boundary_corrections_in_logical_direction,
           cell_centered_inertial_flux, ghost_cell_inertial_flux, subcell_mesh,
           number_of_ghost_cells);
       break;
-    case 8:
+    case DerivativeOrder::Eight:
       cartesian_high_order_fluxes_using_nodes<DerivativeOrder::Eight>(
           high_order_boundary_corrections_in_logical_direction,
           second_order_boundary_corrections_in_logical_direction,
           cell_centered_inertial_flux, ghost_cell_inertial_flux, subcell_mesh,
           number_of_ghost_cells);
       break;
-    case 10:
+    case DerivativeOrder::Ten:
       cartesian_high_order_fluxes_using_nodes<DerivativeOrder::Ten>(
           high_order_boundary_corrections_in_logical_direction,
           second_order_boundary_corrections_in_logical_direction,
@@ -359,8 +359,7 @@ void cartesian_high_order_fluxes_using_nodes(
           number_of_ghost_cells);
       break;
     default:
-      ERROR("Unsupported correction order " << correction_order
-                                            << ". Only know 2,4,6,8,10");
+      ERROR("Unsupported correction order " << derivative_order);
   };
 }
 /// @}
@@ -431,7 +430,7 @@ void cartesian_high_order_flux_corrections(
     const std::optional<Variables<FluxesTags>>& cell_centered_fluxes,
     const std::array<Variables<tmpl::list<EvolvedVarsTags...>>, Dim>&
         second_order_boundary_corrections,
-    const std::optional<size_t>& fd_derivative_order,
+    const fd::DerivativeOrder& fd_derivative_order,
     const FixedHashMap<maximum_number_of_neighbors(Dim),
                        std::pair<Direction<Dim>, ElementId<Dim>>, DataVector,
                        boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>&
@@ -439,9 +438,6 @@ void cartesian_high_order_flux_corrections(
     const Mesh<Dim>& subcell_mesh, const size_t ghost_zone_size,
     const size_t number_of_rdmp_values_in_ghost_data = 0) {
   if (cell_centered_fluxes.has_value()) {
-    ASSERT(fd_derivative_order.has_value(),
-           "No finite difference order is set but we are trying to do "
-           "high-order FD.");
     ASSERT(alg::all_of(
                second_order_boundary_corrections,
                [expected_size = second_order_boundary_corrections[0]
@@ -450,7 +446,7 @@ void cartesian_high_order_flux_corrections(
                }),
            "All second-order boundary corrections must be of the same size, "
                << second_order_boundary_corrections[0].number_of_grid_points());
-    if (fd_derivative_order.value_or(2) > 2) {
+    if (fd_derivative_order != DerivativeOrder::Two) {
       if (not high_order_corrections->has_value()) {
         (*high_order_corrections) =
             make_array<Dim>(Variables<tmpl::list<EvolvedVarsTags...>>{
@@ -475,7 +471,7 @@ void cartesian_high_order_flux_corrections(
           make_not_null(&(high_order_corrections->value())),
           second_order_boundary_corrections, cell_centered_fluxes.value(),
           flux_neighbor_data, subcell_mesh, ghost_zone_size,
-          fd_derivative_order.value());
+          fd_derivative_order);
     }
   }
 }

--- a/tests/Unit/NumericalAlgorithms/FiniteDifference/Test_HighOrderFluxCorrection.cpp
+++ b/tests/Unit/NumericalAlgorithms/FiniteDifference/Test_HighOrderFluxCorrection.cpp
@@ -14,6 +14,7 @@
 #include "Evolution/DgSubcell/CartesianFluxDivergence.hpp"
 #include "Evolution/DgSubcell/SliceData.hpp"
 #include "Framework/TestHelpers.hpp"
+#include "NumericalAlgorithms/FiniteDifference/DerivativeOrder.hpp"
 #include "NumericalAlgorithms/FiniteDifference/HighOrderFluxCorrection.hpp"
 #include "NumericalAlgorithms/Spectral/LogicalCoordinates.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
@@ -30,13 +31,13 @@ struct Vector0 : db::SimpleTag {
 };
 
 template <size_t Dim>
-void test(const size_t correction_order) {
-  const size_t points_per_dimension = correction_order + 2;
+void test(const fd::DerivativeOrder correction_order) {
+  const size_t points_per_dimension = static_cast<size_t>(correction_order) + 2;
   CAPTURE(points_per_dimension);
   CAPTURE(correction_order);
   CAPTURE(Dim);
-  const size_t max_degree = correction_order;
-  const size_t stencil_width = correction_order + 1;
+  const size_t max_degree = static_cast<size_t>(correction_order);
+  const size_t stencil_width = static_cast<size_t>(correction_order) + 1;
   const size_t number_of_ghost_points = (stencil_width - 1) / 2 + 1;
 
   using FluxTags = tmpl::list<Scalar0, Vector0<Dim>>;
@@ -207,9 +208,8 @@ void test(const size_t correction_order) {
   ::fd::cartesian_high_order_flux_corrections(
       make_not_null(&high_order_corrections),
 
-      volume_vars, second_order_corrections,
-      std::optional<size_t>{correction_order}, reconstruction_neighbor_data,
-      mesh, number_of_ghost_points);
+      volume_vars, second_order_corrections, correction_order,
+      reconstruction_neighbor_data, mesh, number_of_ghost_points);
 
   // Now compute the Cartesian derivative of the high_order_corrections to
   // verify that it is computed sufficiently accurately.
@@ -245,7 +245,7 @@ void test(const size_t correction_order) {
 
   // Test assertions
 #ifdef SPECTRE_DEBUG
-  if (correction_order > 2) {
+  if (correction_order != fd::DerivativeOrder::Two) {
     std::optional<std::array<CorrectionVars, Dim>>
         high_order_corrections_assert = make_array<Dim>(CorrectionVars{
             second_order_corrections[0].number_of_grid_points()});
@@ -254,18 +254,11 @@ void test(const size_t correction_order) {
     CHECK_THROWS_WITH(
         ::fd::cartesian_high_order_flux_corrections(
             make_not_null(&high_order_corrections_assert), volume_vars,
-            second_order_corrections, std::optional<size_t>{correction_order},
+            second_order_corrections, correction_order,
             reconstruction_neighbor_data, mesh, number_of_ghost_points),
         Catch::Matchers::Contains(
             "The high_order_corrections must all have size"));
   }
-  CHECK_THROWS_WITH(
-      ::fd::cartesian_high_order_flux_corrections(
-          make_not_null(&high_order_corrections), volume_vars,
-          second_order_corrections, std::optional<size_t>{},
-          reconstruction_neighbor_data, mesh, number_of_ghost_points),
-      Catch::Matchers::Contains(
-          "No finite difference order is set but we are trying to do"));
   if constexpr (Dim > 1) {
     auto second_order_corrections_copy = second_order_corrections;
     second_order_corrections_copy[0].initialize(
@@ -273,8 +266,7 @@ void test(const size_t correction_order) {
     CHECK_THROWS_WITH(
         ::fd::cartesian_high_order_flux_corrections(
             make_not_null(&high_order_corrections), volume_vars,
-            second_order_corrections_copy,
-            std::optional<size_t>{correction_order},
+            second_order_corrections_copy, correction_order,
             reconstruction_neighbor_data, mesh, number_of_ghost_points),
         Catch::Matchers::Contains(
             "All second-order boundary corrections must be of the same size"));
@@ -284,7 +276,9 @@ void test(const size_t correction_order) {
 
 SPECTRE_TEST_CASE("Unit.FiniteDifference.CartesianHighOrderFluxCorrection",
                   "[Unit][NumericalAlgorithms]") {
-  for (const size_t correction_order : {2_st, 4_st, 6_st, 8_st, 10_st}) {
+  using DO = fd::DerivativeOrder;
+  for (const fd::DerivativeOrder correction_order :
+       {DO::Two, DO::Four, DO::Six, DO::Eight, DO::Ten}) {
     test<1>(correction_order);
     test<2>(correction_order);
     test<3>(correction_order);


### PR DESCRIPTION
## Proposed changes

- Switch to use `fd::DerivativeOrder` enum in several places
- Add support for AO derivs/corrections.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
