### PR TITLE
Improve dox for Shape/Size maps.

### DIFF
--- a/src/Domain/CoordinateMaps/TimeDependent/Shape.hpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/Shape.hpp
@@ -44,6 +44,25 @@ namespace domain::CoordinateMaps::TimeDependent {
  * zero at the boundary of the domain. The shape map maps the unmapped
  * coordinates \f$\xi^i\f$ to coordinates \f$x^i\f$:
  *
+ * \note The quantities stored in the FunctionOfTime are not the
+ * complex spherical-harmonic coefficients \f$\lambda_{lm}(t)\f$, but
+ * instead are the real-valued SPHEREPACK coefficients
+ * \f$a_{lm}(t)\f$ and \f$b_{lm}(t)\f$ used by YlmSpherepack.  The
+ * relationship between these two sets of coefficients is
+ * \f{align}
+ * a_{l0} & = \sqrt{\frac{2}{\pi}}\lambda_{l0}&\qquad l\geq 0,\\
+ * a_{lm} & = (-1)^m\sqrt{\frac{2}{\pi}} \mathrm{Re}(\lambda_{lm})
+ * &\qquad l\geq 1, m\geq 1, \\
+ * b_{lm} & = (-1)^m\sqrt{\frac{2}{\pi}} \mathrm{Im}(\lambda_{lm})
+ * &\qquad l\geq 1, m\geq 1.
+ * \f}
+ * The FunctionOfTime stores coefficients only for non-negative \f$m\f$;
+ * this is because the function we are expanding is real, so the
+ * coefficients for \f$m<0\f$ can be obtained from \f$m>0\f$ coefficients by
+ * complex conjugation.  Here and below we write the equations in
+ * terms of \f$\lambda_{lm}(t)\f$ instead of \f$a_{lm}(t)\f$ and
+ * \f$b_{lm}(t)\f$ because the resulting expressions are much shorter.
+ *
  * \f{equation}{
  * x^i = \xi^i - (\xi^i - x_c^i) f(r, \theta, \phi) \sum_{lm}
  * \lambda_{lm}(t)Y_{lm}(\theta, \phi).

--- a/src/Domain/CoordinateMaps/TimeDependent/SphericalCompression.hpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/SphericalCompression.hpp
@@ -52,9 +52,17 @@ namespace domain::CoordinateMaps::TimeDependent {
  * not the identity, using the appropriate template parameter, depending on
  * which region the block is in.
  *
- * \note Currently, this map only performs a compression. A generalization of
- * this map could also change the region's shape as well as its size, by
- * including more terms than the spherically symmetric term included here.
+ * \note This map performs a only a spherical compression. A
+ * generalization of this map that changes the region's shape as well as
+ * its size, by including more terms than the spherically symmetric
+ * term included here, can be found in the
+ * domain::CoordinateMaps::TimeDependent::Shape map.
+ *
+ * \note The quantity stored in the FunctionOfTime is really
+ * the spherical-harmonic coefficient \f$\lambda_{00}(t)\f$.  This is
+ * different from the Shape map, which stores YlmSpherepack coefficients
+ * \f$a_{lm}(t)\f$ and \f$b_{lm}(t)\f$ instead of \f$\lambda_{lm}(t)\f$.
+ * See domain::CoordinateMaps::TimeDependent::Shape for more details.
  *
  * ### Mapped coordinates
  *

--- a/src/Domain/Creators/TimeDependence/Shape.hpp
+++ b/src/Domain/Creators/TimeDependence/Shape.hpp
@@ -63,6 +63,20 @@ namespace domain::creators::time_dependence {
  * shape map will go to the Distorted frame only and other maps will go from the
  * Distorted frame to the Inertial frame.
  *
+ * \note The quantities stored in the FunctionOfTime are not the
+ * complex spherical-harmonic coefficients \f$\lambda_{lm}(t)\f$, but
+ * instead are the real-valued SPHEREPACK coefficients
+ * \f$a_{lm}(t)\f$ and \f$b_{lm}(t)\f$ used by YlmSpherepack.  The
+ * relationship between these two sets of coefficients is
+ * \f{align}
+ * a_{l0} & = \sqrt{\frac{2}{\pi}}\lambda_{l0}&\qquad l\geq 0,\\
+ * a_{lm} & = (-1)^m\sqrt{\frac{2}{\pi}} \mathrm{Re}(\lambda_{lm})
+ * &\qquad l\geq 1, m\geq 1, \\
+ * b_{lm} & = (-1)^m\sqrt{\frac{2}{\pi}} \mathrm{Im}(\lambda_{lm})
+ * &\qquad l\geq 1, m\geq 1.
+ * \f}
+ * See domain::CoordinateMaps::TimeDependent::Shape for more details.
+ *
  * \note To use this time dependence with the `control_system::system::Shape`
  * control system, you must choose the same \tparam Label that the control
  * system is using.

--- a/src/Domain/Creators/TimeDependence/SphericalCompression.hpp
+++ b/src/Domain/Creators/TimeDependence/SphericalCompression.hpp
@@ -49,6 +49,12 @@ namespace domain::creators::time_dependence {
  * \details This TimeDependence is suitable for use on a spherical shell,
  * where MinRadius and MaxRadius are the inner and outer radii of the shell,
  * respectively.
+ *
+ * \note The quantity stored in the FunctionOfTime is really
+ * the spherical-harmonic coefficient \f$\lambda_{00}(t)\f$.  This is
+ * different from the Shape map, which stores YlmSpherepack coefficients
+ * \f$a_{lm}(t)\f$ and \f$b_{lm}(t)\f$ instead of \f$\lambda_{lm}(t)\f$.
+ * See domain::CoordinateMaps::TimeDependent::Shape for more details.
  */
 class SphericalCompression final : public TimeDependence<3> {
  private:


### PR DESCRIPTION
## Proposed changes

Documentation now clearly states what is stored in the FunctionOfTime for each map.

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
