### PR TITLE
Fix History equality operator

### DIFF
--- a/src/Time/History.hpp
+++ b/src/Time/History.hpp
@@ -917,4 +917,19 @@ void History<Vars>::insert_initial_impl(TimeStepId time_step_id,
         std::move(time_step_id), std::nullopt, std::move(derivative)});
   }
 }
+
+template <typename Vars>
+bool operator==(const History<Vars>& a, const History<Vars>& b) {
+  using BaseSequence =
+      stl_boilerplate::RandomAccessSequence<History<Vars>, StepRecord<Vars>>;
+  return a.integration_order() == b.integration_order() and
+         static_cast<const BaseSequence&>(a) ==
+             static_cast<const BaseSequence&>(b) and
+         a.substeps() == b.substeps();
+}
+
+template <typename Vars>
+bool operator!=(const History<Vars>& a, const History<Vars>& b) {
+  return not(a == b);
+}
 }  // namespace TimeSteppers

--- a/tests/Unit/Time/Test_History.cpp
+++ b/tests/Unit/Time/Test_History.cpp
@@ -478,6 +478,32 @@ void test_history() {
   CHECK(history.integration_order() == copy.integration_order());
   CHECK(history.empty());
   CHECK(history.substeps().empty());
+
+  {
+    History a{2};
+    History b{3};
+    History c = b;
+    c.insert(TimeStepId(true, 0, slab.start()), make_value(1.0),
+             make_deriv(10.0));
+    History d = c;
+    d.insert(TimeStepId(true, 0, slab.start(), 1, slab.start().value()),
+             make_value(2.0), make_deriv(20.0));
+
+    CHECK(a == a);
+    CHECK_FALSE(a != a);
+    CHECK(b == b);
+    CHECK_FALSE(b != b);
+    CHECK(c == c);
+    CHECK_FALSE(c != c);
+    CHECK(d == d);
+    CHECK_FALSE(d != d);
+    CHECK(a != b);
+    CHECK_FALSE(a == b);
+    CHECK(b != c);
+    CHECK_FALSE(b == c);
+    CHECK(c != d);
+    CHECK_FALSE(c == d);
+  }
 }
 
 void test_history_assertions() {


### PR DESCRIPTION
It was previously using the generic one inherited from the stl_boilerplate code, which only considered the sequence aspect of the object and missed the integration order and substeps.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
