### PR TITLE
Add `ChangeSlabSize` action to worldtube singleton

### DIFF
--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/Inboxes.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/Inboxes.hpp
@@ -4,15 +4,25 @@
 #pragma once
 
 #include <cstddef>
+#include <map>
 #include <unordered_map>
 
+#include "DataStructures/DataBox/Prefixes.hpp"
 #include "DataStructures/Variables.hpp"
 #include "Domain/Structure/ElementId.hpp"
+#include "Evolution/Systems/CurvedScalarWave/Tags.hpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
 #include "Parallel/InboxInserters.hpp"
 #include "Time/TimeStepId.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+namespace Frame {
+struct Grid;
+}  // namespace Frame
+/// \endcond
 
 namespace CurvedScalarWave::Worldtube::Tags {
-
 /*!
  * \brief Inbox of the worldtube singleton chare which receives quantities
  * projected onto spherical harmonics.

--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonActions/CMakeLists.txt
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonActions/CMakeLists.txt
@@ -5,6 +5,7 @@ spectre_target_headers(
   ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
+  ChangeSlabSize.hpp
   InitializeElementFacesGridCoordinates.hpp
   InitializeEvolvedVariables.hpp
   ReceiveElementData.hpp

--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonActions/ChangeSlabSize.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonActions/ChangeSlabSize.hpp
@@ -1,0 +1,88 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <memory>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "Evolution/Systems/CurvedScalarWave/Worldtube/Inboxes.hpp"
+#include "Evolution/Systems/CurvedScalarWave/Worldtube/Tags.hpp"
+#include "Parallel/AlgorithmExecution.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "ParallelAlgorithms/EventsAndTriggers/Tags.hpp"
+#include "Time/Actions/ChangeSlabSize.hpp"
+#include "Time/Tags.hpp"
+#include "Time/TimeStepId.hpp"
+#include "Time/TimeSteppers/TimeStepper.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace CurvedScalarWave::Worldtube::Actions {
+
+/*!
+ * \brief Waits for the data from all neighboring elements and changes the slab
+ * size if a change in the global time step is detected.
+ * \details We check the slab size of the time step id sent by the elements. If
+ * this is different from the slab size currently used by the worldtube
+ * singleton, we assume a global slab size change has occurred in the elements
+ * and adjust the worldtube slab size accordingly.
+ */
+struct ChangeSlabSize {
+  static constexpr size_t Dim = 3;
+  using inbox_tags = tmpl::list<
+      ::CurvedScalarWave::Worldtube::Tags::SphericalHarmonicsInbox<Dim>>;
+
+  template <typename DbTagsList, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent>
+  static Parallel::iterable_action_return_t apply(
+      db::DataBox<DbTagsList>& box, tuples::TaggedTuple<InboxTags...>& inboxes,
+      const Parallel::GlobalCache<Metavariables>& /*cache*/,
+      const ArrayIndex& /*array_index*/, ActionList /*meta*/,
+      const ParallelComponent* const /*meta*/) {
+    const auto& time_step_id = db::get<::Tags::TimeStepId>(box);
+    const auto& inbox =
+        tuples::get<Tags::SphericalHarmonicsInbox<Dim>>(inboxes);
+    if (inbox.empty()) {
+      return {Parallel::AlgorithmExecution::Retry, std::nullopt};
+    }
+    ASSERT(inbox.size() == 1,
+           "Received data from two different time step ids.");
+    const auto inbox_time_step_id = inbox.begin()->first;
+    const auto& inbox_slab = inbox_time_step_id.step_time().slab();
+    // we received data from a time step id with a different slab size,
+    // indicating a change in the global time step.
+    if (inbox_time_step_id.step_time().slab() !=
+        time_step_id.step_time().slab()) {
+      ASSERT(inbox_slab.start() == time_step_id.step_time().slab().start(),
+             "The new slab should start at the same time as the old one.");
+      // time_step_id comparison does NOT compare slabs.
+      ASSERT(
+          inbox_time_step_id == time_step_id,
+          "Detected change in global time step id but the new time step id is "
+          "different.");
+      const auto new_step = inbox_slab.duration();
+      const auto new_next_time_step_id =
+          db::get<::Tags::TimeStepper<>>(box).next_time_id(inbox_time_step_id,
+                                                           new_step);
+      db::mutate<::Tags::Next<::Tags::TimeStepId>, ::Tags::TimeStep,
+                 ::Tags::Next<::Tags::TimeStep>, ::Tags::TimeStepId>(
+          make_not_null(&box),
+          [&new_next_time_step_id, &new_step, &inbox_time_step_id](
+              const gsl::not_null<TimeStepId*> next_time_step_id,
+              const gsl::not_null<TimeDelta*> time_step,
+              const gsl::not_null<TimeDelta*> next_time_step,
+              const gsl::not_null<TimeStepId*> local_time_step_id) {
+            *next_time_step_id = new_next_time_step_id;
+            *time_step = new_step;
+            *next_time_step = new_step;
+            *local_time_step_id = inbox_time_step_id;
+          });
+    }
+    return {Parallel::AlgorithmExecution::Continue, std::nullopt};
+  }
+};
+}  // namespace CurvedScalarWave::Worldtube::Actions

--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonChare.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonChare.hpp
@@ -7,6 +7,7 @@
 #include "DataStructures/DataBox/Tag.hpp"
 #include "Evolution/Initialization/Evolution.hpp"
 #include "Evolution/Systems/CurvedScalarWave/Tags.hpp"
+#include "Evolution/Systems/CurvedScalarWave/Worldtube/SingletonActions/ChangeSlabSize.hpp"
 #include "Evolution/Systems/CurvedScalarWave/Worldtube/SingletonActions/InitializeElementFacesGridCoordinates.hpp"
 #include "Evolution/Systems/CurvedScalarWave/Worldtube/SingletonActions/InitializeEvolvedVariables.hpp"
 #include "Evolution/Systems/CurvedScalarWave/Worldtube/SingletonActions/ReceiveElementData.hpp"
@@ -60,7 +61,7 @@ struct WorldtubeSingleton {
     using variables_tag = ::Tags::Variables<tmpl::list<Tags::Psi0>>;
   };
   using step_actions =
-      tmpl::list<Actions::ReceiveElementData,
+      tmpl::list<Actions::ChangeSlabSize, Actions::ReceiveElementData,
                  Actions::SendToElements<Metavariables>,
                  ::Actions::RecordTimeStepperData<
                      typename worldtube_system::variables_tag>,

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/CMakeLists.txt
@@ -21,6 +21,7 @@ set(LIBRARY_SOURCES
   Worldtube/Test_Tags.cpp
   Worldtube/ElementActions/Test_SendToWorldtube.cpp
   Worldtube/ElementActions/Test_ReceiveWorldtubeData.cpp
+  Worldtube/SingletonActions/Test_ChangeSlabSize.cpp
   Worldtube/SingletonActions/Test_InitializeElementFacesGridCoordinates.cpp
   Worldtube/SingletonActions/Test_InitializeEvolvedVariables.cpp
   )

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonActions/Test_ChangeSlabSize.cpp
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonActions/Test_ChangeSlabSize.cpp
@@ -1,0 +1,209 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <memory>
+#include <random>
+#include <unordered_map>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Domain/Structure/InitialElementIds.hpp"
+#include "Evolution/Systems/CurvedScalarWave/Worldtube/Inboxes.hpp"
+#include "Evolution/Systems/CurvedScalarWave/Worldtube/SingletonActions/ChangeSlabSize.hpp"
+#include "Evolution/Systems/CurvedScalarWave/Worldtube/SingletonChare.hpp"
+#include "Framework/ActionTesting.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Parallel/ParallelComponentHelpers.hpp"
+#include "Parallel/Phase.hpp"
+#include "Parallel/PhaseDependentActionList.hpp"
+#include "Time/Tags.hpp"
+#include "Time/Time.hpp"
+#include "Time/TimeStepId.hpp"
+#include "Time/TimeSteppers/Rk3HesthavenSsp.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeVector.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace CurvedScalarWave::Worldtube {
+namespace {
+
+template <typename Metavariables>
+struct MockWorldtubeSingleton {
+  using metavariables = Metavariables;
+  static constexpr size_t Dim = metavariables::volume_dim;
+  using chare_type = ActionTesting::MockSingletonChare;
+  using array_index = int;
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<
+          Parallel::Phase::Initialization,
+          tmpl::list<ActionTesting::InitializeDataBox<
+              db::AddSimpleTags<
+                  ::Tags::TimeStepId, ::Tags::Next<::Tags::TimeStepId>,
+                  ::Tags::TimeStep, ::Tags::Next<::Tags::TimeStep>,
+                  ::Tags::TimeStepper<TimeStepper>>,
+              db::AddComputeTags<>>>>,
+      Parallel::PhaseActions<Parallel::Phase::Testing,
+                             tmpl::list<Actions::ChangeSlabSize>>>;
+  using component_being_mocked = WorldtubeSingleton<Metavariables>;
+};
+
+template <size_t Dim>
+struct MockMetavariables {
+  static constexpr size_t volume_dim = Dim;
+  using component_list =
+      tmpl::list<MockWorldtubeSingleton<MockMetavariables<Dim>>>;
+  using const_global_cache_tags = tmpl::list<>;
+};
+
+SPECTRE_TEST_CASE("Unit.CurvedScalarWave.Worldtube.ChangeSlabSize", "[Unit]") {
+  static constexpr size_t Dim = 3;
+  using worldtube_chare = MockWorldtubeSingleton<MockMetavariables<Dim>>;
+  Parallel::register_classes_with_charm<TimeSteppers::Rk3HesthavenSsp>();
+
+  const auto time_stepper = TimeSteppers::Rk3HesthavenSsp{};
+  const double slab_1_start = 1.5;
+  const double slab_1_end = 2.0;
+
+  const Slab slab_1(slab_1_start, slab_1_end);
+  const auto start_time_1 = slab_1.start();
+  const TimeStepId time_step_id_1(true, 1, start_time_1);
+  const auto step_1 = time_step_id_1.step_time().slab().duration();
+
+  // we use two element ids for this test
+  const auto element_ids =
+      initial_element_ids(0, std::array<size_t, Dim>{{1, 0, 0}});
+
+  // we need to create a new runner every time an ASSERT is triggered because
+  // they can not be copied.
+  const auto create_new_runner =
+      [&time_step_id_1, &time_stepper,
+       &step_1](gsl::not_null<
+                ActionTesting::MockRuntimeSystem<MockMetavariables<Dim>>*>
+                    runner) {
+        ActionTesting::emplace_component_and_initialize<worldtube_chare>(
+            runner, 0,
+            {time_step_id_1, time_stepper.next_time_id(time_step_id_1, step_1),
+             step_1, step_1,
+             std::make_unique<TimeSteppers::Rk3HesthavenSsp>()});
+        ActionTesting::set_phase(runner, Parallel::Phase::Testing);
+      };
+  const auto check_time_tags =
+      [](const ActionTesting::MockRuntimeSystem<MockMetavariables<Dim>>& runner,
+         const TimeStepId& time_step_id, const TimeStepId& next_time_step_id,
+         const TimeDelta& step, const TimeDelta& next_step) {
+        CHECK(
+            ActionTesting::get_databox_tag<worldtube_chare, ::Tags::TimeStepId>(
+                runner, 0) == time_step_id);
+        CHECK(ActionTesting::get_databox_tag<worldtube_chare,
+                                             ::Tags::Next<::Tags::TimeStepId>>(
+                  runner, 0) == next_time_step_id);
+        CHECK(ActionTesting::get_databox_tag<worldtube_chare, ::Tags::TimeStep>(
+                  runner, 0) == step);
+        CHECK(ActionTesting::get_databox_tag<worldtube_chare,
+                                             ::Tags::Next<::Tags::TimeStep>>(
+                  runner, 0) == next_step);
+      };
+  using inbox_variables_type =
+      Variables<tmpl::list<CurvedScalarWave::Tags::Psi,
+                           ::Tags::dt<CurvedScalarWave::Tags::Psi>>>;
+  {
+    ActionTesting::MockRuntimeSystem<MockMetavariables<Dim>> runner{{}};
+    create_new_runner(make_not_null(&runner));
+    // ChangeSlabSize but no data sent yet
+    CHECK_FALSE(ActionTesting::next_action_if_ready<worldtube_chare>(
+        make_not_null(&runner), 0));
+    check_time_tags(runner, time_step_id_1,
+                    time_stepper.next_time_id(time_step_id_1, step_1), step_1,
+                    step_1);
+    auto& worldtube_inbox =
+        ActionTesting::get_inbox_tag<worldtube_chare,
+                                     Tags::SphericalHarmonicsInbox<Dim>>(
+            make_not_null(&runner), 0);
+    worldtube_inbox[time_step_id_1][element_ids.at(0)] = inbox_variables_type{};
+    // ChangeSlabSize but only 1/2 elements have sent
+    CHECK(ActionTesting::next_action_if_ready<worldtube_chare>(
+        make_not_null(&runner), 0));
+    check_time_tags(runner, time_step_id_1,
+                    time_stepper.next_time_id(time_step_id_1, step_1), step_1,
+                    step_1);
+    // send from other element
+    worldtube_inbox[time_step_id_1][element_ids.at(1)] = inbox_variables_type{};
+    CHECK(ActionTesting::next_action_if_ready<worldtube_chare>(
+        make_not_null(&runner), 0));
+    // same slab size so nothing shoud have changed.
+    check_time_tags(runner, time_step_id_1,
+                    time_stepper.next_time_id(time_step_id_1, step_1), step_1,
+                    step_1);
+#ifdef SPECTRE_DEBUG
+    const TimeStepId time_step_id_new_slab_number(true, 2, start_time_1);
+    // sending a second time step id, should fail
+    worldtube_inbox[time_step_id_new_slab_number][element_ids.at(0)] =
+        inbox_variables_type{};
+    CHECK_THROWS_WITH(
+        ActionTesting::next_action<worldtube_chare>(make_not_null(&runner), 0),
+        Catch::Contains("Received data from two different time step ids."));
+#endif
+  }
+#ifdef SPECTRE_DEBUG
+  {
+    ActionTesting::MockRuntimeSystem<MockMetavariables<Dim>> runner{{}};
+    create_new_runner(make_not_null(&runner));
+    auto& worldtube_inbox =
+        ActionTesting::get_inbox_tag<worldtube_chare,
+                                     Tags::SphericalHarmonicsInbox<Dim>>(
+            make_not_null(&runner), 0);
+    // different slab start -> invalid
+    const double slab_2_start = 1.7;
+    const Slab slab_2(slab_2_start, slab_1_end);
+    const auto start_time_2 = slab_2.start();
+    const TimeStepId time_step_id_2(true, 1, start_time_2);
+    worldtube_inbox[time_step_id_2][element_ids.at(0)] = inbox_variables_type{};
+    CHECK_THROWS_WITH(
+        ActionTesting::next_action<worldtube_chare>(make_not_null(&runner), 0),
+        Catch::Contains(
+            "The new slab should start at the same time as the old one."));
+  }
+#endif
+
+  {
+    ActionTesting::MockRuntimeSystem<MockMetavariables<Dim>> runner{{}};
+    create_new_runner(make_not_null(&runner));
+    auto& worldtube_inbox =
+        ActionTesting::get_inbox_tag<worldtube_chare,
+                                     Tags::SphericalHarmonicsInbox<Dim>>(
+            make_not_null(&runner), 0);
+    // different slab end
+    const double slab_2_end = 1.7;
+    const Slab slab_2(slab_1_start, slab_2_end);
+    const auto start_time_2 = slab_2.start();
+    const TimeStepId time_step_id_2(true, 1, start_time_2);
+    const auto step_2 = time_step_id_2.step_time().slab().duration();
+    worldtube_inbox[time_step_id_2][element_ids.at(0)] = inbox_variables_type{};
+    // data sent from only one element but with a different time step id, so the
+    // time tags should have changed.
+    CHECK(ActionTesting::next_action_if_ready<worldtube_chare>(
+        make_not_null(&runner), 0));
+    check_time_tags(runner, time_step_id_2,
+                    time_stepper.next_time_id(time_step_id_2, step_2), step_2,
+                    step_2);
+    // data sent from both elements
+    worldtube_inbox[time_step_id_2][element_ids.at(1)] = inbox_variables_type{};
+    CHECK(ActionTesting::next_action_if_ready<worldtube_chare>(
+        make_not_null(&runner), 0));
+    check_time_tags(runner, time_step_id_2,
+                    time_stepper.next_time_id(time_step_id_2, step_2), step_2,
+                    step_2);
+  }
+}
+}  // namespace
+}  // namespace CurvedScalarWave::Worldtube


### PR DESCRIPTION
## Proposed changes

Adds capability for the worldtube to change the global slab size with the elements.

The worldtube singleton checks the `TimeStepId` of the inbox key  to see if a slab change has occurred and changes it accordingly.

~depends on #4826 and  #4825~

