### PR TITLE
Add observer at extremum

### DIFF
--- a/src/ParallelAlgorithms/Events/CMakeLists.txt
+++ b/src/ParallelAlgorithms/Events/CMakeLists.txt
@@ -11,6 +11,7 @@ spectre_target_headers(
   HEADERS
   Factory.hpp
   MonitorMemory.hpp
+  ObserveAtExtremum.hpp
   ObserveFields.hpp
   ObserveNorms.hpp
   ObserveTimeStep.hpp

--- a/src/ParallelAlgorithms/Events/ObserveAtExtremum.hpp
+++ b/src/ParallelAlgorithms/Events/ObserveAtExtremum.hpp
@@ -1,0 +1,404 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <optional>
+#include <pup.h>
+#include <string>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/ObservationBox.hpp"
+#include "DataStructures/DataBox/TagName.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Domain/Tags.hpp"
+#include "IO/Observer/GetSectionObservationKey.hpp"
+#include "IO/Observer/Helpers.hpp"
+#include "IO/Observer/ObservationId.hpp"
+#include "IO/Observer/ObserverComponent.hpp"
+#include "IO/Observer/ReductionActions.hpp"
+#include "IO/Observer/TypeOfObservation.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "Options/Options.hpp"
+#include "Parallel/ArrayIndex.hpp"
+#include "Parallel/CharmPupable.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "Parallel/Invoke.hpp"
+#include "Parallel/Local.hpp"
+#include "Parallel/Reduction.hpp"
+#include "ParallelAlgorithms/Events/Tags.hpp"
+#include "ParallelAlgorithms/EventsAndTriggers/Event.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/Functional.hpp"
+#include "Utilities/Numeric.hpp"
+#include "Utilities/OptionalHelpers.hpp"
+#include "Utilities/TMPL.hpp"
+
+
+namespace Events {
+/// @{
+/*!
+ * \brief Find the extremum of a Scalar<DataVector> over
+ * all elements, as well as the value of other functions
+ * at the location of that extremum.
+ *
+ *
+ * Here is an example of an input file:
+ *
+ * \snippet Test_ObserveAtExtremum.cpp input_file_examples
+ *
+ * \par Array sections
+ * This event supports sections (see `Parallel::Section`). Set the
+ * `ArraySectionIdTag` template parameter to split up observations into subsets
+ * of elements. The `observers::Tags::ObservationKey<ArraySectionIdTag>` must be
+ * available in the DataBox. It identifies the section and is used as a suffix
+ * for the path in the output file.
+ */
+template <typename ObservationValueTag, typename ObservableTensorTagsList,
+          typename NonTensorComputeTagsList = tmpl::list<>,
+          typename ArraySectionIdTag = void>
+class ObserveAtExtremum;
+
+template <typename ObservationValueTag, typename... ObservableTensorTags,
+          typename... NonTensorComputeTags, typename ArraySectionIdTag>
+class ObserveAtExtremum<ObservationValueTag,
+                        tmpl::list<ObservableTensorTags...>,
+                        tmpl::list<NonTensorComputeTags...>, ArraySectionIdTag>
+    : public Event {
+ private:
+  /// Reduction data will contain the time, and either the maximum
+  /// or the minimum of a function
+  template <typename MinMaxFunctional>
+  using ReductionData = Parallel::ReductionData<
+      // Observation value
+      Parallel::ReductionDatum<double, funcl::AssertEqual<>>,
+      // Maximum of first component of a vector
+      Parallel::ReductionDatum<std::vector<double>, MinMaxFunctional>>;
+
+  /// Information about the scalar whose extremum we search for,
+  /// the type of extremum, and the other tensors to observer at
+  /// that extremum
+  struct ObserveTensors {
+    static constexpr Options::String help = {
+        "The tensor to extremize, and other tensors to observe."};
+
+    struct Name {
+      using type = std::string;
+      static constexpr Options::String help = {
+          "The name of the scalar to extremize."};
+    };
+
+    struct ExtremumType {
+      using type = std::string;
+      static constexpr Options::String help = {
+          "The type of extremum -- either Min or Max."};
+    };
+
+    struct AdditionalData {
+      using type = std::vector<std::string>;
+      static constexpr Options::String help = {
+          "List of other tensors to observe at the extremum"};
+    };
+
+    using options = tmpl::list<Name, ExtremumType, AdditionalData>;
+
+    ObserveTensors() = default;
+
+    ObserveTensors(std::string in_scalar, std::string in_extremum_type,
+                   std::vector<std::string> in_additional_data,
+                   const Options::Context& context = {});
+
+    std::string scalar_name;
+    std::string extremum_type;
+    std::vector<std::string> additional_data{};
+  };
+
+ public:
+  /// The name of the subfile inside the HDF5 file
+  struct SubfileName {
+    using type = std::string;
+    static constexpr Options::String help = {
+        "The name of the subfile inside the HDF5 file without an extension and "
+        "without a preceding '/'."};
+  };
+  /// The scalar to extremize, and other tensors to observe at extremum
+  struct TensorsToObserve {
+    using type = ObserveTensors;
+    static constexpr Options::String help = {
+        "Struct specifying the scalar to extremize, the type of extremum "
+        "and other tensors to observe at that extremum."};
+  };
+
+  explicit ObserveAtExtremum(CkMigrateMessage* msg);
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(ObserveAtExtremum);  // NOLINT
+
+  using options = tmpl::list<SubfileName, TensorsToObserve>;
+
+  static constexpr Options::String help =
+      "Observe extremum of a scalar in the DataBox.\n"
+      "\n"
+      "Writes reduction quantities:\n"
+      " * ObservationValueTag (e.g. Time or IterationId)\n"
+      " * Extremum value of the desired scalar\n"
+      " * Additional data at extremum\n";
+
+  ObserveAtExtremum() = default;
+
+  ObserveAtExtremum(std::string subfile_name,
+                    ObserveTensors observe_tensors);
+
+  using observed_reduction_data_tags = observers::make_reduction_data_tags<
+      tmpl::list<ReductionData<funcl::Max<>>, ReductionData<funcl::Min<>>>>;
+
+  using compute_tags_for_observation_box =
+      tmpl::list<ObservableTensorTags..., NonTensorComputeTags...>;
+
+  using argument_tags = tmpl::list<ObservationValueTag, ::Tags::ObservationBox>;
+
+  template <typename ComputeTagsList, typename DataBoxType,
+            typename Metavariables, size_t VolumeDim,
+            typename ParallelComponent>
+  void operator()(const typename ObservationValueTag::type& observation_value,
+                  const ObservationBox<ComputeTagsList, DataBoxType>& box,
+                  Parallel::GlobalCache<Metavariables>& cache,
+                  const ElementId<VolumeDim>& array_index,
+                  const ParallelComponent* const /*meta*/) const;
+
+  using observation_registration_tags = tmpl::list<::Tags::DataBox>;
+
+  template <typename DbTagsList>
+  std::optional<
+      std::pair<observers::TypeOfObservation, observers::ObservationKey>>
+  get_observation_type_and_key_for_registration(
+      const db::DataBox<DbTagsList>& box) const {
+    const std::optional<std::string> section_observation_key =
+        observers::get_section_observation_key<ArraySectionIdTag>(box);
+    if (not section_observation_key.has_value()) {
+      return std::nullopt;
+    }
+    return {{observers::TypeOfObservation::Reduction,
+             observers::ObservationKey(
+                 subfile_path_ + section_observation_key.value() + ".dat")}};
+  }
+
+  using is_ready_argument_tags = tmpl::list<>;
+
+  template <typename Metavariables, typename ArrayIndex, typename Component>
+  bool is_ready(Parallel::GlobalCache<Metavariables>& /*cache*/,
+                const ArrayIndex& /*array_index*/,
+                const Component* const /*meta*/) const {
+    return true;
+  }
+
+  bool needs_evolved_variables() const override { return true; }
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& p) override;
+
+ private:
+  std::string subfile_path_;
+  std::string scalar_name_;
+  std::string extremum_type_;
+  std::vector<std::string> additional_tensor_names_{};
+};
+/// @}
+
+/// \cond
+template <typename ObservationValueTag, typename... ObservableTensorTags,
+          typename... NonTensorComputeTags, typename ArraySectionIdTag>
+ObserveAtExtremum<ObservationValueTag, tmpl::list<ObservableTensorTags...>,
+                  tmpl::list<NonTensorComputeTags...>,
+                  ArraySectionIdTag>::ObserveAtExtremum(CkMigrateMessage* msg)
+    : Event(msg) {}
+
+template <typename ObservationValueTag, typename... ObservableTensorTags,
+          typename... NonTensorComputeTags, typename ArraySectionIdTag>
+ObserveAtExtremum<ObservationValueTag, tmpl::list<ObservableTensorTags...>,
+                  tmpl::list<NonTensorComputeTags...>, ArraySectionIdTag>::
+    ObserveAtExtremum(std::string subfile_name,
+                      ObserveTensors observe_tensors)
+    : subfile_path_("/" + subfile_name),
+      scalar_name_(std::move(observe_tensors.scalar_name)),
+      extremum_type_(std::move(observe_tensors.extremum_type)),
+      additional_tensor_names_(std::move(observe_tensors.additional_data)) {}
+
+template <typename ObservationValueTag, typename... ObservableTensorTags,
+          typename... NonTensorComputeTags, typename ArraySectionIdTag>
+ObserveAtExtremum<ObservationValueTag, tmpl::list<ObservableTensorTags...>,
+                  tmpl::list<NonTensorComputeTags...>, ArraySectionIdTag>::
+    ObserveTensors::ObserveTensors(std::string in_scalar,
+                                   std::string in_extremum_type,
+                                   std::vector<std::string> in_additional_data,
+                                   const Options::Context& context)
+    : scalar_name(std::move(in_scalar)),
+      extremum_type(std::move(in_extremum_type)),
+      additional_data(std::move(in_additional_data)) {
+  if (((scalar_name != db::tag_name<ObservableTensorTags>()) and ...)) {
+    PARSE_ERROR(
+        context, "Tensor '"
+                     << scalar_name << "' is not known. Known tensors are: "
+                     << ((db::tag_name<ObservableTensorTags>() + ",") + ...));
+  }
+  if (extremum_type != "Max" and extremum_type != "Min") {
+    PARSE_ERROR(context, "Extremum type " << extremum_type
+                                          << " not recognized; use Max or Min");
+  }
+  for (const auto& tensor : additional_data) {
+    if (((tensor != db::tag_name<ObservableTensorTags>()) and ...)) {
+      PARSE_ERROR(context,
+                  "Tensor '"
+                      << tensor << "' is not known. Known tensors are: "
+                      << ((db::tag_name<ObservableTensorTags>() + ",") + ...));
+    }
+  }
+}
+
+template <typename ObservationValueTag, typename... ObservableTensorTags,
+          typename... NonTensorComputeTags, typename ArraySectionIdTag>
+template <typename ComputeTagsList, typename DataBoxType,
+          typename Metavariables, size_t VolumeDim, typename ParallelComponent>
+void ObserveAtExtremum<ObservationValueTag, tmpl::list<ObservableTensorTags...>,
+                       tmpl::list<NonTensorComputeTags...>, ArraySectionIdTag>::
+operator()(const typename ObservationValueTag::type& observation_value,
+           const ObservationBox<ComputeTagsList, DataBoxType>& box,
+           Parallel::GlobalCache<Metavariables>& cache,
+           const ElementId<VolumeDim>& array_index,
+           const ParallelComponent* const /*meta*/) const {
+  // Skip observation on elements that are not part of a section
+  const std::optional<std::string> section_observation_key =
+      observers::get_section_observation_key<ArraySectionIdTag>(box);
+  if (not section_observation_key.has_value()) {
+    return;
+  }
+
+  using tensor_tags = tmpl::list<ObservableTensorTags...>;
+
+  // Vector that will contain the local extremum, and the value
+  // of other tensors at that extremum
+  std::vector<double> data_to_reduce{};
+  // Vector containing a description of the data to be reduced.
+  std::vector<std::string> legend{db::tag_name<ObservationValueTag>()};
+  // Location of the local extremum
+  size_t index_of_extremum = 0;
+  // First, look for local extremum of desired scalar
+  tmpl::for_each<tensor_tags>([this, &box, &data_to_reduce, &legend,
+                               &index_of_extremum](auto tag_v) {
+    using tag = tmpl::type_from<decltype(tag_v)>;
+    const std::string tensor_name = db::tag_name<tag>();
+    if (tensor_name == scalar_name_) {
+      if (UNLIKELY(not has_value(get<tag>(box)))) {
+        ERROR("Cannot observe a norm of '"
+              << tensor_name
+              << "' because it is a std::optional and wasn't able to be "
+                 "computed. This can happen when you try to observe errors "
+                 "without an analytic solution.");
+      }
+      const auto& scalar = value(get<tag>(box));
+      const auto [component_names, components] = scalar.get_vector_of_data();
+      if (components.size() > 1) {
+        ERROR("Extremum should be taken on a scalar, yet we have "
+              << components.size() << " components in tensor " << tensor_name);
+      }
+      for (size_t i = 1; i < components[0].size(); i++) {
+        if ((extremum_type_ == "Max" and
+             (components[0][i] > components[0][index_of_extremum])) or
+            (extremum_type_ == "Min" and
+             (components[0][i] < components[0][index_of_extremum]))) {
+          index_of_extremum = i;
+        }
+      }
+      data_to_reduce.push_back(components[0][index_of_extremum]);
+      if (extremum_type_ == "Max") {
+        legend.push_back("Max of " + scalar_name_);
+      } else {
+        legend.push_back("Min of " + scalar_name_);
+      }
+    }
+  });
+  // Now get value of additional tensors at extremum
+  tmpl::for_each<tensor_tags>([this, &box, &data_to_reduce, &legend,
+                               &index_of_extremum](auto tag_v) {
+    using tag = tmpl::type_from<decltype(tag_v)>;
+    const std::string tensor_name = db::tag_name<tag>();
+    for (size_t i = 0; i < additional_tensor_names_.size(); ++i)
+      if (tensor_name == additional_tensor_names_[i]) {
+        if (UNLIKELY(not has_value(get<tag>(box)))) {
+          ERROR("Cannot observe a norm of '"
+                << tensor_name
+                << "' because it is a std::optional and wasn't able to be "
+                   "computed. This can happen when you try to observe errors "
+                   "without an analytic solution.");
+        }
+        const auto& tensor = value(get<tag>(box));
+        const auto [component_names, components] = tensor.get_vector_of_data();
+        for (size_t j = 0; j < components.size(); j++) {
+          data_to_reduce.push_back(components[j][index_of_extremum]);
+          if (components.size() > 1) {
+            legend.push_back("Value of " + tensor_name + "_" +
+                             component_names[j] + " at " + extremum_type_ +
+                             " of " + scalar_name_);
+          } else {
+            legend.push_back("Value of " + tensor_name + " at " +
+                             extremum_type_ + " of " + scalar_name_);
+          }
+        }
+      }
+  });
+
+  // Send data to reduction observer
+  auto& local_observer = *Parallel::local_branch(
+      Parallel::get_parallel_component<observers::Observer<Metavariables>>(
+          cache));
+  const std::string subfile_path_with_suffix =
+      subfile_path_ + section_observation_key.value();
+
+  if (extremum_type_ == "Max") {
+    Parallel::simple_action<observers::Actions::ContributeReductionData>(
+        local_observer,
+        observers::ObservationId(observation_value,
+                                 subfile_path_with_suffix + ".dat"),
+        observers::ArrayComponentId{
+            std::add_pointer_t<ParallelComponent>{nullptr},
+            Parallel::ArrayIndex<ElementId<VolumeDim>>(array_index)},
+        subfile_path_with_suffix, std::move(legend),
+        ReductionData<funcl::Max<>>{static_cast<double>(observation_value),
+                                    std::move(data_to_reduce)});
+  } else {
+    Parallel::simple_action<observers::Actions::ContributeReductionData>(
+        local_observer,
+        observers::ObservationId(observation_value,
+                                 subfile_path_with_suffix + ".dat"),
+        observers::ArrayComponentId{
+            std::add_pointer_t<ParallelComponent>{nullptr},
+            Parallel::ArrayIndex<ElementId<VolumeDim>>(array_index)},
+        subfile_path_with_suffix, std::move(legend),
+        ReductionData<funcl::Min<>>{static_cast<double>(observation_value),
+                                    std::move(data_to_reduce)});
+  }
+}
+
+template <typename ObservationValueTag, typename... ObservableTensorTags,
+          typename... NonTensorComputeTags, typename ArraySectionIdTag>
+void ObserveAtExtremum<ObservationValueTag, tmpl::list<ObservableTensorTags...>,
+                       tmpl::list<NonTensorComputeTags...>,
+                       ArraySectionIdTag>::pup(PUP::er& p) {
+  Event::pup(p);
+  p | subfile_path_;
+  p | scalar_name_;
+  p | extremum_type_;
+  p | additional_tensor_names_;
+}
+
+template <typename ObservationValueTag, typename... ObservableTensorTags,
+          typename... NonTensorComputeTags, typename ArraySectionIdTag>
+PUP::able::PUP_ID
+    ObserveAtExtremum<ObservationValueTag, tmpl::list<ObservableTensorTags...>,
+                      tmpl::list<NonTensorComputeTags...>,
+                      ArraySectionIdTag>::my_PUP_ID = 0;  // NOLINT
+/// \endcond
+}  // namespace Events

--- a/tests/Unit/ParallelAlgorithms/Events/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/Events/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY "Test_ParallelAlgorithmsEvents")
 
 set(LIBRARY_SOURCES
+  Test_ObserveAtExtremum.cpp
   Test_ObserveFields.cpp
   Test_ObserveNorms.cpp
   Test_ObserveTimeStep.cpp

--- a/tests/Unit/ParallelAlgorithms/Events/Test_ObserveAtExtremum.cpp
+++ b/tests/Unit/ParallelAlgorithms/Events/Test_ObserveAtExtremum.cpp
@@ -1,0 +1,317 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Framework/ActionTesting.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "IO/Observer/Actions/RegisterEvents.hpp"
+#include "IO/Observer/ArrayComponentId.hpp"
+#include "IO/Observer/ObservationId.hpp"
+#include "IO/Observer/ObserverComponent.hpp"
+#include "IO/Observer/Tags.hpp"
+#include "Options/Protocols/FactoryCreation.hpp"
+#include "Parallel/Phase.hpp"
+#include "Parallel/PhaseDependentActionList.hpp"
+#include "Parallel/Reduction.hpp"
+#include "Parallel/RegisterDerivedClassesWithCharm.hpp"
+#include "Parallel/Tags/Metavariables.hpp"
+#include "ParallelAlgorithms/Events/ObserveAtExtremum.hpp"
+#include "ParallelAlgorithms/EventsAndTriggers/Event.hpp"
+#include "Time/Tags.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
+#include "Utilities/StdHelpers.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+struct Var0 : db::SimpleTag {
+  using type = Scalar<DataVector>;
+};
+
+struct Var1 : db::SimpleTag {
+  using type = tnsr::I<DataVector, 3, Frame::Inertial>;
+};
+
+struct Var0TimesTwo : db::SimpleTag {
+  using type = std::optional<Scalar<DataVector>>;
+};
+
+struct Var0TimesTwoCompute : db::ComputeTag, Var0TimesTwo {
+  using base = Var0TimesTwo;
+  using return_type = std::optional<Scalar<DataVector>>;
+  using argument_tags = tmpl::list<Var0>;
+  static void function(
+      const gsl::not_null<std::optional<Scalar<DataVector>>*> result,
+      const Scalar<DataVector>& scalar_var) {
+    *result = Scalar<DataVector>{DataVector{2.0 * get(scalar_var)}};
+  }
+};
+
+struct Var0TimesThree : db::SimpleTag {
+  using type = Scalar<DataVector>;
+};
+
+struct Var0TimesThreeCompute : db::ComputeTag,
+                               ::Tags::Variables<tmpl::list<Var0TimesThree>> {
+  using base = Var0TimesThree;
+  using return_type = typename base::type;
+  using argument_tags = tmpl::list<Var0>;
+  static void function(
+      const gsl::not_null<::Variables<tmpl::list<Var0TimesThree>>*> result,
+      const Scalar<DataVector>& scalar_var) {
+    result->initialize(get(scalar_var).size());
+    get(get<Var0TimesThree>(*result)) = 3.0 * get(scalar_var);
+  }
+};
+
+struct TestSectionIdTag {};
+
+struct MockContributeReductionData {
+  struct Results {
+    observers::ObservationId observation_id;
+    std::string subfile_name;
+    std::vector<std::string> legend;
+    double time;
+    std::vector<double> reduced_vector;
+  };
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+  static Results results;
+
+  template <typename ParallelComponent, typename... DbTags,
+            typename Metavariables, typename ArrayIndex, typename... Ts>
+  static void apply(db::DataBox<tmpl::list<DbTags...>>& /*box*/,
+                    Parallel::GlobalCache<Metavariables>& /*cache*/,
+                    const ArrayIndex& /*array_index*/,
+                    const observers::ObservationId& observation_id,
+                    observers::ArrayComponentId /*sender_array_id*/,
+                    const std::string& subfile_name,
+                    const std::vector<std::string>& legend,
+                    Parallel::ReductionData<Ts...>&& reduction_data) {
+    reduction_data.finalize();
+    results.observation_id = observation_id;
+    results.subfile_name = subfile_name;
+    results.legend = legend;
+    results.time = std::get<0>(reduction_data.data());
+    results.reduced_vector = std::get<1>(reduction_data.data());
+  }
+};
+
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+MockContributeReductionData::Results MockContributeReductionData::results{};
+
+template <typename Metavariables>
+struct ElementComponent {
+  using component_being_mocked = void;
+
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = ElementId<Metavariables::volume_dim>;
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<Parallel::Phase::Initialization, tmpl::list<>>>;
+};
+
+template <typename Metavariables>
+struct MockObserverComponent {
+  using component_being_mocked = observers::Observer<Metavariables>;
+  using replace_these_simple_actions =
+      tmpl::list<observers::Actions::ContributeReductionData>;
+  using with_these_simple_actions = tmpl::list<MockContributeReductionData>;
+
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockGroupChare;
+  using array_index = int;
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<Parallel::Phase::Initialization, tmpl::list<>>>;
+};
+
+template <typename ArraySectionIdTag>
+using ObserveAtExtremumEvent = Events::ObserveAtExtremum<
+    ::Tags::Time, tmpl::list<Var0, Var1, Var0TimesTwoCompute, Var0TimesThree>,
+    tmpl::list<Var0TimesThreeCompute>, ArraySectionIdTag>;
+
+template <size_t Dim, typename ArraySectionIdTag>
+struct Metavariables {
+  static constexpr size_t volume_dim = Dim;
+  using component_list = tmpl::list<ElementComponent<Metavariables>,
+                                    MockObserverComponent<Metavariables>>;
+
+  struct factory_creation
+      : tt::ConformsTo<Options::protocols::FactoryCreation> {
+    using factory_classes = tmpl::map<tmpl::pair<
+        Event, tmpl::list<ObserveAtExtremumEvent<ArraySectionIdTag>>>>;
+  };
+};
+
+template <typename ArraySectionIdTag, typename ObserveEvent>
+void test(const std::unique_ptr<ObserveEvent> observe,
+          const std::string& extremum_type, const Spectral::Basis basis,
+          const Spectral::Quadrature quadrature,
+          const std::optional<std::string>& section) {
+  CAPTURE(pretty_type::name<ArraySectionIdTag>());
+  CAPTURE(section);
+  using metavariables = Metavariables<3, ArraySectionIdTag>;
+  using element_component = ElementComponent<metavariables>;
+  using observer_component = MockObserverComponent<metavariables>;
+  const typename element_component::array_index array_index(0);
+  const Mesh<3> mesh{3, basis, quadrature};
+  const size_t num_points = mesh.number_of_grid_points();
+  const double observation_time = 2.0;
+
+  Variables<tmpl::list<Var0, Var1>> vars(num_points);
+  // Fill the variables with some data.  It doesn't matter much what,
+  // but integers are nice in that we don't have to worry about
+  // roundoff error.
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+  // std::iota(vars.data(), vars.data() + vars.size(), 1.0);
+  std::iota(vars.data(), vars.data() + num_points + 5, 1.0);
+  std::iota(vars.data() + num_points + 5, vars.data() + vars.size(), -10.0);
+
+  ActionTesting::MockRuntimeSystem<metavariables> runner{{}};
+  ActionTesting::emplace_component<element_component>(make_not_null(&runner),
+                                                      array_index);
+  ActionTesting::emplace_group_component<observer_component>(&runner);
+
+  const auto box = db::create<
+      db::AddSimpleTags<Parallel::Tags::MetavariablesImpl<metavariables>,
+                        ::Events::Tags::ObserverMesh<3>, ::Tags::Time,
+                        Tags::Variables<typename decltype(vars)::tags_list>,
+                        observers::Tags::ObservationKey<ArraySectionIdTag>>>(
+      metavariables{}, mesh, observation_time, vars, section);
+
+  const auto ids_to_register =
+      observers::get_registration_observation_type_and_key(*observe, box);
+  const std::string expected_subfile_name{
+      "/reduction0" +
+      (std::is_same_v<ArraySectionIdTag, void> ? ""
+                                               : section.value_or("Unused"))};
+  const observers::ObservationKey expected_observation_key_for_reg(
+      expected_subfile_name + ".dat");
+  if (std::is_same_v<ArraySectionIdTag, void> or section.has_value()) {
+    CHECK(ids_to_register->first == observers::TypeOfObservation::Reduction);
+    CHECK(ids_to_register->second == expected_observation_key_for_reg);
+  } else {
+    CHECK_FALSE(ids_to_register.has_value());
+  }
+
+  CHECK(static_cast<const Event&>(*observe).is_ready(
+      box, ActionTesting::cache<element_component>(runner, array_index),
+      array_index, std::add_pointer_t<element_component>{}));
+
+  observe->run(
+      make_observation_box<
+          tmpl::filter<typename ObserveAtExtremumEvent<
+                           ArraySectionIdTag>::compute_tags_for_observation_box,
+                       db::is_compute_tag<tmpl::_1>>>(box),
+      ActionTesting::cache<element_component>(runner, array_index), array_index,
+      std::add_pointer_t<element_component>{});
+
+  // Process the data
+  runner.template invoke_queued_simple_action<observer_component>(0);
+  CHECK(runner.template is_simple_action_queue_empty<observer_component>(0));
+
+  const auto& results = MockContributeReductionData::results;
+  CHECK(results.observation_id.value() == observation_time);
+  CHECK(results.observation_id.observation_key() ==
+        expected_observation_key_for_reg);
+  CHECK(results.subfile_name == expected_subfile_name);
+  CHECK(results.time == observation_time);
+  CHECK(results.legend[0] == "Time");
+  if (extremum_type == "Max") {
+    CHECK(results.legend[1] == "Max of Var0");
+    CHECK(results.legend[2] == "Value of Var0 at Max of Var0");
+    CHECK(results.legend[3] == "Value of Var1_x at Max of Var0");
+    CHECK(results.legend[4] == "Value of Var1_y at Max of Var0");
+    CHECK(results.legend[5] == "Value of Var1_z at Max of Var0");
+    CHECK(results.reduced_vector ==
+          std::vector<double>{27.0, 27.0, 11.0, 38.0, 65.0});
+  } else {
+    CHECK(results.legend[1] == "Min of Var0");
+    CHECK(results.legend[2] == "Value of Var0 at Min of Var0");
+    CHECK(results.legend[3] == "Value of Var1_x at Min of Var0");
+    CHECK(results.legend[4] == "Value of Var1_y at Min of Var0");
+    CHECK(results.legend[5] == "Value of Var1_z at Min of Var0");
+    CHECK(results.reduced_vector ==
+          std::vector<double>{1.0, 1.0, 28.0, 12.0, 39.0});
+  }
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Evolution.ObserveAtExtremum", "[Unit][Evolution]") {
+  test<TestSectionIdTag>(
+      std::make_unique<ObserveAtExtremumEvent<TestSectionIdTag>>(
+          ObserveAtExtremumEvent<TestSectionIdTag>{
+              "reduction0", {"Var0", "Max", {"Var0", "Var1"}}}),
+      "Max", Spectral::Basis::Legendre, Spectral::Quadrature::GaussLobatto,
+      "Section0");
+  test<TestSectionIdTag>(
+      std::make_unique<ObserveAtExtremumEvent<TestSectionIdTag>>(
+          ObserveAtExtremumEvent<TestSectionIdTag>{
+              "reduction0", {"Var0", "Min", {"Var0", "Var1"}}}),
+      "Min", Spectral::Basis::Legendre, Spectral::Quadrature::GaussLobatto,
+      "Section0");
+
+  INFO("create/serialize");
+  Parallel::register_factory_classes_with_charm<Metavariables<3, void>>();
+  const auto factory_event = TestHelpers::test_creation<std::unique_ptr<Event>,
+                                                        Metavariables<3, void>>(
+      // [input_file_examples]
+      R"(
+  ObserveAtExtremum:
+    SubfileName: reduction0
+    TensorsToObserve:
+      Name: Var0
+      ExtremumType: Max
+      AdditionalData:
+      - Var0
+      - Var1
+        )");
+  // [input_file_examples]
+  auto serialized_event = serialize_and_deserialize(factory_event);
+  test<void>(std::move(serialized_event), "Max", Spectral::Basis::Legendre,
+             Spectral::Quadrature::GaussLobatto, std::nullopt);
+
+  test<void>(std::make_unique<ObserveAtExtremumEvent<void>>(
+                 ObserveAtExtremumEvent<void>{
+                     "reduction0", {"Var0", "Max", {"Var0", "Var1"}}}),
+             "Max", Spectral::Basis::FiniteDifference,
+             Spectral::Quadrature::CellCentered, std::nullopt);
+
+  // Test that Max reduction has the desired behavior on vectors
+  {
+    using ReductionData = Parallel::ReductionData<
+        // Observation value
+        Parallel::ReductionDatum<double, funcl::AssertEqual<>>,
+        // Maximum of first component of a vector
+        Parallel::ReductionDatum<std::vector<double>, funcl::Max<>>>;
+    ReductionData first_data_set{1.0, std::vector<double>{1.0, 2.0, -1.0}};
+    ReductionData second_data_set{1.0, std::vector<double>{2.0, 1.0, -3.0}};
+    first_data_set.combine(std::move(second_data_set));
+    CHECK(std::get<0>(first_data_set.data()) == 1.0);
+    CHECK(std::get<1>(first_data_set.data()) ==
+          std::vector<double>{2.0, 1.0, -3.0});
+  }
+  // Test that Min reduction has the desired behavior on vectors
+  {
+    using ReductionData = Parallel::ReductionData<
+        // Observation value
+        Parallel::ReductionDatum<double, funcl::AssertEqual<>>,
+        // Maximum of first component of a vector
+        Parallel::ReductionDatum<std::vector<double>, funcl::Min<>>>;
+    ReductionData first_data_set{1.0, std::vector<double>{1.0, 2.0, -1.0}};
+    ReductionData second_data_set{1.0, std::vector<double>{2.0, 1.0, -3.0}};
+    first_data_set.combine(std::move(second_data_set));
+    CHECK(std::get<0>(first_data_set.data()) == 1.0);
+    CHECK(std::get<1>(first_data_set.data()) ==
+          std::vector<double>{1.0, 2.0, -1.0});
+  }
+}


### PR DESCRIPTION
## Proposed changes

Add an observer to find the extremum of a scalar, as well as the value of other tensors at that extremum

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.