### PR TITLE
Adaptive order derivatives in GRMHD

### DIFF
--- a/src/Evolution/DgSubcell/CellCenteredFlux.hpp
+++ b/src/Evolution/DgSubcell/CellCenteredFlux.hpp
@@ -48,8 +48,8 @@ struct CellCenteredFlux {
       const subcell::SubcellOptions& subcell_options,
       const Mesh<Dim>& subcell_mesh, const bool did_rollback, Args&&... args) {
     if (did_rollback or not ComputeOnlyOnRollback) {
-      if (subcell_options.finite_difference_derivative_order().value_or(0) >
-          2) {
+      if (subcell_options.finite_difference_derivative_order() !=
+          ::fd::DerivativeOrder::Two) {
         if (not cell_centered_fluxes->has_value()) {
           (*cell_centered_fluxes) =
               Variables<db::wrap_tags_in<::Tags::Flux, flux_variables,

--- a/src/Evolution/DgSubcell/SubcellOptions.cpp
+++ b/src/Evolution/DgSubcell/SubcellOptions.cpp
@@ -28,8 +28,7 @@ SubcellOptions::SubcellOptions(
     bool always_use_subcells, fd::ReconstructionMethod recons_method,
     bool use_halo,
     std::optional<std::vector<std::string>> only_dg_block_and_group_names,
-    std::optional<size_t> finite_difference_derivative_order,
-    const Options::Context& context)
+    ::fd::DerivativeOrder finite_difference_derivative_order)
     : initial_data_rdmp_delta0_(initial_data_rdmp_delta0),
       initial_data_rdmp_epsilon_(initial_data_rdmp_epsilon),
       rdmp_delta0_(rdmp_delta0),
@@ -43,14 +42,6 @@ SubcellOptions::SubcellOptions(
       finite_difference_derivative_order_(finite_difference_derivative_order) {
   if (not only_dg_block_and_group_names_.has_value()) {
     only_dg_block_ids_ = std::vector<size_t>{};
-  }
-  if (finite_difference_derivative_order_.has_value() and
-      not alg::found(std::array<size_t, 5>{{2, 4, 6, 8, 10}},
-                     finite_difference_derivative_order_.value())) {
-    PARSE_ERROR(context,
-                "The finite difference order must be Auto or one of "
-                "2,4,6,8,10, but got "
-                    << finite_difference_derivative_order_.value());
   }
 }
 

--- a/src/Evolution/DgSubcell/SubcellOptions.hpp
+++ b/src/Evolution/DgSubcell/SubcellOptions.hpp
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include "Evolution/DgSubcell/ReconstructionMethod.hpp"
+#include "NumericalAlgorithms/FiniteDifference/DerivativeOrder.hpp"
 #include "Options/Auto.hpp"
 #include "Options/Options.hpp"
 #include "Utilities/ErrorHandling/Assert.hpp"
@@ -145,11 +146,11 @@ class SubcellOptions {
   /// the reconstruction scheme order. E.g. for a 5th-order reconstruction we
   /// would use 4th order derivatives.
   struct FiniteDifferenceDerivativeOrder {
-    using type = Options::Auto<size_t, Options::AutoLabel::Auto>;
+    using type = ::fd::DerivativeOrder;
     static constexpr Options::String help = {
-        "The finite difference derivative order to use. Must be one of 2, 4, "
-        "6, 8, or 10. If Auto, then the derivative order will be determined "
-        "for you."};
+        "The finite difference derivative order to use. If computed from the "
+        "reconstruction, then the reconstruction method must support returning "
+        "its reconstruction order."};
   };
 
   using options =
@@ -169,8 +170,7 @@ class SubcellOptions {
       bool always_use_subcells, fd::ReconstructionMethod recons_method,
       bool use_halo,
       std::optional<std::vector<std::string>> only_dg_block_and_group_names,
-      std::optional<size_t> finite_difference_derivative_order,
-      const Options::Context& context = {});
+      ::fd::DerivativeOrder finite_difference_derivative_order);
 
   /// \brief Given an existing SubcellOptions that was created from block and
   /// group names, create one that stores block IDs.
@@ -219,7 +219,7 @@ class SubcellOptions {
     return only_dg_block_ids_.value();
   }
 
-  const std::optional<size_t>& finite_difference_derivative_order() const {
+  ::fd::DerivativeOrder finite_difference_derivative_order() const {
     return finite_difference_derivative_order_;
   }
 
@@ -241,7 +241,7 @@ class SubcellOptions {
   bool use_halo_{false};
   std::optional<std::vector<std::string>> only_dg_block_and_group_names_{};
   std::optional<std::vector<size_t>> only_dg_block_ids_{};
-  std::optional<size_t> finite_difference_derivative_order_{};
+  ::fd::DerivativeOrder finite_difference_derivative_order_{};
 };
 
 bool operator!=(const SubcellOptions& lhs, const SubcellOptions& rhs);

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/Tag.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/Tag.hpp
@@ -40,7 +40,8 @@ struct Reconstructor : db::SimpleTag {
   static type create_from_options(
       const type& reconstructor,
       const ::evolution::dg::subcell::SubcellOptions& subcell_options) {
-    if (not subcell_options.finite_difference_derivative_order().has_value() and
+    if (static_cast<int>(subcell_options.finite_difference_derivative_order()) <
+            0 and
         not reconstructor->supports_adaptive_order()) {
       ERROR_NO_TRACE(
           "Cannot use adaptive finite difference derivative order with "

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/Tag.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/Tag.hpp
@@ -47,6 +47,21 @@ struct Reconstructor : db::SimpleTag {
           "Cannot use adaptive finite difference derivative order with "
           "specified reconstructor.");
     }
+    if ((static_cast<int>(
+             subcell_options.finite_difference_derivative_order()) /
+             2 -
+         1) > static_cast<int>(reconstructor->ghost_zone_size())) {
+      ERROR_NO_TRACE(
+          "The derivative order chosen ("
+          << subcell_options.finite_difference_derivative_order()
+          << ") requires more ghost zones ("
+          << (static_cast<int>(
+                  subcell_options.finite_difference_derivative_order()) /
+                  2 -
+              1)
+          << ") than the reconstructor sends, "
+          << reconstructor->ghost_zone_size());
+    }
     return reconstructor->get_clone();
   }
 };

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TimeDerivative.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TimeDerivative.hpp
@@ -110,7 +110,7 @@ struct TimeDerivative {
         reconstruction_order_data{};
     std::optional<std::array<gsl::span<std::uint8_t>, 3>>
         reconstruction_order{};
-    if (not fd_derivative_order.has_value()) {
+    if (static_cast<int>(fd_derivative_order) < 0) {
       reconstruction_order_data = make_array<3>(std::vector<std::uint8_t>(
           (subcell_mesh.extents(0) + 2) * subcell_mesh.extents(1) *
               subcell_mesh.extents(2),
@@ -325,8 +325,7 @@ struct TimeDerivative {
 
         db::get<evolution::dg::subcell::Tags::CellCenteredFlux<
             evolved_vars_tags, 3>>(*box),
-        boundary_corrections,
-        static_cast<::fd::DerivativeOrder>(fd_derivative_order.value_or(2)),
+        boundary_corrections, fd_derivative_order,
         db::get<evolution::dg::subcell::Tags::GhostDataForReconstruction<3>>(
             *box),
         subcell_mesh, recons.ghost_zone_size());

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TimeDerivative.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TimeDerivative.hpp
@@ -328,7 +328,9 @@ struct TimeDerivative {
         boundary_corrections, fd_derivative_order,
         db::get<evolution::dg::subcell::Tags::GhostDataForReconstruction<3>>(
             *box),
-        subcell_mesh, recons.ghost_zone_size());
+        subcell_mesh, recons.ghost_zone_size(),
+        reconstruction_order.value_or(
+            std::array<gsl::span<std::uint8_t>, 3>{}));
 
     for (size_t dim = 0; dim < 3; ++dim) {
       const auto& boundary_correction_in_axis =

--- a/tests/InputFiles/Burgers/Step.yaml
+++ b/tests/InputFiles/Burgers/Step.yaml
@@ -64,7 +64,7 @@ SpatialDiscretization:
       SubcellToDgReconstructionMethod: DimByDim
       UseHalo: false
       OnlyDgBlocksAndGroups: None
-      FiniteDifferenceDerivativeOrder: Auto
+      FiniteDifferenceDerivativeOrder: 2
   SubcellSolver:
     Reconstructor: MonotonisedCentral
 

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/BinaryNeutronStar.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/BinaryNeutronStar.yaml
@@ -98,7 +98,7 @@ SpatialDiscretization:
       SubcellToDgReconstructionMethod: DimByDim
       UseHalo: True
       OnlyDgBlocksAndGroups: [Wedges]
-      FiniteDifferenceDerivativeOrder: Auto
+      FiniteDifferenceDerivativeOrder: 2
     TciOptions:
       MinimumValueOfD: 1.0e-20
       MinimumValueOfYe: 1.0e-20

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdTovStar.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdTovStar.yaml
@@ -107,7 +107,7 @@ SpatialDiscretization:
       SubcellToDgReconstructionMethod: DimByDim
       UseHalo: false
       OnlyDgBlocksAndGroups: None
-      FiniteDifferenceDerivativeOrder: Auto
+      FiniteDifferenceDerivativeOrder: 2
     TciOptions:
       MinimumValueOfD: 1.0e-20
       MinimumValueOfYe: 1.0e-20

--- a/tests/InputFiles/NewtonianEuler/RiemannProblem1D.yaml
+++ b/tests/InputFiles/NewtonianEuler/RiemannProblem1D.yaml
@@ -46,7 +46,7 @@ SpatialDiscretization:
       SubcellToDgReconstructionMethod: DimByDim
       UseHalo: false
       OnlyDgBlocksAndGroups: None
-      FiniteDifferenceDerivativeOrder: Auto
+      FiniteDifferenceDerivativeOrder: 2
   SubcellSolver:
     Reconstructor:
       MonotonisedCentralPrim:

--- a/tests/InputFiles/NewtonianEuler/RiemannProblem2D.yaml
+++ b/tests/InputFiles/NewtonianEuler/RiemannProblem2D.yaml
@@ -42,7 +42,7 @@ SpatialDiscretization:
       SubcellToDgReconstructionMethod: DimByDim
       UseHalo: false
       OnlyDgBlocksAndGroups: None
-      FiniteDifferenceDerivativeOrder: Auto
+      FiniteDifferenceDerivativeOrder: 2
   SubcellSolver:
     Reconstructor:
       MonotonisedCentralPrim:

--- a/tests/InputFiles/NewtonianEuler/RiemannProblem3D.yaml
+++ b/tests/InputFiles/NewtonianEuler/RiemannProblem3D.yaml
@@ -42,7 +42,7 @@ SpatialDiscretization:
       SubcellToDgReconstructionMethod: DimByDim
       UseHalo: false
       OnlyDgBlocksAndGroups: None
-      FiniteDifferenceDerivativeOrder: Auto
+      FiniteDifferenceDerivativeOrder: 2
   SubcellSolver:
     Reconstructor:
       MonotonisedCentralPrim:

--- a/tests/InputFiles/ScalarAdvection/Krivodonova1D.yaml
+++ b/tests/InputFiles/ScalarAdvection/Krivodonova1D.yaml
@@ -47,7 +47,7 @@ SpatialDiscretization:
       SubcellToDgReconstructionMethod: DimByDim
       UseHalo: false
       OnlyDgBlocksAndGroups: None
-      FiniteDifferenceDerivativeOrder: Auto
+      FiniteDifferenceDerivativeOrder: 2
     TciOptions:
       UCutoff: 1.0e-10
   SubcellSolver:

--- a/tests/InputFiles/ScalarAdvection/Kuzmin2D.yaml
+++ b/tests/InputFiles/ScalarAdvection/Kuzmin2D.yaml
@@ -43,7 +43,7 @@ SpatialDiscretization:
       SubcellToDgReconstructionMethod: DimByDim
       UseHalo: false
       OnlyDgBlocksAndGroups: None
-      FiniteDifferenceDerivativeOrder: Auto
+      FiniteDifferenceDerivativeOrder: 2
     TciOptions:
       UCutoff: 1.0e-10
   SubcellSolver:

--- a/tests/InputFiles/ScalarAdvection/Sinusoid1D.yaml
+++ b/tests/InputFiles/ScalarAdvection/Sinusoid1D.yaml
@@ -47,7 +47,7 @@ SpatialDiscretization:
       SubcellToDgReconstructionMethod: DimByDim
       UseHalo: false
       OnlyDgBlocksAndGroups: None
-      FiniteDifferenceDerivativeOrder: Auto
+      FiniteDifferenceDerivativeOrder: 2
     TciOptions:
       UCutoff: 1.0e-10
   SubcellSolver:

--- a/tests/Unit/Evolution/DgSubcell/Actions/Test_Initialize.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Actions/Test_Initialize.cpp
@@ -216,7 +216,7 @@ void test(const bool always_use_subcell, const bool interior_element,
                allow_subcell_in_block
                    ? std::optional<std::vector<std::string>>{}
                    : std::optional{std::vector<std::string>{"Block0"}},
-               std::nullopt},
+               ::fd::DerivativeOrder::Two},
            TestCreator<Dim>{}}}};
   Metavariables<Dim, TciFails>::DgInitialDataTci::invoked = false;
 

--- a/tests/Unit/Evolution/DgSubcell/Actions/Test_TciAndRollback.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Actions/Test_TciAndRollback.cpp
@@ -279,7 +279,7 @@ void test_impl(const bool rdmp_fails, const bool tci_fails,
               disable_subcell_in_block
                   ? std::optional{std::vector<std::string>{"Block1"}}
                   : std::optional<std::vector<std::string>>{},
-              std::nullopt},
+              ::fd::DerivativeOrder::Two},
           TestCreator<Dim>{}};
 
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<metavars>;

--- a/tests/Unit/Evolution/DgSubcell/Actions/Test_TciAndSwitchToDg.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Actions/Test_TciAndSwitchToDg.cpp
@@ -240,7 +240,7 @@ void test_impl(
           test_block_id_assert
               ? std::optional{std::vector<std::string>{"Block0"}}
               : std::optional<std::vector<std::string>>{},
-          std::nullopt},
+          ::fd::DerivativeOrder::Two},
       TestCreator<Dim>{}}}};
 
   TimeStepId time_step_id{true, self_starting ? -1 : 1,

--- a/tests/Unit/Evolution/DgSubcell/Test_PrepareNeighborData.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Test_PrepareNeighborData.cpp
@@ -201,7 +201,7 @@ void test(const bool all_neighbors_are_doing_dg) {
               all_neighbors_are_doing_dg
                   ? std::optional{std::vector<std::string>{"Block1"}}
                   : std::optional<std::vector<std::string>>{},
-              std::nullopt},
+              ::fd::DerivativeOrder::Two},
           TestCreator<Dim>{}};
 
   auto box =

--- a/tests/Unit/Evolution/DgSubcell/Test_SubcellOptions.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Test_SubcellOptions.cpp
@@ -23,72 +23,76 @@ void test_impl(const std::vector<double>& expected_values,
   const fd::ReconstructionMethod recons_method =
       fd::ReconstructionMethod::AllDimsAtOnce;
 
-  CHECK(SubcellOptions(expected_values[0], expected_values[1],
-                       expected_values[2], expected_values[3],
-                       expected_values[4], expected_values[5], false,
-                       recons_method, false, std::nullopt, std::nullopt) !=
+  CHECK(SubcellOptions(
+            expected_values[0], expected_values[1], expected_values[2],
+            expected_values[3], expected_values[4], expected_values[5], false,
+            recons_method, false, std::nullopt, ::fd::DerivativeOrder::Two) !=
         SubcellOptions(values[0], values[1], values[2], values[3], values[4],
                        values[5], false, recons_method, false, std::nullopt,
-                       std::nullopt));
+                       ::fd::DerivativeOrder::Two));
+  CHECK_FALSE(SubcellOptions(expected_values[0], expected_values[1],
+                             expected_values[2], expected_values[3],
+                             expected_values[4], expected_values[5], false,
+                             recons_method, false, std::nullopt,
+                             ::fd::DerivativeOrder::Two) ==
+              SubcellOptions(values[0], values[1], values[2], values[3],
+                             values[4], values[5], false, recons_method, false,
+                             std::nullopt, ::fd::DerivativeOrder::Two));
+
+  CHECK(SubcellOptions(
+            expected_values[0], expected_values[1], expected_values[2],
+            expected_values[3], expected_values[4], expected_values[5], false,
+            recons_method, false, std::nullopt, ::fd::DerivativeOrder::Two) !=
+        SubcellOptions(
+            expected_values[0], expected_values[1], expected_values[2],
+            expected_values[3], expected_values[4], expected_values[5], true,
+            recons_method, false, std::nullopt, ::fd::DerivativeOrder::Two));
   CHECK_FALSE(
       SubcellOptions(expected_values[0], expected_values[1], expected_values[2],
                      expected_values[3], expected_values[4], expected_values[5],
-                     false, recons_method, false, std::nullopt, std::nullopt) ==
-      SubcellOptions(values[0], values[1], values[2], values[3], values[4],
-                     values[5], false, recons_method, false, std::nullopt,
-                     std::nullopt));
+                     false, recons_method, false, std::nullopt,
+                     ::fd::DerivativeOrder::Two) ==
+      SubcellOptions(expected_values[0], expected_values[1], expected_values[2],
+                     expected_values[3], expected_values[4], expected_values[5],
+                     true, recons_method, false, std::nullopt,
+                     ::fd::DerivativeOrder::Two));
 
   CHECK(
       SubcellOptions(expected_values[0], expected_values[1], expected_values[2],
                      expected_values[3], expected_values[4], expected_values[5],
-                     false, recons_method, false, std::nullopt, std::nullopt) !=
-      SubcellOptions(expected_values[0], expected_values[1], expected_values[2],
-                     expected_values[3], expected_values[4], expected_values[5],
-                     true, recons_method, false, std::nullopt, std::nullopt));
-  CHECK_FALSE(
-      SubcellOptions(expected_values[0], expected_values[1], expected_values[2],
-                     expected_values[3], expected_values[4], expected_values[5],
-                     false, recons_method, false, std::nullopt, std::nullopt) ==
-      SubcellOptions(expected_values[0], expected_values[1], expected_values[2],
-                     expected_values[3], expected_values[4], expected_values[5],
-                     true, recons_method, false, std::nullopt, std::nullopt));
-
-  CHECK(
-      SubcellOptions(expected_values[0], expected_values[1], expected_values[2],
-                     expected_values[3], expected_values[4], expected_values[5],
-                     false, recons_method, false, std::nullopt, std::nullopt) !=
+                     false, recons_method, false, std::nullopt,
+                     ::fd::DerivativeOrder::Two) !=
       SubcellOptions(expected_values[0], expected_values[1], expected_values[2],
                      expected_values[3], expected_values[4], expected_values[5],
                      false, fd::ReconstructionMethod::DimByDim, false,
-                     std::nullopt, std::nullopt));
+                     std::nullopt, ::fd::DerivativeOrder::Two));
   CHECK_FALSE(
       SubcellOptions(expected_values[0], expected_values[1], expected_values[2],
                      expected_values[3], expected_values[4], expected_values[5],
-                     false, recons_method, false, std::nullopt, std::nullopt) ==
+                     false, recons_method, false, std::nullopt,
+                     ::fd::DerivativeOrder::Two) ==
       SubcellOptions(expected_values[0], expected_values[1], expected_values[2],
                      expected_values[3], expected_values[4], expected_values[5],
                      false, fd::ReconstructionMethod::DimByDim, false,
-                     std::nullopt, std::nullopt));
+                     std::nullopt, ::fd::DerivativeOrder::Two));
   CHECK_FALSE(
       SubcellOptions(expected_values[0], expected_values[1], expected_values[2],
                      expected_values[3], expected_values[4], expected_values[5],
-                     false, recons_method, false, std::nullopt, std::nullopt) ==
+                     false, recons_method, false, std::nullopt,
+                     ::fd::DerivativeOrder::Two) ==
       SubcellOptions(expected_values[0], expected_values[1], expected_values[2],
                      expected_values[3], expected_values[4], expected_values[5],
-                     false, recons_method, true, std::nullopt, std::nullopt));
+                     false, recons_method, true, std::nullopt,
+                     ::fd::DerivativeOrder::Two));
   CHECK_FALSE(
       SubcellOptions(expected_values[0], expected_values[1], expected_values[2],
                      expected_values[3], expected_values[4], expected_values[5],
-                     false, recons_method, false, std::nullopt, 6) ==
+                     false, recons_method, false, std::nullopt,
+                     ::fd::DerivativeOrder::Four) ==
       SubcellOptions(expected_values[0], expected_values[1], expected_values[2],
                      expected_values[3], expected_values[4], expected_values[5],
-                     false, recons_method, false, std::nullopt, std::nullopt));
-
-  CHECK_THROWS_WITH(
-      SubcellOptions(values[0], values[1], values[2], values[3], values[4],
-                     values[5], false, recons_method, false, std::nullopt, 5),
-      Catch::Matchers::Contains(
-          "The finite difference order must be Auto or one of"));
+                     false, recons_method, false, std::nullopt,
+                     ::fd::DerivativeOrder::Two));
 }
 
 SPECTRE_TEST_CASE("Unit.Evolution.Subcell.SubcellOptions",
@@ -99,10 +103,11 @@ SPECTRE_TEST_CASE("Unit.Evolution.Subcell.SubcellOptions",
     test_impl(expected_values, i);
   }
 
-  const SubcellOptions options(
-      expected_values[0], expected_values[1], expected_values[2],
-      expected_values[3], expected_values[4], expected_values[5], true,
-      fd::ReconstructionMethod::DimByDim, true, std::nullopt, 4);
+  const SubcellOptions options(expected_values[0], expected_values[1],
+                               expected_values[2], expected_values[3],
+                               expected_values[4], expected_values[5], true,
+                               fd::ReconstructionMethod::DimByDim, true,
+                               std::nullopt, ::fd::DerivativeOrder::Four);
   const SubcellOptions deserialized_options =
       serialize_and_deserialize(options);
   CHECK(options == deserialized_options);

--- a/tests/Unit/Evolution/Systems/Burgers/Subcell/Test_TciOnDgGrid.cpp
+++ b/tests/Unit/Evolution/Systems/Burgers/Subcell/Test_TciOnDgGrid.cpp
@@ -60,7 +60,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Burgers.Subcell.TciOnDgGrid",
         evolution::dg::subcell::fd::ReconstructionMethod::DimByDim,
         false,
         std::nullopt,
-        std::nullopt};
+        fd::DerivativeOrder::Two};
 
     const bool element_stays_on_dg = false;
     const std::tuple<bool, evolution::dg::subcell::RdmpTciData> result =

--- a/tests/Unit/Evolution/Systems/Burgers/Subcell/Test_TciOnFdGrid.cpp
+++ b/tests/Unit/Evolution/Systems/Burgers/Subcell/Test_TciOnFdGrid.cpp
@@ -67,7 +67,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Burgers.Subcell.TciOnFdGrid",
         evolution::dg::subcell::fd::ReconstructionMethod::DimByDim,
         false,
         std::nullopt,
-        std::nullopt};
+        fd::DerivativeOrder::Two};
     const std::tuple<bool, evolution::dg::subcell::RdmpTciData> result =
         Burgers::subcell::TciOnFdGrid::apply(
             u, dg_mesh, subcell_mesh, past_rdmp_tci_data, subcell_options,

--- a/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/Test_NeighborPackagedData.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/Test_NeighborPackagedData.cpp
@@ -327,7 +327,7 @@ double test(const size_t num_dg_pts) {
       evolution::dg::subcell::SubcellOptions{
           1.0e-3, 1.0e-4, 1.0e-3, 1.0e-4, 4.0, 4.0, false,
           evolution::dg::subcell::fd::ReconstructionMethod::DimByDim, false,
-          std::nullopt, std::nullopt});
+          std::nullopt, ::fd::DerivativeOrder::Two});
 
   db::mutate_apply<ValenciaDivClean::ConservativeFromPrimitive>(
       make_not_null(&box));

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_NeighborPackagedData.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_NeighborPackagedData.cpp
@@ -273,7 +273,7 @@ double test(const size_t num_dg_pts) {
       evolution::dg::subcell::SubcellOptions{
           1.0e-3, 1.0e-4, 1.0e-3, 1.0e-4, 4.0, 4.0, false,
           evolution::dg::subcell::fd::ReconstructionMethod::DimByDim, false,
-          std::nullopt, std::nullopt});
+          std::nullopt, ::fd::DerivativeOrder::Two});
   db::mutate_apply<ConservativeFromPrimitive>(make_not_null(&box));
 
   std::vector<std::pair<Direction<3>, ElementId<3>>>

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_TciOnDgGrid.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_TciOnDgGrid.cpp
@@ -120,7 +120,7 @@ void test(const TestThis test_this, const int expected_tci_status,
       evolution::dg::subcell::fd::ReconstructionMethod::DimByDim,
       false,
       std::nullopt,
-      std::nullopt};
+      fd::DerivativeOrder::Two};
 
   auto box = db::create<db::AddSimpleTags<
       ::Tags::Variables<typename ConsVars::tags_list>,

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_TciOnFdGrid.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_TciOnFdGrid.cpp
@@ -66,7 +66,7 @@ void test(const TestThis test_this, const int expected_tci_status) {
       evolution::dg::subcell::fd::ReconstructionMethod::DimByDim,
       false,
       std::nullopt,
-      std::nullopt};
+      fd::DerivativeOrder::Two};
 
   auto box = db::create<db::AddSimpleTags<
       grmhd::ValenciaDivClean::Tags::TildeD,

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/Subcell/Test_NeighborPackagedData.cpp
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/Subcell/Test_NeighborPackagedData.cpp
@@ -256,7 +256,7 @@ double test(const size_t num_dg_pts) {
       evolution::dg::subcell::SubcellOptions{
           1.0e-3, 1.0e-4, 1.0e-3, 1.0e-4, 4.0, 4.0, false,
           evolution::dg::subcell::fd::ReconstructionMethod::DimByDim, false,
-          std::nullopt, std::nullopt});
+          std::nullopt, ::fd::DerivativeOrder::Two});
 
   db::mutate_apply<NewtonianEuler::ConservativeFromPrimitive<Dim>>(
       make_not_null(&box));

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/Subcell/Test_TciOnDgGrid.cpp
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/Subcell/Test_TciOnDgGrid.cpp
@@ -89,7 +89,7 @@ void test(const TestThis test_this) {
       evolution::dg::subcell::fd::ReconstructionMethod::DimByDim,
       false,
       std::nullopt,
-      std::nullopt};
+      fd::DerivativeOrder::Two};
 
   auto box = db::create<db::AddSimpleTags<
       ::Tags::Variables<cons_tags>, ::Tags::Variables<prim_tags>,

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/Subcell/Test_TciOnFdGrid.cpp
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/Subcell/Test_TciOnFdGrid.cpp
@@ -73,7 +73,7 @@ void test(const TestThis test_this) {
       evolution::dg::subcell::fd::ReconstructionMethod::DimByDim,
       false,
       std::nullopt,
-      std::nullopt};
+      fd::DerivativeOrder::Two};
 
   if (test_this == TestThis::PerssonEnergyDensity) {
     get(get<Pressure>(subcell_prim))[subcell_mesh.number_of_grid_points() / 2] =

--- a/tests/Unit/Evolution/Systems/ScalarAdvection/Subcell/Test_NeighborPackagedData.cpp
+++ b/tests/Unit/Evolution/Systems/ScalarAdvection/Subcell/Test_NeighborPackagedData.cpp
@@ -203,7 +203,7 @@ void test_neighbor_packaged_data(const size_t num_dg_pts_per_dimension,
       evolution::dg::subcell::SubcellOptions{
           1.0e-3, 1.0e-4, 1.0e-3, 1.0e-4, 4.0, 4.0, false,
           evolution::dg::subcell::fd::ReconstructionMethod::DimByDim, false,
-          std::nullopt, std::nullopt});
+          std::nullopt, ::fd::DerivativeOrder::Two});
 
   // Compute face-centered velocity field and add it to the box. This action
   // needs to be called in prior since NeighborPackagedData::apply() internally

--- a/tests/Unit/Evolution/Systems/ScalarAdvection/Subcell/Test_TciOnDgGrid.cpp
+++ b/tests/Unit/Evolution/Systems/ScalarAdvection/Subcell/Test_TciOnDgGrid.cpp
@@ -69,7 +69,7 @@ void test(const TestThis& test_this) {
       evolution::dg::subcell::fd::ReconstructionMethod::DimByDim,
       false,
       std::nullopt,
-      std::nullopt};
+      fd::DerivativeOrder::Two};
 
   const bool element_stays_on_dg = false;
   const std::tuple<bool, evolution::dg::subcell::RdmpTciData> result =

--- a/tests/Unit/Evolution/Systems/ScalarAdvection/Subcell/Test_TciOnFdGrid.cpp
+++ b/tests/Unit/Evolution/Systems/ScalarAdvection/Subcell/Test_TciOnFdGrid.cpp
@@ -75,7 +75,7 @@ void test(const TestThis& test_this) {
       evolution::dg::subcell::fd::ReconstructionMethod::DimByDim,
       false,
       std::nullopt,
-      std::nullopt};
+      fd::DerivativeOrder::Two};
 
   const std::tuple<bool, evolution::dg::subcell::RdmpTciData> result =
       ScalarAdvection::subcell::TciOnFdGrid<Dim>::apply(


### PR DESCRIPTION
## Proposed changes

This is the last bit of code I have for high & adaptive order FD derivatives. It'll still need to get added to GH+GRMHD, but that doesn't need to happen immediately.

The only major thing that doesn't work yet is high-order FD with DG-FD. I'll get that working next since that I think is just sending the right data in the right places.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
