### PR TITLE
Increase test timeout for gcc-10 Debug build

### DIFF
--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -336,6 +336,11 @@ jobs:
             COVERAGE: ON
             TEST_TIMEOUT_FACTOR: 3
             ccache_max_size: 2G
+          # This configuration seems to run consistently slower than newer gcc
+          # or clang builds, so we increase the test timeout a bit
+          - compiler: gcc-10
+            build_type: Debug
+            TEST_TIMEOUT_FACTOR: 2
           # Test with Python 3.7 so that we retain backwards compatibility. We
           # keep track of Python versions on supercomputers in this issue:
           # https://github.com/sxs-collaboration/spectre/issues/442


### PR DESCRIPTION
It times out consistently. While we should speed up the failing tests as well, this configuration seems to run slower than newer gcc or clang builds, so we increase the timeout a bit.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
