### PR TITLE
Allow specifying single RadialDist in Sphere

### DIFF
--- a/src/Domain/Creators/Sphere.hpp
+++ b/src/Domain/Creators/Sphere.hpp
@@ -255,14 +255,17 @@ class Sphere : public DomainCreator<3> {
   };
 
   struct RadialDistribution {
-    using type = std::vector<domain::CoordinateMaps::Distribution>;
+    using type =
+        std::variant<domain::CoordinateMaps::Distribution,
+                     std::vector<domain::CoordinateMaps::Distribution>>;
     static constexpr Options::String help = {
         "Select the radial distribution of grid points in each spherical "
         "shell. There must be N+1 radial distributions specified for N radial "
         "partitions. If the interior of the sphere is filled with a cube, the "
         "innermost shell must have a 'Linear' distribution because it changes "
-        "in sphericity."};
-    static size_t lower_bound_on_size() { return 1; }
+        "in sphericity. You can also specify just a single radial distribution "
+        "(not in a vector) which will use the same distribution for all "
+        "partitions."};
   };
 
   struct WhichWedges {
@@ -318,8 +321,8 @@ class Sphere : public DomainCreator<3> {
       bool use_equiangular_map,
       std::optional<EquatorialCompressionOptions> equatorial_compression = {},
       std::vector<double> radial_partitioning = {},
-      std::vector<domain::CoordinateMaps::Distribution> radial_distribution =
-          {domain::CoordinateMaps::Distribution::Linear},
+      const typename RadialDistribution::type& radial_distribution =
+          domain::CoordinateMaps::Distribution::Linear,
       ShellWedges which_wedges = ShellWedges::All,
       std::unique_ptr<domain::creators::time_dependence::TimeDependence<3>>
           time_dependence = nullptr,

--- a/tests/Unit/Domain/Structure/Test_ExcisionSphere.cpp
+++ b/tests/Unit/Domain/Structure/Test_ExcisionSphere.cpp
@@ -101,8 +101,8 @@ void test_abutting_direction_shell() {
         true,
         std::nullopt,
         {2.},
-        {domain::CoordinateMaps::Distribution::Linear,
-         domain::CoordinateMaps::Distribution::Linear}};
+        {std::vector{{domain::CoordinateMaps::Distribution::Linear,
+                      domain::CoordinateMaps::Distribution::Linear}}}};
     std::vector<domain::creators::Sphere> shells{};
     shells.push_back(std::move(shell_plain));
     shells.push_back(std::move(shell_partitioned));


### PR DESCRIPTION
## Proposed changes

When I have a lot of partitions, it got annoying to specify the distribution for each when they were all the same. This allows you to just specify one distribution and it'll be used for all the partitions.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
