### PR TITLE
Print pretty walltime in ObserveTimeStep event

### DIFF
--- a/src/ParallelAlgorithms/Events/ObserveTimeStep.hpp
+++ b/src/ParallelAlgorithms/Events/ObserveTimeStep.hpp
@@ -66,10 +66,9 @@ struct FormatTimeOutput
                          const double min_wall_time,
                          const double max_wall_time) const {
     std::stringstream ss;
-    ss  << "Simulation time: " << std::to_string(time)
-        << "\n  Wall time: " << std::to_string(min_wall_time)
-        << "s (min) - "
-        << std::to_string(max_wall_time) << "s (max)";
+    ss << "Simulation time: " << std::to_string(time)
+       << "\n  Wall time: " << std::to_string(min_wall_time) << "s (min) - "
+       << std::to_string(max_wall_time) << "s (max)";
     return ss.str();
   }
   // NOLINTNEXTLINE

--- a/src/ParallelAlgorithms/Events/ObserveTimeStep.hpp
+++ b/src/ParallelAlgorithms/Events/ObserveTimeStep.hpp
@@ -31,6 +31,7 @@
 #include "Time/Time.hpp"
 #include "Utilities/Functional.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
+#include "Utilities/System/ParallelInfo.hpp"
 #include "Utilities/TMPL.hpp"
 
 /// \cond
@@ -67,8 +68,8 @@ struct FormatTimeOutput
                          const double max_wall_time) const {
     std::stringstream ss;
     ss << "Simulation time: " << std::to_string(time)
-       << "\n  Wall time: " << std::to_string(min_wall_time) << "s (min) - "
-       << std::to_string(max_wall_time) << "s (max)";
+       << "\n  Wall time: " << sys::pretty_wall_time(min_wall_time)
+       << " (min) - " << sys::pretty_wall_time(max_wall_time) << " (max)";
     return ss.str();
   }
   // NOLINTNEXTLINE

--- a/tests/Unit/ParallelAlgorithms/Events/Test_ObserveTimeStep.cpp
+++ b/tests/Unit/ParallelAlgorithms/Events/Test_ObserveTimeStep.cpp
@@ -99,12 +99,11 @@ struct MockContributeReductionData {
     }
 
     if (formatter.has_value()) {
-      const auto formatted_msg = (*formatter)(
-        0.123, 3, 1.560, 3.141, 2.7818, 1023.3, 9.32, 4.148
-      );
+      const auto formatted_msg =
+          (*formatter)(0.123, 3, 1.560, 3.141, 2.7818, 1023.3, 9.32, 4.148);
       CHECK(formatted_msg ==
-        "Simulation time: 0.123000\n"
-        "  Wall time: 9.320000s (min) - 4.148000s (max)");
+            "Simulation time: 0.123000\n"
+            "  Wall time: 9.320000s (min) - 4.148000s (max)");
     }
   }
 };
@@ -160,7 +159,6 @@ struct Metavariables {
         Event,
         tmpl::list<Events::ObserveTimeStep<typename Metavariables::system>>>>;
   };
-
 };
 
 template <typename Observer>
@@ -183,29 +181,28 @@ void test_observe(const Observer& observer, const bool backwards_in_time,
                  Tags::TimeStep, System::variables_tag>;
   std::vector<db::compute_databox_type<tag_list>> element_boxes;
 
-  const auto create_element =
-      [&backwards_in_time, &element_boxes, &observation_time, &observer,
-       &runner,
-       &slab](const size_t num_points, TimeDelta::rational_t slab_fraction) {
-        if (backwards_in_time) {
-          slab_fraction *= -1;
-        }
-        auto box = db::create<tag_list>(
-            Metavariables{}, observation_time, slab.duration() * slab_fraction,
-            System::variables_tag::type(num_points));
+  const auto create_element = [&backwards_in_time, &element_boxes,
+                               &observation_time, &observer, &runner,
+                               &slab](const size_t num_points,
+                                      TimeDelta::rational_t slab_fraction) {
+    if (backwards_in_time) {
+      slab_fraction *= -1;
+    }
+    auto box = db::create<tag_list>(Metavariables{}, observation_time,
+                                    slab.duration() * slab_fraction,
+                                    System::variables_tag::type(num_points));
 
-        const auto ids_to_register =
-            observers::get_registration_observation_type_and_key(observer, box);
-        CHECK(ids_to_register->first ==
-              observers::TypeOfObservation::Reduction);
-        CHECK(ids_to_register->second ==
-              observers::ObservationKey("/time_step_subfile.dat"));
+    const auto ids_to_register =
+        observers::get_registration_observation_type_and_key(observer, box);
+    CHECK(ids_to_register->first == observers::TypeOfObservation::Reduction);
+    CHECK(ids_to_register->second ==
+          observers::ObservationKey("/time_step_subfile.dat"));
 
-        element_boxes.push_back(std::move(box));
+    element_boxes.push_back(std::move(box));
 
-        ActionTesting::emplace_component<element_component>(
-            &runner, element_boxes.size() - 1);
-      };
+    ActionTesting::emplace_component<element_component>(
+        &runner, element_boxes.size() - 1);
+  };
 
   create_element(5, {1, 20});
   create_element(30, {1, 2});

--- a/tests/Unit/ParallelAlgorithms/Events/Test_ObserveTimeStep.cpp
+++ b/tests/Unit/ParallelAlgorithms/Events/Test_ObserveTimeStep.cpp
@@ -103,7 +103,7 @@ struct MockContributeReductionData {
           (*formatter)(0.123, 3, 1.560, 3.141, 2.7818, 1023.3, 9.32, 4.148);
       CHECK(formatted_msg ==
             "Simulation time: 0.123000\n"
-            "  Wall time: 9.320000s (min) - 4.148000s (max)");
+            "  Wall time: 00:00:09 (min) - 00:00:04 (max)");
     }
   }
 };


### PR DESCRIPTION
## Proposed changes

The current format
```
Simulation time: 188.500000
  Wall time: 84983.884055s (min) - 85067.733437s (max)
```

is pretty ugly and I don't think we'll ever need sub-second resolution for this. In my opinion, the following is much easier to read

```
Simulation time: 188.500000
  Wall time: 23:36:23 (min) - 23:37:47 (max)
```

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
