### PR TITLE
No fd element with dg block neighbor at initialize

### DIFF
--- a/src/Evolution/DgSubcell/Actions/TciAndRollback.hpp
+++ b/src/Evolution/DgSubcell/Actions/TciAndRollback.hpp
@@ -135,7 +135,7 @@ struct TciAndRollback {
     const bool bordering_dg_block = alg::any_of(
         element.neighbors(),
         [&subcell_options](const auto& direction_and_neighbor) {
-          const bool first_block_id =
+          const size_t first_block_id =
               direction_and_neighbor.second.ids().begin()->block_id();
           return std::binary_search(subcell_options.only_dg_block_ids().begin(),
                                     subcell_options.only_dg_block_ids().end(),

--- a/tests/Unit/Evolution/DgSubcell/Actions/Test_TciAndRollback.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Actions/Test_TciAndRollback.cpp
@@ -327,7 +327,7 @@ void test_impl(const bool rdmp_fails, const bool tci_fails,
   const bool bordering_dg_block = alg::any_of(
       element.neighbors(),
       [&subcell_options](const auto& direction_and_neighbor) {
-        const bool first_block_id =
+        const size_t first_block_id =
             direction_and_neighbor.second.ids().begin()->block_id();
         return alg::found(subcell_options.only_dg_block_ids(), first_block_id);
       });


### PR DESCRIPTION
## Proposed changes

1. Prevent elements from _initializing_ as FD when bordering a DG neighbor.  Likewise, make sure this check supersedes the `always_use_subcell` parameter.
2. Fix a bug that had block id as bool instead of size_t in `TciAndRollback.hpp`.
3. Rename `subcell_allowed_in_block` to `subcell_allowed_in_element`.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

@nilsvu this may alleviate the artifacts you have been seeing with the head on NSNS evolution.

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
