### PR TITLE
Clean up the time dependent options for BCO domains

### DIFF
--- a/src/Domain/Creators/BinaryCompactObject.cpp
+++ b/src/Domain/Creators/BinaryCompactObject.cpp
@@ -288,8 +288,8 @@ BinaryCompactObject::BinaryCompactObject(
 // Time-dependent constructor, with additional options for specifying
 // the time-dependent maps
 BinaryCompactObject::BinaryCompactObject(
-    double initial_time, double expansion_map_outer_boundary,
-    double initial_expansion, double initial_expansion_velocity,
+    double initial_time, double initial_expansion,
+    double initial_expansion_velocity,
     double asymptotic_velocity_outer_boundary,
     double decay_timescale_outer_boundary_velocity,
     std::array<double, 3> initial_angular_velocity,
@@ -312,7 +312,6 @@ BinaryCompactObject::BinaryCompactObject(
                           std::move(outer_boundary_condition), context) {
   enable_time_dependence_ = true;
   initial_time_ = initial_time;
-  expansion_map_outer_boundary_ = expansion_map_outer_boundary;
   initial_expansion_ = initial_expansion;
   initial_expansion_velocity_ = initial_expansion_velocity;
   asymptotic_velocity_outer_boundary_ = asymptotic_velocity_outer_boundary;
@@ -563,7 +562,7 @@ Domain<3> BinaryCompactObject::create_domain() const {
         distorted_to_inertial_block_maps{number_of_blocks_};
 
     CubicScaleMap expansion_map{
-        expansion_map_outer_boundary_, expansion_function_of_time_name_,
+        outer_radius_, expansion_function_of_time_name_,
         expansion_function_of_time_name_ + "OuterBoundary"s};
     RotationMap3D rotation_map{rotation_function_of_time_name_};
 

--- a/src/Domain/Creators/BinaryCompactObject.hpp
+++ b/src/Domain/Creators/BinaryCompactObject.hpp
@@ -425,15 +425,6 @@ class BinaryCompactObject : public DomainCreator<3> {
     using group = TimeDependentMaps;
   };
 
-  /// \brief The outer boundary or pivot point of the
-  /// `domain::CoordinateMaps::TimeDependent::CubicScale` map
-  struct ExpansionMapOuterBoundary {
-    using type = double;
-    static constexpr Options::String help = {
-        "Outer boundary or pivot point of the map"};
-    using group = ExpansionMap;
-    static std::string name() { return "OuterBoundary"; }
-  };
   /// \brief The initial value of the expansion factor.
   struct InitialExpansion {
     using type = double;
@@ -541,8 +532,8 @@ class BinaryCompactObject : public DomainCreator<3> {
           tmpl::list<>>>;
 
   using time_dependent_options =
-      tmpl::list<InitialTime, ExpansionMapOuterBoundary, InitialExpansion,
-                 InitialExpansionVelocity, AsymptoticVelocityOuterBoundary,
+      tmpl::list<InitialTime, InitialExpansion, InitialExpansionVelocity,
+                 AsymptoticVelocityOuterBoundary,
                  DecayTimescaleOuterBoundaryVelocity, InitialAngularVelocity,
                  InitialSizeMapValues, InitialSizeMapVelocities,
                  InitialSizeMapAccelerations>;
@@ -602,8 +593,8 @@ class BinaryCompactObject : public DomainCreator<3> {
   // Metavariables::domain::enable_time_dependent_maps == true),
   // with parameters corresponding to the additional options
   BinaryCompactObject(
-      double initial_time, double expansion_map_outer_boundary,
-      double initial_expansion, double initial_expansion_velocity,
+      double initial_time, double initial_expansion,
+      double initial_expansion_velocity,
       double asymptotic_velocity_outer_boundary,
       double decay_timescale_outer_boundary_velocity,
       std::array<double, 3> initial_angular_velocity,
@@ -689,8 +680,6 @@ class BinaryCompactObject : public DomainCreator<3> {
   // Variables for FunctionsOfTime options
   bool enable_time_dependence_{false};
   double initial_time_{std::numeric_limits<double>::signaling_NaN()};
-  double expansion_map_outer_boundary_{
-      std::numeric_limits<double>::signaling_NaN()};
   double initial_expansion_{std::numeric_limits<double>::signaling_NaN()};
   double initial_expansion_velocity_{
       std::numeric_limits<double>::signaling_NaN()};

--- a/src/Domain/Creators/BinaryCompactObject.hpp
+++ b/src/Domain/Creators/BinaryCompactObject.hpp
@@ -540,7 +540,7 @@ class BinaryCompactObject : public DomainCreator<3> {
 
   template <typename Metavariables>
   using options = tmpl::conditional_t<
-      domain::creators::detail::enable_time_dependent_maps_v<Metavariables>,
+      domain::creators::bco::enable_time_dependent_maps_v<Metavariables>,
       tmpl::append<time_dependent_options,
                    time_independent_options<Metavariables>>,
       time_independent_options<Metavariables>>;

--- a/src/Domain/Creators/BinaryCompactObjectHelpers.cpp
+++ b/src/Domain/Creators/BinaryCompactObjectHelpers.cpp
@@ -1,0 +1,105 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Domain/Creators/BinaryCompactObjectHelpers.hpp"
+
+#include <array>
+#include <limits>
+#include <memory>
+#include <string>
+#include <unordered_map>
+
+#include "DataStructures/DataVector.hpp"
+#include "Domain/FunctionsOfTime/FixedSpeedCubic.hpp"
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "Domain/FunctionsOfTime/PiecewisePolynomial.hpp"
+#include "Domain/FunctionsOfTime/QuaternionFunctionOfTime.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace domain::creators::bco {
+TimeDependentMapOptions::TimeDependentMapOptions(
+    double initial_time, ExpansionMapOptions expansion_map_options,
+    std::array<double, 3> initial_angular_velocity,
+    std::array<double, 3> initial_size_values_A,
+    std::array<double, 3> initial_size_values_B)
+    : initial_time_(initial_time),
+      expansion_map_options_(expansion_map_options),
+      initial_angular_velocity_(initial_angular_velocity),
+      initial_size_values_(
+          std::array{initial_size_values_A, initial_size_values_B}) {}
+
+std::unordered_map<std::string,
+                   std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
+TimeDependentMapOptions::create_functions_of_time(
+    const std::unordered_map<std::string, double>& initial_expiration_times)
+    const {
+  std::unordered_map<std::string,
+                     std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
+      result{};
+
+  // Get existing function of time names that are used for the maps and assign
+  // their initial expiration time to infinity (i.e. not expiring)
+  std::unordered_map<std::string, double> expiration_times{
+      {expansion_name, std::numeric_limits<double>::infinity()},
+      {rotation_name, std::numeric_limits<double>::infinity()},
+      {gsl::at(size_names, 0), std::numeric_limits<double>::infinity()},
+      {gsl::at(size_names, 1), std::numeric_limits<double>::infinity()}};
+
+  // If we have control systems, overwrite these expiration times with the ones
+  // supplied by the control system
+  for (const auto& [name, expr_time] : initial_expiration_times) {
+    expiration_times[name] = expr_time;
+  }
+
+  // ExpansionMap FunctionOfTime for the function \f$a(t)\f$ in the
+  // domain::CoordinateMaps::TimeDependent::CubicScale map
+  result[expansion_name] =
+      std::make_unique<FunctionsOfTime::PiecewisePolynomial<2>>(
+          initial_time_,
+          std::array<DataVector, 3>{
+              {{gsl::at(expansion_map_options_.initial_values, 0)},
+               {gsl::at(expansion_map_options_.initial_values, 1)},
+               {0.0}}},
+          expiration_times.at(expansion_name));
+
+  // ExpansionMap FunctionOfTime for the function \f$b(t)\f$ in the
+  // domain::CoordinateMaps::TimeDependent::CubicScale map
+  result[expansion_outer_boundary_name] =
+      std::make_unique<FunctionsOfTime::FixedSpeedCubic>(
+          1.0, initial_time_, expansion_map_options_.outer_boundary_velocity,
+          expansion_map_options_.outer_boundary_decay_time);
+
+  // RotationMap FunctionOfTime for the rotation angles about each
+  // axis.  The initial rotation angles don't matter as we never
+  // actually use the angles themselves. We only use their derivatives
+  // (omega) to determine map parameters. In theory we could determine
+  // each initial angle from the input axis-angle representation, but
+  // we don't need to.
+  result[rotation_name] =
+      std::make_unique<FunctionsOfTime::QuaternionFunctionOfTime<3>>(
+          initial_time_,
+          std::array<DataVector, 1>{DataVector{1.0, 0.0, 0.0, 0.0}},
+          std::array<DataVector, 4>{{{3, 0.0},
+                                     {gsl::at(initial_angular_velocity_, 0),
+                                      gsl::at(initial_angular_velocity_, 1),
+                                      gsl::at(initial_angular_velocity_, 2)},
+                                     {3, 0.0},
+                                     {3, 0.0}}},
+          expiration_times.at(rotation_name));
+
+  // CompressionMap FunctionOfTime for objects A and B
+  for (size_t i = 0; i < size_names.size(); i++) {
+    result[gsl::at(size_names, i)] =
+        std::make_unique<FunctionsOfTime::PiecewisePolynomial<3>>(
+            initial_time_,
+            std::array<DataVector, 4>{
+                {{gsl::at(gsl::at(initial_size_values_, i), 0)},
+                 {gsl::at(gsl::at(initial_size_values_, i), 1)},
+                 {gsl::at(gsl::at(initial_size_values_, i), 2)},
+                 {0.0}}},
+            expiration_times.at(gsl::at(size_names, i)));
+  }
+
+  return result;
+}
+}  // namespace domain::creators::bco

--- a/src/Domain/Creators/BinaryCompactObjectHelpers.hpp
+++ b/src/Domain/Creators/BinaryCompactObjectHelpers.hpp
@@ -3,7 +3,18 @@
 
 #pragma once
 
+#include <array>
+#include <limits>
+#include <memory>
+#include <string>
 #include <type_traits>
+#include <unordered_map>
+
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "Domain/Structure/ObjectLabel.hpp"
+#include "Options/Options.hpp"
+#include "Utilities/GetOutput.hpp"
+#include "Utilities/TMPL.hpp"
 
 /// Namespace used to hold things used in both the BinaryCompactObject and
 /// CylindricalBinaryCompactObject domain creators.
@@ -22,4 +33,146 @@ struct enable_time_dependent_maps<Metavariables,
 template <typename Metavariables>
 constexpr bool enable_time_dependent_maps_v =
     enable_time_dependent_maps<Metavariables>::value;
+
+/*!
+ * \brief This holds all options related to the time dependent maps of the
+ * binary compact object domains.
+ *
+ * \details Since both domains will have the same (overall) time dependent maps,
+ * their options are going to be the same as well.
+ *
+ * This class will also create the FunctionsOfTime needed for the binary compact
+ * object domains.
+ *
+ * \note This struct contains no information about what blocks the time
+ * dependent maps will go in.
+ */
+struct TimeDependentMapOptions {
+  /// \brief The initial time of the functions of time.
+  struct InitialTime {
+    using type = double;
+    static constexpr Options::String help = {
+        "The initial time of the functions of time"};
+  };
+
+  /// \brief Options for the expansion map.
+  /// The outer boundary radius of the map is always set to
+  /// the outer boundary of the Domain, so there is no option
+  /// here to set the outer boundary radius.
+  struct ExpansionMapOptions {
+    static constexpr Options::String help = {"Options for the expansion map."};
+    struct InitialValues {
+      using type = std::array<double, 2>;
+      static constexpr Options::String help = {
+          "Initial value and deriv of expansion."};
+    };
+    struct AsymptoticVelocityOuterBoundary {
+      using type = double;
+      static constexpr Options::String help = {
+          "The asymptotic velocity of the outer boundary."};
+    };
+    struct DecayTimescaleOuterBoundaryVelocity {
+      using type = double;
+      static constexpr Options::String help = {
+          "The timescale for how fast the outer boundary velocity approaches "
+          "its asymptotic value."};
+    };
+    using options = tmpl::list<InitialValues, AsymptoticVelocityOuterBoundary,
+                               DecayTimescaleOuterBoundaryVelocity>;
+
+    std::array<double, 2> initial_values{
+        std::numeric_limits<double>::signaling_NaN(),
+        std::numeric_limits<double>::signaling_NaN()};
+    double outer_boundary_velocity{
+        std::numeric_limits<double>::signaling_NaN()};
+    double outer_boundary_decay_time{
+        std::numeric_limits<double>::signaling_NaN()};
+  };
+
+  struct ExpansionMap {
+    using type = ExpansionMapOptions;
+    static constexpr Options::String help = {"Options for CubicScale map."};
+  };
+
+  struct RotationMap {
+    static constexpr Options::String help = {
+        "Options for a time-dependent rotation map about an arbitrary axis."};
+  };
+  struct InitialAngularVelocity {
+    using type = std::array<double, 3>;
+    static constexpr Options::String help = {"The initial angular velocity."};
+    using group = RotationMap;
+  };
+
+  template <domain::ObjectLabel Object>
+  struct SizeMap {
+    static std::string name() { return "SizeMap" + get_output(Object); }
+    static constexpr Options::String help = {
+        "Options for a time-dependent size map about the specified object."};
+  };
+
+  template <domain::ObjectLabel Object>
+  struct SizeMapInitialValues {
+    static std::string name() { return "InitialValues"; }
+    using type = std::array<double, 3>;
+    static constexpr Options::String help = {
+        "Initial value and two derivatives of the size map."};
+    using group = SizeMap<Object>;
+  };
+
+  using options = tmpl::list<InitialTime, ExpansionMap, InitialAngularVelocity,
+                             SizeMapInitialValues<domain::ObjectLabel::A>,
+                             SizeMapInitialValues<domain::ObjectLabel::B>>;
+  static constexpr Options::String help{
+      "The options for all time dependent maps in a binary compact object "
+      "domain."};
+
+  TimeDependentMapOptions() = default;
+
+  TimeDependentMapOptions(double initial_time,
+                          ExpansionMapOptions expansion_map_options,
+                          std::array<double, 3> initial_angular_velocity,
+                          std::array<double, 3> initial_size_values_A,
+                          std::array<double, 3> initial_size_values_B);
+
+  /*!
+   * \brief Create the function of time map using the options that were
+   * provided to this class.
+   *
+   * Currently, this will add:
+   *
+   * - Expansion: `PiecewisePolynomial<2>`
+   * - ExpansionOuterBoundary: `FixedSpeedCubic`
+   * - Rotation: `QuaternionFunctionOfTime<3>`
+   * - SizeA/B: `PiecewisePolynomial<3>`
+   */
+  std::unordered_map<std::string,
+                     std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
+  create_functions_of_time(const std::unordered_map<std::string, double>&
+                               initial_expiration_times) const;
+
+  // Names are public because they need to be used when constructing maps in the
+  // BCO domain creators themselves
+  inline static const std::string expansion_name{"Expansion"};
+  inline static const std::string expansion_outer_boundary_name{
+      "ExpansionOuterBoundary"};
+  inline static const std::string rotation_name{"Rotation"};
+  inline static const std::array<std::string, 2> size_names{{"SizeA", "SizeB"}};
+
+ private:
+  double initial_time_{std::numeric_limits<double>::signaling_NaN()};
+  ExpansionMapOptions expansion_map_options_{};
+  std::array<double, 3> initial_angular_velocity_{
+      std::numeric_limits<double>::signaling_NaN(),
+      std::numeric_limits<double>::signaling_NaN(),
+      std::numeric_limits<double>::signaling_NaN()};
+  std::array<std::array<double, 3>, 2> initial_size_values_{
+      std::array{std::numeric_limits<double>::signaling_NaN(),
+                 std::numeric_limits<double>::signaling_NaN(),
+                 std::numeric_limits<double>::signaling_NaN()},
+      std::array{std::numeric_limits<double>::signaling_NaN(),
+                 std::numeric_limits<double>::signaling_NaN(),
+                 std::numeric_limits<double>::signaling_NaN()}};
+};
+
 }  // namespace domain::creators::bco

--- a/src/Domain/Creators/BinaryCompactObjectHelpers.hpp
+++ b/src/Domain/Creators/BinaryCompactObjectHelpers.hpp
@@ -5,7 +5,9 @@
 
 #include <type_traits>
 
-namespace domain::creators::detail {
+/// Namespace used to hold things used in both the BinaryCompactObject and
+/// CylindricalBinaryCompactObject domain creators.
+namespace domain::creators::bco {
 // If `Metavariables` has a `domain` member struct and
 // `domain::enable_time_dependent_maps` is `true`, then
 // inherit from `std::true_type`; otherwise, inherit from `std::false_type`.
@@ -20,4 +22,4 @@ struct enable_time_dependent_maps<Metavariables,
 template <typename Metavariables>
 constexpr bool enable_time_dependent_maps_v =
     enable_time_dependent_maps<Metavariables>::value;
-}  // namespace domain::creators::detail
+}  // namespace domain::creators::bco

--- a/src/Domain/Creators/CMakeLists.txt
+++ b/src/Domain/Creators/CMakeLists.txt
@@ -10,6 +10,7 @@ spectre_target_sources(
   PRIVATE
   AlignedLattice.cpp
   BinaryCompactObject.cpp
+  BinaryCompactObjectHelpers.cpp
   Brick.cpp
   Cylinder.cpp
   CylindricalBinaryCompactObject.cpp

--- a/src/Domain/Creators/CylindricalBinaryCompactObject.hpp
+++ b/src/Domain/Creators/CylindricalBinaryCompactObject.hpp
@@ -396,7 +396,7 @@ class CylindricalBinaryCompactObject : public DomainCreator<3> {
 
   template <typename Metavariables>
   using basic_options = tmpl::conditional_t<
-      domain::creators::detail::enable_time_dependent_maps_v<Metavariables>,
+      domain::creators::bco::enable_time_dependent_maps_v<Metavariables>,
       tmpl::append<time_dependent_options, time_independent_options>,
       time_independent_options>;
 

--- a/tests/InputFiles/CurvedScalarWave/WorldtubeKerrSchild.yaml
+++ b/tests/InputFiles/CurvedScalarWave/WorldtubeKerrSchild.yaml
@@ -63,7 +63,6 @@ DomainCreator:
     TimeDependentMaps:
       InitialTime: 0.
       ExpansionMap:
-        OuterBoundary: 100.
         InitialExpansion: 1.
         InitialExpansionVelocity: 0.
         AsymptoticVelocityOuterBoundary: 0.

--- a/tests/InputFiles/CurvedScalarWave/WorldtubeKerrSchild.yaml
+++ b/tests/InputFiles/CurvedScalarWave/WorldtubeKerrSchild.yaml
@@ -63,16 +63,15 @@ DomainCreator:
     TimeDependentMaps:
       InitialTime: 0.
       ExpansionMap:
-        InitialExpansion: 1.
-        InitialExpansionVelocity: 0.
+        InitialValues: [1., 0.]
         AsymptoticVelocityOuterBoundary: 0.
         DecayTimescaleOuterBoundaryVelocity: 1.
       RotationMap:
         InitialAngularVelocity: [0., 0., 0.08944271909999159]
-      SizeMap:
-        InitialValues: [0., 0.]
-        InitialVelocities: [0., 0.]
-        InitialAccelerations: [0., 0.]
+      SizeMapA:
+        InitialValues: [0., 0., 0.]
+      SizeMapB:
+        InitialValues: [0., 0., 0.]
 
 SpatialDiscretization:
   BoundaryCorrection:

--- a/tests/InputFiles/ExportCoordinates/InputTimeDependent3D.yaml
+++ b/tests/InputFiles/ExportCoordinates/InputTimeDependent3D.yaml
@@ -47,16 +47,15 @@ DomainCreator:
     TimeDependentMaps:
       InitialTime: 0.0
       ExpansionMap:
-        InitialExpansion: 1.0
-        InitialExpansionVelocity: -4.6148457646200002e-05
+        InitialValues: [1.0, -4.6148457646200002e-05]
         AsymptoticVelocityOuterBoundary: -1.0e-6
         DecayTimescaleOuterBoundaryVelocity: 50.0
       RotationMap:
         InitialAngularVelocity: [0.0, 0.0, 1.5264577062000000e-02]
-      SizeMap:
-        InitialValues: [0.0, 0.0]
-        InitialVelocities: [0.0, 0.0]
-        InitialAccelerations: [0.0, 0.0]
+      SizeMapA:
+        InitialValues: [0.0, 0.0, 0.0]
+      SizeMapB:
+        InitialValues: [0.0, 0.0, 0.0]
 
 SpatialDiscretization:
   ActiveGrid: Dg

--- a/tests/InputFiles/ExportCoordinates/InputTimeDependent3D.yaml
+++ b/tests/InputFiles/ExportCoordinates/InputTimeDependent3D.yaml
@@ -47,7 +47,6 @@ DomainCreator:
     TimeDependentMaps:
       InitialTime: 0.0
       ExpansionMap:
-        OuterBoundary: 300.0
         InitialExpansion: 1.0
         InitialExpansionVelocity: -4.6148457646200002e-05
         AsymptoticVelocityOuterBoundary: -1.0e-6

--- a/tests/InputFiles/GeneralizedHarmonic/BinaryBlackHole.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/BinaryBlackHole.yaml
@@ -90,7 +90,6 @@ DomainCreator:
       ExpansionMap:
         InitialExpansion: 1.0
         InitialExpansionVelocity: 0.0
-        OuterBoundary: 1493.0
         AsymptoticVelocityOuterBoundary: -1.0e-6
         DecayTimescaleOuterBoundaryVelocity: 50.0
       RotationMap:

--- a/tests/InputFiles/GeneralizedHarmonic/BinaryBlackHole.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/BinaryBlackHole.yaml
@@ -88,16 +88,15 @@ DomainCreator:
     TimeDependentMaps:
       InitialTime: 0.0
       ExpansionMap:
-        InitialExpansion: 1.0
-        InitialExpansionVelocity: 0.0
+        InitialValues: [1.0, 0.0]
         AsymptoticVelocityOuterBoundary: -1.0e-6
         DecayTimescaleOuterBoundaryVelocity: 50.0
       RotationMap:
         InitialAngularVelocity: [0.0, 0.0, 0.0]
-      SizeMap:
-        InitialValues: [0.0, 0.0]
-        InitialVelocities: [0.0, 0.0]
-        InitialAccelerations: [0.0, 0.0]
+      SizeMapA:
+        InitialValues: [0.0, 0.0, 0.0]
+      SizeMapB:
+        InitialValues: [0.0, 0.0, 0.0]
 
 EventsAndDenseTriggers:
 

--- a/tests/InputFiles/GeneralizedHarmonic/CylindricalBinaryBlackHole.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/CylindricalBinaryBlackHole.yaml
@@ -1,0 +1,300 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+# Executable: EvolveGhBinaryBlackHole
+# Check: parse
+
+ResourceInfo:
+  AvoidGlobalProc0: false
+  Singletons: Auto
+
+Evolution:
+  InitialTime: 0.0
+  InitialTimeStep: 0.0002
+  InitialSlabSize: 0.25
+  StepChoosers:
+    - Increase:
+        Factor: 2
+    - ElementSizeCfl:
+        SafetyFactor: 0.5
+    - ErrorControl:
+        AbsoluteTolerance: 1e-8
+        RelativeTolerance: 1e-6
+        MaxFactor: 2
+        MinFactor: 0.25
+        SafetyFactor: 0.95
+  TimeStepper:
+    AdamsBashforth:
+      Order: 5
+
+DomainCreator:
+  CylindricalBinaryCompactObject:
+    CenterA: &CenterA [&XCoordA 7.683, 0.0, 0.0]
+    CenterB: &CenterB [&XCoordB -7.683, 0.0, 0.0]
+    RadiusA: &RadiusA 0.45825
+    RadiusB: &RadiusB 0.45825
+    IncludeInnerSphereA: true
+    IncludeInnerSphereB: true
+    IncludeOuterSphere: true
+    UseEquiangularMap: true
+    OuterRadius: 300.0
+    InitialRefinement: 2
+    InitialGridPoints: 7
+    BoundaryConditions:
+      InnerBoundary:
+        DemandOutgoingCharSpeeds:
+      OuterBoundary:
+        ConstraintPreservingBjorhus:
+          Type: ConstraintPreservingPhysical
+    TimeDependentMaps:
+      InitialTime: 0.0
+      ExpansionMap:
+        InitialValues: [1.0, -4.6148457646200002e-05]
+        AsymptoticVelocityOuterBoundary: -1.0e-6
+        DecayTimescaleOuterBoundaryVelocity: 50.0
+      RotationMap:
+        InitialAngularVelocity: [0.0, 0.0, 1.5264577062000000e-02]
+      SizeMapA:
+        InitialValues: [0.0, 0.0, 0.0]
+      SizeMapB:
+        InitialValues: [0.0, 0.0, 0.0]
+
+EventsAndDenseTriggers:
+
+# Set gauge and constraint damping parameters.
+# The values here are chosen empirically based on values that proved
+# successful in SpEC evolutions of binary black holes.
+# Note: Gaussian width = W / sqrt(34.54), so exp(-W^2/w^2) = 1e-15 at x=W,
+# is used in the damped-harmonic gauge parameters.
+# In SpEC, GaugeItems.input set what spectre calls W and spec calls
+# SecondaryWeightRmax. See
+# EvolutionSystems/GeneralizedHarmonic/DampedHarmonicGaugeItems.cpp
+# line 463 in https://github.com/sxs-collaboration/spec for where the Gaussian
+# is actually computed in SpEC.
+EvolutionSystem:
+  GeneralizedHarmonic:
+    GaugeCondition:
+      DampedHarmonic:
+        SpatialDecayWidth: 17.0152695482514 # From SpEC run: 100.0 / sqrt(34.54)
+        Amplitudes: [1.0, 1.0, 1.0]         # From SpEC run: damped harmonic
+        Exponents: [2, 2, 2]                # From SpEC run
+    DampingFunctionGamma0:
+      TimeDependentTripleGaussian:
+        Constant: 0.001             # 0.001 / (m_A + m_B)
+        Gaussian1:
+          Amplitude: 8.0             # 4.0 / m_A
+          Width: 3.5                 # 7.0 * m_A
+          Center: [*XCoordA, 0.0, 0.0] # [x_A, 0, 0]
+        Gaussian2:
+          Amplitude: 8.0             # 4.0 / m_B
+          Width: 3.5                 # 7.0 * m_B
+          Center: [*XCoordB, 0.0, 0.0]  # [x_B, 0, 0]
+        Gaussian3:
+          Amplitude: 0.75            # 0.75 / (m_A + m_B)
+          Width: 38.415              # 2.5 * (x_B - x_A)
+          Center: [0.0, 0.0, 0.0]
+    DampingFunctionGamma1:
+      GaussianPlusConstant:
+        Constant: -0.999
+        Amplitude: 0.999
+        Width: 153.66                # 10.0 * (x_B - x_A)
+        Center: [0.0, 0.0, 0.0]
+    DampingFunctionGamma2:
+      TimeDependentTripleGaussian:
+        Constant: 0.001              # 0.001 / (m_A + m_B)
+        Gaussian1:
+          Amplitude: 8.0             # 4.0 / m_A
+          Width: 3.5                 # 7.0 * m_A
+          Center: [*XCoordA, 0.0, 0.0] # [x_A, 0, 0]
+        Gaussian2:
+          Amplitude: 8.0             # 4.0 / m_B
+          Width: 3.5                 # 7.0 * m_B
+          Center: [*XCoordB, 0.0, 0.0]  # [x_B, 0, 0]
+        Gaussian3:
+          Amplitude: 0.75            # 0.75 / (m_A + m_B)
+          Width: 38.415              # 2.5 * (x_B - x_A)
+          Center: [0.0, 0.0, 0.0]
+
+PhaseChangeAndTriggers:
+
+SpatialDiscretization:
+  BoundaryCorrection:
+    UpwindPenalty:
+  DiscontinuousGalerkin:
+    Formulation: StrongInertial
+    Quadrature: GaussLobatto
+
+Filtering:
+  ExpFilter0:
+    Alpha: 36.0
+    HalfPower: 24
+    DisableForDebugging: True
+
+
+EventsAndTriggers:
+  - - Slabs:
+        EvenlySpaced:
+          Interval: 1
+          Offset: 0
+    - - ObserveNorms:
+          SubfileName: Norms
+          TensorsToObserve:
+          - Name: Lapse
+            NormType: L2Norm
+            Components: Individual
+          - Name: PointwiseL2Norm(GaugeConstraint)
+            NormType: L2Norm
+            Components: Sum
+          - Name: PointwiseL2Norm(ThreeIndexConstraint)
+            NormType: L2Norm
+            Components: Sum
+          - Name: PointwiseL2Norm(FourIndexConstraint)
+            NormType: L2Norm
+            Components: Sum
+  - - Slabs:
+        EvenlySpaced:
+          Interval: 20
+          Offset: 0
+    - - ObserveFields:
+          SubfileName: VolumeData
+          VariablesToObserve:
+            - Lapse
+            - Shift
+            - PointwiseL2Norm(GaugeConstraint)
+            - PointwiseL2Norm(ThreeIndexConstraint)
+            - PointwiseL2Norm(FourIndexConstraint)
+          InterpolateToMesh: None
+          CoordinatesFloatingPointType: Double
+          FloatingPointTypes: [Double]
+          OverrideObservationValue: None
+  - - Slabs:
+        EvenlySpaced:
+          Interval: 1
+          Offset: 0
+    - - ObservationAhA
+      - ObservationAhB
+  - - Slabs:
+        EvenlySpaced:
+          Interval: 100
+          Offset: 0
+    - - MonitorMemory:
+          ComponentsToMonitor: All
+  - - TimeCompares:
+        Comparison: GreaterThan
+        Value: 0.02
+    - - Completion
+
+Observers:
+  VolumeFileName: "GhBinaryBlackHoleVolumeData"
+  ReductionFileName: "GhBinaryBlackHoleReductionData"
+  SurfaceFileName: "GhBinaryBlackHoleSurfacesData"
+
+Interpolator:
+  DumpVolumeDataOnFailure: false
+
+ApparentHorizons:
+  ObservationAhA: &AhA
+    InitialGuess:
+      Lmax: 10
+      Radius: 2.2
+      Center: [*XCoordA, 0.0, 0.0]
+    FastFlow: &DefaultFastFlow
+      Flow: Fast
+      Alpha: 1.0
+      Beta: 0.5
+      AbsTol: 1e-12
+      TruncationTol: 1e-2
+      DivergenceTol: 1.2
+      DivergenceIter: 5
+      MaxIts: 100
+    Verbosity: Verbose
+  ObservationAhB: &AhB
+    InitialGuess:
+      Lmax: 10
+      Radius: 2.2
+      Center: [*XCoordB, 0.0, 0.0]
+    FastFlow: *DefaultFastFlow
+    Verbosity: Verbose
+  ControlSystemAhA: *AhA
+  ControlSystemAhB: *AhB
+
+InterpolationTargets:
+  BondiSachsInterpolation:
+    Lmax: 16
+    Radius: [100, 150, 200]
+    Center: [0, 0, 0]
+    AngularOrdering: Cce
+  ObservationExcisionBoundaryA:
+    Lmax: 10
+    Radius: *RadiusA
+    Center: *CenterA
+    AngularOrdering: Strahlkorper
+  ObservationExcisionBoundaryB:
+    Lmax: 10
+    Radius: *RadiusB
+    Center: *CenterB
+    AngularOrdering: Strahlkorper
+
+Cce:
+  BondiSachsOutputFilePrefix: "BondiSachs"
+
+ControlSystems:
+  WriteDataToDisk: true
+  MeasurementsPerUpdate: 4
+  Expansion:
+    IsActive: true
+    Averager:
+      AverageTimescaleFraction: 0.25
+      Average0thDeriv: false
+    Controller:
+      UpdateFraction: 0.03
+    TimescaleTuner:
+      InitialTimescales: [0.2]
+      MinTimescale: 1.0e-2
+      MaxTimescale: 10.0
+      IncreaseThreshold: 2.5e-4
+      DecreaseThreshold: 1.0e-3
+      IncreaseFactor: 1.01
+      DecreaseFactor: 0.98
+    ControlError:
+  Rotation:
+    IsActive: true
+    Averager:
+      AverageTimescaleFraction: 0.25
+      Average0thDeriv: false
+    Controller:
+      UpdateFraction: 0.03
+    TimescaleTuner:
+      InitialTimescales: [0.2, 0.2, 0.2]
+      MinTimescale: 1.0e-2
+      MaxTimescale: 10.0
+      IncreaseThreshold: 2.5e-4
+      DecreaseThreshold: 1.0e-3
+      IncreaseFactor: 1.01
+      DecreaseFactor: 0.98
+    ControlError:
+
+# initial_data.h5 should contain numerical initial data on a grid that covers
+# the domain given above
+# - One way to produce initial data is with the `SolveXcts` executable. See the
+#   example in `docs/Examples/BbhInitialData`.
+# - You can also produce initial data with SpEC, interpolate it (using SpEC) to
+#   the domain given above (using the `ExportCoordinates` executable to get the
+#   coordinates of all grid points in the domain), and then load it here by
+#   selecting either the GH variables (`SpacetimeMetric`, `Pi`, `Phi`) or the
+#   ADM variables (`Lapse`, `Shift`, `SpatialMetric`, `ExtrinsicCurvature`).
+#   In this case, set `Interpolate: False` because the data is already given
+#   on this exact grid.
+Importers:
+  NumericInitialData:
+    FileGlob: "/path/to/initial_data.h5"
+    Subgroup: "VolumeData"
+    ObservationValue: Last
+    Interpolate: True
+    Variables:
+      Lapse: Lapse
+      # Load a shift that is not corotating. See `docs/Examples/BbhInitialData`
+      # for details.
+      Shift: ShiftExcess
+      SpatialMetric: SpatialMetric
+      ExtrinsicCurvature: ExtrinsicCurvature

--- a/tests/Unit/Domain/Creators/CMakeLists.txt
+++ b/tests/Unit/Domain/Creators/CMakeLists.txt
@@ -9,6 +9,7 @@ set(LIBRARY "Test_DomainCreators")
 set(LIBRARY_SOURCES
   Test_AlignedLattice.cpp
   Test_BinaryCompactObject.cpp
+  Test_BinaryCompactObjectHelpers.cpp
   Test_Brick.cpp
   Test_Cylinder.cpp
   Test_CylindricalBinaryCompactObject.cpp

--- a/tests/Unit/Domain/Creators/Test_BinaryCompactObject.cpp
+++ b/tests/Unit/Domain/Creators/Test_BinaryCompactObject.cpp
@@ -357,7 +357,6 @@ std::string create_option_string(const bool excise_A, const bool excise_B,
       add_time_dependence ? "  TimeDependentMaps:\n"
                             "    InitialTime: 1.0\n"
                             "    ExpansionMap: \n"
-                            "      OuterBoundary: 25.0\n"
                             "      InitialExpansion: 1.0\n"
                             "      InitialExpansionVelocity: -0.1\n"
                             "      AsymptoticVelocityOuterBoundary: -0.1\n"

--- a/tests/Unit/Domain/Creators/Test_BinaryCompactObjectHelpers.cpp
+++ b/tests/Unit/Domain/Creators/Test_BinaryCompactObjectHelpers.cpp
@@ -1,0 +1,118 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <limits>
+#include <memory>
+#include <string>
+#include <unordered_map>
+
+#include "DataStructures/DataVector.hpp"
+#include "Domain/Creators/BinaryCompactObjectHelpers.hpp"
+#include "Domain/FunctionsOfTime/FixedSpeedCubic.hpp"
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "Domain/FunctionsOfTime/PiecewisePolynomial.hpp"
+#include "Domain/FunctionsOfTime/QuaternionFunctionOfTime.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace domain::creators::bco {
+using ExpMapOptions = TimeDependentMapOptions::ExpansionMapOptions;
+namespace {
+void test() {
+  const std::array<double, 2> exp_values{1.0, 0.0};
+  const double exp_outer_boundary_velocity = -0.01;
+  const double exp_outer_boundary_timescale = 25.0;
+  ExpMapOptions exp_map_options{exp_values, exp_outer_boundary_velocity,
+                                exp_outer_boundary_timescale};
+
+  const double initial_time = 1.5;
+  const std::array<double, 3> angular_velocity{0.2, -0.4, 0.6};
+  const std::array<double, 3> size_A_values{0.9, 0.08, 0.007};
+  const std::array<double, 3> size_B_values{-0.001, -0.02, -0.3};
+
+  TimeDependentMapOptions time_dep_options{initial_time, exp_map_options,
+                                           angular_velocity, size_A_values,
+                                           size_B_values};
+
+  std::unordered_map<std::string, double> expiration_times{
+      {TimeDependentMapOptions::expansion_name, 10.0},
+      {TimeDependentMapOptions::rotation_name,
+       std::numeric_limits<double>::infinity()},
+      {gsl::at(TimeDependentMapOptions::size_names, 0), 15.5},
+      {gsl::at(TimeDependentMapOptions::size_names, 1),
+       std::numeric_limits<double>::infinity()}};
+
+  // These are hard-coded so this is just a regression test
+  CHECK(TimeDependentMapOptions::expansion_name == "Expansion"s);
+  CHECK(TimeDependentMapOptions::expansion_outer_boundary_name ==
+        "ExpansionOuterBoundary"s);
+  CHECK(TimeDependentMapOptions::rotation_name == "Rotation"s);
+  CHECK(TimeDependentMapOptions::size_names == std::array{"SizeA"s, "SizeB"s});
+
+  using ExpFoT = domain::FunctionsOfTime::PiecewisePolynomial<2>;
+  using ExpBdryFoT = domain::FunctionsOfTime::FixedSpeedCubic;
+  using RotFoT = domain::FunctionsOfTime::QuaternionFunctionOfTime<3>;
+  using SizeFoT = domain::FunctionsOfTime::PiecewisePolynomial<3>;
+  ExpFoT expansion{
+      initial_time,
+      std::array<DataVector, 3>{
+          {{gsl::at(exp_values, 0)}, {gsl::at(exp_values, 1)}, {0.0}}},
+      expiration_times.at(TimeDependentMapOptions::expansion_name)};
+  ExpBdryFoT expansion_outer_boundary{1.0, initial_time,
+                                      exp_outer_boundary_velocity,
+                                      exp_outer_boundary_timescale};
+  RotFoT rotation{initial_time,
+                  std::array<DataVector, 1>{DataVector{1.0, 0.0, 0.0, 0.0}},
+                  std::array<DataVector, 4>{{{3, 0.0},
+                                             {gsl::at(angular_velocity, 0),
+                                              gsl::at(angular_velocity, 1),
+                                              gsl::at(angular_velocity, 2)},
+                                             {3, 0.0},
+                                             {3, 0.0}}},
+                  expiration_times.at(TimeDependentMapOptions::rotation_name)};
+  SizeFoT size_A{
+      initial_time,
+      std::array<DataVector, 4>{{{gsl::at(size_A_values, 0)},
+                                 {gsl::at(size_A_values, 1)},
+                                 {gsl::at(size_A_values, 2)},
+                                 {0.0}}},
+      expiration_times.at(gsl::at(TimeDependentMapOptions::size_names, 0))};
+  SizeFoT size_B{
+      initial_time,
+      std::array<DataVector, 4>{{{gsl::at(size_B_values, 0)},
+                                 {gsl::at(size_B_values, 1)},
+                                 {gsl::at(size_B_values, 2)},
+                                 {0.0}}},
+      expiration_times.at(gsl::at(TimeDependentMapOptions::size_names, 1))};
+
+  const auto functions_of_time =
+      time_dep_options.create_functions_of_time(expiration_times);
+
+  CHECK(dynamic_cast<ExpFoT&>(
+            *functions_of_time.at(TimeDependentMapOptions::expansion_name)
+                 .get()) == expansion);
+  CHECK(dynamic_cast<ExpBdryFoT&>(
+            *functions_of_time
+                 .at(TimeDependentMapOptions::expansion_outer_boundary_name)
+                 .get()) == expansion_outer_boundary);
+  CHECK(dynamic_cast<RotFoT&>(
+            *functions_of_time.at(TimeDependentMapOptions::rotation_name)
+                 .get()) == rotation);
+  CHECK(
+      dynamic_cast<SizeFoT&>(
+          *functions_of_time.at(gsl::at(TimeDependentMapOptions::size_names, 0))
+               .get()) == size_A);
+  CHECK(
+      dynamic_cast<SizeFoT&>(
+          *functions_of_time.at(gsl::at(TimeDependentMapOptions::size_names, 1))
+               .get()) == size_B);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Domain.Creators.BinaryCompactObjectHelpers",
+                  "[Domain][Unit]") {
+  test();
+}
+}  // namespace domain::creators::bco

--- a/tests/Unit/Helpers/Evolution/Systems/CurvedScalarWave/Worldtube/TestHelpers.cpp
+++ b/tests/Unit/Helpers/Evolution/Systems/CurvedScalarWave/Worldtube/TestHelpers.cpp
@@ -60,18 +60,17 @@ std::unique_ptr<DomainCreator<3>> worldtube_binary_compact_object(
       "  TimeDependentMaps:\n"
       "    InitialTime: 0.0\n"
       "    ExpansionMap: \n"
-      "      InitialExpansion: 1.0\n"
-      "      InitialExpansionVelocity: 0.0\n"
+      "      InitialValues: [1.0, 0.0]\n"
       "      AsymptoticVelocityOuterBoundary: 0.0\n"
       "      DecayTimescaleOuterBoundaryVelocity: 1.0\n"
       "    RotationMap:\n"
       "      InitialAngularVelocity: [0.0, 0.0," +
       angular_velocity_stream.str() +
       "]\n"
-      "    SizeMap:\n"
-      "      InitialValues: [0.0, 0.0]\n"
-      "      InitialVelocities: [0.0, 0.0]\n"
-      "      InitialAccelerations: [0.0, 0.0]";
+      "    SizeMapA:\n"
+      "      InitialValues: [0.0, 0.0, 0.0]\n"
+      "    SizeMapB:\n"
+      "      InitialValues: [0.0, 0.0, 0.0]";
   return ::TestHelpers::test_option_tag<::domain::OptionTags::DomainCreator<3>,
                                         Metavariables>(
       binary_compact_object_options);

--- a/tests/Unit/Helpers/Evolution/Systems/CurvedScalarWave/Worldtube/TestHelpers.cpp
+++ b/tests/Unit/Helpers/Evolution/Systems/CurvedScalarWave/Worldtube/TestHelpers.cpp
@@ -60,7 +60,6 @@ std::unique_ptr<DomainCreator<3>> worldtube_binary_compact_object(
       "  TimeDependentMaps:\n"
       "    InitialTime: 0.0\n"
       "    ExpansionMap: \n"
-      "      OuterBoundary: 1.0\n"
       "      InitialExpansion: 1.0\n"
       "      InitialExpansionVelocity: 0.0\n"
       "      AsymptoticVelocityOuterBoundary: 0.0\n"


### PR DESCRIPTION
## Proposed changes

Both BCO domains now (since #4792) share the exact same time dependent maps and options so we shouldn't be editing things twice.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

~Depends on and includes #4824.~

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
