### PR TITLE
Fix evolution DgElementArray round robin proc skipping and info

### DIFF
--- a/src/Evolution/DiscontinuousGalerkin/DgElementArray.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/DgElementArray.hpp
@@ -168,13 +168,13 @@ void DgElementArray<Metavariables, PhaseDepActionList>::allocate_array(
         grid_points_per_node[target_node] += grid_points_per_element;
       }
     } else {
-      while (procs_to_ignore.find(which_proc) != procs_to_ignore.end()) {
-        which_proc = which_proc + 1 == number_of_procs ? 0 : which_proc + 1;
-      }
       for (size_t i = 0; i < element_ids.size(); ++i) {
+        while (procs_to_ignore.find(which_proc) != procs_to_ignore.end()) {
+          which_proc = which_proc + 1 == number_of_procs ? 0 : which_proc + 1;
+        }
+
         dg_element_array(ElementId<volume_dim>(element_ids[i]))
             .insert(global_cache, initialization_items, which_proc);
-        which_proc = which_proc + 1 == number_of_procs ? 0 : which_proc + 1;
 
         const size_t target_node =
             Parallel::node_of<size_t>(which_proc, local_cache);
@@ -182,6 +182,8 @@ void DgElementArray<Metavariables, PhaseDepActionList>::allocate_array(
         ++elements_per_node[target_node];
         grid_points_per_core[which_proc] += grid_points_per_element;
         grid_points_per_node[target_node] += grid_points_per_element;
+
+        which_proc = which_proc + 1 == number_of_procs ? 0 : which_proc + 1;
       }
     }
   }


### PR DESCRIPTION
## Proposed changes

This fixes two bugs in round robin proc assignment in the evolution `DgElementArray`:
- procs to ignore were not being correctly skipped because the for loop doesn't check for procs to ignore and skip over them
- domain diagnostic information for the current element was being added for the next proc's info, not the current proc's

To test, I ran `EvolveGhSingleBlackHole` with round robin and requested two dedicated procs that should be ignored.

Before changes, procs not ignored and proc info shifted:
```
Allocating Singletons:
AhA on node 0, global proc 0, exclusive = true
ExcisionBoundaryA on node 1, global proc 19, exclusive = true


----- Domain Info -----
Total blocks: 6
Total elements: 3072
Total grid points: 384000
Number of cores: 38
Number of nodes: 2
Elements per core: (81,78,81,81,81,81,81,81,81,81,81,81,81,81,81,81,81,81,81,81,78,81,81,81,81,81,81,81,81,81,81,81,81,81,81,81,81,81)
Elements per node: (1536,1536)
Grid points per core: (10125,9750,10125,10125,10125,10125,10125,10125,10125,10125,10125,10125,10125,10125,10125,10125,10125,10125,10125,10125,9750,10125,10125,10125,10125,10125,10125,10125,10125,10125,10125,10125,10125,10125,10125,10125,10125,10125)
Grid points per node: (192000,192000)
-----------------------
```

After changes, procs successfully ignored and proc info shifting fixed:
```
Allocating Singletons:
AhA on node 0, global proc 0, exclusive = true
ExcisionBoundaryA on node 1, global proc 19, exclusive = true


----- Domain Info -----
Total blocks: 6
Total elements: 3072
Total grid points: 384000
Number of cores: 38
Number of nodes: 2
Elements per core: (0,86,86,86,86,86,86,86,86,86,86,86,86,85,85,85,85,85,85,0,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85)
Elements per node: (1542,1530)
Grid points per core: (0,10750,10750,10750,10750,10750,10750,10750,10750,10750,10750,10750,10750,10625,10625,10625,10625,10625,10625,0,10625,10625,10625,10625,10625,10625,10625,10625,10625,10625,10625,10625,10625,10625,10625,10625,10625,10625)
Grid points per node: (192750,191250)
-----------------------
```

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
