### PR TITLE
Factor out time dep maps for BCO domains

### DIFF
--- a/src/Domain/Creators/BinaryCompactObject.hpp
+++ b/src/Domain/Creators/BinaryCompactObject.hpp
@@ -44,14 +44,6 @@ class Wedge;
 template <size_t VolumeDim>
 class DiscreteRotation;
 class Frustum;
-namespace TimeDependent {
-template <size_t VolumeDim>
-class CubicScale;
-template <size_t VolumeDim>
-class Rotation;
-template <bool InteriorMap>
-class SphericalCompression;
-}  // namespace TimeDependent
 }  // namespace CoordinateMaps
 
 template <typename SourceFrame, typename TargetFrame, typename... Maps>
@@ -144,31 +136,8 @@ class BinaryCompactObject : public DomainCreator<3> {
   using Equiangular3D =
       CoordinateMaps::ProductOf3Maps<Equiangular, Equiangular, Equiangular>;
 
-  // Time-dependent maps
-  using CubicScaleMap = domain::CoordinateMaps::TimeDependent::CubicScale<3>;
-  using RotationMap3D = domain::CoordinateMaps::TimeDependent::Rotation<3>;
-  using CompressionMap =
-      domain::CoordinateMaps::TimeDependent::SphericalCompression<false>;
-
-  template <typename SourceFrame, typename TargetFrame>
-  using CubicScaleMapForComposition =
-      domain::CoordinateMap<SourceFrame, TargetFrame, CubicScaleMap>;
-  template <typename SourceFrame, typename TargetFrame>
-  using RotationMapForComposition =
-      domain::CoordinateMap<SourceFrame, TargetFrame, RotationMap3D>;
-  template <typename SourceFrame, typename TargetFrame>
-  using CubicScaleAndRotationMapForComposition =
-      domain::CoordinateMap<SourceFrame, TargetFrame, CubicScaleMap,
-                            RotationMap3D>;
-  template <typename SourceFrame, typename TargetFrame>
-  using CompressionMapForComposition =
-      domain::CoordinateMap<SourceFrame, TargetFrame, CompressionMap>;
-  using CompressionAndCubicScaleAndRotationMapForComposition =
-      domain::CoordinateMap<Frame::Grid, Frame::Inertial, CompressionMap,
-                            CubicScaleMap, RotationMap3D>;
-
  public:
-  using maps_list = tmpl::list<
+  using maps_list = tmpl::flatten<tmpl::list<
       domain::CoordinateMap<Frame::BlockLogical, Frame::Inertial, Affine3D>,
       domain::CoordinateMap<Frame::BlockLogical, Frame::Inertial,
                             Equiangular3D>,
@@ -186,13 +155,7 @@ class BinaryCompactObject : public DomainCreator<3> {
                             CoordinateMaps::Wedge<3>>,
       domain::CoordinateMap<Frame::BlockLogical, Frame::Inertial,
                             CoordinateMaps::Wedge<3>, Translation>,
-      domain::CoordinateMap<Frame::Grid, Frame::Inertial, CubicScaleMap,
-                            RotationMap3D>,
-      domain::CoordinateMap<Frame::Grid, Frame::Distorted, CompressionMap>,
-      domain::CoordinateMap<Frame::Distorted, Frame::Inertial, CubicScaleMap,
-                            RotationMap3D>,
-      domain::CoordinateMap<Frame::Grid, Frame::Inertial, CompressionMap,
-                            CubicScaleMap, RotationMap3D>>;
+      bco::TimeDependentMapOptions::maps_list>>;
 
   /// Options for an excision region in the domain
   struct Excision {

--- a/src/Domain/Creators/BinaryCompactObjectHelpers.cpp
+++ b/src/Domain/Creators/BinaryCompactObjectHelpers.cpp
@@ -7,13 +7,21 @@
 #include <limits>
 #include <memory>
 #include <string>
+#include <type_traits>
 #include <unordered_map>
 
 #include "DataStructures/DataVector.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
 #include "Domain/FunctionsOfTime/FixedSpeedCubic.hpp"
 #include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
 #include "Domain/FunctionsOfTime/PiecewisePolynomial.hpp"
 #include "Domain/FunctionsOfTime/QuaternionFunctionOfTime.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/YlmSpherepack.hpp"
+#include "Options/Options.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
 
 namespace domain::creators::bco {
@@ -102,4 +110,95 @@ TimeDependentMapOptions::create_functions_of_time(
 
   return result;
 }
+
+void TimeDependentMapOptions::build_maps(
+    const std::array<std::array<double, 3>, 2>& centers,
+    const std::array<std::optional<double>, 2>& object_inner_radii,
+    const std::array<std::optional<double>, 2>& object_outer_radii,
+    const double domain_outer_radius) {
+  expansion_map_ = CubicScaleMap{domain_outer_radius, expansion_name,
+                                 expansion_outer_boundary_name};
+  rotation_map_ = RotationMap3D{rotation_name};
+  for (size_t i = 0; i < 2; i++) {
+    if (gsl::at(object_inner_radii, i).has_value() and
+        gsl::at(object_outer_radii, i).has_value()) {
+      gsl::at(size_maps_, i) = CompressionMap{
+          gsl::at(size_names, i), gsl::at(object_inner_radii, i).value(),
+          gsl::at(object_outer_radii, i).value(), gsl::at(centers, i)};
+    }
+  }
+}
+
+template <typename SourceFrame>
+TimeDependentMapOptions::MapType<SourceFrame, Frame::Inertial>
+TimeDependentMapOptions::frame_to_inertial_map() const {
+  return std::make_unique<
+      CubicScaleAndRotationMapForComposition<SourceFrame, Frame::Inertial>>(
+      expansion_map_, rotation_map_);
+}
+
+template <domain::ObjectLabel Object>
+TimeDependentMapOptions::MapType<Frame::Grid, Frame::Distorted>
+TimeDependentMapOptions::grid_to_distorted_map(const bool use_identity) const {
+  if (use_identity) {
+    return std::make_unique<
+        IdentityForComposition<Frame::Grid, Frame::Distorted>>(IdentityMap{});
+  } else {
+    const size_t index = get_index<Object>();
+    return std::make_unique<
+        CompressionMapForComposition<Frame::Grid, Frame::Distorted>>(
+        gsl::at(size_maps_, index));
+  }
+}
+
+template <domain::ObjectLabel Object>
+TimeDependentMapOptions::MapType<Frame::Grid, Frame::Inertial>
+TimeDependentMapOptions::everything_grid_to_inertial_map(
+    const bool include_distorted_map) const {
+  if (include_distorted_map) {
+    const size_t index = get_index<Object>();
+    return std::make_unique<EverythingMapForComposition>(
+        gsl::at(size_maps_, index), expansion_map_, rotation_map_);
+  } else {
+    return std::make_unique<EverythingMapNoDistortedForComposition>(
+        IdentityMap{}, expansion_map_, rotation_map_);
+  }
+}
+
+template <domain::ObjectLabel Object>
+size_t TimeDependentMapOptions::get_index() const {
+  ASSERT(Object == domain::ObjectLabel::A or Object == domain::ObjectLabel::B,
+         "Object label for TimeDependentMapOptions must be either A or B, not"
+             << Object);
+  return Object == domain::ObjectLabel::A ? 0_st : 1_st;
+}
+
+#define OBJECT(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data)                                                   \
+  template TimeDependentMapOptions::MapType<Frame::Grid, Frame::Distorted>     \
+  TimeDependentMapOptions::grid_to_distorted_map<OBJECT(data)>(bool) const;    \
+  template TimeDependentMapOptions::MapType<Frame::Grid, Frame::Inertial>      \
+  TimeDependentMapOptions::everything_grid_to_inertial_map<OBJECT(data)>(bool) \
+      const;                                                                   \
+  template size_t TimeDependentMapOptions::get_index<OBJECT(data)>() const;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE,
+                        (domain::ObjectLabel::A, domain::ObjectLabel::B))
+
+#undef OBJECT
+#undef INSTANTIATE
+
+#define SOURCE_FRAME(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data)                                    \
+  template TimeDependentMapOptions::MapType<SOURCE_FRAME(data), \
+                                            Frame::Inertial>    \
+  TimeDependentMapOptions::frame_to_inertial_map<SOURCE_FRAME(data)>() const;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (Frame::Grid, Frame::Distorted))
+
+#undef SOURCE_FRAME
+#undef INSTANTIATE
+
 }  // namespace domain::creators::bco

--- a/src/Domain/Creators/CylindricalBinaryCompactObject.hpp
+++ b/src/Domain/Creators/CylindricalBinaryCompactObject.hpp
@@ -39,14 +39,6 @@ class DiscreteRotation;
 class UniformCylindricalEndcap;
 class UniformCylindricalFlatEndcap;
 class UniformCylindricalSide;
-namespace TimeDependent {
-template <size_t VolumeDim>
-class CubicScale;
-template <size_t VolumeDim>
-class Rotation;
-template <bool InteriorMap>
-class SphericalCompression;
-}  // namespace TimeDependent
 }  // namespace CoordinateMaps
 
 template <typename SourceFrame, typename TargetFrame, typename... Maps>
@@ -146,70 +138,41 @@ namespace domain::creators {
  *
  */
 class CylindricalBinaryCompactObject : public DomainCreator<3> {
-  // Time-dependent maps
-  using CubicScaleMap = domain::CoordinateMaps::TimeDependent::CubicScale<3>;
-  using RotationMap3D = domain::CoordinateMaps::TimeDependent::Rotation<3>;
-  using CompressionMap =
-      domain::CoordinateMaps::TimeDependent::SphericalCompression<false>;
-
-  template <typename SourceFrame, typename TargetFrame>
-  using CubicScaleMapForComposition =
-      domain::CoordinateMap<SourceFrame, TargetFrame, CubicScaleMap>;
-  template <typename SourceFrame, typename TargetFrame>
-  using RotationMapForComposition =
-      domain::CoordinateMap<SourceFrame, TargetFrame, RotationMap3D>;
-  template <typename SourceFrame, typename TargetFrame>
-  using CubicScaleAndRotationMapForComposition =
-      domain::CoordinateMap<SourceFrame, TargetFrame, CubicScaleMap,
-                            RotationMap3D>;
-  template <typename SourceFrame, typename TargetFrame>
-  using CompressionMapForComposition =
-      domain::CoordinateMap<SourceFrame, TargetFrame, CompressionMap>;
-  using CompressionAndCubicScaleAndRotationMapForComposition =
-      domain::CoordinateMap<Frame::Grid, Frame::Inertial, CompressionMap,
-                            CubicScaleMap, RotationMap3D>;
-
  public:
-  using maps_list = tmpl::list<
-      domain::CoordinateMap<
-          Frame::BlockLogical, Frame::Inertial,
-          CoordinateMaps::ProductOf3Maps<CoordinateMaps::Interval,
-                                         CoordinateMaps::Interval,
-                                         CoordinateMaps::Interval>,
-          CoordinateMaps::UniformCylindricalEndcap,
-          CoordinateMaps::DiscreteRotation<3>>,
-      domain::CoordinateMap<
-          Frame::BlockLogical, Frame::Inertial,
-          CoordinateMaps::ProductOf2Maps<CoordinateMaps::Wedge<2>,
-                                         CoordinateMaps::Interval>,
-          CoordinateMaps::UniformCylindricalEndcap,
-          CoordinateMaps::DiscreteRotation<3>>,
-      domain::CoordinateMap<
-          Frame::BlockLogical, Frame::Inertial,
-          CoordinateMaps::ProductOf3Maps<CoordinateMaps::Interval,
-                                         CoordinateMaps::Interval,
-                                         CoordinateMaps::Interval>,
-          CoordinateMaps::UniformCylindricalFlatEndcap,
-          CoordinateMaps::DiscreteRotation<3>>,
-      domain::CoordinateMap<
-          Frame::BlockLogical, Frame::Inertial,
-          CoordinateMaps::ProductOf2Maps<CoordinateMaps::Wedge<2>,
-                                         CoordinateMaps::Interval>,
-          CoordinateMaps::UniformCylindricalFlatEndcap,
-          CoordinateMaps::DiscreteRotation<3>>,
-      domain::CoordinateMap<
-          Frame::BlockLogical, Frame::Inertial,
-          CoordinateMaps::ProductOf2Maps<CoordinateMaps::Wedge<2>,
-                                         CoordinateMaps::Interval>,
-          CoordinateMaps::UniformCylindricalSide,
-          CoordinateMaps::DiscreteRotation<3>>,
-      domain::CoordinateMap<Frame::Grid, Frame::Inertial, CubicScaleMap,
-                            RotationMap3D>,
-      domain::CoordinateMap<Frame::Grid, Frame::Distorted, CompressionMap>,
-      domain::CoordinateMap<Frame::Distorted, Frame::Inertial, CubicScaleMap,
-                            RotationMap3D>,
-      domain::CoordinateMap<Frame::Grid, Frame::Inertial, CompressionMap,
-                            CubicScaleMap, RotationMap3D>>;
+  using maps_list = tmpl::flatten<
+      tmpl::list<domain::CoordinateMap<
+                     Frame::BlockLogical, Frame::Inertial,
+                     CoordinateMaps::ProductOf3Maps<CoordinateMaps::Interval,
+                                                    CoordinateMaps::Interval,
+                                                    CoordinateMaps::Interval>,
+                     CoordinateMaps::UniformCylindricalEndcap,
+                     CoordinateMaps::DiscreteRotation<3>>,
+                 domain::CoordinateMap<
+                     Frame::BlockLogical, Frame::Inertial,
+                     CoordinateMaps::ProductOf2Maps<CoordinateMaps::Wedge<2>,
+                                                    CoordinateMaps::Interval>,
+                     CoordinateMaps::UniformCylindricalEndcap,
+                     CoordinateMaps::DiscreteRotation<3>>,
+                 domain::CoordinateMap<
+                     Frame::BlockLogical, Frame::Inertial,
+                     CoordinateMaps::ProductOf3Maps<CoordinateMaps::Interval,
+                                                    CoordinateMaps::Interval,
+                                                    CoordinateMaps::Interval>,
+                     CoordinateMaps::UniformCylindricalFlatEndcap,
+                     CoordinateMaps::DiscreteRotation<3>>,
+                 domain::CoordinateMap<
+                     Frame::BlockLogical, Frame::Inertial,
+                     CoordinateMaps::ProductOf2Maps<CoordinateMaps::Wedge<2>,
+                                                    CoordinateMaps::Interval>,
+                     CoordinateMaps::UniformCylindricalFlatEndcap,
+                     CoordinateMaps::DiscreteRotation<3>>,
+                 domain::CoordinateMap<
+                     Frame::BlockLogical, Frame::Inertial,
+                     CoordinateMaps::ProductOf2Maps<CoordinateMaps::Wedge<2>,
+                                                    CoordinateMaps::Interval>,
+                     CoordinateMaps::UniformCylindricalSide,
+                     CoordinateMaps::DiscreteRotation<3>>,
+                 bco::TimeDependentMapOptions::maps_list>>;
 
   struct CenterA {
     using type = std::array<double, 3>;
@@ -410,6 +373,8 @@ class CylindricalBinaryCompactObject : public DomainCreator<3> {
   std::array<double, 3> center_B_{};
   double radius_A_{};
   double radius_B_{};
+  double outer_radius_A_{};
+  double outer_radius_B_{};
   bool include_inner_sphere_A_{};
   bool include_inner_sphere_B_{};
   bool include_outer_sphere_{};

--- a/tests/Unit/Domain/Creators/Test_BinaryCompactObjectHelpers.cpp
+++ b/tests/Unit/Domain/Creators/Test_BinaryCompactObjectHelpers.cpp
@@ -15,7 +15,15 @@
 #include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
 #include "Domain/FunctionsOfTime/PiecewisePolynomial.hpp"
 #include "Domain/FunctionsOfTime/QuaternionFunctionOfTime.hpp"
+#include "Utilities/CartesianProduct.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/MakeArray.hpp"
+
+namespace Frame {
+struct Grid;
+struct Distorted;
+struct Inertial;
+}  // namespace Frame
 
 namespace domain::creators::bco {
 using ExpMapOptions = TimeDependentMapOptions::ExpansionMapOptions;
@@ -108,6 +116,70 @@ void test() {
       dynamic_cast<SizeFoT&>(
           *functions_of_time.at(gsl::at(TimeDependentMapOptions::size_names, 1))
                .get()) == size_B);
+
+  const std::array<std::array<double, 3>, 2> centers{
+      std::array{5.0, 0.01, 0.02}, std::array{-5.0, -0.01, -0.02}};
+  const double domain_outer_radius = 20.0;
+
+  for (const auto& [include_size_A, include_size_B] :
+       cartesian_product(make_array(true, false), make_array(true, false))) {
+    std::optional<double> inner_radius_A{};
+    std::optional<double> inner_radius_B{};
+    std::optional<double> outer_radius_A{};
+    std::optional<double> outer_radius_B{};
+    if (include_size_A) {
+      inner_radius_A = 0.8;
+      outer_radius_A = 3.2;
+    }
+    if (include_size_B) {
+      inner_radius_B = 0.5;
+      outer_radius_B = 2.1;
+    }
+
+    const std::array<std::optional<double>, 2> inner_radii{inner_radius_A,
+                                                           inner_radius_B};
+    const std::array<std::optional<double>, 2> outer_radii{outer_radius_A,
+                                                           outer_radius_B};
+
+    time_dep_options.build_maps(centers, inner_radii, outer_radii,
+                                domain_outer_radius);
+
+    const auto grid_to_distorted_map_A =
+        time_dep_options.grid_to_distorted_map<domain::ObjectLabel::A>(
+            not include_size_A);
+    const auto grid_to_distorted_map_B =
+        time_dep_options.grid_to_distorted_map<domain::ObjectLabel::B>(
+            not include_size_B);
+    const auto everything_map_A =
+        time_dep_options
+            .everything_grid_to_inertial_map<domain::ObjectLabel::A>(
+                include_size_A);
+    const auto everything_map_B =
+        time_dep_options
+            .everything_grid_to_inertial_map<domain::ObjectLabel::B>(
+                include_size_B);
+    const auto grid_to_inertial_map =
+        time_dep_options.frame_to_inertial_map<Frame::Grid>();
+    const auto dist_to_inertial_map =
+        time_dep_options.frame_to_inertial_map<Frame::Distorted>();
+
+    // All of these maps are tested individually. Rather than going through the
+    // effort of coming up with a source coordinate and calculating analytically
+    // what we would get after it's mapped, we just check that it's not the
+    // identity and that the jacobians are time dependent.
+    const auto check_map = [](const auto& map, const bool is_identity = false) {
+      CHECK(map->is_identity() == is_identity);
+      CHECK(map->inv_jacobian_is_time_dependent() == not is_identity);
+      CHECK(map->jacobian_is_time_dependent() == not is_identity);
+    };
+
+    check_map(grid_to_distorted_map_A, not include_size_A);
+    check_map(grid_to_distorted_map_B, not include_size_B);
+    check_map(everything_map_A);
+    check_map(everything_map_B);
+    check_map(grid_to_inertial_map);
+    check_map(dist_to_inertial_map);
+  }
 }
 }  // namespace
 


### PR DESCRIPTION
## Proposed changes

They both use the same maps, so put this into the `TimeDepndentMapOptions` helper for BCOs.

~I did have to make the member variable that stores the time dependent options mutable because I had to set some parameters. Let me know if there's a better way you see to do this.~

Working towards #4764.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

~Depends on and includes #4824 and #4844.~

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
