### PR TITLE
Fix bug in `Composition`

### DIFF
--- a/src/Domain/CoordinateMaps/Composition.cpp
+++ b/src/Domain/CoordinateMaps/Composition.cpp
@@ -252,7 +252,7 @@ Composition<Frames, Dim, std::index_sequence<Is...>>::inv_jacobian_impl(
       auto& prev_inv_jacobian = get<index - 1>(inv_jacobians);
       if (UNLIKELY(map.is_identity())) {
         for (size_t i = 0; i < Dim; ++i) {
-          for (size_t j = 0; j <= i; ++j) {
+          for (size_t j = 0; j < Dim; ++j) {
             get<index>(inv_jacobians).get(i, j) =
                 std::move(prev_inv_jacobian.get(i, j));
           }
@@ -308,7 +308,7 @@ Composition<Frames, Dim, std::index_sequence<Is...>>::jacobian_impl(
       auto& prev_jacobian = get<index - 1>(jacobians);
       if (UNLIKELY(map.is_identity())) {
         for (size_t i = 0; i < Dim; ++i) {
-          for (size_t j = 0; j <= i; ++j) {
+          for (size_t j = 0; j < Dim; ++j) {
             get<index>(jacobians).get(i, j) =
                 std::move(prev_jacobian.get(i, j));
           }


### PR DESCRIPTION
## Proposed changes
Fixes a bug  in the Composition map. Currently, if any of the maps that are not the first map of the composition evaluate true for `is_identity`, this will leave some components of the jacobian that is returned un-initialized.