### PR TITLE
Add ExcisionBoundaryA and B to EvolveGhBinaryBlackHole

### DIFF
--- a/src/ApparentHorizons/HorizonAliases.hpp
+++ b/src/ApparentHorizons/HorizonAliases.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "ApparentHorizons/TagsDeclarations.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/Tags.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/TagsDeclarations.hpp"
 #include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
 #include "NumericalAlgorithms/SphericalHarmonics/Tags.hpp"
@@ -25,7 +26,8 @@ using source_vars = tmpl::list<
     GeneralizedHarmonic::Tags::Pi<Dim, ::Frame::Inertial>,
     GeneralizedHarmonic::Tags::Phi<Dim, ::Frame::Inertial>,
     ::Tags::deriv<GeneralizedHarmonic::Tags::Phi<Dim, Frame::Inertial>,
-                  tmpl::size_t<Dim>, Frame::Inertial>>;
+                  tmpl::size_t<Dim>, Frame::Inertial>,
+    GeneralizedHarmonic::ConstraintDamping::Tags::ConstraintGamma1>;
 
 template <size_t Dim, typename Frame>
 using vars_to_interpolate_to_target =

--- a/src/ControlSystem/Measurements/BothHorizons.hpp
+++ b/src/ControlSystem/Measurements/BothHorizons.hpp
@@ -99,13 +99,14 @@ struct BothHorizons : tt::ConformsTo<protocols::Measurement> {
         const tnsr::aa<DataVector, 3, ::Frame::Inertial>& pi,
         const tnsr::iaa<DataVector, 3, ::Frame::Inertial>& phi,
         const tnsr::ijaa<DataVector, 3, ::Frame::Inertial>& deriv_phi,
+        const Scalar<DataVector>& constraint_gamma1,
         const LinkedMessageId<double>& measurement_id,
         Parallel::GlobalCache<Metavariables>& cache,
         const ElementId<3>& array_index,
         const ParallelComponent* const /*meta*/, ControlSystems /*meta*/) {
       intrp::interpolate<interpolation_target_tag<ControlSystems>>(
           measurement_id, mesh, cache, array_index, spacetime_metric, pi, phi,
-          deriv_phi);
+          deriv_phi, constraint_gamma1);
     }
   };
 

--- a/tests/InputFiles/GeneralizedHarmonic/BinaryBlackHole.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/BinaryBlackHole.yaml
@@ -7,10 +7,10 @@
 ResourceInfo:
   AvoidGlobalProc0: false
   Singletons:
-    AhA:
+    ObservationAhA:
       Proc: Auto
       Exclusive: true
-    AhB:
+    ObservationAhB:
       Proc: Auto
       Exclusive: true
     ControlSystemAhA:
@@ -23,6 +23,12 @@ ResourceInfo:
     Rotation: Auto
     Expansion: Auto
     BondiSachsInterpolation: Auto
+    ObservationExcisionBoundaryA:
+      Proc: Auto
+      Exclusive: false
+    ObservationExcisionBoundaryB:
+      Proc: Auto
+      Exclusive: false
 
 Evolution:
   InitialTime: 0.0
@@ -206,8 +212,14 @@ EventsAndTriggers:
         EvenlySpaced:
           Interval: 1
           Offset: 0
-    - - AhA
-      - AhB
+    - - ObservationAhA
+      - ObservationAhB
+  - - Slabs:
+        EvenlySpaced:
+          Interval: 1
+          Offset: 0
+    - - ObservationExcisionBoundaryA
+      - ObservationExcisionBoundaryB
   - - Slabs:
         EvenlySpaced:
           Interval: 100
@@ -228,7 +240,7 @@ Interpolator:
   DumpVolumeDataOnFailure: false
 
 ApparentHorizons:
-  AhA: &AhA
+  ObservationAhA: &AhA
     InitialGuess:
       Lmax: 10
       Radius: 2.2
@@ -243,7 +255,7 @@ ApparentHorizons:
       DivergenceIter: 5
       MaxIts: 100
     Verbosity: Verbose
-  AhB: &AhB
+  ObservationAhB: &AhB
     InitialGuess:
       Lmax: 10
       Radius: 2.2
@@ -259,6 +271,16 @@ InterpolationTargets:
     Radius: [100, 150, 200]
     Center: [0, 0, 0]
     AngularOrdering: Cce
+  ObservationExcisionBoundaryA:
+    Lmax: 10
+    Center: [0., 0., 0.]
+    Radius: 2.0
+    AngularOrdering: "Strahlkorper"
+  ObservationExcisionBoundaryB:
+    Lmax: 10
+    Center: [0., 0., 0.]
+    Radius: 2.0
+    AngularOrdering: "Strahlkorper"
 
 Cce:
   BondiSachsOutputFilePrefix: "BondiSachs"


### PR DESCRIPTION
## Proposed changes

Ports over the changes made to the single BH executable, that allows for the characteristic speeds to be observed on the excision boundary, to the BBH executable.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
