### PR TITLE
Do time stepping per-system

### DIFF
--- a/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
+++ b/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
@@ -237,9 +237,9 @@ struct EvolutionMetavars {
           tmpl::list<
               evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
                   system, volume_dim>,
-              Actions::RecordTimeStepperData<>,
+              Actions::RecordTimeStepperData<system>,
               evolution::Actions::RunEventsAndDenseTriggers<tmpl::list<>>,
-              Actions::UpdateU<>>>,
+              Actions::UpdateU<system>>>,
       Limiters::Actions::SendData<EvolutionMetavars>,
       Limiters::Actions::Limit<EvolutionMetavars>>>;
 
@@ -253,9 +253,9 @@ struct EvolutionMetavars {
       tmpl::conditional_t<
           local_time_stepping, tmpl::list<>,
           tmpl::list<
-              Actions::RecordTimeStepperData<>,
+              Actions::RecordTimeStepperData<system>,
               evolution::Actions::RunEventsAndDenseTriggers<tmpl::list<>>,
-              Actions::UpdateU<>>>,
+              Actions::UpdateU<system>>>,
       evolution::dg::subcell::Actions::TciAndRollback<
           Burgers::subcell::TciOnDgGrid>,
       Actions::Goto<evolution::dg::subcell::Actions::Labels::EndOfSolvers>,
@@ -267,9 +267,9 @@ struct EvolutionMetavars {
           evolution::dg::subcell::Actions::Labels::BeginSubcellAfterDgRollback>,
       evolution::dg::subcell::fd::Actions::TakeTimeStep<
           Burgers::subcell::TimeDerivative>,
-      Actions::RecordTimeStepperData<>,
+      Actions::RecordTimeStepperData<system>,
       evolution::Actions::RunEventsAndDenseTriggers<tmpl::list<>>,
-      Actions::UpdateU<>,
+      Actions::UpdateU<system>,
       evolution::dg::subcell::Actions::TciAndSwitchToDg<
           Burgers::subcell::TciOnFdGrid>,
       Actions::Label<evolution::dg::subcell::Actions::Labels::EndOfSolvers>>>;

--- a/src/Evolution/Executables/CurvedScalarWave/EvolveCurvedScalarWave.hpp
+++ b/src/Evolution/Executables/CurvedScalarWave/EvolveCurvedScalarWave.hpp
@@ -258,9 +258,9 @@ struct EvolutionMetavars {
           tmpl::list<
               evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
                   system, volume_dim>,
-              Actions::RecordTimeStepperData<>,
+              Actions::RecordTimeStepperData<system>,
               evolution::Actions::RunEventsAndDenseTriggers<tmpl::list<>>,
-              Actions::UpdateU<>>>,
+              Actions::UpdateU<system>>>,
       tmpl::conditional_t<
           use_filtering,
           dg::Actions::Filter<Filters::Exponential<0>,

--- a/src/Evolution/Executables/CurvedScalarWave/EvolveWorldtubeCurvedScalarWave.hpp
+++ b/src/Evolution/Executables/CurvedScalarWave/EvolveWorldtubeCurvedScalarWave.hpp
@@ -210,9 +210,9 @@ struct EvolutionMetavars {
           volume_dim, system, AllStepChoosers, local_time_stepping>,
       evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
           system, volume_dim>,
-      Actions::RecordTimeStepperData<>,
+      Actions::RecordTimeStepperData<system>,
       evolution::Actions::RunEventsAndDenseTriggers<tmpl::list<>>,
-      Actions::UpdateU<>,
+      Actions::UpdateU<system>,
       tmpl::conditional_t<
           use_filtering,
           dg::Actions::Filter<

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonicCce.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonicCce.hpp
@@ -120,9 +120,9 @@ struct EvolutionMetavars
           tmpl::list<
               evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
                   system, VolumeDim>,
-              Actions::RecordTimeStepperData<>,
+              Actions::RecordTimeStepperData<system>,
               evolution::Actions::RunEventsAndDenseTriggers<tmpl::list<>>,
-              Actions::UpdateU<>,
+              Actions::UpdateU<system>,
               dg::Actions::Filter<
                   Filters::Exponential<0>,
                   tmpl::list<

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
@@ -451,10 +451,10 @@ struct EvolutionMetavars {
           tmpl::list<
               evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
                   system, volume_dim>,
-              Actions::RecordTimeStepperData<>,
+              Actions::RecordTimeStepperData<system>,
               evolution::Actions::RunEventsAndDenseTriggers<tmpl::list<
                   ::domain::CheckFunctionsOfTimeAreReadyPostprocessor>>,
-              Actions::UpdateU<>>>,
+              Actions::UpdateU<system>>>,
       dg::Actions::Filter<
           Filters::Exponential<0>,
           tmpl::list<

--- a/src/Evolution/Executables/GeneralizedHarmonic/GeneralizedHarmonicBase.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/GeneralizedHarmonicBase.hpp
@@ -384,9 +384,9 @@ struct GeneralizedHarmonicTemplateBase<
           tmpl::list<
               evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
                   system, volume_dim>,
-              Actions::RecordTimeStepperData<>,
+              Actions::RecordTimeStepperData<system>,
               evolution::Actions::RunEventsAndDenseTriggers<tmpl::list<>>,
-              Actions::UpdateU<>,
+              Actions::UpdateU<system>,
               dg::Actions::Filter<
                   Filters::Exponential<0>,
                   tmpl::list<gr::Tags::SpacetimeMetric<

--- a/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
+++ b/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
@@ -574,7 +574,8 @@ struct GhValenciaDivCleanTemplateBase<
           tmpl::list<
               evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
                   system, volume_dim>,
-              Actions::RecordTimeStepperData<>, Actions::UpdateU<>>>,
+              Actions::RecordTimeStepperData<system>,
+              Actions::UpdateU<system>>>,
       Limiters::Actions::SendData<derived_metavars>,
       Limiters::Actions::Limit<derived_metavars>,
       VariableFixing::Actions::FixVariables<
@@ -595,10 +596,10 @@ struct GhValenciaDivCleanTemplateBase<
           system, volume_dim>,
       tmpl::conditional_t<
           local_time_stepping, tmpl::list<>,
-          tmpl::list<Actions::RecordTimeStepperData<>,
+          tmpl::list<Actions::RecordTimeStepperData<system>,
                      evolution::Actions::RunEventsAndDenseTriggers<
                          events_and_dense_triggers_subcell_postprocessors>,
-                     Actions::UpdateU<>>>,
+                     Actions::UpdateU<system>>>,
       // Note: The primitive variables are computed as part of the TCI.
       evolution::dg::subcell::Actions::TciAndRollback<
           grmhd::GhValenciaDivClean::subcell::TciOnDgGrid<
@@ -621,10 +622,10 @@ struct GhValenciaDivCleanTemplateBase<
               ordered_list_of_primitive_recovery_schemes>>,
       evolution::dg::subcell::fd::Actions::TakeTimeStep<
           grmhd::GhValenciaDivClean::subcell::TimeDerivative>,
-      Actions::RecordTimeStepperData<>,
+      Actions::RecordTimeStepperData<system>,
       evolution::Actions::RunEventsAndDenseTriggers<
           events_and_dense_triggers_subcell_postprocessors>,
-      Actions::UpdateU<>,
+      Actions::UpdateU<system>,
       Actions::MutateApply<
           grmhd::GhValenciaDivClean::subcell::FixConservativesAndComputePrims<
               ordered_list_of_primitive_recovery_schemes>>,

--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
@@ -361,11 +361,11 @@ struct EvolutionMetavars {
           tmpl::list<
               evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
                   system, volume_dim>,
-              Actions::RecordTimeStepperData<>,
+              Actions::RecordTimeStepperData<system>,
               evolution::Actions::RunEventsAndDenseTriggers<
                   tmpl::list<system::primitive_from_conservative<
                       ordered_list_of_primitive_recovery_schemes>>>,
-              Actions::UpdateU<>>>,
+              Actions::UpdateU<system>>>,
       Limiters::Actions::SendData<EvolutionMetavars>,
       Limiters::Actions::Limit<EvolutionMetavars>,
       VariableFixing::Actions::FixVariables<grmhd::ValenciaDivClean::Flattener<
@@ -384,10 +384,10 @@ struct EvolutionMetavars {
           system, volume_dim>,
       tmpl::conditional_t<
           local_time_stepping, tmpl::list<>,
-          tmpl::list<Actions::RecordTimeStepperData<>,
+          tmpl::list<Actions::RecordTimeStepperData<system>,
                      evolution::Actions::RunEventsAndDenseTriggers<
                          events_and_dense_triggers_subcell_postprocessors>,
-                     Actions::UpdateU<>>>,
+                     Actions::UpdateU<system>>>,
       // Note: The primitive variables are computed as part of the TCI.
       evolution::dg::subcell::Actions::TciAndRollback<
           grmhd::ValenciaDivClean::subcell::TciOnDgGrid<
@@ -413,10 +413,10 @@ struct EvolutionMetavars {
           system, grmhd::ValenciaDivClean::ComputeFluxes, volume_dim, true>>,
       evolution::dg::subcell::fd::Actions::TakeTimeStep<
           grmhd::ValenciaDivClean::subcell::TimeDerivative>,
-      Actions::RecordTimeStepperData<>,
+      Actions::RecordTimeStepperData<system>,
       evolution::Actions::RunEventsAndDenseTriggers<
           events_and_dense_triggers_subcell_postprocessors>,
-      Actions::UpdateU<>,
+      Actions::UpdateU<system>,
       Actions::MutateApply<
           grmhd::ValenciaDivClean::subcell::FixConservativesAndComputePrims<
               ordered_list_of_primitive_recovery_schemes>>,

--- a/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
+++ b/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
@@ -289,10 +289,10 @@ struct EvolutionMetavars {
           tmpl::list<
               evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
                   system, volume_dim>,
-              Actions::RecordTimeStepperData<>,
+              Actions::RecordTimeStepperData<system>,
               evolution::Actions::RunEventsAndDenseTriggers<
                   tmpl::list<typename system::primitive_from_conservative>>,
-              Actions::UpdateU<>>>,
+              Actions::UpdateU<system>>>,
       Limiters::Actions::SendData<EvolutionMetavars>,
       Limiters::Actions::Limit<EvolutionMetavars>,
       // Conservative `UpdatePrimitives` expects system to possess
@@ -329,9 +329,9 @@ struct EvolutionMetavars {
           volume_dim, system, AllStepChoosers, local_time_stepping>,
       evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
           system, volume_dim>,
-      tmpl::conditional_t<
-          local_time_stepping, tmpl::list<>,
-          tmpl::list<Actions::RecordTimeStepperData<>, Actions::UpdateU<>>>,
+      tmpl::conditional_t<local_time_stepping, tmpl::list<>,
+                          tmpl::list<Actions::RecordTimeStepperData<system>,
+                                     Actions::UpdateU<system>>>,
       Actions::MutateApply<typename system::primitive_from_conservative>,
       // Note: The primitive variables are computed as part of the TCI.
       evolution::dg::subcell::Actions::TciAndRollback<
@@ -350,7 +350,7 @@ struct EvolutionMetavars {
           NewtonianEuler::subcell::PrimsAfterRollback<volume_dim>>,
       evolution::dg::subcell::fd::Actions::TakeTimeStep<
           NewtonianEuler::subcell::TimeDerivative>,
-      Actions::RecordTimeStepperData<>, Actions::UpdateU<>,
+      Actions::RecordTimeStepperData<system>, Actions::UpdateU<system>,
       Actions::MutateApply<typename system::primitive_from_conservative>,
       evolution::dg::subcell::Actions::TciAndSwitchToDg<
           NewtonianEuler::subcell::TciOnFdGrid<volume_dim>>,

--- a/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveM1Grey.hpp
+++ b/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveM1Grey.hpp
@@ -197,9 +197,9 @@ struct EvolutionMetavars {
           tmpl::list<
               evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
                   system, volume_dim>,
-              Actions::RecordTimeStepperData<>,
+              Actions::RecordTimeStepperData<system>,
               evolution::Actions::RunEventsAndDenseTriggers<tmpl::list<>>,
-              Actions::UpdateU<>>>,
+              Actions::UpdateU<system>>>,
       Limiters::Actions::SendData<EvolutionMetavars>,
       Limiters::Actions::Limit<EvolutionMetavars>,
       Actions::MutateApply<typename RadiationTransport::M1Grey::

--- a/src/Evolution/Executables/RelativisticEuler/Valencia/EvolveValencia.hpp
+++ b/src/Evolution/Executables/RelativisticEuler/Valencia/EvolveValencia.hpp
@@ -213,11 +213,11 @@ struct EvolutionMetavars {
           tmpl::list<
               evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
                   system, volume_dim>,
-              Actions::RecordTimeStepperData<>,
+              Actions::RecordTimeStepperData<system>,
               evolution::Actions::RunEventsAndDenseTriggers<
                   tmpl::list<AlwaysReadyPostprocessor<
                       typename system::primitive_from_conservative>>>,
-              Actions::UpdateU<>>>,
+              Actions::UpdateU<system>>>,
       Limiters::Actions::SendData<EvolutionMetavars>,
       Limiters::Actions::Limit<EvolutionMetavars>,
       VariableFixing::Actions::FixVariables<

--- a/src/Evolution/Executables/ScalarAdvection/EvolveScalarAdvection.hpp
+++ b/src/Evolution/Executables/ScalarAdvection/EvolveScalarAdvection.hpp
@@ -238,9 +238,9 @@ struct EvolutionMetavars {
       tmpl::conditional_t<
           local_time_stepping, tmpl::list<>,
           tmpl::list<
-              Actions::RecordTimeStepperData<>,
+              Actions::RecordTimeStepperData<system>,
               evolution::Actions::RunEventsAndDenseTriggers<tmpl::list<>>,
-              Actions::UpdateU<>>>,
+              Actions::UpdateU<system>>>,
       Limiters::Actions::SendData<EvolutionMetavars>,
       Limiters::Actions::Limit<EvolutionMetavars>>>;
 
@@ -255,9 +255,9 @@ struct EvolutionMetavars {
       tmpl::conditional_t<
           local_time_stepping, tmpl::list<>,
           tmpl::list<
-              Actions::RecordTimeStepperData<>,
+              Actions::RecordTimeStepperData<system>,
               evolution::Actions::RunEventsAndDenseTriggers<tmpl::list<>>,
-              Actions::UpdateU<>>>,
+              Actions::UpdateU<system>>>,
       evolution::dg::subcell::Actions::TciAndRollback<
           ScalarAdvection::subcell::TciOnDgGrid<Dim>>,
       Actions::Goto<evolution::dg::subcell::Actions::Labels::EndOfSolvers>,
@@ -270,7 +270,7 @@ struct EvolutionMetavars {
           evolution::dg::subcell::Actions::Labels::BeginSubcellAfterDgRollback>,
       evolution::dg::subcell::fd::Actions::TakeTimeStep<
           ScalarAdvection::subcell::TimeDerivative<volume_dim>>,
-      Actions::RecordTimeStepperData<>, Actions::UpdateU<>,
+      Actions::RecordTimeStepperData<system>, Actions::UpdateU<system>,
       evolution::dg::subcell::Actions::TciAndSwitchToDg<
           ScalarAdvection::subcell::TciOnFdGrid<volume_dim>>,
       Actions::Label<evolution::dg::subcell::Actions::Labels::EndOfSolvers>>>;

--- a/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
+++ b/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
@@ -221,9 +221,9 @@ struct EvolutionMetavars {
           tmpl::list<
               evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
                   system, volume_dim>,
-              Actions::RecordTimeStepperData<>,
+              Actions::RecordTimeStepperData<system>,
               evolution::Actions::RunEventsAndDenseTriggers<tmpl::list<>>,
-              Actions::UpdateU<>>>,
+              Actions::UpdateU<system>>>,
       tmpl::conditional_t<
           use_filtering,
           dg::Actions::Filter<

--- a/src/Evolution/Systems/Cce/Components/CharacteristicEvolution.hpp
+++ b/src/Evolution/Systems/Cce/Components/CharacteristicEvolution.hpp
@@ -98,6 +98,8 @@ template <class Metavariables>
 struct CharacteristicEvolution {
   using chare_type = Parallel::Algorithms::Singleton;
   using metavariables = Metavariables;
+  using cce_system =
+      Cce::System<Metavariables::uses_partially_flat_cartesian_coordinates>;
 
   using initialize_action_list = tmpl::list<
       Actions::InitializeCharacteristicEvolutionVariables<Metavariables>,
@@ -161,16 +163,6 @@ struct CharacteristicEvolution {
           observers::ObserverWriter<Metavariables>,
           typename Metavariables::cce_boundary_component>>;
 
-  using record_time_stepper_data_and_step =
-      tmpl::list<::Actions::RecordTimeStepperData<
-                     typename Metavariables::evolved_coordinates_variables_tag>,
-                 ::Actions::RecordTimeStepperData<::Tags::Variables<
-                     tmpl::list<typename Metavariables::evolved_swsh_tag>>>,
-                 ::Actions::UpdateU<
-                     typename Metavariables::evolved_coordinates_variables_tag>,
-                 ::Actions::UpdateU<::Tags::Variables<
-                     tmpl::list<typename Metavariables::evolved_swsh_tag>>>>;
-
   using self_start_extract_action_list = tmpl::list<
       Actions::RequestBoundaryData<
           typename Metavariables::cce_boundary_component,
@@ -197,7 +189,8 @@ struct CharacteristicEvolution {
       tmpl::transform<typename metavariables::cce_scri_tags,
                       tmpl::bind<::Actions::MutateApply,
                                  tmpl::bind<CalculateScriPlusValue, tmpl::_1>>>,
-      record_time_stepper_data_and_step>;
+      ::Actions::RecordTimeStepperData<cce_system>,
+      ::Actions::UpdateU<cce_system>>;
 
   using extract_action_list = tmpl::list<
       Actions::RequestBoundaryData<
@@ -218,7 +211,9 @@ struct CharacteristicEvolution {
       tmpl::transform<bondi_hypersurface_step_tags,
                       tmpl::bind<hypersurface_computation, tmpl::_1>>,
       Actions::FilterSwshVolumeQuantity<Tags::BondiH>,
-      compute_scri_quantities_and_observe, record_time_stepper_data_and_step,
+      compute_scri_quantities_and_observe,
+      ::Actions::RecordTimeStepperData<cce_system>,
+      ::Actions::UpdateU<cce_system>,
       ::Actions::ChangeStepSize<typename Metavariables::cce_step_choosers>,
       // We cannot know our next step for certain until after we've performed
       // step size selection, as we may need to reject a step.
@@ -231,12 +226,9 @@ struct CharacteristicEvolution {
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<Parallel::Phase::Initialization,
                              initialize_action_list>,
-      Parallel::PhaseActions<
-          Parallel::Phase::InitializeTimeStepperHistory,
-          SelfStart::self_start_procedure<
-              self_start_extract_action_list,
-              Cce::System<
-                  Metavariables::uses_partially_flat_cartesian_coordinates>>>,
+      Parallel::PhaseActions<Parallel::Phase::InitializeTimeStepperHistory,
+                             SelfStart::self_start_procedure<
+                                 self_start_extract_action_list, cce_system>>,
       Parallel::PhaseActions<Parallel::Phase::Evolve, extract_action_list>>;
 
   static void initialize(

--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonChare.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonChare.hpp
@@ -62,9 +62,8 @@ struct WorldtubeSingleton {
   using step_actions =
       tmpl::list<Actions::ReceiveElementData,
                  Actions::SendToElements<Metavariables>,
-                 ::Actions::RecordTimeStepperData<
-                     typename worldtube_system::variables_tag>,
-                 ::Actions::UpdateU<typename worldtube_system::variables_tag>>;
+                 ::Actions::RecordTimeStepperData<worldtube_system>,
+                 ::Actions::UpdateU<worldtube_system>>;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<Parallel::Phase::Initialization,
                              initialization_actions>,

--- a/src/Time/Actions/RecordTimeStepperData.hpp
+++ b/src/Time/Actions/RecordTimeStepperData.hpp
@@ -12,7 +12,6 @@
 #include "Parallel/AlgorithmExecution.hpp"
 #include "Time/Tags.hpp"
 #include "Utilities/Gsl.hpp"
-#include "Utilities/NoSuchType.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
 
@@ -25,30 +24,45 @@ class GlobalCache;
 // IWYU pragma: no_forward_declare db::DataBox
 /// \endcond
 
+namespace record_time_stepper_data_detail {
+template <typename System, typename VariablesTag, typename DbTags>
+void record_one_variables(const gsl::not_null<db::DataBox<DbTags>*> box) {
+  using dt_variables_tag = db::add_tag_prefix<Tags::dt, VariablesTag>;
+  using history_tag = Tags::HistoryEvolvedVariables<VariablesTag>;
+
+  db::mutate<history_tag>(
+      box,
+      [](const gsl::not_null<typename history_tag::type*> history,
+         const TimeStepId& time_step_id,
+         const typename VariablesTag::type& vars,
+         const typename dt_variables_tag::type& dt_vars) {
+        history->insert(time_step_id, vars, dt_vars);
+      },
+      db::get<Tags::TimeStepId>(*box), db::get<VariablesTag>(*box),
+      db::get<dt_variables_tag>(*box));
+}
+}  // namespace record_time_stepper_data_detail
+
 /// Records the variables and their time derivatives in the time stepper
 /// history.
 ///
 /// \note this is a free function version of `Actions::RecordTimeStepperData`.
 /// This free function alternative permits the inclusion of the time step
 /// procedure in the middle of another action.
-template <typename System, typename VariablesTag = NoSuchType, typename DbTags>
+template <typename System, typename DbTags>
 void record_time_stepper_data(const gsl::not_null<db::DataBox<DbTags>*> box) {
-  using variables_tag =
-      tmpl::conditional_t<std::is_same_v<VariablesTag, NoSuchType>,
-                          typename System::variables_tag, VariablesTag>;
-  using dt_variables_tag = db::add_tag_prefix<Tags::dt, variables_tag>;
-  using history_tag = Tags::HistoryEvolvedVariables<variables_tag>;
-
-  db::mutate<history_tag>(
-      box,
-      [](const gsl::not_null<typename history_tag::type*> history,
-         const TimeStepId& time_step_id,
-         const typename variables_tag::type& vars,
-         const typename dt_variables_tag::type& dt_vars) {
-        history->insert(time_step_id, vars, dt_vars);
-      },
-      db::get<Tags::TimeStepId>(*box), db::get<variables_tag>(*box),
-      db::get<dt_variables_tag>(*box));
+  if constexpr (tt::is_a_v<tmpl::list, typename System::variables_tag>) {
+    // The system has multiple evolved variables, probably because
+    // there is a mixture of real and complex values or similar.  Step
+    // all of them.
+    tmpl::for_each<typename System::variables_tag>([&](auto tag) {
+      record_time_stepper_data_detail::record_one_variables<
+          System, tmpl::type_from<decltype(tag)>>(box);
+    });
+  } else {
+    record_time_stepper_data_detail::record_one_variables<
+        System, typename System::variables_tag>(box);
+  }
 }
 
 namespace Actions {
@@ -62,15 +76,14 @@ namespace Actions {
 /// Uses:
 /// - GlobalCache: nothing
 /// - DataBox:
-///   - variables_tag (either the provided `VariablesTag` or the
-///   `system::variables_tag` if none is provided)
+///   - System::variables_tag
 ///   - dt_variables_tag
 ///   - Tags::HistoryEvolvedVariables<variables_tag>
 ///   - Tags::TimeStepId
 ///
 /// DataBox changes:
 /// - Tags::HistoryEvolvedVariables<variables_tag>
-template <typename VariablesTag = NoSuchType>
+template <typename System>
 struct RecordTimeStepperData {
   template <typename DbTags, typename... InboxTags, typename Metavariables,
             typename ArrayIndex, typename ActionList,
@@ -80,8 +93,7 @@ struct RecordTimeStepperData {
       const Parallel::GlobalCache<Metavariables>& /*cache*/,
       const ArrayIndex& /*array_index*/, ActionList /*meta*/,
       const ParallelComponent* const /*meta*/) {  // NOLINT const
-    record_time_stepper_data<typename Metavariables::system, VariablesTag>(
-        make_not_null(&box));
+    record_time_stepper_data<System>(make_not_null(&box));
     return {Parallel::AlgorithmExecution::Continue, std::nullopt};
   }
 };

--- a/src/Time/TakeStep.hpp
+++ b/src/Time/TakeStep.hpp
@@ -25,15 +25,14 @@ struct Metavariables;
 /// system, and in the case for which step parameters may need to be rejected
 /// and re-tried, looping until an acceptable step is performed.
 template <typename System, bool LocalTimeStepping,
-          typename StepChoosersToUse = AllStepChoosers,
-          typename VariablesTag = NoSuchType, typename DbTags>
+          typename StepChoosersToUse = AllStepChoosers, typename DbTags>
 void take_step(const gsl::not_null<db::DataBox<DbTags>*> box) {
-  record_time_stepper_data<System, VariablesTag>(box);
+  record_time_stepper_data<System>(box);
   if constexpr (LocalTimeStepping) {
     do {
-      update_u<System, VariablesTag>(box);
+      update_u<System>(box);
     } while (not change_step_size<StepChoosersToUse>(box));
   } else {
-    update_u<System, VariablesTag>(box);
+    update_u<System>(box);
   }
 }

--- a/tests/Unit/Time/Actions/Test_ChangeStepSize.cpp
+++ b/tests/Unit/Time/Actions/Test_ChangeStepSize.cpp
@@ -95,7 +95,7 @@ struct Component {
                      ::Actions::Label<NoOpLabel>,
                      /*UpdateU action is required to satisfy internal checks of
                        `ChangeStepSize`. It is not used in the test.*/
-                     Actions::UpdateU<>>>>;
+                     Actions::UpdateU<System>>>>;
 };
 
 template <typename StepChoosersToUse = AllStepChoosers>

--- a/tests/Unit/Time/Actions/Test_SelfStartActions.cpp
+++ b/tests/Unit/Time/Actions/Test_SelfStartActions.cpp
@@ -154,11 +154,11 @@ struct Component {
   static constexpr bool has_primitives = Metavariables::has_primitives;
 
   using step_actions =
-      tmpl::list<ComputeTimeDerivative, Actions::RecordTimeStepperData<>,
-                 tmpl::conditional_t<
-                     has_primitives,
-                     tmpl::list<Actions::UpdateU<>, Actions::UpdatePrimitives>,
-                     Actions::UpdateU<>>>;
+      tmpl::list<ComputeTimeDerivative,
+                 Actions::RecordTimeStepperData<typename metavariables::system>,
+                 Actions::UpdateU<typename metavariables::system>,
+                 tmpl::conditional_t<has_primitives, Actions::UpdatePrimitives,
+                                     tmpl::list<>>>;
   using action_list = tmpl::flatten<
       tmpl::list<SelfStart::self_start_procedure<
                      step_actions, typename metavariables::system>,
@@ -413,7 +413,8 @@ double error_in_step(const size_t order, const double step) {
 
   run_past<std::is_same<SelfStart::Actions::Cleanup, tmpl::_1>,
            tmpl::bool_<true>, MultipleHistories>(make_not_null(&runner));
-  run_past<std::is_same<tmpl::pin<Actions::UpdateU<>>, tmpl::_1>,
+  run_past<std::is_same<tmpl::pin<Actions::UpdateU<System<TestPrimitives>>>,
+                        tmpl::_1>,
            tmpl::bool_<true>, MultipleHistories>(make_not_null(&runner));
 
   const double exact = -log(exp(-initial_value) - step);

--- a/tests/Unit/Time/Actions/Test_UpdateU.cpp
+++ b/tests/Unit/Time/Actions/Test_UpdateU.cpp
@@ -46,54 +46,47 @@ struct AlternativeVar : db::SimpleTag {
   using type = double;
 };
 
-struct System {
+struct SingleVariableSystem {
   using variables_tag = Var;
 };
 
-template <typename Metavariables, typename VariablesTag, typename HistoryTag,
-          typename UpdateAction>
-struct Component {
-  using test_variables_tag = VariablesTag;
-  using test_history_tag = HistoryTag;
+struct TwoVariableSystem {
+  using variables_tag = tmpl::list<Var, AlternativeVar>;
+};
 
+template <typename Metavariables>
+struct Component {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = int;
   using const_global_cache_tags = tmpl::list<>;
-  using simple_tags = tmpl::list<Tags::TimeStepper<TimeStepper>, Tags::TimeStep,
-                                 ::Tags::IsUsingTimeSteppingErrorControl,
-                                 VariablesTag, HistoryTag>;
+  using simple_tags =
+      tmpl::list<Tags::TimeStepper<TimeStepper>, Tags::TimeStep,
+                 ::Tags::IsUsingTimeSteppingErrorControl, Var,
+                 Tags::HistoryEvolvedVariables<Var>, AlternativeVar,
+                 Tags::HistoryEvolvedVariables<AlternativeVar>>;
 
-  using phase_dependent_action_list =
-      tmpl::list<Parallel::PhaseActions<
-                     Parallel::Phase::Initialization,
-                     tmpl::list<ActionTesting::InitializeDataBox<simple_tags>>>,
-                 Parallel::PhaseActions<Parallel::Phase::Testing,
-                                        tmpl::list<UpdateAction>>>;
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<
+          Parallel::Phase::Initialization,
+          tmpl::list<ActionTesting::InitializeDataBox<simple_tags>>>,
+      Parallel::PhaseActions<Parallel::Phase::Testing,
+                             tmpl::list<Actions::UpdateU<
+                                 typename metavariables::system_for_test>>>>;
 };
 
-struct Metavariables;
-
-using component_with_default_variables =
-    Component<Metavariables, Var, Tags::HistoryEvolvedVariables<Var>,
-              Actions::UpdateU<>>;
-using component_with_template_specified_variables =
-    Component<Metavariables, AlternativeVar,
-              Tags::HistoryEvolvedVariables<AlternativeVar>,
-              Actions::UpdateU<AlternativeVar>>;
-
+template <typename System>
 struct Metavariables {
-  using system = System;
-  using component_list =
-      tmpl::list<component_with_default_variables,
-                 component_with_template_specified_variables>;
+  using system_for_test = System;
+  using component_list = tmpl::list<Component<Metavariables>>;
 
   void pup(PUP::er& /*p*/) {}
 };
 
-template <typename VariablesTag, typename UpdateUArgument>
+template <typename System, bool AlternativeUpdates>
 void test_integration() {
-  using history_tag = Tags::HistoryEvolvedVariables<VariablesTag>;
+  using history_tag = Tags::HistoryEvolvedVariables<Var>;
+  using alternative_history_tag = Tags::HistoryEvolvedVariables<AlternativeVar>;
 
   const Slab slab(1., 3.);
   const TimeDelta time_step = slab.duration() / 2;
@@ -104,9 +97,11 @@ void test_integration() {
 
   auto box = db::create<db::AddSimpleTags<
       Tags::TimeStepper<TimeSteppers::Rk3HesthavenSsp>, Tags::TimeStep,
-      ::Tags::IsUsingTimeSteppingErrorControl, VariablesTag, history_tag>>(
+      ::Tags::IsUsingTimeSteppingErrorControl, Var, history_tag, AlternativeVar,
+      alternative_history_tag>>(
       std::make_unique<TimeSteppers::Rk3HesthavenSsp>(), time_step, false, 1.,
-      typename history_tag::type{3});
+      typename history_tag::type{3}, 1.,
+      typename alternative_history_tag::type{3});
 
   const std::array<Time, 3> substep_times{
       {slab.start(), slab.start() + time_step, slab.start() + time_step / 2}};
@@ -115,53 +110,61 @@ void test_integration() {
   const std::array<double, 3> expected_values{{3., 3., 10. / 3.}};
 
   for (size_t substep = 0; substep < 3; ++substep) {
-    db::mutate<history_tag>(
+    db::mutate<history_tag, alternative_history_tag>(
         make_not_null(&box),
         [&rhs, &substep, &substep_times](
             const gsl::not_null<typename history_tag::type*> history,
+            const gsl::not_null<typename alternative_history_tag::type*>
+                alternative_history,
             const double vars) {
           const double time = gsl::at(substep_times, substep).value();
           history->insert(TimeStepId(true, 0, substep_times[0], substep, time),
                           vars, rhs(time, vars));
+          *alternative_history = *history;
         },
-        db::get<VariablesTag>(box));
+        db::get<Var>(box));
 
-    update_u<System, UpdateUArgument>(make_not_null(&box));
-    CHECK(db::get<VariablesTag>(box) ==
-          approx(gsl::at(expected_values, substep)));
+    update_u<System>(make_not_null(&box));
+    CHECK(db::get<Var>(box) == approx(gsl::at(expected_values, substep)));
+    if (AlternativeUpdates) {
+      CHECK(db::get<AlternativeVar>(box) ==
+            approx(gsl::at(expected_values, substep)));
+    } else {
+      CHECK(db::get<AlternativeVar>(box) == 1.0);
+    }
   }
 }
 
-template <typename Component>
 void test_action() {
-  using variables_tag = typename Component::test_variables_tag;
-  using history_tag = typename Component::test_history_tag;
+  using system = SingleVariableSystem;
+  using metavariables = Metavariables<system>;
+  using component = Component<metavariables>;
 
   const Slab slab(1., 3.);
   const TimeDelta time_step = slab.duration() / 2;
 
-  typename variables_tag::type vars = 1.0;
-  typename history_tag::type history{3};
+  Var::type vars = 1.0;
+  Tags::HistoryEvolvedVariables<Var>::type history{3};
   history.insert(TimeStepId(true, 0, slab.start()), vars, 3.0);
 
-  using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<Metavariables>;
+  using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<metavariables>;
   MockRuntimeSystem runner{{}};
-  ActionTesting::emplace_component_and_initialize<Component>(
+  ActionTesting::emplace_component_and_initialize<component>(
       &runner, 0,
       {std::make_unique<TimeSteppers::Rk3HesthavenSsp>(), time_step, false,
-       vars, std::move(history)});
+       vars, std::move(history), AlternativeVar::type{},
+       Tags::HistoryEvolvedVariables<AlternativeVar>::type{}});
 
   ActionTesting::set_phase(make_not_null(&runner), Parallel::Phase::Testing);
 
   auto box_for_function = serialize_and_deserialize(
-      ActionTesting::get_databox<Component>(make_not_null(&runner), 0));
+      ActionTesting::get_databox<component>(make_not_null(&runner), 0));
 
-  runner.next_action<Component>(0);
-  update_u<System, variables_tag>(make_not_null(&box_for_function));
+  runner.next_action<component>(0);
+  update_u<system>(make_not_null(&box_for_function));
 
-  const auto& action_box = ActionTesting::get_databox<Component>(runner, 0);
-  CHECK(db::get<variables_tag>(box_for_function) ==
-        db::get<variables_tag>(action_box));
+  const auto& action_box = ActionTesting::get_databox<component>(runner, 0);
+  CHECK(db::get<Var>(box_for_function) == db::get<Var>(action_box));
 }
 
 void test_stepper_error() {
@@ -196,7 +199,7 @@ void test_stepper_error() {
         },
         db::get<variables_tag>(box));
 
-    update_u<System>(make_not_null(&box));
+    update_u<SingleVariableSystem>(make_not_null(&box));
   };
 
   using error_tag = Tags::StepperError<variables_tag>;
@@ -225,9 +228,8 @@ void test_stepper_error() {
 SPECTRE_TEST_CASE("Unit.Time.Actions.UpdateU", "[Unit][Time][Actions]") {
   Parallel::register_classes_with_charm<TimeSteppers::Rk3HesthavenSsp>();
 
-  test_integration<Var, NoSuchType>();
-  test_integration<AlternativeVar, AlternativeVar>();
-  test_action<component_with_default_variables>();
-  test_action<component_with_template_specified_variables>();
+  test_integration<SingleVariableSystem, false>();
+  test_integration<TwoVariableSystem, true>();
+  test_action();
   test_stepper_error();
 }


### PR DESCRIPTION
## Proposed changes

Currently the actions are templated on the variables to update, but this is annoying for CCE where the system variables are split into multiple tags.  Now it operates on a particular system.

This change will be required if any such split-variables system wants to do LTS step rejection in the future.

@Sizheng-Ma Can you verify that I defined the CCE system correctly in `src/Evolution/Systems/Cce/Components/CharacteristicEvolution.hpp`?

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
