### PR TITLE
Change storage type of NeighborDataForReconstruction tag

### DIFF
--- a/src/Evolution/DgSubcell/Actions/Initialize.hpp
+++ b/src/Evolution/DgSubcell/Actions/Initialize.hpp
@@ -13,6 +13,7 @@
 #include "Domain/Structure/Element.hpp"
 #include "Domain/Tags.hpp"
 #include "Evolution/DgSubcell/ActiveGrid.hpp"
+#include "Evolution/DgSubcell/GhostData.hpp"
 #include "Evolution/DgSubcell/Mesh.hpp"
 #include "Evolution/DgSubcell/Projection.hpp"
 #include "Evolution/DgSubcell/Tags/ActiveGrid.hpp"

--- a/src/Evolution/DgSubcell/Actions/TciAndRollback.hpp
+++ b/src/Evolution/DgSubcell/Actions/TciAndRollback.hpp
@@ -20,6 +20,7 @@
 #include "Domain/Tags.hpp"
 #include "Evolution/DgSubcell/Actions/Labels.hpp"
 #include "Evolution/DgSubcell/ActiveGrid.hpp"
+#include "Evolution/DgSubcell/GhostData.hpp"
 #include "Evolution/DgSubcell/NeighborRdmpAndVolumeData.hpp"
 #include "Evolution/DgSubcell/Projection.hpp"
 #include "Evolution/DgSubcell/RdmpTci.hpp"
@@ -206,9 +207,9 @@ struct TciAndRollback {
             const gsl::not_null<bool*> did_rollback_ptr,
             const gsl::not_null<FixedHashMap<
                 maximum_number_of_neighbors(Dim),
-                std::pair<Direction<Dim>, ElementId<Dim>>, DataVector,
+                std::pair<Direction<Dim>, ElementId<Dim>>, GhostData,
                 boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>*>
-                neighbor_data_ptr,
+                ghost_data_ptr,
             const FixedHashMap<
                 maximum_number_of_neighbors(Dim),
                 std::pair<Direction<Dim>, ElementId<Dim>>, Mesh<Dim>,
@@ -241,9 +242,10 @@ struct TciAndRollback {
           for (const auto& [directional_element_id, neighbor_mesh] :
                neighbor_meshes) {
             evolution::dg::subcell::insert_or_update_neighbor_volume_data<
-                false>(neighbor_data_ptr,
-                       neighbor_data_ptr->at(directional_element_id), 0,
-                       directional_element_id, neighbor_mesh, element,
+                false>(ghost_data_ptr,
+                       ghost_data_ptr->at(directional_element_id)
+                           .neighbor_ghost_data_for_reconstruction(),
+                       0, directional_element_id, neighbor_mesh, element,
                        subcell_mesh, ghost_zone_size);
           }
 

--- a/src/Evolution/DgSubcell/Actions/TciAndSwitchToDg.hpp
+++ b/src/Evolution/DgSubcell/Actions/TciAndSwitchToDg.hpp
@@ -261,7 +261,7 @@ struct TciAndSwitchToDg {
           [&dg_mesh, &subcell_mesh, &subcell_options](
               const auto active_vars_ptr, const auto active_history_ptr,
               const gsl::not_null<ActiveGrid*> active_grid_ptr,
-              const auto subcell_neighbor_data_ptr,
+              const auto subcell_ghost_data_ptr,
               const gsl::not_null<
                   std::deque<evolution::dg::subcell::ActiveGrid>*>
                   tci_grid_history_ptr,
@@ -284,7 +284,7 @@ struct TciAndSwitchToDg {
 
             // Clear the neighbor data needed for subcell reconstruction since
             // we have now completed the time step.
-            subcell_neighbor_data_ptr->clear();
+            subcell_ghost_data_ptr->clear();
 
             // Clear the TCI grid history since we don't need to use it when on
             // the DG grid.

--- a/src/Evolution/DgSubcell/NeighborRdmpAndVolumeData.hpp
+++ b/src/Evolution/DgSubcell/NeighborRdmpAndVolumeData.hpp
@@ -12,6 +12,7 @@
 #include "Domain/Structure/Direction.hpp"
 #include "Domain/Structure/ElementId.hpp"
 #include "Domain/Structure/MaxNumberOfNeighbors.hpp"
+#include "Evolution/DgSubcell/GhostData.hpp"
 #include "Evolution/DgSubcell/RdmpTciData.hpp"
 #include "Utilities/Gsl.hpp"
 
@@ -25,7 +26,7 @@ class Mesh;
 namespace evolution::dg::subcell {
 /*!
  * \brief Check whether `neighbor_subcell_data` is FD or DG, and either insert
- * or copy into `neighbor_data_ptr` the FD data (projecting if
+ * or copy into `ghost_data_ptr` the FD data (projecting if
  * `neighbor_subcell_data` is DG data).
  *
  * This is intended to be used during a rollback from DG to make sure neighbor
@@ -35,9 +36,9 @@ template <bool InsertIntoMap, size_t Dim>
 void insert_or_update_neighbor_volume_data(
     gsl::not_null<
         FixedHashMap<maximum_number_of_neighbors(Dim),
-                     std::pair<Direction<Dim>, ElementId<Dim>>, DataVector,
+                     std::pair<Direction<Dim>, ElementId<Dim>>, GhostData,
                      boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>*>
-        neighbor_data_ptr,
+        ghost_data_ptr,
     const DataVector& neighbor_subcell_data,
     const size_t number_of_rdmp_vars_in_buffer,
     const std::pair<Direction<Dim>, ElementId<Dim>>& directional_element_id,
@@ -55,9 +56,9 @@ void insert_neighbor_rdmp_and_volume_data(
     gsl::not_null<RdmpTciData*> rdmp_tci_data_ptr,
     gsl::not_null<
         FixedHashMap<maximum_number_of_neighbors(Dim),
-                     std::pair<Direction<Dim>, ElementId<Dim>>, DataVector,
+                     std::pair<Direction<Dim>, ElementId<Dim>>, GhostData,
                      boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>*>
-        neighbor_data_ptr,
+        ghost_data_ptr,
     const DataVector& received_neighbor_subcell_data,
     size_t number_of_rdmp_vars,
     const std::pair<Direction<Dim>, ElementId<Dim>>& directional_element_id,

--- a/src/Evolution/DgSubcell/Tags/GhostDataForReconstruction.hpp
+++ b/src/Evolution/DgSubcell/Tags/GhostDataForReconstruction.hpp
@@ -8,20 +8,25 @@
 #include <utility>
 
 #include "DataStructures/DataBox/Tag.hpp"
-#include "DataStructures/DataVector.hpp"
 #include "DataStructures/FixedHashMap.hpp"
 #include "Domain/Structure/Direction.hpp"
 #include "Domain/Structure/ElementId.hpp"
 #include "Domain/Structure/MaxNumberOfNeighbors.hpp"
+#include "Evolution/DgSubcell/GhostData.hpp"
 
 namespace evolution::dg::subcell::Tags {
-/// The ghost data from neighboring elements used for reconstructing the
-/// solution on the interfaces between elements
+/// The ghost data used for reconstructing the solution on the interfaces
+/// between elements
+///
+/// The `FixedHashMap` stores a `evolution::dg::subcell::GhostData` which stores
+/// both local and received neighbor ghost data. Even though subcell doesn't use
+/// it's local ghost data during reconstruction, we will need to store it when
+/// using Charm++ messages.
 template <size_t Dim>
 struct GhostDataForReconstruction : db::SimpleTag {
   using type =
       FixedHashMap<maximum_number_of_neighbors(Dim),
-                   std::pair<Direction<Dim>, ElementId<Dim>>, DataVector,
+                   std::pair<Direction<Dim>, ElementId<Dim>>, GhostData,
                    boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>;
 };
 }  // namespace evolution::dg::subcell::Tags

--- a/src/Evolution/Systems/Burgers/FiniteDifference/MonotonisedCentral.cpp
+++ b/src/Evolution/Systems/Burgers/FiniteDifference/MonotonisedCentral.cpp
@@ -21,6 +21,7 @@
 #include "Domain/Structure/ElementId.hpp"
 #include "Domain/Structure/MaxNumberOfNeighbors.hpp"
 #include "Domain/Structure/Side.hpp"
+#include "Evolution/DgSubcell/GhostData.hpp"
 #include "Evolution/Systems/Burgers/FiniteDifference/ReconstructWork.tpp"
 #include "Evolution/Systems/Burgers/FiniteDifference/Reconstructor.hpp"
 #include "Evolution/Systems/Burgers/Tags.hpp"
@@ -49,10 +50,10 @@ void MonotonisedCentral::reconstruct(
         vars_on_upper_face,
     const Variables<tmpl::list<Burgers::Tags::U>>& volume_vars,
     const Element<1>& element,
-    const FixedHashMap<maximum_number_of_neighbors(1),
-                       std::pair<Direction<1>, ElementId<1>>, DataVector,
-                       boost::hash<std::pair<Direction<1>, ElementId<1>>>>&
-        neighbor_data,
+    const FixedHashMap<
+        maximum_number_of_neighbors(1), std::pair<Direction<1>, ElementId<1>>,
+        evolution::dg::subcell::GhostData,
+        boost::hash<std::pair<Direction<1>, ElementId<1>>>>& ghost_data,
     const Mesh<1>& subcell_mesh) const {
   reconstruct_work(
       vars_on_lower_face, vars_on_upper_face,
@@ -63,16 +64,16 @@ void MonotonisedCentral::reconstruct(
             upper_face_vars_ptr, lower_face_vars_ptr, volume_variables,
             ghost_cell_vars, subcell_extents, number_of_variables);
       },
-      volume_vars, element, neighbor_data, subcell_mesh, ghost_zone_size());
+      volume_vars, element, ghost_data, subcell_mesh, ghost_zone_size());
 }
 
 void MonotonisedCentral::reconstruct_fd_neighbor(
     const gsl::not_null<Variables<face_vars_tags>*> vars_on_face,
     const Variables<volume_vars_tags>& volume_vars, const Element<1>& element,
-    const FixedHashMap<maximum_number_of_neighbors(1),
-                       std::pair<Direction<1>, ElementId<1>>, DataVector,
-                       boost::hash<std::pair<Direction<1>, ElementId<1>>>>&
-        neighbor_data,
+    const FixedHashMap<
+        maximum_number_of_neighbors(1), std::pair<Direction<1>, ElementId<1>>,
+        evolution::dg::subcell::GhostData,
+        boost::hash<std::pair<Direction<1>, ElementId<1>>>>& ghost_data,
     const Mesh<1>& subcell_mesh,
     const Direction<1> direction_to_reconstruct) const {
   reconstruct_fd_neighbor_work(
@@ -101,8 +102,8 @@ void MonotonisedCentral::reconstruct_fd_neighbor(
             tensor_component_neighbor, subcell_extents, ghost_data_extents,
             local_direction_to_reconstruct);
       },
-      volume_vars, element, neighbor_data, subcell_mesh,
-      direction_to_reconstruct, ghost_zone_size());
+      volume_vars, element, ghost_data, subcell_mesh, direction_to_reconstruct,
+      ghost_zone_size());
 }
 
 bool operator==(const MonotonisedCentral& /*lhs*/,

--- a/src/Evolution/Systems/Burgers/FiniteDifference/MonotonisedCentral.hpp
+++ b/src/Evolution/Systems/Burgers/FiniteDifference/MonotonisedCentral.hpp
@@ -42,6 +42,9 @@ class not_null;
 namespace PUP {
 class er;
 }  // namespace PUP
+namespace evolution::dg::subcell {
+class GhostData;
+}  // namespace evolution::dg::subcell
 /// \endcond
 
 namespace Burgers::fd {
@@ -91,19 +94,19 @@ class MonotonisedCentral : public Reconstructor {
           vars_on_upper_face,
       const Variables<tmpl::list<Burgers::Tags::U>>& volume_vars,
       const Element<1>& element,
-      const FixedHashMap<maximum_number_of_neighbors(1),
-                         std::pair<Direction<1>, ElementId<1>>, DataVector,
-                         boost::hash<std::pair<Direction<1>, ElementId<1>>>>&
-          neighbor_data,
+      const FixedHashMap<
+          maximum_number_of_neighbors(1), std::pair<Direction<1>, ElementId<1>>,
+          evolution::dg::subcell::GhostData,
+          boost::hash<std::pair<Direction<1>, ElementId<1>>>>& ghost_data,
       const Mesh<1>& subcell_mesh) const;
 
   void reconstruct_fd_neighbor(
       gsl::not_null<Variables<face_vars_tags>*> vars_on_face,
       const Variables<volume_vars_tags>& volume_vars, const Element<1>& element,
-      const FixedHashMap<maximum_number_of_neighbors(1),
-                         std::pair<Direction<1>, ElementId<1>>, DataVector,
-                         boost::hash<std::pair<Direction<1>, ElementId<1>>>>&
-          neighbor_data,
+      const FixedHashMap<
+          maximum_number_of_neighbors(1), std::pair<Direction<1>, ElementId<1>>,
+          evolution::dg::subcell::GhostData,
+          boost::hash<std::pair<Direction<1>, ElementId<1>>>>& ghost_data,
       const Mesh<1>& subcell_mesh,
       const Direction<1> direction_to_reconstruct) const;
 };

--- a/src/Evolution/Systems/Burgers/FiniteDifference/ReconstructWork.hpp
+++ b/src/Evolution/Systems/Burgers/FiniteDifference/ReconstructWork.hpp
@@ -29,6 +29,9 @@ template <size_t Dim>
 class Element;
 template <size_t Dim>
 class Mesh;
+namespace evolution::dg::subcell {
+class GhostData;
+}  // namespace evolution::dg::subcell
 /// \endcond
 
 namespace Burgers::fd {
@@ -42,10 +45,10 @@ void reconstruct_work(
     gsl::not_null<std::array<Variables<TagsList>, 1>*> vars_on_upper_face,
     const Reconstructor& reconstruct,
     const Variables<tmpl::list<Tags::U>> volume_vars, const Element<1>& element,
-    const FixedHashMap<maximum_number_of_neighbors(1),
-                       std::pair<Direction<1>, ElementId<1>>, DataVector,
-                       boost::hash<std::pair<Direction<1>, ElementId<1>>>>&
-        neighbor_data,
+    const FixedHashMap<
+        maximum_number_of_neighbors(1), std::pair<Direction<1>, ElementId<1>>,
+        evolution::dg::subcell::GhostData,
+        boost::hash<std::pair<Direction<1>, ElementId<1>>>>& ghost_data,
     const Mesh<1>& subcell_mesh, const size_t ghost_zone_size);
 
 /*!
@@ -62,10 +65,10 @@ void reconstruct_fd_neighbor_work(
     const ReconstructUpper& reconstruct_upper_neighbor,
     const Variables<tmpl::list<Tags::U>>& subcell_volume_vars,
     const Element<1>& element,
-    const FixedHashMap<maximum_number_of_neighbors(1),
-                       std::pair<Direction<1>, ElementId<1>>, DataVector,
-                       boost::hash<std::pair<Direction<1>, ElementId<1>>>>&
-        neighbor_data,
+    const FixedHashMap<
+        maximum_number_of_neighbors(1), std::pair<Direction<1>, ElementId<1>>,
+        evolution::dg::subcell::GhostData,
+        boost::hash<std::pair<Direction<1>, ElementId<1>>>>& ghost_data,
     const Mesh<1>& subcell_mesh, const Direction<1>& direction_to_reconstruct,
     const size_t ghost_zone_size);
 }  // namespace Burgers::fd

--- a/src/Evolution/Systems/Burgers/FiniteDifference/ReconstructWork.tpp
+++ b/src/Evolution/Systems/Burgers/FiniteDifference/ReconstructWork.tpp
@@ -8,8 +8,8 @@
 #include <cstddef>
 #include <utility>
 
-#include "DataStructures/FixedHashMap.hpp"
 #include "DataStructures/DataVector.hpp"
+#include "DataStructures/FixedHashMap.hpp"
 #include "DataStructures/Index.hpp"
 #include "DataStructures/Variables.hpp"
 #include "Domain/Structure/Direction.hpp"
@@ -30,10 +30,10 @@ void reconstruct_work(
     const gsl::not_null<std::array<Variables<TagsList>, 1>*> vars_on_upper_face,
     const Reconstructor& reconstruct,
     const Variables<tmpl::list<Tags::U>> volume_vars, const Element<1>& element,
-    const FixedHashMap<
-        maximum_number_of_neighbors(1), std::pair<Direction<1>, ElementId<1>>,
-        DataVector,
-        boost::hash<std::pair<Direction<1>, ElementId<1>>>>& neighbor_data,
+    const FixedHashMap<maximum_number_of_neighbors(1),
+                       std::pair<Direction<1>, ElementId<1>>, DataVector,
+                       boost::hash<std::pair<Direction<1>, ElementId<1>>>>&
+        neighbor_data,
     const Mesh<1>& subcell_mesh, const size_t ghost_zone_size) {
   const size_t volume_num_pts = subcell_mesh.number_of_grid_points();
   const size_t reconstructed_num_pts = volume_num_pts + 1;
@@ -104,10 +104,10 @@ void reconstruct_fd_neighbor_work(
     const ReconstructUpper& reconstruct_upper_neighbor,
     const Variables<tmpl::list<Tags::U>>& subcell_volume_vars,
     const Element<1>& element,
-    const FixedHashMap<
-        maximum_number_of_neighbors(1), std::pair<Direction<1>, ElementId<1>>,
-        DataVector,
-        boost::hash<std::pair<Direction<1>, ElementId<1>>>>& neighbor_data,
+    const FixedHashMap<maximum_number_of_neighbors(1),
+                       std::pair<Direction<1>, ElementId<1>>, DataVector,
+                       boost::hash<std::pair<Direction<1>, ElementId<1>>>>&
+        neighbor_data,
     const Mesh<1>& subcell_mesh, const Direction<1>& direction_to_reconstruct,
     const size_t ghost_zone_size) {
   const std::pair mortar_id{

--- a/src/Evolution/Systems/Burgers/Subcell/NeighborPackagedData.hpp
+++ b/src/Evolution/Systems/Burgers/Subcell/NeighborPackagedData.hpp
@@ -90,7 +90,7 @@ struct NeighborPackagedData {
         db::get<typename System::variables_tag>(box), dg_mesh,
         subcell_mesh.extents());
 
-    const auto& neighbor_subcell_data =
+    const auto& ghost_subcell_data =
         db::get<evolution::dg::subcell::Tags::GhostDataForReconstruction<1>>(
             box);
 
@@ -129,11 +129,11 @@ struct NeighborPackagedData {
           call_with_dynamic_type<
               void, typename Burgers::fd::Reconstructor::creatable_classes>(
               &recons,
-              [&element, &mortar_id, &neighbor_subcell_data, &subcell_mesh,
+              [&element, &mortar_id, &ghost_subcell_data, &subcell_mesh,
                &vars_on_face, &volume_vars_subcell](const auto& reconstructor) {
                 reconstructor->reconstruct_fd_neighbor(
                     make_not_null(&vars_on_face), volume_vars_subcell, element,
-                    neighbor_subcell_data, subcell_mesh, mortar_id.first);
+                    ghost_subcell_data, subcell_mesh, mortar_id.first);
               });
 
           // Compute fluxes

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/BoundaryConditionGhostData.hpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/BoundaryConditionGhostData.hpp
@@ -121,8 +121,16 @@ void BoundaryConditionGhostData::apply(
 
     // Allocate a vector to store the computed FD ghost data and assign a
     // non-owning Variables on it.
-    DataVector boundary_ghost_data{number_of_tensor_components *
-                                   ghost_zone_size * num_face_pts};
+    auto& all_ghost_data = db::get_mutable_reference<
+        evolution::dg::subcell::Tags::GhostDataForReconstruction<3>>(box);
+    // Put the computed ghost data into neighbor data with {direction,
+    // ElementId::external_boundary_id()} as the mortar_id key
+    const std::pair mortar_id{direction, ElementId<3>::external_boundary_id()};
+    all_ghost_data[mortar_id] = evolution::dg::subcell::GhostData{1};
+    DataVector& boundary_ghost_data =
+        all_ghost_data.at(mortar_id).neighbor_ghost_data_for_reconstruction();
+    boundary_ghost_data.destructive_resize(number_of_tensor_components *
+                                           ghost_zone_size * num_face_pts);
     Variables<reconstruction_tags> ghost_data_vars{boundary_ghost_data.data(),
                                                    boundary_ghost_data.size()};
 
@@ -189,15 +197,6 @@ void BoundaryConditionGhostData::apply(
                   << pretty_type::short_name<BoundaryCondition>()
                   << " when using finite-difference");
           }
-        });
-
-    // Put the computed ghost data into neighbor data with {direction,
-    // ElementId::external_boundary_id()} as the mortar_id key
-    const std::pair mortar_id{direction, ElementId<3>::external_boundary_id()};
-
-    db::mutate<evolution::dg::subcell::Tags::GhostDataForReconstruction<3>>(
-        box, [&mortar_id, &boundary_ghost_data](auto neighbor_data) {
-          (*neighbor_data)[mortar_id] = std::move(boundary_ghost_data);
         });
   }
 }

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/Derivatives.hpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/Derivatives.hpp
@@ -24,6 +24,9 @@ template <size_t Dim>
 class Mesh;
 template <typename TagsList>
 class Variables;
+namespace evolution::dg::subcell {
+class GhostData;
+}  // namespace evolution::dg::subcell
 /// \endcond
 
 namespace grmhd::GhValenciaDivClean::fd {
@@ -48,10 +51,10 @@ void spacetime_derivatives(
     const Variables<
         typename grmhd::GhValenciaDivClean::System::variables_tag::tags_list>&
         volume_evolved_variables,
-    const FixedHashMap<maximum_number_of_neighbors(3),
-                       std::pair<Direction<3>, ElementId<3>>, DataVector,
-                       boost::hash<std::pair<Direction<3>, ElementId<3>>>>&
-        neighbor_data_for_reconstruction,
+    const FixedHashMap<
+        maximum_number_of_neighbors(3), std::pair<Direction<3>, ElementId<3>>,
+        evolution::dg::subcell::GhostData,
+        boost::hash<std::pair<Direction<3>, ElementId<3>>>>& all_ghost_data,
     const Mesh<3>& volume_mesh,
     const InverseJacobian<DataVector, 3, Frame::ElementLogical,
                           Frame::Inertial>&

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/Filters.cpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/Filters.cpp
@@ -14,6 +14,7 @@
 #include "Domain/Structure/Direction.hpp"
 #include "Domain/Structure/ElementId.hpp"
 #include "Domain/Structure/MaxNumberOfNeighbors.hpp"
+#include "Evolution/DgSubcell/GhostData.hpp"
 #include "Evolution/Systems/GrMhd/GhValenciaDivClean/System.hpp"
 #include "Evolution/Systems/GrMhd/GhValenciaDivClean/Tags.hpp"
 #include "NumericalAlgorithms/FiniteDifference/Filter.hpp"
@@ -30,10 +31,10 @@ void spacetime_kreiss_oliger_filter(
     const Variables<
         typename grmhd::GhValenciaDivClean::System::variables_tag::tags_list>&
         volume_evolved_variables,
-    const FixedHashMap<maximum_number_of_neighbors(3),
-                       std::pair<Direction<3>, ElementId<3>>, DataVector,
-                       boost::hash<std::pair<Direction<3>, ElementId<3>>>>&
-        neighbor_data_for_reconstruction,
+    const FixedHashMap<
+        maximum_number_of_neighbors(3), std::pair<Direction<3>, ElementId<3>>,
+        evolution::dg::subcell::GhostData,
+        boost::hash<std::pair<Direction<3>, ElementId<3>>>>& all_ghost_data,
     const Mesh<3>& volume_mesh, const size_t order, const double epsilon) {
   if (UNLIKELY(result->number_of_grid_points() !=
                volume_evolved_variables.number_of_grid_points())) {
@@ -47,11 +48,12 @@ void spacetime_kreiss_oliger_filter(
       number_of_independent_components;
 
   DirectionMap<3, gsl::span<const double>> ghost_cell_vars{};
-  for (const auto& [directional_element_id, neighbor_data] :
-       neighbor_data_for_reconstruction) {
+  for (const auto& [directional_element_id, ghost_data] : all_ghost_data) {
     using NeighborVariables =
         Variables<grmhd::GhValenciaDivClean::Tags::
                       primitive_grmhd_and_spacetime_reconstruction_tags>;
+    const DataVector& neighbor_data =
+        ghost_data.neighbor_ghost_data_for_reconstruction();
     const size_t neighbor_number_of_points =
         neighbor_data.size() /
         NeighborVariables::number_of_independent_components;

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/Filters.hpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/Filters.hpp
@@ -24,6 +24,9 @@ template <size_t Dim>
 class Mesh;
 template <typename TagsList>
 class Variables;
+namespace evolution::dg::subcell {
+class GhostData;
+}  // namespace evolution::dg::subcell
 /// \endcond
 
 namespace grmhd::GhValenciaDivClean::fd {
@@ -38,9 +41,9 @@ void spacetime_kreiss_oliger_filter(
     const Variables<
         typename grmhd::GhValenciaDivClean::System::variables_tag::tags_list>&
         volume_evolved_variables,
-    const FixedHashMap<maximum_number_of_neighbors(3),
-                       std::pair<Direction<3>, ElementId<3>>, DataVector,
-                       boost::hash<std::pair<Direction<3>, ElementId<3>>>>&
-        neighbor_data_for_reconstruction,
+    const FixedHashMap<
+        maximum_number_of_neighbors(3), std::pair<Direction<3>, ElementId<3>>,
+        evolution::dg::subcell::GhostData,
+        boost::hash<std::pair<Direction<3>, ElementId<3>>>>& all_ghost_data,
     const Mesh<3>& volume_mesh, size_t order, double epsilon);
 }  // namespace grmhd::GhValenciaDivClean::fd

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/MonotonisedCentral.cpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/MonotonisedCentral.cpp
@@ -22,6 +22,7 @@
 #include "Domain/Structure/ElementId.hpp"
 #include "Domain/Structure/MaxNumberOfNeighbors.hpp"
 #include "Domain/Structure/Side.hpp"
+#include "Evolution/DgSubcell/GhostData.hpp"
 #include "Evolution/DiscontinuousGalerkin/Actions/NormalCovectorAndMagnitude.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
 #include "Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/ReconstructWork.tpp"
@@ -68,9 +69,10 @@ void MonotonisedCentralPrim::reconstruct(
     const EquationsOfState::EquationOfState<true, ThermodynamicDim>& eos,
     const Element<dim>& element,
     const FixedHashMap<maximum_number_of_neighbors(dim),
-                       std::pair<Direction<dim>, ElementId<dim>>, DataVector,
+                       std::pair<Direction<dim>, ElementId<dim>>,
+                       evolution::dg::subcell::GhostData,
                        boost::hash<std::pair<Direction<dim>, ElementId<dim>>>>&
-        neighbor_data,
+        ghost_data,
     const Mesh<dim>& subcell_mesh) const {
   using prim_tags_for_reconstruction =
       grmhd::GhValenciaDivClean::Tags::primitive_grmhd_reconstruction_tags;
@@ -83,7 +85,7 @@ void MonotonisedCentralPrim::reconstruct(
                boost::hash<std::pair<Direction<dim>, ElementId<dim>>>>
       neighbor_variables_data{};
   ::fd::neighbor_data_as_variables<dim>(make_not_null(&neighbor_variables_data),
-                                        neighbor_data, ghost_zone_size(),
+                                        ghost_data, ghost_zone_size(),
                                         subcell_mesh);
 
   reconstruct_prims_work<tmpl::list<gr::Tags::SpacetimeMetric<3>>,
@@ -139,9 +141,10 @@ void MonotonisedCentralPrim::reconstruct_fd_neighbor(
     const EquationsOfState::EquationOfState<true, ThermodynamicDim>& eos,
     const Element<dim>& element,
     const FixedHashMap<maximum_number_of_neighbors(dim),
-                       std::pair<Direction<dim>, ElementId<dim>>, DataVector,
+                       std::pair<Direction<dim>, ElementId<dim>>,
+                       evolution::dg::subcell::GhostData,
                        boost::hash<std::pair<Direction<dim>, ElementId<dim>>>>&
-        neighbor_data,
+        ghost_data,
     const Mesh<dim>& subcell_mesh,
     const Direction<dim> direction_to_reconstruct) const {
   using prim_tags_for_reconstruction =
@@ -227,7 +230,7 @@ void MonotonisedCentralPrim::reconstruct_fd_neighbor(
                   shift, spacetime_metric);
       },
       subcell_volume_prims, subcell_volume_spacetime_metric, eos, element,
-      neighbor_data, subcell_mesh, direction_to_reconstruct, ghost_zone_size(),
+      ghost_data, subcell_mesh, direction_to_reconstruct, ghost_zone_size(),
       true);
 }
 
@@ -242,7 +245,7 @@ bool operator!=(const MonotonisedCentralPrim& lhs,
 }
 
 #define THERMO_DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
-#define TAGS_LIST_FD(data)                                                       \
+#define TAGS_LIST_FD(data)                                                    \
   tmpl::list<                                                                 \
       gr::Tags::SpacetimeMetric<3>, GeneralizedHarmonic::Tags::Pi<3>,         \
       GeneralizedHarmonic::Tags::Phi<3>, ValenciaDivClean::Tags::TildeD,      \
@@ -326,9 +329,10 @@ bool operator!=(const MonotonisedCentralPrim& lhs,
       const EquationsOfState::EquationOfState<true, THERMO_DIM(data)>& eos,    \
       const Element<3>& element,                                               \
       const FixedHashMap<maximum_number_of_neighbors(3),                       \
-                         std::pair<Direction<3>, ElementId<3>>, DataVector,    \
+                         std::pair<Direction<3>, ElementId<3>>,                \
+                         evolution::dg::subcell::GhostData,                    \
                          boost::hash<std::pair<Direction<3>, ElementId<3>>>>&  \
-          neighbor_data,                                                       \
+          ghost_data,                                                          \
       const Mesh<3>& subcell_mesh) const;                                      \
   template void MonotonisedCentralPrim::reconstruct_fd_neighbor(               \
       gsl::not_null<Variables<TAGS_LIST_DG_FD_INTERFACE(data)>*> vars_on_face, \
@@ -339,9 +343,10 @@ bool operator!=(const MonotonisedCentralPrim& lhs,
       const EquationsOfState::EquationOfState<true, THERMO_DIM(data)>& eos,    \
       const Element<3>& element,                                               \
       const FixedHashMap<maximum_number_of_neighbors(3),                       \
-                         std::pair<Direction<3>, ElementId<3>>, DataVector,    \
+                         std::pair<Direction<3>, ElementId<3>>,                \
+                         evolution::dg::subcell::GhostData,                    \
                          boost::hash<std::pair<Direction<3>, ElementId<3>>>>&  \
-          neighbor_data,                                                       \
+          ghost_data,                                                          \
       const Mesh<3>& subcell_mesh,                                             \
       const Direction<3> direction_to_reconstruct) const;
 

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/MonotonisedCentral.hpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/MonotonisedCentral.hpp
@@ -52,6 +52,9 @@ class not_null;
 namespace PUP {
 class er;
 }  // namespace PUP
+namespace evolution::dg::subcell {
+class GhostData;
+}  // namespace evolution::dg::subcell
 /// \endcond
 
 namespace grmhd::GhValenciaDivClean::fd {
@@ -111,9 +114,9 @@ class MonotonisedCentralPrim : public Reconstructor {
       const Element<dim>& element,
       const FixedHashMap<
           maximum_number_of_neighbors(dim),
-          std::pair<Direction<dim>, ElementId<dim>>, DataVector,
-          boost::hash<std::pair<Direction<dim>, ElementId<dim>>>>&
-          neighbor_data,
+          std::pair<Direction<dim>, ElementId<dim>>,
+          evolution::dg::subcell::GhostData,
+          boost::hash<std::pair<Direction<dim>, ElementId<dim>>>>& ghost_data,
       const Mesh<dim>& subcell_mesh) const;
 
   /// Called by an element doing DG when the neighbor is doing subcell.
@@ -128,9 +131,9 @@ class MonotonisedCentralPrim : public Reconstructor {
       const Element<dim>& element,
       const FixedHashMap<
           maximum_number_of_neighbors(dim),
-          std::pair<Direction<dim>, ElementId<dim>>, DataVector,
-          boost::hash<std::pair<Direction<dim>, ElementId<dim>>>>&
-          neighbor_data,
+          std::pair<Direction<dim>, ElementId<dim>>,
+          evolution::dg::subcell::GhostData,
+          boost::hash<std::pair<Direction<dim>, ElementId<dim>>>>& ghost_data,
       const Mesh<dim>& subcell_mesh,
       const Direction<dim> direction_to_reconstruct) const;
 };

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/ReconstructWork.hpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/ReconstructWork.hpp
@@ -33,6 +33,9 @@ namespace EquationsOfState {
 template <bool IsRelativistic, size_t ThermodynamicDim>
 class EquationOfState;
 }  // namespace EquationsOfState
+namespace evolution::dg::subcell {
+class GhostData;
+}  // namespace evolution::dg::subcell
 /// \endcond
 
 namespace grmhd::GhValenciaDivClean::fd {
@@ -97,10 +100,10 @@ void reconstruct_fd_neighbor_work(
         subcell_volume_spacetime_vars,
     const EquationsOfState::EquationOfState<true, ThermodynamicDim>& eos,
     const Element<3>& element,
-    const FixedHashMap<maximum_number_of_neighbors(3),
-                       std::pair<Direction<3>, ElementId<3>>, DataVector,
-                       boost::hash<std::pair<Direction<3>, ElementId<3>>>>&
-        neighbor_data,
+    const FixedHashMap<
+        maximum_number_of_neighbors(3), std::pair<Direction<3>, ElementId<3>>,
+        evolution::dg::subcell::GhostData,
+        boost::hash<std::pair<Direction<3>, ElementId<3>>>>& ghost_data,
     const Mesh<3>& subcell_mesh, const Direction<3>& direction_to_reconstruct,
     size_t ghost_zone_size, bool compute_conservatives);
 }  // namespace grmhd::GhValenciaDivClean::fd

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/ReconstructWork.tpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/ReconstructWork.tpp
@@ -72,14 +72,14 @@ void reconstruct_prims_work(
       ghost_zone_size * subcell_mesh.extents().slice_away(0).product();
   size_t vars_in_neighbor_count = 0;
   tmpl::for_each<PrimTagsForReconstruction>([&element, &neighbor_data,
-                                                neighbor_num_pts,
-                                                &hydro_reconstructor,
-                                                reconstructed_num_pts,
-                                                volume_num_pts, &volume_prims,
-                                                &vars_in_neighbor_count,
-                                                &vars_on_lower_face,
-                                                &vars_on_upper_face,
-                                                &subcell_mesh](auto tag_v) {
+                                             neighbor_num_pts,
+                                             &hydro_reconstructor,
+                                             reconstructed_num_pts,
+                                             volume_num_pts, &volume_prims,
+                                             &vars_in_neighbor_count,
+                                             &vars_on_lower_face,
+                                             &vars_on_upper_face,
+                                             &subcell_mesh](auto tag_v) {
     using tag = tmpl::type_from<decltype(tag_v)>;
     const typename tag::type* volume_tensor_ptr = nullptr;
     Variables<tmpl::list<
@@ -253,10 +253,10 @@ void reconstruct_fd_neighbor_work(
         subcell_volume_spacetime_vars,
     const EquationsOfState::EquationOfState<true, ThermodynamicDim>& eos,
     const Element<3>& element,
-    const FixedHashMap<
-        maximum_number_of_neighbors(3), std::pair<Direction<3>, ElementId<3>>,
-        DataVector,
-        boost::hash<std::pair<Direction<3>, ElementId<3>>>>& neighbor_data,
+    const FixedHashMap<maximum_number_of_neighbors(3),
+                       std::pair<Direction<3>, ElementId<3>>, DataVector,
+                       boost::hash<std::pair<Direction<3>, ElementId<3>>>>&
+        neighbor_data,
     const Mesh<3>& subcell_mesh, const Direction<3>& direction_to_reconstruct,
     const size_t ghost_zone_size, const bool compute_conservatives) {
   const std::pair mortar_id{

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/NeighborPackagedData.hpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/NeighborPackagedData.hpp
@@ -99,7 +99,7 @@ struct NeighborPackagedData {
       return neighbor_package_data;
     }
 
-    const auto& neighbor_subcell_data =
+    const auto& ghost_subcell_data =
         db::get<evolution::dg::subcell::Tags::GhostDataForReconstruction<3>>(
             box);
     const Mesh<3>& subcell_mesh =
@@ -138,7 +138,7 @@ struct NeighborPackagedData {
     call_with_dynamic_type<void, derived_boundary_corrections>(
         &base_boundary_correction,
         [&box, &dg_mesh, &mortars_to_reconstruct_to, &neighbor_package_data,
-         &neighbor_subcell_data, &recons, &subcell_mesh, &subcell_options,
+         &ghost_subcell_data, &recons, &subcell_mesh, &subcell_options,
          &volume_prims,
          &volume_spacetime_vars](const auto* gh_grmhd_correction) {
           using DerivedCorrection =
@@ -185,13 +185,13 @@ struct NeighborPackagedData {
             call_with_dynamic_type<void,
                                    typename grmhd::GhValenciaDivClean::fd::
                                        Reconstructor::creatable_classes>(
-                &recons, [&element, &eos, &mortar_id, &neighbor_subcell_data,
+                &recons, [&element, &eos, &mortar_id, &ghost_subcell_data,
                           &subcell_mesh, &vars_on_face, &volume_prims,
                           &volume_spacetime_vars](const auto& reconstructor) {
                   reconstructor->reconstruct_fd_neighbor(
                       make_not_null(&vars_on_face), volume_prims,
-                      volume_spacetime_vars, eos, element,
-                      neighbor_subcell_data, subcell_mesh, mortar_id.first);
+                      volume_spacetime_vars, eos, element, ghost_subcell_data,
+                      subcell_mesh, mortar_id.first);
                 });
 
             grmhd::ValenciaDivClean::subcell::compute_fluxes(

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/TimeDerivative.hpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/TimeDerivative.hpp
@@ -483,15 +483,14 @@ struct TimeDerivative {
     // This is reasonable since the systems are a tensor product system.
     const auto& base_boundary_correction =
         db::get<evolution::Tags::BoundaryCorrection<System>>(*box);
-    using derived_boundary_corrections = typename std::decay_t<
-        decltype(base_boundary_correction)>::creatable_classes;
+    using derived_boundary_corrections = typename std::decay_t<decltype(
+        base_boundary_correction)>::creatable_classes;
     std::array<Variables<grmhd_evolved_vars_tags>, 3> boundary_corrections{};
     call_with_dynamic_type<void, derived_boundary_corrections>(
         &base_boundary_correction, [&](const auto* gh_grmhd_correction) {
           // Need the GH packaged tags to avoid projecting them.
-          using gh_dg_package_field_tags = typename std::decay_t<
-              decltype(gh_grmhd_correction
-                           ->gh_correction())>::dg_package_field_tags;
+          using gh_dg_package_field_tags = typename std::decay_t<decltype(
+              gh_grmhd_correction->gh_correction())>::dg_package_field_tags;
           // Only apply correction to GRMHD variables.
           const auto& boundary_correction =
               gh_grmhd_correction->valencia_correction();
@@ -520,8 +519,8 @@ struct TimeDerivative {
               &recons,
               [&box, &package_data_argvars_lower_face,
                &package_data_argvars_upper_face](const auto& reconstructor) {
-                db::apply<typename std::decay_t<
-                    decltype(*reconstructor)>::reconstruction_argument_tags>(
+                db::apply<typename std::decay_t<decltype(
+                    *reconstructor)>::reconstruction_argument_tags>(
                     [&package_data_argvars_lower_face,
                      &package_data_argvars_upper_face,
                      &reconstructor](const auto&... args) {

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/TimeDerivative.hpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/TimeDerivative.hpp
@@ -444,12 +444,12 @@ struct TimeDerivative {
       db::mutate<evolved_vars_tag>(
           box,
           [&filter_options, &recons, &subcell_mesh](const auto evolved_vars_ptr,
-                                                    const auto& neighbor_data) {
+                                                    const auto& ghost_data) {
             typename evolved_vars_tag::type filtered_vars = *evolved_vars_ptr;
             // $(recons.ghost_zone_size() - 1) * 2 + 1$ => always use highest
             // order dissipation filter possible.
             grmhd::GhValenciaDivClean::fd::spacetime_kreiss_oliger_filter(
-                make_not_null(&filtered_vars), *evolved_vars_ptr, neighbor_data,
+                make_not_null(&filtered_vars), *evolved_vars_ptr, ghost_data,
                 subcell_mesh, 2 * recons.ghost_zone_size(),
                 filter_options.spacetime_dissipation.value());
             *evolved_vars_ptr = filtered_vars;

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/MonotonicityPreserving5.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/MonotonicityPreserving5.cpp
@@ -19,6 +19,7 @@
 #include "Domain/Structure/Element.hpp"
 #include "Domain/Structure/ElementId.hpp"
 #include "Domain/Structure/MaxNumberOfNeighbors.hpp"
+#include "Evolution/DgSubcell/GhostData.hpp"
 #include "Evolution/DiscontinuousGalerkin/Actions/NormalCovectorAndMagnitude.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/ReconstructWork.tpp"
 #include "NumericalAlgorithms/FiniteDifference/MonotonicityPreserving5.hpp"
@@ -62,9 +63,10 @@ void MonotonicityPreserving5Prim::reconstruct(
     const EquationsOfState::EquationOfState<true, ThermodynamicDim>& eos,
     const Element<dim>& element,
     const FixedHashMap<maximum_number_of_neighbors(dim),
-                       std::pair<Direction<dim>, ElementId<dim>>, DataVector,
+                       std::pair<Direction<dim>, ElementId<dim>>,
+                       evolution::dg::subcell::GhostData,
                        boost::hash<std::pair<Direction<dim>, ElementId<dim>>>>&
-        neighbor_data,
+        ghost_data,
     const Mesh<dim>& subcell_mesh) const {
   FixedHashMap<maximum_number_of_neighbors(dim),
                std::pair<Direction<dim>, ElementId<dim>>,
@@ -72,7 +74,7 @@ void MonotonicityPreserving5Prim::reconstruct(
                boost::hash<std::pair<Direction<dim>, ElementId<dim>>>>
       neighbor_variables_data{};
   ::fd::neighbor_data_as_variables<dim>(make_not_null(&neighbor_variables_data),
-                                        neighbor_data, ghost_zone_size(),
+                                        ghost_data, ghost_zone_size(),
                                         subcell_mesh);
 
   reconstruct_prims_work<prims_to_reconstruct_tags>(
@@ -96,9 +98,10 @@ void MonotonicityPreserving5Prim::reconstruct_fd_neighbor(
     const EquationsOfState::EquationOfState<true, ThermodynamicDim>& eos,
     const Element<dim>& element,
     const FixedHashMap<maximum_number_of_neighbors(dim),
-                       std::pair<Direction<dim>, ElementId<dim>>, DataVector,
+                       std::pair<Direction<dim>, ElementId<dim>>,
+                       evolution::dg::subcell::GhostData,
                        boost::hash<std::pair<Direction<dim>, ElementId<dim>>>>&
-        neighbor_data,
+        ghost_data,
     const Mesh<dim>& subcell_mesh,
     const Direction<dim> direction_to_reconstruct) const {
   reconstruct_fd_neighbor_work<prims_to_reconstruct_tags,
@@ -130,7 +133,7 @@ void MonotonicityPreserving5Prim::reconstruct_fd_neighbor(
             tensor_component_neighbor, subcell_extents, ghost_data_extents,
             local_direction_to_reconstruct, alpha_, epsilon_);
       },
-      subcell_volume_prims, eos, element, neighbor_data, subcell_mesh,
+      subcell_volume_prims, eos, element, ghost_data, subcell_mesh,
       direction_to_reconstruct, ghost_zone_size(), true);
 }
 
@@ -183,9 +186,10 @@ bool operator!=(const MonotonicityPreserving5Prim& lhs,
       const EquationsOfState::EquationOfState<true, THERMO_DIM(data)>& eos,   \
       const Element<3>& element,                                              \
       const FixedHashMap<maximum_number_of_neighbors(3),                      \
-                         std::pair<Direction<3>, ElementId<3>>, DataVector,   \
+                         std::pair<Direction<3>, ElementId<3>>,               \
+                         evolution::dg::subcell::GhostData,                   \
                          boost::hash<std::pair<Direction<3>, ElementId<3>>>>& \
-          neighbor_data,                                                      \
+          ghost_data,                                                         \
       const Mesh<3>& subcell_mesh) const;                                     \
   template void MonotonicityPreserving5Prim::reconstruct_fd_neighbor(         \
       gsl::not_null<Variables<TAGS_LIST(data)>*> vars_on_face,                \
@@ -193,9 +197,10 @@ bool operator!=(const MonotonicityPreserving5Prim& lhs,
       const EquationsOfState::EquationOfState<true, THERMO_DIM(data)>& eos,   \
       const Element<3>& element,                                              \
       const FixedHashMap<maximum_number_of_neighbors(3),                      \
-                         std::pair<Direction<3>, ElementId<3>>, DataVector,   \
+                         std::pair<Direction<3>, ElementId<3>>,               \
+                         evolution::dg::subcell::GhostData,                   \
                          boost::hash<std::pair<Direction<3>, ElementId<3>>>>& \
-          neighbor_data,                                                      \
+          ghost_data,                                                         \
       const Mesh<3>& subcell_mesh,                                            \
       const Direction<3> direction_to_reconstruct) const;
 

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/MonotonicityPreserving5.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/MonotonicityPreserving5.hpp
@@ -50,6 +50,9 @@ class er;
 }  // namespace PUP
 template <typename TagsList>
 class Variables;
+namespace evolution::dg::subcell {
+class GhostData;
+}  // namespace evolution::dg::subcell
 /// \endcond
 
 namespace grmhd::ValenciaDivClean::fd {
@@ -130,9 +133,9 @@ class MonotonicityPreserving5Prim : public Reconstructor {
       const Element<dim>& element,
       const FixedHashMap<
           maximum_number_of_neighbors(dim),
-          std::pair<Direction<dim>, ElementId<dim>>, DataVector,
-          boost::hash<std::pair<Direction<dim>, ElementId<dim>>>>&
-          neighbor_data,
+          std::pair<Direction<dim>, ElementId<dim>>,
+          evolution::dg::subcell::GhostData,
+          boost::hash<std::pair<Direction<dim>, ElementId<dim>>>>& ghost_data,
       const Mesh<dim>& subcell_mesh) const;
 
   template <size_t ThermodynamicDim, typename TagsList>
@@ -143,9 +146,9 @@ class MonotonicityPreserving5Prim : public Reconstructor {
       const Element<dim>& element,
       const FixedHashMap<
           maximum_number_of_neighbors(dim),
-          std::pair<Direction<dim>, ElementId<dim>>, DataVector,
-          boost::hash<std::pair<Direction<dim>, ElementId<dim>>>>&
-          neighbor_data,
+          std::pair<Direction<dim>, ElementId<dim>>,
+          evolution::dg::subcell::GhostData,
+          boost::hash<std::pair<Direction<dim>, ElementId<dim>>>>& ghost_data,
       const Mesh<dim>& subcell_mesh,
       const Direction<dim> direction_to_reconstruct) const;
 

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/MonotonisedCentral.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/MonotonisedCentral.cpp
@@ -19,6 +19,7 @@
 #include "Domain/Structure/Element.hpp"
 #include "Domain/Structure/ElementId.hpp"
 #include "Domain/Structure/MaxNumberOfNeighbors.hpp"
+#include "Evolution/DgSubcell/GhostData.hpp"
 #include "Evolution/DiscontinuousGalerkin/Actions/NormalCovectorAndMagnitude.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/ReconstructWork.tpp"
 #include "NumericalAlgorithms/FiniteDifference/MonotonisedCentral.hpp"
@@ -52,9 +53,10 @@ void MonotonisedCentralPrim::reconstruct(
     const EquationsOfState::EquationOfState<true, ThermodynamicDim>& eos,
     const Element<dim>& element,
     const FixedHashMap<maximum_number_of_neighbors(dim),
-                       std::pair<Direction<dim>, ElementId<dim>>, DataVector,
+                       std::pair<Direction<dim>, ElementId<dim>>,
+                       evolution::dg::subcell::GhostData,
                        boost::hash<std::pair<Direction<dim>, ElementId<dim>>>>&
-        neighbor_data,
+        ghost_data,
     const Mesh<dim>& subcell_mesh) const {
   FixedHashMap<maximum_number_of_neighbors(dim),
                std::pair<Direction<dim>, ElementId<dim>>,
@@ -62,7 +64,7 @@ void MonotonisedCentralPrim::reconstruct(
                boost::hash<std::pair<Direction<dim>, ElementId<dim>>>>
       neighbor_variables_data{};
   ::fd::neighbor_data_as_variables<dim>(make_not_null(&neighbor_variables_data),
-                                        neighbor_data, ghost_zone_size(),
+                                        ghost_data, ghost_zone_size(),
                                         subcell_mesh);
   reconstruct_prims_work<prims_to_reconstruct_tags>(
       vars_on_lower_face, vars_on_upper_face,
@@ -84,9 +86,10 @@ void MonotonisedCentralPrim::reconstruct_fd_neighbor(
     const EquationsOfState::EquationOfState<true, ThermodynamicDim>& eos,
     const Element<dim>& element,
     const FixedHashMap<maximum_number_of_neighbors(dim),
-                       std::pair<Direction<dim>, ElementId<dim>>, DataVector,
+                       std::pair<Direction<dim>, ElementId<dim>>,
+                       evolution::dg::subcell::GhostData,
                        boost::hash<std::pair<Direction<dim>, ElementId<dim>>>>&
-        neighbor_data,
+        ghost_data,
     const Mesh<dim>& subcell_mesh,
     const Direction<dim> direction_to_reconstruct) const {
   reconstruct_fd_neighbor_work<prims_to_reconstruct_tags,
@@ -118,7 +121,7 @@ void MonotonisedCentralPrim::reconstruct_fd_neighbor(
             tensor_component_neighbor, subcell_extents, ghost_data_extents,
             local_direction_to_reconstruct);
       },
-      subcell_volume_prims, eos, element, neighbor_data, subcell_mesh,
+      subcell_volume_prims, eos, element, ghost_data, subcell_mesh,
       direction_to_reconstruct, ghost_zone_size(), true);
 }
 
@@ -171,9 +174,10 @@ bool operator!=(const MonotonisedCentralPrim& lhs,
       const EquationsOfState::EquationOfState<true, THERMO_DIM(data)>& eos,   \
       const Element<3>& element,                                              \
       const FixedHashMap<maximum_number_of_neighbors(3),                      \
-                         std::pair<Direction<3>, ElementId<3>>, DataVector,   \
+                         std::pair<Direction<3>, ElementId<3>>,               \
+                         evolution::dg::subcell::GhostData,                   \
                          boost::hash<std::pair<Direction<3>, ElementId<3>>>>& \
-          neighbor_data,                                                      \
+          ghost_data,                                                         \
       const Mesh<3>& subcell_mesh) const;                                     \
   template void MonotonisedCentralPrim::reconstruct_fd_neighbor(              \
       gsl::not_null<Variables<TAGS_LIST(data)>*> vars_on_face,                \
@@ -181,9 +185,10 @@ bool operator!=(const MonotonisedCentralPrim& lhs,
       const EquationsOfState::EquationOfState<true, THERMO_DIM(data)>& eos,   \
       const Element<3>& element,                                              \
       const FixedHashMap<maximum_number_of_neighbors(3),                      \
-                         std::pair<Direction<3>, ElementId<3>>, DataVector,   \
+                         std::pair<Direction<3>, ElementId<3>>,               \
+                         evolution::dg::subcell::GhostData,                   \
                          boost::hash<std::pair<Direction<3>, ElementId<3>>>>& \
-          neighbor_data,                                                      \
+          ghost_data,                                                         \
       const Mesh<3>& subcell_mesh,                                            \
       const Direction<3> direction_to_reconstruct) const;
 

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/MonotonisedCentral.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/MonotonisedCentral.hpp
@@ -48,6 +48,9 @@ class er;
 }  // namespace PUP
 template <typename TagsList>
 class Variables;
+namespace evolution::dg::subcell {
+class GhostData;
+}  // namespace evolution::dg::subcell
 /// \endcond
 
 namespace grmhd::ValenciaDivClean::fd {
@@ -106,9 +109,9 @@ class MonotonisedCentralPrim : public Reconstructor {
       const Element<dim>& element,
       const FixedHashMap<
           maximum_number_of_neighbors(dim),
-          std::pair<Direction<dim>, ElementId<dim>>, DataVector,
-          boost::hash<std::pair<Direction<dim>, ElementId<dim>>>>&
-          neighbor_data,
+          std::pair<Direction<dim>, ElementId<dim>>,
+          evolution::dg::subcell::GhostData,
+          boost::hash<std::pair<Direction<dim>, ElementId<dim>>>>& ghost_data,
       const Mesh<dim>& subcell_mesh) const;
 
   /// Called by an element doing DG when the neighbor is doing subcell.
@@ -120,9 +123,9 @@ class MonotonisedCentralPrim : public Reconstructor {
       const Element<dim>& element,
       const FixedHashMap<
           maximum_number_of_neighbors(dim),
-          std::pair<Direction<dim>, ElementId<dim>>, DataVector,
-          boost::hash<std::pair<Direction<dim>, ElementId<dim>>>>&
-          neighbor_data,
+          std::pair<Direction<dim>, ElementId<dim>>,
+          evolution::dg::subcell::GhostData,
+          boost::hash<std::pair<Direction<dim>, ElementId<dim>>>>& ghost_data,
       const Mesh<dim>& subcell_mesh,
       const Direction<dim> direction_to_reconstruct) const;
 };

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/PositivityPreservingAdaptiveOrder.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/PositivityPreservingAdaptiveOrder.cpp
@@ -21,6 +21,7 @@
 #include "Domain/Structure/ElementId.hpp"
 #include "Domain/Structure/MaxNumberOfNeighbors.hpp"
 #include "Domain/Structure/Side.hpp"
+#include "Evolution/DgSubcell/GhostData.hpp"
 #include "Evolution/DiscontinuousGalerkin/Actions/NormalCovectorAndMagnitude.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/ReconstructWork.tpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/Reconstructor.hpp"
@@ -103,10 +104,10 @@ void PositivityPreservingAdaptiveOrderPrim::reconstruct(
     const Variables<hydro::grmhd_tags<DataVector>>& volume_prims,
     const EquationsOfState::EquationOfState<true, ThermodynamicDim>& eos,
     const Element<3>& element,
-    const FixedHashMap<maximum_number_of_neighbors(3),
-                       std::pair<Direction<3>, ElementId<3>>, DataVector,
-                       boost::hash<std::pair<Direction<3>, ElementId<3>>>>&
-        neighbor_data,
+    const FixedHashMap<
+        maximum_number_of_neighbors(3), std::pair<Direction<3>, ElementId<3>>,
+        evolution::dg::subcell::GhostData,
+        boost::hash<std::pair<Direction<3>, ElementId<3>>>>& ghost_data,
     const Mesh<3>& subcell_mesh) const {
   FixedHashMap<maximum_number_of_neighbors(dim),
                std::pair<Direction<dim>, ElementId<dim>>,
@@ -114,7 +115,7 @@ void PositivityPreservingAdaptiveOrderPrim::reconstruct(
                boost::hash<std::pair<Direction<dim>, ElementId<dim>>>>
       neighbor_variables_data{};
   ::fd::neighbor_data_as_variables<dim>(make_not_null(&neighbor_variables_data),
-                                        neighbor_data, ghost_zone_size(),
+                                        ghost_data, ghost_zone_size(),
                                         subcell_mesh);
 
   reconstruct_prims_work<positivity_preserving_tags>(
@@ -157,10 +158,10 @@ void PositivityPreservingAdaptiveOrderPrim::reconstruct_fd_neighbor(
     const Variables<hydro::grmhd_tags<DataVector>>& subcell_volume_prims,
     const EquationsOfState::EquationOfState<true, ThermodynamicDim>& eos,
     const Element<3>& element,
-    const FixedHashMap<maximum_number_of_neighbors(3),
-                       std::pair<Direction<3>, ElementId<3>>, DataVector,
-                       boost::hash<std::pair<Direction<3>, ElementId<3>>>>&
-        neighbor_data,
+    const FixedHashMap<
+        maximum_number_of_neighbors(3), std::pair<Direction<3>, ElementId<3>>,
+        evolution::dg::subcell::GhostData,
+        boost::hash<std::pair<Direction<3>, ElementId<3>>>>& ghost_data,
     const Mesh<3>& subcell_mesh,
     const Direction<3> direction_to_reconstruct) const {
   reconstruct_fd_neighbor_work<positivity_preserving_tags,
@@ -196,7 +197,7 @@ void PositivityPreservingAdaptiveOrderPrim::reconstruct_fd_neighbor(
             eight_to_the_alpha_9_.value_or(
                 std::numeric_limits<double>::signaling_NaN()));
       },
-      subcell_volume_prims, eos, element, neighbor_data, subcell_mesh,
+      subcell_volume_prims, eos, element, ghost_data, subcell_mesh,
       direction_to_reconstruct, ghost_zone_size(), false);
   reconstruct_fd_neighbor_work<non_positive_tags, prims_to_reconstruct_tags>(
       vars_on_face,
@@ -230,7 +231,7 @@ void PositivityPreservingAdaptiveOrderPrim::reconstruct_fd_neighbor(
             eight_to_the_alpha_9_.value_or(
                 std::numeric_limits<double>::signaling_NaN()));
       },
-      subcell_volume_prims, eos, element, neighbor_data, subcell_mesh,
+      subcell_volume_prims, eos, element, ghost_data, subcell_mesh,
       direction_to_reconstruct, ghost_zone_size(), true);
 }
 
@@ -291,9 +292,10 @@ bool operator!=(const PositivityPreservingAdaptiveOrderPrim& lhs,
       const EquationsOfState::EquationOfState<true, THERMO_DIM(data)>& eos,   \
       const Element<3>& element,                                              \
       const FixedHashMap<maximum_number_of_neighbors(3),                      \
-                         std::pair<Direction<3>, ElementId<3>>, DataVector,   \
+                         std::pair<Direction<3>, ElementId<3>>,               \
+                         evolution::dg::subcell::GhostData,                   \
                          boost::hash<std::pair<Direction<3>, ElementId<3>>>>& \
-          neighbor_data,                                                      \
+          ghost_data,                                                         \
       const Mesh<3>& subcell_mesh) const;                                     \
   template void                                                               \
   PositivityPreservingAdaptiveOrderPrim::reconstruct_fd_neighbor(             \
@@ -302,9 +304,10 @@ bool operator!=(const PositivityPreservingAdaptiveOrderPrim& lhs,
       const EquationsOfState::EquationOfState<true, THERMO_DIM(data)>& eos,   \
       const Element<3>& element,                                              \
       const FixedHashMap<maximum_number_of_neighbors(3),                      \
-                         std::pair<Direction<3>, ElementId<3>>, DataVector,   \
+                         std::pair<Direction<3>, ElementId<3>>,               \
+                         evolution::dg::subcell::GhostData,                   \
                          boost::hash<std::pair<Direction<3>, ElementId<3>>>>& \
-          neighbor_data,                                                      \
+          ghost_data,                                                         \
       const Mesh<3>& subcell_mesh,                                            \
       const Direction<3> direction_to_reconstruct) const;
 

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/PositivityPreservingAdaptiveOrder.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/PositivityPreservingAdaptiveOrder.hpp
@@ -45,6 +45,9 @@ class er;
 }  // namespace PUP
 template <typename TagsList>
 class Variables;
+namespace evolution::dg::subcell {
+class GhostData;
+}  // namespace evolution::dg::subcell
 /// \endcond
 
 namespace grmhd::ValenciaDivClean::fd {
@@ -166,9 +169,9 @@ class PositivityPreservingAdaptiveOrderPrim : public Reconstructor {
       const Element<dim>& element,
       const FixedHashMap<
           maximum_number_of_neighbors(dim),
-          std::pair<Direction<dim>, ElementId<dim>>, DataVector,
-          boost::hash<std::pair<Direction<dim>, ElementId<dim>>>>&
-          neighbor_data,
+          std::pair<Direction<dim>, ElementId<dim>>,
+          evolution::dg::subcell::GhostData,
+          boost::hash<std::pair<Direction<dim>, ElementId<dim>>>>& ghost_data,
       const Mesh<dim>& subcell_mesh) const;
 
   template <size_t ThermodynamicDim, typename TagsList>
@@ -179,9 +182,9 @@ class PositivityPreservingAdaptiveOrderPrim : public Reconstructor {
       const Element<dim>& element,
       const FixedHashMap<
           maximum_number_of_neighbors(dim),
-          std::pair<Direction<dim>, ElementId<dim>>, DataVector,
-          boost::hash<std::pair<Direction<dim>, ElementId<dim>>>>&
-          neighbor_data,
+          std::pair<Direction<dim>, ElementId<dim>>,
+          evolution::dg::subcell::GhostData,
+          boost::hash<std::pair<Direction<dim>, ElementId<dim>>>>& ghost_data,
       const Mesh<dim>& subcell_mesh,
       const Direction<dim> direction_to_reconstruct) const;
 

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/PositivityPreservingAdaptiveOrder.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/PositivityPreservingAdaptiveOrder.hpp
@@ -206,12 +206,12 @@ class PositivityPreservingAdaptiveOrderPrim : public Reconstructor {
       const gsl::span<const double>&,
       const DirectionMap<dim, gsl::span<const double>>&, const Index<dim>&,
       size_t, double, double, double);
-  using PointerRecons = void (*)(
-      gsl::not_null<std::array<gsl::span<double>, dim>*>,
-      gsl::not_null<std::array<gsl::span<double>, dim>*>,
-      const gsl::span<const double>&,
-      const DirectionMap<dim, gsl::span<const double>>&, const Index<dim>&,
-      size_t, double, double, double);
+  using PointerRecons =
+      void (*)(gsl::not_null<std::array<gsl::span<double>, dim>*>,
+               gsl::not_null<std::array<gsl::span<double>, dim>*>,
+               const gsl::span<const double>&,
+               const DirectionMap<dim, gsl::span<const double>>&,
+               const Index<dim>&, size_t, double, double, double);
   PointerRecons reconstruct_ = nullptr;
   PointerReconsOrder pp_reconstruct_ = nullptr;
 

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/ReconstructWork.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/ReconstructWork.hpp
@@ -32,6 +32,9 @@ namespace EquationsOfState {
 template <bool IsRelativistic, size_t ThermodynamicDim>
 class EquationOfState;
 }  // namespace EquationsOfState
+namespace evolution::dg::subcell {
+class GhostData;
+}  // namespace evolution::dg::subcell
 /// \endcond
 
 namespace grmhd::ValenciaDivClean::fd {
@@ -87,10 +90,10 @@ void reconstruct_fd_neighbor_work(
     const Variables<PrimsTags>& subcell_volume_prims,
     const EquationsOfState::EquationOfState<true, ThermodynamicDim>& eos,
     const Element<3>& element,
-    const FixedHashMap<maximum_number_of_neighbors(3),
-                       std::pair<Direction<3>, ElementId<3>>, DataVector,
-                       boost::hash<std::pair<Direction<3>, ElementId<3>>>>&
-        neighbor_data,
+    const FixedHashMap<
+        maximum_number_of_neighbors(3), std::pair<Direction<3>, ElementId<3>>,
+        evolution::dg::subcell::GhostData,
+        boost::hash<std::pair<Direction<3>, ElementId<3>>>>& ghost_data,
     const Mesh<3>& subcell_mesh, const Direction<3>& direction_to_reconstruct,
     const size_t ghost_zone_size, bool compute_conservatives);
 }  // namespace grmhd::ValenciaDivClean::fd

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/ReconstructWork.tpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/ReconstructWork.tpp
@@ -229,10 +229,10 @@ void reconstruct_fd_neighbor_work(
     const Variables<PrimsTags>& subcell_volume_prims,
     const EquationsOfState::EquationOfState<true, ThermodynamicDim>& eos,
     const Element<3>& element,
-    const FixedHashMap<
-        maximum_number_of_neighbors(3), std::pair<Direction<3>, ElementId<3>>,
-        DataVector,
-        boost::hash<std::pair<Direction<3>, ElementId<3>>>>& neighbor_data,
+    const FixedHashMap<maximum_number_of_neighbors(3),
+                       std::pair<Direction<3>, ElementId<3>>, DataVector,
+                       boost::hash<std::pair<Direction<3>, ElementId<3>>>>&
+        neighbor_data,
     const Mesh<3>& subcell_mesh, const Direction<3>& direction_to_reconstruct,
     const size_t ghost_zone_size, const bool compute_conservatives) {
   const std::pair mortar_id{

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/ReconstructWork.tpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/ReconstructWork.tpp
@@ -21,6 +21,7 @@
 #include "Domain/Structure/Element.hpp"
 #include "Domain/Structure/ElementId.hpp"
 #include "Domain/Structure/MaxNumberOfNeighbors.hpp"
+#include "Evolution/DgSubcell/GhostData.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/ConservativeFromPrimitive.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/Tags.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
@@ -229,10 +230,10 @@ void reconstruct_fd_neighbor_work(
     const Variables<PrimsTags>& subcell_volume_prims,
     const EquationsOfState::EquationOfState<true, ThermodynamicDim>& eos,
     const Element<3>& element,
-    const FixedHashMap<maximum_number_of_neighbors(3),
-                       std::pair<Direction<3>, ElementId<3>>, DataVector,
-                       boost::hash<std::pair<Direction<3>, ElementId<3>>>>&
-        neighbor_data,
+    const FixedHashMap<
+        maximum_number_of_neighbors(3), std::pair<Direction<3>, ElementId<3>>,
+        evolution::dg::subcell::GhostData,
+        boost::hash<std::pair<Direction<3>, ElementId<3>>>>& ghost_data,
     const Mesh<3>& subcell_mesh, const Direction<3>& direction_to_reconstruct,
     const size_t ghost_zone_size, const bool compute_conservatives) {
   const std::pair mortar_id{
@@ -242,10 +243,11 @@ void reconstruct_fd_neighbor_work(
   ghost_data_extents[direction_to_reconstruct.dimension()] = ghost_zone_size;
   Variables<PrimsTagsSentByNeighbor> neighbor_prims{};
   {
-    ASSERT(neighbor_data.contains(mortar_id),
+    ASSERT(ghost_data.contains(mortar_id),
            "The neighbor data does not contain the mortar: ("
                << mortar_id.first << ',' << mortar_id.second << ")");
-    const auto& neighbor_data_on_mortar = neighbor_data.at(mortar_id);
+    const DataVector& neighbor_data_on_mortar =
+        ghost_data.at(mortar_id).neighbor_ghost_data_for_reconstruction();
     neighbor_prims.set_data_ref(
         const_cast<double*>(neighbor_data_on_mortar.data()),
         neighbor_prims.number_of_independent_components *

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/Wcns5z.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/Wcns5z.cpp
@@ -21,6 +21,7 @@
 #include "Domain/Structure/ElementId.hpp"
 #include "Domain/Structure/MaxNumberOfNeighbors.hpp"
 #include "Domain/Structure/Side.hpp"
+#include "Evolution/DgSubcell/GhostData.hpp"
 #include "Evolution/DiscontinuousGalerkin/Actions/NormalCovectorAndMagnitude.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/ReconstructWork.tpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/Reconstructor.hpp"
@@ -82,10 +83,10 @@ void Wcns5zPrim::reconstruct(
     const Variables<hydro::grmhd_tags<DataVector>>& volume_prims,
     const EquationsOfState::EquationOfState<true, ThermodynamicDim>& eos,
     const Element<3>& element,
-    const FixedHashMap<maximum_number_of_neighbors(3),
-                       std::pair<Direction<3>, ElementId<3>>, DataVector,
-                       boost::hash<std::pair<Direction<3>, ElementId<3>>>>&
-        neighbor_data,
+    const FixedHashMap<
+        maximum_number_of_neighbors(3), std::pair<Direction<3>, ElementId<3>>,
+        evolution::dg::subcell::GhostData,
+        boost::hash<std::pair<Direction<3>, ElementId<3>>>>& ghost_data,
     const Mesh<3>& subcell_mesh) const {
   FixedHashMap<maximum_number_of_neighbors(dim),
                std::pair<Direction<dim>, ElementId<dim>>,
@@ -93,7 +94,7 @@ void Wcns5zPrim::reconstruct(
                boost::hash<std::pair<Direction<dim>, ElementId<dim>>>>
       neighbor_variables_data{};
   ::fd::neighbor_data_as_variables<dim>(make_not_null(&neighbor_variables_data),
-                                        neighbor_data, ghost_zone_size(),
+                                        ghost_data, ghost_zone_size(),
                                         subcell_mesh);
 
   reconstruct_prims_work<prims_to_reconstruct_tags>(
@@ -115,10 +116,10 @@ void Wcns5zPrim::reconstruct_fd_neighbor(
     const Variables<hydro::grmhd_tags<DataVector>>& subcell_volume_prims,
     const EquationsOfState::EquationOfState<true, ThermodynamicDim>& eos,
     const Element<3>& element,
-    const FixedHashMap<maximum_number_of_neighbors(3),
-                       std::pair<Direction<3>, ElementId<3>>, DataVector,
-                       boost::hash<std::pair<Direction<3>, ElementId<3>>>>&
-        neighbor_data,
+    const FixedHashMap<
+        maximum_number_of_neighbors(3), std::pair<Direction<3>, ElementId<3>>,
+        evolution::dg::subcell::GhostData,
+        boost::hash<std::pair<Direction<3>, ElementId<3>>>>& ghost_data,
     const Mesh<3>& subcell_mesh,
     const Direction<3> direction_to_reconstruct) const {
   reconstruct_fd_neighbor_work<prims_to_reconstruct_tags,
@@ -146,7 +147,7 @@ void Wcns5zPrim::reconstruct_fd_neighbor(
             tensor_component_neighbor, subcell_extents, ghost_data_extents,
             local_direction_to_reconstruct, epsilon_, max_number_of_extrema_);
       },
-      subcell_volume_prims, eos, element, neighbor_data, subcell_mesh,
+      subcell_volume_prims, eos, element, ghost_data, subcell_mesh,
       direction_to_reconstruct, ghost_zone_size(), true);
 }
 
@@ -202,9 +203,10 @@ bool operator!=(const Wcns5zPrim& lhs, const Wcns5zPrim& rhs) {
       const EquationsOfState::EquationOfState<true, THERMO_DIM(data)>& eos,   \
       const Element<3>& element,                                              \
       const FixedHashMap<maximum_number_of_neighbors(3),                      \
-                         std::pair<Direction<3>, ElementId<3>>, DataVector,   \
+                         std::pair<Direction<3>, ElementId<3>>,               \
+                         evolution::dg::subcell::GhostData,                   \
                          boost::hash<std::pair<Direction<3>, ElementId<3>>>>& \
-          neighbor_data,                                                      \
+          ghost_data,                                                         \
       const Mesh<3>& subcell_mesh) const;                                     \
   template void Wcns5zPrim::reconstruct_fd_neighbor(                          \
       gsl::not_null<Variables<TAGS_LIST(data)>*> vars_on_face,                \
@@ -212,9 +214,10 @@ bool operator!=(const Wcns5zPrim& lhs, const Wcns5zPrim& rhs) {
       const EquationsOfState::EquationOfState<true, THERMO_DIM(data)>& eos,   \
       const Element<3>& element,                                              \
       const FixedHashMap<maximum_number_of_neighbors(3),                      \
-                         std::pair<Direction<3>, ElementId<3>>, DataVector,   \
+                         std::pair<Direction<3>, ElementId<3>>,               \
+                         evolution::dg::subcell::GhostData,                   \
                          boost::hash<std::pair<Direction<3>, ElementId<3>>>>& \
-          neighbor_data,                                                      \
+          ghost_data,                                                         \
       const Mesh<3>& subcell_mesh,                                            \
       const Direction<3> direction_to_reconstruct) const;
 

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/Wcns5z.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/Wcns5z.hpp
@@ -44,6 +44,9 @@ class er;
 }  // namespace PUP
 template <typename TagsList>
 class Variables;
+namespace evolution::dg::subcell {
+class GhostData;
+}  // namespace evolution::dg::subcell
 /// \endcond
 
 namespace grmhd::ValenciaDivClean::fd {
@@ -139,9 +142,9 @@ class Wcns5zPrim : public Reconstructor {
       const Element<dim>& element,
       const FixedHashMap<
           maximum_number_of_neighbors(dim),
-          std::pair<Direction<dim>, ElementId<dim>>, DataVector,
-          boost::hash<std::pair<Direction<dim>, ElementId<dim>>>>&
-          neighbor_data,
+          std::pair<Direction<dim>, ElementId<dim>>,
+          evolution::dg::subcell::GhostData,
+          boost::hash<std::pair<Direction<dim>, ElementId<dim>>>>& ghost_data,
       const Mesh<dim>& subcell_mesh) const;
 
   template <size_t ThermodynamicDim, typename TagsList>
@@ -152,9 +155,9 @@ class Wcns5zPrim : public Reconstructor {
       const Element<dim>& element,
       const FixedHashMap<
           maximum_number_of_neighbors(dim),
-          std::pair<Direction<dim>, ElementId<dim>>, DataVector,
-          boost::hash<std::pair<Direction<dim>, ElementId<dim>>>>&
-          neighbor_data,
+          std::pair<Direction<dim>, ElementId<dim>>,
+          evolution::dg::subcell::GhostData,
+          boost::hash<std::pair<Direction<dim>, ElementId<dim>>>>& ghost_data,
       const Mesh<dim>& subcell_mesh,
       const Direction<dim> direction_to_reconstruct) const;
 

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/NeighborPackagedData.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/NeighborPackagedData.hpp
@@ -96,7 +96,7 @@ struct NeighborPackagedData {
       return neighbor_package_data;
     }
 
-    const auto& neighbor_subcell_data =
+    const auto& ghost_subcell_data =
         db::get<evolution::dg::subcell::Tags::GhostDataForReconstruction<3>>(
             box);
     const Mesh<3>& subcell_mesh =
@@ -122,7 +122,7 @@ struct NeighborPackagedData {
         derived_boundary_corrections>([&box, &boundary_correction, &dg_mesh,
                                        &mortars_to_reconstruct_to,
                                        &neighbor_package_data,
-                                       &neighbor_subcell_data, &recons,
+                                       &ghost_subcell_data, &recons,
                                        &subcell_mesh, &subcell_options,
                                        &volume_prims](
                                           auto derived_correction_v) {
@@ -183,12 +183,12 @@ struct NeighborPackagedData {
 
           call_with_dynamic_type<void, typename grmhd::ValenciaDivClean::fd::
                                            Reconstructor::creatable_classes>(
-              &recons, [&element, &eos, &mortar_id, &neighbor_subcell_data,
-                        &subcell_mesh, &vars_on_face,
-                        &volume_prims](const auto& reconstructor) {
+              &recons,
+              [&element, &eos, &mortar_id, &ghost_subcell_data, &subcell_mesh,
+               &vars_on_face, &volume_prims](const auto& reconstructor) {
                 reconstructor->reconstruct_fd_neighbor(
                     make_not_null(&vars_on_face), volume_prims, eos, element,
-                    neighbor_subcell_data, subcell_mesh, mortar_id.first);
+                    ghost_subcell_data, subcell_mesh, mortar_id.first);
               });
 
           grmhd::ValenciaDivClean::subcell::compute_fluxes(

--- a/src/Evolution/Systems/NewtonianEuler/FiniteDifference/AoWeno.cpp
+++ b/src/Evolution/Systems/NewtonianEuler/FiniteDifference/AoWeno.cpp
@@ -80,9 +80,10 @@ void AoWeno53Prim<Dim>::reconstruct(
     const EquationsOfState::EquationOfState<false, ThermodynamicDim>& eos,
     const Element<Dim>& element,
     const FixedHashMap<maximum_number_of_neighbors(Dim),
-                       std::pair<Direction<Dim>, ElementId<Dim>>, DataVector,
+                       std::pair<Direction<Dim>, ElementId<Dim>>,
+                       evolution::dg::subcell::GhostData,
                        boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>&
-        neighbor_data,
+        ghost_data,
     const Mesh<Dim>& subcell_mesh) const {
   reconstruct_prims_work(
       vars_on_lower_face, vars_on_upper_face,
@@ -93,8 +94,7 @@ void AoWeno53Prim<Dim>::reconstruct(
                      ghost_cell_vars, subcell_extents, number_of_variables,
                      gamma_hi_, gamma_lo_, epsilon_);
       },
-      volume_prims, eos, element, neighbor_data, subcell_mesh,
-      ghost_zone_size());
+      volume_prims, eos, element, ghost_data, subcell_mesh, ghost_zone_size());
 }
 
 template <size_t Dim>
@@ -105,9 +105,10 @@ void AoWeno53Prim<Dim>::reconstruct_fd_neighbor(
     const EquationsOfState::EquationOfState<false, ThermodynamicDim>& eos,
     const Element<Dim>& element,
     const FixedHashMap<maximum_number_of_neighbors(Dim),
-                       std::pair<Direction<Dim>, ElementId<Dim>>, DataVector,
+                       std::pair<Direction<Dim>, ElementId<Dim>>,
+                       evolution::dg::subcell::GhostData,
                        boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>&
-        neighbor_data,
+        ghost_data,
     const Mesh<Dim>& subcell_mesh,
     const Direction<Dim> direction_to_reconstruct) const {
   reconstruct_fd_neighbor_work(
@@ -134,7 +135,7 @@ void AoWeno53Prim<Dim>::reconstruct_fd_neighbor(
             tensor_component_neighbor, subcell_extents, ghost_data_extents,
             local_direction_to_reconstruct, gamma_hi_, gamma_lo_, epsilon_);
       },
-      subcell_volume_prims, eos, element, neighbor_data, subcell_mesh,
+      subcell_volume_prims, eos, element, ghost_data, subcell_mesh,
       direction_to_reconstruct, ghost_zone_size());
 }
 
@@ -180,9 +181,10 @@ GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
       const Element<DIM(data)>& element,                                       \
       const FixedHashMap<                                                      \
           maximum_number_of_neighbors(DIM(data)),                              \
-          std::pair<Direction<DIM(data)>, ElementId<DIM(data)>>, DataVector,   \
+          std::pair<Direction<DIM(data)>, ElementId<DIM(data)>>,               \
+          evolution::dg::subcell::GhostData,                                   \
           boost::hash<std::pair<Direction<DIM(data)>, ElementId<DIM(data)>>>>& \
-          neighbor_data,                                                       \
+          ghost_data,                                                          \
       const Mesh<DIM(data)>& subcell_mesh) const;                              \
   template void AoWeno53Prim<DIM(data)>::reconstruct_fd_neighbor(              \
       gsl::not_null<Variables<TAGS_LIST(data)>*> vars_on_face,                 \
@@ -191,9 +193,10 @@ GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
       const Element<DIM(data)>& element,                                       \
       const FixedHashMap<                                                      \
           maximum_number_of_neighbors(DIM(data)),                              \
-          std::pair<Direction<DIM(data)>, ElementId<DIM(data)>>, DataVector,   \
+          std::pair<Direction<DIM(data)>, ElementId<DIM(data)>>,               \
+          evolution::dg::subcell::GhostData,                                   \
           boost::hash<std::pair<Direction<DIM(data)>, ElementId<DIM(data)>>>>& \
-          neighbor_data,                                                       \
+          ghost_data,                                                          \
       const Mesh<DIM(data)>& subcell_mesh,                                     \
       const Direction<DIM(data)> direction_to_reconstruct) const;
 

--- a/src/Evolution/Systems/NewtonianEuler/FiniteDifference/AoWeno.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/FiniteDifference/AoWeno.hpp
@@ -16,6 +16,7 @@
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Domain/Structure/MaxNumberOfNeighbors.hpp"
 #include "Domain/Tags.hpp"
+#include "Evolution/DgSubcell/GhostData.hpp"
 #include "Evolution/DgSubcell/Tags/GhostDataForReconstruction.hpp"
 #include "Evolution/DgSubcell/Tags/Mesh.hpp"
 #include "Evolution/Systems/NewtonianEuler/FiniteDifference/Reconstructor.hpp"
@@ -115,9 +116,9 @@ class AoWeno53Prim : public Reconstructor<Dim> {
       const Element<Dim>& element,
       const FixedHashMap<
           maximum_number_of_neighbors(Dim),
-          std::pair<Direction<Dim>, ElementId<Dim>>, DataVector,
-          boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>&
-          neighbor_data,
+          std::pair<Direction<Dim>, ElementId<Dim>>,
+          evolution::dg::subcell::GhostData,
+          boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>& ghost_data,
       const Mesh<Dim>& subcell_mesh) const;
 
   /// Called by an element doing DG when the neighbor is doing subcell.
@@ -129,9 +130,9 @@ class AoWeno53Prim : public Reconstructor<Dim> {
       const Element<Dim>& element,
       const FixedHashMap<
           maximum_number_of_neighbors(Dim),
-          std::pair<Direction<Dim>, ElementId<Dim>>, DataVector,
-          boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>&
-          neighbor_data,
+          std::pair<Direction<Dim>, ElementId<Dim>>,
+          evolution::dg::subcell::GhostData,
+          boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>& ghost_data,
       const Mesh<Dim>& subcell_mesh,
       const Direction<Dim> direction_to_reconstruct) const;
 

--- a/src/Evolution/Systems/NewtonianEuler/FiniteDifference/MonotonisedCentral.cpp
+++ b/src/Evolution/Systems/NewtonianEuler/FiniteDifference/MonotonisedCentral.cpp
@@ -16,6 +16,7 @@
 #include "Domain/Structure/Element.hpp"
 #include "Domain/Structure/ElementId.hpp"
 #include "Domain/Structure/MaxNumberOfNeighbors.hpp"
+#include "Evolution/DgSubcell/GhostData.hpp"
 #include "Evolution/Systems/NewtonianEuler/FiniteDifference/ReconstructWork.tpp"
 #include "NumericalAlgorithms/FiniteDifference/MonotonisedCentral.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
@@ -55,9 +56,10 @@ void MonotonisedCentralPrim<Dim>::reconstruct(
     const EquationsOfState::EquationOfState<false, ThermodynamicDim>& eos,
     const Element<Dim>& element,
     const FixedHashMap<maximum_number_of_neighbors(Dim),
-                       std::pair<Direction<Dim>, ElementId<Dim>>, DataVector,
+                       std::pair<Direction<Dim>, ElementId<Dim>>,
+                       evolution::dg::subcell::GhostData,
                        boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>&
-        neighbor_data,
+        ghost_data,
     const Mesh<Dim>& subcell_mesh) const {
   reconstruct_prims_work(
       vars_on_lower_face, vars_on_upper_face,
@@ -68,8 +70,7 @@ void MonotonisedCentralPrim<Dim>::reconstruct(
             upper_face_vars_ptr, lower_face_vars_ptr, volume_vars,
             ghost_cell_vars, subcell_extents, number_of_variables);
       },
-      volume_prims, eos, element, neighbor_data, subcell_mesh,
-      ghost_zone_size());
+      volume_prims, eos, element, ghost_data, subcell_mesh, ghost_zone_size());
 }
 
 template <size_t Dim>
@@ -80,9 +81,10 @@ void MonotonisedCentralPrim<Dim>::reconstruct_fd_neighbor(
     const EquationsOfState::EquationOfState<false, ThermodynamicDim>& eos,
     const Element<Dim>& element,
     const FixedHashMap<maximum_number_of_neighbors(Dim),
-                       std::pair<Direction<Dim>, ElementId<Dim>>, DataVector,
+                       std::pair<Direction<Dim>, ElementId<Dim>>,
+                       evolution::dg::subcell::GhostData,
                        boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>&
-        neighbor_data,
+        ghost_data,
     const Mesh<Dim>& subcell_mesh,
     const Direction<Dim> direction_to_reconstruct) const {
   reconstruct_fd_neighbor_work(
@@ -113,7 +115,7 @@ void MonotonisedCentralPrim<Dim>::reconstruct_fd_neighbor(
             tensor_component_neighbor, subcell_extents, ghost_data_extents,
             local_direction_to_reconstruct);
       },
-      subcell_volume_prims, eos, element, neighbor_data, subcell_mesh,
+      subcell_volume_prims, eos, element, ghost_data, subcell_mesh,
       direction_to_reconstruct, ghost_zone_size());
 }
 
@@ -147,9 +149,10 @@ GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
       const Element<DIM(data)>& element,                                       \
       const FixedHashMap<                                                      \
           maximum_number_of_neighbors(DIM(data)),                              \
-          std::pair<Direction<DIM(data)>, ElementId<DIM(data)>>, DataVector,   \
+          std::pair<Direction<DIM(data)>, ElementId<DIM(data)>>,               \
+          evolution::dg::subcell::GhostData,                                   \
           boost::hash<std::pair<Direction<DIM(data)>, ElementId<DIM(data)>>>>& \
-          neighbor_data,                                                       \
+          ghost_data,                                                          \
       const Mesh<DIM(data)>& subcell_mesh) const;                              \
   template void MonotonisedCentralPrim<DIM(data)>::reconstruct_fd_neighbor(    \
       gsl::not_null<Variables<TAGS_LIST(data)>*> vars_on_face,                 \
@@ -158,9 +161,10 @@ GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
       const Element<DIM(data)>& element,                                       \
       const FixedHashMap<                                                      \
           maximum_number_of_neighbors(DIM(data)),                              \
-          std::pair<Direction<DIM(data)>, ElementId<DIM(data)>>, DataVector,   \
+          std::pair<Direction<DIM(data)>, ElementId<DIM(data)>>,               \
+          evolution::dg::subcell::GhostData,                                   \
           boost::hash<std::pair<Direction<DIM(data)>, ElementId<DIM(data)>>>>& \
-          neighbor_data,                                                       \
+          ghost_data,                                                          \
       const Mesh<DIM(data)>& subcell_mesh,                                     \
       const Direction<DIM(data)> direction_to_reconstruct) const;
 

--- a/src/Evolution/Systems/NewtonianEuler/FiniteDifference/MonotonisedCentral.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/FiniteDifference/MonotonisedCentral.hpp
@@ -42,6 +42,9 @@ template <size_t Dim>
 class Mesh;
 template <typename TagsList>
 class Variables;
+namespace evolution::dg::subcell {
+class GhostData;
+}  // namespace evolution::dg::subcell
 /// \endcond
 
 namespace NewtonianEuler::fd {
@@ -110,9 +113,9 @@ class MonotonisedCentralPrim : public Reconstructor<Dim> {
       const Element<Dim>& element,
       const FixedHashMap<
           maximum_number_of_neighbors(Dim),
-          std::pair<Direction<Dim>, ElementId<Dim>>, DataVector,
-          boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>&
-          neighbor_data,
+          std::pair<Direction<Dim>, ElementId<Dim>>,
+          evolution::dg::subcell::GhostData,
+          boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>& ghost_data,
       const Mesh<Dim>& subcell_mesh) const;
 
   /// Called by an element doing DG when the neighbor is doing subcell.
@@ -129,9 +132,9 @@ class MonotonisedCentralPrim : public Reconstructor<Dim> {
       const Element<Dim>& element,
       const FixedHashMap<
           maximum_number_of_neighbors(Dim),
-          std::pair<Direction<Dim>, ElementId<Dim>>, DataVector,
-          boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>&
-          neighbor_data,
+          std::pair<Direction<Dim>, ElementId<Dim>>,
+          evolution::dg::subcell::GhostData,
+          boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>& ghost_data,
       const Mesh<Dim>& subcell_mesh,
       const Direction<Dim> direction_to_reconstruct) const;
 };

--- a/src/Evolution/Systems/NewtonianEuler/FiniteDifference/ReconstructWork.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/FiniteDifference/ReconstructWork.hpp
@@ -31,6 +31,9 @@ namespace EquationsOfState {
 template <bool IsRelativistic, size_t ThermodynamicDim>
 class EquationOfState;
 }  // namespace EquationsOfState
+namespace evolution::dg::subcell {
+class GhostData;
+}  // namespace evolution::dg::subcell
 /// \endcond
 
 namespace NewtonianEuler::fd {
@@ -48,9 +51,10 @@ void reconstruct_prims_work(
     const EquationsOfState::EquationOfState<false, ThermodynamicDim>& eos,
     const Element<Dim>& element,
     const FixedHashMap<maximum_number_of_neighbors(Dim),
-                       std::pair<Direction<Dim>, ElementId<Dim>>, DataVector,
+                       std::pair<Direction<Dim>, ElementId<Dim>>,
+                       evolution::dg::subcell::GhostData,
                        boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>&
-        neighbor_data,
+        ghost_data,
     const Mesh<Dim>& subcell_mesh, size_t ghost_zone_size);
 
 /*!
@@ -70,9 +74,10 @@ void reconstruct_fd_neighbor_work(
     const EquationsOfState::EquationOfState<false, ThermodynamicDim>& eos,
     const Element<Dim>& element,
     const FixedHashMap<maximum_number_of_neighbors(Dim),
-                       std::pair<Direction<Dim>, ElementId<Dim>>, DataVector,
+                       std::pair<Direction<Dim>, ElementId<Dim>>,
+                       evolution::dg::subcell::GhostData,
                        boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>&
-        neighbor_data,
+        ghost_data,
     const Mesh<Dim>& subcell_mesh,
     const Direction<Dim>& direction_to_reconstruct, size_t ghost_zone_size);
 }  // namespace NewtonianEuler::fd

--- a/src/Evolution/Systems/NewtonianEuler/Subcell/NeighborPackagedData.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/Subcell/NeighborPackagedData.hpp
@@ -95,7 +95,7 @@ struct NeighborPackagedData {
       return neighbor_package_data;
     }
 
-    const auto& neighbor_subcell_data =
+    const auto& ghost_subcell_data =
         db::get<evolution::dg::subcell::Tags::GhostDataForReconstruction<Dim>>(
             box);
     const Mesh<Dim>& subcell_mesh =
@@ -121,7 +121,7 @@ struct NeighborPackagedData {
         derived_boundary_corrections>([&box, &boundary_correction, &dg_mesh,
                                        &mortars_to_reconstruct_to,
                                        &neighbor_package_data,
-                                       &neighbor_subcell_data, &recons,
+                                       &ghost_subcell_data, &recons,
                                        &subcell_mesh, &subcell_options,
                                        &volume_prims](
                                           auto derived_correction_v) {
@@ -157,12 +157,12 @@ struct NeighborPackagedData {
           call_with_dynamic_type<void,
                                  typename NewtonianEuler::fd::Reconstructor<
                                      Dim>::creatable_classes>(
-              &recons, [&element, &eos, &mortar_id, &neighbor_subcell_data,
-                        &subcell_mesh, &vars_on_face,
-                        &volume_prims](const auto& reconstructor) {
+              &recons,
+              [&element, &eos, &mortar_id, &ghost_subcell_data, &subcell_mesh,
+               &vars_on_face, &volume_prims](const auto& reconstructor) {
                 reconstructor->reconstruct_fd_neighbor(
                     make_not_null(&vars_on_face), volume_prims, eos, element,
-                    neighbor_subcell_data, subcell_mesh, mortar_id.first);
+                    ghost_subcell_data, subcell_mesh, mortar_id.first);
               });
 
           NewtonianEuler::subcell::compute_fluxes<Dim>(

--- a/src/Evolution/Systems/ScalarAdvection/FiniteDifference/AoWeno.cpp
+++ b/src/Evolution/Systems/ScalarAdvection/FiniteDifference/AoWeno.cpp
@@ -83,9 +83,10 @@ void AoWeno53<Dim>::reconstruct(
     const Variables<tmpl::list<Tags::U>>& volume_vars,
     const Element<Dim>& element,
     const FixedHashMap<maximum_number_of_neighbors(Dim),
-                       std::pair<Direction<Dim>, ElementId<Dim>>, DataVector,
+                       std::pair<Direction<Dim>, ElementId<Dim>>,
+                       evolution::dg::subcell::GhostData,
                        boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>&
-        neighbor_data,
+        ghost_data,
     const Mesh<Dim>& subcell_mesh) const {
   reconstruct_work(
       vars_on_lower_face, vars_on_upper_face,
@@ -96,7 +97,7 @@ void AoWeno53<Dim>::reconstruct(
                      ghost_cell_vars, subcell_extents, number_of_variables,
                      gamma_hi_, gamma_lo_, epsilon_);
       },
-      volume_vars, element, neighbor_data, subcell_mesh, ghost_zone_size());
+      volume_vars, element, ghost_data, subcell_mesh, ghost_zone_size());
 }
 
 template <size_t Dim>
@@ -106,9 +107,10 @@ void AoWeno53<Dim>::reconstruct_fd_neighbor(
     const Variables<tmpl::list<Tags::U>>& volume_vars,
     const Element<Dim>& element,
     const FixedHashMap<maximum_number_of_neighbors(Dim),
-                       std::pair<Direction<Dim>, ElementId<Dim>>, DataVector,
+                       std::pair<Direction<Dim>, ElementId<Dim>>,
+                       evolution::dg::subcell::GhostData,
                        boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>&
-        neighbor_data,
+        ghost_data,
     const Mesh<Dim>& subcell_mesh,
     const Direction<Dim> direction_to_reconstruct) const {
   reconstruct_fd_neighbor_work(
@@ -135,8 +137,8 @@ void AoWeno53<Dim>::reconstruct_fd_neighbor(
             tensor_component_neighbor, subcell_extents, ghost_data_extents,
             local_direction_to_reconstruct, gamma_hi_, gamma_lo_, epsilon_);
       },
-      volume_vars, element, neighbor_data, subcell_mesh,
-      direction_to_reconstruct, ghost_zone_size());
+      volume_vars, element, ghost_data, subcell_mesh, direction_to_reconstruct,
+      ghost_zone_size());
 }
 
 template <size_t Dim>
@@ -177,9 +179,10 @@ GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2))
       const Element<DIM(data)>& element,                                       \
       const FixedHashMap<                                                      \
           maximum_number_of_neighbors(DIM(data)),                              \
-          std::pair<Direction<DIM(data)>, ElementId<DIM(data)>>, DataVector,   \
+          std::pair<Direction<DIM(data)>, ElementId<DIM(data)>>,               \
+          evolution::dg::subcell::GhostData,                                   \
           boost::hash<std::pair<Direction<DIM(data)>, ElementId<DIM(data)>>>>& \
-          neighbor_data,                                                       \
+          ghost_data,                                                          \
       const Mesh<DIM(data)>& subcell_mesh) const;                              \
   template void AoWeno53<DIM(data)>::reconstruct_fd_neighbor(                  \
       gsl::not_null<Variables<TAGS_LIST(data)>*> vars_on_face,                 \
@@ -187,9 +190,10 @@ GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2))
       const Element<DIM(data)>& element,                                       \
       const FixedHashMap<                                                      \
           maximum_number_of_neighbors(DIM(data)),                              \
-          std::pair<Direction<DIM(data)>, ElementId<DIM(data)>>, DataVector,   \
+          std::pair<Direction<DIM(data)>, ElementId<DIM(data)>>,               \
+          evolution::dg::subcell::GhostData,                                   \
           boost::hash<std::pair<Direction<DIM(data)>, ElementId<DIM(data)>>>>& \
-          neighbor_data,                                                       \
+          ghost_data,                                                          \
       const Mesh<DIM(data)>& subcell_mesh,                                     \
       const Direction<DIM(data)> direction_to_reconstruct) const;
 

--- a/src/Evolution/Systems/ScalarAdvection/FiniteDifference/AoWeno.hpp
+++ b/src/Evolution/Systems/ScalarAdvection/FiniteDifference/AoWeno.hpp
@@ -45,6 +45,9 @@ class Variables;
 namespace PUP {
 class er;
 }  // namespace PUP
+namespace evolution::dg::subcell {
+class GhostData;
+}  // namespace evolution::dg::subcell
 /// \endcond
 
 namespace ScalarAdvection::fd {
@@ -122,9 +125,9 @@ class AoWeno53 : public Reconstructor<Dim> {
       const Element<Dim>& element,
       const FixedHashMap<
           maximum_number_of_neighbors(Dim),
-          std::pair<Direction<Dim>, ElementId<Dim>>, DataVector,
-          boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>&
-          neighbor_data,
+          std::pair<Direction<Dim>, ElementId<Dim>>,
+          evolution::dg::subcell::GhostData,
+          boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>& ghost_data,
       const Mesh<Dim>& subcell_mesh) const;
 
   template <typename TagsList>
@@ -134,9 +137,9 @@ class AoWeno53 : public Reconstructor<Dim> {
       const Element<Dim>& element,
       const FixedHashMap<
           maximum_number_of_neighbors(Dim),
-          std::pair<Direction<Dim>, ElementId<Dim>>, DataVector,
-          boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>&
-          neighbor_data,
+          std::pair<Direction<Dim>, ElementId<Dim>>,
+          evolution::dg::subcell::GhostData,
+          boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>& ghost_data,
       const Mesh<Dim>& subcell_mesh,
       const Direction<Dim> direction_to_reconstruct) const;
 

--- a/src/Evolution/Systems/ScalarAdvection/FiniteDifference/MonotonisedCentral.cpp
+++ b/src/Evolution/Systems/ScalarAdvection/FiniteDifference/MonotonisedCentral.cpp
@@ -20,6 +20,7 @@
 #include "Domain/Structure/ElementId.hpp"
 #include "Domain/Structure/MaxNumberOfNeighbors.hpp"
 #include "Domain/Structure/Side.hpp"
+#include "Evolution/DgSubcell/GhostData.hpp"
 #include "Evolution/Systems/ScalarAdvection/FiniteDifference/ReconstructWork.tpp"
 #include "Evolution/Systems/ScalarAdvection/FiniteDifference/Reconstructor.hpp"
 #include "Evolution/Systems/ScalarAdvection/Tags.hpp"
@@ -57,9 +58,10 @@ void MonotonisedCentral<Dim>::reconstruct(
     const Variables<tmpl::list<Tags::U>>& volume_vars,
     const Element<Dim>& element,
     const FixedHashMap<maximum_number_of_neighbors(Dim),
-                       std::pair<Direction<Dim>, ElementId<Dim>>, DataVector,
+                       std::pair<Direction<Dim>, ElementId<Dim>>,
+                       evolution::dg::subcell::GhostData,
                        boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>&
-        neighbor_data,
+        ghost_data,
     const Mesh<Dim>& subcell_mesh) const {
   reconstruct_work(
       vars_on_lower_face, vars_on_upper_face,
@@ -70,7 +72,7 @@ void MonotonisedCentral<Dim>::reconstruct(
             upper_face_vars_ptr, lower_face_vars_ptr, volume_variables,
             ghost_cell_vars, subcell_extents, number_of_variables);
       },
-      volume_vars, element, neighbor_data, subcell_mesh, ghost_zone_size());
+      volume_vars, element, ghost_data, subcell_mesh, ghost_zone_size());
 }
 
 template <size_t Dim>
@@ -80,9 +82,10 @@ void MonotonisedCentral<Dim>::reconstruct_fd_neighbor(
     const Variables<tmpl::list<Tags::U>>& volume_vars,
     const Element<Dim>& element,
     const FixedHashMap<maximum_number_of_neighbors(Dim),
-                       std::pair<Direction<Dim>, ElementId<Dim>>, DataVector,
+                       std::pair<Direction<Dim>, ElementId<Dim>>,
+                       evolution::dg::subcell::GhostData,
                        boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>&
-        neighbor_data,
+        ghost_data,
     const Mesh<Dim>& subcell_mesh,
     const Direction<Dim> direction_to_reconstruct) const {
   reconstruct_fd_neighbor_work(
@@ -111,8 +114,8 @@ void MonotonisedCentral<Dim>::reconstruct_fd_neighbor(
             tensor_component_neighbor, subcell_extents, ghost_data_extents,
             local_direction_to_reconstruct);
       },
-      volume_vars, element, neighbor_data, subcell_mesh,
-      direction_to_reconstruct, ghost_zone_size());
+      volume_vars, element, ghost_data, subcell_mesh, direction_to_reconstruct,
+      ghost_zone_size());
 }
 
 template <size_t Dim>
@@ -155,9 +158,10 @@ GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2))
       const Element<DIM(data)>& element,                                       \
       const FixedHashMap<                                                      \
           maximum_number_of_neighbors(DIM(data)),                              \
-          std::pair<Direction<DIM(data)>, ElementId<DIM(data)>>, DataVector,   \
+          std::pair<Direction<DIM(data)>, ElementId<DIM(data)>>,               \
+          evolution::dg::subcell::GhostData,                                   \
           boost::hash<std::pair<Direction<DIM(data)>, ElementId<DIM(data)>>>>& \
-          neighbor_data,                                                       \
+          ghost_data,                                                          \
       const Mesh<DIM(data)>& subcell_mesh) const;                              \
   template void MonotonisedCentral<DIM(data)>::reconstruct_fd_neighbor(        \
       gsl::not_null<Variables<TAGS_LIST(data)>*> vars_on_face,                 \
@@ -165,9 +169,10 @@ GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2))
       const Element<DIM(data)>& element,                                       \
       const FixedHashMap<                                                      \
           maximum_number_of_neighbors(DIM(data)),                              \
-          std::pair<Direction<DIM(data)>, ElementId<DIM(data)>>, DataVector,   \
+          std::pair<Direction<DIM(data)>, ElementId<DIM(data)>>,               \
+          evolution::dg::subcell::GhostData,                                   \
           boost::hash<std::pair<Direction<DIM(data)>, ElementId<DIM(data)>>>>& \
-          neighbor_data,                                                       \
+          ghost_data,                                                          \
       const Mesh<DIM(data)>& subcell_mesh,                                     \
       const Direction<DIM(data)> direction_to_reconstruct) const;
 

--- a/src/Evolution/Systems/ScalarAdvection/FiniteDifference/MonotonisedCentral.hpp
+++ b/src/Evolution/Systems/ScalarAdvection/FiniteDifference/MonotonisedCentral.hpp
@@ -42,6 +42,9 @@ class not_null;
 namespace PUP {
 class er;
 }  // namespace PUP
+namespace evolution::dg::subcell {
+class GhostData;
+}  // namespace evolution::dg::subcell
 /// \endcond
 
 namespace ScalarAdvection::fd {
@@ -94,9 +97,9 @@ class MonotonisedCentral : public Reconstructor<Dim> {
       const Element<Dim>& element,
       const FixedHashMap<
           maximum_number_of_neighbors(Dim),
-          std::pair<Direction<Dim>, ElementId<Dim>>, DataVector,
-          boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>&
-          neighbor_data,
+          std::pair<Direction<Dim>, ElementId<Dim>>,
+          evolution::dg::subcell::GhostData,
+          boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>& ghost_data,
       const Mesh<Dim>& subcell_mesh) const;
 
   template <typename TagsList>
@@ -106,9 +109,9 @@ class MonotonisedCentral : public Reconstructor<Dim> {
       const Element<Dim>& element,
       const FixedHashMap<
           maximum_number_of_neighbors(Dim),
-          std::pair<Direction<Dim>, ElementId<Dim>>, DataVector,
-          boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>&
-          neighbor_data,
+          std::pair<Direction<Dim>, ElementId<Dim>>,
+          evolution::dg::subcell::GhostData,
+          boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>& ghost_data,
       const Mesh<Dim>& subcell_mesh,
       const Direction<Dim> direction_to_reconstruct) const;
 };

--- a/src/Evolution/Systems/ScalarAdvection/FiniteDifference/ReconstructWork.hpp
+++ b/src/Evolution/Systems/ScalarAdvection/FiniteDifference/ReconstructWork.hpp
@@ -29,6 +29,9 @@ namespace gsl {
 template <typename>
 class not_null;
 }  // namespace gsl
+namespace evolution::dg::subcell {
+class GhostData;
+}  // namespace evolution::dg::subcell
 /// \endcond
 
 namespace ScalarAdvection::fd {
@@ -44,9 +47,10 @@ void reconstruct_work(
     const Variables<tmpl::list<Tags::U>> volume_vars,
     const Element<Dim>& element,
     const FixedHashMap<maximum_number_of_neighbors(Dim),
-                       std::pair<Direction<Dim>, ElementId<Dim>>, DataVector,
+                       std::pair<Direction<Dim>, ElementId<Dim>>,
+                       evolution::dg::subcell::GhostData,
                        boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>&
-        neighbor_data,
+        ghost_data,
     const Mesh<Dim>& subcell_mesh, const size_t ghost_zone_size);
 
 /*!
@@ -65,9 +69,10 @@ void reconstruct_fd_neighbor_work(
     const Variables<tmpl::list<Tags::U>>& subcell_volume_vars,
     const Element<Dim>& element,
     const FixedHashMap<maximum_number_of_neighbors(Dim),
-                       std::pair<Direction<Dim>, ElementId<Dim>>, DataVector,
+                       std::pair<Direction<Dim>, ElementId<Dim>>,
+                       evolution::dg::subcell::GhostData,
                        boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>&
-        neighbor_data,
+        ghost_data,
     const Mesh<Dim>& subcell_mesh,
     const Direction<Dim>& direction_to_reconstruct,
     const size_t ghost_zone_size);

--- a/src/Evolution/Systems/ScalarAdvection/FiniteDifference/ReconstructWork.tpp
+++ b/src/Evolution/Systems/ScalarAdvection/FiniteDifference/ReconstructWork.tpp
@@ -8,8 +8,8 @@
 #include <cstddef>
 #include <utility>
 
-#include "DataStructures/FixedHashMap.hpp"
 #include "DataStructures/DataVector.hpp"
+#include "DataStructures/FixedHashMap.hpp"
 #include "DataStructures/Index.hpp"
 #include "DataStructures/Variables.hpp"
 #include "Domain/Structure/Direction.hpp"
@@ -33,10 +33,10 @@ void reconstruct_work(
     const Reconstructor& reconstruct,
     const Variables<tmpl::list<Tags::U>> volume_vars,
     const Element<Dim>& element,
-    const FixedHashMap<
-        maximum_number_of_neighbors(Dim),
-        std::pair<Direction<Dim>, ElementId<Dim>>, DataVector,
-        boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>& neighbor_data,
+    const FixedHashMap<maximum_number_of_neighbors(Dim),
+                       std::pair<Direction<Dim>, ElementId<Dim>>, DataVector,
+                       boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>&
+        neighbor_data,
     const Mesh<Dim>& subcell_mesh, const size_t ghost_zone_size) {
   // check if subcell mesh is isotropic
   ASSERT(Mesh<Dim>(subcell_mesh.extents(0), subcell_mesh.basis(0),
@@ -78,11 +78,11 @@ void reconstruct_work(
            "got "
                << neighbors_in_direction.size() << " in direction "
                << direction);
-    ASSERT(neighbor_data
-                   .at(std::pair{direction, *neighbors_in_direction.begin()})
-                   .size() != 0,
-           "The neighber data is empty in direction "
-               << direction << " on element id " << element.id());
+    ASSERT(
+        neighbor_data.at(std::pair{direction, *neighbors_in_direction.begin()})
+                .size() != 0,
+        "The neighber data is empty in direction "
+            << direction << " on element id " << element.id());
 
     ghost_cell_vars[direction] =
         gsl::make_span(&neighbor_data.at(std::pair{
@@ -109,10 +109,10 @@ void reconstruct_fd_neighbor_work(
     const ReconstructUpper& reconstruct_upper_neighbor,
     const Variables<tmpl::list<Tags::U>>& subcell_volume_vars,
     const Element<Dim>& element,
-    const FixedHashMap<
-        maximum_number_of_neighbors(Dim),
-        std::pair<Direction<Dim>, ElementId<Dim>>, DataVector,
-        boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>& neighbor_data,
+    const FixedHashMap<maximum_number_of_neighbors(Dim),
+                       std::pair<Direction<Dim>, ElementId<Dim>>, DataVector,
+                       boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>&
+        neighbor_data,
     const Mesh<Dim>& subcell_mesh,
     const Direction<Dim>& direction_to_reconstruct,
     const size_t ghost_zone_size) {

--- a/src/Evolution/Systems/ScalarAdvection/Subcell/NeighborPackagedData.hpp
+++ b/src/Evolution/Systems/ScalarAdvection/Subcell/NeighborPackagedData.hpp
@@ -99,7 +99,7 @@ struct NeighborPackagedData {
         db::get<typename System<Dim>::variables_tag>(box), dg_mesh,
         subcell_mesh.extents());
 
-    const auto& neighbor_subcell_data =
+    const auto& ghost_subcell_data =
         db::get<evolution::dg::subcell::Tags::GhostDataForReconstruction<Dim>>(
             box);
 
@@ -160,11 +160,11 @@ struct NeighborPackagedData {
                                  typename ScalarAdvection::fd::Reconstructor<
                                      Dim>::creatable_classes>(
               &recons,
-              [&element, &mortar_id, &neighbor_subcell_data, &subcell_mesh,
+              [&element, &mortar_id, &ghost_subcell_data, &subcell_mesh,
                &vars_on_face, &volume_vars_subcell](const auto& reconstructor) {
                 reconstructor->reconstruct_fd_neighbor(
                     make_not_null(&vars_on_face), volume_vars_subcell, element,
-                    neighbor_subcell_data, subcell_mesh, mortar_id.first);
+                    ghost_subcell_data, subcell_mesh, mortar_id.first);
               });
 
           // Compute fluxes

--- a/src/NumericalAlgorithms/FiniteDifference/NeighborDataAsVariables.hpp
+++ b/src/NumericalAlgorithms/FiniteDifference/NeighborDataAsVariables.hpp
@@ -13,6 +13,7 @@
 #include "Domain/Structure/Direction.hpp"
 #include "Domain/Structure/ElementId.hpp"
 #include "Domain/Structure/MaxNumberOfNeighbors.hpp"
+#include "Evolution/DgSubcell/GhostData.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/Gsl.hpp"
@@ -36,9 +37,10 @@ void neighbor_data_as_variables(
                      boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>*>
         vars_neighbor_data,
     const FixedHashMap<maximum_number_of_neighbors(Dim),
-                       std::pair<Direction<Dim>, ElementId<Dim>>, DataVector,
+                       std::pair<Direction<Dim>, ElementId<Dim>>,
+                       evolution::dg::subcell::GhostData,
                        boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>&
-        neighbor_data,
+        all_ghost_data,
     const size_t ghost_zone_size, const Mesh<Dim>& subcell_mesh) {
   const size_t neighbor_num_pts =
       ghost_zone_size * subcell_mesh.extents().slice_away(0).product();
@@ -47,7 +49,9 @@ void neighbor_data_as_variables(
                                 subcell_mesh.quadrature(0)),
       "subcell_mesh must be isotropic but got " << subcell_mesh);
   vars_neighbor_data->clear();
-  for (const auto& [neighbor_id, data] : neighbor_data) {
+  for (const auto& [neighbor_id, ghost_data] : all_ghost_data) {
+    const DataVector& data =
+        ghost_data.neighbor_ghost_data_for_reconstruction();
     (*vars_neighbor_data)[neighbor_id] = {};
     (*vars_neighbor_data)[neighbor_id].set_data_ref(
         const_cast<double*>(data.data()),

--- a/tests/Unit/Evolution/DgSubcell/Actions/Test_TciAndSwitchToDg.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Actions/Test_TciAndSwitchToDg.cpp
@@ -29,6 +29,7 @@
 #include "Domain/Tags.hpp"
 #include "Evolution/DgSubcell/Actions/TciAndSwitchToDg.hpp"
 #include "Evolution/DgSubcell/ActiveGrid.hpp"
+#include "Evolution/DgSubcell/GhostData.hpp"
 #include "Evolution/DgSubcell/Mesh.hpp"
 #include "Evolution/DgSubcell/RdmpTciData.hpp"
 #include "Evolution/DgSubcell/Reconstruction.hpp"
@@ -259,9 +260,10 @@ void test_impl(
       make_time_stepper(multistep_time_stepper);
 
   FixedHashMap<maximum_number_of_neighbors(Dim),
-               std::pair<Direction<Dim>, ElementId<Dim>>, DataVector,
+               std::pair<Direction<Dim>, ElementId<Dim>>,
+               evolution::dg::subcell::GhostData,
                boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>
-      neighbor_data{};
+      ghost_data{};
 
   const int tci_decision{-1};  // default value
 
@@ -322,10 +324,9 @@ void test_impl(
   ActionTesting::emplace_array_component_and_initialize<comp>(
       &runner, ActionTesting::NodeId{0}, ActionTesting::LocalCoreId{0}, 0,
       {time_step_id, dg_mesh, subcell_mesh, active_grid, did_rollback,
-       neighbor_data, tci_decision, rdmp_tci_data, tci_grid_history,
-       evolved_vars, time_stepper_history,
-       make_time_stepper(multistep_time_stepper), neighbor_decisions,
-       Element<Dim>{ElementId<Dim>{0}, {}},
+       ghost_data, tci_decision, rdmp_tci_data, tci_grid_history, evolved_vars,
+       time_stepper_history, make_time_stepper(multistep_time_stepper),
+       neighbor_decisions, Element<Dim>{ElementId<Dim>{0}, {}},
        typename evolution::dg::subcell::Tags::CellCenteredFlux<
            typename metavars::system::flux_variables, Dim>::type::value_type{
            subcell_mesh.number_of_grid_points()}});

--- a/tests/Unit/Evolution/Systems/Burgers/FiniteDifference/Test_BoundaryConditionGhostData.cpp
+++ b/tests/Unit/Evolution/Systems/Burgers/FiniteDifference/Test_BoundaryConditionGhostData.cpp
@@ -107,7 +107,7 @@ void test(const BoundaryConditionType& boundary_condition) {
 
   // dummy neighbor data to put into DataBox
   typename evolution::dg::subcell::Tags::GhostDataForReconstruction<1>::type
-      neighbor_data{};
+      ghost_data{};
 
   // Below are tags required by DirichletAnalytic boundary condition to compute
   // inertial coords of ghost FD cells:
@@ -196,7 +196,7 @@ void test(const BoundaryConditionType& boundary_condition) {
                                                   Frame::Inertial>,
       Tags::AnalyticSolution<SolutionForTest>, Burgers::Tags::U>>(
       EvolutionMetaVars{}, std::move(domain), std::move(boundary_conditions),
-      subcell_mesh, subcell_logical_coords, neighbor_data,
+      subcell_mesh, subcell_logical_coords, ghost_data,
       std::unique_ptr<Burgers::fd::Reconstructor>{
           std::make_unique<ReconstructorForTest>()},
       volume_mesh_velocity, normal_vectors, time,
@@ -218,7 +218,8 @@ void test(const BoundaryConditionType& boundary_condition) {
                                  ElementId<1>::external_boundary_id()};
     const DataVector& fd_ghost_data =
         get<evolution::dg::subcell::Tags::GhostDataForReconstruction<1>>(box)
-            .at(mortar_id);
+            .at(mortar_id)
+            .neighbor_ghost_data_for_reconstruction();
 
     // now check values for each types of boundary conditions
 

--- a/tests/Unit/Evolution/Systems/Burgers/Subcell/Test_NeighborPackagedData.cpp
+++ b/tests/Unit/Evolution/Systems/Burgers/Subcell/Test_NeighborPackagedData.cpp
@@ -104,7 +104,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Burgers.Subcell.NeighborPackagedData",
     return vars;
   };
   typename evolution::dg::subcell::Tags::GhostDataForReconstruction<1>::type
-      neighbor_data = TestHelpers::Burgers::fd::compute_neighbor_data(
+      ghost_data = TestHelpers::Burgers::fd::compute_ghost_data(
           subcell_mesh, logical_coords_subcell, element.neighbors(),
           reconstructor.ghost_zone_size(), compute_random_variable);
 
@@ -155,7 +155,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Burgers.Subcell.NeighborPackagedData",
       evolution::dg::subcell::Tags::Coordinates<1, Frame::ElementLogical>,
       domain::Tags::MeshVelocity<1>,
       evolution::dg::Tags::NormalCovectorAndMagnitude<1>>>(
-      element, dg_mesh, subcell_mesh, volume_vars_dg, neighbor_data,
+      element, dg_mesh, subcell_mesh, volume_vars_dg, ghost_data,
       std::unique_ptr<fd::Reconstructor>{
           std::make_unique<ReconstructorUsedForTest>()},
       std::unique_ptr<BoundaryCorrections::BoundaryCorrection>{
@@ -200,7 +200,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Burgers.Subcell.NeighborPackagedData",
     // reconstruct U on the mortar
     dynamic_cast<const ReconstructorUsedForTest&>(reconstructor)
         .reconstruct_fd_neighbor(make_not_null(&vars_on_mortar_face),
-                                 volume_vars_subcell, element, neighbor_data,
+                                 volume_vars_subcell, element, ghost_data,
                                  subcell_mesh, direction);
 
     // compute fluxes

--- a/tests/Unit/Evolution/Systems/Burgers/Subcell/Test_TimeDerivative.cpp
+++ b/tests/Unit/Evolution/Systems/Burgers/Subcell/Test_TimeDerivative.cpp
@@ -114,8 +114,8 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Burgers.Subcell.TimeDerivative",
 
   // set the ghost data from neighbor
   const ReconstructionForTest reconstructor{};
-  evolution::dg::subcell::Tags::GhostDataForReconstruction<1>::type
-      neighbor_data = TestHelpers::Burgers::fd::compute_neighbor_data(
+  evolution::dg::subcell::Tags::GhostDataForReconstruction<1>::type ghost_data =
+      TestHelpers::Burgers::fd::compute_ghost_data(
           subcell_mesh, logical_coords_subcell, element.neighbors(),
           reconstructor.ghost_zone_size(), compute_test_solution);
 
@@ -150,7 +150,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Burgers.Subcell.TimeDerivative",
       element, subcell_mesh, volume_vars_subcell,
       Variables<typename dt_variables_tag::tags_list>{
           subcell_mesh.number_of_grid_points()},
-      neighbor_data,
+      ghost_data,
       std::unique_ptr<fd::Reconstructor>{
           std::make_unique<ReconstructionForTest>()},
       std::unique_ptr<BoundaryCorrections::BoundaryCorrection>{

--- a/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/Test_BoundaryConditionGhostData.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/Test_BoundaryConditionGhostData.cpp
@@ -256,8 +256,9 @@ void test(const BoundaryConditionType& boundary_condition) {
   const auto direction = Direction<3>::upper_xi();
   const std::pair mortar_id = {direction, ElementId<3>::external_boundary_id()};
   const DataVector& fd_ghost_data =
-      get<evolution::dg::subcell::Tags::GhostDataForReconstruction<3>>(box).at(
-          mortar_id);
+      get<evolution::dg::subcell::Tags::GhostDataForReconstruction<3>>(box)
+          .at(mortar_id)
+          .neighbor_ghost_data_for_reconstruction();
 
   // Copy the computed FD ghost data into a Variables object in order to
   // facilitate comparison. Note that the returned FD ghost data contains the

--- a/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/Test_NeighborPackagedData.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/Test_NeighborPackagedData.cpp
@@ -164,8 +164,10 @@ double test(const size_t num_dg_pts) {
             directions_to_slice, 0)
             .at(direction.opposite());
 
-    neighbor_data[std::pair{direction,
-                            *element.neighbors().at(direction).begin()}] =
+    const auto key =
+        std::pair{direction, *element.neighbors().at(direction).begin()};
+    neighbor_data[key] = evolution::dg::subcell::GhostData{1};
+    neighbor_data[key].neighbor_ghost_data_for_reconstruction() =
         std::move(neighbor_data_in_direction);
   }
 

--- a/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/Test_TimeDerivative.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/Test_TimeDerivative.cpp
@@ -214,8 +214,10 @@ double test(const size_t num_dg_pts) {
                 .ghost_zone_size(),
             directions_to_slice, 0)
             .at(direction.opposite());
-    neighbor_data[std::pair{direction,
-                            *element.neighbors().at(direction).begin()}] =
+    const auto key =
+        std::pair{direction, *element.neighbors().at(direction).begin()};
+    neighbor_data[key] = evolution::dg::subcell::GhostData{1};
+    neighbor_data[key].neighbor_ghost_data_for_reconstruction() =
         neighbor_data_in_direction;
   }
 

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/Test_BoundaryConditionGhostData.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/Test_BoundaryConditionGhostData.cpp
@@ -261,7 +261,8 @@ void test(const BoundaryConditionType& boundary_condition) {
                                  ElementId<3>::external_boundary_id()};
     const DataVector& fd_ghost_data =
         get<evolution::dg::subcell::Tags::GhostDataForReconstruction<3>>(box)
-            .at(mortar_id);
+            .at(mortar_id)
+            .neighbor_ghost_data_for_reconstruction();
 
     // Copy the computed FD ghost data into a Variables object in order to
     // facilitate comparison. Note that the returned FD ghost data contains the
@@ -443,7 +444,8 @@ void test(const BoundaryConditionType& boundary_condition) {
 
       const DataVector& fd_ghost_data_velocity_inward =
           get<evolution::dg::subcell::Tags::GhostDataForReconstruction<3>>(box)
-              .at(mortar_id);
+              .at(mortar_id)
+              .neighbor_ghost_data_for_reconstruction();
       Variables<prims_to_reconstruct> fd_ghost_vars_velocity_inward{
           ghost_zone_size * num_face_pts};
       std::copy(fd_ghost_data_velocity_inward.begin(),

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_NeighborPackagedData.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_NeighborPackagedData.cpp
@@ -173,8 +173,10 @@ double test(const size_t num_dg_pts) {
                 .ghost_zone_size(),
             directions_to_slice, 0)
             .at(direction.opposite());
-    neighbor_data[std::pair{direction,
-                            *element.neighbors().at(direction).begin()}] =
+    const auto key =
+        std::pair{direction, *element.neighbors().at(direction).begin()};
+    neighbor_data[key] = evolution::dg::subcell::GhostData{1};
+    neighbor_data[key].neighbor_ghost_data_for_reconstruction() =
         std::move(neighbor_data_in_direction);
   }
 

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_TimeDerivative.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_TimeDerivative.cpp
@@ -251,8 +251,10 @@ std::array<double, 5> test(const size_t num_dg_pts,
             volume_neighbor_data, subcell_mesh.extents(),
             recons.ghost_zone_size(), directions_to_slice, 0)
             .at(direction.opposite());
-    neighbor_data[std::pair{direction,
-                            *element.neighbors().at(direction).begin()}] =
+    const auto key =
+        std::pair{direction, *element.neighbors().at(direction).begin()};
+    neighbor_data[key] = evolution::dg::subcell::GhostData{1};
+    neighbor_data[key].neighbor_ghost_data_for_reconstruction() =
         neighbor_data_in_direction;
   }
 

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/Subcell/Test_NeighborPackagedData.cpp
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/Subcell/Test_NeighborPackagedData.cpp
@@ -32,6 +32,7 @@
 #include "Domain/Tags.hpp"
 #include "Domain/TagsTimeDependent.hpp"
 #include "Evolution/BoundaryCorrectionTags.hpp"
+#include "Evolution/DgSubcell/GhostData.hpp"
 #include "Evolution/DgSubcell/Mesh.hpp"
 #include "Evolution/DgSubcell/SliceData.hpp"
 #include "Evolution/DgSubcell/SubcellOptions.hpp"
@@ -193,8 +194,10 @@ double test(const size_t num_dg_pts) {
             NewtonianEuler::fd::MonotonisedCentralPrim<Dim>{}.ghost_zone_size(),
             directions_to_slice, 0)
             .at(direction.opposite());
-    neighbor_data[std::pair{direction,
-                            *element.neighbors().at(direction).begin()}] =
+    const auto key =
+        std::pair{direction, *element.neighbors().at(direction).begin()};
+    neighbor_data[key] = evolution::dg::subcell::GhostData{1};
+    neighbor_data[key].neighbor_ghost_data_for_reconstruction() =
         neighbor_data_in_direction;
   }
   Variables<prim_tags> dg_prim_vars{dg_mesh.number_of_grid_points()};

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/Subcell/Test_TimeDerivative.cpp
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/Subcell/Test_TimeDerivative.cpp
@@ -23,6 +23,7 @@
 #include "Domain/Structure/Element.hpp"
 #include "Domain/Tags.hpp"
 #include "Evolution/BoundaryCorrectionTags.hpp"
+#include "Evolution/DgSubcell/GhostData.hpp"
 #include "Evolution/DgSubcell/Mesh.hpp"
 #include "Evolution/DgSubcell/SliceData.hpp"
 #include "Evolution/DgSubcell/Tags/Coordinates.hpp"
@@ -207,8 +208,10 @@ std::array<double, 3> test(const size_t num_dg_pts) {
             NewtonianEuler::fd::MonotonisedCentralPrim<dim>{}.ghost_zone_size(),
             directions_to_slice, 0)
             .at(direction.opposite());
-    neighbor_data[std::pair{direction,
-                            *element.neighbors().at(direction).begin()}] =
+    const auto key =
+        std::pair{direction, *element.neighbors().at(direction).begin()};
+    neighbor_data[key] = evolution::dg::subcell::GhostData{1};
+    neighbor_data[key].neighbor_ghost_data_for_reconstruction() =
         neighbor_data_in_direction;
   }
 

--- a/tests/Unit/Evolution/Systems/ScalarAdvection/Subcell/Test_NeighborPackagedData.cpp
+++ b/tests/Unit/Evolution/Systems/ScalarAdvection/Subcell/Test_NeighborPackagedData.cpp
@@ -126,7 +126,7 @@ void test_neighbor_packaged_data(const size_t num_dg_pts_per_dimension,
     return vars;
   };
   typename evolution::dg::subcell::Tags::GhostDataForReconstruction<Dim>::type
-      neighbor_data = TestHelpers::ScalarAdvection::fd::compute_neighbor_data(
+      ghost_data = TestHelpers::ScalarAdvection::fd::compute_ghost_data(
           subcell_mesh, logical_coords_subcell, element.neighbors(),
           reconstructor.ghost_zone_size(), compute_random_variable);
 
@@ -183,7 +183,7 @@ void test_neighbor_packaged_data(const size_t num_dg_pts_per_dimension,
       domain::Tags::MeshVelocity<Dim>,
       evolution::dg::Tags::NormalCovectorAndMagnitude<Dim>,
       evolution::dg::subcell::Tags::SubcellOptions<Dim>>>(
-      element, dg_mesh, subcell_mesh, volume_vars_dg, neighbor_data,
+      element, dg_mesh, subcell_mesh, volume_vars_dg, ghost_data,
       std::unique_ptr<fd::Reconstructor<Dim>>{
           std::make_unique<ReconstructionForTest>()},
       std::unique_ptr<BoundaryCorrections::BoundaryCorrection<Dim>>{
@@ -252,7 +252,7 @@ void test_neighbor_packaged_data(const size_t num_dg_pts_per_dimension,
     // reconstruct U on the mortar
     dynamic_cast<const ReconstructionForTest&>(reconstructor)
         .reconstruct_fd_neighbor(make_not_null(&vars_on_mortar_face),
-                                 volume_vars_subcell, element, neighbor_data,
+                                 volume_vars_subcell, element, ghost_data,
                                  subcell_mesh, direction);
 
     // retrieve face-centered velocity field and slice it on the mortar, then

--- a/tests/Unit/Evolution/Systems/ScalarAdvection/Subcell/Test_TimeDerivative.cpp
+++ b/tests/Unit/Evolution/Systems/ScalarAdvection/Subcell/Test_TimeDerivative.cpp
@@ -101,7 +101,7 @@ void test_subcell_timederivative() {
   // set the ghost data from neighbor
   const ReconstructionForTest reconstructor{};
   typename evolution::dg::subcell::Tags::GhostDataForReconstruction<Dim>::type
-      neighbor_data = TestHelpers::ScalarAdvection::fd::compute_neighbor_data(
+      ghost_data = TestHelpers::ScalarAdvection::fd::compute_ghost_data(
           subcell_mesh, logical_coords_subcell, element.neighbors(),
           reconstructor.ghost_zone_size(), compute_test_solution);
 
@@ -121,7 +121,7 @@ void test_subcell_timederivative() {
       element, subcell_mesh, volume_vars_subcell,
       Variables<typename dt_variables_tag::tags_list>{
           subcell_mesh.number_of_grid_points()},
-      neighbor_data,
+      ghost_data,
       std::unique_ptr<fd::Reconstructor<Dim>>{
           std::make_unique<ReconstructionForTest>()},
       std::unique_ptr<BoundaryCorrections::BoundaryCorrection<Dim>>{


### PR DESCRIPTION
## Proposed changes

Use the new `GhostData` class instead of just a single DataVector. This will be used for Charm++ messages when we need to keep local data around for a while so we can send pointers.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

~Depends on and includes #4854 and #4855~

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
