### PR TITLE
Improve CSW characteristics calculations

### DIFF
--- a/src/Evolution/Systems/CurvedScalarWave/BoundaryConditions/Worldtube.cpp
+++ b/src/Evolution/Systems/CurvedScalarWave/BoundaryConditions/Worldtube.cpp
@@ -84,12 +84,10 @@ std::optional<std::string> Worldtube<Dim>::dg_ghost(
     const gsl::not_null<tnsr::i<DataVector, Dim, Frame::Inertial>*> phi,
     const gsl::not_null<Scalar<DataVector>*> lapse,
     const gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*> shift,
-    const gsl::not_null<tnsr::II<DataVector, Dim, Frame::Inertial>*>
-        inverse_spatial_metric,
     const gsl::not_null<Scalar<DataVector>*> gamma1,
     const gsl::not_null<Scalar<DataVector>*> gamma2,
     const gsl::not_null<tnsr::II<DataVector, Dim, Frame::Inertial>*>
-        inverse_spatial_metric_2,
+        inverse_spatial_metric,
 
     const std::optional<tnsr::I<DataVector, Dim, Frame::Inertial>>&
     /*face_mesh_velocity*/,
@@ -115,7 +113,6 @@ std::optional<std::string> Worldtube<Dim>::dg_ghost(
   *lapse = lapse_interior;
   *shift = shift_interior;
   *inverse_spatial_metric = inverse_spatial_metric_interior;
-  *inverse_spatial_metric_2 = inverse_spatial_metric_interior;
   *gamma1 = gamma1_interior;
   *gamma2 = gamma2_interior;
 

--- a/src/Evolution/Systems/CurvedScalarWave/BoundaryConditions/Worldtube.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/BoundaryConditions/Worldtube.hpp
@@ -117,12 +117,10 @@ class Worldtube final : public BoundaryConditions::BoundaryCondition<Dim> {
       const gsl::not_null<tnsr::i<DataVector, Dim, Frame::Inertial>*> phi,
       const gsl::not_null<Scalar<DataVector>*> lapse,
       const gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*> shift,
-      const gsl::not_null<tnsr::II<DataVector, Dim, Frame::Inertial>*>
-          inverse_spatial_metric,
       const gsl::not_null<Scalar<DataVector>*> gamma1,
       const gsl::not_null<Scalar<DataVector>*> gamma2,
       const gsl::not_null<tnsr::II<DataVector, Dim, Frame::Inertial>*>
-          inverse_spatial_metric_2,
+          inverse_spatial_metric,
 
       const std::optional<tnsr::I<DataVector, Dim, Frame::Inertial>>&
       /*face_mesh_velocity*/,

--- a/src/Evolution/Systems/CurvedScalarWave/BoundaryCorrections/UpwindPenalty.cpp
+++ b/src/Evolution/Systems/CurvedScalarWave/BoundaryCorrections/UpwindPenalty.cpp
@@ -117,39 +117,20 @@ double UpwindPenalty<Dim>::dg_package_data(
 
     const Scalar<DataVector>& lapse,
     const tnsr::I<DataVector, Dim, Frame::Inertial>& shift,
-    const tnsr::II<DataVector, Dim, Frame::Inertial>& inverse_spatial_metric,
     const Scalar<DataVector>& constraint_gamma1,
     const Scalar<DataVector>& constraint_gamma2,
 
     const tnsr::i<DataVector, Dim, Frame::Inertial>& interface_unit_normal,
-    const tnsr::I<DataVector, Dim,
-                  Frame::Inertial>& /* interface_unit_normal_vector */,
+    const tnsr::I<DataVector, Dim, Frame::Inertial>&
+        interface_unit_normal_vector,
     const std::optional<tnsr::I<DataVector, Dim, Frame::Inertial>>&
     /*mesh_velocity*/,
     const std::optional<Scalar<DataVector>>& normal_dot_mesh_velocity) const {
   *packaged_gamma2 = constraint_gamma2;
   *packaged_interface_unit_normal = interface_unit_normal;
-
-  {  // package characteristic fields
-    Variables<CurvedScalarWave_detail::char_field_tags<Dim>> char_fields{};
-    get(get<Tags::VPsi>(char_fields))
-        .set_data_ref(make_not_null(&get(*packaged_v_psi)));
-    for (size_t i = 0; i < Dim; ++i) {
-      get<Tags::VZero<Dim>>(char_fields)
-          .get(i)
-          .set_data_ref(make_not_null(&packaged_v_zero->get(i)));
-    }
-    get(get<Tags::VPlus>(char_fields))
-        .set_data_ref(make_not_null(&get(*packaged_v_plus)));
-    get(get<Tags::VMinus>(char_fields))
-        .set_data_ref(make_not_null(&get(*packaged_v_minus)));
-
-    characteristic_fields(make_not_null(&char_fields), constraint_gamma2,
-                          inverse_spatial_metric, psi, pi, phi,
-                          interface_unit_normal);
-  }
-
-  // package characteristic speeds
+  characteristic_fields(packaged_v_psi, packaged_v_zero, packaged_v_plus,
+                        packaged_v_minus, constraint_gamma2, psi, pi, phi,
+                        interface_unit_normal, interface_unit_normal_vector);
   characteristic_speeds(packaged_char_speeds, constraint_gamma1, lapse, shift,
                         interface_unit_normal);
   if (normal_dot_mesh_velocity.has_value()) {

--- a/src/Evolution/Systems/CurvedScalarWave/BoundaryCorrections/UpwindPenalty.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/BoundaryCorrections/UpwindPenalty.hpp
@@ -119,7 +119,6 @@ class UpwindPenalty final : public BoundaryCorrection<Dim> {
   using dg_package_data_temporary_tags = tmpl::list<
       gr::Tags::Lapse<DataVector>,
       gr::Tags::Shift<Dim, Frame::Inertial, DataVector>,
-      gr::Tags::InverseSpatialMetric<Dim, Frame::Inertial, DataVector>,
       Tags::ConstraintGamma1, Tags::ConstraintGamma2>;
   using dg_package_data_volume_tags = tmpl::list<>;
 
@@ -139,7 +138,6 @@ class UpwindPenalty final : public BoundaryCorrection<Dim> {
 
       const Scalar<DataVector>& lapse,
       const tnsr::I<DataVector, Dim, Frame::Inertial>& shift,
-      const tnsr::II<DataVector, Dim, Frame::Inertial>& inverse_spatial_metric,
       const Scalar<DataVector>& constraint_gamma1,
       const Scalar<DataVector>& constraint_gamma2,
 

--- a/src/Evolution/Systems/CurvedScalarWave/Characteristics.cpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Characteristics.cpp
@@ -24,10 +24,7 @@ void characteristic_speeds(
     const tnsr::I<DataVector, SpatialDim, Frame::Inertial>& shift,
     const tnsr::i<DataVector, SpatialDim, Frame::Inertial>&
         unit_normal_one_form) {
-  if (UNLIKELY(get_size(get<0>(*char_speeds)) != get_size(get(gamma_1)))) {
-    *char_speeds = make_with_value<tnsr::a<DataVector, 3, Frame::Inertial>>(
-        get(gamma_1), std::numeric_limits<double>::signaling_NaN());
-  }
+  destructive_resize_components(char_speeds, get(gamma_1).size());
   const auto shift_dot_normal = get(dot_product(shift, unit_normal_one_form));
   get<0>(*char_speeds) = -(1. + get(gamma_1)) * shift_dot_normal;  // v(VPsi)
   get<1>(*char_speeds) = -shift_dot_normal;                        // v(VZero)
@@ -42,9 +39,9 @@ void characteristic_speeds(
     const tnsr::I<DataVector, SpatialDim, Frame::Inertial>& shift,
     const tnsr::i<DataVector, SpatialDim, Frame::Inertial>&
         unit_normal_one_form) {
-  if (UNLIKELY(get_size((*char_speeds)[0]) != get_size(get(gamma_1)))) {
-    *char_speeds = make_with_value<std::array<DataVector, 4>>(
-        get(gamma_1), std::numeric_limits<double>::signaling_NaN());
+  const size_t size = get(gamma_1).size();
+  for (auto& char_speed : *char_speeds) {
+    char_speed.destructive_resize(size);
   }
   const auto shift_dot_normal = get(dot_product(shift, unit_normal_one_form));
   (*char_speeds)[0] = -(1. + get(gamma_1)) * shift_dot_normal;  // v(VPsi)
@@ -59,9 +56,7 @@ std::array<DataVector, 4> characteristic_speeds(
     const tnsr::I<DataVector, SpatialDim, Frame::Inertial>& shift,
     const tnsr::i<DataVector, SpatialDim, Frame::Inertial>&
         unit_normal_one_form) {
-  auto char_speeds = make_with_value<std::array<DataVector, 4>>(
-      get<0>(unit_normal_one_form),
-      std::numeric_limits<double>::signaling_NaN());
+  std::array<DataVector, 4> char_speeds{};
   characteristic_speeds(make_not_null(&char_speeds), gamma_1, lapse, shift,
                         unit_normal_one_form);
   return char_speeds;
@@ -183,9 +178,8 @@ evolved_fields_from_characteristic_fields(
     const Scalar<DataVector>& v_plus, const Scalar<DataVector>& v_minus,
     const tnsr::i<DataVector, SpatialDim, Frame::Inertial>&
         unit_normal_one_form) {
-  auto evolved_fields = make_with_value<
-      Variables<tmpl::list<Tags::Psi, Tags::Pi, Tags::Phi<SpatialDim>>>>(
-      get(gamma_2), std::numeric_limits<double>::signaling_NaN());
+  Variables<tmpl::list<Tags::Psi, Tags::Pi, Tags::Phi<SpatialDim>>>
+      evolved_fields(get(gamma_2).size());
   evolved_fields_from_characteristic_fields(make_not_null(&evolved_fields),
                                             gamma_2, v_psi, v_zero, v_plus,
                                             v_minus, unit_normal_one_form);

--- a/src/Evolution/Systems/CurvedScalarWave/Characteristics.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Characteristics.hpp
@@ -141,26 +141,25 @@ template <size_t SpatialDim>
 Variables<
     tmpl::list<Tags::VPsi, Tags::VZero<SpatialDim>, Tags::VPlus, Tags::VMinus>>
 characteristic_fields(
-    const Scalar<DataVector>& gamma_2,
-    const tnsr::II<DataVector, SpatialDim, Frame::Inertial>&
-        inverse_spatial_metric,
-    const Scalar<DataVector>& psi, const Scalar<DataVector>& pi,
+    const Scalar<DataVector>& gamma_2, const Scalar<DataVector>& psi,
+    const Scalar<DataVector>& pi,
     const tnsr::i<DataVector, SpatialDim, Frame::Inertial>& phi,
     const tnsr::i<DataVector, SpatialDim, Frame::Inertial>&
-        unit_normal_one_form);
+        unit_normal_one_form,
+    const tnsr::I<DataVector, SpatialDim, Frame::Inertial>& unit_normal_vector);
 
 template <size_t SpatialDim>
 void characteristic_fields(
     gsl::not_null<Variables<tmpl::list<Tags::VPsi, Tags::VZero<SpatialDim>,
                                        Tags::VPlus, Tags::VMinus>>*>
         char_fields,
-    const Scalar<DataVector>& gamma_2,
-    const tnsr::II<DataVector, SpatialDim, Frame::Inertial>&
-        inverse_spatial_metric,
-    const Scalar<DataVector>& psi, const Scalar<DataVector>& pi,
+    const Scalar<DataVector>& gamma_2, const Scalar<DataVector>& psi,
+    const Scalar<DataVector>& pi,
     const tnsr::i<DataVector, SpatialDim, Frame::Inertial>& phi,
     const tnsr::i<DataVector, SpatialDim, Frame::Inertial>&
-        unit_normal_one_form);
+        unit_normal_one_form,
+    const tnsr::I<DataVector, SpatialDim, Frame::Inertial>& unit_normal_vector);
+
 
 template <size_t SpatialDim>
 struct CharacteristicFieldsCompute : Tags::CharacteristicFields<SpatialDim>,
@@ -181,8 +180,10 @@ struct CharacteristicFieldsCompute : Tags::CharacteristicFields<SpatialDim>,
       const tnsr::i<DataVector, SpatialDim, Frame::Inertial>& phi,
       const tnsr::i<DataVector, SpatialDim, Frame::Inertial>&
           unit_normal_one_form) {
-    characteristic_fields<SpatialDim>(result, gamma_2, inverse_spatial_metric,
-                                      psi, pi, phi, unit_normal_one_form);
+    const auto unit_normal_vector = tenex::evaluate<ti::I>(
+        inverse_spatial_metric(ti::I, ti::J) * unit_normal_one_form(ti::j));
+    characteristic_fields<SpatialDim>(result, gamma_2, psi, pi, phi,
+                                      unit_normal_one_form, unit_normal_vector);
   }
 };
 /// @}

--- a/src/Evolution/Systems/CurvedScalarWave/Characteristics.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Characteristics.hpp
@@ -160,6 +160,19 @@ void characteristic_fields(
         unit_normal_one_form,
     const tnsr::I<DataVector, SpatialDim, Frame::Inertial>& unit_normal_vector);
 
+template <size_t SpatialDim>
+void characteristic_fields(
+    const gsl::not_null<Scalar<DataVector>*>& v_psi,
+    const gsl::not_null<tnsr::i<DataVector, SpatialDim, Frame::Inertial>*>&
+        v_zero,
+    const gsl::not_null<Scalar<DataVector>*>& v_plus,
+    const gsl::not_null<Scalar<DataVector>*>& v_minus,
+    const Scalar<DataVector>& gamma_2, const Scalar<DataVector>& psi,
+    const Scalar<DataVector>& pi,
+    const tnsr::i<DataVector, SpatialDim, Frame::Inertial>& phi,
+    const tnsr::i<DataVector, SpatialDim, Frame::Inertial>&
+        unit_normal_one_form,
+    const tnsr::I<DataVector, SpatialDim, Frame::Inertial>& unit_normal_vector);
 
 template <size_t SpatialDim>
 struct CharacteristicFieldsCompute : Tags::CharacteristicFields<SpatialDim>,

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/BoundaryConditions/Worldtube.py
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/BoundaryConditions/Worldtube.py
@@ -58,22 +58,18 @@ def pi(face_mesh_velocity, normal_covector, normal_vector, psi, pi, phi, lapse,
     wt_pi = 1.
     wt_phi = np.ones(3)
 
-    vpsi_interior = Characteristics.char_field_vpsi(gamma2,
-                                                    inverse_spatial_metric,
-                                                    psi, pi, phi,
-                                                    normal_covector)
-    vzero_interior = Characteristics.char_field_vzero(gamma2,
-                                                      inverse_spatial_metric,
-                                                      psi, pi, phi,
-                                                      normal_covector)
-    vplus_interior = Characteristics.char_field_vplus(gamma2,
-                                                      inverse_spatial_metric,
-                                                      psi, pi, phi,
-                                                      normal_covector)
-    vminus_wt = Characteristics.char_field_vminus(gamma2,
-                                                  inverse_spatial_metric,
-                                                  wt_psi, wt_pi, wt_phi,
-                                                  normal_covector)
+    vpsi_interior = Characteristics.char_field_vpsi(gamma2, psi, pi, phi,
+                                                    normal_covector,
+                                                    normal_vector)
+    vzero_interior = Characteristics.char_field_vzero(gamma2, psi, pi, phi,
+                                                      normal_covector,
+                                                      normal_vector)
+    vplus_interior = Characteristics.char_field_vplus(gamma2, psi, pi, phi,
+                                                      normal_covector,
+                                                      normal_vector)
+    vminus_wt = Characteristics.char_field_vminus(gamma2, wt_psi, wt_pi,
+                                                  wt_phi, normal_covector,
+                                                  normal_vector)
 
     return Characteristics.evol_field_pi(gamma2, vpsi_interior, vzero_interior,
                                          vplus_interior, vminus_wt,
@@ -89,22 +85,18 @@ def phi(face_mesh_velocity, normal_covector, normal_vector, psi, pi, phi,
     wt_pi = 1.
     wt_phi = np.ones(3)
 
-    vpsi_interior = Characteristics.char_field_vpsi(gamma2,
-                                                    inverse_spatial_metric,
-                                                    psi, pi, phi,
-                                                    normal_covector)
-    vzero_interior = Characteristics.char_field_vzero(gamma2,
-                                                      inverse_spatial_metric,
-                                                      psi, pi, phi,
-                                                      normal_covector)
-    vplus_interior = Characteristics.char_field_vplus(gamma2,
-                                                      inverse_spatial_metric,
-                                                      psi, pi, phi,
-                                                      normal_covector)
-    vminus_wt = Characteristics.char_field_vminus(gamma2,
-                                                  inverse_spatial_metric,
-                                                  wt_psi, wt_pi, wt_phi,
-                                                  normal_covector)
+    vpsi_interior = Characteristics.char_field_vpsi(gamma2, psi, pi, phi,
+                                                    normal_covector,
+                                                    normal_vector)
+    vzero_interior = Characteristics.char_field_vzero(gamma2, psi, pi, phi,
+                                                      normal_covector,
+                                                      normal_vector)
+    vplus_interior = Characteristics.char_field_vplus(gamma2, psi, pi, phi,
+                                                      normal_covector,
+                                                      normal_vector)
+    vminus_wt = Characteristics.char_field_vminus(gamma2, wt_psi, wt_pi,
+                                                  wt_phi, normal_covector,
+                                                  normal_vector)
     return Characteristics.evol_field_phi(gamma2, vpsi_interior,
                                           vzero_interior, vplus_interior,
                                           vminus_wt, normal_covector)

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/BoundaryCorrections/Test_UpwindPenalty.cpp
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/BoundaryCorrections/Test_UpwindPenalty.cpp
@@ -193,14 +193,14 @@ void test_flat_spacetime(const gsl::not_null<std::mt19937*> gen) {
       make_not_null(&csw_v_plus_int), make_not_null(&csw_v_minus_int),
       make_not_null(&csw_gamma2_int), make_not_null(&csw_normal_int),
       make_not_null(&csw_char_speeds_int), psi, pi, phi, lapse, shift,
-      inverse_spatial_metric, gamma1, gamma2, normal_int, normal_vector_int,
+      gamma1, gamma2, normal_int, normal_vector_int,
       mesh_velocity, normal_dot_mesh_velociy_int);
   csw_flux_computer.dg_package_data(
       make_not_null(&csw_v_psi_ext), make_not_null(&csw_v_zero_ext),
       make_not_null(&csw_v_plus_ext), make_not_null(&csw_v_minus_ext),
       make_not_null(&csw_gamma2_ext), make_not_null(&csw_normal_ext),
       make_not_null(&csw_char_speeds_ext), psi, pi, phi, lapse, shift,
-      inverse_spatial_metric, gamma1, gamma2, normal_ext, normal_vector_ext,
+      gamma1, gamma2, normal_ext, normal_vector_ext,
       mesh_velocity, normal_dot_mesh_velociy_ext);
   csw_flux_computer.dg_boundary_terms(
       make_not_null(&csw_psi_bcorr), make_not_null(&csw_pi_bcorr),

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/BoundaryCorrections/UpwindPenalty.py
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/BoundaryCorrections/UpwindPenalty.py
@@ -9,55 +9,58 @@ from Evolution.Systems.CurvedScalarWave.Characteristics import (
     evol_field_psi, evol_field_pi, evol_field_phi)
 
 
-def dg_package_data_v_psi(psi, pi, phi, lapse, shift, inverse_spatial_metric,
-                          constraint_gamma1, constraint_gamma2,
-                          interface_unit_normal, interface_unit_normal_vector,
-                          mesh_velocity, normal_dot_mesh_velocity):
-    return char_field_vpsi(constraint_gamma2, inverse_spatial_metric, psi, pi,
-                           phi, interface_unit_normal)
+def dg_package_data_v_psi(psi, pi, phi, lapse, shift, constraint_gamma1,
+                          constraint_gamma2, interface_unit_normal,
+                          interface_unit_normal_vector, mesh_velocity,
+                          normal_dot_mesh_velocity):
+    return char_field_vpsi(constraint_gamma2, psi, pi, phi,
+                           interface_unit_normal, interface_unit_normal_vector)
 
 
-def dg_package_data_v_zero(psi, pi, phi, lapse, shift, inverse_spatial_metric,
-                           constraint_gamma1, constraint_gamma2,
-                           interface_unit_normal, interface_unit_normal_vector,
-                           mesh_velocity, normal_dot_mesh_velocity):
-    return char_field_vzero(constraint_gamma2, inverse_spatial_metric, psi, pi,
-                            phi, interface_unit_normal)
-
-
-def dg_package_data_v_plus(psi, pi, phi, lapse, shift, inverse_spatial_metric,
-                           constraint_gamma1, constraint_gamma2,
-                           interface_unit_normal, interface_unit_normal_vector,
-                           mesh_velocity, normal_dot_mesh_velocity):
-    return char_field_vplus(constraint_gamma2, inverse_spatial_metric, psi, pi,
-                            phi, interface_unit_normal)
-
-
-def dg_package_data_v_minus(psi, pi, phi, lapse, shift, inverse_spatial_metric,
-                            constraint_gamma1, constraint_gamma2,
+def dg_package_data_v_zero(psi, pi, phi, lapse, shift, constraint_gamma1,
+                           constraint_gamma2, interface_unit_normal,
+                           interface_unit_normal_vector, mesh_velocity,
+                           normal_dot_mesh_velocity):
+    return char_field_vzero(constraint_gamma2, psi, pi, phi,
                             interface_unit_normal,
+                            interface_unit_normal_vector)
+
+
+def dg_package_data_v_plus(psi, pi, phi, lapse, shift, constraint_gamma1,
+                           constraint_gamma2, interface_unit_normal,
+                           interface_unit_normal_vector, mesh_velocity,
+                           normal_dot_mesh_velocity):
+    return char_field_vplus(constraint_gamma2, psi, pi, phi,
+                            interface_unit_normal,
+                            interface_unit_normal_vector)
+
+
+def dg_package_data_v_minus(psi, pi, phi, lapse, shift, constraint_gamma1,
+                            constraint_gamma2, interface_unit_normal,
                             interface_unit_normal_vector, mesh_velocity,
                             normal_dot_mesh_velocity):
-    return char_field_vminus(constraint_gamma2, inverse_spatial_metric, psi,
-                             pi, phi, interface_unit_normal)
+    return char_field_vminus(constraint_gamma2, psi, pi, phi,
+                             interface_unit_normal,
+                             interface_unit_normal_vector)
 
 
-def dg_package_data_gamma2(psi, pi, phi, lapse, shift, inverse_spatial_metric,
-                           constraint_gamma1, constraint_gamma2,
-                           interface_unit_normal, interface_unit_normal_vector,
-                           mesh_velocity, normal_dot_mesh_velocity):
+def dg_package_data_gamma2(psi, pi, phi, lapse, shift, constraint_gamma1,
+                           constraint_gamma2, interface_unit_normal,
+                           interface_unit_normal_vector, mesh_velocity,
+                           normal_dot_mesh_velocity):
     return constraint_gamma2
 
 
-def dg_package_data_interface_unit_normal(
-    psi, pi, phi, lapse, shift, inverse_spatial_metric, constraint_gamma1,
-    constraint_gamma2, interface_unit_normal, interface_unit_normal_vector,
-    mesh_velocity, normal_dot_mesh_velocity):
+def dg_package_data_interface_unit_normal(psi, pi, phi, lapse, shift,
+                                          constraint_gamma1, constraint_gamma2,
+                                          interface_unit_normal,
+                                          interface_unit_normal_vector,
+                                          mesh_velocity,
+                                          normal_dot_mesh_velocity):
     return interface_unit_normal
 
 
-def dg_package_data_char_speeds(psi, pi, phi, lapse, shift,
-                                inverse_spatial_metric, constraint_gamma1,
+def dg_package_data_char_speeds(psi, pi, phi, lapse, shift, constraint_gamma1,
                                 constraint_gamma2, interface_unit_normal,
                                 interface_unit_normal_vector, mesh_velocity,
                                 normal_dot_mesh_velocity):

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Characteristics.py
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Characteristics.py
@@ -27,31 +27,23 @@ def char_speed_vminus(gamma1, lapse, shift, unit_normal):
 # Test functions for characteristic fields
 
 
-def char_field_vpsi(gamma2, inverse_spatial_metric, psi, pi, phi,
-                    normal_one_form):
+def char_field_vpsi(gamma2, psi, pi, phi, normal_one_form, normal_vector):
     return psi
 
 
-def char_field_vzero(gamma2, inverse_spatial_metric, psi, pi, phi,
-                     normal_one_form):
-    normal_vector =\
-        np.einsum('ij,j', inverse_spatial_metric, normal_one_form)
+def char_field_vzero(gamma2, psi, pi, phi, normal_one_form, normal_vector):
     projection_tensor = np.identity(len(normal_vector)) -\
         np.einsum('i,j', normal_one_form, normal_vector)
     return np.einsum('ij,j->i', projection_tensor, phi)
 
 
-def char_field_vplus(gamma2, inverse_spatial_metric, psi, pi, phi,
-                     normal_one_form):
-    phi_dot_normal = np.einsum('ij,i,j', inverse_spatial_metric,
-                               normal_one_form, phi)
+def char_field_vplus(gamma2, psi, pi, phi, normal_one_form, normal_vector):
+    phi_dot_normal = np.dot(normal_vector, phi)
     return pi + phi_dot_normal - (gamma2 * psi)
 
 
-def char_field_vminus(gamma2, inverse_spatial_metric, psi, pi, phi,
-                      normal_one_form):
-    phi_dot_normal = np.einsum('ij,i,j', inverse_spatial_metric,
-                               normal_one_form, phi)
+def char_field_vminus(gamma2, psi, pi, phi, normal_one_form, normal_vector):
+    phi_dot_normal = np.dot(normal_vector, phi)
     return pi - phi_dot_normal - (gamma2 * psi)
 
 

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Test_Characteristics.cpp
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Test_Characteristics.cpp
@@ -77,15 +77,15 @@ void test_characteristic_speeds() {
 
 namespace {
 template <typename Tag, size_t SpatialDim>
-typename Tag::type field_with_tag(
-    const Scalar<DataVector>& gamma_2,
-    const tnsr::II<DataVector, SpatialDim, Frame::Inertial>&
-        inverse_spatial_metric,
-    const Scalar<DataVector>& psi, const Scalar<DataVector>& pi,
+typename Tag::type field_with_tag_variables(
+    const Scalar<DataVector>& gamma_2, const Scalar<DataVector>& psi,
+    const Scalar<DataVector>& pi,
     const tnsr::i<DataVector, SpatialDim, Frame::Inertial>& phi,
-    const tnsr::i<DataVector, SpatialDim, Frame::Inertial>& normal_one_form) {
+    const tnsr::i<DataVector, SpatialDim, Frame::Inertial>& normal_one_form,
+    const tnsr::I<DataVector, SpatialDim, Frame::Inertial>& normal_vector) {
   return get<Tag>(CurvedScalarWave::characteristic_fields(
-      gamma_2, inverse_spatial_metric, psi, pi, phi, normal_one_form));
+      gamma_2, psi, pi, phi, normal_one_form, normal_vector));
+}
 }
 
 template <size_t SpatialDim>
@@ -93,19 +93,20 @@ void test_characteristic_fields() {
   const DataVector used_for_size(5);
   // VPsi
   pypp::check_with_random_values<1>(
-      field_with_tag<CurvedScalarWave::Tags::VPsi, SpatialDim>,
+      field_with_tag_variables<CurvedScalarWave::Tags::VPsi, SpatialDim>,
       "Characteristics", "char_field_vpsi", {{{-2.0, 2.0}}}, used_for_size);
   // VZero
   pypp::check_with_random_values<1>(
-      field_with_tag<CurvedScalarWave::Tags::VZero<SpatialDim>, SpatialDim>,
+      field_with_tag_variables<CurvedScalarWave::Tags::VZero<SpatialDim>,
+                               SpatialDim>,
       "Characteristics", "char_field_vzero", {{{-2.0, 2.0}}}, used_for_size);
   // VPlus
   pypp::check_with_random_values<1>(
-      field_with_tag<CurvedScalarWave::Tags::VPlus, SpatialDim>,
+      field_with_tag_variables<CurvedScalarWave::Tags::VPlus, SpatialDim>,
       "Characteristics", "char_field_vplus", {{{-2.0, 2.0}}}, used_for_size);
   // VMinus
   pypp::check_with_random_values<1>(
-      field_with_tag<CurvedScalarWave::Tags::VMinus, SpatialDim>,
+      field_with_tag_variables<CurvedScalarWave::Tags::VMinus, SpatialDim>,
       "Characteristics", "char_field_vminus", {{{-2.0, 2.0}}}, used_for_size);
 }
 }  // namespace
@@ -216,9 +217,11 @@ void test_characteristics_compute_tags() {
   const auto phi =
       make_with_random_values<tnsr::i<DataVector, SpatialDim, Frame::Inertial>>(
           nn_generator, nn_distribution, used_for_size);
-  const auto normal =
+  const auto normal_one_form =
       make_with_random_values<tnsr::i<DataVector, SpatialDim, Frame::Inertial>>(
           nn_generator, nn_distribution, used_for_size);
+  const auto normal_vector = tenex::evaluate<ti::I>(
+      inverse_spatial_metric(ti::I, ti::J) * normal_one_form(ti::j));
 
   // Insert into databox
   const auto box = db::create<
@@ -235,16 +238,17 @@ void test_characteristics_compute_tags() {
           CurvedScalarWave::CharacteristicSpeedsCompute<SpatialDim>,
           CurvedScalarWave::CharacteristicFieldsCompute<SpatialDim>>>(
       gamma_1, gamma_2, lapse, shift, inverse_spatial_metric, psi, pi, phi,
-      normal);
+      normal_one_form);
   // Test compute tag for char speeds
   CHECK(
       db::get<CurvedScalarWave::Tags::CharacteristicSpeeds<SpatialDim>>(box) ==
-      CurvedScalarWave::characteristic_speeds(gamma_1, lapse, shift, normal));
+      CurvedScalarWave::characteristic_speeds(gamma_1, lapse, shift,
+                                              normal_one_form));
   // Test compute tag for char fields
   CHECK(
       db::get<CurvedScalarWave::Tags::CharacteristicFields<SpatialDim>>(box) ==
-      CurvedScalarWave::characteristic_fields(gamma_2, inverse_spatial_metric,
-                                              psi, pi, phi, normal));
+      CurvedScalarWave::characteristic_fields(gamma_2, psi, pi, phi,
+                                              normal_one_form, normal_vector));
 
   // more randomized tensors
   const auto u_psi = make_with_random_values<Scalar<DataVector>>(
@@ -266,12 +270,13 @@ void test_characteristics_compute_tags() {
           ::Tags::Normalized<domain::Tags::UnnormalizedFaceNormal<SpatialDim>>>,
       db::AddComputeTags<
           CurvedScalarWave::EvolvedFieldsFromCharacteristicFieldsCompute<
-              SpatialDim>>>(gamma_2, u_psi, u_zero, u_plus, u_minus, normal);
+              SpatialDim>>>(gamma_2, u_psi, u_zero, u_plus, u_minus,
+                            normal_one_form);
   // Test compute tag for evolved fields computed from char fields
   CHECK(db::get<CurvedScalarWave::Tags::EvolvedFieldsFromCharacteristicFields<
             SpatialDim>>(box2) ==
         CurvedScalarWave::evolved_fields_from_characteristic_fields(
-            gamma_2, u_psi, u_zero, u_plus, u_minus, normal));
+            gamma_2, u_psi, u_zero, u_plus, u_minus, normal_one_form));
 }
 }  // namespace
 


### PR DESCRIPTION
## Proposed changes
Fixes some outdated initialization and adds an overload to `characteristic_fields` that is a lot safer and looks more tidy.

There are now a lot of unused overloads that use variables directly and  unused compute tags  `EvolvedFieldsFromCharacteristicFieldsCompute`, `CharacteristicFieldsCompute` and `CharacteristicSpeedsCompute` in this file, should they be deleted?