### PR TITLE
Correct options to generate-xdmf in tutorials

### DIFF
--- a/docs/Tutorials/BeginnersTutorial.md
+++ b/docs/Tutorials/BeginnersTutorial.md
@@ -146,12 +146,11 @@ directory where you have the `H5` files, run
 
 ```
 spectre generate-xdmf \
-  --file-prefix ExportTimeDependentCoordinates3DVolume \
-  --subfile-name element_data --output BBH_Coords
+  --subfile-name element_data --output BBH_Coords \
+  ExportTimeDependentCoordinates3DVolume*h5
 ```
 
-The `--file-prefix` argument must be whatever is before the number `0` in the
-name of your `Volume` file. We output volume data per node so we append the
+We output volume data per node so we append the
 node number to each volume file we have. Since you're most likely running on a
 laptop, you'll only be running on one node so you should only get one output
 file for the volume. The `--subfile-name` argument is the group name inside the

--- a/docs/Tutorials/Visualization.md
+++ b/docs/Tutorials/Visualization.md
@@ -50,9 +50,8 @@ files. An XDMF file must be created from the volume data in order to do
 visualization using ParaView. To this end we provide the tool
 `generate-xdmf` in the Python command-line interface. Run it in your build
 directory as `spectre generate-xdmf`. It
-takes three required arguments which are passed to `--file-prefix`,
-`--subfile-name`, and `--output`. The argument passed to `--file-prefix` is the
-name of the H5 volume data, leaving out the node number and extension. The
+takes two required arguments which are passed to `--subfile-name`, and
+`--output`. The
 argument passed to `--subfile-name` is the name of the subfile inside the H5
 volume data file where data is stored. In the above example, `--subfile-name`
 would be `VolumePsiPiPhiEvery50Slabs`. The argument passed to `--output` is the


### PR DESCRIPTION
## Proposed changes

Modify example use of generate-xdmf to match current syntax (please check; this syntax worked for me, while the old one did not)

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.