### PR TITLE
Add real spherical harmonics implementation

### DIFF
--- a/src/NumericalAlgorithms/SphericalHarmonics/CMakeLists.txt
+++ b/src/NumericalAlgorithms/SphericalHarmonics/CMakeLists.txt
@@ -9,6 +9,7 @@ spectre_target_sources(
   ${LIBRARY}
   PRIVATE
   ChangeCenterOfStrahlkorper.cpp
+  RealSphericalHarmonics.cpp
   SpherepackIterator.cpp
   Strahlkorper.cpp
   StrahlkorperFunctions.cpp
@@ -22,6 +23,7 @@ spectre_target_headers(
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   ChangeCenterOfStrahlkorper.hpp
+  RealSphericalHarmonics.hpp
   SpherepackIterator.hpp
   Strahlkorper.hpp
   StrahlkorperFunctions.hpp
@@ -36,6 +38,7 @@ target_link_libraries(
   ${LIBRARY}
   PUBLIC
   Blas
+  Boost::boost
   DataStructures
   ErrorHandling
   SPHEREPACK

--- a/src/NumericalAlgorithms/SphericalHarmonics/RealSphericalHarmonics.cpp
+++ b/src/NumericalAlgorithms/SphericalHarmonics/RealSphericalHarmonics.cpp
@@ -1,0 +1,42 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "NumericalAlgorithms/SphericalHarmonics/RealSphericalHarmonics.hpp"
+
+#include <boost/math/special_functions/spherical_harmonic.hpp>
+#include <cstddef>
+
+#include "DataStructures/DataVector.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/Gsl.hpp"
+
+void real_spherical_harmonic(gsl::not_null<DataVector*> spherical_harmonic,
+                             const DataVector& theta, const DataVector& phi,
+                             size_t l, int m) {
+  ASSERT(size_t(abs(m)) <= l, "m needs to be smaller than l");
+  const int sign = (m % 2 == 0) ? 1 : -1;
+  const double prefactor = sign * M_SQRT2;
+  if (m < 0) {
+    for (size_t i = 0; i < theta.size(); ++i) {
+      (*spherical_harmonic)[i] = prefactor * boost::math::spherical_harmonic_i(
+                                                 l, abs(m), theta[i], phi[i]);
+    }
+  } else if (m > 0) {
+    for (size_t i = 0; i < theta.size(); ++i) {
+      (*spherical_harmonic)[i] =
+          prefactor * boost::math::spherical_harmonic_r(l, m, theta[i], phi[i]);
+    }
+  } else {
+    for (size_t i = 0; i < theta.size(); ++i) {
+      (*spherical_harmonic)[i] =
+          boost::math::spherical_harmonic_r(l, m, theta[i], phi[i]);
+    }
+  }
+}
+
+DataVector real_spherical_harmonic(const DataVector& theta,
+                                   const DataVector& phi, size_t l, int m) {
+  DataVector result(theta.size());
+  real_spherical_harmonic(make_not_null(&result), theta, phi, l, m);
+  return result;
+}

--- a/src/NumericalAlgorithms/SphericalHarmonics/RealSphericalHarmonics.hpp
+++ b/src/NumericalAlgorithms/SphericalHarmonics/RealSphericalHarmonics.hpp
@@ -1,0 +1,41 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/DataVector.hpp"
+#include "Utilities/Gsl.hpp"
+
+/// @{
+/*!
+ * \ingroup SpectralGroup
+ *
+ * \brief Evaluates a real spherical harmonic of order l at the requested
+ * angles \f$\theta\f$ and \f$\phi\f$.
+ *
+ * The real spherical harmonics are defined as:
+ * \begin{equation}
+ * Y_{lm}(\theta, \phi) =
+ * \begin{cases}
+ * \sqrt{2} (-1)^m \mathcal{I}[Y_l^{|m|}] & \text{if } m < 0 \\
+ *  Y_l^{0} & \text{if } m = 0 \\
+ * \sqrt{2} (-1)^m \mathcal{R}[Y_l^{m}] & \text{if } m > 0
+ * \end{cases}
+ * \end{equation}
+ *
+ * where \f$Y_l^m\f$ are the complex spherical harmonics and \f$\mathcal{R}\f$
+ * denotes the real part and \f$\mathcal{I}\f$ denotes the imaginary part.
+ *
+ * \note This implementation uses the boost implementation of spherical
+ * harmonics. The calculation is not vectorized and may be slow.
+ * Stability has not been tested for large l.
+ */
+void real_spherical_harmonic(gsl::not_null<DataVector*> spherical_harmonic,
+                             const DataVector& theta, const DataVector& phi,
+                             size_t l, int m);
+
+DataVector real_spherical_harmonic(const DataVector& theta,
+                                   const DataVector& phi, size_t l, int m);
+/// @}

--- a/tests/Unit/NumericalAlgorithms/SphericalHarmonics/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/SphericalHarmonics/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY "Test_SphericalHarmonics")
 
 set(LIBRARY_SOURCES
   Test_ChangeCenterOfStrahlkorper.cpp
+  Test_RealSphericalHarmonics.cpp
   Test_SpherepackIterator.cpp
   Test_Strahlkorper.cpp
   Test_StrahlkorperFunctions.cpp

--- a/tests/Unit/NumericalAlgorithms/SphericalHarmonics/Test_RealSphericalHarmonics.cpp
+++ b/tests/Unit/NumericalAlgorithms/SphericalHarmonics/Test_RealSphericalHarmonics.cpp
@@ -1,0 +1,61 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <random>
+
+#include "DataStructures/DataVector.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "NumericalAlgorithms/Spectral/SwshInterpolation.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/RealSphericalHarmonics.hpp"
+
+SPECTRE_TEST_CASE("Unit.SphericalHarmonics.RealSphericalHarmonics",
+                  "[NumericalAlgorithms][Unit]") {
+  const size_t l_max = 10;
+  MAKE_GENERATOR(gen);
+  std::uniform_real_distribution<> phi_distribution(0., 2. * M_PI);
+  std::uniform_real_distribution<> theta_distribution(0., M_PI);
+  const size_t num_points = 100;
+  const auto thetas = make_with_random_values<DataVector>(
+      make_not_null(&gen), make_not_null(&theta_distribution),
+      DataVector(num_points));
+  const auto phis = make_with_random_values<DataVector>(
+      make_not_null(&gen), make_not_null(&phi_distribution),
+      DataVector(num_points));
+  Approx custom_approx = Approx::custom().epsilon(1.e-12).scale(1.0);
+
+  for (size_t l = 0; l <= l_max; ++l) {
+    for (int m = -l; m <= static_cast<int>(l); ++m) {
+      const auto spherical_harmonic =
+          real_spherical_harmonic(thetas, phis, l, m);
+      if (m == 0) {
+        const Spectral::Swsh::SpinWeightedSphericalHarmonic
+            complex_spherical_harmonic(0, l, m);
+        CHECK_ITERABLE_CUSTOM_APPROX(
+            real(complex_spherical_harmonic.evaluate(
+                thetas, phis, sin(thetas / 2.), cos(thetas / 2.))),
+            spherical_harmonic, custom_approx);
+      } else if (m > 0) {
+        const Spectral::Swsh::SpinWeightedSphericalHarmonic
+            complex_spherical_harmonic(0, l, m);
+        const int sign = (m % 2 == 0) ? 1 : -1;
+        CHECK_ITERABLE_CUSTOM_APPROX(
+            real(complex_spherical_harmonic.evaluate(
+                thetas, phis, sin(thetas / 2.), cos(thetas / 2.))) *
+                M_SQRT2 * sign,
+            spherical_harmonic, custom_approx);
+      } else {
+        const Spectral::Swsh::SpinWeightedSphericalHarmonic
+            complex_spherical_harmonic(0, l, abs(m));
+        const int sign = (m % 2 == 0) ? 1 : -1;
+        CHECK_ITERABLE_CUSTOM_APPROX(
+            imag(complex_spherical_harmonic.evaluate(
+                thetas, phis, sin(thetas / 2.), cos(thetas / 2.))) *
+                M_SQRT2 * sign,
+            spherical_harmonic, custom_approx);
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Proposed changes

Adds a simple implementation to calculate real spherical harmonics using boost. I will only need to use it up to l=2. Alternatively, they could be calculated with the spin-weighted spherical harmonics, see the test.