### PR TITLE
Enforce 3-con in GH numeric initial data

### DIFF
--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Actions/Test_NumericInitialData.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Actions/Test_NumericInitialData.cpp
@@ -84,8 +84,6 @@ struct MockReadVolumeData {
                 selected_fields) == "CustomSpacetimeMetric");
       CHECK(get<importers::Tags::Selected<Tags::Pi<3, Frame::Inertial>>>(
                 selected_fields) == "CustomPi");
-      CHECK(get<importers::Tags::Selected<Tags::Phi<3, Frame::Inertial>>>(
-                selected_fields) == "CustomPhi");
       CHECK_FALSE(get<importers::Tags::Selected<
                       gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>>>(
           selected_fields));
@@ -115,8 +113,6 @@ struct MockReadVolumeData {
               gr::Tags::SpacetimeMetric<3, Frame::Inertial, DataVector>>>(
               selected_fields));
       CHECK_FALSE(get<importers::Tags::Selected<Tags::Pi<3, Frame::Inertial>>>(
-          selected_fields));
-      CHECK_FALSE(get<importers::Tags::Selected<Tags::Phi<3, Frame::Inertial>>>(
           selected_fields));
     } else {
       REQUIRE(false);
@@ -215,8 +211,6 @@ void test_numeric_initial_data(
             kerr_gh_vars);
     get<Tags::Pi<3, Frame::Inertial>>(inbox) =
         get<Tags::Pi<3, Frame::Inertial>>(kerr_gh_vars);
-    get<Tags::Phi<3, Frame::Inertial>>(inbox) =
-        get<Tags::Phi<3, Frame::Inertial>>(kerr_gh_vars);
   } else if (std::holds_alternative<detail::Adm>(selected_vars)) {
     const auto kerr_adm_vars = kerr.variables(
         coords, 0.,
@@ -263,11 +257,9 @@ void test_numeric_initial_data(
 SPECTRE_TEST_CASE("Unit.Evolution.Systems.Gh.NumericInitialData",
                   "[Unit][Evolution]") {
   test_numeric_initial_data(
-      detail::GeneralizedHarmonic{"CustomSpacetimeMetric", "CustomPi",
-                                  "CustomPhi"},
+      detail::GeneralizedHarmonic{"CustomSpacetimeMetric", "CustomPi"},
       "SpacetimeMetric: CustomSpacetimeMetric\n"
-      "Pi: CustomPi\n"
-      "Phi: CustomPhi");
+      "Pi: CustomPi\n");
   test_numeric_initial_data(
       detail::Adm{"CustomSpatialMetric", "CustomLapse", "CustomShift",
                   "CustomExtrinsicCurvature"},


### PR DESCRIPTION
## Proposed changes

Currently, when reading numeric initial data for generalized-harmonic evolutions (e.g. BBHs), the 3-index constraint is set to zero if the data provided are ADM quantities but not if the evolution variables are provided directly. This PR makes the latter case also set the 3-index constraint to zero at t=0.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
After this change, all numeric initial data for generalized-harmonic evolutions enforce that the three-index constraint vanishes at the initial time.
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
