### PR TITLE
Allow different boundary conditions in Brick

### DIFF
--- a/src/Domain/Creators/Brick.hpp
+++ b/src/Domain/Creators/Brick.hpp
@@ -83,9 +83,12 @@ class Brick : public DomainCreator<3> {
         "The time dependence of the moving mesh domain."};
   };
 
-  template <typename BoundaryConditionsBase>
+  template <typename BoundaryConditionsBase, size_t Dim>
   struct BoundaryCondition {
-    static std::string name() { return "BoundaryCondition"; }
+    static std::string name() {
+      return "BoundaryConditionIn" +
+             std::string{Dim == 0 ? 'X' : (Dim == 1 ? 'Y' : 'Z')};
+    }
     static constexpr Options::String help =
         "The boundary condition to impose on all sides.";
     using type = std::unique_ptr<BoundaryConditionsBase>;
@@ -101,9 +104,19 @@ class Brick : public DomainCreator<3> {
       tmpl::conditional_t<
           domain::BoundaryConditions::has_boundary_conditions_base_v<
               typename Metavariables::system>,
-          tmpl::list<BoundaryCondition<
-              domain::BoundaryConditions::get_boundary_conditions_base<
-                  typename Metavariables::system>>>,
+          tmpl::list<
+              BoundaryCondition<
+                  domain::BoundaryConditions::get_boundary_conditions_base<
+                      typename Metavariables::system>,
+                  0>,
+              BoundaryCondition<
+                  domain::BoundaryConditions::get_boundary_conditions_base<
+                      typename Metavariables::system>,
+                  1>,
+              BoundaryCondition<
+                  domain::BoundaryConditions::get_boundary_conditions_base<
+                      typename Metavariables::system>,
+                  2>>,
           options_periodic>,
       tmpl::list<TimeDependence>>;
 
@@ -122,7 +135,11 @@ class Brick : public DomainCreator<3> {
         typename InitialRefinement::type initial_refinement_level_xyz,
         typename InitialGridPoints::type initial_number_of_grid_points_in_xyz,
         std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
-            boundary_condition = nullptr,
+            boundary_condition_in_x = nullptr,
+        std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
+            boundary_condition_in_y = nullptr,
+        std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
+            boundary_condition_in_z = nullptr,
         std::unique_ptr<domain::creators::time_dependence::TimeDependence<3>>
             time_dependence = nullptr,
         const Options::Context& context = {});
@@ -161,7 +178,11 @@ class Brick : public DomainCreator<3> {
   std::unique_ptr<domain::creators::time_dependence::TimeDependence<3>>
       time_dependence_;
   std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
-      boundary_condition_;
+      boundary_condition_in_x_;
+  std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
+      boundary_condition_in_y_;
+  std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
+      boundary_condition_in_z_;
   inline static const std::vector<std::string> block_names_{"Brick"};
 };
 }  // namespace creators

--- a/tests/InputFiles/CurvedScalarWave/PlaneWaveMinkowski3D.yaml
+++ b/tests/InputFiles/CurvedScalarWave/PlaneWaveMinkowski3D.yaml
@@ -57,7 +57,9 @@ DomainCreator:
     InitialRefinement: [1, 1, 1]
     InitialGridPoints: [6, 6, 6]
     TimeDependence: None
-    BoundaryCondition: Periodic
+    BoundaryConditionInX: Periodic
+    BoundaryConditionInY: Periodic
+    BoundaryConditionInZ: Periodic
 
 SpatialDiscretization:
   BoundaryCorrection:

--- a/tests/InputFiles/GeneralizedHarmonic/GaugeWave3D.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/GaugeWave3D.yaml
@@ -39,7 +39,9 @@ DomainCreator:
     InitialRefinement: [1, 1, 1]
     InitialGridPoints: [5, 5, 5]
     TimeDependence: None
-    BoundaryCondition: Periodic
+    BoundaryConditionInX: Periodic
+    BoundaryConditionInY: Periodic
+    BoundaryConditionInZ: Periodic
 
 EvolutionSystem:
   GeneralizedHarmonic:

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdTovStar.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdTovStar.yaml
@@ -43,7 +43,11 @@ DomainCreator:
     InitialRefinement: [1, 1, 1]
     InitialGridPoints: [3, 3, 3]
     TimeDependence: None
-    BoundaryCondition:
+    BoundaryConditionInX:
+      DirichletAnalytic:
+    BoundaryConditionInY:
+      DirichletAnalytic:
+    BoundaryConditionInZ:
       DirichletAnalytic:
 
 VariableFixing:

--- a/tests/InputFiles/GrMhd/ValenciaDivClean/BlastWave.yaml
+++ b/tests/InputFiles/GrMhd/ValenciaDivClean/BlastWave.yaml
@@ -28,7 +28,9 @@ DomainCreator:
     InitialRefinement: [2, 2, 0]
     InitialGridPoints: [3, 3, 3]
     TimeDependence: None
-    BoundaryCondition: Periodic
+    BoundaryConditionInX: Periodic
+    BoundaryConditionInY: Periodic
+    BoundaryConditionInZ: Periodic
 
 SpatialDiscretization:
   BoundaryCorrection:

--- a/tests/InputFiles/GrMhd/ValenciaDivClean/FishboneMoncriefDisk.yaml
+++ b/tests/InputFiles/GrMhd/ValenciaDivClean/FishboneMoncriefDisk.yaml
@@ -43,7 +43,9 @@ DomainCreator:
     InitialRefinement: [0, 0, 0]
     InitialGridPoints: [5, 5, 5]
     TimeDependence: None
-    BoundaryCondition: DirichletAnalytic
+    BoundaryConditionInX: DirichletAnalytic
+    BoundaryConditionInY: DirichletAnalytic
+    BoundaryConditionInZ: DirichletAnalytic
 
 SpatialDiscretization:
   BoundaryCorrection:

--- a/tests/InputFiles/NewtonianEuler/RiemannProblem3D.yaml
+++ b/tests/InputFiles/NewtonianEuler/RiemannProblem3D.yaml
@@ -22,7 +22,9 @@ DomainCreator:
     InitialRefinement: [4, 0, 0]
     InitialGridPoints: [2, 2, 2]
     TimeDependence: None
-    BoundaryCondition: DirichletAnalytic
+    BoundaryConditionInX: DirichletAnalytic
+    BoundaryConditionInY: DirichletAnalytic
+    BoundaryConditionInZ: DirichletAnalytic
 
 SpatialDiscretization:
   BoundaryCorrection:

--- a/tests/InputFiles/Poisson/ProductOfSinusoids3D.yaml
+++ b/tests/InputFiles/Poisson/ProductOfSinusoids3D.yaml
@@ -34,7 +34,13 @@ DomainCreator:
     InitialRefinement: [1, 0, 0]
     InitialGridPoints: [4, 3, 5]
     TimeDependence: None
-    BoundaryCondition:
+    BoundaryConditionInX:
+      AnalyticSolution:
+        Field: Dirichlet
+    BoundaryConditionInY:
+      AnalyticSolution:
+        Field: Dirichlet
+    BoundaryConditionInZ:
       AnalyticSolution:
         Field: Dirichlet
 

--- a/tests/InputFiles/RadiationTransport/M1Grey/ConstantM1.yaml
+++ b/tests/InputFiles/RadiationTransport/M1Grey/ConstantM1.yaml
@@ -25,7 +25,9 @@ DomainCreator:
     InitialRefinement: [0, 0, 0]
     InitialGridPoints: [5, 5, 5]
     TimeDependence: None
-    BoundaryCondition: DirichletAnalytic
+    BoundaryConditionInX: DirichletAnalytic
+    BoundaryConditionInY: DirichletAnalytic
+    BoundaryConditionInZ: DirichletAnalytic
 
 AnalyticSolution:
   ConstantM1:

--- a/tests/InputFiles/RelativisticEuler/Valencia/SmoothFlow3D.yaml
+++ b/tests/InputFiles/RelativisticEuler/Valencia/SmoothFlow3D.yaml
@@ -22,7 +22,9 @@ DomainCreator:
     InitialRefinement: [0, 0, 0]
     InitialGridPoints: [4, 4, 4]
     TimeDependence: None
-    BoundaryCondition: DirichletAnalytic
+    BoundaryConditionInX: DirichletAnalytic
+    BoundaryConditionInY: DirichletAnalytic
+    BoundaryConditionInZ: DirichletAnalytic
 
 AnalyticSolution:
   SmoothFlow:

--- a/tests/InputFiles/ScalarWave/PlaneWave3D.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave3D.yaml
@@ -41,7 +41,9 @@ DomainCreator:
     InitialRefinement: [1, 1, 1]
     InitialGridPoints: [5, 5, 5]
     TimeDependence: None
-    BoundaryCondition: Periodic
+    BoundaryConditionInX: Periodic
+    BoundaryConditionInY: Periodic
+    BoundaryConditionInZ: Periodic
 
 SpatialDiscretization:
   BoundaryCorrection:

--- a/tests/Unit/ApparentHorizons/Test_ComputeExcisionBoundaryVolumeQuantities.cpp
+++ b/tests/Unit/ApparentHorizons/Test_ComputeExcisionBoundaryVolumeQuantities.cpp
@@ -59,7 +59,8 @@ void test_compute_excision_boundary_volume_quantities() {
         std::array<double, 3>{3.1, 3.2, 3.3},
         std::array<double, 3>{4.1, 4.2, 4.3}, std::array<size_t, 3>{0, 0, 0},
         std::array<size_t, 3>{number_of_grid_points, number_of_grid_points,
-                              number_of_grid_points});
+                              number_of_grid_points},
+        std::array<bool, 3>{false, false, false});
   }
   const auto domain = domain_creator->create_domain();
   ASSERT(domain.blocks().size() == 1, "Expected a Domain with one block");

--- a/tests/Unit/ApparentHorizons/Test_ComputeHorizonVolumeQuantities.cpp
+++ b/tests/Unit/ApparentHorizons/Test_ComputeHorizonVolumeQuantities.cpp
@@ -40,6 +40,7 @@ namespace {
 template <typename IsTimeDependent, typename TargetFrame, typename SrcTags,
           typename DestTags>
 void test_compute_horizon_volume_quantities() {
+  CAPTURE(IsTimeDependent::value);
   const size_t number_of_grid_points = 8;
 
   // slab and temporal_id used only in the TimeDependent version.
@@ -64,7 +65,8 @@ void test_compute_horizon_volume_quantities() {
         std::array<double, 3>{3.1, 3.2, 3.3},
         std::array<double, 3>{4.1, 4.2, 4.3}, std::array<size_t, 3>{0, 0, 0},
         std::array<size_t, 3>{number_of_grid_points, number_of_grid_points,
-                              number_of_grid_points});
+                              number_of_grid_points},
+        std::array<bool, 3>{false, false, false});
   }
   const auto domain = domain_creator->create_domain();
   ASSERT(domain.blocks().size() == 1, "Expected a Domain with one block");

--- a/tests/Unit/Domain/Creators/Test_Brick.cpp
+++ b/tests/Unit/Domain/Creators/Test_Brick.cpp
@@ -122,6 +122,8 @@ void test_brick() {
                                                  refinement_level[0],
                                                  grid_points[0],
                                                  create_boundary_condition(),
+                                                 create_boundary_condition(),
+                                                 create_boundary_condition(),
                                                  {}};
   test_brick_construction(brick_boundary_condition, lower_bound, upper_bound,
                           grid_points, refinement_level,
@@ -163,11 +165,12 @@ void test_brick() {
            {Direction<3>::lower_zeta()},
            {Direction<3>::upper_zeta()}}});
 
-  const creators::Brick periodic_z_brick{
-      lower_bound, upper_bound, refinement_level[0], grid_points[0],
-      std::array<bool, 3>{{false, false, true}}};
+  // Test periodic in z
   test_brick_construction(
-      periodic_z_brick, lower_bound, upper_bound, grid_points, refinement_level,
+      creators::Brick{lower_bound, upper_bound, refinement_level[0],
+                      grid_points[0],
+                      std::array<bool, 3>{{false, false, true}}},
+      lower_bound, upper_bound, grid_points, refinement_level,
       std::vector<DirectionMap<3, BlockNeighbor<3>>>{
           {{Direction<3>::lower_zeta(), {0, aligned_orientation}},
            {Direction<3>::upper_zeta(), {0, aligned_orientation}}}},
@@ -176,13 +179,65 @@ void test_brick() {
            {Direction<3>::upper_xi()},
            {Direction<3>::lower_eta()},
            {Direction<3>::upper_eta()}}});
-
-  const creators::Brick periodic_xy_brick{
-      lower_bound, upper_bound, refinement_level[0], grid_points[0],
-      std::array<bool, 3>{{true, true, false}}};
   test_brick_construction(
-      periodic_xy_brick, lower_bound, upper_bound, grid_points,
-      refinement_level,
+      creators::Brick{lower_bound, upper_bound, refinement_level[0],
+                      grid_points[0], create_boundary_condition(),
+                      create_boundary_condition(),
+                      TestHelpers::domain::BoundaryConditions::
+                          TestPeriodicBoundaryCondition<3>{}
+                              .get_clone()},
+      lower_bound, upper_bound, grid_points, refinement_level,
+      std::vector<DirectionMap<3, BlockNeighbor<3>>>{
+          {{Direction<3>::lower_zeta(), {0, aligned_orientation}},
+           {Direction<3>::upper_zeta(), {0, aligned_orientation}}}},
+      std::vector<std::unordered_set<Direction<3>>>{
+          {{Direction<3>::lower_xi()},
+           {Direction<3>::upper_xi()},
+           {Direction<3>::lower_eta()},
+           {Direction<3>::upper_eta()}}},
+      {}, {}, true);
+  // Periodic in x
+  test_brick_construction(
+      creators::Brick{lower_bound, upper_bound, refinement_level[0],
+                      grid_points[0],
+                      TestHelpers::domain::BoundaryConditions::
+                          TestPeriodicBoundaryCondition<3>{}
+                              .get_clone(),
+                      create_boundary_condition(), create_boundary_condition()},
+      lower_bound, upper_bound, grid_points, refinement_level,
+      std::vector<DirectionMap<3, BlockNeighbor<3>>>{
+          {{Direction<3>::lower_xi(), {0, aligned_orientation}},
+           {Direction<3>::upper_xi(), {0, aligned_orientation}}}},
+      std::vector<std::unordered_set<Direction<3>>>{
+          {{Direction<3>::lower_eta()},
+           {Direction<3>::upper_eta()},
+           {Direction<3>::lower_zeta()},
+           {Direction<3>::upper_zeta()}}},
+      {}, {}, true);
+  // Periodic in y
+  test_brick_construction(
+      creators::Brick{lower_bound, upper_bound, refinement_level[0],
+                      grid_points[0], create_boundary_condition(),
+                      TestHelpers::domain::BoundaryConditions::
+                          TestPeriodicBoundaryCondition<3>{}
+                              .get_clone(),
+                      create_boundary_condition()},
+      lower_bound, upper_bound, grid_points, refinement_level,
+      std::vector<DirectionMap<3, BlockNeighbor<3>>>{
+          {{Direction<3>::lower_eta(), {0, aligned_orientation}},
+           {Direction<3>::upper_eta(), {0, aligned_orientation}}}},
+      std::vector<std::unordered_set<Direction<3>>>{
+          {{Direction<3>::lower_xi()},
+           {Direction<3>::upper_xi()},
+           {Direction<3>::lower_zeta()},
+           {Direction<3>::upper_zeta()}}},
+      {}, {}, true);
+
+  // Test periodic in xy
+  test_brick_construction(
+      creators::Brick{lower_bound, upper_bound, refinement_level[0],
+                      grid_points[0], std::array<bool, 3>{{true, true, false}}},
+      lower_bound, upper_bound, grid_points, refinement_level,
       std::vector<DirectionMap<3, BlockNeighbor<3>>>{
           {{Direction<3>::lower_xi(), {0, aligned_orientation}},
            {Direction<3>::upper_xi(), {0, aligned_orientation}},
@@ -190,7 +245,27 @@ void test_brick() {
            {Direction<3>::upper_eta(), {0, aligned_orientation}}}},
       std::vector<std::unordered_set<Direction<3>>>{
           {{Direction<3>::lower_zeta()}, {Direction<3>::upper_zeta()}}});
+  test_brick_construction(
+      creators::Brick{lower_bound, upper_bound, refinement_level[0],
+                      grid_points[0],
+                      TestHelpers::domain::BoundaryConditions::
+                          TestPeriodicBoundaryCondition<3>{}
+                              .get_clone(),
+                      TestHelpers::domain::BoundaryConditions::
+                          TestPeriodicBoundaryCondition<3>{}
+                              .get_clone(),
+                      create_boundary_condition()},
+      lower_bound, upper_bound, grid_points, refinement_level,
+      std::vector<DirectionMap<3, BlockNeighbor<3>>>{
+          {{Direction<3>::lower_xi(), {0, aligned_orientation}},
+           {Direction<3>::upper_xi(), {0, aligned_orientation}},
+           {Direction<3>::lower_eta(), {0, aligned_orientation}},
+           {Direction<3>::upper_eta(), {0, aligned_orientation}}}},
+      std::vector<std::unordered_set<Direction<3>>>{
+          {{Direction<3>::lower_zeta()}, {Direction<3>::upper_zeta()}}},
+      {}, {}, true);
 
+  // Test periodic in yz
   const creators::Brick periodic_yz_brick{
       lower_bound, upper_bound, refinement_level[0], grid_points[0],
       std::array<bool, 3>{{false, true, true}}};
@@ -206,6 +281,24 @@ void test_brick() {
           {Direction<3>::lower_xi()},
           {Direction<3>::upper_xi()},
       }});
+  test_brick_construction(
+      creators::Brick{lower_bound, upper_bound, refinement_level[0],
+                      grid_points[0], create_boundary_condition(),
+                      TestHelpers::domain::BoundaryConditions::
+                          TestPeriodicBoundaryCondition<3>{}
+                              .get_clone(),
+                      TestHelpers::domain::BoundaryConditions::
+                          TestPeriodicBoundaryCondition<3>{}
+                              .get_clone()},
+      lower_bound, upper_bound, grid_points, refinement_level,
+      std::vector<DirectionMap<3, BlockNeighbor<3>>>{
+          {{Direction<3>::lower_eta(), {0, aligned_orientation}},
+           {Direction<3>::upper_eta(), {0, aligned_orientation}},
+           {Direction<3>::lower_zeta(), {0, aligned_orientation}},
+           {Direction<3>::upper_zeta(), {0, aligned_orientation}}}},
+      std::vector<std::unordered_set<Direction<3>>>{
+          {{Direction<3>::lower_xi()}, {Direction<3>::upper_xi()}}},
+      {}, {}, true);
 
   const creators::Brick periodic_xz_brick{
       lower_bound, upper_bound, refinement_level[0], grid_points[0],
@@ -220,6 +313,25 @@ void test_brick() {
            {Direction<3>::upper_zeta(), {0, aligned_orientation}}}},
       std::vector<std::unordered_set<Direction<3>>>{
           {{Direction<3>::lower_eta()}, {Direction<3>::upper_eta()}}});
+  test_brick_construction(
+      creators::Brick{lower_bound, upper_bound, refinement_level[0],
+                      grid_points[0],
+                      TestHelpers::domain::BoundaryConditions::
+                          TestPeriodicBoundaryCondition<3>{}
+                              .get_clone(),
+                      create_boundary_condition(),
+                      TestHelpers::domain::BoundaryConditions::
+                          TestPeriodicBoundaryCondition<3>{}
+                              .get_clone()},
+      lower_bound, upper_bound, grid_points, refinement_level,
+      std::vector<DirectionMap<3, BlockNeighbor<3>>>{
+          {{Direction<3>::lower_xi(), {0, aligned_orientation}},
+           {Direction<3>::upper_xi(), {0, aligned_orientation}},
+           {Direction<3>::lower_zeta(), {0, aligned_orientation}},
+           {Direction<3>::upper_zeta(), {0, aligned_orientation}}}},
+      std::vector<std::unordered_set<Direction<3>>>{
+          {{Direction<3>::lower_eta()}, {Direction<3>::upper_eta()}}},
+      {}, {}, true);
 
   const creators::Brick periodic_xyz_brick{
       lower_bound, upper_bound, refinement_level[0], grid_points[0],
@@ -237,7 +349,16 @@ void test_brick() {
       std::vector<std::unordered_set<Direction<3>>>{{}});
 
   const creators::Brick periodic_brick_boundary_conditions{
-      lower_bound, upper_bound, refinement_level[0], grid_points[0],
+      lower_bound,
+      upper_bound,
+      refinement_level[0],
+      grid_points[0],
+      TestHelpers::domain::BoundaryConditions::TestPeriodicBoundaryCondition<
+          3>{}
+          .get_clone(),
+      TestHelpers::domain::BoundaryConditions::TestPeriodicBoundaryCondition<
+          3>{}
+          .get_clone(),
       TestHelpers::domain::BoundaryConditions::TestPeriodicBoundaryCondition<
           3>{}
           .get_clone()};
@@ -272,6 +393,36 @@ void test_brick() {
                       grid_points[0],
                       std::make_unique<TestHelpers::domain::BoundaryConditions::
                                            TestNoneBoundaryCondition<3>>(),
+                      std::make_unique<TestHelpers::domain::BoundaryConditions::
+                                           TestPeriodicBoundaryCondition<3>>(),
+                      std::make_unique<TestHelpers::domain::BoundaryConditions::
+                                           TestPeriodicBoundaryCondition<3>>(),
+                      nullptr, Options::Context{false, {}, 1, 1}),
+      Catch::Matchers::Contains(
+          "None boundary condition is not supported. If you would like an "
+          "outflow-type boundary condition, you must use that."));
+  CHECK_THROWS_WITH(
+      creators::Brick(lower_bound, upper_bound, refinement_level[0],
+                      grid_points[0],
+                      std::make_unique<TestHelpers::domain::BoundaryConditions::
+                                           TestPeriodicBoundaryCondition<3>>(),
+                      std::make_unique<TestHelpers::domain::BoundaryConditions::
+                                           TestNoneBoundaryCondition<3>>(),
+                      std::make_unique<TestHelpers::domain::BoundaryConditions::
+                                           TestPeriodicBoundaryCondition<3>>(),
+                      nullptr, Options::Context{false, {}, 1, 1}),
+      Catch::Matchers::Contains(
+          "None boundary condition is not supported. If you would like an "
+          "outflow-type boundary condition, you must use that."));
+  CHECK_THROWS_WITH(
+      creators::Brick(lower_bound, upper_bound, refinement_level[0],
+                      grid_points[0],
+                      std::make_unique<TestHelpers::domain::BoundaryConditions::
+                                           TestPeriodicBoundaryCondition<3>>(),
+                      std::make_unique<TestHelpers::domain::BoundaryConditions::
+                                           TestPeriodicBoundaryCondition<3>>(),
+                      std::make_unique<TestHelpers::domain::BoundaryConditions::
+                                           TestNoneBoundaryCondition<3>>(),
                       nullptr, Options::Context{false, {}, 1, 1}),
       Catch::Matchers::Contains(
           "None boundary condition is not supported. If you would like an "
@@ -280,7 +431,15 @@ void test_brick() {
 
 void test_brick_factory() {
   const std::string boundary_conditions{
-      "  BoundaryCondition:\n"
+      "  BoundaryConditionInX:\n"
+      "    TestBoundaryCondition:\n"
+      "      Direction: upper-zeta\n"
+      "      BlockId: 2\n"
+      "  BoundaryConditionInY:\n"
+      "    TestBoundaryCondition:\n"
+      "      Direction: upper-zeta\n"
+      "      BlockId: 2\n"
+      "  BoundaryConditionInZ:\n"
       "    TestBoundaryCondition:\n"
       "      Direction: upper-zeta\n"
       "      BlockId: 2\n"};

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/SubdomainOperator/Test_SubdomainOperator.cpp
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/SubdomainOperator/Test_SubdomainOperator.cpp
@@ -719,6 +719,10 @@ SPECTRE_TEST_CASE("Unit.Elliptic.DG.SubdomainOperator", "[Unit][Elliptic]") {
           {{3, 3, 3}},
           make_boundary_condition<system>(
               elliptic::BoundaryConditionType::Dirichlet),
+          make_boundary_condition<system>(
+              elliptic::BoundaryConditionType::Dirichlet),
+          make_boundary_condition<system>(
+              elliptic::BoundaryConditionType::Dirichlet),
           nullptr};
       test_subdomain_operator<system>(domain_creator);
     }
@@ -895,6 +899,10 @@ SPECTRE_TEST_CASE("Unit.Elliptic.DG.SubdomainOperator", "[Unit][Elliptic]") {
         {{2., 1., 1.}},
         {{1, 1, 1}},
         {{3, 3, 3}},
+        make_boundary_condition<system>(
+            elliptic::BoundaryConditionType::Dirichlet),
+        make_boundary_condition<system>(
+            elliptic::BoundaryConditionType::Dirichlet),
         make_boundary_condition<system>(
             elliptic::BoundaryConditionType::Dirichlet),
         nullptr};

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_DgOperator.cpp
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_DgOperator.cpp
@@ -657,6 +657,12 @@ SPECTRE_TEST_CASE("Unit.Elliptic.DG.Operator", "[Unit][Elliptic]") {
           std::make_unique<
               elliptic::BoundaryConditions::AnalyticSolution<system>>(
               elliptic::BoundaryConditionType::Dirichlet),
+          std::make_unique<
+              elliptic::BoundaryConditions::AnalyticSolution<system>>(
+              elliptic::BoundaryConditionType::Dirichlet),
+          std::make_unique<
+              elliptic::BoundaryConditions::AnalyticSolution<system>>(
+              elliptic::BoundaryConditionType::Dirichlet),
           nullptr};
       const ElementId<3> self_id{0, {{{1, 0}, {1, 0}, {1, 0}}}};
       const ElementId<3> neighbor_id_xi{0, {{{1, 1}, {1, 0}, {1, 0}}}};
@@ -742,6 +748,12 @@ SPECTRE_TEST_CASE("Unit.Elliptic.DG.Operator", "[Unit][Elliptic]") {
           {{1.5, 1., 3.}},
           {{1, 1, 1}},
           {{12, 12, 12}},
+          std::make_unique<
+              elliptic::BoundaryConditions::AnalyticSolution<system>>(
+              elliptic::BoundaryConditionType::Dirichlet),
+          std::make_unique<
+              elliptic::BoundaryConditions::AnalyticSolution<system>>(
+              elliptic::BoundaryConditionType::Dirichlet),
           std::make_unique<
               elliptic::BoundaryConditions::AnalyticSolution<system>>(
               elliptic::BoundaryConditionType::Dirichlet),

--- a/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/Test_BoundaryConditionGhostData.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/Test_BoundaryConditionGhostData.cpp
@@ -93,6 +93,8 @@ void test(const BoundaryConditionType& boundary_condition) {
                                                     num_dg_pts};
   const auto brick = domain::creators::Brick(
       lower_bounds, upper_bounds, refinement_levels, number_of_grid_points,
+      std::make_unique<BoundaryConditionType>(boundary_condition),
+      std::make_unique<BoundaryConditionType>(boundary_condition),
       std::make_unique<BoundaryConditionType>(boundary_condition), nullptr);
   auto domain = brick.create_domain();
   auto boundary_conditions = brick.external_boundary_conditions();

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/Test_BoundaryConditionGhostData.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/Test_BoundaryConditionGhostData.cpp
@@ -81,6 +81,8 @@ void test(const BoundaryConditionType& boundary_condition) {
                                                     num_dg_pts};
   const auto brick = domain::creators::Brick(
       lower_bounds, upper_bounds, refinement_levels, number_of_grid_points,
+      std::make_unique<BoundaryConditionType>(boundary_condition),
+      std::make_unique<BoundaryConditionType>(boundary_condition),
       std::make_unique<BoundaryConditionType>(boundary_condition), nullptr);
   auto domain = brick.create_domain();
   auto boundary_conditions = brick.external_boundary_conditions();


### PR DESCRIPTION
This is useful for testing 1d GRMHD problems where y & z are periodic.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
Change input files from:
```
    BoundaryCondition: Periodic
```
to
```
    BoundaryConditionInX: Periodic
    BoundaryConditionInY: Periodic
    BoundaryConditionInZ: Periodic
```
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
