### PR TITLE
Allow read access to inboxes in DistributedObject

### DIFF
--- a/src/Parallel/DistributedObject.hpp
+++ b/src/Parallel/DistributedObject.hpp
@@ -248,6 +248,9 @@ class DistributedObject<ParallelComponent,
   /// Print the current contents of the DataBox
   std::string print_databox() const;
 
+  /// Get read access to all the inboxes
+  const auto& get_inboxes() const { return inboxes_; }
+
   void pup(PUP::er& p) override;  // NOLINT
 
   /*!


### PR DESCRIPTION
## Proposed changes

This has been helpful to access during my deadlock debugging extravaganza. I also don't see a reason not to allow this.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
