### PR TITLE
Template Shape control on measurement

### DIFF
--- a/tests/Unit/ControlSystem/ControlErrors/Test_Shape.cpp
+++ b/tests/Unit/ControlSystem/ControlErrors/Test_Shape.cpp
@@ -100,8 +100,7 @@ void test_shape_control_error() {
   initial_size_func[0][0] = ah_radius;
 
   // Setup control system stuff
-  const std::string shape_name =
-      Systems::Shape<::domain::ObjectLabel::A, deriv_order>::name();
+  const std::string shape_name = system::name();
   const std::string size_name =
       ControlErrors::detail::size_name<::domain::ObjectLabel::A>();
   const std::string excision_sphere_A_name =

--- a/tests/Unit/ControlSystem/Systems/Test_Shape.cpp
+++ b/tests/Unit/ControlSystem/Systems/Test_Shape.cpp
@@ -455,7 +455,8 @@ void test_suite(const gsl::not_null<Generator*> generator, const size_t l_max,
 }
 
 void test_names() {
-  using shape = control_system::Systems::Shape<::domain::ObjectLabel::A, 2>;
+  using shape = control_system::Systems::Shape<::domain::ObjectLabel::A, 2,
+                                               measurements::BothHorizons>;
 
   CHECK(pretty_type::name<shape>() == "ShapeA");
 

--- a/tests/Unit/Helpers/ControlSystem/SystemHelpers.hpp
+++ b/tests/Unit/Helpers/ControlSystem/SystemHelpers.hpp
@@ -289,14 +289,17 @@ struct MockMetavars {
 
   using element_component = MockElementComponent<metavars>;
 
-  using expansion_system = control_system::Systems::Expansion<
-      exp_deriv_order, control_system::measurements::BothHorizons>;
-  using rotation_system = control_system::Systems::Rotation<
-      rot_deriv_order, control_system::measurements::BothHorizons>;
-  using translation_system = control_system::Systems::Translation<
-      trans_deriv_order, control_system::measurements::BothHorizons>;
-  using shape_system = control_system::Systems::Shape<::domain::ObjectLabel::A,
-                                                      shape_deriv_order>;
+  using BothHorizons = control_system::measurements::BothHorizons;
+
+  using expansion_system =
+      control_system::Systems::Expansion<exp_deriv_order, BothHorizons>;
+  using rotation_system =
+      control_system::Systems::Rotation<rot_deriv_order, BothHorizons>;
+  using translation_system =
+      control_system::Systems::Translation<trans_deriv_order, BothHorizons>;
+  using shape_system =
+      control_system::Systems::Shape<::domain::ObjectLabel::A,
+                                     shape_deriv_order, BothHorizons>;
 
   using control_systems = tmpl::flatten<tmpl::list<
       tmpl::conditional_t<using_expansion, expansion_system, tmpl::list<>>,


### PR DESCRIPTION
For a single BH, we just want the SingleHorizon measurement. However, for BBH, shape control should use the same measurements as the other slow control systems (because shape is one of the slow control systems) which is the BothHorizons measurement.

## Proposed changes

Part of #4592.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
