### PR TITLE
Add function for determining new neighbors after h-refinement

### DIFF
--- a/src/Domain/Amr/CMakeLists.txt
+++ b/src/Domain/Amr/CMakeLists.txt
@@ -10,6 +10,7 @@ spectre_target_sources(
   PRIVATE
   Flag.cpp
   Helpers.cpp
+  NewNeighborIds.cpp
   UpdateAmrDecision.cpp
   )
 
@@ -20,6 +21,7 @@ spectre_target_headers(
   Amr.hpp
   Flag.hpp
   Helpers.hpp
+  NewNeighborIds.hpp
   UpdateAmrDecision.hpp
   )
 

--- a/src/Domain/Amr/NewNeighborIds.cpp
+++ b/src/Domain/Amr/NewNeighborIds.cpp
@@ -1,0 +1,192 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Domain/Amr/NewNeighborIds.hpp"
+
+#include <array>
+#include <cstddef>
+#include <unordered_map>
+#include <unordered_set>
+
+#include "DataStructures/Index.hpp"
+#include "DataStructures/IndexIterator.hpp"
+#include "Domain/Amr/Helpers.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Domain/Structure/Neighbors.hpp"
+#include "Domain/Structure/OrientationMap.hpp"
+#include "Domain/Structure/SegmentId.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/StdHelpers.hpp"
+
+namespace {
+bool overlapping_within_one_level(const SegmentId& segment1,
+                                  const SegmentId& segment2) {
+  if (0 == segment1.refinement_level()) {
+    return (2 > segment2.refinement_level());
+  }
+  if (0 == segment2.refinement_level()) {
+    return (2 > segment1.refinement_level());
+  }
+  return (segment1 == segment2 or segment1.id_of_parent() == segment2 or
+          segment1 == segment2.id_of_parent());
+}
+
+}  // namespace
+
+namespace amr {
+template <size_t VolumeDim>
+std::unordered_set<ElementId<VolumeDim>> new_neighbor_ids(
+    const ElementId<VolumeDim>& my_id, const Direction<VolumeDim>& direction,
+    const Neighbors<VolumeDim>& previous_neighbors_in_direction,
+    const std::unordered_map<ElementId<VolumeDim>,
+                             std::array<amr::Flag, VolumeDim>>&
+        previous_neighbors_amr_flags) {
+  std::unordered_set<ElementId<VolumeDim>> new_neighbors_in_direction;
+
+  const OrientationMap<VolumeDim>& orientation_map_from_me_to_neighbors =
+      previous_neighbors_in_direction.orientation();
+  const Direction<VolumeDim> direction_to_me_in_neighbor_frame =
+      orientation_map_from_me_to_neighbors(direction.opposite());
+
+  // Only one neighbor in 1D in a given direction
+  if constexpr (VolumeDim == 1) {
+    const ElementId<1>& previous_neighbor_id =
+        *(previous_neighbors_in_direction.ids().begin());
+    const amr::Flag neighbor_flag =
+        previous_neighbors_amr_flags.at(previous_neighbor_id)[0];
+    SegmentId previous_segment_id = previous_neighbor_id.segment_ids()[0];
+    SegmentId new_segment_id =
+        (amr::Flag::Join == neighbor_flag
+             ? previous_segment_id.id_of_parent()
+             : (amr::Flag::Split == neighbor_flag
+                    ? previous_segment_id.id_of_child(
+                          direction_to_me_in_neighbor_frame.side())
+                    : previous_segment_id));
+    new_neighbors_in_direction.emplace(
+        previous_neighbor_id.block_id(),
+        std::array<SegmentId, 1>({{new_segment_id}}));
+    return new_neighbors_in_direction;
+  }
+
+  const size_t dim_of_direction_to_me_in_neighbor_frame =
+      direction_to_me_in_neighbor_frame.dimension();
+  const std::array<SegmentId, VolumeDim> my_segment_ids_in_neighbor_frame =
+      orientation_map_from_me_to_neighbors(my_id.segment_ids());
+
+  for (const auto& previous_neighbor_id :
+       previous_neighbors_in_direction.ids()) {
+    // a neighbor_segment_id is valid if it touches me in the normal direction
+    // (which is in dim_of_direction_to_me_in_neighbor_frame) or overlaps with
+    // me in the transverse directions
+    std::array<std::vector<SegmentId>, VolumeDim> valid_neighbor_segment_ids;
+    // it is possible that a previous neighbor (or its children) will not be
+    // a neighbor of me (Note: the previous_neighbors may be those of my parent
+    // or children if I am the result of h-refinement)
+    bool there_is_no_neighbor = false;
+    const auto neighbor_segment_ids = previous_neighbor_id.segment_ids();
+    for (size_t d = 0; d < VolumeDim; ++d) {
+      const amr::Flag neighbor_flag =
+          previous_neighbors_amr_flags.at(previous_neighbor_id)[d];
+      const SegmentId neighbor_segment_id = gsl::at(neighbor_segment_ids, d);
+      if (dim_of_direction_to_me_in_neighbor_frame == d) {
+        // This is the normal direction.  I know my previous neighbor touched
+        // me so there is exactly one valid segment.
+        gsl::at(valid_neighbor_segment_ids, d)
+            .push_back(
+                amr::Flag::Join == neighbor_flag
+                    ? neighbor_segment_id.id_of_parent()
+                    : (amr::Flag::Split == neighbor_flag
+                           ? neighbor_segment_id.id_of_child(
+                                 direction_to_me_in_neighbor_frame.side())
+                           : neighbor_segment_id));
+      } else {
+        // This is a transverse direction.  Since we keep refinement levels
+        // within one, there can be 0 to 2 valid segments.
+        if (amr::Flag::Join == neighbor_flag) {
+          if (overlapping_within_one_level(
+                  neighbor_segment_id.id_of_parent(),
+                  gsl::at(my_segment_ids_in_neighbor_frame, d))) {
+            gsl::at(valid_neighbor_segment_ids, d)
+                .push_back(neighbor_segment_id.id_of_parent());
+          }
+        } else if (amr::Flag::Split == neighbor_flag) {
+          if (overlapping_within_one_level(
+                  neighbor_segment_id.id_of_child(Side::Lower),
+                  gsl::at(my_segment_ids_in_neighbor_frame, d))) {
+            gsl::at(valid_neighbor_segment_ids, d)
+                .push_back(neighbor_segment_id.id_of_child(Side::Lower));
+          }
+          if (overlapping_within_one_level(
+                  neighbor_segment_id.id_of_child(Side::Upper),
+                  gsl::at(my_segment_ids_in_neighbor_frame, d))) {
+            gsl::at(valid_neighbor_segment_ids, d)
+                .push_back(neighbor_segment_id.id_of_child(Side::Upper));
+          }
+        } else {
+          if (overlapping_within_one_level(
+                  neighbor_segment_id,
+                  gsl::at(my_segment_ids_in_neighbor_frame, d))) {
+            gsl::at(valid_neighbor_segment_ids, d)
+                .push_back(neighbor_segment_id);
+          }
+        }  // if-elseif-else on neighbor_flag
+
+        if (gsl::at(valid_neighbor_segment_ids, d).empty()) {
+          there_is_no_neighbor = true;
+        }
+      }  // if-else on normal vs transverse dimension
+
+      if (there_is_no_neighbor) {
+        // No need to loop over the remaining dimensions
+        break;
+      }
+    }  // loop over dimensions
+
+    if (there_is_no_neighbor) {
+      // This previous neighbor produced no new neighbors, continue with the
+      // next neighbor
+      continue;
+    }
+
+    for (const auto segment_id_xi : valid_neighbor_segment_ids[0]) {
+      if constexpr (VolumeDim > 1) {
+        for (const auto segment_id_eta : valid_neighbor_segment_ids[1]) {
+          if constexpr (VolumeDim == 2) {
+            new_neighbors_in_direction.emplace(
+                previous_neighbor_id.block_id(),
+                std::array{segment_id_xi, segment_id_eta},
+                previous_neighbor_id.grid_index());
+          } else if constexpr (VolumeDim == 3) {
+            for (const auto segment_id_zeta : valid_neighbor_segment_ids[2]) {
+              new_neighbors_in_direction.emplace(
+                  previous_neighbor_id.block_id(),
+                  std::array{segment_id_xi, segment_id_eta, segment_id_zeta},
+                  previous_neighbor_id.grid_index());
+            }
+          }
+        }
+      }
+    }
+  }  // loop over previous neighbors
+
+  return new_neighbors_in_direction;
+}
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data)                                          \
+  template std::unordered_set<ElementId<DIM(data)>> new_neighbor_ids( \
+      const ElementId<DIM(data)>& my_id,                              \
+      const Direction<DIM(data)>& direction,                          \
+      const Neighbors<DIM(data)>& previous_neighbors_in_direction,    \
+      const std::unordered_map<ElementId<DIM(data)>,                  \
+                               std::array<amr::Flag, DIM(data)>>&     \
+          previous_neighbors_amr_flags);
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
+
+#undef DIM
+#undef INSTANTIATE
+}  // namespace amr

--- a/src/Domain/Amr/NewNeighborIds.hpp
+++ b/src/Domain/Amr/NewNeighborIds.hpp
@@ -1,0 +1,41 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <unordered_map>
+#include <unordered_set>
+
+#include "Domain/Amr/Flag.hpp"
+
+/// \cond
+template <size_t VolumeDim>
+class Direction;
+template <size_t VolumeDim>
+class ElementId;
+template <size_t VolumeDim>
+class Neighbors;
+/// \endcond
+
+namespace amr {
+/// \ingroup AmrGroup
+/// \brief returns the ElementId%s of the neighbors in the given `direction` of
+/// the Element whose ElementId is `my_id` given the
+/// `previous_neighbors_in_direction` and their amr::Flag%s.
+///
+/// \note `previous_neighbors_in_direction` should be from the parent (or a
+/// child) of the Element with `my_id` if `my_id` corresponds to a newly created
+/// child (or parent) Element.
+///
+/// \note `previous_neighbors_amr_flags` may contain flags from neighbors in
+/// directions other than `direction`
+template <size_t VolumeDim>
+std::unordered_set<ElementId<VolumeDim>> new_neighbor_ids(
+    const ElementId<VolumeDim>& my_id, const Direction<VolumeDim>& direction,
+    const Neighbors<VolumeDim>& previous_neighbors_in_direction,
+    const std::unordered_map<ElementId<VolumeDim>,
+                             std::array<amr::Flag, VolumeDim>>&
+        previous_neighbors_amr_flags);
+}  // namespace amr

--- a/src/Utilities/Algorithm.hpp
+++ b/src/Utilities/Algorithm.hpp
@@ -371,6 +371,14 @@ decltype(auto) remove_if(Container& c, UnaryPredicate&& unary_predicate) {
                         std::forward<UnaryPredicate>(unary_predicate));
 }
 
+/// Convience wrapper around std::sample
+template <class Container, class OutputIt, class Distance, class URBG>
+decltype(auto) sample(Container& c, OutputIt out, Distance n, URBG&& g) {
+  using std::begin;
+  using std::end;
+  return std::sample(begin(c), end(c), out, n, g);
+}
+
 /// Convenience wrapper around std::sort
 template <class Container>
 decltype(auto) sort(Container& c) {

--- a/src/Utilities/CartesianProduct.hpp
+++ b/src/Utilities/CartesianProduct.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <array>
+#include <iterator>
 #include <tuple>
 #include <utility>
 #include <vector>
@@ -56,7 +57,7 @@ void cartesian_product(OutputIterator result,
 
 /*!
  * \ingroup UtilitiesGroup
- * \brief The Cartesian product of a sequence arrays
+ * \brief The Cartesian product of a sequence of arrays
  *
  * Returns a `std::array` with all possible combinations of the input arrays.
  * The last dimension varies fastest.
@@ -71,5 +72,22 @@ std::array<std::tuple<Ts...>, (... * Lens)> cartesian_product(
   std::array<std::tuple<Ts...>, (... * Lens)> result{};
   cartesian_product(result.begin(),
                     std::make_pair(dimensions.begin(), dimensions.end())...);
+  return result;
+}
+
+/*!
+ * \ingroup UtilitiesGroup
+ * \brief The Cartesian product of several containers
+ *
+ * Returns a `std::vector` with all possible combinations of the values of the
+ * input containers. The value of the last container varies fastest.
+ */
+template <typename... Containers>
+std::vector<std::tuple<typename Containers::value_type...>> cartesian_product(
+    const Containers&... containers) {
+  std::vector<std::tuple<typename Containers::value_type...>> result{};
+  cartesian_product(
+      std::back_inserter(result),
+      std::make_pair(std::begin(containers), std::end(containers))...);
   return result;
 }

--- a/tests/Unit/Domain/Amr/CMakeLists.txt
+++ b/tests/Unit/Domain/Amr/CMakeLists.txt
@@ -6,6 +6,7 @@ set(LIBRARY "Test_Amr")
 set(LIBRARY_SOURCES
   Test_Flag.cpp
   Test_Helpers.cpp
+  Test_NewNeighborIds.cpp
   Test_Tags.cpp
   Test_UpdateAmrDecision.cpp
   )
@@ -14,5 +15,15 @@ add_test_library(
   ${LIBRARY}
   "Domain/Amr"
   "${LIBRARY_SOURCES}"
-  "Amr;DomainStructure;Utilities"
+  ""
+  )
+
+target_link_libraries(
+  ${LIBRARY}
+  PRIVATE
+  Amr
+  DomainAmrHelpers
+  DomainStructure
+  DomainStructureHelpers
+  Utilities
   )

--- a/tests/Unit/Domain/Amr/Test_NewNeighborIds.cpp
+++ b/tests/Unit/Domain/Amr/Test_NewNeighborIds.cpp
@@ -1,0 +1,133 @@
+// // Distributed under the MIT License.
+// // See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "Domain/Amr/Flag.hpp"
+#include "Domain/Amr/NewNeighborIds.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Domain/Structure/Neighbors.hpp"
+#include "Domain/Structure/SegmentId.hpp"
+#include "Domain/Structure/Side.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/Domain/Amr/NeighborFlagHelpers.hpp"
+#include "Helpers/Domain/Structure/NeighborHelpers.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeString.hpp"
+#include "Utilities/StdHelpers.hpp"
+
+namespace {
+template <size_t Dim>
+std::vector<ElementId<Dim>> element_ids_to_test() {
+  static constexpr size_t max_level = 5 - Dim;
+  std::vector<ElementId<Dim>> result{};
+  for (size_t lx = 0; lx <= max_level; ++lx) {
+    for (size_t ix = 0; ix < two_to_the(lx); ++ix) {
+      if constexpr (Dim == 1) {
+        result.emplace_back(0, std::array{SegmentId{lx, ix}});
+      } else {
+        for (size_t ly = 0; ly <= max_level; ++ly) {
+          for (size_t iy = 0; iy < two_to_the(ly); ++iy) {
+            if constexpr (Dim == 2) {
+              result.emplace_back(
+                  0, std::array{SegmentId{lx, ix}, SegmentId{ly, iy}});
+            } else {
+              for (size_t lz = 0; lz <= max_level; ++lz) {
+                for (size_t iz = 0; iz < two_to_the(lz); ++iz) {
+                  result.emplace_back(
+                      0, std::array{SegmentId{lx, ix}, SegmentId{ly, iy},
+                                    SegmentId{lz, iz}});
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  return result;
+}
+
+template <size_t Dim>
+void test(const gsl::not_null<std::mt19937*> generator) {
+  for (const auto& element_id : element_ids_to_test<Dim>()) {
+    CAPTURE(element_id);
+    for (const auto& direction :
+         random_sample(2, Direction<Dim>::all_directions(), generator)) {
+      CAPTURE(direction);
+      const size_t dim = direction.dimension();
+      const Side side = direction.side();
+      const SegmentId& normal_segment = element_id.segment_id(dim);
+      const double endpoint = normal_segment.endpoint(side);
+      if (endpoint == 1.0 or endpoint == -1.0) {
+        for (const auto face_type :
+             std::array{TestHelpers::domain::FaceType::Periodic,
+                        TestHelpers::domain::FaceType::Block}) {
+          for (const auto& neighbors :
+               random_sample(5,
+                             TestHelpers::domain::valid_neighbors(
+                                 generator, element_id, direction, face_type),
+                             generator)) {
+            CAPTURE(neighbors);
+            for (const auto& neighbor_flags : random_sample(
+                     5,
+                     TestHelpers::amr::valid_neighbor_flags(
+                         element_id,
+                         make_array<Dim>(::amr::Flag::IncreaseResolution),
+                         neighbors),
+                     generator)) {
+              CAPTURE(neighbor_flags);
+              const auto new_neighbors =
+                  Neighbors<Dim>{new_neighbor_ids(element_id, direction,
+                                                  neighbors, neighbor_flags),
+                                 neighbors.orientation()};
+              CAPTURE(new_neighbors);
+              TestHelpers::domain::check_neighbors(new_neighbors, element_id,
+                                                   direction);
+            }
+          }
+        }
+      } else {
+        for (const auto& neighbors :
+             random_sample(5,
+                           TestHelpers::domain::valid_neighbors(
+                               generator, element_id, direction),
+                           generator)) {
+          CAPTURE(neighbors);
+          for (const auto& neighbor_flags : random_sample(
+                   5,
+                   TestHelpers::amr::valid_neighbor_flags(
+                       element_id,
+                       make_array<Dim>(::amr::Flag::IncreaseResolution),
+                       neighbors),
+                   generator)) {
+            CAPTURE(neighbor_flags);
+            const auto new_neighbors =
+                Neighbors<Dim>{new_neighbor_ids(element_id, direction,
+                                                neighbors, neighbor_flags),
+                               neighbors.orientation()};
+            CAPTURE(new_neighbors);
+            TestHelpers::domain::check_neighbors(new_neighbors, element_id,
+                                                 direction);
+          }
+        }
+      }
+    }
+  }
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Domain.Amr.NewNeighborIds", "[Domain][Unit]") {
+  MAKE_GENERATOR(generator);
+  test<1>(make_not_null(&generator));
+  test<2>(make_not_null(&generator));
+  test<3>(make_not_null(&generator));
+}

--- a/tests/Unit/Helpers/Domain/Amr/CMakeLists.txt
+++ b/tests/Unit/Helpers/Domain/Amr/CMakeLists.txt
@@ -1,0 +1,27 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBRARY "DomainAmrHelpers")
+
+add_spectre_library(${LIBRARY})
+
+spectre_target_sources(
+  ${LIBRARY}
+  PRIVATE
+  NeighborFlagHelpers.cpp
+  )
+
+spectre_target_headers(
+  ${LIBRARY}
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/tests/Unit
+  HEADERS
+  NeighborFlagHelpers.hpp
+  )
+
+target_link_libraries(
+  ${LIBRARY}
+  PUBLIC
+  Amr
+  DomainStructure
+  Utilities
+  )

--- a/tests/Unit/Helpers/Domain/Amr/NeighborFlagHelpers.cpp
+++ b/tests/Unit/Helpers/Domain/Amr/NeighborFlagHelpers.cpp
@@ -1,0 +1,198 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Helpers/Domain/Amr/NeighborFlagHelpers.hpp"
+
+#include <array>
+#include <vector>
+
+#include "Domain/Amr/Helpers.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Domain/Structure/Neighbors.hpp"
+#include "Domain/Structure/OrientationMap.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace {
+template <size_t Dim>
+std::vector<std::array<::amr::Flag, Dim>> amr_flags();
+
+template <>
+std::vector<std::array<::amr::Flag, 1>> amr_flags<1>() {
+  // use IncreaseResolution instead of DoNothing to catch any instances of
+  // hard-coding DoNothing when the function should be valid for any of
+  // DoNothing, DecreaseResolution, or IncreaseResolution
+  return std::vector{std::array{::amr::Flag::Join},
+                     std::array{::amr::Flag::IncreaseResolution},
+                     std::array{::amr::Flag::Split}};
+}
+
+template <>
+std::vector<std::array<::amr::Flag, 2>> amr_flags<2>() {
+  // use IncreaseResolution instead of DoNothing to catch any instances of
+  // hard-coding DoNothing when the function should be valid for any of
+  // DoNothing, DecreaseResolution, or IncreaseResolution
+  return std::vector{
+      std::array{::amr::Flag::Join, ::amr::Flag::Join},
+      std::array{::amr::Flag::Join, ::amr::Flag::IncreaseResolution},
+      std::array{::amr::Flag::IncreaseResolution, ::amr::Flag::Join},
+      std::array{::amr::Flag::IncreaseResolution,
+                 ::amr::Flag::IncreaseResolution},
+      std::array{::amr::Flag::IncreaseResolution, ::amr::Flag::Split},
+      std::array{::amr::Flag::Split, ::amr::Flag::IncreaseResolution},
+      std::array{::amr::Flag::Split, ::amr::Flag::Split}};
+}
+
+template <>
+std::vector<std::array<::amr::Flag, 3>> amr_flags<3>() {
+  // use IncreaseResolution instead of DoNothing to catch any instances of
+  // hard-coding DoNothing when the function should be valid for any of
+  // DoNothing, DecreaseResolution, or IncreaseResolution
+  return std::vector{
+      std::array{::amr::Flag::Join, ::amr::Flag::Join, ::amr::Flag::Join},
+      std::array{::amr::Flag::Join, ::amr::Flag::Join,
+                 ::amr::Flag::IncreaseResolution},
+      std::array{::amr::Flag::Join, ::amr::Flag::IncreaseResolution,
+                 ::amr::Flag::Join},
+      std::array{::amr::Flag::Join, ::amr::Flag::IncreaseResolution,
+                 ::amr::Flag::IncreaseResolution},
+      std::array{::amr::Flag::IncreaseResolution, ::amr::Flag::Join,
+                 ::amr::Flag::Join},
+      std::array{::amr::Flag::IncreaseResolution, ::amr::Flag::Join,
+                 ::amr::Flag::IncreaseResolution},
+      std::array{::amr::Flag::IncreaseResolution,
+                 ::amr::Flag::IncreaseResolution, ::amr::Flag::Join},
+      std::array{::amr::Flag::IncreaseResolution,
+                 ::amr::Flag::IncreaseResolution,
+                 ::amr::Flag::IncreaseResolution},
+      std::array{::amr::Flag::IncreaseResolution,
+                 ::amr::Flag::IncreaseResolution, ::amr::Flag::Split},
+      std::array{::amr::Flag::IncreaseResolution, ::amr::Flag::Split,
+                 ::amr::Flag::IncreaseResolution},
+      std::array{::amr::Flag::IncreaseResolution, ::amr::Flag::Split,
+                 ::amr::Flag::Split},
+      std::array{::amr::Flag::Split, ::amr::Flag::IncreaseResolution,
+                 ::amr::Flag::IncreaseResolution},
+      std::array{::amr::Flag::Split, ::amr::Flag::IncreaseResolution,
+                 ::amr::Flag::Split},
+      std::array{::amr::Flag::Split, ::amr::Flag::Split,
+                 ::amr::Flag::IncreaseResolution},
+      std::array{::amr::Flag::Split, ::amr::Flag::Split, ::amr::Flag::Split}};
+}
+
+template <size_t Dim>
+bool are_valid_neighbor_flags(
+    const ElementId<Dim>& element_id,
+    const std::array<::amr::Flag, Dim>& element_flags,
+    const ElementId<Dim>& neighbor_id,
+    const std::array<::amr::Flag, Dim>& neighbor_flags,
+    const OrientationMap<Dim>& orientation_of_neighbor = {}) {
+  if (element_id == neighbor_id) {
+    return element_flags == neighbor_flags;
+  }
+  for (size_t d = 0; d < Dim; ++d) {
+    if (neighbor_id.segment_id(d) == SegmentId{0, 0} and
+        gsl::at(neighbor_flags, d) == amr::Flag::Join) {
+      return false;
+    }
+  }
+  const auto element_desired_levels =
+      desired_refinement_levels(element_id, element_flags);
+  const auto neighbor_desired_levels = desired_refinement_levels_of_neighbor(
+      neighbor_id, neighbor_flags, orientation_of_neighbor);
+  for (size_t d = 0; d < Dim; ++d) {
+    if ((gsl::at(element_desired_levels, d) >
+         gsl::at(neighbor_desired_levels, d) + 1) or
+        (gsl::at(neighbor_desired_levels, d) >
+         gsl::at(element_desired_levels, d) + 1)) {
+      return false;
+    }
+    if (element_id.block_id() == neighbor_id.block_id()) {
+      const auto& element_segment = element_id.segment_id(d);
+      const auto& neighbor_segment = neighbor_id.segment_id(d);
+      if (element_segment.refinement_level() == 0 or
+          neighbor_segment.refinement_level() == 0) {
+        continue;
+      }
+      if (element_segment.endpoint(element_segment.side_of_sibling()) ==
+          neighbor_segment.endpoint(neighbor_segment.side_of_sibling())) {
+        if (gsl::at(element_flags, d) == ::amr::Flag::Join) {
+          if (element_desired_levels != neighbor_desired_levels) {
+            return false;
+          }
+        } else if (gsl::at(neighbor_flags, d) == ::amr::Flag::Join and
+                   element_segment.id_of_sibling() == neighbor_segment) {
+          return false;
+        }
+      }
+    }
+  }
+  return true;
+}
+}  // namespace
+
+namespace TestHelpers::amr {
+
+template <size_t Dim>
+valid_flags_t<Dim> valid_neighbor_flags(
+    const ElementId<Dim>& element_id,
+    const std::array<::amr::Flag, Dim>& element_flags,
+    const Neighbors<Dim>& neighbors) {
+  valid_flags_t<Dim> result{};
+  const auto& orientation_of_neighbors = neighbors.orientation();
+  const auto& first_neighbor_id = *(neighbors.begin());
+  for (const auto& neighbor_flags : amr_flags<Dim>()) {
+    if (are_valid_neighbor_flags(element_id, element_flags, first_neighbor_id,
+                                 neighbor_flags, orientation_of_neighbors)) {
+      result.emplace_back(
+          neighbor_flags_t<Dim>{{first_neighbor_id, neighbor_flags}});
+    }
+  }
+
+  for (auto it = std::next(neighbors.begin()); it != neighbors.end(); ++it) {
+    valid_flags_t<Dim> prev_result{};
+    std::swap(result, prev_result);
+    const auto& neighbor_id = *it;
+    for (const auto& neighbor_flags : amr_flags<Dim>()) {
+      if (not are_valid_neighbor_flags(element_id, element_flags, neighbor_id,
+                                       neighbor_flags,
+                                       orientation_of_neighbors)) {
+        // neighbor_flags conflicts with element
+        continue;
+      }
+      for (const auto& valid_flags : prev_result) {
+        bool can_add_flag = true;
+        for (const auto& [prev_neighbor_id, prev_neighbor_flags] :
+             valid_flags) {
+          if (not are_valid_neighbor_flags(prev_neighbor_id,
+                                           prev_neighbor_flags, neighbor_id,
+                                           neighbor_flags)) {
+            // neighbor_flags conflicts with previous neighbor
+            can_add_flag = false;
+            break;
+          }
+        }
+        if (can_add_flag) {
+          auto new_flags = valid_flags;
+          new_flags.emplace(neighbor_id, neighbor_flags);
+          result.emplace_back(std::move(new_flags));
+        }
+      }
+    }
+  }
+  return result;
+}
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data)                                   \
+  template valid_flags_t<DIM(data)> valid_neighbor_flags(      \
+      const ElementId<DIM(data)>& element_id,                  \
+      const std::array<::amr::Flag, DIM(data)>& element_flags, \
+      const Neighbors<DIM(data)>& neighbors);
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
+
+#undef DIM
+#undef INSTANTIATE
+}  // namespace TestHelpers::amr

--- a/tests/Unit/Helpers/Domain/Amr/NeighborFlagHelpers.hpp
+++ b/tests/Unit/Helpers/Domain/Amr/NeighborFlagHelpers.hpp
@@ -1,0 +1,35 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <unordered_map>
+#include <vector>
+
+#include "Domain/Amr/Flag.hpp"
+
+/// \cond
+template <size_t Dim>
+class ElementId;
+template <size_t Dim>
+class Neighbors;
+/// \endcond
+
+namespace TestHelpers::amr {
+template <size_t Dim>
+using neighbor_flags_t =
+    std::unordered_map<ElementId<Dim>, std::array<::amr::Flag, Dim>>;
+
+template <size_t Dim>
+using valid_flags_t = std::vector<neighbor_flags_t<Dim>>;
+
+/// Returns all permutations of valid flags for the `neighbors` (in a single
+/// direction) of an Element with `element_id` and `element_flags`
+template <size_t Dim>
+valid_flags_t<Dim> valid_neighbor_flags(
+    const ElementId<Dim>& element_id,
+    const std::array<::amr::Flag, Dim>& element_flags,
+    const Neighbors<Dim>& neighbors);
+}  // namespace TestHelpers::amr

--- a/tests/Unit/Helpers/Domain/CMakeLists.txt
+++ b/tests/Unit/Helpers/Domain/CMakeLists.txt
@@ -30,5 +30,6 @@ target_link_libraries(
   Utilities
   )
 
+add_subdirectory(Amr)
 add_subdirectory(BoundaryConditions)
 add_subdirectory(Structure)

--- a/tests/Unit/Helpers/Domain/CMakeLists.txt
+++ b/tests/Unit/Helpers/Domain/CMakeLists.txt
@@ -31,3 +31,4 @@ target_link_libraries(
   )
 
 add_subdirectory(BoundaryConditions)
+add_subdirectory(Structure)

--- a/tests/Unit/Helpers/Domain/Structure/CMakeLists.txt
+++ b/tests/Unit/Helpers/Domain/Structure/CMakeLists.txt
@@ -8,6 +8,7 @@ add_spectre_library(${LIBRARY} ${SPECTRE_TEST_LIBS_TYPE})
 spectre_target_sources(
   ${LIBRARY}
   PRIVATE
+  NeighborHelpers.cpp
   OrientationMapHelpers.cpp
   )
 
@@ -15,6 +16,7 @@ spectre_target_headers(
   ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/tests/Unit
   HEADERS
+  NeighborHelpers.hpp
   OrientationMapHelpers.hpp
   )
 

--- a/tests/Unit/Helpers/Domain/Structure/CMakeLists.txt
+++ b/tests/Unit/Helpers/Domain/Structure/CMakeLists.txt
@@ -1,0 +1,28 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBRARY "DomainStructureHelpers")
+
+add_spectre_library(${LIBRARY} ${SPECTRE_TEST_LIBS_TYPE})
+
+spectre_target_sources(
+  ${LIBRARY}
+  PRIVATE
+  OrientationMapHelpers.cpp
+  )
+
+spectre_target_headers(
+  ${LIBRARY}
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/tests/Unit
+  HEADERS
+  OrientationMapHelpers.hpp
+  )
+
+target_link_libraries(
+  ${LIBRARY}
+  PUBLIC
+  DomainStructure
+  Utilities
+  PRIVATE
+  Framework
+  )

--- a/tests/Unit/Helpers/Domain/Structure/NeighborHelpers.cpp
+++ b/tests/Unit/Helpers/Domain/Structure/NeighborHelpers.cpp
@@ -1,0 +1,586 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include "Helpers/Domain/Structure/NeighborHelpers.hpp"
+
+#include <array>
+#include <unordered_set>
+#include <vector>
+
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Domain/Structure/Neighbors.hpp"
+#include "Domain/Structure/OrientationMap.hpp"
+#include "Domain/Structure/SegmentId.hpp"
+#include "Domain/Structure/Side.hpp"
+#include "Helpers/Domain/Structure/OrientationMapHelpers.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace {
+template <size_t Dim>
+std::vector<std::unordered_set<ElementId<Dim>>> valid_aligned_neighbor_ids(
+    const ElementId<Dim>& element_id, size_t neighbor_block_id,
+    size_t normal_dim,
+    const std::vector<SegmentId>& valid_neighbor_normal_segments);
+
+template <>
+std::vector<std::unordered_set<ElementId<1>>> valid_aligned_neighbor_ids<1>(
+    const ElementId<1>& /*element_id*/, size_t neighbor_block_id,
+    size_t /*normal_dim*/,
+    const std::vector<SegmentId>& valid_neighbor_normal_segments) {
+  std::vector<std::unordered_set<ElementId<1>>> result{};
+  for (const auto& normal_segment : valid_neighbor_normal_segments) {
+    result.emplace_back(std::unordered_set{
+        ElementId<1>{neighbor_block_id, std::array{normal_segment}}});
+  }
+  return result;
+}
+
+std::array<SegmentId, 2> make_segment_ids(const SegmentId& normal_segment,
+                                          const SegmentId& transverse_segment,
+                                          const size_t normal_dim) {
+  return normal_dim == 0 ? std::array{normal_segment, transverse_segment}
+                         : std::array{transverse_segment, normal_segment};
+}
+
+template <>
+std::vector<std::unordered_set<ElementId<2>>> valid_aligned_neighbor_ids<2>(
+    const ElementId<2>& element_id, size_t neighbor_block_id,
+    const size_t normal_dim,
+    const std::vector<SegmentId>& valid_neighbor_normal_segments) {
+  const SegmentId transverse_segment =
+      element_id.segment_id(normal_dim == 0 ? 1 : 0);
+  std::vector<std::unordered_set<ElementId<2>>> result{};
+  for (const auto& normal_segment : valid_neighbor_normal_segments) {
+    result.emplace_back(std::unordered_set{ElementId<2>{
+        neighbor_block_id,
+        make_segment_ids(normal_segment, transverse_segment, normal_dim)}});
+    if (normal_segment == SegmentId{0, 0} and
+        neighbor_block_id == element_id.block_id()) {
+      // periodic so transverse extents must match
+      continue;
+    }
+    if (transverse_segment.refinement_level() > 0) {
+      result.emplace_back(std::unordered_set{ElementId<2>{
+          neighbor_block_id,
+          make_segment_ids(normal_segment, transverse_segment.id_of_parent(),
+                           normal_dim)}});
+    }
+    result.emplace_back(std::unordered_set{
+        ElementId<2>{
+            neighbor_block_id,
+            make_segment_ids(normal_segment,
+                             transverse_segment.id_of_child(Side::Lower),
+                             normal_dim)},
+        ElementId<2>{
+            neighbor_block_id,
+            make_segment_ids(normal_segment,
+                             transverse_segment.id_of_child(Side::Upper),
+                             normal_dim)}});
+    if (normal_segment != valid_neighbor_normal_segments.front()) {
+      result.emplace_back(std::unordered_set{
+          ElementId<2>{
+              neighbor_block_id,
+              make_segment_ids(normal_segment.id_of_parent(),
+                               transverse_segment.id_of_child(Side::Lower),
+                               normal_dim)},
+          ElementId<2>{
+              neighbor_block_id,
+              make_segment_ids(normal_segment,
+                               transverse_segment.id_of_child(Side::Upper),
+                               normal_dim)}});
+      result.emplace_back(std::unordered_set{
+          ElementId<2>{
+              neighbor_block_id,
+              make_segment_ids(normal_segment,
+                               transverse_segment.id_of_child(Side::Lower),
+                               normal_dim)},
+          ElementId<2>{
+              neighbor_block_id,
+              make_segment_ids(normal_segment.id_of_parent(),
+                               transverse_segment.id_of_child(Side::Upper),
+                               normal_dim)}});
+    }
+  }
+  return result;
+}
+
+std::array<SegmentId, 3> make_segment_ids(
+    const SegmentId& normal_segment, const SegmentId& first_transverse_segment,
+    const SegmentId& second_transverse_segment, const size_t normal_dim) {
+  return normal_dim == 0
+             ? std::array{normal_segment, first_transverse_segment,
+                          second_transverse_segment}
+             : (normal_dim == 1
+                    ? std::array{first_transverse_segment, normal_segment,
+                                 second_transverse_segment}
+                    : std::array{first_transverse_segment,
+                                 second_transverse_segment, normal_segment});
+}
+
+template <>
+std::vector<std::unordered_set<ElementId<3>>> valid_aligned_neighbor_ids<3>(
+    const ElementId<3>& element_id, size_t neighbor_block_id, size_t normal_dim,
+    const std::vector<SegmentId>& valid_neighbor_normal_segments) {
+  const SegmentId first_transverse_segment =
+      element_id.segment_id(normal_dim == 0 ? 1 : 0);
+  const SegmentId second_transverse_segment =
+      element_id.segment_id(normal_dim == 2 ? 1 : 2);
+  std::vector<std::unordered_set<ElementId<3>>> result{};
+  for (const auto& normal_segment : valid_neighbor_normal_segments) {
+    result.emplace_back(std::unordered_set{
+        ElementId<3>{neighbor_block_id,
+                     make_segment_ids(normal_segment, first_transverse_segment,
+                                      second_transverse_segment, normal_dim)}});
+    if (normal_segment == SegmentId{0, 0} and
+        neighbor_block_id == element_id.block_id()) {
+      // periodic so transverse extents must match
+      continue;
+    }
+    if (first_transverse_segment.refinement_level() > 0) {
+      result.emplace_back(std::unordered_set{ElementId<3>{
+          neighbor_block_id,
+          make_segment_ids(normal_segment,
+                           first_transverse_segment.id_of_parent(),
+                           second_transverse_segment, normal_dim)}});
+      if (second_transverse_segment.refinement_level() > 0) {
+        result.emplace_back(std::unordered_set{ElementId<3>{
+            neighbor_block_id,
+            make_segment_ids(
+                normal_segment, first_transverse_segment.id_of_parent(),
+                second_transverse_segment.id_of_parent(), normal_dim)}});
+      }
+    }
+    if (second_transverse_segment.refinement_level() > 0) {
+      result.emplace_back(std::unordered_set{ElementId<3>{
+          neighbor_block_id,
+          make_segment_ids(normal_segment, first_transverse_segment,
+                           second_transverse_segment.id_of_parent(),
+                           normal_dim)}});
+    }
+    result.emplace_back(std::unordered_set{
+        ElementId<3>{
+            neighbor_block_id,
+            make_segment_ids(normal_segment,
+                             first_transverse_segment.id_of_child(Side::Lower),
+                             second_transverse_segment, normal_dim)},
+        ElementId<3>{
+            neighbor_block_id,
+            make_segment_ids(normal_segment,
+                             first_transverse_segment.id_of_child(Side::Upper),
+                             second_transverse_segment, normal_dim)}});
+    if (second_transverse_segment.refinement_level() > 0) {
+      result.emplace_back(std::unordered_set{
+          ElementId<3>{
+              neighbor_block_id,
+              make_segment_ids(
+                  normal_segment,
+                  first_transverse_segment.id_of_child(Side::Lower),
+                  second_transverse_segment.id_of_parent(), normal_dim)},
+          ElementId<3>{neighbor_block_id,
+                       make_segment_ids(
+                           normal_segment,
+                           first_transverse_segment.id_of_child(Side::Upper),
+                           second_transverse_segment, normal_dim)}});
+      result.emplace_back(std::unordered_set{
+          ElementId<3>{neighbor_block_id,
+                       make_segment_ids(
+                           normal_segment,
+                           first_transverse_segment.id_of_child(Side::Lower),
+                           second_transverse_segment, normal_dim)},
+          ElementId<3>{
+              neighbor_block_id,
+              make_segment_ids(
+                  normal_segment,
+                  first_transverse_segment.id_of_child(Side::Upper),
+                  second_transverse_segment.id_of_parent(), normal_dim)}});
+      result.emplace_back(std::unordered_set{
+          ElementId<3>{
+              neighbor_block_id,
+              make_segment_ids(
+                  normal_segment,
+                  first_transverse_segment.id_of_child(Side::Lower),
+                  second_transverse_segment.id_of_parent(), normal_dim)},
+          ElementId<3>{
+              neighbor_block_id,
+              make_segment_ids(
+                  normal_segment,
+                  first_transverse_segment.id_of_child(Side::Upper),
+                  second_transverse_segment.id_of_parent(), normal_dim)}});
+    }
+    result.emplace_back(std::unordered_set{
+        ElementId<3>{
+            neighbor_block_id,
+            make_segment_ids(normal_segment, first_transverse_segment,
+                             second_transverse_segment.id_of_child(Side::Lower),
+                             normal_dim)},
+        ElementId<3>{
+            neighbor_block_id,
+            make_segment_ids(normal_segment, first_transverse_segment,
+                             second_transverse_segment.id_of_child(Side::Upper),
+                             normal_dim)}});
+    if (first_transverse_segment.refinement_level() > 0) {
+      result.emplace_back(std::unordered_set{
+          ElementId<3>{
+              neighbor_block_id,
+              make_segment_ids(
+                  normal_segment, first_transverse_segment.id_of_parent(),
+                  second_transverse_segment.id_of_child(Side::Lower),
+                  normal_dim)},
+          ElementId<3>{neighbor_block_id,
+                       make_segment_ids(
+                           normal_segment, first_transverse_segment,
+                           second_transverse_segment.id_of_child(Side::Upper),
+                           normal_dim)}});
+      result.emplace_back(std::unordered_set{
+          ElementId<3>{neighbor_block_id,
+                       make_segment_ids(
+                           normal_segment, first_transverse_segment,
+                           second_transverse_segment.id_of_child(Side::Lower),
+                           normal_dim)},
+          ElementId<3>{
+              neighbor_block_id,
+              make_segment_ids(
+                  normal_segment, first_transverse_segment.id_of_parent(),
+                  second_transverse_segment.id_of_child(Side::Upper),
+                  normal_dim)}});
+      result.emplace_back(std::unordered_set{
+          ElementId<3>{
+              neighbor_block_id,
+              make_segment_ids(
+                  normal_segment, first_transverse_segment.id_of_parent(),
+                  second_transverse_segment.id_of_child(Side::Lower),
+                  normal_dim)},
+          ElementId<3>{
+              neighbor_block_id,
+              make_segment_ids(
+                  normal_segment, first_transverse_segment.id_of_parent(),
+                  second_transverse_segment.id_of_child(Side::Upper),
+                  normal_dim)}});
+    }
+    result.emplace_back(std::unordered_set{
+        ElementId<3>{
+            neighbor_block_id,
+            make_segment_ids(normal_segment,
+                             first_transverse_segment.id_of_child(Side::Lower),
+                             second_transverse_segment.id_of_child(Side::Lower),
+                             normal_dim)},
+        ElementId<3>{
+            neighbor_block_id,
+            make_segment_ids(normal_segment,
+                             first_transverse_segment.id_of_child(Side::Upper),
+                             second_transverse_segment.id_of_child(Side::Lower),
+                             normal_dim)},
+        ElementId<3>{
+            neighbor_block_id,
+            make_segment_ids(normal_segment, first_transverse_segment,
+                             second_transverse_segment.id_of_child(Side::Upper),
+                             normal_dim)}});
+    result.emplace_back(std::unordered_set{
+        ElementId<3>{
+            neighbor_block_id,
+            make_segment_ids(normal_segment, first_transverse_segment,
+                             second_transverse_segment.id_of_child(Side::Lower),
+                             normal_dim)},
+        ElementId<3>{
+            neighbor_block_id,
+            make_segment_ids(normal_segment,
+                             first_transverse_segment.id_of_child(Side::Lower),
+                             second_transverse_segment.id_of_child(Side::Upper),
+                             normal_dim)},
+        ElementId<3>{
+            neighbor_block_id,
+            make_segment_ids(normal_segment,
+                             first_transverse_segment.id_of_child(Side::Upper),
+                             second_transverse_segment.id_of_child(Side::Upper),
+                             normal_dim)}});
+    result.emplace_back(std::unordered_set{
+        ElementId<3>{
+            neighbor_block_id,
+            make_segment_ids(normal_segment,
+                             first_transverse_segment.id_of_child(Side::Lower),
+                             second_transverse_segment.id_of_child(Side::Lower),
+                             normal_dim)},
+        ElementId<3>{
+            neighbor_block_id,
+            make_segment_ids(normal_segment,
+                             first_transverse_segment.id_of_child(Side::Upper),
+                             second_transverse_segment, normal_dim)},
+        ElementId<3>{
+            neighbor_block_id,
+            make_segment_ids(normal_segment,
+                             first_transverse_segment.id_of_child(Side::Lower),
+                             second_transverse_segment.id_of_child(Side::Upper),
+                             normal_dim)}});
+    result.emplace_back(std::unordered_set{
+        ElementId<3>{
+            neighbor_block_id,
+            make_segment_ids(normal_segment,
+                             first_transverse_segment.id_of_child(Side::Lower),
+                             second_transverse_segment, normal_dim)},
+        ElementId<3>{
+            neighbor_block_id,
+            make_segment_ids(normal_segment,
+                             first_transverse_segment.id_of_child(Side::Upper),
+                             second_transverse_segment.id_of_child(Side::Lower),
+                             normal_dim)},
+        ElementId<3>{
+            neighbor_block_id,
+            make_segment_ids(normal_segment,
+                             first_transverse_segment.id_of_child(Side::Upper),
+                             second_transverse_segment.id_of_child(Side::Upper),
+                             normal_dim)}});
+    result.emplace_back(std::unordered_set{
+        ElementId<3>{
+            neighbor_block_id,
+            make_segment_ids(normal_segment,
+                             first_transverse_segment.id_of_child(Side::Lower),
+                             second_transverse_segment.id_of_child(Side::Lower),
+                             normal_dim)},
+        ElementId<3>{
+            neighbor_block_id,
+            make_segment_ids(normal_segment,
+                             first_transverse_segment.id_of_child(Side::Upper),
+                             second_transverse_segment.id_of_child(Side::Lower),
+                             normal_dim)},
+        ElementId<3>{
+            neighbor_block_id,
+            make_segment_ids(normal_segment,
+                             first_transverse_segment.id_of_child(Side::Lower),
+                             second_transverse_segment.id_of_child(Side::Upper),
+                             normal_dim)},
+        ElementId<3>{
+            neighbor_block_id,
+            make_segment_ids(normal_segment,
+                             first_transverse_segment.id_of_child(Side::Upper),
+                             second_transverse_segment.id_of_child(Side::Upper),
+                             normal_dim)}});
+  }
+  return result;
+}
+
+template <size_t Dim>
+std::unordered_set<ElementId<Dim>> oriented_neighbor_ids(
+    const std::unordered_set<ElementId<Dim>>& aligned_neighbor_ids,
+    const OrientationMap<Dim>& orientation) {
+  std::unordered_set<ElementId<Dim>> result{};
+  for (const auto& neighbor_id : aligned_neighbor_ids) {
+    result.emplace(neighbor_id.block_id(),
+                   orientation(neighbor_id.segment_ids()));
+  }
+  return result;
+}
+
+template <size_t Dim>
+bool elements_overlap(const ElementId<Dim>& element_one,
+                      const ElementId<Dim>& element_two) {
+  for (size_t d = 0; d < Dim; ++d) {
+    if (not element_one.segment_id(d).overlaps(element_two.segment_id(d))) {
+      return false;
+    }
+  }
+  return true;
+}
+
+template <size_t Dim>
+bool are_neighbors_overlapping(const Neighbors<Dim>& neighbors) {
+  const auto& neighbor_ids = neighbors.ids();
+  for (auto it = std::next(neighbor_ids.begin()); it != neighbor_ids.end();
+       ++it) {
+    for (auto prev_it = neighbor_ids.begin(); prev_it != it; ++prev_it) {
+      if (elements_overlap(*prev_it, *it)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+}  // namespace
+
+namespace TestHelpers::domain {
+std::vector<SegmentId> valid_neighbor_segments(const FaceType face_type,
+                                               const Side side) {
+  if (face_type == FaceType::External) {
+    return std::vector<SegmentId>{};
+  }
+  if (face_type == FaceType::Periodic) {
+    return std::vector{SegmentId{0, 0}};
+  }
+  ASSERT(face_type != FaceType::Internal,
+         "Face type cannot be Internal for the root segment.");
+  if (side == Side::Lower) {
+    return std::vector{SegmentId{0, 0}, SegmentId{1, 1}};
+  }
+  return std::vector{SegmentId{0, 0}, SegmentId{1, 0}};
+}
+
+std::vector<SegmentId> valid_neighbor_segments(const SegmentId& segment_id) {
+  return std::vector{segment_id.id_of_sibling(),
+                     segment_id.id_of_abutting_nibling()};
+}
+
+std::vector<SegmentId> valid_neighbor_segments(const SegmentId& segment_id,
+                                               const FaceType face_type) {
+  if (face_type == FaceType::External) {
+    return std::vector<SegmentId>{};
+  }
+  const size_t level = segment_id.refinement_level();
+  ASSERT(level != 0,
+         "Cannot call this function on the root segment.  Use "
+         "valid_neighbor_segments(face_type, side) instead.");
+
+  const Side sibling_side = segment_id.side_of_sibling();
+  const SegmentId base_segment =
+      (face_type == FaceType::Block or face_type == FaceType::Periodic)
+          ? segment_id.id_if_flipped()
+          : SegmentId{level, sibling_side == Side::Upper
+                                 ? segment_id.index() - 1
+                                 : segment_id.index() + 1};
+
+  const bool neighbor_can_be_parent_of_base =
+      face_type == FaceType::Block or
+      not(segment_id.id_of_parent() == base_segment.id_of_parent());
+
+  if (not neighbor_can_be_parent_of_base) {
+    return std::vector{base_segment, base_segment.id_of_child(sibling_side)};
+  }
+
+  return std::vector{base_segment.id_of_parent(), base_segment,
+                     base_segment.id_of_child(sibling_side)};
+}
+
+template <size_t Dim>
+std::vector<Neighbors<Dim>> valid_neighbors(
+    const gsl::not_null<std::mt19937*> generator,
+    const ElementId<Dim>& element_id, const Direction<Dim>& direction,
+    const FaceType face_type) {
+  const size_t normal_dim = direction.dimension();
+  const Side side = direction.side();
+  const SegmentId& normal_segment = element_id.segment_id(normal_dim);
+  const double endpoint = normal_segment.endpoint(side);
+  const OrientationMap<Dim> aligned{};
+  const size_t block_id = element_id.block_id();
+  const size_t neighbor_block_id =
+      (face_type == FaceType::Block ? block_id + 1 : block_id);
+  std::vector<Neighbors<Dim>> result;
+  if (endpoint == 1.0 or endpoint == -1.0) {
+    ASSERT(face_type != FaceType::Internal,
+           "Element abuts the Block Boundary in the given direction, please "
+           "pass a valid FaceType");
+    if (face_type == FaceType::External) {
+      return std::vector<Neighbors<Dim>>{};
+    }
+    const auto valid_neighbor_normal_segments =
+        (normal_segment.refinement_level() == 0
+             ? valid_neighbor_segments(face_type, side)
+             : valid_neighbor_segments(normal_segment, face_type));
+    const auto valid_orientations =
+        (face_type == FaceType::Periodic
+             ? std::vector{aligned}
+             : random_orientation_maps<Dim>(2, generator));
+    for (const auto& aligned_neighbor_ids :
+         valid_aligned_neighbor_ids(element_id, neighbor_block_id, normal_dim,
+                                    valid_neighbor_normal_segments)) {
+      for (const auto& orientation : valid_orientations) {
+        if (orientation.is_aligned()) {
+          result.emplace_back(aligned_neighbor_ids, orientation);
+        } else {
+          result.emplace_back(
+              oriented_neighbor_ids(aligned_neighbor_ids, orientation),
+              orientation);
+        }
+      }
+    }
+    return result;
+  }
+  ASSERT(face_type == FaceType::Internal,
+         "Element is in the interior of a Block in the provided direction");
+  const auto valid_neighbor_normal_segments =
+      (side == normal_segment.side_of_sibling()
+           ? valid_neighbor_segments(normal_segment)
+           : valid_neighbor_segments(normal_segment, face_type));
+  for (const auto& neighbor_ids :
+       valid_aligned_neighbor_ids(element_id, neighbor_block_id, normal_dim,
+                                  valid_neighbor_normal_segments)) {
+    result.emplace_back(neighbor_ids, aligned);
+  }
+  return result;
+}
+
+template <size_t Dim>
+void check_neighbors(const Neighbors<Dim>& neighbors,
+                     const ElementId<Dim>& element_id,
+                     const Direction<Dim>& direction) {
+  CAPTURE(element_id);
+  CAPTURE(neighbors);
+  CAPTURE(direction);
+  if (neighbors.size() > 1) {
+    CHECK_FALSE(are_neighbors_overlapping(neighbors));
+  }
+  const size_t dim_normal_to_face = direction.dimension();
+  const Side neighbor_side = direction.side();
+  const Side element_side = opposite(neighbor_side);
+  const OrientationMap<Dim>& orientation_map = neighbors.orientation();
+  double surface_area_covered = 0.0;
+  for (const auto& neighbor : neighbors) {
+    double neighbor_overlap_area = 1.0;
+    const std::array<SegmentId, Dim> neighbor_segment_ids =
+        orientation_map.is_aligned()
+            ? neighbor.segment_ids()
+            : orientation_map.inverse_map()(neighbor.segment_ids());
+    for (size_t d = 0; d < Dim; ++d) {
+      const SegmentId& element_segment = element_id.segment_id(d);
+      const SegmentId& neighbor_segment = gsl::at(neighbor_segment_ids, d);
+      if (d == dim_normal_to_face) {
+        const double endpoint = element_segment.endpoint(neighbor_side);
+        if (endpoint == 1.0 or endpoint == -1.0) {
+          // point lies on a Block boundary, neighbor point should lie
+          // on opposite side of the Block
+          CHECK(-endpoint == neighbor_segment.endpoint(element_side));
+        } else {
+          // interior point, should be shared
+          CHECK(endpoint == neighbor_segment.endpoint(element_side));
+        }
+        if (element_id.block_id() == neighbor.block_id()) {
+          CHECK((element_id == neighbor or
+                 not element_segment.overlaps(neighbor_segment)));
+        }
+      } else {  // transverse to face
+        if (neighbors.size() == 1) {
+          CHECK((element_segment == neighbor_segment or
+                 element_segment.id_of_parent() == neighbor_segment));
+        } else {
+          if (neighbor_segment.refinement_level() > 0 and
+              element_segment == neighbor_segment.id_of_parent()) {
+            neighbor_overlap_area *= 0.5;
+          } else {
+            CHECK((element_segment == neighbor_segment or
+                   element_segment.id_of_parent() == neighbor_segment));
+          }
+        }
+      }
+    }
+    surface_area_covered += neighbor_overlap_area;
+  }
+  CHECK(surface_area_covered == 1.0);
+}
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data)                                            \
+  template std::vector<Neighbors<DIM(data)>> valid_neighbors(           \
+      const gsl::not_null<std::mt19937*> generator,                     \
+      const ElementId<DIM(data)>& element_id,                           \
+      const Direction<DIM(data)>& direction, const FaceType face_type); \
+  template void check_neighbors(const Neighbors<DIM(data)>& neighbors,  \
+                                const ElementId<DIM(data)>& element_id, \
+                                const Direction<DIM(data)>& direction);
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
+
+#undef DIM
+#undef INSTANTIATE
+}  // namespace TestHelpers::domain

--- a/tests/Unit/Helpers/Domain/Structure/NeighborHelpers.hpp
+++ b/tests/Unit/Helpers/Domain/Structure/NeighborHelpers.hpp
@@ -1,0 +1,90 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <vector>
+
+#include "Domain/Structure/Side.hpp"
+
+/// \cond
+template <size_t Dim>
+class Direction;
+template <size_t Dim>
+class ElementId;
+template <size_t Dim>
+class Neighbors;
+class SegmentId;
+namespace gsl {
+template <typename T>
+class not_null;
+}
+/// \endcond
+
+namespace TestHelpers::domain {
+
+/// The type of face of an Element
+enum class FaceType {
+  /// Used to denote an Element face on an external boundary
+  External,
+  /// Used to denote an Element face on a periodic boundary
+  Periodic,
+  /// Used to denote an Element face shared with a neighboring Block
+  Block,
+  /// Used to denote an Element face not on the boundary of a Block
+  Internal
+};
+
+/// Valid SegmentIds for a neighbor of the root segment on the given side
+///
+/// \details Returns an empty vector if `side` abuts an external boundary
+/// (indicated by passing External as the `face_type`). Returns the root segment
+/// if `face_type` is Periodic.
+///
+/// \note If the neighbor segment is in another Block (indicated by passing
+/// Block as `face_type`), the returned SegmentId%s are in the logical frame of
+/// `segment_id` (i.e. they will need to be mapped to the neighbor logical frame
+/// by using the appropriate OrientationMap of the Block owning the ElementId
+/// with `segment_id`).
+std::vector<SegmentId> valid_neighbor_segments(const FaceType face_type,
+                                               const Side side);
+
+/// Valid SegmentIds for a neighbor on the sibling side of a segment
+std::vector<SegmentId> valid_neighbor_segments(const SegmentId& segment_id);
+
+/// Valid SegmentIds for a neighbor on the non-sibling side of a segment
+///
+/// \details Returns an empty vector if the non-sibling side abuts an external
+/// boundary (indicated by passing External as `face_type`).
+///
+/// \note If the non-sibling side abuts another Block (indicated by passing
+/// Block as `face_type`), the returned SegmentId%s are in the logical frame of
+/// `segment_id` (i.e. they will need to be mapped to the neighbor logical frame
+/// by using the appropriate OrientationMap of the Block owning the ElementId
+/// with `segment_id`).
+std::vector<SegmentId> valid_neighbor_segments(const SegmentId& segment_id,
+                                               const FaceType face_type);
+
+/// Valid Neighbors for an Element with `element_id` in the given `direction`
+/// with the given `face_type`
+///
+/// \details FaceType needs to be passed in only if the Element abuts a Block
+/// boundary in the given `direction`
+template <size_t Dim>
+std::vector<Neighbors<Dim>> valid_neighbors(
+    gsl::not_null<std::mt19937*> generator, const ElementId<Dim>& element_id,
+    const Direction<Dim>& direction,
+    const FaceType face_type = FaceType::Internal);
+
+/// Checks that the `neighbors` for the Element with `element_id` in the given
+/// `direction` are a complete set of valid face neighbors
+///
+/// \details A valid neighbor is within one refinement level in the dimensions
+/// parallel to the face between the Element  and the neighbor.  The set is
+/// complete if there are neighboring Element%s they completely cover the face.
+template <size_t Dim>
+void check_neighbors(const Neighbors<Dim>& neighbors,
+                     const ElementId<Dim>& element_id,
+                     const Direction<Dim>& direction);
+}  // namespace TestHelpers::domain

--- a/tests/Unit/Helpers/Domain/Structure/OrientationMapHelpers.cpp
+++ b/tests/Unit/Helpers/Domain/Structure/OrientationMapHelpers.cpp
@@ -1,0 +1,124 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Helpers/Domain/Structure/OrientationMapHelpers.hpp"
+
+#include <cstddef>
+#include <vector>
+
+#include "Domain/Structure/OrientationMap.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Utilities/Algorithm.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace TestHelpers::domain {
+template <>
+std::vector<OrientationMap<1>> valid_orientation_maps<1>() {
+  return std::vector{OrientationMap<1>{},
+                     OrientationMap<1>{std::array{Direction<1>::lower_xi()}}};
+}
+
+template <>
+std::vector<OrientationMap<2>> valid_orientation_maps<2>() {
+  return std::vector{OrientationMap<2>{},
+                     OrientationMap<2>{std::array{Direction<2>::upper_eta(),
+                                                  Direction<2>::lower_xi()}},
+                     OrientationMap<2>{std::array{Direction<2>::lower_xi(),
+                                                  Direction<2>::lower_eta()}},
+                     OrientationMap<2>{std::array{Direction<2>::lower_eta(),
+                                                  Direction<2>::upper_xi()}}};
+}
+
+template <>
+std::vector<OrientationMap<3>> valid_orientation_maps<3>() {
+  return std::vector{OrientationMap<3>{},
+                     OrientationMap<3>{std::array{Direction<3>::lower_xi(),
+                                                  Direction<3>::lower_eta(),
+                                                  Direction<3>::upper_zeta()}},
+                     OrientationMap<3>{std::array{Direction<3>::lower_xi(),
+                                                  Direction<3>::upper_eta(),
+                                                  Direction<3>::lower_zeta()}},
+                     OrientationMap<3>{std::array{Direction<3>::upper_xi(),
+                                                  Direction<3>::lower_eta(),
+                                                  Direction<3>::lower_zeta()}},
+                     OrientationMap<3>{std::array{Direction<3>::upper_eta(),
+                                                  Direction<3>::upper_zeta(),
+                                                  Direction<3>::upper_xi()}},
+                     OrientationMap<3>{std::array{Direction<3>::lower_eta(),
+                                                  Direction<3>::lower_zeta(),
+                                                  Direction<3>::upper_xi()}},
+                     OrientationMap<3>{std::array{Direction<3>::lower_eta(),
+                                                  Direction<3>::upper_zeta(),
+                                                  Direction<3>::lower_xi()}},
+                     OrientationMap<3>{std::array{Direction<3>::upper_eta(),
+                                                  Direction<3>::lower_zeta(),
+                                                  Direction<3>::lower_xi()}},
+                     OrientationMap<3>{std::array{Direction<3>::upper_zeta(),
+                                                  Direction<3>::upper_xi(),
+                                                  Direction<3>::upper_eta()}},
+                     OrientationMap<3>{std::array{Direction<3>::lower_zeta(),
+                                                  Direction<3>::lower_xi(),
+                                                  Direction<3>::upper_eta()}},
+                     OrientationMap<3>{std::array{Direction<3>::lower_zeta(),
+                                                  Direction<3>::upper_xi(),
+                                                  Direction<3>::lower_eta()}},
+                     OrientationMap<3>{std::array{Direction<3>::upper_zeta(),
+                                                  Direction<3>::lower_xi(),
+                                                  Direction<3>::lower_eta()}},
+                     OrientationMap<3>{std::array{Direction<3>::upper_eta(),
+                                                  Direction<3>::lower_xi(),
+                                                  Direction<3>::upper_zeta()}},
+                     OrientationMap<3>{std::array{Direction<3>::lower_eta(),
+                                                  Direction<3>::upper_xi(),
+                                                  Direction<3>::upper_zeta()}},
+                     OrientationMap<3>{std::array{Direction<3>::lower_eta(),
+                                                  Direction<3>::lower_xi(),
+                                                  Direction<3>::lower_zeta()}},
+                     OrientationMap<3>{std::array{Direction<3>::upper_eta(),
+                                                  Direction<3>::upper_xi(),
+                                                  Direction<3>::lower_zeta()}},
+                     OrientationMap<3>{std::array{Direction<3>::lower_xi(),
+                                                  Direction<3>::upper_zeta(),
+                                                  Direction<3>::upper_eta()}},
+                     OrientationMap<3>{std::array{Direction<3>::upper_xi(),
+                                                  Direction<3>::lower_zeta(),
+                                                  Direction<3>::upper_eta()}},
+                     OrientationMap<3>{std::array{Direction<3>::upper_xi(),
+                                                  Direction<3>::upper_zeta(),
+                                                  Direction<3>::lower_eta()}},
+                     OrientationMap<3>{std::array{Direction<3>::lower_xi(),
+                                                  Direction<3>::lower_zeta(),
+                                                  Direction<3>::lower_eta()}},
+                     OrientationMap<3>{std::array{Direction<3>::upper_zeta(),
+                                                  Direction<3>::upper_eta(),
+                                                  Direction<3>::lower_xi()}},
+                     OrientationMap<3>{std::array{Direction<3>::lower_zeta(),
+                                                  Direction<3>::lower_eta(),
+                                                  Direction<3>::lower_xi()}},
+                     OrientationMap<3>{std::array{Direction<3>::lower_zeta(),
+                                                  Direction<3>::upper_eta(),
+                                                  Direction<3>::upper_xi()}},
+                     OrientationMap<3>{std::array{Direction<3>::upper_zeta(),
+                                                  Direction<3>::lower_eta(),
+                                                  Direction<3>::upper_xi()}}};
+}
+
+template <size_t Dim>
+std::vector<OrientationMap<Dim>> random_orientation_maps(
+    const size_t number_of_samples, gsl::not_null<std::mt19937*> generator) {
+  return random_sample(number_of_samples, valid_orientation_maps<Dim>(),
+                       generator);
+}
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data)                                               \
+  template std::vector<OrientationMap<DIM(data)>> random_orientation_maps( \
+      const size_t number_of_samples, gsl::not_null<std::mt19937*> generator);
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
+
+#undef DIM
+#undef INSTANTIATE
+}  // namespace TestHelpers::domain

--- a/tests/Unit/Helpers/Domain/Structure/OrientationMapHelpers.hpp
+++ b/tests/Unit/Helpers/Domain/Structure/OrientationMapHelpers.hpp
@@ -1,0 +1,36 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <random>
+#include <vector>
+
+/// \cond
+template <size_t Dim>
+class OrientationMap;
+namespace gsl {
+template <typename T>
+class not_null;
+}
+/// \endcond
+
+namespace TestHelpers::domain {
+/// \brief List of all valid OrientationMap%s in a given dimension
+///
+/// \details In more than one dimension, an OrientationMap is considered to be
+/// valid if it has a positive determinant for its discrete_rotation_jacobian.
+/// This restriction is relaxed in one dimension so that a non-aligned
+/// OrientationMap can be tested in 1D.
+template <size_t Dim>
+std::vector<OrientationMap<Dim>> valid_orientation_maps();
+
+/// Return a random sample of unique OrientationMap%s
+///
+/// \note If the requested number_of_samples is larger than the number of
+/// possible OrientationMap%s, this will return all possible OrientationMap%s
+template <size_t Dim>
+std::vector<OrientationMap<Dim>> random_orientation_maps(
+    size_t number_of_samples, gsl::not_null<std::mt19937*> generator);
+}  // namespace TestHelpers::domain

--- a/tests/Unit/Helpers/Tests/CMakeLists.txt
+++ b/tests/Unit/Helpers/Tests/CMakeLists.txt
@@ -24,5 +24,6 @@ target_link_libraries(
   GeneralRelativityHelpers
   )
 
+add_subdirectory(Domain)
 add_subdirectory(IO)
 add_subdirectory(PointwiseFunctions)

--- a/tests/Unit/Helpers/Tests/Domain/Amr/CMakeLists.txt
+++ b/tests/Unit/Helpers/Tests/Domain/Amr/CMakeLists.txt
@@ -1,0 +1,25 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBRARY "Test_DomainAmrHelpers")
+
+set(LIBRARY_SOURCES
+  Test_NeighborFlagHelpers.cpp
+  )
+
+add_test_library(
+  ${LIBRARY}
+  "Helpers/Tests/Domain/Amr/"
+  "${LIBRARY_SOURCES}"
+  ""
+  )
+
+target_link_libraries(
+  ${LIBRARY}
+  PRIVATE
+  Amr
+  DomainAmrHelpers
+  DomainStructure
+  DomainStructureHelpers
+  Utilities
+  )

--- a/tests/Unit/Helpers/Tests/Domain/Amr/Test_NeighborFlagHelpers.cpp
+++ b/tests/Unit/Helpers/Tests/Domain/Amr/Test_NeighborFlagHelpers.cpp
@@ -1,0 +1,155 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+
+#include "Domain/Amr/Flag.hpp"
+#include "Domain/Amr/Helpers.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Domain/Structure/Neighbors.hpp"
+#include "Domain/Structure/OrientationMap.hpp"
+#include "Domain/Structure/SegmentId.hpp"
+#include "Helpers/Domain/Amr/NeighborFlagHelpers.hpp"
+#include "Helpers/Domain/Structure/NeighborHelpers.hpp"
+#include "Utilities/StdHelpers.hpp"
+
+namespace TestHelpers::amr {
+namespace {
+void test_valid_neighbor_flags_1d() {
+  const ElementId<1> root{0};
+  const ElementId<1> neighbor_root{2};
+  const ElementId<1> lower_child{0, std::array{SegmentId{1, 0}}};
+  const ElementId<1> upper_child{0, std::array{SegmentId{1, 1}}};
+  const ElementId<1> neighbor_child{2, std::array{SegmentId{1, 0}}};
+  const ElementId<1> abutting_nibling{0, std::array{SegmentId{2, 2}}};
+  const auto split = std::array{::amr::Flag::Split};
+  const auto join = std::array{::amr::Flag::Join};
+  const auto stay = std::array{::amr::Flag::IncreaseResolution};
+  const auto all_allowed = [&join, &stay,
+                            &split](const ElementId<1>& neighbor_id) {
+    return std::vector{neighbor_flags_t<1>{{neighbor_id, join}},
+                       neighbor_flags_t<1>{{neighbor_id, stay}},
+                       neighbor_flags_t<1>{{neighbor_id, split}}};
+  };
+  const auto join_not_allowed = [&stay,
+                                 &split](const ElementId<1>& neighbor_id) {
+    return std::vector{neighbor_flags_t<1>{{neighbor_id, stay}},
+                       neighbor_flags_t<1>{{neighbor_id, split}}};
+  };
+  const auto split_not_allowed = [&join,
+                                  &stay](const ElementId<1>& neighbor_id) {
+    return std::vector{neighbor_flags_t<1>{{neighbor_id, join}},
+                       neighbor_flags_t<1>{{neighbor_id, stay}}};
+  };
+  const OrientationMap<1> aligned{};
+  CHECK(valid_neighbor_flags(
+            root, stay,
+            Neighbors<1>{std::unordered_set{neighbor_root}, aligned}) ==
+        join_not_allowed(neighbor_root));
+  CHECK(valid_neighbor_flags(
+            upper_child, stay,
+            Neighbors<1>{std::unordered_set{neighbor_root}, aligned}) ==
+        join_not_allowed(neighbor_root));
+  CHECK(valid_neighbor_flags(
+            lower_child, stay,
+            Neighbors<1>{std::unordered_set{upper_child}, aligned}) ==
+        join_not_allowed(upper_child));
+  CHECK(valid_neighbor_flags(
+            lower_child, stay,
+            Neighbors<1>{std::unordered_set{abutting_nibling}, aligned}) ==
+        split_not_allowed(abutting_nibling));
+  CHECK(valid_neighbor_flags(
+            root, stay,
+            Neighbors<1>{std::unordered_set{neighbor_child}, aligned}) ==
+        split_not_allowed(neighbor_child));
+  CHECK(valid_neighbor_flags(
+            upper_child, stay,
+            Neighbors<1>{std::unordered_set{neighbor_child}, aligned}) ==
+        all_allowed(neighbor_child));
+  CHECK(valid_neighbor_flags(
+            abutting_nibling, stay,
+            Neighbors<1>{std::unordered_set{lower_child}, aligned}) ==
+        join_not_allowed(lower_child));
+}
+
+void test_valid_neighbor_flags_2d() {
+  ElementId<2> element_id{0, std::array{SegmentId{2, 3}, SegmentId{3, 4}}};
+  const auto join_join = std::array{::amr::Flag::Join, ::amr::Flag::Join};
+  const auto join_stay =
+      std::array{::amr::Flag::Join, ::amr::Flag::IncreaseResolution};
+  const auto stay_join =
+      std::array{::amr::Flag::IncreaseResolution, ::amr::Flag::Join};
+  const auto stay_stay = std::array{::amr::Flag::IncreaseResolution,
+                                    ::amr::Flag::IncreaseResolution};
+  const auto stay_split =
+      std::array{::amr::Flag::IncreaseResolution, ::amr::Flag::Split};
+  const auto split_stay =
+      std::array{::amr::Flag::Split, ::amr::Flag::IncreaseResolution};
+  const auto split_split = std::array{::amr::Flag::Split, ::amr::Flag::Split};
+  const OrientationMap<2> aligned{};
+  ElementId<2> neighbor_0{1, std::array{SegmentId{2, 0}, SegmentId{3, 4}}};
+  const Neighbors<2> neighbors_0{std::unordered_set{neighbor_0}, aligned};
+  ::TestHelpers::domain::check_neighbors(neighbors_0, element_id,
+                                         Direction<2>::upper_xi());
+  CHECK(valid_neighbor_flags(element_id, stay_stay, neighbors_0) ==
+        std::vector{neighbor_flags_t<2>{{neighbor_0, join_join}},
+                    neighbor_flags_t<2>{{neighbor_0, join_stay}},
+                    neighbor_flags_t<2>{{neighbor_0, stay_join}},
+                    neighbor_flags_t<2>{{neighbor_0, stay_stay}},
+                    neighbor_flags_t<2>{{neighbor_0, stay_split}},
+                    neighbor_flags_t<2>{{neighbor_0, split_stay}},
+                    neighbor_flags_t<2>{{neighbor_0, split_split}}});
+  ElementId<2> neighbor_1{1, std::array{SegmentId{2, 0}, SegmentId{4, 8}}};
+  ElementId<2> neighbor_2{1, std::array{SegmentId{2, 0}, SegmentId{4, 9}}};
+  const Neighbors<2> neighbors_1_2{std::unordered_set{neighbor_1, neighbor_2},
+                                   aligned};
+  ::TestHelpers::domain::check_neighbors(neighbors_1_2, element_id,
+                                         Direction<2>::upper_xi());
+  CHECK(
+      valid_neighbor_flags(element_id, stay_stay, neighbors_1_2) ==
+      std::vector{
+          neighbor_flags_t<2>{{neighbor_1, join_join}, {neighbor_2, join_join}},
+          neighbor_flags_t<2>{{neighbor_1, join_stay}, {neighbor_2, join_stay}},
+          neighbor_flags_t<2>{{neighbor_1, join_stay}, {neighbor_2, stay_stay}},
+          neighbor_flags_t<2>{{neighbor_1, stay_join}, {neighbor_2, stay_join}},
+          neighbor_flags_t<2>{{neighbor_1, stay_stay}, {neighbor_2, stay_stay}},
+          neighbor_flags_t<2>{{neighbor_1, stay_stay},
+                              {neighbor_2, split_stay}},
+          neighbor_flags_t<2>{{neighbor_1, split_stay},
+                              {neighbor_2, stay_stay}},
+          neighbor_flags_t<2>{{neighbor_1, split_stay},
+                              {neighbor_2, split_stay}}});
+  ElementId<2> neighbor_3{1, std::array{SegmentId{2, 0}, SegmentId{2, 2}}};
+  const Neighbors<2> neighbors_3{std::unordered_set{neighbor_3}, aligned};
+  ::TestHelpers::domain::check_neighbors(neighbors_3, element_id,
+                                         Direction<2>::upper_xi());
+  CHECK(valid_neighbor_flags(element_id, stay_stay, neighbors_3) ==
+        std::vector{neighbor_flags_t<2>{{neighbor_3, join_stay}},
+                    neighbor_flags_t<2>{{neighbor_3, stay_stay}},
+                    neighbor_flags_t<2>{{neighbor_3, stay_split}},
+                    neighbor_flags_t<2>{{neighbor_3, split_stay}},
+                    neighbor_flags_t<2>{{neighbor_3, split_split}}});
+  ElementId<2> neighbor_4{1, std::array{SegmentId{2, 2}, SegmentId{2, 3}}};
+  const OrientationMap<2> rotated{
+      std::array{Direction<2>::lower_eta(), Direction<2>::upper_xi()}};
+  const Neighbors<2> neighbors_4{std::unordered_set{neighbor_4}, rotated};
+  ::TestHelpers::domain::check_neighbors(neighbors_4, element_id,
+                                         Direction<2>::upper_xi());
+  CHECK(valid_neighbor_flags(element_id, stay_stay, neighbors_4) ==
+        std::vector{neighbor_flags_t<2>{{neighbor_4, stay_join}},
+                    neighbor_flags_t<2>{{neighbor_4, stay_stay}},
+                    neighbor_flags_t<2>{{neighbor_4, stay_split}},
+                    neighbor_flags_t<2>{{neighbor_4, split_stay}},
+                    neighbor_flags_t<2>{{neighbor_4, split_split}}});
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("TestHelpers.Domain.Amr.NeighborFlagHelpers",
+                  "[Domain][Unit]") {
+  test_valid_neighbor_flags_1d();
+  test_valid_neighbor_flags_2d();
+  // testing 3d does not test anything new
+}
+}  // namespace TestHelpers::amr

--- a/tests/Unit/Helpers/Tests/Domain/CMakeLists.txt
+++ b/tests/Unit/Helpers/Tests/Domain/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
+add_subdirectory(Amr)
 add_subdirectory(Structure)

--- a/tests/Unit/Helpers/Tests/Domain/CMakeLists.txt
+++ b/tests/Unit/Helpers/Tests/Domain/CMakeLists.txt
@@ -1,0 +1,4 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+add_subdirectory(Structure)

--- a/tests/Unit/Helpers/Tests/Domain/Structure/CMakeLists.txt
+++ b/tests/Unit/Helpers/Tests/Domain/Structure/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY "Test_DomainStructureHelpers")
 
 set(LIBRARY_SOURCES
+  Test_NeighborHelpers.cpp
   Test_OrientationMapHelpers.cpp
   )
 

--- a/tests/Unit/Helpers/Tests/Domain/Structure/CMakeLists.txt
+++ b/tests/Unit/Helpers/Tests/Domain/Structure/CMakeLists.txt
@@ -1,0 +1,22 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBRARY "Test_DomainStructureHelpers")
+
+set(LIBRARY_SOURCES
+  Test_OrientationMapHelpers.cpp
+  )
+
+add_test_library(
+  ${LIBRARY}
+  "Helpers/Tests/Domain/Structure/"
+  "${LIBRARY_SOURCES}"
+  ""
+  )
+
+target_link_libraries(
+  ${LIBRARY}
+  PRIVATE
+  DomainStructure
+  DomainStructureHelpers
+  )

--- a/tests/Unit/Helpers/Tests/Domain/Structure/Test_NeighborHelpers.cpp
+++ b/tests/Unit/Helpers/Tests/Domain/Structure/Test_NeighborHelpers.cpp
@@ -1,0 +1,153 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+
+#include "Domain/Structure/ElementId.hpp"
+#include "Domain/Structure/Neighbors.hpp"
+#include "Domain/Structure/OrientationMap.hpp"
+#include "Domain/Structure/SegmentId.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/Domain/Structure/NeighborHelpers.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/StdHelpers.hpp"
+
+namespace TestHelpers::domain {
+namespace {
+void test_valid_sibling_side_segments() {
+  for (size_t l = 1; l < 5; ++l) {
+    for (size_t i = 0; i < two_to_the(l); ++i) {
+      SegmentId my_id{l, i};
+      const auto valid_segments = valid_neighbor_segments(my_id);
+      if (i % 2 == 0) {
+        CHECK(valid_segments ==
+              std::vector{SegmentId{l, i + 1}, SegmentId{l + 1, 2 * i + 2}});
+      } else {
+        CHECK(valid_segments ==
+              std::vector{SegmentId{l, i - 1}, SegmentId{l + 1, 2 * i - 1}});
+      }
+    }
+  }
+}
+
+void test_valid_nonsibling_side_segments() {
+  CHECK(valid_neighbor_segments(SegmentId{1, 0}, FaceType::Periodic) ==
+        std::vector{SegmentId{1, 1}, SegmentId{2, 3}});
+  CHECK(valid_neighbor_segments(SegmentId{1, 1}, FaceType::Periodic) ==
+        std::vector{SegmentId{1, 0}, SegmentId{2, 0}});
+  for (size_t l = 1; l < 5; ++l) {
+    SegmentId lower_boundary_segment{l, 0};
+    SegmentId upper_boundary_segment{l, two_to_the(l) - 1};
+    CHECK(valid_neighbor_segments(lower_boundary_segment, FaceType::External) ==
+          std::vector<SegmentId>{});
+    CHECK(valid_neighbor_segments(upper_boundary_segment, FaceType::External) ==
+          std::vector<SegmentId>{});
+    CHECK(valid_neighbor_segments(lower_boundary_segment, FaceType::Block) ==
+          std::vector{SegmentId{l - 1, two_to_the(l - 1) - 1},
+                      SegmentId{l, two_to_the(l) - 1},
+                      SegmentId{l + 1, two_to_the(l + 1) - 1}});
+    CHECK(
+        valid_neighbor_segments(upper_boundary_segment, FaceType::Block) ==
+        std::vector{SegmentId{l - 1, 0}, SegmentId{l, 0}, SegmentId{l + 1, 0}});
+    if (l > 1) {
+      CHECK(
+          valid_neighbor_segments(lower_boundary_segment, FaceType::Periodic) ==
+          std::vector{SegmentId{l - 1, two_to_the(l - 1) - 1},
+                      SegmentId{l, two_to_the(l) - 1},
+                      SegmentId{l + 1, two_to_the(l + 1) - 1}});
+      CHECK(
+          valid_neighbor_segments(upper_boundary_segment, FaceType::Periodic) ==
+          std::vector{SegmentId{l - 1, 0}, SegmentId{l, 0},
+                      SegmentId{l + 1, 0}});
+    }
+  }
+  for (size_t l = 2; l < 5; ++l) {
+    for (size_t i = 1; i < two_to_the(l) - 1; ++i) {
+      SegmentId my_id{l, i};
+      const auto valid_segments =
+          valid_neighbor_segments(my_id, FaceType::Internal);
+      if (i % 2 == 0) {
+        CHECK(valid_segments == std::vector{SegmentId{l - 1, i / 2 - 1},
+                                            SegmentId{l, i - 1},
+                                            SegmentId{l + 1, 2 * i - 1}});
+      } else {
+        CHECK(valid_segments == std::vector{SegmentId{l - 1, i / 2 + 1},
+                                            SegmentId{l, i + 1},
+                                            SegmentId{l + 1, 2 * i + 2}});
+      }
+    }
+  }
+}
+
+template <size_t Dim>
+std::vector<ElementId<Dim>> element_ids_to_test() {
+  static constexpr size_t max_level = 2;
+  std::vector<ElementId<Dim>> result{};
+  for (size_t lx = 0; lx <= max_level; ++lx) {
+    for (size_t ix = 0; ix < two_to_the(lx); ++ix) {
+      if constexpr (Dim == 1) {
+        result.emplace_back(0, std::array{SegmentId{lx, ix}});
+      } else {
+        for (size_t ly = 0; ly <= max_level; ++ly) {
+          for (size_t iy = 0; iy < two_to_the(ly); ++iy) {
+            if constexpr (Dim == 2) {
+              result.emplace_back(
+                  0, std::array{SegmentId{lx, ix}, SegmentId{ly, iy}});
+            } else {
+              for (size_t lz = 0; lz <= max_level; ++lz) {
+                for (size_t iz = 0; iz < two_to_the(lz); ++iz) {
+                  result.emplace_back(
+                      0, std::array{SegmentId{lx, ix}, SegmentId{ly, iy},
+                                    SegmentId{lz, iz}});
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  return result;
+}
+
+template <size_t Dim>
+void test_valid_neighbors(const gsl::not_null<std::mt19937*> generator) {
+  for (const auto& element_id : element_ids_to_test<Dim>()) {
+    for (const auto& direction : Direction<Dim>::all_directions()) {
+      const size_t dim = direction.dimension();
+      const Side side = direction.side();
+      const SegmentId& normal_segment = element_id.segment_id(dim);
+      const double endpoint = normal_segment.endpoint(side);
+      if (endpoint == 1.0 or endpoint == -1.0) {
+        for (const auto face_type :
+             std::array{FaceType::Periodic, FaceType::Block}) {
+          for (const auto& neighbors :
+               valid_neighbors(generator, element_id, direction, face_type)) {
+            check_neighbors(neighbors, element_id, direction);
+          }
+        }
+      } else {
+        for (const auto& neighbors :
+             valid_neighbors(generator, element_id, direction)) {
+          check_neighbors(neighbors, element_id, direction);
+        }
+      }
+    }
+  }
+}
+
+}  // namespace
+
+SPECTRE_TEST_CASE("TestHelpers.Domain.Structure.NeighborHelpers",
+                  "[Domain][Unit]") {
+  MAKE_GENERATOR(generator);
+  test_valid_sibling_side_segments();
+  test_valid_nonsibling_side_segments();
+  test_valid_neighbors<1>(make_not_null(&generator));
+  test_valid_neighbors<2>(make_not_null(&generator));
+  test_valid_neighbors<3>(make_not_null(&generator));
+}
+}  // namespace TestHelpers::domain

--- a/tests/Unit/Helpers/Tests/Domain/Structure/Test_OrientationMapHelpers.cpp
+++ b/tests/Unit/Helpers/Tests/Domain/Structure/Test_OrientationMapHelpers.cpp
@@ -1,0 +1,59 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <utility>
+#include <vector>
+
+#include "DataStructures/Tensor/EagerMath/Determinant.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/Structure/OrientationMap.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/Domain/Structure/OrientationMapHelpers.hpp"
+#include "Utilities/Algorithm.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+
+namespace TestHelpers::domain {
+namespace {
+template <size_t Dim>
+void test_valid_orientation_maps() {
+  auto orientation_maps = valid_orientation_maps<Dim>();
+  constexpr size_t expected_size =
+      (Dim == 1 ? 2 : two_to_the(Dim - 1) * factorial(Dim));
+  CHECK(orientation_maps.size() == expected_size);
+  for (const auto& orientation_map : orientation_maps) {
+    if constexpr (Dim > 1) {
+      CHECK(get(determinant(discrete_rotation_jacobian(orientation_map))) ==
+            1.0);
+    }
+    CHECK(alg::count(orientation_maps, orientation_map) == 1);
+  }
+}
+template <size_t Dim>
+void test_random_orientation_maps(gsl::not_null<std::mt19937*> generator) {
+  const auto valid_maps = valid_orientation_maps<Dim>();
+  for (size_t s = 0; s < 6; ++s) {
+    const auto random_maps = random_orientation_maps<Dim>(s, generator);
+    const size_t expected_size = std::min(s, valid_maps.size());
+    CHECK(random_maps.size() == expected_size);
+    for (const auto& random_map : random_maps) {
+      CHECK(alg::count(valid_maps, random_map) == 1);
+      CHECK(alg::count(random_maps, random_map) == 1);
+    }
+  }
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("TestHelpers.Domain.OrientationMapHelpers",
+                  "[Domain][Unit]") {
+  MAKE_GENERATOR(generator);
+  test_valid_orientation_maps<1>();
+  test_valid_orientation_maps<2>();
+  test_valid_orientation_maps<3>();
+  test_random_orientation_maps<1>(make_not_null(&generator));
+  test_random_orientation_maps<2>(make_not_null(&generator));
+  test_random_orientation_maps<3>(make_not_null(&generator));
+}
+}  // namespace TestHelpers::domain

--- a/tests/Unit/Utilities/Test_Algorithm.cpp
+++ b/tests/Unit/Utilities/Test_Algorithm.cpp
@@ -3,8 +3,11 @@
 
 #include "Framework/TestingFramework.hpp"
 
+#include <algorithm>
 #include <cctype>
+#include <cstddef>
 #include <iterator>
+#include <random>
 #include <string>
 #include <vector>
 
@@ -209,6 +212,20 @@ void test_remove() {
   CHECK(str2 == "Textwithsomewhitespaces");
 }
 
+void test_sample() {
+  std::vector<int> v{-1, 3, 5, 9, -24, 8};
+  std::mt19937 gen;
+  for (size_t s = 0; s < 8; ++s) {
+    std::vector<int> alg_s{};
+    gen.seed(1);
+    alg::sample(v, std::back_inserter(alg_s), s, gen);
+    std::vector<int> std_s{};
+    gen.seed(1);
+    std::sample(std::begin(v), std::end(v), std::back_inserter(std_s), s, gen);
+    CHECK(alg_s == std_s);
+  }
+}
+
 void test_sort() {
   std::vector<int> t_orig{3, 5, 8, -1};
   std::vector<int> t0 = t_orig;
@@ -246,6 +263,7 @@ SPECTRE_TEST_CASE("Unit.Utilities.Algorithm", "[Unit][Utilities]") {
   test_for_each();
   test_min_max_element();
   test_remove();
+  test_sample();
   test_sort();
   test_transform();
 }

--- a/tests/Unit/Utilities/Test_CartesianProduct.cpp
+++ b/tests/Unit/Utilities/Test_CartesianProduct.cpp
@@ -9,12 +9,32 @@
 #include "Utilities/CartesianProduct.hpp"
 #include "Utilities/MakeArray.hpp"
 
+namespace {
+void test_product_of_arrays() {
+  const auto result =
+      cartesian_product(make_array(true, false), make_array(1, 2, 3));
+  const std::array<std::tuple<bool, int>, 6> expected{
+      {{true, 1}, {true, 2}, {true, 3}, {false, 1}, {false, 2}, {false, 3}}};
+  CHECK(result == expected);
+}
+
+void test_product_of_containers() {
+  std::array bools{true, false};
+  std::vector ints{1, 2, 3};
+  std::set doubles{-1., 0.5, 3.0, 7.25};
+  const auto result = cartesian_product(bools, ints, doubles);
+  const std::vector<std::tuple<bool, int, double>> expected{
+      {true, 1, -1.},  {true, 1, 0.5},  {true, 1, 3.0},  {true, 1, 7.25},
+      {true, 2, -1.},  {true, 2, 0.5},  {true, 2, 3.0},  {true, 2, 7.25},
+      {true, 3, -1.},  {true, 3, 0.5},  {true, 3, 3.0},  {true, 3, 7.25},
+      {false, 1, -1.}, {false, 1, 0.5}, {false, 1, 3.0}, {false, 1, 7.25},
+      {false, 2, -1.}, {false, 2, 0.5}, {false, 2, 3.0}, {false, 2, 7.25},
+      {false, 3, -1.}, {false, 3, 0.5}, {false, 3, 3.0}, {false, 3, 7.25}};
+  CHECK(result == expected);
+}
+}  // namespace
+
 SPECTRE_TEST_CASE("Unit.Utilities.CartesianProduct", "[Unit][Utilities]") {
-  {
-    const auto result =
-        cartesian_product(make_array(true, false), make_array(1, 2, 3));
-    const std::array<std::tuple<bool, int>, 6> expected{
-        {{true, 1}, {true, 2}, {true, 3}, {false, 1}, {false, 2}, {false, 3}}};
-    CHECK(result == expected);
-  }
+  test_product_of_arrays();
+  test_product_of_containers();
 }


### PR DESCRIPTION
## Proposed changes

- Add function for determining new neighbors after h-refinement
- Also add overloads of `random_sample` and `cartesian_product` for other containers

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
