### PR TITLE
Make Worldtube use STF tensors

### DIFF
--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonActions/SendToElements.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonActions/SendToElements.hpp
@@ -15,6 +15,7 @@
 #include "Domain/Tags.hpp"
 #include "Evolution/Systems/CurvedScalarWave/Worldtube/Inboxes.hpp"
 #include "Evolution/Systems/CurvedScalarWave/Worldtube/Tags.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/Tags.hpp"
 #include "Parallel/AlgorithmExecution.hpp"
 #include "Parallel/GlobalCache.hpp"
 #include "ParallelAlgorithms/Initialization/MutateAssign.hpp"
@@ -58,9 +59,12 @@ struct SendToElements {
     for (const auto& [element_id, grid_coords] : faces_grid_coords) {
       const size_t grid_size = get<0>(grid_coords).size();
       Variables<tags_to_send> vars_to_send(grid_size);
-      get(get<psi_tag>(vars_to_send)) = get<Tags::PsiMonopole>(box);
+      get(get<psi_tag>(vars_to_send)) = get(
+          get<Stf::Tags::StfTensor<Tags::PsiWorldtube, 0, Dim, Frame::Grid>>(
+              box));
       get(get<dt_psi_tag>(vars_to_send)) =
-          get<::Tags::dt<Tags::PsiMonopole>>(box);
+          get(get<Stf::Tags::StfTensor<::Tags::dt<Tags::PsiWorldtube>, 0, Dim,
+                                       Frame::Grid>>(box));
       for (size_t i = 0; i < Dim; ++i) {
         // at 0th order the spatial derivative is just zero
         get<di_psi_tag>(vars_to_send).get(i) = 0.;

--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/Tags.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/Tags.hpp
@@ -293,13 +293,12 @@ struct WorldtubeSolution : db::SimpleTag {
 };
 
 /*!
- * \brief Holds the monopole of the regular field inside the worldtube.
+ * \brief The scalar field inside the worldtube.
  *
- * \warning This tag will be removed once higher expansion orders of the
- * worldtube scheme are implemented.
+ * \details This tag is used as a base tag for Stf::Tags::StfTensor
  */
-struct PsiMonopole : db::SimpleTag {
-  using type = double;
+struct PsiWorldtube : db::SimpleTag {
+  using type = Scalar<double>;
 };
 
 /*!

--- a/src/NumericalAlgorithms/SphericalHarmonics/Tags.hpp
+++ b/src/NumericalAlgorithms/SphericalHarmonics/Tags.hpp
@@ -358,3 +358,28 @@ using compute_items_tags =
                D2xRadiusCompute<Frame>, LaplacianRadiusCompute<Frame>,
                NormalOneFormCompute<Frame>, TangentsCompute<Frame>>;
 }  // namespace StrahlkorperTags
+
+/// Tags related to symmetric trace-free tensors
+namespace Stf::Tags {
+
+/*!
+ * \brief Tag used to hold a symmetric trace-free tensor of a certain rank.
+ * \details The type is a symmetric tensor of the requested rank. A
+ * ScalarBaseTag of type `Scalar<double>` is used to identify the tag of which
+ * the symmetric trace-free expansion is done.
+ */
+template <typename ScalarBaseTag, size_t rank, size_t Dim, typename Frame>
+struct StfTensor : db::SimpleTag {
+  static_assert(std::is_same_v<typename ScalarBaseTag::type, Scalar<double>>,
+                "StfTensor base tags must be a Scalar.");
+  static_assert(rank <= 3, "StfTensor tag is only implemented up to rank 3.");
+  static std::string name() {
+    return MakeString{} << "StfTensor(" << db::tag_name<ScalarBaseTag>()
+                        << "," << rank << ")";
+  }
+  using type_list =
+      tmpl::list<Scalar<double>, tnsr::i<double, Dim, Frame>,
+                 tnsr::ii<double, Dim, Frame>, tnsr::iii<double, Dim, Frame>>;
+  using type = tmpl::at<type_list, tmpl::size_t<rank>>;
+};
+}  // namespace Stf::Tags

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/ElementActions/Test_ReceiveWorldtubeData.cpp
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/ElementActions/Test_ReceiveWorldtubeData.cpp
@@ -80,9 +80,11 @@ struct MockWorldtubeSingleton {
       Parallel::PhaseActions<
           Parallel::Phase::Initialization,
           tmpl::list<ActionTesting::InitializeDataBox<
-              db::AddSimpleTags<Tags::ElementFacesGridCoordinates<Dim>,
-                                ::Tags::TimeStepId, Tags::PsiMonopole,
-                                ::Tags::dt<Tags::PsiMonopole>>,
+              db::AddSimpleTags<
+                  Tags::ElementFacesGridCoordinates<Dim>, ::Tags::TimeStepId,
+                  Stf::Tags::StfTensor<Tags::PsiWorldtube, 0, Dim, Frame::Grid>,
+                  Stf::Tags::StfTensor<::Tags::dt<Tags::PsiWorldtube>, 0, Dim,
+                                       Frame::Grid>>,
               db::AddComputeTags<>>>>,
       Parallel::PhaseActions<
           Parallel::Phase::Testing,
@@ -188,8 +190,8 @@ SPECTRE_TEST_CASE("Unit.CurvedScalarWave.Worldtube.ReceiveWorldtubeData",
 
     ActionTesting::emplace_singleton_component_and_initialize<worldtube_chare>(
         &runner, ActionTesting::NodeId{0}, ActionTesting::LocalCoreId{0},
-        {element_faces_grid_coords, dummy_time_step_id, psi_value,
-         dt_psi_value});
+        {element_faces_grid_coords, dummy_time_step_id,
+         Scalar<double>(psi_value), Scalar<double>(dt_psi_value)});
 
     ActionTesting::set_phase(make_not_null(&runner), Parallel::Phase::Testing);
 

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/ElementActions/Test_SendToWorldtube.cpp
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/ElementActions/Test_SendToWorldtube.cpp
@@ -224,17 +224,17 @@ SPECTRE_TEST_CASE("Unit.CurvedScalarWave.Worldtube.SendToWorldtube", "[Unit]") {
     CHECK(ActionTesting::next_action_if_ready<worldtube_chare>(
         make_not_null(&runner), 0));
     CHECK(worldtube_inbox.empty());
-    const auto& psi_monopole_worldtube =
-        ActionTesting::get_databox_tag<worldtube_chare, Tags::PsiMonopole>(
-            runner, 0);
-    const auto& dt_psi_monopole_worldtube =
-        ActionTesting::get_databox_tag<worldtube_chare,
-                                       ::Tags::dt<Tags::PsiMonopole>>(runner,
-                                                                      0);
+    const auto& psi_monopole_worldtube = ActionTesting::get_databox_tag<
+        worldtube_chare,
+        Stf::Tags::StfTensor<Tags::PsiWorldtube, 0, Dim, Frame::Grid>>(runner,
+                                                                       0);
+    const auto& dt_psi_monopole_worldtube = ActionTesting::get_databox_tag<
+        worldtube_chare, Stf::Tags::StfTensor<::Tags::dt<Tags::PsiWorldtube>, 0,
+                                              Dim, Frame::Grid>>(runner, 0);
     Approx apprx = Approx::custom().epsilon(1e-8).scale(1.0);
     // result is constant we set multiplied by l=m=0 spherical harmonic
-    CHECK(psi_monopole_worldtube == apprx(psi_value));
-    CHECK(dt_psi_monopole_worldtube == -apprx(pi_value));
+    CHECK(get(psi_monopole_worldtube) == apprx(psi_value));
+    CHECK(get(dt_psi_monopole_worldtube) == -apprx(pi_value));
   }
 }
 }  // namespace

--- a/tests/Unit/NumericalAlgorithms/SphericalHarmonics/Test_Tags.cpp
+++ b/tests/Unit/NumericalAlgorithms/SphericalHarmonics/Test_Tags.cpp
@@ -118,11 +118,11 @@ void test_radius_and_derivs() {
         (9. * sin(3. * phi) * sin_theta -
          sin_phi * (7. * sin_theta + 12. * square(cos_phi) * sin(3. * theta))) /
         (16. * square(r));
-    expected_d2x_radius.get(0, 1)[s] =
-        -((cos_phi * (square(cos_phi) +
-                      ((-1. + 3. * cos_2_theta) * square(sin_phi)) / 2.) *
-           sin_theta) /
-          square(r));
+    expected_d2x_radius.get(0, 1)[s] = -(
+        (cos_phi *
+         (square(cos_phi) + ((-1. + 3. * cos_2_theta) * square(sin_phi)) / 2.) *
+         sin_theta) /
+        square(r));
     expected_d2x_radius.get(0, 2)[s] =
         (3. * cos_phi * cos_theta * sin_phi * square(sin_theta)) / square(r);
     expected_d2x_radius.get(1, 1)[s] =
@@ -235,14 +235,44 @@ struct SomeType {};
 struct SomeTag : db::SimpleTag {
   using type = SomeType;
 };
+struct DummyScalar : db::SimpleTag {
+  using type = Scalar<double>;
+};
+
+void test_stf_tensor_tag() {
+  static_assert(std::is_same_v<
+                Stf::Tags::StfTensor<DummyScalar, 0, 3, Frame::Inertial>::type,
+                Scalar<double>>);
+  static_assert(std::is_same_v<
+                Stf::Tags::StfTensor<DummyScalar, 1, 3, Frame::Inertial>::type,
+                tnsr::i<double, 3, Frame::Inertial>>);
+  static_assert(std::is_same_v<
+                Stf::Tags::StfTensor<DummyScalar, 2, 3, Frame::Inertial>::type,
+                tnsr::ii<double, 3, Frame::Inertial>>);
+  static_assert(std::is_same_v<
+                Stf::Tags::StfTensor<DummyScalar, 3, 3, Frame::Inertial>::type,
+                tnsr::iii<double, 3, Frame::Inertial>>);
+  TestHelpers::db::test_simple_tag<
+      Stf::Tags::StfTensor<DummyScalar, 0, 3, Frame::Inertial>>(
+      "StfTensor(DummyScalar,0)");
+  TestHelpers::db::test_simple_tag<
+      Stf::Tags::StfTensor<DummyScalar, 1, 3, Frame::Inertial>>(
+      "StfTensor(DummyScalar,1)");
+  TestHelpers::db::test_simple_tag<
+      Stf::Tags::StfTensor<DummyScalar, 2, 3, Frame::Inertial>>(
+      "StfTensor(DummyScalar,2)");
+  TestHelpers::db::test_simple_tag<
+      Stf::Tags::StfTensor<DummyScalar, 3, 3, Frame::Inertial>>(
+      "StfTensor(DummyScalar,3)");
+}
 
 }  // namespace
 
-SPECTRE_TEST_CASE("Unit.SphericalHarmonics.StrahlkorperDataBox",
-                  "[ApparentHorizons][Unit]") {
+SPECTRE_TEST_CASE("Unit.SphericalHarmonics.Tags", "[ApparentHorizons][Unit]") {
   test_average_radius();
   test_radius_and_derivs();
   test_normals();
+  test_stf_tensor_tag();
   TestHelpers::db::test_simple_tag<
       StrahlkorperTags::Strahlkorper<Frame::Inertial>>("Strahlkorper");
   TestHelpers::db::test_simple_tag<StrahlkorperTags::ThetaPhi<Frame::Inertial>>(


### PR DESCRIPTION
## Proposed changes
Introduces a `STFTensor` tag that holds a symmetric trace free tensor of a given rank and makes the worldtube use it. This will be necessary for the second order implementation.

~depends on #4866~ 