### PR TITLE
Add compute tag for time deriv of strahlkorper

### DIFF
--- a/src/ApparentHorizons/CMakeLists.txt
+++ b/src/ApparentHorizons/CMakeLists.txt
@@ -9,6 +9,7 @@ spectre_target_sources(
   ${LIBRARY}
   PRIVATE
   FastFlow.cpp
+  TimeDerivStrahlkorper.cpp
   StrahlkorperGr.cpp
   StrahlkorperCoordsInDifferentFrame.cpp
   StrahlkorperInDifferentFrame.cpp
@@ -31,6 +32,7 @@ spectre_target_headers(
   StrahlkorperInDifferentFrame.hpp
   Tags.hpp
   TagsDeclarations.hpp
+  TimeDerivStrahlkorper.hpp
   )
 
 target_link_libraries(
@@ -38,6 +40,7 @@ target_link_libraries(
   PUBLIC
   DataStructures
   ErrorHandling
+  FiniteDifference
   GeneralRelativity
   LinearAlgebra
   Options

--- a/src/ApparentHorizons/Tags.hpp
+++ b/src/ApparentHorizons/Tags.hpp
@@ -10,6 +10,7 @@
 
 #include "ApparentHorizons/StrahlkorperGr.hpp"
 #include "ApparentHorizons/TagsDeclarations.hpp"  // IWYU pragma: keep
+#include "ApparentHorizons/TimeDerivStrahlkorper.hpp"
 #include "DataStructures/DataBox/Tag.hpp"
 #include "DataStructures/DataBox/TagName.hpp"
 #include "DataStructures/DataVector.hpp"
@@ -53,6 +54,28 @@ struct ObserveCentersBase : db::BaseTag {};
 struct ObserveCenters : ObserveCentersBase, db::SimpleTag {
   using type = bool;
 };
+
+/// @{
+/// Tag to compute the time derivative of the coefficients of a Strahlkorper
+/// from a number of previous Strahlkorpers.
+template <typename Frame>
+struct TimeDerivStrahlkorper : db::SimpleTag {
+  using type = ::Strahlkorper<Frame>;
+};
+
+template <typename Frame>
+struct TimeDerivStrahlkorperCompute : db::ComputeTag,
+                                      TimeDerivStrahlkorper<Frame> {
+  using base = TimeDerivStrahlkorper<Frame>;
+  using return_type = typename base::type;
+  static constexpr auto function = static_cast<void (*)(
+      gsl::not_null<::Strahlkorper<Frame>*>,
+      const std::deque<std::pair<double, ::Strahlkorper<Frame>>>&)>(
+      &ah::time_deriv_of_strahlkorper<Frame>);
+
+  using argument_tags = tmpl::list<PreviousStrahlkorpers<Frame>>;
+};
+/// @}
 }  // namespace ah::Tags
 
 /// \ingroup SurfacesGroup

--- a/src/ApparentHorizons/TimeDerivStrahlkorper.cpp
+++ b/src/ApparentHorizons/TimeDerivStrahlkorper.cpp
@@ -1,0 +1,86 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "ApparentHorizons/TimeDerivStrahlkorper.hpp"
+
+#include <deque>
+#include <utility>
+
+#include "DataStructures/DataVector.hpp"
+#include "NumericalAlgorithms/FiniteDifference/NonUniform1D.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/Strahlkorper.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace Frame {
+struct Grid;
+struct Distorted;
+struct Inertial;
+}  // namespace Frame
+
+namespace ah {
+namespace {
+template <size_t NumTimes>
+static DataVector compute_coefs(
+    const std::deque<double>& times,
+    const std::deque<const DataVector*>& coefficients) {
+  const auto weights = fd::non_uniform_1d_weights<NumTimes>(times);
+
+  DataVector new_coefficients{coefficients.front()->size(), 0.0};
+
+  for (size_t i = 0; i < NumTimes; i++) {
+    new_coefficients += *coefficients[i] * gsl::at(gsl::at(weights, 1), i);
+  }
+
+  return new_coefficients;
+}
+}  // namespace
+
+template <typename Frame>
+void time_deriv_of_strahlkorper(
+    gsl::not_null<Strahlkorper<Frame>*> time_deriv,
+    const std::deque<std::pair<double, ::Strahlkorper<Frame>>>&
+        previous_strahlkorpers) {
+  std::deque<double> times{};
+  std::deque<const DataVector*> coefficients{};
+
+  for (const auto& [time, strahlkorper] : previous_strahlkorpers) {
+    times.emplace_back(time);
+    coefficients.emplace_back(&strahlkorper.coefficients());
+  }
+
+  DataVector new_coefficients{};
+
+  // Switch needed to convert times size into template parameter
+  switch (previous_strahlkorpers.size()) {
+    case 2:
+      new_coefficients = compute_coefs<2>(times, coefficients);
+      break;
+    case 3:
+      new_coefficients = compute_coefs<3>(times, coefficients);
+      break;
+    case 4:
+      new_coefficients = compute_coefs<4>(times, coefficients);
+      break;
+    default:
+      ERROR("Unsupported size for number of previous Strahlkorpers "
+            << previous_strahlkorpers.size());
+  }
+
+  time_deriv->coefficients() = std::move(new_coefficients);
+}
+
+#define FRAME(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data)                           \
+  template void time_deriv_of_strahlkorper(            \
+      const gsl::not_null<Strahlkorper<FRAME(data)>*>, \
+      const std::deque<std::pair<double, ::Strahlkorper<FRAME(data)>>>&);
+
+GENERATE_INSTANTIATIONS(INSTANTIATE,
+                        (::Frame::Grid, ::Frame::Distorted, ::Frame::Inertial))
+
+#undef INSTANTIATE
+#undef FRAME
+}  // namespace ah

--- a/src/ApparentHorizons/TimeDerivStrahlkorper.hpp
+++ b/src/ApparentHorizons/TimeDerivStrahlkorper.hpp
@@ -1,0 +1,32 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <deque>
+#include <utility>
+
+/// \cond
+template <typename Frame>
+class Strahlkorper;
+namespace gsl {
+template <typename T>
+class not_null;
+}  // namespace gsl
+/// \endcond
+
+namespace ah {
+/// \brief Compute the time derivative of a Strahlkorper from a number of
+/// previous Strahlkorpers
+///
+/// \details Does simple 1D FD with non-uniform spacing using
+/// `fd::non_uniform_1d_weights`.
+/// \param previous_strahlkorpers All previous Strahlkorpers and the times they
+/// are at. They are expected to have the most recent Strahlkorper in the front
+/// and the Strahlkorper furthest in the past in the back of the deque.
+template <typename Frame>
+void time_deriv_of_strahlkorper(
+    gsl::not_null<Strahlkorper<Frame>*> time_deriv,
+    const std::deque<std::pair<double, ::Strahlkorper<Frame>>>&
+        previous_strahlkorpers);
+}  // namespace ah

--- a/src/ControlSystem/Averager.cpp
+++ b/src/ControlSystem/Averager.cpp
@@ -5,6 +5,7 @@
 
 #include <ostream>
 
+#include "NumericalAlgorithms/FiniteDifference/NonUniform1D.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
@@ -165,65 +166,8 @@ template <size_t DerivOrder>
 std::array<DataVector, DerivOrder + 1> Averager<DerivOrder>::get_derivs()
     const {
   // initialize the finite difference coefs
-  std::array<std::array<double, DerivOrder + 1>, DerivOrder + 1> coefs{};
-
-  // These coeffiecients are the weights of the Lagrange interpolation
-  // polynomial and its derivatives evaluated at `time_[0]`
-  if constexpr (DerivOrder == 1) {
-    const double one_over_delta_t = 1.0 / (times_[0] - times_[1]);
-
-    // set coefs for function value
-    coefs[0] = {{1.0, 0.0}};
-    // first deriv coefs
-    coefs[1] = {{one_over_delta_t, -one_over_delta_t}};
-  } else if constexpr (DerivOrder == 2) {
-    const double t0_minus_t1 = times_[0] - times_[1];
-    const double t1_minus_t2 = times_[1] - times_[2];
-    const double t0_minus_t2 = times_[0] - times_[2];
-    const double denom = 1.0 / t0_minus_t2;
-    const double one_over_mult_dts = 1.0 / (t0_minus_t1 * t1_minus_t2);
-
-    // set coefs for function value
-    coefs[0] = {{1.0, 0.0, 0.0}};
-    // first deriv coefs
-    coefs[1] = {{(2.0 + t1_minus_t2 / t0_minus_t1) * denom,
-                 -t0_minus_t2 * one_over_mult_dts,
-                 t0_minus_t1 / t1_minus_t2 * denom}};
-    // second deriv coefs
-    coefs[2] = {{2.0 / t0_minus_t1 * denom, -2.0 * one_over_mult_dts,
-                 2.0 / t1_minus_t2 * denom}};
-  } else if constexpr (DerivOrder == 3) {
-    const double t1_minus_t0 = times_[1] - times_[0];
-    const double t2_minus_t0 = times_[2] - times_[0];
-    const double t3_minus_t0 = times_[3] - times_[0];
-    const double t1_minus_t2 = times_[1] - times_[2];
-    const double t1_minus_t3 = times_[1] - times_[3];
-    const double t2_minus_t3 = times_[2] - times_[3];
-
-    // set coefs for function value
-    coefs[0] = {{1.0, 0.0, 0.0, 0.0}};
-    // first deriv coefs
-    coefs[1] = {
-        {-1.0 / t1_minus_t0 - 1.0 / t2_minus_t0 - 1.0 / t3_minus_t0,
-         t2_minus_t0 * t3_minus_t0 / (t1_minus_t0 * t1_minus_t2 * t1_minus_t3),
-         -t1_minus_t0 * t3_minus_t0 / (t2_minus_t0 * t1_minus_t2 * t2_minus_t3),
-         t1_minus_t0 * t2_minus_t0 /
-             (t3_minus_t0 * t1_minus_t3 * t2_minus_t3)}};
-    // second deriv coefs
-    coefs[2] = {{2.0 * (t1_minus_t0 + t2_minus_t0 + t3_minus_t0) /
-                     (t1_minus_t0 * t2_minus_t0 * t3_minus_t0),
-                 -2.0 * (t2_minus_t0 + t3_minus_t0) /
-                     (t1_minus_t0 * t1_minus_t2 * t1_minus_t3),
-                 2.0 * (t1_minus_t0 + t3_minus_t0) /
-                     (t2_minus_t0 * t1_minus_t2 * t2_minus_t3),
-                 -2.0 * (t1_minus_t0 + t2_minus_t0) /
-                     (t3_minus_t0 * t1_minus_t3 * t2_minus_t3)}};
-    // third deriv coefs
-    coefs[3] = {{-6.0 / (t1_minus_t0 * t2_minus_t0 * t3_minus_t0),
-                 6.0 / (t1_minus_t0 * t1_minus_t2 * t1_minus_t3),
-                 -6.0 / (t2_minus_t0 * t1_minus_t2 * t2_minus_t3),
-                 6.0 / (t3_minus_t0 * t1_minus_t3 * t2_minus_t3)}};
-  }
+  std::array<std::array<double, DerivOrder + 1>, DerivOrder + 1> coefs =
+      fd::non_uniform_1d_weights<DerivOrder + 1>(times_);
 
   std::array<DataVector, DerivOrder + 1> result =
       make_array<DerivOrder + 1>(DataVector(raw_qs_[0].size(), 0.0));

--- a/src/ControlSystem/Averager.cpp
+++ b/src/ControlSystem/Averager.cpp
@@ -100,8 +100,9 @@ void Averager<DerivOrder>::update(const double time, const DataVector& raw_q,
 
   // Do not allow updates at or before last update time
   if (UNLIKELY(not times_.empty() and time <= last_time_updated())) {
-    ERROR("The specified time t=" << time << " is at or before the last time "
-                                             "updated, t_update="
+    ERROR("The specified time t=" << time
+                                  << " is at or before the last time "
+                                     "updated, t_update="
                                   << last_time_updated() << ".");
   }
 

--- a/src/ControlSystem/CMakeLists.txt
+++ b/src/ControlSystem/CMakeLists.txt
@@ -47,6 +47,7 @@ target_link_libraries(
   Domain
   DomainStructure
   ErrorHandling
+  FiniteDifference
   FunctionsOfTime
   INTERFACE
   Observer

--- a/src/NumericalAlgorithms/FiniteDifference/CMakeLists.txt
+++ b/src/NumericalAlgorithms/FiniteDifference/CMakeLists.txt
@@ -15,6 +15,7 @@ spectre_target_sources(
   Minmod.cpp
   MonotonicityPreserving5.cpp
   MonotonisedCentral.cpp
+  NonUniform1D.cpp
   PartialDerivatives.cpp
   PositivityPreservingAdaptiveOrder.cpp
   Unlimited.cpp
@@ -35,6 +36,7 @@ spectre_target_headers(
   MonotonicityPreserving5.hpp
   MonotonisedCentral.hpp
   NeighborDataAsVariables.hpp
+  NonUniform1D.hpp
   PartialDerivatives.hpp
   PartialDerivatives.tpp
   PositivityPreservingAdaptiveOrder.hpp

--- a/src/NumericalAlgorithms/FiniteDifference/NonUniform1D.cpp
+++ b/src/NumericalAlgorithms/FiniteDifference/NonUniform1D.cpp
@@ -1,0 +1,105 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "NumericalAlgorithms/FiniteDifference/NonUniform1D.hpp"
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <deque>
+
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/StdHelpers.hpp"
+
+namespace fd {
+template <size_t StencilSize>
+std::array<std::array<double, StencilSize>, StencilSize> non_uniform_1d_weights(
+    const std::deque<double>& times) {
+  static_assert(StencilSize >= 2 and StencilSize <= 4,
+                "Finite difference for a 1D non-uniform stencil is only "
+                "implemented for stencil sizes 2, 3, and 4.");
+
+  ASSERT(times.size() == StencilSize,
+         "The size of the times passed in ("
+             << times.size() << ") must be the same as the stencil size ("
+             << StencilSize << ").");
+  using ::operator<<;
+  ASSERT(std::is_sorted(times.begin(), times.end(), std::greater<double>()),
+         "Times must be monotonically decreasing: " << times);
+
+  // initialize the finite difference coefs
+  std::array<std::array<double, StencilSize>, StencilSize> coefs{};
+
+  // These coefficients are the weights of the Lagrange interpolation
+  // polynomial and its derivatives evaluated at `time[0]`
+  if constexpr (StencilSize == 2) {
+    const double one_over_delta_t = 1.0 / (times[0] - times[1]);
+
+    // set coefs for function value
+    coefs[0] = {{1.0, 0.0}};
+    // first deriv coefs
+    coefs[1] = {{one_over_delta_t, -one_over_delta_t}};
+  } else if constexpr (StencilSize == 3) {
+    const double t0_minus_t1 = times[0] - times[1];
+    const double t1_minus_t2 = times[1] - times[2];
+    const double t0_minus_t2 = times[0] - times[2];
+    const double denom = 1.0 / t0_minus_t2;
+    const double one_over_mult_dts = 1.0 / (t0_minus_t1 * t1_minus_t2);
+
+    // set coefs for function value
+    coefs[0] = {{1.0, 0.0, 0.0}};
+    // first deriv coefs
+    coefs[1] = {{(2.0 + t1_minus_t2 / t0_minus_t1) * denom,
+                 -t0_minus_t2 * one_over_mult_dts,
+                 t0_minus_t1 / t1_minus_t2 * denom}};
+    // second deriv coefs
+    coefs[2] = {{2.0 / t0_minus_t1 * denom, -2.0 * one_over_mult_dts,
+                 2.0 / t1_minus_t2 * denom}};
+  } else if constexpr (StencilSize == 4) {
+    const double t1_minus_t0 = times[1] - times[0];
+    const double t2_minus_t0 = times[2] - times[0];
+    const double t3_minus_t0 = times[3] - times[0];
+    const double t1_minus_t2 = times[1] - times[2];
+    const double t1_minus_t3 = times[1] - times[3];
+    const double t2_minus_t3 = times[2] - times[3];
+
+    // set coefs for function value
+    coefs[0] = {{1.0, 0.0, 0.0, 0.0}};
+    // first deriv coefs
+    coefs[1] = {
+        {-1.0 / t1_minus_t0 - 1.0 / t2_minus_t0 - 1.0 / t3_minus_t0,
+         t2_minus_t0 * t3_minus_t0 / (t1_minus_t0 * t1_minus_t2 * t1_minus_t3),
+         -t1_minus_t0 * t3_minus_t0 / (t2_minus_t0 * t1_minus_t2 * t2_minus_t3),
+         t1_minus_t0 * t2_minus_t0 /
+             (t3_minus_t0 * t1_minus_t3 * t2_minus_t3)}};
+    // second deriv coefs
+    coefs[2] = {{2.0 * (t1_minus_t0 + t2_minus_t0 + t3_minus_t0) /
+                     (t1_minus_t0 * t2_minus_t0 * t3_minus_t0),
+                 -2.0 * (t2_minus_t0 + t3_minus_t0) /
+                     (t1_minus_t0 * t1_minus_t2 * t1_minus_t3),
+                 2.0 * (t1_minus_t0 + t3_minus_t0) /
+                     (t2_minus_t0 * t1_minus_t2 * t2_minus_t3),
+                 -2.0 * (t1_minus_t0 + t2_minus_t0) /
+                     (t3_minus_t0 * t1_minus_t3 * t2_minus_t3)}};
+    // third deriv coefs
+    coefs[3] = {{-6.0 / (t1_minus_t0 * t2_minus_t0 * t3_minus_t0),
+                 6.0 / (t1_minus_t0 * t1_minus_t2 * t1_minus_t3),
+                 -6.0 / (t2_minus_t0 * t1_minus_t2 * t2_minus_t3),
+                 6.0 / (t3_minus_t0 * t1_minus_t3 * t2_minus_t3)}};
+  }
+
+  return coefs;
+}
+
+#define STENCIL(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATION(_, data)                                          \
+  template std::array<std::array<double, STENCIL(data)>, STENCIL(data)> \
+  non_uniform_1d_weights(const std::deque<double>&);
+
+GENERATE_INSTANTIATIONS(INSTANTIATION, (2, 3, 4))
+
+#undef STENCIL
+#undef INSTANTIATION
+}  // namespace fd

--- a/src/NumericalAlgorithms/FiniteDifference/NonUniform1D.hpp
+++ b/src/NumericalAlgorithms/FiniteDifference/NonUniform1D.hpp
@@ -1,0 +1,35 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <deque>
+
+namespace fd {
+/*!
+ * \ingroup FiniteDifferenceGroup
+ * \brief Returns the weights for a 1D non-uniform finite difference stencil.
+ *
+ * These weights are for the Lagrange interpolation polynomial and its
+ * derivatives evaluated at `times[0]`. If the number of times is not the same
+ * as `StencilSize`, then an error will occur.
+ *
+ * The reason that `times` was chosen to be monotonically decreasing is because
+ * the intended use of this function is with data that is stored in a
+ * `std::deque` where the zeroth element is the "most recent" in time and then
+ * later elements are further in the "past".
+ *
+ * \param times A monotonically *decreasing* sequence of times
+ * \return A 2D array of all finite difference weights that correspond to the
+ * input times. The outer dimension is the Nth derivative, and the inner
+ * dimension loops over the weights for each of the times.
+ *
+ * \note Only stencil sizes 2, 3, and 4 are implemented right now. If you need
+ * more, you'll either need to add it yourself or generalize the algorithm.
+ */
+template <size_t StencilSize>
+std::array<std::array<double, StencilSize>, StencilSize> non_uniform_1d_weights(
+    const std::deque<double>& times);
+}  // namespace fd

--- a/src/ParallelAlgorithms/Interpolation/Targets/ApparentHorizon.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Targets/ApparentHorizon.hpp
@@ -159,7 +159,9 @@ struct ApparentHorizon : tt::ConformsTo<intrp::protocols::ComputeTargetPoints> {
       tmpl::conditional_t<
           std::is_same_v<Frame, ::Frame::Inertial>, tmpl::list<>,
           tmpl::list<StrahlkorperTags::CartesianCoords<::Frame::Inertial>>>>;
-  using compute_tags = typename StrahlkorperTags::compute_items_tags<Frame>;
+  using compute_tags =
+      tmpl::append<typename StrahlkorperTags::compute_items_tags<Frame>,
+                   ::ah::Tags::TimeDerivStrahlkorperCompute<Frame>>;
 
   template <typename DbTags, typename Metavariables>
   static void initialize(const gsl::not_null<db::DataBox<DbTags>*> box,

--- a/tests/Unit/ApparentHorizons/CMakeLists.txt
+++ b/tests/Unit/ApparentHorizons/CMakeLists.txt
@@ -14,6 +14,7 @@ set(LIBRARY_SOURCES
   Test_StrahlkorperCoordsInDifferentFrame.cpp
   Test_StrahlkorperInDifferentFrame.cpp
   Test_Tags.cpp
+  Test_TimeDerivStrahlkorper.cpp
   )
 
 add_test_library(
@@ -28,6 +29,7 @@ target_link_libraries(
   PRIVATE
   ApparentHorizons
   ApparentHorizonsHelpers
+  FiniteDifference
   GeneralRelativitySolutions
   LinearOperators
   Logging

--- a/tests/Unit/ApparentHorizons/Test_Tags.cpp
+++ b/tests/Unit/ApparentHorizons/Test_Tags.cpp
@@ -204,7 +204,6 @@ struct SomeType {};
 struct SomeTag : db::SimpleTag {
   using type = SomeType;
 };
-
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.ApparentHorizons.StrahlkorperDataBox",
@@ -218,6 +217,9 @@ SPECTRE_TEST_CASE("Unit.ApparentHorizons.StrahlkorperDataBox",
   TestHelpers::db::test_base_tag<ah::Tags::ObserveCentersBase>(
       "ObserveCentersBase");
   TestHelpers::db::test_simple_tag<ah::Tags::ObserveCenters>("ObserveCenters");
+  TestHelpers::db::test_simple_tag<
+      ah::Tags::TimeDerivStrahlkorper<Frame::Inertial>>(
+      "TimeDerivStrahlkorper");
   TestHelpers::db::test_simple_tag<StrahlkorperGr::Tags::Area>("Area");
   TestHelpers::db::test_simple_tag<StrahlkorperGr::Tags::IrreducibleMass>(
       "IrreducibleMass");
@@ -268,6 +270,9 @@ SPECTRE_TEST_CASE("Unit.ApparentHorizons.StrahlkorperDataBox",
   TestHelpers::db::test_simple_tag<
       StrahlkorperGr::Tags::DimensionlessSpinMagnitude<Frame::Inertial>>(
       "DimensionlessSpinMagnitude");
+  TestHelpers::db::test_compute_tag<
+      ah::Tags::TimeDerivStrahlkorperCompute<Frame::Inertial>>(
+      "TimeDerivStrahlkorper");
   TestHelpers::db::test_compute_tag<
       StrahlkorperTags::EuclideanAreaElementCompute<Frame::Inertial>>(
       "EuclideanAreaElement");

--- a/tests/Unit/ApparentHorizons/Test_Tags.cpp
+++ b/tests/Unit/ApparentHorizons/Test_Tags.cpp
@@ -75,17 +75,19 @@ void test_normals() {
               cos_phi * (2.0 / 3.0) *
                   (amp * (-1. + square(cos_theta)) * sin_phi - r * sin_theta) +
               cos_theta * (-10. * r - 10. * amp * sin_phi * sin_theta)) +
-         0.1 * cos_phi * (amp * (-1. + 1. * square(cos_theta)) * sin_phi -
-                          1. * r * sin_theta) *
+         0.1 * cos_phi *
+             (amp * (-1. + 1. * square(cos_theta)) * sin_phi -
+              1. * r * sin_theta) *
              (1. * amp * square(cos_phi) +
               1. * amp * square(cos_theta) * square(sin_phi) -
               1. * r * sin_phi * sin_theta +
               cos_phi * (amp * (-10. + 10. * square(cos_theta)) * sin_phi -
                          10. * r * sin_theta) +
               cos_theta * (-2. * r - 2. * amp * sin_phi * sin_theta)) +
-         2. * (amp * square(cos_phi) +
-               sin_phi *
-                   (amp * square(cos_theta) * sin_phi - 1. * r * sin_theta)) *
+         2. *
+             (amp * square(cos_phi) +
+              sin_phi *
+                  (amp * square(cos_theta) * sin_phi - 1. * r * sin_theta)) *
              (amp * square(cos_phi) +
               amp * square(cos_theta) * square(sin_phi) -
               1. * r * sin_phi * sin_theta +
@@ -166,7 +168,7 @@ void test_dimensionful_spin_vector_compute_tag() {
       db::AddComputeTags<StrahlkorperGr::Tags::DimensionfulSpinVectorCompute<
           Frame::Inertial, Frame::Inertial>>>(
       dimensionful_spin_magnitude, area_element, radius, r_hat, ricci_scalar,
-      spin_function, strahlkorper,strahlkorper_cartesian_coords);
+      spin_function, strahlkorper, strahlkorper_cartesian_coords);
   // LHS of the == in the CHECK is retrieving the computed dimensionful spin
   // vector from your DimensionfulSpinVectorCompute tag and RHS of ==
   // should be same logic as DimensionfulSpinVectorCompute::function
@@ -312,8 +314,7 @@ SPECTRE_TEST_CASE("Unit.ApparentHorizons.StrahlkorperDataBox",
       StrahlkorperTags::UnitNormalVectorCompute<Frame::Inertial>>(
       "UnitNormalVector");
   TestHelpers::db::test_compute_tag<
-      StrahlkorperTags::RicciScalarCompute<Frame::Inertial>>(
-      "RicciScalar");
+      StrahlkorperTags::RicciScalarCompute<Frame::Inertial>>("RicciScalar");
   TestHelpers::db::test_compute_tag<StrahlkorperTags::MaxRicciScalarCompute>(
       "MaxRicciScalar");
   TestHelpers::db::test_compute_tag<StrahlkorperTags::MinRicciScalarCompute>(

--- a/tests/Unit/ApparentHorizons/Test_TimeDerivStrahlkorper.cpp
+++ b/tests/Unit/ApparentHorizons/Test_TimeDerivStrahlkorper.cpp
@@ -1,0 +1,75 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <deque>
+#include <utility>
+
+#include "ApparentHorizons/TimeDerivStrahlkorper.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/SpherepackIterator.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/Strahlkorper.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace {
+void test_time_deriv_strahlkorper() {
+  const size_t l_max = 2;
+  Strahlkorper<Frame::Inertial> strahlkorper{l_max, l_max, 1.0,
+                                             std::array{0.0, 0.0, 0.0}};
+  SpherepackIterator iter{l_max, l_max};
+  // Set a random coefficient non-zero
+  strahlkorper.coefficients()[iter.set(2, 1)()] = 1.3;
+
+  for (size_t num_times = 2; num_times <= 4; num_times++) {
+    CAPTURE(num_times);
+    std::deque<std::pair<double, Strahlkorper<Frame::Inertial>>>
+        previous_strahlkorpers{};
+
+    // Set all strahlkorpers to be the same
+    for (size_t i = 0; i < num_times; i++) {
+      previous_strahlkorpers.emplace_front(
+          std::make_pair(static_cast<double>(i), strahlkorper));
+    }
+
+    auto time_deriv = strahlkorper;
+
+    ah::time_deriv_of_strahlkorper(make_not_null(&time_deriv),
+                                   previous_strahlkorpers);
+
+    const DataVector& time_deriv_strahlkorper_coefs = time_deriv.coefficients();
+
+    // Since we made all the Strahlkorpers the same, the time deriv should be
+    // zero.
+    CHECK_ITERABLE_APPROX(
+        time_deriv_strahlkorper_coefs,
+        (DataVector{time_deriv_strahlkorper_coefs.size(), 0.0}));
+
+    // Check that the deriv works for 2 times (easy to calculate by hand)
+    if (num_times == 2) {
+      // Set a single coefficient to a random value for each previous
+      // strahlkorper
+      previous_strahlkorpers.front().second.coefficients()[iter.set(2, -1)()] =
+          2.0;
+      previous_strahlkorpers.back().second.coefficients()[iter()] = 2.5;
+
+      ah::time_deriv_of_strahlkorper(make_not_null(&time_deriv),
+                                     previous_strahlkorpers);
+
+      const DataVector& coefs = time_deriv.coefficients();
+
+      DataVector expected_coefs{coefs.size(), 0.0};
+      expected_coefs[iter()] = -0.5;
+
+      CHECK_ITERABLE_APPROX(coefs, expected_coefs);
+    }
+  }
+}
+
+SPECTRE_TEST_CASE("Unit.ApparentHorizons.TimeDerivStrahlkorper", "[Unit]") {
+  test_time_deriv_strahlkorper();
+}
+
+}  // namespace

--- a/tests/Unit/NumericalAlgorithms/FiniteDifference/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/FiniteDifference/CMakeLists.txt
@@ -13,6 +13,7 @@ set(LIBRARY_SOURCES
   Test_MonotonicityPreserving5.cpp
   Test_MonotonisedCentral.cpp
   Test_NeighborDataAsVariables.cpp
+  Test_NonUniform1D.cpp
   Test_PartialDerivatives.cpp
   Test_PositivityPreservingAdaptiveOrder.cpp
   Test_Unlimited.cpp

--- a/tests/Unit/NumericalAlgorithms/FiniteDifference/Test_NonUniform1D.cpp
+++ b/tests/Unit/NumericalAlgorithms/FiniteDifference/Test_NonUniform1D.cpp
@@ -1,0 +1,87 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <deque>
+
+#include "NumericalAlgorithms/FiniteDifference/NonUniform1D.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace {
+
+template <size_t StencilSize>
+void test_impl() {
+  std::deque<double> times{};
+  times.emplace_front(4.0);
+  times.emplace_back(3.0);
+  if constexpr (StencilSize > 2) {
+    times.emplace_back(2.5);
+    if constexpr (StencilSize > 3) {
+      times.emplace_back(0.5);
+    }
+  }
+
+  const auto weights = fd::non_uniform_1d_weights<StencilSize>(times);
+
+  std::array<double, StencilSize> zeroth_weights{};
+  gsl::at(zeroth_weights, 0) = 1.0;
+  // All stencil sizes have this as the zeroth values
+  CHECK(gsl::at(weights, 0) == zeroth_weights);
+
+  if constexpr (StencilSize == 2) {
+    CHECK_ITERABLE_APPROX(gsl::at(weights, 1), (std::array{1.0, -1.0}));
+  } else if constexpr (StencilSize == 3) {
+    CHECK_ITERABLE_APPROX(gsl::at(weights, 1),
+                          (std::array{5.0 / 3.0, -3.0, 4.0 / 3.0}));
+    CHECK_ITERABLE_APPROX(gsl::at(weights, 2),
+                          (std::array{4.0 / 3.0, -4.0, 8.0 / 3.0}));
+  } else if constexpr (StencilSize == 4) {
+    CHECK_ITERABLE_APPROX(
+        gsl::at(weights, 1),
+        (std::array{41.0 / 21.0, -21.0 / 5.0, 7.0 / 3.0, -3.0 / 35.0}));
+    CHECK_ITERABLE_APPROX(gsl::at(weights, 2),
+                          (std::array{16.0 / 7.0, -8.0, 6.0, -2.0 / 7.0}));
+    CHECK_ITERABLE_APPROX(
+        gsl::at(weights, 3),
+        (std::array{8.0 / 7.0, -24.0 / 5.0, 4.0, -12.0 / 35.0}));
+  }
+}
+
+template <size_t StencilSize>
+void test_errors() {
+#ifdef SPECTRE_DEBUG
+  std::deque<double> times{};
+  times.emplace_front(1.0);
+
+  CHECK_THROWS_WITH(fd::non_uniform_1d_weights<StencilSize>(times),
+                    Catch::Contains("The size of the times passed in"));
+
+  times.emplace_back(2.0);
+  if constexpr (StencilSize > 2) {
+    times.emplace_back(0.5);
+    if constexpr (StencilSize > 3) {
+      times.emplace_back(0.3);
+    }
+  }
+
+  CHECK_THROWS_WITH(fd::non_uniform_1d_weights<StencilSize>(times),
+                    Catch::Contains("Times must be monotonically decreasing"));
+#endif
+}
+
+template <size_t StencilSize>
+void test() {
+  test_impl<StencilSize>();
+  test_errors<StencilSize>();
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.FiniteDifference.NonUniform1D",
+                  "[Unit][NumericalAlgorithms]") {
+  test<2>();
+  test<3>();
+  test<4>();
+}


### PR DESCRIPTION
## Proposed changes

This is needed for size control. Part of #4592.

Since the previous horizon finds aren't evenly spaced, we need a FD stencil that can handle non-uniformly spaced times. The control system Averager has this internally. So this PR also factors that code out into its own function first, so it can be used in both places.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
