### PR TITLE
Transform time derivative of regular field to grid frame

### DIFF
--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/ElementActions/ReceiveWorldtubeData.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/ElementActions/ReceiveWorldtubeData.hpp
@@ -99,8 +99,12 @@ struct ReceiveWorldtubeData {
       auto& received_data = inbox.at(time_step_id);
       get(get<psi_tag>(received_data)) +=
           get(get<psi_tag>(puncture_field.value()));
+
+      // the advective term transforms the time derivative back into the
+      // inertial frame
       get(get<dt_psi_tag>(received_data)) +=
-          get(get<dt_psi_tag>(puncture_field.value()));
+          get(get<dt_psi_tag>(puncture_field.value())) -
+          get(get<Tags::RegularFieldAdvectiveTerm<Dim>>(box));
 
       db::mutate<Tags::WorldtubeSolution<Dim>>(
           make_not_null(&box),

--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/Tags.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/Tags.hpp
@@ -271,6 +271,15 @@ struct PunctureFieldCompute : PunctureField<Dim>, db::ComputeTag {
 /// @}
 
 /*!
+ * \brief Holds the advection term that is the scalar product of the
+ * mesh velocity with the spatial derivative of the regular scalar field.
+ */
+template <size_t Dim>
+struct RegularFieldAdvectiveTerm : db::SimpleTag {
+  using type = Scalar<DataVector>;
+};
+
+/*!
  * \brief A map that holds the grid coordinates centered on the worldtube of
  * all element faces abutting the worldtube with the corresponding ElementIds.
  */

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/ElementActions/Test_ReceiveWorldtubeData.cpp
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/ElementActions/Test_ReceiveWorldtubeData.cpp
@@ -65,7 +65,8 @@ struct MockElementArray {
                   gr::Tags::Lapse<DataVector>,
                   domain::Tags::InverseJacobian<Dim, Frame::Grid,
                                                 Frame::Inertial>,
-                  ::Tags::TimeStepId, Tags::WorldtubeSolution<Dim>>,
+                  ::Tags::TimeStepId, Tags::RegularFieldAdvectiveTerm<Dim>,
+                  Tags::WorldtubeSolution<Dim>>,
               db::AddComputeTags<>>>>,
       Parallel::PhaseActions<Parallel::Phase::Testing,
                              tmpl::list<Actions::ReceiveWorldtubeData>>>;
@@ -173,13 +174,15 @@ SPECTRE_TEST_CASE("Unit.CurvedScalarWave.Worldtube.ReceiveWorldtubeData",
           excision_sphere.abutting_direction(element_id).has_value()
               ? std::make_optional<puncture_field_type>(puncture_field)
               : std::nullopt;
+
+      Scalar<DataVector> advective_term(face_size, 0.);
       ActionTesting::emplace_array_component_and_initialize<element_chare>(
           &runner, ActionTesting::NodeId{0}, ActionTesting::LocalCoreId{0},
           element_id,
           {std::move(element), std::move(mesh),
            std::move(optional_puncture_field), std::move(shift),
            std::move(lapse), std::move(grid_inv_jacobian), dummy_time_step_id,
-           worldtube_solution});
+           std::move(advective_term), worldtube_solution});
     }
 
     std::unordered_map<ElementId<Dim>, tnsr::I<DataVector, Dim, Frame::Grid>>

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/Test_Tags.cpp
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/Test_Tags.cpp
@@ -460,7 +460,8 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.CurvedScalarWave.Worldtube.Tags",
   TestHelpers::db::test_simple_tag<Tags::PunctureField<3>>("PunctureField");
   TestHelpers::db::test_simple_tag<
       Tags::CheckInputFile<3, gr::Solutions::KerrSchild>>("CheckInputFile");
-
+  TestHelpers::db::test_simple_tag<Tags::RegularFieldAdvectiveTerm<3>>(
+      "RegularFieldAdvectiveTerm");
   test_excision_sphere_tag();
   test_compute_face_coordinates_grid();
   test_compute_face_coordinates();


### PR DESCRIPTION
## Proposed changes
This transforms the time derivative of the regular field to the grid frame before sending it to the worldtube. The advective term needed for this is stored in an extra tag which is used to transform the worldtube solution back to the inertial frame before applying boundary conditions to the elements.

For the 0th and 1st order this does not matter but for 2nd order evolution this is required.
