### PR TITLE
Register BNS observers with Factory

### DIFF
--- a/src/PointwiseFunctions/Hydro/MassWeightedFluidItems.cpp
+++ b/src/PointwiseFunctions/Hydro/MassWeightedFluidItems.cpp
@@ -15,10 +15,11 @@ namespace hydro {
 template <typename DataType, size_t Dim, typename Frame>
 void u_lower_t(const gsl::not_null<Scalar<DataType>*> result,
                const Scalar<DataType>& lorentz_factor,
-               const tnsr::i<DataType, Dim, Frame>& spatial_velocity_one_form,
+               const tnsr::I<DataType, Dim, Frame>& spatial_velocity,
+               const tnsr::ii<DataType, Dim, Frame>& spatial_metric,
                const Scalar<DataType>& lapse,
                const tnsr::I<DataType, Dim, Frame>& shift) {
-  dot_product(result, spatial_velocity_one_form, shift);
+  dot_product(result, spatial_velocity, shift, spatial_metric);
   result->get() = get(lorentz_factor) * (get(lapse) * (-1.0) + result->get());
 }
 
@@ -41,29 +42,31 @@ template <typename DataType, size_t Dim, typename Fr>
 void tilde_d_unbound_ut_criterion(
     const gsl::not_null<Scalar<DataType>*> result,
     const Scalar<DataType>& tilde_d, const Scalar<DataType>& lorentz_factor,
-    const tnsr::i<DataType, Dim, Fr>& spatial_velocity_one_form,
+    const tnsr::I<DataType, Dim, Fr>& spatial_velocity,
+    const tnsr::ii<DataType, Dim, Fr>& spatial_metric,
     const Scalar<DataType>& lapse, const tnsr::I<DataType, Dim, Fr>& shift) {
-  u_lower_t(result, lorentz_factor, spatial_velocity_one_form, lapse, shift);
+  u_lower_t(result, lorentz_factor, spatial_velocity, spatial_metric, lapse,
+            shift);
   result->get() = get(tilde_d) * step_function(-1.0 - result->get());
 }
 
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 
-#define INSTANTIATE(_, data)                                         \
-  template void u_lower_t(                                           \
-      const gsl::not_null<Scalar<DataVector>*> result,               \
-      const Scalar<DataVector>& lorentz_factor,                      \
-      const tnsr::i<DataVector, DIM(data), Frame::Inertial>&         \
-          spatial_velocity_one_form,                                 \
-      const Scalar<DataVector>& lapse,                               \
-      const tnsr::I<DataVector, DIM(data), Frame::Inertial>& shift); \
-  template void tilde_d_unbound_ut_criterion(                        \
-      const gsl::not_null<Scalar<DataVector>*> result,               \
-      const Scalar<DataVector>& tilde_d,                             \
-      const Scalar<DataVector>& lorentz_factor,                      \
-      const tnsr::i<DataVector, DIM(data), Frame::Inertial>&         \
-          spatial_velocity_one_form,                                 \
-      const Scalar<DataVector>& lapse,                               \
+#define INSTANTIATE(_, data)                                                   \
+  template void u_lower_t(                                                     \
+      const gsl::not_null<Scalar<DataVector>*> result,                         \
+      const Scalar<DataVector>& lorentz_factor,                                \
+      const tnsr::I<DataVector, DIM(data), Frame::Inertial>& spatial_velocity, \
+      const tnsr::ii<DataVector, DIM(data), Frame::Inertial>& spatial_metric,  \
+      const Scalar<DataVector>& lapse,                                         \
+      const tnsr::I<DataVector, DIM(data), Frame::Inertial>& shift);           \
+  template void tilde_d_unbound_ut_criterion(                                  \
+      const gsl::not_null<Scalar<DataVector>*> result,                         \
+      const Scalar<DataVector>& tilde_d,                                       \
+      const Scalar<DataVector>& lorentz_factor,                                \
+      const tnsr::I<DataVector, DIM(data), Frame::Inertial>& spatial_velocity, \
+      const tnsr::ii<DataVector, DIM(data), Frame::Inertial>& spatial_metric,  \
+      const Scalar<DataVector>& lapse,                                         \
       const tnsr::I<DataVector, DIM(data), Frame::Inertial>& shift);
 
 GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))

--- a/src/PointwiseFunctions/Hydro/MassWeightedFluidItems.hpp
+++ b/src/PointwiseFunctions/Hydro/MassWeightedFluidItems.hpp
@@ -68,7 +68,8 @@ template <typename DataType, size_t Dim, typename Fr = Frame::Inertial>
 void tilde_d_unbound_ut_criterion(
     const gsl::not_null<Scalar<DataType>*> result,
     const Scalar<DataType>& tilde_d, const Scalar<DataType>& lorentz_factor,
-    const tnsr::i<DataType, Dim, Fr>& spatial_velocity_one_form,
+    const tnsr::I<DataType, Dim, Fr>& spatial_velocity,
+    const tnsr::ii<DataType, Dim, Fr>& spatial_metric,
     const Scalar<DataType>& lapse, const tnsr::I<DataType, Dim, Fr>& shift);
 
 namespace Tags {
@@ -119,7 +120,8 @@ struct TildeDUnboundUtCriterionCompute : TildeDUnboundUtCriterion<DataType>,
                                          db::ComputeTag {
   using argument_tags =
       tmpl::list<grmhd::ValenciaDivClean::Tags::TildeD, LorentzFactor<DataType>,
-                 SpatialVelocityOneForm<DataType, Dim, Fr>,
+                 SpatialVelocity<DataType, Dim, Fr>,
+                 gr::Tags::SpatialMetric<DataType, Dim, Fr>,
                  gr::Tags::Lapse<DataType>, gr::Tags::Shift<DataType, Dim, Fr>>;
 
   using return_type = Scalar<DataType>;
@@ -129,7 +131,8 @@ struct TildeDUnboundUtCriterionCompute : TildeDUnboundUtCriterion<DataType>,
   static constexpr auto function = static_cast<void (*)(
       const gsl::not_null<Scalar<DataType>*> result,
       const Scalar<DataType>& tilde_d, const Scalar<DataType>& lorentz_factor,
-      const tnsr::i<DataType, Dim, Fr>& spatial_velocity_one_form,
+      const tnsr::I<DataType, Dim, Fr>& spatial_velocity,
+      const tnsr::ii<DataType, Dim, Fr>& spacial_metric,
       const Scalar<DataType>& lapse, const tnsr::I<DataType, Dim, Fr>& shift)>(
       &tilde_d_unbound_ut_criterion<DataType, Dim, Fr>);
 };

--- a/tests/Unit/PointwiseFunctions/Hydro/TestFunctions.py
+++ b/tests/Unit/PointwiseFunctions/Hydro/TestFunctions.py
@@ -14,9 +14,10 @@ def mass_weighted_kinetic_energy(tilde_d, lorentz_factor):
     return tilde_d * (lorentz_factor - 1.0)
 
 
-def tilde_d_unbound_ut_criterion(tilde_d, lorentz_factor,
-                                 spatial_velocity_one_form, lapse, shift):
-    shift_dot_velocity = np.dot(spatial_velocity_one_form, shift)
+def tilde_d_unbound_ut_criterion(tilde_d, lorentz_factor, spatial_velocity,
+                                 spatial_metric, lapse, shift):
+    shift_dot_velocity = np.einsum("ab, ab", spatial_metric,
+                                   np.outer(spatial_velocity, shift))
     u_t = lorentz_factor * (-lapse + shift_dot_velocity)
     return tilde_d * (u_t < -1.0)
 


### PR DESCRIPTION
## Proposed changes

Modifications needed to use BNS observers within spectre evolutions

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

A few modifications where needed in order to make it possible to use the new observers and the integrals of conserved quantities in BNS evolution.

(1) Adding the new observers to the list of observers in GhValenciaDivCleanBase.hpp
(2) Adding the tags that we would like to integrate for diagnostics purposes (e.g. MassWeightedInternalEnergyCompute) to the observe_field list in GhValenciaDivCleanBase.hpp (should we instead have a variable elsewhere in the code with the list of integrands we want to use?)
(3) Because SpatialVelocityOneForm is not at this point a db::ComputeTag and it is not stored in memory, I changed the input of an integrand from "SpatialVelocityOneForm" to "SpatialVelocity" and "SpatialMetric" and modified the relevant tests.
(4) Create an integrand_list variable containing the tags to be used in the VolumeIntegral observer (we can't input all tags, because the current version of VolumeIntegral does not handle optionals... and there are a lot of tensors there whose integral is pretty meaningless anyways)