### PR TITLE
Add InitializeSpacetimeTags mutator

### DIFF
--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonActions/CMakeLists.txt
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonActions/CMakeLists.txt
@@ -5,6 +5,7 @@
 spectre_target_sources(
   ${LIBRARY}
   PRIVATE
+  InitializeSpacetimeTags.cpp
   TimeDerivative.cpp
   )
 
@@ -15,6 +16,7 @@ spectre_target_headers(
   ChangeSlabSize.hpp
   InitializeElementFacesGridCoordinates.hpp
   InitializeEvolvedVariables.hpp
+  InitializeSpacetimeTags.hpp
   ReceiveElementData.hpp
   SendToElements.hpp
   TimeDerivative.hpp

--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonActions/InitializeSpacetimeTags.cpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonActions/InitializeSpacetimeTags.cpp
@@ -1,0 +1,43 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/CurvedScalarWave/Worldtube/SingletonActions/InitializeSpacetimeTags.hpp"
+
+#include <cstddef>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace CurvedScalarWave::Worldtube::Initialization {
+
+void InitializeSpacetimeTags::apply(
+    const gsl::not_null<tnsr::AA<double, Dim, Frame::Grid>*>
+        inverse_spacetime_metric,
+    const gsl::not_null<tnsr::A<double, Dim, Frame::Grid>*>
+        trace_spacetime_christoffel,
+    const ExcisionSphere<Dim>& excision_sphere) {
+  const double M = 1.;
+  const double orbit_radius = get(magnitude(excision_sphere.center()));
+  *inverse_spacetime_metric = tnsr::AA<double, Dim, Frame::Grid>(0.);
+  get<0, 0>(*inverse_spacetime_metric) = -1. - 2. * M / orbit_radius;
+  get<1, 1>(*inverse_spacetime_metric) = 1. - 2. * M / orbit_radius;
+  get<2, 2>(*inverse_spacetime_metric) =
+      (-2. * M + square(orbit_radius) - orbit_radius) / square(orbit_radius);
+  get<3, 3>(*inverse_spacetime_metric) = 1.;
+  get<0, 1>(*inverse_spacetime_metric) = 2. * M / orbit_radius;
+  get<2, 0>(*inverse_spacetime_metric) =
+      (2. * M + orbit_radius) / (orbit_radius * sqrt(orbit_radius));
+  get<2, 1>(*inverse_spacetime_metric) =
+      -2. * M / (orbit_radius * sqrt(orbit_radius));
+
+  get<0>(*trace_spacetime_christoffel) = -2. * M / square(orbit_radius);
+  get<1>(*trace_spacetime_christoffel) =
+      -(2. * M + orbit_radius - 2. * M * orbit_radius) / cube(orbit_radius);
+  get<2>(*trace_spacetime_christoffel) =
+      6. * M / (square(orbit_radius) * sqrt(orbit_radius));
+  get<3>(*trace_spacetime_christoffel) = 0.;
+}
+}  // namespace CurvedScalarWave::Worldtube::Initialization

--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonActions/InitializeSpacetimeTags.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonActions/InitializeSpacetimeTags.hpp
@@ -1,0 +1,48 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Evolution/Systems/CurvedScalarWave/Worldtube/Tags.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace CurvedScalarWave::Worldtube::Initialization {
+
+/*!
+ * \brief Initializes the inverse spacetime metric and trace of the spacetime
+ * christoffel symbol in the co-rotating grid frame at the position of the
+ * scalar charge.
+ *
+ * \details This assumes a circular orbit so the spacetime quantities are
+ * constant in the co-rotating grid frame due to the spherical symmetry of the
+ * background spacetime. The mass of the central, non-spinning black hole is
+ * hard-coded to be 1 and. For non-circular orbits, this should probably be a
+ * compute tag that computes the background quantities at the current
+ * coordinates of the scalar charge each time step.
+ */
+struct InitializeSpacetimeTags {
+  static constexpr size_t Dim = 3;
+
+  using compute_tags = tmpl::list<>;
+  using simple_tags_from_options = tmpl::list<Tags::ExcisionSphere<Dim>>;
+  using const_global_cache_tags = tmpl::list<>;
+  using mutable_global_cache_tags = tmpl::list<>;
+  using argument_tags = simple_tags_from_options;
+  using simple_tags = tmpl::list<
+      gr::Tags::InverseSpacetimeMetric<Dim, Frame::Grid, double>,
+      gr::Tags::TraceSpacetimeChristoffelSecondKind<Dim, Frame::Grid, double>>;
+  using return_tags = simple_tags;
+
+  static void apply(const gsl::not_null<tnsr::AA<double, Dim, Frame::Grid>*>
+                        inverse_spacetime_metric,
+                    const gsl::not_null<tnsr::A<double, Dim, Frame::Grid>*>
+                        trace_spacetime_christoffel,
+                    const ExcisionSphere<Dim>& excision_sphere);
+};
+}  // namespace CurvedScalarWave::Worldtube::Initialization

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/CMakeLists.txt
@@ -24,6 +24,7 @@ set(LIBRARY_SOURCES
   Worldtube/SingletonActions/Test_ChangeSlabSize.cpp
   Worldtube/SingletonActions/Test_InitializeElementFacesGridCoordinates.cpp
   Worldtube/SingletonActions/Test_InitializeEvolvedVariables.cpp
+  Worldtube/SingletonActions/Test_InitializeSpacetimeTags.cpp
   Worldtube/SingletonActions/Test_TimeDerivative.cpp
   )
 

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonActions/Test_InitializeSpacetimeTags.cpp
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonActions/Test_InitializeSpacetimeTags.cpp
@@ -1,0 +1,128 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp"
+#include "Domain/Structure/ExcisionSphere.hpp"
+#include "Evolution/Systems/CurvedScalarWave/Worldtube/SingletonActions/InitializeSpacetimeTags.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Christoffel.hpp"
+#include "PointwiseFunctions/GeneralRelativity/DerivativesOfSpacetimeMetric.hpp"
+#include "PointwiseFunctions/GeneralRelativity/InverseSpacetimeMetric.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeArray.hpp"
+
+namespace CurvedScalarWave::Worldtube {
+namespace {
+
+SPECTRE_TEST_CASE(
+    "Unit.Evolution.Systems.CSW.Worldtube.InitializeSpacetimeTags",
+    "[Unit][Evolution]") {
+  for (const double orbital_radius :
+       make_array<double>(2.5, 3., 5., 6.1234, 15., 173.6)) {
+    CAPTURE(orbital_radius);
+    static constexpr size_t Dim = 3;
+    const double angular_velocity =
+        1. / (orbital_radius * sqrt(orbital_radius));
+    const tnsr::I<double, Dim, Frame::Grid> wt_center{{orbital_radius, 0., 0.}};
+    auto box = db::create<db::AddSimpleTags<
+        gr::Tags::InverseSpacetimeMetric<Dim, Frame::Grid, double>,
+        gr::Tags::TraceSpacetimeChristoffelSecondKind<Dim, Frame::Grid, double>,
+        Tags::ExcisionSphere<Dim>>>(tnsr::AA<double, Dim, Frame::Grid>{},
+                                    tnsr::A<double, Dim, Frame::Grid>{},
+                                    ExcisionSphere<Dim>(1., wt_center, {}));
+
+    db::mutate_apply<Initialization::InitializeSpacetimeTags>(
+        make_not_null(&box));
+
+    const gr::Solutions::KerrSchild kerr_schild(1., {0., 0., 0.}, {0., 0., 0.});
+    using background_tags = tmpl::list<
+        gr::Tags::Lapse<double>, ::Tags::dt<gr::Tags::Lapse<double>>,
+        ::Tags::deriv<gr::Tags::Lapse<double>, tmpl::size_t<Dim>, Frame::Grid>,
+        gr::Tags::Shift<Dim, Frame::Grid, double>,
+        ::Tags::dt<gr::Tags::Shift<Dim, Frame::Grid, double>>,
+        ::Tags::deriv<gr::Tags::Shift<Dim, Frame::Grid, double>,
+                      tmpl::size_t<Dim>, Frame::Grid>,
+        gr::Tags::SpatialMetric<Dim, Frame::Grid, double>,
+        gr::Tags::InverseSpatialMetric<Dim, Frame::Grid, double>,
+        ::Tags::dt<gr::Tags::SpatialMetric<Dim, Frame::Grid, double>>,
+        ::Tags::deriv<gr::Tags::SpatialMetric<Dim, Frame::Grid, double>,
+                      tmpl::size_t<Dim>, Frame::Grid>>;
+    const auto background_vars =
+        kerr_schild.variables(wt_center, 0., background_tags{});
+
+    const auto inverse_metric = gr::inverse_spacetime_metric(
+        get<gr::Tags::Lapse<double>>(background_vars),
+        get<gr::Tags::Shift<Dim, Frame::Grid, double>>(background_vars),
+        get<gr::Tags::InverseSpatialMetric<Dim, Frame::Grid, double>>(
+            background_vars));
+
+    // jacobian and hessian to transform into a frame co-rotating about the
+    // z-axis evaluated at (t,x,y,z) = (0,R,0,0)
+    tnsr::Ab<double, Dim, Frame::Grid> jacobian(0.);
+    for (size_t i = 0; i < 4; ++i) {
+      jacobian.get(i, i) = 1.;
+    }
+    get<2, 0>(jacobian) = -orbital_radius * angular_velocity;
+
+    tnsr::AA<double, Dim, Frame::Grid> boosted_inverse_metric{};
+    tenex::evaluate<ti::A, ti::B>(make_not_null(&boosted_inverse_metric),
+                                  jacobian(ti::A, ti::c) *
+                                      jacobian(ti::B, ti::d) *
+                                      inverse_metric(ti::C, ti::D));
+    const auto& inverse_spacetime_metric =
+        get<gr::Tags::InverseSpacetimeMetric<Dim, Frame::Grid, double>>(box);
+    CHECK_ITERABLE_APPROX(boosted_inverse_metric, inverse_spacetime_metric);
+
+    tnsr::Abb<double, Dim, Frame::Grid> inverse_hessian(0.);
+    get<1, 0, 0>(inverse_hessian) =
+        -angular_velocity * angular_velocity * orbital_radius;
+    get<1, 0, 2>(inverse_hessian) = -angular_velocity;
+    get<2, 0, 1>(inverse_hessian) = angular_velocity;
+
+    const auto d_spacetime_metric = gr::derivatives_of_spacetime_metric(
+        get<gr::Tags::Lapse<double>>(background_vars),
+        get<::Tags::dt<gr::Tags::Lapse<double>>>(background_vars),
+        get<::Tags::deriv<gr::Tags::Lapse<double>, tmpl::size_t<Dim>,
+                          Frame::Grid>>(background_vars),
+        get<gr::Tags::Shift<Dim, Frame::Grid, double>>(background_vars),
+        get<::Tags::dt<gr::Tags::Shift<Dim, Frame::Grid, double>>>(
+            background_vars),
+        get<::Tags::deriv<gr::Tags::Shift<Dim, Frame::Grid, double>,
+                          tmpl::size_t<Dim>, Frame::Grid>>(background_vars),
+        get<gr::Tags::SpatialMetric<Dim, Frame::Grid, double>>(background_vars),
+        get<::Tags::dt<gr::Tags::SpatialMetric<Dim, Frame::Grid, double>>>(
+            background_vars),
+        get<::Tags::deriv<gr::Tags::SpatialMetric<Dim, Frame::Grid, double>,
+                          tmpl::size_t<Dim>, Frame::Grid>>(background_vars));
+
+    const auto christoffel =
+        gr::christoffel_second_kind(d_spacetime_metric, inverse_metric);
+
+    const auto inverse_jacobian = determinant_and_inverse(jacobian).second;
+
+    // christoffel symbol needs Hessian to transform
+    tnsr::Abb<double, Dim, Frame::Grid> boosted_christoffel{};
+    tenex::evaluate<ti::A, ti::b, ti::c>(
+        make_not_null(&boosted_christoffel),
+        jacobian(ti::A, ti::d) * inverse_jacobian(ti::E, ti::b) *
+                inverse_jacobian(ti::F, ti::c) *
+                christoffel(ti::D, ti::e, ti::f) +
+            inverse_hessian(ti::D, ti::b, ti::c) * jacobian(ti::A, ti::d));
+    const auto contracted_boosted_christoffel =
+        tenex::evaluate<ti::A>(boosted_inverse_metric(ti::B, ti::C) *
+                               boosted_christoffel(ti::A, ti::b, ti::c));
+    const auto& contracted_christoffel =
+        get<gr::Tags::TraceSpacetimeChristoffelSecondKind<Dim, Frame::Grid,
+                                                          double>>(box);
+    CHECK_ITERABLE_APPROX(contracted_christoffel,
+                          contracted_boosted_christoffel);
+  }
+}
+}  // namespace
+}  // namespace CurvedScalarWave::Worldtube


### PR DESCRIPTION
## Proposed changes
Adds a mutator that computes the inverse spacetime metric and the trace of the Christoffel symbols of the second kind. These will be needed for the 2nd order evolution of the worldtube.