### PR TITLE
Improve error messages when parsing a variant

### DIFF
--- a/tests/Unit/Options/Test_Options.cpp
+++ b/tests/Unit/Options/Test_Options.cpp
@@ -598,15 +598,22 @@ void test_options_variant() {
     }
   }
 
-  using tag = VariantTag<int, std::string>;
-  CHECK_THROWS_WITH(
-      []() {
-        Options::Parser<tmpl::list<tag>> opts("");
-        opts.parse("VariantTag: []");
-        opts.get<tag>();
-      }(),
-      Catch::Contains("While creating a variant:\nAt line 1 column 13:\nFailed "
-                      "to convert value to type int or string"));
+  {
+    using tag = VariantTag<int, std::string>;
+    CHECK_THROWS_WITH(
+        []() {
+          Options::Parser<tmpl::list<tag>> opts("");
+          opts.parse("VariantTag: []");
+          opts.get<tag>();
+        }(),
+        Catch::Contains("While creating a variant:\nAt line 1 column "
+                        "13:\nFailed to convert value to type int or string: "
+                        "[]") and
+            Catch::Contains("At line 1 column 13:\nFailed to convert value to "
+                            "type int: []") and
+            Catch::Contains("At line 1 column 13:\nFailed to convert value to "
+                            "type string: []"));
+  }
 }
 
 template <typename T>


### PR DESCRIPTION
Examples:

Parsing `std::variant<int, std::vector<int>>` from `VariantTag: X`:
```
In string:
While parsing option VariantTag:
While creating a variant:
At line 1 column 13:
Failed to convert value to type int or [int, ...]: X

Possible errors:

While creating a variant:
At line 1 column 13:
Failed to convert value to type int: X

While creating a variant:
At line 1 column 13:
Failed to convert value to type [int, ...]: X
```

Parsing two classes `std::variant<VariantOption1, VariantOption2>` taking `int`s `Opt1` and `Opt2`, respectively, from `VariantTag: X`:
```
In string:
While parsing option VariantTag:
While creating a variant:
At line 1 column 13:
'X' does not look like options.

==== Description of expected options:
VariantOption1
  VariantOption1 help

VariantOption2
  VariantOption2 help

Options:
  EITHER
    Opt1:
      type=int
      Opt1 help

  OR
    Opt2:
      type=int
      Opt2 help
```

Same type, but from
```
VariantTag:
  Opt1: X
```
gives
```
In string:
While parsing option VariantTag:
While creating a variant:
While parsing option Opt1:
At line 2 column 9:
Failed to convert value to type int: X
```
(Assumes since you passed "Opt1" that you are trying to create the first type.)

Fixes #4868.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
