### PR TITLE
Add `TimeDerivative` action to worldtube

### DIFF
--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonActions/CMakeLists.txt
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonActions/CMakeLists.txt
@@ -1,6 +1,13 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
+
+spectre_target_sources(
+  ${LIBRARY}
+  PRIVATE
+  TimeDerivative.cpp
+  )
+
 spectre_target_headers(
   ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
@@ -10,4 +17,5 @@ spectre_target_headers(
   InitializeEvolvedVariables.hpp
   ReceiveElementData.hpp
   SendToElements.hpp
+  TimeDerivative.hpp
 )

--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonActions/InitializeEvolvedVariables.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonActions/InitializeEvolvedVariables.hpp
@@ -5,6 +5,7 @@
 
 #include <cstddef>
 
+#include "DataStructures/DataBox/Prefixes.hpp"
 #include "DataStructures/Variables.hpp"
 #include "DataStructures/VariablesTag.hpp"
 #include "Evolution/Systems/CurvedScalarWave/Worldtube/Tags.hpp"
@@ -22,9 +23,8 @@ namespace CurvedScalarWave::Worldtube::Initialization {
  * which use the same time stepper.
  */
 struct InitializeEvolvedVariables {
-  using variables_tag = ::Tags::Variables<tmpl::list<Tags::Psi0>>;
-  using dt_variables_tag =
-      ::Tags::Variables<tmpl::list<::Tags::dt<Tags::Psi0>>>;
+  using variables_tag = ::Tags::Variables<tmpl::list<Tags::Psi0, Tags::dtPsi0>>;
+  using dt_variables_tag = db::add_tag_prefix<::Tags::dt, variables_tag>;
 
   using simple_tags =
       tmpl::list<variables_tag, dt_variables_tag,
@@ -37,9 +37,11 @@ struct InitializeEvolvedVariables {
   using mutable_global_cache_tags = tmpl::list<>;
   using argument_tags = tmpl::list<::Tags::TimeStepper<>>;
   static void apply(
-      const gsl::not_null<Variables<tmpl::list<Tags::Psi0>>*> psi0,
-      const gsl::not_null<Variables<tmpl::list<::Tags::dt<Tags::Psi0>>>*>
-          dt_psi0,
+      const gsl::not_null<Variables<tmpl::list<Tags::Psi0, Tags::dtPsi0>>*>
+          evolved_vars,
+      const gsl::not_null<Variables<
+          tmpl::list<::Tags::dt<Tags::Psi0>, ::Tags::dt<Tags::dtPsi0>>>*>
+          dt_evolved_vars,
       const gsl::not_null<::Tags::HistoryEvolvedVariables<variables_tag>::type*>
           time_stepper_history,
       const TimeStepper& time_stepper) {
@@ -48,8 +50,8 @@ struct InitializeEvolvedVariables {
     *time_stepper_history =
         typename ::Tags::HistoryEvolvedVariables<variables_tag>::type{
             starting_order};
-    psi0->initialize(size_t(1), 0.);
-    dt_psi0->initialize(size_t(1), 0.);
+    evolved_vars->initialize(size_t(1), 0.);
+    dt_evolved_vars->initialize(size_t(1), 0.);
   }
 };
 }  // namespace CurvedScalarWave::Worldtube::Initialization

--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonActions/ReceiveElementData.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonActions/ReceiveElementData.hpp
@@ -48,6 +48,9 @@ namespace CurvedScalarWave::Worldtube::Actions {
  * - Mutates:
  *    - `Stf::Tags::StfTensor<Tags::PsiWorldtube, 0, Dim, Frame::Grid>`
  *    - `Stf::Tags::StfTensor<::Tags::dt<Tags::PsiWorldtube>, 0, Dim,
+ *                                     Frame::Grid>`
+ *    - `Stf::Tags::StfTensor<Tags::PsiWorldtube, 1, Dim, Frame::Grid>`
+ *    - `Stf::Tags::StfTensor<::Tags::dt<Tags::PsiWorldtube>, 1, Dim,
                                       Frame::Grid>`
  */
 struct ReceiveElementData {

--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonActions/TimeDerivative.cpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonActions/TimeDerivative.cpp
@@ -1,0 +1,55 @@
+
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/CurvedScalarWave/Worldtube/SingletonActions/TimeDerivative.hpp"
+
+#include <cstddef>
+
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Evolution/Systems/CurvedScalarWave/Worldtube/Tags.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/Tags.hpp"
+#include "Parallel/AlgorithmExecution.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "Time/Tags.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace CurvedScalarWave::Worldtube {
+
+void TimeDerivativeMutator::apply(
+    const gsl::not_null<Variables<
+        tmpl::list<::Tags::dt<Tags::Psi0>, ::Tags::dt<Tags::dtPsi0>>>*>
+        dt_evolved_vars,
+    const Variables<tmpl::list<Tags::Psi0, Tags::dtPsi0>>& evolved_vars,
+    const Scalar<double>& psi_monopole,
+    const tnsr::i<double, Dim, Frame::Grid>& psi_dipole,
+    const tnsr::ii<double, Dim, Frame::Grid>& psi_quadrupole,
+    const tnsr::i<double, Dim, Frame::Grid>& dt_psi_dipole,
+    const tnsr::AA<double, Dim, Frame::Grid>& inverse_spacetime_metric,
+    const tnsr::A<double, Dim, Frame::Grid>& trace_spacetime_christoffel,
+    const ExcisionSphere<Dim>& excision_sphere) {
+  const double wt_radius = excision_sphere.radius();
+  const auto& psi0 = get(get<Tags::Psi0>(evolved_vars));
+  const auto& dt_psi0 = get(get<Tags::dtPsi0>(evolved_vars));
+  get(get<::Tags::dt<Tags::Psi0>>(*dt_evolved_vars)) = dt_psi0;
+  double trace_inverse_spatial_metric = 0.;
+  auto& dt2_psi0 = get(get<::Tags::dt<Tags::dtPsi0>>(*dt_evolved_vars));
+  dt2_psi0 = get<0>(trace_spacetime_christoffel) * dt_psi0;
+  for (size_t i = 0; i < Dim; ++i) {
+    dt2_psi0 -=
+        2. * inverse_spacetime_metric.get(0, i + 1) * dt_psi_dipole.get(i);
+    dt2_psi0 += trace_spacetime_christoffel.get(i + 1) * psi_dipole.get(i);
+    trace_inverse_spatial_metric += inverse_spacetime_metric.get(i + 1, i + 1);
+    for (size_t j = 0; j < 3; ++j) {
+      dt2_psi0 -= 2. * inverse_spacetime_metric.get(i + 1, j + 1) *
+                  psi_quadrupole.get(i, j);
+    }
+  }
+  dt2_psi0 -= 2. * trace_inverse_spatial_metric * (get(psi_monopole) - psi0) /
+              (wt_radius * wt_radius);
+  dt2_psi0 /= inverse_spacetime_metric.get(0, 0);
+}
+
+}  // namespace CurvedScalarWave::Worldtube

--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonActions/TimeDerivative.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonActions/TimeDerivative.hpp
@@ -1,0 +1,108 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/Tags.hpp"
+#include "Evolution/Systems/CurvedScalarWave/Worldtube/Tags.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/Tags.hpp"
+#include "Parallel/AlgorithmExecution.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace CurvedScalarWave::Worldtube {
+
+/// @{
+/*!
+ * \brief Calculates the time derivative of `Psi0`, the constant coefficient of
+ * the expansion of `Psi`.
+ *
+ * \details The derivation comes from expanding the scalar wave equation to
+ * second order and reads
+ *
+ * \f{equation}
+ * g^{00}_0 \ddot{\Psi}^R_0(t_s) + 2 g_0^{0i}
+ * \dot{\Psi}^N_i(t_s) + 2 g_0^{ij} \Psi^N_{\langle ij \rangle}(t_s)
+ * + \frac{2 \delta_{ij}  g_0^{ij}}{R^2}
+ * \left(\Psi^N_0(t_s) - \Psi^R_0(t_s) \right) -
+ * \Gamma_0^0\dot{\Psi}R_0(t_s) -  \Gamma_0^i \Psi_i^N(t_s) = 0.
+ *\f}
+ *
+ * Here, \f$ \Gamma^\mu_0 \f$ and \f$ g^{\mu \nu}_0 \f$ are the trace of the
+ * spacetime Christoffel symbol and the inverse spacetime metric, respectively,
+ * evaluated at the position of the particle; \f$\Psi^N_0\f$, \f$\Psi^N_i\f$,
+ * \f$\Psi^N_\langle i j \rangle\f$ are the monopole, dipole and quadrupole of
+ * the regular field on the worldtube boundary transformed to symmetric
+ * trace-free tensors and \f$ R\f$ is the worldtube radius.
+ */
+struct TimeDerivativeMutator {
+  static constexpr size_t Dim = 3;
+
+  using variables_tag = ::Tags::Variables<tmpl::list<Tags::Psi0, Tags::dtPsi0>>;
+  using dt_variables_tag = db::add_tag_prefix<::Tags::dt, variables_tag>;
+  using return_tags = tmpl::list<dt_variables_tag>;
+  using argument_tags = tmpl::list<
+      variables_tag,
+      Stf::Tags::StfTensor<Tags::PsiWorldtube, 0, Dim, Frame::Grid>,
+      Stf::Tags::StfTensor<Tags::PsiWorldtube, 1, Dim, Frame::Grid>,
+      Stf::Tags::StfTensor<Tags::PsiWorldtube, 2, Dim, Frame::Grid>,
+      Stf::Tags::StfTensor<::Tags::dt<Tags::PsiWorldtube>, 1, Dim, Frame::Grid>,
+      gr::Tags::InverseSpacetimeMetric<Dim, Frame::Grid, double>,
+      gr::Tags::TraceSpacetimeChristoffelSecondKind<Dim, Frame::Grid, double>,
+      Tags::ExcisionSphere<Dim>>;
+
+  static void apply(
+      const gsl::not_null<Variables<
+          tmpl::list<::Tags::dt<Tags::Psi0>, ::Tags::dt<Tags::dtPsi0>>>*>
+          dt_evolved_vars,
+      const Variables<tmpl::list<Tags::Psi0, Tags::dtPsi0>>& evolved_vars,
+      const Scalar<double>& psi_monopole,
+      const tnsr::i<double, Dim, Frame::Grid>& psi_dipole,
+      const tnsr::ii<double, Dim, Frame::Grid>& psi_quadrupole,
+      const tnsr::i<double, Dim, Frame::Grid>& dt_psi_dipole,
+      const tnsr::AA<double, Dim, Frame::Grid>& inverse_spacetime_metric,
+      const tnsr::A<double, Dim, Frame::Grid>& trace_spacetime_christoffel,
+      const ExcisionSphere<Dim>& excision_sphere);
+};
+
+namespace Actions {
+struct ComputeTimeDerivative {
+  static constexpr size_t Dim = 3;
+  using variables_tag = ::Tags::Variables<tmpl::list<Tags::Psi0, Tags::dtPsi0>>;
+  using dt_variables_tag = db::add_tag_prefix<::Tags::dt, variables_tag>;
+  using simple_tags = tmpl::list<
+      dt_variables_tag, variables_tag,
+      Stf::Tags::StfTensor<Tags::PsiWorldtube, 0, Dim, Frame::Grid>,
+      Stf::Tags::StfTensor<Tags::PsiWorldtube, 1, Dim, Frame::Grid>,
+      Stf::Tags::StfTensor<Tags::PsiWorldtube, 2, Dim, Frame::Grid>,
+      Stf::Tags::StfTensor<::Tags::dt<Tags::PsiWorldtube>, 1, Dim, Frame::Grid>,
+      gr::Tags::InverseSpacetimeMetric<Dim, Frame::Grid, double>,
+      gr::Tags::TraceSpacetimeChristoffelSecondKind<Dim, Frame::Grid, double>,
+      Tags::ExcisionSphere<Dim>>;
+
+  template <typename DbTagsList, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent>
+  static Parallel::iterable_action_return_t apply(
+      db::DataBox<DbTagsList>& box,
+      tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+      Parallel::GlobalCache<Metavariables>& /*cache*/,
+      const ArrayIndex& /*array_index*/, ActionList /*meta*/,
+      const ParallelComponent* /*meta*/) {
+    if (db::get<Tags::ExpansionOrder>(box) >= 2) {
+      db::mutate_apply<TimeDerivativeMutator>(make_not_null(&box));
+    }
+    return {Parallel::AlgorithmExecution::Continue, std::nullopt};
+  }
+};
+/// @}
+
+}  // namespace Actions
+}  // namespace CurvedScalarWave::Worldtube

--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonChare.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonChare.hpp
@@ -58,7 +58,8 @@ struct WorldtubeSingleton {
   struct worldtube_system {
     static constexpr size_t volume_dim = Dim;
     static constexpr bool has_primitive_and_conservative_vars = false;
-    using variables_tag = ::Tags::Variables<tmpl::list<Tags::Psi0>>;
+    using variables_tag =
+        ::Tags::Variables<tmpl::list<Tags::Psi0, Tags::dtPsi0>>;
   };
   using step_actions =
       tmpl::list<Actions::ChangeSlabSize, Actions::ReceiveElementData,

--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/Tags.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/Tags.hpp
@@ -324,5 +324,13 @@ struct Psi0 : db::SimpleTag {
   using type = Scalar<DataVector>;
 };
 
+/*!
+ * \brief Holds the time derivative of Psi0 which is used as a reduction
+ * variable.
+ */
+struct dtPsi0 : db::SimpleTag {
+  using type = Scalar<DataVector>;
+};
+
 }  // namespace Tags
 }  // namespace CurvedScalarWave::Worldtube

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/CMakeLists.txt
@@ -24,6 +24,7 @@ set(LIBRARY_SOURCES
   Worldtube/SingletonActions/Test_ChangeSlabSize.cpp
   Worldtube/SingletonActions/Test_InitializeElementFacesGridCoordinates.cpp
   Worldtube/SingletonActions/Test_InitializeEvolvedVariables.cpp
+  Worldtube/SingletonActions/Test_TimeDerivative.cpp
   )
 
 add_test_library(

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonActions/Test_InitializeEvolvedVariables.cpp
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonActions/Test_InitializeEvolvedVariables.cpp
@@ -17,9 +17,8 @@ namespace {
 SPECTRE_TEST_CASE(
     "Unit.Evolution.Systems.CSW.Worldtube.InitializeEvolvedVariables",
     "[Unit][Evolution]") {
-  using variables_tag = ::Tags::Variables<tmpl::list<Tags::Psi0>>;
-  using dt_variables_tag =
-      ::Tags::Variables<tmpl::list<::Tags::dt<Tags::Psi0>>>;
+  using variables_tag = ::Tags::Variables<tmpl::list<Tags::Psi0, Tags::dtPsi0>>;
+  using dt_variables_tag = db::add_tag_prefix<::Tags::dt, variables_tag>;
 
   auto box = db::create<
       db::AddSimpleTags<variables_tag, dt_variables_tag,

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonActions/Test_TimeDerivative.cpp
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonActions/Test_TimeDerivative.cpp
@@ -1,0 +1,182 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <limits>
+#include <random>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Evolution/Systems/CurvedScalarWave/Worldtube/SingletonActions/TimeDerivative.hpp"
+#include "Evolution/Systems/CurvedScalarWave/Worldtube/SingletonChare.hpp"
+#include "Framework/ActionTesting.hpp"
+#include "Framework/CheckWithRandomValues.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "Parallel/ParallelComponentHelpers.hpp"
+#include "Parallel/Phase.hpp"
+#include "Parallel/PhaseDependentActionList.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeWithValue.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace CurvedScalarWave::Worldtube {
+namespace {
+
+template <size_t Dim>
+void time_derivative_wrapper(
+    const gsl::not_null<Scalar<double>*> dt_psi0,
+    const gsl::not_null<Scalar<double>*> dt2_psi0,
+    const Scalar<double>& psi_monopole,
+    const tnsr::i<double, Dim, Frame::Grid>& psi_dipole,
+    const tnsr::ii<double, Dim, Frame::Grid>& psi_quadrupole,
+    const tnsr::i<double, Dim, Frame::Grid>& dt_psi_dipole,
+    const tnsr::AA<double, Dim, Frame::Grid>& inverse_spacetime_metric,
+    const tnsr::A<double, Dim, Frame::Grid>& trace_christoffel,
+    const tnsr::i<double, Dim, Frame::Grid>& evolved_vars_tnsr,
+    const Scalar<double> wt_radius) {
+  // we pack the evolved_vars into a tensor so we can test it on the python
+  // side. the zeroth element of the tensor is Psi0 and the first element is
+  // dtPsi0.
+  Variables<tmpl::list<Tags::Psi0, Tags::dtPsi0>> evolved_vars(1);
+  get(get<Tags::Psi0>(evolved_vars))[0] = get<0>(evolved_vars_tnsr);
+  get(get<Tags::dtPsi0>(evolved_vars))[0] = get<1>(evolved_vars_tnsr);
+  Variables<tmpl::list<::Tags::dt<Tags::Psi0>, ::Tags::dt<Tags::dtPsi0>>>
+      dt_evolved_vars(1);
+  // only the radius is used
+  const ::ExcisionSphere<3> excision_sphere(
+      get(wt_radius), tnsr::I<double, Dim, Frame::Grid>{{0., 0., 0.}}, {});
+  TimeDerivativeMutator::apply(make_not_null(&dt_evolved_vars), evolved_vars,
+                               psi_monopole, psi_dipole, psi_quadrupole,
+                               dt_psi_dipole, inverse_spacetime_metric,
+                               trace_christoffel, excision_sphere);
+  get(*dt_psi0) = get(get<::Tags::dt<Tags::Psi0>>(dt_evolved_vars))[0];
+  get(*dt2_psi0) = get(get<::Tags::dt<Tags::dtPsi0>>(dt_evolved_vars))[0];
+}
+
+template <size_t Dim>
+void test_mutator() {
+  pypp::SetupLocalPythonEnvironment local_python_env{
+      "Evolution/Systems/CurvedScalarWave/Worldtube/SingletonActions"};
+  MAKE_GENERATOR(generator);
+  pypp::check_with_random_values<1>(&time_derivative_wrapper<Dim>,
+                                    "TimeDerivatives", {"dt_psi0", "dt2_psi0"},
+                                    {{{0.1, 1.}}}, 1, 1.e-12);
+}
+
+template <typename Metavariables>
+struct MockWorldtubeSingleton {
+  using metavariables = Metavariables;
+  static constexpr size_t Dim = metavariables::volume_dim;
+  using chare_type = ActionTesting::MockSingletonChare;
+  using array_index = int;
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<
+          Parallel::Phase::Initialization,
+          tmpl::list<ActionTesting::InitializeDataBox<
+              db::AddSimpleTags<
+                  TimeDerivativeMutator::dt_variables_tag,
+                  TimeDerivativeMutator::variables_tag,
+                  Stf::Tags::StfTensor<Tags::PsiWorldtube, 0, Dim, Frame::Grid>,
+                  Stf::Tags::StfTensor<Tags::PsiWorldtube, 1, Dim, Frame::Grid>,
+                  Stf::Tags::StfTensor<Tags::PsiWorldtube, 2, Dim, Frame::Grid>,
+                  Stf::Tags::StfTensor<::Tags::dt<Tags::PsiWorldtube>, 1, Dim,
+                                       Frame::Grid>,
+                  gr::Tags::InverseSpacetimeMetric<Dim, Frame::Grid, double>,
+                  gr::Tags::TraceSpacetimeChristoffelSecondKind<
+                      Dim, Frame::Grid, double>,
+                  Tags::ExpansionOrder, Tags::ExcisionSphere<Dim>>,
+              db::AddComputeTags<>>>>,
+      Parallel::PhaseActions<Parallel::Phase::Testing,
+                             tmpl::list<Actions::ComputeTimeDerivative>>>;
+  using component_being_mocked = WorldtubeSingleton<Metavariables>;
+};
+
+template <size_t Dim>
+struct MockMetavariables {
+  static constexpr size_t volume_dim = Dim;
+  using component_list =
+      tmpl::list<MockWorldtubeSingleton<MockMetavariables<Dim>>>;
+  using const_global_cache_tags = tmpl::list<>;
+};
+
+template <size_t Dim>
+void test_action() {
+  using dt_variables_tag = TimeDerivativeMutator::dt_variables_tag;
+  using metavars = MockMetavariables<Dim>;
+  using worldtube_chare = MockWorldtubeSingleton<metavars>;
+  MAKE_GENERATOR(generator);
+  std::uniform_real_distribution<> wt_radius_dist(0.1, 50.);
+  std::uniform_real_distribution<> tensor_dist(-1., 10.);
+  const double wt_radius = wt_radius_dist(generator);
+
+  const ::ExcisionSphere<3> excision_sphere(
+      wt_radius, tnsr::I<double, Dim, Frame::Grid>{{0., 0., 0.}}, {});
+
+  const auto psi_monopole = make_with_random_values<Scalar<double>>(
+      make_not_null(&generator), make_not_null(&tensor_dist), 1);
+  const auto psi_dipole =
+      make_with_random_values<tnsr::i<double, Dim, Frame::Grid>>(
+          make_not_null(&generator), make_not_null(&tensor_dist), 1);
+  const auto psi_quadrupole =
+      make_with_random_values<tnsr::ii<double, Dim, Frame::Grid>>(
+          make_not_null(&generator), make_not_null(&tensor_dist), 1);
+  const auto dt_psi_dipole =
+      make_with_random_values<tnsr::i<double, Dim, Frame::Grid>>(
+          make_not_null(&generator), make_not_null(&tensor_dist), 1);
+  const auto inverse_spacetime_metric =
+      make_with_random_values<tnsr::AA<double, Dim, Frame::Grid>>(
+          make_not_null(&generator), make_not_null(&tensor_dist), 1);
+  const auto trace_christoffel =
+      make_with_random_values<tnsr::A<double, Dim, Frame::Grid>>(
+          make_not_null(&generator), make_not_null(&tensor_dist), 1);
+  const auto evolved_vars =
+      make_with_random_values<Variables<tmpl::list<Tags::Psi0, Tags::dtPsi0>>>(
+          make_not_null(&generator), make_not_null(&tensor_dist),
+          DataVector(1));
+  const Variables<tmpl::list<::Tags::dt<Tags::Psi0>, ::Tags::dt<Tags::dtPsi0>>>
+      dt_evolved_vars_initial(1, -999.);
+  for (size_t expansion_order = 0; expansion_order <= 2; ++expansion_order) {
+    CAPTURE(expansion_order);
+    ActionTesting::MockRuntimeSystem<metavars> runner{{}};
+    ActionTesting::emplace_singleton_component_and_initialize<worldtube_chare>(
+        &runner, ActionTesting::NodeId{0}, ActionTesting::LocalCoreId{0},
+        {dt_evolved_vars_initial, evolved_vars, psi_monopole, psi_dipole,
+         psi_quadrupole, dt_psi_dipole, inverse_spacetime_metric,
+         trace_christoffel, expansion_order, excision_sphere});
+    const auto& dt_evolved_vars =
+        ActionTesting::get_databox_tag<worldtube_chare, dt_variables_tag>(
+            runner, 0);
+    ActionTesting::set_phase(make_not_null(&runner), Parallel::Phase::Testing);
+    ActionTesting::next_action<worldtube_chare>(make_not_null(&runner), 0);
+    if (expansion_order < 2) {
+      CHECK(dt_evolved_vars == dt_evolved_vars_initial);
+    } else {
+      dt_variables_tag::type dt_evolved_vars_expected(
+          1, std::numeric_limits<double>::signaling_NaN());
+      TimeDerivativeMutator::apply(
+          make_not_null(&dt_evolved_vars_expected), evolved_vars, psi_monopole,
+          psi_dipole, psi_quadrupole, dt_psi_dipole, inverse_spacetime_metric,
+          trace_christoffel, excision_sphere);
+      CHECK_VARIABLES_APPROX(dt_evolved_vars, dt_evolved_vars_expected);
+    }
+  }
+}
+
+SPECTRE_TEST_CASE("Unit.CurvedScalarWave.Worldtube.TimeDerivative", "[Unit]") {
+  MAKE_GENERATOR(generator);
+  static constexpr size_t Dim = 3;
+  test_mutator<Dim>();
+  test_action<Dim>();
+}
+
+}  // namespace
+}  // namespace CurvedScalarWave::Worldtube

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonActions/TimeDerivatives.py
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonActions/TimeDerivatives.py
@@ -1,0 +1,25 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+
+
+def dt_psi0(psi_monopole, psi_dipole, psi_quadrupole, dt_psi_dipole,
+            inverse_spacetime_metric, trace_christoffel, evolved_vars,
+            wt_radius):
+    return evolved_vars[1]
+
+
+def dt2_psi0(psi_monopole, psi_dipole, psi_quadrupole, dt_psi_dipole,
+             inverse_spacetime_metric, trace_christoffel, evolved_vars,
+             wt_radius):
+    psi0 = evolved_vars[0]
+    dt_psi0 = evolved_vars[1]
+    result = -2 * np.dot(inverse_spacetime_metric[0, 1:], dt_psi_dipole)
+    result -= 2. * np.einsum("ij,ij", inverse_spacetime_metric[1:, 1:],
+                             psi_quadrupole)
+    result -= 2 * np.trace(inverse_spacetime_metric[1:, 1:]) * (
+        psi_monopole - psi0) / wt_radius**2
+    result += trace_christoffel[0] * dt_psi0
+    result += np.dot(trace_christoffel[1:], psi_dipole)
+    return result / inverse_spacetime_metric[0][0]

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonActions/__init__.py
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonActions/__init__.py
@@ -1,0 +1,2 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.


### PR DESCRIPTION
## Proposed changes
For the second order worldtube evolution, we need to evolve the expanded scalar wave equation inside the worldtube. This PR adds the required ODE.