### PR TITLE
Add `spectre status` CLI endpoint 

### DIFF
--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -700,7 +700,8 @@ ${{ env.CACHE_KEY_SUFFIX }}"
       # to create the cache.
       SPECTRE_SPACK_DEPS: >-
         blaze boost brigand catch2 charmpp gsl hdf5 libsharp libxsmm openblas
-        py-h5py py-numpy py-matplotlib py-pybind11 py-scipy py-pyyaml yaml-cpp
+        py-h5py py-humanize py-numpy py-matplotlib py-pandas py-pybind11
+        py-scipy py-pyyaml yaml-cpp
       CCACHE_DIR: $HOME/ccache
       CCACHE_MAXSIZE: 700M
       CCACHE_COMPRESS: 1

--- a/src/Visualization/Python/CMakeLists.txt
+++ b/src/Visualization/Python/CMakeLists.txt
@@ -14,6 +14,7 @@ spectre_python_add_module(
   PlotPowerMonitors.py
   plots.mplstyle
   ReadH5.py
+  ReadInputFile.py
   Render1D.py
   TransformVolumeData.py
 )

--- a/src/Visualization/Python/ReadInputFile.py
+++ b/src/Visualization/Python/ReadInputFile.py
@@ -1,0 +1,52 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+"""Tools for parsing YAML input files
+
+To simply read an input file as a dictionary, use a standard YAML parser like
+PyYAML or ruaml.yaml:
+
+    import yaml
+    with open(input_file_path) as open_input_file:
+        input_file = yaml.safe_load(open_input_file)
+
+The functions in this module provide additional functionality to work with input
+files.
+"""
+
+import re
+from typing import Optional
+
+
+def get_executable(input_file_content: str) -> Optional[str]:
+    """Extract the executable the input file is supposed to run with.
+
+    The executable is parsed from a comment like this in the input file:
+
+        # Executable: EvolveScalarWave
+
+    Arguments:
+      input_file_contents: The full input file read in as a string.
+
+    Returns: The executable ("EvolveScalarWave" in the example above), or None
+      if no executable was found.
+    """
+    match = re.search(r'#\s+Executable:\s+(.+)', input_file_content)
+    if not match:
+        return None
+    return match.group(1)
+
+
+def find_event(event_name: str, input_file: dict) -> dict:
+    """Find a particular event in the "EventsAndTriggers" of the input file.
+
+    Arguments:
+      event_name: The name of an event like "ObserveTimeSteps".
+      input_file: The input file read in as a dictionary.
+
+    Returns: The event as a dictionary, or None if the event wasn't found.
+    """
+    for _, events in input_file["EventsAndTriggers"]:
+        for event in events:
+            if event_name in event:
+                return event[event_name]
+    return None

--- a/support/DevEnvironments/spack.yaml
+++ b/support/DevEnvironments/spack.yaml
@@ -61,9 +61,11 @@ spack:
   - 'python@3.7:'
   - py-click
   - py-h5py -mpi
+  - py-humanize
   - py-nbconvert
   - py-numpy
   - py-matplotlib
+  - py-pandas
   - 'py-pybind11@2.6:'
   - py-pyyaml
   - py-rich

--- a/support/Python/__main__.py
+++ b/support/Python/__main__.py
@@ -27,6 +27,7 @@ class Cli(click.MultiCommand):
             "plot-power-monitors",
             "render-1d",
             "simplify-traces",
+            "status",
             "transform-volume-data",
         ]
 
@@ -70,6 +71,9 @@ class Cli(click.MultiCommand):
             from spectre.tools.CharmSimplifyTraces import (
                 simplify_traces_command)
             return simplify_traces_command
+        elif name == "status":
+            from spectre.tools.Status import (status_command)
+            return status_command
         elif name in ["transform-volume-data", "transform-vol"]:
             from spectre.Visualization.TransformVolumeData import (
                 transform_volume_data_command)

--- a/support/Python/requirements.txt
+++ b/support/Python/requirements.txt
@@ -17,10 +17,14 @@
 # autocompletion
 click
 h5py >= 3.5.0
+# Humanize: For human-readable output like "2 hours ago"
+humanize
 # - We constrain the Numpy version because v1.22+ segfaults in Pypp tests, see
 #   issue: https://github.com/sxs-collaboration/spectre/issues/3844
 numpy < 1.22.0
 matplotlib
+# Pandas: To work with columns of data
+pandas
 pyyaml
 # Rich: to format CLI output and tracebacks
 rich >= 10.11.0

--- a/tests/Unit/Visualization/Python/CMakeLists.txt
+++ b/tests/Unit/Visualization/Python/CMakeLists.txt
@@ -41,6 +41,12 @@ spectre_add_python_bindings_test(
   None)
 
 spectre_add_python_bindings_test(
+  "Unit.Visualization.Python.ReadInputFile"
+  Test_ReadInputFile.py
+  "unit;visualization;python"
+  None)
+
+spectre_add_python_bindings_test(
   "Unit.Visualization.Python.Render1D"
   Test_Render1D.py
   "unit;visualization;python"

--- a/tests/Unit/Visualization/Python/Test_ReadH5.py
+++ b/tests/Unit/Visualization/Python/Test_ReadH5.py
@@ -1,12 +1,14 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-from spectre.Visualization.ReadH5 import available_subfiles
+import os
+import unittest
 
 import h5py
-import os
+import pandas.testing as pdt
 import spectre.Informer as spectre_informer
-import unittest
+import spectre.IO.H5 as spectre_h5
+from spectre.Visualization.ReadH5 import available_subfiles, to_dataframe
 
 
 class TestReadH5(unittest.TestCase):
@@ -27,6 +29,18 @@ class TestReadH5(unittest.TestCase):
                              [])
             self.assertEqual(available_subfiles(open_file, extension=".vol"),
                              ["element_data.vol"])
+
+    def test_to_dataframe(self):
+        # h5py subfile
+        with h5py.File(os.path.join(self.data_dir, "DatTestData.h5"),
+                       "r") as open_file:
+            df = to_dataframe(open_file["TimeSteps2.dat"])
+            self.assertEqual(df.columns[0], "Time")
+        # SpECTRE subfile
+        with spectre_h5.H5File(os.path.join(self.data_dir, "DatTestData.h5"),
+                               "r") as open_file:
+            df2 = to_dataframe(open_file.get_dat("/TimeSteps2"))
+            pdt.assert_frame_equal(df2, df)
 
 
 if __name__ == '__main__':

--- a/tests/Unit/Visualization/Python/Test_ReadInputFile.py
+++ b/tests/Unit/Visualization/Python/Test_ReadInputFile.py
@@ -1,0 +1,30 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import unittest
+from pathlib import Path
+
+import yaml
+from spectre.Informer import unit_test_src_path
+from spectre.Visualization.ReadInputFile import find_event, get_executable
+
+
+class TestReadInputFile(unittest.TestCase):
+    def setUp(self):
+        self.input_files_dir = Path(unit_test_src_path(), "..", "InputFiles")
+        self.input_file = Path(self.input_files_dir, "Burgers/Step.yaml")
+
+    def test_get_executable(self):
+        self.assertEqual(get_executable(self.input_file.read_text()),
+                         "EvolveBurgers")
+
+    def test_find_event(self):
+        with self.input_file.open() as open_input_file:
+            input_file = yaml.safe_load(open_input_file)
+        self.assertEqual(
+            find_event("ChangeSlabSize", input_file)["DelayChange"], 5)
+        self.assertIsNone(find_event("NonexistentEvent", input_file))
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/tests/tools/CMakeLists.txt
+++ b/tests/tools/CMakeLists.txt
@@ -12,3 +12,9 @@ spectre_add_python_bindings_test(
   Test_CleanOutput.py
   "Python"
   None)
+
+spectre_add_python_bindings_test(
+  "tools.Status"
+  Test_Status.py
+  "Python"
+  None)

--- a/tests/tools/Test_Status.py
+++ b/tests/tools/Test_Status.py
@@ -1,0 +1,125 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import logging
+import os
+import shutil
+import unittest
+
+import numpy as np
+import spectre.IO.H5 as spectre_h5
+from spectre.Informer import unit_test_build_path
+
+from spectre.tools.Status.Status import get_input_file, get_executable_name
+from spectre.tools.Status.ExecutableStatus import match_executable_status
+
+
+class TestExecutableStatus(unittest.TestCase):
+    def setUp(self):
+        self.input_file = {
+            "Observers": {
+                "ReductionFileName": "Reductions"
+            },
+            "EventsAndTriggers": [("Always", [{
+                "ObserveTimeStep": {
+                    "SubfileName": "TimeSteps"
+                }
+            }])]
+        }
+        self.work_dir = os.path.join(unit_test_build_path(),
+                                     "tools/ExecutableStatus")
+        shutil.rmtree(self.work_dir, ignore_errors=True)
+        os.makedirs(self.work_dir, exist_ok=True)
+        with spectre_h5.H5File(os.path.join(self.work_dir, "Reductions.h5"),
+                               "w") as open_h5_file:
+            # Time data
+            time_subfile = open_h5_file.insert_dat(
+                "/TimeSteps",
+                legend=["Time", "Minimum Walltime", "Maximum Walltime"],
+                version=0)
+            time_subfile.append([0., 1., 2.])
+            time_subfile.append([1., 2., 3.])
+            open_h5_file.close_current_object()
+            # Control systems data
+            rotation_subfile = open_h5_file.insert_dat(
+                "/ControlSystems/Rotation/z", legend=["Lambda"], version=0)
+            rotation_subfile.append([0.])
+            rotation_subfile.append([np.pi])
+            open_h5_file.close_current_object()
+            # AH data
+            aha_subfile = open_h5_file.insert_dat(
+                "/ApparentHorizons/ControlSystemAhA_Centers",
+                legend=[
+                    "InertialCenter_x", "InertialCenter_y", "InertialCenter_z"
+                ],
+                version=0)
+            aha_subfile.append([1., 0., 0.])
+            open_h5_file.close_current_object()
+            ahb_subfile = open_h5_file.insert_dat(
+                "/ApparentHorizons/ControlSystemAhB_Centers",
+                legend=[
+                    "InertialCenter_x", "InertialCenter_y", "InertialCenter_z"
+                ],
+                version=0)
+            ahb_subfile.append([-1., 0., 0.])
+            open_h5_file.close_current_object()
+            # Constraints
+            constraints_subfile = open_h5_file.insert_dat(
+                "/Norms", legend=["L2Norm(ConstraintEnergy)"], version=0)
+            constraints_subfile.append([1.e-3])
+
+    def tearDown(self):
+        shutil.rmtree(self.work_dir, ignore_errors=True)
+
+    def test_evolution_status(self):
+        executable_status = match_executable_status("EvolveSomething")
+        status = executable_status.status(self.input_file, self.work_dir)
+        self.assertEqual(status, {"Time": 1., "Speed": 3600.})
+        self.assertEqual(executable_status.format("Time", 1.5), "1.5")
+        self.assertEqual(executable_status.format("Speed", 1.2), "1.2")
+
+    def test_evolve_bbh_status(self):
+        executable_status = match_executable_status("EvolveGhBinaryBlackHole")
+        status = executable_status.status(self.input_file, self.work_dir)
+        self.assertEqual(status["Time"], 1.)
+        self.assertEqual(status["Speed"], 3600.)
+        self.assertEqual(status["Orbits"], 0.5)
+        self.assertEqual(status["Separation"], 2.)
+        self.assertEqual(status["Constraint Energy"], 1.e-3)
+
+
+class TestStatus(unittest.TestCase):
+    def setUp(self):
+        self.slurm_comment = ("SPECTRE_INPUT_FILE=path/to/input/file\n"
+                              "SPECTRE_EXECUTABLE=path/to/executable\n")
+        self.work_dir = os.path.join(unit_test_build_path(), "tools/Status")
+        self.input_file_path = os.path.join(self.work_dir, "InputFile.yaml")
+        os.makedirs(self.work_dir, exist_ok=True)
+        with open(self.input_file_path, "w") as open_input_file:
+            open_input_file.write("# Some comment\n\n"
+                                  "# Executable: MyExec\n"
+                                  "Key: Value\n")
+
+    def tearDown(self):
+        shutil.rmtree(self.work_dir, ignore_errors=True)
+
+    def test_get_input_file(self):
+        self.assertEqual(get_input_file(self.slurm_comment, self.work_dir),
+                         "path/to/input/file")
+        self.assertIsNone(
+            get_input_file("", os.path.join(self.work_dir, "nonexistent")))
+        self.assertEqual(get_input_file("", self.work_dir),
+                         self.input_file_path)
+
+    def test_get_executable_name(self):
+        self.assertEqual(
+            get_executable_name(self.slurm_comment, self.input_file_path),
+            "executable")
+        self.assertIsNone(get_executable_name("", None))
+        self.assertEqual(get_executable_name("", self.input_file_path),
+                         "MyExec")
+
+
+if __name__ == '__main__':
+    logging.basicConfig(level=logging.DEBUG)
+    unittest.main(verbosity=2)

--- a/tools/Status/CMakeLists.txt
+++ b/tools/Status/CMakeLists.txt
@@ -2,10 +2,11 @@
 # See LICENSE.txt for details.
 
 spectre_python_add_module(
-  tools
+  Status
+  MODULE_PATH "tools"
   PYTHON_FILES
-  CharmSimplifyTraces.py
-  CleanOutput.py
+  __init__.py
+  Status.py
 )
 
-add_subdirectory(Status)
+add_subdirectory(ExecutableStatus)

--- a/tools/Status/ExecutableStatus/CMakeLists.txt
+++ b/tools/Status/ExecutableStatus/CMakeLists.txt
@@ -2,10 +2,10 @@
 # See LICENSE.txt for details.
 
 spectre_python_add_module(
-  tools
+  ExecutableStatus
+  MODULE_PATH tools/Status
   PYTHON_FILES
-  CharmSimplifyTraces.py
-  CleanOutput.py
+  __init__.py
+  EvolveGhBinaryBlackHole.py
+  ExecutableStatus.py
 )
-
-add_subdirectory(Status)

--- a/tools/Status/ExecutableStatus/EvolveGhBinaryBlackHole.py
+++ b/tools/Status/ExecutableStatus/EvolveGhBinaryBlackHole.py
@@ -1,0 +1,75 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import logging
+import os
+
+import h5py
+import numpy as np
+from spectre.Visualization.ReadH5 import to_dataframe
+
+from .ExecutableStatus import EvolutionStatus
+
+logger = logging.getLogger(__name__)
+
+
+class EvolveGhBinaryBlackHole(EvolutionStatus):
+    executable_name_patterns = [r"^EvolveGhBinaryBlackHole"]
+    fields = {
+        "Time": "M",
+        "Speed": "M/h",
+        "Orbits": None,
+        "Separation": "M",
+        "Constraint Energy": None,
+    }
+
+    def status(self, input_file, work_dir):
+        try:
+            reductions_file = input_file["Observers"]["ReductionFileName"]
+            open_reductions_file = h5py.File(
+                os.path.join(work_dir, reductions_file + ".h5"), "r")
+        except:
+            logger.debug("Unable to open reductions file.", exc_info=True)
+            return {}
+        with open_reductions_file:
+            result = self.time_status(input_file, open_reductions_file)
+            # Number of orbits. We use the rotation control system for this.
+            try:
+                rotation_z = to_dataframe(
+                    open_reductions_file["ControlSystems/Rotation/z.dat"])
+                covered_angle = np.diff(rotation_z["Lambda"].iloc[[0, -1]])[0]
+                result["Orbits"] = covered_angle / (2. * np.pi)
+            except:
+                logger.debug("Unable to extract orbits.", exc_info=True)
+            # Euclidean separation between horizons
+            try:
+                ah_centers = [
+                    to_dataframe(open_reductions_file[
+                        f"ApparentHorizons/ControlSystemAh{ab}_Centers.dat"]).
+                    iloc[-1] for ab in "AB"
+                ]
+                ah_separation = np.sqrt(
+                    sum((ah_centers[0]["InertialCenter" + xyz] -
+                         ah_centers[1]["InertialCenter" + xyz])**2
+                        for xyz in ["_x", "_y", "_z"]))
+                result["Separation"] = ah_separation
+            except:
+                logger.debug("Unable to extract separation.", exc_info=True)
+            # Norms
+            try:
+                norms = to_dataframe(open_reductions_file["Norms.dat"])
+                result["Constraint Energy"] = norms.iloc[-1][
+                    "L2Norm(ConstraintEnergy)"]
+            except:
+                logger.debug("Unable to extract constraint energy.",
+                             exc_info=True)
+        return result
+
+    def format(self, field, value):
+        if field == "Separation":
+            return f"{value:g}"
+        elif field == "Orbits":
+            return f"{value:g}"
+        elif field == "Constraint Energy":
+            return f"{value:.2e}"
+        return super().format(field, value)

--- a/tools/Status/ExecutableStatus/ExecutableStatus.py
+++ b/tools/Status/ExecutableStatus/ExecutableStatus.py
@@ -1,0 +1,139 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import logging
+import os
+from typing import Any, Dict, List, Optional
+
+import h5py
+import numpy as np
+import pandas as pd
+from spectre.Visualization.ReadH5 import to_dataframe
+from spectre.Visualization.ReadInputFile import find_event
+
+logger = logging.getLogger(__name__)
+
+
+class ExecutableStatus:
+    """Base class for providing status information for SpECTRE executables.
+
+    Subclasses read output from executables and provide status information.
+    For example, a subclass for a binary black hole evolution executable can
+    provide the current separation and number of orbits.
+
+    Properties:
+      executable_name_patterns: List of regex patterns that match the executable
+        names the subclass applies to. For example, r"^Evolve" matches all
+        executables that start with "Evolve".
+      fields: Dictionary of all field names the subclass provides and their
+        units. For example: {"Time": "M", "Orbits": None} if the subclass
+        provides time in units of mass and orbits with no unit.
+    """
+    executable_name_patterns: List[str] = []
+    fields: Dict[str, Optional[str]] = {}
+
+    def status(self, input_file: dict, work_dir: str) -> dict:
+        """Provide status information of an executable run.
+
+        Arguments:
+          input_file: The input file read in as a dictionary.
+          work_dir: The working directory of the executable run. Paths in the
+            input file are relative to this directory.
+
+        Returns: Dictionary of 'fields' and their values. For example:
+          {"Time": 10.5, "Orbits": 3}. Not all fields must be provided if they
+          can't be determined.
+
+        Note: Avoid raising exceptions in this function. It is better to provide
+          only a subset of fields than to raise an exception. For example, if
+          there's an error reading the number of orbits, intercept and log the
+          exception and just skip providing the number of orbits.
+        """
+        return {}
+
+    def format(self, field: str, value: Any) -> str:
+        """Transform status values to human-readable strings.
+
+        Arguments:
+          field: The name of the field, as listed in 'fields' (e.g. "Time").
+          value: The status value of the field, as returned by 'status()'.
+
+        Returns: Human-readable representation of the value.
+        """
+        raise NotImplementedError
+
+
+class EvolutionStatus(ExecutableStatus):
+    """An 'ExecutableStatus' subclass that matches all evolution executables.
+
+    This is a fallback if no more specialized subclass is implemented. It just
+    determines the current time and run speed. This class can be subclassed
+    further to use the 'time_status' function in subclasses.
+    """
+    executable_name_patterns = [r"^Evolve"]
+    fields = {
+        "Time": None,
+        "Speed": "1/h",
+    }
+
+    def time_status(self, input_file: dict, open_reductions_file) -> dict:
+        """Report the simulation time and speed.
+
+        Uses the 'ObserveTimeStep' event, so the status information is only as
+        current as the output frequency of the event. The reported time is the
+        most recent output of the 'ObserveTimeStep' event, and the reported
+        speed is determined from the two most recent outputs. Since the walltime
+        at which different elements in the computational domain reach the
+        timestep varies because of the lack of a global synchronization point in
+        the task-based parallel evolution, this function returns the average
+        between the minimum and maximum walltime.
+
+        Arguments:
+          input_file: The input file read in as a dictionary.
+          open_reductions_file: The open h5py reductions data file.
+
+        Returns: Status fields "Time" in code units and "Speed" in simulation
+          time per hour.
+        """
+        observe_time_event = find_event("ObserveTimeStep", input_file)
+        if observe_time_event is None:
+            return {}
+        subfile_name = observe_time_event["SubfileName"] + ".dat"
+        logger.debug(f"Reading time steps from subfile: '{subfile_name}'")
+        try:
+            time_steps = to_dataframe(open_reductions_file[subfile_name])
+        except:
+            logger.debug("Unable to read time steps.", exc_info=True)
+            return {}
+        result = {
+            "Time": time_steps.iloc[-1]["Time"],
+        }
+        # Estimate simulation speed
+        try:
+            dt_sim = time_steps.iloc[-1]["Time"] - time_steps.iloc[-2]["Time"]
+            dt_wall_min = (time_steps.iloc[-1]["Minimum Walltime"] -
+                           time_steps.iloc[-2]["Minimum Walltime"])
+            dt_wall_max = (time_steps.iloc[-1]["Maximum Walltime"] -
+                           time_steps.iloc[-2]["Maximum Walltime"])
+            speed = (dt_sim / dt_wall_min +
+                     dt_sim / dt_wall_max) / 2. * 60. * 60.
+            result["Speed"] = speed
+        except:
+            logger.debug("Unable to estimate simulation speed.", exc_info=True)
+        return result
+
+    def status(self, input_file, work_dir):
+        try:
+            reductions_file = input_file["Observers"]["ReductionFileName"]
+            open_reductions_file = h5py.File(
+                os.path.join(work_dir, reductions_file + ".h5"), "r")
+        except:
+            logger.debug("Unable to open reductions file.", exc_info=True)
+            return {}
+        with open_reductions_file:
+            return self.time_status(input_file, open_reductions_file)
+
+    def format(self, field, value):
+        if field in ["Time", "Speed"]:
+            return f"{value:g}"
+        raise ValueError

--- a/tools/Status/ExecutableStatus/__init__.py
+++ b/tools/Status/ExecutableStatus/__init__.py
@@ -1,0 +1,33 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import logging
+import re
+
+from .EvolveGhBinaryBlackHole import EvolveGhBinaryBlackHole
+from .ExecutableStatus import ExecutableStatus, EvolutionStatus
+
+logger = logging.getLogger(__name__)
+
+# Subclasses are matched in this order. Add new subclasses here.
+executable_status_subclasses = [
+    EvolveGhBinaryBlackHole,
+    EvolutionStatus,
+]
+
+
+def match_executable_status(executable_name: str) -> ExecutableStatus:
+    """Get the 'ExecutableStatus' subclass that matches the 'executable_name'.
+
+    The 'executable_name' is matched against all 'executable_name_patterns' in
+    the 'executable_status_subclasses' list. If no pattern matches, a plain
+    'ExecutableStatus' object is returned.
+    """
+    for cls in executable_status_subclasses:
+        for pattern in cls.executable_name_patterns:
+            if re.match(pattern, executable_name):
+                return cls()
+    logger.warning("No 'ExecutableStatus' subclass matches executable name "
+                   f"'{executable_name}'. Implement one and add it to "
+                   "'executable_status_classes'.")
+    return ExecutableStatus()

--- a/tools/Status/Status.py
+++ b/tools/Status/Status.py
@@ -1,0 +1,332 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import datetime
+import glob
+import logging
+import os
+import pathlib
+import re
+import subprocess
+from io import StringIO
+from typing import Any, Optional, Sequence
+
+import click
+import humanize
+import pandas as pd
+import rich.console
+import rich.table
+import yaml
+from spectre.Visualization.ReadInputFile import get_executable
+
+from .ExecutableStatus import match_executable_status
+
+logger = logging.getLogger(__name__)
+
+
+def fetch_job_data(fields: Sequence[str],
+                   user: Optional[str],
+                   allusers: bool = False,
+                   state: Optional[str] = None,
+                   starttime: Optional[str] = None) -> pd.DataFrame:
+    """Query Slurm 'sacct' to get metadata of recent jobs on the machine.
+
+    Arguments:
+      fields: List of Slurm fields that 'sacct --format' accepts.
+        Run 'sacct --helpformat' to print all available fields.
+      user: Slurm user IDs or names, or None for the current user.
+        See documentation for 'sacct -u' for details.
+      allusers: Fetch data for all users.
+        See documentation for 'sacct -a' for details.
+      state: Fetch only jobs with this state.
+        See documentation for 'sacct -s' for details.
+      starttime: Fetch only jobs after this time.
+        See documentation for 'sacct -S' for details.
+
+    Returns: Pandas DataFrame with the job data.
+    """
+    completed_process = subprocess.run(
+        ["sacct", "-P", "--format", ",".join(fields)] +
+        (["-u", user] if user else []) + (["-a"] if allusers else []) +
+        (["-s", state] if state else []) +
+        (["-S", starttime] if starttime else []),
+        capture_output=True,
+        text=True)
+    try:
+        completed_process.check_returncode()
+    except subprocess.CalledProcessError as err:
+        raise ValueError(completed_process.stderr) from err
+    job_data = pd.read_table(StringIO(completed_process.stdout),
+                             sep="|",
+                             keep_default_na=False)
+    # Filter out some derived jobs. Not sure what these jobs are.
+    job_data = job_data[~job_data["JobName"].
+                        isin(["batch", "extern", "pmi_proxy", "orted"])]
+    job_data = job_data[job_data["User"] != ""]
+    # Parse dates and times. Do this in postprocessing because
+    # `pd.read_table(parse_dates=...)` doesn't handle NaN values well.
+    date_cols = set(fields).intersection({"Start", "End"})
+    for date_col in date_cols:
+        job_data[date_col] = job_data[date_col].apply(
+            lambda v: v.replace("Unknown", "NaN"))
+        job_data[date_col] = pd.to_datetime(job_data[date_col],
+                                            infer_datetime_format=True)
+    # We could parse the elapsed time as a timedelta, but the string
+    # representation is fine so we don't right now. Here's the code for it:
+    # if "Elapsed" in fields:
+    #     job_data["Elapsed"] = pd.to_timedelta(
+    #         job_data["Elapsed"].apply(lambda v: v.replace("-", " days ")))
+    return job_data
+
+
+def get_input_file(comment: Optional[str], work_dir: str) -> Optional[str]:
+    """Find the input file corresponding to a job.
+
+    Arguments:
+      comment: The Slurm comment field. The input file is extracted from it if
+        it includes a line like "SPECTRE_INPUT_FILE=path/to/input/file".
+      work_dir: The working directory of the job. If no input file was found
+        in the Slurm comment, we see if there's a single YAML file in the
+        work dir and assume that's the input file.
+
+    Returns: Path to the input file, or None.
+    """
+    if comment:
+        # Get the input file from the Slurm comment if the submission
+        # specified it
+        match = re.search(r"^SPECTRE_INPUT_FILE=(.*)",
+                          comment,
+                          flags=re.MULTILINE)
+        if match:
+            return match.group(1)
+        else:
+            logger.debug("Could not find 'SPECTRE_INPUT_FILE' "
+                         "in Slurm comment:\n" + comment)
+    # Fallback: Check if there's a single YAML file in the work dir
+    yaml_files = glob.glob(os.path.join(work_dir, "*.yaml"))
+    if len(yaml_files) == 1:
+        return yaml_files[0]
+    else:
+        logger.debug("No input file found. "
+                     "Didn't find a single YAML file in '{work_dir}'. "
+                     f"YAML files found: {yaml_files}")
+        return None
+
+
+def get_executable_name(comment: Optional[str],
+                        input_file_path: Optional[str]) -> Optional[str]:
+    """Determine the executable name of a job.
+
+    Arguments:
+      comment: The Slurm comment field. The executable name is extracted from it
+        if it includes a line like "SPECTRE_EXECUTABLE=path/to/executable".
+      input_file_path: Path to input file. If no executable name was found in
+        the Slurm comment, we try to extract it from the input file.
+
+    Returns: Executable name, or None.
+    """
+    if comment:
+        # Get the executable from the Slurm comment if the submission
+        # specified it
+        match = re.search(r"^SPECTRE_EXECUTABLE=(.*)",
+                          comment,
+                          flags=re.MULTILINE)
+        if match:
+            return os.path.basename(match.group(1))
+        else:
+            logger.debug("Could not find 'SPECTRE_EXECUTABLE' "
+                         "in Slurm comment:\n" + comment)
+    # Fallback: Look for a comment like "# Executable: ..." in the input file
+    if not input_file_path:
+        return None
+    executable = get_executable(pathlib.Path(input_file_path).read_text())
+    return os.path.basename(executable) if executable else None
+
+
+def _state_order(state):
+    order = ["RUNNING", "PENDING", "COMPLETED", "TIMEOUT", "FAILED"]
+    try:
+        return order.index(state)
+    except ValueError:
+        return None
+
+
+def _format(field: str, value: Any) -> str:
+    if field == "State":
+        style = {
+            "RUNNING": "[blue]",
+            "COMPLETED": "[green]",
+            "PENDING": "[magenta]",
+            "FAILED": "[red]",
+            "TIMEOUT": "[red]",
+        }
+        return style.get(value, "") + str(value)
+    elif field in ["Start", "End"]:
+        if pd.isnull(value):
+            return "-"
+        else:
+            return humanize.naturaldate(value) + " " + value.strftime("%X")
+    else:
+        return str(value)
+
+
+@click.command()
+@click.option("-u",
+              "--uid",
+              "--user",
+              "user",
+              show_default="you",
+              help=("User name or user ID. "
+                    "See documentation for 'sacct -u' for details."))
+@click.option("-a",
+              "--allusers",
+              is_flag=True,
+              help=("Show jobs for all users. "
+                    "See documentation for 'sacct -a' for details."))
+@click.option("-p",
+              "--show-paths",
+              is_flag=True,
+              help=("Show job working directory and input file paths."))
+@click.option("-U",
+              "--show-unidentified",
+              is_flag=True,
+              help=("Also show jobs that were not identified "
+                    "as SpECTRE executables."))
+@click.option("-s",
+              "--state",
+              help=("Show only jobs with this state, "
+                    "e.g. running (r) or completed (cd). "
+                    "See documentation for 'sacct -s' for details."))
+@click.option("-S",
+              "--starttime",
+              show_default="start of today",
+              help=("Show jobs eligible after this time, e.g. 'now-2days'. "
+                    "See documentation for 'sacct -S' for details."))
+def status_command(show_paths, show_unidentified, **kwargs):
+    """Gives an overview of simulations running on this machine."""
+    job_data = fetch_job_data([
+        "JobID",
+        "User",
+        "JobName",
+        "AllocCPUS",
+        "AllocNodes",
+        "Elapsed",
+        "End",
+        "State",
+        "WorkDir",
+        "Comment",
+    ], **kwargs)
+
+    # Do nothing if job list is empty
+    if len(job_data) == 0:
+        return
+
+    # List most recent jobs first
+    job_data.sort_values("JobID", inplace=True, ascending=False)
+
+    # Get the input file corresponding to each job
+    job_data["InputFile"] = [
+        get_input_file(comment, work_dir)
+        for comment, work_dir in zip(job_data["Comment"], job_data["WorkDir"])
+    ]
+
+    # Get the executable name corresponding to each job.
+    job_data["ExecutableName"] = [
+        get_executable_name(comment,
+                            input_file) for comment, input_file in zip(
+                                job_data["Comment"], job_data["InputFile"])
+    ]
+
+    # Add metadata so jobs can be grouped by state
+    job_data["StateOrder"] = job_data["State"].apply(_state_order)
+
+    # Start printing things
+    console = rich.console.Console()
+
+    # We'll print these columns
+    standard_fields = [
+        "State",
+        "End",
+        "JobID",
+        "JobName",
+        "Elapsed",
+        "AllocCPUS",
+        "AllocNodes",
+    ]
+    if kwargs["allusers"]:
+        standard_fields.insert(2, "User")
+    # Transform some column names for better readability
+    col_names = {
+        "AllocCPUS": "Cores",
+        "AllocNodes": "Nodes",
+    }
+    standard_columns = [col_names.get(col, col) for col in standard_fields]
+
+    # Group output by executable
+    first_section = True
+    for executable_name, exec_data in job_data.groupby("ExecutableName"):
+        if first_section:
+            first_section = False
+        else:
+            console.print("")
+        console.rule(f"[bold]{executable_name}", align="left")
+        executable_status = match_executable_status(executable_name)
+
+        extra_columns = [(field + f" [{unit}]") if unit else field
+                         for field, unit in executable_status.fields.items()]
+        columns = standard_columns + extra_columns
+        table = rich.table.Table(*columns, box=None)
+
+        # Group by job state
+        for state_index, data in exec_data.groupby("StateOrder"):
+            for _, row in data.iterrows():
+
+                # Extract job status and format row for output
+                row_formatted = [
+                    _format(field, row[field]) for field in standard_fields
+                ]
+                with open(row["InputFile"], "r") as open_input_file:
+                    try:
+                        input_file = yaml.safe_load(open_input_file)
+                    except:
+                        logger.debug("Unable to load input file.",
+                                     exc_info=True)
+                        input_file = None
+                try:
+                    status = executable_status.status(input_file,
+                                                      row["WorkDir"])
+                except:
+                    logger.debug("Unable to extract executable status.",
+                                 exc_info=True)
+                    status = {}
+                row_formatted += [
+                    executable_status.format(field, status[field])
+                    if field in status else "-"
+                    for field in executable_status.fields.keys()
+                ]
+                table.add_row(*row_formatted)
+
+                # Print paths if requested
+                if show_paths:
+                    console.print(table)
+                    # Print WorkDir in its own line so it wraps nicely in the
+                    # terminal and can be copied
+                    console.print(" [bold]WorkDir:[/bold] " + row['WorkDir'])
+                    console.print(" [bold]InputFile:[/bold] " +
+                                  row['InputFile'])
+                    table = rich.table.Table(*columns, box=None)
+        if not show_paths:
+            console.print(table)
+
+    # Output jobs that couldn't be parsed
+    unidentified_jobs = job_data[job_data["ExecutableName"].isnull()]
+    if len(unidentified_jobs) > 0 and show_unidentified:
+        console.print("")
+        console.rule("[bold]Unidentified Jobs", align="left")
+        table = rich.table.Table(*standard_columns, box=None)
+        for i, row in unidentified_jobs.iterrows():
+            row_formatted = [
+                _format(field, row[field]) for field in standard_fields
+            ]
+            table.add_row(*row_formatted)
+        console.print(table)

--- a/tools/Status/__init__.py
+++ b/tools/Status/__init__.py
@@ -1,0 +1,4 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+from .Status import status_command


### PR DESCRIPTION
## Proposed changes

Gives an overview of simulations running on the machine. Try it like this (e.g. on Wheeler):

```sh
$ ./bin/spectre status
```

Here's a recent sample output with the `-a / --allusers` flag (any resemblance of names to real persons is purely coincidental, and @pajkosmi is surely not setting Wheeler on fire):

<img width="911" alt="Bildschirm­foto 2023-04-01 um 21 56 18" src="https://user-images.githubusercontent.com/746230/229332249-bd0cfb1e-f047-414a-b050-76b351d20092.png">


### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
Add `pandas` and `humanize` to your Python environment. An easy way to update your Py env is this:

```
# in your Py env
pip install -r support/Python/requirements.txt
```
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
