### PR TITLE
Add `ObserveLineSegment` to worldtube

### DIFF
--- a/src/ParallelAlgorithms/Interpolation/Targets/LineSegment.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Targets/LineSegment.hpp
@@ -117,15 +117,15 @@ namespace TargetPoints {
 ///
 /// For requirements on InterpolationTargetTag, see
 /// intrp::protocols::InterpolationTargetTag
-template <typename InterpolationTargetTag, size_t VolumeDim>
+template <typename InterpolationTargetTag, size_t VolumeDim, typename Frame>
 struct LineSegment : tt::ConformsTo<intrp::protocols::ComputeTargetPoints> {
   using const_global_cache_tags =
       tmpl::list<Tags::LineSegment<InterpolationTargetTag, VolumeDim>>;
   using is_sequential = std::false_type;
-  using frame = Frame::Inertial;
+  using frame = Frame;
 
   template <typename Metavariables, typename DbTags>
-  static tnsr::I<DataVector, VolumeDim, Frame::Inertial> points(
+  static tnsr::I<DataVector, VolumeDim, Frame> points(
       const db::DataBox<DbTags>& box,
       const tmpl::type_<Metavariables>& /*meta*/) {
     const auto& options =
@@ -133,7 +133,7 @@ struct LineSegment : tt::ConformsTo<intrp::protocols::ComputeTargetPoints> {
 
     // Fill points on a line segment
     const double fractional_distance = 1.0 / (options.number_of_points - 1);
-    tnsr::I<DataVector, VolumeDim, Frame::Inertial> target_points(
+    tnsr::I<DataVector, VolumeDim, Frame> target_points(
         options.number_of_points);
     for (size_t n = 0; n < options.number_of_points; ++n) {
       for (size_t d = 0; d < VolumeDim; ++d) {
@@ -147,7 +147,7 @@ struct LineSegment : tt::ConformsTo<intrp::protocols::ComputeTargetPoints> {
   }
 
   template <typename Metavariables, typename DbTags, typename TemporalId>
-  static tnsr::I<DataVector, VolumeDim, Frame::Inertial> points(
+  static tnsr::I<DataVector, VolumeDim, Frame> points(
       const db::DataBox<DbTags>& box, const tmpl::type_<Metavariables>& meta,
       const TemporalId& /*temporal_id*/) {
     return points(box, meta);

--- a/tests/InputFiles/CurvedScalarWave/WorldtubeKerrSchild.yaml
+++ b/tests/InputFiles/CurvedScalarWave/WorldtubeKerrSchild.yaml
@@ -22,10 +22,7 @@ BackgroundSpacetime:
 
 ResourceInfo:
   AvoidGlobalProc0: false
-  Singletons:
-    WorldtubeSingleton:
-      Proc: Auto
-      Exclusive: false
+  Singletons: Auto
 
 PhaseChangeAndTriggers:
 
@@ -94,6 +91,12 @@ EventsAndTriggers:
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double]
           OverrideObservationValue: None
+  - - Slabs:
+        EvenlySpaced:
+          Interval: 1000
+          Offset: 0
+    - - PsiAlongAxis1
+      - PsiAlongAxis2
   - - Times:
         Specified:
           Values: &FinalTime [1000.]
@@ -102,6 +105,16 @@ EventsAndTriggers:
 Worldtube:
   ExcisionSphere: ExcisionSphereA
   ExpansionOrder: 1
+
+InterpolationTargets:
+  PsiAlongAxis1:
+    Begin: [0., 0., 0.]
+    End: [0., 0., 400.]
+    NumberOfPoints: 1000
+  PsiAlongAxis2:
+    Begin: [0., 0., 0.]
+    End: [400., 0., 0.]
+    NumberOfPoints: 1000
 
 Filtering:
   ExpFilter0:

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_ElementReceiveInterpPoints.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_ElementReceiveInterpPoints.cpp
@@ -86,7 +86,8 @@ struct MockMetavariables {
     using vars_to_interpolate_to_target = tmpl::list<Tags::TestSolution>;
     using compute_items_on_target = tmpl::list<>;
     using compute_target_points =
-        ::intrp::TargetPoints::LineSegment<InterpolationTargetA, 3>;
+        ::intrp::TargetPoints::LineSegment<InterpolationTargetA, 3,
+                                           Frame::Inertial>;
     using post_interpolation_callback =
         intrp::callbacks::ObserveTimeSeriesOnSurface<tmpl::list<>,
                                                      InterpolationTargetA>;
@@ -99,7 +100,8 @@ struct MockMetavariables {
     using vars_to_interpolate_to_target = tmpl::list<Tags::TestSolution>;
     using compute_items_on_target = tmpl::list<>;
     using compute_target_points =
-        ::intrp::TargetPoints::LineSegment<InterpolationTargetB, 3>;
+        ::intrp::TargetPoints::LineSegment<InterpolationTargetB, 3,
+                                           Frame::Inertial>;
     using post_interpolation_callback =
         intrp::callbacks::ObserveTimeSeriesOnSurface<tmpl::list<>,
                                                      InterpolationTargetA>;

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_InitializeInterpolationTarget.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_InitializeInterpolationTarget.cpp
@@ -60,7 +60,8 @@ struct Metavariables {
         intrp::callbacks::ObserveTimeSeriesOnSurface<tmpl::list<>,
                                                      InterpolationTargetA>;
     using compute_target_points =
-        ::intrp::TargetPoints::LineSegment<InterpolationTargetA, 3>;
+        ::intrp::TargetPoints::LineSegment<InterpolationTargetA, 3,
+                                           Frame::Inertial>;
   };
 
   using component_list = tmpl::list<

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_Interpolate.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_Interpolate.cpp
@@ -131,10 +131,9 @@ struct mock_interpolator {
   using array_index = size_t;
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
       Parallel::Phase::Initialization,
-      tmpl::list<
-          ::intrp::Actions::InitializeInterpolator<
-              intrp::Tags::VolumeVarsInfo<Metavariables, ::Tags::TimeStepId>,
-              intrp::Tags::InterpolatedVarsHolders<Metavariables>>>>>;
+      tmpl::list<::intrp::Actions::InitializeInterpolator<
+          intrp::Tags::VolumeVarsInfo<Metavariables, ::Tags::TimeStepId>,
+          intrp::Tags::InterpolatedVarsHolders<Metavariables>>>>>;
   using initial_databox = db::compute_databox_type<
       typename ::intrp::Actions::InitializeInterpolator<
           intrp::Tags::VolumeVarsInfo<Metavariables, ::Tags::TimeStepId>,
@@ -183,7 +182,8 @@ struct MockMetavariables {
     using vars_to_interpolate_to_target = tmpl::list<Tags::Lapse>;
     using compute_items_on_target = tmpl::list<>;
     using compute_target_points =
-        ::intrp::TargetPoints::LineSegment<InterpolatorTargetA, 3>;
+        ::intrp::TargetPoints::LineSegment<InterpolatorTargetA, 3,
+                                           Frame::Inertial>;
     using post_interpolation_callback =
         intrp::callbacks::ObserveTimeSeriesOnSurface<tmpl::list<>,
                                                      InterpolatorTargetA>;

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolateWithoutInterpComponent.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolateWithoutInterpComponent.cpp
@@ -117,7 +117,7 @@ struct MockMetavariables {
     // The following are not used in this test, but must be there to
     // conform to the protocol.
     using compute_target_points = ::intrp::TargetPoints::LineSegment<
-        InterpolationTargetAWithComputeVarsToInterpolate, 3>;
+        InterpolationTargetAWithComputeVarsToInterpolate, 3, Frame::Inertial>;
     using post_interpolation_callback =
         intrp::callbacks::ObserveTimeSeriesOnSurface<
             tmpl::list<>, InterpolationTargetAWithComputeVarsToInterpolate>;
@@ -131,7 +131,8 @@ struct MockMetavariables {
     // The following are not used in this test, but must be there to
     // conform to the protocol.
     using compute_target_points = ::intrp::TargetPoints::LineSegment<
-        InterpolationTargetAWithoutComputeVarsToInterpolate, 3>;
+        InterpolationTargetAWithoutComputeVarsToInterpolate, 3,
+        Frame::Inertial>;
     using post_interpolation_callback =
         intrp::callbacks::ObserveTimeSeriesOnSurface<
             tmpl::list<>, InterpolationTargetAWithoutComputeVarsToInterpolate>;
@@ -156,7 +157,6 @@ struct MockMetavariables {
       : tt::ConformsTo<Options::protocols::FactoryCreation> {
     using factory_classes = tmpl::map<tmpl::pair<Event, tmpl::list<event>>>;
   };
-
 };
 
 template <typename MockMetavariables>

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolationTargetLineSegment.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolationTargetLineSegment.cpp
@@ -27,6 +27,7 @@
 #include "Utilities/TMPL.hpp"
 
 namespace {
+template <typename Frame>
 struct MockMetavariables {
   struct InterpolationTargetA
       : tt::ConformsTo<intrp::protocols::InterpolationTargetTag> {
@@ -35,7 +36,7 @@ struct MockMetavariables {
         tmpl::list<gr::Tags::Lapse<DataVector>>;
     using compute_items_on_target = tmpl::list<>;
     using compute_target_points =
-        ::intrp::TargetPoints::LineSegment<InterpolationTargetA, 3>;
+        ::intrp::TargetPoints::LineSegment<InterpolationTargetA, 3, Frame>;
     using post_interpolation_callback =
         intrp::callbacks::ObserveTimeSeriesOnSurface<tmpl::list<>,
                                                      InterpolationTargetA>;
@@ -80,13 +81,22 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.InterpolationTarget.LineSegment",
     return block_logical_coordinates(domain_creator.create_domain(), points);
   }();
 
-  TestHelpers::db::test_simple_tag<
-      intrp::Tags::LineSegment<MockMetavariables::InterpolationTargetA, 3>>(
+  TestHelpers::db::test_simple_tag<intrp::Tags::LineSegment<
+      MockMetavariables<Frame::Grid>::InterpolationTargetA, 3>>("LineSegment");
+  TestHelpers::db::test_simple_tag<intrp::Tags::LineSegment<
+      MockMetavariables<Frame::Inertial>::InterpolationTargetA, 3>>(
       "LineSegment");
 
   InterpTargetTestHelpers::test_interpolation_target<
-      MockMetavariables,
-      intrp::Tags::LineSegment<MockMetavariables::InterpolationTargetA, 3>>(
+      MockMetavariables<Frame::Grid>,
+      intrp::Tags::LineSegment<
+          MockMetavariables<Frame::Grid>::InterpolationTargetA, 3>>(
+      domain_creator, std::move(line_segment_opts),
+      expected_block_coord_holders);
+  InterpTargetTestHelpers::test_interpolation_target<
+      MockMetavariables<Frame::Inertial>,
+      intrp::Tags::LineSegment<
+          MockMetavariables<Frame::Inertial>::InterpolationTargetA, 3>>(
       domain_creator, std::move(line_segment_opts),
       expected_block_coord_holders);
 }

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolatorReceiveAndDumpVolumeData.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolatorReceiveAndDumpVolumeData.cpp
@@ -318,7 +318,8 @@ struct MockMetavariables {
     using compute_vars_to_interpolate = ComputeSquare;
     using compute_items_on_target = tmpl::list<>;
     using compute_target_points =
-        ::intrp::TargetPoints::LineSegment<InterpolationTargetA, 3>;
+        ::intrp::TargetPoints::LineSegment<InterpolationTargetA, 3,
+                                           Frame::Inertial>;
     using post_interpolation_callback =
         intrp::callbacks::ObserveTimeSeriesOnSurface<tmpl::list<>,
                                                      InterpolationTargetA>;

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolatorReceivePoints.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolatorReceivePoints.cpp
@@ -153,7 +153,8 @@ struct Metavariables {
         tmpl::list<gr::Tags::Lapse<DataVector>>;
     using compute_items_on_target = tmpl::list<>;
     using compute_target_points =
-        ::intrp::TargetPoints::LineSegment<InterpolationTargetA, 3>;
+        ::intrp::TargetPoints::LineSegment<InterpolationTargetA, 3,
+                                           Frame::Inertial>;
     using post_interpolation_callback =
         intrp::callbacks::ObserveTimeSeriesOnSurface<tmpl::list<>,
                                                      InterpolationTargetA>;

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_ObserveLineSegment.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_ObserveLineSegment.cpp
@@ -169,7 +169,7 @@ struct MockMetavariables {
                    domain::Tags::Coordinates<volume_dim, Frame::Inertial>>;
     using compute_items_on_target = tmpl::list<Tags::SquareCompute>;
     using compute_target_points =
-        intrp::TargetPoints::LineSegment<LineA, volume_dim>;
+        intrp::TargetPoints::LineSegment<LineA, volume_dim, Frame::Inertial>;
     using post_interpolation_callback = intrp::callbacks::ObserveLineSegment<
         tmpl::append<vars_to_interpolate_to_target, compute_items_on_target>,
         LineA>;
@@ -183,7 +183,7 @@ struct MockMetavariables {
                    domain::Tags::Coordinates<volume_dim, Frame::Inertial>>;
     using compute_items_on_target = tmpl::list<Tags::SquareCompute>;
     using compute_target_points =
-        intrp::TargetPoints::LineSegment<LineB, volume_dim>;
+        intrp::TargetPoints::LineSegment<LineB, volume_dim, Frame::Inertial>;
     using post_interpolation_callback = intrp::callbacks::ObserveLineSegment<
         tmpl::append<vars_to_interpolate_to_target, compute_items_on_target>,
         LineB>;
@@ -462,13 +462,13 @@ void run_test(gsl::not_null<Generator*> generator,
 
   const auto& data_box_a =
       ActionTesting::get_databox<target_a_component>(runner, 0);
-  const auto interpolated_coords_a =
-      intrp::TargetPoints::LineSegment<typename metavars::LineA, Dim>::points(
+  const auto interpolated_coords_a = intrp::TargetPoints::
+      LineSegment<typename metavars::LineA, Dim, Frame::Inertial>::points(
           data_box_a, tmpl::type_<metavars>{});
   const auto& data_box_b =
       ActionTesting::get_databox<target_b_component>(runner, 0);
-  const auto interpolated_coords_b =
-      intrp::TargetPoints::LineSegment<typename metavars::LineB, Dim>::points(
+  const auto interpolated_coords_b = intrp::TargetPoints::
+      LineSegment<typename metavars::LineB, Dim, Frame::Inertial>::points(
           data_box_b, tmpl::type_<metavars>{});
 
   check_file_contents("/LineA", interpolated_coords_a);

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_ParallelInterpolator.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_ParallelInterpolator.cpp
@@ -240,7 +240,8 @@ struct MockMetavariables {
     using vars_to_interpolate_to_target = tmpl::list<Tags::Square>;
     using compute_items_on_target = tmpl::list<>;
     using compute_target_points =
-        intrp::TargetPoints::LineSegment<InterpolationTargetA, 3>;
+        intrp::TargetPoints::LineSegment<InterpolationTargetA, 3,
+                                         Frame::Inertial>;
     using post_interpolation_callback =
         TestFunction<InterpolationTargetA, Tags::Square>;
   };
@@ -251,7 +252,8 @@ struct MockMetavariables {
     using vars_to_interpolate_to_target = tmpl::list<Tags::Square>;
     using compute_items_on_target = tmpl::list<Tags::NegateCompute>;
     using compute_target_points =
-        intrp::TargetPoints::LineSegment<InterpolationTargetB, 3>;
+        intrp::TargetPoints::LineSegment<InterpolationTargetB, 3,
+                                         Frame::Inertial>;
     using post_interpolation_callback =
         TestFunction<InterpolationTargetB, Tags::Negate>;
   };


### PR DESCRIPTION
## Proposed changes
adds two InterpolationTargets to the worldube which are used to observed the co-moving x- and z-axis.