### PR TITLE
Initialize constraint gammas for worldtube scheme

### DIFF
--- a/src/Evolution/Executables/CurvedScalarWave/EvolveWorldtubeCurvedScalarWave.hpp
+++ b/src/Evolution/Executables/CurvedScalarWave/EvolveWorldtubeCurvedScalarWave.hpp
@@ -38,6 +38,7 @@
 #include "Evolution/Systems/CurvedScalarWave/PsiSquared.hpp"
 #include "Evolution/Systems/CurvedScalarWave/System.hpp"
 #include "Evolution/Systems/CurvedScalarWave/Tags.hpp"
+#include "Evolution/Systems/CurvedScalarWave/Worldtube/ElementActions/InitializeConstraintGammas.hpp"
 #include "Evolution/Systems/CurvedScalarWave/Worldtube/ElementActions/ReceiveWorldtubeData.hpp"
 #include "Evolution/Systems/CurvedScalarWave/Worldtube/ElementActions/SendToWorldtube.hpp"
 #include "Evolution/Systems/CurvedScalarWave/Worldtube/Tags.hpp"
@@ -278,8 +279,8 @@ struct EvolutionMetavars {
       Initialization::Actions::NonconservativeSystem<system>,
       CurvedScalarWave::Actions::CalculateGrVars<system>,
       Initialization::Actions::AddSimpleTags<
-          CurvedScalarWave::Initialization::InitializeConstraintDampingGammas<
-              volume_dim>,
+          CurvedScalarWave::Worldtube::Initialization::
+              InitializeConstraintDampingGammas<volume_dim>,
           CurvedScalarWave::Initialization::InitializeEvolvedVariables<
               volume_dim>>,
       Initialization::Actions::AddComputeTags<

--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/ElementActions/CMakeLists.txt
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/ElementActions/CMakeLists.txt
@@ -1,10 +1,17 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
+spectre_target_sources(
+  ${LIBRARY}
+  PRIVATE
+  InitializeConstraintGammas.cpp
+  )
+
 spectre_target_headers(
   ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
+  InitializeConstraintGammas.hpp
   ReceiveWorldtubeData.hpp
   SendToWorldtube.hpp
 )

--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/ElementActions/InitializeConstraintGammas.cpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/ElementActions/InitializeConstraintGammas.cpp
@@ -1,0 +1,33 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/CurvedScalarWave/Worldtube/ElementActions/InitializeConstraintGammas.hpp"
+
+#include <cstddef>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace CurvedScalarWave::Worldtube::Initialization {
+
+template <size_t Dim>
+void InitializeConstraintDampingGammas<Dim>::apply(
+    const gsl::not_null<Scalar<DataVector>*> gamma1,
+    const gsl::not_null<Scalar<DataVector>*> gamma2,
+    const tnsr::I<DataVector, Dim, Frame::Inertial>& inertial_coords) {
+  const size_t number_of_grid_points = get<0>(inertial_coords).size();
+  *gamma1 = Scalar<DataVector>{number_of_grid_points, 0.};
+  const double amplitude = 10.;
+  const double sigma = 1.e-1;
+  const double constant = 1.e-4;
+  const auto radius = magnitude(inertial_coords);
+  get(*gamma2) = amplitude * exp(-square(sigma * radius.get())) + constant;
+}
+
+template struct InitializeConstraintDampingGammas<1>;
+template struct InitializeConstraintDampingGammas<2>;
+template struct InitializeConstraintDampingGammas<3>;
+}  // namespace CurvedScalarWave::Worldtube::Initialization

--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/ElementActions/InitializeConstraintGammas.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/ElementActions/InitializeConstraintGammas.hpp
@@ -1,0 +1,53 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/Tags.hpp"
+#include "Evolution/Systems/CurvedScalarWave/Tags.hpp"
+
+namespace CurvedScalarWave::Worldtube::Initialization {
+
+/*!
+ * \ingroup InitializationGroup
+ * \brief Initializes the constraint damping parameters \f$\gamma_1\f$ and
+ * \f$\gamma_2\f$.
+ *
+ * \details The constraint damping parameters  of the CurvedScalarWave system
+ * are initialized according to a Gaussian
+ * \f{align*}
+ *  \gamma_1 &= 0 \\
+ *  \gamma_2 &= A e^{-(\sigma r)^2 } + c,
+ * \f}
+ * where \f$r = \sqrt{\delta_{ij} x^i x^j}\f$ and with \f$A = 10\f$, \f$\sigma =
+ * 10^{-1}\f$, \f$c = 10^{-4}\f$. These values were experimentally found to
+ * ensure a stable evolution when using the worldtube scheme.
+ *
+ *  DataBox changes:
+ * - Adds:
+ *   * `CurvedScalarWave::Tags::ConstraintGamma1`
+ *   * `CurvedScalarWave::Tags::ConstraintGamma2`
+ * - Removes: nothing
+ * - Modifies: nothing
+ */
+template <size_t Dim>
+struct InitializeConstraintDampingGammas {
+  using return_tags = tmpl::list<CurvedScalarWave::Tags::ConstraintGamma1,
+                                 CurvedScalarWave::Tags::ConstraintGamma2>;
+  using argument_tags =
+      tmpl::list<domain::Tags::Coordinates<Dim, Frame::Inertial>>;
+  using simple_tags = return_tags;
+  using compute_tags = tmpl::list<>;
+  using simple_tags_from_options = tmpl::list<>;
+  using const_global_cache_tags = tmpl::list<>;
+  using mutable_global_cache_tags = tmpl::list<>;
+  static void apply(
+      const gsl::not_null<Scalar<DataVector>*> gamma1,
+      const gsl::not_null<Scalar<DataVector>*> gamma2,
+      const tnsr::I<DataVector, Dim, Frame::Inertial>& inertial_coords);
+};
+}  // namespace CurvedScalarWave::Worldtube::Initialization

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/CMakeLists.txt
@@ -21,6 +21,7 @@ set(LIBRARY_SOURCES
   Worldtube/Test_Tags.cpp
   Worldtube/ElementActions/Test_SendToWorldtube.cpp
   Worldtube/ElementActions/Test_ReceiveWorldtubeData.cpp
+  Worldtube/ElementActions/Test_InitializeConstraintGammas.cpp
   Worldtube/SingletonActions/Test_ChangeSlabSize.cpp
   Worldtube/SingletonActions/Test_InitializeElementFacesGridCoordinates.cpp
   Worldtube/SingletonActions/Test_InitializeEvolvedVariables.cpp

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/ElementActions/Test_InitializeConstraintGammas.cpp
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/ElementActions/Test_InitializeConstraintGammas.cpp
@@ -1,0 +1,56 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cmath>
+#include <random>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/Tags.hpp"
+#include "Evolution/Systems/CurvedScalarWave/Tags.hpp"
+#include "Evolution/Systems/CurvedScalarWave/Worldtube/ElementActions/InitializeConstraintGammas.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+
+namespace {
+template <size_t Dim>
+void test_initialize_constraint_damping_gammas(
+    const gsl::not_null<std::mt19937*> gen,
+    const gsl::not_null<std::uniform_real_distribution<>*> dist) {
+  const size_t num_points = 100;
+  const auto random_coords =
+      make_with_random_values<tnsr::I<DataVector, Dim, Frame::Inertial>>(
+          gen, dist, DataVector(num_points));
+  auto box = db::create<
+      db::AddSimpleTags<CurvedScalarWave::Tags::ConstraintGamma1,
+                        CurvedScalarWave::Tags::ConstraintGamma2,
+                        domain::Tags::Coordinates<Dim, Frame::Inertial>>>(
+      Scalar<DataVector>{}, Scalar<DataVector>{}, random_coords);
+  db::mutate_apply<CurvedScalarWave::Worldtube::Initialization::
+                       InitializeConstraintDampingGammas<Dim>>(
+      make_not_null(&box));
+  CHECK(get<CurvedScalarWave::Tags::ConstraintGamma1>(box) ==
+        Scalar<DataVector>{num_points, 0.});
+  CHECK_ITERABLE_APPROX(
+      get(get<CurvedScalarWave::Tags::ConstraintGamma2>(box)),
+      10. * exp(-square(get(magnitude(random_coords)) * 1.e-1)) + 1.e-4);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE(
+    "Unit.Evolution.Systems.CSW.Worldtube.InitializeConstraintDampingGammas",
+    "[Unit][Evolution]") {
+  MAKE_GENERATOR(gen);
+  std::uniform_real_distribution<> dist(-10., 10.);
+  test_initialize_constraint_damping_gammas<1>(make_not_null(&gen),
+                                               make_not_null(&dist));
+  test_initialize_constraint_damping_gammas<2>(make_not_null(&gen),
+                                               make_not_null(&dist));
+  test_initialize_constraint_damping_gammas<3>(make_not_null(&gen),
+                                               make_not_null(&dist));
+}


### PR DESCRIPTION
## Proposed changes
Adds an initializer that creates a Gaussian profile for gamma 2, necessary for stable evolution with the worldtube scheme.