### PR TITLE
Add action to initialize a newly created child element during adaptive mesh refinement

### DIFF
--- a/src/Domain/Amr/CMakeLists.txt
+++ b/src/Domain/Amr/CMakeLists.txt
@@ -10,6 +10,7 @@ spectre_target_sources(
   PRIVATE
   Flag.cpp
   Helpers.cpp
+  NeighborsOfChild.cpp
   NewNeighborIds.cpp
   UpdateAmrDecision.cpp
   )
@@ -21,6 +22,7 @@ spectre_target_headers(
   Amr.hpp
   Flag.hpp
   Helpers.hpp
+  NeighborsOfChild.hpp
   NewNeighborIds.hpp
   UpdateAmrDecision.hpp
   )

--- a/src/Domain/Amr/NeighborsOfChild.cpp
+++ b/src/Domain/Amr/NeighborsOfChild.cpp
@@ -1,0 +1,82 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Domain/Amr/NeighborsOfChild.hpp"
+
+#include <array>
+#include <cstddef>
+#include <unordered_map>
+#include <unordered_set>
+
+#include "Domain/Amr/Flag.hpp"
+#include "Domain/Amr/Helpers.hpp"
+#include "Domain/Amr/NewNeighborIds.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/DirectionMap.hpp"
+#include "Domain/Structure/Element.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Domain/Structure/Neighbors.hpp"
+#include "Domain/Structure/OrientationMap.hpp"
+#include "Domain/Structure/SegmentId.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace amr {
+template <size_t VolumeDim>
+DirectionMap<VolumeDim, Neighbors<VolumeDim>> neighbors_of_child(
+    const Element<VolumeDim>& parent,
+    const std::array<Flag, VolumeDim>& parent_flags,
+    const std::unordered_map<ElementId<VolumeDim>, std::array<Flag, VolumeDim>>&
+        parent_neighbor_flags,
+    const ElementId<VolumeDim>& child_id) {
+  DirectionMap<VolumeDim, Neighbors<VolumeDim>> result;
+
+  const auto sibling_id = [&child_id](const size_t dim) {
+    auto sibling_segment_ids = child_id.segment_ids();
+    auto& segment_id_to_change = gsl::at(sibling_segment_ids, dim);
+    segment_id_to_change = segment_id_to_change.id_of_sibling();
+    return ElementId<VolumeDim>{child_id.block_id(), sibling_segment_ids,
+                                child_id.grid_index()};
+  };
+
+  for (const auto& [direction, old_neighbors] : parent.neighbors()) {
+    const auto dim = direction.dimension();
+    if (gsl::at(parent_flags, dim) == Flag::Split and
+        has_potential_sibling(child_id, direction)) {
+      result.emplace(direction, Neighbors<VolumeDim>{{sibling_id(dim)}, {}});
+    } else {
+      result.emplace(direction,
+                     Neighbors<VolumeDim>{
+                         new_neighbor_ids(child_id, direction, old_neighbors,
+                                          parent_neighbor_flags),
+                         old_neighbors.orientation()});
+    }
+  }
+
+  for (const auto& direction : parent.external_boundaries()) {
+    const auto dim = direction.dimension();
+    if (gsl::at(parent_flags, dim) == Flag::Split and
+        has_potential_sibling(child_id, direction)) {
+      result.emplace(direction, Neighbors<VolumeDim>{{sibling_id(dim)}, {}});
+    }
+  }
+
+  return result;
+}
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data)                                                 \
+  template DirectionMap<DIM(data), Neighbors<DIM(data)>> neighbors_of_child( \
+      const Element<DIM(data)>& parent,                                      \
+      const std::array<Flag, DIM(data)>& parent_flags,                       \
+      const std::unordered_map<ElementId<DIM(data)>,                         \
+                               std::array<Flag, DIM(data)>>&                 \
+          parent_neighbor_flags,                                             \
+      const ElementId<DIM(data)>& child_id);
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
+
+#undef DIM
+#undef INSTANTIATE
+}  // namespace amr

--- a/src/Domain/Amr/NeighborsOfChild.hpp
+++ b/src/Domain/Amr/NeighborsOfChild.hpp
@@ -1,0 +1,35 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <unordered_map>
+
+#include "Domain/Amr/Flag.hpp"
+
+/// \cond
+template <size_t VolumeDim, typename T>
+class DirectionMap;
+template <size_t VolumeDim>
+class Element;
+template <size_t VolumeDim>
+class ElementId;
+template <size_t VolumeDim>
+class Neighbors;
+/// \endcond
+
+namespace amr {
+/// \ingroup AmrGroup
+/// \brief returns the neighbors of the Element with ElementId `child_id`,
+/// whose parent Element is `parent` which has refinement flags `parent_flags`
+/// and neighbor flags `parent_neighbor_flags`
+template <size_t VolumeDim>
+DirectionMap<VolumeDim, Neighbors<VolumeDim>> neighbors_of_child(
+    const Element<VolumeDim>& parent,
+    const std::array<Flag, VolumeDim>& parent_flags,
+    const std::unordered_map<ElementId<VolumeDim>, std::array<Flag, VolumeDim>>&
+        parent_neighbor_flags,
+    const ElementId<VolumeDim>& child_id);
+}  // namespace amr

--- a/src/ParallelAlgorithms/Amr/Actions/CMakeLists.txt
+++ b/src/ParallelAlgorithms/Amr/Actions/CMakeLists.txt
@@ -10,6 +10,7 @@ spectre_target_headers(
   EvaluateRefinementCriteria.hpp
   Initialization.hpp
   Initialize.hpp
+  InitializeChild.hpp
   RunAmrDiagnostics.hpp
   SendAmrDiagnostics.hpp
   UpdateAmrDecision.hpp

--- a/src/ParallelAlgorithms/Amr/Actions/InitializeChild.hpp
+++ b/src/ParallelAlgorithms/Amr/Actions/InitializeChild.hpp
@@ -1,0 +1,82 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <unordered_map>
+#include <utility>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "Domain/Amr/Flag.hpp"
+#include "Domain/Amr/NeighborsOfChild.hpp"
+#include "Domain/Amr/Tags/Flags.hpp"
+#include "Domain/Amr/Tags/NeighborFlags.hpp"
+#include "Domain/Structure/DirectionMap.hpp"
+#include "Domain/Structure/Element.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Domain/Structure/Neighbors.hpp"
+#include "Domain/Tags.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "ParallelAlgorithms/Amr/Projectors/Mesh.hpp"
+#include "ParallelAlgorithms/Initialization/MutateAssign.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+/// \cond
+namespace Parallel {
+template <typename Metavariables>
+class GlobalCache;
+}  // namespace Parallel
+/// \endcond
+
+namespace amr::Actions {
+/// \brief Initializes the data of a newly created child element from the data
+/// of its parent element
+///
+/// \warning At the moment, this action only initializes the Element, Mesh,
+/// and amr::Flag%s of the child element.  It does not initialize any data
+/// related to evolution or elliptic solves.
+///
+/// DataBox:
+/// - Modifies:
+///   * domain::Tags::Element<volume_dim>
+///   * domain::Tags::Mesh<volume_dim>
+///
+/// \details This action is meant to be invoked by
+/// amr::Actions::SendDataToChildren
+struct InitializeChild {
+  template <typename ParallelComponent, typename DbTagList,
+            typename Metavariables, typename... Tags>
+  static void apply(db::DataBox<DbTagList>& box,
+                    const Parallel::GlobalCache<Metavariables>& /*cache*/,
+                    const ElementId<Metavariables::volume_dim>& child_id,
+                    const tuples::TaggedTuple<Tags...>& parent_items) {
+    constexpr size_t volume_dim = Metavariables::volume_dim;
+    const auto& parent =
+        tuples::get<::domain::Tags::Element<volume_dim>>(parent_items);
+    const auto& parent_flags =
+        tuples::get<amr::Tags::Flags<volume_dim>>(parent_items);
+    const auto& parent_neighbor_flags =
+        tuples::get<amr::Tags::NeighborFlags<volume_dim>>(parent_items);
+    const auto& parent_mesh =
+        tuples::get<::domain::Tags::Mesh<volume_dim>>(parent_items);
+    auto neighbors = amr::neighbors_of_child(parent, parent_flags,
+                                             parent_neighbor_flags, child_id);
+    Element<volume_dim> child(child_id, std::move(neighbors));
+    Mesh<volume_dim> child_mesh =
+        amr::projectors::mesh(parent_mesh, parent_flags);
+
+    // Default initialization of amr::Tags::Flags and amr::Tags::NeighborFlags
+    // is okay
+    ::Initialization::mutate_assign<tmpl::list<
+        ::domain::Tags::Element<volume_dim>, ::domain::Tags::Mesh<volume_dim>>>(
+        make_not_null(&box), std::move(child), std::move(child_mesh));
+
+    // In the near future, add the capability of updating all data needed for
+    // an evolution or elliptic system
+  }
+};
+}  // namespace amr::Actions

--- a/tests/Unit/Domain/Amr/CMakeLists.txt
+++ b/tests/Unit/Domain/Amr/CMakeLists.txt
@@ -6,6 +6,7 @@ set(LIBRARY "Test_Amr")
 set(LIBRARY_SOURCES
   Test_Flag.cpp
   Test_Helpers.cpp
+  Test_NeighborsOfChild.cpp
   Test_NewNeighborIds.cpp
   Test_Tags.cpp
   Test_UpdateAmrDecision.cpp

--- a/tests/Unit/Domain/Amr/Test_NeighborsOfChild.cpp
+++ b/tests/Unit/Domain/Amr/Test_NeighborsOfChild.cpp
@@ -1,0 +1,186 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <random>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "Domain/Amr/Flag.hpp"
+#include "Domain/Amr/Helpers.hpp"
+#include "Domain/Amr/NeighborsOfChild.hpp"
+#include "Domain/Amr/NewNeighborIds.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/DirectionMap.hpp"
+#include "Domain/Structure/Element.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Domain/Structure/Neighbors.hpp"
+#include "Domain/Structure/SegmentId.hpp"
+#include "Domain/Structure/Side.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/Domain/Amr/NeighborFlagHelpers.hpp"
+#include "Helpers/Domain/Structure/NeighborHelpers.hpp"
+#include "Utilities/CartesianProduct.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace {
+template <size_t Dim>
+std::vector<ElementId<Dim>> element_ids_to_test() {
+  static constexpr size_t max_level = 2;
+  std::vector<ElementId<Dim>> result{};
+  for (size_t lx = 0; lx <= max_level; ++lx) {
+    for (size_t ix = 0; ix < two_to_the(lx); ++ix) {
+      if constexpr (Dim == 1) {
+        result.emplace_back(0, std::array{SegmentId{lx, ix}});
+      } else {
+        for (size_t ly = 0; ly <= max_level; ++ly) {
+          for (size_t iy = 0; iy < two_to_the(ly); ++iy) {
+            if constexpr (Dim == 2) {
+              result.emplace_back(
+                  0, std::array{SegmentId{lx, ix}, SegmentId{ly, iy}});
+            } else {
+              for (size_t lz = 0; lz <= max_level; ++lz) {
+                for (size_t iz = 0; iz < two_to_the(lz); ++iz) {
+                  result.emplace_back(
+                      0, std::array{SegmentId{lx, ix}, SegmentId{ly, iy},
+                                    SegmentId{lz, iz}});
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  return result;
+}
+
+template <size_t Dim>
+std::vector<Element<Dim>> valid_elements(
+    const gsl::not_null<std::mt19937*> generator,
+    const ElementId<Dim>& element_id) {
+  const SegmentId xi_segment = element_id.segment_id(0);
+  const double lower_xi_endpoint = xi_segment.endpoint(Side::Lower);
+  const auto valid_lower_xi_neighbors = TestHelpers::domain::valid_neighbors(
+      generator, element_id, Direction<Dim>::lower_xi(),
+      lower_xi_endpoint == -1.0 ? TestHelpers::domain::FaceType::Block
+                                : TestHelpers::domain::FaceType::Internal);
+  const double upper_xi_endpoint = xi_segment.endpoint(Side::Upper);
+  const auto valid_upper_xi_neighbors = TestHelpers::domain::valid_neighbors(
+      generator, element_id, Direction<Dim>::upper_xi(),
+      upper_xi_endpoint == 1.0 ? TestHelpers::domain::FaceType::Block
+                               : TestHelpers::domain::FaceType::Internal);
+  std::vector<Element<Dim>> result{};
+  for (const auto& [lower_xi_neighbors, upper_xi_neighbors] :
+       cartesian_product(valid_lower_xi_neighbors, valid_upper_xi_neighbors)) {
+    typename Element<Dim>::Neighbors_t neighbors{};
+    neighbors.emplace(Direction<Dim>::lower_xi(), lower_xi_neighbors);
+    neighbors.emplace(Direction<Dim>::upper_xi(), upper_xi_neighbors);
+    result.emplace_back(element_id, std::move(neighbors));
+  }
+  return result;
+}
+
+template <size_t Dim>
+std::vector<std::array<amr::Flag, Dim>> valid_parent_flags();
+
+template <>
+std::vector<std::array<amr::Flag, 1>> valid_parent_flags<1>() {
+  return std::vector{std::array{amr::Flag::Split}};
+}
+
+template <>
+std::vector<std::array<amr::Flag, 2>> valid_parent_flags<2>() {
+  return std::vector{
+      std::array{amr::Flag::Split, amr::Flag::Split},
+      std::array{amr::Flag::IncreaseResolution, amr::Flag::Split},
+      std::array{amr::Flag::Split, amr::Flag::IncreaseResolution}};
+}
+
+template <>
+std::vector<std::array<amr::Flag, 3>> valid_parent_flags<3>() {
+  return std::vector{
+      std::array{amr::Flag::Split, amr::Flag::Split, amr::Flag::Split},
+      std::array{amr::Flag::IncreaseResolution, amr::Flag::Split,
+                 amr::Flag::Split},
+      std::array{amr::Flag::Split, amr::Flag::IncreaseResolution,
+                 amr::Flag::Split},
+      std::array{amr::Flag::Split, amr::Flag::Split,
+                 amr::Flag::IncreaseResolution},
+      std::array{amr::Flag::Split, amr::Flag::IncreaseResolution,
+                 amr::Flag::IncreaseResolution},
+      std::array{amr::Flag::IncreaseResolution, amr::Flag::Split,
+                 amr::Flag::IncreaseResolution},
+      std::array{amr::Flag::IncreaseResolution, amr::Flag::IncreaseResolution,
+                 amr::Flag::Split}};
+}
+
+template <size_t Dim>
+TestHelpers::amr::valid_flags_t<Dim> valid_parent_neighbor_flags(
+    const Element<Dim>& element,
+    const std::array<::amr::Flag, Dim>& element_flags) {
+  TestHelpers::amr::valid_flags_t<Dim> result{};
+  const auto valid_lower_xi_neighbor_flags =
+      TestHelpers::amr::valid_neighbor_flags(
+          element.id(), element_flags,
+          element.neighbors().at(Direction<Dim>::lower_xi()));
+  const auto valid_upper_xi_neighbor_flags =
+      TestHelpers::amr::valid_neighbor_flags(
+          element.id(), element_flags,
+          element.neighbors().at(Direction<Dim>::upper_xi()));
+  for (const auto& lower_xi_neighbor_flags : valid_lower_xi_neighbor_flags) {
+    for (const auto& upper_xi_neighbor_flags : valid_upper_xi_neighbor_flags) {
+      auto joined_flags = lower_xi_neighbor_flags;
+      for (const auto& flags : upper_xi_neighbor_flags) {
+        joined_flags.emplace(flags);
+      }
+      result.emplace_back(joined_flags);
+    }
+  }
+  return result;
+}
+
+template <size_t Dim>
+void test(const gsl::not_null<std::mt19937*> generator) {
+  for (const auto& parent_id :
+       random_sample(3, element_ids_to_test<Dim>(), generator)) {
+    CAPTURE(parent_id);
+    for (const auto& parent :
+         random_sample(3, valid_elements(generator, parent_id), generator)) {
+      CAPTURE(parent);
+      for (const auto& parent_flags : valid_parent_flags<Dim>()) {
+        CAPTURE(parent_flags);
+        for (const auto& parent_neighbor_flags :
+             random_sample(3, valid_parent_neighbor_flags(parent, parent_flags),
+                           generator)) {
+          CAPTURE(parent_neighbor_flags);
+          for (const auto& child_id :
+               amr::ids_of_children(parent_id, parent_flags)) {
+            CAPTURE(child_id);
+            const auto new_neighbors = amr::neighbors_of_child(
+                parent, parent_flags, parent_neighbor_flags, child_id);
+            for (const auto& direction : std::vector{
+                     Direction<Dim>::lower_xi(), Direction<Dim>::upper_xi()}) {
+              TestHelpers::domain::check_neighbors(new_neighbors.at(direction),
+                                                   child_id, direction);
+            }
+          }
+        }
+      }
+    }
+  }
+}
+}  // namespace
+
+// [[TimeOut, 30]]
+SPECTRE_TEST_CASE("Unit.Domain.Amr.NeighborsOfChild", "[Domain][Unit]") {
+  MAKE_GENERATOR(generator);
+  test<1>(make_not_null(&generator));
+  test<2>(make_not_null(&generator));
+  test<3>(make_not_null(&generator));
+}

--- a/tests/Unit/Helpers/Domain/Structure/NeighborHelpers.cpp
+++ b/tests/Unit/Helpers/Domain/Structure/NeighborHelpers.cpp
@@ -464,7 +464,9 @@ std::vector<Neighbors<Dim>> valid_neighbors(
   const OrientationMap<Dim> aligned{};
   const size_t block_id = element_id.block_id();
   const size_t neighbor_block_id =
-      (face_type == FaceType::Block ? block_id + 1 : block_id);
+      (face_type == FaceType::Block
+           ? block_id + 2 * normal_dim + (side == Side::Lower ? 1 : 2)
+           : block_id);
   std::vector<Neighbors<Dim>> result;
   if (endpoint == 1.0 or endpoint == -1.0) {
     ASSERT(face_type != FaceType::Internal,

--- a/tests/Unit/ParallelAlgorithms/Amr/Actions/Test_InitializeChild.cpp
+++ b/tests/Unit/ParallelAlgorithms/Amr/Actions/Test_InitializeChild.cpp
@@ -1,0 +1,136 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+
+#include "Domain/Amr/Tags/Flags.hpp"
+#include "Domain/Amr/Tags/NeighborFlags.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/DirectionMap.hpp"
+#include "Domain/Structure/Element.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Domain/Structure/Neighbors.hpp"
+#include "Domain/Structure/OrientationMap.hpp"
+#include "Domain/Structure/SegmentId.hpp"
+#include "Domain/Tags.hpp"
+#include "Framework/ActionTesting.hpp"
+#include "Framework/MockRuntimeSystem.hpp"
+#include "Framework/MockRuntimeSystemFreeFunctions.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "Parallel/Phase.hpp"
+#include "Parallel/PhaseDependentActionList.hpp"
+#include "ParallelAlgorithms/Amr/Actions/InitializeChild.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace {
+
+template <typename Metavariables>
+struct Component {
+  using metavariables = Metavariables;
+  static constexpr size_t volume_dim = Metavariables::volume_dim;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = ElementId<volume_dim>;
+  using const_global_cache_tags = tmpl::list<>;
+  using simple_tags =
+      tmpl::list<domain::Tags::Element<volume_dim>,
+                 domain::Tags::Mesh<volume_dim>, amr::Tags::Flags<volume_dim>,
+                 amr::Tags::NeighborFlags<volume_dim>>;
+  using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
+      Parallel::Phase::Initialization,
+      tmpl::list<ActionTesting::InitializeDataBox<simple_tags>>>>;
+};
+
+struct Metavariables {
+  static constexpr size_t volume_dim = 2;
+  using component_list = tmpl::list<Component<Metavariables>>;
+};
+
+void test() {
+  using my_component = Component<Metavariables>;
+
+  const ElementId<2> parent_id{0, std::array{SegmentId{2, 1}, SegmentId{0, 0}}};
+  const ElementId<2> parent_lower_neighbor_id{
+      0, std::array{SegmentId{2, 0}, SegmentId{0, 0}}};
+  const ElementId<2> parent_upper_neighbor_id{
+      0, std::array{SegmentId{2, 2}, SegmentId{0, 0}}};
+  DirectionMap<2, Neighbors<2>> parent_neighbors{};
+  OrientationMap<2> aligned{};
+  parent_neighbors.emplace(
+      Direction<2>::lower_xi(),
+      Neighbors<2>{std::unordered_set{parent_lower_neighbor_id}, aligned});
+  parent_neighbors.emplace(
+      Direction<2>::upper_xi(),
+      Neighbors<2>{std::unordered_set{parent_upper_neighbor_id}, aligned});
+  Element<2> parent{parent_id, std::move(parent_neighbors)};
+  Mesh<2> parent_mesh{3, Spectral::Basis::Legendre,
+                      Spectral::Quadrature::GaussLobatto};
+  std::array<amr::Flag, 2> parent_flags{amr::Flag::Split,
+                                        amr::Flag::IncreaseResolution};
+  std::unordered_map<ElementId<2>, std::array<amr::Flag, 2>>
+      parent_neighbor_flags;
+  parent_neighbor_flags.emplace(
+      parent_lower_neighbor_id,
+      std::array{amr::Flag::DoNothing, amr::Flag::DoNothing});
+  parent_neighbor_flags.emplace(
+      parent_upper_neighbor_id,
+      std::array{amr::Flag::DoNothing, amr::Flag::Split});
+  const tuples::TaggedTuple<domain::Tags::Element<2>, domain::Tags::Mesh<2>,
+                            amr::Tags::Flags<2>, amr::Tags::NeighborFlags<2>>
+      parent_items{std::move(parent), std::move(parent_mesh),
+                   std::move(parent_flags), std::move(parent_neighbor_flags)};
+
+  const ElementId<2> child_id{0, std::array{SegmentId{3, 3}, SegmentId{0, 0}}};
+  const ElementId<2> expected_child_upper_neighbor_id_0{
+      0, std::array{SegmentId{2, 2}, SegmentId{1, 0}}};
+  const ElementId<2> expected_child_upper_neighbor_id_1{
+      0, std::array{SegmentId{2, 2}, SegmentId{1, 1}}};
+  const ElementId<2> sibling_id{0,
+                                std::array{SegmentId{3, 2}, SegmentId{0, 0}}};
+  DirectionMap<2, Neighbors<2>> expected_child_neighbors{};
+  expected_child_neighbors.emplace(
+      Direction<2>::lower_xi(),
+      Neighbors<2>{std::unordered_set{sibling_id}, aligned});
+  expected_child_neighbors.emplace(
+      Direction<2>::upper_xi(),
+      Neighbors<2>{std::unordered_set{expected_child_upper_neighbor_id_0,
+                                      expected_child_upper_neighbor_id_1},
+                   aligned});
+  const Element<2> expected_child{child_id,
+                                  std::move(expected_child_neighbors)};
+
+  const Mesh<2> expected_child_mesh{std::array{3_st, 4_st},
+                                    Spectral::Basis::Legendre,
+                                    Spectral::Quadrature::GaussLobatto};
+  const std::array<amr::Flag, 2> expected_child_flags{amr::Flag::Undefined,
+                                                      amr::Flag::Undefined};
+  const std::unordered_map<ElementId<2>, std::array<amr::Flag, 2>>
+      expected_child_neighbor_flags{};
+
+  ActionTesting::MockRuntimeSystem<Metavariables> runner{{}};
+  ActionTesting::emplace_component<my_component>(&runner, child_id);
+  ActionTesting::simple_action<my_component, amr::Actions::InitializeChild>(
+      make_not_null(&runner), child_id, parent_items);
+  CHECK(ActionTesting::get_databox_tag<my_component, domain::Tags::Element<2>>(
+            runner, child_id) == expected_child);
+  CHECK(ActionTesting::get_databox_tag<my_component, domain::Tags::Mesh<2>>(
+            runner, child_id) == expected_child_mesh);
+  CHECK(ActionTesting::get_databox_tag<my_component, amr::Tags::Flags<2>>(
+            runner, child_id) == expected_child_flags);
+  CHECK(
+      ActionTesting::get_databox_tag<my_component, amr::Tags::NeighborFlags<2>>(
+          runner, child_id) == expected_child_neighbor_flags);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Amr.Actions.InitializeChild",
+                  "[Unit][ParallelAlgorithms]") {
+  test();
+}

--- a/tests/Unit/ParallelAlgorithms/Amr/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/Amr/CMakeLists.txt
@@ -6,6 +6,7 @@ set(LIBRARY "Test_ParallelAmr")
 set(LIBRARY_SOURCES
   Actions/Test_EvaluateRefinementCriteria.cpp
   Actions/Test_Initialize.cpp
+  Actions/Test_InitializeChild.cpp
   Actions/Test_UpdateAmrDecision.cpp
   Criteria/Test_Criterion.cpp
   Criteria/Test_DriveToTarget.cpp


### PR DESCRIPTION
## Proposed changes

- This adds the action that will be called to initialize the data on each new element that was created by splitting an existing element.
- At the moment this only initializes the Element and Mesh, which is sufficient to test the infrastructure of AMR.
- A future PR will add the functionality for initializing the data needed for an evolution or elliptic system, most likely by calling a system dependent mutator (see the AdjustDomain action in #4773 for what I currently have in mind).  All the data needed by such a mutator is already being passed into the action in the `parent_items`.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
