### PR TITLE
dest_vars_from_src_vars now treats time-independent case with different tags.

### DIFF
--- a/src/ApparentHorizons/ComputeExcisionBoundaryVolumeQuantities.hpp
+++ b/src/ApparentHorizons/ComputeExcisionBoundaryVolumeQuantities.hpp
@@ -88,11 +88,9 @@ struct ComputeExcisionBoundaryVolumeQuantities
 
   template <typename TargetFrame>
   using allowed_dest_tags_target_frame = tmpl::list<
-      gr::Tags::SpatialMetric<3, Frame::Inertial>,
-      gr::Tags::SpatialMetric<3, Frame::Grid>,
-      gr::Tags::SpacetimeMetric<3, Frame::Inertial>,
-      gr::Tags::Lapse<DataVector>, gr::Tags::Shift<3, Frame::Inertial>,
-      gr::Tags::Shift<3, Frame::Grid>,
+      gr::Tags::SpatialMetric<3, TargetFrame>,
+      gr::Tags::SpacetimeMetric<3, TargetFrame>, gr::Tags::Lapse<DataVector>,
+      gr::Tags::Shift<3, TargetFrame>,
       GeneralizedHarmonic::ConstraintDamping::Tags::ConstraintGamma1>;
 
   template <typename TargetFrame>

--- a/src/ParallelAlgorithms/Interpolation/CMakeLists.txt
+++ b/src/ParallelAlgorithms/Interpolation/CMakeLists.txt
@@ -24,6 +24,7 @@ spectre_target_headers(
   IntrpOptionHolders.hpp
   PointInfoTag.hpp
   Tags.hpp
+  TagsMetafunctions.hpp
   )
 
 add_dependencies(

--- a/src/ParallelAlgorithms/Interpolation/TagsMetafunctions.hpp
+++ b/src/ParallelAlgorithms/Interpolation/TagsMetafunctions.hpp
@@ -1,0 +1,61 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+/// \file
+/// Defines metafunctions for manipulating Tags that refer to Tensors
+
+#pragma once
+
+#include "DataStructures/Tensor/IndexType.hpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace TensorMetafunctions {
+/// \ingroup TensorGroup
+/// \brief Replaces Tag with an equivalent Tag but in frame NewFrame
+template <typename Tag, typename NewFrame>
+struct replace_frame_in_tag {
+  // Base definition, for tags with no template parameters,
+  // like some scalars.
+  using type = Tag;
+};
+// Specialization for tensors in GeneralizedHarmonic::Tags
+template <template <size_t, typename> typename Tag, size_t Dim, typename Frame,
+          typename NewFrame>
+struct replace_frame_in_tag<Tag<Dim, Frame>, NewFrame> {
+  using type = Tag<Dim, NewFrame>;
+};
+// Specialization for tensors in gr::Tags
+template <template <size_t, typename, typename> typename Tag, size_t Dim,
+          typename Frame, typename DataType, typename NewFrame>
+struct replace_frame_in_tag<Tag<Dim, Frame, DataType>, NewFrame> {
+  using type = Tag<Dim, NewFrame, DataType>;
+};
+// Specialization for scalars in gr::Tags (which have a DataType).
+template <template <typename> typename Tag, typename DataType,
+          typename NewFrame>
+struct replace_frame_in_tag<Tag<DataType>, NewFrame> {
+  using type = Tag<DataType>;
+};
+// Specialization for Tags::deriv<Tag> with Tag in GeneralizedHarmonic::Tags
+template <template <size_t, typename> typename Tag, size_t Dim, typename Frame,
+          typename NewFrame>
+struct replace_frame_in_tag<
+    ::Tags::deriv<Tag<Dim, Frame>, tmpl::size_t<Dim>, Frame>, NewFrame> {
+  using type = ::Tags::deriv<Tag<Dim, NewFrame>, tmpl::size_t<Dim>, NewFrame>;
+};
+
+/// \ingroup TensorGroup
+/// \brief Replaces Tag with an equivalent Tag but in frame NewFrame
+template <typename Tag, typename NewFrame>
+using replace_frame_in_tag_t =
+    typename replace_frame_in_tag<Tag, NewFrame>::type;
+
+/// \ingroup TensorGroup
+/// \brief Replaces every Tag in Taglist with an equivalent Tag
+/// but in frame NewFrame
+template <typename TagList, typename NewFrame>
+using replace_frame_in_taglist =
+    tmpl::transform<TagList,
+                    tmpl::bind<replace_frame_in_tag_t, tmpl::_1, NewFrame>>;
+}  // namespace TensorMetafunctions

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_Tags.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_Tags.cpp
@@ -5,10 +5,14 @@
 
 #include <cstddef>
 
+#include "Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/Tags.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
 #include "Framework/TestCreation.hpp"
 #include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
 #include "ParallelAlgorithms/Interpolation/PointInfoTag.hpp"
 #include "ParallelAlgorithms/Interpolation/Tags.hpp"
+#include "ParallelAlgorithms/Interpolation/TagsMetafunctions.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
 #include "Utilities/TMPL.hpp"
 
 namespace {
@@ -24,9 +28,64 @@ struct Metavars {
 struct InterpolationTargetTag {
   using vars_to_interpolate_to_target = tmpl::list<>;
 };
+
+void test_tags_metafunctions() {
+  static_assert(
+      std::is_same_v<
+          TensorMetafunctions::replace_frame_in_tag_t<
+              GeneralizedHarmonic::Tags::Pi<3, Frame::Inertial>, Frame::Grid>,
+          GeneralizedHarmonic::Tags::Pi<3, Frame::Grid>>,
+      "Failed testing replace_frame_in_tag_t");
+  static_assert(
+      not std::is_same_v<
+          TensorMetafunctions::replace_frame_in_tag_t<
+              GeneralizedHarmonic::Tags::Pi<3, Frame::Inertial>, Frame::Grid>,
+          GeneralizedHarmonic::Tags::Pi<3, Frame::Distorted>>,
+      "Failed testing replace_frame_in_tag_t");
+  static_assert(
+      std::is_same_v<
+          TensorMetafunctions::replace_frame_in_tag_t<
+              gr::Tags::SpacetimeMetric<3, Frame::Inertial, DataVector>,
+              Frame::Grid>,
+          gr::Tags::SpacetimeMetric<3, Frame::Grid, DataVector>>,
+      "Failed testing replace_frame_in_tag_t");
+  static_assert(std::is_same_v<TensorMetafunctions::replace_frame_in_tag_t<
+                                   gr::Tags::Lapse<DataVector>, Frame::Grid>,
+                               gr::Tags::Lapse<DataVector>>,
+                "Failed testing replace_frame_in_tag_t");
+  static_assert(
+      std::is_same_v<
+          TensorMetafunctions::replace_frame_in_tag_t<
+              GeneralizedHarmonic::ConstraintDamping::Tags::ConstraintGamma0,
+              Frame::Grid>,
+          GeneralizedHarmonic::ConstraintDamping::Tags::ConstraintGamma0>,
+      "Failed testing replace_frame_in_tag_t");
+  static_assert(
+      std::is_same_v<
+          TensorMetafunctions::replace_frame_in_tag_t<
+              Tags::deriv<GeneralizedHarmonic::Tags::Phi<3, Frame::Inertial>,
+                          tmpl::size_t<3>, Frame::Inertial>,
+              Frame::Grid>,
+          Tags::deriv<GeneralizedHarmonic::Tags::Phi<3, Frame::Grid>,
+                      tmpl::size_t<3>, Frame::Grid>>,
+      "Failed testing replace_frame_in_tag_t");
+  static_assert(
+      std::is_same_v<
+          TensorMetafunctions::replace_frame_in_taglist<
+              tmpl::list<Tags::deriv<
+                             GeneralizedHarmonic::Tags::Phi<3, Frame::Inertial>,
+                             tmpl::size_t<3>, Frame::Inertial>,
+                         GeneralizedHarmonic::Tags::Pi<3, Frame::Distorted>>,
+              Frame::Grid>,
+          tmpl::list<Tags::deriv<GeneralizedHarmonic::Tags::Phi<3, Frame::Grid>,
+                                 tmpl::size_t<3>, Frame::Grid>,
+                     GeneralizedHarmonic::Tags::Pi<3, Frame::Grid>>>,
+      "Failed testing replace_frame_in_taglist");
+}
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Interpolation.Tags", "[Unit][NumericalAlgorithms]") {
+  test_tags_metafunctions();
   TestHelpers::db::test_simple_tag<intrp::Tags::DumpVolumeDataOnFailure>(
       "DumpVolumeDataOnFailure");
   TestHelpers::db::test_simple_tag<


### PR DESCRIPTION
## Proposed changes

dest_vars_from_src_vars now treats the case where the block is time-independent, but the Frame tags for source and destination variables are different (even though the Grid, Distorted, and Inertial frames are really the same). Previously it threw a runtime error in this case.

Also fixes some small bugs in ComputeExcisionBoundaryVolumeQuantities.

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
