### PR TITLE
Add option to use hard coded time dep maps in Sphere

### DIFF
--- a/src/Domain/Creators/CMakeLists.txt
+++ b/src/Domain/Creators/CMakeLists.txt
@@ -24,6 +24,7 @@ spectre_target_sources(
   RotatedIntervals.cpp
   RotatedRectangles.cpp
   Sphere.cpp
+  SphereTimeDependentMaps.cpp
   )
 
 spectre_target_headers(
@@ -52,6 +53,7 @@ spectre_target_headers(
   RotatedIntervals.hpp
   RotatedRectangles.hpp
   Sphere.hpp
+  SphereTimeDependentMaps.hpp
   )
 
 target_link_libraries(

--- a/src/Domain/Creators/SphereTimeDependentMaps.cpp
+++ b/src/Domain/Creators/SphereTimeDependentMaps.cpp
@@ -1,0 +1,122 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Domain/Creators/SphereTimeDependentMaps.hpp"
+
+#include <array>
+#include <limits>
+#include <memory>
+#include <optional>
+#include <string>
+#include <unordered_map>
+
+#include "DataStructures/DataVector.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
+#include "Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/ShapeMapTransitionFunction.hpp"
+#include "Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/SphereTransition.hpp"
+#include "Domain/FunctionsOfTime/FixedSpeedCubic.hpp"
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "Domain/FunctionsOfTime/PiecewisePolynomial.hpp"
+#include "Domain/FunctionsOfTime/QuaternionFunctionOfTime.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/YlmSpherepack.hpp"
+
+namespace domain::creators::sphere {
+TimeDependentMapOptions::TimeDependentMapOptions(
+    const double initial_time, const std::array<double, 3> initial_size_values,
+    const size_t initial_l_max)
+    : initial_time_(initial_time),
+      initial_size_values_(initial_size_values),
+      initial_l_max_(initial_l_max) {}
+
+std::unordered_map<std::string,
+                   std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
+TimeDependentMapOptions::create_functions_of_time(
+    const std::unordered_map<std::string, double>& initial_expiration_times)
+    const {
+  std::unordered_map<std::string,
+                     std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
+      result{};
+
+  // Get existing function of time names that are used for the maps and assign
+  // their initial expiration time to infinity (i.e. not expiring)
+  std::unordered_map<std::string, double> expiration_times{
+      {size_name, std::numeric_limits<double>::infinity()},
+      {shape_name, std::numeric_limits<double>::infinity()}};
+
+  // If we have control systems, overwrite these expiration times with the ones
+  // supplied by the control system
+  for (const auto& [name, expr_time] : initial_expiration_times) {
+    expiration_times[name] = expr_time;
+  }
+
+  // CompressionMap FunctionOfTime
+  result[size_name] = std::make_unique<FunctionsOfTime::PiecewisePolynomial<3>>(
+      initial_time_,
+      std::array<DataVector, 4>{{{gsl::at(initial_size_values_, 0)},
+                                 {gsl::at(initial_size_values_, 1)},
+                                 {gsl::at(initial_size_values_, 2)},
+                                 {0.0}}},
+      expiration_times.at(size_name));
+
+  const DataVector shape_zeros{
+      YlmSpherepack::spectral_size(initial_l_max_, initial_l_max_), 0.0};
+
+  // ShapeMap FunctionOfTime
+  result[shape_name] =
+      std::make_unique<FunctionsOfTime::PiecewisePolynomial<2>>(
+          initial_time_,
+          std::array<DataVector, 3>{{shape_zeros, shape_zeros, shape_zeros}},
+          expiration_times.at(shape_name));
+
+  return result;
+}
+
+void TimeDependentMapOptions::build_maps(const std::array<double, 3>& center,
+                                         const double inner_radius,
+                                         const double outer_radius) {
+  std::unique_ptr<domain::CoordinateMaps::ShapeMapTransitionFunctions::
+                      ShapeMapTransitionFunction>
+      transition_func =
+          std::make_unique<domain::CoordinateMaps::ShapeMapTransitionFunctions::
+                               SphereTransition>(inner_radius, outer_radius);
+  shape_map_ = ShapeMap{center,         initial_l_max_,
+                        initial_l_max_, std::move(transition_func),
+                        shape_name,     size_name};
+}
+
+// If you edit any of the functions below, be sure to update the documentation
+// in the Sphere domain creator as well as this class' documentation.
+TimeDependentMapOptions::MapType<Frame::Distorted, Frame::Inertial>
+TimeDependentMapOptions::distorted_to_inertial_map(
+    const bool include_distorted_map) {
+  if (include_distorted_map) {
+    return std::make_unique<
+        IdentityForComposition<Frame::Distorted, Frame::Inertial>>(
+        IdentityMap{});
+  } else {
+    return nullptr;
+  }
+}
+
+TimeDependentMapOptions::MapType<Frame::Grid, Frame::Distorted>
+TimeDependentMapOptions::grid_to_distorted_map(
+    const bool include_distorted_map) const {
+  if (include_distorted_map) {
+    return std::make_unique<GridToDistortedComposition>(shape_map_);
+  } else {
+    return nullptr;
+  }
+}
+
+TimeDependentMapOptions::MapType<Frame::Grid, Frame::Inertial>
+TimeDependentMapOptions::grid_to_inertial_map(
+    const bool include_distorted_map) const {
+  if (include_distorted_map) {
+    return std::make_unique<GridToInertialComposition>(shape_map_);
+  } else {
+    return std::make_unique<
+        IdentityForComposition<Frame::Grid, Frame::Inertial>>(IdentityMap{});
+  }
+}
+}  // namespace domain::creators::sphere

--- a/src/Domain/Creators/SphereTimeDependentMaps.hpp
+++ b/src/Domain/Creators/SphereTimeDependentMaps.hpp
@@ -1,0 +1,176 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <limits>
+#include <memory>
+#include <optional>
+#include <string>
+#include <type_traits>
+
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/Identity.hpp"
+#include "Domain/CoordinateMaps/TimeDependent/Shape.hpp"
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "Options/Options.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+namespace Frame {
+struct Grid;
+struct Distorted;
+struct Inertial;
+}  // namespace Frame
+/// \endcond
+
+namespace domain::creators::sphere {
+/*!
+ * \brief This holds all options related to the time dependent maps of the
+ * domain::creators::Sphere domain creator.
+ *
+ * \details Currently this class will only add a Size and a Shape map (and
+ * FunctionsOfTime) to the domain. Other maps can be added as needed.
+ *
+ * \note This struct contains no information about what blocks the time
+ * dependent maps will go in.
+ */
+struct TimeDependentMapOptions {
+ private:
+  template <typename SourceFrame, typename TargetFrame>
+  using MapType =
+      std::unique_ptr<domain::CoordinateMapBase<SourceFrame, TargetFrame, 3>>;
+  using IdentityMap = domain::CoordinateMaps::Identity<3>;
+  // Time-dependent maps
+  using ShapeMap = domain::CoordinateMaps::TimeDependent::Shape;
+
+  template <typename SourceFrame, typename TargetFrame>
+  using IdentityForComposition =
+      domain::CoordinateMap<SourceFrame, TargetFrame, IdentityMap>;
+  using GridToDistortedComposition =
+      domain::CoordinateMap<Frame::Grid, Frame::Distorted, ShapeMap>;
+  using GridToInertialComposition =
+      domain::CoordinateMap<Frame::Grid, Frame::Inertial, ShapeMap>;
+
+ public:
+  using maps_list =
+      tmpl::list<IdentityForComposition<Frame::Grid, Frame::Inertial>,
+                 IdentityForComposition<Frame::Grid, Frame::Distorted>,
+                 IdentityForComposition<Frame::Distorted, Frame::Inertial>,
+                 GridToDistortedComposition, GridToInertialComposition>;
+
+  /// \brief The initial time of the functions of time.
+  struct InitialTime {
+    using type = double;
+    static constexpr Options::String help = {
+        "The initial time of the functions of time"};
+  };
+
+  struct SizeMap {
+    static constexpr Options::String help = {
+        "Options for a time-dependent size map in the inner-most shell of the "
+        "domain."};
+  };
+
+  struct SizeMapInitialValues {
+    static std::string name() { return "InitialValues"; }
+    using type = std::array<double, 3>;
+    static constexpr Options::String help = {
+        "Initial value and two derivatives of the size map."};
+    using group = SizeMap;
+  };
+
+  struct ShapeMapOptions {
+    static std::string name() { return "ShapeMap"; }
+    static constexpr Options::String help = {
+        "Options for a time-dependent size map in the inner-most shell of the "
+        "domain."};
+  };
+
+  struct ShapeMapLmax {
+    static std::string name() { return "Lmax"; }
+    using type = size_t;
+    static constexpr Options::String help = {"Initial Lmax for the shape map."};
+    using group = ShapeMapOptions;
+  };
+
+  using options = tmpl::list<InitialTime, SizeMapInitialValues, ShapeMapLmax>;
+  static constexpr Options::String help{
+      "The options for all the hard-coded time dependent maps in the Sphere "
+      "domain."};
+
+  TimeDependentMapOptions() = default;
+
+  TimeDependentMapOptions(double initial_time,
+                          std::array<double, 3> initial_size_values,
+                          size_t initial_l_max);
+
+  /*!
+   * \brief Create the function of time map using the options that were
+   * provided to this class.
+   *
+   * Currently, this will add:
+   *
+   * - Size: `PiecewisePolynomial<3>`
+   * - Shape: `PiecewisePolynomial<2>`
+   */
+  std::unordered_map<std::string,
+                     std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
+  create_functions_of_time(const std::unordered_map<std::string, double>&
+                               initial_expiration_times) const;
+
+  /*!
+   * \brief Construct the actual maps that will be used.
+   *
+   * Currently, this constructs a:
+   *
+   * - Shape: `Shape` (with a size function of time)
+   */
+  void build_maps(const std::array<double, 3>& center, double inner_radius,
+                  double outer_radius);
+
+  /*!
+   * \brief This will construct the map from `Frame::Distorted` to
+   * `Frame::Inertial`.
+   *
+   * If the argument `include_distorted_map` is true, then this will be an
+   * identity map. If it is false, then this returns `nullptr`.
+   */
+  static MapType<Frame::Distorted, Frame::Inertial> distorted_to_inertial_map(
+      bool include_distorted_map);
+
+  /*!
+   * \brief This will construct the map from `Frame::Grid` to
+   * `Frame::Distorted`.
+   *
+   * If the argument `include_distorted_map` is true, then this will add a
+   * `Shape` map (with a size function of time). If it is false, then this
+   * returns `nullptr`.
+   */
+  MapType<Frame::Grid, Frame::Distorted> grid_to_distorted_map(
+      bool include_distorted_map) const;
+
+  /*!
+   * \brief This will construct the map from `Frame::Grid` to `Frame::Inertial`.
+   *
+   * If the argument `include_distorted_map` is true, then this map will have a
+   * `Shape` map (with a size function of time). If it is false, then there will
+   * only be an identity map.
+   */
+  MapType<Frame::Grid, Frame::Inertial> grid_to_inertial_map(
+      bool include_distorted_map) const;
+
+  inline static const std::string size_name{"Size"};
+  inline static const std::string shape_name{"Shape"};
+
+ private:
+  double initial_time_{std::numeric_limits<double>::signaling_NaN()};
+  std::array<double, 3> initial_size_values_{
+      std::numeric_limits<double>::signaling_NaN(),
+      std::numeric_limits<double>::signaling_NaN(),
+      std::numeric_limits<double>::signaling_NaN()};
+  size_t initial_l_max_{};
+  ShapeMap shape_map_{};
+};
+}  // namespace domain::creators::sphere

--- a/tests/InputFiles/FindHorizons/FindHorizons3D.yaml
+++ b/tests/InputFiles/FindHorizons/FindHorizons3D.yaml
@@ -23,7 +23,7 @@ DomainCreator:
     WhichWedges: All
     RadialPartitioning: []
     RadialDistribution: [Logarithmic]
-    TimeDependence: None
+    TimeDependentMaps: None
 
 Importers:
   VolumeData:

--- a/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
@@ -61,7 +61,7 @@ DomainCreator:
     RadialPartitioning: []
     RadialDistribution: [Logarithmic]
     WhichWedges: All
-    TimeDependence: None
+    TimeDependentMaps: None
     OuterBoundaryCondition:
       DirichletAnalytic:
         AnalyticPrescription: *InitialData

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/BinaryNeutronStar.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/BinaryNeutronStar.yaml
@@ -34,7 +34,7 @@ DomainCreator:
     RadialDistribution: [Linear]
     EquatorialCompression: None
     WhichWedges: All
-    TimeDependence: None
+    TimeDependentMaps: None
     OuterBoundaryCondition:
       ConstraintPreservingFreeOutflow:
         Type: ConstraintPreservingPhysical

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdBondiMichel.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdBondiMichel.yaml
@@ -54,7 +54,7 @@ DomainCreator:
     WhichWedges: All
     RadialPartitioning: []
     RadialDistribution: [Logarithmic]
-    TimeDependence: None
+    TimeDependentMaps: None
     OuterBoundaryCondition:
       ProductDirichletAnalyticAndDirichletAnalytic:
         GeneralizedHarmonicDirichletAnalytic:

--- a/tests/InputFiles/Punctures/MultiplePunctures.yaml
+++ b/tests/InputFiles/Punctures/MultiplePunctures.yaml
@@ -35,7 +35,7 @@ DomainCreator:
     UseEquiangularMap: True
     EquatorialCompression: None
     WhichWedges: All
-    TimeDependence: None
+    TimeDependentMaps: None
     OuterBoundaryCondition: Flatness
 
 Discretization:

--- a/tests/InputFiles/Xcts/KerrSchild.yaml
+++ b/tests/InputFiles/Xcts/KerrSchild.yaml
@@ -43,7 +43,7 @@ DomainCreator:
     WhichWedges: All
     RadialPartitioning: []
     RadialDistribution: [Logarithmic]
-    TimeDependence: None
+    TimeDependentMaps: None
     OuterBoundaryCondition:
       AnalyticSolution:
         ConformalFactor: Dirichlet

--- a/tests/InputFiles/Xcts/TovStar.yaml
+++ b/tests/InputFiles/Xcts/TovStar.yaml
@@ -42,7 +42,7 @@ DomainCreator:
     UseEquiangularMap: True
     EquatorialCompression: None
     WhichWedges: All
-    TimeDependence: None
+    TimeDependentMaps: None
     OuterBoundaryCondition:
       AnalyticSolution:
         ConformalFactor: Dirichlet

--- a/tests/Unit/Domain/Creators/CMakeLists.txt
+++ b/tests/Unit/Domain/Creators/CMakeLists.txt
@@ -23,6 +23,7 @@ set(LIBRARY_SOURCES
   Test_RotatedIntervals.cpp
   Test_RotatedRectangles.cpp
   Test_Sphere.cpp
+  Test_SphereTimeDependentMaps.cpp
   )
 
 add_test_library(

--- a/tests/Unit/Domain/Creators/Test_SphereTimeDependentMaps.cpp
+++ b/tests/Unit/Domain/Creators/Test_SphereTimeDependentMaps.cpp
@@ -1,0 +1,108 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <limits>
+#include <memory>
+#include <string>
+#include <unordered_map>
+
+#include "DataStructures/DataVector.hpp"
+#include "Domain/Creators/SphereTimeDependentMaps.hpp"
+#include "Domain/FunctionsOfTime/FixedSpeedCubic.hpp"
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "Domain/FunctionsOfTime/PiecewisePolynomial.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeArray.hpp"
+
+namespace Frame {
+struct Grid;
+struct Distorted;
+struct Inertial;
+}  // namespace Frame
+
+namespace domain::creators::sphere {
+namespace {
+void test() {
+  const double initial_time = 1.5;
+  const std::array<double, 3> size_values{0.9, 0.08, 0.007};
+  const size_t l_max = 8;
+
+  TimeDependentMapOptions time_dep_options{initial_time, size_values, l_max};
+
+  std::unordered_map<std::string, double> expiration_times{
+      {TimeDependentMapOptions::shape_name, 15.5},
+      {TimeDependentMapOptions::size_name,
+       std::numeric_limits<double>::infinity()}};
+
+  // These are hard-coded so this is just a regression test
+  CHECK(TimeDependentMapOptions::size_name == "Size"s);
+  CHECK(TimeDependentMapOptions::shape_name == "Shape"s);
+
+  using PP2 = domain::FunctionsOfTime::PiecewisePolynomial<2>;
+  using PP3 = domain::FunctionsOfTime::PiecewisePolynomial<3>;
+  PP3 size{initial_time,
+           std::array<DataVector, 4>{{{gsl::at(size_values, 0)},
+                                      {gsl::at(size_values, 1)},
+                                      {gsl::at(size_values, 2)},
+                                      {0.0}}},
+           expiration_times.at(TimeDependentMapOptions::size_name)};
+  const DataVector shape_zeros{YlmSpherepack::spectral_size(l_max, l_max), 0.0};
+  PP2 shape{initial_time,
+            std::array<DataVector, 3>{shape_zeros, shape_zeros, shape_zeros},
+            expiration_times.at(TimeDependentMapOptions::shape_name)};
+
+  const auto functions_of_time =
+      time_dep_options.create_functions_of_time(expiration_times);
+
+  CHECK(dynamic_cast<PP3&>(
+            *functions_of_time.at(TimeDependentMapOptions::size_name).get()) ==
+        size);
+  CHECK(dynamic_cast<PP2&>(
+            *functions_of_time.at(TimeDependentMapOptions::shape_name).get()) ==
+        shape);
+
+  const std::array<double, 3> center{-5.0, -0.01, -0.02};
+  const double inner_radius = 0.5;
+  const double outer_radius = 2.1;
+
+  for (const bool include_distorted : make_array(true, false)) {
+    time_dep_options.build_maps(center, inner_radius, outer_radius);
+
+    const auto grid_to_distorted_map =
+        time_dep_options.grid_to_distorted_map(include_distorted);
+    const auto grid_to_inertial_map =
+        time_dep_options.grid_to_inertial_map(include_distorted);
+    const auto distorted_to_inertial_map =
+        time_dep_options.distorted_to_inertial_map(include_distorted);
+
+    // All of these maps are tested individually. Rather than going through the
+    // effort of coming up with a source coordinate and calculating analytically
+    // what we would get after it's mapped, we just check that whether it's
+    // supposed to be a nullptr and if it's not, if it's the identity and that
+    // the jacobians are time dependent.
+    const auto check_map = [](const auto& map, const bool is_null,
+                              const bool is_identity) {
+      if (is_null) {
+        CHECK(map == nullptr);
+      } else {
+        CHECK(map->is_identity() == is_identity);
+        CHECK(map->inv_jacobian_is_time_dependent() == not is_identity);
+        CHECK(map->jacobian_is_time_dependent() == not is_identity);
+      }
+    };
+
+    check_map(grid_to_inertial_map, false, not include_distorted);
+    check_map(grid_to_distorted_map, not include_distorted, false);
+    check_map(distorted_to_inertial_map, not include_distorted, true);
+  }
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Domain.Creators.SphereTimeDependentMaps",
+                  "[Domain][Unit]") {
+  test();
+}
+}  // namespace domain::creators::sphere


### PR DESCRIPTION
## Proposed changes

Adds the ability to choose to use a TimeDependence or hard-coded time dependent maps in the Sphere domain creator. To have no time dependent maps, still specify `None`. Currently, the hard coded maps are

- Inner-most shell: a size and shape map from grid to distorted frame, identity map from distorted to inertial frame
- All other shells: no distorted frame. Only an identity map from grid to inertial
- Inner cube: Cannot have an inner cube (at the moment) when using hard coded time dependent maps

In the future we can add more maps and change where we place them, but this is sufficient for me to test shape control on a single BH while maintaining the flexibility of having TimeDependences for others.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
If you are using the `Sphere` domain creator, the name of the time dependent options has changed from
```yaml
Sphere:
  ...
  TimeDependence:
    ...
```
to
```yaml
Sphere:
  ...
  TimeDependentMaps:
    ...
```

To specify no time dependent maps, still use `None` as before like
```yaml
Sphere:
  ...
  TimeDependentMaps: None
```
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
