### PR TITLE
Load config file in CLI

### DIFF
--- a/tests/support/Python/CMakeLists.txt
+++ b/tests/support/Python/CMakeLists.txt
@@ -2,10 +2,10 @@
 # See LICENSE.txt for details.
 
 if (BUILD_PYTHON_BINDINGS)
-  add_test(NAME "support.Python.main"
+  add_test(NAME "support.Python.Cli"
     COMMAND ${CMAKE_BINARY_DIR}/bin/spectre --version)
   set_tests_properties(
-    "support.Python.main" PROPERTIES
+    "support.Python.Cli" PROPERTIES
     PASS_REGULAR_EXPRESSION "${SPECTRE_VERSION}"
     LABELS "python")
 
@@ -22,4 +22,10 @@ spectre_add_python_bindings_test(
   "support.Machines"
   Test_Machines.py
   "Machines"
+  None)
+
+spectre_add_python_bindings_test(
+  "support.Python.Main"
+  Test_Main.py
+  "Python"
   None)

--- a/tests/support/Python/Test_Main.py
+++ b/tests/support/Python/Test_Main.py
@@ -1,0 +1,49 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import os
+import shutil
+import unittest
+
+import yaml
+from click.testing import CliRunner
+from spectre.__main__ import cli
+from spectre.Informer import unit_test_build_path, unit_test_src_path
+from spectre.tools.CleanOutput import MissingExpectedOutputError
+
+
+class TestMain(unittest.TestCase):
+    def setUp(self):
+        self.test_dir = os.path.join(unit_test_build_path(),
+                                     "support/Python/Main")
+        os.makedirs(self.test_dir, exist_ok=True)
+
+    def tearDown(self):
+        shutil.rmtree(self.test_dir)
+
+    def test_config_file(self):
+        # Collect some test data
+        input_file = os.path.join(
+            unit_test_src_path(),
+            "../InputFiles/Poisson/ProductOfSinusoids1D.yaml")
+        # Create a config file
+        config_file_path = os.path.join(self.test_dir, "config.yaml")
+        with open(config_file_path, "w") as open_config_file:
+            yaml.safe_dump({"clean-output": {"force": True}}, open_config_file)
+        # Run. The 'clean-output' command should fail because there's no data to
+        # clean up in the test dir, but with the 'force' option from the config
+        # file it should pass.
+        runner = CliRunner()
+        with self.assertRaises(MissingExpectedOutputError):
+            runner.invoke(cli,
+                          ["clean-output", "-o", self.test_dir, input_file],
+                          catch_exceptions=False)
+        result = runner.invoke(
+            cli, ["clean-output", "-o", self.test_dir, input_file],
+            catch_exceptions=False,
+            env={"SPECTRE_CONFIG_FILE": config_file_path})
+        self.assertEqual(result.exit_code, 0, result.output)
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Proposed changes

The config file is expected in `~/.config/spectre.yaml` but can also be set with the `SPECTRE_CONFIG_FILE` environment variable. Suggestions welcome for the default place of the config file.

Options listed in the config file are used as defaults in the CLI subcommands. For example, this is a valid config file:

```yaml
status:
  starttime: now-2days
  state_styles:
    RUNNING: blink  # if this really is what you desire
```

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
