### PR TITLE
Add two AMR actions used when creating new child elements

### DIFF
--- a/src/ParallelAlgorithms/Amr/Actions/CMakeLists.txt
+++ b/src/ParallelAlgorithms/Amr/Actions/CMakeLists.txt
@@ -7,11 +7,13 @@ spectre_target_headers(
   HEADERS
   Actions.hpp
   Component.hpp
+  CreateChild.hpp
   EvaluateRefinementCriteria.hpp
   Initialization.hpp
   Initialize.hpp
   InitializeChild.hpp
   RunAmrDiagnostics.hpp
   SendAmrDiagnostics.hpp
+  SendDataToChildren.hpp
   UpdateAmrDecision.hpp
   )

--- a/src/ParallelAlgorithms/Amr/Actions/CreateChild.hpp
+++ b/src/ParallelAlgorithms/Amr/Actions/CreateChild.hpp
@@ -1,0 +1,74 @@
+
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <charm++.h>
+#include <iterator>
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "Parallel/Callback.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "Parallel/Phase.hpp"
+#include "ParallelAlgorithms/Amr/Actions/SendDataToChildren.hpp"
+#include "Utilities/Algorithm.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+
+/// \cond
+namespace db {
+template <typename>
+class DataBox;
+}  // namespace db
+/// \endcond
+
+namespace amr::Actions {
+/// \brief Creates a new element in an ArrayAlgorithm whose id is `child_id`
+///
+/// \details This action is meant to be initially invoked by
+/// amr::Actions::AdjustDomain on the amr::Component.  This action inserts a new
+/// element with id `children_ids[index_of_child_id]` in the array referenced by
+/// `element_proxy`.  A Parallel::SimpleActionCallback is passed to the
+/// constructor of the new DistributedObject.  If `index_of_child_id` is that of
+/// the last element of `children_ids`, the Parallel::SimpleActionCallback will
+/// invoke amr::Actions::SendDataToChildren on the element with id `parent_id`.
+/// Otherwise, it will invoke amr::Actions::CreateChild on the next element of
+/// `children_ids`.
+///
+/// This action does not modify anything in the DataBox
+struct CreateChild {
+  template <typename ParallelComponent, typename DbTagList,
+            typename Metavariables, typename ElementProxy>
+  static void apply(
+      db::DataBox<DbTagList>& /*box*/,
+      Parallel::GlobalCache<Metavariables>& cache, const int /*array_index*/,
+      ElementProxy element_proxy,
+      ElementId<Metavariables::volume_dim> parent_id,
+      std::vector<ElementId<Metavariables::volume_dim>> children_ids,
+      const size_t index_of_child_id) {
+    auto my_proxy = Parallel::get_parallel_component<ParallelComponent>(cache);
+    const ElementId<Metavariables::volume_dim>& child_id =
+        children_ids[index_of_child_id];
+    if (index_of_child_id + 1 == children_ids.size()) {
+      auto parent_proxy = element_proxy[parent_id];
+      element_proxy[child_id].insert(
+          cache.thisProxy, Parallel::Phase::AdjustDomain,
+          std::make_unique<Parallel::SimpleActionCallback<
+              SendDataToChildren, decltype(parent_proxy),
+              std::vector<ElementId<Metavariables::volume_dim>>>>(
+              parent_proxy, std::move(children_ids)));
+    } else {
+      element_proxy[child_id].insert(
+          cache.thisProxy, Parallel::Phase::AdjustDomain,
+          std::make_unique<Parallel::SimpleActionCallback<
+              CreateChild, decltype(my_proxy), ElementProxy,
+              ElementId<Metavariables::volume_dim>,
+              std::vector<ElementId<Metavariables::volume_dim>>, size_t>>(
+              my_proxy, std::move(element_proxy), std::move(parent_id),
+              std::move(children_ids), index_of_child_id + 1));
+    }
+  }
+};
+}  // namespace amr::Actions

--- a/src/ParallelAlgorithms/Amr/Actions/SendDataToChildren.hpp
+++ b/src/ParallelAlgorithms/Amr/Actions/SendDataToChildren.hpp
@@ -1,0 +1,43 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <vector>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "Parallel/Invoke.hpp"
+#include "ParallelAlgorithms/Amr/Actions/InitializeChild.hpp"
+
+namespace amr::Actions {
+/// \brief Sends data from the parent element to its children elements during
+/// adaptive mesh refinement
+///
+/// \details  This action should be called after all children elements have been
+/// created by amr::Actions::CreateChild.  This action sends a copy of all items
+/// corresponding to the mutable_item_creation_tags of `box` to each of the
+/// elements with `ids_of_children`.  Finally, the parent element destroys
+/// itself.
+struct SendDataToChildren {
+  template <typename ParallelComponent, typename DbTagList,
+            typename Metavariables>
+  static void apply(db::DataBox<DbTagList>& box,
+                    Parallel::GlobalCache<Metavariables>& cache,
+                    const ElementId<Metavariables::volume_dim>& element_id,
+                    const std::vector<ElementId<Metavariables::volume_dim>>&
+                        ids_of_children) {
+    auto& array_proxy =
+        Parallel::get_parallel_component<ParallelComponent>(cache);
+    for (const auto& child_id : ids_of_children) {
+      Parallel::simple_action<amr::Actions::InitializeChild>(
+          array_proxy[child_id],
+          db::copy_items<
+              typename db::DataBox<DbTagList>::mutable_item_creation_tags>(
+              box));
+    }
+    array_proxy[element_id].ckDestroy();
+  }
+};
+}  // namespace amr::Actions

--- a/tests/Unit/Framework/ActionTesting.hpp
+++ b/tests/Unit/Framework/ActionTesting.hpp
@@ -518,6 +518,20 @@ class MockDistributedObjectProxy : public CProxyElement_ArrayElement {
                : nullptr;
   }
 
+  // This does not create a new MockDistributedObject as dynamically
+  // creating/destroying MockDistributedObjects is not supported; it must be
+  // called on an existing MockDistrubtedObject.
+  template <typename CacheProxy>
+  void insert(const CacheProxy& /*global_cache_proxy*/,
+              Parallel::Phase /*current_phase*/,
+              const std::unique_ptr<Parallel::Callback>& callback) {
+    callback->invoke();
+  }
+
+  // This does nothing as dynamically creating/destroying MockDistributedObjects
+  // is not supported; the mock object will still exist...
+  void ckDestroy() {}
+
   // NOLINTNEXTLINE(google-runtime-references)
   void pup(PUP::er& /*p*/) {
     ERROR(

--- a/tests/Unit/ParallelAlgorithms/Amr/Actions/Test_CreateChild.cpp
+++ b/tests/Unit/ParallelAlgorithms/Amr/Actions/Test_CreateChild.cpp
@@ -1,0 +1,168 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <pup.h>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include "Domain/Amr/Helpers.hpp"
+#include "Domain/Amr/Tags/Flags.hpp"
+#include "Domain/Amr/Tags/NeighborFlags.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/DirectionMap.hpp"
+#include "Domain/Structure/Element.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Domain/Structure/Neighbors.hpp"
+#include "Domain/Structure/OrientationMap.hpp"
+#include "Domain/Structure/SegmentId.hpp"
+#include "Domain/Tags.hpp"
+#include "Framework/ActionTesting.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "Parallel/Phase.hpp"
+#include "Parallel/PhaseDependentActionList.hpp"
+#include "ParallelAlgorithms/Amr/Actions/CreateChild.hpp"
+#include "Utilities/Literals.hpp"
+
+namespace {
+
+struct MockSendDataToChildren {
+  template <typename ParallelComponent, typename DataBox,
+            typename Metavariables, typename... Tags>
+  static void apply(DataBox& /*box*/,
+                    const Parallel::GlobalCache<Metavariables>& /*cache*/,
+                    const ElementId<Metavariables::volume_dim>& /*parent_id*/,
+                    const std::vector<ElementId<Metavariables::volume_dim>>&
+                        ids_of_children) {
+    CHECK(ids_of_children ==
+          std::vector{ElementId<1>{0, std::array{SegmentId{3, 2}}},
+                      ElementId<1>{0, std::array{SegmentId{3, 3}}}});
+  }
+};
+
+template <typename Metavariables>
+struct ArrayComponent {
+  using metavariables = Metavariables;
+  static constexpr size_t volume_dim = Metavariables::volume_dim;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = ElementId<volume_dim>;
+  using const_global_cache_tags = tmpl::list<>;
+  using simple_tags =
+      tmpl::list<domain::Tags::Element<volume_dim>,
+                 domain::Tags::Mesh<volume_dim>, amr::Tags::Flags<volume_dim>,
+                 amr::Tags::NeighborFlags<volume_dim>>;
+  using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
+      Parallel::Phase::Initialization,
+      tmpl::list<ActionTesting::InitializeDataBox<simple_tags>>>>;
+  using replace_these_simple_actions =
+      tmpl::list<amr::Actions::SendDataToChildren>;
+  using with_these_simple_actions = tmpl::list<MockSendDataToChildren>;
+};
+
+template <typename Metavariables>
+struct SingletonComponent {
+  using metavariables = Metavariables;
+  using array_index = int;
+  static constexpr size_t volume_dim = Metavariables::volume_dim;
+  using chare_type = ActionTesting::MockSingletonChare;
+  using const_global_cache_tags = tmpl::list<>;
+  using simple_tags = tmpl::list<>;
+  using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
+      Parallel::Phase::Initialization,
+      tmpl::list<ActionTesting::InitializeDataBox<simple_tags>>>>;
+};
+
+struct Metavariables {
+  static constexpr size_t volume_dim = 1;
+  using component_list = tmpl::list<ArrayComponent<Metavariables>,
+                                    SingletonComponent<Metavariables>>;
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& /*p*/) {}
+};
+
+void test() {
+  using array_component = ArrayComponent<Metavariables>;
+  using singleton_component = SingletonComponent<Metavariables>;
+  const ElementId<1> parent_id{0, std::array{SegmentId{2, 1}}};
+  const ElementId<1> parent_lower_neighbor_id{0, std::array{SegmentId{2, 0}}};
+  const ElementId<1> parent_upper_neighbor_id{0, std::array{SegmentId{2, 2}}};
+  DirectionMap<1, Neighbors<1>> parent_neighbors{};
+  OrientationMap<1> aligned{};
+  parent_neighbors.emplace(
+      Direction<1>::lower_xi(),
+      Neighbors<1>{std::unordered_set{parent_lower_neighbor_id}, aligned});
+  parent_neighbors.emplace(
+      Direction<1>::upper_xi(),
+      Neighbors<1>{std::unordered_set{parent_upper_neighbor_id}, aligned});
+  Element<1> parent{parent_id, std::move(parent_neighbors)};
+  Mesh<1> parent_mesh{3, Spectral::Basis::Legendre,
+                      Spectral::Quadrature::GaussLobatto};
+  std::array<amr::Flag, 1> parent_flags{amr::Flag::Split};
+  std::unordered_map<ElementId<1>, std::array<amr::Flag, 1>>
+      parent_neighbor_flags;
+  parent_neighbor_flags.emplace(parent_lower_neighbor_id,
+                                std::array{amr::Flag::DoNothing});
+  parent_neighbor_flags.emplace(parent_upper_neighbor_id,
+                                std::array{amr::Flag::DoNothing});
+  const auto children_ids = amr::ids_of_children(parent_id, parent_flags);
+
+  ActionTesting::MockRuntimeSystem<Metavariables> runner{{}};
+  ActionTesting::emplace_component_and_initialize<array_component>(
+      &runner, parent_id,
+      {parent, parent_mesh, parent_flags, parent_neighbor_flags});
+  ActionTesting::emplace_component<singleton_component>(&runner, 0);
+  for (const auto& child_id : children_ids) {
+    ActionTesting::emplace_component<array_component>(&runner, child_id);
+    CHECK(ActionTesting::is_simple_action_queue_empty<array_component>(
+        runner, child_id));
+  }
+  CHECK(ActionTesting::is_simple_action_queue_empty<singleton_component>(runner,
+                                                                         0));
+  CHECK(ActionTesting::is_simple_action_queue_empty<array_component>(
+      runner, parent_id));
+
+  auto& cache = ActionTesting::cache<array_component>(runner, parent_id);
+  auto& element_proxy =
+      Parallel::get_parallel_component<array_component>(cache);
+
+  // Call CreateChild, creating the first child and queueing CreateChild on
+  // the singleton component in order to create the second child
+  ActionTesting::simple_action<singleton_component, amr::Actions::CreateChild>(
+      make_not_null(&runner), 0, element_proxy, parent_id, children_ids, 0_st);
+  for (const auto& child_id : children_ids) {
+    CHECK(ActionTesting::is_simple_action_queue_empty<array_component>(
+        runner, child_id));
+  }
+  CHECK(ActionTesting::number_of_queued_simple_actions<singleton_component>(
+            runner, 0) == 1);
+  CHECK(ActionTesting::is_simple_action_queue_empty<array_component>(
+      runner, parent_id));
+
+  // Call CreateChild, creating the second child and queueing SendDataToChildren
+  // on the parent element in order to send data to the first child
+  ActionTesting::invoke_queued_simple_action<singleton_component>(
+      make_not_null(&runner), 0);
+  for (const auto& child_id : children_ids) {
+    CHECK(ActionTesting::is_simple_action_queue_empty<array_component>(
+        runner, child_id));
+  }
+  CHECK(ActionTesting::is_simple_action_queue_empty<singleton_component>(runner,
+                                                                         0));
+  CHECK(ActionTesting::number_of_queued_simple_actions<array_component>(
+            runner, parent_id) == 1);
+  // Invoke the mock action to check that CreateChild sent the correct data to
+  // SendDataToChildren
+  ActionTesting::invoke_queued_simple_action<array_component>(
+      make_not_null(&runner), parent_id);
+  CHECK(ActionTesting::is_simple_action_queue_empty<array_component>(
+      runner, parent_id));
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Amr.Actions.CreateChild",
+                  "[Unit][ParallelAlgorithms]") {
+  test();
+}

--- a/tests/Unit/ParallelAlgorithms/Amr/Actions/Test_SendDataToChildren.cpp
+++ b/tests/Unit/ParallelAlgorithms/Amr/Actions/Test_SendDataToChildren.cpp
@@ -1,0 +1,143 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <pup.h>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include "Domain/Amr/Helpers.hpp"
+#include "Domain/Amr/Tags/Flags.hpp"
+#include "Domain/Amr/Tags/NeighborFlags.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/DirectionMap.hpp"
+#include "Domain/Structure/Element.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Domain/Structure/Neighbors.hpp"
+#include "Domain/Structure/OrientationMap.hpp"
+#include "Domain/Structure/SegmentId.hpp"
+#include "Domain/Tags.hpp"
+#include "Framework/ActionTesting.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "Parallel/Phase.hpp"
+#include "Parallel/PhaseDependentActionList.hpp"
+#include "ParallelAlgorithms/Amr/Actions/SendDataToChildren.hpp"
+
+namespace {
+
+Element<1> create_parent() {
+  const ElementId<1> parent_id{0, std::array{SegmentId{2, 1}}};
+  const ElementId<1> parent_lower_neighbor_id{0, std::array{SegmentId{2, 0}}};
+  const ElementId<1> parent_upper_neighbor_id{0, std::array{SegmentId{2, 2}}};
+  DirectionMap<1, Neighbors<1>> parent_neighbors{};
+  OrientationMap<1> aligned{};
+  parent_neighbors.emplace(
+      Direction<1>::lower_xi(),
+      Neighbors<1>{std::unordered_set{parent_lower_neighbor_id}, aligned});
+  parent_neighbors.emplace(
+      Direction<1>::upper_xi(),
+      Neighbors<1>{std::unordered_set{parent_upper_neighbor_id}, aligned});
+  return Element<1>{parent_id, std::move(parent_neighbors)};
+}
+
+Mesh<1> create_parent_mesh() {
+  return Mesh<1>{3, Spectral::Basis::Legendre,
+                 Spectral::Quadrature::GaussLobatto};
+}
+
+std::array<amr::Flag, 1> create_parent_flags() {
+  return std::array{amr::Flag::Split};
+}
+
+std::unordered_map<ElementId<1>, std::array<amr::Flag, 1>>
+create_parent_neighbor_flags() {
+  const ElementId<1> parent_lower_neighbor_id{0, std::array{SegmentId{2, 0}}};
+  const ElementId<1> parent_upper_neighbor_id{0, std::array{SegmentId{2, 2}}};
+  std::unordered_map<ElementId<1>, std::array<amr::Flag, 1>> result{};
+  result.emplace(parent_lower_neighbor_id, std::array{amr::Flag::DoNothing});
+  result.emplace(parent_upper_neighbor_id, std::array{amr::Flag::DoNothing});
+  return result;
+}
+
+struct MockInitializeChild {
+  template <typename ParallelComponent, typename DataBox,
+            typename Metavariables, typename... Tags>
+  static void apply(DataBox& /*box*/,
+                    const Parallel::GlobalCache<Metavariables>& /*cache*/,
+                    const ElementId<Metavariables::volume_dim>& /*child_id*/,
+                    const tuples::TaggedTuple<Tags...>& parent_items) {
+    CHECK(get<domain::Tags::Element<1>>(parent_items) == create_parent());
+    CHECK(get<domain::Tags::Mesh<1>>(parent_items) == create_parent_mesh());
+    CHECK(get<amr::Tags::Flags<1>>(parent_items) == create_parent_flags());
+    CHECK(get<amr::Tags::NeighborFlags<1>>(parent_items) ==
+          create_parent_neighbor_flags());
+  }
+};
+
+template <typename Metavariables>
+struct Component {
+  using metavariables = Metavariables;
+  static constexpr size_t volume_dim = Metavariables::volume_dim;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = ElementId<volume_dim>;
+  using const_global_cache_tags = tmpl::list<>;
+  using simple_tags =
+      tmpl::list<domain::Tags::Element<volume_dim>,
+                 domain::Tags::Mesh<volume_dim>, amr::Tags::Flags<volume_dim>,
+                 amr::Tags::NeighborFlags<volume_dim>>;
+  using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
+      Parallel::Phase::Initialization,
+      tmpl::list<ActionTesting::InitializeDataBox<simple_tags>>>>;
+  using replace_these_simple_actions =
+      tmpl::list<amr::Actions::InitializeChild>;
+  using with_these_simple_actions = tmpl::list<MockInitializeChild>;
+};
+
+struct Metavariables {
+  static constexpr size_t volume_dim = 1;
+  using component_list = tmpl::list<Component<Metavariables>>;
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& /*p*/) {}
+};
+
+void test() {
+  using my_component = Component<Metavariables>;
+  const auto parent = create_parent();
+  const ElementId<1>& parent_id = parent.id();
+  const auto parent_mesh = create_parent_mesh();
+  const auto parent_flags = create_parent_flags();
+  const auto parent_neighbor_flags = create_parent_neighbor_flags();
+  const auto children_ids = amr::ids_of_children(parent_id, parent_flags);
+
+  ActionTesting::MockRuntimeSystem<Metavariables> runner{{}};
+  ActionTesting::emplace_component_and_initialize<my_component>(
+      &runner, parent_id,
+      {parent, parent_mesh, parent_flags, parent_neighbor_flags});
+  for (const auto& child_id : children_ids) {
+    ActionTesting::emplace_component<my_component>(&runner, child_id);
+    CHECK(ActionTesting::number_of_queued_simple_actions<my_component>(
+              runner, child_id) == 0);
+  }
+  ActionTesting::simple_action<my_component, amr::Actions::SendDataToChildren>(
+      make_not_null(&runner), parent_id, children_ids);
+  // SendDataToChildren calls InitializeChild on each child element
+  for (const auto& child_id : children_ids) {
+    CHECK(ActionTesting::number_of_queued_simple_actions<my_component>(
+              runner, child_id) == 1);
+    // Invoke the mock action to check that SendDataToChildren sent the correct
+    // data
+    ActionTesting::invoke_queued_simple_action<my_component>(
+        make_not_null(&runner), child_id);
+    CHECK(ActionTesting::is_simple_action_queue_empty<my_component>(runner,
+                                                                    child_id));
+  }
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Amr.Actions.SendDataToChildren",
+                  "[Unit][ParallelAlgorithms]") {
+  test();
+}

--- a/tests/Unit/ParallelAlgorithms/Amr/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/Amr/CMakeLists.txt
@@ -4,9 +4,11 @@
 set(LIBRARY "Test_ParallelAmr")
 
 set(LIBRARY_SOURCES
+  Actions/Test_CreateChild.cpp
   Actions/Test_EvaluateRefinementCriteria.cpp
   Actions/Test_Initialize.cpp
   Actions/Test_InitializeChild.cpp
+  Actions/Test_SendDataToChildren.cpp
   Actions/Test_UpdateAmrDecision.cpp
   Criteria/Test_Criterion.cpp
   Criteria/Test_DriveToTarget.cpp


### PR DESCRIPTION
## Proposed changes

- Adds AMR actions CreateChild and SendDataToChildren which are invoked when a DG element splits into multiple child elements.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments


