### PR TITLE
Speed up status CLI

### DIFF
--- a/tests/Unit/Visualization/Python/Test_ReadH5.py
+++ b/tests/Unit/Visualization/Python/Test_ReadH5.py
@@ -5,6 +5,7 @@ import os
 import unittest
 
 import h5py
+import numpy as np
 import pandas.testing as pdt
 import spectre.Informer as spectre_informer
 import spectre.IO.H5 as spectre_h5
@@ -36,11 +37,26 @@ class TestReadH5(unittest.TestCase):
                        "r") as open_file:
             df = to_dataframe(open_file["TimeSteps2.dat"])
             self.assertEqual(df.columns[0], "Time")
+
+            df_one_row = to_dataframe(open_file["TimeSteps2.dat"],
+                                      slice=np.s_[1:])
+            num_rows, num_cols = df_one_row.shape
+            self.assertEqual(num_rows, 1)
+            self.assertEqual(num_cols, df.shape[1])
         # SpECTRE subfile
         with spectre_h5.H5File(os.path.join(self.data_dir, "DatTestData.h5"),
                                "r") as open_file:
             df2 = to_dataframe(open_file.get_dat("/TimeSteps2"))
+            open_file.close_current_object()
             pdt.assert_frame_equal(df2, df)
+            open_file.close_current_object()
+
+            df2_one_row = to_dataframe(open_file.get_dat("/TimeSteps2"),
+                                       slice=np.s_[1:])
+            num_rows, num_cols = df2_one_row.shape
+            self.assertEqual(num_rows, 1)
+            self.assertEqual(num_cols, df2.shape[1])
+            pdt.assert_frame_equal(df2_one_row, df_one_row)
 
 
 if __name__ == '__main__':

--- a/tests/tools/Test_Status.py
+++ b/tests/tools/Test_Status.py
@@ -37,8 +37,9 @@ class TestExecutableStatus(unittest.TestCase):
                 "/TimeSteps",
                 legend=["Time", "Minimum Walltime", "Maximum Walltime"],
                 version=0)
-            time_subfile.append([0., 1., 2.])
+            time_subfile.append([0., 0.5, 1.0])
             time_subfile.append([1., 2., 3.])
+            time_subfile.append([2., 3., 4.])
             open_h5_file.close_current_object()
             # Control systems data
             rotation_subfile = open_h5_file.insert_dat(
@@ -76,14 +77,14 @@ class TestExecutableStatus(unittest.TestCase):
     def test_evolution_status(self):
         executable_status = match_executable_status("EvolveSomething")
         status = executable_status.status(self.input_file, self.work_dir)
-        self.assertEqual(status, {"Time": 1., "Speed": 3600.})
+        self.assertEqual(status, {"Time": 2., "Speed": 3600.})
         self.assertEqual(executable_status.format("Time", 1.5), "1.5")
         self.assertEqual(executable_status.format("Speed", 1.2), "1.2")
 
     def test_evolve_bbh_status(self):
         executable_status = match_executable_status("EvolveGhBinaryBlackHole")
         status = executable_status.status(self.input_file, self.work_dir)
-        self.assertEqual(status["Time"], 1.)
+        self.assertEqual(status["Time"], 2.)
         self.assertEqual(status["Speed"], 3600.)
         self.assertEqual(status["Orbits"], 0.5)
         self.assertEqual(status["Separation"], 2.)
@@ -92,7 +93,7 @@ class TestExecutableStatus(unittest.TestCase):
     def test_evolve_single_bh_status(self):
         executable_status = match_executable_status("EvolveGhSingleBlackHole")
         status = executable_status.status(self.input_file, self.work_dir)
-        self.assertEqual(status["Time"], 1.)
+        self.assertEqual(status["Time"], 2.)
         self.assertEqual(status["Speed"], 3600.)
         self.assertEqual(status["Constraint Energy"], 1.e-3)
 

--- a/tools/Status/ExecutableStatus/ExecutableStatus.py
+++ b/tools/Status/ExecutableStatus/ExecutableStatus.py
@@ -101,7 +101,8 @@ class EvolutionStatus(ExecutableStatus):
         subfile_name = observe_time_event["SubfileName"] + ".dat"
         logger.debug(f"Reading time steps from subfile: '{subfile_name}'")
         try:
-            time_steps = to_dataframe(open_reductions_file[subfile_name])
+            time_steps = to_dataframe(open_reductions_file[subfile_name],
+                                      slice=np.s_[-2:])
         except:
             logger.debug("Unable to read time steps.", exc_info=True)
             return {}


### PR DESCRIPTION
## Proposed changes

Reading the full dat file in to calculate the speed of the run was slowing things down. Now it only reads in the last 2 lines of the dat file.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
