### PR TITLE
Fix num orbits in BBH status

### DIFF
--- a/tools/Status/ExecutableStatus/EvolveGhBinaryBlackHole.py
+++ b/tools/Status/ExecutableStatus/EvolveGhBinaryBlackHole.py
@@ -36,9 +36,12 @@ class EvolveGhBinaryBlackHole(EvolutionStatus):
             # Number of orbits. We use the rotation control system for this.
             try:
                 rotation_z = to_dataframe(
-                    open_reductions_file["ControlSystems/Rotation/z.dat"])
-                covered_angle = np.diff(
-                    rotation_z["FunctionOfTime"].iloc[[0, -1]])[0]
+                    open_reductions_file["ControlSystems/Rotation/z.dat"],
+                    slice=np.s_[-1:])
+                # Assume the initial rotation angle is 0 for now. We can update
+                # this to read the initial rotation angle once we can read
+                # previous segments / checkpoints of a simulation.
+                covered_angle = rotation_z["FunctionOfTime"].iloc[-1]
                 result["Orbits"] = covered_angle / (2. * np.pi)
             except:
                 logger.debug("Unable to extract orbits.", exc_info=True)


### PR DESCRIPTION
## Proposed changes

Assume the initial rotation angle is 0 for now. We can update this to read the initial rotation angle once we can read previous segments / checkpoints of a simulation.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
