### PR TITLE
Allow sphere transition inverse to handle epsilon

### DIFF
--- a/src/Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/SphereTransition.cpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/SphereTransition.cpp
@@ -49,7 +49,8 @@ std::optional<double> SphereTransition::original_radius_over_radius(
   }
   const double original_radius = (mag + distorted_radius * b_) / denom;
 
-  return original_radius >= r_min_ and original_radius <= r_max_
+  return (original_radius + eps_) >= r_min_ and
+                 (original_radius - eps_) <= r_max_
              ? std::optional<double>{original_radius / mag}
              : std::nullopt;
 }
@@ -115,10 +116,9 @@ bool SphereTransition::operator!=(
 template <typename T>
 void SphereTransition::check_magnitudes([[maybe_unused]] const T& mag) const {
 #ifdef SPECTRE_DEBUG
-  const double eps = std::numeric_limits<double>::epsilon() * 100;
   for (size_t i = 0; i < get_size(mag); ++i) {
-    if (get_element(mag, i) + eps < r_min_ or
-        get_element(mag, i) - eps > r_max_) {
+    if (get_element(mag, i) + eps_ < r_min_ or
+        get_element(mag, i) - eps_ > r_max_) {
       ERROR(
           "The sphere transition map was called with coordinates outside the "
           "set minimum and maximum radius. The minimum radius is "

--- a/src/Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/SphereTransition.hpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/SphereTransition.hpp
@@ -70,5 +70,6 @@ class SphereTransition final : public ShapeMapTransitionFunction {
   double r_max_{};
   double a_{};
   double b_{};
+  static constexpr double eps_ = std::numeric_limits<double>::epsilon() * 100;
 };
 }  // namespace domain::CoordinateMaps::ShapeMapTransitionFunctions

--- a/tests/Unit/Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/Test_SphereTransition.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/Test_SphereTransition.cpp
@@ -4,6 +4,7 @@
 #include "Framework/TestingFramework.hpp"
 
 #include <array>
+#include <limits>
 
 #include "Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/SphereTransition.hpp"
 
@@ -12,12 +13,17 @@ namespace domain::CoordinateMaps::ShapeMapTransitionFunctions {
 SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Shape.SphereTransition",
                   "[Domain][Unit]") {
   SphereTransition sphere_transition{2., 4.};
+  constexpr double eps = std::numeric_limits<double>::epsilon() * 100;
   const std::array<double, 3> lower_bound{{2., 0., 0.}};
   CHECK(sphere_transition(lower_bound) == approx(1.));
+  const std::array<double, 3> lower_bound_eps{{2. - eps, 0., 0.}};
+  CHECK(sphere_transition(lower_bound_eps) == approx(1.));
   const std::array<double, 3> midpoint{{3., 0., 0.}};
   CHECK(sphere_transition(midpoint) == approx(1. / 3.));
   const std::array<double, 3> upper_bound{{4., 0., 0.}};
   CHECK(sphere_transition(upper_bound) == approx(0.));
+  const std::array<double, 3> upper_bound_eps{{4. + eps, 0., 0.}};
+  CHECK(sphere_transition(upper_bound_eps) == approx(0.));
 }
 
 }  // namespace domain::CoordinateMaps::ShapeMapTransitionFunctions


### PR DESCRIPTION
## Proposed changes

The inverse of the shape map uses the `original_radius_over_radius` function of the transition function. Previously the sphere transition didn't account for epsilon differences so mapping a point on a boundary of the shape map to/from the grid frame would result in a point just outside of the bounds of the shape map, causing the inverse to be `nullopt` even though it was perfectly fine. Now, the sphere transition checks for epsilon differences in `original_radius_over_radius`

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
