### PR TITLE
Fix status CLI for jobs running in same work dir

### DIFF
--- a/tools/Status/ExecutableStatus/EvolveGhBinaryBlackHole.py
+++ b/tools/Status/ExecutableStatus/EvolveGhBinaryBlackHole.py
@@ -46,8 +46,8 @@ class EvolveGhBinaryBlackHole(EvolutionStatus):
             try:
                 ah_centers = [
                     to_dataframe(open_reductions_file[
-                        f"ApparentHorizons/ControlSystemAh{ab}_Centers.dat"]).
-                    iloc[-1] for ab in "AB"
+                        f"ApparentHorizons/ControlSystemAh{ab}_Centers.dat"],
+                                 slice=np.s_[-1:]).iloc[-1] for ab in "AB"
                 ]
                 ah_separation = np.sqrt(
                     sum((ah_centers[0]["InertialCenter" + xyz] -
@@ -58,7 +58,8 @@ class EvolveGhBinaryBlackHole(EvolutionStatus):
                 logger.debug("Unable to extract separation.", exc_info=True)
             # Norms
             try:
-                norms = to_dataframe(open_reductions_file["Norms.dat"])
+                norms = to_dataframe(open_reductions_file["Norms.dat"],
+                                     slice=np.s_[-1:])
                 result["Constraint Energy"] = norms.iloc[-1][
                     "L2Norm(ConstraintEnergy)"]
             except:

--- a/tools/Status/ExecutableStatus/EvolveGhSingleBlackHole.py
+++ b/tools/Status/ExecutableStatus/EvolveGhSingleBlackHole.py
@@ -33,7 +33,8 @@ class EvolveGhSingleBlackHole(EvolutionStatus):
             result = self.time_status(input_file, open_reductions_file)
             # Norms
             try:
-                norms = to_dataframe(open_reductions_file["Norms.dat"])
+                norms = to_dataframe(open_reductions_file["Norms.dat"],
+                                     slice=np.s_[-1:])
                 result["Constraint Energy"] = norms.iloc[-1][
                     "L2Norm(ConstraintEnergy)"]
             except:

--- a/tools/Status/ExecutableStatus/ExecutableStatus.py
+++ b/tools/Status/ExecutableStatus/ExecutableStatus.py
@@ -32,7 +32,8 @@ class ExecutableStatus:
     executable_name_patterns: List[str] = []
     fields: Dict[str, Optional[str]] = {}
 
-    def status(self, input_file: dict, work_dir: str) -> dict:
+    def status(self, input_file: Optional[dict],
+               work_dir: Optional[str]) -> dict:
         """Provide status information of an executable run.
 
         Arguments:

--- a/tools/Status/Status.py
+++ b/tools/Status/Status.py
@@ -208,6 +208,19 @@ def render_status(show_paths, show_unidentified, **kwargs):
                                 job_data["Comment"], job_data["InputFile"])
     ]
 
+    # Invalidate older jobs that ran in the same work dir because they would
+    # report wrong information (that of the newer job).
+    for work_dir in pd.unique(job_data["WorkDir"]):
+        duplicate_jobs = job_data[job_data["WorkDir"] == work_dir]
+        if len(duplicate_jobs) == 1:
+            continue
+        # Jobs are already sorted by JobID, so just keep the latest job
+        # associated and invalidate the others.
+        latest_job_id = duplicate_jobs.iloc[0]["JobID"]
+        job_data.loc[(job_data["WorkDir"] == work_dir) &
+                     (job_data["JobID"] != latest_job_id),
+                     ["WorkDir", "NewJobID"]] = [None, latest_job_id]
+
     # Add metadata so jobs can be grouped by state
     job_data["StateOrder"] = job_data["State"].apply(_state_order)
 
@@ -254,13 +267,12 @@ def render_status(show_paths, show_unidentified, **kwargs):
                 row_formatted = [
                     _format(field, row[field]) for field in standard_fields
                 ]
-                with open(row["InputFile"], "r") as open_input_file:
-                    try:
+                try:
+                    with open(row["InputFile"], "r") as open_input_file:
                         input_file = yaml.safe_load(open_input_file)
-                    except:
-                        logger.debug("Unable to load input file.",
-                                     exc_info=True)
-                        input_file = None
+                except:
+                    logger.debug("Unable to load input file.", exc_info=True)
+                    input_file = None
                 try:
                     status = executable_status.status(input_file,
                                                       row["WorkDir"])
@@ -280,8 +292,10 @@ def render_status(show_paths, show_unidentified, **kwargs):
                     yield table
                     # Print WorkDir in its own line so it wraps nicely in the
                     # terminal and can be copied
-                    yield " [bold]WorkDir:[/bold] " + row['WorkDir']
-                    yield " [bold]InputFile:[/bold] " + row['InputFile']
+                    yield (" [bold]WorkDir:[/bold] " +
+                           (row['WorkDir'] if row['WorkDir'] else
+                            f"[italic]Same as job {row['NewJobID']}[/italic]"))
+                    yield " [bold]InputFile:[/bold] " + str(row['InputFile'])
                     table = rich.table.Table(*columns, box=None)
         if not show_paths:
             yield table

--- a/tools/Status/Status.py
+++ b/tools/Status/Status.py
@@ -111,7 +111,7 @@ def get_input_file(comment: Optional[str], work_dir: str) -> Optional[str]:
         return yaml_files[0]
     else:
         logger.debug("No input file found. "
-                     "Didn't find a single YAML file in '{work_dir}'. "
+                     f"Didn't find a single YAML file in '{work_dir}'. "
                      f"YAML files found: {yaml_files}")
         return None
 


### PR DESCRIPTION
## Proposed changes

This happens when a job is restarted and overwrites output in the work dir. The output belongs to the new job now, and the old job's data is lost. We shouldn't associate the new data with the old job.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
