### PR TITLE
Clenshaw method

### DIFF
--- a/src/NumericalAlgorithms/Spectral/CMakeLists.txt
+++ b/src/NumericalAlgorithms/Spectral/CMakeLists.txt
@@ -30,6 +30,7 @@ spectre_target_headers(
   ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
+  Clenshaw.hpp
   ComplexDataView.hpp
   Filtering.hpp
   LogicalCoordinates.hpp

--- a/src/NumericalAlgorithms/Spectral/Clenshaw.hpp
+++ b/src/NumericalAlgorithms/Spectral/Clenshaw.hpp
@@ -1,0 +1,47 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cmath>
+#include <numeric>
+#include <utility>
+#include <vector>
+
+#include "DataStructures/DataVector.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/MakeWithValue.hpp"
+
+namespace Spectral {
+/// Clenshaw's algorithm for evaluating linear combinations of
+/// basis functions obeying a given three term recurrence relation.
+/// See numerical recipes 3rd edition 5.4.2 for details.
+/// `alpha` and `beta` define the recursion
+/// \f$ f_n(x) = \alpha f_{n-1}(x) + \beta f_{n-2}(x) \f$
+/// `f0_of_x` and `f1_of_x` are \f$ f_0(x)\f$ and \f$f_1(x)\f$ respectively
+template <typename CoefficientDataType, typename DataType>
+DataType evaluate_clenshaw(const std::vector<CoefficientDataType>& coefficients,
+                           const DataType& alpha, const DataType& beta,
+                           const DataType& f0_of_x, const DataType& f1_of_x) {
+  if (coefficients.empty()) {
+    return make_with_value<DataType>(f0_of_x, 0.0);
+  }
+
+  DataType y_upper{make_with_value<DataType>(f0_of_x, 0.0)};  // y_{N+2} = 0
+  DataType new_y_lower;
+  // Do the loop to calculate y_1 and y_2 (the accumulate function leaves
+  // y_lower_final = y_1, and y_upper = y_2)
+  const DataType y_lower_final =
+      std::accumulate(coefficients.rbegin(), coefficients.rend() - 1,
+                      make_with_value<DataType>(f0_of_x, 0.0),
+                      [&y_upper, &alpha, &beta, &new_y_lower](
+                          const auto& y_lower, const auto& c_k) {
+                        new_y_lower = c_k + alpha * y_lower + beta * y_upper;
+                        y_upper = y_lower;
+                        return new_y_lower;
+                      });
+  return f0_of_x * coefficients[0] + f1_of_x * y_lower_final +
+         beta * f0_of_x * y_upper;
+}
+
+}  // namespace Spectral

--- a/tests/Unit/NumericalAlgorithms/Spectral/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/Spectral/CMakeLists.txt
@@ -8,6 +8,7 @@ set(LIBRARY "Test_Spectral")
 set(LIBRARY_SOURCES
   Test_ChebyshevGauss.cpp
   Test_ChebyshevGaussLobatto.cpp
+  Test_Clenshaw.cpp
   Test_ComplexDataView.cpp
   Test_Filtering.cpp
   Test_FiniteDifference.cpp

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_Clenshaw.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_Clenshaw.cpp
@@ -1,0 +1,124 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cmath>
+#include <cstddef>
+#include <string>
+#include <vector>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Matrix.hpp"
+#include "NumericalAlgorithms/Spectral/Clenshaw.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
+
+namespace Spectral {
+namespace {
+template <typename BasisFunction, typename DataType>
+DataType evaluate_with_function_basis(const std::vector<double>& coefficients,
+                                      const DataType& x,
+                                      const BasisFunction& f_of_k_and_x) {
+  size_t counter = 0;
+  return std::accumulate(
+      coefficients.begin(), coefficients.end(),
+      make_with_value<DataType>(x, 0.0),
+      [&x, &f_of_k_and_x, &counter](auto& sum, const auto& coefficient) {
+        counter++;
+        return sum + coefficient * f_of_k_and_x(counter - 1, x);
+      });
+}
+// Check that for small arguments the clenshaw expansion and the direct cosine
+// evaluation agree.
+
+template <typename DataType>
+void test_cosine_series(const std::vector<double>& coefficients,
+                        const DataType& x) {
+  // cos(nx) = 2*x * cos((n-1)x) - cos((n-2)x)
+  // cos(nx) = alpha * cos((n-1)x) + beta cos((n-2)x)
+  const DataType alpha = 2.0 * cos(x);
+  const DataType beta = make_with_value<DataType>(x, -1.0);
+  const DataType cos_0x = make_with_value<DataType>(x, 1.0);
+  const DataType cos_x = cos(x);
+  const DataType true_value = evaluate_with_function_basis(
+      coefficients, x, [](const size_t& k, const DataType& z) {
+        return cos(static_cast<double>(k) * z);
+      });
+  const DataType clenshaw_value =
+      Spectral::evaluate_clenshaw(coefficients, alpha, beta, cos_0x, cos_x);
+  CHECK_ITERABLE_APPROX(clenshaw_value, true_value);
+}
+// More broad testing allowing a custom approx, in general the clenshaw and
+// machine computed series values may not agree to within machine precision.
+template <typename DataType>
+void test_approximate_cosine_series(const std::vector<double>& coefficients,
+                                    const DataType& x, Approx custom_approx) {
+  // cos(nx) = 2*cos(x) * cos((n-1)x) - cos((n-2)x)
+  // cos(nx) = alpha * cos((n-1)x) + beta cos((n-2)x)
+  const DataType alpha = 2.0 * cos(x);
+  const DataType beta = make_with_value<DataType>(x, -1.0);
+  const DataType cos_0x = make_with_value<DataType>(x, 1.0);
+  const DataType cos_x = cos(x);
+  const DataType true_value = evaluate_with_function_basis(
+      coefficients, x, [](const size_t& k, const DataType& z) {
+        return cos(static_cast<double>(k) * z);
+      });
+  const DataType clenshaw_value =
+      Spectral::evaluate_clenshaw(coefficients, alpha, beta, cos_0x, cos_x);
+  CHECK_ITERABLE_CUSTOM_APPROX(clenshaw_value, true_value, custom_approx);
+}
+
+template <typename DataType>
+void test_sine_series(const std::vector<double>& coefficients,
+                      const DataType& x) {
+  // sin(nx) = 2*cos(x) * sin((n-1)x) - sin((n-2)x)
+  // sin(nx) = alpha * sin((n-1)x) + beta sin((n-2)x)
+  const DataType alpha = 2.0 * cos(x);
+  const DataType beta = make_with_value<DataType>(x, -1.0);
+  const DataType sin_0x = make_with_value<DataType>(x, 0.0);
+  const DataType sin_x = sin(x);
+  const DataType true_value = evaluate_with_function_basis(
+      coefficients, x, [](const size_t& k, const DataType& z) {
+        return sin(static_cast<double>(k) * z);
+      });
+  const DataType clenshaw_value =
+      Spectral::evaluate_clenshaw(coefficients, alpha, beta, sin_0x, sin_x);
+  CHECK_ITERABLE_APPROX(clenshaw_value, true_value);
+}
+
+}  // namespace
+SPECTRE_TEST_CASE("Unit.Numerical.Spectral.Clenshaw",
+                  "[NumericalAlgorithms][Spectral][Unit]") {
+  test_cosine_series({}, M_PI);
+  test_cosine_series({1.0}, 1.0);
+  test_cosine_series({1.0, 2.0, 3.6}, M_PI);
+  test_cosine_series({1.0, 2.0, 3.6, -21.1, M_E}, 2.1214353);
+  test_cosine_series({0.0, -1.5, 0.0001, -1.1, M_E}, 32.1222);
+  test_cosine_series({3200.0, 2100.0, 5065.0, 200000.0, 2211.0}, M_PI * 2.0);
+
+  test_cosine_series(
+      {1.0, 2.0, 3.6, 9.5, M_E},
+      DataVector{1.0, M_PI, 1.04, 9.0211, 5.1, -92.2, -M_PI / 2.0});
+
+  Approx coarse_approx{1.0e-12};
+  CHECK(1.0 == coarse_approx(cos(M_PI * 100000000.0)));
+  test_approximate_cosine_series({1.0, 2.0, 3.6}, 200000 * M_PI, coarse_approx);
+  test_approximate_cosine_series(
+      {1.0, 2.0, 3.6, 9.5, M_E},
+      DataVector{100020.0, M_PI * 3000.0, -10002312.0, 1.0e-11, 3.2, -22.1,
+                 -M_PI / 2000.0},
+      coarse_approx);
+
+  test_sine_series({}, M_PI);
+  test_sine_series({1.0}, 1.0);
+  test_sine_series({1.0, 2.0, 3.6}, M_PI);
+  test_sine_series({1.0, 2.0, 3.6, -21.1, M_E}, 2.1214353);
+  test_sine_series({0.0, -1.5, 0.0001, -1.1, M_E}, 32.1222);
+  test_sine_series({3200.0, 2100.0, 5065.0, 200000.0, 2211.0}, M_PI * 2.0);
+
+  test_sine_series({1.0, 2.0, 3.6, 9.5, M_E},
+                   DataVector{1.0, M_PI, 1.04, 9.0211, 5.1, -9.2, -M_PI / 2.0});
+}
+
+}  // namespace Spectral


### PR DESCRIPTION
## Proposed changes

This PR adds the Clenshaw method for computing three term recurrences.  It implements this in the `Enthalpy` EoS for evaluating a series of trigonometric terms in evaluating thermodynamic quantities.  Nonetheless, this code will probably be useful elsewhere, so it is implemented more generically.  

### Upgrade instructions

No changes to the interface should be necessary.



### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

Benchmarking results indicate that avoiding the evaluation of trig functions leads to about an order of magnitude (or more) speed up per term.  This can be significant when the same expanded function has to be called many times, like with the EoS in primitive recovery.  
