### PR TITLE
Minor fixes on GRMHD TCIs

### DIFF
--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TciOnDgGrid.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TciOnDgGrid.cpp
@@ -59,6 +59,8 @@ TciOnDgGrid<RecoveryScheme>::apply(
       [&temp_buffer, &offset_into_temp_buffer](
           const gsl::not_null<Scalar<DataVector>*> to_assign,
           const size_t size) {
+        ASSERT(offset_into_temp_buffer + size <= temp_buffer.size(),
+               "Trying to assign data out of allocated memory size");
         get(*to_assign)
             .set_data_ref(temp_buffer.data() + offset_into_temp_buffer, size);
         offset_into_temp_buffer += size;

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TciOnFdGrid.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TciOnFdGrid.cpp
@@ -155,6 +155,6 @@ std::tuple<int, evolution::dg::subcell::RdmpTciData> TciOnFdGrid::apply(
     return {+10, rdmp_tci_data};
   }
 
-  return {false, rdmp_tci_data};
+  return {0, rdmp_tci_data};
 }
 }  // namespace grmhd::ValenciaDivClean::subcell


### PR DESCRIPTION
## Proposed changes

* Add a missing `ASSERT` checking the temp buffer size
* Change the first return value of an untroubled case from `false` to `0`, which conforms slightly better to documentation.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
