### PR TITLE
Improve YAML formatting of EventsAndTriggers

### DIFF
--- a/docs/DevGuide/LoadBalancingNotes.md
+++ b/docs/DevGuide/LoadBalancingNotes.md
@@ -77,10 +77,12 @@ the problem:
   been carefully tested. To do this, use an input file similar to
 ```
 PhaseChangeAndTriggers:
-  - - Slabs:
+  - Trigger:
+      Slabs:
         Specified:
           Values: [5, 10, 15]
-    - - VisitAndReturn(LoadBalancing)
+    PhaseChanges:
+      - VisitAndReturn(LoadBalancing)
 ```
 - Use `LBTurnInstrumentOff` and `LBTurnInstrumentOn` to specifically exclude
   setup procedures from the LB instrumentation. First attempts indicate that
@@ -132,10 +134,12 @@ evolutions, it may be worth experimenting to see whether 1-3 applications of
 performance for the system, for instance by using the input file:
 ```
 PhaseChangeAndTriggers:
-  - - Slabs:
+  - Trigger:
+      Slabs:
         Specified:
           Values: [5, 10, 15]
-    - - VisitAndReturn(LoadBalancing)
+    PhaseChanges:
+      - VisitAndReturn(LoadBalancing)
 ```
 and command-line args `+balancer RecBipartLB` (or `ScotchLB` when its
 bugs are fixed). This may be particularly relevant for cases with numeric
@@ -151,11 +155,13 @@ balancer. It is likely worth attempting the evolution with a
 periodically-applied centralized communication-aware balancer, e.g.:
 ```
 PhaseChangeAndTriggers:
-  - - Slabs:
+  - Trigger:
+      Slabs:
         EvenlySpaced:
           Interval: 1000
           Offset: 5
-    - - VisitAndReturn(LoadBalancing)
+    PhaseChanges:
+      - VisitAndReturn(LoadBalancing)
 ```
 paired with command-line args `+balancer RecBipartLB` (or `ScotchLB` when its
 bugs are fixed).

--- a/docs/Tutorials/EventsAndTriggers.md
+++ b/docs/Tutorials/EventsAndTriggers.md
@@ -52,25 +52,13 @@ consistently over the entire domain.
 ### Input file syntax
 
 The `%EventsAndTriggers` (and `%EventsAndDenseTriggers`) sections of
-the \ref dev_guide_option_parsing "input file" are parsed as several
-nested YAML lists representing vectors and pairs.  The outermost list
-is a vector with one entry for each trigger.  The entries in this
-vector are two-element lists representing pairs whose first elements
-are triggers and whose second elements are a third level of list
-containing the events.
+the \ref dev_guide_option_parsing "input file" are parsed as a list of
+Trigger/Events pairs:
 
 \snippet PlaneWave1DEventsAndTriggersExample.yaml multiple_events
 
 In this example, we are using the \ref Triggers::Slabs "Slabs" trigger
-to run two events every 10 slabs: ObserveFields and \ref
-::Events::ObserveNorms "ObserveNorms".
-
-If an event and trigger both took no options, the syntax
-
-\snippet PlaneWave1DEventsAndTriggersExample.yaml no_arguments
-
-could be written in the more familiar form
-
-\snippet PlaneWave1DEventsAndTriggersExample.yaml no_arguments_single_line
-
-but we recommend always using the expanded form for consistency.
+to run two events every 10 slabs: ObserveFields and
+\ref ::Events::ObserveNorms "ObserveNorms". We also run the
+\ref ::Events::Completion "Completion" event at the
+\ref ::Triggers::Always "Always" trigger, so the run will terminate immediately.

--- a/src/Evolution/EventsAndDenseTriggers/EventsAndDenseTriggers.cpp
+++ b/src/Evolution/EventsAndDenseTriggers/EventsAndDenseTriggers.cpp
@@ -24,8 +24,8 @@ EventsAndDenseTriggers::EventsAndDenseTriggers(
   for (auto& events_and_trigger : events_and_triggers) {
     events_and_triggers_.push_back(TriggerRecord{
         std::numeric_limits<double>::signaling_NaN(), std::optional<bool>{}, 0,
-        std::move(events_and_trigger.first),
-        std::move(events_and_trigger.second)});
+        std::move(events_and_trigger.trigger),
+        std::move(events_and_trigger.events)});
   }
 }
 

--- a/src/Evolution/EventsAndDenseTriggers/EventsAndDenseTriggers.hpp
+++ b/src/Evolution/EventsAndDenseTriggers/EventsAndDenseTriggers.hpp
@@ -58,9 +58,28 @@ class EventsAndDenseTriggers {
   };
 
  public:
-  using ConstructionType =
-      std::vector<std::pair<std::unique_ptr<DenseTrigger>,
-                            std::vector<std::unique_ptr<Event>>>>;
+  struct TriggerAndEvents {
+    struct Trigger {
+      using type = std::unique_ptr<::DenseTrigger>;
+      static constexpr Options::String help = "Determines when the Events run.";
+    };
+    struct Events {
+      using type = std::vector<std::unique_ptr<::Event>>;
+      static constexpr Options::String help =
+          "These events run when the Trigger fires.";
+    };
+    static constexpr Options::String help =
+        "Events that run when the Trigger fires.";
+    using options = tmpl::list<Trigger, Events>;
+    void pup(PUP::er& p) {
+      p | trigger;
+      p | events;
+    }
+    std::unique_ptr<::DenseTrigger> trigger;
+    std::vector<std::unique_ptr<::Event>> events;
+  };
+
+  using ConstructionType = std::vector<TriggerAndEvents>;
 
  private:
   struct TriggerRecord {

--- a/src/Parallel/PhaseControl/ExecutePhaseChange.hpp
+++ b/src/Parallel/PhaseControl/ExecutePhaseChange.hpp
@@ -64,8 +64,10 @@ struct ExecutePhaseChange {
     const auto& phase_change_and_triggers =
         Parallel::get<Tags::PhaseChangeAndTriggers>(cache);
     bool should_halt = false;
-    for (const auto& [trigger, phase_changes] : phase_change_and_triggers) {
+    for (const auto& trigger_and_phase_changes : phase_change_and_triggers) {
+      const auto& trigger = trigger_and_phase_changes.trigger;
       if (trigger->is_triggered(box)) {
+        const auto& phase_changes = trigger_and_phase_changes.phase_changes;
         for (const auto& phase_change : phase_changes) {
           phase_change->template contribute_phase_data<ParallelComponent>(
               make_not_null(&box), cache, array_index);
@@ -135,10 +137,8 @@ typename std::optional<Parallel::Phase> arbitrate_phase_change(
     const auto& phase_change_and_triggers =
         Parallel::get<Tags::PhaseChangeAndTriggers>(cache);
     bool phase_chosen = false;
-    for (const auto& [trigger, phase_changes] : phase_change_and_triggers) {
-      // avoid unused variable warning
-      (void)trigger;
-      for (const auto& phase_change : phase_changes) {
+    for (const auto& trigger_and_phase_changes : phase_change_and_triggers) {
+      for (const auto& phase_change : trigger_and_phase_changes.phase_changes) {
         const auto phase_result = phase_change->arbitrate_phase_change(
             phase_change_decision_data, current_phase, cache);
         if (phase_result.has_value()) {

--- a/src/Parallel/PhaseControl/InitializePhaseChangeDecisionData.hpp
+++ b/src/Parallel/PhaseControl/InitializePhaseChangeDecisionData.hpp
@@ -25,10 +25,8 @@ void initialize_phase_change_decision_data(
                                              Tags::PhaseChangeAndTriggers>) {
     const auto& phase_change_and_triggers =
         Parallel::get<Tags::PhaseChangeAndTriggers>(cache);
-    for (const auto& [trigger, phase_changes] : phase_change_and_triggers) {
-      // avoid unused variable warning
-      (void)trigger;
-      for (const auto& phase_change : phase_changes) {
+    for (const auto& trigger_and_phase_changes : phase_change_and_triggers) {
+      for (const auto& phase_change : trigger_and_phase_changes.phase_changes) {
         phase_change->template initialize_phase_data<Metavariables>(
             phase_change_decision_data);
       }

--- a/src/Visualization/Python/ReadInputFile.py
+++ b/src/Visualization/Python/ReadInputFile.py
@@ -45,8 +45,8 @@ def find_event(event_name: str, input_file: dict) -> dict:
 
     Returns: The event as a dictionary, or None if the event wasn't found.
     """
-    for _, events in input_file["EventsAndTriggers"]:
-        for event in events:
+    for trigger_and_events in input_file["EventsAndTriggers"]:
+        for event in trigger_and_events["Events"]:
             if event_name in event:
                 return event[event_name]
     return None

--- a/tests/InputFiles/Burgers/Step.yaml
+++ b/tests/InputFiles/Burgers/Step.yaml
@@ -23,11 +23,13 @@ Evolution:
       Order: 3
 
 PhaseChangeAndTriggers:
-  - - Slabs:
+  - Trigger:
+      Slabs:
         EvenlySpaced:
           Interval: 10
           Offset: 0
-    - - VisitAndReturn(LoadBalancing)
+    PhaseChanges:
+      - VisitAndReturn(LoadBalancing)
 
 DomainCreator:
   Interval:
@@ -69,8 +71,9 @@ SpatialDiscretization:
     Reconstructor: MonotonisedCentral
 
 EventsAndTriggers:
-  - - Always
-    - - ChangeSlabSize:
+  - Trigger: Always
+    Events:
+      - ChangeSlabSize:
           DelayChange: 5
           StepChoosers:
             - Cfl:
@@ -79,10 +82,12 @@ EventsAndTriggers:
                 Factor: 2.0
 
 EventsAndDenseTriggers:
-  - - Times:
+  - Trigger:
+      Times:
         Specified:
           Values: [0.123456]
-    - - Completion
+    Events:
+      - Completion
 
 Observers:
   VolumeFileName: "BurgersStepVolume"

--- a/tests/InputFiles/CurvedScalarWave/PlaneWaveMinkowski1D.yaml
+++ b/tests/InputFiles/CurvedScalarWave/PlaneWaveMinkowski1D.yaml
@@ -64,10 +64,12 @@ Filtering:
     BlocksToFilter: All
 
 EventsAndTriggers:
-  - - Slabs:
+  - Trigger:
+      Slabs:
         Specified:
           Values: [100]
-    - - Completion
+    Events:
+      - Completion
 
 EventsAndDenseTriggers:
 

--- a/tests/InputFiles/CurvedScalarWave/PlaneWaveMinkowski2D.yaml
+++ b/tests/InputFiles/CurvedScalarWave/PlaneWaveMinkowski2D.yaml
@@ -60,10 +60,12 @@ Filtering:
     BlocksToFilter: All
 
 EventsAndTriggers:
-  - - Slabs:
+  - Trigger:
+      Slabs:
         Specified:
           Values: [100]
-    - - Completion
+    Events:
+      - Completion
 
 EventsAndDenseTriggers:
 

--- a/tests/InputFiles/CurvedScalarWave/PlaneWaveMinkowski3D.yaml
+++ b/tests/InputFiles/CurvedScalarWave/PlaneWaveMinkowski3D.yaml
@@ -76,25 +76,31 @@ Filtering:
     BlocksToFilter: All
 
 EventsAndTriggers:
-  - - Slabs:
+  - Trigger:
+      Slabs:
         Specified:
           Values: [30]
-    - - Completion
-  - - Slabs:
+    Events:
+      - Completion
+  - Trigger:
+      Slabs:
         Specified:
           Values: [0, 15]
-    - - ObserveFields:
+    Events:
+      - ObserveFields:
           SubfileName: VolumePsi0And25
           VariablesToObserve: ["Psi"]
           InterpolateToMesh: None
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double]
           OverrideObservationValue: None
-  - - Slabs:
+  - Trigger:
+      Slabs:
         EvenlySpaced:
           Interval: 10
           Offset: 0
-    - - ObserveFields:
+    Events:
+      - ObserveFields:
           SubfileName: VolumeVarsConstraintsEvery10Slabs
           VariablesToObserve:
             - Psi
@@ -105,11 +111,13 @@ EventsAndTriggers:
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double]
           OverrideObservationValue: None
-  - - Slabs:
+  - Trigger:
+      Slabs:
         EvenlySpaced:
           Interval: 10
           Offset: 0
-    - - ObserveNorms:
+    Events:
+      - ObserveNorms:
           SubfileName: Norms
           TensorsToObserve:
             - Name: PointwiseL2Norm(OneIndexConstraint)

--- a/tests/InputFiles/CurvedScalarWave/WorldtubeKerrSchild.yaml
+++ b/tests/InputFiles/CurvedScalarWave/WorldtubeKerrSchild.yaml
@@ -78,11 +78,13 @@ SpatialDiscretization:
     Quadrature: GaussLobatto
 
 EventsAndTriggers:
-  - - Slabs:
+  - Trigger:
+      Slabs:
         EvenlySpaced:
           Interval: 5000
           Offset: 0
-    - - ObserveFields:
+    Events:
+      - ObserveFields:
           SubfileName: Volume
           VariablesToObserve:
             - Psi
@@ -91,20 +93,26 @@ EventsAndTriggers:
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double]
           OverrideObservationValue: None
-  - - Slabs:
+  - Trigger:
+      Slabs:
         EvenlySpaced:
           Interval: 1000
           Offset: 0
-    - - PsiAlongAxis1
+    Events:
+      - PsiAlongAxis1
       - PsiAlongAxis2
-  - - TimeCompares:
+  - Trigger:
+      TimeCompares:
         Comparison: GreaterThan
         Value: 2000.
-    - - Completion
-  - - Slabs:
+    Events:
+      - Completion
+  - Trigger:
+      Slabs:
         Specified:
           Values: [0]
-    - - ChangeSlabSize:
+    Events:
+      - ChangeSlabSize:
           DelayChange: 0
           StepChoosers:
             - Cfl:

--- a/tests/InputFiles/Elasticity/BentBeam.yaml
+++ b/tests/InputFiles/Elasticity/BentBeam.yaml
@@ -76,8 +76,9 @@ LinearSolver:
     ObservePerCoreReductions: False
 
 EventsAndTriggers:
-  - - HasConverged
-    - - ObserveNorms:
+  - Trigger: HasConverged
+    Events:
+      - ObserveNorms:
           SubfileName: ErrorNorms
           TensorsToObserve:
             - Name: Error(Displacement)

--- a/tests/InputFiles/Elasticity/HalfSpaceMirror.yaml
+++ b/tests/InputFiles/Elasticity/HalfSpaceMirror.yaml
@@ -102,8 +102,9 @@ LinearSolver:
     ObservePerCoreReductions: False
 
 EventsAndTriggers:
-  - - HasConverged
-    - - ObserveNorms:
+  - Trigger: HasConverged
+    Events:
+      - ObserveNorms:
           SubfileName: ErrorNorms
           TensorsToObserve:
             - Name: Error(Displacement)

--- a/tests/InputFiles/ExportCoordinates/Input1D.yaml
+++ b/tests/InputFiles/ExportCoordinates/Input1D.yaml
@@ -30,10 +30,12 @@ SpatialDiscretization:
     Quadrature: GaussLobatto
 
 EventsAndTriggers:
-  - - TimeCompares:
+  - Trigger:
+      TimeCompares:
         Comparison: GreaterThanOrEqualTo
         Value: 1.0
-    - - Completion
+    Events:
+      - Completion
 
 Evolution:
   InitialTime: 0.0

--- a/tests/InputFiles/ExportCoordinates/Input2D.yaml
+++ b/tests/InputFiles/ExportCoordinates/Input2D.yaml
@@ -28,10 +28,12 @@ SpatialDiscretization:
     Quadrature: GaussLobatto
 
 EventsAndTriggers:
-  - - TimeCompares:
+  - Trigger:
+      TimeCompares:
         Comparison: GreaterThanOrEqualTo
         Value: 1.0
-    - - Completion
+    Events:
+      - Completion
 
 Evolution:
   InitialTime: 0.0

--- a/tests/InputFiles/ExportCoordinates/Input3D.yaml
+++ b/tests/InputFiles/ExportCoordinates/Input3D.yaml
@@ -35,10 +35,12 @@ Evolution:
       Order: 1
 
 EventsAndTriggers:
-  - - TimeCompares:
+  - Trigger:
+      TimeCompares:
         Comparison: GreaterThanOrEqualTo
         Value: 1.0
-    - - Completion
+    Events:
+      - Completion
 
 Observers:
   VolumeFileName: "ExportCoordinates3DVolume"

--- a/tests/InputFiles/ExportCoordinates/InputTimeDependent3D.yaml
+++ b/tests/InputFiles/ExportCoordinates/InputTimeDependent3D.yaml
@@ -70,10 +70,12 @@ Evolution:
       Order: 1
 
 EventsAndTriggers:
-  - - TimeCompares:
+  - Trigger:
+      TimeCompares:
         Comparison: GreaterThanOrEqualTo
         Value: 0.5
-    - - Completion
+    Events:
+      - Completion
 
 Observers:
   VolumeFileName: "ExportTimeDependentCoordinates3DVolume"

--- a/tests/InputFiles/GeneralizedHarmonic/BinaryBlackHole.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/BinaryBlackHole.yaml
@@ -171,11 +171,13 @@ Filtering:
     BlocksToFilter: All
 
 EventsAndTriggers:
-  - - Slabs:
+  - Trigger:
+      Slabs:
         EvenlySpaced:
           Interval: 1
           Offset: 0
-    - - ObserveNorms:
+    Events:
+      - ObserveNorms:
           SubfileName: Norms
           TensorsToObserve:
           - Name: Lapse
@@ -190,11 +192,13 @@ EventsAndTriggers:
           - Name: PointwiseL2Norm(FourIndexConstraint)
             NormType: L2Norm
             Components: Sum
-  - - Slabs:
+  - Trigger:
+      Slabs:
         EvenlySpaced:
           Interval: 1000
           Offset: 0
-    - - ObserveFields:
+    Events:
+      - ObserveFields:
           SubfileName: VolumeData
           VariablesToObserve:
             - Lapse
@@ -206,28 +210,30 @@ EventsAndTriggers:
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double]
           OverrideObservationValue: None
-  - - Slabs:
+  - Trigger:
+      Slabs:
         EvenlySpaced:
           Interval: 1
           Offset: 0
-    - - ObservationAhA
+    Events:
+      - ObservationAhA
       - ObservationAhB
-  - - Slabs:
-        EvenlySpaced:
-          Interval: 1
-          Offset: 0
-    - - ObservationExcisionBoundaryA
+      - ObservationExcisionBoundaryA
       - ObservationExcisionBoundaryB
-  - - Slabs:
+  - Trigger:
+      Slabs:
         EvenlySpaced:
           Interval: 100
           Offset: 0
-    - - MonitorMemory:
+    Events:
+      - MonitorMemory:
           ComponentsToMonitor: All
-  - - TimeCompares:
+  - Trigger:
+      TimeCompares:
         Comparison: GreaterThan
         Value: 0.02
-    - - Completion
+    Events:
+      - Completion
 
 Observers:
   VolumeFileName: "GhBinaryBlackHoleVolumeData"

--- a/tests/InputFiles/GeneralizedHarmonic/CylindricalBinaryBlackHole.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/CylindricalBinaryBlackHole.yaml
@@ -133,11 +133,13 @@ Filtering:
 
 
 EventsAndTriggers:
-  - - Slabs:
+  - Trigger:
+      Slabs:
         EvenlySpaced:
           Interval: 1
           Offset: 0
-    - - ObserveNorms:
+    Events:
+      - ObserveNorms:
           SubfileName: Norms
           TensorsToObserve:
           - Name: Lapse
@@ -152,11 +154,13 @@ EventsAndTriggers:
           - Name: PointwiseL2Norm(FourIndexConstraint)
             NormType: L2Norm
             Components: Sum
-  - - Slabs:
+  - Trigger:
+      Slabs:
         EvenlySpaced:
           Interval: 20
           Offset: 0
-    - - ObserveFields:
+    Events:
+      - ObserveFields:
           SubfileName: VolumeData
           VariablesToObserve:
             - Lapse
@@ -168,22 +172,28 @@ EventsAndTriggers:
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double]
           OverrideObservationValue: None
-  - - Slabs:
+  - Trigger:
+      Slabs:
         EvenlySpaced:
           Interval: 1
           Offset: 0
-    - - ObservationAhA
+    Events:
+      - ObservationAhA
       - ObservationAhB
-  - - Slabs:
+  - Trigger:
+      Slabs:
         EvenlySpaced:
           Interval: 100
           Offset: 0
-    - - MonitorMemory:
+    Events:
+      - MonitorMemory:
           ComponentsToMonitor: All
-  - - TimeCompares:
+  - Trigger:
+      TimeCompares:
         Comparison: GreaterThan
         Value: 0.02
-    - - Completion
+    Events:
+      - Completion
 
 Observers:
   VolumeFileName: "GhBinaryBlackHoleVolumeData"

--- a/tests/InputFiles/GeneralizedHarmonic/GaugeWave1D.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/GaugeWave1D.yaml
@@ -19,12 +19,14 @@ Evolution:
       Order: 3
 
 PhaseChangeAndTriggers:
-  - - Slabs:
+  - Trigger:
+      Slabs:
        EvenlySpaced:
          # Current implementation checks wallclock at these global syncs
          Interval: 100
          Offset: 0
-    - - CheckpointAndExitAfterWallclock:
+    PhaseChanges:
+      - CheckpointAndExitAfterWallclock:
           WallclockHours: None
 
 InitialData: &InitialData
@@ -90,11 +92,13 @@ SpatialDiscretization:
     UpwindPenalty:
 
 EventsAndTriggers:
-  - - Slabs:
+  - Trigger:
+      Slabs:
         EvenlySpaced:
           Interval: 2
           Offset: 0
-    - - ObserveNorms:
+    Events:
+      - ObserveNorms:
           SubfileName: Errors
           TensorsToObserve:
             - Name: Error(SpacetimeMetric)
@@ -106,11 +110,13 @@ EventsAndTriggers:
             - Name: Error(Phi)
               NormType: L2Norm
               Components: Sum
-  - - Slabs:
+  - Trigger:
+      Slabs:
         EvenlySpaced:
           Interval: 5
           Offset: 0
-    - - ObserveFields:
+    Events:
+      - ObserveFields:
           SubfileName: VolumeData
           VariablesToObserve:
             - SpacetimeMetric
@@ -122,10 +128,12 @@ EventsAndTriggers:
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double]
           OverrideObservationValue: None
-  - - Slabs:
+  - Trigger:
+      Slabs:
         Specified:
           Values: [5]
-    - - Completion
+    Events:
+      - Completion
 
 EventsAndDenseTriggers:
 

--- a/tests/InputFiles/GeneralizedHarmonic/GaugeWave3D.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/GaugeWave3D.yaml
@@ -19,12 +19,14 @@ Evolution:
       Order: 3
 
 PhaseChangeAndTriggers:
-  - - Slabs:
+  - Trigger:
+      Slabs:
        EvenlySpaced:
          # Current implementation checks wallclock at these global syncs
          Interval: 100
          Offset: 0
-    - - CheckpointAndExitAfterWallclock:
+    PhaseChanges:
+      - CheckpointAndExitAfterWallclock:
           WallclockHours: None
 
 InitialData: &InitialData
@@ -82,11 +84,13 @@ SpatialDiscretization:
     UpwindPenalty:
 
 EventsAndTriggers:
-  - - Slabs:
+  - Trigger:
+      Slabs:
         EvenlySpaced:
           Interval: 2
           Offset: 0
-    - - ObserveNorms:
+    Events:
+      - ObserveNorms:
           SubfileName: Errors
           TensorsToObserve:
             - Name: Error(SpacetimeMetric)
@@ -98,11 +102,13 @@ EventsAndTriggers:
             - Name: Error(Phi)
               NormType: L2Norm
               Components: Sum
-  - - Slabs:
+  - Trigger:
+      Slabs:
         EvenlySpaced:
           Interval: 5
           Offset: 0
-    - - ObserveFields:
+    Events:
+      - ObserveFields:
           SubfileName: VolumeData
           VariablesToObserve:
             - SpacetimeMetric
@@ -115,10 +121,12 @@ EventsAndTriggers:
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double]
           OverrideObservationValue: None
-  - - Slabs:
+  - Trigger:
+      Slabs:
         Specified:
           Values: [2]
-    - - Completion
+    Events:
+      - Completion
 
 EventsAndDenseTriggers:
 

--- a/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
@@ -32,12 +32,14 @@ Evolution:
       Order: 1
 
 PhaseChangeAndTriggers:
-  - - Slabs:
+  - Trigger:
+      Slabs:
        EvenlySpaced:
          # Current implementation checks wallclock at these global syncs
          Interval: 100
          Offset: 0
-    - - CheckpointAndExitAfterWallclock:
+    PhaseChanges:
+      - CheckpointAndExitAfterWallclock:
           WallclockHours: None
 
 InitialData: &InitialData
@@ -108,11 +110,13 @@ SpatialDiscretization:
     Quadrature: GaussLobatto
 
 EventsAndTriggers:
-  - - Slabs:
+  - Trigger:
+      Slabs:
         EvenlySpaced:
           Interval: 2
           Offset: 0
-    - - ObserveNorms:
+    Events:
+      - ObserveNorms:
           SubfileName: Errors
           TensorsToObserve:
             - Name: Error(SpacetimeMetric)
@@ -124,11 +128,7 @@ EventsAndTriggers:
             - Name: Error(Phi)
               NormType: L2Norm
               Components: Sum
-  - - Slabs:
-        EvenlySpaced:
-          Interval: 2
-          Offset: 0
-    - - ObserveNorms:
+      - ObserveNorms:
           SubfileName: Norms
           TensorsToObserve:
           - Name: Lapse
@@ -143,11 +143,13 @@ EventsAndTriggers:
           - Name: PointwiseL2Norm(FourIndexConstraint)
             NormType: L2Norm
             Components: Sum
-  - - Slabs:
+  - Trigger:
+      Slabs:
         EvenlySpaced:
           Interval: 5
           Offset: 0
-    - - ObserveFields:
+    Events:
+      - ObserveFields:
           SubfileName: VolumeData
           VariablesToObserve:
             - SpacetimeMetric
@@ -161,20 +163,20 @@ EventsAndTriggers:
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double]
           OverrideObservationValue: None
-  - - Slabs:
+  - Trigger:
+      Slabs:
         EvenlySpaced:
           Interval: 5
           Offset: 2
-    - - AhA
-  - - Slabs:
-        EvenlySpaced:
-          Interval: 5
-          Offset: 2
-    - - ExcisionBoundaryA
-  - - Slabs:
+    Events:
+      - AhA
+      - ExcisionBoundaryA
+  - Trigger:
+      Slabs:
         Specified:
           Values: [3]
-    - - Completion
+    Events:
+      - Completion
 
 EventsAndDenseTriggers:
 

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/BinaryNeutronStar.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/BinaryNeutronStar.yaml
@@ -121,19 +121,23 @@ Filtering:
 
 EventsAndTriggers:
   # Set time step based on CLF condition
-  - - Slabs:
+  - Trigger:
+      Slabs:
         Specified:
           Values: [0]
-    - - ChangeSlabSize:
+    Events:
+      - ChangeSlabSize:
           DelayChange: 0
           StepChoosers:
             - Cfl:
                 SafetyFactor: 0.5
-  - - Slabs:
+  - Trigger:
+      Slabs:
         EvenlySpaced:
           Interval: 1
           Offset: 0
-    - - ObserveTimeStep:
+    Events:
+      - ObserveTimeStep:
             SubfileName: TimeSteps
             PrintTimeToTerminal: True
             ObservePerCore: False
@@ -162,10 +166,12 @@ EventsAndTriggers:
           CoordinatesFloatingPointType: Float
           FloatingPointTypes: [Float]
           OverrideObservationValue: None
-  - - TimeCompares:
+  - Trigger:
+      TimeCompares:
         Comparison: GreaterThan
         Value: 1.5
-    - - Completion
+    Events:
+      - Completion
 
 Observers:
   VolumeFileName: "GhMhdVolume"

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdBondiMichel.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdBondiMichel.yaml
@@ -23,11 +23,13 @@ Evolution:
       Order: 3
 
 PhaseChangeAndTriggers:
-  - - Slabs:
+  - Trigger:
+      Slabs:
         EvenlySpaced:
           Interval: 1000
           Offset: 5
-    - - VisitAndReturn(LoadBalancing)
+    PhaseChanges:
+      - VisitAndReturn(LoadBalancing)
 
 AnalyticSolution: &InitialData
   BondiMichel:
@@ -118,22 +120,26 @@ SpatialDiscretization:
       Rusanov:
 
 EventsAndTriggers:
-  - - Slabs:
+  - Trigger:
+      Slabs:
         EvenlySpaced:
           Interval: 5
           Offset: 0
-    - - ChangeSlabSize:
+    Events:
+      - ChangeSlabSize:
           DelayChange: 5
           StepChoosers:
             - Cfl:
                 SafetyFactor: 0.6
             - Increase:
                 Factor: 1.5
-  - - Slabs:
+  - Trigger:
+      Slabs:
         EvenlySpaced:
           Interval: 1
           Offset: 0
-    - - ObserveNorms:
+    Events:
+      - ObserveNorms:
           SubfileName: Errors
           TensorsToObserve:
             - Name: Error(SpacetimeMetric)
@@ -169,11 +175,13 @@ EventsAndTriggers:
             - Name: Error(SpecificEnthalpy)
               NormType: L2Norm
               Components: Sum
-  - - Slabs:
+  - Trigger:
+      Slabs:
         EvenlySpaced:
           Interval: 2
           Offset: 0
-    - - ObserveFields:
+    Events:
+      - ObserveFields:
           SubfileName: VolumeData
           VariablesToObserve:
             - SpacetimeMetric
@@ -185,15 +193,19 @@ EventsAndTriggers:
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double, Double, Double, Double, Double]
           OverrideObservationValue: None
-  - - Slabs:
+  - Trigger:
+      Slabs:
         EvenlySpaced:
           Interval: 5
           Offset: 3
-    - - AhA
-  - - Slabs:
+    Events:
+      - AhA
+  - Trigger:
+      Slabs:
         Specified:
           Values: [2]
-    - - Completion
+    Events:
+      - Completion
 
 ApparentHorizons:
   AhA:

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdTovStar.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdTovStar.yaml
@@ -19,11 +19,13 @@ Evolution:
       Order: 3
 
 PhaseChangeAndTriggers:
-  - - Slabs:
+  - Trigger:
+      Slabs:
         EvenlySpaced:
           Interval: 1000
           Offset: 5
-    - - VisitAndReturn(LoadBalancing)
+    PhaseChanges:
+      - VisitAndReturn(LoadBalancing)
 
 AnalyticSolution: &InitialData
   TovStar:
@@ -134,22 +136,26 @@ Filtering:
 
 
 EventsAndTriggers:
-  - - Slabs:
+  - Trigger:
+      Slabs:
         EvenlySpaced:
           Interval: 5
           Offset: 0
-    - - ChangeSlabSize:
+    Events:
+      - ChangeSlabSize:
           DelayChange: 5
           StepChoosers:
             - Cfl:
                 SafetyFactor: 0.6
             - Increase:
                 Factor: 1.5
-  - - Slabs:
+  - Trigger:
+      Slabs:
         EvenlySpaced:
           Interval: 1
           Offset: 0
-    - - ObserveNorms:
+    Events:
+      - ObserveNorms:
           SubfileName: Errors
           TensorsToObserve:
             - Name: Error(SpacetimeMetric)
@@ -185,11 +191,13 @@ EventsAndTriggers:
             - Name: Error(SpecificEnthalpy)
               NormType: L2Norm
               Components: Sum
-  - - Slabs:
+  - Trigger:
+      Slabs:
         EvenlySpaced:
           Interval: 2
           Offset: 0
-    - - ObserveFields:
+    Events:
+      - ObserveFields:
           SubfileName: VolumeData
           VariablesToObserve:
             - SpacetimeMetric
@@ -201,10 +209,12 @@ EventsAndTriggers:
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double, Double, Double, Double, Double]
           OverrideObservationValue: None
-  - - Slabs:
+  - Trigger:
+      Slabs:
         Specified:
           Values: [3]
-    - - Completion
+    Events:
+      - Completion
 
 Observers:
   VolumeFileName: "GhMhdTovStarVolume"

--- a/tests/InputFiles/GrMhd/ValenciaDivClean/BlastWave.yaml
+++ b/tests/InputFiles/GrMhd/ValenciaDivClean/BlastWave.yaml
@@ -13,12 +13,14 @@ Evolution:
   TimeStepper: Rk3HesthavenSsp
 
 PhaseChangeAndTriggers:
-  - - Slabs:
+  - Trigger:
+      Slabs:
        EvenlySpaced:
          # Current implementation checks wallclock at these global syncs
          Interval: 100
          Offset: 0
-    - - CheckpointAndExitAfterWallclock:
+    PhaseChanges:
+      - CheckpointAndExitAfterWallclock:
           WallclockHours: None
 
 DomainCreator:
@@ -104,10 +106,12 @@ Interpolator:
   DumpVolumeDataOnFailure: false
 
 EventsAndTriggers:
-  - - Slabs:
+  - Trigger:
+      Slabs:
         Specified:
           Values: [2]
-    - - Completion
+    Events:
+      - Completion
 
 EventsAndDenseTriggers:
 

--- a/tests/InputFiles/GrMhd/ValenciaDivClean/FishboneMoncriefDisk.yaml
+++ b/tests/InputFiles/GrMhd/ValenciaDivClean/FishboneMoncriefDisk.yaml
@@ -28,12 +28,14 @@ Evolution:
   # InitialSlabSize: 0.01
 
 PhaseChangeAndTriggers:
-  - - Slabs:
+  - Trigger:
+      Slabs:
        EvenlySpaced:
          # Current implementation checks wallclock at these global syncs
          Interval: 100
          Offset: 0
-    - - CheckpointAndExitAfterWallclock:
+    PhaseChanges:
+      - CheckpointAndExitAfterWallclock:
           WallclockHours: None
 
 DomainCreator:
@@ -105,15 +107,19 @@ VariableFixing:
     MaxVelocityMagnitude: 1.0e-4
 
 EventsAndTriggers:
-  - - Slabs:
+  - Trigger:
+      Slabs:
         Specified:
           Values: [10]
-    - - Completion
-  - - Slabs:
+    Events:
+      - Completion
+  - Trigger:
+      Slabs:
         EvenlySpaced:
           Interval: 1
           Offset: 0
-    - - ChangeSlabSize:
+    Events:
+      - ChangeSlabSize:
           # DelayChange: 0 forces a synchronization after every slab.
           # It is more efficient to use a higher value.  This is for
           # testing.

--- a/tests/InputFiles/NewtonianEuler/RiemannProblem1D.yaml
+++ b/tests/InputFiles/NewtonianEuler/RiemannProblem1D.yaml
@@ -64,12 +64,16 @@ AnalyticSolution:
     PressureStarTol: 1e-9
 
 EventsAndTriggers:
-  - - TimeCompares:
+  - Trigger:
+      TimeCompares:
         Comparison: GreaterThanOrEqualTo
         Value: 0.2
-    - - Completion
-  - - Always
-    - - ChangeSlabSize:
+    Events:
+      - Completion
+  - Trigger:
+      Always
+    Events:
+      - ChangeSlabSize:
           # Smaller values for DelayChange make the error control more
           # responsive, while larger values reduce the global coupling
           # between all the elements.  Experimentally, varying this
@@ -88,10 +92,12 @@ EventsAndTriggers:
   # with a delay of 0 with no downside.  We don't want them to start
   # increasing the slab size before the error control is active,
   # though.
-  - - SlabCompares:
+  - Trigger:
+      SlabCompares:
         Comparison: GreaterThanOrEqualTo
         Value: *slab_update_delay
-    - - ChangeSlabSize:
+    Events:
+      - ChangeSlabSize:
           DelayChange: 0
           StepChoosers:
             - Increase:

--- a/tests/InputFiles/NewtonianEuler/RiemannProblem2D.yaml
+++ b/tests/InputFiles/NewtonianEuler/RiemannProblem2D.yaml
@@ -60,10 +60,12 @@ AnalyticSolution:
     PressureStarTol: 1e-9
 
 EventsAndTriggers:
-  - - Slabs:
+  - Trigger:
+      Slabs:
         Specified:
           Values: [10]
-    - - Completion
+    Events:
+      - Completion
 
 EventsAndDenseTriggers:
 

--- a/tests/InputFiles/NewtonianEuler/RiemannProblem3D.yaml
+++ b/tests/InputFiles/NewtonianEuler/RiemannProblem3D.yaml
@@ -62,10 +62,12 @@ AnalyticSolution:
     PressureStarTol: 1e-9
 
 EventsAndTriggers:
-  - - Slabs:
+  - Trigger:
+      Slabs:
         Specified:
           Values: [10]
-    - - Completion
+    Events:
+      - Completion
 
 EventsAndDenseTriggers:
 

--- a/tests/InputFiles/Poisson/ProductOfSinusoids1D.yaml
+++ b/tests/InputFiles/Poisson/ProductOfSinusoids1D.yaml
@@ -78,8 +78,9 @@ LinearSolver:
 RadiallyCompressedCoordinates: None
 
 EventsAndTriggers:
-  - - HasConverged
-    - - ObserveNorms:
+  - Trigger: HasConverged
+    Events:
+      - ObserveNorms:
           SubfileName: ErrorNorms
           TensorsToObserve:
             - Name: Error(Field)

--- a/tests/InputFiles/Poisson/ProductOfSinusoids2D.yaml
+++ b/tests/InputFiles/Poisson/ProductOfSinusoids2D.yaml
@@ -72,8 +72,9 @@ LinearSolver:
 RadiallyCompressedCoordinates: None
 
 EventsAndTriggers:
-  - - HasConverged
-    - - ObserveNorms:
+  - Trigger: HasConverged
+    Events:
+      - ObserveNorms:
           SubfileName: ErrorNorms
           TensorsToObserve:
             - Name: Error(Field)

--- a/tests/InputFiles/Poisson/ProductOfSinusoids3D.yaml
+++ b/tests/InputFiles/Poisson/ProductOfSinusoids3D.yaml
@@ -78,8 +78,9 @@ LinearSolver:
 RadiallyCompressedCoordinates: None
 
 EventsAndTriggers:
-  - - HasConverged
-    - - ObserveNorms:
+  - Trigger: HasConverged
+    Events:
+      - ObserveNorms:
           SubfileName: ErrorNorms
           TensorsToObserve:
             - Name: Error(Field)

--- a/tests/InputFiles/Punctures/MultiplePunctures.yaml
+++ b/tests/InputFiles/Punctures/MultiplePunctures.yaml
@@ -94,8 +94,9 @@ LinearSolver:
     ObservePerCoreReductions: False
 
 EventsAndTriggers:
-  - - HasConverged
-    - - ObserveFields:
+  - Trigger: HasConverged
+    Events:
+      - ObserveFields:
           SubfileName: VolumeData
           VariablesToObserve:
             - Field

--- a/tests/InputFiles/RadiationTransport/M1Grey/ConstantM1.yaml
+++ b/tests/InputFiles/RadiationTransport/M1Grey/ConstantM1.yaml
@@ -50,11 +50,13 @@ Limiter:
     DisableForDebugging: false
 
 EventsAndTriggers:
-  - - Slabs:
+  - Trigger:
+      Slabs:
         EvenlySpaced:
           Interval: 3
           Offset: 5
-    - - ObserveNorms:
+    Events:
+      - ObserveNorms:
           SubfileName: Errors
           TensorsToObserve:
             - Name: Error(TildeE_ElectronNeutrinos1)
@@ -63,10 +65,12 @@ EventsAndTriggers:
             - Name: Error(TildeS_ElectronNeutrinos1)
               NormType: L2Norm
               Components: Sum
-  - - Slabs:
+  - Trigger:
+      Slabs:
         Specified:
           Values: [10]
-    - - Completion
+    Events:
+      - Completion
 
 EventsAndDenseTriggers:
 

--- a/tests/InputFiles/RelativisticEuler/Valencia/SmoothFlow1D.yaml
+++ b/tests/InputFiles/RelativisticEuler/Valencia/SmoothFlow1D.yaml
@@ -63,16 +63,20 @@ VariableFixing:
     MaxVelocityMagnitude: 1.0e-4
 
 EventsAndTriggers:
-  # - - Slabs:
+  # - Trigger:
+  #     Slabs:
   #       EvenlySpaced:
   #         Interval: 10
   #         Offset: 0
-  #   - - ObserveFields:
+  #   Events:
+  #     - ObserveFields:
   #         VariablesToObserve: [RestMassDensity]
-  - - Slabs:
+  - Trigger:
+      Slabs:
         Specified:
           Values: [10]
-    - - Completion
+    Events:
+      - Completion
 
 EventsAndDenseTriggers:
 

--- a/tests/InputFiles/RelativisticEuler/Valencia/SmoothFlow2D.yaml
+++ b/tests/InputFiles/RelativisticEuler/Valencia/SmoothFlow2D.yaml
@@ -59,16 +59,20 @@ VariableFixing:
     MaxVelocityMagnitude: 1.0e-4
 
 EventsAndTriggers:
-  # - - Slabs:
+  # - Trigger:
+  #     Slabs:
   #       EvenlySpaced:
   #         Interval: 100
   #         Offset: 0
-  #   - - ObserveFields:
+  #   Events:
+  #     - ObserveFields:
   #         VariablesToObserve: [RestMassDensity]
-  - - Slabs:
+  - Trigger:
+      Slabs:
         Specified:
           Values: [10]
-    - - Completion
+    Events:
+      - Completion
 
 EventsAndDenseTriggers:
 

--- a/tests/InputFiles/RelativisticEuler/Valencia/SmoothFlow3D.yaml
+++ b/tests/InputFiles/RelativisticEuler/Valencia/SmoothFlow3D.yaml
@@ -61,16 +61,20 @@ VariableFixing:
     MaxVelocityMagnitude: 1.0e-4
 
 EventsAndTriggers:
-  # - - Slabs:
+  # - Trigger:
+  #     Slabs:
   #       EvenlySpaced:
   #         Interval: 100
   #         Offset: 0
-  #   - - ObserveFields:
+  #   Events:
+  #     - ObserveFields:
   #         VariablesToObserve: [RestMassDensity]
-  - - Slabs:
+  - Trigger:
+      Slabs:
         Specified:
           Values: [10]
-    - - Completion
+    Events:
+      - Completion
 
 EventsAndDenseTriggers:
 

--- a/tests/InputFiles/ScalarAdvection/Krivodonova1D.yaml
+++ b/tests/InputFiles/ScalarAdvection/Krivodonova1D.yaml
@@ -58,15 +58,19 @@ InitialData:
   Krivodonova:
 
 EventsAndTriggers:
-  - - Slabs:
+  - Trigger:
+      Slabs:
         Specified:
           Values: [10]
-    - - Completion
-  - - Slabs:
+    Events:
+      - Completion
+  - Trigger:
+      Slabs:
         EvenlySpaced:
           Interval: 10
           Offset: 0
-    - - ObserveFields:
+    Events:
+      - ObserveFields:
           SubfileName: VolumeData
           VariablesToObserve: [U, TciStatus]
           InterpolateToMesh: None

--- a/tests/InputFiles/ScalarAdvection/Kuzmin2D.yaml
+++ b/tests/InputFiles/ScalarAdvection/Kuzmin2D.yaml
@@ -54,15 +54,19 @@ InitialData:
   Kuzmin:
 
 EventsAndTriggers:
-  - - Slabs:
+  - Trigger:
+      Slabs:
         Specified:
           Values: [10]
-    - - Completion
-  - - Slabs:
+    Events:
+      - Completion
+  - Trigger:
+      Slabs:
         EvenlySpaced:
           Interval: 10
           Offset: 0
-    - - ObserveFields:
+    Events:
+      - ObserveFields:
           SubfileName: VolumeData
           VariablesToObserve: [U, TciStatus]
           InterpolateToMesh: None

--- a/tests/InputFiles/ScalarAdvection/Sinusoid1D.yaml
+++ b/tests/InputFiles/ScalarAdvection/Sinusoid1D.yaml
@@ -58,15 +58,19 @@ InitialData:
   Sinusoid:
 
 EventsAndTriggers:
-  - - Slabs:
+  - Trigger:
+      Slabs:
         Specified:
           Values: [10]
-    - - Completion
-  - - Slabs:
+    Events:
+      - Completion
+  - Trigger:
+      Slabs:
         EvenlySpaced:
           Interval: 10
           Offset: 0
-    - - ObserveFields:
+    Events:
+      - ObserveFields:
           SubfileName: VolumeData
           VariablesToObserve: [U, TciStatus]
           InterpolateToMesh: None

--- a/tests/InputFiles/ScalarWave/PlaneWave1D.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave1D.yaml
@@ -69,10 +69,12 @@ SpatialDiscretization:
 #     BlocksToFilter: All
 
 EventsAndTriggers:
-  - - Slabs:
+  - Trigger:
+      Slabs:
         Specified:
           Values: [5]
-    - - Completion
+    Events:
+      - Completion
 
 EventsAndDenseTriggers:
 

--- a/tests/InputFiles/ScalarWave/PlaneWave1DEventsAndTriggersExample.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave1DEventsAndTriggersExample.yaml
@@ -55,11 +55,13 @@ EventsAndDenseTriggers:
 
 # [multiple_events]
 EventsAndTriggers:
-  - - Slabs:
+  - Trigger:
+      Slabs:
         EvenlySpaced:
           Interval: 10
           Offset: 0
-    - - ObserveFields:
+    Events:
+      - ObserveFields:
           SubfileName: Fields
           VariablesToObserve: [Psi]
           InterpolateToMesh: None
@@ -78,15 +80,10 @@ EventsAndTriggers:
             - Name: Error(Pi)
               NormType: L2Norm
               Components: Sum
+  - Trigger: Always
+    Events:
+      - Completion
 # [multiple_events]
-
-# [no_arguments]
-  - - Always
-    - - Completion
-# [no_arguments]
-# [no_arguments_single_line]
-  - [Always, [Completion]]
-# [no_arguments_single_line]
 
 Observers:
   VolumeFileName: "ScalarWavePlaneWave1DEventsAndTriggersExampleVolume"

--- a/tests/InputFiles/ScalarWave/PlaneWave1DObserveExample.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave1DObserveExample.yaml
@@ -70,10 +70,12 @@ SpatialDiscretization:
 
 # [observe_event_trigger]
 EventsAndDenseTriggers:
-  - - Times:
+  - Trigger:
+      Times:
         Specified:
           Values: [0.0, 1.0]
-    - - ObserveNorms:
+    Events:
+      - ObserveNorms:
           SubfileName: Errors
           TensorsToObserve:
             - Name: Error(Psi)
@@ -87,15 +89,19 @@ EventsAndDenseTriggers:
               Components: Sum
 
 EventsAndTriggers:
-  - - Slabs:
+  - Trigger:
+      Slabs:
         Specified:
           Values: [100]
-    - - Completion
-  - - Slabs:
+    Events:
+      - Completion
+  - Trigger:
+      Slabs:
         EvenlySpaced:
           Interval: 50
           Offset: 0
-    - - ObserveFields:
+    Events:
+      - ObserveFields:
           SubfileName: VolumePsiPiPhiEvery50Slabs
           VariablesToObserve: ["Psi", "Pi", "Phi"]
           InterpolateToMesh: None

--- a/tests/InputFiles/ScalarWave/PlaneWave2D.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave2D.yaml
@@ -67,17 +67,21 @@ Filtering:
     BlocksToFilter: All
 
 EventsAndTriggers:
-  - - Slabs:
+  - Trigger:
+      Slabs:
         Specified:
           Values: [5]
-    - - Completion
+    Events:
+      - Completion
 
 EventsAndDenseTriggers:
   # Test LTS dense output at the initial time
-  - - Times:
+  - Trigger:
+      Times:
         Specified:
           Values: [*initial_time]
-    - - ObserveNorms:
+    Events:
+      - ObserveNorms:
           SubfileName: Errors
           TensorsToObserve:
             - Name: Error(Psi)

--- a/tests/InputFiles/ScalarWave/PlaneWave3D.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave3D.yaml
@@ -61,12 +61,15 @@ SpatialDiscretization:
 #     BlocksToFilter: All
 
 EventsAndTriggers:
-  - - Times:
+  - Trigger:
+      Times:
         Specified:
           Values: [&final_time -0.05]
-    - - Completion
-  - - Always
-    - - ChangeSlabSize:
+    Events:
+      - Completion
+  - Trigger: Always
+    Events:
+      - ChangeSlabSize:
           DelayChange: 0
           StepChoosers:
             - Increase:

--- a/tests/InputFiles/Xcts/BinaryBlackHole.yaml
+++ b/tests/InputFiles/Xcts/BinaryBlackHole.yaml
@@ -161,8 +161,9 @@ RadiallyCompressedCoordinates:
   Compression: *outer_shell_distribution
 
 EventsAndTriggers:
-  - - HasConverged
-    - - ObserveNorms:
+  - Trigger: HasConverged
+    Events:
+      - ObserveNorms:
           SubfileName: Norms
           TensorsToObserve:
             - Name: ConformalFactor

--- a/tests/InputFiles/Xcts/HeadOnBns.yaml
+++ b/tests/InputFiles/Xcts/HeadOnBns.yaml
@@ -155,8 +155,9 @@ RadiallyCompressedCoordinates:
   Compression: *outer_shell_distribution
 
 EventsAndTriggers:
-  - - HasConverged
-    - - ObserveNorms:
+  - Trigger: HasConverged
+    Events:
+      - ObserveNorms:
           SubfileName: Norms
           TensorsToObserve:
             - Name: ConformalFactor

--- a/tests/InputFiles/Xcts/KerrSchild.yaml
+++ b/tests/InputFiles/Xcts/KerrSchild.yaml
@@ -111,8 +111,9 @@ LinearSolver:
 RadiallyCompressedCoordinates: None
 
 EventsAndTriggers:
-  - - HasConverged
-    - - ObserveNorms:
+  - Trigger: HasConverged
+    Events:
+      - ObserveNorms:
           SubfileName: ErrorNorms
           TensorsToObserve:
             - Name: Error(ConformalFactor)

--- a/tests/InputFiles/Xcts/TovStar.yaml
+++ b/tests/InputFiles/Xcts/TovStar.yaml
@@ -107,8 +107,9 @@ LinearSolver:
 RadiallyCompressedCoordinates: None
 
 EventsAndTriggers:
-  - - HasConverged
-    - - ObserveNorms:
+  - Trigger: HasConverged
+    Events:
+      - ObserveNorms:
           SubfileName: ErrorNorms
           TensorsToObserve:
             - Name: Error(ConformalFactor)

--- a/tests/Unit/Evolution/Actions/Test_RunEventsAndDenseTriggers.cpp
+++ b/tests/Unit/Evolution/Actions/Test_RunEventsAndDenseTriggers.cpp
@@ -346,11 +346,11 @@ void test(const bool time_runs_forward) {
         events_and_dense_triggers.reserve(triggers.size());
         for (auto [trigger_time, is_triggered, next_trigger,
                    needs_evolved_variables] : triggers) {
-          events_and_dense_triggers.emplace_back(
-              std::make_unique<TestTrigger>(start_time, trigger_time,
-                                            is_triggered, next_trigger),
-              make_vector<std::unique_ptr<Event>>(
-                  std::make_unique<TestEvent>(needs_evolved_variables)));
+          events_and_dense_triggers.push_back(
+              {std::make_unique<TestTrigger>(start_time, trigger_time,
+                                             is_triggered, next_trigger),
+               make_vector<std::unique_ptr<Event>>(
+                   std::make_unique<TestEvent>(needs_evolved_variables))});
         }
 
         tmpl::as_pack<extra_data>([&](auto... tags_v) {

--- a/tests/Unit/Evolution/EventsAndDenseTriggers/Test_EventsAndDenseTriggers.cpp
+++ b/tests/Unit/Evolution/EventsAndDenseTriggers/Test_EventsAndDenseTriggers.cpp
@@ -151,12 +151,14 @@ void do_test(const bool time_runs_forward, const bool add_event) {
   const int* component = nullptr;
 
   std::string creation_string =
-      "- - BoxTrigger<A>\n"
-      "  - - TestEvent<A>\n";
+      "- Trigger: BoxTrigger<A>\n"
+      "  Events:\n"
+      "    - TestEvent<A>\n";
   if (not add_event) {
     creation_string +=
-        "- - BoxTrigger<B>\n"
-        "  - - TestEvent<B>\n"
+        "- Trigger: BoxTrigger<B>\n"
+        "  Events:\n"
+        "    - TestEvent<B>\n"
         "    - TestEvent<C>\n";
   }
 

--- a/tests/Unit/IO/Observers/Test_RegisterEvents.cpp
+++ b/tests/Unit/IO/Observers/Test_RegisterEvents.cpp
@@ -177,8 +177,10 @@ SPECTRE_TEST_CASE("Unit.IO.Observers.RegisterEvents", "[Unit][Observers]") {
 
   const auto events_and_triggers =
       TestHelpers::test_creation<EventsAndTriggers, Metavariables>(
-          "- - Not: Always\n"
-          "  - - SomeEvent:\n"
+          "- Trigger:\n"
+          "    Not: Always\n"
+          "  Events:\n"
+          "    - SomeEvent:\n"
           "        SubfileName: element_data\n");
 
   using my_component = Component<Metavariables>;

--- a/tests/Unit/Parallel/PhaseControl/Test_CheckpointAndExitAfterWallclock.cpp
+++ b/tests/Unit/Parallel/PhaseControl/Test_CheckpointAndExitAfterWallclock.cpp
@@ -41,8 +41,9 @@ SPECTRE_TEST_CASE("Unit.Parallel.PhaseControl.CheckpointAndExitAfterWallclock",
 
   const auto created_phase_changes = TestHelpers::test_option_tag<
       PhaseControl::OptionTags::PhaseChangeAndTriggers, Metavariables>(
-      " - - Always:\n"
-      "   - - CheckpointAndExitAfterWallclock:\n"
+      " - Trigger: Always\n"
+      "   PhaseChanges:\n"
+      "     - CheckpointAndExitAfterWallclock:\n"
       "         WallclockHours: 0.0");
 
   Parallel::GlobalCache<Metavariables> cache{};

--- a/tests/Unit/Parallel/PhaseControl/Test_ExecutePhaseChange.cpp
+++ b/tests/Unit/Parallel/PhaseControl/Test_ExecutePhaseChange.cpp
@@ -182,10 +182,10 @@ SPECTRE_TEST_CASE("Unit.Parallel.PhaseControl.ExecutePhaseChange",
 
   using phase_change_and_triggers = PhaseControl::Tags::PhaseChangeAndTriggers;
   phase_change_and_triggers::type vector_of_triggers_and_phase_changes;
-  vector_of_triggers_and_phase_changes.emplace_back(
-      static_cast<std::unique_ptr<Trigger>>(
-          std::make_unique<Triggers::Always>()),
-      std::move(phase_change_vector));
+  vector_of_triggers_and_phase_changes.push_back(
+      {static_cast<std::unique_ptr<Trigger>>(
+           std::make_unique<Triggers::Always>()),
+       std::move(phase_change_vector)});
 
   Parallel::MutableGlobalCache<Metavariables> mutable_cache{};
   Parallel::GlobalCache<Metavariables> global_cache{

--- a/tests/Unit/Parallel/PhaseControl/Test_PhaseControlTags.cpp
+++ b/tests/Unit/Parallel/PhaseControl/Test_PhaseControlTags.cpp
@@ -104,17 +104,19 @@ SPECTRE_TEST_CASE("Unit.Parallel.PhaseControl.PhaseControlTags",
 
   const auto created_phase_changes = TestHelpers::test_option_tag<
       PhaseControl::OptionTags::PhaseChangeAndTriggers, Metavariables>(
-      " - - Slabs:\n"
+      " - Trigger:\n"
+      "     Slabs:\n"
       "       EvenlySpaced:\n"
       "         Interval: 2\n"
       "         Offset: 0\n"
-      "   - - TestCreatable(1):\n"
+      "   PhaseChanges:\n"
+      "     - TestCreatable(1):\n"
       "         IntOption: 4\n"
       "     - TestCreatable(2):\n"
       "         IntOption: 2");
   CHECK(created_phase_changes.size() == 1_st);
-  const auto& first_creatable = created_phase_changes[0].second[0];
-  const auto& second_creatable = created_phase_changes[0].second[1];
+  const auto& first_creatable = created_phase_changes[0].phase_changes[0];
+  const auto& second_creatable = created_phase_changes[0].phase_changes[1];
   REQUIRE(dynamic_cast<TestCreatable<1_st>*>(first_creatable.get()) != nullptr);
   CHECK(dynamic_cast<TestCreatable<1_st>*>(first_creatable.get())
             ->option_value_ == 4);

--- a/tests/Unit/Parallel/PhaseControl/Test_VisitAndReturn.cpp
+++ b/tests/Unit/Parallel/PhaseControl/Test_VisitAndReturn.cpp
@@ -47,14 +47,15 @@ SPECTRE_TEST_CASE("Unit.Parallel.PhaseControl.VisitAndReturn",
 
   const auto created_phase_changes = TestHelpers::test_option_tag<
       PhaseControl::OptionTags::PhaseChangeAndTriggers, Metavariables>(
-      " - - Always:\n"
-      "   - - VisitAndReturn(Evolve):\n"
-      "     - VisitAndReturn(Execute):");
+      " - Trigger: Always\n"
+      "   PhaseChanges:\n"
+      "     - VisitAndReturn(Evolve)\n"
+      "     - VisitAndReturn(Execute)");
   using PhaseChangeDecisionData = tuples::tagged_tuple_from_typelist<
       PhaseControl::get_phase_change_tags<Metavariables>>;
 
-  const auto& first_phase_change = created_phase_changes[0].second[0];
-  const auto& second_phase_change = created_phase_changes[0].second[1];
+  const auto& first_phase_change = created_phase_changes[0].phase_changes[0];
+  const auto& second_phase_change = created_phase_changes[0].phase_changes[1];
   {
     INFO("Test initialize phase change decision data");
     PhaseChangeDecisionData phase_change_decision_data{

--- a/tests/Unit/Parallel/Test_AlgorithmPhaseControl.yaml
+++ b/tests/Unit/Parallel/Test_AlgorithmPhaseControl.yaml
@@ -4,10 +4,12 @@
 # note that this is a vector of pairs, so has the peculiar '- -' for the
 # elements
 PhaseChangeAndTriggers:
-  - - RegisterTrigger:
-    - - VisitAndReturn(Register)
-  - - SolveTrigger:
-    - - VisitAndReturn(Solve)
+  - Trigger: RegisterTrigger
+    PhaseChanges:
+      - VisitAndReturn(Register)
+  - Trigger: SolveTrigger
+    PhaseChanges:
+      - VisitAndReturn(Solve)
 
 ResourceInfo:
   AvoidGlobalProc0: false

--- a/tests/Unit/ParallelAlgorithms/EventsAndTriggers/Test_EventsAndTriggers.cpp
+++ b/tests/Unit/ParallelAlgorithms/EventsAndTriggers/Test_EventsAndTriggers.cpp
@@ -82,9 +82,9 @@ void check_trigger(const bool expected, const std::string& trigger_string) {
           trigger_string);
 
   EventsAndTriggers::Storage events_and_triggers_input;
-  events_and_triggers_input.emplace_back(
-      std::move(trigger), make_vector<std::unique_ptr<Event>>(
-                              std::make_unique<Events::Completion>()));
+  events_and_triggers_input.push_back(
+      {std::move(trigger), make_vector<std::unique_ptr<Event>>(
+                               std::make_unique<Events::Completion>())});
   const EventsAndTriggers events_and_triggers(
       std::move(events_and_triggers_input));
 
@@ -153,25 +153,31 @@ void test_basic_triggers() {
 void test_factory() {
   const auto events_and_triggers =
       TestHelpers::test_creation<EventsAndTriggers, Metavariables<>>(
-          "- - Not: Always\n"
-          "  - - Completion\n"
-          "- - Or:\n"
-          "    - Not: Always\n"
-          "    - Always\n"
-          "  - - Completion\n"
+          "- Trigger:\n"
+          "    Not: Always\n"
+          "  Events:\n"
           "    - Completion\n"
-          "- - Not: Always\n"
-          "  - - Completion\n");
+          "- Trigger:\n"
+          "    Or:\n"
+          "      - Not: Always\n"
+          "      - Always\n"
+          "  Events:\n"
+          "    - Completion\n"
+          "    - Completion\n"
+          "- Trigger:\n"
+          "    Not: Always\n"
+          "  Events:\n"
+          "    - Completion\n");
 
   run_events_and_triggers(events_and_triggers, true);
 }
 
 void test_slab_limits() {
   EventsAndTriggers::Storage events_and_triggers_input;
-  events_and_triggers_input.emplace_back(
-      std::make_unique<Triggers::Always>(),
-      make_vector<std::unique_ptr<Event>>(
-          std::make_unique<Events::Completion>()));
+  events_and_triggers_input.push_back(
+      {std::make_unique<Triggers::Always>(),
+       make_vector<std::unique_ptr<Event>>(
+           std::make_unique<Events::Completion>())});
 
   const Slab slab(0.0, 1.0);
   const auto start = slab.start();

--- a/tests/Unit/Time/StepChoosers/Test_ErrorControl.cpp
+++ b/tests/Unit/Time/StepChoosers/Test_ErrorControl.cpp
@@ -329,10 +329,12 @@ SPECTRE_TEST_CASE("Unit.Time.StepChoosers.ErrorControl", "[Unit][Time]") {
         [](const gsl::not_null<Tags::EventsAndTriggers::type*> events) {
           *events = TestHelpers::test_creation<Tags::EventsAndTriggers::type,
                                                Metavariables<true>>(
-              "- - Always:\n"
-              "  - - Completion\n"
-              "- - Always:\n"
-              "  - - Completion\n"
+              "- Trigger: Always\n"
+              "  Events:\n"
+              "    - Completion\n"
+              "- Trigger: Always\n"
+              "  Events:\n"
+              "    - Completion\n"
               "    - ChangeSlabSize:\n"
               "        DelayChange: 0\n"
               "        StepChoosers:\n"
@@ -352,10 +354,12 @@ SPECTRE_TEST_CASE("Unit.Time.StepChoosers.ErrorControl", "[Unit][Time]") {
         [](const gsl::not_null<Tags::EventsAndTriggers::type*> events) {
           *events = TestHelpers::test_creation<Tags::EventsAndTriggers::type,
                                                Metavariables<true>>(
-              "- - Always:\n"
-              "  - - Completion\n"
-              "- - Always:\n"
-              "  - - Completion\n"
+              "- Trigger: Always\n"
+              "  Events:\n"
+              "    - Completion\n"
+              "- Trigger: Always\n"
+              "  Events:\n"
+              "    - Completion\n"
               "    - ChangeSlabSize:\n"
               "        DelayChange: 0\n"
               "        StepChoosers:\n"
@@ -369,10 +373,12 @@ SPECTRE_TEST_CASE("Unit.Time.StepChoosers.ErrorControl", "[Unit][Time]") {
         [](const gsl::not_null<Tags::EventsAndTriggers::type*> events) {
           *events = TestHelpers::test_creation<Tags::EventsAndTriggers::type,
                                                Metavariables<true>>(
-              "- - Always:\n"
-              "  - - Completion\n"
-              "- - Always:\n"
-              "  - - Completion");
+              "- Trigger: Always\n"
+              "  Events:\n"
+              "    - Completion\n"
+              "- Trigger: Always\n"
+              "  Events:\n"
+              "    - Completion");
         });
     CHECK_FALSE(db::get<Tags::IsUsingTimeSteppingErrorControl>(box));
     db::mutate<Tags::EventsAndTriggers>(

--- a/tests/tools/Test_Status.py
+++ b/tests/tools/Test_Status.py
@@ -20,11 +20,15 @@ class TestExecutableStatus(unittest.TestCase):
             "Observers": {
                 "ReductionFileName": "Reductions"
             },
-            "EventsAndTriggers": [("Always", [{
-                "ObserveTimeStep": {
-                    "SubfileName": "TimeSteps"
-                }
-            }])]
+            "EventsAndTriggers": [{
+                "Trigger":
+                "Always",
+                "Events": [{
+                    "ObserveTimeStep": {
+                        "SubfileName": "TimeSteps"
+                    }
+                }]
+            }]
         }
         self.work_dir = os.path.join(unit_test_build_path(),
                                      "tools/ExecutableStatus")


### PR DESCRIPTION
## Proposed changes

Attempt to improve the awkward `- -` syntax in EventsAndTriggers.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
In input files that use EventsAndTriggers, EventsAndDenseTriggers, or PhaseChanges, change the `- -` syntax to something like this:

```yaml
EventsAndTriggers:
  - Trigger:
      Slabs:
        Specified:
          Values: [100]
    Events:
      - Completion
```
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
