### PR TITLE
Test hash function is stable

### DIFF
--- a/tests/Unit/IO/Observers/Test_ObservationId.cpp
+++ b/tests/Unit/IO/Observers/Test_ObservationId.cpp
@@ -18,6 +18,9 @@ SPECTRE_TEST_CASE("Unit.IO.Observers.ObservationId", "[Unit][Observers]") {
   ObservationId id3(8., "subtype3");
   CHECK(id0 == id0);
   CHECK(id0.hash() == id0.hash());
+  // Make sure the hash function doesn't change under our feet
+  // (see https://github.com/sxs-collaboration/spectre/issues/4944)
+  CHECK(id0.hash() == 1721708090011444335);
   CHECK(id0.observation_key() == id0.observation_key());
   CHECK(id0 == ObservationId(4., "ObservationType1"));
   CHECK(id0 != id1);


### PR DESCRIPTION
## Proposed changes

This test demonstrates https://github.com/sxs-collaboration/spectre/issues/4944. It fails on my M2 machine with AppleClang 14.0.2.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
