### PR TITLE
Repack H5 file in `delete-subfiles` CLI

### DIFF
--- a/cmake/SetupHdf5.cmake
+++ b/cmake/SetupHdf5.cmake
@@ -71,3 +71,7 @@ file(APPEND
   "${CMAKE_BINARY_DIR}/BuildInfo.txt"
   "HDF5 version: ${HDF5_VERSION}\n"
   )
+
+# Find HDF5 tools
+get_filename_component(HDF5_TOOLS_DIR HDF5_DIFF_EXECUTABLE DIRECTORY)
+find_program(HDF5_REPACK_EXECUTABLE h5repack HINTS ${HDF5_TOOLS_DIR})

--- a/src/IO/H5/Python/DeleteSubfiles.py
+++ b/src/IO/H5/Python/DeleteSubfiles.py
@@ -4,8 +4,14 @@
 import click
 import h5py
 import logging
+import os
+import shutil
+import subprocess
+import tempfile
 
 logger = logging.getLogger(__name__)
+
+HDF5_REPACK_EXECUTABLE = "@HDF5_REPACK_EXECUTABLE@"
 
 
 @click.command()
@@ -21,7 +27,12 @@ logger = logging.getLogger(__name__)
               required=True,
               multiple=True,
               help="Subfile to delete")
-def delete_subfiles_command(h5files, subfiles):
+@click.option("--repack/--no-repack",
+              default=False,
+              help=("Repack the H5 files after deleting subfiles "
+                    "to reduce file size. Otherwise, the subfiles are deleted "
+                    "but the file size remains unchanged."))
+def delete_subfiles_command(h5files, subfiles, repack):
     """Delete subfiles from the 'H5FILES'"""
     for h5file in h5files:
         with h5py.File(h5file, "a") as open_h5_file:
@@ -32,3 +43,11 @@ def delete_subfiles_command(h5files, subfiles):
                         f"Deleted subfile '{subfile}' from file: {h5file}")
                 else:
                     logger.warning(f"No subfile '{subfile}' in file: {h5file}")
+        if repack:
+            # h5repack must write to a new file, so we create a temporary one
+            with tempfile.TemporaryDirectory() as tempdir:
+                tmp_h5file = os.path.join(tempdir, "temp.h5")
+                subprocess.run([HDF5_REPACK_EXECUTABLE, h5file, tmp_h5file],
+                               capture_output=True,
+                               text=True)
+                shutil.move(tmp_h5file, h5file)

--- a/tests/Unit/IO/H5/Python/Test_DeleteSubfiles.py
+++ b/tests/Unit/IO/H5/Python/Test_DeleteSubfiles.py
@@ -26,11 +26,22 @@ class TestDeleteSubfiles(unittest.TestCase):
     def tearDown(self):
         shutil.rmtree(self.test_dir)
 
-    def test_deletes_subfile(self):
+    def test_delete_subfiles(self):
         runner = CliRunner()
         result = runner.invoke(delete_subfiles_command,
                                [self.h5_filename, "-d", "TimeSteps2.dat"],
                                catch_exceptions=False)
+        self.assertEqual(result.exit_code, 0)
+        self.assertEqual(result.output, "")
+        with h5py.File(self.h5_filename, "r") as open_h5_file:
+            self.assertNotIn("TimeSteps2.dat", open_h5_file.keys())
+
+    def test_delete_subfiles_and_repack(self):
+        runner = CliRunner()
+        result = runner.invoke(
+            delete_subfiles_command,
+            [self.h5_filename, "-d", "TimeSteps2.dat", "--repack"],
+            catch_exceptions=False)
         self.assertEqual(result.exit_code, 0)
         self.assertEqual(result.output, "")
         with h5py.File(self.h5_filename, "r") as open_h5_file:


### PR DESCRIPTION
## Proposed changes

Repacking is needed to actually reduce the file size when deleting subfiles.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
