### PR TITLE
Add projection matrices for cell faces

### DIFF
--- a/src/Evolution/DgSubcell/CellCenteredFlux.hpp
+++ b/src/Evolution/DgSubcell/CellCenteredFlux.hpp
@@ -10,6 +10,8 @@
 #include "DataStructures/DataBox/PrefixHelpers.hpp"
 #include "DataStructures/DataBox/Prefixes.hpp"
 #include "DataStructures/Variables.hpp"
+#include "Domain/TagsTimeDependent.hpp"
+#include "Evolution/DgSubcell/Projection.hpp"
 #include "Evolution/DgSubcell/SubcellOptions.hpp"
 #include "Evolution/DgSubcell/Tags/CellCenteredFlux.hpp"
 #include "Evolution/DgSubcell/Tags/DidRollback.hpp"
@@ -36,17 +38,21 @@ struct CellCenteredFlux {
 
   using return_tags =
       tmpl::list<subcell::Tags::CellCenteredFlux<flux_variables, Dim>>;
-  using argument_tags =
-      tmpl::push_front<typename FluxMutator::argument_tags,
-                       subcell::Tags::SubcellOptions<Dim>,
-                       subcell::Tags::Mesh<Dim>, subcell::Tags::DidRollback>;
+  using argument_tags = tmpl::push_front<
+      typename FluxMutator::argument_tags, subcell::Tags::SubcellOptions<Dim>,
+      subcell::Tags::Mesh<Dim>, domain::Tags::Mesh<Dim>,
+      domain::Tags::MeshVelocity<Dim, Frame::Inertial>,
+      ::Tags::Variables<flux_variables>, subcell::Tags::DidRollback>;
 
   template <typename... FluxTags, typename... Args>
   static void apply(
       const gsl::not_null<std::optional<Variables<tmpl::list<FluxTags...>>>*>
           cell_centered_fluxes,
       const subcell::SubcellOptions& subcell_options,
-      const Mesh<Dim>& subcell_mesh, const bool did_rollback, Args&&... args) {
+      const Mesh<Dim>& subcell_mesh, const Mesh<Dim>& dg_mesh,
+      const std::optional<tnsr::I<DataVector, Dim>>& dg_mesh_velocity,
+      const ::Variables<flux_variables>& cell_centered_flux_vars,
+      const bool did_rollback, Args&&... args) {
     if (did_rollback or not ComputeOnlyOnRollback) {
       if (subcell_options.finite_difference_derivative_order() !=
           ::fd::DerivativeOrder::Two) {
@@ -59,6 +65,37 @@ struct CellCenteredFlux {
         FluxMutator::apply(
             make_not_null(&get<FluxTags>((*cell_centered_fluxes).value()))...,
             std::forward<Args>(args)...);
+        if (dg_mesh_velocity.has_value()) {
+          for (size_t i = 0; i < Dim; i++) {
+            //
+            // Project mesh velocity on face mesh. We only need the component
+            // orthogonal to the face.
+            const DataVector& cell_centered_mesh_velocity =
+                evolution::dg::subcell::fd::project(
+                    dg_mesh_velocity.value().get(i), dg_mesh,
+                    subcell_mesh.extents());
+
+            tmpl::for_each<flux_variables>(
+                [&cell_centered_flux_vars, &cell_centered_mesh_velocity,
+                 &cell_centered_fluxes, &i](auto tag_v) {
+                  using tag = tmpl::type_from<decltype(tag_v)>;
+                  using flux_tag =
+                      ::Tags::Flux<tag, tmpl::size_t<Dim>, Frame::Inertial>;
+                  using FluxTensor = typename flux_tag::type;
+                  const auto& var = get<tag>(cell_centered_flux_vars);
+                  auto& flux = get<flux_tag>(cell_centered_fluxes->value());
+                  for (size_t storage_index = 0; storage_index < var.size();
+                       ++storage_index) {
+                    const auto tensor_index =
+                        var.get_tensor_index(storage_index);
+                    const auto flux_storage_index =
+                        FluxTensor::get_storage_index(prepend(tensor_index, i));
+                    flux[flux_storage_index] -=
+                        cell_centered_mesh_velocity * var[storage_index];
+                  }
+                });
+          }
+        }
       }
     }
   }

--- a/src/Evolution/DgSubcell/Matrices.hpp
+++ b/src/Evolution/DgSubcell/Matrices.hpp
@@ -5,6 +5,7 @@
 #include <cstddef>
 
 #include "Domain/Structure/Side.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
 
 /// \cond
 class DataVector;
@@ -21,7 +22,8 @@ namespace evolution::dg::subcell::fd {
  * \brief Computes the projection matrix in 1 dimension going from a DG
  * mesh to a conservative finite difference subcell mesh.
  */
-const Matrix& projection_matrix(const Mesh<1>& dg_mesh, size_t subcell_extents);
+const Matrix& projection_matrix(const Mesh<1>& dg_mesh, size_t subcell_extents,
+                                const Spectral::Quadrature& subcell_quadrature);
 
 /*!
  * \ingroup DgSubcellGroup

--- a/src/Evolution/DgSubcell/NeighborRdmpAndVolumeData.cpp
+++ b/src/Evolution/DgSubcell/NeighborRdmpAndVolumeData.cpp
@@ -111,7 +111,8 @@ void insert_or_update_neighbor_volume_data(
               gsl::at(ghost_projection_mat, i) =
                   std::cref(evolution::dg::subcell::fd::projection_matrix(
                       neighbor_mesh_for_projection.slice_through(i),
-                      subcell_mesh.extents(i)));
+                      subcell_mesh.extents(i),
+                      Spectral::Quadrature::CellCentered));
             }
           }
           apply_matrices(make_not_null(&computed_ghost_data),

--- a/src/Evolution/DgSubcell/Projection.cpp
+++ b/src/Evolution/DgSubcell/Projection.cpp
@@ -26,7 +26,36 @@ void project_impl(gsl::span<double> subcell_u,
   auto projection_mat = make_array<Dim>(std::cref(empty));
   for (size_t d = 0; d < Dim; d++) {
     gsl::at(projection_mat, d) = std::cref(
-        projection_matrix(dg_mesh.slice_through(d), subcell_extents[d]));
+        projection_matrix(dg_mesh.slice_through(d), subcell_extents[d],
+                          Spectral::Quadrature::CellCentered));
+  }
+  DataVector result{subcell_u.data(), subcell_u.size()};
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
+  const DataVector u{const_cast<double*>(dg_u.data()), dg_u.size()};
+  apply_matrices(make_not_null(&result), projection_mat, u, dg_mesh.extents());
+}
+
+// Project to a face of a Cartesian grid. We reconstruct on a FaceCentered basis
+// in the dimension of the desired face, and on a CellCentered basis in other
+// dimensions.
+template <size_t Dim>
+void project_to_face_impl(gsl::span<double> subcell_u,
+                          const gsl::span<const double> dg_u,
+                          const Mesh<Dim>& dg_mesh,
+                          const Index<Dim>& subcell_extents,
+                          const size_t& face_direction) {
+  const Matrix empty{};
+  auto projection_mat = make_array<Dim>(std::cref(empty));
+  for (size_t d = 0; d < Dim; d++) {
+    if (d == face_direction) {
+      gsl::at(projection_mat, d) = std::cref(
+          projection_matrix(dg_mesh.slice_through(d), subcell_extents[d],
+                            Spectral::Quadrature::FaceCentered));
+    } else {
+      gsl::at(projection_mat, d) = std::cref(
+          projection_matrix(dg_mesh.slice_through(d), subcell_extents[d],
+                            Spectral::Quadrature::CellCentered));
+    }
   }
   DataVector result{subcell_u.data(), subcell_u.size()};
   // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
@@ -61,17 +90,57 @@ DataVector project(const DataVector& dg_u, const Mesh<Dim>& dg_mesh,
   return subcell_u;
 }
 
+template <size_t Dim>
+void project_to_face(const gsl::not_null<DataVector*> subcell_u,
+                     const DataVector& dg_u, const Mesh<Dim>& dg_mesh,
+                     const Index<Dim>& subcell_extents,
+                     const size_t& face_direction) {
+  ASSERT(dg_u.size() % dg_mesh.number_of_grid_points() == 0,
+         "The vector dg_u must have size that is a multiple of the number of "
+         "grid points "
+             << dg_mesh.number_of_grid_points() << " but got " << dg_u.size());
+  subcell_u->destructive_resize(subcell_extents.product() * dg_u.size() /
+                                dg_mesh.number_of_grid_points());
+  detail::project_to_face_impl(
+      gsl::span<double>{subcell_u->data(), subcell_u->size()},
+      gsl::span<const double>{dg_u.data(), dg_u.size()}, dg_mesh,
+      subcell_extents, face_direction);
+}
+
+template <size_t Dim>
+DataVector project_to_face(const DataVector& dg_u, const Mesh<Dim>& dg_mesh,
+                           const Index<Dim>& subcell_extents,
+                           const size_t& face_direction) {
+  ASSERT(dg_u.size() % dg_mesh.number_of_grid_points() == 0,
+         "The vector dg_u must have size that is a multiple of the number of "
+         "grid points "
+             << dg_mesh.number_of_grid_points() << " but got " << dg_u.size());
+  DataVector subcell_u{};
+  project_to_face(&subcell_u, dg_u, dg_mesh, subcell_extents, face_direction);
+  return subcell_u;
+}
+
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 
-#define INSTANTIATION(r, data)                                            \
-  template DataVector project(const DataVector&, const Mesh<DIM(data)>&,  \
-                              const Index<DIM(data)>&);                   \
-  template void project(gsl::not_null<DataVector*>, const DataVector&,    \
-                        const Mesh<DIM(data)>&, const Index<DIM(data)>&); \
-  template void detail::project_impl(gsl::span<double> subcell_u,         \
-                                     const gsl::span<const double> dg_u,  \
-                                     const Mesh<DIM(data)>& dg_mesh,      \
-                                     const Index<DIM(data)>& subcell_extents);
+#define INSTANTIATION(r, data)                                                 \
+  template DataVector project(const DataVector&, const Mesh<DIM(data)>&,       \
+                              const Index<DIM(data)>&);                        \
+  template void project(gsl::not_null<DataVector*>, const DataVector&,         \
+                        const Mesh<DIM(data)>&, const Index<DIM(data)>&);      \
+  template void detail::project_impl(gsl::span<double> subcell_u,              \
+                                     const gsl::span<const double> dg_u,       \
+                                     const Mesh<DIM(data)>& dg_mesh,           \
+                                     const Index<DIM(data)>& subcell_extents); \
+  template DataVector project_to_face(const DataVector&,                       \
+                                      const Mesh<DIM(data)>&,                  \
+                                      const Index<DIM(data)>&, const size_t&); \
+  template void project_to_face(gsl::not_null<DataVector*>, const DataVector&, \
+                                const Mesh<DIM(data)>&,                        \
+                                const Index<DIM(data)>&, const size_t&);       \
+  template void detail::project_to_face_impl(                                  \
+      gsl::span<double> subcell_u, const gsl::span<const double> dg_u,         \
+      const Mesh<DIM(data)>& dg_mesh, const Index<DIM(data)>& subcell_extents, \
+      const size_t& face_direction);
 
 GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
 

--- a/src/Evolution/DgSubcell/Projection.hpp
+++ b/src/Evolution/DgSubcell/Projection.hpp
@@ -24,6 +24,12 @@ namespace detail {
 template <size_t Dim>
 void project_impl(gsl::span<double> subcell_u, gsl::span<const double> dg_u,
                   const Mesh<Dim>& dg_mesh, const Index<Dim>& subcell_extents);
+template <size_t Dim>
+void project_to_face_impl(gsl::span<double> subcell_u,
+                          gsl::span<const double> dg_u,
+                          const Mesh<Dim>& dg_mesh,
+                          const Index<Dim>& subcell_extents,
+                          const size_t& face_direction);
 }  // namespace detail
 
 /// @{
@@ -75,6 +81,55 @@ Variables<TagList> project(const Variables<TagList>& dg_u,
                            const Index<Dim>& subcell_extents) {
   Variables<TagList> subcell_u(subcell_extents.product());
   project(make_not_null(&subcell_u), dg_u, dg_mesh, subcell_extents);
+  return subcell_u;
+}
+
+template <size_t Dim>
+DataVector project_to_face(const DataVector& dg_u, const Mesh<Dim>& dg_mesh,
+                           const Index<Dim>& subcell_extents,
+                           const size_t& face_direction);
+
+template <size_t Dim>
+void project_to_face(gsl::not_null<DataVector*> subcell_u,
+                     const DataVector& dg_u, const Mesh<Dim>& dg_mesh,
+                     const Index<Dim>& subcell_extents,
+                     const size_t& face_direction);
+
+template <typename SubcellTagList, typename DgTagList, size_t Dim>
+void project_to_face(const gsl::not_null<Variables<SubcellTagList>*> subcell_u,
+                     const Variables<DgTagList>& dg_u, const Mesh<Dim>& dg_mesh,
+                     const Index<Dim>& subcell_extents,
+                     const size_t& face_direction) {
+  static_assert(
+      std::is_same_v<
+          tmpl::transform<SubcellTagList,
+                          tmpl::bind<db::remove_all_prefixes, tmpl::_1>>,
+          tmpl::transform<DgTagList,
+                          tmpl::bind<db::remove_all_prefixes, tmpl::_1>>>,
+      "DG and subcell tag lists must be the same once prefix tags "
+      "are removed.");
+  ASSERT(dg_u.number_of_grid_points() == dg_mesh.number_of_grid_points(),
+         "dg_u has incorrect size " << dg_u.number_of_grid_points()
+                                    << " since the mesh is size "
+                                    << dg_mesh.number_of_grid_points());
+  if (UNLIKELY(subcell_u->number_of_grid_points() !=
+               subcell_extents.product())) {
+    subcell_u->initialize(subcell_extents.product());
+  }
+  detail::project_to_face_impl(
+      gsl::span<double>{subcell_u->data(), subcell_u->size()},
+      gsl::span<const double>{dg_u.data(), dg_u.size()}, dg_mesh,
+      subcell_extents, face_direction);
+}
+
+template <typename TagList, size_t Dim>
+Variables<TagList> project_to_face(const Variables<TagList>& dg_u,
+                                   const Mesh<Dim>& dg_mesh,
+                                   const Index<Dim>& subcell_extents,
+                                   const size_t& face_direction) {
+  Variables<TagList> subcell_u(subcell_extents.product());
+  project_to_face(make_not_null(&subcell_u), dg_u, dg_mesh, subcell_extents,
+                  face_direction);
   return subcell_u;
 }
 /// @}

--- a/tests/Unit/Evolution/DgSubcell/Test_NeighborRdmpAndVolumeData.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Test_NeighborRdmpAndVolumeData.cpp
@@ -111,7 +111,8 @@ void test() {
     // Note: assume isotropic meshes
     auto projection_matrices =
         make_array<Dim>(std::cref(evolution::dg::subcell::fd::projection_matrix(
-            dg_mesh.slice_through(0), subcell_mesh.extents(0))));
+            dg_mesh.slice_through(0), subcell_mesh.extents(0),
+            Spectral::Quadrature::CellCentered)));
     projection_matrices[0] =
         std::cref(evolution::dg::subcell::fd::projection_matrix(
             dg_mesh.slice_through(0), subcell_mesh.extents(0),
@@ -225,7 +226,8 @@ void test() {
 
     auto projection_matrices =
         make_array<Dim>(std::cref(evolution::dg::subcell::fd::projection_matrix(
-            dg_mesh.slice_through(0), subcell_mesh.extents(0))));
+            dg_mesh.slice_through(0), subcell_mesh.extents(0),
+            Spectral::Quadrature::CellCentered)));
     projection_matrices[1] =
         std::cref(evolution::dg::subcell::fd::projection_matrix(
             dg_mesh.slice_through(0), subcell_mesh.extents(0),
@@ -270,7 +272,8 @@ void test() {
 
     auto projection_matrices =
         make_array<Dim>(std::cref(evolution::dg::subcell::fd::projection_matrix(
-            dg_mesh.slice_through(0), subcell_mesh.extents(0))));
+            dg_mesh.slice_through(0), subcell_mesh.extents(0),
+            Spectral::Quadrature::CellCentered)));
     projection_matrices[2] =
         std::cref(evolution::dg::subcell::fd::projection_matrix(
             dg_mesh.slice_through(0), subcell_mesh.extents(0),

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_TimeDerivative.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_TimeDerivative.cpp
@@ -267,6 +267,7 @@ std::array<double, 5> test(const size_t num_dg_pts,
   // initialized.
   Domain<3> dummy_domain{};
   std::optional<tnsr::I<DataVector, 3>> dummy_volume_mesh_velocity{};
+  std::optional<Scalar<DataVector>> dummy_volume_div_mesh_velocity{};
   typename evolution::dg::Tags::NormalCovectorAndMagnitude<3>::type
       dummy_normal_covector_and_magnitude{};
   const double dummy_time{0.0};
@@ -293,7 +294,7 @@ std::array<double, 5> test(const size_t num_dg_pts,
   auto box = db::create<
       db::AddSimpleTags<
           domain::Tags::Element<3>, evolution::dg::subcell::Tags::Mesh<3>,
-          fd::Tags::Reconstructor,
+          domain::Tags::Mesh<3>, fd::Tags::Reconstructor,
           evolution::Tags::BoundaryCorrection<grmhd::ValenciaDivClean::System>,
           hydro::Tags::EquationOfState<EquationsOfState::PolytropicFluid<true>>,
           typename System::spacetime_variables_tag,
@@ -308,6 +309,7 @@ std::array<double, 5> test(const size_t num_dg_pts,
                                                       Frame::Inertial>,
           domain::Tags::Domain<3>,
           domain::Tags::MeshVelocity<3, Frame::Inertial>,
+          domain::Tags::DivMeshVelocity,
           evolution::dg::Tags::NormalCovectorAndMagnitude<3>, ::Tags::Time,
           domain::Tags::FunctionsOfTimeInitialize, DummyAnalyticSolutionTag,
           Parallel::Tags::MetavariablesImpl<DummyEvolutionMetaVars>,
@@ -316,7 +318,7 @@ std::array<double, 5> test(const size_t num_dg_pts,
           evolution::dg::subcell::Tags::ReconstructionOrder<3>>,
       db::AddComputeTags<
           evolution::dg::subcell::Tags::LogicalCoordinatesCompute<3>>>(
-      element, subcell_mesh,
+      element, subcell_mesh, dg_mesh,
       std::unique_ptr<grmhd::ValenciaDivClean::fd::Reconstructor>{
           std::make_unique<std::decay_t<decltype(recons)>>(recons)},
       std::unique_ptr<
@@ -337,8 +339,8 @@ std::array<double, 5> test(const size_t num_dg_pts,
       domain::make_coordinate_map_base<Frame::Grid, Frame::Inertial>(
           domain::CoordinateMaps::Identity<3>{}),
       std::move(dummy_domain), dummy_volume_mesh_velocity,
-      dummy_normal_covector_and_magnitude, dummy_time,
-      clone_unique_ptrs(dummy_functions_of_time),
+      dummy_volume_div_mesh_velocity, dummy_normal_covector_and_magnitude,
+      dummy_time, clone_unique_ptrs(dummy_functions_of_time),
       grmhd::Solutions::SmoothFlow{}, DummyEvolutionMetaVars{},
       cell_centered_fluxes,
       evolution::dg::subcell::SubcellOptions{


### PR DESCRIPTION
## Proposed changes

Add functionality to project from DG grid to the faces of a FD subcell grid.

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
