### PR TITLE
Add shape control to single BH executable

### DIFF
--- a/src/ControlSystem/ControlErrors/Shape.hpp
+++ b/src/ControlSystem/ControlErrors/Shape.hpp
@@ -90,8 +90,8 @@ template <::domain::ObjectLabel Horizon>
 struct Shape : tt::ConformsTo<protocols::ControlError> {
   static constexpr size_t expected_number_of_excisions = 1;
 
-  // Shape doesn't need the center tags
-  using object_centers = domain::object_list<>;
+  // Shape needs an excision sphere
+  using object_centers = domain::object_list<Horizon>;
 
   using options = tmpl::list<>;
   static constexpr Options::String help{

--- a/src/ControlSystem/Tags/FunctionsOfTimeInitialize.cpp
+++ b/src/ControlSystem/Tags/FunctionsOfTimeInitialize.cpp
@@ -14,26 +14,31 @@ namespace control_system::Tags::detail {
 
 void check_expiration_time_consistency(
     const std::unordered_map<std::string, double>& initial_expiration_times,
+    const std::unordered_map<std::string, bool>& is_active_map,
     const std::unordered_map<
         std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
         functions_of_time) {
   for (const auto& [name, expr_time] : initial_expiration_times) {
-    if (functions_of_time.count(name) == 0) {
-      ERROR("The control system '"
+    // Only need to check the expiration times if the control system is active
+    if (is_active_map.at(name)) {
+      if (functions_of_time.count(name) == 0) {
+        ERROR(
+            "The control system '"
             << name
             << "' is not controlling a function of time. Check that the "
                "DomainCreator you have chosen uses all of the control "
                "systems in the executable. The existing functions of time are: "
             << keys_of(functions_of_time));
-    }
+      }
 
-    if (functions_of_time.at(name)->time_bounds()[1] != expr_time) {
-      ERROR("The expiration time for the function of time '"
-            << name << "' has been set improperly. It is supposed to be "
-            << expr_time << " but is currently set to "
-            << functions_of_time.at(name)->time_bounds()[1]
-            << ". It is possible that the DomainCreator you are using isn't "
-               "compatible with the control systems.");
+      if (functions_of_time.at(name)->time_bounds()[1] != expr_time) {
+        ERROR("The expiration time for the function of time '"
+              << name << "' has been set improperly. It is supposed to be "
+              << expr_time << " but is currently set to "
+              << functions_of_time.at(name)->time_bounds()[1]
+              << ". It is possible that the DomainCreator you are using isn't "
+                 "compatible with the control systems.");
+      }
     }
   }
 }

--- a/src/ControlSystem/Tags/SystemTags.hpp
+++ b/src/ControlSystem/Tags/SystemTags.hpp
@@ -196,8 +196,9 @@ struct ControlError : db::SimpleTag {
 
     if constexpr (expected_number_of_excisions == 1) {
       if (excision_spheres.count("ExcisionSphereA") != 1 and
-          excision_spheres.count("ExcisionSphereB") != 1) {
-        print_error("ExcisionSphereA' or 'ExcisionSphereB");
+          excision_spheres.count("ExcisionSphereB") != 1 and
+          excision_spheres.count("ExcisionSphere") != 1) {
+        print_error("ExcisionSphereA' or 'ExcisionSphereB' or 'ExcisionSphere");
       }
     }
     if constexpr (expected_number_of_excisions == 2) {

--- a/src/Evolution/Executables/GeneralizedHarmonic/CMakeLists.txt
+++ b/src/Evolution/Executables/GeneralizedHarmonic/CMakeLists.txt
@@ -52,7 +52,7 @@ add_spectre_parallel_executable(
   EvolveGeneralizedHarmonicSingleBlackHole
   Evolution/Executables/GeneralizedHarmonic
   "EvolutionMetavars<3, false>"
-  "${LIBS_TO_LINK};ApparentHorizons;GeneralRelativitySolutions"
+  "${LIBS_TO_LINK};ApparentHorizons;ControlSystem;GeneralRelativitySolutions"
   )
 
 add_spectre_parallel_executable(

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonicNoBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonicNoBlackHole.hpp
@@ -29,7 +29,8 @@ struct EvolutionMetavars
       EvolutionMetavars<VolumeDim, UseNumericalInitialData>>;
   using typename gh_base::const_global_cache_tags;
   using typename gh_base::dg_registration_list;
-  using typename gh_base::initialization_actions;
+  using initialization_actions =
+      typename gh_base::template initialization_actions<false>;
   using typename gh_base::initialize_initial_data_dependent_quantities_actions;
   using typename gh_base::observed_reduction_data_tags;
   using typename gh_base::step_actions;

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonicSingleBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonicSingleBlackHole.hpp
@@ -13,9 +13,17 @@
 #include "ApparentHorizons/ComputeItems.hpp"
 #include "ApparentHorizons/HorizonAliases.hpp"
 #include "ApparentHorizons/Tags.hpp"
+#include "ControlSystem/Actions/InitializeMeasurements.hpp"
+#include "ControlSystem/Component.hpp"
+#include "ControlSystem/Event.hpp"
+#include "ControlSystem/Measurements/SingleHorizon.hpp"
+#include "ControlSystem/Systems/Shape.hpp"
+#include "ControlSystem/Trigger.hpp"
 #include "Domain/Creators/RegisterDerivedWithCharm.hpp"
 #include "Domain/Creators/TimeDependence/RegisterDerivedWithCharm.hpp"
+#include "Domain/FunctionsOfTime/FunctionsOfTimeAreReady.hpp"
 #include "Domain/FunctionsOfTime/RegisterDerivedWithCharm.hpp"
+#include "Domain/Structure/ObjectLabel.hpp"
 #include "Evolution/Executables/GeneralizedHarmonic/GeneralizedHarmonicBase.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/Actions/NumericInitialData.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/BoundaryCorrections/RegisterDerived.hpp"
@@ -122,13 +130,18 @@ struct EvolutionMetavars
     using interpolating_component = typename metavariables::gh_dg_element_array;
   };
 
-  using interpolation_target_tags = tmpl::list<AhA, ExcisionBoundaryA>;
-  using interpolator_source_vars_excision_boundary = tmpl::list<
-      gr::Tags::SpacetimeMetric<volume_dim, Frame::Inertial>,
-      GeneralizedHarmonic::ConstraintDamping::Tags::ConstraintGamma1>;
-  using interpolator_source_vars = tmpl::remove_duplicates<
-      tmpl::append<interpolator_source_vars_excision_boundary,
-                   ::ah::source_vars<volume_dim>>>;
+  using control_systems = tmpl::list<control_system::Systems::Shape<
+      ::domain::ObjectLabel::None, 2,
+      control_system::measurements::SingleHorizon<
+          ::domain::ObjectLabel::None>>>;
+
+  static constexpr bool use_control_systems =
+      tmpl::size<control_systems>::value > 0;
+
+  using interpolation_target_tags = tmpl::push_back<
+      control_system::metafunctions::interpolation_target_tags<control_systems>,
+      AhA, ExcisionBoundaryA>;
+  using interpolator_source_vars = ::ah::source_vars<volume_dim>;
 
   // The interpolator_source_vars need to be the same in both the Interpolate
   // event and the InterpolateWithoutInterpComponent event.  The Interpolate
@@ -140,12 +153,16 @@ struct EvolutionMetavars
       : tt::ConformsTo<Options::protocols::FactoryCreation> {
     using factory_classes = Options::add_factory_classes<
         typename gh_base::factory_creation::factory_classes,
-        tmpl::pair<Event,
-                   tmpl::list<intrp::Events::Interpolate<
-                                  3, AhA, interpolator_source_vars>,
-                              intrp::Events::InterpolateWithoutInterpComponent<
-                                  3, ExcisionBoundaryA, EvolutionMetavars,
-                                  interpolator_source_vars>>>>;
+        tmpl::pair<
+            Event,
+            tmpl::flatten<tmpl::list<
+                intrp::Events::Interpolate<3, AhA, interpolator_source_vars>,
+                control_system::control_system_events<control_systems>,
+                intrp::Events::InterpolateWithoutInterpComponent<
+                    3, ExcisionBoundaryA, EvolutionMetavars,
+                    interpolator_source_vars>>>>,
+        tmpl::pair<DenseTrigger,
+                   control_system::control_system_triggers<control_systems>>>;
   };
 
   using typename gh_base::const_global_cache_tags;
@@ -162,11 +179,14 @@ struct EvolutionMetavars
 
   using typename gh_base::step_actions;
 
-  using initialization_actions =
-      tmpl::push_back<tmpl::pop_back<typename gh_base::initialization_actions>,
-                      intrp::Actions::ElementInitInterpPoints<
-                          intrp::Tags::InterpPointInfo<EvolutionMetavars>>,
-                      tmpl::back<typename gh_base::initialization_actions>>;
+  using initialization_actions = tmpl::push_back<
+      tmpl::pop_back<typename gh_base::template initialization_actions<
+          use_control_systems>>,
+      control_system::Actions::InitializeMeasurements<control_systems>,
+      intrp::Actions::ElementInitInterpPoints<
+          intrp::Tags::InterpPointInfo<EvolutionMetavars>>,
+      tmpl::back<typename gh_base::template initialization_actions<
+          use_control_systems>>>;
 
   using gh_dg_element_array = DgElementArray<
       EvolutionMetavars,
@@ -201,7 +221,8 @@ struct EvolutionMetavars
                                             Parallel::Actions::TerminatePhase>>,
           Parallel::PhaseActions<
               Parallel::Phase::Evolve,
-              tmpl::list<Actions::RunEventsAndTriggers, Actions::ChangeSlabSize,
+              tmpl::list<::domain::Actions::CheckFunctionsOfTimeAreReady,
+                         Actions::RunEventsAndTriggers, Actions::ChangeSlabSize,
                          step_actions, Actions::AdvanceTime,
                          PhaseControl::Actions::ExecutePhaseChange>>>>>;
 
@@ -219,8 +240,10 @@ struct EvolutionMetavars
                          importers::ElementDataReader<EvolutionMetavars>,
                          tmpl::list<>>,
       gh_dg_element_array, intrp::Interpolator<EvolutionMetavars>,
-      intrp::InterpolationTarget<EvolutionMetavars, AhA>,
-      intrp::InterpolationTarget<EvolutionMetavars, ExcisionBoundaryA>>>;
+      control_system::control_components<EvolutionMetavars, control_systems>,
+      tmpl::transform<interpolation_target_tags,
+                      tmpl::bind<intrp::InterpolationTarget,
+                                 tmpl::pin<EvolutionMetavars>, tmpl::_1>>>>;
 };
 
 static const std::vector<void (*)()> charm_init_node_funcs{

--- a/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
@@ -23,6 +23,8 @@ ResourceInfo:
     ExcisionBoundaryA:
       Proc: Auto
       Exclusive: false
+    ControlSystemSingleAh: Auto
+    Shape: Auto
 
 Evolution:
   InitialTime: 0.0
@@ -46,11 +48,11 @@ InitialData: &InitialData
   KerrSchild:
     Mass: 1.0
     Spin: [0.0, 0.0, 0.0]
-    Center: [0.0, 0.0, 0.0]
+    Center: &Center [0.0, 0.0, 0.0]
 
 DomainCreator:
   Sphere:
-    InnerRadius: 1.9
+    InnerRadius: &InnerRadius 1.9
     OuterRadius: 2.3
     Interior:
       ExciseWithBoundaryCondition:
@@ -189,11 +191,11 @@ Interpolator:
   DumpVolumeDataOnFailure: false
 
 ApparentHorizons:
-  AhA:
+  AhA: &AhA
     InitialGuess:
-      Lmax: 4
+      Lmax: &LMax 4
       Radius: 2.2
-      Center: [0.0, 0.0, 0.0]
+      Center: *Center
     FastFlow:
       Flow: Fast
       Alpha: 1.0
@@ -204,10 +206,31 @@ ApparentHorizons:
       DivergenceIter: 5
       MaxIts: 100
     Verbosity: Verbose
+  ControlSystemSingleAh: *AhA
 
 InterpolationTargets:
   ExcisionBoundaryA:
-    Lmax: 10
-    Center: [0., 0., 0.]
-    Radius: 2.0
+    Lmax: *LMax
+    Center: *Center
+    Radius: *InnerRadius
     AngularOrdering: "Strahlkorper"
+
+ControlSystems:
+  WriteDataToDisk: false
+  MeasurementsPerUpdate: 4
+  Shape:
+    IsActive: false
+    Averager:
+      AverageTimescaleFraction: 0.25
+      Average0thDeriv: false
+    Controller:
+      UpdateFraction: 0.03
+    TimescaleTuner:
+      InitialTimescales: 0.2
+      MinTimescale: 1.0e-2
+      MaxTimescale: 10.0
+      IncreaseThreshold: 2.5e-4
+      DecreaseThreshold: 1.0e-3
+      IncreaseFactor: 1.01
+      DecreaseFactor: 0.98
+    ControlError:

--- a/tests/Unit/ControlSystem/Test_Tags.cpp
+++ b/tests/Unit/ControlSystem/Test_Tags.cpp
@@ -223,9 +223,11 @@ void test_individual_tags() {
       std::make_unique<FakeCreator>(std::unordered_map<std::string, size_t>{},
                                     1);
 
-  CHECK_THROWS_WITH(control_error_tag::create_from_options<MetavarsEmpty>(
-                        holder, creator_error_0),
-                    Catch::Contains("ExcisionSphereA' or 'ExcisionSphereB"));
+  CHECK_THROWS_WITH(
+      control_error_tag::create_from_options<MetavarsEmpty>(holder,
+                                                            creator_error_0),
+      Catch::Contains(
+          "ExcisionSphereA' or 'ExcisionSphereB' or 'ExcisionSphere"));
   CHECK_THROWS_WITH(control_error_tag2::create_from_options<MetavarsEmpty>(
                         holder2, creator_error_1),
                     Catch::Contains("'ExcisionSphereB'"));


### PR DESCRIPTION
## Proposed changes

Adds the shape control system to the single BH executable. Defaults the control system to be inactive because I'm not 100% confident it's working properly yet.

I had to make some other small changes to things to account for not having a function of time corresponding to a control system when the control system is inactive.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
There must be a new `ControlSystem:` block in your input file for a SingleBH run like so:

```yaml
ControlSystems:
  WriteDataToDisk: false
  MeasurementsPerUpdate: 4
  Shape:
    IsActive: false
    Averager:
      AverageTimescaleFraction: 0.25
      Average0thDeriv: false
    Controller:
      UpdateFraction: 0.03
    TimescaleTuner:
      InitialTimescales: 0.2
      MinTimescale: 1.0e-2
      MaxTimescale: 10.0
      IncreaseThreshold: 2.5e-4
      DecreaseThreshold: 1.0e-3
      IncreaseFactor: 1.01
      DecreaseFactor: 0.98
    ControlError:
```
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
