### PR TITLE
Add remaining AMR actions

### DIFF
--- a/src/Domain/Amr/CMakeLists.txt
+++ b/src/Domain/Amr/CMakeLists.txt
@@ -11,6 +11,7 @@ spectre_target_sources(
   Flag.cpp
   Helpers.cpp
   NeighborsOfChild.cpp
+  NeighborsOfParent.cpp
   NewNeighborIds.cpp
   UpdateAmrDecision.cpp
   )
@@ -23,6 +24,7 @@ spectre_target_headers(
   Flag.hpp
   Helpers.hpp
   NeighborsOfChild.hpp
+  NeighborsOfParent.hpp
   NewNeighborIds.hpp
   UpdateAmrDecision.hpp
   )

--- a/src/Domain/Amr/Helpers.cpp
+++ b/src/Domain/Amr/Helpers.cpp
@@ -70,8 +70,11 @@ boost::rational<size_t> fraction_of_block_volume(
 template <size_t VolumeDim>
 bool has_potential_sibling(const ElementId<VolumeDim>& element_id,
                            const Direction<VolumeDim>& direction) {
-  return direction.side() ==
-         element_id.segment_id(direction.dimension()).side_of_sibling();
+  const SegmentId segment_id = element_id.segment_id(direction.dimension());
+  if (segment_id.refinement_level() == 0) {
+    return false;
+  }
+  return direction.side() == segment_id.side_of_sibling();
 }
 
 template <size_t VolumeDim>

--- a/src/Domain/Amr/NeighborsOfParent.cpp
+++ b/src/Domain/Amr/NeighborsOfParent.cpp
@@ -1,0 +1,84 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Domain/Amr/NeighborsOfParent.hpp"
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <iterator>
+#include <tuple>
+#include <unordered_map>
+#include <vector>
+
+#include "Domain/Amr/Flag.hpp"
+#include "Domain/Amr/Helpers.hpp"
+#include "Domain/Amr/NewNeighborIds.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/DirectionMap.hpp"
+#include "Domain/Structure/Element.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Domain/Structure/Neighbors.hpp"
+#include "Domain/Structure/OrientationMap.hpp"
+#include "Utilities/Algorithm.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+
+namespace amr {
+template <size_t VolumeDim>
+DirectionMap<VolumeDim, Neighbors<VolumeDim>> neighbors_of_parent(
+    const ElementId<VolumeDim>& parent_id,
+    const std::vector<
+        std::tuple<const Element<VolumeDim>&,
+                   const std::unordered_map<ElementId<VolumeDim>,
+                                            std::array<Flag, VolumeDim>>&>>&
+        children_elements_and_neighbor_flags) {
+  DirectionMap<VolumeDim, Neighbors<VolumeDim>> result;
+
+  std::vector<ElementId<VolumeDim>> children_ids;
+  children_ids.reserve(children_elements_and_neighbor_flags.size());
+  alg::transform(
+      children_elements_and_neighbor_flags, std::back_inserter(children_ids),
+      [](const auto& child_items) { return std::get<0>(child_items).id(); });
+
+  const auto is_child = [&children_ids](const ElementId<VolumeDim>& id) {
+    return alg::find(children_ids, id) != children_ids.end();
+  };
+
+  for (const auto& [child, child_neighbor_flags] :
+       children_elements_and_neighbor_flags) {
+    for (const auto& [direction, child_neighbors] : child.neighbors()) {
+      if (has_potential_sibling(child.id(), direction) and
+          is_child(*(child_neighbors.ids().begin()))) {
+        continue;  // neighbor in this direction was joined sibling
+      }
+      if (0 == result.count(direction)) {
+        result.emplace(direction, Neighbors<VolumeDim>{
+                                      amr::new_neighbor_ids(
+                                          parent_id, direction, child_neighbors,
+                                          child_neighbor_flags),
+                                      child_neighbors.orientation()});
+      } else {
+        result.at(direction).add_ids(amr::new_neighbor_ids(
+            parent_id, direction, child_neighbors, child_neighbor_flags));
+      }
+    }
+  }
+  return result;
+}
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data)                                                   \
+  template DirectionMap<DIM(data), Neighbors<DIM(data)>> neighbors_of_parent(  \
+      const ElementId<DIM(data)>& parent_id,                                   \
+      const std::vector<                                                       \
+          std::tuple<const Element<DIM(data)>&,                                \
+                     const std::unordered_map<ElementId<DIM(data)>,            \
+                                              std::array<Flag, DIM(data)>>&>>& \
+          children_elements_and_neighbor_flags);
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
+
+#undef DIM
+#undef INSTANTIATE
+}  // namespace amr

--- a/src/Domain/Amr/NeighborsOfParent.hpp
+++ b/src/Domain/Amr/NeighborsOfParent.hpp
@@ -1,0 +1,37 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <tuple>
+#include <unordered_map>
+#include <vector>
+
+#include "Domain/Amr/Flag.hpp"
+
+/// \cond
+template <size_t VolumeDim, typename T>
+class DirectionMap;
+template <size_t VolumeDim>
+class Element;
+template <size_t VolumeDim>
+class ElementId;
+template <size_t VolumeDim>
+class Neighbors;
+/// \endcond
+
+namespace amr {
+/// \ingroup AmrGroup
+/// \brief returns the neighbors of the Element with ElementId `parent_id`,
+/// that is created from its `children_elements_and_neighbor_flags`
+template <size_t VolumeDim>
+DirectionMap<VolumeDim, Neighbors<VolumeDim>> neighbors_of_parent(
+    const ElementId<VolumeDim>& parent_id,
+    const std::vector<
+        std::tuple<const Element<VolumeDim>&,
+                   const std::unordered_map<ElementId<VolumeDim>,
+                                            std::array<Flag, VolumeDim>>&>>&
+        children_elements_and_neighbor_flags);
+}  // namespace amr

--- a/src/ParallelAlgorithms/Amr/Actions/AdjustDomain.hpp
+++ b/src/ParallelAlgorithms/Amr/Actions/AdjustDomain.hpp
@@ -1,0 +1,144 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <unordered_set>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "Domain/Amr/Flag.hpp"
+#include "Domain/Amr/Helpers.hpp"
+#include "Domain/Amr/NewNeighborIds.hpp"
+#include "Domain/Amr/Tags/Flags.hpp"
+#include "Domain/Amr/Tags/NeighborFlags.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/DirectionMap.hpp"
+#include "Domain/Structure/Element.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Domain/Structure/Neighbors.hpp"
+#include "Domain/Tags.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "Parallel/Invoke.hpp"
+#include "Parallel/Phase.hpp"
+#include "ParallelAlgorithms/Amr/Actions/CreateChild.hpp"
+#include "ParallelAlgorithms/Amr/Actions/CreateParent.hpp"
+#include "ParallelAlgorithms/Amr/Projectors/Mesh.hpp"
+#include "Utilities/Algorithm.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Literals.hpp"
+
+namespace amr {
+/// \cond
+template <class Metavariables>
+struct Component;
+/// \endcond
+}  // namespace amr
+
+namespace amr::Actions {
+/// \brief Adjusts the domain given the refinement criteria
+///
+/// \details
+/// - Checks if an Element wants to split in any dimension; if yes, determines
+///   the ElementId%s of the new children Element%s and calls
+///   amr::Actions::CreateChild on the amr::Component, then exits the action.
+/// - Checks if an Element wants to join in any dimension; if yes, either calls
+///   amr::Actions::CreateParent on the amr::Component if this is the child
+///   Element that should create the parent Element or does nothing, and then
+///   exits the action.
+/// - Checks if an Element wants to increase or decrease its resolution, if yes,
+///   mutates the Mesh
+/// - Updates the Neighbors of the Element
+/// - Resets amr::Tags::Flag%s to amr::Flag::Undefined
+/// - Resets amr::Tags::NeighborFlags to an empty map
+///
+/// \warning At the moment, this action only updates the Mesh for a p-refined
+/// Element.  It does not update any data related to evolution or elliptic
+/// solves.
+struct AdjustDomain {
+  template <typename ParallelComponent, typename DbTagList,
+            typename Metavariables>
+  static void apply(db::DataBox<DbTagList>& box,
+                    Parallel::GlobalCache<Metavariables>& cache,
+                    const ElementId<Metavariables::volume_dim>& element_id) {
+    constexpr size_t volume_dim = Metavariables::volume_dim;
+    const auto& my_amr_flags = db::get<amr::Tags::Flags<volume_dim>>(box);
+    auto& element_array =
+        Parallel::get_parallel_component<ParallelComponent>(cache);
+
+    // Check for h-refinement
+    if (alg::any_of(my_amr_flags,
+                    [](amr::Flag flag) { return flag == amr::Flag::Split; })) {
+      using ::operator<<;
+      ASSERT(alg::count(my_amr_flags, amr::Flag::Join) == 0,
+             "Element " << element_id
+                        << " cannot both split and join, but had AMR flags "
+                        << my_amr_flags << "\n");
+      auto children_ids = amr::ids_of_children(element_id, my_amr_flags);
+      auto& amr_component =
+          Parallel::get_parallel_component<amr::Component<Metavariables>>(
+              cache);
+      Parallel::simple_action<CreateChild>(amr_component, element_array,
+                                           element_id, children_ids, 0_st);
+
+    } else if (alg::any_of(my_amr_flags, [](amr::Flag flag) {
+                 return flag == amr::Flag::Join;
+               })) {
+      // Only one element should create the new parent
+      if (amr::is_child_that_creates_parent(element_id, my_amr_flags)) {
+        auto parent_id = amr::id_of_parent(element_id, my_amr_flags);
+        const auto& element = db::get<::domain::Tags::Element<volume_dim>>(box);
+        auto ids_to_join = amr::ids_of_joining_neighbors(element, my_amr_flags);
+        auto& amr_component =
+            Parallel::get_parallel_component<amr::Component<Metavariables>>(
+                cache);
+        Parallel::simple_action<CreateParent>(amr_component, element_array,
+                                              std::move(parent_id), element_id,
+                                              std::move(ids_to_join));
+      }
+
+    } else {
+      // Check for p-refinement
+      if (alg::any_of(my_amr_flags, [](amr::Flag flag) {
+            return (flag == amr::Flag::IncreaseResolution or
+                    flag == amr::Flag::DecreaseResolution);
+          })) {
+        db::mutate<::domain::Tags::Mesh<volume_dim>>(
+            make_not_null(&box),
+            [&my_amr_flags](const gsl::not_null<Mesh<volume_dim>*> mesh) {
+              *mesh = amr::projectors::mesh(*mesh, my_amr_flags);
+            });
+      }
+
+      // Need to reset AMR flags and determine new neighbors
+      db::mutate<::domain::Tags::Element<volume_dim>,
+                 amr::Tags::Flags<volume_dim>,
+                 amr::Tags::NeighborFlags<volume_dim>>(
+          make_not_null(&box),
+          [&element_id](
+              const gsl::not_null<Element<volume_dim>*> element,
+              const gsl::not_null<std::array<amr::Flag, volume_dim>*> amr_flags,
+              const gsl::not_null<std::unordered_map<
+                  ElementId<volume_dim>, std::array<amr::Flag, volume_dim>>*>
+                  amr_flags_of_neighbors) {
+            auto new_neighbors = element->neighbors();
+            for (auto& [direction, neighbors] : new_neighbors) {
+              neighbors.set_ids_to(amr::new_neighbor_ids(
+                  element_id, direction, neighbors, *amr_flags_of_neighbors));
+            }
+            *element = Element<volume_dim>(element_id, new_neighbors);
+            amr_flags_of_neighbors->clear();
+            for (size_t d = 0; d < volume_dim; ++d) {
+              (*amr_flags)[d] = amr::Flag::Undefined;
+            }
+          });
+    }
+
+    // In the near future, add the capability of updating all data needed for
+    // an evolution or elliptic system
+  }
+};
+}  // namespace amr::Actions

--- a/src/ParallelAlgorithms/Amr/Actions/CMakeLists.txt
+++ b/src/ParallelAlgorithms/Amr/Actions/CMakeLists.txt
@@ -6,8 +6,10 @@ spectre_target_headers(
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   Actions.hpp
+  CollectDataFromChildren.hpp
   Component.hpp
   CreateChild.hpp
+  CreateParent.hpp
   EvaluateRefinementCriteria.hpp
   Initialization.hpp
   Initialize.hpp

--- a/src/ParallelAlgorithms/Amr/Actions/CMakeLists.txt
+++ b/src/ParallelAlgorithms/Amr/Actions/CMakeLists.txt
@@ -6,6 +6,7 @@ spectre_target_headers(
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   Actions.hpp
+  AdjustDomain.hpp
   CollectDataFromChildren.hpp
   Component.hpp
   CreateChild.hpp

--- a/src/ParallelAlgorithms/Amr/Actions/CMakeLists.txt
+++ b/src/ParallelAlgorithms/Amr/Actions/CMakeLists.txt
@@ -12,6 +12,7 @@ spectre_target_headers(
   Initialization.hpp
   Initialize.hpp
   InitializeChild.hpp
+  InitializeParent.hpp
   RunAmrDiagnostics.hpp
   SendAmrDiagnostics.hpp
   SendDataToChildren.hpp

--- a/src/ParallelAlgorithms/Amr/Actions/CollectDataFromChildren.hpp
+++ b/src/ParallelAlgorithms/Amr/Actions/CollectDataFromChildren.hpp
@@ -1,0 +1,121 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <deque>
+#include <unordered_map>
+#include <utility>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "Domain/Amr/Flag.hpp"
+#include "Domain/Amr/Helpers.hpp"
+#include "Domain/Amr/Tags/Flags.hpp"
+#include "Domain/Structure/Element.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Domain/Tags.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "Parallel/Invoke.hpp"
+#include "ParallelAlgorithms/Amr/Actions/InitializeParent.hpp"
+#include "Utilities/Algorithm.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace amr::Actions {
+/// \brief Collects data from child elements to send to their parent element
+/// during adaptive mesh refinement
+struct CollectDataFromChildren {
+  /// \brief  This function should be called after the parent element has been
+  /// created by amr::Actions::CreateParent.
+  ///
+  /// \details This function sends a copy of all items corresponding to the
+  /// mutable_item_creation_tags of `box` of `child_id` to the first sibling in
+  /// `sibling_ids_to_collect` by invoking this action.  Finally, the child
+  /// element destroys itself.
+  template <typename ParallelComponent, typename DbTagList,
+            typename Metavariables>
+  static void apply(
+      db::DataBox<DbTagList>& box, Parallel::GlobalCache<Metavariables>& cache,
+      const ElementId<Metavariables::volume_dim>& child_id,
+      const ElementId<Metavariables::volume_dim>& parent_id,
+      std::deque<ElementId<Metavariables::volume_dim>> sibling_ids_to_collect) {
+    std::unordered_map<ElementId<Metavariables::volume_dim>,
+                       tuples::tagged_tuple_from_typelist<typename db::DataBox<
+                           DbTagList>::mutable_item_creation_tags>>
+        children_data{};
+    children_data.emplace(
+        child_id,
+        db::copy_items<
+            typename db::DataBox<DbTagList>::mutable_item_creation_tags>(box));
+    const auto next_child_id = sibling_ids_to_collect.front();
+    sibling_ids_to_collect.pop_front();
+    auto& array_proxy =
+        Parallel::get_parallel_component<ParallelComponent>(cache);
+    Parallel::simple_action<CollectDataFromChildren>(
+        array_proxy[next_child_id], parent_id, sibling_ids_to_collect,
+        std::move(children_data));
+    array_proxy[child_id].ckDestroy();
+  }
+
+  /// \brief  This function should be called after a child element has added its
+  /// data to `children_data` by a previous invocation of this action.
+  ///
+  /// \details This function adds a copy of all items corresponding to the
+  /// mutable_item_creation_tags of `box` of `child_id` to `children_data`.
+  /// In addition, it checks if there are additional siblings that need to be
+  /// added to `sibiling_ids_to_collect`.  (This is necessary as not all
+  /// siblings share a face.) If `sibling_ids_to_collect` is not empty, this
+  /// action is invoked again on the first sibling in `sibling_ids_to_collect`.
+  /// If it is empty, the data is sent to the parent element by calling
+  /// amr::Actions::InitializeParent. Finally, the child element destroys
+  /// itself.
+  template <typename ParallelComponent, typename DbTagList,
+            typename Metavariables>
+  static void apply(
+      db::DataBox<DbTagList>& box, Parallel::GlobalCache<Metavariables>& cache,
+      const ElementId<Metavariables::volume_dim>& child_id,
+      const ElementId<Metavariables::volume_dim>& parent_id,
+      std::deque<ElementId<Metavariables::volume_dim>> sibling_ids_to_collect,
+      std::unordered_map<
+          ElementId<Metavariables::volume_dim>,
+          tuples::tagged_tuple_from_typelist<
+              typename db::DataBox<DbTagList>::mutable_item_creation_tags>>
+          children_data) {
+    constexpr size_t volume_dim = Metavariables::volume_dim;
+
+    // Determine if there are additional siblings that are joining
+    // This is necessary because AMR flags are only communicated to face
+    // neighbors.
+    const auto& element = db::get<::domain::Tags::Element<volume_dim>>(box);
+    const auto& my_amr_flags = db::get<amr::Tags::Flags<volume_dim>>(box);
+    auto ids_to_join = amr::ids_of_joining_neighbors(element, my_amr_flags);
+    for (const auto& id_to_check : ids_to_join) {
+      if (alg::count(sibling_ids_to_collect, id_to_check) == 0 and
+          children_data.count(id_to_check) == 0) {
+        sibling_ids_to_collect.emplace_back(id_to_check);
+      }
+    }
+
+    children_data.emplace(
+        child_id,
+        db::copy_items<
+            typename db::DataBox<DbTagList>::mutable_item_creation_tags>(box));
+    auto& array_proxy =
+        Parallel::get_parallel_component<ParallelComponent>(cache);
+
+    if (sibling_ids_to_collect.empty()) {
+      Parallel::simple_action<InitializeParent>(array_proxy[parent_id],
+                                                std::move(children_data));
+    } else {
+      const auto next_child_id = sibling_ids_to_collect.front();
+      sibling_ids_to_collect.pop_front();
+      Parallel::simple_action<CollectDataFromChildren>(
+          array_proxy[next_child_id], parent_id, sibling_ids_to_collect,
+          std::move(children_data));
+    }
+    array_proxy[child_id].ckDestroy();
+  }
+};
+}  // namespace amr::Actions

--- a/src/ParallelAlgorithms/Amr/Actions/CreateParent.hpp
+++ b/src/ParallelAlgorithms/Amr/Actions/CreateParent.hpp
@@ -1,0 +1,55 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <deque>
+#include <memory>
+#include <utility>
+
+#include "Domain/Structure/ElementId.hpp"
+#include "Parallel/Callback.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "Parallel/Phase.hpp"
+#include "ParallelAlgorithms/Amr/Actions/CollectDataFromChildren.hpp"
+
+/// \cond
+namespace db {
+template <typename>
+class DataBox;
+}  // namespace db
+/// \endcond
+
+namespace amr::Actions {
+/// \brief Creates a new element in an ArrayAlgorithm whose id is `parent_id`
+///
+/// \details This action is meant to be initially invoked by
+/// amr::Actions::AdjustDomain on the amr::Component.  This action inserts a
+/// new element with id `parent_id` in the array referenced by
+/// `element_proxy`.  A Parallel::SimpleActionCallback `callback` is passed to
+/// the constructor of the new DistributedObject, which will invoke
+/// amr::Actions::CollectDataFromChildren on the element with id `child_id`.
+///
+/// This action does not modify anything in the DataBox
+struct CreateParent {
+  template <typename ParallelComponent, typename DbTagList,
+            typename Metavariables, typename ElementProxy>
+  static void apply(
+      db::DataBox<DbTagList>& /*box*/,
+      Parallel::GlobalCache<Metavariables>& cache, const int /*array_index*/,
+      ElementProxy element_proxy,
+      ElementId<Metavariables::volume_dim> parent_id,
+      const ElementId<Metavariables::volume_dim>& child_id,
+      std::deque<ElementId<Metavariables::volume_dim>> sibling_ids_to_collect) {
+    auto child_proxy = element_proxy[child_id];
+    element_proxy[parent_id].insert(
+        cache.thisProxy, Parallel::Phase::AdjustDomain,
+        std::make_unique<Parallel::SimpleActionCallback<
+            CollectDataFromChildren, decltype(child_proxy),
+            ElementId<Metavariables::volume_dim>,
+            std::deque<ElementId<Metavariables::volume_dim>>>>(
+            child_proxy, std::move(parent_id),
+            std::move(sibling_ids_to_collect)));
+  }
+};
+}  // namespace amr::Actions

--- a/src/ParallelAlgorithms/Amr/Actions/InitializeParent.hpp
+++ b/src/ParallelAlgorithms/Amr/Actions/InitializeParent.hpp
@@ -1,0 +1,102 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <tuple>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "Domain/Amr/NeighborsOfParent.hpp"
+#include "Domain/Amr/Tags/Flags.hpp"
+#include "Domain/Amr/Tags/NeighborFlags.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/DirectionMap.hpp"
+#include "Domain/Structure/Element.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Domain/Structure/Neighbors.hpp"
+#include "Domain/Tags.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "ParallelAlgorithms/Amr/Projectors/Mesh.hpp"
+#include "ParallelAlgorithms/Initialization/MutateAssign.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+/// \cond
+namespace Parallel {
+template <typename Metavariables>
+class GlobalCache;
+}  // namespace Parallel
+/// \endcond
+
+namespace amr::Actions {
+/// \brief Initializes the data of a newly created parent element from the data
+/// of its children elements
+///
+/// \warning At the moment, this action only initializes the Element, Mesh,
+/// and amr::Flag%s of the parent element.  It does not initialize any data
+/// related to evolution or elliptic solves.
+///
+/// DataBox:
+/// - Modifies:
+///   * domain::Tags::Element<volume_dim>
+///   * domain::Tags::Mesh<volume_dim>
+///
+/// \details This action is meant to be invoked by
+/// amr::Actions::CollectDataFromChildren
+struct InitializeParent {
+  template <typename ParallelComponent, typename DbTagList,
+            typename Metavariables>
+  static void apply(
+      db::DataBox<DbTagList>& box,
+      const Parallel::GlobalCache<Metavariables>& /*cache*/,
+      const ElementId<Metavariables::volume_dim>& parent_id,
+      std::unordered_map<
+          ElementId<Metavariables::volume_dim>,
+          tuples::tagged_tuple_from_typelist<
+              typename db::DataBox<DbTagList>::mutable_item_creation_tags>>
+          children_items) {
+    constexpr size_t volume_dim = Metavariables::volume_dim;
+    std::vector<
+        std::tuple<const Element<volume_dim>&,
+                   const std::unordered_map<ElementId<volume_dim>,
+                                            std::array<Flag, volume_dim>>&>>
+        children_elements_and_neighbor_flags;
+    for (const auto& [_, child_items] : children_items) {
+      children_elements_and_neighbor_flags.emplace_back(std::forward_as_tuple(
+          tuples::get<::domain::Tags::Element<volume_dim>>(child_items),
+          tuples::get<amr::Tags::NeighborFlags<volume_dim>>(child_items)));
+    }
+    auto parent_neighbors = amr::neighbors_of_parent(
+        parent_id, children_elements_and_neighbor_flags);
+    Element<volume_dim> parent(parent_id, std::move(parent_neighbors));
+
+    std::vector<Mesh<volume_dim>> projected_children_meshes{};
+    projected_children_meshes.reserve(children_items.size());
+    for (const auto& [child_id, child_items] : children_items) {
+      const auto& child_mesh =
+          tuples::get<::domain::Tags::Mesh<volume_dim>>(child_items);
+      const auto& child_flags =
+          tuples::get<amr::Tags::Flags<volume_dim>>(child_items);
+      projected_children_meshes.emplace_back(
+          amr::projectors::mesh(child_mesh, child_flags));
+    }
+    Mesh<volume_dim> parent_mesh =
+        amr::projectors::parent_mesh(projected_children_meshes);
+
+    // Default initialization of amr::Tags::Flags and amr::Tags::NeighborFlags
+    // is okay
+    ::Initialization::mutate_assign<tmpl::list<
+        ::domain::Tags::Element<volume_dim>, ::domain::Tags::Mesh<volume_dim>>>(
+        make_not_null(&box), std::move(parent), std::move(parent_mesh));
+
+    // In the near future, add the capability of updating all data needed for
+    // an evolution or elliptic system
+  }
+};
+}  // namespace amr::Actions

--- a/tests/Unit/Domain/Amr/CMakeLists.txt
+++ b/tests/Unit/Domain/Amr/CMakeLists.txt
@@ -7,6 +7,7 @@ set(LIBRARY_SOURCES
   Test_Flag.cpp
   Test_Helpers.cpp
   Test_NeighborsOfChild.cpp
+  Test_NeighborsOfParent.cpp
   Test_NewNeighborIds.cpp
   Test_Tags.cpp
   Test_UpdateAmrDecision.cpp

--- a/tests/Unit/Domain/Amr/Test_Helpers.cpp
+++ b/tests/Unit/Domain/Amr/Test_Helpers.cpp
@@ -118,6 +118,11 @@ void test_fraction_of_block_volume() {
 }
 
 void test_has_potential_sibling() {
+  const ElementId<1> element_id_root{0, {{SegmentId(0, 0)}}};
+  CHECK_FALSE(
+      amr::has_potential_sibling(element_id_root, Direction<1>::lower_xi()));
+  CHECK_FALSE(
+      amr::has_potential_sibling(element_id_root, Direction<1>::upper_xi()));
   const ElementId<1> element_id_1d{0, {{SegmentId(2, 3)}}};
   CHECK(amr::has_potential_sibling(element_id_1d, Direction<1>::lower_xi()));
   CHECK_FALSE(

--- a/tests/Unit/Domain/Amr/Test_NeighborsOfParent.cpp
+++ b/tests/Unit/Domain/Amr/Test_NeighborsOfParent.cpp
@@ -1,0 +1,271 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <tuple>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include "Domain/Amr/Flag.hpp"
+#include "Domain/Amr/Helpers.hpp"
+#include "Domain/Amr/NeighborsOfParent.hpp"
+#include "Domain/Amr/NewNeighborIds.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/DirectionMap.hpp"
+#include "Domain/Structure/Element.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Domain/Structure/Neighbors.hpp"
+#include "Domain/Structure/SegmentId.hpp"
+#include "Domain/Structure/Side.hpp"
+#include "Framework/TestHelpers.hpp"
+
+namespace {
+SegmentId s_00{0, 0};
+SegmentId s_10{1, 0};
+SegmentId s_11{1, 1};
+
+void test_periodic_interval() {
+  OrientationMap<1> aligned{};
+  ElementId<1> parent_id{0, std::array{s_00}};
+  ElementId<1> child_1_id{0, std::array{s_10}};
+  ElementId<1> child_2_id{0, std::array{s_11}};
+
+  DirectionMap<1, Neighbors<1>> child_1_neighbors{};
+  child_1_neighbors.emplace(
+      Direction<1>::lower_xi(),
+      Neighbors<1>{std::unordered_set{child_2_id}, aligned});
+  child_1_neighbors.emplace(
+      Direction<1>::upper_xi(),
+      Neighbors<1>{std::unordered_set{child_2_id}, aligned});
+  Element<1> child_1{child_1_id, std::move(child_1_neighbors)};
+  std::unordered_map<ElementId<1>, std::array<amr::Flag, 1>>
+      child_1_neighbor_flags{{child_2_id, {{amr::Flag::Join}}}};
+
+  DirectionMap<1, Neighbors<1>> child_2_neighbors{};
+  child_2_neighbors.emplace(
+      Direction<1>::lower_xi(),
+      Neighbors<1>{std::unordered_set{child_1_id}, aligned});
+  child_2_neighbors.emplace(
+      Direction<1>::upper_xi(),
+      Neighbors<1>{std::unordered_set{child_1_id}, aligned});
+  Element<1> child_2{child_2_id, std::move(child_2_neighbors)};
+  std::unordered_map<ElementId<1>, std::array<amr::Flag, 1>>
+      child_2_neighbor_flags{{child_1_id, {{amr::Flag::Join}}}};
+
+  std::vector<std::tuple<
+      const Element<1>&,
+      const std::unordered_map<ElementId<1>, std::array<amr::Flag, 1>>&>>
+      children_elements_and_neighbor_flags;
+  children_elements_and_neighbor_flags.emplace_back(
+      std::forward_as_tuple(child_1, child_1_neighbor_flags));
+  children_elements_and_neighbor_flags.emplace_back(
+      std::forward_as_tuple(child_2, child_2_neighbor_flags));
+
+  const auto parent_neighbors =
+      amr::neighbors_of_parent(parent_id, children_elements_and_neighbor_flags);
+  DirectionMap<1, Neighbors<1>> expected_parent_neighbors{};
+  expected_parent_neighbors.emplace(
+      Direction<1>::lower_xi(),
+      Neighbors<1>{std::unordered_set{parent_id}, aligned});
+  expected_parent_neighbors.emplace(
+      Direction<1>::upper_xi(),
+      Neighbors<1>{std::unordered_set{parent_id}, aligned});
+  CHECK(parent_neighbors == expected_parent_neighbors);
+}
+
+void test_interval() {
+  OrientationMap<1> aligned{};
+  OrientationMap<1> flipped{std::array{Direction<1>::lower_xi()}};
+  ElementId<1> parent_id{0, std::array{s_00}};
+  ElementId<1> child_1_id{0, std::array{s_10}};
+  ElementId<1> child_2_id{0, std::array{s_11}};
+  ElementId<1> lower_neighbor_id{1, std::array{s_11}};
+  ElementId<1> upper_neighbor_id{2, std::array{s_00}};
+
+  DirectionMap<1, Neighbors<1>> child_1_neighbors{};
+  child_1_neighbors.emplace(
+      Direction<1>::lower_xi(),
+      Neighbors<1>{std::unordered_set{lower_neighbor_id}, aligned});
+  child_1_neighbors.emplace(
+      Direction<1>::upper_xi(),
+      Neighbors<1>{std::unordered_set{child_2_id}, aligned});
+  Element<1> child_1{child_1_id, std::move(child_1_neighbors)};
+  std::unordered_map<ElementId<1>, std::array<amr::Flag, 1>>
+      child_1_neighbor_flags{{lower_neighbor_id, {{amr::Flag::DoNothing}}},
+                             {child_2_id, {{amr::Flag::Join}}}};
+
+  DirectionMap<1, Neighbors<1>> child_2_neighbors{};
+  child_2_neighbors.emplace(
+      Direction<1>::lower_xi(),
+      Neighbors<1>{std::unordered_set{child_1_id}, aligned});
+  child_2_neighbors.emplace(
+      Direction<1>::upper_xi(),
+      Neighbors<1>{std::unordered_set{upper_neighbor_id}, flipped});
+  Element<1> child_2{child_2_id, std::move(child_2_neighbors)};
+  std::unordered_map<ElementId<1>, std::array<amr::Flag, 1>>
+      child_2_neighbor_flags{{child_1_id, {{amr::Flag::Join}}},
+                             {upper_neighbor_id, {{amr::Flag::Split}}}};
+
+  std::vector<std::tuple<
+      const Element<1>&,
+      const std::unordered_map<ElementId<1>, std::array<amr::Flag, 1>>&>>
+      children_elements_and_neighbor_flags;
+  children_elements_and_neighbor_flags.emplace_back(
+      std::forward_as_tuple(child_1, child_1_neighbor_flags));
+  children_elements_and_neighbor_flags.emplace_back(
+      std::forward_as_tuple(child_2, child_2_neighbor_flags));
+
+  const auto parent_neighbors =
+      amr::neighbors_of_parent(parent_id, children_elements_and_neighbor_flags);
+  DirectionMap<1, Neighbors<1>> expected_parent_neighbors{};
+  expected_parent_neighbors.emplace(
+      Direction<1>::lower_xi(),
+      Neighbors<1>{std::unordered_set{lower_neighbor_id}, aligned});
+  ElementId<1> split_upper_neighbor_id{2, std::array{s_11}};
+  expected_parent_neighbors.emplace(
+      Direction<1>::upper_xi(),
+      Neighbors<1>{std::unordered_set{split_upper_neighbor_id}, flipped});
+  CHECK(parent_neighbors == expected_parent_neighbors);
+}
+
+void test_rectangle() {
+  OrientationMap<2> aligned{};
+  OrientationMap<2> rotated{
+      std::array{Direction<2>::lower_eta(), Direction<2>::upper_xi()}};
+
+  ElementId<2> parent_id{0, std::array{s_00, s_00}};
+  ElementId<2> child_1_id{0, std::array{s_10, s_10}};
+  ElementId<2> child_2_id{0, std::array{s_11, s_10}};
+  ElementId<2> child_3_id{0, std::array{s_10, s_11}};
+  ElementId<2> child_4_id{0, std::array{s_11, s_11}};
+  ElementId<2> neighbor_1_id{1, std::array{s_11, s_00}};
+  ElementId<2> neighbor_2_id{2, std::array{s_10, s_00}};
+  ElementId<2> neighbor_3_id{2, std::array{s_11, s_11}};
+
+  std::array join_join{amr::Flag::Join, amr::Flag::Join};
+  std::array neighbor_1_flags{amr::Flag::Join, amr::Flag::DoNothing};
+  std::array neighbor_2_flags{amr::Flag::DoNothing, amr::Flag::Split};
+  std::array neighbor_3_flags{amr::Flag::DoNothing, amr::Flag::Join};
+
+  ElementId<2> neighbor_4_id{1, std::array{s_00, s_00}};
+  ElementId<2> neighbor_5_id{2, std::array{s_10, s_11}};
+  ElementId<2> neighbor_6_id{2, std::array{s_11, s_00}};
+
+  DirectionMap<2, Neighbors<2>> child_1_neighbors{};
+  child_1_neighbors.emplace(
+      Direction<2>::lower_xi(),
+      Neighbors<2>{std::unordered_set{neighbor_1_id}, aligned});
+  child_1_neighbors.emplace(
+      Direction<2>::upper_xi(),
+      Neighbors<2>{std::unordered_set{child_2_id}, aligned});
+  child_1_neighbors.emplace(
+      Direction<2>::lower_eta(),
+      Neighbors<2>{std::unordered_set{child_3_id}, aligned});
+  child_1_neighbors.emplace(
+      Direction<2>::upper_eta(),
+      Neighbors<2>{std::unordered_set{child_3_id}, aligned});
+  Element<2> child_1{child_1_id, std::move(child_1_neighbors)};
+  std::unordered_map<ElementId<2>, std::array<amr::Flag, 2>>
+      child_1_neighbor_flags{{neighbor_1_id, neighbor_1_flags},
+                             {child_2_id, join_join},
+                             {child_3_id, join_join}};
+
+  DirectionMap<2, Neighbors<2>> child_2_neighbors{};
+  child_2_neighbors.emplace(
+      Direction<2>::lower_xi(),
+      Neighbors<2>{std::unordered_set{child_1_id}, aligned});
+  child_2_neighbors.emplace(
+      Direction<2>::upper_xi(),
+      Neighbors<2>{std::unordered_set{neighbor_2_id}, rotated});
+  child_2_neighbors.emplace(
+      Direction<2>::lower_eta(),
+      Neighbors<2>{std::unordered_set{child_4_id}, aligned});
+  child_2_neighbors.emplace(
+      Direction<2>::upper_eta(),
+      Neighbors<2>{std::unordered_set{child_4_id}, aligned});
+  Element<2> child_2{child_2_id, std::move(child_2_neighbors)};
+  std::unordered_map<ElementId<2>, std::array<amr::Flag, 2>>
+      child_2_neighbor_flags{{child_1_id, join_join},
+                             {child_4_id, join_join},
+                             {neighbor_2_id, neighbor_2_flags}};
+
+  DirectionMap<2, Neighbors<2>> child_3_neighbors{};
+  child_3_neighbors.emplace(
+      Direction<2>::lower_xi(),
+      Neighbors<2>{std::unordered_set{neighbor_1_id}, aligned});
+  child_3_neighbors.emplace(
+      Direction<2>::upper_xi(),
+      Neighbors<2>{std::unordered_set{child_4_id}, aligned});
+  child_3_neighbors.emplace(
+      Direction<2>::lower_eta(),
+      Neighbors<2>{std::unordered_set{child_1_id}, aligned});
+  child_3_neighbors.emplace(
+      Direction<2>::upper_eta(),
+      Neighbors<2>{std::unordered_set{child_1_id}, aligned});
+  Element<2> child_3{child_3_id, std::move(child_3_neighbors)};
+  std::unordered_map<ElementId<2>, std::array<amr::Flag, 2>>
+      child_3_neighbor_flags{{neighbor_1_id, neighbor_1_flags},
+                             {child_1_id, join_join},
+                             {child_4_id, join_join}};
+
+  DirectionMap<2, Neighbors<2>> child_4_neighbors{};
+  child_4_neighbors.emplace(
+      Direction<2>::lower_xi(),
+      Neighbors<2>{std::unordered_set{child_3_id}, aligned});
+  child_4_neighbors.emplace(
+      Direction<2>::upper_xi(),
+      Neighbors<2>{std::unordered_set{neighbor_3_id}, rotated});
+  child_4_neighbors.emplace(
+      Direction<2>::lower_eta(),
+      Neighbors<2>{std::unordered_set{child_2_id}, aligned});
+  child_4_neighbors.emplace(
+      Direction<2>::upper_eta(),
+      Neighbors<2>{std::unordered_set{child_2_id}, aligned});
+  Element<2> child_4{child_4_id, std::move(child_4_neighbors)};
+  std::unordered_map<ElementId<2>, std::array<amr::Flag, 2>>
+      child_4_neighbor_flags{{child_2_id, join_join},
+                             {child_3_id, join_join},
+                             {neighbor_3_id, neighbor_3_flags}};
+
+  std::vector<std::tuple<
+      const Element<2>&,
+      const std::unordered_map<ElementId<2>, std::array<amr::Flag, 2>>&>>
+      children_elements_and_neighbor_flags;
+  children_elements_and_neighbor_flags.emplace_back(
+      std::forward_as_tuple(child_1, child_1_neighbor_flags));
+  children_elements_and_neighbor_flags.emplace_back(
+      std::forward_as_tuple(child_2, child_2_neighbor_flags));
+  children_elements_and_neighbor_flags.emplace_back(
+      std::forward_as_tuple(child_3, child_3_neighbor_flags));
+  children_elements_and_neighbor_flags.emplace_back(
+      std::forward_as_tuple(child_4, child_4_neighbor_flags));
+
+  const auto parent_neighbors =
+      amr::neighbors_of_parent(parent_id, children_elements_and_neighbor_flags);
+  DirectionMap<2, Neighbors<2>> expected_parent_neighbors{};
+  expected_parent_neighbors.emplace(
+      Direction<2>::lower_xi(),
+      Neighbors<2>{std::unordered_set{neighbor_4_id}, aligned});
+  expected_parent_neighbors.emplace(
+      Direction<2>::upper_xi(),
+      Neighbors<2>{std::unordered_set{neighbor_5_id, neighbor_6_id}, rotated});
+  expected_parent_neighbors.emplace(
+      Direction<2>::lower_eta(),
+      Neighbors<2>{std::unordered_set{parent_id}, aligned});
+  expected_parent_neighbors.emplace(
+      Direction<2>::upper_eta(),
+      Neighbors<2>{std::unordered_set{parent_id}, aligned});
+  CHECK(parent_neighbors == expected_parent_neighbors);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Domain.Amr.NeighborsOfParent", "[Domain][Unit]") {
+  test_periodic_interval();
+  test_interval();
+  test_rectangle();
+}

--- a/tests/Unit/ParallelAlgorithms/Amr/Actions/Test_AdjustDomain.cpp
+++ b/tests/Unit/ParallelAlgorithms/Amr/Actions/Test_AdjustDomain.cpp
@@ -1,0 +1,296 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <deque>
+#include <pup.h>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "Domain/Amr/Flag.hpp"
+#include "Domain/Amr/Tags/Flags.hpp"
+#include "Domain/Amr/Tags/NeighborFlags.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/DirectionMap.hpp"
+#include "Domain/Structure/Element.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Domain/Structure/Neighbors.hpp"
+#include "Domain/Structure/OrientationMap.hpp"
+#include "Domain/Structure/SegmentId.hpp"
+#include "Domain/Tags.hpp"
+#include "Framework/ActionTesting.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "Parallel/PhaseDependentActionList.hpp"
+#include "ParallelAlgorithms/Amr/Actions/AdjustDomain.hpp"
+#include "ParallelAlgorithms/Amr/Actions/Component.hpp"
+#include "ParallelAlgorithms/Amr/Actions/CreateChild.hpp"
+#include "ParallelAlgorithms/Amr/Actions/CreateParent.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+struct MockCreateParent {
+  template <typename ParallelComponent, typename DataBox,
+            typename Metavariables, typename ElementProxy>
+  static void apply(
+      DataBox& /*box*/, Parallel::GlobalCache<Metavariables>& /*cache*/,
+      const int /*array_index*/, ElementProxy /*element_proxy*/,
+      ElementId<Metavariables::volume_dim> parent_id,
+      const ElementId<Metavariables::volume_dim>& child_id,
+      std::deque<ElementId<Metavariables::volume_dim>> sibling_ids_to_collect) {
+    CHECK(parent_id == ElementId<1>{0, std::array{SegmentId{2, 0}}});
+    CHECK(child_id == ElementId<1>{0, std::array{SegmentId{3, 0}}});
+    CHECK(sibling_ids_to_collect ==
+          std::deque{ElementId<1>{0, std::array{SegmentId{3, 1}}}});
+  }
+};
+
+struct MockCreateChild {
+  template <typename ParallelComponent, typename DataBox,
+            typename Metavariables, typename ElementProxy>
+  static void apply(
+      DataBox& /*box*/, Parallel::GlobalCache<Metavariables>& /*cache*/,
+      const int /*array_index*/, ElementProxy /*element_proxy*/,
+      ElementId<Metavariables::volume_dim> parent_id,
+      std::vector<ElementId<Metavariables::volume_dim>> children_ids,
+      const size_t index_of_child_id) {
+    CHECK(parent_id == ElementId<1>{0, std::array{SegmentId{1, 1}}});
+    if (index_of_child_id == 0) {
+      CHECK(children_ids ==
+            std::vector{ElementId<1>{0, std::array{SegmentId{2, 2}}},
+                        ElementId<1>{0, std::array{SegmentId{2, 3}}}});
+    } else {
+      CHECK(index_of_child_id == 1);
+      CHECK(children_ids ==
+            std::vector{ElementId<1>{0, std::array{SegmentId{2, 2}}},
+                        ElementId<1>{0, std::array{SegmentId{2, 3}}}});
+    }
+  }
+};
+
+template <typename Metavariables>
+struct ArrayComponent {
+  using metavariables = Metavariables;
+  static constexpr size_t volume_dim = Metavariables::volume_dim;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = ElementId<volume_dim>;
+  using const_global_cache_tags = tmpl::list<>;
+  using simple_tags =
+      tmpl::list<domain::Tags::Element<volume_dim>,
+                 domain::Tags::Mesh<volume_dim>, amr::Tags::Flags<volume_dim>,
+                 amr::Tags::NeighborFlags<volume_dim>>;
+  using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
+      Parallel::Phase::Initialization,
+      tmpl::list<ActionTesting::InitializeDataBox<simple_tags>>>>;
+};
+
+template <typename Metavariables>
+struct SingletonComponent {
+  using metavariables = Metavariables;
+  using array_index = int;
+
+  using component_being_mocked = amr::Component<Metavariables>;
+  static constexpr size_t volume_dim = Metavariables::volume_dim;
+  using chare_type = ActionTesting::MockSingletonChare;
+  using const_global_cache_tags = tmpl::list<>;
+  using simple_tags = tmpl::list<>;
+  using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
+      Parallel::Phase::Initialization,
+      tmpl::list<ActionTesting::InitializeDataBox<simple_tags>>>>;
+  using replace_these_simple_actions =
+      tmpl::list<amr::Actions::CreateChild, amr::Actions::CreateParent>;
+  using with_these_simple_actions =
+      tmpl::list<MockCreateChild, MockCreateParent>;
+};
+
+struct Metavariables {
+  static constexpr size_t volume_dim = 1;
+  using component_list = tmpl::list<ArrayComponent<Metavariables>,
+                                    SingletonComponent<Metavariables>>;
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& /*p*/) {}
+};
+
+void check_box(const ActionTesting::MockRuntimeSystem<Metavariables>& runner,
+               const ElementId<1>& element_id,
+               const Element<1>& expected_element, const Mesh<1>& expected_mesh,
+               const std::array<amr::Flag, 1>& expected_flags,
+               const std::unordered_map<ElementId<1>, std::array<amr::Flag, 1>>&
+                   expected_neighbor_flags) {
+  using array_component = ArrayComponent<Metavariables>;
+  CHECK(
+      ActionTesting::get_databox_tag<array_component, domain::Tags::Element<1>>(
+          runner, element_id) == expected_element);
+  CHECK(ActionTesting::get_databox_tag<array_component, domain::Tags::Mesh<1>>(
+            runner, element_id) == expected_mesh);
+  CHECK(ActionTesting::get_databox_tag<array_component, amr::Tags::Flags<1>>(
+            runner, element_id) == expected_flags);
+  CHECK(ActionTesting::get_databox_tag<array_component,
+                                       amr::Tags::NeighborFlags<1>>(
+            runner, element_id) == expected_neighbor_flags);
+}
+
+void test() {
+  using array_component = ArrayComponent<Metavariables>;
+  using singleton_component = SingletonComponent<Metavariables>;
+
+  const OrientationMap<1> aligned{};
+
+  const ElementId<1> element_1_id{0, std::array{SegmentId{3, 0}}};
+  const ElementId<1> element_2_id{0, std::array{SegmentId{3, 1}}};
+  const ElementId<1> element_3_id{0, std::array{SegmentId{2, 1}}};
+  const ElementId<1> element_4_id{0, std::array{SegmentId{1, 1}}};
+
+  const Element<1> element_1{
+      element_1_id,
+      DirectionMap<1, Neighbors<1>>{
+          {Direction<1>::upper_xi(),
+           Neighbors<1>{std::unordered_set{element_2_id}, aligned}}}};
+  const Element<1> element_2{
+      element_2_id,
+      DirectionMap<1, Neighbors<1>>{
+          {Direction<1>::lower_xi(),
+           Neighbors<1>{std::unordered_set{element_1_id}, aligned}},
+          {Direction<1>::upper_xi(),
+           Neighbors<1>{std::unordered_set{element_3_id}, aligned}}}};
+  const Element<1> element_3{
+      element_3_id,
+      DirectionMap<1, Neighbors<1>>{
+          {Direction<1>::lower_xi(),
+           Neighbors<1>{std::unordered_set{element_2_id}, aligned}},
+          {Direction<1>::upper_xi(),
+           Neighbors<1>{std::unordered_set{element_4_id}, aligned}}}};
+  const Element<1> element_4{
+      element_4_id,
+      DirectionMap<1, Neighbors<1>>{
+          {Direction<1>::lower_xi(),
+           Neighbors<1>{std::unordered_set{element_3_id}, aligned}}}};
+
+  const Mesh<1> element_1_mesh{std::array{3_st}, Spectral::Basis::Legendre,
+                               Spectral::Quadrature::GaussLobatto};
+  const Mesh<1> element_2_mesh{std::array{4_st}, Spectral::Basis::Legendre,
+                               Spectral::Quadrature::GaussLobatto};
+  const Mesh<1> element_3_mesh{std::array{5_st}, Spectral::Basis::Legendre,
+                               Spectral::Quadrature::GaussLobatto};
+  const Mesh<1> element_4_mesh{std::array{7_st}, Spectral::Basis::Legendre,
+                               Spectral::Quadrature::GaussLobatto};
+
+  std::array element_1_flags{amr::Flag::Join};
+  std::array element_2_flags{amr::Flag::Join};
+  std::array element_3_flags{amr::Flag::IncreaseResolution};
+  std::array element_4_flags{amr::Flag::Split};
+
+  std::unordered_map<ElementId<1>, std::array<amr::Flag, 1>>
+      element_1_neighbor_flags{{element_2_id, element_2_flags}};
+  std::unordered_map<ElementId<1>, std::array<amr::Flag, 1>>
+      element_2_neighbor_flags{{element_1_id, element_1_flags},
+                               {element_3_id, element_3_flags}};
+  std::unordered_map<ElementId<1>, std::array<amr::Flag, 1>>
+      element_3_neighbor_flags{{element_2_id, element_2_flags},
+                               {element_4_id, element_4_flags}};
+  std::unordered_map<ElementId<1>, std::array<amr::Flag, 1>>
+      element_4_neighbor_flags{{element_3_id, element_3_flags}};
+
+  ActionTesting::MockRuntimeSystem<Metavariables> runner{{}};
+  ActionTesting::emplace_component_and_initialize<array_component>(
+      &runner, element_1_id,
+      {element_1, element_1_mesh, element_1_flags, element_1_neighbor_flags});
+  ActionTesting::emplace_component_and_initialize<array_component>(
+      &runner, element_2_id,
+      {element_2, element_2_mesh, element_2_flags, element_2_neighbor_flags});
+  ActionTesting::emplace_component_and_initialize<array_component>(
+      &runner, element_3_id,
+      {element_3, element_3_mesh, element_3_flags, element_3_neighbor_flags});
+  ActionTesting::emplace_component_and_initialize<array_component>(
+      &runner, element_4_id,
+      {element_4, element_4_mesh, element_4_flags, element_4_neighbor_flags});
+  ActionTesting::emplace_component<singleton_component>(&runner, 0);
+
+  const auto check_for_empty_queues_on_elements =
+      [&element_1_id, &element_2_id, &element_3_id, &element_4_id, &runner]() {
+        for (const auto& id : std::vector{element_1_id, element_2_id,
+                                          element_3_id, element_4_id}) {
+          CHECK(ActionTesting::is_simple_action_queue_empty<array_component>(
+              runner, id));
+        }
+      };
+  check_for_empty_queues_on_elements();
+  CHECK(ActionTesting::number_of_queued_simple_actions<singleton_component>(
+            runner, 0) == 0);
+
+  // This should queue CreateParent on the singleton
+  ActionTesting::simple_action<array_component, amr::Actions::AdjustDomain>(
+      make_not_null(&runner), element_1_id);
+  check_for_empty_queues_on_elements();
+  CHECK(ActionTesting::number_of_queued_simple_actions<singleton_component>(
+            runner, 0) == 1);
+
+  // This should do nothing
+  ActionTesting::simple_action<array_component, amr::Actions::AdjustDomain>(
+      make_not_null(&runner), element_2_id);
+  check_for_empty_queues_on_elements();
+  CHECK(ActionTesting::number_of_queued_simple_actions<singleton_component>(
+            runner, 0) == 1);
+
+  // This should p-refine element_3
+  ActionTesting::simple_action<array_component, amr::Actions::AdjustDomain>(
+      make_not_null(&runner), element_3_id);
+  check_for_empty_queues_on_elements();
+  CHECK(ActionTesting::number_of_queued_simple_actions<singleton_component>(
+            runner, 0) == 1);
+
+  // This should queue CreateChild on the singleton
+  ActionTesting::simple_action<array_component, amr::Actions::AdjustDomain>(
+      make_not_null(&runner), element_4_id);
+  check_for_empty_queues_on_elements();
+  CHECK(ActionTesting::number_of_queued_simple_actions<singleton_component>(
+            runner, 0) == 2);
+
+  // This will invoke the queued actions on the singleton calling the mock
+  // actions
+  ActionTesting::invoke_queued_simple_action<singleton_component>(
+      make_not_null(&runner), 0);
+  check_for_empty_queues_on_elements();
+  CHECK(ActionTesting::number_of_queued_simple_actions<singleton_component>(
+            runner, 0) == 1);
+  ActionTesting::invoke_queued_simple_action<singleton_component>(
+      make_not_null(&runner), 0);
+  check_for_empty_queues_on_elements();
+  CHECK(ActionTesting::number_of_queued_simple_actions<singleton_component>(
+            runner, 0) == 0);
+
+  check_box(runner, element_1_id, element_1, element_1_mesh, element_1_flags,
+            element_1_neighbor_flags);
+  check_box(runner, element_2_id, element_2, element_2_mesh, element_2_flags,
+            element_2_neighbor_flags);
+  check_box(runner, element_4_id, element_4, element_4_mesh, element_4_flags,
+            element_4_neighbor_flags);
+  const ElementId<1> new_parent_id{
+      ElementId<1>{0, std::array{SegmentId{2, 0}}}};
+  const ElementId<1> new_lower_child_id{
+      ElementId<1>{0, std::array{SegmentId{2, 2}}}};
+  const Element<1> element_3_post_refinement{
+      element_3_id,
+      DirectionMap<1, Neighbors<1>>{
+          {Direction<1>::lower_xi(),
+           Neighbors<1>{std::unordered_set{new_parent_id}, aligned}},
+          {Direction<1>::upper_xi(),
+           Neighbors<1>{std::unordered_set{new_lower_child_id}, aligned}}}};
+  const Mesh<1> element_3_mesh_post_refinement{
+      std::array{6_st}, Spectral::Basis::Legendre,
+      Spectral::Quadrature::GaussLobatto};
+  check_box(runner, element_3_id, element_3_post_refinement,
+            element_3_mesh_post_refinement, std::array{amr::Flag::Undefined},
+            {});
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Amr.Actions.AdjustDomain",
+                  "[Unit][ParallelAlgorithms]") {
+  test();
+}

--- a/tests/Unit/ParallelAlgorithms/Amr/Actions/Test_CollectDataFromChildren.cpp
+++ b/tests/Unit/ParallelAlgorithms/Amr/Actions/Test_CollectDataFromChildren.cpp
@@ -1,0 +1,304 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <deque>
+#include <pup.h>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include "Domain/Amr/Helpers.hpp"
+#include "Domain/Amr/Tags/Flags.hpp"
+#include "Domain/Amr/Tags/NeighborFlags.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/DirectionMap.hpp"
+#include "Domain/Structure/Element.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Domain/Structure/Neighbors.hpp"
+#include "Domain/Structure/OrientationMap.hpp"
+#include "Domain/Structure/SegmentId.hpp"
+#include "Domain/Tags.hpp"
+#include "Framework/ActionTesting.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "Parallel/Phase.hpp"
+#include "Parallel/PhaseDependentActionList.hpp"
+#include "ParallelAlgorithms/Amr/Actions/CollectDataFromChildren.hpp"
+#include "Utilities/Literals.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace {
+ElementId<2> parent_id{0, std::array{SegmentId{0, 0}, SegmentId{0, 0}}};
+ElementId<2> child_1_id{0, std::array{SegmentId{1, 0}, SegmentId{1, 0}}};
+ElementId<2> child_2_id{0, std::array{SegmentId{1, 1}, SegmentId{1, 0}}};
+ElementId<2> child_3_id{0, std::array{SegmentId{1, 0}, SegmentId{1, 1}}};
+ElementId<2> child_4_id{0, std::array{SegmentId{1, 1}, SegmentId{1, 1}}};
+ElementId<2> neighbor_1_id{1, std::array{SegmentId{1, 1}, SegmentId{0, 0}}};
+ElementId<2> neighbor_2_id{2, std::array{SegmentId{1, 0}, SegmentId{0, 0}}};
+ElementId<2> neighbor_3_id{2, std::array{SegmentId{1, 1}, SegmentId{1, 1}}};
+
+auto child_1_mesh() {
+  return Mesh<2>{std::array{3_st, 3_st}, Spectral::Basis::Legendre,
+                 Spectral::Quadrature::GaussLobatto};
+}
+auto child_2_mesh() {
+  return Mesh<2>{std::array{3_st, 4_st}, Spectral::Basis::Legendre,
+                 Spectral::Quadrature::GaussLobatto};
+}
+auto child_3_mesh() {
+  return Mesh<2>{std::array{4_st, 3_st}, Spectral::Basis::Legendre,
+                 Spectral::Quadrature::GaussLobatto};
+}
+auto child_4_mesh() {
+  return Mesh<2>{std::array{4_st, 4_st}, Spectral::Basis::Legendre,
+                 Spectral::Quadrature::GaussLobatto};
+}
+
+auto child_flags() { return std::array{amr::Flag::Join, amr::Flag::Join}; }
+auto neighbor_1_flags() {
+  return std::array{amr::Flag::Join, amr::Flag::DoNothing};
+}
+
+Element<2> child_1() {
+  static Element<2> result{
+      child_1_id,
+      DirectionMap<2, Neighbors<2>>{
+          {Direction<2>::lower_xi(),
+           Neighbors<2>{std::unordered_set{neighbor_1_id},
+                        OrientationMap<2>{}}},
+          {Direction<2>::upper_xi(),
+           Neighbors<2>{std::unordered_set{child_2_id}, OrientationMap<2>{}}},
+          {Direction<2>::lower_eta(),
+           Neighbors<2>{std::unordered_set{child_3_id}, OrientationMap<2>{}}},
+          {Direction<2>::upper_eta(),
+           Neighbors<2>{std::unordered_set{child_3_id}, OrientationMap<2>{}}}}};
+  return result;
+}
+
+Element<2> child_2() {
+  static Element<2> result{
+      child_2_id,
+      DirectionMap<2, Neighbors<2>>{
+          {Direction<2>::lower_xi(),
+           Neighbors<2>{std::unordered_set{child_1_id}, OrientationMap<2>{}}},
+          {Direction<2>::upper_xi(),
+           Neighbors<2>{
+               std::unordered_set{neighbor_2_id},
+               OrientationMap<2>{std::array{Direction<2>::lower_eta(),
+                                            Direction<2>::upper_xi()}}}},
+          {Direction<2>::lower_eta(),
+           Neighbors<2>{std::unordered_set{child_4_id}, OrientationMap<2>{}}},
+          {Direction<2>::upper_eta(),
+           Neighbors<2>{std::unordered_set{child_4_id}, OrientationMap<2>{}}}}};
+  return result;
+}
+
+Element<2> child_3() {
+  static Element<2> result{
+      child_3_id,
+      DirectionMap<2, Neighbors<2>>{
+          {Direction<2>::lower_xi(),
+           Neighbors<2>{std::unordered_set{neighbor_1_id},
+                        OrientationMap<2>{}}},
+          {Direction<2>::upper_xi(),
+           Neighbors<2>{std::unordered_set{child_4_id}, OrientationMap<2>{}}},
+          {Direction<2>::lower_eta(),
+           Neighbors<2>{std::unordered_set{child_1_id}, OrientationMap<2>{}}},
+          {Direction<2>::upper_eta(),
+           Neighbors<2>{std::unordered_set{child_1_id}, OrientationMap<2>{}}}}};
+  return result;
+}
+
+Element<2> child_4() {
+  static Element<2> result{
+      child_4_id,
+      DirectionMap<2, Neighbors<2>>{
+          {Direction<2>::lower_xi(),
+           Neighbors<2>{std::unordered_set{child_3_id}, OrientationMap<2>{}}},
+          {Direction<2>::upper_xi(),
+           Neighbors<2>{
+               std::unordered_set{neighbor_3_id},
+               OrientationMap<2>{std::array{Direction<2>::lower_eta(),
+                                            Direction<2>::upper_xi()}}}},
+          {Direction<2>::lower_eta(),
+           Neighbors<2>{std::unordered_set{child_2_id}, OrientationMap<2>{}}},
+          {Direction<2>::upper_eta(),
+           Neighbors<2>{std::unordered_set{child_2_id}, OrientationMap<2>{}}}}};
+  return result;
+}
+
+auto child_1_neighbor_flags() {
+  return std::unordered_map<ElementId<2>, std::array<amr::Flag, 2>>{
+      {neighbor_1_id, neighbor_1_flags()},
+      {child_2_id, child_flags()},
+      {child_3_id, child_flags()}};
+}
+
+auto child_2_neighbor_flags() {
+  return std::unordered_map<ElementId<2>, std::array<amr::Flag, 2>>{
+      {child_1_id, child_flags()},
+      {child_4_id, child_flags()},
+      {neighbor_2_id, std::array{amr::Flag::DoNothing, amr::Flag::Split}}};
+}
+
+auto child_3_neighbor_flags() {
+  return std::unordered_map<ElementId<2>, std::array<amr::Flag, 2>>{
+      {neighbor_1_id, neighbor_1_flags()},
+      {child_1_id, child_flags()},
+      {child_4_id, child_flags()}};
+}
+auto child_4_neighbor_flags() {
+  return std::unordered_map<ElementId<2>, std::array<amr::Flag, 2>>{
+      {child_2_id, child_flags()},
+      {child_3_id, child_flags()},
+      {neighbor_3_id, std::array{amr::Flag::DoNothing, amr::Flag::Join}}};
+}
+
+struct MockInitializeParent {
+  template <typename ParallelComponent, typename DataBox,
+            typename Metavariables, typename... Tags>
+  static void apply(
+      DataBox& /*box*/, const Parallel::GlobalCache<Metavariables>& /*cache*/,
+      const ElementId<Metavariables::volume_dim>& mock_parent_id,
+      const std::unordered_map<ElementId<Metavariables::volume_dim>,
+                               tuples::TaggedTuple<Tags...>>& children_items) {
+    CHECK(mock_parent_id == parent_id);
+    const auto& child_1_items = children_items.at(child_1_id);
+    CHECK(get<domain::Tags::Element<2>>(child_1_items) == child_1());
+    CHECK(get<domain::Tags::Mesh<2>>(child_1_items) == child_1_mesh());
+    CHECK(get<amr::Tags::Flags<2>>(child_1_items) == child_flags());
+    CHECK(get<amr::Tags::NeighborFlags<2>>(child_1_items) ==
+          child_1_neighbor_flags());
+
+    const auto& child_2_items = children_items.at(child_2_id);
+    CHECK(get<domain::Tags::Element<2>>(child_2_items) == child_2());
+    CHECK(get<domain::Tags::Mesh<2>>(child_2_items) == child_2_mesh());
+    CHECK(get<amr::Tags::Flags<2>>(child_2_items) == child_flags());
+    CHECK(get<amr::Tags::NeighborFlags<2>>(child_2_items) ==
+          child_2_neighbor_flags());
+
+    const auto& child_3_items = children_items.at(child_3_id);
+    CHECK(get<domain::Tags::Element<2>>(child_3_items) == child_3());
+    CHECK(get<domain::Tags::Mesh<2>>(child_3_items) == child_3_mesh());
+    CHECK(get<amr::Tags::Flags<2>>(child_3_items) == child_flags());
+    CHECK(get<amr::Tags::NeighborFlags<2>>(child_3_items) ==
+          child_3_neighbor_flags());
+
+    const auto& child_4_items = children_items.at(child_4_id);
+    CHECK(get<domain::Tags::Element<2>>(child_4_items) == child_4());
+    CHECK(get<domain::Tags::Mesh<2>>(child_4_items) == child_4_mesh());
+    CHECK(get<amr::Tags::Flags<2>>(child_4_items) == child_flags());
+    CHECK(get<amr::Tags::NeighborFlags<2>>(child_4_items) ==
+          child_4_neighbor_flags());
+  }
+};
+
+template <typename Metavariables>
+struct Component {
+  using metavariables = Metavariables;
+  static constexpr size_t volume_dim = Metavariables::volume_dim;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = ElementId<volume_dim>;
+  using const_global_cache_tags = tmpl::list<>;
+  using simple_tags =
+      tmpl::list<domain::Tags::Element<volume_dim>,
+                 domain::Tags::Mesh<volume_dim>, amr::Tags::Flags<volume_dim>,
+                 amr::Tags::NeighborFlags<volume_dim>>;
+  using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
+      Parallel::Phase::Initialization,
+      tmpl::list<ActionTesting::InitializeDataBox<simple_tags>>>>;
+  using replace_these_simple_actions =
+      tmpl::list<amr::Actions::InitializeParent>;
+  using with_these_simple_actions = tmpl::list<MockInitializeParent>;
+};
+
+struct Metavariables {
+  static constexpr size_t volume_dim = 2;
+  using component_list = tmpl::list<Component<Metavariables>>;
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& /*p*/) {}
+};
+
+void test() {
+  using my_component = Component<Metavariables>;
+
+  ActionTesting::MockRuntimeSystem<Metavariables> runner{{}};
+  ActionTesting::emplace_component_and_initialize<my_component>(
+      &runner, child_1_id,
+      {child_1(), child_1_mesh(), child_flags(), child_1_neighbor_flags()});
+  ActionTesting::emplace_component_and_initialize<my_component>(
+      &runner, child_2_id,
+      {child_2(), child_2_mesh(), child_flags(), child_2_neighbor_flags()});
+  ActionTesting::emplace_component_and_initialize<my_component>(
+      &runner, child_3_id,
+      {child_3(), child_3_mesh(), child_flags(), child_3_neighbor_flags()});
+  ActionTesting::emplace_component_and_initialize<my_component>(
+      &runner, child_4_id,
+      {child_4(), child_4_mesh(), child_flags(), child_4_neighbor_flags()});
+  ActionTesting::emplace_component<my_component>(&runner, parent_id);
+
+  for (const auto& id :
+       std::vector{child_1_id, child_2_id, child_3_id, child_4_id, parent_id}) {
+    CHECK(
+        ActionTesting::is_simple_action_queue_empty<my_component>(runner, id));
+  }
+
+  ActionTesting::simple_action<my_component,
+                               amr::Actions::CollectDataFromChildren>(
+      make_not_null(&runner), child_1_id, parent_id,
+      std::deque{child_2_id, child_3_id});
+  for (const auto& id :
+       std::vector{child_1_id, child_3_id, child_4_id, parent_id}) {
+    CHECK(
+        ActionTesting::is_simple_action_queue_empty<my_component>(runner, id));
+  }
+  CHECK(ActionTesting::number_of_queued_simple_actions<my_component>(
+            runner, child_2_id) == 1);
+
+  ActionTesting::invoke_queued_simple_action<my_component>(
+      make_not_null(&runner), child_2_id);
+  for (const auto& id :
+       std::vector{child_1_id, child_2_id, child_4_id, parent_id}) {
+    CHECK(
+        ActionTesting::is_simple_action_queue_empty<my_component>(runner, id));
+  }
+  CHECK(ActionTesting::number_of_queued_simple_actions<my_component>(
+            runner, child_3_id) == 1);
+
+  ActionTesting::invoke_queued_simple_action<my_component>(
+      make_not_null(&runner), child_3_id);
+  for (const auto& id :
+       std::vector{child_1_id, child_2_id, child_3_id, parent_id}) {
+    CHECK(
+        ActionTesting::is_simple_action_queue_empty<my_component>(runner, id));
+  }
+  CHECK(ActionTesting::number_of_queued_simple_actions<my_component>(
+            runner, child_4_id) == 1);
+
+  ActionTesting::invoke_queued_simple_action<my_component>(
+      make_not_null(&runner), child_4_id);
+  for (const auto& id :
+       std::vector{child_1_id, child_2_id, child_3_id, child_4_id}) {
+    CHECK(
+        ActionTesting::is_simple_action_queue_empty<my_component>(runner, id));
+  }
+  CHECK(ActionTesting::number_of_queued_simple_actions<my_component>(
+            runner, parent_id) == 1);
+
+  ActionTesting::invoke_queued_simple_action<my_component>(
+      make_not_null(&runner), parent_id);
+  for (const auto& id :
+       std::vector{child_1_id, child_2_id, child_3_id, child_4_id, parent_id}) {
+    CHECK(
+        ActionTesting::is_simple_action_queue_empty<my_component>(runner, id));
+  }
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Amr.Actions.CollectDataFromChildren",
+                  "[Unit][ParallelAlgorithms]") {
+  test();
+}

--- a/tests/Unit/ParallelAlgorithms/Amr/Actions/Test_CreateParent.cpp
+++ b/tests/Unit/ParallelAlgorithms/Amr/Actions/Test_CreateParent.cpp
@@ -1,0 +1,115 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <deque>
+#include <pup.h>
+#include <vector>
+
+#include "Domain/Structure/ElementId.hpp"
+#include "Domain/Structure/SegmentId.hpp"
+#include "Framework/ActionTesting.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "Parallel/Phase.hpp"
+#include "Parallel/PhaseDependentActionList.hpp"
+#include "ParallelAlgorithms/Amr/Actions/CollectDataFromChildren.hpp"
+#include "ParallelAlgorithms/Amr/Actions/CreateParent.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+
+struct MockCollectDataFromChildren {
+  template <typename ParallelComponent, typename DataBox,
+            typename Metavariables, typename... Tags>
+  static void apply(
+      DataBox& /*box*/, Parallel::GlobalCache<Metavariables>& /*cache*/,
+      const ElementId<Metavariables::volume_dim>& /*child_id*/,
+      const ElementId<Metavariables::volume_dim>& parent_id,
+      std::deque<ElementId<Metavariables::volume_dim>> sibling_ids_to_collect) {
+    CHECK(parent_id == ElementId<1>{0, std::array{SegmentId{2, 1}}});
+    CHECK(sibling_ids_to_collect ==
+          std::deque{ElementId<1>{0, std::array{SegmentId{3, 3}}}});
+  }
+};
+
+template <typename Metavariables>
+struct ArrayComponent {
+  using metavariables = Metavariables;
+  static constexpr size_t volume_dim = Metavariables::volume_dim;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = ElementId<volume_dim>;
+  using const_global_cache_tags = tmpl::list<>;
+  using simple_tags = tmpl::list<>;
+  using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
+      Parallel::Phase::Initialization,
+      tmpl::list<ActionTesting::InitializeDataBox<simple_tags>>>>;
+  using replace_these_simple_actions =
+      tmpl::list<amr::Actions::CollectDataFromChildren>;
+  using with_these_simple_actions = tmpl::list<MockCollectDataFromChildren>;
+};
+
+template <typename Metavariables>
+struct SingletonComponent {
+  using metavariables = Metavariables;
+  using array_index = int;
+  static constexpr size_t volume_dim = Metavariables::volume_dim;
+  using chare_type = ActionTesting::MockSingletonChare;
+  using const_global_cache_tags = tmpl::list<>;
+  using simple_tags = tmpl::list<>;
+  using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
+      Parallel::Phase::Initialization,
+      tmpl::list<ActionTesting::InitializeDataBox<simple_tags>>>>;
+};
+
+struct Metavariables {
+  static constexpr size_t volume_dim = 1;
+  using component_list = tmpl::list<ArrayComponent<Metavariables>,
+                                    SingletonComponent<Metavariables>>;
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& /*p*/) {}
+};
+
+void test() {
+  using array_component = ArrayComponent<Metavariables>;
+  using singleton_component = SingletonComponent<Metavariables>;
+  const ElementId<1> lower_child_id{0, std::array{SegmentId{3, 2}}};
+  const ElementId<1> upper_child_id{0, std::array{SegmentId{3, 3}}};
+  const ElementId<1> parent_id{0, std::array{SegmentId{2, 1}}};
+
+  ActionTesting::MockRuntimeSystem<Metavariables> runner{{}};
+  ActionTesting::emplace_component<singleton_component>(&runner, 0);
+  for (const auto& id :
+       std::vector{lower_child_id, upper_child_id, parent_id}) {
+    ActionTesting::emplace_component<array_component>(&runner, id);
+    CHECK(ActionTesting::is_simple_action_queue_empty<array_component>(runner,
+                                                                       id));
+  }
+  CHECK(ActionTesting::is_simple_action_queue_empty<singleton_component>(runner,
+                                                                         0));
+
+  auto& cache = ActionTesting::cache<array_component>(runner, parent_id);
+  auto& element_proxy =
+      Parallel::get_parallel_component<array_component>(cache);
+
+  ActionTesting::simple_action<singleton_component, amr::Actions::CreateParent>(
+      make_not_null(&runner), 0, element_proxy, parent_id, lower_child_id,
+      std::deque{upper_child_id});
+  for (const auto& id : std::vector{upper_child_id, parent_id}) {
+    CHECK(ActionTesting::is_simple_action_queue_empty<array_component>(runner,
+                                                                       id));
+  }
+  CHECK(ActionTesting::number_of_queued_simple_actions<array_component>(
+            runner, lower_child_id) == 1);
+  ActionTesting::invoke_queued_simple_action<array_component>(
+      make_not_null(&runner), lower_child_id);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Amr.Actions.CreateParent",
+                  "[Unit][ParallelAlgorithms]") {
+  test();
+}

--- a/tests/Unit/ParallelAlgorithms/Amr/Actions/Test_InitializeParent.cpp
+++ b/tests/Unit/ParallelAlgorithms/Amr/Actions/Test_InitializeParent.cpp
@@ -1,0 +1,290 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+
+#include "Domain/Amr/Tags/Flags.hpp"
+#include "Domain/Amr/Tags/NeighborFlags.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/DirectionMap.hpp"
+#include "Domain/Structure/Element.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Domain/Structure/Neighbors.hpp"
+#include "Domain/Structure/OrientationMap.hpp"
+#include "Domain/Structure/SegmentId.hpp"
+#include "Domain/Tags.hpp"
+#include "Framework/ActionTesting.hpp"
+#include "Framework/MockRuntimeSystem.hpp"
+#include "Framework/MockRuntimeSystemFreeFunctions.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "Parallel/Phase.hpp"
+#include "Parallel/PhaseDependentActionList.hpp"
+#include "ParallelAlgorithms/Amr/Actions/InitializeParent.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace {
+
+template <typename Metavariables>
+struct Component {
+  using metavariables = Metavariables;
+  static constexpr size_t volume_dim = Metavariables::volume_dim;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = ElementId<volume_dim>;
+  using const_global_cache_tags = tmpl::list<>;
+  using simple_tags =
+      tmpl::list<domain::Tags::Element<volume_dim>,
+                 domain::Tags::Mesh<volume_dim>, amr::Tags::Flags<volume_dim>,
+                 amr::Tags::NeighborFlags<volume_dim>>;
+  using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
+      Parallel::Phase::Initialization,
+      tmpl::list<ActionTesting::InitializeDataBox<simple_tags>>>>;
+};
+
+struct Metavariables {
+  static constexpr size_t volume_dim = 3;
+  using component_list = tmpl::list<Component<Metavariables>>;
+};
+
+// Test setup showing xi and eta dimensions which are hp-refined; only
+// p-refinement in zeta dimension
+
+// Before refinement:                     After refinement:
+//
+//       |-----------|                         |-----------|
+//       |           |                         |           |
+//       |    N5     |                         |    N5     |
+//       |           |                         |           |
+// |-----|-----------|-----------|       |-----|-----------|-----------|
+// |     |           |           |       |     |           |           |
+// |  N6 |    C3     |           |       |  N6 |           |    N11    |
+// |     |           |           |       |     |           |           |
+// |--|--|-----|-----|    N4     |       |-----|     P     |-----------|
+//    |N7|     |     |           |       |     |           |           |
+//    |--|  C1 |  C2 |           |       | N12 |           |    N10    |
+//    |N8|     |     |           |       |     |           |           |
+//    |--|--|--|-----|-----------|       |-----|--|--|-----|-----------|
+//       |  |  |     |                         |     |     |
+//       |N1|N2|  N3 |                         |  N9 |  N3 |
+//       |  |  |     |                         |     |     |
+//       |-----|-----|                         |-----|-----|
+//
+// Block setup is:
+// Elements C1, C2, and C3 are in Block 0
+// Element N4 is in Block 1 which is aligned with Block 0
+// Element N5 is in Block 2 which is rotated by 90 degrees counter clockwise
+// Elments N6, N7, and N8 are in Block 3 which is anti-aligned with Block 0
+// Elements N1, N2, and N3 are in Block 4 which is rotated 90 deg. clockwise
+void test() {
+  using my_component = Component<Metavariables>;
+
+  OrientationMap<3> aligned{};
+  OrientationMap<3> b1_orientation{};
+  OrientationMap<3> b2_orientation{std::array{Direction<3>::lower_eta(),
+                                              Direction<3>::upper_xi(),
+                                              Direction<3>::upper_zeta()}};
+  OrientationMap<3> b3_orientation{std::array{Direction<3>::lower_xi(),
+                                              Direction<3>::lower_eta(),
+                                              Direction<3>::upper_zeta()}};
+  OrientationMap<3> b4_orientation{std::array{Direction<3>::upper_eta(),
+                                              Direction<3>::lower_xi(),
+                                              Direction<3>::upper_zeta()}};
+
+  SegmentId s_00{0, 0};
+  SegmentId s_10{1, 0};
+  SegmentId s_11{1, 1};
+  SegmentId s_20{2, 0};
+  SegmentId s_21{2, 1};
+  SegmentId s_22{2, 2};
+  SegmentId s_23{2, 3};
+
+  const ElementId<3> parent_id{0, std::array{s_00, s_00, s_00}};
+
+  const ElementId<3> child_1_id{0, std::array{s_10, s_10, s_00}};
+  const ElementId<3> child_2_id{0, std::array{s_11, s_10, s_00}};
+  const ElementId<3> child_3_id{0, std::array{s_00, s_11, s_00}};
+
+  const ElementId<3> neighbor_1_id{4, std::array{s_10, s_20, s_00}};
+  const ElementId<3> neighbor_2_id{4, std::array{s_10, s_21, s_00}};
+  const ElementId<3> neighbor_3_id{4, std::array{s_10, s_11, s_00}};
+  const ElementId<3> neighbor_9_id{4, std::array{s_10, s_10, s_00}};
+
+  const ElementId<3> neighbor_4_id{1, std::array{s_00, s_00, s_00}};
+  const ElementId<3> neighbor_10_id{1, std::array{s_00, s_10, s_00}};
+  const ElementId<3> neighbor_11_id{1, std::array{s_00, s_11, s_00}};
+
+  const ElementId<3> neighbor_5_id{2, std::array{s_10, s_00, s_00}};
+
+  const ElementId<3> neighbor_6_id{3, std::array{s_10, s_10, s_00}};
+  const ElementId<3> neighbor_7_id{3, std::array{s_20, s_22, s_00}};
+  const ElementId<3> neighbor_8_id{3, std::array{s_20, s_23, s_00}};
+  const ElementId<3> neighbor_12_id{3, std::array{s_10, s_11, s_00}};
+
+  DirectionMap<3, Neighbors<3>> child_1_neighbors{};
+  child_1_neighbors.emplace(
+      Direction<3>::lower_xi(),
+      Neighbors<3>{std::unordered_set{neighbor_8_id, neighbor_7_id},
+                   b3_orientation});
+  child_1_neighbors.emplace(
+      Direction<3>::upper_xi(),
+      Neighbors<3>{std::unordered_set{child_2_id}, aligned});
+  child_1_neighbors.emplace(
+      Direction<3>::lower_eta(),
+      Neighbors<3>{std::unordered_set{neighbor_1_id, neighbor_2_id},
+                   b4_orientation});
+  child_1_neighbors.emplace(
+      Direction<3>::upper_eta(),
+      Neighbors<3>{std::unordered_set{child_3_id}, aligned});
+  Element<3> child_1{child_1_id, std::move(child_1_neighbors)};
+  Mesh<3> child_1_mesh{std::array{3_st, 4_st, 3_st}, Spectral::Basis::Legendre,
+                       Spectral::Quadrature::GaussLobatto};
+  std::array child_1_flags{amr::Flag::Join, amr::Flag::Join,
+                           amr::Flag::IncreaseResolution};
+
+  DirectionMap<3, Neighbors<3>> child_2_neighbors{};
+  child_2_neighbors.emplace(
+      Direction<3>::lower_xi(),
+      Neighbors<3>{std::unordered_set{child_1_id}, aligned});
+  child_2_neighbors.emplace(
+      Direction<3>::upper_xi(),
+      Neighbors<3>{std::unordered_set{neighbor_4_id}, b1_orientation});
+  child_2_neighbors.emplace(
+      Direction<3>::lower_eta(),
+      Neighbors<3>{std::unordered_set{neighbor_3_id}, b4_orientation});
+  child_2_neighbors.emplace(
+      Direction<3>::upper_eta(),
+      Neighbors<3>{std::unordered_set{child_3_id}, aligned});
+  Element<3> child_2{child_2_id, std::move(child_2_neighbors)};
+  Mesh<3> child_2_mesh{std::array{4_st, 3_st, 4_st}, Spectral::Basis::Legendre,
+                       Spectral::Quadrature::GaussLobatto};
+  std::array child_2_flags{amr::Flag::Join, amr::Flag::Join,
+                           amr::Flag::DecreaseResolution};
+
+  DirectionMap<3, Neighbors<3>> child_3_neighbors{};
+  child_3_neighbors.emplace(
+      Direction<3>::lower_xi(),
+      Neighbors<3>{std::unordered_set{neighbor_6_id}, b3_orientation});
+  child_3_neighbors.emplace(
+      Direction<3>::upper_xi(),
+      Neighbors<3>{std::unordered_set{neighbor_4_id}, b1_orientation});
+  child_3_neighbors.emplace(
+      Direction<3>::lower_eta(),
+      Neighbors<3>{std::unordered_set{child_2_id, child_1_id}, aligned});
+  child_3_neighbors.emplace(
+      Direction<3>::upper_eta(),
+      Neighbors<3>{std::unordered_set{neighbor_5_id}, b2_orientation});
+  Element<3> child_3{child_3_id, std::move(child_3_neighbors)};
+  Mesh<3> child_3_mesh{std::array{4_st, 4_st, 3_st}, Spectral::Basis::Legendre,
+                       Spectral::Quadrature::GaussLobatto};
+  std::array child_3_flags{amr::Flag::DecreaseResolution, amr::Flag::Join,
+                           amr::Flag::IncreaseResolution};
+
+  std::unordered_map<ElementId<3>, std::array<amr::Flag, 3>>
+      child_1_neighbor_flags{
+          {neighbor_1_id,
+           {{amr::Flag::DoNothing, amr::Flag::Join, amr::Flag::DoNothing}}},
+          {neighbor_2_id,
+           {{amr::Flag::DoNothing, amr::Flag::Join, amr::Flag::DoNothing}}},
+          {child_2_id, child_2_flags},
+          {child_3_id, child_3_flags},
+          {neighbor_7_id,
+           {{amr::Flag::Join, amr::Flag::Join, amr::Flag::DoNothing}}},
+          {neighbor_8_id,
+           {{amr::Flag::Join, amr::Flag::Join, amr::Flag::DoNothing}}}};
+  std::unordered_map<ElementId<3>, std::array<amr::Flag, 3>>
+      child_2_neighbor_flags{
+          {neighbor_3_id,
+           {{amr::Flag::DoNothing, amr::Flag::DoNothing,
+             amr::Flag::DoNothing}}},
+          {neighbor_4_id,
+           {{amr::Flag::DoNothing, amr::Flag::Split, amr::Flag::DoNothing}}},
+          {child_2_id, child_2_flags},
+          {child_1_id, child_1_flags}};
+  std::unordered_map<ElementId<3>, std::array<amr::Flag, 3>>
+      child_3_neighbor_flags{
+          {child_1_id, child_1_flags},
+          {child_2_id, child_2_flags},
+          {neighbor_4_id,
+           {{amr::Flag::DoNothing, amr::Flag::Split, amr::Flag::DoNothing}}},
+          {neighbor_5_id,
+           {{amr::Flag::DoNothing, amr::Flag::DoNothing,
+             amr::Flag::DoNothing}}},
+          {neighbor_6_id,
+           {{amr::Flag::DoNothing, amr::Flag::DoNothing,
+             amr::Flag::DoNothing}}}};
+
+  using TaggedTupleType =
+      tuples::TaggedTuple<Parallel::Tags::MetavariablesImpl<Metavariables>,
+                          Parallel::Tags::ArrayIndexImpl<ElementId<3>>,
+                          Parallel::Tags::GlobalCacheImpl<Metavariables>,
+                          domain::Tags::Element<3>, domain::Tags::Mesh<3>,
+                          amr::Tags::Flags<3>, amr::Tags::NeighborFlags<3>>;
+  std::unordered_map<ElementId<3>, TaggedTupleType> children_items;
+  children_items.emplace(
+      child_1_id,
+      TaggedTupleType{Metavariables{}, child_1_id, nullptr, std::move(child_1),
+                      std::move(child_1_mesh), std::move(child_1_flags),
+                      std::move(child_1_neighbor_flags)});
+  children_items.emplace(
+      child_2_id,
+      TaggedTupleType{Metavariables{}, child_2_id, nullptr, std::move(child_2),
+                      std::move(child_2_mesh), std::move(child_2_flags),
+                      std::move(child_2_neighbor_flags)});
+  children_items.emplace(
+      child_3_id,
+      TaggedTupleType{Metavariables{}, child_3_id, nullptr, std::move(child_3),
+                      std::move(child_3_mesh), std::move(child_3_flags),
+                      std::move(child_3_neighbor_flags)});
+
+  DirectionMap<3, Neighbors<3>> expected_parent_neighbors{};
+  expected_parent_neighbors.emplace(
+      Direction<3>::lower_xi(),
+      Neighbors<3>{std::unordered_set{neighbor_12_id, neighbor_6_id},
+                   b3_orientation});
+  expected_parent_neighbors.emplace(
+      Direction<3>::upper_xi(),
+      Neighbors<3>{std::unordered_set{neighbor_10_id, neighbor_11_id},
+                   b1_orientation});
+  expected_parent_neighbors.emplace(
+      Direction<3>::lower_eta(),
+      Neighbors<3>{std::unordered_set{neighbor_9_id, neighbor_3_id},
+                   b4_orientation});
+  expected_parent_neighbors.emplace(
+      Direction<3>::upper_eta(),
+      Neighbors<3>{std::unordered_set{neighbor_5_id}, b2_orientation});
+  Element<3> expected_parent{parent_id, std::move(expected_parent_neighbors)};
+
+  const Mesh<3> expected_parent_mesh{4, Spectral::Basis::Legendre,
+                                     Spectral::Quadrature::GaussLobatto};
+  const std::array expected_parent_flags{
+      amr::Flag::Undefined, amr::Flag::Undefined, amr::Flag::Undefined};
+  const std::unordered_map<ElementId<3>, std::array<amr::Flag, 3>>
+      expected_parent_neighbor_flags{};
+
+  ActionTesting::MockRuntimeSystem<Metavariables> runner{{}};
+  ActionTesting::emplace_component<my_component>(&runner, parent_id);
+  ActionTesting::simple_action<my_component, amr::Actions::InitializeParent>(
+      make_not_null(&runner), parent_id, children_items);
+  CHECK(ActionTesting::get_databox_tag<my_component, domain::Tags::Element<3>>(
+            runner, parent_id) == expected_parent);
+  CHECK(ActionTesting::get_databox_tag<my_component, domain::Tags::Mesh<3>>(
+            runner, parent_id) == expected_parent_mesh);
+  CHECK(ActionTesting::get_databox_tag<my_component, amr::Tags::Flags<3>>(
+            runner, parent_id) == expected_parent_flags);
+  CHECK(
+      ActionTesting::get_databox_tag<my_component, amr::Tags::NeighborFlags<3>>(
+          runner, parent_id) == expected_parent_neighbor_flags);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Amr.Actions.InitializeParent",
+                  "[Unit][ParallelAlgorithms]") {
+  test();
+}

--- a/tests/Unit/ParallelAlgorithms/Amr/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/Amr/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY "Test_ParallelAmr")
 
 set(LIBRARY_SOURCES
+  Actions/Test_AdjustDomain.cpp
   Actions/Test_CollectDataFromChildren.cpp
   Actions/Test_CreateChild.cpp
   Actions/Test_CreateParent.cpp

--- a/tests/Unit/ParallelAlgorithms/Amr/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/Amr/CMakeLists.txt
@@ -4,7 +4,9 @@
 set(LIBRARY "Test_ParallelAmr")
 
 set(LIBRARY_SOURCES
+  Actions/Test_CollectDataFromChildren.cpp
   Actions/Test_CreateChild.cpp
+  Actions/Test_CreateParent.cpp
   Actions/Test_EvaluateRefinementCriteria.cpp
   Actions/Test_Initialize.cpp
   Actions/Test_InitializeChild.cpp

--- a/tests/Unit/ParallelAlgorithms/Amr/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/Amr/CMakeLists.txt
@@ -8,6 +8,7 @@ set(LIBRARY_SOURCES
   Actions/Test_EvaluateRefinementCriteria.cpp
   Actions/Test_Initialize.cpp
   Actions/Test_InitializeChild.cpp
+  Actions/Test_InitializeParent.cpp
   Actions/Test_SendDataToChildren.cpp
   Actions/Test_UpdateAmrDecision.cpp
   Criteria/Test_Criterion.cpp


### PR DESCRIPTION
## Proposed changes

- Adds an action that initializes the data on a new element created when joining multiple existing elements.  Currently, only the Element and Mesh are initialized, which is sufficient to test the infrastructure of AMR.
- Adds an action that collects the data from the existing elements that are being joined and sends them to the new element, as well as deleting the elements that have joined
- Adds an action that creates the new element when joining existing elements
- Adds an action that given the refinement flags for an element, will either call the AMR actions for creating new elements if the element wants to join or split (h-refinement), updates the Mesh if the element wants to change the number of grid points (p-refinement), and updates the Element based on the refinement flags of its neighbors.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

After this PR is merged:
- I will update `Executables/Examples/RandomAmr` which can be used to test all the AMR actions on an arbitrary Domain using random refinement.
- I will add mutators and projectors which will update the data used by an evolution system starting with scalar waves
