### PR TITLE
Add debug prints to control system

### DIFF
--- a/src/ControlSystem/Actions/Initialization.hpp
+++ b/src/ControlSystem/Actions/Initialization.hpp
@@ -46,6 +46,7 @@ struct get_center_tags<domain::object_list<>> {
  *   - `control_system::Tags::MeasurementTimescales`
  *   - `control_system::Tags::WriteDataToDisk`
  *   - `control_system::Tags::ObserveCenters`
+ *   - `control_system::Tags::Verbosity`
  *   - `domain::Tags::ExcisionCenter<domain::ObjectLabel::A>`
  *   - `domain::Tags::ExcisionCenter<domain::ObjectLabel::B>`
  *
@@ -80,7 +81,7 @@ struct Initialize {
   using const_global_cache_tags = tmpl::flatten<tmpl::list<
       control_system::Tags::MeasurementsPerUpdate,
       control_system::Tags::WriteDataToDisk,
-      control_system::Tags::ObserveCenters,
+      control_system::Tags::ObserveCenters, control_system::Tags::Verbosity,
       typename detail::get_center_tags<
           typename ControlSystem::control_error::object_centers>::type>>;
 

--- a/src/ControlSystem/CMakeLists.txt
+++ b/src/ControlSystem/CMakeLists.txt
@@ -47,6 +47,7 @@ target_link_libraries(
   ErrorHandling
   FiniteDifference
   FunctionsOfTime
+  Logging
   Serialization
   INTERFACE
   Observer

--- a/src/ControlSystem/Measurements/BNSCenterOfMass.hpp
+++ b/src/ControlSystem/Measurements/BNSCenterOfMass.hpp
@@ -90,6 +90,7 @@ void center_of_mass_integral_on_element(
 /// center of mass of the two neutron stars in a BNS merger).
 struct BothNSCenters : tt::ConformsTo<protocols::Measurement> {
   struct FindTwoCenters : tt::ConformsTo<protocols::Submeasurement> {
+    static std::string name() { return "BothNSCenters::FindTwoCenters"; }
     /// Unused tag needed to conform to the submeasurement protocol.
     template <typename ControlSystems>
     using interpolation_target_tag = void;

--- a/src/ControlSystem/Measurements/BothHorizons.hpp
+++ b/src/ControlSystem/Measurements/BothHorizons.hpp
@@ -55,6 +55,10 @@ struct BothHorizons : tt::ConformsTo<protocols::Measurement> {
    */
   template <::domain::ObjectLabel Horizon>
   struct FindHorizon : tt::ConformsTo<protocols::Submeasurement> {
+    static std::string name() {
+      return "BothHorizons::FindHorizon" + ::domain::name(Horizon);
+    }
+
    private:
     template <typename ControlSystems>
     struct InterpolationTarget

--- a/src/ControlSystem/Measurements/CharSpeed.hpp
+++ b/src/ControlSystem/Measurements/CharSpeed.hpp
@@ -54,6 +54,8 @@ namespace control_system::measurements {
  */
 template <::domain::ObjectLabel Object>
 struct CharSpeed : tt::ConformsTo<protocols::Measurement> {
+  static std::string name() { return "CharSpeed" + ::domain::name(Object); }
+
   /*!
    * \brief A `control_system::protocols::Submeasurement` that does an
    * interpolation to the excision boundary for this `Object` from the elements.
@@ -61,6 +63,8 @@ struct CharSpeed : tt::ConformsTo<protocols::Measurement> {
    * This does not go through the interpolation framework.
    */
   struct Excision : tt::ConformsTo<protocols::Submeasurement> {
+    static std::string name() { return CharSpeed::name() + "::Excision"; }
+
    private:
     template <typename ControlSystems>
     struct InterpolationTarget
@@ -136,6 +140,8 @@ struct CharSpeed : tt::ConformsTo<protocols::Measurement> {
    * horizon.
    */
   struct Horizon : tt::ConformsTo<protocols::Submeasurement> {
+    static std::string name() { return CharSpeed::name() + "::Horizon"; }
+
    private:
     template <typename ControlSystems>
     struct InterpolationTarget

--- a/src/ControlSystem/Measurements/SingleHorizon.hpp
+++ b/src/ControlSystem/Measurements/SingleHorizon.hpp
@@ -48,12 +48,18 @@ namespace control_system::measurements {
  */
 template <::domain::ObjectLabel Horizon>
 struct SingleHorizon : tt::ConformsTo<protocols::Measurement> {
+  static std::string name() {
+    return "SingleHorizon" + ::domain::name(Horizon);
+  }
+
   /*!
    * \brief A `control_system::protocols::Submeasurement` that starts the
    * interpolation to the interpolation target in order to find the apparent
    * horizon.
    */
   struct Submeasurement : tt::ConformsTo<protocols::Submeasurement> {
+    static std::string name() { return SingleHorizon::name(); }
+
    private:
     template <typename ControlSystems>
     struct InterpolationTarget

--- a/src/ControlSystem/RunCallbacks.hpp
+++ b/src/ControlSystem/RunCallbacks.hpp
@@ -9,7 +9,10 @@
 #include "ControlSystem/Protocols/Submeasurement.hpp"
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/LinkedMessageId.hpp"
+#include "IO/Logging/Verbosity.hpp"
+#include "Parallel/Printf.hpp"
 #include "ParallelAlgorithms/Interpolation/Protocols/PostInterpolationCallback.hpp"
+#include "Utilities/PrettyType.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -18,6 +21,9 @@ namespace Parallel {
 template <typename Metavariables>
 class GlobalCache;
 }  // namespace Parallel
+namespace control_system::Tags {
+struct Verbosity;
+}  // namespace control_system::Tags
 /// \endcond
 
 namespace control_system {
@@ -62,6 +68,14 @@ struct RunCallbacks
               },
               box);
         });
+
+    if (Parallel::get<Tags::Verbosity>(cache) >= ::Verbosity::Verbose) {
+      Parallel::printf(
+          "time = %.16f: For the '%s' measurement, calling process_measurement "
+          "for the following control systems: (%s).\n",
+          measurement_id.id, pretty_type::name<Submeasurement>(),
+          pretty_type::list_of_names<ControlSystems>());
+    }
   }
 };
 }  // namespace control_system

--- a/src/ControlSystem/Systems/Expansion.hpp
+++ b/src/ControlSystem/Systems/Expansion.hpp
@@ -106,7 +106,7 @@ struct Expansion : tt::ConformsTo<protocols::ControlSystem> {
 
     template <::domain::ObjectLabel Horizon, typename Metavariables>
     static void apply(
-        measurements::BothHorizons::FindHorizon<Horizon> /*meta*/,
+        measurements::BothHorizons::FindHorizon<Horizon> submeasurement,
         const Strahlkorper<Frame::Distorted>& horizon_strahlkorper,
         Parallel::GlobalCache<Metavariables>& cache,
         const LinkedMessageId<double>& measurement_id) {
@@ -121,14 +121,21 @@ struct Expansion : tt::ConformsTo<protocols::ControlSystem> {
           QueueTags::Center<Horizon>, MeasurementQueue,
           UpdateControlSystem<Expansion>>>(control_sys_proxy, measurement_id,
                                            center);
+
+      if (Parallel::get<Tags::Verbosity>(cache) >= ::Verbosity::Verbose) {
+        Parallel::printf("%s, time = %.16f: Received measurement '%s'.\n",
+                         name(), measurement_id.id,
+                         pretty_type::name(submeasurement));
+      }
     }
 
     template <typename Metavariables>
-    static void apply(measurements::BothNSCenters::FindTwoCenters /*meta*/,
-                      const std::array<double, 3> center_a,
-                      const std::array<double, 3> center_b,
-                      Parallel::GlobalCache<Metavariables>& cache,
-                      const LinkedMessageId<double>& measurement_id) {
+    static void apply(
+        measurements::BothNSCenters::FindTwoCenters submeasurement,
+        const std::array<double, 3> center_a,
+        const std::array<double, 3> center_b,
+        Parallel::GlobalCache<Metavariables>& cache,
+        const LinkedMessageId<double>& measurement_id) {
       auto& control_sys_proxy = Parallel::get_parallel_component<
           ControlComponent<Metavariables, Expansion<DerivOrder, Measurement>>>(
           cache);
@@ -143,6 +150,12 @@ struct Expansion : tt::ConformsTo<protocols::ControlSystem> {
           QueueTags::Center<::domain::ObjectLabel::B>, MeasurementQueue,
           UpdateControlSystem<Expansion>>>(control_sys_proxy, measurement_id,
                                            center_b_dv);
+
+      if (Parallel::get<Tags::Verbosity>(cache) >= ::Verbosity::Verbose) {
+        Parallel::printf("%s, time = %.16f: Received measurement '%s'.\n",
+                         name(), measurement_id.id,
+                         pretty_type::name(submeasurement));
+      }
     }
   };
 };

--- a/src/ControlSystem/Systems/Rotation.hpp
+++ b/src/ControlSystem/Systems/Rotation.hpp
@@ -111,10 +111,11 @@ struct Rotation : tt::ConformsTo<protocols::ControlSystem> {
         tmpl::list<StrahlkorperTags::Strahlkorper<Frame::Distorted>>>;
 
     template <::domain::ObjectLabel Horizon, typename Metavariables>
-    static void apply(measurements::BothHorizons::FindHorizon<Horizon> /*meta*/,
-                      const Strahlkorper<Frame::Distorted>& strahlkorper,
-                      Parallel::GlobalCache<Metavariables>& cache,
-                      const LinkedMessageId<double>& measurement_id) {
+    static void apply(
+        measurements::BothHorizons::FindHorizon<Horizon> submeasurement,
+        const Strahlkorper<Frame::Distorted>& strahlkorper,
+        Parallel::GlobalCache<Metavariables>& cache,
+        const LinkedMessageId<double>& measurement_id) {
       auto& control_sys_proxy = Parallel::get_parallel_component<
           ControlComponent<Metavariables, Rotation<DerivOrder, Measurement>>>(
           cache);
@@ -126,14 +127,21 @@ struct Rotation : tt::ConformsTo<protocols::ControlSystem> {
           QueueTags::Center<Horizon>, MeasurementQueue,
           UpdateControlSystem<Rotation>>>(control_sys_proxy, measurement_id,
                                           center);
+
+      if (Parallel::get<Tags::Verbosity>(cache) >= ::Verbosity::Verbose) {
+        Parallel::printf("%s, time = %.16f: Received measurement '%s'.\n",
+                         name(), measurement_id.id,
+                         pretty_type::name(submeasurement));
+      }
     }
 
     template <typename Metavariables>
-    static void apply(measurements::BothNSCenters::FindTwoCenters /*meta*/,
-                      const std::array<double, 3> center_a,
-                      const std::array<double, 3> center_b,
-                      Parallel::GlobalCache<Metavariables>& cache,
-                      const LinkedMessageId<double>& measurement_id) {
+    static void apply(
+        measurements::BothNSCenters::FindTwoCenters submeasurement,
+        const std::array<double, 3> center_a,
+        const std::array<double, 3> center_b,
+        Parallel::GlobalCache<Metavariables>& cache,
+        const LinkedMessageId<double>& measurement_id) {
       auto& control_sys_proxy = Parallel::get_parallel_component<
           ControlComponent<Metavariables, Rotation<DerivOrder, Measurement>>>(
           cache);
@@ -148,6 +156,12 @@ struct Rotation : tt::ConformsTo<protocols::ControlSystem> {
           QueueTags::Center<::domain::ObjectLabel::B>, MeasurementQueue,
           UpdateControlSystem<Rotation>>>(control_sys_proxy, measurement_id,
                                           center_b_dv);
+
+      if (Parallel::get<Tags::Verbosity>(cache) >= ::Verbosity::Verbose) {
+        Parallel::printf("%s, time = %.16f: Received measurement '%s'.\n",
+                         name(), measurement_id.id,
+                         pretty_type::name(submeasurement));
+      }
     }
   };
 };

--- a/src/ControlSystem/Systems/Shape.hpp
+++ b/src/ControlSystem/Systems/Shape.hpp
@@ -110,11 +110,11 @@ struct Shape : tt::ConformsTo<protocols::ControlSystem> {
         tmpl::list<StrahlkorperTags::Strahlkorper<Frame::Distorted>>;
 
     template <typename Metavariables>
-    static void apply(
-        typename measurements::SingleHorizon<Horizon>::Submeasurement /*meta*/,
-        const Strahlkorper<Frame::Distorted>& strahlkorper,
-        Parallel::GlobalCache<Metavariables>& cache,
-        const LinkedMessageId<double>& measurement_id) {
+    static void apply(typename measurements::SingleHorizon<
+                          Horizon>::Submeasurement submeasurement,
+                      const Strahlkorper<Frame::Distorted>& strahlkorper,
+                      Parallel::GlobalCache<Metavariables>& cache,
+                      const LinkedMessageId<double>& measurement_id) {
       auto& control_sys_proxy = Parallel::get_parallel_component<
           ControlComponent<Metavariables, Shape>>(cache);
 
@@ -122,11 +122,17 @@ struct Shape : tt::ConformsTo<protocols::ControlSystem> {
           QueueTags::Strahlkorper<Frame::Distorted>, MeasurementQueue,
           UpdateControlSystem<Shape>>>(control_sys_proxy, measurement_id,
                                        strahlkorper);
+
+      if (Parallel::get<Tags::Verbosity>(cache) >= ::Verbosity::Verbose) {
+        Parallel::printf("%s, time = %.16f: Received measurement '%s'.\n",
+                         name(), measurement_id.id,
+                         pretty_type::name(submeasurement));
+      }
     }
 
     template <::domain::ObjectLabel MeasureHorizon, typename Metavariables>
     static void apply(
-        measurements::BothHorizons::FindHorizon<MeasureHorizon> /*meta*/,
+        measurements::BothHorizons::FindHorizon<MeasureHorizon> submeasurement,
         const Strahlkorper<Frame::Distorted>& strahlkorper,
         Parallel::GlobalCache<Metavariables>& cache,
         const LinkedMessageId<double>& measurement_id) {
@@ -141,6 +147,12 @@ struct Shape : tt::ConformsTo<protocols::ControlSystem> {
             QueueTags::Strahlkorper<Frame::Distorted>, MeasurementQueue,
             UpdateControlSystem<Shape>>>(control_sys_proxy, measurement_id,
                                          strahlkorper);
+
+        if (Parallel::get<Tags::Verbosity>(cache) >= ::Verbosity::Verbose) {
+          Parallel::printf("%s, time = %.16f: Received measurement '%s'.\n",
+                           name(), measurement_id.id,
+                           pretty_type::name(submeasurement));
+        }
       } else {
         (void)strahlkorper;
         (void)cache;

--- a/src/ControlSystem/Systems/Translation.hpp
+++ b/src/ControlSystem/Systems/Translation.hpp
@@ -98,10 +98,11 @@ struct Translation : tt::ConformsTo<protocols::ControlSystem> {
         tmpl::list<StrahlkorperTags::Strahlkorper<Frame::Distorted>>>;
 
     template <::domain::ObjectLabel Horizon, typename Metavariables>
-    static void apply(measurements::BothHorizons::FindHorizon<Horizon> /*meta*/,
-                      const Strahlkorper<Frame::Distorted>& strahlkorper,
-                      Parallel::GlobalCache<Metavariables>& cache,
-                      const LinkedMessageId<double>& measurement_id) {
+    static void apply(
+        measurements::BothHorizons::FindHorizon<Horizon> submeasurement,
+        const Strahlkorper<Frame::Distorted>& strahlkorper,
+        Parallel::GlobalCache<Metavariables>& cache,
+        const LinkedMessageId<double>& measurement_id) {
       auto& control_sys_proxy =
           Parallel::get_parallel_component<ControlComponent<
               Metavariables, Translation<DerivOrder, Measurement>>>(cache);
@@ -113,14 +114,21 @@ struct Translation : tt::ConformsTo<protocols::ControlSystem> {
           QueueTags::Center<Horizon>, MeasurementQueue,
           UpdateControlSystem<Translation>>>(control_sys_proxy, measurement_id,
                                              center);
+
+      if (Parallel::get<Tags::Verbosity>(cache) >= ::Verbosity::Verbose) {
+        Parallel::printf("%s, time = %.16f: Received measurement '%s'.\n",
+                         name(), measurement_id.id,
+                         pretty_type::name(submeasurement));
+      }
     }
 
     template <typename Metavariables>
-    static void apply(measurements::BothNSCenters::FindTwoCenters /*meta*/,
-                      const std::array<double, 3> center_a,
-                      const std::array<double, 3> center_b,
-                      Parallel::GlobalCache<Metavariables>& cache,
-                      const LinkedMessageId<double>& measurement_id) {
+    static void apply(
+        measurements::BothNSCenters::FindTwoCenters submeasurement,
+        const std::array<double, 3> center_a,
+        const std::array<double, 3> center_b,
+        Parallel::GlobalCache<Metavariables>& cache,
+        const LinkedMessageId<double>& measurement_id) {
       auto& control_sys_proxy =
           Parallel::get_parallel_component<ControlComponent<
               Metavariables, Translation<DerivOrder, Measurement>>>(cache);
@@ -135,6 +143,12 @@ struct Translation : tt::ConformsTo<protocols::ControlSystem> {
           QueueTags::Center<::domain::ObjectLabel::B>, MeasurementQueue,
           UpdateControlSystem<Translation>>>(control_sys_proxy, measurement_id,
                                              center_b_dv);
+
+      if (Parallel::get<Tags::Verbosity>(cache) >= ::Verbosity::Verbose) {
+        Parallel::printf("%s, time = %.16f: Received measurement '%s'.\n",
+                         name(), measurement_id.id,
+                         pretty_type::name(submeasurement));
+      }
     }
   };
 };

--- a/src/ControlSystem/Tags/OptionTags.hpp
+++ b/src/ControlSystem/Tags/OptionTags.hpp
@@ -10,6 +10,7 @@
 #include "ControlSystem/Controller.hpp"
 #include "ControlSystem/Protocols/ControlSystem.hpp"
 #include "ControlSystem/TimescaleTuner.hpp"
+#include "IO/Logging/Verbosity.hpp"
 #include "Options/Options.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/TMPL.hpp"
@@ -148,6 +149,18 @@ struct MeasurementsPerUpdate {
       "How many AH measurements are to be done between control system "
       "updates."};
   static int lower_bound() { return 1; }
+  using group = ControlSystemGroup;
+};
+
+/// \ingroup OptionTagsGroup
+/// \ingroup ControlSystemGroup
+/// Verbosity tag for printing diagnostics about the control system algorithm.
+/// This does not control when data is written to disk.
+struct Verbosity {
+  using type = ::Verbosity;
+  static constexpr Options::String help = {
+      "Verbosity of control system algorithm. Determines verbosity for all "
+      "control systems."};
   using group = ControlSystemGroup;
 };
 }  // namespace OptionTags

--- a/src/ControlSystem/Tags/SystemTags.hpp
+++ b/src/ControlSystem/Tags/SystemTags.hpp
@@ -233,4 +233,18 @@ struct MeasurementsPerUpdate : db::SimpleTag {
 struct CurrentNumberOfMeasurements : db::SimpleTag {
   using type = int;
 };
+
+/// \ingroup DataBoxTagsGroup
+/// \ingroup ControlSystemGroup
+/// DataBox tag that holds the verbosity used to print info about the control
+/// system algorithm.
+struct Verbosity : db::SimpleTag {
+  using type = ::Verbosity;
+
+  using option_tags = tmpl::list<OptionTags::Verbosity>;
+  static constexpr bool pass_metavariables = false;
+  static type create_from_options(const ::Verbosity verbosity) {
+    return verbosity;
+  }
+};
 }  // namespace control_system::Tags

--- a/src/ControlSystem/UpdateControlSystem.hpp
+++ b/src/ControlSystem/UpdateControlSystem.hpp
@@ -20,7 +20,9 @@
 #include "DataStructures/LinkedMessageId.hpp"
 #include "Domain/FunctionsOfTime/Tags.hpp"
 #include "Domain/Tags.hpp"
+#include "IO/Logging/Verbosity.hpp"
 #include "Parallel/GlobalCache.hpp"
+#include "Parallel/Printf.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TaggedTuple.hpp"
 
@@ -123,6 +125,12 @@ struct UpdateControlSystem {
     const DataVector Q =
         control_error(cache, time, function_of_time_name, data);
 
+    if (Parallel::get<Tags::Verbosity>(cache) >= ::Verbosity::Verbose) {
+      Parallel::printf(
+          "%s, time = %.16f: current measurement = %d, control error = %s\n",
+          function_of_time_name, time, current_measurement, Q);
+    }
+
     // Update the averager. We do this for every measurement because we still
     // want the averager to be up-to-date even if we aren't updating at this
     // time
@@ -132,6 +140,11 @@ struct UpdateControlSystem {
     const auto& opt_avg_values = averager(time);
 
     if (not opt_avg_values.has_value()) {
+      if (Parallel::get<Tags::Verbosity>(cache) >= ::Verbosity::Verbose) {
+        Parallel::printf(
+            "%s, time = %.16f: Averager does not have enough data.\n",
+            function_of_time_name, time);
+      }
       return;
     }
 
@@ -153,6 +166,13 @@ struct UpdateControlSystem {
     // Begin step 5
     // Check if it is time to update
     if (current_measurement != measurements_per_update) {
+      if (Parallel::get<Tags::Verbosity>(cache) >= ::Verbosity::Verbose) {
+        Parallel::printf(
+            "%s, time = %.16f: current measurement = %d is not at "
+            "measurements_per_update = %s. Waiting for more data.\n",
+            function_of_time_name, time, current_measurement,
+            measurements_per_update);
+      }
       return;
     }
 
@@ -204,6 +224,23 @@ struct UpdateControlSystem {
     const double new_measurement_expiration_time = measurement_expiration_time(
         time, old_measurement_timescale, new_measurement_timescale,
         measurements_per_update);
+
+    if (Parallel::get<Tags::Verbosity>(cache) >= ::Verbosity::Verbose) {
+      Parallel::printf("%s, time = %.16f: Control signal = %s\n",
+                       function_of_time_name, time, control_signal);
+      Parallel::printf(
+          "%s, time = %.16f: Updating the functions of time.\n"
+          " min(old_measure_timescale) = %.16f\n"
+          " min(new_measure_timescale) = %.16f\n"
+          " old_measure_expr_time = %.16f\n"
+          " new_measure_expr_time = %.16f\n"
+          " old_function_expr_time = %.16f\n"
+          " new_function_expr_time = %.16f\n",
+          function_of_time_name, time, min(old_measurement_timescale),
+          min(new_measurement_timescale), current_measurement_expiration_time,
+          new_measurement_expiration_time, current_fot_expiration_time,
+          new_fot_expiration_time);
+    }
 
     Parallel::mutate<::domain::Tags::FunctionsOfTime, UpdateFunctionOfTime>(
         cache, function_of_time_name, current_fot_expiration_time,

--- a/src/Utilities/PrettyType.hpp
+++ b/src/Utilities/PrettyType.hpp
@@ -719,6 +719,7 @@ struct name_helper<T, std::void_t<decltype(T::name())>> {
 };
 }  // namespace detail
 
+/// @{
 /*!
  * \ingroup PrettyTypeGroup
  * \brief Return the result of the `name()` member of a class. If a class
@@ -732,4 +733,10 @@ template <typename T>
 std::string name() {
   return detail::name_helper<T>::name();
 }
+
+template <typename T>
+std::string name(const T& /*unused*/) {
+  return name<T>();
+}
+/// @}
 }  // namespace pretty_type

--- a/src/Utilities/PrettyType.hpp
+++ b/src/Utilities/PrettyType.hpp
@@ -739,4 +739,33 @@ std::string name(const T& /*unused*/) {
   return name<T>();
 }
 /// @}
+
+/*!
+ * \ingroup PrettyTypeGroup
+ * \brief Return a comma separated list of the `pretty_type::name` of every type
+ * in a `tmpl::list`.
+ *
+ * \note The `tmpl::list` must be flattened.
+ */
+template <typename List>
+std::string list_of_names() {
+  static_assert(tt::is_a_v<tmpl::list, List>);
+  std::stringstream ss{};
+  bool first_element = true;
+  tmpl::for_each<List>([&first_element, &ss](auto v) {
+    using type = tmpl::type_from<decltype(v)>;
+    static_assert(not tt::is_a_v<tmpl::list, type>,
+                  "The tmpl::list provided to pretty_type::list_of_names must "
+                  "be flattened.");
+    if (not first_element) {
+      ss << ", ";
+    } else {
+      first_element = false;
+    }
+
+    ss << pretty_type::name<type>();
+  });
+
+  return ss.str();
+}
 }  // namespace pretty_type

--- a/tests/InputFiles/GeneralizedHarmonic/BinaryBlackHole.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/BinaryBlackHole.yaml
@@ -292,6 +292,7 @@ Cce:
 ControlSystems:
   WriteDataToDisk: true
   MeasurementsPerUpdate: 4
+  Verbosity: Silent
   Expansion:
     IsActive: true
     Averager:

--- a/tests/InputFiles/GeneralizedHarmonic/CylindricalBinaryBlackHole.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/CylindricalBinaryBlackHole.yaml
@@ -252,6 +252,7 @@ Cce:
 ControlSystems:
   WriteDataToDisk: true
   MeasurementsPerUpdate: 4
+  Verbosity: Silent
   Expansion:
     IsActive: true
     Averager:

--- a/tests/Unit/ControlSystem/Actions/Test_InitializeMeasurements.cpp
+++ b/tests/Unit/ControlSystem/Actions/Test_InitializeMeasurements.cpp
@@ -17,6 +17,7 @@
 #include "ControlSystem/Protocols/ControlSystem.hpp"
 #include "ControlSystem/Protocols/Measurement.hpp"
 #include "ControlSystem/Protocols/Submeasurement.hpp"
+#include "ControlSystem/Tags/SystemTags.hpp"
 #include "ControlSystem/Trigger.hpp"
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataVector.hpp"
@@ -33,6 +34,7 @@
 #include "Framework/MockRuntimeSystem.hpp"
 #include "Framework/MockRuntimeSystemFreeFunctions.hpp"
 #include "Helpers/ControlSystem/TestStructs.hpp"
+#include "IO/Logging/Verbosity.hpp"
 #include "Options/Protocols/FactoryCreation.hpp"
 #include "Parallel/Phase.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
@@ -154,6 +156,7 @@ struct Component {
   using simple_tags = tmpl::list<Tags::TimeStepId, Tags::Time>;
   using compute_tags = tmpl::list<Parallel::Tags::FromGlobalCache<
       ::domain::Tags::FunctionsOfTimeInitialize>>;
+  using const_global_cache_tags = tmpl::list<control_system::Tags::Verbosity>;
   using mutable_global_cache_tags =
       tmpl::list<domain::Tags::FunctionsOfTimeInitialize>;
 
@@ -205,7 +208,8 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.InitializeMeasurements",
   functions.emplace("B", timescale->get_clone());
   functions.emplace("C", timescale->get_clone());
 
-  MockRuntimeSystem runner{{}, {std::move(functions), std::move(timescales)}};
+  MockRuntimeSystem runner{{::Verbosity::Silent},
+                           {std::move(functions), std::move(timescales)}};
   ActionTesting::emplace_array_component_and_initialize<component>(
       make_not_null(&runner), ActionTesting::NodeId{0},
       ActionTesting::LocalCoreId{0}, 0,

--- a/tests/Unit/ControlSystem/ControlErrors/Test_Expansion.cpp
+++ b/tests/Unit/ControlSystem/ControlErrors/Test_Expansion.cpp
@@ -82,10 +82,11 @@ void test_expansion_control_error() {
   // Setup runner and element component because it's the easiest way to get the
   // global cache
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<metavars>;
-  MockRuntimeSystem runner{{"DummyFileName", std::move(domain), 4, false,
-                            std::move(grid_center_A), std::move(grid_center_B)},
-                           {std::move(initial_functions_of_time),
-                            std::move(initial_measurement_timescales)}};
+  MockRuntimeSystem runner{
+      {"DummyFileName", std::move(domain), 4, false, ::Verbosity::Silent,
+       std::move(grid_center_A), std::move(grid_center_B)},
+      {std::move(initial_functions_of_time),
+       std::move(initial_measurement_timescales)}};
   ActionTesting::emplace_array_component<element_component>(
       make_not_null(&runner), ActionTesting::NodeId{0},
       ActionTesting::LocalCoreId{0}, 0);

--- a/tests/Unit/ControlSystem/ControlErrors/Test_Rotation.cpp
+++ b/tests/Unit/ControlSystem/ControlErrors/Test_Rotation.cpp
@@ -87,10 +87,11 @@ void test_rotation_control_error() {
   // Setup runner and element component because it's the easiest way to get the
   // global cache
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<metavars>;
-  MockRuntimeSystem runner{{"DummyFileName", std::move(domain), 4, false,
-                            std::move(grid_center_A), std::move(grid_center_B)},
-                           {std::move(initial_functions_of_time),
-                            std::move(initial_measurement_timescales)}};
+  MockRuntimeSystem runner{
+      {"DummyFileName", std::move(domain), 4, false, ::Verbosity::Silent,
+       std::move(grid_center_A), std::move(grid_center_B)},
+      {std::move(initial_functions_of_time),
+       std::move(initial_measurement_timescales)}};
   ActionTesting::emplace_array_component<element_component>(
       make_not_null(&runner), ActionTesting::NodeId{0},
       ActionTesting::LocalCoreId{0}, 0);

--- a/tests/Unit/ControlSystem/ControlErrors/Test_Shape.cpp
+++ b/tests/Unit/ControlSystem/ControlErrors/Test_Shape.cpp
@@ -149,10 +149,11 @@ void test_shape_control_error() {
 
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<metavars>;
   // Excision centers aren't used so their values can be anything
-  MockRuntimeSystem runner{{"DummyFilename", std::move(fake_domain), 4, false,
-                            std::move(grid_center_A), std::move(grid_center_B)},
-                           {std::move(initial_functions_of_time),
-                            std::move(initial_measurement_timescales)}};
+  MockRuntimeSystem runner{
+      {"DummyFilename", std::move(fake_domain), 4, false, ::Verbosity::Silent,
+       std::move(grid_center_A), std::move(grid_center_B)},
+      {std::move(initial_functions_of_time),
+       std::move(initial_measurement_timescales)}};
   ActionTesting::emplace_array_component<element_component>(
       make_not_null(&runner), ActionTesting::NodeId{0},
       ActionTesting::LocalCoreId{0}, 0);

--- a/tests/Unit/ControlSystem/ControlErrors/Test_Translation.cpp
+++ b/tests/Unit/ControlSystem/ControlErrors/Test_Translation.cpp
@@ -89,10 +89,11 @@ void test_translation_control_error() {
   // Setup runner and element component because it's the easiest way to get the
   // global cache
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<metavars>;
-  MockRuntimeSystem runner{{"DummyFileName", std::move(domain), 4, false,
-                            std::move(grid_center_A), std::move(grid_center_B)},
-                           {std::move(initial_functions_of_time),
-                            std::move(initial_measurement_timescales)}};
+  MockRuntimeSystem runner{
+      {"DummyFileName", std::move(domain), 4, false, ::Verbosity::Silent,
+       std::move(grid_center_A), std::move(grid_center_B)},
+      {std::move(initial_functions_of_time),
+       std::move(initial_measurement_timescales)}};
   ActionTesting::emplace_array_component<element_component>(
       make_not_null(&runner), ActionTesting::NodeId{0},
       ActionTesting::LocalCoreId{0}, 0);

--- a/tests/Unit/ControlSystem/Systems/Test_Expansion.cpp
+++ b/tests/Unit/ControlSystem/Systems/Test_Expansion.cpp
@@ -103,10 +103,11 @@ void test_expansion_control_system() {
 
   // Setup runner and all components
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<metavars>;
-  MockRuntimeSystem runner{{"DummyFileName", std::move(domain), 4, false,
-                            std::move(grid_center_A), std::move(grid_center_B)},
-                           {std::move(initial_functions_of_time),
-                            std::move(initial_measurement_timescales)}};
+  MockRuntimeSystem runner{
+      {"DummyFileName", std::move(domain), 4, false, ::Verbosity::Silent,
+       std::move(grid_center_A), std::move(grid_center_B)},
+      {std::move(initial_functions_of_time),
+       std::move(initial_measurement_timescales)}};
   ActionTesting::emplace_singleton_component_and_initialize<
       expansion_component>(make_not_null(&runner), ActionTesting::NodeId{0},
                            ActionTesting::LocalCoreId{0}, init_exp_tuple);

--- a/tests/Unit/ControlSystem/Systems/Test_RotScaleTrans.cpp
+++ b/tests/Unit/ControlSystem/Systems/Test_RotScaleTrans.cpp
@@ -159,7 +159,7 @@ void test_rotscaletrans_control_system(const double rotation_eps = 5.0e-5) {
   // Setup runner and all components
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<metavars>;
   MockRuntimeSystem runner{
-      {"DummyFileName", std::move(domain), 4, false,
+      {"DummyFileName", std::move(domain), 4, false, ::Verbosity::Silent,
        tnsr::I<double, 3, Frame::Grid>{{0.5 * initial_separation, 0.0, 0.0}},
        tnsr::I<double, 3, Frame::Grid>{{-0.5 * initial_separation, 0.0, 0.0}}},
       {std::move(initial_functions_of_time),

--- a/tests/Unit/ControlSystem/Systems/Test_Rotation.cpp
+++ b/tests/Unit/ControlSystem/Systems/Test_Rotation.cpp
@@ -108,10 +108,11 @@ void test_rotation_control_system(const bool newtonian) {
 
   // Setup runner and all components
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<metavars>;
-  MockRuntimeSystem runner{{"DummyFileName", std::move(domain), 4, false,
-                            std::move(grid_center_A), std::move(grid_center_B)},
-                           {std::move(initial_functions_of_time),
-                            std::move(initial_measurement_timescales)}};
+  MockRuntimeSystem runner{
+      {"DummyFileName", std::move(domain), 4, false, ::Verbosity::Silent,
+       std::move(grid_center_A), std::move(grid_center_B)},
+      {std::move(initial_functions_of_time),
+       std::move(initial_measurement_timescales)}};
   ActionTesting::emplace_singleton_component_and_initialize<rotation_component>(
       make_not_null(&runner), ActionTesting::NodeId{0},
       ActionTesting::LocalCoreId{0}, init_rot_tuple);

--- a/tests/Unit/ControlSystem/Systems/Test_Shape.cpp
+++ b/tests/Unit/ControlSystem/Systems/Test_Shape.cpp
@@ -83,10 +83,11 @@ void test_shape_control(
 
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<Metavars>;
   // Excision centers aren't used so their values can be anything
-  MockRuntimeSystem runner{{"DummyFileName", std::move(domain), 4, false,
-                            std::move(grid_center_A), std::move(grid_center_B)},
-                           {std::move(initial_functions_of_time),
-                            std::move(initial_measurement_timescales)}};
+  MockRuntimeSystem runner{
+      {"DummyFileName", std::move(domain), 4, false, ::Verbosity::Silent,
+       std::move(grid_center_A), std::move(grid_center_B)},
+      {std::move(initial_functions_of_time),
+       std::move(initial_measurement_timescales)}};
   ActionTesting::emplace_singleton_component_and_initialize<shape_component>(
       make_not_null(&runner), ActionTesting::NodeId{0},
       ActionTesting::LocalCoreId{0}, init_shape_tuple);

--- a/tests/Unit/ControlSystem/Systems/Test_Translation.cpp
+++ b/tests/Unit/ControlSystem/Systems/Test_Translation.cpp
@@ -113,10 +113,11 @@ void test_translation_control_system() {
 
   // Setup runner and all components
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<metavars>;
-  MockRuntimeSystem runner{{"DummyFileName", std::move(domain), 4, false,
-                            std::move(grid_center_A), std::move(grid_center_B)},
-                           {std::move(initial_functions_of_time),
-                            std::move(initial_measurement_timescales)}};
+  MockRuntimeSystem runner{
+      {"DummyFileName", std::move(domain), 4, false, ::Verbosity::Silent,
+       std::move(grid_center_A), std::move(grid_center_B)},
+      {std::move(initial_functions_of_time),
+       std::move(initial_measurement_timescales)}};
   ActionTesting::emplace_singleton_component_and_initialize<
       translation_component>(make_not_null(&runner), ActionTesting::NodeId{0},
                              ActionTesting::LocalCoreId{0}, init_trans_tuple);

--- a/tests/Unit/ControlSystem/Test_Measurements.cpp
+++ b/tests/Unit/ControlSystem/Test_Measurements.cpp
@@ -7,10 +7,12 @@
 #include "ControlSystem/Measurements/BothHorizons.hpp"
 #include "ControlSystem/Measurements/CharSpeed.hpp"
 #include "ControlSystem/Measurements/SingleHorizon.hpp"
+#include "ControlSystem/Tags/SystemTags.hpp"
 #include "DataStructures/DataVector.hpp"
 #include "Domain/Structure/ObjectLabel.hpp"
 #include "Framework/ActionTesting.hpp"
 #include "Helpers/ControlSystem/Examples.hpp"
+#include "IO/Logging/Verbosity.hpp"
 #include "ParallelAlgorithms/Interpolation/Protocols/InterpolationTargetTag.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
 
@@ -125,6 +127,7 @@ template <typename Metavariables>
 struct MockControlSystemComponent {
   using component_being_mocked =
       ControlComponent<Metavariables, MockControlSystem>;
+  using const_global_cache_tags = tmpl::list<control_system::Tags::Verbosity>;
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockSingletonChare;
   using array_index = int;
@@ -176,7 +179,7 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.FindTwoCenters",
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<Metavariables>;
   using control_system_component = MockControlSystemComponent<Metavariables>;
 
-  MockRuntimeSystem runner{{}};
+  MockRuntimeSystem runner{{::Verbosity::Silent}};
   ActionTesting::emplace_singleton_component<control_system_component>(
       make_not_null(&runner), ActionTesting::NodeId{0},
       ActionTesting::LocalCoreId{0});

--- a/tests/Unit/ControlSystem/Test_RunCallbacks.cpp
+++ b/tests/Unit/ControlSystem/Test_RunCallbacks.cpp
@@ -8,11 +8,13 @@
 
 #include "ControlSystem/Component.hpp"
 #include "ControlSystem/Event.hpp"
+#include "ControlSystem/Tags/SystemTags.hpp"
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataBox/ObservationBox.hpp"
 #include "Evolution/EventsAndDenseTriggers/EventsAndDenseTriggers.hpp"
 #include "Framework/ActionTesting.hpp"
 #include "Helpers/ControlSystem/Examples.hpp"
+#include "IO/Logging/Verbosity.hpp"
 #include "Options/Protocols/FactoryCreation.hpp"
 #include "Parallel/Phase.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
@@ -44,6 +46,7 @@ struct MockControlSystemComponent {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockSingletonChare;
   using array_index = int;
+  using const_global_cache_tags = tmpl::list<control_system::Tags::Verbosity>;
   using simple_tags_from_options = tmpl::list<
       control_system::TestHelpers::ExampleControlSystem::MeasurementQueue,
       control_system::TestHelpers::MeasurementResultTime,
@@ -61,7 +64,6 @@ struct Metavariables {
     using factory_classes =
         tmpl::map<tmpl::pair<Event, tmpl::list<MeasureEvent>>>;
   };
-
 };
 }  // namespace
 
@@ -74,7 +76,7 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.RunCallbacks", "[ControlSystem][Unit]") {
   using control_system_component = MockControlSystemComponent<Metavariables>;
   const element_component* const element_component_p = nullptr;
 
-  MockRuntimeSystem runner{{}};
+  MockRuntimeSystem runner{{::Verbosity::Silent}};
   ActionTesting::emplace_array_component<element_component>(
       make_not_null(&runner), ActionTesting::NodeId{0},
       ActionTesting::LocalCoreId{0}, 0);

--- a/tests/Unit/ControlSystem/Test_Tags.cpp
+++ b/tests/Unit/ControlSystem/Test_Tags.cpp
@@ -58,6 +58,8 @@ void test_all_tags() {
   TestHelpers::db::test_simple_tag<controller_tag>("Controller");
   using fot_tag = control_system::Tags::FunctionsOfTimeInitialize;
   TestHelpers::db::test_simple_tag<fot_tag>("FunctionsOfTime");
+  using verbosity_tag = control_system::Tags::Verbosity;
+  TestHelpers::db::test_simple_tag<verbosity_tag>("Verbosity");
 
   using control_error_tag = control_system::Tags::ControlError<system>;
   TestHelpers::db::test_simple_tag<control_error_tag>("ControlError");

--- a/tests/Unit/ControlSystem/Test_Trigger.cpp
+++ b/tests/Unit/ControlSystem/Test_Trigger.cpp
@@ -9,6 +9,7 @@
 #include <utility>
 
 #include "ControlSystem/Tags/MeasurementTimescales.hpp"
+#include "ControlSystem/Tags/SystemTags.hpp"
 #include "ControlSystem/Trigger.hpp"
 #include "ControlSystem/UpdateFunctionOfTime.hpp"
 #include "DataStructures/DataBox/DataBox.hpp"
@@ -21,6 +22,7 @@
 #include "Framework/MockRuntimeSystemFreeFunctions.hpp"
 #include "Framework/TestHelpers.hpp"
 #include "Helpers/ControlSystem/TestStructs.hpp"
+#include "IO/Logging/Verbosity.hpp"
 #include "Options/Protocols/FactoryCreation.hpp"
 #include "Parallel/GlobalCache.hpp"
 #include "Parallel/Phase.hpp"
@@ -55,6 +57,7 @@ struct Component {
   using simple_tags = tmpl::list<Tags::Time>;
   using compute_tags = tmpl::list<Parallel::Tags::FromGlobalCache<
       control_system::Tags::MeasurementTimescales>>;
+  using const_global_cache_tags = tmpl::list<control_system::Tags::Verbosity>;
   using mutable_global_cache_tags =
       tmpl::list<control_system::Tags::MeasurementTimescales>;
 
@@ -90,7 +93,8 @@ void test_trigger_no_replace() {
   measurement_timescales["DifferentMeasurement"] =
       std::make_unique<MeasurementFoT>(0.0, std::array{DataVector{1.0}}, 0.1);
 
-  MockRuntimeSystem runner{{}, {std::move(measurement_timescales)}};
+  MockRuntimeSystem runner{{::Verbosity::Silent},
+                           {std::move(measurement_timescales)}};
   ActionTesting::emplace_array_component_and_initialize<component>(
       make_not_null(&runner), ActionTesting::NodeId{0},
       ActionTesting::LocalCoreId{0}, 0, {0.0});

--- a/tests/Unit/Helpers/ControlSystem/SystemHelpers.hpp
+++ b/tests/Unit/Helpers/ControlSystem/SystemHelpers.hpp
@@ -207,6 +207,7 @@ struct MockControlComponent {
   using const_global_cache_tags =
       tmpl::list<control_system::Tags::MeasurementsPerUpdate,
                  control_system::Tags::WriteDataToDisk,
+                 control_system::Tags::Verbosity,
                  domain::Tags::ExcisionCenter<domain::ObjectLabel::A>,
                  domain::Tags::ExcisionCenter<domain::ObjectLabel::B>>;
 

--- a/tests/Unit/Utilities/Test_PrettyType.cpp
+++ b/tests/Unit/Utilities/Test_PrettyType.cpp
@@ -206,6 +206,7 @@ struct ShortName {
 struct Name {
   template <typename TestType>
   static std::string name() {
+    CHECK(pretty_type::name<TestType>() == pretty_type::name(TestType{}));
     return pretty_type::name<TestType>();
   }
 };

--- a/tests/Unit/Utilities/Test_PrettyType.cpp
+++ b/tests/Unit/Utilities/Test_PrettyType.cpp
@@ -206,7 +206,9 @@ struct ShortName {
 struct Name {
   template <typename TestType>
   static std::string name() {
-    CHECK(pretty_type::name<TestType>() == pretty_type::name(TestType{}));
+    if constexpr (std::is_constructible_v<TestType>) {
+      CHECK(pretty_type::name<TestType>() == pretty_type::name(TestType{}));
+    }
     return pretty_type::name<TestType>();
   }
 };
@@ -461,12 +463,26 @@ void test_name_func() {
   CHECK(NameFunc::template name<tmpl::range<int, 0, 1000>>() == "list");
 }
 
+void test_list_of_names() {
+  using empty_list = tmpl::list<>;
+  using one_element_list = tmpl::list<Type1Containing2Digits3>;
+  using three_element_list =
+      tmpl::list<TestType, Type1Containing2Digits3, NonTemplateWithName>;
+
+  CHECK(pretty_type::list_of_names<empty_list>() == "");
+  CHECK(pretty_type::list_of_names<one_element_list>() ==
+        "Type1Containing2Digits3");
+  CHECK(pretty_type::list_of_names<three_element_list>() ==
+        "TestType, Type1Containing2Digits3, UniqueNonTemplateWithName");
+}
+
 SPECTRE_TEST_CASE("Unit.Utilities.PrettyType.name_and_short_name",
                   "[Utilities][Unit]") {
   test_name_func<ShortName>();
   // For all these types without a name() member, the results should be
   // identical to that of pretty_type::short_name()
   test_name_func<Name>();
+  test_list_of_names();
 
   CHECK(NonTemplateWithName::name() == "UniqueNonTemplateWithName");
   CHECK(TemplateWithName<int>::name() == "UniqueTemplateWithName");


### PR DESCRIPTION
## Proposed changes

I found my self adding the same prints every time I needed to debug the control system so I just made them part of develop.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
Add
```yaml
ControlSystems:
  ...
  Verbosity: Silent
```
to you input file with control systems. To turn on debug prints for the control system, change the verbosity to `Verbose` or `Debug`. Note that `Debug` will print things for every element of the domain.
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
