### PR TITLE
Fix help_option_names in standalone Py scripts

### DIFF
--- a/src/Visualization/Python/PlotDatFile.py
+++ b/src/Visualization/Python/PlotDatFile.py
@@ -211,4 +211,4 @@ def plot_dat_command(h5_file, subfile_name, output, legend_only, functions,
 
 
 if __name__ == "__main__":
-    plot_dat_command(help_option_name=["-h", "--help"])
+    plot_dat_command(help_option_names=["-h", "--help"])

--- a/src/Visualization/Python/Render1D.py
+++ b/src/Visualization/Python/Render1D.py
@@ -417,4 +417,4 @@ def render_1d_command(h5_files, subfile_name, list_vars, vars, output, x_label,
 
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO)
-    render_1d_command(help_option_name=["-h", "--help"])
+    render_1d_command(help_option_names=["-h", "--help"])

--- a/tools/CharmSimplifyTraces.py
+++ b/tools/CharmSimplifyTraces.py
@@ -243,4 +243,4 @@ def simplify_traces_command(projections_file, output_file, in_place,
 
 
 if __name__ == "__main__":
-    simplify_traces_command(help_option_name=["-h", "--help"])
+    simplify_traces_command(help_option_names=["-h", "--help"])


### PR DESCRIPTION
## Proposed changes

Only relevant when running the files as standalone Py scripts, which shouldn't usually happen (since they're included in the CLI). It's a bug nevertheless.

Fixes https://github.com/sxs-collaboration/spectre/issues/4961.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
