### PR TITLE
Add StrahlkorperInDifferentFrameAligned

### DIFF
--- a/src/ApparentHorizons/StrahlkorperInDifferentFrame.hpp
+++ b/src/ApparentHorizons/StrahlkorperInDifferentFrame.hpp
@@ -26,13 +26,54 @@ class not_null;
 /// The destination Strahlkorper has the same l_max() and m_max() as the
 /// source Strahlkorper.
 ///
-/// Note that because the Blocks inside the Domain allow access to
+/// \note Because the Blocks inside the Domain allow access to
 /// maps only between a selected subset of frames, we cannot use
 /// strahlkorper_in_different_frame to map between arbitrary frames;
 /// allowing strahlkorper_in_different_frame to work on more frames
 /// requires adding member functions to Block.
+///
+/// \note strahlkorper_in_different_frame is currently instantiated
+/// only for SrcFrame=Grid and DestFrame=Inertial.  In particular, we
+/// intentionally do not instantiate strahlkorper_in_different_frame
+/// for SrcFrame=Grid and DestFrame=Distorted, because our
+/// Grid->Distorted maps preserve centers and angles, so for
+/// Grid->Distorted one should use
+/// strahlkorper_in_different_frame_aligned because it is more
+/// efficient.
 template <typename SrcFrame, typename DestFrame>
 void strahlkorper_in_different_frame(
+    gsl::not_null<Strahlkorper<DestFrame>*> dest_strahlkorper,
+    const Strahlkorper<SrcFrame>& src_strahlkorper, const Domain<3>& domain,
+    const std::unordered_map<
+        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+        functions_of_time,
+    double time);
+
+/// \brief Transforms a Strahlkorper from SrcFrame to DestFrame, for easy maps.
+///
+/// This is a simplified version of strahlkorper_in_different_frame
+/// with the following two assumptions: First, the map leaves the
+/// center of the Strahlkorper invariant. Second, for every point on
+/// the Strahlkorper, the map leaves the angles about the center
+/// (i.e. the quantity
+/// \f$(x^i-c^i)/\sqrt{(x^0-c^0)^2+(x^1-c^1)^2+(x^2-c^2)^2}\f$)
+/// invariant. If those assumptions are not satisfied, then
+/// strahlkorper_in_different_frame_aligned will give the wrong answer
+/// and you must use strahlkorper_in_different_frame.  Those
+/// assumptions are satisfied for the shape and size maps but not for
+/// general maps.
+///
+/// \note strahlkorper_in_different_frame_aligned is instantiated only
+/// for SrcFrame=Grid and DestFrame=Distorted or Inertial. This
+/// doesn't mean that strahlkorper_in_different_frame_aligned is
+/// always correct for Grid->Inertial; the correctness depends on
+/// whether the Grid->Inertial map satisfies the above assumptions,
+/// which it might for simple cases (like single BHs) but it won't for
+/// more complicated cases (like BBHs).  To add different frames to
+/// strahlkorper_in_different_frame_aligned, one must add `if
+/// constexpr`s to call the appropriate member functions of Block.
+template <typename SrcFrame, typename DestFrame>
+void strahlkorper_in_different_frame_aligned(
     gsl::not_null<Strahlkorper<DestFrame>*> dest_strahlkorper,
     const Strahlkorper<SrcFrame>& src_strahlkorper, const Domain<3>& domain,
     const std::unordered_map<

--- a/tests/Unit/ApparentHorizons/Test_StrahlkorperInDifferentFrame.cpp
+++ b/tests/Unit/ApparentHorizons/Test_StrahlkorperInDifferentFrame.cpp
@@ -11,15 +11,18 @@
 #include "Domain/Creators/RegisterDerivedWithCharm.hpp"
 #include "Domain/Creators/Sphere.hpp"
 #include "Domain/Creators/TimeDependence/RegisterDerivedWithCharm.hpp"
+#include "Domain/Creators/TimeDependence/Shape.hpp"
 #include "Domain/Domain.hpp"
 #include "Domain/FunctionsOfTime/RegisterDerivedWithCharm.hpp"
 #include "Framework/TestHelpers.hpp"
 #include "NumericalAlgorithms/SphericalHarmonics/SpherepackIterator.hpp"
 #include "NumericalAlgorithms/SphericalHarmonics/Strahlkorper.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrHorizon.hpp"
 #include "Utilities/Gsl.hpp"
 
 namespace {
 
+template <bool Aligned, typename DestFrame>
 void test_strahlkorper_in_different_frame() {
   const size_t grid_points_each_dimension = 5;
 
@@ -40,32 +43,64 @@ void test_strahlkorper_in_different_frame() {
   std::vector<double> radial_partitioning{};
   std::vector<domain::CoordinateMaps::Distribution> radial_distribution{
       domain::CoordinateMaps::Distribution::Linear};
-  domain::creators::Sphere domain_creator(
-      1.9, 2.9, domain::creators::Sphere::Excision{}, 1_st,
-      grid_points_each_dimension, false, std::nullopt, radial_partitioning,
-      radial_distribution, ShellWedges::All,
-      std::make_unique<
-          domain::creators::time_dependence::UniformTranslation<3>>(
-          0.0, std::array<double, 3>({{0.01, 0.02, 0.03}})));
-  Domain<3> domain = domain_creator.create_domain();
-  const auto functions_of_time = domain_creator.functions_of_time();
+  std::unique_ptr<domain::creators::Sphere> domain_creator;
+  if constexpr (Aligned) {
+    domain_creator.reset(new domain::creators::Sphere(
+        1.9, 2.9, domain::creators::Sphere::Excision{}, 1_st,
+        grid_points_each_dimension, false, std::nullopt, radial_partitioning,
+        radial_distribution, ShellWedges::All,
+        // Choose time dependence to be centered at the strahlkorper center.
+        std::make_unique<domain::creators::time_dependence::Shape<
+            domain::ObjectLabel::None>>(0.0, l_max, 1.0,
+                                        std::array<double, 3>{{0.1, 0.2, 0.3}},
+                                        strahlkorper_grid_center, 2.0, 12.0)));
+  } else {
+    domain_creator.reset(new domain::creators::Sphere(
+        1.9, 2.9, domain::creators::Sphere::Excision{}, 1_st,
+        grid_points_each_dimension, false, std::nullopt, radial_partitioning,
+        radial_distribution, ShellWedges::All,
+        std::make_unique<
+            domain::creators::time_dependence::UniformTranslation<3>>(
+            0.0, std::array<double, 3>({{0.01, 0.02, 0.03}}))));
+  }
+  Domain<3> domain = domain_creator->create_domain();
+  const auto functions_of_time = domain_creator->functions_of_time();
 
-  // Compute strahlkorper in the inertial frame.
+  // Compute strahlkorper in the destination frame.
   const double time = 0.5;
-  Strahlkorper<Frame::Inertial> strahlkorper_inertial{};
-  strahlkorper_in_different_frame(make_not_null(&strahlkorper_inertial),
-                                  strahlkorper_grid, domain, functions_of_time,
-                                  time);
+  Strahlkorper<DestFrame> strahlkorper_dest{};
+  if constexpr (Aligned) {
+    strahlkorper_in_different_frame_aligned(make_not_null(&strahlkorper_dest),
+                                            strahlkorper_grid, domain,
+                                            functions_of_time, time);
+
+  } else {
+    strahlkorper_in_different_frame(make_not_null(&strahlkorper_dest),
+                                    strahlkorper_grid, domain,
+                                    functions_of_time, time);
+  }
 
   // Now compare.
-  const Strahlkorper<Frame::Inertial> strahlkorper_expected(
-      l_max, 2.0,
-      {{strahlkorper_grid_center[0] + 0.005, strahlkorper_grid_center[1] + 0.01,
-        strahlkorper_grid_center[2] + 0.015}});
-  CHECK_ITERABLE_APPROX(strahlkorper_expected.physical_center(),
-                        strahlkorper_inertial.physical_center());
-  CHECK_ITERABLE_APPROX(strahlkorper_expected.coefficients(),
-                        strahlkorper_inertial.coefficients());
+  std::unique_ptr<Strahlkorper<DestFrame>> strahlkorper_expected;
+  if constexpr (Aligned) {
+    const YlmSpherepack ylm{l_max, l_max};
+    const DataVector new_radius =
+        get(gr::Solutions::kerr_schild_radius_from_boyer_lindquist(
+            2.0, ylm.theta_phi_points(), 1.0,
+            std::array<double, 3>{{0.1, 0.2, 0.3}}));
+    strahlkorper_expected.reset(new Strahlkorper<DestFrame>(
+        l_max, l_max, new_radius, strahlkorper_grid_center));
+  } else {
+    strahlkorper_expected.reset(
+        new Strahlkorper<DestFrame>(l_max, 2.0,
+                                    {{strahlkorper_grid_center[0] + 0.005,
+                                      strahlkorper_grid_center[1] + 0.01,
+                                      strahlkorper_grid_center[2] + 0.015}}));
+  }
+  CHECK_ITERABLE_APPROX(strahlkorper_expected->physical_center(),
+                        strahlkorper_dest.physical_center());
+  CHECK_ITERABLE_APPROX(strahlkorper_expected->coefficients(),
+                        strahlkorper_dest.coefficients());
 }
 
 SPECTRE_TEST_CASE("Unit.ApparentHorizons.StrahlkorperInDifferentFrame",
@@ -73,7 +108,9 @@ SPECTRE_TEST_CASE("Unit.ApparentHorizons.StrahlkorperInDifferentFrame",
   domain::creators::register_derived_with_charm();
   domain::creators::time_dependence::register_derived_with_charm();
   domain::FunctionsOfTime::register_derived_with_charm();
-  test_strahlkorper_in_different_frame();
+  test_strahlkorper_in_different_frame<false, Frame::Inertial>();
+  test_strahlkorper_in_different_frame<true, Frame::Inertial>();
+  test_strahlkorper_in_different_frame<true, Frame::Distorted>();
 }
 
 }  // namespace


### PR DESCRIPTION
## Proposed changes

    This is a simplified version of StrahlkorperInDifferentFrame,
    that assumes:
     * The map preserves the center of the Strahlkorper.
     * For each point on the Strahlkorper, the map preserves the angles
       between that point and the center.

Edit: this *does* know about the distorted frame now.

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

