### PR TITLE
Add distorted frame to TimeDependence::SphericalCompression

### DIFF
--- a/src/Domain/Creators/TimeDependence/SphericalCompression.cpp
+++ b/src/Domain/Creators/TimeDependence/SphericalCompression.cpp
@@ -37,9 +37,42 @@ SphericalCompression::SphericalCompression(
       min_radius_(min_radius),
       max_radius_(max_radius),
       center_(center),
-      initial_value_(initial_value),
-      initial_velocity_(initial_velocity),
-      initial_acceleration_(initial_acceleration) {
+      initial_value_grid_to_distorted_(initial_value),
+      initial_velocity_grid_to_distorted_(initial_velocity),
+      initial_acceleration_grid_to_distorted_(initial_acceleration) {
+  if (min_radius >= max_radius) {
+    PARSE_ERROR(context,
+                "Tried to create a SphericalCompression TimeDependence, but "
+                "the minimum radius ("
+                    << min_radius << ") is not less than the maximum radius ("
+                    << max_radius << ")");
+  }
+}
+
+SphericalCompression::SphericalCompression(
+    const double initial_time, const double min_radius, const double max_radius,
+    const std::array<double, 3> center,
+    const double initial_value_grid_to_distorted,
+    const double initial_velocity_grid_to_distorted,
+    const double initial_acceleration_grid_to_distorted,
+    const double initial_value_distorted_to_inertial,
+    const double initial_velocity_distorted_to_inertial,
+    const double initial_acceleration_distorted_to_inertial,
+    const Options::Context& context)
+    : initial_time_(initial_time),
+      min_radius_(min_radius),
+      max_radius_(max_radius),
+      center_(center),
+      initial_value_grid_to_distorted_(initial_value_grid_to_distorted),
+      initial_velocity_grid_to_distorted_(initial_velocity_grid_to_distorted),
+      initial_acceleration_grid_to_distorted_(
+          initial_acceleration_grid_to_distorted),
+      initial_value_distorted_to_inertial_(initial_value_distorted_to_inertial),
+      initial_velocity_distorted_to_inertial_(
+          initial_velocity_distorted_to_inertial),
+      initial_acceleration_distorted_to_inertial_(
+          initial_acceleration_distorted_to_inertial),
+      distorted_and_inertial_frames_are_equal_(false) {
   if (min_radius >= max_radius) {
     PARSE_ERROR(context,
                 "Tried to create a SphericalCompression TimeDependence, but "
@@ -50,9 +83,20 @@ SphericalCompression::SphericalCompression(
 }
 
 std::unique_ptr<TimeDependence<3>> SphericalCompression::get_clone() const {
-  return std::make_unique<SphericalCompression>(
-      initial_time_, min_radius_, max_radius_, center_, initial_value_,
-      initial_velocity_, initial_acceleration_);
+  if (distorted_and_inertial_frames_are_equal_) {
+    return std::make_unique<SphericalCompression>(
+        initial_time_, min_radius_, max_radius_, center_,
+        initial_value_grid_to_distorted_, initial_velocity_grid_to_distorted_,
+        initial_acceleration_grid_to_distorted_);
+  } else {
+    return std::make_unique<SphericalCompression>(
+        initial_time_, min_radius_, max_radius_, center_,
+        initial_value_grid_to_distorted_, initial_velocity_grid_to_distorted_,
+        initial_acceleration_grid_to_distorted_,
+        initial_value_distorted_to_inertial_,
+        initial_velocity_distorted_to_inertial_,
+        initial_acceleration_distorted_to_inertial_);
+  }
 }
 
 std::vector<
@@ -64,9 +108,52 @@ SphericalCompression::block_maps_grid_to_inertial(
   std::vector<std::unique_ptr<
       domain::CoordinateMapBase<Frame::Grid, Frame::Inertial, 3>>>
       result{number_of_blocks};
-  result[0] = std::make_unique<GridToInertialMap>(grid_to_inertial_map());
+  if (distorted_and_inertial_frames_are_equal_) {
+    result[0] = std::make_unique<GridToInertialMapSimple>(
+        grid_to_inertial_map_simple());
+  } else {
+    result[0] = std::make_unique<GridToInertialMapCombined>(
+        grid_to_inertial_map_combined());
+  }
   for (size_t i = 1; i < number_of_blocks; ++i) {
     result[i] = result[0]->get_clone();
+  }
+  return result;
+}
+
+std::vector<std::unique_ptr<
+    domain::CoordinateMapBase<Frame::Grid, Frame::Distorted, 3>>>
+SphericalCompression::block_maps_grid_to_distorted(
+    const size_t number_of_blocks) const {
+  ASSERT(number_of_blocks > 0,
+         "Must have at least one block on which to create a map.");
+  std::vector<std::unique_ptr<
+      domain::CoordinateMapBase<Frame::Grid, Frame::Distorted, 3>>>
+      result{number_of_blocks};
+  if (not distorted_and_inertial_frames_are_equal_) {
+    result[0] = std::make_unique<GridToDistortedMap>(grid_to_distorted_map());
+    for (size_t i = 1; i < number_of_blocks; ++i) {
+      result[i] = result[0]->get_clone();
+    }
+  }
+  return result;
+}
+
+std::vector<std::unique_ptr<
+    domain::CoordinateMapBase<Frame::Distorted, Frame::Inertial, 3>>>
+SphericalCompression::block_maps_distorted_to_inertial(
+    const size_t number_of_blocks) const {
+  ASSERT(number_of_blocks > 0,
+         "Must have at least one block on which to create a map.");
+  std::vector<std::unique_ptr<
+      domain::CoordinateMapBase<Frame::Distorted, Frame::Inertial, 3>>>
+      result{number_of_blocks};
+  if (not distorted_and_inertial_frames_are_equal_) {
+    result[0] =
+        std::make_unique<DistortedToInertialMap>(distorted_to_inertial_map());
+    for (size_t i = 1; i < number_of_blocks; ++i) {
+      result[i] = result[0]->get_clone();
+    }
   }
   return result;
 }
@@ -81,28 +168,74 @@ SphericalCompression::functions_of_time(
       result{};
 
   // Functions of time don't expire by default
-  double expiration_time = std::numeric_limits<double>::infinity();
+  double expiration_time_grid_to_distorted =
+      std::numeric_limits<double>::infinity();
 
   // If we have control systems, overwrite the expiration time with the one
   // supplied by the control system
-  if (initial_expiration_times.count(function_of_time_name_) == 1) {
-    expiration_time = initial_expiration_times.at(function_of_time_name_);
+  if (initial_expiration_times.count(
+          function_of_time_name_grid_to_distorted_) == 1) {
+    expiration_time_grid_to_distorted =
+        initial_expiration_times.at(function_of_time_name_grid_to_distorted_);
   }
 
-  result[function_of_time_name_] =
+  result[function_of_time_name_grid_to_distorted_] =
       std::make_unique<FunctionsOfTime::PiecewisePolynomial<3>>(
           initial_time_,
-          std::array<DataVector, 4>{{{initial_value_},
-                                     {initial_velocity_},
-                                     {initial_acceleration_},
+          std::array<DataVector, 4>{{{initial_value_grid_to_distorted_},
+                                     {initial_velocity_grid_to_distorted_},
+                                     {initial_acceleration_grid_to_distorted_},
                                      {0.0}}},
-          expiration_time);
+          expiration_time_grid_to_distorted);
+
+  if (not distorted_and_inertial_frames_are_equal_) {
+    double expiration_time_distorted_to_inertial =
+        std::numeric_limits<double>::infinity();
+    if (initial_expiration_times.count(
+            function_of_time_name_distorted_to_inertial_) == 1) {
+      expiration_time_distorted_to_inertial = initial_expiration_times.at(
+          function_of_time_name_distorted_to_inertial_);
+    }
+    result[function_of_time_name_distorted_to_inertial_] =
+        std::make_unique<FunctionsOfTime::PiecewisePolynomial<3>>(
+            initial_time_,
+            std::array<DataVector, 4>{
+                {{initial_value_distorted_to_inertial_},
+                 {initial_velocity_distorted_to_inertial_},
+                 {initial_acceleration_distorted_to_inertial_},
+                 {0.0}}},
+            expiration_time_distorted_to_inertial);
+  }
   return result;
 }
 
-auto SphericalCompression::grid_to_inertial_map() const -> GridToInertialMap {
-  return GridToInertialMap{SphericalCompressionMap{
-      function_of_time_name_, min_radius_, max_radius_, center_}};
+auto SphericalCompression::grid_to_inertial_map_simple() const
+    -> GridToInertialMapSimple {
+  return GridToInertialMapSimple{
+      SphericalCompressionMap{function_of_time_name_grid_to_distorted_,
+                              min_radius_, max_radius_, center_}};
+}
+
+auto SphericalCompression::grid_to_distorted_map() const -> GridToDistortedMap {
+  return GridToDistortedMap{
+      SphericalCompressionMap{function_of_time_name_grid_to_distorted_,
+                              min_radius_, max_radius_, center_}};
+}
+
+auto SphericalCompression::distorted_to_inertial_map() const
+    -> DistortedToInertialMap {
+  return DistortedToInertialMap{
+      SphericalCompressionMap{function_of_time_name_distorted_to_inertial_,
+                              min_radius_, max_radius_, center_}};
+}
+
+auto SphericalCompression::grid_to_inertial_map_combined() const
+    -> GridToInertialMapCombined {
+  return GridToInertialMapCombined{
+      SphericalCompressionMap{function_of_time_name_grid_to_distorted_,
+                              min_radius_, max_radius_, center_},
+      SphericalCompressionMap{function_of_time_name_distorted_to_inertial_,
+                              min_radius_, max_radius_, center_}};
 }
 
 bool operator==(const SphericalCompression& lhs,
@@ -110,9 +243,21 @@ bool operator==(const SphericalCompression& lhs,
   return lhs.initial_time_ == rhs.initial_time_ and
          lhs.min_radius_ == rhs.min_radius_ and
          lhs.max_radius_ == rhs.max_radius_ and lhs.center_ == rhs.center_ and
-         lhs.initial_value_ == rhs.initial_value_ and
-         lhs.initial_velocity_ == rhs.initial_velocity_ and
-         lhs.initial_acceleration_ == rhs.initial_acceleration_;
+         lhs.initial_value_grid_to_distorted_ ==
+             rhs.initial_value_grid_to_distorted_ and
+         lhs.initial_velocity_grid_to_distorted_ ==
+             rhs.initial_velocity_grid_to_distorted_ and
+         lhs.initial_acceleration_grid_to_distorted_ ==
+             rhs.initial_acceleration_grid_to_distorted_ and
+         lhs.distorted_and_inertial_frames_are_equal_ ==
+             rhs.distorted_and_inertial_frames_are_equal_ and
+         (lhs.distorted_and_inertial_frames_are_equal_ or
+          (lhs.initial_value_distorted_to_inertial_ ==
+               rhs.initial_value_distorted_to_inertial_ and
+           lhs.initial_velocity_distorted_to_inertial_ ==
+               rhs.initial_velocity_distorted_to_inertial_ and
+           lhs.initial_acceleration_distorted_to_inertial_ ==
+               rhs.initial_acceleration_distorted_to_inertial_));
 }
 
 bool operator!=(const SphericalCompression& lhs,
@@ -125,6 +270,9 @@ using SphericalCompressionMap3d =
     CoordinateMaps::TimeDependent::SphericalCompression<false>;
 
 INSTANTIATE_MAPS_FUNCTIONS(((SphericalCompressionMap3d)), (Frame::Grid),
+                           (Frame::Distorted, Frame::Inertial),
+                           (double, DataVector))
+INSTANTIATE_MAPS_FUNCTIONS(((SphericalCompressionMap3d)), (Frame::Distorted),
                            (Frame::Inertial), (double, DataVector))
 
 }  // namespace domain

--- a/tests/Unit/Domain/Creators/TimeDependence/Test_SphericalCompression.cpp
+++ b/tests/Unit/Domain/Creators/TimeDependence/Test_SphericalCompression.cpp
@@ -32,14 +32,131 @@ namespace {
 using SphericalCompressionMap =
     domain::CoordinateMaps::TimeDependent::SphericalCompression<false>;
 
-using ConcreteMap = domain::CoordinateMap<Frame::Grid, Frame::Inertial,
-                                          SphericalCompressionMap>;
+template <typename InputFrame = Frame::Grid,
+          typename OutputFrame = Frame::Inertial>
+using ConcreteMapSimple =
+    domain::CoordinateMap<InputFrame, OutputFrame, SphericalCompressionMap>;
 
-ConcreteMap create_coord_map(const std::string& f_of_t_name,
-                             const double min_radius, const double max_radius,
-                             const std::array<double, 3>& center) {
-  return ConcreteMap{
+using ConcreteMapCombined =
+    domain::CoordinateMap<Frame::Grid, Frame::Inertial, SphericalCompressionMap,
+                          SphericalCompressionMap>;
+
+template <typename InputFrame = Frame::Grid,
+          typename OutputFrame = Frame::Inertial>
+ConcreteMapSimple<InputFrame, OutputFrame> create_coord_map(
+    const std::string& f_of_t_name, const double min_radius,
+    const double max_radius, const std::array<double, 3>& center) {
+  return ConcreteMapSimple<InputFrame, OutputFrame>{
       {SphericalCompressionMap{f_of_t_name, min_radius, max_radius, center}}};
+}
+
+ConcreteMapCombined create_coord_map_grid_to_inertial(
+    const std::string& f_of_t_grid_to_distorted,
+    const std::string& f_of_t_distorted_to_inertial, const double min_radius,
+    const double max_radius, const std::array<double, 3>& center) {
+  return ConcreteMapCombined{
+      SphericalCompressionMap{f_of_t_grid_to_distorted, min_radius, max_radius,
+                              center},
+      SphericalCompressionMap{f_of_t_distorted_to_inertial, min_radius,
+                              max_radius, center}};
+}
+
+template <typename InputFrame, typename OutputFrame, typename BlockMaps,
+          typename BlockMap, typename Gen>
+void test_maps(const std::unique_ptr<TimeDependence<3>>& time_dep_unique_ptr,
+               const double initial_time,
+               const tnsr::I<DataVector, 3, InputFrame>& input_coords_dv,
+               const tnsr::I<double, 3, InputFrame>& input_coords_double,
+               const tnsr::I<double, 3, OutputFrame>& output_coords_double,
+               const BlockMaps& block_maps, const BlockMap& expected_block_map,
+               std::uniform_real_distribution<double>& dist, Gen& gen) {
+  const auto functions_of_time = time_dep_unique_ptr->functions_of_time();
+  for (const auto& block_map : block_maps) {
+    // We've checked equivalence above
+    // (CHECK(*block_map == expected_block_map);), but have sometimes been
+    // burned by incorrect operator== implementations so we check that the
+    // mappings behave as expected.
+    const double time_offset = dist(gen) + 1.2;
+    CHECK_ITERABLE_APPROX(
+        expected_block_map(input_coords_dv, initial_time + time_offset,
+                           functions_of_time),
+        (*block_map)(input_coords_dv, initial_time + time_offset,
+                     functions_of_time));
+    CHECK_ITERABLE_APPROX(
+        expected_block_map(input_coords_double, initial_time + time_offset,
+                           functions_of_time),
+        (*block_map)(input_coords_double, initial_time + time_offset,
+                     functions_of_time));
+
+    CHECK_ITERABLE_APPROX(
+        *expected_block_map.inverse(output_coords_double,
+                                    initial_time + time_offset,
+                                    functions_of_time),
+        *block_map->inverse(output_coords_double, initial_time + time_offset,
+                            functions_of_time));
+
+    CHECK_ITERABLE_APPROX(
+        expected_block_map.inv_jacobian(
+            input_coords_dv, initial_time + time_offset, functions_of_time),
+        block_map->inv_jacobian(input_coords_dv, initial_time + time_offset,
+                                functions_of_time));
+    CHECK_ITERABLE_APPROX(
+        expected_block_map.inv_jacobian(
+            input_coords_double, initial_time + time_offset, functions_of_time),
+        block_map->inv_jacobian(input_coords_double, initial_time + time_offset,
+                                functions_of_time));
+
+    CHECK_ITERABLE_APPROX(
+        expected_block_map.jacobian(input_coords_dv, initial_time + time_offset,
+                                    functions_of_time),
+        block_map->jacobian(input_coords_dv, initial_time + time_offset,
+                            functions_of_time));
+    CHECK_ITERABLE_APPROX(
+        expected_block_map.jacobian(
+            input_coords_double, initial_time + time_offset, functions_of_time),
+        block_map->jacobian(input_coords_double, initial_time + time_offset,
+                            functions_of_time));
+  }
+}
+
+void test_common(
+    const std::unique_ptr<TimeDependence<3>>& time_dep_unique_ptr) {
+  CHECK_FALSE(time_dep_unique_ptr->is_none());
+
+  // We downcast to the expected derived class to make sure that factory
+  // creation worked correctly. In order to maximize code reuse this check is
+  // done here as opposed to separately elsewhere.
+  const auto* const time_dep =
+      dynamic_cast<const SphericalCompression*>(time_dep_unique_ptr.get());
+  REQUIRE(time_dep != nullptr);
+}
+
+void test_f_of_time(
+    const std::unique_ptr<TimeDependence<3>>& time_dep_unique_ptr,
+    const std::vector<std::string>& f_of_t_names) {
+  // Test without expiration times
+  const auto functions_of_time = time_dep_unique_ptr->functions_of_time();
+  REQUIRE(functions_of_time.size() == f_of_t_names.size());
+  for (const auto& f_of_t_name : f_of_t_names) {
+    CHECK(functions_of_time.count(f_of_t_name) == 1);
+    CHECK(functions_of_time.at(f_of_t_name)->time_bounds()[1] ==
+          std::numeric_limits<double>::infinity());
+  }
+
+  // Test with expiration times
+  const double init_expr_time = 5.0;
+  std::unordered_map<std::string, double> init_expr_times{};
+  for (const auto& f_of_t_name : f_of_t_names) {
+    init_expr_times[f_of_t_name] = init_expr_time;
+  }
+  const auto functions_of_time_with_expr_times =
+      time_dep_unique_ptr->functions_of_time(init_expr_times);
+  REQUIRE(functions_of_time_with_expr_times.size() == f_of_t_names.size());
+  for (const auto& f_of_t_name : f_of_t_names) {
+    CHECK(functions_of_time_with_expr_times.count(f_of_t_name) == 1);
+    CHECK(functions_of_time_with_expr_times.at(f_of_t_name)->time_bounds()[1] ==
+          init_expr_time);
+  }
 }
 
 void test(const std::unique_ptr<TimeDependence<3>>& time_dep_unique_ptr,
@@ -53,14 +170,7 @@ void test(const std::unique_ptr<TimeDependence<3>>& time_dep_unique_ptr,
   CAPTURE(max_radius);
   CAPTURE(center);
 
-  CHECK_FALSE(time_dep_unique_ptr->is_none());
-
-  // We downcast to the expected derived class to make sure that factory
-  // creation worked correctly. In order to maximize code reuse this check is
-  // done here as opposed to separately elsewhere.
-  const auto* const time_dep =
-      dynamic_cast<const SphericalCompression*>(time_dep_unique_ptr.get());
-  REQUIRE(time_dep != nullptr);
+  test_common(time_dep_unique_ptr);
 
   // Test coordinate maps
   UniformCustomDistribution<size_t> dist_size_t{1, 10};
@@ -74,7 +184,8 @@ void test(const std::unique_ptr<TimeDependence<3>>& time_dep_unique_ptr,
       time_dep_unique_ptr->block_maps_grid_to_inertial(num_blocks);
   for (const auto& block_map_unique_ptr : block_maps) {
     const auto* const block_map =
-        dynamic_cast<const ConcreteMap*>(block_map_unique_ptr.get());
+        dynamic_cast<const ConcreteMapSimple<Frame::Grid, Frame::Inertial>*>(
+            block_map_unique_ptr.get());
     REQUIRE(block_map != nullptr);
     CHECK(*block_map == expected_block_map);
   }
@@ -85,28 +196,7 @@ void test(const std::unique_ptr<TimeDependence<3>>& time_dep_unique_ptr,
   CHECK(time_dep_unique_ptr->block_maps_distorted_to_inertial(1)[0].get() ==
         nullptr);
 
-  // Test functions of time without expiration times
-  {
-    const auto functions_of_time = time_dep_unique_ptr->functions_of_time();
-    REQUIRE(functions_of_time.size() == 1);
-    CHECK(functions_of_time.count(f_of_t_name) == 1);
-    CHECK(functions_of_time.at(f_of_t_name)->time_bounds()[1] ==
-          std::numeric_limits<double>::infinity());
-  }
-  // Test functions of time with expiration times
-  {
-    const double init_expr_time = 5.0;
-    std::unordered_map<std::string, double> init_expr_times{};
-    init_expr_times[f_of_t_name] = init_expr_time;
-    const auto functions_of_time =
-        time_dep_unique_ptr->functions_of_time(init_expr_times);
-    REQUIRE(functions_of_time.size() == 1);
-    CHECK(functions_of_time.count(f_of_t_name) == 1);
-    CHECK(functions_of_time.at(f_of_t_name)->time_bounds()[1] ==
-          init_expr_time);
-  }
-
-  const auto functions_of_time = time_dep_unique_ptr->functions_of_time();
+  test_f_of_time(time_dep_unique_ptr, {f_of_t_name});
 
   // For a random point at a random time check that the values agree. This is
   // to check that the internals were assigned the correct function of times.
@@ -119,80 +209,170 @@ void test(const std::unique_ptr<TimeDependence<3>>& time_dep_unique_ptr,
   TIME_DEPENDENCE_GENERATE_COORDS(make_not_null(&gen), 3, min_radius * 1.001,
                                   max_radius * 0.5);
 
-  for (const auto& block_map : block_maps) {
-    // We've checked equivalence above
-    // (CHECK(*block_map == expected_block_map);), but have sometimes been
-    // burned by incorrect operator== implementations so we check that the
-    // mappings behave as expected.
-    const double time_offset = dist(gen) + 1.2;
-    CHECK_ITERABLE_APPROX(
-        expected_block_map(grid_coords_dv, initial_time + time_offset,
-                           functions_of_time),
-        (*block_map)(grid_coords_dv, initial_time + time_offset,
-                     functions_of_time));
-    CHECK_ITERABLE_APPROX(
-        expected_block_map(grid_coords_double, initial_time + time_offset,
-                           functions_of_time),
-        (*block_map)(grid_coords_double, initial_time + time_offset,
-                     functions_of_time));
+  test_maps(time_dep_unique_ptr, initial_time, grid_coords_dv,
+            grid_coords_double, inertial_coords_double, block_maps,
+            expected_block_map, dist, gen);
+}
 
-    CHECK_ITERABLE_APPROX(
-        *expected_block_map.inverse(inertial_coords_double,
-                                    initial_time + time_offset,
-                                    functions_of_time),
-        *block_map->inverse(inertial_coords_double, initial_time + time_offset,
-                            functions_of_time));
+void test_with_distorted_frame(
+    const std::unique_ptr<TimeDependence<3>>& time_dep_unique_ptr,
+    const double initial_time, const std::string& f_of_t_grid_to_distorted,
+    const std::string& f_of_t_distorted_to_inertial, const double min_radius,
+    const double max_radius, const std::array<double, 3>& center) {
+  MAKE_GENERATOR(gen);
+  CAPTURE(initial_time);
+  CAPTURE(f_of_t_grid_to_distorted);
+  CAPTURE(f_of_t_distorted_to_inertial);
+  CAPTURE(min_radius);
+  CAPTURE(max_radius);
+  CAPTURE(center);
 
-    CHECK_ITERABLE_APPROX(
-        expected_block_map.inv_jacobian(
-            grid_coords_dv, initial_time + time_offset, functions_of_time),
-        block_map->inv_jacobian(grid_coords_dv, initial_time + time_offset,
-                                functions_of_time));
-    CHECK_ITERABLE_APPROX(
-        expected_block_map.inv_jacobian(
-            grid_coords_double, initial_time + time_offset, functions_of_time),
-        block_map->inv_jacobian(grid_coords_double, initial_time + time_offset,
-                                functions_of_time));
+  test_common(time_dep_unique_ptr);
 
-    CHECK_ITERABLE_APPROX(
-        expected_block_map.jacobian(grid_coords_dv, initial_time + time_offset,
-                                    functions_of_time),
-        block_map->jacobian(grid_coords_dv, initial_time + time_offset,
-                            functions_of_time));
-    CHECK_ITERABLE_APPROX(
-        expected_block_map.jacobian(
-            grid_coords_double, initial_time + time_offset, functions_of_time),
-        block_map->jacobian(grid_coords_double, initial_time + time_offset,
-                            functions_of_time));
+  // Test coordinate maps
+  UniformCustomDistribution<size_t> dist_size_t{1, 10};
+  const size_t num_blocks = dist_size_t(gen);
+  CAPTURE(num_blocks);
+
+  const auto expected_block_map_grid_to_inertial =
+      create_coord_map_grid_to_inertial(f_of_t_grid_to_distorted,
+                                        f_of_t_distorted_to_inertial,
+                                        min_radius, max_radius, center);
+
+  const auto block_maps_grid_to_inertial =
+      time_dep_unique_ptr->block_maps_grid_to_inertial(num_blocks);
+  for (const auto& block_map_unique_ptr : block_maps_grid_to_inertial) {
+    const auto* const block_map =
+        dynamic_cast<const ConcreteMapCombined*>(block_map_unique_ptr.get());
+    REQUIRE(block_map != nullptr);
+    CHECK(*block_map == expected_block_map_grid_to_inertial);
   }
+
+  const auto expected_block_map_grid_to_distorted =
+      create_coord_map<Frame::Grid, Frame::Distorted>(
+          f_of_t_grid_to_distorted, min_radius, max_radius, center);
+  const auto block_maps_grid_to_distorted =
+      time_dep_unique_ptr->block_maps_grid_to_distorted(num_blocks);
+  for (const auto& block_map_unique_ptr : block_maps_grid_to_distorted) {
+    const auto* const block_map =
+        dynamic_cast<const ConcreteMapSimple<Frame::Grid, Frame::Distorted>*>(
+            block_map_unique_ptr.get());
+    REQUIRE(block_map != nullptr);
+    CHECK(*block_map == expected_block_map_grid_to_distorted);
+  }
+
+  const auto expected_block_map_distorted_to_inertial =
+      create_coord_map<Frame::Distorted, Frame::Inertial>(
+          f_of_t_distorted_to_inertial, min_radius, max_radius, center);
+  const auto block_maps_distorted_to_inertial =
+      time_dep_unique_ptr->block_maps_distorted_to_inertial(num_blocks);
+  for (const auto& block_map_unique_ptr : block_maps_distorted_to_inertial) {
+    const auto* const block_map = dynamic_cast<
+        const ConcreteMapSimple<Frame::Distorted, Frame::Inertial>*>(
+        block_map_unique_ptr.get());
+    REQUIRE(block_map != nullptr);
+    CHECK(*block_map == expected_block_map_distorted_to_inertial);
+  }
+
+  test_f_of_time(time_dep_unique_ptr,
+                 {f_of_t_grid_to_distorted, f_of_t_distorted_to_inertial});
+
+  // For a random point at a random time check that the values agree. This is
+  // to check that the internals were assigned the correct function of times.
+  // The points are are drawn from the positive x/y/z quadrant in a that
+  // guarantees that they are in the region where the map is valid (min_radius
+  // <= radius <= max_radius), provided that min_radius is sufficiently small
+  // compared to max_radius. This could be generalized, but in practice,
+  // this map will not be used in cases where min_radius and max_radius
+  // are very close to each other.
+  TIME_DEPENDENCE_GENERATE_COORDS(make_not_null(&gen), 3, min_radius * 1.001,
+                                  max_radius * 0.5);
+
+  test_maps(time_dep_unique_ptr, initial_time, grid_coords_dv,
+            grid_coords_double, inertial_coords_double,
+            block_maps_grid_to_inertial, expected_block_map_grid_to_inertial,
+            dist, gen);
+
+  TIME_DEPENDENCE_GENERATE_DISTORTED_COORDS(make_not_null(&gen), dist, 3);
+
+  test_maps(time_dep_unique_ptr, initial_time, grid_coords_dv,
+            grid_coords_double, distorted_coords_double,
+            block_maps_grid_to_distorted, expected_block_map_grid_to_distorted,
+            dist, gen);
+
+  test_maps(time_dep_unique_ptr, initial_time, distorted_coords_dv,
+            distorted_coords_double, inertial_coords_double,
+            block_maps_distorted_to_inertial,
+            expected_block_map_distorted_to_inertial, dist, gen);
 }
 
 void test_equivalence() {
-  SphericalCompression sc0{1.0, 0.4, 4.0, {{-0.2, 1.3, 2.4}}, 3.5, -4.6, 5.7};
-  SphericalCompression sc1{1.0, 0.4, 4.0, {{-0.2, 1.3, 2.4}}, 3.5, -4.6, 5.7};
-  SphericalCompression sc2{1.0, 0.3, 4.0, {{-0.2, 1.3, 2.4}}, 3.5, -4.6, 5.7};
-  SphericalCompression sc3{1.0, 0.4, 4.1, {{-0.2, 1.3, 2.4}}, 3.5, -4.6, 5.7};
-  SphericalCompression sc4{1.0, 0.4, 4.0, {{0.2, 1.3, 2.4}}, 3.5, -4.6, 5.7};
-  SphericalCompression sc5{1.0, 0.4, 4.0, {{-0.2, 1.3, 2.4}}, 3.8, -4.6, 5.7};
-  SphericalCompression sc6{1.0, 0.4, 4.0, {{-0.2, 1.3, 2.4}}, 3.5, 4.6, 5.7};
-  SphericalCompression sc7{1.0, 0.4, 4.0, {{-0.2, 1.3, 2.4}}, 3.5, -4.6, 5.9};
+  {
+    SphericalCompression sc0{1.0, 0.4, 4.0, {{-0.2, 1.3, 2.4}}, 3.5, -4.6, 5.7};
+    SphericalCompression sc1{1.0, 0.4, 4.0, {{-0.2, 1.3, 2.4}}, 3.5, -4.6, 5.7};
+    SphericalCompression sc2{1.0, 0.3, 4.0, {{-0.2, 1.3, 2.4}}, 3.5, -4.6, 5.7};
+    SphericalCompression sc3{1.0, 0.4, 4.1, {{-0.2, 1.3, 2.4}}, 3.5, -4.6, 5.7};
+    SphericalCompression sc4{1.0, 0.4, 4.0, {{0.2, 1.3, 2.4}}, 3.5, -4.6, 5.7};
+    SphericalCompression sc5{1.0, 0.4, 4.0, {{-0.2, 1.3, 2.4}}, 3.8, -4.6, 5.7};
+    SphericalCompression sc6{1.0, 0.4, 4.0, {{-0.2, 1.3, 2.4}}, 3.5, 4.6, 5.7};
+    SphericalCompression sc7{1.0, 0.4, 4.0, {{-0.2, 1.3, 2.4}}, 3.5, -4.6, 5.9};
 
-  CHECK(sc0 == sc0);
-  CHECK_FALSE(sc0 != sc0);
-  CHECK(sc0 == sc1);
-  CHECK_FALSE(sc0 != sc1);
-  CHECK(sc0 != sc2);
-  CHECK_FALSE(sc0 == sc2);
-  CHECK(sc0 != sc3);
-  CHECK_FALSE(sc0 == sc3);
-  CHECK(sc0 != sc4);
-  CHECK_FALSE(sc0 == sc4);
-  CHECK(sc0 != sc5);
-  CHECK_FALSE(sc0 == sc5);
-  CHECK(sc0 != sc6);
-  CHECK_FALSE(sc0 == sc6);
-  CHECK(sc0 != sc7);
-  CHECK_FALSE(sc0 == sc7);
+    CHECK(sc0 == sc0);
+    CHECK_FALSE(sc0 != sc0);
+    CHECK(sc0 == sc1);
+    CHECK_FALSE(sc0 != sc1);
+    CHECK(sc0 != sc2);
+    CHECK_FALSE(sc0 == sc2);
+    CHECK(sc0 != sc3);
+    CHECK_FALSE(sc0 == sc3);
+    CHECK(sc0 != sc4);
+    CHECK_FALSE(sc0 == sc4);
+    CHECK(sc0 != sc5);
+    CHECK_FALSE(sc0 == sc5);
+    CHECK(sc0 != sc6);
+    CHECK_FALSE(sc0 == sc6);
+    CHECK(sc0 != sc7);
+    CHECK_FALSE(sc0 == sc7);
+  }
+  // With distorted frame
+  {
+    SphericalCompression sc0{1.0, 0.4, 4.0, {{-0.2, 1.3, 2.4}}, 3.5, -4.6, 5.7,
+                             0.2, 3.4, 3.6};
+    SphericalCompression sc1{1.0, 0.4, 4.0, {{-0.2, 1.3, 2.4}}, 3.5, -4.6, 5.7,
+                             0.2, 3.4, 3.6};
+    SphericalCompression sc2{1.0, 0.4, 4.0, {{-0.2, 1.3, 2.4}}, 3.5, -4.6, 5.7};
+    SphericalCompression sc3{1.0,  0.4, 4.0, {{-0.2, 1.3, 2.4}}, 3.5, -4.6, 5.7,
+                             0.21, 3.4, 3.6};
+    SphericalCompression sc4{1.0, 0.4,  4.0, {{-0.2, 1.3, 2.4}}, 3.5, -4.6, 5.7,
+                             0.2, -3.4, 3.6};
+    SphericalCompression sc5{1.0, 0.4, 4.0, {{-0.2, 1.3, 2.4}}, 3.5, -4.6, 5.7,
+                             0.2, 3.4, 3.7};
+    SphericalCompression sc6{1.0, 0.4, 4.0, {{-0.2, 1.3, 2.4}}, 3.25, -4.6, 5.7,
+                             0.2, 3.4, 3.6};
+    SphericalCompression sc7{1.0, 0.4, 4.0, {{-0.2, 1.3, 2.4}}, 3.5, -4.5, 5.7,
+                             0.2, 3.4, 3.6};
+    SphericalCompression sc8{1.0, 0.4, 4.0, {{-0.2, 1.3, 2.4}}, 3.5, -4.6, 5.5,
+                             0.2, 3.4, 3.6};
+
+    CHECK(sc0 == sc0);
+    CHECK_FALSE(sc0 != sc0);
+    CHECK(sc0 == sc1);
+    CHECK_FALSE(sc0 != sc1);
+    CHECK(sc0 != sc2);
+    CHECK_FALSE(sc0 == sc2);
+    CHECK(sc0 != sc3);
+    CHECK_FALSE(sc0 == sc3);
+    CHECK(sc0 != sc4);
+    CHECK_FALSE(sc0 == sc4);
+    CHECK(sc0 != sc5);
+    CHECK_FALSE(sc0 == sc5);
+    CHECK(sc0 != sc6);
+    CHECK_FALSE(sc0 == sc6);
+    CHECK(sc0 != sc7);
+    CHECK_FALSE(sc0 == sc7);
+    CHECK(sc0 != sc8);
+    CHECK_FALSE(sc0 == sc8);
+  }
 }
 
 SPECTRE_TEST_CASE("Unit.Domain.Creators.TimeDependence.SphericalCompression",
@@ -206,6 +386,13 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.TimeDependence.SphericalCompression",
   constexpr double initial_acceleration{0.01};
   // This name must match the hard coded one in SphericalCompression
   const std::string f_of_t_name = "Size";
+
+  CHECK_THROWS_WITH(
+      SphericalCompression(initial_time, max_radius, min_radius, center,
+                           initial_value, initial_velocity,
+                           initial_acceleration),
+      Catch::Matchers::Contains(
+          "Tried to create a SphericalCompression TimeDependence"));
 
   const std::unique_ptr<domain::creators::time_dependence::TimeDependence<3>>
       time_dep = std::make_unique<SphericalCompression>(
@@ -227,22 +414,31 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.TimeDependence.SphericalCompression",
        initial_time, f_of_t_name, min_radius, max_radius, center);
 
   test_equivalence();
-}
 
-// [[OutputRegex, Tried to create a SphericalCompression TimeDependence]]
-SPECTRE_TEST_CASE(
-    "Unit.Domain.Creators.TimeDependence.SphericalCompression.ErrorTest",
-    "[Domain][Unit]") {
-  ERROR_TEST();
-  TestHelpers::test_creation<std::unique_ptr<TimeDependence<3>>>(
-      "SphericalCompression:\n"
-      "  InitialTime: 1.3\n"
-      "  MinRadius: 4.0\n"
-      "  MaxRadius: 0.4\n"
-      "  Center: [-0.01, 0.02, 0.01]\n"
-      "  InitialValue: 3.5\n"
-      "  InitialVelocity: -4.6\n"
-      "  InitialAcceleration: 5.7\n");
+  // Now distorted-frame tests.
+
+  CHECK_THROWS_WITH(
+      SphericalCompression(initial_time, max_radius, min_radius, center,
+                           initial_value, initial_velocity,
+                           initial_acceleration, initial_value,
+                           initial_velocity, initial_acceleration),
+      Catch::Matchers::Contains(
+          "Tried to create a SphericalCompression TimeDependence"));
+
+  // These names must match the hard coded one in SphericalCompression
+  const std::string f_of_t_grid_to_distorted = "Size";
+  const std::string f_of_t_distorted_to_inertial = "SizeDistortedToInertial";
+  const std::unique_ptr<domain::creators::time_dependence::TimeDependence<3>>
+      time_dep_distorted = std::make_unique<SphericalCompression>(
+          initial_time, min_radius, max_radius, center, initial_value,
+          initial_velocity, initial_acceleration, initial_value,
+          initial_velocity, initial_acceleration);
+  test_with_distorted_frame(
+      time_dep_distorted, initial_time, f_of_t_grid_to_distorted,
+      f_of_t_distorted_to_inertial, min_radius, max_radius, center);
+  test_with_distorted_frame(
+      time_dep_distorted->get_clone(), initial_time, f_of_t_grid_to_distorted,
+      f_of_t_distorted_to_inertial, min_radius, max_radius, center);
 }
 }  // namespace
 


### PR DESCRIPTION
Adds distorted frame to TimeDependence::SphericalCompression

This will be used for tests.
We treat extra arguments the same way they
are treated in UniformTranslation:
providing two sets of functionvstime
arguments means that the first set is
the grid_to_distorted map and the second
set is the distorted_to_inertial map.

Had to refactor Test_SphericalCompression to reduce duplicating code for that test.
Also, replaced an ERROR_TEST in Test_SphericalCompression with a CHECK_THROWS_WITH

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

