### PR TITLE
Speed up `GH::TimeDerivative` calculation for harmonic gauge

### DIFF
--- a/src/Evolution/Systems/GeneralizedHarmonic/TimeDerivative.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/TimeDerivative.hpp
@@ -97,6 +97,11 @@ namespace gh {
  * terms added to this implementation of the generalized harmonic system.
  * Mesh-velocity corrections that are applicable to all systems are made in
  * `evolution::dg::Actions::detail::volume_terms()`.
+ *
+ * \warning When using harmonic gauge,
+ * gr::Tags::SqrtDetSpatialMetric<DataVector> and
+ * gr::Tags::SpacetimeChristoffelSecondKind<Dim, Frame::Inertial, DataVector>
+ * are not computed. In Debug mode, they are filled with with signaling NaNs.
  */
 template <size_t Dim>
 struct TimeDerivative {


### PR DESCRIPTION
## Proposed changes
When using harmonic gauge, some terms of the field equations can be set to zero and we can avoid calculating the second order Christoffel symbols and the sqrt of the determinant of the spatial metric alltogether.

This PR adds a check in `GH::TimeDerivative` whether the harmonic gauge is used and only computes these terms if it is not. The uncomputed variables are filled with NaNs in debug mode.

Benchmarking showed this leads to a ~15% speed-up of `GH::TimeDerivative`  on a single core on my laptop.