### PR TITLE
Clean up docs and code in Shape control error

### DIFF
--- a/tests/Unit/ControlSystem/ControlErrors/Test_Shape.cpp
+++ b/tests/Unit/ControlSystem/ControlErrors/Test_Shape.cpp
@@ -182,8 +182,9 @@ void test_shape_control_error() {
       functions_of_time.at(shape_name)->func(check_time)[0];
 
   DataVector expected_control_error =
-      -(sqrt(0.5 * M_PI) * excision_radius / Y00 - lambda_00_coef) /
-          measurement_coefs[iter.set(0, 0)()] * measurement_coefs -
+      -(excision_radius / Y00 - lambda_00_coef) /
+          (sqrt(0.5 * M_PI) * measurement_coefs[iter.set(0, 0)()]) *
+          measurement_coefs -
       lambda_lm_coefs;
   // We don't control l=0 or l=1 modes
   for (iter.reset(); iter; ++iter) {

--- a/tests/Unit/ControlSystem/Systems/Test_Shape.cpp
+++ b/tests/Unit/ControlSystem/Systems/Test_Shape.cpp
@@ -127,7 +127,7 @@ void test_shape_control(
 
   const auto& functions_of_time =
       Parallel::get<domain::Tags::FunctionsOfTime>(cache);
-  const double excision_radius = sqrt(0.5 * M_PI) * excision_sphere.radius();
+  const double excision_radius = excision_sphere.radius();
   const std::string size_name =
       control_system::ControlErrors::detail::size_name<
           ::domain::ObjectLabel::A>();
@@ -143,9 +143,10 @@ void test_shape_control(
   // Our expected coefs are just the (minus) coefs of the AH (except for l=0,l=1
   // which should be zero) scaled by the relative size factor defined in the
   // control error
-  auto expected_shape_coefs = -1.0 * (excision_radius / Y00 - lambda_00_coef) /
-                              ah_coefs_and_derivs[0][iter.set(0, 0)()] *
-                              ah_coefs_and_derivs;
+  auto expected_shape_coefs =
+      -1.0 * (excision_radius / Y00 - lambda_00_coef) /
+      (sqrt(0.5 * M_PI) * ah_coefs_and_derivs[0][iter.set(0, 0)()]) *
+      ah_coefs_and_derivs;
   // Manually set 0,0 component to 0
   expected_shape_coefs[0][iter.set(0, 0)()] = 0.0;
 


### PR DESCRIPTION
## Proposed changes

While debugging shape control, I found the control error was incorrect along with the docs. Documentation for the shape map was improved in #4822, but the control error was never updated to reflect those changes.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
