### PR TITLE
Pass grid to target velocity in Compute*Quantities

### DIFF
--- a/src/ApparentHorizons/ComputeExcisionBoundaryVolumeQuantities.hpp
+++ b/src/ApparentHorizons/ComputeExcisionBoundaryVolumeQuantities.hpp
@@ -73,7 +73,9 @@ struct ComputeExcisionBoundaryVolumeQuantities
           jac_logical_to_target,
       const InverseJacobian<DataVector, 3, Frame::ElementLogical, TargetFrame>&
           invjac_logical_to_target,
-      const tnsr::I<DataVector, 3, Frame::Inertial>& inertial_mesh_velocity);
+      const tnsr::I<DataVector, 3, Frame::Inertial>& inertial_mesh_velocity,
+      const tnsr::I<DataVector, 3, TargetFrame>&
+          grid_to_target_frame_mesh_velocity);
 
   using allowed_src_tags =
       tmpl::list<gr::Tags::SpacetimeMetric<DataVector, 3>,

--- a/src/ApparentHorizons/ComputeExcisionBoundaryVolumeQuantities.tpp
+++ b/src/ApparentHorizons/ComputeExcisionBoundaryVolumeQuantities.tpp
@@ -67,12 +67,10 @@ void ComputeExcisionBoundaryVolumeQuantities::apply(
 
   using spacetime_metric_tag = gr::Tags::SpacetimeMetric<DataVector, 3>;
   using spatial_metric_tag = gr::Tags::SpatialMetric<DataVector, 3>;
-  using inv_spatial_metric_tag =
-    gr::Tags::InverseSpatialMetric<DataVector, 3>;
+  using inv_spatial_metric_tag = gr::Tags::InverseSpatialMetric<DataVector, 3>;
   using lapse_tag = gr::Tags::Lapse<DataVector>;
   using shift_tag = gr::Tags::Shift<DataVector, 3>;
-  using constraint_gamma1_tag =
-    gh::ConstraintDamping::Tags::ConstraintGamma1;
+  using constraint_gamma1_tag = gh::ConstraintDamping::Tags::ConstraintGamma1;
 
   // All of the temporary tags, including some that may be repeated
   // in the target_variables (for now).
@@ -87,18 +85,16 @@ void ComputeExcisionBoundaryVolumeQuantities::apply(
   TempBuffer<temp_tags_list> buffer(src_vars.number_of_grid_points());
 
   // These may or may not be temporaries
-  auto& lapse = *(get<lapse_tag>(
-      target_vars, make_not_null(&buffer)));
-  auto& shift = *(get<shift_tag>(
-      target_vars, make_not_null(&buffer)));
-  auto& spatial_metric = *(get<spatial_metric_tag>(
-      target_vars, make_not_null(&buffer)));
-  auto& spacetime_metric = *(get<spacetime_metric_tag>(
-      target_vars, make_not_null(&buffer)));
-  auto& inv_spatial_metric = *(get<inv_spatial_metric_tag>(
-      target_vars, make_not_null(&buffer)));
-  auto& constraint_gamma1 = *(get<constraint_gamma1_tag>(
-      target_vars, make_not_null(&buffer)));
+  auto& lapse = *(get<lapse_tag>(target_vars, make_not_null(&buffer)));
+  auto& shift = *(get<shift_tag>(target_vars, make_not_null(&buffer)));
+  auto& spatial_metric =
+      *(get<spatial_metric_tag>(target_vars, make_not_null(&buffer)));
+  auto& spacetime_metric =
+      *(get<spacetime_metric_tag>(target_vars, make_not_null(&buffer)));
+  auto& inv_spatial_metric =
+      *(get<inv_spatial_metric_tag>(target_vars, make_not_null(&buffer)));
+  auto& constraint_gamma1 =
+      *(get<constraint_gamma1_tag>(target_vars, make_not_null(&buffer)));
 
   // Actual computation starts here
   const auto& src_spacetime_metric =
@@ -108,12 +104,11 @@ void ComputeExcisionBoundaryVolumeQuantities::apply(
   gr::spatial_metric(make_not_null(&spatial_metric), spacetime_metric);
   // put determinant of 3-metric temporarily into lapse to save memory.
   determinant_and_inverse(make_not_null(&lapse),
-                          make_not_null(&inv_spatial_metric),
-                          spatial_metric);
+                          make_not_null(&inv_spatial_metric), spatial_metric);
   gr::shift(make_not_null(&shift), spacetime_metric, inv_spatial_metric);
   gr::lapse(make_not_null(&lapse), shift, spacetime_metric);
   constraint_gamma1 =
-  get<gh::ConstraintDamping::Tags::ConstraintGamma1>(src_vars);
+      get<gh::ConstraintDamping::Tags::ConstraintGamma1>(src_vars);
 }
 
 /// Dual frame case
@@ -122,13 +117,13 @@ void ComputeExcisionBoundaryVolumeQuantities::apply(
     const gsl::not_null<Variables<DestTagList>*> target_vars,
     const Variables<SrcTagList>& src_vars, const Mesh<3>& /*mesh*/,
     const Jacobian<DataVector, 3, TargetFrame, Frame::Inertial>&
-      jac_target_to_inertial,
+        jac_target_to_inertial,
     const InverseJacobian<DataVector, 3, TargetFrame, Frame::Inertial>&
-      invjac_target_to_inertial,
+        invjac_target_to_inertial,
     const Jacobian<DataVector, 3, Frame::ElementLogical, TargetFrame>&
-      /*jac_logical_to_target*/,
+    /*jac_logical_to_target*/,
     const InverseJacobian<DataVector, 3, Frame::ElementLogical, TargetFrame>&
-      /*invjac_logical_to_target*/,
+    /*invjac_logical_to_target*/,
     const tnsr::I<DataVector, 3, Frame::Inertial>& inertial_mesh_velocity) {
   static_assert(
       std::is_same_v<tmpl::list_difference<SrcTagList, allowed_src_tags>,
@@ -165,21 +160,18 @@ void ComputeExcisionBoundaryVolumeQuantities::apply(
   using lapse_tag = gr::Tags::Lapse<DataVector>;
   using shift_tag = gr::Tags::Shift<DataVector, 3, TargetFrame>;
   using inertial_shift_tag = gr::Tags::Shift<DataVector, 3>;
-  using constraint_gamma1_tag =
-    gh::ConstraintDamping::Tags::ConstraintGamma1;
+  using constraint_gamma1_tag = gh::ConstraintDamping::Tags::ConstraintGamma1;
 
   // Additional temporary tags used for multiple frames
-  using inertial_spatial_metric_tag =
-      gr::Tags::SpatialMetric<DataVector, 3>;
+  using inertial_spatial_metric_tag = gr::Tags::SpatialMetric<DataVector, 3>;
   using inertial_inv_spatial_metric_tag =
       gr::Tags::InverseSpatialMetric<DataVector, 3>;
 
   // All of the temporary tags, including some that may be repeated
   // in the target_variables (for now).
   using full_temp_tags_list =
-      tmpl::list<spatial_metric_tag, inv_spatial_metric_tag,
-                 lapse_tag, shift_tag, inertial_shift_tag,
-                 inertial_spatial_metric_tag,
+      tmpl::list<spatial_metric_tag, inv_spatial_metric_tag, lapse_tag,
+                 shift_tag, inertial_shift_tag, inertial_spatial_metric_tag,
                  inertial_inv_spatial_metric_tag, constraint_gamma1_tag>;
 
   // temp tags without variables that are already in DestTagList.
@@ -189,23 +181,20 @@ void ComputeExcisionBoundaryVolumeQuantities::apply(
 
   // These may or may not be temporaries, depending on if they are asked for
   // in target_vars.
-  auto& lapse = *(get<lapse_tag>(
+  auto& lapse = *(get<lapse_tag>(target_vars, make_not_null(&buffer)));
+  auto& shift = *(get<shift_tag>(target_vars, make_not_null(&buffer)));
+  auto& inertial_shift =
+      *(get<inertial_shift_tag>(target_vars, make_not_null(&buffer)));
+  auto& inertial_spatial_metric =
+      *(get<inertial_spatial_metric_tag>(target_vars, make_not_null(&buffer)));
+  auto& inertial_inv_spatial_metric = *(get<inertial_inv_spatial_metric_tag>(
       target_vars, make_not_null(&buffer)));
-  auto& shift = *(get<shift_tag>(
-      target_vars, make_not_null(&buffer)));
-  auto& inertial_shift = *(get<inertial_shift_tag>(
-      target_vars, make_not_null(&buffer)));
-  auto& inertial_spatial_metric = *(get<inertial_spatial_metric_tag>(
-      target_vars, make_not_null(&buffer)));
-  auto& inertial_inv_spatial_metric =
-      *(get<inertial_inv_spatial_metric_tag>(
-          target_vars, make_not_null(&buffer)));
-  auto& spatial_metric = *(get<spatial_metric_tag>(
-      target_vars, make_not_null(&buffer)));
-  auto& inv_spatial_metric = *(get<inv_spatial_metric_tag>(
-      target_vars, make_not_null(&buffer)));
-  auto& constraint_gamma1 = *(get<constraint_gamma1_tag>(
-      target_vars, make_not_null(&buffer)));
+  auto& spatial_metric =
+      *(get<spatial_metric_tag>(target_vars, make_not_null(&buffer)));
+  auto& inv_spatial_metric =
+      *(get<inv_spatial_metric_tag>(target_vars, make_not_null(&buffer)));
+  auto& constraint_gamma1 =
+      *(get<constraint_gamma1_tag>(target_vars, make_not_null(&buffer)));
 
   // Actual computation starts here
 
@@ -218,20 +207,17 @@ void ComputeExcisionBoundaryVolumeQuantities::apply(
   // Transform spatial metric
   transform::to_different_frame(make_not_null(&spatial_metric),
                                 inertial_spatial_metric,
-                                jac_target_to_inertial
-);
+                                jac_target_to_inertial);
 
   // Invert transformed 3-metric.
   // put determinant of 3-metric temporarily into lapse to save memory.
   determinant_and_inverse(make_not_null(&lapse),
-                          make_not_null(&inv_spatial_metric),
-                          spatial_metric);
+                          make_not_null(&inv_spatial_metric), spatial_metric);
 
   // Only the inertial shift is computed at this time, so there is no
   // transformation done.
-  gr::shift(make_not_null(&inertial_shift),
-                          spacetime_metric,
-                          inertial_inv_spatial_metric);
+  gr::shift(make_not_null(&inertial_shift), spacetime_metric,
+            inertial_inv_spatial_metric);
   // We assume the lapse does note transform between the target and
   // inertial frames.
   gr::lapse(make_not_null(&lapse), inertial_shift, spacetime_metric);
@@ -242,14 +228,14 @@ void ComputeExcisionBoundaryVolumeQuantities::apply(
   const auto& src = inertial_shift;
   for (size_t i = 0; i < VolumeDim; ++i) {
     dest->get(i) = invjac_target_to_inertial.get(i, 0) *
-    (src.get(0) + inertial_mesh_velocity.get(0));
+                   (src.get(0) + inertial_mesh_velocity.get(0));
     for (size_t j = 1; j < VolumeDim; ++j) {
-          dest->get(i) += invjac_target_to_inertial.get(i, j) *
-          (src.get(j) + inertial_mesh_velocity.get(j));
+      dest->get(i) += invjac_target_to_inertial.get(i, j) *
+                      (src.get(j) + inertial_mesh_velocity.get(j));
     }
   }
   constraint_gamma1 =
-  get<gh::ConstraintDamping::Tags::ConstraintGamma1>(src_vars);
+      get<gh::ConstraintDamping::Tags::ConstraintGamma1>(src_vars);
 }
 
 }  // namespace ah

--- a/src/ApparentHorizons/ComputeExcisionBoundaryVolumeQuantities.tpp
+++ b/src/ApparentHorizons/ComputeExcisionBoundaryVolumeQuantities.tpp
@@ -124,7 +124,9 @@ void ComputeExcisionBoundaryVolumeQuantities::apply(
     /*jac_logical_to_target*/,
     const InverseJacobian<DataVector, 3, Frame::ElementLogical, TargetFrame>&
     /*invjac_logical_to_target*/,
-    const tnsr::I<DataVector, 3, Frame::Inertial>& inertial_mesh_velocity) {
+    const tnsr::I<DataVector, 3, Frame::Inertial>& inertial_mesh_velocity,
+    const tnsr::I<DataVector, 3, TargetFrame>&
+        /*grid_to_target_frame_mesh_velocity*/) {
   static_assert(
       std::is_same_v<tmpl::list_difference<SrcTagList, allowed_src_tags>,
                      tmpl::list<>>,

--- a/src/ApparentHorizons/ComputeHorizonVolumeQuantities.hpp
+++ b/src/ApparentHorizons/ComputeHorizonVolumeQuantities.hpp
@@ -73,7 +73,9 @@ struct ComputeHorizonVolumeQuantities
           jac_logical_to_target,
       const InverseJacobian<DataVector, 3, Frame::ElementLogical, TargetFrame>&
           invjac_logical_to_target,
-      const tnsr::I<DataVector, 3, Frame::Inertial>& inertial_mesh_velocity);
+      const tnsr::I<DataVector, 3, Frame::Inertial>& inertial_mesh_velocity,
+      const tnsr::I<DataVector, 3, TargetFrame>&
+          grid_to_target_frame_mesh_velocity);
 
   using allowed_src_tags =
       tmpl::list<gr::Tags::SpacetimeMetric<DataVector, 3>,

--- a/src/ApparentHorizons/ComputeHorizonVolumeQuantities.tpp
+++ b/src/ApparentHorizons/ComputeHorizonVolumeQuantities.tpp
@@ -64,12 +64,9 @@ void ComputeHorizonVolumeQuantities::apply(
                      tmpl::list<>>,
       "A required dest tag is missing");
 
-  const auto& psi =
-      get<gr::Tags::SpacetimeMetric<DataVector, 3>>(src_vars);
-  const auto& pi =
-      get<gh::Tags::Pi<DataVector, 3>>(src_vars);
-  const auto& phi =
-      get<gh::Tags::Phi<DataVector, 3>>(src_vars);
+  const auto& psi = get<gr::Tags::SpacetimeMetric<DataVector, 3>>(src_vars);
+  const auto& pi = get<gh::Tags::Pi<DataVector, 3>>(src_vars);
+  const auto& phi = get<gh::Tags::Phi<DataVector, 3>>(src_vars);
 
   if (target_vars->number_of_grid_points() !=
       src_vars.number_of_grid_points()) {
@@ -97,8 +94,7 @@ void ComputeHorizonVolumeQuantities::apply(
   auto& extrinsic_curvature =
       get<gr::Tags::ExtrinsicCurvature<DataVector, 3>>(*target_vars);
   auto& spatial_christoffel_second_kind =
-      get<gr::Tags::SpatialChristoffelSecondKind<DataVector, 3>>(
-          *target_vars);
+      get<gr::Tags::SpatialChristoffelSecondKind<DataVector, 3>>(*target_vars);
 
   // These are always temporaries.
   auto& lapse = get<lapse_tag>(buffer);
@@ -106,10 +102,9 @@ void ComputeHorizonVolumeQuantities::apply(
   auto& spacetime_normal_vector = get<spacetime_normal_vector_tag>(buffer);
 
   // These may or may not be temporaries
-  auto& metric = *(get<metric_tag>(
-      target_vars, make_not_null(&buffer)));
-  auto& inv_metric = *(get<inv_metric_tag>(
-      target_vars, make_not_null(&buffer)));
+  auto& metric = *(get<metric_tag>(target_vars, make_not_null(&buffer)));
+  auto& inv_metric =
+      *(get<inv_metric_tag>(target_vars, make_not_null(&buffer)));
 
   // Actual computation starts here
 
@@ -122,24 +117,23 @@ void ComputeHorizonVolumeQuantities::apply(
   gr::spacetime_normal_vector(make_not_null(&spacetime_normal_vector), lapse,
                               shift);
   gh::extrinsic_curvature(make_not_null(&extrinsic_curvature),
-                                           spacetime_normal_vector, pi, phi);
-  gh::christoffel_second_kind(
-      make_not_null(&spatial_christoffel_second_kind), phi, inv_metric);
+                          spacetime_normal_vector, pi, phi);
+  gh::christoffel_second_kind(make_not_null(&spatial_christoffel_second_kind),
+                              phi, inv_metric);
 
-  if constexpr (tmpl::list_contains_v<
-                    DestTagList, gr::Tags::SpatialRicci<DataVector, 3>>) {
+  if constexpr (tmpl::list_contains_v<DestTagList,
+                                      gr::Tags::SpatialRicci<DataVector, 3>>) {
     static_assert(
-        tmpl::list_contains_v<
-            SrcTagList,
-            Tags::deriv<gh::Tags::Phi<DataVector, 3>,
-                        tmpl::size_t<3>, Frame::Inertial>>,
+        tmpl::list_contains_v<SrcTagList,
+                              Tags::deriv<gh::Tags::Phi<DataVector, 3>,
+                                          tmpl::size_t<3>, Frame::Inertial>>,
         "If Ricci is requested, SrcTags must include deriv of Phi");
     auto& spatial_ricci =
         get<gr::Tags::SpatialRicci<DataVector, 3>>(*target_vars);
     gh::spatial_ricci_tensor(
         make_not_null(&spatial_ricci), phi,
-        get<Tags::deriv<gh::Tags::Phi<DataVector, 3>,
-                        tmpl::size_t<3>, Frame::Inertial>>(src_vars),
+        get<Tags::deriv<gh::Tags::Phi<DataVector, 3>, tmpl::size_t<3>,
+                        Frame::Inertial>>(src_vars),
         inv_metric);
   }
 }
@@ -150,13 +144,13 @@ void ComputeHorizonVolumeQuantities::apply(
     const gsl::not_null<Variables<DestTagList>*> target_vars,
     const Variables<SrcTagList>& src_vars, const Mesh<3>& mesh,
     const Jacobian<DataVector, 3, TargetFrame, Frame::Inertial>&
-      jac_target_to_inertial,
+        jac_target_to_inertial,
     const InverseJacobian<DataVector, 3, TargetFrame, Frame::Inertial>&
-      /*invjac_target_to_inertial*/,
+    /*invjac_target_to_inertial*/,
     const Jacobian<DataVector, 3, Frame::ElementLogical, TargetFrame>&
-      /*jac_logical_to_target*/,
+    /*jac_logical_to_target*/,
     const InverseJacobian<DataVector, 3, Frame::ElementLogical, TargetFrame>&
-      invjac_logical_to_target,
+        invjac_logical_to_target,
     const tnsr::I<DataVector, 3, Frame::Inertial>& /*inertial_mesh_velocity*/) {
   static_assert(
       std::is_same_v<tmpl::list_difference<SrcTagList, allowed_src_tags>,
@@ -182,12 +176,9 @@ void ComputeHorizonVolumeQuantities::apply(
           tmpl::list<>>,
       "A required dest tag is missing");
 
-  const auto& psi =
-      get<gr::Tags::SpacetimeMetric<DataVector, 3>>(src_vars);
-  const auto& pi =
-      get<gh::Tags::Pi<DataVector, 3>>(src_vars);
-  const auto& phi =
-      get<gh::Tags::Phi<DataVector, 3>>(src_vars);
+  const auto& psi = get<gr::Tags::SpacetimeMetric<DataVector, 3>>(src_vars);
+  const auto& pi = get<gh::Tags::Pi<DataVector, 3>>(src_vars);
+  const auto& phi = get<gh::Tags::Phi<DataVector, 3>>(src_vars);
 
   if (target_vars->number_of_grid_points() !=
       src_vars.number_of_grid_points()) {
@@ -204,10 +195,8 @@ void ComputeHorizonVolumeQuantities::apply(
 
   // Additional temporary tags used for multiple frames
   using inertial_metric_tag = gr::Tags::SpatialMetric<DataVector, 3>;
-  using inertial_inv_metric_tag =
-      gr::Tags::InverseSpatialMetric<DataVector, 3>;
-  using inertial_ex_curvature_tag =
-      gr::Tags::ExtrinsicCurvature<DataVector, 3>;
+  using inertial_inv_metric_tag = gr::Tags::InverseSpatialMetric<DataVector, 3>;
+  using inertial_ex_curvature_tag = gr::Tags::ExtrinsicCurvature<DataVector, 3>;
   using logical_deriv_metric_tag = ::Tags::TempTensor<
       6, Tensor<DataVector, tmpl::integral_list<std::int32_t, 2, 1, 1>,
                 index_list<SpatialIndex<3, UpLo::Lo, Frame::ElementLogical>,
@@ -250,18 +239,15 @@ void ComputeHorizonVolumeQuantities::apply(
 
   // These may or may not be temporaries, depending on if they are asked for
   // in target_vars.
-  auto& inertial_metric = *(get<inertial_metric_tag>(
-      target_vars, make_not_null(&buffer)));
+  auto& inertial_metric =
+      *(get<inertial_metric_tag>(target_vars, make_not_null(&buffer)));
   auto& inertial_inv_metric =
-      *(get<inertial_inv_metric_tag>(
-          target_vars, make_not_null(&buffer)));
+      *(get<inertial_inv_metric_tag>(target_vars, make_not_null(&buffer)));
   auto& inertial_ex_curvature =
-      *(get<inertial_ex_curvature_tag>(
-          target_vars, make_not_null(&buffer)));
-  auto& metric = *(get<metric_tag>(
-      target_vars, make_not_null(&buffer)));
-  auto& inv_metric = *(get<inv_metric_tag>(
-      target_vars, make_not_null(&buffer)));
+      *(get<inertial_ex_curvature_tag>(target_vars, make_not_null(&buffer)));
+  auto& metric = *(get<metric_tag>(target_vars, make_not_null(&buffer)));
+  auto& inv_metric =
+      *(get<inv_metric_tag>(target_vars, make_not_null(&buffer)));
 
   // Actual computation starts here
 
@@ -275,8 +261,8 @@ void ComputeHorizonVolumeQuantities::apply(
   gr::lapse(make_not_null(&lapse), shift, psi);
   gr::spacetime_normal_vector(make_not_null(&spacetime_normal_vector), lapse,
                               shift);
-  gh::extrinsic_curvature(
-      make_not_null(&inertial_ex_curvature), spacetime_normal_vector, pi, phi);
+  gh::extrinsic_curvature(make_not_null(&inertial_ex_curvature),
+                          spacetime_normal_vector, pi, phi);
 
   // Transform spatial metric and extrinsic curvature
   transform::to_different_frame(make_not_null(&metric), inertial_metric,
@@ -292,10 +278,9 @@ void ComputeHorizonVolumeQuantities::apply(
   // Differentiate 3-metric.
   logical_partial_derivative(make_not_null(&logical_deriv_metric), metric,
                              mesh);
-  transform::first_index_to_different_frame(
-      make_not_null(&deriv_metric),
-      logical_deriv_metric,
-      invjac_logical_to_target);
+  transform::first_index_to_different_frame(make_not_null(&deriv_metric),
+                                            logical_deriv_metric,
+                                            invjac_logical_to_target);
   gr::christoffel_second_kind(make_not_null(&spatial_christoffel_second_kind),
                               deriv_metric, inv_metric);
 
@@ -320,19 +305,17 @@ void ComputeHorizonVolumeQuantities::apply(
                     DestTagList,
                     gr::Tags::SpatialRicci<DataVector, 3, TargetFrame>>) {
     static_assert(
-        tmpl::list_contains_v<
-            SrcTagList,
-            Tags::deriv<gh::Tags::Phi<DataVector, 3>,
-                        tmpl::size_t<3>, Frame::Inertial>>,
+        tmpl::list_contains_v<SrcTagList,
+                              Tags::deriv<gh::Tags::Phi<DataVector, 3>,
+                                          tmpl::size_t<3>, Frame::Inertial>>,
         "If Ricci is requested, SrcTags must include deriv of Phi");
 
     auto& inertial_spatial_ricci =
-        *(get<inertial_spatial_ricci_tag>(
-            target_vars, make_not_null(&buffer)));
+        *(get<inertial_spatial_ricci_tag>(target_vars, make_not_null(&buffer)));
     gh::spatial_ricci_tensor(
         make_not_null(&inertial_spatial_ricci), phi,
-        get<Tags::deriv<gh::Tags::Phi<DataVector, 3>,
-                        tmpl::size_t<3>, Frame::Inertial>>(src_vars),
+        get<Tags::deriv<gh::Tags::Phi<DataVector, 3>, tmpl::size_t<3>,
+                        Frame::Inertial>>(src_vars),
         inertial_inv_metric);
 
     if constexpr (tmpl::list_contains_v<

--- a/src/ApparentHorizons/ComputeHorizonVolumeQuantities.tpp
+++ b/src/ApparentHorizons/ComputeHorizonVolumeQuantities.tpp
@@ -151,7 +151,9 @@ void ComputeHorizonVolumeQuantities::apply(
     /*jac_logical_to_target*/,
     const InverseJacobian<DataVector, 3, Frame::ElementLogical, TargetFrame>&
         invjac_logical_to_target,
-    const tnsr::I<DataVector, 3, Frame::Inertial>& /*inertial_mesh_velocity*/) {
+    const tnsr::I<DataVector, 3, Frame::Inertial>& /*inertial_mesh_velocity*/,
+    const tnsr::I<DataVector, 3, TargetFrame>&
+    /*grid_to_target_frame_mesh_velocity*/) {
   static_assert(
       std::is_same_v<tmpl::list_difference<SrcTagList, allowed_src_tags>,
                      tmpl::list<>>,

--- a/src/ParallelAlgorithms/Interpolation/Protocols/ComputeVarsToInterpolate.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Protocols/ComputeVarsToInterpolate.hpp
@@ -92,8 +92,14 @@ struct ComputeVarsToInterpolate {
             std::declval<const Mesh<Dim>&>(),
             std::declval<const Jacobian<DataVector, Dim, Frame::Grid,
                                         Frame::Inertial>&>(),
+            std::declval<const InverseJacobian<DataVector, Dim, Frame::Grid,
+                                               Frame::Inertial>&>(),
+            std::declval<const Jacobian<DataVector, Dim, Frame::ElementLogical,
+                                        Frame::Grid>&>(),
             std::declval<const InverseJacobian<
-                DataVector, Dim, Frame::ElementLogical, Frame::Grid>&>()))>>
+                DataVector, Dim, Frame::ElementLogical, Frame::Grid>&>(),
+            std::declval<const tnsr::I<DataVector, Dim, Frame::Inertial>&>(),
+            std::declval<const tnsr::I<DataVector, Dim, Frame::Grid>&>()))>>
         : std::true_type {};
 
     static_assert(has_signature_1<ConformingType, 1>::value or

--- a/tests/Unit/ApparentHorizons/Test_ComputeExcisionBoundaryVolumeQuantities.cpp
+++ b/tests/Unit/ApparentHorizons/Test_ComputeExcisionBoundaryVolumeQuantities.cpp
@@ -212,8 +212,7 @@ void test_compute_excision_boundary_volume_quantities() {
         std::get<3>(coords_frame_velocity_jacobians);
     inv_jacobian_target_to_inertial =
         std::get<1>(coords_frame_velocity_jacobians);
-    jacobian_target_to_inertial =
-        std::get<2>(coords_frame_velocity_jacobians);
+    jacobian_target_to_inertial = std::get<2>(coords_frame_velocity_jacobians);
 
     // Now compute metric variables and transform them into the
     // inertial frame.  We transform lapse, shift, 3-metric.  Then we
@@ -253,7 +252,8 @@ void test_compute_excision_boundary_volume_quantities() {
     ah::ComputeExcisionBoundaryVolumeQuantities::apply(
         make_not_null(&dest_vars), src_vars, mesh, jacobian_target_to_inertial,
         inv_jacobian_target_to_inertial, jacobian_logical_to_target,
-        inv_jacobian_logical_to_target, frame_velocity_grid_to_inertial);
+        inv_jacobian_logical_to_target, frame_velocity_grid_to_inertial,
+        tnsr::I<DataVector, 3, TargetFrame>{});
   } else {
     // time-independent.
     ah::ComputeExcisionBoundaryVolumeQuantities::apply(
@@ -335,8 +335,8 @@ SPECTRE_TEST_CASE(
   static_assert(
       tt::assert_conforms_to_v<ah::ComputeExcisionBoundaryVolumeQuantities,
                                intrp::protocols::ComputeVarsToInterpolate>);
-    // time-independent.
-    // All possible tags.
+  // time-independent.
+  // All possible tags.
   test_compute_excision_boundary_volume_quantities<
       std::false_type, Frame::Inertial,
       tmpl::list<gr::Tags::SpacetimeMetric<DataVector, 3>,

--- a/tests/Unit/ApparentHorizons/Test_ComputeHorizonVolumeQuantities.cpp
+++ b/tests/Unit/ApparentHorizons/Test_ComputeHorizonVolumeQuantities.cpp
@@ -351,7 +351,8 @@ void test_compute_horizon_volume_quantities() {
     ah::ComputeHorizonVolumeQuantities::apply(
         make_not_null(&dest_vars), src_vars, mesh, jacobian_target_to_inertial,
         inv_jacobian_target_to_inertial, jacobian_logical_to_target,
-        inv_jacobian_logical_to_target, inertial_mesh_velocity);
+        inv_jacobian_logical_to_target, inertial_mesh_velocity,
+        tnsr::I<DataVector, 3, TargetFrame>{});
   } else {
     // time-independent.
     ah::ComputeHorizonVolumeQuantities::apply(make_not_null(&dest_vars),

--- a/tests/Unit/Helpers/ParallelAlgorithms/Interpolation/Examples.hpp
+++ b/tests/Unit/Helpers/ParallelAlgorithms/Interpolation/Examples.hpp
@@ -104,10 +104,16 @@ struct ExampleComputeVarsToInterpolate
       const gsl::not_null<Variables<DestTagList>*> /*target_vars*/,
       const Variables<SrcTagList>& /*src_vars*/, const Mesh<Dim>& /*mesh*/,
       const Jacobian<DataVector, Dim, TargetFrame,
-                     Frame::Inertial>& /*jacobian*/,
-      const InverseJacobian<DataVector, Dim, Frame::ElementLogical,
-                            TargetFrame>&
-      /*inverse_jacobian*/) {
+                     Frame::Inertial>& /*jacobian_target_to_inertial*/,
+      const InverseJacobian<DataVector, Dim, TargetFrame, Frame::Inertial>&
+      /*inverse_jacobian_target_to_inertial*/,
+      const Jacobian<DataVector, 3, Frame::ElementLogical, TargetFrame>&
+      /*jac_logical_to_target*/,
+      const InverseJacobian<DataVector, 3, Frame::ElementLogical, TargetFrame>&
+      /*invjac_logical_to_target*/,
+      const tnsr::I<DataVector, 3, Frame::Inertial>& /*inertial_mesh_velocity*/,
+      const tnsr::I<DataVector, 3, TargetFrame>&
+      /*grid_to_target_frame_mesh_velocity*/) {
     // Need to switch frames first
     // Do some GR calculations to get correct variables
     // Then modify target_vars


### PR DESCRIPTION
## Proposed changes

I will need this quantity for size control. This just passes it, but it's currently not used. That will be a future PR.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
