### PR TITLE
Allow control sys Info and state to be copyable

### DIFF
--- a/src/ApparentHorizons/TimeDerivStrahlkorper.cpp
+++ b/src/ApparentHorizons/TimeDerivStrahlkorper.cpp
@@ -46,6 +46,14 @@ void time_deriv_of_strahlkorper(
   std::deque<const DataVector*> coefficients{};
 
   for (const auto& [time, strahlkorper] : previous_strahlkorpers) {
+    // This only happens toward the beginning because the first time is NaN and
+    // if that happens we can't actually take a derivative
+    if (UNLIKELY(std::isnan(time))) {
+      time_deriv->coefficients() =
+          DataVector{strahlkorper.coefficients().size(), 0.0};
+      return;
+    }
+
     times.emplace_back(time);
     coefficients.emplace_back(&strahlkorper.coefficients());
   }

--- a/src/ControlSystem/ControlErrors/Size/AhSpeed.hpp
+++ b/src/ControlSystem/ControlErrors/Size/AhSpeed.hpp
@@ -13,6 +13,8 @@ namespace control_system::size::States {
 class AhSpeed : public State {
  public:
   AhSpeed() = default;
+  std::string name() const override { return "AhSpeed"; }
+  size_t number() const override { return 1; }
   std::unique_ptr<State> get_clone() const override;
   void update(const gsl::not_null<Info*> info,
               const StateUpdateArgs& update_args,

--- a/src/ControlSystem/ControlErrors/Size/DeltaR.hpp
+++ b/src/ControlSystem/ControlErrors/Size/DeltaR.hpp
@@ -13,6 +13,8 @@ namespace control_system::size::States {
 class DeltaR : public State {
  public:
   DeltaR() = default;
+  std::string name() const override { return "DeltaR"; }
+  size_t number() const override { return 2; }
   std::unique_ptr<State> get_clone() const override;
   void update(const gsl::not_null<Info*> info,
               const StateUpdateArgs& update_args,

--- a/src/ControlSystem/ControlErrors/Size/Info.cpp
+++ b/src/ControlSystem/ControlErrors/Size/Info.cpp
@@ -10,6 +10,28 @@
 #include "Utilities/Serialization/CharmPupable.hpp"
 
 namespace control_system::size {
+Info::Info(std::unique_ptr<State> in_state, double in_damping_time,
+           double in_target_char_speed, double in_target_drift_velocity,
+           double in_suggested_time_scale,
+           bool in_discontinuous_change_has_occurred)
+    : state(std::move(in_state)),
+      damping_time(in_damping_time),
+      target_char_speed(in_target_char_speed),
+      target_drift_velocity(in_target_drift_velocity),
+      suggested_time_scale(in_suggested_time_scale),
+      discontinuous_change_has_occurred(in_discontinuous_change_has_occurred) {}
+
+// NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init,-warnings-as-errors)
+Info::Info(const Info& rhs) {
+  set_all_but_state(rhs);
+  state = rhs.state->get_clone();
+}
+
+Info& Info::operator=(const Info& rhs) {
+  set_all_but_state(rhs);
+  state = rhs.state->get_clone();
+  return *this;
+}
 
 void Info::pup(PUP::er& p) {
   p | state;
@@ -18,6 +40,14 @@ void Info::pup(PUP::er& p) {
   p | target_drift_velocity;
   p | suggested_time_scale;
   p | discontinuous_change_has_occurred;
+}
+
+void Info::set_all_but_state(const Info& info) {
+  damping_time = info.damping_time;
+  target_char_speed = info.target_char_speed;
+  target_drift_velocity = info.target_drift_velocity;
+  suggested_time_scale = info.suggested_time_scale;
+  discontinuous_change_has_occurred = info.discontinuous_change_has_occurred;
 }
 
 CrossingTimeInfo::CrossingTimeInfo(

--- a/src/ControlSystem/ControlErrors/Size/Info.hpp
+++ b/src/ControlSystem/ControlErrors/Size/Info.hpp
@@ -16,6 +16,17 @@ namespace control_system::size {
 
 /// Holds information that is saved between calls of SizeControl.
 struct Info {
+  Info() = default;
+  Info(const Info& rhs);
+  Info& operator=(const Info& rhs);
+  Info(Info&& rhs) = default;
+  Info& operator=(Info&& rhs) = default;
+
+  Info(std::unique_ptr<State> in_state, double in_damping_time,
+       double in_target_char_speed, double in_target_drift_velocity,
+       double in_suggested_time_scale,
+       bool in_discontinuous_change_has_occurred);
+
   // Info needs to be serializable because it will be
   // stored inside of a ControlError.
   void pup(PUP::er& p);
@@ -38,6 +49,9 @@ struct Info {
   /// State::update if it changes anything in such a way that
   /// the control signal jumps discontinuously in time.
   bool discontinuous_change_has_occurred;
+
+ private:
+  void set_all_but_state(const Info& info);
 };
 
 /// Holds information about crossing times, as computed by

--- a/src/ControlSystem/ControlErrors/Size/Initial.hpp
+++ b/src/ControlSystem/ControlErrors/Size/Initial.hpp
@@ -13,6 +13,8 @@ namespace control_system::size::States {
 class Initial : public State {
  public:
   Initial() = default;
+  std::string name() const override { return "Initial"; }
+  size_t number() const override { return 0; }
   std::unique_ptr<State> get_clone() const override;
   void update(const gsl::not_null<Info*> info,
               const StateUpdateArgs& update_args,

--- a/src/ControlSystem/ControlErrors/Size/State.hpp
+++ b/src/ControlSystem/ControlErrors/Size/State.hpp
@@ -117,6 +117,12 @@ class State : public PUP::able {
   State& operator=(State&& /*rhs*/) = default;
   virtual ~State() override = default;
 
+  /// Name of this state
+  virtual std::string name() const = 0;
+
+  /// Return a size_t that corresponds to the state number in SpEC
+  virtual size_t number() const = 0;
+
   virtual std::unique_ptr<State> get_clone() const = 0;
   /// Updates the Info in `info`.  Notice that `info`
   /// includes a state, which might be different than the current

--- a/src/NumericalAlgorithms/Interpolation/ZeroCrossingPredictor.hpp
+++ b/src/NumericalAlgorithms/Interpolation/ZeroCrossingPredictor.hpp
@@ -27,12 +27,6 @@ class ZeroCrossingPredictor {
   ZeroCrossingPredictor(size_t min_size, size_t max_size);
 
   ZeroCrossingPredictor() = default;
-  ZeroCrossingPredictor(const ZeroCrossingPredictor& /*rhs*/) = delete;
-  ZeroCrossingPredictor& operator=(const ZeroCrossingPredictor& /*rhs*/) =
-      delete;
-  ZeroCrossingPredictor(ZeroCrossingPredictor&& /*rhs*/) = default;
-  ZeroCrossingPredictor& operator=(ZeroCrossingPredictor&& rhs) = default;
-  ~ZeroCrossingPredictor() = default;
 
   /// Adds a data point at time t to the ZeroCrossingPredictor.
   void add(double t, DataVector data_at_time_t);

--- a/tests/Unit/ApparentHorizons/Test_TimeDerivStrahlkorper.cpp
+++ b/tests/Unit/ApparentHorizons/Test_TimeDerivStrahlkorper.cpp
@@ -30,8 +30,12 @@ void test_time_deriv_strahlkorper() {
 
     // Set all strahlkorpers to be the same
     for (size_t i = 0; i < num_times; i++) {
-      previous_strahlkorpers.emplace_front(
-          std::make_pair(static_cast<double>(i), strahlkorper));
+      // If num_times = 3, set one of the times == NaN to test that we get back
+      // zero
+      previous_strahlkorpers.emplace_front(std::make_pair(
+          (num_times == 3 and i == 0) ? std::numeric_limits<double>::quiet_NaN()
+                                      : static_cast<double>(i),
+          strahlkorper));
     }
 
     auto time_deriv = strahlkorper;
@@ -41,8 +45,8 @@ void test_time_deriv_strahlkorper() {
 
     const DataVector& time_deriv_strahlkorper_coefs = time_deriv.coefficients();
 
-    // Since we made all the Strahlkorpers the same, the time deriv should be
-    // zero.
+    // Since we made all the Strahlkorpers the same (or there is a NaN time),
+    // the time deriv should be zero.
     CHECK_ITERABLE_APPROX(
         time_deriv_strahlkorper_coefs,
         (DataVector{time_deriv_strahlkorper_coefs.size(), 0.0}));

--- a/tests/Unit/ControlSystem/ControlErrors/Test_SizeControlStates.cpp
+++ b/tests/Unit/ControlSystem/ControlErrors/Test_SizeControlStates.cpp
@@ -395,6 +395,19 @@ void test_clone_and_serialization() {
   CHECK(dynamic_cast<State*>(state->get_clone().get()) != nullptr);
 }
 
+void test_name_and_number() {
+  const control_system::size::States::Initial initial{};
+  const control_system::size::States::AhSpeed ah_speed{};
+  const control_system::size::States::DeltaR delta_r{};
+
+  CHECK(initial.name() == "Initial"s);
+  CHECK(initial.number() == 0_st);
+  CHECK(ah_speed.name() == "AhSpeed"s);
+  CHECK(ah_speed.number() == 1_st);
+  CHECK(delta_r.name() == "DeltaR"s);
+  CHECK(delta_r.number() == 2_st);
+}
+
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.ControlSystem.SizeControlStates", "[Domain][Unit]") {
@@ -404,4 +417,5 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.SizeControlStates", "[Domain][Unit]") {
   test_clone_and_serialization<control_system::size::States::Initial>();
   test_clone_and_serialization<control_system::size::States::AhSpeed>();
   test_clone_and_serialization<control_system::size::States::DeltaR>();
+  test_name_and_number();
 }

--- a/tests/Unit/ControlSystem/ControlErrors/Test_SizeControlStates.cpp
+++ b/tests/Unit/ControlSystem/ControlErrors/Test_SizeControlStates.cpp
@@ -54,6 +54,9 @@ void do_test(const TestParams& test_params,
 
   // Check serialization of info
   const auto info_copy = serialize_and_deserialize(info);
+  CHECK_FALSE(info.state == nullptr);
+  const auto info_copy2 = info_copy;
+  CHECK_FALSE(info_copy2.state == nullptr);
   // Note that there is no equality operator for info.state, because the
   // state contains no data; so here we check that the state can be cast to
   // the type it should be.

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_ZeroCrossingPredictor.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_ZeroCrossingPredictor.cpp
@@ -66,6 +66,11 @@ void test_zero_crossing_predictor() {
   CHECK(predictor == serialize_and_deserialize(predictor));
   CHECK_FALSE(predictor != serialize_and_deserialize(predictor));
 
+  test_copy_semantics(predictor);
+  test_move_semantics(serialize_and_deserialize(predictor),
+                      serialize_and_deserialize(predictor), min_size,
+                      x_values.size());
+
   Approx custom_approx = Approx::custom().epsilon(5e-6).scale(1.0);
   CHECK_ITERABLE_CUSTOM_APPROX(
       predictor.zero_crossing_time(x_values.back()),


### PR DESCRIPTION
## Proposed changes

Also handle a NaN in the time deriv of a strahlkorper, and make the `ZeroCrossingPredictor` copyable. This is all needed for size control.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
