### PR TITLE
Allow extract-dat to extract single subfile to stdout

### DIFF
--- a/src/IO/H5/Python/ExtractDatFromH5.py
+++ b/src/IO/H5/Python/ExtractDatFromH5.py
@@ -9,14 +9,11 @@ import click
 import multiprocessing as mp
 import numpy as np
 import os
+import pandas as pd
 import shutil
 
 
-def save_dat_data(dat_path, h5_filename, out_dir):
-    dat_dir = os.path.join(out_dir, os.path.dirname(dat_path))
-    os.makedirs(dat_dir, exist_ok=True)
-    dat_filename = os.path.join(out_dir, dat_path)
-
+def write_dat_data(dat_path, h5_filename, out_dir, precision):
     with h5py.File(h5_filename, "r") as h5file:
         dat_file = h5file.get(dat_path)
         legend = dat_file.attrs["Legend"]
@@ -25,56 +22,88 @@ def save_dat_data(dat_path, h5_filename, out_dir):
     header = "\n".join(f"[{i}] " + "{}"
                        for i in range(len(legend))).format(*legend)
 
+    format_string = f"%.{precision}e"
+
+    # Write to stdout
+    if not out_dir:
+        print(
+            pd.DataFrame(dat_data).to_string(index=False,
+                                             header=legend,
+                                             float_format=format_string,
+                                             justify="left"))
+        return
+
+    dat_dir = os.path.join(out_dir, os.path.dirname(dat_path))
+    os.makedirs(dat_dir, exist_ok=True)
+    dat_filename = os.path.join(out_dir, dat_path)
+
     np.savetxt(dat_filename,
                dat_data,
                delimiter=' ',
-               fmt="% .15e",
+               fmt=format_string,
                header=header)
 
 
-def extract_dat_files(filename, out_dir, num_cores, list=False, force=False):
+def get_all_dat_files(filename):
+    with h5py.File(filename, "r") as h5file:
+        return available_subfiles(h5file, extension=".dat")
+
+
+def extract_dat_files(filename,
+                      out_dir,
+                      num_cores,
+                      precision,
+                      list=False,
+                      force=False,
+                      subfiles=None):
     """Extract dat files from an H5 file
 
     Extract all Dat files inside a SpECTRE HDF5 file. The resulting files will
     be put into the 'OUT_DIR'. The directory structure will be identical to the
     group structure inside the HDF5 file.
     """
-    with h5py.File(filename, "r") as h5file:
-        all_dat_files = available_subfiles(h5file, extension=".dat")
-
     if list:
-        print_str = "\n ".join(all_dat_files)
+        print_str = "\n ".join(get_all_dat_files(filename))
         print(f"Dat files within '{filename}':\n {print_str}")
         return
 
-    if out_dir is None:
-        raise ValueError(
-            "An output directory is required unless listing file content.")
-    if not os.path.exists(out_dir):
-        os.mkdir(out_dir)
+    if subfiles:
+        all_dat_files = subfiles
     else:
-        if force:
-            shutil.rmtree(out_dir, ignore_errors=True)
+        all_dat_files = get_all_dat_files(filename)
+
+    if out_dir:
+        if not os.path.exists(out_dir):
             os.mkdir(out_dir)
         else:
+            if force:
+                shutil.rmtree(out_dir, ignore_errors=True)
+                os.mkdir(out_dir)
+            else:
+                raise ValueError(
+                    f"Could not make directory '{out_dir}'. Already exists.")
+    else:
+        if subfiles and len(subfiles) > 1:
             raise ValueError(
-                f"Could not make directory '{out_dir}'. Already exists.")
+                "If no output directory is specified, can only write "
+                f"one subfile to stdout, not {len(subfiles)}")
 
     num_dat_files = len(all_dat_files)
 
-    # Only use multiprocessing if we are using more than one core. Otherwise
-    # avoid the overhead
-    if num_cores > 1:
+    # Only use multiprocessing if we are writing to a directory and using more
+    # than one core. Otherwise avoid the overhead
+    if out_dir and num_cores > 1:
         with mp.Pool(processes=num_cores) as pool:
             pool.starmap(
-                save_dat_data,
+                write_dat_data,
                 zip(all_dat_files, [filename] * num_dat_files,
-                    [out_dir] * num_dat_files))
+                    [out_dir] * num_dat_files, [precision] * num_dat_files))
     else:
         for dat_filename in all_dat_files:
-            save_dat_data(dat_filename, filename, out_dir)
+            write_dat_data(dat_filename, filename, out_dir, precision)
 
-    print(f"Successfully extracted all Dat files into '{out_dir}'")
+    if out_dir:
+        print(f"Successfully extracted all Dat files into '{out_dir}'")
 
 
 @click.command(help=extract_dat_files.__doc__)
@@ -91,6 +120,11 @@ def extract_dat_files(filename, out_dir, num_cores, list=False, force=False):
               default=1,
               show_default=True,
               help="Number of cores to run on.")
+@click.option('--precision',
+              '-p',
+              default=16,
+              show_default=True,
+              help="Precision with which to save (or print) the data.")
 @click.option('--force',
               '-f',
               is_flag=True,
@@ -99,6 +133,11 @@ def extract_dat_files(filename, out_dir, num_cores, list=False, force=False):
               '-l',
               is_flag=True,
               help="List all dat files in the HDF5 file and exit.")
+@click.option('--subfile',
+              '-d',
+              "subfiles",
+              multiple=True,
+              help="Full path of subfile to extract (including extension).")
 def extract_dat_command(**kwargs):
     _rich_traceback_guard = True  # Hide traceback until here
     extract_dat_files(**kwargs)


### PR DESCRIPTION
## Proposed changes

Fixes #4972 

Prints something like (for a 1 line dat file)
```
 Time  NumberOfPoints       Volume  L2Norm(GaugeConstraint)  L2Norm(ThreeIndexConstraint)
 0.02        154350.0 4.188761e+06             5.762183e-08                      0.000002
```

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
