### PR TITLE
Add baryon mass to eos

### DIFF
--- a/src/Executables/ExportEquationOfStateForRotNS/ExportEquationOfStateForRotNS.cpp
+++ b/src/Executables/ExportEquationOfStateForRotNS/ExportEquationOfStateForRotNS.cpp
@@ -41,7 +41,9 @@ void dump_barotropic_eos(
   // might be different from the baryon mass that the EoS uses.
   //
   // https://github.com/sxs-collaboration/spectre/issues/4694
-  const double baryon_mass_of_rotns_cgs = 1.659e-24;
+  const double baryon_mass_of_rotns_cgs =
+      hydro::units::geometric::default_baryon_mass *
+      hydro::units::cgs::mass_unit;
   const double log10_lower_bound_number_density_cgs =
       log10(lower_bound_rest_mass_density_cgs / baryon_mass_of_rotns_cgs);
   const double log10_upper_bound_number_density_cgs =
@@ -66,15 +68,13 @@ void dump_barotropic_eos(
         pow(10.0, log10_lower_bound_number_density_cgs +
                       static_cast<double>(log10_number_density_index) *
                           delta_log_number_density_cgs);
-    const double rest_mass_density_cgs =
-        number_density_cgs * baryon_mass_of_rotns_cgs;
 
     // Note: we will want to add the baryon mass to our EOS interface.
     //
     // https://github.com/sxs-collaboration/spectre/issues/4694
-    const double baryon_mass_of_eos_cgs = baryon_mass_of_rotns_cgs;
-    const Scalar<double> rest_mass_density_geometric{rest_mass_density_cgs /
-                                                     baryon_mass_of_eos_cgs};
+    const Scalar<double> rest_mass_density_geometric{
+        number_density_cgs * cube(hydro::units::cgs::length_unit) *
+        eos.baryon_mass()};
     const Scalar<double> pressure_geometric =
         eos.pressure_from_density(rest_mass_density_geometric);
     const Scalar<double> specific_internal_energy_geometric =
@@ -83,11 +83,11 @@ void dump_barotropic_eos(
         get(rest_mass_density_geometric) *
         (1.0 + get(specific_internal_energy_geometric))};
 
-    // Note: the energy density is divided by c^2, so the rest-mass part is rho
-    // c^2
+    // Note: the energy density is divided by c^2
     const double total_energy_density_cgs =
         get(total_energy_density_geometric) *
-        hydro::units::cgs::rest_mass_density_unit;
+        hydro::units::cgs::rest_mass_density_unit *
+        square(hydro::units::cgs::speed_of_light);
 
     // should be dyne cm^(-3)
     const double pressure_cgs =

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/CcsnCollapse.hpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/CcsnCollapse.hpp
@@ -14,6 +14,7 @@
 #include "PointwiseFunctions/AnalyticData/AnalyticData.hpp"
 #include "PointwiseFunctions/AnalyticData/GrMhd/AnalyticData.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/PolytropicFluid.hpp"
+#include "PointwiseFunctions/Hydro/Units.hpp"
 #include "PointwiseFunctions/InitialDataUtilities/InitialData.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
@@ -56,17 +57,16 @@ class ProgenitorProfile {
 
   // Begin constants to translate units from cgs to c=G=M_Sun=(k_Boltzmann=1)=1
   // Divide cm/s by speed_of_light_cgs_ to get into c=G=M_Sun=1 units
-  static constexpr double speed_of_light_cgs_ = 2.99792458e10;
+  static constexpr double speed_of_light_cgs_ =
+      hydro::units::cgs::speed_of_light;
 
   // Multiply cm by c2g_length_ to get into c=G=M_Sun=1 units
   // (speed of light)^2 / (Newton's constant * Msun)
   // c2g_length_ = c^2 / (G*M_Sun)
-  // Note G*M_Sun = 1.32712440042x10^26 +/- 1e16 [1/cm]
-  // G*M_Sun factor from https://doi.org/10.1063/1.4921980
   // c2g_length_~6.7706e-6 [1/cm]
-  static constexpr double g_times_m_sun_ = 1.32712440042e26;
-  static constexpr double c2g_length_ =
-      square(speed_of_light_cgs_) / g_times_m_sun_;
+  static constexpr double g_times_m_sun_ =
+      hydro::units::cgs::G_Newton_times_m_sun;
+  static constexpr double c2g_length_ = 1.0 / hydro::units::cgs::length_unit;
 
   // Multiply g/cm^3 by c2g_dens_ to get into c=G=M_Sun=1 units
   // c2g_dens_ = (G*M_Sun)^2*G/c^6.
@@ -76,25 +76,19 @@ class ProgenitorProfile {
   // a neutron star (~1%~10%), a quantity assumed to be 2.2 M_Sun when
   // converting to c=G=M_Sun=1 units; see
   // https://iopscience.iop.org/article/10.3847/2041-8213/aaa401.
-  // G factor from
-  // https://journals.aps.org/rmp/abstract/10.1103/RevModPhys.93.025010.
   // c2g_dens_~1.61887e-18 [cm^3/g]
-  static constexpr double newtons_grav_constant_ = 6.67430e-8;
-  static constexpr double c2g_dens_ = square(g_times_m_sun_) *
-                                      newtons_grav_constant_ /
-                                      pow<6>(speed_of_light_cgs_);
+  static constexpr double newtons_grav_constant_ = hydro::units::cgs::G_Newton;
+  static constexpr double c2g_dens_ =
+      1.0 / hydro::units::cgs::rest_mass_density_unit;
 
   // Multiply Kelvin by c2g_temp_ to get into c=G=M_Sun=k_Boltzmann=1 units.
   // c2g_temp_ = (k_B/(M_Sun*c^2))
-  // Note k_B = 1.380649e−16.
-  // k_B factor from
-  // https://journals.aps.org/rmp/pdf/10.1103/RevModPhys.93.025010.
   // c2g_temp_=7.72567e-71
-  static constexpr double boltzmann_constant_ = 1.380649e-16;
+  static constexpr double boltzmann_constant_ = hydro::units::cgs::k_Boltzmann;
   // Note setting MSun=1.0 is a choice made independent of EoS,
   // so that there are no unit ambiguities between 2 simulations
   // ran with different EoSs (e.g., polytropic vs. tabulated)
-  static constexpr double m_sun_ = g_times_m_sun_ / newtons_grav_constant_;
+  static constexpr double m_sun_ = hydro::units::cgs::mass_unit;
   static constexpr double c2g_temp_ =
       boltzmann_constant_ / (m_sun_ * square(speed_of_light_cgs_));
 

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/Enthalpy.hpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/Enthalpy.hpp
@@ -17,6 +17,7 @@
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Options/String.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"  // IWYU pragma: keep
+#include "PointwiseFunctions/Hydro/Units.hpp"
 #include "Utilities/Math.hpp"
 #include "Utilities/Serialization/CharmPupable.hpp"
 #include "Utilities/TMPL.hpp"
@@ -261,6 +262,9 @@ class Enthalpy : public EquationOfState<true, 1> {
 
   /// The lower bound of the specific enthalpy that is valid for this EOS
   double specific_enthalpy_lower_bound() const override { return 1.0; }
+
+  /// The vacuum baryon mass for this EoS
+  double baryon_mass() const override { return low_density_eos_.baryon_mass(); }
 
  private:
   EQUATION_OF_STATE_FORWARD_DECLARE_MEMBER_IMPLS(1)

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp
@@ -12,6 +12,7 @@
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "PointwiseFunctions/Hydro/Units.hpp"
 #include "Utilities/Serialization/CharmPupable.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TypeTraits.hpp"
@@ -45,11 +46,10 @@ struct DerivedClasses {};
 
 template <>
 struct DerivedClasses<true, 1> {
-  using type = tmpl::list<Enthalpy<Enthalpy<Enthalpy<Spectral>>>,
-                          Enthalpy<Enthalpy<Spectral>>, Enthalpy<Spectral>,
-                          Enthalpy<PolytropicFluid<true>>,
-                          PiecewisePolytropicFluid<true>, PolytropicFluid<true>,
-                          Spectral>;
+  using type = tmpl::list<
+      Enthalpy<Enthalpy<Enthalpy<Spectral>>>, Enthalpy<Enthalpy<Spectral>>,
+      Enthalpy<Spectral>, Enthalpy<PolytropicFluid<true>>,
+      PiecewisePolytropicFluid<true>, PolytropicFluid<true>, Spectral>;
 };
 
 template <>
@@ -275,6 +275,11 @@ class EquationOfState<IsRelativistic, 1> : public PUP::able {
 
   /// The lower bound of the specific enthalpy that is valid for this EOS
   virtual double specific_enthalpy_lower_bound() const = 0;
+
+  /// The vacuum mass of a baryon for this EOS
+  virtual double baryon_mass() const {
+    return hydro::units::geometric::default_baryon_mass;
+  }
 };
 
 /*!
@@ -454,6 +459,11 @@ class EquationOfState<IsRelativistic, 2> : public PUP::able {
 
   /// The lower bound of the specific enthalpy that is valid for this EOS
   virtual double specific_enthalpy_lower_bound() const = 0;
+
+  /// The vacuum mass of a baryon for this EOS
+  virtual double baryon_mass() const {
+    return hydro::units::geometric::default_baryon_mass;
+  }
 };
 
 /*!
@@ -544,13 +554,13 @@ class EquationOfState<IsRelativistic, 3> : public PUP::able {
       const Scalar<double>& /*rest_mass_density*/,
       const Scalar<double>& /*temperature*/,
       const Scalar<double>& /*electron_fraction*/
-      ) const = 0;
+  ) const = 0;
   virtual Scalar<DataVector>
   specific_internal_energy_from_density_and_temperature(
       const Scalar<DataVector>& /*rest_mass_density*/,
       const Scalar<DataVector>& /*temperature*/,
       const Scalar<DataVector>& /*electron_fraction*/
-      ) const = 0;
+  ) const = 0;
   /// @}
 
   /// @{
@@ -602,6 +612,11 @@ class EquationOfState<IsRelativistic, 3> : public PUP::able {
 
   /// The upper bound of the temperature that is valid for this EOS
   virtual double temperature_upper_bound() const = 0;
+
+  /// The vacuum mass of a baryon for this EOS
+  virtual double baryon_mass() const {
+    return hydro::units::geometric::default_baryon_mass;
+  }
 };
 
 /// Compare two equations of state for equality

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/HybridEos.hpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/HybridEos.hpp
@@ -17,6 +17,7 @@
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Options/String.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
+#include "PointwiseFunctions/Hydro/Units.hpp"
 #include "Utilities/Serialization/CharmPupable.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -129,6 +130,9 @@ class HybridEos
   double specific_enthalpy_lower_bound() const override {
     return cold_eos_.specific_enthalpy_lower_bound();
   }
+
+  /// The vacuum baryon mass for this EoS
+  double baryon_mass() const override { return cold_eos_.baryon_mass(); }
 
  private:
   EQUATION_OF_STATE_FORWARD_DECLARE_MEMBER_IMPLS(2)

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/IdealFluid.hpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/IdealFluid.hpp
@@ -16,6 +16,7 @@
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Options/String.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"  // IWYU pragma: keep
+#include "PointwiseFunctions/Hydro/Units.hpp"
 #include "Utilities/Serialization/CharmPupable.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -110,6 +111,11 @@ class IdealFluid : public EquationOfState<IsRelativistic, 2> {
   /// The lower bound of the specific enthalpy that is valid for this EOS
   double specific_enthalpy_lower_bound() const override {
     return IsRelativistic ? 1.0 : 0.0;
+  }
+
+  /// The vacuum baryon mass for this EoS
+  double baryon_mass() const override {
+    return hydro::units::geometric::default_baryon_mass;
   }
 
  private:

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/PiecewisePolytropicFluid.hpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/PiecewisePolytropicFluid.hpp
@@ -16,6 +16,7 @@
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Options/String.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"  // IWYU pragma: keep
+#include "PointwiseFunctions/Hydro/Units.hpp"
 #include "Utilities/Serialization/CharmPupable.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -157,6 +158,11 @@ class PiecewisePolytropicFluid : public EquationOfState<IsRelativistic, 1> {
   /// The lower bound of the specific enthalpy that is valid for this EOS
   double specific_enthalpy_lower_bound() const override {
     return IsRelativistic ? 1.0 : 0.0;
+  }
+
+  /// The vacuum baryon mass for this EoS
+  double baryon_mass() const override {
+    return hydro::units::geometric::default_baryon_mass;
   }
 
  private:

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/PolytropicFluid.hpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/PolytropicFluid.hpp
@@ -16,6 +16,7 @@
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Options/String.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"  // IWYU pragma: keep
+#include "PointwiseFunctions/Hydro/Units.hpp"
 #include "Utilities/Serialization/CharmPupable.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -108,6 +109,11 @@ class PolytropicFluid : public EquationOfState<IsRelativistic, 1> {
   /// The lower bound of the specific enthalpy that is valid for this EOS
   double specific_enthalpy_lower_bound() const override {
     return IsRelativistic ? 1.0 : 0.0;
+  }
+
+  /// The vacuum baryon mass for this EoS
+  double baryon_mass() const override {
+    return hydro::units::geometric::default_baryon_mass;
   }
 
  private:

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/Spectral.hpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/Spectral.hpp
@@ -18,6 +18,7 @@
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Options/String.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"  // IWYU pragma: keep
+#include "PointwiseFunctions/Hydro/Units.hpp"
 #include "Utilities/Math.hpp"
 #include "Utilities/Serialization/CharmPupable.hpp"
 #include "Utilities/TMPL.hpp"
@@ -141,6 +142,11 @@ class Spectral : public EquationOfState<true, 1> {
 
   /// The lower bound of the specific enthalpy that is valid for this EOS
   double specific_enthalpy_lower_bound() const override { return 1.0; }
+
+  /// The vacuum baryon mass for this EoS
+  double baryon_mass() const override {
+    return hydro::units::geometric::default_baryon_mass;
+  }
 
  private:
   EQUATION_OF_STATE_FORWARD_DECLARE_MEMBER_IMPLS(1)

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/Tabulated3d.hpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/Tabulated3d.hpp
@@ -19,6 +19,7 @@
 #include "NumericalAlgorithms/Interpolation/MultiLinearSpanInterpolation.hpp"
 #include "Options/String.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"  // IWYU pragma: keep
+#include "PointwiseFunctions/Hydro/Units.hpp"
 #include "Utilities/Serialization/CharmPupable.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -67,7 +68,7 @@ class Tabulated3D : public EquationOfState<IsRelativistic, 3> {
   using options = tmpl::list<TableFilename, TableSubFilename>;
 
   /// Fields stored in the table
-  enum : size_t { Epsilon = 0, Pressure, CsSquared, DeltaMu,  NumberOfVars };
+  enum : size_t { Epsilon = 0, Pressure, CsSquared, DeltaMu, NumberOfVars };
 
   Tabulated3D() = default;
   Tabulated3D(const Tabulated3D&) = default;
@@ -162,7 +163,6 @@ class Tabulated3D : public EquationOfState<IsRelativistic, 3> {
   WRAPPED_PUPable_decl_base_template(  // NOLINT
       SINGLE_ARG(EquationOfState<IsRelativistic, 3>), Tabulated3D);
 
-
   /// The lower bound of the electron fraction that is valid for this EOS
   double electron_fraction_lower_bound() const override {
     return table_electron_fraction_.front();
@@ -208,6 +208,11 @@ class Tabulated3D : public EquationOfState<IsRelativistic, 3> {
   /// The lower bound of the specific enthalpy that is valid for this EOS
   double specific_enthalpy_lower_bound() const override {
     return enthalpy_minimum_;
+  }
+
+  /// The baryon mass for this EoS
+  double baryon_mass() const override {
+    return hydro::units::geometric::neutron_mass;
   }
 
  private:

--- a/src/PointwiseFunctions/Hydro/Units.hpp
+++ b/src/PointwiseFunctions/Hydro/Units.hpp
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <cmath>
+
 namespace hydro {
 /*!
  * \brief Functions, constants, and classes for converting between different
@@ -19,23 +21,54 @@ namespace units {
  * \brief Entities for converting between geometric units where
  * \f$G=c=M_{\odot}=1\f$ and CGS units.
  *
- * Note: the baryon mass is not implemented here since it depends on what the
- * specific place assumes. E.g. different EoS can assume different baryon
- * masses. See https://github.com/sxs-collaboration/spectre/issues/4694
  */
 namespace cgs {
+
+/// The speed of light in cm/s (This is exact)
+constexpr double speed_of_light = 29979245800.0;
+/// Newton's gravitational constant as given by
+/// https://journals.aps.org/rmp/abstract/10.1103/RevModPhys.93.025010.
+/// G is likely to vary between sources, even beyond the reported uncertainty
+constexpr double G_Newton = 6.67430e-8;
+/// Note G*M_Sun = 1.32712440042x10^26 +/- 1e16 [1/cm]
+/// G*M_Sun factor from https://doi.org/10.1063/1.4921980
+static constexpr double G_Newton_times_m_sun = 1.32712440042e26;
+/// k_B factor in erg/K from
+/// https://journals.aps.org/rmp/pdf/10.1103/RevModPhys.93.025010.
+/// (This is exact)
+static constexpr double k_Boltzmann = 1.380649e-16;
+
 /// `mass_cgs = mass_geometric * mass_unit`
-constexpr double mass_unit = 1.0 / 5.02765209e-34;
+/// Heuristically the mass of the sun in grams
+constexpr double mass_unit = G_Newton_times_m_sun / G_Newton;
 /// `length_cgs = length_geometric * length_unit`
-constexpr double length_unit = 1.0 / 6.77140812e-6;
+/// Heuristically, half the schwarzschild radius of the sun
+/// in cm
+constexpr double length_unit = G_Newton_times_m_sun / square(speed_of_light);
 /// `time_cgs = time_geometric * time_unit`
-constexpr double time_unit = 1.0 / 2.03001708e5;
+/// Heuristically, half the light crossing time of a
+/// solar schwarzschild radius in seconds
+constexpr double time_unit = length_unit / speed_of_light;
 /// `rho_cgs = rho_geometric * rho_unit`
+/// Heuristically, the density in g/cm^3 of matter ~2200 times the density of
+/// atomic nuclei.  Note this is much larger than any density realized in the
+/// universe.
 constexpr double rest_mass_density_unit =
     mass_unit / (length_unit * length_unit * length_unit);
 /// `pressure_cgs = pressure_geometric * pressure_unit`
+/// Heuristically, the quantity above but times the speed of light squared in
+/// cgs
 constexpr double pressure_unit =
     mass_unit / (length_unit * time_unit * time_unit);
+
+// Extra constants, which are known to greatest precision in SI / (equvialently
+// CGS)
+/// The accepted value for the atomic mass unit in g, uncertainty +-30e-10
+constexpr double atomic_mass_unit = 1.66053906660e-24;
+/// The neutron mass, given in grams, uncertainty at 5.7 x 10^-10 level
+constexpr double neutron_mass = 1.67492749804e-24;
+/// The electron-volt (eV) given in ergs, which is known exactly in SI/cgs
+constexpr double electron_volt = 1.602176634e-12;
 
 /*!
  * \brief CGS unit of Gauss.
@@ -78,5 +111,70 @@ constexpr double pressure_unit =
  */
 constexpr double gauss_unit = 2.3558985e+19;
 }  // namespace cgs
+
+/*!
+ * \brief The defining quantities of the nuclear fm-MeV/c^2-fm/c unit system
+ *
+ * Constants are defined in terms of cgs units where possible, which are, in
+ * many cases known exactly due to their relation to SI.
+ */
+namespace nuclear {
+/// `mass_nuclear = mass_unit * mass_geometric`
+/// Heuristically a solar mass in MeV/c^2
+constexpr double mass_unit =
+     cgs::mass_unit /
+    (1.0e6 * cgs::electron_volt / square(cgs::speed_of_light));
+/// `length_nuclear = length_unit * length_geometric`
+/// Heuristically GM_sun/c^2 in fm
+constexpr double length_unit =  cgs::length_unit / (1.0e-13);
+/// `time_nuclear = time_unit * time_geometric`
+/// Heuristically GM_sun/c^3 in fm/c
+constexpr double time_unit =
+     cgs::time_unit / (1.0e-13 / cgs::speed_of_light);
+/// `pressure_nuclear = pressure_geometric * pressure_geometric`
+/// Heuristically the rest-mass energy density of
+/// ~2200 the density of atomic nucli expressed in MeV/fm^3
+constexpr double pressure_unit = mass_unit / (length_unit * square(time_unit));
+/// `rest_mass_density_nuclear = rest_mass_density_geometric *
+/// rest_mass_density_geometric` Heuristically ~2200 the density of atomic nucli
+/// expressed in MeV/c^2/fm^3
+constexpr double rest_mass_density_unit = mass_unit / cube(length_unit);
+constexpr double neutron_mass =
+    cgs::neutron_mass /
+    (1.0e6 * cgs::electron_volt / square(cgs::speed_of_light));
+constexpr double atomic_mass_unit =
+    cgs::atomic_mass_unit /
+    (1.0e6 * cgs::electron_volt / square(cgs::speed_of_light));
+
+/// The saturation number density of baryons in nuclear matter, in
+/// units of 1/fm^3.  This is a standard value, consistent with  e.g.
+/// https://journals.aps.org/prc/abstract/10.1103/PhysRevC.102.044321
+constexpr double saturation_number_density = 0.16;
+
+}  // namespace nuclear
+/*!
+ * \brief Quantities given in terms of geometric units G = c = M_odot =
+ * 1
+ *
+ * All quantities are given in terms of unit systems which are related exactly
+ * to SI units.  The limiting factor in conversions is the poorly known value
+ * of G; which leads to large uncertainties in the relative value of SI-derived
+ * masses to the solar mass.  For this reason, it is best to avoid using
+ * geometric units in calculations except where conversion is explicitly needed.
+ */
+namespace geometric {
+/// Neutron mass in G = c = M_sun = 1.0 units
+constexpr double neutron_mass = cgs::neutron_mass / cgs::mass_unit;
+/// The rest mass density of matter at the saturation point
+constexpr double default_saturation_rest_mass_density =
+    1 / nuclear::rest_mass_density_unit *
+    (nuclear::saturation_number_density * nuclear::atomic_mass_unit);
+/// The default baryon mass in geometric units.
+/// Accepted value of atomic mass unit as expressed in
+/// solar masses
+/// Limited by precision of knowledge of solar mass.
+constexpr double default_baryon_mass = cgs::atomic_mass_unit / cgs::mass_unit;
+}  // namespace geometric
+
 }  // namespace units
 }  // namespace hydro

--- a/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_DarkEnergyFluid.cpp
+++ b/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_DarkEnergyFluid.cpp
@@ -14,6 +14,7 @@
 #include "PointwiseFunctions/Hydro/EquationsOfState/DarkEnergyFluid.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/Factory.hpp"
+#include "PointwiseFunctions/Hydro/Units.hpp"
 #include "Utilities/Serialization/RegisterDerivedClassesWithCharm.hpp"
 
 namespace {
@@ -25,6 +26,8 @@ void check_bounds() {
   const double max_double = std::numeric_limits<double>::max();
   CHECK(max_double == eos.rest_mass_density_upper_bound());
   CHECK(max_double == eos.specific_internal_energy_upper_bound(1.0));
+  CHECK(eos.baryon_mass() ==
+        approx(hydro::units::geometric::default_baryon_mass));
 }
 }  // namespace
 

--- a/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_Enthalpy.cpp
+++ b/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_Enthalpy.cpp
@@ -16,6 +16,7 @@
 #include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/Factory.hpp"
 #include "PointwiseFunctions/Hydro/SpecificEnthalpy.hpp"
+#include "PointwiseFunctions/Hydro/Units.hpp"
 #include "Utilities/Serialization/RegisterDerivedClassesWithCharm.hpp"
 namespace EquationsOfState {
 namespace {
@@ -84,6 +85,8 @@ void check_exact() {
     CHECK(eos != other_eos);
     CHECK(eos != other_type_eos);
     CHECK(other_low_eos != other_type_eos);
+    CHECK(eos.baryon_mass() ==
+          approx(hydro::units::geometric::default_baryon_mass));
   }
   // Test DataVector functions
   {

--- a/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_HybridEos.cpp
+++ b/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_HybridEos.cpp
@@ -14,6 +14,7 @@
 #include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/Factory.hpp"
 #include "PointwiseFunctions/Hydro/SpecificEnthalpy.hpp"
+#include "PointwiseFunctions/Hydro/Units.hpp"
 #include "Utilities/Serialization/RegisterDerivedClassesWithCharm.hpp"
 
 namespace {
@@ -104,6 +105,8 @@ void check_bounds() {
   const double max_double = std::numeric_limits<double>::max();
   CHECK(max_double == eos.rest_mass_density_upper_bound());
   CHECK(max_double == eos.specific_internal_energy_upper_bound(1.0));
+  CHECK(eos.baryon_mass() ==
+        approx(hydro::units::geometric::default_baryon_mass));
 }
 
 }  // namespace

--- a/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_IdealFluid.cpp
+++ b/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_IdealFluid.cpp
@@ -16,6 +16,7 @@
 #include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/Factory.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/IdealFluid.hpp"
+#include "PointwiseFunctions/Hydro/Units.hpp"
 #include "Utilities/Serialization/RegisterDerivedClassesWithCharm.hpp"
 
 namespace {
@@ -54,6 +55,8 @@ void check_bounds() {
   const double max_double = std::numeric_limits<double>::max();
   CHECK(max_double == eos.rest_mass_density_upper_bound());
   CHECK(max_double == eos.specific_internal_energy_upper_bound(1.0));
+  CHECK(eos.baryon_mass() ==
+        approx(hydro::units::geometric::default_baryon_mass));
 }
 
 }  // namespace

--- a/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_PiecewisePolytropicFluid.cpp
+++ b/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_PiecewisePolytropicFluid.cpp
@@ -17,6 +17,7 @@
 #include "PointwiseFunctions/Hydro/EquationsOfState/Factory.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/PiecewisePolytropicFluid.hpp"
 #include "PointwiseFunctions/Hydro/SpecificEnthalpy.hpp"
+#include "PointwiseFunctions/Hydro/Units.hpp"
 #include "Utilities/Serialization/RegisterDerivedClassesWithCharm.hpp"
 
 // parts of PiecewisePolytropicFluid
@@ -337,6 +338,9 @@ SPECTRE_TEST_CASE(
   CHECK(eos != other_eos);
   // Different eos types should NOT match
   CHECK(eos != other_type_eos);
+  // Check baryon density
+  CHECK(eos.baryon_mass() ==
+        approx(hydro::units::geometric::default_baryon_mass));
   const double d_for_size = std::numeric_limits<double>::signaling_NaN();
   const DataVector dv_for_size(5);
   const double transition_density = 10.0;

--- a/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_PolytropicFluid.cpp
+++ b/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_PolytropicFluid.cpp
@@ -16,6 +16,7 @@
 #include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/Factory.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/PolytropicFluid.hpp"
+#include "PointwiseFunctions/Hydro/Units.hpp"
 #include "Utilities/Serialization/RegisterDerivedClassesWithCharm.hpp"
 
 namespace {
@@ -55,6 +56,8 @@ void check_bounds() {
   const double max_double = std::numeric_limits<double>::max();
   CHECK(max_double == eos.rest_mass_density_upper_bound());
   CHECK(max_double == eos.specific_internal_energy_upper_bound(1.0));
+  CHECK(eos.baryon_mass() ==
+        approx(hydro::units::geometric::default_baryon_mass));
 }
 
 }  // namespace

--- a/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_SpectralEoS.cpp
+++ b/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_SpectralEoS.cpp
@@ -14,6 +14,7 @@
 #include "PointwiseFunctions/Hydro/EquationsOfState/Factory.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/Spectral.hpp"
 #include "PointwiseFunctions/Hydro/SpecificEnthalpy.hpp"
+#include "PointwiseFunctions/Hydro/Units.hpp"
 #include "Utilities/Serialization/RegisterDerivedClassesWithCharm.hpp"
 
 namespace {
@@ -97,6 +98,8 @@ void check_exact() {
   const double max_double = std::numeric_limits<double>::max();
   CHECK(max_double == eos.rest_mass_density_upper_bound());
   CHECK(max_double == eos.specific_internal_energy_upper_bound(1.0));
+  CHECK(eos.baryon_mass() ==
+        approx(hydro::units::geometric::default_baryon_mass));
 }
 }  // namespace
 

--- a/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_Tabulated3D.cpp
+++ b/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_Tabulated3D.cpp
@@ -228,13 +228,15 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.EquationsOfState.Tabulated3D",
 
   get(state[1]) = 1.e-4;
 
-  CHECK(std::abs(0.302085884022446 -
-                 get(eos.specific_internal_energy_from_density_and_temperature(
-                     state[1], state[0], state[2]))) < 1.e-12);
-  CHECK(std::abs((1.10346262693259e-05) -
-                 get(eos.pressure_from_density_and_temperature(
-                     state[1], state[0], state[2]))) < 1.e-12);
-  CHECK(std::abs(0.416718905610434 -
-                 get(eos.sound_speed_squared_from_density_and_temperature(
-                     state[1], state[0], state[2]))) < 1.e-12);
+  CHECK_ITERABLE_APPROX(
+      get(eos.specific_internal_energy_from_density_and_temperature(
+          state[1], state[0], state[2])),
+      0.30204636358732767);
+  CHECK_ITERABLE_APPROX(get(eos.pressure_from_density_and_temperature(
+                            state[1], state[0], state[2])),
+                        0.00001103280164124);
+  CHECK_ITERABLE_APPROX(
+      get(eos.sound_speed_squared_from_density_and_temperature(
+          state[1], state[0], state[2])),
+      0.41669901507784435);
 }


### PR DESCRIPTION
## Proposed changes

This PR adds a `baryon_mass` function to each EoS, addressing  #4694.  It also factors certain code into `Hydro/Units.hpp` to facilitate standardizing certain definitions of constants/units.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

The upshot of the technical parts of this PR is that  changing the value of G (even within the reported uncertainty) changes all microscopic-hydro things to factors of order 10^-5 in geometric units, so we want to standardize this value and track changes between versions to make comparisons to previous code versions (and other codes) as easy as possible.  On top of that we'd prefer to have standardized values for constants in a standard location, again to guarantee everything is self consistent and in rare cases to check consistency to other codes when G based conversions are the limiting factor.  
