### PR TITLE
Get CaltechHPC up and running again

### DIFF
--- a/support/Environments/caltech_hpc_gcc.sh
+++ b/support/Environments/caltech_hpc_gcc.sh
@@ -13,7 +13,7 @@ spectre_load_sys_modules() {
     module load boost/1_68_0-gcc730
     module load cmake/3.18.0
     module load python3/3.8.5
-    module load git/2.26.0
+    module load git/2.37.2
 }
 
 # Unload system modules
@@ -26,7 +26,7 @@ spectre_unload_sys_modules() {
     module unload gcc/9.2.0
     module unload cmake/3.18.0
     module unload python3/3.8.5
-    module unload git/2.26.0
+    module unload git/2.37.2
 }
 
 
@@ -135,6 +135,7 @@ EOF
         cd build
         cmake -D CMAKE_BUILD_TYPE=Release -D YAML_CPP_BUILD_TESTS=OFF \
               -D CMAKE_C_COMPILER=gcc -D CMAKE_CXX_COMPILER=g++ \
+              -D CMAKE_POSITION_INDEPENDENT_CODE=ON \
               -D YAML_CPP_BUILD_CONTRIB=OFF \
               -D YAML_CPP_BUILD_TOOLS=ON \
               -D CMAKE_INSTALL_PREFIX=$dep_dir/yaml-cpp ..
@@ -296,6 +297,7 @@ EOF
 setenv VIRTUAL_ENV $dep_dir/py_env
 prepend-path PATH ${VIRTUAL_ENV}/bin
 EOF
+    pip install --upgrade pip
     pip install pybind11~=2.6.1
     # HDF5_DIR is set by the HDF5 module
     pip install --no-binary=h5py \
@@ -356,10 +358,10 @@ spectre_run_cmake() {
     cmake -D CHARM_ROOT=$CHARM_ROOT \
           -D CMAKE_BUILD_TYPE=Release \
           -D CMAKE_Fortran_COMPILER=gfortran \
-          -D MEMORY_ALLOCATOR=JEMALLOC \
+          -D MEMORY_ALLOCATOR=SYSTEM \
           -D BUILD_PYTHON_BINDINGS=ON \
+          -D MACHINE=CaltechHpc \
           -D Python_EXECUTABLE=`which python3` \
-          -D USE_SCOTCH_LB=ON \
           -D OVERRIDE_ARCH=skylake-avx512 \
           "$@" \
           $SPECTRE_HOME

--- a/support/Machines/CaltechHpc.yaml
+++ b/support/Machines/CaltechHpc.yaml
@@ -1,0 +1,14 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+Machine:
+  Name: CaltechHPC
+  Description: |
+    Public supercomputer at Caltech.
+    More information:
+    https://www.hpc.caltech.edu/documentation
+  # Split one physical 56 core node into two charm nodes
+  DefaultTasksPerNode: 2
+  DefaultProcsPerTasks: 28
+  DefaultQueue: "any"
+  DefaultTimeLimit: "1-00:00:00"


### PR DESCRIPTION
## Proposed changes

- I edited the default number of cores to be 56 (with 2 charm nodes per physical node) so we can make use of our new reservation. If you decide to run on the 32 core nodes, you'll have to edit the submit script. Specifically, make the tasks per node only 1 now.
- Yaml-cpp told me to compile with `-fPIC` so I did.
- Load balancing doesn't work (as far as I know) with charm 7, so don't even bother including the Scotch LB in cmake
- Use system memory allocator so we can use pybindings.


<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
