### PR TITLE
Add scheduling CLI

### DIFF
--- a/support/Python/CMakeLists.txt
+++ b/support/Python/CMakeLists.txt
@@ -9,6 +9,7 @@ spectre_python_add_module(
   PYTHON_FILES
   DirectoryStructure.py
   Machines.py
+  Schedule.py
 )
 
 if(MACHINE)
@@ -19,7 +20,7 @@ if(MACHINE)
     )
   configure_file(
     ${CMAKE_SOURCE_DIR}/support/SubmitScripts/${MACHINE}.sh
-    ${SPECTRE_PYTHON_PREFIX}/support/Submit.sh
+    ${SPECTRE_PYTHON_PREFIX}/support/SubmitTemplate.sh
     @ONLY
     )
 endif()

--- a/support/Python/CMakeLists.txt
+++ b/support/Python/CMakeLists.txt
@@ -9,6 +9,7 @@ spectre_python_add_module(
   PYTHON_FILES
   DirectoryStructure.py
   Machines.py
+  Resubmit.py
   Schedule.py
 )
 

--- a/support/Python/CMakeLists.txt
+++ b/support/Python/CMakeLists.txt
@@ -20,6 +20,11 @@ if(MACHINE)
     ${SPECTRE_PYTHON_PREFIX}/support/Machine.yaml
     )
   configure_file(
+    ${CMAKE_SOURCE_DIR}/support/SubmitScripts/SubmitTemplateBase.sh
+    ${SPECTRE_PYTHON_PREFIX}/support/SubmitTemplateBase.sh
+    @ONLY
+    )
+  configure_file(
     ${CMAKE_SOURCE_DIR}/support/SubmitScripts/${MACHINE}.sh
     ${SPECTRE_PYTHON_PREFIX}/support/SubmitTemplate.sh
     @ONLY

--- a/support/Python/Resubmit.py
+++ b/support/Python/Resubmit.py
@@ -1,0 +1,108 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import subprocess
+from pathlib import Path
+from typing import Optional
+
+import click
+import yaml
+
+from spectre.support.DirectoryStructure import Segment, list_segments
+from spectre.support.Schedule import schedule
+
+
+def resubmit(
+    segments_dir: Path, context_file_name: str = "SubmitContext.yaml", **kwargs
+) -> Optional[subprocess.CompletedProcess]:
+    """Create the next segment in the SEGMENTS_DIR and schedule it
+
+    \f
+    Arguments:
+      segments_dir: Path to the segments directory, or path to the last segment
+        in the segments directory. The next segment will be created here.
+      context_file_name: Optional. Name of the file that stores the context
+        for resubmissions in the 'run_dir'. This file gets created by
+        'spectre.support.schedule'. (Default: "SubmitContext.yaml")
+
+    Returns: The 'subprocess.CompletedProcess' representing the process
+      that scheduled the run. Returns 'None' if no run was scheduled.
+    """
+    # Resolve segments dir (if invoked from within a segment)
+    segment = Segment.match(segments_dir)
+    if segment:
+        segments_dir = segment.path.resolve().parent
+    # Resolve last segment
+    all_segments = list_segments(segments_dir)
+    assert all_segments, (
+        f"Directory '{segments_dir}' contains no segments "
+        f"that match the pattern '{Segment.NAME_PATTERN.pattern}'."
+    )
+    last_segment = all_segments[-1]
+    if segment:
+        assert segment.path.resolve() == last_segment.path.resolve(), (
+            f"The specified segment ({segment.path}) is not the last in the"
+            f" directory ({last_segment.path}). If you want to resubmit from"
+            " the specified segment, remove the later segments and try again."
+            " Otherwise, resubmit from the last segment or the parent"
+            " (segments) directory."
+        )
+    context_file = last_segment.path / context_file_name
+    # Load context
+    with open(context_file, "r") as open_context_file:
+        context = yaml.safe_load(open_context_file)
+    # Continue from the last checkpoint
+    last_segment_checkpoints = last_segment.checkpoints
+    assert last_segment_checkpoints, (
+        f"The last segment '{last_segment.path}' contains no checkpoints. It"
+        " may be incomplete. Did you forget to remove it?"
+    )
+    context["from_checkpoint"] = last_segment_checkpoints[-1]
+    # We resubmit the rendered input file from the last segment instead of
+    # trying to render the template again (the input file template wasn't copied
+    # to the segments directory, so there's no guarantee it still exists)
+    context["input_file_template"] = last_segment.path / context["input_file"]
+    # Remove the old `run_dir`. It will be set to the new segment.
+    del context["run_dir"]
+    # Override the `segments_dir` just to be safe
+    context["segments_dir"] = segments_dir
+    # Override with CLI options
+    context.update(kwargs)
+    schedule(**context)
+
+
+@click.command(help=resubmit.__doc__)
+@click.argument(
+    "segments_dirs",
+    type=click.Path(
+        exists=True,
+        file_okay=False,
+        dir_okay=True,
+        readable=True,
+        path_type=Path,
+    ),
+    nargs=-1,
+)
+@click.option(
+    "--submit/--no-submit",
+    default=None,
+    help=(
+        "Submit jobs automatically. If neither option is "
+        "specified, a prompt will ask for confirmation before "
+        "a job is submitted."
+    ),
+)
+@click.option(
+    "--context-file-name",
+    default="SubmitContext.yaml",
+    show_default=True,
+    help="Name of the context file that supports resubmissions.",
+)
+def resubmit_command(segments_dirs, **kwargs):
+    _rich_traceback_guard = True  # Hide tracebacks until here
+    for segment_dir in segments_dirs:
+        resubmit(segment_dir, **kwargs)
+
+
+if __name__ == "__main__":
+    resubmit_command(help_option_names=["-h", "--help"])

--- a/support/Python/Schedule.py
+++ b/support/Python/Schedule.py
@@ -1,0 +1,943 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import logging
+import re
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Optional, Sequence, Union
+
+import click
+import jinja2
+import jinja2.meta
+import yaml
+
+from spectre.support.DirectoryStructure import (
+    Checkpoint,
+    Segment,
+    list_checkpoints,
+    list_segments,
+)
+from spectre.tools.ValidateInputFile import validate_input_file
+from spectre.Visualization.ReadInputFile import find_phase_change
+
+logger = logging.getLogger(__name__)
+
+# CMake configures the submit script templates for the current machine to this
+# path
+default_submit_script_template = Path(__file__).parent / "SubmitTemplate.sh"
+
+
+def _resolve_executable(executable: Union[str, Path]) -> Path:
+    """Look up the 'executable' in the PATH
+
+    Raises 'ValueError' if the executable is not found.
+    """
+    logger.debug(f"Resolving executable: {executable}")
+    which_exec = shutil.which(executable)
+    if not which_exec:
+        raise ValueError(f"Executable not found in PATH: {executable}")
+    logger.debug(f"Found executable in PATH: {which_exec}")
+    return Path(which_exec).resolve()
+
+
+def _write_or_overwrite(
+    text: str, path: Path, error_hint: Optional[str] = None, force: bool = False
+):
+    """Write the 'text' to a file at 'path'
+
+    Raise an 'OSError' if the file already exists, unless called with 'force'
+    or if the existing file content is identical to the 'text'.
+    The 'hint' is appended to the error message.
+    """
+    if path.exists():
+        if path.read_text() == text:
+            return
+        if not force:
+            raise OSError(
+                f"File already exists at '{path}'. Retry with "
+                "'force' ('--force' / '-f') to overwrite."
+                + (("\n" + error_hint) if error_hint else "")
+            )
+    logger.debug(f"Write file: {path}")
+    path.write_text(text)
+
+
+def _copy_to_dir(src_file: Path, dest_dir: Path, force: bool = False) -> Path:
+    """Copy the 'src_file' to the 'dest_dir', keeping the file name the same
+
+    Returns the path to the new file.
+    """
+    assert src_file.is_file()
+    assert dest_dir.is_dir()
+    if src_file.resolve().parent == dest_dir.resolve():
+        return src_file
+    dest = (dest_dir / src_file.name).resolve()
+    if dest.exists() and not force:
+        raise OSError(
+            f"File already exists at '{dest}'. Retry with "
+            "'force' ('--force' / '-f') to overwrite."
+        )
+    logging.debug(f"Copy file: {src_file} -> {dest}")
+    shutil.copy(src_file, dest)
+    return dest
+
+
+def _copy_submit_script_template(
+    submit_script_template: Path,
+    dest_dir: Path,
+    template_env: jinja2.Environment,
+    force: bool = False,
+) -> Path:
+    dest = _copy_to_dir(submit_script_template, dest_dir, force=force)
+    # Also copy all referenced templates (the "SubmitBase.sh" parent template)
+    syntax_tree = template_env.parse(dest.read_text())
+    for referenced_template in jinja2.meta.find_referenced_templates(
+        syntax_tree
+    ):
+        referenced_template_src = (
+            submit_script_template.resolve().parent / referenced_template
+        )
+        _copy_to_dir(referenced_template_src, dest_dir, force=force)
+    return dest
+
+
+# Write `pathlib.Path` objects to YAML as plain strings
+def _path_representer(dumper: yaml.Dumper, path: Path) -> yaml.nodes.ScalarNode:
+    return dumper.represent_scalar("tag:yaml.org,2002:str", str(path))
+
+
+def schedule(
+    input_file_template: Union[str, Path],
+    scheduler: Optional[Union[str, Sequence]],
+    executable: Optional[Union[str, Path]] = None,
+    run_dir: Optional[Union[str, Path]] = None,
+    segments_dir: Optional[Union[str, Path]] = None,
+    copy_executable: Optional[bool] = None,
+    job_name: Optional[str] = None,
+    submit_script_template: Optional[Union[str, Path]] = None,
+    from_checkpoint: Optional[Union[str, Path, Checkpoint]] = None,
+    input_file_name: Optional[str] = None,
+    submit_script_name: str = "Submit.sh",
+    out_file_name: str = "spectre.out",
+    context_file_name: str = "SubmitContext.yaml",
+    submit: Optional[bool] = None,
+    clean_output: bool = False,
+    force: bool = False,
+    **kwargs,
+) -> Optional[subprocess.CompletedProcess]:
+    """Schedule executable runs with an input file
+
+    Configures the input file, submit script, etc. to the 'run_dir', and then
+    invokes the 'scheduler' to submit the run (typically "sbatch"). You can also
+    bypass the scheduler and run the executable directly by setting the
+    'scheduler' to 'None'.
+
+    # Selecting the executable
+
+    Specify either a path to the executable, or just its name if it's in the
+    'PATH'. If unspecified, the 'Executable' listed in the input file metadata
+    is used.
+
+    By default, the executable and submit scripts will be copied to the segments
+    directory to support resubmissions (see below). See the 'copy_executable'
+    argument docs for details on controlling this behavior.
+
+    # Segments and run directories
+
+    You can set either the 'run_dir' or the 'segments_dir' to specify where the
+    executable will run (but not both). If you specify a 'run_dir', the
+    executable will run in it directly. If you specify a 'segments_dir', a new
+    segment will be created and used as the 'run_dir'. Segments are named with
+    incrementing integers and continue the run from the previous segment. For
+    example, the following is a typical 'segments_dir':
+
+    \b
+    ```sh
+    # Copy of the executable
+    MyExecutable
+    # Copy of the submit script template (base and machine-specific)
+    SubmitTemplateBase.sh
+    SubmitTemplate.sh
+    # One segment per day
+    Segment_0000/
+        InputFile.yaml
+        Submit.sh
+        Output.h5
+        # Occasional checkpoints, and a checkpoint before termination
+        Checkpoints/
+            Checkpoint_0000/
+            Checkpoint_0001/...
+    # Next segment continues from last checkpoint of previous segment
+    Segment_0001/...
+    ```
+
+    You can omit the 'run_dir' if the current working directory already contains
+    the input file.
+
+    # Placeholders
+
+    The input file, submit script, 'run_dir', 'segments_dir', and 'job_name' can
+    have placeholders like '{{ num_nodes }}'. They must conform to the
+    [Jinja template format](https://jinja.palletsprojects.com/en/3.0.x/templates/).
+    The placeholders are resolved in the following stages.
+    The following parameters are available as placeholders:
+
+    1. 'job_name' (if specified):
+
+    \b
+        - All arguments to this function, including all additional '**kwargs'.
+          For example, the additional '**kwargs' can include parameters
+          controlling resolution in the input file.
+        - 'executable_name': Just the name of the executable (basename of the
+          'executable' path).
+
+    2. 'run_dir' and 'segments_dir':
+
+    \b
+        - All parameters from the previous stage.
+        - 'job_name': Either the resolved 'job_name' from the previous stage, or
+          the 'executable_name' if unspecified.
+
+    3. Input file & submit script:
+
+    \b
+        - All parameters from the previous stages.
+        - 'run_dir': Absolute path to the 'run_dir'.
+        - 'segments_dir': Absolute path to the 'segments_dir', or 'None' if no
+          segments directory is available.
+        - 'input_file': Relative path to the configured input file (in the
+          'run_dir').
+        - 'out_file': Absolute path to the log file (in the 'run_dir').
+        - 'spectre_cli': Absolute path to the SpECTRE CLI.
+        - Typical additional parameters used in submit scripts are 'queue' and
+          'time_limit'.
+
+    The parameters used to render the submit script are stored in a context file
+    (named 'context_file_name') in the 'run_dir' to support resubmissions. The
+    context file is used by 'spectre.support.resubmit' to schedule the next
+    segment using the same parameters.
+
+    # Scheduling multiple runs
+
+    You can pass ranges of parameters to the '**kwargs' of this function to
+    schedule multiple runs using the same input file template. For example, you
+    can do an h-convergence test by using a placeholder for the refinement level
+    in your input file:
+
+    \b
+    ```yaml
+    # In the domain creator:
+    InitialRefinement: {{ lev }}
+    ```
+
+    When a parameter in '**kwargs' is an iterable, the 'schedule' function will
+    recurse for every element in the iterable. For example, you can schedule
+    multiple runs for a convergence test like this:
+
+    \b
+    ```py
+    schedule(
+        run_dir="Lev{{ lev }}",
+        # ...
+        lev=range(1, 3))
+    ```
+
+    \f
+    Arguments:
+      input_file_template: Path to an input file. It will be copied to the
+        'run_dir'. It can be a Jinja template (see above).
+      scheduler: 'None' to run the executable directly, or a scheduler such as
+        "sbatch" to submit the run to a queue.
+      executable: Path or name of the executable to run. If unspecified, use the
+        'Executable' set in the input file metadata.
+      run_dir: The directory to which input file, submit script, etc. are
+        copied, and relative to which the executable will run.
+        Can be a Jinja template (see above).
+      segments_dir: The directory in which a new segment is created as the
+        'run_dir'. Mutually exclusive with 'run_dir'.
+        Can be a Jinja template (see above).
+      copy_executable: Copy the executable to the run or segments directory.
+        By default (when set to 'None'):
+          - If '--run-dir' / '-o' is set, don't copy.
+          - If '--segments-dir' / '-O' is set, copy to segments directory to
+            support resubmission.
+        When set to 'True':
+          - If '--run-dir' / '-o' is set, copy to the run directory.
+          - If '--segments-dir' / '-O' is set, copy to segments directory to
+            support resubmission. Still don't copy to individual segments.
+        When set to 'False': Never copy.
+      job_name: Optional. A string describing the job.
+        Can be a Jinja template (see above). (Default: executable name)
+      submit_script_template: Optional only when 'scheduler' is 'None'. Path to
+        a submit script. It will be copied to the 'run_dir'.
+        Can be a Jinja template (see above).
+      from_checkpoint: Optional. Path to a checkpoint directory.
+      input_file_name: Optional. Filename of the input file in the 'run_dir'.
+        (Default: basename of the 'input_file_template')
+      submit_script_name: Optional. Filename of the submit script. (Default:
+        "Submit.sh")
+      out_file_name: Optional. Name of the log file. (Default:
+        "spectre.out")
+      context_file_name: Optional. Name of the file that stores the context
+        for resubmissions in the `run_dir`. Used by `spectre.support.resubmit`.
+        (Default: "SubmitContext.yaml")
+      submit: Optional. If 'True', automatically submit jobs using the
+        'scheduler'. If 'False', skip the job submission. If 'None', prompt for
+        confirmation before submitting.
+      clean_output: Optional. When 'True', use
+        'spectre.tools.CleanOutput.clean_output' to clean up existing output
+        files in the 'run_dir' before scheduling the run. (Default: 'False')
+      force: Optional. When 'True', overwrite input file and submit script
+        in the 'run_dir' instead of raising an error when they already exist.
+
+    Returns: The 'subprocess.CompletedProcess' representing either the process
+      that scheduled the run, or the process that ran the executable if
+      'scheduler' is 'None'. Returns 'None' if no or multiple runs were
+      scheduled.
+    """
+    # Defaults
+    input_file_template = Path(input_file_template)
+    if not input_file_name:
+        input_file_name = input_file_template.resolve().name
+    if isinstance(from_checkpoint, Checkpoint):
+        from_checkpoint = from_checkpoint.path
+    if from_checkpoint:
+        from_checkpoint = Path(from_checkpoint).resolve()
+
+    # Snapshot function arguments for template substitutions
+    all_args = locals().copy()
+    del all_args["kwargs"]
+
+    # Recursively schedule ranges of runs
+    for key, value in kwargs.items():
+        # Check if the parameter is an iterable
+        if isinstance(value, str):
+            # Strings are iterable, but we don't want to treat them as such
+            continue
+        try:
+            iter(value)
+        except TypeError:
+            continue
+        # Recurse for each value of the iterable
+        for value_i in value:
+            logger.info(f"Recurse for {key}={value_i}")
+            kwargs_i = kwargs.copy()
+            kwargs_i.update({key: value_i})
+            try:
+                schedule(**all_args, **kwargs_i)
+            except:
+                logger.exception(f"Recursion for {key}={value_i} failed.")
+        return
+
+    # Set up template environment with basic configuration
+    template_env = jinja2.Environment(
+        undefined=jinja2.StrictUndefined,
+        trim_blocks=True,
+        keep_trailing_newline=True,
+    )
+
+    # Start collecting parameters for template substitutions. We filter 'None'
+    # values so they properly trigger undefined-variable errors when templates
+    # need them.
+    context = {
+        key: value
+        for key, value in dict(**all_args, **kwargs).items()
+        if value is not None
+    }
+
+    # Read input file template
+    input_file_contents = input_file_template.read_text()
+
+    # Resolve executable
+    if not executable:
+        metadata = next(yaml.safe_load_all(input_file_contents))
+        try:
+            executable = metadata["Executable"]
+        except KeyError as err:
+            raise ValueError(
+                "Specify an 'executable' ('--executable' / '-e') "
+                "or list one in the input file metadata "
+                "as 'Executable:'."
+            ) from err
+    executable = _resolve_executable(executable)
+    # Only set executable name because the path may change if we copy it later
+    context.update(executable_name=executable.name)
+
+    # Resolve number of cores, nodes, etc.
+    num_procs = kwargs.get("num_procs")
+    num_nodes = kwargs.get("num_nodes")
+    if num_procs:
+        assert (
+            num_nodes is None or num_nodes == 1
+        ), "Specify either 'num_procs' or 'num_nodes', not both."
+        num_nodes = 1
+    # Set the context variables only if defined, so they don't print as "None"
+    # https://jinja.palletsprojects.com/en/3.0.x/templates/#jinja-filters.default
+    if num_procs:
+        context.update(num_procs=num_procs)
+    if num_nodes:
+        context.update(num_nodes=num_nodes)
+
+    # Resolve job_name
+    if job_name:
+        job_name = template_env.from_string(job_name).render(context).strip()
+    else:
+        job_name = executable.name
+    context.update(job_name=job_name)
+
+    # Resolve run_dir and segments_dir
+    if run_dir and segments_dir:
+        raise ValueError(
+            "Specify either 'run_dir' ('--run-dir' / '-o') "
+            "or 'segments_dir' ('--segments-dir' / '-O'), not both."
+        )
+    elif not run_dir and not segments_dir:
+        # Neither run_dir nor segments_dir were specified. Set run_dir to the
+        # current working directory.
+        if input_file_template.resolve().parent == Path.cwd():
+            run_dir = Path.cwd()
+        else:
+            raise ValueError(
+                "Specify a 'run_dir' ('--run-dir' / '-o') "
+                "or a 'segments_dir' ('--segments-dir' / '-O'), "
+                "or place the input file into the current directory."
+            )
+    # At this point either run_dir or segments_dir are set, but not both.
+    if run_dir:
+        # Run directly in the run_dir. If the run_dir looks like a segment, set
+        # the segments_dir so resubmitting works.
+        run_dir = Path(
+            template_env.from_string(str(run_dir)).render(context).strip()
+        )
+        if Segment.match(run_dir):
+            segments_dir = run_dir.resolve().parent
+            all_segments = list_segments(segments_dir)
+    else:
+        # Run in next segment in the segments_dir
+        segments_dir = Path(
+            template_env.from_string(str(segments_dir)).render(context).strip()
+        )
+        all_segments = list_segments(segments_dir)
+        if all_segments:
+            run_dir = all_segments[-1].next.path
+        else:
+            run_dir = Segment.first(segments_dir).path
+    if segments_dir and all_segments:
+        # Make sure we're continuing the last checkpoint of the last segment.
+        # This requirement can be relaxed in the future if needed.
+        assert from_checkpoint, (
+            f"Found existing segments in directory '{segments_dir}'. Use"
+            " '--from-last-checkpoint' to continue from the last"
+            " checkpoint in this directory."
+        )
+        last_segment = all_segments[-1]
+        assert (
+            from_checkpoint.parent == last_segment.checkpoints_dir.resolve()
+        ), (
+            "You're not continuing from the last segment"
+            f" ({last_segment.path}). It is technically possible to continue"
+            " from a different checkpoint, but probably wrong. This assert"
+            " safeguards against inconsistent usage. If you want to continue"
+            f" from the checkpoint you specified ({from_checkpoint}), choose a"
+            " different directory to run in. Otherwise, use"
+            " '--from-last-checkpoint SEGMENTS_DIR' to continue from the"
+            " latest segment."
+        )
+        last_segment_checkpoints = last_segment.checkpoints
+        assert last_segment_checkpoints, (
+            f"The last segment '{last_segment.path}' has no checkpoints to"
+            " continue from. It is technically possible to continue from a"
+            " different checkpoint, but probably wrong. This assert safeguards"
+            " against inconsistent usage. If you want to continue from the"
+            f" checkpoint you specified ({from_checkpoint}), choose a different"
+            " directory to run in. Otherwise, remove the incomplete segment"
+            " and use '--from-last-checkpoint SEGMENTS_DIR' to continue from"
+            " the latest segment."
+        )
+        last_checkpoint = last_segment_checkpoints[-1]
+        assert from_checkpoint == last_checkpoint.path.resolve(), (
+            "You're not continuing from the previous segment's last checkpoint"
+            f" ({last_checkpoint.path}). This is technically possible, but"
+            " probably wrong. This assert safeguards against inconsistent"
+            " usage. If you want to continue from the checkpoint you specified"
+            f" ({from_checkpoint}), choose a different directory to run in."
+            " Otherwise, use '--from-last-checkpoint LAST_SEGMENT' to continue"
+            " from the last checkpoint."
+        )
+    context.update(run_dir=run_dir.resolve())
+    if segments_dir:
+        context.update(segments_dir=segments_dir.resolve())
+
+    # Resolve outfile
+    out_file = run_dir / out_file_name
+    context.update(out_file=out_file.resolve())
+
+    # Create the run directory
+    logger.info(f"Configure run directory '{run_dir}'")
+    run_dir.mkdir(parents=True, exist_ok=True)
+
+    # Configure input file
+    input_file_path = run_dir / input_file_name
+    context.update(input_file=input_file_name)
+    rendered_input_file = template_env.from_string(input_file_contents).render(
+        context
+    )
+    _write_or_overwrite(
+        rendered_input_file,
+        input_file_path,
+        error_hint=(
+            "If you're scheduling multiple runs, use "
+            "placeholders in the directory name such as:\n"
+            "  -p lev=1...3 --run-dir 'Lev{{ lev }}'"
+        ),
+        force=force,
+    )
+
+    # Validate input file
+    validate_input_file(
+        input_file_path.resolve(), executable=executable, work_dir=run_dir
+    )
+    # - If the input file may request resubmissions, make sure we have a
+    #   segments directory
+    _, input_file = yaml.safe_load_all(rendered_input_file)
+    wallclock_exit_phase_change = find_phase_change(
+        "CheckpointAndExitAfterWallclock", input_file
+    )
+    if wallclock_exit_phase_change is not None and not segments_dir:
+        raise ValueError(
+            "Found 'CheckpointAndExitAfterWallclock' in the input file but "
+            "no 'segments_dir' ('--segments-dir' / '-O') is set. "
+            "Specify a segments directory to enable resubmissions, or "
+            "remove 'CheckpointAndExitAfterWallclock' from the input file."
+        )
+
+    # Clean output
+    if clean_output:
+        from spectre.tools.CleanOutput import clean_output
+
+        clean_output(input_file=input_file_path, output_dir=run_dir, force=True)
+
+    # Copy executable to run directory if enabled
+    if copy_executable and not segments_dir:
+        executable = _copy_to_dir(executable, run_dir, force=force)
+
+    # If requested, run executable directly and return early
+    if not scheduler:
+        assert num_nodes is None or num_nodes == 1, (
+            "Running executables directly is only supported on a single node. "
+            "Set the 'scheduler' ('--scheduler') to submit a multi-node job "
+            "to the queue."
+        )
+        auto_provision = num_procs is None
+        provision_info = (
+            "all available cores"
+            if auto_provision
+            else f"{num_procs} core{'s'[:num_procs!=1]}"
+        )
+        logger.info(
+            f"Run '{executable.name}' in '{run_dir}' on {provision_info}."
+        )
+        run_command = [executable, "--input-file", input_file_path.resolve()]
+        if auto_provision:
+            run_command += ["+auto-provision"]
+        else:
+            run_command += ["+p", str(num_procs)]
+        if from_checkpoint:
+            run_command += ["+restart", from_checkpoint]
+        process = subprocess.Popen(run_command, cwd=run_dir)
+        # Realtime streaming of _captured_ stdout and stderr to the console
+        # doesn't seem to work reliably, so we just let the process stream
+        # directly to the console and wait for it to complete.
+        process.wait()
+        return process
+
+    # Copy executable to segments directory
+    if (copy_executable or copy_executable is None) and segments_dir:
+        executable = _copy_to_dir(executable, segments_dir, force=force)
+    context.update(executable=executable, copy_executable=copy_executable)
+
+    # Resolve CLI for resubmissions
+    # This is the path of the `spectre` CLI where this script is installed.
+    # We may have to make this more robust for resubmissions if we run into
+    # problems or unexpected behavior.
+    spectre_cli = Path(__file__).parent.parent.parent.parent / "spectre"
+    if spectre_cli:
+        context.update(spectre_cli=spectre_cli)
+
+    # Configure submit script
+    assert (
+        submit_script_template
+    ), "Please specify the 'submit_script_template'."
+    submit_script_template = Path(submit_script_template).resolve()
+    if segments_dir:
+        submit_script_template = _copy_submit_script_template(
+            submit_script_template,
+            segments_dir,
+            template_env=template_env,
+            force=force,
+        )
+    context.update(submit_script_template=submit_script_template)
+    # Use a FileSystemLoader to support template inheritance
+    submit_script_template_env = template_env.overlay(
+        loader=jinja2.FileSystemLoader(submit_script_template.parent)
+    )
+    rendered_submit_script = submit_script_template_env.get_template(
+        submit_script_template.name
+    ).render(context)
+    submit_script_path = run_dir / submit_script_name
+    _write_or_overwrite(rendered_submit_script, submit_script_path, force=force)
+
+    # Write context to file to support resubmissions
+    if segments_dir:
+        with open(run_dir / context_file_name, "w") as open_context_file:
+            yaml_dumper = yaml.SafeDumper
+            yaml_dumper.add_multi_representer(Path, _path_representer)
+            yaml.dump(context, open_context_file, Dumper=yaml_dumper)
+
+    # Submit
+    if submit or (
+        submit is None
+        and click.confirm(f"Submit '{submit_script_path}'?", default=True)
+    ):
+        if isinstance(scheduler, str):
+            scheduler = [scheduler]
+        submit_process = subprocess.run(
+            list(scheduler) + [submit_script_name],
+            cwd=run_dir,
+            capture_output=True,
+            text=True,
+        )
+        try:
+            submit_process.check_returncode()
+        except subprocess.CalledProcessError as err:
+            raise RuntimeError(
+                f"Failed submitting job '{job_name}':\n"
+                f"{submit_process.stderr.strip()}"
+            ) from err
+        # Write Job ID to a file
+        matched_submit_msg = re.match(
+            r"Submitted batch job (\d+)", submit_process.stdout
+        )
+        if matched_submit_msg:
+            jobid = matched_submit_msg.group(1)
+            (run_dir / "jobid.txt").write_text(jobid)
+        else:
+            logger.warning(
+                f"Unable to parse job ID from output: " + submit_process.stdout
+            )
+            jobid = None
+        logger.info(f"Submitted job '{job_name}' ({jobid}).")
+        return submit_process
+
+
+def _parse_param(value):
+    """Parse an additional command-line parameter for template substitutions
+
+    The following values are supported:
+
+    - Integers or floats
+    - List of values: "1,2,3"
+    - Exclusive range: "0..3" or "0..<3" (the latter is clearer, but "<" is a
+      special character in the shell)
+    - Inclusive range: "0...3"
+    - Exponentiated values: Single numbers like "2**3" or "10**4", or ranges
+      like "10**4...6"
+
+    Note: The syntax for ranges is borrowed from the Swift language:
+    https://docs.swift.org/swift-book/documentation/the-swift-programming-language/basicoperators/#Range-Operators
+    """
+    if not isinstance(value, str):
+        return value
+    value = value.strip()
+    # Exponent prefix: 2**x or 10**x, where x is parsed recursively
+    match = re.match(r"(\d+)[*]{2}(.+)$", value)
+    if match:
+        logger.debug(f"'{value}' is exponentiated")
+        base = int(match.group(1))
+        exponent = _parse_param(match.group(2))
+        try:
+            # Single exponentiated number
+            return base**exponent
+        except TypeError:
+            # Exponent is a range
+            return [base**exponent_i for exponent_i in exponent]
+    # List
+    value_list = value.strip(",[]").split(",")
+    if len(value_list) > 1:
+        logger.debug(f"'{value}' is a list")
+        return [_parse_param(element.strip()) for element in value_list]
+    # Exclusive range: 0..3 or 0..<3 (the latter is clearer, but '<' is a
+    # special character in the shell)
+    match = re.match(r"(-?\d+)[.]{2}[<]?(-?\d+)$", value)
+    if match:
+        logger.debug(f"'{value}' is an exclusive range")
+        return range(int(match.group(1)), int(match.group(2)))
+    # Inclusive range: 0...3
+    match = re.match(r"(-?\d+)[.]{3}(-?\d+)$", value)
+    if match:
+        logger.debug(f"'{value}' is an inclusive range")
+        return range(int(match.group(1)), int(match.group(2)) + 1)
+    # Integers
+    match = re.match(r"(-?\d+)$", value)
+    if match:
+        logger.debug(f"'{value}' is an int")
+        return int(match.group(1))
+    # Floats
+    match = re.match(r"(-?\d+[.]\d*)$", value)
+    if match:
+        logger.debug(f"'{value}' is a float")
+        return float(match.group(1))
+    return value
+
+
+def _parse_params(ctx, param, all_values):
+    if all_values is None:
+        return {}
+    params = {}
+    for value in all_values:
+        key_and_value = value.split("=")
+        if len(key_and_value) != 2:
+            raise click.BadParameter(
+                f"The value of '{value}' could not be parsed as a key-value "
+                "pair. It should have a single '=' or none."
+            )
+        params[key_and_value[0]] = _parse_param(key_and_value[1])
+    return params
+
+
+@click.command(help=schedule.__doc__.replace("**kwargs", "--params"))
+@click.argument(
+    "input_file_template",
+    type=click.Path(
+        exists=True,
+        file_okay=True,
+        dir_okay=False,
+        readable=True,
+        path_type=Path,
+    ),
+)
+@click.option(
+    "--executable",
+    "-e",
+    show_default="executable listed in input file",
+    help=(
+        "The executable to run. Can be a path, or just the name "
+        "of the executable if it's in the 'PATH'. "
+        "If unspecified, the 'Executable' listed in the input file metadata "
+        "is used."
+    ),
+)
+@click.option(
+    "--run-dir",
+    "-o",
+    # No `type=click.Path` because this can be a Jinja template
+    help=(
+        "The directory to which input file, submit script, etc. are "
+        "copied, relative to which the executable will run, and to "
+        "which output files are written. "
+        "Defaults to the current working directory if the input file is "
+        "already there. "
+        "Mutually exclusive with '--segments-dir' / '-O'."
+    ),
+)
+@click.option(
+    "--segments-dir",
+    "-O",
+    # No `type=click.Path` because this can be a Jinja template
+    help=(
+        "The directory in which to create the next segment. "
+        "Requires '--from-checkpoint' or '--from-last-checkpoint' "
+        "unless starting the first segment."
+    ),
+)
+@click.option(
+    "--copy-executable/--no-copy-executable",
+    default=None,
+    help=(
+        "Copy the executable to the run or segments directory. "
+        "(1) When no flag is specified: "
+        "If '--run-dir' / '-o' is set, don't copy. "
+        "If '--segments-dir' / '-O' is set, copy to segments "
+        "directory to support resubmission. "
+        "(2) When '--copy-executable' is specified: "
+        "If '--run-dir' / '-o' is set, copy to the run "
+        "directory. "
+        "If '--segments-dir' / '-O' is set, copy to segments "
+        "directory to support resubmission. Still don't copy to "
+        "individual segments. "
+        "(3) When '--no-copy-executable' is specified: "
+        "Never copy."
+    ),
+)
+@click.option(
+    "--from-checkpoint",
+    type=click.Path(
+        exists=True,
+        file_okay=False,
+        dir_okay=True,
+        readable=True,
+        path_type=Path,
+    ),
+    help="Restart from this checkpoint.",
+)
+@click.option(
+    "--from-last-checkpoint",
+    type=click.Path(
+        exists=True,
+        file_okay=False,
+        dir_okay=True,
+        readable=True,
+        path_type=Path,
+    ),
+    help="Restart from the last checkpoint in this directory.",
+)
+@click.option(
+    "--job-name",
+    "-J",
+    show_default="executable name",
+    help=(
+        "A short name for the job "
+        "(see main help text for possible placeholders)."
+    ),
+)
+@click.option(
+    "--num-procs",
+    "-j",
+    "-c",
+    type=_parse_param,
+    help=(
+        "Number of worker threads. "
+        "Mutually exclusive with '--num-nodes' / '-N'."
+    ),
+)
+@click.option("--num-nodes", "-N", type=_parse_param, help="Number of nodes")
+@click.option(
+    "--param",
+    "-p",
+    "params",
+    multiple=True,
+    callback=_parse_params,
+    help=(
+        "Forward additional parameters to input file "
+        "and submit script templates. "
+        "Can be specified multiple times. "
+        "Each entry must be a 'key=value' pair, where the key is "
+        "the parameter name. The value can be an int, float, "
+        "string, a comma-separated list, an inclusive range "
+        "like '0...3', an exclusive range like '0..3' or '0..<3', "
+        "or an exponentiated value or range like "
+        "'2**3' or '10**4...6'. "
+        "If a parameter is a list or range, multiple runs are "
+        "scheduled recursively. "
+        "You can also use the parameter in the 'job_name' and "
+        "in the 'run_dir' or 'segment_dir', and when scheduling "
+        "ranges of runs you probably should."
+    ),
+)
+@click.option(
+    "--clean-output",
+    "-C",
+    is_flag=True,
+    help=(
+        "Clean up existing output files in the run directory "
+        "before running the executable. "
+        "See the 'spectre clean-output' command for details."
+    ),
+)
+@click.option(
+    "--force",
+    "-f",
+    is_flag=True,
+    help=(
+        "Overwrite existing files in the '--run-dir' / '-o'. "
+        "You may also want to use '--clean-output'."
+    ),
+)
+# Scheduling options
+@click.option(
+    "--submit-script-template",
+    default=default_submit_script_template,
+    show_default=True,
+    # No `type=click.Path` because this can be a Jinja template
+    help=(
+        "Path to a submit script. "
+        "It will be copied to the 'run_dir'. It can be a [Jinja template]("
+        "https://jinja.palletsprojects.com/en/3.0.x/templates/) "
+        "(see main help text for possible placeholders)."
+    ),
+)
+@click.option("--queue", help="Name of the queue.")
+@click.option(
+    "--time-limit",
+    help="Wall time limit. Must be compatible with the chosen queue.",
+)
+@click.option(
+    "--scheduler",
+    default=("sbatch" if default_submit_script_template.exists() else None),
+    show_default=True if default_submit_script_template.exists() else "none",
+    help="The scheduler invoked to queue jobs on the machine.",
+)
+@click.option(
+    "--no-schedule",
+    is_flag=True,
+    help="Run the executable directly, without scheduling it.",
+)
+@click.option(
+    "--submit/--no-submit",
+    default=None,
+    help=(
+        "Submit jobs automatically. If neither option is "
+        "specified, a prompt will ask for confirmation before "
+        "a job is submitted."
+    ),
+)
+@click.option(
+    "--context-file-name",
+    default="SubmitContext.yaml",
+    show_default=True,
+    help="Name of the context file that supports resubmissions.",
+)
+def schedule_command(
+    params,
+    scheduler,
+    no_schedule,
+    from_checkpoint,
+    from_last_checkpoint,
+    **kwargs,
+):
+    _rich_traceback_guard = True  # Hide traceback until here
+    if no_schedule:
+        scheduler = None
+    if from_checkpoint and from_last_checkpoint:
+        raise click.UsageError(
+            "Specify either '--from-checkpoint' or '--from-last-checkpoint', "
+            "not both."
+        )
+    if from_last_checkpoint:
+        segments = list_segments(from_last_checkpoint)
+        if segments:
+            segment = segments[-1]
+        else:
+            segment = Segment.match(from_last_checkpoint)
+        if segment:
+            all_checkpoints = segment.checkpoints
+            assert all_checkpoints, (
+                f"The segment '{segment}' contains no checkpoints. It may"
+                " be incomplete. Did you forget to remove it?"
+            )
+        else:
+            all_checkpoints = list_checkpoints(from_last_checkpoint)
+            assert all_checkpoints, (
+                f"Directory '{from_last_checkpoint}' contains no checkpoints "
+                f"that match the pattern '{Checkpoint.NAME_PATTERN.pattern}'."
+            )
+        from_checkpoint = all_checkpoints[-1]
+    schedule(
+        scheduler=scheduler, from_checkpoint=from_checkpoint, **kwargs, **params
+    )
+
+
+if __name__ == "__main__":
+    schedule_command(help_option_names=["-h", "--help"])

--- a/support/Python/__main__.py
+++ b/support/Python/__main__.py
@@ -30,6 +30,7 @@ class Cli(click.MultiCommand):
             "plot-dat",
             "plot-power-monitors",
             "render-1d",
+            "schedule",
             "simplify-traces",
             "status",
             "transform-volume-data",
@@ -85,6 +86,10 @@ class Cli(click.MultiCommand):
             from spectre.Visualization.Render1D import render_1d_command
 
             return render_1d_command
+        elif name in ["schedule", "run"]:
+            from spectre.support.Schedule import schedule_command
+
+            return schedule_command
         elif name == "simplify-traces":
             from spectre.tools.CharmSimplifyTraces import (
                 simplify_traces_command,

--- a/support/Python/__main__.py
+++ b/support/Python/__main__.py
@@ -30,6 +30,7 @@ class Cli(click.MultiCommand):
             "plot-dat",
             "plot-power-monitors",
             "render-1d",
+            "resubmit",
             "schedule",
             "simplify-traces",
             "status",
@@ -86,6 +87,10 @@ class Cli(click.MultiCommand):
             from spectre.Visualization.Render1D import render_1d_command
 
             return render_1d_command
+        elif name == "resubmit":
+            from spectre.support.Resubmit import resubmit_command
+
+            return resubmit_command
         elif name in ["schedule", "run"]:
             from spectre.support.Schedule import schedule_command
 

--- a/support/Python/requirements.txt
+++ b/support/Python/requirements.txt
@@ -19,6 +19,8 @@ click
 h5py >= 3.5.0
 # Humanize: For human-readable output like "2 hours ago"
 humanize
+# Jinja2: To work with placeholders in input files and submit scripts
+Jinja2
 # - We constrain the Numpy version because v1.22+ segfaults in Pypp tests, see
 #   issue: https://github.com/sxs-collaboration/spectre/issues/3844
 numpy < 1.22.0

--- a/support/SubmitScripts/CaltechHpc.sh
+++ b/support/SubmitScripts/CaltechHpc.sh
@@ -1,92 +1,18 @@
-#!/bin/bash -
-#SBATCH -o spectre.stdout
-#SBATCH -e spectre.stderr
-#SBATCH --ntasks-per-node 2
-#SBATCH --cpus-per-task 28
-#SBATCH -J KerrSchild
-#SBATCH --nodes 2
-#SBATCH -p any
-#SBATCH -t 12:00:00
-#SBATCH -D .
+{% extends "SubmitTemplateBase.sh" %}
 
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-# To run a job on Caltech HPC:
-# - Set the -J, --nodes, and -t options above, which correspond to job name,
-#   number of nodes, and wall time limit in HH:MM:SS, respectively.
-# - Set an `#SBATCH -A` argument for the computing account id.
-# - Or set --reservation=RES_NAME if there is a reservation available
-# - Set the build directory, run directory, executable name,
-#   and input file below.
-#
-# NOTE: The executable will not be copied from the build directory, so if you
-#       update your build directory this file will use the updated executable.
-#
-# Optionally, if you need more control over how SpECTRE is launched on
-# Caltech HPC you can edit the launch command at the end of this file directly.
-#
-# To submit the script to the queue run:
-#   sbatch CaltechHpc.sh
+# CaltechHPC is a supercomputer at Caltech.
+# More information:
+# https://www.hpc.caltech.edu/documentation
 
-# Replace these paths with the path to your build directory, to the source root
-# directory, the spectre dependencies module directory, and to the directory
-# where you want the output to appear, i.e. the run directory.
-# E.g., if you cloned spectre in your home directory, set
-# SPECTRE_BUILD_DIR to ${HOME}/spectre/build. If you want to run in a
-# directory called "Run" in the current directory, set
-# SPECTRE_RUN_DIR to ${PWD}/Run
-export SPECTRE_BUILD_DIR=${HOME}/Codes/spectre/build_clang/
-export SPECTRE_MODULE_DIR=${HOME}/Codes/spectre_deps/modules/
-export SPECTRE_HOME=${HOME}/Codes/spectre/
-export SPECTRE_RUN_DIR=${PWD}/Run
-
-# Choose the executable and input file to run
-# To use an input file in the current directory, set
-# SPECTRE_INPUT_FILE to ${PWD}/InputFileName.yaml
-export SPECTRE_EXECUTABLE=${SPECTRE_BUILD_DIR}/bin/EvolveGeneralizedHarmonic
-export SPECTRE_INPUT_FILE=${PWD}/KerrSchild.yaml
-
-# These commands load the relevant modules and cd into the run directory,
-# creating it if it doesn't exist
-source ${SPECTRE_HOME}/support/Environments/caltech_hpc_gcc.sh
-module use ${SPECTRE_MODULE_DIR}
-spectre_load_modules
-module list
-
-mkdir -p ${SPECTRE_RUN_DIR}
-cd ${SPECTRE_RUN_DIR}
-
-# Copy the input file into the run directory, to preserve it
-cp ${SPECTRE_INPUT_FILE} ${SPECTRE_RUN_DIR}/
-
-# Set desired permissions for files created with this script
-umask 0022
-
-# Set the path to include the build directory's bin directory
-export PATH=${SPECTRE_BUILD_DIR}/bin:$PATH
-
-CHARM_PPN=$(expr ${SLURM_CPUS_PER_TASK} - 1)
-
-echo "###################################"
-echo "######       JOB INFO        ######"
-echo "###################################"
-echo
-echo "Job ID: ${SLURM_JOB_ID}"
-echo "Run Directory: ${SPECTRE_RUN_DIR}"
-echo "Submit Directory: ${SLURM_SUBMIT_DIR}"
-echo "Queue: ${SLURM_JOB_PARTITION}"
-echo "Nodelist: ${SLURM_JOB_NODELIST}"
-echo "Tasks: ${SLURM_NTASKS}"
-echo "CPUs per Task: ${SLURM_CPUS_PER_TASK}"
-echo "Charm ppn: ${CHARM_PPN}"
-echo "PATH: ${PATH}"
-echo
-echo "###################################"
-echo "######   Executable Output   ######"
-echo "###################################"
-echo
-
-mpirun -n ${SLURM_NTASKS} \
-    ${SPECTRE_EXECUTABLE} ++ppn ${CHARM_PPN} +setcpuaffinity \
-    --input-file ${SPECTRE_INPUT_FILE}
+{% block head %}
+{{ super() -}}
+#SBATCH --nodes {{ num_nodes | default(1) }}
+#SBATCH --ntasks-per-node 2
+#SBATCH --cpus-per-task 28
+#SBATCH -p {{ queue | default("any") }}
+#SBATCH -t {{ time_limit | default("1-00:00:00") }}
+#SBATCH --reservation sxs
+{% endblock %}

--- a/support/SubmitScripts/SubmitTemplateBase.sh
+++ b/support/SubmitScripts/SubmitTemplateBase.sh
@@ -1,0 +1,74 @@
+#!/bin/bash -
+{% block head %}
+#SBATCH -o {{ out_file }}
+#SBATCH -e {{ out_file }}
+#SBATCH -J {{ job_name }}
+#SBATCH --no-requeue
+#SBATCH --comment "SPECTRE_INPUT_FILE={{ input_file }}"
+{% endblock %}
+
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+export RUN_DIR={{ run_dir }}
+export SPECTRE_INPUT_FILE={{ input_file }}
+export SPECTRE_EXECUTABLE={{ executable }}
+export SPECTRE_CHECKPOINT={{ from_checkpoint | default("") }}
+export SPECTRE_CLI={{ spectre_cli }}
+
+{% block charm_ppn %}
+CHARM_PPN=$(expr ${SLURM_CPUS_PER_TASK} - 1)
+{% endblock %}
+
+echo "###################################"
+echo "######       JOB INFO        ######"
+echo "###################################"
+echo
+echo "Job ID: ${SLURM_JOB_ID}"
+echo "Run Directory: ${RUN_DIR}"
+echo "Submit Directory: ${SLURM_SUBMIT_DIR}"
+echo "Queue: ${SLURM_JOB_PARTITION}"
+echo "Nodelist: ${SLURM_JOB_NODELIST}"
+echo "Tasks: ${SLURM_NTASKS}"
+echo "CPUs per Task: ${SLURM_CPUS_PER_TASK}"
+echo "Charm ppn: ${CHARM_PPN}"
+echo "PATH: ${PATH}"
+echo "Executable: ${SPECTRE_EXECUTABLE}"
+echo "CLI: ${SPECTRE_CLI}"
+echo
+
+{% block list_modules %}
+module list
+{% endblock %}
+
+############################################################################
+# Set desired permissions for files created with this script
+umask 0022
+
+echo
+echo "###################################"
+echo "######   Executable Output   ######"
+echo "###################################"
+echo
+
+cd ${RUN_DIR}
+
+{% block run_command %}
+mpirun -n ${SLURM_NTASKS} \
+  ${SPECTRE_EXECUTABLE} --input-file ${SPECTRE_INPUT_FILE} \
+  ++ppn ${CHARM_PPN} +setcpuaffinity \
+  ${SPECTRE_CHECKPOINT:+ +restart "${SPECTRE_CHECKPOINT}"}
+{% endblock %}
+
+{% if segments_dir is defined %}
+# Resubmit
+exit_code=$?
+if [ $exit_code -eq 2 ]; then
+  sleep 10s
+  ${SPECTRE_CLI} resubmit . \
+    --context-file-name {{ context_file_name }} \
+    --submit
+else
+  exit $exit_code
+fi
+{% endif %}

--- a/support/SubmitScripts/Wheeler.sh
+++ b/support/SubmitScripts/Wheeler.sh
@@ -1,103 +1,23 @@
-#!/bin/bash -
-#SBATCH -o spectre.out
-#SBATCH -e spectre.out
-#SBATCH --ntasks-per-node 1
-#SBATCH --cpus-per-task=24
-#SBATCH -A sxs
-#SBATCH --no-requeue
-#SBATCH -J MyJobName
-#SBATCH --nodes 4
-#SBATCH -t 0:15:00
+{% extends "SubmitTemplateBase.sh" %}
 
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-# To run a job on Wheeler:
-# - Set the -J, --nodes, and -t options above, which correspond to job name,
-#   number of nodes, and wall time limit in HH:MM:SS, respectively.
-# - Set the build directory, run directory, executable name,
-#   and input file below. The input file path is relative to ${RUN_DIR}.
-#
-# NOTE: The executable will not be copied from the build directory, so if you
-#       update your build directory this file will use the updated executable.
-#
-# Optionally, if you need more control over how SpECTRE is launched on
-# Wheeler you can edit the launch command at the end of this file directly.
-#
-# To submit the script to the queue run:
-#   sbatch Wheeler.sh
+# Wheeler is a supercomputer at Caltech.
+# More information:
+# https://github.com/sxs-collaboration/WelcomeToSXS/wiki/Wheeler
 
-export SPECTRE_BUILD_DIR=/path/to/build/dir
-export RUN_DIR=/panfs/ds08/sxs/run/dir
-export SPECTRE_EXECUTABLE=EvolveScalarWave3D
-export SPECTRE_INPUT_FILE=./Input3DPeriodic.yaml
+{% block head %}
+{{ super() -}}
+#SBATCH --nodes {{ num_nodes | default(1) }}
+#SBATCH --ntasks-per-node 1
+#SBATCH --cpus-per-task 24
+#SBATCH -A sxs
+#SBATCH -p {{ queue | default("productionQ") }}
+#SBATCH -t {{ time_limit | default("1-00:00:00") }}
+{% endblock %}
 
-export PATH=${SPECTRE_BUILD_DIR}/bin:$PATH
-
-CHARM_PPN=$(expr ${SLURM_CPUS_PER_TASK} - 1)
-
-echo "###################################"
-echo "######       JOB INFO        ######"
-echo "###################################"
-echo
-echo "Job ID: ${SLURM_JOB_ID}"
-echo "Run Directory: ${RUN_DIR}"
-echo "Submit Directory: ${SLURM_SUBMIT_DIR}"
-echo "Queue: ${SLURM_JOB_PARTITION}"
-echo "Nodelist: ${SLURM_JOB_NODELIST}"
-echo "Tasks: ${SLURM_NTASKS}"
-echo "CPUs per Task: ${SLURM_CPUS_PER_TASK}"
-echo "Charm ppn: ${CHARM_PPN}"
-echo "PATH: ${PATH}"
-echo
-
+# We had an issue calling 'module list' on the 'unlimited' queue
+{% block list_modules %}
 /usr/bin/modulecmd bash list
-
-############################################################################
-# Set desired permissions for files created with this script
-umask 0022
-
-echo
-echo "###################################"
-echo "######   Executable Output   ######"
-echo "###################################"
-echo
-
-cd ${RUN_DIR}
-
-checkpoints=0
-current_checkpoint=0000
-if [[ $checkpoints == 0 ]]; then
-  mpirun -n ${SLURM_NTASKS} \
-       ${SPECTRE_EXECUTABLE} ++ppn ${CHARM_PPN} +setcpuaffinity \
-       --input-file ${SPECTRE_INPUT_FILE}
-  sleep 10s
-  # If a checkpoint is found add one to checkpoint and sumbit next job
-  if test -e "${PWD}/Checkpoints/Checkpoint_$current_checkpoint"; then
-    mv spectre.out "${PWD}/Checkpoints/Checkpoint_$current_checkpoint"
-    sed -i "s/^checkpoints=0/checkpoints=1/" Wheeler.sh
-    sbatch Wheeler.sh
-  fi
-# Section to start from checkpoint
-elif [[ $checkpoints -gt 0 && $checkpoints -lt 10000 ]]; then
-  mpirun -n ${SLURM_NTASKS} \
-       ${SPECTRE_EXECUTABLE} ++ppn ${CHARM_PPN} +setcpuaffinity \
-       --input-file ${SPECTRE_INPUT_FILE} \
-       +restart Checkpoints/Checkpoint_${current_checkpoint}
-  sleep 10s
-  # If the next checkpoint was created modify variables and submit next job
-  printf -v next_checkpoint %04d $checkpoints
-  if test -e "${PWD}/Checkpoints/Checkpoint_$next_checkpoint"; then
-    # We move the current spectre.out to the checkpoint directory because SLURM
-    # will overwrite it once the new job is run.
-    mv spectre.out "${PWD}/Checkpoints/Checkpoint_$next_checkpoint"
-    next_num_of_checkpoints=$(($checkpoints + 1))
-    #Updating variables for the next possible checkpoint
-    sed -i "s/^checkpoints=$checkpoints/"\
-"checkpoints=$next_num_of_checkpoints/" Wheeler.sh
-    sed -i "s/^current_checkpoint=$current_checkpoint/"\
-"current_checkpoint=$next_checkpoint/" Wheeler.sh
-    sbatch Wheeler.sh
-  fi
-fi
-
+{% endblock %}

--- a/tests/support/Python/CMakeLists.txt
+++ b/tests/support/Python/CMakeLists.txt
@@ -35,3 +35,9 @@ spectre_add_python_bindings_test(
   Test_Main.py
   "Python"
   None)
+
+spectre_add_python_bindings_test(
+  "support.Python.Schedule"
+  Test_Schedule.py
+  "Python"
+  None)

--- a/tests/support/Python/Test_Schedule.py
+++ b/tests/support/Python/Test_Schedule.py
@@ -1,0 +1,306 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import logging
+import shutil
+import stat
+import unittest
+from pathlib import Path
+
+import yaml
+from click.testing import CliRunner
+
+from spectre.Informer import unit_test_build_path, unit_test_src_path
+from spectre.support.Schedule import (
+    Checkpoint,
+    Segment,
+    list_checkpoints,
+    list_segments,
+    schedule,
+    schedule_command,
+)
+
+
+class TestSchedule(unittest.TestCase):
+    def setUp(self):
+        self.test_dir = Path(unit_test_build_path(), "Schedule")
+        self.test_dir.mkdir(parents=True, exist_ok=True)
+        self.spectre_cli = (
+            Path(unit_test_build_path()).parent.parent / "bin/spectre"
+        )
+
+        # Create an executable that just outputs all arguments passed to it
+        self.executable = self.test_dir / "TestExec"
+        self.executable.write_text("""#!/bin/bash
+echo $@ > out.txt
+""")
+        self.executable.chmod(self.executable.stat().st_mode | stat.S_IEXEC)
+
+        # Create an input file template
+        self.input_file_template = self.test_dir / "InputFile.yaml"
+        self.input_file_template.write_text("""
+Executable: TestExec
+---
+Option: {{ extra_option }}
+""")
+
+        # Create a submit script template
+        (self.test_dir / "SubmitTemplateBase.sh").write_text("""\
+SPECTRE_EXECUTABLE={{ executable }}
+SPECTRE_CLI={{ spectre_cli }}
+{% block derived %}
+{% endblock %}
+""")
+        self.submit_script_template = self.test_dir / "SubmitTemplate.sh"
+        self.submit_script_template.write_text("""\
+{% extends "SubmitTemplateBase.sh" %}
+{% block derived %}
+NUM_NODES={{ num_nodes | default(1) }}
+{% endblock %}
+""")
+
+    def tearDown(self):
+        shutil.rmtree(self.test_dir, ignore_errors=True)
+
+    def test_run(self):
+        # Run executable once
+        proc = schedule(
+            input_file_template=self.input_file_template,
+            scheduler=None,
+            executable=self.executable,
+            run_dir=self.test_dir / "Run",
+            extra_option="TestOpt",
+        )
+        self.assertEqual(proc.returncode, 0)
+        with open(self.test_dir / "Run/InputFile.yaml", "r") as open_input_file:
+            _, rendered_input_file = yaml.safe_load_all(open_input_file)
+            self.assertEqual(rendered_input_file["Option"], "TestOpt")
+        args = (self.test_dir / "Run/out.txt").read_text().split()
+        self.assertEqual(
+            args,
+            [
+                "--input-file",
+                str(self.test_dir / "Run/InputFile.yaml"),
+                "+auto-provision",
+            ],
+        )
+
+        # Run executable multiple times (like a convergence test)
+        schedule(
+            input_file_template=self.input_file_template,
+            scheduler=None,
+            executable=self.executable,
+            run_dir=self.test_dir / "Lev{{ lev }}",
+            lev=range(1, 3),
+            extra_option="TestOpt",
+        )
+        self.assertEqual(
+            sorted(self.test_dir.glob("Lev*")),
+            [self.test_dir / "Lev1", self.test_dir / "Lev2"],
+        )
+        self.assertEqual(
+            sorted(self.test_dir.glob("Lev*/InputFile.yaml")),
+            [
+                self.test_dir / "Lev1/InputFile.yaml",
+                self.test_dir / "Lev2/InputFile.yaml",
+            ],
+        )
+
+        # Create first of a series of segments
+        schedule(
+            input_file_template=self.input_file_template,
+            scheduler=None,
+            executable=self.executable,
+            segments_dir=self.test_dir,
+            extra_option="TestOpt",
+        )
+        self.assertEqual(
+            sorted(self.test_dir.glob("Segment*")),
+            [self.test_dir / "Segment_0000"],
+        )
+        self.assertEqual(
+            sorted(self.test_dir.glob("Segment*/InputFile.yaml")),
+            [self.test_dir / "Segment_0000/InputFile.yaml"],
+        )
+
+        # Create next segment
+        # - Can't continue without a previous checkpoint
+        with self.assertRaisesRegex(AssertionError, "continue from the last"):
+            schedule(
+                input_file_template=self.input_file_template,
+                scheduler=None,
+                executable=self.executable,
+                segments_dir=self.test_dir,
+                extra_option="TestOpt",
+            )
+        # - Can't continue from an earlier checkpoint than the last
+        earlier_checkpoint = Checkpoint.match(
+            self.test_dir / "Segment_0000/Checkpoints/Checkpoint_0000"
+        )
+        earlier_checkpoint.path.mkdir(parents=True)
+        last_checkpoint = Checkpoint.match(
+            self.test_dir / "Segment_0000/Checkpoints/Checkpoint_0001"
+        )
+        last_checkpoint.path.mkdir(parents=True)
+        with self.assertRaisesRegex(AssertionError, "continue from the last"):
+            schedule(
+                input_file_template=self.input_file_template,
+                scheduler=None,
+                executable=self.executable,
+                segments_dir=self.test_dir,
+                from_checkpoint=earlier_checkpoint,
+                extra_option="TestOpt",
+            )
+        # - Continue from last checkpoint
+        schedule(
+            input_file_template=self.input_file_template,
+            scheduler=None,
+            executable=self.executable,
+            segments_dir=self.test_dir,
+            from_checkpoint=last_checkpoint,
+            extra_option="TestOpt",
+        )
+
+    def test_schedule(self):
+        # Submit a batch job to create the first segment
+        schedule(
+            input_file_template=self.input_file_template,
+            scheduler=["echo", "Submitted batch job 000"],
+            submit_script_template=self.submit_script_template,
+            executable=self.executable,
+            segments_dir=self.test_dir / "Segments",
+            extra_option="TestOpt",
+            submit=True,
+        )
+        self.assertEqual(
+            sorted(self.test_dir.glob("Segments/**/*")),
+            [
+                self.test_dir / "Segments/Segment_0000",
+                self.test_dir / "Segments/Segment_0000/InputFile.yaml",
+                self.test_dir / "Segments/Segment_0000/Submit.sh",
+                self.test_dir / "Segments/Segment_0000/SubmitContext.yaml",
+                self.test_dir / "Segments/Segment_0000/jobid.txt",
+                self.test_dir / "Segments/Segment_0000/out.txt",
+                self.test_dir / "Segments/SubmitTemplate.sh",
+                self.test_dir / "Segments/SubmitTemplateBase.sh",
+                self.test_dir / "Segments/TestExec",
+            ],
+        )
+        self.assertEqual(
+            (self.test_dir / "Segments/Segment_0000/jobid.txt").read_text(),
+            "000",
+        )
+        self.assertEqual(
+            (self.test_dir / "Segments/Segment_0000/out.txt")
+            .read_text()
+            .split(),
+            [
+                "--input-file",
+                str(self.test_dir / "Segments/Segment_0000/InputFile.yaml"),
+                "--check-options",
+            ],
+        )
+        with open(
+            self.test_dir / "Segments/Segment_0000/SubmitContext.yaml", "r"
+        ) as open_context_file:
+            context = yaml.safe_load(open_context_file)
+        self.assertDictEqual(
+            context,
+            dict(
+                clean_output=False,
+                context_file_name="SubmitContext.yaml",
+                copy_executable=None,
+                executable=str(self.test_dir / "Segments/TestExec"),
+                executable_name="TestExec",
+                extra_option="TestOpt",
+                force=False,
+                input_file="InputFile.yaml",
+                input_file_name="InputFile.yaml",
+                input_file_template=str(self.test_dir / "InputFile.yaml"),
+                job_name="TestExec",
+                out_file=str(
+                    self.test_dir / "Segments/Segment_0000/spectre.out"
+                ),
+                out_file_name="spectre.out",
+                run_dir=str(self.test_dir / "Segments/Segment_0000"),
+                scheduler=["echo", "Submitted batch job 000"],
+                segments_dir=str(self.test_dir / "Segments"),
+                spectre_cli=str(self.spectre_cli),
+                submit=True,
+                submit_script_name="Submit.sh",
+                submit_script_template=str(
+                    self.test_dir / "Segments/SubmitTemplate.sh"
+                ),
+            ),
+        )
+        self.assertEqual(
+            (self.test_dir / "Segments/Segment_0000/Submit.sh").read_text(),
+            """\
+SPECTRE_EXECUTABLE={executable}
+SPECTRE_CLI={spectre_cli}
+NUM_NODES=1
+""".format(
+                executable=self.test_dir / "Segments/TestExec",
+                spectre_cli=self.spectre_cli,
+            ),
+        )
+
+        # Resubmit from the first segment using `schedule`
+        checkpoint = Checkpoint.match(
+            self.test_dir / "Segments/Segment_0000/Checkpoints/Checkpoint_0000"
+        )
+        checkpoint.path.mkdir(parents=True)
+        schedule(
+            input_file_template=self.test_dir
+            / "Segments/Segment_0000/InputFile.yaml",
+            scheduler=["echo", "Submitted batch job 001"],
+            submit_script_template=self.test_dir / "Segments/SubmitTemplate.sh",
+            executable=self.test_dir / "Segments/TestExec",
+            segments_dir=self.test_dir / "Segments",
+            from_checkpoint=checkpoint,
+            extra_option="TestOpt",
+            submit=True,
+        )
+        self.assertEqual(
+            (self.test_dir / "Segments/Segment_0001/jobid.txt").read_text(),
+            "001",
+        )
+
+    def test_cli(self):
+        runner = CliRunner()
+        runner.invoke(
+            schedule_command,
+            [
+                str(self.input_file_template),
+                "-e",
+                str(self.executable),
+                "-o",
+                str(self.test_dir / "Run"),
+                "-p",
+                "extra_option=TestOpt",
+            ],
+            catch_exceptions=False,
+        )
+        runner.invoke(
+            schedule_command,
+            [
+                str(self.input_file_template),
+                "-e",
+                str(self.executable),
+                "-O",
+                str(self.test_dir / "Segments"),
+                "-p",
+                "extra_option=TestOpt",
+                "--scheduler",
+                "cat",
+                "--submit-script-template",
+                str(self.submit_script_template),
+                "--submit",
+            ],
+            catch_exceptions=False,
+        )
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.DEBUG)
+    unittest.main(verbosity=2)

--- a/tests/support/Python/Test_Schedule.py
+++ b/tests/support/Python/Test_Schedule.py
@@ -11,6 +11,7 @@ import yaml
 from click.testing import CliRunner
 
 from spectre.Informer import unit_test_build_path, unit_test_src_path
+from spectre.support.Resubmit import resubmit, resubmit_command
 from spectre.support.Schedule import (
     Checkpoint,
     Segment,
@@ -266,6 +267,17 @@ NUM_NODES=1
             "001",
         )
 
+        # Resubmit from the second segment using `resubmit`
+        checkpoint = Checkpoint.match(
+            self.test_dir / "Segments/Segment_0001/Checkpoints/Checkpoint_0000"
+        )
+        checkpoint.path.mkdir(parents=True)
+        resubmit(self.test_dir / "Segments", submit=True)
+        self.assertEqual(
+            (self.test_dir / "Segments/Segment_0002/jobid.txt").read_text(),
+            "001",
+        )
+
     def test_cli(self):
         runner = CliRunner()
         runner.invoke(
@@ -296,6 +308,17 @@ NUM_NODES=1
                 "--submit-script-template",
                 str(self.submit_script_template),
                 "--submit",
+            ],
+            catch_exceptions=False,
+        )
+        checkpoint = Checkpoint.match(
+            self.test_dir / "Segments/Segment_0000/Checkpoints/Checkpoint_0000"
+        )
+        checkpoint.path.mkdir(parents=True)
+        runner.invoke(
+            resubmit_command,
+            [
+                str(self.test_dir / "Segments"),
             ],
             catch_exceptions=False,
         )

--- a/tools/Status/Status.py
+++ b/tools/Status/Status.py
@@ -112,6 +112,12 @@ def get_input_file(comment: Optional[str], work_dir: str) -> Optional[str]:
                 "Could not find 'SPECTRE_INPUT_FILE' in Slurm comment:\n"
                 + comment
             )
+    # Fallback: Get the input file from the submit context file if present
+    context_file = Path(work_dir) / "SubmitContext.yaml"
+    if context_file.exists():
+        with open(context_file, "r") as open_context_file:
+            input_file = yaml.safe_load(open_context_file)["input_file"]
+            return os.path.join(work_dir, input_file)
     # Fallback: Check if there's a single YAML file in the work dir
     yaml_files = glob.glob(os.path.join(work_dir, "*.yaml"))
     if len(yaml_files) == 1:


### PR DESCRIPTION
## Proposed changes

Tool for scheduling runs, submitting jobs, setting up directories for segments and checkpoints, restarting from checkpoints, resubmitting jobs. Also allows to schedule ranges of runs, e.g. for convergence tests.

Try it like this:

```sh
spectre schedule INPUT_FILE -o ./Run
```

To run a convergence test put something like `InitialGridPoints: {{ num_points }}` in your input file and try this:

```sh
spectre schedule INPUT_FILE -p num_points=6...8 -o './Run_p{{ num_points - 1 }}'
```

Closes #2987.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
- Install `Jinja2` in your Python environment (it's probably already installed because other packages need it).
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
