### PR TITLE
Add TCI on DG grid for ForceFree evolution system

### DIFF
--- a/src/Evolution/Systems/ForceFree/CMakeLists.txt
+++ b/src/Evolution/Systems/ForceFree/CMakeLists.txt
@@ -55,3 +55,4 @@ target_link_libraries(
 add_subdirectory(BoundaryConditions)
 add_subdirectory(BoundaryCorrections)
 add_subdirectory(FiniteDifference)
+add_subdirectory(Subcell)

--- a/src/Evolution/Systems/ForceFree/Subcell/CMakeLists.txt
+++ b/src/Evolution/Systems/ForceFree/Subcell/CMakeLists.txt
@@ -1,0 +1,17 @@
+#
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+spectre_target_sources(
+  ${LIBRARY}
+  PRIVATE
+  TciOnDgGrid.cpp
+  )
+
+spectre_target_headers(
+  ${LIBRARY}
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  Subcell.hpp
+  TciOnDgGrid.hpp
+  )

--- a/src/Evolution/Systems/ForceFree/Subcell/Subcell.hpp
+++ b/src/Evolution/Systems/ForceFree/Subcell/Subcell.hpp
@@ -1,0 +1,9 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+namespace ForceFree {
+/// \brief Code required by the DG-FD hybrid solver.
+namespace subcell {}
+}  // namespace ForceFree

--- a/src/Evolution/Systems/ForceFree/Subcell/TciOnDgGrid.cpp
+++ b/src/Evolution/Systems/ForceFree/Subcell/TciOnDgGrid.cpp
@@ -1,0 +1,111 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/ForceFree/Subcell/TciOnDgGrid.hpp"
+
+#include <cstddef>
+#include <utility>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Evolution/DgSubcell/Mesh.hpp"
+#include "Evolution/DgSubcell/PerssonTci.hpp"
+#include "Evolution/DgSubcell/Projection.hpp"
+#include "Evolution/DgSubcell/RdmpTci.hpp"
+#include "Evolution/DgSubcell/RdmpTciData.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace ForceFree::subcell {
+
+std::tuple<int, evolution::dg::subcell::RdmpTciData> TciOnDgGrid::apply(
+    const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_e,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_b,
+    const Scalar<DataVector>& tilde_q, const Mesh<3>& dg_mesh,
+    const Mesh<3>& subcell_mesh,
+    const evolution::dg::subcell::RdmpTciData& past_rdmp_tci_data,
+    const evolution::dg::subcell::SubcellOptions& subcell_options,
+    const double persson_exponent, bool /*element_stays_on_dg*/) {
+  evolution::dg::subcell::RdmpTciData rdmp_tci_data{};
+
+  const size_t num_dg_pts = dg_mesh.number_of_grid_points();
+  const size_t num_subcell_pts = subcell_mesh.number_of_grid_points();
+
+  DataVector temp_buffer{2 * num_dg_pts + 3 * num_subcell_pts};
+  size_t offset_into_temp_buffer = 0;
+  const auto assign_data =
+      [&temp_buffer, &offset_into_temp_buffer](
+          const gsl::not_null<Scalar<DataVector>*> to_assign,
+          const size_t size) {
+        ASSERT(offset_into_temp_buffer + size <= temp_buffer.size(),
+               "Trying to assign data out of allocated memory size");
+        get(*to_assign)
+            .set_data_ref(temp_buffer.data() + offset_into_temp_buffer, size);
+        offset_into_temp_buffer += size;
+      };
+
+  // Note : for RDMP TCI data, we compute mag(E), mag(B) on DG grid and then
+  // project their magnitude to FD grid, NOT projecting E^i and B^i on FD grid
+  // then compute magnitudes of them.
+
+  Scalar<DataVector> dg_mag_tilde_e{};
+  Scalar<DataVector> subcell_mag_tilde_e{};
+  assign_data(make_not_null(&dg_mag_tilde_e), num_dg_pts);
+  magnitude(make_not_null(&dg_mag_tilde_e), tilde_e);
+  assign_data(make_not_null(&subcell_mag_tilde_e), num_subcell_pts);
+  evolution::dg::subcell::fd::project(make_not_null(&get(subcell_mag_tilde_e)),
+                                      get(dg_mag_tilde_e), dg_mesh,
+                                      subcell_mesh.extents());
+
+  Scalar<DataVector> dg_mag_tilde_b{};
+  Scalar<DataVector> subcell_mag_tilde_b{};
+  assign_data(make_not_null(&dg_mag_tilde_b), num_dg_pts);
+  magnitude(make_not_null(&dg_mag_tilde_b), tilde_b);
+  assign_data(make_not_null(&subcell_mag_tilde_b), num_subcell_pts);
+  evolution::dg::subcell::fd::project(make_not_null(&get(subcell_mag_tilde_b)),
+                                      get(dg_mag_tilde_b), dg_mesh,
+                                      subcell_mesh.extents());
+
+  Scalar<DataVector> subcell_tilde_q{};
+  assign_data(make_not_null(&subcell_tilde_q), num_subcell_pts);
+  evolution::dg::subcell::fd::project(make_not_null(&get(subcell_tilde_q)),
+                                      get(tilde_q), dg_mesh,
+                                      subcell_mesh.extents());
+
+  using std::max;
+  using std::min;
+  rdmp_tci_data.max_variables_values =
+      DataVector{max(max(get(subcell_mag_tilde_e)), max(get(dg_mag_tilde_e))),
+                 max(max(get(subcell_mag_tilde_b)), max(get(dg_mag_tilde_b))),
+                 max(max(get(subcell_tilde_q)), max(get(tilde_q)))};
+  rdmp_tci_data.min_variables_values =
+      DataVector{min(min(get(subcell_mag_tilde_e)), min(get(dg_mag_tilde_e))),
+                 min(min(get(subcell_mag_tilde_b)), min(get(dg_mag_tilde_b))),
+                 min(min(get(subcell_tilde_q)), min(get(tilde_q)))};
+
+  // Perform the TCI checks
+  if (evolution::dg::subcell::persson_tci(dg_mag_tilde_e, dg_mesh,
+                                          persson_exponent)) {
+    return {-1, std::move(rdmp_tci_data)};
+  }
+  if (evolution::dg::subcell::persson_tci(dg_mag_tilde_b, dg_mesh,
+                                          persson_exponent)) {
+    return {-2, std::move(rdmp_tci_data)};
+  }
+  if (evolution::dg::subcell::persson_tci(tilde_q, dg_mesh, persson_exponent)) {
+    return {-3, std::move(rdmp_tci_data)};
+  }
+  if (const int rdmp_tci_status = evolution::dg::subcell::rdmp_tci(
+          rdmp_tci_data.max_variables_values,
+          rdmp_tci_data.min_variables_values,
+          past_rdmp_tci_data.max_variables_values,
+          past_rdmp_tci_data.min_variables_values,
+          subcell_options.rdmp_delta0(), subcell_options.rdmp_epsilon())) {
+    return {-(3 + rdmp_tci_status), std::move(rdmp_tci_data)};
+  }
+
+  return {0, std::move(rdmp_tci_data)};
+}
+
+}  // namespace ForceFree::subcell

--- a/src/Evolution/Systems/ForceFree/Subcell/TciOnDgGrid.hpp
+++ b/src/Evolution/Systems/ForceFree/Subcell/TciOnDgGrid.hpp
@@ -1,0 +1,98 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <tuple>
+
+#include "Domain/Tags.hpp"
+#include "Evolution/DgSubcell/RdmpTciData.hpp"
+#include "Evolution/DgSubcell/SubcellOptions.hpp"
+#include "Evolution/DgSubcell/Tags/DataForRdmpTci.hpp"
+#include "Evolution/DgSubcell/Tags/Mesh.hpp"
+#include "Evolution/DgSubcell/Tags/SubcellOptions.hpp"
+#include "Evolution/Systems/ForceFree/Tags.hpp"
+#include "PointwiseFunctions/GeneralRelativity/TagsDeclarations.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+class DataVector;
+template <size_t Dim>
+class Mesh;
+namespace gsl {
+template <typename T>
+class not_null;
+}  // namespace gsl
+/// \endcond
+
+namespace ForceFree::subcell {
+/*!
+ * \brief The troubled-cell indicator run on the DG grid to check if the
+ * solution is admissible.
+ *
+ * The following checks are done in the order they are listed:
+ *
+ * <table>
+ * <caption>List of checks</caption>
+ * <tr><th> Description <th> TCI status
+ *
+ * <tr><td> apply the Persson TCI to magnitude of `TildeE`
+ * <td> `-1`
+ *
+ * <tr><td> apply the Persson TCI to magnitude of `TildeB`
+ * <td> `-2`
+ *
+ * <tr><td> apply the Persson TCI to `TildeQ`
+ * <td> `-3`
+ *
+ * <tr><td> apply the RDMP TCI to magnitude of `TildeE`
+ * <td> `-4`
+ *
+ * <tr><td> apply the RDMP TCI to magnitude of `TildeB`
+ * <td> `-5`
+ *
+ * <tr><td> apply the RDMP TCI to `TildeQ`
+ * <td> `-6`
+ *
+ * </table>
+ *
+ * The second column of the table above denotes the value of an integer stored
+ * as the first element of the returned `std::tuple`, which indicates the
+ * particular kind of check that failed. For example, if the 3rd check
+ * (Persson TCI to TildeQ) fails and cell is marked as troubled, an integer with
+ * value `-3` is stored in the first slot of the returned tuple. Note that this
+ * integer is marking only the first check to fail since checks are done in a
+ * particular sequence as listed above. If all checks are passed and cell is not
+ * troubled, it is returned with the value `0`.
+ *
+ * When computing magnitudes of tensor quantities (TildeE, TildeB) here for TCI
+ * checks, we simply use the square root of the sum of spatial components
+ * squared, _not_ the square root of the scalar product using the spatial
+ * metric.
+ *
+ * \note We adopt negative integers to mark TCI status from DG grid returned by
+ * TciOnDgGrid class. Positive integers are used for TCIs on FD grid; see
+ * TciOnFdGrid and its documentation.
+ *
+ */
+class TciOnDgGrid {
+ public:
+  using return_tags = tmpl::list<>;
+  using argument_tags =
+      tmpl::list<Tags::TildeE, Tags::TildeB, Tags::TildeQ,
+                 domain::Tags::Mesh<3>, evolution::dg::subcell::Tags::Mesh<3>,
+                 evolution::dg::subcell::Tags::DataForRdmpTci,
+                 evolution::dg::subcell::Tags::SubcellOptions<3>>;
+
+  static std::tuple<int, evolution::dg::subcell::RdmpTciData> apply(
+      const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_e,
+      const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_b,
+      const Scalar<DataVector>& tilde_q, const Mesh<3>& dg_mesh,
+      const Mesh<3>& subcell_mesh,
+      const evolution::dg::subcell::RdmpTciData& past_rdmp_tci_data,
+      const evolution::dg::subcell::SubcellOptions& subcell_options,
+      double persson_exponent, bool /*element_stays_on_dg*/);
+};
+
+}  // namespace ForceFree::subcell

--- a/tests/Unit/Evolution/Systems/ForceFree/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/ForceFree/CMakeLists.txt
@@ -8,6 +8,7 @@ set(LIBRARY_SOURCES
   BoundaryConditions/Test_DirichletAnalytic.cpp
   BoundaryCorrections/Test_Rusanov.cpp
   FiniteDifference/Test_Tags.cpp
+  Subcell/Test_TciOnDgGrid.cpp
   Test_Characteristics.cpp
   Test_ElectricCurrentDensity.cpp
   Test_Fluxes.cpp

--- a/tests/Unit/Evolution/Systems/ForceFree/Subcell/Test_TciOnDgGrid.cpp
+++ b/tests/Unit/Evolution/Systems/ForceFree/Subcell/Test_TciOnDgGrid.cpp
@@ -1,0 +1,187 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <limits>
+#include <memory>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "DataStructures/VariablesTag.hpp"
+#include "Domain/Tags.hpp"
+#include "Evolution/DgSubcell/Mesh.hpp"
+#include "Evolution/DgSubcell/Projection.hpp"
+#include "Evolution/DgSubcell/SubcellOptions.hpp"
+#include "Evolution/DgSubcell/Tags/Mesh.hpp"
+#include "Evolution/DgSubcell/Tags/SubcellOptions.hpp"
+#include "Evolution/Systems/ForceFree/Subcell/TciOnDgGrid.hpp"
+#include "Evolution/Systems/ForceFree/System.hpp"
+#include "Evolution/Systems/ForceFree/Tags.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace {
+enum class TestThis {
+  AllGood,
+  PerssonMagTildeE,
+  PerssonMagTildeB,
+  PerssonTildeQ,
+  RdmpMagTildeE,
+  RdmpMagTildeB,
+  RdmpTildeQ
+};
+
+void test(const TestThis test_this, const int expected_tci_status) {
+  CAPTURE(test_this);
+  CAPTURE(expected_tci_status);
+
+  const Mesh<3> dg_mesh{6, Spectral::Basis::Legendre,
+                        Spectral::Quadrature::GaussLobatto};
+  const Mesh<3> subcell_mesh = evolution::dg::subcell::fd::mesh(dg_mesh);
+
+  using TildeE = ForceFree::Tags::TildeE;
+  using TildeB = ForceFree::Tags::TildeB;
+  using TildeQ = ForceFree::Tags::TildeQ;
+
+  using VarsForTciTest = Variables<tmpl::list<TildeE, TildeB, TildeQ>>;
+  VarsForTciTest dg_vars{dg_mesh.number_of_grid_points(), 0.0};
+
+  // set variables on the dg mesh for the test
+  get(get<TildeQ>(dg_vars)) = 1.0;
+  for (size_t i = 0; i < 3; ++i) {
+    get<TildeE>(dg_vars).get(i) = 2.0;
+    get<TildeB>(dg_vars).get(i) = 3.0;
+  }
+
+  // Just use flat spacetime since none of the TCI checks depends on metric
+  // variables
+  tnsr::ii<DataVector, 3, Frame::Inertial> spatial_metric{
+      dg_mesh.number_of_grid_points(), 0.0};
+  tnsr::II<DataVector, 3, Frame::Inertial> inv_spatial_metric{
+      dg_mesh.number_of_grid_points(), 0.0};
+  for (size_t i = 0; i < 3; ++i) {
+    spatial_metric.get(i, i) = inv_spatial_metric.get(i, i) = 1.0;
+  }
+  const Scalar<DataVector> sqrt_det_spatial_metric{
+      dg_mesh.number_of_grid_points(), 1.0};
+
+  const double persson_exponent = 4.0;
+
+  const evolution::dg::subcell::SubcellOptions subcell_options{
+      1.0e-10,
+      1.0e-10,
+      1.0e-10,
+      1.0e-10,
+      persson_exponent,
+      persson_exponent,
+      false,
+      evolution::dg::subcell::fd::ReconstructionMethod::DimByDim,
+      false,
+      std::nullopt,
+      fd::DerivativeOrder::Two};
+
+  auto box = db::create<db::AddSimpleTags<
+      ::Tags::Variables<VarsForTciTest::tags_list>, ::domain::Tags::Mesh<3>,
+      ::evolution::dg::subcell::Tags::Mesh<3>,
+      gr::Tags::SqrtDetSpatialMetric<DataVector>,
+      gr::Tags::SpatialMetric<DataVector, 3>,
+      gr::Tags::InverseSpatialMetric<DataVector, 3>,
+      evolution::dg::subcell::Tags::SubcellOptions<3>,
+      evolution::dg::subcell::Tags::DataForRdmpTci>>(
+      dg_vars, dg_mesh, subcell_mesh, sqrt_det_spatial_metric, spatial_metric,
+      inv_spatial_metric, subcell_options,
+      evolution::dg::subcell::RdmpTciData{});
+
+  const size_t point_to_change = dg_mesh.number_of_grid_points() / 2;
+
+  if (test_this == TestThis::PerssonMagTildeE) {
+    db::mutate<TildeE>(make_not_null(&box),
+                       [point_to_change](const auto tilde_e_ptr) {
+                         (*tilde_e_ptr).get(0)[point_to_change] *= 2.0;
+                       });
+  } else if (test_this == TestThis::PerssonMagTildeB) {
+    db::mutate<TildeB>(make_not_null(&box),
+                       [point_to_change](const auto tilde_b_ptr) {
+                         (*tilde_b_ptr).get(0)[point_to_change] *= 2.0;
+                       });
+  } else if (test_this == TestThis::PerssonTildeQ) {
+    db::mutate<TildeQ>(make_not_null(&box),
+                       [point_to_change](const auto tilde_q_ptr) {
+                         get(*tilde_q_ptr)[point_to_change] *= 2.0;
+                       });
+  }
+
+  // Set the RDMP TCI past data.
+  using std::max;
+  using std::min;
+
+  const auto dg_mag_tilde_e = get(magnitude(db::get<TildeE>(box)));
+  const auto dg_mag_tilde_b = get(magnitude(db::get<TildeB>(box)));
+  const auto dg_tilde_q = get(db::get<TildeQ>(box));
+  const auto subcell_mag_tilde_e = evolution::dg::subcell::fd::project(
+      dg_mag_tilde_e, dg_mesh, subcell_mesh.extents());
+  const auto subcell_mag_tilde_b = evolution::dg::subcell::fd::project(
+      dg_mag_tilde_b, dg_mesh, subcell_mesh.extents());
+  const auto subcell_tilde_q = evolution::dg::subcell::fd::project(
+      dg_tilde_q, dg_mesh, subcell_mesh.extents());
+
+  evolution::dg::subcell::RdmpTciData past_rdmp_tci_data{};
+  past_rdmp_tci_data.max_variables_values =
+      DataVector{max(max(dg_mag_tilde_e), max(subcell_mag_tilde_e)),
+                 max(max(dg_mag_tilde_b), max(subcell_mag_tilde_b)),
+                 max(max(dg_tilde_q), max(subcell_tilde_q))};
+  past_rdmp_tci_data.min_variables_values =
+      DataVector{min(min(dg_mag_tilde_e), min(subcell_mag_tilde_e)),
+                 min(min(dg_mag_tilde_b), min(subcell_mag_tilde_b)),
+                 min(min(dg_tilde_q), min(subcell_tilde_q))};
+
+  const evolution::dg::subcell::RdmpTciData expected_rdmp_tci_data =
+      past_rdmp_tci_data;
+
+  // Modify past data if we are expecting an RDMP TCI failure.
+  db::mutate<evolution::dg::subcell::Tags::DataForRdmpTci>(
+      make_not_null(&box),
+      [&past_rdmp_tci_data, &test_this](const auto rdmp_tci_data_ptr) {
+        *rdmp_tci_data_ptr = past_rdmp_tci_data;
+        // Assumes min is positive, increase it so we fail the TCI
+        if (test_this == TestThis::RdmpMagTildeE) {
+          rdmp_tci_data_ptr->min_variables_values[0] *= 1.01;
+        } else if (test_this == TestThis::RdmpMagTildeB) {
+          rdmp_tci_data_ptr->min_variables_values[1] *= 1.01;
+        } else if (test_this == TestThis::RdmpTildeQ) {
+          rdmp_tci_data_ptr->min_variables_values[2] *= 1.01;
+        }
+      });
+
+  const bool element_stays_on_dg = false;
+  const std::tuple<int, evolution::dg::subcell::RdmpTciData> result =
+      db::mutate_apply<ForceFree::subcell::TciOnDgGrid>(
+          make_not_null(&box), persson_exponent, element_stays_on_dg);
+
+  CHECK(get<1>(result) == expected_rdmp_tci_data);
+
+  if (test_this == TestThis::AllGood) {
+    CHECK_FALSE(get<0>(result));
+  } else {
+    CHECK(get<0>(result) == expected_tci_status);
+  }
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Evolution.ForceFree.Subcell.TciOnDgGrid",
+                  "[Unit][Evolution]") {
+  test(TestThis::AllGood, 0);
+  test(TestThis::PerssonMagTildeE, -1);
+  test(TestThis::PerssonMagTildeB, -2);
+  test(TestThis::PerssonTildeQ, -3);
+  test(TestThis::RdmpMagTildeE, -4);
+  test(TestThis::RdmpMagTildeB, -5);
+  test(TestThis::RdmpTildeQ, -6);
+}


### PR DESCRIPTION
## Proposed changes

I'm submitting PRs of TCIs with their simplest version, applying Persson and RDMP for obvious choices of scalar quantities (|E|, |B|, q). We might actually need more specific TCI options, but those will be updated in upcoming PRs soon.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
