### PR TITLE
Add moving mesh terms to GhGrhd system

### DIFF
--- a/src/Evolution/DgSubcell/Actions/Initialize.hpp
+++ b/src/Evolution/DgSubcell/Actions/Initialize.hpp
@@ -86,12 +86,14 @@ namespace evolution::dg::subcell::Actions {
  *   - `subcell::Tags::GhostDataForReconstruction<Dim>`
  *   - `subcell::Tags::TciDecision`
  *   - `subcell::Tags::DataForRdmpTci`
- *   - `subcell::fd::Tags::InverseJacobianLogicalToGrid<Dim>`
- *   - `subcell::fd::Tags::DetInverseJacobianLogicalToGrid`
+ *   - `subcell::fd::Tags::InverseJacobianLogicalToGrid<Dim>`(as compute tag)
+ *   - `subcell::fd::Tags::DetInverseJacobianLogicalToGrid` (as compute tag)
  *   - `subcell::Tags::LogicalCoordinates<Dim>`
  *   - `subcell::Tags::ReconstructionOrder<Dim>` (set as `std::nullopt`)
  *   - `subcell::Tags::Coordinates<Dim, Frame::Grid>` (as compute tag)
  *   - `subcell::Tags::Coordinates<Dim, Frame::Inertial>` (as compute tag)
+ *   - 'subcell::fd::Tags::InverseJacobianLogicalToInertial<Dim>` (as compute
+ * tag)
  * - Removes: nothing
  * - Modifies:
  *   - `System::variables_tag` and `System::primitive_variables_tag` if the cell
@@ -106,8 +108,6 @@ struct Initialize {
       Tags::ActiveGrid, Tags::DidRollback, Tags::TciGridHistory,
       Tags::GhostDataForReconstruction<Dim>, Tags::TciDecision,
       Tags::NeighborTciDecisions<Dim>, Tags::DataForRdmpTci,
-      fd::Tags::InverseJacobianLogicalToGrid<Dim>,
-      fd::Tags::DetInverseJacobianLogicalToGrid,
       subcell::Tags::CellCenteredFlux<typename System::flux_variables, Dim>,
       subcell::Tags::ReconstructionOrder<Dim>>;
   using compute_tags =
@@ -118,7 +118,16 @@ struct Initialize {
                      subcell::Tags::Coordinates>,
                  Tags::InertialCoordinatesCompute<
                      ::domain::CoordinateMaps::Tags::CoordinateMap<
-                         Dim, Frame::Grid, Frame::Inertial>>>;
+                         Dim, Frame::Grid, Frame::Inertial>>,
+                 fd::Tags::InverseJacobianLogicalToGridCompute<
+                   ::domain::Tags::ElementMap<Dim, Frame::Grid>,
+                   Dim>,
+                 fd::Tags::DetInverseJacobianLogicalToGridCompute<
+                   Dim>,
+                 fd::Tags::InverseJacobianLogicalToInertialCompute<
+                     ::domain::CoordinateMaps::Tags::CoordinateMap<
+                         Dim, Frame::Grid, Frame::Inertial>,
+                     Dim>>;
 
   template <typename DbTagsList, typename... InboxTags, typename ArrayIndex,
             typename ActionList, typename ParallelComponent,

--- a/src/Evolution/DgSubcell/Actions/TakeTimeStep.hpp
+++ b/src/Evolution/DgSubcell/Actions/TakeTimeStep.hpp
@@ -55,8 +55,6 @@ namespace evolution::dg::subcell::fd::Actions {
  * - Adds: nothing
  * - Removes: nothing
  * - Modifies:
- *   - `subcell::fd::Tags::InverseJacobianLogicalToGrid<Dim>`
- *   - `subcell::fd::Tags::DetInverseJacobianLogicalToGrid`
  *   - Anything that `Metavariables::SubcellOptions::TimeDerivative` modifies
  */
 template <typename TimeDerivative>
@@ -73,23 +71,11 @@ struct TakeTimeStep {
                 Dim, Frame::Grid, Frame::Inertial>>(box))
                .is_identity(),
            "Do not yet support moving mesh with DG-subcell.");
-    db::mutate<fd::Tags::InverseJacobianLogicalToGrid<Dim>,
-               fd::Tags::DetInverseJacobianLogicalToGrid>(
-        [](const auto inv_jac_ptr, const auto det_inv_jac_ptr,
-           const auto& logical_to_grid_map, const auto& logical_coords) {
-          if (not inv_jac_ptr->has_value()) {
-            *inv_jac_ptr = logical_to_grid_map.inv_jacobian(logical_coords);
-            *det_inv_jac_ptr = determinant(**inv_jac_ptr);
-          }
-        },
-        make_not_null(&box),
-        db::get<::domain::Tags::ElementMap<Dim, Frame::Grid>>(box),
-        db::get<subcell::Tags::Coordinates<Dim, Frame::ElementLogical>>(box));
 
     TimeDerivative::apply(
         make_not_null(&box),
-        *db::get<fd::Tags::InverseJacobianLogicalToGrid<Dim>>(box),
-        *db::get<fd::Tags::DetInverseJacobianLogicalToGrid>(box));
+        db::get<fd::Tags::InverseJacobianLogicalToGrid<Dim>>(box),
+        db::get<fd::Tags::DetInverseJacobianLogicalToGrid>(box));
 
     db::mutate<evolution::dg::Tags::MortarData<Dim>>(
         [](const auto mortar_data_ptr) {

--- a/src/Evolution/DgSubcell/Tags/Jacobians.hpp
+++ b/src/Evolution/DgSubcell/Tags/Jacobians.hpp
@@ -8,7 +8,10 @@
 #include <string>
 
 #include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/Tensor/EagerMath/Determinant.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Domain/ElementMap.hpp"
+#include "Utilities/SetNumberOfGridPoints.hpp"
 
 namespace evolution::dg::subcell::fd::Tags {
 /// \brief The inverse Jacobian from the element logical frame to the grid frame
@@ -22,8 +25,8 @@ namespace evolution::dg::subcell::fd::Tags {
 template <size_t Dim>
 struct InverseJacobianLogicalToGrid : db::SimpleTag {
   static std::string name() { return "InverseJacobian(Logical,Grid)"; }
-  using type = std::optional<
-      ::InverseJacobian<DataVector, Dim, Frame::ElementLogical, Frame::Grid>>;
+  using type =
+      ::InverseJacobian<DataVector, Dim, Frame::ElementLogical, Frame::Grid>;
 };
 
 /// \brief The determinant of the inverse Jacobian from the element logical
@@ -33,6 +36,123 @@ struct InverseJacobianLogicalToGrid : db::SimpleTag {
 /// and reduce the memory footprint.
 struct DetInverseJacobianLogicalToGrid : db::SimpleTag {
   static std::string name() { return "Det(InverseJacobian(Logical,Grid))"; }
-  using type = std::optional<Scalar<DataVector>>;
+  using type = Scalar<DataVector>;
 };
+
+/// \brief The inverse Jacobian from the element logical frame to the inertial
+/// frame at the cell centers.
+///
+/// Specifically, \f$\partial x^{\bar{i}} / \partial x^i\f$, where \f$\bar{i}\f$
+/// denotes the element logical frame and \f$i\f$ denotes the inertial frame.
+///
+/// \note stored as a `std::optional` so we can reset it when switching to DG
+/// and reduce the memory footprint (is it useful for a ComputeTag though?).
+template <size_t Dim>
+struct InverseJacobianLogicalToInertial : db::SimpleTag {
+  static std::string name() { return "InverseJacobian(Logical,Inertial)"; }
+  using type = ::InverseJacobian < DataVector, Dim, Frame::ElementLogical,
+        Frame::Inertial >;
+};
+
+/// Compute item for the inverse jacobian matrix from logical to
+/// grid coordinates
+template <typename MapTagLogicalToGrid, size_t Dim>
+struct InverseJacobianLogicalToGridCompute : InverseJacobianLogicalToGrid<Dim>,
+                                             db::ComputeTag {
+  static constexpr size_t dim = Dim;
+  using base = InverseJacobianLogicalToGrid<Dim>;
+  using return_type = typename base::type;
+  using argument_tags = tmpl::list<
+      MapTagLogicalToGrid,
+      evolution::dg::subcell::Tags::Coordinates<dim, Frame::ElementLogical>>;
+  static void function(
+      const gsl::not_null<return_type*> inverse_jacobian_logical_to_grid,
+      const ElementMap<Dim, Frame::Grid>& logical_to_grid_map,
+      const tnsr::I<DataVector, dim, Frame::ElementLogical>& logical_coords) {
+    *inverse_jacobian_logical_to_grid =
+        logical_to_grid_map.inv_jacobian(logical_coords);
+  }
+};
+
+/// Compute item for the determinant of the inverse jacobian matrix
+/// from logical to grid coordinates
+template <size_t Dim>
+struct DetInverseJacobianLogicalToGridCompute
+    : DetInverseJacobianLogicalToGrid,
+      db::ComputeTag {
+  static constexpr size_t dim = Dim;
+  using base = DetInverseJacobianLogicalToGrid;
+  using return_type = typename base::type;
+  using argument_tags = tmpl::list<InverseJacobianLogicalToGrid<Dim>>;
+  static void function(
+      const gsl::not_null<return_type*> det_inverse_jacobian_logical_to_grid,
+      const ::InverseJacobian<DataVector, Dim, Frame::ElementLogical,
+                              Frame::Grid>
+          inverse_jacobian_logical_to_grid) {
+    *det_inverse_jacobian_logical_to_grid =
+        determinant(inverse_jacobian_logical_to_grid);
+  }
+};
+
+/// Compute item for the inverse jacobian matrix from logical to
+/// inertial coordinates
+template <typename MapTagGridToInertial, size_t Dim>
+struct InverseJacobianLogicalToInertialCompute
+    : InverseJacobianLogicalToInertial<Dim>,
+      db::ComputeTag {
+  static constexpr size_t dim = Dim;
+  using base = InverseJacobianLogicalToInertial<Dim>;
+  using return_type = typename base::type;
+  using argument_tags =
+      tmpl::list<MapTagGridToInertial,
+                 evolution::dg::subcell::Tags::Coordinates<dim, Frame::Grid>,
+                 ::Tags::Time, ::domain::Tags::FunctionsOfTime,
+                 InverseJacobianLogicalToGrid<Dim>>;
+  static void function(
+      const gsl::not_null<return_type*> inverse_jacobian_logical_to_inertial,
+      const ::domain::CoordinateMapBase<Frame::Grid, Frame::Inertial, dim>&
+          grid_to_inertial_map,
+      const tnsr::I<DataVector, dim, Frame::Grid>& grid_coords,
+      const double time,
+      const std::unordered_map<
+          std::string,
+          std::unique_ptr<::domain::FunctionsOfTime::FunctionOfTime>>&
+          functions_of_time,
+      const ::InverseJacobian<DataVector, Dim, Frame::ElementLogical,
+                              Frame::Grid>& inverse_jacobian_logical_to_grid) {
+    if (grid_to_inertial_map.is_identity()) {
+      // Optimization for time-independent maps; we just point to the
+      // logical-to-grid inverse jacobian.
+      const size_t num_pts = inverse_jacobian_logical_to_grid[0].size();
+      for (size_t storage_index = 0;
+           storage_index < inverse_jacobian_logical_to_grid.size();
+           ++storage_index) {
+        make_const_view(
+            make_not_null(&std::as_const(
+                (*inverse_jacobian_logical_to_inertial)[storage_index])),
+            inverse_jacobian_logical_to_grid[storage_index], 0, num_pts);
+      }
+    } else {
+      set_number_of_grid_points(inverse_jacobian_logical_to_inertial,
+                                get<0>(grid_coords).size());
+      // Get grid to inertial inverse jacobian
+      const auto& inverse_jacobian_grid_to_inertial =
+          grid_to_inertial_map.inv_jacobian(grid_coords, time,
+                                            functions_of_time);
+      for (size_t i = 0; i < Dim; i++) {
+        for (size_t j = 0; j < Dim; j++) {
+          auto& inv_jacobian_component =
+              inverse_jacobian_logical_to_inertial->get(i, j);
+          inv_jacobian_component = 0.;
+          for (size_t k = 0; k < Dim; k++) {
+            inv_jacobian_component +=
+                inverse_jacobian_logical_to_grid.get(i, k) *
+                inverse_jacobian_grid_to_inertial.get(k, j);
+          }
+        }
+      }
+    }
+  }
+};
+
 }  // namespace evolution::dg::subcell::fd::Tags

--- a/tests/Unit/Evolution/DgSubcell/Actions/Test_TakeTimeStep.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Actions/Test_TakeTimeStep.cpp
@@ -59,12 +59,14 @@ struct component {
       domain::Tags::ElementMap<Dim, Frame::Grid>,
       domain::CoordinateMaps::Tags::CoordinateMap<Dim, Frame::Grid,
                                                   Frame::Inertial>,
-      evolution::dg::subcell::fd::Tags::InverseJacobianLogicalToGrid<Dim>,
-      evolution::dg::subcell::fd::Tags::DetInverseJacobianLogicalToGrid,
       evolution::dg::Tags::MortarData<Dim>>;
 
-  using initial_compute_tags =
-      tmpl::list<evolution::dg::subcell::Tags::LogicalCoordinatesCompute<Dim>>;
+  using initial_compute_tags = tmpl::list<
+      evolution::dg::subcell::Tags::LogicalCoordinatesCompute<Dim>,
+      evolution::dg::subcell::fd::Tags::InverseJacobianLogicalToGridCompute<
+          ::domain::Tags::ElementMap<Dim, Frame::Grid>, Dim>,
+      evolution::dg::subcell::fd::Tags::DetInverseJacobianLogicalToGridCompute<
+          Dim>>;
 
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
       Parallel::Phase::Initialization,
@@ -167,7 +169,7 @@ void test() {
       &runner, ActionTesting::NodeId{0}, ActionTesting::LocalCoreId{0}, 0,
       {subcell_mesh,
        ElementMap<Dim, Frame::Grid>{ElementId<Dim>{0}, make_grid_map<Dim>()},
-       make_inertial_map<Dim>(), std::nullopt, std::nullopt, mortar_data});
+       make_inertial_map<Dim>(), mortar_data});
 
   CHECK(ActionTesting::get_databox_tag<comp,
                                        evolution::dg::Tags::MortarData<Dim>>(

--- a/tests/Unit/Evolution/DgSubcell/CMakeLists.txt
+++ b/tests/Unit/Evolution/DgSubcell/CMakeLists.txt
@@ -18,6 +18,7 @@ set(LIBRARY_SOURCES
   Test_GetTciDecision.cpp
   Test_GhostData.cpp
   Test_GhostZoneLogicalCoordinates.cpp
+  Test_JacobianCompute.cpp
   Test_Matrices.cpp
   Test_Mesh.cpp
   Test_NeighborRdmpAndVolumeData.cpp
@@ -50,6 +51,7 @@ target_link_libraries(
   ${LIBRARY}
   PRIVATE
   DataStructures
+  DiscontinuousGalerkin
   Domain
   DgSubcell
   DgSubcellHelpers

--- a/tests/Unit/Evolution/DgSubcell/Test_JacobianCompute.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Test_JacobianCompute.cpp
@@ -1,0 +1,104 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <memory>
+#include <optional>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "Domain/Block.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
+#include "Domain/CoordinateMaps/Identity.hpp"
+#include "Domain/CreateInitialElement.hpp"
+#include "Domain/Creators/Tags/FunctionsOfTime.hpp"
+#include "Domain/Structure/Element.hpp"
+#include "Domain/Tags.hpp"
+#include "Domain/TagsTimeDependent.hpp"
+#include "Evolution/DgSubcell/Mesh.hpp"
+#include "Evolution/DgSubcell/Tags/Coordinates.hpp"
+#include "Evolution/DgSubcell/Tags/Jacobians.hpp"
+#include "Evolution/DgSubcell/Tags/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/LogicalCoordinates.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "Time/Tags.hpp"
+#include "Time/Time.hpp"
+#include "Utilities/CloneUniquePtrs.hpp"
+
+namespace grmhd::GhValenciaDivClean {
+namespace {
+
+void test() {
+  const ElementId<3> element_id{
+      0, {SegmentId{3, 4}, SegmentId{3, 4}, SegmentId{3, 7}}};
+
+  Block<3> block{
+      domain::make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
+          domain::CoordinateMaps::Identity<3>{}),
+      0,
+      {}};
+
+  std::unordered_map<std::string,
+                     std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
+      functions_of_time{};
+
+  ElementMap<3, Frame::Grid> element_map{
+      element_id, block.is_time_dependent()
+                      ? block.moving_mesh_logical_to_grid_map().get_clone()
+                      : block.stationary_map().get_to_grid_frame()};
+  const double time = 0.0;
+  const Mesh<3> subcell_mesh{2, Spectral::Basis::FiniteDifference,
+                             Spectral::Quadrature::CellCentered};
+
+  auto box = db::create<
+      db::AddSimpleTags<evolution::dg::subcell::Tags::Mesh<3>,
+                        domain::Tags::ElementMap<3, Frame::Grid>,
+                        domain::CoordinateMaps::Tags::CoordinateMap<
+                            3, Frame::Grid, Frame::Inertial>,
+                        ::Tags::Time, domain::Tags::FunctionsOfTimeInitialize>,
+      db::AddComputeTags<
+          evolution::dg::subcell::Tags::LogicalCoordinatesCompute<3>,
+          ::domain::Tags::MappedCoordinates<
+              ::domain::Tags::ElementMap<3, Frame::Grid>,
+              evolution::dg::subcell::Tags::Coordinates<3,
+                                                        Frame::ElementLogical>,
+              evolution::dg::subcell::Tags::Coordinates>,
+          evolution::dg::subcell::fd::Tags::InverseJacobianLogicalToGridCompute<
+              ::domain::Tags::ElementMap<3, Frame::Grid>, 3>,
+          evolution::dg::subcell::fd::Tags::
+              InverseJacobianLogicalToInertialCompute<
+                  ::domain::CoordinateMaps::Tags::CoordinateMap<
+                      3, Frame::Grid, Frame::Inertial>,
+                  3>>>(
+      subcell_mesh, std::move(element_map),
+      domain::make_coordinate_map_base<Frame::Grid, Frame::Inertial>(
+          domain::CoordinateMaps::Identity<3>{}),
+      time, clone_unique_ptrs(functions_of_time));
+
+  const auto& inv_jac_grid = db::get<
+      evolution::dg::subcell::fd::Tags::InverseJacobianLogicalToGrid<3>>(box);
+  const auto& inv_jac_inertial = db::get<
+      evolution::dg::subcell::fd::Tags::InverseJacobianLogicalToInertial<3>>(
+      box);
+
+  // Check that the two jacobians in frames connected by an identity map are
+  // identical
+  for (size_t storage_index = 0; storage_index < inv_jac_inertial.size();
+       ++storage_index) {
+    CHECK_ITERABLE_APPROX(inv_jac_inertial[storage_index],
+                          inv_jac_grid[storage_index]);
+  }
+}
+
+SPECTRE_TEST_CASE("Unit.Evolution.DgSubcell.JacobianCompute",
+                  "[Unit][Evolution]") {
+  test();
+}
+}  // namespace
+}  // namespace grmhd::GhValenciaDivClean

--- a/tests/Unit/Evolution/DgSubcell/Test_Tags.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Test_Tags.cpp
@@ -79,6 +79,9 @@ void test(const bool moving_mesh) {
   TestHelpers::db::test_simple_tag<
       subcell::fd::Tags::InverseJacobianLogicalToGrid<Dim>>(
       "InverseJacobian(Logical,Grid)");
+  TestHelpers::db::test_simple_tag<
+      subcell::fd::Tags::InverseJacobianLogicalToInertial<Dim>>(
+      "InverseJacobian(Logical,Inertial)");
   TestHelpers::db::test_simple_tag<subcell::Tags::OnSubcellFaces<Var1, Dim>>(
       "OnSubcellFaces(Var1)");
   TestHelpers::db::test_simple_tag<subcell::Tags::OnSubcellFaces<
@@ -107,6 +110,11 @@ void test(const bool moving_mesh) {
                                                     Frame::Inertial>>>(
       "InertialCoordinates");
 
+  TestHelpers::db::test_compute_tag<
+      subcell::fd::Tags::InverseJacobianLogicalToInertialCompute<
+          ::domain::CoordinateMaps::Tags::CoordinateMap<
+              Dim, Frame::ElementLogical, Frame::Inertial>,
+          Dim>>("InverseJacobian(Logical,Inertial)");
   TestHelpers::db::test_compute_tag<
       subcell::Tags::ObserverInverseJacobianCompute<Dim, Frame::ElementLogical,
                                                     Frame::Grid>>(


### PR DESCRIPTION
## Proposed changes

This PR adds terms needed to capture moving meshes in the GhValenciaDivClean system to the TimeDerivative.hpp file of GhValenciaDivClean/Subcell.

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.