### PR TITLE
Enable Logarithmic Distribution in Envelope of BinaryCompactObject

### DIFF
--- a/src/Domain/CoordinateMaps/Distribution.cpp
+++ b/src/Domain/CoordinateMaps/Distribution.cpp
@@ -22,6 +22,8 @@ std::ostream& operator<<(std::ostream& os, const Distribution distribution) {
       return os << "Logarithmic";
     case Distribution::Inverse:
       return os << "Inverse";
+    case Distribution::Projective:
+      return os << "Projective";
     default:
       ERROR("Unknown domain::CoordinateMaps::Distribution type");
   }
@@ -42,7 +44,10 @@ Options::create_from_yaml<domain::CoordinateMaps::Distribution>::create<void>(
     return domain::CoordinateMaps::Distribution::Logarithmic;
   } else if (distribution == "Inverse") {
     return domain::CoordinateMaps::Distribution::Inverse;
+  } else if (distribution == "Projective") {
+    return domain::CoordinateMaps::Distribution::Projective;
   }
   PARSE_ERROR(options.context(),
-              "Distribution must be 'Linear', 'Logarithmic' or 'Inverse'");
-}
+              "Distribution must be 'Linear', 'Equiangular', 'Logarithmic', "
+              "'Inverse', or 'Projective'.");
+  }

--- a/src/Domain/CoordinateMaps/Distribution.hpp
+++ b/src/Domain/CoordinateMaps/Distribution.hpp
@@ -22,7 +22,13 @@ namespace domain::CoordinateMaps {
  *
  * \see domain::CoordinateMaps::Wedge
  */
-enum class Distribution { Linear, Equiangular, Logarithmic, Inverse };
+enum class Distribution {
+  Linear,
+  Equiangular,
+  Logarithmic,
+  Inverse,
+  Projective
+};
 
 std::ostream& operator<<(std::ostream& os, Distribution distribution);
 

--- a/src/Domain/CoordinateMaps/Frustum.hpp
+++ b/src/Domain/CoordinateMaps/Frustum.hpp
@@ -9,6 +9,7 @@
 #include <optional>
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Domain/CoordinateMaps/Distribution.hpp"
 #include "Domain/Structure/OrientationMap.hpp"
 #include "Utilities/TypeTraits/RemoveReferenceWrapper.hpp"
 
@@ -271,11 +272,10 @@ class Frustum {
    * \param orientation_of_frustum The orientation of the frustum in 3D space.
    * \param with_equiangular_map Determines whether to apply a tangent function
    * mapping to the logical coordinates (true) or not (false).
-   * \param projective_scale_factor The scale factor of the projective map
-   * applied to the zeta logical coordinate.
-   * \param auto_projective_scale_factor Determines whether to automatically
-   * calculate the projective scale factor based on the frustum geometry (true)
-   * or use the provided scale factor (false).
+   * \param zeta_distribution Whether to apply a linear, logarithmic, or
+   * projective mapping to the logical zeta coordinate.
+   * \param distribution_value In the case of a projective map, the projective
+   * scale factor, otherwise unused.
    * \param sphericity Value between 0 and 1 which determines whether the
    * surface of the upper base of the Frustum is flat (value of 0), spherical
    * (value of 1), or somewhere in between.
@@ -289,9 +289,10 @@ class Frustum {
           double lower_bound, double upper_bound,
           OrientationMap<3> orientation_of_frustum,
           bool with_equiangular_map = false,
-          double projective_scale_factor = 1.0,
-          bool auto_projective_scale_factor = false, double sphericity = 0.0,
-          double transition_phi = 0.0, double opening_angle = M_PI_2);
+          Distribution zeta_distribution = Distribution::Linear,
+          std::optional<double> distribution_value = std::nullopt,
+          double sphericity = 0.0, double transition_phi = 0.0,
+          double opening_angle = M_PI_2);
   Frustum() = default;
   ~Frustum() = default;
   Frustum(Frustum&&) = default;
@@ -333,7 +334,7 @@ class Frustum {
   OrientationMap<3> orientation_of_frustum_{};
   bool with_equiangular_map_{false};
   bool is_identity_{false};
-  bool with_projective_map_{false};
+  Distribution zeta_distribution_ = Distribution::Linear;
   double sigma_x_{std::numeric_limits<double>::signaling_NaN()};
   double delta_x_zeta_{std::numeric_limits<double>::signaling_NaN()};
   double delta_x_xi_{std::numeric_limits<double>::signaling_NaN()};
@@ -352,6 +353,7 @@ class Frustum {
   double half_opening_angle_{std::numeric_limits<double>::signaling_NaN()};
   double one_over_tan_half_opening_angle_{
       std::numeric_limits<double>::signaling_NaN()};
+  double inner_radius_{std::numeric_limits<double>::signaling_NaN()};
 };
 
 bool operator!=(const Frustum& lhs, const Frustum& rhs);

--- a/src/Domain/Creators/BinaryCompactObject.hpp
+++ b/src/Domain/Creators/BinaryCompactObject.hpp
@@ -356,11 +356,13 @@ class BinaryCompactObject : public DomainCreator<3> {
     static bool suggested_value() { return true; }
   };
 
-  struct UseProjectiveMap {
+  struct RadialDistributionEnvelope {
     using group = Envelope;
-    using type = bool;
+    static std::string name() { return "RadialDistribution"; }
+    using type = CoordinateMaps::Distribution;
     static constexpr Options::String help = {
-        "Use projective scaling on the frustums in the envelope."};
+        "The distribution of radial grid points in the envelope, the layer "
+        "made of ten bulged Frustums."};
   };
 
   struct RadialDistributionOuterShell {
@@ -391,7 +393,8 @@ class BinaryCompactObject : public DomainCreator<3> {
   using time_independent_options = tmpl::append<
       tmpl::list<ObjectA, ObjectB, EnvelopeRadius, OuterRadius,
                  InitialRefinement, InitialGridPoints, UseEquiangularMap,
-                 UseProjectiveMap, RadialDistributionOuterShell, OpeningAngle>,
+                 RadialDistributionEnvelope, RadialDistributionOuterShell,
+                 OpeningAngle>,
       tmpl::conditional_t<
           domain::BoundaryConditions::has_boundary_conditions_base_v<
               typename Metavariables::system>,
@@ -443,7 +446,9 @@ class BinaryCompactObject : public DomainCreator<3> {
       double envelope_radius, double outer_radius,
       const typename InitialRefinement::type& initial_refinement,
       const typename InitialGridPoints::type& initial_number_of_grid_points,
-      bool use_equiangular_map = true, bool use_projective_map = true,
+      bool use_equiangular_map = true,
+      CoordinateMaps::Distribution radial_distribution_envelope =
+          CoordinateMaps::Distribution::Projective,
       CoordinateMaps::Distribution radial_distribution_outer_shell =
           CoordinateMaps::Distribution::Linear,
       double opening_angle_in_degrees = 90.0,
@@ -461,7 +466,9 @@ class BinaryCompactObject : public DomainCreator<3> {
       double envelope_radius, double outer_radius,
       const typename InitialRefinement::type& initial_refinement,
       const typename InitialGridPoints::type& initial_number_of_grid_points,
-      bool use_equiangular_map = true, bool use_projective_map = true,
+      bool use_equiangular_map = true,
+      CoordinateMaps::Distribution radial_distribution_envelope =
+          CoordinateMaps::Distribution::Projective,
       CoordinateMaps::Distribution radial_distribution_outer_shell =
           CoordinateMaps::Distribution::Linear,
       double opening_angle_in_degrees = 90.0,
@@ -512,10 +519,10 @@ class BinaryCompactObject : public DomainCreator<3> {
   std::vector<std::array<size_t, 3>> initial_refinement_{};
   std::vector<std::array<size_t, 3>> initial_number_of_grid_points_{};
   bool use_equiangular_map_ = true;
-  bool use_projective_map_ = true;
+  CoordinateMaps::Distribution radial_distribution_envelope_ =
+      CoordinateMaps::Distribution::Projective;
   CoordinateMaps::Distribution radial_distribution_outer_shell_ =
       CoordinateMaps::Distribution::Linear;
-  double projective_scale_factor_{};
   double translation_{};
   double length_inner_cube_{};
   double length_outer_cube_{};

--- a/src/Domain/Creators/FrustalCloak.cpp
+++ b/src/Domain/Creators/FrustalCloak.cpp
@@ -74,11 +74,11 @@ FrustalCloak::FrustalCloak(
 Domain<3> FrustalCloak::create_domain() const {
   std::vector<std::unique_ptr<
       CoordinateMapBase<Frame::BlockLogical, Frame::Inertial, 3>>>
-      coord_maps = domain::make_vector_coordinate_map_base<Frame::BlockLogical,
-                                                           Frame::Inertial, 3>(
-          frustum_coordinate_maps(length_inner_cube_, length_outer_cube_,
-                                  use_equiangular_map_, origin_preimage_,
-                                  projection_factor_));
+      coord_maps = domain::make_vector_coordinate_map_base<
+          Frame::BlockLogical, Frame::Inertial, 3>(frustum_coordinate_maps(
+          length_inner_cube_, length_outer_cube_, use_equiangular_map_,
+          origin_preimage_, domain::CoordinateMaps::Distribution::Projective,
+          projection_factor_));
   return Domain<3>{std::move(coord_maps),
                    corners_for_biradially_layered_domains(
                        0, 1, false, false, {{1, 2, 3, 4, 5, 6, 7, 8}})};

--- a/src/Domain/DomainHelpers.cpp
+++ b/src/Domain/DomainHelpers.cpp
@@ -688,7 +688,8 @@ std::vector<domain::CoordinateMaps::Frustum> frustum_coordinate_maps(
     const double length_inner_cube, const double length_outer_cube,
     const bool use_equiangular_map,
     const std::array<double, 3>& origin_preimage,
-    const double projective_scale_factor, const double sphericity,
+    const domain::CoordinateMaps::Distribution radial_distribution,
+    const std::optional<double> distribution_value, const double sphericity,
     const double opening_angle) {
   ASSERT(length_inner_cube < 0.5 * length_outer_cube,
          "The outer cube is too small! The inner cubes will pierce the surface "
@@ -730,8 +731,8 @@ std::vector<domain::CoordinateMaps::Frustum> frustum_coordinate_maps(
         top,
         gsl::at(frustum_orientations, i),
         use_equiangular_map,
-        projective_scale_factor,
-        false,
+        radial_distribution,
+        distribution_value,
         sphericity,
         -1.0,
         opening_angle});
@@ -746,8 +747,8 @@ std::vector<domain::CoordinateMaps::Frustum> frustum_coordinate_maps(
                                   top,
                                   gsl::at(frustum_orientations, i),
                                   use_equiangular_map,
-                                  projective_scale_factor,
-                                  false,
+                                  radial_distribution,
+                                  distribution_value,
                                   sphericity,
                                   1.0,
                                   opening_angle});
@@ -765,8 +766,8 @@ std::vector<domain::CoordinateMaps::Frustum> frustum_coordinate_maps(
                                 stretch * top,
                                 frustum_orientations[4],
                                 use_equiangular_map,
-                                projective_scale_factor,
-                                false,
+                                radial_distribution,
+                                distribution_value,
                                 sphericity,
                                 0.0,
                                 M_PI_2});
@@ -783,8 +784,8 @@ std::vector<domain::CoordinateMaps::Frustum> frustum_coordinate_maps(
                                 stretch * top,
                                 frustum_orientations[5],
                                 use_equiangular_map,
-                                projective_scale_factor,
-                                false,
+                                radial_distribution,
+                                distribution_value,
                                 sphericity,
                                 0.0,
                                 M_PI_2});

--- a/src/Domain/DomainHelpers.hpp
+++ b/src/Domain/DomainHelpers.hpp
@@ -181,23 +181,31 @@ std::vector<domain::CoordinateMaps::Wedge<3>> sph_wedge_coordinate_maps(
 /// objects. The Frustums partition the volume defined by two bounding
 /// surfaces: The inner surface is the surface of the two joined inner cubes
 /// enveloping the two compact objects, while the outer is the surface of the
-/// outer cube. The cubes enveloping the two Shells each have a side length of
-/// `length_inner_cube`. The outer cube has a side length of
-/// `length_outer_cube`. `origin_preimage` is a parameter
-/// that moves the center of the two joined inner cubes away from the origin
-/// and to `-origin_preimage`. `projective_scale_factor` acts to change the
-/// gridpoint distribution in the radial direction. \see Frustum for details.
-/// The value for `sphericity` determines whether the outer surface is a cube
+/// outer cube.
+/// \param length_inner_cube The side length of the cubes enveloping the two
+/// shells.
+/// \param length_outer_cube The side length of the outer cube.
+/// \param use_equiangular_map Whether to apply a tangent map in the angular
+/// directions.
+/// \param origin_preimage The center of the two joined inner cubes is moved
+/// away from the origin and to this point, origin_preimage.
+/// \param radial_distribution The gridpoint distribution in the radial
+/// direction, possibly dependent on the value passed to `distribution_value`.
+/// \param distribution_value Used by `radial_distribution`. \see Frustum for
+/// details.
+/// \param sphericity Determines whether the outer surface is a cube
 /// (value of 0), a sphere (value of 1) or somewhere in between.
-/// The value for `opening_angle` determines the gridpoint distribution used
+/// \param opening_angle determines the gridpoint distribution used
 /// in the Frustums such that they conform to the outer sphere of Wedges with
 /// the same value for `opening_angle`.
 std::vector<domain::CoordinateMaps::Frustum> frustum_coordinate_maps(
     double length_inner_cube, double length_outer_cube,
     bool use_equiangular_map,
     const std::array<double, 3>& origin_preimage = {{0.0, 0.0, 0.0}},
-    double projective_scale_factor = 1.0, double sphericity = 0.0,
-    double opening_angle = M_PI_2);
+    domain::CoordinateMaps::Distribution radial_distribution =
+        domain::CoordinateMaps::Distribution::Linear,
+    std::optional<double> distribution_value = std::nullopt,
+    double sphericity = 0.0, double opening_angle = M_PI_2);
 
 /// \ingroup ComputationalDomainGroup
 /// \brief The corners for a domain with radial layers.

--- a/tests/InputFiles/CurvedScalarWave/WorldtubeKerrSchild.yaml
+++ b/tests/InputFiles/CurvedScalarWave/WorldtubeKerrSchild.yaml
@@ -54,7 +54,7 @@ DomainCreator:
         ExciseWithBoundaryCondition: Worldtube
       UseLogarithmicMap: false
     Envelope:
-      UseProjectiveMap: false
+      RadialDistribution: Linear
       Radius: 50.
     OuterShell:
       Radius: 400.

--- a/tests/InputFiles/ExportCoordinates/InputTimeDependent3D.yaml
+++ b/tests/InputFiles/ExportCoordinates/InputTimeDependent3D.yaml
@@ -34,7 +34,7 @@ DomainCreator:
       UseLogarithmicMap: true
     Envelope:
       Radius: 100.0
-      UseProjectiveMap: false
+      RadialDistribution: Linear
     OuterShell:
       Radius: 300.0
       RadialDistribution: Linear

--- a/tests/InputFiles/GeneralizedHarmonic/BinaryBlackHole.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/BinaryBlackHole.yaml
@@ -50,7 +50,7 @@ DomainCreator:
       UseLogarithmicMap: true
     Envelope:
       Radius: 100.0
-      UseProjectiveMap: true
+      RadialDistribution: Projective
     OuterShell:
       Radius: 1493.0
       RadialDistribution: Logarithmic

--- a/tests/InputFiles/Xcts/BinaryBlackHole.yaml
+++ b/tests/InputFiles/Xcts/BinaryBlackHole.yaml
@@ -59,7 +59,7 @@ DomainCreator:
       UseLogarithmicMap: True
     Envelope:
       Radius: &outer_shell_inner_radius 60.
-      UseProjectiveMap: True
+      RadialDistribution: Projective
     OuterShell:
       Radius: &outer_radius 300.
       RadialDistribution: &outer_shell_distribution Inverse

--- a/tests/InputFiles/Xcts/HeadOnBns.yaml
+++ b/tests/InputFiles/Xcts/HeadOnBns.yaml
@@ -49,7 +49,7 @@ DomainCreator:
       UseLogarithmicMap: False
     Envelope:
       Radius: &outer_shell_inner_radius 120.
-      UseProjectiveMap: True
+      RadialDistribution: Projective
     OuterShell:
       Radius: &outer_radius 600.
       RadialDistribution: &outer_shell_distribution Inverse

--- a/tests/Unit/Domain/CoordinateMaps/Test_Distribution.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_Distribution.cpp
@@ -16,6 +16,7 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Distribution", "[Domain][Unit]") {
   CHECK(get_output(Distribution::Equiangular) == "Equiangular");
   CHECK(get_output(Distribution::Logarithmic) == "Logarithmic");
   CHECK(get_output(Distribution::Inverse) == "Inverse");
+  CHECK(get_output(Distribution::Projective) == "Projective");
   CHECK(TestHelpers::test_creation<Distribution>("Linear") ==
         Distribution::Linear);
   CHECK(TestHelpers::test_creation<Distribution>("Equiangular") ==
@@ -24,6 +25,8 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Distribution", "[Domain][Unit]") {
         Distribution::Logarithmic);
   CHECK(TestHelpers::test_creation<Distribution>("Inverse") ==
         Distribution::Inverse);
+  CHECK(TestHelpers::test_creation<Distribution>("Projective") ==
+        Distribution::Projective);
 }
 
 }  // namespace domain::CoordinateMaps

--- a/tests/Unit/Domain/Test_Domain.cpp
+++ b/tests/Unit/Domain/Test_Domain.cpp
@@ -452,7 +452,8 @@ void test_versioning() {
                                                     true},
       100., 300.,
       // Initial refinement and num points don't matter
-      1_st, 3_st, true, false, CoordinateMaps::Distribution::Linear, 90.};
+      1_st, 3_st, true, CoordinateMaps::Distribution::Linear,
+      CoordinateMaps::Distribution::Linear, 90.};
   CHECK(domain == expected_domain_creator.create_domain());
   // Also check that we can deserialize the functions of time.
   const auto serialized_fot = *volfile.get_functions_of_time(obs_id);

--- a/tests/Unit/Domain/Test_DomainHelpers.cpp
+++ b/tests/Unit/Domain/Test_DomainHelpers.cpp
@@ -350,7 +350,8 @@ void test_all_frustum_directions() {
           .inverse_map(),
       origin_preimage);
 
-  const double projective_scale_factor = 0.3;
+  const CoordinateMaps::Distribution radial_distribution =
+      CoordinateMaps::Distribution::Projective;
   const double sphericity = 0.;
   for (const bool use_equiangular_map : {true, false}) {
     const double stretch = tan(0.5 * M_PI_2);
@@ -364,8 +365,8 @@ void test_all_frustum_directions() {
             top,
             OrientationMap<3>{},
             use_equiangular_map,
-            projective_scale_factor,
-            false,
+            radial_distribution,
+            std::nullopt,
             sphericity,
             -1.},
         FrustumMap{
@@ -377,8 +378,8 @@ void test_all_frustum_directions() {
             top,
             OrientationMap<3>{},
             use_equiangular_map,
-            projective_scale_factor,
-            false,
+            radial_distribution,
+            std::nullopt,
             sphericity,
             1.},
         FrustumMap{
@@ -392,8 +393,8 @@ void test_all_frustum_directions() {
                 {Direction<3>::upper_xi(), Direction<3>::lower_eta(),
                  Direction<3>::lower_zeta()}}},
             use_equiangular_map,
-            projective_scale_factor,
-            false,
+            radial_distribution,
+            std::nullopt,
             sphericity,
             -1.},
         FrustumMap{
@@ -407,8 +408,8 @@ void test_all_frustum_directions() {
                 {Direction<3>::upper_xi(), Direction<3>::lower_eta(),
                  Direction<3>::lower_zeta()}}},
             use_equiangular_map,
-            projective_scale_factor,
-            false,
+            radial_distribution,
+            std::nullopt,
             sphericity,
             1.},
         FrustumMap{
@@ -422,8 +423,8 @@ void test_all_frustum_directions() {
                 {Direction<3>::upper_xi(), Direction<3>::upper_zeta(),
                  Direction<3>::lower_eta()}}},
             use_equiangular_map,
-            projective_scale_factor,
-            false,
+            radial_distribution,
+            std::nullopt,
             sphericity,
             -1.},
         FrustumMap{
@@ -437,8 +438,8 @@ void test_all_frustum_directions() {
                 {Direction<3>::upper_xi(), Direction<3>::upper_zeta(),
                  Direction<3>::lower_eta()}}},
             use_equiangular_map,
-            projective_scale_factor,
-            false,
+            radial_distribution,
+            std::nullopt,
             sphericity,
             1.},
         FrustumMap{
@@ -452,8 +453,8 @@ void test_all_frustum_directions() {
                 {Direction<3>::upper_xi(), Direction<3>::lower_zeta(),
                  Direction<3>::upper_eta()}}},
             use_equiangular_map,
-            projective_scale_factor,
-            false,
+            radial_distribution,
+            std::nullopt,
             sphericity,
             -1.},
         FrustumMap{
@@ -467,8 +468,8 @@ void test_all_frustum_directions() {
                 {Direction<3>::upper_xi(), Direction<3>::lower_zeta(),
                  Direction<3>::upper_eta()}}},
             use_equiangular_map,
-            projective_scale_factor,
-            false,
+            radial_distribution,
+            std::nullopt,
             sphericity,
             1.},
         // Frustum on right half in the +x direction
@@ -482,7 +483,7 @@ void test_all_frustum_directions() {
                        {Direction<3>::upper_zeta(), Direction<3>::upper_xi(),
                         Direction<3>::upper_eta()}}},
                    use_equiangular_map,
-                   projective_scale_factor},
+                   radial_distribution},
         // Frustum on left half in the -x direction
         FrustumMap{{{{{-lower - displacement10[0], -lower - displacement10[1]}},
                      {{lower - displacement10[0], lower - displacement10[1]}},
@@ -494,10 +495,11 @@ void test_all_frustum_directions() {
                        {Direction<3>::lower_zeta(), Direction<3>::lower_xi(),
                         Direction<3>::upper_eta()}}},
                    use_equiangular_map,
-                   projective_scale_factor});
+                   radial_distribution});
 
     const auto maps = frustum_coordinate_maps(
-        2.0 * lower, 2.0 * top, use_equiangular_map, origin_preimage, 0.3);
+        2.0 * lower, 2.0 * top, use_equiangular_map, origin_preimage,
+        CoordinateMaps::Distribution::Projective);
     CHECK(maps == expected_coord_maps);
   }
 }

--- a/tests/Unit/Helpers/Evolution/Systems/CurvedScalarWave/Worldtube/TestHelpers.cpp
+++ b/tests/Unit/Helpers/Evolution/Systems/CurvedScalarWave/Worldtube/TestHelpers.cpp
@@ -48,7 +48,7 @@ std::unique_ptr<DomainCreator<3>> worldtube_binary_compact_object(
       "    UseLogarithmicMap: false\n"
       "  Envelope:\n"
       "    Radius: 30.0\n"
-      "    UseProjectiveMap: false\n"
+      "    RadialDistribution: Linear\n"
       "  OuterShell:\n"
       "    Radius: 50.0\n"
       "    RadialDistribution: Linear\n"

--- a/tests/Unit/IO/Importers/Test_VolumeDataReaderAlgorithm3D.yaml
+++ b/tests/Unit/IO/Importers/Test_VolumeDataReaderAlgorithm3D.yaml
@@ -20,7 +20,7 @@ SourceDomainCreator:
       UseLogarithmicMap: True
     Envelope:
       Radius: 60.
-      UseProjectiveMap: True
+      RadialDistribution: Projective
     OuterShell:
       Radius: 350.
       RadialDistribution: Inverse
@@ -45,7 +45,7 @@ TargetDomainCreator:
       UseLogarithmicMap: true
     Envelope:
       Radius: 100.
-      UseProjectiveMap: true
+      RadialDistribution: Projective
     OuterShell:
       Radius: 300.
       RadialDistribution: Linear


### PR DESCRIPTION
## Proposed changes

Addresses issue #3545 by allowing the user to specify a logarithmic distribution of points in the Blocks that use the Frustum map in the BinaryCompactObject Domain. Dependent on #4934 .

Fixes #4695 .

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
In input files that use the `BinaryCompactObject` domain creator, change the `Envelope.UseProjectiveMap` option to `Envelope.RadialDistribution`. Previous values of `True` and `False` correspond to `Projective` and `Linear` now.
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
