### PR TITLE
Add More Pybindings for GR Functions and Tensor Types

### DIFF
--- a/src/DataStructures/Tensor/Python/__init__.py
+++ b/src/DataStructures/Tensor/Python/__init__.py
@@ -21,18 +21,11 @@ def _dtype_to_name(dtype: type):
 
 class TensorMeta:
     def __init__(self, name: str):
-        self.__members__ = {
-            (dtype, dim, frame):
-            globals()[f"Tensor{name}{_dtype_to_name(dtype)}{dim}{frame.name}"]
-            for dtype, dim, frame in itertools.product(
-                [DataVector, float], [1, 2, 3], [
-                    Frame.ElementLogical, Frame.BlockLogical, Frame.Grid,
-                    Frame.Distorted, Frame.Inertial
-                ])
-        }
+        self.name = name
 
     def _getitem(self, dtype: type, dim: int, frame: Frame = Frame.Inertial):
-        return self.__members__[(dtype, dim, frame)]
+        return globals(
+        )[f"Tensor{self.name}{_dtype_to_name(dtype)}{dim}{frame.name}"]
 
     def __getitem__(self, key):
         try:
@@ -43,14 +36,12 @@ class TensorMeta:
 
 class JacobianMeta(TensorMeta):
     def __init__(self, inverse: bool):
-        self.__members__ = {
-            (dtype, dim, frame):
-            globals()[f"Jacobian{_dtype_to_name(dtype)}{dim}" +
-                      (f"{frame.name}ToElementLogical"
-                       if inverse else f"ElementLogicalTo{frame.name}")]
-            for dtype, dim, frame in itertools.product(
-                [DataVector, float], [1, 2, 3], [Frame.Grid, Frame.Inertial])
-        }
+        self.inverse = inverse
+
+    def _getitem(self, dtype: type, dim: int, frame: Frame = Frame.Inertial):
+        return globals()[f"Jacobian{_dtype_to_name(dtype)}{dim}" +
+                         (f"{frame.name}ToElementLogical" if self.
+                          inverse else f"ElementLogicalTo{frame.name}")]
 
 
 # Define Tensor types that aren't in 'tnsr.py'

--- a/src/DataStructures/Tensor/Python/tnsr.py
+++ b/src/DataStructures/Tensor/Python/tnsr.py
@@ -13,6 +13,17 @@ Use this module like this:
 
 from spectre.DataStructures.Tensor import TensorMeta
 
+a = TensorMeta("a")
+A = TensorMeta("A")
+ab = TensorMeta("ab")
+aB = TensorMeta("aB")
+Ab = TensorMeta("Ab")
+aa = TensorMeta("aa")
+AA = TensorMeta("AA")
+abb = TensorMeta("abb")
+Abb = TensorMeta("Abb")
+aBcc = TensorMeta("aBcc")
+
 i = TensorMeta("i")
 I = TensorMeta("I")
 ij = TensorMeta("ij")
@@ -21,3 +32,5 @@ Ij = TensorMeta("Ij")
 ii = TensorMeta("ii")
 II = TensorMeta("II")
 ijj = TensorMeta("ijj")
+Ijj = TensorMeta("Ijj")
+iJkk = TensorMeta("iJkk")

--- a/src/PointwiseFunctions/GeneralRelativity/Python/Bindings.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/Python/Bindings.cpp
@@ -6,16 +6,135 @@
 #include <type_traits>
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Christoffel.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Lapse.hpp"
+#include "PointwiseFunctions/GeneralRelativity/ProjectionOperators.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Psi4Real.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Ricci.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Shift.hpp"
+#include "PointwiseFunctions/GeneralRelativity/SpacetimeNormalOneForm.hpp"
+#include "PointwiseFunctions/GeneralRelativity/SpacetimeNormalVector.hpp"
 
 namespace py = pybind11;
 
-namespace GeneralRelativity {
+namespace GeneralRelativity::py_bindings {
+
+namespace {
+template <size_t Dim, IndexType Index>
+void bind_spacetime_impl(py::module& m) {  // NOLINT
+  m.def("christoffel_first_kind",
+        static_cast<tnsr::abb<DataVector, Dim, Frame::Inertial, Index> (*)(
+            const tnsr::abb<DataVector, Dim, Frame::Inertial, Index>&)>(
+            &::gr::christoffel_first_kind),
+        py::arg("d_metric"));
+
+  m.def("christoffel_second_kind",
+        static_cast<tnsr::Abb<DataVector, Dim, Frame::Inertial, Index> (*)(
+            const tnsr::abb<DataVector, Dim, Frame::Inertial, Index>&,
+            const tnsr::AA<DataVector, Dim, Frame::Inertial, Index>&)>(
+            &::gr::christoffel_second_kind),
+        py::arg("d_metric"), py::arg("inverse_metric"));
+
+  m.def("ricci_scalar",
+        static_cast<Scalar<DataVector> (*)(
+            const tnsr::aa<DataVector, Dim, Frame::Inertial, Index>&,
+            const tnsr::AA<DataVector, Dim, Frame::Inertial, Index>&)>(
+            &::gr::ricci_scalar),
+        py::arg("ricci_tensor"), py::arg("inverse_metric"));
+
+  m.def("ricci_tensor",
+        static_cast<tnsr::aa<DataVector, Dim, Frame::Inertial, Index> (*)(
+            const tnsr::Abb<DataVector, Dim, Frame::Inertial, Index>&,
+            const tnsr::aBcc<DataVector, Dim, Frame::Inertial, Index>&)>(
+            &::gr::ricci_tensor),
+        py::arg("christoffel_2nd_kind"), py::arg("d_christoffel_2nd_kind"));
+}
+
+template <size_t Dim>
+void bind_impl(py::module& m) {  // NOLINT
+  m.def("lapse",
+        static_cast<Scalar<DataVector> (*)(const tnsr::I<DataVector, Dim>&,
+                                           const tnsr::aa<DataVector, Dim>&)>(
+            &::gr::lapse),
+        py::arg("shift"), py::arg("spacetime_metric"));
+
+  m.def("transverse_projection_operator",
+        static_cast<tnsr::II<DataVector, Dim> (*)(
+            const tnsr::II<DataVector, Dim>&, const tnsr::I<DataVector, Dim>&)>(
+            &::gr::transverse_projection_operator),
+        py::arg("inverse_spatial_metric"), py::arg("normal_vector"));
+
+  m.def("transverse_projection_operator",
+        static_cast<tnsr::ii<DataVector, Dim> (*)(
+            const tnsr::ii<DataVector, Dim>&, const tnsr::i<DataVector, Dim>&)>(
+            &::gr::transverse_projection_operator),
+        py::arg("spatial_metric"), py::arg("normal_one_form"));
+
+  m.def("transverse_projection_operator",
+        static_cast<tnsr::Ij<DataVector, Dim> (*)(
+            const tnsr::I<DataVector, Dim>&, const tnsr::i<DataVector, Dim>&)>(
+            &::gr::transverse_projection_operator),
+        py::arg("normal_vector"), py::arg("normal_one_form"));
+
+  m.def("transverse_projection_operator",
+        static_cast<tnsr::aa<DataVector, Dim> (*)(
+            const tnsr::aa<DataVector, Dim>&, const tnsr::a<DataVector, Dim>&,
+            const tnsr::i<DataVector, Dim>&)>(
+            &::gr::transverse_projection_operator),
+        py::arg("spacetime_metric"), py::arg("spacetime_normal_one_form"),
+        py::arg("interface_unit_normal_one_form"));
+
+  m.def("transverse_projection_operator",
+        static_cast<tnsr::AA<DataVector, Dim> (*)(
+            const tnsr::AA<DataVector, Dim>&, const tnsr::A<DataVector, Dim>&,
+            const tnsr::I<DataVector, Dim>&)>(
+            &::gr::transverse_projection_operator),
+        py::arg("inverse_spacetime_metric"), py::arg("spacetime_normal_vector"),
+        py::arg("interface_unit_normal_vector"));
+
+  m.def("transverse_projection_operator",
+        static_cast<tnsr::Ab<DataVector, Dim> (*)(
+            const tnsr::A<DataVector, Dim>&, const tnsr::a<DataVector, Dim>&,
+            const tnsr::I<DataVector, Dim>&, const tnsr::i<DataVector, Dim>&)>(
+            &::gr::transverse_projection_operator),
+        py::arg("spacetime_normal_vector"),
+        py::arg("spacetime_normal_one_form"),
+        py::arg("interface_unit_normal_vector"),
+        py::arg("interface_unit_normal_one_form"));
+
+  m.def(
+      "shift",
+      static_cast<tnsr::I<DataVector, Dim> (*)(
+          const tnsr::aa<DataVector, Dim>&, const tnsr::II<DataVector, Dim>&)>(
+          &::gr::shift),
+      py::arg("spacetime_metric"), py::arg("inverse_spatial_metric"));
+
+  m.def("spacetime_normal_one_form",
+        static_cast<tnsr::a<DataVector, 3> (*)(const Scalar<DataVector>&)>(
+            &::gr::spacetime_normal_one_form),
+        py::arg("lapse"));
+
+  m.def("spacetime_normal_vector",
+        static_cast<tnsr::A<DataVector, 3> (*)(const Scalar<DataVector>&,
+                                               const tnsr::I<DataVector, 3>&)>(
+            &::gr::spacetime_normal_vector),
+        py::arg("lapse"), py::arg("shift"));
+}
+}  // namespace
 
 PYBIND11_MODULE(_PyGeneralRelativity, m) {  // NOLINT
   py::module_::import("spectre.DataStructures");
   py::module_::import("spectre.DataStructures.Tensor");
   py::module_::import("spectre.Spectral");
+  py_bindings::bind_spacetime_impl<1, IndexType::Spatial>(m);
+  py_bindings::bind_spacetime_impl<2, IndexType::Spatial>(m);
+  py_bindings::bind_spacetime_impl<3, IndexType::Spatial>(m);
+  py_bindings::bind_spacetime_impl<1, IndexType::Spacetime>(m);
+  py_bindings::bind_spacetime_impl<2, IndexType::Spacetime>(m);
+  py_bindings::bind_spacetime_impl<3, IndexType::Spacetime>(m);
+  py_bindings::bind_impl<1>(m);
+  py_bindings::bind_impl<2>(m);
+  py_bindings::bind_impl<3>(m);
   m.def("psi4real",
         static_cast<Scalar<DataVector> (*)(
             const tnsr::ii<DataVector, 3>&, const tnsr::ii<DataVector, 3>&,
@@ -26,4 +145,4 @@ PYBIND11_MODULE(_PyGeneralRelativity, m) {  // NOLINT
         py::arg("cov_deriv_extrinsic_curvature"), py::arg("spatial_metric"),
         py::arg("inverse_spatial_metric"), py::arg("inertial_coords"));
 }
-}  // namespace GeneralRelativity
+}  // namespace GeneralRelativity::py_bindings

--- a/tests/Unit/DataStructures/Tensor/Python/Test_Tensor.py
+++ b/tests/Unit/DataStructures/Tensor/Python/Test_Tensor.py
@@ -15,10 +15,16 @@ from spectre.PointwiseFunctions.Punctures import adm_mass_integrand
 class TestTensor(unittest.TestCase):
     def test_tensor(self):
         coords = tnsr.I[DataVector, 3, Frame.Inertial](num_points=4, fill=0.)
+        spacetime_coords = tnsr.A[DataVector, 3, Frame.Inertial](num_points=1,
+                                                                 fill=0.)
         self.assertEqual(coords.rank, 1)
         self.assertEqual(coords.size, 3)
         self.assertEqual(coords.dim, 3)
         self.assertEqual(len(coords), 3)
+        self.assertEqual(spacetime_coords.rank, coords.rank)
+        self.assertEqual(spacetime_coords.size, coords.size + 1)
+        self.assertEqual(spacetime_coords.dim, coords.dim + 1)
+        self.assertEqual(len(spacetime_coords), len(coords) + 1)
         npt.assert_equal(coords[0], np.zeros(4))
         npt.assert_equal(coords[1], np.zeros(4))
         npt.assert_equal(coords[2], np.zeros(4))

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Python/Test_Bindings.py
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Python/Test_Bindings.py
@@ -1,16 +1,59 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-from spectre.PointwiseFunctions.GeneralRelativity import psi4real
+from spectre.PointwiseFunctions.GeneralRelativity import *
 from spectre.DataStructures import DataVector
-from spectre.DataStructures.Tensor import tnsr, Frame
+from spectre.DataStructures.Tensor import tnsr
 
 import numpy as np
 import numpy.testing as npt
 import unittest
 
 
-class TestPsi4(unittest.TestCase):
+class TestBindings(unittest.TestCase):
+    def test_lapse_shift_normals(self):
+        spacetime_metric = tnsr.aa[DataVector, 3](num_points=1, fill=1.)
+        inverse_spatial_metric = tnsr.II[DataVector, 3](num_points=1, fill=1.)
+        shift_ = shift(spacetime_metric, inverse_spatial_metric)
+        lapse_ = lapse(shift_, spacetime_metric)
+        spacetime_normal_one_form(lapse_)
+        spacetime_normal_vector(lapse_, shift_)
+
+    def test_projections(self):
+        inverse_spatial_metric = tnsr.II[DataVector, 3](num_points=1, fill=1.)
+        normal_vector = tnsr.I[DataVector, 3](num_points=1, fill=1.)
+        # tnsr.II
+        transverse_projection_operator(inverse_spatial_metric, normal_vector)
+        spatial_metric = tnsr.ii[DataVector, 3](num_points=1, fill=1.)
+        normal_one_form = tnsr.i[DataVector, 3](num_points=1, fill=1.)
+        # tnsr.ii
+        transverse_projection_operator(spatial_metric, normal_one_form)
+        # tnsr.Ij
+        transverse_projection_operator(normal_vector, normal_one_form)
+        spacetime_metric = tnsr.aa[DataVector, 3](num_points=1, fill=1.)
+        spacetime_normal_one_form = tnsr.a[DataVector, 3](num_points=1,
+                                                          fill=1.)
+        interface_unit_normal_one_form = tnsr.i[DataVector, 3](num_points=1,
+                                                               fill=1.)
+        # tnsr.aa
+        transverse_projection_operator(spacetime_metric,
+                                       spacetime_normal_one_form,
+                                       interface_unit_normal_one_form)
+        inverse_spacetime_metric = tnsr.AA[DataVector, 3](num_points=1,
+                                                          fill=1.)
+        spacetime_normal_vector = tnsr.A[DataVector, 3](num_points=1, fill=1.)
+        interface_unit_normal_vector = tnsr.I[DataVector, 3](num_points=1,
+                                                             fill=1.)
+        # tnsr.AA
+        transverse_projection_operator(inverse_spacetime_metric,
+                                       spacetime_normal_vector,
+                                       interface_unit_normal_vector)
+        # tnsr.Ab
+        transverse_projection_operator(spacetime_normal_vector,
+                                       spacetime_normal_one_form,
+                                       interface_unit_normal_vector,
+                                       interface_unit_normal_one_form)
+
     def test_psi4(self):
         spatial_ricci = tnsr.ii[DataVector, 3](num_points=1, fill=0.)
         extrinsic_curvature = tnsr.ii[DataVector, 3](num_points=1, fill=0.)
@@ -26,6 +69,16 @@ class TestPsi4(unittest.TestCase):
                               cov_deriv_extrinsic_curvature, flat_metric,
                               inverse_metric, inertial_coords)
         npt.assert_allclose(psi_4_real, 0)
+
+    def test_ricci(self):
+        christoffel_second_kind = tnsr.Abb[DataVector, 3](num_points=1,
+                                                          fill=0.)
+        d_christoffel_second_kind = tnsr.aBcc[DataVector, 3](num_points=1,
+                                                             fill=0.)
+        spatial_ricci = ricci_tensor(christoffel_second_kind,
+                                     d_christoffel_second_kind)
+        inverse_metric = tnsr.AA[DataVector, 3](num_points=1, fill=0.)
+        ricci_scalar(spatial_ricci, inverse_metric)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Proposed changes

The first commit of this PR adds Spacetime tensor support in Python and the second commit adds more python bindings for GR functions. 

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
