### PR TITLE
Change interface for evolution::dg::subcell::slice_data

### DIFF
--- a/src/Evolution/DgSubcell/Actions/ReconstructionCommunication.hpp
+++ b/src/Evolution/DgSubcell/Actions/ReconstructionCommunication.hpp
@@ -12,6 +12,7 @@
 #include <map>
 #include <optional>
 #include <tuple>
+#include <unordered_set>
 #include <utility>
 
 #include "DataStructures/DataBox/DataBox.hpp"
@@ -134,14 +135,6 @@ struct SendDataForReconstruction {
     const Element<Dim>& element = db::get<::domain::Tags::Element<Dim>>(box);
     const size_t ghost_zone_size =
         Metavariables::SubcellOptions::ghost_zone_size(box);
-    DirectionMap<Dim, bool> directions_to_slice{};
-    for (const auto& direction_neighbors : element.neighbors()) {
-      if (direction_neighbors.second.size() == 0) {
-        directions_to_slice[direction_neighbors.first] = false;
-      } else {
-        directions_to_slice[direction_neighbors.first] = true;
-      }
-    }
 
     // Optimization note: could save a copy+allocation if we moved
     // all_sliced_data when possible before sending.
@@ -167,7 +160,7 @@ struct SendDataForReconstruction {
     }
     const DirectionMap<Dim, DataVector> all_sliced_data =
         slice_data(volume_data_to_slice, subcell_mesh.extents(),
-                   ghost_zone_size, directions_to_slice, 0);
+                   ghost_zone_size, element.internal_boundaries(), 0);
 
     auto& receiver_proxy =
         Parallel::get_parallel_component<ParallelComponent>(cache);

--- a/src/Evolution/DgSubcell/SliceData.cpp
+++ b/src/Evolution/DgSubcell/SliceData.cpp
@@ -5,6 +5,7 @@
 
 #include <array>
 #include <cstddef>
+#include <unordered_set>
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Index.hpp"
@@ -82,7 +83,7 @@ template <size_t Dim>
 DirectionMap<Dim, DataVector> slice_data_impl(
     const gsl::span<const double>& volume_subcell_vars,
     const Index<Dim>& subcell_extents, const size_t number_of_ghost_points,
-    const DirectionMap<Dim, bool>& directions_to_slice,
+    const std::unordered_set<Direction<Dim>>& directions_to_slice,
     const size_t additional_buffer) {
   const size_t num_pts = subcell_extents.product();
   const size_t number_of_components = volume_subcell_vars.size() / num_pts;
@@ -101,12 +102,11 @@ DirectionMap<Dim, DataVector> slice_data_impl(
     gsl::at(result_grid_points, d) = num_sliced_pts;
   }
   DirectionMap<Dim, DataVector> result{};
-  for (const auto& [dir, should_slice] : directions_to_slice) {
-    if (should_slice) {
-      result[dir] = DataVector{gsl::at(result_grid_points, dir.dimension()) *
-                                   number_of_components +
-                               additional_buffer};
-    }
+  for (const auto& direction : directions_to_slice) {
+    result[direction] =
+        DataVector{gsl::at(result_grid_points, direction.dimension()) *
+                       number_of_components +
+                   additional_buffer};
   }
 
   for (size_t component_index = 0; component_index < number_of_components;
@@ -139,11 +139,11 @@ DirectionMap<Dim, DataVector> slice_data_impl(
 
 template DirectionMap<1, DataVector> slice_data_impl(
     const gsl::span<const double>&, const Index<1>&, const size_t,
-    const DirectionMap<1, bool>&, size_t);
+    const std::unordered_set<Direction<1>>&, size_t);
 template DirectionMap<2, DataVector> slice_data_impl(
     const gsl::span<const double>&, const Index<2>&, const size_t,
-    const DirectionMap<2, bool>&, size_t);
+    const std::unordered_set<Direction<2>>&, size_t);
 template DirectionMap<3, DataVector> slice_data_impl(
     const gsl::span<const double>&, const Index<3>&, const size_t,
-    const DirectionMap<3, bool>&, size_t);
+    const std::unordered_set<Direction<3>>&, size_t);
 }  // namespace evolution::dg::subcell::detail

--- a/src/Evolution/DgSubcell/SliceData.hpp
+++ b/src/Evolution/DgSubcell/SliceData.hpp
@@ -4,12 +4,15 @@
 #pragma once
 
 #include <cstddef>
+#include <unordered_set>
 
+#include "DataStructures/DataVector.hpp"
 #include "DataStructures/Variables.hpp"
 #include "Utilities/Gsl.hpp"
 
 /// \cond
-class DataVector;
+template <size_t Dim>
+class Direction;
 template <size_t Dim, typename T>
 class DirectionMap;
 template <size_t Dim>
@@ -22,7 +25,7 @@ template <size_t Dim>
 DirectionMap<Dim, DataVector> slice_data_impl(
     const gsl::span<const double>& volume_subcell_vars,
     const Index<Dim>& subcell_extents, size_t number_of_ghost_points,
-    const DirectionMap<Dim, bool>& directions_to_slice,
+    const std::unordered_set<Direction<Dim>>& directions_to_slice,
     size_t additional_buffer);
 }  // namespace detail
 
@@ -51,7 +54,7 @@ template <size_t Dim>
 DirectionMap<Dim, DataVector> slice_data(
     const DataVector& volume_subcell_vars, const Index<Dim>& subcell_extents,
     const size_t number_of_ghost_points,
-    const DirectionMap<Dim, bool>& directions_to_slice,
+    const std::unordered_set<Direction<Dim>>& directions_to_slice,
     const size_t additional_buffer) {
   return detail::slice_data_impl(
       gsl::make_span(volume_subcell_vars.data(), volume_subcell_vars.size()),
@@ -63,7 +66,7 @@ template <size_t Dim, typename TagList>
 DirectionMap<Dim, DataVector> slice_data(
     const Variables<TagList>& volume_subcell_vars,
     const Index<Dim>& subcell_extents, const size_t number_of_ghost_points,
-    const DirectionMap<Dim, bool>& directions_to_slice,
+    const std::unordered_set<Direction<Dim>>& directions_to_slice,
     const size_t additional_buffer) {
   // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
   const DataVector view{const_cast<double*>(volume_subcell_vars.data()),

--- a/src/Evolution/DgSubcell/SliceTensor.hpp
+++ b/src/Evolution/DgSubcell/SliceTensor.hpp
@@ -5,6 +5,7 @@
 
 #include <algorithm>
 #include <cstddef>
+#include <unordered_set>
 
 #include "DataStructures/Index.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
@@ -23,8 +24,7 @@ void slice_tensor_for_subcell(
     const Tensor<VectorType, Symmetry<>, index_list<>>& volume_scalar,
     const Index<Dim>& subcell_extents, size_t number_of_ghost_points,
     const Direction<Dim>& direction) {
-  DirectionMap<Dim, bool> directions_to_slice{};
-  directions_to_slice[direction] = true;
+  std::unordered_set directions_to_slice{direction};
 
   auto& scalar_dv = get(volume_scalar);
   auto sliced_data = evolution::dg::subcell::detail::slice_data_impl(
@@ -49,8 +49,7 @@ void slice_tensor_for_subcell(
     const Tensor<VectorType, Structure...>& volume_tensor,
     const Index<Dim>& subcell_extents, size_t number_of_ghost_points,
     const Direction<Dim>& direction) {
-  DirectionMap<Dim, bool> directions_to_slice{};
-  directions_to_slice[direction] = true;
+  std::unordered_set directions_to_slice{direction};
 
   for (size_t i = 0; i < volume_tensor.size(); i++) {
     auto& ti = volume_tensor[i];

--- a/src/Evolution/DgSubcell/SliceVariable.hpp
+++ b/src/Evolution/DgSubcell/SliceVariable.hpp
@@ -5,6 +5,7 @@
 
 #include <algorithm>
 #include <cstddef>
+#include <unordered_set>
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Index.hpp"
@@ -36,8 +37,7 @@ void slice_variable(
 
   // Slice volume variables. Note that the return type of the
   // `slice_data_impl()` function is DataVector.
-  DirectionMap<Dim, bool> directions_to_slice{};
-  directions_to_slice[direction] = true;
+  std::unordered_set directions_to_slice{direction};
 
   const DataVector sliced_data{detail::slice_data_impl(
       gsl::make_span(volume_subcell_vars.data(), volume_subcell_vars.size()),

--- a/src/Evolution/Systems/Burgers/BoundaryConditions/DemandOutgoingCharSpeeds.cpp
+++ b/src/Evolution/Systems/Burgers/BoundaryConditions/DemandOutgoingCharSpeeds.cpp
@@ -11,7 +11,6 @@
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Variables.hpp"
 #include "Domain/Structure/DirectionMap.hpp"
-#include "Evolution/DgSubcell/SliceData.hpp"
 #include "Evolution/Systems/Burgers/Fluxes.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"

--- a/src/Evolution/Systems/Burgers/BoundaryConditions/DirichletAnalytic.hpp
+++ b/src/Evolution/Systems/Burgers/BoundaryConditions/DirichletAnalytic.hpp
@@ -24,8 +24,6 @@
 #include "Domain/Tags.hpp"
 #include "Evolution/BoundaryConditions/Type.hpp"
 #include "Evolution/DgSubcell/GhostZoneLogicalCoordinates.hpp"
-#include "Evolution/DgSubcell/SliceData.hpp"
-#include "Evolution/DgSubcell/SliceTensor.hpp"
 #include "Evolution/DgSubcell/Tags/Coordinates.hpp"
 #include "Evolution/DgSubcell/Tags/Mesh.hpp"
 #include "Evolution/Systems/Burgers/BoundaryConditions/BoundaryCondition.hpp"

--- a/tests/Unit/Evolution/DgSubcell/Actions/Test_ReconstructionCommunication.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Actions/Test_ReconstructionCommunication.cpp
@@ -8,6 +8,7 @@
 #include <deque>
 #include <iterator>
 #include <memory>
+#include <unordered_set>
 #include <utility>
 
 #include "DataStructures/DataBox/DataBox.hpp"
@@ -29,6 +30,7 @@
 #include "Evolution/DgSubcell/Mesh.hpp"
 #include "Evolution/DgSubcell/RdmpTciData.hpp"
 #include "Evolution/DgSubcell/Reconstruction.hpp"
+#include "Evolution/DgSubcell/SliceData.hpp"
 #include "Evolution/DgSubcell/SubcellOptions.hpp"
 #include "Evolution/DgSubcell/Tags/ActiveGrid.hpp"
 #include "Evolution/DgSubcell/Tags/CellCenteredFlux.hpp"
@@ -318,14 +320,7 @@ void test(const bool use_cell_centered_flux) {
   CHECK(rdmp_tci_data.min_variables_values[0] ==
         min(get(get<Var1>(evolved_vars))));
   // Check data sent to neighbors
-  DirectionMap<Dim, bool> directions_to_slice{};
-  for (const auto& direction_neighbors : element.neighbors()) {
-    if (direction_neighbors.second.size() == 0) {
-      directions_to_slice[direction_neighbors.first] = false;
-    } else {
-      directions_to_slice[direction_neighbors.first] = true;
-    }
-  }
+  const auto& directions_to_slice = element.internal_boundaries();
   const size_t ghost_zone_size = 2;
   const size_t rdmp_size = rdmp_tci_data.max_variables_values.size() +
                            rdmp_tci_data.min_variables_values.size();

--- a/tests/Unit/Evolution/DgSubcell/Test_PrepareNeighborData.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Test_PrepareNeighborData.cpp
@@ -5,6 +5,7 @@
 
 #include <cstddef>
 #include <iterator>
+#include <unordered_set>
 #include <utility>
 
 #include "DataStructures/DataBox/DataBox.hpp"
@@ -26,6 +27,7 @@
 #include "Evolution/DgSubcell/PrepareNeighborData.hpp"
 #include "Evolution/DgSubcell/Projection.hpp"
 #include "Evolution/DgSubcell/RdmpTciData.hpp"
+#include "Evolution/DgSubcell/SliceData.hpp"
 #include "Evolution/DgSubcell/SubcellOptions.hpp"
 #include "Evolution/DgSubcell/Tags/DataForRdmpTci.hpp"
 #include "Evolution/DgSubcell/Tags/Mesh.hpp"
@@ -258,10 +260,7 @@ void test(const bool all_neighbors_are_doing_dg,
     }
   } else {
     // Set all directions to false, enable the desired ones below
-    DirectionMap<Dim, bool> directions_to_slice{};
-    for (const auto& direction : Direction<Dim>::all_directions()) {
-      directions_to_slice[direction] = false;
-    }
+    std::unordered_set<Direction<Dim>> directions_to_slice{};
 
     REQUIRE(data_for_neighbors.size() == Dim);
     const size_t num_ghost_points =
@@ -270,7 +269,7 @@ void test(const bool all_neighbors_are_doing_dg,
       REQUIRE(data_for_neighbors.contains(direction));
       REQUIRE(data_for_neighbors.at(direction).size() ==
               num_ghost_points * (need_fluxes ? (Dim + 1) : 1) + 2);
-      directions_to_slice[direction] = true;
+      directions_to_slice.emplace(direction);
     }
 
     // do same operation as GhostDataToSlice

--- a/tests/Unit/Evolution/Systems/Burgers/FiniteDifference/Test_BoundaryConditionGhostData.cpp
+++ b/tests/Unit/Evolution/Systems/Burgers/FiniteDifference/Test_BoundaryConditionGhostData.cpp
@@ -38,7 +38,6 @@
 #include "Domain/TagsTimeDependent.hpp"
 #include "Evolution/DgSubcell/GhostZoneLogicalCoordinates.hpp"
 #include "Evolution/DgSubcell/Mesh.hpp"
-#include "Evolution/DgSubcell/SliceData.hpp"
 #include "Evolution/DgSubcell/Tags/Coordinates.hpp"
 #include "Evolution/DgSubcell/Tags/GhostDataForReconstruction.hpp"
 #include "Evolution/DgSubcell/Tags/Mesh.hpp"

--- a/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/Test_Filters.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/Test_Filters.cpp
@@ -4,6 +4,7 @@
 #include "Framework/TestingFramework.hpp"
 
 #include <cstddef>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -85,11 +86,9 @@ void set_solution(
                      make_not_null(&neighbor_vars));
     set_polynomial(&neighbor_dvs, neighbor_logical_coords, degree);
 
-    DirectionMap<3, bool> directions_to_slice{};
-    directions_to_slice[direction.opposite()] = true;
     const auto sliced_data = evolution::dg::subcell::detail::slice_data_impl(
         gsl::make_span(neighbor_vars), mesh.extents(), deriv_order / 2 + 1,
-        directions_to_slice, 0);
+        std::unordered_set{direction.opposite()}, 0);
     CAPTURE(deriv_order / 2 + 1);
     REQUIRE(sliced_data.size() == 1);
     REQUIRE(sliced_data.contains(direction.opposite()));

--- a/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/Test_NeighborPackagedData.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/Test_NeighborPackagedData.cpp
@@ -7,6 +7,7 @@
 #include <cstddef>
 #include <memory>
 #include <optional>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -153,14 +154,12 @@ double test(const size_t num_dg_pts) {
     }
 
     // Slice data so we can add it to the element's neighbor data
-    DirectionMap<3, bool> directions_to_slice{};
-    directions_to_slice[direction.opposite()] = true;
     DataVector neighbor_data_in_direction =
         evolution::dg::subcell::slice_data(
             prims_to_reconstruct, subcell_mesh.extents(),
             grmhd::ValenciaDivClean::fd::MonotonisedCentralPrim{}
                 .ghost_zone_size(),
-            directions_to_slice, 0)
+            std::unordered_set{direction.opposite()}, 0)
             .at(direction.opposite());
 
     const auto key =

--- a/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/Test_TimeDerivative.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/Test_TimeDerivative.cpp
@@ -7,6 +7,7 @@
 #include <cstddef>
 #include <memory>
 #include <optional>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -204,14 +205,12 @@ double test(const size_t num_dg_pts) {
     }
 
     // Slice data so we can add it to the element's neighbor data
-    DirectionMap<3, bool> directions_to_slice{};
-    directions_to_slice[direction.opposite()] = true;
     DataVector neighbor_data_in_direction =
         evolution::dg::subcell::slice_data(
             prims_to_reconstruct, subcell_mesh.extents(),
             grmhd::ValenciaDivClean::fd::MonotonisedCentralPrim{}
                 .ghost_zone_size(),
-            directions_to_slice, 0)
+            std::unordered_set{direction.opposite()}, 0)
             .at(direction.opposite());
     const auto key =
         std::pair{direction, *element.neighbors().at(direction).begin()};

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_NeighborPackagedData.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_NeighborPackagedData.cpp
@@ -6,6 +6,7 @@
 #include <array>
 #include <cstddef>
 #include <memory>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -164,14 +165,12 @@ double test(const size_t num_dg_pts) {
     }
 
     // Slice data so we can add it to the element's neighbor data
-    DirectionMap<3, bool> directions_to_slice{};
-    directions_to_slice[direction.opposite()] = true;
     DataVector neighbor_data_in_direction =
         evolution::dg::subcell::slice_data(
             prims_to_reconstruct, subcell_mesh.extents(),
             grmhd::ValenciaDivClean::fd::MonotonisedCentralPrim{}
                 .ghost_zone_size(),
-            directions_to_slice, 0)
+            std::unordered_set{direction.opposite()}, 0)
             .at(direction.opposite());
     const auto key =
         std::pair{direction, *element.neighbors().at(direction).begin()};

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_TimeDerivative.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_TimeDerivative.cpp
@@ -9,6 +9,7 @@
 #include <iterator>
 #include <memory>
 #include <optional>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -303,12 +304,11 @@ std::array<double, 5> test(const size_t num_dg_pts,
           get(get<hydro::Tags::LorentzFactor<DataVector>>(neighbor_prims));
     }
     // Slice data so we can add it to the element's neighbor data
-    DirectionMap<3, bool> directions_to_slice{};
-    directions_to_slice[direction.opposite()] = true;
     DataVector neighbor_data_in_direction =
         evolution::dg::subcell::slice_data(
             volume_neighbor_data, subcell_mesh.extents(),
-            recons.ghost_zone_size(), directions_to_slice, 0)
+            recons.ghost_zone_size(), std::unordered_set{direction.opposite()},
+            0)
             .at(direction.opposite());
     const auto key =
         std::pair{direction, *element.neighbors().at(direction).begin()};

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/Subcell/Test_NeighborPackagedData.cpp
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/Subcell/Test_NeighborPackagedData.cpp
@@ -6,6 +6,7 @@
 #include <array>
 #include <cstddef>
 #include <memory>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -186,13 +187,11 @@ double test(const size_t num_dg_pts) {
           get<tag>(prims_to_reconstruct) = get<tag>(neighbor_prims);
         });
     // Slice data so we can add it to the element's neighbor data
-    DirectionMap<Dim, bool> directions_to_slice{};
-    directions_to_slice[direction.opposite()] = true;
     DataVector neighbor_data_in_direction =
         evolution::dg::subcell::slice_data(
             prims_to_reconstruct, subcell_mesh.extents(),
             NewtonianEuler::fd::MonotonisedCentralPrim<Dim>{}.ghost_zone_size(),
-            directions_to_slice, 0)
+            std::unordered_set{direction.opposite()}, 0)
             .at(direction.opposite());
     const auto key =
         std::pair{direction, *element.neighbors().at(direction).begin()};

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/Subcell/Test_TimeDerivative.cpp
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/Subcell/Test_TimeDerivative.cpp
@@ -6,6 +6,7 @@
 #include <array>
 #include <cstddef>
 #include <memory>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -200,13 +201,11 @@ std::array<double, 3> test(const size_t num_dg_pts) {
         });
 
     // Slice data so we can add it to the element's neighbor data
-    DirectionMap<dim, bool> directions_to_slice{};
-    directions_to_slice[direction.opposite()] = true;
     DataVector neighbor_data_in_direction =
         evolution::dg::subcell::slice_data(
             prims_to_reconstruct, subcell_mesh.extents(),
             NewtonianEuler::fd::MonotonisedCentralPrim<dim>{}.ghost_zone_size(),
-            directions_to_slice, 0)
+            std::unordered_set{direction.opposite()}, 0)
             .at(direction.opposite());
     const auto key =
         std::pair{direction, *element.neighbors().at(direction).begin()};

--- a/tests/Unit/Helpers/Evolution/Systems/Burgers/FiniteDifference/TestHelpers.hpp
+++ b/tests/Unit/Helpers/Evolution/Systems/Burgers/FiniteDifference/TestHelpers.hpp
@@ -6,6 +6,7 @@
 #include <array>
 #include <boost/functional/hash.hpp>
 #include <cstddef>
+#include <unordered_set>
 #include <utility>
 
 #include "DataStructures/DataBox/Prefixes.hpp"
@@ -63,12 +64,11 @@ compute_ghost_data(
     const auto neighbor_vars_for_reconstruction =
         compute_variables_of_neighbor_data(neighbor_logical_coords);
 
-    DirectionMap<1, bool> directions_to_slice{};
-    directions_to_slice[direction.opposite()] = true;
     const auto sliced_data = evolution::dg::subcell::detail::slice_data_impl(
         gsl::make_span(neighbor_vars_for_reconstruction.data(),
                        neighbor_vars_for_reconstruction.size()),
-        subcell_mesh.extents(), ghost_zone_size, directions_to_slice, 0);
+        subcell_mesh.extents(), ghost_zone_size,
+        std::unordered_set{direction.opposite()}, 0);
     REQUIRE(sliced_data.size() == 1);
     REQUIRE(sliced_data.contains(direction.opposite()));
     ghost_data[std::pair{direction, neighbor_id}] =

--- a/tests/Unit/Helpers/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/PrimReconstructor.hpp
+++ b/tests/Unit/Helpers/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/PrimReconstructor.hpp
@@ -7,6 +7,7 @@
 
 #include <array>
 #include <cstddef>
+#include <unordered_set>
 #include <utility>
 
 #include "DataStructures/DataBox/PrefixHelpers.hpp"
@@ -70,12 +71,11 @@ compute_ghost_data(
     const auto neighbor_vars_for_reconstruction =
         compute_variables_of_neighbor_data(neighbor_logical_coords);
 
-    DirectionMap<3, bool> directions_to_slice{};
-    directions_to_slice[direction.opposite()] = true;
     const auto sliced_data = evolution::dg::subcell::detail::slice_data_impl(
         gsl::make_span(neighbor_vars_for_reconstruction.data(),
                        neighbor_vars_for_reconstruction.size()),
-        subcell_mesh.extents(), ghost_zone_size, directions_to_slice, 0);
+        subcell_mesh.extents(), ghost_zone_size,
+        std::unordered_set{direction.opposite()}, 0);
     REQUIRE(sliced_data.size() == 1);
     REQUIRE(sliced_data.contains(direction.opposite()));
     ghost_data[std::pair{direction, neighbor_id}] = GhostData{1};

--- a/tests/Unit/Helpers/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/PrimReconstructor.hpp
+++ b/tests/Unit/Helpers/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/PrimReconstructor.hpp
@@ -7,6 +7,7 @@
 
 #include <array>
 #include <cstddef>
+#include <unordered_set>
 #include <utility>
 
 #include "DataStructures/DataBox/PrefixHelpers.hpp"
@@ -67,12 +68,11 @@ compute_ghost_data(
     const auto neighbor_vars_for_reconstruction =
         compute_variables_of_neighbor_data(neighbor_logical_coords);
 
-    DirectionMap<3, bool> directions_to_slice{};
-    directions_to_slice[direction.opposite()] = true;
     const auto sliced_data = evolution::dg::subcell::detail::slice_data_impl(
         gsl::make_span(neighbor_vars_for_reconstruction.data(),
                        neighbor_vars_for_reconstruction.size()),
-        subcell_mesh.extents(), ghost_zone_size, directions_to_slice, 0);
+        subcell_mesh.extents(), ghost_zone_size,
+        std::unordered_set{direction.opposite()}, 0);
     REQUIRE(sliced_data.size() == 1);
     REQUIRE(sliced_data.contains(direction.opposite()));
     ghost_data[std::pair{direction, neighbor_id}] = GhostData{1};

--- a/tests/Unit/Helpers/Evolution/Systems/NewtonianEuler/FiniteDifference/PrimReconstructor.hpp
+++ b/tests/Unit/Helpers/Evolution/Systems/NewtonianEuler/FiniteDifference/PrimReconstructor.hpp
@@ -6,6 +6,7 @@
 #include "Framework/TestingFramework.hpp"
 
 #include <cstddef>
+#include <unordered_set>
 #include <utility>
 
 #include "DataStructures/DataBox/PrefixHelpers.hpp"
@@ -61,12 +62,11 @@ compute_ghost_data(const Mesh<Dim>& subcell_mesh,
     const auto neighbor_vars_for_reconstruction =
         compute_variables_of_neighbor_data(neighbor_logical_coords);
 
-    DirectionMap<Dim, bool> directions_to_slice{};
-    directions_to_slice[direction.opposite()] = true;
     const auto sliced_data = evolution::dg::subcell::detail::slice_data_impl(
         gsl::make_span(neighbor_vars_for_reconstruction.data(),
                        neighbor_vars_for_reconstruction.size()),
-        subcell_mesh.extents(), ghost_zone_size, directions_to_slice, 0);
+        subcell_mesh.extents(), ghost_zone_size,
+        std::unordered_set{direction.opposite()}, 0);
     REQUIRE(sliced_data.size() == 1);
     REQUIRE(sliced_data.contains(direction.opposite()));
     ghost_data[std::pair{direction, neighbor_id}] = GhostData{1};

--- a/tests/Unit/Helpers/Evolution/Systems/ScalarAdvection/FiniteDifference/TestHelpers.hpp
+++ b/tests/Unit/Helpers/Evolution/Systems/ScalarAdvection/FiniteDifference/TestHelpers.hpp
@@ -6,6 +6,7 @@
 #include <array>
 #include <boost/functional/hash.hpp>
 #include <cstddef>
+#include <unordered_set>
 #include <utility>
 
 #include "DataStructures/DataBox/Prefixes.hpp"
@@ -63,12 +64,11 @@ compute_ghost_data(const Mesh<Dim>& subcell_mesh,
     const auto neighbor_vars_for_reconstruction =
         compute_variables_of_neighbor_data(neighbor_logical_coords);
 
-    DirectionMap<Dim, bool> directions_to_slice{};
-    directions_to_slice[direction.opposite()] = true;
     const auto sliced_data = evolution::dg::subcell::detail::slice_data_impl(
         gsl::make_span(neighbor_vars_for_reconstruction.data(),
                        neighbor_vars_for_reconstruction.size()),
-        subcell_mesh.extents(), ghost_zone_size, directions_to_slice, 0);
+        subcell_mesh.extents(), ghost_zone_size,
+        std::unordered_set{direction.opposite()}, 0);
     REQUIRE(sliced_data.size() == 1);
     REQUIRE(sliced_data.contains(direction.opposite()));
     ghost_data[std::pair{direction, neighbor_id}] = GhostData{1};

--- a/tests/Unit/Helpers/NumericalAlgorithms/FiniteDifference/Exact.hpp
+++ b/tests/Unit/Helpers/NumericalAlgorithms/FiniteDifference/Exact.hpp
@@ -7,6 +7,7 @@
 
 #include <array>
 #include <cstddef>
+#include <unordered_set>
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/SliceIterator.hpp"
@@ -96,11 +97,10 @@ void test_reconstruction_is_exact_if_in_basis(
         mesh.number_of_grid_points());
     set_polynomial(&neighbor_var1, &neighbor_var2, neighbor_logical_coords);
 
-    DirectionMap<Dim, bool> directions_to_slice{};
-    directions_to_slice[direction.opposite()] = true;
     const auto sliced_data = evolution::dg::subcell::detail::slice_data_impl(
         gsl::make_span(neighbor_vars.data(), neighbor_vars.size()),
-        mesh.extents(), (stencil_width - 1) / 2 + 1, directions_to_slice, 0);
+        mesh.extents(), (stencil_width - 1) / 2 + 1,
+        std::unordered_set{direction.opposite()}, 0);
     REQUIRE(sliced_data.size() == 1);
     REQUIRE(sliced_data.contains(direction.opposite()));
     neighbor_data[direction] = sliced_data.at(direction.opposite());

--- a/tests/Unit/NumericalAlgorithms/FiniteDifference/Test_Filter.cpp
+++ b/tests/Unit/NumericalAlgorithms/FiniteDifference/Test_Filter.cpp
@@ -6,6 +6,7 @@
 #include <array>
 #include <cstddef>
 #include <iterator>
+#include <unordered_set>
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tags/TempTensor.hpp"
@@ -68,11 +69,10 @@ void set_solution(
     set_polynomial(&neighbor_var1, &neighbor_var2, neighbor_logical_coords,
                    degree);
 
-    DirectionMap<Dim, bool> directions_to_slice{};
-    directions_to_slice[direction.opposite()] = true;
     const auto sliced_data = evolution::dg::subcell::detail::slice_data_impl(
         gsl::make_span(neighbor_vars.data(), neighbor_vars.size()),
-        mesh.extents(), deriv_order / 2 + 1, directions_to_slice, 0);
+        mesh.extents(), deriv_order / 2 + 1,
+        std::unordered_set{direction.opposite()}, 0);
     CAPTURE(deriv_order / 2 + 1);
     REQUIRE(sliced_data.size() == 1);
     REQUIRE(sliced_data.contains(direction.opposite()));

--- a/tests/Unit/NumericalAlgorithms/FiniteDifference/Test_HighOrderFluxCorrection.cpp
+++ b/tests/Unit/NumericalAlgorithms/FiniteDifference/Test_HighOrderFluxCorrection.cpp
@@ -6,6 +6,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <random>
+#include <unordered_set>
 
 #include "DataStructures/DataBox/PrefixHelpers.hpp"
 #include "DataStructures/DataBox/Prefixes.hpp"
@@ -166,11 +167,9 @@ void test(const fd::DerivativeOrder correction_order) {
     FluxVars neighbor_vars(mesh.number_of_grid_points(), 0.0);
     set_polynomial(&neighbor_vars, neighbor_logical_coords);
 
-    DirectionMap<Dim, bool> directions_to_slice{};
-    directions_to_slice[direction.opposite()] = true;
     const auto sliced_data = evolution::dg::subcell::slice_data(
         neighbor_vars, mesh.extents(), number_of_ghost_points,
-        directions_to_slice, 0);
+        std::unordered_set{direction.opposite()}, 0);
     CAPTURE(number_of_ghost_points);
     REQUIRE(sliced_data.size() == 1);
     REQUIRE(sliced_data.contains(direction.opposite()));

--- a/tests/Unit/NumericalAlgorithms/FiniteDifference/Test_PartialDerivatives.cpp
+++ b/tests/Unit/NumericalAlgorithms/FiniteDifference/Test_PartialDerivatives.cpp
@@ -5,6 +5,7 @@
 
 #include <array>
 #include <cstddef>
+#include <unordered_set>
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tags/TempTensor.hpp"
@@ -112,11 +113,10 @@ void test(const gsl::not_null<std::mt19937*> generator,
         mesh.number_of_grid_points());
     set_polynomial(&neighbor_var1, &neighbor_var2, neighbor_logical_coords);
 
-    DirectionMap<Dim, bool> directions_to_slice{};
-    directions_to_slice[direction.opposite()] = true;
     const auto sliced_data = evolution::dg::subcell::detail::slice_data_impl(
         gsl::make_span(neighbor_vars.data(), neighbor_vars.size()),
-        mesh.extents(), (stencil_width - 1) / 2 + 1, directions_to_slice, 0);
+        mesh.extents(), (stencil_width - 1) / 2 + 1,
+        std::unordered_set{direction.opposite()}, 0);
     CAPTURE((stencil_width - 1) / 2 + 1);
     REQUIRE(sliced_data.size() == 1);
     REQUIRE(sliced_data.contains(direction.opposite()));


### PR DESCRIPTION
It is easier to use a std::unordered_set<Direction<Dim>> instead of a DirectionMap<Dim, bool> to specify directions_to_slice. In the current use cases, the set is given by element.internal_boundaries().

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
