### PR TITLE
Add CLI endpoint to validate input files

### DIFF
--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -700,8 +700,7 @@ ${{ env.CACHE_KEY_SUFFIX }}"
       # to create the cache.
       SPECTRE_SPACK_DEPS: >-
         blaze boost brigand catch2 charmpp gsl hdf5 libsharp libxsmm openblas
-        py-h5py py-humanize py-numpy py-matplotlib py-pandas py-pybind11
-        py-scipy py-pyyaml yaml-cpp
+        py-pybind11 yaml-cpp
       CCACHE_DIR: $HOME/ccache
       CCACHE_MAXSIZE: 700M
       CCACHE_COMPRESS: 1
@@ -758,10 +757,17 @@ ${{ env.CACHE_KEY_SUFFIX }}"
           source $HOME/spack/share/spack/setup-env.sh
           spack env create spectre support/DevEnvironments/spack.yaml
           spack env activate spectre
-          spack remove doxygen jemalloc py-nbconvert
+          spack remove doxygen jemalloc
           spack concretize --reuse
           spack install --no-check-signature
           spack find -v
+      # Install remaining pure Python dependencies with pip because the Spack
+      # package index can be incomplete (it can't mirror all of pip)
+      - name: Install Python dependencies
+        run: |
+          source $HOME/spack/share/spack/setup-env.sh
+          spack env activate spectre
+          pip install -r support/Python/requirements.txt
       # Replace the ccache directory that building the dependencies may have
       # generated with the cached ccache directory.
       - name: Clear ccache from dependencies

--- a/src/Visualization/Python/InterpolateToCoords.py
+++ b/src/Visualization/Python/InterpolateToCoords.py
@@ -238,26 +238,12 @@ def interpolate_to_coords_command(h5_files, subfile_name, list_vars, vars,
 
     # Interpolate!
     import rich.progress
-    try:
-        progress_cols = (
-            rich.progress.TextColumn(
-                "[progress.description]{task.description}"),
-            rich.progress.BarColumn(),
-            # Added in rich v12.0
-            rich.progress.MofNCompleteColumn(),
-            rich.progress.TimeRemainingColumn(),
-        )
-    except AttributeError:
-        progress_cols = (
-            rich.progress.TextColumn(
-                "[progress.description]{task.description}"),
-            rich.progress.BarColumn(),
-            rich.progress.TextColumn(
-                "[progress.percentage]{task.percentage:>3.0f}%"),
-            rich.progress.TimeRemainingColumn(),
-        )
-    progress = rich.progress.Progress(*progress_cols,
-                                      disable=(len(volfiles) == 1))
+    progress = rich.progress.Progress(
+        rich.progress.TextColumn("[progress.description]{task.description}"),
+        rich.progress.BarColumn(),
+        rich.progress.MofNCompleteColumn(),
+        rich.progress.TimeRemainingColumn(),
+        disable=(len(volfiles) == 1))
     task_id = progress.add_task("Interpolating files")
     volfiles_progress = progress.track(volfiles, task_id=task_id)
     with progress:

--- a/src/Visualization/Python/PlotPowerMonitors.py
+++ b/src/Visualization/Python/PlotPowerMonitors.py
@@ -420,26 +420,12 @@ def plot_power_monitors_command(h5_files, subfile_name, step, time,
 
     # Plot!
     import rich.progress
-    try:
-        progress_cols = (
-            rich.progress.TextColumn(
-                "[progress.description]{task.description}"),
-            rich.progress.BarColumn(),
-            # Added in rich v12.0
-            rich.progress.MofNCompleteColumn(),
-            rich.progress.TimeRemainingColumn(),
-        )
-    except AttributeError:
-        progress_cols = (
-            rich.progress.TextColumn(
-                "[progress.description]{task.description}"),
-            rich.progress.BarColumn(),
-            rich.progress.TextColumn(
-                "[progress.percentage]{task.percentage:>3.0f}%"),
-            rich.progress.TimeRemainingColumn(),
-        )
-    progress = rich.progress.Progress(*progress_cols,
-                                      disable=(len(volfiles) == 1))
+    progress = rich.progress.Progress(
+        rich.progress.TextColumn("[progress.description]{task.description}"),
+        rich.progress.BarColumn(),
+        rich.progress.MofNCompleteColumn(),
+        rich.progress.TimeRemainingColumn(),
+        disable=(len(volfiles) == 1))
     task_id = progress.add_task("Processing files")
     volfiles_progress = progress.track(volfiles, task_id=task_id)
     with progress:

--- a/src/Visualization/Python/TransformVolumeData.py
+++ b/src/Visualization/Python/TransformVolumeData.py
@@ -689,26 +689,12 @@ def transform_volume_data_command(h5files, subfile_name, kernels, exec_files,
 
     # Apply!
     import rich.progress
-    try:
-        progress_cols = (
-            rich.progress.TextColumn(
-                "[progress.description]{task.description}"),
-            rich.progress.BarColumn(),
-            # Added in rich v12.0
-            rich.progress.MofNCompleteColumn(),
-            rich.progress.TimeRemainingColumn(),
-        )
-    except AttributeError:
-        progress_cols = (
-            rich.progress.TextColumn(
-                "[progress.description]{task.description}"),
-            rich.progress.BarColumn(),
-            rich.progress.TextColumn(
-                "[progress.percentage]{task.percentage:>3.0f}%"),
-            rich.progress.TimeRemainingColumn(),
-        )
-    progress = rich.progress.Progress(*progress_cols,
-                                      disable=(len(volfiles) == 1))
+    progress = rich.progress.Progress(
+        rich.progress.TextColumn("[progress.description]{task.description}"),
+        rich.progress.BarColumn(),
+        rich.progress.MofNCompleteColumn(),
+        rich.progress.TimeRemainingColumn(),
+        disable=(len(volfiles) == 1))
     task_id = progress.add_task("Applying to files")
     volfiles_progress = progress.track(volfiles, task_id=task_id)
     with progress:

--- a/support/DevEnvironments/spack.yaml
+++ b/support/DevEnvironments/spack.yaml
@@ -59,17 +59,7 @@ spack:
   - 'libxsmm@1.16.1:'
   - openblas
   - 'python@3.7:'
-  - py-click
-  - py-h5py -mpi
-  - py-humanize
-  - py-nbconvert
-  - py-numpy
-  - py-matplotlib
-  - py-pandas
   - 'py-pybind11@2.6:'
-  - py-pyyaml
-  - py-rich
-  - py-scipy
   - yaml-cpp@0.6.3
   concretizer:
     unify: true

--- a/support/Python/__main__.py
+++ b/support/Python/__main__.py
@@ -33,6 +33,7 @@ class Cli(click.MultiCommand):
             "simplify-traces",
             "status",
             "transform-volume-data",
+            "validate",
         ]
 
     def get_command(self, ctx, name):
@@ -82,6 +83,10 @@ class Cli(click.MultiCommand):
             from spectre.Visualization.TransformVolumeData import (
                 transform_volume_data_command)
             return transform_volume_data_command
+        elif name == "validate":
+            from spectre.tools.ValidateInputFile import (
+                validate_input_file_command)
+            return validate_input_file_command
 
         available_commands = " " + "\n ".join(self.list_commands(ctx))
         raise click.UsageError(

--- a/support/Python/requirements.txt
+++ b/support/Python/requirements.txt
@@ -28,5 +28,5 @@ matplotlib
 pandas ~= 1.5
 pyyaml
 # Rich: to format CLI output and tracebacks
-rich >= 10.11.0
+rich >= 12.0.0
 scipy

--- a/tests/tools/CMakeLists.txt
+++ b/tests/tools/CMakeLists.txt
@@ -18,3 +18,18 @@ spectre_add_python_bindings_test(
   Test_Status.py
   "Python"
   None)
+
+spectre_add_python_bindings_test(
+  "tools.ValidateInputFile"
+  Test_ValidateInputFile.py
+  "Python"
+  None)
+
+if(${BUILD_PYTHON_BINDINGS})
+  # Test is a bit slow because it runs an executable
+  set_tests_properties(
+    "tools.ValidateInputFile"
+    PROPERTIES
+    TIMEOUT 10
+    )
+endif()

--- a/tests/tools/Test_ValidateInputFile.py
+++ b/tests/tools/Test_ValidateInputFile.py
@@ -1,0 +1,60 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import shutil
+import unittest
+from pathlib import Path
+
+import yaml
+from click.testing import CliRunner
+from spectre.Informer import unit_test_build_path, unit_test_src_path
+
+from spectre.tools.ValidateInputFile import (InvalidInputFileError,
+                                             validate_input_file,
+                                             validate_input_file_command)
+
+
+class TestValidateInputFile(unittest.TestCase):
+    def setUp(self):
+        self.test_dir = Path(unit_test_build_path(), "tools/ValidateInputFile")
+        self.test_dir.mkdir(parents=True, exist_ok=True)
+        self.executable = Path(unit_test_build_path(),
+                               "../../bin/SolvePoisson1D")
+        self.valid_input_file_path = Path(
+            unit_test_src_path(),
+            "../InputFiles/Poisson/ProductOfSinusoids1D.yaml")
+        self.invalid_input_file_path = (self.test_dir /
+                                        "InvalidInputFile.yaml")
+        with open(self.valid_input_file_path, "r") as open_input_file:
+            metadata, input_file = yaml.safe_load_all(open_input_file)
+        del input_file["DomainCreator"]["Interval"]["LowerBound"]
+        with open(self.invalid_input_file_path, "w") as open_input_file:
+            yaml.safe_dump_all([metadata, input_file], open_input_file)
+
+    def tearDown(self):
+        shutil.rmtree(self.test_dir, ignore_errors=True)
+
+    def test_validate_input_file(self):
+        validate_input_file(self.valid_input_file_path,
+                            executable=self.executable)
+        with self.assertRaisesRegex(InvalidInputFileError, "LowerBound"):
+            validate_input_file(self.invalid_input_file_path,
+                                executable=self.executable)
+
+    def test_cli(self):
+        runner = CliRunner()
+        result = runner.invoke(
+            validate_input_file_command,
+            [str(self.valid_input_file_path), "-e",
+             str(self.executable)])
+        self.assertEqual(result.exit_code, 0)
+        result = runner.invoke(
+            validate_input_file_command,
+            [str(self.invalid_input_file_path), "-e",
+             str(self.executable)])
+        self.assertEqual(result.exit_code, 1)
+        self.assertIn("LowerBound", result.output)
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -6,6 +6,7 @@ spectre_python_add_module(
   PYTHON_FILES
   CharmSimplifyTraces.py
   CleanOutput.py
+  ValidateInputFile.py
 )
 
 add_subdirectory(Status)

--- a/tools/ValidateInputFile.py
+++ b/tools/ValidateInputFile.py
@@ -1,0 +1,151 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import logging
+import re
+import subprocess
+from pathlib import Path
+from typing import Optional, Sequence, Union
+
+import click
+import rich
+import rich.syntax
+import yaml
+
+logger = logging.getLogger(__name__)
+
+
+class InvalidInputFileError(Exception):
+    """Indicates that the input file cannot be parsed by the executable
+
+    The exception prints the 'message' by default. To print additional context,
+    catch the exception and print the 'render_context()' as well.
+
+    Attributes:
+      input_file_path: Path to the input file on disk.
+      line_number: Line number in the input file where the parse error occurred.
+      yaml_path: Sequence of YAML keys in the input file that lead to the
+        parse error, such as '["DomainCreator", "Interval", "LowerBound"]'.
+      message: Error message emitted by the option parsing.
+    """
+    def __init__(self, input_file_path: Union[str, Path],
+                 line_number: Optional[int], yaml_path: Sequence[str],
+                 message: Optional[str]):
+        self.input_file_path = Path(input_file_path)
+        self.line_number = line_number
+        self.yaml_path = yaml_path
+        self.message = message
+        super().__init__(message)
+
+    @rich.console.group()
+    def render_context(self) -> rich.console.RenderResult:
+        if self.line_number is not None:
+            yield f"{self.input_file_path.resolve()}:{self.line_number}"
+            yield rich.syntax.Syntax(self.input_file_path.read_text(),
+                                     theme="ansi_dark",
+                                     lexer="yaml",
+                                     line_range=(self.line_number - 2,
+                                                 self.line_number + 2),
+                                     highlight_lines={self.line_number},
+                                     line_numbers=True)
+            yield ""
+        if self.yaml_path:
+            yield "In [bold]" + ".".join(self.yaml_path) + ":"
+            yield ""
+
+
+def validate_input_file(input_file_path: Union[str, Path],
+                        executable: Optional[Union[str, Path]] = None,
+                        print_context: bool = True,
+                        raise_exception: bool = True):
+    """Check an input file for parse errors
+
+    Invokes the executable with the '--check-options' flag to check for parse
+    errors.
+
+    Arguments:
+      input_file_path: Path to the input file on disk.
+      executable: Name or path of the executable. If unspecified, use the
+        'Executable:' in the input file metadata.
+      print_context: Print additional context where the parse error occurred
+        before raising an exception (default: True).
+      raise_exception: Raise an 'InvalidInputFileError' if a parse error
+        occurred (default: True).
+    """
+    input_file_path = Path(input_file_path)
+
+    # Resolve the executable
+    if not executable:
+        with open(input_file_path, "r") as open_input_file:
+            executable = next(
+                yaml.safe_load_all(open_input_file))["Executable"]
+
+    # Use the executable to validate the input file
+    process = subprocess.run(
+        [executable, "--input-file", input_file_path, "--check-options"],
+        capture_output=True,
+        text=True)
+
+    if process.returncode == 0:
+        return
+
+    # Parse the validation error
+    logger.debug(process.stderr)
+    found_hints = False
+    path = []
+    line_number = None
+    col = None
+    msg = []
+    for line in process.stderr.split("\n"):
+        if str(input_file_path) in line:
+            found_hints = True
+            continue
+        if found_hints:
+            if line.startswith("In group"):
+                path.append(line[9:-1])
+            elif line.startswith("While parsing option"):
+                path.append(line[21:-1])
+            elif line.startswith("While creating a"):
+                path.append(line[17:-1])
+            elif line.startswith("At line"):
+                match = re.match(r"At line ([0-9]+) column ([0-9]+)", line)
+                line_number, _ = map(int, match.groups())
+            elif line.startswith("While operating factory for"):
+                # remove "unique_ptr" entry from path
+                path.pop()
+            elif "ERROR" in line:
+                break
+            else:
+                msg.append(line)
+
+    # Print context and raise exception
+    error = InvalidInputFileError(input_file_path=input_file_path,
+                                  line_number=line_number,
+                                  yaml_path=path,
+                                  message="\n".join(msg).strip())
+    if print_context:
+        rich.print(error.render_context())
+    if raise_exception:
+        _rich_traceback_guard = True
+        raise error
+
+
+@click.command()
+@click.argument('input_file_path',
+                type=click.Path(exists=True,
+                                file_okay=True,
+                                dir_okay=False,
+                                readable=True,
+                                path_type=Path))
+@click.option('--executable',
+              '-e',
+              help=("Name or path of the executable. "
+                    "If unspecified, the 'Executable:' in the input file "
+                    "metadata is used."))
+def validate_input_file_command(**kwargs):
+    """Check an input file for parse errors"""
+    validate_input_file(**kwargs)
+
+
+if __name__ == "__main__":
+    validate_input_file_command(help_option_names=["-h", "--help"])


### PR DESCRIPTION
## Proposed changes

Try it like this:

```
spectre validate INPUT_FILE
```

In particular, this will be used in #4996 to validate input files before scheduling runs.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
