### PR TITLE
Add size control diagnostics

### DIFF
--- a/src/ControlSystem/ControlErrors/Size/AhSpeed.cpp
+++ b/src/ControlSystem/ControlErrors/Size/AhSpeed.cpp
@@ -116,12 +116,11 @@ void AhSpeed::update(const gsl::not_null<Info*> info,
   // the same as they were.
 }
 
-double AhSpeed::control_signal(
-    const Info& info,
-    const ControlSignalArgs& control_signal_args) const {
+double AhSpeed::control_error(
+    const Info& info, const ControlErrorArgs& control_error_args) const {
   const double Y00 = sqrt(0.25 / M_PI);
-  return (info.target_char_speed - control_signal_args.min_char_speed) /
-         (Y00 * control_signal_args.avg_distorted_normal_dot_unit_coord_vector);
+  return (info.target_char_speed - control_error_args.min_char_speed) /
+         (Y00 * control_error_args.avg_distorted_normal_dot_unit_coord_vector);
 }
 
 PUP::able::PUP_ID AhSpeed::my_PUP_ID = 0;

--- a/src/ControlSystem/ControlErrors/Size/AhSpeed.hpp
+++ b/src/ControlSystem/ControlErrors/Size/AhSpeed.hpp
@@ -20,9 +20,9 @@ class AhSpeed : public State {
               const StateUpdateArgs& update_args,
               const CrossingTimeInfo& crossing_time_info) const override;
   /// The return value is Q from Eq. 92 of \cite Hemberger2012jz.
-  double control_signal(
+  double control_error(
       const Info& info,
-      const ControlSignalArgs& control_signal_args) const override;
+      const ControlErrorArgs& control_error_args) const override;
 
   WRAPPED_PUPable_decl_template(AhSpeed); // NOLINT
   explicit AhSpeed(CkMigrateMessage* const /*msg*/) {}

--- a/src/ControlSystem/ControlErrors/Size/CMakeLists.txt
+++ b/src/ControlSystem/ControlErrors/Size/CMakeLists.txt
@@ -11,9 +11,9 @@ spectre_target_sources(
   Info.cpp
   AhSpeed.cpp
   DeltaR.cpp
+  Error.cpp
   Initial.cpp
   RegisterDerivedWithCharm.cpp
-  Signal.cpp
   )
 
 spectre_target_headers(
@@ -24,9 +24,9 @@ spectre_target_headers(
   State.hpp
   AhSpeed.hpp
   DeltaR.hpp
+  Error.hpp
   Initial.hpp
   RegisterDerivedWithCharm.hpp
-  Signal.hpp
   )
 
 target_link_libraries(

--- a/src/ControlSystem/ControlErrors/Size/DeltaR.cpp
+++ b/src/ControlSystem/ControlErrors/Size/DeltaR.cpp
@@ -17,14 +17,14 @@ void DeltaR::update(const gsl::not_null<Info*> info,
                     const StateUpdateArgs& update_args,
                     const CrossingTimeInfo& crossing_time_info) const {
   // If update_args.control_error_delta_r is larger than
-  // delta_r_control_signal_threshold (and neither char speed nor
+  // delta_r_control_error_threshold (and neither char speed nor
   // delta radius is in danger), then the timescale is decreased to
   // keep the control error small. This behavior is similar to what
   // TimecaleTuners do, but is triggered only in some situations. The
   // value of 1e-3 was chosen by trial and error in SpEC but it might
   // be helpful to decrease this value in the future if size control
   // needs to be very tight.
-  constexpr double delta_r_control_signal_threshold = 1.e-3;
+  constexpr double delta_r_control_error_threshold = 1.e-3;
 
   // Note that delta_radius_is_in_danger and char_speed_is_in_danger
   // can be different for different States.
@@ -68,7 +68,7 @@ void DeltaR::update(const gsl::not_null<Info*> info,
     info->suggested_time_scale = crossing_time_info.t_delta_radius;
   } else if (update_args.min_comoving_char_speed > 0.0 and
              std::abs(update_args.control_error_delta_r) >
-                 delta_r_control_signal_threshold) {
+                 delta_r_control_error_threshold) {
     // delta_r_state_decrease_factor should be slightly less than unity.
     // The value of 0.99 below was chosen arbitrarily in SpEC and never
     // needed to be changed.
@@ -80,10 +80,9 @@ void DeltaR::update(const gsl::not_null<Info*> info,
   // state DeltaRDriftOutward will go.
 }
 
-double DeltaR::control_signal(
-    const Info& /*info*/,
-    const ControlSignalArgs& control_signal_args) const {
-  return control_signal_args.control_error_delta_r;
+double DeltaR::control_error(const Info& /*info*/,
+                             const ControlErrorArgs& control_error_args) const {
+  return control_error_args.control_error_delta_r;
 }
 
 PUP::able::PUP_ID DeltaR::my_PUP_ID = 0;

--- a/src/ControlSystem/ControlErrors/Size/DeltaR.hpp
+++ b/src/ControlSystem/ControlErrors/Size/DeltaR.hpp
@@ -20,9 +20,9 @@ class DeltaR : public State {
               const StateUpdateArgs& update_args,
               const CrossingTimeInfo& crossing_time_info) const override;
   /// The return value is Q from Eq. 96 of \cite Hemberger2012jz.
-  double control_signal(
+  double control_error(
       const Info& info,
-      const ControlSignalArgs& control_signal_args) const override;
+      const ControlErrorArgs& control_error_args) const override;
 
   WRAPPED_PUPable_decl_template(DeltaR); // NOLINT
   explicit DeltaR(CkMigrateMessage* const /*msg*/) {}

--- a/src/ControlSystem/ControlErrors/Size/Error.cpp
+++ b/src/ControlSystem/ControlErrors/Size/Error.cpp
@@ -1,7 +1,7 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
-#include "ControlSystem/ControlErrors/Size/Signal.hpp"
+#include "ControlSystem/ControlErrors/Size/Error.hpp"
 
 #include <algorithm>
 #include <cstddef>
@@ -27,7 +27,7 @@
 namespace control_system::size {
 
 template <typename Frame>
-double control_signal(
+double control_error(
     const gsl::not_null<Info*> info,
     const gsl::not_null<intrp::ZeroCrossingPredictor*> predictor_char_speed,
     const gsl::not_null<intrp::ZeroCrossingPredictor*>
@@ -221,18 +221,18 @@ double control_signal(
                        comoving_char_speed_crossing_time,
                        delta_radius_crossing_time});
 
-  // Return the control signal.
-  return info->state->control_signal(
-      *info, ControlSignalArgs{min_char_speed, control_error_delta_r,
-                               avg_distorted_normal_dot_unit_coord_vector,
-                               dt_lambda_00});
+  // Return the control error.
+  return info->state->control_error(
+      *info, ControlErrorArgs{min_char_speed, control_error_delta_r,
+                              avg_distorted_normal_dot_unit_coord_vector,
+                              dt_lambda_00});
 }
 }  // namespace control_system::size
 
 #define FRAME(data) BOOST_PP_TUPLE_ELEM(0, data)
 
 #define INSTANTIATE(_, data)                                                   \
-  template double control_system::size::control_signal(                        \
+  template double control_system::size::control_error(                         \
       const gsl::not_null<control_system::size::Info*> info,                   \
       const gsl::not_null<intrp::ZeroCrossingPredictor*> predictor_char_speed, \
       const gsl::not_null<intrp::ZeroCrossingPredictor*>                       \

--- a/src/ControlSystem/ControlErrors/Size/Error.cpp
+++ b/src/ControlSystem/ControlErrors/Size/Error.cpp
@@ -27,7 +27,7 @@
 namespace control_system::size {
 
 template <typename Frame>
-double control_error(
+ErrorDiagnostics control_error(
     const gsl::not_null<Info*> info,
     const gsl::not_null<intrp::ZeroCrossingPredictor*> predictor_char_speed,
     const gsl::not_null<intrp::ZeroCrossingPredictor*>
@@ -221,18 +221,35 @@ double control_error(
                        comoving_char_speed_crossing_time,
                        delta_radius_crossing_time});
 
-  // Return the control error.
-  return info->state->control_error(
+  const double control_error = info->state->control_error(
       *info, ControlErrorArgs{min_char_speed, control_error_delta_r,
                               avg_distorted_normal_dot_unit_coord_vector,
                               dt_lambda_00});
+
+  return ErrorDiagnostics{control_error,
+                          info->state->number(),
+                          lambda_00,
+                          dt_lambda_00,
+                          horizon_00,
+                          dt_horizon_00,
+                          control_error_delta_r,
+                          min_char_speed,
+                          min_comoving_char_speed,
+                          char_speed_crossing_time,
+                          comoving_char_speed_crossing_time,
+                          delta_radius_crossing_time,
+                          info->target_char_speed,
+                          info->suggested_time_scale,
+                          info->damping_time,
+                          info->discontinuous_change_has_occurred};
 }
 }  // namespace control_system::size
 
 #define FRAME(data) BOOST_PP_TUPLE_ELEM(0, data)
 
 #define INSTANTIATE(_, data)                                                   \
-  template double control_system::size::control_error(                         \
+  template control_system::size::ErrorDiagnostics                              \
+  control_system::size::control_error(                                         \
       const gsl::not_null<control_system::size::Info*> info,                   \
       const gsl::not_null<intrp::ZeroCrossingPredictor*> predictor_char_speed, \
       const gsl::not_null<intrp::ZeroCrossingPredictor*>                       \

--- a/src/ControlSystem/ControlErrors/Size/Error.hpp
+++ b/src/ControlSystem/ControlErrors/Size/Error.hpp
@@ -24,6 +24,28 @@ class ZeroCrossingPredictor;
 /// \endcond
 
 namespace control_system::size {
+/*!
+ * \brief A simple struct to hold diagnostic information about computing the
+ * size control error.
+ */
+struct ErrorDiagnostics {
+  double control_error;
+  size_t state_number;
+  double lambda_00;
+  double dt_lambda_00;
+  double horizon_00;
+  double dt_horizon_00;
+  double control_error_delta_r;
+  double min_char_speed;
+  double min_comoving_char_speed;
+  double char_speed_crossing_time;
+  double comoving_char_speed_crossing_time;
+  double delta_r_crossing_time;
+  double target_char_speed;
+  double suggested_timescale;
+  double damping_timescale;
+  bool discontinuous_change_has_occurred;
+};
 
 /*!
  * \brief Computes the size control error, updating the stored info.
@@ -59,6 +81,10 @@ namespace control_system::size {
  * \param inverse_spatial_metric_on_excision_boundary metric in frame Frame.
  * \param function_of_time FunctionOfTime that is being controlled.
  *        This function_of_time contains DataVectors of size 1.
+ * \return Returns an `ErrorDiagnostics` object which, in addition to the actual
+ *         control error, holds a lot of diagnostic information about how the
+ *         control error was calculated. This information could be used to print
+ *         to a file if desired.
  *
  * The characteristic speed that is needed here is
  * \f{align}
@@ -108,7 +134,7 @@ namespace control_system::size {
  * in different frames.
  */
 template <typename Frame>
-double control_error(
+ErrorDiagnostics control_error(
     const gsl::not_null<Info*> info,
     const gsl::not_null<intrp::ZeroCrossingPredictor*> predictor_char_speed,
     const gsl::not_null<intrp::ZeroCrossingPredictor*>

--- a/src/ControlSystem/ControlErrors/Size/Error.hpp
+++ b/src/ControlSystem/ControlErrors/Size/Error.hpp
@@ -26,7 +26,7 @@ class ZeroCrossingPredictor;
 namespace control_system::size {
 
 /*!
- * \brief Computes the size control signal, updating the stored info.
+ * \brief Computes the size control error, updating the stored info.
  *
  * \tparam Frame should be ::Frame::Distorted if ::Frame::Distorted exists.
  * \param info struct containing parameters that will be used/filled. Some of
@@ -37,7 +37,7 @@ namespace control_system::size {
  * \param predictor_comoving_char_speed ZeroCrossingPredictor for the
  *        comoving characteristic speed.
  * \param predictor_delta_radius ZeroCrossingPredictor for the difference
- *        in radius between the horizon and the exision boundary.
+ *        in radius between the horizon and the excision boundary.
  * \param time the current time.
  * \param apparent_horizon the current horizon in frame Frame.
  * \param excision_boundary a Strahlkorper representing the excision
@@ -108,7 +108,7 @@ namespace control_system::size {
  * in different frames.
  */
 template <typename Frame>
-double control_signal(
+double control_error(
     const gsl::not_null<Info*> info,
     const gsl::not_null<intrp::ZeroCrossingPredictor*> predictor_char_speed,
     const gsl::not_null<intrp::ZeroCrossingPredictor*>

--- a/src/ControlSystem/ControlErrors/Size/Initial.cpp
+++ b/src/ControlSystem/ControlErrors/Size/Initial.cpp
@@ -54,13 +54,12 @@ void Initial::update(const gsl::not_null<Info*> info,
   // Otherwise, no change.
 }
 
-double Initial::control_signal(
-    const Info& info,
-    const ControlSignalArgs& control_signal_args) const {
+double Initial::control_error(
+    const Info& info, const ControlErrorArgs& control_error_args) const {
   // The return value is the Q that directly controls the speed of the
   // excision boundary in the distorted frame relative to the grid frame.
   return info.target_drift_velocity -
-         control_signal_args.time_deriv_of_lambda_00;
+         control_error_args.time_deriv_of_lambda_00;
 }
 
 PUP::able::PUP_ID Initial::my_PUP_ID = 0;

--- a/src/ControlSystem/ControlErrors/Size/Initial.hpp
+++ b/src/ControlSystem/ControlErrors/Size/Initial.hpp
@@ -19,9 +19,9 @@ class Initial : public State {
   void update(const gsl::not_null<Info*> info,
               const StateUpdateArgs& update_args,
               const CrossingTimeInfo& crossing_time_info) const override;
-  double control_signal(
+  double control_error(
       const Info& info,
-      const ControlSignalArgs& control_signal_args) const override;
+      const ControlErrorArgs& control_error_args) const override;
 
   WRAPPED_PUPable_decl_template(Initial); // NOLINT
   explicit Initial(CkMigrateMessage* const /*msg*/) {}

--- a/src/ControlSystem/ControlErrors/Size/State.hpp
+++ b/src/ControlSystem/ControlErrors/Size/State.hpp
@@ -33,10 +33,10 @@ struct StateUpdateArgs {
   double control_error_delta_r;
 };
 
-/// Packages some of the inputs to the State::control_signal, so
-/// that State::control_signal doesn't need a large number of
+/// Packages some of the inputs to the State::control_error, so
+/// that State::control_error doesn't need a large number of
 /// arguments.
-struct ControlSignalArgs {
+struct ControlErrorArgs {
   double min_char_speed;
   double control_error_delta_r;
   /// avg_distorted_normal_dot_unit_coord_vector is the average of
@@ -133,8 +133,8 @@ class State : public PUP::able {
                       const CrossingTimeInfo& crossing_time_info) const = 0;
   /// Returns the control signal, but does not modify the state or any
   /// parameters.
-  virtual double control_signal(
-      const Info& info, const ControlSignalArgs& control_signal_args) const = 0;
+  virtual double control_error(
+      const Info& info, const ControlErrorArgs& control_error_args) const = 0;
 
   WRAPPED_PUPable_abstract(State);  // NOLINT
   explicit State(CkMigrateMessage* msg) : PUP::able(msg) {}

--- a/tests/Unit/ControlSystem/ControlErrors/CMakeLists.txt
+++ b/tests/Unit/ControlSystem/ControlErrors/CMakeLists.txt
@@ -7,6 +7,6 @@ set(LIBRARY_SOURCES
   ControlErrors/Test_Rotation.cpp
   ControlErrors/Test_Shape.cpp
   ControlErrors/Test_SizeControlStates.cpp
-  ControlErrors/Test_SizeSignal.cpp
+  ControlErrors/Test_SizeError.cpp
   ControlErrors/Test_Translation.cpp
   PARENT_SCOPE)

--- a/tests/Unit/ControlSystem/ControlErrors/Test_SizeControlStates.cpp
+++ b/tests/Unit/ControlSystem/ControlErrors/Test_SizeControlStates.cpp
@@ -359,10 +359,10 @@ void test_size_control_update() {
       test_params, true, 0.0, test_params.original_target_char_speed);
 }
 
-void test_size_control_signal() {
+void test_size_control_error() {
   // This is a very rudimentary test.  It just computes
   // the same thing as the thing it is testing, but coded differently.
-  const control_system::size::ControlSignalArgs args{0.01, 0.03, 1.2, 0.33};
+  const control_system::size::ControlErrorArgs args{0.01, 0.03, 1.2, 0.33};
   const control_system::size::Info info{
       std::make_unique<control_system::size::States::Initial>(),
       1.1,
@@ -370,11 +370,11 @@ void test_size_control_signal() {
       1.e-3,
       2.e-3,
       false};
-  CHECK(control_system::size::States::Initial{}.control_signal(info, args) ==
+  CHECK(control_system::size::States::Initial{}.control_error(info, args) ==
         -0.329);
-  CHECK(control_system::size::States::AhSpeed{}.control_signal(info, args) ==
+  CHECK(control_system::size::States::AhSpeed{}.control_error(info, args) ==
         approx(0.001 * sqrt(4.0 * M_PI) / 1.2));
-  CHECK(control_system::size::States::DeltaR{}.control_signal(info, args) ==
+  CHECK(control_system::size::States::DeltaR{}.control_error(info, args) ==
         0.03);
 }
 
@@ -413,7 +413,7 @@ void test_name_and_number() {
 SPECTRE_TEST_CASE("Unit.ControlSystem.SizeControlStates", "[Domain][Unit]") {
   control_system::size::register_derived_with_charm();
   test_size_control_update();
-  test_size_control_signal();
+  test_size_control_error();
   test_clone_and_serialization<control_system::size::States::Initial>();
   test_clone_and_serialization<control_system::size::States::AhSpeed>();
   test_clone_and_serialization<control_system::size::States::DeltaR>();

--- a/tests/Unit/ControlSystem/ControlErrors/Test_SizeError.cpp
+++ b/tests/Unit/ControlSystem/ControlErrors/Test_SizeError.cpp
@@ -124,7 +124,7 @@ void test_size_error_one_step(
   // Here we merely check that control_error does the correct
   // thing for a few cases.
   CHECK(dynamic_cast<FinalState*>(info.state.get()) != nullptr);
-  CHECK(error == approx(expected_error));
+  CHECK(error.control_error == approx(expected_error));
 }
 
 template <typename InitialState, typename FinalState>


### PR DESCRIPTION
## Proposed changes

First, rename everything that says "control signal" to "control error" because the "control signal" is what the Controller itself outputs and is what's used to update the Nth deriv of the function of time. Everything here is the "control error" which tells us how off we are from our desired value.

Then add a simple struct for gathering diagnostic information from the size control error calculation. This info will be printed out once I add the control error class.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
