### PR TITLE
Add subcell ghost data for ForceFree system

### DIFF
--- a/src/Evolution/Systems/ForceFree/FiniteDifference/Tags.hpp
+++ b/src/Evolution/Systems/ForceFree/FiniteDifference/Tags.hpp
@@ -16,11 +16,12 @@
 namespace ForceFree::fd {
 
 // A tag list of variables used for FD reconstruction process. For the ForceFree
-// evolution system, we just use the whole set of evolved variables.
-using tags_for_reconstruction =
-    tmpl::list<ForceFree::Tags::TildeE, ForceFree::Tags::TildeB,
-               ForceFree::Tags::TildePsi, ForceFree::Tags::TildePhi,
-               ForceFree::Tags::TildeQ>;
+// evolution system, we use the whole set of evolved variables and the
+// generalized current density TildeJ.
+using tags_list_for_reconstruction =
+    tmpl::list<ForceFree::Tags::TildeJ, ForceFree::Tags::TildeE,
+               ForceFree::Tags::TildeB, ForceFree::Tags::TildePsi,
+               ForceFree::Tags::TildePhi, ForceFree::Tags::TildeQ>;
 
 namespace OptionTags {
 /*!

--- a/src/Evolution/Systems/ForceFree/Subcell/CMakeLists.txt
+++ b/src/Evolution/Systems/ForceFree/Subcell/CMakeLists.txt
@@ -6,6 +6,7 @@ spectre_target_sources(
   ${LIBRARY}
   PRIVATE
   ComputeFluxes.hpp
+  GhostData.cpp
   InitialDataTci.cpp
   TciOnDgGrid.cpp
   TciOnFdGrid.cpp
@@ -15,6 +16,7 @@ spectre_target_headers(
   ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
+  GhostData.hpp
   InitialDataTci.hpp
   Subcell.hpp
   TciOnDgGrid.hpp

--- a/src/Evolution/Systems/ForceFree/Subcell/GhostData.cpp
+++ b/src/Evolution/Systems/ForceFree/Subcell/GhostData.cpp
@@ -1,0 +1,39 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/ForceFree/Subcell/GhostData.hpp"
+
+#include <cstddef>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Evolution/Systems/ForceFree/Tags.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace ForceFree::subcell {
+DataVector GhostVariables::apply(
+    const Variables<evolved_vars>& vars,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_j,
+    const size_t rdmp_size) {
+  DataVector buffer{
+      vars.number_of_grid_points() *
+          (tilde_j.size() +
+           Variables<evolved_vars>::number_of_independent_components) +
+      rdmp_size};
+
+  Variables<tmpl::append<tmpl::list<ForceFree::Tags::TildeJ>, evolved_vars>>
+      vars_to_reconstruct(buffer.data(), buffer.size() - rdmp_size);
+
+  for (size_t i = 0; i < 3; ++i) {
+    get<ForceFree::Tags::TildeJ>(vars_to_reconstruct).get(i) = tilde_j.get(i);
+  }
+
+  tmpl::for_each<evolved_vars>([&vars, &vars_to_reconstruct](auto tag_v) {
+    using tag = tmpl::type_from<decltype(tag_v)>;
+    get<tag>(vars_to_reconstruct) = get<tag>(vars);
+  });
+
+  return buffer;
+}
+}  // namespace ForceFree::subcell

--- a/src/Evolution/Systems/ForceFree/Subcell/GhostData.hpp
+++ b/src/Evolution/Systems/ForceFree/Subcell/GhostData.hpp
@@ -1,0 +1,46 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Evolution/Systems/ForceFree/Tags.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+template <typename T>
+class Variables;
+namespace Tags {
+template <typename TagsList>
+struct Variables;
+}  // namespace Tags
+/// \endcond
+
+namespace ForceFree::subcell {
+/*!
+ * \brief Returns \f$\tilde{J}^i\f$, \f$\tilde{E}^i\f$, \f$\tilde{B}^i\f$,
+ * \f$\tilde{\psi}\f$, \f$\tilde{\phi}\f$ and \f$\tilde{q}\f$ for FD
+ * reconstruction.
+ *
+ * This mutator is passed to
+ * `evolution::dg::subcell::Actions::SendDataForReconstruction`.
+ */
+class GhostVariables {
+ private:
+  using evolved_vars =
+      tmpl::list<ForceFree::Tags::TildeE, ForceFree::Tags::TildeB,
+                 ForceFree::Tags::TildePsi, ForceFree::Tags::TildePhi,
+                 ForceFree::Tags::TildeQ>;
+
+ public:
+  using return_tags = tmpl::list<>;
+  using argument_tags =
+      tmpl::list<::Tags::Variables<evolved_vars>, ForceFree::Tags::TildeJ>;
+
+  static DataVector apply(
+      const Variables<evolved_vars>& vars,
+      const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_j, size_t rdmp_size);
+};
+}  // namespace ForceFree::subcell

--- a/tests/Unit/Evolution/Systems/ForceFree/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/ForceFree/CMakeLists.txt
@@ -9,6 +9,7 @@ set(LIBRARY_SOURCES
   BoundaryCorrections/Test_Rusanov.cpp
   FiniteDifference/Test_Tags.cpp
   Subcell/Test_ComputeFluxes.cpp
+  Subcell/Test_GhostData.cpp
   Subcell/Test_InitialDataTci.cpp
   Subcell/Test_TciOnDgGrid.cpp
   Subcell/Test_TciOnFdGrid.cpp

--- a/tests/Unit/Evolution/Systems/ForceFree/Subcell/Test_GhostData.cpp
+++ b/tests/Unit/Evolution/Systems/ForceFree/Subcell/Test_GhostData.cpp
@@ -1,0 +1,68 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <limits>
+#include <random>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "DataStructures/VariablesTag.hpp"
+#include "Evolution/DgSubcell/Mesh.hpp"
+#include "Evolution/Systems/ForceFree/FiniteDifference/Tags.hpp"
+#include "Evolution/Systems/ForceFree/Subcell/GhostData.hpp"
+#include "Evolution/Systems/ForceFree/System.hpp"
+#include "Evolution/Systems/ForceFree/Tags.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace ForceFree::fd {
+
+namespace {
+void test_ghost_data_on_subcells(
+    const gsl::not_null<std::mt19937*> gen,
+    const gsl::not_null<std::uniform_real_distribution<>*> dist) {
+  const Mesh<3> dg_mesh{5, Spectral::Basis::Legendre,
+                        Spectral::Quadrature::GaussLobatto};
+  const Mesh<3> subcell_mesh = evolution::dg::subcell::fd::mesh(dg_mesh);
+
+  using evolved_vars_tags = System::variables_tag::tags_list;
+  const auto evolved_vars =
+      make_with_random_values<Variables<evolved_vars_tags>>(
+          gen, dist, subcell_mesh.number_of_grid_points());
+  const auto tilde_j = make_with_random_values<ForceFree::Tags::TildeJ::type>(
+      gen, dist, subcell_mesh.number_of_grid_points());
+
+  auto box = db::create<db::AddSimpleTags<::Tags::Variables<evolved_vars_tags>,
+                                          ForceFree::Tags::TildeJ>>(
+      evolved_vars, tilde_j);
+  DataVector recons_prims_rdmp =
+      db::mutate_apply<ForceFree::subcell::GhostVariables>(make_not_null(&box),
+                                                           2_st);
+  const Variables<ForceFree::fd::tags_list_for_reconstruction> recons_vars{
+      recons_prims_rdmp.data(), recons_prims_rdmp.size() - 2};
+
+  tmpl::for_each<evolved_vars_tags>([&evolved_vars, &recons_vars](auto tag_v) {
+    using tag = tmpl::type_from<decltype(tag_v)>;
+    CHECK_ITERABLE_APPROX(get<tag>(recons_vars), get<tag>(evolved_vars));
+  });
+  CHECK_ITERABLE_APPROX(get<ForceFree::Tags::TildeJ>(recons_vars), tilde_j);
+}
+
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.ForceFree.Subcell.GhostData",
+                  "[Unit][Evolution]") {
+  MAKE_GENERATOR(gen);
+  std::uniform_real_distribution<> dist(-1.0, 1.0);
+  test_ghost_data_on_subcells(make_not_null(&gen), make_not_null(&dist));
+}
+}  // namespace
+
+}  // namespace ForceFree::fd


### PR DESCRIPTION
## Proposed changes

Side note : It turns out that we should not evaluate `TildeJ` on faces from the reconstructed values of `E, B, ..`, but reconstruct `TildeJ` itself for stable evolution.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
