### PR TITLE
Add Python Bindings for weyl_magnetic and weyl_magnetic_scalar.

### DIFF
--- a/src/PointwiseFunctions/GeneralRelativity/Python/Bindings.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/Python/Bindings.cpp
@@ -15,6 +15,7 @@
 #include "PointwiseFunctions/GeneralRelativity/Shift.hpp"
 #include "PointwiseFunctions/GeneralRelativity/SpacetimeNormalOneForm.hpp"
 #include "PointwiseFunctions/GeneralRelativity/SpacetimeNormalVector.hpp"
+#include "PointwiseFunctions/GeneralRelativity/WeylMagnetic.hpp"
 #include "PointwiseFunctions/GeneralRelativity/WeylPropagating.hpp"
 
 namespace py = pybind11;
@@ -132,6 +133,21 @@ void bind_impl(py::module& m) {  // NOLINT
                                                const tnsr::I<DataVector, 3>&)>(
             &::gr::spacetime_normal_vector),
         py::arg("lapse"), py::arg("shift"));
+
+  m.def("weyl_magnetic",
+        static_cast<tnsr::ii<DataVector, 3, Frame::Inertial> (*)(
+            const tnsr::ijj<DataVector, 3, Frame::Inertial>&,
+            const tnsr::ii<DataVector, 3, Frame::Inertial>&,
+            const Scalar<DataVector>&)>(&gr::weyl_magnetic),
+        py::arg("grad_extrinsic_curvature"), py::arg("spatial_metric"),
+        py::arg("sqrt_det_spatial_metric"));
+
+  m.def("weyl_magnetic_scalar",
+        static_cast<Scalar<DataVector> (*)(
+            const tnsr::ii<DataVector, 3, Frame::Inertial>&,
+            const tnsr::II<DataVector, 3, Frame::Inertial>&)>(
+            &gr::weyl_magnetic_scalar),
+        py::arg("weyl_magnetic"), py::arg("inverse_spatial_metric"));
 
   m.def("weyl_propagating",
         py::overload_cast<

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Python/Test_Bindings.py
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Python/Test_Bindings.py
@@ -116,6 +116,22 @@ class TestBindings(unittest.TestCase):
                                      sign=1.0)
         npt.assert_allclose(weyl_prop, 0)
 
+    def test_weyl_magnetic(self):
+        grad_extrinsic_curvature = tnsr.ijj[DataVector, 3](num_points=1,
+                                                           fill=1.)
+        spatial_metric = tnsr.ii[DataVector, 3](num_points=1, fill=1.)
+        sqrt_det_spatial_metric = Scalar[DataVector](num_points=1, fill=1.)
+        weyl_mag = weyl_magnetic(grad_extrinsic_curvature, spatial_metric,
+                                 sqrt_det_spatial_metric)
+        npt.assert_allclose(weyl_mag, 0)
+
+    def test_weyl_magnetic_scalar(self):
+        weyl_magnetic = tnsr.ii[DataVector, 3](num_points=1, fill=1.)
+        inverse_spatial_metric = tnsr.II[DataVector, 3](num_points=1, fill=0.)
+        weyl_mag_scalar = weyl_magnetic_scalar(weyl_magnetic,
+                                               inverse_spatial_metric)
+        npt.assert_allclose(weyl_mag_scalar, 0)
+
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Proposed changes


This adds Python bindings for weyl_magnetic and weyl_magnetic_scalar. 


### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
