### PR TITLE
Print stacktrace on segfaults

### DIFF
--- a/src/DataStructures/Python/Bindings.cpp
+++ b/src/DataStructures/Python/Bindings.cpp
@@ -5,8 +5,10 @@
 
 #include "DataStructures/Python/DataVector.hpp"
 #include "DataStructures/Python/Matrix.hpp"
+#include "Utilities/ErrorHandling/SegfaultHandler.hpp"
 
 PYBIND11_MODULE(_PyDataStructures, m) {  // NOLINT
+  enable_segfault_handler();
   py_bindings::bind_datavector(m);
   py_bindings::bind_matrix(m);
 }

--- a/src/DataStructures/Tensor/EagerMath/Python/Bindings.cpp
+++ b/src/DataStructures/Tensor/EagerMath/Python/Bindings.cpp
@@ -5,10 +5,12 @@
 
 #include "DataStructures/Tensor/EagerMath/Python/Determinant.hpp"
 #include "DataStructures/Tensor/EagerMath/Python/Magnitude.hpp"
+#include "Utilities/ErrorHandling/SegfaultHandler.hpp"
 
 namespace py = pybind11;
 
 PYBIND11_MODULE(_PyTensorEagerMath, m) {  // NOLINT
+  enable_segfault_handler();
   py::module_::import("spectre.DataStructures");
   py::module_::import("spectre.DataStructures.Tensor");
   py_bindings::bind_determinant(m);

--- a/src/DataStructures/Tensor/Python/Bindings.cpp
+++ b/src/DataStructures/Tensor/Python/Bindings.cpp
@@ -4,10 +4,12 @@
 #include <pybind11/pybind11.h>
 
 #include "DataStructures/Tensor/Python/Tensor.hpp"
+#include "Utilities/ErrorHandling/SegfaultHandler.hpp"
 
 namespace py = pybind11;
 
 PYBIND11_MODULE(_PyTensor, m) {  // NOLINT
+  enable_segfault_handler();
   py::module_::import("spectre.DataStructures");
   py_bindings::bind_scalar(m);
   py_bindings::bind_tensor<1>(m);

--- a/src/Domain/CoordinateMaps/Python/Bindings.cpp
+++ b/src/Domain/CoordinateMaps/Python/Bindings.cpp
@@ -5,12 +5,14 @@
 
 #include "Domain/CoordinateMaps/Distribution.hpp"
 #include "Domain/CoordinateMaps/Python/CoordinateMap.hpp"
+#include "Utilities/ErrorHandling/SegfaultHandler.hpp"
 
 namespace py = pybind11;
 
 namespace domain {
 
 PYBIND11_MODULE(_PyCoordinateMaps, m) {  // NOLINT
+  enable_segfault_handler();
   py::module_::import("spectre.DataStructures");
   py::module_::import("spectre.DataStructures.Tensor");
   py::enum_<CoordinateMaps::Distribution>(m, "Distribution")

--- a/src/Domain/Creators/Python/Bindings.cpp
+++ b/src/Domain/Creators/Python/Bindings.cpp
@@ -11,12 +11,14 @@
 #include "Domain/Creators/Python/Sphere.hpp"
 #include "Domain/Creators/RegisterDerivedWithCharm.hpp"
 #include "Domain/Creators/TimeDependence/RegisterDerivedWithCharm.hpp"
+#include "Utilities/ErrorHandling/SegfaultHandler.hpp"
 
 namespace py = pybind11;
 
 namespace domain::creators {
 
 PYBIND11_MODULE(_PyDomainCreators, m) {  // NOLINT
+  enable_segfault_handler();
   py::module_::import("spectre.Domain");
   py::module_::import("spectre.Domain.CoordinateMaps");
   domain::creators::register_derived_with_charm();

--- a/src/Domain/Python/Bindings.cpp
+++ b/src/Domain/Python/Bindings.cpp
@@ -13,12 +13,14 @@
 #include "Domain/Python/JacobianDiagnostic.hpp"
 #include "Domain/Python/RadiallyCompressedCoordinates.hpp"
 #include "Domain/Python/SegmentId.hpp"
+#include "Utilities/ErrorHandling/SegfaultHandler.hpp"
 
 namespace py = pybind11;
 
 namespace domain {
 
 PYBIND11_MODULE(_PyDomain, m) {  // NOLINT
+  enable_segfault_handler();
   py::module_::import("spectre.DataStructures");
   py::module_::import("spectre.DataStructures.Tensor");
   py::module_::import("spectre.Domain.CoordinateMaps");

--- a/src/Elliptic/Executables/Elasticity/SolveElasticity.hpp
+++ b/src/Elliptic/Executables/Elasticity/SolveElasticity.hpp
@@ -63,6 +63,7 @@
 #include "PointwiseFunctions/InitialDataUtilities/InitialGuess.hpp"
 #include "Utilities/Blas.hpp"
 #include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
+#include "Utilities/ErrorHandling/SegfaultHandler.hpp"
 #include "Utilities/Functional.hpp"
 #include "Utilities/MemoryHelpers.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
@@ -302,5 +303,5 @@ static const std::vector<void (*)()> charm_init_node_funcs{
     &elliptic::subdomain_preconditioners::register_derived_with_charm,
     &register_factory_classes_with_charm<metavariables>};
 static const std::vector<void (*)()> charm_init_proc_funcs{
-    &enable_floating_point_exceptions};
+    &enable_floating_point_exceptions, &enable_segfault_handler};
 /// \endcond

--- a/src/Elliptic/Executables/Poisson/SolvePoisson.hpp
+++ b/src/Elliptic/Executables/Poisson/SolvePoisson.hpp
@@ -57,6 +57,7 @@
 #include "PointwiseFunctions/MathFunctions/Factory.hpp"
 #include "Utilities/Blas.hpp"
 #include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
+#include "Utilities/ErrorHandling/SegfaultHandler.hpp"
 #include "Utilities/Functional.hpp"
 #include "Utilities/MemoryHelpers.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
@@ -292,5 +293,5 @@ static const std::vector<void (*)()> charm_init_node_funcs{
         metavariables::schwarz_smoother::subdomain_solver>,
     &register_factory_classes_with_charm<metavariables>};
 static const std::vector<void (*)()> charm_init_proc_funcs{
-    &enable_floating_point_exceptions};
+    &enable_floating_point_exceptions, &enable_segfault_handler};
 /// \endcond

--- a/src/Elliptic/Executables/Punctures/SolvePunctures.hpp
+++ b/src/Elliptic/Executables/Punctures/SolvePunctures.hpp
@@ -40,6 +40,7 @@
 #include "PointwiseFunctions/InitialDataUtilities/InitialGuess.hpp"
 #include "Utilities/Blas.hpp"
 #include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
+#include "Utilities/ErrorHandling/SegfaultHandler.hpp"
 #include "Utilities/MemoryHelpers.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/Serialization/RegisterDerivedClassesWithCharm.hpp"
@@ -141,5 +142,5 @@ static const std::vector<void (*)()> charm_init_node_funcs{
     &elliptic::subdomain_preconditioners::register_derived_with_charm,
     &register_factory_classes_with_charm<metavariables>};
 static const std::vector<void (*)()> charm_init_proc_funcs{
-    &enable_floating_point_exceptions};
+    &enable_floating_point_exceptions, &enable_segfault_handler};
 /// \endcond

--- a/src/Elliptic/Executables/Xcts/SolveXcts.hpp
+++ b/src/Elliptic/Executables/Xcts/SolveXcts.hpp
@@ -48,6 +48,7 @@
 #include "PointwiseFunctions/Xcts/SpacetimeQuantities.hpp"
 #include "Utilities/Blas.hpp"
 #include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
+#include "Utilities/ErrorHandling/SegfaultHandler.hpp"
 #include "Utilities/Functional.hpp"
 #include "Utilities/MemoryHelpers.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
@@ -189,5 +190,5 @@ static const std::vector<void (*)()> charm_init_node_funcs{
     &EquationsOfState::register_derived_with_charm,
     &register_factory_classes_with_charm<metavariables>};
 static const std::vector<void (*)()> charm_init_proc_funcs{
-    &enable_floating_point_exceptions};
+    &enable_floating_point_exceptions, &enable_segfault_handler};
 /// \endcond

--- a/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
+++ b/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
@@ -107,6 +107,7 @@
 #include "Time/Triggers/TimeTriggers.hpp"
 #include "Utilities/Blas.hpp"
 #include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
+#include "Utilities/ErrorHandling/SegfaultHandler.hpp"
 #include "Utilities/MemoryHelpers.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/Serialization/RegisterDerivedClassesWithCharm.hpp"
@@ -367,4 +368,4 @@ static const std::vector<void (*)()> charm_init_node_funcs{
     &Burgers::fd::register_derived_with_charm,
     &register_factory_classes_with_charm<metavariables>};
 static const std::vector<void (*)()> charm_init_proc_funcs{
-    &enable_floating_point_exceptions};
+    &enable_floating_point_exceptions, &enable_segfault_handler};

--- a/src/Evolution/Executables/Cce/CharacteristicExtract.hpp
+++ b/src/Evolution/Executables/Cce/CharacteristicExtract.hpp
@@ -42,6 +42,7 @@
 #include "Time/TimeSteppers/LtsTimeStepper.hpp"
 #include "Utilities/Blas.hpp"
 #include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
+#include "Utilities/ErrorHandling/SegfaultHandler.hpp"
 #include "Utilities/MemoryHelpers.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/Serialization/RegisterDerivedClassesWithCharm.hpp"
@@ -106,4 +107,4 @@ static const std::vector<void (*)()> charm_init_node_funcs{
     &register_factory_classes_with_charm<metavariables>};
 
 static const std::vector<void (*)()> charm_init_proc_funcs{
-    &enable_floating_point_exceptions};
+    &enable_floating_point_exceptions, &enable_segfault_handler};

--- a/src/Evolution/Executables/CurvedScalarWave/EvolveCurvedScalarWave.hpp
+++ b/src/Evolution/Executables/CurvedScalarWave/EvolveCurvedScalarWave.hpp
@@ -108,6 +108,7 @@
 #include "Time/Triggers/TimeTriggers.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
+#include "Utilities/ErrorHandling/SegfaultHandler.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/Serialization/RegisterDerivedClassesWithCharm.hpp"
 #include "Utilities/TMPL.hpp"
@@ -352,4 +353,4 @@ static const std::vector<void (*)()> charm_init_node_funcs{
     &register_factory_classes_with_charm<metavariables>};
 
 static const std::vector<void (*)()> charm_init_proc_funcs{
-    &enable_floating_point_exceptions};
+    &enable_floating_point_exceptions, &enable_segfault_handler};

--- a/src/Evolution/Executables/CurvedScalarWave/EvolveWorldtubeCurvedScalarWave.hpp
+++ b/src/Evolution/Executables/CurvedScalarWave/EvolveWorldtubeCurvedScalarWave.hpp
@@ -115,6 +115,7 @@
 #include "Time/Triggers/TimeTriggers.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
+#include "Utilities/ErrorHandling/SegfaultHandler.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/Serialization/RegisterDerivedClassesWithCharm.hpp"
 #include "Utilities/TMPL.hpp"
@@ -358,4 +359,4 @@ static const std::vector<void (*)()> charm_init_node_funcs{
     &register_factory_classes_with_charm<metavariables>};
 
 static const std::vector<void (*)()> charm_init_proc_funcs{
-    &enable_floating_point_exceptions};
+    &enable_floating_point_exceptions, &enable_segfault_handler};

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonicCce.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonicCce.hpp
@@ -61,6 +61,7 @@
 #include "Utilities/Blas.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
+#include "Utilities/ErrorHandling/SegfaultHandler.hpp"
 #include "Utilities/Serialization/RegisterDerivedClassesWithCharm.hpp"
 
 /// \cond
@@ -269,4 +270,4 @@ static const std::vector<void (*)()> charm_init_node_funcs{
     &register_factory_classes_with_charm<metavariables>};
 
 static const std::vector<void (*)()> charm_init_proc_funcs{
-    &enable_floating_point_exceptions};
+    &enable_floating_point_exceptions, &enable_segfault_handler};

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonicNoBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonicNoBlackHole.hpp
@@ -20,6 +20,7 @@
 #include "Utilities/Blas.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
+#include "Utilities/ErrorHandling/SegfaultHandler.hpp"
 #include "Utilities/Serialization/RegisterDerivedClassesWithCharm.hpp"
 
 template <size_t VolumeDim, bool UseNumericalInitialData>
@@ -105,4 +106,4 @@ static const std::vector<void (*)()> charm_init_node_funcs{
     &register_factory_classes_with_charm<metavariables>};
 
 static const std::vector<void (*)()> charm_init_proc_funcs{
-    &enable_floating_point_exceptions};
+    &enable_floating_point_exceptions, &enable_segfault_handler};

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonicSingleBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonicSingleBlackHole.hpp
@@ -62,6 +62,7 @@
 #include "Utilities/Blas.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
+#include "Utilities/ErrorHandling/SegfaultHandler.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/Serialization/RegisterDerivedClassesWithCharm.hpp"
 
@@ -256,4 +257,4 @@ static const std::vector<void (*)()> charm_init_node_funcs{
     &register_factory_classes_with_charm<metavariables>};
 
 static const std::vector<void (*)()> charm_init_proc_funcs{
-    &enable_floating_point_exceptions};
+    &enable_floating_point_exceptions, &enable_segfault_handler};

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
@@ -151,6 +151,7 @@
 #include "Utilities/Blas.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
+#include "Utilities/ErrorHandling/SegfaultHandler.hpp"
 #include "Utilities/Functional.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/Serialization/RegisterDerivedClassesWithCharm.hpp"
@@ -580,4 +581,4 @@ static const std::vector<void (*)()> charm_init_node_funcs{
     &register_factory_classes_with_charm<metavariables>};
 
 static const std::vector<void (*)()> charm_init_proc_funcs{
-    &enable_floating_point_exceptions};
+    &enable_floating_point_exceptions, &enable_segfault_handler};

--- a/src/Evolution/Executables/GrMhd/GhValenciaDivClean/EvolveGhValenciaDivClean.hpp
+++ b/src/Evolution/Executables/GrMhd/GhValenciaDivClean/EvolveGhValenciaDivClean.hpp
@@ -25,6 +25,7 @@
 #include "ParallelAlgorithms/Interpolation/InterpolationTarget.hpp"
 #include "ParallelAlgorithms/Interpolation/Tags.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/RegisterDerivedWithCharm.hpp"
+#include "Utilities/ErrorHandling/SegfaultHandler.hpp"
 #include "Utilities/Serialization/RegisterDerivedClassesWithCharm.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -64,4 +65,4 @@ static const std::vector<void (*)()> charm_init_node_funcs{
     &register_factory_classes_with_charm<metavariables>};
 
 static const std::vector<void (*)()> charm_init_proc_funcs{
-    &enable_floating_point_exceptions};
+    &enable_floating_point_exceptions, &enable_segfault_handler};

--- a/src/Evolution/Executables/GrMhd/GhValenciaDivClean/EvolveGhValenciaDivCleanWithHorizon.hpp
+++ b/src/Evolution/Executables/GrMhd/GhValenciaDivClean/EvolveGhValenciaDivCleanWithHorizon.hpp
@@ -46,6 +46,7 @@
 #include "Utilities/Blas.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
+#include "Utilities/ErrorHandling/SegfaultHandler.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/Serialization/RegisterDerivedClassesWithCharm.hpp"
 #include "Utilities/TMPL.hpp"
@@ -178,4 +179,4 @@ static const std::vector<void (*)()> charm_init_node_funcs{
     &register_factory_classes_with_charm<metavariables>};
 
 static const std::vector<void (*)()> charm_init_proc_funcs{
-    &enable_floating_point_exceptions};
+    &enable_floating_point_exceptions, &enable_segfault_handler};

--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
@@ -175,6 +175,7 @@
 #include "Time/Triggers/TimeTriggers.hpp"
 #include "Utilities/Blas.hpp"
 #include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
+#include "Utilities/ErrorHandling/SegfaultHandler.hpp"
 #include "Utilities/Functional.hpp"
 #include "Utilities/MemoryHelpers.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
@@ -616,4 +617,4 @@ static const std::vector<void (*)()> charm_init_node_funcs{
     &register_factory_classes_with_charm<metavariables>};
 
 static const std::vector<void (*)()> charm_init_proc_funcs{
-    &enable_floating_point_exceptions};
+    &enable_floating_point_exceptions, &enable_segfault_handler};

--- a/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
+++ b/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
@@ -117,6 +117,7 @@
 #include "Time/Triggers/TimeTriggers.hpp"
 #include "Utilities/Blas.hpp"
 #include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
+#include "Utilities/ErrorHandling/SegfaultHandler.hpp"
 #include "Utilities/Functional.hpp"
 #include "Utilities/MemoryHelpers.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
@@ -424,4 +425,4 @@ static const std::vector<void (*)()> charm_init_node_funcs{
     &register_factory_classes_with_charm<metavariables>};
 
 static const std::vector<void (*)()> charm_init_proc_funcs{
-    &enable_floating_point_exceptions};
+    &enable_floating_point_exceptions, &enable_segfault_handler};

--- a/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveM1Grey.hpp
+++ b/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveM1Grey.hpp
@@ -85,6 +85,7 @@
 #include "Time/Triggers/TimeTriggers.hpp"
 #include "Utilities/Blas.hpp"
 #include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
+#include "Utilities/ErrorHandling/SegfaultHandler.hpp"
 #include "Utilities/Functional.hpp"
 #include "Utilities/MemoryHelpers.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
@@ -289,4 +290,4 @@ static const std::vector<void (*)()> charm_init_node_funcs{
     &register_factory_classes_with_charm<metavariables>};
 
 static const std::vector<void (*)()> charm_init_proc_funcs{
-    &enable_floating_point_exceptions};
+    &enable_floating_point_exceptions, &enable_segfault_handler};

--- a/src/Evolution/Executables/RelativisticEuler/Valencia/EvolveValencia.hpp
+++ b/src/Evolution/Executables/RelativisticEuler/Valencia/EvolveValencia.hpp
@@ -91,6 +91,7 @@
 #include "Time/Triggers/TimeTriggers.hpp"
 #include "Utilities/Blas.hpp"
 #include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
+#include "Utilities/ErrorHandling/SegfaultHandler.hpp"
 #include "Utilities/Functional.hpp"
 #include "Utilities/MemoryHelpers.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
@@ -312,4 +313,4 @@ static const std::vector<void (*)()> charm_init_node_funcs{
     &register_factory_classes_with_charm<metavariables>};
 
 static const std::vector<void (*)()> charm_init_proc_funcs{
-    &enable_floating_point_exceptions};
+    &enable_floating_point_exceptions, &enable_segfault_handler};

--- a/src/Evolution/Executables/ScalarAdvection/EvolveScalarAdvection.hpp
+++ b/src/Evolution/Executables/ScalarAdvection/EvolveScalarAdvection.hpp
@@ -108,6 +108,7 @@
 #include "Time/Triggers/TimeTriggers.hpp"
 #include "Utilities/Blas.hpp"
 #include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
+#include "Utilities/ErrorHandling/SegfaultHandler.hpp"
 #include "Utilities/MemoryHelpers.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/Serialization/RegisterDerivedClassesWithCharm.hpp"
@@ -377,4 +378,4 @@ static const std::vector<void (*)()> charm_init_node_funcs{
     &register_factory_classes_with_charm<metavariables>};
 
 static const std::vector<void (*)()> charm_init_proc_funcs{
-    &enable_floating_point_exceptions};
+    &enable_floating_point_exceptions, &enable_segfault_handler};

--- a/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
+++ b/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
@@ -93,6 +93,7 @@
 #include "Utilities/Blas.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
+#include "Utilities/ErrorHandling/SegfaultHandler.hpp"
 #include "Utilities/Functional.hpp"
 #include "Utilities/MemoryHelpers.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
@@ -309,4 +310,4 @@ static const std::vector<void (*)()> charm_init_node_funcs{
     &register_factory_classes_with_charm<metavariables>};
 
 static const std::vector<void (*)()> charm_init_proc_funcs{
-    &enable_floating_point_exceptions};
+    &enable_floating_point_exceptions, &enable_segfault_handler};

--- a/src/Executables/Examples/HelloWorld/SingletonHelloWorld.hpp
+++ b/src/Executables/Examples/HelloWorld/SingletonHelloWorld.hpp
@@ -18,6 +18,7 @@
 #include "Parallel/PhaseDependentActionList.hpp"
 #include "Parallel/Printf.hpp"
 #include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
+#include "Utilities/ErrorHandling/SegfaultHandler.hpp"
 #include "Utilities/MemoryHelpers.hpp"
 #include "Utilities/System/ParallelInfo.hpp"
 #include "Utilities/TMPL.hpp"
@@ -109,6 +110,6 @@ struct Metavars {
 static const std::vector<void (*)()> charm_init_node_funcs{
     &setup_error_handling, &setup_memory_allocation_failure_reporting};
 static const std::vector<void (*)()> charm_init_proc_funcs{
-    &enable_floating_point_exceptions};
+    &enable_floating_point_exceptions, &enable_segfault_handler};
 /// [executable_example_charm_init]
 /// \endcond

--- a/src/Executables/Examples/RandomAmr/RandomAmr.hpp
+++ b/src/Executables/Examples/RandomAmr/RandomAmr.hpp
@@ -39,6 +39,7 @@
 #include "ParallelAlgorithms/Amr/Criteria/Tags/Criteria.hpp"
 #include "ParallelAlgorithms/EventsAndTriggers/LogicalTriggers.hpp"
 #include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
+#include "Utilities/ErrorHandling/SegfaultHandler.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/Serialization/RegisterDerivedClassesWithCharm.hpp"
 #include "Utilities/TMPL.hpp"
@@ -136,4 +137,4 @@ static const std::vector<void (*)()> charm_init_node_funcs{
     &register_factory_classes_with_charm<metavariables>,
     &register_amr_callbacks<typename metavariables::dg_element_array>};
 static const std::vector<void (*)()> charm_init_proc_funcs{
-    &enable_floating_point_exceptions};
+    &enable_floating_point_exceptions, &enable_segfault_handler};

--- a/src/Executables/ExportCoordinates/ExportCoordinates.hpp
+++ b/src/Executables/ExportCoordinates/ExportCoordinates.hpp
@@ -63,6 +63,7 @@
 #include "Time/Triggers/TimeCompares.hpp"
 #include "Utilities/Blas.hpp"
 #include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
+#include "Utilities/ErrorHandling/SegfaultHandler.hpp"
 #include "Utilities/Functional.hpp"
 #include "Utilities/GetOutput.hpp"
 #include "Utilities/Gsl.hpp"
@@ -323,5 +324,5 @@ static const std::vector<void (*)()> charm_init_node_funcs{
     &domain::FunctionsOfTime::register_derived_with_charm,
     &register_factory_classes_with_charm<metavariables>};
 static const std::vector<void (*)()> charm_init_proc_funcs{
-    &enable_floating_point_exceptions};
+    &enable_floating_point_exceptions, &enable_segfault_handler};
 /// \endcond

--- a/src/Executables/FindHorizons/FindHorizons.hpp
+++ b/src/Executables/FindHorizons/FindHorizons.hpp
@@ -62,6 +62,7 @@
 #include "Time/Tags.hpp"
 #include "Utilities/Blas.hpp"
 #include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
+#include "Utilities/ErrorHandling/SegfaultHandler.hpp"
 #include "Utilities/Overloader.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/Serialization/RegisterDerivedClassesWithCharm.hpp"
@@ -314,5 +315,5 @@ static const std::vector<void (*)()> charm_init_node_funcs{
     &domain::creators::register_derived_with_charm,
     &register_factory_classes_with_charm<metavariables>};
 static const std::vector<void (*)()> charm_init_proc_funcs{
-    &enable_floating_point_exceptions};
+    &enable_floating_point_exceptions, &enable_segfault_handler};
 /// \endcond

--- a/src/IO/H5/Python/Bindings.cpp
+++ b/src/IO/H5/Python/Bindings.cpp
@@ -7,10 +7,12 @@
 #include "IO/H5/Python/File.hpp"
 #include "IO/H5/Python/TensorData.hpp"
 #include "IO/H5/Python/VolumeData.hpp"
+#include "Utilities/ErrorHandling/SegfaultHandler.hpp"
 
 namespace py = pybind11;
 
 PYBIND11_MODULE(_PyH5, m) {  // NOLINT
+  enable_segfault_handler();
   py::module_::import("spectre.DataStructures");
   py::module_::import("spectre.Spectral");
   py_bindings::bind_h5file(m);

--- a/src/Informer/Python/Bindings.cpp
+++ b/src/Informer/Python/Bindings.cpp
@@ -4,7 +4,9 @@
 #include <pybind11/pybind11.h>
 
 #include "Informer/Python/InfoAtCompile.hpp"
+#include "Utilities/ErrorHandling/SegfaultHandler.hpp"
 
 PYBIND11_MODULE(_PyInformer, m) {  // NOLINT
+  enable_segfault_handler();
   py_bindings::bind_info_at_compile(m);
 }

--- a/src/NumericalAlgorithms/Interpolation/Python/Bindings.cpp
+++ b/src/NumericalAlgorithms/Interpolation/Python/Bindings.cpp
@@ -7,10 +7,12 @@
 #include "NumericalAlgorithms/Interpolation/Python/CubicSpline.hpp"
 #include "NumericalAlgorithms/Interpolation/Python/IrregularInterpolant.hpp"
 #include "NumericalAlgorithms/Interpolation/Python/RegularGridInterpolant.hpp"
+#include "Utilities/ErrorHandling/SegfaultHandler.hpp"
 
 namespace py = pybind11;
 
 PYBIND11_MODULE(_PyInterpolation, m) {  // NOLINT
+  enable_segfault_handler();
   py::module_::import("spectre.DataStructures");
   py::module_::import("spectre.Spectral");
   intrp::py_bindings::bind_barycentric_rational(m);

--- a/src/NumericalAlgorithms/LinearOperators/Python/Bindings.cpp
+++ b/src/NumericalAlgorithms/LinearOperators/Python/Bindings.cpp
@@ -6,10 +6,12 @@
 #include "NumericalAlgorithms/LinearOperators/Python/DefiniteIntegral.hpp"
 #include "NumericalAlgorithms/LinearOperators/Python/PartialDerivatives.hpp"
 #include "NumericalAlgorithms/LinearOperators/Python/PowerMonitors.hpp"
+#include "Utilities/ErrorHandling/SegfaultHandler.hpp"
 
 namespace py = pybind11;
 
 PYBIND11_MODULE(_PyLinearOperators, m) {  // NOLINT
+  enable_segfault_handler();
   py::module_::import("spectre.DataStructures");
   py::module_::import("spectre.DataStructures.Tensor");
   py::module_::import("spectre.Spectral");

--- a/src/NumericalAlgorithms/Spectral/Python/Bindings.cpp
+++ b/src/NumericalAlgorithms/Spectral/Python/Bindings.cpp
@@ -6,10 +6,12 @@
 #include "NumericalAlgorithms/Spectral/Python/LogicalCoordinates.hpp"
 #include "NumericalAlgorithms/Spectral/Python/Mesh.hpp"
 #include "NumericalAlgorithms/Spectral/Python/Spectral.hpp"
+#include "Utilities/ErrorHandling/SegfaultHandler.hpp"
 
 namespace py = pybind11;
 
 PYBIND11_MODULE(_PySpectral, m) {  // NOLINT
+  enable_segfault_handler();
   py::module_::import("spectre.DataStructures");
   py::module_::import("spectre.DataStructures.Tensor");
   Spectral::py_bindings::bind_basis(m);

--- a/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/Python/Bindings.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/Python/Bindings.cpp
@@ -4,10 +4,12 @@
 #include <pybind11/pybind11.h>
 
 #include "PointwiseFunctions/AnalyticSolutions/RelativisticEuler/Python/Tov.hpp"
+#include "Utilities/ErrorHandling/SegfaultHandler.hpp"
 
 namespace py = pybind11;
 
 PYBIND11_MODULE(_PyRelativisticEulerSolutions, m) {  // NOLINT
+  enable_segfault_handler();
   py::module_::import("spectre.Interpolation");
   py::module_::import("spectre.PointwiseFunctions.Hydro.EquationsOfState");
   RelativisticEuler::Solutions::py_bindings::bind_tov(m);

--- a/src/PointwiseFunctions/GeneralRelativity/Python/Bindings.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/Python/Bindings.cpp
@@ -17,6 +17,7 @@
 #include "PointwiseFunctions/GeneralRelativity/SpacetimeNormalVector.hpp"
 #include "PointwiseFunctions/GeneralRelativity/WeylMagnetic.hpp"
 #include "PointwiseFunctions/GeneralRelativity/WeylPropagating.hpp"
+#include "Utilities/ErrorHandling/SegfaultHandler.hpp"
 
 namespace py = pybind11;
 
@@ -166,6 +167,7 @@ void bind_impl(py::module& m) {  // NOLINT
 }  // namespace
 
 PYBIND11_MODULE(_PyGeneralRelativity, m) {  // NOLINT
+  enable_segfault_handler();
   py::module_::import("spectre.DataStructures");
   py::module_::import("spectre.DataStructures.Tensor");
   py::module_::import("spectre.Spectral");

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/Python/Bindings.cpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/Python/Bindings.cpp
@@ -6,12 +6,14 @@
 #include "PointwiseFunctions/Hydro/EquationsOfState/Python/EquationOfState.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/Python/PiecewisePolytropicFluid.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/Python/PolytropicFluid.hpp"
+#include "Utilities/ErrorHandling/SegfaultHandler.hpp"
 
 namespace py = pybind11;
 
 namespace EquationsOfState {
 
 PYBIND11_MODULE(_PyEquationsOfState, m) {  // NOLINT
+  enable_segfault_handler();
   py::module_::import("spectre.DataStructures");
   py::module_::import("spectre.DataStructures.Tensor");
   // Abstract base class

--- a/src/PointwiseFunctions/Punctures/Python/Bindings.cpp
+++ b/src/PointwiseFunctions/Punctures/Python/Bindings.cpp
@@ -8,12 +8,14 @@
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "PointwiseFunctions/Punctures/AdmIntegrals.hpp"
+#include "Utilities/ErrorHandling/SegfaultHandler.hpp"
 
 namespace py = pybind11;
 
 namespace Punctures {
 
 PYBIND11_MODULE(_PyPuncturesPointwiseFunctions, m) {  // NOLINT
+  enable_segfault_handler();
   py::module_::import("spectre.DataStructures");
   py::module_::import("spectre.DataStructures.Tensor");
   m.def("adm_mass_integrand",

--- a/src/Utilities/ErrorHandling/CMakeLists.txt
+++ b/src/Utilities/ErrorHandling/CMakeLists.txt
@@ -11,6 +11,7 @@ spectre_target_sources(
   AbortWithErrorMessage.cpp
   Breakpoint.cpp
   FloatingPointExceptions.cpp
+  SegfaultHandler.cpp
   )
 
 spectre_target_headers(
@@ -24,6 +25,7 @@ spectre_target_headers(
   Exceptions.hpp
   ExpectsAndEnsures.hpp
   FloatingPointExceptions.hpp
+  SegfaultHandler.hpp
   StaticAssert.hpp
   )
 

--- a/src/Utilities/ErrorHandling/SegfaultHandler.cpp
+++ b/src/Utilities/ErrorHandling/SegfaultHandler.cpp
@@ -1,0 +1,18 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Utilities/ErrorHandling/SegfaultHandler.hpp"
+
+#include "Utilities/ErrorHandling/Error.hpp"
+
+#include <csignal>
+
+namespace {
+[[noreturn]] void segfault_signal_handler(int /*signal*/) {
+  ERROR("Segmentation fault!");
+}
+}  // namespace
+
+void enable_segfault_handler() {
+  std::signal(SIGSEGV, segfault_signal_handler);
+}

--- a/src/Utilities/ErrorHandling/SegfaultHandler.hpp
+++ b/src/Utilities/ErrorHandling/SegfaultHandler.hpp
@@ -1,0 +1,12 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+/// \file
+/// Functions to enable handling segmentation faults
+
+#pragma once
+
+/// \ingroup ErrorHandlingGroup
+/// After a call to this function, the code will handle `SIGSEGV` segmentation
+/// faults by printing an error with a stacktrace.
+void enable_segfault_handler();

--- a/tests/Unit/ArchitectureVectorization/TestArchitectureVectorization.cpp
+++ b/tests/Unit/ArchitectureVectorization/TestArchitectureVectorization.cpp
@@ -16,6 +16,7 @@
 #include "Informer/InfoFromBuild.hpp"
 #include "Parallel/Printf.hpp"
 #include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
+#include "Utilities/ErrorHandling/SegfaultHandler.hpp"
 #include "Utilities/System/Abort.hpp"
 #include "Utilities/System/Exit.hpp"
 
@@ -24,6 +25,7 @@ RunTests::RunTests(CkArgMsg* msg) {
       []() { sys::abort("Called terminate. Aborting..."); });
   Parallel::printf("%s", info_from_build().c_str());
   enable_floating_point_exceptions();
+  enable_segfault_handler();
   const int result = Catch::Session().run(msg->argc, msg->argv);
   if (0 == result) {
     sys::exit();

--- a/tests/Unit/ErrorHandling/CMakeLists.txt
+++ b/tests/Unit/ErrorHandling/CMakeLists.txt
@@ -8,6 +8,7 @@ set(LIBRARY_SOURCES
   Test_AssertAndError.cpp
   Test_Exceptions.cpp
   Test_FloatingPointExceptions.cpp
+  Test_SegfaultHandler.cpp
   )
 
 add_test_library(

--- a/tests/Unit/ErrorHandling/Test_SegfaultHandler.cpp
+++ b/tests/Unit/ErrorHandling/Test_SegfaultHandler.cpp
@@ -1,0 +1,16 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <csignal>
+
+#include "Utilities/ErrorHandling/SegfaultHandler.hpp"
+
+// [[OutputRegex, Segmentation fault!]]
+SPECTRE_TEST_CASE("Unit.ErrorHandling.SegfaultHandler",
+                  "[ErrorHandling][Unit]") {
+  ERROR_TEST();
+  enable_segfault_handler();
+  std::raise(SIGSEGV);
+}

--- a/tests/Unit/IO/Importers/Test_VolumeDataReaderAlgorithm.hpp
+++ b/tests/Unit/IO/Importers/Test_VolumeDataReaderAlgorithm.hpp
@@ -72,6 +72,7 @@
 #include "Utilities/EqualWithinRoundoff.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
+#include "Utilities/ErrorHandling/SegfaultHandler.hpp"
 #include "Utilities/FileSystem.hpp"
 #include "Utilities/Functional.hpp"
 #include "Utilities/MakeString.hpp"
@@ -504,4 +505,4 @@ static const std::vector<void (*)()> charm_init_node_funcs{
     &domain::FunctionsOfTime::register_derived_with_charm,
     &register_factory_classes_with_charm<metavariables>};
 static const std::vector<void (*)()> charm_init_proc_funcs{
-    &enable_floating_point_exceptions};
+    &enable_floating_point_exceptions, &enable_segfault_handler};

--- a/tests/Unit/Parallel/Test_AlgorithmCore.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmCore.cpp
@@ -46,6 +46,7 @@
 #include "Time/TimeStepId.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
+#include "Utilities/ErrorHandling/SegfaultHandler.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MemoryHelpers.hpp"
 #include "Utilities/Requires.hpp"
@@ -850,7 +851,7 @@ struct TestMetavariables {
 static const std::vector<void (*)()> charm_init_node_funcs{
     &setup_error_handling, &setup_memory_allocation_failure_reporting};
 static const std::vector<void (*)()> charm_init_proc_funcs{
-    &enable_floating_point_exceptions};
+    &enable_floating_point_exceptions, &enable_segfault_handler};
 // [charm_init_funcs_example]
 
 // [charm_main_example]

--- a/tests/Unit/Parallel/Test_AlgorithmGlobalCache.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmGlobalCache.cpp
@@ -34,6 +34,7 @@
 #include "Parallel/PhaseDependentActionList.hpp"
 #include "ParallelAlgorithms/Actions/MemoryMonitor/ContributeMemoryData.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/ErrorHandling/SegfaultHandler.hpp"
 #include "Utilities/FileSystem.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MemoryHelpers.hpp"
@@ -507,7 +508,7 @@ struct TestMetavariables {
 static const std::vector<void (*)()> charm_init_node_funcs{
     &setup_error_handling, &setup_memory_allocation_failure_reporting};
 static const std::vector<void (*)()> charm_init_proc_funcs{
-    &enable_floating_point_exceptions};
+    &enable_floating_point_exceptions, &enable_segfault_handler};
 
 using charmxx_main_component = Parallel::Main<TestMetavariables>;
 

--- a/tests/Unit/Parallel/Test_AlgorithmLocalSyncAction.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmLocalSyncAction.cpp
@@ -29,6 +29,7 @@
 #include "ParallelAlgorithms/Actions/TerminatePhase.hpp"
 #include "Utilities/Blas.hpp"
 #include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
+#include "Utilities/ErrorHandling/SegfaultHandler.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MemoryHelpers.hpp"
 #include "Utilities/System/ParallelInfo.hpp"
@@ -254,7 +255,7 @@ static const std::vector<void (*)()> charm_init_node_funcs{
     &setup_error_handling, &setup_memory_allocation_failure_reporting,
     &disable_openblas_multithreading};
 static const std::vector<void (*)()> charm_init_proc_funcs{
-    &enable_floating_point_exceptions};
+    &enable_floating_point_exceptions, &enable_segfault_handler};
 
 using charmxx_main_component = Parallel::Main<TestMetavariables>;
 

--- a/tests/Unit/Parallel/Test_AlgorithmMessages.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmMessages.cpp
@@ -38,6 +38,7 @@
 #include "Time/TimeStepId.hpp"
 #include "Utilities/Blas.hpp"
 #include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
+#include "Utilities/ErrorHandling/SegfaultHandler.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeString.hpp"
 #include "Utilities/System/ParallelInfo.hpp"
@@ -435,7 +436,7 @@ static const std::vector<void (*)()> charm_init_node_funcs{
     &setup_error_handling, &setup_memory_allocation_failure_reporting,
     &disable_openblas_multithreading};
 static const std::vector<void (*)()> charm_init_proc_funcs{
-    &enable_floating_point_exceptions};
+    &enable_floating_point_exceptions, &enable_segfault_handler};
 
 using charmxx_main_component = Parallel::Main<TestMetavariables>;
 

--- a/tests/Unit/Parallel/Test_AlgorithmNestedApply1.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmNestedApply1.cpp
@@ -15,6 +15,7 @@
 #include "Parallel/Phase.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"  // IWYU pragma: keep
 #include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
+#include "Utilities/ErrorHandling/SegfaultHandler.hpp"
 #include "Utilities/MemoryHelpers.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -78,7 +79,7 @@ struct TestMetavariables {
 static const std::vector<void (*)()> charm_init_node_funcs{
     &setup_error_handling, &setup_memory_allocation_failure_reporting};
 static const std::vector<void (*)()> charm_init_proc_funcs{
-    &enable_floating_point_exceptions};
+    &enable_floating_point_exceptions, &enable_segfault_handler};
 
 using charmxx_main_component = Parallel::Main<TestMetavariables>;
 

--- a/tests/Unit/Parallel/Test_AlgorithmNestedApply2.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmNestedApply2.cpp
@@ -15,6 +15,7 @@
 #include "Parallel/Phase.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"  // IWYU pragma: keep
 #include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
+#include "Utilities/ErrorHandling/SegfaultHandler.hpp"
 #include "Utilities/MemoryHelpers.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -82,7 +83,7 @@ struct TestMetavariables {
 static const std::vector<void (*)()> charm_init_node_funcs{
     &setup_error_handling, &setup_memory_allocation_failure_reporting};
 static const std::vector<void (*)()> charm_init_proc_funcs{
-    &enable_floating_point_exceptions};
+    &enable_floating_point_exceptions, &enable_segfault_handler};
 
 using charmxx_main_component = Parallel::Main<TestMetavariables>;
 

--- a/tests/Unit/Parallel/Test_AlgorithmNodelock.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmNodelock.cpp
@@ -29,6 +29,7 @@
 #include "Parallel/PhaseDependentActionList.hpp"  // IWYU pragma: keep
 #include "ParallelAlgorithms/Initialization/MutateAssign.hpp"
 #include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
+#include "Utilities/ErrorHandling/SegfaultHandler.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MemoryHelpers.hpp"
 #include "Utilities/Requires.hpp"
@@ -327,7 +328,7 @@ struct TestMetavariables {
 static const std::vector<void (*)()> charm_init_node_funcs{
     &setup_error_handling, &setup_memory_allocation_failure_reporting};
 static const std::vector<void (*)()> charm_init_proc_funcs{
-    &enable_floating_point_exceptions};
+    &enable_floating_point_exceptions, &enable_segfault_handler};
 
 using charmxx_main_component = Parallel::Main<TestMetavariables>;
 

--- a/tests/Unit/Parallel/Test_AlgorithmParallel.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmParallel.cpp
@@ -32,6 +32,7 @@
 #include "ParallelAlgorithms/Initialization/MutateAssign.hpp"
 #include "Utilities/Blas.hpp"
 #include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
+#include "Utilities/ErrorHandling/SegfaultHandler.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MemoryHelpers.hpp"
 #include "Utilities/System/ParallelInfo.hpp"
@@ -608,7 +609,7 @@ static const std::vector<void (*)()> charm_init_node_funcs{
     &setup_error_handling, &setup_memory_allocation_failure_reporting,
     &disable_openblas_multithreading};
 static const std::vector<void (*)()> charm_init_proc_funcs{
-    &enable_floating_point_exceptions};
+    &enable_floating_point_exceptions, &enable_segfault_handler};
 
 using charmxx_main_component = Parallel::Main<TestMetavariables>;
 

--- a/tests/Unit/Parallel/Test_AlgorithmPhaseControl.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmPhaseControl.cpp
@@ -40,6 +40,7 @@
 #include "ParallelAlgorithms/Actions/TerminatePhase.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
+#include "Utilities/ErrorHandling/SegfaultHandler.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeString.hpp"
 #include "Utilities/MemoryHelpers.hpp"
@@ -435,7 +436,7 @@ static const std::vector<void (*)()> charm_init_node_funcs{
     &setup_error_handling, &setup_memory_allocation_failure_reporting,
     &register_factory_classes_with_charm<TestMetavariables>};
 static const std::vector<void (*)()> charm_init_proc_funcs{
-    &enable_floating_point_exceptions};
+    &enable_floating_point_exceptions, &enable_segfault_handler};
 // [charm_init_funcs_example]
 
 // [charm_main_example]

--- a/tests/Unit/Parallel/Test_AlgorithmReduction.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmReduction.cpp
@@ -32,6 +32,7 @@
 #include "Utilities/EqualWithinRoundoff.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
+#include "Utilities/ErrorHandling/SegfaultHandler.hpp"
 #include "Utilities/Functional.hpp"
 #include "Utilities/MemoryHelpers.hpp"
 #include "Utilities/System/ParallelInfo.hpp"
@@ -279,7 +280,7 @@ struct TestMetavariables {
 static const std::vector<void (*)()> charm_init_node_funcs{
     &setup_error_handling, &setup_memory_allocation_failure_reporting};
 static const std::vector<void (*)()> charm_init_proc_funcs{
-    &enable_floating_point_exceptions};
+    &enable_floating_point_exceptions, &enable_segfault_handler};
 
 using charmxx_main_component = Parallel::Main<TestMetavariables>;
 

--- a/tests/Unit/Parallel/Test_Callback.cpp
+++ b/tests/Unit/Parallel/Test_Callback.cpp
@@ -23,6 +23,7 @@
 #include "Parallel/PhaseDependentActionList.hpp"
 #include "ParallelAlgorithms/Initialization/MutateAssign.hpp"
 #include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
+#include "Utilities/ErrorHandling/SegfaultHandler.hpp"
 #include "Utilities/MemoryHelpers.hpp"
 #include "Utilities/Serialization/RegisterDerivedClassesWithCharm.hpp"
 #include "Utilities/TMPL.hpp"
@@ -264,7 +265,7 @@ static const std::vector<void (*)()> charm_init_node_funcs{
     &setup_error_handling, &setup_memory_allocation_failure_reporting,
     &register_callbacks};
 static const std::vector<void (*)()> charm_init_proc_funcs{
-    &enable_floating_point_exceptions};
+    &enable_floating_point_exceptions, &enable_segfault_handler};
 
 using charmxx_main_component = Parallel::Main<TestMetavariables>;
 

--- a/tests/Unit/Parallel/Test_CheckpointRestart.cpp
+++ b/tests/Unit/Parallel/Test_CheckpointRestart.cpp
@@ -29,6 +29,7 @@
 #include "Parallel/PhaseDependentActionList.hpp"
 #include "ParallelAlgorithms/Initialization/MutateAssign.hpp"
 #include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
+#include "Utilities/ErrorHandling/SegfaultHandler.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MemoryHelpers.hpp"
 #include "Utilities/System/ParallelInfo.hpp"
@@ -238,7 +239,7 @@ struct TestMetavariables {
 static const std::vector<void (*)()> charm_init_node_funcs{
     &setup_error_handling, &setup_memory_allocation_failure_reporting};
 static const std::vector<void (*)()> charm_init_proc_funcs{
-    &enable_floating_point_exceptions};
+    &enable_floating_point_exceptions, &enable_segfault_handler};
 
 using charmxx_main_component = Parallel::Main<TestMetavariables>;
 

--- a/tests/Unit/Parallel/Test_DetectHangArray.cpp
+++ b/tests/Unit/Parallel/Test_DetectHangArray.cpp
@@ -32,6 +32,7 @@
 #include "Utilities/Algorithm.hpp"
 #include "Utilities/Blas.hpp"
 #include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
+#include "Utilities/ErrorHandling/SegfaultHandler.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MemoryHelpers.hpp"
 #include "Utilities/System/ParallelInfo.hpp"
@@ -233,7 +234,7 @@ static const std::vector<void (*)()> charm_init_node_funcs{
     &setup_error_handling, &setup_memory_allocation_failure_reporting,
     &disable_openblas_multithreading};
 static const std::vector<void (*)()> charm_init_proc_funcs{
-    &enable_floating_point_exceptions};
+    &enable_floating_point_exceptions, &enable_segfault_handler};
 
 using charmxx_main_component = Parallel::Main<TestMetavariables>;
 

--- a/tests/Unit/Parallel/Test_DynamicInsertion.cpp
+++ b/tests/Unit/Parallel/Test_DynamicInsertion.cpp
@@ -25,6 +25,7 @@
 #include "ParallelAlgorithms/Amr/Actions/Component.hpp"
 #include "ParallelAlgorithms/Initialization/MutateAssign.hpp"
 #include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
+#include "Utilities/ErrorHandling/SegfaultHandler.hpp"
 #include "Utilities/MemoryHelpers.hpp"
 #include "Utilities/Serialization/RegisterDerivedClassesWithCharm.hpp"
 #include "Utilities/TMPL.hpp"
@@ -364,7 +365,7 @@ static const std::vector<void (*)()> charm_init_node_funcs{
     &setup_error_handling, &setup_memory_allocation_failure_reporting,
     &register_callback};
 static const std::vector<void (*)()> charm_init_proc_funcs{
-    &enable_floating_point_exceptions};
+    &enable_floating_point_exceptions, &enable_segfault_handler};
 
 using charmxx_main_component = Parallel::Main<TestMetavariables>;
 

--- a/tests/Unit/Parallel/Test_GlobalCache.cpp
+++ b/tests/Unit/Parallel/Test_GlobalCache.cpp
@@ -32,6 +32,7 @@
 #include "Parallel/ResourceInfo.hpp"
 #include "Parallel/Tags/ResourceInfo.hpp"
 #include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
+#include "Utilities/ErrorHandling/SegfaultHandler.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MemoryHelpers.hpp"
 #include "Utilities/Serialization/CharmPupable.hpp"
@@ -587,7 +588,7 @@ PUP::able::PUP_ID Arthropod::my_PUP_ID = 0;  // NOLINT
 static const std::vector<void (*)()> charm_init_node_funcs{
     &setup_error_handling, &setup_memory_allocation_failure_reporting};
 static const std::vector<void (*)()> charm_init_proc_funcs{
-    &enable_floating_point_exceptions};
+    &enable_floating_point_exceptions, &enable_segfault_handler};
 
 using charmxx_main_component = Test_GlobalCache<TestMetavariables>;
 

--- a/tests/Unit/Parallel/Test_PhaseChangeMain.cpp
+++ b/tests/Unit/Parallel/Test_PhaseChangeMain.cpp
@@ -31,6 +31,7 @@
 #include "Parallel/PhaseDependentActionList.hpp"
 #include "ParallelAlgorithms/Initialization/MutateAssign.hpp"
 #include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
+#include "Utilities/ErrorHandling/SegfaultHandler.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MemoryHelpers.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
@@ -235,7 +236,7 @@ struct TestMetavariables {
 static const std::vector<void (*)()> charm_init_node_funcs{
     &setup_error_handling, &setup_memory_allocation_failure_reporting};
 static const std::vector<void (*)()> charm_init_proc_funcs{
-    &enable_floating_point_exceptions};
+    &enable_floating_point_exceptions, &enable_segfault_handler};
 
 using charmxx_main_component = Parallel::Main<TestMetavariables>;
 

--- a/tests/Unit/Parallel/Test_SectionReductions.cpp
+++ b/tests/Unit/Parallel/Test_SectionReductions.cpp
@@ -29,6 +29,7 @@
 #include "Parallel/Tags/Section.hpp"
 #include "ParallelAlgorithms/Actions/TerminatePhase.hpp"
 #include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
+#include "Utilities/ErrorHandling/SegfaultHandler.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MemoryHelpers.hpp"
 #include "Utilities/System/ParallelInfo.hpp"
@@ -233,7 +234,7 @@ struct Metavariables {
 static const std::vector<void (*)()> charm_init_node_funcs{
     &setup_error_handling, &setup_memory_allocation_failure_reporting};
 static const std::vector<void (*)()> charm_init_proc_funcs{
-    &enable_floating_point_exceptions};
+    &enable_floating_point_exceptions, &enable_segfault_handler};
 
 using charmxx_main_component = Parallel::Main<Metavariables>;
 

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/ConjugateGradient/Test_ConjugateGradientAlgorithm.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/ConjugateGradient/Test_ConjugateGradientAlgorithm.cpp
@@ -10,6 +10,7 @@
 #include "Parallel/Main.hpp"
 #include "ParallelAlgorithms/LinearSolver/ConjugateGradient/ConjugateGradient.hpp"
 #include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
+#include "Utilities/ErrorHandling/SegfaultHandler.hpp"
 #include "Utilities/MemoryHelpers.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -50,7 +51,7 @@ struct Metavariables {
 static const std::vector<void (*)()> charm_init_node_funcs{
     &setup_error_handling, &setup_memory_allocation_failure_reporting};
 static const std::vector<void (*)()> charm_init_proc_funcs{
-    &enable_floating_point_exceptions};
+    &enable_floating_point_exceptions, &enable_segfault_handler};
 
 using charmxx_main_component = Parallel::Main<Metavariables>;
 

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/ConjugateGradient/Test_DistributedConjugateGradientAlgorithm.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/ConjugateGradient/Test_DistributedConjugateGradientAlgorithm.cpp
@@ -16,6 +16,7 @@
 #include "Parallel/Main.hpp"
 #include "ParallelAlgorithms/LinearSolver/ConjugateGradient/ConjugateGradient.hpp"
 #include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
+#include "Utilities/ErrorHandling/SegfaultHandler.hpp"
 #include "Utilities/MemoryHelpers.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/TMPL.hpp"
@@ -70,7 +71,7 @@ static const std::vector<void (*)()> charm_init_node_funcs{
     &domain::creators::register_derived_with_charm,
     &TestHelpers::domain::BoundaryConditions::register_derived_with_charm};
 static const std::vector<void (*)()> charm_init_proc_funcs{
-    &enable_floating_point_exceptions};
+    &enable_floating_point_exceptions, &enable_segfault_handler};
 
 using charmxx_main_component = Parallel::Main<Metavariables>;
 

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/Test_DistributedGmresAlgorithm.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/Test_DistributedGmresAlgorithm.cpp
@@ -16,6 +16,7 @@
 #include "Parallel/Main.hpp"
 #include "ParallelAlgorithms/LinearSolver/Gmres/Gmres.hpp"
 #include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
+#include "Utilities/ErrorHandling/SegfaultHandler.hpp"
 #include "Utilities/MemoryHelpers.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/TMPL.hpp"
@@ -69,7 +70,7 @@ static const std::vector<void (*)()> charm_init_node_funcs{
     &setup_error_handling, &setup_memory_allocation_failure_reporting,
     &domain::creators::register_derived_with_charm};
 static const std::vector<void (*)()> charm_init_proc_funcs{
-    &enable_floating_point_exceptions};
+    &enable_floating_point_exceptions, &enable_segfault_handler};
 
 using charmxx_main_component = Parallel::Main<Metavariables>;
 

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/Test_DistributedGmresPreconditionedAlgorithm.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/Test_DistributedGmresPreconditionedAlgorithm.cpp
@@ -17,6 +17,7 @@
 #include "ParallelAlgorithms/LinearSolver/Gmres/Gmres.hpp"
 #include "ParallelAlgorithms/LinearSolver/Richardson/Richardson.hpp"
 #include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
+#include "Utilities/ErrorHandling/SegfaultHandler.hpp"
 #include "Utilities/MemoryHelpers.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/TMPL.hpp"
@@ -77,7 +78,7 @@ static const std::vector<void (*)()> charm_init_node_funcs{
     &setup_error_handling, &setup_memory_allocation_failure_reporting,
     &domain::creators::register_derived_with_charm};
 static const std::vector<void (*)()> charm_init_proc_funcs{
-    &enable_floating_point_exceptions};
+    &enable_floating_point_exceptions, &enable_segfault_handler};
 
 using charmxx_main_component = Parallel::Main<Metavariables>;
 

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/Test_GmresAlgorithm.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/Test_GmresAlgorithm.cpp
@@ -10,6 +10,7 @@
 #include "Parallel/Main.hpp"
 #include "ParallelAlgorithms/LinearSolver/Gmres/Gmres.hpp"
 #include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
+#include "Utilities/ErrorHandling/SegfaultHandler.hpp"
 #include "Utilities/MemoryHelpers.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -50,7 +51,7 @@ struct Metavariables {
 static const std::vector<void (*)()> charm_init_node_funcs{
     &setup_error_handling, &setup_memory_allocation_failure_reporting};
 static const std::vector<void (*)()> charm_init_proc_funcs{
-    &enable_floating_point_exceptions};
+    &enable_floating_point_exceptions, &enable_segfault_handler};
 
 using charmxx_main_component = Parallel::Main<Metavariables>;
 

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/Test_GmresPreconditionedAlgorithm.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/Test_GmresPreconditionedAlgorithm.cpp
@@ -11,6 +11,7 @@
 #include "ParallelAlgorithms/LinearSolver/Gmres/Gmres.hpp"
 #include "ParallelAlgorithms/LinearSolver/Richardson/Richardson.hpp"
 #include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
+#include "Utilities/ErrorHandling/SegfaultHandler.hpp"
 #include "Utilities/MemoryHelpers.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -57,7 +58,7 @@ struct Metavariables {
 static const std::vector<void (*)()> charm_init_node_funcs{
     &setup_error_handling, &setup_memory_allocation_failure_reporting};
 static const std::vector<void (*)()> charm_init_proc_funcs{
-    &enable_floating_point_exceptions};
+    &enable_floating_point_exceptions, &enable_segfault_handler};
 
 using charmxx_main_component = Parallel::Main<Metavariables>;
 

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Multigrid/Test_MultigridAlgorithm.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Multigrid/Test_MultigridAlgorithm.cpp
@@ -24,6 +24,7 @@
 #include "ParallelAlgorithms/LinearSolver/Multigrid/Tags.hpp"
 #include "ParallelAlgorithms/LinearSolver/Richardson/Richardson.hpp"
 #include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
+#include "Utilities/ErrorHandling/SegfaultHandler.hpp"
 #include "Utilities/MemoryHelpers.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/TMPL.hpp"
@@ -136,7 +137,7 @@ static const std::vector<void (*)()> charm_init_node_funcs{
     &setup_error_handling, &setup_memory_allocation_failure_reporting,
     &domain::creators::register_derived_with_charm};
 static const std::vector<void (*)()> charm_init_proc_funcs{
-    &enable_floating_point_exceptions};
+    &enable_floating_point_exceptions, &enable_segfault_handler};
 
 using charmxx_main_component = Parallel::Main<Metavariables>;
 

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Multigrid/Test_MultigridPreconditionedGmresAlgorithm.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Multigrid/Test_MultigridPreconditionedGmresAlgorithm.cpp
@@ -26,6 +26,7 @@
 #include "ParallelAlgorithms/LinearSolver/Richardson/Richardson.hpp"
 #include "ParallelAlgorithms/NonlinearSolver/NewtonRaphson/NewtonRaphson.hpp"
 #include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
+#include "Utilities/ErrorHandling/SegfaultHandler.hpp"
 #include "Utilities/MemoryHelpers.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/TMPL.hpp"
@@ -172,7 +173,7 @@ static const std::vector<void (*)()> charm_init_node_funcs{
     &setup_error_handling, &setup_memory_allocation_failure_reporting,
     &domain::creators::register_derived_with_charm};
 static const std::vector<void (*)()> charm_init_proc_funcs{
-    &enable_floating_point_exceptions};
+    &enable_floating_point_exceptions, &enable_segfault_handler};
 
 using charmxx_main_component = Parallel::Main<Metavariables>;
 

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Richardson/Test_DistributedRichardsonAlgorithm.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Richardson/Test_DistributedRichardsonAlgorithm.cpp
@@ -16,6 +16,7 @@
 #include "Parallel/Main.hpp"
 #include "ParallelAlgorithms/LinearSolver/Richardson/Richardson.hpp"
 #include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
+#include "Utilities/ErrorHandling/SegfaultHandler.hpp"
 #include "Utilities/MemoryHelpers.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/TMPL.hpp"
@@ -69,7 +70,7 @@ static const std::vector<void (*)()> charm_init_node_funcs{
     &domain::creators::register_derived_with_charm,
     &TestHelpers::domain::BoundaryConditions::register_derived_with_charm};
 static const std::vector<void (*)()> charm_init_proc_funcs{
-    &enable_floating_point_exceptions};
+    &enable_floating_point_exceptions, &enable_segfault_handler};
 
 using charmxx_main_component = Parallel::Main<Metavariables>;
 

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Richardson/Test_RichardsonAlgorithm.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Richardson/Test_RichardsonAlgorithm.cpp
@@ -10,6 +10,7 @@
 #include "Parallel/Main.hpp"
 #include "ParallelAlgorithms/LinearSolver/Richardson/Richardson.hpp"
 #include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
+#include "Utilities/ErrorHandling/SegfaultHandler.hpp"
 #include "Utilities/MemoryHelpers.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -50,7 +51,7 @@ struct Metavariables {
 static const std::vector<void (*)()> charm_init_node_funcs{
     &setup_error_handling, &setup_memory_allocation_failure_reporting};
 static const std::vector<void (*)()> charm_init_proc_funcs{
-    &enable_floating_point_exceptions};
+    &enable_floating_point_exceptions, &enable_segfault_handler};
 
 using charmxx_main_component = Parallel::Main<Metavariables>;
 

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Schwarz/Test_SchwarzAlgorithm.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Schwarz/Test_SchwarzAlgorithm.cpp
@@ -30,6 +30,7 @@
 #include "ParallelAlgorithms/LinearSolver/Schwarz/Schwarz.hpp"
 #include "ParallelAlgorithms/LinearSolver/Schwarz/SubdomainOperator.hpp"
 #include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
+#include "Utilities/ErrorHandling/SegfaultHandler.hpp"
 #include "Utilities/MakeArray.hpp"
 #include "Utilities/MemoryHelpers.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
@@ -209,7 +210,7 @@ static const std::vector<void (*)()> charm_init_node_funcs{
         Metavariables::linear_solver::subdomain_solver>,
     &TestHelpers::domain::BoundaryConditions::register_derived_with_charm};
 static const std::vector<void (*)()> charm_init_proc_funcs{
-    &enable_floating_point_exceptions};
+    &enable_floating_point_exceptions, &enable_segfault_handler};
 
 using charmxx_main_component = Parallel::Main<Metavariables>;
 

--- a/tests/Unit/ParallelAlgorithms/NonlinearSolver/NewtonRaphson/Test_NewtonRaphsonAlgorithm.cpp
+++ b/tests/Unit/ParallelAlgorithms/NonlinearSolver/NewtonRaphson/Test_NewtonRaphsonAlgorithm.cpp
@@ -14,6 +14,7 @@
 #include "ParallelAlgorithms/LinearSolver/Gmres/Gmres.hpp"
 #include "ParallelAlgorithms/NonlinearSolver/NewtonRaphson/NewtonRaphson.hpp"
 #include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
+#include "Utilities/ErrorHandling/SegfaultHandler.hpp"
 #include "Utilities/MemoryHelpers.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -105,7 +106,7 @@ struct Metavariables {
 static const std::vector<void (*)()> charm_init_node_funcs{
     &setup_error_handling, &setup_memory_allocation_failure_reporting};
 static const std::vector<void (*)()> charm_init_proc_funcs{
-    &enable_floating_point_exceptions};
+    &enable_floating_point_exceptions, &enable_segfault_handler};
 
 using charmxx_main_component = Parallel::Main<Metavariables>;
 

--- a/tests/Unit/RunSingleTest/RunSingleTest.cpp
+++ b/tests/Unit/RunSingleTest/RunSingleTest.cpp
@@ -18,6 +18,7 @@
 #include "Parallel/InitializationFunctions.hpp"
 #include "Parallel/Printf.hpp"
 #include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
+#include "Utilities/ErrorHandling/SegfaultHandler.hpp"
 #include "Utilities/System/Abort.hpp"
 #include "Utilities/System/Exit.hpp"
 
@@ -25,6 +26,7 @@ RunTests::RunTests(CkArgMsg* msg) {
   setup_error_handling();
   Parallel::printf("%s", info_from_build().c_str());
   enable_floating_point_exceptions();
+  enable_segfault_handler();
   Catch::StringMaker<double>::precision =
       std::numeric_limits<double>::max_digits10;
   Catch::StringMaker<float>::precision =

--- a/tests/Unit/RunTests.cpp
+++ b/tests/Unit/RunTests.cpp
@@ -19,6 +19,7 @@
 #include "Parallel/InitializationFunctions.hpp"
 #include "Parallel/Printf.hpp"
 #include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
+#include "Utilities/ErrorHandling/SegfaultHandler.hpp"
 #include "Utilities/MemoryHelpers.hpp"
 #include "Utilities/System/Abort.hpp"
 #include "Utilities/System/Exit.hpp"
@@ -30,6 +31,7 @@ RunTests::RunTests(CkArgMsg* msg) {
   register_run_tests_libs();
   Parallel::printf("%s", info_from_build().c_str());
   enable_floating_point_exceptions();
+  enable_segfault_handler();
   Catch::StringMaker<double>::precision =
       std::numeric_limits<double>::max_digits10;
   Catch::StringMaker<float>::precision =


### PR DESCRIPTION
## Proposed changes

This seems to work on the machines that I have tested (Wheeler, macOS, CI container). It would have saved me so much time and sanity over the years. The printed stacktraces are improved a lot by #3907.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
