### PR TITLE
Add Pybindings for Weyl Electric

### DIFF
--- a/src/PointwiseFunctions/GeneralRelativity/Python/Bindings.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/Python/Bindings.cpp
@@ -15,6 +15,7 @@
 #include "PointwiseFunctions/GeneralRelativity/Shift.hpp"
 #include "PointwiseFunctions/GeneralRelativity/SpacetimeNormalOneForm.hpp"
 #include "PointwiseFunctions/GeneralRelativity/SpacetimeNormalVector.hpp"
+#include "PointwiseFunctions/GeneralRelativity/WeylElectric.hpp"
 #include "PointwiseFunctions/GeneralRelativity/WeylMagnetic.hpp"
 #include "PointwiseFunctions/GeneralRelativity/WeylPropagating.hpp"
 
@@ -124,15 +125,28 @@ void bind_impl(py::module& m) {  // NOLINT
       py::arg("spacetime_metric"), py::arg("inverse_spatial_metric"));
 
   m.def("spacetime_normal_one_form",
-        static_cast<tnsr::a<DataVector, 3> (*)(const Scalar<DataVector>&)>(
+        static_cast<tnsr::a<DataVector, Dim> (*)(const Scalar<DataVector>&)>(
             &::gr::spacetime_normal_one_form),
         py::arg("lapse"));
 
   m.def("spacetime_normal_vector",
-        static_cast<tnsr::A<DataVector, 3> (*)(const Scalar<DataVector>&,
-                                               const tnsr::I<DataVector, 3>&)>(
+        static_cast<tnsr::A<DataVector, Dim> (*)(
+            const Scalar<DataVector>&, const tnsr::I<DataVector, Dim>&)>(
             &::gr::spacetime_normal_vector),
         py::arg("lapse"), py::arg("shift"));
+
+  m.def("weyl_electric",
+        static_cast<tnsr::ii<DataVector, Dim> (*)(
+            const tnsr::ii<DataVector, Dim>&, const tnsr::ii<DataVector, Dim>&,
+            const tnsr::II<DataVector, Dim>&)>(&::gr::weyl_electric),
+        py::arg("spatial_ricci"), py::arg("extrinsic_curvature"),
+        py::arg("inverse_spatial_metric"));
+
+  m.def("weyl_electric_scalar",
+        static_cast<Scalar<DataVector> (*)(const tnsr::ii<DataVector, Dim>&,
+                                           const tnsr::II<DataVector, Dim>&)>(
+            &::gr::weyl_electric_scalar),
+        py::arg("weyl_electric"), py::arg("inverse_spatial_metric"));
 
   m.def("weyl_magnetic",
         static_cast<tnsr::ii<DataVector, 3, Frame::Inertial> (*)(

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Python/Test_Bindings.py
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Python/Test_Bindings.py
@@ -94,6 +94,15 @@ class TestBindings(unittest.TestCase):
         inverse_metric = tnsr.AA[DataVector, 3](num_points=1, fill=0.)
         ricci_scalar(spatial_ricci, inverse_metric)
 
+    def test_weyl_electric(self):
+        spatial_ricci = tnsr.ii[DataVector, 3](num_points=1, fill=0.)
+        extrinsic_curvature = tnsr.ii[DataVector, 3](num_points=1, fill=0.)
+        inverse_spatial_metric = tnsr.II[DataVector, 3](num_points=1, fill=1.)
+        weyl_electric_tensor = weyl_electric(spatial_ricci,
+                                             extrinsic_curvature,
+                                             inverse_spatial_metric)
+        weyl_electric_scalar(weyl_electric_tensor, inverse_spatial_metric)
+
     def test_weyl_propagating(self):
         ricci = tnsr.ii[DataVector, 3](num_points=1, fill=0.)
         extrinsic_curvature = tnsr.ii[DataVector, 3](num_points=1, fill=0.)


### PR DESCRIPTION
## Proposed changes

I added Pybindings for Weyl Electric. I also noticed that two functions were not templated for Dim, so I changed that as well.

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

