### PR TITLE
Add computation of inertial center(s) of mass in GhGrmhd code

### DIFF
--- a/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
+++ b/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
@@ -404,6 +404,11 @@ struct GhValenciaDivCleanTemplateBase<
                      hydro::Tags::MassWeightedKineticEnergyCompute<DataVector>,
                      hydro::Tags::TildeDUnboundUtCriterionCompute<
                          DataVector, volume_dim, domain_frame>,
+                     hydro::Tags::MassWeightedCoordsCompute<
+                         DataVector, volume_dim, ::domain::ObjectLabel::None,
+                         Events::Tags::ObserverCoordinates<3, Frame::Grid>,
+                         Events::Tags::ObserverCoordinates<3, Frame::Inertial>,
+                         Frame::Inertial>,
                      gr::Tags::SpacetimeNormalOneFormCompute<
                          DataVector, volume_dim, domain_frame>,
                      gr::Tags::SpacetimeNormalVectorCompute<
@@ -439,7 +444,12 @@ struct GhValenciaDivCleanTemplateBase<
       tmpl::list<hydro::Tags::MassWeightedInternalEnergyCompute<DataVector>,
                  hydro::Tags::MassWeightedKineticEnergyCompute<DataVector>,
                  hydro::Tags::TildeDUnboundUtCriterionCompute<
-                     DataVector, volume_dim, domain_frame>>>;
+                     DataVector, volume_dim, domain_frame>,
+                 hydro::Tags::MassWeightedCoordsCompute<
+                     DataVector, volume_dim, ::domain::ObjectLabel::None,
+                     Events::Tags::ObserverCoordinates<3, Frame::Grid>,
+                     Events::Tags::ObserverCoordinates<3, Frame::Inertial>,
+                     Frame::Inertial>>>;
 
   using non_tensor_compute_tags = tmpl::append<
       tmpl::conditional_t<

--- a/src/PointwiseFunctions/Hydro/MassWeightedFluidItems.cpp
+++ b/src/PointwiseFunctions/Hydro/MassWeightedFluidItems.cpp
@@ -50,6 +50,27 @@ void tilde_d_unbound_ut_criterion(
   result->get() = get(tilde_d) * step_function(-1.0 - result->get());
 }
 
+template <domain::ObjectLabel Label, typename DataType, size_t Dim, typename Fr>
+void mass_weighted_coords(
+    const gsl::not_null<tnsr::I<DataType, Dim, Fr>*> result,
+    const Scalar<DataType>& tilde_d,
+    const tnsr::I<DataType, Dim, Frame::Grid>& grid_coords,
+    const tnsr::I<DataType, Dim, Fr>& compute_coords) {
+  for (size_t i = 0; i < Dim; i++) {
+    result->get(i) = get(tilde_d) * (compute_coords.get(i));
+    switch (Label) {
+      case ::domain::ObjectLabel::A:
+        result->get(i) *= step_function(get<0>(grid_coords));
+        break;
+      case ::domain::ObjectLabel::B:
+        result->get(i) *= step_function(get<0>(grid_coords) * (-1.0));
+        break;
+      default:
+        break;
+    }
+  }
+}
+
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 
 #define INSTANTIATE(_, data)                                                   \
@@ -72,6 +93,25 @@ void tilde_d_unbound_ut_criterion(
 GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
 
 #undef DIM
+#undef INSTANTIATE
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define OBJECT(data) BOOST_PP_TUPLE_ELEM(1, data)
+
+#define INSTANTIATE(_, data)                                                \
+  template void mass_weighted_coords<OBJECT(data)>(                         \
+      const gsl::not_null<tnsr::I<DataVector, DIM(data), Frame::Inertial>*> \
+          result,                                                           \
+      const Scalar<DataVector>& tilde_d,                                    \
+      const tnsr::I<DataVector, DIM(data), Frame::Grid>& dg_grid_coords,    \
+      const tnsr::I<DataVector, DIM(data), Frame::Inertial>& dg_coords);
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3),
+                        (::domain::ObjectLabel::None, ::domain::ObjectLabel::A,
+                         ::domain::ObjectLabel::B))
+
+#undef DIM
+#undef OBJECT
 #undef INSTANTIATE
 
 template void mass_weighted_internal_energy(

--- a/tests/Unit/PointwiseFunctions/Hydro/TestFunctions.py
+++ b/tests/Unit/PointwiseFunctions/Hydro/TestFunctions.py
@@ -24,6 +24,18 @@ def tilde_d_unbound_ut_criterion(
     return tilde_d * (u_t < -1.0)
 
 
+def mass_weighted_coords_none(tilde_d, grid_coords, compute_coords):
+    return tilde_d * compute_coords
+
+
+def mass_weighted_coords_a(tilde_d, grid_coords, compute_coords):
+    return tilde_d * compute_coords * np.heaviside(grid_coords, 0)
+
+
+def mass_weighted_coords_b(tilde_d, grid_coords, compute_coords):
+    return tilde_d * compute_coords * np.heaviside(grid_coords * (-1.0), 0)
+
+
 # Functions testing the MassWeightedFluidItems
 
 

--- a/tests/Unit/PointwiseFunctions/Hydro/Test_MassWeightedFluidItems.cpp
+++ b/tests/Unit/PointwiseFunctions/Hydro/Test_MassWeightedFluidItems.cpp
@@ -8,6 +8,7 @@
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/Structure/ObjectLabel.hpp"
 #include "Framework/CheckWithRandomValues.hpp"
 #include "Framework/SetupLocalPythonEnvironment.hpp"
 #include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
@@ -29,6 +30,36 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.Hydro.MassWeightedFluidItems",
   pypp::check_with_random_values<1>(
       &tilde_d_unbound_ut_criterion<DataVector, 1, Frame::Inertial>,
       "TestFunctions", {"tilde_d_unbound_ut_criterion"}, {{{0.0, 1.0}}},
+      used_for_size);
+  pypp::check_with_random_values<1>(
+      &mass_weighted_coords<::domain::ObjectLabel::None, DataVector, 1,
+                            Frame::Inertial>,
+      "TestFunctions", {"mass_weighted_coords_none"}, {{{0.0, 1.0}}},
+      used_for_size);
+  pypp::check_with_random_values<3>(
+      &mass_weighted_coords<::domain::ObjectLabel::None, DataVector, 3,
+                            Frame::Inertial>,
+      "TestFunctions", {"mass_weighted_coords_none"}, {{{0.0, 1.0}}},
+      used_for_size);
+  pypp::check_with_random_values<1>(
+      &mass_weighted_coords<::domain::ObjectLabel::A, DataVector, 1,
+                            Frame::Inertial>,
+      "TestFunctions", {"mass_weighted_coords_a"}, {{{-1.0, 1.0}}},
+      used_for_size);
+  pypp::check_with_random_values<3>(
+      &mass_weighted_coords<::domain::ObjectLabel::A, DataVector, 3,
+                            Frame::Inertial>,
+      "TestFunctions", {"mass_weighted_coords_a"}, {{{-1.0, 1.0}}},
+      used_for_size);
+  pypp::check_with_random_values<1>(
+      &mass_weighted_coords<::domain::ObjectLabel::B, DataVector, 1,
+                            Frame::Inertial>,
+      "TestFunctions", {"mass_weighted_coords_b"}, {{{-1.0, 1.0}}},
+      used_for_size);
+  pypp::check_with_random_values<3>(
+      &mass_weighted_coords<::domain::ObjectLabel::B, DataVector, 3,
+                            Frame::Inertial>,
+      "TestFunctions", {"mass_weighted_coords_b"}, {{{-1.0, 1.0}}},
       used_for_size);
 }
 


### PR DESCRIPTION
## Proposed changes

Add 3 new integrands for the volume integral observer in Gh-Grmhd providing 
(a) the global center of mass in inertial coordinates
(b) the center of mass in inertial coordinates for matter with coordinate grid x>0
(c) the center of mass in inertial coordinates for matter with coordinate grid x<0
The second and third are expected to be the centers of the two NSs in BNS mergers.

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.