### PR TITLE
Use correct mesh and jacobian for integrals with subcell

### DIFF
--- a/src/Elliptic/Executables/Elasticity/SolveElasticity.hpp
+++ b/src/Elliptic/Executables/Elasticity/SolveElasticity.hpp
@@ -171,6 +171,8 @@ struct Metavariables {
                  domain::Tags::Coordinates<volume_dim, Frame::Inertial>>>;
   using observer_compute_tags =
       tmpl::list<::Events::Tags::ObserverMeshCompute<volume_dim>,
+                 ::Events::Tags::ObserverDetInvJacobianCompute<
+                     Frame::ElementLogical, Frame::Inertial>,
                  error_compute>;
 
   // Collect all items to store in the cache.

--- a/src/Elliptic/Executables/Punctures/SolvePunctures.hpp
+++ b/src/Elliptic/Executables/Punctures/SolvePunctures.hpp
@@ -66,7 +66,9 @@ struct Metavariables {
                  domain::Tags::RadiallyCompressedCoordinatesCompute<
                      volume_dim, Frame::Inertial>>>;
   using observer_compute_tags =
-      tmpl::list<::Events::Tags::ObserverMeshCompute<volume_dim>>;
+      tmpl::list<::Events::Tags::ObserverMeshCompute<volume_dim>,
+                 ::Events::Tags::ObserverDetInvJacobianCompute<
+                     Frame::ElementLogical, Frame::Inertial>>;
 
   struct factory_creation
       : tt::ConformsTo<Options::protocols::FactoryCreation> {

--- a/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
+++ b/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
@@ -152,8 +152,10 @@ struct EvolutionMetavars {
       domain::Tags::Coordinates<volume_dim, Frame::Grid>,
       domain::Tags::Coordinates<volume_dim, Frame::Inertial>>;
   using non_tensor_compute_tags =
-      tmpl::list<::Events::Tags::ObserverMeshCompute<volume_dim>, deriv_compute,
-                 analytic_compute, error_compute>;
+      tmpl::list<::Events::Tags::ObserverMeshCompute<volume_dim>,
+                 ::Events::Tags::ObserverDetInvJacobianCompute<
+                     Frame::ElementLogical, Frame::Inertial>,
+                 deriv_compute, analytic_compute, error_compute>;
 
   struct factory_creation
       : tt::ConformsTo<Options::protocols::FactoryCreation> {

--- a/src/ParallelAlgorithms/Events/ObserveVolumeIntegrals.hpp
+++ b/src/ParallelAlgorithms/Events/ObserveVolumeIntegrals.hpp
@@ -119,12 +119,12 @@ class ObserveVolumeIntegrals<
   using compute_tags_for_observation_box =
       tmpl::list<Tensors..., NonTensorComputeTags...>;
 
-  using argument_tags = tmpl::list<
-      ::Tags::ObservationBox, ObservationValueTag,
-      ::Events::Tags::ObserverMesh<VolumeDim>,
-      ::Events::Tags::ObserverDetInvJacobian<Frame::ElementLogical,
-                                           Frame::Inertial>,
-      Tensors...>;
+  using argument_tags =
+      tmpl::list<::Tags::ObservationBox, ObservationValueTag,
+                 ::Events::Tags::ObserverMesh<VolumeDim>,
+                 ::Events::Tags::ObserverDetInvJacobian<Frame::ElementLogical,
+                                                        Frame::Inertial>,
+                 Tensors...>;
 
   template <typename DataBoxType, typename ComputeTagsList,
             typename Metavariables, typename ArrayIndex,

--- a/src/ParallelAlgorithms/Events/ObserveVolumeIntegrals.hpp
+++ b/src/ParallelAlgorithms/Events/ObserveVolumeIntegrals.hpp
@@ -28,6 +28,7 @@
 #include "Parallel/Invoke.hpp"
 #include "Parallel/Local.hpp"
 #include "Parallel/Reduction.hpp"
+#include "ParallelAlgorithms/Events/Tags.hpp"
 #include "ParallelAlgorithms/EventsAndTriggers/Event.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/Functional.hpp"
@@ -120,8 +121,9 @@ class ObserveVolumeIntegrals<
 
   using argument_tags = tmpl::list<
       ::Tags::ObservationBox, ObservationValueTag,
-      domain::Tags::Mesh<VolumeDim>,
-      domain::Tags::DetInvJacobian<Frame::ElementLogical, Frame::Inertial>,
+      ::Events::Tags::ObserverMesh<VolumeDim>,
+      ::Events::Tags::ObserverDetInvJacobian<Frame::ElementLogical,
+                                           Frame::Inertial>,
       Tensors...>;
 
   template <typename DataBoxType, typename ComputeTagsList,

--- a/tests/Unit/ParallelAlgorithms/Events/Test_ObserveVolumeIntegrals.cpp
+++ b/tests/Unit/ParallelAlgorithms/Events/Test_ObserveVolumeIntegrals.cpp
@@ -259,8 +259,9 @@ void test_observe(const std::unique_ptr<ObserveEvent> observe,
   const double observation_time = 2.0;
   const auto box = db::create<db::AddSimpleTags<
       Parallel::Tags::MetavariablesImpl<metavariables>, ObservationTimeTag,
-      domain::Tags::Mesh<VolumeDim>,
-      domain::Tags::DetInvJacobian<Frame::ElementLogical, Frame::Inertial>,
+      ::Events::Tags::ObserverMesh<VolumeDim>,
+      ::Events::Tags::ObserverDetInvJacobian<Frame::ElementLogical,
+                                             Frame::Inertial>,
       Tags::Variables<typename decltype(vars)::tags_list>,
       observers::Tags::ObservationKey<ArraySectionIdTag>>>(
       metavariables{}, observation_time, mesh, det_inv_jacobian, vars, section);


### PR DESCRIPTION
## Proposed changes

Modify ObserveVolumeIntegrals so that it uses the Dg or Subcell mesh as appropriate.

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.