### PR TITLE
Add RAII class for saving and restoring FPE state

### DIFF
--- a/src/ApparentHorizons/StrahlkorperInDifferentFrame.cpp
+++ b/src/ApparentHorizons/StrahlkorperInDifferentFrame.cpp
@@ -7,6 +7,7 @@
 #include <cstddef>
 #include <optional>
 #include <stdexcept>
+#include <tuple>
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tags/TempTensor.hpp"
@@ -210,7 +211,9 @@ void strahlkorper_in_different_frame(
   };
 
   // We try to roughly bracket the root between r_min and r_max.
-  const auto [r_min, r_max] = [&dest_cartesian_coords, &center_dest]() {
+  double r_min{};
+  double r_max{};
+  std::tie(r_min, r_max) = [&dest_cartesian_coords, &center_dest]() {
     const DataVector dest_radius =
         sqrt(square(get<0>(dest_cartesian_coords) - center_dest[0]) +
              square(get<1>(dest_cartesian_coords) - center_dest[1]) +

--- a/src/ControlSystem/Tags/FunctionsOfTimeInitialize.cpp
+++ b/src/ControlSystem/Tags/FunctionsOfTimeInitialize.cpp
@@ -18,7 +18,9 @@ void check_expiration_time_consistency(
     const std::unordered_map<
         std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
         functions_of_time) {
-  for (const auto& [name, expr_time] : initial_expiration_times) {
+  for (const auto& expiration_entry : initial_expiration_times) {
+    const auto& name = expiration_entry.first;
+    const auto& expr_time = expiration_entry.second;
     // Only need to check the expiration times if the control system is active
     if (is_active_map.at(name)) {
       if (functions_of_time.count(name) == 0) {

--- a/src/Domain/CoordinateMaps/CoordinateMapHelpers.hpp
+++ b/src/Domain/CoordinateMaps/CoordinateMapHelpers.hpp
@@ -48,10 +48,8 @@ void apply_map(
          "A function of time must be present if the maps are time-dependent.");
   ASSERT(
       [t]() {
-        disable_floating_point_exceptions();
-        const bool isnan = std::isnan(t);
-        enable_floating_point_exceptions();
-        return not isnan;
+        const ScopedFpeState disable_fpes(false);
+        return not std::isnan(t);
       }(),
       "The time must not be NaN for time-dependent maps.");
   *t_map_point = the_map(*t_map_point, t, functions_of_time);
@@ -91,10 +89,8 @@ auto apply_map(
          "A function of time must be present if the maps are time-dependent.");
   ASSERT(
       [t]() {
-        disable_floating_point_exceptions();
-        const bool isnan = std::isnan(t);
-        enable_floating_point_exceptions();
-        return not isnan;
+        const ScopedFpeState disable_fpes(false);
+        return not std::isnan(t);
       }(),
       "The time must not be NaN for time-dependent maps.");
   return the_map(source_points, t, functions_of_time);
@@ -134,10 +130,8 @@ auto apply_inverse_map(
          "A function of time must be present if the maps are time-dependent.");
   ASSERT(
       [t]() {
-        disable_floating_point_exceptions();
-        const bool isnan = std::isnan(t);
-        enable_floating_point_exceptions();
-        return not isnan;
+        const ScopedFpeState disable_fpes(false);
+        return not std::isnan(t);
       }(),
       "The time must not be NaN for time-dependent maps.");
   return the_map.inverse(target_points, t, functions_of_time);
@@ -171,10 +165,8 @@ auto apply_frame_velocity(
          "A function of time must be present if the maps are time-dependent.");
   ASSERT(
       [t]() {
-        disable_floating_point_exceptions();
-        const bool isnan = std::isnan(t);
-        enable_floating_point_exceptions();
-        return not isnan;
+        const ScopedFpeState disable_fpes(false);
+        return not std::isnan(t);
       }(),
       "The time must not be NaN for time-dependent maps.");
   return the_map.frame_velocity(source_points, t, functions_of_time);
@@ -209,10 +201,8 @@ auto apply_jacobian(
          "A function of time must be present if the maps are time-dependent.");
   ASSERT(
       [t]() {
-        disable_floating_point_exceptions();
-        const bool isnan = std::isnan(t);
-        enable_floating_point_exceptions();
-        return not isnan;
+        const ScopedFpeState disable_fpes(false);
+        return not std::isnan(t);
       }(),
       "The time must not be NaN for time-dependent maps.");
   if (LIKELY(not the_map.is_identity())) {
@@ -250,10 +240,8 @@ auto apply_inverse_jacobian(
          "A function of time must be present if the maps are time-dependent.");
   ASSERT(
       [t]() {
-        disable_floating_point_exceptions();
-        const bool isnan = std::isnan(t);
-        enable_floating_point_exceptions();
-        return not isnan;
+        const ScopedFpeState disable_fpes(false);
+        return not std::isnan(t);
       }(),
       "The time must not be NaN for time-dependent maps.");
   if (LIKELY(not the_map.is_identity())) {

--- a/src/Domain/CoordinateMaps/UniformCylindricalEndcap.cpp
+++ b/src/Domain/CoordinateMaps/UniformCylindricalEndcap.cpp
@@ -8,6 +8,7 @@
 #include <optional>
 #include <pup.h>
 #include <sstream>
+#include <tuple>
 #include <utility>
 
 #include "DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp"
@@ -43,7 +44,7 @@ double this_function_is_zero_for_correct_rhobar(
 }
 
 // min and max values of rhobar in the inverse function.
-std::array<double, 2> rhobar_min_max(
+std::tuple<double, double> rhobar_min_max(
     const std::array<double, 3>& center_one,
     const std::array<double, 3>& center_two, const double radius_one,
     const double radius_two, const double theta_max_one,
@@ -432,8 +433,9 @@ std::optional<std::array<double, 3>> UniformCylindricalEndcap::inverse(
         return std::make_pair(func_to_zero, deriv_of_func_to_zero);
       };
 
-  // Non-const because might be changed below.
-  auto [rhobar_min, rhobar_max] =
+  double rhobar_min{};
+  double rhobar_max{};
+  std::tie(rhobar_min, rhobar_max) =
       rhobar_min_max(center_one_, center_two_, radius_one_, radius_two_,
                      theta_max_one_, theta_max_two_, target_coords);
 

--- a/src/Domain/CoordinateMaps/UniformCylindricalFlatEndcap.cpp
+++ b/src/Domain/CoordinateMaps/UniformCylindricalFlatEndcap.cpp
@@ -9,6 +9,7 @@
 #include <optional>
 #include <pup.h>
 #include <sstream>
+#include <tuple>
 #include <utility>
 
 #include "DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp"
@@ -44,7 +45,7 @@ double this_function_is_zero_for_correct_rhobar(
 }
 
 // min and max values of rhobar in the inverse function.
-std::array<double, 2> rhobar_min_max(
+std::tuple<double, double> rhobar_min_max(
     const std::array<double, 3>& center_one, const double radius_one,
     const double theta_max_one, const std::array<double, 3>& target_coords) {
   // Choose the minimum value of rhobar so that lambda >=0, where
@@ -366,8 +367,9 @@ std::optional<std::array<double, 3>> UniformCylindricalFlatEndcap::inverse(
                 lambda * radius_two_);
   };
 
-  // Non-const because might be changed below.
-  auto [rhobar_min, rhobar_max] =
+  double rhobar_min{};
+  double rhobar_max{};
+  std::tie(rhobar_min, rhobar_max) =
       rhobar_min_max(center_one_, radius_one_, theta_max_one_, target_coords);
 
   // If rhobar is zero, then the root finding doesn't converge

--- a/src/Domain/FunctionsOfTime/ReadSpecPiecewisePolynomial.cpp
+++ b/src/Domain/FunctionsOfTime/ReadSpecPiecewisePolynomial.cpp
@@ -33,7 +33,9 @@ void read_spec_piecewise_polynomial(
     const std::map<std::string, std::string>& dataset_name_map,
     const bool quaternion_rotation) {
   h5::H5File<h5::AccessType::ReadOnly> file{file_name};
-  for (const auto& [spec_name, spectre_name] : dataset_name_map) {
+  for (const auto& name_pair : dataset_name_map) {
+    const auto& spec_name = name_pair.first;
+    const auto& spectre_name = name_pair.second;
     file.close_current_object();
     const auto& dat_file = file.get<h5::Dat>("/" + spec_name);
     const auto& dat_data = dat_file.get_data();
@@ -244,7 +246,9 @@ void override_functions_of_time(
         function_of_time_file, function_of_time_name_map, true);
   }
 
-  for (const auto& [spec_name, spectre_name] : function_of_time_name_map) {
+  for (const auto& name_pair : function_of_time_name_map) {
+    const auto& spec_name = name_pair.first;
+    const auto& spectre_name = name_pair.second;
     (void)spec_name;
     // The FunctionsOfTime we are mutating must already have
     // an element with key==spectre_name; this action only

--- a/src/Evolution/Actions/RunEventsAndDenseTriggers.hpp
+++ b/src/Evolution/Actions/RunEventsAndDenseTriggers.hpp
@@ -140,7 +140,14 @@ struct RunEventsAndDenseTriggers {
           using tag = tmpl::type_from<decltype(tag_v)>;
           db::mutate<tag>(
               [this](const gsl::not_null<typename tag::type*> value) {
+#if defined(__GNUC__) and not defined(__clang__) and __GNUC__ < 13
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
                 *value = std::move(tuples::get<tag>(*non_tensors_));
+#if defined(__GNUC__) and not defined(__clang__) and __GNUC__ < 13
+#pragma GCC diagnostic pop
+#endif
               },
               box_);
         });

--- a/src/Evolution/EventsAndDenseTriggers/EventsAndDenseTriggers.cpp
+++ b/src/Evolution/EventsAndDenseTriggers/EventsAndDenseTriggers.cpp
@@ -46,9 +46,7 @@ void EventsAndDenseTriggers::pup(PUP::er& p) {
 }
 
 bool EventsAndDenseTriggers::initialized() const {
-  disable_floating_point_exceptions();
-  const bool result = not std::isnan(next_check_);
-  enable_floating_point_exceptions();
-  return result;
+  const ScopedFpeState disable_fpes(false);
+  return not std::isnan(next_check_);
 }
 }  // namespace evolution

--- a/src/Evolution/Systems/Ccz4/CMakeLists.txt
+++ b/src/Evolution/Systems/Ccz4/CMakeLists.txt
@@ -13,7 +13,9 @@ spectre_target_sources(
   DerivChristoffel.cpp
   DerivLapse.cpp
   DerivZ4Constraint.cpp
-  Ricci.cpp
+  Ricci1.cpp
+  Ricci2.cpp
+  Ricci3.cpp
   RicciScalarPlusDivergenceZ4Constraint.cpp
   TimeDerivative.cpp
   Z4Constraint.cpp
@@ -29,6 +31,7 @@ spectre_target_headers(
   DerivLapse.hpp
   DerivZ4Constraint.hpp
   Ricci.hpp
+  Ricci.tpp
   RicciScalarPlusDivergenceZ4Constraint.hpp
   System.hpp
   Tags.hpp

--- a/src/Evolution/Systems/Ccz4/Ricci.tpp
+++ b/src/Evolution/Systems/Ccz4/Ricci.tpp
@@ -1,6 +1,8 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
+#pragma once
+
 #include "Evolution/Systems/Ccz4/Ricci.hpp"
 
 #include <cstddef>
@@ -138,10 +140,5 @@ tnsr::ii<DataType, Dim, Frame> spatial_ricci_tensor(
       const tnsr::i<DTYPE(data), DIM(data), FRAME(data)>& field_p,        \
       const tnsr::ij<DTYPE(data), DIM(data), FRAME(data)>& d_field_p);
 
-GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (Frame::Grid, Frame::Inertial),
-                        (double, DataVector))
-
-#undef INSTANTIATE
-#undef DTYPE
-#undef FRAME
-#undef DIM
+// Instantiations are split into several compilation units to reduce
+// compiler memory consumption.

--- a/src/Evolution/Systems/Ccz4/Ricci1.cpp
+++ b/src/Evolution/Systems/Ccz4/Ricci1.cpp
@@ -1,0 +1,7 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/Ccz4/Ricci.tpp"
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1), (Frame::Grid, Frame::Inertial),
+                        (double, DataVector))

--- a/src/Evolution/Systems/Ccz4/Ricci2.cpp
+++ b/src/Evolution/Systems/Ccz4/Ricci2.cpp
@@ -1,0 +1,7 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/Ccz4/Ricci.tpp"
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (2), (Frame::Grid, Frame::Inertial),
+                        (double, DataVector))

--- a/src/Evolution/Systems/Ccz4/Ricci3.cpp
+++ b/src/Evolution/Systems/Ccz4/Ricci3.cpp
@@ -1,0 +1,7 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/Ccz4/Ricci.tpp"
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (3), (Frame::Grid, Frame::Inertial),
+                        (double, DataVector))

--- a/src/NumericalAlgorithms/FiniteDifference/PartialDerivatives.cpp
+++ b/src/NumericalAlgorithms/FiniteDifference/PartialDerivatives.cpp
@@ -452,6 +452,13 @@ void logical_partial_derivatives(
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 
 #define INSTANTIATION(r, data)                                                 \
+  template void detail::logical_partial_derivatives_impl(                      \
+      gsl::not_null<std::array<gsl::span<double>, DIM(data)>*> derivative,     \
+      gsl::span<double>* const buffer,                                         \
+      const gsl::span<const double>& volume_vars,                              \
+      const DirectionMap<DIM(data), gsl::span<const double>>& ghost_cell_vars, \
+      const Mesh<DIM(data)>& volume_fd_mesh, size_t number_of_variables,       \
+      size_t fd_order);                                                        \
   template void logical_partial_derivatives(                                   \
       gsl::not_null<std::array<gsl::span<double>, DIM(data)>*> derivative,     \
       const gsl::span<const double>& volume_vars,                              \

--- a/src/Parallel/DistributedObject.hpp
+++ b/src/Parallel/DistributedObject.hpp
@@ -1118,7 +1118,9 @@ bool DistributedObject<
   }
 #endif // SPECTRE_CHARM_PROJECTIONS
 
-  const auto& [requested_execution, next_action_step] = ThisAction::apply(
+  AlgorithmExecution requested_execution{};
+  std::optional<std::size_t> next_action_step{};
+  std::tie(requested_execution, next_action_step) = ThisAction::apply(
       box_, inboxes_, *Parallel::local_branch(global_cache_proxy_),
       std::as_const(array_index_), actions_list{},
       std::add_pointer_t<ParallelComponent>{});

--- a/src/Parallel/Printf.hpp
+++ b/src/Parallel/Printf.hpp
@@ -82,10 +82,9 @@ inline void print_helper(Printer&& printer, const std::string& format,
 template <typename Printer, typename... Args>
 inline void call_printer(Printer&& printer, const std::string& format,
                          Args&&... args) {
-  disable_floating_point_exceptions();
+  const ScopedFpeState disable_fpes(false);
   print_helper(printer, format,
                stream_object_to_string(std::forward<Args>(args))...);
-  enable_floating_point_exceptions();
 }
 }  // namespace detail
 

--- a/src/ParallelAlgorithms/Events/ObserveAtExtremum.hpp
+++ b/src/ParallelAlgorithms/Events/ObserveAtExtremum.hpp
@@ -315,7 +315,7 @@ operator()(const typename ObservationValueTag::type& observation_value,
                  "without an analytic solution.");
       }
       const auto& scalar = value(get<tag>(box));
-      const auto [component_names, components] = scalar.get_vector_of_data();
+      const auto components = get<1>(scalar.get_vector_of_data());
       if (components.size() > 1) {
         ERROR("Extremum should be taken on a scalar, yet we have "
               << components.size() << " components in tensor " << tensor_name);

--- a/src/ParallelAlgorithms/Events/ObserveNorms.hpp
+++ b/src/ParallelAlgorithms/Events/ObserveNorms.hpp
@@ -374,7 +374,9 @@ operator()(const typename ObservationValueTag::type& observation_value,
         const auto& tensor = value(get<tag>(box));
 
         auto& [values, names] = norm_values_and_names[tensor_norm_types_[i]];
-        const auto [component_names, components] = tensor.get_vector_of_data();
+        const auto names_and_components = tensor.get_vector_of_data();
+        const auto& component_names = names_and_components.first;
+        const auto& components = names_and_components.second;
         if (components[0].size() != number_of_points) {
           ERROR("The number of grid points of the mesh is "
                 << number_of_points << " but the tensor '" << tensor_name

--- a/src/Utilities/ErrorHandling/Assert.hpp
+++ b/src/Utilities/ErrorHandling/Assert.hpp
@@ -37,7 +37,7 @@
 #define ASSERT(a, m)                                                           \
   do {                                                                         \
     if (!(a)) {                                                                \
-      disable_floating_point_exceptions();                                     \
+      const ScopedFpeState disable_fpes_ASSERT(false);                         \
       std::ostringstream avoid_name_collisions_ASSERT;                         \
       /* clang-tidy: macro arg in parentheses */                               \
       avoid_name_collisions_ASSERT << std::setprecision(18) << std::scientific \
@@ -52,13 +52,12 @@
   do {                                                                         \
     if (false) {                                                               \
       static_cast<void>(a);                                                    \
-      disable_floating_point_exceptions();                                     \
+      const ScopedFpeState disable_fpes_ASSERT(false);                         \
       std::ostringstream avoid_name_collisions_ASSERT;                         \
       /* clang-tidy: macro arg in parentheses */                               \
       avoid_name_collisions_ASSERT << std::setprecision(18) << std::scientific \
                                    << m; /* NOLINT */                          \
       static_cast<void>(avoid_name_collisions_ASSERT);                         \
-      enable_floating_point_exceptions();                                      \
     }                                                                          \
   } while (false)
 #endif

--- a/src/Utilities/ErrorHandling/FloatingPointExceptions.cpp
+++ b/src/Utilities/ErrorHandling/FloatingPointExceptions.cpp
@@ -3,26 +3,25 @@
 
 #include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
 
+#include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"
 
 #include <csignal>
 
-#ifdef __APPLE__
-#ifdef __arm64__
-#include <fenv.h>
-#else
+#if SPECTRE_FPE_CSR
 #include <xmmintrin.h>
-#endif
-#else
+#elif SPECTRE_FPE_FENV
 #include <cfenv>
 #endif
 
 namespace {
 
-#ifdef __APPLE__
-#ifndef __arm64__
-auto old_mask = _mm_getcsr();
-#endif
+#if SPECTRE_FPE_CSR
+const unsigned int disabled_mask = _mm_getcsr();
+const unsigned int exception_flags =
+    _MM_MASK_MASK & ~(_MM_MASK_OVERFLOW | _MM_MASK_INVALID | _MM_MASK_DIV_ZERO);
+#elif SPECTRE_FPE_FENV
+const int exception_flags = FE_DIVBYZERO | FE_INVALID | FE_OVERFLOW;
 #endif
 
 [[noreturn]] void fpe_signal_handler(int /*signal*/) {
@@ -31,23 +30,62 @@ auto old_mask = _mm_getcsr();
 }  // namespace
 
 void enable_floating_point_exceptions() {
-#ifdef __APPLE__
-#ifndef __arm64__
-  _mm_setcsr(_MM_MASK_MASK &
-             ~(_MM_MASK_OVERFLOW | _MM_MASK_INVALID | _MM_MASK_DIV_ZERO));
-#endif
-#else
-  feenableexcept(FE_DIVBYZERO | FE_INVALID | FE_OVERFLOW);
+#if SPECTRE_FPE_CSR
+  _mm_setcsr(exception_flags);
+#elif SPECTRE_FPE_FENV
+  feenableexcept(exception_flags);
 #endif
   std::signal(SIGFPE, fpe_signal_handler);
 }
 
 void disable_floating_point_exceptions() {
-#ifdef __APPLE__
-#ifndef __arm64__
-  _mm_setcsr(old_mask);
+#if SPECTRE_FPE_CSR
+  _mm_setcsr(disabled_mask);
+#elif SPECTRE_FPE_FENV
+  fedisableexcept(exception_flags);
 #endif
+}
+
+ScopedFpeState::~ScopedFpeState() { restore_exceptions(); }
+
+ScopedFpeState::ScopedFpeState() { save_exceptions(); }
+
+ScopedFpeState::ScopedFpeState(const bool exceptions_enabled)
+    : ScopedFpeState() {
+  set_exceptions(exceptions_enabled);
+}
+
+ScopedFpeState::ScopedFpeState(ScopedFpeState::DoNotSave /*meta*/) {}
+
+void ScopedFpeState::set_exceptions(const bool exceptions_enabled) const {
+  ASSERT(original_state_.has_value(), "FPE state not saved.");
+  if (exceptions_enabled) {
+    enable_floating_point_exceptions();
+  } else {
+    disable_floating_point_exceptions();
+  }
+}
+
+void ScopedFpeState::save_exceptions() {
+  ASSERT(not original_state_.has_value(), "FPE state already saved.");
+#if SPECTRE_FPE_CSR
+  original_state_.emplace(_mm_getcsr());
+#elif SPECTRE_FPE_FENV
+  original_state_.emplace(fegetexcept());
 #else
-  fedisableexcept(FE_DIVBYZERO | FE_INVALID | FE_OVERFLOW);
+  original_state_.emplace();
 #endif
+}
+
+void ScopedFpeState::restore_exceptions() {
+  if (not original_state_.has_value()) {
+    return;
+  }
+#if SPECTRE_FPE_CSR
+  _mm_setcsr(*original_state_);
+#elif SPECTRE_FPE_FENV
+  fedisableexcept(exception_flags);
+  feenableexcept(*original_state_);
+#endif
+  original_state_.reset();
 }

--- a/src/Utilities/ErrorHandling/FloatingPointExceptions.hpp
+++ b/src/Utilities/ErrorHandling/FloatingPointExceptions.hpp
@@ -6,6 +6,18 @@
 
 #pragma once
 
+#include <optional>
+
+/// \cond
+#ifdef __APPLE__
+#ifndef __arm64__
+#define SPECTRE_FPE_CSR 1
+#endif
+#else
+#define SPECTRE_FPE_FENV 1
+#endif
+/// \endcond
+
 /// \ingroup ErrorHandlingGroup
 /// After a call to this function, the code will terminate with a floating
 /// point exception on overflow, divide-by-zero, and invalid operations.
@@ -14,4 +26,60 @@ void enable_floating_point_exceptions();
 /// \ingroup ErrorHandlingGroup
 /// After a call to this function, the code will NOT terminate with a floating
 /// point exception on overflow, divide-by-zero, and invalid operations.
+///
+/// \warning Do not use this function to temporarily disable FPEs,
+/// because it will not interact correctly with C++ exceptions.  Use
+/// `ScopedFpeState` instead.
 void disable_floating_point_exceptions();
+
+/// \ingroup ErrorHandlingGroup
+/// An RAII object to temporarily modify the handling of floating
+/// point exceptions.
+class ScopedFpeState {
+ public:
+  ScopedFpeState(const ScopedFpeState&) = delete;
+  ScopedFpeState(ScopedFpeState&&) = delete;
+  ScopedFpeState& operator=(const ScopedFpeState&) = delete;
+  ScopedFpeState& operator=(ScopedFpeState&&) = delete;
+  ~ScopedFpeState();
+
+  /// Start a scope that will be restored, without changing the
+  /// current state.
+  ScopedFpeState();
+  /// Start a scope with the specified exception state.  This is
+  /// equivalent to calling the default constructor followed by
+  /// `set_exceptions`.
+  explicit ScopedFpeState(bool exceptions_enabled);
+
+  struct DoNotSave {};
+  /// Start a scope without saving the current state.  The only valid
+  /// method call from this state is `save_exceptions`.
+  explicit ScopedFpeState(DoNotSave /*meta*/);
+
+  /// Enable or disable floating point exceptions.  It is an error if
+  /// the exception state is not currently saved.
+  void set_exceptions(bool exceptions_enabled) const;
+
+  /// Save the current exception handling state after it has been
+  /// cleared by `restore_exceptions`.  It will be restored by a later
+  /// call to `restore_exceptions`.  It is an error to call this if
+  /// a state is already saved.
+  void save_exceptions();
+
+  /// Restore the FPE handling to the internally saved state if
+  /// present and clear that state.  This is called automatically by
+  /// the destructor if it is not called manually.
+  void restore_exceptions();
+
+ private:
+#if SPECTRE_FPE_CSR
+  std::optional<unsigned int> original_state_;
+#elif SPECTRE_FPE_FENV
+  std::optional<int> original_state_;
+#else
+  // FPEs not supported, but this is still used to check method calls
+  // are valid.
+  struct DummyState {};
+  std::optional<DummyState> original_state_;
+#endif
+};

--- a/tests/Unit/ErrorHandling/Test_FloatingPointExceptions.cpp
+++ b/tests/Unit/ErrorHandling/Test_FloatingPointExceptions.cpp
@@ -8,6 +8,12 @@
 
 #include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
 
+#if SPECTRE_FPE_CSR
+#include <xmmintrin.h>
+#elif SPECTRE_FPE_FENV
+#include <cfenv>
+#endif
+
 // Trapping floating-point exceptions is apparently unsupported on
 // the arm64 architecture, so when building on Apple Silicon,
 // directly call the fpe_signal_handler in these tests so that they pass.
@@ -80,4 +86,127 @@ SPECTRE_TEST_CASE("Unit.ErrorHandling.FloatingPointExceptions.Disable",
   div_by_zero /= 0.0;
   (void)div_by_zero;
   CHECK(true);
+}
+
+SPECTRE_TEST_CASE("Unit.ErrorHandling.FloatingPointExceptions.ScopedFpeState",
+                  "[ErrorHandling][Unit]") {
+#ifdef SPECTRE_DEBUG
+  CHECK_THROWS_WITH(
+      []() {
+        ScopedFpeState s{ScopedFpeState::DoNotSave{}};
+        s.set_exceptions(true);
+      }(),
+      Catch::Contains("FPE state not saved"));
+  CHECK_THROWS_WITH(
+      []() {
+        ScopedFpeState s{true};
+        s.save_exceptions();
+      }(),
+      Catch::Contains("FPE state already saved"));
+#endif  // SPECTRE_DEBUG
+
+#ifdef __APPLE__
+#ifdef __arm64__
+  CHECK(true);
+  return;
+  // Don't stick the rest of the function in an #else or something
+  // because it should still compile.
+#pragma GCC diagnostic ignored "-Wunreachable-code"
+#endif
+#endif
+
+  // Stack unwinding from a signal handler doesn't work on all
+  // compilers, so we can't actually test causing FPEs.
+  const auto exceptions_enabled = []() {
+#if SPECTRE_FPE_CSR
+    return (_mm_getcsr() & _MM_MASK_OVERFLOW) == 0;
+#elif SPECTRE_FPE_FENV
+    return (fegetexcept() & FE_DIVBYZERO) != 0;
+#else
+    return false;
+#endif
+  };
+
+  enable_floating_point_exceptions();
+  CHECK(exceptions_enabled());
+  {
+    const ScopedFpeState s{};
+    CHECK(exceptions_enabled());
+  }
+  CHECK(exceptions_enabled());
+
+  {
+    const ScopedFpeState s(true);
+    CHECK(exceptions_enabled());
+  }
+  CHECK(exceptions_enabled());
+
+  {
+    const ScopedFpeState s(false);
+    CHECK(not exceptions_enabled());
+  }
+  CHECK(exceptions_enabled());
+
+  CHECK(exceptions_enabled());
+  {
+    const ScopedFpeState s(ScopedFpeState::DoNotSave{});
+    CHECK(exceptions_enabled());
+    disable_floating_point_exceptions();
+  }
+  CHECK(not exceptions_enabled());
+  enable_floating_point_exceptions();
+
+  {
+    const ScopedFpeState s(false);
+    CHECK(not exceptions_enabled());
+    s.set_exceptions(false);
+    CHECK(not exceptions_enabled());
+    s.set_exceptions(true);
+    CHECK(exceptions_enabled());
+  }
+  CHECK(exceptions_enabled());
+
+  {
+    const ScopedFpeState s{};
+    // Other methods of modifying the state should also be scoped
+    disable_floating_point_exceptions();
+  }
+  CHECK(exceptions_enabled());
+
+  {
+    ScopedFpeState s(false);
+    CHECK(not exceptions_enabled());
+    // Restoring the state explicitly should suppress the implicit one
+    // in the destructor.
+    s.restore_exceptions();
+    CHECK(exceptions_enabled());
+    disable_floating_point_exceptions();
+  }
+  CHECK(not exceptions_enabled());
+  enable_floating_point_exceptions();
+
+  {
+    ScopedFpeState s(false);
+    CHECK(not exceptions_enabled());
+    s.restore_exceptions();
+    CHECK(exceptions_enabled());
+    // Saving the state again should return the restoring behavior.
+    s.save_exceptions();
+    disable_floating_point_exceptions();
+  }
+  CHECK(exceptions_enabled());
+
+  {
+    const ScopedFpeState s1(false);
+    {
+      const ScopedFpeState s2(false);
+      {
+        const ScopedFpeState s3(true);
+        CHECK(exceptions_enabled());
+      }
+      CHECK(not exceptions_enabled());
+    }
+    CHECK(not exceptions_enabled());
+  }
+  CHECK(exceptions_enabled());
 }

--- a/tests/Unit/ErrorHandling/Test_FloatingPointExceptions.cpp
+++ b/tests/Unit/ErrorHandling/Test_FloatingPointExceptions.cpp
@@ -209,4 +209,10 @@ SPECTRE_TEST_CASE("Unit.ErrorHandling.FloatingPointExceptions.ScopedFpeState",
     CHECK(not exceptions_enabled());
   }
   CHECK(exceptions_enabled());
+
+  // Test that ERROR preserves the state.  This primarily matters for
+  // tests.
+  enable_floating_point_exceptions();
+  CHECK_THROWS_WITH([]() { ERROR("BOOM"); }(), Catch::Contains("BOOM"));
+  CHECK(exceptions_enabled());
 }

--- a/tests/Unit/Framework/MockDistributedObject.hpp
+++ b/tests/Unit/Framework/MockDistributedObject.hpp
@@ -660,7 +660,9 @@ class MockDistributedObject {
 
   template <typename ThisAction, typename ActionList, typename DbTags>
   bool invoke_iterable_action(db::DataBox<DbTags>& my_box) {
-    const auto& [requested_execution, next_action_step] = ThisAction::apply(
+    Parallel::AlgorithmExecution requested_execution{};
+    std::optional<std::size_t> next_action_step{};
+    std::tie(requested_execution, next_action_step) = ThisAction::apply(
         my_box, *inboxes_, *global_cache_, std::as_const(array_index_),
         ActionList{}, std::add_pointer_t<Component>{});
 

--- a/tests/Unit/Framework/Pypp.hpp
+++ b/tests/Unit/Framework/Pypp.hpp
@@ -494,10 +494,8 @@ template <typename ReturnType, typename ConversionClassList = tmpl::list<>,
           typename... Args>
 ReturnType call(const std::string& module_name,
                 const std::string& function_name, const Args&... t) {
-  disable_floating_point_exceptions();
-  auto result = detail::CallImpl<ReturnType, ConversionClassList>::call(
+  const ScopedFpeState disable_fpes(false);
+  return detail::CallImpl<ReturnType, ConversionClassList>::call(
       module_name, function_name, t...);
-  enable_floating_point_exceptions();
-  return result;
 }
 }  // namespace pypp

--- a/tests/Unit/Framework/SetupLocalPythonEnvironment.cpp
+++ b/tests/Unit/Framework/SetupLocalPythonEnvironment.cpp
@@ -70,9 +70,9 @@ SetupLocalPythonEnvironment::SetupLocalPythonEnvironment(
 
     // On some python versions init_numpy() can throw an FPE, this occurred at
     // least with python 3.6, numpy 1.14.2.
-    disable_floating_point_exceptions();
+    ScopedFpeState disable_fpes(false);
     init_numpy();
-    enable_floating_point_exceptions();
+    disable_fpes.restore_exceptions();
   }
   initialized = true;
 }

--- a/tests/Unit/Utilities/Test_MakeSignalingNan.cpp
+++ b/tests/Unit/Utilities/Test_MakeSignalingNan.cpp
@@ -10,7 +10,7 @@
 #include "Utilities/MakeSignalingNan.hpp"
 
 SPECTRE_TEST_CASE("Unit.Utilities.MakeSignalingNaN", "[Unit][Utilities]") {
-  disable_floating_point_exceptions();
+  const ScopedFpeState disable_fpes(false);
   const auto double_snan = make_signaling_NaN<double>();
   CHECK(std::isnan(double_snan));
   const auto float_snan = make_signaling_NaN<float>();
@@ -18,5 +18,4 @@ SPECTRE_TEST_CASE("Unit.Utilities.MakeSignalingNaN", "[Unit][Utilities]") {
   const auto complex_snan = make_signaling_NaN<std::complex<double>>();
   CHECK(std::isnan(complex_snan.real()));
   CHECK(std::isnan(complex_snan.imag()));
-  enable_floating_point_exceptions();
 }


### PR DESCRIPTION
We still can't reliably recover from an FPE because throwing exceptions from a signal handler isn't well supported, but this should make FPE-handling preserved when other errors occur.  It will also prevent code from unintentionally enabling FPEs if it temporarily disables them when they were already disabled.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
