### PR TITLE
Allow L2IntegralNorm for subcell

### DIFF
--- a/src/Elliptic/Executables/Poisson/SolvePoisson.hpp
+++ b/src/Elliptic/Executables/Poisson/SolvePoisson.hpp
@@ -162,6 +162,8 @@ struct Metavariables {
                      volume_dim, Frame::Inertial>>>;
   using observer_compute_tags =
       tmpl::list<::Events::Tags::ObserverMeshCompute<volume_dim>,
+                 ::Events::Tags::ObserverDetInvJacobianCompute<
+                   Frame::ElementLogical, Frame::Inertial>,
                  error_compute>;
 
   // Collect all items to store in the cache.

--- a/src/Elliptic/Executables/Xcts/SolveXcts.hpp
+++ b/src/Elliptic/Executables/Xcts/SolveXcts.hpp
@@ -96,10 +96,11 @@ struct Metavariables {
                      Xcts::Tags::ShiftExcess<DataVector, 3, Frame::Inertial>,
                      gr::Tags::SpatialMetric<DataVector, 3>>,
                  hydro::Tags::LowerSpatialFourVelocityCompute>>;
-  using observer_compute_tags =
-      tmpl::list<::Events::Tags::ObserverMeshCompute<volume_dim>,
-                 spacetime_quantities_compute, hydro_quantities_compute,
-                 error_compute>;
+  using observer_compute_tags = tmpl::list<
+      ::Events::Tags::ObserverMeshCompute<volume_dim>,
+      ::Events::Tags::ObserverDetInvJacobianCompute<Frame::ElementLogical,
+                                                    Frame::Inertial>,
+      spacetime_quantities_compute, hydro_quantities_compute, error_compute>;
 
   // Collect all items to store in the cache.
   using const_global_cache_tags =

--- a/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
+++ b/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
@@ -153,6 +153,8 @@ struct EvolutionMetavars {
                               tmpl::list<evolution::dg::subcell::Tags::
                                              TciStatusCompute<volume_dim>>,
                               tmpl::list<>>>,
+      ::Events::Tags::ObserverDetInvJacobianCompute<Frame::ElementLogical,
+                                                    Frame::Inertial>,
       tmpl::conditional_t<
           use_dg_subcell,
           evolution::dg::subcell::Tags::ObserverCoordinatesCompute<volume_dim,

--- a/src/Evolution/Executables/CurvedScalarWave/EvolveCurvedScalarWave.hpp
+++ b/src/Evolution/Executables/CurvedScalarWave/EvolveCurvedScalarWave.hpp
@@ -149,6 +149,8 @@ struct EvolutionMetavars {
       tmpl::flatten<tmpl::list<
           tmpl::append<typename system::variables_tag::tags_list,
                        typename deriv_compute::type::tags_list>,
+          ::Events::Tags::ObserverDetInvJacobianCompute<
+            Frame::ElementLogical, Frame::Inertial>,
           CurvedScalarWave::Tags::OneIndexConstraintCompute<volume_dim>,
           CurvedScalarWave::Tags::TwoIndexConstraintCompute<volume_dim>,
           ::Tags::PointwiseL2NormCompute<

--- a/src/Evolution/Executables/CurvedScalarWave/EvolveWorldtubeCurvedScalarWave.hpp
+++ b/src/Evolution/Executables/CurvedScalarWave/EvolveWorldtubeCurvedScalarWave.hpp
@@ -158,6 +158,8 @@ struct EvolutionMetavars {
       tmpl::flatten<tmpl::list<
           tmpl::append<typename system::variables_tag::tags_list,
                        typename deriv_compute::type::tags_list>,
+          ::Events::Tags::ObserverDetInvJacobianCompute<
+            Frame::ElementLogical, Frame::Inertial>,
           CurvedScalarWave::Tags::OneIndexConstraintCompute<volume_dim>,
           CurvedScalarWave::Tags::TwoIndexConstraintCompute<volume_dim>>>,
       domain::Tags::Coordinates<volume_dim, Frame::Grid>,

--- a/src/Evolution/Executables/ForceFree/EvolveForceFree.hpp
+++ b/src/Evolution/Executables/ForceFree/EvolveForceFree.hpp
@@ -129,6 +129,8 @@ struct EvolutionMetavars {
 
   using non_tensor_compute_tags =
       tmpl::list<::Events::Tags::ObserverMeshCompute<volume_dim>,
+                 ::Events::Tags::ObserverDetInvJacobianCompute<
+                     Frame::ElementLogical, Frame::Inertial>,
                  analytic_compute, error_compute>;
 
   struct factory_creation

--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
@@ -259,19 +259,37 @@ struct EvolutionMetavars {
               tmpl::list<>>>,
       tmpl::conditional_t<
           use_dg_subcell,
+          evolution::dg::subcell::Tags::ObserverCoordinatesCompute<
+              volume_dim, Frame::ElementLogical>,
+          ::Events::Tags::ObserverCoordinatesCompute<volume_dim,
+                                                     Frame::ElementLogical>>,
+      tmpl::conditional_t<
+          use_dg_subcell,
           evolution::dg::subcell::Tags::ObserverCoordinatesCompute<volume_dim,
                                                                    Frame::Grid>,
-          domain::Tags::Coordinates<volume_dim, Frame::Grid>>,
+          ::Events::Tags::ObserverCoordinatesCompute<volume_dim, Frame::Grid>>,
       tmpl::conditional_t<
           use_dg_subcell,
           evolution::dg::subcell::Tags::ObserverCoordinatesCompute<
               volume_dim, Frame::Inertial>,
-          domain::Tags::Coordinates<volume_dim, Frame::Inertial>>>;
+          ::Events::Tags::ObserverCoordinatesCompute<volume_dim,
+                                                     Frame::Inertial>>>;
   using non_tensor_compute_tags = tmpl::list<
       tmpl::conditional_t<
           use_dg_subcell,
-          evolution::dg::subcell::Tags::ObserverMeshCompute<volume_dim>,
-          ::Events::Tags::ObserverMeshCompute<volume_dim>>,
+          tmpl::list<
+              evolution::dg::subcell::Tags::ObserverMeshCompute<volume_dim>,
+              evolution::dg::subcell::Tags::ObserverInverseJacobianCompute<
+                  volume_dim, Frame::ElementLogical, Frame::Inertial>,
+              evolution::dg::subcell::Tags::ObserverJacobianAndDetInvJacobian<
+                  volume_dim, Frame::ElementLogical, Frame::Inertial>>,
+          tmpl::list<::Events::Tags::ObserverMeshCompute<volume_dim>,
+                     ::Events::Tags::ObserverInverseJacobianCompute<
+                         volume_dim, Frame::ElementLogical, Frame::Inertial>,
+                     ::Events::Tags::ObserverJacobianCompute<
+                         volume_dim, Frame::ElementLogical, Frame::Inertial>,
+                     ::Events::Tags::ObserverDetInvJacobianCompute<
+                         Frame::ElementLogical, Frame::Inertial>>>,
       analytic_compute, error_compute>;
 
   struct factory_creation

--- a/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
+++ b/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
@@ -190,6 +190,12 @@ struct EvolutionMetavars {
                               tmpl::list<>>>,
       tmpl::conditional_t<
           use_dg_subcell,
+          evolution::dg::subcell::Tags::ObserverCoordinatesCompute<
+              volume_dim, Frame::ElementLogical>,
+          ::Events::Tags::ObserverCoordinatesCompute<volume_dim,
+                                                     Frame::ElementLogical>>,
+      tmpl::conditional_t<
+          use_dg_subcell,
           evolution::dg::subcell::Tags::ObserverCoordinatesCompute<volume_dim,
                                                                    Frame::Grid>,
           domain::Tags::Coordinates<volume_dim, Frame::Grid>>,
@@ -198,12 +204,23 @@ struct EvolutionMetavars {
           evolution::dg::subcell::Tags::ObserverCoordinatesCompute<
               volume_dim, Frame::Inertial>,
           domain::Tags::Coordinates<volume_dim, Frame::Inertial>>>;
-  using non_tensor_compute_tags = tmpl::list<
+  using non_tensor_compute_tags = tmpl::append<
       tmpl::conditional_t<
           use_dg_subcell,
-          evolution::dg::subcell::Tags::ObserverMeshCompute<volume_dim>,
-          ::Events::Tags::ObserverMeshCompute<volume_dim>>,
-      analytic_compute, error_compute>;
+          tmpl::list<
+              evolution::dg::subcell::Tags::ObserverMeshCompute<volume_dim>,
+              evolution::dg::subcell::Tags::ObserverInverseJacobianCompute<
+                  volume_dim, Frame::ElementLogical, Frame::Inertial>,
+              evolution::dg::subcell::Tags::ObserverJacobianAndDetInvJacobian<
+                  volume_dim, Frame::ElementLogical, Frame::Inertial>>,
+          tmpl::list<::Events::Tags::ObserverMeshCompute<volume_dim>,
+                     ::Events::Tags::ObserverInverseJacobianCompute<
+                         volume_dim, Frame::ElementLogical, Frame::Inertial>,
+                     ::Events::Tags::ObserverJacobianCompute<
+                         volume_dim, Frame::ElementLogical, Frame::Inertial>,
+                     ::Events::Tags::ObserverDetInvJacobianCompute<
+                         Frame::ElementLogical, Frame::Inertial>>>,
+      tmpl::list<analytic_compute, error_compute>>;
 
   struct factory_creation
       : tt::ConformsTo<Options::protocols::FactoryCreation> {

--- a/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveM1Grey.hpp
+++ b/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveM1Grey.hpp
@@ -145,6 +145,8 @@ struct EvolutionMetavars {
       domain::Tags::Coordinates<volume_dim, Frame::Inertial>>;
   using non_tensor_compute_tags =
       tmpl::list<::Events::Tags::ObserverMeshCompute<volume_dim>,
+                 ::Events::Tags::ObserverDetInvJacobianCompute<
+                     Frame::ElementLogical, Frame::Inertial>,
                  analytic_compute, error_compute>;
 
   struct factory_creation

--- a/src/Evolution/Executables/RelativisticEuler/Valencia/EvolveValencia.hpp
+++ b/src/Evolution/Executables/RelativisticEuler/Valencia/EvolveValencia.hpp
@@ -160,6 +160,8 @@ struct EvolutionMetavars {
       domain::Tags::Coordinates<volume_dim, Frame::Inertial>>;
   using non_tensor_compute_tags =
       tmpl::list<::Events::Tags::ObserverMeshCompute<volume_dim>,
+                 ::Events::Tags::ObserverDetInvJacobianCompute<
+                     Frame::ElementLogical, Frame::Inertial>,
                  analytic_compute, error_compute>;
 
   struct factory_creation

--- a/src/Evolution/Executables/ScalarAdvection/EvolveScalarAdvection.hpp
+++ b/src/Evolution/Executables/ScalarAdvection/EvolveScalarAdvection.hpp
@@ -160,6 +160,12 @@ struct EvolutionMetavars {
                               tmpl::list<>>>,
       tmpl::conditional_t<
           use_dg_subcell,
+          evolution::dg::subcell::Tags::ObserverCoordinatesCompute<
+              volume_dim, Frame::ElementLogical>,
+          ::Events::Tags::ObserverCoordinatesCompute<volume_dim,
+                                                     Frame::ElementLogical>>,
+      tmpl::conditional_t<
+          use_dg_subcell,
           evolution::dg::subcell::Tags::ObserverCoordinatesCompute<volume_dim,
                                                                    Frame::Grid>,
           domain::Tags::Coordinates<volume_dim, Frame::Grid>>,
@@ -171,9 +177,20 @@ struct EvolutionMetavars {
   using non_tensor_compute_tags = tmpl::list<
       tmpl::conditional_t<
           use_dg_subcell,
-          evolution::dg::subcell::Tags::ObserverMeshCompute<volume_dim>,
-          ::Events::Tags::ObserverMeshCompute<volume_dim>>,
-      analytic_compute, error_compute>;
+          tmpl::list<
+              evolution::dg::subcell::Tags::ObserverMeshCompute<volume_dim>,
+              evolution::dg::subcell::Tags::ObserverInverseJacobianCompute<
+                  volume_dim, Frame::ElementLogical, Frame::Inertial>,
+              evolution::dg::subcell::Tags::ObserverJacobianAndDetInvJacobian<
+                  volume_dim, Frame::ElementLogical, Frame::Inertial>>,
+          tmpl::list<::Events::Tags::ObserverMeshCompute<volume_dim>,
+                     ::Events::Tags::ObserverInverseJacobianCompute<
+                         volume_dim, Frame::ElementLogical, Frame::Inertial>,
+                     ::Events::Tags::ObserverJacobianCompute<
+                         volume_dim, Frame::ElementLogical, Frame::Inertial>,
+                     ::Events::Tags::ObserverDetInvJacobianCompute<
+                         Frame::ElementLogical, Frame::Inertial>>>,
+      tmpl::list<analytic_compute, error_compute>>;
 
   struct factory_creation
       : tt::ConformsTo<Options::protocols::FactoryCreation> {

--- a/src/ParallelAlgorithms/Events/ObserveNorms.hpp
+++ b/src/ParallelAlgorithms/Events/ObserveNorms.hpp
@@ -187,9 +187,6 @@ class ObserveNorms<ObservationValueTag, tmpl::list<ObservableTensorTags...>,
       "grid points, whereas the 'L2IntegralNorm' emphasizes regions of the\n"
       "domain with large volume. Choose wisely! When in doubt, try the\n"
       "'L2Norm' first.\n"
-      "The 'L2IntegralNorm' does not currently work with finite difference\n"
-      "(subcell) meshes. [We need to figure out how to provide the proper \n"
-      "determinant of the Jacobian]\n"
       "\n"
       "Writes reduction quantities:\n"
       " * ObservationValueTag (e.g. Time or IterationId)\n"
@@ -343,16 +340,10 @@ operator()(const typename ObservationValueTag::type& observation_value,
       norm_values_and_names{};
   const auto& mesh = get<::Events::Tags::ObserverMesh<VolumeDim>>(box);
   const DataVector det_jacobian =
-    1. / get(get<domain::Tags::DetInvJacobian<Frame::ElementLogical,
-                                              Frame::Inertial>>(box));
+    1. / get(get<::Events::Tags::ObserverDetInvJacobian
+                   <Frame::ElementLogical, Frame::Inertial>>(box));
   const size_t number_of_points = mesh.number_of_grid_points();
-  const double local_volume = [&mesh, &det_jacobian]() {
-    if (mesh.basis(0) == Spectral::Basis::FiniteDifference) {
-      return std::numeric_limits<double>::quiet_NaN();
-    } else {
-      return definite_integral(det_jacobian, mesh);
-    }
-  }();
+  const double local_volume = definite_integral(det_jacobian, mesh);
 
   // Loop over ObservableTensorTags and see if it was requested to be observed.
   // This approach allows us to delay evaluating any compute tags until they're
@@ -397,11 +388,6 @@ operator()(const typename ObservationValueTag::type& observation_value,
               values.push_back(
                   alg::accumulate(square(components[storage_index]), 0.0));
             } else if (tensor_norm_types_[i] == "L2IntegralNorm") {
-             if (mesh.basis(0) == Spectral::Basis::FiniteDifference) {
-                ERROR(
-                    "The 'L2IntegralNorm' is currently not supported on finite "
-                    "difference (subcell) meshes.");
-              }
               values.push_back(definite_integral(
                   square(components[storage_index]) * det_jacobian, mesh));
             }


### PR DESCRIPTION
## Proposed changes

By getting the determinant of the jacobian on the correct grid (subcell or dg), we can take the L2IntegralNorm of a field when using the subcell code.

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Upgrade instructions

Any executable that uses ObserverNorm but does not use subcell needs the ComputeTag
` ::Events::Tags::ObserverDetInvJacobianCompute< Frame::ElementLogical, Frame::Inertial>`
in `non_tensor_compute_tags ` 

Any executable that uses ObserverNorm AND subcell needs to have in `non_tensor_compute_tags ` something like
`using non_tensor_compute_tags = tmpl::append< tmpl::conditional_t< use_dg_subcell, tmpl::list< evolution::dg::subcell::Tags::ObserverMeshCompute<volume_dim>, evolution::dg::subcell::Tags::ObserverInverseJacobianCompute< volume_dim, Frame::ElementLogical, Frame::Inertial>, evolution::dg::subcell::Tags::ObserverJacobianAndDetInvJacobian< volume_dim, Frame::ElementLogical, Frame::Inertial>>, tmpl::list<::Events::Tags::ObserverMeshCompute<volume_dim>, ::Events::Tags::ObserverInverseJacobianCompute< volume_dim, Frame::ElementLogical, Frame::Inertial>, ::Events::Tags::ObserverJacobianCompute< volume_dim, Frame::ElementLogical, Frame::Inertial>, ::Events::Tags::ObserverDetInvJacobianCompute< Frame::ElementLogical, Frame::Inertial>>>,`