### PR TITLE
Have zero crossing predictor actually return min positive time

### DIFF
--- a/src/NumericalAlgorithms/Interpolation/ZeroCrossingPredictor.cpp
+++ b/src/NumericalAlgorithms/Interpolation/ZeroCrossingPredictor.cpp
@@ -4,6 +4,7 @@
 #include "NumericalAlgorithms/Interpolation/ZeroCrossingPredictor.hpp"
 
 #include <algorithm>
+#include <limits>
 #include <pup.h>
 #include <pup_stl.h>
 
@@ -55,9 +56,10 @@ double ZeroCrossingPredictor::min_positive_zero_crossing_time(
     return 0.0;
   }
   auto crossing_time = zero_crossing_time(current_time);
-  // Replace all negative crossing times with zero.
-  std::for_each(crossing_time.begin(), crossing_time.end(),
-                [](double& a) { a = std::max(0.0, a); });
+  // Replace all negative crossing times with infinity.
+  std::for_each(crossing_time.begin(), crossing_time.end(), [](double& a) {
+    a = a < 0.0 ? std::numeric_limits<double>::infinity() : a;
+  });
 
   return *std::min_element(crossing_time.begin(), crossing_time.end());
 }

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_ZeroCrossingPredictor.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_ZeroCrossingPredictor.cpp
@@ -71,7 +71,7 @@ void test_zero_crossing_predictor() {
                       serialize_and_deserialize(predictor), min_size,
                       x_values.size());
 
-  Approx custom_approx = Approx::custom().epsilon(5e-6).scale(1.0);
+  Approx custom_approx = Approx::custom().epsilon(1e-5).scale(1.0);
   CHECK_ITERABLE_CUSTOM_APPROX(
       predictor.zero_crossing_time(x_values.back()),
       SINGLE_ARG(DataVector{expected_zero_crossing_value1,

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_ZeroCrossingPredictor.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_ZeroCrossingPredictor.cpp
@@ -78,9 +78,17 @@ void test_zero_crossing_predictor() {
                             expected_zero_crossing_value2}),
       custom_approx);
 
+  const double adjusted_value1 = expected_zero_crossing_value1 < 0.0
+                                     ? std::numeric_limits<double>::infinity()
+                                     : expected_zero_crossing_value1;
+  const double adjusted_value2 = expected_zero_crossing_value2 < 0.0
+                                     ? std::numeric_limits<double>::infinity()
+                                     : expected_zero_crossing_value2;
+  const double expected_zero_crossing =
+      std::min(adjusted_value1, adjusted_value2);
+
   CHECK(predictor.min_positive_zero_crossing_time(x_values.back()) ==
-        custom_approx(std::min(std::max(0.0, expected_zero_crossing_value1),
-                               std::max(0.0, expected_zero_crossing_value2))));
+        custom_approx(expected_zero_crossing));
 
   // Re-add the first point.  Adding the first point should cause the
   // (original) first point to be popped off the deque [and thus test
@@ -89,8 +97,7 @@ void test_zero_crossing_predictor() {
   DataVector first_point = y_values.front();
   predictor.add(x_values.front(), std::move(first_point));
   CHECK(predictor.min_positive_zero_crossing_time(0.0) ==
-        custom_approx(std::min(std::max(0.0, expected_zero_crossing_value1),
-                               std::max(0.0, expected_zero_crossing_value2))));
+        custom_approx(expected_zero_crossing));
 
   // Clear the predictor, and check that min_positive_zero_crossing_time
   // returns zero again for the cleared (and now invalid) predictor.


### PR DESCRIPTION
## Proposed changes

Previously, it replaced all negative times with 0 and then took the minimum so the minimum was almost always 0 in practice. Now it replaces negative times with inf and then takes the minimum. This works as desired.

Fixes #5044 also

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
