### PR TITLE
Allow adaptive mesh refinement for ExportCoordinates

### DIFF
--- a/src/Evolution/Initialization/DgDomain.hpp
+++ b/src/Evolution/Initialization/DgDomain.hpp
@@ -42,6 +42,7 @@
 #include "Parallel/AlgorithmExecution.hpp"
 #include "Parallel/GlobalCache.hpp"
 #include "Parallel/Tags/ArrayIndex.hpp"
+#include "ParallelAlgorithms/Amr/Protocols/Projector.hpp"
 #include "ParallelAlgorithms/Initialization/MutateAssign.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/Requires.hpp"
@@ -168,7 +169,7 @@ struct Domain {
 /// \brief Initialize/update items related to coordinate maps after an AMR
 /// change
 template <size_t Dim>
-struct ProjectDomain {
+struct ProjectDomain : tt::ConformsTo<amr::protocols::Projector> {
   using return_tags = tmpl::list<::domain::Tags::ElementMap<Dim, Frame::Grid>,
                                  ::domain::CoordinateMaps::Tags::CoordinateMap<
                                      Dim, Frame::Grid, Frame::Inertial>>;

--- a/src/Evolution/Initialization/Evolution.hpp
+++ b/src/Evolution/Initialization/Evolution.hpp
@@ -70,7 +70,8 @@ struct TimeStepping {
 
   /// Tags for constant items added to the GlobalCache.  These items are
   /// initialized from input file options.
-  using const_global_cache_tags = tmpl::list<>;
+  using const_global_cache_tags =
+      tmpl::list<::Tags::TimeStepper<TimeStepperType>>;
 
   /// Tags for mutable items added to the MutableGlobalCache.  These items are
   /// initialized from input file options.
@@ -82,10 +83,10 @@ struct TimeStepping {
                                    ::Tags::TimeStepper<TimeStepperType>>;
 
   /// Tags for simple DataBox items that are initialized from input file options
-  using simple_tags_from_options = tmpl::flatten<
-      tmpl::list<argument_tags,
-                 tmpl::conditional_t<UsingLts, tmpl::list<::Tags::StepChoosers>,
-                                     tmpl::list<>>>>;
+  using simple_tags_from_options = tmpl::flatten<tmpl::list<
+      ::Tags::Time, Tags::InitialTimeDelta, Tags::InitialSlabSize<UsingLts>,
+      tmpl::conditional_t<UsingLts, tmpl::list<::Tags::StepChoosers>,
+                          tmpl::list<>>>>;
 
   /// Tags for simple DataBox items that are default initialized.
   using default_initialized_simple_tags = tmpl::push_back<

--- a/src/Evolution/Initialization/Evolution.hpp
+++ b/src/Evolution/Initialization/Evolution.hpp
@@ -3,15 +3,25 @@
 
 #pragma once
 
+#include <array>
 #include <cstddef>
 #include <cstdint>
 #include <optional>
+#include <unordered_map>
+#include <utility>
 
+#include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataBox/PrefixHelpers.hpp"
 #include "DataStructures/DataBox/Prefixes.hpp"
+#include "Domain/Amr/Flag.hpp"
+#include "Domain/Amr/Helpers.hpp"
+#include "Domain/Amr/Tags/Flags.hpp"
+#include "Domain/Structure/ElementId.hpp"
 #include "Domain/Tags.hpp"
 #include "Evolution/Initialization/Tags.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "Parallel/Tags/ArrayIndex.hpp"
+#include "Time/AdaptiveSteppingDiagnostics.hpp"
 #include "Time/ChooseLtsStepSize.hpp"
 #include "Time/Slab.hpp"
 #include "Time/StepChoosers/StepChooser.hpp"
@@ -26,8 +36,10 @@
 #include "Time/TimeStepId.hpp"
 #include "Time/TimeSteppers/LtsTimeStepper.hpp"
 #include "Time/TimeSteppers/TimeStepper.hpp"
+#include "Utilities/Algorithm.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
 
 namespace Initialization {
 
@@ -141,6 +153,105 @@ struct TimeStepping {
                                   time_runs_forward, time_stepper);
     *time_step = (time_runs_forward ? 1 : -1) * initial_time.slab().duration();
     *next_time_step = *time_step;
+  }
+};
+
+/// \brief Initialize/update items related to time stepping after an AMR change
+template <size_t Dim>
+struct ProjectTimeStepping {
+  using return_tags =
+      tmpl::list<::Tags::TimeStepId, ::Tags::Next<::Tags::TimeStepId>,
+                 ::Tags::TimeStep, ::Tags::Next<::Tags::TimeStep>, ::Tags::Time,
+                 ::Tags::AdaptiveSteppingDiagnostics>;
+  using argument_tags = tmpl::list<Parallel::Tags::ArrayIndex>;
+
+  static void apply(
+      const gsl::not_null<TimeStepId*> /*time_step_id*/,
+      const gsl::not_null<TimeStepId*> /*next_time_step_id*/,
+      const gsl::not_null<TimeDelta*> /*time_step*/,
+      const gsl::not_null<TimeDelta*> /*next_time_step*/,
+      const gsl::not_null<double*> /*time*/,
+      const gsl::not_null<AdaptiveSteppingDiagnostics*>
+      /*adaptive_stepping_diagnostics*/,
+      const ElementId<Dim>& /*element_id*/,
+      const std::pair<Mesh<Dim>, Element<Dim>>& /*old_mesh_and_element*/) {
+    // Do not change anything for p-refinement
+  }
+
+  template <typename... Tags>
+  static void apply(const gsl::not_null<TimeStepId*> time_step_id,
+                    const gsl::not_null<TimeStepId*> next_time_step_id,
+                    const gsl::not_null<TimeDelta*> time_step,
+                    const gsl::not_null<TimeDelta*> next_time_step,
+                    const gsl::not_null<double*> time,
+                    const gsl::not_null<AdaptiveSteppingDiagnostics*>
+                        adaptive_stepping_diagnostics,
+                    const ElementId<Dim>& element_id,
+                    const tuples::TaggedTuple<Tags...>& parent_items) {
+    *time_step_id = get<::Tags::TimeStepId>(parent_items);
+    *next_time_step_id = get<::Tags::Next<::Tags::TimeStepId>>(parent_items);
+    *time_step = get<::Tags::TimeStep>(parent_items);
+    *next_time_step = get<::Tags::Next<::Tags::TimeStep>>(parent_items);
+    *time = get<::Tags::Time>(parent_items);
+
+    // Since AdaptiveSteppingDiagnostics are reduced over all elements, we
+    // set the slab quantities to the same value over all children, and the
+    // step quantities to belong to the first child
+    const auto& parent_diagnostics =
+        get<::Tags::AdaptiveSteppingDiagnostics>(parent_items);
+    const auto& parent_amr_flags = get<amr::Tags::Flags<Dim>>(parent_items);
+    const auto& parent_id =
+        get<Parallel::Tags::ArrayIndexImpl<ElementId<Dim>>>(parent_items);
+    auto children_ids = amr::ids_of_children(parent_id, parent_amr_flags);
+    if (element_id == children_ids.front()) {
+      *adaptive_stepping_diagnostics = parent_diagnostics;
+    } else {
+      adaptive_stepping_diagnostics->number_of_slabs =
+          parent_diagnostics.number_of_slabs;
+      adaptive_stepping_diagnostics->number_of_slab_size_changes =
+          parent_diagnostics.number_of_slab_size_changes;
+    }
+  }
+
+  template <typename... Tags>
+  static void apply(
+      const gsl::not_null<TimeStepId*> time_step_id,
+      const gsl::not_null<TimeStepId*> next_time_step_id,
+      const gsl::not_null<TimeDelta*> time_step,
+      const gsl::not_null<TimeDelta*> next_time_step,
+      const gsl::not_null<double*> time,
+      const gsl::not_null<AdaptiveSteppingDiagnostics*>
+          adaptive_stepping_diagnostics,
+      const ElementId<Dim>& /*element_id*/,
+      const std::unordered_map<ElementId<Dim>, tuples::TaggedTuple<Tags...>>&
+          children_items) {
+    const auto slowest_child =
+        alg::min_element(children_items, [](const auto& a, const auto& b) {
+          const auto& time_step_a = get<::Tags::TimeStep>(a.second);
+          const auto& time_step_b = get<::Tags::TimeStep>(b.second);
+          ASSERT(time_step_a.is_positive() == time_step_b.is_positive(),
+                 "Elements are not taking time steps in the same direction!");
+          return time_step_a.is_positive() ? (time_step_a < time_step_b)
+                                           : (time_step_a > time_step_b);
+        });
+    const auto& slowest_child_items = (*slowest_child).second;
+    *time_step_id = get<::Tags::TimeStepId>(slowest_child_items);
+    *next_time_step_id =
+        get<::Tags::Next<::Tags::TimeStepId>>(slowest_child_items);
+    *time_step = get<::Tags::TimeStep>(slowest_child_items);
+    *next_time_step = get<::Tags::Next<::Tags::TimeStep>>(slowest_child_items);
+    *time = get<::Tags::Time>(slowest_child_items);
+    const auto& slowest_child_diagnostics =
+        get<::Tags::AdaptiveSteppingDiagnostics>(slowest_child_items);
+
+    adaptive_stepping_diagnostics->number_of_slabs =
+        slowest_child_diagnostics.number_of_slabs;
+    adaptive_stepping_diagnostics->number_of_slab_size_changes =
+        slowest_child_diagnostics.number_of_slab_size_changes;
+    for (const auto& [_, child_items] : children_items) {
+      *adaptive_stepping_diagnostics +=
+          get<::Tags::AdaptiveSteppingDiagnostics>(child_items);
+    }
   }
 };
 

--- a/src/Evolution/Initialization/Evolution.hpp
+++ b/src/Evolution/Initialization/Evolution.hpp
@@ -21,6 +21,7 @@
 #include "Evolution/Initialization/Tags.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "Parallel/Tags/ArrayIndex.hpp"
+#include "ParallelAlgorithms/Amr/Protocols/Projector.hpp"
 #include "Time/AdaptiveSteppingDiagnostics.hpp"
 #include "Time/ChooseLtsStepSize.hpp"
 #include "Time/Slab.hpp"
@@ -158,7 +159,7 @@ struct TimeStepping {
 
 /// \brief Initialize/update items related to time stepping after an AMR change
 template <size_t Dim>
-struct ProjectTimeStepping {
+struct ProjectTimeStepping : tt::ConformsTo<amr::protocols::Projector> {
   using return_tags =
       tmpl::list<::Tags::TimeStepId, ::Tags::Next<::Tags::TimeStepId>,
                  ::Tags::TimeStep, ::Tags::Next<::Tags::TimeStep>, ::Tags::Time,

--- a/src/Executables/Examples/RandomAmr/RandomAmr.hpp
+++ b/src/Executables/Examples/RandomAmr/RandomAmr.hpp
@@ -34,6 +34,7 @@
 #include "ParallelAlgorithms/Amr/Criteria/DriveToTarget.hpp"
 #include "ParallelAlgorithms/Amr/Criteria/Random.hpp"
 #include "ParallelAlgorithms/Amr/Criteria/Tags/Criteria.hpp"
+#include "ParallelAlgorithms/Amr/Protocols/AmrMetavariables.hpp"
 #include "ParallelAlgorithms/EventsAndTriggers/LogicalTriggers.hpp"
 #include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
 #include "Utilities/ErrorHandling/SegfaultHandler.hpp"
@@ -108,7 +109,9 @@ struct RandomAmrMetavars {
   // NOLINTNEXTLINE(google-runtime-references)
   void pup(PUP::er& /*p*/) {}
 
-  using amr_mutators = tmpl::list<>;
+  struct amr : tt::ConformsTo<::amr::protocols::AmrMetavariables> {
+    using projectors = tmpl::list<>;
+  };
 };
 
 static const std::vector<void (*)()> charm_init_node_funcs{

--- a/src/Executables/Examples/RandomAmr/RandomAmr.hpp
+++ b/src/Executables/Examples/RandomAmr/RandomAmr.hpp
@@ -107,6 +107,8 @@ struct RandomAmrMetavars {
 
   // NOLINTNEXTLINE(google-runtime-references)
   void pup(PUP::er& /*p*/) {}
+
+  using amr_mutators = tmpl::list<>;
 };
 
 static const std::vector<void (*)()> charm_init_node_funcs{

--- a/src/Executables/ExportCoordinates/CMakeLists.txt
+++ b/src/Executables/ExportCoordinates/CMakeLists.txt
@@ -2,6 +2,9 @@
 # See LICENSE.txt for details.
 
 set(LIBS_TO_LINK
+  Amr
+  AmrCriteria
+  AmrProjectors
   CoordinateMaps
   DgSubcell
   Domain
@@ -13,6 +16,8 @@ set(LIBS_TO_LINK
   Observer
   Options
   Parallel
+  PhaseControl
+  Spectral
   Time
   Utilities
   )

--- a/src/Executables/ExportCoordinates/ExportCoordinates.hpp
+++ b/src/Executables/ExportCoordinates/ExportCoordinates.hpp
@@ -65,6 +65,7 @@
 #include "ParallelAlgorithms/Amr/Criteria/DriveToTarget.hpp"
 #include "ParallelAlgorithms/Amr/Criteria/Random.hpp"
 #include "ParallelAlgorithms/Amr/Criteria/Tags/Criteria.hpp"
+#include "ParallelAlgorithms/Amr/Protocols/AmrMetavariables.hpp"
 #include "ParallelAlgorithms/EventsAndTriggers/Completion.hpp"
 #include "ParallelAlgorithms/EventsAndTriggers/Event.hpp"
 #include "ParallelAlgorithms/EventsAndTriggers/EventsAndTriggers.hpp"
@@ -320,9 +321,10 @@ struct Metavariables {
                  observers::Actions::RegisterWithObservers<
                      Actions::FindGlobalMinimumGridSpacing>>;
 
-  using amr_mutators =
-      tmpl::list<Initialization::ProjectTimeStepping<volume_dim>,
-                 evolution::dg::Initialization::ProjectDomain<volume_dim>>;
+  struct amr : tt::ConformsTo<::amr::protocols::AmrMetavariables> {
+    using projectors =
+        tmpl::list<Initialization::ProjectTimeStepping<volume_dim>,
+                   evolution::dg::Initialization::ProjectDomain<volume_dim>>;
   };
 
   using dg_element_array = DgElementArray<
@@ -334,12 +336,12 @@ struct Metavariables {
                              Initialization::TimeStepping<Metavariables,
                                                           local_time_stepping>,
                              evolution::dg::Initialization::Domain<Dim>,
-                             amr::Initialization::Initialize<volume_dim>,
+                             ::amr::Initialization::Initialize<volume_dim>,
                              Initialization::SetMeshType<Dim>>,
-                      Initialization::Actions::AddComputeTags<tmpl::list<
+                         Initialization::Actions::AddComputeTags<tmpl::list<
                              ::domain::Tags::MinimumGridSpacingCompute<
-                              Dim, Frame::Inertial>,
-                          ::domain::Tags::FlatLogicalMetricCompute<Dim>>>,
+                                 Dim, Frame::Inertial>,
+                             ::domain::Tags::FlatLogicalMetricCompute<Dim>>>,
                          Parallel::Actions::TerminatePhase>>,
           Parallel::PhaseActions<
               Parallel::Phase::Register,
@@ -363,7 +365,7 @@ struct Metavariables {
   };
 
   using component_list =
-      tmpl::list<amr::Component<Metavariables>, dg_element_array,
+      tmpl::list<::amr::Component<Metavariables>, dg_element_array,
                  observers::Observer<Metavariables>,
                  observers::ObserverWriter<Metavariables>>;
 

--- a/src/Executables/ExportCoordinates/ExportCoordinates.hpp
+++ b/src/Executables/ExportCoordinates/ExportCoordinates.hpp
@@ -47,11 +47,24 @@
 #include "Parallel/Invoke.hpp"
 #include "Parallel/Local.hpp"
 #include "Parallel/Phase.hpp"
+#include "Parallel/PhaseControl/CheckpointAndExitAfterWallclock.hpp"
+#include "Parallel/PhaseControl/ExecutePhaseChange.hpp"
+#include "Parallel/PhaseControl/VisitAndReturn.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
 #include "Parallel/Reduction.hpp"
 #include "ParallelAlgorithms/Actions/AddComputeTags.hpp"
 #include "ParallelAlgorithms/Actions/InitializeItems.hpp"
 #include "ParallelAlgorithms/Actions/TerminatePhase.hpp"
+#include "ParallelAlgorithms/Amr/Actions/CollectDataFromChildren.hpp"
+#include "ParallelAlgorithms/Amr/Actions/Component.hpp"
+#include "ParallelAlgorithms/Amr/Actions/CreateChild.hpp"
+#include "ParallelAlgorithms/Amr/Actions/Initialize.hpp"
+#include "ParallelAlgorithms/Amr/Actions/RegisterCallbacks.hpp"
+#include "ParallelAlgorithms/Amr/Actions/SendAmrDiagnostics.hpp"
+#include "ParallelAlgorithms/Amr/Criteria/Criterion.hpp"
+#include "ParallelAlgorithms/Amr/Criteria/DriveToTarget.hpp"
+#include "ParallelAlgorithms/Amr/Criteria/Random.hpp"
+#include "ParallelAlgorithms/Amr/Criteria/Tags/Criteria.hpp"
 #include "ParallelAlgorithms/EventsAndTriggers/Completion.hpp"
 #include "ParallelAlgorithms/EventsAndTriggers/Event.hpp"
 #include "ParallelAlgorithms/EventsAndTriggers/EventsAndTriggers.hpp"
@@ -269,7 +282,7 @@ struct Metavariables {
     static constexpr bool enable_time_dependent_maps = EnableTimeDependentMaps;
   };
 
-  using const_global_cache_tags = tmpl::list<>;
+  using const_global_cache_tags = tmpl::list<amr::Criteria::Tags::Criteria>;
 
   static constexpr Options::String help{
       "Export the inertial coordinates of the Domain specified in the input "
@@ -282,53 +295,85 @@ struct Metavariables {
       : tt::ConformsTo<Options::protocols::FactoryCreation> {
     using factory_classes = tmpl::map<
         tmpl::pair<DomainCreator<volume_dim>, domain_creators<volume_dim>>,
+        tmpl::pair<amr::Criterion,
+                   tmpl::list<amr::Criteria::DriveToTarget<volume_dim>,
+                              amr::Criteria::Random>>,
+        tmpl::pair<
+            PhaseChange,
+            tmpl::list<
+                PhaseControl::VisitAndReturn<
+                    Parallel::Phase::EvaluateAmrCriteria>,
+                PhaseControl::VisitAndReturn<Parallel::Phase::AdjustDomain>,
+                PhaseControl::VisitAndReturn<Parallel::Phase::CheckDomain>,
+                PhaseControl::CheckpointAndExitAfterWallclock>>,
         tmpl::pair<StepChooser<StepChooserUse::LtsStep>, tmpl::list<>>,
         tmpl::pair<StepChooser<StepChooserUse::Slab>, tmpl::list<>>,
         tmpl::pair<Event, tmpl::list<Events::Completion>>,
         tmpl::pair<TimeStepper, TimeSteppers::time_steppers>,
-        tmpl::pair<Trigger,
-                   tmpl::list<Triggers::SlabCompares, Triggers::TimeCompares>>>;
+        tmpl::pair<Trigger, tmpl::list<Triggers::Always, Triggers::SlabCompares,
+                                       Triggers::TimeCompares>>>;
   };
 
-  using component_list = tmpl::list<
-      DgElementArray<
-          Metavariables,
-          tmpl::list<
-              Parallel::PhaseActions<
-                  Parallel::Phase::Initialization,
-                  tmpl::list<
-                      Initialization::Actions::InitializeItems<
-                          Initialization::TimeStepping<Metavariables,
-                                                       local_time_stepping>,
-                          evolution::dg::Initialization::Domain<Dim>,
-                          Initialization::SetMeshType<Dim>>,
+  using dg_registration_list =
+      tmpl::list<observers::Actions::RegisterWithObservers<
+                     Actions::ExportCoordinates<Dim>>,
+                 observers::Actions::RegisterWithObservers<
+                     Actions::FindGlobalMinimumGridSpacing>>;
+
+  using amr_mutators =
+      tmpl::list<Initialization::ProjectTimeStepping<volume_dim>,
+                 evolution::dg::Initialization::ProjectDomain<volume_dim>>;
+  };
+
+  using dg_element_array = DgElementArray<
+      Metavariables,
+      tmpl::list<
+          Parallel::PhaseActions<
+              Parallel::Phase::Initialization,
+              tmpl::list<Initialization::Actions::InitializeItems<
+                             Initialization::TimeStepping<Metavariables,
+                                                          local_time_stepping>,
+                             evolution::dg::Initialization::Domain<Dim>,
+                             amr::Initialization::Initialize<volume_dim>,
+                             Initialization::SetMeshType<Dim>>,
                       Initialization::Actions::AddComputeTags<tmpl::list<
-                          ::domain::Tags::MinimumGridSpacingCompute<
+                             ::domain::Tags::MinimumGridSpacingCompute<
                               Dim, Frame::Inertial>,
                           ::domain::Tags::FlatLogicalMetricCompute<Dim>>>,
-                      Parallel::Actions::TerminatePhase>>,
-              Parallel::PhaseActions<
-                  Parallel::Phase::Register,
-                  tmpl::list<observers::Actions::RegisterWithObservers<
-                                 Actions::ExportCoordinates<Dim>>,
-                             observers::Actions::RegisterWithObservers<
-                                 Actions::FindGlobalMinimumGridSpacing>,
-                             Parallel::Actions::TerminatePhase>>,
-              Parallel::PhaseActions<
-                  Parallel::Phase::Execute,
-                  tmpl::list<Actions::AdvanceTime,
-                             Actions::ExportCoordinates<Dim>,
-                             Actions::FindGlobalMinimumGridSpacing,
-                             evolution::Actions::RunEventsAndTriggers>>>>,
-      observers::Observer<Metavariables>,
-      observers::ObserverWriter<Metavariables>>;
+                         Parallel::Actions::TerminatePhase>>,
+          Parallel::PhaseActions<
+              Parallel::Phase::Register,
+              tmpl::push_back<dg_registration_list,
+                              Parallel::Actions::TerminatePhase>>,
+          Parallel::PhaseActions<Parallel::Phase::CheckDomain,
+                                 tmpl::list<::amr::Actions::SendAmrDiagnostics,
+                                            Parallel::Actions::TerminatePhase>>,
+          Parallel::PhaseActions<
+              Parallel::Phase::Execute,
+              tmpl::list<Actions::AdvanceTime, Actions::ExportCoordinates<Dim>,
+                         Actions::FindGlobalMinimumGridSpacing,
+                         evolution::Actions::RunEventsAndTriggers,
+                         PhaseControl::Actions::ExecutePhaseChange>>>>;
+
+  template <typename ParallelComponent>
+  struct registration_list {
+    using type =
+        std::conditional_t<std::is_same_v<ParallelComponent, dg_element_array>,
+                           dg_registration_list, tmpl::list<>>;
+  };
+
+  using component_list =
+      tmpl::list<amr::Component<Metavariables>, dg_element_array,
+                 observers::Observer<Metavariables>,
+                 observers::ObserverWriter<Metavariables>>;
 
   using observed_reduction_data_tags = observers::make_reduction_data_tags<
       tmpl::list<MinGridSpacingReductionData>>;
 
-  static constexpr std::array<Parallel::Phase, 4> default_phase_order{
-      {Parallel::Phase::Initialization, Parallel::Phase::Register,
-       Parallel::Phase::Execute, Parallel::Phase::Exit}};
+  static constexpr auto default_phase_order =
+      std::array{Parallel::Phase::Initialization, Parallel::Phase::Register,
+                 Parallel::Phase::CheckDomain, Parallel::Phase::Execute,
+                 Parallel::Phase::Exit};
 
   // NOLINTNEXTLINE(google-runtime-references)
   void pup(PUP::er& /*p*/) {}
@@ -341,7 +386,9 @@ static const std::vector<void (*)()> charm_init_node_funcs{
     &domain::creators::register_derived_with_charm,
     &domain::creators::time_dependence::register_derived_with_charm,
     &domain::FunctionsOfTime::register_derived_with_charm,
-    &register_factory_classes_with_charm<metavariables>};
+    &register_factory_classes_with_charm<metavariables>,
+    &amr::register_callbacks<metavariables,
+                             typename metavariables::dg_element_array>};
 static const std::vector<void (*)()> charm_init_proc_funcs{
     &enable_floating_point_exceptions, &enable_segfault_handler};
 /// \endcond

--- a/src/Parallel/CMakeLists.txt
+++ b/src/Parallel/CMakeLists.txt
@@ -29,6 +29,7 @@ spectre_target_headers(
   CharmRegistration.hpp
   CreateFromOptions.hpp
   DistributedObject.hpp
+  ElementRegistration.hpp
   ExitCode.hpp
   GetSection.hpp
   GlobalCache.hpp

--- a/src/Parallel/ElementRegistration.hpp
+++ b/src/Parallel/ElementRegistration.hpp
@@ -1,0 +1,91 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <type_traits>
+
+#include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+namespace db {
+template <typename DbTagList>
+class DataBox;
+}  // namespace db
+namespace Parallel {
+template <typename Metavariables>
+class GlobalCache;
+}  // namespace Parallel
+/// \endcond
+
+namespace Parallel {
+namespace detail {
+template <typename Metavariables, typename ParallelComponent,
+          typename = std::void_t<>>
+struct has_registration_list : std::false_type {};
+
+template <typename Metavariables, typename ParallelComponent>
+struct has_registration_list<
+    Metavariables, ParallelComponent,
+    std::void_t<typename Metavariables::template registration_list<
+        ParallelComponent>::type>> : std::true_type {};
+
+template <typename Metavariables, typename ParallelComponent>
+constexpr bool has_registration_list_v =
+    has_registration_list<Metavariables, ParallelComponent>::value;
+
+template <typename Metavariables, typename ParallelComponent>
+using registration_list =
+    typename Metavariables::template registration_list<ParallelComponent>::type;
+}  // namespace detail
+
+/// @{
+/// \brief (De)register an array element for specified actions
+///
+/// \details Array elements are (de)registered with actions on components that
+/// need to know which elements are contributing data before the action can be
+/// executed.  If array elements are migrated (e.g. during load balancing),
+/// or are created/destroyed (e.g. during adaptive mesh refinement), these
+/// functions must be called in order to (un)register (old) new elements.
+/// The list of registration actions is obtained from
+/// `Metavariables::registration_list::type`.
+template <typename ParallelComponent, typename DbTagList,
+          typename Metavariables, typename ArrayIndex>
+void deregister_element(db::DataBox<DbTagList>& box,
+                        Parallel::GlobalCache<Metavariables>& cache,
+                        const ArrayIndex& array_index) {
+  if constexpr (detail::has_registration_list_v<Metavariables,
+                                                ParallelComponent>) {
+    using registration_list =
+        typename Metavariables::template registration_list<
+            ParallelComponent>::type;
+    tmpl::for_each<registration_list>(
+        [&box, &cache, &array_index](auto registration_v) {
+          using registration = typename decltype(registration_v)::type;
+          registration::template perform_deregistration<ParallelComponent>(
+              box, cache, array_index);
+        });
+  }
+}
+
+template <typename ParallelComponent, typename DbTagList,
+          typename Metavariables, typename ArrayIndex>
+void register_element(db::DataBox<DbTagList>& box,
+                      Parallel::GlobalCache<Metavariables>& cache,
+                      const ArrayIndex& array_index) {
+  if constexpr (detail::has_registration_list_v<Metavariables,
+                                                ParallelComponent>) {
+    using registration_list =
+        typename Metavariables::template registration_list<
+            ParallelComponent>::type;
+    tmpl::for_each<registration_list>(
+        [&box, &cache, &array_index](auto registration_v) {
+          using registration = typename decltype(registration_v)::type;
+          registration::template perform_registration<ParallelComponent>(
+              box, cache, array_index);
+        });
+  }
+}
+/// @}
+}  // namespace Parallel

--- a/src/ParallelAlgorithms/Amr/Actions/AdjustDomain.hpp
+++ b/src/ParallelAlgorithms/Amr/Actions/AdjustDomain.hpp
@@ -54,7 +54,7 @@ namespace amr::Actions {
 /// - Updates the Neighbors of the Element
 /// - Resets amr::Tags::Flag%s to amr::Flag::Undefined
 /// - Resets amr::Tags::NeighborFlags to an empty map
-/// - Mutates all return_tags of Metavariables::amr_mutators
+/// - Mutates all return_tags of Metavariables::amr::projectors
 struct AdjustDomain {
   template <typename ParallelComponent, typename DbTagList,
             typename Metavariables>
@@ -133,14 +133,14 @@ struct AdjustDomain {
             make_not_null(&box));
       }
 
-      // Run the mutators on all elements, even if they did no h-refinement.
-      // This allows mutators to update mutable items that depend upon the
+      // Run the projectors on all elements, even if they did no h-refinement.
+      // This allows projectors to update mutable items that depend upon the
       // neighbors of the element.
-      tmpl::for_each<typename Metavariables::amr_mutators>(
-          [&box, &old_mesh_and_element](auto mutator_v) {
-            using mutator = typename decltype(mutator_v)::type;
-            db::mutate_apply<mutator>(make_not_null(&box),
-                                      old_mesh_and_element);
+      tmpl::for_each<typename Metavariables::amr::projectors>(
+          [&box, &old_mesh_and_element](auto projector_v) {
+            using projector = typename decltype(projector_v)::type;
+            db::mutate_apply<projector>(make_not_null(&box),
+                                        old_mesh_and_element);
           });
 
       // Reset the AMR flags

--- a/src/ParallelAlgorithms/Amr/Actions/CMakeLists.txt
+++ b/src/ParallelAlgorithms/Amr/Actions/CMakeLists.txt
@@ -16,6 +16,7 @@ spectre_target_headers(
   Initialize.hpp
   InitializeChild.hpp
   InitializeParent.hpp
+  RegisterCallbacks.hpp
   RunAmrDiagnostics.hpp
   SendAmrDiagnostics.hpp
   SendDataToChildren.hpp

--- a/src/ParallelAlgorithms/Amr/Actions/CollectDataFromChildren.hpp
+++ b/src/ParallelAlgorithms/Amr/Actions/CollectDataFromChildren.hpp
@@ -16,6 +16,7 @@
 #include "Domain/Structure/Element.hpp"
 #include "Domain/Structure/ElementId.hpp"
 #include "Domain/Tags.hpp"
+#include "Parallel/ElementRegistration.hpp"
 #include "Parallel/GlobalCache.hpp"
 #include "Parallel/Invoke.hpp"
 #include "ParallelAlgorithms/Amr/Actions/InitializeParent.hpp"
@@ -56,6 +57,8 @@ struct CollectDataFromChildren {
     Parallel::simple_action<CollectDataFromChildren>(
         array_proxy[next_child_id], parent_id, sibling_ids_to_collect,
         std::move(children_data));
+
+    Parallel::deregister_element<ParallelComponent>(box, cache, child_id);
     array_proxy[child_id].ckDestroy();
   }
 
@@ -115,6 +118,8 @@ struct CollectDataFromChildren {
           array_proxy[next_child_id], parent_id, sibling_ids_to_collect,
           std::move(children_data));
     }
+
+    Parallel::deregister_element<ParallelComponent>(box, cache, child_id);
     array_proxy[child_id].ckDestroy();
   }
 };

--- a/src/ParallelAlgorithms/Amr/Actions/InitializeChild.hpp
+++ b/src/ParallelAlgorithms/Amr/Actions/InitializeChild.hpp
@@ -41,7 +41,7 @@ namespace amr::Actions {
 /// - Modifies:
 ///   * domain::Tags::Element<volume_dim>
 ///   * domain::Tags::Mesh<volume_dim>
-///   * all return_tags of Metavariables::amr_mutators
+///   * all return_tags of Metavariables::amr::projectors
 ///
 /// \details This action is meant to be invoked by
 /// amr::Actions::SendDataToChildren
@@ -73,10 +73,10 @@ struct InitializeChild {
         ::domain::Tags::Element<volume_dim>, ::domain::Tags::Mesh<volume_dim>>>(
         make_not_null(&box), std::move(child), std::move(child_mesh));
 
-    tmpl::for_each<typename Metavariables::amr_mutators>(
-        [&box, &parent_items](auto mutator_v) {
-          using mutator = typename decltype(mutator_v)::type;
-          db::mutate_apply<mutator>(make_not_null(&box), parent_items);
+    tmpl::for_each<typename Metavariables::amr::projectors>(
+        [&box, &parent_items](auto projector_v) {
+          using projector = typename decltype(projector_v)::type;
+          db::mutate_apply<projector>(make_not_null(&box), parent_items);
         });
 
     Parallel::register_element<ParallelComponent>(box, cache, child_id);

--- a/src/ParallelAlgorithms/Amr/Actions/InitializeChild.hpp
+++ b/src/ParallelAlgorithms/Amr/Actions/InitializeChild.hpp
@@ -19,6 +19,7 @@
 #include "Domain/Structure/Neighbors.hpp"
 #include "Domain/Tags.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "Parallel/ElementRegistration.hpp"
 #include "ParallelAlgorithms/Amr/Projectors/Mesh.hpp"
 #include "ParallelAlgorithms/Initialization/MutateAssign.hpp"
 #include "Utilities/Gsl.hpp"
@@ -51,7 +52,7 @@ struct InitializeChild {
   template <typename ParallelComponent, typename DbTagList,
             typename Metavariables, typename... Tags>
   static void apply(db::DataBox<DbTagList>& box,
-                    const Parallel::GlobalCache<Metavariables>& /*cache*/,
+                    Parallel::GlobalCache<Metavariables>& cache,
                     const ElementId<Metavariables::volume_dim>& child_id,
                     const tuples::TaggedTuple<Tags...>& parent_items) {
     constexpr size_t volume_dim = Metavariables::volume_dim;
@@ -77,6 +78,8 @@ struct InitializeChild {
 
     // In the near future, add the capability of updating all data needed for
     // an evolution or elliptic system
+
+    Parallel::register_element<ParallelComponent>(box, cache, child_id);
   }
 };
 }  // namespace amr::Actions

--- a/src/ParallelAlgorithms/Amr/Actions/InitializeChild.hpp
+++ b/src/ParallelAlgorithms/Amr/Actions/InitializeChild.hpp
@@ -37,14 +37,11 @@ namespace amr::Actions {
 /// \brief Initializes the data of a newly created child element from the data
 /// of its parent element
 ///
-/// \warning At the moment, this action only initializes the Element, Mesh,
-/// and amr::Flag%s of the child element.  It does not initialize any data
-/// related to evolution or elliptic solves.
-///
 /// DataBox:
 /// - Modifies:
 ///   * domain::Tags::Element<volume_dim>
 ///   * domain::Tags::Mesh<volume_dim>
+///   * all return_tags of Metavariables::amr_mutators
 ///
 /// \details This action is meant to be invoked by
 /// amr::Actions::SendDataToChildren
@@ -76,8 +73,11 @@ struct InitializeChild {
         ::domain::Tags::Element<volume_dim>, ::domain::Tags::Mesh<volume_dim>>>(
         make_not_null(&box), std::move(child), std::move(child_mesh));
 
-    // In the near future, add the capability of updating all data needed for
-    // an evolution or elliptic system
+    tmpl::for_each<typename Metavariables::amr_mutators>(
+        [&box, &parent_items](auto mutator_v) {
+          using mutator = typename decltype(mutator_v)::type;
+          db::mutate_apply<mutator>(make_not_null(&box), parent_items);
+        });
 
     Parallel::register_element<ParallelComponent>(box, cache, child_id);
   }

--- a/src/ParallelAlgorithms/Amr/Actions/InitializeParent.hpp
+++ b/src/ParallelAlgorithms/Amr/Actions/InitializeParent.hpp
@@ -43,7 +43,7 @@ namespace amr::Actions {
 /// - Modifies:
 ///   * domain::Tags::Element<volume_dim>
 ///   * domain::Tags::Mesh<volume_dim>
-///   * all return_tags of Metavariables::amr_mutators
+///   * all return_tags of Metavariables::amr::projectors
 ///
 /// \details This action is meant to be invoked by
 /// amr::Actions::CollectDataFromChildren
@@ -92,10 +92,10 @@ struct InitializeParent {
         ::domain::Tags::Element<volume_dim>, ::domain::Tags::Mesh<volume_dim>>>(
         make_not_null(&box), std::move(parent), std::move(parent_mesh));
 
-    tmpl::for_each<typename Metavariables::amr_mutators>(
-        [&box, &children_items](auto mutator_v) {
-          using mutator = typename decltype(mutator_v)::type;
-          db::mutate_apply<mutator>(make_not_null(&box), children_items);
+    tmpl::for_each<typename Metavariables::amr::projectors>(
+        [&box, &children_items](auto projector_v) {
+          using projector = typename decltype(projector_v)::type;
+          db::mutate_apply<projector>(make_not_null(&box), children_items);
         });
 
     Parallel::register_element<ParallelComponent>(box, cache, parent_id);

--- a/src/ParallelAlgorithms/Amr/Actions/InitializeParent.hpp
+++ b/src/ParallelAlgorithms/Amr/Actions/InitializeParent.hpp
@@ -21,6 +21,7 @@
 #include "Domain/Structure/Neighbors.hpp"
 #include "Domain/Tags.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "Parallel/ElementRegistration.hpp"
 #include "ParallelAlgorithms/Amr/Projectors/Mesh.hpp"
 #include "ParallelAlgorithms/Initialization/MutateAssign.hpp"
 #include "Utilities/Gsl.hpp"
@@ -53,8 +54,7 @@ struct InitializeParent {
   template <typename ParallelComponent, typename DbTagList,
             typename Metavariables>
   static void apply(
-      db::DataBox<DbTagList>& box,
-      const Parallel::GlobalCache<Metavariables>& /*cache*/,
+      db::DataBox<DbTagList>& box, Parallel::GlobalCache<Metavariables>& cache,
       const ElementId<Metavariables::volume_dim>& parent_id,
       std::unordered_map<
           ElementId<Metavariables::volume_dim>,
@@ -97,6 +97,8 @@ struct InitializeParent {
 
     // In the near future, add the capability of updating all data needed for
     // an evolution or elliptic system
+
+    Parallel::register_element<ParallelComponent>(box, cache, parent_id);
   }
 };
 }  // namespace amr::Actions

--- a/src/ParallelAlgorithms/Amr/Actions/RegisterCallbacks.hpp
+++ b/src/ParallelAlgorithms/Amr/Actions/RegisterCallbacks.hpp
@@ -1,0 +1,38 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <deque>
+#include <vector>
+
+#include "Parallel/Callback.hpp"
+#include "ParallelAlgorithms/Amr/Actions/CollectDataFromChildren.hpp"
+#include "ParallelAlgorithms/Amr/Actions/Component.hpp"
+#include "ParallelAlgorithms/Amr/Actions/CreateChild.hpp"
+#include "ParallelAlgorithms/Amr/Actions/SendDataToChildren.hpp"
+#include "Utilities/Serialization/RegisterDerivedClassesWithCharm.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace amr {
+template <typename Metavariables, typename Component>
+void register_callbacks() {
+  using ArrayIndex = typename Component::array_index;
+  register_classes_with_charm(
+      tmpl::list<
+          Parallel::SimpleActionCallback<
+              amr::Actions::CreateChild,
+              CProxy_AlgorithmSingleton<amr::Component<Metavariables>, int>,
+              CProxy_AlgorithmArray<Component, ArrayIndex>, ArrayIndex,
+              std::vector<ArrayIndex>, size_t>,
+          Parallel::SimpleActionCallback<
+              amr::Actions::SendDataToChildren,
+              CProxyElement_AlgorithmArray<Component, ArrayIndex>,
+              std::vector<ArrayIndex>>,
+          Parallel::SimpleActionCallback<
+              amr::Actions::CollectDataFromChildren,
+              CProxyElement_AlgorithmArray<Component, ArrayIndex>, ArrayIndex,
+              std::deque<ArrayIndex>>>{});
+}
+}  // namespace amr

--- a/src/ParallelAlgorithms/Amr/Actions/SendDataToChildren.hpp
+++ b/src/ParallelAlgorithms/Amr/Actions/SendDataToChildren.hpp
@@ -7,6 +7,7 @@
 
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "Domain/Structure/ElementId.hpp"
+#include "Parallel/ElementRegistration.hpp"
 #include "Parallel/GlobalCache.hpp"
 #include "Parallel/Invoke.hpp"
 #include "ParallelAlgorithms/Amr/Actions/InitializeChild.hpp"
@@ -37,6 +38,9 @@ struct SendDataToChildren {
               typename db::DataBox<DbTagList>::mutable_item_creation_tags>(
               box));
     }
+
+    Parallel::deregister_element<ParallelComponent>(box, cache, element_id);
+
     array_proxy[element_id].ckDestroy();
   }
 };

--- a/src/ParallelAlgorithms/Amr/CMakeLists.txt
+++ b/src/ParallelAlgorithms/Amr/CMakeLists.txt
@@ -25,3 +25,4 @@ target_link_libraries(
 add_subdirectory(Actions)
 add_subdirectory(Criteria)
 add_subdirectory(Projectors)
+add_subdirectory(Protocols)

--- a/src/ParallelAlgorithms/Amr/Protocols/AmrMetavariables.hpp
+++ b/src/ParallelAlgorithms/Amr/Protocols/AmrMetavariables.hpp
@@ -1,0 +1,34 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <type_traits>
+
+#include "ParallelAlgorithms/Amr/Protocols/Projector.hpp"
+
+namespace amr::protocols {
+/// \brief Compile-time information for AMR projectors
+///
+/// A class conforming to this protocol is placed in the metavariables to
+/// provide the list of AMR projectors (each of which must conform to
+/// amr::protocols::Projector) that will be applied by:
+/// - amr::Actions::InitializeChild and amr::Actions::InitializeParent in order
+///   to initialize data on newly created elements.
+/// - amr::Actions::AdjustDomain in order to update data on existing elements in
+///   case their Mesh or neighbors have changed.
+///
+///
+/// Here is an example for a class conforming to this protocol:
+///
+/// \snippet Amr/Test_Protocols.cpp amr_projectors
+struct AmrMetavariables {
+  template <typename ConformingType>
+  struct test {
+    using projectors = typename ConformingType::projectors;
+    static_assert(
+        tmpl::all<projectors,
+                  tt::assert_conforms_to<tmpl::_1, Projector>>::value);
+  };
+};
+}  // namespace amr::protocols

--- a/src/ParallelAlgorithms/Amr/Protocols/CMakeLists.txt
+++ b/src/ParallelAlgorithms/Amr/Protocols/CMakeLists.txt
@@ -1,0 +1,10 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+spectre_target_headers(
+  ${LIBRARY}
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  AmrMetavariables.hpp
+  Projector.hpp
+  )

--- a/src/ParallelAlgorithms/Amr/Protocols/Projector.hpp
+++ b/src/ParallelAlgorithms/Amr/Protocols/Projector.hpp
@@ -1,0 +1,62 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <type_traits>
+
+#include "Utilities/ProtocolHelpers.hpp"
+
+namespace amr::protocols {
+
+/// \brief A DataBox mutator used in AMR actions
+///
+/// A class conforming to this protocol can be used as a projector in the list
+/// of `projectors` for a class conforming to amr::protocols::AmrMetavariables.
+/// The conforming class will be used when adaptive mesh refinement occurs to
+/// either initialize items on a newly created element of a DgElementArray, or
+/// update items on an existing element.
+///
+/// The conforming class must provide the following:
+/// - `return_tags`: A type list of tags corresponding to mutable items in the
+///   DataBox that may be modified during refinement.
+/// - `argument_tags`: A type list of tags corresponding to items in the DataBox
+///   that are not changed, but used to initialize/update the items
+///   corresponding to the `return_tags`.
+/// - `apply`:  static functions whose return value are void, and that take as
+///   arguments:
+///      - A `const gsl::not_null<Tag::type*>` for each `Tag` in `return_tags`
+///      - A `const db::const_item_type<Tag, BoxTags>` for each `Tag` in
+///        `argument_tags`
+///      - and one additional argument which is either:
+///           - `const std::pair<Mesh<Dim>, Element<Dim>>&` (used by
+///             amr::Actions::AdjustDomain)
+///           - `const tuples::TaggedTuple<Tags...>&` (used by
+///             amr::Actions::InitializeChild)
+///           - `const std::unordered_map<ElementId<Dim>,
+///                                       tuples::TaggedTuple<Tags...>>&`
+///             (used by amr::Actions::InitializeParent)
+///
+///   The Mesh and Element passed to amr::Actions::AdjustDomain are their
+///   values before the grid changes.  The tuples passed to
+///   amr::Actions::InitializeChild and amr::Actions::InitializeParent hold the
+///   items corresponding to the `DataBox<BoxTags>::mutable_item_creation_tags`
+///   of the parent (children) of the child (parent) being initialized.
+///
+/// \note In amr::Actions::AdjustDomain the projectors are called on
+/// all elements that were not h-refined (i.e. split or joined) even
+/// if their Mesh did not change.  This allows a projector to mutate a
+/// mutable item that depends upon information about the neighboring
+/// elements.  Therefore a particular projector may want to check
+/// whether or not the Mesh changed before projecting any data.
+///
+/// For examples, see Initialization::ProjectTimeStepping and
+/// evolution::dg::Initialization::ProjectDomain
+struct Projector {
+  template <typename ConformingType>
+  struct test {
+    using argument_tags = typename ConformingType::argument_tags;
+    using return_tags = typename ConformingType::return_tags;
+  };
+};
+}  // namespace amr::protocols

--- a/src/Time/AdaptiveSteppingDiagnostics.cpp
+++ b/src/Time/AdaptiveSteppingDiagnostics.cpp
@@ -5,6 +5,23 @@
 
 #include <pup.h>
 
+#include "Utilities/ErrorHandling/Assert.hpp"
+
+AdaptiveSteppingDiagnostics& AdaptiveSteppingDiagnostics::operator+=(
+    const AdaptiveSteppingDiagnostics& other) {
+  ASSERT(number_of_slabs == other.number_of_slabs,
+         "Unequal number of slabs(" << number_of_slabs << ","
+                                    << other.number_of_slabs << ")");
+  ASSERT(number_of_slab_size_changes == other.number_of_slab_size_changes,
+         "Unequal number of slab_size_changes("
+             << number_of_slab_size_changes << ","
+             << other.number_of_slab_size_changes << ")");
+  number_of_steps += other.number_of_steps;
+  number_of_step_fraction_changes += other.number_of_step_fraction_changes;
+  number_of_step_rejections += other.number_of_step_rejections;
+  return *this;
+}
+
 void AdaptiveSteppingDiagnostics::pup(PUP::er& p) {
   p | number_of_slabs;
   p | number_of_slab_size_changes;

--- a/src/Time/AdaptiveSteppingDiagnostics.hpp
+++ b/src/Time/AdaptiveSteppingDiagnostics.hpp
@@ -18,6 +18,9 @@ struct AdaptiveSteppingDiagnostics {
   uint64_t number_of_step_fraction_changes = 0;
   uint64_t number_of_step_rejections = 0;
 
+  AdaptiveSteppingDiagnostics& operator+=(
+      const AdaptiveSteppingDiagnostics& other);
+
   void pup(PUP::er& p);
 };
 

--- a/tests/InputFiles/ExportCoordinates/Input1D.yaml
+++ b/tests/InputFiles/ExportCoordinates/Input1D.yaml
@@ -10,8 +10,16 @@ ExpectedOutput:
 
 ---
 
+Amr:
+  Criteria:
+    - Random:
+        ChangeRefinementFraction: 0.8
+        MaximumRefinementLevel: 4
+  Verbosity: Verbose
+
 ResourceInfo:
   AvoidGlobalProc0: false
+  Singletons: Auto
 
 DomainCreator:
   Interval:
@@ -50,3 +58,11 @@ Evolution:
 Observers:
   VolumeFileName: "ExportCoordinates1DVolume"
   ReductionFileName: "ExportCoordinates1DReductions"
+
+PhaseChangeAndTriggers:
+  - Trigger:
+      Always
+    PhaseChanges:
+      - VisitAndReturn(EvaluateAmrCriteria)
+      - VisitAndReturn(AdjustDomain)
+      - VisitAndReturn(CheckDomain)

--- a/tests/InputFiles/ExportCoordinates/Input2D.yaml
+++ b/tests/InputFiles/ExportCoordinates/Input2D.yaml
@@ -10,8 +10,13 @@ ExpectedOutput:
 
 ---
 
+Amr:
+  Criteria:
+  Verbosity: Quiet
+
 ResourceInfo:
   AvoidGlobalProc0: false
+  Singletons: Auto
 
 DomainCreator:
   Rectangle:
@@ -48,3 +53,5 @@ Evolution:
 Observers:
   VolumeFileName: "ExportCoordinates2DVolume"
   ReductionFileName: "ExportCoordinates2DReductions"
+
+PhaseChangeAndTriggers:

--- a/tests/InputFiles/ExportCoordinates/Input3D.yaml
+++ b/tests/InputFiles/ExportCoordinates/Input3D.yaml
@@ -10,8 +10,13 @@ ExpectedOutput:
 
 ---
 
+Amr:
+  Criteria:
+  Verbosity: Quiet
+
 ResourceInfo:
   AvoidGlobalProc0: false
+  Singletons: Auto
 
 DomainCreator:
   Brick:
@@ -48,3 +53,5 @@ EventsAndTriggers:
 Observers:
   VolumeFileName: "ExportCoordinates3DVolume"
   ReductionFileName: "ExportCoordinates3DReductions"
+
+PhaseChangeAndTriggers:

--- a/tests/InputFiles/ExportCoordinates/InputTimeDependent3D.yaml
+++ b/tests/InputFiles/ExportCoordinates/InputTimeDependent3D.yaml
@@ -11,8 +11,13 @@ ExpectedOutput:
 
 ---
 
+Amr:
+  Criteria:
+  Verbosity: Quiet
+
 ResourceInfo:
   AvoidGlobalProc0: false
+  Singletons: Auto
 
 DomainCreator:
   # Parameters are chosen for an equal-mass, non-spinning binary black hole
@@ -86,3 +91,5 @@ EventsAndTriggers:
 Observers:
   VolumeFileName: "ExportTimeDependentCoordinates3DVolume"
   ReductionFileName: "ExportTimeDependentCoordinates3DReductions"
+
+PhaseChangeAndTriggers:

--- a/tests/Unit/Evolution/Initialization/CMakeLists.txt
+++ b/tests/Unit/Evolution/Initialization/CMakeLists.txt
@@ -8,8 +8,8 @@ set(LIBRARY_SOURCES
   Test_DgDomain.cpp
   Test_Evolution.cpp
   Test_NonconservativeSystem.cpp
-  Test_Tags.cpp
   Test_SetVariables.cpp
+  Test_Tags.cpp
   )
 
 add_test_library(
@@ -22,6 +22,7 @@ add_test_library(
 target_link_libraries(
   ${LIBRARY}
   PRIVATE
+  Amr
   DataStructures
   Domain
   Evolution

--- a/tests/Unit/Evolution/Initialization/Test_Evolution.cpp
+++ b/tests/Unit/Evolution/Initialization/Test_Evolution.cpp
@@ -3,24 +3,42 @@
 
 #include "Framework/TestingFramework.hpp"
 
+#include <array>
+#include <cstddef>
 #include <memory>
+#include <unordered_map>
 #include <utility>
 
 #include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "Domain/Amr/Flag.hpp"
+#include "Domain/Amr/Tags/Flags.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/DirectionMap.hpp"
+#include "Domain/Structure/Element.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Domain/Structure/Neighbors.hpp"
 #include "Evolution/Initialization/Evolution.hpp"
 #include "Evolution/Initialization/Tags.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "Options/Protocols/FactoryCreation.hpp"
 #include "Parallel/GlobalCache.hpp"
+#include "Parallel/Tags/ArrayIndex.hpp"
+#include "Time/AdaptiveSteppingDiagnostics.hpp"
 #include "Time/ChooseLtsStepSize.hpp"
 #include "Time/Slab.hpp"
 #include "Time/StepChoosers/Increase.hpp"
+#include "Time/Tags/AdaptiveSteppingDiagnostics.hpp"
 #include "Time/Tags/Time.hpp"
 #include "Time/Tags/TimeStep.hpp"
 #include "Time/Tags/TimeStepId.hpp"
 #include "Time/Tags/TimeStepper.hpp"
 #include "Time/Time.hpp"
 #include "Time/TimeSteppers/AdamsBashforth.hpp"
+#include "Utilities/Algorithm.hpp"
+#include "Utilities/Gsl.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
+#include "Utilities/Rational.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
 
@@ -131,10 +149,176 @@ void test_lts() {
   CHECK(db::get<::Tags::Next<::Tags::TimeStep>>(box) ==
         expected_next_time_step);
 }
+using items_type =
+    tuples::TaggedTuple<Parallel::Tags::ArrayIndexImpl<ElementId<1>>,
+                        ::Tags::TimeStepId, ::Tags::Next<::Tags::TimeStepId>,
+                        ::Tags::TimeStep, ::Tags::Next<::Tags::TimeStep>,
+                        ::Tags::Time, ::Tags::AdaptiveSteppingDiagnostics>;
+
+using parent_items_type =
+    tuples::TaggedTuple<Parallel::Tags::ArrayIndexImpl<ElementId<1>>,
+                        ::Tags::TimeStepId, ::Tags::Next<::Tags::TimeStepId>,
+                        ::Tags::TimeStep, ::Tags::Next<::Tags::TimeStep>,
+                        ::Tags::Time, ::Tags::AdaptiveSteppingDiagnostics,
+                        ::amr::Tags::Flags<1>>;
+
+template <typename DbTagList>
+void check(const db::DataBox<DbTagList>& box,
+           const TimeStepId& expected_time_step_id,
+           const TimeStepId& expected_next_time_step_id,
+           const TimeDelta& expected_time_step,
+           const TimeDelta& expected_next_time_step, const double expected_time,
+           const AdaptiveSteppingDiagnostics& expected_diagnostics) {
+  CHECK(db::get<::Tags::TimeStepId>(box) == expected_time_step_id);
+  CHECK(db::get<::Tags::Next<::Tags::TimeStepId>>(box) ==
+        expected_next_time_step_id);
+  CHECK(db::get<::Tags::TimeStep>(box) == expected_time_step);
+  CHECK(db::get<::Tags::Next<::Tags::TimeStep>>(box) ==
+        expected_next_time_step);
+  CHECK(db::get<::Tags::Time>(box) == expected_time);
+  CHECK(db::get<::Tags::AdaptiveSteppingDiagnostics>(box) ==
+        expected_diagnostics);
+}
+
+void test_p_refine() {
+  const ElementId<1> element_id{0};
+  const Element<1> element{element_id, DirectionMap<1, Neighbors<1>>{}};
+  const Mesh<1> mesh{2, Spectral::Basis::Legendre,
+                     Spectral::Quadrature::GaussLobatto};
+  const Slab slab(0., 1.);
+  const Time start{slab.start()};
+  const TimeDelta time_step{slab.duration()};
+  const TimeDelta next_time_step = time_step;
+  const TimeStepId time_step_id{time_step.is_positive(), 8, start};
+  const TimeStepId next_time_step_id{time_step.is_positive(), 8,
+                                     start + time_step};
+  const double time = start.value();
+  const AdaptiveSteppingDiagnostics diagnostics{7, 2, 13, 4, 5};
+
+  auto box = db::create<
+      db::AddSimpleTags<Parallel::Tags::ArrayIndexImpl<ElementId<1>>,
+                        ::Tags::TimeStepId, ::Tags::Next<::Tags::TimeStepId>,
+                        ::Tags::TimeStep, ::Tags::Next<::Tags::TimeStep>,
+                        ::Tags::Time, ::Tags::AdaptiveSteppingDiagnostics>>(
+      element_id, time_step_id, next_time_step_id, time_step, next_time_step,
+      time, diagnostics);
+
+  db::mutate_apply<Initialization::ProjectTimeStepping<1>>(
+      make_not_null(&box), std::make_pair(mesh, element));
+
+  check(box, time_step_id, next_time_step_id, time_step, next_time_step, time,
+        diagnostics);
+}
+
+void test_split() {
+  const ElementId<1> parent_id{0};
+  const ElementId<1> child_1_id{0, std::array{SegmentId{1, 0}}};
+  const ElementId<1> child_2_id{0, std::array{SegmentId{1, 1}}};
+
+  const Slab slab(1., 1.5);
+  const Time start{slab.start()};
+  const TimeDelta time_step{slab.duration()};
+  const TimeDelta next_time_step = time_step;
+  const TimeStepId time_step_id{time_step.is_positive(), 8, start};
+  const TimeStepId next_time_step_id{time_step.is_positive(), 8,
+                                     start + time_step};
+  const double time = start.value();
+  const AdaptiveSteppingDiagnostics diagnostics{7, 2, 13, 4, 5};
+
+  const parent_items_type parent_items{
+      parent_id,         time_step_id,
+      next_time_step_id, time_step,
+      next_time_step,    time,
+      diagnostics,       std::array{::amr::Flag::Split}};
+
+  auto child_1_box = db::create<
+      db::AddSimpleTags<Parallel::Tags::ArrayIndexImpl<ElementId<1>>,
+                        ::Tags::TimeStepId, ::Tags::Next<::Tags::TimeStepId>,
+                        ::Tags::TimeStep, ::Tags::Next<::Tags::TimeStep>,
+                        ::Tags::Time, ::Tags::AdaptiveSteppingDiagnostics>>(
+      child_1_id, TimeStepId{}, TimeStepId{}, TimeDelta{}, TimeDelta{}, 0.0,
+      AdaptiveSteppingDiagnostics{});
+
+  auto child_2_box = db::create<
+      db::AddSimpleTags<Parallel::Tags::ArrayIndexImpl<ElementId<1>>,
+                        ::Tags::TimeStepId, ::Tags::Next<::Tags::TimeStepId>,
+                        ::Tags::TimeStep, ::Tags::Next<::Tags::TimeStep>,
+                        ::Tags::Time, ::Tags::AdaptiveSteppingDiagnostics>>(
+      child_2_id, TimeStepId{}, TimeStepId{}, TimeDelta{}, TimeDelta{}, 0.0,
+      AdaptiveSteppingDiagnostics{});
+
+  db::mutate_apply<Initialization::ProjectTimeStepping<1>>(
+      make_not_null(&child_1_box), parent_items);
+
+  check(child_1_box, time_step_id, next_time_step_id, time_step, next_time_step,
+        time, diagnostics);
+
+  db::mutate_apply<Initialization::ProjectTimeStepping<1>>(
+      make_not_null(&child_2_box), parent_items);
+
+  check(child_2_box, time_step_id, next_time_step_id, time_step, next_time_step,
+        time, AdaptiveSteppingDiagnostics{7, 2, 0, 0, 0});
+}
+
+template <bool ForwardInTime>
+void test_join() {
+  const ElementId<1> parent_id{0};
+  const ElementId<1> child_1_id{0, std::array{SegmentId{1, 0}}};
+  const ElementId<1> child_2_id{0, std::array{SegmentId{1, 1}}};
+
+  const Slab slab_1(1., 1.5);
+  const Time start_1{ForwardInTime ? slab_1.start() : slab_1.end()};
+  const TimeDelta time_step_1{ForwardInTime ? slab_1.duration()
+                                            : -slab_1.duration()};
+  const TimeDelta next_time_step_1 = time_step_1;
+  const TimeStepId time_step_id_1{time_step_1.is_positive(), 8, start_1};
+  const TimeStepId next_time_step_id_1{time_step_1.is_positive(), 8,
+                                       start_1 + time_step_1};
+  const double time_1 = start_1.value();
+  const AdaptiveSteppingDiagnostics diagnostics_1{7, 2, 13, 4, 5};
+
+  const Slab slab_2(1., 1.5);
+  const Time start_2{ForwardInTime ? slab_2.start() : slab_2.end()};
+  const TimeDelta time_step_2{slab_2, Rational{ForwardInTime ? 1 : -1, 2}};
+  const TimeDelta next_time_step_2 = time_step_2;
+  const TimeStepId time_step_id_2{time_step_2.is_positive(), 8, start_2};
+  const TimeStepId next_time_step_id_2{time_step_2.is_positive(), 8,
+                                       start_2 + time_step_2};
+  const double time_2 = start_2.value();
+  const AdaptiveSteppingDiagnostics diagnostics_2{7, 2, 27, 2, 8};
+
+  std::unordered_map<ElementId<1>, items_type> children_items;
+  children_items.emplace(
+      child_1_id,
+      items_type{child_1_id, time_step_id_1, next_time_step_id_1, time_step_1,
+                 next_time_step_1, time_1, diagnostics_1});
+  children_items.emplace(
+      child_2_id,
+      items_type{child_2_id, time_step_id_2, next_time_step_id_2, time_step_2,
+                 next_time_step_2, time_2, diagnostics_2});
+
+  auto parent_box = db::create<
+      db::AddSimpleTags<Parallel::Tags::ArrayIndexImpl<ElementId<1>>,
+                        ::Tags::TimeStepId, ::Tags::Next<::Tags::TimeStepId>,
+                        ::Tags::TimeStep, ::Tags::Next<::Tags::TimeStep>,
+                        ::Tags::Time, ::Tags::AdaptiveSteppingDiagnostics>>(
+      parent_id, TimeStepId{}, TimeStepId{}, TimeDelta{}, TimeDelta{}, 0.0,
+      AdaptiveSteppingDiagnostics{});
+
+  db::mutate_apply<Initialization::ProjectTimeStepping<1>>(
+      make_not_null(&parent_box), children_items);
+
+  check(parent_box, time_step_id_2, next_time_step_id_2, time_step_2,
+        next_time_step_2, time_2, AdaptiveSteppingDiagnostics{7, 2, 40, 6, 13});
+}
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Evolution.Initialization.TimeStepping",
                   "[Evolution][Unit]") {
   test_gts();
   test_lts();
+  test_p_refine();
+  test_split();
+  test_join<true>();
+  test_join<false>();
 }

--- a/tests/Unit/Helpers/Domain/Amr/RegistrationHelpers.hpp
+++ b/tests/Unit/Helpers/Domain/Amr/RegistrationHelpers.hpp
@@ -1,0 +1,107 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <unordered_set>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/Tag.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Framework/ActionTesting.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "Parallel/Invoke.hpp"
+#include "Parallel/Local.hpp"
+#include "Parallel/Phase.hpp"
+#include "Parallel/PhaseDependentActionList.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace TestHelpers::amr {
+template <size_t Dim>
+struct RegisteredElements : db::SimpleTag {
+  using type = std::unordered_set<ElementId<Dim>>;
+};
+
+template <typename Metavariables>
+struct Registrar {
+  using metavariables = Metavariables;
+  static constexpr size_t volume_dim = Metavariables::volume_dim;
+  using chare_type = ActionTesting::MockGroupChare;
+  using array_index = int;
+  using simple_tags = tmpl::list<RegisteredElements<volume_dim>>;
+  using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
+      Parallel::Phase::Initialization,
+      tmpl::list<ActionTesting::InitializeDataBox<simple_tags>>>>;
+};
+
+struct DeregisterWithRegistrant {
+  template <typename ParallelComponent, typename DbTagList,
+            typename Metavariables, typename ArrayIndex>
+  static void apply(db::DataBox<DbTagList>& box,
+                    Parallel::GlobalCache<Metavariables>& /*cache*/,
+                    const ArrayIndex& /*array_index*/,
+                    const ElementId<Metavariables::volume_dim>& element_id) {
+    static constexpr size_t volume_dim = Metavariables::volume_dim;
+    db::mutate<RegisteredElements<volume_dim>>(
+        [&element_id](
+            const gsl::not_null<std::unordered_set<ElementId<volume_dim>>*>
+                registered_elements) {
+          registered_elements->erase(element_id);
+        },
+        make_not_null(&box));
+  }
+};
+
+struct RegisterWithRegistrant {
+  template <typename ParallelComponent, typename DbTagList,
+            typename Metavariables, typename ArrayIndex>
+  static void apply(db::DataBox<DbTagList>& box,
+                    Parallel::GlobalCache<Metavariables>& /*cache*/,
+                    const ArrayIndex& /*array_index*/,
+                    const ElementId<Metavariables::volume_dim>& element_id) {
+    static constexpr size_t volume_dim = Metavariables::volume_dim;
+    db::mutate<RegisteredElements<volume_dim>>(
+        [&element_id](
+            const gsl::not_null<std::unordered_set<ElementId<volume_dim>>*>
+                registered_elements) {
+          registered_elements->insert(element_id);
+        },
+        make_not_null(&box));
+  }
+};
+
+struct RegisterElement {
+ private:
+  template <typename ParallelComponent, typename RegisterOrDeregisterAction,
+            typename DbTagList, typename Metavariables, typename ArrayIndex>
+  static void register_or_deregister_impl(
+      db::DataBox<DbTagList>& /*box*/,
+      Parallel::GlobalCache<Metavariables>& cache,
+      const ArrayIndex& array_index) {
+    auto& registrar = *Parallel::local_branch(
+        Parallel::get_parallel_component<Registrar<Metavariables>>(cache));
+    Parallel::simple_action<RegisterOrDeregisterAction>(registrar, array_index);
+  }
+
+ public:
+  template <typename ParallelComponent, typename DbTagList,
+            typename Metavariables, typename ArrayIndex>
+  static void perform_registration(db::DataBox<DbTagList>& box,
+                                   Parallel::GlobalCache<Metavariables>& cache,
+                                   const ArrayIndex& array_index) {
+    register_or_deregister_impl<ParallelComponent, RegisterWithRegistrant>(
+        box, cache, array_index);
+  }
+
+  template <typename ParallelComponent, typename DbTagList,
+            typename Metavariables, typename ArrayIndex>
+  static void perform_deregistration(
+      db::DataBox<DbTagList>& box, Parallel::GlobalCache<Metavariables>& cache,
+      const ArrayIndex& array_index) {
+    register_or_deregister_impl<ParallelComponent, DeregisterWithRegistrant>(
+        box, cache, array_index);
+  }
+};
+}  // namespace TestHelpers::amr

--- a/tests/Unit/Helpers/Domain/CoordinateMaps/TestMapHelpers.hpp
+++ b/tests/Unit/Helpers/Domain/CoordinateMaps/TestMapHelpers.hpp
@@ -39,11 +39,10 @@
  * downcasting `map_base` and then comparing to `map`. Returns false if the
  * downcast fails.
  */
-template <typename Map>
-bool are_maps_equal(
-    const Map& map,
-    const domain::CoordinateMapBase<Frame::BlockLogical, Frame::Inertial,
-                                    Map::dim>& map_base) {
+template <typename Map, typename SourceFrame, typename TargetFrame>
+bool are_maps_equal(const Map& map,
+                    const domain::CoordinateMapBase<SourceFrame, TargetFrame,
+                                                    Map::dim>& map_base) {
   const auto* map_derived = dynamic_cast<const Map*>(&map_base);
   return map_derived == nullptr ? false : (*map_derived == map);
 }

--- a/tests/Unit/ParallelAlgorithms/Amr/Actions/Test_AdjustDomain.cpp
+++ b/tests/Unit/ParallelAlgorithms/Amr/Actions/Test_AdjustDomain.cpp
@@ -114,6 +114,8 @@ struct Metavariables {
                                     SingletonComponent<Metavariables>>;
   // NOLINTNEXTLINE(google-runtime-references)
   void pup(PUP::er& /*p*/) {}
+
+  using amr_mutators = tmpl::list<>;
 };
 
 void check_box(const ActionTesting::MockRuntimeSystem<Metavariables>& runner,

--- a/tests/Unit/ParallelAlgorithms/Amr/Actions/Test_AdjustDomain.cpp
+++ b/tests/Unit/ParallelAlgorithms/Amr/Actions/Test_AdjustDomain.cpp
@@ -31,6 +31,7 @@
 #include "ParallelAlgorithms/Amr/Actions/Component.hpp"
 #include "ParallelAlgorithms/Amr/Actions/CreateChild.hpp"
 #include "ParallelAlgorithms/Amr/Actions/CreateParent.hpp"
+#include "ParallelAlgorithms/Amr/Protocols/AmrMetavariables.hpp"
 #include "Utilities/TMPL.hpp"
 
 namespace {
@@ -115,7 +116,9 @@ struct Metavariables {
   // NOLINTNEXTLINE(google-runtime-references)
   void pup(PUP::er& /*p*/) {}
 
-  using amr_mutators = tmpl::list<>;
+  struct amr : tt::ConformsTo<::amr::protocols::AmrMetavariables> {
+    using projectors = tmpl::list<>;
+  };
 };
 
 void check_box(const ActionTesting::MockRuntimeSystem<Metavariables>& runner,

--- a/tests/Unit/ParallelAlgorithms/Amr/Actions/Test_InitializeChild.cpp
+++ b/tests/Unit/ParallelAlgorithms/Amr/Actions/Test_InitializeChild.cpp
@@ -27,6 +27,7 @@
 #include "Parallel/Phase.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
 #include "ParallelAlgorithms/Amr/Actions/InitializeChild.hpp"
+#include "ParallelAlgorithms/Amr/Protocols/AmrMetavariables.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
@@ -60,7 +61,9 @@ struct Metavariables {
         tmpl::list<TestHelpers::amr::RegisterElement>, tmpl::list<>>;
   };
 
-  using amr_mutators = tmpl::list<>;
+  struct amr : tt::ConformsTo<::amr::protocols::AmrMetavariables> {
+    using projectors = tmpl::list<>;
+  };
 };
 
 void test() {

--- a/tests/Unit/ParallelAlgorithms/Amr/Actions/Test_InitializeChild.cpp
+++ b/tests/Unit/ParallelAlgorithms/Amr/Actions/Test_InitializeChild.cpp
@@ -59,6 +59,8 @@ struct Metavariables {
         std::is_same_v<ParallelComponent, Component<Metavariables>>,
         tmpl::list<TestHelpers::amr::RegisterElement>, tmpl::list<>>;
   };
+
+  using amr_mutators = tmpl::list<>;
 };
 
 void test() {

--- a/tests/Unit/ParallelAlgorithms/Amr/Actions/Test_InitializeChild.cpp
+++ b/tests/Unit/ParallelAlgorithms/Amr/Actions/Test_InitializeChild.cpp
@@ -22,6 +22,7 @@
 #include "Framework/ActionTesting.hpp"
 #include "Framework/MockRuntimeSystem.hpp"
 #include "Framework/MockRuntimeSystemFreeFunctions.hpp"
+#include "Helpers/Domain/Amr/RegistrationHelpers.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "Parallel/Phase.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
@@ -50,12 +51,17 @@ struct Component {
 
 struct Metavariables {
   static constexpr size_t volume_dim = 2;
-  using component_list = tmpl::list<Component<Metavariables>>;
+  using component_list = tmpl::list<Component<Metavariables>,
+                                    TestHelpers::amr::Registrar<Metavariables>>;
+  template <typename ParallelComponent>
+  struct registration_list {
+    using type = std::conditional_t<
+        std::is_same_v<ParallelComponent, Component<Metavariables>>,
+        tmpl::list<TestHelpers::amr::RegisterElement>, tmpl::list<>>;
+  };
 };
 
 void test() {
-  using my_component = Component<Metavariables>;
-
   const ElementId<2> parent_id{0, std::array{SegmentId{2, 1}, SegmentId{0, 0}}};
   const ElementId<2> parent_lower_neighbor_id{
       0, std::array{SegmentId{2, 0}, SegmentId{0, 0}}};
@@ -114,19 +120,37 @@ void test() {
   const std::unordered_map<ElementId<2>, std::array<amr::Flag, 2>>
       expected_child_neighbor_flags{};
 
+  using array_component = Component<Metavariables>;
+  using registrar = TestHelpers::amr::Registrar<Metavariables>;
+
   ActionTesting::MockRuntimeSystem<Metavariables> runner{{}};
-  ActionTesting::emplace_component<my_component>(&runner, child_id);
-  ActionTesting::simple_action<my_component, amr::Actions::InitializeChild>(
+  ActionTesting::emplace_group_component<registrar>(&runner);
+  ActionTesting::emplace_component<array_component>(&runner, child_id);
+  CHECK(ActionTesting::get_databox_tag<registrar,
+                                       TestHelpers::amr::RegisteredElements<2>>(
+            runner, 0)
+            .empty());
+  ActionTesting::simple_action<array_component, amr::Actions::InitializeChild>(
       make_not_null(&runner), child_id, parent_items);
-  CHECK(ActionTesting::get_databox_tag<my_component, domain::Tags::Element<2>>(
-            runner, child_id) == expected_child);
-  CHECK(ActionTesting::get_databox_tag<my_component, domain::Tags::Mesh<2>>(
-            runner, child_id) == expected_child_mesh);
-  CHECK(ActionTesting::get_databox_tag<my_component, amr::Tags::Flags<2>>(
-            runner, child_id) == expected_child_flags);
   CHECK(
-      ActionTesting::get_databox_tag<my_component, amr::Tags::NeighborFlags<2>>(
-          runner, child_id) == expected_child_neighbor_flags);
+      ActionTesting::get_databox_tag<array_component, domain::Tags::Element<2>>(
+          runner, child_id) == expected_child);
+  CHECK(ActionTesting::get_databox_tag<array_component, domain::Tags::Mesh<2>>(
+            runner, child_id) == expected_child_mesh);
+  CHECK(ActionTesting::get_databox_tag<array_component, amr::Tags::Flags<2>>(
+            runner, child_id) == expected_child_flags);
+  CHECK(ActionTesting::get_databox_tag<array_component,
+                                       amr::Tags::NeighborFlags<2>>(
+            runner, child_id) == expected_child_neighbor_flags);
+  CHECK(ActionTesting::get_databox_tag<registrar,
+                                       TestHelpers::amr::RegisteredElements<2>>(
+            runner, 0)
+            .empty());
+  ActionTesting::invoke_queued_simple_action<registrar>(make_not_null(&runner),
+                                                        0);
+  CHECK(ActionTesting::get_databox_tag<registrar,
+                                       TestHelpers::amr::RegisteredElements<2>>(
+            runner, 0) == std::unordered_set{child_id});
 }
 }  // namespace
 

--- a/tests/Unit/ParallelAlgorithms/Amr/Actions/Test_InitializeParent.cpp
+++ b/tests/Unit/ParallelAlgorithms/Amr/Actions/Test_InitializeParent.cpp
@@ -22,6 +22,7 @@
 #include "Framework/ActionTesting.hpp"
 #include "Framework/MockRuntimeSystem.hpp"
 #include "Framework/MockRuntimeSystemFreeFunctions.hpp"
+#include "Helpers/Domain/Amr/RegistrationHelpers.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "Parallel/Phase.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
@@ -50,7 +51,14 @@ struct Component {
 
 struct Metavariables {
   static constexpr size_t volume_dim = 3;
-  using component_list = tmpl::list<Component<Metavariables>>;
+  using component_list = tmpl::list<Component<Metavariables>,
+                                    TestHelpers::amr::Registrar<Metavariables>>;
+  template <typename ParallelComponent>
+  struct registration_list {
+    using type = std::conditional_t<
+        std::is_same_v<ParallelComponent, Component<Metavariables>>,
+        tmpl::list<TestHelpers::amr::RegisterElement>, tmpl::list<>>;
+  };
 };
 
 // Test setup showing xi and eta dimensions which are hp-refined; only
@@ -83,8 +91,6 @@ struct Metavariables {
 // Elments N6, N7, and N8 are in Block 3 which is anti-aligned with Block 0
 // Elements N1, N2, and N3 are in Block 4 which is rotated 90 deg. clockwise
 void test() {
-  using my_component = Component<Metavariables>;
-
   OrientationMap<3> aligned{};
   OrientationMap<3> b1_orientation{};
   OrientationMap<3> b2_orientation{std::array{Direction<3>::lower_eta(),
@@ -268,19 +274,37 @@ void test() {
   const std::unordered_map<ElementId<3>, std::array<amr::Flag, 3>>
       expected_parent_neighbor_flags{};
 
+  using array_component = Component<Metavariables>;
+  using registrar = TestHelpers::amr::Registrar<Metavariables>;
+
   ActionTesting::MockRuntimeSystem<Metavariables> runner{{}};
-  ActionTesting::emplace_component<my_component>(&runner, parent_id);
-  ActionTesting::simple_action<my_component, amr::Actions::InitializeParent>(
+  ActionTesting::emplace_group_component<registrar>(&runner);
+  ActionTesting::emplace_component<array_component>(&runner, parent_id);
+  CHECK(ActionTesting::get_databox_tag<registrar,
+                                       TestHelpers::amr::RegisteredElements<3>>(
+            runner, 0)
+            .empty());
+  ActionTesting::simple_action<array_component, amr::Actions::InitializeParent>(
       make_not_null(&runner), parent_id, children_items);
-  CHECK(ActionTesting::get_databox_tag<my_component, domain::Tags::Element<3>>(
-            runner, parent_id) == expected_parent);
-  CHECK(ActionTesting::get_databox_tag<my_component, domain::Tags::Mesh<3>>(
-            runner, parent_id) == expected_parent_mesh);
-  CHECK(ActionTesting::get_databox_tag<my_component, amr::Tags::Flags<3>>(
-            runner, parent_id) == expected_parent_flags);
   CHECK(
-      ActionTesting::get_databox_tag<my_component, amr::Tags::NeighborFlags<3>>(
-          runner, parent_id) == expected_parent_neighbor_flags);
+      ActionTesting::get_databox_tag<array_component, domain::Tags::Element<3>>(
+          runner, parent_id) == expected_parent);
+  CHECK(ActionTesting::get_databox_tag<array_component, domain::Tags::Mesh<3>>(
+            runner, parent_id) == expected_parent_mesh);
+  CHECK(ActionTesting::get_databox_tag<array_component, amr::Tags::Flags<3>>(
+            runner, parent_id) == expected_parent_flags);
+  CHECK(ActionTesting::get_databox_tag<array_component,
+                                       amr::Tags::NeighborFlags<3>>(
+            runner, parent_id) == expected_parent_neighbor_flags);
+  CHECK(ActionTesting::get_databox_tag<registrar,
+                                       TestHelpers::amr::RegisteredElements<3>>(
+            runner, 0)
+            .empty());
+  ActionTesting::invoke_queued_simple_action<registrar>(make_not_null(&runner),
+                                                        0);
+  CHECK(ActionTesting::get_databox_tag<registrar,
+                                       TestHelpers::amr::RegisteredElements<3>>(
+            runner, 0) == std::unordered_set{parent_id});
 }
 }  // namespace
 

--- a/tests/Unit/ParallelAlgorithms/Amr/Actions/Test_InitializeParent.cpp
+++ b/tests/Unit/ParallelAlgorithms/Amr/Actions/Test_InitializeParent.cpp
@@ -27,6 +27,7 @@
 #include "Parallel/Phase.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
 #include "ParallelAlgorithms/Amr/Actions/InitializeParent.hpp"
+#include "ParallelAlgorithms/Amr/Protocols/AmrMetavariables.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
@@ -60,7 +61,9 @@ struct Metavariables {
         tmpl::list<TestHelpers::amr::RegisterElement>, tmpl::list<>>;
   };
 
-  using amr_mutators = tmpl::list<>;
+  struct amr : tt::ConformsTo<::amr::protocols::AmrMetavariables> {
+    using projectors = tmpl::list<>;
+  };
 };
 
 // Test setup showing xi and eta dimensions which are hp-refined; only

--- a/tests/Unit/ParallelAlgorithms/Amr/Actions/Test_InitializeParent.cpp
+++ b/tests/Unit/ParallelAlgorithms/Amr/Actions/Test_InitializeParent.cpp
@@ -59,6 +59,8 @@ struct Metavariables {
         std::is_same_v<ParallelComponent, Component<Metavariables>>,
         tmpl::list<TestHelpers::amr::RegisterElement>, tmpl::list<>>;
   };
+
+  using amr_mutators = tmpl::list<>;
 };
 
 // Test setup showing xi and eta dimensions which are hp-refined; only

--- a/tests/Unit/ParallelAlgorithms/Amr/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/Amr/CMakeLists.txt
@@ -18,6 +18,7 @@ set(LIBRARY_SOURCES
   Criteria/Test_DriveToTarget.cpp
   Criteria/Test_Random.cpp
   Projectors/Test_Mesh.cpp
+  Test_Protocols.cpp
   )
 
 add_test_library(

--- a/tests/Unit/ParallelAlgorithms/Amr/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/Amr/CMakeLists.txt
@@ -33,6 +33,8 @@ target_link_libraries(
   Amr
   AmrCriteria
   AmrProjectors
+  CoordinateMaps
+  Domain
   DomainStructure
   Utilities
   )

--- a/tests/Unit/ParallelAlgorithms/Amr/Test_Protocols.cpp
+++ b/tests/Unit/ParallelAlgorithms/Amr/Test_Protocols.cpp
@@ -1,0 +1,22 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Initialization/DgDomain.hpp"
+#include "Evolution/Initialization/Evolution.hpp"
+#include "ParallelAlgorithms/Amr/Protocols/AmrMetavariables.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+struct Metavariables {
+  // [amr_projectors]
+  struct amr : tt::ConformsTo<::amr::protocols::AmrMetavariables> {
+    using projectors =
+        tmpl::list<Initialization::ProjectTimeStepping<1>,
+                   evolution::dg::Initialization::ProjectDomain<1>>;
+  };
+  // [amr_projectors]
+};
+static_assert(tt::assert_conforms_to_v<Metavariables::amr,
+                                       ::amr::protocols::AmrMetavariables>);
+}  // namespace

--- a/tests/Unit/Time/Test_AdaptiveSteppingDiagnostics.cpp
+++ b/tests/Unit/Time/Test_AdaptiveSteppingDiagnostics.cpp
@@ -7,7 +7,7 @@
 #include "Time/AdaptiveSteppingDiagnostics.hpp"
 
 SPECTRE_TEST_CASE("Unit.Time.AdaptiveSteppingDiagnostics", "[Unit][Time]") {
-  const AdaptiveSteppingDiagnostics diags{1, 2, 3, 4, 5};
+  AdaptiveSteppingDiagnostics diags{1, 2, 3, 4, 5};
   CHECK(diags.number_of_slabs == 1);
   CHECK(diags.number_of_slab_size_changes == 2);
   CHECK(diags.number_of_steps == 3);
@@ -28,4 +28,6 @@ SPECTRE_TEST_CASE("Unit.Time.AdaptiveSteppingDiagnostics", "[Unit][Time]") {
   CHECK_FALSE(diags == AdaptiveSteppingDiagnostics{1, 2, 3, 4, 6});
 
   CHECK(diags == serialize_and_deserialize(diags));
+  diags += diags;
+  CHECK(diags == AdaptiveSteppingDiagnostics{1, 2, 6, 8, 10});
 }


### PR DESCRIPTION
## Proposed changes

- Enables AMR when running ExportCoordinates
   - This only makes sense for a limited set of AMR criteria for testing
   - Will allow generating data on a dynamic grid to test post-processing scripts
- This adds the functionality to the AMR actions to:
   - (de)register (old) new array elements
   - Apply mutators to initialize items on each element

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
