### PR TITLE
Somewhat fix ordering issues in interpolator

### DIFF
--- a/src/DataStructures/LinkedMessageId.hpp
+++ b/src/DataStructures/LinkedMessageId.hpp
@@ -72,3 +72,8 @@ struct LinkedMessageIdLessComparator {
     return linked_message_id.id < id;
   }
 };
+
+template <typename Id>
+bool operator<(const LinkedMessageId<Id>& lhs, const LinkedMessageId<Id>& rhs) {
+  return LinkedMessageIdLessComparator<Id>{}(lhs, rhs);
+}


### PR DESCRIPTION
## Proposed changes

The reason this is "somewhat" is explained in the code comments. I couldn't figure out a permanent fix without some extensive changes (i.e. checking the temporal id type and then doing something custom if it's a LinkedMessageId). These changes have been enough for me to test size control without issues so far, but it's possible I just haven't hit the case where this change won't fix anything yet. I plan to deal with that later if needed.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
