### PR TITLE
Add index to TimeAndPrevious tag

### DIFF
--- a/src/ControlSystem/Measurements/BothHorizons.hpp
+++ b/src/ControlSystem/Measurements/BothHorizons.hpp
@@ -67,7 +67,7 @@ struct BothHorizons : tt::ConformsTo<protocols::Measurement> {
         return "ControlSystemAh" + ::domain::name(Horizon);
       }
 
-      using temporal_id = ::Tags::TimeAndPrevious;
+      using temporal_id = ::Tags::TimeAndPrevious<0>;
 
       using vars_to_interpolate_to_target =
           ::ah::vars_to_interpolate_to_target<3, ::Frame::Distorted>;

--- a/src/ControlSystem/Measurements/CharSpeed.hpp
+++ b/src/ControlSystem/Measurements/CharSpeed.hpp
@@ -73,7 +73,7 @@ struct CharSpeed : tt::ConformsTo<protocols::Measurement> {
         return "ControlSystemCharSpeedExcision" + ::domain::name(Object);
       }
 
-      using temporal_id = ::Tags::TimeAndPrevious;
+      using temporal_id = ::Tags::TimeAndPrevious<1>;
 
       using vars_to_interpolate_to_target =
           tmpl::list<gr::Tags::Lapse<DataVector>,
@@ -150,7 +150,7 @@ struct CharSpeed : tt::ConformsTo<protocols::Measurement> {
         return "ControlSystemCharSpeedAh" + ::domain::name(Object);
       }
 
-      using temporal_id = ::Tags::TimeAndPrevious;
+      using temporal_id = ::Tags::TimeAndPrevious<1>;
 
       using vars_to_interpolate_to_target =
           ::ah::vars_to_interpolate_to_target<3, ::Frame::Distorted>;

--- a/src/ControlSystem/Measurements/SingleHorizon.hpp
+++ b/src/ControlSystem/Measurements/SingleHorizon.hpp
@@ -68,7 +68,7 @@ struct SingleHorizon : tt::ConformsTo<protocols::Measurement> {
         return "ControlSystemSingleAh" + ::domain::name(Horizon);
       }
 
-      using temporal_id = ::Tags::TimeAndPrevious;
+      using temporal_id = ::Tags::TimeAndPrevious<0>;
 
       using vars_to_interpolate_to_target =
           ::ah::vars_to_interpolate_to_target<3, ::Frame::Distorted>;

--- a/src/Time/Tags.hpp
+++ b/src/Time/Tags.hpp
@@ -22,6 +22,7 @@
 #include "Time/StepChoosers/StepChooser.hpp"  // IWYU pragma: keep
 #include "Time/Time.hpp"
 #include "Time/TimeStepId.hpp"
+#include "Utilities/GetOutput.hpp"
 #include "Utilities/Serialization/Serialize.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -131,14 +132,20 @@ struct Time : db::SimpleTag {
 /// ::evolution::Tags::PreviousTriggerTime tag is set. Any Events that request
 /// this tag in their `argument_tags` type alias, must be triggered by a
 /// DenseTrigger.
+///
+/// \note The Index is just so we can have multiple of this tag in the same
+/// DataBox.
+template <size_t Index>
 struct TimeAndPrevious : db::SimpleTag {
   using type = LinkedMessageId<double>;
+  static std::string name() { return "TimeAndPrevious" + get_output(Index); }
 };
 
-struct TimeAndPreviousCompute : TimeAndPrevious, db::ComputeTag {
+template <size_t Index>
+struct TimeAndPreviousCompute : TimeAndPrevious<Index>, db::ComputeTag {
   using argument_tags =
       tmpl::list<::Tags::Time, ::evolution::Tags::PreviousTriggerTime>;
-  using base = TimeAndPrevious;
+  using base = TimeAndPrevious<Index>;
   using return_type = LinkedMessageId<double>;
 
   static void function(

--- a/tests/Unit/Time/Test_Tags.cpp
+++ b/tests/Unit/Time/Test_Tags.cpp
@@ -31,9 +31,14 @@ SPECTRE_TEST_CASE("Unit.Time.Tags", "[Unit][Time]") {
   TestHelpers::db::test_simple_tag<Tags::TimeStepId>("TimeStepId");
   TestHelpers::db::test_simple_tag<Tags::TimeStep>("TimeStep");
   TestHelpers::db::test_simple_tag<Tags::Time>("Time");
-  TestHelpers::db::test_simple_tag<Tags::TimeAndPrevious>("TimeAndPrevious");
-  TestHelpers::db::test_compute_tag<Tags::TimeAndPreviousCompute>(
-      "TimeAndPrevious");
+  TestHelpers::db::test_simple_tag<Tags::TimeAndPrevious<0>>(
+      "TimeAndPrevious0");
+  TestHelpers::db::test_simple_tag<Tags::TimeAndPrevious<1>>(
+      "TimeAndPrevious1");
+  TestHelpers::db::test_compute_tag<Tags::TimeAndPreviousCompute<0>>(
+      "TimeAndPrevious0");
+  TestHelpers::db::test_compute_tag<Tags::TimeAndPreviousCompute<1>>(
+      "TimeAndPrevious1");
   TestHelpers::db::test_simple_tag<
       Tags::HistoryEvolvedVariables<DummyVariablesTag>>(
       "HistoryEvolvedVariables");


### PR DESCRIPTION
## Proposed changes

I ran into some issues with size and shape control where the interpolator would hold volume data indefinitely (and eventually cause a OOM error) because both size and shape use this TemporalId. This is just to distinguish the two until a better solution can be found for the interpolation framework (probably https://github.com/orgs/sxs-collaboration/projects/15)

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
