### PR TITLE
Add more Pybindings for GR

### DIFF
--- a/src/PointwiseFunctions/GeneralRelativity/Python/Bindings.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/Python/Bindings.cpp
@@ -7,14 +7,20 @@
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Christoffel.hpp"
+#include "PointwiseFunctions/GeneralRelativity/DerivativesOfSpacetimeMetric.hpp"
 #include "PointwiseFunctions/GeneralRelativity/ExtrinsicCurvature.hpp"
+#include "PointwiseFunctions/GeneralRelativity/InverseSpacetimeMetric.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Lapse.hpp"
 #include "PointwiseFunctions/GeneralRelativity/ProjectionOperators.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Psi4Real.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Ricci.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Shift.hpp"
+#include "PointwiseFunctions/GeneralRelativity/SpacetimeMetric.hpp"
 #include "PointwiseFunctions/GeneralRelativity/SpacetimeNormalOneForm.hpp"
 #include "PointwiseFunctions/GeneralRelativity/SpacetimeNormalVector.hpp"
+#include "PointwiseFunctions/GeneralRelativity/SpatialMetric.hpp"
+#include "PointwiseFunctions/GeneralRelativity/TimeDerivativeOfSpacetimeMetric.hpp"
+#include "PointwiseFunctions/GeneralRelativity/TimeDerivativeOfSpatialMetric.hpp"
 #include "PointwiseFunctions/GeneralRelativity/WeylElectric.hpp"
 #include "PointwiseFunctions/GeneralRelativity/WeylMagnetic.hpp"
 #include "PointwiseFunctions/GeneralRelativity/WeylPropagating.hpp"
@@ -68,11 +74,63 @@ void bind_impl(py::module& m) {  // NOLINT
       py::arg("spatial_metric"), py::arg("dt_spatial_metric"),
       py::arg("deriv_spatial_metric"));
 
+  m.def("inverse_spacetime_metric",
+        static_cast<tnsr::AA<DataVector, Dim> (*)(
+            const Scalar<DataVector>&, const tnsr::I<DataVector, Dim>&,
+            const tnsr::II<DataVector, Dim>&)>(&::gr::inverse_spacetime_metric),
+        py::arg("lapse"), py::arg("shift"), py::arg("inverse_spatial_metric"));
+
   m.def("lapse",
         static_cast<Scalar<DataVector> (*)(const tnsr::I<DataVector, Dim>&,
                                            const tnsr::aa<DataVector, Dim>&)>(
             &::gr::lapse),
         py::arg("shift"), py::arg("spacetime_metric"));
+
+  m.def("derivatives_of_spacetime_metric",
+        static_cast<tnsr::abb<DataVector, Dim> (*)(
+            const Scalar<DataVector>&, const Scalar<DataVector>&,
+            const tnsr::i<DataVector, Dim>&, const tnsr::I<DataVector, Dim>&,
+            const tnsr::I<DataVector, Dim>&, const tnsr::iJ<DataVector, Dim>&,
+            const tnsr::ii<DataVector, Dim>&, const tnsr::ii<DataVector, Dim>&,
+            const tnsr::ijj<DataVector, Dim>&)>(
+            &::gr::derivatives_of_spacetime_metric),
+        py::arg("lapse"), py::arg("dt_lapse"), py::arg("deriv_lapse"),
+        py::arg("shift"), py::arg("dt_shift"), py::arg("deriv_shift"),
+        py::arg("spatial_metric"), py::arg("dt_spatial_metric"),
+        py::arg("deriv_spatial_metric"));
+
+  m.def("spacetime_metric",
+        static_cast<tnsr::aa<DataVector, Dim> (*)(
+            const Scalar<DataVector>&, const tnsr::I<DataVector, Dim>&,
+            const tnsr::ii<DataVector, Dim>&)>(&::gr::spacetime_metric),
+        py::arg("lapse"), py::arg("shift"), py::arg("spatial_metric"));
+
+  m.def("spatial_metric",
+        static_cast<tnsr::ii<DataVector, Dim> (*)(
+            const tnsr::aa<DataVector, Dim>&)>(&::gr::spatial_metric),
+        py::arg("spacetime_metric"));
+
+  m.def(
+      "time_derivative_of_spacetime_metric",
+      static_cast<tnsr::aa<DataVector, Dim> (*)(
+          const Scalar<DataVector>&, const Scalar<DataVector>&,
+          const tnsr::I<DataVector, Dim>&, const tnsr::I<DataVector, Dim>&,
+          const tnsr::ii<DataVector, Dim>&, const tnsr::ii<DataVector, Dim>&)>(
+          &::gr::time_derivative_of_spacetime_metric),
+      py::arg("lapse"), py::arg("dt_lapse"), py::arg("shift"),
+      py::arg("dt_shift"), py::arg("spatial_metric"),
+      py::arg("dt_spatial_metric"));
+
+  m.def(
+      "time_derivative_of_spatial_metric",
+      static_cast<tnsr::ii<DataVector, Dim> (*)(
+          const Scalar<DataVector>&, const tnsr::I<DataVector, Dim>&,
+          const tnsr::iJ<DataVector, Dim>&, const tnsr::ii<DataVector, Dim>&,
+          const tnsr::ijj<DataVector, Dim>&, const tnsr::ii<DataVector, Dim>&)>(
+          &::gr::time_derivative_of_spatial_metric),
+      py::arg("lapse"), py::arg("shift"), py::arg("deriv_shift"),
+      py::arg("spatial_metric"), py::arg("deriv_spatial_metric"),
+      py::arg("extrinsic_curvature"));
 
   m.def("transverse_projection_operator",
         static_cast<tnsr::II<DataVector, Dim> (*)(

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Python/Test_Bindings.py
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Python/Test_Bindings.py
@@ -32,6 +32,15 @@ class TestBindings(unittest.TestCase):
         )
         npt.assert_allclose(extrinsic_curv, 0)
 
+    def test_inverse_spacetime_metric(self):
+        lapse = Scalar[DataVector](num_points=1, fill=1.0)
+        shift = tnsr.I[DataVector, 3](num_points=1, fill=-1.0)
+        inverse_spatial_metric = tnsr.II[DataVector, 3](num_points=1, fill=0.0)
+        inverse_spacetime_metric_test = inverse_spacetime_metric(
+            lapse, shift, inverse_spatial_metric
+        )
+        npt.assert_allclose(inverse_spacetime_metric_test, -1)
+
     def test_lapse_shift_normals(self):
         spacetime_metric = tnsr.aa[DataVector, 3](num_points=1, fill=1.0)
         inverse_spatial_metric = tnsr.II[DataVector, 3](num_points=1, fill=1.0)
@@ -120,6 +129,70 @@ class TestBindings(unittest.TestCase):
         )
         inverse_metric = tnsr.AA[DataVector, 3](num_points=1, fill=0.0)
         ricci_scalar(spatial_ricci, inverse_metric)
+
+    def test_derivatives_of_spacetime_metric(self):
+        lapse = Scalar[DataVector](num_points=1, fill=1.0)
+        dt_lapse = Scalar[DataVector](num_points=1, fill=0.0)
+        deriv_lapse = tnsr.i[DataVector, 3](num_points=1, fill=0.0)
+        shift = tnsr.I[DataVector, 3](num_points=1, fill=1.0)
+        dt_shift = tnsr.I[DataVector, 3](num_points=1, fill=0.0)
+        deriv_shift = tnsr.iJ[DataVector, 3](num_points=1, fill=0.0)
+        spatial_metric = tnsr.ii[DataVector, 3](num_points=1, fill=1.0)
+        dt_spatial_metric = tnsr.ii[DataVector, 3](num_points=1, fill=0.0)
+        deriv_spatial_metric = tnsr.ijj[DataVector, 3](num_points=1, fill=0.0)
+        derivatives_of_spacetime_metric_test = derivatives_of_spacetime_metric(
+            lapse,
+            dt_lapse,
+            deriv_lapse,
+            shift,
+            dt_shift,
+            deriv_shift,
+            spatial_metric,
+            dt_spatial_metric,
+            deriv_spatial_metric,
+        )
+        npt.assert_allclose(derivatives_of_spacetime_metric_test, 0)
+
+    def test_spacetime_metric(self):
+        lapse = Scalar[DataVector](num_points=1, fill=0.0)
+        shift = tnsr.I[DataVector, 3](num_points=1, fill=1.0)
+        spatial_metric = tnsr.ii[DataVector, 3](num_points=1, fill=0.0)
+        spacetime_metric_test = spacetime_metric(lapse, shift, spatial_metric)
+        npt.assert_allclose(spacetime_metric_test, 0)
+
+    def test_spatial_metric(self):
+        spacetime_metric = tnsr.aa[DataVector, 3](num_points=1, fill=0.0)
+        spatial_metric_test = spatial_metric(spacetime_metric)
+        npt.assert_allclose(spatial_metric_test, 0)
+
+    def test_time_derivative_of_spacetime_metric(self):
+        lapse = Scalar[DataVector](num_points=1, fill=1.0)
+        dt_lapse = Scalar[DataVector](num_points=1, fill=0.0)
+        shift = tnsr.I[DataVector, 3](num_points=1, fill=1.0)
+        dt_shift = tnsr.I[DataVector, 3](num_points=1, fill=0.0)
+        spatial_metric = tnsr.ii[DataVector, 3](num_points=1, fill=1.0)
+        dt_spatial_metric = tnsr.ii[DataVector, 3](num_points=1, fill=0.0)
+        t_deriv_of_spacetime_metric_test = time_derivative_of_spacetime_metric(
+            lapse, dt_lapse, shift, dt_shift, spatial_metric, dt_spatial_metric
+        )
+        npt.assert_allclose(t_deriv_of_spacetime_metric_test, 0)
+
+    def test_time_derivative_of_spatial_metric(self):
+        lapse = Scalar[DataVector](num_points=1, fill=1.0)
+        shift = tnsr.I[DataVector, 3](num_points=1, fill=1.0)
+        deriv_shift = tnsr.iJ[DataVector, 3](num_points=1, fill=0.0)
+        spatial_metric = tnsr.ii[DataVector, 3](num_points=1, fill=1.0)
+        deriv_spatial_metric = tnsr.ijj[DataVector, 3](num_points=1, fill=0.0)
+        extrinsic_curvature = tnsr.ii[DataVector, 3](num_points=1, fill=0.0)
+        t_deriv_of_spatial_metric_test = time_derivative_of_spatial_metric(
+            lapse,
+            shift,
+            deriv_shift,
+            spatial_metric,
+            deriv_spatial_metric,
+            extrinsic_curvature,
+        )
+        npt.assert_allclose(t_deriv_of_spatial_metric_test, 0)
 
     def test_weyl_electric(self):
         spatial_ricci = tnsr.ii[DataVector, 3](num_points=1, fill=0.0)


### PR DESCRIPTION
## Proposed changes

This adds pybindings for the following in GR:

- DerivativesOfSpacetimeMetric
- InverseSpacetimeMetric
- SpacetimeMetric
- SpatialMetric
- TimeDerivativeOfSpacetimeMetric
- TimeDerivativeOfSpatialMetric

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
