### PR TITLE
Allow control sys dense output during first time step

### DIFF
--- a/src/ControlSystem/ExpirationTimes.hpp
+++ b/src/ControlSystem/ExpirationTimes.hpp
@@ -103,24 +103,17 @@ double measurement_expiration_time(const double time,
  *
  * If the control system isn't active then expiration time is
  * `std::numeric_limits<double>::infinity()`.
- *
- * To protect against bad inputs, if the initial expiration time that is
- * calculated is smaller than the initial time step, then the expiration time is
- * simply set to the initial time step. However, the MeasurementTimescales have
- * the same protection so if this does happen, then something is most likely
- * wrong with your initial parameters for the control system.
  */
 template <size_t Dim, typename... OptionHolders>
 std::unordered_map<std::string, double> initial_expiration_times(
-    const double initial_time, const double initial_time_step,
-    const int measurements_per_update,
+    const double initial_time, const int measurements_per_update,
     const std::unique_ptr<::DomainCreator<Dim>>& domain_creator,
     const OptionHolders&... option_holders) {
   std::unordered_map<std::string, double> initial_expiration_times{};
 
   [[maybe_unused]] const auto gather_initial_expiration_times =
-      [&initial_time, &initial_time_step, &measurements_per_update,
-       &domain_creator, &initial_expiration_times](const auto& option_holder) {
+      [&initial_time, &measurements_per_update, &domain_creator,
+       &initial_expiration_times](const auto& option_holder) {
         const auto& controller = option_holder.controller;
         const std::string& name =
             std::decay_t<decltype(option_holder)>::control_system::name();
@@ -138,8 +131,7 @@ std::unordered_map<std::string, double> initial_expiration_times(
         // Don't have to worry about if functions of time are being overridden
         // because that will be taken care of elsewhere.
         initial_expiration_times[name] =
-            option_holder.is_active ? std::max(initial_time + initial_time_step,
-                                               initial_expiration_time)
+            option_holder.is_active ? initial_expiration_time
                                     : std::numeric_limits<double>::infinity();
       };
 

--- a/src/ControlSystem/Tags/MeasurementTimescales.hpp
+++ b/src/ControlSystem/Tags/MeasurementTimescales.hpp
@@ -52,7 +52,7 @@ struct MeasurementTimescales : db::SimpleTag {
 
   template <typename Metavariables>
   using option_tags = typename detail::OptionList<
-      Metavariables, true,
+      Metavariables, true, true,
       ::detail::has_override_functions_of_time_v<Metavariables>>::type;
 
   /// This version of create_from_options is used if the metavariables
@@ -92,11 +92,6 @@ struct MeasurementTimescales : db::SimpleTag {
 
           DataVector measurement_timescales = calculate_measurement_timescales(
               controller, tuner, measurements_per_update);
-          for (size_t i = 0; i < measurement_timescales.size(); i++) {
-            measurement_timescales[i] =
-                std::max(initial_time_step / measurements_per_update,
-                         measurement_timescales[i]);
-          }
 
           double expr_time = measurement_expiration_time(
               initial_time, DataVector{measurement_timescales.size(), 0.0},

--- a/tests/Unit/ControlSystem/Tags/Test_FunctionsOfTimeInitialize.cpp
+++ b/tests/Unit/ControlSystem/Tags/Test_FunctionsOfTimeInitialize.cpp
@@ -218,9 +218,11 @@ void test_functions_of_time_tag() {
   // Controller. This value for the timescale was chosen to give an expiration
   // time between the two expiration times used above in the TestCreator
   const double timescale = 27.0;
+  const double timescale2 = 0.1;
   const TimescaleTuner tuner1(std::vector<double>{timescale}, 10.0, 1.0e-3,
                               1.0e-2, 1.0e-4, 1.01, 0.99);
-  const TimescaleTuner tuner2(0.1, 10.0, 1.0e-3, 1.0e-2, 1.0e-4, 1.01, 0.99);
+  const TimescaleTuner tuner2(timescale2, 10.0, 1.0e-3, 1.0e-2, 1.0e-4, 1.01,
+                              0.99);
   const Averager<1> averager(0.25, true);
   const double update_fraction = 0.3;
   const Controller<2> controller(update_fraction);
@@ -235,17 +237,16 @@ void test_functions_of_time_tag() {
 
   // First test construction with only control systems and no
   // override_functions_of_time
-  const double initial_time_step = 1.0;
   fot_tag::type functions_of_time = fot_tag::create_from_options<Metavariables>(
-      measurements_per_update, creator, initial_time, initial_time_step,
-      option_holder1, option_holder2, option_holder3);
+      measurements_per_update, creator, initial_time, option_holder1,
+      option_holder2, option_holder3);
 
   CHECK(functions_of_time.at("Controlled1")->time_bounds()[1] ==
         std::numeric_limits<double>::infinity());
   CHECK(functions_of_time.at("Controlled2")->time_bounds()[1] ==
         initial_time + update_fraction * timescale);
   CHECK(functions_of_time.at("Controlled3")->time_bounds()[1] ==
-        initial_time + initial_time_step);
+        initial_time + update_fraction * timescale2);
   CHECK(functions_of_time.at("Uncontrolled")->time_bounds()[1] ==
         std::numeric_limits<double>::infinity());
 
@@ -255,8 +256,7 @@ void test_functions_of_time_tag() {
           tmpl::list<
               control_system::OptionTags::MeasurementsPerUpdate,
               domain::OptionTags::DomainCreator<Metavariables::volume_dim>,
-              ::OptionTags::InitialTime, ::OptionTags::InitialTimeStep,
-              ControlSysInputs<FakeControlSystem<1>>,
+              ::OptionTags::InitialTime, ControlSysInputs<FakeControlSystem<1>>,
               ControlSysInputs<FakeControlSystem<2>>,
               ControlSysInputs<FakeControlSystem<3>>>>);
 
@@ -322,15 +322,14 @@ void test_functions_of_time_tag() {
                     MetavariablesReplace::volume_dim>,
                 domain::FunctionsOfTime::OptionTags::FunctionOfTimeFile,
                 domain::FunctionsOfTime::OptionTags::FunctionOfTimeNameMap,
-                ::OptionTags::InitialTime, ::OptionTags::InitialTimeStep,
+                ::OptionTags::InitialTime,
                 ControlSysInputs<FakeControlSystem<1>>,
                 ControlSysInputs<FakeControlSystem<2>>,
                 ControlSysInputs<FakeControlSystem<3>>>>);
     auto replace_functions_of_time =
         fot_tag::create_from_options<MetavariablesReplace>(
             measurements_per_update, creator, {test_filename}, test_name_map,
-            initial_time, initial_time_step, option_holder1, option_holder2,
-            option_holder3);
+            initial_time, option_holder1, option_holder2, option_holder3);
 
     const double final_time = expected_times[number_of_times - 1];
     CHECK(replace_functions_of_time.at("Controlled2")->time_bounds()[1] ==
@@ -345,14 +344,13 @@ void test_functions_of_time_tag() {
     auto no_replace_functions_of_time =
         fot_tag::create_from_options<MetavariablesReplace>(
             measurements_per_update, creator, std::nullopt, test_name_map,
-            initial_time, initial_time_step, option_holder1, option_holder2,
-            option_holder3);
+            initial_time, option_holder1, option_holder2, option_holder3);
     CHECK(no_replace_functions_of_time.at("Controlled1")->time_bounds()[1] ==
           std::numeric_limits<double>::infinity());
     CHECK(no_replace_functions_of_time.at("Controlled2")->time_bounds()[1] ==
           initial_time + update_fraction * timescale);
     CHECK(no_replace_functions_of_time.at("Controlled3")->time_bounds()[1] ==
-          initial_time + initial_time_step);
+          initial_time + update_fraction * timescale2);
     CHECK(no_replace_functions_of_time.at("Uncontrolled")->time_bounds()[1] ==
           std::numeric_limits<double>::infinity());
 
@@ -436,11 +434,10 @@ void not_controlling(const bool is_active) {
   OptionHolder<4> option_holder4(is_active, averager, controller, tuner,
                                  control_error);
 
-  const double initial_time_step = 1.0;
   [[maybe_unused]] fot_tag::type functions_of_time =
       fot_tag::create_from_options<Metavariables>(
-          measurements_per_update, creator, initial_time, initial_time_step,
-          option_holder1, option_holder2, option_holder3, option_holder4);
+          measurements_per_update, creator, initial_time, option_holder1,
+          option_holder2, option_holder3, option_holder4);
 }
 
 void incompatible(const bool is_active) {
@@ -460,11 +457,10 @@ void incompatible(const bool is_active) {
   OptionHolder<3> option_holder3(is_active, averager, controller, tuner,
                                  control_error);
 
-  const double initial_time_step = 1.0;
   [[maybe_unused]] fot_tag::type functions_of_time =
       fot_tag::create_from_options<Metavariables>(
-          measurements_per_update, creator, initial_time, initial_time_step,
-          option_holder1, option_holder2, option_holder3);
+          measurements_per_update, creator, initial_time, option_holder1,
+          option_holder2, option_holder3);
 }
 
 void test_errors(const bool is_active) {

--- a/tests/Unit/ControlSystem/Tags/Test_MeasurementTimescales.cpp
+++ b/tests/Unit/ControlSystem/Tags/Test_MeasurementTimescales.cpp
@@ -107,8 +107,8 @@ void test_measurement_tag() {
     const TimescaleTuner tuner1(std::vector<double>{timescale1}, 10.0, 1.0e-3,
                                 1.0e-2, 1.0e-4, 1.01, 0.99);
     const double timescale2 = 0.5;
-    const TimescaleTuner tuner2(timescale2, 10.0, 1.0e-3, 1.0e-2, 1.0e-4, 1.01,
-                                0.99);
+    TimescaleTuner tuner2(timescale2, 10.0, 1.0e-3, 1.0e-2, 1.0e-4, 1.01, 0.99);
+    tuner2.resize_timescales(2);
     const double averaging_fraction = 0.25;
     const Averager<1> averager(averaging_fraction, true);
     const double update_fraction = 0.3;
@@ -152,10 +152,13 @@ void test_measurement_tag() {
     const double measure_time1 =
         control_system::calculate_measurement_timescales(
             controller, tuner1, measurements_per_update)[0];
-    const double measure_time2 = time_step / measurements_per_update;
+    const double measure_time2 =
+        control_system::calculate_measurement_timescales(
+            controller, tuner2, measurements_per_update)[0];
     const double expr_time1 =
         initial_time + update_fraction * timescale1 - 0.5 * measure_time1;
-    const double expr_time2 = initial_time + time_step - 0.5 * measure_time2;
+    const double expr_time2 =
+        initial_time + update_fraction * timescale2 - 0.5 * measure_time2;
     CHECK(timescales.at("Controlled1")->time_bounds() ==
           std::array{initial_time, expr_time1});
     CHECK(timescales.at("Controlled1")->func(2.0)[0] ==

--- a/tests/Unit/ControlSystem/Test_ExpirationTimes.cpp
+++ b/tests/Unit/ControlSystem/Test_ExpirationTimes.cpp
@@ -59,7 +59,6 @@ void check_expiration_times(
 
 void test_expiration_time_construction() {
   const double initial_time = 0.9;
-  const double initial_time_step = 0.1;
   constexpr int measurements_per_update = 4;
 
   const double timescale = 2.0;
@@ -96,7 +95,7 @@ void test_expiration_time_construction() {
     INFO("No control systems");
     const auto initial_expiration_times =
         control_system::initial_expiration_times(
-            initial_time, initial_time_step, measurements_per_update, creator1);
+            initial_time, measurements_per_update, creator1);
 
     const std::unordered_map<std::string, double>
         expected_initial_expiration_times{};
@@ -108,8 +107,7 @@ void test_expiration_time_construction() {
     INFO("One control system");
     const auto initial_expiration_times =
         control_system::initial_expiration_times(
-            initial_time, initial_time_step, measurements_per_update, creator2,
-            option_holder1);
+            initial_time, measurements_per_update, creator2, option_holder1);
 
     const std::unordered_map<std::string, double>
         expected_initial_expiration_times{
@@ -128,8 +126,8 @@ void test_expiration_time_construction() {
     INFO("Three control system");
     const auto initial_expiration_times =
         control_system::initial_expiration_times(
-            initial_time, initial_time_step, measurements_per_update, creator3,
-            option_holder1, option_holder2, option_holder3);
+            initial_time, measurements_per_update, creator3, option_holder1,
+            option_holder2, option_holder3);
 
     const std::unordered_map<std::string, double>
         expected_initial_expiration_times{
@@ -141,7 +139,12 @@ void test_expiration_time_construction() {
                  measurements_per_update)},
             {FakeControlSystem<2>::name(),
              std::numeric_limits<double>::infinity()},
-            {FakeControlSystem<3>::name(), initial_time + initial_time_step}};
+            {FakeControlSystem<3>::name(),
+             control_system::function_of_time_expiration_time(
+                 initial_time, DataVector{0.0},
+                 control_system::calculate_measurement_timescales(
+                     controller, tuner2, measurements_per_update),
+                 measurements_per_update)}};
 
     check_expiration_times(expected_initial_expiration_times,
                            initial_expiration_times);


### PR DESCRIPTION
## Proposed changes

Size control needs a very small damping timescale compared to the other control systems initially. This may cause the measurement timescale (and thus the horizon finds/interpolations) to be smaller than a timestep initially. Previously the control system prevented this, but now it's ok. And since we can do dense output between steps without having to take the full step for linear-multistep methods, we don't have to worry about functions of time being expired.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
