### PR TITLE
Add PyBindings for Time Derivative of Shift in GH

### DIFF
--- a/src/DataStructures/Tensor/Python/Tensor.tpp
+++ b/src/DataStructures/Tensor/Python/Tensor.tpp
@@ -244,7 +244,7 @@ void bind_tensor(py::module& m) {
   GENERATE_INSTANTIATIONS(INSTANTIATE_TNSR, (double, DataVector),
                           (Frame::Inertial),
                           (a, A, ii, aa, II, AA, ij, ab, Ij, Ab, iJ, aB, ijj,
-                           abb, Ijj, Abb, iJkk, aBcc))
+                           abb, Ijj, Abb, iaa, iJkk, aBcc))
 
   GENERATE_INSTANTIATIONS(INSTANTIATE_JAC, (double, DataVector),
                           (Frame::Grid, Frame::Inertial))

--- a/src/DataStructures/Tensor/Python/tnsr.py
+++ b/src/DataStructures/Tensor/Python/tnsr.py
@@ -34,3 +34,5 @@ II = TensorMeta("II")
 ijj = TensorMeta("ijj")
 Ijj = TensorMeta("Ijj")
 iJkk = TensorMeta("iJkk")
+
+iaa = TensorMeta("iaa")

--- a/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/CMakeLists.txt
+++ b/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/CMakeLists.txt
@@ -48,3 +48,5 @@ spectre_target_headers(
   TimeDerivOfSpatialMetric.hpp
   TimeDerivativeOfSpacetimeMetric.hpp
 )
+
+add_subdirectory(Python)

--- a/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/Python/Bindings.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/Python/Bindings.cpp
@@ -1,0 +1,39 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include <cstddef>
+#include <pybind11/pybind11.h>
+#include <type_traits>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/TimeDerivOfShift.hpp"
+#include "Utilities/ErrorHandling/SegfaultHandler.hpp"
+
+namespace py = pybind11;
+
+namespace GeneralizedHarmonic::py_bindings {
+
+namespace {
+template <size_t Dim>
+void bind_impl(py::module& m) {  // NOLINT
+  m.def(
+      "time_deriv_of_shift",
+      static_cast<tnsr::I<DataVector, Dim> (*)(
+          const Scalar<DataVector>&, const tnsr::I<DataVector, Dim>&,
+          const tnsr::II<DataVector, Dim>&, const tnsr::A<DataVector, Dim>&,
+          const tnsr::iaa<DataVector, Dim>&, const tnsr::aa<DataVector, Dim>&)>(
+          &::gh::time_deriv_of_shift),
+      py::arg("lapse"), py::arg("shift"), py::arg("inverse_spatial_metric"),
+      py::arg("spacetime_unit_normal"), py::arg("phi"), py::arg("pi"));
+}
+}  // namespace
+
+PYBIND11_MODULE(_Pybindings, m) {  // NOLINT
+  enable_segfault_handler();
+  py::module_::import("spectre.DataStructures");
+  py::module_::import("spectre.DataStructures.Tensor");
+  py_bindings::bind_impl<1>(m);
+  py_bindings::bind_impl<2>(m);
+  py_bindings::bind_impl<3>(m);
+}
+}  // namespace GeneralizedHarmonic::py_bindings

--- a/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/Python/CMakeLists.txt
+++ b/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/Python/CMakeLists.txt
@@ -1,0 +1,35 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBRARY "PyGeneralizedHarmonic")
+
+spectre_python_add_module(
+    GeneralizedHarmonic
+    LIBRARY_NAME ${LIBRARY}
+    MODULE_PATH "PointwiseFunctions/GeneralRelativity"
+    SOURCES
+    Bindings.cpp
+    PYTHON_FILES
+    __init__.py
+)
+
+spectre_python_headers(
+    ${LIBRARY}
+    INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+    HEADERS
+)
+
+spectre_python_link_libraries(
+    ${LIBRARY}
+    PRIVATE
+    DataStructures
+    GeneralizedHarmonic
+    pybind11::module
+    Utilities
+)
+
+spectre_python_add_dependencies(
+  ${LIBRARY}
+  PyDataStructures
+  PyTensor
+  )

--- a/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/Python/__init__.py
+++ b/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/Python/__init__.py
@@ -1,0 +1,4 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+from ._Pybindings import *

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Python/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Python/CMakeLists.txt
@@ -6,3 +6,9 @@ spectre_add_python_bindings_test(
   Test_Bindings.py
   "Unit;GeneralRelativity;Python"
   PyGeneralRelativity)
+
+spectre_add_python_bindings_test(
+  "Unit.GeneralizedHarmonic.Python"
+  Test_GhBindings.py
+  "Unit;GeneralizedHarmonic;Python"
+  PyGeneralizedHarmonic)

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Python/Test_GhBindings.py
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Python/Test_GhBindings.py
@@ -1,0 +1,33 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import unittest
+
+import numpy as np
+import numpy.testing as npt
+
+import spectre.PointwiseFunctions.GeneralRelativity.GeneralizedHarmonic as gh
+from spectre.DataStructures import DataVector
+from spectre.DataStructures.Tensor import Scalar, tnsr
+
+
+class TestBindings(unittest.TestCase):
+    def test_time_deriv_of_shift(self):
+        lapse = Scalar[DataVector](num_points=1, fill=1.0)
+        shift = tnsr.I[DataVector, 3](num_points=1, fill=0.0)
+        inverse_spatial_metric = tnsr.II[DataVector, 3](num_points=1, fill=1.0)
+        spacetime_unit_normal = tnsr.A[DataVector, 3](num_points=1, fill=1.0)
+        phi = tnsr.iaa[DataVector, 3](num_points=1, fill=1.0)
+        pi = tnsr.aa[DataVector, 3](num_points=1, fill=1.0)
+        gh.time_deriv_of_shift(
+            lapse,
+            shift,
+            inverse_spatial_metric,
+            spacetime_unit_normal,
+            phi,
+            pi,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Proposed changes

Added python binding for time derivative of shift in the General Harmonic directory.

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
