### PR TITLE
Make db::mutate_apply and db::mutate consistent

### DIFF
--- a/src/ControlSystem/Actions/InitializeMeasurements.hpp
+++ b/src/ControlSystem/Actions/InitializeMeasurements.hpp
@@ -61,7 +61,6 @@ struct InitializeMeasurements {
       const ArrayIndex& /*array_index*/, ActionList /*meta*/,
       const ParallelComponent* const /*meta*/) {
     db::mutate<evolution::Tags::EventsAndDenseTriggers>(
-        make_not_null(&box),
         [](const gsl::not_null<evolution::EventsAndDenseTriggers*>
                events_and_dense_triggers) {
           tmpl::for_each<metafunctions::measurements_t<ControlSystems>>(
@@ -77,7 +76,8 @@ struct InitializeMeasurements {
                         std::make_unique<
                             control_system::Event<control_system_group>>()));
               });
-        });
+        },
+        make_not_null(&box));
     return {Parallel::AlgorithmExecution::Continue, std::nullopt};
   }
 };

--- a/src/Elliptic/DiscontinuousGalerkin/SubdomainOperator/InitializeSubdomain.hpp
+++ b/src/Elliptic/DiscontinuousGalerkin/SubdomainOperator/InitializeSubdomain.hpp
@@ -286,11 +286,12 @@ struct InitializeSubdomain {
             auto tag_v, const Direction<Dim>& direction) {
           using tag = tmpl::type_from<std::decay_t<decltype(tag_v)>>;
           db::mutate<overlaps_tag<domain::Tags::Faces<Dim, tag>>>(
-              box, [&face_background_fields, &overlap_id,
-                    &direction](const auto stored_value) {
+              [&face_background_fields, &overlap_id,
+               &direction](const auto stored_value) {
                 (*stored_value)[overlap_id][direction] =
                     get<tag>(face_background_fields.at(direction));
-              });
+              },
+              box);
         };
     const auto& element =
         db::get<overlaps_tag<domain::Tags::Element<Dim>>>(*box).at(overlap_id);

--- a/src/Evolution/DgSubcell/Actions/ReconstructionCommunication.hpp
+++ b/src/Evolution/DgSubcell/Actions/ReconstructionCommunication.hpp
@@ -125,10 +125,11 @@ struct SendDataForReconstruction {
     using flux_variables = typename Metavariables::system::flux_variables;
 
     db::mutate<Tags::GhostDataForReconstruction<Dim>>(
-        make_not_null(&box), [](const auto ghost_data_ptr) {
+        [](const auto ghost_data_ptr) {
           // Clear the previous neighbor data and add current local data
           ghost_data_ptr->clear();
-        });
+        },
+        make_not_null(&box));
 
     const Mesh<Dim>& dg_mesh = db::get<::domain::Tags::Mesh<Dim>>(box);
     const Mesh<Dim>& subcell_mesh = db::get<Tags::Mesh<Dim>>(box);
@@ -331,7 +332,6 @@ struct ReceiveDataForReconstruction {
                evolution::dg::Tags::MortarNextTemporalId<Dim>,
                evolution::dg::Tags::NeighborMesh<Dim>,
                evolution::dg::subcell::Tags::NeighborTciDecisions<Dim>>(
-        make_not_null(&box),
         [&current_time_step_id, &element,
          ghost_zone_size = Metavariables::SubcellOptions::ghost_zone_size(box),
          &received_data, &subcell_mesh](
@@ -421,7 +421,8 @@ struct ReceiveDataForReconstruction {
                   std::get<5>(received_data[directional_element_id]);
             }
           }
-        });
+        },
+        make_not_null(&box));
     return {Parallel::AlgorithmExecution::Continue, std::nullopt};
   }
 };

--- a/src/Evolution/DgSubcell/Actions/TakeTimeStep.hpp
+++ b/src/Evolution/DgSubcell/Actions/TakeTimeStep.hpp
@@ -75,7 +75,6 @@ struct TakeTimeStep {
            "Do not yet support moving mesh with DG-subcell.");
     db::mutate<fd::Tags::InverseJacobianLogicalToGrid<Dim>,
                fd::Tags::DetInverseJacobianLogicalToGrid>(
-        make_not_null(&box),
         [](const auto inv_jac_ptr, const auto det_inv_jac_ptr,
            const auto& logical_to_grid_map, const auto& logical_coords) {
           if (not inv_jac_ptr->has_value()) {
@@ -83,6 +82,7 @@ struct TakeTimeStep {
             *det_inv_jac_ptr = determinant(**inv_jac_ptr);
           }
         },
+        make_not_null(&box),
         db::get<::domain::Tags::ElementMap<Dim, Frame::Grid>>(box),
         db::get<subcell::Tags::Coordinates<Dim, Frame::ElementLogical>>(box));
 
@@ -92,11 +92,12 @@ struct TakeTimeStep {
         *db::get<fd::Tags::DetInverseJacobianLogicalToGrid>(box));
 
     db::mutate<evolution::dg::Tags::MortarData<Dim>>(
-        make_not_null(&box), [](const auto mortar_data_ptr) {
+        [](const auto mortar_data_ptr) {
           for (auto& data : *mortar_data_ptr) {
             data.second = evolution::dg::MortarData<Dim>{};
           }
-        });
+        },
+        make_not_null(&box));
     return {Parallel::AlgorithmExecution::Continue, std::nullopt};
   }
 };

--- a/src/Evolution/DgSubcell/NeighborReconstructedFaceSolution.hpp
+++ b/src/Evolution/DgSubcell/NeighborReconstructedFaceSolution.hpp
@@ -82,8 +82,8 @@ void neighbor_reconstructed_face_solution(
   constexpr size_t volume_dim = Metavariables::volume_dim;
   db::mutate<subcell::Tags::GhostDataForReconstruction<volume_dim>,
              subcell::Tags::DataForRdmpTci>(
-      box, [&received_temporal_id_and_data](const auto subcell_ghost_data_ptr,
-                                            const auto rdmp_tci_data_ptr) {
+      [&received_temporal_id_and_data](const auto subcell_ghost_data_ptr,
+                                       const auto rdmp_tci_data_ptr) {
         const size_t number_of_evolved_vars =
             rdmp_tci_data_ptr->max_variables_values.size();
         for (auto& received_mortar_data :
@@ -136,7 +136,8 @@ void neighbor_reconstructed_face_solution(
                                       number_of_evolved_vars)),
                     neighbor_data.begin());
         }
-      });
+      },
+      box);
   std::vector<std::pair<Direction<volume_dim>, ElementId<volume_dim>>>
       mortars_to_reconstruct_to{};
   for (auto& received_mortar_data : received_temporal_id_and_data->second) {

--- a/src/Evolution/DgSubcell/NeighborTciDecision.hpp
+++ b/src/Evolution/DgSubcell/NeighborTciDecision.hpp
@@ -39,7 +39,6 @@ void neighbor_tci_decision(
             boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>>&
         received_temporal_id_and_data) {
   db::mutate<subcell::Tags::NeighborTciDecisions<Dim>>(
-      box,
       [&received_temporal_id_and_data](const auto neighbor_tci_decisions_ptr) {
         for (const auto& [directional_element_id, neighbor_data] :
              received_temporal_id_and_data.second) {
@@ -50,6 +49,7 @@ void neighbor_tci_decision(
           neighbor_tci_decisions_ptr->at(directional_element_id) =
               std::get<5>(neighbor_data);
         }
-      });
+      },
+      box);
 }
 }  // namespace evolution::dg::subcell

--- a/src/Evolution/DgSubcell/ReconstructionOrder.hpp
+++ b/src/Evolution/DgSubcell/ReconstructionOrder.hpp
@@ -30,7 +30,6 @@ void store_reconstruction_order_in_databox(
         reconstruction_order) {
   if (reconstruction_order.has_value()) {
     db::mutate<evolution::dg::subcell::Tags::ReconstructionOrder<Dim>>(
-        box,
         [&reconstruction_order](const auto recons_order_ptr,
                                 const ::Mesh<Dim>& subcell_mesh) {
           if (UNLIKELY(not recons_order_ptr->has_value())) {
@@ -53,27 +52,27 @@ void store_reconstruction_order_in_databox(
                             d)[j * (subcell_mesh.extents(d) + 2) + i + 1];
               }
             }
-              if (d == 1) {
-                // Order is (y, z, x) -> (x, y, z)
-                transpose(make_not_null(&recons_order_ptr->value().get(d)),
-                          get<0>(recons_order_ptr->value()),
-                          subcell_mesh.extents(1) *
-                              (Dim > 2 ? subcell_mesh.extents(2) : 1),
-                          subcell_mesh.number_of_grid_points() /
-                              (subcell_mesh.extents(1) *
-                               (Dim > 2 ? subcell_mesh.extents(2) : 1)));
-              } else if (d == 2) {
-                // Order is (z, x, y) -> (x, y, z)
-                transpose(make_not_null(&recons_order_ptr->value().get(d)),
-                          get<0>(recons_order_ptr->value()),
-                          subcell_mesh.extents(2),
-                          subcell_mesh.number_of_grid_points() /
-                              subcell_mesh.extents(2));
-              }
+            if (d == 1) {
+              // Order is (y, z, x) -> (x, y, z)
+              transpose(make_not_null(&recons_order_ptr->value().get(d)),
+                        get<0>(recons_order_ptr->value()),
+                        subcell_mesh.extents(1) *
+                            (Dim > 2 ? subcell_mesh.extents(2) : 1),
+                        subcell_mesh.number_of_grid_points() /
+                            (subcell_mesh.extents(1) *
+                             (Dim > 2 ? subcell_mesh.extents(2) : 1)));
+            } else if (d == 2) {
+              // Order is (z, x, y) -> (x, y, z)
+              transpose(make_not_null(&recons_order_ptr->value().get(d)),
+                        get<0>(recons_order_ptr->value()),
+                        subcell_mesh.extents(2),
+                        subcell_mesh.number_of_grid_points() /
+                            subcell_mesh.extents(2));
+            }
             // }
           }
         },
-        db::get<evolution::dg::subcell::Tags::Mesh<Dim>>(*box));
+        box, db::get<evolution::dg::subcell::Tags::Mesh<Dim>>(*box));
   }
 }
 }  // namespace evolution::dg::subcell

--- a/src/Evolution/DiscontinuousGalerkin/Actions/ApplyBoundaryCorrections.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Actions/ApplyBoundaryCorrections.hpp
@@ -135,7 +135,6 @@ bool receive_boundary_data_global_time_stepping(
   db::mutate<evolution::dg::Tags::MortarData<volume_dim>,
              evolution::dg::Tags::MortarNextTemporalId<volume_dim>,
              evolution::dg::Tags::NeighborMesh<volume_dim>>(
-      box,
       [&received_temporal_id_and_data](
           const gsl::not_null<std::unordered_map<
               Key, evolution::dg::MortarData<volume_dim>, boost::hash<Key>>*>
@@ -176,7 +175,8 @@ bool receive_boundary_data_global_time_stepping(
                 std::move(*std::get<3>(received_mortar_data.second)));
           }
         }
-      });
+      },
+      box);
   inbox.erase(received_temporal_id_and_data);
   return true;
 }
@@ -235,7 +235,6 @@ bool receive_boundary_data_local_time_stepping(
                                              typename dt_variables_tag::type>,
       evolution::dg::Tags::MortarNextTemporalId<volume_dim>,
       evolution::dg::Tags::NeighborMesh<volume_dim>>(
-      box,
       [&inbox, &needed_time](
           const gsl::not_null<
               std::unordered_map<Key,
@@ -307,7 +306,7 @@ bool receive_boundary_data_local_time_stepping(
         }
         return true;
       },
-      db::get<::domain::Tags::Element<volume_dim>>(*box));
+      box, db::get<::domain::Tags::Element<volume_dim>>(*box));
 
   if (not have_all_intermediate_messages) {
     return false;

--- a/src/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivative.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivative.hpp
@@ -766,7 +766,6 @@ void ComputeTimeDerivative<Dim, EvolutionSystem, DgStepChoosers,
     db::mutate<evolution::dg::Tags::MortarData<Dim>,
                evolution::dg::Tags::MortarDataHistory<
                    Dim, typename dt_variables_tag::type>>(
-        box,
         [&element, integration_order, &time_step_id, using_gauss_points,
          &volume_det_inv_jacobian](
             const gsl::not_null<std::unordered_map<
@@ -844,7 +843,7 @@ void ComputeTimeDerivative<Dim, EvolutionSystem, DgStepChoosers,
             }
           }
         },
-        db::get<domain::Tags::Mesh<Dim>>(*box),
+        box, db::get<domain::Tags::Mesh<Dim>>(*box),
         db::get<evolution::dg::Tags::NormalCovectorAndMagnitude<Dim>>(*box));
   }
 }

--- a/src/Evolution/DiscontinuousGalerkin/Actions/InternalMortarDataImpl.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Actions/InternalMortarDataImpl.hpp
@@ -355,7 +355,6 @@ void internal_mortar_data(
     tmpl::list<PackageDataVolumeTags...> /*meta*/) {
   db::mutate<evolution::dg::Tags::NormalCovectorAndMagnitude<Dim>,
              evolution::dg::Tags::MortarData<Dim>>(
-      box,
       [&boundary_correction, &face_temporaries, &packaged_data_buffer,
        &element = db::get<domain::Tags::Element<Dim>>(*box), &evolved_variables,
        &logical_to_inertial_inverse_jacobian =
@@ -379,6 +378,6 @@ void internal_mortar_data(
             moving_mesh_map, mesh_velocity,
             logical_to_inertial_inverse_jacobian, package_data_volume_args...);
       },
-      db::get<PackageDataVolumeTags>(*box)...);
+      box, db::get<PackageDataVolumeTags>(*box)...);
 }
 }  // namespace evolution::dg::Actions::detail

--- a/src/Evolution/EventsAndDenseTriggers/EventsAndDenseTriggers.hpp
+++ b/src/Evolution/EventsAndDenseTriggers/EventsAndDenseTriggers.hpp
@@ -241,22 +241,23 @@ void EventsAndDenseTriggers::run_events(
   for (auto& trigger_entry : events_and_triggers_) {
     if (trigger_entry.is_triggered == std::optional{true}) {
       db::mutate<::evolution::Tags::PreviousTriggerTime>(
-          make_not_null(&box),
           [&trigger_entry](const gsl::not_null<std::optional<double>*>
                                previous_trigger_time) {
             *previous_trigger_time =
                 trigger_entry.trigger->previous_trigger_time();
-          });
+          },
+          make_not_null(&box));
       const auto observation_box = make_observation_box<compute_tags>(box);
       for (const auto& event : trigger_entry.events) {
         event->run(observation_box, cache, array_index, component);
       }
       db::mutate<::evolution::Tags::PreviousTriggerTime>(
-          make_not_null(&box), [](const gsl::not_null<std::optional<double>*>
-                                      previous_trigger_time) {
+          [](const gsl::not_null<std::optional<double>*>
+                 previous_trigger_time) {
             *previous_trigger_time =
                 std::numeric_limits<double>::signaling_NaN();
-          });
+          },
+          make_not_null(&box));
     }
     // Mark this trigger as handled so we will not reprocess it if
     // this method or is_ready is called again.

--- a/src/Evolution/Initialization/SetVariables.hpp
+++ b/src/Evolution/Initialization/SetVariables.hpp
@@ -125,28 +125,30 @@ struct SetVariables {
       using primitives_tag = typename system::primitive_variables_tag;
       // Set initial data from analytic solution
       db::mutate<primitives_tag>(
-          box, [&initial_time, &inertial_coords, &solution_or_data](
-                   const gsl::not_null<typename primitives_tag::type*>
-                       primitive_vars) {
+          [&initial_time, &inertial_coords, &solution_or_data](
+              const gsl::not_null<typename primitives_tag::type*>
+                  primitive_vars) {
             primitive_vars->assign_subset(
                 evolution::Initialization::initial_data(
                     solution_or_data, inertial_coords, initial_time,
                     typename Metavariables::analytic_variables_tags{}));
-          });
+          },
+          box);
       using non_conservative_variables =
           typename system::non_conservative_variables;
       using variables_tag = typename system::variables_tag;
       if constexpr (not std::is_same_v<non_conservative_variables,
                                        tmpl::list<>>) {
         db::mutate<variables_tag>(
-            box, [&initial_time, &inertial_coords, &solution_or_data](
-                     const gsl::not_null<typename variables_tag::type*>
-                         evolved_vars) {
+            [&initial_time, &inertial_coords, &solution_or_data](
+                const gsl::not_null<typename variables_tag::type*>
+                    evolved_vars) {
               evolved_vars->assign_subset(
                   evolution::Initialization::initial_data(
                       solution_or_data, inertial_coords, initial_time,
                       non_conservative_variables{}));
-            });
+            },
+            box);
       }
     } else {
       using variables_tag = typename system::variables_tag;
@@ -154,12 +156,13 @@ struct SetVariables {
       // Set initial data from analytic solution
       using Vars = typename variables_tag::type;
       db::mutate<variables_tag>(
-          box, [&initial_time, &inertial_coords,
-                &solution_or_data](const gsl::not_null<Vars*> vars) {
+          [&initial_time, &inertial_coords,
+           &solution_or_data](const gsl::not_null<Vars*> vars) {
             vars->assign_subset(evolution::Initialization::initial_data(
                 solution_or_data, inertial_coords, initial_time,
                 typename Vars::tags_list{}));
-          });
+          },
+          box);
     }
   }
 };

--- a/src/Evolution/Systems/Burgers/FiniteDifference/BoundaryConditionGhostData.hpp
+++ b/src/Evolution/Systems/Burgers/FiniteDifference/BoundaryConditionGhostData.hpp
@@ -196,7 +196,7 @@ void BoundaryConditionGhostData::apply(
     const std::pair mortar_id{direction, ElementId<1>::external_boundary_id()};
 
     db::mutate<evolution::dg::subcell::Tags::GhostDataForReconstruction<1>>(
-        box, [&mortar_id, &ghost_data_vars](auto ghost_data_ptr) {
+        [&mortar_id, &ghost_data_vars](auto ghost_data_ptr) {
           (*ghost_data_ptr)[mortar_id] = evolution::dg::subcell::GhostData{1};
           DataVector& neighbor_data =
               ghost_data_ptr->at(mortar_id)
@@ -205,7 +205,8 @@ void BoundaryConditionGhostData::apply(
           std::copy(get(get<Burgers::Tags::U>(ghost_data_vars)).begin(),
                     get(get<Burgers::Tags::U>(ghost_data_vars)).end(),
                     neighbor_data.begin());
-        });
+        },
+        box);
   }
 }
 }  // namespace Burgers::fd

--- a/src/Evolution/Systems/Burgers/Subcell/TimeDerivative.hpp
+++ b/src/Evolution/Systems/Burgers/Subcell/TimeDerivative.hpp
@@ -211,9 +211,9 @@ struct TimeDerivative {
         db::add_tag_prefix<::Tags::dt, typename System::variables_tag>;
     const size_t num_pts = subcell_mesh.number_of_grid_points();
     db::mutate<dt_variables_tag>(
-        box, [&cell_centered_logical_to_grid_inv_jacobian, &num_pts,
-              &fd_boundary_corrections, &subcell_mesh,
-              &one_over_delta_xi](const auto dt_vars_ptr) {
+        [&cell_centered_logical_to_grid_inv_jacobian, &num_pts,
+         &fd_boundary_corrections, &subcell_mesh,
+         &one_over_delta_xi](const auto dt_vars_ptr) {
           dt_vars_ptr->initialize(num_pts, 0.0);
           auto& dt_u = get<::Tags::dt<::Burgers::Tags::U>>(*dt_vars_ptr);
 
@@ -223,7 +223,8 @@ struct TimeDerivative {
               make_not_null(&get(dt_u)), gsl::at(one_over_delta_xi, 0),
               cell_centered_logical_to_grid_inv_jacobian.get(0, 0),
               get(u_correction), subcell_mesh.extents(), 0);
-        });
+        },
+        box);
   }
 };
 }  // namespace Burgers::subcell

--- a/src/Evolution/Systems/Cce/Actions/CalculateScriInputs.hpp
+++ b/src/Evolution/Systems/Cce/Actions/CalculateScriInputs.hpp
@@ -81,7 +81,6 @@ struct CalculateScriInputs {
                                        const size_t l_max,
                                        tmpl::list<TagPack...> /*meta*/) {
     db::mutate<TagPack...>(
-        make_not_null(&box),
         [&l_max](const gsl::not_null<typename TagPack::type*>... derivatives,
                  const typename TagPack::derivative_of::type&... arguments) {
           Spectral::Swsh::angular_derivatives<
@@ -89,7 +88,7 @@ struct CalculateScriInputs {
               l_max, 1, make_not_null(&get(*derivatives))...,
               get(arguments)...);
         },
-        db::get<typename TagPack::derivative_of>(box)...);
+        make_not_null(&box), db::get<typename TagPack::derivative_of>(box)...);
   }
 };
 }  // namespace Actions

--- a/src/Evolution/Systems/Cce/Actions/FilterSwshVolumeQuantity.hpp
+++ b/src/Evolution/Systems/Cce/Actions/FilterSwshVolumeQuantity.hpp
@@ -61,14 +61,14 @@ struct FilterSwshVolumeQuantity {
     const size_t radial_filter_half_power =
         get<Tags::RadialFilterHalfPower>(box);
     db::mutate<BondiTag>(
-        make_not_null(&box),
         [&l_max, &l_filter_start, &radial_filter_alpha,
          &radial_filter_half_power](
             const gsl::not_null<typename BondiTag::type*> bondi_quantity) {
           Spectral::Swsh::filter_swsh_volume_quantity(
               make_not_null(&get(*bondi_quantity)), l_max, l_filter_start,
               radial_filter_alpha, radial_filter_half_power);
-        });
+        },
+        make_not_null(&box));
     return {Parallel::AlgorithmExecution::Continue, std::nullopt};
   }
 };

--- a/src/Evolution/Systems/Cce/Actions/InsertInterpolationScriData.hpp
+++ b/src/Evolution/Systems/Cce/Actions/InsertInterpolationScriData.hpp
@@ -171,7 +171,6 @@ struct InsertInterpolationScriData {
 
       // insert the target times into the interpolator.
       db::mutate<Tags::InterpolationManager<ComplexDataVector, Tag>>(
-          make_not_null(&box),
           [&this_time, &time_delta_estimate](
               const gsl::not_null<
                   ScriPlusInterpolationManager<ComplexDataVector, Tag>*>
@@ -184,6 +183,7 @@ struct InsertInterpolationScriData {
                       static_cast<double>(number_of_interpolated_times));
             }
           },
+          make_not_null(&box),
           db::get<InitializationTags::ScriOutputDensity>(box));
     }
     return {Parallel::AlgorithmExecution::Continue, std::nullopt};

--- a/src/Evolution/Systems/Cce/Actions/ReceiveGhWorldtubeData.hpp
+++ b/src/Evolution/Systems/Cce/Actions/ReceiveGhWorldtubeData.hpp
@@ -75,10 +75,10 @@ struct ReceiveGhWorldtubeData {
         };
     if constexpr (DuringSelfStart) {
       db::mutate<Tags::SelfStartGhInterfaceManager>(
-          make_not_null(&box), insert_gh_data_to_interface_manager);
+          insert_gh_data_to_interface_manager, make_not_null(&box));
     } else {
-      db::mutate<Tags::GhInterfaceManager>(make_not_null(&box),
-                                           insert_gh_data_to_interface_manager);
+      db::mutate<Tags::GhInterfaceManager>(insert_gh_data_to_interface_manager,
+                                           make_not_null(&box));
     }
   }
 };

--- a/src/Evolution/Systems/Cce/Actions/ReceiveWorldtubeData.hpp
+++ b/src/Evolution/Systems/Cce/Actions/ReceiveWorldtubeData.hpp
@@ -61,12 +61,11 @@ struct ReceiveWorldtubeData {
         [&inbox, &box](auto tag_v) {
           using tag = typename decltype(tag_v)::type;
           db::mutate<tag>(
-              make_not_null(&box),
               [&inbox](const gsl::not_null<typename tag::type*> destination,
                        const TimeStepId& time) {
                 *destination = get<tag>(inbox[time]);
               },
-              db::get<::Tags::TimeStepId>(box));
+              make_not_null(&box), db::get<::Tags::TimeStepId>(box));
         });
     inbox.erase(db::get<::Tags::TimeStepId>(box));
     return {Parallel::AlgorithmExecution::Continue,

--- a/src/Evolution/Systems/Cce/Actions/ScriObserveInterpolated.hpp
+++ b/src/Evolution/Systems/Cce/Actions/ScriObserveInterpolated.hpp
@@ -159,14 +159,14 @@ struct ScriObserveInterpolated {
         using tag = typename decltype(tag_v)::type;
         std::pair<double, ComplexDataVector> interpolation;
         db::mutate<Tags::InterpolationManager<ComplexDataVector, tag>>(
-            make_not_null(&box),
             [&interpolation](
                 const gsl::not_null<
                     ScriPlusInterpolationManager<ComplexDataVector, tag>*>
                     interpolation_manager) {
               interpolation =
                   interpolation_manager->interpolate_and_pop_first_time();
-            });
+            },
+            make_not_null(&box));
         interpolation_time = interpolation.first;
         get(get<tag>(corrected_scri_plus_weyl)).data() = interpolation.second;
       });
@@ -201,14 +201,14 @@ struct ScriObserveInterpolated {
             using tag = typename decltype(tag_v)::type;
             std::pair<double, ComplexDataVector> interpolation;
             db::mutate<Tags::InterpolationManager<ComplexDataVector, tag>>(
-                make_not_null(&box),
                 [&interpolation](
                     const gsl::not_null<
                         ScriPlusInterpolationManager<ComplexDataVector, tag>*>
                         interpolation_manager) {
                   interpolation =
                       interpolation_manager->interpolate_and_pop_first_time();
-                });
+                },
+                make_not_null(&box));
             ScriObserveInterpolated::transform_and_write<
                 tag, tag::type::type::spin, ParallelComponent>(
                 interpolation.second, interpolation.first,

--- a/src/Evolution/Systems/CurvedScalarWave/CalculateGrVars.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/CalculateGrVars.hpp
@@ -50,11 +50,11 @@ struct CalculateGrVars {
         [&box, &initial_data](auto spacetime_tag_v) {
           using spacetime_tag = tmpl::type_from<decltype(spacetime_tag_v)>;
           db::mutate<spacetime_tag>(
-              make_not_null(&box),
               [&initial_data](const auto spacetime_tag_ptr) {
                 *spacetime_tag_ptr =
                     std::move(get<spacetime_tag>(initial_data));
-              });
+              },
+              make_not_null(&box));
         });
 
     return {Parallel::AlgorithmExecution::Continue, std::nullopt};

--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/ElementActions/ReceiveWorldtubeData.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/ElementActions/ReceiveWorldtubeData.hpp
@@ -106,7 +106,6 @@ struct ReceiveWorldtubeData {
           get(get<Tags::RegularFieldAdvectiveTerm<Dim>>(box));
 
       db::mutate<Tags::WorldtubeSolution<Dim>>(
-          make_not_null(&box),
           [&received_data, &puncture_field,
            &vars_on_face](const gsl::not_null<Variables<evolved_tags_list>*>
                               worldtube_solution) {
@@ -139,7 +138,8 @@ struct ReceiveWorldtubeData {
             get(pi) = (-get(get<dt_psi_tag>(received_data)) +
                        get(dot_product(shift, phi_inertial))) /
                       get(lapse);
-          });
+          },
+          make_not_null(&box));
       inbox.erase(time_step_id);
     }
     return {Parallel::AlgorithmExecution::Continue, std::nullopt};

--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/ElementActions/SendToWorldtube.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/ElementActions/SendToWorldtube.hpp
@@ -148,7 +148,6 @@ struct SendToWorldtube {
                     direction.value().dimension(),
                     index_to_slice_at(mesh.extents(), direction.value()));
       db::mutate<Tags::RegularFieldAdvectiveTerm<Dim>>(
-          make_not_null(&box),
           [&face_phi, &mesh_velocity_on_face,
            &di_psi_puncture =
                get<::Tags::deriv<CurvedScalarWave::Tags::Psi, tmpl::size_t<3>,
@@ -157,7 +156,8 @@ struct SendToWorldtube {
             tenex::evaluate<>(regular_advective_term,
                               (face_phi(ti::i) - di_psi_puncture(ti::i)) *
                                   mesh_velocity_on_face(ti::I));
-          });
+          },
+          make_not_null(&box));
       // The time derivative is transformed into the grid frame using the
       // advective term which comes from the transformation of the time
       // derivative due to the moving mesh.

--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonActions/ChangeSlabSize.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonActions/ChangeSlabSize.hpp
@@ -70,7 +70,6 @@ struct ChangeSlabSize {
                                                            new_step);
       db::mutate<::Tags::Next<::Tags::TimeStepId>, ::Tags::TimeStep,
                  ::Tags::Next<::Tags::TimeStep>, ::Tags::TimeStepId>(
-          make_not_null(&box),
           [&new_next_time_step_id, &new_step, &inbox_time_step_id](
               const gsl::not_null<TimeStepId*> next_time_step_id,
               const gsl::not_null<TimeDelta*> time_step,
@@ -80,7 +79,8 @@ struct ChangeSlabSize {
             *time_step = new_step;
             *next_time_step = new_step;
             *local_time_step_id = inbox_time_step_id;
-          });
+          },
+          make_not_null(&box));
     }
     return {Parallel::AlgorithmExecution::Continue, std::nullopt};
   }

--- a/src/Evolution/Systems/GeneralizedHarmonic/Actions/SetInitialData.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Actions/SetInitialData.hpp
@@ -359,7 +359,7 @@ struct SetInitialData {
                                               Frame::Inertial>>(*box);
     db::mutate<gr::Tags::SpacetimeMetric<DataVector, Dim>,
                Tags::Pi<DataVector, Dim>, Tags::Phi<DataVector, Dim>>(
-        box, &gh::initial_gh_variables_from_adm<Dim>, spatial_metric, lapse,
+        &gh::initial_gh_variables_from_adm<Dim>, box, spatial_metric, lapse,
         shift, extrinsic_curvature, mesh, inv_jacobian);
 
     // No need to import numeric initial data, so we terminate the phase by
@@ -411,7 +411,6 @@ struct ReceiveNumericInitialData {
 
     db::mutate<gr::Tags::SpacetimeMetric<DataVector, 3>,
                Tags::Pi<DataVector, 3>, Tags::Phi<DataVector, 3>>(
-        make_not_null(&box),
         [&initial_data, &numeric_data, &mesh, &inv_jacobian](
             const gsl::not_null<tnsr::aa<DataVector, 3>*> spacetime_metric,
             const gsl::not_null<tnsr::aa<DataVector, 3>*> pi,
@@ -419,7 +418,8 @@ struct ReceiveNumericInitialData {
           initial_data.set_initial_data(spacetime_metric, pi, phi,
                                         make_not_null(&numeric_data), mesh,
                                         inv_jacobian);
-        });
+        },
+        make_not_null(&box));
     return {Parallel::AlgorithmExecution::Continue, std::nullopt};
   }
 };

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/Actions/SetInitialData.hpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/Actions/SetInitialData.hpp
@@ -250,7 +250,7 @@ struct SetInitialData {
                                               Frame::Inertial>>(*box);
     db::mutate<gr::Tags::SpacetimeMetric<DataVector, 3>,
                gh::Tags::Pi<DataVector, 3>, gh::Tags::Phi<DataVector, 3>>(
-        box, &gh::initial_gh_variables_from_adm<3>, spatial_metric, lapse,
+        &gh::initial_gh_variables_from_adm<3>, box, spatial_metric, lapse,
         shift, extrinsic_curvature, mesh, inv_jacobian);
 
     // Move hydro vars directly into the DataBox
@@ -327,7 +327,6 @@ struct ReceiveNumericInitialData {
                hydro::Tags::LorentzFactor<DataVector>,
                hydro::Tags::Pressure<DataVector>,
                hydro::Tags::SpecificEnthalpy<DataVector>>(
-        make_not_null(&box),
         [&initial_data, &numeric_data, &mesh, &inv_jacobian,
          &equation_of_state](
             const gsl::not_null<tnsr::aa<DataVector, 3>*> spacetime_metric,
@@ -348,7 +347,8 @@ struct ReceiveNumericInitialData {
               div_cleaning_field, lorentz_factor, pressure, specific_enthalpy,
               make_not_null(&numeric_data), mesh, inv_jacobian,
               equation_of_state);
-        });
+        },
+        make_not_null(&box));
 
     return {Parallel::AlgorithmExecution::Continue, std::nullopt};
   }

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/TimeDerivative.hpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/TimeDerivative.hpp
@@ -135,9 +135,9 @@ struct ComputeTimeDerivImpl<
     using variables_tag = typename System::variables_tag;
     using dt_variables_tag = db::add_tag_prefix<::Tags::dt, variables_tag>;
     const gsl::not_null<typename dt_variables_tag::type*> dt_vars_ptr =
-        db::mutate<dt_variables_tag>(box, [](const auto local_dt_vars_ptr) {
-          return local_dt_vars_ptr;
-        });
+        db::mutate<dt_variables_tag>(
+            [](const auto local_dt_vars_ptr) { return local_dt_vars_ptr; },
+            box);
     dt_vars_ptr->initialize(subcell_mesh.number_of_grid_points());
 
     using primitives_tag = typename System::primitive_variables_tag;
@@ -437,7 +437,6 @@ struct TimeDerivative {
             db::get<grmhd::GhValenciaDivClean::fd::Tags::FilterOptions>(*box);
         filter_options.spacetime_dissipation.has_value()) {
       db::mutate<evolved_vars_tag>(
-          box,
           [&filter_options, &recons, &subcell_mesh](const auto evolved_vars_ptr,
                                                     const auto& ghost_data) {
             typename evolved_vars_tag::type filtered_vars = *evolved_vars_ptr;
@@ -449,6 +448,7 @@ struct TimeDerivative {
                 filter_options.spacetime_dissipation.value());
             *evolved_vars_ptr = filtered_vars;
           },
+          box,
           db::get<evolution::dg::subcell::Tags::GhostDataForReconstruction<3>>(
               *box));
     }

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Actions/NumericInitialData.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Actions/NumericInitialData.hpp
@@ -391,7 +391,6 @@ struct SetNumericInitialData {
                hydro::Tags::LorentzFactor<DataVector>,
                hydro::Tags::Pressure<DataVector>,
                hydro::Tags::SpecificEnthalpy<DataVector>>(
-        make_not_null(&box),
         [&initial_data, &numeric_data, &inv_spatial_metric, &equation_of_state](
             const gsl::not_null<Scalar<DataVector>*> rest_mass_density,
             const gsl::not_null<Scalar<DataVector>*> electron_fraction,
@@ -408,7 +407,8 @@ struct SetNumericInitialData {
               lorentz_factor, pressure, specific_enthalpy,
               make_not_null(&numeric_data), inv_spatial_metric,
               equation_of_state);
-        });
+        },
+        make_not_null(&box));
 
     return {Parallel::AlgorithmExecution::Continue, std::nullopt};
   }

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TimeDerivative.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TimeDerivative.hpp
@@ -355,9 +355,9 @@ struct TimeDerivative {
     using variables_tag = typename System::variables_tag;
     using dt_variables_tag = db::add_tag_prefix<::Tags::dt, variables_tag>;
     const gsl::not_null<typename dt_variables_tag::type*> dt_vars_ptr =
-        db::mutate<dt_variables_tag>(box, [](const auto local_dt_vars_ptr) {
-          return local_dt_vars_ptr;
-        });
+        db::mutate<dt_variables_tag>(
+            [](const auto local_dt_vars_ptr) { return local_dt_vars_ptr; },
+            box);
     dt_vars_ptr->initialize(subcell_mesh.number_of_grid_points());
 
     using grmhd_source_tags =

--- a/src/Evolution/Systems/RadiationTransport/M1Grey/Initialize.hpp
+++ b/src/Evolution/Systems/RadiationTransport/M1Grey/Initialize.hpp
@@ -71,14 +71,14 @@ struct InitializeM1Tags {
         db::get<domain::Tags::Coordinates<dim, Frame::Inertial>>(box);
 
     db::mutate<evolved_variables_tag>(
-        make_not_null(&box),
         [&cache, initial_time,
          &inertial_coords](const gsl::not_null<EvolvedVars*> evolved_vars) {
           evolved_vars->assign_subset(evolution::Initialization::initial_data(
               Parallel::get<::Tags::AnalyticSolutionOrData>(cache),
               inertial_coords, initial_time,
               typename evolved_variables_tag::tags_list{}));
-        });
+        },
+        make_not_null(&box));
 
     // Get hydro variables
     HydroVars hydro_variables{num_grid_points};

--- a/src/Evolution/Systems/ScalarAdvection/Subcell/TimeDerivative.hpp
+++ b/src/Evolution/Systems/ScalarAdvection/Subcell/TimeDerivative.hpp
@@ -231,9 +231,9 @@ struct TimeDerivative {
         db::add_tag_prefix<::Tags::dt, typename System<Dim>::variables_tag>;
     const size_t num_pts = subcell_mesh.number_of_grid_points();
     db::mutate<dt_variables_tag>(
-        box, [&cell_centered_logical_to_grid_inv_jacobian, &num_pts,
-              &fd_boundary_corrections, &subcell_mesh,
-              &one_over_delta_xi](const auto dt_vars_ptr) {
+        [&cell_centered_logical_to_grid_inv_jacobian, &num_pts,
+         &fd_boundary_corrections, &subcell_mesh,
+         &one_over_delta_xi](const auto dt_vars_ptr) {
           dt_vars_ptr->initialize(num_pts, 0.0);
           auto& dt_u =
               get<::Tags::dt<::ScalarAdvection::Tags::U>>(*dt_vars_ptr);
@@ -246,7 +246,8 @@ struct TimeDerivative {
                 cell_centered_logical_to_grid_inv_jacobian.get(dim, dim),
                 get(u_correction), subcell_mesh.extents(), dim);
           }
-        });
+        },
+        box);
   }
 };
 }  // namespace ScalarAdvection::subcell

--- a/src/IO/Importers/Actions/ReadVolumeData.hpp
+++ b/src/IO/Importers/Actions/ReadVolumeData.hpp
@@ -384,10 +384,10 @@ struct ReadAllVolumeDataAndDistribute {
       return;
     }
     db::mutate<Tags::ElementDataAlreadyRead>(
-        make_not_null(&box),
         [&volume_data_id](const auto local_has_read_volume_data) {
           local_has_read_volume_data->insert(volume_data_id);
-        });
+        },
+        make_not_null(&box));
 
     // This is the subset of elements that reside on this node. They have
     // registered themselves before. Our job is to fill them with volume data.

--- a/src/IO/Importers/Actions/ReceiveVolumeData.hpp
+++ b/src/IO/Importers/Actions/ReceiveVolumeData.hpp
@@ -51,10 +51,10 @@ struct ReceiveVolumeData {
     tmpl::for_each<FieldTagsList>([&box, &element_data](auto tag_v) {
       using tag = tmpl::type_from<decltype(tag_v)>;
       db::mutate<tag>(
-          make_not_null(&box),
           [&element_data](const gsl::not_null<typename tag::type*> value) {
             *value = std::move(tuples::get<tag>(element_data));
-          });
+          },
+          make_not_null(&box));
     });
     inbox.erase(received_data);
     return {Parallel::AlgorithmExecution::Continue, std::nullopt};

--- a/src/IO/Importers/Actions/RegisterWithElementDataReader.hpp
+++ b/src/IO/Importers/Actions/RegisterWithElementDataReader.hpp
@@ -85,14 +85,14 @@ struct RegisterElementWithSelf {
       const observers::ArrayComponentId& array_component_id,
       const tnsr::I<DataVector, Dim, Frame::Inertial>& inertial_coords) {
     db::mutate<Tags::RegisteredElements<Dim>>(
-        make_not_null(&box),
         [&array_component_id, &inertial_coords](
             const gsl::not_null<
                 std::unordered_map<observers::ArrayComponentId,
                                    tnsr::I<DataVector, Dim, Frame::Inertial>>*>
                 registered_elements) {
           (*registered_elements)[array_component_id] = inertial_coords;
-        });
+        },
+        make_not_null(&box));
   }
 };
 

--- a/src/IO/Observer/Actions/GetLockPointer.hpp
+++ b/src/IO/Observer/Actions/GetLockPointer.hpp
@@ -33,10 +33,10 @@ struct GetLockPointer {
     Parallel::NodeLock* result_lock;
     const std::lock_guard hold_lock(*node_lock);
     db::mutate<LockTag>(
-        make_not_null(&box),
         [&result_lock](const gsl::not_null<Parallel::NodeLock*> lock) {
           result_lock = lock;
-        });
+        },
+        make_not_null(&box));
     return result_lock;
   }
 };

--- a/src/IO/Observer/Actions/ObserverRegistration.hpp
+++ b/src/IO/Observer/Actions/ObserverRegistration.hpp
@@ -45,7 +45,6 @@ struct RegisterVolumeContributorWithObserverWriter {
                     const observers::ObservationKey& observation_key,
                     const ArrayComponentId& id_of_caller) {
     db::mutate<Tags::ExpectedContributorsForObservations>(
-        make_not_null(&box),
         [&id_of_caller, &observation_key](
             const gsl::not_null<std::unordered_map<
                 ObservationKey, std::unordered_set<ArrayComponentId>>*>
@@ -65,7 +64,8 @@ struct RegisterVolumeContributorWithObserverWriter {
           }
 
           volume_observers_registered->at(observation_key).insert(id_of_caller);
-        });
+        },
+        make_not_null(&box));
   }
 };
 
@@ -86,7 +86,6 @@ struct DeregisterVolumeContributorWithObserverWriter {
                     const observers::ObservationKey& observation_key,
                     const ArrayComponentId& id_of_caller) {
     db::mutate<Tags::ExpectedContributorsForObservations>(
-        make_not_null(&box),
         [&id_of_caller, &observation_key](
             const gsl::not_null<std::unordered_map<
                 ObservationKey, std::unordered_set<ArrayComponentId>>*>
@@ -113,7 +112,8 @@ struct DeregisterVolumeContributorWithObserverWriter {
                   0)) {
             volume_observers_registered->erase(observation_key);
           }
-        });
+        },
+        make_not_null(&box));
   }
 };
 
@@ -136,7 +136,6 @@ struct RegisterReductionNodeWithWritingNode {
                              << ", should be called from another node");
 
     db::mutate<Tags::NodesExpectedToContributeReductions>(
-        make_not_null(&box),
         [&caller_node_id, &observation_key](
             const gsl::not_null<
                 std::unordered_map<ObservationKey, std::set<size_t>>*>
@@ -154,7 +153,8 @@ struct RegisterReductionNodeWithWritingNode {
                                              << " for reduction observations.");
           }
           registered_nodes_for_key.insert(caller_node_id);
-        });
+        },
+        make_not_null(&box));
   }
 };
 
@@ -178,7 +178,6 @@ struct DeregisterReductionNodeWithWritingNode {
                << node_id << " should deregister other nodes in the reduction");
 
     db::mutate<Tags::NodesExpectedToContributeReductions>(
-        make_not_null(&box),
         [&caller_node_id, &observation_key](
             const gsl::not_null<
                 std::unordered_map<ObservationKey, std::set<size_t>>*>
@@ -202,7 +201,8 @@ struct DeregisterReductionNodeWithWritingNode {
           if (UNLIKELY(registered_nodes_for_key.size() == 0)) {
             reduction_observers_registered_nodes->erase(observation_key);
           }
-        });
+        },
+        make_not_null(&box));
   }
 };
 
@@ -226,7 +226,6 @@ struct RegisterReductionContributorWithObserverWriter {
     const auto node_id =
         Parallel::my_node<size_t>(*Parallel::local_branch(my_proxy));
     db::mutate<Tags::ExpectedContributorsForObservations>(
-        make_not_null(&box),
         [&cache, &id_of_caller, &node_id, &observation_key](
             const gsl::not_null<std::unordered_map<
                 ObservationKey, std::unordered_set<ArrayComponentId>>*>
@@ -253,7 +252,8 @@ struct RegisterReductionContributorWithObserverWriter {
                   << id_of_caller
                   << " with observation key: " << observation_key);
           }
-        });
+        },
+        make_not_null(&box));
   }
 };
 
@@ -278,7 +278,6 @@ struct DeregisterReductionContributorWithObserverWriter {
     const auto node_id =
         Parallel::my_node<size_t>(*Parallel::local_branch(my_proxy));
     db::mutate<Tags::ExpectedContributorsForObservations>(
-        make_not_null(&box),
         [&cache, &id_of_caller, &node_id, &observation_key](
             const gsl::not_null<std::unordered_map<
                 ObservationKey, std::unordered_set<ArrayComponentId>>*>
@@ -307,7 +306,8 @@ struct DeregisterReductionContributorWithObserverWriter {
                 observation_key, node_id);
             reduction_observers_registered->erase(observation_key);
           }
-        });
+        },
+        make_not_null(&box));
   }
 };
 
@@ -328,7 +328,6 @@ struct RegisterContributorWithObserver {
                     const TypeOfObservation& type_of_observation) {
     bool observation_key_already_registered = true;
     db::mutate<observers::Tags::ExpectedContributorsForObservations>(
-        make_not_null(&box),
         [&component_id, &observation_key, &observation_key_already_registered](
             const gsl::not_null<std::unordered_map<
                 ObservationKey, std::unordered_set<ArrayComponentId>>*>
@@ -348,7 +347,8 @@ struct RegisterContributorWithObserver {
                 << observation_key);
           }
           array_component_ids->operator[](observation_key).insert(component_id);
-        });
+        },
+        make_not_null(&box));
 
     if (observation_key_already_registered) {
       // We only need to register with the observer writer on the first call
@@ -401,7 +401,6 @@ struct DeregisterContributorWithObserver {
                     const TypeOfObservation& type_of_observation) {
     bool all_array_components_have_been_deregistered = false;
     db::mutate<observers::Tags::ExpectedContributorsForObservations>(
-        make_not_null(&box),
         [&component_id, &observation_key,
          &all_array_components_have_been_deregistered](
             const gsl::not_null<std::unordered_map<
@@ -427,7 +426,8 @@ struct DeregisterContributorWithObserver {
             array_component_ids->erase(observation_key);
             all_array_components_have_been_deregistered = true;
           }
-        });
+        },
+        make_not_null(&box));
 
     if (not all_array_components_have_been_deregistered) {
       // Only deregister with the observer writer if this deregistration

--- a/src/IO/Observer/ReductionActions.hpp
+++ b/src/IO/Observer/ReductionActions.hpp
@@ -128,7 +128,6 @@ struct ContributeReductionData {
                     const bool observe_per_core = false) {
     db::mutate<Tags::ReductionData<Ts...>, Tags::ReductionDataNames<Ts...>,
                Tags::ContributorsOfReductionData>(
-        make_not_null(&box),
         [&array_index, &cache, &observation_id,
          reduction_data = std::move(reduction_data), &reduction_names,
          &sender_array_id, &subfile_name, &formatter, &observe_per_core](
@@ -206,6 +205,7 @@ struct ContributeReductionData {
             reduction_observers_contributed->erase(observation_id);
           }
         },
+        make_not_null(&box),
         db::get<Tags::ExpectedContributorsForObservations>(box));
     // Silence a gcc <= 9 unused-variable warning
     (void)observe_per_core;
@@ -300,7 +300,6 @@ struct CollectReductionDataOnNode {
                  Tags::ReductionDataNames<ReductionDatums...>,
                  Tags::ContributorsOfReductionData, Tags::ReductionDataLock,
                  Tags::H5FileLock>(
-          make_not_null(&box),
           [&reduction_data, &reduction_names_map,
            &reduction_observers_contributed, &reduction_data_lock,
            &reduction_file_lock, &observation_id, &observer_group_id,
@@ -339,6 +338,7 @@ struct CollectReductionDataOnNode {
             observations_registered_with_id =
                 observations_registered.at(key).size();
           },
+          make_not_null(&box),
           db::get<Tags::ExpectedContributorsForObservations>(box));
     }
 
@@ -504,7 +504,6 @@ struct WriteReductionData {
                  Tags::ReductionDataNames<ReductionDatums...>,
                  Tags::NodesThatContributedReductions, Tags::ReductionDataLock,
                  Tags::H5FileLock>(
-          make_not_null(&box),
           [&nodes_contributed, &reduction_data, &reduction_names_map,
            &reduction_data_lock, &reduction_file_lock, &observation_id,
            &observations_registered_with_id, &sender_node_number](
@@ -544,6 +543,7 @@ struct WriteReductionData {
             observations_registered_with_id =
                 nodes_registered_for_reductions.at(key).size();
           },
+          make_not_null(&box),
           db::get<Tags::NodesExpectedToContributeReductions>(box));
     }
 

--- a/src/IO/Observer/VolumeActions.hpp
+++ b/src/IO/Observer/VolumeActions.hpp
@@ -67,7 +67,6 @@ struct ContributeVolumeData {
                     const observers::ArrayComponentId& sender_array_id,
                     ElementVolumeData&& received_volume_data) {
     db::mutate<Tags::TensorData, Tags::ContributorsOfTensorData>(
-        make_not_null(&box),
         [&array_index, &cache, &received_volume_data, &observation_id,
          &sender_array_id, &subfile_name](
             const gsl::not_null<std::unordered_map<
@@ -142,6 +141,7 @@ struct ContributeVolumeData {
             volume_data->erase(observation_id);
           }
         },
+        make_not_null(&box),
         db::get<Tags::ExpectedContributorsForObservations>(box));
   }
 };
@@ -226,7 +226,6 @@ struct ContributeVolumeDataToWriter {
       const std::lock_guard hold_lock(*node_lock);
       db::mutate<TensorDataTag, Tags::ContributorsOfTensorData,
                  Tags::VolumeDataLock, Tags::H5FileLock>(
-          make_not_null(&box),
           [&observation_id, &observations_registered_with_id,
            &observer_group_id, &all_volume_data, &volume_observers_contributed,
            &volume_data_lock, &volume_file_lock](
@@ -257,6 +256,7 @@ struct ContributeVolumeDataToWriter {
                 observations_registered.at(key).size();
             volume_file_lock = &*volume_file_lock_ptr;
           },
+          make_not_null(&box),
           db::get<Tags::ExpectedContributorsForObservations>(box));
     }
 

--- a/src/IO/Observer/WriteSimpleData.hpp
+++ b/src/IO/Observer/WriteSimpleData.hpp
@@ -45,10 +45,10 @@ struct WriteSimpleData {
     {
       const std::lock_guard hold_lock(*node_lock);
       db::mutate<Tags::H5FileLock>(
-          make_not_null(&box),
           [&file_lock](const gsl::not_null<Parallel::NodeLock*> in_file_lock) {
             file_lock = in_file_lock;
-          });
+          },
+          make_not_null(&box));
     }
 
     // scoped to close file

--- a/src/NumericalAlgorithms/LinearOperators/FilterAction.hpp
+++ b/src/NumericalAlgorithms/LinearOperators/FilterAction.hpp
@@ -167,17 +167,15 @@ class Filter<FilterType, tmpl::list<TagsToFilter...>> {
                            tmpl::list<TagsToFilter...>>>::
             template f<evolved_vars_tags_list, TagsToFilter...>::value) {
       db::mutate<typename Metavariables::system::variables_tag>(
-          make_not_null(&box),
           [&filter](const gsl::not_null<
                         typename Metavariables::system::variables_tag::type*>
                         vars,
                     const auto& local_mesh) {
             *vars = apply_matrices(filter, *vars, local_mesh.extents());
           },
-          mesh);
+          make_not_null(&box), mesh);
     } else {
       db::mutate<TagsToFilter...>(
-          make_not_null(&box),
           [&filter](const gsl::not_null<
                         typename TagsToFilter::type*>... tensors_to_filter,
                     const auto& local_mesh) {
@@ -193,7 +191,7 @@ class Filter<FilterType, tmpl::list<TagsToFilter...>> {
             };
             EXPAND_PACK_LEFT_TO_RIGHT(helper(tensors_to_filter));
           },
-          mesh);
+          make_not_null(&box), mesh);
     }
     return {Parallel::AlgorithmExecution::Continue, std::nullopt};
   }

--- a/src/Parallel/DistributedObject.hpp
+++ b/src/Parallel/DistributedObject.hpp
@@ -668,10 +668,10 @@ void DistributedObject<
   // unpacking.)
   if (p.isUnpacking()) {
     db::mutate<Tags::GlobalCacheProxy<metavariables>>(
-        make_not_null(&box_),
         [](const gsl::not_null<CProxy_GlobalCache<metavariables>*> proxy) {
           (void)proxy;
-        });
+        },
+        make_not_null(&box_));
   }
   p | inboxes_;
   p | array_index_;

--- a/src/ParallelAlgorithms/Actions/MemoryMonitor/ContributeMemoryData.hpp
+++ b/src/ParallelAlgorithms/Actions/MemoryMonitor/ContributeMemoryData.hpp
@@ -66,7 +66,6 @@ struct ContributeMemoryData {
 
     using tag = Tags::MemoryHolder;
     db::mutate<tag>(
-        make_not_null(&box),
         [&cache, &time, &node_or_proc, &size_in_megabytes](
             const gsl::not_null<std::unordered_map<
                 std::string,
@@ -163,7 +162,8 @@ struct ContributeMemoryData {
             auto finished_time_iter = memory_holder.find(time);
             memory_holder.erase(finished_time_iter);
           }
-        });
+        },
+        make_not_null(&box));
   }
 };
 }  // namespace mem_monitor

--- a/src/ParallelAlgorithms/Actions/RandomizeVariables.hpp
+++ b/src/ParallelAlgorithms/Actions/RandomizeVariables.hpp
@@ -108,12 +108,13 @@ struct RandomizeVariables {
     // Set up the random distribution
     std::uniform_real_distribution<> dist(-amplitude, amplitude);
     // Add noise to the fields
-    db::mutate<VariablesTag>(make_not_null(&box),
-                             [&generator, &dist](const auto fields) {
-                               for (size_t i = 0; i < fields->size(); ++i) {
-                                 fields->data()[i] += dist(generator);
-                               }
-                             });
+    db::mutate<VariablesTag>(
+        [&generator, &dist](const auto fields) {
+          for (size_t i = 0; i < fields->size(); ++i) {
+            fields->data()[i] += dist(generator);
+          }
+        },
+        make_not_null(&box));
     return {Parallel::AlgorithmExecution::Continue, std::nullopt};
   }
 };

--- a/src/ParallelAlgorithms/Actions/SetData.hpp
+++ b/src/ParallelAlgorithms/Actions/SetData.hpp
@@ -41,10 +41,11 @@ struct SetData<tmpl::list<Tags...>> {
                     tuples::TaggedTuple<Tags...> data) {
     tmpl::for_each<tmpl::list<Tags...>>([&box, &data](auto tag_v) {
       using tag = tmpl::type_from<decltype(tag_v)>;
-      db::mutate<tag>(make_not_null(&box),
-                      [&data](const gsl::not_null<typename tag::type*> value) {
-                        *value = std::move(tuples::get<tag>(data));
-                      });
+      db::mutate<tag>(
+          [&data](const gsl::not_null<typename tag::type*> value) {
+            *value = std::move(tuples::get<tag>(data));
+          },
+          make_not_null(&box));
     });
   }
 };

--- a/src/ParallelAlgorithms/Amr/Actions/AdjustDomain.hpp
+++ b/src/ParallelAlgorithms/Amr/Actions/AdjustDomain.hpp
@@ -107,17 +107,16 @@ struct AdjustDomain {
                     flag == amr::Flag::DecreaseResolution);
           })) {
         db::mutate<::domain::Tags::Mesh<volume_dim>>(
-            make_not_null(&box),
             [&my_amr_flags](const gsl::not_null<Mesh<volume_dim>*> mesh) {
               *mesh = amr::projectors::mesh(*mesh, my_amr_flags);
-            });
+            },
+            make_not_null(&box));
       }
 
       // Need to reset AMR flags and determine new neighbors
       db::mutate<::domain::Tags::Element<volume_dim>,
                  amr::Tags::Flags<volume_dim>,
                  amr::Tags::NeighborFlags<volume_dim>>(
-          make_not_null(&box),
           [&element_id](
               const gsl::not_null<Element<volume_dim>*> element,
               const gsl::not_null<std::array<amr::Flag, volume_dim>*> amr_flags,
@@ -134,7 +133,8 @@ struct AdjustDomain {
             for (size_t d = 0; d < volume_dim; ++d) {
               (*amr_flags)[d] = amr::Flag::Undefined;
             }
-          });
+          },
+          make_not_null(&box));
     }
 
     // In the near future, add the capability of updating all data needed for

--- a/src/ParallelAlgorithms/Amr/Actions/EvaluateRefinementCriteria.hpp
+++ b/src/ParallelAlgorithms/Amr/Actions/EvaluateRefinementCriteria.hpp
@@ -121,11 +121,11 @@ struct EvaluateRefinementCriteria {
     }
 
     db::mutate<amr::Tags::Flags<Metavariables::volume_dim>>(
-        make_not_null(&box),
         [&overall_decision](
             const gsl::not_null<std::array<amr::Flag, volume_dim>*> amr_flags) {
           *amr_flags = overall_decision;
-        });
+        },
+        make_not_null(&box));
 
     auto& amr_element_array =
         Parallel::get_parallel_component<ParallelComponent>(cache);

--- a/src/ParallelAlgorithms/Initialization/MutateAssign.hpp
+++ b/src/ParallelAlgorithms/Initialization/MutateAssign.hpp
@@ -19,10 +19,12 @@ SPECTRE_ALWAYS_INLINE constexpr void mutate_assign_impl(
   static_assert(sizeof...(MutateTags) == sizeof...(args),
                 "The number of arguments passed to `mutate_assign` must be "
                 "equal to the number of tags passed.");
-  db::mutate<MutateTags...>(box, [&args...](const auto... box_args) {
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-    EXPAND_PACK_LEFT_TO_RIGHT((*box_args = std::forward<Args>(args)));
-  });
+  db::mutate<MutateTags...>(
+      [&args...](const auto... box_args) {
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+        EXPAND_PACK_LEFT_TO_RIGHT((*box_args = std::forward<Args>(args)));
+      },
+      box);
 }
 }  // namespace detail
 

--- a/src/ParallelAlgorithms/Interpolation/Actions/CleanUpInterpolator.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Actions/CleanUpInterpolator.hpp
@@ -69,7 +69,6 @@ struct CleanUpInterpolator {
       const typename InterpolationTargetTag::temporal_id::type& temporal_id) {
     // Signal that this InterpolationTarget is done at this time.
     db::mutate<Tags::InterpolatedVarsHolders<Metavariables>>(
-        make_not_null(&box),
         [&temporal_id](
             const gsl::not_null<
                 typename Tags::InterpolatedVarsHolders<Metavariables>::type*>
@@ -77,7 +76,8 @@ struct CleanUpInterpolator {
           get<Vars::HolderTag<InterpolationTargetTag, Metavariables>>(*holders)
               .temporal_ids_when_data_has_been_interpolated.push_back(
                   temporal_id);
-        });
+        },
+        make_not_null(&box));
 
     // If we don't need any of the volume data anymore for this
     // temporal_id, we will remove them.
@@ -119,19 +119,18 @@ struct CleanUpInterpolator {
     if (this_temporal_id_is_done) {
       db::mutate<Tags::VolumeVarsInfo<
           Metavariables, typename InterpolationTargetTag::temporal_id>>(
-          make_not_null(&box),
           [&temporal_id](
               const gsl::not_null<typename Tags::VolumeVarsInfo<
                   Metavariables,
                   typename InterpolationTargetTag::temporal_id>::type*>
-                  volume_vars_info) { volume_vars_info->erase(temporal_id); });
+                  volume_vars_info) { volume_vars_info->erase(temporal_id); },
+          make_not_null(&box));
 
       // Clean up temporal_ids_when_data_has_been_interpolated, if
       // it is too large.
       [[maybe_unused]] constexpr size_t finished_temporal_ids_max_size = 1000;
 
       db::mutate<Tags::InterpolatedVarsHolders<Metavariables>>(
-          make_not_null(&box),
           [](const gsl::not_null<
               typename Tags::InterpolatedVarsHolders<Metavariables>::type*>
                  holders_l) {
@@ -157,7 +156,8 @@ struct CleanUpInterpolator {
                     }
                   }
                 });
-          });
+          },
+          make_not_null(&box));
     }
   }
 };

--- a/src/ParallelAlgorithms/Interpolation/Actions/ElementReceiveInterpPoints.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Actions/ElementReceiveInterpPoints.hpp
@@ -40,14 +40,14 @@ struct ElementReceiveInterpPoints {
               typename InterpolationTargetTag::compute_target_points::frame>&&
           coords) {
     db::mutate<intrp::Tags::InterpPointInfo<Metavariables>>(
-        make_not_null(&box),
         [&coords](const gsl::not_null<
                   typename intrp::Tags::InterpPointInfo<Metavariables>::type*>
                       point_infos) {
           get<intrp::Vars::PointInfoTag<InterpolationTargetTag,
                                         Metavariables::volume_dim>>(
               *point_infos) = std::move(coords);
-        });
+        },
+        make_not_null(&box));
   }
 };
 }  // namespace Actions

--- a/src/ParallelAlgorithms/Interpolation/Actions/InterpolatorReceivePoints.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Actions/InterpolatorReceivePoints.hpp
@@ -71,7 +71,6 @@ struct ReceivePoints {
                  tnsr::I<double, VolumeDim, typename ::Frame::BlockLogical>>>>&&
           block_logical_coords) {
     db::mutate<intrp::Tags::InterpolatedVarsHolders<Metavariables>>(
-        make_not_null(&box),
         [&temporal_id, &block_logical_coords](
             const gsl::not_null<typename intrp::Tags::InterpolatedVarsHolders<
                 Metavariables>::type*>
@@ -87,7 +86,8 @@ struct ReceivePoints {
               intrp::Vars::Info<VolumeDim, typename InterpolationTargetTag::
                                                vars_to_interpolate_to_target>{
                   std::move(block_logical_coords)}));
-        });
+        },
+        make_not_null(&box));
 
     try_to_interpolate<InterpolationTargetTag>(
         make_not_null(&box), make_not_null(&cache), temporal_id);

--- a/src/ParallelAlgorithms/Interpolation/Actions/InterpolatorReceiveVolumeData.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Actions/InterpolatorReceiveVolumeData.hpp
@@ -121,7 +121,6 @@ struct InterpolatorReceiveVolumeData {
     // done only for this TemporalId type and not for any other
     // VolumeVarsInfos that might be in the DataBox.)
     db::mutate<Tags::VolumeVarsInfo<Metavariables, TemporalId>>(
-        make_not_null(&box),
         [&temporal_id, &element_id, &mesh, &interpolator_source_vars](
             const gsl::not_null<
                 typename Tags::VolumeVarsInfo<Metavariables, TemporalId>::type*>
@@ -139,7 +138,8 @@ struct InterpolatorReceiveVolumeData {
                   typename Tags::VolumeVarsInfo<Metavariables,
                                                 TemporalId>::Info{
                       mesh, std::move(interpolator_source_vars), {}}));
-        });
+        },
+        make_not_null(&box));
 
     // Try to interpolate data for all InterpolationTargets for this
     // temporal_id.

--- a/src/ParallelAlgorithms/Interpolation/Actions/InterpolatorRegisterElement.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Actions/InterpolatorRegisterElement.hpp
@@ -51,8 +51,8 @@ struct RegisterElement {
                     const Parallel::GlobalCache<Metavariables>& /*cache*/,
                     const ArrayIndex& /*array_index*/) {
     db::mutate<Tags::NumberOfElements>(
-        make_not_null(&box),
-        [](const gsl::not_null<size_t*> num_elements) { ++(*num_elements); });
+        [](const gsl::not_null<size_t*> num_elements) { ++(*num_elements); },
+        make_not_null(&box));
   }
 };
 
@@ -78,8 +78,8 @@ struct DeregisterElement {
                     const Parallel::GlobalCache<Metavariables>& /*cache*/,
                     const ArrayIndex& /*array_index*/) {
     db::mutate<Tags::NumberOfElements>(
-        make_not_null(&box),
-        [](const gsl::not_null<size_t*> num_elements) { --(*num_elements); });
+        [](const gsl::not_null<size_t*> num_elements) { --(*num_elements); },
+        make_not_null(&box));
   }
 };
 

--- a/src/ParallelAlgorithms/Interpolation/Actions/TryToInterpolate.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Actions/TryToInterpolate.hpp
@@ -193,7 +193,6 @@ void try_to_interpolate(
 
     // Clear interpolated data, since we don't need it anymore.
     db::mutate<Tags::InterpolatedVarsHolders<Metavariables>>(
-        box,
         [&temporal_id](
             const gsl::not_null<
                 typename Tags::InterpolatedVarsHolders<Metavariables>::type*>
@@ -201,7 +200,8 @@ void try_to_interpolate(
           get<Vars::HolderTag<InterpolationTargetTag, Metavariables>>(
               *holders_l)
               .infos.erase(temporal_id);
-        });
+        },
+        box);
   }
 }
 

--- a/src/ParallelAlgorithms/Interpolation/Targets/Sphere.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Targets/Sphere.hpp
@@ -169,11 +169,11 @@ struct Sphere : tt::ConformsTo<intrp::protocols::ComputeTargetPoints> {
           sphere.center);
 
       db::mutate<StrahlkorperTags::Strahlkorper<Frame>>(
-          box,
           [&strahlkorper](
               const gsl::not_null<::Strahlkorper<Frame>*> local_strahlkorper) {
             *local_strahlkorper = std::move(strahlkorper);
-          });
+          },
+          box);
 
       // This copy is ok because it's just in initialization
       auto coords = db::get<StrahlkorperTags::CartesianCoords<Frame>>(*box);

--- a/src/ParallelAlgorithms/LinearSolver/Actions/MakeIdentityIfSkipped.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Actions/MakeIdentityIfSkipped.hpp
@@ -99,9 +99,8 @@ struct MakeIdentityIfSkipped {
          has_converged.reason() == Convergence::Reason::MaxIterations) and
         has_converged.num_iterations() == 0) {
       db::mutate<typename LinearSolverType::fields_tag>(
-          make_not_null(&box),
           [](const auto fields, const auto& source) { *fields = source; },
-          get<typename LinearSolverType::source_tag>(box));
+          make_not_null(&box), get<typename LinearSolverType::source_tag>(box));
       return {Parallel::AlgorithmExecution::Continue, std::nullopt};
     }
     return {Parallel::AlgorithmExecution::Continue, proceed_action_index};

--- a/src/ParallelAlgorithms/LinearSolver/AsynchronousSolvers/ElementActions.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/AsynchronousSolvers/ElementActions.hpp
@@ -268,7 +268,6 @@ struct PrepareSolve {
 
     db::mutate<Convergence::Tags::IterationId<OptionsGroup>,
                Convergence::Tags::HasConverged<OptionsGroup>>(
-        make_not_null(&box),
         [](const gsl::not_null<size_t*> local_iteration_id,
            const gsl::not_null<Convergence::HasConverged*> has_converged,
            const size_t num_iterations) {
@@ -276,6 +275,7 @@ struct PrepareSolve {
           *has_converged =
               Convergence::HasConverged{num_iterations, iteration_id};
         },
+        make_not_null(&box),
         get<Convergence::Tags::Iterations<OptionsGroup>>(box));
 
     if constexpr (ObserveInitialResidual) {
@@ -359,7 +359,6 @@ struct CompleteStep {
     // Prepare for next iteration
     db::mutate<Convergence::Tags::IterationId<OptionsGroup>,
                Convergence::Tags::HasConverged<OptionsGroup>>(
-        make_not_null(&box),
         [](const gsl::not_null<size_t*> iteration_id,
            const gsl::not_null<Convergence::HasConverged*> has_converged,
            const size_t num_iterations) {
@@ -367,6 +366,7 @@ struct CompleteStep {
           *has_converged =
               Convergence::HasConverged{num_iterations, *iteration_id};
         },
+        make_not_null(&box),
         get<Convergence::Tags::Iterations<OptionsGroup>>(box));
 
     // Observe element-local residual magnitude

--- a/src/ParallelAlgorithms/LinearSolver/ConjugateGradient/ResidualMonitorActions.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/ConjugateGradient/ResidualMonitorActions.hpp
@@ -56,13 +56,13 @@ struct InitializeResidual {
     const double residual_magnitude = sqrt(residual_square);
 
     db::mutate<residual_square_tag, initial_residual_magnitude_tag>(
-        make_not_null(&box),
         [residual_square, residual_magnitude](
             const gsl::not_null<double*> local_residual_square,
             const gsl::not_null<double*> initial_residual_magnitude) {
           *local_residual_square = residual_square;
           *initial_residual_magnitude = residual_magnitude;
-        });
+        },
+        make_not_null(&box));
 
     LinearSolver::observe_detail::contribute_to_reduction_observer<
         OptionsGroup, ParallelComponent>(iteration_id, residual_magnitude,
@@ -136,10 +136,10 @@ struct UpdateResidual {
     const double res_ratio = residual_square / get<residual_square_tag>(box);
 
     db::mutate<residual_square_tag>(
-        make_not_null(&box),
         [residual_square](const gsl::not_null<double*> local_residual_square) {
           *local_residual_square = residual_square;
-        });
+        },
+        make_not_null(&box));
 
     // At this point, the iteration is complete. We proceed with observing,
     // logging and checking convergence before broadcasting back to the

--- a/src/ParallelAlgorithms/LinearSolver/Multigrid/Actions/RestrictFields.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Multigrid/Actions/RestrictFields.hpp
@@ -229,8 +229,8 @@ struct ReceiveFieldsFromFinerGrid<Dim, FieldsTags, OptionsGroup,
           }
           return '0';
         };
-    expand_pack(db::mutate<ReceiveTags>(
-        make_not_null(&box), assemble_children_data, ReceiveTags{})...);
+    expand_pack(db::mutate<ReceiveTags>(assemble_children_data,
+                                        make_not_null(&box), ReceiveTags{})...);
 
     return {Parallel::AlgorithmExecution::Continue, std::nullopt};
   }

--- a/src/ParallelAlgorithms/LinearSolver/Multigrid/ElementActions.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Multigrid/ElementActions.hpp
@@ -170,7 +170,6 @@ struct PreparePreSmoothing {
     // the fields directly, so there's nothing to prepare.
     if (element_id.grid_index() > 0) {
       db::mutate<fields_tag, operator_applied_to_fields_tag>(
-          make_not_null(&box),
           [](const auto fields, const auto operator_applied_to_fields,
              const auto& source) {
             *fields = make_with_value<typename fields_tag::type>(source, 0.);
@@ -180,13 +179,12 @@ struct PreparePreSmoothing {
                 make_with_value<typename operator_applied_to_fields_tag::type>(
                     source, 0.);
           },
-          db::get<source_tag>(box));
+          make_not_null(&box), db::get<source_tag>(box));
     }
 
     // Record pre-smoothing initial fields and source
     if (db::get<Tags::OutputVolumeData<OptionsGroup>>(box)) {
       db::mutate<Tags::VolumeDataForOutput<OptionsGroup, FieldsTag>>(
-          make_not_null(&box),
           [](const auto volume_data, const auto& initial_fields,
              const auto& source) {
             volume_data->assign_subset(
@@ -198,7 +196,8 @@ struct PreparePreSmoothing {
                                            typename fields_tag::tags_list>>(
                     source));
           },
-          db::get<fields_tag>(box), db::get<source_tag>(box));
+          make_not_null(&box), db::get<fields_tag>(box),
+          db::get<source_tag>(box));
     }
 
     // Skip pre-smoothing, if requested
@@ -244,7 +243,6 @@ struct SkipPostSmoothingAtBottom {
     // Record pre-smoothing result fields and residual
     if (db::get<Tags::OutputVolumeData<OptionsGroup>>(box)) {
       db::mutate<Tags::VolumeDataForOutput<OptionsGroup, FieldsTag>>(
-          make_not_null(&box),
           [](const auto volume_data, const auto& result_fields,
              const auto& residuals) {
             volume_data->assign_subset(
@@ -256,7 +254,8 @@ struct SkipPostSmoothingAtBottom {
                                            typename fields_tag::tags_list>>(
                     residuals));
           },
-          db::get<fields_tag>(box), db::get<residual_tag>(box));
+          make_not_null(&box), db::get<fields_tag>(box),
+          db::get<residual_tag>(box));
     }
 
     // Skip post-smoothing on the coarsest grid, if requested
@@ -312,7 +311,6 @@ struct SendCorrectionToFinerGrid {
     // Record post-smoothing result fields and residual
     if (db::get<Tags::OutputVolumeData<OptionsGroup>>(box)) {
       db::mutate<Tags::VolumeDataForOutput<OptionsGroup, FieldsTag>>(
-          make_not_null(&box),
           [](const auto volume_data, const auto& result_fields,
              const auto& residuals) {
             volume_data->assign_subset(
@@ -324,7 +322,8 @@ struct SendCorrectionToFinerGrid {
                                            typename fields_tag::tags_list>>(
                     residuals));
           },
-          db::get<fields_tag>(box), db::get<residual_tag>(box));
+          make_not_null(&box), db::get<fields_tag>(box),
+          db::get<residual_tag>(box));
     }
 
     if (child_ids.empty()) {
@@ -416,15 +415,15 @@ struct ReceiveCorrectionFromCoarserGrid {
         }();
 
     // Add correction to the solution on this grid
-    db::mutate<fields_tag>(make_not_null(&box),
-                           [&prolongated_parent_correction](const auto fields) {
-                             *fields += prolongated_parent_correction;
-                           });
+    db::mutate<fields_tag>(
+        [&prolongated_parent_correction](const auto fields) {
+          *fields += prolongated_parent_correction;
+        },
+        make_not_null(&box));
 
     // Record post-smoothing initial fields and source
     if (db::get<Tags::OutputVolumeData<OptionsGroup>>(box)) {
       db::mutate<Tags::VolumeDataForOutput<OptionsGroup, FieldsTag>>(
-          make_not_null(&box),
           [](const auto volume_data, const auto& initial_fields,
              const auto& source) {
             volume_data->assign_subset(
@@ -436,7 +435,8 @@ struct ReceiveCorrectionFromCoarserGrid {
                                            typename fields_tag::tags_list>>(
                     source));
           },
-          db::get<fields_tag>(box), db::get<source_tag>(box));
+          make_not_null(&box), db::get<fields_tag>(box),
+          db::get<source_tag>(box));
     }
 
     return {Parallel::AlgorithmExecution::Continue, std::nullopt};

--- a/src/ParallelAlgorithms/LinearSolver/Multigrid/ObserveVolumeData.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Multigrid/ObserveVolumeData.hpp
@@ -116,8 +116,8 @@ struct ObserveVolumeData {
 
     // Increment observation ID
     db::mutate<Tags::ObservationId<OptionsGroup>>(
-        make_not_null(&box),
-        [](const auto local_observation_id) { ++(*local_observation_id); });
+        [](const auto local_observation_id) { ++(*local_observation_id); },
+        make_not_null(&box));
     return {Parallel::AlgorithmExecution::Continue, std::nullopt};
   }
 };

--- a/src/ParallelAlgorithms/LinearSolver/Richardson/Richardson.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Richardson/Richardson.hpp
@@ -57,12 +57,11 @@ struct UpdateFields {
       const ParallelComponent* const /*meta*/) {
     // Update the solution fields according to the Richardson scheme
     db::mutate<FieldsTag>(
-        make_not_null(&box),
         [](const auto fields, const auto& residual,
            const double relaxation_parameter) {
           *fields += relaxation_parameter * residual;
         },
-        get<residual_tag>(box),
+        make_not_null(&box), get<residual_tag>(box),
         get<Tags::RelaxationParameter<OptionsGroup>>(box));
     return {Parallel::AlgorithmExecution::Continue, std::nullopt};
   }

--- a/src/ParallelAlgorithms/LinearSolver/Schwarz/Actions/CommunicateOverlapFields.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Schwarz/Actions/CommunicateOverlapFields.hpp
@@ -225,7 +225,6 @@ struct ReceiveOverlapFields<Dim, tmpl::list<OverlapFields...>, OptionsGroup> {
                       .extract(iteration_id)
                       .mapped());
     db::mutate<Tags::Overlaps<OverlapFields, Dim, OptionsGroup>...>(
-        make_not_null(&box),
         [&received_overlap_fields](const auto... local_overlap_fields) {
           if constexpr (sizeof...(OverlapFields) > 1) {
             for (auto& [overlap_id, overlap_fields] : received_overlap_fields) {
@@ -236,7 +235,8 @@ struct ReceiveOverlapFields<Dim, tmpl::list<OverlapFields...>, OptionsGroup> {
             expand_pack((*local_overlap_fields =
                              std::move(received_overlap_fields))...);
           }
-        });
+        },
+        make_not_null(&box));
 
     return {Parallel::AlgorithmExecution::Continue, std::nullopt};
   }

--- a/src/ParallelAlgorithms/LinearSolver/Schwarz/Actions/ResetSubdomainSolver.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Schwarz/Actions/ResetSubdomainSolver.hpp
@@ -79,7 +79,7 @@ struct ResetSubdomainSolver {
       }
       db::mutate<
           LinearSolver::Schwarz::Tags::SubdomainSolverBase<OptionsGroup>>(
-          make_not_null(&box), [](const auto subdomain_solver) {
+          [](const auto subdomain_solver) {
             // Dereference the gsl::not_null pointer, and then the
             // std::unique_ptr for the subdomain solver's abstract superclass.
             // This needs adjustment if the subdomain solver is stored in the
@@ -88,7 +88,8 @@ struct ResetSubdomainSolver {
             // function, which must not be confused with the serial linear
             // solver's `reset` function here.
             (*subdomain_solver)->reset();
-          });
+          },
+          make_not_null(&box));
     }
     return {Parallel::AlgorithmExecution::Continue, std::nullopt};
   }

--- a/src/ParallelAlgorithms/LinearSolver/Schwarz/ElementActions.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Schwarz/ElementActions.hpp
@@ -357,7 +357,6 @@ struct SolveSubdomain {
     // Assemble the subdomain data from the data on the element and the
     // communicated overlap data
     db::mutate<SubdomainDataBufferTag<SubdomainData, OptionsGroup>>(
-        make_not_null(&box),
         [&inboxes, &iteration_id, &has_overlap_data](
             const gsl::not_null<SubdomainData*> subdomain_data,
             const auto& residual) {
@@ -370,7 +369,7 @@ struct SolveSubdomain {
                               .mapped());
           }
         },
-        db::get<residual_tag>(box));
+        make_not_null(&box), db::get<residual_tag>(box));
     const auto& subdomain_residual =
         db::get<SubdomainDataBufferTag<SubdomainData, OptionsGroup>>(box);
 
@@ -430,10 +429,11 @@ struct SolveSubdomain {
     }
 
     // Apply solution to central element
-    db::mutate<fields_tag>(make_not_null(&box),
-                           [&subdomain_solution](const auto fields) {
-                             *fields += subdomain_solution.element_data;
-                           });
+    db::mutate<fields_tag>(
+        [&subdomain_solution](const auto fields) {
+          *fields += subdomain_solution.element_data;
+        },
+        make_not_null(&box));
 
     // Send overlap solutions back to the neighbors that they are on
     if (LIKELY(max_overlap > 0)) {
@@ -512,7 +512,6 @@ struct ReceiveOverlapSolution {
                       .extract(iteration_id)
                       .mapped());
     db::mutate<fields_tag>(
-        make_not_null(&box),
         [&received_overlap_solutions](
             const auto fields, const Index<Dim>& full_extents,
             const std::array<size_t, Dim>& all_intruding_extents,
@@ -530,7 +529,7 @@ struct ReceiveOverlapSolution {
                 intruding_extents, direction);
           }
         },
-        db::get<domain::Tags::Mesh<Dim>>(box).extents(),
+        make_not_null(&box), db::get<domain::Tags::Mesh<Dim>>(box).extents(),
         db::get<Tags::IntrudingExtents<Dim, OptionsGroup>>(box),
         db::get<domain::Tags::Faces<Dim, Tags::Weight<OptionsGroup>>>(box));
     return {Parallel::AlgorithmExecution::Continue, std::nullopt};

--- a/src/ParallelAlgorithms/NonlinearSolver/NewtonRaphson/ResidualMonitorActions.hpp
+++ b/src/ParallelAlgorithms/NonlinearSolver/NewtonRaphson/ResidualMonitorActions.hpp
@@ -60,11 +60,11 @@ struct CheckResidualMagnitude {
 
     if (UNLIKELY(iteration_id == 0)) {
       db::mutate<initial_residual_magnitude_tag>(
-          make_not_null(&box),
           [residual_magnitude](
               const gsl::not_null<double*> initial_residual_magnitude) {
             *initial_residual_magnitude = residual_magnitude;
-          });
+          },
+          make_not_null(&box));
     } else {
       // Make sure we are converging. Far away from the solution the correction
       // determined by the linear solve might be bad, so we employ a
@@ -107,14 +107,14 @@ struct CheckResidualMagnitude {
               0.1 * step_length, 0.5 * step_length);
           db::mutate<NonlinearSolver::Tags::StepLength<OptionsGroup>,
                      prev_residual_magnitude_square_tag>(
-              make_not_null(&box),
               [step_length, next_residual_magnitude_square](
                   const gsl::not_null<double*> prev_step_length,
                   const gsl::not_null<double*> prev_residual_magnitude_square) {
                 *prev_step_length = step_length;
                 *prev_residual_magnitude_square =
                     next_residual_magnitude_square;
-              });
+              },
+              make_not_null(&box));
           // Do some logging
           if (UNLIKELY(get<logging::Tags::Verbosity<OptionsGroup>>(box) >=
                        ::Verbosity::Verbose)) {
@@ -152,11 +152,11 @@ struct CheckResidualMagnitude {
     }      // initial iteration
 
     db::mutate<residual_magnitude_square_tag>(
-        make_not_null(&box),
         [next_residual_magnitude_square](
             const gsl::not_null<double*> local_residual_magnitude_square) {
           *local_residual_magnitude_square = next_residual_magnitude_square;
-        });
+        },
+        make_not_null(&box));
 
     // At this point, the iteration is complete. We proceed with logging and
     // checking convergence before broadcasting back to the elements.

--- a/src/Time/Actions/AdvanceTime.hpp
+++ b/src/Time/Actions/AdvanceTime.hpp
@@ -72,7 +72,6 @@ struct AdvanceTime {
     db::mutate<Tags::TimeStepId, Tags::Next<Tags::TimeStepId>, Tags::TimeStep,
                Tags::Time, Tags::Next<Tags::TimeStep>,
                Tags::AdaptiveSteppingDiagnostics>(
-        make_not_null(&box),
         [](const gsl::not_null<TimeStepId*> time_id,
            const gsl::not_null<TimeStepId*> next_time_id,
            const gsl::not_null<TimeDelta*> time_step,
@@ -107,7 +106,8 @@ struct AdvanceTime {
               time_step->with_slab(next_time_id->step_time().slab());
           *time = time_id->substep_time();
         },
-        db::get<Tags::TimeStepper<>>(box), is_using_error_control);
+        make_not_null(&box), db::get<Tags::TimeStepper<>>(box),
+        is_using_error_control);
 
     return {Parallel::AlgorithmExecution::Continue, std::nullopt};
   }

--- a/src/Time/Actions/ChangeSlabSize.hpp
+++ b/src/Time/Actions/ChangeSlabSize.hpp
@@ -196,7 +196,6 @@ struct ChangeSlabSize {
     db::mutate<::Tags::Next<::Tags::TimeStepId>, ::Tags::TimeStep,
                ::Tags::Next<::Tags::TimeStep>, ::Tags::TimeStepId,
                ::Tags::AdaptiveSteppingDiagnostics>(
-        make_not_null(&box),
         [&new_next_time_step_id, &new_step, &new_time_step_id](
             const gsl::not_null<TimeStepId*> next_time_step_id,
             const gsl::not_null<TimeDelta*> time_step,
@@ -208,7 +207,8 @@ struct ChangeSlabSize {
           *next_time_step = new_step;
           *local_time_step_id = new_time_step_id;
           ++diags->number_of_slab_size_changes;
-        });
+        },
+        make_not_null(&box));
 
     return {Parallel::AlgorithmExecution::Continue, std::nullopt};
   }

--- a/src/Time/Actions/RecordTimeStepperData.hpp
+++ b/src/Time/Actions/RecordTimeStepperData.hpp
@@ -31,14 +31,13 @@ void record_one_variables(const gsl::not_null<db::DataBox<DbTags>*> box) {
   using history_tag = Tags::HistoryEvolvedVariables<VariablesTag>;
 
   db::mutate<history_tag>(
-      box,
       [](const gsl::not_null<typename history_tag::type*> history,
          const TimeStepId& time_step_id,
          const typename VariablesTag::type& vars,
          const typename dt_variables_tag::type& dt_vars) {
         history->insert(time_step_id, vars, dt_vars);
       },
-      db::get<Tags::TimeStepId>(*box), db::get<VariablesTag>(*box),
+      box, db::get<Tags::TimeStepId>(*box), db::get<VariablesTag>(*box),
       db::get<dt_variables_tag>(*box));
 }
 }  // namespace record_time_stepper_data_detail

--- a/src/Time/Actions/SelfStartActions.hpp
+++ b/src/Time/Actions/SelfStartActions.hpp
@@ -232,12 +232,12 @@ struct Initialize {
         tmpl::push_back<detail::vars_to_save<System>, ::Tags::TimeStep,
                         ::Tags::Next<::Tags::TimeStep>>>::apply(box);
     db::mutate<::Tags::TimeStep, ::Tags::Next<::Tags::TimeStep>>(
-        make_not_null(&box),
         [&self_start_step](const gsl::not_null<::TimeDelta*> time_step,
                            const gsl::not_null<::TimeDelta*> next_time_step) {
           *time_step = self_start_step;
           *next_time_step = self_start_step;
-        });
+        },
+        make_not_null(&box));
 
     return {Parallel::AlgorithmExecution::Continue, std::nullopt};
   }
@@ -275,12 +275,11 @@ struct CheckForCompletion {
       tmpl::for_each<detail::vars_to_save<System>>([&box](auto tag) {
         using Tag = tmpl::type_from<decltype(tag)>;
         db::mutate<Tag>(
-            make_not_null(&box),
             [](const gsl::not_null<typename Tag::type*> value,
                const std::tuple<typename Tag::type>& initial_value) {
               *value = get<0>(initial_value);
             },
-            db::get<Tags::InitialValue<Tag>>(box));
+            make_not_null(&box), db::get<Tags::InitialValue<Tag>>(box));
       });
     }
 
@@ -343,7 +342,6 @@ struct CheckForOrderIncrease {
 
     if (done_with_order) {
       db::mutate<::Tags::Next<::Tags::TimeStepId>>(
-          make_not_null(&box),
           [](const gsl::not_null<::TimeStepId*> next_time_id,
              const ::TimeStepId& current_time_id) {
             const Slab slab = current_time_id.step_time().slab();
@@ -353,12 +351,11 @@ struct CheckForOrderIncrease {
                            current_time_id.time_runs_forward() ? slab.start()
                                                                : slab.end());
           },
-          db::get<::Tags::TimeStepId>(box));
+          make_not_null(&box), db::get<::Tags::TimeStepId>(box));
       tmpl::for_each<history_tags>([&box,
                                     &history_integration_order](auto tag_v) {
         using history_tag = typename decltype(tag_v)::type;
         db::mutate<history_tag>(
-            make_not_null(&box),
             [&history_integration_order](
                 const gsl::not_null<typename history_tag::type*>
                     mutable_history) {
@@ -382,7 +379,8 @@ struct CheckForOrderIncrease {
               for (const auto& record : *mutable_history) {
                 mutable_history->discard_value(record.time_step_id);
               }
-            });
+            },
+            make_not_null(&box));
       });
     }
     return {Parallel::AlgorithmExecution::Continue, std::nullopt};
@@ -425,7 +423,6 @@ struct Cleanup {
     // Reset the time step to the value requested by the user.  The
     // variables were reset in CheckForCompletion.
     db::mutate<::Tags::TimeStep, ::Tags::Next<::Tags::TimeStep>>(
-        make_not_null(&box),
         [](const gsl::not_null<::TimeDelta*> time_step,
            const gsl::not_null<::TimeDelta*> next_time_step,
            const std::tuple<::TimeDelta>& initial_step,
@@ -433,7 +430,7 @@ struct Cleanup {
           *time_step = get<0>(initial_step);
           *next_time_step = get<0>(initial_next_step);
         },
-        db::get<initial_step_tag>(box),
+        make_not_null(&box), db::get<initial_step_tag>(box),
         db::get<Tags::InitialValue<::Tags::Next<::Tags::TimeStep>>>(box));
     using remove_tags = tmpl::filter<DbTags, is_a_initial_value<tmpl::_1>>;
     // reset each tag to default constructed values to reduce memory usage (Data
@@ -442,9 +439,11 @@ struct Cleanup {
     // constructing more DataBox types with and without this handful of tags.
     tmpl::for_each<remove_tags>([&box](auto tag_v) {
       using tag = typename decltype(tag_v)::type;
-      db::mutate<tag>(make_not_null(&box), [](auto tag_value) {
-        *tag_value = std::decay_t<decltype(*tag_value)>{};
-      });
+      db::mutate<tag>(
+          [](auto tag_value) {
+            *tag_value = std::decay_t<decltype(*tag_value)>{};
+          },
+          make_not_null(&box));
     });
     using history_tags = ::Tags::get_all_history_tags<DbTags>;
     tmpl::for_each<history_tags>([&box](auto tag_v) {

--- a/src/Time/Actions/UpdateU.hpp
+++ b/src/Time/Actions/UpdateU.hpp
@@ -46,7 +46,6 @@ void update_one_variables(const gsl::not_null<db::DataBox<DbTags>*> box) {
     if constexpr (tmpl::list_contains_v<DbTags, error_tag>) {
       db::mutate<Tags::StepperErrorUpdated, VariablesTag, error_tag,
                  previous_error_tag, history_tag>(
-          box,
           [](const gsl::not_null<bool*> stepper_error_updated,
              const gsl::not_null<typename VariablesTag::type*> vars,
              const gsl::not_null<typename error_tag::type*> error,
@@ -71,7 +70,8 @@ void update_one_variables(const gsl::not_null<db::DataBox<DbTags>*> box) {
               swap(*error, *previous_error);
             }
           },
-          db::get<Tags::TimeStep>(*box), db::get<Tags::TimeStepper<>>(*box));
+          box, db::get<Tags::TimeStep>(*box),
+          db::get<Tags::TimeStepper<>>(*box));
     } else {
       ERROR(
           "Cannot update the stepper error measure -- "
@@ -79,13 +79,12 @@ void update_one_variables(const gsl::not_null<db::DataBox<DbTags>*> box) {
     }
   } else {
     db::mutate<VariablesTag, history_tag>(
-        box,
         [](const gsl::not_null<typename VariablesTag::type*> vars,
            const gsl::not_null<typename history_tag::type*> history,
            const ::TimeDelta& time_step, const auto& time_stepper) {
           time_stepper.update_u(vars, history, time_step);
         },
-        db::get<Tags::TimeStep>(*box), db::get<Tags::TimeStepper<>>(*box));
+        box, db::get<Tags::TimeStep>(*box), db::get<Tags::TimeStepper<>>(*box));
   }
 }
 }  // namespace update_u_detail

--- a/src/Time/TakeStep.hpp
+++ b/src/Time/TakeStep.hpp
@@ -40,13 +40,14 @@ void take_step(const gsl::not_null<db::DataBox<DbTags>*> box) {
       update_u<System>(box);
     } while (not change_step_size<StepChoosersToUse>(box));
     db::mutate<Tags::AdaptiveSteppingDiagnostics>(
-        box, [&](const gsl::not_null<AdaptiveSteppingDiagnostics*> diags,
-                 const TimeDelta& new_step) {
+        [&](const gsl::not_null<AdaptiveSteppingDiagnostics*> diags,
+            const TimeDelta& new_step) {
           diags->number_of_step_rejections += step_attempts - 1;
           if (original_step != new_step) {
             ++diags->number_of_step_fraction_changes;
           }
-        }, db::get<Tags::TimeStep>(*box));
+        },
+        box, db::get<Tags::TimeStep>(*box));
   } else {
     update_u<System>(box);
   }

--- a/tests/Unit/ApparentHorizons/Test_ObserveCenters.cpp
+++ b/tests/Unit/ApparentHorizons/Test_ObserveCenters.cpp
@@ -78,7 +78,6 @@ void test() {
     db::mutate<StrahlkorperTags::Strahlkorper<Frame>,
                StrahlkorperTags::CartesianCoords<::Frame::Inertial>,
                StrahlkorperTags::EuclideanAreaElement<Frame>>(
-        make_not_null(&box),
         [&grid_center, &inertial_center](
             gsl::not_null<Strahlkorper<Frame>*> box_grid_horizon,
             gsl::not_null<tnsr::I<DataVector, 3, ::Frame::Inertial>*>
@@ -108,7 +107,8 @@ void test() {
                                           gsl::at(inertial_center, i) -
                                           gsl::at(grid_center, i);
           }
-        });
+        },
+        make_not_null(&box));
   };
 
   // times to write

--- a/tests/Unit/ControlSystem/Test_Trigger.cpp
+++ b/tests/Unit/ControlSystem/Test_Trigger.cpp
@@ -105,8 +105,8 @@ void test_trigger_no_replace() {
 
   const auto set_time = [&box](const double time) {
     db::mutate<Tags::Time>(
-        make_not_null(&box),
-        [&time](const gsl::not_null<double*> box_time) { *box_time = time; });
+        [&time](const gsl::not_null<double*> box_time) { *box_time = time; },
+        make_not_null(&box));
   };
 
   MeasureTrigger typed_trigger = serialize_and_deserialize(MeasureTrigger{});

--- a/tests/Unit/DataStructures/DataBox/Test_BaseTags.cpp
+++ b/tests/Unit/DataStructures/DataBox/Test_BaseTags.cpp
@@ -92,7 +92,7 @@ void test_non_subitems() {
 
   // Check mutating Vector<0> using VectorBase<0>
   db::mutate<TestTags::VectorBase<0>>(
-      make_not_null(&box), [](const auto vector) { (*vector)[0] = 101.8; });
+      [](const auto vector) { (*vector)[0] = 101.8; }, make_not_null(&box));
 
   CHECK(db::get<TestTags::VectorBase<0>>(box) ==
         std::vector<double>{101.8, 10.0});
@@ -133,7 +133,7 @@ void test_non_subitems() {
   CHECK(db::get<TestTags::ArrayBase<1>>(box4) ==
         std::array<int, 4>{{2, 101, -7, 103}});
   db::mutate<TestTags::VectorBase<2>>(
-      make_not_null(&box4), [](const auto vector) { (*vector)[0] = 408.8; });
+      [](const auto vector) { (*vector)[0] = 408.8; }, make_not_null(&box4));
   CHECK(db::get<TestTags::ArrayBase<1>>(box4) ==
         std::array<int, 4>{{2, 101, -7, 408}});
 }
@@ -317,8 +317,8 @@ void test_subitems_tags() {
 
   // - `mutate`ing a subitem by a base tag
   db::mutate<TestTags::FirstBase<0>>(
-      make_not_null(&box),
-      [](const gsl::not_null<TestTags::Boxed<int>*> first) { **first = -3; });
+      [](const gsl::not_null<TestTags::Boxed<int>*> first) { **first = -3; },
+      make_not_null(&box));
   CHECK(*db::get<TestTags::FirstBase<0>>(box) == -3);
   CHECK(*db::get<TestTags::SecondBase<0>>(box) == 3.5);
   CHECK(db::get<TestTags::ParentBase<0>>(box) ==
@@ -347,14 +347,14 @@ void test_subitems_tags() {
               TestTags::Boxed<double>(std::make_shared<double>(9.5))));
   CHECK(db::get<TestTags::MultiplyByTwoBase<0, 2>>(box3) == -3 * 9.5);
   db::mutate<TestTags::FirstBase<0>>(
-      make_not_null(&box3),
-      [](const gsl::not_null<TestTags::Boxed<int>*> first) { **first = 4; });
+      [](const gsl::not_null<TestTags::Boxed<int>*> first) { **first = 4; },
+      make_not_null(&box3));
   CHECK(db::get<TestTags::MultiplyByTwoBase<0, 2>>(box3) == 4 * 9.5);
   db::mutate<TestTags::ParentBase<0>>(
-      make_not_null(&box3),
       [](const gsl::not_null<
           std::pair<TestTags::Boxed<int>, TestTags::Boxed<double>>*>
-             parent0) { *parent0->first = 8; });
+             parent0) { *parent0->first = 8; },
+      make_not_null(&box3));
   CHECK(db::get<TestTags::MultiplyByTwoBase<0, 2>>(box3) == 8 * 9.5);
 }
 }  // namespace

--- a/tests/Unit/Domain/Tags/Test_Faces.cpp
+++ b/tests/Unit/Domain/Tags/Test_Faces.cpp
@@ -60,20 +60,20 @@ SPECTRE_TEST_CASE("Unit.Domain.Tags.Faces", "[Unit][Domain]") {
     auto box = db::create<db::AddSimpleTags<vars_on_faces_tag>>(
         DirectionMap<Dim, Vars>{});
     CHECK(db::get<scalar_on_faces_tag>(box).empty());
-    db::mutate<
-        vars_on_faces_tag>(make_not_null(&box), [](const gsl::not_null<
-                                                    DirectionMap<Dim, Vars>*>
-                                                       vars_on_faces) {
-      vars_on_faces->emplace(Direction<Dim>::lower_xi(), Vars{size_t{3}, 0.});
-    });
+    db::mutate<vars_on_faces_tag>(
+        [](const gsl::not_null<DirectionMap<Dim, Vars>*> vars_on_faces) {
+          vars_on_faces->emplace(Direction<Dim>::lower_xi(),
+                                 Vars{size_t{3}, 0.});
+        },
+        make_not_null(&box));
     CHECK(db::get<scalar_on_faces_tag>(box).at(Direction<Dim>::lower_xi()) ==
           Scalar<DataVector>{size_t{3}, 0.});
     db::mutate<scalar_on_faces_tag>(
-        make_not_null(&box),
         [](const gsl::not_null<DirectionMap<Dim, Scalar<DataVector>>*>
                scalar_on_faces) {
           get(scalar_on_faces->at(Direction<Dim>::lower_xi())) = 1.;
-        });
+        },
+        make_not_null(&box));
     CHECK(db::get<vars_on_faces_tag>(box).at(Direction<Dim>::lower_xi()) ==
           Vars{size_t{3}, 1.});
   }

--- a/tests/Unit/Domain/Test_InterfaceItems.cpp
+++ b/tests/Unit/Domain/Test_InterfaceItems.cpp
@@ -471,9 +471,10 @@ void test_interface_subitems() {
       "Interface<Dirs, Var>");
 
   db::mutate<Tags::Interface<Dirs, Var<0>>>(
-      make_not_null(&box), [](const auto boundary_tensor) {
+      [](const auto boundary_tensor) {
         get(boundary_tensor->at(Direction<dim>::lower_xi())) *= 3.;
-      });
+      },
+      make_not_null(&box));
   CHECK((db::get<Tags::Interface<Dirs, Var<0>>>(box)) ==
         make_interface_tensor(3. * boundary_vars_xi, boundary_vars_eta));
 }

--- a/tests/Unit/Domain/Test_SizeOfElement.cpp
+++ b/tests/Unit/Domain/Test_SizeOfElement.cpp
@@ -209,8 +209,8 @@ void test_compute_tag(const std::array<double, 4>& times_to_check) {
 
   for (const double time : times_to_check) {
     db::mutate<::Tags::Time>(
-        make_not_null(&box),
-        [time](const gsl::not_null<double*> time_ptr) { *time_ptr = time; });
+        [time](const gsl::not_null<double*> time_ptr) { *time_ptr = time; },
+        make_not_null(&box));
     const auto expected_size_of_element = make_array(0.05, 0.425) * time;
     CHECK_ITERABLE_APPROX(db::get<domain::Tags::SizeOfElement<2>>(box),
                           expected_size_of_element);

--- a/tests/Unit/Domain/Test_TagsTimeDependent.cpp
+++ b/tests/Unit/Domain/Test_TagsTimeDependent.cpp
@@ -332,8 +332,8 @@ void test() {
   check_helper(3.0);
 
   db::mutate<Tags::Time>(
-      make_not_null(&box),
-      [](const gsl::not_null<double*> local_time) { *local_time = 4.5; });
+      [](const gsl::not_null<double*> local_time) { *local_time = 4.5; },
+      make_not_null(&box));
   check_helper(4.5);
 }
 

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/SubdomainOperator/Test_SubdomainOperator.cpp
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/SubdomainOperator/Test_SubdomainOperator.cpp
@@ -151,7 +151,6 @@ struct InitializeRandomSubdomainData {
     using SubdomainData = typename SubdomainDataTag<Dim, Fields>::type;
 
     db::mutate<SubdomainDataTag<Dim, Fields>>(
-        make_not_null(&box),
         [](const auto subdomain_data, const auto& mesh, const auto& element,
            const auto& all_overlap_meshes, const auto& all_overlap_extents) {
           MAKE_GENERATOR(gen);
@@ -178,7 +177,7 @@ struct InitializeRandomSubdomainData {
             }
           }
         },
-        db::get<domain::Tags::Mesh<Dim>>(box),
+        make_not_null(&box), db::get<domain::Tags::Mesh<Dim>>(box),
         db::get<domain::Tags::Element<Dim>>(box),
         db::get<LinearSolver::Schwarz::Tags::Overlaps<domain::Tags::Mesh<Dim>,
                                                       Dim, DummyOptionsGroup>>(
@@ -295,10 +294,10 @@ struct ApplySubdomainOperator {
 
     // Store result in the DataBox for checks
     db::mutate<SubdomainOperatorAppliedToDataTag<Dim, Fields>>(
-        make_not_null(&box),
         [&subdomain_result](const auto subdomain_operator_applied_to_data) {
           *subdomain_operator_applied_to_data = std::move(subdomain_result);
-        });
+        },
+        make_not_null(&box));
     return {Parallel::AlgorithmExecution::Continue, std::nullopt};
   }
 };

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_DgOperator.cpp
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_DgOperator.cpp
@@ -86,8 +86,8 @@ struct IncrementTemporalId {
       const Parallel::GlobalCache<Metavariables>& /*cache*/,
       const ArrayIndex& /*array_index*/, const ActionList /*meta*/,
       const ParallelComponent* const /*meta*/) {
-    db::mutate<TemporalIdTag>(make_not_null(&box),
-                              [](const auto temporal_id) { (*temporal_id)++; });
+    db::mutate<TemporalIdTag>([](const auto temporal_id) { (*temporal_id)++; },
+                              make_not_null(&box));
     return {Parallel::AlgorithmExecution::Continue, std::nullopt};
   }
 };

--- a/tests/Unit/Elliptic/Triggers/Test_EveryNIterations.cpp
+++ b/tests/Unit/Elliptic/Triggers/Test_EveryNIterations.cpp
@@ -58,7 +58,7 @@ SPECTRE_TEST_CASE("Unit.Elliptic.Triggers.EveryNIterations",
        {false, false, false, false, false, true, false, false, true, false}) {
     CHECK(sent_trigger->is_triggered(box) == expected);
     db::mutate<Convergence::Tags::IterationId<OptionsGroup>>(
-        make_not_null(&box),
-        [](const gsl::not_null<size_t*> iteration_id) { (*iteration_id)++; });
+        [](const gsl::not_null<size_t*> iteration_id) { (*iteration_id)++; },
+        make_not_null(&box));
   }
 }

--- a/tests/Unit/Elliptic/Triggers/Test_HasConverged.cpp
+++ b/tests/Unit/Elliptic/Triggers/Test_HasConverged.cpp
@@ -48,9 +48,9 @@ SPECTRE_TEST_CASE("Unit.Elliptic.Triggers.HasConverged", "[Unit][Elliptic]") {
       Metavariables{}, Convergence::HasConverged{});
   CHECK_FALSE(trigger.is_triggered(box));
   db::mutate<Convergence::Tags::HasConverged<OptionsGroup>>(
-      make_not_null(&box),
       [](const gsl::not_null<Convergence::HasConverged*> has_converged) {
         *has_converged = Convergence::HasConverged{0, 0};
-      });
+      },
+      make_not_null(&box));
   CHECK(trigger.is_triggered(box));
 }

--- a/tests/Unit/Evolution/Actions/Test_RunEventsAndDenseTriggers.cpp
+++ b/tests/Unit/Evolution/Actions/Test_RunEventsAndDenseTriggers.cpp
@@ -384,9 +384,10 @@ void test(const bool time_runs_forward) {
       auto& box =
           ActionTesting::get_databox<component>(make_not_null(&runner), 0);
       db::mutate<Tags::TimeStepId>(
-          make_not_null(&box), [](const gsl::not_null<TimeStepId*> id) {
+          [](const gsl::not_null<TimeStepId*> id) {
             *id = TimeStepId(id->time_runs_forward(), -1, id->step_time());
-          });
+          },
+          make_not_null(&box));
     }
     CHECK(run_if_ready(make_not_null(&runner)));
     TestEvent::check_calls({});
@@ -483,7 +484,6 @@ void test(const bool time_runs_forward) {
       auto& box =
           ActionTesting::get_databox<component>(make_not_null(&runner), 0);
       db::mutate<Tags::HistoryEvolvedVariables<variables_tag>>(
-          make_not_null(&box),
           [&deriv_vars, &initial_vars, &time_step_id](
               const gsl::not_null<History*> history,
               const TimeStepper& time_stepper) {
@@ -496,7 +496,7 @@ void test(const bool time_runs_forward) {
                         time_step_id.step_time().slab().duration() / 4),
                 initial_vars, deriv_vars);
           },
-          db::get<Tags::TimeStepper<>>(box));
+          make_not_null(&box), db::get<Tags::TimeStepper<>>(box));
     }
     if (data_needed) {
       TestCase::check_dense(&runner, true, {});

--- a/tests/Unit/Evolution/DgSubcell/Test_GetTciDecision.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Test_GetTciDecision.cpp
@@ -14,10 +14,11 @@ SPECTRE_TEST_CASE("Unit.Evolution.Subcell.GetTciDecision",
                   "[Evolution][Unit]") {
   auto box = db::create<db::AddSimpleTags<Tags::TciDecision>>(10);
   CHECK(get_tci_decision(box) == 10);
-  db::mutate<Tags::TciDecision>(make_not_null(&box),
-                                [](const gsl::not_null<int*> tci_decision_ptr) {
-                                  *tci_decision_ptr = -7;
-                                });
+  db::mutate<Tags::TciDecision>(
+      [](const gsl::not_null<int*> tci_decision_ptr) {
+        *tci_decision_ptr = -7;
+      },
+      make_not_null(&box));
   CHECK(get_tci_decision(box) == -7);
 }
 }  // namespace evolution::dg::subcell

--- a/tests/Unit/Evolution/DgSubcell/Test_NeighborTciDecision.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Test_NeighborTciDecision.cpp
@@ -57,17 +57,18 @@ void test() {
       Catch::Matchers::Contains(
           "The NeighborTciDecisions tag does not contain the neighbor"));
 #endif
-  db::mutate<tag>(make_not_null(&box), [&id_xi, &id_eta, &id_zeta](
-                                           const auto neighbor_decisions_ptr) {
-    (void)id_eta, (void)id_zeta;
-    neighbor_decisions_ptr->insert(std::pair{id_xi, 0});
-    if constexpr (Dim > 1) {
-      neighbor_decisions_ptr->insert(std::pair{id_eta, 0});
-    }
-    if constexpr (Dim > 2) {
-      neighbor_decisions_ptr->insert(std::pair{id_zeta, 0});
-    }
-  });
+  db::mutate<tag>(
+      [&id_xi, &id_eta, &id_zeta](const auto neighbor_decisions_ptr) {
+        (void)id_eta, (void)id_zeta;
+        neighbor_decisions_ptr->insert(std::pair{id_xi, 0});
+        if constexpr (Dim > 1) {
+          neighbor_decisions_ptr->insert(std::pair{id_eta, 0});
+        }
+        if constexpr (Dim > 2) {
+          neighbor_decisions_ptr->insert(std::pair{id_zeta, 0});
+        }
+      },
+      make_not_null(&box));
   neighbor_tci_decision(make_not_null(&box), neighbor_data);
   CHECK(db::get<tag>(box).at(id_xi) == 10);
   if constexpr (Dim > 1) {

--- a/tests/Unit/Evolution/DgSubcell/Test_Tags.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Test_Tags.cpp
@@ -352,18 +352,19 @@ void test(const bool moving_mesh) {
 
   check_box(db::get<domain::Tags::Mesh<Dim>>(active_coords_box));
   db::mutate<subcell::Tags::ActiveGrid>(
-      make_not_null(&active_coords_box), [](const auto active_grid_ptr) {
+      [](const auto active_grid_ptr) {
         *active_grid_ptr = subcell::ActiveGrid::Subcell;
-      });
+      },
+      make_not_null(&active_coords_box));
   check_box(db::get<subcell::Tags::Mesh<Dim>>(active_coords_box));
   db::mutate<subcell::Tags::ReconstructionOrder<Dim>>(
-      make_not_null(&active_coords_box),
       [](const auto recons_order_ptr, const size_t num_pts) {
         (*recons_order_ptr) = ReconsOrder{num_pts};
         for (size_t i = 0; i < Dim; ++i) {
           recons_order_ptr->value()[i] = static_cast<double>(i) + 3.0;
         }
       },
+      make_not_null(&active_coords_box),
       db::get<subcell::Tags::Mesh<Dim>>(active_coords_box)
           .number_of_grid_points());
   check_box(db::get<subcell::Tags::Mesh<Dim>>(active_coords_box));

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Actions/Test_BoundaryConditions.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Actions/Test_BoundaryConditions.cpp
@@ -2347,7 +2347,6 @@ void test_1d(const bool moving_mesh, const dg::Formulation formulation,
     INFO("Ghost");
     CAPTURE(outgoing_direction);
     db::mutate<domain::Tags::ExternalBoundaryConditions<Dim>, dt_variables_tag>(
-        make_not_null(&box),
         [&moving_mesh, &outgoing_direction](const auto all_boundary_conditions,
                                             const auto dt_vars_ptr) {
           DirectionMap<Dim, std::unique_ptr<
@@ -2360,7 +2359,8 @@ void test_1d(const bool moving_mesh, const dg::Formulation formulation,
           (*all_boundary_conditions)[0] = std::move(boundary_conditions);
 
           fill_variables(dt_vars_ptr, offset_dt_evolved_vars);
-        });
+        },
+        make_not_null(&box));
     evolution::dg::Actions::detail::
         apply_boundary_conditions_on_all_external_faces<System, Dim>(
             make_not_null(&box),
@@ -2423,7 +2423,6 @@ void test_1d(const bool moving_mesh, const dg::Formulation formulation,
     INFO("TimeDerivative");
     CAPTURE(outgoing_direction);
     db::mutate<domain::Tags::ExternalBoundaryConditions<Dim>, dt_variables_tag>(
-        make_not_null(&box),
         [&moving_mesh, &outgoing_direction](const auto all_boundary_conditions,
                                             const auto dt_vars_ptr) {
           DirectionMap<Dim, std::unique_ptr<
@@ -2437,7 +2436,8 @@ void test_1d(const bool moving_mesh, const dg::Formulation formulation,
           (*all_boundary_conditions)[0] = std::move(boundary_conditions);
 
           fill_variables(dt_vars_ptr, offset_dt_evolved_vars);
-        });
+        },
+        make_not_null(&box));
     evolution::dg::Actions::detail::
         apply_boundary_conditions_on_all_external_faces<System, Dim>(
             make_not_null(&box),
@@ -2487,7 +2487,6 @@ void test_1d(const bool moving_mesh, const dg::Formulation formulation,
 
         db::mutate<domain::Tags::ExternalBoundaryConditions<Dim>,
                    dt_variables_tag>(
-            make_not_null(&box),
             [&expected_dt_var1 =
                  get<::Tags::dt<Tags::Var1>>(expected_dt_on_boundary),
              &moving_mesh, &ghost_direction](const auto all_boundary_conditions,
@@ -2504,7 +2503,8 @@ void test_1d(const bool moving_mesh, const dg::Formulation formulation,
               (*all_boundary_conditions)[0] = std::move(boundary_conditions);
 
               fill_variables(dt_vars_ptr, offset_dt_evolved_vars);
-            });
+            },
+            make_not_null(&box));
         evolution::dg::Actions::detail::
             apply_boundary_conditions_on_all_external_faces<System, Dim>(
                 make_not_null(&box),
@@ -2542,7 +2542,6 @@ void test_1d(const bool moving_mesh, const dg::Formulation formulation,
         // applied in different directions.
         db::mutate<domain::Tags::ExternalBoundaryConditions<Dim>,
                    dt_variables_tag>(
-            make_not_null(&box),
             [&moving_mesh, &outgoing_direction](
                 const auto all_boundary_conditions, const auto dt_vars_ptr) {
               DirectionMap<Dim,
@@ -2557,7 +2556,8 @@ void test_1d(const bool moving_mesh, const dg::Formulation formulation,
               (*all_boundary_conditions)[0] = std::move(boundary_conditions);
 
               fill_variables(dt_vars_ptr, offset_dt_evolved_vars);
-            });
+            },
+            make_not_null(&box));
         evolution::dg::Actions::detail::
             apply_boundary_conditions_on_all_external_faces<System, Dim>(
                 make_not_null(&box),

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Actions/Test_NormalCovectorAndMagnitude.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Actions/Test_NormalCovectorAndMagnitude.cpp
@@ -190,13 +190,12 @@ void check_normal_covector_quantities(
     }
 
     db::mutate<evolution::dg::Tags::NormalCovectorAndMagnitude<Dim>>(
-        box,
         &evolution::dg::Actions::detail::
             unit_normal_vector_and_covector_and_magnitude<
                 tmpl::conditional_t<UseFlatSpace, FlatSpaceSystem,
                                     SystemWithInverseMetric<Dim>>,
                 Dim, field_face_tags>,
-        make_not_null(&fields_on_face), direction,
+        box, make_not_null(&fields_on_face), direction,
         unnormalized_normal_covectors,
         db::get<domain::CoordinateMaps::Tags::CoordinateMap<Dim, Frame::Grid,
                                                             Frame::Inertial>>(
@@ -260,9 +259,10 @@ void test(const bool use_moving_mesh) {
     // Mutate the x component of the unnormalized normal vector to simulate
     // moving mesh
     db::mutate<ScaleZeroIndex>(
-        make_not_null(&box), [](const gsl::not_null<double*> scale_zero_index) {
+        [](const gsl::not_null<double*> scale_zero_index) {
           *scale_zero_index = 2.3;
-        });
+        },
+        make_not_null(&box));
 
     check_normal_covector_quantities<IsFlatSpace, Dim>(make_not_null(&box));
   }

--- a/tests/Unit/Evolution/EventsAndDenseTriggers/DenseTriggers/Test_Times.cpp
+++ b/tests/Unit/Evolution/EventsAndDenseTriggers/DenseTriggers/Test_Times.cpp
@@ -76,8 +76,8 @@ void check_one_direction(const std::vector<double>& trigger_times,
   if (expected_is_triggered == std::optional{true}) {
     CHECK_FALSE(trigger->previous_trigger_time().has_value());
     db::mutate<::Tags::Time>(
-        make_not_null(&box),
-        [](const gsl::not_null<double*> time) { *time += 0.01; });
+        [](const gsl::not_null<double*> time) { *time += 0.01; },
+        make_not_null(&box));
     CHECK(trigger->is_triggered(box, cache, array_index, component) ==
           std::optional{false});
     REQUIRE(trigger->previous_trigger_time().has_value());
@@ -85,8 +85,8 @@ void check_one_direction(const std::vector<double>& trigger_times,
   } else {
     CHECK_FALSE(trigger->previous_trigger_time().has_value());
     db::mutate<::Tags::Time>(
-        make_not_null(&box),
-        [](const gsl::not_null<double*> time) { *time += 0.01; });
+        [](const gsl::not_null<double*> time) { *time += 0.01; },
+        make_not_null(&box));
     CHECK(trigger->is_triggered(box, cache, array_index, component) ==
           std::optional{false});
     CHECK_FALSE(trigger->previous_trigger_time().has_value());

--- a/tests/Unit/Evolution/EventsAndDenseTriggers/Test_EventsAndDenseTriggers.cpp
+++ b/tests/Unit/Evolution/EventsAndDenseTriggers/Test_EventsAndDenseTriggers.cpp
@@ -185,10 +185,11 @@ void do_test(const bool time_runs_forward, const bool add_event) {
 
   const auto set_tag = [&box](auto tag_v, const auto value) {
     using Tag = decltype(tag_v);
-    db::mutate<Tag>(make_not_null(&box),
-                    [&value](const gsl::not_null<typename Tag::type*> var) {
-                      *var = value;
-                    });
+    db::mutate<Tag>(
+        [&value](const gsl::not_null<typename Tag::type*> var) {
+          *var = value;
+        },
+        make_not_null(&box));
   };
 
   const auto check_events = [](const bool expected_a, const bool expected_b,

--- a/tests/Unit/Evolution/Initialization/Test_DgDomain.cpp
+++ b/tests/Unit/Evolution/Initialization/Test_DgDomain.cpp
@@ -120,8 +120,8 @@ struct IncrementTime {
       const ArrayIndex& /*array_index*/, const ActionList /*meta*/,
       const ParallelComponent* const /*meta*/) {
     db::mutate<Tags::Time>(
-        make_not_null(&box),
-        [](const gsl::not_null<double*> time) { *time += 1.2; });
+        [](const gsl::not_null<double*> time) { *time += 1.2; },
+        make_not_null(&box));
     return {Parallel::AlgorithmExecution::Continue, std::nullopt};
   }
 };

--- a/tests/Unit/Evolution/Systems/Burgers/FiniteDifference/Test_BoundaryConditionGhostData.cpp
+++ b/tests/Unit/Evolution/Systems/Burgers/FiniteDifference/Test_BoundaryConditionGhostData.cpp
@@ -260,10 +260,10 @@ void test(const BoundaryConditionType& boundary_condition) {
       // Test when U=-1.0, which will raise ERROR by violating the
       // DemandOutgoingCharSpeeds condition.
       db::mutate<Burgers::Tags::U>(
-          make_not_null(&box),
           [](const gsl::not_null<Scalar<DataVector>*> volume_u) {
             get(*volume_u) = -1.0;
-          });
+          },
+          make_not_null(&box));
       // See if the code fails correctly.
       CHECK_THROWS_WITH(([&box, &element]() {
                           Burgers::fd::BoundaryConditionGhostData::apply(
@@ -275,14 +275,14 @@ void test(const BoundaryConditionType& boundary_condition) {
 
       // Test when the volume mesh velocity has value, which will raise ERROR.
       db::mutate<domain::Tags::MeshVelocity<1>>(
-          make_not_null(&box),
           [&subcell_mesh](
               const gsl::not_null<std::optional<tnsr::I<DataVector, 1>>*>
                   mesh_velocity) {
             tnsr::I<DataVector, 1> volume_mesh_velocity_tnsr(
                 subcell_mesh.number_of_grid_points(), 0.0);
             *mesh_velocity = volume_mesh_velocity_tnsr;
-          });
+          },
+          make_not_null(&box));
       // See if the code fails correctly.
       CHECK_THROWS_WITH(
           ([&box, &element]() {

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_CalculateScriInputs.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_CalculateScriInputs.cpp
@@ -238,7 +238,6 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.Actions.CalculateScriInputs",
         using swsh_derivative_tag =
             typename decltype(swsh_derivative_tag_v)::type;
         db::mutate<swsh_derivative_tag>(
-            make_not_null(&expected_box),
             [&l_max](const gsl::not_null<typename swsh_derivative_tag::type*>
                          derivative,
                      const typename swsh_derivative_tag::derivative_of::type&
@@ -247,6 +246,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.Actions.CalculateScriInputs",
                   tmpl::list<typename swsh_derivative_tag::derivative_kind>>(
                   l_max, 1, make_not_null(&get(*derivative)), get(argument));
             },
+            make_not_null(&expected_box),
             db::get<typename swsh_derivative_tag::derivative_of>(expected_box));
       });
 

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_CharacteristicEvolutionBondiCalculations.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_CharacteristicEvolutionBondiCalculations.cpp
@@ -302,7 +302,6 @@ SPECTRE_TEST_CASE(
           number_of_angular_points * number_of_radial_points},
       Spectral::Swsh::SwshInterpolator{}, l_max, number_of_radial_points);
   db::mutate<boundary_variables_tag>(
-      make_not_null(&boundary_box),
       [&spatial_metric_coefficients, &dt_spatial_metric_coefficients,
        &dr_spatial_metric_coefficients, &shift_coefficients,
        &dt_shift_coefficients, &dr_shift_coefficients, &lapse_coefficients,
@@ -317,7 +316,8 @@ SPECTRE_TEST_CASE(
             shift_coefficients, dt_shift_coefficients, dr_shift_coefficients,
             lapse_coefficients, dt_lapse_coefficients, dr_lapse_coefficients,
             extraction_radius, l_max);
-      });
+      },
+      make_not_null(&boundary_box));
 
   for (size_t i = 0; i < 2; ++i) {
     ActionTesting::next_action<component>(make_not_null(&runner), 0);

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_InsertInterpolationScriData.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_InsertInterpolationScriData.cpp
@@ -95,23 +95,23 @@ struct SetRandomBoundaryValues {
         [&gen, &value_dist, &box](auto tag_v) {
           using tag = typename decltype(tag_v)::type;
           db::mutate<tag>(
-              make_not_null(&box),
               [&gen, &value_dist](
                   const gsl::not_null<typename tag::type*> scri_value) {
                 fill_with_random_values(make_not_null(&get(*scri_value).data()),
                                         make_not_null(&gen),
                                         make_not_null(&value_dist));
-              });
+              },
+              make_not_null(&box));
         });
 
     db::mutate<Tags::InertialRetardedTime>(
-        make_not_null(&box),
         [&gen,
          &value_dist](const gsl::not_null<Scalar<DataVector>*> scri_value) {
           fill_with_random_values(make_not_null(&get(*scri_value)),
                                   make_not_null(&gen),
                                   make_not_null(&value_dist));
-        });
+        },
+        make_not_null(&box));
     return {Parallel::AlgorithmExecution::Continue, std::nullopt};
   }
 };

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_ScriObserveInterpolated.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_ScriObserveInterpolated.cpp
@@ -64,12 +64,12 @@ struct SetBoundaryValues {
                     const Parallel::GlobalCache<Metavariables>& /*cache*/,
                     const ArrayIndex& /*array_index*/,
                     ComplexDataVector set_values) {
-    db::mutate<Tag>(make_not_null(&box),
-                    [&set_values](const gsl::not_null<typename Tag::type*>
-                                      spin_weighted_scalar_quantity) {
-                      get(*spin_weighted_scalar_quantity).data() =
-                          std::move(set_values);
-                    });
+    db::mutate<Tag>(
+        [&set_values](const gsl::not_null<typename Tag::type*>
+                          spin_weighted_scalar_quantity) {
+          get(*spin_weighted_scalar_quantity).data() = std::move(set_values);
+        },
+        make_not_null(&box));
   }
 
   template <
@@ -80,11 +80,11 @@ struct SetBoundaryValues {
                     const Parallel::GlobalCache<Metavariables>& /*cache*/,
                     const ArrayIndex& /*array_index*/, DataVector set_values) {
     db::mutate<Tag>(
-        make_not_null(&box),
         [&set_values](
             const gsl::not_null<typename Tag::type*> scalar_quantity) {
           get(*scalar_quantity) = std::move(set_values);
-        });
+        },
+        make_not_null(&box));
   }
 };
 

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_TimeManagement.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_TimeManagement.cpp
@@ -78,9 +78,10 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.Actions.TimeManagement",
 
   auto& box = ActionTesting::get_databox<component>(make_not_null(&runner), 0);
   db::mutate<::Tags::TimeStepId>(
-      make_not_null(&box), [](const gsl::not_null<TimeStepId*> time_step_id) {
+      [](const gsl::not_null<TimeStepId*> time_step_id) {
         *time_step_id = TimeStepId{true, 0, Time{{1.5, 2.5}, {3, 4}}};
-      });
+      },
+      make_not_null(&box));
 
   ActionTesting::next_action<component>(make_not_null(&runner), 0);
   CHECK(ActionTesting::get_terminate<component>(runner, 0));

--- a/tests/Unit/Evolution/Systems/Cce/Test_InitializeCce.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_InitializeCce.cpp
@@ -208,7 +208,6 @@ void test_initialize_j_zero_nonsmooth(
   db::mutate<Tags::BoundaryValue<Tags::BondiR>,
              Tags::BoundaryValue<Tags::Dr<Tags::BondiJ>>,
              Tags::BoundaryValue<Tags::BondiJ>>(
-      make_not_null(&box_to_initialize),
       [&generator, &dist, &l_max](
           const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 0>>*>
               boundary_r,
@@ -245,7 +244,8 @@ void test_initialize_j_zero_nonsmooth(
                            10.0;
         Spectral::Swsh::filter_swsh_boundary_quantity(
             make_not_null(&get(*boundary_r)), l_max, l_max / 2);
-      });
+      },
+      make_not_null(&box_to_initialize));
   auto node_lock = Parallel::NodeLock{};
   db::mutate_apply<InitializeJ::InitializeJ<false>::mutate_tags,
                    InitializeJ::InitializeJ<false>::argument_tags>(
@@ -602,7 +602,6 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.InitializeJ", "[Unit][Cce]") {
              Tags::BoundaryValue<Tags::BondiBeta>,
              Tags::BoundaryValue<Tags::Dr<Tags::BondiJ>>,
              Tags::BoundaryValue<Tags::BondiJ>>(
-      make_not_null(&box_to_initialize),
       [&generator, &dist, &l_max](
           const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 0>>*>
               boundary_r,
@@ -640,7 +639,8 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.InitializeJ", "[Unit][Cce]") {
             make_not_null(&get(*boundary_r)), l_max, l_max / 2);
 
         get(*boundary_dr_j) = -get(*boundary_j) / get(*boundary_r);
-      });
+      },
+      make_not_null(&box_to_initialize));
   {
     INFO("Check inverse cubic initial data generator");
     test_initialize_j_inverse_cubic(make_not_null(&box_to_initialize), l_max,

--- a/tests/Unit/Evolution/Systems/Cce/Test_NewmanPenrose.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_NewmanPenrose.cpp
@@ -185,7 +185,6 @@ void compute_psi0_of_bh_on_wt(const gsl::not_null<Generator*> gen) {
       amplitude, frequency, target_time, l_max, false);
 
   db::mutate<spin_weighted_variables_tag>(
-      make_not_null(&box),
       [&spatial_metric_coefficients, &dt_spatial_metric_coefficients,
        &dr_spatial_metric_coefficients, &shift_coefficients,
        &dt_shift_coefficients, &dr_shift_coefficients, &lapse_coefficients,
@@ -198,14 +197,14 @@ void compute_psi0_of_bh_on_wt(const gsl::not_null<Generator*> gen) {
             shift_coefficients, dt_shift_coefficients, dr_shift_coefficients,
             lapse_coefficients, dt_lapse_coefficients, dr_lapse_coefficients,
             extraction_radius, l_max);
-      });
+      },
+      make_not_null(&box));
 
   // construct the coordinate transform quantities
   const double variation_amplitude_inertial = value_dist(*gen);
   db::mutate<Tags::CauchyCartesianCoords>(
-      make_not_null(&box),
       [&l_max](const gsl::not_null<tnsr::i<DataVector, 3>*>
-                                 cauchy_cartesian_coordinates) {
+                   cauchy_cartesian_coordinates) {
         tnsr::i<DataVector, 2> cauchy_angular_coordinates{
             get<0>(*cauchy_cartesian_coordinates).size()};
         // There is a bug in Clang 10.0.0 that gives a nonsensical
@@ -233,10 +232,10 @@ void compute_psi0_of_bh_on_wt(const gsl::not_null<Generator*> gen) {
             sin(get<1>(cauchy_angular_coordinates));
         get<2>(*cauchy_cartesian_coordinates) =
             cos(get<0>(cauchy_angular_coordinates));
-      });
+      },
+      make_not_null(&box));
 
   db::mutate<Tags::PartiallyFlatCartesianCoords>(
-      make_not_null(&box),
       [&l_max, &variation_amplitude_inertial](
           const gsl::not_null<tnsr::i<DataVector, 3>*>
               inertial_cartesian_coordinates) {
@@ -269,7 +268,8 @@ void compute_psi0_of_bh_on_wt(const gsl::not_null<Generator*> gen) {
             sin(get<1>(inertial_angular_coordinates));
         get<2>(*inertial_cartesian_coordinates) =
             cos(get<0>(inertial_angular_coordinates));
-      });
+      },
+      make_not_null(&box));
 
   // Update various auxiliary boundary variables in order to prepare the
   // boundary data for BondiJ. Operartions are done for both Cauchy coordiantes

--- a/tests/Unit/Evolution/Systems/Cce/Test_PreSwshDerivatives.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_PreSwshDerivatives.cpp
@@ -113,7 +113,6 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.PreSwshDerivatives",
   db::mutate<pre_swsh_derivatives_variables_tag, swsh_derivatives_variables_tag,
              separated_pre_swsh_derivatives_angular_data,
              separated_pre_swsh_derivatives_radial_modes>(
-      make_not_null(&expected_box),
       [&generator](
           const gsl::not_null<
               typename pre_swsh_derivatives_variables_tag::type*>
@@ -143,7 +142,8 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.PreSwshDerivatives",
             pre_swsh_separated_angular_data, pre_swsh_separated_radial_modes,
             make_not_null(&generator), boundary_r, l_max,
             number_of_radial_grid_points);
-      });
+      },
+      make_not_null(&expected_box));
 
   auto computation_box =
       db::create<db::AddSimpleTags<Tags::LMax, Tags::Integrand<Tags::BondiBeta>,
@@ -202,12 +202,12 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.PreSwshDerivatives",
       [&spare_computation_box, &generator, &dist](auto tag_v) {
         using tag = typename decltype(tag_v)::type;
         db::mutate<tag>(
-            make_not_null(&spare_computation_box),
             [&generator,
              &dist](const gsl::not_null<typename tag::type*> to_generate) {
               fill_with_random_values(to_generate, make_not_null(&generator),
                                       make_not_null(&dist));
-            });
+            },
+            make_not_null(&spare_computation_box));
       });
   db::mutate_apply<
       PrecomputeCceDependencies<Tags::BoundaryValue, Tags::OneMinusY>>(

--- a/tests/Unit/Evolution/Systems/Cce/Test_PrecomputeCceDependencies.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_PrecomputeCceDependencies.cpp
@@ -42,7 +42,6 @@ void generate_boundary_values_and_expected(
   db::mutate<Tags::BoundaryValue<Tags::BondiR>,
              Tags::BoundaryValue<Tags::DuRDividedByR>, Tags::BondiR,
              Tags::DuRDividedByR, Tags::OneMinusY, Tags::BondiJ, Tags::BondiK>(
-      expected_box,
       [&generator, &dist, &l_max, &number_of_radial_grid_points, &y](
           const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 0>>*>
               boundary_r,
@@ -81,7 +80,8 @@ void generate_boundary_values_and_expected(
             number_of_radial_grid_points *
                 Spectral::Swsh::number_of_swsh_collocation_points(l_max));
         get(*k).data() = sqrt(1.0 + get(*j).data() * conj(get(*j).data()));
-      });
+      },
+      expected_box);
 
   TestHelpers::CopyDataBoxTags<Tags::BoundaryValue<Tags::BondiR>,
                                Tags::BoundaryValue<Tags::DuRDividedByR>,
@@ -90,7 +90,6 @@ void generate_boundary_values_and_expected(
 
   db::mutate<Tags::EthRDividedByR, Tags::EthEthbarRDividedByR,
              Tags::EthEthRDividedByR>(
-      expected_box,
       [&l_max, &number_of_radial_grid_points](
           const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 1>>*>
               eth_r_divided_by_r,
@@ -114,7 +113,7 @@ void generate_boundary_values_and_expected(
                 l_max, number_of_radial_grid_points, r_buffer) /
             (get(r));
       },
-      db::get<Tags::BondiR>(*expected_box));
+      expected_box, db::get<Tags::BondiR>(*expected_box));
 }
 
 SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.PrecomputeCceDependencies",

--- a/tests/Unit/Evolution/Systems/Cce/Test_ScriPlusValues.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_ScriPlusValues.cpp
@@ -115,14 +115,14 @@ void check_inertial_retarded_time_utilities() {
       Scalar<DataVector>{number_of_angular_points});
 
   db::mutate<Tags::Exp2Beta>(
-      make_not_null(&time_box),
       [&gen, &value_dist](
           const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 0>>*>
               exp_2_beta) {
         fill_with_random_values(make_not_null(&get(*exp_2_beta).data()),
                                 make_not_null(&gen),
                                 make_not_null(&value_dist));
-      });
+      },
+      make_not_null(&time_box));
   const double random_time = value_dist(gen);
 
   db::mutate_apply<InitializeScriPlusValue<Tags::InertialRetardedTime>>(
@@ -162,7 +162,6 @@ void check_inertial_retarded_time_utilities() {
               expected_retarded_time_intermediate_value));
   expected_eth_retarded_time.data() *= random_time_delta;
   db::mutate<Tags::ComplexInertialRetardedTime>(
-      make_not_null(&time_box),
       [&random_time_delta](
           const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 0>>*>
               complex_retarded_time,
@@ -170,6 +169,7 @@ void check_inertial_retarded_time_utilities() {
         get(*complex_retarded_time) = std::complex<double>(1.0, 0.0) *
                                       random_time_delta * get(dt_inertial_time);
       },
+      make_not_null(&time_box),
       db::get<::Tags::dt<Tags::InertialRetardedTime>>(time_box));
   db::mutate_apply<CalculateScriPlusValue<Tags::EthInertialRetardedTime>>(
       make_not_null(&time_box));

--- a/tests/Unit/Evolution/Systems/Cce/Test_SwshDerivatives.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_SwshDerivatives.cpp
@@ -258,7 +258,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.SwshDerivatives", "[Unit][Cce]") {
              Tags::BoundaryValue<Tags::DuRDividedByR>, Tags::BondiJ,
              TestHelpers::AngularCollocationsFor<Tags::BondiJ>,
              TestHelpers::RadialPolyCoefficientsFor<Tags::BondiJ>>(
-      make_not_null(&expected_box), GenerateStartingData{},
+      GenerateStartingData{}, make_not_null(&expected_box),
       make_not_null(&generator), make_not_null(&dist), l_max,
       number_of_radial_grid_points, y);
 
@@ -267,7 +267,6 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.SwshDerivatives", "[Unit][Cce]") {
   db::mutate<pre_swsh_derivatives_variables_tag, swsh_derivatives_variables_tag,
              separated_angular_data_variables_tag,
              separated_radial_modes_variables_tag>(
-      make_not_null(&expected_box),
       [&generator](
           const gsl::not_null<
               typename pre_swsh_derivatives_variables_tag::type*>
@@ -288,6 +287,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.SwshDerivatives", "[Unit][Cce]") {
             separated_radial_modes, make_not_null(&generator), boundary_r,
             l_max, number_of_radial_grid_points);
       },
+      make_not_null(&expected_box),
       get(db::get<Tags::BoundaryValue<Tags::BondiR>>(expected_box)));
 
   auto computation_box = db::create<db::AddSimpleTags<

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonActions/Test_ObserveWorldtubeSolution.cpp
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonActions/Test_ObserveWorldtubeSolution.cpp
@@ -138,8 +138,8 @@ void check_observe_worldtube_solution(
   // mutate time so we trigger an observation
   const double new_time = 3.9;
   db::mutate<::Tags::Time>(
-      make_not_null(&box),
-      [&new_time](const gsl::not_null<double*> time) { *time = new_time; });
+      [&new_time](const gsl::not_null<double*> time) { *time = new_time; },
+      make_not_null(&box));
 
   ActionTesting::next_action<worldtube_chare>(make_not_null(&runner), 0);
   CHECK_FALSE(

--- a/tests/Unit/Evolution/Systems/ForceFree/Subcell/Test_TciOnDgGrid.cpp
+++ b/tests/Unit/Evolution/Systems/ForceFree/Subcell/Test_TciOnDgGrid.cpp
@@ -102,20 +102,23 @@ void test(const TestThis test_this, const int expected_tci_status) {
   const size_t point_to_change = dg_mesh.number_of_grid_points() / 2;
 
   if (test_this == TestThis::PerssonMagTildeE) {
-    db::mutate<TildeE>(make_not_null(&box),
-                       [point_to_change](const auto tilde_e_ptr) {
-                         (*tilde_e_ptr).get(0)[point_to_change] *= 2.0;
-                       });
+    db::mutate<TildeE>(
+        [point_to_change](const auto tilde_e_ptr) {
+          (*tilde_e_ptr).get(0)[point_to_change] *= 2.0;
+        },
+        make_not_null(&box));
   } else if (test_this == TestThis::PerssonMagTildeB) {
-    db::mutate<TildeB>(make_not_null(&box),
-                       [point_to_change](const auto tilde_b_ptr) {
-                         (*tilde_b_ptr).get(0)[point_to_change] *= 2.0;
-                       });
+    db::mutate<TildeB>(
+        [point_to_change](const auto tilde_b_ptr) {
+          (*tilde_b_ptr).get(0)[point_to_change] *= 2.0;
+        },
+        make_not_null(&box));
   } else if (test_this == TestThis::PerssonTildeQ) {
-    db::mutate<TildeQ>(make_not_null(&box),
-                       [point_to_change](const auto tilde_q_ptr) {
-                         get(*tilde_q_ptr)[point_to_change] *= 2.0;
-                       });
+    db::mutate<TildeQ>(
+        [point_to_change](const auto tilde_q_ptr) {
+          get(*tilde_q_ptr)[point_to_change] *= 2.0;
+        },
+        make_not_null(&box));
   }
 
   // Set the RDMP TCI past data.
@@ -147,7 +150,6 @@ void test(const TestThis test_this, const int expected_tci_status) {
 
   // Modify past data if we are expecting an RDMP TCI failure.
   db::mutate<evolution::dg::subcell::Tags::DataForRdmpTci>(
-      make_not_null(&box),
       [&past_rdmp_tci_data, &test_this](const auto rdmp_tci_data_ptr) {
         *rdmp_tci_data_ptr = past_rdmp_tci_data;
         // Assumes min is positive, increase it so we fail the TCI
@@ -158,7 +160,8 @@ void test(const TestThis test_this, const int expected_tci_status) {
         } else if (test_this == TestThis::RdmpTildeQ) {
           rdmp_tci_data_ptr->min_variables_values[2] *= 1.01;
         }
-      });
+      },
+      make_not_null(&box));
 
   const bool element_stays_on_dg = false;
   const std::tuple<int, evolution::dg::subcell::RdmpTciData> result =

--- a/tests/Unit/Evolution/Systems/ForceFree/Subcell/Test_TciOnFdGrid.cpp
+++ b/tests/Unit/Evolution/Systems/ForceFree/Subcell/Test_TciOnFdGrid.cpp
@@ -86,24 +86,27 @@ void test(const TestThis test_this, const int expected_tci_status) {
   const size_t point_to_change = subcell_mesh.number_of_grid_points() / 2;
 
   if (test_this == TestThis::PerssonMagTildeE) {
-    db::mutate<TildeE>(make_not_null(&box),
-                       [point_to_change](const auto tilde_e_ptr) {
-                         for (size_t i = 0; i < 3; ++i) {
-                           tilde_e_ptr->get(i)[point_to_change] *= 10.0;
-                         }
-                       });
+    db::mutate<TildeE>(
+        [point_to_change](const auto tilde_e_ptr) {
+          for (size_t i = 0; i < 3; ++i) {
+            tilde_e_ptr->get(i)[point_to_change] *= 10.0;
+          }
+        },
+        make_not_null(&box));
   } else if (test_this == TestThis::PerssonMagTildeB) {
-    db::mutate<TildeB>(make_not_null(&box),
-                       [point_to_change](const auto tilde_b_ptr) {
-                         for (size_t i = 0; i < 3; ++i) {
-                           tilde_b_ptr->get(i)[point_to_change] *= 10.0;
-                         }
-                       });
+    db::mutate<TildeB>(
+        [point_to_change](const auto tilde_b_ptr) {
+          for (size_t i = 0; i < 3; ++i) {
+            tilde_b_ptr->get(i)[point_to_change] *= 10.0;
+          }
+        },
+        make_not_null(&box));
   } else if (test_this == TestThis::PerssonTildeQ) {
-    db::mutate<TildeQ>(make_not_null(&box),
-                       [point_to_change](const auto tilde_q_ptr) {
-                         get(*tilde_q_ptr)[point_to_change] *= 10.0;
-                       });
+    db::mutate<TildeQ>(
+        [point_to_change](const auto tilde_q_ptr) {
+          get(*tilde_q_ptr)[point_to_change] *= 10.0;
+        },
+        make_not_null(&box));
   }
 
   // Set the RDMP TCI past data.
@@ -142,7 +145,6 @@ void test(const TestThis test_this, const int expected_tci_status) {
 
   // Modify past data if we are expecting an RDMP TCI failure.
   db::mutate<evolution::dg::subcell::Tags::DataForRdmpTci>(
-      make_not_null(&box),
       [&past_rdmp_tci_data, &test_this](const auto rdmp_tci_data_ptr) {
         *rdmp_tci_data_ptr = past_rdmp_tci_data;
         // Assumes min is positive, increase it so we fail the TCI
@@ -153,7 +155,8 @@ void test(const TestThis test_this, const int expected_tci_status) {
         } else if (test_this == TestThis::RdmpTildeQ) {
           rdmp_tci_data_ptr->min_variables_values[2] *= 1.01;
         }
-      });
+      },
+      make_not_null(&box));
 
   const std::tuple<int, evolution::dg::subcell::RdmpTciData> result =
       db::mutate_apply<ForceFree::subcell::TciOnFdGrid>(

--- a/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/Test_SetPiFromGauge.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/Test_SetPiFromGauge.cpp
@@ -143,11 +143,12 @@ SPECTRE_TEST_CASE(
   // Switch to subcell grid and check we compute Pi correctly
   db::mutate<evolution::dg::subcell::Tags::ActiveGrid,
              ::Tags::Variables<evolved_vars_tags>>(
-      make_not_null(&box), [&initial_subcell_vars](const auto active_grid_ptr,
-                                                   const auto variables_ptr) {
+      [&initial_subcell_vars](const auto active_grid_ptr,
+                              const auto variables_ptr) {
         *active_grid_ptr = evolution::dg::subcell::ActiveGrid::Subcell;
         *variables_ptr = initial_subcell_vars;
-      });
+      },
+      make_not_null(&box));
   db::mutate_apply<grmhd::GhValenciaDivClean::SetPiFromGauge>(
       make_not_null(&box));
   check(db::get<evolution::dg::subcell::Tags::Mesh<3>>(box),
@@ -156,11 +157,11 @@ SPECTRE_TEST_CASE(
   // // Switch back to DG and check we compute Pi correctly
   db::mutate<evolution::dg::subcell::Tags::ActiveGrid,
              ::Tags::Variables<evolved_vars_tags>>(
-      make_not_null(&box),
       [&initial_dg_vars](const auto active_grid_ptr, const auto variables_ptr) {
         *active_grid_ptr = evolution::dg::subcell::ActiveGrid::Dg;
         *variables_ptr = initial_dg_vars;
-      });
+      },
+      make_not_null(&box));
   db::mutate_apply<grmhd::GhValenciaDivClean::SetPiFromGauge>(
       make_not_null(&box));
   check(db::get<domain::Tags::Mesh<3>>(box), initial_dg_vars);

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/Test_BoundaryConditionGhostData.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/Test_BoundaryConditionGhostData.cpp
@@ -570,12 +570,12 @@ void test(const BoundaryConditionType& boundary_condition,
       // Set shift to be zero so that the DemandOutgoingCharSpeeds condition is
       // violated. See if the code fails correctly.
       db::mutate<gr::Tags::Shift<DataVector, 3>>(
-          make_not_null(&box),
           [](const gsl::not_null<tnsr::I<DataVector, 3>*> shift_vector) {
             for (size_t i = 0; i < 3; ++i) {
               (*shift_vector).get(i) = 0.0;
             }
-          });
+          },
+          make_not_null(&box));
       CHECK_THROWS_WITH(
           ([&box, &element]() {
             fd::BoundaryConditionGhostData::apply(make_not_null(&box), element,
@@ -587,14 +587,14 @@ void test(const BoundaryConditionType& boundary_condition,
       // Test when the volume mesh velocity has value, which will raise ERROR.
       // See if the code fails correctly.
       db::mutate<domain::Tags::MeshVelocity<3>>(
-          make_not_null(&box),
           [&subcell_mesh](
               const gsl::not_null<std::optional<tnsr::I<DataVector, 3>>*>
                   mesh_velocity) {
             tnsr::I<DataVector, 3> volume_mesh_velocity_tnsr(
                 subcell_mesh.number_of_grid_points(), 0.0);
             *mesh_velocity = volume_mesh_velocity_tnsr;
-          });
+          },
+          make_not_null(&box));
       CHECK_THROWS_WITH(
           ([&box, &element]() {
             fd::BoundaryConditionGhostData::apply(make_not_null(&box), element,
@@ -658,10 +658,11 @@ void test(const BoundaryConditionType& boundary_condition,
       // Then re-compute ghost zone data to see if inward-pointing components
       // are set to zero.
       db::mutate<SpatialVelocity>(
-          make_not_null(&box), [](const gsl::not_null<tnsr::I<DataVector, 3>*>
-                                      interior_spatial_velocity) {
+          [](const gsl::not_null<tnsr::I<DataVector, 3>*>
+                 interior_spatial_velocity) {
             (*interior_spatial_velocity).get(0) = -0.2;
-          });
+          },
+          make_not_null(&box));
       fd::BoundaryConditionGhostData::apply(make_not_null(&box), element,
                                             ReconstructorForTest{});
 

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_SwapGrTags.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_SwapGrTags.cpp
@@ -50,9 +50,10 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.ValenciaDivClean.Subcell.SwapGrTags",
                                  evolution::dg::subcell::ActiveGrid::Subcell,
                                  evolution::dg::subcell::ActiveGrid::Dg}) {
     db::mutate<evolution::dg::subcell::Tags::ActiveGrid>(
-        make_not_null(&box), [&active_grid](const auto active_grid_ptr) {
+        [&active_grid](const auto active_grid_ptr) {
           *active_grid_ptr = active_grid;
-        });
+        },
+        make_not_null(&box));
 
     db::mutate_apply<grmhd::ValenciaDivClean::subcell::SwapGrTags>(
         make_not_null(&box));

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_TciOnFdGrid.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_TciOnFdGrid.cpp
@@ -93,51 +93,59 @@ void test(const TestThis test_this, const int expected_tci_status) {
   const size_t point_to_change = mesh.number_of_grid_points() / 2;
   if (test_this == TestThis::PerssonPressure) {
     db::mutate<hydro::Tags::Pressure<DataVector>>(
-        make_not_null(&box), [point_to_change](const auto pressure_ptr) {
+        [point_to_change](const auto pressure_ptr) {
           get(*pressure_ptr)[point_to_change] *= 2.0;
-        });
+        },
+        make_not_null(&box));
   } else if (test_this == TestThis::PerssonTildeD) {
     db::mutate<grmhd::ValenciaDivClean::Tags::TildeD>(
-        make_not_null(&box), [point_to_change](const auto tilde_d_ptr) {
+        [point_to_change](const auto tilde_d_ptr) {
           get(*tilde_d_ptr)[point_to_change] *= 2.0;
-        });
+        },
+        make_not_null(&box));
   } else if (test_this == TestThis::PerssonTildeYe) {
     db::mutate<grmhd::ValenciaDivClean::Tags::TildeYe>(
-        make_not_null(&box), [point_to_change](const auto tilde_d_ptr) {
+        [point_to_change](const auto tilde_d_ptr) {
           get(*tilde_d_ptr)[point_to_change] *= 2.0;
-        });
+        },
+        make_not_null(&box));
   } else if (test_this == TestThis::PerssonTildeB) {
     db::mutate<grmhd::ValenciaDivClean::Tags::TildeB<>>(
-        make_not_null(&box), [point_to_change](const auto tilde_b_ptr) {
+        [point_to_change](const auto tilde_b_ptr) {
           for (size_t i = 0; i < 3; ++i) {
             tilde_b_ptr->get(i)[point_to_change] *= 2.0;
           }
-        });
+        },
+        make_not_null(&box));
   } else if (test_this == TestThis::NegativeTildeD) {
     db::mutate<grmhd::ValenciaDivClean::Tags::TildeD>(
-        make_not_null(&box), [point_to_change](const auto tilde_d_ptr) {
+        [point_to_change](const auto tilde_d_ptr) {
           get(*tilde_d_ptr)[point_to_change] = -1.0e-20;
-        });
+        },
+        make_not_null(&box));
   } else if (test_this == TestThis::NegativeTildeYe) {
     db::mutate<grmhd::ValenciaDivClean::Tags::TildeYe>(
-        make_not_null(&box), [point_to_change](const auto tilde_d_ptr) {
+        [point_to_change](const auto tilde_d_ptr) {
           get(*tilde_d_ptr)[point_to_change] = -1.0e-20;
-        });
+        },
+        make_not_null(&box));
   } else if (test_this == TestThis::NegativeTildeTau) {
     db::mutate<grmhd::ValenciaDivClean::Tags::TildeTau>(
-        make_not_null(&box), [point_to_change](const auto tilde_tau_ptr) {
+        [point_to_change](const auto tilde_tau_ptr) {
           get(*tilde_tau_ptr)[point_to_change] = -1.0e-20;
-        });
+        },
+        make_not_null(&box));
   } else if (test_this == TestThis::Atmosphere) {
     db::mutate<hydro::Tags::RestMassDensity<DataVector>,
                grmhd::ValenciaDivClean::Tags::VariablesNeededFixing>(
-        make_not_null(&box), [](const auto rest_mass_density_ptr,
-                                const auto variables_needed_fixing_ptr) {
+        [](const auto rest_mass_density_ptr,
+           const auto variables_needed_fixing_ptr) {
           *variables_needed_fixing_ptr = true;
           get(*rest_mass_density_ptr) =
               5.0e-12;  // smaller than atmosphere density but
                         // bigger than the Min(TildeD) TCI option
-        });
+        },
+        make_not_null(&box));
   }
 
   // Set the RDMP TCI past data.
@@ -202,7 +210,6 @@ void test(const TestThis test_this, const int expected_tci_status) {
 
   // Modify past data if we are expected an RDMP TCI failure.
   db::mutate<evolution::dg::subcell::Tags::DataForRdmpTci>(
-      make_not_null(&box),
       [&past_rdmp_tci_data, &test_this](const auto rdmp_tci_data_ptr) {
         *rdmp_tci_data_ptr = past_rdmp_tci_data;
         if (test_this == TestThis::RdmpTildeD) {
@@ -218,7 +225,8 @@ void test(const TestThis test_this, const int expected_tci_status) {
           // Assumes min is positive, increase it so we fail the TCI
           rdmp_tci_data_ptr->min_variables_values[3] *= 1.01;
         }
-      });
+      },
+      make_not_null(&box));
 
   const std::tuple<int, evolution::dg::subcell::RdmpTciData> result =
       db::mutate_apply<grmhd::ValenciaDivClean::subcell::TciOnFdGrid>(

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/Subcell/Test_TciOnDgGrid.cpp
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/Subcell/Test_TciOnDgGrid.cpp
@@ -130,7 +130,6 @@ void test(const TestThis test_this) {
 
   // Modify past data if we are expected an RDMP TCI failure.
   db::mutate<evolution::dg::subcell::Tags::DataForRdmpTci>(
-      make_not_null(&box),
       [&past_rdmp_tci_data, &test_this](const auto rdmp_tci_data_ptr) {
         *rdmp_tci_data_ptr = past_rdmp_tci_data;
         if (test_this == TestThis::RdmpMassDensity) {
@@ -140,7 +139,8 @@ void test(const TestThis test_this) {
           // Assumes min is positive, increase it so we fail the TCI
           rdmp_tci_data_ptr->min_variables_values[1] *= 1.01;
         }
-      });
+      },
+      make_not_null(&box));
 
   const bool element_stays_on_dg = false;
   const std::tuple<bool, evolution::dg::subcell::RdmpTciData> result =

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/Subcell/Test_TciOnFdGrid.cpp
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/Subcell/Test_TciOnFdGrid.cpp
@@ -142,7 +142,6 @@ void test(const TestThis test_this) {
 
   // Modify past data if we are expected an RDMP TCI failure.
   db::mutate<evolution::dg::subcell::Tags::DataForRdmpTci>(
-      make_not_null(&box),
       [&past_rdmp_tci_data, &test_this](const auto rdmp_tci_data_ptr) {
         *rdmp_tci_data_ptr = past_rdmp_tci_data;
         if (test_this == TestThis::RdmpMassDensity) {
@@ -152,7 +151,8 @@ void test(const TestThis test_this) {
           // Assumes min is positive, increase it so we fail the TCI
           rdmp_tci_data_ptr->min_variables_values[1] *= 1.01;
         }
-      });
+      },
+      make_not_null(&box));
 
   const auto result =
       db::mutate_apply<NewtonianEuler::subcell::TciOnFdGrid<Dim>>(

--- a/tests/Unit/Evolution/Test_ComputeTags.cpp
+++ b/tests/Unit/Evolution/Test_ComputeTags.cpp
@@ -137,12 +137,12 @@ SPECTRE_TEST_CASE("Unit.Evolution.ComputeTags", "[Unit][Evolution]") {
                           expected_error);
     db::mutate<evolution::dg::subcell::Tags::ActiveGrid,
                ::Tags::Variables<tmpl::list<FieldTag>>>(
-        make_not_null(&box),
         [](const auto active_grid_ptr, const auto vars_ptr) {
           *active_grid_ptr = evolution::dg::subcell::ActiveGrid::Subcell;
           vars_ptr->initialize(7);
           *vars_ptr = Variables<tmpl::list<FieldTag>>{7, 3.};
-        });
+        },
+        make_not_null(&box));
     const DataVector subcell_expected{2., 3., 4., 5., 6., 7., 8.};
     const DataVector subcell_expected_error{1., 0., -1., -2., -3., -4., -5.};
     CHECK_ITERABLE_APPROX(get(get<Tags::Analytic<FieldTag>>(box).value()),

--- a/tests/Unit/Evolution/Test_TagsDomain.cpp
+++ b/tests/Unit/Evolution/Test_TagsDomain.cpp
@@ -138,8 +138,8 @@ void test() {
   check_helper();
 
   db::mutate<Tags::Time>(
-      make_not_null(&box),
-      [](const gsl::not_null<double*> local_time) { *local_time = 4.5; });
+      [](const gsl::not_null<double*> local_time) { *local_time = 4.5; },
+      make_not_null(&box));
   check_helper();
 }
 }  // namespace

--- a/tests/Unit/Framework/Tests/Test_ActionTesting.cpp
+++ b/tests/Unit/Framework/Tests/Test_ActionTesting.cpp
@@ -103,8 +103,8 @@ struct simple_action_a_mock {
                     const Parallel::GlobalCache<Metavariables>& /*cache*/,
                     const ArrayIndex& /*array_index*/, const int value) {
     db::mutate<ValueTag>(
-        make_not_null(&box),
-        [&value](const gsl::not_null<int*> value_box) { *value_box = value; });
+        [&value](const gsl::not_null<int*> value_box) { *value_box = value; },
+        make_not_null(&box));
   }
 };
 
@@ -121,10 +121,11 @@ struct simple_action_b {
     // verify the mock actions were actually called.
     //
     // We do some "work" here by updating the `PassedToB` tag in the DataBox.
-    db::mutate<PassedToB>(make_not_null(&box),
-                          [&to_call](const gsl::not_null<double*> passed_to_b) {
-                            *passed_to_b = to_call;
-                          });
+    db::mutate<PassedToB>(
+        [&to_call](const gsl::not_null<double*> passed_to_b) {
+          *passed_to_b = to_call;
+        },
+        make_not_null(&box));
     if (to_call == 0) {
       Parallel::simple_action<simple_action_a>(
           Parallel::get_parallel_component<
@@ -157,8 +158,8 @@ struct simple_action_c_mock {
                     const Parallel::GlobalCache<Metavariables>& /*cache*/,
                     const ArrayIndex& /*array_index*/) {
     db::mutate<ValueTag>(
-        make_not_null(&box),
-        [](const gsl::not_null<int*> value_box) { *value_box = 25; });
+        [](const gsl::not_null<int*> value_box) { *value_box = 25; },
+        make_not_null(&box));
   }
 };
 
@@ -171,8 +172,8 @@ struct threaded_action_a {
                     const ArrayIndex& /*array_index*/,
                     const gsl::not_null<Parallel::NodeLock*> /*node_lock*/) {
     db::mutate<ValueTag>(
-        make_not_null(&box),
-        [](const gsl::not_null<int*> value_box) { *value_box = 35; });
+        [](const gsl::not_null<int*> value_box) { *value_box = 35; },
+        make_not_null(&box));
   }
 };
 
@@ -187,8 +188,8 @@ struct threaded_action_b_mock {
                     const int tag) {
     node_lock->lock();
     db::mutate<ValueTag>(
-        make_not_null(&box),
-        [tag](const gsl::not_null<int*> value_box) { *value_box = tag; });
+        [tag](const gsl::not_null<int*> value_box) { *value_box = tag; },
+        make_not_null(&box));
     node_lock->unlock();
   }
 };
@@ -493,8 +494,8 @@ struct ActionCalledOnComponentB {
   static void apply(db::DataBox<DbTagsList>& box,                     // NOLINT
                     Parallel::GlobalCache<Metavariables>& /*cache*/,  // NOLINT
                     const ArrayIndex& /*array_index*/) {
-    db::mutate<ValueTag>(make_not_null(&box),
-                         [](const gsl::not_null<int*> value) { *value = 5; });
+    db::mutate<ValueTag>([](const gsl::not_null<int*> value) { *value = 5; },
+                         make_not_null(&box));
   }
 };
 
@@ -678,10 +679,11 @@ struct ActionSetValueTo {
     // We must specify all templates here explicitly otherwise it won't build
     T function_value =
         Functor::template f<ProxyType, ArrayIndex, T>(my_proxy, array_index);
-    db::mutate<Tag>(make_not_null(&box),
-                    [&function_value](const gsl::not_null<T*> value) {
-                      *value = function_value;
-                    });
+    db::mutate<Tag>(
+        [&function_value](const gsl::not_null<T*> value) {
+          *value = function_value;
+        },
+        make_not_null(&box));
   }
 };
 

--- a/tests/Unit/Helpers/ControlSystem/Examples.hpp
+++ b/tests/Unit/Helpers/ControlSystem/Examples.hpp
@@ -51,11 +51,12 @@ struct SomeControlSystemUpdater {
                     const ArrayIndex& /*array_index*/, const double time,
                     tuples::TaggedTuple<SubmeasurementTag> data) {
     db::mutate<MeasurementResultTime, MeasurementResultTag>(
-        box, [&time, &data](const gsl::not_null<double*> stored_time,
-                            const gsl::not_null<double*> stored_data) {
+        [&time, &data](const gsl::not_null<double*> stored_time,
+                       const gsl::not_null<double*> stored_data) {
           *stored_time = time;
           *stored_data = tuples::get<SubmeasurementTag>(data);
-        });
+        },
+        box);
   }
 };
 

--- a/tests/Unit/Helpers/Evolution/Systems/Cce/CceComputationTestHelpers.hpp
+++ b/tests/Unit/Helpers/Evolution/Systems/Cce/CceComputationTestHelpers.hpp
@@ -60,7 +60,6 @@ struct CopyDataBoxTags {
   static void apply(const gsl::not_null<ToDataBox*> to_data_box,
                     const FromDataBox& from_data_box) {
     db::mutate<Tags...>(
-        to_data_box,
         [](const gsl::not_null<typename Tags::type*>... to_value,
            const typename Tags::type&... from_value) {
           const auto assign = [](auto to, const auto& from) {
@@ -69,7 +68,7 @@ struct CopyDataBoxTags {
           };
           expand_pack(assign(to_value, from_value)...);
         },
-        db::get<Tags>(from_data_box)...);
+        to_data_box, db::get<Tags>(from_data_box)...);
   }
 };
 

--- a/tests/Unit/Helpers/IO/Observers/MockWriteReductionDataRow.hpp
+++ b/tests/Unit/Helpers/IO/Observers/MockWriteReductionDataRow.hpp
@@ -49,7 +49,6 @@ struct MockWriteReductionDataRow {
     if constexpr (::db::tag_is_retrievable_v<MockReductionFileTag,
                                              ::db::DataBox<DbTagsList>>) {
       ::db::mutate<MockReductionFileTag>(
-          make_not_null(&box),
           [subfile_name, legend,
            in_reduction_data](const gsl::not_null<MockH5File*> mock_h5_file) {
             auto& dat_file = (*mock_h5_file).try_insert(subfile_name);
@@ -66,7 +65,8 @@ struct MockWriteReductionDataRow {
                 });
 
             dat_file.append(legend, data);
-          });
+          },
+          make_not_null(&box));
     } else {
       (void)subfile_name;
       (void)legend;

--- a/tests/Unit/Helpers/ParallelAlgorithms/Interpolation/InterpolationTargetTestHelpers.hpp
+++ b/tests/Unit/Helpers/ParallelAlgorithms/Interpolation/InterpolationTargetTestHelpers.hpp
@@ -103,7 +103,6 @@ struct MockReceivePoints {
                  tnsr::I<double, VolumeDim, typename Frame::BlockLogical>>>>&&
           block_coord_holders) {
     db::mutate<intrp::Tags::InterpolatedVarsHolders<Metavariables>>(
-        make_not_null(&box),
         [&temporal_id, &block_coord_holders](
             const gsl::not_null<typename intrp::Tags::InterpolatedVarsHolders<
                 Metavariables>::type*>
@@ -119,7 +118,8 @@ struct MockReceivePoints {
               intrp::Vars::Info<VolumeDim, typename InterpolationTargetTag::
                                                vars_to_interpolate_to_target>{
                   std::move(block_coord_holders)}));
-        });
+        },
+        make_not_null(&box));
   }
 };
 

--- a/tests/Unit/Helpers/ParallelAlgorithms/LinearSolver/DistributedLinearSolverAlgorithmTestHelpers.hpp
+++ b/tests/Unit/Helpers/ParallelAlgorithms/LinearSolver/DistributedLinearSolverAlgorithmTestHelpers.hpp
@@ -210,12 +210,13 @@ struct CollectOperatorAction {
                   static_cast<int>((element_index + 1) * number_of_grid_points),
               Ap_local.begin());
     db::mutate<local_operator_applied_to_operand_tag>(
-        make_not_null(&box), [&Ap_local, &number_of_grid_points](auto Ap) {
+        [&Ap_local, &number_of_grid_points](auto Ap) {
           *Ap = typename local_operator_applied_to_operand_tag::type{
               number_of_grid_points};
           get(get<LinearSolver::Tags::OperatorAppliedTo<ScalarFieldOperandTag>>(
               *Ap)) = Ap_local;
-        });
+        },
+        make_not_null(&box));
     // Proceed with algorithm
     Parallel::get_parallel_component<ParallelComponent>(cache)[element_id]
         .perform_algorithm(true);

--- a/tests/Unit/Helpers/ParallelAlgorithms/LinearSolver/LinearSolverAlgorithmTestHelpers.hpp
+++ b/tests/Unit/Helpers/ParallelAlgorithms/LinearSolver/LinearSolverAlgorithmTestHelpers.hpp
@@ -145,14 +145,13 @@ struct ComputeOperatorAction {
       // NOLINTNEXTLINE(readability-avoid-const-params-in-decls)
       const ParallelComponent* const /*meta*/) {
     db::mutate<LinearSolver::Tags::OperatorAppliedTo<OperandTag>>(
-        make_not_null(&box),
         [](const gsl::not_null<blaze::DynamicVector<double>*>
                operator_applied_to_operand,
            const blaze::DynamicMatrix<double>& linear_operator,
            const blaze::DynamicVector<double>& operand) {
           *operator_applied_to_operand = linear_operator * operand;
         },
-        get<LinearOperator>(box), get<OperandTag>(box));
+        make_not_null(&box), get<LinearOperator>(box), get<OperandTag>(box));
     return {Parallel::AlgorithmExecution::Continue, std::nullopt};
   }
 };

--- a/tests/Unit/Helpers/ParallelAlgorithms/LinearSolver/Multigrid/Helpers.hpp
+++ b/tests/Unit/Helpers/ParallelAlgorithms/LinearSolver/Multigrid/Helpers.hpp
@@ -203,7 +203,6 @@ struct CollectOperatorAction {
     const size_t number_of_grid_points =
         get<LinearOperator>(box)[multigrid_level][0].columns();
     db::mutate<OperatorAppliedToOperandTag>(
-        make_not_null(&box),
         [&operator_applied_to_operand_global_data, &number_of_grid_points,
          &element_index](auto operator_applied_to_operand) {
           operator_applied_to_operand->initialize(number_of_grid_points);
@@ -212,7 +211,8 @@ struct CollectOperatorAction {
                 operator_applied_to_operand_global_data
                     .data()[i + element_index * number_of_grid_points];
           }
-        });
+        },
+        make_not_null(&box));
     // Proceed with algorithm
     Parallel::get_parallel_component<ParallelComponent>(cache)[element_id]
         .perform_algorithm(true);

--- a/tests/Unit/Helpers/ParallelAlgorithms/LinearSolver/ResidualMonitorActionsTestHelpers.hpp
+++ b/tests/Unit/Helpers/ParallelAlgorithms/LinearSolver/ResidualMonitorActionsTestHelpers.hpp
@@ -61,7 +61,6 @@ struct MockWriteReductionData {
       Parallel::ReductionData<ReductionDatums...>&& in_reduction_data) {
     db::mutate<CheckObservationIdTag, CheckSubfileNameTag,
                CheckReductionNamesTag, CheckReductionDataTag>(
-        make_not_null(&box),
         [observation_id, subfile_name, reduction_names, in_reduction_data](
             const gsl::not_null<typename CheckObservationIdTag::type*>
                 check_observation_id,
@@ -75,7 +74,8 @@ struct MockWriteReductionData {
           *check_subfile_name = subfile_name;
           *check_reduction_names = reduction_names;
           *check_reduction_data = in_reduction_data.data();
-        });
+        },
+        make_not_null(&box));
   }
 };
 
@@ -93,14 +93,14 @@ struct MockWriteReductionDataRow {
                     std::tuple<Ts...>&& in_reduction_data) {
     db::mutate<CheckSubfileNameTag, CheckReductionNamesTag,
                CheckReductionDataTag>(
-        make_not_null(&box),
         [subfile_name, legend, in_reduction_data](
             const auto check_subfile_name, const auto check_reduction_names,
             const auto check_reduction_data) {
           *check_subfile_name = subfile_name;
           *check_reduction_names = legend;
           *check_reduction_data = in_reduction_data;
-        });
+        },
+        make_not_null(&box));
   }
 };
 

--- a/tests/Unit/IO/Observers/Test_GetLockPointer.cpp
+++ b/tests/Unit/IO/Observers/Test_GetLockPointer.cpp
@@ -106,11 +106,11 @@ SPECTRE_TEST_CASE("Unit.IO.Observer.GetNodeLockPointer", "[Unit][Cce]") {
       make_not_null(&runner), 0);
 
   db::mutate<observers::Tags::H5FileLock, observers::Tags::VolumeDataLock>(
-      make_not_null(&ActionTesting::get_databox<writer_component>(
-          make_not_null(&runner), 0)),
       [](const gsl::not_null<Parallel::NodeLock*> h5_lock,
          const gsl::not_null<Parallel::NodeLock*> volume_lock) {
         CHECK(h5_lock.get() == h5_lock_to_check);
         CHECK(volume_lock.get() == volume_lock_to_check);
-      });
+      },
+      make_not_null(&ActionTesting::get_databox<writer_component>(
+          make_not_null(&runner), 0)));
 }

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_SwshDerivatives.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_SwshDerivatives.cpp
@@ -177,12 +177,10 @@ void test_compute_angular_derivatives() {
       };
   // Put the collocation information derived from the generated modes in the
   // DataBox
-  db::mutate<TestTag<0, Spin0>>(make_not_null(&box),
-                                coefficients_to_analytic_collocation,
-                                expected_modes_spin_0);
-  db::mutate<TestTag<1, Spin1>>(make_not_null(&box),
-                                coefficients_to_analytic_collocation,
-                                expected_modes_spin_1);
+  db::mutate<TestTag<0, Spin0>>(coefficients_to_analytic_collocation,
+                                make_not_null(&box), expected_modes_spin_0);
+  db::mutate<TestTag<1, Spin1>>(coefficients_to_analytic_collocation,
+                                make_not_null(&box), expected_modes_spin_1);
 
   // these could be packed into a variables, but the current test wouldn't be
   // much shorter. If the test is expanded to verify more than four results at a

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_SwshTransform.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_SwshTransform.cpp
@@ -124,12 +124,10 @@ void test_transform_and_inverse_transform() {
             number_of_radial_points,
             TestHelpers::spin_weighted_spherical_harmonic);
       };
-  db::mutate<TestTag<0, S>>(make_not_null(&box),
-                            coefficients_to_analytic_collocation,
-                            expected_modes);
-  db::mutate<TestTag<1, S>>(make_not_null(&box),
-                            coefficients_to_analytic_collocation,
-                            two_times_expected_modes);
+  db::mutate<TestTag<0, S>>(coefficients_to_analytic_collocation,
+                            make_not_null(&box), expected_modes);
+  db::mutate<TestTag<1, S>>(coefficients_to_analytic_collocation,
+                            make_not_null(&box), two_times_expected_modes);
 
   const auto source_collocation_copy = get(db::get<TestTag<0, S>>(box));
   // transform using the DataBox mutate interface
@@ -186,14 +184,14 @@ void test_transform_and_inverse_transform() {
   // clear out the existing collocation data so we know we get the
   // correct inverse transform
   db::mutate<TestTag<0, S>, TestTag<1, S>>(
-      make_not_null(&box),
       [](const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, S>>*>
              collocation,
          const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, S>>*>
              another_collocation) {
         get(*collocation).data() = 0.0;
         get(*another_collocation).data() = 0.0;
-      });
+      },
+      make_not_null(&box));
 
   // transform using the DataBox mutate interface
   db::mutate_apply<InverseSwshTransform<

--- a/tests/Unit/Parallel/Test_AlgorithmLocalSyncAction.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmLocalSyncAction.cpp
@@ -80,10 +80,10 @@ struct SyncGetPointerFromNodegroup {
       // of the box.
       node_lock->lock();
       db::mutate<StepNumber>(
-          make_not_null(&box),
           [&result](const gsl::not_null<size_t*> step_number) {
             result = step_number;
-          });
+          },
+          make_not_null(&box));
       node_lock->unlock();
       return result;
     } else {
@@ -130,8 +130,8 @@ struct IncrementNodegroupStep {
       // nodegroups can have multiple actions running in separate threads.
       node_lock->lock();
       db::mutate<StepNumber>(
-          make_not_null(&box),
-          [](const gsl::not_null<size_t*> step_number) { ++(*step_number); });
+          [](const gsl::not_null<size_t*> step_number) { ++(*step_number); },
+          make_not_null(&box));
       node_lock->unlock();
     } else {
       // avoid 'unused' warnings

--- a/tests/Unit/Parallel/Test_AlgorithmMessages.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmMessages.cpp
@@ -190,10 +190,10 @@ struct SendAddressOfVector0 {
                     const ArrayIndex& /*array_index*/,
                     const std::string& sent_address) {
     db::mutate<Tags::AddressOfVector0OnSender>(
-        make_not_null(&box),
         [&sent_address](const gsl::not_null<std::string*> address) {
           *address = sent_address;
-        });
+        },
+        make_not_null(&box));
   }
 };
 
@@ -296,11 +296,11 @@ struct ReceiveMessage {
       auto& boundary_message_ptr = inbox.at(array_index);
 
       db::mutate<Tags::Vector1>(
-          make_not_null(&box),
           [&boundary_message_ptr](const gsl::not_null<DataVector*> vector_1) {
             vector_1->set_data_ref(boundary_message_ptr->dg_flux_data,
                                    boundary_message_ptr->dg_flux_data_size);
-          });
+          },
+          make_not_null(&box));
 
       const int my_node = db::get<Tags::MyNode>(box);
       const int node_of_element_to_receive_from =

--- a/tests/Unit/Parallel/Test_AlgorithmNodelock.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmNodelock.cpp
@@ -105,7 +105,6 @@ struct nodegroup_receive {
                                  NodegroupParallelComponent<TestMetavariables>>,
                   "The ParallelComponent is not deduced to be the right type");
     db::mutate<Tags::vector_of_array_indexs, Tags::total_receives_on_node>(
-        make_not_null(&box),
         [&id_of_array](const gsl::not_null<std::vector<int>*> array_indexs,
                        const gsl::not_null<int*> total_receives_on_node) {
           if (static_cast<int>(array_indexs->size()) !=
@@ -116,7 +115,8 @@ struct nodegroup_receive {
           std::for_each(array_indexs->begin(), array_indexs->end(),
                         [](int& t) { t++; });
           ++*total_receives_on_node;
-        });
+        },
+        make_not_null(&box));
   }
 };
 
@@ -159,7 +159,6 @@ struct nodegroup_threaded_receive {
     // [threaded_action_example]
     node_lock->lock();
     db::mutate<Tags::vector_of_array_indexs, Tags::total_receives_on_node>(
-        make_not_null(&box),
         [&id_of_array](const gsl::not_null<std::vector<int>*> array_indexs,
                        const gsl::not_null<int*> total_receives_on_node) {
           if (static_cast<int>(array_indexs->size()) !=
@@ -170,7 +169,8 @@ struct nodegroup_threaded_receive {
           std::for_each(array_indexs->begin(), array_indexs->end(),
                         [](int& t) { t++; });
           ++*total_receives_on_node;
-        });
+        },
+        make_not_null(&box));
     node_lock->unlock();
   }
 };

--- a/tests/Unit/Parallel/Test_AlgorithmParallel.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmParallel.cpp
@@ -217,10 +217,10 @@ struct CountReceives {
     }
 
     db::mutate<Tags::ReceiveArrayComponentsOnceMore>(
-        make_not_null(&box),
         [](bool* const receive_array_components_once_more) {
           *receive_array_components_once_more = true;
-        });
+        },
+        make_not_null(&box));
 
     // [return_with_termination]
     return {Parallel::AlgorithmExecution::Pause, std::nullopt};
@@ -277,10 +277,10 @@ struct AddIntValue10 {
       // [broadcast_to_group]
     }
     db::mutate<Tags::CountActionsCalled>(
-        make_not_null(&box),
         [](const gsl::not_null<int*> count_actions_called) {
           ++*count_actions_called;
-        });
+        },
+        make_not_null(&box));
     Initialization::mutate_assign<simple_tags>(make_not_null(&box), 10);
     return {Parallel::AlgorithmExecution::Continue, std::nullopt};
   }
@@ -323,12 +323,12 @@ struct IncrementInt0 {
                                  ArrayParallelComponent<TestMetavariables>>,
                   "The ParallelComponent is not deduced to be the right type");
     db::mutate<Tags::CountActionsCalled>(
-        make_not_null(&box),
         [](const gsl::not_null<int*> count_actions_called) {
           ++*count_actions_called;
-        });
-    db::mutate<Tags::Int0>(make_not_null(&box),
-                           [](const gsl::not_null<int*> int0) { ++*int0; });
+        },
+        make_not_null(&box));
+    db::mutate<Tags::Int0>([](const gsl::not_null<int*> int0) { ++*int0; },
+                           make_not_null(&box));
     // [iterable_action_return_continue_next_action]
     return {Parallel::AlgorithmExecution::Continue, std::nullopt};
     // [iterable_action_return_continue_next_action]
@@ -349,10 +349,10 @@ struct RemoveInt0 {
                   "The ParallelComponent is not deduced to be the right type");
     SPECTRE_PARALLEL_REQUIRE(db::get<Tags::Int0>(box) == 11);
     db::mutate<Tags::CountActionsCalled>(
-        make_not_null(&box),
         [](const gsl::not_null<int*> count_actions_called) {
           ++*count_actions_called;
-        });
+        },
+        make_not_null(&box));
     // Run the iterable action sequence several times to ensure that
     // load-balancing has a chance to be invoked multiple times.
     if (db::get<Tags::CountActionsCalled>(box) < 150) {

--- a/tests/Unit/Parallel/Test_AlgorithmPhaseControl.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmPhaseControl.cpp
@@ -239,13 +239,14 @@ struct RecordPhaseIteration {
       const ArrayIndex& /*array_index*/, const ActionList /*meta*/,
       const ParallelComponent* const /*meta*/) {
     db::mutate<Tags::PhaseRecord>(
-        make_not_null(&box), [](const gsl::not_null<std::string*> phase_log) {
+        [](const gsl::not_null<std::string*> phase_log) {
           *phase_log += MakeString{} << "Running phase: " << Phase << "\n";
-        });
+        },
+        make_not_null(&box));
     if (Phase == Parallel::Phase::Evolve) {
       db::mutate<Tags::Step>(
-          make_not_null(&box),
-          [](const gsl::not_null<size_t*> step) { ++(*step); });
+          [](const gsl::not_null<size_t*> step) { ++(*step); },
+          make_not_null(&box));
     }
     return {Parallel::AlgorithmExecution::Continue, std::nullopt};
   }
@@ -280,17 +281,17 @@ struct TerminateAndRestart {
             Parallel::get_parallel_component<OtherComponent>(cache));
 
         db::mutate<Tags::PhaseRecord>(
-            make_not_null(&box),
             [](const gsl::not_null<std::string*> phase_log) {
               *phase_log += "Terminate and Restart\n";
-            });
+            },
+            make_not_null(&box));
         return {Parallel::AlgorithmExecution::Pause, std::nullopt};
       } else {
         db::mutate<Tags::PhaseRecord>(
-            make_not_null(&box),
             [](const gsl::not_null<std::string*> phase_log) {
               *phase_log += "Terminate Completion\n";
-            });
+            },
+            make_not_null(&box));
         return {Parallel::AlgorithmExecution::Halt, std::nullopt};
       }
     }

--- a/tests/Unit/Parallel/Test_Callback.cpp
+++ b/tests/Unit/Parallel/Test_Callback.cpp
@@ -60,9 +60,8 @@ struct IncrementValue {
   static void apply(db::DataBox<DbTagList>& box,
                     const Parallel::GlobalCache<Metavariables>& /*cache*/,
                     const ArrayIndex& /*array_index*/) {
-    db::mutate<Value>(
-        make_not_null(&box),
-        [](const gsl::not_null<double*> value) { *value += 1.0; });
+    db::mutate<Value>([](const gsl::not_null<double*> value) { *value += 1.0; },
+                      make_not_null(&box));
   }
 };
 
@@ -73,8 +72,8 @@ struct MultiplyValueByFactor {
                     const Parallel::GlobalCache<Metavariables>& /*cache*/,
                     const ArrayIndex& /*array_index*/, const double factor) {
     db::mutate<Value>(
-        make_not_null(&box),
-        [&factor](const gsl::not_null<double*> value) { *value *= factor; });
+        [&factor](const gsl::not_null<double*> value) { *value *= factor; },
+        make_not_null(&box));
   }
 };
 
@@ -89,12 +88,12 @@ struct DoubleValueOfElement0 {
       const ArrayIndex& array_index, const ActionList /*meta*/,
       const ParallelComponent* const /*meta*/) {
     db::mutate<TimesIterableActionCalled>(
-        make_not_null(&box),
-        [](const gsl::not_null<int*> counter) { ++(*counter); });
+        [](const gsl::not_null<int*> counter) { ++(*counter); },
+        make_not_null(&box));
     if (array_index == 0) {
       db::mutate<Value>(
-          make_not_null(&box),
-          [](const gsl::not_null<double*> value) { *value *= 2.0; });
+          [](const gsl::not_null<double*> value) { *value *= 2.0; },
+          make_not_null(&box));
       if (db::get<TimesIterableActionCalled>(box) < 5) {
         return {Parallel::AlgorithmExecution::Retry, std::nullopt};
       }

--- a/tests/Unit/Parallel/Test_CheckpointRestart.cpp
+++ b/tests/Unit/Parallel/Test_CheckpointRestart.cpp
@@ -80,13 +80,13 @@ struct MutateLog {
       const ArrayIndex& array_index, ActionList /*meta*/,
       const ParallelComponent* const /*meta*/) {
     db::mutate<Tags::Log>(
-        make_not_null(&box),
         [&array_index](const gsl::not_null<std::string*> log) {
           const std::string component_name =
               pretty_type::short_name<ParallelComponent>() + " " +
               std::to_string(static_cast<int>(array_index));
           log->append(component_name + " invoked action MutateLog\n");
-        });
+        },
+        make_not_null(&box));
     return {Parallel::AlgorithmExecution::Pause, std::nullopt};
   }
 };

--- a/tests/Unit/Parallel/Test_DynamicInsertion.cpp
+++ b/tests/Unit/Parallel/Test_DynamicInsertion.cpp
@@ -125,10 +125,11 @@ struct SetValue {
   static void apply(db::DataBox<DbTagList>& box,
                     const Parallel::GlobalCache<Metavariables>& /*cache*/,
                     const ArrayIndex& /*array_index*/, const double value) {
-    db::mutate<Value>(make_not_null(&box),
-                      [&value](const gsl::not_null<double*> box_value) {
-                        *box_value = value;
-                      });
+    db::mutate<Value>(
+        [&value](const gsl::not_null<double*> box_value) {
+          *box_value = value;
+        },
+        make_not_null(&box));
   }
 };
 

--- a/tests/Unit/Parallel/Test_GlobalCacheDataBox.cpp
+++ b/tests/Unit/Parallel/Test_GlobalCacheDataBox.cpp
@@ -147,10 +147,10 @@ SPECTRE_TEST_CASE("Unit.Parallel.GlobalCacheDataBox", "[Unit][Parallel]") {
   MutableGlobalCache<Metavars> mutable_cache2{tuples::TaggedTuple<>{}};
   GlobalCache<Metavars> cache2{std::move(tuple2), &mutable_cache2};
   db::mutate<Tags::GlobalCache>(
-      make_not_null(&box),
       [&cache2](const gsl::not_null<Parallel::GlobalCache<Metavars>**> t) {
         *t = std::addressof(cache2);
-      });
+      },
+      make_not_null(&box));
 
   CHECK(db::get<Tags::GlobalCache>(box) == &cache2);
   CHECK(std::array<int, 3>{{10, -3, 700}} == db::get<Tags::IntegerList>(box));

--- a/tests/Unit/Parallel/Test_InboxInserters.cpp
+++ b/tests/Unit/Parallel/Test_InboxInserters.cpp
@@ -89,8 +89,9 @@ struct SendMap {
         Parallel::get_parallel_component<ParallelComponent>(cache)[0], 1_st,
         std::make_pair(10, 23));
     db::mutate<Tags::MapCounter>(
-        make_not_null(&box),
-        [](const gsl::not_null<size_t*> map_counter) { (*map_counter)++; });
+
+        [](const gsl::not_null<size_t*> map_counter) { (*map_counter)++; },
+        make_not_null(&box));
     return {Parallel::AlgorithmExecution::Continue, std::nullopt};
   }
 };
@@ -112,8 +113,9 @@ struct ReceiveMap {
     }
 
     db::mutate<Tags::MapCounter>(
-        make_not_null(&box),
-        [](const gsl::not_null<size_t*> map_counter) { (*map_counter)++; });
+
+        [](const gsl::not_null<size_t*> map_counter) { (*map_counter)++; },
+        make_not_null(&box));
     return {Parallel::AlgorithmExecution::Continue, std::nullopt};
   }
 };
@@ -132,10 +134,11 @@ struct SendMemberInsert {
         Parallel::get_parallel_component<ParallelComponent>(cache)[0], 1_st,
         23);
     db::mutate<Tags::MemberInsertCounter>(
-        make_not_null(&box),
+
         [](const gsl::not_null<size_t*> member_insert_counter) {
           (*member_insert_counter)++;
-        });
+        },
+        make_not_null(&box));
     return {Parallel::AlgorithmExecution::Continue, std::nullopt};
   }
 };
@@ -157,10 +160,11 @@ struct ReceiveMemberInsert {
     }
 
     db::mutate<Tags::MemberInsertCounter>(
-        make_not_null(&box),
+
         [](const gsl::not_null<size_t*> member_insert_counter) {
           (*member_insert_counter)++;
-        });
+        },
+        make_not_null(&box));
     return {Parallel::AlgorithmExecution::Continue, std::nullopt};
   }
 };
@@ -179,8 +183,9 @@ struct SendValue {
         Parallel::get_parallel_component<ParallelComponent>(cache)[0], 1_st,
         23);
     db::mutate<Tags::ValueCounter>(
-        make_not_null(&box),
-        [](const gsl::not_null<size_t*> value_counter) { (*value_counter)++; });
+
+        [](const gsl::not_null<size_t*> value_counter) { (*value_counter)++; },
+        make_not_null(&box));
     return {Parallel::AlgorithmExecution::Continue, std::nullopt};
   }
 };
@@ -202,8 +207,9 @@ struct ReceiveValue {
     }
 
     db::mutate<Tags::ValueCounter>(
-        make_not_null(&box),
-        [](const gsl::not_null<size_t*> value_counter) { (*value_counter)++; });
+
+        [](const gsl::not_null<size_t*> value_counter) { (*value_counter)++; },
+        make_not_null(&box));
     return {Parallel::AlgorithmExecution::Continue, std::nullopt};
   }
 };
@@ -222,9 +228,10 @@ struct SendPushback {
         Parallel::get_parallel_component<ParallelComponent>(cache)[0], 1_st,
         23);
     db::mutate<Tags::PushbackCounter>(
-        make_not_null(&box), [](const gsl::not_null<size_t*> pushback_counter) {
+        [](const gsl::not_null<size_t*> pushback_counter) {
           (*pushback_counter)++;
-        });
+        },
+        make_not_null(&box));
     return {Parallel::AlgorithmExecution::Continue, std::nullopt};
   }
 };
@@ -246,9 +253,10 @@ struct ReceivePushback {
     }
 
     db::mutate<Tags::PushbackCounter>(
-        make_not_null(&box), [](const gsl::not_null<size_t*> pushback_counter) {
+        [](const gsl::not_null<size_t*> pushback_counter) {
           (*pushback_counter)++;
-        });
+        },
+        make_not_null(&box));
     return {Parallel::AlgorithmExecution::Continue, std::nullopt};
   }
 };

--- a/tests/Unit/Parallel/Test_PhaseChangeMain.cpp
+++ b/tests/Unit/Parallel/Test_PhaseChangeMain.cpp
@@ -91,8 +91,8 @@ struct IncrementStep {
       const ArrayIndex& /*array_index*/, ActionList /*meta*/,
       const ParallelComponent* const /*meta*/) {
     db::mutate<StepNumber>(
-        make_not_null(&box),
-        [](const gsl::not_null<size_t*> step_number) { ++(*step_number); });
+        [](const gsl::not_null<size_t*> step_number) { ++(*step_number); },
+        make_not_null(&box));
     SPECTRE_PARALLEL_REQUIRE(db::get<StepNumber>(box) < 31);
     return {Parallel::AlgorithmExecution::Continue, std::nullopt};
   }

--- a/tests/Unit/ParallelAlgorithms/Actions/Test_Goto.cpp
+++ b/tests/Unit/ParallelAlgorithms/Actions/Test_Goto.cpp
@@ -49,8 +49,8 @@ struct Increment {
       const ArrayIndex& /*array_index*/, const ActionList /*meta*/,
       const ParallelComponent* const /*meta*/) {
     db::mutate<Counter>(
-        make_not_null(&box),
-        [](const gsl::not_null<size_t*> counter) { (*counter)++; });
+        [](const gsl::not_null<size_t*> counter) { (*counter)++; },
+        make_not_null(&box));
     return {Parallel::AlgorithmExecution::Continue, std::nullopt};
   }
 };

--- a/tests/Unit/ParallelAlgorithms/EventsAndTriggers/Test_EventsAndTriggers.cpp
+++ b/tests/Unit/ParallelAlgorithms/EventsAndTriggers/Test_EventsAndTriggers.cpp
@@ -193,24 +193,27 @@ void test_slab_limits() {
   auto& box =
       ActionTesting::get_databox<my_component>(make_not_null(&runner), 0);
 
-  db::mutate<Tags::TimeStepId>(make_not_null(&box),
-                               [&](const gsl::not_null<TimeStepId*> id) {
-                                 *id = TimeStepId(true, 0, center);
-                               });
+  db::mutate<Tags::TimeStepId>(
+      [&](const gsl::not_null<TimeStepId*> id) {
+        *id = TimeStepId(true, 0, center);
+      },
+      make_not_null(&box));
   ActionTesting::next_action<my_component>(make_not_null(&runner), 0);
   CHECK(not ActionTesting::get_terminate<my_component>(runner, 0));
 
   db::mutate<Tags::TimeStepId>(
-      make_not_null(&box), [&](const gsl::not_null<TimeStepId*> id) {
+      [&](const gsl::not_null<TimeStepId*> id) {
         *id = TimeStepId(true, 0, start, 1, slab.duration(), start.value());
-      });
+      },
+      make_not_null(&box));
   ActionTesting::next_action<my_component>(make_not_null(&runner), 0);
   CHECK(not ActionTesting::get_terminate<my_component>(runner, 0));
 
-  db::mutate<Tags::TimeStepId>(make_not_null(&box),
-                               [&](const gsl::not_null<TimeStepId*> id) {
-                                 *id = TimeStepId(true, 0, start);
-                               });
+  db::mutate<Tags::TimeStepId>(
+      [&](const gsl::not_null<TimeStepId*> id) {
+        *id = TimeStepId(true, 0, start);
+      },
+      make_not_null(&box));
   ActionTesting::next_action<my_component>(make_not_null(&runner), 0);
   CHECK(ActionTesting::get_terminate<my_component>(runner, 0));
 }

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_AddTemporalIdsToInterpolationTarget.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_AddTemporalIdsToInterpolationTarget.cpp
@@ -73,13 +73,13 @@ struct MockSendPointsToInterpolator {
     // this function was called.  This isn't the usual usage of
     // IndicesOfFilledInterpPoints.
     db::mutate<::intrp::Tags::IndicesOfFilledInterpPoints<TemporalId>>(
-        make_not_null(&box),
         [&temporal_id](
             const gsl::not_null<
                 std::unordered_map<TemporalId, std::unordered_set<size_t>>*>
                 indices) {
           (*indices)[temporal_id].insert((*indices)[temporal_id].size() + 1);
-        });
+        },
+        make_not_null(&box));
   }
 };
 

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_Interpolate.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_Interpolate.cpp
@@ -296,8 +296,8 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.InterpolateEvent",
       box, cache, array_index, std::add_pointer_t<elem_component>{}));
 
   // Update time in box and functions of time
-  db::mutate<::Tags::Time>(make_not_null(&box),
-                           [](gsl::not_null<double*> time) { *time = 1.0; });
+  db::mutate<::Tags::Time>([](gsl::not_null<double*> time) { *time = 1.0; },
+                           make_not_null(&box));
   Parallel::mutate<domain::Tags::FunctionsOfTime,
                    control_system::UpdateFunctionOfTime>(
       cache, name, initial_expr_time, DataVector{1, 0.0}, observation_time);

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolationTargetReceiveVars.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolationTargetReceiveVars.cpp
@@ -99,13 +99,13 @@ struct MockSendPointsToInterpolator {
     // whether this function was called.  This isn't the usual usage
     // of IndicesOfFilledInterpPoints; this is done only for the test.
     db::mutate<intrp::Tags::IndicesOfFilledInterpPoints<temporal_id_type>>(
-        make_not_null(&box),
         [&temporal_id](
             const gsl::not_null<std::unordered_map<temporal_id_type,
                                                    std::unordered_set<size_t>>*>
                 indices) {
           (*indices)[temporal_id].insert((*indices)[temporal_id].size() + 1);
-        });
+        },
+        make_not_null(&box));
   }
 };
 
@@ -153,10 +153,10 @@ struct MockCleanUpInterpolator {
     // this function was called.  This isn't the usual usage of
     // NumberOfElements.
     db::mutate<intrp::Tags::NumberOfElements>(
-        make_not_null(&box),
         [](const gsl::not_null<size_t*> number_of_elements) {
           ++(*number_of_elements);
-        });
+        },
+        make_not_null(&box));
   }
 };
 

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolatorReceiveAndDumpVolumeData.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolatorReceiveAndDumpVolumeData.cpp
@@ -146,10 +146,10 @@ struct ClearVolumeVarsInfo {
                     const Parallel::GlobalCache<Metavariables>& /*cache*/,
                     const ArrayIndex& /*array_index*/) {
     db::mutate<intrp::Tags::VolumeVarsInfo<Metavariables, TemporalIdTag>>(
-        make_not_null(&box),
         [](const gsl::not_null<typename intrp::Tags::VolumeVarsInfo<
                Metavariables, TemporalIdTag>::type*>
-               container) { container->clear(); });
+               container) { container->clear(); },
+        make_not_null(&box));
   }
 };
 
@@ -168,7 +168,6 @@ struct AddToTemporalIdsWhenDataHasBeenInterpolated {
       const ArrayIndex& /*array_index*/,
       const typename InterpolationTargetTag::temporal_id::type& temporal_id) {
     db::mutate<intrp::Tags::InterpolatedVarsHolders<Metavariables>>(
-        make_not_null(&box),
         [&temporal_id](
             const gsl::not_null<typename intrp::Tags::InterpolatedVarsHolders<
                 Metavariables>::type*>
@@ -177,7 +176,8 @@ struct AddToTemporalIdsWhenDataHasBeenInterpolated {
               *holders)
               .temporal_ids_when_data_has_been_interpolated.push_back(
                   temporal_id);
-        });
+        },
+        make_not_null(&box));
   }
 };
 
@@ -227,11 +227,11 @@ struct MockInterpolationTargetReceiveVars {
     Slab slab(0.0, 1.0);
     TimeStepId strange_temporal_id(true, 0, Time(slab, Rational(111, 135)));
     db::mutate<intrp::Tags::TemporalIds<TemporalId>>(
-        make_not_null(&box),
         [&strange_temporal_id](
             const gsl::not_null<std::deque<TemporalId>*> temporal_ids) {
           temporal_ids->push_back(strange_temporal_id);
-        });
+        },
+        make_not_null(&box));
   }
 };
 

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Actions/Test_MakeIdentityIfSkipped.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Actions/Test_MakeIdentityIfSkipped.cpp
@@ -57,8 +57,8 @@ struct RunIfSkipped {
       const ArrayIndex& /*array_index*/, const ActionList /*meta*/,
       const ParallelComponent* const /*meta*/) {
     db::mutate<CheckRunIfSkippedTag>(
-        make_not_null(&box),
-        [](const gsl::not_null<bool*> flag) { *flag = true; });
+        [](const gsl::not_null<bool*> flag) { *flag = true; },
+        make_not_null(&box));
     return {Parallel::AlgorithmExecution::Continue, std::nullopt};
   }
 };

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Schwarz/Test_Tags.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Schwarz/Test_Tags.cpp
@@ -64,9 +64,10 @@ SPECTRE_TEST_CASE("Unit.ParallelSchwarz.Tags",
                   .at(overlap_id)) == DataVector(3, 0.));
     // Test mutating the individual tags
     db::mutate<Tags::Overlaps<ScalarFieldTag<0>, 1, DummyOptionsGroup>>(
-        make_not_null(&box), [&overlap_id](const auto scalar0_overlaps) {
+        [&overlap_id](const auto scalar0_overlaps) {
           get(scalar0_overlaps->at(overlap_id)) = 1.;
-        });
+        },
+        make_not_null(&box));
     CHECK(get(get<Tags::Overlaps<ScalarFieldTag<0>, 1, DummyOptionsGroup>>(box)
                   .at(overlap_id)) == DataVector(3, 1.));
     CHECK(

--- a/tests/Unit/ParallelAlgorithms/NonlinearSolver/NewtonRaphson/Test_NewtonRaphsonAlgorithm.cpp
+++ b/tests/Unit/ParallelAlgorithms/NonlinearSolver/NewtonRaphson/Test_NewtonRaphsonAlgorithm.cpp
@@ -47,9 +47,8 @@ struct ApplyNonlinearOperator {
       const int /*array_index*/, const ActionList /*meta*/,
       const ParallelComponent* const /*component*/) {
     db::mutate<::NonlinearSolver::Tags::OperatorAppliedTo<OperandTag>>(
-        make_not_null(&box),
         [](const auto Ax, const auto& x) { *Ax = cube(x) - x; },
-        get<OperandTag>(box));
+        make_not_null(&box), get<OperandTag>(box));
     return {Parallel::AlgorithmExecution::Continue, std::nullopt};
   }
 };
@@ -65,11 +64,10 @@ struct ApplyLinearizedOperator {
       const int /*array_index*/, const ActionList /*meta*/,
       const ParallelComponent* const /*component*/) {
     db::mutate<LinearSolver::Tags::OperatorAppliedTo<OperandTag>>(
-        make_not_null(&box),
         [](const auto Ap, const auto& dx, const auto& x) {
           *Ap = (3. * square(x) - 1) * dx;
         },
-        get<OperandTag>(box), get<FieldTag>(box));
+        make_not_null(&box), get<OperandTag>(box), get<FieldTag>(box));
     return {Parallel::AlgorithmExecution::Continue, std::nullopt};
   }
 };

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Test_Tags.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Test_Tags.cpp
@@ -70,9 +70,10 @@ SPECTRE_TEST_CASE("Unit.AnalyticSolutions.Tags", "[Unit][PointwiseFunctions]") {
     CHECK_ITERABLE_APPROX(get(get<Tags::Error<FieldTag>>(box).value()),
                           expected_error);
     db::mutate<::Tags::Variables<tmpl::list<FieldTag>>>(
-        make_not_null(&box), [](const auto vars_ptr) {
+        [](const auto vars_ptr) {
           *vars_ptr = Variables<tmpl::list<FieldTag>>{4, 4.};
-        });
+        },
+        make_not_null(&box));
     const DataVector new_expected_error{2., 0., -2., -4.};
     CHECK_ITERABLE_APPROX(get(get<Tags::Analytic<FieldTag>>(box).value()),
                           expected);

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/WaveEquation/Test_SemidiscretizedDg.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/WaveEquation/Test_SemidiscretizedDg.cpp
@@ -226,13 +226,13 @@ std::pair<tnsr::I<DataVector, 1>, EvolvedVariables> evaluate_rhs(
             tmpl::append<component::simple_tags, component::compute_tags>>(
             make_not_null(&runner), id);
         db::mutate<system::variables_tag>(
-            make_not_null(&box),
             [&solution, &time](
                 const gsl::not_null<EvolvedVariables*> vars,
                 const tnsr::I<DataVector, 1, Frame::Inertial>& coords) {
               vars->assign_subset(solution.variables(
                   coords, time, system::variables_tag::tags_list{}));
             },
+            make_not_null(&box),
             db::get<domain::Tags::Coordinates<1, Frame::Inertial>>(box));
       };
 

--- a/tests/Unit/Time/Actions/Test_ChangeSlabSize.cpp
+++ b/tests/Unit/Time/Actions/Test_ChangeSlabSize.cpp
@@ -106,7 +106,6 @@ SPECTRE_TEST_CASE("Unit.Time.Actions.ChangeSlabSize", "[Unit][Time][Actions]") {
 
     db::mutate<Tags::TimeStepId, Tags::Next<Tags::TimeStepId>, Tags::TimeStep,
                Tags::Next<Tags::TimeStep>, Tags::AdaptiveSteppingDiagnostics>(
-        make_not_null(&box),
         [&get_step, &start_time, &time_runs_forward](
             const gsl::not_null<TimeStepId*> id,
             const gsl::not_null<TimeStepId*> next_id,
@@ -120,7 +119,7 @@ SPECTRE_TEST_CASE("Unit.Time.Actions.ChangeSlabSize", "[Unit][Time][Actions]") {
           *next_id = stepper.next_time_id(*id, *step);
           *diags = AdaptiveSteppingDiagnostics{1, 2, 3, 4, 5};
         },
-        db::get<Tags::TimeStepper<>>(box));
+        make_not_null(&box), db::get<Tags::TimeStepper<>>(box));
 
     using ExpectedMessages =
         ChangeSlabSize_detail::NumberOfExpectedMessagesInbox;
@@ -188,7 +187,6 @@ SPECTRE_TEST_CASE("Unit.Time.Actions.ChangeSlabSize", "[Unit][Time][Actions]") {
     // Check interior of slab
     {
       db::mutate<Tags::TimeStepId, Tags::Next<Tags::TimeStepId>>(
-          make_not_null(&box),
           [&start_time, &time_runs_forward](
               const gsl::not_null<TimeStepId*> id,
               const gsl::not_null<TimeStepId*> next_id, const TimeDelta& step,
@@ -196,7 +194,8 @@ SPECTRE_TEST_CASE("Unit.Time.Actions.ChangeSlabSize", "[Unit][Time][Actions]") {
             *id = TimeStepId(time_runs_forward, 3, start_time + step);
             *next_id = stepper.next_time_id(*id, step);
           },
-          db::get<Tags::TimeStep>(box), db::get<Tags::TimeStepper<>>(box));
+          make_not_null(&box), db::get<Tags::TimeStep>(box),
+          db::get<Tags::TimeStepper<>>(box));
       const TimeStepId initial_id = db::get<Tags::TimeStepId>(box);
       get<ExpectedMessages>(inboxes)[3].insert(ExpectedMessages::NoData{});
       get<ExpectedMessages>(inboxes)[4].insert(ExpectedMessages::NoData{});
@@ -217,7 +216,6 @@ SPECTRE_TEST_CASE("Unit.Time.Actions.ChangeSlabSize", "[Unit][Time][Actions]") {
     // Check at a substep
     {
       db::mutate<Tags::TimeStepId, Tags::Next<Tags::TimeStepId>>(
-          make_not_null(&box),
           [](const gsl::not_null<TimeStepId*> id,
              const gsl::not_null<TimeStepId*> next_id, const TimeDelta& step,
              const TimeStepper& stepper) {
@@ -229,7 +227,8 @@ SPECTRE_TEST_CASE("Unit.Time.Actions.ChangeSlabSize", "[Unit][Time][Actions]") {
               *next_id = stepper.next_time_id(*id, step);
             }
           },
-          db::get<Tags::TimeStep>(box), db::get<Tags::TimeStepper<>>(box));
+          make_not_null(&box), db::get<Tags::TimeStep>(box),
+          db::get<Tags::TimeStepper<>>(box));
       const TimeStepId initial_id = db::get<Tags::TimeStepId>(box);
       get<ExpectedMessages>(inboxes)[3].insert(ExpectedMessages::NoData{});
       get<ExpectedMessages>(inboxes)[4].insert(ExpectedMessages::NoData{});

--- a/tests/Unit/Time/Actions/Test_SelfStartActions.cpp
+++ b/tests/Unit/Time/Actions/Test_SelfStartActions.cpp
@@ -79,12 +79,9 @@ struct ComputeTimeDerivative {
     using argument_tag = tmpl::conditional_t<
         Metavariables::system::has_primitive_and_conservative_vars,
         PrimitiveVar, Var>;
-    db::mutate<Tags::dt<Var>>(
-        make_not_null(&box),
-        [](const gsl::not_null<double*> dt_var, const double var) {
-          *dt_var = exp(var);
-        },
-        db::get<argument_tag>(box));
+    db::mutate<Tags::dt<Var>>([](const gsl::not_null<double*> dt_var,
+                                 const double var) { *dt_var = exp(var); },
+                              make_not_null(&box), db::get<argument_tag>(box));
     return {Parallel::AlgorithmExecution::Continue, std::nullopt};
   }
 };

--- a/tests/Unit/Time/Actions/Test_UpdateU.cpp
+++ b/tests/Unit/Time/Actions/Test_UpdateU.cpp
@@ -111,7 +111,6 @@ void test_integration() {
 
   for (size_t substep = 0; substep < 3; ++substep) {
     db::mutate<history_tag, alternative_history_tag>(
-        make_not_null(&box),
         [&rhs, &substep, &substep_times, &time_step](
             const gsl::not_null<typename history_tag::type*> history,
             const gsl::not_null<typename alternative_history_tag::type*>
@@ -123,7 +122,7 @@ void test_integration() {
               vars, rhs(time, vars));
           *alternative_history = *history;
         },
-        db::get<Var>(box));
+        make_not_null(&box), db::get<Var>(box));
 
     update_u<System>(make_not_null(&box));
     CHECK(db::get<Var>(box) == approx(gsl::at(expected_values, substep)));
@@ -189,7 +188,6 @@ void test_stepper_error() {
   const auto do_substep = [&box, &substep_offsets, &time_step](
                               const Time& step_start, const size_t substep) {
     db::mutate<history_tag>(
-        make_not_null(&box),
         [&step_start, &substep, &substep_offsets, &time_step](
             const gsl::not_null<typename history_tag::type*> history,
             const double vars) {
@@ -198,7 +196,7 @@ void test_stepper_error() {
               TimeStepId(true, 0, step_start, substep, time_step, time.value()),
               vars, vars);
         },
-        db::get<variables_tag>(box));
+        make_not_null(&box), db::get<variables_tag>(box));
 
     update_u<SingleVariableSystem>(make_not_null(&box));
   };

--- a/tests/Unit/Time/StepChoosers/Test_ErrorControl.cpp
+++ b/tests/Unit/Time/StepChoosers/Test_ErrorControl.cpp
@@ -128,9 +128,10 @@ std::pair<double, bool> get_suggestion(
         error_control_base->desired_step(previous_step, box));
 
   db::mutate<Tags::StepperErrorUpdated>(
-      make_not_null(&box), [](const gsl::not_null<bool*> stepper_updated) {
+      [](const gsl::not_null<bool*> stepper_updated) {
         *stepper_updated = true;
-      });
+      },
+      make_not_null(&box));
   const std::pair<double, bool> result = error_control(
       history, error, previous_error, true, time_stepper, previous_step);
   CHECK(error_control_base->desired_step(previous_step, box) == result);
@@ -281,7 +282,6 @@ SPECTRE_TEST_CASE("Unit.Time.StepChoosers.ErrorControl", "[Unit][Time]") {
                    db::AddComputeTags<
                        Tags::IsUsingTimeSteppingErrorControlCompute<true>>>();
     db::mutate<Tags::StepChoosers>(
-        make_not_null(&box),
         [](const gsl::not_null<Tags::StepChoosers::type*> choosers) {
           *choosers =
               TestHelpers::test_creation<typename Tags::StepChoosers::type,
@@ -295,10 +295,10 @@ SPECTRE_TEST_CASE("Unit.Time.StepChoosers.ErrorControl", "[Unit][Time]") {
                   "- Increase:\n"
                   "    Factor: 2\n"
                   "- Constant: 0.5");
-        });
+        },
+        make_not_null(&box));
     CHECK(db::get<Tags::IsUsingTimeSteppingErrorControl>(box));
     db::mutate<Tags::StepChoosers>(
-        make_not_null(&box),
         [](const gsl::not_null<Tags::StepChoosers::type*> choosers) {
           *choosers =
               TestHelpers::test_creation<typename Tags::StepChoosers::type,
@@ -307,15 +307,16 @@ SPECTRE_TEST_CASE("Unit.Time.StepChoosers.ErrorControl", "[Unit][Time]") {
                   "- Increase:\n"
                   "    Factor: 2\n"
                   "- Constant: 0.5");
-        });
+        },
+        make_not_null(&box));
     CHECK_FALSE(db::get<Tags::IsUsingTimeSteppingErrorControl>(box));
     db::mutate<Tags::StepChoosers>(
-        make_not_null(&box),
         [](const gsl::not_null<Tags::StepChoosers::type*> choosers) {
           *choosers =
               TestHelpers::test_creation<typename Tags::StepChoosers::type,
                                          Metavariables<true>>("");
-        });
+        },
+        make_not_null(&box));
     CHECK_FALSE(db::get<Tags::IsUsingTimeSteppingErrorControl>(box));
   }
   {
@@ -325,7 +326,6 @@ SPECTRE_TEST_CASE("Unit.Time.StepChoosers.ErrorControl", "[Unit][Time]") {
                    db::AddComputeTags<
                        Tags::IsUsingTimeSteppingErrorControlCompute<false>>>();
     db::mutate<Tags::EventsAndTriggers>(
-        make_not_null(&box),
         [](const gsl::not_null<Tags::EventsAndTriggers::type*> events) {
           *events = TestHelpers::test_creation<Tags::EventsAndTriggers::type,
                                                Metavariables<true>>(
@@ -347,10 +347,10 @@ SPECTRE_TEST_CASE("Unit.Time.StepChoosers.ErrorControl", "[Unit][Time]") {
               "              MaxFactor: 2.1\n"
               "              MinFactor: 0.5\n"
               "          - Constant: 0.5");
-        });
+        },
+        make_not_null(&box));
     CHECK(db::get<Tags::IsUsingTimeSteppingErrorControl>(box));
     db::mutate<Tags::EventsAndTriggers>(
-        make_not_null(&box),
         [](const gsl::not_null<Tags::EventsAndTriggers::type*> events) {
           *events = TestHelpers::test_creation<Tags::EventsAndTriggers::type,
                                                Metavariables<true>>(
@@ -366,10 +366,10 @@ SPECTRE_TEST_CASE("Unit.Time.StepChoosers.ErrorControl", "[Unit][Time]") {
               "          - Increase:\n"
               "              Factor: 2\n"
               "          - Constant: 0.5");
-        });
+        },
+        make_not_null(&box));
     CHECK_FALSE(db::get<Tags::IsUsingTimeSteppingErrorControl>(box));
     db::mutate<Tags::EventsAndTriggers>(
-        make_not_null(&box),
         [](const gsl::not_null<Tags::EventsAndTriggers::type*> events) {
           *events = TestHelpers::test_creation<Tags::EventsAndTriggers::type,
                                                Metavariables<true>>(
@@ -379,14 +379,15 @@ SPECTRE_TEST_CASE("Unit.Time.StepChoosers.ErrorControl", "[Unit][Time]") {
               "- Trigger: Always\n"
               "  Events:\n"
               "    - Completion");
-        });
+        },
+        make_not_null(&box));
     CHECK_FALSE(db::get<Tags::IsUsingTimeSteppingErrorControl>(box));
     db::mutate<Tags::EventsAndTriggers>(
-        make_not_null(&box),
         [](const gsl::not_null<Tags::EventsAndTriggers::type*> events) {
           *events = TestHelpers::test_creation<Tags::EventsAndTriggers::type,
                                                Metavariables<true>>("");
-        });
+        },
+        make_not_null(&box));
     CHECK_FALSE(db::get<Tags::IsUsingTimeSteppingErrorControl>(box));
   }
 }

--- a/tests/Unit/Time/Triggers/Test_Slabs.cpp
+++ b/tests/Unit/Time/Triggers/Test_Slabs.cpp
@@ -56,16 +56,18 @@ SPECTRE_TEST_CASE("Unit.Time.Triggers.Slabs", "[Unit][Time]") {
        {false, false, false, true, false, false, true, false, true, false}) {
     CHECK(sent_trigger->is_triggered(box) == expected);
     db::mutate<Tags::TimeStepId>(
-        make_not_null(&box), [&slab](const gsl::not_null<TimeStepId*> time_id) {
+        [&slab](const gsl::not_null<TimeStepId*> time_id) {
           *time_id = TimeStepId(true, time_id->slab_number(),
                                 time_id->step_time(), 1, slab.duration(),
                                 time_id->step_time().value());
-        });
+        },
+        make_not_null(&box));
     CHECK_FALSE(sent_trigger->is_triggered(box));
     db::mutate<Tags::TimeStepId>(
-        make_not_null(&box), [](const gsl::not_null<TimeStepId*> time_id) {
+        [](const gsl::not_null<TimeStepId*> time_id) {
           *time_id = TimeStepId(true, time_id->slab_number() + 1,
                                 time_id->step_time());
-        });
+        },
+        make_not_null(&box));
   }
 }


### PR DESCRIPTION
## Proposed changes

Make the order of arguments the same. Choosing the same order as `std::apply`.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
