### PR TITLE
Fix element_name Documentation

### DIFF
--- a/src/IO/H5/TensorData.hpp
+++ b/src/IO/H5/TensorData.hpp
@@ -68,7 +68,7 @@ struct ElementVolumeData {
   void pup(PUP::er& p);
   /// Name of the grid (should be human-readable). For standard volume data this
   /// name must be the string representation of an ElementId, such as
-  /// [B0,(I1L0,I0L0,I2L3)]. Code that reads the volume data may rely on this
+  /// [B0,(L0I1,L0I0,L3I2)]. Code that reads the volume data may rely on this
   /// pattern to reconstruct the ElementId.
   std::string element_name{};
   /// All tensor components on the grid


### PR DESCRIPTION
## Proposed changes

Fix to the documentation to element_name. A string representation of an ElementId should specify the refinement then the index, rather than the index then the refinement.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
