### PR TITLE
Support segments in GenerateXdmf

### DIFF
--- a/src/IO/H5/Python/ExtractDatFromH5.py
+++ b/src/IO/H5/Python/ExtractDatFromH5.py
@@ -11,6 +11,7 @@ import click
 import h5py
 import numpy as np
 import pandas as pd
+import rich
 
 from spectre.Visualization.ReadH5 import available_subfiles
 
@@ -48,11 +49,6 @@ def write_dat_data(dat_path, h5_filename, out_dir, precision):
     )
 
 
-def get_all_dat_files(filename):
-    with h5py.File(filename, "r") as h5file:
-        return available_subfiles(h5file, extension=".dat")
-
-
 def extract_dat_files(
     filename,
     out_dir,
@@ -69,14 +65,16 @@ def extract_dat_files(
     group structure inside the HDF5 file.
     """
     if list:
-        print_str = "\n ".join(get_all_dat_files(filename))
-        print(f"Dat files within '{filename}':\n {print_str}")
+        import rich.columns
+
+        subfiles = available_subfiles(filename, extension=".dat")
+        rich.print(rich.columns.Columns(subfiles))
         return
 
     if subfiles:
         all_dat_files = subfiles
     else:
-        all_dat_files = get_all_dat_files(filename)
+        all_dat_files = available_subfiles(filename, extension=".dat")
 
     if out_dir:
         if not os.path.exists(out_dir):

--- a/src/Visualization/Python/GenerateXdmf.py
+++ b/src/Visualization/Python/GenerateXdmf.py
@@ -3,9 +3,17 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-import glob
+"""Tools to generate XDMF files that ParaView and VisIt can read.
+
+The XDMF file format is documented here:
+https://xdmf.org/index.php/XDMF_Model_and_Format
+"""
+
 import logging
+import os
 import sys
+import xml.etree.ElementTree as ET
+from typing import Optional
 
 import click
 import h5py
@@ -14,19 +22,283 @@ import rich
 
 from spectre.Visualization.ReadH5 import available_subfiles
 
+logger = logging.getLogger(__name__)
+
+
+def _list_tensor_components(observation):
+    components = list(observation.keys())
+    components.remove("connectivity")
+    if "pole_connectivity" in components:
+        components.remove("pole_connectivity")
+    components.remove("total_extents")
+    components.remove("grid_names")
+    components.remove("bases")
+    components.remove("quadratures")
+    if "domain" in components:
+        components.remove("domain")
+    if "functions_of_time" in components:
+        components.remove("functions_of_time")
+    return components
+
+
+def _xmf_dtype(dtype: type):
+    assert dtype in [
+        np.dtype("float32"),
+        np.dtype("float64"),
+    ], f"Data type must be either a 32-bit or 64-bit float but got {dtype}."
+    return "Double" if dtype == np.dtype("float64") else "Float"
+
+
+def _xmf_topology(
+    observation, topology_type: str, connectivity_name: str, grid_path: str
+) -> ET.Element:
+    num_vertices = {
+        "Hexahedron": 8,
+        "Quadrilateral": 4,
+        "Triangle": 3,
+    }[topology_type]
+    num_cells = len(observation[connectivity_name]) // num_vertices
+    xmf_topology = ET.Element(
+        "Topology",
+        TopologyType=topology_type,
+        NumberOfElements=str(num_cells),
+    )
+    xmf_data_item = ET.SubElement(
+        xmf_topology,
+        "DataItem",
+        Dimensions=f"{num_cells} {num_vertices}",
+        NumberType="Int",
+        Format="HDF5",
+    )
+    xmf_data_item.text = os.path.join(grid_path, connectivity_name)
+    return xmf_topology
+
+
+def _xmf_geometry(
+    observation, coordinates: str, dim: int, num_points: int, grid_path: str
+) -> ET.Element:
+    # The X_Y_Z and X_Y means that the x, y, and z coordinates are stored in
+    # separate datasets, rather than something like interleaved.
+    xmf_geometry = ET.Element(
+        "Geometry", GeometryType="X_Y_Z" if dim == 3 else "X_Y"
+    )
+    for xyz in "xyz"[:dim]:
+        component_name = coordinates + "_" + xyz
+        xmf_data_item = ET.SubElement(
+            xmf_geometry,
+            "DataItem",
+            Dimensions=str(num_points),
+            NumberType=_xmf_dtype(observation[component_name].dtype),
+            Precision="8",
+            Format="HDF5",
+        )
+        xmf_data_item.text = os.path.join(grid_path, component_name)
+    return xmf_geometry
+
+
+def _xmf_scalar(
+    observation, name: str, num_points: int, grid_path: str
+) -> ET.Element:
+    xmf_attribute = ET.Element(
+        "Attribute",
+        Name=name,
+        AttributeType="Scalar",
+        Center="Node",
+    )
+    xmf_data_item = ET.SubElement(
+        xmf_attribute,
+        "DataItem",
+        Dimensions=str(num_points),
+        NumberType=_xmf_dtype(observation[name].dtype),
+        Precision="8",
+        Format="HDF5",
+    )
+    xmf_data_item.text = os.path.join(grid_path, name)
+    return xmf_attribute
+
+
+def _xmf_vector(
+    observation, name: str, dim: int, num_points: int, grid_path: str
+) -> ET.Element:
+    # Write a vector using the three components that make up the vector (i.e.
+    # v_x, v_y, v_z)
+    xmf_attribute = ET.Element(
+        "Attribute",
+        Name=name,
+        AttributeType="Vector",
+        Center="Node",
+    )
+    xmf_data_item = ET.SubElement(
+        xmf_attribute,
+        "DataItem",
+        Dimensions=f" {num_points} 3",
+        ItemType="Function",
+        # In 2d we still need a 3d dataset to have a vector because ParaView
+        # only supports 3d vectors. We deal with this by making the z-component
+        # all zeros.
+        Function=("JOIN($0,$1,$2)" if dim == 3 else "JOIN($0,$1, 0 * $1)"),
+    )
+    for xyz in "xyz"[:dim]:
+        component_name = name + "_" + xyz
+        xmf_data_item = ET.SubElement(
+            xmf_attribute,
+            "DataItem",
+            Dimensions=str(num_points),
+            NumberType=_xmf_dtype(observation[component_name].dtype),
+            Precision="8",
+            Format="HDF5",
+        )
+        xmf_data_item.text = os.path.join(grid_path, component_name)
+    return xmf_attribute
+
+
+def _xmf_grid(
+    observation,
+    topo_dim: int,
+    filename: str,
+    subfile_name: str,
+    temporal_id: str,
+    coordinates: str,
+    filling_poles: bool = False,
+) -> ET.Element:
+    # Make sure the coordinates are found in the file. We assume there should
+    # always be an x-coordinate.
+    assert coordinates + "_x" in observation, (
+        f"No '{coordinates}_x' dataset found in '{filename}'. Existing"
+        " datasets with 'Coordinates' in their name: "
+        + str(
+            [
+                dataset_name[:-2]
+                for dataset_name in observation
+                if "Coordinates" in dataset_name and dataset_name.endswith("_x")
+            ]
+        )
+    )
+
+    # Determine dimension of embedding space by counting the number of
+    # coordinate components
+    dim = sum((coordinates + "_" + xyz) in observation for xyz in "xyz")
+
+    if filling_poles:
+        # Filling poles is currently supported for a 2D surface embedded in 3D
+        assert "pole_connectivity" in observation and topo_dim == 2 and dim == 3
+
+    xmf_grid = ET.Element("Grid", Name=filename, GridType="Uniform")
+
+    # Extents in the logical directions for each element in the dataset. The
+    # extents are stored in one long list with the dimension varying fast and
+    # the element index varying slow.
+    total_extents = observation["total_extents"]
+    num_elements = len(total_extents) // topo_dim
+    extents = np.reshape(total_extents, (num_elements, topo_dim), order="C")
+    num_points = np.sum(np.prod(extents, axis=1))
+
+    # Configure grid location in the H5 file
+    grid_path = filename + ":/" + subfile_name + "/" + temporal_id + "/"
+
+    # Write topology
+    if topo_dim == 2 and dim == 3:
+        # 2D surface embedded in 3D space
+        if filling_poles:
+            # Cover poles with triangles
+            xmf_topology = _xmf_topology(
+                observation,
+                topology_type="Triangle",
+                connectivity_name="pole_connectivity",
+                grid_path=grid_path,
+            )
+        else:
+            # Cover 2D surface
+            xmf_topology = _xmf_topology(
+                observation,
+                topology_type="Quadrilateral",
+                connectivity_name="connectivity",
+                grid_path=grid_path,
+            )
+    else:
+        # Cover volume
+        xmf_topology = _xmf_topology(
+            observation,
+            topology_type={3: "Hexahedron", 2: "Quadrilateral"}[topo_dim],
+            connectivity_name="connectivity",
+            grid_path=grid_path,
+        )
+    xmf_grid.append(xmf_topology)
+
+    # Write geometry
+    xmf_grid.append(
+        _xmf_geometry(
+            observation,
+            coordinates=coordinates,
+            dim=dim,
+            num_points=num_points,
+            grid_path=grid_path,
+        )
+    )
+
+    # Write the tensors that are to be visualized
+    for component in _list_tensor_components(observation):
+        if component in [coordinates + "_" + xyz for xyz in "xyz"[:dim]]:
+            # Skip coordinates
+            continue
+        elif component.endswith("_x"):
+            # Vectors
+            xmf_grid.append(
+                _xmf_vector(
+                    observation,
+                    name=component[:-2],
+                    dim=dim,
+                    num_points=num_points,
+                    grid_path=grid_path,
+                )
+            )
+        elif component.endswith("_y") or component.endswith("_z"):
+            # Skip other vector components since they're processed above
+            continue
+        else:
+            # Treat everything else as scalars
+            xmf_grid.append(
+                _xmf_scalar(
+                    observation,
+                    name=component,
+                    num_points=num_points,
+                    grid_path=grid_path,
+                )
+            )
+    return xmf_grid
+
 
 def generate_xdmf(
-    h5files, output, subfile_name, start_time, stop_time, stride, coordinates
+    h5files,
+    output: str,
+    subfile_name: str,
+    start_time: Optional[float] = None,
+    stop_time: Optional[float] = None,
+    stride: int = 1,
+    coordinates: str = "InertialCoordinates",
 ):
     """Generate an XDMF file for ParaView and VisIt
 
-    Read volume data from the 'H5FILES' and generate an XDMF file. The XDMF
-    file points into the 'H5FILES' files so ParaView and VisIt can load the
-    volume data. To process multiple files suffixed with the node number,
-    specify a glob like 'VolumeData*.h5'.
+    Read volume data from the 'H5FILES' and generate an XDMF file. The XDMF file
+    points into the 'H5FILES' files so ParaView and VisIt can load the volume
+    data. To process multiple files suffixed with the node number and from
+    multiple segments specify a glob like 'Segment*/VolumeData*.h5'.
 
     To load the XDMF file in ParaView you must choose the 'Xdmf Reader', NOT
     'Xdmf3 Reader'.
+
+    \f
+    Arguments:
+      h5files: List of H5 volume data files.
+      output: Output filename. A '.xmf' extension is added if not present.
+      subfile_name: Volume data subfile in the H5 files.
+      start_time: Optional. The earliest time at which to start visualizing. The
+        start-time value is included.
+      stop_time: Optional. The time at which to stop visualizing. The stop-time
+        value is not included.
+      stride: Optional. View only every stride'th time step.
+      coordinates: Optional. Name of coordinates dataset. Default:
+        "InertialCoordinates".
     """
     # CLI scripts should be noops when input is empty
     if not h5files:
@@ -49,355 +321,111 @@ def generate_xdmf(
     if not subfile_name.endswith(".vol"):
         subfile_name += ".vol"
 
-    element_data = h5files[0][0].get(subfile_name)
-    if element_data is None:
-        subfiles = available_subfiles(
-            (h5file for h5file, _ in h5files), extension=".vol"
-        )
-        raise ValueError(
-            f"Could not open subfile name '{subfile_name}'. Available "
-            f"subfiles: {subfiles}"
-        )
-    temporal_ids_and_values = [
-        (x, element_data.get(x).attrs["observation_value"])
-        for x in element_data.keys()
-    ]
-    temporal_ids_and_values.sort(key=lambda x: x[1])
-
-    xdmf_output = (
-        '<?xml version="1.0" ?>\n'
-        '<!DOCTYPE Xdmf SYSTEM "Xdmf.dtd">\n'
-        '<Xdmf Version="2.0">\n'
-        "<Domain>\n"
-        '<Grid Name="Evolution" GridType="Collection" '
-        'CollectionType="Temporal">\n'
+    # Prepare XDMF document by building up an XML tree
+    xmf_root = ET.Element("Xdmf", Version="2.0")
+    xmf_domain = ET.SubElement(xmf_root, "Domain")
+    xmf_timesteps = ET.SubElement(
+        xmf_domain,
+        "Grid",
+        Name="Evolution",
+        GridType="Collection",
+        CollectionType="Temporal",
     )
+    # Collect timesteps in a hash map before inserting into XML so we can insert
+    # grids while stepping through H5 files
+    timesteps = dict()
 
-    # counter used to enforce the stride
-    stride_counter = 0
-    for id_and_value in temporal_ids_and_values:
-        if start_time is not None and id_and_value[1] < start_time:
-            continue
-        if stop_time is not None and id_and_value[1] > stop_time:
-            break
+    for h5file, filename in h5files:
+        # Open subfile
+        try:
+            vol_subfile = h5file[subfile_name]
+        except KeyError as err:
+            raise ValueError(
+                f"Could not open subfile name '{subfile_name}' in '{filename}'."
+                " Available subfiles: "
+                + str(available_subfiles(h5file, extension=".vol"))
+            ) from err
+        topo_dim = int(vol_subfile.attrs["dimension"])
 
-        stride_counter += 1
-        if (stride_counter - 1) % stride != 0:
-            continue
+        # Sort timesteps by time
+        temporal_ids_and_values = sorted(
+            [
+                (key, vol_subfile[key].attrs["observation_value"])
+                for key in vol_subfile.keys()
+            ],
+            key=lambda key_and_time: key_and_time[1],
+        )
 
-        h5temporal = element_data.get(id_and_value[0])
-        xdmf_output += '  <Grid Name="Grids" GridType="Collection">\n'
-        xdmf_output += '    <Time Value="%1.14e"/>\n' % (id_and_value[1])
-        # The following while loop will execute once, unless visualizing
-        # a 2D surface in 3D space. In that case, the loop will execute
-        # twice, with the second time through taking care of filling in the
-        # poles.
-        done = False
-        filling_poles_this_iteration = False
-        while not done:
-            # loop over each h5 file
-            for h5file in h5files:
-                h5temporal = h5file[0].get(subfile_name).get(id_and_value[0])
-                # Skip this file if the observation does not exist in it.
-                # Usually this is because the program crashed before
-                # writing it.  Data in other files will still be processed
-                # to allow viewing the part that was written.
-                if not h5temporal:
-                    continue
-                # Make sure the coordinates are found in the file. We assume
-                # there should always be an x-coordinate.
-                assert coordinates + "_x" in h5temporal, (
-                    "No '{}_x' dataset found in file '{}'. Existing datasets "
-                    "with 'Coordinates' in their name: {}"
-                ).format(
-                    coordinates,
-                    h5file[1],
-                    list(
-                        map(
-                            lambda coords_name: coords_name.strip("_x"),
-                            filter(
-                                lambda dataset_name: "Coordinates"
-                                in dataset_name
-                                and "_x" in dataset_name,
-                                h5temporal.keys(),
-                            ),
-                        )
-                    ),
-                )
-                dimensionality = 3
-                is_2d_surface_in_3d_space = False
-                # If pole_connectivity is in the list of keys, then this is 2D
-                # surface data in 3D space. Otherwise, if there are no
-                # z-coordinates then assume the data is 2d. If in the future
-                # this assumption is invalid on datasets we will need an extra
-                # command line argument.
-                if "pole_connectivity" in list(h5temporal.keys()):
-                    is_2d_surface_in_3d_space = True
-                elif coordinates + "_z" not in list(h5temporal.keys()):
-                    dimensionality = 2
+        # Stride through timesteps
+        for temporal_id, time in temporal_ids_and_values[::stride]:
+            # Filter by start and end time
+            if start_time is not None and time < start_time:
+                continue
+            if stop_time is not None and time > stop_time:
+                break
 
-                # Compute the extents in the x, y, (and z) logical directions
-                # for each element in the dataset.
-                extents = h5temporal.get("total_extents")
-                extents_x = np.array(
-                    [
-                        extents[i]
-                        for i in range(extents.size)
-                        if i % dimensionality == 0
-                    ]
-                )
-                extents_y = np.array(
-                    [
-                        extents[i]
-                        for i in range(extents.size)
-                        if i % dimensionality == 1
-                    ]
-                )
-
-                # So that we can have more generic code, set that we have 1
-                # grid point in z in 2d. For a 2D surface in 3D space, we have
-                # 1 grid point in z, extents_x == l+1 and extents_y == 2l+1.
-                extents_z = np.array([1])
-                if not is_2d_surface_in_3d_space and dimensionality == 3:
-                    extents_z = np.array(
-                        [
-                            extents[i]
-                            for i in range(extents.size)
-                            if i % dimensionality == 2
-                        ]
-                    )
-
-                # The total number of points is the sum of the tensor product
-                # of the 1d number of grid points.
-                numpoints = sum(extents_x * extents_y * extents_z)
-                # Because we can't have zero cells if rendering a 2d surface,
-                # return 1 in that case.
-                number_of_cells = 1
-                # This is used to compute the number of elements rather than
-                # the extents in case the connectivity is greater than what
-                # extents predicts
-                connectivity_length = len(h5temporal.get("connectivity"))
-                if filling_poles_this_iteration:
-                    # Number_of_cells == pole_connectivity size / 3
-                    # because we are using triangles to fill the poles
-                    number_of_cells = (
-                        h5temporal.get("pole_connectivity").size / 3
-                    )
-                elif is_2d_surface_in_3d_space or dimensionality == 2:
-                    number_of_cells = connectivity_length / 4
-                else:
-                    number_of_cells = connectivity_length / 8
-
-                topology = "Hexahedron"
-                vertices = 8
-                connectivity_path = "connectivity"
-                if filling_poles_this_iteration:
-                    topology = "Triangle"
-                    vertices = 3
-                    connectivity_path = "pole_connectivity"
-                elif is_2d_surface_in_3d_space or dimensionality == 2:
-                    topology = "Quadrilateral"
-                    vertices = 4
-
-                def data_item(data_type):
-                    assert data_type == np.dtype(
-                        "float64"
-                    ) or data_type == np.dtype("float32"), (
-                        "Data type must be either a 32-bit or 64-bit float but"
-                        " got "
-                        + str(data_type)
-                    )
-                    return (
-                        '        <DataItem Dimensions=" %d" '
-                        'NumberType="%s" Precision="8" Format="HDF5">\n'
-                        % (
-                            numpoints,
-                            (
-                                "Double"
-                                if data_type == np.dtype("float64")
-                                else "Float"
-                            ),
-                        )
-                    )
-
-                # Set up vectors
-                if dimensionality == 3:
-                    data_item_vec = (
-                        '        <DataItem Dimensions=" %d 3" '
-                        'ItemType = "Function" Function = "JOIN($0,$1,$2)">'
-                        "\n" % (numpoints)
-                    )
-                else:
-                    # In 2d we still need a 3d dataset to have a vector because
-                    # ParaView only supports 3d vectors. We deal with this by
-                    # making the z-component all zeros.
-                    data_item_vec = (
-                        '        <DataItem Dimensions=" %d 3" '
-                        'ItemType = "Function" '
-                        'Function = "JOIN($0,$1, 0 * $1)">\n' % (numpoints)
-                    )
-
-                # Configure grid location
-                Grid_path = (
-                    "          {}:/".format(h5file[1])
-                    + subfile_name
-                    + "/{}".format(id_and_value[0])
-                )
-                xdmf_output += '    <Grid Name="%s" GridType="Uniform">\n' % (
-                    h5file[1]
-                )
-                # Write topology information. In 3d we write a hexahedral
-                # topology (this may need to change when we have DG-subcell),
-                # while in 2d we write a quadrilateral topology (and may also
-                # need to change when we have DG-subcell).
-                if dimensionality == 3:
-                    xdmf_output += (
-                        '      <Topology TopologyType="%s" '
-                        'NumberOfElements="%d">\n' % (topology, number_of_cells)
-                    )
-                else:
-                    xdmf_output += (
-                        "      <Topology "
-                        'TopologyType="quadrilateral" '
-                        'NumberOfElements="%d">\n' % (number_of_cells)
-                    )
-
-                # The ternary for 3d returns 8 because that's how many vertices
-                # a hexahedron has, and 4 in 2d because that's how many vertices
-                # a quadrilateral has.
-                xdmf_output += (
-                    '        <DataItem Dimensions="%d %d" '
-                    'NumberType="Int" Format="HDF5">\n'
-                    % (number_of_cells, vertices)
-                )
-                xdmf_output += (
-                    Grid_path
-                    + "/"
-                    + connectivity_path
-                    + "\n        </DataItem>\n      </Topology>\n"
-                )
-
-                # Write geometry/coordinates. The X_Y_Z and X_Y means that the
-                # x, y, and z coordinates are stored in separate datasets,
-                # rather than something like interleaved.
-                if dimensionality == 3:
-                    xdmf_output += '      <Geometry Type="X_Y_Z">\n'
-                else:
-                    xdmf_output += '      <Geometry Type="X_Y">\n'
-                xdmf_output += (
-                    data_item(h5temporal.get(coordinates + "_x").dtype)
-                    + Grid_path
-                    + "/"
-                    + coordinates
-                    + "_x\n        </DataItem>\n"
-                )
-                xdmf_output += (
-                    data_item(h5temporal.get(coordinates + "_y").dtype)
-                    + Grid_path
-                    + "/"
-                    + coordinates
-                    + "_y\n        </DataItem>\n"
-                )
-                if dimensionality == 3:
-                    xdmf_output += (
-                        data_item(h5temporal.get(coordinates + "_z").dtype)
-                        + Grid_path
-                        + "/"
-                        + coordinates
-                        + "_z\n        </DataItem>\n"
-                    )
-                xdmf_output += "      </Geometry>\n"
-                # Everything that isn't a coordinate is a "component"
-                components = list(h5temporal.keys())
-                components.remove(coordinates + "_x")
-                components.remove(coordinates + "_y")
-                if dimensionality == 3:
-                    # In 2d we cannot read any z-coordinates because they
-                    # were never written.
-                    components.remove(coordinates + "_z")
-                components.remove("connectivity")
-                if is_2d_surface_in_3d_space:
-                    components.remove("pole_connectivity")
-                components.remove("total_extents")
-                components.remove("grid_names")
-                components.remove("bases")
-                components.remove("quadratures")
-                if "domain" in components:
-                    components.remove("domain")
-                if "functions_of_time" in components:
-                    components.remove("functions_of_time")
-
-                # Write the tensors that are to be visualized.
-                for component in components:
-                    if component.endswith("_x"):
-                        # Write a vector using the three components that make up
-                        # the vector (i.e. v_x, v_y, v_z)
-                        vector = component[:-2]
-                        xdmf_output += (
-                            '      <Attribute Name="%s" '
-                            'AttributeType="Vector" Center="Node">\n' % (vector)
-                        )
-                        xdmf_output += data_item_vec
-
-                        index_list = ["_x", "_y"]
-                        if dimensionality == 3:
-                            index_list.append("_z")
-                        for index in index_list:
-                            xdmf_output += (
-                                data_item(h5temporal.get(vector + index).dtype)
-                                + Grid_path
-                                + "/%s" % (vector)
-                                + index
-                                + "\n"
-                                + "        </DataItem>\n"
-                            )
-                        xdmf_output += "        </DataItem>\n"
-                        xdmf_output += "      </Attribute>\n"
-                    elif component.endswith("_y") or component.endswith("_z"):
-                        # The component is a y or z component of a vector
-                        # it will be processed with the x component
-                        continue
-                    else:
-                        # If the component is not part of a vector,
-                        # write it as a scalar
-                        xdmf_output += (
-                            '      <Attribute Name="%s" '
-                            'AttributeType="Scalar" Center="Node">\n'
-                            % (component)
-                        )
-                        xdmf_output += (
-                            data_item(h5temporal.get(component).dtype)
-                            + Grid_path
-                            + "/%s\n" % component
-                            + "        </DataItem>\n"
-                        )
-                        xdmf_output += "      </Attribute>\n"
-                xdmf_output += "    </Grid>\n"
-
-            if is_2d_surface_in_3d_space:
-                if filling_poles_this_iteration:
-                    done = True
-                    # close time grid
-                    xdmf_output += "  </Grid>\n"
-                else:
-                    filling_poles_this_iteration = True
+            # A timestep is represented by a collection of grids. We store the
+            # grid collection in a hash map so each H5 file can insert grids.
+            if temporal_id in timesteps:
+                xmf_timestep_grid = timesteps[temporal_id]
             else:
-                done = True
-                # close time grid
-                xdmf_output += "  </Grid>\n"
+                xmf_timestep_grid = ET.SubElement(
+                    xmf_timesteps, "Grid", Name="Grids", GridType="Collection"
+                )
+                # The time is stored as a `Time` tag in the grid collection
+                ET.SubElement(xmf_timestep_grid, "Time", Value=f"{time:.14e}")
+                timesteps[temporal_id] = xmf_timestep_grid
 
-    xdmf_output += "</Grid>\n</Domain>\n</Xdmf>\n"
+            # Construct the grid for this observation
+            observation = vol_subfile[temporal_id]
+            xmf_timestep_grid.append(
+                _xmf_grid(
+                    observation,
+                    topo_dim=topo_dim,
+                    filename=filename,
+                    subfile_name=subfile_name,
+                    temporal_id=temporal_id,
+                    coordinates=coordinates,
+                )
+            )
+            # Connect poles if the data is a 2D surface in 3D
+            if "pole_connectivity" in observation:
+                xmf_timestep_grid.append(
+                    _xmf_grid(
+                        observation,
+                        topo_dim=topo_dim,
+                        filename=filename,
+                        subfile_name=subfile_name,
+                        temporal_id=temporal_id,
+                        coordinates=coordinates,
+                        filling_poles=True,
+                    )
+                )
 
     for h5file in h5files:
         h5file[0].close()
 
+    # Pretty-print XML
+    try:
+        # Added in Py 3.9
+        ET.indent(xmf_root)
+    except AttributeError:
+        pass
+
+    # Output XML
+    xmf_document = """\
+<?xml version="1.0" ?>
+<!DOCTYPE Xdmf SYSTEM "Xdmf.dtd">
+"""
+    xmf_document += ET.tostring(xmf_root, encoding="unicode")
+    xmf_document += "\n"
     if output:
         if not output.endswith(".xmf"):
             output += ".xmf"
-        with open(output, "w") as xmf_file:
-            xmf_file.write(xdmf_output)
+        with open(output, "w") as open_output_file:
+            open_output_file.write(xmf_document)
     else:
-        sys.stdout.write(xdmf_output)
+        sys.stdout.write(xmf_document)
 
 
 @click.command(help=generate_xdmf.__doc__)
@@ -411,7 +439,7 @@ def generate_xdmf(
     "-o",
     type=click.Path(writable=True),
     help=(
-        "Output file name, an xmf extension will be added. "
+        "Output file name. A '.xmf' extension will be added if not present. "
         "If unspecified, the output will be written to stdout."
     ),
 )

--- a/src/Visualization/Python/GenerateXdmf.py
+++ b/src/Visualization/Python/GenerateXdmf.py
@@ -28,7 +28,7 @@ def generate_xdmf(
     To load the XDMF file in ParaView you must choose the 'Xdmf Reader', NOT
     'Xdmf3 Reader'.
     """
-    # CLI scripts should be noops when input is empy
+    # CLI scripts should be noops when input is empty
     if not h5files:
         return
 
@@ -37,11 +37,10 @@ def generate_xdmf(
     if not subfile_name:
         import rich.columns
 
-        rich.print(
-            rich.columns.Columns(
-                available_subfiles(h5files[0][0], extension=".vol")
-            )
+        subfiles = available_subfiles(
+            (h5file for h5file, _ in h5files), extension=".vol"
         )
+        rich.print(rich.columns.Columns(subfiles))
         return
 
     if not subfile_name.endswith(".vol"):
@@ -49,9 +48,12 @@ def generate_xdmf(
 
     element_data = h5files[0][0].get(subfile_name)
     if element_data is None:
+        subfiles = available_subfiles(
+            (h5file for h5file, _ in h5files), extension=".vol"
+        )
         raise ValueError(
             f"Could not open subfile name '{subfile_name}'. Available "
-            f"subfiles: {available_subfiles(h5files[0][0], extension='.vol')}"
+            f"subfiles: {subfiles}"
         )
     temporal_ids_and_values = [
         (x, element_data.get(x).attrs["observation_value"])

--- a/src/Visualization/Python/GenerateXdmf.py
+++ b/src/Visualization/Python/GenerateXdmf.py
@@ -40,8 +40,11 @@ def generate_xdmf(
         subfiles = available_subfiles(
             (h5file for h5file, _ in h5files), extension=".vol"
         )
-        rich.print(rich.columns.Columns(subfiles))
-        return
+        if len(subfiles) == 1:
+            subfile_name = subfiles[0]
+        else:
+            rich.print(rich.columns.Columns(subfiles))
+            return
 
     if not subfile_name.endswith(".vol"):
         subfile_name += ".vol"
@@ -416,9 +419,10 @@ def generate_xdmf(
     "--subfile-name",
     "-d",
     help=(
-        "Name of the volume data subfile in the H5 files. A '.vol' "
-        "extension is added if needed. If unspecified, list all '.vol' "
-        "subfiles and exit."
+        "Name of the volume data subfile in the H5 files. A '.vol' extension is"
+        " added if needed. If unspecified, and the first H5 file contains only"
+        " a single '.vol' subfile, choose that. Otherwise, list all '.vol'"
+        " subfiles and exit."
     ),
 )
 @click.option(

--- a/tests/Unit/Visualization/Python/Test_ReadH5.py
+++ b/tests/Unit/Visualization/Python/Test_ReadH5.py
@@ -3,6 +3,7 @@
 
 import os
 import unittest
+from pathlib import Path
 
 import h5py
 import numpy as np
@@ -19,14 +20,13 @@ from spectre.Visualization.ReadH5 import (
 
 class TestReadH5(unittest.TestCase):
     def setUp(self):
-        self.data_dir = os.path.join(
+        self.data_dir = Path(
             spectre_informer.unit_test_src_path(), "Visualization/Python"
         )
 
     def test_available_subfiles(self):
-        with h5py.File(
-            os.path.join(self.data_dir, "DatTestData.h5"), "r"
-        ) as open_file:
+        # Test with open file
+        with h5py.File(self.data_dir / "DatTestData.h5", "r") as open_file:
             self.assertEqual(
                 available_subfiles(open_file, extension=".dat"),
                 ["Group0/MemoryData.dat", "TimeSteps2.dat"],
@@ -34,16 +34,31 @@ class TestReadH5(unittest.TestCase):
             self.assertEqual(
                 available_subfiles(open_file, extension=".vol"), []
             )
-        with h5py.File(
-            os.path.join(self.data_dir, "VolTestData0.h5"), "r"
-        ) as open_file:
-            self.assertEqual(
-                available_subfiles(open_file, extension=".dat"), []
-            )
-            self.assertEqual(
-                available_subfiles(open_file, extension=".vol"),
-                ["element_data.vol"],
-            )
+        # Test with path
+        self.assertEqual(
+            available_subfiles(
+                self.data_dir / "VolTestData0.h5", extension=".dat"
+            ),
+            [],
+        )
+        # Test with string
+        self.assertEqual(
+            available_subfiles(
+                os.path.join(self.data_dir, "VolTestData0.h5"), extension=".vol"
+            ),
+            ["element_data.vol"],
+        )
+        # Test with multiple files
+        self.assertEqual(
+            available_subfiles(
+                [
+                    self.data_dir / "DatTestData.h5",
+                    self.data_dir / "VolTestData0.h5",
+                ],
+                extension=".vol",
+            ),
+            ["element_data.vol"],
+        )
 
     def test_to_dataframe(self):
         # h5py subfile

--- a/tests/Unit/Visualization/Python/VolTestData.xmf
+++ b/tests/Unit/Visualization/Python/VolTestData.xmf
@@ -11,24 +11,24 @@
           VolTestData0.h5:/element_data.vol/ObservationId1090594013349131584/connectivity
         </DataItem>
       </Topology>
-      <Geometry Type="X_Y_Z">
-        <DataItem Dimensions=" 128" NumberType="Double" Precision="8" Format="HDF5">
+      <Geometry GeometryType="X_Y_Z">
+        <DataItem Dimensions="128" NumberType="Double" Precision="8" Format="HDF5">
           VolTestData0.h5:/element_data.vol/ObservationId1090594013349131584/InertialCoordinates_x
         </DataItem>
-        <DataItem Dimensions=" 128" NumberType="Double" Precision="8" Format="HDF5">
+        <DataItem Dimensions="128" NumberType="Double" Precision="8" Format="HDF5">
           VolTestData0.h5:/element_data.vol/ObservationId1090594013349131584/InertialCoordinates_y
         </DataItem>
-        <DataItem Dimensions=" 128" NumberType="Double" Precision="8" Format="HDF5">
+        <DataItem Dimensions="128" NumberType="Double" Precision="8" Format="HDF5">
           VolTestData0.h5:/element_data.vol/ObservationId1090594013349131584/InertialCoordinates_z
         </DataItem>
       </Geometry>
       <Attribute Name="Error(Psi)" AttributeType="Scalar" Center="Node">
-        <DataItem Dimensions=" 128" NumberType="Double" Precision="8" Format="HDF5">
+        <DataItem Dimensions="128" NumberType="Double" Precision="8" Format="HDF5">
           VolTestData0.h5:/element_data.vol/ObservationId1090594013349131584/Error(Psi)
         </DataItem>
       </Attribute>
       <Attribute Name="Psi" AttributeType="Scalar" Center="Node">
-        <DataItem Dimensions=" 128" NumberType="Double" Precision="8" Format="HDF5">
+        <DataItem Dimensions="128" NumberType="Double" Precision="8" Format="HDF5">
           VolTestData0.h5:/element_data.vol/ObservationId1090594013349131584/Psi
         </DataItem>
       </Attribute>


### PR DESCRIPTION
## Proposed changes

Also refactor to use Python's XML engine. This allows inserting grids into the XML tree, which helps with supporting H5 files with different observations.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
