### PR TITLE
Temporarily revert simd-accelerated transpose

### DIFF
--- a/src/DataStructures/Transpose.hpp
+++ b/src/DataStructures/Transpose.hpp
@@ -30,7 +30,10 @@ void transpose_impl(double* matrix_transpose, const double* matrix,
 template <typename T>
 void raw_transpose(const gsl::not_null<T*> result, const T* const data,
                    const size_t chunk_size, const size_t number_of_chunks) {
-  if constexpr (std::is_same_v<double, T>) {
+   // Currently using the optimized double implementation leads to segfaults in
+   // Gh executables.  It should be tested and then re-enabled.
+   // if constexpr (std::is_same_v<double, T>) {
+   if constexpr (false) {
     detail::transpose_impl(result, data, static_cast<int32_t>(number_of_chunks),
                            static_cast<int32_t>(chunk_size));
   } else {


### PR DESCRIPTION
## Proposed changes
Change the raw transpose function to never use the explicit simd-vectorized transpose until the segfaults it causes can be diagnosed 

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
