### PR TITLE
Fix compiling Transpose.cpp on M2 Mac

### DIFF
--- a/src/DataStructures/Transpose.cpp
+++ b/src/DataStructures/Transpose.cpp
@@ -4,7 +4,7 @@
 #include "DataStructures/Transpose.hpp"
 #include <type_traits>
 
-#if __has_include(<emmintrin.h>)
+#if defined(__SSE2__)
 #include <emmintrin.h>
 #endif
 #if defined(__AVX__)


### PR DESCRIPTION
The emmintrin.h header is available in AppleClang 14 but throws a preprocessor error on ARM architecture.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
