### PR TITLE
Move LowerSpatialFourVelocity out of Xcts

### DIFF
--- a/src/Elliptic/Executables/Xcts/SolveXcts.hpp
+++ b/src/Elliptic/Executables/Xcts/SolveXcts.hpp
@@ -42,6 +42,7 @@
 #include "PointwiseFunctions/AnalyticSolutions/Xcts/Factory.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/RegisterDerivedWithCharm.hpp"
 #include "PointwiseFunctions/Hydro/Tags.hpp"
+#include "PointwiseFunctions/Hydro/LowerSpatialFourVelocity.hpp"
 #include "PointwiseFunctions/InitialDataUtilities/AnalyticSolution.hpp"
 #include "PointwiseFunctions/InitialDataUtilities/Background.hpp"
 #include "PointwiseFunctions/InitialDataUtilities/InitialGuess.hpp"
@@ -94,7 +95,7 @@ struct Metavariables {
                  ::Tags::NonEuclideanMagnitude<
                      Xcts::Tags::ShiftExcess<DataVector, 3, Frame::Inertial>,
                      gr::Tags::SpatialMetric<DataVector, 3>>,
-                 Xcts::Tags::LowerSpatialFourVelocityCompute>>;
+                 hydro::Tags::LowerSpatialFourVelocityCompute>>;
   using observer_compute_tags =
       tmpl::list<::Events::Tags::ObserverMeshCompute<volume_dim>,
                  spacetime_quantities_compute, hydro_quantities_compute,

--- a/src/Elliptic/Systems/Xcts/CMakeLists.txt
+++ b/src/Elliptic/Systems/Xcts/CMakeLists.txt
@@ -10,7 +10,6 @@ spectre_target_sources(
   PRIVATE
   Equations.cpp
   FluxesAndSources.cpp
-  HydroQuantities.cpp
   )
 
 spectre_target_headers(

--- a/src/Elliptic/Systems/Xcts/HydroQuantities.hpp
+++ b/src/Elliptic/Systems/Xcts/HydroQuantities.hpp
@@ -52,28 +52,4 @@ struct HydroQuantitiesCompute : ::Tags::Variables<HydroTags>, db::ComputeTag {
   }
 };
 
-/*!
- * \brief Computes $u_i=W \gamma_{ij} v^j$, where $W$ is the Lorentz factor,
- * $\gamma_{ij}$ is the spatial metric, and $v^j$ is the spatial velocity.
- *
- * This compute item is intended for observations in a pure XCTS solve where the
- * hydro quantities are retrieved directly from the background solution/data.
- *
- * \see HydroQuantitiesCompute
- */
-struct LowerSpatialFourVelocityCompute
-    : hydro::Tags::LowerSpatialFourVelocity<DataVector, 3, Frame::Inertial>,
-      db::ComputeTag {
-  using base =
-      hydro::Tags::LowerSpatialFourVelocity<DataVector, 3, Frame::Inertial>;
-  using argument_tags =
-      tmpl::list<hydro::Tags::SpatialVelocity<DataVector, 3, Frame::Inertial>,
-                 gr::Tags::SpatialMetric<DataVector, 3>,
-                 hydro::Tags::LorentzFactor<DataVector>>;
-  static void function(const gsl::not_null<tnsr::i<DataVector, 3>*> result,
-                       const tnsr::I<DataVector, 3>& spatial_velocity,
-                       const tnsr::ii<DataVector, 3>& spatial_metric,
-                       const Scalar<DataVector>& lorentz_factor);
-};
-
 }  // namespace Xcts::Tags

--- a/src/PointwiseFunctions/Hydro/CMakeLists.txt
+++ b/src/PointwiseFunctions/Hydro/CMakeLists.txt
@@ -10,6 +10,7 @@ spectre_target_sources(
   PRIVATE
   ComovingMagneticField.cpp
   LorentzFactor.cpp
+  LowerSpatialFourVelocity.cpp
   MassFlux.cpp
   MassWeightedFluidItems.cpp
   SoundSpeedSquared.cpp
@@ -23,6 +24,7 @@ spectre_target_headers(
   HEADERS
   ComovingMagneticField.hpp
   LorentzFactor.hpp
+  LowerSpatialFourVelocity.hpp
   MassFlux.hpp
   MassWeightedFluidItems.hpp
   SoundSpeedSquared.hpp
@@ -39,6 +41,7 @@ target_link_libraries(
   Boost::boost
   DataStructures
   ErrorHandling
+  GeneralRelativity
   H5
   Options
   Serialization

--- a/src/PointwiseFunctions/Hydro/LowerSpatialFourVelocity.cpp
+++ b/src/PointwiseFunctions/Hydro/LowerSpatialFourVelocity.cpp
@@ -1,14 +1,13 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
-#include "Elliptic/Systems/Xcts/HydroQuantities.hpp"
+#include "PointwiseFunctions/Hydro/LowerSpatialFourVelocity.hpp"
 
+#include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "PointwiseFunctions/GeneralRelativity/IndexManipulation.hpp"
-#include "Utilities/Gsl.hpp"
 
-namespace Xcts::Tags {
-
+namespace hydro::Tags {
 void LowerSpatialFourVelocityCompute::function(
     const gsl::not_null<tnsr::i<DataVector, 3>*> result,
     const tnsr::I<DataVector, 3>& spatial_velocity,
@@ -20,4 +19,4 @@ void LowerSpatialFourVelocityCompute::function(
   }
 }
 
-}  // namespace Xcts::Tags
+}  // namespace hydro::Tags

--- a/src/PointwiseFunctions/Hydro/LowerSpatialFourVelocity.hpp
+++ b/src/PointwiseFunctions/Hydro/LowerSpatialFourVelocity.hpp
@@ -1,0 +1,39 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <string>
+
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/Tensor/IndexType.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "PointwiseFunctions/GeneralRelativity/TagsDeclarations.hpp"
+#include "PointwiseFunctions/Hydro/Tags.hpp"
+#include "PointwiseFunctions/Hydro/TagsDeclarations.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace hydro::Tags {
+
+/*!
+ * \brief Computes $u_i=W \gamma_{ij} v^j$, where $W$ is the Lorentz factor,
+ * $\gamma_{ij}$ is the spatial metric, and $v^j$ is the spatial velocity.
+ *
+ */
+struct LowerSpatialFourVelocityCompute
+    : hydro::Tags::LowerSpatialFourVelocity<DataVector, 3, Frame::Inertial>,
+      db::ComputeTag {
+  using base =
+      hydro::Tags::LowerSpatialFourVelocity<DataVector, 3, Frame::Inertial>;
+  using argument_tags =
+      tmpl::list<hydro::Tags::SpatialVelocity<DataVector, 3, Frame::Inertial>,
+                 gr::Tags::SpatialMetric<DataVector, 3>,
+                 hydro::Tags::LorentzFactor<DataVector>>;
+  static void function(const gsl::not_null<tnsr::i<DataVector, 3>*> result,
+                       const tnsr::I<DataVector, 3>& spatial_velocity,
+                       const tnsr::ii<DataVector, 3>& spatial_metric,
+                       const Scalar<DataVector>& lorentz_factor);
+};
+
+}  // namespace hydro::Tags

--- a/tests/Unit/Elliptic/Systems/Xcts/Test_HydroQuantities.cpp
+++ b/tests/Unit/Elliptic/Systems/Xcts/Test_HydroQuantities.cpp
@@ -18,6 +18,7 @@
 #include "PointwiseFunctions/AnalyticSolutions/Xcts/TovStar.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/PolytropicFluid.hpp"
 #include "PointwiseFunctions/Hydro/Tags.hpp"
+#include "PointwiseFunctions/Hydro/LowerSpatialFourVelocity.hpp"
 #include "PointwiseFunctions/InitialDataUtilities/AnalyticSolution.hpp"
 #include "PointwiseFunctions/InitialDataUtilities/Background.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
@@ -60,7 +61,7 @@ SPECTRE_TEST_CASE("Unit.Elliptic.Systems.Xcts.HydroQuantities",
           elliptic::Tags::Background<elliptic::analytic_data::Background>,
           Parallel::Tags::MetavariablesImpl<Metavariables>>,
       db::AddComputeTags<Tags::HydroQuantitiesCompute<hydro_tags>,
-                         Tags::LowerSpatialFourVelocityCompute>>(
+                         hydro::Tags::LowerSpatialFourVelocityCompute>>(
       x, spatial_metric,
       std::unique_ptr<elliptic::analytic_data::Background>(
           std::make_unique<Solutions::TovStar>(tov_star)),


### PR DESCRIPTION
## Proposed changes

Move LowerSpatialFourVelocityCompute from Xcts to PointwiseFunctions/Hydro. This should allow us to observe LowerSpatialFourVelocityCompute  if we want to write it on disk and restart using NumericInitialData.
The base tag was already in PointwiseFunctions/Hydro, so hopefully this does not create any new dependencies.

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
