### PR TITLE
Add dox for running on an interactive wheeler node

### DIFF
--- a/docs/Installation/InstallationOnClusters.md
+++ b/docs/Installation/InstallationOnClusters.md
@@ -72,6 +72,13 @@ you do not need to install any dependencies, so you can skip steps 5 and 6. You
 can optionally compile using LLVM/Clang by sourcing `wheeler_clang.sh` instead
 of `wheeler_gcc.sh`
 
+If you are running jobs on a Wheeler interactive compute
+node, make sure that when you allocate the interactive node using
+`srun`, use the `-c <CPUS_PER_TASK>` option to `srun`, and not the `-n
+<NUMBER_OF_TASKS>` option.  If you use the `-n <NUMBER_OF_TASKS>`
+option and pass the number of cores for NUMBER_OF_TASKS, then you will
+get multiple MPI ranks on your node and the run will hang.
+
 ## CaltechHPC at Caltech
 
 Follow the general instructions, using `caltech_hpc` for `SYSTEM_TO_RUN_ON`.


### PR DESCRIPTION
Add a caution to the installation notes on wheeler, to avoid a problem that multiple people have run into.

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

