### PR TITLE
Infer output buffer tags in partial_derivatives

### DIFF
--- a/src/Elliptic/DiscontinuousGalerkin/CMakeLists.txt
+++ b/src/Elliptic/DiscontinuousGalerkin/CMakeLists.txt
@@ -31,6 +31,7 @@ target_link_libraries(
   Domain
   DomainStructure
   ErrorHandling
+  LinearOperators
   Spectral
   Utilities
   INTERFACE

--- a/src/Elliptic/DiscontinuousGalerkin/Initialization.cpp
+++ b/src/Elliptic/DiscontinuousGalerkin/Initialization.cpp
@@ -24,7 +24,6 @@
 #include "Domain/Structure/Element.hpp"
 #include "Domain/Structure/IndexToSliceAt.hpp"
 #include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
-#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.tpp"
 #include "NumericalAlgorithms/Spectral/LogicalCoordinates.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
@@ -91,16 +90,8 @@ void deriv_unnormalized_face_normals_impl(
          "Slicing the Hessian to the boundary currently supports only "
          "Gauss-Lobatto grids. Add support to "
          "'elliptic::dg::InitializeFacesAndMortars'.");
-  using inv_jac_tag = domain::Tags::InverseJacobian<Dim, Frame::ElementLogical,
-                                                    Frame::Inertial>;
-  Variables<tmpl::list<inv_jac_tag>> vars_to_differentiate{
-      mesh.number_of_grid_points()};
-  get<inv_jac_tag>(vars_to_differentiate) = inv_jacobian;
-  const auto deriv_vars = partial_derivatives<tmpl::list<inv_jac_tag>>(
-      vars_to_differentiate, mesh, inv_jacobian);
-  const auto& deriv_inv_jac =
-      get<::Tags::deriv<inv_jac_tag, tmpl::size_t<Dim>, Frame::Inertial>>(
-          deriv_vars);
+  const auto deriv_inv_jac =
+      partial_derivative(inv_jacobian, mesh, inv_jacobian);
   for (const auto& direction : element.external_boundaries()) {
     const auto deriv_inv_jac_on_face =
         data_on_slice(deriv_inv_jac, mesh.extents(), direction.dimension(),

--- a/src/Evolution/DiscontinuousGalerkin/Actions/VolumeTermsImpl.tpp
+++ b/src/Evolution/DiscontinuousGalerkin/Actions/VolumeTermsImpl.tpp
@@ -112,15 +112,13 @@ void volume_terms(
       "are defined, and that at least one of them is a non-empty list of "
       "tags.");
 
-  using partial_derivative_tags = tmpl::list<PartialDerivTags...>;
   using flux_variables =
       tmpl::list<FluxVariablesTags...>;
 
   // Compute d_i u_\alpha for nonconservative products
   if constexpr (has_partial_derivs) {
-    partial_derivatives<partial_derivative_tags>(
-        partial_derivs, evolved_vars, mesh,
-        logical_to_inertial_inverse_jacobian);
+    partial_derivatives(partial_derivs, evolved_vars, mesh,
+                        logical_to_inertial_inverse_jacobian);
   }
 
   // For now just zero dt_vars. If this is a performance bottle neck we

--- a/src/NumericalAlgorithms/FiniteDifference/PartialDerivatives.tpp
+++ b/src/NumericalAlgorithms/FiniteDifference/PartialDerivatives.tpp
@@ -83,8 +83,10 @@ void partial_derivatives(
     gsl::at(logical_partial_derivs_ptrs, i) =
         gsl::at(logical_partial_derivs, i).data();
   }
-  ::partial_derivatives_detail::partial_derivatives_impl<DerivativeTags>(
-      partial_derivatives, logical_partial_derivs_ptrs, inverse_jacobian);
+  ::partial_derivatives_detail::partial_derivatives_impl(
+      partial_derivatives, logical_partial_derivs_ptrs,
+      Variables<DerivativeTags>::number_of_independent_components,
+      inverse_jacobian);
 }
 
 }  // namespace fd

--- a/src/NumericalAlgorithms/LinearOperators/PartialDerivatives.cpp
+++ b/src/NumericalAlgorithms/LinearOperators/PartialDerivatives.cpp
@@ -266,10 +266,9 @@ GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3),
                         (tnsr::a, tnsr::A, tnsr::i, tnsr::I, tnsr::ab, tnsr::Ab,
                          tnsr::aB, tnsr::AB, tnsr::ij, tnsr::iJ, tnsr::Ij,
                          tnsr::IJ, tnsr::iA, tnsr::ia, tnsr::aa, tnsr::AA,
-                         tnsr::ii, tnsr::II, tnsr::ijj, tnsr::Ijj))
+                         tnsr::ii, tnsr::II, tnsr::ijj, tnsr::Ijj, tnsr::iaa))
 
 #undef INSTANTIATION
-#undef GET_TENSOR
 
 #define INSTANTIATION(r, data)                                               \
   template void logical_partial_derivative(                                  \
@@ -293,6 +292,25 @@ GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3),
 GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
 
 #undef INSTANTIATION
+
+#define INSTANTIATE_JACOBIANS(r, data)                                        \
+  template TensorMetafunctions::prepend_spatial_index<                        \
+      GET_TENSOR(data) < DataVector, GET_DIM(data), Frame::ElementLogical,    \
+      GET_FRAME(data)>,                                                       \
+      GET_DIM(data), UpLo::Lo,                                                \
+      GET_FRAME(data) >                                                       \
+          partial_derivative(                                                 \
+              const GET_TENSOR(data) < DataVector, GET_DIM(data),             \
+              Frame::ElementLogical, GET_FRAME(data) > &u,                    \
+              const Mesh<GET_DIM(data)>& mesh,                                \
+              const InverseJacobian<DataVector, GET_DIM(data),                \
+                                    Frame::ElementLogical, GET_FRAME(data)>&  \
+                  inverse_jacobian);
+
+GENERATE_INSTANTIATIONS(INSTANTIATE_JACOBIANS, (1, 2, 3), (Frame::Inertial),
+                        (InverseJacobian))
+
+#undef INSTANTIATE_JACOBIANS
 
 #define INSTANTIATE_SCALAR(r, data)                                           \
   template void partial_derivative<Symmetry<>, index_list<>>(                 \
@@ -319,3 +337,4 @@ GENERATE_INSTANTIATIONS(INSTANTIATE_SCALAR, (1, 2, 3),
 #undef INSTANTIATE_SCALAR
 #undef GET_FRAME
 #undef GET_DIM
+#undef GET_TENSOR

--- a/tests/Unit/Elliptic/Systems/Xcts/BoundaryConditions/CMakeLists.txt
+++ b/tests/Unit/Elliptic/Systems/Xcts/BoundaryConditions/CMakeLists.txt
@@ -24,6 +24,7 @@ target_link_libraries(
   DomainStructure
   Elliptic
   GeneralRelativitySolutions
+  LinearOperators
   Utilities
   XctsBoundaryConditions
   XctsSolutions

--- a/tests/Unit/Elliptic/Systems/Xcts/BoundaryConditions/Test_ApparentHorizon.cpp
+++ b/tests/Unit/Elliptic/Systems/Xcts/BoundaryConditions/Test_ApparentHorizon.cpp
@@ -33,7 +33,6 @@
 #include "Framework/TestHelpers.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/NormalDotFlux.hpp"
 #include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
-#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.tpp"
 #include "NumericalAlgorithms/Spectral/LogicalCoordinates.hpp"
 #include "Options/Protocols/FactoryCreation.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrHorizon.hpp"
@@ -434,15 +433,8 @@ void test_consistency_with_kerr(const bool compute_expansion) {
   const auto logical_coords = logical_coordinates(mesh);
   const tnsr::I<DataVector, 3> inertial_coords = (*coord_map)(logical_coords);
   const auto inv_jacobian = coord_map->inv_jacobian(logical_coords);
-  using inv_jac_tag =
-      domain::Tags::InverseJacobian<3, Frame::ElementLogical, Frame::Inertial>;
-  Variables<tmpl::list<inv_jac_tag>> vars_to_derive{num_points};
-  get<inv_jac_tag>(vars_to_derive) = inv_jacobian;
-  const auto deriv_vars = partial_derivatives<tmpl::list<inv_jac_tag>>(
-      vars_to_derive, mesh, inv_jacobian);
-  const auto& deriv_inv_jac =
-      get<::Tags::deriv<inv_jac_tag, tmpl::size_t<3>, Frame::Inertial>>(
-          deriv_vars);
+  const auto deriv_inv_jac =
+      partial_derivative(inv_jacobian, mesh, inv_jacobian);
   // Coords on the face
   const auto direction = Direction<3>::lower_zeta();
   const size_t slice_index = index_to_slice_at(mesh.extents(), direction);

--- a/tests/Unit/Evolution/Systems/Ccz4/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/Ccz4/CMakeLists.txt
@@ -21,7 +21,20 @@ add_test_library(
   ${LIBRARY}
   "Evolution/Systems/Ccz4/"
   "${LIBRARY_SOURCES}"
-  "Ccz4;DataBoxTestHelpers;DataStructures;Domain;GeneralRelativity"
-  "GeneralRelativityHelpers;GeneralRelativitySolutions;LinearOperators;Spectral"
-  "Utilities"
+  ""
   )
+
+target_link_libraries(
+  ${LIBRARY}
+  PRIVATE
+  Ccz4
+  DataBoxTestHelpers
+  DataStructures
+  Domain
+  GeneralRelativity
+  GeneralRelativityHelpers
+  GeneralRelativitySolutions
+  LinearOperators
+  Spectral
+  Utilities
+)

--- a/tests/Unit/Evolution/Systems/Ccz4/Test_RicciScalarPlusDivergenceZ4Constraint.cpp
+++ b/tests/Unit/Evolution/Systems/Ccz4/Test_RicciScalarPlusDivergenceZ4Constraint.cpp
@@ -24,7 +24,6 @@
 #include "Framework/SetupLocalPythonEnvironment.hpp"
 #include "Framework/TestHelpers.hpp"
 #include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
-#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.tpp"
 #include "NumericalAlgorithms/Spectral/LogicalCoordinates.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
@@ -113,20 +112,8 @@ void test_divergence_spatial_z4_constraint_vanishes(
 
   const auto christoffel_second_kind =
       gr::christoffel_second_kind(d_spatial_metric, inverse_spatial_metric);
-
-  using christoffel_second_kind_tag =
-      gr::Tags::SpatialChristoffelSecondKind<DataVector, SpatialDim>;
-  Variables<tmpl::list<christoffel_second_kind_tag>>
-      christoffel_second_kind_var(num_points_3d);
-  get<christoffel_second_kind_tag>(christoffel_second_kind_var) =
-      christoffel_second_kind;
-  const auto d_christoffel_second_kind_var =
-      partial_derivatives<tmpl::list<christoffel_second_kind_tag>>(
-          christoffel_second_kind_var, mesh, coord_map.inv_jacobian(x_logical));
-  const auto& d_christoffel_second_kind =
-      get<Tags::deriv<christoffel_second_kind_tag, tmpl::size_t<SpatialDim>,
-                      Frame::Inertial>>(d_christoffel_second_kind_var);
-
+  const auto d_christoffel_second_kind = partial_derivative(
+      christoffel_second_kind, mesh, coord_map.inv_jacobian(x_logical));
   const auto spatial_ricci_tensor =
       gr::ricci_tensor(christoffel_second_kind, d_christoffel_second_kind);
 

--- a/tests/Unit/NumericalAlgorithms/FiniteDifference/Test_PartialDerivatives.cpp
+++ b/tests/Unit/NumericalAlgorithms/FiniteDifference/Test_PartialDerivatives.cpp
@@ -192,9 +192,11 @@ void test(const gsl::not_null<std::mt19937*> generator,
   Variables<db::wrap_tags_in<Tags::deriv, derivative_tags, tmpl::size_t<Dim>,
                              Frame::Inertial>>
       expected_partial_derivatives{mesh.number_of_grid_points()};
-  ::partial_derivatives_detail::partial_derivatives_impl<derivative_tags>(
+  ::partial_derivatives_detail::partial_derivatives_impl(
       make_not_null(&expected_partial_derivatives),
-      expected_logical_derivs_ptrs, inverse_jacobian);
+      expected_logical_derivs_ptrs,
+      Variables<derivative_tags>::number_of_independent_components,
+      inverse_jacobian);
 
   using d_var1_tag = Tags::deriv<Tags::TempScalar<0, DataVector>,
                                  tmpl::size_t<Dim>, Frame::Inertial>;

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/Test_PartialDerivatives.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/Test_PartialDerivatives.cpp
@@ -361,14 +361,13 @@ void test_partial_derivatives_1d(const Mesh<1>& mesh) {
     using vars_type =
         decltype(partial_derivatives<GradientTags>(u, mesh, inverse_jacobian));
     vars_type du{};
-    partial_derivatives<GradientTags>(make_not_null(&du), u, mesh,
-                                      inverse_jacobian);
+    partial_derivatives(make_not_null(&du), u, mesh, inverse_jacobian);
     helper(du);
 
     vars_type du_with_logical{};
-    partial_derivatives<GradientTags>(
-        make_not_null(&du_with_logical),
-        logical_partial_derivatives<GradientTags>(u, mesh), inverse_jacobian);
+    partial_derivatives(make_not_null(&du_with_logical),
+                        logical_partial_derivatives<GradientTags>(u, mesh),
+                        inverse_jacobian);
     helper(du_with_logical);
 
     // We've checked that du is correct, now test that taking derivatives of
@@ -415,14 +414,13 @@ void test_partial_derivatives_2d(const Mesh<2>& mesh) {
       using vars_type = decltype(
           partial_derivatives<GradientTags>(u, mesh, inverse_jacobian));
       vars_type du{};
-      partial_derivatives<GradientTags>(make_not_null(&du), u, mesh,
-                                        inverse_jacobian);
+      partial_derivatives(make_not_null(&du), u, mesh, inverse_jacobian);
       helper(du);
 
       vars_type du_with_logical{};
-      partial_derivatives<GradientTags>(
-          make_not_null(&du_with_logical),
-          logical_partial_derivatives<GradientTags>(u, mesh), inverse_jacobian);
+      partial_derivatives(make_not_null(&du_with_logical),
+                          logical_partial_derivatives<GradientTags>(u, mesh),
+                          inverse_jacobian);
       helper(du_with_logical);
 
       // We've checked that du is correct, now test that taking derivatives of
@@ -474,15 +472,13 @@ void test_partial_derivatives_3d(const Mesh<3>& mesh) {
         using vars_type = decltype(
             partial_derivatives<GradientTags>(u, mesh, inverse_jacobian));
         vars_type du{};
-        partial_derivatives<GradientTags>(make_not_null(&du), u, mesh,
-                                          inverse_jacobian);
+        partial_derivatives(make_not_null(&du), u, mesh, inverse_jacobian);
         helper(du);
 
         vars_type du_with_logical{};
-        partial_derivatives<GradientTags>(
-            make_not_null(&du_with_logical),
-            logical_partial_derivatives<GradientTags>(u, mesh),
-            inverse_jacobian);
+        partial_derivatives(make_not_null(&du_with_logical),
+                            logical_partial_derivatives<GradientTags>(u, mesh),
+                            inverse_jacobian);
         helper(du_with_logical);
 
         // We've checked that du is correct, now test that taking derivatives of

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/CMakeLists.txt
@@ -30,6 +30,7 @@ target_link_libraries(
   GeneralizedHarmonic
   GrSolutionsTestHelpers
   Hydro
+  LinearOperators
   Options
   Spectral
   Utilities

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Test_KerrSchild.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Test_KerrSchild.cpp
@@ -27,7 +27,6 @@
 #include "Helpers/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/VerifyGrSolution.hpp"
 #include "Helpers/PointwiseFunctions/AnalyticSolutions/TestHelpers.hpp"
 #include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
-#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.tpp"
 #include "NumericalAlgorithms/Spectral/LogicalCoordinates.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
@@ -283,13 +282,8 @@ void test_numerical_deriv_det_spatial_metric(const DataVector& used_for_size) {
   using H_tag = gr::Solutions::KerrSchild::internal_tags::H<DataVector>;
   ks_computer(make_not_null(&H), make_not_null(&ks_cache), H_tag{});
 
-  Variables<tmpl::list<H_tag>> H_var(num_points_3d);
-  get<H_tag>(H_var) = H;
-  const auto expected_deriv_H_var = partial_derivatives<tmpl::list<H_tag>>(
-      H_var, mesh, coord_map.inv_jacobian(x_logical));
-  const auto& expected_deriv_H =
-      get<Tags::deriv<H_tag, tmpl::size_t<SpatialDim>, FrameType>>(
-          expected_deriv_H_var);
+  const auto expected_deriv_H =
+      partial_derivative(H, mesh, coord_map.inv_jacobian(x_logical));
 
   tnsr::i<DataVector, SpatialDim, FrameType>
       expected_deriv_det_spatial_metric{};

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Test_SphericalKerrSchild.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Test_SphericalKerrSchild.cpp
@@ -26,7 +26,6 @@
 #include "Helpers/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/VerifyGrSolution.hpp"
 #include "Helpers/PointwiseFunctions/AnalyticSolutions/TestHelpers.hpp"
 #include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
-#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.tpp"
 #include "NumericalAlgorithms/Spectral/LogicalCoordinates.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
@@ -283,13 +282,8 @@ void test_numerical_deriv_det_spatial_metric(const DataVector& used_for_size) {
       gr::Solutions::SphericalKerrSchild::internal_tags::H<DataVector>;
   sks_computer(make_not_null(&H), make_not_null(&sks_cache), H_tag{});
 
-  Variables<tmpl::list<H_tag>> H_var(num_points_3d);
-  get<H_tag>(H_var) = H;
-  const auto expected_deriv_H_var = partial_derivatives<tmpl::list<H_tag>>(
-      H_var, mesh, coord_map.inv_jacobian(x_logical));
-  const auto& expected_deriv_H =
-      get<Tags::deriv<H_tag, tmpl::size_t<SpatialDim>, FrameType>>(
-          expected_deriv_H_var);
+  const auto expected_deriv_H =
+      partial_derivative(H, mesh, coord_map.inv_jacobian(x_logical));
 
   tnsr::i<DataVector, SpatialDim, FrameType>
       expected_deriv_det_spatial_metric{};


### PR DESCRIPTION
## Proposed changes

This allows the compiler to infer the template parameters in the return-by-reference overloads of partial_derivatives. It also relaxes the restriction that the output buffer must have ::Tags::deriv prefixes. This is useful to compute derivatives directly into output buffers, e.g. for variables that are represented by another tag (like Phi = deriv(Psi)) or for variables augmented by more computations (like adding a Christoffel-symbol term for the covariant derivative) or for prefixed variables where the output buffer ignores the prefixes.

This is part of merging the code published in the thermal noise paper (https://iopscience.iop.org/article/10.1088/1361-6382/acad62/meta).

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
