### PR TITLE
Add set_number_of_grid_points utility

### DIFF
--- a/src/ApparentHorizons/ComputeItems.hpp
+++ b/src/ApparentHorizons/ComputeItems.hpp
@@ -23,8 +23,8 @@ class DataVector;
 #include "PointwiseFunctions/GeneralRelativity/SpacetimeNormalVector.hpp"
 #include "PointwiseFunctions/GeneralRelativity/SpatialMetric.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
-#include "Utilities/ContainerHelpers.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/SetNumberOfGridPoints.hpp"
 #include "Utilities/TMPL.hpp"
 
 namespace ah {
@@ -45,7 +45,6 @@ struct InverseSpatialMetricCompute
   static void function(
       const gsl::not_null<tnsr::II<DataVector, Dim, Frame>*> result,
       const tnsr::aa<DataVector, Dim, Frame>& psi) {
-    destructive_resize_components(result, psi.begin()->size());
     *result = determinant_and_inverse(gr::spatial_metric(psi)).second;
   };
   using argument_tags =
@@ -64,7 +63,7 @@ struct ExtrinsicCurvatureCompute
       const tnsr::iaa<DataVector, Dim, Frame>& phi,
       const tnsr::II<DataVector, Dim, Frame>& inv_g) {
     const auto shift = gr::shift(psi, inv_g);
-    destructive_resize_components(result, psi.begin()->size());
+    set_number_of_grid_points(result, psi);
     gh::extrinsic_curvature(
         result, gr::spacetime_normal_vector(gr::lapse(shift, psi), shift), pi,
         phi);
@@ -85,7 +84,7 @@ struct SpatialChristoffelSecondKindCompute
       const gsl::not_null<tnsr::Ijj<DataVector, Dim, Frame>*> result,
       const tnsr::iaa<DataVector, Dim, Frame>& phi,
       const tnsr::II<DataVector, Dim, Frame>& inv_g) {
-    destructive_resize_components(result, phi.begin()->size());
+    set_number_of_grid_points(result, phi);
     raise_or_lower_first_index(
         result, gr::christoffel_first_kind(gh::deriv_spatial_metric(phi)),
         inv_g);

--- a/src/ApparentHorizons/StrahlkorperCoordsInDifferentFrame.cpp
+++ b/src/ApparentHorizons/StrahlkorperCoordsInDifferentFrame.cpp
@@ -15,10 +15,10 @@
 #include "NumericalAlgorithms/SphericalHarmonics/Spherepack.hpp"
 #include "NumericalAlgorithms/SphericalHarmonics/Strahlkorper.hpp"
 #include "NumericalAlgorithms/SphericalHarmonics/Tags.hpp"
-#include "Utilities/ContainerHelpers.hpp"
 #include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/SetNumberOfGridPoints.hpp"
 
 template <typename SrcFrame, typename DestFrame>
 void strahlkorper_coords_in_different_frame(
@@ -31,8 +31,8 @@ void strahlkorper_coords_in_different_frame(
     const double time) {
   static_assert(std::is_same_v<DestFrame, ::Frame::Inertial>,
                 "Destination frame must currently be Inertial frame");
-  destructive_resize_components(
-      dest_cartesian_coords, src_strahlkorper.ylm_spherepack().physical_size());
+  set_number_of_grid_points(dest_cartesian_coords,
+                            src_strahlkorper.ylm_spherepack().physical_size());
 
   // Temporary storage; reduce the number of allocations.
   Variables<tmpl::list<::Tags::Tempi<0, 2, ::Frame::Spherical<SrcFrame>>,

--- a/src/ApparentHorizons/StrahlkorperGr.cpp
+++ b/src/ApparentHorizons/StrahlkorperGr.cpp
@@ -22,12 +22,12 @@
 #include "PointwiseFunctions/GeneralRelativity/Christoffel.hpp"
 #include "PointwiseFunctions/GeneralRelativity/IndexManipulation.hpp"
 #include "Utilities/ConstantExpressions.hpp"
-#include "Utilities/ContainerHelpers.hpp"
 #include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeWithValue.hpp"
+#include "Utilities/SetNumberOfGridPoints.hpp"
 #include "Utilities/StdArrayHelpers.hpp"
 
 // IWYU pragma: no_include <complex>
@@ -393,7 +393,6 @@ void grad_unit_normal_one_form(
     const tnsr::ii<DataVector, 3, Frame>& d2x_radius,
     const DataVector& one_over_one_form_magnitude,
     const tnsr::Ijj<DataVector, 3, Frame>& christoffel_2nd_kind) {
-  destructive_resize_components(result, radius.size());
   const DataVector one_over_radius = 1.0 / get(radius);
   for (size_t i = 0; i < 3; ++i) {
     for (size_t j = i; j < 3; ++j) {  // symmetry
@@ -464,7 +463,7 @@ void expansion(const gsl::not_null<Scalar<DataVector>*> result,
   // (g^ij - S^i S^j) (GsBar_ij - K_ij)
   // and the ingoing expansion is
   // (g^ij - S^i S^j) (-GsBar_ij - K_ij)
-  destructive_resize_components(result, grad_normal.begin()->size());
+  set_number_of_grid_points(result, grad_normal);
   get(*result) = 0.0;
   for (size_t i = 0; i < 3; ++i) {
     for (size_t j = 0; j < 3; ++j) {
@@ -671,7 +670,7 @@ void spin_function(const gsl::not_null<Scalar<DataVector>*> result,
                    const tnsr::I<DataVector, 3, Frame>& unit_normal_vector,
                    const Scalar<DataVector>& area_element,
                    const tnsr::ii<DataVector, 3, Frame>& extrinsic_curvature) {
-  destructive_resize_components(result, get(area_element).size());
+  set_number_of_grid_points(result, area_element);
   for (auto& component : *result) {
     component = 0.0;
   }

--- a/src/DataStructures/DynamicVector.hpp
+++ b/src/DataStructures/DynamicVector.hpp
@@ -14,6 +14,7 @@
 #include <vector>
 
 #include "Utilities/MakeWithValue.hpp"
+#include "Utilities/SetNumberOfGridPoints.hpp"
 
 /// \cond
 namespace Options {
@@ -65,6 +66,17 @@ struct MakeWithSize<blaze::DynamicVector<T, TF, Tag>> {
   }
 };
 }  // namespace MakeWithValueImpls
+
+template <typename T, bool TF, typename Tag>
+struct SetNumberOfGridPointsImpls::SetNumberOfGridPointsImpl<
+    blaze::DynamicVector<T, TF, Tag>> {
+  static constexpr bool is_trivial = false;
+  static SPECTRE_ALWAYS_INLINE void apply(
+      const gsl::not_null<blaze::DynamicVector<T, TF, Tag>*> result,
+      const size_t size) {
+    result->resize(size);
+  }
+};
 
 namespace DynamicVector_detail {
 template <typename T>

--- a/src/DataStructures/SpinWeighted.hpp
+++ b/src/DataStructures/SpinWeighted.hpp
@@ -6,6 +6,7 @@
 #include "DataStructures/ComplexDataVector.hpp"
 #include "Utilities/ForceInline.hpp"
 #include "Utilities/Requires.hpp"
+#include "Utilities/SetNumberOfGridPoints.hpp"
 #include "Utilities/TypeTraits.hpp"
 
 /// @{
@@ -575,3 +576,15 @@ struct MakeWithSize<SpinWeighted<SpinWeightedType, Spin>> {
   }
 };
 }  // namespace MakeWithValueImpls
+
+template <int Spin, typename SpinWeightedType>
+struct SetNumberOfGridPointsImpls::SetNumberOfGridPointsImpl<
+    SpinWeighted<SpinWeightedType, Spin>> {
+  static constexpr bool is_trivial =
+      SetNumberOfGridPointsImpl<SpinWeightedType>::is_trivial;
+  static SPECTRE_ALWAYS_INLINE void apply(
+      const gsl::not_null<SpinWeighted<SpinWeightedType, Spin>*> result,
+      const size_t size) {
+    set_number_of_grid_points(make_not_null(&result->data()), size);
+  }
+};

--- a/src/DataStructures/StaticVector.hpp
+++ b/src/DataStructures/StaticVector.hpp
@@ -15,7 +15,9 @@
 
 #include "Options/ParseOptions.hpp"
 #include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/MakeWithValue.hpp"
+#include "Utilities/SetNumberOfGridPoints.hpp"
 
 namespace PUP {
 /// @{
@@ -60,6 +62,19 @@ struct MakeWithSize<blaze::StaticVector<T, N, TF, AF, PF, Tag>> {
   }
 };
 }  // namespace MakeWithValueImpls
+
+template <typename T, size_t N, bool TF, blaze::AlignmentFlag AF,
+          blaze::PaddingFlag PF, typename Tag>
+struct SetNumberOfGridPointsImpls::SetNumberOfGridPointsImpl<
+    blaze::StaticVector<T, N, TF, AF, PF, Tag>> {
+  static constexpr bool is_trivial = false;
+  static SPECTRE_ALWAYS_INLINE void apply(
+      const gsl::not_null<blaze::StaticVector<T, N, TF, AF, PF, Tag>*>
+      /*result*/,
+      const size_t size) {
+    ERROR("Tried to resize a StaticVector to " << size);
+  }
+};
 
 template <typename T, size_t N, bool TF, blaze::AlignmentFlag AF,
           blaze::PaddingFlag PF, typename Tag>

--- a/src/DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp
+++ b/src/DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp
@@ -12,13 +12,12 @@
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Variables.hpp"
-#include "Utilities/ContainerHelpers.hpp"
 #include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeWithValue.hpp"
 #include "Utilities/Requires.hpp"
+#include "Utilities/SetNumberOfGridPoints.hpp"
 #include "Utilities/TMPL.hpp"
-#include "Utilities/TypeTraits/IsComplexOfFundamental.hpp"
 
 namespace determinant_and_inverse_detail {
 // Helps to shorten some repeated code:
@@ -378,10 +377,8 @@ void determinant_and_inverse(
                 "Tensor is not allowed since it's not clear what that means.");
   static_assert(not std::is_integral<T>::value, "Can't invert a Tensor<int>.");
 
-  if constexpr (not tt::is_complex_or_fundamental_v<T>) {
-    destructive_resize_components(det, get<0, 0>(tensor).size());
-    destructive_resize_components(inv, get<0, 0>(tensor).size());
-  }
+  set_number_of_grid_points(det, tensor);
+  set_number_of_grid_points(inv, tensor);
   determinant_and_inverse_detail::DetAndInverseImpl<Symm, Index0,
                                                     Index1>::apply(det, inv,
                                                                    tensor);

--- a/src/DataStructures/Tensor/EagerMath/Magnitude.hpp
+++ b/src/DataStructures/Tensor/EagerMath/Magnitude.hpp
@@ -10,8 +10,8 @@
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
-#include "Utilities/ContainerHelpers.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/SetNumberOfGridPoints.hpp"
 #include "Utilities/TMPL.hpp"
 
 /// @{
@@ -32,7 +32,7 @@ Scalar<DataType> magnitude(
 template <typename DataType, typename Index>
 void magnitude(const gsl::not_null<Scalar<DataType>*> magnitude,
                const Tensor<DataType, Symmetry<1>, index_list<Index>>& vector) {
-  destructive_resize_components(magnitude, get_size(get<0>(vector)));
+  set_number_of_grid_points(magnitude, vector);
   dot_product(magnitude, vector, vector);
   get(*magnitude) = sqrt(get(*magnitude));
 }
@@ -130,7 +130,6 @@ struct NormalizedCompute : Normalized<Tag>, db::ComputeTag {
   static void function(const gsl::not_null<return_type*> normalized_vector,
                        const typename Tag::type& vector_in,
                        const typename Magnitude<Tag>::type& magnitude) {
-    destructive_resize_components(normalized_vector, get_size(get(magnitude)));
     *normalized_vector = vector_in;
     for (size_t d = 0; d < normalized_vector->index_dim(0); ++d) {
       normalized_vector->get(d) /= get(magnitude);

--- a/src/DataStructures/Tensor/EagerMath/Norms.hpp
+++ b/src/DataStructures/Tensor/EagerMath/Norms.hpp
@@ -9,7 +9,6 @@
 #include "DataStructures/DataBox/TagName.hpp"
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
-#include "Utilities/ContainerHelpers.hpp"
 #include "Utilities/Functional.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/Numeric.hpp"
@@ -59,7 +58,6 @@ Scalar<DataType> pointwise_l2_norm(
 template <typename DataType, typename Symm, typename IndexList>
 void pointwise_l2_norm(const gsl::not_null<Scalar<DataType>*> norm,
                        const Tensor<DataType, Symm, IndexList>& tensor) {
-  destructive_resize_components(norm, get_size(tensor[0].size()));
   get(*norm) = sqrt(get(L2Norm_detail::pointwise_l2_norm_square(tensor)));
 }
 /// @}

--- a/src/DataStructures/Tensor/Tensor.hpp
+++ b/src/DataStructures/Tensor/Tensor.hpp
@@ -42,6 +42,7 @@
 #include "Utilities/MakeWithValue.hpp"
 #include "Utilities/PrettyType.hpp"
 #include "Utilities/Requires.hpp"
+#include "Utilities/SetNumberOfGridPoints.hpp"
 #include "Utilities/StdHelpers.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TypeTraits.hpp"
@@ -615,3 +616,15 @@ struct MakeWithValueImpl<Tensor<std::complex<double>, Structure...>, T> {
   }
 };
 }  // namespace MakeWithValueImpls
+
+template <typename T, typename... Structure>
+struct SetNumberOfGridPointsImpls::SetNumberOfGridPointsImpl<
+    Tensor<T, Structure...>> {
+  static constexpr bool is_trivial = SetNumberOfGridPointsImpl<T>::is_trivial;
+  static SPECTRE_ALWAYS_INLINE void apply(
+      const gsl::not_null<Tensor<T, Structure...>*> result, const size_t size) {
+    for (auto& component : *result) {
+      set_number_of_grid_points(make_not_null(&component), size);
+    }
+  }
+};

--- a/src/DataStructures/Variables.hpp
+++ b/src/DataStructures/Variables.hpp
@@ -40,6 +40,7 @@
 #include "Utilities/MemoryHelpers.hpp"
 #include "Utilities/PrettyType.hpp"
 #include "Utilities/Requires.hpp"
+#include "Utilities/SetNumberOfGridPoints.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
 #include "Utilities/TypeTraits.hpp"
@@ -1073,6 +1074,16 @@ struct NumberOfPoints<Variables<TagList>> {
   }
 };
 }  // namespace MakeWithValueImpls
+
+template <typename TagList>
+struct SetNumberOfGridPointsImpls::SetNumberOfGridPointsImpl<
+    Variables<TagList>> {
+  static constexpr bool is_trivial = false;
+  static SPECTRE_ALWAYS_INLINE void apply(
+      const gsl::not_null<Variables<TagList>*> result, const size_t size) {
+    result->initialize(size);
+  }
+};
 
 namespace EqualWithinRoundoffImpls {
 // It would be nice to use `blaze::equal` in these implementations, but it

--- a/src/DataStructures/VectorImpl.hpp
+++ b/src/DataStructures/VectorImpl.hpp
@@ -30,6 +30,7 @@
 #include "Utilities/MemoryHelpers.hpp"
 #include "Utilities/PrintHelpers.hpp"
 #include "Utilities/Requires.hpp"
+#include "Utilities/SetNumberOfGridPoints.hpp"
 #include "Utilities/StdArrayHelpers.hpp"
 #include "Utilities/TypeTraits/IsComplexOfFundamental.hpp"
 
@@ -639,22 +640,30 @@ std::ostream& operator<<(std::ostream& os,
  *
  * \param VECTOR_TYPE The vector type (e.g. `DataVector`)
  */
-#define MAKE_WITH_VALUE_IMPL_DEFINITION_FOR(VECTOR_TYPE)                  \
-  namespace MakeWithValueImpls {                                          \
-  template <>                                                             \
-  struct NumberOfPoints<VECTOR_TYPE> {                                    \
-    static SPECTRE_ALWAYS_INLINE size_t apply(const VECTOR_TYPE& input) { \
-      return input.size();                                                \
-    }                                                                     \
-  };                                                                      \
-  template <>                                                             \
-  struct MakeWithSize<VECTOR_TYPE> {                                      \
-    static SPECTRE_ALWAYS_INLINE VECTOR_TYPE                              \
-    apply(const size_t size, const VECTOR_TYPE::value_type value) {       \
-      return VECTOR_TYPE(size, value);                                    \
-    }                                                                     \
-  };                                                                      \
-  }  // namespace MakeWithValueImpls
+#define MAKE_WITH_VALUE_IMPL_DEFINITION_FOR(VECTOR_TYPE)                      \
+  namespace MakeWithValueImpls {                                              \
+  template <>                                                                 \
+  struct NumberOfPoints<VECTOR_TYPE> {                                        \
+    static SPECTRE_ALWAYS_INLINE size_t apply(const VECTOR_TYPE& input) {     \
+      return input.size();                                                    \
+    }                                                                         \
+  };                                                                          \
+  template <>                                                                 \
+  struct MakeWithSize<VECTOR_TYPE> {                                          \
+    static SPECTRE_ALWAYS_INLINE VECTOR_TYPE                                  \
+    apply(const size_t size, const VECTOR_TYPE::value_type value) {           \
+      return VECTOR_TYPE(size, value);                                        \
+    }                                                                         \
+  };                                                                          \
+  } /* namespace MakeWithValueImpls */                                        \
+  template <>                                                                 \
+  struct SetNumberOfGridPointsImpls::SetNumberOfGridPointsImpl<VECTOR_TYPE> { \
+    static constexpr bool is_trivial = false;                                 \
+    static SPECTRE_ALWAYS_INLINE void apply(                                  \
+        const gsl::not_null<VECTOR_TYPE*> result, const size_t size) {        \
+      result->destructive_resize(size);                                       \
+    }                                                                         \
+  };
 
 /// @{
 /*!

--- a/src/Domain/AreaElement.cpp
+++ b/src/Domain/AreaElement.cpp
@@ -10,7 +10,6 @@
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/Structure/Direction.hpp"
 #include "Utilities/ConstantExpressions.hpp"
-#include "Utilities/ContainerHelpers.hpp"
 #include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
@@ -28,8 +27,6 @@ void euclidean_area_element(
          "of grid points but have "
              << inverse_jacobian_face.get(0, 0).size() << " and "
              << get(inverse_jacobian_determinant_face).size());
-  destructive_resize_components(result,
-                                get(inverse_jacobian_determinant_face).size());
   get(*result) = square(inverse_jacobian_face.get(direction.dimension(), 0));
   for (size_t d = 1; d < VolumeDim; ++d) {
     get(*result) += square(inverse_jacobian_face.get(direction.dimension(), d));

--- a/src/Domain/CoordinateMaps/FocallyLiftedEndcap.cpp
+++ b/src/Domain/CoordinateMaps/FocallyLiftedEndcap.cpp
@@ -12,12 +12,12 @@
 #include "Domain/CoordinateMaps/CylindricalEndcapHelpers.hpp"
 #include "Domain/CoordinateMaps/FocallyLiftedMapHelpers.hpp"
 #include "Utilities/ConstantExpressions.hpp"
-#include "Utilities/ContainerHelpers.hpp"
 #include "Utilities/DereferenceWrapper.hpp"
 #include "Utilities/EqualWithinRoundoff.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/MakeWithValue.hpp"
 #include "Utilities/Serialization/PupStlCpp11.hpp"
+#include "Utilities/SetNumberOfGridPoints.hpp"
 
 namespace domain::CoordinateMaps::FocallyLiftedInnerMaps {
 
@@ -68,10 +68,7 @@ void Endcap::jacobian(const gsl::not_null<tnsr::Ij<tt::remove_cvref_wrap_t<T>,
   const ReturnType& xbar = source_coords[0];
   const ReturnType& ybar = source_coords[1];
 
-  if constexpr (not std::is_same<ReturnType, double>::value) {
-    destructive_resize_components(
-        jacobian_out, static_cast<ReturnType>(source_coords[0]).size());
-  }
+  set_number_of_grid_points(jacobian_out, source_coords);
   // Most of the jacobian components are zero.
   for (auto& jac_component : *jacobian_out) {
     jac_component = 0.0;
@@ -118,10 +115,7 @@ void Endcap::inv_jacobian(
   const ReturnType& xbar = source_coords[0];
   const ReturnType& ybar = source_coords[1];
 
-  if constexpr (not std::is_same<ReturnType, double>::value) {
-    destructive_resize_components(
-        inv_jacobian_out, static_cast<ReturnType>(source_coords[0]).size());
-  }
+  set_number_of_grid_points(inv_jacobian_out, source_coords);
   // Most of the inverse jacobian components are zero.
   for (auto& jac_component : *inv_jacobian_out) {
     jac_component = 0.0;
@@ -219,11 +213,7 @@ void Endcap::deriv_sigma(
     const gsl::not_null<std::array<tt::remove_cvref_wrap_t<T>, 3>*>
         deriv_sigma_out,
     const std::array<T, 3>& source_coords) const {
-  using ReturnType = tt::remove_cvref_wrap_t<T>;
-  if constexpr (not std::is_same<ReturnType, double>::value) {
-    destructive_resize_components(
-        deriv_sigma_out, static_cast<ReturnType>(source_coords[0]).size());
-  }
+  set_number_of_grid_points(deriv_sigma_out, source_coords);
   (*deriv_sigma_out)[0] = 0.0;
   (*deriv_sigma_out)[1] = 0.0;
   (*deriv_sigma_out)[2] = 0.5;
@@ -234,11 +224,7 @@ void Endcap::dxbar_dsigma(
     const gsl::not_null<std::array<tt::remove_cvref_wrap_t<T>, 3>*>
         dxbar_dsigma_out,
     const std::array<T, 3>& source_coords) const {
-  using ReturnType = tt::remove_cvref_wrap_t<T>;
-  if constexpr (not std::is_same<ReturnType, double>::value) {
-    destructive_resize_components(
-        dxbar_dsigma_out, static_cast<ReturnType>(source_coords[0]).size());
-  }
+  set_number_of_grid_points(dxbar_dsigma_out, source_coords);
   (*dxbar_dsigma_out)[0] = 0.0;
   (*dxbar_dsigma_out)[1] = 0.0;
   (*dxbar_dsigma_out)[2] = 2.0;

--- a/src/Domain/CoordinateMaps/FocallyLiftedFlatEndcap.cpp
+++ b/src/Domain/CoordinateMaps/FocallyLiftedFlatEndcap.cpp
@@ -10,11 +10,11 @@
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Utilities/ConstantExpressions.hpp"
-#include "Utilities/ContainerHelpers.hpp"
 #include "Utilities/DereferenceWrapper.hpp"
 #include "Utilities/EqualWithinRoundoff.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Serialization/PupStlCpp11.hpp"
+#include "Utilities/SetNumberOfGridPoints.hpp"
 
 namespace domain::CoordinateMaps::FocallyLiftedInnerMaps {
 
@@ -55,12 +55,7 @@ void FlatEndcap::jacobian(
         tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame>*>
         jacobian_out,
     const std::array<T, 3>& source_coords) const {
-  using ReturnType = tt::remove_cvref_wrap_t<T>;
-
-  if constexpr (not std::is_same_v<ReturnType, double>) {
-    destructive_resize_components(
-        jacobian_out, static_cast<ReturnType>(source_coords[0]).size());
-  }
+  set_number_of_grid_points(jacobian_out, source_coords);
   // Most of the jacobian components are zero.
   for (auto& jac_component : *jacobian_out) {
     jac_component = 0.0;
@@ -78,12 +73,7 @@ void FlatEndcap::inv_jacobian(
         tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame>*>
         inv_jacobian_out,
     const std::array<T, 3>& source_coords) const {
-  using ReturnType = tt::remove_cvref_wrap_t<T>;
-
-  if constexpr (not std::is_same_v<ReturnType, double>) {
-    destructive_resize_components(
-        inv_jacobian_out, static_cast<ReturnType>(source_coords[0]).size());
-  }
+  set_number_of_grid_points(inv_jacobian_out, source_coords);
   // Most of the inverse jacobian components are zero.
   for (auto& jac_component : *inv_jacobian_out) {
     jac_component = 0.0;
@@ -124,11 +114,7 @@ void FlatEndcap::deriv_sigma(
     const gsl::not_null<std::array<tt::remove_cvref_wrap_t<T>, 3>*>
         deriv_sigma_out,
     const std::array<T, 3>& source_coords) const {
-  using ReturnType = tt::remove_cvref_wrap_t<T>;
-  if constexpr (not std::is_same_v<ReturnType, double>) {
-    destructive_resize_components(
-        deriv_sigma_out, static_cast<ReturnType>(source_coords[0]).size());
-  }
+  set_number_of_grid_points(deriv_sigma_out, source_coords);
   (*deriv_sigma_out)[0] = 0.0;
   (*deriv_sigma_out)[1] = 0.0;
   (*deriv_sigma_out)[2] = 0.5;
@@ -139,11 +125,7 @@ void FlatEndcap::dxbar_dsigma(
     const gsl::not_null<std::array<tt::remove_cvref_wrap_t<T>, 3>*>
         dxbar_dsigma_out,
     const std::array<T, 3>& source_coords) const {
-  using ReturnType = tt::remove_cvref_wrap_t<T>;
-  if constexpr (not std::is_same_v<ReturnType, double>) {
-    destructive_resize_components(
-        dxbar_dsigma_out, static_cast<ReturnType>(source_coords[0]).size());
-  }
+  set_number_of_grid_points(dxbar_dsigma_out, source_coords);
   (*dxbar_dsigma_out)[0] = 0.0;
   (*dxbar_dsigma_out)[1] = 0.0;
   (*dxbar_dsigma_out)[2] = 2.0;
@@ -167,13 +149,7 @@ void FlatEndcap::deriv_lambda_tilde(
         deriv_lambda_tilde_out,
     const std::array<T, 3>& target_coords, const T& lambda_tilde,
     const std::array<double, 3>& projection_point) const {
-  using ReturnType = tt::remove_cvref_wrap_t<T>;
-
-  if constexpr (not std::is_same_v<ReturnType, double>) {
-    destructive_resize_components(
-        deriv_lambda_tilde_out,
-        static_cast<ReturnType>(target_coords[0]).size());
-  }
+  set_number_of_grid_points(deriv_lambda_tilde_out, target_coords);
 
   (*deriv_lambda_tilde_out)[0] = 0.0;
   (*deriv_lambda_tilde_out)[1] = 0.0;

--- a/src/Domain/CoordinateMaps/FocallyLiftedFlatSide.cpp
+++ b/src/Domain/CoordinateMaps/FocallyLiftedFlatSide.cpp
@@ -13,13 +13,13 @@
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Utilities/ConstantExpressions.hpp"
-#include "Utilities/ContainerHelpers.hpp"
 #include "Utilities/DereferenceWrapper.hpp"
 #include "Utilities/EqualWithinRoundoff.hpp"
 #include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/Serialization/PupStlCpp11.hpp"
+#include "Utilities/SetNumberOfGridPoints.hpp"
 #include "Utilities/TypeTraits/RemoveReferenceWrapper.hpp"
 
 namespace domain::CoordinateMaps::FocallyLiftedInnerMaps {
@@ -71,10 +71,7 @@ void FlatSide::jacobian(const gsl::not_null<tnsr::Ij<tt::remove_cvref_wrap_t<T>,
   const ReturnType& xbar = source_coords[0];
   const ReturnType& ybar = source_coords[1];
 
-  if constexpr (not std::is_same_v<ReturnType, double>) {
-    destructive_resize_components(
-        jacobian_out, static_cast<ReturnType>(source_coords[0]).size());
-  }
+  set_number_of_grid_points(jacobian_out, source_coords);
 
   // Use part of Jacobian as temp storage to reduce allocations.
   get<1, 1>(*jacobian_out) = 1.0 / cube(sqrt(square(xbar) + square(ybar)));
@@ -112,10 +109,7 @@ void FlatSide::inv_jacobian(
   const ReturnType& xbar = source_coords[0];
   const ReturnType& ybar = source_coords[1];
 
-  if constexpr (not std::is_same<ReturnType, double>::value) {
-    destructive_resize_components(
-        inv_jacobian_out, static_cast<ReturnType>(source_coords[0]).size());
-  }
+  set_number_of_grid_points(inv_jacobian_out, source_coords);
 
   // Use part of inverse Jacobian for temp storage to avoid allocations.
   const double tmp =
@@ -182,11 +176,7 @@ void FlatSide::deriv_sigma(
     const gsl::not_null<std::array<tt::remove_cvref_wrap_t<T>, 3>*>
         deriv_sigma_out,
     const std::array<T, 3>& source_coords) const {
-  using ReturnType = tt::remove_cvref_wrap_t<T>;
-  if constexpr (not std::is_same<ReturnType, double>::value) {
-    destructive_resize_components(
-        deriv_sigma_out, static_cast<ReturnType>(source_coords[0]).size());
-  }
+  set_number_of_grid_points(deriv_sigma_out, source_coords);
   (*deriv_sigma_out)[0] = 0.0;
   (*deriv_sigma_out)[1] = 0.0;
   (*deriv_sigma_out)[2] = 0.5;
@@ -197,11 +187,7 @@ void FlatSide::dxbar_dsigma(
     const gsl::not_null<std::array<tt::remove_cvref_wrap_t<T>, 3>*>
         dxbar_dsigma_out,
     const std::array<T, 3>& source_coords) const {
-  using ReturnType = tt::remove_cvref_wrap_t<T>;
-  if constexpr (not std::is_same<ReturnType, double>::value) {
-    destructive_resize_components(
-        dxbar_dsigma_out, static_cast<ReturnType>(source_coords[0]).size());
-  }
+  set_number_of_grid_points(dxbar_dsigma_out, source_coords);
   (*dxbar_dsigma_out)[0] = 0.0;
   (*dxbar_dsigma_out)[1] = 0.0;
   (*dxbar_dsigma_out)[2] = 2.0;
@@ -225,12 +211,7 @@ void FlatSide::deriv_lambda_tilde(
         deriv_lambda_tilde_out,
     const std::array<T, 3>& target_coords, const T& lambda_tilde,
     const std::array<double, 3>& projection_point) const {
-  using ReturnType = tt::remove_cvref_wrap_t<T>;
-  if constexpr (not std::is_same<ReturnType, double>::value) {
-    destructive_resize_components(
-        deriv_lambda_tilde_out,
-        static_cast<ReturnType>(target_coords[0]).size());
-  }
+  set_number_of_grid_points(deriv_lambda_tilde_out, target_coords);
   (*deriv_lambda_tilde_out)[0] = 0.0;
   (*deriv_lambda_tilde_out)[1] = 0.0;
   (*deriv_lambda_tilde_out)[2] =

--- a/src/Domain/CoordinateMaps/FocallyLiftedSide.cpp
+++ b/src/Domain/CoordinateMaps/FocallyLiftedSide.cpp
@@ -11,12 +11,12 @@
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/CoordinateMaps/FocallyLiftedMapHelpers.hpp"
 #include "Utilities/ConstantExpressions.hpp"
-#include "Utilities/ContainerHelpers.hpp"
 #include "Utilities/DereferenceWrapper.hpp"
 #include "Utilities/EqualWithinRoundoff.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/MakeWithValue.hpp"
 #include "Utilities/Serialization/PupStlCpp11.hpp"
+#include "Utilities/SetNumberOfGridPoints.hpp"
 
 namespace domain::CoordinateMaps::FocallyLiftedInnerMaps {
 
@@ -84,10 +84,7 @@ void Side::jacobian(const gsl::not_null<tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3,
   const ReturnType& ybar = source_coords[1];
   const ReturnType& zbar = source_coords[2];
 
-  if constexpr (not std::is_same_v<ReturnType, double>) {
-    destructive_resize_components(
-        jacobian_out, static_cast<ReturnType>(source_coords[0]).size());
-  }
+  set_number_of_grid_points(jacobian_out, source_coords);
 
   // Use (1,1) (2,2), and (1,2) parts of Jacobian as temp storage to
   // reduce allocations.
@@ -132,10 +129,7 @@ void Side::inv_jacobian(const gsl::not_null<tnsr::Ij<tt::remove_cvref_wrap_t<T>,
   const ReturnType& ybar = source_coords[1];
   const ReturnType& zbar = source_coords[2];
 
-  if constexpr (not std::is_same<ReturnType, double>::value) {
-    destructive_resize_components(
-        inv_jacobian_out, static_cast<ReturnType>(source_coords[0]).size());
-  }
+  set_number_of_grid_points(inv_jacobian_out, source_coords);
 
   // Use parts of inverse Jacobian as temp storage to reduce allocations.
   const double theta_factor = 0.5 * (theta_min_ - theta_max_);
@@ -202,10 +196,7 @@ void Side::deriv_sigma(
   using ReturnType = tt::remove_cvref_wrap_t<T>;
   const ReturnType& xbar = source_coords[0];
   const ReturnType& ybar = source_coords[1];
-  if constexpr (not std::is_same<ReturnType, double>::value) {
-    destructive_resize_components(
-        deriv_sigma_out, static_cast<ReturnType>(source_coords[0]).size());
-  }
+  set_number_of_grid_points(deriv_sigma_out, source_coords);
 
   // Use as temp storage to reduce allocations.
   // Note that denominator is guaranteed to be nonzero.

--- a/src/Domain/FaceNormal.cpp
+++ b/src/Domain/FaceNormal.cpp
@@ -10,21 +10,19 @@
 #include "Domain/InterfaceLogicalCoordinates.hpp"
 #include "Domain/Structure/Direction.hpp"  // IWYU pragma: keep
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
-#include "Utilities/ContainerHelpers.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
 
 template <size_t VolumeDim, typename TargetFrame>
 void unnormalized_face_normal(
     const gsl::not_null<tnsr::i<DataVector, VolumeDim, TargetFrame>*> result,
-    const Mesh<VolumeDim - 1>& interface_mesh,
+    const Mesh<VolumeDim - 1>& /*interface_mesh*/,
     const InverseJacobian<DataVector, VolumeDim, Frame::ElementLogical,
                           TargetFrame>& inv_jacobian_on_interface,
     const Direction<VolumeDim>& direction) {
   const auto sliced_away_dim = direction.dimension();
   const double sign = direction.sign();
 
-  destructive_resize_components(result, interface_mesh.number_of_grid_points());
   for (size_t d = 0; d < VolumeDim; ++d) {
     result->get(d) = sign * inv_jacobian_on_interface.get(sliced_away_dim, d);
   }

--- a/src/Domain/JacobianDiagnostic.cpp
+++ b/src/Domain/JacobianDiagnostic.cpp
@@ -25,7 +25,6 @@ void jacobian_diagnostic(
         tnsr::I<DataVector, Dim, Fr>, Dim, UpLo::Lo,
         typename Frame::ElementLogical>& numeric_jacobian_transpose) {
   const size_t number_of_points = analytic_jacobian.begin()->size();
-  destructive_resize_components(jacobian_diag, number_of_points);
 
   // i_hat = logical frame index
   // i = mapped frame index

--- a/src/Evolution/DgSubcell/GhostZoneLogicalCoordinates.cpp
+++ b/src/Evolution/DgSubcell/GhostZoneLogicalCoordinates.cpp
@@ -12,10 +12,10 @@
 #include "Domain/Structure/Side.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
-#include "Utilities/ContainerHelpers.hpp"
 #include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/SetNumberOfGridPoints.hpp"
 
 namespace evolution::dg::subcell::fd {
 
@@ -35,7 +35,7 @@ void ghost_zone_logical_coordinates(
              << ghost_zone_size << ") is larger than the volume extent ("
              << subcell_extent_to_direction << ") to the direction");
 
-  destructive_resize_components(
+  set_number_of_grid_points(
       ghost_logical_coords,
       ghost_zone_size *
           subcell_mesh.extents().slice_away(dim_direction).product());

--- a/src/Evolution/DgSubcell/ReconstructionOrder.hpp
+++ b/src/Evolution/DgSubcell/ReconstructionOrder.hpp
@@ -16,8 +16,8 @@
 #include "Evolution/DgSubcell/Tags/Mesh.hpp"
 #include "Evolution/DgSubcell/Tags/ReconstructionOrder.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
-#include "Utilities/ContainerHelpers.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/SetNumberOfGridPoints.hpp"
 
 namespace evolution::dg::subcell {
 /// Copies the `reconstruction_order` into the DataBox tag
@@ -36,7 +36,7 @@ void store_reconstruction_order_in_databox(
             (*recons_order_ptr) = typename std::decay_t<
                 decltype(*recons_order_ptr)>::value_type{};
           }
-          destructive_resize_components(
+          set_number_of_grid_points(
               make_not_null(&(recons_order_ptr->value())),
               subcell_mesh.number_of_grid_points());
           for (size_t d = Dim - 1; d < Dim; --d) {

--- a/src/Evolution/DgSubcell/Tags/MethodOrder.cpp
+++ b/src/Evolution/DgSubcell/Tags/MethodOrder.cpp
@@ -6,10 +6,10 @@
 #include "Evolution/DgSubcell/ActiveGrid.hpp"
 #include "Evolution/DgSubcell/SubcellOptions.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
-#include "Utilities/ContainerHelpers.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/SetNumberOfGridPoints.hpp"
 
 namespace evolution::dg::subcell::Tags {
 template <size_t Dim>
@@ -23,14 +23,14 @@ void MethodOrderCompute<Dim>::function(
     *method_order = typename return_type::value_type{};
   }
   if (active_grid == subcell::ActiveGrid::Dg) {
-    destructive_resize_components(make_not_null(&method_order->value()),
-                                  dg_mesh.number_of_grid_points());
+    set_number_of_grid_points(make_not_null(&method_order->value()),
+                              dg_mesh.number_of_grid_points());
     for (size_t i = 0; i < Dim; ++i) {
       method_order->value()[i] = dg_mesh.extents(i);
     }
   } else {
-    destructive_resize_components(make_not_null(&method_order->value()),
-                                  subcell_mesh.number_of_grid_points());
+    set_number_of_grid_points(make_not_null(&method_order->value()),
+                              subcell_mesh.number_of_grid_points());
     if (reconstruction_order.has_value()) {
       *method_order = reconstruction_order;
     } else {

--- a/src/Evolution/Systems/Cce/AnalyticSolutions/WorldtubeData.hpp
+++ b/src/Evolution/Systems/Cce/AnalyticSolutions/WorldtubeData.hpp
@@ -16,9 +16,9 @@
 #include "NumericalAlgorithms/Spectral/SwshCollocation.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/AnalyticSolution.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
-#include "Utilities/ContainerHelpers.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/Serialization/CharmPupable.hpp"
+#include "Utilities/SetNumberOfGridPoints.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
 
@@ -139,7 +139,7 @@ struct WorldtubeData : public PUP::able {
       return item_cache.data;
     }
     auto& item = item_cache.data;
-    destructive_resize_components(
+    set_number_of_grid_points(
         make_not_null(&item),
         Spectral::Swsh::number_of_swsh_collocation_points(output_l_max));
     variables_impl(make_not_null(&item), output_l_max, time,

--- a/src/Evolution/Systems/Cce/BoundaryData.cpp
+++ b/src/Evolution/Systems/Cce/BoundaryData.cpp
@@ -15,8 +15,8 @@
 #include "DataStructures/Variables.hpp"
 #include "NumericalAlgorithms/Spectral/SwshCollocation.hpp"
 #include "NumericalAlgorithms/Spectral/SwshDerivatives.hpp"
-#include "Utilities/ContainerHelpers.hpp"
 #include "Utilities/Math.hpp"
+#include "Utilities/SetNumberOfGridPoints.hpp"
 
 namespace Cce {
 
@@ -26,10 +26,10 @@ void trigonometric_functions_on_swsh_collocation(
     const gsl::not_null<Scalar<DataVector>*> sin_phi,
     const gsl::not_null<Scalar<DataVector>*> sin_theta, const size_t l_max) {
   const size_t size = Spectral::Swsh::number_of_swsh_collocation_points(l_max);
-  destructive_resize_components(cos_phi, size);
-  destructive_resize_components(cos_theta, size);
-  destructive_resize_components(sin_phi, size);
-  destructive_resize_components(sin_theta, size);
+  set_number_of_grid_points(cos_phi, size);
+  set_number_of_grid_points(cos_theta, size);
+  set_number_of_grid_points(sin_phi, size);
+  set_number_of_grid_points(sin_theta, size);
 
   const auto& collocation = Spectral::Swsh::cached_collocation_metadata<
       Spectral::Swsh::ComplexRepresentation::Interleaved>(l_max);
@@ -50,9 +50,9 @@ void cartesian_to_spherical_coordinates_and_jacobians(
     const Scalar<DataVector>& sin_phi, const Scalar<DataVector>& sin_theta,
     const double extraction_radius) {
   const size_t size = get(cos_phi).size();
-  destructive_resize_components(unit_cartesian_coords, size);
-  destructive_resize_components(cartesian_to_spherical_jacobian, size);
-  destructive_resize_components(inverse_cartesian_to_spherical_jacobian, size);
+  set_number_of_grid_points(unit_cartesian_coords, size);
+  set_number_of_grid_points(cartesian_to_spherical_jacobian, size);
+  set_number_of_grid_points(inverse_cartesian_to_spherical_jacobian, size);
 
   // note: factor of r scaled out
   get<0>(*unit_cartesian_coords) = get(sin_theta) * get(cos_phi);
@@ -115,13 +115,13 @@ void cartesian_spatial_metric_and_derivatives_from_modes(
     const CartesianiSphericalJ& inverse_cartesian_to_spherical_jacobian,
     const size_t l_max) {
   const size_t size = get<0, 0>(inverse_cartesian_to_spherical_jacobian).size();
-  destructive_resize_components(cartesian_spatial_metric, size);
-  destructive_resize_components(d_cartesian_spatial_metric, size);
-  destructive_resize_components(dt_cartesian_spatial_metric, size);
+  set_number_of_grid_points(cartesian_spatial_metric, size);
+  set_number_of_grid_points(d_cartesian_spatial_metric, size);
+  set_number_of_grid_points(dt_cartesian_spatial_metric, size);
 
-  destructive_resize_components(interpolation_buffer, size);
-  destructive_resize_components(interpolation_modal_buffer, size);
-  destructive_resize_components(eth_buffer, size);
+  set_number_of_grid_points(interpolation_buffer, size);
+  set_number_of_grid_points(interpolation_modal_buffer, size);
+  set_number_of_grid_points(eth_buffer, size);
 
   // Allocation
   SphericaliCartesianjj spherical_d_cartesian_spatial_metric{size};
@@ -206,13 +206,13 @@ void cartesian_shift_and_derivatives_from_modes(
     const CartesianiSphericalJ& inverse_cartesian_to_spherical_jacobian,
     const size_t l_max) {
   const size_t size = get<0, 0>(inverse_cartesian_to_spherical_jacobian).size();
-  destructive_resize_components(cartesian_shift, size);
-  destructive_resize_components(d_cartesian_shift, size);
-  destructive_resize_components(dt_cartesian_shift, size);
+  set_number_of_grid_points(cartesian_shift, size);
+  set_number_of_grid_points(d_cartesian_shift, size);
+  set_number_of_grid_points(dt_cartesian_shift, size);
 
-  destructive_resize_components(interpolation_buffer, size);
-  destructive_resize_components(interpolation_modal_buffer, size);
-  destructive_resize_components(eth_buffer, size);
+  set_number_of_grid_points(interpolation_buffer, size);
+  set_number_of_grid_points(interpolation_modal_buffer, size);
+  set_number_of_grid_points(eth_buffer, size);
 
   // Allocation
   SphericaliCartesianJ spherical_d_cartesian_shift{size};
@@ -279,13 +279,13 @@ void cartesian_lapse_and_derivatives_from_modes(
     const CartesianiSphericalJ& inverse_cartesian_to_spherical_jacobian,
     const size_t l_max) {
   const size_t size = get<0, 0>(inverse_cartesian_to_spherical_jacobian).size();
-  destructive_resize_components(cartesian_lapse, size);
-  destructive_resize_components(d_cartesian_lapse, size);
-  destructive_resize_components(dt_cartesian_lapse, size);
+  set_number_of_grid_points(cartesian_lapse, size);
+  set_number_of_grid_points(d_cartesian_lapse, size);
+  set_number_of_grid_points(dt_cartesian_lapse, size);
 
-  destructive_resize_components(interpolation_buffer, size);
-  destructive_resize_components(interpolation_modal_buffer, size);
-  destructive_resize_components(eth_buffer, size);
+  set_number_of_grid_points(interpolation_buffer, size);
+  set_number_of_grid_points(interpolation_modal_buffer, size);
+  set_number_of_grid_points(eth_buffer, size);
 
   // Allocation
   tnsr::i<DataVector, 3> spherical_d_cartesian_lapse{size};
@@ -338,8 +338,8 @@ void null_metric_and_derivative(
     const tnsr::aa<DataVector, 3>& dt_spacetime_metric,
     const tnsr::aa<DataVector, 3>& spacetime_metric) {
   const size_t size = get<0, 0>(spacetime_metric).size();
-  destructive_resize_components(null_metric, size);
-  destructive_resize_components(du_null_metric, size);
+  set_number_of_grid_points(null_metric, size);
+  set_number_of_grid_points(du_null_metric, size);
 
   get<0, 0>(*null_metric) = get<0, 0>(spacetime_metric);
   get<0, 0>(*du_null_metric) = get<0, 0>(dt_spacetime_metric);
@@ -427,8 +427,6 @@ void worldtube_normal_and_derivatives(
     const Scalar<DataVector>& sin_phi, const Scalar<DataVector>& sin_theta,
     const tnsr::II<DataVector, 3>& inverse_spatial_metric) {
   const size_t size = get<0, 0>(spacetime_metric).size();
-  destructive_resize_components(worldtube_normal, size);
-  destructive_resize_components(dt_worldtube_normal, size);
 
   // Allocation
   Variables<tmpl::list<::Tags::Tempi<0, 3>, ::Tags::TempScalar<1>>>
@@ -486,8 +484,6 @@ void null_vector_l_and_derivatives(
     const tnsr::I<DataVector, 3>& shift,
     const tnsr::I<DataVector, 3>& worldtube_normal) {
   const size_t size = get(lapse).size();
-  destructive_resize_components(du_null_l, size);
-  destructive_resize_components(null_l, size);
 
   // Allocation
   Variables<tmpl::list<::Tags::TempScalar<0>, ::Tags::TempScalar<1>,
@@ -577,8 +573,8 @@ void dlambda_null_metric_and_inverse(
     const tnsr::aa<DataVector, 3>& spacetime_metric) {
   // first, the (down-index) null metric
   const size_t size = get<0, 0>(spacetime_metric).size();
-  destructive_resize_components(dlambda_null_metric, size);
-  destructive_resize_components(dlambda_inverse_null_metric, size);
+  set_number_of_grid_points(dlambda_null_metric, size);
+  set_number_of_grid_points(dlambda_inverse_null_metric, size);
 
   get<0, 0>(*dlambda_null_metric) =
       get<0>(null_l) * get<0, 0>(dt_spacetime_metric) +
@@ -723,8 +719,6 @@ void dlambda_null_metric_and_inverse(
 void bondi_r(
     const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 0>>*> bondi_r,
     const tnsr::aa<DataVector, 3, Frame::RadialNull>& null_metric) {
-  destructive_resize_components(bondi_r, get<0, 0>(null_metric).size());
-
   // the inclusion of the std::complex<double> informs the expression
   // templates to turn the result into a ComplexDataVector
   get(*bondi_r).data() = std::complex<double>(1.0, 0) *
@@ -740,9 +734,6 @@ void d_bondi_r(
     const tnsr::aa<DataVector, 3, Frame::RadialNull>& du_null_metric,
     const tnsr::AA<DataVector, 3, Frame::RadialNull>& inverse_null_metric,
     const size_t l_max) {
-  destructive_resize_components(d_bondi_r,
-                                get<0, 0>(inverse_null_metric).size());
-
   // compute the time derivative part
   get<0>(*d_bondi_r) =
       0.25 * real(get(bondi_r).data()) *
@@ -779,7 +770,6 @@ void dyads(
 void beta_worldtube_data(
     const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 0>>*> beta,
     const tnsr::a<DataVector, 3, Frame::RadialNull>& d_bondi_r) {
-  destructive_resize_components(beta, get<0>(d_bondi_r).size());
   get(*beta).data() = std::complex<double>(-0.5, 0.0) * log(get<1>(d_bondi_r));
 }
 
@@ -788,7 +778,6 @@ void bondi_u_worldtube_data(
     const tnsr::i<ComplexDataVector, 2, Frame::RadialNull>& dyad,
     const tnsr::a<DataVector, 3, Frame::RadialNull>& d_bondi_r,
     const tnsr::AA<DataVector, 3, Frame::RadialNull>& inverse_null_metric) {
-  destructive_resize_components(bondi_u, get<0>(d_bondi_r).size());
   get(*bondi_u).data() = -get<0>(dyad) * get<1, 2>(inverse_null_metric) -
                          get<1>(dyad) * get<1, 3>(inverse_null_metric);
 
@@ -806,8 +795,6 @@ void bondi_w_worldtube_data(
     const tnsr::a<DataVector, 3, Frame::RadialNull>& d_bondi_r,
     const tnsr::AA<DataVector, 3, Frame::RadialNull>& inverse_null_metric,
     const Scalar<SpinWeighted<ComplexDataVector, 0>>& bondi_r) {
-  destructive_resize_components(bondi_w, get(bondi_r).data().size());
-
   get(*bondi_w).data() =
       std::complex<double>(1.0, 0.0) *
       (-1.0 + get<1>(d_bondi_r) * get<1, 1>(inverse_null_metric) -
@@ -833,8 +820,6 @@ void bondi_j_worldtube_data(
     const tnsr::aa<DataVector, 3, Frame::RadialNull>& null_metric,
     const Scalar<SpinWeighted<ComplexDataVector, 0>>& bondi_r,
     const tnsr::I<ComplexDataVector, 2, Frame::RadialNull>& dyad) {
-  destructive_resize_components(bondi_j, get(bondi_r).data().size());
-
   get(*bondi_j).data() =
       0.5 *
       (square(get<0>(dyad)) * get<2, 2>(null_metric) +
@@ -852,8 +837,6 @@ void dr_bondi_j(
     const Scalar<SpinWeighted<ComplexDataVector, 2>>& bondi_j,
     const Scalar<SpinWeighted<ComplexDataVector, 0>>& bondi_r,
     const tnsr::I<ComplexDataVector, 2, Frame::RadialNull>& dyad) {
-  destructive_resize_components(dr_bondi_j, get(bondi_r).data().size());
-  destructive_resize_components(denominator_buffer, get(bondi_r).data().size());
   get(*dr_bondi_j) = -2.0 * get(bondi_j) / get(bondi_r);
   get(*denominator_buffer).data() =
       1.0 / (square(get(bondi_r).data()) * get<1>(d_bondi_r));
@@ -872,7 +855,6 @@ void d2lambda_bondi_r(
     const Scalar<SpinWeighted<ComplexDataVector, 2>>& dr_bondi_j,
     const Scalar<SpinWeighted<ComplexDataVector, 2>>& bondi_j,
     const Scalar<SpinWeighted<ComplexDataVector, 0>>& bondi_r) {
-  destructive_resize_components(d2lambda_bondi_r, get(bondi_j).data().size());
   get(*d2lambda_bondi_r) =
       real(-0.25 * get(bondi_r).data() *
            (get(dr_bondi_j).data() * conj(get(dr_bondi_j).data()) -
@@ -896,7 +878,6 @@ void bondi_q_worldtube_data(
     const Scalar<SpinWeighted<ComplexDataVector, 2>>& bondi_j,
     const Scalar<SpinWeighted<ComplexDataVector, 0>>& bondi_r,
     const Scalar<SpinWeighted<ComplexDataVector, 1>>& bondi_u) {
-  destructive_resize_components(bondi_q, get(bondi_j).data().size());
   // Allocation
   Scalar<SpinWeighted<ComplexDataVector, 1>> dlambda_bondi_u{
       get(bondi_j).data().size()};
@@ -936,8 +917,6 @@ void bondi_h_worldtube_data(
     const tnsr::aa<DataVector, 3, Frame::RadialNull>& du_null_metric,
     const Scalar<SpinWeighted<ComplexDataVector, 0>>& bondi_r,
     const tnsr::I<ComplexDataVector, 2, Frame::RadialNull>& dyad) {
-  destructive_resize_components(bondi_h, get(bondi_j).data().size());
-
   get(*bondi_h).data() =
       -2.0 * get<0>(d_bondi_r) / get(bondi_r).data() * get(bondi_j).data();
   for (size_t A = 0; A < 2; ++A) {
@@ -952,13 +931,11 @@ void bondi_h_worldtube_data(
 void du_j_worldtube_data(
     const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 2>>*> du_bondi_j,
     const tnsr::a<DataVector, 3, Frame::RadialNull>& d_bondi_r,
-    const Scalar<SpinWeighted<ComplexDataVector, 2>>& bondi_j,
+    const Scalar<SpinWeighted<ComplexDataVector, 2>>& /*bondi_j*/,
     const tnsr::aa<DataVector, 3, Frame::RadialNull>& du_null_metric,
     const tnsr::aa<DataVector, 3, Frame::RadialNull>& dlambda_null_metric,
     const Scalar<SpinWeighted<ComplexDataVector, 0>>& bondi_r,
     const tnsr::I<ComplexDataVector, 2, Frame::RadialNull>& dyad) {
-  destructive_resize_components(du_bondi_j, get(bondi_j).data().size());
-
   for (size_t A = 0; A < 2; ++A) {
     for (size_t B = 0; B < 2; ++B) {
       if (UNLIKELY(A == 0 and B == 0)) {

--- a/src/Evolution/Systems/Cce/SpecBoundaryData.cpp
+++ b/src/Evolution/Systems/Cce/SpecBoundaryData.cpp
@@ -14,9 +14,9 @@
 #include "NumericalAlgorithms/Spectral/SwshCollocation.hpp"
 #include "NumericalAlgorithms/Spectral/SwshDerivatives.hpp"
 #include "Utilities/ConstantExpressions.hpp"
-#include "Utilities/ContainerHelpers.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/Math.hpp"
+#include "Utilities/SetNumberOfGridPoints.hpp"
 #include "Utilities/TMPL.hpp"
 
 namespace Cce {
@@ -39,14 +39,14 @@ void cartesian_spatial_metric_and_derivatives_from_unnormalized_spec_modes(
     const CartesianiSphericalJ& inverse_cartesian_to_spherical_jacobian,
     const tnsr::I<DataVector, 3>& unit_cartesian_coords, const size_t l_max) {
   const size_t size = get<0, 0>(inverse_cartesian_to_spherical_jacobian).size();
-  destructive_resize_components(cartesian_spatial_metric, size);
-  destructive_resize_components(d_cartesian_spatial_metric, size);
-  destructive_resize_components(dt_cartesian_spatial_metric, size);
+  set_number_of_grid_points(cartesian_spatial_metric, size);
+  set_number_of_grid_points(d_cartesian_spatial_metric, size);
+  set_number_of_grid_points(dt_cartesian_spatial_metric, size);
 
-  destructive_resize_components(interpolation_buffer, size);
-  destructive_resize_components(interpolation_modal_buffer, size);
-  destructive_resize_components(eth_buffer, size);
-  destructive_resize_components(radial_correction_factor, size);
+  set_number_of_grid_points(interpolation_buffer, size);
+  set_number_of_grid_points(interpolation_modal_buffer, size);
+  set_number_of_grid_points(eth_buffer, size);
+  set_number_of_grid_points(radial_correction_factor, size);
 
   // Allocation
   SphericaliCartesianjj spherical_d_cartesian_spatial_metric{size};
@@ -148,13 +148,13 @@ void cartesian_shift_and_derivatives_from_unnormalized_spec_modes(
     const Scalar<DataVector>& radial_derivative_correction_factor,
     const size_t l_max) {
   const size_t size = get<0, 0>(inverse_cartesian_to_spherical_jacobian).size();
-  destructive_resize_components(cartesian_shift, size);
-  destructive_resize_components(d_cartesian_shift, size);
-  destructive_resize_components(dt_cartesian_shift, size);
+  set_number_of_grid_points(cartesian_shift, size);
+  set_number_of_grid_points(d_cartesian_shift, size);
+  set_number_of_grid_points(dt_cartesian_shift, size);
 
-  destructive_resize_components(interpolation_buffer, size);
-  destructive_resize_components(interpolation_modal_buffer, size);
-  destructive_resize_components(eth_buffer, size);
+  set_number_of_grid_points(interpolation_buffer, size);
+  set_number_of_grid_points(interpolation_modal_buffer, size);
+  set_number_of_grid_points(eth_buffer, size);
 
   // Allocation
   SphericaliCartesianJ spherical_d_cartesian_shift{size};
@@ -223,13 +223,13 @@ void cartesian_lapse_and_derivatives_from_unnormalized_spec_modes(
     const Scalar<DataVector>& radial_derivative_correction_factor,
     const size_t l_max) {
   const size_t size = get<0, 0>(inverse_cartesian_to_spherical_jacobian).size();
-  destructive_resize_components(cartesian_lapse, size);
-  destructive_resize_components(d_cartesian_lapse, size);
-  destructive_resize_components(dt_cartesian_lapse, size);
+  set_number_of_grid_points(cartesian_lapse, size);
+  set_number_of_grid_points(d_cartesian_lapse, size);
+  set_number_of_grid_points(dt_cartesian_lapse, size);
 
-  destructive_resize_components(interpolation_buffer, size);
-  destructive_resize_components(interpolation_modal_buffer, size);
-  destructive_resize_components(eth_buffer, size);
+  set_number_of_grid_points(interpolation_buffer, size);
+  set_number_of_grid_points(interpolation_modal_buffer, size);
+  set_number_of_grid_points(eth_buffer, size);
 
   // Allocation
   tnsr::i<DataVector, 3> spherical_d_cartesian_lapse{size};

--- a/src/Evolution/Systems/Ccz4/ATilde.cpp
+++ b/src/Evolution/Systems/Ccz4/ATilde.cpp
@@ -7,7 +7,6 @@
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
-#include "Utilities/ContainerHelpers.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
 
@@ -19,11 +18,6 @@ void a_tilde(const gsl::not_null<tnsr::ii<DataType, Dim, Frame>*> result,
              const tnsr::ii<DataType, Dim, Frame>& spatial_metric,
              const tnsr::ii<DataType, Dim, Frame>& extrinsic_curvature,
              const Scalar<DataType>& trace_extrinsic_curvature) {
-  destructive_resize_components(result,
-                                get_size(get(conformal_factor_squared)));
-  destructive_resize_components(buffer,
-                                get_size(get(conformal_factor_squared)));
-
   ::tenex::evaluate(buffer, trace_extrinsic_curvature() / 3.0);
   ::tenex::evaluate<ti::i, ti::j>(
       result, conformal_factor_squared() *

--- a/src/Evolution/Systems/Ccz4/Christoffel.cpp
+++ b/src/Evolution/Systems/Ccz4/Christoffel.cpp
@@ -7,7 +7,6 @@
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
-#include "Utilities/ContainerHelpers.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
 
@@ -17,9 +16,6 @@ void conformal_christoffel_second_kind(
     const gsl::not_null<tnsr::Ijj<DataType, Dim, Frame>*> result,
     const tnsr::II<DataType, Dim, Frame>& inverse_conformal_spatial_metric,
     const tnsr::ijj<DataType, Dim, Frame>& field_d) {
-  destructive_resize_components(
-      result, get_size(get<0, 0>(inverse_conformal_spatial_metric)));
-
   ::tenex::evaluate<ti::K, ti::i, ti::j>(
       result, inverse_conformal_spatial_metric(ti::K, ti::L) *
                   (field_d(ti::i, ti::j, ti::l) + field_d(ti::j, ti::i, ti::l) -
@@ -43,9 +39,6 @@ void christoffel_second_kind(
     const tnsr::II<DataType, Dim, Frame>& inverse_conformal_spatial_metric,
     const tnsr::i<DataType, Dim, Frame>& field_p,
     const tnsr::Ijj<DataType, Dim, Frame>& conformal_christoffel_second_kind) {
-  destructive_resize_components(result,
-                                get_size(get<0, 0>(conformal_spatial_metric)));
-
   ::tenex::evaluate<ti::K, ti::i, ti::j>(
       result,
       conformal_christoffel_second_kind(ti::K, ti::i, ti::j) -
@@ -73,9 +66,6 @@ void contracted_conformal_christoffel_second_kind(
     const gsl::not_null<tnsr::I<DataType, Dim, Frame>*> result,
     const tnsr::II<DataType, Dim, Frame>& inverse_conformal_spatial_metric,
     const tnsr::Ijj<DataType, Dim, Frame>& conformal_christoffel_second_kind) {
-  destructive_resize_components(
-      result, get_size(get<0, 0>(inverse_conformal_spatial_metric)));
-
   ::tenex::evaluate<ti::I>(
       result, inverse_conformal_spatial_metric(ti::J, ti::L) *
                   conformal_christoffel_second_kind(ti::I, ti::j, ti::l));

--- a/src/Evolution/Systems/Ccz4/DerivChristoffel.cpp
+++ b/src/Evolution/Systems/Ccz4/DerivChristoffel.cpp
@@ -7,7 +7,6 @@
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
-#include "Utilities/ContainerHelpers.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
 
@@ -19,9 +18,6 @@ void deriv_conformal_christoffel_second_kind(
     const tnsr::ijj<DataType, Dim, Frame>& field_d,
     const tnsr::ijkk<DataType, Dim, Frame>& d_field_d,
     const tnsr::iJJ<DataType, Dim, Frame>& field_d_up) {
-  destructive_resize_components(
-      result, get_size(get<0, 0>(inverse_conformal_spatial_metric)));
-
   for (size_t i = 0; i < Dim; ++i) {
     for (size_t j = i; j < Dim; ++j) {
       for (size_t k = 0; k < Dim; ++k) {
@@ -71,9 +67,6 @@ void deriv_contracted_conformal_christoffel_second_kind(
     const tnsr::Ijj<DataType, Dim, Frame>& conformal_christoffel_second_kind,
     const tnsr::iJkk<DataType, Dim, Frame>&
         d_conformal_christoffel_second_kind) {
-  destructive_resize_components(
-      result, get_size(get<0, 0>(inverse_conformal_spatial_metric)));
-
   ::tenex::evaluate<ti::k, ti::I>(
       result,
       -2.0 * field_d_up(ti::k, ti::J, ti::L) *

--- a/src/Evolution/Systems/Ccz4/DerivLapse.cpp
+++ b/src/Evolution/Systems/Ccz4/DerivLapse.cpp
@@ -8,9 +8,9 @@
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Utilities/ConstantExpressions.hpp"
-#include "Utilities/ContainerHelpers.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/SetNumberOfGridPoints.hpp"
 
 namespace Ccz4 {
 template <typename DataType, size_t Dim, typename Frame>
@@ -20,8 +20,6 @@ void grad_grad_lapse(
     const tnsr::Ijj<DataType, Dim, Frame>& christoffel_second_kind,
     const tnsr::i<DataType, Dim, Frame>& field_a,
     const tnsr::ij<DataType, Dim, Frame>& d_field_a) {
-  destructive_resize_components(result, get_size(get(lapse)));
-
   for (size_t i = 0; i < Dim; ++i) {
     for (size_t j = 0; j < Dim; ++j) {
       result->get(i, j) = field_a.get(i) * field_a.get(j) +
@@ -53,8 +51,7 @@ void divergence_lapse(
     const Scalar<DataType>& conformal_factor_squared,
     const tnsr::II<DataType, Dim, Frame>& inverse_conformal_metric,
     const tnsr::ij<DataType, Dim, Frame>& grad_grad_lapse) {
-  destructive_resize_components(result,
-                                get_size(get(conformal_factor_squared)));
+  set_number_of_grid_points(result, conformal_factor_squared);
 
   get(*result) = 0.0;
   for (size_t i = 0; i < Dim; ++i) {

--- a/src/Evolution/Systems/Ccz4/DerivZ4Constraint.cpp
+++ b/src/Evolution/Systems/Ccz4/DerivZ4Constraint.cpp
@@ -7,7 +7,6 @@
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
-#include "Utilities/ContainerHelpers.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
 
@@ -23,9 +22,6 @@ void grad_spatial_z4_constraint(
         gamma_hat_minus_contracted_conformal_christoffel,
     const tnsr::iJ<DataType, Dim, Frame>&
         d_gamma_hat_minus_contracted_conformal_christoffel) {
-  destructive_resize_components(result,
-                                get_size(get<0, 0>(conformal_spatial_metric)));
-
   ::tenex::evaluate<ti::i, ti::j>(
       result,
       field_d(ti::i, ti::j, ti::l) *

--- a/src/Evolution/Systems/Ccz4/Ricci.tpp
+++ b/src/Evolution/Systems/Ccz4/Ricci.tpp
@@ -9,7 +9,6 @@
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
-#include "Utilities/ContainerHelpers.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
 
@@ -28,9 +27,6 @@ void spatial_ricci_tensor(
     const tnsr::I<DataType, Dim, Frame>& contracted_field_d_up,
     const tnsr::i<DataType, Dim, Frame>& field_p,
     const tnsr::ij<DataType, Dim, Frame>& d_field_p) {
-  destructive_resize_components(result,
-                                get_size(get<0, 0>(conformal_spatial_metric)));
-
   tenex::evaluate<ti::i, ti::j>(
       result,
       contracted_d_conformal_christoffel_difference(ti::i, ti::j) +

--- a/src/Evolution/Systems/Ccz4/RicciScalarPlusDivergenceZ4Constraint.cpp
+++ b/src/Evolution/Systems/Ccz4/RicciScalarPlusDivergenceZ4Constraint.cpp
@@ -7,7 +7,6 @@
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
-#include "Utilities/ContainerHelpers.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
 
@@ -19,9 +18,6 @@ void ricci_scalar_plus_divergence_z4_constraint(
     const tnsr::II<DataType, Dim, Frame>& inverse_conformal_spatial_metric,
     const tnsr::ii<DataType, Dim, Frame>& spatial_ricci_tensor,
     const tnsr::ij<DataType, Dim, Frame>& grad_spatial_z4_constraint) {
-  destructive_resize_components(result,
-                                get_size(get(conformal_factor_squared)));
-
   ::tenex::evaluate(result, conformal_factor_squared() *
                                 inverse_conformal_spatial_metric(ti::I, ti::J) *
                                 (spatial_ricci_tensor(ti::i, ti::j) +

--- a/src/Evolution/Systems/Ccz4/Z4Constraint.cpp
+++ b/src/Evolution/Systems/Ccz4/Z4Constraint.cpp
@@ -7,7 +7,6 @@
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
-#include "Utilities/ContainerHelpers.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
 
@@ -18,9 +17,6 @@ void spatial_z4_constraint(
     const tnsr::ii<DataType, Dim, Frame>& conformal_spatial_metric,
     const tnsr::I<DataType, Dim, Frame>&
         gamma_hat_minus_contracted_conformal_christoffel) {
-  destructive_resize_components(result,
-                                get_size(get<0, 0>(conformal_spatial_metric)));
-
   ::tenex::evaluate<ti::i>(
       result, 0.5 * (conformal_spatial_metric(ti::i, ti::j) *
                      gamma_hat_minus_contracted_conformal_christoffel(ti::J)));
@@ -43,9 +39,6 @@ void upper_spatial_z4_constraint(
     const Scalar<DataType>& half_conformal_factor_squared,
     const tnsr::I<DataType, Dim, Frame>&
         gamma_hat_minus_contracted_conformal_christoffel) {
-  destructive_resize_components(result,
-                                get_size(get(half_conformal_factor_squared)));
-
   ::tenex::evaluate<ti::I>(
       result, half_conformal_factor_squared() *
                   gamma_hat_minus_contracted_conformal_christoffel(ti::I));

--- a/src/Evolution/Systems/CurvedScalarWave/Characteristics.cpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Characteristics.cpp
@@ -24,7 +24,6 @@ void characteristic_speeds(
     const tnsr::I<DataVector, SpatialDim, Frame::Inertial>& shift,
     const tnsr::i<DataVector, SpatialDim, Frame::Inertial>&
         unit_normal_one_form) {
-  destructive_resize_components(char_speeds, get(gamma_1).size());
   const auto shift_dot_normal = get(dot_product(shift, unit_normal_one_form));
   get<0>(*char_speeds) = -(1. + get(gamma_1)) * shift_dot_normal;  // v(VPsi)
   get<1>(*char_speeds) = -shift_dot_normal;                        // v(VZero)
@@ -125,12 +124,6 @@ void characteristic_fields(
         unit_normal_one_form,
     const tnsr::I<DataVector, SpatialDim, Frame::Inertial>&
         unit_normal_vector) {
-  const size_t size = get(gamma_2).size();
-  destructive_resize_components(v_psi, size);
-  destructive_resize_components(v_zero, size);
-  destructive_resize_components(v_plus, size);
-  destructive_resize_components(v_minus, size);
-
   dot_product(v_minus, unit_normal_vector, phi);
   // Eq.(34) of Holst+ (2004) for VZero
   for (size_t i = 0; i < SpatialDim; ++i) {
@@ -153,10 +146,6 @@ void evolved_fields_from_characteristic_fields(
     const Scalar<DataVector>& v_plus, const Scalar<DataVector>& v_minus,
     const tnsr::i<DataVector, SpatialDim, Frame::Inertial>&
         unit_normal_one_form) {
-  const size_t size = get(gamma_2).size();
-  destructive_resize_components(psi, size);
-  destructive_resize_components(pi, size);
-  destructive_resize_components(phi, size);
   // Eq.(36) of Holst+ (2005) for Psi
   *psi = v_psi;
   // Eq.(37) - (38) of Holst+ (2004) for Pi and Phi

--- a/src/Evolution/Systems/CurvedScalarWave/Constraints.cpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Constraints.cpp
@@ -27,7 +27,6 @@ void one_index_constraint(
         constraint,
     const tnsr::i<DataVector, SpatialDim, Frame::Inertial>& d_psi,
     const tnsr::i<DataVector, SpatialDim, Frame::Inertial>& phi) {
-  destructive_resize_components(constraint, get<0>(phi).size());
   tenex::evaluate<ti::i>(constraint, d_psi(ti::i) - phi(ti::i));
 }
 
@@ -44,7 +43,6 @@ void two_index_constraint(
     const gsl::not_null<tnsr::ij<DataVector, SpatialDim, Frame::Inertial>*>
         constraint,
     const tnsr::ij<DataVector, SpatialDim, Frame::Inertial>& d_phi) {
-  destructive_resize_components(constraint, get<0, 0>(d_phi).size());
   for (size_t i = 0; i < SpatialDim; ++i) {
     for (size_t j = 0; j < SpatialDim; ++j) {
       constraint->get(i, j) = d_phi.get(i, j) - d_phi.get(j, i);

--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/Tags.cpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/Tags.cpp
@@ -18,8 +18,8 @@
 #include "Evolution/Systems/CurvedScalarWave/Worldtube/PunctureField.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "Time/Tags.hpp"
-#include "Utilities/ContainerHelpers.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/SetNumberOfGridPoints.hpp"
 
 namespace CurvedScalarWave::Worldtube::Tags {
 
@@ -42,8 +42,7 @@ void FaceCoordinatesCompute<Dim, Frame, Centered>::function(
     const size_t grid_size =
         mesh.slice_away(direction->dimension()).number_of_grid_points();
     if (result->has_value()) {
-      destructive_resize_components(make_not_null(&(result->value())),
-                                    grid_size);
+      set_number_of_grid_points(make_not_null(&(result->value())), grid_size);
     } else {
       result->emplace(grid_size);
     }
@@ -84,8 +83,7 @@ void FaceCoordinatesCompute<Dim, Frame, Centered>::function(
     const size_t grid_size =
         mesh.slice_away(direction->dimension()).number_of_grid_points();
     if (result->has_value()) {
-      destructive_resize_components(make_not_null(&(result->value())),
-                                    grid_size);
+      set_number_of_grid_points(make_not_null(&(result->value())), grid_size);
     } else {
       result->emplace(grid_size);
     }

--- a/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/BjorhusImpl.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/BjorhusImpl.cpp
@@ -67,7 +67,7 @@ void constraint_preserving_bjorhus_corrections_dt_v_zero(
   }
   std::fill(bc_dt_v_zero->begin(), bc_dt_v_zero->end(), 0.);
 
-  if (LIKELY(VolumeDim == 3)) {
+  if (VolumeDim == 3) {
     for (size_t a = 0; a <= VolumeDim; ++a) {
       for (size_t b = a; b <= VolumeDim; ++b) {
         // Lets say this term is T2_{iab} := - n_l \beta^l n^j C_{jiab}.
@@ -90,7 +90,7 @@ void constraint_preserving_bjorhus_corrections_dt_v_zero(
         }
       }
     }
-  } else if (LIKELY(VolumeDim == 2)) {
+  } else if (VolumeDim == 2) {
     for (size_t a = 0; a <= VolumeDim; ++a) {
       for (size_t b = a; b <= VolumeDim; ++b) {
         // Lets say this term is T2_{kab} := - n_l \beta^l n^j C_{jkab}.

--- a/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/BjorhusImpl.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/BjorhusImpl.cpp
@@ -32,11 +32,6 @@ void constraint_preserving_bjorhus_corrections_dt_v_psi(
     const tnsr::iaa<DataType, VolumeDim, Frame::Inertial>&
         three_index_constraint,
     const std::array<DataType, 4>& char_speeds) {
-  if (UNLIKELY(get_size(get<0, 0>(*bc_dt_v_psi)) !=
-               get_size(get<0>(unit_interface_normal_vector)))) {
-    *bc_dt_v_psi = tnsr::aa<DataType, VolumeDim, Frame::Inertial>{
-        get_size(get<0>(unit_interface_normal_vector))};
-  }
   for (size_t a = 0; a <= VolumeDim; ++a) {
     for (size_t b = a; b <= VolumeDim; ++b) {
       bc_dt_v_psi->get(a, b) = char_speeds[0] *
@@ -60,11 +55,7 @@ void constraint_preserving_bjorhus_corrections_dt_v_zero(
     const tnsr::iaa<DataType, VolumeDim, Frame::Inertial>&
         four_index_constraint,
     const std::array<DataType, 4>& char_speeds) {
-  if (UNLIKELY(get_size(get<0, 0, 0>(*bc_dt_v_zero)) !=
-               get_size(get<0>(unit_interface_normal_vector)))) {
-    *bc_dt_v_zero = tnsr::iaa<DataType, VolumeDim, Frame::Inertial>{
-        get_size(get<0>(unit_interface_normal_vector))};
-  }
+  set_number_of_grid_points(bc_dt_v_zero, unit_interface_normal_vector);
   std::fill(bc_dt_v_zero->begin(), bc_dt_v_zero->end(), 0.);
 
   if (VolumeDim == 3) {
@@ -524,7 +515,6 @@ void constraint_preserving_bjorhus_corrections_dt_v_minus(
     const tnsr::a<DataType, VolumeDim, Frame::Inertial>&
         constraint_char_zero_minus,
     const std::array<DataType, 4>& char_speeds) {
-  destructive_resize_components(bc_dt_v_minus, get_size(get(gamma2)));
   for (size_t a = 0; a <= VolumeDim; ++a) {
     for (size_t b = a; b <= VolumeDim; ++b) {
       bc_dt_v_minus->get(a, b) = -char_projected_rhs_dt_v_minus.get(a, b);
@@ -580,7 +570,6 @@ void constraint_preserving_physical_bjorhus_corrections_dt_v_minus(
     const tnsr::ijaa<DataType, VolumeDim, Frame::Inertial>& d_phi,
     const tnsr::iaa<DataType, VolumeDim, Frame::Inertial>& d_pi,
     const std::array<DataType, 4>& char_speeds) {
-  destructive_resize_components(bc_dt_v_minus, get_size(get(gamma2)));
   for (size_t a = 0; a <= VolumeDim; ++a) {
     for (size_t b = a; b <= VolumeDim; ++b) {
       bc_dt_v_minus->get(a, b) = -char_projected_rhs_dt_v_minus.get(a, b);

--- a/src/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/Constant.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/Constant.cpp
@@ -14,9 +14,9 @@
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Utilities/ConstantExpressions.hpp"
-#include "Utilities/ContainerHelpers.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/SetNumberOfGridPoints.hpp"
 
 namespace domain::FunctionsOfTime {
 class FunctionOfTime;
@@ -53,7 +53,7 @@ void Constant<VolumeDim, Fr>::operator()(
     const std::unordered_map<
         std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
     /*functions_of_time*/) const {
-  destructive_resize_components(value_at_x, get<0>(x).size());
+  set_number_of_grid_points(value_at_x, x);
   apply_call_operator(value_at_x);
 }
 

--- a/src/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/GaussianPlusConstant.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/GaussianPlusConstant.cpp
@@ -15,9 +15,9 @@
 #include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Utilities/ConstantExpressions.hpp"
-#include "Utilities/ContainerHelpers.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/SetNumberOfGridPoints.hpp"
 
 namespace domain::FunctionsOfTime {
 class FunctionOfTime;
@@ -67,7 +67,7 @@ void GaussianPlusConstant<VolumeDim, Fr>::operator()(
     const std::unordered_map<
         std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
     /*functions_of_time*/) const {
-  destructive_resize_components(value_at_x, get<0>(x).size());
+  set_number_of_grid_points(value_at_x, x);
   apply_call_operator(value_at_x, x);
 }
 

--- a/src/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/TimeDependentTripleGaussian.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/TimeDependentTripleGaussian.cpp
@@ -18,10 +18,10 @@
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
 #include "Utilities/ConstantExpressions.hpp"
-#include "Utilities/ContainerHelpers.hpp"
 #include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/SetNumberOfGridPoints.hpp"
 
 namespace gh::ConstraintDamping {
 TimeDependentTripleGaussian::TimeDependentTripleGaussian(CkMigrateMessage* msg)
@@ -100,7 +100,7 @@ void TimeDependentTripleGaussian::operator()(
     const std::unordered_map<
         std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
         functions_of_time) const {
-  destructive_resize_components(value_at_x, get<0>(x).size());
+  set_number_of_grid_points(value_at_x, x);
   apply_call_operator(value_at_x, x, time, functions_of_time);
 }
 

--- a/src/Evolution/Systems/GeneralizedHarmonic/Constraints.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Constraints.hpp
@@ -15,7 +15,7 @@
 #include "Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/Tags.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
 #include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
-#include "Utilities/ContainerHelpers.hpp"
+#include "Utilities/SetNumberOfGridPoints.hpp"
 #include "Utilities/TMPL.hpp"
 
 /// \cond
@@ -764,8 +764,7 @@ struct ConstraintEnergyCompute
       const tnsr::iaa<DataVector, SpatialDim, Frame>& four_index_constraint,
       const tnsr::II<DataVector, SpatialDim, Frame>& inverse_spatial_metric,
       const Scalar<DataVector>& spatial_metric_determinant) {
-    destructive_resize_components(energy,
-                                  get(spatial_metric_determinant).size());
+    set_number_of_grid_points(energy, spatial_metric_determinant);
     constraint_energy<DataVector, SpatialDim, Frame>(
         energy, gauge_constraint, f_constraint, two_index_constraint,
         three_index_constraint, four_index_constraint, inverse_spatial_metric,

--- a/src/Evolution/Systems/GeneralizedHarmonic/Equations.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Equations.cpp
@@ -7,9 +7,9 @@
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
-#include "Utilities/ContainerHelpers.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/SetNumberOfGridPoints.hpp"
 
 namespace gh {
 template <size_t Dim>
@@ -19,12 +19,9 @@ void ComputeNormalDotFluxes<Dim>::apply(
     const gsl::not_null<tnsr::aa<DataVector, Dim>*> pi_normal_dot_flux,
     const gsl::not_null<tnsr::iaa<DataVector, Dim>*> phi_normal_dot_flux,
     const tnsr::aa<DataVector, Dim>& spacetime_metric) {
-  destructive_resize_components(pi_normal_dot_flux,
-                                get<0, 0>(spacetime_metric).size());
-  destructive_resize_components(phi_normal_dot_flux,
-                                get<0, 0>(spacetime_metric).size());
-  destructive_resize_components(spacetime_metric_normal_dot_flux,
-                                get<0, 0>(spacetime_metric).size());
+  set_number_of_grid_points(pi_normal_dot_flux, spacetime_metric);
+  set_number_of_grid_points(phi_normal_dot_flux, spacetime_metric);
+  set_number_of_grid_points(spacetime_metric_normal_dot_flux, spacetime_metric);
   for (size_t storage_index = 0; storage_index < pi_normal_dot_flux->size();
        ++storage_index) {
     (*pi_normal_dot_flux)[storage_index] = 0.0;

--- a/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedHarmonic.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedHarmonic.cpp
@@ -27,9 +27,9 @@
 #include "PointwiseFunctions/GeneralRelativity/SpacetimeNormalVector.hpp"
 #include "PointwiseFunctions/GeneralRelativity/SpatialMetric.hpp"
 #include "Utilities/ConstantExpressions.hpp"
-#include "Utilities/ContainerHelpers.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/SetNumberOfGridPoints.hpp"
 #include "Utilities/TMPL.hpp"
 
 // IWYU pragma: no_forward_declare Tensor
@@ -91,8 +91,6 @@ void damped_harmonic_impl(
     const double rollon_start_time, const double rollon_width,
     const double sigma_r) {
   const size_t num_points = get(lapse).size();
-  destructive_resize_components(gauge_h, num_points);
-  destructive_resize_components(d4_gauge_h, num_points);
 
   if constexpr (UseRollon) {
     ASSERT(gauge_h_init != nullptr,

--- a/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/HalfPiPhiTwoNormals.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/HalfPiPhiTwoNormals.cpp
@@ -19,8 +19,8 @@ void half_pi_and_phi_two_normals(
     const tnsr::A<DataVector, Dim, Frame>& spacetime_normal_vector,
     const tnsr::aa<DataVector, Dim, Frame>& pi,
     const tnsr::iaa<DataVector, Dim, Frame>& phi) {
-  destructive_resize_components(half_pi_two_normals, get<0, 0>(pi).size());
-  destructive_resize_components(half_phi_two_normals, get<0, 0>(pi).size());
+  set_number_of_grid_points(half_pi_two_normals, pi);
+  set_number_of_grid_points(half_phi_two_normals, pi);
   get(*half_pi_two_normals) = 0.0;
   for (size_t i = 0; i < Dim; ++i) {
     half_phi_two_normals->get(i) = 0.0;

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Actions/NumericInitialData.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Actions/NumericInitialData.hpp
@@ -28,6 +28,7 @@
 #include "PointwiseFunctions/InitialDataUtilities/Tags/InitialData.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/SetNumberOfGridPoints.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
 
@@ -207,7 +208,7 @@ class NumericInitialData : public evolution::initial_data::InitialData {
     } else {
       const double constant_electron_fraction =
           std::get<double>(electron_fraction_selection);
-      destructive_resize_components(electron_fraction, num_points);
+      set_number_of_grid_points(electron_fraction, num_points);
       get(*electron_fraction) = constant_electron_fraction;
     }
     // Velocity and Lorentz factor from u_i dataset
@@ -224,9 +225,9 @@ class NumericInitialData : public evolution::initial_data::InitialData {
       spatial_velocity->get(d) /= get(*lorentz_factor);
     }
     // Specific internal energy, pressure, and enthalpy from EOS
-    destructive_resize_components(specific_internal_energy, num_points);
-    destructive_resize_components(pressure, num_points);
-    destructive_resize_components(specific_enthalpy, num_points);
+    set_number_of_grid_points(specific_internal_energy, num_points);
+    set_number_of_grid_points(pressure, num_points);
+    set_number_of_grid_points(specific_enthalpy, num_points);
     for (size_t i = 0; i < num_points; ++i) {
       double& local_rest_mass_density = get(*rest_mass_density)[i];
       // Apply the EOS and specific enthalpy only where the density is above the
@@ -270,12 +271,12 @@ class NumericInitialData : public evolution::initial_data::InitialData {
             "in the input file. Generate a dataset for the nonzero "
             "uniform magnetic field if you need to.");
       }
-      destructive_resize_components(magnetic_field, num_points);
+      set_number_of_grid_points(magnetic_field, num_points);
       std::fill(magnetic_field->begin(), magnetic_field->end(),
                 constant_magnetic_field);
     }
     // Divergence cleaning field
-    destructive_resize_components(div_cleaning_field, num_points);
+    set_number_of_grid_points(div_cleaning_field, num_points);
     get(*div_cleaning_field) = 0.;
   }
 

--- a/src/Evolution/Systems/NewtonianEuler/InternalEnergyDensity.cpp
+++ b/src/Evolution/Systems/NewtonianEuler/InternalEnergyDensity.cpp
@@ -4,7 +4,6 @@
 #include "Evolution/Systems/NewtonianEuler/InternalEnergyDensity.hpp"
 
 #include "DataStructures/Tensor/Tensor.hpp"
-#include "Utilities/ContainerHelpers.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
 
@@ -13,7 +12,6 @@ template <typename DataType>
 void internal_energy_density(const gsl::not_null<Scalar<DataType>*> result,
                              const Scalar<DataType>& mass_density,
                              const Scalar<DataType>& specific_internal_energy) {
-  destructive_resize_components(result, get_size(get(mass_density)));
   get(*result) = get(mass_density) * get(specific_internal_energy);
 }
 

--- a/src/Evolution/Systems/NewtonianEuler/KineticEnergyDensity.cpp
+++ b/src/Evolution/Systems/NewtonianEuler/KineticEnergyDensity.cpp
@@ -5,7 +5,6 @@
 
 #include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
-#include "Utilities/ContainerHelpers.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
 
@@ -14,7 +13,6 @@ template <typename DataType, size_t Dim, typename Fr>
 void kinetic_energy_density(const gsl::not_null<Scalar<DataType>*> result,
                             const Scalar<DataType>& mass_density,
                             const tnsr::I<DataType, Dim, Fr>& velocity) {
-  destructive_resize_components(result, get_size(get(mass_density)));
   get(*result) = 0.5 * get(mass_density) * get(dot_product(velocity, velocity));
 }
 

--- a/src/Evolution/Systems/NewtonianEuler/MachNumber.cpp
+++ b/src/Evolution/Systems/NewtonianEuler/MachNumber.cpp
@@ -5,7 +5,6 @@
 
 #include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
-#include "Utilities/ContainerHelpers.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeWithValue.hpp"
@@ -15,7 +14,6 @@ template <typename DataType, size_t Dim, typename Fr>
 void mach_number(const gsl::not_null<Scalar<DataType>*> result,
                  const tnsr::I<DataType, Dim, Fr>& velocity,
                  const Scalar<DataType>& sound_speed) {
-  destructive_resize_components(result, get_size(get(sound_speed)));
   get(*result) = get(magnitude(velocity)) / get(sound_speed);
 }
 

--- a/src/Evolution/Systems/NewtonianEuler/RamPressure.cpp
+++ b/src/Evolution/Systems/NewtonianEuler/RamPressure.cpp
@@ -4,7 +4,6 @@
 #include "Evolution/Systems/NewtonianEuler/RamPressure.hpp"
 
 #include "DataStructures/Tensor/Tensor.hpp"
-#include "Utilities/ContainerHelpers.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
 
@@ -13,7 +12,6 @@ template <typename DataType, size_t Dim, typename Fr>
 void ram_pressure(const gsl::not_null<tnsr::II<DataType, Dim, Fr>*> result,
                   const Scalar<DataType>& mass_density,
                   const tnsr::I<DataType, Dim, Fr>& velocity) {
-  destructive_resize_components(result, get_size(get(mass_density)));
   for (size_t i = 0; i < Dim; ++i) {
     for (size_t j = i; j < Dim; ++j) {
       result->get(i, j) = get(mass_density) * velocity.get(i) * velocity.get(j);

--- a/src/Evolution/Systems/NewtonianEuler/SoundSpeedSquared.cpp
+++ b/src/Evolution/Systems/NewtonianEuler/SoundSpeedSquared.cpp
@@ -6,7 +6,6 @@
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
 #include "PointwiseFunctions/Hydro/Tags.hpp"
-#include "Utilities/ContainerHelpers.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
 
@@ -18,7 +17,6 @@ void sound_speed_squared(
     const Scalar<DataType>& specific_internal_energy,
     const EquationsOfState::EquationOfState<false, ThermodynamicDim>&
         equation_of_state) {
-  destructive_resize_components(result, get_size(get(mass_density)));
   if constexpr (ThermodynamicDim == 1) {
     get(*result) =
         get(equation_of_state.chi_from_density(mass_density)) +

--- a/src/Evolution/Systems/NewtonianEuler/SpecificKineticEnergy.cpp
+++ b/src/Evolution/Systems/NewtonianEuler/SpecificKineticEnergy.cpp
@@ -5,7 +5,6 @@
 
 #include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
-#include "Utilities/ContainerHelpers.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeWithValue.hpp"
@@ -14,7 +13,6 @@ namespace NewtonianEuler {
 template <typename DataType, size_t Dim, typename Fr>
 void specific_kinetic_energy(const gsl::not_null<Scalar<DataType>*> result,
                              const tnsr::I<DataType, Dim, Fr>& velocity) {
-  destructive_resize_components(result, get_size(get<0>(velocity)));
   get(*result) = 0.5 * get(dot_product(velocity, velocity));
 }
 

--- a/src/Evolution/Systems/ScalarAdvection/VelocityField.cpp
+++ b/src/Evolution/Systems/ScalarAdvection/VelocityField.cpp
@@ -10,6 +10,7 @@
 #include "Utilities/ContainerHelpers.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/SetNumberOfGridPoints.hpp"
 
 namespace ScalarAdvection::Tags {
 
@@ -17,8 +18,7 @@ template <size_t Dim>
 void VelocityFieldCompute<Dim>::function(
     const gsl::not_null<tnsr::I<DataVector, Dim>*> velocity_field,
     const tnsr::I<DataVector, Dim, Frame::Inertial>& inertial_coords) {
-  destructive_resize_components(velocity_field,
-                                get_size(get<0>(inertial_coords)));
+  set_number_of_grid_points(velocity_field, inertial_coords);
   if constexpr (Dim == 1) {
     // 1D : advection to +x direction with velocity 1.0
     get<0>(*velocity_field) = 1.0;

--- a/src/Evolution/Systems/ScalarWave/Characteristics.cpp
+++ b/src/Evolution/Systems/ScalarWave/Characteristics.cpp
@@ -11,6 +11,7 @@
 #include "Utilities/ContainerHelpers.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/SetNumberOfGridPoints.hpp"
 #include "Utilities/TMPL.hpp"
 
 namespace ScalarWave {
@@ -18,8 +19,7 @@ template <size_t Dim>
 void characteristic_speeds(
     const gsl::not_null<std::array<DataVector, 4>*> char_speeds,
     const tnsr::i<DataVector, Dim, Frame::Inertial>& unit_normal_one_form) {
-  destructive_resize_components(char_speeds,
-                                get<0>(unit_normal_one_form).size());
+  set_number_of_grid_points(char_speeds, unit_normal_one_form);
   (*char_speeds)[0] = 0.;   // v(VPsi)
   (*char_speeds)[1] = 0.;   // v(VZero)
   (*char_speeds)[2] = 1.;   // v(VPlus)

--- a/src/Evolution/Systems/ScalarWave/Constraints.cpp
+++ b/src/Evolution/Systems/ScalarWave/Constraints.cpp
@@ -29,7 +29,6 @@ void one_index_constraint(
         constraint,
     const tnsr::i<DataVector, SpatialDim, Frame::Inertial>& d_psi,
     const tnsr::i<DataVector, SpatialDim, Frame::Inertial>& phi) {
-  destructive_resize_components(constraint, get_size(get<0>(phi)));
   // Declare iterators for d_psi and phi outside the for loop,
   // because they are const but constraint is not
   auto d_psi_it = d_psi.cbegin(), phi_it = phi.cbegin();
@@ -55,7 +54,6 @@ void two_index_constraint(
     const gsl::not_null<tnsr::ij<DataVector, SpatialDim, Frame::Inertial>*>
         constraint,
     const tnsr::ij<DataVector, SpatialDim, Frame::Inertial>& d_phi) {
-  destructive_resize_components(constraint, get_size(get<0, 0>(d_phi)));
   for (size_t i = 0; i < SpatialDim; ++i) {
     for (size_t j = 0; j < SpatialDim; ++j) {
       constraint->get(i, j) = d_phi.get(i, j) - d_phi.get(j, i);

--- a/src/Evolution/Systems/ScalarWave/Equations.cpp
+++ b/src/Evolution/Systems/ScalarWave/Equations.cpp
@@ -7,9 +7,9 @@
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
-#include "Utilities/ContainerHelpers.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/SetNumberOfGridPoints.hpp"
 #include "Utilities/TMPL.hpp"
 
 namespace ScalarWave {
@@ -20,9 +20,9 @@ void ComputeNormalDotFluxes<Dim>::apply(
     const gsl::not_null<tnsr::i<DataVector, Dim, Frame::Inertial>*>
         phi_normal_dot_flux,
     const Scalar<DataVector>& pi) {
-  destructive_resize_components(psi_normal_dot_flux, get(pi).size());
-  destructive_resize_components(pi_normal_dot_flux, get(pi).size());
-  destructive_resize_components(phi_normal_dot_flux, get(pi).size());
+  set_number_of_grid_points(psi_normal_dot_flux, pi);
+  set_number_of_grid_points(pi_normal_dot_flux, pi);
+  set_number_of_grid_points(phi_normal_dot_flux, pi);
   get(*pi_normal_dot_flux) = 0.0;
   get(*psi_normal_dot_flux) = 0.0;
   for (size_t i = 0; i < Dim; ++i) {

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/MetricIdentityJacobian.cpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/MetricIdentityJacobian.cpp
@@ -17,11 +17,11 @@
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
 #include "Utilities/Algorithm.hpp"
-#include "Utilities/ContainerHelpers.hpp"
 #include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeArray.hpp"
+#include "Utilities/SetNumberOfGridPoints.hpp"
 
 namespace {
 template <size_t Dim>
@@ -34,8 +34,8 @@ void metric_identity_det_jac_times_inv_jac_impl(
     const Jacobian<DataVector, Dim, Frame::ElementLogical, Frame::Inertial>&
         jacobian) {
   static_assert(Dim == 1 or Dim == 2, "Generic impl handles only 1d and 2d.");
-  destructive_resize_components(det_jac_times_inverse_jacobian,
-                                mesh.number_of_grid_points());
+  set_number_of_grid_points(det_jac_times_inverse_jacobian,
+                            mesh.number_of_grid_points());
   if constexpr (Dim == 1) {
     (void)jacobian;
     get<0, 0>(*det_jac_times_inverse_jacobian) = 1.0;
@@ -83,8 +83,8 @@ void metric_identity_det_jac_times_inv_jac_impl(
   //
   // The 3d implementation is what should be generalized to higher dimensions if
   // the need arises.
-  destructive_resize_components(det_jac_times_inverse_jacobian,
-                                mesh.number_of_grid_points());
+  set_number_of_grid_points(det_jac_times_inverse_jacobian,
+                            mesh.number_of_grid_points());
   const Mesh<1>& mesh0 = mesh.slice_through(0);
   const Mesh<1>& mesh1 = mesh.slice_through(1);
   const Mesh<1>& mesh2 = mesh.slice_through(2);
@@ -262,10 +262,10 @@ void metric_identity_jacobian_quantities(
     const tnsr::I<DataVector, Dim, Frame::Inertial>& inertial_coords) {
   static_assert(Dim == 1 or Dim == 2 or Dim == 3,
                 "Only implemented for 1, 2, and 3d.");
-  destructive_resize_components(det_jac_times_inverse_jacobian,
-                                mesh.number_of_grid_points());
-  destructive_resize_components(inverse_jacobian, mesh.number_of_grid_points());
-  destructive_resize_components(det_jacobian, mesh.number_of_grid_points());
+  set_number_of_grid_points(det_jac_times_inverse_jacobian,
+                            mesh.number_of_grid_points());
+  set_number_of_grid_points(inverse_jacobian, mesh.number_of_grid_points());
+  set_number_of_grid_points(det_jacobian, mesh.number_of_grid_points());
   ASSERT(
       alg::all_of(*jacobian,
                   [&mesh](const DataVector& jac_component) {

--- a/src/NumericalAlgorithms/LinearOperators/Divergence.cpp
+++ b/src/NumericalAlgorithms/LinearOperators/Divergence.cpp
@@ -11,9 +11,9 @@
 #include "DataStructures/Variables.hpp"
 #include "NumericalAlgorithms/LinearOperators/PartialDerivatives.tpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
-#include "Utilities/ContainerHelpers.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/SetNumberOfGridPoints.hpp"
 #include "Utilities/TMPL.hpp"
 
 namespace {
@@ -41,7 +41,7 @@ void divergence(
     const Mesh<Dim>& mesh,
     const InverseJacobian<DataVector, Dim, Frame::ElementLogical,
                           DerivativeFrame>& inverse_jacobian) {
-  destructive_resize_components(div_input, mesh.number_of_grid_points());
+  set_number_of_grid_points(div_input, mesh.number_of_grid_points());
 
   // We have to copy into a Variables because we don't currently have partial
   // derivative functions for anything other than Variables.

--- a/src/NumericalAlgorithms/LinearOperators/PartialDerivatives.cpp
+++ b/src/NumericalAlgorithms/LinearOperators/PartialDerivatives.cpp
@@ -16,10 +16,10 @@
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
 #include "Utilities/Blas.hpp"
-#include "Utilities/ContainerHelpers.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/Literals.hpp"
+#include "Utilities/SetNumberOfGridPoints.hpp"
 #include "Utilities/StdArrayHelpers.hpp"
 
 namespace {
@@ -56,8 +56,8 @@ void logical_partial_derivative(
          "The buffer in logical_partial_derivative must be at least of size "
              << num_grid_points << " but is of size " << buffer->size());
 
-  destructive_resize_components(logical_derivative_of_u,
-                                mesh.number_of_grid_points());
+  set_number_of_grid_points(logical_derivative_of_u,
+                            mesh.number_of_grid_points());
   const Matrix empty_matrix{};
   std::array<std::reference_wrapper<const Matrix>, Dim> diff_matrices{
       make_array<Dim, std::reference_wrapper<const Matrix>>(empty_matrix)};
@@ -134,11 +134,9 @@ void partial_derivative(
     const TensorMetafunctions::prepend_spatial_index<
         Tensor<DataVector, SymmList, IndexList>, Dim, UpLo::Lo,
         Frame::ElementLogical>& logical_partial_derivative_of_u,
-    const Mesh<Dim>& mesh,
+    const Mesh<Dim>& /*mesh*/,
     const InverseJacobian<DataVector, Dim, Frame::ElementLogical,
                           DerivativeFrame>& inverse_jacobian) {
-  destructive_resize_components(du, mesh.number_of_grid_points());
-
   for (size_t storage_index = 0;
        storage_index < Tensor<DataVector, SymmList, IndexList>::size();
        ++storage_index) {

--- a/src/NumericalAlgorithms/Spectral/LogicalCoordinates.cpp
+++ b/src/NumericalAlgorithms/Spectral/LogicalCoordinates.cpp
@@ -12,15 +12,15 @@
 #include "Domain/Structure/Side.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"  // IWYU pragma: keep
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
-#include "Utilities/ContainerHelpers.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/SetNumberOfGridPoints.hpp"
 
 template <size_t VolumeDim>
 void logical_coordinates(
     const gsl::not_null<tnsr::I<DataVector, VolumeDim, Frame::ElementLogical>*>
         logical_coords,
     const Mesh<VolumeDim>& mesh) {
-  destructive_resize_components(logical_coords, mesh.number_of_grid_points());
+  set_number_of_grid_points(logical_coords, mesh.number_of_grid_points());
   for (size_t d = 0; d < VolumeDim; ++d) {
     const auto& collocation_points_in_this_dim =
         Spectral::collocation_points(mesh.slice_through(d));

--- a/src/NumericalAlgorithms/Spectral/SwshCollocation.cpp
+++ b/src/NumericalAlgorithms/Spectral/SwshCollocation.cpp
@@ -11,12 +11,12 @@
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "NumericalAlgorithms/Spectral/ComplexDataView.hpp"
 #include "NumericalAlgorithms/Spectral/SwshCollocation.hpp"
-#include "Utilities/ContainerHelpers.hpp"
 #include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/ForceInline.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/Literals.hpp"
+#include "Utilities/SetNumberOfGridPoints.hpp"
 #include "Utilities/StaticCache.hpp"
 
 namespace Spectral::Swsh {
@@ -79,10 +79,10 @@ void create_angular_and_cartesian_coordinates(
         tnsr::i<DataVector, 2, ::Frame::Spherical<::Frame::Inertial>>*>
         angular_coordinates,
     const size_t l_max) {
-  destructive_resize_components(cartesian_coordinates,
-                                number_of_swsh_collocation_points(l_max));
-  destructive_resize_components(angular_coordinates,
-                                number_of_swsh_collocation_points(l_max));
+  set_number_of_grid_points(cartesian_coordinates,
+                            number_of_swsh_collocation_points(l_max));
+  set_number_of_grid_points(angular_coordinates,
+                            number_of_swsh_collocation_points(l_max));
   const auto& collocation = Spectral::Swsh::cached_collocation_metadata<
       Spectral::Swsh::ComplexRepresentation::Interleaved>(l_max);
   for (const auto collocation_point : collocation) {

--- a/src/ParallelAlgorithms/LinearSolver/Schwarz/ComputeTags.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Schwarz/ComputeTags.hpp
@@ -17,6 +17,7 @@
 #include "ParallelAlgorithms/LinearSolver/Schwarz/OverlapHelpers.hpp"
 #include "ParallelAlgorithms/LinearSolver/Schwarz/Tags.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/SetNumberOfGridPoints.hpp"
 #include "Utilities/TMPL.hpp"
 
 namespace LinearSolver::Schwarz::Tags {
@@ -42,8 +43,8 @@ struct SummedIntrudingOverlapWeightsCompute
           all_intruding_weights,
       const Mesh<Dim>& mesh,
       const std::array<size_t, Dim>& all_intruding_extents) {
-    destructive_resize_components(summed_intruding_overlap_weights,
-                                  mesh.number_of_grid_points());
+    set_number_of_grid_points(summed_intruding_overlap_weights,
+                              mesh.number_of_grid_points());
     get(*summed_intruding_overlap_weights) = 0.;
     for (const auto& [direction, intruding_weight] : all_intruding_weights) {
       // Extend intruding weight to full extents

--- a/src/ParallelAlgorithms/LinearSolver/Schwarz/Weighting.cpp
+++ b/src/ParallelAlgorithms/LinearSolver/Schwarz/Weighting.cpp
@@ -14,11 +14,11 @@
 #include "Domain/Structure/Direction.hpp"
 #include "Domain/Structure/Hypercube.hpp"
 #include "Domain/Structure/Side.hpp"
-#include "Utilities/ContainerHelpers.hpp"
 #include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/Math.hpp"
+#include "Utilities/SetNumberOfGridPoints.hpp"
 
 namespace LinearSolver::Schwarz {
 
@@ -51,7 +51,7 @@ void element_weight(
     const tnsr::I<DataVector, Dim, Frame::ElementLogical>& logical_coords,
     const std::array<double, Dim>& overlap_widths,
     const std::unordered_set<Direction<Dim>>& external_boundaries) {
-  destructive_resize_components(weight, logical_coords.begin()->size());
+  set_number_of_grid_points(weight, logical_coords);
   get(*weight) = 1.;
   for (size_t d = 0; d < Dim; ++d) {
     ASSERT(gsl::at(overlap_widths, d) > 0,
@@ -108,7 +108,7 @@ void intruding_weight(
         num_intruding_overlaps;
   } else {
     const size_t num_points = logical_coords.begin()->size();
-    destructive_resize_components(weight, num_points);
+    set_number_of_grid_points(weight, num_points);
     get(*weight) = 1.;
     const auto has_overlap = [&external_boundaries](const size_t dimension,
                                                     const Side side) {

--- a/src/PointwiseFunctions/AnalyticData/GeneralRelativity/InterpolateFromSpec.hpp
+++ b/src/PointwiseFunctions/AnalyticData/GeneralRelativity/InterpolateFromSpec.hpp
@@ -12,6 +12,7 @@
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Utilities/ContainerHelpers.hpp"
 #include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/SetNumberOfGridPoints.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
 
@@ -68,7 +69,7 @@ tuples::tagged_tuple_from_typelist<Tags> interpolate_from_spec(
                         &var_i](const auto tag_v) {
     using tag = tmpl::type_from<std::decay_t<decltype(tag_v)>>;
     auto& tensor = get<tag>(interpolation_buffer);
-    destructive_resize_components(make_not_null(&tensor), num_points);
+    set_number_of_grid_points(make_not_null(&tensor), num_points);
     const size_t num_components = tensor.size();
     buffer_pointers[var_i].resize(num_components);
     // The SpEC exporter supports tensors up to symmetric rank 2, which are

--- a/src/PointwiseFunctions/Elasticity/PotentialEnergy.cpp
+++ b/src/PointwiseFunctions/Elasticity/PotentialEnergy.cpp
@@ -11,10 +11,10 @@
 #include "Elliptic/Systems/Elasticity/Tags.hpp"
 #include "PointwiseFunctions/Elasticity/ConstitutiveRelations/ConstitutiveRelation.hpp"
 #include "PointwiseFunctions/Elasticity/ConstitutiveRelations/Tags.hpp"
-#include "Utilities/ContainerHelpers.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeWithValue.hpp"
+#include "Utilities/SetNumberOfGridPoints.hpp"
 
 namespace Elasticity {
 
@@ -25,8 +25,7 @@ void potential_energy_density(
     const tnsr::I<DataVector, Dim>& coordinates,
     const ConstitutiveRelations::ConstitutiveRelation<Dim>&
         constitutive_relation) {
-  destructive_resize_components(potential_energy_density,
-                                coordinates.begin()->size());
+  set_number_of_grid_points(potential_energy_density, coordinates);
   tnsr::II<DataVector, Dim> stress{coordinates.begin()->size()};
   constitutive_relation.stress(make_not_null(&stress), strain, coordinates);
   get(*potential_energy_density) = 0.;

--- a/src/PointwiseFunctions/GeneralRelativity/Christoffel.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/Christoffel.cpp
@@ -44,7 +44,6 @@ void christoffel_second_kind(
         christoffel,
     const tnsr::abb<DataType, SpatialDim, Frame, Index>& d_metric,
     const tnsr::AA<DataType, SpatialDim, Frame, Index>& inverse_metric) {
-  destructive_resize_components(christoffel, get_size(*d_metric.begin()));
   constexpr auto dimensionality =
       Index == IndexType::Spatial ? SpatialDim : SpatialDim + 1;
   for (size_t d = 0; d < dimensionality; ++d) {

--- a/src/PointwiseFunctions/GeneralRelativity/DerivativeSpatialMetric.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/DerivativeSpatialMetric.cpp
@@ -9,9 +9,9 @@
 #include "DataStructures/Tensor/IndexType.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
-#include "Utilities/ContainerHelpers.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/SetNumberOfGridPoints.hpp"
 
 namespace gr {
 template <typename DataType, size_t Dim, typename Frame>
@@ -19,8 +19,7 @@ void deriv_inverse_spatial_metric(
     const gsl::not_null<tnsr::iJJ<DataType, Dim, Frame>*> result,
     const tnsr::II<DataType, Dim, Frame>& inverse_spatial_metric,
     const tnsr::ijj<DataType, Dim, Frame>& d_spatial_metric) {
-  destructive_resize_components(result,
-                                get_size(get<0, 0>(inverse_spatial_metric)));
+  set_number_of_grid_points(result, inverse_spatial_metric);
   for (auto& component : *result) {
     component = 0.0;
   }

--- a/src/PointwiseFunctions/GeneralRelativity/DerivativesOfSpacetimeMetric.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/DerivativesOfSpacetimeMetric.cpp
@@ -39,8 +39,7 @@ void derivatives_of_spacetime_metric(
     const tnsr::ii<DataType, Dim, Frame>& spatial_metric,
     const tnsr::ii<DataType, Dim, Frame>& dt_spatial_metric,
     const tnsr::ijj<DataType, Dim, Frame>& deriv_spatial_metric) {
-  destructive_resize_components(spacetime_deriv_spacetime_metric,
-                                get_size(get(lapse)));
+  set_number_of_grid_points(spacetime_deriv_spacetime_metric, lapse);
   for (size_t a = 0; a < Dim + 1; ++a) {
     for (size_t i = 0; i < Dim; ++i) {
       spacetime_deriv_spacetime_metric->get(a, 0, i + 1) = 0.0;

--- a/src/PointwiseFunctions/GeneralRelativity/DetAndInverseSpatialMetric.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/DetAndInverseSpatialMetric.hpp
@@ -15,7 +15,6 @@
 #include "DataStructures/VariablesTag.hpp"
 #include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
-#include "Utilities/ContainerHelpers.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
@@ -66,7 +65,6 @@ struct SqrtDetSpatialMetricCompute : SqrtDetSpatialMetric<DataType>,
 
   static void function(const gsl::not_null<Scalar<DataType>*> result,
                        const Scalar<DataType>& det_spatial_metric) {
-    destructive_resize_components(result, get_size(get(det_spatial_metric)));
     get(*result) = sqrt(get(det_spatial_metric));
   }
 

--- a/src/PointwiseFunctions/GeneralRelativity/ExtrinsicCurvature.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/ExtrinsicCurvature.cpp
@@ -7,7 +7,6 @@
 
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Utilities/ConstantExpressions.hpp"
-#include "Utilities/ContainerHelpers.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeWithValue.hpp"
@@ -23,7 +22,6 @@ void extrinsic_curvature(
     const tnsr::ii<DataType, SpatialDim, Frame>& spatial_metric,
     const tnsr::ii<DataType, SpatialDim, Frame>& dt_spatial_metric,
     const tnsr::ijj<DataType, SpatialDim, Frame>& deriv_spatial_metric) {
-  destructive_resize_components(ex_curvature, get_size(get(lapse)));
   const DataType half_over_lapse = 0.5 / get(lapse);
   for (size_t i = 0; i < SpatialDim; ++i) {
     for (size_t j = i; j < SpatialDim; ++j) {  // Symmetry

--- a/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/Christoffel.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/Christoffel.cpp
@@ -9,6 +9,7 @@
 #include "Utilities/ContainerHelpers.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/SetNumberOfGridPoints.hpp"
 
 namespace gh {
 template <typename DataType, size_t SpatialDim, typename Frame>
@@ -16,7 +17,6 @@ void christoffel_second_kind(
     const gsl::not_null<tnsr::Ijj<DataType, SpatialDim, Frame>*> christoffel,
     const tnsr::iaa<DataType, SpatialDim, Frame>& phi,
     const tnsr::II<DataType, SpatialDim, Frame>& inv_metric) {
-  destructive_resize_components(christoffel, get_size(*phi.begin()));
   for (size_t i = 0; i < SpatialDim; ++i) {
     for (size_t j = i; j < SpatialDim; ++j) {
       for (size_t m = 0; m < SpatialDim; ++m) {
@@ -69,8 +69,7 @@ void trace_christoffel(
     const tnsr::AA<DataType, SpatialDim, Frame>& inverse_spacetime_metric,
     const tnsr::aa<DataType, SpatialDim, Frame>& pi,
     const tnsr::iaa<DataType, SpatialDim, Frame>& phi) {
-  destructive_resize_components(trace,
-                                get_size(get<0>(spacetime_normal_one_form)));
+  set_number_of_grid_points(trace, spacetime_normal_one_form);
   get<0>(*trace) = 0.0;
   // Compute common terms between components.
   for (size_t b = 0; b < SpatialDim + 1; ++b) {

--- a/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/CovariantDerivOfExtrinsicCurvature.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/CovariantDerivOfExtrinsicCurvature.cpp
@@ -44,9 +44,6 @@ void covariant_deriv_of_extrinsic_curvature(
     const tnsr::iaa<DataType, SpatialDim, Frame>& phi,
     const tnsr::iaa<DataType, SpatialDim, Frame>& d_pi,
     const tnsr::ijaa<DataType, SpatialDim, Frame>& d_phi) {
-  destructive_resize_components(d_extrinsic_curvature,
-                                get_size(get<0>(spacetime_unit_normal_vector)));
-
   // Ordinary derivative first
   for (size_t i = 0; i < SpatialDim; ++i) {
     for (size_t j = i; j < SpatialDim; ++j) {

--- a/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/ExtrinsicCurvature.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/ExtrinsicCurvature.cpp
@@ -7,9 +7,9 @@
 #include "DataStructures/Tensor/Tensor.hpp"  // IWYU pragma: keep
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Utilities/ConstantExpressions.hpp"
-#include "Utilities/ContainerHelpers.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/SetNumberOfGridPoints.hpp"
 
 // IWYU pragma: no_forward_declare Tensor
 
@@ -20,8 +20,7 @@ void extrinsic_curvature(
     const tnsr::A<DataType, SpatialDim, Frame>& spacetime_normal_vector,
     const tnsr::aa<DataType, SpatialDim, Frame>& pi,
     const tnsr::iaa<DataType, SpatialDim, Frame>& phi) {
-  destructive_resize_components(ex_curv,
-                                get_size(get<0>(spacetime_normal_vector)));
+  set_number_of_grid_points(ex_curv, spacetime_normal_vector);
   for (auto& component : *ex_curv) {
     component = 0.0;
   }

--- a/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/GaugeSource.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/GaugeSource.cpp
@@ -7,9 +7,9 @@
 #include "DataStructures/Tensor/Tensor.hpp"  // IWYU pragma: keep
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Utilities/ConstantExpressions.hpp"
-#include "Utilities/ContainerHelpers.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/SetNumberOfGridPoints.hpp"
 
 // IWYU pragma: no_forward_declare Tensor
 
@@ -26,7 +26,7 @@ void gauge_source(
     const Scalar<DataType>& trace_extrinsic_curvature,
     const tnsr::i<DataType, SpatialDim, Frame>&
         trace_christoffel_last_indices) {
-  destructive_resize_components(gauge_source_h, get_size(get(lapse)));
+  set_number_of_grid_points(gauge_source_h, lapse);
   for (auto& component : *gauge_source_h) {
     component = 0.0;
   }

--- a/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/GaugeSource.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/GaugeSource.hpp
@@ -12,7 +12,6 @@
 #include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
 #include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
-#include "Utilities/ContainerHelpers.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -136,8 +135,6 @@ struct SpacetimeDerivGaugeHCompute
           spacetime_deriv_gauge_source,
       const tnsr::a<DataVector, SpatialDim, Frame>& time_deriv_gauge_source,
       const tnsr::ia<DataVector, SpatialDim, Frame>& deriv_gauge_source) {
-    destructive_resize_components(spacetime_deriv_gauge_source,
-                                  get<0>(time_deriv_gauge_source).size());
     for (size_t b = 0; b < SpatialDim + 1; ++b) {
       spacetime_deriv_gauge_source->get(0, b) = time_deriv_gauge_source.get(b);
       for (size_t a = 1; a < SpatialDim + 1; ++a) {

--- a/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/Ricci.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/Ricci.cpp
@@ -11,6 +11,7 @@
 #include "Utilities/ContainerHelpers.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/SetNumberOfGridPoints.hpp"
 
 // IWYU pragma: no_forward_declare Tensor
 
@@ -21,7 +22,7 @@ void spatial_ricci_tensor(
     const tnsr::iaa<DataType, VolumeDim, Frame>& phi,
     const tnsr::ijaa<DataType, VolumeDim, Frame>& deriv_phi,
     const tnsr::II<DataType, VolumeDim, Frame>& inverse_spatial_metric) {
-  destructive_resize_components(ricci, get_size(get<0, 0, 0>(phi)));
+  set_number_of_grid_points(ricci, phi);
 
   TempBuffer<tmpl::list<::Tags::TempIjj<0, VolumeDim, Frame, DataType>,
                         ::Tags::TempijK<0, VolumeDim, Frame, DataType>,

--- a/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/SpacetimeDerivativeOfSpacetimeMetric.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/SpacetimeDerivativeOfSpacetimeMetric.cpp
@@ -7,7 +7,6 @@
 #include "DataStructures/Tensor/Tensor.hpp"  // IWYU pragma: keep
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Utilities/ConstantExpressions.hpp"
-#include "Utilities/ContainerHelpers.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
 
@@ -22,7 +21,6 @@ void spacetime_derivative_of_spacetime_metric(
     const tnsr::I<DataType, SpatialDim, Frame>& shift,
     const tnsr::aa<DataType, SpatialDim, Frame>& pi,
     const tnsr::iaa<DataType, SpatialDim, Frame>& phi) {
-  destructive_resize_components(da_spacetime_metric, get_size(get(lapse)));
   for (size_t a = 0; a < SpatialDim + 1; ++a) {
     for (size_t b = a; b < SpatialDim + 1; ++b) {
       da_spacetime_metric->get(0, a, b) = -pi.get(a, b) * get(lapse);

--- a/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/TimeDerivativeOfSpacetimeMetric.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/TimeDerivativeOfSpacetimeMetric.cpp
@@ -7,7 +7,6 @@
 #include "DataStructures/Tensor/Tensor.hpp"  // IWYU pragma: keep
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Utilities/ConstantExpressions.hpp"
-#include "Utilities/ContainerHelpers.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
 
@@ -22,7 +21,6 @@ void time_derivative_of_spacetime_metric(
     const tnsr::I<DataType, SpatialDim, Frame>& shift,
     const tnsr::aa<DataType, SpatialDim, Frame>& pi,
     const tnsr::iaa<DataType, SpatialDim, Frame>& phi) {
-  destructive_resize_components(dt_spacetime_metric, get_size(get(lapse)));
   for (size_t a = 0; a < SpatialDim + 1; ++a) {
     for (size_t b = a; b < SpatialDim + 1; ++b) {
       dt_spacetime_metric->get(a, b) = -pi.get(a, b) * get(lapse);

--- a/src/PointwiseFunctions/GeneralRelativity/InterfaceNullNormal.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/InterfaceNullNormal.cpp
@@ -36,8 +36,6 @@ void interface_null_normal(
   ASSERT((sign == 1.) or (sign == -1.),
          "Calculation of interface null normal accepts only +1/-1 to indicate "
          "whether the outgoing/incoming normal is needed.");
-  destructive_resize_components(null_one_form,
-                                get_size(get<0>(spacetime_normal_one_form)));
 
   const double one_by_sqrt_2 = 1. / sqrt(2.);
   get<0>(*null_one_form) = one_by_sqrt_2 * get<0>(spacetime_normal_one_form);
@@ -72,8 +70,6 @@ void interface_null_normal(
   ASSERT((sign == 1.) or (sign == -1.),
          "Calculation of interface null normal accepts only +1/-1 to indicate "
          "whether the outgoing/incoming normal is needed.");
-  destructive_resize_components(null_vector,
-                                get_size(get<0>(spacetime_normal_vector)));
 
   const double one_by_sqrt_2 = 1. / sqrt(2.);
   get<0>(*null_vector) = one_by_sqrt_2 * get<0>(spacetime_normal_vector);

--- a/src/PointwiseFunctions/GeneralRelativity/Lapse.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/Lapse.cpp
@@ -26,7 +26,6 @@ template <typename DataType, size_t SpatialDim, typename Frame>
 void lapse(const gsl::not_null<Scalar<DataType>*> lapse,
            const tnsr::I<DataType, SpatialDim, Frame>& shift,
            const tnsr::aa<DataType, SpatialDim, Frame>& spacetime_metric) {
-  destructive_resize_components(lapse, get_size(get<0, 0>(spacetime_metric)));
   get(*lapse) = -get<0, 0>(spacetime_metric);
   for (size_t i = 0; i < SpatialDim; ++i) {
     get(*lapse) += shift.get(i) * spacetime_metric.get(i + 1, 0);

--- a/src/PointwiseFunctions/GeneralRelativity/ProjectionOperators.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/ProjectionOperators.cpp
@@ -26,9 +26,6 @@ void transverse_projection_operator(
         projection_tensor,
     const tnsr::II<DataType, VolumeDim, Frame>& inverse_spatial_metric,
     const tnsr::I<DataType, VolumeDim, Frame>& normal_vector) {
-  destructive_resize_components(projection_tensor,
-                                get_size(get<0>(normal_vector)));
-
   for (size_t i = 0; i < VolumeDim; ++i) {
     for (size_t j = i; j < VolumeDim; ++j) {
       projection_tensor->get(i, j) =
@@ -55,9 +52,6 @@ void transverse_projection_operator(
         projection_tensor,
     const tnsr::ii<DataType, VolumeDim, Frame>& spatial_metric,
     const tnsr::i<DataType, VolumeDim, Frame>& normal_one_form) {
-  destructive_resize_components(projection_tensor,
-                                get_size(get<0>(normal_one_form)));
-
   for (size_t i = 0; i < VolumeDim; ++i) {
     for (size_t j = i; j < VolumeDim; ++j) {
       projection_tensor->get(i, j) =
@@ -84,9 +78,6 @@ void transverse_projection_operator(
         projection_tensor,
     const tnsr::I<DataType, VolumeDim, Frame>& normal_vector,
     const tnsr::i<DataType, VolumeDim, Frame>& normal_one_form) {
-  destructive_resize_components(projection_tensor,
-                                get_size(get<0>(normal_vector)));
-
   for (size_t i = 0; i < VolumeDim; ++i) {
     for (size_t j = 0; j < VolumeDim; ++j) {
       projection_tensor->get(i, j) =
@@ -116,9 +107,6 @@ void transverse_projection_operator(
     const tnsr::AA<DataType, VolumeDim, Frame>& inverse_spacetime_metric,
     const tnsr::A<DataType, VolumeDim, Frame>& spacetime_normal_vector,
     const tnsr::I<DataType, VolumeDim, Frame>& interface_unit_normal_vector) {
-  destructive_resize_components(projection_tensor,
-                                get_size(get<0>(spacetime_normal_vector)));
-
   for (size_t a = 0, b = 0; b < VolumeDim + 1; ++b) {
     projection_tensor->get(a, b) =
         inverse_spacetime_metric.get(a, b) +
@@ -155,9 +143,6 @@ void transverse_projection_operator(
     const tnsr::aa<DataType, VolumeDim, Frame>& spacetime_metric,
     const tnsr::a<DataType, VolumeDim, Frame>& spacetime_normal_one_form,
     const tnsr::i<DataType, VolumeDim, Frame>& interface_unit_normal_one_form) {
-  destructive_resize_components(projection_tensor,
-                                get_size(get<0>(spacetime_normal_one_form)));
-
   for (size_t a = 0, b = 0; b < VolumeDim + 1; ++b) {
     projection_tensor->get(a, b) =
         spacetime_metric.get(a, b) +
@@ -197,9 +182,6 @@ void transverse_projection_operator(
     const tnsr::a<DataType, VolumeDim, Frame>& spacetime_normal_one_form,
     const tnsr::I<DataType, VolumeDim, Frame>& interface_unit_normal_vector,
     const tnsr::i<DataType, VolumeDim, Frame>& interface_unit_normal_one_form) {
-  destructive_resize_components(projection_tensor,
-                                get_size(get<0>(spacetime_normal_vector)));
-
   for (size_t a = 0, b = 0; b < VolumeDim + 1; ++b) {
     projection_tensor->get(a, b) =
         spacetime_normal_vector.get(a) * spacetime_normal_one_form.get(b);

--- a/src/PointwiseFunctions/GeneralRelativity/Ricci.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/Ricci.cpp
@@ -5,10 +5,10 @@
 
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "IndexManipulation.hpp"
-#include "Utilities/ContainerHelpers.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeWithValue.hpp"
+#include "Utilities/SetNumberOfGridPoints.hpp"
 
 namespace gr {
 template <size_t SpatialDim, typename Frame, IndexType Index, typename DataType>
@@ -17,8 +17,7 @@ void ricci_tensor(
     const tnsr::Abb<DataType, SpatialDim, Frame, Index>& christoffel_2nd_kind,
     const tnsr::aBcc<DataType, SpatialDim, Frame, Index>&
         d_christoffel_2nd_kind) {
-  destructive_resize_components(result,
-                                get_size(get<0, 0, 0>(christoffel_2nd_kind)));
+  set_number_of_grid_points(result, christoffel_2nd_kind);
   for (auto& component : *result) {
     component = 0.0;
   }

--- a/src/PointwiseFunctions/GeneralRelativity/Shift.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/Shift.cpp
@@ -28,7 +28,6 @@ void shift(
     const gsl::not_null<tnsr::I<DataType, SpatialDim, Frame>*> shift,
     const tnsr::aa<DataType, SpatialDim, Frame>& spacetime_metric,
     const tnsr::II<DataType, SpatialDim, Frame>& inverse_spatial_metric) {
-  destructive_resize_components(shift, get_size(get<0, 0>(spacetime_metric)));
   for (size_t i = 0; i < SpatialDim; ++i) {
     shift->get(i) =
         inverse_spatial_metric.get(i, 0) * get<1, 0>(spacetime_metric);

--- a/src/PointwiseFunctions/GeneralRelativity/SpacetimeNormalOneForm.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/SpacetimeNormalOneForm.cpp
@@ -7,17 +7,17 @@
 
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Utilities/ConstantExpressions.hpp"
-#include "Utilities/ContainerHelpers.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeWithValue.hpp"
+#include "Utilities/SetNumberOfGridPoints.hpp"
 
 namespace gr {
 template <typename DataType, size_t SpatialDim, typename Frame>
 void spacetime_normal_one_form(
     const gsl::not_null<tnsr::a<DataType, SpatialDim, Frame>*> normal_one_form,
     const Scalar<DataType>& lapse) {
-  destructive_resize_components(normal_one_form, get_size(get(lapse)));
+  set_number_of_grid_points(normal_one_form, lapse);
   for (auto& component : *normal_one_form) {
     component = 0.0;
   }

--- a/src/PointwiseFunctions/GeneralRelativity/SpacetimeNormalVector.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/SpacetimeNormalVector.cpp
@@ -30,7 +30,6 @@ void spacetime_normal_vector(
         spacetime_normal_vector,
     const Scalar<DataType>& lapse,
     const tnsr::I<DataType, SpatialDim, Frame>& shift) {
-  destructive_resize_components(spacetime_normal_vector, get_size(get(lapse)));
   get<0>(*spacetime_normal_vector) = 1. / get(lapse);
   for (size_t i = 0; i < SpatialDim; i++) {
     spacetime_normal_vector->get(i + 1) =

--- a/src/PointwiseFunctions/GeneralRelativity/SpatialMetric.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/SpatialMetric.cpp
@@ -26,8 +26,6 @@ template <typename DataType, size_t SpatialDim, typename Frame>
 void spatial_metric(
     const gsl::not_null<tnsr::ii<DataType, SpatialDim, Frame>*> spatial_metric,
     const tnsr::aa<DataType, SpatialDim, Frame>& spacetime_metric) {
-  destructive_resize_components(spatial_metric,
-                                get_size(get<0, 0>(spacetime_metric)));
   for (size_t i = 0; i < SpatialDim; ++i) {
     for (size_t j = i; j < SpatialDim; ++j) {
       spatial_metric->get(i, j) = spacetime_metric.get(i + 1, j + 1);

--- a/src/PointwiseFunctions/GeneralRelativity/TimeDerivativeOfSpacetimeMetric.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/TimeDerivativeOfSpacetimeMetric.cpp
@@ -22,7 +22,6 @@ void time_derivative_of_spacetime_metric(
     const tnsr::I<DataType, SpatialDim, Frame>& dt_shift,
     const tnsr::ii<DataType, SpatialDim, Frame>& spatial_metric,
     const tnsr::ii<DataType, SpatialDim, Frame>& dt_spatial_metric) {
-  destructive_resize_components(dt_spacetime_metric, get_size(get(dt_lapse)));
   get<0, 0>(*dt_spacetime_metric) = -2.0 * get(lapse) * get(dt_lapse);
   for (size_t i = 0; i < SpatialDim; ++i) {
     for (size_t j = 0; j < SpatialDim; ++j) {

--- a/src/PointwiseFunctions/GeneralRelativity/TimeDerivativeOfSpatialMetric.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/TimeDerivativeOfSpatialMetric.cpp
@@ -23,7 +23,6 @@ void time_derivative_of_spatial_metric(
     const tnsr::ii<DataType, SpatialDim, Frame>& spatial_metric,
     const tnsr::ijj<DataType, SpatialDim, Frame>& deriv_spatial_metric,
     const tnsr::ii<DataType, SpatialDim, Frame>& extrinsic_curvature) {
-  destructive_resize_components(dt_spatial_metric, get_size(get(lapse)));
   for (size_t i = 0; i < SpatialDim; ++i) {
     for (size_t j = 0; j <= i; ++j) {
       dt_spatial_metric->get(i, j) =

--- a/src/PointwiseFunctions/GeneralRelativity/Transform.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/Transform.cpp
@@ -7,7 +7,6 @@
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
-#include "Utilities/ContainerHelpers.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
 
@@ -284,7 +283,6 @@ void first_index_to_different_frame(
                             SpatialIndex<VolumeDim, UpLo::Lo, DestFrame>,
                             SpatialIndex<VolumeDim, UpLo::Lo, DestFrame>>>& src,
     const Jacobian<DataVector, VolumeDim, DestFrame, SrcFrame>& jacobian) {
-  destructive_resize_components(dest, src.begin()->size());
   for (size_t i = 0; i < VolumeDim; ++i) {
     for (size_t j = i; j < VolumeDim; ++j) {  // symmetry
       for (size_t k = 0; k < VolumeDim; ++k) {

--- a/src/PointwiseFunctions/GeneralRelativity/WeylMagnetic.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/WeylMagnetic.cpp
@@ -8,7 +8,6 @@
 #include "DataStructures/LeviCivitaIterator.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/VectorImpl.hpp"
-#include "Utilities/ContainerHelpers.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeWithValue.hpp"
@@ -35,8 +34,6 @@ void weyl_magnetic(
     const tnsr::ijj<DataType, 3, Frame>& grad_extrinsic_curvature,
     const tnsr::ii<DataType, 3, Frame>& spatial_metric,
     const Scalar<DataType>& sqrt_det_spatial_metric) {
-  destructive_resize_components(weyl_magnetic_part,
-                                get_size(get<0, 0>(spatial_metric)));
   auto grad_extrinsic_curvature_cross_spatial_metric =
       make_with_value<tnsr::ij<DataType, 3, Frame>>(get<0, 0>(spatial_metric),
                                                     0.0);
@@ -66,11 +63,6 @@ void weyl_magnetic_scalar(
     const gsl::not_null<Scalar<DataType>*> weyl_magnetic_scalar_result,
     const tnsr::ii<DataType, 3, Frame>& weyl_magnetic,
     const tnsr::II<DataType, 3, Frame>& inverse_spatial_metric) {
-  destructive_resize_components(weyl_magnetic_scalar_result,
-                                get_size(get<0, 0>(inverse_spatial_metric)));
-  *weyl_magnetic_scalar_result =
-      make_with_value<Scalar<DataType>>(get<0, 0>(inverse_spatial_metric), 0.0);
-
   auto weyl_magnetic_up_down = make_with_value<tnsr::Ij<DataType, 3, Frame>>(
       get<0, 0>(inverse_spatial_metric), 0.0);
   for (size_t i = 0; i < 3; ++i) {

--- a/src/PointwiseFunctions/GeneralRelativity/WeylPropagating.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/WeylPropagating.cpp
@@ -13,6 +13,7 @@
 #include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/SetNumberOfGridPoints.hpp"
 
 // IWYU pragma: no_forward_declare Tensor
 
@@ -53,8 +54,7 @@ void weyl_propagating(
   ASSERT((sign == 1.) or (sign == -1.),
          "Calculation of weyl propagating modes accepts only +1/-1 to indicate "
          "which of U8+/- is needed.");
-  destructive_resize_components(weyl_prop_u8,
-                                get_size(get<0>(unit_interface_normal_vector)));
+  set_number_of_grid_points(weyl_prop_u8, unit_interface_normal_vector);
 
   TempBuffer<tmpl::list<::Tags::Tempii<0, SpatialDim, Frame, DataType>>>
       unprojected_weyl_prop_u8_vars(

--- a/src/PointwiseFunctions/Hydro/ComovingMagneticField.cpp
+++ b/src/PointwiseFunctions/Hydro/ComovingMagneticField.cpp
@@ -5,7 +5,6 @@
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
-#include "Utilities/ContainerHelpers.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
 
@@ -19,7 +18,6 @@ void comoving_magnetic_field_one_form(
     const Scalar<DataType>& magnetic_field_dot_spatial_velocity,
     const Scalar<DataType>& lorentz_factor, const tnsr::I<DataType, 3>& shift,
     const Scalar<DataType>& lapse) {
-  destructive_resize_components(result, get_size(get(lapse)));
   get<0>(*result) = -get(lapse) * get(lorentz_factor) *
                     get(magnetic_field_dot_spatial_velocity);
   for (size_t i = 0; i < 3; ++i) {

--- a/src/PointwiseFunctions/Hydro/LorentzFactor.cpp
+++ b/src/PointwiseFunctions/Hydro/LorentzFactor.cpp
@@ -7,16 +7,14 @@
 
 #include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
-#include "Utilities/ContainerHelpers.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/SetNumberOfGridPoints.hpp"
 
 namespace hydro {
 template <typename DataType>
 void lorentz_factor(const gsl::not_null<Scalar<DataType>*> result,
                     const Scalar<DataType>& spatial_velocity_squared) {
-  destructive_resize_components(result,
-                                get_size(get(spatial_velocity_squared)));
   get(*result) = 1.0 / sqrt(1.0 - get(spatial_velocity_squared));
 }
 
@@ -33,7 +31,7 @@ void lorentz_factor(
     const gsl::not_null<Scalar<DataType>*> result,
     const tnsr::I<DataType, Dim, Frame>& spatial_velocity,
     const tnsr::i<DataType, Dim, Frame>& spatial_velocity_form) {
-  destructive_resize_components(result, get_size(get<0>(spatial_velocity)));
+  set_number_of_grid_points(result, spatial_velocity);
   lorentz_factor(result, dot_product(spatial_velocity, spatial_velocity_form));
 }
 

--- a/src/PointwiseFunctions/Hydro/MassFlux.cpp
+++ b/src/PointwiseFunctions/Hydro/MassFlux.cpp
@@ -5,7 +5,6 @@
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
-#include "Utilities/ContainerHelpers.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeWithValue.hpp"
@@ -20,7 +19,6 @@ void mass_flux(const gsl::not_null<tnsr::I<DataType, Dim, Frame>*> result,
                const Scalar<DataType>& lapse,
                const tnsr::I<DataType, Dim, Frame>& shift,
                const Scalar<DataType>& sqrt_det_spatial_metric) {
-  destructive_resize_components(result, get_size(get(rest_mass_density)));
   for (size_t i = 0; i < Dim; ++i) {
     result->get(i) = get(rest_mass_density) * get(lorentz_factor) *
                      get(sqrt_det_spatial_metric) *

--- a/src/PointwiseFunctions/Hydro/SoundSpeedSquared.cpp
+++ b/src/PointwiseFunctions/Hydro/SoundSpeedSquared.cpp
@@ -8,7 +8,6 @@
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
-#include "Utilities/ContainerHelpers.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
 
@@ -22,7 +21,6 @@ void sound_speed_squared(
     const Scalar<DataType>& specific_enthalpy,
     const EquationsOfState::EquationOfState<true, ThermodynamicDim>&
         equation_of_state) {
-  destructive_resize_components(result, get_size(get(rest_mass_density)));
   if constexpr (ThermodynamicDim == 1) {
     get(*result) =
         get(equation_of_state.chi_from_density(rest_mass_density)) +

--- a/src/PointwiseFunctions/Hydro/SpecificEnthalpy.cpp
+++ b/src/PointwiseFunctions/Hydro/SpecificEnthalpy.cpp
@@ -5,7 +5,6 @@
 
 #include "DataStructures/DataVector.hpp"  // IWYU pragma: keep
 #include "DataStructures/Tensor/Tensor.hpp"
-#include "Utilities/ContainerHelpers.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
 
@@ -16,7 +15,6 @@ void relativistic_specific_enthalpy(
     const Scalar<DataType>& rest_mass_density,
     const Scalar<DataType>& specific_internal_energy,
     const Scalar<DataType>& pressure) {
-  destructive_resize_components(result, get_size(get(rest_mass_density)));
   get(*result) = 1.0 + get(specific_internal_energy) +
                  get(pressure) / get(rest_mass_density);
 }

--- a/src/Time/Actions/UpdateU.hpp
+++ b/src/Time/Actions/UpdateU.hpp
@@ -15,6 +15,7 @@
 #include "Parallel/AlgorithmExecution.hpp"
 #include "Time/Tags.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/SetNumberOfGridPoints.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
 #include "Utilities/TypeTraits/IsA.hpp"
@@ -54,15 +55,7 @@ void update_one_variables(const gsl::not_null<db::DataBox<DbTags>*> box) {
              const gsl::not_null<typename history_tag::type*> history,
              const ::TimeDelta& time_step, const auto& time_stepper) {
             using std::swap;
-            // We need to make sure *previous_error has the correct
-            // size.  We don't care about the value, but it could be
-            // several types so we can't just call ->initialize() or
-            // something.
-            //
-            // We are not required to preserve the old value, because
-            // the errors will only be used after a successful error
-            // update.
-            *previous_error = *vars;
+            set_number_of_grid_points(previous_error, *vars);
             swap(*error, *previous_error);
             *stepper_error_updated = time_stepper.update_u(
                 vars, make_not_null(&*error), history, time_step);

--- a/src/Utilities/CMakeLists.txt
+++ b/src/Utilities/CMakeLists.txt
@@ -62,6 +62,7 @@ spectre_target_headers(
   Rational.hpp
   Registration.hpp
   Requires.hpp
+  SetNumberOfGridPoints.hpp
   Spherepack.hpp
   StaticCache.hpp
   StdArrayHelpers.hpp

--- a/src/Utilities/MakeWithValue.hpp
+++ b/src/Utilities/MakeWithValue.hpp
@@ -9,6 +9,7 @@
 #include <array>
 #include <complex>
 #include <type_traits>
+#include <vector>
 
 #include "Utilities/Algorithm.hpp"
 #include "Utilities/ErrorHandling/Assert.hpp"
@@ -140,6 +141,24 @@ struct NumberOfPoints<std::array<T, Size>> {
         alg::all_of(input,
                     [&](const T& t) { return number_of_points(t) == points; }),
         "Inconsistent number of points in array entries.");
+    return points;
+  }
+};
+
+template <typename T>
+struct NumberOfPoints<std::vector<T>> {
+  static SPECTRE_ALWAYS_INLINE size_t apply(const std::vector<T>& input) {
+    // size_t is interpreted as the number of points in other
+    // contexts, but that doesn't make sense here.
+    static_assert(not std::is_same_v<T, size_t>,
+                  "Cannot get number_of_points from non-vector.");
+    ASSERT(not input.empty(),
+           "Cannot get number of points from empty std::vector.");
+    const size_t points = number_of_points(input[0]);
+    ASSERT(
+        alg::all_of(input,
+                    [&](const T& t) { return number_of_points(t) == points; }),
+        "Inconsistent number of points in vector entries.");
     return points;
   }
 };

--- a/src/Utilities/MakeWithValue.hpp
+++ b/src/Utilities/MakeWithValue.hpp
@@ -83,7 +83,7 @@ struct MakeWithValueImpl {
 /// \tparam ValueType The type of `value`. For most containers, this will be
 /// `double`.
 ///
-/// \see MakeWithValueImpls
+/// \see MakeWithValueImpls, set_number_of_grid_points
 template <typename R, typename T, typename ValueType>
 SPECTRE_ALWAYS_INLINE std::remove_const_t<R> make_with_value(
     const T& input, const ValueType& value) {

--- a/src/Utilities/MakeWithValue.hpp
+++ b/src/Utilities/MakeWithValue.hpp
@@ -8,6 +8,7 @@
 
 #include <array>
 #include <complex>
+#include <functional>
 #include <type_traits>
 #include <vector>
 
@@ -160,6 +161,14 @@ struct NumberOfPoints<std::vector<T>> {
                     [&](const T& t) { return number_of_points(t) == points; }),
         "Inconsistent number of points in vector entries.");
     return points;
+  }
+};
+
+template <typename T>
+struct NumberOfPoints<std::reference_wrapper<T>> {
+  static SPECTRE_ALWAYS_INLINE size_t apply(
+      const std::reference_wrapper<T>& input) {
+    return number_of_points(input.get());
   }
 };
 

--- a/src/Utilities/SetNumberOfGridPoints.hpp
+++ b/src/Utilities/SetNumberOfGridPoints.hpp
@@ -7,6 +7,7 @@
 #include <complex>
 #include <cstddef>
 #include <type_traits>
+#include <vector>
 
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeWithValue.hpp"
@@ -75,6 +76,17 @@ struct SetNumberOfGridPointsImpls::SetNumberOfGridPointsImpl<std::array<T, N>> {
   static constexpr bool is_trivial =
       N == 0 or SetNumberOfGridPointsImpl<T>::is_trivial;
   static void apply(const gsl::not_null<std::array<T, N>*> result,
+                    const size_t size) {
+    for (auto& entry : *result) {
+      set_number_of_grid_points(make_not_null(&entry), size);
+    }
+  }
+};
+
+template <typename T>
+struct SetNumberOfGridPointsImpls::SetNumberOfGridPointsImpl<std::vector<T>> {
+  static constexpr bool is_trivial = SetNumberOfGridPointsImpl<T>::is_trivial;
+  static void apply(const gsl::not_null<std::vector<T>*> result,
                     const size_t size) {
     for (auto& entry : *result) {
       set_number_of_grid_points(make_not_null(&entry), size);

--- a/src/Utilities/SetNumberOfGridPoints.hpp
+++ b/src/Utilities/SetNumberOfGridPoints.hpp
@@ -1,0 +1,96 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <complex>
+#include <cstddef>
+#include <type_traits>
+
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeWithValue.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+/// Implementations of \link set_number_of_grid_points \endlink
+///
+/// Specializations may be trivial, meaning the object is similar to a
+/// `double` and doesn't actually represent grid data.  The only
+/// requirement for trivial specializations is defining `is_trivial`
+/// as `true`.
+///
+/// Non-trivial specializations must define `is_trivial` to `false`,
+/// and must define a static `apply` function with the signature shown
+/// in the below example.  Non-trivial specializations must also be
+/// accompanied by a specialization of the
+/// MakeWithValueImpls::NumberOfPoints struct.  The `apply` function
+/// will only be called if the current size is incorrect, so
+/// implementations should not check the current size.
+///
+/// \snippet Test_SetNumberOfGridPoints.cpp SetNumberOfGridPointsImpl
+namespace SetNumberOfGridPointsImpls {
+/// Default implementation is not defined.
+template <typename T, typename = std::nullptr_t>
+struct SetNumberOfGridPointsImpl;
+}  // namespace SetNumberOfGridPointsImpls
+
+/// \ingroup DataStructuresGroup
+/// Change the number of grid points in an object.
+///
+/// Change the number of points stored in \p result to a given value
+/// or to match another object.  If \p pattern is a `size_t` it will
+/// be used as the number of points, otherwise it will be interpreted
+/// as data on a collection of grid points.
+///
+/// \see SetNumberOfGridPointsImpls, make_with_value
+template <typename T, typename U>
+void set_number_of_grid_points(const gsl::not_null<T*> result,
+                               const U& pattern) {
+  (void)result;
+  (void)pattern;
+  if constexpr (not SetNumberOfGridPointsImpls::SetNumberOfGridPointsImpl<
+                    T>::is_trivial) {
+    const size_t size = MakeWithValueImpls::number_of_points(pattern);
+    if (UNLIKELY(MakeWithValueImpls::number_of_points(*result) != size)) {
+      SetNumberOfGridPointsImpls::SetNumberOfGridPointsImpl<T>::apply(result,
+                                                                      size);
+    }
+  }
+}
+
+template <>
+struct SetNumberOfGridPointsImpls::SetNumberOfGridPointsImpl<double> {
+  static constexpr bool is_trivial = true;
+};
+
+template <>
+struct SetNumberOfGridPointsImpls::SetNumberOfGridPointsImpl<
+    std::complex<double>> {
+  static constexpr bool is_trivial = true;
+};
+
+template <typename T, size_t N>
+struct SetNumberOfGridPointsImpls::SetNumberOfGridPointsImpl<std::array<T, N>> {
+  static constexpr bool is_trivial =
+      N == 0 or SetNumberOfGridPointsImpl<T>::is_trivial;
+  static void apply(const gsl::not_null<std::array<T, N>*> result,
+                    const size_t size) {
+    for (auto& entry : *result) {
+      set_number_of_grid_points(make_not_null(&entry), size);
+    }
+  }
+};
+
+template <typename... Tags>
+struct SetNumberOfGridPointsImpls::SetNumberOfGridPointsImpl<
+    tuples::TaggedTuple<Tags...>> {
+  static constexpr bool is_trivial =
+      (... and SetNumberOfGridPointsImpl<typename Tags::type>::is_trivial);
+  static void apply(const gsl::not_null<tuples::TaggedTuple<Tags...>*> result,
+                    const size_t size) {
+    expand_pack((set_number_of_grid_points(
+                     make_not_null(&tuples::get<Tags>(*result)), size),
+                 0)...);
+  }
+};

--- a/tests/Unit/DataStructures/Tensor/Test_Tensor.cpp
+++ b/tests/Unit/DataStructures/Tensor/Test_Tensor.cpp
@@ -23,6 +23,7 @@
 #include "Utilities/GetOutput.hpp"
 #include "Utilities/Literals.hpp"
 #include "Utilities/MakeArray.hpp"
+#include "Utilities/SetNumberOfGridPoints.hpp"
 #include "Utilities/StdHelpers.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TypeTraits.hpp"
@@ -1409,6 +1410,9 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.MakeWithValue",
     const double expected_value = 7.0;
     CHECK(get<0>(tensor_double) == expected_value);
     CHECK(get<1>(tensor_double) == expected_value);
+    tnsr::I<double, 2> resized{};
+    set_number_of_grid_points(make_not_null(&resized), used_for_size);
+    // Nothing to check.  Just verify compilation.
   };
   check_double(1.2);
   check_double(std::complex<double>{1.2, 1.3});
@@ -1430,6 +1434,9 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.MakeWithValue",
     for (size_t i = 0; i < 3; ++i) {
       CHECK(complex_tensor_made_with_complex_values.get(i) == expected_value);
     }
+    tnsr::i<std::complex<double>, 3> resized{};
+    set_number_of_grid_points(make_not_null(&resized), used_for_size);
+    // Nothing to check.  Just verify compilation.
   };
   check_real_complex_double(1.2);
   check_real_complex_double(std::complex<double>{1.2, 1.3});
@@ -1478,6 +1485,11 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.MakeWithValue",
         CHECK(tensor.get(i)[j] == expected_value);
       }
     }
+    tnsr::i<DataVector, 2> resized{};
+    set_number_of_grid_points(make_not_null(&resized), used_for_size);
+    for (size_t i = 0; i < 2; ++i) {
+      CHECK(resized.get(i).size() == 5);
+    }
   };
   check_data_vector(5_st);
   check_data_vector(DataVector{5});
@@ -1498,6 +1510,11 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.MakeWithValue",
       for (size_t j = 0; j < 5; ++j) {
         CHECK(complex_tensor.get(i)[j] == expected_value);
       }
+    }
+    tnsr::i<ComplexDataVector, 3> resized{};
+    set_number_of_grid_points(make_not_null(&resized), used_for_size);
+    for (size_t i = 0; i < 3; ++i) {
+      CHECK(resized.get(i).size() == 5);
     }
   };
   check_complex_data_vector(5_st);
@@ -1520,6 +1537,11 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.MakeWithValue",
         CHECK(tensor.get(i)[j] == expected_value);
       }
     }
+    tnsr::i<ModalVector, 2> resized{};
+    set_number_of_grid_points(make_not_null(&resized), structure);
+    for (size_t i = 0; i < 2; ++i) {
+      CHECK(resized.get(i).size() == 5);
+    }
   };
   check_modal_vector(5_st);
   check_modal_vector(DataVector{5});
@@ -1540,6 +1562,11 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.MakeWithValue",
       for (size_t j = 0; j < 5; ++j) {
         CHECK(complex_tensor.get(i)[j] == expected_value);
       }
+    }
+    tnsr::i<ComplexModalVector, 3> resized{};
+    set_number_of_grid_points(make_not_null(&resized), structure);
+    for (size_t i = 0; i < 3; ++i) {
+      CHECK(resized.get(i).size() == 5);
     }
   };
   check_complex_modal_vector(5_st);
@@ -1562,6 +1589,9 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.MakeWithValue",
         for (size_t j = 0; j < 5; ++j) {
           CHECK(get(spin_weighted_complex).data()[j] == expected_value);
         }
+        Scalar<SpinWeighted<ComplexDataVector, 2>> resized{};
+        set_number_of_grid_points(make_not_null(&resized), used_for_size);
+        CHECK(get(resized).data().size() == 5);
       };
   check_spin_weighted_complex_data_vector(5_st);
   check_spin_weighted_complex_data_vector(DataVector{5});
@@ -1587,6 +1617,9 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.MakeWithValue",
         for (size_t j = 0; j < 5; ++j) {
           CHECK(get(spin_weighted_complex).data()[j] == expected_value);
         }
+        Scalar<SpinWeighted<ComplexModalVector, 2>> resized{};
+        set_number_of_grid_points(make_not_null(&resized), structure);
+        CHECK(get(resized).data().size() == 5);
       };
   check_spin_weighted_complex_modal_vector(5_st);
   check_spin_weighted_complex_modal_vector(DataVector{5});

--- a/tests/Unit/DataStructures/Test_BlazeInteroperability.cpp
+++ b/tests/Unit/DataStructures/Test_BlazeInteroperability.cpp
@@ -13,7 +13,9 @@
 #include "DataStructures/StaticVector.hpp"
 #include "Framework/TestCreation.hpp"
 #include "Framework/TestHelpers.hpp"
+#include "Utilities/Literals.hpp"
 #include "Utilities/MakeWithValue.hpp"
+#include "Utilities/SetNumberOfGridPoints.hpp"
 
 SPECTRE_TEST_CASE("Unit.DataStructures.BlazeInteroperability",
                   "[DataStructures][Unit]") {
@@ -26,6 +28,14 @@ SPECTRE_TEST_CASE("Unit.DataStructures.BlazeInteroperability",
     CHECK(TestHelpers::test_creation<blaze::StaticVector<double, 4>>(
               "[0., 1., 0., 2.]") ==
           blaze::StaticVector<double, 4>{0., 1., 0., 2.});
+
+    blaze::StaticVector<double, 4> v{0., 1., 0., 2.};
+    set_number_of_grid_points(make_not_null(&v), 4_st);
+    CHECK(v == blaze::StaticVector<double, 4>{0., 1., 0., 2.});
+#ifdef SPECTRE_DEBUG
+    CHECK_THROWS_WITH(set_number_of_grid_points(make_not_null(&v), 3_st),
+                      Catch::Contains("Tried to resize a StaticVector to 3"));
+#endif  // SPECTRE_DEBUG
   }
   {
     INFO("DynamicVector");
@@ -36,6 +46,12 @@ SPECTRE_TEST_CASE("Unit.DataStructures.BlazeInteroperability",
     CHECK(TestHelpers::test_creation<blaze::DynamicVector<double>>(
               "[0., 1., 0., 2.]") ==
           blaze::DynamicVector<double>{0., 1., 0., 2.});
+
+    blaze::DynamicVector<double> v{0., 1., 0., 2.};
+    set_number_of_grid_points(make_not_null(&v), 4_st);
+    CHECK(v == blaze::DynamicVector<double>{0., 1., 0., 2.});
+    set_number_of_grid_points(make_not_null(&v), 3_st);
+    CHECK(v.size() == 3);
   }
   {
     INFO("CompressedVector");

--- a/tests/Unit/DataStructures/Test_SpinWeighted.cpp
+++ b/tests/Unit/DataStructures/Test_SpinWeighted.cpp
@@ -15,6 +15,7 @@
 #include "Utilities/Gsl.hpp"
 #include "Utilities/Literals.hpp"
 #include "Utilities/MakeWithValue.hpp"
+#include "Utilities/SetNumberOfGridPoints.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TypeTraits.hpp"
 #include "Utilities/TypeTraits/GetFundamentalType.hpp"
@@ -229,6 +230,21 @@ SPECTRE_TEST_CASE("Unit.DataStructures.SpinWeighted",
   CHECK(make_with_value<SpinWeighted<DataVector, 2>>(
             SpinWeighted<DataVector, 2>(DataVector{1.2, 2.1}), 1.1) ==
         SpinWeighted<DataVector, 2>(DataVector{1.1, 1.1}));
+
+  {
+    SpinWeighted<double, 2> spin_double(1.1);
+    set_number_of_grid_points(make_not_null(&spin_double), 2_st);
+    CHECK(spin_double == SpinWeighted<double, 2>(1.1));
+    set_number_of_grid_points(make_not_null(&spin_double), 1.2);
+    CHECK(spin_double == SpinWeighted<double, 2>(1.1));
+  }
+  {
+    SpinWeighted<DataVector, 2> spin_vector(DataVector{1.1, 1.2});
+    set_number_of_grid_points(make_not_null(&spin_vector), 2_st);
+    CHECK(spin_vector == SpinWeighted<DataVector, 2>(DataVector{1.1, 1.2}));
+    set_number_of_grid_points(make_not_null(&spin_vector), 3_st);
+    CHECK(spin_vector.size() == 3);
+  }
 }
 
 // A macro which will static_assert fail when LHSTYPE OP RHSTYPE succeeds during

--- a/tests/Unit/DataStructures/Test_SpinWeighted.cpp
+++ b/tests/Unit/DataStructures/Test_SpinWeighted.cpp
@@ -13,6 +13,8 @@
 #include "Framework/TestHelpers.hpp"
 #include "Helpers/DataStructures/MakeWithRandomValues.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/Literals.hpp"
+#include "Utilities/MakeWithValue.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TypeTraits.hpp"
 #include "Utilities/TypeTraits/GetFundamentalType.hpp"
@@ -219,6 +221,14 @@ SPECTRE_TEST_CASE("Unit.DataStructures.SpinWeighted",
   destructive_resize_check.destructive_resize(6);
   CHECK(destructive_resize_check != destructive_resize_copy);
   CHECK(destructive_resize_check.size() == destructive_resize_copy.size() + 1);
+
+  CHECK(make_with_value<SpinWeighted<double, 2>>(2_st, 1.1) ==
+        SpinWeighted<double, 2>(1.1));
+  CHECK(make_with_value<SpinWeighted<DataVector, 2>>(2_st, 1.1) ==
+        SpinWeighted<DataVector, 2>(DataVector{1.1, 1.1}));
+  CHECK(make_with_value<SpinWeighted<DataVector, 2>>(
+            SpinWeighted<DataVector, 2>(DataVector{1.2, 2.1}), 1.1) ==
+        SpinWeighted<DataVector, 2>(DataVector{1.1, 1.1}));
 }
 
 // A macro which will static_assert fail when LHSTYPE OP RHSTYPE succeeds during

--- a/tests/Unit/DataStructures/Test_Variables.cpp
+++ b/tests/Unit/DataStructures/Test_Variables.cpp
@@ -34,6 +34,7 @@
 #include "Utilities/MakeString.hpp"
 #include "Utilities/MakeWithValue.hpp"
 #include "Utilities/PrettyType.hpp"
+#include "Utilities/SetNumberOfGridPoints.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
 #include "Utilities/TypeTraits/GetFundamentalType.hpp"
@@ -1331,6 +1332,23 @@ void test_make_with_value() {
         DataVector(num_points, -2.3));
 }
 
+template <typename VectorType>
+void test_set_number_of_grid_points() {
+  INFO(pretty_type::short_name<VectorType>());
+  using Vars = Variables<tmpl::list<TestHelpers::Tags::Vector<VectorType>,
+                                    TestHelpers::Tags::Scalar<VectorType>>>;
+  MAKE_GENERATOR(gen);
+  UniformCustomDistribution<size_t> sdist{1, 5};
+  const size_t num_points = sdist(gen);
+
+  Vars resized{};
+  set_number_of_grid_points(make_not_null(&resized), num_points);
+  CHECK(resized.number_of_grid_points() == num_points);
+  DataVector resized_vector{};
+  set_number_of_grid_points(make_not_null(&resized_vector), Vars(num_points));
+  CHECK(resized_vector.size() == num_points);
+}
+
 void test_asserts() {
 #ifdef SPECTRE_DEBUG
   CHECK_THROWS_WITH(
@@ -1494,6 +1512,14 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Variables", "[DataStructures][Unit]") {
     test_make_with_value<ComplexModalVector>();
     test_make_with_value<DataVector>();
     test_make_with_value<ModalVector>();
+  }
+
+  {
+    INFO("Test set_number_of_grid_points");
+    test_set_number_of_grid_points<ComplexDataVector>();
+    test_set_number_of_grid_points<ComplexModalVector>();
+    test_set_number_of_grid_points<DataVector>();
+    test_set_number_of_grid_points<ModalVector>();
   }
 
   TestHelpers::db::test_simple_tag<Tags::TempScalar<1>>("TempTensor1");

--- a/tests/Unit/DataStructures/Test_Variables.cpp
+++ b/tests/Unit/DataStructures/Test_Variables.cpp
@@ -32,6 +32,7 @@
 #include "Utilities/Gsl.hpp"
 #include "Utilities/Literals.hpp"  // IWYU pragma: keep
 #include "Utilities/MakeString.hpp"
+#include "Utilities/MakeWithValue.hpp"
 #include "Utilities/PrettyType.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
@@ -1316,6 +1317,20 @@ void test_contains_allocations() {
   }
 }
 
+template <typename VectorType>
+void test_make_with_value() {
+  INFO(pretty_type::short_name<VectorType>());
+  using Vars = Variables<tmpl::list<TestHelpers::Tags::Vector<VectorType>,
+                                    TestHelpers::Tags::Scalar<VectorType>>>;
+  MAKE_GENERATOR(gen);
+  UniformCustomDistribution<size_t> sdist{1, 5};
+  const size_t num_points = sdist(gen);
+  CHECK(make_with_value<Vars>(DataVector(num_points, 4.5), -2.3) ==
+        Vars(num_points, -2.3));
+  CHECK(make_with_value<DataVector>(Vars(num_points, 4.5), -2.3) ==
+        DataVector(num_points, -2.3));
+}
+
 void test_asserts() {
 #ifdef SPECTRE_DEBUG
   CHECK_THROWS_WITH(
@@ -1471,6 +1486,14 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Variables", "[DataStructures][Unit]") {
     test_contains_allocations<ComplexModalVector>();
     test_contains_allocations<DataVector>();
     test_contains_allocations<ModalVector>();
+  }
+
+  {
+    INFO("Test make_with_value");
+    test_make_with_value<ComplexDataVector>();
+    test_make_with_value<ComplexModalVector>();
+    test_make_with_value<DataVector>();
+    test_make_with_value<ModalVector>();
   }
 
   TestHelpers::db::test_simple_tag<Tags::TempScalar<1>>("TempTensor1");

--- a/tests/Unit/Helpers/DataStructures/VectorImplTestHelper.hpp
+++ b/tests/Unit/Helpers/DataStructures/VectorImplTestHelper.hpp
@@ -469,6 +469,12 @@ void vector_test_construct_and_assign(
       const VectorType reference(dest.data(), dest.size());
       CHECK(not contains_allocations(reference));
     }
+
+    CHECK(make_with_value<VectorType>(size, generated_value1) ==
+          VectorType(size, generated_value1));
+    CHECK(make_with_value<VectorType>(VectorType(size, ValueType{}),
+                                      generated_value1) ==
+          VectorType(size, generated_value1));
   }
 }
 

--- a/tests/Unit/Helpers/DataStructures/VectorImplTestHelper.hpp
+++ b/tests/Unit/Helpers/DataStructures/VectorImplTestHelper.hpp
@@ -25,6 +25,7 @@
 #include "Utilities/Gsl.hpp"
 #include "Utilities/Math.hpp"  // IWYU pragma: keep
 #include "Utilities/Requires.hpp"
+#include "Utilities/SetNumberOfGridPoints.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/Tuple.hpp"
 #include "Utilities/TypeTraits.hpp"
@@ -475,6 +476,16 @@ void vector_test_construct_and_assign(
     CHECK(make_with_value<VectorType>(VectorType(size, ValueType{}),
                                       generated_value1) ==
           VectorType(size, generated_value1));
+
+    {
+      VectorType resize_from_size_t{};
+      set_number_of_grid_points(make_not_null(&resize_from_size_t), size);
+      CHECK(resize_from_size_t.size() == size);
+      VectorType resize_from_vector{};
+      set_number_of_grid_points(make_not_null(&resize_from_vector),
+                                VectorType(size, ValueType{}));
+      CHECK(resize_from_vector.size() == size);
+    }
   }
 }
 

--- a/tests/Unit/Helpers/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/TestHelpers.hpp
+++ b/tests/Unit/Helpers/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/TestHelpers.hpp
@@ -88,8 +88,8 @@ void check_impl(
               }
               // Default-construct the scalar, to test that the damping
               // function's call operator correctly resizes it
-              // (in the case T is a DataVector) with
-              // destructive_resize_components()
+              // (in the case T is a DataVector)
+              // with set_number_of_grid_points()
               Scalar<T> value_at_coordinates{};
               gh_damping_function->operator()(
                   make_not_null(&value_at_coordinates), coordinates, time,

--- a/tests/Unit/Utilities/CMakeLists.txt
+++ b/tests/Unit/Utilities/CMakeLists.txt
@@ -37,6 +37,7 @@ set(LIBRARY_SOURCES
   Test_Rational.cpp
   Test_Registration.cpp
   Test_Requires.cpp
+  Test_SetNumberOfGridPoints.cpp
   Test_StaticCache.cpp
   Test_StdArrayHelpers.cpp
   Test_StdHelpers.cpp

--- a/tests/Unit/Utilities/Test_ContainerHelpers.cpp
+++ b/tests/Unit/Utilities/Test_ContainerHelpers.cpp
@@ -121,21 +121,4 @@ SPECTRE_TEST_CASE("Unit.Utilities.ContainerHelpers", "[Unit][Utilities]") {
   }
   CHECK(min(constant_spectre_vector) == min(2.0));
   CHECK(max(constant_spectre_vector) == max(2.0));
-
-  // Check the destructive resize function applied to tensors
-  tnsr::i<DataVector, 3> rank_one{static_cast<size_t>(4)};
-  Scalar<ComplexDataVector> complex_scalar{static_cast<size_t>(10)};
-  Scalar<DataVector> right_sized{static_cast<size_t>(5), 2.0};
-
-  destructive_resize_components(make_not_null(&rank_one), 5);
-  destructive_resize_components(make_not_null(&complex_scalar), 5);
-  destructive_resize_components(make_not_null(&right_sized), 5);
-  for (const auto& vector : rank_one) {
-    CHECK(vector.size() == 5);
-  }
-  CHECK(get(complex_scalar).size() == 5);
-  CHECK(get(right_sized).size() == 5);
-  for (const auto& element : get(right_sized)) {
-    CHECK(element == 2.0);
-  }
 }

--- a/tests/Unit/Utilities/Test_MakeWithValue.cpp
+++ b/tests/Unit/Utilities/Test_MakeWithValue.cpp
@@ -7,6 +7,7 @@
 #include <complex>
 #include <cstddef>
 
+#include "Utilities/Literals.hpp"
 #include "Utilities/MakeArray.hpp"
 #include "Utilities/MakeWithValue.hpp"
 #include "Utilities/TaggedTuple.hpp"
@@ -69,7 +70,20 @@ void test_make_tagged_tuple() {
         tuples::TaggedTuple<Tags::Makeable, Tags::Makeable2, Tags::Double>(
             Makeable{n_pts, 3.8}, Makeable{n_pts, 3.8}, 3.8),
         Makeable{n_pts, 0.0}, 3.8);
+    check_make_with_value(Makeable{n_pts, 3.8},
+                          tuples::TaggedTuple<Tags::Makeable, Tags::Makeable2>(
+                              Makeable{n_pts, 0.0}, Makeable{n_pts, 1.0}),
+                          3.8);
   }
+
+#ifdef SPECTRE_DEBUG
+  CHECK_THROWS_WITH(
+      make_with_value<Makeable>(
+          tuples::TaggedTuple<Tags::Makeable, Tags::Makeable2>(
+              Makeable{1, 0.0}, Makeable{2, 0.0}),
+          0.0),
+      Catch::Contains("Inconsistent number of points in tuple entries"));
+#endif  // SPECTRE_DEBUG
 }
 
 }  // namespace
@@ -88,6 +102,16 @@ SPECTRE_TEST_CASE("Unit.DataStructures.MakeWithValue",
 
   check_make_with_value(make_array<4>(8.3), 1.3, 8.3);
   check_make_with_value(make_array<3>(Makeable{5, 8.3}), Makeable{5, 4.5}, 8.3);
+  check_make_with_value(1.3, make_array<4>(8.3), 1.3);
+  check_make_with_value(make_array<3>(Makeable{5, 8.3}),
+                        make_array<4>(Makeable{5, 4.5}), 8.3);
+
+#ifdef SPECTRE_DEBUG
+  CHECK_THROWS_WITH(
+      make_with_value<Makeable>(make_array(Makeable{1, 0.0}, Makeable{2, 0.0}),
+                                0.0),
+      Catch::Contains("Inconsistent number of points in array entries"));
+#endif  // SPECTRE_DEBUG
 
   test_make_tagged_tuple();
 }

--- a/tests/Unit/Utilities/Test_MakeWithValue.cpp
+++ b/tests/Unit/Utilities/Test_MakeWithValue.cpp
@@ -6,6 +6,7 @@
 #include <array>
 #include <complex>
 #include <cstddef>
+#include <vector>
 
 #include "Utilities/Literals.hpp"
 #include "Utilities/MakeArray.hpp"
@@ -111,6 +112,22 @@ SPECTRE_TEST_CASE("Unit.DataStructures.MakeWithValue",
       make_with_value<Makeable>(make_array(Makeable{1, 0.0}, Makeable{2, 0.0}),
                                 0.0),
       Catch::Contains("Inconsistent number of points in array entries"));
+#endif  // SPECTRE_DEBUG
+
+  // std::vector is only usable as input because the number of entries
+  // in a result vector cannot be inferred.
+  check_make_with_value(1.3, std::vector{8.3, 4.5}, 1.3);
+  check_make_with_value(Makeable{5, 8.3},
+                        std::vector{Makeable{5, 4.5}, Makeable{5, 1.2}}, 8.3);
+
+#ifdef SPECTRE_DEBUG
+  CHECK_THROWS_WITH(
+      make_with_value<Makeable>(std::vector{Makeable{1, 0.0}, Makeable{2, 0.0}},
+                                0.0),
+      Catch::Contains("Inconsistent number of points in vector entries"));
+  CHECK_THROWS_WITH(
+      make_with_value<Makeable>(std::vector<Makeable>{}, 0.0),
+      Catch::Contains("Cannot get number of points from empty std::vector"));
 #endif  // SPECTRE_DEBUG
 
   test_make_tagged_tuple();

--- a/tests/Unit/Utilities/Test_MakeWithValue.cpp
+++ b/tests/Unit/Utilities/Test_MakeWithValue.cpp
@@ -6,6 +6,7 @@
 #include <array>
 #include <complex>
 #include <cstddef>
+#include <functional>
 #include <vector>
 
 #include "Utilities/Literals.hpp"
@@ -129,6 +130,15 @@ SPECTRE_TEST_CASE("Unit.DataStructures.MakeWithValue",
       make_with_value<Makeable>(std::vector<Makeable>{}, 0.0),
       Catch::Contains("Cannot get number of points from empty std::vector"));
 #endif  // SPECTRE_DEBUG
+
+  // std::reference_wrapper is only usable as input.
+  {
+    Makeable used_for_size{3, 1.1};
+    check_make_with_value(1.3, std::ref(used_for_size), 1.3);
+    check_make_with_value(Makeable{3, 8.3}, std::ref(used_for_size), 8.3);
+    check_make_with_value(1.3, std::cref(used_for_size), 1.3);
+    check_make_with_value(Makeable{3, 8.3}, std::cref(used_for_size), 8.3);
+  }
 
   test_make_tagged_tuple();
 }

--- a/tests/Unit/Utilities/Test_SetNumberOfGridPoints.cpp
+++ b/tests/Unit/Utilities/Test_SetNumberOfGridPoints.cpp
@@ -1,0 +1,192 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <complex>
+#include <cstddef>
+
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Literals.hpp"
+#include "Utilities/MakeWithValue.hpp"
+#include "Utilities/SetNumberOfGridPoints.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace {
+struct TriviallyResizable {};
+
+struct Resizable {
+  size_t size = 0;
+  bool resized = false;
+};
+
+struct NoSize {};
+
+template <typename T, int Label>
+struct Tag {
+  using type = T;
+};
+}  // namespace
+
+// [SetNumberOfGridPointsImpl]
+template <>
+struct SetNumberOfGridPointsImpls::SetNumberOfGridPointsImpl<
+    TriviallyResizable> {
+  static constexpr bool is_trivial = true;
+};
+
+template <>
+struct SetNumberOfGridPointsImpls::SetNumberOfGridPointsImpl<Resizable> {
+  static constexpr bool is_trivial = false;
+  static void apply(const gsl::not_null<Resizable*> result, const size_t size) {
+    result->size = size;
+    result->resized = true;
+  }
+};
+// [SetNumberOfGridPointsImpl]
+
+namespace MakeWithValueImpls {
+template <>
+struct NumberOfPoints<Resizable> {
+  static size_t apply(const Resizable& input) { return input.size; }
+};
+}  // namespace MakeWithValueImpls
+
+SPECTRE_TEST_CASE("Unit.Utilities.SetNumberOfGridPoints", "[Utilities][Unit]") {
+  Resizable pattern3;
+  pattern3.size = 3;
+
+  {
+    TriviallyResizable x;
+    set_number_of_grid_points(make_not_null(&x), 3_st);
+    set_number_of_grid_points(make_not_null(&x), pattern3);
+    set_number_of_grid_points(make_not_null(&x), TriviallyResizable{});
+  }
+
+  {
+    Resizable r;
+    set_number_of_grid_points(make_not_null(&r), 3_st);
+    CHECK(r.size == 3);
+    CHECK(r.resized);
+  }
+  {
+    Resizable r;
+    r.size = 3;
+    set_number_of_grid_points(make_not_null(&r), 3_st);
+    CHECK(r.size == 3);
+    CHECK(not r.resized);
+  }
+  {
+    Resizable r;
+    set_number_of_grid_points(make_not_null(&r), pattern3);
+    CHECK(r.size == 3);
+    CHECK(r.resized);
+  }
+  {
+    Resizable r;
+    r.size = 3;
+    set_number_of_grid_points(make_not_null(&r), pattern3);
+    CHECK(r.size == 3);
+    CHECK(not r.resized);
+  }
+
+  {
+    double x = 2.0;
+    set_number_of_grid_points(make_not_null(&x), 3_st);
+    CHECK(x == 2.0);
+  }
+  {
+    double x = 2.0;
+    set_number_of_grid_points(make_not_null(&x), NoSize{});
+    CHECK(x == 2.0);
+  }
+
+  {
+    std::complex<double> x(2.0, 4.0);
+    set_number_of_grid_points(make_not_null(&x), 3_st);
+    CHECK(x == std::complex<double>(2.0, 4.0));
+  }
+  {
+    std::complex<double> x(2.0, 4.0);
+    set_number_of_grid_points(make_not_null(&x), NoSize{});
+    CHECK(x == std::complex<double>(2.0, 4.0));
+  }
+
+  {
+    std::array<Resizable, 3> x;
+    x[0].size = 2;
+    x[1].size = 2;
+    x[2].size = 2;
+    set_number_of_grid_points(make_not_null(&x), pattern3);
+    CHECK(x[0].size == 3);
+    CHECK(x[1].size == 3);
+    CHECK(x[2].size == 3);
+    CHECK(x[0].resized);
+    CHECK(x[1].resized);
+    CHECK(x[2].resized);
+  }
+  {
+    std::array<Resizable, 3> x;
+    x[0].size = 3;
+    x[1].size = 3;
+    x[2].size = 3;
+    set_number_of_grid_points(make_not_null(&x), pattern3);
+    CHECK(x[0].size == 3);
+    CHECK(x[1].size == 3);
+    CHECK(x[2].size == 3);
+    CHECK(not x[0].resized);
+    CHECK(not x[1].resized);
+    CHECK(not x[2].resized);
+  }
+  {
+    std::array<double, 3> x{1.0, 2.0, 3.0};
+    set_number_of_grid_points(make_not_null(&x), NoSize{});
+    CHECK(x == std::array{1.0, 2.0, 3.0});
+  }
+  {
+    std::array<double, 3> x{1.0, 2.0, 3.0};
+    set_number_of_grid_points(make_not_null(&x), 1_st);
+    CHECK(x == std::array{1.0, 2.0, 3.0});
+  }
+  {
+    std::array<Resizable, 0> x{};
+    set_number_of_grid_points(make_not_null(&x), 1_st);
+  }
+
+  {
+    tuples::TaggedTuple<Tag<Resizable, 0>, Tag<Resizable, 1>> x;
+    set_number_of_grid_points(make_not_null(&x), pattern3);
+    CHECK(tuples::get<Tag<Resizable, 0>>(x).size == 3);
+    CHECK(tuples::get<Tag<Resizable, 1>>(x).size == 3);
+    CHECK(tuples::get<Tag<Resizable, 0>>(x).resized);
+    CHECK(tuples::get<Tag<Resizable, 1>>(x).resized);
+  }
+  {
+    tuples::TaggedTuple<Tag<Resizable, 0>, Tag<Resizable, 1>> x;
+    tuples::get<Tag<Resizable, 0>>(x).size = 3;
+    tuples::get<Tag<Resizable, 1>>(x).size = 3;
+    set_number_of_grid_points(make_not_null(&x), pattern3);
+    CHECK(tuples::get<Tag<Resizable, 0>>(x).size == 3);
+    CHECK(tuples::get<Tag<Resizable, 1>>(x).size == 3);
+    CHECK(not tuples::get<Tag<Resizable, 0>>(x).resized);
+    CHECK(not tuples::get<Tag<Resizable, 1>>(x).resized);
+  }
+  {
+    tuples::TaggedTuple<Tag<Resizable, 0>, Tag<Resizable, 1>> x;
+    set_number_of_grid_points(make_not_null(&x), 3_st);
+    CHECK(tuples::get<Tag<Resizable, 0>>(x).size == 3);
+    CHECK(tuples::get<Tag<Resizable, 1>>(x).size == 3);
+    CHECK(tuples::get<Tag<Resizable, 0>>(x).resized);
+    CHECK(tuples::get<Tag<Resizable, 1>>(x).resized);
+  }
+  {
+    // We've checked resizing double and complex<double> above.  This
+    // just checks that the correct overloads are called so these
+    // compile.
+    tuples::TaggedTuple<Tag<double, 0>, Tag<std::complex<double>, 0>> x;
+    set_number_of_grid_points(make_not_null(&x), 3_st);
+    set_number_of_grid_points(make_not_null(&x), pattern3);
+    set_number_of_grid_points(make_not_null(&x), NoSize{});
+  }
+}

--- a/tests/Unit/Utilities/Test_SetNumberOfGridPoints.cpp
+++ b/tests/Unit/Utilities/Test_SetNumberOfGridPoints.cpp
@@ -6,6 +6,7 @@
 #include <array>
 #include <complex>
 #include <cstddef>
+#include <vector>
 
 #include "Utilities/Gsl.hpp"
 #include "Utilities/Literals.hpp"
@@ -152,6 +153,37 @@ SPECTRE_TEST_CASE("Unit.Utilities.SetNumberOfGridPoints", "[Utilities][Unit]") {
   {
     std::array<Resizable, 0> x{};
     set_number_of_grid_points(make_not_null(&x), 1_st);
+  }
+
+  {
+    std::vector<Resizable> x{{2, false}, {2, false}, {2, false}};
+    set_number_of_grid_points(make_not_null(&x), pattern3);
+    CHECK(x[0].size == 3);
+    CHECK(x[1].size == 3);
+    CHECK(x[2].size == 3);
+    CHECK(x[0].resized);
+    CHECK(x[1].resized);
+    CHECK(x[2].resized);
+  }
+  {
+    std::vector<Resizable> x{{3, false}, {3, false}, {3, false}};
+    set_number_of_grid_points(make_not_null(&x), pattern3);
+    CHECK(x[0].size == 3);
+    CHECK(x[1].size == 3);
+    CHECK(x[2].size == 3);
+    CHECK(not x[0].resized);
+    CHECK(not x[1].resized);
+    CHECK(not x[2].resized);
+  }
+  {
+    std::vector<double> x{1.0, 2.0, 3.0};
+    set_number_of_grid_points(make_not_null(&x), NoSize{});
+    CHECK(x == std::vector{1.0, 2.0, 3.0});
+  }
+  {
+    std::vector<double> x{1.0, 2.0, 3.0};
+    set_number_of_grid_points(make_not_null(&x), 1_st);
+    CHECK(x == std::vector{1.0, 2.0, 3.0});
   }
 
   {


### PR DESCRIPTION
## Proposed changes

This allows resizing existing objects in a similar way to the sizing in `make_with_value`.  It fixes one case where I was copying data just to get the correct structure, and will likely be convenient in other cases.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
Replace `destructive_resize_components` with the new `set_number_of_grid_points`.
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
