### PR TITLE
Add size StateHistory

### DIFF
--- a/src/ControlSystem/ControlErrors/Size.cpp
+++ b/src/ControlSystem/ControlErrors/Size.cpp
@@ -17,8 +17,8 @@
 #include "Utilities/GetOutput.hpp"
 
 namespace control_system::ControlErrors {
-template <::domain::ObjectLabel Horizon>
-Size<Horizon>::Size(const int max_times) {
+template <size_t DerivOrder, ::domain::ObjectLabel Horizon>
+Size<DerivOrder, Horizon>::Size(const int max_times) {
   const auto max_times_size_t = static_cast<size_t>(max_times);
   info_.state = std::make_unique<size::States::Initial>();
   char_speed_predictor_ = intrp::ZeroCrossingPredictor{3, max_times_size_t};
@@ -47,23 +47,24 @@ Size<Horizon>::Size(const int max_times) {
   subfile_name_ = "/ControlSystems/Size" + get_output(Horizon) + "/Diagnostics";
 }
 
-template <::domain::ObjectLabel Horizon>
-const std::optional<double>& Size<Horizon>::get_suggested_timescale() const {
+template <size_t DerivOrder, ::domain::ObjectLabel Horizon>
+const std::optional<double>&
+Size<DerivOrder, Horizon>::get_suggested_timescale() const {
   return info_.suggested_time_scale;
 }
 
-template <::domain::ObjectLabel Horizon>
-bool Size<Horizon>::discontinuous_change_has_occurred() const {
+template <size_t DerivOrder, ::domain::ObjectLabel Horizon>
+bool Size<DerivOrder, Horizon>::discontinuous_change_has_occurred() const {
   return info_.discontinuous_change_has_occurred;
 }
 
-template <::domain::ObjectLabel Horizon>
-void Size<Horizon>::reset() {
+template <size_t DerivOrder, ::domain::ObjectLabel Horizon>
+void Size<DerivOrder, Horizon>::reset() {
   info_.reset();
 }
 
-template <::domain::ObjectLabel Horizon>
-void Size<Horizon>::pup(PUP::er& p) {
+template <size_t DerivOrder, ::domain::ObjectLabel Horizon>
+void Size<DerivOrder, Horizon>::pup(PUP::er& p) {
   p | info_;
   p | char_speed_predictor_;
   p | comoving_char_speed_predictor_;
@@ -72,14 +73,17 @@ void Size<Horizon>::pup(PUP::er& p) {
   p | subfile_name_;
 }
 
-#define HORIZON(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define DERIV_ORDER(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define HORIZON(data) BOOST_PP_TUPLE_ELEM(1, data)
 
-#define INSTANTIATE(_, data) template struct Size<HORIZON(data)>;
+#define INSTANTIATE(_, data) \
+  template struct Size<DERIV_ORDER(data), HORIZON(data)>;
 
-GENERATE_INSTANTIATIONS(INSTANTIATE,
+GENERATE_INSTANTIATIONS(INSTANTIATE, (2, 3),
                         (::domain::ObjectLabel::A, ::domain::ObjectLabel::B,
                          ::domain::ObjectLabel::None))
 
 #undef INSTANTIATE
 #undef HORIZON
+#undef DERIV_ORDER
 }  // namespace control_system::ControlErrors

--- a/src/ControlSystem/ControlErrors/Size.cpp
+++ b/src/ControlSystem/ControlErrors/Size.cpp
@@ -25,6 +25,7 @@ Size<DerivOrder, Horizon>::Size(const int max_times) {
   comoving_char_speed_predictor_ =
       intrp::ZeroCrossingPredictor{3, max_times_size_t};
   delta_radius_predictor_ = intrp::ZeroCrossingPredictor{3, max_times_size_t};
+  state_history_ = size::StateHistory{DerivOrder + 1};
   legend_ = std::vector<std::string>{"Time",
                                      "ControlError",
                                      "StateNumber",
@@ -64,11 +65,23 @@ void Size<DerivOrder, Horizon>::reset() {
 }
 
 template <size_t DerivOrder, ::domain::ObjectLabel Horizon>
+std::deque<std::pair<double, double>>
+Size<DerivOrder, Horizon>::control_error_history() const {
+  std::deque<std::pair<double, double>> history =
+      state_history_.state_history(info_.state->number());
+  // pop back so we don't include the current time, otherwise the averager
+  // will error
+  history.pop_back();
+  return history;
+}
+
+template <size_t DerivOrder, ::domain::ObjectLabel Horizon>
 void Size<DerivOrder, Horizon>::pup(PUP::er& p) {
   p | info_;
   p | char_speed_predictor_;
   p | comoving_char_speed_predictor_;
   p | delta_radius_predictor_;
+  p | state_history_;
   p | legend_;
   p | subfile_name_;
 }

--- a/src/ControlSystem/ControlErrors/Size.hpp
+++ b/src/ControlSystem/ControlErrors/Size.hpp
@@ -99,7 +99,7 @@ namespace control_system::ControlErrors {
  *   of the State%s
  * - DampingTime
  */
-template <::domain::ObjectLabel Horizon>
+template <size_t DerivOrder, ::domain::ObjectLabel Horizon>
 struct Size : tt::ConformsTo<protocols::ControlError> {
   static constexpr size_t expected_number_of_excisions = 1;
 

--- a/src/ControlSystem/ControlErrors/Size/CMakeLists.txt
+++ b/src/ControlSystem/ControlErrors/Size/CMakeLists.txt
@@ -14,6 +14,7 @@ spectre_target_sources(
   Error.cpp
   Initial.cpp
   RegisterDerivedWithCharm.cpp
+  StateHistory.cpp
   )
 
 spectre_target_headers(
@@ -22,6 +23,7 @@ spectre_target_headers(
   HEADERS
   Info.hpp
   State.hpp
+  StateHistory.hpp
   AhSpeed.hpp
   DeltaR.hpp
   Error.hpp

--- a/src/ControlSystem/ControlErrors/Size/Error.cpp
+++ b/src/ControlSystem/ControlErrors/Size/Error.cpp
@@ -221,22 +221,21 @@ ErrorDiagnostics control_error(
                        comoving_char_speed_crossing_time,
                        delta_radius_crossing_time});
 
-  const double control_error = info->state->control_error(
-      *info, ControlErrorArgs{min_char_speed, control_error_delta_r,
-                              avg_distorted_normal_dot_unit_coord_vector,
-                              dt_lambda_00});
+  const ControlErrorArgs control_error_args{
+      min_char_speed, control_error_delta_r,
+      avg_distorted_normal_dot_unit_coord_vector, dt_lambda_00};
+
+  const double control_error =
+      info->state->control_error(*info, control_error_args);
 
   return ErrorDiagnostics{
       control_error,
       info->state->number(),
       lambda_00,
-      dt_lambda_00,
       horizon_00,
       dt_horizon_00,
       min(get(radial_distance)),
       min(get(radial_distance)) / apparent_horizon.average_radius(),
-      control_error_delta_r,
-      min_char_speed,
       min_comoving_char_speed,
       char_speed_crossing_time,
       comoving_char_speed_crossing_time,
@@ -244,6 +243,7 @@ ErrorDiagnostics control_error(
       info->target_char_speed,
       info->suggested_time_scale.value_or(0.0),
       info->damping_time,
+      control_error_args,
       info->discontinuous_change_has_occurred};
 }
 }  // namespace control_system::size

--- a/src/ControlSystem/ControlErrors/Size/Error.hpp
+++ b/src/ControlSystem/ControlErrors/Size/Error.hpp
@@ -5,6 +5,7 @@
 
 #include <memory>
 
+#include "ControlSystem/ControlErrors/Size/State.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Utilities/Gsl.hpp"
 
@@ -32,13 +33,10 @@ struct ErrorDiagnostics {
   double control_error;
   size_t state_number;
   double lambda_00;
-  double dt_lambda_00;
   double horizon_00;
   double dt_horizon_00;
   double min_delta_r;
   double min_relative_delta_r;
-  double control_error_delta_r;
-  double min_char_speed;
   double min_comoving_char_speed;
   double char_speed_crossing_time;
   double comoving_char_speed_crossing_time;
@@ -46,6 +44,7 @@ struct ErrorDiagnostics {
   double target_char_speed;
   double suggested_timescale;
   double damping_timescale;
+  ControlErrorArgs control_error_args;
   bool discontinuous_change_has_occurred;
 };
 

--- a/src/ControlSystem/ControlErrors/Size/StateHistory.cpp
+++ b/src/ControlSystem/ControlErrors/Size/StateHistory.cpp
@@ -1,0 +1,61 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "ControlSystem/ControlErrors/Size/StateHistory.hpp"
+
+#include <deque>
+#include <memory>
+#include <pup.h>
+#include <pup_stl.h>
+#include <unordered_map>
+#include <utility>
+
+#include "ControlSystem/ControlErrors/Size/AhSpeed.hpp"
+#include "ControlSystem/ControlErrors/Size/DeltaR.hpp"
+#include "ControlSystem/ControlErrors/Size/Info.hpp"
+#include "ControlSystem/ControlErrors/Size/Initial.hpp"
+#include "ControlSystem/ControlErrors/Size/State.hpp"
+#include "DataStructures/DataVector.hpp"
+
+namespace control_system::size {
+StateHistory::StateHistory() { initialize_stored_control_errors(); }
+
+StateHistory::StateHistory(const size_t num_times_to_store)
+    : num_times_to_store_(num_times_to_store) {
+  initialize_stored_control_errors();
+}
+
+void StateHistory::initialize_stored_control_errors() {
+  stored_control_errors_[States::Initial{}.number()];
+  stored_control_errors_[States::DeltaR{}.number()];
+  stored_control_errors_[States::AhSpeed{}.number()];
+}
+
+void StateHistory::store(double time, const Info& info,
+                         const ControlErrorArgs& control_error_args) {
+  const auto store_state = [this, &time, &info,
+                            &control_error_args](auto state) {
+    const double control_error = state.control_error(info, control_error_args);
+    std::deque<std::pair<double, double>>& history =
+        stored_control_errors_.at(state.number());
+    history.emplace_back(time, control_error);
+    while (history.size() > num_times_to_store_) {
+      history.pop_front();
+    }
+  };
+
+  store_state(States::Initial{});
+  store_state(States::DeltaR{});
+  store_state(States::AhSpeed{});
+}
+
+const std::deque<std::pair<double, double>>& StateHistory::state_history(
+    const size_t state_number) const {
+  return stored_control_errors_.at(state_number);
+}
+
+void StateHistory::pup(PUP::er& p) {
+  p | num_times_to_store_;
+  p | stored_control_errors_;
+}
+}  // namespace control_system::size

--- a/src/ControlSystem/ControlErrors/Size/StateHistory.hpp
+++ b/src/ControlSystem/ControlErrors/Size/StateHistory.hpp
@@ -1,0 +1,60 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <deque>
+#include <pup.h>
+#include <unordered_map>
+#include <utility>
+
+#include "ControlSystem/ControlErrors/Size/Info.hpp"
+#include "ControlSystem/ControlErrors/Size/State.hpp"
+
+namespace control_system::size {
+/*!
+ * \brief A struct for holding a history of control errors for each state in the
+ * `control_system::Systems::Size` control system.
+ */
+struct StateHistory {
+  StateHistory();
+
+  /// \brief Only keep `num_times_to_store` entries in the state_history
+  StateHistory(size_t num_times_to_store);
+
+  /*!
+   * \brief Store the control errors for all `control_system::size::State`s.
+   *
+   * \param time Time to store control errors at
+   * \param info `control_system::size::Info`
+   * \param control_error_args `control_system::size::ControlErrorArgs`
+   */
+  void store(double time, const Info& info,
+             const ControlErrorArgs& control_error_args);
+
+  /*!
+   * \brief Return a const reference to the stored control errors from all the
+   * states.
+   *
+   * \param state_number `size_t` corresponding to the
+   * `control_system::size::State::number()` of a state.
+   * \return std::deque<std::pair<double, double>> The `std::pair` holds
+   * the time and control error, respectively. The `std::deque` is ordered with
+   * earlier times at the "front" and later times at the "back". This is to make
+   * iteration over the deque easier as we typically want to start with earlier
+   * times.
+   */
+  const std::deque<std::pair<double, double>>& state_history(
+      size_t state_number) const;
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& p);
+
+ private:
+  void initialize_stored_control_errors();
+
+  size_t num_times_to_store_{};
+  std::unordered_map<size_t, std::deque<std::pair<double, double>>>
+      stored_control_errors_{};
+};
+}  // namespace control_system::size

--- a/src/ControlSystem/Systems/Size.hpp
+++ b/src/ControlSystem/Systems/Size.hpp
@@ -74,7 +74,7 @@ struct Size : tt::ConformsTo<protocols::ControlSystem> {
   static_assert(
       tt::conforms_to_v<measurement, control_system::protocols::Measurement>);
 
-  using control_error = ControlErrors::Size<Horizon>;
+  using control_error = ControlErrors::Size<deriv_order, Horizon>;
   static_assert(tt::conforms_to_v<control_error,
                                   control_system::protocols::ControlError>);
 

--- a/tests/Unit/ControlSystem/ControlErrors/CMakeLists.txt
+++ b/tests/Unit/ControlSystem/ControlErrors/CMakeLists.txt
@@ -8,5 +8,6 @@ set(LIBRARY_SOURCES
   ControlErrors/Test_Shape.cpp
   ControlErrors/Test_SizeControlStates.cpp
   ControlErrors/Test_SizeError.cpp
+  ControlErrors/Test_StateHistory.cpp
   ControlErrors/Test_Translation.cpp
   PARENT_SCOPE)

--- a/tests/Unit/ControlSystem/ControlErrors/Test_SizeError.cpp
+++ b/tests/Unit/ControlSystem/ControlErrors/Test_SizeError.cpp
@@ -161,7 +161,7 @@ void test_size_error_one_step(
   if constexpr (std::is_same_v<InitialState,
                                control_system::size::States::Initial>) {
     using size_error =
-        control_system::ControlErrors::Size<domain::ObjectLabel::A>;
+        control_system::ControlErrors::Size<2, domain::ObjectLabel::A>;
     static_assert(
         tt::assert_conforms_to_v<size_error,
                                  control_system::protocols::ControlError>);

--- a/tests/Unit/ControlSystem/ControlErrors/Test_SizeError.cpp
+++ b/tests/Unit/ControlSystem/ControlErrors/Test_SizeError.cpp
@@ -200,6 +200,7 @@ void test_size_error_one_step(
 
     const double control_error_from_class =
         error_class(tuner, cache, time, "Size"s, measurements)[0];
+    const auto control_error_history = error_class.control_error_history();
 
     // These should be identical because the control error class calls the
     // control_error function
@@ -208,11 +209,14 @@ void test_size_error_one_step(
     CHECK_FALSE(error_class.get_suggested_timescale().has_value());
     CHECK(error_class.discontinuous_change_has_occurred() !=
           std::is_same_v<InitialState, FinalState>);
+    // The current time is popped back so we only get times in the past
+    CHECK(control_error_history.empty());
 
     error_class.reset();
 
     CHECK_FALSE(error_class.get_suggested_timescale().has_value());
     CHECK_FALSE(error_class.discontinuous_change_has_occurred());
+    CHECK(control_error_history.empty());
   }
 }
 

--- a/tests/Unit/ControlSystem/ControlErrors/Test_StateHistory.cpp
+++ b/tests/Unit/ControlSystem/ControlErrors/Test_StateHistory.cpp
@@ -1,0 +1,87 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <deque>
+#include <numeric>
+#include <optional>
+#include <utility>
+#include <vector>
+
+#include "ControlSystem/ControlErrors/Size/AhSpeed.hpp"
+#include "ControlSystem/ControlErrors/Size/DeltaR.hpp"
+#include "ControlSystem/ControlErrors/Size/Info.hpp"
+#include "ControlSystem/ControlErrors/Size/Initial.hpp"
+#include "ControlSystem/ControlErrors/Size/RegisterDerivedWithCharm.hpp"
+#include "ControlSystem/ControlErrors/Size/StateHistory.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace control_system::size {
+namespace {
+void test_state_history(const size_t num_times_to_store) {
+  CAPTURE(num_times_to_store);
+  Info info{
+      std::make_unique<States::Initial>(), 1.0, 1.0, 1.0, std::nullopt, false};
+  ControlErrorArgs control_error_args{1.0, 1.0, 1.0, 1.0};
+
+  StateHistory state_history{num_times_to_store};
+  const std::vector<size_t> states{0, 1, 2};
+
+  // Test that as we fill up the history, we have the expected number of stored
+  // entries and that they are the correct values, for each state
+  for (size_t i = 0; i < num_times_to_store; i++) {
+    const double time = static_cast<double>(i);
+    state_history.store(time, info, control_error_args);
+
+    for (const size_t state : states) {
+      CAPTURE(state);
+      const auto history = state_history.state_history(state);
+      CHECK(history.size() == i + 1);
+      for (size_t j = 0; j < history.size(); j++) {
+        double stored_time, control_error;
+        std::tie(stored_time, control_error) = history[j];
+        CHECK(static_cast<double>(j) == stored_time);
+        // These are hand calculated from the above parameters Info and
+        // ControlErrorArgs.
+        switch (state) {
+          case 0:
+            CHECK(control_error == 0.0);
+            break;
+          case 1:
+            CHECK(control_error == 0.0);
+            break;
+          case 2:
+            CHECK(control_error == 1.0);
+            break;
+          default:
+            ERROR("Unknown state: " << state);
+        }
+      }
+    }
+  }
+
+  // Test that trying to store one more value causes us to pop off the initial
+  // (first) value and add this new one to the end (last), while keeping the
+  // total number of entries at num_times_to_store
+  state_history.store(static_cast<double>(num_times_to_store), info,
+                      control_error_args);
+  for (const size_t state : states) {
+    const auto history = state_history.state_history(state);
+    CHECK(history.size() == num_times_to_store);
+    CHECK(history.front().first == 1.0);
+    CHECK(history.back().first == static_cast<double>(num_times_to_store));
+  }
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.ControlSystem.ControlErrors.StateHistory",
+                  "[Domain][Unit]") {
+  control_system::size::register_derived_with_charm();
+  for (size_t num_times = 1; num_times < 5; num_times++) {
+    test_state_history(num_times);
+  }
+}
+}  // namespace control_system::size


### PR DESCRIPTION
## Proposed changes

This is useful for repopulating the Averager with previous control errors when a discontinuous change has occurred. Also add this to the size control error. It will be used in a later PR.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
