### PR TITLE
Fix bug in computation of zero crossing predictor

### DIFF
--- a/src/ControlSystem/ControlErrors/Size.hpp
+++ b/src/ControlSystem/ControlErrors/Size.hpp
@@ -90,13 +90,15 @@ namespace control_system::ControlErrors {
  * - MinCharSpeed
  * - MinComovingCharSpeed: Eq. 98 in \cite Hemberger2012jz
  * - CharSpeedCrossingTime: %Time at which the min char speed is predicted to
- *   cross zero and become negative.
+ *   cross zero and become negative (or 0.0 if that time is in the past).
  * - ComovingCharSpeedCrossingTime: %Time at which the min comoving char speed
- *   is predicted to cross zero and become negative.
+ *   is predicted to cross zero and become negative (or 0.0 if that time is in
+ *   the past).
  * - DeltaRCrossingTime: %Time at which the distance between the excision and
- *   horizon surfaces is predicted to be zero.
+ *   horizon surfaces is predicted to be zero (or 0.0 if that time is in the
+ *   past).
  * - SuggestedTimescale: A timescale for the `TimescaleTuner` suggested by one
- *   of the State%s
+ *   of the State%s (or 0.0 if no timescale was suggested)
  * - DampingTime
  */
 template <::domain::ObjectLabel Horizon>

--- a/src/ControlSystem/ControlErrors/Size/DeltaR.cpp
+++ b/src/ControlSystem/ControlErrors/Size/DeltaR.cpp
@@ -35,15 +35,17 @@ void DeltaR::update(const gsl::not_null<Info*> info,
   constexpr double time_tolerance_for_delta_r_in_danger = 0.99;
   const bool delta_radius_is_in_danger =
       crossing_time_info.horizon_will_hit_excision_boundary_first and
-      crossing_time_info.t_delta_radius <
+      crossing_time_info.t_delta_radius.value_or(
+          std::numeric_limits<double>::infinity()) <
           info->damping_time * time_tolerance_for_delta_r_in_danger;
   const bool char_speed_is_in_danger =
       crossing_time_info.char_speed_will_hit_zero_first and
-      crossing_time_info.t_char_speed < info->damping_time and
+      crossing_time_info.t_char_speed.value_or(
+          std::numeric_limits<double>::infinity()) < info->damping_time and
       not delta_radius_is_in_danger;
 
   if (char_speed_is_in_danger) {
-    if (crossing_time_info.t_comoving_char_speed > 0.0 or
+    if (crossing_time_info.t_comoving_char_speed.has_value() or
         update_args.min_comoving_char_speed < 0.0) {
       // Comoving char speed is negative or threatening to cross zero, so
       // staying in DeltaR mode will not work.  So switch to AhSpeed mode.

--- a/src/ControlSystem/ControlErrors/Size/Error.cpp
+++ b/src/ControlSystem/ControlErrors/Size/Error.cpp
@@ -205,11 +205,11 @@ ErrorDiagnostics control_error(
   predictor_delta_radius->add(time, get(radial_distance));
 
   // Compute crossing times for state-change logic.
-  const double char_speed_crossing_time =
+  const std::optional<double> char_speed_crossing_time =
       predictor_char_speed->min_positive_zero_crossing_time(time);
-  const double comoving_char_speed_crossing_time =
+  const std::optional<double> comoving_char_speed_crossing_time =
       predictor_comoving_char_speed->min_positive_zero_crossing_time(time);
-  const double delta_radius_crossing_time =
+  const std::optional<double> delta_radius_crossing_time =
       predictor_delta_radius->min_positive_zero_crossing_time(time);
 
   // Update the info, possibly changing the state inside of info.
@@ -238,9 +238,9 @@ ErrorDiagnostics control_error(
       control_error_delta_r,
       min_char_speed,
       min_comoving_char_speed,
-      char_speed_crossing_time,
-      comoving_char_speed_crossing_time,
-      delta_radius_crossing_time,
+      char_speed_crossing_time.value_or(0.0),
+      comoving_char_speed_crossing_time.value_or(0.0),
+      delta_radius_crossing_time.value_or(0.0),
       info->target_char_speed,
       info->suggested_time_scale.value_or(0.0),
       info->damping_time,

--- a/src/ControlSystem/ControlErrors/Size/Info.cpp
+++ b/src/ControlSystem/ControlErrors/Size/Info.cpp
@@ -61,19 +61,20 @@ void Info::set_all_but_state(const Info& info) {
 }
 
 CrossingTimeInfo::CrossingTimeInfo(
-    const double char_speed_crossing_time,
-    const double comoving_char_speed_crossing_time,
-    const double delta_radius_crossing_time)
+    const std::optional<double>& char_speed_crossing_time,
+    const std::optional<double>& comoving_char_speed_crossing_time,
+    const std::optional<double>& delta_radius_crossing_time)
     : t_char_speed(char_speed_crossing_time),
       t_comoving_char_speed(comoving_char_speed_crossing_time),
       t_delta_radius(delta_radius_crossing_time) {
-  if (t_char_speed > 0.0) {
-    if (t_delta_radius > 0.0 and t_delta_radius <= t_char_speed) {
+  if (t_char_speed.value_or(-1.0) > 0.0) {
+    if (t_delta_radius.value_or(-1.0) > 0.0 and
+        t_delta_radius.value() <= t_char_speed.value()) {
       horizon_will_hit_excision_boundary_first = true;
     } else {
       char_speed_will_hit_zero_first = true;
     }
-  } else if (t_delta_radius > 0.0) {
+  } else if (t_delta_radius.value_or(-1.0) > 0.0) {
     horizon_will_hit_excision_boundary_first = true;
   }
 }

--- a/src/ControlSystem/ControlErrors/Size/Info.hpp
+++ b/src/ControlSystem/ControlErrors/Size/Info.hpp
@@ -62,22 +62,23 @@ struct Info {
 /// Holds information about crossing times, as computed by
 /// ZeroCrossingPredictors.
 struct CrossingTimeInfo {
-  CrossingTimeInfo(const double char_speed_crossing_time,
-                   const double comoving_char_speed_crossing_time,
-                   const double delta_radius_crossing_time);
+  CrossingTimeInfo(
+      const std::optional<double>& char_speed_crossing_time,
+      const std::optional<double>& comoving_char_speed_crossing_time,
+      const std::optional<double>& delta_radius_crossing_time);
   /// t_char_speed is the time (relative to the current time) when the
-  /// minimum characteristic speed is predicted to cross zero (or zero if
+  /// minimum characteristic speed is predicted to cross zero (or nullopt if
   /// the minimum characteristic speed is increasing).
-  double t_char_speed;
+  std::optional<double> t_char_speed;
   /// t_comoving_char_speed is the time (relative to the current time) when the
   /// minimum comoving characteristic speed is predicted to cross zero
-  /// (or zero if the minimum comoving characteristic speed is increasing).
-  double t_comoving_char_speed;
+  /// (or nullopt if the minimum comoving characteristic speed is increasing).
+  std::optional<double> t_comoving_char_speed;
   /// t_delta_radius is the time (relative to the current time) when the
   /// minimum distance between the horizon and the excision boundary is
-  /// predicted to cross zero (or zero if the minimum distance is
+  /// predicted to cross zero (or nullopt if the minimum distance is
   /// increasing).
-  double t_delta_radius;
+  std::optional<double> t_delta_radius;
   /// Extra variables to simplify the logic; these indicate whether
   /// the characteristic speed or the excision boundary (or neither) are
   /// expected to cross zero soon.

--- a/src/ControlSystem/ControlErrors/Size/Initial.cpp
+++ b/src/ControlSystem/ControlErrors/Size/Initial.cpp
@@ -21,10 +21,12 @@ void Initial::update(const gsl::not_null<Info*> info,
   // can be different for different States.
   const bool char_speed_is_in_danger =
       crossing_time_info.char_speed_will_hit_zero_first and
-      crossing_time_info.t_char_speed < info->damping_time;
+      crossing_time_info.t_char_speed.value_or(
+          std::numeric_limits<double>::infinity()) < info->damping_time;
   const bool delta_radius_is_in_danger =
       crossing_time_info.horizon_will_hit_excision_boundary_first and
-      crossing_time_info.t_delta_radius < info->damping_time and
+      crossing_time_info.t_delta_radius.value_or(
+          std::numeric_limits<double>::infinity()) < info->damping_time and
       not char_speed_is_in_danger;
 
   // This factor is present in SpEC, but it probably isn't necessary

--- a/src/NumericalAlgorithms/Interpolation/ZeroCrossingPredictor.hpp
+++ b/src/NumericalAlgorithms/Interpolation/ZeroCrossingPredictor.hpp
@@ -5,6 +5,7 @@
 
 #include <cstddef>
 #include <deque>
+#include <optional>
 
 #include "DataStructures/DataVector.hpp"
 
@@ -44,8 +45,11 @@ class ZeroCrossingPredictor {
   DataVector zero_crossing_time(double current_time) const;
 
   /// The minimum positive value over the DataVector returned
-  /// by zero_crossing_time.  Returns zero if is_valid() is false.
-  double min_positive_zero_crossing_time(double current_time) const;
+  /// by zero_crossing_time. If there is no minimum positive value (all are
+  /// negative), returns `std::nullopt`. Also returns `std::nullopt` if
+  /// is_valid() is false.
+  std::optional<double> min_positive_zero_crossing_time(
+      double current_time) const;
 
   /// Returns whether we have enough data to call zero_crossing_time.
   bool is_valid() const;

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_ZeroCrossingPredictor.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_ZeroCrossingPredictor.cpp
@@ -49,8 +49,9 @@ void test_zero_crossing_predictor() {
   intrp::ZeroCrossingPredictor predictor(min_size, x_values.size());
 
   // Check trivial case that min_positive_zero_crossing_time returns
-  // zero for an invalid predictor.
-  CHECK(predictor.min_positive_zero_crossing_time(x_values.back()) == 0.0);
+  // nullopt for an invalid predictor.
+  CHECK_FALSE(
+      predictor.min_positive_zero_crossing_time(x_values.back()).has_value());
 
   // Fill points in predictor.
   for (size_t i = 0; i < x_values.size(); i++) {
@@ -87,8 +88,15 @@ void test_zero_crossing_predictor() {
   const double expected_zero_crossing =
       std::min(adjusted_value1, adjusted_value2);
 
-  CHECK(predictor.min_positive_zero_crossing_time(x_values.back()) ==
-        custom_approx(expected_zero_crossing));
+  if (expected_zero_crossing == std::numeric_limits<double>::infinity()) {
+    CHECK_FALSE(
+        predictor.min_positive_zero_crossing_time(x_values.back()).has_value());
+  } else {
+    CHECK(
+        predictor.min_positive_zero_crossing_time(x_values.back()).has_value());
+    CHECK(predictor.min_positive_zero_crossing_time(x_values.back()).value() ==
+          custom_approx(expected_zero_crossing));
+  }
 
   // Re-add the first point.  Adding the first point should cause the
   // (original) first point to be popped off the deque [and thus test
@@ -96,13 +104,19 @@ void test_zero_crossing_predictor() {
   // previous result.
   DataVector first_point = y_values.front();
   predictor.add(x_values.front(), std::move(first_point));
-  CHECK(predictor.min_positive_zero_crossing_time(0.0) ==
-        custom_approx(expected_zero_crossing));
+  if (expected_zero_crossing == std::numeric_limits<double>::infinity()) {
+    CHECK_FALSE(predictor.min_positive_zero_crossing_time(0.0).has_value());
+  } else {
+    CHECK(predictor.min_positive_zero_crossing_time(0.0).has_value());
+    CHECK(predictor.min_positive_zero_crossing_time(0.0).value() ==
+          custom_approx(expected_zero_crossing));
+  }
 
   // Clear the predictor, and check that min_positive_zero_crossing_time
-  // returns zero again for the cleared (and now invalid) predictor.
+  // returns nullopt again for the cleared (and now invalid) predictor.
   predictor.clear();
-  CHECK(predictor.min_positive_zero_crossing_time(x_values.back()) == 0.0);
+  CHECK_FALSE(
+      predictor.min_positive_zero_crossing_time(x_values.back()).has_value());
 }
 }  // namespace
 


### PR DESCRIPTION
## Proposed changes

Zero was used as a sentinel value in too many places and sometimes had double meaning. This uses `std::optional`s where possible to clear things up.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
