### PR TITLE
Add Py Bindings for Pi, Phi, and GaugeSource

### DIFF
--- a/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/Python/Bindings.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/Python/Bindings.cpp
@@ -8,6 +8,9 @@
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/Christoffel.hpp"
 #include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/DerivSpatialMetric.hpp"
+#include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/GaugeSource.hpp"
+#include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/Phi.hpp"
+#include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/Pi.hpp"
 #include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/Ricci.hpp"
 #include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/TimeDerivOfShift.hpp"
 #include "Utilities/ErrorHandling/SegfaultHandler.hpp"
@@ -30,6 +33,39 @@ void bind_impl(py::module& m) {  // NOLINT
         static_cast<tnsr::ijj<DataVector, Dim> (*)(
             const tnsr::iaa<DataVector, Dim>&)>(&::gh::deriv_spatial_metric),
         py::arg("phi"));
+
+  m.def("gauge_source",
+        static_cast<tnsr::a<DataVector, Dim> (*)(
+            const Scalar<DataVector>&, const Scalar<DataVector>&,
+            const tnsr::i<DataVector, Dim>&, const tnsr::I<DataVector, Dim>&,
+            const tnsr::I<DataVector, Dim>&, const tnsr::iJ<DataVector, Dim>&,
+            const tnsr::ii<DataVector, Dim>&, const Scalar<DataVector>&,
+            const tnsr::i<DataVector, Dim>&)>(&::gh::gauge_source),
+        py::arg("lapse"), py::arg("dt_lapse"), py::arg("deriv_lapse"),
+        py::arg("shift"), py::arg("dt_shift"), py::arg("deriv_shift"),
+        py::arg("spatial_metric"), py::arg("trace_extrinsic_curvature"),
+        py::arg("trace_christoffel_last_indices"));
+
+  m.def(
+      "phi",
+      static_cast<tnsr::iaa<DataVector, Dim> (*)(
+          const Scalar<DataVector>&, const tnsr::i<DataVector, Dim>&,
+          const tnsr::I<DataVector, Dim>&, const tnsr::iJ<DataVector, Dim>&,
+          const tnsr::ii<DataVector, Dim>&, const tnsr::ijj<DataVector, Dim>&)>(
+          &::gh::phi),
+      py::arg("lapse"), py::arg("deriv_lapse"), py::arg("shift"),
+      py::arg("deriv_shift"), py::arg("spatial_metric"),
+      py::arg("deriv_spatial_metric"));
+
+  m.def("pi",
+        static_cast<tnsr::aa<DataVector, Dim> (*)(
+            const Scalar<DataVector>&, const Scalar<DataVector>&,
+            const tnsr::I<DataVector, Dim>&, const tnsr::I<DataVector, Dim>&,
+            const tnsr::ii<DataVector, Dim>&, const tnsr::ii<DataVector, Dim>&,
+            const tnsr::iaa<DataVector, Dim>&)>(&::gh::pi),
+        py::arg("lapse"), py::arg("dt_lapse"), py::arg("shift"),
+        py::arg("dt_shift"), py::arg("spatial_metric"),
+        py::arg("dt_spatial_metric"), py::arg("phi"));
 
   m.def(
       "spatial_ricci_tensor",

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Python/Test_GhBindings.py
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Python/Test_GhBindings.py
@@ -26,6 +26,64 @@ class TestBindings(unittest.TestCase):
             phi,
         )
 
+    def test_gauge_source(self):
+        lapse = Scalar[DataVector](num_points=1, fill=1.0)
+        dt_lapse = Scalar[DataVector](num_points=1, fill=0.0)
+        deriv_lapse = tnsr.i[DataVector, 3](num_points=1, fill=0.0)
+        shift = tnsr.I[DataVector, 3](num_points=1, fill=0.0)
+        dt_shift = tnsr.I[DataVector, 3](num_points=1, fill=0.0)
+        deriv_shift = tnsr.iJ[DataVector, 3](num_points=1, fill=0.0)
+        spatial_metric = tnsr.ii[DataVector, 3](num_points=1, fill=1.0)
+        trace_extrinsic_curvature = Scalar[DataVector](num_points=1, fill=1.0)
+        trace_christoffel_last_indices = tnsr.i[DataVector, 3](
+            num_points=1, fill=1.0
+        )
+        gh.gauge_source(
+            lapse,
+            dt_lapse,
+            deriv_lapse,
+            shift,
+            dt_shift,
+            deriv_shift,
+            spatial_metric,
+            trace_extrinsic_curvature,
+            trace_christoffel_last_indices,
+        )
+
+    def test_phi(self):
+        lapse = Scalar[DataVector](num_points=1, fill=1.0)
+        deriv_lapse = tnsr.i[DataVector, 3](num_points=1, fill=0.0)
+        shift = tnsr.I[DataVector, 3](num_points=1, fill=0.0)
+        deriv_shift = tnsr.iJ[DataVector, 3](num_points=1, fill=0.0)
+        spatial_metric = tnsr.ii[DataVector, 3](num_points=1, fill=1.0)
+        deriv_spatial_metric = tnsr.ijj[DataVector, 3](num_points=1, fill=0.0)
+        gh.phi(
+            lapse,
+            deriv_lapse,
+            shift,
+            deriv_shift,
+            spatial_metric,
+            deriv_spatial_metric,
+        )
+
+    def test_pi(self):
+        lapse = Scalar[DataVector](num_points=1, fill=1.0)
+        dt_lapse = Scalar[DataVector](num_points=1, fill=0.0)
+        shift = tnsr.I[DataVector, 3](num_points=1, fill=0.0)
+        dt_shift = tnsr.I[DataVector, 3](num_points=1, fill=0.0)
+        spatial_metric = tnsr.ii[DataVector, 3](num_points=1, fill=1.0)
+        dt_spatial_metric = tnsr.ii[DataVector, 3](num_points=1, fill=0.0)
+        phi = tnsr.iaa[DataVector, 3](num_points=1, fill=1.0)
+        gh.pi(
+            lapse,
+            dt_lapse,
+            shift,
+            dt_shift,
+            spatial_metric,
+            dt_spatial_metric,
+            phi,
+        )
+
     def test_spatial_ricci_tensor(self):
         phi = tnsr.iaa[DataVector, 3](num_points=1, fill=0.0)
         deriv_phi = tnsr.ijaa[DataVector, 3](num_points=1, fill=0.0)


### PR DESCRIPTION
## Proposed changes

This adds GH Python bindings for Pi, Phi, and GaugeSource.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
