### PR TITLE
Add PyBinding for DerivSpatialMetric

### DIFF
--- a/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/Python/Bindings.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/Python/Bindings.cpp
@@ -6,6 +6,7 @@
 #include <type_traits>
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/DerivSpatialMetric.hpp"
 #include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/Ricci.hpp"
 #include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/TimeDerivOfShift.hpp"
 #include "Utilities/ErrorHandling/SegfaultHandler.hpp"
@@ -17,6 +18,11 @@ namespace GeneralizedHarmonic::py_bindings {
 namespace {
 template <size_t Dim>
 void bind_impl(py::module& m) {  // NOLINT
+  m.def("deriv_spatial_metric",
+        static_cast<tnsr::ijj<DataVector, Dim> (*)(
+            const tnsr::iaa<DataVector, Dim>&)>(&::gh::deriv_spatial_metric),
+        py::arg("phi"));
+
   m.def(
       "spatial_ricci_tensor",
       static_cast<tnsr::ii<DataVector, Dim> (*)(

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Python/Test_GhBindings.py
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Python/Test_GhBindings.py
@@ -12,6 +12,12 @@ from spectre.DataStructures.Tensor import Scalar, tnsr
 
 
 class TestBindings(unittest.TestCase):
+    def test_deriv_spatial_metric(self):
+        phi = tnsr.iaa[DataVector, 3](num_points=1, fill=1.0)
+        gh.deriv_spatial_metric(
+            phi,
+        )
+
     def test_time_deriv_of_shift(self):
         lapse = Scalar[DataVector](num_points=1, fill=1.0)
         shift = tnsr.I[DataVector, 3](num_points=1, fill=0.0)


### PR DESCRIPTION
## Proposed changes

Add PyBinding for the Derivative of the Spatial Metric in Generalized Harmonic. 

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
