### PR TITLE
Add Correct Gaussian3 Amplitude in BBH input files

### DIFF
--- a/tests/InputFiles/GeneralizedHarmonic/BinaryBlackHole.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/BinaryBlackHole.yaml
@@ -115,7 +115,7 @@ EvolutionSystem:
           Width: 3.5                 # 7.0 * m_B
           Center: [*XCoordB, 0.0, 0.0]  # [x_B, 0, 0]
         Gaussian3:
-          Amplitude: 0.75            # 0.75 / (m_A + m_B)
+          Amplitude: 0.075            # 0.075 / (m_A + m_B)
           Width: 38.415              # 2.5 * (x_B - x_A)
           Center: [0.0, 0.0, 0.0]
     DampingFunctionGamma1:
@@ -136,7 +136,7 @@ EvolutionSystem:
           Width: 3.5                 # 7.0 * m_B
           Center: [*XCoordB, 0.0, 0.0]  # [x_B, 0, 0]
         Gaussian3:
-          Amplitude: 0.75            # 0.75 / (m_A + m_B)
+          Amplitude: 0.075            # 0.075 / (m_A + m_B)
           Width: 38.415              # 2.5 * (x_B - x_A)
           Center: [0.0, 0.0, 0.0]
 

--- a/tests/InputFiles/GeneralizedHarmonic/CylindricalBinaryBlackHole.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/CylindricalBinaryBlackHole.yaml
@@ -97,7 +97,7 @@ EvolutionSystem:
           Width: 3.5                 # 7.0 * m_B
           Center: [*XCoordB, 0.0, 0.0]  # [x_B, 0, 0]
         Gaussian3:
-          Amplitude: 0.75            # 0.75 / (m_A + m_B)
+          Amplitude: 0.075            # 0.075 / (m_A + m_B)
           Width: 38.415              # 2.5 * (x_B - x_A)
           Center: [0.0, 0.0, 0.0]
     DampingFunctionGamma1:
@@ -118,7 +118,7 @@ EvolutionSystem:
           Width: 3.5                 # 7.0 * m_B
           Center: [*XCoordB, 0.0, 0.0]  # [x_B, 0, 0]
         Gaussian3:
-          Amplitude: 0.75            # 0.75 / (m_A + m_B)
+          Amplitude: 0.075            # 0.075 / (m_A + m_B)
           Width: 38.415              # 2.5 * (x_B - x_A)
           Center: [0.0, 0.0, 0.0]
 


### PR DESCRIPTION
## Proposed changes

Puts the correct amplitude for the Gaussian3 in BBH yamls

### Upgrade instructions


### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.


