### PR TITLE
Silence gcc 12 and 13 warnings

### DIFF
--- a/cmake/EnableWarnings.cmake
+++ b/cmake/EnableWarnings.cmake
@@ -26,6 +26,7 @@ if(${ENABLE_WARNINGS})
 -Wmissing-include-dirs;\
 -Wmissing-noreturn;\
 -Wnewline-eof;\
+-Wno-dangling-reference;\
 -Wno-documentation-unknown-command;\
 -Wno-mismatched-tags;\
 -Wno-non-template-friend;\

--- a/src/DataStructures/Index.hpp
+++ b/src/DataStructures/Index.hpp
@@ -85,12 +85,11 @@ class Index {
     ASSERT(d < Dim,
            "Can't slice dimension " << d << " from an Index<" << Dim << ">");
     std::array<size_t, Dim - 1> t{};
-    for (size_t i = 0; i < Dim; ++i) {
-      if (i < d) {
-        gsl::at(t, i) = gsl::at(indices_, i);
-      } else if (i > d) {
-        gsl::at(t, i - 1) = gsl::at(indices_, i);
-      }
+    for (size_t i = 0; i < d; ++i) {
+      gsl::at(t, i) = gsl::at(indices_, i);
+    }
+    for (size_t i = d + 1; i < Dim; ++i) {
+      gsl::at(t, i - 1) = gsl::at(indices_, i);
     }
     return Index<Dim - 1>(t);
   }

--- a/src/Evolution/Actions/RunEventsAndDenseTriggers.hpp
+++ b/src/Evolution/Actions/RunEventsAndDenseTriggers.hpp
@@ -140,12 +140,12 @@ struct RunEventsAndDenseTriggers {
           using tag = tmpl::type_from<decltype(tag_v)>;
           db::mutate<tag>(
               [this](const gsl::not_null<typename tag::type*> value) {
-#if defined(__GNUC__) and not defined(__clang__) and __GNUC__ < 13
+#if defined(__GNUC__) and not defined(__clang__) and __GNUC__ < 14
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 #endif
                 *value = std::move(tuples::get<tag>(*non_tensors_));
-#if defined(__GNUC__) and not defined(__clang__) and __GNUC__ < 13
+#if defined(__GNUC__) and not defined(__clang__) and __GNUC__ < 14
 #pragma GCC diagnostic pop
 #endif
               },

--- a/src/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/Tags.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/Tags.hpp
@@ -105,7 +105,7 @@ struct DampingFunctionGamma1 : db::SimpleTag {
 
   static constexpr bool pass_metavariables = false;
   static type create_from_options(const type& damping_function) {
-    return std::move(damping_function->get_clone());
+    return damping_function->get_clone();
   }
 };
 
@@ -124,7 +124,7 @@ struct DampingFunctionGamma2 : db::SimpleTag {
 
   static constexpr bool pass_metavariables = false;
   static type create_from_options(const type& damping_function) {
-    return std::move(damping_function->get_clone());
+    return damping_function->get_clone();
   }
 };
 }  // namespace Tags

--- a/src/Options/Auto.hpp
+++ b/src/Options/Auto.hpp
@@ -43,6 +43,18 @@ class Auto {
   Auto() = default;
   explicit Auto(T value) : value_(std::move(value)) {}
 
+  // These lines are just to work around a spurious warning.
+  Auto(Auto&&) = default;
+  Auto& operator=(Auto&&) = default;
+#if defined(__GNUC__) and not defined(__clang__) and __GNUC__ >= 12 and __GNUC__ < 14
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+  ~Auto() = default;
+#if defined(__GNUC__) and not defined(__clang__) and __GNUC__ >= 12 and __GNUC__ < 14
+#pragma GCC diagnostic pop
+#endif
+
   // NOLINTNEXTLINE(google-explicit-constructor)
   template <typename U>
   operator std::optional<U>() && { return std::move(value_); }

--- a/src/Options/ParseOptions.hpp
+++ b/src/Options/ParseOptions.hpp
@@ -92,7 +92,14 @@ T Option::parse_as() const {
     // yaml-cpp's `as` method won't parse empty nodes, so we need to
     // inline a bit of its logic.
     Options_detail::wrap_create_types<T, Metavariables> result{};
+#if defined(__GNUC__) and not defined(__clang__) and __GNUC__ == 13
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
     if (YAML::convert<decltype(result)>::decode(node(), result)) {
+#if defined(__GNUC__) and not defined(__clang__) and __GNUC__ == 13
+#pragma GCC diagnostic pop
+#endif
       return Options_detail::unwrap_create_types(std::move(result));
     }
     // clang-tidy: thrown exception is not nothrow copy constructible

--- a/src/Options/ParseOptions.hpp
+++ b/src/Options/ParseOptions.hpp
@@ -82,10 +82,6 @@ inline void Option::set_node(YAML::Node node) {
   context_.column = node_->Mark().column;
 }
 
-#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ < 8
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wsuggest-attribute=noreturn"
-#endif  // defined(__GNUC__) && !defined(__clang__) && __GNUC__ < 8
 template <typename T, typename Metavariables>
 T Option::parse_as() const {
   try {
@@ -150,9 +146,6 @@ T Option::parse_as() const {
     ERROR("Unexpected exception: " << e.what());
   }
 }
-#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ < 8
-#pragma GCC diagnostic pop
-#endif  // defined(__GNUC__) && !defined(__clang__) && __GNUC__ < 8
 
 namespace Options_detail {
 template <typename T, typename Metavariables, typename Subgroup>

--- a/src/ParallelAlgorithms/LinearSolver/ConjugateGradient/ElementActions.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/ConjugateGradient/ElementActions.hpp
@@ -259,15 +259,7 @@ struct UpdateOperand {
       return {Parallel::AlgorithmExecution::Retry, std::nullopt};
     }
 
-    // Silence a warning with GCC 7 (occurs in Release mode)
-#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ == 7
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
     auto received_data = std::move(inbox.extract(iteration_id).mapped());
-#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ == 7
-#pragma GCC diagnostic pop
-#endif
     const double res_ratio = get<0>(received_data);
     auto& has_converged = get<1>(received_data);
 

--- a/src/Utilities/StaticCache.hpp
+++ b/src/Utilities/StaticCache.hpp
@@ -140,17 +140,15 @@ class StaticCache {
                                    Is + IndexOffset>>...}};
     // The array `cache` holds pointers to member functions, so we dereference
     // the pointer and invoke it on `this`.
-#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ > 10 && __GNUC__ < 13
+#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ > 10 && __GNUC__ < 14
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Warray-bounds"
-#endif  // defined(__GNUC__) && !defined(__clang__) && __GNUC__ > 10 && __GNUC__
-        // < 13
+#endif
     return (this->*gsl::at(cache, std::get<0>(parameter0) - IndexOffset))(
         parameters...);
-#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ > 10 && __GNUC__ < 13
+#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ > 10 && __GNUC__ < 14
 #pragma GCC diagnostic pop
-#endif  // defined(__GNUC__) && !defined(__clang__) && __GNUC__ > 10 && __GNUC__
-        // < 13
+#endif
   }
 
   template <typename... IntegralConstantValues, typename EnumType,
@@ -181,16 +179,14 @@ class StaticCache {
             std::integral_constant<EnumType, EnumValues>>...}};
     // The array `cache` holds pointers to member functions, so we dereference
     // the pointer and invoke it on `this`.
-#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ > 10 && __GNUC__ < 13
+#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ > 10 && __GNUC__ < 14
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Warray-bounds"
-#endif  // defined(__GNUC__) && !defined(__clang__) && __GNUC__ > 10 && __GNUC__
-        // < 13
+#endif
     return (this->*gsl::at(cache, array_location))(parameters...);
-#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ > 10 && __GNUC__ < 13
+#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ > 10 && __GNUC__ < 14
 #pragma GCC diagnostic pop
-#endif  // defined(__GNUC__) && !defined(__clang__) && __GNUC__ > 10 && __GNUC__
-        // < 13
+#endif
   }
 
   const Generator generator_;

--- a/tests/Unit/DataStructures/Test_Variables.cpp
+++ b/tests/Unit/DataStructures/Test_Variables.cpp
@@ -332,14 +332,14 @@ void test_variables_move() {
               non_owning_move_to)[0][0] == non_owning_data_from.data());
 
     // Intentionally testing self-move
-#ifdef __clang__
+#if defined(__clang__) or __GNUC__ >= 13
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wself-move"
-#endif  // defined(__clang__)
+#endif
     non_owning_move_to = std::move(non_owning_move_to);
-#ifdef __clang__
+#if defined(__clang__) or __GNUC__ >= 13
 #pragma GCC diagnostic pop
-#endif  // defined(__clang__)
+#endif
     // clang-tidy: false positive 'move_to' used after it was moved
     CHECK(non_owning_move_to ==  // NOLINT
           Vars{number_of_grid_points2, initial_fill_values[1]});
@@ -371,14 +371,14 @@ void test_variables_move() {
         move_to.data());
 
   // Intentionally testing self-move
-#ifdef __clang__
+#if defined(__clang__) or __GNUC__ >= 13
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wself-move"
-#endif  // defined(__clang__)
+#endif
   move_to = std::move(move_to);
-#ifdef __clang__
+#if defined(__clang__) or __GNUC__ >= 13
 #pragma GCC diagnostic pop
-#endif  // defined(__clang__)
+#endif
   // clang-tidy: false positive 'move_to' used after it was moved
   CHECK(move_to ==  // NOLINT
         Vars{number_of_grid_points2, initial_fill_values[1]});

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Test_InboxTags.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Test_InboxTags.cpp
@@ -147,7 +147,14 @@ void test_no_ghost_cells() {
   bm_inbox.erase(time_step_id_b);
   CHECK(bc_inbox.count(time_step_id_b) == 0);
   CHECK(bm_inbox.count(time_step_id_b) == 0);
+#if defined(__GNUC__) and not defined(__clang__) and __GNUC__ >= 12 and __GNUC__ < 14
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
 }
+#if defined(__GNUC__) and not defined(__clang__) and __GNUC__ >= 12 and __GNUC__ < 14
+#pragma GCC diagnostic pop
+#endif
 
 template <size_t Dim>
 void test_with_ghost_cells() {

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/Test_Constant.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/Test_Constant.cpp
@@ -42,8 +42,8 @@ void test_constant_random(const DataType& used_for_size) {
               value);
 
   TestHelpers::gh::ConstraintDamping::check(
-      std::move(val_unique_ptr->get_clone()), "constant", used_for_size,
-      {{{-1.0, 1.0}}}, {"IgnoredFunctionOfTime"}, value);
+      val_unique_ptr->get_clone(), "constant", used_for_size, {{{-1.0, 1.0}}},
+      {"IgnoredFunctionOfTime"}, value);
 }
 }  // namespace
 

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/Test_GaussianPlusConstant.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/Test_GaussianPlusConstant.cpp
@@ -54,9 +54,9 @@ void test_gaussian_plus_constant_random(const DataType& used_for_size) {
           constant, amplitude, width, center);
 
   TestHelpers::gh::ConstraintDamping::check(
-      std::move(gauss_plus_const_unique_ptr->get_clone()),
-      "gaussian_plus_constant", used_for_size, {{{-1.0, 1.0}}},
-      {"IgnoredFunctionOfTime"}, constant, amplitude, width, center);
+      gauss_plus_const_unique_ptr->get_clone(), "gaussian_plus_constant",
+      used_for_size, {{{-1.0, 1.0}}}, {"IgnoredFunctionOfTime"}, constant,
+      amplitude, width, center);
 }
 }  // namespace
 

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/Test_TimeDependentTripleGaussian.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/Test_TimeDependentTripleGaussian.cpp
@@ -70,10 +70,10 @@ void test_triple_gaussian_random(const DataType& used_for_size) {
               center_2, amplitude_3, width_3, center_3);
 
   TestHelpers::gh::ConstraintDamping::check(
-      std::move(triple_gauss_unique_ptr->get_clone()),
-      "time_dependent_triple_gaussian", used_for_size, {{{-1.0, 1.0}}},
-      {function_of_time_for_scaling}, constant, amplitude_1, width_1, center_1,
-      amplitude_2, width_2, center_2, amplitude_3, width_3, center_3);
+      triple_gauss_unique_ptr->get_clone(), "time_dependent_triple_gaussian",
+      used_for_size, {{{-1.0, 1.0}}}, {function_of_time_for_scaling}, constant,
+      amplitude_1, width_1, center_1, amplitude_2, width_2, center_2,
+      amplitude_3, width_3, center_3);
 }
 }  // namespace
 

--- a/tests/Unit/NumericalAlgorithms/LinearSolver/Test_Gmres.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearSolver/Test_Gmres.cpp
@@ -5,11 +5,19 @@
 
 #include <cstddef>
 
+#if defined(__GNUC__) and not defined(__clang__) and __GNUC__ == 12
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+#include "Framework/TestCreation.hpp"
+#if defined(__GNUC__) and not defined(__clang__) and __GNUC__ == 12
+#pragma GCC diagnostic pop
+#endif
+
 #include "DataStructures/DataBox/Tag.hpp"
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/DynamicMatrix.hpp"
 #include "DataStructures/DynamicVector.hpp"
-#include "Framework/TestCreation.hpp"
 #include "Framework/TestHelpers.hpp"
 #include "Helpers/DataStructures/MakeWithRandomValues.hpp"
 #include "Helpers/NumericalAlgorithms/LinearSolver/TestHelpers.hpp"

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Schwarz/Test_SchwarzAlgorithm.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Schwarz/Test_SchwarzAlgorithm.cpp
@@ -72,9 +72,16 @@ blaze::DynamicVector<double> extend_subdomain_data(
     const size_t num_points_per_element, const size_t overlap_extent) {
   blaze::DynamicVector<double> extended_subdomain_data(
       num_elements * num_points_per_element, 0.);
+#if defined(__GNUC__) and not defined(__clang__) and __GNUC__ == 12
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wuse-after-free"
+#endif
   blaze::subvector(
       extended_subdomain_data, element_index * num_points_per_element,
       num_points_per_element) = get(get<Tag>(subdomain_data.element_data));
+#if defined(__GNUC__) and not defined(__clang__) and __GNUC__ == 12
+#pragma GCC diagnostic pop
+#endif
   for (const auto& [overlap_id, overlap_data] : subdomain_data.overlap_data) {
     const auto& direction = overlap_id.first;
     const auto direction_from_neighbor = direction.opposite();


### PR DESCRIPTION
At least on my machine, there is still a runtime test failure as described in #5145.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
