### PR TITLE
Add extend-connectivity to CLI

### DIFF
--- a/src/IO/H5/Python/CMakeLists.txt
+++ b/src/IO/H5/Python/CMakeLists.txt
@@ -15,6 +15,7 @@ spectre_python_add_module(
   PYTHON_FILES
   __init__.py
   DeleteSubfiles.py
+  ExtendConnectivityData.py
   ExtractDatFromH5.py
   ExtractInputSourceYamlFromH5.py
   IterElements.py

--- a/src/IO/H5/Python/ExtendConnectivityData.py
+++ b/src/IO/H5/Python/ExtendConnectivityData.py
@@ -1,0 +1,66 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import logging
+
+import click
+import rich
+
+import spectre.IO.H5 as spectre_h5
+
+
+@click.command(name="extend-connectivity")
+@click.argument(
+    "filename",
+    required=True,
+    type=click.Path(
+        exists=True,
+        file_okay=True,
+        dir_okay=False,
+        readable=True,
+        writable=True,
+    ),
+)
+@click.option(
+    "--subfile-name",
+    "-d",
+    required=True,
+    type=str,
+    help="subfile name of the volume file in the H5 file (omit file extension)",
+)
+def extend_connectivity_data_command(filename, subfile_name):
+    """Extend the connectivity inside a single HDF5 volume file.
+
+    This extended connectivity is for some SpECTRE evolution, in
+    order to fill in gaps between elements. Intended to be used as
+    a post-processing routine to improve the quality of
+    visualizations. Note: This does not work with subcell or AMR systems, and
+    the connectivity only extends *within* each block and not between them.
+    This only works for a single HDF5 volume file. If there are multiple
+    files, the combine-h5 executable must be run first. The extend-connectivity
+    command can then be run on the newly generated HDF5 file.
+    """
+    # Ensure that the format of the subfile is correct
+    if subfile_name.endswith(".vol"):
+        subfile_name = subfile_name[:-4]
+    if subfile_name[0] != "/":
+        subfile_name = "/" + subfile_name
+    # Read the h5 file and extract the volume file from it
+    h5_file = spectre_h5.H5File(filename, "r+")
+    vol_file = h5_file.get_vol(subfile_name)
+
+    observation_ids = vol_file.list_observation_ids()
+    dim = vol_file.get_dimension()
+
+    if dim == 1:
+        vol_file.extend_connectivity_data_1d(observation_ids)
+    elif dim == 2:
+        vol_file.extend_connectivity_data_2d(observation_ids)
+    elif dim == 3:
+        vol_file.extend_connectivity_data_3d(observation_ids)
+    else:
+        raise ValueError("Invalid Dimensionality")
+
+
+if __name__ == "__main__":
+    extend_connectivity_data_command(help_option_names=["-h", "--help"])

--- a/support/Python/__main__.py
+++ b/support/Python/__main__.py
@@ -22,6 +22,7 @@ class Cli(click.MultiCommand):
         return [
             "clean-output",
             "delete-subfiles",
+            "extend-connectivity",
             "extract-dat",
             "extract-input",
             "generate-xdmf",
@@ -47,6 +48,12 @@ class Cli(click.MultiCommand):
             from spectre.IO.H5.DeleteSubfiles import delete_subfiles_command
 
             return delete_subfiles_command
+        elif name == "extend-connectivity":
+            from spectre.IO.H5.ExtendConnectivityData import (
+                extend_connectivity_data_command,
+            )
+
+            return extend_connectivity_data_command
         elif name == "extract-dat":
             from spectre.IO.H5.ExtractDatFromH5 import extract_dat_command
 

--- a/tests/Unit/IO/H5/Python/CMakeLists.txt
+++ b/tests/Unit/IO/H5/Python/CMakeLists.txt
@@ -8,6 +8,12 @@ spectre_add_python_bindings_test(
   PyH5)
 
 spectre_add_python_bindings_test(
+  "Unit.IO.H5.Python.ExtendConnectivity"
+  Test_ExtendConnectivity.py
+  "unit;IO;H5;python"
+  PyH5)
+
+spectre_add_python_bindings_test(
   "Unit.IO.H5.Python.ExtractDatFromH5"
   Test_ExtractDatFromH5.py
   "unit;IO;H5;python"
@@ -25,3 +31,5 @@ spectre_add_python_bindings_test(
   Test_IterElements.py
   "unit;IO;H5;python"
   PyH5)
+
+

--- a/tests/Unit/IO/H5/Python/Test_ExtendConnectivity.py
+++ b/tests/Unit/IO/H5/Python/Test_ExtendConnectivity.py
@@ -1,0 +1,61 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import os
+import shutil
+import unittest
+
+from click.testing import CliRunner
+
+import spectre.IO.H5 as spectre_h5
+from spectre.Informer import unit_test_build_path, unit_test_src_path
+from spectre.IO.H5.ExtendConnectivityData import (
+    extend_connectivity_data_command,
+)
+
+
+class TestExtendConnectivity(unittest.TestCase):
+    def setUp(self):
+        self.test_dir = os.path.join(
+            unit_test_build_path(), "IO/H5/Python/ExtendConnectivityData"
+        )
+
+        self.filename = os.path.join(self.test_dir, "TestVolume.h5")
+        os.makedirs(self.test_dir, exist_ok=True)
+        shutil.copyfile(
+            os.path.join(
+                unit_test_src_path(), "Visualization/Python", "VolTestData0.h5"
+            ),
+            self.filename,
+        )
+
+    def tearDown(self):
+        shutil.rmtree(self.test_dir)
+
+    # Helper function to obtain the length of the connectivity in
+    # the volume data file.
+    def get_connectivity_length(self):
+        with spectre_h5.H5File(self.filename, "r") as open_h5_file:
+            volfile = open_h5_file.get_vol("/element_data")
+            obs_id = volfile.list_observation_ids()[0]
+            h5_connectivity = volfile.get_tensor_component(
+                obs_id, "connectivity"
+            ).data
+        return len(h5_connectivity)
+
+    def test_cli(self):
+        runner = CliRunner()
+        initial_connectivity = self.get_connectivity_length()
+        result = runner.invoke(
+            extend_connectivity_data_command,
+            [self.filename, "-d", "element_data.vol"],
+            catch_exceptions=False,
+        )
+        self.assertEqual(result.exit_code, 0, result.output)
+        final_connectivity = self.get_connectivity_length()
+
+        assert initial_connectivity <= final_connectivity
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Proposed changes

<!--
Added Python CLI functionality for Extend Connectivity along with a test case. The command to extend-connectivity can be given directly through the CLI. The command requires an input h5 filename and a subfile name to be passed as arguments. Then, it works on the connectivity data in the volume file, interpolating through the regions that have gaps.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
