### PR TITLE
Add grid anchors to domain creators

### DIFF
--- a/src/ControlSystem/Actions/Initialization.hpp
+++ b/src/ControlSystem/Actions/Initialization.hpp
@@ -27,7 +27,7 @@ struct get_center_tags;
 
 template <domain::ObjectLabel... Object>
 struct get_center_tags<domain::object_list<Object...>> {
-  using type = tmpl::list<domain::Tags::ExcisionCenter<Object>...>;
+  using type = tmpl::list<domain::Tags::ObjectCenter<Object>...>;
 };
 
 template <>
@@ -47,8 +47,8 @@ struct get_center_tags<domain::object_list<>> {
  *   - `control_system::Tags::WriteDataToDisk`
  *   - `control_system::Tags::ObserveCenters`
  *   - `control_system::Tags::Verbosity`
- *   - `domain::Tags::ExcisionCenter<domain::ObjectLabel::A>`
- *   - `domain::Tags::ExcisionCenter<domain::ObjectLabel::B>`
+ *   - `domain::Tags::ObjectCenter<domain::ObjectLabel::A>`
+ *   - `domain::Tags::ObjectCenter<domain::ObjectLabel::B>`
  *
  * DataBox:
  * - Uses: Nothing

--- a/src/ControlSystem/Tags/SystemTags.hpp
+++ b/src/ControlSystem/Tags/SystemTags.hpp
@@ -161,54 +161,12 @@ template <typename ControlSystem>
 struct ControlError : db::SimpleTag {
   using type = typename ControlSystem::control_error;
 
-  template <typename Metavariables>
   using option_tags =
-      tmpl::list<OptionTags::ControlSystemInputs<ControlSystem>,
-                 domain::OptionTags::DomainCreator<Metavariables::volume_dim>>;
-  static constexpr bool pass_metavariables = true;
+      tmpl::list<OptionTags::ControlSystemInputs<ControlSystem>>;
+  static constexpr bool pass_metavariables = false;
 
-  template <typename Metavariables>
   static type create_from_options(
-      const control_system::OptionHolder<ControlSystem>& option_holder,
-      const std::unique_ptr<::DomainCreator<Metavariables::volume_dim>>&
-          domain_creator) {
-    const auto domain = domain_creator->create_domain();
-    const auto& excision_spheres = domain.excision_spheres();
-
-    constexpr size_t expected_number_of_excisions =
-        type::expected_number_of_excisions;
-
-    const auto print_error =
-        [&excision_spheres](const std::string& excision_sphere_name) {
-          ERROR_NO_TRACE(
-              "The control error for the"
-              << pretty_type::name<type>()
-              << " control system expected there to be at least one excision "
-                 "sphere named '"
-              << excision_sphere_name
-              << "' in the domain, but there wasn't. The existing excision "
-                 "spheres are: "
-              << keys_of(excision_spheres)
-              << ". Check that the domain you have chosen has excision spheres "
-                 "implemented.");
-        };
-
-    if constexpr (expected_number_of_excisions == 1) {
-      if (excision_spheres.count("ExcisionSphereA") != 1 and
-          excision_spheres.count("ExcisionSphereB") != 1 and
-          excision_spheres.count("ExcisionSphere") != 1) {
-        print_error("ExcisionSphereA' or 'ExcisionSphereB' or 'ExcisionSphere");
-      }
-    }
-    if constexpr (expected_number_of_excisions == 2) {
-      if (excision_spheres.count("ExcisionSphereA") != 1) {
-        print_error("ExcisionSphereA");
-      }
-      if (excision_spheres.count("ExcisionSphereB") != 1) {
-        print_error("ExcisionSphereB");
-      }
-    }
-
+      const control_system::OptionHolder<ControlSystem>& option_holder) {
     return option_holder.control_error;
   }
 };

--- a/src/Domain/Creators/BinaryCompactObject.cpp
+++ b/src/Domain/Creators/BinaryCompactObject.cpp
@@ -202,6 +202,10 @@ BinaryCompactObject::BinaryCompactObject(
         "Cannot have periodic boundary conditions with a binary domain");
   }
 
+  // Create grid anchors
+  grid_anchors_ = bco::create_grid_anchors(std::array{x_coord_a_, 0.0, 0.0},
+                                           std::array{x_coord_b_, 0.0, 0.0});
+
   // Create block names and groups
   static std::array<std::string, 6> wedge_directions{
       "UpperZ", "LowerZ", "UpperY", "LowerY", "UpperX", "LowerX"};

--- a/src/Domain/Creators/BinaryCompactObject.hpp
+++ b/src/Domain/Creators/BinaryCompactObject.hpp
@@ -15,6 +15,7 @@
 #include <variant>
 #include <vector>
 
+#include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/BoundaryConditions/BoundaryCondition.hpp"
 #include "Domain/BoundaryConditions/GetBoundaryConditionsBase.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
@@ -100,6 +101,8 @@ namespace creators {
  *
  * - Object A is located to the right of the origin (along the positive x-axis)
  *   and Object B is located to the left of the origin.
+ * - This domain offers some grid anchors. See
+ *   `domain::creators::bco::create_grid_anchors` for which ones are offered.
  * - "Cutting plane" refers to the plane along which the domain divides into two
  *   hemispheres. The cutting plane always intersects the x-axis at the origin.
  * - The x-coordinate locations of the two objects should be chosen such that
@@ -478,6 +481,11 @@ class BinaryCompactObject : public DomainCreator<3> {
 
   Domain<3> create_domain() const override;
 
+  std::unordered_map<std::string, tnsr::I<double, 3, Frame::Grid>>
+  grid_anchors() const override {
+    return grid_anchors_;
+  }
+
   std::vector<DirectionMap<
       3, std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>>
   external_boundary_conditions() const override;
@@ -525,6 +533,8 @@ class BinaryCompactObject : public DomainCreator<3> {
   std::vector<std::string> block_names_{};
   std::unordered_map<std::string, std::unordered_set<std::string>>
       block_groups_{};
+  std::unordered_map<std::string, tnsr::I<double, 3, Frame::Grid>>
+      grid_anchors_{};
 
   // Variables to handle std::variant on Object A and B
   double x_coord_a_{};

--- a/src/Domain/Creators/BinaryCompactObjectHelpers.cpp
+++ b/src/Domain/Creators/BinaryCompactObjectHelpers.cpp
@@ -27,6 +27,19 @@
 #include "Utilities/Gsl.hpp"
 
 namespace domain::creators::bco {
+std::unordered_map<std::string, tnsr::I<double, 3, Frame::Grid>>
+create_grid_anchors(const std::array<double, 3>& center_a,
+                    const std::array<double, 3>& center_b) {
+  std::unordered_map<std::string, tnsr::I<double, 3, Frame::Grid>> result{};
+  result["Center" + get_output(ObjectLabel::A)] =
+      tnsr::I<double, 3, Frame::Grid>{center_a};
+  result["Center" + get_output(ObjectLabel::B)] =
+      tnsr::I<double, 3, Frame::Grid>{center_b};
+  result["Center"] = tnsr::I<double, 3, Frame::Grid>{std::array{0.0, 0.0, 0.0}};
+
+  return result;
+}
+
 TimeDependentMapOptions::TimeDependentMapOptions(
     double initial_time, ExpansionMapOptions expansion_map_options,
     std::array<double, 3> initial_angular_velocity,

--- a/src/Domain/Creators/BinaryCompactObjectHelpers.hpp
+++ b/src/Domain/Creators/BinaryCompactObjectHelpers.hpp
@@ -49,6 +49,21 @@ constexpr bool enable_time_dependent_maps_v =
     enable_time_dependent_maps<Metavariables>::value;
 
 /*!
+ * \brief Create a set of centers of objects for the binary domains.
+ *
+ * \details Will add the following centers to the set:
+ *
+ * - Center: The origin
+ * - CenterA: Center of object A
+ * - CenterB: Center of object B
+ *
+ * \return Object required by the DomainCreator%s
+ */
+std::unordered_map<std::string, tnsr::I<double, 3, Frame::Grid>>
+create_grid_anchors(const std::array<double, 3>& center_a,
+                    const std::array<double, 3>& center_b);
+
+/*!
  * \brief This holds all options related to the time dependent maps of the
  * binary compact object domains.
  *

--- a/src/Domain/Creators/CylindricalBinaryCompactObject.cpp
+++ b/src/Domain/Creators/CylindricalBinaryCompactObject.cpp
@@ -211,6 +211,9 @@ CylindricalBinaryCompactObject::CylindricalBinaryCompactObject(
            "future");
   }
 
+  // Create grid anchors
+  grid_anchors_ = bco::create_grid_anchors(center_A_, center_B_);
+
   // Create block names and groups
   auto add_filled_cylinder_name = [this](const std::string& prefix,
                                          const std::string& group_name) {

--- a/src/Domain/Creators/CylindricalBinaryCompactObject.hpp
+++ b/src/Domain/Creators/CylindricalBinaryCompactObject.hpp
@@ -12,6 +12,7 @@
 #include <variant>
 #include <vector>
 
+#include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/BoundaryConditions/BoundaryCondition.hpp"
 #include "Domain/BoundaryConditions/GetBoundaryConditionsBase.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
@@ -78,6 +79,9 @@ namespace domain::creators {
  * user must specify the center and radius of this surface for both
  * `ObjectA` and `ObjectB`, and the user must specify the outer boundary
  * radius.  The outer boundary is a sphere centered at the origin.
+ *
+ * This domain offers some grid anchors. See
+ * `domain::creators::bco::create_grid_anchors` for which ones are offered.
  *
  * Note that Figure 20 of \cite Buchman:2012dw illustrates additional
  * spherical shells inside the "EA" and "EB" blocks, and the caption
@@ -343,6 +347,11 @@ class CylindricalBinaryCompactObject : public DomainCreator<3> {
 
   Domain<3> create_domain() const override;
 
+  std::unordered_map<std::string, tnsr::I<double, 3, Frame::Grid>>
+  grid_anchors() const override {
+    return grid_anchors_;
+  }
+
   std::vector<DirectionMap<
       3, std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>>
   external_boundary_conditions() const override;
@@ -400,6 +409,8 @@ class CylindricalBinaryCompactObject : public DomainCreator<3> {
   std::vector<std::string> block_names_{};
   std::unordered_map<std::string, std::unordered_set<std::string>>
       block_groups_{};
+  std::unordered_map<std::string, tnsr::I<double, 3, Frame::Grid>>
+      grid_anchors_{};
   // FunctionsOfTime options
   std::optional<bco::TimeDependentMapOptions> time_dependent_options_{};
 };

--- a/src/Domain/Creators/DomainCreator.hpp
+++ b/src/Domain/Creators/DomainCreator.hpp
@@ -14,10 +14,14 @@
 #include <unordered_set>
 #include <vector>
 
+#include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
 #include "Domain/Structure/DirectionMap.hpp"
 
 /// \cond
+namespace Frame {
+struct Grid;
+}  // namespace Frame
 template <size_t>
 class Domain;
 namespace domain::BoundaryConditions {
@@ -46,6 +50,14 @@ class DomainCreator {
   virtual ~DomainCreator() = default;
 
   virtual Domain<VolumeDim> create_domain() const = 0;
+
+  /// A set of named coordinates in the grid frame, like the center of the
+  /// domain or the positions of specific objects in a domain
+  virtual std::unordered_map<std::string,
+                             tnsr::I<double, VolumeDim, Frame::Grid>>
+  grid_anchors() const {
+    return {};
+  }
 
   /// The set of external boundary condition for every block in the domain
   virtual std::vector<DirectionMap<

--- a/src/Domain/Creators/Sphere.cpp
+++ b/src/Domain/Creators/Sphere.cpp
@@ -149,6 +149,10 @@ Sphere::Sphere(
                 "which you can select different radial distributions.");
   }
 
+  // Create grid anchors
+  grid_anchors_["Center"] =
+      tnsr::I<double, 3, Frame::Grid>{std::array{0.0, 0.0, 0.0}};
+
   // Determine number of blocks
   num_blocks_per_shell_ =
       which_wedges_ == ShellWedges::All

--- a/src/Domain/Creators/Sphere.hpp
+++ b/src/Domain/Creators/Sphere.hpp
@@ -131,6 +131,8 @@ namespace domain::creators {
  * \image html WedgeOrientations.png "The orientation of each wedge in a cubed
  * sphere."
  *
+ * This domain creator offers one grid anchor "Center" at the origin.
+ *
  * #### Inner cube sphericity
  * The inner cube is a BulgedCube except if the inner cube sphericity is
  * exactly 0. Then an Equiangular or Affine map is used (depending on if it's
@@ -382,6 +384,11 @@ class Sphere : public DomainCreator<3> {
 
   Domain<3> create_domain() const override;
 
+  std::unordered_map<std::string, tnsr::I<double, 3, Frame::Grid>>
+  grid_anchors() const override {
+    return grid_anchors_;
+  }
+
   std::vector<DirectionMap<
       3, std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>>
   external_boundary_conditions() const override;
@@ -430,6 +437,8 @@ class Sphere : public DomainCreator<3> {
   std::vector<std::string> block_names_{};
   std::unordered_map<std::string, std::unordered_set<std::string>>
       block_groups_{};
+  std::unordered_map<std::string, tnsr::I<double, 3, Frame::Grid>>
+      grid_anchors_{};
 };
 
 }  // namespace domain::creators

--- a/src/Domain/Creators/Tags/ObjectCenter.cpp
+++ b/src/Domain/Creators/Tags/ObjectCenter.cpp
@@ -17,24 +17,24 @@
 
 namespace domain::Tags {
 template <ObjectLabel Label>
-tnsr::I<double, 3, Frame::Grid> ExcisionCenter<Label>::create_from_options(
+tnsr::I<double, 3, Frame::Grid> ObjectCenter<Label>::create_from_options(
     const std::unique_ptr<::DomainCreator<3>>& domain_creator) {
-  const auto domain = domain_creator->create_domain();
-  const std::string name = "ExcisionSphere"s + get_output(Label);
-  if (domain.excision_spheres().count(name) != 1) {
-    ERROR(name << " is not in the domains excision spheres but is needed to "
-                  "generate the ExcisionCenter<"
-               << Label << ">.");
+  const auto grid_anchors = domain_creator->grid_anchors();
+  const std::string name = "Center"s + get_output(Label);
+  if (grid_anchors.count(name) != 1) {
+    ERROR(
+        "'" << name
+            << "' is not in the domain creators grid anchors but is needed to "
+               "generate the ObjectCenter<"
+            << Label << ">.");
   }
 
-  return domain.excision_spheres().at(name).center();
+  return grid_anchors.at(name);
 }
 
 #define OBJECT(data) BOOST_PP_TUPLE_ELEM(0, data)
 
-#define INSTANTIATE(_, data)                  \
-  template struct ObjectCenter<OBJECT(data)>; \
-  template struct ExcisionCenter<OBJECT(data)>;
+#define INSTANTIATE(_, data) template struct ObjectCenter<OBJECT(data)>;
 
 GENERATE_INSTANTIATIONS(INSTANTIATE,
                         (ObjectLabel::A, ObjectLabel::B, ObjectLabel::None))

--- a/src/Domain/Creators/Tags/ObjectCenter.hpp
+++ b/src/Domain/Creators/Tags/ObjectCenter.hpp
@@ -22,25 +22,18 @@ struct Grid;
 /// \endcond
 
 namespace domain::Tags {
-/// \ingroup DataBoxTagsGroup
-/// \ingroup ComputationalDomainGroup
-/// Base tag to retrieve the grid frame centers of objects in the domain
-/// corresponding to the `ObjectLabel`.
+/*!
+ * \ingroup DataBoxTagsGroup
+ * \ingroup ComputationalDomainGroup
+ * \brief The grid frame center of the given object.
+ *
+ * \note Requires that the domain creator has a grid anchor with the name:
+ * "Center + get_output(Label)"
+ */
 template <ObjectLabel Label>
-struct ObjectCenter : db::BaseTag {};
-
-/// \ingroup DataBoxTagsGroup
-/// \ingroup ComputationalDomainGroup
-/// The grid frame center of the excision sphere for the given object.
-///
-/// Even though this can easily be retrieved from the domain, we add it as its
-/// own tag so we can access it through the base tag. This way, other things
-/// (like the control system) can grab the center and be agnostic to what the
-/// object actually is.
-template <ObjectLabel Label>
-struct ExcisionCenter : ObjectCenter<Label>, db::SimpleTag {
+struct ObjectCenter : db::SimpleTag {
   using type = tnsr::I<double, 3, Frame::Grid>;
-  static std::string name() { return "CenterObject" + get_output(Label); }
+  static std::string name() { return "ObjectCenter" + get_output(Label); }
 
   using option_tags = tmpl::list<domain::OptionTags::DomainCreator<3>>;
   static constexpr bool pass_metavariables = false;

--- a/tests/Unit/ControlSystem/Test_Tags.cpp
+++ b/tests/Unit/ControlSystem/Test_Tags.cpp
@@ -228,22 +228,9 @@ void test_individual_tags() {
   // We're only checking for errors here, so the fact that it doesn't error is
   // enough of a check. We test errors below.
   [[maybe_unused]] const control_error_tag::type created_control_error =
-      control_error_tag::create_from_options<MetavarsEmpty>(holder, creator);
+      control_error_tag::create_from_options(holder);
   [[maybe_unused]] const control_error_tag2::type created_control_error2 =
-      control_error_tag2::create_from_options<MetavarsEmpty>(holder2, creator);
-
-  const std::unique_ptr<DomainCreator<3>> creator_error_0 =
-      std::make_unique<FakeCreator>(std::unordered_map<std::string, size_t>{},
-                                    0);
-
-  CHECK_THROWS_WITH(
-      control_error_tag::create_from_options<MetavarsEmpty>(holder,
-                                                            creator_error_0),
-      Catch::Contains(
-          "ExcisionSphereA' or 'ExcisionSphereB' or 'ExcisionSphere"));
-  CHECK_THROWS_WITH(control_error_tag2::create_from_options<MetavarsEmpty>(
-                        holder2, creator_empty),
-                    Catch::Contains("'ExcisionSphereB'"));
+      control_error_tag2::create_from_options(holder2);
 
   using controller_tag = control_system::Tags::Controller<system>;
 

--- a/tests/Unit/Domain/Creators/Test_AlignedLattice.cpp
+++ b/tests/Unit/Domain/Creators/Test_AlignedLattice.cpp
@@ -89,6 +89,7 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.AlignedLattice", "[Domain][Unit]") {
             domain_creator_1d.get());
     TestHelpers::domain::creators::test_domain_creator(
         *aligned_blocks_creator_1d, use_boundary_condition);
+    CHECK(domain_creator_1d->grid_anchors().empty());
 
     const auto domain_creator_2d = make_domain_creator<2>(
         "AlignedLattice:\n"

--- a/tests/Unit/Domain/Creators/Test_BinaryCompactObjectHelpers.cpp
+++ b/tests/Unit/Domain/Creators/Test_BinaryCompactObjectHelpers.cpp
@@ -150,6 +150,15 @@ void test() {
       std::array{5.0, 0.01, 0.02}, std::array{-5.0, -0.01, -0.02}};
   const double domain_outer_radius = 20.0;
 
+  const auto anchors = create_grid_anchors(centers[0], centers[1]);
+  CHECK(anchors.count("Center") == 1);
+  CHECK(anchors.count("CenterA") == 1);
+  CHECK(anchors.count("CenterB") == 1);
+  CHECK(anchors.at("Center") ==
+        tnsr::I<double, 3, Frame::Grid>(std::array{0.0, 0.0, 0.0}));
+  CHECK(anchors.at("CenterA") == tnsr::I<double, 3, Frame::Grid>(centers[0]));
+  CHECK(anchors.at("CenterB") == tnsr::I<double, 3, Frame::Grid>(centers[1]));
+
   for (const auto& [excise_A, excise_B] :
        cartesian_product(make_array(true, false), make_array(true, false))) {
     std::optional<double> inner_radius_A{};

--- a/tests/Unit/Domain/Creators/Test_Brick.cpp
+++ b/tests/Unit/Domain/Creators/Test_Brick.cpp
@@ -66,6 +66,7 @@ void test_brick_construction(
         {}) {
   const auto domain = TestHelpers::domain::creators::test_domain_creator(
       brick, expect_boundary_conditions);
+  CHECK(brick.grid_anchors().empty());
 
   CHECK(brick.initial_extents() == expected_extents);
   CHECK(brick.initial_refinement_levels() == expected_refinement_level);

--- a/tests/Unit/Domain/Creators/Test_Cylinder.cpp
+++ b/tests/Unit/Domain/Creators/Test_Cylinder.cpp
@@ -93,6 +93,7 @@ void test_cylinder_construction(
     const bool expect_boundary_conditions = false) {
   const auto domain = TestHelpers::domain::creators::test_domain_creator(
       cylinder, expect_boundary_conditions, is_periodic_in_z);
+  CHECK(cylinder.grid_anchors().empty());
 
   const OrientationMap<3> aligned_orientation{};
   const OrientationMap<3> quarter_turn_ccw(std::array<Direction<3>, 3>{

--- a/tests/Unit/Domain/Creators/Test_Disk.cpp
+++ b/tests/Unit/Domain/Creators/Test_Disk.cpp
@@ -47,6 +47,7 @@ void test_disk_construction(
     const bool expect_boundary_conditions = false) {
   const auto domain = TestHelpers::domain::creators::test_domain_creator(
       disk, expect_boundary_conditions);
+  CHECK(disk.grid_anchors().empty());
 
   const OrientationMap<2> aligned_orientation{};
   const OrientationMap<2> quarter_turn_ccw(std::array<Direction<2>, 2>{

--- a/tests/Unit/Domain/Creators/Test_FrustalCloak.cpp
+++ b/tests/Unit/Domain/Creators/Test_FrustalCloak.cpp
@@ -100,6 +100,7 @@ void test_connectivity() {
         with_boundary_conditions ? create_boundary_condition() : nullptr};
     TestHelpers::domain::creators::test_domain_creator(
         frustal_cloak, with_boundary_conditions);
+    CHECK(frustal_cloak.grid_anchors().empty());
   }
 
   CHECK_THROWS_WITH(

--- a/tests/Unit/Domain/Creators/Test_Interval.cpp
+++ b/tests/Unit/Domain/Creators/Test_Interval.cpp
@@ -41,6 +41,7 @@ void test_interval_construction(const creators::Interval& domain_creator,
       domain_creator, expect_boundary_conditions, is_periodic, times);
   TestHelpers::domain::BoundaryConditions::test_boundary_conditions(
       domain_creator.external_boundary_conditions());
+  CHECK(domain_creator.grid_anchors().empty());
 
   // Interval-specific tests
   CHECK(domain.block_groups().empty());

--- a/tests/Unit/Domain/Creators/Test_Rectangle.cpp
+++ b/tests/Unit/Domain/Creators/Test_Rectangle.cpp
@@ -67,6 +67,7 @@ void test_rectangle_construction(
         {}) {
   const auto domain = TestHelpers::domain::creators::test_domain_creator(
       rectangle, expect_boundary_conditions);
+  CHECK(rectangle.grid_anchors().empty());
 
   CHECK(rectangle.initial_extents() == expected_extents);
   CHECK(rectangle.initial_refinement_levels() == expected_refinement_level);

--- a/tests/Unit/Domain/Creators/Test_RotatedBricks.cpp
+++ b/tests/Unit/Domain/Creators/Test_RotatedBricks.cpp
@@ -56,6 +56,7 @@ void test_rotated_bricks_construction(
     const bool is_periodic = false) {
   const auto domain = TestHelpers::domain::creators::test_domain_creator(
       rotated_bricks, expect_boundary_conditions, is_periodic);
+  CHECK(rotated_bricks.grid_anchors().empty());
 
   CHECK(rotated_bricks.initial_extents() == expected_extents);
   CHECK(rotated_bricks.initial_refinement_levels() ==

--- a/tests/Unit/Domain/Creators/Test_RotatedIntervals.cpp
+++ b/tests/Unit/Domain/Creators/Test_RotatedIntervals.cpp
@@ -62,6 +62,7 @@ void test_rotated_intervals_construction(
   const std::vector<double> times{1.};
   const auto domain = TestHelpers::domain::creators::test_domain_creator(
       rotated_intervals, expect_boundary_conditions, is_periodic, times);
+  CHECK(rotated_intervals.grid_anchors().empty());
 
   CHECK(rotated_intervals.initial_extents() == expected_extents);
   CHECK(rotated_intervals.initial_refinement_levels() ==

--- a/tests/Unit/Domain/Creators/Test_RotatedRectangles.cpp
+++ b/tests/Unit/Domain/Creators/Test_RotatedRectangles.cpp
@@ -49,6 +49,7 @@ void test_rotated_rectangles_construction(
     const bool is_periodic = false) {
   const auto domain = TestHelpers::domain::creators::test_domain_creator(
       rotated_rectangles, expect_boundary_conditions, is_periodic);
+  CHECK(rotated_rectangles.grid_anchors().empty());
 
   CHECK(rotated_rectangles.initial_extents() == expected_extents);
   CHECK(rotated_rectangles.initial_refinement_levels() ==

--- a/tests/Unit/Domain/Creators/Test_Sphere.cpp
+++ b/tests/Unit/Domain/Creators/Test_Sphere.cpp
@@ -244,6 +244,11 @@ void test_sphere_construction(
   // check consistency of domain
   const auto domain = TestHelpers::domain::creators::test_domain_creator(
       sphere, expect_boundary_conditions, false, times);
+  const auto& grid_anchors = sphere.grid_anchors();
+  CHECK(grid_anchors.size() == 1);
+  CHECK(grid_anchors.count("Center") == 1);
+  CHECK(grid_anchors.at("Center") ==
+        tnsr::I<double, 3, Frame::Grid>{std::array{0.0, 0.0, 0.0}});
 
   const auto& blocks = domain.blocks();
   const auto block_names = sphere.block_names();

--- a/tests/Unit/Domain/Creators/Test_Tags.cpp
+++ b/tests/Unit/Domain/Creators/Test_Tags.cpp
@@ -33,14 +33,10 @@ void test_simple_tags() {
 }
 
 void test_center_tags() {
-  TestHelpers::db::test_base_tag<Tags::ObjectCenter<ObjectLabel::A>>(
-      "ObjectCenter");
-  TestHelpers::db::test_base_tag<Tags::ObjectCenter<ObjectLabel::B>>(
-      "ObjectCenter");
-  TestHelpers::db::test_simple_tag<Tags::ExcisionCenter<ObjectLabel::A>>(
-      "CenterObjectA");
-  TestHelpers::db::test_simple_tag<Tags::ExcisionCenter<ObjectLabel::B>>(
-      "CenterObjectB");
+  TestHelpers::db::test_simple_tag<Tags::ObjectCenter<ObjectLabel::A>>(
+      "ObjectCenterA");
+  TestHelpers::db::test_simple_tag<Tags::ObjectCenter<ObjectLabel::B>>(
+      "ObjectCenterB");
 
   using Object = domain::creators::BinaryCompactObject::Object;
 
@@ -50,9 +46,9 @@ void test_center_tags() {
           100.0, 500.0, 1_st, 5_st);
 
   const auto grid_center_A =
-      Tags::ExcisionCenter<ObjectLabel::A>::create_from_options(domain_creator);
+      Tags::ObjectCenter<ObjectLabel::A>::create_from_options(domain_creator);
   const auto grid_center_B =
-      Tags::ExcisionCenter<ObjectLabel::B>::create_from_options(domain_creator);
+      Tags::ObjectCenter<ObjectLabel::B>::create_from_options(domain_creator);
 
   CHECK(grid_center_A == tnsr::I<double, 3, Frame::Grid>{{8.0, 0.0, 0.0}});
   CHECK(grid_center_B == tnsr::I<double, 3, Frame::Grid>{{-5.5, 0.0, 0.0}});
@@ -64,10 +60,11 @@ void test_center_tags() {
           std::array{false, false, false});
 
   CHECK_THROWS_WITH(
-      Tags::ExcisionCenter<ObjectLabel::B>::create_from_options(
+      Tags::ObjectCenter<ObjectLabel::B>::create_from_options(
           creator_no_excision),
-      Catch::Contains(" is not in the domains excision spheres but is needed "
-                      "to generate the ExcisionCenter"));
+      Catch::Contains(
+          " is not in the domain creators grid anchors but is needed "
+          "to generate the ObjectCenter"));
 }
 
 template <bool Override>

--- a/tests/Unit/Helpers/ControlSystem/SystemHelpers.hpp
+++ b/tests/Unit/Helpers/ControlSystem/SystemHelpers.hpp
@@ -208,8 +208,8 @@ struct MockControlComponent {
       tmpl::list<control_system::Tags::MeasurementsPerUpdate,
                  control_system::Tags::WriteDataToDisk,
                  control_system::Tags::Verbosity,
-                 domain::Tags::ExcisionCenter<domain::ObjectLabel::A>,
-                 domain::Tags::ExcisionCenter<domain::ObjectLabel::B>>;
+                 domain::Tags::ObjectCenter<domain::ObjectLabel::A>,
+                 domain::Tags::ObjectCenter<domain::ObjectLabel::B>>;
 
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
       Parallel::Phase::Initialization,

--- a/tests/Unit/Helpers/Domain/Creators/TestHelpers.hpp
+++ b/tests/Unit/Helpers/Domain/Creators/TestHelpers.hpp
@@ -12,10 +12,12 @@
 #include <unordered_map>
 #include <utility>
 
+#include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/Creators/OptionTags.hpp"
 #include "Domain/Creators/RegisterDerivedWithCharm.hpp"
 #include "Domain/Creators/TimeDependence/RegisterDerivedWithCharm.hpp"
 #include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "Domain/Structure/ObjectLabel.hpp"
 #include "Framework/TestCreation.hpp"
 #include "Framework/TestHelpers.hpp"
 #include "Helpers/Domain/BoundaryConditions/BoundaryCondition.hpp"


### PR DESCRIPTION
## Proposed changes

For the control system, we need to know the centers of the objects. For BBHs, excisions sufficed to find the centers. However, for BNSs this clearly won't work. But we still need to know what the centers of the objects are in order for the control systems to work. The information about where the centers are is known to the domain creator). Thus, we add a new function to the `DomainCreator` base class called `grid_anchors` which gets a set of `tnsr::I<double, 3, Frame::Grid>` indexed by a string. These grid anchors are special points of the domain in the grid frame that won't move and are potentially needed by other parts of the code (e.g. control systems). They aren't restricted to be objects. They can be any point within the domain.

This also uses the `grid_anchors` to initialize the `ObjectCenters` tag, rather than using excision spheres like it did before. And we clean up a control system tag.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
