### PR TITLE
Add parameterized deleptonization, without entropy

### DIFF
--- a/docs/References.bib
+++ b/docs/References.bib
@@ -1420,6 +1420,21 @@ archivePrefix = {arXiv},
   year =         "2010"
 }
 
+@article{Liebendorfer2005,
+doi = {10.1086/466517},
+url = {https://dx.doi.org/10.1086/466517},
+year = {2005},
+month = {nov},
+publisher = {},
+volume = {633},
+number = {2},
+pages = {1042},
+author = {Matthias Liebendörfer},
+title = {A Simple Parameterization of the Consequences of Deleptonization
+ for Simulations of Stellar Core Collapse},
+journal = {The Astrophysical Journal}
+}
+
 @article{Lindblom1998dp,
   author         = "Lindblom, Lee",
   title          = "Phase transitions and the mass radius curves of

--- a/src/Evolution/VariableFixing/CMakeLists.txt
+++ b/src/Evolution/VariableFixing/CMakeLists.txt
@@ -10,6 +10,7 @@ spectre_target_sources(
   PRIVATE
   FixToAtmosphere.cpp
   LimitLorentzFactor.cpp
+  ParameterizedDeleptonization.cpp
   RadiallyFallingFloor.cpp
   )
 
@@ -20,6 +21,7 @@ spectre_target_headers(
   Actions.hpp
   FixToAtmosphere.hpp
   LimitLorentzFactor.hpp
+  ParameterizedDeleptonization.hpp
   RadiallyFallingFloor.hpp
   Tags.hpp
   )

--- a/src/Evolution/VariableFixing/ParameterizedDeleptonization.cpp
+++ b/src/Evolution/VariableFixing/ParameterizedDeleptonization.cpp
@@ -1,0 +1,182 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/VariableFixing/ParameterizedDeleptonization.hpp"
+
+#include <pup.h>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Options/ParseError.hpp"
+#include "PointwiseFunctions/Hydro/SpecificEnthalpy.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+
+namespace VariableFixing {
+
+ParameterizedDeleptonization::ParameterizedDeleptonization(
+    const bool enable, const double high_density_scale,
+    const double low_density_scale,
+    const double electron_fraction_at_high_density,
+    const double electron_fraction_at_low_density,
+    const double electron_fraction_correction_scale,
+    const Options::Context& context)
+    : enable_(enable),
+      high_density_scale_(high_density_scale),
+      low_density_scale_(low_density_scale),
+      electron_fraction_at_high_density_(electron_fraction_at_high_density),
+      electron_fraction_at_low_density_(electron_fraction_at_low_density),
+      electron_fraction_half_sum_(0.5 * (electron_fraction_at_high_density +
+                                         electron_fraction_at_low_density)),
+      electron_fraction_half_difference_(0.5 *
+                                         (electron_fraction_at_high_density -
+                                          electron_fraction_at_low_density)),
+      electron_fraction_correction_scale_(electron_fraction_correction_scale) {
+  if (high_density_scale_ < low_density_scale_) {
+    PARSE_ERROR(context, "The high density scale("
+                             << high_density_scale_
+                             << ") should be greater than the low"
+                                " density scale ("
+                             << low_density_scale_ << ')');
+  }
+  // high density material should have a lower Ye
+  if (electron_fraction_at_high_density_ > electron_fraction_at_low_density_) {
+    PARSE_ERROR(context, "The Ye at high density("
+                             << electron_fraction_at_high_density_
+                             << ") should be less than the Ye at low"
+                                " density ("
+                             << electron_fraction_at_low_density_ << ')');
+  }
+}
+
+// NOLINTNEXTLINE(google-runtime-references)
+void ParameterizedDeleptonization::pup(PUP::er& p) {
+  p | enable_;
+  p | high_density_scale_;
+  p | low_density_scale_;
+  p | electron_fraction_at_high_density_;
+  p | electron_fraction_at_low_density_;
+  p | electron_fraction_half_sum_;
+  p | electron_fraction_half_difference_;
+  p | electron_fraction_correction_scale_;
+}
+
+template <size_t ThermodynamicDim>
+void ParameterizedDeleptonization::operator()(
+    const gsl::not_null<Scalar<DataVector>*> specific_internal_energy,
+    const gsl::not_null<Scalar<DataVector>*> electron_fraction,
+    const gsl::not_null<Scalar<DataVector>*> pressure,
+    const gsl::not_null<Scalar<DataVector>*> specific_enthalpy,
+    const Scalar<DataVector>& rest_mass_density,
+    const EquationsOfState::EquationOfState<true, ThermodynamicDim>&
+        equation_of_state) const {
+  if (LIKELY(enable_)) {
+    for (size_t i = 0; i < rest_mass_density.get().size(); i++) {
+      correct_electron_fraction(specific_internal_energy, electron_fraction,
+                                pressure, specific_enthalpy, rest_mass_density,
+                                equation_of_state, i);
+    }
+  }
+}
+
+template <size_t ThermodynamicDim>
+void ParameterizedDeleptonization::correct_electron_fraction(
+    const gsl::not_null<Scalar<DataVector>*> specific_internal_energy,
+    const gsl::not_null<Scalar<DataVector>*> electron_fraction,
+    const gsl::not_null<Scalar<DataVector>*> pressure,
+    const gsl::not_null<Scalar<DataVector>*> specific_enthalpy,
+    const Scalar<DataVector>& rest_mass_density,
+    const EquationsOfState::EquationOfState<true, ThermodynamicDim>&
+        equation_of_state,
+    const size_t grid_index) const {
+  // calculate x
+  const auto x_of_rho = std::max(
+      -1.0,
+      std::min(1.0, (2.0 * std::log10(rest_mass_density.get()[grid_index]) -
+                     std::log10(high_density_scale_) -
+                     std::log10(low_density_scale_)) /
+                        (std::log10(high_density_scale_) -
+                         std::log10(low_density_scale_))));
+
+  // calculate ye_new
+  const auto electron_fraction_from_analytic =
+      electron_fraction_half_sum_ +
+      x_of_rho * electron_fraction_half_difference_ +
+      electron_fraction_correction_scale_ *
+          (1.0 - abs(x_of_rho) +
+           4.0 * abs(x_of_rho) * (abs(x_of_rho) - 0.5) * (abs(x_of_rho) - 1.0));
+
+  // Ye can only decrease with this prescription
+  if (electron_fraction_from_analytic < electron_fraction->get()[grid_index]) {
+    electron_fraction->get()[grid_index] = electron_fraction_from_analytic;
+  }
+
+  // call EoS (eventually Ye dependent tabulated eos here)
+  if constexpr (ThermodynamicDim == 1) {
+    pressure->get()[grid_index] = get(equation_of_state.pressure_from_density(
+        Scalar<double>{rest_mass_density.get()[grid_index]}));
+    specific_internal_energy->get()[grid_index] =
+        get(equation_of_state.specific_internal_energy_from_density(
+            Scalar<double>{rest_mass_density.get()[grid_index]}));
+  } else if constexpr (ThermodynamicDim == 2) {
+    pressure->get()[grid_index] =
+        get(equation_of_state.pressure_from_density_and_energy(
+            Scalar<double>{rest_mass_density.get()[grid_index]},
+            Scalar<double>{specific_internal_energy->get()[grid_index]}));
+  }
+  specific_enthalpy->get()[grid_index] =
+      get(hydro::relativistic_specific_enthalpy(
+          Scalar<double>{rest_mass_density.get()[grid_index]},
+          Scalar<double>{specific_internal_energy->get()[grid_index]},
+          Scalar<double>{pressure->get()[grid_index]}));
+}
+
+bool operator==(const ParameterizedDeleptonization& lhs,
+                const ParameterizedDeleptonization& rhs) {
+  return lhs.enable_ == rhs.enable_ and
+         lhs.high_density_scale_ == rhs.high_density_scale_ and
+         lhs.low_density_scale_ == rhs.low_density_scale_ and
+         lhs.electron_fraction_at_high_density_ ==
+             rhs.electron_fraction_at_high_density_ and
+         lhs.electron_fraction_at_low_density_ ==
+             rhs.electron_fraction_at_low_density_ and
+         lhs.electron_fraction_half_sum_ == rhs.electron_fraction_half_sum_ and
+         lhs.electron_fraction_half_difference_ ==
+             rhs.electron_fraction_half_difference_ and
+         lhs.electron_fraction_correction_scale_ ==
+             rhs.electron_fraction_correction_scale_;
+}
+
+bool operator!=(const ParameterizedDeleptonization& lhs,
+                const ParameterizedDeleptonization& rhs) {
+  return not(lhs == rhs);
+}
+
+#define THERMO_DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATION(r, data)                             \
+  template class ParameterizedDeleptonization;  \
+  template bool operator==(                                \
+      const ParameterizedDeleptonization& lhs,  \
+      const ParameterizedDeleptonization& rhs); \
+  template bool operator!=(                                \
+      const ParameterizedDeleptonization& lhs,  \
+      const ParameterizedDeleptonization& rhs);
+
+#undef INSTANTIATION
+
+#define INSTANTIATION(r, data)                                           \
+  template void ParameterizedDeleptonization::operator()(     \
+      const gsl::not_null<Scalar<DataVector>*> specific_internal_energy, \
+      const gsl::not_null<Scalar<DataVector>*> electron_fraction,        \
+      const gsl::not_null<Scalar<DataVector>*> pressure,                 \
+      const gsl::not_null<Scalar<DataVector>*> specific_enthalpy,        \
+      const Scalar<DataVector>& rest_mass_density,                       \
+      const EquationsOfState::EquationOfState<true, THERMO_DIM(data)>&   \
+          equation_of_state) const;
+
+GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2))
+
+#undef THERMO_DIM
+#undef INSTANTIATION
+
+}  // namespace VariableFixing

--- a/src/Evolution/VariableFixing/ParameterizedDeleptonization.hpp
+++ b/src/Evolution/VariableFixing/ParameterizedDeleptonization.hpp
@@ -1,0 +1,212 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <limits>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Options/Options.hpp"
+#include "Options/String.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
+#include "PointwiseFunctions/Hydro/TagsDeclarations.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+class DataVector;
+
+namespace PUP {
+class er;
+}  // namespace PUP
+/// \endcond
+
+namespace VariableFixing {
+
+/*!
+ * \ingroup VariableFixingGroup
+ * \brief Adjust the electron fraction (Ye) based on rest mass density (rho).
+ *
+ * Based on \cite Liebendorfer2005 spherically symmetric Boltzmann calculations,
+ * during the collapse phase just before a core-collapse supernova, the electron
+ * fraction naturally follows the rest mass density.  Intuitively, the higher
+ * the density, the more electrons are captured onto protons, leading to
+ * neutrino production.  As these neutrinos diffuse out of the center of the
+ * collapsing star, the total number of leptons near center of the CCSN
+ * drops---the process of deleptonization.
+ *
+ * https://iopscience.iop.org/article/10.1086/466517
+ */
+class ParameterizedDeleptonization {
+ public:
+  /// \brief Use an analytic expression vs rest mass density profile
+  ///
+  /// The option to choose between analytic and tabulated will be added in the
+  /// future.  If analytic is chosen (currently the only option), use the below
+  /// parameters.  If tabulated is chosen, a Ye (rho) profile will need to be
+  /// provided.
+  //   struct DeleptonizationFormat {
+  //     using type = double;
+  //     static type lower_bound() { return 0.0; }
+  //     static constexpr Options::String help = {"Choose an 'analytic' or
+  //     'tabulated' expression to express electron fraction as a function of
+  //     rest mass density."};
+  //   };
+
+  /// \brief Enable parameterized deleptonizations
+  struct Enable {
+    using type = bool;
+    static constexpr Options::String help = {
+        "Whether or not to activate parameterized deleptonization for "
+        "supernovae."};
+  };
+
+  /// \brief Density near the center of the supernova at bounce, above which
+  /// the central Ye is assumed
+  ///
+  /// In practice: rho(high) ~ 2x10^13 g / cm^3
+  struct HighDensityScale {
+    using type = double;
+    static type lower_bound() { return 0.0; }
+    static constexpr Options::String help = {
+        "High end of density scale for parameterized deleptonization."};
+  };
+  /// \brief Density near the Silicon-Oxygen interface, below which the lower
+  /// Ye is assumed
+  ///
+  /// In practice: rho(low) ~ 2x10^7 g / cm^3
+  struct LowDensityScale {
+    using type = double;
+    static type lower_bound() { return 0.0; }
+    static constexpr Options::String help = {
+        "Low end of density scale for parameterized deleptonization."};
+  };
+  /// \brief Electron fraction of material when the rest mass density is above
+  /// HighDensityScale
+  ///
+  /// In practice: Y_e (high density) ~ 0.28.
+  struct ElectronFractionAtHighDensity {
+    using type = double;
+    static type lower_bound() { return 0.0; }
+    static type upper_bound() { return 0.5; }
+    static constexpr Options::String help = {
+        "For densities above HighDensityScale, the electron fraction will "
+        "take this value."};
+  };
+  /// \brief Electron fraction of material when the rest mass density is below
+  /// LowDensityScale
+  ///
+  /// In practice: Y_e (low density) ~ 0.5
+  struct ElectronFractionAtLowDensity {
+    using type = double;
+    static type lower_bound() { return 0.0; }
+    static type upper_bound() { return 0.5; }
+    static constexpr Options::String help = {
+        "For densities below LowDensityScale, the electron fraction will "
+        "take this value."};
+  };
+
+  /// \brief Electron fraction correction term.  The larger this value, the
+  /// higher the Ye of matter at densities between LowDensityScale and
+  /// HighDensityScale.
+  ///
+  /// In practice: Y_e (correction) ~ 0.035
+  struct ElectronFractionCorrectionScale {
+    using type = double;
+    static type lower_bound() { return 0.0; }
+    static constexpr Options::String help = {
+        "For densities between low and high limits, a higher value of "
+        "ElectronFractionCorrectionScale will increase the value of Ye."};
+  };
+
+  using options =
+      tmpl::list<Enable, HighDensityScale, LowDensityScale,
+                 ElectronFractionAtHighDensity, ElectronFractionAtLowDensity,
+                 ElectronFractionCorrectionScale>;
+  static constexpr Options::String help = {
+      "Set electron fraction based on rest mass density.  "
+      "(Low/High)DensityScale sets the limits of the density, beyond which "
+      "the ElectronFractionAt(Low/High)Density is assumed.  At intermediate "
+      "densities, the higher the ElectronFractionCorrectionScale, the higher "
+      "the Ye."};
+
+  ParameterizedDeleptonization(bool enable, double high_density_scale,
+                               double low_density_scale,
+                               double electron_fraction_at_high_density,
+                               double electron_fraction_at_low_density,
+                               double electron_fraction_correction_scale,
+                               const Options::Context& context = {});
+
+  ParameterizedDeleptonization() = default;
+  ParameterizedDeleptonization(const ParameterizedDeleptonization& /*rhs*/) =
+      default;
+  ParameterizedDeleptonization& operator=(
+      const ParameterizedDeleptonization& /*rhs*/) = default;
+  ParameterizedDeleptonization(ParameterizedDeleptonization&& /*rhs*/) =
+      default;
+  ParameterizedDeleptonization& operator=(
+      ParameterizedDeleptonization&& /*rhs*/) = default;
+  ~ParameterizedDeleptonization() = default;
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& p);
+
+  // Quantities being mutated
+  using return_tags =
+      tmpl::list<hydro::Tags::SpecificInternalEnergy<DataVector>,
+                 hydro::Tags::ElectronFraction<DataVector>,
+                 hydro::Tags::Pressure<DataVector>,
+                 hydro::Tags::SpecificEnthalpy<DataVector>>;
+
+  // Things you want from DataBox that won't be change and are passed in as
+  // const-refs
+  using argument_tags = tmpl::list<hydro::Tags::RestMassDensity<DataVector>,
+                                   hydro::Tags::EquationOfStateBase>;
+
+  // for use in `db::mutate_apply`
+  template <size_t ThermodynamicDim>
+  void operator()(
+      gsl::not_null<Scalar<DataVector>*> specific_internal_energy,
+      gsl::not_null<Scalar<DataVector>*> electron_fraction,
+      gsl::not_null<Scalar<DataVector>*> pressure,
+      gsl::not_null<Scalar<DataVector>*> specific_enthalpy,
+      const Scalar<DataVector>& rest_mass_density,
+      const EquationsOfState::EquationOfState<true, ThermodynamicDim>&
+          equation_of_state) const;
+
+ private:
+  template <size_t ThermodynamicDim>
+  void correct_electron_fraction(
+      gsl::not_null<Scalar<DataVector>*> specific_internal_energy,
+      gsl::not_null<Scalar<DataVector>*> electron_fraction,
+      gsl::not_null<Scalar<DataVector>*> pressure,
+      gsl::not_null<Scalar<DataVector>*> specific_enthalpy,
+      const Scalar<DataVector>& rest_mass_density,
+      const EquationsOfState::EquationOfState<true, ThermodynamicDim>&
+          equation_of_state,
+      size_t grid_index) const;
+
+  // NOLINTNEXTLINE(readability-redundant-declaration)
+  friend bool operator==(const ParameterizedDeleptonization& lhs,
+                         const ParameterizedDeleptonization& rhs);
+
+  bool enable_{false};
+  double high_density_scale_{std::numeric_limits<double>::signaling_NaN()};
+  double low_density_scale_{std::numeric_limits<double>::signaling_NaN()};
+  double electron_fraction_at_high_density_{
+      std::numeric_limits<double>::signaling_NaN()};
+  double electron_fraction_at_low_density_{
+      std::numeric_limits<double>::signaling_NaN()};
+  double electron_fraction_half_sum_{
+      std::numeric_limits<double>::signaling_NaN()};
+  double electron_fraction_half_difference_{
+      std::numeric_limits<double>::signaling_NaN()};
+  double electron_fraction_correction_scale_{
+      std::numeric_limits<double>::signaling_NaN()};
+};
+bool operator!=(const ParameterizedDeleptonization& lhs,
+                const ParameterizedDeleptonization& rhs);
+
+}  // namespace VariableFixing

--- a/tests/Unit/Evolution/VariableFixing/CMakeLists.txt
+++ b/tests/Unit/Evolution/VariableFixing/CMakeLists.txt
@@ -7,6 +7,7 @@ set(LIBRARY_SOURCES
   Test_Actions.cpp
   Test_FixToAtmosphere.cpp
   Test_LimitLorentzFactor.cpp
+  Test_ParameterizedDeleptonization.cpp
   Test_RadiallyFallingFloor.cpp
   )
 

--- a/tests/Unit/Evolution/VariableFixing/Test_ParameterizedDeleptonization.cpp
+++ b/tests/Unit/Evolution/VariableFixing/Test_ParameterizedDeleptonization.cpp
@@ -1,0 +1,172 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Evolution/VariableFixing/ParameterizedDeleptonization.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/IdealFluid.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/PolytropicFluid.hpp"
+#include "PointwiseFunctions/Hydro/SpecificEnthalpy.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeWithValue.hpp"
+
+namespace {
+
+void test_variable_fixer(
+    const VariableFixing::ParameterizedDeleptonization& variable_fixer,
+    const EquationsOfState::EquationOfState<true, 1>& equation_of_state) {
+  // 8.0e-11 -> below cutoff (less dense/further out in the star), picks high Ye
+  // 1.5e-10 -> above cutoff (high dense/closer to star center), pick low Ye
+  // 3.0e-10 -> density transition regions, should be in between
+
+  const Scalar<DataVector> density{DataVector{0.8e-10, 1.5e-10, 3e-10}};
+  Scalar<DataVector> electron_fraction{DataVector{0.5, 0.5, 0.5}};
+  // These should remain unchanged, sinced param delep can only make Ye drop
+  Scalar<DataVector> electron_fraction_low{DataVector{0.1, 0.15, 0.2}};
+
+  auto pressure = equation_of_state.pressure_from_density(density);
+  auto specific_internal_energy =
+      equation_of_state.specific_internal_energy_from_density(density);
+  auto specific_enthalpy = hydro::relativistic_specific_enthalpy(
+      density, specific_internal_energy, pressure);
+
+  // check Ye values that will naturally decrease
+  variable_fixer(&specific_internal_energy, &electron_fraction, &pressure,
+                 &specific_enthalpy, density, equation_of_state);
+
+  const Scalar<DataVector> expected_electron_fraction{
+      DataVector{0.5, 0.40980370118030457, 0.285}};
+
+  CHECK_ITERABLE_APPROX(electron_fraction, expected_electron_fraction);
+
+  // check Ye values that will stay constant
+  const Scalar<DataVector> expected_electron_fraction_low{
+      electron_fraction_low};
+
+  variable_fixer(&specific_internal_energy, &electron_fraction_low, &pressure,
+                 &specific_enthalpy, density, equation_of_state);
+
+  CHECK_ITERABLE_APPROX(electron_fraction_low, expected_electron_fraction_low);
+}
+
+// 2D EoS version
+void test_variable_fixer(
+    const VariableFixing::ParameterizedDeleptonization& variable_fixer,
+    const EquationsOfState::EquationOfState<true, 2>& equation_of_state) {
+  const Scalar<DataVector> density{DataVector{3.0e-9, 3.7e-9, 4.0e-9}};
+  Scalar<DataVector> electron_fraction{DataVector{0.5, 0.5, 0.5}};
+  // These should remain unchanged, sinced param delep can only make Ye drop
+  Scalar<DataVector> electron_fraction_low{DataVector{0.1, 0.15, 0.2}};
+
+  Scalar<DataVector> specific_internal_energy{DataVector{1.0, 2.0, 3.0}};
+  auto pressure = equation_of_state.pressure_from_density_and_energy(
+      density, specific_internal_energy);
+  auto specific_enthalpy = hydro::relativistic_specific_enthalpy(
+      density, specific_internal_energy, pressure);
+
+  // check Ye values that will naturally decrease
+  variable_fixer(&specific_internal_energy, &electron_fraction, &pressure,
+                 &specific_enthalpy, density, equation_of_state);
+
+  const Scalar<DataVector> expected_electron_fraction{
+      DataVector{0.49, 0.3077746733472282, 0.2}};
+
+  CHECK_ITERABLE_APPROX(electron_fraction, expected_electron_fraction);
+
+  // check Ye values that will stay constant
+  const Scalar<DataVector> expected_electron_fraction_low{
+      electron_fraction_low};
+  variable_fixer(&specific_internal_energy, &electron_fraction_low, &pressure,
+                 &specific_enthalpy, density, equation_of_state);
+
+  CHECK_ITERABLE_APPROX(electron_fraction_low, expected_electron_fraction_low);
+}
+
+void test_variable_fixer() {
+  // Test for representative 1-d equation of state
+
+  const bool enable_param_delep = true;
+
+  const double hi_dens_cutoff = 2.0e-10;
+  const double lo_dens_cutoff = 1.0e-10;
+
+  const double ye_at_hi_dens = 0.285;
+  const double ye_at_lo_dens = 0.5;
+
+  const double ye_magnitude_scale = 0.035;
+
+  // high density scale, low density scale, Ye(hi dens), Ye(low dens), Ye
+  // correction scale
+  const VariableFixing::ParameterizedDeleptonization variable_fixer{
+      enable_param_delep, hi_dens_cutoff, lo_dens_cutoff,
+      ye_at_hi_dens,      ye_at_lo_dens,  ye_magnitude_scale};
+
+  const EquationsOfState::PolytropicFluid<true> polytrope{1.0, 2.0};
+
+  // catch error messages
+  CHECK_THROWS_WITH(([&hi_dens_cutoff, &lo_dens_cutoff, &ye_at_hi_dens,
+                      &ye_at_lo_dens, &ye_magnitude_scale]() {
+                      const VariableFixing::ParameterizedDeleptonization
+                          variable_fixer_dens_error{
+                              enable_param_delep,    hi_dens_cutoff,
+                              10.0 * lo_dens_cutoff, ye_at_hi_dens,
+                              ye_at_lo_dens,         ye_magnitude_scale};
+                    })(),
+                    Catch::Contains("The high density scale"));
+
+  CHECK_THROWS_WITH(([&hi_dens_cutoff, &lo_dens_cutoff, &ye_at_lo_dens,
+                      &ye_magnitude_scale]() {
+                      const VariableFixing::ParameterizedDeleptonization
+                          variable_fixer_dens_error{
+                              enable_param_delep, hi_dens_cutoff,
+                              lo_dens_cutoff,     10.0 * ye_at_lo_dens,
+                              ye_at_lo_dens,      ye_magnitude_scale};
+                    })(),
+                    Catch::Contains("The Ye at high density("));
+
+  // check expected values
+  test_variable_fixer(variable_fixer, polytrope);
+  test_serialization(variable_fixer);
+
+  {
+    INFO("Test 1D/barotropic EOS");
+    const auto fixer_from_options = TestHelpers::test_creation<
+        VariableFixing::ParameterizedDeleptonization>(
+        "Enable: true\n"
+        "HighDensityScale: 2.0e-10\n"
+        "LowDensityScale: 1.0e-10\n"
+        "ElectronFractionAtHighDensity: 0.285\n"
+        "ElectronFractionAtLowDensity: 0.5\n"
+        "ElectronFractionCorrectionScale: 0.035");
+
+    test_serialization(fixer_from_options);
+    test_variable_fixer(fixer_from_options, polytrope);
+  }
+
+  {
+    INFO("Test 2D EOS");
+    const auto fixer_from_options = TestHelpers::test_creation<
+        VariableFixing::ParameterizedDeleptonization>(
+        "Enable: true\n"
+        "HighDensityScale: 4.0e-9\n"
+        "LowDensityScale: 3.0e-9\n"
+        "ElectronFractionAtHighDensity: 0.2\n"
+        "ElectronFractionAtLowDensity: 0.49\n"
+        "ElectronFractionCorrectionScale: 0.05");
+
+    EquationsOfState::IdealFluid<true> ideal_fluid{5.0 / 3.0};
+    test_serialization(fixer_from_options);
+    test_variable_fixer(fixer_from_options, ideal_fluid);
+  }
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Evolution.VariableFixing.ParameterizedDeleptonization",
+                  "[VariableFixing][Unit]") {
+  test_variable_fixer();
+}


### PR DESCRIPTION
## Proposed changes

Allow electron fraction to evolve according to parameterized deleptonization scheme outlined in[ Liebendorfer 2005](https://iopscience.iop.org/article/10.1086/466517). 

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

~~For now, tracking how this behaves with simulation evolution will need to be verified by me before this is merged.~~
edit: The Ye tracks the density evolution as well. 

This is the first of a few changes, as it only applies to the fixed spacetime CCSN executable.  Further changes will involve expanding to the ghgrmhd system, explicitly conserving entropy, and finally hook in to the tabulated 3D EoS call.

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
