### PR TITLE
Add prefetch function

### DIFF
--- a/src/Utilities/System/CMakeLists.txt
+++ b/src/Utilities/System/CMakeLists.txt
@@ -10,6 +10,7 @@ spectre_target_sources(
   PRIVATE
   Abort.cpp
   ParallelInfo.cpp
+  Prefetch.cpp
   )
 
 spectre_target_headers(
@@ -19,6 +20,7 @@ spectre_target_headers(
   Abort.hpp
   Exit.hpp
   ParallelInfo.hpp
+  Prefetch.hpp
   )
 
 target_link_libraries(

--- a/src/Utilities/System/Prefetch.cpp
+++ b/src/Utilities/System/Prefetch.cpp
@@ -1,0 +1,28 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Utilities/System/Prefetch.hpp"
+
+#include <ostream>
+#include <stdexcept>
+
+namespace sys {
+std::ostream& operator<<(std::ostream& os, const PrefetchTo cache_location) {
+  switch (cache_location) {
+    case PrefetchTo::L1Cache:
+      return os << "L1Cache";
+    case PrefetchTo::L2Cache:
+      return os << "L2Cache";
+    case PrefetchTo::L3Cache:
+      return os << "L3Cache";
+    case PrefetchTo::NonTemporal:
+      return os << "NonTemporal";
+    case PrefetchTo::WriteL1Cache:
+      return os << "WriteL1Cache";
+    case PrefetchTo::WriteL2Cache:
+      return os << "WriteL2Cache";
+    default:
+      throw std::runtime_error("Unknown value of cache_location");
+  };
+}
+}  // namespace sys

--- a/src/Utilities/System/Prefetch.hpp
+++ b/src/Utilities/System/Prefetch.hpp
@@ -1,0 +1,48 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <iosfwd>
+
+namespace sys {
+/// The cache location to prefetch data to.
+enum class PrefetchTo : int {
+  /// Prefetch into L1 data cache
+  ///
+  /// Typically the fastest CPU cache, about 32 KB in size.
+  L1Cache = 3,
+  /// Prefetch into L2 data cache
+  ///
+  /// Typically the second fastest CPU cache, about 128 or 256 KB in size.
+  L2Cache = 2,
+  /// Prefetch into L3 data cache
+  ///
+  /// Typically the slowest CPU cache and is shared among multiple cores with
+  /// sizes varying by factors of several.
+  L3Cache = 1,
+  /// Non-temporal is an element that is unlikely to be re-used. E.g., read
+  /// once, written but never read.
+  NonTemporal = 0,
+  /// Prefetch to L1 data cache for writing
+  WriteL1Cache = 7,
+  /// Prefetch to L2 data cache for writing
+  WriteL2Cache = 6
+};
+
+/// \brief Prefetch data into a specific level of data cache.
+template <PrefetchTo CacheLocation>
+#if defined(__GNUC__)
+__attribute__((always_inline)) inline
+#endif
+void prefetch(const void* address_to_prefetch) {
+  // The enum values are bit flags where the lowest two bits (right-most)
+  // control the cache level and the 3rd bit controls whether it is a write-only
+  // or read-write operation.
+  __builtin_prefetch(address_to_prefetch,
+                     (static_cast<int>(CacheLocation) >> 2) & 1,
+                     static_cast<int>(CacheLocation) & 0x3);
+}
+
+std::ostream& operator<<(std::ostream& os, PrefetchTo cache_location);
+}  // namespace sys

--- a/tests/Unit/Utilities/CMakeLists.txt
+++ b/tests/Unit/Utilities/CMakeLists.txt
@@ -52,6 +52,7 @@ set(LIBRARY_SOURCES
 
 add_subdirectory(TypeTraits)
 add_subdirectory(Serialization)
+add_subdirectory(System)
 
 add_test_library(
   ${LIBRARY}

--- a/tests/Unit/Utilities/System/CMakeLists.txt
+++ b/tests/Unit/Utilities/System/CMakeLists.txt
@@ -1,0 +1,21 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBRARY "Test_SystemUtilities")
+
+set(LIBRARY_SOURCES
+  Test_Prefetch.cpp
+)
+
+add_test_library(
+  ${LIBRARY}
+  "Utilities/System"
+  "${LIBRARY_SOURCES}"
+  ""
+)
+
+target_link_libraries(
+  ${LIBRARY}
+  PRIVATE
+  SystemUtilities
+)

--- a/tests/Unit/Utilities/System/Test_Prefetch.cpp
+++ b/tests/Unit/Utilities/System/Test_Prefetch.cpp
@@ -1,0 +1,30 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <vector>
+
+#include "Utilities/GetOutput.hpp"
+#include "Utilities/System/Prefetch.hpp"
+
+SPECTRE_TEST_CASE("Unit.Utilities.System.Prefetch", "[Unit][Utilities]") {
+  // The goal of this test is just to make sure the code compiles and doesn't
+  // segfault.
+  std::vector<double> vector(20);
+  sys::prefetch<sys::PrefetchTo::L1Cache>(vector.data());
+  sys::prefetch<sys::PrefetchTo::L2Cache>(vector.data());
+  sys::prefetch<sys::PrefetchTo::L3Cache>(vector.data());
+
+  sys::prefetch<sys::PrefetchTo::NonTemporal>(vector.data());
+
+  sys::prefetch<sys::PrefetchTo::WriteL1Cache>(vector.data());
+  sys::prefetch<sys::PrefetchTo::WriteL2Cache>(vector.data());
+
+  CHECK(get_output(sys::PrefetchTo::L1Cache) == "L1Cache");
+  CHECK(get_output(sys::PrefetchTo::L2Cache) == "L2Cache");
+  CHECK(get_output(sys::PrefetchTo::L3Cache) == "L3Cache");
+  CHECK(get_output(sys::PrefetchTo::NonTemporal) == "NonTemporal");
+  CHECK(get_output(sys::PrefetchTo::WriteL1Cache) == "WriteL1Cache");
+  CHECK(get_output(sys::PrefetchTo::WriteL2Cache) == "WriteL2Cache");
+}


### PR DESCRIPTION
## Proposed changes

Wraps the compiler builtin prefetch function to make it more user-friendly.

Software prefetching reduced L1 dcache misses in Adams-Bashforth `update_u_common` from ~27% to ~3% on my machine. Since once we start using nodegroups we become completely dominated by cache misses and DRAM accesses, manual prefetching in pieces of the code that take up a lot of runtime will become increasingly important. The compiler builtin is rather ugly to use, so this gives it a more intuitive wrapper. From current profiling the places that using cache-blocking with prefetching will be critical are (in no particular order):
1. RHS (GH especially has like 70% cache misses)
2. time stepping work, both volume and boundary terms
3. boundary corrections
4. partial derivatives when applying the inverse Jacobian
5. transpose operations (SIMD sped this up a lot, but now there are still a lot of cache misses that prefetching could eliminate)

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
