### PR TITLE
Minor cleanups to CombineH5

### DIFF
--- a/src/Executables/CombineH5/CombineH5.cpp
+++ b/src/Executables/CombineH5/CombineH5.cpp
@@ -3,6 +3,7 @@
 
 #include <boost/program_options.hpp>
 #include <cstddef>
+#include <cstdlib>
 #include <iterator>
 #include <string>
 #include <vector>
@@ -15,11 +16,14 @@
 #include "IO/H5/VolumeData.hpp"
 #include "Parallel/Printf.hpp"
 #include "Utilities/FileSystem.hpp"
+#include "Utilities/MakeString.hpp"
+#include "Utilities/StdHelpers.hpp"
 
 // Charm looks for this function but since we build without a main function or
 // main module we just have it be empty
 extern "C" void CkRegisterMainModule(void) {}
 
+namespace {
 // Returns all the observation_ids stored in the volume files. Assumes all
 // volume files have the same observation ids
 std::vector<size_t> get_observation_ids(const std::string& file_prefix,
@@ -51,7 +55,9 @@ void combine_h5(const std::string& file_prefix, const std::string& subfile_name,
                 const std::string& output) {
   // Parses for and stores all input files to be looped over
   const std::vector<std::string>& file_names =
-      file_system::glob(file_prefix + "*.h5");
+      file_system::glob(file_prefix + "[0-9]*.h5");
+  Parallel::printf("Processing files:\n%s\n",
+                   std::string{MakeString{} << file_names}.c_str());
 
   // Checks that volume data was generated with identical versions of SpECTRE
   if (!h5::check_src_files_match(file_names)) {
@@ -72,6 +78,7 @@ void combine_h5(const std::string& file_prefix, const std::string& subfile_name,
   {
     // Instantiates the output file and the .vol subfile to be filled with the
     // combined data later
+    Parallel::printf("Creating output file: %s0.h5\n", output.c_str());
     h5::H5File<h5::AccessType::ReadWrite> new_file(output + "0.h5", true);
     new_file.insert<h5::VolumeData>("/" + subfile_name + ".vol");
     new_file.close_current_object();
@@ -82,7 +89,8 @@ void combine_h5(const std::string& file_prefix, const std::string& subfile_name,
       get_observation_ids(file_prefix, subfile_name);
 
   // Loops over observation ids to write volume data by observation id
-  for (const auto& obs_id : observation_ids) {
+  for (size_t obs_index = 0; obs_index < observation_ids.size(); ++obs_index) {
+    const size_t obs_id = observation_ids[obs_index];
     // Pre-calculates size of vector to store element data and allocates
     // corresponding memory
     const size_t vector_dim =
@@ -96,12 +104,21 @@ void combine_h5(const std::string& file_prefix, const std::string& subfile_name,
 
     // Loops over input files to append element data into a single vector to be
     // stored in a single H5
+    bool printed = false;
     for (auto const& file_name : file_names) {
       const h5::H5File<h5::AccessType::ReadOnly> original_file(file_name,
                                                                false);
       const auto& original_volume_file =
           original_file.get<h5::VolumeData>("/" + subfile_name);
       obs_val = original_volume_file.get_observation_value(obs_id);
+      if (not printed) {
+        Parallel::printf(
+            "Processing obsevation ID %lo (%lo/%lo) with value %1.14e\n",
+            obs_id, obs_index, observation_ids.size(), obs_val);
+        printed = true;
+      }
+      Parallel::printf("  Processing file: %s\n", file_name.c_str());
+
       serialized_domain = original_volume_file.get_domain(obs_id);
       serialized_functions_of_time =
           original_volume_file.get_functions_of_time(obs_id);
@@ -129,6 +146,7 @@ void combine_h5(const std::string& file_prefix, const std::string& subfile_name,
     new_file.close_current_object();
   }
 }
+}  // namespace
 
 /*
  * This executable is used for combining a series of HDF5 volume files into one


### PR DESCRIPTION
## Proposed changes

- Fixes a compiler warning about not using an anonymous namespace
- Adds some status printing info, which I found useful because otherwise for large datasets you just sit there hoping something is happening. @aasthabagree21 will rework this to be part of the CLI soon.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
