### PR TITLE
Add Radial Function to Translation Map

### DIFF
--- a/src/Domain/CoordinateMaps/CMakeLists.txt
+++ b/src/Domain/CoordinateMaps/CMakeLists.txt
@@ -92,6 +92,7 @@ target_link_libraries(
   ErrorHandling
   FunctionsOfTime
   GSL::gsl
+  MathFunctions
   RootFinding
   Serialization
   SphericalHarmonics

--- a/src/Domain/CoordinateMaps/TimeDependent/Translation.cpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/Translation.cpp
@@ -3,17 +3,24 @@
 
 #include "Domain/CoordinateMaps/TimeDependent/Translation.hpp"
 
+#include <cmath>
 #include <ostream>
 #include <pup.h>
 #include <pup_stl.h>
 #include <utility>
 
 #include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp"
 #include "DataStructures/Tensor/Identity.hpp"
 #include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "NumericalAlgorithms/RootFinding/RootBracketing.hpp"
+#include "NumericalAlgorithms/RootFinding/TOMS748.hpp"
+#include "PointwiseFunctions/MathFunctions/MathFunction.hpp"
+#include "Utilities/ContainerHelpers.hpp"
 #include "Utilities/DereferenceWrapper.hpp"
 #include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/MakeArray.hpp"
 #include "Utilities/MakeWithValue.hpp"
 #include "Utilities/StdArrayHelpers.hpp"
 #include "Utilities/StdHelpers.hpp"
@@ -22,7 +29,29 @@ namespace domain::CoordinateMaps::TimeDependent {
 
 template <size_t Dim>
 Translation<Dim>::Translation(std::string function_of_time_name)
-    : f_of_t_name_(std::move(function_of_time_name)) {}
+    : f_of_t_name_(std::move(function_of_time_name)),
+      f_of_r_(nullptr),
+      center_(make_array<Dim, double>(0.0)) {}
+
+template <size_t Dim>
+Translation<Dim>::Translation(
+    std::string function_of_time_name,
+    std::unique_ptr<MathFunction<1, Frame::Inertial>> radial_function,
+    std::array<double, Dim>& center)
+    : f_of_t_name_(std::move(function_of_time_name)),
+      f_of_r_(std::move(radial_function)),
+      center_(center) {}
+
+template <size_t Dim>
+Translation<Dim>::Translation(const Translation<Dim>& Translation_Map)
+    : f_of_t_name_(Translation_Map.f_of_t_name_),
+      center_(Translation_Map.center_) {
+  if (Translation_Map.f_of_r_ == nullptr) {
+    f_of_r_ = nullptr;
+  } else {
+    f_of_r_ = Translation_Map.f_of_r_->get_clone();
+  }
+}
 
 template <size_t Dim>
 template <typename T>
@@ -31,23 +60,7 @@ std::array<tt::remove_cvref_wrap_t<T>, Dim> Translation<Dim>::operator()(
     const std::unordered_map<
         std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
         functions_of_time) const {
-  ASSERT(functions_of_time.count(f_of_t_name_) == 1,
-         "The function of time '" << f_of_t_name_
-                                  << "' is not one of the known functions of "
-                                     "time. The known functions of time are: "
-                                  << keys_of(functions_of_time));
-  std::array<tt::remove_cvref_wrap_t<T>, Dim> result{};
-  const DataVector function_of_time =
-      functions_of_time.at(f_of_t_name_)->func(time)[0];
-  ASSERT(function_of_time.size() == Dim,
-         "The dimension of the function of time ("
-             << function_of_time.size()
-             << ") does not match the dimension of the translation map (" << Dim
-             << ").");
-  for (size_t i = 0; i < Dim; i++) {
-    gsl::at(result, i) = gsl::at(source_coords, i) + function_of_time[i];
-  }
-  return result;
+  return coord_helper(source_coords, time, functions_of_time, 0);
 }
 
 template <size_t Dim>
@@ -62,6 +75,9 @@ std::optional<std::array<double, Dim>> Translation<Dim>::inverse(
                                      "time. The known functions of time are: "
                                   << keys_of(functions_of_time));
   std::array<double, Dim> result{};
+  for (size_t i = 0; i < Dim; i++) {
+    gsl::at(result, i) = gsl::at(target_coords, i);
+  }
   const DataVector function_of_time =
       functions_of_time.at(f_of_t_name_)->func(time)[0];
   ASSERT(function_of_time.size() == Dim,
@@ -69,8 +85,23 @@ std::optional<std::array<double, Dim>> Translation<Dim>::inverse(
              << function_of_time.size()
              << ") does not match the dimension of the translation map (" << Dim
              << ").");
+  double radial_function_value = 1.0;
+  if (f_of_r_ != nullptr) {
+    std::array<double, Dim> distance_to_center = target_coords;
+    double root_factor = 0.;
+    for (size_t i = 0; i < Dim; i++) {
+      // shifted center
+      gsl::at(distance_to_center, i) -= gsl::at(center_, i);
+      // root_factor needed for root_finder
+      root_factor +=
+          -2.0 * gsl::at(distance_to_center, i) * function_of_time[i];
+    }
+    const double root = root_finder(magnitude(distance_to_center),
+                                    sqrNorm(function_of_time), root_factor);
+    radial_function_value = (*f_of_r_)(root);
+  }
   for (size_t i = 0; i < Dim; i++) {
-    gsl::at(result, i) = gsl::at(target_coords, i) - function_of_time[i];
+    gsl::at(result, i) -= function_of_time[i] * radial_function_value;
   }
   return result;
 }
@@ -82,44 +113,161 @@ std::array<tt::remove_cvref_wrap_t<T>, Dim> Translation<Dim>::frame_velocity(
     const std::unordered_map<
         std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
         functions_of_time) const {
+  return coord_helper(source_coords, time, functions_of_time, 1);
+}
+
+template <size_t Dim>
+template <typename T>
+tnsr::Ij<tt::remove_cvref_wrap_t<T>, Dim, Frame::NoFrame>
+Translation<Dim>::jacobian(
+    const std::array<T, Dim>& source_coords, const double time,
+    const std::unordered_map<
+        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+        functions_of_time) const {
+  if (f_of_r_ == nullptr) {
+    return identity<Dim>(dereference_wrapper(source_coords[0]));
+  } else {
+    std::array<tt::remove_cvref_wrap_t<T>, Dim> distance_to_center{};
+    for (size_t i = 0; i < Dim; i++) {
+      gsl::at(distance_to_center, i) =
+          gsl::at(source_coords, i) - gsl::at(center_, i);
+    }
+    auto radius = magnitude(distance_to_center);
+
+    const DataVector function_of_time =
+        functions_of_time.at(f_of_t_name_)->func(time)[0];
+
+    auto result = make_with_value<
+        tnsr::Ij<tt::remove_cvref_wrap_t<T>, Dim, Frame::NoFrame>>(
+        dereference_wrapper(source_coords[0]), 0.0);
+    for (size_t i = 0; i < Dim; i++) {
+      for (size_t j = 0; j < Dim; j++) {
+        for (size_t k = 0; k < get_size(radius); k++) {
+          if (get_element(radius, k) > 1.e-13) {
+            result.get(i, j) = (*f_of_r_).first_deriv(get_element(radius, k)) *
+                               gsl::at(function_of_time, i) *
+                               gsl::at(distance_to_center, j) /
+                               get_element(radius, k);
+          } else {
+            result.get(i, j) = (*f_of_r_).second_deriv(get_element(radius, k)) *
+                               gsl::at(function_of_time, i) *
+                               gsl::at(distance_to_center, j);
+          }
+        }
+      }
+      result.get(i, i) += 1.0;
+    }
+    return result;
+  }
+}
+template <size_t Dim>
+template <typename T>
+tnsr::Ij<tt::remove_cvref_wrap_t<T>, Dim, Frame::NoFrame>
+Translation<Dim>::inv_jacobian(
+    const std::array<T, Dim>& source_coords, const double time,
+    const std::unordered_map<
+        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+        functions_of_time) const {
+  if (f_of_r_ == nullptr) {
+    return identity<Dim>(dereference_wrapper(source_coords[0]));
+  } else {
+    return determinant_and_inverse(
+               jacobian(source_coords, time, functions_of_time))
+        .second;
+  }
+}
+
+template <size_t Dim>
+template <typename T>
+std::array<tt::remove_cvref_wrap_t<T>, Dim> Translation<Dim>::coord_helper(
+    const std::array<T, Dim>& source_coords, double time,
+    const std::unordered_map<
+        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+        functions_of_time,
+    const size_t function_or_deriv_index) const {
   ASSERT(functions_of_time.count(f_of_t_name_) == 1,
          "The function of time '" << f_of_t_name_
                                   << "' is not one of the known functions of "
                                      "time. The known functions of time are: "
                                   << keys_of(functions_of_time));
-  std::array<tt::remove_cvref_wrap_t<T>, Dim> result{};
-  const auto function_of_time_and_deriv =
-      functions_of_time.at(f_of_t_name_)->func_and_deriv(time);
-  const DataVector& velocity = function_of_time_and_deriv[1];
-  ASSERT(velocity.size() == Dim,
+  const auto func_or_deriv_of_time =
+      gsl::at(functions_of_time.at(f_of_t_name_)->func_and_deriv(time),
+              function_or_deriv_index);
+  ASSERT(func_or_deriv_of_time.size() == Dim,
          "The dimension of the function of time ("
-             << velocity.size()
+             << func_or_deriv_of_time.size()
              << ") does not match the dimension of the translation map (" << Dim
              << ").");
+  std::array<tt::remove_cvref_wrap_t<T>, Dim> result{};
+  // sizing the result and getting the radial function value
   for (size_t i = 0; i < Dim; i++) {
-    gsl::at(result, i) = make_with_value<tt::remove_cvref_wrap_t<T>>(
-        dereference_wrapper(gsl::at(source_coords, i)), velocity[i]);
+    gsl::at(result, i) = gsl::at(source_coords, i);
+  }
+  auto radial_function_value = make_with_value<tt::remove_cvref_wrap_t<T>>(
+      dereference_wrapper(source_coords[0]), 1.0);
+  if (f_of_r_ != nullptr) {
+    radial_function_value = (*f_of_r_)(magnitude(result - center_));
+  }
+  if (function_or_deriv_index == 1) {
+    for (size_t i = 0; i < Dim; i++) {
+      gsl::at(result, i) = 0.0;
+    }
+  }
+  for (size_t i = 0; i < Dim; i++) {
+    gsl::at(result, i) +=
+        gsl::at(func_or_deriv_of_time, i) * radial_function_value;
   }
   return result;
 }
 
 template <size_t Dim>
-template <typename T>
-tnsr::Ij<tt::remove_cvref_wrap_t<T>, Dim, Frame::NoFrame>
-Translation<Dim>::jacobian(const std::array<T, Dim>& source_coords) const {
-  return identity<Dim>(dereference_wrapper(source_coords[0]));
-}
-
-template <size_t Dim>
-template <typename T>
-tnsr::Ij<tt::remove_cvref_wrap_t<T>, Dim, Frame::NoFrame>
-Translation<Dim>::inv_jacobian(const std::array<T, Dim>& source_coords) const {
-  return identity<Dim>(dereference_wrapper(source_coords[0]));
+double Translation<Dim>::root_finder(const double target_radius,
+                                     const double squared_function_of_time,
+                                     const double root_factor) const {
+  const double center_offset = sqrt(squared_function_of_time);
+  // These bounds come from the SpEC implementation
+  double lower_bound = (target_radius - center_offset) * (1.0 - 1.e-9);
+  double upper_bound = (target_radius + center_offset) * (1.0 + 1.e-9);
+  if (lower_bound < 0.) {
+    lower_bound = 0.;
+  }
+  // If the upper and lower bounds are < 0., then there's no need to find a root
+  // the root will be 0.
+  if (upper_bound < 0.) {
+    return 0.;
+  }
+  double function_at_lower_bound = std::numeric_limits<double>::min();
+  double function_at_upper_bound = (*f_of_r_)(upper_bound);
+  // bracket function requires a function to return std::optionals
+  const auto radius_bracket_function =
+      [this, &target_radius, &squared_function_of_time,
+       &root_factor](const double x) -> std::optional<double> {
+    return square(target_radius) +
+           ((*f_of_r_)(x)) *
+               (root_factor + squared_function_of_time * (*f_of_r_)(x)) -
+           square(x);
+  };
+  RootFinder::bracket_possibly_undefined_function_in_interval(
+      &lower_bound, &upper_bound, &function_at_lower_bound,
+      &function_at_upper_bound, radius_bracket_function);
+  const double absolute_tol = std::numeric_limits<double>::epsilon() *
+                              std::max(target_radius, center_offset);
+  const double relative_tol = 2.0 * std::numeric_limits<double>::epsilon();
+  const auto wrapper = [this, &target_radius, &squared_function_of_time,
+                        &root_factor](const double x) {
+    return square(target_radius) +
+           ((*f_of_r_)(x)) *
+               (root_factor + squared_function_of_time * (*f_of_r_)(x)) -
+           square(x);
+  };
+  return RootFinder::toms748(wrapper, lower_bound, upper_bound,
+                             function_at_lower_bound, function_at_upper_bound,
+                             absolute_tol, relative_tol);
 }
 
 template <size_t Dim>
 void Translation<Dim>::pup(PUP::er& p) {
-  size_t version = 0;
+  size_t version = 1;
   p | version;
   // Remember to increment the version number when making changes to this
   // function. Retain support for unpacking data written by previous versions
@@ -127,11 +275,22 @@ void Translation<Dim>::pup(PUP::er& p) {
   if (version >= 0) {
     p | f_of_t_name_;
   }
+  if (version >= 1) {
+    p | f_of_r_;
+    p | center_;
+  } else if (p.isUnpacking()) {
+    f_of_r_ = nullptr;
+    center_ = make_array<Dim, double>(0.0);
+  }
 }
 
 template <size_t Dim>
 bool operator==(const Translation<Dim>& lhs, const Translation<Dim>& rhs) {
-  return lhs.f_of_t_name_ == rhs.f_of_t_name_;
+  return lhs.f_of_t_name_ == rhs.f_of_t_name_ and
+         (lhs.f_of_r_ == nullptr) == (rhs.f_of_r_ == nullptr) and
+         ((lhs.f_of_r_ == nullptr and rhs.f_of_r_ == nullptr) or
+          *lhs.f_of_r_ == *rhs.f_of_r_) and
+         lhs.center_ == rhs.center_;
 }
 
 // Explicit instantiations
@@ -148,31 +307,37 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
 
 #define DTYPE(data) BOOST_PP_TUPLE_ELEM(1, data)
 
-#define INSTANTIATE(_, data)                                           \
-  template std::array<tt::remove_cvref_wrap_t<DTYPE(data)>, DIM(data)> \
-  Translation<DIM(data)>::operator()(                                  \
-      const std::array<DTYPE(data), DIM(data)>& source_coords,         \
-      const double time,                                               \
-      const std::unordered_map<                                        \
-          std::string,                                                 \
-          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&   \
-          functions_of_time) const;                                    \
-  template std::array<tt::remove_cvref_wrap_t<DTYPE(data)>, DIM(data)> \
-  Translation<DIM(data)>::frame_velocity(                              \
-      const std::array<DTYPE(data), DIM(data)>& source_coords,         \
-      const double time,                                               \
-      const std::unordered_map<                                        \
-          std::string,                                                 \
-          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&   \
-          functions_of_time) const;                                    \
-  template tnsr::Ij<tt::remove_cvref_wrap_t<DTYPE(data)>, DIM(data),   \
-                    Frame::NoFrame>                                    \
-  Translation<DIM(data)>::jacobian(                                    \
-      const std::array<DTYPE(data), DIM(data)>& source_coords) const;  \
-  template tnsr::Ij<tt::remove_cvref_wrap_t<DTYPE(data)>, DIM(data),   \
-                    Frame::NoFrame>                                    \
-  Translation<DIM(data)>::inv_jacobian(                                \
-      const std::array<DTYPE(data), DIM(data)>& source_coords) const;
+#define INSTANTIATE(_, data)                                                \
+  template std::array<tt::remove_cvref_wrap_t<DTYPE(data)>, DIM(data)>      \
+  Translation<DIM(data)>::operator()(                                       \
+      const std::array<DTYPE(data), DIM(data)>& source_coords, double time, \
+      const std::unordered_map<                                             \
+          std::string,                                                      \
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&        \
+          functions_of_time) const;                                         \
+  template std::array<tt::remove_cvref_wrap_t<DTYPE(data)>, DIM(data)>      \
+  Translation<DIM(data)>::frame_velocity(                                   \
+      const std::array<DTYPE(data), DIM(data)>& source_coords, double time, \
+      const std::unordered_map<                                             \
+          std::string,                                                      \
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&        \
+          functions_of_time) const;                                         \
+  template tnsr::Ij<tt::remove_cvref_wrap_t<DTYPE(data)>, DIM(data),        \
+                    Frame::NoFrame>                                         \
+  Translation<DIM(data)>::jacobian(                                         \
+      const std::array<DTYPE(data), DIM(data)>& source_coords, double time, \
+      const std::unordered_map<                                             \
+          std::string,                                                      \
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&        \
+          functions_of_time) const;                                         \
+  template tnsr::Ij<tt::remove_cvref_wrap_t<DTYPE(data)>, DIM(data),        \
+                    Frame::NoFrame>                                         \
+  Translation<DIM(data)>::inv_jacobian(                                     \
+      const std::array<DTYPE(data), DIM(data)>& source_coords, double time, \
+      const std::unordered_map<                                             \
+          std::string,                                                      \
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&        \
+          functions_of_time) const;
 
 GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3),
                         (double, DataVector,

--- a/src/Domain/CoordinateMaps/TimeDependent/Translation.hpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/Translation.hpp
@@ -11,28 +11,91 @@
 #include <unordered_map>
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "PointwiseFunctions/MathFunctions/MathFunction.hpp"
 #include "Utilities/TypeTraits/RemoveReferenceWrapper.hpp"
 
 /// \cond
-namespace domain {
-namespace FunctionsOfTime {
+namespace domain::FunctionsOfTime {
 class FunctionOfTime;
-}  // namespace FunctionsOfTime
-}  // namespace domain
+}  // namespace domain::FunctionsOfTime
 namespace PUP {
 class er;
 }  // namespace PUP
 /// \endcond
 
-namespace domain {
-namespace CoordinateMaps {
-namespace TimeDependent {
+namespace domain::CoordinateMaps::TimeDependent {
 /*!
  * \ingroup CoordMapsTimeDependentGroup
- * \brief Translation map defined by \f$\vec{x} = \vec{\xi}+\vec{T}(t)\f$.
+ * \brief Translation map defined by \f$\vec{x} = \vec{\xi}+F(r)\vec{T}(t)\f$.
  *
- * The map adds a translation, \f$\vec{T}(t)\f$, to the coordinates
- * \f$\vec{\xi}\f$, where \f$\vec{T}(t)\f$ is a FunctionOfTime.
+ * \details The map adds a translation, \f$F(r)\vec{T}(t)\f$, to the coordinates
+ * \f$\vec{\xi}\f$, where \f$\vec{T}(t)\f$ is a FunctionOfTime and\f$F(r)\f$ is
+ * a 1D radial MathFunction. The radius of each point is found by subtracting
+ * the center map argument from the coordinates \f$\vec{\xi}\f$ or the target
+ * coordinates \f$\vec{\bar{\xi}}\f$. The Translation Map class is overloaded so
+ * that the user can choose if a radial depedence is needed for their problem.
+ * If a radial dependence is not specified, this sets \f$F(r) = 1\f$.
+ *
+ * ### Mapped Coordinates
+ *
+ * The translation map translates the coordinates \f$\vec{\xi}\f$ to the
+ * target coordinates
+ * \f{equation}{
+ * \vec{\bar{\xi}} = \vec{\xi} + F(r)\vec{T}(t)
+ * \f}
+ *
+ * If you only supply a FunctionOfTime to the constructor of this class, the
+ * radial function will be set to 1.0 causing a uniform translation for your
+ * coordinates. If a FunctionOfTime, MathFunction, and map center are passed in,
+ * the radius will be found through
+ * \f{equation}{
+ * r = |\vec{\xi} - \vec{c}|
+ * \f}
+ * where r is the radius and \f$\vec{c}\f$ is the center argument.
+ *
+ * ### Inverse Translation
+ * The inverse translation translates the coordinate \f$\vec{\bar{\xi}}\f$ to
+ * the original coordinates
+ * \f{equation}{
+ * \vec{\xi} = \vec{\bar{\xi}} - F(R)\vec{T}(t)
+ * \f}
+ * Where R is the root where \f$F(r)\f$ and \f$\vec{T}(t)\f$
+ * cross zero. This is done by bracketing and finding the root of
+ * \f{equation}{
+ * \bar{r}^2 + F(x) (A + |\vec{T}(t)| F(x)) - x^2
+ * \f}
+ * This equation comes from the SpEC implementation where \f$x\f$ is the root
+ * guess and \f$A\f$ is the Root Factor given by \f{equation}{ A = -2.0
+ * (\vec{\xi} - \vec{c}) \cdot \vec{T}(t) \f}
+ *
+ * ### Frame Velocity
+ *
+ * The frame velocity is given by
+ * \f{equation}{
+ * \vec{v} = \frac{\vec{dT}(t)}{dt} F(r)
+ * \f}
+ * where \f$\frac{\vec{dT}(t)}{dt}\f$ is the first derivative of the
+ * FunctionOfTime.
+ *
+ * ### Jacobian
+ * The jacobian is computed through either first or second derivatives of the
+ * radial MathFunction based on your radius. When the radius is bigger
+ * than 1.e-13, the jacobian is given by:
+ * \f{equation}{
+ * {J^{i}}_{j} = \frac{dF(r)}{dr} T(t)^i \frac{(\xi_j - c_j)}{r}
+ * \f}
+ * Where \f$\frac{dF(r)}{dr}\f$ is the first derivative of the MathFunction,
+ * \f$\vec{\xi_j}\f$ is the source coordinates, \f$\vec{c}\f$ is the center of
+ * your map, and r is the radius.
+ *
+ * At a radius smaller than 1e-13, we use L'Hopital's rule to compute the
+ * jacobian as
+ * \f{equation}{
+ * {J^{i}}_{j} = \frac{d^2F(r)}{dr^2} T(t)^i (\xi_j - c_j)
+ * \f}
+ *
+ * ### Inverse Jacobian
+ * The inverse jacobian is computed numerically by inverting the jacobian.
  */
 template <size_t Dim>
 class Translation {
@@ -41,6 +104,18 @@ class Translation {
 
   Translation() = default;
   explicit Translation(std::string function_of_time_name);
+
+  explicit Translation(
+      std::string function_of_time_name,
+      std::unique_ptr<MathFunction<1, Frame::Inertial>> radial_function,
+      std::array<double, Dim>& center);
+
+  Translation(const Translation<Dim>& Translation_Map);
+
+  ~Translation() = default;
+  Translation(Translation&&) = default;
+  Translation& operator=(Translation&&) = default;
+  Translation& operator=(const Translation& Translation_Map);
 
   template <typename T>
   std::array<tt::remove_cvref_wrap_t<T>, Dim> operator()(
@@ -71,11 +146,19 @@ class Translation {
 
   template <typename T>
   tnsr::Ij<tt::remove_cvref_wrap_t<T>, Dim, Frame::NoFrame> inv_jacobian(
-      const std::array<T, Dim>& source_coords) const;
+      const std::array<T, Dim>& source_coords, double time,
+      const std::unordered_map<
+          std::string,
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+          functions_of_time) const;
 
   template <typename T>
   tnsr::Ij<tt::remove_cvref_wrap_t<T>, Dim, Frame::NoFrame> jacobian(
-      const std::array<T, Dim>& source_coords) const;
+      const std::array<T, Dim>& source_coords, double time,
+      const std::unordered_map<
+          std::string,
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+          functions_of_time) const;
 
   // NOLINTNEXTLINE(google-runtime-references)
   void pup(PUP::er& p);
@@ -87,7 +170,24 @@ class Translation {
   friend bool operator==(  // NOLINT(readability-redundant-declaration)
       const Translation<LocalDim>& lhs, const Translation<LocalDim>& rhs);
 
+  // This helper function computes the translated coordinates or frame velocity
+  // based on the option passed in, 0 for translated coordinates, and frame
+  // velocity for any other number.
+  template <typename T>
+  std::array<tt::remove_cvref_wrap_t<T>, Dim> coord_helper(
+      const std::array<T, Dim>& source_coords, double time,
+      const std::unordered_map<
+          std::string,
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+          functions_of_time,
+      size_t function_or_deriv_index) const;
+
+  double root_finder(double target_radius, double squared_function_of_time,
+                     double root_factor) const;
+
   std::string f_of_t_name_{};
+  std::unique_ptr<MathFunction<1, Frame::Inertial>> f_of_r_{};
+  std::array<double, Dim> center_{};
 };
 
 template <size_t Dim>
@@ -96,6 +196,4 @@ inline bool operator!=(const Translation<Dim>& lhs,
   return not(lhs == rhs);
 }
 
-}  // namespace TimeDependent
-}  // namespace CoordinateMaps
-}  // namespace domain
+}  // namespace domain::CoordinateMaps::TimeDependent

--- a/src/PointwiseFunctions/MathFunctions/CMakeLists.txt
+++ b/src/PointwiseFunctions/MathFunctions/CMakeLists.txt
@@ -10,6 +10,7 @@ spectre_target_sources(
   PRIVATE
   Gaussian.cpp
   PowX.cpp
+  RegisterDerivedWithCharm.cpp
   Sinusoid.cpp
   TensorProduct.cpp
   )
@@ -22,6 +23,7 @@ spectre_target_headers(
   Gaussian.hpp
   MathFunction.hpp
   PowX.hpp
+  RegisterDerivedWithCharm.hpp
   Sinusoid.hpp
   TensorProduct.hpp
   )

--- a/src/PointwiseFunctions/MathFunctions/RegisterDerivedWithCharm.cpp
+++ b/src/PointwiseFunctions/MathFunctions/RegisterDerivedWithCharm.cpp
@@ -1,0 +1,18 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "PointwiseFunctions/MathFunctions/RegisterDerivedWithCharm.hpp"
+
+#include "PointwiseFunctions/MathFunctions/Gaussian.hpp"
+#include "PointwiseFunctions/MathFunctions/MathFunction.hpp"
+#include "PointwiseFunctions/MathFunctions/PowX.hpp"
+#include "PointwiseFunctions/MathFunctions/Sinusoid.hpp"
+#include "Utilities/Serialization/RegisterDerivedClassesWithCharm.hpp"
+
+namespace MathFunctions {
+void register_derived_with_charm() {
+  register_classes_with_charm<Gaussian<1, Frame::Inertial>,
+                              PowX<1, Frame::Inertial>,
+                              Sinusoid<1, Frame::Inertial>>();
+}
+}  // namespace MathFunctions

--- a/src/PointwiseFunctions/MathFunctions/RegisterDerivedWithCharm.hpp
+++ b/src/PointwiseFunctions/MathFunctions/RegisterDerivedWithCharm.hpp
@@ -1,0 +1,8 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+namespace MathFunctions {
+void register_derived_with_charm();
+}  // namespace MathFunctions

--- a/tests/Unit/Domain/CoordinateMaps/Test_CoordinateMap.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_CoordinateMap.cpp
@@ -1098,10 +1098,10 @@ void test_time_dependent_map() {
       make_coordinate_map<Frame::BlockLogical, Frame::Inertial>(affine_map,
                                                                 trans_map);
 
-  CHECK_FALSE(time_dependent_map_first.inv_jacobian_is_time_dependent());
-  CHECK_FALSE(time_dependent_map_first.jacobian_is_time_dependent());
-  CHECK_FALSE(time_dependent_map_second.inv_jacobian_is_time_dependent());
-  CHECK_FALSE(time_dependent_map_second.jacobian_is_time_dependent());
+  CHECK(time_dependent_map_first.inv_jacobian_is_time_dependent());
+  CHECK(time_dependent_map_first.jacobian_is_time_dependent());
+  CHECK(time_dependent_map_second.inv_jacobian_is_time_dependent());
+  CHECK(time_dependent_map_second.jacobian_is_time_dependent());
 
   const tnsr::I<double, 1, Frame::BlockLogical> tnsr_double_logical{{{3.2}}};
   const tnsr::I<DataVector, 1, Frame::BlockLogical> tnsr_datavector_logical{

--- a/tests/Unit/Domain/CoordinateMaps/TimeDependent/CMakeLists.txt
+++ b/tests/Unit/Domain/CoordinateMaps/TimeDependent/CMakeLists.txt
@@ -28,6 +28,7 @@ target_link_libraries(
   DataStructures
   Domain
   DataStructuresHelpers
+  MathFunctions
   FunctionsOfTime
   SphericalHarmonics
   Spectral


### PR DESCRIPTION
## Proposed changes

This pr adds a radial MathFunction to the Translation map that'll allow the outer boundary to remain fixed while the inner boundary translates with the compact objects. The constructor is overloaded to keep a uniform translation so that everywhere using the simple translation map doesn't break. There will be a followup pr to add translation map options into the EvolveGhBinaryBlackHole.hpp and the Binary yaml input files.

### Upgrade instructions


### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments


