### PR TITLE
Find streamable decls before static assert in stream_obj_to_stream

### DIFF
--- a/src/Parallel/Printf.hpp
+++ b/src/Parallel/Printf.hpp
@@ -43,11 +43,11 @@ template <typename T,
           Requires<std::is_class<std::decay_t<T>>::value or
                    std::is_enum<std::decay_t<T>>::value> = nullptr>
 inline std::string stream_object_to_string(T&& t) {
+  using ::operator<<;
   static_assert(tt::is_streamable<std::stringstream, T>::value,
                 "Cannot stream type and therefore it cannot be printed. Please "
                 "define a stream operator for the type.");
   std::stringstream ss;
-  using ::operator<<;
   ss << std::setprecision(std::numeric_limits<double>::digits10 + 4)
      << std::scientific << t;
   return ss.str();


### PR DESCRIPTION
## Proposed changes

This static assert has been causing me trouble lately not being able to find stream declarations we most definitely have (std::vector, std::optional). I'm pretty sure it's because the `using ::operator<<` was after the static assert, not before.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
