### PR TITLE
Add ComputeTags for observing electromagnetic variables in ForceFree system

### DIFF
--- a/src/Evolution/Executables/ForceFree/EvolveForceFree.hpp
+++ b/src/Evolution/Executables/ForceFree/EvolveForceFree.hpp
@@ -39,6 +39,7 @@
 #include "Evolution/Systems/ForceFree/BoundaryCorrections/Factory.hpp"
 #include "Evolution/Systems/ForceFree/BoundaryCorrections/RegisterDerived.hpp"
 #include "Evolution/Systems/ForceFree/ElectricCurrentDensity.hpp"
+#include "Evolution/Systems/ForceFree/ElectromagneticVariables.hpp"
 #include "Evolution/Systems/ForceFree/System.hpp"
 #include "Evolution/Systems/ForceFree/Tags.hpp"
 #include "IO/Observer/Actions/RegisterEvents.hpp"
@@ -127,7 +128,11 @@ struct EvolutionMetavars {
   using observe_fields = tmpl::push_back<
       tmpl::append<typename system::variables_tag::tags_list, error_tags>,
       domain::Tags::Coordinates<volume_dim, Frame::Grid>,
-      domain::Tags::Coordinates<volume_dim, Frame::Inertial>>;
+      domain::Tags::Coordinates<volume_dim, Frame::Inertial>,
+      ForceFree::Tags::ElectricFieldCompute,
+      ForceFree::Tags::MagneticFieldCompute,
+      ForceFree::Tags::ChargeDensityCompute,
+      ForceFree::Tags::ElectricCurrentDensityCompute>;
 
   using non_tensor_compute_tags =
       tmpl::list<::Events::Tags::ObserverMeshCompute<volume_dim>,

--- a/src/Evolution/Systems/ForceFree/CMakeLists.txt
+++ b/src/Evolution/Systems/ForceFree/CMakeLists.txt
@@ -10,6 +10,7 @@ spectre_target_sources(
   PRIVATE
   Characteristics.cpp
   ElectricCurrentDensity.cpp
+  ElectromagneticVariables.cpp
   Fluxes.cpp
   Sources.cpp
   TimeDerivativeTerms.cpp
@@ -22,6 +23,7 @@ spectre_target_headers(
   HEADERS
   Characteristics.hpp
   ElectricCurrentDensity.hpp
+  ElectromagneticVariables.hpp
   Fluxes.hpp
   Sources.hpp
   System.hpp

--- a/src/Evolution/Systems/ForceFree/ElectromagneticVariables.cpp
+++ b/src/Evolution/Systems/ForceFree/ElectromagneticVariables.cpp
@@ -1,0 +1,45 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/ForceFree/ElectromagneticVariables.hpp"
+
+#include <cstddef>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace ForceFree {
+
+void em_field_from_evolved_fields(
+    const gsl::not_null<tnsr::I<DataVector, 3>*> vector,
+    const tnsr::I<DataVector, 3>& densitized_vector,
+    const Scalar<DataVector>& sqrt_det_spatial_metric) {
+  get<0>(*vector) = get<0>(densitized_vector) / get(sqrt_det_spatial_metric);
+  get<1>(*vector) = get<1>(densitized_vector) / get(sqrt_det_spatial_metric);
+  get<2>(*vector) = get<2>(densitized_vector) / get(sqrt_det_spatial_metric);
+}
+
+void charge_density_from_tilde_q(
+    const gsl::not_null<Scalar<DataVector>*> charge_density,
+    const Scalar<DataVector>& tilde_q,
+    const Scalar<DataVector>& sqrt_det_spatial_metric) {
+  get(*charge_density) = get(tilde_q) / get(sqrt_det_spatial_metric);
+}
+
+void electric_current_density_from_tilde_j(
+    const gsl::not_null<tnsr::I<DataVector, 3>*> electric_current_density,
+    const tnsr::I<DataVector, 3>& tilde_j,
+    const Scalar<DataVector>& sqrt_det_spatial_metric,
+    const Scalar<DataVector>& lapse) {
+  em_field_from_evolved_fields(electric_current_density, tilde_j,
+                               sqrt_det_spatial_metric);
+  get<0>(*electric_current_density) =
+      get<0>(*electric_current_density) / get(lapse);
+  get<1>(*electric_current_density) =
+      get<1>(*electric_current_density) / get(lapse);
+  get<2>(*electric_current_density) =
+      get<2>(*electric_current_density) / get(lapse);
+}
+
+}  // namespace ForceFree

--- a/src/Evolution/Systems/ForceFree/ElectromagneticVariables.hpp
+++ b/src/Evolution/Systems/ForceFree/ElectromagneticVariables.hpp
@@ -1,0 +1,110 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Evolution/Systems/ForceFree/Tags.hpp"
+#include "PointwiseFunctions/GeneralRelativity/TagsDeclarations.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+class DataVector;
+namespace gsl {
+template <typename T>
+class not_null;
+}  // namespace gsl
+/// \endcond
+
+namespace ForceFree {
+
+/*!
+ * \brief Computes electric field $E^i$ from TildeE or magnetic field $B^i$ from
+ * TildeB.
+ */
+void em_field_from_evolved_fields(
+    const gsl::not_null<tnsr::I<DataVector, 3>*> vector,
+    const tnsr::I<DataVector, 3>& densitized_vector,
+    const Scalar<DataVector>& sqrt_det_spatial_metric);
+
+/*!
+ * \brief Computes electric charge density $q$ from TildeQ.
+ */
+void charge_density_from_tilde_q(
+    const gsl::not_null<Scalar<DataVector>*> charge_density,
+    const Scalar<DataVector>& tilde_q,
+    const Scalar<DataVector>& sqrt_det_spatial_metric);
+
+/*!
+ * \brief Computes electric current density $J^i$ from TildeJ.
+ */
+void electric_current_density_from_tilde_j(
+    const gsl::not_null<tnsr::I<DataVector, 3>*> electric_current_density,
+    const tnsr::I<DataVector, 3>& tilde_j,
+    const Scalar<DataVector>& sqrt_det_spatial_metric,
+    const Scalar<DataVector>& lapse);
+
+namespace Tags {
+/*!
+ * \brief Compute item for electric field $E^i$ from TildeE.
+ *
+ * \note This ComputeTag is solely for observation purpose, not related to
+ * actual time evolution.
+ */
+struct ElectricFieldCompute : ElectricField, db::ComputeTag {
+  using argument_tags =
+      tmpl::list<TildeE, gr::Tags::SqrtDetSpatialMetric<DataVector>>;
+  using return_type = tnsr::I<DataVector, 3>;
+  using base = ElectricField;
+
+  static constexpr auto function = &em_field_from_evolved_fields;
+};
+
+/*!
+ * \brief Compute item for magnetic field $B^i$ from TildeB.
+ *
+ * \note This ComputeTag is solely for observation purpose, not related to
+ * actual time evolution.
+ */
+struct MagneticFieldCompute : MagneticField, db::ComputeTag {
+  using argument_tags =
+      tmpl::list<TildeB, gr::Tags::SqrtDetSpatialMetric<DataVector>>;
+  using return_type = tnsr::I<DataVector, 3>;
+  using base = MagneticField;
+
+  static constexpr auto function = &em_field_from_evolved_fields;
+};
+
+/*!
+ * \brief Compute item for electric charge density $q$ from TildeQ.
+ *
+ * \note This ComputeTag is solely for observation purpose, not related to
+ * actual time evolution.
+ */
+struct ChargeDensityCompute : ChargeDensity, db::ComputeTag {
+  using argument_tags =
+      tmpl::list<TildeQ, gr::Tags::SqrtDetSpatialMetric<DataVector>>;
+  using return_type = Scalar<DataVector>;
+  using base = ChargeDensity;
+
+  static constexpr auto function = &charge_density_from_tilde_q;
+};
+
+/*!
+ * \brief Compute item for electric current density $J^i$ from TildeJ.
+ *
+ * \note This ComputeTag is solely for observation purpose, not related to
+ * actual time evolution.
+ */
+struct ElectricCurrentDensityCompute : ElectricCurrentDensity, db::ComputeTag {
+  using argument_tags = tmpl::list<TildeJ, gr::Tags::Lapse<DataVector>,
+                                   gr::Tags::SqrtDetSpatialMetric<DataVector>>;
+  using return_type = tnsr::I<DataVector, 3>;
+  using base = ElectricCurrentDensity;
+
+  static constexpr auto function = &electric_current_density_from_tilde_j;
+};
+
+}  // namespace Tags
+}  // namespace ForceFree

--- a/tests/Unit/Evolution/Systems/ForceFree/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/ForceFree/CMakeLists.txt
@@ -15,6 +15,7 @@ set(LIBRARY_SOURCES
   Subcell/Test_TciOnFdGrid.cpp
   Test_Characteristics.cpp
   Test_ElectricCurrentDensity.cpp
+  Test_ElectromagneticVariables.cpp
   Test_Fluxes.cpp
   Test_Sources.cpp
   Test_Tags.cpp

--- a/tests/Unit/Evolution/Systems/ForceFree/TestFunctions.py
+++ b/tests/Unit/Evolution/Systems/ForceFree/TestFunctions.py
@@ -1,0 +1,24 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+
+
+# Functions for testing ElectromagneticVariables
+def electric_field_compute(tilde_e, sqrt_det_spatial_metric):
+    return tilde_e / sqrt_det_spatial_metric
+
+
+def magnetic_field_compute(tilde_b, sqrt_det_spatial_metric):
+    return tilde_b / sqrt_det_spatial_metric
+
+
+def charge_density_compute(tilde_q, sqrt_det_spatial_metric):
+    return tilde_q / sqrt_det_spatial_metric
+
+
+def electric_current_density_compute(tilde_j, lapse, sqrt_det_spatial_metric):
+    return tilde_j / (lapse * sqrt_det_spatial_metric)
+
+
+# end functions for testing ElectromagneticVariables

--- a/tests/Unit/Evolution/Systems/ForceFree/Test_ElectromagneticVariables.cpp
+++ b/tests/Unit/Evolution/Systems/ForceFree/Test_ElectromagneticVariables.cpp
@@ -1,0 +1,31 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include "DataStructures/DataVector.hpp"
+#include "Evolution/Systems/ForceFree/ElectromagneticVariables.hpp"
+#include "Framework/CheckWithRandomValues.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.ForceFree.ElectromagneticVariables",
+                  "[Unit][Evolution]") {
+  pypp::SetupLocalPythonEnvironment local_python_env{
+      "Evolution/Systems/ForceFree"};
+
+  pypp::check_with_random_values<1>(
+      ForceFree::Tags::ElectricFieldCompute::function, "TestFunctions",
+      {"electric_field_compute"}, {{{-1.0, 1.0}}}, DataVector{5});
+
+  pypp::check_with_random_values<1>(
+      ForceFree::Tags::MagneticFieldCompute::function, "TestFunctions",
+      {"magnetic_field_compute"}, {{{-1.0, 1.0}}}, DataVector{5});
+
+  pypp::check_with_random_values<1>(
+      ForceFree::Tags::ChargeDensityCompute::function, "TestFunctions",
+      {"charge_density_compute"}, {{{-1.0, 1.0}}}, DataVector{5});
+
+  pypp::check_with_random_values<1>(
+      ForceFree::Tags::ElectricCurrentDensityCompute::function, "TestFunctions",
+      {"electric_current_density_compute"}, {{{-1.0, 1.0}}}, DataVector{5});
+}


### PR DESCRIPTION

## Proposed changes

Compute tags for observing electromagnetic field variables without metric (densitizing) factors.


### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
