### PR TITLE
Upgrade SpEC exporter build on Wheeler

### DIFF
--- a/cmake/FindSpEC.cmake
+++ b/cmake/FindSpEC.cmake
@@ -1,0 +1,73 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+# Optionally link SpEC libraries. Pass `SPEC_ROOT` to the CMake build
+# configuration to set up the following targets:
+#
+# - SpEC::Exporter: Functionality to load SpEC volume data and interpolate to
+#   arbitrary points.
+
+if(NOT SPEC_ROOT)
+  # Need to set to empty to avoid warnings with --warn-uninitialized
+  set(SPEC_ROOT "")
+  set(SPEC_ROOT $ENV{SPEC_ROOT})
+endif()
+
+if (SPEC_ROOT)
+  set(SPEC_EXPORTER_ROOT ${SPEC_ROOT}/Support/ApplyObservers/Exporter)
+else()
+  set(SPEC_EXPORTER_ROOT "")
+endif()
+
+find_library(
+  SPEC_PACKAGED_EXPORTER_LIB
+  NAMES libPackagedExporter.a
+  PATHS ${SPEC_EXPORTER_ROOT}
+  NO_DEFAULT_PATHS
+  )
+find_file(
+  SPEC_EXPORTER_FACTORY_OBJECTS
+  NAMES ExporterFactoryObjects.o
+  PATHS ${SPEC_EXPORTER_ROOT}
+  NO_DEFAULT_PATHS
+  )
+find_path(
+  SPEC_EXPORTER_INCLUDE_DIR
+  NAMES Exporter.hpp
+  PATHS ${SPEC_EXPORTER_ROOT}
+  NO_DEFAULT_PATHS
+  )
+
+# SpEC needs MPI.
+# NOTE: You should use the same MPI as SpEC. At least the same distribution. So
+# mixing OpenMPI and MPICH would be bad.
+find_package(MPI COMPONENTS C)
+
+if (SPEC_PACKAGED_EXPORTER_LIB AND SPEC_EXPORTER_FACTORY_OBJECTS AND
+    SPEC_EXPORTER_INCLUDE_DIR AND MPI_C_FOUND)
+  add_library(SpEC::Exporter INTERFACE IMPORTED)
+  target_include_directories(
+    SpEC::Exporter INTERFACE ${SPEC_EXPORTER_INCLUDE_DIR})
+  add_interface_lib_headers(
+    TARGET SpEC::Exporter
+    HEADERS
+    Exporter.hpp
+  )
+  target_link_libraries(
+    SpEC::Exporter
+    INTERFACE
+    MPI::MPI_C
+    # The order of these next two lines is important
+    ${SPEC_EXPORTER_FACTORY_OBJECTS}
+    ${SPEC_PACKAGED_EXPORTER_LIB}
+  )
+endif()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(
+  SpEC
+  REQUIRED_VARS
+  SPEC_PACKAGED_EXPORTER_LIB
+  SPEC_EXPORTER_FACTORY_OBJECTS
+  SPEC_EXPORTER_INCLUDE_DIR
+  )

--- a/cmake/SetupSpec.cmake
+++ b/cmake/SetupSpec.cmake
@@ -1,42 +1,11 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-# Optionally link SpEC libraries. Pass `SPEC_ROOT` to the CMake build
-# configuration to set up the following targets:
-#
-# - SpEC::Exporter: Functionality to load SpEC volume data and interpolate to
-#   arbitrary points.
+find_package(SpEC)
 
-option(SPEC_ROOT "Path to the git directory of SpEC." OFF)
-
-if (DEFINED ENV{SPEC_ROOT} AND NOT SPEC_ROOT)
-  set(SPEC_ROOT "$ENV{SPEC_ROOT}")
+if (SpEC_FOUND)
+  file(APPEND
+    "${CMAKE_BINARY_DIR}/BuildInfo.txt"
+    "SpEC exporter: ${SPEC_EXPORTER_ROOT}\n"
+    )
 endif()
-
-if(NOT SPEC_ROOT)
-  return()
-endif()
-
-message(STATUS "Linking with SpEC: ${SPEC_ROOT}")
-
-# SpEC needs MPI.
-# NOTE: You should use the same MPI as SpEC. At least the same distribution. So
-# mixing OpenMPI and MPICH would be bad.
-find_package(MPI COMPONENTS C)
-
-add_library(SpEC::Exporter INTERFACE IMPORTED)
-set(SPEC_EXPORTER_ROOT ${SPEC_ROOT}/Support/ApplyObservers/Exporter)
-target_include_directories(SpEC::Exporter INTERFACE ${SPEC_EXPORTER_ROOT})
-add_interface_lib_headers(
-  TARGET SpEC::Exporter
-  HEADERS
-  Exporter.hpp
-)
-target_link_libraries(
-  SpEC::Exporter
-  INTERFACE
-  MPI::MPI_C
-  # The order of these next two lines is important
-  ${SPEC_EXPORTER_ROOT}/ExporterFactoryObjects.o
-  ${SPEC_EXPORTER_ROOT}/libPackagedExporter.a
-)

--- a/support/Environments/wheeler_gcc.sh
+++ b/support/Environments/wheeler_gcc.sh
@@ -31,7 +31,7 @@ spectre_unload_modules() {
     module unload pybind11/2.6.1
     module unload hdf5/1.12.2
     module unload libbacktrace/1.0
-    module unload spec-exporter/2023-05
+    module unload spec-exporter/2023-07
 }
 
 spectre_load_modules() {
@@ -58,7 +58,7 @@ spectre_load_modules() {
     module load pybind11/2.6.1
     module load hdf5/1.12.2
     module load libbacktrace/1.0
-    module load spec-exporter/2023-05
+    module load spec-exporter/2023-07
 }
 
 spectre_run_cmake() {


### PR DESCRIPTION
## Proposed changes

Built on SpEC revision https://github.com/sxs-collaboration/spec/commit/4616b567adfbefcfd4f3d72b78c9298b060c792a and with `-fPIC` so Pybindings work.

With this change the SpEC importing is enabled automatically on all builds on Wheeler.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
