### PR TITLE
Add quadrupole moment and its first derivative calculations to Hydro

### DIFF
--- a/docs/References.bib
+++ b/docs/References.bib
@@ -1991,6 +1991,22 @@ archivePrefix = {arXiv},
   url     = {https://ui.adsabs.harvard.edu/abs/1983bhwd.book.....S},
 }
 
+@article{Shibata2003,
+  title     = "Gravitational waves from axisymmetrically oscillating neutron
+               stars in general relativistic simulations",
+  author    = "Shibata, Masaru and Sekiguchi, Yu-ichirou",
+  journal   = "Phys. Rev. D",
+  volume    = "68",
+  issue     = "10",
+  pages     = "104020",
+  numpages  = "14",
+  year      = "2003",
+  month     = "Nov",
+  publisher = "American Physical Society",
+  doi       = "10.1103/PhysRevD.68.104020",
+  url       = "https://link.aps.org/doi/10.1103/PhysRevD.68.104020"
+}
+
 @article{Shu1988439,
   title =        "Efficient implementation of essentially non-oscillatory
                   shock-capturing schemes",

--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
@@ -68,6 +68,7 @@
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/KastaunEtAl.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/NewmanHamlin.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/PalenzuelaEtAl.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/QuadrupoleFormula.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/SetVariablesNeededFixingToFalse.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/FixConservativesAndComputePrims.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/GrTagsForHydro.hpp"
@@ -161,6 +162,7 @@
 #include "PointwiseFunctions/Hydro/EquationsOfState/Factory.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/RegisterDerivedWithCharm.hpp"
 #include "PointwiseFunctions/Hydro/MassFlux.hpp"
+#include "PointwiseFunctions/Hydro/QuadrupoleFormula.hpp"
 #include "PointwiseFunctions/Hydro/Tags.hpp"
 #include "Time/Actions/AdvanceTime.hpp"
 #include "Time/Actions/ChangeSlabSize.hpp"
@@ -289,7 +291,13 @@ struct EvolutionMetavars {
           evolution::dg::subcell::Tags::ObserverCoordinatesCompute<
               volume_dim, Frame::Inertial>,
           ::Events::Tags::ObserverCoordinatesCompute<volume_dim,
-                                                     Frame::Inertial>>>;
+                                                     Frame::Inertial>>,
+      grmhd::ValenciaDivClean::Tags::QuadrupoleMomentCompute<
+             DataVector, volume_dim,
+             ::Events::Tags::ObserverCoordinates<volume_dim, Frame::Inertial>>,
+      grmhd::ValenciaDivClean::Tags::QuadrupoleMomentDerivativeCompute<
+             DataVector, volume_dim,
+             ::Events::Tags::ObserverCoordinates<volume_dim, Frame::Inertial>>>;
   using non_tensor_compute_tags = tmpl::list<
       tmpl::conditional_t<
           use_dg_subcell,

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/CMakeLists.txt
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/CMakeLists.txt
@@ -39,6 +39,7 @@ spectre_target_headers(
   PalenzuelaEtAl.hpp
   PrimitiveFromConservative.hpp
   PrimitiveRecoveryData.hpp
+  QuadrupoleFormula.hpp
   SetVariablesNeededFixingToFalse.hpp
   Sources.hpp
   System.hpp
@@ -59,7 +60,9 @@ target_link_libraries(
   Evolution
   FiniteDifference
   GeneralRelativity
+  H5
   Hydro
+  HydroHelpers
   Limiters
   Options
   Utilities

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/QuadrupoleFormula.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/QuadrupoleFormula.hpp
@@ -1,0 +1,74 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "PointwiseFunctions/Hydro/QuadrupoleFormula.hpp"
+#include "PointwiseFunctions/Hydro/Tags.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/TagsDeclarations.hpp"  // IWYU pragma: keep
+#include "PointwiseFunctions/GeneralRelativity/TagsDeclarations.hpp"  // IWYU pragma: keep
+#include "PointwiseFunctions/Hydro/TagsDeclarations.hpp"  // IWYU pragma: keep
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+namespace gsl {
+template <typename>
+struct not_null;
+}  // namespace gsl
+/// \endcond
+
+namespace grmhd::ValenciaDivClean::Tags {
+/// \brief Compute tag for the quadrupole moment.
+///
+/// Compute item for the quadrupole moment, using
+/// \f$\tilde{D} x^i x^j\f$ (equation 21 of \cite Shibata2003),
+/// with \f$\tilde{D}=\sqrt{\gamma}\rho W\f$, $W$ being the Lorentz factor,
+/// $\gamma$ being the determinant of the spatial metric, and
+/// \f$x\f$ the coordinates in Frame Fr.
+template <typename DataType, size_t Dim, typename OutputCoordsTag,
+          typename Fr = Frame::Inertial>
+struct QuadrupoleMomentCompute
+    : hydro::Tags::QuadrupoleMoment<DataType, Dim, Fr>,
+      db::ComputeTag {
+  using argument_tags = tmpl::list<TildeD, OutputCoordsTag>;
+
+  using base = hydro::Tags::QuadrupoleMoment<DataType, Dim, Fr>;
+  using return_type = typename base::type;
+
+  static constexpr auto function = static_cast<void (*)(
+      const gsl::not_null<tnsr::ii<DataType, Dim, Fr>*> result,
+      const Scalar<DataType>& tilde_d,
+      const tnsr::I<DataType, Dim, Fr>& coordinates)>(
+      &hydro::quadrupole_moment<DataType, Dim, Fr>);
+};
+
+/// \brief Compute tag for the first time derivative of the quadrupole moment.
+///
+/// Compute item for the first time derivative of the quadrupole moment, using
+/// \f$\tilde{D} (v^i x^j + x^i v^j)\f$ (equation 23 of \cite Shibata2003),
+/// with \f$\tilde{D}=\sqrt{\gamma}\rho W\f$, $W$ being the Lorentz factor,
+/// $\gamma$ being the determinant of the spatial metric, \f$x\f$ the
+/// coordinates in Frame Fr, and \f$v\f$ the corresponding spatial velocity.
+template <typename DataType, size_t Dim, typename OutputCoordsTag,
+          typename Fr = Frame::Inertial>
+struct QuadrupoleMomentDerivativeCompute
+    : hydro::Tags::QuadrupoleMomentDerivative<DataType, Dim, Fr>,
+      db::ComputeTag {
+  using argument_tags = tmpl::list<TildeD, OutputCoordsTag,
+                              hydro::Tags::SpatialVelocity<DataType, Dim, Fr>>;
+
+  using base = hydro::Tags::QuadrupoleMomentDerivative<DataType, Dim, Fr>;
+  using return_type = typename base::type;
+
+  static constexpr auto function = static_cast<void (*)(
+      const gsl::not_null<tnsr::ii<DataType, Dim, Fr>*> result,
+      const Scalar<DataType>& tilde_d,
+      const tnsr::I<DataType, Dim, Fr>& coordinates,
+      const tnsr::I<DataType, Dim, Fr>& spatial_velocity)>(
+      &hydro::quadrupole_moment_derivative<DataType, Dim, Fr>);
+};
+}  // namespace grmhd::ValenciaDivClean::Tags

--- a/src/PointwiseFunctions/Hydro/CMakeLists.txt
+++ b/src/PointwiseFunctions/Hydro/CMakeLists.txt
@@ -13,6 +13,7 @@ spectre_target_sources(
   LowerSpatialFourVelocity.cpp
   MassFlux.cpp
   MassWeightedFluidItems.cpp
+  QuadrupoleFormula.cpp
   SoundSpeedSquared.cpp
   SpecificEnthalpy.cpp
   StressEnergy.cpp
@@ -27,6 +28,7 @@ spectre_target_headers(
   LowerSpatialFourVelocity.hpp
   MassFlux.hpp
   MassWeightedFluidItems.hpp
+  QuadrupoleFormula.hpp
   SoundSpeedSquared.hpp
   SpecificEnthalpy.hpp
   StressEnergy.hpp

--- a/src/PointwiseFunctions/Hydro/QuadrupoleFormula.cpp
+++ b/src/PointwiseFunctions/Hydro/QuadrupoleFormula.cpp
@@ -1,0 +1,70 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "QuadrupoleFormula.hpp"
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/SetNumberOfGridPoints.hpp"
+
+namespace hydro {
+
+template <typename DataType, size_t Dim, typename Fr>
+void quadrupole_moment(
+    const gsl::not_null<tnsr::ii<DataType, Dim, Fr>*> result,
+    const Scalar<DataType>& tilde_d,
+    const tnsr::I<DataType, Dim, Fr>& coordinates) {
+  set_number_of_grid_points(result, tilde_d);
+  for (size_t i = 0; i < Dim; i++) {
+    for (size_t j = i; j < Dim; j++) {
+      result->get(i, j) = get(tilde_d) * coordinates.get(i) *
+                          coordinates.get(j);
+    }
+  }
+}
+
+template <typename DataType, size_t Dim, typename Fr>
+void quadrupole_moment_derivative(
+    const gsl::not_null<tnsr::ii<DataType, Dim, Fr>*> result,
+    const Scalar<DataType>& tilde_d,
+    const tnsr::I<DataType, Dim, Fr>& coordinates,
+    const tnsr::I<DataType, Dim, Fr>& spatial_velocity) {
+  set_number_of_grid_points(result, tilde_d);
+  for (size_t i = 0; i < Dim; i++) {
+    for (size_t j = i; j < Dim; j++) {
+      result->get(i, j) = get(tilde_d) *
+                          (spatial_velocity.get(i) * coordinates.get(j) +
+                          coordinates.get(i) * spatial_velocity.get(j));
+    }
+  }
+}
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(1, data)
+#define FRAME(data) BOOST_PP_TUPLE_ELEM(2, data)
+
+#define INSTANTIATE(_, data)                                                 \
+  template void quadrupole_moment<DTYPE(data), DIM(data), FRAME(data)>(      \
+      const gsl::not_null<tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>*>    \
+          result,                                                            \
+      const Scalar<DTYPE(data)>& tilde_d,                                    \
+      const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& spatial_position); \
+  template void quadrupole_moment_derivative<DTYPE(data), DIM(data),         \
+          FRAME(data)>(                                                      \
+      const gsl::not_null<tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>*>    \
+          result,                                                            \
+      const Scalar<DTYPE(data)>& tilde_d,                                    \
+      const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& spatial_position,  \
+      const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& spatial_velocity);
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (DataVector),
+                        (Frame::Inertial))
+
+#undef DIM
+#undef DTYPE
+#undef FRAME
+#undef INSTANTIATE
+
+}  // namespace hydro

--- a/src/PointwiseFunctions/Hydro/QuadrupoleFormula.hpp
+++ b/src/PointwiseFunctions/Hydro/QuadrupoleFormula.hpp
@@ -1,0 +1,75 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+
+/// \cond
+namespace gsl {
+template <typename>
+struct not_null;
+}  // namespace gsl
+/// \endcond
+
+namespace hydro {
+
+namespace Tags {
+/// \brief Tag containing the quadrupole moment.
+///
+/// The quadrupole moment is defined as \f$\tilde{D} x^i x^j\f$
+/// (equation 21 of \cite Shibata2003), with
+/// \f$\tilde{D}=\sqrt{\gamma}\rho W\f$, $W$ being the Lorentz factor,
+/// $\gamma$ being the determinant of the spatial metric, and
+/// \f$x\f$ the coordinates in Frame Fr.
+template <typename DataType, size_t Dim, typename Fr = Frame::Inertial>
+struct QuadrupoleMoment : db::SimpleTag {
+  using type = tnsr::ii<DataType, Dim, Fr>;
+};
+
+/// \brief Tag containing the first time derivative of the quadrupole moment.
+///
+/// For the first derivative of the quadrupole moment, we use
+/// \f$\tilde{D} (v^i x^j + x^i v^j)\f$ (equation 23 of \cite Shibata2003),
+/// with \f$\tilde{D}=\sqrt{\gamma}\rho W\f$, $W$ being the Lorentz factor,
+/// $\gamma$ being the determinant of the spatial metric, \f$x\f$ the
+/// coordinates in Frame Fr, and \f$v\f$ the corresponding spatial velocity.
+template <typename DataType, size_t Dim, typename Fr = Frame::Inertial>
+struct QuadrupoleMomentDerivative : db::SimpleTag {
+  using type = tnsr::ii<DataType, Dim, Fr>;
+};
+}  // namespace Tags
+
+/// \brief Function computing the quadrupole moment.
+///
+/// Computes the quadrupole moment, using
+/// \f$\tilde{D} x^i x^j\f$ (equation 21 of \cite Shibata2003),
+/// with \f$\tilde{D}=\sqrt{\gamma}\rho W\f$, $W$ being the Lorentz factor,
+/// $\gamma$ being the determinant of the spatial metric, and
+/// \f$x\f$ the coordinates in Frame Fr. Result of calculation stored in result.
+template <typename DataType, size_t Dim, typename Fr = Frame::Inertial>
+void quadrupole_moment(
+    const gsl::not_null<tnsr::ii<DataType, Dim, Fr>*> result,
+    const Scalar<DataType>& tilde_d,
+    const tnsr::I<DataType, Dim, Fr>& coordinates);
+
+/// \brief Function computing the first time derivative of the
+/// quadrupole moment.
+///
+/// Computes the first time derivative of the quadrupole moment, using
+/// \f$\tilde{D} (v^i x^j + x^i v^j)\f$ (equation 23 of \cite Shibata2003),
+/// with \f$\tilde{D}=\sqrt{\gamma}\rho W\f$, $W$ being the Lorentz factor,
+/// $\gamma$ being the determinant of the spatial metric, \f$x\f$ the
+/// coordinates in Frame Fr, and \f$v\f$ the corresponding spatial velocity.
+/// Result of calculation stored in result.
+template <typename DataType, size_t Dim, typename Fr = Frame::Inertial>
+void quadrupole_moment_derivative(
+    const gsl::not_null<tnsr::ii<DataType, Dim, Fr>*> result,
+    const Scalar<DataType>& tilde_d,
+    const tnsr::I<DataType, Dim, Fr>& coordinates,
+    const tnsr::I<DataType, Dim, Fr>& spatial_velocity);
+
+} // namespace hydro

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/CMakeLists.txt
@@ -37,6 +37,7 @@ set(LIBRARY_SOURCES
   Test_Flattener.cpp
   Test_Fluxes.cpp
   Test_PrimitiveFromConservative.cpp
+  Test_QuadrupoleFormula.cpp
   Test_SetVariablesNeededFixingToFalse.cpp
   Test_Sources.cpp
   Test_Tags.cpp

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Test_QuadrupoleFormula.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Test_QuadrupoleFormula.cpp
@@ -1,0 +1,19 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/QuadrupoleFormula.hpp"
+#include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
+
+SPECTRE_TEST_CASE("Unit.GrMhd.ValenciaDivClean.QuadrupoleFormula",
+                  "[Unit][Evolution]") {
+  TestHelpers::db::test_compute_tag<
+      grmhd::ValenciaDivClean::Tags::QuadrupoleMomentCompute<
+               DataVector, 3, Frame::Inertial>>("QuadrupoleMoment");
+  TestHelpers::db::test_compute_tag<
+      grmhd::ValenciaDivClean::Tags::QuadrupoleMomentDerivativeCompute<
+               DataVector, 3, Frame::Inertial>>("QuadrupoleMomentDerivative");
+}

--- a/tests/Unit/PointwiseFunctions/Hydro/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/Hydro/CMakeLists.txt
@@ -10,6 +10,7 @@ set(LIBRARY_SOURCES
   Test_LorentzFactor.cpp
   Test_MassFlux.cpp
   Test_MassWeightedFluidItems.cpp
+  Test_QuadrupoleFormula.cpp
   Test_SoundSpeedSquared.cpp
   Test_SpecificEnthalpy.cpp
   Test_StressEnergy.cpp
@@ -29,6 +30,7 @@ target_link_libraries(
   PRIVATE
   DataStructures
   DataStructuresHelpers
+  Domain
   GeneralRelativity
   GeneralRelativityHelpers
   Hydro

--- a/tests/Unit/PointwiseFunctions/Hydro/QuadrupoleFormula.py
+++ b/tests/Unit/PointwiseFunctions/Hydro/QuadrupoleFormula.py
@@ -1,0 +1,20 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+
+# Functions testing QuadrupoleFormula
+
+
+def quadrupole_moment(tilde_d, compute_coords):
+    xi, xj = np.meshgrid(compute_coords, compute_coords, indexing="ij")
+    return tilde_d * xi * xj
+
+
+def quadrupole_moment_derivative(tilde_d, compute_coords, spatial_velocity):
+    xi, xj = np.meshgrid(compute_coords, compute_coords, indexing="ij")
+    vi, vj = np.meshgrid(spatial_velocity, spatial_velocity, indexing="ij")
+    return tilde_d * (vi * xj + xi * vj)
+
+
+# End functions for testing QuadrupoleFormula

--- a/tests/Unit/PointwiseFunctions/Hydro/Test_QuadrupoleFormula.cpp
+++ b/tests/Unit/PointwiseFunctions/Hydro/Test_QuadrupoleFormula.cpp
@@ -1,0 +1,113 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <string>
+
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
+#include "Domain/CoordinateMaps/Identity.hpp"
+#include "Domain/ElementMap.hpp"
+#include "Domain/Tags.hpp"
+#include "Framework/CheckWithRandomValues.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
+#include "NumericalAlgorithms/LinearOperators/DefiniteIntegral.hpp"
+#include "NumericalAlgorithms/Spectral/LogicalCoordinates.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "PointwiseFunctions/Hydro/LorentzFactor.hpp"
+#include "PointwiseFunctions/Hydro/QuadrupoleFormula.hpp"
+
+namespace hydro {
+
+SPECTRE_TEST_CASE("Unit.PointwiseFunctions.Hydro.QuadrupoleFormula",
+                  "[Unit][Hydro]") {
+  TestHelpers::db::test_simple_tag<
+      Tags::QuadrupoleMoment<
+                 DataVector, 3, Frame::Inertial>>("QuadrupoleMoment");
+  TestHelpers::db::test_simple_tag<
+      Tags::QuadrupoleMomentDerivative<
+                 DataVector, 3, Frame::Inertial>>("QuadrupoleMomentDerivative");
+  pypp::SetupLocalPythonEnvironment local_python_env(
+      "PointwiseFunctions/Hydro/");
+  const DataVector used_for_size(5);
+  pypp::check_with_random_values<1>(
+      &quadrupole_moment<DataVector, 1, Frame::Inertial>,
+      "QuadrupoleFormula", {"quadrupole_moment"}, {{{0.0, 1.0}}},
+      used_for_size);
+  pypp::check_with_random_values<1>(
+      &quadrupole_moment<DataVector, 3, Frame::Inertial>,
+      "QuadrupoleFormula", {"quadrupole_moment"}, {{{0.0, 1.0}}},
+      used_for_size);
+  pypp::check_with_random_values<1>(
+      &quadrupole_moment_derivative<DataVector, 1, Frame::Inertial>,
+      "QuadrupoleFormula", {"quadrupole_moment_derivative"}, {{{0.0, 1.0}}},
+      used_for_size);
+  pypp::check_with_random_values<1>(
+      &quadrupole_moment_derivative<DataVector, 3, Frame::Inertial>,
+      "QuadrupoleFormula", {"quadrupole_moment_derivative"}, {{{0.0, 1.0}}},
+      used_for_size);
+
+  const Mesh<3> mesh{12, Spectral::Basis::Legendre,
+                     Spectral::Quadrature::GaussLobatto};
+  const Scalar<DataVector> rho_flat{mesh.number_of_grid_points(), 1.28e-3};
+  const Scalar<DataVector> velocity_squared{mesh.number_of_grid_points(), 0.04};
+  const Scalar<DataVector> W = lorentz_factor(velocity_squared);
+  const Scalar<DataVector> tildeD{get(W) * get(rho_flat)};
+
+  const auto logical_coords = logical_coordinates(mesh);
+  const size_t Dim=3;
+  ElementMap<Dim, Frame::Inertial> logical_to_inertial_map{
+      ElementId<Dim>{0},
+      domain::make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
+          domain::CoordinateMaps::Identity<Dim>{})};
+  const auto inertial_coords = logical_to_inertial_map(logical_coords);
+
+  tnsr::I<DataVector, 3> velocity_x{mesh.number_of_grid_points(), 0.};
+  get<0>(velocity_x) = 0.2;
+  tnsr::I<DataVector, 3> velocity_y{mesh.number_of_grid_points(), 0.};
+  get<1>(velocity_y) = 0.2;
+  tnsr::I<DataVector, 3> velocity_z{mesh.number_of_grid_points(), 0.};
+  get<2>(velocity_z) = 0.2;
+
+  tnsr::ii<DataVector, 3, Frame::Inertial> q{};
+  quadrupole_moment(make_not_null(&q), tildeD, inertial_coords);
+  tnsr::ii<DataVector, 3, Frame::Inertial> qd_x{};
+  quadrupole_moment_derivative(make_not_null(&qd_x), tildeD, inertial_coords,
+                                                                    velocity_x);
+  tnsr::ii<DataVector, 3, Frame::Inertial> qd_y{};
+  quadrupole_moment_derivative(make_not_null(&qd_y), tildeD, inertial_coords,
+                                                                    velocity_y);
+  tnsr::ii<DataVector, 3, Frame::Inertial> qd_z{};
+  quadrupole_moment_derivative(make_not_null(&qd_z), tildeD, inertial_coords,
+                                                                    velocity_z);
+
+  tnsr::ii<double, 3> q_integral{};
+  tnsr::ii<double, 3> qd_x_integral{};
+  tnsr::ii<double, 3> qd_y_integral{};
+  tnsr::ii<double, 3> qd_z_integral{};
+  for (size_t i = 0; i < 3; ++i) {
+    for (size_t j = i; j < 3; ++j) {
+      q_integral.get(i,j) = definite_integral(q.get(i,j), mesh);
+      qd_x_integral.get(i,j) = definite_integral(qd_x.get(i,j), mesh);
+      qd_y_integral.get(i,j) = definite_integral(qd_y.get(i,j), mesh);
+      qd_z_integral.get(i,j) = definite_integral(qd_z.get(i,j), mesh);
+      CHECK(qd_x_integral.get(i, j) == approx(0.0));
+      CHECK(qd_y_integral.get(i, j) == approx(0.0));
+      CHECK(qd_z_integral.get(i, j) == approx(0.0));
+      if (i == j) {
+        CHECK(q_integral.get(i, j) == approx(3.483718745291631e-3));
+      }
+      else {
+        CHECK(q_integral.get(i, j) == approx(0.0));
+      }
+    }
+  }
+}
+
+}  // namespace hydro


### PR DESCRIPTION
## Proposed changes

Add `QuadrupoleMomentCompute` and `QuadrupoleMomentDerivativeCompute` tags, which compute the quadrupole moment for a given cell/subcell, to namespace `hydro`.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
