### PR TITLE
Allow observation of 3+1 metric in GrGhmd runs

### DIFF
--- a/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
+++ b/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
@@ -180,10 +180,15 @@
 #include "PointwiseFunctions/GeneralRelativity/Christoffel.hpp"
 #include "PointwiseFunctions/GeneralRelativity/DetAndInverseSpatialMetric.hpp"
 #include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/ConstraintGammas.hpp"
+#include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/ExtrinsicCurvature.hpp"
 #include "PointwiseFunctions/GeneralRelativity/IndexManipulation.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Lapse.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Ricci.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Shift.hpp"
+#include "PointwiseFunctions/GeneralRelativity/SpatialMetric.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/Factory.hpp"
+#include "PointwiseFunctions/Hydro/LowerSpatialFourVelocity.hpp"
 #include "PointwiseFunctions/Hydro/MassFlux.hpp"
 #include "PointwiseFunctions/Hydro/MassWeightedFluidItems.hpp"
 #include "PointwiseFunctions/Hydro/Tags.hpp"
@@ -414,24 +419,30 @@ struct GhValenciaDivCleanTemplateBase<
           typename system::primitive_variables_tag::tags_list,
           tmpl::conditional_t<use_numeric_initial_data, tmpl::list<>,
                               error_tags>,
-          tmpl::list<hydro::Tags::MassWeightedInternalEnergyCompute<DataVector>,
-                     hydro::Tags::MassWeightedKineticEnergyCompute<DataVector>,
-                     hydro::Tags::TildeDUnboundUtCriterionCompute<
-                         DataVector, volume_dim, domain_frame>,
-                     hydro::Tags::MassWeightedCoordsCompute<
-                         DataVector, volume_dim, ::domain::ObjectLabel::None,
-                         Events::Tags::ObserverCoordinates<3, Frame::Grid>,
-                         Events::Tags::ObserverCoordinates<3, Frame::Inertial>,
-                         Frame::Inertial>,
-                     gr::Tags::SpacetimeNormalOneFormCompute<
-                         DataVector, volume_dim, domain_frame>,
-                     gr::Tags::SpacetimeNormalVectorCompute<
-                         DataVector, volume_dim, domain_frame>,
-                     gr::Tags::InverseSpacetimeMetricCompute<
-                         DataVector, volume_dim, domain_frame>,
-                     gh::Tags::GaugeConstraintCompute<volume_dim, domain_frame>,
-                     ::Tags::PointwiseL2NormCompute<gh::Tags::GaugeConstraint<
-                         DataVector, volume_dim, domain_frame>>>,
+          tmpl::list<
+              hydro::Tags::MassWeightedInternalEnergyCompute<DataVector>,
+              hydro::Tags::MassWeightedKineticEnergyCompute<DataVector>,
+              hydro::Tags::TildeDUnboundUtCriterionCompute<
+                  DataVector, volume_dim, domain_frame>,
+              hydro::Tags::LowerSpatialFourVelocityCompute,
+              hydro::Tags::MassWeightedCoordsCompute<
+                  DataVector, volume_dim, ::domain::ObjectLabel::None,
+                  Events::Tags::ObserverCoordinates<3, Frame::Grid>,
+                  Events::Tags::ObserverCoordinates<3, Frame::Inertial>,
+                  Frame::Inertial>,
+              gr::Tags::SpacetimeNormalOneFormCompute<DataVector, volume_dim,
+                                                      domain_frame>,
+              gr::Tags::SpacetimeNormalVectorCompute<DataVector, volume_dim,
+                                                     domain_frame>,
+              gr::Tags::InverseSpacetimeMetricCompute<DataVector, volume_dim,
+                                                      domain_frame>,
+              gr::Tags::Lapse<DataVector>,
+              gr::Tags::Shift<DataVector, volume_dim, domain_frame>,
+              gr::Tags::SpatialMetric<DataVector, volume_dim, domain_frame>,
+              gh::Tags::ExtrinsicCurvatureCompute<volume_dim, domain_frame>,
+              gh::Tags::GaugeConstraintCompute<volume_dim, domain_frame>,
+              ::Tags::PointwiseL2NormCompute<gh::Tags::GaugeConstraint<
+                  DataVector, volume_dim, domain_frame>>>,
           tmpl::conditional_t<use_dg_subcell,
                               tmpl::list<evolution::dg::subcell::Tags::
                                              TciStatusCompute<volume_dim>>,


### PR DESCRIPTION
## Proposed changes

Add 3+1 metric quantities to the observer databox.

### Upgrade instructions

None

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

This allows visualization of the 3+1 metric quantities (Lapse, Shift, 3-metric, extrinsic curvature), as well as potentially writing down the current state of the simulation in a way that can be restarted using NumericInitialData (which can do interpolated restarts and can restart on different number of cores).