### PR TITLE
Add scalar stress energy tensor compute functions

### DIFF
--- a/src/Evolution/Systems/ScalarTensor/StressEnergy.cpp
+++ b/src/Evolution/Systems/ScalarTensor/StressEnergy.cpp
@@ -3,4 +3,41 @@
 
 #include "Evolution/Systems/ScalarTensor/StressEnergy.hpp"
 
-namespace ScalarTensor {}  // namespace ScalarTensor
+#include <cstddef>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace ScalarTensor {
+
+void add_stress_energy_term_to_dt_pi(
+    const gsl::not_null<tnsr::aa<DataVector, 3_st>*> dt_pi,
+    const tnsr::aa<DataVector, 3_st>& trace_reversed_stress_energy,
+    const Scalar<DataVector>& lapse) {
+  for (size_t a = 0; a < 4; ++a) {
+    for (size_t b = a; b < 4; ++b) {
+      dt_pi->get(a, b) -=
+          16.0 * M_PI * get(lapse) * trace_reversed_stress_energy.get(a, b);
+    }
+  }
+}
+
+void trace_reversed_stress_energy(
+    const gsl::not_null<tnsr::aa<DataVector, 3_st>*> stress_energy,
+    const Scalar<DataVector>& pi_scalar,
+    const tnsr::i<DataVector, 3_st>& phi_scalar,
+    const Scalar<DataVector>& lapse) {
+  get<0, 0>(*stress_energy) = square(get(lapse) * get(pi_scalar));
+  for (size_t i = 0; i < 3; ++i) {
+    stress_energy->get(0, i + 1) =
+        -get(lapse) * get(pi_scalar) * phi_scalar.get(i);
+  }
+  for (size_t i = 0; i < 3; ++i) {
+    for (size_t j = i; j < 3; ++j) {
+      stress_energy->get(i + 1, j + 1) = phi_scalar.get(i) * phi_scalar.get(j);
+    }
+  }
+}
+
+}  // namespace ScalarTensor

--- a/src/Evolution/Systems/ScalarTensor/StressEnergy.hpp
+++ b/src/Evolution/Systems/ScalarTensor/StressEnergy.hpp
@@ -3,4 +3,108 @@
 
 #pragma once
 
-namespace ScalarTensor {}  // namespace ScalarTensor
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Evolution/Systems/CurvedScalarWave/Tags.hpp"
+#include "Evolution/Systems/ScalarTensor/Tags.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace ScalarTensor {
+
+/*!
+ * \brief Add in the trace-reversed stress-energy source term to the \f$\Pi\f$
+ * evolved variable of the ::gh system.
+ *
+ * \details The only stress energy source term in the Generalized Harmonic
+ * evolution equations is in the equation for \f$\Pi_{a b}\f$:
+ * \f[
+ * \partial_t \Pi_{ab} + \text{\{spatial derivative terms\}} =
+ * \text{\{GH source terms\}}
+ * - 16 \pi \alpha (T^{(\Psi)}_{ab} - \frac{1}{2} g_{a b} g^{cd}T^{(\Psi)}_{cd})
+ * ~.
+ * \f]
+ *
+ * (note that this function takes as argument the trace-reversed stress-energy
+ * tensor)
+ *
+ * This function adds that contribution to the existing value of `dt_pi`. The
+ * spacetime terms in the GH equation should be computed before passing the
+ * `dt_pi` to this function for updating.
+ *
+ * \param dt_pi Time derivative of the $\Pi_{ab}$ variable in the ::gh system.
+ * The vacuum part should be computed before with ::gh::TimeDerivative
+ * \param trace_reversed_stress_energy Trace-reversed stress energy tensor of
+ * the scalar $T^{(\Psi), \text{TR}}_{a b} \equiv T^{(\Psi)}_{ab} - \frac{1}{2}
+ *  g_{a b} g^{cd}T^{(\Psi)}_{cd} = \partial_a \Psi \partial_b \Psi $.
+ * \param lapse Lapse $\alpha$.
+ *
+ * \see `gh::TimeDerivative` for details about the spacetime
+ * part of the time derivative calculation.
+ */
+void add_stress_energy_term_to_dt_pi(
+    gsl::not_null<tnsr::aa<DataVector, 3_st>*> dt_pi,
+    const tnsr::aa<DataVector, 3_st>& trace_reversed_stress_energy,
+    const Scalar<DataVector>& lapse);
+
+/*!
+ * \brief Compute the trace-reversed stress-energy tensor of the scalar field.
+ *
+ * \details The trace-reversed stress energy tensor is needed to compute the
+ * backreaction of the scalar to the spacetime evolution and is given by
+ * \f{align*}{
+ * T^{(\Psi), \text{TR}}_{a b} &\equiv T^{(\Psi)}_{ab} - \frac{1}{2}
+ *  g_{a b} g^{cd}T^{(\Psi)}_{cd} \\
+ *  &= \partial_a \Psi \partial_b \Psi ~,
+ * \f}
+ *
+ * where \f$T^{(\Psi)}_{ab}\f$ is the standard stress-energy tensor of the
+ * scalar.
+ *
+ * In terms of the evolved variables of the scalar,
+ * \f{align*}{
+    T^{(\Psi), \text{TR}}_{00} &= \alpha^2 \Pi^2 ~, \\
+    T^{(\Psi), \text{TR}}_{j 0} &= T^{(\Psi), \text{TR}}_{0j}
+                                 = - \alpha \Pi \Phi_j ~, \\
+    T^{(\Psi), \text{TR}}_{ij} &= \Phi_i \Phi_j ~,
+ * \f}
+ *
+ * where \f$\alpha\f$ is the lapse.
+ *
+ * \param stress_energy Trace-reversed stress energy tensor of
+ * the scalar $T^{(\Psi), \text{TR}}_{a b} \equiv T^{(\Psi)}_{ab} - \frac{1}{2}
+ *  g_{a b} g^{cd}T^{(\Psi)}_{cd} = \partial_a \Psi \partial_b \Psi $.
+ * \param pi_scalar Scalar evolution variable $\Pi$.
+ * \param phi_scalar Scalar evolution variable $\Phi_i$.
+ * \param lapse Lapse $\alpha$.
+ */
+void trace_reversed_stress_energy(
+    gsl::not_null<tnsr::aa<DataVector, 3_st>*> stress_energy,
+    const Scalar<DataVector>& pi_scalar,
+    const tnsr::i<DataVector, 3_st>& phi_scalar,
+    const Scalar<DataVector>& lapse);
+
+namespace Tags {
+
+/*!
+ * \brief Compute tag for the trace reversed stress energy tensor.
+ *
+ * \details Compute using ScalarTensor::trace_reversed_stress_energy.
+ */
+struct TraceReversedStressEnergyCompute
+    : TraceReversedStressEnergy<DataVector, 3_st, Frame::Inertial>,
+      db::ComputeTag {
+  static constexpr size_t Dim = 3;
+  using argument_tags =
+      tmpl::list<CurvedScalarWave::Tags::Pi, CurvedScalarWave::Tags::Phi<Dim>,
+                 gr::Tags::Lapse<DataVector>>;
+  using return_type = tnsr::aa<DataVector, Dim, Frame::Inertial>;
+  static constexpr void (*function)(
+      const gsl::not_null<tnsr::aa<DataVector, Dim>*> result,
+      const Scalar<DataVector>&, const tnsr::i<DataVector, Dim>&,
+      const Scalar<DataVector>&) = &trace_reversed_stress_energy;
+  using base = TraceReversedStressEnergy<DataVector, Dim, Frame::Inertial>;
+};
+}  // namespace Tags
+
+}  // namespace ScalarTensor

--- a/tests/Unit/Evolution/Systems/ScalarTensor/StressEnergy.py
+++ b/tests/Unit/Evolution/Systems/ScalarTensor/StressEnergy.py
@@ -1,0 +1,25 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+
+
+def trace_reversed_stress_energy(pi_scalar, phi_scalar, lapse):
+    # Define the different components
+    tt_component = lapse * lapse * pi_scalar * pi_scalar
+    tj_component = -lapse * pi_scalar * phi_scalar
+    ij_component = np.outer(phi_scalar, phi_scalar)
+
+    # Construct the trace-reversed stress energy tensor
+    stress_energy = np.zeros((4, 4))
+
+    stress_energy[0, 0] = tt_component
+    stress_energy[0, 1:] = tj_component
+    stress_energy[1:, 0] = stress_energy[0, 1:]
+    stress_energy[1:, 1:] = ij_component
+
+    return stress_energy
+
+
+def add_stress_energy_term_to_dt_pi(trace_reversed_stress_energy, lapse):
+    return 0.1234 - 16.0 * np.pi * lapse * trace_reversed_stress_energy

--- a/tests/Unit/Evolution/Systems/ScalarTensor/Test_StressEnergy.cpp
+++ b/tests/Unit/Evolution/Systems/ScalarTensor/Test_StressEnergy.cpp
@@ -1,0 +1,35 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include "DataStructures/DataVector.hpp"
+#include "Evolution/Systems/ScalarTensor/StressEnergy.hpp"
+#include "Evolution/Systems/ScalarTensor/Tags.hpp"
+#include "Framework/CheckWithRandomValues.hpp"
+#include "Framework/Pypp.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
+#include "Helpers/Domain/DomainTestHelpers.hpp"
+#include "Helpers/PointwiseFunctions/GeneralRelativity/TestHelpers.hpp"
+
+SPECTRE_TEST_CASE("Unit.ScalarTensor.StressEnergy", "[Unit][ScalarTensor]") {
+  pypp::SetupLocalPythonEnvironment local_python_env{
+      "Evolution/Systems/ScalarTensor"};
+
+  pypp::check_with_random_values<1>(
+      &ScalarTensor::trace_reversed_stress_energy, "StressEnergy",
+      {"trace_reversed_stress_energy"},
+      {{{1.0e-2, 0.5}}}, DataVector{5});
+
+  pypp::check_with_random_values<1>(
+      &ScalarTensor::add_stress_energy_term_to_dt_pi,
+      "StressEnergy", {"add_stress_energy_term_to_dt_pi"},
+      {{{1.0e-2, 0.5}}}, DataVector{5}, 1.0e-12, std::random_device{}(),
+      0.1234);
+
+  TestHelpers::db::test_compute_tag<
+      ScalarTensor::Tags::TraceReversedStressEnergyCompute>(
+      "TraceReversedStressEnergy");
+}


### PR DESCRIPTION
## Proposed changes

<!--
At a high level, describe what this PR does.
-->

Add methods to compute the trace-reversed stress energy tensor of the scalar field and add it to the rhs of the metric equations

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
