### PR TITLE
Add scalar sources

### DIFF
--- a/src/Evolution/Systems/ScalarTensor/CMakeLists.txt
+++ b/src/Evolution/Systems/ScalarTensor/CMakeLists.txt
@@ -35,3 +35,5 @@ target_link_libraries(
   Options
   Parallel
   )
+
+add_subdirectory(Sources)

--- a/src/Evolution/Systems/ScalarTensor/Sources/CMakeLists.txt
+++ b/src/Evolution/Systems/ScalarTensor/Sources/CMakeLists.txt
@@ -1,0 +1,15 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+spectre_target_sources(
+  ${LIBRARY}
+  PRIVATE
+  ScalarSource.cpp
+)
+
+spectre_target_headers(
+  ${LIBRARY}
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  ScalarSource.hpp
+)

--- a/src/Evolution/Systems/ScalarTensor/Sources/ScalarSource.cpp
+++ b/src/Evolution/Systems/ScalarTensor/Sources/ScalarSource.cpp
@@ -1,0 +1,24 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/ScalarTensor/Sources/ScalarSource.hpp"
+
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/SetNumberOfGridPoints.hpp"
+
+namespace ScalarTensor {
+
+void add_scalar_source_to_dt_pi_scalar(
+    gsl::not_null<Scalar<DataVector>*> dt_pi_scalar,
+    const Scalar<DataVector>& scalar_source, const Scalar<DataVector>& lapse) {
+  get(*dt_pi_scalar) += get(lapse) * get(scalar_source);
+}
+
+void mass_source(
+    const gsl::not_null<Scalar<DataVector>*> scalar_source,
+    const Scalar<DataVector>& psi, const double mass_psi) {
+  get(*scalar_source) = square(mass_psi) * get(psi);
+}
+}  // namespace ScalarTensor

--- a/src/Evolution/Systems/ScalarTensor/Sources/ScalarSource.hpp
+++ b/src/Evolution/Systems/ScalarTensor/Sources/ScalarSource.hpp
@@ -1,0 +1,96 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Evolution/Systems/CurvedScalarWave/Tags.hpp"
+#include "Evolution/Systems/ScalarTensor/Tags.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace ScalarTensor {
+
+/*!
+ * \brief Add in the source term to the \f$\Pi\f$
+ * evolved variable of the ::CurvedScalarWave system.
+ *
+ * \details The only source term in the wave equation
+ * \f[
+ *  \Box \Psi = \mathcal{S} ~,
+ *  \f]
+ *
+ * is in the equation for \f$\Pi\f$:
+ * \f[
+ *  \partial_t \Pi + \text{\{spatial derivative
+ * terms\}} = \alpha \mathcal{S}
+ * ~,
+ * \f]
+ *
+ * where \f$\mathcal{S}\f$ is the source term (e. g. in the Klein-Gordon
+ * equation, the source term is the derivative of the scalar potential
+ * \f$\mathcal{S} \equiv \partial V / \partial \Psi \f$.)
+ *
+ * This function adds that contribution to the existing value of `dt_pi_scalar`.
+ * The wave equation terms in the scalar equation should be computed before
+ * passing the `dt_pi_scalar` to this function for updating.
+ *
+ * \param dt_pi_scalar Time derivative terms of $\Pi$. The sourceless part
+ * should be computed before with ::CurvedScalarWave::TimeDerivative.
+ * \param scalar_source Source term $\mathcal{S}$ for the scalar equation.
+ * \param lapse Lapse $\alpha$.
+ *
+ * \see `CurvedScalarWave::TimeDerivative` for details about the source-less
+ * part of the time derivative calculation.
+ */
+void add_scalar_source_to_dt_pi_scalar(
+    gsl::not_null<Scalar<DataVector>*> dt_pi_scalar,
+    const Scalar<DataVector>& scalar_source, const Scalar<DataVector>& lapse);
+
+/*!
+ * \brief Computes the source term given by the mass of the scalar.
+ *
+ * \details For a scalar field with mass parameter \f$ m_\Psi \f$,
+ * the wave equation takes the form
+ * \f[
+ *   \Box \Psi = \mathcal{S} ~,
+ * \f]
+ *
+ * where the source is given by
+ * \f[
+ *   \mathcal{S} \equiv m^2_\Psi ~.
+ * \f]
+ *
+ * Here the mass parameter value is an option that needs to be specified in the
+ * input file.
+ *
+ * \param scalar_source Source term $\mathcal{S}$ for the scalar equation.
+ * \param psi Scalar field $\Psi$.
+ * \param mass_psi Mass of the scalar field $m_\Psi$.
+ *
+ * \see `ScalarTensor::Tags::ScalarMass` for details about the mass.
+ */
+void mass_source(gsl::not_null<Scalar<DataVector>*> scalar_source,
+                 const Scalar<DataVector>& psi, const double mass_psi);
+
+namespace Tags {
+
+/*!
+ * \brief Compute tag for the scalar source.
+ *
+ * \details Compute the scalar source from data box items using
+ * `mass_source`.
+ */
+struct ScalarSourceCompute : ScalarSource, db::ComputeTag {
+  using argument_tags =
+      tmpl::list<CurvedScalarWave::Tags::Psi, ScalarTensor::Tags::ScalarMass>;
+  using return_type = Scalar<DataVector>;
+  static constexpr void (*function)(const gsl::not_null<return_type*> result,
+                                    const Scalar<DataVector>&,
+                                    const double) = &mass_source;
+  using base = ScalarSource;
+};
+
+}  // namespace Tags
+}  // namespace ScalarTensor

--- a/src/Evolution/Systems/ScalarTensor/Tags.hpp
+++ b/src/Evolution/Systems/ScalarTensor/Tags.hpp
@@ -7,13 +7,14 @@
 #include "DataStructures/DataBox/Tag.hpp"
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "Options/String.hpp"
 #include "Utilities/TMPL.hpp"
 
 /*!
  * \brief Tags for the scalar tensor system.
  */
-namespace ScalarTensor::Tags {
-
+namespace ScalarTensor {
+namespace Tags {
 /*!
  * \brief Represents the trace-reversed stress-energy tensor of the scalar
  * field.
@@ -23,4 +24,40 @@ struct TraceReversedStressEnergy : db::SimpleTag {
   using type = tnsr::aa<DataType, Dim, Fr>;
 };
 
-}  // namespace ScalarTensor::Tags
+/*!
+ * \brief Tag holding the source term of the scalar equation.
+ *
+ * \details This tag hold the source term \f$ \mathcal{S} \f$,
+ * entering a wave equation of the form
+ * \f[
+ *   \Box \Psi = \mathcal{S} ~.
+ * \f]
+ */
+struct ScalarSource : db::SimpleTag {
+  using type = Scalar<DataVector>;
+};
+
+}  // namespace Tags
+
+namespace OptionTags {
+/*!
+ * \brief Scalar mass parameter.
+ */
+struct ScalarMass {
+  static std::string name() { return "ScalarMass"; }
+  using type = double;
+  static constexpr Options::String help{
+      "Mass of the scalar field in code units"};
+};
+}  // namespace OptionTags
+
+namespace Tags {
+struct ScalarMass : db::SimpleTag {
+  using type = double;
+  using option_tags = tmpl::list<OptionTags::ScalarMass>;
+  static constexpr bool pass_metavariables = false;
+  static double create_from_options(const double mass_psi) { return mass_psi; }
+};
+}  // namespace Tags
+
+}  // namespace ScalarTensor

--- a/tests/Unit/Evolution/Systems/ScalarTensor/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/ScalarTensor/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY "Test_ScalarTensor")
 
 set(LIBRARY_SOURCES
+  Test_Sources.cpp
   Test_Tags.cpp
   )
 
@@ -18,4 +19,5 @@ target_link_libraries(
   ${LIBRARY}
   PRIVATE
   Framework
+  ScalarTensor
   )

--- a/tests/Unit/Evolution/Systems/ScalarTensor/Sources.py
+++ b/tests/Unit/Evolution/Systems/ScalarTensor/Sources.py
@@ -1,0 +1,12 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+
+
+def mass_source(psi, mass_psi):
+    return mass_psi * mass_psi * psi
+
+
+def add_scalar_source_to_dt_pi_scalar(scalar_source, lapse):
+    return 0.1234 + lapse * scalar_source

--- a/tests/Unit/Evolution/Systems/ScalarTensor/Test_Sources.cpp
+++ b/tests/Unit/Evolution/Systems/ScalarTensor/Test_Sources.cpp
@@ -1,0 +1,37 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <string>
+
+#include "Evolution/Systems/ScalarTensor/Sources/ScalarSource.hpp"
+#include "Framework/CheckWithRandomValues.hpp"
+#include "Framework/Pypp.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
+#include "Helpers/Domain/DomainTestHelpers.hpp"
+#include "Helpers/PointwiseFunctions/GeneralRelativity/TestHelpers.hpp"
+
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.ScalarTensor.SourceTags",
+                  "[Unit][Evolution]") {
+  TestHelpers::db::test_compute_tag<ScalarTensor::Tags::ScalarSourceCompute>(
+      "ScalarSource");
+}
+
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.ScalarTensor.Sources",
+                  "[Unit][Evolution]") {
+  pypp::SetupLocalPythonEnvironment local_python_env{
+      "Evolution/Systems/ScalarTensor"};
+
+  pypp::check_with_random_values<1>(&ScalarTensor::mass_source, "Sources",
+                                    {"mass_source"}, {{{1.0e-2, 0.5}}},
+                                    DataVector{5});
+
+  pypp::check_with_random_values<1>(
+      &ScalarTensor::add_scalar_source_to_dt_pi_scalar, "Sources",
+      {"add_scalar_source_to_dt_pi_scalar"}, {{{1.0e-2, 0.5}}}, DataVector{5},
+      1.0e-12, std::random_device{}(), 0.1234);
+}

--- a/tests/Unit/Evolution/Systems/ScalarTensor/Test_Tags.cpp
+++ b/tests/Unit/Evolution/Systems/ScalarTensor/Test_Tags.cpp
@@ -6,6 +6,7 @@
 #include <string>
 
 #include "Evolution/Systems/ScalarTensor/Tags.hpp"
+#include "Framework/TestCreation.hpp"
 #include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
 
 namespace {
@@ -24,4 +25,9 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.ScalarTensor.Tags",
   test_simple_tags<1_st, ArbitraryFrame>();
   test_simple_tags<2_st, ArbitraryFrame>();
   test_simple_tags<3_st, ArbitraryFrame>();
+  TestHelpers::db::test_simple_tag<ScalarTensor::Tags::ScalarMass>(
+      "ScalarMass");
+  TestHelpers::test_option_tag<ScalarTensor::OptionTags::ScalarMass>("1.0");
+  TestHelpers::db::test_simple_tag<ScalarTensor::Tags::ScalarSource>(
+      "ScalarSource");
 }


### PR DESCRIPTION
## Proposed changes

Add a scalar field mass term to the rhs of the scalar equations. The idea is to add more complicate sources in the same way.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
