### PR TITLE
Add AhC to BBH

### DIFF
--- a/src/Domain/Structure/ObjectLabel.cpp
+++ b/src/Domain/Structure/ObjectLabel.cpp
@@ -14,6 +14,8 @@ std::string name(const ObjectLabel x) {
     return "A"s;
   } else if (x == ObjectLabel::B) {
     return "B"s;
+  } else if (x == ObjectLabel::C) {
+    return "C"s;
   } else if (x == ObjectLabel::None) {
     return ""s;
   } else {

--- a/src/Domain/Structure/ObjectLabel.hpp
+++ b/src/Domain/Structure/ObjectLabel.hpp
@@ -13,6 +13,8 @@ enum class ObjectLabel {
   A,
   /// The object along the negative x-axis in the grid frame
   B,
+  /// A third object, typically centered at the origin.
+  C,
   /// This object has no label
   None
 };

--- a/src/Evolution/Executables/GeneralizedHarmonic/CMakeLists.txt
+++ b/src/Evolution/Executables/GeneralizedHarmonic/CMakeLists.txt
@@ -67,7 +67,7 @@ add_spectre_parallel_executable(
   EvolveGhBinaryBlackHole
   Evolution/Executables/GeneralizedHarmonic
   "EvolutionMetavars"
-  "${LIBS_TO_LINK};ApparentHorizons;Cce;ControlSystem"
+  "${LIBS_TO_LINK};ApparentHorizons;Cce;ControlSystem;EvolutionTriggers"
 )
 
 if (TARGET SpEC::Exporter)

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
@@ -63,6 +63,7 @@
 #include "Evolution/Systems/GeneralizedHarmonic/System.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
 #include "Evolution/Tags/Filter.hpp"
+#include "Evolution/Triggers/SeparationLessThan.hpp"
 #include "Evolution/TypeTraits.hpp"
 #include "IO/Importers/Actions/RegisterWithElementDataReader.hpp"
 #include "IO/Importers/ElementDataReader.hpp"
@@ -439,8 +440,10 @@ struct EvolutionMetavars {
         tmpl::pair<TimeSequence<std::uint64_t>,
                    TimeSequences::all_time_sequences<std::uint64_t>>,
         tmpl::pair<TimeStepper, TimeSteppers::time_steppers>,
-        tmpl::pair<Trigger, tmpl::append<Triggers::logical_triggers,
-                                         Triggers::time_triggers>>>;
+        tmpl::pair<
+            Trigger,
+            tmpl::append<Triggers::logical_triggers, Triggers::time_triggers,
+                         tmpl::list<Triggers::SeparationLessThan>>>>;
   };
 
   // A tmpl::list of tags to be added to the GlobalCache by the

--- a/src/Time/Tags/TimeAndPrevious.hpp
+++ b/src/Time/Tags/TimeAndPrevious.hpp
@@ -39,6 +39,7 @@ namespace Tags {
 /// DataBox.
 template <size_t Index>
 struct TimeAndPrevious : db::SimpleTag {
+  static constexpr size_t index = Index;
   using type = LinkedMessageId<double>;
   static std::string name() { return "TimeAndPrevious" + get_output(Index); }
 };

--- a/tests/InputFiles/GeneralizedHarmonic/BinaryBlackHole.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/BinaryBlackHole.yaml
@@ -224,6 +224,11 @@ EventsAndTriggers:
       - MonitorMemory:
           ComponentsToMonitor: All
   - Trigger:
+      SeparationLessThan:
+        Value: 2.0
+    Events:
+      - ObservationAhC
+  - Trigger:
       TimeCompares:
         Comparison: GreaterThan
         Value: 0.02

--- a/tests/InputFiles/GeneralizedHarmonic/BinaryBlackHole.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/BinaryBlackHole.yaml
@@ -261,6 +261,13 @@ ApparentHorizons:
       Center: [*XCoordB, 0.0, 0.0]
     FastFlow: *DefaultFastFlow
     Verbosity: Verbose
+  ObservationAhC:
+    InitialGuess:
+      LMax: 20
+      Radius: 10.0
+      Center: [0.0, 0.0, 0.0]
+    FastFlow: *DefaultFastFlow
+    Verbosity: Verbose
   ControlSystemAhA: *AhA
   ControlSystemAhB: *AhB
 

--- a/tests/InputFiles/GeneralizedHarmonic/CylindricalBinaryBlackHole.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/CylindricalBinaryBlackHole.yaml
@@ -205,6 +205,11 @@ EventsAndTriggers:
       - MonitorMemory:
           ComponentsToMonitor: All
   - Trigger:
+      SeparationLessThan:
+        Value: 2.0
+    Events:
+      - ObservationAhC
+  - Trigger:
       TimeCompares:
         Comparison: GreaterThan
         Value: 0.02

--- a/tests/InputFiles/GeneralizedHarmonic/CylindricalBinaryBlackHole.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/CylindricalBinaryBlackHole.yaml
@@ -242,6 +242,13 @@ ApparentHorizons:
       Center: [*XCoordB, 0.0, 0.0]
     FastFlow: *DefaultFastFlow
     Verbosity: Verbose
+  ObservationAhC:
+    InitialGuess:
+      LMax: 20
+      Radius: 10.0
+      Center: [0.0, 0.0, 0.0]
+    FastFlow: *DefaultFastFlow
+    Verbosity: Verbose
   ControlSystemAhA: *AhA
   ControlSystemAhB: *AhB
 

--- a/tests/Unit/Domain/Structure/Test_ObjectLabel.cpp
+++ b/tests/Unit/Domain/Structure/Test_ObjectLabel.cpp
@@ -11,6 +11,8 @@ SPECTRE_TEST_CASE("Unit.Domain.ObjectLabel", "[Domain][Unit]") {
   CHECK(get_output(domain::ObjectLabel::A) == "A");
   CHECK(name(domain::ObjectLabel::B) == "B");
   CHECK(get_output(domain::ObjectLabel::B) == "B");
+  CHECK(name(domain::ObjectLabel::C) == "C");
+  CHECK(get_output(domain::ObjectLabel::C) == "C");
   CHECK(name(domain::ObjectLabel::None) == "");
   CHECK(get_output(domain::ObjectLabel::None) == "");
 }


### PR DESCRIPTION
## Proposed changes

Also add the new `SeparationLessThan` trigger to the input files along with the event that will find AhC.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
BBH input files must now have an

```yaml
ApparentHorizons:
  ObservationAhC:
```

block.
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
