### PR TITLE
Pybindings for Combine-H5 functionality

### DIFF
--- a/src/Executables/CombineH5/CombineH5.cpp
+++ b/src/Executables/CombineH5/CombineH5.cpp
@@ -11,6 +11,7 @@
 #include "DataStructures/DataVector.hpp"
 #include "IO/H5/AccessType.hpp"
 #include "IO/H5/CheckH5PropertiesMatch.hpp"
+#include "IO/H5/CombineH5.hpp"
 #include "IO/H5/File.hpp"
 #include "IO/H5/SourceArchive.hpp"
 #include "IO/H5/VolumeData.hpp"
@@ -22,131 +23,6 @@
 // Charm looks for this function but since we build without a main function or
 // main module we just have it be empty
 extern "C" void CkRegisterMainModule(void) {}
-
-namespace {
-// Returns all the observation_ids stored in the volume files. Assumes all
-// volume files have the same observation ids
-std::vector<size_t> get_observation_ids(const std::string& file_prefix,
-                                        const std::string& subfile_name) {
-  const h5::H5File<h5::AccessType::ReadOnly> initial_file(file_prefix + "0.h5",
-                                                          false);
-  const auto& initial_volume_file =
-      initial_file.get<h5::VolumeData>("/" + subfile_name);
-  return initial_volume_file.list_observation_ids();
-}
-
-// Returns total number of elements for an observation id across all volume data
-// files
-size_t get_number_of_elements(const std::vector<std::string>& input_filenames,
-                              const std::string& subfile_name,
-                              const size_t& observation_id) {
-  size_t total_elements = 0;
-  for (const auto& input_filename : input_filenames) {
-    const h5::H5File<h5::AccessType::ReadOnly> original_file(input_filename,
-                                                             false);
-    const auto& original_volume_file =
-        original_file.get<h5::VolumeData>("/" + subfile_name);
-    total_elements += original_volume_file.get_extents(observation_id).size();
-  }
-  return total_elements;
-}
-
-void combine_h5(const std::string& file_prefix, const std::string& subfile_name,
-                const std::string& output) {
-  // Parses for and stores all input files to be looped over
-  const std::vector<std::string>& file_names =
-      file_system::glob(file_prefix + "[0-9]*.h5");
-  Parallel::printf("Processing files:\n%s\n",
-                   std::string{MakeString{} << file_names}.c_str());
-
-  // Checks that volume data was generated with identical versions of SpECTRE
-  if (!h5::check_src_files_match(file_names)) {
-    ERROR(
-        "One or more of your files were found to have differing src.tar.gz "
-        "files, meaning that they may be from differing versions of SpECTRE.");
-  }
-
-  // Checks that volume data files contain the same observation ids
-  if (!h5::check_observation_ids_match(file_names, subfile_name)) {
-    ERROR(
-        "One or more of your files were found to have differing observation "
-        "ids, meaning they may be from different runs of your SpECTRE "
-        "executable or were corrupted.");
-  }
-
-  // Braces to specify scope for H5 file
-  {
-    // Instantiates the output file and the .vol subfile to be filled with the
-    // combined data later
-    Parallel::printf("Creating output file: %s0.h5\n", output.c_str());
-    h5::H5File<h5::AccessType::ReadWrite> new_file(output + "0.h5", true);
-    new_file.insert<h5::VolumeData>("/" + subfile_name + ".vol");
-    new_file.close_current_object();
-  }  // End of scope for H5 file
-
-  // Obtains list of observation ids to loop over
-  const std::vector<size_t> observation_ids =
-      get_observation_ids(file_prefix, subfile_name);
-
-  // Loops over observation ids to write volume data by observation id
-  for (size_t obs_index = 0; obs_index < observation_ids.size(); ++obs_index) {
-    const size_t obs_id = observation_ids[obs_index];
-    // Pre-calculates size of vector to store element data and allocates
-    // corresponding memory
-    const size_t vector_dim =
-        get_number_of_elements(file_names, subfile_name, obs_id);
-    std::vector<ElementVolumeData> element_data;
-    element_data.reserve(vector_dim);
-
-    double obs_val = 0.0;
-    std::optional<std::vector<char>> serialized_domain{};
-    std::optional<std::vector<char>> serialized_functions_of_time{};
-
-    // Loops over input files to append element data into a single vector to be
-    // stored in a single H5
-    bool printed = false;
-    for (auto const& file_name : file_names) {
-      const h5::H5File<h5::AccessType::ReadOnly> original_file(file_name,
-                                                               false);
-      const auto& original_volume_file =
-          original_file.get<h5::VolumeData>("/" + subfile_name);
-      obs_val = original_volume_file.get_observation_value(obs_id);
-      if (not printed) {
-        Parallel::printf(
-            "Processing obsevation ID %lo (%lo/%lo) with value %1.14e\n",
-            obs_id, obs_index, observation_ids.size(), obs_val);
-        printed = true;
-      }
-      Parallel::printf("  Processing file: %s\n", file_name.c_str());
-
-      serialized_domain = original_volume_file.get_domain(obs_id);
-      serialized_functions_of_time =
-          original_volume_file.get_functions_of_time(obs_id);
-
-      // Get vector of element data for this `obs_id` and `file_name`
-      std::vector<ElementVolumeData> data_by_element =
-          std::move(std::get<2>(original_volume_file.get_data_by_element(
-              obs_val * (1.0 - 4.0 * std::numeric_limits<double>::epsilon()),
-              obs_val * (1.0 + 4.0 * std::numeric_limits<double>::epsilon()),
-              std::nullopt)[0]));
-
-      // Append vector to total vector of element data for this `obs_id`
-      element_data.insert(element_data.end(),
-                          std::make_move_iterator(data_by_element.begin()),
-                          std::make_move_iterator(data_by_element.end()));
-      data_by_element.clear();
-      original_file.close_current_object();
-    }
-
-    h5::H5File<h5::AccessType::ReadWrite> new_file(output + "0.h5", true);
-    auto& new_volume_file = new_file.get<h5::VolumeData>("/" + subfile_name);
-    new_volume_file.write_volume_data(obs_id, obs_val, element_data,
-                                      serialized_domain,
-                                      serialized_functions_of_time);
-    new_file.close_current_object();
-  }
-}
-}  // namespace
 
 /*
  * This executable is used for combining a series of HDF5 volume files into one
@@ -180,7 +56,7 @@ int main(int argc, char** argv) {
     return 1;
   }
 
-  combine_h5(vars["file_prefix"].as<std::string>(),
-             vars["subfile_name"].as<std::string>(),
-             vars["output"].as<std::string>());
+  h5::combine_h5(vars["file_prefix"].as<std::string>(),
+                 vars["subfile_name"].as<std::string>(),
+                 vars["output"].as<std::string>());
 }

--- a/src/IO/H5/CMakeLists.txt
+++ b/src/IO/H5/CMakeLists.txt
@@ -10,6 +10,7 @@ spectre_target_sources(
   PRIVATE
   AccessType.cpp
   CheckH5PropertiesMatch.cpp
+  CombineH5.cpp
   Dat.cpp
   EosTable.cpp
   ExtendConnectivityHelpers.cpp
@@ -32,6 +33,7 @@ spectre_target_headers(
   AccessType.hpp
   CheckH5.hpp
   CheckH5PropertiesMatch.hpp
+  CombineH5.hpp
   Dat.hpp
   EosTable.hpp
   ExtendConnectivityHelpers.hpp

--- a/src/IO/H5/CombineH5.cpp
+++ b/src/IO/H5/CombineH5.cpp
@@ -46,7 +46,7 @@ size_t get_number_of_elements(const std::vector<std::string>& input_filenames,
   }
   return total_elements;
 }
-}  // namespace
+}
 namespace h5 {
 
 void combine_h5(const std::string& file_prefix, const std::string& subfile_name,

--- a/src/IO/H5/CombineH5.cpp
+++ b/src/IO/H5/CombineH5.cpp
@@ -1,6 +1,8 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
+#include "IO/H5/CombineH5.hpp"
+
 #include <boost/program_options.hpp>
 #include <cstddef>
 #include <cstdlib>
@@ -46,11 +48,11 @@ size_t get_number_of_elements(const std::vector<std::string>& input_filenames,
   }
   return total_elements;
 }
-}
+} //namespace
 namespace h5 {
 
 void combine_h5(const std::string& file_prefix, const std::string& subfile_name,
-                const std::string& output) {
+                const std::string& output, const bool check_src) {
   // Parses for and stores all input files to be looped over
   const std::vector<std::string>& file_names =
       file_system::glob(file_prefix + "[0-9]*.h5");
@@ -58,10 +60,12 @@ void combine_h5(const std::string& file_prefix, const std::string& subfile_name,
                    std::string{MakeString{} << file_names}.c_str());
 
   // Checks that volume data was generated with identical versions of SpECTRE
-  if (!h5::check_src_files_match(file_names)) {
+  if (check_src){
+    if (!h5::check_src_files_match(file_names)) {
     ERROR(
         "One or more of your files were found to have differing src.tar.gz "
         "files, meaning that they may be from differing versions of SpECTRE.");
+  }
   }
 
   // Checks that volume data files contain the same observation ids

--- a/src/IO/H5/CombineH5.cpp
+++ b/src/IO/H5/CombineH5.cpp
@@ -1,0 +1,147 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include <boost/program_options.hpp>
+#include <cstddef>
+#include <cstdlib>
+#include <iterator>
+#include <string>
+#include <vector>
+
+#include "DataStructures/DataVector.hpp"
+#include "IO/H5/AccessType.hpp"
+#include "IO/H5/CheckH5PropertiesMatch.hpp"
+#include "IO/H5/File.hpp"
+#include "IO/H5/SourceArchive.hpp"
+#include "IO/H5/VolumeData.hpp"
+#include "Parallel/Printf.hpp"
+#include "Utilities/FileSystem.hpp"
+#include "Utilities/MakeString.hpp"
+#include "Utilities/StdHelpers.hpp"
+
+namespace {
+// Returns all the observation_ids stored in the volume files. Assumes all
+// volume files have the same observation ids
+std::vector<size_t> get_observation_ids(const std::string& file_prefix,
+                                        const std::string& subfile_name) {
+  const h5::H5File<h5::AccessType::ReadOnly> initial_file(file_prefix + "0.h5",
+                                                          false);
+  const auto& initial_volume_file =
+      initial_file.get<h5::VolumeData>("/" + subfile_name);
+  return initial_volume_file.list_observation_ids();
+}
+
+// Returns total number of elements for an observation id across all volume data
+// files
+size_t get_number_of_elements(const std::vector<std::string>& input_filenames,
+                              const std::string& subfile_name,
+                              const size_t& observation_id) {
+  size_t total_elements = 0;
+  for (const auto& input_filename : input_filenames) {
+    const h5::H5File<h5::AccessType::ReadOnly> original_file(input_filename,
+                                                             false);
+    const auto& original_volume_file =
+        original_file.get<h5::VolumeData>("/" + subfile_name);
+    total_elements += original_volume_file.get_extents(observation_id).size();
+  }
+  return total_elements;
+}
+}  // namespace
+namespace h5 {
+
+void combine_h5(const std::string& file_prefix, const std::string& subfile_name,
+                const std::string& output) {
+  // Parses for and stores all input files to be looped over
+  const std::vector<std::string>& file_names =
+      file_system::glob(file_prefix + "[0-9]*.h5");
+  Parallel::printf("Processing files:\n%s\n",
+                   std::string{MakeString{} << file_names}.c_str());
+
+  // Checks that volume data was generated with identical versions of SpECTRE
+  if (!h5::check_src_files_match(file_names)) {
+    ERROR(
+        "One or more of your files were found to have differing src.tar.gz "
+        "files, meaning that they may be from differing versions of SpECTRE.");
+  }
+
+  // Checks that volume data files contain the same observation ids
+  if (!h5::check_observation_ids_match(file_names, subfile_name)) {
+    ERROR(
+        "One or more of your files were found to have differing observation "
+        "ids, meaning they may be from different runs of your SpECTRE "
+        "executable or were corrupted.");
+  }
+
+  // Braces to specify scope for H5 file
+  {
+    // Instantiates the output file and the .vol subfile to be filled with the
+    // combined data later
+    Parallel::printf("Creating output file: %s0.h5\n", output.c_str());
+    h5::H5File<h5::AccessType::ReadWrite> new_file(output + "0.h5", true);
+    new_file.insert<h5::VolumeData>("/" + subfile_name + ".vol");
+    new_file.close_current_object();
+  }  // End of scope for H5 file
+
+  // Obtains list of observation ids to loop over
+  const std::vector<size_t> observation_ids =
+      get_observation_ids(file_prefix, subfile_name);
+
+  // Loops over observation ids to write volume data by observation id
+  for (size_t obs_index = 0; obs_index < observation_ids.size(); ++obs_index) {
+    const size_t obs_id = observation_ids[obs_index];
+    // Pre-calculates size of vector to store element data and allocates
+    // corresponding memory
+    const size_t vector_dim =
+        get_number_of_elements(file_names, subfile_name, obs_id);
+    std::vector<ElementVolumeData> element_data;
+    element_data.reserve(vector_dim);
+
+    double obs_val = 0.0;
+    std::optional<std::vector<char>> serialized_domain{};
+    std::optional<std::vector<char>> serialized_functions_of_time{};
+
+    // Loops over input files to append element data into a single vector to be
+    // stored in a single H5
+    bool printed = false;
+    for (auto const& file_name : file_names) {
+      const h5::H5File<h5::AccessType::ReadOnly> original_file(file_name,
+                                                               false);
+      const auto& original_volume_file =
+          original_file.get<h5::VolumeData>("/" + subfile_name);
+      obs_val = original_volume_file.get_observation_value(obs_id);
+      if (not printed) {
+        Parallel::printf(
+            "Processing obsevation ID %lo (%lo/%lo) with value %1.14e\n",
+            obs_id, obs_index, observation_ids.size(), obs_val);
+        printed = true;
+      }
+      Parallel::printf("  Processing file: %s\n", file_name.c_str());
+
+      serialized_domain = original_volume_file.get_domain(obs_id);
+      serialized_functions_of_time =
+          original_volume_file.get_functions_of_time(obs_id);
+
+      // Get vector of element data for this `obs_id` and `file_name`
+      std::vector<ElementVolumeData> data_by_element =
+          std::move(std::get<2>(original_volume_file.get_data_by_element(
+              obs_val * (1.0 - 4.0 * std::numeric_limits<double>::epsilon()),
+              obs_val * (1.0 + 4.0 * std::numeric_limits<double>::epsilon()),
+              std::nullopt)[0]));
+
+      // Append vector to total vector of element data for this `obs_id`
+      element_data.insert(element_data.end(),
+                          std::make_move_iterator(data_by_element.begin()),
+                          std::make_move_iterator(data_by_element.end()));
+      data_by_element.clear();
+      original_file.close_current_object();
+    }
+
+    h5::H5File<h5::AccessType::ReadWrite> new_file(output + "0.h5", true);
+    auto& new_volume_file = new_file.get<h5::VolumeData>("/" + subfile_name);
+    new_volume_file.write_volume_data(obs_id, obs_val, element_data,
+                                      serialized_domain,
+                                      serialized_functions_of_time);
+    new_file.close_current_object();
+  }
+}
+}  // namespace h5

--- a/src/IO/H5/CombineH5.hpp
+++ b/src/IO/H5/CombineH5.hpp
@@ -1,28 +1,13 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
+
 #pragma once
 
-#include <boost/program_options.hpp>
-#include <cstddef>
-#include <cstdlib>
-#include <iterator>
 #include <string>
-#include <vector>
-
-#include "DataStructures/DataVector.hpp"
-#include "IO/H5/AccessType.hpp"
-#include "IO/H5/CheckH5PropertiesMatch.hpp"
-#include "IO/H5/File.hpp"
-#include "IO/H5/SourceArchive.hpp"
-#include "IO/H5/VolumeData.hpp"
-#include "Parallel/Printf.hpp"
-#include "Utilities/FileSystem.hpp"
-#include "Utilities/MakeString.hpp"
-#include "Utilities/StdHelpers.hpp"
 
 namespace h5 {
 
 void combine_h5(const std::string& file_prefix, const std::string& subfile_name,
-                const std::string& output);
+                const std::string& output, const bool check_src = true);
 
 }  // namespace h5

--- a/src/IO/H5/CombineH5.hpp
+++ b/src/IO/H5/CombineH5.hpp
@@ -1,0 +1,26 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+#pragma once
+
+#include <boost/program_options.hpp>
+#include <cstddef>
+#include <cstdlib>
+#include <iterator>
+#include <string>
+#include <vector>
+
+#include "DataStructures/DataVector.hpp"
+#include "IO/H5/AccessType.hpp"
+#include "IO/H5/CheckH5PropertiesMatch.hpp"
+#include "IO/H5/File.hpp"
+#include "IO/H5/SourceArchive.hpp"
+#include "IO/H5/VolumeData.hpp"
+#include "Parallel/Printf.hpp"
+#include "Utilities/FileSystem.hpp"
+#include "Utilities/MakeString.hpp"
+#include "Utilities/StdHelpers.hpp"
+
+namespace h5 {
+void combine_h5(const std::string& file_prefix, const std::string& subfile_name,
+                const std::string& output);
+}  // namespace h5

--- a/src/IO/H5/CombineH5.hpp
+++ b/src/IO/H5/CombineH5.hpp
@@ -21,6 +21,8 @@
 #include "Utilities/StdHelpers.hpp"
 
 namespace h5 {
+
 void combine_h5(const std::string& file_prefix, const std::string& subfile_name,
                 const std::string& output);
+
 }  // namespace h5

--- a/src/IO/H5/Python/Bindings.cpp
+++ b/src/IO/H5/Python/Bindings.cpp
@@ -3,6 +3,7 @@
 
 #include <pybind11/pybind11.h>
 
+#include "IO/H5/Python/CombineH5.hpp"
 #include "IO/H5/Python/Dat.hpp"
 #include "IO/H5/Python/File.hpp"
 #include "IO/H5/Python/TensorData.hpp"
@@ -19,4 +20,5 @@ PYBIND11_MODULE(_Pybindings, m) {  // NOLINT
   py_bindings::bind_h5dat(m);
   py_bindings::bind_h5vol(m);
   py_bindings::bind_tensordata(m);
+  py_bindings::bind_h5combine(m);
 }

--- a/src/IO/H5/Python/CMakeLists.txt
+++ b/src/IO/H5/Python/CMakeLists.txt
@@ -15,6 +15,7 @@ spectre_python_add_module(
   VolumeData.cpp
   PYTHON_FILES
   __init__.py
+  CombineH5.py
   DeleteSubfiles.py
   ExtendConnectivityData.py
   ExtractDatFromH5.py

--- a/src/IO/H5/Python/CMakeLists.txt
+++ b/src/IO/H5/Python/CMakeLists.txt
@@ -8,6 +8,7 @@ spectre_python_add_module(
   LIBRARY_NAME ${LIBRARY}
   SOURCES
   Bindings.cpp
+  CombineH5.cpp
   Dat.cpp
   File.cpp
   TensorData.cpp
@@ -26,6 +27,7 @@ spectre_python_headers(
   ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
+  CombineH5.hpp
   Dat.hpp
   File.hpp
   TensorData.hpp

--- a/src/IO/H5/Python/CombineH5.cpp
+++ b/src/IO/H5/Python/CombineH5.cpp
@@ -1,0 +1,20 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "IO/H5/Python/CombineH5.hpp"
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <string>
+
+#include "IO/H5/CombineH5.hpp"
+
+namespace py = pybind11;
+
+namespace py_bindings {
+void bind_h5combine(py::module& m) {
+  // Wrapper for combining h5 files
+  m.def("combine_h5", &h5::combine_h5, py::arg("file_prefix"),
+        py::arg("subfile_name"), py::arg("output"));
+}
+}  // namespace py_bindings

--- a/src/IO/H5/Python/CombineH5.cpp
+++ b/src/IO/H5/Python/CombineH5.cpp
@@ -15,6 +15,6 @@ namespace py_bindings {
 void bind_h5combine(py::module& m) {
   // Wrapper for combining h5 files
   m.def("combine_h5", &h5::combine_h5, py::arg("file_prefix"),
-        py::arg("subfile_name"), py::arg("output"));
+        py::arg("subfile_name"), py::arg("output"), py::arg("check_src"));
 }
 }  // namespace py_bindings

--- a/src/IO/H5/Python/CombineH5.hpp
+++ b/src/IO/H5/Python/CombineH5.hpp
@@ -1,0 +1,11 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <pybind11/pybind11.h>
+
+namespace py_bindings {
+// NOLINTNEXTLINE(google-runtime-references)
+void bind_h5combine(pybind11::module& m);
+}  // namespace py_bindings

--- a/src/IO/H5/Python/CombineH5.py
+++ b/src/IO/H5/Python/CombineH5.py
@@ -1,0 +1,71 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import logging
+import os
+
+import click
+import rich
+
+import spectre.IO.H5 as spectre_h5
+
+
+@click.command(name="combine-h5")
+@click.option(
+    "--file-prefix",
+    required=True,
+    type=str,
+    help="prefix of the files to be combined (omit number and file extension)",
+)
+@click.option(
+    "--subfile-name",
+    "-d",
+    type=str,
+    help="subfile name of the volume file in the H5 file (omit file extension)",
+)
+@click.option(
+    "--output",
+    "-o",
+    required=True,
+    type=click.Path(
+        exists=False,
+        file_okay=True,
+        dir_okay=False,
+        writable=True,
+        readable=True,
+    ),
+    help="combined output filename (omit file extension)",
+)
+@click.option(
+    "--check-src/--no-check-src",
+    default=True,
+    show_default=True,
+    help=(
+        "flag to check src files, True implies src files exist and can be"
+        " checked, False implies no src files to check."
+    ),
+)
+def combine_h5_command(file_prefix, subfile_name, output, check_src):
+    """Combines multiple HDF5 volume files
+
+    This executable is used for combining a series of HDF5 volume files into one
+    continuous dataset to be stored in a single HDF5 volume file."""
+
+    # Print available subfile names and exit
+    filename = file_prefix + "0.h5"
+    if not subfile_name:
+        if os.path.exists(filename):
+            spectre_file = spectre_h5.H5File(filename, "r")
+            import rich.columns
+
+            rich.print(rich.columns.Columns(spectre_file.all_vol_files()))
+            return
+
+    if subfile_name[0] == "/":
+        subfile_name = subfile_name[1:]
+
+    spectre_h5.combine_h5(file_prefix, subfile_name, output, check_src)
+
+
+if __name__ == "__main__":
+    combine_h5_command(help_option_names=["-h", "--help"])

--- a/support/Python/__main__.py
+++ b/support/Python/__main__.py
@@ -21,6 +21,7 @@ class Cli(click.MultiCommand):
     def list_commands(self, ctx):
         return [
             "clean-output",
+            "combine-h5",
             "delete-subfiles",
             "extend-connectivity",
             "extract-dat",
@@ -44,6 +45,10 @@ class Cli(click.MultiCommand):
             from spectre.tools.CleanOutput import clean_output_command
 
             return clean_output_command
+        elif name == "combine-h5":
+            from spectre.IO.H5.CombineH5 import combine_h5_command
+
+            return combine_h5_command
         elif name == "delete-subfiles":
             from spectre.IO.H5.DeleteSubfiles import delete_subfiles_command
 

--- a/tests/Unit/IO/H5/CMakeLists.txt
+++ b/tests/Unit/IO/H5/CMakeLists.txt
@@ -35,6 +35,23 @@ target_link_libraries(
   )
 
 spectre_add_python_bindings_test(
+  "Unit.IO.H5.CombineH5.Python"
+  "Test_CombineH5.py"
+  "unit;IO;H5;Python"
+  PyH5
+  )
+
+if(${BUILD_PYTHON_BINDINGS})
+  # Test is a bit slow because it writes a bunch of plot files to verify
+  # the argument handling works.
+  set_tests_properties(
+    "Unit.IO.H5.CombineH5.Python"
+    PROPERTIES
+    TIMEOUT 80
+    )
+endif()
+
+spectre_add_python_bindings_test(
   "Unit.IO.H5.Python"
   "Test_H5.py"
   "unit;IO;H5;python"

--- a/tests/Unit/IO/H5/CMakeLists.txt
+++ b/tests/Unit/IO/H5/CMakeLists.txt
@@ -42,12 +42,10 @@ spectre_add_python_bindings_test(
   )
 
 if(${BUILD_PYTHON_BINDINGS})
-  # Test is a bit slow because it writes a bunch of plot files to verify
-  # the argument handling works.
   set_tests_properties(
     "Unit.IO.H5.CombineH5.Python"
     PROPERTIES
-    TIMEOUT 80
+    TIMEOUT 10
     )
 endif()
 

--- a/tests/Unit/IO/H5/Test_CombineH5.py
+++ b/tests/Unit/IO/H5/Test_CombineH5.py
@@ -1,0 +1,159 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import os
+import unittest
+
+import numpy as np
+
+import spectre.IO.H5 as spectre_h5
+from spectre import Informer
+from spectre.DataStructures import DataVector
+from spectre.IO.H5 import ElementVolumeData, TensorComponent, combine_h5
+from spectre.Spectral import Basis, Quadrature
+
+
+class TestCombineH5(unittest.TestCase):
+    # Test Fixtures
+    def setUp(self):
+        # The tests in this class combine 2 HDF5 files to generate one,
+        # using the Combine_H5 functionality.
+        self.file_name1 = os.path.join(
+            Informer.unit_test_build_path(), "IO/TestVolumeData0.h5"
+        )
+        self.file_name2 = os.path.join(
+            Informer.unit_test_build_path(), "IO/TestVolumeData1.h5"
+        )
+
+        self.output_file = os.path.join(
+            Informer.unit_test_build_path(), "IO/TestOutput"
+        )
+
+        if os.path.isfile(self.file_name1):
+            os.remove(self.file_name1)
+        if os.path.isfile(self.file_name2):
+            os.remove(self.file_name2)
+        if os.path.isfile(self.output_file + "0.h5"):
+            os.remove(self.output_file + "0.h5")
+
+        # Initializing attributes
+        grid_names1 = ["[B0(L0I0,L0I0,L1I0)]"]
+        grid_names2 = ["[B0(L1I0,L0I0,L0I0)]"]
+        observation_values = {0: 7.0, 1: 1.3}
+        basis = Basis.Legendre
+        quad = Quadrature.Gauss
+        self.observation_ids = [0, 1]
+
+        # Writing ElementVolume data and TensorComponent Data to first file
+        self.h5_file1 = spectre_h5.H5File(file_name=self.file_name1, mode="a")
+        self.tensor_component_data1 = np.array([[0.0], [0.3], [0.6]])
+        self.h5_file1.insert_vol("/element_data", version=0)
+        self.h5_file1.close_current_object()
+        self.vol_file1 = self.h5_file1.get_vol(path="/element_data")
+
+        self.element_vol_data_file_1 = [
+            ElementVolumeData(
+                element_name=grid_names1[0],
+                components=[
+                    TensorComponent(
+                        "field_1", DataVector(self.tensor_component_data1[i])
+                    ),
+                    TensorComponent(
+                        "field_2",
+                        DataVector(self.tensor_component_data1[i + 1]),
+                    ),
+                ],
+                extents=3 * [2],
+                basis=3 * [basis],
+                quadrature=3 * [quad],
+            )
+            for i, observation_id in enumerate(self.observation_ids)
+        ]
+
+        # Write extents and tensor volume data to the volfile
+        for i, observation_id in enumerate(self.observation_ids):
+            self.vol_file1.write_volume_data(
+                observation_id,
+                observation_values[observation_id],
+                [
+                    self.element_vol_data_file_1[i],
+                ],
+            )
+
+        # Store initial connectivity data
+        self.initial_h5_connectivity = self.vol_file1.get_tensor_component(
+            self.observation_ids[0], "connectivity"
+        ).data
+
+        self.h5_file1.close()
+
+        # Writing ElementVolume data and TensorComponent Data to second file
+        self.h5_file2 = spectre_h5.H5File(file_name=self.file_name2, mode="a")
+        self.tensor_component_data2 = np.array([[1.0], [0.13], [0.16]])
+        self.h5_file2.insert_vol("/element_data", version=0)
+        self.h5_file2.close_current_object()
+        self.vol_file2 = self.h5_file2.get_vol(path="/element_data")
+
+        self.element_vol_data_file_2 = [
+            ElementVolumeData(
+                element_name=grid_names2[0],
+                components=[
+                    TensorComponent(
+                        "field_1", DataVector(self.tensor_component_data2[i])
+                    ),
+                    TensorComponent(
+                        "field_2",
+                        DataVector(self.tensor_component_data2[i + 1]),
+                    ),
+                ],
+                extents=3 * [2],
+                basis=3 * [basis],
+                quadrature=3 * [quad],
+            )
+            for i, observation_id in enumerate(self.observation_ids)
+        ]
+
+        # Write extents and tensor volume data to the volfile
+        for i, observation_id in enumerate(self.observation_ids):
+            self.vol_file2.write_volume_data(
+                observation_id,
+                observation_values[observation_id],
+                [
+                    self.element_vol_data_file_2[i],
+                ],
+            )
+        self.h5_file2.close()
+
+    def tearDown(self):
+        self.h5_file1.close()
+        self.h5_file2.close()
+        if os.path.isfile(self.file_name1):
+            os.remove(self.file_name1)
+        if os.path.isfile(self.file_name2):
+            os.remove(self.file_name2)
+        if os.path.isfile(self.output_file + "0.h5"):
+            os.remove(self.output_file + "0.h5")
+
+    def test_combine_h5(self):
+        # Run the combine_h5 command and check if any feature (for eg.
+        # connectivity length has increased due to combining two files)
+
+        combine_h5(self.file_name1[:-4], "element_data", self.output_file)
+        h5_output = spectre_h5.H5File(
+            file_name=self.output_file + "0.h5", mode="a"
+        )
+        output_vol = h5_output.get_vol(path="/element_data")
+
+        # Extracts the connectivity data from the volume file
+        # If length of final connectivity is more, combine_h5
+        # has successfully merged the two HDF5 files.
+
+        final_h5_connectivity = output_vol.get_tensor_component(
+            self.observation_ids[0], "connectivity"
+        ).data
+
+        assert len(self.initial_h5_connectivity) < len(final_h5_connectivity)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Proposed changes

Creates a different file for the combine_h5 cpp function. Adds the pybinding wrapper for the function along with a test. Creates a CLI endpoint for the combineh5 functionality. (Proposal to add a flag to the combine_h5 function in CombineH5.cpp for src files that may not exist before attempting to check them.)

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [x] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
