### PR TITLE
Only use BCO domains in BBH exec

### DIFF
--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
@@ -24,9 +24,8 @@
 #include "ControlSystem/Trigger.hpp"
 #include "DataStructures/DataBox/PrefixHelpers.hpp"
 #include "DataStructures/DataBox/Tag.hpp"
-#include "Domain/Creators/Factory1D.hpp"
-#include "Domain/Creators/Factory2D.hpp"
-#include "Domain/Creators/Factory3D.hpp"
+#include "Domain/Creators/BinaryCompactObject.hpp"
+#include "Domain/Creators/CylindricalBinaryCompactObject.hpp"
 #include "Domain/Creators/RegisterDerivedWithCharm.hpp"
 #include "Domain/Creators/TimeDependence/RegisterDerivedWithCharm.hpp"
 #include "Domain/FunctionsOfTime/FunctionsOfTimeAreReady.hpp"
@@ -395,7 +394,10 @@ struct EvolutionMetavars {
                    tmpl::flatten<tmpl::list<
                        control_system::control_system_triggers<control_systems>,
                        DenseTriggers::standard_dense_triggers>>>,
-        tmpl::pair<DomainCreator<volume_dim>, domain_creators<volume_dim>>,
+        tmpl::pair<
+            DomainCreator<volume_dim>,
+            tmpl::list<::domain::creators::BinaryCompactObject,
+                       ::domain::creators::CylindricalBinaryCompactObject>>,
         tmpl::pair<
             Event,
             tmpl::flatten<tmpl::list<


### PR DESCRIPTION
## Proposed changes

Not sure why we allowed other domains before. BBHs only work with 2 excisions and we only have 2 domains that can support that.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
