### PR TITLE
Add time derivative computation to ScalarTensor

### DIFF
--- a/src/Evolution/Systems/ScalarTensor/CMakeLists.txt
+++ b/src/Evolution/Systems/ScalarTensor/CMakeLists.txt
@@ -9,6 +9,8 @@ spectre_target_sources(
   ${LIBRARY}
   PRIVATE
   StressEnergy.cpp
+  TimeDerivative.cpp
+  VolumeTermsInstantiation.cpp
   )
 
 spectre_target_headers(
@@ -19,6 +21,7 @@ spectre_target_headers(
   StressEnergy.hpp
   System.hpp
   Tags.hpp
+  TimeDerivative.hpp
   )
 
 target_link_libraries(

--- a/src/Evolution/Systems/ScalarTensor/System.hpp
+++ b/src/Evolution/Systems/ScalarTensor/System.hpp
@@ -9,6 +9,8 @@
 #include "Evolution/Systems/CurvedScalarWave/System.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/System.hpp"
 #include "Evolution/Systems/ScalarTensor/Characteristics.hpp"
+#include "Evolution/Systems/ScalarTensor/Tags.hpp"
+#include "Evolution/Systems/ScalarTensor/TimeDerivative.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -81,6 +83,7 @@ struct System {
   using compute_largest_characteristic_speed =
       Tags::ComputeLargestCharacteristicSpeed<>;
 
+  using compute_volume_time_derivative_terms = ScalarTensor::TimeDerivative;
   using inverse_spatial_metric_tag =
       typename gh_system::inverse_spatial_metric_tag;
 };

--- a/src/Evolution/Systems/ScalarTensor/TimeDerivative.cpp
+++ b/src/Evolution/Systems/ScalarTensor/TimeDerivative.cpp
@@ -1,0 +1,166 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/ScalarTensor/TimeDerivative.hpp"
+
+#include <cstddef>
+
+#include "DataStructures/DataBox/PrefixHelpers.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/TaggedContainers.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Evolution/Systems/CurvedScalarWave/System.hpp"
+#include "Evolution/Systems/CurvedScalarWave/TimeDerivative.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/System.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/TimeDerivative.hpp"
+#include "Evolution/Systems/ScalarTensor/Sources/ScalarSource.hpp"
+#include "Evolution/Systems/ScalarTensor/StressEnergy.hpp"
+#include "Evolution/Systems/ScalarTensor/System.hpp"
+#include "Evolution/Systems/ScalarTensor/Tags.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Time/Tags/Time.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Literals.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace ScalarTensor {
+void TimeDerivative::apply(
+    // GH dt variables
+    const gsl::not_null<tnsr::aa<DataVector, dim>*> dt_spacetime_metric,
+    const gsl::not_null<tnsr::aa<DataVector, dim>*> dt_pi,
+    const gsl::not_null<tnsr::iaa<DataVector, dim>*> dt_phi,
+    // Scalar dt variables
+    const gsl::not_null<Scalar<DataVector>*> dt_psi_scalar,
+    const gsl::not_null<Scalar<DataVector>*> dt_pi_scalar,
+    const gsl::not_null<tnsr::i<DataVector, dim, Frame::Inertial>*>
+        dt_phi_scalar,
+
+    // GH temporal variables
+    const gsl::not_null<Scalar<DataVector>*> temp_gamma1,
+    const gsl::not_null<Scalar<DataVector>*> temp_gamma2,
+    const gsl::not_null<tnsr::a<DataVector, dim>*> temp_gauge_function,
+    const gsl::not_null<tnsr::ab<DataVector, dim>*>
+        temp_spacetime_deriv_gauge_function,
+    const gsl::not_null<Scalar<DataVector>*> gamma1gamma2,
+    const gsl::not_null<Scalar<DataVector>*> half_half_pi_two_normals,
+    const gsl::not_null<Scalar<DataVector>*> normal_dot_gauge_constraint,
+    const gsl::not_null<Scalar<DataVector>*> gamma1_plus_1,
+    const gsl::not_null<tnsr::a<DataVector, dim>*> pi_one_normal,
+    const gsl::not_null<tnsr::a<DataVector, dim>*> gauge_constraint,
+    const gsl::not_null<tnsr::i<DataVector, dim>*> half_phi_two_normals,
+    const gsl::not_null<tnsr::aa<DataVector, dim>*>
+        shift_dot_three_index_constraint,
+    const gsl::not_null<tnsr::aa<DataVector, dim>*>
+        mesh_velocity_dot_three_index_constraint,
+    const gsl::not_null<tnsr::ia<DataVector, dim>*> phi_one_normal,
+    const gsl::not_null<tnsr::aB<DataVector, dim>*> pi_2_up,
+    const gsl::not_null<tnsr::iaa<DataVector, dim>*> three_index_constraint,
+    const gsl::not_null<tnsr::Iaa<DataVector, dim>*> phi_1_up,
+    const gsl::not_null<tnsr::iaB<DataVector, dim>*> phi_3_up,
+    const gsl::not_null<tnsr::abC<DataVector, dim>*>
+        christoffel_first_kind_3_up,
+    const gsl::not_null<Scalar<DataVector>*> lapse,
+    const gsl::not_null<tnsr::I<DataVector, dim>*> shift,
+    const gsl::not_null<tnsr::II<DataVector, dim>*> inverse_spatial_metric,
+    const gsl::not_null<Scalar<DataVector>*> det_spatial_metric,
+    const gsl::not_null<Scalar<DataVector>*> sqrt_det_spatial_metric,
+    const gsl::not_null<tnsr::AA<DataVector, dim>*> inverse_spacetime_metric,
+    const gsl::not_null<tnsr::abb<DataVector, dim>*> christoffel_first_kind,
+    const gsl::not_null<tnsr::Abb<DataVector, dim>*> christoffel_second_kind,
+    const gsl::not_null<tnsr::a<DataVector, dim>*> trace_christoffel,
+    const gsl::not_null<tnsr::A<DataVector, dim>*> normal_spacetime_vector,
+
+    // Scalar temporal variables
+    const gsl::not_null<Scalar<DataVector>*> result_gamma1_scalar,
+    const gsl::not_null<Scalar<DataVector>*> result_gamma2_scalar,
+
+    // Extra temporal tags
+    const gsl::not_null<tnsr::aa<DataVector, dim>*> stress_energy,
+
+    // GH spatial derivatives
+    const tnsr::iaa<DataVector, dim>& d_spacetime_metric,
+    const tnsr::iaa<DataVector, dim>& d_pi,
+    const tnsr::ijaa<DataVector, dim>& d_phi,
+
+    // scalar spatial derivatives
+    const tnsr::i<DataVector, dim>& d_psi_scalar,
+    const tnsr::i<DataVector, dim>& d_pi_scalar,
+    const tnsr::ij<DataVector, dim>& d_phi_scalar,
+
+    // GH argument variables
+    const tnsr::aa<DataVector, dim>& spacetime_metric,
+    const tnsr::aa<DataVector, dim>& pi, const tnsr::iaa<DataVector, dim>& phi,
+    const Scalar<DataVector>& gamma0, const Scalar<DataVector>& gamma1,
+    const Scalar<DataVector>& gamma2,
+    const gh::gauges::GaugeCondition& gauge_condition, const Mesh<dim>& mesh,
+    double time,
+    const tnsr::I<DataVector, dim, Frame::Inertial>& inertial_coords,
+    const InverseJacobian<DataVector, dim, Frame::ElementLogical,
+                          Frame::Inertial>& inverse_jacobian,
+    const std::optional<tnsr::I<DataVector, dim, Frame::Inertial>>&
+        mesh_velocity,
+
+    // Scalar argument variables
+    const Scalar<DataVector>& pi_scalar,
+    const tnsr::i<DataVector, dim>& phi_scalar,
+    const Scalar<DataVector>& lapse_scalar,
+    const tnsr::I<DataVector, dim>& shift_scalar,
+    const tnsr::i<DataVector, dim>& deriv_lapse,
+    const tnsr::iJ<DataVector, dim>& deriv_shift,
+    const tnsr::II<DataVector, dim>& upper_spatial_metric,
+    const tnsr::I<DataVector, dim>& trace_spatial_christoffel,
+    const Scalar<DataVector>& trace_extrinsic_curvature,
+    const Scalar<DataVector>& gamma1_scalar,
+    const Scalar<DataVector>& gamma2_scalar,
+
+    const Scalar<DataVector>& scalar_source) {
+  // Compute sourceless part of the RHS of the metric equations
+  gh::TimeDerivative<dim>::apply(
+      // GH dt variables
+      dt_spacetime_metric, dt_pi, dt_phi,
+
+      // GH temporal variables
+      temp_gamma1, temp_gamma2, temp_gauge_function,
+      temp_spacetime_deriv_gauge_function, gamma1gamma2,
+      half_half_pi_two_normals, normal_dot_gauge_constraint, gamma1_plus_1,
+      pi_one_normal, gauge_constraint, half_phi_two_normals,
+      shift_dot_three_index_constraint,
+      mesh_velocity_dot_three_index_constraint, phi_one_normal, pi_2_up,
+      three_index_constraint, phi_1_up, phi_3_up, christoffel_first_kind_3_up,
+      lapse, shift, inverse_spatial_metric, det_spatial_metric,
+      sqrt_det_spatial_metric, inverse_spacetime_metric, christoffel_first_kind,
+      christoffel_second_kind, trace_christoffel, normal_spacetime_vector,
+
+      // GH argument variables
+      d_spacetime_metric, d_pi, d_phi, spacetime_metric, pi, phi, gamma0,
+      gamma1, gamma2, gauge_condition, mesh, time, inertial_coords,
+      inverse_jacobian, mesh_velocity);
+
+  // Compute sourceless part of the RHS of the scalar equation
+  CurvedScalarWave::TimeDerivative<dim>::apply(
+      // Scalar dt variables
+      dt_psi_scalar, dt_pi_scalar, dt_phi_scalar,
+
+      // Scalar temporal variables
+      lapse, shift, inverse_spatial_metric,
+
+      result_gamma1_scalar, result_gamma2_scalar,
+
+      // Scalar argument variables
+      d_psi_scalar, d_pi_scalar, d_phi_scalar, pi_scalar, phi_scalar,
+
+      lapse_scalar, shift_scalar,
+
+      deriv_lapse, deriv_shift, upper_spatial_metric, trace_spatial_christoffel,
+      trace_extrinsic_curvature, gamma1_scalar, gamma2_scalar);
+
+  // Compute the (trace-reversed) stress energy tensor here
+  trace_reversed_stress_energy(stress_energy, pi_scalar, phi_scalar,
+                               lapse_scalar);
+
+  add_stress_energy_term_to_dt_pi(dt_pi, *stress_energy, lapse_scalar);
+
+  add_scalar_source_to_dt_pi_scalar(dt_pi_scalar, scalar_source, lapse_scalar);
+}
+}  // namespace ScalarTensor

--- a/src/Evolution/Systems/ScalarTensor/TimeDerivative.hpp
+++ b/src/Evolution/Systems/ScalarTensor/TimeDerivative.hpp
@@ -1,0 +1,157 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/DataBox/PrefixHelpers.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/TaggedContainers.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Evolution/Systems/CurvedScalarWave/System.hpp"
+#include "Evolution/Systems/CurvedScalarWave/TimeDerivative.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/System.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/TimeDerivative.hpp"
+#include "Evolution/Systems/ScalarTensor/Sources/ScalarSource.hpp"
+#include "Evolution/Systems/ScalarTensor/StressEnergy.hpp"
+#include "Evolution/Systems/ScalarTensor/Tags.hpp"
+#include "Time/Tags/Time.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace ScalarTensor {
+/*!
+ * \brief Compute the RHS terms of the evolution equations for the scalar tensor
+ * system.
+ *
+ * \details The bulk of the computations in this class dispatch to
+ * `GeneralizedHarmonic::TimeDerivative` and
+ * `CurvedScalarWave::TimeDerivative` as a 'product system' -- each
+ * independently operating on its own subset of the supplied variable
+ * collections.
+ * The additional steps taken are to compute the trace-reversed stress energy
+ * tensor associated with the scalar part of the system and add its contribution
+ * to the \f$\partial_t \Pi_{a b}\f$ variable in the Generalized Harmonic
+ * system, as well as adding any scalar sources to the variable \f$\partial_t
+ * \Pi\f$.
+ */
+struct TimeDerivative {
+  static constexpr size_t dim = 3;
+  using gh_dt_tags =
+      db::wrap_tags_in<::Tags::dt,
+                       typename gh::System<dim>::variables_tag::tags_list>;
+  using scalar_dt_tags = db::wrap_tags_in<
+      ::Tags::dt,
+      typename CurvedScalarWave::System<dim>::variables_tag::tags_list>;
+  using dt_tags = tmpl::append<gh_dt_tags, scalar_dt_tags>;
+  using gh_temp_tags = typename gh::TimeDerivative<dim>::temporary_tags;
+  using gh_gradient_tags = typename gh::System<dim>::gradients_tags;
+  using gh_arg_tags = typename gh::TimeDerivative<dim>::argument_tags;
+  using scalar_temp_tags =
+      typename CurvedScalarWave::TimeDerivative<dim>::temporary_tags;
+  using scalar_extra_temp_tags =
+      tmpl::list<ScalarTensor::Tags::TraceReversedStressEnergy<
+          DataVector, dim, ::Frame::Inertial>>;
+  using scalar_gradient_tags =
+      typename CurvedScalarWave::System<dim>::gradients_tags;
+  using gradient_tags = tmpl::append<gh_gradient_tags, scalar_gradient_tags>;
+  using scalar_arg_tags =
+      typename CurvedScalarWave::TimeDerivative<dim>::argument_tags;
+  using temporary_tags = tmpl::remove_duplicates<
+      tmpl::append<gh_temp_tags, scalar_temp_tags, scalar_extra_temp_tags>>;
+  using argument_tags =
+      tmpl::append<gh_arg_tags, scalar_arg_tags,
+                   tmpl::list<ScalarTensor::Tags::ScalarSource>>;
+
+  static void apply(
+      // GH dt variables
+      gsl::not_null<tnsr::aa<DataVector, dim>*> dt_spacetime_metric,
+      gsl::not_null<tnsr::aa<DataVector, dim>*> dt_pi,
+      gsl::not_null<tnsr::iaa<DataVector, dim>*> dt_phi,
+      // Scalar dt variables
+      gsl::not_null<Scalar<DataVector>*> dt_psi_scalar,
+      gsl::not_null<Scalar<DataVector>*> dt_pi_scalar,
+      gsl::not_null<tnsr::i<DataVector, dim, Frame::Inertial>*> dt_phi_scalar,
+
+      // GH temporal variables
+      gsl::not_null<Scalar<DataVector>*> temp_gamma1,
+      gsl::not_null<Scalar<DataVector>*> temp_gamma2,
+      gsl::not_null<tnsr::a<DataVector, dim>*> temp_gauge_function,
+      gsl::not_null<tnsr::ab<DataVector, dim>*>
+          temp_spacetime_deriv_gauge_function,
+      gsl::not_null<Scalar<DataVector>*> gamma1gamma2,
+      gsl::not_null<Scalar<DataVector>*> half_half_pi_two_normals,
+      gsl::not_null<Scalar<DataVector>*> normal_dot_gauge_constraint,
+      gsl::not_null<Scalar<DataVector>*> gamma1_plus_1,
+      gsl::not_null<tnsr::a<DataVector, dim>*> pi_one_normal,
+      gsl::not_null<tnsr::a<DataVector, dim>*> gauge_constraint,
+      gsl::not_null<tnsr::i<DataVector, dim>*> half_phi_two_normals,
+      gsl::not_null<tnsr::aa<DataVector, dim>*>
+          shift_dot_three_index_constraint,
+      gsl::not_null<tnsr::aa<DataVector, dim>*>
+          mesh_velocity_dot_three_index_constraint,
+      gsl::not_null<tnsr::ia<DataVector, dim>*> phi_one_normal,
+      gsl::not_null<tnsr::aB<DataVector, dim>*> pi_2_up,
+      gsl::not_null<tnsr::iaa<DataVector, dim>*> three_index_constraint,
+      gsl::not_null<tnsr::Iaa<DataVector, dim>*> phi_1_up,
+      gsl::not_null<tnsr::iaB<DataVector, dim>*> phi_3_up,
+      gsl::not_null<tnsr::abC<DataVector, dim>*> christoffel_first_kind_3_up,
+      gsl::not_null<Scalar<DataVector>*> lapse,
+      gsl::not_null<tnsr::I<DataVector, dim>*> shift,
+      gsl::not_null<tnsr::II<DataVector, dim>*> inverse_spatial_metric,
+      gsl::not_null<Scalar<DataVector>*> det_spatial_metric,
+      gsl::not_null<Scalar<DataVector>*> sqrt_det_spatial_metric,
+      gsl::not_null<tnsr::AA<DataVector, dim>*> inverse_spacetime_metric,
+      gsl::not_null<tnsr::abb<DataVector, dim>*> christoffel_first_kind,
+      gsl::not_null<tnsr::Abb<DataVector, dim>*> christoffel_second_kind,
+      gsl::not_null<tnsr::a<DataVector, dim>*> trace_christoffel,
+      gsl::not_null<tnsr::A<DataVector, dim>*> normal_spacetime_vector,
+
+      // Scalar temporal variables
+      gsl::not_null<Scalar<DataVector>*> result_gamma1_scalar,
+      gsl::not_null<Scalar<DataVector>*> result_gamma2_scalar,
+
+      // Extra temporal tags
+      gsl::not_null<tnsr::aa<DataVector, dim>*> stress_energy,
+
+      // GH spatial derivatives
+      const tnsr::iaa<DataVector, dim>& d_spacetime_metric,
+      const tnsr::iaa<DataVector, dim>& d_pi,
+      const tnsr::ijaa<DataVector, dim>& d_phi,
+
+      // scalar spatial derivatives
+      const tnsr::i<DataVector, dim>& d_psi_scalar,
+      const tnsr::i<DataVector, dim>& d_pi_scalar,
+      const tnsr::ij<DataVector, dim>& d_phi_scalar,
+
+      // GH argument variables
+      const tnsr::aa<DataVector, dim>& spacetime_metric,
+      const tnsr::aa<DataVector, dim>& pi,
+      const tnsr::iaa<DataVector, dim>& phi, const Scalar<DataVector>& gamma0,
+      const Scalar<DataVector>& gamma1, const Scalar<DataVector>& gamma2,
+      const gh::gauges::GaugeCondition& gauge_condition, const Mesh<dim>& mesh,
+      double time,
+      const tnsr::I<DataVector, dim, Frame::Inertial>& inertial_coords,
+      const InverseJacobian<DataVector, dim, Frame::ElementLogical,
+                            Frame::Inertial>& inverse_jacobian,
+      const std::optional<tnsr::I<DataVector, dim, Frame::Inertial>>&
+          mesh_velocity,
+
+      // Scalar argument variables
+      const Scalar<DataVector>& pi_scalar,
+      const tnsr::i<DataVector, dim>& phi_scalar,
+      const Scalar<DataVector>& lapse_scalar,
+      const tnsr::I<DataVector, dim>& shift_scalar,
+      const tnsr::i<DataVector, dim>& deriv_lapse,
+      const tnsr::iJ<DataVector, dim>& deriv_shift,
+      const tnsr::II<DataVector, dim>& upper_spatial_metric,
+      const tnsr::I<DataVector, dim>& trace_spatial_christoffel,
+      const Scalar<DataVector>& trace_extrinsic_curvature,
+      const Scalar<DataVector>& gamma1_scalar,
+      const Scalar<DataVector>& gamma2_scalar,
+
+      const Scalar<DataVector>& scalar_source);
+};
+}  // namespace ScalarTensor

--- a/src/Evolution/Systems/ScalarTensor/VolumeTermsInstantiation.cpp
+++ b/src/Evolution/Systems/ScalarTensor/VolumeTermsInstantiation.cpp
@@ -1,0 +1,73 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include <optional>
+
+#include "DataStructures/DataBox/PrefixHelpers.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "Evolution/DiscontinuousGalerkin/Actions/VolumeTermsImpl.tpp"
+#include "Evolution/Systems/ScalarTensor/System.hpp"
+#include "Evolution/Systems/ScalarTensor/TimeDerivative.hpp"
+
+namespace evolution::dg::Actions::detail {
+template void volume_terms<::ScalarTensor::TimeDerivative>(
+    const gsl::not_null<Variables<db::wrap_tags_in<
+        ::Tags::dt,
+        typename ::ScalarTensor::System::variables_tag::tags_list>>*>
+        dt_vars_ptr,
+    const gsl::not_null<Variables<db::wrap_tags_in<
+        ::Tags::Flux, typename ::ScalarTensor::System::flux_variables,
+        tmpl::size_t<3>, Frame::Inertial>>*>
+        volume_fluxes,
+    const gsl::not_null<Variables<db::wrap_tags_in<
+        ::Tags::deriv, typename ::ScalarTensor::System::gradient_variables,
+        tmpl::size_t<3>, Frame::Inertial>>*>
+        partial_derivs,
+    const gsl::not_null<
+        Variables<typename ::ScalarTensor::System::
+                      compute_volume_time_derivative_terms::temporary_tags>*>
+        temporaries,
+    const gsl::not_null<Variables<db::wrap_tags_in<
+        ::Tags::div,
+        db::wrap_tags_in<::Tags::Flux,
+                         typename ::ScalarTensor::System::flux_variables,
+                         tmpl::size_t<3>, Frame::Inertial>>>*>
+        div_fluxes,
+    const Variables<typename ::ScalarTensor::System::variables_tag::tags_list>&
+        evolved_vars,
+    const ::dg::Formulation dg_formulation, const Mesh<3>& mesh,
+    [[maybe_unused]] const tnsr::I<DataVector, 3, Frame::Inertial>&
+        inertial_coordinates,
+    const InverseJacobian<DataVector, 3, Frame::ElementLogical,
+                          Frame::Inertial>&
+        logical_to_inertial_inverse_jacobian,
+    [[maybe_unused]] const Scalar<DataVector>* const det_inverse_jacobian,
+    const std::optional<tnsr::I<DataVector, 3, Frame::Inertial>>& mesh_velocity,
+    const std::optional<Scalar<DataVector>>& div_mesh_velocity,
+    // GH argument variables
+    const tnsr::aa<DataVector, 3>& spacetime_metric,
+    const tnsr::aa<DataVector, 3>& pi, const tnsr::iaa<DataVector, 3>& phi,
+    const Scalar<DataVector>& gamma0, const Scalar<DataVector>& gamma1,
+    const Scalar<DataVector>& gamma2,
+    const ::gh::gauges::GaugeCondition& gauge_condition,
+    const Mesh<3>& mesh_for_rhs, const double& time,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& inertial_coords,
+    const InverseJacobian<DataVector, 3, Frame::ElementLogical,
+                          Frame::Inertial>& inverse_jacobian,
+    const std::optional<tnsr::I<DataVector, 3, Frame::Inertial>>&
+        mesh_velocity_gh,
+    // Scalar argument variables
+    const Scalar<DataVector>& pi_scalar,
+    const tnsr::i<DataVector, 3>& phi_scalar,
+    const Scalar<DataVector>& lapse_scalar,
+    const tnsr::I<DataVector, 3>& shift_scalar,
+    const tnsr::i<DataVector, 3>& deriv_lapse,
+    const tnsr::iJ<DataVector, 3>& deriv_shift,
+    const tnsr::II<DataVector, 3>& upper_spatial_metric,
+    const tnsr::I<DataVector, 3>& trace_spatial_christoffel,
+    const Scalar<DataVector>& trace_extrinsic_curvature,
+    const Scalar<DataVector>& gamma1_scalar,
+    const Scalar<DataVector>& gamma2_scalar,
+    // Scalar Tensor extra argument tags
+    const Scalar<DataVector>& scalar_source);
+}  // namespace evolution::dg::Actions::detail

--- a/tests/Unit/Evolution/Systems/ScalarTensor/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/ScalarTensor/CMakeLists.txt
@@ -8,6 +8,7 @@ set(LIBRARY_SOURCES
   Test_Sources.cpp
   Test_StressEnergy.cpp
   Test_Tags.cpp
+  Test_TimeDerivative.cpp
   )
 
 add_test_library(

--- a/tests/Unit/Evolution/Systems/ScalarTensor/Test_TimeDerivative.cpp
+++ b/tests/Unit/Evolution/Systems/ScalarTensor/Test_TimeDerivative.cpp
@@ -1,0 +1,405 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <memory>
+#include <random>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Evolution/Systems/CurvedScalarWave/System.hpp"
+#include "Evolution/Systems/CurvedScalarWave/Tags.hpp"
+#include "Evolution/Systems/CurvedScalarWave/TimeDerivative.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedHarmonic.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Tags/GaugeCondition.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
+#include "Evolution/Systems/ScalarTensor/System.hpp"
+#include "Evolution/Systems/ScalarTensor/TimeDerivative.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/DerivSpatialMetric.hpp"
+#include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/ExtrinsicCurvature.hpp"
+#include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/SpatialDerivOfLapse.hpp"
+#include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/SpatialDerivOfShift.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Utilities/MakeWithValue.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TypeTraits/IsA.hpp"
+
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.ScalarTensor.TimeDerivative",
+                  "[Unit][Evolution]") {
+
+  using gh_dt_variables_tags = ScalarTensor::TimeDerivative::gh_dt_tags;
+  using scalar_dt_variables_tags = ScalarTensor::TimeDerivative::scalar_dt_tags;
+  using dt_variables_type =
+      Variables<tmpl::append<gh_dt_variables_tags, scalar_dt_variables_tags>>;
+
+  using temp_variables_type =
+      Variables<typename ScalarTensor::TimeDerivative::temporary_tags>;
+
+  using gh_gradient_tags = tmpl::transform<
+      ScalarTensor::TimeDerivative::gh_gradient_tags,
+      tmpl::bind<::Tags::deriv, tmpl::_1, tmpl::pin<tmpl::size_t<3>>,
+                 tmpl::pin<Frame::Inertial>>>;
+  using scalar_gradient_tags = tmpl::transform<
+      ScalarTensor::TimeDerivative::scalar_gradient_tags,
+      tmpl::bind<::Tags::deriv, tmpl::_1, tmpl::pin<tmpl::size_t<3>>,
+                 tmpl::pin<Frame::Inertial>>>;
+  using gradient_variables_type =
+      Variables<tmpl::append<gh_gradient_tags, scalar_gradient_tags>>;
+
+  using gh_arg_tags = ScalarTensor::TimeDerivative::gh_arg_tags;
+  using scalar_arg_tags = ScalarTensor::TimeDerivative::scalar_arg_tags;
+  using arg_variables_type = tuples::tagged_tuple_from_typelist<
+      tmpl::append<gh_arg_tags, scalar_arg_tags,
+                   tmpl::list<ScalarTensor::Tags::ScalarSource>>>;
+
+  const size_t element_size = 10;
+  MAKE_GENERATOR(gen);
+  std::uniform_real_distribution<> dist(0.1, 1.0);
+
+  dt_variables_type expected_dt_variables{element_size};
+  dt_variables_type dt_variables{element_size};
+
+  temp_variables_type expected_temp_variables{element_size};
+  temp_variables_type temp_variables{element_size};
+
+  const auto gradient_variables =
+      make_with_random_values<gradient_variables_type>(
+          make_not_null(&gen), make_not_null(&dist), DataVector{element_size});
+
+  arg_variables_type arg_variables;
+  tmpl::for_each<tmpl::append<gh_arg_tags, scalar_arg_tags,
+                              tmpl::list<ScalarTensor::Tags::ScalarSource>>>(
+      [&gen, &dist, &arg_variables](auto tag_v) {
+        using tag = typename decltype(tag_v)::type;
+        if constexpr (std::is_same_v<typename tag::type,
+                                     std::optional<tnsr::I<DataVector, 3,
+                                                           Frame::Inertial>>>) {
+          tuples::get<tag>(arg_variables) = make_with_random_values<
+              typename tnsr::I<DataVector, 3, Frame::Inertial>>(
+              make_not_null(&gen), make_not_null(&dist),
+              DataVector{element_size});
+        } else if constexpr (tt::is_a_v<Tensor, typename tag::type>) {
+          tuples::get<tag>(arg_variables) =
+              make_with_random_values<typename tag::type>(
+                  make_not_null(&gen), make_not_null(&dist),
+                  DataVector{element_size});
+        }
+      });
+  get<gh::gauges::Tags::GaugeCondition>(arg_variables) =
+      std::make_unique<gh::gauges::DampedHarmonic>(
+          100., std::array{1.2, 1.5, 1.7}, std::array{2, 4, 6});
+
+  // ensure that the signature of the metric is correct
+  {
+    auto& metric =
+        tuples::get<gr::Tags::SpacetimeMetric<DataVector, 3>>(arg_variables);
+    get<0, 0>(metric) += -2.0;
+    for (size_t i = 0; i < 3; ++i) {
+      metric.get(i + 1, i + 1) += 4.0;
+      metric.get(i + 1, 0) *= 0.01;
+    }
+  }
+
+  // The logic of the test is the following:
+  // We compute the individual time derivative functions for each system
+  // and then compare the results with the time derivative function for the
+  // combined system
+
+  // The time derivative function for GeneralizedHarmonic is
+  gh::TimeDerivative<3>::apply(
+      // GH evolved variables
+      make_not_null(&get<::Tags::dt<gr::Tags::SpacetimeMetric<DataVector, 3>>>(
+          expected_dt_variables)),
+      make_not_null(
+          &get<::Tags::dt<gh::Tags::Pi<DataVector, 3>>>(expected_dt_variables)),
+      make_not_null(&get<::Tags::dt<gh::Tags::Phi<DataVector, 3>>>(
+          expected_dt_variables)),
+      // GH temporaries
+      make_not_null(&get<gh::ConstraintDamping::Tags::ConstraintGamma1>(
+          expected_temp_variables)),
+      make_not_null(&get<gh::ConstraintDamping::Tags::ConstraintGamma2>(
+          expected_temp_variables)),
+      make_not_null(
+          &get<gh::Tags::GaugeH<DataVector, 3>>(expected_temp_variables)),
+      make_not_null(&get<gh::Tags::SpacetimeDerivGaugeH<DataVector, 3>>(
+          expected_temp_variables)),
+      make_not_null(&get<gh::Tags::Gamma1Gamma2>(expected_temp_variables)),
+      make_not_null(&get<gh::Tags::HalfPiTwoNormals>(expected_temp_variables)),
+      make_not_null(
+          &get<gh::Tags::NormalDotOneIndexConstraint>(expected_temp_variables)),
+      make_not_null(&get<gh::Tags::Gamma1Plus1>(expected_temp_variables)),
+      make_not_null(&get<gh::Tags::PiOneNormal<3>>(expected_temp_variables)),
+      make_not_null(&get<gh::Tags::GaugeConstraint<DataVector, 3>>(
+          expected_temp_variables)),
+      make_not_null(
+          &get<gh::Tags::HalfPhiTwoNormals<3>>(expected_temp_variables)),
+      make_not_null(&get<gh::Tags::ShiftDotThreeIndexConstraint<3>>(
+          expected_temp_variables)),
+      make_not_null(&get<gh::Tags::MeshVelocityDotThreeIndexConstraint<3>>(
+          expected_temp_variables)),
+      make_not_null(&get<gh::Tags::PhiOneNormal<3>>(expected_temp_variables)),
+      make_not_null(
+          &get<gh::Tags::PiSecondIndexUp<3>>(expected_temp_variables)),
+      make_not_null(&get<gh::Tags::ThreeIndexConstraint<DataVector, 3>>(
+          expected_temp_variables)),
+      make_not_null(
+          &get<gh::Tags::PhiFirstIndexUp<3>>(expected_temp_variables)),
+      make_not_null(
+          &get<gh::Tags::PhiThirdIndexUp<3>>(expected_temp_variables)),
+      make_not_null(
+          &get<gh::Tags::SpacetimeChristoffelFirstKindThirdIndexUp<3>>(
+              expected_temp_variables)),
+      make_not_null(&get<gr::Tags::Lapse<DataVector>>(expected_temp_variables)),
+      make_not_null(
+          &get<gr::Tags::Shift<DataVector, 3>>(expected_temp_variables)),
+      make_not_null(&get<gr::Tags::InverseSpatialMetric<DataVector, 3>>(
+          expected_temp_variables)),
+      make_not_null(&get<gr::Tags::DetSpatialMetric<DataVector>>(
+          expected_temp_variables)),
+      make_not_null(&get<gr::Tags::SqrtDetSpatialMetric<DataVector>>(
+          expected_temp_variables)),
+      make_not_null(&get<gr::Tags::InverseSpacetimeMetric<DataVector, 3>>(
+          expected_temp_variables)),
+      make_not_null(
+          &get<gr::Tags::SpacetimeChristoffelFirstKind<DataVector, 3>>(
+              expected_temp_variables)),
+      make_not_null(
+          &get<gr::Tags::SpacetimeChristoffelSecondKind<DataVector, 3>>(
+              expected_temp_variables)),
+      make_not_null(
+          &get<gr::Tags::TraceSpacetimeChristoffelFirstKind<DataVector, 3>>(
+              expected_temp_variables)),
+      make_not_null(&get<gr::Tags::SpacetimeNormalVector<DataVector, 3>>(
+          expected_temp_variables)),
+      // GH gradient tags
+      get<::Tags::deriv<gr::Tags::SpacetimeMetric<DataVector, 3>,
+                        tmpl::size_t<3>, Frame::Inertial>>(gradient_variables),
+      get<::Tags::deriv<gh::Tags::Pi<DataVector, 3>, tmpl::size_t<3>,
+                        Frame::Inertial>>(gradient_variables),
+      get<::Tags::deriv<gh::Tags::Phi<DataVector, 3>, tmpl::size_t<3>,
+                        Frame::Inertial>>(gradient_variables),
+      // GH argument tags
+      tuples::get<gr::Tags::SpacetimeMetric<DataVector, 3>>(arg_variables),
+      tuples::get<gh::Tags::Pi<DataVector, 3>>(arg_variables),
+      tuples::get<gh::Tags::Phi<DataVector, 3>>(arg_variables),
+      tuples::get<gh::ConstraintDamping::Tags::ConstraintGamma0>(arg_variables),
+      tuples::get<gh::ConstraintDamping::Tags::ConstraintGamma1>(arg_variables),
+      tuples::get<gh::ConstraintDamping::Tags::ConstraintGamma2>(arg_variables),
+
+      *tuples::get<gh::gauges::Tags::GaugeCondition>(arg_variables),
+
+      tuples::get<domain::Tags::Mesh<3>>(arg_variables),
+      tuples::get<::Tags::Time>(arg_variables),
+      tuples::get<domain::Tags::Coordinates<3, Frame::Inertial>>(arg_variables),
+      tuples::get<domain::Tags::InverseJacobian<3, Frame::ElementLogical,
+                                                Frame::Inertial>>(
+          arg_variables),
+      tuples::get<domain::Tags::MeshVelocity<3, Frame::Inertial>>(
+          arg_variables));
+
+  // The time derivative function for CurvedScalarWave is
+  CurvedScalarWave::TimeDerivative<3>::apply(
+      // Scalar evolved variables
+      make_not_null(
+          &get<::Tags::dt<CurvedScalarWave::Tags::Psi>>(expected_dt_variables)),
+      make_not_null(
+          &get<::Tags::dt<CurvedScalarWave::Tags::Pi>>(expected_dt_variables)),
+      make_not_null(&get<::Tags::dt<CurvedScalarWave::Tags::Phi<3>>>(
+          expected_dt_variables)),
+      // Scalar temporaries
+      make_not_null(&get<gr::Tags::Lapse<DataVector>>(expected_temp_variables)),
+      make_not_null(
+          &get<gr::Tags::Shift<DataVector, 3>>(expected_temp_variables)),
+      make_not_null(&get<gr::Tags::InverseSpatialMetric<DataVector, 3>>(
+          expected_temp_variables)),
+      make_not_null(&get<CurvedScalarWave::Tags::ConstraintGamma1>(
+          expected_temp_variables)),
+      make_not_null(&get<CurvedScalarWave::Tags::ConstraintGamma2>(
+          expected_temp_variables)),
+      // Scalar gradient tags
+      get<::Tags::deriv<CurvedScalarWave::Tags::Psi, tmpl::size_t<3>,
+                        Frame::Inertial>>(gradient_variables),
+      get<::Tags::deriv<CurvedScalarWave::Tags::Pi, tmpl::size_t<3>,
+                        Frame::Inertial>>(gradient_variables),
+      get<::Tags::deriv<CurvedScalarWave::Tags::Phi<3>, tmpl::size_t<3>,
+                        Frame::Inertial>>(gradient_variables),
+      // Scalar argument tags
+      tuples::get<CurvedScalarWave::Tags::Pi>(arg_variables),
+      tuples::get<CurvedScalarWave::Tags::Phi<3>>(arg_variables),
+
+      tuples::get<gr::Tags::Lapse<DataVector>>(arg_variables),
+      tuples::get<gr::Tags::Shift<DataVector, 3>>(arg_variables),
+      tuples::get<::Tags::deriv<gr::Tags::Lapse<DataVector>, tmpl::size_t<3>,
+                                Frame::Inertial>>(arg_variables),
+      tuples::get<::Tags::deriv<gr::Tags::Shift<DataVector, 3>, tmpl::size_t<3>,
+                                Frame::Inertial>>(arg_variables),
+      tuples::get<gr::Tags::InverseSpatialMetric<DataVector, 3>>(arg_variables),
+      tuples::get<gr::Tags::TraceSpatialChristoffelSecondKind<DataVector, 3>>(
+          arg_variables),
+      tuples::get<gr::Tags::TraceExtrinsicCurvature<DataVector>>(arg_variables),
+      tuples::get<CurvedScalarWave::Tags::ConstraintGamma1>(arg_variables),
+      tuples::get<CurvedScalarWave::Tags::ConstraintGamma2>(arg_variables));
+
+  // We compute the trace-reversed stress energy tensor for the expected
+  // variables
+  ScalarTensor::trace_reversed_stress_energy(
+      make_not_null(
+          &get<ScalarTensor::Tags::TraceReversedStressEnergy<
+              DataVector, 3, ::Frame::Inertial>>(expected_temp_variables)),
+      tuples::get<CurvedScalarWave::Tags::Pi>(arg_variables),
+      tuples::get<CurvedScalarWave::Tags::Phi<3>>(arg_variables),
+      tuples::get<gr::Tags::Lapse<DataVector>>(arg_variables));
+
+  // When we have backreaction we also need to compute and apply the correction
+  // to dt pi for the expected variables
+
+  ScalarTensor::add_stress_energy_term_to_dt_pi(
+      make_not_null(
+          &get<::Tags::dt<gh::Tags::Pi<DataVector, 3>>>(expected_dt_variables)),
+      get<ScalarTensor::Tags::TraceReversedStressEnergy<DataVector, 3,
+                                                        ::Frame::Inertial>>(
+          expected_temp_variables),
+      tuples::get<gr::Tags::Lapse<DataVector>>(arg_variables));
+
+  ScalarTensor::add_scalar_source_to_dt_pi_scalar(
+      make_not_null(
+          &get<::Tags::dt<CurvedScalarWave::Tags::Pi>>(expected_dt_variables)),
+      tuples::get<ScalarTensor::Tags::ScalarSource>(arg_variables),
+      tuples::get<gr::Tags::Lapse<DataVector>>(arg_variables));
+
+  // The time derivative function for the combined system is
+  ScalarTensor::TimeDerivative::apply(
+      // GH evolved variables
+      make_not_null(&get<::Tags::dt<gr::Tags::SpacetimeMetric<DataVector, 3>>>(
+          dt_variables)),
+      make_not_null(
+          &get<::Tags::dt<gh::Tags::Pi<DataVector, 3>>>(dt_variables)),
+      make_not_null(
+          &get<::Tags::dt<gh::Tags::Phi<DataVector, 3>>>(dt_variables)),
+      // Scalar evolved variables
+      make_not_null(
+          &get<::Tags::dt<CurvedScalarWave::Tags::Psi>>(dt_variables)),
+      make_not_null(&get<::Tags::dt<CurvedScalarWave::Tags::Pi>>(dt_variables)),
+      make_not_null(
+          &get<::Tags::dt<CurvedScalarWave::Tags::Phi<3>>>(dt_variables)),
+      // GH temporaries
+      make_not_null(
+          &get<gh::ConstraintDamping::Tags::ConstraintGamma1>(temp_variables)),
+      make_not_null(
+          &get<gh::ConstraintDamping::Tags::ConstraintGamma2>(temp_variables)),
+      make_not_null(&get<gh::Tags::GaugeH<DataVector, 3>>(temp_variables)),
+      make_not_null(
+          &get<gh::Tags::SpacetimeDerivGaugeH<DataVector, 3>>(temp_variables)),
+      make_not_null(&get<gh::Tags::Gamma1Gamma2>(temp_variables)),
+      make_not_null(&get<gh::Tags::HalfPiTwoNormals>(temp_variables)),
+      make_not_null(
+          &get<gh::Tags::NormalDotOneIndexConstraint>(temp_variables)),
+      make_not_null(&get<gh::Tags::Gamma1Plus1>(temp_variables)),
+      make_not_null(&get<gh::Tags::PiOneNormal<3>>(temp_variables)),
+      make_not_null(
+          &get<gh::Tags::GaugeConstraint<DataVector, 3>>(temp_variables)),
+      make_not_null(&get<gh::Tags::HalfPhiTwoNormals<3>>(temp_variables)),
+      make_not_null(
+          &get<gh::Tags::ShiftDotThreeIndexConstraint<3>>(temp_variables)),
+      make_not_null(&get<gh::Tags::MeshVelocityDotThreeIndexConstraint<3>>(
+          temp_variables)),
+      make_not_null(&get<gh::Tags::PhiOneNormal<3>>(temp_variables)),
+      make_not_null(&get<gh::Tags::PiSecondIndexUp<3>>(temp_variables)),
+      make_not_null(
+          &get<gh::Tags::ThreeIndexConstraint<DataVector, 3>>(temp_variables)),
+      make_not_null(&get<gh::Tags::PhiFirstIndexUp<3>>(temp_variables)),
+      make_not_null(&get<gh::Tags::PhiThirdIndexUp<3>>(temp_variables)),
+      make_not_null(
+          &get<gh::Tags::SpacetimeChristoffelFirstKindThirdIndexUp<3>>(
+              temp_variables)),
+      make_not_null(&get<gr::Tags::Lapse<DataVector>>(temp_variables)),
+      make_not_null(&get<gr::Tags::Shift<DataVector, 3>>(temp_variables)),
+      make_not_null(
+          &get<gr::Tags::InverseSpatialMetric<DataVector, 3>>(temp_variables)),
+      make_not_null(
+          &get<gr::Tags::DetSpatialMetric<DataVector>>(temp_variables)),
+      make_not_null(
+          &get<gr::Tags::SqrtDetSpatialMetric<DataVector>>(temp_variables)),
+      make_not_null(&get<gr::Tags::InverseSpacetimeMetric<DataVector, 3>>(
+          temp_variables)),
+      make_not_null(
+          &get<gr::Tags::SpacetimeChristoffelFirstKind<DataVector, 3>>(
+              temp_variables)),
+      make_not_null(
+          &get<gr::Tags::SpacetimeChristoffelSecondKind<DataVector, 3>>(
+              temp_variables)),
+      make_not_null(
+          &get<gr::Tags::TraceSpacetimeChristoffelFirstKind<DataVector, 3>>(
+              temp_variables)),
+      make_not_null(
+          &get<gr::Tags::SpacetimeNormalVector<DataVector, 3>>(temp_variables)),
+      // Scalar temporaries
+      make_not_null(
+          &get<CurvedScalarWave::Tags::ConstraintGamma1>(temp_variables)),
+      make_not_null(
+          &get<CurvedScalarWave::Tags::ConstraintGamma2>(temp_variables)),
+      // Extra scalar temporaries
+      make_not_null(&get<ScalarTensor::Tags::TraceReversedStressEnergy<
+                        DataVector, 3, ::Frame::Inertial>>(temp_variables)),
+      // GH gradient tags
+      get<::Tags::deriv<gr::Tags::SpacetimeMetric<DataVector, 3>,
+                        tmpl::size_t<3>, Frame::Inertial>>(gradient_variables),
+      get<::Tags::deriv<gh::Tags::Pi<DataVector, 3>, tmpl::size_t<3>,
+                        Frame::Inertial>>(gradient_variables),
+      get<::Tags::deriv<gh::Tags::Phi<DataVector, 3>, tmpl::size_t<3>,
+                        Frame::Inertial>>(gradient_variables),
+      // Scalar gradient tags
+      get<::Tags::deriv<CurvedScalarWave::Tags::Psi, tmpl::size_t<3>,
+                        Frame::Inertial>>(gradient_variables),
+      get<::Tags::deriv<CurvedScalarWave::Tags::Pi, tmpl::size_t<3>,
+                        Frame::Inertial>>(gradient_variables),
+      get<::Tags::deriv<CurvedScalarWave::Tags::Phi<3>, tmpl::size_t<3>,
+                        Frame::Inertial>>(gradient_variables),
+      // GH argument tags
+      tuples::get<gr::Tags::SpacetimeMetric<DataVector, 3>>(arg_variables),
+
+      tuples::get<gh::Tags::Pi<DataVector, 3>>(arg_variables),
+      tuples::get<gh::Tags::Phi<DataVector, 3>>(arg_variables),
+      tuples::get<gh::ConstraintDamping::Tags::ConstraintGamma0>(arg_variables),
+      tuples::get<gh::ConstraintDamping::Tags::ConstraintGamma1>(arg_variables),
+      tuples::get<gh::ConstraintDamping::Tags::ConstraintGamma2>(arg_variables),
+
+      *tuples::get<gh::gauges::Tags::GaugeCondition>(arg_variables),
+
+      tuples::get<domain::Tags::Mesh<3>>(arg_variables),
+      tuples::get<::Tags::Time>(arg_variables),
+      tuples::get<domain::Tags::Coordinates<3, Frame::Inertial>>(arg_variables),
+      tuples::get<domain::Tags::InverseJacobian<3, Frame::ElementLogical,
+                                                Frame::Inertial>>(
+          arg_variables),
+      tuples::get<domain::Tags::MeshVelocity<3, Frame::Inertial>>(
+          arg_variables),
+      // Scalar argument tags
+      tuples::get<CurvedScalarWave::Tags::Pi>(arg_variables),
+      tuples::get<CurvedScalarWave::Tags::Phi<3>>(arg_variables),
+
+      tuples::get<gr::Tags::Lapse<DataVector>>(arg_variables),
+      tuples::get<gr::Tags::Shift<DataVector, 3>>(arg_variables),
+      tuples::get<::Tags::deriv<gr::Tags::Lapse<DataVector>, tmpl::size_t<3>,
+                                Frame::Inertial>>(arg_variables),
+      tuples::get<::Tags::deriv<gr::Tags::Shift<DataVector, 3>, tmpl::size_t<3>,
+                                Frame::Inertial>>(arg_variables),
+      tuples::get<gr::Tags::InverseSpatialMetric<DataVector, 3>>(arg_variables),
+      tuples::get<gr::Tags::TraceSpatialChristoffelSecondKind<DataVector, 3>>(
+          arg_variables),
+      tuples::get<gr::Tags::TraceExtrinsicCurvature<DataVector>>(arg_variables),
+      tuples::get<CurvedScalarWave::Tags::ConstraintGamma1>(arg_variables),
+      tuples::get<CurvedScalarWave::Tags::ConstraintGamma2>(arg_variables),
+
+      // Scalar extra argument tags
+      tuples::get<ScalarTensor::Tags::ScalarSource>(arg_variables));
+
+  // Finally we compare
+  CHECK_VARIABLES_APPROX(dt_variables, expected_dt_variables);
+  CHECK_VARIABLES_APPROX(temp_variables, expected_temp_variables);
+}


### PR DESCRIPTION
## Proposed changes
We compute the time derivative of the combined ScalarTensor system by calling the computation from each of the individual (CSW and GH) systems. Additionally, we add any sources to the RHS of the equations to include the back-reaction of the spacetime and source terms in the wave equation of the scalar.

In the current approach, the geometrical quantities needed by CSW are provided by compute tags. An optimization of this might be to add them as temporaries (or to store them in cache?). However, we may do this in another PR.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
