### PR TITLE
Add missing sqrt in calculation of W in SpEC ID

### DIFF
--- a/src/PointwiseFunctions/AnalyticData/GrMhd/SpecInitialData.cpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/SpecInitialData.cpp
@@ -190,7 +190,7 @@ void SpecInitialData::VariablesComputer<DataType>::operator()(
   const auto& lorentz_factor_times_spatial_velocity = cache->get_var(
       *this, hydro::Tags::LorentzFactorTimesSpatialVelocity<DataType, 3>{});
   dot_product(lorentz_factor, u_i, lorentz_factor_times_spatial_velocity);
-  get(*lorentz_factor) += 1.;
+  get(*lorentz_factor) = sqrt(1.0+get(*lorentz_factor));
 }
 
 template <typename DataType>


### PR DESCRIPTION
## Proposed changes

The Lorentz factor was calculated as (1-u^2) instead of sqrt(1-u^2) in SpecInitial data; this PR adds the missing sqrt.

### Upgrade instructions

None

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.