### PR TITLE
Handle relative paths in GenerateXdmf

### DIFF
--- a/src/Visualization/Python/GenerateXdmf.py
+++ b/src/Visualization/Python/GenerateXdmf.py
@@ -272,6 +272,7 @@ def generate_xdmf(
     h5files,
     output: str,
     subfile_name: str,
+    relative_paths: bool = True,
     start_time: Optional[float] = None,
     stop_time: Optional[float] = None,
     stride: int = 1,
@@ -292,6 +293,8 @@ def generate_xdmf(
       h5files: List of H5 volume data files.
       output: Output filename. A '.xmf' extension is added if not present.
       subfile_name: Volume data subfile in the H5 files.
+      relative_paths: If True, use relative paths in the XDMF file (default). If
+        False, use absolute paths.
       start_time: Optional. The earliest time at which to start visualizing. The
         start-time value is included.
       stop_time: Optional. The time at which to stop visualizing. The stop-time
@@ -347,6 +350,15 @@ def generate_xdmf(
             ) from err
         topo_dim = int(vol_subfile.attrs["dimension"])
 
+        # Use paths relative to the output file or absolute paths
+        filename_in_output = (
+            os.path.relpath(
+                filename, os.path.dirname(output) if output else None
+            )
+            if relative_paths
+            else os.path.abspath(filename)
+        )
+
         # Sort timesteps by time
         temporal_ids_and_values = sorted(
             [
@@ -382,7 +394,7 @@ def generate_xdmf(
                 _xmf_grid(
                     observation,
                     topo_dim=topo_dim,
-                    filename=filename,
+                    filename=filename_in_output,
                     subfile_name=subfile_name,
                     temporal_id=temporal_id,
                     coordinates=coordinates,
@@ -394,7 +406,7 @@ def generate_xdmf(
                     _xmf_grid(
                         observation,
                         topo_dim=topo_dim,
-                        filename=filename,
+                        filename=filename_in_output,
                         subfile_name=subfile_name,
                         temporal_id=temporal_id,
                         coordinates=coordinates,
@@ -452,6 +464,12 @@ def generate_xdmf(
         " a single '.vol' subfile, choose that. Otherwise, list all '.vol'"
         " subfiles and exit."
     ),
+)
+@click.option(
+    "--relative-paths/--absolute-paths",
+    default=True,
+    show_default=True,
+    help="Use relative paths or absolute paths in the XDMF file.",
 )
 @click.option(
     "--stride", default=1, type=int, help="View only every stride'th time step"

--- a/tests/Unit/Visualization/Python/Test_GenerateXdmf.py
+++ b/tests/Unit/Visualization/Python/Test_GenerateXdmf.py
@@ -68,7 +68,10 @@ class TestGenerateXdmf(unittest.TestCase):
                 ET.canonicalize(
                     from_file=os.path.join(self.data_dir, "VolTestData.xmf"),
                     strip_text=True,
-                ).replace("VolTestData0.h5", data_files[0]),
+                ).replace(
+                    "VolTestData0.h5",
+                    os.path.relpath(data_files[0], self.test_dir),
+                ),
             )
 
     def test_surface_generate_xdmf(self):


### PR DESCRIPTION
## Proposed changes

Writes the correct path relative to the output file when passing data files in subdirectories like `spectre generate-xdmf Run/Volume0.h5 -o Run/Volume.xmf`. Also adds the option to write absolute paths.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
