### PR TITLE
Add Boundary Corrections for ScalarTensor

### DIFF
--- a/src/Evolution/Systems/CurvedScalarWave/BoundaryCorrections/UpwindPenalty.cpp
+++ b/src/Evolution/Systems/CurvedScalarWave/BoundaryCorrections/UpwindPenalty.cpp
@@ -137,12 +137,28 @@ void UpwindPenalty<Dim>::dg_boundary_terms(
 }
 
 template <size_t Dim>
+bool operator==(const UpwindPenalty<Dim>& /*lhs*/,
+                const UpwindPenalty<Dim>& /*rhs*/) {
+  return true;
+}
+
+template <size_t Dim>
+bool operator!=(const UpwindPenalty<Dim>& lhs, const UpwindPenalty<Dim>& rhs) {
+  return not(lhs == rhs);
+}
+
+template <size_t Dim>
 // NOLINTNEXTLINE
 PUP::able::PUP_ID UpwindPenalty<Dim>::my_PUP_ID = 0;
 
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 
-#define INSTANTIATION(_, data) template class UpwindPenalty<DIM(data)>;
+#define INSTANTIATION(_, data)                                       \
+  template class UpwindPenalty<DIM(data)>;                           \
+  template bool operator==(const UpwindPenalty<DIM(data)>& /*lhs*/,  \
+                           const UpwindPenalty<DIM(data)>& /*rhs*/); \
+  template bool operator!=(const UpwindPenalty<DIM(data)>& /*lhs*/,  \
+                           const UpwindPenalty<DIM(data)>& /*rhs*/);
 
 GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
 

--- a/src/Evolution/Systems/CurvedScalarWave/BoundaryCorrections/UpwindPenalty.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/BoundaryCorrections/UpwindPenalty.hpp
@@ -172,4 +172,9 @@ class UpwindPenalty final : public BoundaryCorrection<Dim> {
       const tnsr::a<DataVector, 3, Frame::Inertial>& char_speeds_ext,
       dg::Formulation /*dg_formulation*/) const;
 };
+
+template <size_t Dim>
+bool operator==(const UpwindPenalty<Dim>& lhs, const UpwindPenalty<Dim>& rhs);
+template <size_t Dim>
+bool operator!=(const UpwindPenalty<Dim>& lhs, const UpwindPenalty<Dim>& rhs);
 }  // namespace CurvedScalarWave::BoundaryCorrections

--- a/src/Evolution/Systems/ScalarTensor/BoundaryCorrections/BoundaryCorrection.hpp
+++ b/src/Evolution/Systems/ScalarTensor/BoundaryCorrections/BoundaryCorrection.hpp
@@ -1,0 +1,62 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <memory>
+#include <pup.h>
+
+#include "Evolution/Systems/CurvedScalarWave/BoundaryCorrections/BoundaryCorrection.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/BoundaryCorrections/BoundaryCorrection.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Serialization/CharmPupable.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// Boundary corrections/numerical fluxes
+namespace ScalarTensor::BoundaryCorrections {
+/// \cond
+template <typename DerivedGhCorrection, typename DerivedScalarCorrection>
+class ProductOfCorrections;
+/// \endcond
+
+namespace detail {
+
+template <typename GhList, typename ScalarList>
+struct AllProductCorrections;
+
+template <typename GhList, typename... ScalarCorrections>
+struct AllProductCorrections<GhList, tmpl::list<ScalarCorrections...>> {
+  using type = tmpl::flatten<tmpl::list<
+      tmpl::transform<GhList, tmpl::bind<ProductOfCorrections, tmpl::_1,
+                                         tmpl::pin<ScalarCorrections>>>...>>;
+};
+}  // namespace detail
+
+/*!
+ * \brief The base class used to make boundary corrections factory creatable so
+ * they can be specified in the input file.
+ */
+class BoundaryCorrection : public PUP::able {
+ public:
+  BoundaryCorrection() = default;
+  BoundaryCorrection(const BoundaryCorrection&) = default;
+  BoundaryCorrection& operator=(const BoundaryCorrection&) = default;
+  BoundaryCorrection(BoundaryCorrection&&) = default;
+  BoundaryCorrection& operator=(BoundaryCorrection&&) = default;
+  ~BoundaryCorrection() override = default;
+
+  /// \cond
+  explicit BoundaryCorrection(CkMigrateMessage* msg) : PUP::able(msg) {}
+  WRAPPED_PUPable_abstract(BoundaryCorrection);  // NOLINT
+  /// \endcond
+
+  using creatable_classes = typename detail::AllProductCorrections<
+      typename gh::BoundaryCorrections::BoundaryCorrection<
+          3>::creatable_classes,
+      typename CurvedScalarWave::BoundaryCorrections::BoundaryCorrection<
+          3>::creatable_classes>::type;
+
+  virtual std::unique_ptr<BoundaryCorrection> get_clone() const = 0;
+};
+}  // namespace ScalarTensor::BoundaryCorrections

--- a/src/Evolution/Systems/ScalarTensor/BoundaryCorrections/CMakeLists.txt
+++ b/src/Evolution/Systems/ScalarTensor/BoundaryCorrections/CMakeLists.txt
@@ -1,0 +1,18 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+spectre_target_sources(
+  ${LIBRARY}
+  PRIVATE
+  RegisterDerived.cpp
+  )
+
+spectre_target_headers(
+  ${LIBRARY}
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  BoundaryCorrection.hpp
+  ProductOfCorrections.hpp
+  Factory.hpp
+  RegisterDerived.hpp
+  )

--- a/src/Evolution/Systems/ScalarTensor/BoundaryCorrections/Factory.hpp
+++ b/src/Evolution/Systems/ScalarTensor/BoundaryCorrections/Factory.hpp
@@ -1,0 +1,7 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "Evolution/Systems/ScalarTensor/BoundaryCorrections/BoundaryCorrection.hpp"
+#include "Evolution/Systems/ScalarTensor/BoundaryCorrections/ProductOfCorrections.hpp"

--- a/src/Evolution/Systems/ScalarTensor/BoundaryCorrections/ProductOfCorrections.hpp
+++ b/src/Evolution/Systems/ScalarTensor/BoundaryCorrections/ProductOfCorrections.hpp
@@ -1,0 +1,310 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <memory>
+#include <optional>
+#include <pup.h>
+
+#include "Evolution/Systems/CurvedScalarWave/BoundaryCorrections/Factory.hpp"
+#include "Evolution/Systems/CurvedScalarWave/System.hpp"
+#include "Evolution/Systems/CurvedScalarWave/Tags.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/BoundaryCorrections/Factory.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/System.hpp"
+#include "Evolution/Systems/ScalarTensor/BoundaryCorrections/BoundaryCorrection.hpp"
+#include "Evolution/Systems/ScalarTensor/Tags.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Formulation.hpp"
+#include "Options/String.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/PrettyType.hpp"
+#include "Utilities/Serialization/CharmPupable.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+class DataVector;
+/// \endcond
+
+namespace ScalarTensor::BoundaryCorrections {
+
+/*!
+ * \brief Apply a boundary condition to the combined Generalized Harmonic (::gh)
+ * and scalar field (::CurvedScalarWave) system using boundary corrections
+ * defined separately.
+ * \see gh::BoundaryCorrections and CurvedScalarWave::BoundaryCorrections.
+ */
+template <typename DerivedGhCorrection, typename DerivedScalarCorrection>
+class ProductOfCorrections final : public BoundaryCorrection {
+ public:
+  static constexpr size_t dim = 3;
+  using dg_package_field_tags =
+      tmpl::append<typename DerivedGhCorrection::dg_package_field_tags,
+                   typename DerivedScalarCorrection::dg_package_field_tags>;
+
+  using dg_package_data_temporary_tags = tmpl::remove_duplicates<tmpl::append<
+      typename DerivedGhCorrection::dg_package_data_temporary_tags,
+      typename DerivedScalarCorrection::dg_package_data_temporary_tags>>;
+
+  using dg_package_data_primitive_tags = tmpl::list<>;
+
+  using dg_package_data_volume_tags = tmpl::append<
+      typename DerivedGhCorrection::dg_package_data_volume_tags,
+      typename DerivedScalarCorrection::dg_package_data_volume_tags>;
+
+  static std::string name() {
+    return "Product" + pretty_type::name<DerivedGhCorrection>() + "GH" + "And" +
+           pretty_type::name<DerivedScalarCorrection>() + "Scalar";
+  }
+
+  struct GhCorrection {
+    using type = DerivedGhCorrection;
+    static std::string name() {
+      // We change the default name of the boundary correction to avoid errors
+      // during option parsing
+      return pretty_type::name<DerivedGhCorrection>() + "GH";
+    }
+    static constexpr Options::String help{
+        "The Generalized Harmonic part of the product boundary condition"};
+  };
+  struct ScalarCorrection {
+    using type = DerivedScalarCorrection;
+    static std::string name() {
+      // We change the default name of the boundary correction to avoid errors
+      // during option parsing
+      return pretty_type::name<DerivedScalarCorrection>() + "Scalar";
+    }
+    static constexpr Options::String help{
+        "The scalar part of the product boundary condition"};
+    };
+
+  using options = tmpl::list<GhCorrection, ScalarCorrection>;
+
+  static constexpr Options::String help = {
+      "Direct product of a GH and CurvedScalarWave boundary correction. "
+      "See the documentation for the two individual boundary corrections for "
+      "further details."};
+
+  ProductOfCorrections() = default;
+  ProductOfCorrections(DerivedGhCorrection gh_correction,
+                       DerivedScalarCorrection scalar_correction)
+      : derived_gh_correction_{gh_correction},
+        derived_scalar_correction_{scalar_correction} {}
+  ProductOfCorrections(const ProductOfCorrections&) = default;
+  ProductOfCorrections& operator=(const ProductOfCorrections&) = default;
+  ProductOfCorrections(ProductOfCorrections&&) = default;
+  ProductOfCorrections& operator=(ProductOfCorrections&&) = default;
+  ~ProductOfCorrections() override = default;
+
+  /// \cond
+  explicit ProductOfCorrections(CkMigrateMessage* msg)
+      : BoundaryCorrection(msg) {}
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(ProductOfCorrections);  // NOLINT
+  /// \endcond
+  void pup(PUP::er& p) override {
+    BoundaryCorrection::pup(p);
+    p | derived_gh_correction_;
+    p | derived_scalar_correction_;
+  }
+
+  std::unique_ptr<BoundaryCorrection> get_clone() const override {
+    return std::make_unique<ProductOfCorrections>(*this);
+  }
+
+  double dg_package_data(
+      // GH packaged fields
+      const gsl::not_null<tnsr::aa<DataVector, dim, Frame::Inertial>*>
+          packaged_char_speed_v_spacetime_metric,
+      const gsl::not_null<tnsr::iaa<DataVector, dim, Frame::Inertial>*>
+          packaged_char_speed_v_zero,
+      const gsl::not_null<tnsr::aa<DataVector, dim, Frame::Inertial>*>
+          packaged_char_speed_v_plus,
+      const gsl::not_null<tnsr::aa<DataVector, dim, Frame::Inertial>*>
+          packaged_char_speed_v_minus,
+      const gsl::not_null<tnsr::iaa<DataVector, dim, Frame::Inertial>*>
+          packaged_char_speed_n_times_v_plus,
+      const gsl::not_null<tnsr::iaa<DataVector, dim, Frame::Inertial>*>
+          packaged_char_speed_n_times_v_minus,
+      const gsl::not_null<tnsr::aa<DataVector, dim, Frame::Inertial>*>
+          packaged_char_speed_gamma2_v_spacetime_metric,
+      const gsl::not_null<tnsr::a<DataVector, dim, Frame::Inertial>*>
+          packaged_char_speeds,
+      // Scalar packaged fields
+      const gsl::not_null<Scalar<DataVector>*> packaged_v_psi_scalar,
+      const gsl::not_null<tnsr::i<DataVector, dim, Frame::Inertial>*>
+          packaged_v_zero_scalar,
+      const gsl::not_null<Scalar<DataVector>*> packaged_v_plus_scalar,
+      const gsl::not_null<Scalar<DataVector>*> packaged_v_minus_scalar,
+      const gsl::not_null<Scalar<DataVector>*> packaged_gamma2_scalar,
+      const gsl::not_null<tnsr::i<DataVector, dim, Frame::Inertial>*>
+          packaged_interface_unit_normal_scalar,
+      const gsl::not_null<tnsr::a<DataVector, dim, Frame::Inertial>*>
+          packaged_char_speeds_scalar,
+      // GH variables
+      const tnsr::aa<DataVector, dim, Frame::Inertial>& spacetime_metric,
+      const tnsr::aa<DataVector, dim, Frame::Inertial>& pi,
+      const tnsr::iaa<DataVector, dim, Frame::Inertial>& phi,
+      // Scalar variables
+      const Scalar<DataVector>& psi_scalar, const Scalar<DataVector>& pi_scalar,
+      const tnsr::i<DataVector, dim, Frame::Inertial>& phi_scalar,
+      // GH fluxes
+      // Scalar fluxes
+      // GH temporaries
+      const Scalar<DataVector>& constraint_gamma1,
+      const Scalar<DataVector>& constraint_gamma2,
+      const Scalar<DataVector>& lapse,
+      const tnsr::I<DataVector, dim, Frame::Inertial>& shift,
+      // Scalar temporaries
+
+      const Scalar<DataVector>& constraint_gamma1_scalar,
+      const Scalar<DataVector>& constraint_gamma2_scalar,
+      // Mesh variables
+      const tnsr::i<DataVector, dim, Frame::Inertial>& normal_covector,
+      const tnsr::I<DataVector, dim, Frame::Inertial>& normal_vector,
+      const std::optional<tnsr::I<DataVector, dim, Frame::Inertial>>&
+          mesh_velocity,
+      const std::optional<Scalar<DataVector>>& normal_dot_mesh_velocity
+      // GH volume quantities
+      // Scalar volume quantities
+  ) const {
+    const double gh_correction_result = derived_gh_correction_.dg_package_data(
+        // GH packaged variables
+        packaged_char_speed_v_spacetime_metric, packaged_char_speed_v_zero,
+        packaged_char_speed_v_plus, packaged_char_speed_v_minus,
+        packaged_char_speed_n_times_v_plus, packaged_char_speed_n_times_v_minus,
+        packaged_char_speed_gamma2_v_spacetime_metric, packaged_char_speeds,
+        // GH variables
+        spacetime_metric, pi, phi,
+        // GH temporaries
+        constraint_gamma1, constraint_gamma2, lapse, shift,
+        // GH mesh variables
+        normal_covector, normal_vector, mesh_velocity,
+        normal_dot_mesh_velocity);
+
+    const double scalar_correction_result =
+        derived_scalar_correction_.dg_package_data(
+            // Scalar packaged variables
+            packaged_v_psi_scalar, packaged_v_zero_scalar,
+            packaged_v_plus_scalar, packaged_v_minus_scalar,
+            packaged_gamma2_scalar, packaged_interface_unit_normal_scalar,
+            packaged_char_speeds_scalar,
+            // Scalar variables
+            psi_scalar, pi_scalar, phi_scalar,
+            // Scalar temporaries
+            lapse, shift, constraint_gamma1_scalar, constraint_gamma2_scalar,
+            // Scalar mesh variables
+            normal_covector, normal_vector, mesh_velocity,
+            normal_dot_mesh_velocity);
+    return std::max(gh_correction_result, scalar_correction_result);
+  }
+
+  void dg_boundary_terms(
+      // GH boundary corrections
+      const gsl::not_null<tnsr::aa<DataVector, dim, Frame::Inertial>*>
+          boundary_correction_spacetime_metric,
+      const gsl::not_null<tnsr::aa<DataVector, dim, Frame::Inertial>*>
+          boundary_correction_pi,
+      const gsl::not_null<tnsr::iaa<DataVector, dim, Frame::Inertial>*>
+          boundary_correction_phi,
+      // Scalar boundary corrections
+      const gsl::not_null<Scalar<DataVector>*> psi_boundary_correction_scalar,
+      const gsl::not_null<Scalar<DataVector>*> pi_boundary_correction_scalar,
+      const gsl::not_null<tnsr::i<DataVector, dim, Frame::Inertial>*>
+          phi_boundary_correction_scalar,
+      // GH internal packages field tags
+      const tnsr::aa<DataVector, dim, Frame::Inertial>&
+          char_speed_v_spacetime_metric_int,
+      const tnsr::iaa<DataVector, dim, Frame::Inertial>& char_speed_v_zero_int,
+      const tnsr::aa<DataVector, dim, Frame::Inertial>& char_speed_v_plus_int,
+      const tnsr::aa<DataVector, dim, Frame::Inertial>& char_speed_v_minus_int,
+      const tnsr::iaa<DataVector, dim, Frame::Inertial>&
+          char_speed_normal_times_v_plus_int,
+      const tnsr::iaa<DataVector, dim, Frame::Inertial>&
+          char_speed_normal_times_v_minus_int,
+      const tnsr::aa<DataVector, dim, Frame::Inertial>&
+          char_speed_constraint_gamma2_v_spacetime_metric_int,
+      const tnsr::a<DataVector, dim, Frame::Inertial>& char_speeds_int,
+      // Scalar internal packaged field tags
+      const Scalar<DataVector>& v_psi_int_scalar,
+      const tnsr::i<DataVector, dim, Frame::Inertial>& v_zero_int_scalar,
+      const Scalar<DataVector>& v_plus_int_scalar,
+      const Scalar<DataVector>& v_minus_int_scalar,
+      const Scalar<DataVector>& gamma2_int_scalar,
+      const tnsr::i<DataVector, dim, Frame::Inertial>&
+          interface_unit_normal_int_scalar,
+      const tnsr::a<DataVector, dim, Frame::Inertial>& char_speeds_int_scalar,
+      // GH external packaged fields
+      const tnsr::aa<DataVector, dim, Frame::Inertial>&
+          char_speed_v_spacetime_metric_ext,
+      const tnsr::iaa<DataVector, dim, Frame::Inertial>& char_speed_v_zero_ext,
+      const tnsr::aa<DataVector, dim, Frame::Inertial>& char_speed_v_plus_ext,
+      const tnsr::aa<DataVector, dim, Frame::Inertial>& char_speed_v_minus_ext,
+      const tnsr::iaa<DataVector, dim, Frame::Inertial>&
+          char_speed_normal_times_v_plus_ext,
+      const tnsr::iaa<DataVector, dim, Frame::Inertial>&
+          char_speed_normal_times_v_minus_ext,
+      const tnsr::aa<DataVector, dim, Frame::Inertial>&
+          char_speed_constraint_gamma2_v_spacetime_metric_ext,
+      const tnsr::a<DataVector, dim, Frame::Inertial>& char_speeds_ext,
+      // Scalar external packaged fields
+      const Scalar<DataVector>& v_psi_ext_scalar,
+      const tnsr::i<DataVector, dim, Frame::Inertial>& v_zero_ext_scalar,
+      const Scalar<DataVector>& v_plus_ext_scalar,
+      const Scalar<DataVector>& v_minus_ext_scalar,
+      const Scalar<DataVector>& gamma2_ext_scalar,
+      const tnsr::i<DataVector, dim, Frame::Inertial>&
+          interface_unit_normal_ext_scalar,
+      const tnsr::a<DataVector, dim, Frame::Inertial>& char_speeds_ext_scalar,
+      // DG formulation
+      const dg::Formulation dg_formulation) const {
+    derived_gh_correction_.dg_boundary_terms(
+        // GH boundary corrections
+        boundary_correction_spacetime_metric, boundary_correction_pi,
+        boundary_correction_phi,
+        // GH internal packaged fields
+        char_speed_v_spacetime_metric_int, char_speed_v_zero_int,
+        char_speed_v_plus_int, char_speed_v_minus_int,
+        char_speed_normal_times_v_plus_int, char_speed_normal_times_v_minus_int,
+        char_speed_constraint_gamma2_v_spacetime_metric_int, char_speeds_int,
+        // GH external packaged fields
+        char_speed_v_spacetime_metric_ext, char_speed_v_zero_ext,
+        char_speed_v_plus_ext, char_speed_v_minus_ext,
+        char_speed_normal_times_v_plus_ext, char_speed_normal_times_v_minus_ext,
+        char_speed_constraint_gamma2_v_spacetime_metric_ext, char_speeds_ext,
+        dg_formulation);
+
+    derived_scalar_correction_.dg_boundary_terms(
+        // Scalar boundary corrections
+        psi_boundary_correction_scalar, pi_boundary_correction_scalar,
+        phi_boundary_correction_scalar,
+        // Scalar internal packaged fields
+        v_psi_int_scalar, v_zero_int_scalar, v_plus_int_scalar,
+        v_minus_int_scalar, gamma2_int_scalar, interface_unit_normal_int_scalar,
+        char_speeds_int_scalar,
+        // Scalar external packaged fields
+        v_psi_ext_scalar, v_zero_ext_scalar, v_plus_ext_scalar,
+        v_minus_ext_scalar, gamma2_ext_scalar, interface_unit_normal_ext_scalar,
+        char_speeds_ext_scalar, dg_formulation);
+  }
+
+  const DerivedGhCorrection& gh_correction() const {
+    return derived_gh_correction_;
+  }
+
+  const DerivedScalarCorrection& scalar_correction() const {
+    return derived_scalar_correction_;
+  }
+
+ private:
+  DerivedGhCorrection derived_gh_correction_;
+  DerivedScalarCorrection derived_scalar_correction_;
+};
+
+/// \cond
+template <typename DerivedGhCorrection, typename DerivedScalarCorrection>
+PUP::able::PUP_ID ProductOfCorrections<DerivedGhCorrection,
+                                       DerivedScalarCorrection>::my_PUP_ID =
+    0;  // NOLINT
+/// \endcond
+}  // namespace ScalarTensor::BoundaryCorrections

--- a/src/Evolution/Systems/ScalarTensor/BoundaryCorrections/RegisterDerived.cpp
+++ b/src/Evolution/Systems/ScalarTensor/BoundaryCorrections/RegisterDerived.cpp
@@ -1,0 +1,13 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/ScalarTensor/BoundaryCorrections/RegisterDerived.hpp"
+
+#include "Evolution/Systems/ScalarTensor/BoundaryCorrections/Factory.hpp"
+#include "Utilities/Serialization/RegisterDerivedClassesWithCharm.hpp"
+
+namespace ScalarTensor::BoundaryCorrections {
+void register_derived_with_charm() {
+  register_derived_classes_with_charm<BoundaryCorrection>();
+}
+}  // namespace ScalarTensor::BoundaryCorrections

--- a/src/Evolution/Systems/ScalarTensor/BoundaryCorrections/RegisterDerived.hpp
+++ b/src/Evolution/Systems/ScalarTensor/BoundaryCorrections/RegisterDerived.hpp
@@ -1,0 +1,8 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+namespace ScalarTensor::BoundaryCorrections {
+void register_derived_with_charm();
+}  // namespace ScalarTensor::BoundaryCorrections

--- a/src/Evolution/Systems/ScalarTensor/CMakeLists.txt
+++ b/src/Evolution/Systems/ScalarTensor/CMakeLists.txt
@@ -41,4 +41,5 @@ target_link_libraries(
   )
 
 add_subdirectory(BoundaryConditions)
+add_subdirectory(BoundaryCorrections)
 add_subdirectory(Sources)

--- a/src/Evolution/Systems/ScalarTensor/Sources/ScalarSource.hpp
+++ b/src/Evolution/Systems/ScalarTensor/Sources/ScalarSource.hpp
@@ -59,7 +59,7 @@ void add_scalar_source_to_dt_pi_scalar(
  *
  * where the source is given by
  * \f[
- *   \mathcal{S} \equiv m^2_\Psi ~.
+ *   \mathcal{S} \equiv m^2_\Psi \Psi~.
  * \f]
  *
  * Here the mass parameter value is an option that needs to be specified in the

--- a/src/Evolution/Systems/ScalarTensor/System.hpp
+++ b/src/Evolution/Systems/ScalarTensor/System.hpp
@@ -8,6 +8,8 @@
 #include "DataStructures/VariablesTag.hpp"
 #include "Evolution/Systems/CurvedScalarWave/System.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/System.hpp"
+#include "Evolution/Systems/ScalarTensor/BoundaryConditions/BoundaryCondition.hpp"
+#include "Evolution/Systems/ScalarTensor/BoundaryCorrections/BoundaryCorrection.hpp"
 #include "Evolution/Systems/ScalarTensor/Characteristics.hpp"
 #include "Evolution/Systems/ScalarTensor/Tags.hpp"
 #include "Evolution/Systems/ScalarTensor/TimeDerivative.hpp"
@@ -60,6 +62,8 @@ namespace ScalarTensor {
  * only implement this system in three spatial dimensions.
  */
 struct System {
+  using boundary_conditions_base = BoundaryConditions::BoundaryCondition;
+  using boundary_correction_base = BoundaryCorrections::BoundaryCorrection;
   static constexpr bool has_primitive_and_conservative_vars = false;
   static constexpr size_t volume_dim = 3;
 

--- a/tests/Unit/Evolution/Systems/ScalarTensor/BoundaryCorrections/Test_ProductOfCorrections.cpp
+++ b/tests/Unit/Evolution/Systems/ScalarTensor/BoundaryCorrections/Test_ProductOfCorrections.cpp
@@ -1,0 +1,259 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <optional>
+#include <string>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Evolution/Systems/ScalarTensor/BoundaryCorrections/BoundaryCorrection.hpp"
+#include "Evolution/Systems/ScalarTensor/BoundaryCorrections/ProductOfCorrections.hpp"
+#include "Evolution/Systems/ScalarTensor/System.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "Helpers/Evolution/DiscontinuousGalerkin/BoundaryCorrections.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Formulation.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+template <typename DerivedCorrection, typename PackagedFieldTagList,
+          typename EvolvedTagList, typename TempTagList, typename VolumeTagList>
+struct ComputeBoundaryCorrectionHelperImpl;
+
+template <typename DerivedCorrection, typename... PackagedFieldTags,
+          typename... EvolvedTags, typename... TempTags, typename... VolumeTags>
+struct ComputeBoundaryCorrectionHelperImpl<
+    DerivedCorrection, tmpl::list<PackagedFieldTags...>,
+    tmpl::list<EvolvedTags...>, tmpl::list<TempTags...>,
+    tmpl::list<VolumeTags...>> {
+  template <typename PackagedVariables, typename EvolvedVariables,
+            typename TempVariables,
+            typename VolumeVariables>
+  static double dg_package_data(
+      const gsl::not_null<PackagedVariables*> packaged_variables,
+      const EvolvedVariables& evolved_variables,
+      const TempVariables& temp_variables,
+      const VolumeVariables& volume_variables,
+      const tnsr::i<DataVector, 3, Frame::Inertial>& normal_covector,
+      const tnsr::I<DataVector, 3, Frame::Inertial>& normal_vector,
+      const std::optional<tnsr::I<DataVector, 3, Frame::Inertial>>&
+          mesh_velocity,
+      const std::optional<Scalar<DataVector>>& normal_dot_mesh_velocity,
+      const DerivedCorrection& derived_correction) {
+    return derived_correction.dg_package_data(
+        make_not_null(&get<PackagedFieldTags>(*packaged_variables))...,
+        get<EvolvedTags>(evolved_variables)...,
+        get<TempTags>(temp_variables)..., normal_covector, normal_vector,
+        mesh_velocity, normal_dot_mesh_velocity,
+        get<VolumeTags>(volume_variables)...);
+  }
+
+  template <typename EvolvedVariables, typename PackagedVariables>
+  static void dg_boundary_terms(
+      const gsl::not_null<EvolvedVariables*> boundary_corrections,
+      const PackagedVariables& internal_packaged_fields,
+      const PackagedVariables& external_packaged_fields,
+      dg::Formulation dg_formulation,
+      const DerivedCorrection& derived_correction) {
+    derived_correction.dg_boundary_terms(
+        make_not_null(&get<EvolvedTags>(*boundary_corrections))...,
+        get<PackagedFieldTags>(internal_packaged_fields)...,
+        get<PackagedFieldTags>(external_packaged_fields)..., dg_formulation);
+  }
+};
+
+template <typename DerivedCorrection, typename EvolvedTagList
+          >
+using ComputeBoundaryCorrectionHelper = ComputeBoundaryCorrectionHelperImpl<
+    DerivedCorrection, typename DerivedCorrection::dg_package_field_tags,
+    EvolvedTagList,
+    typename DerivedCorrection::dg_package_data_temporary_tags,
+    typename DerivedCorrection::dg_package_data_volume_tags>;
+
+template <typename DerivedGhCorrection, typename DerivedScalarCorrection>
+void test_boundary_correction_combination(
+    const DerivedGhCorrection& derived_gh_correction,
+    const DerivedScalarCorrection& derived_scalar_correction,
+    const ScalarTensor::BoundaryCorrections::ProductOfCorrections<
+        DerivedGhCorrection, DerivedScalarCorrection>&
+        derived_product_correction,
+    const dg::Formulation formulation) {
+  CHECK(derived_product_correction.gh_correction() == derived_gh_correction);
+  CHECK(derived_product_correction.scalar_correction() ==
+        derived_scalar_correction);
+  using gh_variables_tags = typename gh::System<3>::variables_tag::tags_list;
+  using scalar_variables_tags =
+      typename CurvedScalarWave::System<3>::variables_tag::tags_list;
+  using evolved_variables_type =
+      Variables<tmpl::append<gh_variables_tags, scalar_variables_tags>>;
+
+  using derived_product_correction_type =
+      ScalarTensor::BoundaryCorrections::ProductOfCorrections<
+          DerivedGhCorrection, DerivedScalarCorrection>;
+
+  using packaged_variables_type = Variables<
+      typename derived_product_correction_type::dg_package_field_tags>;
+
+  using temporary_variables_type = Variables<
+      typename derived_product_correction_type::dg_package_data_temporary_tags>;
+
+  using volume_variables_type = Variables<
+      typename derived_product_correction_type::dg_package_data_volume_tags>;
+
+  const size_t element_size = 10_st;
+  MAKE_GENERATOR(gen);
+  std::uniform_real_distribution<> dist(0.1, 1.0);
+
+  packaged_variables_type expected_packaged_variables{element_size};
+  packaged_variables_type packaged_variables{element_size};
+
+  const auto evolved_variables =
+      make_with_random_values<evolved_variables_type>(
+          make_not_null(&gen), make_not_null(&dist), element_size);
+
+  const auto temporary_variables =
+      make_with_random_values<temporary_variables_type>(
+          make_not_null(&gen), make_not_null(&dist), element_size);
+  volume_variables_type volume_variables{element_size};
+  if constexpr (tmpl::size<typename derived_product_correction_type::
+                               dg_package_data_volume_tags>::value > 0) {
+    fill_with_random_values(make_not_null(&volume_variables),
+                            make_not_null(&gen), make_not_null(&dist));
+  }
+
+  const auto normal_covector =
+      make_with_random_values<tnsr::i<DataVector, 3, Frame::Inertial>>(
+          make_not_null(&gen), make_not_null(&dist), element_size);
+  const auto normal_vector =
+      make_with_random_values<tnsr::I<DataVector, 3, Frame::Inertial>>(
+          make_not_null(&gen), make_not_null(&dist), element_size);
+  const auto mesh_velocity =
+      make_with_random_values<tnsr::I<DataVector, 3, Frame::Inertial>>(
+          make_not_null(&gen), make_not_null(&dist), element_size);
+  const auto normal_dot_mesh_velocity =
+      make_with_random_values<Scalar<DataVector>>(
+          make_not_null(&gen), make_not_null(&dist), element_size);
+
+  double expected_package_gh_result =
+      ComputeBoundaryCorrectionHelper<DerivedGhCorrection, gh_variables_tags>::
+          dg_package_data(make_not_null(&expected_packaged_variables),
+                          evolved_variables, temporary_variables,
+                          volume_variables, normal_covector, normal_vector,
+                          mesh_velocity, normal_dot_mesh_velocity,
+                          derived_gh_correction);
+  double expected_package_scalar_result =
+      ComputeBoundaryCorrectionHelper<DerivedScalarCorrection,
+                                      scalar_variables_tags>::
+          dg_package_data(make_not_null(&expected_packaged_variables),
+                          evolved_variables, temporary_variables,
+                          volume_variables, normal_covector, normal_vector,
+                          mesh_velocity, normal_dot_mesh_velocity,
+                          derived_scalar_correction);
+
+  double package_combined_result = ComputeBoundaryCorrectionHelper<
+      derived_product_correction_type,
+      tmpl::append<gh_variables_tags, scalar_variables_tags>>::
+      dg_package_data(make_not_null(&packaged_variables), evolved_variables,
+                      temporary_variables, volume_variables, normal_covector,
+                      normal_vector, mesh_velocity, normal_dot_mesh_velocity,
+                      derived_product_correction);
+  CHECK(approx(SINGLE_ARG(std::max(expected_package_gh_result,
+                                   expected_package_scalar_result))) ==
+        package_combined_result);
+  CHECK_VARIABLES_APPROX(packaged_variables, expected_packaged_variables);
+
+  auto serialized_and_deserialized_correction =
+      serialize_and_deserialize(derived_product_correction);
+
+  package_combined_result = ComputeBoundaryCorrectionHelper<
+      derived_product_correction_type,
+      tmpl::append<gh_variables_tags, scalar_variables_tags>>::
+      dg_package_data(make_not_null(&packaged_variables), evolved_variables,
+                      temporary_variables, volume_variables, normal_covector,
+                      normal_vector, mesh_velocity, normal_dot_mesh_velocity,
+                      serialized_and_deserialized_correction);
+  CHECK(approx(SINGLE_ARG(std::max(expected_package_gh_result,
+                                   expected_package_scalar_result))) ==
+        package_combined_result);
+  CHECK_VARIABLES_APPROX(packaged_variables, expected_packaged_variables);
+
+  const auto external_packaged_fields =
+      make_with_random_values<packaged_variables_type>(
+          make_not_null(&gen), make_not_null(&dist), element_size);
+  const auto internal_packaged_fields =
+      make_with_random_values<packaged_variables_type>(
+          make_not_null(&gen), make_not_null(&dist), element_size);
+
+  evolved_variables_type expected_boundary_correction{element_size};
+  evolved_variables_type boundary_correction{element_size};
+  ComputeBoundaryCorrectionHelper<DerivedGhCorrection, gh_variables_tags>::
+      dg_boundary_terms(make_not_null(&expected_boundary_correction),
+                        internal_packaged_fields, external_packaged_fields,
+                        formulation, derived_gh_correction);
+  ComputeBoundaryCorrectionHelper<DerivedScalarCorrection,
+                                  scalar_variables_tags>::
+      dg_boundary_terms(make_not_null(&expected_boundary_correction),
+                        internal_packaged_fields, external_packaged_fields,
+                        formulation, derived_scalar_correction);
+
+  ComputeBoundaryCorrectionHelper<
+      derived_product_correction_type,
+      tmpl::append<gh_variables_tags, scalar_variables_tags>>::
+      dg_boundary_terms(make_not_null(&boundary_correction),
+                        internal_packaged_fields, external_packaged_fields,
+                        formulation, derived_product_correction);
+  CHECK_VARIABLES_APPROX(boundary_correction, expected_boundary_correction);
+
+  ComputeBoundaryCorrectionHelper<
+      derived_product_correction_type,
+      tmpl::append<gh_variables_tags, scalar_variables_tags>>::
+      dg_boundary_terms(make_not_null(&boundary_correction),
+                        internal_packaged_fields, external_packaged_fields,
+                        formulation, serialized_and_deserialized_correction);
+  CHECK_VARIABLES_APPROX(boundary_correction, expected_boundary_correction);
+
+  PUPable_reg(
+      SINGLE_ARG(ScalarTensor::BoundaryCorrections::ProductOfCorrections<
+                 DerivedGhCorrection, DerivedScalarCorrection>));
+
+  TestHelpers::evolution::dg::test_boundary_correction_conservation<
+      ScalarTensor::System>(
+      make_not_null(&gen), derived_product_correction,
+      Mesh<2>{5, Spectral::Basis::Legendre, Spectral::Quadrature::Gauss}, {},
+      {});
+}
+}  // namespace
+
+SPECTRE_TEST_CASE(
+ "Unit.Evolution.Systems.ScalarTensor.BoundaryCorrections.ProductOfCorrections",
+    "[Unit][Evolution]") {
+  {
+    INFO("Product correction UpwindPenalty and UpwindPenalty");
+    CurvedScalarWave::BoundaryCorrections::UpwindPenalty<3> scalar_correction{};
+    gh::BoundaryCorrections::UpwindPenalty<3> gh_correction{};
+    TestHelpers::test_creation<
+        std::unique_ptr<ScalarTensor::BoundaryCorrections::BoundaryCorrection>>(
+        "ProductUpwindPenaltyGHAndUpwindPenaltyScalar:\n"
+        "  UpwindPenaltyGH:\n"
+        "  UpwindPenaltyScalar:");
+    ScalarTensor::BoundaryCorrections::ProductOfCorrections<
+        gh::BoundaryCorrections::UpwindPenalty<3>,
+        CurvedScalarWave::BoundaryCorrections::UpwindPenalty<3>>
+        product_boundary_correction{gh_correction, scalar_correction};
+    for (const auto formulation :
+         {dg::Formulation::StrongInertial, dg::Formulation::WeakInertial}) {
+      test_boundary_correction_combination<
+          gh::BoundaryCorrections::UpwindPenalty<3>,
+          CurvedScalarWave::BoundaryCorrections::UpwindPenalty<3>>(
+          gh_correction, scalar_correction, product_boundary_correction,
+          formulation);
+    }
+  }
+}

--- a/tests/Unit/Evolution/Systems/ScalarTensor/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/ScalarTensor/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY "Test_ScalarTensor")
 
 set(LIBRARY_SOURCES
   BoundaryConditions/Test_ProductOfConditions.cpp
+  BoundaryCorrections/Test_ProductOfCorrections.cpp
   Test_Characteristics.cpp
   Test_Sources.cpp
   Test_StressEnergy.cpp


### PR DESCRIPTION
## Proposed changes

Implement boundary corrections for ScalarTensor by taking the product of the boundary corrections for the individual component systems. This is done in the exactly the same way as it is done for the grmhd system.

We also overload the equality operator in CSW, just to check in the unit test that the combined system is calling each condition correctly.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
