### PR TITLE
Changes to get clang 16 to compile

### DIFF
--- a/cmake/FindCatch.cmake
+++ b/cmake/FindCatch.cmake
@@ -29,7 +29,8 @@ endfunction()
 
 find_path(
   CATCH_INCLUDE_DIR
-  PATH_SUFFIXES single_include include catch catch2 include/catch2
+  PATH_SUFFIXES
+    single_include single_include/catch2 include catch catch2 include/catch2
   NAMES catch.hpp
   HINTS ${CATCH_ROOT}
   DOC "catch include dir"

--- a/cmake/SetupSphinx.cmake
+++ b/cmake/SetupSphinx.cmake
@@ -30,7 +30,7 @@ file(
   DESTINATION ${SPHINX_SOURCE}
 )
 
-add_custom_target(py-docs ALL
+add_custom_target(py-docs
   COMMAND
   ${CMAKE_COMMAND} -E env
   ${CMAKE_BINARY_DIR}/bin/python-spectre -m sphinx -b html

--- a/src/Domain/CoordinateMaps/Composition.cpp
+++ b/src/Domain/CoordinateMaps/Composition.cpp
@@ -380,7 +380,103 @@ bool Composition<Frames, Dim, std::index_sequence<Is...>>::is_equal_to(
 
 GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
 
-#undef DIM
 #undef INSTANTIATE
+
+#if defined(__clang__) && __clang_major__ >= 16
+#define INSTANTIATE2(_, data)                                                  \
+  template domain::CoordinateMaps::Composition<                                \
+      brigand::list<Frame::ElementLogical, Frame::BlockLogical,                \
+                    Frame::Inertial>,                                          \
+      DIM(data), std::integer_sequence<unsigned long, 0ul, 1ul>>::             \
+      Composition(                                                             \
+          std::unique_ptr<                                                     \
+              domain::CoordinateMapBase<Frame::ElementLogical,                 \
+                                        Frame::BlockLogical, DIM(data)>,       \
+              std::default_delete<domain::CoordinateMapBase<                   \
+                  Frame::ElementLogical, Frame::BlockLogical, DIM(data)>>>,    \
+          std::unique_ptr<                                                     \
+              domain::CoordinateMapBase<Frame::BlockLogical, Frame::Inertial,  \
+                                        DIM(data)>,                            \
+              std::default_delete<domain::CoordinateMapBase<                   \
+                  Frame::BlockLogical, Frame::Inertial, DIM(data)>>>);         \
+  template domain::CoordinateMaps::Composition<                                \
+      brigand::list<Frame::ElementLogical, Frame::BlockLogical, Frame::Grid>,  \
+      DIM(data), std::integer_sequence<unsigned long, 0ul, 1ul>>::             \
+      Composition(                                                             \
+          std::unique_ptr<                                                     \
+              domain::CoordinateMapBase<Frame::ElementLogical,                 \
+                                        Frame::BlockLogical, DIM(data)>,       \
+              std::default_delete<domain::CoordinateMapBase<                   \
+                  Frame::ElementLogical, Frame::BlockLogical, DIM(data)>>>,    \
+          std::unique_ptr<domain::CoordinateMapBase<Frame::BlockLogical,       \
+                                                    Frame::Grid, DIM(data)>,   \
+                          std::default_delete<domain::CoordinateMapBase<       \
+                              Frame::BlockLogical, Frame::Grid, DIM(data)>>>); \
+  template domain::CoordinateMaps::Composition<                                \
+      brigand::list<Frame::ElementLogical, Frame::BlockLogical, Frame::Grid,   \
+                    Frame::Distorted>,                                         \
+      DIM(data), std::integer_sequence<unsigned long, 0ul, 1ul, 2ul>>::        \
+      Composition(                                                             \
+          std::unique_ptr<                                                     \
+              domain::CoordinateMapBase<Frame::ElementLogical,                 \
+                                        Frame::BlockLogical, DIM(data)>,       \
+              std::default_delete<domain::CoordinateMapBase<                   \
+                  Frame::ElementLogical, Frame::BlockLogical, DIM(data)>>>,    \
+          std::unique_ptr<domain::CoordinateMapBase<Frame::BlockLogical,       \
+                                                    Frame::Grid, DIM(data)>,   \
+                          std::default_delete<domain::CoordinateMapBase<       \
+                              Frame::BlockLogical, Frame::Grid, DIM(data)>>>,  \
+          std::unique_ptr<domain::CoordinateMapBase<                           \
+                              Frame::Grid, Frame::Distorted, DIM(data)>,       \
+                          std::default_delete<domain::CoordinateMapBase<       \
+                              Frame::Grid, Frame::Distorted, DIM(data)>>>);    \
+  template domain::CoordinateMaps::Composition<                                \
+      brigand::list<Frame::ElementLogical, Frame::BlockLogical, Frame::Grid,   \
+                    Frame::Inertial>,                                          \
+      DIM(data), std::integer_sequence<unsigned long, 0ul, 1ul, 2ul>>::        \
+      Composition(                                                             \
+          std::unique_ptr<                                                     \
+              domain::CoordinateMapBase<Frame::ElementLogical,                 \
+                                        Frame::BlockLogical, DIM(data)>,       \
+              std::default_delete<domain::CoordinateMapBase<                   \
+                  Frame::ElementLogical, Frame::BlockLogical, DIM(data)>>>,    \
+          std::unique_ptr<domain::CoordinateMapBase<Frame::BlockLogical,       \
+                                                    Frame::Grid, DIM(data)>,   \
+                          std::default_delete<domain::CoordinateMapBase<       \
+                              Frame::BlockLogical, Frame::Grid, DIM(data)>>>,  \
+          std::unique_ptr<domain::CoordinateMapBase<                           \
+                              Frame::Grid, Frame::Inertial, DIM(data)>,        \
+                          std::default_delete<domain::CoordinateMapBase<       \
+                              Frame::Grid, Frame::Inertial, DIM(data)>>>);     \
+  template domain::CoordinateMaps::Composition<                                \
+      brigand::list<Frame::ElementLogical, Frame::BlockLogical, Frame::Grid,   \
+                    Frame::Distorted, Frame::Inertial>,                        \
+      DIM(data), std::integer_sequence<unsigned long, 0ul, 1ul, 2ul, 3ul>>::   \
+      Composition(                                                             \
+          std::unique_ptr<                                                     \
+              domain::CoordinateMapBase<Frame::ElementLogical,                 \
+                                        Frame::BlockLogical, DIM(data)>,       \
+              std::default_delete<domain::CoordinateMapBase<                   \
+                  Frame::ElementLogical, Frame::BlockLogical, DIM(data)>>>,    \
+          std::unique_ptr<domain::CoordinateMapBase<Frame::BlockLogical,       \
+                                                    Frame::Grid, DIM(data)>,   \
+                          std::default_delete<domain::CoordinateMapBase<       \
+                              Frame::BlockLogical, Frame::Grid, DIM(data)>>>,  \
+          std::unique_ptr<domain::CoordinateMapBase<                           \
+                              Frame::Grid, Frame::Distorted, DIM(data)>,       \
+                          std::default_delete<domain::CoordinateMapBase<       \
+                              Frame::Grid, Frame::Distorted, DIM(data)>>>,     \
+          std::unique_ptr<                                                     \
+              domain::CoordinateMapBase<Frame::Distorted, Frame::Inertial,     \
+                                        DIM(data)>,                            \
+              std::default_delete<domain::CoordinateMapBase<                   \
+                  Frame::Distorted, Frame::Inertial, DIM(data)>>>);
+
+GENERATE_INSTANTIATIONS(INSTANTIATE2, (1, 2, 3))
+
+#undef INSTANTIATE2
+#endif /* defined(__clang__) && __clang_major__ >= 16 */
+
+#undef DIM
 
 }  // namespace domain::CoordinateMaps

--- a/src/Utilities/OptimizerHacks.cpp
+++ b/src/Utilities/OptimizerHacks.cpp
@@ -8,3 +8,18 @@ namespace optimizer_hacks {
 void indicate_value_can_be_changed(void* /*variable*/) {}
 }  // namespace optimizer_hacks
 #endif  /* defined(__clang__) && __clang__ < 11 */
+
+#if defined(__clang__) && __clang_major__ >= 15 && defined(__GLIBCXX__)
+#include <string>
+// clang v15+ fails to instantiate the following std library templates if
+// pre-compiled headers are used
+template std::__cxx11::basic_string<char, std::char_traits<char>,
+                                    std::allocator<char>>::pointer
+std::__cxx11::basic_string<char, std::char_traits<char>,
+                           std::allocator<char>>::_M_use_local_data();
+template std::__cxx11::basic_string<wchar_t, std::char_traits<wchar_t>,
+                                    std::allocator<wchar_t>>::pointer
+std::__cxx11::basic_string<wchar_t, std::char_traits<wchar_t>,
+                           std::allocator<wchar_t>>::_M_use_local_data();
+#endif /* defined(__clang__) && __clang_major__ >= 15 && defined(__GLIBCXX__) \
+        */

--- a/tests/Unit/PointwiseFunctions/Elasticity/Test_Strain.cpp
+++ b/tests/Unit/PointwiseFunctions/Elasticity/Test_Strain.cpp
@@ -11,6 +11,7 @@
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.tpp"
 #include "Elliptic/Systems/Elasticity/Tags.hpp"


### PR DESCRIPTION
## Proposed changes

- Add new path for finding catch.  
- Don't build python documentation unless requested explicitly
- Add explicit instantiations for things that clang didn't produce symbols for

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
