### PR TITLE
Add Spacetime Deriv Of Norm Of Shift PyBind

### DIFF
--- a/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/Python/Bindings.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/Python/Bindings.cpp
@@ -13,6 +13,7 @@
 #include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/Phi.hpp"
 #include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/Pi.hpp"
 #include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/Ricci.hpp"
+#include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/SpacetimeDerivOfNormOfShift.hpp"
 #include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/SpatialDerivOfLapse.hpp"
 #include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/SpatialDerivOfShift.hpp"
 #include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/TimeDerivOfShift.hpp"
@@ -82,6 +83,18 @@ void bind_impl(py::module& m) {  // NOLINT
         py::arg("lapse"), py::arg("dt_lapse"), py::arg("shift"),
         py::arg("dt_shift"), py::arg("spatial_metric"),
         py::arg("dt_spatial_metric"), py::arg("phi"));
+
+  m.def(
+      "spacetime_deriv_of_norm_of_shift",
+      static_cast<tnsr::a<DataVector, Dim> (*)(
+          const Scalar<DataVector>&, const tnsr::I<DataVector, Dim>&,
+          const tnsr::ii<DataVector, Dim>&, const tnsr::II<DataVector, Dim>&,
+          const tnsr::AA<DataVector, Dim>&, const tnsr::A<DataVector, Dim>&,
+          const tnsr::iaa<DataVector, Dim>&, const tnsr::aa<DataVector, Dim>&)>(
+          &::gh::spacetime_deriv_of_norm_of_shift),
+      py::arg("lapse"), py::arg("shift"), py::arg("spatial_metric"),
+      py::arg("inverse_spatial_metric"), py::arg("inverse_spacetime_metric"),
+      py::arg("spacetime_unit_normal"), py::arg("phi"), py::arg("pi"));
 
   m.def("spatial_deriv_of_lapse",
         static_cast<tnsr::i<DataVector, Dim> (*)(

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Python/Test_GhBindings.py
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Python/Test_GhBindings.py
@@ -116,9 +116,9 @@ class TestBindings(unittest.TestCase):
 
     def test_pi(self):
         lapse = Scalar[DataVector](num_points=1, fill=1.0)
-        dt_lapse = Scalar[DataVector](num_points=1, fill=0.0)
-        shift = tnsr.I[DataVector, 3](num_points=1, fill=0.0)
-        dt_shift = tnsr.I[DataVector, 3](num_points=1, fill=0.0)
+        dt_lapse = Scalar[DataVector](num_points=1, fill=1.0)
+        shift = tnsr.I[DataVector, 3](num_points=1, fill=1.0)
+        dt_shift = tnsr.I[DataVector, 3](num_points=1, fill=1.0)
         spatial_metric = tnsr.ii[DataVector, 3](num_points=1, fill=1.0)
         dt_spatial_metric = tnsr.ii[DataVector, 3](num_points=1, fill=0.0)
         phi = tnsr.iaa[DataVector, 3](num_points=1, fill=1.0)
@@ -130,6 +130,28 @@ class TestBindings(unittest.TestCase):
             spatial_metric,
             dt_spatial_metric,
             phi,
+        )
+
+    def test_spacetime_deriv_of_norm_of_shift(self):
+        lapse = Scalar[DataVector](num_points=1, fill=1.0)
+        shift = tnsr.I[DataVector, 3](num_points=1, fill=1.0)
+        spatial_metric = tnsr.ii[DataVector, 3](num_points=1, fill=1.0)
+        inverse_spatial_metric = tnsr.II[DataVector, 3](num_points=1, fill=1.0)
+        inverse_spacetime_metric = tnsr.AA[DataVector, 3](
+            num_points=1, fill=1.0
+        )
+        spacetime_unit_normal = tnsr.A[DataVector, 3](num_points=1, fill=1.0)
+        phi = tnsr.iaa[DataVector, 3](num_points=1, fill=1.0)
+        pi = tnsr.aa[DataVector, 3](num_points=1, fill=1.0)
+        gh.spacetime_deriv_of_norm_of_shift(
+            lapse,
+            shift,
+            spatial_metric,
+            inverse_spatial_metric,
+            inverse_spacetime_metric,
+            spacetime_unit_normal,
+            phi,
+            pi,
         )
 
     def test_spatial_ricci_tensor(self):


### PR DESCRIPTION
## Proposed changes
Add Python Binding for Spacetime Derivative of Norm of Shift. 
<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
