### PR TITLE
Change observation value handling, allow any observation on failure

### DIFF
--- a/src/ControlSystem/Event.hpp
+++ b/src/ControlSystem/Event.hpp
@@ -92,7 +92,8 @@ class Event : public ::Event {
   void operator()(const db::DataBox<DbTags>& box,
                   Parallel::GlobalCache<Metavariables>& cache,
                   const ArrayIndex& array_index,
-                  const Component* const component) const {
+                  const Component* const component,
+                  const ObservationValue& /*observation_value*/) const {
     const LinkedMessageId<double> measurement_id{
         db::get<::Tags::Time>(box),
         db::get<::evolution::Tags::PreviousTriggerTime>(box)};

--- a/src/Elliptic/Executables/Elasticity/SolveElasticity.hpp
+++ b/src/Elliptic/Executables/Elasticity/SolveElasticity.hpp
@@ -201,11 +201,10 @@ struct Metavariables {
                    tmpl::flatten<tmpl::list<
                        Events::Completion,
                        dg::Events::field_observations<
-                           volume_dim, linear_solver_iteration_id,
-                           observe_fields, observer_compute_tags,
+                           volume_dim, observe_fields, observer_compute_tags,
                            LinearSolver::multigrid::Tags::IsFinestGrid>,
                        dg::Events::ObserveVolumeIntegrals<
-                           volume_dim, linear_solver_iteration_id,
+                           volume_dim,
                            tmpl::list<Elasticity::Tags::PotentialEnergyDensity<
                                volume_dim>>,
                            tmpl::list<>,
@@ -260,14 +259,15 @@ struct Metavariables {
 
   using solve_actions = tmpl::list<
       typename linear_solver::template solve<tmpl::list<
-          Actions::RunEventsAndTriggers,
+          Actions::RunEventsAndTriggers<linear_solver_iteration_id>,
           typename multigrid::template solve<
               build_linear_operator_actions,
               smooth_actions<LinearSolver::multigrid::VcycleDownLabel>,
               smooth_actions<LinearSolver::multigrid::VcycleUpLabel>>,
           ::LinearSolver::Actions::make_identity_if_skipped<
               multigrid, build_linear_operator_actions>>>,
-      Actions::RunEventsAndTriggers, Parallel::Actions::TerminatePhase>;
+      Actions::RunEventsAndTriggers<linear_solver_iteration_id>,
+      Parallel::Actions::TerminatePhase>;
 
   using dg_element_array = elliptic::DgElementArray<
       Metavariables,

--- a/src/Elliptic/Executables/Poisson/SolvePoisson.hpp
+++ b/src/Elliptic/Executables/Poisson/SolvePoisson.hpp
@@ -191,8 +191,7 @@ struct Metavariables {
                    tmpl::flatten<tmpl::list<
                        Events::Completion,
                        dg::Events::field_observations<
-                           volume_dim, linear_solver_iteration_id,
-                           observe_fields, observer_compute_tags,
+                           volume_dim, observe_fields, observer_compute_tags,
                            LinearSolver::multigrid::Tags::IsFinestGrid>>>>,
         tmpl::pair<Trigger, elliptic::Triggers::all_triggers<
                                 typename linear_solver::options_group>>>;
@@ -257,7 +256,7 @@ struct Metavariables {
                   smooth_actions<LinearSolver::multigrid::VcycleUpLabel>>,
               ::LinearSolver::Actions::make_identity_if_skipped<
                   multigrid, build_linear_operator_actions>>,
-          Actions::RunEventsAndTriggers>,
+          Actions::RunEventsAndTriggers<linear_solver_iteration_id>>,
       Parallel::Actions::TerminatePhase>;
 
   using dg_element_array = elliptic::DgElementArray<

--- a/src/Elliptic/Executables/Punctures/SolvePunctures.hpp
+++ b/src/Elliptic/Executables/Punctures/SolvePunctures.hpp
@@ -86,12 +86,10 @@ struct Metavariables {
             tmpl::flatten<tmpl::list<
                 Events::Completion,
                 dg::Events::field_observations<
-                    volume_dim, typename solver::nonlinear_solver_iteration_id,
-                    observe_fields, observer_compute_tags,
+                    volume_dim, observe_fields, observer_compute_tags,
                     LinearSolver::multigrid::Tags::IsFinestGrid>,
                 dg::Events::ObserveVolumeIntegrals<
-                    volume_dim, typename solver::nonlinear_solver_iteration_id,
-                    observe_integral_fields, observer_compute_tags,
+                    volume_dim, observe_integral_fields, observer_compute_tags,
                     LinearSolver::multigrid::Tags::IsFinestGrid>>>>,
         tmpl::pair<Trigger,
                    elliptic::Triggers::all_triggers<
@@ -116,7 +114,8 @@ struct Metavariables {
                       observers::Actions::RegisterEventsWithObservers,
                       Parallel::Actions::TerminatePhase>;
 
-  using step_actions = tmpl::list<Actions::RunEventsAndTriggers>;
+  using step_actions = tmpl::list<
+      Actions::RunEventsAndTriggers<solver::nonlinear_solver_iteration_id>>;
 
   using solve_actions =
       tmpl::push_back<typename solver::template solve_actions<step_actions>,

--- a/src/Elliptic/Executables/Xcts/SolveXcts.hpp
+++ b/src/Elliptic/Executables/Xcts/SolveXcts.hpp
@@ -124,14 +124,12 @@ struct Metavariables {
         tmpl::pair<
             elliptic::BoundaryConditions::BoundaryCondition<volume_dim>,
             Xcts::BoundaryConditions::standard_boundary_conditions<system>>,
-        tmpl::pair<
-            Event,
-            tmpl::flatten<tmpl::list<
-                Events::Completion,
-                dg::Events::field_observations<
-                    volume_dim, typename solver::nonlinear_solver_iteration_id,
-                    observe_fields, observer_compute_tags,
-                    LinearSolver::multigrid::Tags::IsFinestGrid>>>>,
+        tmpl::pair<Event,
+                   tmpl::flatten<tmpl::list<
+                       Events::Completion,
+                       dg::Events::field_observations<
+                           volume_dim, observe_fields, observer_compute_tags,
+                           LinearSolver::multigrid::Tags::IsFinestGrid>>>>,
         tmpl::pair<Trigger,
                    elliptic::Triggers::all_triggers<
                        typename solver::nonlinear_solver::options_group>>>;
@@ -151,7 +149,8 @@ struct Metavariables {
                       observers::Actions::RegisterEventsWithObservers,
                       Parallel::Actions::TerminatePhase>;
 
-  using step_actions = tmpl::list<Actions::RunEventsAndTriggers>;
+  using step_actions = tmpl::list<
+      Actions::RunEventsAndTriggers<solver::nonlinear_solver_iteration_id>>;
 
   using solve_actions =
       tmpl::push_back<typename solver::template solve_actions<step_actions>,

--- a/src/Evolution/EventsAndDenseTriggers/EventsAndDenseTriggers.hpp
+++ b/src/Evolution/EventsAndDenseTriggers/EventsAndDenseTriggers.hpp
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/TagName.hpp"
 #include "Evolution/EventsAndDenseTriggers/DenseTrigger.hpp"
 #include "Options/Options.hpp"
 #include "Options/String.hpp"
@@ -237,6 +238,8 @@ void EventsAndDenseTriggers::run_events(
                    Event>,
           get_tags<tmpl::_1>>>,
       db::is_compute_tag<tmpl::_1>>>;
+  const Event::ObservationValue observation_value{db::tag_name<::Tags::Time>(),
+                                                  db::get<::Tags::Time>(box)};
   const auto observation_box = make_observation_box<compute_tags>(box);
 
   for (auto& trigger_entry : events_and_triggers_) {
@@ -249,7 +252,8 @@ void EventsAndDenseTriggers::run_events(
           },
           make_not_null(&box));
       for (const auto& event : trigger_entry.events) {
-        event->run(observation_box, cache, array_index, component);
+        event->run(observation_box, cache, array_index, component,
+                   observation_value);
       }
       db::mutate<::evolution::Tags::PreviousTriggerTime>(
           [](const gsl::not_null<std::optional<double>*>

--- a/src/Evolution/EventsAndDenseTriggers/EventsAndDenseTriggers.hpp
+++ b/src/Evolution/EventsAndDenseTriggers/EventsAndDenseTriggers.hpp
@@ -237,6 +237,7 @@ void EventsAndDenseTriggers::run_events(
                    Event>,
           get_tags<tmpl::_1>>>,
       db::is_compute_tag<tmpl::_1>>>;
+  const auto observation_box = make_observation_box<compute_tags>(box);
 
   for (auto& trigger_entry : events_and_triggers_) {
     if (trigger_entry.is_triggered == std::optional{true}) {
@@ -247,7 +248,6 @@ void EventsAndDenseTriggers::run_events(
                 trigger_entry.trigger->previous_trigger_time();
           },
           make_not_null(&box));
-      const auto observation_box = make_observation_box<compute_tags>(box);
       for (const auto& event : trigger_entry.events) {
         event->run(observation_box, cache, array_index, component);
       }

--- a/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
+++ b/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
@@ -180,12 +180,12 @@ struct EvolutionMetavars {
                    Burgers::BoundaryConditions::standard_boundary_conditions>,
         tmpl::pair<DenseTrigger, DenseTriggers::standard_dense_triggers>,
         tmpl::pair<DomainCreator<volume_dim>, domain_creators<volume_dim>>,
-        tmpl::pair<Event, tmpl::flatten<tmpl::list<
-                              Events::Completion,
-                              dg::Events::field_observations<
-                                  volume_dim, Tags::Time, observe_fields,
-                                  non_tensor_compute_tags>,
-                              Events::time_events<system>>>>,
+        tmpl::pair<Event,
+                   tmpl::flatten<tmpl::list<
+                       Events::Completion,
+                       dg::Events::field_observations<
+                           volume_dim, observe_fields, non_tensor_compute_tags>,
+                       Events::time_events<system>>>>,
         tmpl::pair<evolution::initial_data::InitialData, initial_data_list>,
         tmpl::pair<PhaseChange, PhaseControl::factory_creatable_classes>,
         tmpl::pair<StepChooser<StepChooserUse::LtsStep>,
@@ -330,8 +330,9 @@ struct EvolutionMetavars {
 
           Parallel::PhaseActions<
               Parallel::Phase::Evolve,
-              tmpl::list<Actions::RunEventsAndTriggers, Actions::ChangeSlabSize,
-                         step_actions, Actions::AdvanceTime,
+              tmpl::list<Actions::RunEventsAndTriggers<Tags::Time>,
+                         Actions::ChangeSlabSize, step_actions,
+                         Actions::AdvanceTime,
                          PhaseControl::Actions::ExecutePhaseChange>>>>;
 
   template <typename ParallelComponent>

--- a/src/Evolution/Executables/CurvedScalarWave/EvolveCurvedScalarWave.hpp
+++ b/src/Evolution/Executables/CurvedScalarWave/EvolveCurvedScalarWave.hpp
@@ -203,9 +203,8 @@ struct EvolutionMetavars {
         tmpl::pair<Event,
                    tmpl::flatten<tmpl::list<
                        Events::Completion,
-                       dg::Events::field_observations<volume_dim, Tags::Time,
-                                                      observe_fields,
-                                                      non_tensor_compute_tags>,
+                       dg::Events::field_observations<
+                           volume_dim, observe_fields, non_tensor_compute_tags>,
                        tmpl::conditional_t<
                            interpolate,
                            intrp::Events::InterpolateWithoutInterpComponent<
@@ -312,8 +311,9 @@ struct EvolutionMetavars {
                                             Parallel::Actions::TerminatePhase>>,
           Parallel::PhaseActions<
               Parallel::Phase::Evolve,
-              tmpl::list<Actions::RunEventsAndTriggers, Actions::ChangeSlabSize,
-                         step_actions, Actions::AdvanceTime,
+              tmpl::list<Actions::RunEventsAndTriggers<Tags::Time>,
+                         Actions::ChangeSlabSize, step_actions,
+                         Actions::AdvanceTime,
                          PhaseControl::Actions::ExecutePhaseChange>>>>;
 
   template <typename ParallelComponent>

--- a/src/Evolution/Executables/CurvedScalarWave/EvolveWorldtubeCurvedScalarWave.hpp
+++ b/src/Evolution/Executables/CurvedScalarWave/EvolveWorldtubeCurvedScalarWave.hpp
@@ -207,17 +207,18 @@ struct EvolutionMetavars {
                 CurvedScalarWave::BoundaryConditions::Worldtube<volume_dim>>>>,
         tmpl::pair<DenseTrigger, DenseTriggers::standard_dense_triggers>,
         tmpl::pair<DomainCreator<volume_dim>, domain_creators<volume_dim>>,
-        tmpl::pair<Event, tmpl::flatten<tmpl::list<
-                              Events::time_events<system>, Events::Completion,
-                              intrp::Events::InterpolateWithoutInterpComponent<
-                                  volume_dim, PsiAlongAxis<1>,
-                                  EvolutionMetavars, interpolator_source_vars>,
-                              intrp::Events::InterpolateWithoutInterpComponent<
-                                  volume_dim, PsiAlongAxis<2>,
-                                  EvolutionMetavars, interpolator_source_vars>,
-                              dg::Events::field_observations<
-                                  volume_dim, Tags::Time, observe_fields,
-                                  non_tensor_compute_tags>>>>,
+        tmpl::pair<
+            Event,
+            tmpl::flatten<tmpl::list<
+                Events::time_events<system>, Events::Completion,
+                intrp::Events::InterpolateWithoutInterpComponent<
+                    volume_dim, PsiAlongAxis<1>, EvolutionMetavars,
+                    interpolator_source_vars>,
+                intrp::Events::InterpolateWithoutInterpComponent<
+                    volume_dim, PsiAlongAxis<2>, EvolutionMetavars,
+                    interpolator_source_vars>,
+                dg::Events::field_observations<volume_dim, observe_fields,
+                                               non_tensor_compute_tags>>>>,
         tmpl::pair<MathFunction<1, Frame::Inertial>,
                    MathFunctions::all_math_functions<1, Frame::Inertial>>,
         tmpl::pair<PhaseChange,
@@ -319,8 +320,9 @@ struct EvolutionMetavars {
                                             Parallel::Actions::TerminatePhase>>,
           Parallel::PhaseActions<
               Parallel::Phase::Evolve,
-              tmpl::list<Actions::RunEventsAndTriggers, Actions::ChangeSlabSize,
-                         step_actions, Actions::AdvanceTime,
+              tmpl::list<Actions::RunEventsAndTriggers<Tags::Time>,
+                         Actions::ChangeSlabSize, step_actions,
+                         Actions::AdvanceTime,
                          PhaseControl::Actions::ExecutePhaseChange>>>>;
 
   template <typename ParallelComponent>

--- a/src/Evolution/Executables/ForceFree/EvolveForceFree.hpp
+++ b/src/Evolution/Executables/ForceFree/EvolveForceFree.hpp
@@ -142,12 +142,12 @@ struct EvolutionMetavars {
                    ForceFree::BoundaryConditions::standard_boundary_conditions>,
         tmpl::pair<DenseTrigger, DenseTriggers::standard_dense_triggers>,
         tmpl::pair<DomainCreator<volume_dim>, domain_creators<volume_dim>>,
-        tmpl::pair<Event, tmpl::flatten<tmpl::list<
-                              Events::Completion,
-                              dg::Events::field_observations<
-                                  volume_dim, Tags::Time, observe_fields,
-                                  non_tensor_compute_tags>,
-                              Events::time_events<system>>>>,
+        tmpl::pair<Event,
+                   tmpl::flatten<tmpl::list<
+                       Events::Completion,
+                       dg::Events::field_observations<
+                           volume_dim, observe_fields, non_tensor_compute_tags>,
+                       Events::time_events<system>>>>,
         tmpl::pair<evolution::initial_data::InitialData, initial_data_list>,
         tmpl::pair<LtsTimeStepper, TimeSteppers::lts_time_steppers>,
         tmpl::pair<PhaseChange,
@@ -239,8 +239,9 @@ struct EvolutionMetavars {
 
           Parallel::PhaseActions<
               Parallel::Phase::Evolve,
-              tmpl::list<Actions::RunEventsAndTriggers, Actions::ChangeSlabSize,
-                         dg_step_actions, Actions::AdvanceTime,
+              tmpl::list<Actions::RunEventsAndTriggers<Tags::Time>,
+                         Actions::ChangeSlabSize, dg_step_actions,
+                         Actions::AdvanceTime,
                          PhaseControl::Actions::ExecutePhaseChange>>>>;
 
   template <typename ParallelComponent>

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
@@ -417,9 +417,8 @@ struct EvolutionMetavars {
                 intrp::Events::InterpolateWithoutInterpComponent<
                     3, ExcisionBoundaryB, EvolutionMetavars,
                     interpolator_source_vars>,
-                Events::MonitorMemory<3, ::Tags::Time>, Events::Completion,
-                dg::Events::field_observations<volume_dim, Tags::Time,
-                                               observe_fields,
+                Events::MonitorMemory<3>, Events::Completion,
+                dg::Events::field_observations<volume_dim, observe_fields,
                                                non_tensor_compute_tags>,
                 control_system::control_system_events<control_systems>,
                 Events::time_events<system>>>>,
@@ -552,8 +551,9 @@ struct EvolutionMetavars {
           Parallel::PhaseActions<
               Parallel::Phase::Evolve,
               tmpl::list<::domain::Actions::CheckFunctionsOfTimeAreReady,
-                         Actions::RunEventsAndTriggers, Actions::ChangeSlabSize,
-                         step_actions, Actions::AdvanceTime,
+                         Actions::RunEventsAndTriggers<Tags::Time>,
+                         Actions::ChangeSlabSize, step_actions,
+                         Actions::AdvanceTime,
                          PhaseControl::Actions::ExecutePhaseChange>>>>>;
 
   struct BondiSachs : tt::ConformsTo<intrp::protocols::InterpolationTargetTag> {

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhNoBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhNoBlackHole.hpp
@@ -65,8 +65,9 @@ struct EvolutionMetavars : public GeneralizedHarmonicTemplateBase<VolumeDim> {
                                             Parallel::Actions::TerminatePhase>>,
           Parallel::PhaseActions<
               Parallel::Phase::Evolve,
-              tmpl::list<Actions::RunEventsAndTriggers, Actions::ChangeSlabSize,
-                         step_actions, Actions::AdvanceTime,
+              tmpl::list<Actions::RunEventsAndTriggers<Tags::Time>,
+                         Actions::ChangeSlabSize, step_actions,
+                         Actions::AdvanceTime,
                          PhaseControl::Actions::ExecutePhaseChange>>>>>;
 
   template <typename ParallelComponent>

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhSingleBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhSingleBlackHole.hpp
@@ -218,8 +218,9 @@ struct EvolutionMetavars : public GeneralizedHarmonicTemplateBase<VolumeDim> {
           Parallel::PhaseActions<
               Parallel::Phase::Evolve,
               tmpl::list<::domain::Actions::CheckFunctionsOfTimeAreReady,
-                         Actions::RunEventsAndTriggers, Actions::ChangeSlabSize,
-                         step_actions, Actions::AdvanceTime,
+                         Actions::RunEventsAndTriggers<Tags::Time>,
+                         Actions::ChangeSlabSize, step_actions,
+                         Actions::AdvanceTime,
                          PhaseControl::Actions::ExecutePhaseChange>>>>>;
 
   template <typename ParallelComponent>

--- a/src/Evolution/Executables/GeneralizedHarmonic/GeneralizedHarmonicBase.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/GeneralizedHarmonicBase.hpp
@@ -245,7 +245,7 @@ struct ObserverTags {
       gh::gauges::Tags::GaugeAndDerivativeCompute<volume_dim>>;
 
   using field_observations =
-      dg::Events::field_observations<volume_dim, Tags::Time, observe_fields,
+      dg::Events::field_observations<volume_dim, observe_fields,
                                      non_tensor_compute_tags>;
 };
 
@@ -259,8 +259,7 @@ struct FactoryCreation : tt::ConformsTo<Options::protocols::FactoryCreation> {
       tmpl::pair<
           Event,
           tmpl::flatten<tmpl::list<
-              Events::Completion,
-              Events::MonitorMemory<volume_dim, ::Tags::Time>,
+              Events::Completion, Events::MonitorMemory<volume_dim>,
               typename detail::ObserverTags<volume_dim>::field_observations,
               Events::time_events<system>>>>,
       tmpl::pair<

--- a/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
+++ b/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
@@ -522,13 +522,11 @@ struct GhValenciaDivCleanTemplateBase<
             Event,
             tmpl::flatten<tmpl::list<
                 Events::Completion,
-                dg::Events::field_observations<volume_dim, Tags::Time,
-                                               observe_fields,
+                dg::Events::field_observations<volume_dim, observe_fields,
                                                non_tensor_compute_tags>,
-                dg::Events::ObserveVolumeIntegrals<volume_dim,
-                                                   Tags::Time, integrand_fields,
+                dg::Events::ObserveVolumeIntegrals<volume_dim, integrand_fields,
                                                    non_tensor_compute_tags>,
-                Events::ObserveAtExtremum<Tags::Time, observe_fields,
+                Events::ObserveAtExtremum<observe_fields,
                                           non_tensor_compute_tags>,
                 Events::time_events<system>,
                 intrp::Events::Interpolate<3, InterpolationTargetTags,
@@ -758,12 +756,13 @@ struct GhValenciaDivCleanTemplateBase<
               tmpl::list<VariableFixing::Actions::FixVariables<
                              VariableFixing::FixToAtmosphere<volume_dim>>,
                          Actions::UpdateConservatives,
-                         Actions::RunEventsAndTriggers, Actions::ChangeSlabSize,
-                         step_actions, Actions::AdvanceTime,
+                         Actions::RunEventsAndTriggers<Tags::Time>,
+                         Actions::ChangeSlabSize, step_actions,
+                         Actions::AdvanceTime,
                          PhaseControl::Actions::ExecutePhaseChange>>,
           Parallel::PhaseActions<
               Parallel::Phase::PostFailureCleanup,
-              tmpl::list<Actions::RunEventsOnFailure,
+              tmpl::list<Actions::RunEventsOnFailure<Tags::Time>,
                          Parallel::Actions::TerminatePhase>>>>>;
 
   template <typename ParallelComponent>

--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
@@ -305,15 +305,15 @@ struct EvolutionMetavars {
     using factory_classes = tmpl::map<
         tmpl::pair<DenseTrigger, DenseTriggers::standard_dense_triggers>,
         tmpl::pair<DomainCreator<volume_dim>, domain_creators<volume_dim>>,
-        tmpl::pair<Event, tmpl::flatten<tmpl::list<
-                              Events::Completion,
-                              dg::Events::field_observations<
-                                  volume_dim, Tags::Time, observe_fields,
-                                  non_tensor_compute_tags>,
-                              Events::time_events<system>,
-                              intrp::Events::InterpolateWithoutInterpComponent<
-                                  3, InterpolationTargetTags, EvolutionMetavars,
-                                  interpolator_source_vars>...>>>,
+        tmpl::pair<Event,
+                   tmpl::flatten<tmpl::list<
+                       Events::Completion,
+                       dg::Events::field_observations<
+                           volume_dim, observe_fields, non_tensor_compute_tags>,
+                       Events::time_events<system>,
+                       intrp::Events::InterpolateWithoutInterpComponent<
+                           3, InterpolationTargetTags, EvolutionMetavars,
+                           interpolator_source_vars>...>>>,
         tmpl::pair<
             grmhd::ValenciaDivClean::BoundaryConditions::BoundaryCondition,
             grmhd::ValenciaDivClean::BoundaryConditions::
@@ -515,28 +515,28 @@ struct EvolutionMetavars {
 
   using dg_element_array_component = DgElementArray<
       EvolutionMetavars,
-      tmpl::list<
-          Parallel::PhaseActions<Parallel::Phase::Initialization,
-                                 initialization_actions>,
+      tmpl::list<Parallel::PhaseActions<Parallel::Phase::Initialization,
+                                        initialization_actions>,
 
-          Parallel::PhaseActions<
-              Parallel::Phase::InitializeTimeStepperHistory,
-              SelfStart::self_start_procedure<step_actions, system>>,
+                 Parallel::PhaseActions<
+                     Parallel::Phase::InitializeTimeStepperHistory,
+                     SelfStart::self_start_procedure<step_actions, system>>,
 
-          Parallel::PhaseActions<
-              Parallel::Phase::Register,
-              tmpl::push_back<dg_registration_list,
-                              Parallel::Actions::TerminatePhase>>,
+                 Parallel::PhaseActions<
+                     Parallel::Phase::Register,
+                     tmpl::push_back<dg_registration_list,
+                                     Parallel::Actions::TerminatePhase>>,
 
-          Parallel::PhaseActions<
-              Parallel::Phase::Evolve,
-              tmpl::list<Actions::RunEventsAndTriggers, Actions::ChangeSlabSize,
-                         step_actions, Actions::AdvanceTime,
-                         PhaseControl::Actions::ExecutePhaseChange>>,
-          Parallel::PhaseActions<
-              Parallel::Phase::PostFailureCleanup,
-              tmpl::list<Actions::RunEventsOnFailure,
-                         Parallel::Actions::TerminatePhase>>>>;
+                 Parallel::PhaseActions<
+                     Parallel::Phase::Evolve,
+                     tmpl::list<Actions::RunEventsAndTriggers<Tags::Time>,
+                                Actions::ChangeSlabSize, step_actions,
+                                Actions::AdvanceTime,
+                                PhaseControl::Actions::ExecutePhaseChange>>,
+                 Parallel::PhaseActions<
+                     Parallel::Phase::PostFailureCleanup,
+                     tmpl::list<Actions::RunEventsOnFailure<Tags::Time>,
+                                Parallel::Actions::TerminatePhase>>>>;
 
   template <typename ParallelComponent>
   struct registration_list {

--- a/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
+++ b/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
@@ -228,12 +228,12 @@ struct EvolutionMetavars {
     using factory_classes = tmpl::map<
         tmpl::pair<DenseTrigger, DenseTriggers::standard_dense_triggers>,
         tmpl::pair<DomainCreator<volume_dim>, domain_creators<volume_dim>>,
-        tmpl::pair<Event, tmpl::flatten<tmpl::list<
-                              Events::Completion,
-                              dg::Events::field_observations<
-                                  volume_dim, Tags::Time, observe_fields,
-                                  non_tensor_compute_tags>,
-                              Events::time_events<system>>>>,
+        tmpl::pair<Event,
+                   tmpl::flatten<tmpl::list<
+                       Events::Completion,
+                       dg::Events::field_observations<
+                           volume_dim, observe_fields, non_tensor_compute_tags>,
+                       Events::time_events<system>>>>,
         tmpl::pair<LtsTimeStepper, TimeSteppers::lts_time_steppers>,
         tmpl::pair<
             NewtonianEuler::BoundaryConditions::BoundaryCondition<volume_dim>,
@@ -394,8 +394,9 @@ struct EvolutionMetavars {
 
           Parallel::PhaseActions<
               Parallel::Phase::Evolve,
-              tmpl::list<Actions::RunEventsAndTriggers, Actions::ChangeSlabSize,
-                         step_actions, Actions::AdvanceTime,
+              tmpl::list<Actions::RunEventsAndTriggers<Tags::Time>,
+                         Actions::ChangeSlabSize, step_actions,
+                         Actions::AdvanceTime,
                          PhaseControl::Actions::ExecutePhaseChange>>>>;
 
   template <typename ParallelComponent>

--- a/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveM1Grey.hpp
+++ b/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveM1Grey.hpp
@@ -156,12 +156,12 @@ struct EvolutionMetavars {
     using factory_classes = tmpl::map<
         tmpl::pair<DenseTrigger, DenseTriggers::standard_dense_triggers>,
         tmpl::pair<DomainCreator<volume_dim>, domain_creators<volume_dim>>,
-        tmpl::pair<Event, tmpl::flatten<tmpl::list<
-                              Events::Completion,
-                              dg::Events::field_observations<
-                                  volume_dim, Tags::Time, observe_fields,
-                                  non_tensor_compute_tags>,
-                              Events::time_events<system>>>>,
+        tmpl::pair<Event,
+                   tmpl::flatten<tmpl::list<
+                       Events::Completion,
+                       dg::Events::field_observations<
+                           volume_dim, observe_fields, non_tensor_compute_tags>,
+                       Events::time_events<system>>>>,
         tmpl::pair<LtsTimeStepper, TimeSteppers::lts_time_steppers>,
         tmpl::pair<PhaseChange, PhaseControl::factory_creatable_classes>,
         tmpl::pair<
@@ -254,8 +254,9 @@ struct EvolutionMetavars {
 
           Parallel::PhaseActions<
               Parallel::Phase::Evolve,
-              tmpl::list<Actions::RunEventsAndTriggers, Actions::ChangeSlabSize,
-                         step_actions, Actions::AdvanceTime,
+              tmpl::list<Actions::RunEventsAndTriggers<Tags::Time>,
+                         Actions::ChangeSlabSize, step_actions,
+                         Actions::AdvanceTime,
                          PhaseControl::Actions::ExecutePhaseChange>>>>;
 
   template <typename ParallelComponent>

--- a/src/Evolution/Executables/RelativisticEuler/Valencia/EvolveValencia.hpp
+++ b/src/Evolution/Executables/RelativisticEuler/Valencia/EvolveValencia.hpp
@@ -171,12 +171,12 @@ struct EvolutionMetavars {
     using factory_classes = tmpl::map<
         tmpl::pair<DenseTrigger, DenseTriggers::standard_dense_triggers>,
         tmpl::pair<DomainCreator<volume_dim>, domain_creators<volume_dim>>,
-        tmpl::pair<Event, tmpl::flatten<tmpl::list<
-                              Events::Completion,
-                              dg::Events::field_observations<
-                                  volume_dim, Tags::Time, observe_fields,
-                                  non_tensor_compute_tags>,
-                              Events::time_events<system>>>>,
+        tmpl::pair<Event,
+                   tmpl::flatten<tmpl::list<
+                       Events::Completion,
+                       dg::Events::field_observations<
+                           volume_dim, observe_fields, non_tensor_compute_tags>,
+                       Events::time_events<system>>>>,
         tmpl::pair<LtsTimeStepper, TimeSteppers::lts_time_steppers>,
         tmpl::pair<PhaseChange, PhaseControl::factory_creatable_classes>,
         tmpl::pair<RelativisticEuler::Valencia::BoundaryConditions::
@@ -276,8 +276,9 @@ struct EvolutionMetavars {
               tmpl::list<VariableFixing::Actions::FixVariables<
                              VariableFixing::FixToAtmosphere<volume_dim>>,
                          Actions::UpdateConservatives,
-                         Actions::RunEventsAndTriggers, Actions::ChangeSlabSize,
-                         step_actions, Actions::AdvanceTime,
+                         Actions::RunEventsAndTriggers<Tags::Time>,
+                         Actions::ChangeSlabSize, step_actions,
+                         Actions::AdvanceTime,
                          PhaseControl::Actions::ExecutePhaseChange>>>>;
 
   template <typename ParallelComponent>

--- a/src/Evolution/Executables/ScalarAdvection/EvolveScalarAdvection.hpp
+++ b/src/Evolution/Executables/ScalarAdvection/EvolveScalarAdvection.hpp
@@ -198,12 +198,12 @@ struct EvolutionMetavars {
     using factory_classes = tmpl::map<
         tmpl::pair<DenseTrigger, DenseTriggers::standard_dense_triggers>,
         tmpl::pair<DomainCreator<volume_dim>, domain_creators<volume_dim>>,
-        tmpl::pair<Event, tmpl::flatten<tmpl::list<
-                              Events::Completion,
-                              dg::Events::field_observations<
-                                  volume_dim, Tags::Time, observe_fields,
-                                  non_tensor_compute_tags>,
-                              Events::time_events<system>>>>,
+        tmpl::pair<Event,
+                   tmpl::flatten<tmpl::list<
+                       Events::Completion,
+                       dg::Events::field_observations<
+                           volume_dim, observe_fields, non_tensor_compute_tags>,
+                       Events::time_events<system>>>>,
         tmpl::pair<evolution::initial_data::InitialData, initial_data_list>,
         tmpl::pair<LtsTimeStepper, TimeSteppers::lts_time_steppers>,
         tmpl::pair<PhaseChange, PhaseControl::factory_creatable_classes>,
@@ -356,8 +356,9 @@ struct EvolutionMetavars {
 
           Parallel::PhaseActions<
               Parallel::Phase::Evolve,
-              tmpl::list<Actions::RunEventsAndTriggers, Actions::ChangeSlabSize,
-                         step_actions, Actions::AdvanceTime,
+              tmpl::list<Actions::RunEventsAndTriggers<Tags::Time>,
+                         Actions::ChangeSlabSize, step_actions,
+                         Actions::AdvanceTime,
                          PhaseControl::Actions::ExecutePhaseChange>>>>;
 
   template <typename ParallelComponent>

--- a/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
+++ b/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
@@ -166,11 +166,10 @@ struct EvolutionMetavars {
         tmpl::pair<Event,
                    tmpl::flatten<tmpl::list<
                        Events::Completion,
-                       dg::Events::field_observations<volume_dim, Tags::Time,
-                                                      observe_fields,
-                                                      non_tensor_compute_tags>,
+                       dg::Events::field_observations<
+                           volume_dim, observe_fields, non_tensor_compute_tags>,
                        dg::Events::ObserveVolumeIntegrals<
-                           volume_dim, Tags::Time,
+                           volume_dim,
                            tmpl::list<ScalarWave::Tags::EnergyDensityCompute<
                                volume_dim>>>,
                        Events::time_events<system>>>>,
@@ -273,8 +272,9 @@ struct EvolutionMetavars {
 
           Parallel::PhaseActions<
               Parallel::Phase::Evolve,
-              tmpl::list<Actions::RunEventsAndTriggers, Actions::ChangeSlabSize,
-                         step_actions, Actions::AdvanceTime,
+              tmpl::list<Actions::RunEventsAndTriggers<Tags::Time>,
+                         Actions::ChangeSlabSize, step_actions,
+                         Actions::AdvanceTime,
                          PhaseControl::Actions::ExecutePhaseChange>>>>;
 
   template <typename ParallelComponent>

--- a/src/Evolution/Systems/Cce/Actions/SendGhVarsToCce.hpp
+++ b/src/Evolution/Systems/Cce/Actions/SendGhVarsToCce.hpp
@@ -45,6 +45,8 @@ struct SendGhVarsToCce {
       Parallel::GlobalCache<Metavariables>& cache,
       const ArrayIndex& array_index, const ActionList /*meta*/,
       const ParallelComponent* const component) {
+    // not used by interpolation
+    const Event::ObservationValue observation_value{};
     auto interpolate_event = intrp::Events::InterpolateWithoutInterpComponent<
         Metavariables::volume_dim, CceWorltubeTargetTag, Metavariables,
         typename CceWorltubeTargetTag::vars_to_interpolate_to_target>{};
@@ -52,7 +54,7 @@ struct SendGhVarsToCce {
         interpolate_event,
         make_observation_box<db::AddComputeTags<
             Events::Tags::ObserverMeshCompute<Metavariables::volume_dim>>>(box),
-        cache, array_index, component);
+        cache, array_index, component, observation_value);
     return {Parallel::AlgorithmExecution::Continue, std::nullopt};
   }
 };

--- a/src/Executables/ExportCoordinates/ExportCoordinates.hpp
+++ b/src/Executables/ExportCoordinates/ExportCoordinates.hpp
@@ -319,7 +319,7 @@ struct Metavariables {
                   tmpl::list<Actions::AdvanceTime,
                              Actions::ExportCoordinates<Dim>,
                              Actions::FindGlobalMinimumGridSpacing,
-                             Actions::RunEventsAndTriggers>>>>,
+                             Actions::RunEventsAndTriggers<Tags::Time>>>>>,
       observers::Observer<Metavariables>,
       observers::ObserverWriter<Metavariables>>;
 

--- a/src/ParallelAlgorithms/Events/Factory.hpp
+++ b/src/ParallelAlgorithms/Events/Factory.hpp
@@ -14,12 +14,12 @@
 #include "Utilities/TMPL.hpp"
 
 namespace dg::Events {
-template <size_t VolumeDim, typename TimeTag, typename Fields,
-          typename NonTensorComputeTagsList, typename ArraySectionIdTag = void>
+template <size_t VolumeDim, typename Fields, typename NonTensorComputeTagsList,
+          typename ArraySectionIdTag = void>
 using field_observations = tmpl::flatten<
-    tmpl::list<ObserveFields<VolumeDim, TimeTag, Fields,
-                             NonTensorComputeTagsList, ArraySectionIdTag>,
-               ::Events::ObserveNorms<TimeTag, Fields, NonTensorComputeTagsList,
+    tmpl::list<ObserveFields<VolumeDim, Fields, NonTensorComputeTagsList,
+                             ArraySectionIdTag>,
+               ::Events::ObserveNorms<Fields, NonTensorComputeTagsList,
                                       ArraySectionIdTag>>>;
 }  // namespace dg::Events
 

--- a/src/ParallelAlgorithms/EventsAndTriggers/Actions/RunEventsOnFailure.hpp
+++ b/src/ParallelAlgorithms/EventsAndTriggers/Actions/RunEventsOnFailure.hpp
@@ -42,7 +42,9 @@ struct RunEventsOnFailure {
   };
 
  public:
-  using const_global_cache_tags = tmpl::list<::Tags::EventsRunAtCleanup>;
+  using const_global_cache_tags =
+      tmpl::list<::Tags::EventsRunAtCleanup,
+                 ::Tags::EventsRunAtCleanupObservationValue>;
 
   template <typename DbTags, typename... InboxTags, typename Metavariables,
             typename ArrayIndex, typename ActionList,
@@ -56,9 +58,9 @@ struct RunEventsOnFailure {
     // so can't rely on the data being safe.
     disable_floating_point_exceptions();
 
-    // This will be fixed in the next commit.
     const Event::ObservationValue observation_value{
-        db::tag_name<ObservationId>(), 123456.7};
+        db::tag_name<ObservationId>(),
+        db::get<Tags::EventsRunAtCleanupObservationValue>(box)};
 
     using compute_tags = tmpl::remove_duplicates<tmpl::filter<
         tmpl::flatten<tmpl::transform<

--- a/src/ParallelAlgorithms/EventsAndTriggers/Completion.hpp
+++ b/src/ParallelAlgorithms/EventsAndTriggers/Completion.hpp
@@ -33,7 +33,8 @@ class Completion : public Event {
   template <typename Metavariables, typename ArrayIndex, typename Component>
   void operator()(Parallel::GlobalCache<Metavariables>& cache,
                   const ArrayIndex& array_index,
-                  const Component* const /*meta*/) const {
+                  const Component* const /*meta*/,
+                  const ObservationValue& /*observation_value*/) const {
     auto al_gore = Parallel::local(
         Parallel::get_parallel_component<Component>(cache)[array_index]);
     al_gore->set_terminate(true);

--- a/src/ParallelAlgorithms/EventsAndTriggers/EventsAndTriggers.hpp
+++ b/src/ParallelAlgorithms/EventsAndTriggers/EventsAndTriggers.hpp
@@ -67,8 +67,8 @@ class EventsAndTriggers {
             typename Component>
   void run_events(const db::DataBox<DbTags>& box,
                   Parallel::GlobalCache<Metavariables>& cache,
-                  const ArrayIndex& array_index,
-                  const Component* component) const {
+                  const ArrayIndex& array_index, const Component* component,
+                  const Event::ObservationValue& observation_value) const {
     using compute_tags = tmpl::remove_duplicates<tmpl::filter<
         tmpl::flatten<tmpl::transform<
             tmpl::at<typename Metavariables::factory_creation::factory_classes,
@@ -85,7 +85,8 @@ class EventsAndTriggers {
           observation_box = make_observation_box<compute_tags>(box);
         }
         for (const auto& event : events) {
-          event->run(observation_box.value(), cache, array_index, component);
+          event->run(observation_box.value(), cache, array_index, component,
+                     observation_value);
         }
       }
     }

--- a/src/ParallelAlgorithms/EventsAndTriggers/Tags.hpp
+++ b/src/ParallelAlgorithms/EventsAndTriggers/Tags.hpp
@@ -48,15 +48,33 @@ struct EventsAndTriggers {
   static std::string name() { return "EventsAndTriggers"; }
 };
 
-/// \brief A list of events to run at cleanpppp.
+namespace EventsRunAtCleanup {
+struct Group {
+  static std::string name() { return "EventsRunAtCleanup"; }
+  static constexpr Options::String help =
+      "Options related to running events on failure.  This is generally "
+      "intended for dumping volume data to diagnose failure reasons.";
+};
+
+/// \brief A list of events to run at cleanup.
 ///
 /// See `Actions::RunEventsOnFailure` for details and caveats.
-struct EventsRunAtCleanup {
+struct Events {
+  static std::string name() { return "Events"; }
   using type = std::vector<std::unique_ptr<::Event>>;
   static constexpr Options::String help =
-      "Events to run during the cleanup phase. This is generally intended for "
-      "dumping volume data to diagnose failure reasons.";
+      "Events to run during the cleanup phase.";
+  using group = Group;
 };
+
+/// \brief Observation value for Actions::RunEventsOnFailure.
+struct ObservationValue {
+  using type = double;
+  static constexpr Options::String help =
+      "Observation value for events run during the cleanup phase.";
+  using group = Group;
+};
+}  // namespace EventsRunAtCleanup
 }  // namespace OptionTags
 
 namespace Tags {
@@ -78,11 +96,21 @@ struct EventsAndTriggers : db::SimpleTag {
 /// Useful for troubleshooting runs that are failing.
 struct EventsRunAtCleanup : db::SimpleTag {
   using type = std::vector<std::unique_ptr<::Event>>;
-  using option_tags = tmpl::list<OptionTags::EventsRunAtCleanup>;
+  using option_tags = tmpl::list<OptionTags::EventsRunAtCleanup::Events>;
 
   static constexpr bool pass_metavariables = false;
   static type create_from_options(const type& events_run_at_cleanup) {
     return deserialize<type>(serialize<type>(events_run_at_cleanup).data());
   }
+};
+
+/// \brief Observation value for Actions::RunEventsOnFailure.
+struct EventsRunAtCleanupObservationValue : db::SimpleTag {
+  using type = double;
+  using option_tags =
+      tmpl::list<OptionTags::EventsRunAtCleanup::ObservationValue>;
+
+  static constexpr bool pass_metavariables = false;
+  static type create_from_options(const type& value) { return value; }
 };
 }  // namespace Tags

--- a/src/ParallelAlgorithms/Interpolation/Events/Interpolate.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Events/Interpolate.hpp
@@ -77,7 +77,8 @@ class Interpolate<VolumeDim, InterpolationTargetTag,
           type&... interpolator_source_vars,
       Parallel::GlobalCache<Metavariables>& cache,
       const ElementId<VolumeDim>& array_index,
-      const ParallelComponent* const /*meta*/) const {
+      const ParallelComponent* const /*meta*/,
+      const ObservationValue& /*observation_value*/) const {
     static_assert(
         std::is_same_v<typename Metavariables::interpolator_source_vars,
                        tmpl::list<InterpolatorSourceVarTags...>>);

--- a/src/ParallelAlgorithms/Interpolation/Events/InterpolateWithoutInterpComponent.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Events/InterpolateWithoutInterpComponent.hpp
@@ -104,7 +104,8 @@ class InterpolateWithoutInterpComponent<VolumeDim, InterpolationTargetTag,
       const typename SourceVarTags::type&... source_vars_input,
       Parallel::GlobalCache<Metavariables>& cache,
       const ElementId<VolumeDim>& array_index,
-      const ParallelComponent* const /*meta*/) const {
+      const ParallelComponent* const /*meta*/,
+      const ObservationValue& /*observation_value*/) const {
     const auto& block_logical_coords =
         InterpolationTarget_detail::block_logical_coords<
             InterpolationTargetTag>(
@@ -209,15 +210,16 @@ class InterpolateWithoutInterpComponent<VolumeDim, InterpolationTargetTag,
       const typename SourceVarTags::type&... source_vars,
       Parallel::GlobalCache<Metavariables>& cache,
       const ElementId<VolumeDim>& array_index,
-      const ParallelComponent* const meta) const {
+      const ParallelComponent* const meta,
+      const ObservationValue& observation_value) const {
     if (active_grid == evolution::dg::subcell::ActiveGrid::Dg) {
       this->operator()(temporal_id, point_infos, dg_mesh, source_vars..., cache,
-                       array_index, meta);
+                       array_index, meta, observation_value);
     } else {
       ASSERT(active_grid == evolution::dg::subcell::ActiveGrid::Subcell,
              "Active grid must be either Dg or Subcell");
       this->operator()(temporal_id, point_infos, subcell_mesh, source_vars...,
-                       cache, array_index, meta);
+                       cache, array_index, meta, observation_value);
     }
   }
 

--- a/src/Time/Actions/ChangeSlabSize.hpp
+++ b/src/Time/Actions/ChangeSlabSize.hpp
@@ -278,7 +278,8 @@ class ChangeSlabSize : public Event {
                   const db::DataBox<DbTags>& box_for_step_choosers,
                   Parallel::GlobalCache<Metavariables>& cache,
                   const ArrayIndex& array_index,
-                  const ParallelComponent* const /*meta*/) const {
+                  const ParallelComponent* const /*meta*/,
+                  const ObservationValue& /*observation_value*/) const {
     const auto next_changable_slab = time_step_id.is_at_slab_boundary()
                                          ? time_step_id.slab_number()
                                          : time_step_id.slab_number() + 1;

--- a/tests/InputFiles/CurvedScalarWave/PlaneWaveMinkowski3D.yaml
+++ b/tests/InputFiles/CurvedScalarWave/PlaneWaveMinkowski3D.yaml
@@ -96,7 +96,6 @@ EventsAndTriggers:
           InterpolateToMesh: None
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double]
-          OverrideObservationValue: None
   - Trigger:
       Slabs:
         EvenlySpaced:
@@ -113,7 +112,6 @@ EventsAndTriggers:
           InterpolateToMesh: None
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double]
-          OverrideObservationValue: None
   - Trigger:
       Slabs:
         EvenlySpaced:

--- a/tests/InputFiles/CurvedScalarWave/WorldtubeKerrSchild.yaml
+++ b/tests/InputFiles/CurvedScalarWave/WorldtubeKerrSchild.yaml
@@ -98,7 +98,6 @@ EventsAndTriggers:
           InterpolateToMesh: None
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double]
-          OverrideObservationValue: None
   - Trigger:
       Slabs:
         EvenlySpaced:

--- a/tests/InputFiles/Elasticity/BentBeam.yaml
+++ b/tests/InputFiles/Elasticity/BentBeam.yaml
@@ -95,4 +95,3 @@ EventsAndTriggers:
           InterpolateToMesh: None
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double]
-          OverrideObservationValue: None

--- a/tests/InputFiles/Elasticity/HalfSpaceMirror.yaml
+++ b/tests/InputFiles/Elasticity/HalfSpaceMirror.yaml
@@ -123,4 +123,3 @@ EventsAndTriggers:
           InterpolateToMesh: None
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double]
-          OverrideObservationValue: None

--- a/tests/InputFiles/GeneralizedHarmonic/BinaryBlackHole.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/BinaryBlackHole.yaml
@@ -202,7 +202,6 @@ EventsAndTriggers:
           InterpolateToMesh: None
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double]
-          OverrideObservationValue: None
   - Trigger:
       Slabs:
         EvenlySpaced:

--- a/tests/InputFiles/GeneralizedHarmonic/CylindricalBinaryBlackHole.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/CylindricalBinaryBlackHole.yaml
@@ -185,7 +185,6 @@ EventsAndTriggers:
           InterpolateToMesh: None
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double]
-          OverrideObservationValue: None
   - Trigger:
       Slabs:
         EvenlySpaced:

--- a/tests/InputFiles/GeneralizedHarmonic/GaugeWave1D.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/GaugeWave1D.yaml
@@ -131,7 +131,6 @@ EventsAndTriggers:
           InterpolateToMesh: None
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double]
-          OverrideObservationValue: None
   - Trigger:
       Slabs:
         Specified:

--- a/tests/InputFiles/GeneralizedHarmonic/GaugeWave3D.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/GaugeWave3D.yaml
@@ -124,7 +124,6 @@ EventsAndTriggers:
           InterpolateToMesh: None
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double]
-          OverrideObservationValue: None
   - Trigger:
       Slabs:
         Specified:

--- a/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
@@ -163,7 +163,6 @@ EventsAndTriggers:
           InterpolateToMesh: None
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double]
-          OverrideObservationValue: None
   - Trigger:
       Slabs:
         EvenlySpaced:

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/BinaryNeutronStar.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/BinaryNeutronStar.yaml
@@ -168,7 +168,6 @@ EventsAndTriggers:
           InterpolateToMesh: None
           CoordinatesFloatingPointType: Float
           FloatingPointTypes: [Float]
-          OverrideObservationValue: None
   - Trigger:
       TimeCompares:
         Comparison: GreaterThan

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/BinaryNeutronStar.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/BinaryNeutronStar.yaml
@@ -185,6 +185,8 @@ Interpolator:
 EventsAndDenseTriggers:
 
 EventsRunAtCleanup:
+  ObservationValue: -1000.0
+  Events:
 
 InitialData:
   NumericInitialData:

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdBondiMichel.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdBondiMichel.yaml
@@ -236,3 +236,5 @@ Interpolator:
 EventsAndDenseTriggers:
 
 EventsRunAtCleanup:
+  ObservationValue: -1000.0
+  Events:

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdBondiMichel.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdBondiMichel.yaml
@@ -195,7 +195,6 @@ EventsAndTriggers:
           InterpolateToMesh: None
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double, Double, Double, Double, Double]
-          OverrideObservationValue: None
   - Trigger:
       Slabs:
         EvenlySpaced:

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdTovStar.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdTovStar.yaml
@@ -228,3 +228,5 @@ Interpolator:
 EventsAndDenseTriggers:
 
 EventsRunAtCleanup:
+  ObservationValue: -1000.0
+  Events:

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdTovStar.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdTovStar.yaml
@@ -211,7 +211,6 @@ EventsAndTriggers:
           InterpolateToMesh: None
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double, Double, Double, Double, Double]
-          OverrideObservationValue: None
   - Trigger:
       Slabs:
         Specified:

--- a/tests/InputFiles/GrMhd/ValenciaDivClean/BlastWave.yaml
+++ b/tests/InputFiles/GrMhd/ValenciaDivClean/BlastWave.yaml
@@ -119,3 +119,5 @@ EventsAndTriggers:
 EventsAndDenseTriggers:
 
 EventsRunAtCleanup:
+  ObservationValue: -1000.0
+  Events:

--- a/tests/InputFiles/GrMhd/ValenciaDivClean/FishboneMoncriefDisk.yaml
+++ b/tests/InputFiles/GrMhd/ValenciaDivClean/FishboneMoncriefDisk.yaml
@@ -138,6 +138,8 @@ EventsAndTriggers:
 EventsAndDenseTriggers:
 
 EventsRunAtCleanup:
+  ObservationValue: -1000.0
+  Events:
 
 Observers:
   VolumeFileName: "ValenciaDivCleanFishboneMoncriefDiskVolume"

--- a/tests/InputFiles/Poisson/ProductOfSinusoids1D.yaml
+++ b/tests/InputFiles/Poisson/ProductOfSinusoids1D.yaml
@@ -95,4 +95,3 @@ EventsAndTriggers:
           InterpolateToMesh: None
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double]
-          OverrideObservationValue: None

--- a/tests/InputFiles/Poisson/ProductOfSinusoids2D.yaml
+++ b/tests/InputFiles/Poisson/ProductOfSinusoids2D.yaml
@@ -89,4 +89,3 @@ EventsAndTriggers:
           InterpolateToMesh: None
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double]
-          OverrideObservationValue: None

--- a/tests/InputFiles/Poisson/ProductOfSinusoids3D.yaml
+++ b/tests/InputFiles/Poisson/ProductOfSinusoids3D.yaml
@@ -95,4 +95,3 @@ EventsAndTriggers:
           InterpolateToMesh: None
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double]
-          OverrideObservationValue: None

--- a/tests/InputFiles/Punctures/MultiplePunctures.yaml
+++ b/tests/InputFiles/Punctures/MultiplePunctures.yaml
@@ -110,6 +110,5 @@ EventsAndTriggers:
           InterpolateToMesh: None
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double]
-          OverrideObservationValue: None
       - ObserveVolumeIntegrals:
           SubfileName: VolumeIntegrals

--- a/tests/InputFiles/ScalarAdvection/Krivodonova1D.yaml
+++ b/tests/InputFiles/ScalarAdvection/Krivodonova1D.yaml
@@ -79,7 +79,6 @@ EventsAndTriggers:
           InterpolateToMesh: None
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Float, Float]
-          OverrideObservationValue: None
 
 EventsAndDenseTriggers:
 

--- a/tests/InputFiles/ScalarAdvection/Kuzmin2D.yaml
+++ b/tests/InputFiles/ScalarAdvection/Kuzmin2D.yaml
@@ -75,7 +75,6 @@ EventsAndTriggers:
           InterpolateToMesh: None
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Float, Float]
-          OverrideObservationValue: None
 
 EventsAndDenseTriggers:
 

--- a/tests/InputFiles/ScalarAdvection/Sinusoid1D.yaml
+++ b/tests/InputFiles/ScalarAdvection/Sinusoid1D.yaml
@@ -79,7 +79,6 @@ EventsAndTriggers:
           InterpolateToMesh: None
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Float, Float]
-          OverrideObservationValue: None
 
 EventsAndDenseTriggers:
 

--- a/tests/InputFiles/ScalarWave/PlaneWave1DEventsAndTriggersExample.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave1DEventsAndTriggersExample.yaml
@@ -70,7 +70,6 @@ EventsAndTriggers:
           InterpolateToMesh: None
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double]
-          OverrideObservationValue: None
       - ObserveNorms:
           SubfileName: Errors
           TensorsToObserve:

--- a/tests/InputFiles/ScalarWave/PlaneWave1DObserveExample.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave1DObserveExample.yaml
@@ -110,7 +110,6 @@ EventsAndTriggers:
           InterpolateToMesh: None
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double, Float, Float]
-          OverrideObservationValue: None
 # [observe_event_trigger]
 
 Observers:

--- a/tests/InputFiles/Xcts/BinaryBlackHole.yaml
+++ b/tests/InputFiles/Xcts/BinaryBlackHole.yaml
@@ -200,4 +200,3 @@ EventsAndTriggers:
           InterpolateToMesh: None
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double]
-          OverrideObservationValue: None

--- a/tests/InputFiles/Xcts/HeadOnBns.yaml
+++ b/tests/InputFiles/Xcts/HeadOnBns.yaml
@@ -207,4 +207,3 @@ EventsAndTriggers:
           InterpolateToMesh: None
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double]
-          OverrideObservationValue: None

--- a/tests/InputFiles/Xcts/KerrSchild.yaml
+++ b/tests/InputFiles/Xcts/KerrSchild.yaml
@@ -159,4 +159,3 @@ EventsAndTriggers:
           InterpolateToMesh: None
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double]
-          OverrideObservationValue: None

--- a/tests/InputFiles/Xcts/TovStar.yaml
+++ b/tests/InputFiles/Xcts/TovStar.yaml
@@ -146,4 +146,3 @@ EventsAndTriggers:
           InterpolateToMesh: None
           CoordinatesFloatingPointType: Float
           FloatingPointTypes: [Float]
-          OverrideObservationValue: None

--- a/tests/Unit/ControlSystem/Test_RunCallbacks.cpp
+++ b/tests/Unit/ControlSystem/Test_RunCallbacks.cpp
@@ -100,7 +100,7 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.RunCallbacks", "[ControlSystem][Unit]") {
   const MeasureEvent event{};
   CHECK(event.needs_evolved_variables());
   event.run(make_observation_box<db::AddComputeTags<>>(box), cache, 0,
-            element_component_p);
+            element_component_p, {});
 
   ActionTesting::invoke_queued_simple_action<control_system_component>(
       make_not_null(&runner), 0);

--- a/tests/Unit/Evolution/Actions/Test_RunEventsAndDenseTriggers.cpp
+++ b/tests/Unit/Evolution/Actions/Test_RunEventsAndDenseTriggers.cpp
@@ -179,7 +179,8 @@ struct TestEvent : public Event {
   void operator()(const db::DataBox<DbTags>& box,
                   Parallel::GlobalCache<Metavariables>& /*cache*/,
                   const ArrayIndex& /*array_index*/,
-                  const Component* const /*meta*/) const {
+                  const Component* const /*meta*/,
+                  const ObservationValue& /*observation_value*/) const {
     tmpl::as_pack<all_data>([&](auto... tags_v) {
       calls.emplace_back(db::get<tmpl::type_from<decltype(tags_v)>>(box)...);
     });

--- a/tests/Unit/Evolution/EventsAndDenseTriggers/Test_EventsAndDenseTriggers.cpp
+++ b/tests/Unit/Evolution/EventsAndDenseTriggers/Test_EventsAndDenseTriggers.cpp
@@ -76,11 +76,14 @@ class TestEvent : public Event {
                   const double time_plus_two,
                   Parallel::GlobalCache<Metavariables>& /*cache*/,
                   const ArrayIndex& /*array_index*/,
-                  const Component* const /*meta*/) const {
+                  const Component* const /*meta*/,
+                  const ObservationValue& observation_value) const {
     event_ran = true;
     time_during_event = time;
     CHECK(time_plus_two == time + 2.0);
     previous_time_during_event = previous_trigger_time;
+    CHECK(observation_value.name == "Time");
+    CHECK(observation_value.value == time);
   }
 
   struct IsReady : db::SimpleTag {

--- a/tests/Unit/Helpers/ParallelAlgorithms/Events/ObserveFields.hpp
+++ b/tests/Unit/Helpers/ParallelAlgorithms/Events/ObserveFields.hpp
@@ -49,10 +49,6 @@ struct ContributeVolumeData;
 /// \endcond
 
 namespace TestHelpers::dg::Events::ObserveFields {
-struct ObservationTimeTag : db::SimpleTag {
-  using type = double;
-};
-
 struct TestSectionIdTag {};
 
 struct MockContributeVolumeData {
@@ -202,7 +198,7 @@ struct ScalarSystem {
   };
 
   using ObserveEvent = ObservationEvent<
-      volume_dim, ObservationTimeTag,
+      volume_dim,
       tmpl::push_back<all_vars_for_test,
                       Tags::ScalarVarTimesTwoCompute<ScalarVar>,
                       Tags::ScalarVarTimesThree,
@@ -319,7 +315,7 @@ struct ComplicatedSystem {
   };
 
   using ObserveEvent = ObservationEvent<
-      volume_dim, ObservationTimeTag,
+      volume_dim,
       tmpl::push_back<all_vars_for_test,
                       Tags::ScalarVarTimesTwoCompute<ScalarVar>,
                       Tags::ScalarVarTimesThree,

--- a/tests/Unit/Parallel/Test_MemoryMonitor.cpp
+++ b/tests/Unit/Parallel/Test_MemoryMonitor.cpp
@@ -33,10 +33,6 @@
 #include "Utilities/TypeTraits/RemoveReferenceWrapper.hpp"
 
 namespace {
-struct TimeTag {
-  using type = double;
-};
-
 template <typename Metavariables>
 struct MockMemoryMonitor {
   using chare_type = ActionTesting::MockSingletonChare;
@@ -486,7 +482,7 @@ void test_event_construction() {
       ([]() {
         std::vector<std::string> misspelled_component{"GlabolCahce"};
 
-        Events::MonitorMemory<1, TimeTag> event{
+        Events::MonitorMemory<1> event{
             {misspelled_component}, Options::Context{}, metavars{}};
       }()),
       Catch::Contains(
@@ -496,9 +492,9 @@ void test_event_construction() {
       ([]() {
         std::vector<std::string> array_component{"ArrayParallelComponent"};
 
-        Events::MonitorMemory<2, TimeTag> event{{array_component},
-                                                Options::Context{},
-                                                BadArrayChareMetavariables{}};
+        Events::MonitorMemory<2> event{{array_component},
+                                       Options::Context{},
+                                       BadArrayChareMetavariables{}};
       }()),
       Catch::Contains("Currently, the only Array parallel component allowed to "
                       "be monitored is the DgElementArray."));
@@ -533,7 +529,7 @@ void test_monitor_memory_event() {
   });
 
   // Create event
-  Events::MonitorMemory<3, TimeTag> monitor_memory{
+  Events::MonitorMemory<3> monitor_memory{
       {components_to_monitor}, Options::Context{}, metavars{}};
 
   const auto& element =
@@ -542,8 +538,9 @@ void test_monitor_memory_event() {
 
   // Run the event. This will queue a lot of actions
   const double time = 1.4;
-  monitor_memory(time, element, cache, 0,
-                 std::add_pointer_t<dg_elem_comp<event_metavars>>{});
+  monitor_memory(element, cache, 0,
+                 std::add_pointer_t<dg_elem_comp<event_metavars>>{},
+                 {"TimeName", time});
 
   // Check how many simple actions are queued:
   // - MemoryMonitor: 1

--- a/tests/Unit/ParallelAlgorithms/Events/Test_ObserveAdaptiveSteppingDiagnostics.cpp
+++ b/tests/Unit/ParallelAlgorithms/Events/Test_ObserveAdaptiveSteppingDiagnostics.cpp
@@ -183,7 +183,8 @@ void test_observe(const Observer& observer) {
         make_observation_box<db::AddComputeTags<>>(element_boxes[index]),
         ActionTesting::cache<element_component>(runner, index),
         static_cast<element_component::array_index>(index),
-        std::add_pointer_t<element_component>{});
+        std::add_pointer_t<element_component>{},
+        {"TimeName", observation_time});
   }
 
   // Process the data
@@ -201,7 +202,7 @@ void test_observe(const Observer& observer) {
 
   CHECK(results->observation_id.value() == observation_time);
   CHECK(results->subfile_name == "/subfile");
-  CHECK(results->reduction_names[0] == "Time");
+  CHECK(results->reduction_names[0] == "TimeName");
   CHECK(std::get<0>(reduction_data.data()) == observation_time);
   CHECK(results->reduction_names[1] == "Number of slabs");
   CHECK(std::get<1>(reduction_data.data()) == num_slabs);

--- a/tests/Unit/ParallelAlgorithms/EventsAndTriggers/Test_RunEventsOnFailure.cpp
+++ b/tests/Unit/ParallelAlgorithms/EventsAndTriggers/Test_RunEventsOnFailure.cpp
@@ -16,6 +16,7 @@
 #include "ParallelAlgorithms/EventsAndTriggers/Completion.hpp"
 #include "ParallelAlgorithms/EventsAndTriggers/Event.hpp"
 #include "ParallelAlgorithms/EventsAndTriggers/Tags.hpp"
+#include "Time/Tags/Time.hpp"
 #include "Utilities/MakeVector.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/Serialization/RegisterDerivedClassesWithCharm.hpp"
@@ -28,9 +29,10 @@ struct Component {
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = int;
   using const_global_cache_tags =
-      typename Actions::RunEventsOnFailure::const_global_cache_tags;
+      Actions::RunEventsOnFailure<Tags::Time>::const_global_cache_tags;
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
-      Parallel::Phase::Testing, tmpl::list<Actions::RunEventsOnFailure>>>;
+      Parallel::Phase::Testing,
+      tmpl::list<Actions::RunEventsOnFailure<Tags::Time>>>>;
 };
 
 struct Metavariables {

--- a/tests/Unit/ParallelAlgorithms/EventsAndTriggers/Test_RunEventsOnFailure.cpp
+++ b/tests/Unit/ParallelAlgorithms/EventsAndTriggers/Test_RunEventsOnFailure.cpp
@@ -54,7 +54,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.EventsAndTriggers.RunEventsOnFailure",
 
   using my_component = Component<Metavariables>;
   ActionTesting::MockRuntimeSystem<Metavariables> runner{
-      {serialize_and_deserialize(events)}};
+      {serialize_and_deserialize(events), 1234.5}};
   ActionTesting::emplace_component<my_component>(&runner, 0);
   ActionTesting::set_phase(make_not_null(&runner), Parallel::Phase::Testing);
 

--- a/tests/Unit/ParallelAlgorithms/EventsAndTriggers/Test_Tags.cpp
+++ b/tests/Unit/ParallelAlgorithms/EventsAndTriggers/Test_Tags.cpp
@@ -12,4 +12,8 @@ SPECTRE_TEST_CASE("Unit.ParallelAlgorithms.EventsAndTriggers.Tags",
                   "[Unit][ParallelAlgorithms]") {
   TestHelpers::db::test_simple_tag<Tags::EventsAndTriggers>(
       "EventsAndTriggers");
+  TestHelpers::db::test_simple_tag<Tags::EventsRunAtCleanup>(
+      "EventsRunAtCleanup");
+  TestHelpers::db::test_simple_tag<Tags::EventsRunAtCleanupObservationValue>(
+      "EventsRunAtCleanupObservationValue");
 }

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_Interpolate.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_Interpolate.cpp
@@ -311,7 +311,7 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.InterpolateEvent",
   event.run(
       make_observation_box<
           typename metavars::event::compute_tags_for_observation_box>(box),
-      cache, array_index, std::add_pointer_t<elem_component>{});
+      cache, array_index, std::add_pointer_t<elem_component>{}, {});
 
   check_results();
 }

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolateWithoutInterpComponent.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolateWithoutInterpComponent.cpp
@@ -93,7 +93,7 @@ struct initialize_elements_and_queue_simple_actions {
           make_observation_box<
               typename metavars::event::compute_tags_for_observation_box>(box),
           ActionTesting::cache<elem_component>(runner, element_id), element_id,
-          std::add_pointer_t<elem_component>{});
+          std::add_pointer_t<elem_component>{}, {});
     }
   }
 };


### PR DESCRIPTION
This is primarily in preparation for observing on substeps, but generalizing the failure observation handling came almost for free.

There is a preexisting fixup commit to help reviewers.  It will be squashed into the preceding commit before merging.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
The template for the type of observation value as been moved from Events to the actions that run them, so observation events that previously had an `OverrideObservationValue` option no longer do, and such behavior is handled at a higher level.  When used in `EventsAndTriggers` or `EventsAndDenseTriggers`, the behavior is as if `None` had been specified.  When used in `EventsRunAtCleanup`, the value is taken from the new, higher-level `ObservationValue` option.

In addition to removing any `OverrideObservationValue` options, any existing `EventsRunAtCleanup` section of input files should be changed to
```yaml
EventsRunAtCleanup:
  ObservationValue: <value, -1000.0 is used in our examples>
  Events:
    <list of events>
```
This is required even if the list of events is empty.
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
