### PR TITLE
Disable some tests in PY_DEV_MODE

### DIFF
--- a/tests/Unit/IO/H5/Python/CMakeLists.txt
+++ b/tests/Unit/IO/H5/Python/CMakeLists.txt
@@ -1,11 +1,15 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-spectre_add_python_bindings_test(
-  "Unit.IO.H5.Python.DeleteSubfiles"
-  Test_DeleteSubfiles.py
-  "unit;IO;H5;python"
-  PyH5)
+# The HDF5_REPACK_EXECUTABLE is inserted in DeleteSubfiles.py by cmake, so this
+# test doesn't work in PY_DEV_MODE
+if (NOT PY_DEV_MODE)
+  spectre_add_python_bindings_test(
+    "Unit.IO.H5.Python.DeleteSubfiles"
+    Test_DeleteSubfiles.py
+    "unit;IO;H5;python"
+    PyH5)
+endif()
 
 spectre_add_python_bindings_test(
   "Unit.IO.H5.Python.ExtendConnectivity"

--- a/tests/support/Python/CMakeLists.txt
+++ b/tests/support/Python/CMakeLists.txt
@@ -2,12 +2,16 @@
 # See LICENSE.txt for details.
 
 if (BUILD_PYTHON_BINDINGS)
-  add_test(NAME "support.Python.Cli"
-    COMMAND ${CMAKE_BINARY_DIR}/bin/spectre --version)
-  set_tests_properties(
-    "support.Python.Cli" PROPERTIES
-    PASS_REGULAR_EXPRESSION "${SPECTRE_VERSION}"
-    LABELS "python")
+  # The SPECTRE_VERSION is inserted in __init__.py by cmake, so this test
+  # doesn't work in PY_DEV_MODE
+  if (NOT PY_DEV_MODE)
+    add_test(NAME "support.Python.Cli"
+      COMMAND ${CMAKE_BINARY_DIR}/bin/spectre --version)
+    set_tests_properties(
+      "support.Python.Cli" PROPERTIES
+      PASS_REGULAR_EXPRESSION "${SPECTRE_VERSION}"
+      LABELS "python")
+  endif()
 
   add_test(NAME "support.Python.python-spectre"
     COMMAND ${CMAKE_BINARY_DIR}/bin/python-spectre -c


### PR DESCRIPTION
## Proposed changes

In `PY_DEV_MODE` the Python files are symlinked, so CMake doesn't substitute any variables in them.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
