### PR TITLE
Add a tag for masking neutron star interior in ForceFree evolution system

### DIFF
--- a/src/Evolution/Systems/ForceFree/Tags.hpp
+++ b/src/Evolution/Systems/ForceFree/Tags.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <optional>
 #include <string>
 
 #include "DataStructures/DataBox/Tag.hpp"
@@ -115,6 +116,23 @@ struct TildeJ : db::SimpleTag {
 struct LargestCharacteristicSpeed : db::SimpleTag {
   using type = double;
 };
+
+/*!
+ * \brief An optional scalar variable used for masking the interior of neutron
+ * star(s) when running neutron star magnetosphere simulations.
+ *
+ * For elements that contain any grid points inside the NS, we assign the value
+ * +1.0 to the grid points located outside the NS and assign -1.0 if located
+ * inside the NS.
+ *
+ * For elements that do not contain any grid points inside the NS, this tag is
+ * not initialized and has `null` value i.e. `has_value() == false`.
+ *
+ */
+struct NsInteriorMask : db::SimpleTag {
+  using type = std::optional<Scalar<DataVector>>;
+};
+
 }  // namespace Tags
 
 namespace OptionTags {

--- a/tests/Unit/Evolution/Systems/ForceFree/Test_Tags.cpp
+++ b/tests/Unit/Evolution/Systems/ForceFree/Test_Tags.cpp
@@ -29,9 +29,12 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.ForceFree.Tags",
   TestHelpers::db::test_simple_tag<ForceFree::Tags::TildePhi>("TildePhi");
   TestHelpers::db::test_simple_tag<ForceFree::Tags::TildeQ>("TildeQ");
 
-  // etc.
+  // Electric current density & constraint damping
+  TestHelpers::db::test_simple_tag<ForceFree::Tags::TildeJ>("TildeJ");
   TestHelpers::db::test_simple_tag<ForceFree::Tags::ElectricCurrentDensity>(
       "ElectricCurrentDensity");
   TestHelpers::db::test_simple_tag<ForceFree::Tags::KappaPsi>("KappaPsi");
   TestHelpers::db::test_simple_tag<ForceFree::Tags::KappaPhi>("KappaPhi");
+  TestHelpers::db::test_simple_tag<ForceFree::Tags::ParallelConductivity>(
+      "ParallelConductivity");
 }

--- a/tests/Unit/Evolution/Systems/ForceFree/Test_Tags.cpp
+++ b/tests/Unit/Evolution/Systems/ForceFree/Test_Tags.cpp
@@ -37,4 +37,8 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.ForceFree.Tags",
   TestHelpers::db::test_simple_tag<ForceFree::Tags::KappaPhi>("KappaPhi");
   TestHelpers::db::test_simple_tag<ForceFree::Tags::ParallelConductivity>(
       "ParallelConductivity");
+
+  // etc.
+  TestHelpers::db::test_simple_tag<ForceFree::Tags::NsInteriorMask>(
+      "NsInteriorMask");
 }


### PR DESCRIPTION
## Proposed changes

When running neutron star magnetosphere simulations, our plan is to assign this masking variable at the initialization phase to identify grid points located inside the NS surface (e.g. r < 1). In evolution phase, one checks the value of this mask variable and overwrites the electric field to `- v x B` for grid points inside the NS surface.


### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
