### PR TITLE
Add Imex sub-namespace to ForceFree system

### DIFF
--- a/src/Evolution/Systems/ForceFree/CMakeLists.txt
+++ b/src/Evolution/Systems/ForceFree/CMakeLists.txt
@@ -55,4 +55,5 @@ target_link_libraries(
 add_subdirectory(BoundaryConditions)
 add_subdirectory(BoundaryCorrections)
 add_subdirectory(FiniteDifference)
+add_subdirectory(Imex)
 add_subdirectory(Subcell)

--- a/src/Evolution/Systems/ForceFree/Imex/CMakeLists.txt
+++ b/src/Evolution/Systems/ForceFree/Imex/CMakeLists.txt
@@ -1,0 +1,14 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+spectre_target_sources(
+  ${LIBRARY}
+  PRIVATE
+  )
+
+spectre_target_headers(
+  ${LIBRARY}
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  Imex.hpp
+  )

--- a/src/Evolution/Systems/ForceFree/Imex/Imex.hpp
+++ b/src/Evolution/Systems/ForceFree/Imex/Imex.hpp
@@ -1,0 +1,11 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+namespace ForceFree {
+/*!
+ * \brief Code related to IMEX time integration of ForceFree evolution system.
+ */
+namespace Imex {}
+}  // namespace ForceFree


### PR DESCRIPTION
## Proposed changes

Rather than piling up files in the base directory (`Evolution/Systems/ForceFree/`), it'd be good to group IMEX-related files into a subdirectory.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
