### PR TITLE
Add EquatorialCompression to Sphere

### DIFF
--- a/tests/Unit/Domain/Creators/Test_Sphere.cpp
+++ b/tests/Unit/Domain/Creators/Test_Sphere.cpp
@@ -166,11 +166,8 @@ std::string option_string(
          std::to_string(initial_extents[2]) +
          "]\n"
          "  UseEquiangularMap: " +
-         stringize(equiangular) +
-         "\n"
-         "  EquatorialCompression: None\n"
-         "  WhichWedges: " +
-         get_output(which_wedges) +
+         stringize(equiangular) + "\n" + equatorial_compression_option +
+         "  WhichWedges: " + get_output(which_wedges) +
          "\n"
          "  RadialPartitioning: " +
          stringize(radial_partitioning) +
@@ -601,8 +598,12 @@ void test_sphere() {
     const auto& interior = interiors[interior_index];
     const bool fill_interior =
         std::holds_alternative<creators::Sphere::InnerCube>(interior);
+    if (equatorial_compression.has_value() and fill_interior) {
+      continue;
+    }
     CAPTURE(fill_interior);
     CAPTURE(equiangular);
+    CAPTURE(equatorial_compression.has_value());  // Whether map is present.
     CAPTURE(radial_partitioning[array_index]);
     CAPTURE(radial_distribution[array_index]);
     CAPTURE(which_wedges);


### PR DESCRIPTION
## Proposed changes

Restores the EquatorialCompression option in the Sphere domain for excised Spheres.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
