### PR TITLE
Add boundary conditions for ScalarTensor

### DIFF
--- a/src/Evolution/Systems/ScalarTensor/BoundaryConditions/BoundaryCondition.cpp
+++ b/src/Evolution/Systems/ScalarTensor/BoundaryConditions/BoundaryCondition.cpp
@@ -1,0 +1,18 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/ScalarTensor/BoundaryConditions/BoundaryCondition.hpp"
+
+#include <pup.h>
+
+#include "Domain/BoundaryConditions/BoundaryCondition.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+
+namespace ScalarTensor::BoundaryConditions {
+BoundaryCondition::BoundaryCondition(CkMigrateMessage* const msg)
+    : domain::BoundaryConditions::BoundaryCondition(msg) {}
+
+void BoundaryCondition::pup(PUP::er& p) {
+  domain::BoundaryConditions::BoundaryCondition::pup(p);
+}
+}  // namespace ScalarTensor::BoundaryConditions

--- a/src/Evolution/Systems/ScalarTensor/BoundaryConditions/BoundaryCondition.hpp
+++ b/src/Evolution/Systems/ScalarTensor/BoundaryConditions/BoundaryCondition.hpp
@@ -1,0 +1,31 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <pup.h>
+
+#include "Domain/BoundaryConditions/BoundaryCondition.hpp"
+
+namespace ScalarTensor {
+/// \brief Boundary conditions for the combined Generalized Harmonic and
+/// CurvedScalarWave systems
+namespace BoundaryConditions {
+
+/// \brief The base class for Generalized Harmonic and scalar field combined
+/// boundary conditions; all boundary conditions for this system must inherit
+/// from this base class.
+class BoundaryCondition : public domain::BoundaryConditions::BoundaryCondition {
+ public:
+  BoundaryCondition() = default;
+  BoundaryCondition(BoundaryCondition&&) = default;
+  BoundaryCondition& operator=(BoundaryCondition&&) = default;
+  BoundaryCondition(const BoundaryCondition&) = default;
+  BoundaryCondition& operator=(const BoundaryCondition&) = default;
+  ~BoundaryCondition() override = default;
+  explicit BoundaryCondition(CkMigrateMessage* msg);
+
+  void pup(PUP::er& p) override;
+};
+} // namespace BoundaryCondition
+} // namespace ScalarTensor

--- a/src/Evolution/Systems/ScalarTensor/BoundaryConditions/CMakeLists.txt
+++ b/src/Evolution/Systems/ScalarTensor/BoundaryConditions/CMakeLists.txt
@@ -1,0 +1,17 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+spectre_target_sources(
+  ${LIBRARY}
+  PRIVATE
+  BoundaryCondition.cpp
+  )
+
+spectre_target_headers(
+  ${LIBRARY}
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  BoundaryCondition.hpp
+  Factory.hpp
+  ProductOfConditions.hpp
+  )

--- a/src/Evolution/Systems/ScalarTensor/BoundaryConditions/Factory.hpp
+++ b/src/Evolution/Systems/ScalarTensor/BoundaryConditions/Factory.hpp
@@ -1,0 +1,60 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "Domain/BoundaryConditions/Periodic.hpp"
+#include "Evolution/Systems/CurvedScalarWave/BoundaryConditions/AnalyticConstant.hpp"
+#include "Evolution/Systems/CurvedScalarWave/BoundaryConditions/DemandOutgoingCharSpeeds.hpp"
+#include "Evolution/Systems/CurvedScalarWave/BoundaryConditions/Factory.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/BoundaryCondition.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/DemandOutgoingCharSpeeds.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/DirichletAnalytic.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Factory.hpp"
+#include "Evolution/Systems/ScalarTensor/BoundaryConditions/BoundaryCondition.hpp"
+#include "Evolution/Systems/ScalarTensor/BoundaryConditions/ProductOfConditions.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace ScalarTensor::BoundaryConditions {
+
+namespace detail {
+
+// Remove boundary condition products of DemandOutgoingCharSpeeds with
+// other types of boundary conditions
+template <typename DerivedGhCondition, typename DerivedScalarCondition>
+using ProductOfConditionsIfConsistent = tmpl::conditional_t<
+    (DerivedGhCondition::bc_type ==
+     evolution::BoundaryConditions::Type::DemandOutgoingCharSpeeds) xor
+        (DerivedScalarCondition::bc_type ==
+         evolution::BoundaryConditions::Type::DemandOutgoingCharSpeeds),
+    tmpl::list<>,
+    ProductOfConditions<DerivedGhCondition, DerivedScalarCondition>>;
+
+template <typename GhList, typename ScalarList>
+struct AllProductConditions;
+
+template <typename GhList, typename... ScalarConditions>
+struct AllProductConditions<GhList, tmpl::list<ScalarConditions...>> {
+  using type = tmpl::flatten<tmpl::list<tmpl::transform<
+      GhList, tmpl::bind<ProductOfConditionsIfConsistent, tmpl::_1,
+                         tmpl::pin<ScalarConditions>>>...>>;
+};
+
+}  // namespace detail
+
+/// Typelist of standard BoundaryConditions. For now, we only support a subset
+/// of the available boundary conditions
+using subset_standard_boundary_conditions_gh =
+    tmpl::list<gh::BoundaryConditions::DemandOutgoingCharSpeeds<3>,
+               gh::BoundaryConditions::DirichletAnalytic<3>>;
+
+using subset_standard_boundary_conditions_scalar = tmpl::list<
+    CurvedScalarWave::BoundaryConditions::AnalyticConstant<3>,
+    CurvedScalarWave::BoundaryConditions::DemandOutgoingCharSpeeds<3>>;
+using standard_boundary_conditions =
+    tmpl::push_back<typename detail::AllProductConditions<
+                        subset_standard_boundary_conditions_gh,
+                        subset_standard_boundary_conditions_scalar>::type,
+                    domain::BoundaryConditions::Periodic<BoundaryCondition>>;
+
+}  // namespace ScalarTensor::BoundaryConditions

--- a/src/Evolution/Systems/ScalarTensor/BoundaryConditions/ProductOfConditions.hpp
+++ b/src/Evolution/Systems/ScalarTensor/BoundaryConditions/ProductOfConditions.hpp
@@ -1,0 +1,373 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <memory>
+#include <optional>
+#include <pup.h>
+#include <string>
+#include <utility>
+
+#include "DataStructures/DataBox/PrefixHelpers.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Evolution/BoundaryConditions/Type.hpp"
+#include "Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivativeHelpers.hpp"
+#include "Evolution/Systems/CurvedScalarWave/BoundaryConditions/Factory.hpp"
+#include "Evolution/Systems/CurvedScalarWave/System.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Factory.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/System.hpp"
+#include "Evolution/Systems/ScalarTensor/BoundaryConditions/BoundaryCondition.hpp"
+#include "Evolution/Systems/ScalarTensor/Tags.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Formulation.hpp"
+#include "Options/String.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Lapse.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Shift.hpp"
+#include "PointwiseFunctions/GeneralRelativity/SpatialMetric.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Serialization/CharmPupable.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace ScalarTensor::BoundaryConditions {
+namespace detail {
+
+template <evolution::BoundaryConditions::Type GhBcType,
+          evolution::BoundaryConditions::Type ScalarBcType>
+struct UnionOfBcTypes {
+  static_assert(
+      (GhBcType == evolution::BoundaryConditions::Type::TimeDerivative) or
+          (ScalarBcType ==
+           evolution::BoundaryConditions::Type::TimeDerivative) or
+          (GhBcType ==
+           evolution::BoundaryConditions::Type::GhostAndTimeDerivative) or
+          (ScalarBcType ==
+           evolution::BoundaryConditions::Type::GhostAndTimeDerivative),
+      "TimeDerivative boundary conditions are not yet supported.");
+  static constexpr evolution::BoundaryConditions::Type bc_type =
+      evolution::BoundaryConditions::Type::Ghost;
+};
+
+template <>
+struct UnionOfBcTypes<evolution::BoundaryConditions::Type::Ghost,
+                      evolution::BoundaryConditions::Type::Ghost> {
+  static constexpr evolution::BoundaryConditions::Type bc_type =
+      evolution::BoundaryConditions::Type::Ghost;
+};
+
+template <evolution::BoundaryConditions::Type GhBcType>
+struct UnionOfBcTypes<
+    GhBcType, evolution::BoundaryConditions::Type::DemandOutgoingCharSpeeds> {
+  static_assert(
+      GhBcType == evolution::BoundaryConditions::Type::DemandOutgoingCharSpeeds,
+      "If either boundary condition in `ProductOfConditions` has "
+      "`Type::DemandOutgoingCharSpeeds`, both must have "
+      "`Type::DemandOutgoingCharSpeeds`");
+};
+
+template <evolution::BoundaryConditions::Type ScalarBcType>
+struct UnionOfBcTypes<
+    evolution::BoundaryConditions::Type::DemandOutgoingCharSpeeds,
+    ScalarBcType> {
+  static_assert(
+      ScalarBcType ==
+          evolution::BoundaryConditions::Type::DemandOutgoingCharSpeeds,
+      "If either boundary condition in `ProductOfConditions` has "
+      "`Type::DemandOutgoingCharSpeeds`, both must have "
+      "`Type::DemandOutgoingCharSpeeds`");
+};
+
+template <>
+struct UnionOfBcTypes<
+    evolution::BoundaryConditions::Type::DemandOutgoingCharSpeeds,
+    evolution::BoundaryConditions::Type::DemandOutgoingCharSpeeds> {
+  static constexpr evolution::BoundaryConditions::Type bc_type =
+      evolution::BoundaryConditions::Type::DemandOutgoingCharSpeeds;
+};
+
+}  // namespace detail
+
+/*!
+ * \brief Apply a boundary condition to the combined Generalized Harmonic (GH)
+ * and CurvedScalarWave (CSW) system using the boundary conditions defined
+ * separately for the GH and CSW systems.
+ */
+template <typename DerivedGhCondition, typename DerivedScalarCondition>
+class ProductOfConditions final : public BoundaryCondition {
+ public:
+  static constexpr size_t dim = 3;
+  static constexpr evolution::BoundaryConditions::Type bc_type =
+      detail::UnionOfBcTypes<DerivedGhCondition::bc_type,
+                             DerivedScalarCondition::bc_type>::bc_type;
+
+  using dg_interior_evolved_variables_tags =
+      tmpl::remove_duplicates<tmpl::append<
+          typename DerivedGhCondition::dg_interior_evolved_variables_tags,
+          typename DerivedScalarCondition::dg_interior_evolved_variables_tags>>;
+
+  using dg_interior_temporary_tags = tmpl::remove_duplicates<tmpl::append<
+      typename DerivedGhCondition::dg_interior_temporary_tags,
+      typename DerivedScalarCondition::dg_interior_temporary_tags>>;
+
+  using dg_gridless_tags = tmpl::remove_duplicates<
+      tmpl::append<typename DerivedGhCondition::dg_gridless_tags,
+                   typename DerivedScalarCondition::dg_gridless_tags>>;
+
+  using dg_interior_dt_vars_tags = tmpl::append<
+      evolution::dg::Actions::detail::get_dt_vars_from_boundary_condition<
+          DerivedGhCondition>,
+      evolution::dg::Actions::detail::get_dt_vars_from_boundary_condition<
+          DerivedScalarCondition>>;
+
+  using dg_interior_deriv_vars_tags = tmpl::append<
+      evolution::dg::Actions::detail::get_deriv_vars_from_boundary_condition<
+          DerivedGhCondition>,
+      evolution::dg::Actions::detail::get_deriv_vars_from_boundary_condition<
+          DerivedScalarCondition>>;
+
+  static std::string name() {
+    return "Product" + pretty_type::name<DerivedGhCondition>() + "And" +
+           pretty_type::name<DerivedScalarCondition>();
+  }
+
+  struct GhCondition {
+    using type = DerivedGhCondition;
+    static std::string name() {
+      return "GeneralizedHarmonic" + pretty_type::name<DerivedGhCondition>();
+    }
+    static constexpr Options::String help{
+        "The Generalized Harmonic part of the product boundary condition"};
+  };
+
+  struct ScalarCondition {
+    using type = DerivedScalarCondition;
+    static std::string name() {
+      return "Scalar" + pretty_type::name<DerivedScalarCondition>();
+    }
+    static constexpr Options::String help{
+        "The Scalar part of the product boundary condition"};
+  };
+
+  using options = tmpl::list<GhCondition, ScalarCondition>;
+
+  static constexpr Options::String help = {
+      "Direct product of a GH and CurvedScalarWave boundary conditions. "
+      "See the documentation for the two individual boundary conditions for "
+      "further details."};
+
+  ProductOfConditions() = default;
+  ProductOfConditions(DerivedGhCondition gh_condition,
+                      DerivedScalarCondition scalar_condition)
+      : derived_gh_condition_{gh_condition},
+        derived_scalar_condition_{scalar_condition} {}
+  ProductOfConditions(const ProductOfConditions&) = default;
+  ProductOfConditions& operator=(const ProductOfConditions&) = default;
+  ProductOfConditions(ProductOfConditions&&) = default;
+  ProductOfConditions& operator=(ProductOfConditions&&) = default;
+  ~ProductOfConditions() override = default;
+
+  /// \cond
+  explicit ProductOfConditions(CkMigrateMessage* msg)
+      : BoundaryCondition(msg) {}
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_base_template(
+      domain::BoundaryConditions::BoundaryCondition, ProductOfConditions);
+  /// \endcond
+
+  void pup(PUP::er& p) override;
+
+  auto get_clone() const -> std::unique_ptr<
+      domain::BoundaryConditions::BoundaryCondition> override;
+
+  std::optional<std::string> dg_demand_outgoing_char_speeds(
+      // GH arguments
+      const std::optional<tnsr::I<DataVector, dim, Frame::Inertial>>&
+          face_mesh_velocity,
+      const tnsr::i<DataVector, dim, Frame::Inertial>&
+          outward_directed_normal_covector,
+      const tnsr::I<DataVector, dim, Frame::Inertial>&
+          outward_directed_normal_vector,
+      const Scalar<DataVector>& gamma_1, const Scalar<DataVector>& lapse,
+      const tnsr::I<DataVector, dim, Frame::Inertial>& shift,
+      // Scalar arguments
+      const Scalar<DataVector>& gamma1_scalar) const {
+    // DemandOutgoingCharSpeeds condition is only valid if both boundary
+    // conditions are DemandOutgoingCharSpeeds, so we directly apply both. A
+    // static_assert elsewhere is triggered if only one boundary condition is
+    // DemandOutgoingCharSpeeds.
+    auto gh_string = derived_gh_condition_.dg_demand_outgoing_char_speeds(
+        face_mesh_velocity, outward_directed_normal_covector,
+        outward_directed_normal_vector, gamma_1, lapse, shift);
+
+    auto scalar_string =
+        derived_scalar_condition_.dg_demand_outgoing_char_speeds(
+            face_mesh_velocity, outward_directed_normal_covector,
+            outward_directed_normal_vector, gamma1_scalar, lapse, shift);
+
+    if (not gh_string.has_value()) {
+      return scalar_string;
+    }
+    if (not scalar_string.has_value()) {
+      return gh_string;
+    }
+    return gh_string.value() + ";" + scalar_string.value();
+  }
+
+  // We overload dg_ghost for the different analytic boundary conditions
+
+  // Boundary conditions for DirichletAnalytic and AnalyticConstant
+  std::optional<std::string> dg_ghost(
+      // GH evolved variables
+      const gsl::not_null<tnsr::aa<DataVector, dim, Frame::Inertial>*>
+          spacetime_metric,
+      const gsl::not_null<tnsr::aa<DataVector, dim, Frame::Inertial>*> pi,
+      const gsl::not_null<tnsr::iaa<DataVector, dim, Frame::Inertial>*> phi,
+      // Scalar evolved variables
+      const gsl::not_null<Scalar<DataVector>*> psi_scalar,
+      const gsl::not_null<Scalar<DataVector>*> pi_scalar,
+      const gsl::not_null<tnsr::i<DataVector, dim, Frame::Inertial>*>
+          phi_scalar,
+      // GH temporary variables
+      const gsl::not_null<Scalar<DataVector>*> gamma1,
+      const gsl::not_null<Scalar<DataVector>*> gamma2,
+      const gsl::not_null<Scalar<DataVector>*> lapse,
+      const gsl::not_null<tnsr::I<DataVector, dim, Frame::Inertial>*> shift,
+      // Scalar temporary variables
+      const gsl::not_null<Scalar<DataVector>*> gamma1_scalar,
+      const gsl::not_null<Scalar<DataVector>*> gamma2_scalar,
+      // Inverse metric
+      const gsl::not_null<tnsr::II<DataVector, dim, Frame::Inertial>*>
+          inv_spatial_metric,
+      // Mesh variables
+      const std::optional<tnsr::I<DataVector, dim, Frame::Inertial>>&
+          face_mesh_velocity,
+      const tnsr::i<DataVector, dim, Frame::Inertial>& normal_covector,
+      const tnsr::I<DataVector, dim, Frame::Inertial>& normal_vector,
+      // GH interior variables
+      const tnsr::I<DataVector, dim, Frame::Inertial>& coords,
+      const Scalar<DataVector>& interior_gamma1,
+      const Scalar<DataVector>& interior_gamma2,
+      // Scalar interior variables
+      const tnsr::II<DataVector, dim, Frame::Inertial>&
+          inverse_spatial_metric_interior,
+      const Scalar<DataVector>& gamma1_interior_scalar,
+      const Scalar<DataVector>& gamma2_interior_scalar,
+      const Scalar<DataVector>& lapse_interior,
+      const tnsr::I<DataVector, dim>& shift_interior, const double time) const {
+    // For gh::BoundaryConditions::DirichletAnalytic
+    auto gh_string = derived_gh_condition_.dg_ghost(
+        spacetime_metric, pi, phi, gamma1, gamma2, lapse, shift,
+        inv_spatial_metric, face_mesh_velocity, normal_covector, normal_vector,
+        coords, interior_gamma1, interior_gamma2, time);
+
+    // For CurvedScalarWave::BoundaryConditions::AnalyticConstant
+    auto scalar_string = derived_scalar_condition_.dg_ghost(
+        psi_scalar, pi_scalar, phi_scalar, lapse, shift, gamma1_scalar,
+        gamma2_scalar, inv_spatial_metric, face_mesh_velocity, normal_covector,
+        normal_vector, inverse_spatial_metric_interior, gamma1_interior_scalar,
+        gamma2_interior_scalar, lapse_interior, shift_interior);
+
+    if (not gh_string.has_value()) {
+      return scalar_string;
+    }
+    if (not scalar_string.has_value()) {
+      return gh_string;
+    }
+    return gh_string.value() + ";" + scalar_string.value();
+  }
+
+  // Boundary conditions for DirichletMinkowski and AnalyticConstant
+  std::optional<std::string> dg_ghost(
+      // GH evolved variables
+      const gsl::not_null<tnsr::aa<DataVector, dim, Frame::Inertial>*>
+          spacetime_metric,
+      const gsl::not_null<tnsr::aa<DataVector, dim, Frame::Inertial>*> pi,
+      const gsl::not_null<tnsr::iaa<DataVector, dim, Frame::Inertial>*> phi,
+      // Scalar evolved variables
+      const gsl::not_null<Scalar<DataVector>*> psi_scalar,
+      const gsl::not_null<Scalar<DataVector>*> pi_scalar,
+      const gsl::not_null<tnsr::i<DataVector, dim, Frame::Inertial>*>
+          phi_scalar,
+      // GH temporary variables
+      const gsl::not_null<Scalar<DataVector>*> gamma1,
+      const gsl::not_null<Scalar<DataVector>*> gamma2,
+      const gsl::not_null<Scalar<DataVector>*> lapse,
+      const gsl::not_null<tnsr::I<DataVector, dim, Frame::Inertial>*> shift,
+      // Scalar temporary variables
+      const gsl::not_null<Scalar<DataVector>*> gamma1_scalar,
+      const gsl::not_null<Scalar<DataVector>*> gamma2_scalar,
+      // Inverse metric
+      const gsl::not_null<tnsr::II<DataVector, dim, Frame::Inertial>*>
+          inv_spatial_metric,
+      // Mesh variables
+      const std::optional<tnsr::I<DataVector, dim, Frame::Inertial>>&
+          face_mesh_velocity,
+      const tnsr::i<DataVector, dim, Frame::Inertial>& normal_covector,
+      const tnsr::I<DataVector, dim, Frame::Inertial>& normal_vector,
+      // GH interior variables
+      const Scalar<DataVector>& interior_gamma1,
+      const Scalar<DataVector>& interior_gamma2,
+      // Scalar interior variables
+      const tnsr::II<DataVector, dim, Frame::Inertial>&
+          inverse_spatial_metric_interior,
+      const Scalar<DataVector>& gamma1_interior_scalar,
+      const Scalar<DataVector>& gamma2_interior_scalar,
+      const Scalar<DataVector>& lapse_interior,
+      const tnsr::I<DataVector, dim>& shift_interior) const {
+    // For gh::BoundaryConditions::DirichletMinkowski
+    auto gh_string = derived_gh_condition_.dg_ghost(
+        spacetime_metric, pi, phi, gamma1, gamma2, lapse, shift,
+        inv_spatial_metric, face_mesh_velocity, normal_covector, normal_vector,
+        interior_gamma1, interior_gamma2);
+
+    // For CurvedScalarWave::BoundaryConditions::AnalyticConstant
+    auto scalar_string = derived_scalar_condition_.dg_ghost(
+        psi_scalar, pi_scalar, phi_scalar, lapse, shift, gamma1_scalar,
+        gamma2_scalar, inv_spatial_metric, face_mesh_velocity, normal_covector,
+        normal_vector, inverse_spatial_metric_interior, gamma1_interior_scalar,
+        gamma2_interior_scalar, lapse_interior, shift_interior);
+
+    if (not gh_string.has_value()) {
+      return scalar_string;
+    }
+    if (not scalar_string.has_value()) {
+      return gh_string;
+    }
+    return gh_string.value() + ";" + scalar_string.value();
+  }
+
+ private:
+  DerivedGhCondition derived_gh_condition_;
+  DerivedScalarCondition derived_scalar_condition_;
+};
+
+template <typename DerivedGhCondition, typename DerivedScalarCondition>
+void ProductOfConditions<DerivedGhCondition, DerivedScalarCondition>::pup(
+    PUP::er& p) {
+  BoundaryCondition::pup(p);
+  p | derived_gh_condition_;
+  p | derived_scalar_condition_;
+}
+
+template <typename DerivedGhCondition, typename DerivedScalarCondition>
+auto ProductOfConditions<DerivedGhCondition,
+                         DerivedScalarCondition>::get_clone() const
+    -> std::unique_ptr<domain::BoundaryConditions::BoundaryCondition> {
+  return std::make_unique<ProductOfConditions>(*this);
+}
+
+/// \cond
+template <typename DerivedGhCondition, typename DerivedScalarCondition>
+PUP::able::PUP_ID ProductOfConditions<DerivedGhCondition,
+                                      DerivedScalarCondition>::my_PUP_ID =
+    0;  // NOLINT
+/// \endcond
+
+template <typename DerivedGhCondition, typename DerivedScalarCondition>
+ProductOfConditions(DerivedGhCondition gh_condition,
+                    DerivedScalarCondition scalar_condition)
+    -> ProductOfConditions<DerivedGhCondition, DerivedScalarCondition>;
+
+}  // namespace ScalarTensor::BoundaryConditions

--- a/src/Evolution/Systems/ScalarTensor/CMakeLists.txt
+++ b/src/Evolution/Systems/ScalarTensor/CMakeLists.txt
@@ -40,4 +40,5 @@ target_link_libraries(
   Parallel
   )
 
+add_subdirectory(BoundaryConditions)
 add_subdirectory(Sources)

--- a/tests/Unit/Evolution/Systems/ScalarTensor/BoundaryConditions/Test_ProductOfConditions.cpp
+++ b/tests/Unit/Evolution/Systems/ScalarTensor/BoundaryConditions/Test_ProductOfConditions.cpp
@@ -1,0 +1,379 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <optional>
+#include <string>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/TagsTimeDependent.hpp"
+#include "Evolution/DiscontinuousGalerkin/Actions/NormalCovectorAndMagnitude.hpp"
+#include "Evolution/DiscontinuousGalerkin/NormalVectorTags.hpp"
+#include "Evolution/Systems/CurvedScalarWave/BoundaryConditions/Factory.hpp"
+#include "Evolution/Systems/CurvedScalarWave/BoundaryCorrections/Factory.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Factory.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/BoundaryCorrections/Factory.hpp"
+#include "Evolution/Systems/ScalarTensor/BoundaryConditions/BoundaryCondition.hpp"
+#include "Evolution/Systems/ScalarTensor/BoundaryConditions/ProductOfConditions.hpp"
+#include "Evolution/Systems/ScalarTensor/System.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Formulation.hpp"
+#include "Options/Protocols/FactoryCreation.hpp"
+#include "PointwiseFunctions/AnalyticData/ScalarTensor/KerrSphericalHarmonic.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/WrappedGr.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
+#include "Time/Tags/Time.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace {
+struct DummyAnalyticSolutionTag : db::SimpleTag, Tags::AnalyticSolutionOrData {
+  using type = gh::Solutions::WrappedGr<
+      ScalarTensor::AnalyticData::KerrSphericalHarmonic>;
+};
+
+struct Metavariables {
+  struct factory_creation
+      : tt::ConformsTo<Options::protocols::FactoryCreation> {
+    using factory_classes = tmpl::map<
+        tmpl::pair<
+            ScalarTensor::BoundaryConditions::BoundaryCondition,
+            tmpl::list<ScalarTensor::BoundaryConditions::ProductOfConditions<
+                gh::BoundaryConditions::DirichletAnalytic<3_st>,
+                CurvedScalarWave::BoundaryConditions::AnalyticConstant<3_st>>>>,
+        tmpl::pair<evolution::initial_data::InitialData,
+                   tmpl::list<gh::Solutions::WrappedGr<
+                       ScalarTensor::AnalyticData::KerrSphericalHarmonic>>>>;
+  };
+};
+
+template <typename DerivedCondition, typename EvolvedTagList,
+          typename MutatedTagList, typename ArgumentTagList,
+          typename GridlessTagList>
+struct ComputeBoundaryConditionHelper;
+
+template <typename DerivedCondition, typename... EvolvedTags,
+          typename... MutatedTags, typename... ArgumentTags,
+          typename... GridlessTags>
+struct ComputeBoundaryConditionHelper<
+    DerivedCondition, tmpl::list<EvolvedTags...>, tmpl::list<MutatedTags...>,
+    tmpl::list<ArgumentTags...>, tmpl::list<GridlessTags...>> {
+  template <typename MutatedVariables, typename ArgumentVariables,
+            typename GridlessBox>
+  static std::optional<std::string> dg_ghost(
+      const gsl::not_null<MutatedVariables*> mutated_variables,
+      const ArgumentVariables& argument_variables,
+      const GridlessBox& gridless_box,
+      const DerivedCondition& derived_condition) {
+    return derived_condition.dg_ghost(
+        make_not_null(&get<MutatedTags>(*mutated_variables))...,
+        tuples::get<ArgumentTags>(argument_variables)...,
+        db::get<GridlessTags>(gridless_box)...);
+  }
+
+  template <typename ArgumentVariables, typename GridlessBox>
+  static std::optional<std::string> dg_demand_outgoing_char_speeds(
+      const ArgumentVariables& argument_variables,
+      const GridlessBox& gridless_box,
+      const DerivedCondition& derived_condition) {
+    return derived_condition.dg_demand_outgoing_char_speeds(
+        tuples::get<ArgumentTags>(argument_variables)...,
+        db::get<GridlessTags>(gridless_box)...);
+  }
+};
+
+template <typename GhCorrectionTempTagList,
+          typename ScalarCorrectionTempTagList, typename DerivedGhCondition,
+          typename DerivedScalarCondition, typename GridlessBox>
+void test_boundary_condition_combination(
+    const DerivedGhCondition& derived_gh_condition,
+    const DerivedScalarCondition& derived_scalar_condition,
+    const ScalarTensor::BoundaryConditions::ProductOfConditions<
+        DerivedGhCondition, DerivedScalarCondition>& derived_product_condition,
+    const GridlessBox& gridless_box) {
+  using product_condition_type =
+      ScalarTensor::BoundaryConditions::ProductOfConditions<
+          DerivedGhCondition, DerivedScalarCondition>;
+
+  using gh_mutable_tags = tmpl::append<
+      typename gh::System<3_st>::variables_tag::tags_list,
+      db::wrap_tags_in<::Tags::Flux, typename gh::System<3_st>::flux_variables,
+                       tmpl::size_t<3_st>, Frame::Inertial>,
+      GhCorrectionTempTagList,
+      tmpl::list<gr::Tags::InverseSpatialMetric<DataVector, 3_st>>>;
+  using scalar_mutable_tags = tmpl::append<
+      typename CurvedScalarWave::System<3_st>::variables_tag::tags_list,
+      db::wrap_tags_in<::Tags::Flux,
+                       typename CurvedScalarWave::System<3_st>::flux_variables,
+                       tmpl::size_t<3_st>, Frame::Inertial>,
+      ScalarCorrectionTempTagList,
+      tmpl::list<gr::Tags::InverseSpatialMetric<DataVector, 3_st>>>;
+  using product_mutable_tags = tmpl::append<
+      typename gh::System<3_st>::variables_tag::tags_list,
+      typename CurvedScalarWave::System<3_st>::variables_tag::tags_list,
+      db::wrap_tags_in<::Tags::Flux, typename gh::System<3_st>::flux_variables,
+                       tmpl::size_t<3_st>, Frame::Inertial>,
+      db::wrap_tags_in<::Tags::Flux,
+                       typename CurvedScalarWave::System<3_st>::flux_variables,
+                       tmpl::size_t<3_st>, Frame::Inertial>,
+      tmpl::remove_duplicates<
+          tmpl::append<GhCorrectionTempTagList, ScalarCorrectionTempTagList>>,
+      tmpl::list<gr::Tags::InverseSpatialMetric<DataVector, 3_st>>>;
+
+  using gh_arg_tags = tmpl::append<
+      tmpl::list<::domain::Tags::MeshVelocity<3_st>,
+                 evolution::dg::Tags::NormalCovector<3_st>,
+                 evolution::dg::Actions::detail::NormalVector<3_st>>,
+      typename DerivedGhCondition::dg_interior_evolved_variables_tags,
+      tmpl::list<>, typename DerivedGhCondition::dg_interior_temporary_tags,
+      evolution::dg::Actions::detail::get_dt_vars_from_boundary_condition<
+          DerivedGhCondition>,
+      evolution::dg::Actions::detail::get_deriv_vars_from_boundary_condition<
+          DerivedGhCondition>>;
+  using scalar_arg_tags = tmpl::append<
+      tmpl::list<::domain::Tags::MeshVelocity<3_st>,
+                 evolution::dg::Tags::NormalCovector<3_st>,
+                 evolution::dg::Actions::detail::NormalVector<3_st>>,
+      typename DerivedScalarCondition::dg_interior_evolved_variables_tags,
+      typename DerivedScalarCondition::dg_interior_temporary_tags,
+      evolution::dg::Actions::detail::get_dt_vars_from_boundary_condition<
+          DerivedScalarCondition>,
+      evolution::dg::Actions::detail::get_deriv_vars_from_boundary_condition<
+          DerivedScalarCondition>>;
+  using product_arg_tags = tmpl::append<
+      tmpl::list<::domain::Tags::MeshVelocity<3_st>,
+                 evolution::dg::Tags::NormalCovector<3_st>,
+                 evolution::dg::Actions::detail::NormalVector<3_st>>,
+      typename product_condition_type::dg_interior_evolved_variables_tags,
+      typename product_condition_type::dg_interior_temporary_tags,
+      typename product_condition_type::dg_interior_dt_vars_tags,
+      typename product_condition_type::dg_interior_deriv_vars_tags>;
+
+  using gh_gridless_tags = typename DerivedGhCondition::dg_gridless_tags;
+  using scalar_gridless_tags =
+      typename DerivedScalarCondition::dg_gridless_tags;
+  using product_gridless_tags =
+      typename product_condition_type::dg_gridless_tags;
+
+  const size_t element_size = 10_st;
+  MAKE_GENERATOR(gen);
+  std::uniform_real_distribution<> dist(0.1, 1.0);
+  std::uniform_int_distribution<int> optional_dist(0, 1);
+
+  auto mutable_variables =
+      make_with_random_values<Variables<product_mutable_tags>>(
+          make_not_null(&gen), make_not_null(&dist), element_size);
+  auto expected_mutable_variables =
+      make_with_random_values<Variables<product_mutable_tags>>(
+          make_not_null(&gen), make_not_null(&dist), element_size);
+  tuples::tagged_tuple_from_typelist<product_arg_tags> argument_variables;
+  tmpl::for_each<product_arg_tags>([&dist, &optional_dist, &gen, &element_size,
+                                    &argument_variables](auto tag_v) {
+    using tag = typename decltype(tag_v)::type;
+    if constexpr (tt::is_a_v<std::optional, typename tag::type>) {
+      if (optional_dist(gen) == 1) {
+        tuples::get<tag>(argument_variables) =
+            make_with_random_values<typename tag::type::value_type>(
+                make_not_null(&gen), make_not_null(&dist), element_size);
+      } else {
+        tuples::get<tag>(argument_variables) = std::nullopt;
+      }
+    } else {
+      tuples::get<tag>(argument_variables) =
+          make_with_random_values<typename tag::type>(
+              make_not_null(&gen), make_not_null(&dist), element_size);
+    }
+  });
+  if constexpr (tmpl::list_contains_v<
+                    product_arg_tags,
+                    gr::Tags::SpacetimeMetric<DataVector, 3_st>>) {
+    get<0, 0>(tuples::get<gr::Tags::SpacetimeMetric<DataVector, 3_st>>(
+        argument_variables)) += -2.0;
+    for (size_t i = 0; i < 3; ++i) {
+      tuples::get<gr::Tags::SpacetimeMetric<DataVector, 3_st>>(
+          argument_variables)
+          .get(i + 1, 0) *= 0.01;
+    }
+  }
+
+  using gh_bc_helper = ComputeBoundaryConditionHelper<
+      DerivedGhCondition, typename gh::System<3_st>::variables_tag::tags_list,
+      gh_mutable_tags, gh_arg_tags, gh_gridless_tags>;
+  using scalar_bc_helper = ComputeBoundaryConditionHelper<
+      DerivedScalarCondition,
+      typename CurvedScalarWave::System<3_st>::variables_tag::tags_list,
+      scalar_mutable_tags, scalar_arg_tags, scalar_gridless_tags>;
+  using product_bc_helper = ComputeBoundaryConditionHelper<
+      product_condition_type,
+      tmpl::append<
+          typename gh::System<3_st>::variables_tag::tags_list,
+          typename CurvedScalarWave::System<3_st>::variables_tag::tags_list>,
+      product_mutable_tags, product_arg_tags, product_gridless_tags>;
+
+  static constexpr evolution::BoundaryConditions::Type bc_type =
+      product_condition_type::bc_type;
+
+  if constexpr (bc_type ==
+                evolution::BoundaryConditions::Type::DemandOutgoingCharSpeeds) {
+    auto gh_result = gh_bc_helper::dg_demand_outgoing_char_speeds(
+        argument_variables, gridless_box, derived_gh_condition);
+    auto scalar_result = scalar_bc_helper::dg_demand_outgoing_char_speeds(
+        argument_variables, gridless_box, derived_scalar_condition);
+    auto product_result = product_bc_helper::dg_demand_outgoing_char_speeds(
+        argument_variables, gridless_box, derived_product_condition);
+    if (gh_result.has_value()) {
+      if (scalar_result.has_value()) {
+        CHECK((product_result.value() ==
+               gh_result.value() + ";" + scalar_result.value()));
+      } else {
+        CHECK(product_result == gh_result);
+      }
+    } else {
+      CHECK(product_result == scalar_result);
+    }
+    return;
+  }
+  std::optional<std::string> gh_result_ghost;
+  std::optional<std::string> scalar_result_ghost;
+  std::optional<std::string> product_result_ghost;
+
+  std::optional<std::string> gh_result_time_derivative;
+  std::optional<std::string> scalar_result_time_derivative;
+  std::optional<std::string> product_result_time_derivative;
+
+  if constexpr (DerivedGhCondition::bc_type ==
+                evolution::BoundaryConditions::Type::Ghost) {
+    gh_result_ghost = gh_bc_helper::dg_ghost(
+        make_not_null(&expected_mutable_variables), argument_variables,
+        gridless_box, derived_gh_condition);
+  }
+
+  if constexpr (DerivedScalarCondition::bc_type ==
+                evolution::BoundaryConditions::Type::Ghost) {
+    scalar_result_ghost = scalar_bc_helper::dg_ghost(
+        make_not_null(&expected_mutable_variables), argument_variables,
+        gridless_box, derived_scalar_condition);
+  }
+
+  if constexpr (bc_type == evolution::BoundaryConditions::Type::Ghost) {
+    product_result_ghost = product_bc_helper::dg_ghost(
+        make_not_null(&mutable_variables), argument_variables, gridless_box,
+        derived_product_condition);
+  }
+
+  if (gh_result_ghost.has_value()) {
+    if (scalar_result_ghost.has_value()) {
+      CHECK((product_result_ghost.value() ==
+             gh_result_ghost.value() + ";" + scalar_result_ghost.value()));
+    } else {
+      CHECK(product_result_ghost == gh_result_ghost);
+    }
+  } else {
+    CHECK(product_result_ghost == scalar_result_ghost);
+  }
+
+  CHECK_VARIABLES_APPROX(mutable_variables, expected_mutable_variables);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE(
+   "Unit.Evolution.Systems.ScalarTensor.BoundaryConditions.ProductOfConditions",
+   "[Unit][Evolution]") {
+  register_factory_classes_with_charm<Metavariables>();
+  // scoped to separate out each product combination
+  {
+    INFO(
+        "Product condition of DirichletAnalytic for Generalized Harmonic and "
+        "AnalyticConstant for CurvedScalarWave.");
+
+    const gh::BoundaryConditions::DirichletAnalytic<3_st> gh_condition{
+        std::unique_ptr<evolution::initial_data::InitialData>(
+            std::make_unique<gh::Solutions::WrappedGr<
+                ScalarTensor::AnalyticData::KerrSphericalHarmonic>>(
+                // Black Hole parameters
+                1.5, std::array<double, 3>{{0.1, -0.2, 0.3}},
+                // Scalar wave parameters
+                2.3, 1.7, 2.9, std::pair<size_t, int>{1, 0}))};
+    // Note: We test for non-zero amplitude of the scalar at the boundary for
+    // robustness, however, this test initial data asymptotes to zero.
+    const CurvedScalarWave::BoundaryConditions::AnalyticConstant<3_st>
+        scalar_condition{// Amplitude
+                         1.1};
+    const auto product_boundary_condition = TestHelpers::test_creation<
+        std::unique_ptr<ScalarTensor::BoundaryConditions::BoundaryCondition>,
+        Metavariables>(
+        "ProductDirichletAnalyticAndAnalyticConstant:\n"
+        "  GeneralizedHarmonicDirichletAnalytic:\n"
+        "    AnalyticPrescription:\n"
+        "      KerrSphericalHarmonic:\n"
+        "        Mass: 1.5\n"
+        "        Spin: [0.1, -0.2, 0.3]\n"
+        "        Amplitude: 2.3\n"
+        "        Radius: 1.7\n"
+        "        Width: 2.9\n"
+        "        Mode: [1, 0]\n"
+        "  ScalarAnalyticConstant:\n"
+        "    Amplitude: 1.1\n");
+    const auto gridless_box =
+        db::create<db::AddSimpleTags<::Tags::Time, DummyAnalyticSolutionTag>>(
+            0.5, gh::Solutions::WrappedGr<
+                     ScalarTensor::AnalyticData::KerrSphericalHarmonic>{
+                     // Black Hole parameters
+                     1.5, std::array<double, 3>{{0.1, -0.2, 0.3}},
+                     // Scalar wave parameters
+                     2.3, 1.7, 2.9, std::pair<size_t, int>{1, 0}});
+    auto serialized_and_deserialized_condition = serialize_and_deserialize(
+        *dynamic_cast<ScalarTensor::BoundaryConditions::ProductOfConditions<
+            gh::BoundaryConditions::DirichletAnalytic<3_st>,
+            CurvedScalarWave::BoundaryConditions::AnalyticConstant<3_st>>*>(
+            product_boundary_condition.get()));
+    test_boundary_condition_combination<
+        gh::BoundaryCorrections::UpwindPenalty<
+            3_st>::dg_package_data_temporary_tags,
+        CurvedScalarWave::BoundaryCorrections::UpwindPenalty<
+            3_st>::dg_package_data_temporary_tags,
+        gh::BoundaryConditions::DirichletAnalytic<3_st>,
+        CurvedScalarWave::BoundaryConditions::AnalyticConstant<3_st>>(
+        gh_condition, scalar_condition, serialized_and_deserialized_condition,
+        gridless_box);
+  }
+  {
+    INFO(
+        "Product condition of CurvedScalarWave DemandOutgoingCharSpeeds and "
+        "GeneralizedHarmonic DemandOutgoingCharSpeeds");
+    const CurvedScalarWave::BoundaryConditions::DemandOutgoingCharSpeeds<3_st>
+        scalar_condition{};
+    const gh::BoundaryConditions::DemandOutgoingCharSpeeds<3_st> gh_condition{};
+    const auto product_boundary_condition = TestHelpers::test_factory_creation<
+        ScalarTensor::BoundaryConditions::BoundaryCondition,
+        ScalarTensor::BoundaryConditions::ProductOfConditions<
+            gh::BoundaryConditions::DemandOutgoingCharSpeeds<3_st>,
+            CurvedScalarWave::BoundaryConditions::DemandOutgoingCharSpeeds<
+                3_st>>>(
+        "ProductDemandOutgoingCharSpeedsAndDemandOutgoingCharSpeeds:\n"
+        "  GeneralizedHarmonicDemandOutgoingCharSpeeds:\n"
+        "  ScalarDemandOutgoingCharSpeeds:");
+    const auto gridless_box = db::create<db::AddSimpleTags<>>();
+    auto serialized_and_deserialized_condition = serialize_and_deserialize(
+        *dynamic_cast<ScalarTensor::BoundaryConditions::ProductOfConditions<
+            gh::BoundaryConditions::DemandOutgoingCharSpeeds<3_st>,
+            CurvedScalarWave::BoundaryConditions::DemandOutgoingCharSpeeds<
+                3_st>>*>(product_boundary_condition.get()));
+    test_boundary_condition_combination<
+        tmpl::list<>, tmpl::list<>,
+        gh::BoundaryConditions::DemandOutgoingCharSpeeds<3_st>,
+        CurvedScalarWave::BoundaryConditions::DemandOutgoingCharSpeeds<3_st>>(
+        gh_condition, scalar_condition, serialized_and_deserialized_condition,
+        gridless_box);
+  }
+}

--- a/tests/Unit/Evolution/Systems/ScalarTensor/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/ScalarTensor/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY "Test_ScalarTensor")
 
 set(LIBRARY_SOURCES
+  BoundaryConditions/Test_ProductOfConditions.cpp
   Test_Characteristics.cpp
   Test_Sources.cpp
   Test_StressEnergy.cpp


### PR DESCRIPTION
## Proposed changes

Add product of boundary conditions for the ScalarTensor system. For now, only we allow for Ghost type boundary conditions for both systems and `demand_outgoing_char_speeds` for excision boundaries.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
