### PR TITLE
Cleanups for starting on FD

### DIFF
--- a/src/Evolution/DgSubcell/Actions/Initialize.hpp
+++ b/src/Evolution/DgSubcell/Actions/Initialize.hpp
@@ -120,11 +120,13 @@ struct Initialize {
                      ::domain::CoordinateMaps::Tags::CoordinateMap<
                          Dim, Frame::Grid, Frame::Inertial>>,
                  fd::Tags::InverseJacobianLogicalToGridCompute<
-                   ::domain::Tags::ElementMap<Dim, Frame::Grid>,
-                   Dim>,
-                 fd::Tags::DetInverseJacobianLogicalToGridCompute<
-                   Dim>,
+                     ::domain::Tags::ElementMap<Dim, Frame::Grid>, Dim>,
+                 fd::Tags::DetInverseJacobianLogicalToGridCompute<Dim>,
                  fd::Tags::InverseJacobianLogicalToInertialCompute<
+                     ::domain::CoordinateMaps::Tags::CoordinateMap<
+                         Dim, Frame::Grid, Frame::Inertial>,
+                     Dim>,
+                 fd::Tags::DetInverseJacobianLogicalToInertialCompute<
                      ::domain::CoordinateMaps::Tags::CoordinateMap<
                          Dim, Frame::Grid, Frame::Inertial>,
                      Dim>>;

--- a/src/Evolution/DgSubcell/Actions/TakeTimeStep.hpp
+++ b/src/Evolution/DgSubcell/Actions/TakeTimeStep.hpp
@@ -67,11 +67,7 @@ struct TakeTimeStep {
       const Parallel::GlobalCache<Metavariables>& /*cache*/,
       const ArrayIndex& /*array_index*/, const ActionList /*meta*/,
       const ParallelComponent* const /*meta*/) {
-
-    TimeDerivative::apply(
-        make_not_null(&box),
-        db::get<fd::Tags::InverseJacobianLogicalToGrid<Dim>>(box),
-        db::get<fd::Tags::DetInverseJacobianLogicalToGrid>(box));
+    TimeDerivative::apply(make_not_null(&box));
 
     db::mutate<evolution::dg::Tags::MortarData<Dim>>(
         [](const auto mortar_data_ptr) {

--- a/src/Evolution/DgSubcell/Actions/TakeTimeStep.hpp
+++ b/src/Evolution/DgSubcell/Actions/TakeTimeStep.hpp
@@ -67,10 +67,6 @@ struct TakeTimeStep {
       const Parallel::GlobalCache<Metavariables>& /*cache*/,
       const ArrayIndex& /*array_index*/, const ActionList /*meta*/,
       const ParallelComponent* const /*meta*/) {
-    ASSERT((db::get<::domain::CoordinateMaps::Tags::CoordinateMap<
-                Dim, Frame::Grid, Frame::Inertial>>(box))
-               .is_identity(),
-           "Do not yet support moving mesh with DG-subcell.");
 
     TimeDerivative::apply(
         make_not_null(&box),

--- a/src/Evolution/DgSubcell/NeighborRdmpAndVolumeData.cpp
+++ b/src/Evolution/DgSubcell/NeighborRdmpAndVolumeData.cpp
@@ -90,7 +90,8 @@ void insert_or_update_neighbor_volume_data(
             << end_of_volume_data
             << ") must be a multiple of the number of DG volume grid points: "
             << neighbor_mesh.number_of_grid_points() << " number of RDMP vars "
-            << number_of_rdmp_vars_in_buffer);
+            << number_of_rdmp_vars_in_buffer << "\nThis element: " << element
+            << "\nDirection: " << direction);
     const size_t number_of_vars =
         end_of_volume_data / neighbor_mesh.number_of_grid_points();
     const auto project_to_ghost_data =

--- a/src/Evolution/DgSubcell/Tags/Jacobians.hpp
+++ b/src/Evolution/DgSubcell/Tags/Jacobians.hpp
@@ -4,13 +4,13 @@
 #pragma once
 
 #include <cstddef>
-#include <optional>
 #include <string>
 
 #include "DataStructures/DataBox/Tag.hpp"
 #include "DataStructures/Tensor/EagerMath/Determinant.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Domain/ElementMap.hpp"
+#include "Evolution/DgSubcell/Tags/Coordinates.hpp"
 #include "Utilities/SetNumberOfGridPoints.hpp"
 
 /// \cond
@@ -25,9 +25,6 @@ namespace evolution::dg::subcell::fd::Tags {
 ///
 /// Specifically, \f$\partial x^{\bar{i}} / \partial x^i\f$, where \f$\bar{i}\f$
 /// denotes the element logical frame and \f$i\f$ denotes the grid frame.
-///
-/// \note stored as a `std::optional` so we can reset it when switching to DG
-/// and reduce the memory footprint.
 template <size_t Dim>
 struct InverseJacobianLogicalToGrid : db::SimpleTag {
   static std::string name() { return "InverseJacobian(Logical,Grid)"; }
@@ -37,9 +34,6 @@ struct InverseJacobianLogicalToGrid : db::SimpleTag {
 
 /// \brief The determinant of the inverse Jacobian from the element logical
 /// frame to the grid frame at the cell centers.
-///
-/// \note stored as a `std::optional` so we can reset it when switching to DG
-/// and reduce the memory footprint.
 struct DetInverseJacobianLogicalToGrid : db::SimpleTag {
   static std::string name() { return "Det(InverseJacobian(Logical,Grid))"; }
   using type = Scalar<DataVector>;
@@ -50,14 +44,11 @@ struct DetInverseJacobianLogicalToGrid : db::SimpleTag {
 ///
 /// Specifically, \f$\partial x^{\bar{i}} / \partial x^i\f$, where \f$\bar{i}\f$
 /// denotes the element logical frame and \f$i\f$ denotes the inertial frame.
-///
-/// \note stored as a `std::optional` so we can reset it when switching to DG
-/// and reduce the memory footprint (is it useful for a ComputeTag though?).
 template <size_t Dim>
 struct InverseJacobianLogicalToInertial : db::SimpleTag {
   static std::string name() { return "InverseJacobian(Logical,Inertial)"; }
-  using type = ::InverseJacobian < DataVector, Dim, Frame::ElementLogical,
-        Frame::Inertial >;
+  using type = ::InverseJacobian<DataVector, Dim, Frame::ElementLogical,
+                                 Frame::Inertial>;
 };
 
 /// Compute item for the inverse jacobian matrix from logical to
@@ -93,8 +84,7 @@ struct DetInverseJacobianLogicalToGridCompute
   static void function(
       const gsl::not_null<return_type*> det_inverse_jacobian_logical_to_grid,
       const ::InverseJacobian<DataVector, Dim, Frame::ElementLogical,
-                              Frame::Grid>
-          inverse_jacobian_logical_to_grid) {
+                              Frame::Grid>& inverse_jacobian_logical_to_grid) {
     *det_inverse_jacobian_logical_to_grid =
         determinant(inverse_jacobian_logical_to_grid);
   }

--- a/src/Evolution/DgSubcell/Tags/ObserverCoordinates.hpp
+++ b/src/Evolution/DgSubcell/Tags/ObserverCoordinates.hpp
@@ -139,7 +139,7 @@ struct ObserverInverseJacobianCompute
  * \brief Computes the active Jacobian and determinant of the inverse Jacobian.
  */
 template <size_t Dim, typename SourceFrame, typename TargetFrame>
-struct ObserverJacobianAndDetInvJacobian
+struct ObserverJacobianAndDetInvJacobianCompute
     : ::Tags::Variables<tmpl::list<
           ::Events::Tags::ObserverDetInvJacobian<SourceFrame, TargetFrame>,
           ::Events::Tags::ObserverJacobian<Dim, SourceFrame, TargetFrame>>>,

--- a/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
+++ b/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
@@ -484,8 +484,9 @@ struct GhValenciaDivCleanTemplateBase<
               evolution::dg::subcell::Tags::ObserverMeshCompute<volume_dim>,
               evolution::dg::subcell::Tags::ObserverInverseJacobianCompute<
                   volume_dim, Frame::ElementLogical, Frame::Inertial>,
-              evolution::dg::subcell::Tags::ObserverJacobianAndDetInvJacobian<
-                  volume_dim, Frame::ElementLogical, Frame::Inertial>>,
+              evolution::dg::subcell::Tags::
+                  ObserverJacobianAndDetInvJacobianCompute<
+                      volume_dim, Frame::ElementLogical, Frame::Inertial>>,
           tmpl::list<::Events::Tags::ObserverMeshCompute<volume_dim>,
                      ::Events::Tags::ObserverInverseJacobianCompute<
                          volume_dim, Frame::ElementLogical, Frame::Inertial>,

--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
@@ -297,8 +297,9 @@ struct EvolutionMetavars {
               evolution::dg::subcell::Tags::ObserverMeshCompute<volume_dim>,
               evolution::dg::subcell::Tags::ObserverInverseJacobianCompute<
                   volume_dim, Frame::ElementLogical, Frame::Inertial>,
-              evolution::dg::subcell::Tags::ObserverJacobianAndDetInvJacobian<
-                  volume_dim, Frame::ElementLogical, Frame::Inertial>>,
+              evolution::dg::subcell::Tags::
+                  ObserverJacobianAndDetInvJacobianCompute<
+                      volume_dim, Frame::ElementLogical, Frame::Inertial>>,
           tmpl::list<::Events::Tags::ObserverMeshCompute<volume_dim>,
                      ::Events::Tags::ObserverInverseJacobianCompute<
                          volume_dim, Frame::ElementLogical, Frame::Inertial>,

--- a/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
+++ b/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
@@ -212,8 +212,9 @@ struct EvolutionMetavars {
               evolution::dg::subcell::Tags::ObserverMeshCompute<volume_dim>,
               evolution::dg::subcell::Tags::ObserverInverseJacobianCompute<
                   volume_dim, Frame::ElementLogical, Frame::Inertial>,
-              evolution::dg::subcell::Tags::ObserverJacobianAndDetInvJacobian<
-                  volume_dim, Frame::ElementLogical, Frame::Inertial>>,
+              evolution::dg::subcell::Tags::
+                  ObserverJacobianAndDetInvJacobianCompute<
+                      volume_dim, Frame::ElementLogical, Frame::Inertial>>,
           tmpl::list<::Events::Tags::ObserverMeshCompute<volume_dim>,
                      ::Events::Tags::ObserverInverseJacobianCompute<
                          volume_dim, Frame::ElementLogical, Frame::Inertial>,

--- a/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
+++ b/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
@@ -364,7 +364,7 @@ struct EvolutionMetavars {
       Actions::MutateApply<
           NewtonianEuler::subcell::PrimsAfterRollback<volume_dim>>,
       evolution::dg::subcell::fd::Actions::TakeTimeStep<
-          NewtonianEuler::subcell::TimeDerivative>,
+          NewtonianEuler::subcell::TimeDerivative<volume_dim>>,
       Actions::RecordTimeStepperData<system>, Actions::UpdateU<system>,
       Actions::MutateApply<typename system::primitive_from_conservative>,
       evolution::dg::subcell::Actions::TciAndSwitchToDg<

--- a/src/Evolution/Executables/ScalarAdvection/EvolveScalarAdvection.hpp
+++ b/src/Evolution/Executables/ScalarAdvection/EvolveScalarAdvection.hpp
@@ -182,8 +182,9 @@ struct EvolutionMetavars {
               evolution::dg::subcell::Tags::ObserverMeshCompute<volume_dim>,
               evolution::dg::subcell::Tags::ObserverInverseJacobianCompute<
                   volume_dim, Frame::ElementLogical, Frame::Inertial>,
-              evolution::dg::subcell::Tags::ObserverJacobianAndDetInvJacobian<
-                  volume_dim, Frame::ElementLogical, Frame::Inertial>>,
+              evolution::dg::subcell::Tags::
+                  ObserverJacobianAndDetInvJacobianCompute<
+                      volume_dim, Frame::ElementLogical, Frame::Inertial>>,
           tmpl::list<::Events::Tags::ObserverMeshCompute<volume_dim>,
                      ::Events::Tags::ObserverInverseJacobianCompute<
                          volume_dim, Frame::ElementLogical, Frame::Inertial>,

--- a/src/Evolution/Executables/ScalarAdvection/EvolveScalarAdvection.hpp
+++ b/src/Evolution/Executables/ScalarAdvection/EvolveScalarAdvection.hpp
@@ -327,7 +327,7 @@ struct EvolutionMetavars {
               Initialization::Actions::AddSimpleTags<
                   ScalarAdvection::subcell::VelocityAtFace<volume_dim>>,
               Actions::MutateApply<
-                  ScalarAdvection::subcell::SetInitialRdmpData>>,
+                  ScalarAdvection::subcell::SetInitialRdmpData<volume_dim>>>,
           tmpl::list<>>,
 
       Initialization::Actions::AddComputeTags<

--- a/src/Evolution/Systems/Burgers/Subcell/InitialDataTci.hpp
+++ b/src/Evolution/Systems/Burgers/Subcell/InitialDataTci.hpp
@@ -46,12 +46,15 @@ struct DgInitialDataTci {
 /// Used on the subcells after the TCI marked the DG solution as inadmissible.
 struct SetInitialRdmpData {
   using argument_tags =
-      tmpl::list<Burgers::Tags::U, evolution::dg::subcell::Tags::ActiveGrid>;
+      tmpl::list<Burgers::Tags::U, evolution::dg::subcell::Tags::ActiveGrid,
+                 ::domain::Tags::Mesh<1>,
+                 evolution::dg::subcell::Tags::Mesh<1>>;
   using return_tags = tmpl::list<evolution::dg::subcell::Tags::DataForRdmpTci>;
 
   static void apply(
       gsl::not_null<evolution::dg::subcell::RdmpTciData*> rdmp_tci_data,
-      const Scalar<DataVector>& subcell_u,
-      evolution::dg::subcell::ActiveGrid active_grid);
+      const Scalar<DataVector>& u,
+      evolution::dg::subcell::ActiveGrid active_grid, const Mesh<1>& dg_mesh,
+      const Mesh<1>& subcell_mesh);
 };
 }  // namespace Burgers::subcell

--- a/src/Evolution/Systems/Burgers/Subcell/TimeDerivative.hpp
+++ b/src/Evolution/Systems/Burgers/Subcell/TimeDerivative.hpp
@@ -55,6 +55,10 @@ struct TimeDerivative {
       const InverseJacobian<DataVector, 1, Frame::ElementLogical, Frame::Grid>&
           cell_centered_logical_to_grid_inv_jacobian,
       const Scalar<DataVector>& /*cell_centered_det_inv_jacobian*/) {
+    ASSERT((db::get<::domain::CoordinateMaps::Tags::CoordinateMap<
+                1, Frame::Grid, Frame::Inertial>>(*box))
+               .is_identity(),
+           "Do not yet support moving mesh with DG-subcell.");
     const Element<1>& element = db::get<domain::Tags::Element<1>>(*box);
 
     const bool element_is_interior = element.external_boundaries().size() == 0;

--- a/src/Evolution/Systems/Burgers/Subcell/TimeDerivative.hpp
+++ b/src/Evolution/Systems/Burgers/Subcell/TimeDerivative.hpp
@@ -22,6 +22,7 @@
 #include "Evolution/DgSubcell/CorrectPackagedData.hpp"
 #include "Evolution/DgSubcell/SubcellOptions.hpp"
 #include "Evolution/DgSubcell/Tags/Coordinates.hpp"
+#include "Evolution/DgSubcell/Tags/Jacobians.hpp"
 #include "Evolution/DgSubcell/Tags/Mesh.hpp"
 #include "Evolution/DiscontinuousGalerkin/Actions/PackageDataImpl.hpp"
 #include "Evolution/DiscontinuousGalerkin/MortarTags.hpp"
@@ -50,11 +51,7 @@ namespace Burgers::subcell {
  */
 struct TimeDerivative {
   template <typename DbTagsList>
-  static void apply(
-      const gsl::not_null<db::DataBox<DbTagsList>*> box,
-      const InverseJacobian<DataVector, 1, Frame::ElementLogical, Frame::Grid>&
-          cell_centered_logical_to_grid_inv_jacobian,
-      const Scalar<DataVector>& /*cell_centered_det_inv_jacobian*/) {
+  static void apply(const gsl::not_null<db::DataBox<DbTagsList>*> box) {
     ASSERT((db::get<::domain::CoordinateMaps::Tags::CoordinateMap<
                 1, Frame::Grid, Frame::Inertial>>(*box))
                .is_identity(),
@@ -215,9 +212,11 @@ struct TimeDerivative {
         db::add_tag_prefix<::Tags::dt, typename System::variables_tag>;
     const size_t num_pts = subcell_mesh.number_of_grid_points();
     db::mutate<dt_variables_tag>(
-        [&cell_centered_logical_to_grid_inv_jacobian, &num_pts,
-         &fd_boundary_corrections, &subcell_mesh,
-         &one_over_delta_xi](const auto dt_vars_ptr) {
+        [&num_pts, &fd_boundary_corrections, &subcell_mesh, &one_over_delta_xi](
+            const auto dt_vars_ptr,
+            const InverseJacobian<DataVector, 1, Frame::ElementLogical,
+                                  Frame::Grid>&
+                cell_centered_logical_to_grid_inv_jacobian) {
           dt_vars_ptr->initialize(num_pts, 0.0);
           auto& dt_u = get<::Tags::dt<::Burgers::Tags::U>>(*dt_vars_ptr);
 
@@ -228,7 +227,10 @@ struct TimeDerivative {
               cell_centered_logical_to_grid_inv_jacobian.get(0, 0),
               get(u_correction), subcell_mesh.extents(), 0);
         },
-        box);
+        box,
+        db::get<
+            evolution::dg::subcell::fd::Tags::InverseJacobianLogicalToGrid<1>>(
+            *box));
   }
 };
 }  // namespace Burgers::subcell

--- a/src/Evolution/Systems/ForceFree/Subcell/InitialDataTci.cpp
+++ b/src/Evolution/Systems/ForceFree/Subcell/InitialDataTci.cpp
@@ -90,22 +90,41 @@ std::tuple<int, evolution::dg::subcell::RdmpTciData> DgInitialDataTci::apply(
 
 void SetInitialRdmpData::apply(
     const gsl::not_null<evolution::dg::subcell::RdmpTciData*> rdmp_tci_data,
-    const tnsr::I<DataVector, 3, Frame::Inertial>& subcell_tilde_e,
-    const tnsr::I<DataVector, 3, Frame::Inertial>& subcell_tilde_b,
-    const Scalar<DataVector>& subcell_tilde_q,
-    const evolution::dg::subcell::ActiveGrid active_grid) {
+    const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_e,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_b,
+    const Scalar<DataVector>& tilde_q,
+    const evolution::dg::subcell::ActiveGrid active_grid,
+    const Mesh<3>& dg_mesh, const Mesh<3>& subcell_mesh) {
   if (active_grid == evolution::dg::subcell::ActiveGrid::Subcell) {
-    const Scalar<DataVector> subcell_tilde_e_magnitude =
-        magnitude(subcell_tilde_e);
-    const Scalar<DataVector> subcell_tilde_b_magnitude =
-        magnitude(subcell_tilde_b);
+    const Scalar<DataVector> tilde_e_magnitude = magnitude(tilde_e);
+    const Scalar<DataVector> tilde_b_magnitude = magnitude(tilde_b);
 
-    rdmp_tci_data->max_variables_values = DataVector{
-        max(get(subcell_tilde_e_magnitude)),
-        max(get(subcell_tilde_b_magnitude)), max(get(subcell_tilde_q))};
-    rdmp_tci_data->min_variables_values = DataVector{
-        min(get(subcell_tilde_e_magnitude)),
-        min(get(subcell_tilde_b_magnitude)), min(get(subcell_tilde_q))};
+    rdmp_tci_data->max_variables_values =
+        DataVector{max(get(tilde_e_magnitude)), max(get(tilde_b_magnitude)),
+                   max(get(tilde_q))};
+    rdmp_tci_data->min_variables_values =
+        DataVector{min(get(tilde_e_magnitude)), min(get(tilde_b_magnitude)),
+                   min(get(tilde_q))};
+  } else {
+    using std::max;
+    using std::min;
+    const Scalar<DataVector> tilde_e_magnitude = magnitude(tilde_e);
+    const Scalar<DataVector> tilde_b_magnitude = magnitude(tilde_b);
+    const auto subcell_tilde_e_mag = evolution::dg::subcell::fd::project(
+        get(tilde_e_magnitude), dg_mesh, subcell_mesh.extents());
+    const auto subcell_tilde_b_mag = evolution::dg::subcell::fd::project(
+        get(tilde_b_magnitude), dg_mesh, subcell_mesh.extents());
+    const auto subcell_tilde_q = evolution::dg::subcell::fd::project(
+        get(tilde_q), dg_mesh, subcell_mesh.extents());
+
+    rdmp_tci_data->max_variables_values =
+        DataVector{max(max(get(tilde_e_magnitude)), max(subcell_tilde_e_mag)),
+                   max(max(get(tilde_b_magnitude)), max(subcell_tilde_b_mag)),
+                   max(max(get(tilde_q)), max(subcell_tilde_q))};
+    rdmp_tci_data->min_variables_values =
+        DataVector{min(min(get(tilde_e_magnitude)), min(subcell_tilde_e_mag)),
+                   min(min(get(tilde_b_magnitude)), min(subcell_tilde_b_mag)),
+                   min(min(get(tilde_q)), min(subcell_tilde_q))};
   }
 }
 

--- a/src/Evolution/Systems/ForceFree/Subcell/InitialDataTci.hpp
+++ b/src/Evolution/Systems/ForceFree/Subcell/InitialDataTci.hpp
@@ -95,10 +95,10 @@ struct DgInitialDataTci {
  * Used on the subcells after the TCI marked the DG solution as inadmissible.
  */
 struct SetInitialRdmpData {
-  using argument_tags =
-      tmpl::list<ForceFree::Tags::TildeE, ForceFree::Tags::TildeB,
-                 ForceFree::Tags::TildeQ,
-                 evolution::dg::subcell::Tags::ActiveGrid>;
+  using argument_tags = tmpl::list<
+      ForceFree::Tags::TildeE, ForceFree::Tags::TildeB, ForceFree::Tags::TildeQ,
+      evolution::dg::subcell::Tags::ActiveGrid, ::domain::Tags::Mesh<3>,
+      evolution::dg::subcell::Tags::Mesh<3>>;
   using return_tags = tmpl::list<evolution::dg::subcell::Tags::DataForRdmpTci>;
 
   static void apply(
@@ -106,6 +106,7 @@ struct SetInitialRdmpData {
       const tnsr::I<DataVector, 3, Frame::Inertial>& subcell_tilde_e,
       const tnsr::I<DataVector, 3, Frame::Inertial>& subcell_tilde_b,
       const Scalar<DataVector>& subcell_tilde_q,
-      evolution::dg::subcell::ActiveGrid active_grid);
+      evolution::dg::subcell::ActiveGrid active_grid, const Mesh<3>& dg_mesh,
+      const Mesh<3>& subcell_mesh);
 };
 }  // namespace ForceFree::subcell

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/NeighborPackagedData.hpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/NeighborPackagedData.hpp
@@ -66,6 +66,9 @@ namespace grmhd::GhValenciaDivClean::subcell {
  * However, in practice such strict conservation doesn't seem to be necessary
  * and can be explained by that we only need strict conservation at shocks, and
  * if one element is doing DG, then we aren't at a shock.
+ *
+ * Developer note: For performance reasons We should consider storing the mesh
+ * velocity on the faces instead of re-slicing/projecting.
  */
 struct NeighborPackagedData {
   template <typename DbTagsList>
@@ -87,12 +90,6 @@ struct NeighborPackagedData {
     using grmhd_evolved_vars_tag =
         typename grmhd::ValenciaDivClean::System::variables_tag;
     using grmhd_evolved_vars_tags = typename grmhd_evolved_vars_tag::tags_list;
-
-    ASSERT(not db::get<domain::Tags::MeshVelocity<3>>(box).has_value(),
-           "Haven't yet added support for moving mesh to DG-subcell. This "
-           "should be easy to generalize, but we will want to consider "
-           "storing the mesh velocity on the faces instead of "
-           "re-slicing/projecting.");
 
     FixedHashMap<maximum_number_of_neighbors(3),
                  std::pair<Direction<3>, ElementId<3>>, DataVector,

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/TimeDerivative.hpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/TimeDerivative.hpp
@@ -26,6 +26,7 @@
 #include "Evolution/DgSubcell/Projection.hpp"
 #include "Evolution/DgSubcell/Tags/Coordinates.hpp"
 #include "Evolution/DgSubcell/Tags/GhostDataForReconstruction.hpp"
+#include "Evolution/DgSubcell/Tags/Jacobians.hpp"
 #include "Evolution/DgSubcell/Tags/Mesh.hpp"
 #include "Evolution/DgSubcell/Tags/OnSubcellFaces.hpp"
 #include "Evolution/DiscontinuousGalerkin/Actions/NormalCovectorAndMagnitude.hpp"
@@ -430,11 +431,7 @@ struct ComputeTimeDerivImpl<
  */
 struct TimeDerivative {
   template <typename DbTagsList>
-  static void apply(
-      const gsl::not_null<db::DataBox<DbTagsList>*> box,
-      const InverseJacobian<DataVector, 3, Frame::ElementLogical, Frame::Grid>&
-      /*cell_centered_logical_to_grid_inv_jacobian*/,
-      const Scalar<DataVector>& cell_centered_det_inv_jacobian) {
+  static void apply(const gsl::not_null<db::DataBox<DbTagsList>*> box) {
     using evolved_vars_tag =
         typename grmhd::GhValenciaDivClean::System::variables_tag;
     using evolved_vars_tags = typename evolved_vars_tag::tags_list;
@@ -790,9 +787,11 @@ struct TimeDerivative {
                                  gh_gradient_tags, gh_extra_tags,
                                  grmhd_evolved_vars_tags, grmhd_source_tags,
                                  grmhd_source_argument_tags>::
-        apply(box, inertial_coords, cell_centered_det_inv_jacobian,
-              cell_centered_logical_to_inertial_inv_jacobian,
-              one_over_delta_xi, boundary_corrections, cell_centered_gh_derivs);
+        apply(box, inertial_coords,
+              db::get<evolution::dg::subcell::fd::Tags::
+                          DetInverseJacobianLogicalToInertial>(*box),
+              cell_centered_logical_to_inertial_inv_jacobian, one_over_delta_xi,
+              boundary_corrections, cell_centered_gh_derivs);
   }
 };
 }  // namespace grmhd::GhValenciaDivClean::subcell

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/InitialDataTci.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/InitialDataTci.cpp
@@ -113,21 +113,43 @@ std::tuple<int, evolution::dg::subcell::RdmpTciData> DgInitialDataTci::apply(
 
 void SetInitialRdmpData::apply(
     const gsl::not_null<evolution::dg::subcell::RdmpTciData*> rdmp_tci_data,
-    const Scalar<DataVector>& subcell_tilde_d,
-    const Scalar<DataVector>& subcell_tilde_ye,
-    const Scalar<DataVector>& subcell_tilde_tau,
-    const tnsr::I<DataVector, 3, Frame::Inertial>& subcell_tilde_b,
-    const evolution::dg::subcell::ActiveGrid active_grid) {
+    const Scalar<DataVector>& tilde_d, const Scalar<DataVector>& tilde_ye,
+    const Scalar<DataVector>& tilde_tau,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_b,
+    const evolution::dg::subcell::ActiveGrid active_grid,
+    const Mesh<3>& dg_mesh, const Mesh<3>& subcell_mesh) {
   if (active_grid == evolution::dg::subcell::ActiveGrid::Subcell) {
-    const Scalar<DataVector> subcell_tilde_b_magnitude =
-        magnitude(subcell_tilde_b);
+    const Scalar<DataVector> tilde_b_magnitude = magnitude(tilde_b);
 
-    rdmp_tci_data->max_variables_values = DataVector{
-        max(get(subcell_tilde_d)), max(get(subcell_tilde_ye)),
-        max(get(subcell_tilde_tau)), max(get(subcell_tilde_b_magnitude))};
-    rdmp_tci_data->min_variables_values = DataVector{
-        min(get(subcell_tilde_d)), min(get(subcell_tilde_ye)),
-        min(get(subcell_tilde_tau)), min(get(subcell_tilde_b_magnitude))};
+    rdmp_tci_data->max_variables_values =
+        DataVector{max(get(tilde_d)), max(get(tilde_ye)), max(get(tilde_tau)),
+                   max(get(tilde_b_magnitude))};
+    rdmp_tci_data->min_variables_values =
+        DataVector{min(get(tilde_d)), min(get(tilde_ye)), min(get(tilde_tau)),
+                   min(get(tilde_b_magnitude))};
+  } else {
+    const Scalar<DataVector> tilde_b_magnitude = magnitude(tilde_b);
+    const auto subcell_tilde_b_mag = evolution::dg::subcell::fd::project(
+        get(tilde_b_magnitude), dg_mesh, subcell_mesh.extents());
+    const auto subcell_tilde_d = evolution::dg::subcell::fd::project(
+        get(tilde_d), dg_mesh, subcell_mesh.extents());
+    const auto subcell_tilde_ye = evolution::dg::subcell::fd::project(
+        get(tilde_ye), dg_mesh, subcell_mesh.extents());
+    const auto subcell_tilde_tau = evolution::dg::subcell::fd::project(
+        get(tilde_tau), dg_mesh, subcell_mesh.extents());
+
+    using std::max;
+    using std::min;
+    rdmp_tci_data->max_variables_values =
+        DataVector{max(max(subcell_tilde_d), max(get(tilde_d))),
+                   max(max(subcell_tilde_ye), max(get(tilde_ye))),
+                   max(max(subcell_tilde_tau), max(get(tilde_tau))),
+                   max(max(subcell_tilde_b_mag), max(get(tilde_b_magnitude)))};
+    rdmp_tci_data->min_variables_values =
+        DataVector{min(min(subcell_tilde_d), min(get(tilde_d))),
+                   min(min(subcell_tilde_ye), min(get(tilde_ye))),
+                   min(min(subcell_tilde_tau), min(get(tilde_tau))),
+                   min(min(subcell_tilde_b_mag), min(get(tilde_b_magnitude)))};
   }
 }
 }  // namespace grmhd::ValenciaDivClean::subcell

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/InitialDataTci.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/InitialDataTci.hpp
@@ -112,7 +112,8 @@ struct SetInitialRdmpData {
   using argument_tags = tmpl::list<
       ValenciaDivClean::Tags::TildeD, ValenciaDivClean::Tags::TildeYe,
       ValenciaDivClean::Tags::TildeTau, ValenciaDivClean::Tags::TildeB<>,
-      evolution::dg::subcell::Tags::ActiveGrid>;
+      evolution::dg::subcell::Tags::ActiveGrid, ::domain::Tags::Mesh<3>,
+      evolution::dg::subcell::Tags::Mesh<3>>;
   using return_tags = tmpl::list<evolution::dg::subcell::Tags::DataForRdmpTci>;
 
   static void apply(
@@ -121,6 +122,7 @@ struct SetInitialRdmpData {
       const Scalar<DataVector>& subcell_tilde_ye,
       const Scalar<DataVector>& subcell_tilde_tau,
       const tnsr::I<DataVector, 3, Frame::Inertial>& subcell_tilde_b,
-      const evolution::dg::subcell::ActiveGrid active_grid);
+      evolution::dg::subcell::ActiveGrid active_grid, const Mesh<3>& dg_mesh,
+      const Mesh<3>& subcell_mesh);
 };
 }  // namespace grmhd::ValenciaDivClean::subcell

--- a/src/Evolution/Systems/NewtonianEuler/Subcell/InitialDataTci.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/Subcell/InitialDataTci.hpp
@@ -59,16 +59,18 @@ struct SetInitialRdmpData {
   using MomentumDensity = NewtonianEuler::Tags::MomentumDensity<Dim>;
 
  public:
-  using argument_tags =
-      tmpl::list<::Tags::Variables<tmpl::list<MassDensityCons, MomentumDensity,
-                                              EnergyDensity>>,
-                 evolution::dg::subcell::Tags::ActiveGrid>;
+  using argument_tags = tmpl::list<
+      ::Tags::Variables<
+          tmpl::list<MassDensityCons, MomentumDensity, EnergyDensity>>,
+      evolution::dg::subcell::Tags::ActiveGrid, ::domain::Tags::Mesh<Dim>,
+      evolution::dg::subcell::Tags::Mesh<Dim>>;
   using return_tags = tmpl::list<evolution::dg::subcell::Tags::DataForRdmpTci>;
 
   static void apply(
       gsl::not_null<evolution::dg::subcell::RdmpTciData*> rdmp_tci_data,
       const Variables<tmpl::list<MassDensityCons, MomentumDensity,
                                  EnergyDensity>>& subcell_vars,
-      evolution::dg::subcell::ActiveGrid active_grid);
+      evolution::dg::subcell::ActiveGrid active_grid, const Mesh<Dim>& dg_mesh,
+      const Mesh<Dim>& subcell_mesh);
 };
 }  // namespace NewtonianEuler::subcell

--- a/src/Evolution/Systems/NewtonianEuler/Subcell/TimeDerivative.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/Subcell/TimeDerivative.hpp
@@ -14,6 +14,7 @@
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Variables.hpp"
+#include "Domain/CoordinateMaps/Tags.hpp"
 #include "Domain/Structure/Element.hpp"
 #include "Domain/Tags.hpp"
 #include "Evolution/BoundaryCorrectionTags.hpp"
@@ -67,6 +68,11 @@ struct TimeDerivative {
     using prim_tags = typename system::primitive_variables_tag::tags_list;
     using fluxes_tags = db::wrap_tags_in<::Tags::Flux, evolved_vars_tags,
                                          tmpl::size_t<Dim>, Frame::Inertial>;
+
+    ASSERT((db::get<::domain::CoordinateMaps::Tags::CoordinateMap<
+                Dim, Frame::Grid, Frame::Inertial>>(*box))
+               .is_identity(),
+           "Do not yet support moving mesh with DG-subcell.");
 
     // The copy of Mesh is intentional to avoid a GCC-7 internal compiler error.
     const Mesh<Dim> subcell_mesh =

--- a/src/Evolution/Systems/ScalarAdvection/Subcell/InitialDataTci.cpp
+++ b/src/Evolution/Systems/ScalarAdvection/Subcell/InitialDataTci.cpp
@@ -44,18 +44,30 @@ DgInitialDataTci<Dim>::apply(
           std::move(rdmp_tci_data)};
 }
 
-void SetInitialRdmpData::apply(
+template <size_t Dim>
+void SetInitialRdmpData<Dim>::apply(
     const gsl::not_null<evolution::dg::subcell::RdmpTciData*> rdmp_tci_data,
-    const Scalar<DataVector>& subcell_u,
-    const evolution::dg::subcell::ActiveGrid active_grid) {
+    const Scalar<DataVector>& u,
+    const evolution::dg::subcell::ActiveGrid active_grid,
+    const Mesh<Dim>& dg_mesh, const Mesh<Dim>& subcell_mesh) {
   if (active_grid == evolution::dg::subcell::ActiveGrid::Subcell) {
-    *rdmp_tci_data = {{max(get(subcell_u))}, {min(get(subcell_u))}};
+    *rdmp_tci_data = {{max(get(u))}, {min(get(u))}};
+  } else {
+    using std::max;
+    using std::min;
+    const auto subcell_u = evolution::dg::subcell::fd::project(
+        get(u), dg_mesh, subcell_mesh.extents());
+
+    *rdmp_tci_data = {{max(max(get(u)), max(subcell_u))},
+                      {min(min(get(u)), min(subcell_u))}};
   }
 }
 
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 
-#define INSTANTIATION(r, data) template struct DgInitialDataTci<DIM(data)>;
+#define INSTANTIATION(r, data)                 \
+  template struct DgInitialDataTci<DIM(data)>; \
+  template struct SetInitialRdmpData<DIM(data)>;
 
 GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2))
 

--- a/src/Evolution/Systems/ScalarAdvection/Subcell/InitialDataTci.hpp
+++ b/src/Evolution/Systems/ScalarAdvection/Subcell/InitialDataTci.hpp
@@ -51,14 +51,17 @@ struct DgInitialDataTci {
 /// \brief Sets the initial RDMP data.
 ///
 /// Used on the subcells after the TCI marked the DG solution as inadmissible.
+template <size_t Dim>
 struct SetInitialRdmpData {
-  using argument_tags = tmpl::list<ScalarAdvection::Tags::U,
-                                   evolution::dg::subcell::Tags::ActiveGrid>;
+  using argument_tags = tmpl::list<
+      ScalarAdvection::Tags::U, evolution::dg::subcell::Tags::ActiveGrid,
+      ::domain::Tags::Mesh<Dim>, evolution::dg::subcell::Tags::Mesh<Dim>>;
   using return_tags = tmpl::list<evolution::dg::subcell::Tags::DataForRdmpTci>;
 
   static void apply(
       gsl::not_null<evolution::dg::subcell::RdmpTciData*> rdmp_tci_data,
-      const Scalar<DataVector>& subcell_u,
-      evolution::dg::subcell::ActiveGrid active_grid);
+      const Scalar<DataVector>& u,
+      evolution::dg::subcell::ActiveGrid active_grid, const Mesh<Dim>& dg_mesh,
+      const Mesh<Dim>& subcell_mesh);
 };
 }  // namespace ScalarAdvection::subcell

--- a/src/Evolution/Systems/ScalarAdvection/Subcell/TimeDerivative.hpp
+++ b/src/Evolution/Systems/ScalarAdvection/Subcell/TimeDerivative.hpp
@@ -14,6 +14,7 @@
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Variables.hpp"
+#include "Domain/CoordinateMaps/Tags.hpp"
 #include "Domain/Structure/Element.hpp"
 #include "Domain/Tags.hpp"
 #include "Evolution/BoundaryCorrectionTags.hpp"
@@ -55,6 +56,10 @@ struct TimeDerivative {
                             Frame::Grid>&
           cell_centered_logical_to_grid_inv_jacobian,
       const Scalar<DataVector>& /*cell_centered_det_inv_jacobian*/) {
+    ASSERT((db::get<::domain::CoordinateMaps::Tags::CoordinateMap<
+                Dim, Frame::Grid, Frame::Inertial>>(*box))
+               .is_identity(),
+           "Do not yet support moving mesh with DG-subcell.");
     // subcell is currently not supported for external boundary elements
     const Element<Dim>& element = db::get<domain::Tags::Element<Dim>>(*box);
     ASSERT(element.external_boundaries().size() == 0,

--- a/src/Evolution/Systems/ScalarAdvection/Subcell/TimeDerivative.hpp
+++ b/src/Evolution/Systems/ScalarAdvection/Subcell/TimeDerivative.hpp
@@ -22,6 +22,7 @@
 #include "Evolution/DgSubcell/ComputeBoundaryTerms.hpp"
 #include "Evolution/DgSubcell/CorrectPackagedData.hpp"
 #include "Evolution/DgSubcell/Tags/Coordinates.hpp"
+#include "Evolution/DgSubcell/Tags/Jacobians.hpp"
 #include "Evolution/DgSubcell/Tags/Mesh.hpp"
 #include "Evolution/DgSubcell/Tags/OnSubcellFaces.hpp"
 #include "Evolution/DiscontinuousGalerkin/Actions/PackageDataImpl.hpp"
@@ -50,12 +51,7 @@ namespace ScalarAdvection::subcell {
 template <size_t Dim>
 struct TimeDerivative {
   template <typename DbTagsList>
-  static void apply(
-      const gsl::not_null<db::DataBox<DbTagsList>*> box,
-      const InverseJacobian<DataVector, Dim, Frame::ElementLogical,
-                            Frame::Grid>&
-          cell_centered_logical_to_grid_inv_jacobian,
-      const Scalar<DataVector>& /*cell_centered_det_inv_jacobian*/) {
+  static void apply(const gsl::not_null<db::DataBox<DbTagsList>*> box) {
     ASSERT((db::get<::domain::CoordinateMaps::Tags::CoordinateMap<
                 Dim, Frame::Grid, Frame::Inertial>>(*box))
                .is_identity(),
@@ -236,9 +232,11 @@ struct TimeDerivative {
         db::add_tag_prefix<::Tags::dt, typename System<Dim>::variables_tag>;
     const size_t num_pts = subcell_mesh.number_of_grid_points();
     db::mutate<dt_variables_tag>(
-        [&cell_centered_logical_to_grid_inv_jacobian, &num_pts,
-         &fd_boundary_corrections, &subcell_mesh,
-         &one_over_delta_xi](const auto dt_vars_ptr) {
+        [&num_pts, &fd_boundary_corrections, &subcell_mesh, &one_over_delta_xi](
+            const auto dt_vars_ptr,
+            const InverseJacobian<DataVector, Dim, Frame::ElementLogical,
+                                  Frame::Grid>&
+                cell_centered_logical_to_grid_inv_jacobian) {
           dt_vars_ptr->initialize(num_pts, 0.0);
           auto& dt_u =
               get<::Tags::dt<::ScalarAdvection::Tags::U>>(*dt_vars_ptr);
@@ -252,7 +250,9 @@ struct TimeDerivative {
                 get(u_correction), subcell_mesh.extents(), dim);
           }
         },
-        box);
+        box,
+        db::get<evolution::dg::subcell::fd::Tags::InverseJacobianLogicalToGrid<
+            Dim>>(*box));
   }
 };
 }  // namespace ScalarAdvection::subcell

--- a/src/PointwiseFunctions/AnalyticData/GeneralRelativity/InterpolateFromSpec.hpp
+++ b/src/PointwiseFunctions/AnalyticData/GeneralRelativity/InterpolateFromSpec.hpp
@@ -82,18 +82,19 @@ tuples::tagged_tuple_from_typelist<Tags> interpolate_from_spec(
 #ifdef SPECTRE_DEBUG
       const auto component_name =
           tensor.component_name(tensor.get_tensor_index(component_i));
-      if constexpr (tensor.rank() == 1) {
+      if constexpr (std::decay_t<decltype(tensor)>::rank() == 1) {
         const std::array<std::string, 3> spec_component_order{{"x", "y", "z"}};
         ASSERT(component_name == gsl::at(spec_component_order, component_i),
                "Unexpected Tensor component order. Expected "
                    << spec_component_order);
-      } else if constexpr (tensor.rank() == 2 and tensor.size() == 6) {
+      } else if constexpr (std::decay_t<decltype(tensor)>::rank() == 2 and
+                           std::decay_t<decltype(tensor)>::size() == 6) {
         const std::array<std::string, 6> spec_component_order{
             {"xx", "yx", "zx", "yy", "zy", "zz"}};
         ASSERT(component_name == gsl::at(spec_component_order, component_i),
                "Unexpected Tensor component order. Expected "
                    << spec_component_order);
-      } else if constexpr (tensor.rank() > 0) {
+      } else if constexpr (std::decay_t<decltype(tensor)>::rank() > 0) {
         ASSERT(
             false,
             "Unsupported Tensor type for SpEC import. Only scalars, "

--- a/tests/Unit/Evolution/DgSubcell/Actions/Test_Initialize.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Actions/Test_Initialize.cpp
@@ -314,6 +314,13 @@ void test(const bool always_use_subcell, const bool interior_element,
         evolution::dg::subcell::fd::Tags::DetInverseJacobianLogicalToGrid>(
       runner, 0));
   CHECK(ActionTesting::tag_is_retrievable<
+        comp, evolution::dg::subcell::fd::Tags::
+                  InverseJacobianLogicalToInertial<Dim>>(runner, 0));
+  CHECK(ActionTesting::tag_is_retrievable<
+        comp,
+        evolution::dg::subcell::fd::Tags::DetInverseJacobianLogicalToInertial>(
+      runner, 0));
+  CHECK(ActionTesting::tag_is_retrievable<
         comp,
         evolution::dg::subcell::Tags::Coordinates<Dim, Frame::ElementLogical>>(
       runner, 0));

--- a/tests/Unit/Evolution/DgSubcell/Actions/Test_TakeTimeStep.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Actions/Test_TakeTimeStep.cpp
@@ -87,12 +87,7 @@ struct Metavariables {
 
   struct TimeDerivative {
     template <typename DbTagsList>
-    static void apply(
-        const gsl::not_null<db::DataBox<DbTagsList>*> box,
-        const InverseJacobian<DataVector, Dim, Frame::ElementLogical,
-                              Frame::Grid>&
-            cell_centered_logical_to_grid_inv_jacobian,
-        const Scalar<DataVector>& cell_centered_det_inv_jacobian) {
+    static void apply(const gsl::not_null<db::DataBox<DbTagsList>*> box) {
       time_derivative_invoked = true;
       CHECK(db::get<evolution::dg::subcell::Tags::Mesh<Dim>>(*box) ==
             Mesh<Dim>(5, Spectral::Basis::FiniteDifference,
@@ -101,9 +96,6 @@ struct Metavariables {
           db::get<domain::Tags::ElementMap<Dim, Frame::Grid>>(*box)
               .inv_jacobian(db::get<evolution::dg::subcell::Tags::Coordinates<
                                 Dim, Frame::ElementLogical>>(*box));
-      CHECK(cell_centered_logical_to_grid_inv_jacobian == inv_jacobian);
-      const auto det_inv_jacobian = determinant(inv_jacobian);
-      CHECK_ITERABLE_APPROX(cell_centered_det_inv_jacobian, det_inv_jacobian);
     }
   };
 };

--- a/tests/Unit/Evolution/DgSubcell/Test_Tags.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Test_Tags.cpp
@@ -388,6 +388,9 @@ SPECTRE_TEST_CASE("Unit.Evolution.Subcell.Tags", "[Evolution][Unit]") {
   TestHelpers::db::test_simple_tag<
       subcell::fd::Tags::DetInverseJacobianLogicalToGrid>(
       "Det(InverseJacobian(Logical,Grid))");
+  TestHelpers::db::test_simple_tag<
+      subcell::fd::Tags::DetInverseJacobianLogicalToInertial>(
+      "Det(InverseJacobian(Logical,Inertial))");
   TestHelpers::db::test_simple_tag<subcell::Tags::DidRollback>("DidRollback");
   TestHelpers::db::test_simple_tag<subcell::Tags::Inactive<Var1>>(
       "Inactive(Var1)");

--- a/tests/Unit/Evolution/DgSubcell/Test_Tags.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Test_Tags.cpp
@@ -130,18 +130,18 @@ void test(const bool moving_mesh) {
       "InverseJacobian(Grid,Inertial)");
 
   TestHelpers::db::test_compute_tag<
-      subcell::Tags::ObserverJacobianAndDetInvJacobian<
+      subcell::Tags::ObserverJacobianAndDetInvJacobianCompute<
           Dim, Frame::ElementLogical, Frame::Grid>>(
       "Variables(DetInvJacobian(ElementLogical,Grid),Jacobian(ElementLogical,"
       "Grid))");
   TestHelpers::db::test_compute_tag<
-      subcell::Tags::ObserverJacobianAndDetInvJacobian<
+      subcell::Tags::ObserverJacobianAndDetInvJacobianCompute<
           Dim, Frame::ElementLogical, Frame::Inertial>>(
       "Variables(DetInvJacobian(ElementLogical,Inertial),Jacobian("
       "ElementLogical,Inertial))");
   TestHelpers::db::test_compute_tag<
-      subcell::Tags::ObserverJacobianAndDetInvJacobian<Dim, Frame::Grid,
-                                                       Frame::Inertial>>(
+      subcell::Tags::ObserverJacobianAndDetInvJacobianCompute<Dim, Frame::Grid,
+                                                              Frame::Inertial>>(
       "Variables(DetInvJacobian(Grid,Inertial),Jacobian(Grid,Inertial))");
   TestHelpers::db::test_compute_tag<subcell::Tags::TciStatusCompute<Dim>>(
       "TciStatus");
@@ -210,12 +210,12 @@ void test(const bool moving_mesh) {
               Dim, Frame::ElementLogical, Frame::Inertial>,
           subcell::Tags::ObserverInverseJacobianCompute<Dim, Frame::Grid,
                                                         Frame::Inertial>,
-          subcell::Tags::ObserverJacobianAndDetInvJacobian<
+          subcell::Tags::ObserverJacobianAndDetInvJacobianCompute<
               Dim, Frame::ElementLogical, Frame::Grid>,
-          subcell::Tags::ObserverJacobianAndDetInvJacobian<
+          subcell::Tags::ObserverJacobianAndDetInvJacobianCompute<
               Dim, Frame::ElementLogical, Frame::Inertial>,
-          subcell::Tags::ObserverJacobianAndDetInvJacobian<Dim, Frame::Grid,
-                                                           Frame::Inertial>,
+          subcell::Tags::ObserverJacobianAndDetInvJacobianCompute<
+              Dim, Frame::Grid, Frame::Inertial>,
           subcell::Tags::TciStatusCompute<Dim>,
           subcell::Tags::MethodOrderCompute<Dim>>>(
       ElementMap<Dim, Frame::Grid>{

--- a/tests/Unit/Evolution/Systems/Burgers/Subcell/Test_InitialDataTci.cpp
+++ b/tests/Unit/Evolution/Systems/Burgers/Subcell/Test_InitialDataTci.cpp
@@ -85,17 +85,25 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Burgers.Subcell.InitialDataTci",
     INFO("Test SetInitialRdmpData");
     // While the code is supposed to be used on the subcells, that doesn't
     // actually matter.
+    const auto& dg_u = get<Burgers::Tags::U>(dg_vars);
+    using std::max;
+    using std::min;
+    const auto subcell_u = evolution::dg::subcell::fd::project(
+        get(dg_u), dg_mesh, subcell_mesh.extents());
     evolution::dg::subcell::RdmpTciData rdmp_data{};
     Burgers::subcell::SetInitialRdmpData::apply(
         make_not_null(&rdmp_data), get<Burgers::Tags::U>(dg_vars),
-        evolution::dg::subcell::ActiveGrid::Dg);
-    CHECK(rdmp_data == evolution::dg::subcell::RdmpTciData{});
+        evolution::dg::subcell::ActiveGrid::Dg, dg_mesh, subcell_mesh);
+    const evolution::dg::subcell::RdmpTciData expected_dg_rdmp_data{
+        {max(max(get(dg_u), max(subcell_u)))},
+        {min(min(get(dg_u)), min(subcell_u))}};
+    CHECK(rdmp_data == expected_dg_rdmp_data);
+
     Burgers::subcell::SetInitialRdmpData::apply(
         make_not_null(&rdmp_data), get<Burgers::Tags::U>(dg_vars),
-        evolution::dg::subcell::ActiveGrid::Subcell);
-    const evolution::dg::subcell::RdmpTciData expected_rdmp_data{
-        {max(get(get<Burgers::Tags::U>(dg_vars)))},
-        {min(get(get<Burgers::Tags::U>(dg_vars)))}};
-    CHECK(rdmp_data == expected_rdmp_data);
+        evolution::dg::subcell::ActiveGrid::Subcell, dg_mesh, subcell_mesh);
+    const evolution::dg::subcell::RdmpTciData expected_subcell_rdmp_data{
+        {max(get(dg_u))}, {min(get(dg_u))}};
+    CHECK(rdmp_data == expected_subcell_rdmp_data);
   }
 }

--- a/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/Test_TimeDerivative.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/Test_TimeDerivative.cpp
@@ -162,8 +162,7 @@ double test(const size_t num_dg_pts, std::optional<double> expansion_velocity,
 
   const InverseJacobian<DataVector, 3, Frame::ElementLogical, Frame::Grid>
       cell_centered_logical_to_grid_inv_jacobian =
-          InverseJacobian<DataVector, 3, Frame::ElementLogical, Frame::Grid>(
-              element_map.inv_jacobian(logical_coords));
+          element_map.inv_jacobian(logical_coords);
   InverseJacobian<DataVector, 3, Frame::ElementLogical, Frame::Inertial>
       cell_centered_logical_to_inertial_inv_jacobian =
           InverseJacobian<DataVector, 3, Frame::ElementLogical,
@@ -186,8 +185,7 @@ double test(const size_t num_dg_pts, std::optional<double> expansion_velocity,
 
   const InverseJacobian<DataVector, 3, Frame::ElementLogical, Frame::Grid>
       dg_logical_to_grid_inv_jacobian =
-          InverseJacobian<DataVector, 3, Frame::ElementLogical, Frame::Grid>(
-              element_map.inv_jacobian(logical_coordinates(dg_mesh)));
+          element_map.inv_jacobian(logical_coordinates(dg_mesh));
   InverseJacobian<DataVector, 3, Frame::ElementLogical, Frame::Inertial>
       dg_logical_to_inertial_inv_jacobian =
           InverseJacobian<DataVector, 3, Frame::ElementLogical,
@@ -649,6 +647,11 @@ double test(const size_t num_dg_pts, std::optional<double> expansion_velocity,
                   ::domain::CoordinateMaps::Tags::CoordinateMap<
                       3, Frame::Grid, Frame::Inertial>,
                   3>,
+          evolution::dg::subcell::fd::Tags::
+              DetInverseJacobianLogicalToInertialCompute<
+                  ::domain::CoordinateMaps::Tags::CoordinateMap<
+                      3, Frame::Grid, Frame::Inertial>,
+                  3>,
           domain::Tags::DetInvJacobianCompute<3, Frame::ElementLogical,
                                               Frame::Inertial>,
           gr::Tags::SpatialMetricCompute<DataVector, 3, Frame::Inertial>,
@@ -673,9 +676,9 @@ double test(const size_t num_dg_pts, std::optional<double> expansion_velocity,
           domain::CoordinateMaps::Identity<3>{}),
       std::move(domain), std::move(external_boundary_conditions),
       dg_mesh_velocity, div_dg_mesh_velocity,
-      dg_logical_to_inertial_inv_jacobian,
-      dummy_normal_covector_and_magnitude, time,
-      clone_unique_ptrs(functions_of_time), soln, DummyEvolutionMetaVars{},
+      dg_logical_to_inertial_inv_jacobian, dummy_normal_covector_and_magnitude,
+      time, clone_unique_ptrs(functions_of_time), soln,
+      DummyEvolutionMetaVars{},
       // Note: These damping functions all assume Grid==Inertial. We need to
       // rescale the widths in the Grid frame for binaries.
       std::unique_ptr<DampingFunction>(  // Gamma0, taken from SpEC BNS
@@ -690,9 +693,7 @@ double test(const size_t num_dg_pts, std::optional<double> expansion_velocity,
   db::mutate_apply<ValenciaDivClean::ConservativeFromPrimitive>(
       make_not_null(&box));
 
-  subcell::TimeDerivative::apply(
-      make_not_null(&box), cell_centered_logical_to_grid_inv_jacobian,
-      determinant(cell_centered_logical_to_inertial_inv_jacobian));
+  subcell::TimeDerivative::apply(make_not_null(&box));
 
   // We test that the time derivative converges to zero,
   // so we remove the expected value of the time derivative for moving meshes

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_InitialDataTci.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_InitialDataTci.cpp
@@ -1,6 +1,7 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
+#include "Evolution/DgSubcell/Reconstruction.hpp"
 #include "Framework/TestingFramework.hpp"
 
 #include <cstddef>
@@ -12,6 +13,8 @@
 #include "Evolution/DgSubcell/ActiveGrid.hpp"
 #include "Evolution/DgSubcell/Mesh.hpp"
 #include "Evolution/DgSubcell/Projection.hpp"
+#include "Evolution/DgSubcell/Reconstruction.hpp"
+#include "Evolution/DgSubcell/ReconstructionMethod.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/InitialDataTci.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/System.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
@@ -191,6 +194,8 @@ SPECTRE_TEST_CASE(
     INFO("Test SetInitialRdmpData");
     // While the code is supposed to be used on the subcells, that doesn't
     // actually matter.
+    const auto subcell_vars = evolution::dg::subcell::fd::project(
+        dg_vars, dg_mesh, subcell_mesh.extents());
     evolution::dg::subcell::RdmpTciData rdmp_data{};
     grmhd::ValenciaDivClean::subcell::SetInitialRdmpData::apply(
         make_not_null(&rdmp_data),
@@ -198,16 +203,7 @@ SPECTRE_TEST_CASE(
         get<grmhd::ValenciaDivClean::Tags::TildeYe>(dg_vars),
         get<grmhd::ValenciaDivClean::Tags::TildeTau>(dg_vars),
         get<grmhd::ValenciaDivClean::Tags::TildeB<>>(dg_vars),
-        evolution::dg::subcell::ActiveGrid::Dg);
-    CHECK(rdmp_data == evolution::dg::subcell::RdmpTciData{});
-    grmhd::ValenciaDivClean::subcell::SetInitialRdmpData::apply(
-        make_not_null(&rdmp_data),
-        get<grmhd::ValenciaDivClean::Tags::TildeD>(dg_vars),
-        get<grmhd::ValenciaDivClean::Tags::TildeYe>(dg_vars),
-        get<grmhd::ValenciaDivClean::Tags::TildeTau>(dg_vars),
-        get<grmhd::ValenciaDivClean::Tags::TildeB<>>(dg_vars),
-        evolution::dg::subcell::ActiveGrid::Subcell);
-    evolution::dg::subcell::RdmpTciData expected_rdmp_data{};
+        evolution::dg::subcell::ActiveGrid::Dg, dg_mesh, subcell_mesh);
     const auto& dg_tilde_d =
         get<grmhd::ValenciaDivClean::Tags::TildeD>(dg_vars);
     const auto& dg_tilde_ye =
@@ -216,12 +212,50 @@ SPECTRE_TEST_CASE(
         get<grmhd::ValenciaDivClean::Tags::TildeTau>(dg_vars);
     const auto dg_tilde_b_magnitude =
         magnitude(get<grmhd::ValenciaDivClean::Tags::TildeB<>>(dg_vars));
-    expected_rdmp_data.max_variables_values =
-        DataVector{max(get(dg_tilde_d)), max(get(dg_tilde_ye)),
-                   max(get(dg_tilde_tau)), max(get(dg_tilde_b_magnitude))};
-    expected_rdmp_data.min_variables_values =
-        DataVector{min(get(dg_tilde_d)), min(get(dg_tilde_ye)),
-                   min(get(dg_tilde_tau)), min(get(dg_tilde_b_magnitude))};
-    CHECK(rdmp_data == expected_rdmp_data);
+    const auto& subcell_tilde_d =
+        get<grmhd::ValenciaDivClean::Tags::TildeD>(subcell_vars);
+    const auto& subcell_tilde_ye =
+        get<grmhd::ValenciaDivClean::Tags::TildeYe>(subcell_vars);
+    const auto& subcell_tilde_tau =
+        get<grmhd::ValenciaDivClean::Tags::TildeTau>(subcell_vars);
+    const auto projected_subcell_tilde_b_magnitude =
+        Scalar<DataVector>(evolution::dg::subcell::fd::project(
+            get(dg_tilde_b_magnitude), dg_mesh, subcell_mesh.extents()));
+
+    evolution::dg::subcell::RdmpTciData expected_dg_rdmp_data{};
+    using std::max;
+    using std::min;
+    expected_dg_rdmp_data.max_variables_values =
+        DataVector{max(max(get(dg_tilde_d)), max(get(subcell_tilde_d))),
+                   max(max(get(dg_tilde_ye)), max(get(subcell_tilde_ye))),
+                   max(max(get(dg_tilde_tau)), max(get(subcell_tilde_tau))),
+                   max(max(get(dg_tilde_b_magnitude)),
+                       max(get(projected_subcell_tilde_b_magnitude)))};
+    expected_dg_rdmp_data.min_variables_values =
+        DataVector{min(min(get(dg_tilde_d)), min(get(subcell_tilde_d))),
+                   min(min(get(dg_tilde_ye)), min(get(subcell_tilde_ye))),
+                   min(min(get(dg_tilde_tau)), min(get(subcell_tilde_tau))),
+                   min(min(get(dg_tilde_b_magnitude)),
+                       min(get(projected_subcell_tilde_b_magnitude)))};
+    CHECK(rdmp_data == expected_dg_rdmp_data);
+
+    grmhd::ValenciaDivClean::subcell::SetInitialRdmpData::apply(
+        make_not_null(&rdmp_data),
+        get<grmhd::ValenciaDivClean::Tags::TildeD>(subcell_vars),
+        get<grmhd::ValenciaDivClean::Tags::TildeYe>(subcell_vars),
+        get<grmhd::ValenciaDivClean::Tags::TildeTau>(subcell_vars),
+        get<grmhd::ValenciaDivClean::Tags::TildeB<>>(subcell_vars),
+        evolution::dg::subcell::ActiveGrid::Subcell, dg_mesh, subcell_mesh);
+
+    const auto subcell_tilde_b_magnitude =
+        magnitude(get<grmhd::ValenciaDivClean::Tags::TildeB<>>(subcell_vars));
+    evolution::dg::subcell::RdmpTciData expected_subcell_rdmp_data{};
+    expected_subcell_rdmp_data.max_variables_values = DataVector{
+        max(get(subcell_tilde_d)), max(get(subcell_tilde_ye)),
+        max(get(subcell_tilde_tau)), max(get(subcell_tilde_b_magnitude))};
+    expected_subcell_rdmp_data.min_variables_values = DataVector{
+        min(get(subcell_tilde_d)), min(get(subcell_tilde_ye)),
+        min(get(subcell_tilde_tau)), min(get(subcell_tilde_b_magnitude))};
+    CHECK(rdmp_data == expected_subcell_rdmp_data);
   }
 }

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/Subcell/Test_InitialDataTci.cpp
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/Subcell/Test_InitialDataTci.cpp
@@ -104,23 +104,34 @@ void test() {
     INFO("Test SetInitialRdmpData");
     // While the code is supposed to be used on the subcells, that doesn't
     // actually matter.
-    evolution::dg::subcell::RdmpTciData rdmp_data{};
-    NewtonianEuler::subcell::SetInitialRdmpData<Dim>::apply(
-        make_not_null(&rdmp_data), dg_vars,
-        evolution::dg::subcell::ActiveGrid::Dg);
-    CHECK(rdmp_data == evolution::dg::subcell::RdmpTciData{});
-    NewtonianEuler::subcell::SetInitialRdmpData<Dim>::apply(
-        make_not_null(&rdmp_data), dg_vars,
-        evolution::dg::subcell::ActiveGrid::Subcell);
+    using std::max;
+    using std::min;
     const auto& dg_mass_density =
         get<NewtonianEuler::Tags::MassDensityCons>(dg_vars);
     const auto& dg_energy_density =
         get<NewtonianEuler::Tags::EnergyDensity>(dg_vars);
-    const evolution::dg::subcell::RdmpTciData expected_rdmp_data{
+    const auto subcell_mass_density = evolution::dg::subcell::fd::project(
+        get(dg_mass_density), dg_mesh, subcell_mesh.extents());
+    const auto subcell_energy_density = evolution::dg::subcell::fd::project(
+        get(dg_energy_density), dg_mesh, subcell_mesh.extents());
+    evolution::dg::subcell::RdmpTciData rdmp_data{};
+    NewtonianEuler::subcell::SetInitialRdmpData<Dim>::apply(
+        make_not_null(&rdmp_data), dg_vars,
+        evolution::dg::subcell::ActiveGrid::Dg, dg_mesh, subcell_mesh);
+    const evolution::dg::subcell::RdmpTciData expected_dg_rdmp_data{
+        {max(max(get(dg_mass_density)), max(subcell_mass_density)),
+         max(max(get(dg_energy_density)), max(subcell_energy_density))},
+        {min(min(get(dg_mass_density)), min(subcell_mass_density)),
+         min(min(get(dg_energy_density)), min(subcell_energy_density))}};
+    CHECK(rdmp_data == expected_dg_rdmp_data);
+
+    NewtonianEuler::subcell::SetInitialRdmpData<Dim>::apply(
+        make_not_null(&rdmp_data), dg_vars,
+        evolution::dg::subcell::ActiveGrid::Subcell, dg_mesh, subcell_mesh);
+    const evolution::dg::subcell::RdmpTciData expected_subcell_rdmp_data{
         {max(get(dg_mass_density)), max(get(dg_energy_density))},
         {min(get(dg_mass_density)), min(get(dg_energy_density))}};
-
-    CHECK(rdmp_data == expected_rdmp_data);
+    CHECK(rdmp_data == expected_subcell_rdmp_data);
   }
 }
 }  // namespace

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/Subcell/Test_TimeDerivative.cpp
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/Subcell/Test_TimeDerivative.cpp
@@ -18,6 +18,7 @@
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.tpp"
+#include "Domain/CoordinateMaps/Identity.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.tpp"
 #include "Domain/CreateInitialElement.hpp"
@@ -227,7 +228,9 @@ std::array<double, 3> test(const size_t num_dg_pts) {
           typename system::primitive_variables_tag, dt_variables_tag,
           variables_tag,
           evolution::dg::subcell::Tags::GhostDataForReconstruction<dim>,
-          evolution::dg::Tags::MortarData<dim>>,
+          evolution::dg::Tags::MortarData<dim>,
+          domain::CoordinateMaps::Tags::CoordinateMap<dim, Frame::Grid,
+                                                      Frame::Inertial>>,
       db::AddComputeTags<
           evolution::dg::subcell::Tags::LogicalCoordinatesCompute<dim>>>(
       metavariables{}, typename metavariables::source_term_tag::type{}, soln,
@@ -241,7 +244,9 @@ std::array<double, 3> test(const size_t num_dg_pts) {
       Variables<typename dt_variables_tag::tags_list>{
           subcell_mesh.number_of_grid_points()},
       typename variables_tag::type{}, neighbor_data,
-      typename evolution::dg::Tags::MortarData<dim>::type{});
+      typename evolution::dg::Tags::MortarData<dim>::type{},
+      domain::make_coordinate_map_base<Frame::Grid, Frame::Inertial>(
+          domain::CoordinateMaps::Identity<dim>{}));
   db::mutate_apply<ConservativeFromPrimitive<dim>>(make_not_null(&box));
 
   InverseJacobian<DataVector, dim, Frame::ElementLogical, Frame::Grid>


### PR DESCRIPTION
## Proposed changes

Various cleanups for moving mesh and work towards starting on the FD grid instead of the DG grid.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
