### PR TITLE
Add Dirichlet boundary condition for CurvedScalarWave

### DIFF
--- a/src/Evolution/Systems/CurvedScalarWave/BoundaryConditions/AnalyticConstant.cpp
+++ b/src/Evolution/Systems/CurvedScalarWave/BoundaryConditions/AnalyticConstant.cpp
@@ -1,0 +1,86 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/CurvedScalarWave/BoundaryConditions/AnalyticConstant.hpp"
+
+#include <cstddef>
+#include <memory>
+#include <optional>
+#include <pup.h>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Evolution/Systems/CurvedScalarWave/Characteristics.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/MakeString.hpp"
+
+namespace CurvedScalarWave::BoundaryConditions {
+
+template <size_t Dim>
+std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
+AnalyticConstant<Dim>::get_clone() const {
+  return std::make_unique<AnalyticConstant>(*this);
+}
+
+template <size_t Dim>
+void AnalyticConstant<Dim>::pup(PUP::er& p) {
+  BoundaryCondition<Dim>::pup(p);
+  p | amplitude_;
+}
+
+template <size_t Dim>
+AnalyticConstant<Dim>::AnalyticConstant(CkMigrateMessage* const msg)
+    : BoundaryCondition<Dim>(msg) {}
+
+template <size_t Dim>
+AnalyticConstant<Dim>::AnalyticConstant(const double amplitude)
+    : amplitude_(amplitude) {}
+
+template <size_t Dim>
+std::optional<std::string> AnalyticConstant<Dim>::dg_ghost(
+    const gsl::not_null<Scalar<DataVector>*> psi,
+    const gsl::not_null<Scalar<DataVector>*> pi,
+    const gsl::not_null<tnsr::i<DataVector, Dim, Frame::Inertial>*> phi,
+    const gsl::not_null<Scalar<DataVector>*> lapse,
+    const gsl::not_null<tnsr::I<DataVector, Dim>*> shift,
+    const gsl::not_null<Scalar<DataVector>*> gamma1,
+    const gsl::not_null<Scalar<DataVector>*> gamma2,
+    const gsl::not_null<tnsr::II<DataVector, Dim, Frame::Inertial>*>
+        inverse_spatial_metric,
+    const std::optional<tnsr::I<DataVector, Dim, Frame::Inertial>>&
+    /*face_mesh_velocity*/,
+    const tnsr::i<DataVector, Dim>& /*normal_covector*/,
+    const tnsr::I<DataVector, Dim>& /*normal_vector*/,
+    const tnsr::II<DataVector, Dim, Frame::Inertial>&
+        inverse_spatial_metric_interior,
+    const Scalar<DataVector>& gamma1_interior,
+    const Scalar<DataVector>& gamma2_interior,
+    const Scalar<DataVector>& lapse_interior,
+    const tnsr::I<DataVector, Dim>& shift_interior) const {
+  *psi = make_with_value<Scalar<DataVector>>(gamma1_interior, amplitude_);
+  *pi = make_with_value<Scalar<DataVector>>(gamma1_interior, 0.0);
+  *phi = make_with_value<tnsr::i<DataVector, Dim, Frame::Inertial>>(
+      gamma1_interior, 0.0);
+  *lapse = lapse_interior;
+  *shift = shift_interior;
+  *inverse_spatial_metric = inverse_spatial_metric_interior;
+  *gamma1 = gamma1_interior;
+  *gamma2 = gamma2_interior;
+
+  return {};
+}
+
+template <size_t Dim>
+// NOLINTNEXTLINE
+PUP::able::PUP_ID AnalyticConstant<Dim>::my_PUP_ID = 0;
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATION(r, data) template class AnalyticConstant<DIM(data)>;
+
+GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
+
+#undef INSTANTIATION
+#undef DIM
+}  // namespace CurvedScalarWave::BoundaryConditions

--- a/src/Evolution/Systems/CurvedScalarWave/BoundaryConditions/AnalyticConstant.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/BoundaryConditions/AnalyticConstant.hpp
@@ -1,0 +1,101 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <memory>
+#include <optional>
+#include <pup.h>
+#include <string>
+#include <type_traits>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/FaceNormal.hpp"
+#include "Evolution/BoundaryConditions/Type.hpp"
+#include "Evolution/Systems/CurvedScalarWave/BoundaryConditions/BoundaryCondition.hpp"
+#include "Evolution/Systems/CurvedScalarWave/Tags.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Utilities/Serialization/CharmPupable.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+namespace domain::Tags {
+template <size_t Dim, typename Frame>
+struct Coordinates;
+}  // namespace domain::Tags
+/// \endcond
+
+namespace CurvedScalarWave::BoundaryConditions {
+/// A `BoundaryCondition` that imposes the scalar to be constant at the
+/// outer boundary.
+template <size_t Dim>
+class AnalyticConstant final : public BoundaryCondition<Dim> {
+ public:
+  struct Amplitude {
+    using type = double;
+    static constexpr Options::String help = {
+        "Amplitude of the scalar at the boundary"};
+  };
+  using options = tmpl::list<Amplitude>;
+  static constexpr Options::String help{
+      "Boundary conditions which impose a constant scalar at the boundary."};
+
+  AnalyticConstant(double amplitude);
+  AnalyticConstant() = default;
+  /// \cond
+  AnalyticConstant(AnalyticConstant&&) = default;
+  AnalyticConstant& operator=(AnalyticConstant&&) = default;
+  AnalyticConstant(const AnalyticConstant&) = default;
+  AnalyticConstant& operator=(const AnalyticConstant&) = default;
+  /// \endcond
+  ~AnalyticConstant() override = default;
+
+  explicit AnalyticConstant(CkMigrateMessage* msg);
+
+  WRAPPED_PUPable_decl_base_template(
+      domain::BoundaryConditions::BoundaryCondition, AnalyticConstant);
+
+  auto get_clone() const -> std::unique_ptr<
+      domain::BoundaryConditions::BoundaryCondition> override;
+
+  static constexpr evolution::BoundaryConditions::Type bc_type =
+      evolution::BoundaryConditions::Type::Ghost;
+
+  void pup(PUP::er& p) override;
+
+  using dg_interior_evolved_variables_tags = tmpl::list<>;
+  using dg_interior_temporary_tags = tmpl::list<
+      gr::Tags::InverseSpatialMetric<DataVector, Dim, Frame::Inertial>,
+      Tags::ConstraintGamma1, Tags::ConstraintGamma2,
+      gr::Tags::Lapse<DataVector>,
+      gr::Tags::Shift<DataVector, Dim, Frame::Inertial>>;
+  using dg_interior_dt_vars_tags = tmpl::list<>;
+  using dg_interior_deriv_vars_tags = tmpl::list<>;
+  using dg_gridless_tags = tmpl::list<>;
+
+  std::optional<std::string> dg_ghost(
+      const gsl::not_null<Scalar<DataVector>*> psi,
+      const gsl::not_null<Scalar<DataVector>*> pi,
+      const gsl::not_null<tnsr::i<DataVector, Dim, Frame::Inertial>*> phi,
+      const gsl::not_null<Scalar<DataVector>*> lapse,
+      const gsl::not_null<tnsr::I<DataVector, Dim>*> shift,
+      const gsl::not_null<Scalar<DataVector>*> gamma1,
+      const gsl::not_null<Scalar<DataVector>*> gamma2,
+      const gsl::not_null<tnsr::II<DataVector, Dim, Frame::Inertial>*>
+          inverse_spatial_metric,
+      const std::optional<tnsr::I<DataVector, Dim, Frame::Inertial>>&
+      /*face_mesh_velocity*/,
+      const tnsr::i<DataVector, Dim>& /*normal_covector*/,
+      const tnsr::I<DataVector, Dim>& /*normal_vector*/,
+      const tnsr::II<DataVector, Dim, Frame::Inertial>&
+          inverse_spatial_metric_interior,
+      const Scalar<DataVector>& gamma1_interior,
+      const Scalar<DataVector>& gamma2_interior,
+      const Scalar<DataVector>& lapse_interior,
+      const tnsr::I<DataVector, Dim>& shift_interior) const;
+
+ private:
+  double amplitude_ = std::numeric_limits<double>::signaling_NaN();
+};
+}  // namespace CurvedScalarWave::BoundaryConditions

--- a/src/Evolution/Systems/CurvedScalarWave/BoundaryConditions/CMakeLists.txt
+++ b/src/Evolution/Systems/CurvedScalarWave/BoundaryConditions/CMakeLists.txt
@@ -4,6 +4,7 @@
 spectre_target_sources(
   ${LIBRARY}
   PRIVATE
+  AnalyticConstant.cpp
   ConstraintPreservingSphericalRadiation.cpp
   BoundaryCondition.cpp
   DemandOutgoingCharSpeeds.cpp
@@ -14,6 +15,7 @@ spectre_target_headers(
   ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
+  AnalyticConstant.hpp
   ConstraintPreservingSphericalRadiation.hpp
   BoundaryCondition.hpp
   DemandOutgoingCharSpeeds.hpp

--- a/src/Evolution/Systems/CurvedScalarWave/BoundaryConditions/Factory.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/BoundaryConditions/Factory.hpp
@@ -6,6 +6,7 @@
 #include <cstddef>
 
 #include "Domain/BoundaryConditions/Periodic.hpp"
+#include "Evolution/Systems/CurvedScalarWave/BoundaryConditions/AnalyticConstant.hpp"
 #include "Evolution/Systems/CurvedScalarWave/BoundaryConditions/ConstraintPreservingSphericalRadiation.hpp"
 #include "Evolution/Systems/CurvedScalarWave/BoundaryConditions/DemandOutgoingCharSpeeds.hpp"
 #include "Utilities/TMPL.hpp"
@@ -14,7 +15,8 @@ namespace CurvedScalarWave::BoundaryConditions {
 /// Typelist of standard BoundaryConditions
 template <size_t Dim>
 using standard_boundary_conditions =
-    tmpl::list<ConstraintPreservingSphericalRadiation<Dim>,
+    tmpl::list<AnalyticConstant<Dim>,
+               ConstraintPreservingSphericalRadiation<Dim>,
                DemandOutgoingCharSpeeds<Dim>,
                domain::BoundaryConditions::Periodic<BoundaryCondition<Dim>>>;
 }  // namespace CurvedScalarWave::BoundaryConditions

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/BoundaryConditions/AnalyticConstant.py
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/BoundaryConditions/AnalyticConstant.py
@@ -1,0 +1,108 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+
+
+def error(
+    face_mesh_velocity,
+    normal_covector,
+    normal_vector,
+    inverse_spatial_metric_interior,
+    gamma1_interior,
+    gamma2_interior,
+    lapse_interior,
+    shift_interior,
+):
+    return None
+
+
+def psi_analytic_constant(
+    face_mesh_velocity,
+    normal_covector,
+    normal_vector,
+    inverse_spatial_metric_interior,
+    gamma1_interior,
+    gamma2_interior,
+    lapse_interior,
+    shift_interior,
+):
+    return 2.71
+
+
+def pi_analytic_constant(
+    face_mesh_velocity,
+    normal_covector,
+    normal_vector,
+    inverse_spatial_metric_interior,
+    gamma1_interior,
+    gamma2_interior,
+    lapse_interior,
+    shift_interior,
+):
+    return 0.0
+
+
+def phi_analytic_constant(
+    face_mesh_velocity,
+    normal_covector,
+    normal_vector,
+    inverse_spatial_metric_interior,
+    gamma1_interior,
+    gamma2_interior,
+    lapse_interior,
+    shift_interior,
+):
+    return 0.0 * shift_interior
+
+
+def lapse_analytic_constant(
+    face_mesh_velocity,
+    normal_covector,
+    normal_vector,
+    inverse_spatial_metric_interior,
+    gamma1_interior,
+    gamma2_interior,
+    lapse_interior,
+    shift_interior,
+):
+    return lapse_interior
+
+
+def shift_analytic_constant(
+    face_mesh_velocity,
+    normal_covector,
+    normal_vector,
+    inverse_spatial_metric_interior,
+    gamma1_interior,
+    gamma2_interior,
+    lapse_interior,
+    shift_interior,
+):
+    return shift_interior
+
+
+def constraint_gamma1_analytic_constant(
+    face_mesh_velocity,
+    normal_covector,
+    normal_vector,
+    inverse_spatial_metric_interior,
+    gamma1_interior,
+    gamma2_interior,
+    lapse_interior,
+    shift_interior,
+):
+    return gamma1_interior
+
+
+def constraint_gamma2_analytic_constant(
+    face_mesh_velocity,
+    normal_covector,
+    normal_vector,
+    inverse_spatial_metric_interior,
+    gamma1_interior,
+    gamma2_interior,
+    lapse_interior,
+    shift_interior,
+):
+    return gamma2_interior

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/BoundaryConditions/Test_AnalyticConstant.cpp
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/BoundaryConditions/Test_AnalyticConstant.cpp
@@ -1,0 +1,66 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <string>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/Index.hpp"
+#include "Evolution/Systems/CurvedScalarWave/BoundaryConditions/AnalyticConstant.hpp"
+#include "Evolution/Systems/CurvedScalarWave/BoundaryConditions/Factory.hpp"
+#include "Evolution/Systems/CurvedScalarWave/BoundaryCorrections/UpwindPenalty.hpp"
+#include "Evolution/Systems/CurvedScalarWave/System.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/Evolution/DiscontinuousGalerkin/BoundaryConditions.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace helpers = TestHelpers::evolution::dg;
+namespace {
+
+template <size_t Dim>
+void test() {
+  MAKE_GENERATOR(gen);
+
+  helpers::test_boundary_condition_with_python<
+      CurvedScalarWave::BoundaryConditions::AnalyticConstant<Dim>,
+      CurvedScalarWave::BoundaryConditions::BoundaryCondition<Dim>,
+      CurvedScalarWave::System<Dim>,
+      tmpl::list<CurvedScalarWave::BoundaryCorrections::UpwindPenalty<Dim>>>(
+      make_not_null(&gen),
+      "Evolution.Systems.CurvedScalarWave.BoundaryConditions."
+      "AnalyticConstant",
+      tuples::TaggedTuple<
+          helpers::Tags::PythonFunctionForErrorMessage<>,
+          helpers::Tags::PythonFunctionName<CurvedScalarWave::Tags::Psi>,
+          helpers::Tags::PythonFunctionName<CurvedScalarWave::Tags::Pi>,
+          helpers::Tags::PythonFunctionName<CurvedScalarWave::Tags::Phi<Dim>>,
+          helpers::Tags::PythonFunctionName<gr::Tags::Lapse<DataVector>>,
+          helpers::Tags::PythonFunctionName<gr::Tags::Shift<DataVector, Dim>>,
+          helpers::Tags::PythonFunctionName<
+              CurvedScalarWave::Tags::ConstraintGamma1>,
+          helpers::Tags::PythonFunctionName<
+              CurvedScalarWave::Tags::ConstraintGamma2>>{
+          "error", "psi_analytic_constant", "pi_analytic_constant",
+          "phi_analytic_constant", "lapse_analytic_constant",
+          "shift_analytic_constant", "constraint_gamma1_analytic_constant",
+          "constraint_gamma2_analytic_constant"},
+      "AnalyticConstant:\n"
+      "  Amplitude: 2.71\n",
+      Index<Dim - 1>{Dim == 1 ? 0 : 5}, db::DataBox<tmpl::list<>>{},
+      tuples::TaggedTuple<>{});
+}
+}  // namespace
+SPECTRE_TEST_CASE(
+    "Unit.CurvedScalarWave.BoundaryConditions.AnalyticConstant",
+    "[Unit][Evolution]") {
+  pypp::SetupLocalPythonEnvironment local_python_env{""};
+  test<1>();
+  test<2>();
+  test<3>();
+}

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY "Test_CurvedScalarWave")
 
 set(LIBRARY_SOURCES
   BoundaryCorrections/Test_UpwindPenalty.cpp
+  BoundaryConditions/Test_AnalyticConstant.cpp
   BoundaryConditions/Test_ConstraintPreservingSphericalRadiation.cpp
   BoundaryConditions/Test_DemandOutgoingCharSpeeds.cpp
   BoundaryConditions/Test_Worldtube.cpp


### PR DESCRIPTION
## Proposed changes

I propose to add this simple boundary condition (BC) for CurvedScalarWave (CSW) in order to be able to write a fully Ghost type boundary condition for the ScalarTensor system (#5235). This is because they are the simplest conditions to implement in the combined system and also because the CSW constraint preserving BCs may not trivially generalize to the ScalarTensor system (where the metric is evolving as well).


<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
