### PR TITLE
Dynamically link FFTW3 if SpEC uses it

### DIFF
--- a/cmake/FindSpEC.cmake
+++ b/cmake/FindSpEC.cmake
@@ -45,6 +45,33 @@ find_package(MPI COMPONENTS C)
 
 if (SPEC_PACKAGED_EXPORTER_LIB AND SPEC_EXPORTER_FACTORY_OBJECTS AND
     SPEC_EXPORTER_INCLUDE_DIR AND MPI_C_FOUND)
+
+  # Deal with FFTW3
+  #
+  # If it was dynamically linked into SpEC then we need to dynamically link it
+  # into SpECTRE.
+  set(_MACHINE_DEF_FILE
+    ${SPEC_ROOT}/MakefileRules/this_machine.def)
+  set(_FFTW3_LINK_FLAGS "")
+  if (EXISTS ${_MACHINE_DEF_FILE})
+    file(STRINGS ${_MACHINE_DEF_FILE} _MACHINE_DEF)
+    # Filter starting comments
+    list(FILTER _MACHINE_DEF EXCLUDE REGEX "^[ ]*#")
+    # Remove inline comments
+    list(TRANSFORM _MACHINE_DEF REPLACE "[ ]*#.*" "")
+    string(REGEX MATCH "FFTW_LIB[^;]+"
+      _FFTW3_DEF "${_MACHINE_DEF}")
+    string(REGEX REPLACE
+      "FFTW_LIB[ +]+=[ ]" ""
+      _FFTW3_LINK_FLAGS
+      ${_FFTW3_DEF})
+    string(FIND ${_FFTW3_DEF} "-lfftw3" _FOUND_FFTW3_SHARED)
+    # If we did not find a shared lib, do not add linking flags.
+    if(${_FOUND_FFTW3_SHARED} STREQUAL -1)
+      set(_FFTW3_LINK_FLAGS "")
+    endif()
+  endif()
+
   add_library(SpEC::Exporter INTERFACE IMPORTED)
   target_include_directories(
     SpEC::Exporter INTERFACE ${SPEC_EXPORTER_INCLUDE_DIR})
@@ -60,6 +87,7 @@ if (SPEC_PACKAGED_EXPORTER_LIB AND SPEC_EXPORTER_FACTORY_OBJECTS AND
     # The order of these next two lines is important
     ${SPEC_EXPORTER_FACTORY_OBJECTS}
     ${SPEC_PACKAGED_EXPORTER_LIB}
+    ${_FFTW3_LINK_FLAGS}
   )
 endif()
 


### PR DESCRIPTION
## Proposed changes

Checks if SpEC links FFTW3 dynamically, and if so adds the dynamic linking flags.

Could someone test on Wheeler and/or Caltech HPC to make sure I'm not breaking production runs?

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
