### PR TITLE
Fix commit hook for older clang-format versions

### DIFF
--- a/tools/Hooks/pre-commit.sh
+++ b/tools/Hooks/pre-commit.sh
@@ -36,19 +36,20 @@ printf '%s\0' "${commit_files[@]}" | \
 # Use git-clang-format to check for any suspicious formatting of code.
 @CLANG_FORMAT_BIN@ --version > /dev/null
 if [ $? -eq 0 ]; then
-    clang_format_diffstat=$(@GIT_EXECUTABLE@ --no-pager \
-        clang-format --binary @CLANG_FORMAT_BIN@ --diffstat --quiet)
+    clang_format_diff=$(@GIT_EXECUTABLE@ --no-pager \
+        clang-format --binary @CLANG_FORMAT_BIN@ --diff --quiet)
     # Clang-format didn't always return the right exit code before version 15,
-    # so we check the diffstat output instead (see issue:
+    # so we check the diff output instead (see issue:
     # https://github.com/llvm/llvm-project/issues/54758)
-    if [ -n "$clang_format_diffstat" ]; then
-        @GIT_EXECUTABLE@ clang-format --binary @CLANG_FORMAT_BIN@ --diff \
-            > @CMAKE_SOURCE_DIR@/.clang_format_diff.patch
-        echo "Found C++ formatting errors:"
-        echo "$clang_format_diffstat"
+    if [ -n "$clang_format_diff" ] \
+        && [[ "$clang_format_diff" != *"no modified files to format"* ]] \
+        && [[ "$clang_format_diff" != *"did not modify any files"* ]]; then
+        echo "$clang_format_diff" > @CMAKE_SOURCE_DIR@/.clang_format_diff.patch
+        echo "Found C++ formatting errors."
         echo "Please run 'git clang-format' in the repository."
         echo "You can also apply the patch directly:"
         echo "git apply @CMAKE_SOURCE_DIR@/.clang_format_diff.patch"
+        echo ""
     fi
 fi
 


### PR DESCRIPTION
## Proposed changes

Fixes #5249 . @knelli2 could you confirm?

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
