### PR TITLE
Fix GH harmonic gauge FPEs

### DIFF
--- a/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Gauges.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Gauges.hpp
@@ -34,6 +34,8 @@ class GaugeCondition : public PUP::able {
   WRAPPED_PUPable_abstract(GaugeCondition);  // NOLINT
 
   virtual std::unique_ptr<GaugeCondition> get_clone() const = 0;
+
+  virtual bool is_harmonic() const { return false; }
 };
 }  // namespace gauges
 }  // namespace gh

--- a/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Harmonic.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Harmonic.cpp
@@ -38,6 +38,8 @@ void Harmonic::gauge_and_spacetime_derivative(
   }
 }
 
+bool Harmonic::is_harmonic() const { return true; }
+
 // NOLINTNEXTLINE
 PUP::able::PUP_ID Harmonic::my_PUP_ID = 0;
 

--- a/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Harmonic.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Harmonic.hpp
@@ -56,5 +56,7 @@ class Harmonic final : public GaugeCondition {
   void pup(PUP::er& p) override;
 
   std::unique_ptr<GaugeCondition> get_clone() const override;
+
+  bool is_harmonic() const override;
 };
 }  // namespace gh::gauges

--- a/src/Evolution/Systems/GeneralizedHarmonic/TimeDerivative.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/TimeDerivative.cpp
@@ -268,19 +268,6 @@ void TimeDerivative<Dim>::apply(
     for (size_t nu = 0; nu < Dim + 1; ++nu) {
       gauge_constraint->get(nu) += gauge_function->get(nu);
     }
-  } else {
-#ifdef SPECTRE_DEBUG
-    get(*sqrt_det_spatial_metric) =
-        std::numeric_limits<double>::signaling_NaN();
-    for (size_t mu = 0; mu < Dim + 1; ++mu) {
-      for (size_t nu = 0; nu < Dim + 1; ++nu) {
-        for (size_t rho = 0; rho < Dim + 1; ++rho) {
-          christoffel_second_kind->get(mu, nu, rho) =
-              std::numeric_limits<double>::signaling_NaN();
-        }
-      }
-    }
-#endif
   }
 
   get(*normal_dot_gauge_constraint) =

--- a/src/Evolution/Systems/GeneralizedHarmonic/TimeDerivative.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/TimeDerivative.cpp
@@ -251,8 +251,7 @@ void TimeDerivative<Dim>::apply(
     }
   }
 
-  const bool using_harmonic_gauge =
-      dynamic_cast<const gauges::Harmonic*>(&gauge_condition) != nullptr;
+  const bool using_harmonic_gauge = gauge_condition.is_harmonic();
   if (not using_harmonic_gauge) {
     // Compute gauge condition.
     get(*sqrt_det_spatial_metric) = sqrt(get(*det_spatial_metric));

--- a/src/Evolution/Systems/GeneralizedHarmonic/TimeDerivative.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/TimeDerivative.cpp
@@ -257,11 +257,13 @@ void TimeDerivative<Dim>::apply(
     get(*sqrt_det_spatial_metric) = sqrt(get(*det_spatial_metric));
     raise_or_lower_first_index(christoffel_second_kind, *christoffel_first_kind,
                                *inverse_spacetime_metric);
-    gauges::dispatch<Dim>(
-        gauge_function, spacetime_deriv_gauge_function, *lapse, *shift,
-        *sqrt_det_spatial_metric, *inverse_spatial_metric, *da_spacetime_metric,
-        *half_pi_two_normals, *half_phi_two_normals, spacetime_metric, phi,
-        mesh, time, inertial_coords, inverse_jacobian, gauge_condition);
+  }
+  gauges::dispatch<Dim>(
+      gauge_function, spacetime_deriv_gauge_function, *lapse, *shift,
+      *sqrt_det_spatial_metric, *inverse_spatial_metric, *da_spacetime_metric,
+      *half_pi_two_normals, *half_phi_two_normals, spacetime_metric, phi, mesh,
+      time, inertial_coords, inverse_jacobian, gauge_condition);
+  if (not using_harmonic_gauge) {
     // Compute source function last so that we don't need to recompute any of
     // the other temporary tags.
     for (size_t nu = 0; nu < Dim + 1; ++nu) {

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/TimeDerivative.hpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/TimeDerivative.hpp
@@ -186,6 +186,11 @@ struct ComputeTimeDerivImpl<
         db::get<evolution::dg::subcell::Tags::Mesh<3>>(*box), time,
         inertial_coords, cell_centered_logical_to_inertial_inv_jacobian,
         mesh_velocity_subcell);
+    if (get<gh::gauges::Tags::GaugeCondition>(*box).is_harmonic()) {
+      get(get<gr::Tags::SqrtDetSpatialMetric<DataVector>>(*temp_tags_ptr)) =
+          sqrt(
+              get(get<gr::Tags::DetSpatialMetric<DataVector>>(*temp_tags_ptr)));
+    }
 
     // Add source terms from moving mesh
     if (mesh_velocity_dg.has_value()) {

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/TimeDerivativeTerms.hpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/TimeDerivativeTerms.hpp
@@ -12,6 +12,7 @@
 #include "DataStructures/TaggedContainers.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Evolution/PassVariables.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Harmonic.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/System.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/TimeDerivative.hpp"
 #include "Evolution/Systems/GrMhd/GhValenciaDivClean/StressEnergy.hpp"
@@ -84,6 +85,13 @@ struct TimeDerivativeTermsImpl<
         get<GhDtTags>(dt_vars_ptr)..., get<GhTempTags>(temps_ptr)...,
         d_spacetime_metric, d_pi, d_phi,
         get<Tags::detail::TemporaryReference<GhArgTags>>(arguments)...);
+
+    if (get<Tags::detail::TemporaryReference<gh::gauges::Tags::GaugeCondition>>(
+            arguments)
+            .is_harmonic()) {
+      get(get<gr::Tags::SqrtDetSpatialMetric<DataVector>>(*temps_ptr)) =
+          sqrt(get(get<gr::Tags::DetSpatialMetric<DataVector>>(*temps_ptr)));
+    }
 
     for (size_t i = 0; i < 3; ++i) {
       get<::Tags::deriv<gr::Tags::Lapse<DataVector>, tmpl::size_t<3>,

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Test_AnalyticChristoffel.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Test_AnalyticChristoffel.cpp
@@ -87,6 +87,7 @@ void test_gauge_wave(const Mesh<Dim>& mesh) {
                                                      "      Amplitude: 0.0012\n"
                                                      "      Wavelength: 1.4\n")
           ->get_clone());
+  CHECK_FALSE(gauge_condition->is_harmonic());
 
   const size_t num_points = mesh.number_of_grid_points();
 
@@ -122,6 +123,7 @@ void test_ks(const Mesh<3>& mesh) {
           "      Spin: [0.1, 0.2, 0.3]\n"
           "      Center: [-0.1, -0.2, -0.4]\n")
           ->get_clone());
+  CHECK_FALSE(gauge_condition->is_harmonic());
 
   const size_t num_points = mesh.number_of_grid_points();
 

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Test_DampedHarmonic.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Test_DampedHarmonic.cpp
@@ -214,6 +214,7 @@ void test_derived_class(const Mesh<Dim>& mesh) {
           "  Amplitudes: [0.5, 1.5, 2.5]\n"
           "  Exponents: [2, 4, 6]\n")
           ->get_clone());
+  CHECK_FALSE(gauge_condition->is_harmonic());
 
   const size_t num_points = mesh.number_of_grid_points();
 

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Test_Harmonic.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Test_Harmonic.cpp
@@ -36,6 +36,7 @@ void test() {
       TestHelpers::test_creation<std::unique_ptr<gh::gauges::GaugeCondition>,
                                  Metavariables>("Harmonic:")
           ->get_clone());
+  CHECK(gauge_condition->is_harmonic());
 
   const size_t num_points = 5;
   tnsr::a<DataVector, Dim, Frame::Inertial> gauge_h(num_points);


### PR DESCRIPTION
## Proposed changes

The constraint-preserving BCs need H_a and d_a H_b. We could propagate whether we are using harmonic gauge through, but that's a pretty big change I don't have time for right now. This will still elide _most_ of the work for (d_b) H_a=0, except actually setting the numerical values to zero. The boundary condition could be optimized separately.

As-is, I believe all GH simulations that use harmonic gauge and constraint preserving BCs are broken in develop.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
