### PR TITLE
Add Mutator protocol

### DIFF
--- a/src/DataStructures/DataBox/CMakeLists.txt
+++ b/src/DataStructures/DataBox/CMakeLists.txt
@@ -18,3 +18,5 @@ spectre_target_headers(
   TagName.hpp
   TagTraits.hpp
   )
+
+add_subdirectory(Protocols)

--- a/src/DataStructures/DataBox/Protocols/CMakeLists.txt
+++ b/src/DataStructures/DataBox/Protocols/CMakeLists.txt
@@ -5,7 +5,5 @@ spectre_target_headers(
   ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
-  CreatedFromOptionsTagAdder.hpp
   Mutator.hpp
-  OptionCreatableTag.hpp
   )

--- a/src/DataStructures/DataBox/Protocols/CMakeLists.txt
+++ b/src/DataStructures/DataBox/Protocols/CMakeLists.txt
@@ -1,0 +1,11 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+spectre_target_headers(
+  ${LIBRARY}
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  CreatedFromOptionsTagAdder.hpp
+  Mutator.hpp
+  OptionCreatableTag.hpp
+  )

--- a/src/DataStructures/DataBox/Protocols/Mutator.hpp
+++ b/src/DataStructures/DataBox/Protocols/Mutator.hpp
@@ -25,6 +25,7 @@ namespace db::protocols {
 ///      - A `const db::const_item_type<Tag, BoxTags>` for each `Tag` in
 ///        `argument_tags`
 ///      - The additional arguments passed to `db::mutate_apply`
+///
 ///   Note: use the explicit type whenever possible, not the type aliases.
 ///   `db::const_item_type` will usually be `Tag::type` unless that is a
 ///   `std::unique_ptr<T>`, in which case it will be `T`

--- a/src/DataStructures/DataBox/Protocols/Mutator.hpp
+++ b/src/DataStructures/DataBox/Protocols/Mutator.hpp
@@ -1,0 +1,42 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <type_traits>
+
+#include "Utilities/ProtocolHelpers.hpp"
+
+namespace db::protocols {
+
+/// \brief A DataBox mutator
+///
+/// A class conforming to this protocol can be used as the template argument for
+/// a call to db::mutate_apply(const gsl::not_null<DataBox<BoxTags>*> box,
+/// Args&&... args).  The conforming class must provide the following:
+///
+/// - `return_tags`: A type list of tags corresponding to mutable items in the
+///   DataBox passed to `db::mutate_apply` that may be modified.
+/// - `argument_tags`: A type list of tags corresponding to items in the DataBox
+///   passed to `db::mutate_apply` that may not be modified.
+/// - `apply`: A static function whose return value is returned by
+///   `db::mutate_apply`, and that takes as arguments:
+///      - A `const gsl::not_null<Tag::type*>` for each `Tag` in `return_tags`
+///      - A `const db::const_item_type<Tag, BoxTags>` for each `Tag` in
+///        `argument_tags`
+///      - The additional arguments passed to `db::mutate_apply`
+///   Note: use the explicit type whenever possible, not the type aliases.
+///   `db::const_item_type` will usually be `Tag::type` unless that is a
+///   `std::unique_ptr<T>`, in which case it will be `T`
+///
+/// Here is an example for a class conforming to this protocol:
+///
+/// \snippet DataBox/Examples.hpp mutator_protocol
+struct Mutator {
+  template <typename ConformingType>
+  struct test {
+    using argument_tags = typename ConformingType::argument_tags;
+    using return_tags = typename ConformingType::return_tags;
+  };
+};
+}  // namespace db::protocols

--- a/src/Evolution/DiscontinuousGalerkin/BackgroundGrVars.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/BackgroundGrVars.hpp
@@ -5,6 +5,7 @@
 
 #include <cstddef>
 
+#include "DataStructures/DataBox/Protocols/Mutator.hpp"
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Variables.hpp"
@@ -23,6 +24,7 @@
 #include "Time/Tags/Time.hpp"
 #include "Utilities/CallWithDynamicType.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TypeTraits/CreateGetTypeAliasOrDefault.hpp"
 
@@ -46,7 +48,7 @@ struct EmptyStruct {
  *
  */
 template <typename System, typename Metavariables, bool UsingRuntimeId>
-struct BackgroundGrVars {
+struct BackgroundGrVars : tt::ConformsTo<db::protocols::Mutator> {
   static constexpr size_t volume_dim = System::volume_dim;
 
   // Collect all the GR quantities used in the templated evolution system

--- a/src/Evolution/Systems/CurvedScalarWave/Initialize.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Initialize.hpp
@@ -5,6 +5,7 @@
 
 #include <cstddef>
 
+#include "DataStructures/DataBox/Protocols/Mutator.hpp"
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/Tags.hpp"
@@ -16,6 +17,7 @@
 #include "Evolution/Systems/ScalarWave/TagsDeclarations.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "PointwiseFunctions/AnalyticData/Tags.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
 
 /// \cond
 namespace Tags {
@@ -37,7 +39,8 @@ namespace CurvedScalarWave::Initialization {
 /// - Modifies: nothing
 
 template <size_t Dim>
-struct InitializeConstraintDampingGammas {
+struct InitializeConstraintDampingGammas
+    : tt::ConformsTo<db::protocols::Mutator> {
   using return_tags =
       tmpl::list<Tags::ConstraintGamma1, Tags::ConstraintGamma2>;
   using argument_tags = tmpl::list<domain::Tags::Mesh<Dim>>;
@@ -88,7 +91,7 @@ struct InitializeConstraintDampingGammas {
  */
 
 template <size_t Dim>
-struct InitializeEvolvedVariables {
+struct InitializeEvolvedVariables : tt::ConformsTo<db::protocols::Mutator> {
   using flat_variables_tag = typename ScalarWave::System<Dim>::variables_tag;
   using curved_variables_tag =
       typename CurvedScalarWave::System<Dim>::variables_tag;

--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/ElementActions/InitializeConstraintGammas.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/ElementActions/InitializeConstraintGammas.hpp
@@ -5,10 +5,12 @@
 
 #include <cstddef>
 
+#include "DataStructures/DataBox/Protocols/Mutator.hpp"
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/Tags.hpp"
 #include "Evolution/Systems/CurvedScalarWave/Tags.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
 
 namespace CurvedScalarWave::Worldtube::Initialization {
 
@@ -35,7 +37,8 @@ namespace CurvedScalarWave::Worldtube::Initialization {
  * - Modifies: nothing
  */
 template <size_t Dim>
-struct InitializeConstraintDampingGammas {
+struct InitializeConstraintDampingGammas
+    : tt::ConformsTo<db::protocols::Mutator> {
   using return_tags = tmpl::list<CurvedScalarWave::Tags::ConstraintGamma1,
                                  CurvedScalarWave::Tags::ConstraintGamma2>;
   using argument_tags =

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/SetVariablesNeededFixingToFalse.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/SetVariablesNeededFixingToFalse.hpp
@@ -3,7 +3,9 @@
 
 #pragma once
 
+#include "DataStructures/DataBox/Protocols/Mutator.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/Tags.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/TMPL.hpp"
 
 /// \cond
@@ -18,7 +20,8 @@ namespace grmhd::ValenciaDivClean {
  * \brief Mutator used with `Initialization::Actions::AddSimpleTags` to
  * initialize the `VariablesNeededFixing` to `false`
  */
-struct SetVariablesNeededFixingToFalse {
+struct SetVariablesNeededFixingToFalse
+    : tt::ConformsTo<db::protocols::Mutator> {
   using return_tags = tmpl::list<Tags::VariablesNeededFixing>;
   using argument_tags = tmpl::list<>;
 

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/GrTagsForHydro.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/GrTagsForHydro.hpp
@@ -10,6 +10,7 @@
 #include <unordered_map>
 #include <utility>
 
+#include "DataStructures/DataBox/Protocols/Mutator.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Variables.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
@@ -28,6 +29,7 @@
 #include "Time/Tags/Time.hpp"
 #include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/TMPL.hpp"
 
 /// \cond
@@ -71,7 +73,7 @@ namespace subcell {
  * - Modifies: nothing
  */
 template <typename System, size_t Dim>
-struct GrTagsForHydro {
+struct GrTagsForHydro : tt::ConformsTo<db::protocols::Mutator> {
   using simple_tags_from_options = tmpl::list<::Tags::Time>;
 
   using gr_tag = typename System::spacetime_variables_tag;

--- a/src/Evolution/Systems/ScalarAdvection/Subcell/VelocityAtFace.hpp
+++ b/src/Evolution/Systems/ScalarAdvection/Subcell/VelocityAtFace.hpp
@@ -10,6 +10,7 @@
 #include <unordered_map>
 #include <utility>
 
+#include "DataStructures/DataBox/Protocols/Mutator.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/Tags.hpp"
 #include "Domain/ElementMap.hpp"
@@ -27,6 +28,7 @@
 #include "Time/Tags/Time.hpp"
 #include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/TMPL.hpp"
 
 /// \cond
@@ -67,7 +69,7 @@ namespace ScalarAdvection::subcell {
  * `Initialization::Actions::AddSimpleTags`.
  */
 template <size_t Dim>
-struct VelocityAtFace {
+struct VelocityAtFace : tt::ConformsTo<db::protocols::Mutator> {
   using simple_tags_from_options = tmpl::list<::Tags::Time>;
 
   using velocity_field = ::ScalarAdvection::Tags::VelocityField<Dim>;

--- a/src/Parallel/MemoryMonitor/MemoryMonitor.hpp
+++ b/src/Parallel/MemoryMonitor/MemoryMonitor.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "DataStructures/DataBox/Protocols/Mutator.hpp"
 #include "Parallel/Algorithms/AlgorithmSingletonDeclarations.hpp"
 #include "Parallel/GlobalCache.hpp"
 #include "Parallel/Local.hpp"
@@ -12,6 +13,7 @@
 #include "ParallelAlgorithms/Actions/AddSimpleTags.hpp"
 #include "ParallelAlgorithms/Actions/TerminatePhase.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/TMPL.hpp"
 
 /*!
@@ -23,7 +25,7 @@ namespace mem_monitor {}
 
 namespace mem_monitor {
 namespace detail {
-struct InitializeMutator {
+struct InitializeMutator : tt::ConformsTo<db::protocols::Mutator> {
   using return_tags = tmpl::list<mem_monitor::Tags::MemoryHolder>;
   using argument_tags = tmpl::list<>;
 

--- a/src/ParallelAlgorithms/Actions/AddSimpleTags.hpp
+++ b/src/ParallelAlgorithms/Actions/AddSimpleTags.hpp
@@ -7,6 +7,7 @@
 #include <utility>
 
 #include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/Protocols/Mutator.hpp"
 #include "Parallel/AlgorithmExecution.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
@@ -43,6 +44,9 @@ struct AddSimpleTags {
   using simple_tags =
       tmpl::flatten<tmpl::append<typename Mutators::return_tags...>>;
   using compute_tags = tmpl::list<>;
+
+  static_assert((tt::assert_conforms_to_v<Mutators, db::protocols::Mutator> and
+                 ...));
 
   template <typename DbTagsList, typename... InboxTags, typename Metavariables,
             typename ArrayIndex, typename ActionList,

--- a/tests/Unit/DataStructures/DataBox/CMakeLists.txt
+++ b/tests/Unit/DataStructures/DataBox/CMakeLists.txt
@@ -10,6 +10,7 @@ set(LIBRARY_SOURCES
   Test_DataBoxPrefixes.cpp
   Test_ObservationBox.cpp
   Test_PrefixHelpers.cpp
+  Test_Protocols.cpp
   Test_TagName.cpp
   Test_TagTraits.cpp
   Test_TestHelpers.cpp

--- a/tests/Unit/DataStructures/DataBox/Test_Protocols.cpp
+++ b/tests/Unit/DataStructures/DataBox/Test_Protocols.cpp
@@ -1,0 +1,9 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "DataStructures/DataBox/Protocols/Mutator.hpp"
+#include "Helpers/DataStructures/DataBox/Examples.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
+
+static_assert(tt::assert_conforms_to_v<db::TestHelpers::ExampleMutator,
+                                       db::protocols::Mutator>);

--- a/tests/Unit/Helpers/DataStructures/DataBox/CMakeLists.txt
+++ b/tests/Unit/Helpers/DataStructures/DataBox/CMakeLists.txt
@@ -9,6 +9,7 @@ spectre_target_headers(
   ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/tests/Unit
   HEADERS
+  Examples.hpp
   TestHelpers.hpp
   TestTags.hpp
   )

--- a/tests/Unit/Helpers/DataStructures/DataBox/Examples.hpp
+++ b/tests/Unit/Helpers/DataStructures/DataBox/Examples.hpp
@@ -1,0 +1,47 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "DataStructures/DataBox/Protocols/Mutator.hpp"
+#include "DataStructures/DataBox/Tag.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace db::TestHelpers {
+
+struct OptionTag {};
+
+struct ExampleSimpleTag0 : db::SimpleTag {
+  using type = double;
+  using option_tags = tmpl::list<OptionTag>;
+  static constexpr bool pass_metavariables = false;
+  static type create_from_options(const type& option) { return option; }
+};
+
+struct ExampleSimpleTag1 : db::SimpleTag {
+  using type = int;
+  using option_tags = tmpl::list<OptionTag>;
+  static constexpr bool pass_metavariables = false;
+  static type create_from_options(const type& option) { return option; }
+};
+
+struct ExampleSimpleTag2 : db::SimpleTag {
+  using type = double;
+};
+
+// [mutator_protocol]
+struct ExampleMutator : tt::ConformsTo<db::protocols::Mutator> {
+  using return_tags = tmpl::list<ExampleSimpleTag0, ExampleSimpleTag1>;
+  using argument_tags = tmpl::list<ExampleSimpleTag2>;
+
+  static void apply(const gsl::not_null<double*> item_0,
+                    const gsl::not_null<int*> item_1, const double item_2,
+                    const int additional_arg) {
+    *item_0 = 2.0 * item_2;
+    *item_1 = 2 * additional_arg;
+  }
+};
+// [mutator_protocol]
+}  // namespace db::TestHelpers

--- a/tests/Unit/ParallelAlgorithms/Actions/Test_AddSimpleTags.cpp
+++ b/tests/Unit/ParallelAlgorithms/Actions/Test_AddSimpleTags.cpp
@@ -6,6 +6,7 @@
 #include <string>
 
 #include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/Protocols/Mutator.hpp"
 #include "DataStructures/DataBox/Tag.hpp"
 #include "Framework/ActionTesting.hpp"
 #include "Parallel/GlobalCache.hpp"
@@ -13,6 +14,7 @@
 #include "Parallel/PhaseDependentActionList.hpp"
 #include "ParallelAlgorithms/Actions/AddSimpleTags.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/TMPL.hpp"
 
 namespace {
@@ -28,7 +30,7 @@ struct SquareNumber : db::SimpleTag {
   using type = double;
 };
 
-struct AddSomeAndOtherNumber {
+struct AddSomeAndOtherNumber : tt::ConformsTo<db::protocols::Mutator> {
   using return_tags = tmpl::list<SomeNumber, SomeOtherNumber>;
   using argument_tags = tmpl::list<>;
 
@@ -39,7 +41,7 @@ struct AddSomeAndOtherNumber {
   }
 };
 
-struct AddSquareNumber {
+struct AddSquareNumber : tt::ConformsTo<db::protocols::Mutator> {
   using return_tags = tmpl::list<SquareNumber>;
   using argument_tags = tmpl::list<SomeNumber>;
   static void apply(const gsl::not_null<double*> square_number,


### PR DESCRIPTION
## Proposed changes

This adds a protocol for a class that can be used by `db::mutate_apply` and uses it for the mutators that are passed to the action AddSimpleTags

Was part of #4983 

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
