### PR TITLE
Add Python Bindings For Spectral And Enthalpy EoS

### DIFF
--- a/src/PointwiseFunctions/Hydro/EquationsOfState/Python/Bindings.cpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/Python/Bindings.cpp
@@ -3,9 +3,11 @@
 
 #include <pybind11/pybind11.h>
 
+#include "PointwiseFunctions/Hydro/EquationsOfState/Python/Enthalpy.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/Python/EquationOfState.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/Python/PiecewisePolytropicFluid.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/Python/PolytropicFluid.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/Python/Spectral.hpp"
 #include "Utilities/ErrorHandling/SegfaultHandler.hpp"
 
 namespace py = pybind11;
@@ -19,8 +21,10 @@ PYBIND11_MODULE(_Pybindings, m) {  // NOLINT
   // Abstract base class
   py_bindings::bind_equation_of_state(m);
   // Derived classes
+  py_bindings::bind_enthalpy(m);
   py_bindings::bind_piecewisepolytropic_fluid(m);
   py_bindings::bind_polytropic_fluid(m);
+  py_bindings::bind_spectral(m);
 }
 
 }  // namespace EquationsOfState

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/Python/CMakeLists.txt
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/Python/CMakeLists.txt
@@ -10,8 +10,10 @@ spectre_python_add_module(
   SOURCES
   Bindings.cpp
   EquationOfState.cpp
+  Enthalpy.cpp
   PiecewisePolytropicFluid.cpp
   PolytropicFluid.cpp
+  Spectral.cpp
   PYTHON_FILES
   __init__.py
   )
@@ -21,8 +23,10 @@ spectre_python_headers(
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   EquationOfState.hpp
+  Enthalpy.hpp
   PiecewisePolytropicFluid.hpp
   PolytropicFluid.hpp
+  Spectral.hpp
   )
 
 spectre_python_link_libraries(

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/Python/Enthalpy.cpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/Python/Enthalpy.cpp
@@ -1,0 +1,45 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "PointwiseFunctions/Hydro/EquationsOfState/Python/Enthalpy.hpp"
+
+#include <pybind11/numpy.h>
+#include <pybind11/operators.h>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <string>
+#include <vector>
+
+#include "PointwiseFunctions/Hydro/EquationsOfState/Enthalpy.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/PolytropicFluid.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/Spectral.hpp"
+// low_density_eos uses Spectral and Polytropic Fluid type EoS.
+
+namespace py = pybind11;
+
+namespace EquationsOfState::py_bindings {
+
+template <typename LowDensityEoS>
+// NOLINTNEXTLINE(google-runtime-references)
+void bind_enthalpy_impl(py::module& m, const std::string& name) {
+  py::class_<Enthalpy<LowDensityEoS>, EquationOfState<true, 1>>(
+    m, name.c_str()).def(
+      py::init<double, double, double, double, std::vector<double>,
+               std::vector<double>, std::vector<double>, LowDensityEoS,
+               double>(),
+      py::arg("reference_density"), py::arg("max_density"),
+      py::arg("min_density"), py::arg("trig_scale"),
+      py::arg("polynomial_coefficients"), py::arg("sin_coefficients"),
+      py::arg("cos_coefficients"), py::arg("low_density_eos"),
+      py::arg("transition_delta_epsilon"));
+}
+
+void bind_enthalpy(py::module& m) {
+  bind_enthalpy_impl<PolytropicFluid<true>>(m, "EnthalpyPolytropicFluid");
+  bind_enthalpy_impl<Spectral>(m, "EnthalpySpectral");
+  bind_enthalpy_impl<Enthalpy<Spectral>>(m, "EnthalpyEnthalpySpectral");
+  bind_enthalpy_impl<Enthalpy<Enthalpy<Spectral>>>(
+      m, "EnthalpyEnthalpyEnthalpySpectral");
+}
+
+}  // namespace EquationsOfState::py_bindings

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/Python/Enthalpy.hpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/Python/Enthalpy.hpp
@@ -1,0 +1,11 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <pybind11/pybind11.h>
+
+namespace EquationsOfState::py_bindings {
+// NOLINTNEXTLINE(google-runtime-references)
+void bind_enthalpy(pybind11::module& m);
+}  // namespace EquationsOfState::py_bindings

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/Python/Spectral.cpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/Python/Spectral.cpp
@@ -1,0 +1,27 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "PointwiseFunctions/Hydro/EquationsOfState/Python/Spectral.hpp"
+
+#include <pybind11/numpy.h>
+#include <pybind11/operators.h>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <string>
+#include <vector>
+
+#include "PointwiseFunctions/Hydro/EquationsOfState/Spectral.hpp"
+
+namespace py = pybind11;
+
+namespace EquationsOfState::py_bindings {
+
+void bind_spectral(py::module& m) {
+  py::class_<Spectral, EquationOfState<true, 1>>(
+      m, "Spectral")
+      .def(py::init<double, double, std::vector<double>, double>(),
+           py::arg("reference_density"), py::arg("reference_pressure"),
+           py::arg("spectral_coefficients"),
+           py::arg("upper_density"));
+}
+}  // namespace EquationsOfState::py_bindings

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/Python/Spectral.hpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/Python/Spectral.hpp
@@ -1,0 +1,11 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <pybind11/pybind11.h>
+
+namespace EquationsOfState::py_bindings {
+// NOLINTNEXTLINE(google-runtime-references)
+void bind_spectral(pybind11::module& m);
+}  // namespace EquationsOfState::py_bindings

--- a/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Python/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Python/CMakeLists.txt
@@ -2,6 +2,12 @@
 # See LICENSE.txt for details.
 
 spectre_add_python_bindings_test(
+  "Unit.Hydro.EquationsOfState.Python.Enthalpy"
+  "Test_Enthalpy.py"
+  "Unit;EquationsOfState;Python"
+  PyEquationsOfState)
+
+spectre_add_python_bindings_test(
   "Unit.Hydro.EquationsOfState.Python.PolytropicFluid"
   "Test_PolytropicFluid.py"
   "Unit;EquationsOfState;Python"
@@ -10,5 +16,11 @@ spectre_add_python_bindings_test(
 spectre_add_python_bindings_test(
   "Unit.Hydro.EquationsOfState.Python.PiecewisePolytropicFluid"
   "Test_PiecewisePolytropicFluid.py"
+  "Unit;EquationsOfState;Python"
+  PyEquationsOfState)
+
+spectre_add_python_bindings_test(
+  "Unit.Hydro.EquationsOfState.Python.Spectral"
+  "Test_Spectral.py"
   "Unit;EquationsOfState;Python"
   PyEquationsOfState)

--- a/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Python/Test_Enthalpy.py
+++ b/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Python/Test_Enthalpy.py
@@ -1,0 +1,96 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import unittest
+
+import numpy as np
+import numpy.testing as npt
+
+import spectre
+import spectre.PointwiseFunctions.Hydro.EquationsOfState as EoS
+from spectre.DataStructures import DataVector
+from spectre.DataStructures.Tensor import Scalar
+
+
+class TestEnthalpy(unittest.TestCase):
+    def test_enthalpy(self):
+        # Parameters are DBHF parameters from https://doi.org/10.48550/arXiv.2301.13818
+
+        low_eos_spectre = EoS.Spectral(
+            reference_density=4.533804669935759e-05,
+            reference_pressure=9.970647727158039e-08,
+            spectral_coefficients=[
+                1.2,
+                0.0,
+                1.34440187653529,
+                -0.46098357752567365,
+            ],
+            upper_density=0.0004533804669935759,
+        )
+
+        eos_spectre = EoS.EnthalpySpectral(
+            reference_density=0.00022669023349678794,
+            max_density=0.0031736632689550316,
+            min_density=0.0004533804669935759,
+            trig_scale=1.26426988871305,
+            polynomial_coefficients=[
+                1.0,
+                0.08063293075870805,
+                4.406887319408924e-26,
+                8.177895241388924e-22,
+                0.013558242085066733,
+                0.004117320982626606,
+                9.757362504479485e-26,
+                1.5646573325075753e-30,
+                0.00016253964205058317,
+            ],
+            sin_coefficients=[
+                0.0003763514388305583,
+                0.017968749910748837,
+                0.008140052979970034,
+                -0.003067418379116628,
+                -0.0008236601907322793,
+            ],
+            cos_coefficients=[
+                -0.01080996024705052,
+                -0.003421193490191067,
+                0.012325774692378716,
+                0.004367136076912163,
+                -0.00020374276952538073,
+            ],
+            low_density_eos=low_eos_spectre,
+            transition_delta_epsilon=0.0,
+        )
+        self.assertTrue(
+            isinstance(eos_spectre, EoS.RelativisticEquationOfState1D)
+        )
+        # Only testing p(rho) because the class is tested thoroughly in C++
+        density = np.geomspace(4.6e-4, 5e-3, 10)
+        pressure = eos_spectre.pressure_from_density(
+            Scalar[DataVector](density)
+        )
+        # These are the pressures calculated in python implementation
+        # testing the bindings. The python implementation will be added
+        # in a second merge request.
+
+        pressures_pyth = [
+            1.5302849088016283e-5,
+            3.1441124536164583e-5,
+            6.5907292284151015e-5,
+            1.4033564857885284e-4,
+            3.0098826697494873e-4,
+            6.4603643776028635e-4,
+            1.3821660234437354e-3,
+            2.9420820328679361e-3,
+            6.2206944563790453e-3,
+            1.3007001237896111e-2,
+        ]
+
+        npt.assert_allclose(
+            pressure[0],
+            pressures_pyth,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Python/Test_Spectral.py
+++ b/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Python/Test_Spectral.py
@@ -1,0 +1,56 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+
+import unittest
+
+import numpy as np
+import numpy.testing as npt
+
+import spectre.PointwiseFunctions.Hydro.EquationsOfState as spectre_eos
+from spectre.DataStructures import DataVector
+from spectre.DataStructures.Tensor import Scalar
+
+
+class TestSpectral(unittest.TestCase):
+    def test_spectral(self):
+        # Parameters are sLy$\Gamma$2 from https://doi.org/10.48550/arXiv.1908.05277
+
+        eos = spectre_eos.Spectral(
+            reference_density=1.0118e-4,
+            reference_pressure=3.33625e-7,
+            spectral_coefficients=[2, 0, 0.4029, -0.1008],
+            upper_density=6e-3,
+        )
+
+        # These are the pressures calculated in python implementation
+        # testing the bindings. The python implementation will be added
+        # in a second merge request.
+
+        pressures_pyth = [
+            3.258886510983e-7,
+            7.846581912375e-7,
+            1.990840482194e-6,
+            5.508910104189e-6,
+            1.683916561373e-5,
+            5.636080617205e-5,
+            2.003712243313e-4,
+            7.183209159534e-4,
+            2.412536276978e-3,
+            6.901956906998e-3,
+        ]
+        self.assertTrue(
+            isinstance(eos, spectre_eos.RelativisticEquationOfState1D)
+        )
+        # Only testing p(rho) because the class is tested thoroughly in C++
+        density = np.geomspace(1e-4, 5e-3, 10)
+        pressure = eos.pressure_from_density(Scalar[DataVector](density))
+
+        npt.assert_allclose(
+            pressure,
+            [pressures_pyth],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Proposed changes

Add python bindings for enthalpy and spectral equations of state.  We add this so we can create simulation domains and for post-processing.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
