### PR TITLE
Add largest characteristic speed for ScalarTensor

### DIFF
--- a/src/Evolution/Systems/ScalarTensor/CMakeLists.txt
+++ b/src/Evolution/Systems/ScalarTensor/CMakeLists.txt
@@ -15,6 +15,7 @@ spectre_target_headers(
   ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
+  Characteristics.hpp
   StressEnergy.hpp
   System.hpp
   Tags.hpp

--- a/src/Evolution/Systems/ScalarTensor/Characteristics.hpp
+++ b/src/Evolution/Systems/ScalarTensor/Characteristics.hpp
@@ -1,0 +1,62 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Evolution/Systems/CurvedScalarWave/Characteristics.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Characteristics.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace ScalarTensor::Tags {
+struct LargestCharacteristicSpeed : db::SimpleTag {
+  using type = double;
+};
+
+/*!
+ * \brief Computes the largest magnitude of the characteristic speeds.
+ *
+ * \details Compute the maximum of the largest characteristic speed of each
+ * component system, i.e. the largest speed between ::gh and ::CurvedScalarWave.
+ */
+template <typename Frame = Frame::Inertial>
+struct ComputeLargestCharacteristicSpeed : db::ComputeTag,
+                                           LargestCharacteristicSpeed {
+  static constexpr size_t Dim = 3_st;
+  using argument_tags =
+      tmpl::list<::gh::ConstraintDamping::Tags::ConstraintGamma1,
+                 gr::Tags::Lapse<DataVector>,
+                 gr::Tags::Shift<DataVector, Dim, Frame>,
+                 gr::Tags::SpatialMetric<DataVector, Dim, Frame>,
+                 CurvedScalarWave::Tags::ConstraintGamma1>;
+  using return_type = double;
+  using base = LargestCharacteristicSpeed;
+  static void function(const gsl::not_null<double*> speed,
+                       // GH arguments
+                       const Scalar<DataVector>& gamma_1,
+                       const Scalar<DataVector>& lapse,
+                       const tnsr::I<DataVector, Dim, Frame>& shift,
+                       const tnsr::ii<DataVector, Dim, Frame>& spatial_metric,
+                       // Scalar arguments
+                       const Scalar<DataVector>& gamma_1_scalar) {
+    // Largest speed in for Generalized Harmonic
+    double gh_largest_speed = 0.0;
+    gh::Tags::ComputeLargestCharacteristicSpeed<Dim, Frame>::function(
+        make_not_null(&gh_largest_speed), gamma_1, lapse, shift,
+        spatial_metric);
+    // Largest speed for CurvedScalarWave
+    double scalar_largest_speed = 0.0;
+    CurvedScalarWave::Tags::ComputeLargestCharacteristicSpeed<Dim>::function(
+        make_not_null(&scalar_largest_speed), gamma_1_scalar, lapse, shift,
+        spatial_metric);
+    // Compute the maximum speed
+    *speed = std::max(gh_largest_speed, scalar_largest_speed);
+  }
+};
+}  // namespace ScalarTensor::Tags

--- a/src/Evolution/Systems/ScalarTensor/System.hpp
+++ b/src/Evolution/Systems/ScalarTensor/System.hpp
@@ -8,6 +8,7 @@
 #include "DataStructures/VariablesTag.hpp"
 #include "Evolution/Systems/CurvedScalarWave/System.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/System.hpp"
+#include "Evolution/Systems/ScalarTensor/Characteristics.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -76,6 +77,9 @@ struct System {
   using gradients_tags = gradient_variables;
 
   static constexpr bool is_in_flux_conservative_form = false;
+
+  using compute_largest_characteristic_speed =
+      Tags::ComputeLargestCharacteristicSpeed<>;
 
   using inverse_spatial_metric_tag =
       typename gh_system::inverse_spatial_metric_tag;

--- a/tests/Unit/Evolution/Systems/ScalarTensor/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/ScalarTensor/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY "Test_ScalarTensor")
 
 set(LIBRARY_SOURCES
+  Test_Characteristics.cpp
   Test_Sources.cpp
   Test_Tags.cpp
   )
@@ -19,5 +20,6 @@ target_link_libraries(
   ${LIBRARY}
   PRIVATE
   Framework
+  GeneralRelativityHelpers
   ScalarTensor
   )

--- a/tests/Unit/Evolution/Systems/ScalarTensor/Test_Characteristics.cpp
+++ b/tests/Unit/Evolution/Systems/ScalarTensor/Test_Characteristics.cpp
@@ -1,0 +1,48 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <limits>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Evolution/Systems/CurvedScalarWave/Characteristics.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Characteristics.hpp"
+#include "Evolution/Systems/ScalarTensor/Characteristics.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/PointwiseFunctions/GeneralRelativity/TestHelpers.hpp"
+
+namespace {
+void check_max_char_speed(const DataVector& used_for_size) {
+  MAKE_GENERATOR(gen);
+
+  const Scalar<DataVector> gamma_1{used_for_size.size(), 0.0};
+  const auto lapse = TestHelpers::gr::random_lapse(&gen, used_for_size);
+  const auto shift = TestHelpers::gr::random_shift<3>(&gen, used_for_size);
+  const auto spatial_metric =
+      TestHelpers::gr::random_spatial_metric<3>(&gen, used_for_size);
+  const Scalar<DataVector> gamma_1_scalar{used_for_size.size(), 0.0};
+
+  double max_char_speed = std::numeric_limits<double>::signaling_NaN();
+  ScalarTensor::Tags::ComputeLargestCharacteristicSpeed<
+      Frame::Inertial>::function(make_not_null(&max_char_speed), gamma_1, lapse,
+                                 shift, spatial_metric, gamma_1_scalar);
+
+  double gh_max_char_speed = std::numeric_limits<double>::signaling_NaN();
+  gh::Tags::ComputeLargestCharacteristicSpeed<3, Frame::Inertial>::function(
+      make_not_null(&gh_max_char_speed), gamma_1, lapse, shift, spatial_metric);
+
+  double scalar_max_char_speed = std::numeric_limits<double>::signaling_NaN();
+  CurvedScalarWave::Tags::ComputeLargestCharacteristicSpeed<3>::function(
+      make_not_null(&scalar_max_char_speed), gamma_1_scalar, lapse, shift,
+      spatial_metric);
+
+  CHECK(max_char_speed == std::max(gh_max_char_speed, scalar_max_char_speed));
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.ScalarTensor.MaxCharSpeed",
+                  "[Unit][Evolution]") {
+  check_max_char_speed(DataVector(5));
+}


### PR DESCRIPTION
## Proposed changes

We add a compute tag for the maximum speed of the combined ScalarTensor system. We simply take the max of the largest speed of each component system (i.e. generalized harmonic and CurvedScalarWave).

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
