### PR TITLE
Avoid running out of disk space on CI

### DIFF
--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -606,14 +606,16 @@ ${{ env.CACHE_KEY_SUFFIX }}"
           # it is a random timeout or systematic
           ctest -j2 -LE unit --output-on-failure --repeat after-timeout:3
       - name: Install
-        if: matrix.COVERAGE != 'ON'
+        # Coverage and ASAN builds are larger, so skip install to avoid running
+        # out of disk space
+        if: matrix.COVERAGE != 'ON' && matrix.ASAN != 'ON'
         working-directory: /work/build
         # Make sure the `install` target runs without error. We could add some
         # basic smoke tests here to make sure the installation worked.
         run: |
           make install
       - name: Print size of install directory
-        if: matrix.COVERAGE != 'ON'
+        if: matrix.COVERAGE != 'ON' && matrix.ASAN != 'ON'
         working-directory: /work/spectre_install
         # Remove files post-install to reduce disk space for later on.
         run: |


### PR DESCRIPTION
## Proposed changes

The ASAN build is a lot larger than the others, so it has been running out of disk space.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
