### PR TITLE
Add list of compute tags for ScalarTensor initialization

### DIFF
--- a/src/Evolution/Systems/ScalarTensor/CMakeLists.txt
+++ b/src/Evolution/Systems/ScalarTensor/CMakeLists.txt
@@ -18,6 +18,7 @@ spectre_target_headers(
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   Characteristics.hpp
+  Initialize.hpp
   StressEnergy.hpp
   System.hpp
   Tags.hpp

--- a/src/Evolution/Systems/ScalarTensor/Initialize.hpp
+++ b/src/Evolution/Systems/ScalarTensor/Initialize.hpp
@@ -1,0 +1,74 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <optional>
+
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/Tags.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Constraints.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/System.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
+#include "Evolution/Systems/ScalarTensor/Sources/ScalarSource.hpp"
+#include "Evolution/Systems/ScalarTensor/Tags.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Christoffel.hpp"
+#include "PointwiseFunctions/GeneralRelativity/DerivativesOfSpacetimeMetric.hpp"
+#include "PointwiseFunctions/GeneralRelativity/DetAndInverseSpatialMetric.hpp"
+#include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/ConstraintGammas.hpp"
+#include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/DerivSpatialMetric.hpp"
+#include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/ExtrinsicCurvature.hpp"
+#include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/SpatialDerivOfLapse.hpp"
+#include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/SpatialDerivOfShift.hpp"
+#include "PointwiseFunctions/GeneralRelativity/InverseSpacetimeMetric.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Lapse.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Shift.hpp"
+#include "PointwiseFunctions/GeneralRelativity/SpacetimeMetric.hpp"
+#include "PointwiseFunctions/GeneralRelativity/SpacetimeNormalOneForm.hpp"
+#include "PointwiseFunctions/GeneralRelativity/SpacetimeNormalVector.hpp"
+#include "PointwiseFunctions/GeneralRelativity/SpatialMetric.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace ScalarTensor::Initialization {
+
+/// \brief List of compute tags to be initialized in the ScalarTensor system
+///
+/// \details The compute tags required include those specified in
+/// ::gh::Actions::InitializeGhAnd3Plus1Variables as well as the tags required
+/// to compute spacetime quantities appearing in the scalar evolution equations.
+/// Namely, we include the compute tags associated to the trace of the extrinsic
+/// curvature and the trace of the spatial Christoffel symbol, as well as the
+/// compute tag required to calculate the source term of the scalar equation.
+template <size_t Dim, typename Fr = Frame::Inertial>
+using scalar_tensor_3plus1_compute_tags = tmpl::list<
+    // Needed to compute the characteristic speeds for the AH finder
+    gr::Tags::SpatialMetricCompute<DataVector, Dim, Fr>,
+    gr::Tags::DetAndInverseSpatialMetricCompute<DataVector, Dim, Fr>,
+    gr::Tags::ShiftCompute<DataVector, Dim, Fr>,
+    gr::Tags::LapseCompute<DataVector, Dim, Fr>,
+
+    gr::Tags::SpacetimeNormalVectorCompute<DataVector, Dim, Fr>,
+    gh::Tags::DerivLapseCompute<Dim, Fr>,
+
+    gr::Tags::InverseSpacetimeMetricCompute<DataVector, Dim, Fr>,
+    gh::Tags::DerivShiftCompute<Dim, Fr>,
+
+    gh::Tags::DerivSpatialMetricCompute<Dim, Fr>,
+
+    // Compute tags for Trace of Christoffel and Extrinsic curvature
+    gr::Tags::SpatialChristoffelFirstKindCompute<DataVector, Dim, Fr>,
+    gr::Tags::SpatialChristoffelSecondKindCompute<DataVector, Dim, Fr>,
+    gr::Tags::TraceSpatialChristoffelSecondKindCompute<DataVector, Dim, Fr>,
+    gh::Tags::ExtrinsicCurvatureCompute<Dim, Fr>,
+    gh::Tags::TraceExtrinsicCurvatureCompute<Dim, Fr>,
+
+    // Compute constraint damping parameters.
+    gh::ConstraintDamping::Tags::ConstraintGamma0Compute<Dim, Frame::Grid>,
+    gh::ConstraintDamping::Tags::ConstraintGamma1Compute<Dim, Frame::Grid>,
+    gh::ConstraintDamping::Tags::ConstraintGamma2Compute<Dim, Frame::Grid>,
+
+    ScalarTensor::Tags::ScalarSourceCompute>;
+
+}  // namespace ScalarTensor::Initialization


### PR DESCRIPTION
## Proposed changes

Add list of compute tags required for the initialization of ScalarTensor. These tags are added directly in the executable with `Initialization::Actions::AddComputeTags`.

Note: 
- For now, we add the trace of the extrinsic curvature and trace of christoffel as compute tags. In a future PR the idea would be to replace these for their computation directly in `ScalarTensor::TimeDerivative::apply`. (In testing, the current implementation did not seem significantly slower than just GH.)

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
