### PR TITLE
Add FoT names to CoordMaps

### DIFF
--- a/src/Domain/CoordinateMaps/Composition.cpp
+++ b/src/Domain/CoordinateMaps/Composition.cpp
@@ -17,7 +17,9 @@ Composition<Frames, Dim, std::index_sequence<Is...>>::Composition(
     std::unique_ptr<
         CoordinateMapBase<tmpl::at<frames, tmpl::size_t<Is>>,
                           tmpl::at<frames, tmpl::size_t<Is + 1>>, Dim>>... maps)
-    : maps_{std::move(maps)...} {}
+    : maps_{std::move(maps)...},
+      function_of_time_names_(CoordinateMap_detail::initialize_names(
+          maps_, std::index_sequence<Is...>{})) {}
 
 template <typename Frames, size_t Dim, size_t... Is>
 Composition<Frames, Dim, std::index_sequence<Is...>>&
@@ -166,6 +168,12 @@ void Composition<Frames, Dim, std::index_sequence<Is...>>::pup(PUP::er& p) {
   // whenever possible. See `Domain` docs for details.
   if (version >= 0) {
     p | maps_;
+  }
+
+  // No need to pup this because it is uniquely determined by the maps
+  if (p.isUnpacking()) {
+    function_of_time_names_ = CoordinateMap_detail::initialize_names(
+        maps_, std::index_sequence<Is...>{});
   }
 }
 
@@ -350,10 +358,9 @@ template <typename Frames, size_t Dim, size_t... Is>
 bool Composition<Frames, Dim, std::index_sequence<Is...>>::is_equal_to(
     const CoordinateMapBase<SourceFrame, TargetFrame, Dim>& other) const {
   const auto& cast_of_other = dynamic_cast<const Composition&>(other);
-  bool result = true;
-  EXPAND_PACK_LEFT_TO_RIGHT(
-      (result = result and (*get<Is>(maps_) == *get<Is>(cast_of_other.maps_))));
-  return result;
+
+  return ((function_of_time_names_ == cast_of_other.function_of_time_names_) and
+          ... and (*get<Is>(maps_) == *get<Is>(cast_of_other.maps_)));
 }
 
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)

--- a/src/Domain/CoordinateMaps/Composition.cpp
+++ b/src/Domain/CoordinateMaps/Composition.cpp
@@ -359,8 +359,7 @@ bool Composition<Frames, Dim, std::index_sequence<Is...>>::is_equal_to(
     const CoordinateMapBase<SourceFrame, TargetFrame, Dim>& other) const {
   const auto& cast_of_other = dynamic_cast<const Composition&>(other);
 
-  return ((function_of_time_names_ == cast_of_other.function_of_time_names_) and
-          ... and (*get<Is>(maps_) == *get<Is>(cast_of_other.maps_)));
+  return (... and (*get<Is>(maps_) == *get<Is>(cast_of_other.maps_)));
 }
 
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)

--- a/src/Domain/CoordinateMaps/Composition.hpp
+++ b/src/Domain/CoordinateMaps/Composition.hpp
@@ -9,6 +9,7 @@
 #include <tuple>
 #include <type_traits>
 #include <unordered_map>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -115,6 +116,11 @@ struct Composition<Frames, Dim, std::index_sequence<Is...>>
 
   bool jacobian_is_time_dependent() const override;
 
+  const std::unordered_set<std::string>& function_of_time_names()
+      const override {
+    return function_of_time_names_;
+  }
+
   tnsr::I<double, Dim, TargetFrame> operator()(
       tnsr::I<double, Dim, SourceFrame> source_point,
       double time = std::numeric_limits<double>::signaling_NaN(),
@@ -208,6 +214,7 @@ struct Composition<Frames, Dim, std::index_sequence<Is...>>
       CoordinateMapBase<tmpl::at<frames, tmpl::size_t<Is>>,
                         tmpl::at<frames, tmpl::size_t<Is + 1>>, Dim>>...>
       maps_;
+  std::unordered_set<std::string> function_of_time_names_;
 };
 
 // Template deduction guide

--- a/src/Domain/CoordinateMaps/CoordinateMap.hpp
+++ b/src/Domain/CoordinateMaps/CoordinateMap.hpp
@@ -511,6 +511,12 @@ class CoordinateMap
     return *this == cast_of_other;
   }
 
+  void check_functions_of_time(
+      const std::unordered_map<
+          std::string,
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+          functions_of_time) const;
+
   template <typename T, size_t... Is>
   tnsr::I<T, dim, TargetFrame> call_impl(
       tnsr::I<T, dim, SourceFrame>&& source_point, double time,

--- a/src/Domain/CoordinateMaps/CoordinateMap.hpp
+++ b/src/Domain/CoordinateMaps/CoordinateMap.hpp
@@ -16,6 +16,7 @@
 #include <type_traits>
 #include <typeinfo>
 #include <unordered_map>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -36,6 +37,11 @@ namespace TimeDependent {}
 template <typename FirstMap, typename... Maps>
 constexpr size_t map_dim = FirstMap::dim;
 }  // namespace CoordinateMaps
+namespace CoordinateMap_detail {
+template <typename... Maps, size_t... Is>
+std::unordered_set<std::string> initialize_names(
+    const std::tuple<Maps...>& maps, std::index_sequence<Is...> /*meta*/);
+}
 
 /*!
  * \ingroup CoordinateMapsGroup
@@ -77,6 +83,10 @@ class CoordinateMapBase : public PUP::able {
 
   /// Returns `true` if the Jacobian depends on time.
   virtual bool jacobian_is_time_dependent() const = 0;
+
+  /// Get a set of all FunctionOfTime names used in this mapping
+  virtual const std::unordered_set<std::string>& function_of_time_names()
+      const = 0;
 
   /// @{
   /// Apply the `Maps` to the point(s) `source_point`
@@ -284,6 +294,12 @@ class CoordinateMap
   /// Returns `true` if the Jacobian depends on time.
   bool jacobian_is_time_dependent() const override;
 
+  /// Get a set of all FunctionOfTime names from `Maps`
+  const std::unordered_set<std::string>& function_of_time_names()
+      const override {
+    return function_of_time_names_;
+  }
+
   /// @{
   /// Apply the `Maps...` to the point(s) `source_point`
   constexpr tnsr::I<double, dim, TargetFrame> operator()(
@@ -445,6 +461,12 @@ class CoordinateMap
       CoordinateMapBase<SourceFrame, TargetFrame, dim>::pup(p);
       p | maps_;
     }
+
+    // No need to pup this because it is uniquely determined by the maps
+    if (p.isUnpacking()) {
+      function_of_time_names_ = CoordinateMap_detail::initialize_names(
+          maps_, std::make_index_sequence<sizeof...(Maps)>{});
+    }
   }
 
  private:
@@ -536,6 +558,7 @@ class CoordinateMap
           functions_of_time) const;
 
   std::tuple<Maps...> maps_;
+  std::unordered_set<std::string> function_of_time_names_;
 };
 
 /// \ingroup ComputationalDomainGroup

--- a/src/Domain/CoordinateMaps/CoordinateMap.tpp
+++ b/src/Domain/CoordinateMaps/CoordinateMap.tpp
@@ -25,9 +25,9 @@
 #include "Domain/CoordinateMaps/CoordinateMapHelpers.hpp"
 #include "Domain/CoordinateMaps/TimeDependentHelpers.hpp"
 #include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
-#include "Utilities/Serialization/CharmPupable.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeArray.hpp"
+#include "Utilities/Serialization/CharmPupable.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/Tuple.hpp"
 
@@ -42,8 +42,7 @@ template <typename... Maps, size_t... Is>
 bool is_identity_impl(const std::tuple<Maps...>& maps,
                       std::index_sequence<Is...> /*meta*/) {
   bool is_identity = true;
-  const auto check_map_is_identity = [&is_identity,
-                                      &maps](auto index) {
+  const auto check_map_is_identity = [&is_identity, &maps](auto index) {
     if (is_identity) {
       is_identity = std::get<decltype(index)::value>(maps).is_identity();
     }
@@ -56,8 +55,7 @@ bool is_identity_impl(const std::tuple<Maps...>& maps,
 }  // namespace CoordinateMap_detail
 
 template <typename SourceFrame, typename TargetFrame, typename... Maps>
-bool CoordinateMap<SourceFrame, TargetFrame, Maps...>::is_identity() const
-    {
+bool CoordinateMap<SourceFrame, TargetFrame, Maps...>::is_identity() const {
   return CoordinateMap_detail::is_identity_impl(
       maps_, std::make_index_sequence<sizeof...(Maps)>{});
 }
@@ -254,42 +252,38 @@ auto CoordinateMap<SourceFrame, TargetFrame, Maps...>::inv_jacobian_impl(
 
   InverseJacobian<T, dim, SourceFrame, TargetFrame> inv_jac{};
 
-  tuple_transform(
-      maps_, [&inv_jac, &mapped_point, time, &functions_of_time](
-                 const auto& map, auto index) {
-        constexpr size_t count = decltype(index)::value;
-        using Map = std::decay_t<decltype(map)>;
+  tuple_transform(maps_, [&inv_jac, &mapped_point, time, &functions_of_time](
+                             const auto& map, auto index) {
+    constexpr size_t count = decltype(index)::value;
+    using Map = std::decay_t<decltype(map)>;
 
-        tnsr::Ij<T, dim, Frame::NoFrame> noframe_inv_jac{};
+    tnsr::Ij<T, dim, Frame::NoFrame> noframe_inv_jac{};
 
-        if (UNLIKELY(count == 0)) {
-          detail::get_inv_jacobian(
-              make_not_null(&noframe_inv_jac), map, mapped_point, time,
-              functions_of_time,
-              domain::is_jacobian_time_dependent_t<Map, T>{});
-          for (size_t source = 0; source < dim; ++source) {
-            for (size_t target = 0; target < dim; ++target) {
-              inv_jac.get(source, target) =
-                  std::move(noframe_inv_jac.get(source, target));
-            }
-          }
-        } else if (LIKELY(not map.is_identity())) {
-          detail::get_inv_jacobian(
-              make_not_null(&noframe_inv_jac), map, mapped_point, time,
-              functions_of_time,
-              domain::is_jacobian_time_dependent_t<Map, T>{});
-          detail::multiply_inv_jacobian(make_not_null(&inv_jac),
-                                        noframe_inv_jac);
+    if (UNLIKELY(count == 0)) {
+      detail::get_inv_jacobian(make_not_null(&noframe_inv_jac), map,
+                               mapped_point, time, functions_of_time,
+                               domain::is_jacobian_time_dependent_t<Map, T>{});
+      for (size_t source = 0; source < dim; ++source) {
+        for (size_t target = 0; target < dim; ++target) {
+          inv_jac.get(source, target) =
+              std::move(noframe_inv_jac.get(source, target));
         }
+      }
+    } else if (LIKELY(not map.is_identity())) {
+      detail::get_inv_jacobian(make_not_null(&noframe_inv_jac), map,
+                               mapped_point, time, functions_of_time,
+                               domain::is_jacobian_time_dependent_t<Map, T>{});
+      detail::multiply_inv_jacobian(make_not_null(&inv_jac), noframe_inv_jac);
+    }
 
-        // Compute the source coordinates for the next map, only if we are not
-        // the last map and the map is not the identity.
-        if (not map.is_identity() and count + 1 != sizeof...(Maps)) {
-          CoordinateMap_detail::apply_map(
-              make_not_null(&mapped_point), map, time, functions_of_time,
-              domain::is_map_time_dependent_t<decltype(map)>{});
-        }
-      });
+    // Compute the source coordinates for the next map, only if we are not
+    // the last map and the map is not the identity.
+    if (not map.is_identity() and count + 1 != sizeof...(Maps)) {
+      CoordinateMap_detail::apply_map(
+          make_not_null(&mapped_point), map, time, functions_of_time,
+          domain::is_map_time_dependent_t<decltype(map)>{});
+    }
+  });
   return inv_jac;
 }
 
@@ -299,44 +293,41 @@ auto CoordinateMap<SourceFrame, TargetFrame, Maps...>::jacobian_impl(
     tnsr::I<T, dim, SourceFrame>&& source_point, const double time,
     const std::unordered_map<
         std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
-        functions_of_time) const
-    -> Jacobian<T, dim, SourceFrame, TargetFrame> {
+        functions_of_time) const -> Jacobian<T, dim, SourceFrame, TargetFrame> {
   std::array<T, dim> mapped_point = make_array<T, dim>(std::move(source_point));
   Jacobian<T, dim, SourceFrame, TargetFrame> jac{};
 
-  tuple_transform(
-      maps_, [&jac, &mapped_point, time, &functions_of_time](
-                 const auto& map, auto index) {
-        constexpr size_t count = decltype(index)::value;
-        using Map = std::decay_t<decltype(map)>;
+  tuple_transform(maps_, [&jac, &mapped_point, time, &functions_of_time](
+                             const auto& map, auto index) {
+    constexpr size_t count = decltype(index)::value;
+    using Map = std::decay_t<decltype(map)>;
 
-        tnsr::Ij<T, dim, Frame::NoFrame> noframe_jac{};
+    tnsr::Ij<T, dim, Frame::NoFrame> noframe_jac{};
 
-        if (UNLIKELY(count == 0)) {
-          detail::get_jacobian(make_not_null(&noframe_jac), map, mapped_point,
-                               time, functions_of_time,
-                               domain::is_jacobian_time_dependent_t<Map, T>{});
-          for (size_t target = 0; target < dim; ++target) {
-            for (size_t source = 0; source < dim; ++source) {
-              jac.get(target, source) =
-                  std::move(noframe_jac.get(target, source));
-            }
-          }
-        } else if (LIKELY(not map.is_identity())) {
-          detail::get_jacobian(make_not_null(&noframe_jac), map, mapped_point,
-                               time, functions_of_time,
-                               domain::is_jacobian_time_dependent_t<Map, T>{});
-          detail::multiply_jacobian(make_not_null(&jac), noframe_jac);
+    if (UNLIKELY(count == 0)) {
+      detail::get_jacobian(make_not_null(&noframe_jac), map, mapped_point, time,
+                           functions_of_time,
+                           domain::is_jacobian_time_dependent_t<Map, T>{});
+      for (size_t target = 0; target < dim; ++target) {
+        for (size_t source = 0; source < dim; ++source) {
+          jac.get(target, source) = std::move(noframe_jac.get(target, source));
         }
+      }
+    } else if (LIKELY(not map.is_identity())) {
+      detail::get_jacobian(make_not_null(&noframe_jac), map, mapped_point, time,
+                           functions_of_time,
+                           domain::is_jacobian_time_dependent_t<Map, T>{});
+      detail::multiply_jacobian(make_not_null(&jac), noframe_jac);
+    }
 
-        // Compute the source coordinates for the next map, only if we are not
-        // the last map and the map is not the identity.
-        if (not map.is_identity() and count + 1 != sizeof...(Maps)) {
-          CoordinateMap_detail::apply_map(
-              make_not_null(&mapped_point), map, time, functions_of_time,
-              domain::is_map_time_dependent_t<decltype(map)>{});
-        }
-      });
+    // Compute the source coordinates for the next map, only if we are not
+    // the last map and the map is not the identity.
+    if (not map.is_identity() and count + 1 != sizeof...(Maps)) {
+      CoordinateMap_detail::apply_map(
+          make_not_null(&mapped_point), map, time, functions_of_time,
+          domain::is_map_time_dependent_t<decltype(map)>{});
+    }
+  });
   return jac;
 }
 
@@ -507,9 +498,8 @@ auto CoordinateMap<SourceFrame, TargetFrame, Maps...>::get_to_grid_frame_impl(
 }
 
 template <typename SourceFrame, typename TargetFrame, typename... Maps>
-bool operator!=(
-    const CoordinateMap<SourceFrame, TargetFrame, Maps...>& lhs,
-    const CoordinateMap<SourceFrame, TargetFrame, Maps...>& rhs) {
+bool operator!=(const CoordinateMap<SourceFrame, TargetFrame, Maps...>& lhs,
+                const CoordinateMap<SourceFrame, TargetFrame, Maps...>& rhs) {
   return not(lhs == rhs);
 }
 
@@ -532,8 +522,7 @@ auto make_coordinate_map_base(Maps&&... maps)
 
 template <typename SourceFrame, typename TargetFrame, typename Arg0,
           typename... Args>
-auto make_vector_coordinate_map_base(Arg0&& arg_0,
-                                     Args&&... remaining_args)
+auto make_vector_coordinate_map_base(Arg0&& arg_0, Args&&... remaining_args)
     -> std::vector<std::unique_ptr<
         CoordinateMapBase<SourceFrame, TargetFrame, std::decay_t<Arg0>::dim>>> {
   std::vector<std::unique_ptr<
@@ -579,8 +568,7 @@ template <typename... NewMaps, typename SourceFrame, typename TargetFrame,
 CoordinateMap<SourceFrame, TargetFrame, Maps..., NewMaps...> push_back_impl(
     CoordinateMap<SourceFrame, TargetFrame, Maps...>&& old_map,
     CoordinateMap<SourceFrame, TargetFrame, NewMaps...> new_map,
-    std::index_sequence<Is...> /*meta*/,
-    std::index_sequence<Js...> /*meta*/) {
+    std::index_sequence<Is...> /*meta*/, std::index_sequence<Js...> /*meta*/) {
   return CoordinateMap<SourceFrame, TargetFrame, Maps..., NewMaps...>{
       std::move(std::get<Is>(old_map.maps_))...,
       std::move(std::get<Js>(new_map.maps_))...};
@@ -598,8 +586,7 @@ CoordinateMap<SourceFrame, TargetFrame, NewMap, Maps...> push_front_impl(
 template <typename SourceFrame, typename TargetFrame, typename... Maps,
           typename NewMap>
 CoordinateMap<SourceFrame, TargetFrame, Maps..., NewMap> push_back(
-    CoordinateMap<SourceFrame, TargetFrame, Maps...> old_map,
-    NewMap new_map) {
+    CoordinateMap<SourceFrame, TargetFrame, Maps...> old_map, NewMap new_map) {
   return push_back_impl(std::move(old_map), std::move(new_map),
                         std::make_index_sequence<sizeof...(Maps)>{});
 }
@@ -617,8 +604,7 @@ CoordinateMap<SourceFrame, TargetFrame, Maps..., NewMaps...> push_back(
 template <typename SourceFrame, typename TargetFrame, typename... Maps,
           typename NewMap>
 CoordinateMap<SourceFrame, TargetFrame, NewMap, Maps...> push_front(
-    CoordinateMap<SourceFrame, TargetFrame, Maps...> old_map,
-    NewMap new_map) {
+    CoordinateMap<SourceFrame, TargetFrame, Maps...> old_map, NewMap new_map) {
   return push_front_impl(std::move(old_map), std::move(new_map),
                          std::make_index_sequence<sizeof...(Maps)>{});
 }

--- a/src/Domain/CoordinateMaps/TimeDependent/CubicScale.cpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/CubicScale.cpp
@@ -150,7 +150,7 @@ std::optional<std::array<double, Dim>> CubicScale<Dim>::inverse(
     return {make_array<Dim>(0.0)};
   }
 
-  double scale_factor;
+  double scale_factor = std::numeric_limits<double>::signaling_NaN();
   // Check if x_bar is outside of the range of the map.
   // We need a slight buffer because computing (r/R) is not equal to (r * (1/R))
   // at roundoff and thus to make sure we include the boundary we need to

--- a/src/Domain/CoordinateMaps/TimeDependent/CubicScale.cpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/CubicScale.cpp
@@ -21,7 +21,6 @@
 #include "NumericalAlgorithms/RootFinding/TOMS748.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/DereferenceWrapper.hpp"
-#include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
@@ -54,15 +53,6 @@ std::array<tt::remove_cvref_wrap_t<T>, Dim> CubicScale<Dim>::operator()(
     const std::unordered_map<
         std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
         functions_of_time) const {
-  ASSERT(functions_of_time.find(f_of_t_a_) != functions_of_time.end(),
-         "Could not find function of time: '"
-             << f_of_t_a_ << "' in functions of time. Known functions are "
-             << keys_of(functions_of_time));
-  ASSERT(functions_of_time.find(f_of_t_b_) != functions_of_time.end(),
-         "Could not find function of time: '"
-             << f_of_t_b_ << "' in functions of time. Known functions are "
-             << keys_of(functions_of_time));
-
   const double a_of_t = functions_of_time.at(f_of_t_a_)->func(time)[0][0];
 
   if (functions_of_time_equal_) {
@@ -100,15 +90,6 @@ std::optional<std::array<double, Dim>> CubicScale<Dim>::inverse(
     const std::unordered_map<
         std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
         functions_of_time) const {
-  ASSERT(functions_of_time.find(f_of_t_a_) != functions_of_time.end(),
-         "Could not find function of time: '"
-             << f_of_t_a_ << "' in functions of time. Known functions are "
-             << keys_of(functions_of_time));
-  ASSERT(functions_of_time.find(f_of_t_b_) != functions_of_time.end(),
-         "Could not find function of time: '"
-             << f_of_t_b_ << "' in functions of time. Known functions are "
-             << keys_of(functions_of_time));
-
   if (functions_of_time_equal_) {
     // optimization for linear radial scaling
     const double one_over_a_of_t =
@@ -188,15 +169,6 @@ std::array<tt::remove_cvref_wrap_t<T>, Dim> CubicScale<Dim>::frame_velocity(
     const std::unordered_map<
         std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
         functions_of_time) const {
-  ASSERT(functions_of_time.find(f_of_t_a_) != functions_of_time.end(),
-         "Could not find function of time: '"
-             << f_of_t_a_ << "' in functions of time. Known functions are "
-             << keys_of(functions_of_time));
-  ASSERT(functions_of_time.find(f_of_t_b_) != functions_of_time.end(),
-         "Could not find function of time: '"
-             << f_of_t_b_ << "' in functions of time. Known functions are "
-             << keys_of(functions_of_time));
-
   const double dt_a_of_t =
       functions_of_time.at(f_of_t_a_)->func_and_deriv(time)[1][0];
 
@@ -238,15 +210,6 @@ CubicScale<Dim>::jacobian(
     const std::unordered_map<
         std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
         functions_of_time) const {
-  ASSERT(functions_of_time.find(f_of_t_a_) != functions_of_time.end(),
-         "Could not find function of time: '"
-             << f_of_t_a_ << "' in functions of time. Known functions are "
-             << keys_of(functions_of_time));
-  ASSERT(functions_of_time.find(f_of_t_b_) != functions_of_time.end(),
-         "Could not find function of time: '"
-             << f_of_t_b_ << "' in functions of time. Known functions are "
-             << keys_of(functions_of_time));
-
   const double a_of_t = functions_of_time.at(f_of_t_a_)->func(time)[0][0];
 
   if (functions_of_time_equal_) {
@@ -299,15 +262,6 @@ CubicScale<Dim>::inv_jacobian(
     const std::unordered_map<
         std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
         functions_of_time) const {
-  ASSERT(functions_of_time.find(f_of_t_a_) != functions_of_time.end(),
-         "Could not find function of time: '"
-             << f_of_t_a_ << "' in functions of time. Known functions are "
-             << keys_of(functions_of_time));
-  ASSERT(functions_of_time.find(f_of_t_b_) != functions_of_time.end(),
-         "Could not find function of time: '"
-             << f_of_t_b_ << "' in functions of time. Known functions are "
-             << keys_of(functions_of_time));
-
   const double a_of_t = functions_of_time.at(f_of_t_a_)->func(time)[0][0];
 
   if (functions_of_time_equal_) {

--- a/src/Domain/CoordinateMaps/TimeDependent/CubicScale.cpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/CubicScale.cpp
@@ -12,6 +12,7 @@
 #include <pup_stl.h>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <utility>
 
 #include "DataStructures/DataVector.hpp"
@@ -37,6 +38,7 @@ CubicScale<Dim>::CubicScale(const double outer_boundary,
                             std::string function_of_time_name_b)
     : f_of_t_a_(std::move(function_of_time_name_a)),
       f_of_t_b_(std::move(function_of_time_name_b)),
+      f_of_t_names_({f_of_t_a_, f_of_t_b_}),
       functions_of_time_equal_(f_of_t_a_ == f_of_t_b_) {
   if (outer_boundary <= 0.0) {
     ERROR("For invertability, we require outer_boundary to be positive, but is "
@@ -378,6 +380,11 @@ void CubicScale<Dim>::pup(PUP::er& p) {
     p | f_of_t_b_;
     p | one_over_outer_boundary_;
     p | functions_of_time_equal_;
+  }
+
+  // No need to pup this because it is uniquely determined by f_of_t_{a,b}_
+  if (p.isUnpacking()) {
+    f_of_t_names_ = std::unordered_set<std::string>{{f_of_t_a_, f_of_t_b_}};
   }
 }
 

--- a/src/Domain/CoordinateMaps/TimeDependent/CubicScale.hpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/CubicScale.hpp
@@ -10,6 +10,7 @@
 #include <optional>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Utilities/TypeTraits/RemoveReferenceWrapper.hpp"
@@ -154,6 +155,10 @@ class CubicScale {
 
   static bool is_identity() { return false; }
 
+  const std::unordered_set<std::string>& function_of_time_names() const {
+    return f_of_t_names_;
+  }
+
  private:
   template <size_t LocalDim>
   // NOLINTNEXTLINE(readability-redundant-declaration)
@@ -162,6 +167,7 @@ class CubicScale {
 
   std::string f_of_t_a_{};
   std::string f_of_t_b_{};
+  std::unordered_set<std::string> f_of_t_names_;
   double one_over_outer_boundary_{std::numeric_limits<double>::signaling_NaN()};
   bool functions_of_time_equal_{false};
 };

--- a/src/Domain/CoordinateMaps/TimeDependent/ProductMaps.hpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/ProductMaps.hpp
@@ -10,6 +10,7 @@
 #include <optional>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <utility>
 
 #include "DataStructures/Tensor/Tensor.hpp"
@@ -103,6 +104,10 @@ class ProductOf2Maps {
     return map1_.is_identity() and map2_.is_identity();
   }
 
+  const std::unordered_set<std::string>& function_of_time_names() const {
+    return f_of_t_names_;
+  }
+
  private:
   friend bool operator==(const ProductOf2Maps& lhs, const ProductOf2Maps& rhs) {
     return lhs.map1_ == rhs.map1_ and lhs.map2_ == rhs.map2_;
@@ -110,6 +115,7 @@ class ProductOf2Maps {
 
   Map1 map1_;
   Map2 map2_;
+  std::unordered_set<std::string> f_of_t_names_;
 };
 
 template <typename Map1, typename Map2>
@@ -183,6 +189,10 @@ class ProductOf3Maps {
     return map1_.is_identity() and map2_.is_identity() and map3_.is_identity();
   }
 
+  const std::unordered_set<std::string>& function_of_time_names() const {
+    return f_of_t_names_;
+  }
+
  private:
   friend bool operator==(const ProductOf3Maps& lhs, const ProductOf3Maps& rhs) {
     return lhs.map1_ == rhs.map1_ and lhs.map2_ == rhs.map2_ and
@@ -192,6 +202,7 @@ class ProductOf3Maps {
   Map1 map1_;
   Map2 map2_;
   Map3 map3_;
+  std::unordered_set<std::string> f_of_t_names_;
 };
 
 template <typename Map1, typename Map2, typename Map3>

--- a/src/Domain/CoordinateMaps/TimeDependent/Rotation.cpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/Rotation.cpp
@@ -16,7 +16,6 @@
 #include "Domain/CoordinateMaps/TimeDependent/RotationMatrixHelpers.hpp"
 #include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
 #include "Utilities/DereferenceWrapper.hpp"
-#include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/MakeWithValue.hpp"
 #include "Utilities/StdHelpers.hpp"
@@ -35,11 +34,6 @@ std::array<tt::remove_cvref_wrap_t<T>, Dim> Rotation<Dim>::operator()(
     const std::unordered_map<
         std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
         functions_of_time) const {
-  ASSERT(functions_of_time.find(f_of_t_name_) != functions_of_time.end(),
-         "Could not find function of time: '"
-             << f_of_t_name_ << "' in functions of time. Known functions are "
-             << keys_of(functions_of_time));
-
   const Matrix rot_matrix =
       rotation_matrix<Dim>(time, *(functions_of_time.at(f_of_t_name_)));
 
@@ -59,11 +53,6 @@ std::optional<std::array<double, Dim>> Rotation<Dim>::inverse(
     const std::unordered_map<
         std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
         functions_of_time) const {
-  ASSERT(functions_of_time.find(f_of_t_name_) != functions_of_time.end(),
-         "Could not find function of time: '"
-             << f_of_t_name_ << "' in functions of time. Known functions are "
-             << keys_of(functions_of_time));
-
   const Matrix rot_matrix =
       rotation_matrix<Dim>(time, *(functions_of_time.at(f_of_t_name_)));
 
@@ -86,11 +75,6 @@ std::array<tt::remove_cvref_wrap_t<T>, Dim> Rotation<Dim>::frame_velocity(
     const std::unordered_map<
         std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
         functions_of_time) const {
-  ASSERT(functions_of_time.find(f_of_t_name_) != functions_of_time.end(),
-         "Could not find function of time: '"
-             << f_of_t_name_ << "' in functions of time. Known functions are "
-             << keys_of(functions_of_time));
-
   const Matrix rot_matrix_deriv =
       rotation_matrix_deriv<Dim>(time, *(functions_of_time.at(f_of_t_name_)));
 
@@ -113,11 +97,6 @@ Rotation<Dim>::jacobian(
     const std::unordered_map<
         std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
         functions_of_time) const {
-  ASSERT(functions_of_time.find(f_of_t_name_) != functions_of_time.end(),
-         "Could not find function of time: '"
-             << f_of_t_name_ << "' in functions of time. Known functions are "
-             << keys_of(functions_of_time));
-
   const Matrix rot_matrix =
       rotation_matrix<Dim>(time, *(functions_of_time.at(f_of_t_name_)));
 
@@ -143,11 +122,6 @@ Rotation<Dim>::inv_jacobian(
     const std::unordered_map<
         std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
         functions_of_time) const {
-  ASSERT(functions_of_time.find(f_of_t_name_) != functions_of_time.end(),
-         "Could not find function of time: '"
-             << f_of_t_name_ << "' in functions of time. Known functions are "
-             << keys_of(functions_of_time));
-
   const Matrix rot_matrix =
       rotation_matrix<Dim>(time, *(functions_of_time.at(f_of_t_name_)));
 

--- a/src/Domain/CoordinateMaps/TimeDependent/Rotation.cpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/Rotation.cpp
@@ -7,6 +7,7 @@
 #include <ostream>
 #include <pup.h>
 #include <pup_stl.h>
+#include <unordered_set>
 #include <utility>
 
 #include "DataStructures/DataVector.hpp"
@@ -24,7 +25,8 @@ namespace domain::CoordinateMaps::TimeDependent {
 
 template <size_t Dim>
 Rotation<Dim>::Rotation(std::string function_of_time_name)
-    : f_of_t_name_(std::move(function_of_time_name)) {}
+    : f_of_t_name_(std::move(function_of_time_name)),
+      f_of_t_names_({f_of_t_name_}) {}
 
 template <size_t Dim>
 template <typename T>
@@ -173,6 +175,12 @@ void Rotation<Dim>::pup(PUP::er& p) {
   // whenever possible. See `Domain` docs for details.
   if (version >= 0) {
     p | f_of_t_name_;
+  }
+
+  // No need to pup this because it is uniquely determined by f_of_t_name_
+  if (p.isUnpacking()) {
+    f_of_t_names_.clear();
+    f_of_t_names_.insert(f_of_t_name_);
   }
 }
 

--- a/src/Domain/CoordinateMaps/TimeDependent/Rotation.hpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/Rotation.hpp
@@ -9,6 +9,7 @@
 #include <optional>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Utilities/TypeTraits/RemoveReferenceWrapper.hpp"
@@ -214,12 +215,17 @@ class Rotation {
 
   static bool is_identity() { return false; }
 
+  const std::unordered_set<std::string>& function_of_time_names() const {
+    return f_of_t_names_;
+  }
+
  private:
   template <size_t LocalDim>
   // NOLINTNEXTLINE(readability-redundant-declaration)
   friend bool operator==(const Rotation<LocalDim>& lhs,
                          const Rotation<LocalDim>& rhs);
   std::string f_of_t_name_;
+  std::unordered_set<std::string> f_of_t_names_;
 };
 
 template <size_t Dim>

--- a/src/Domain/CoordinateMaps/TimeDependent/Shape.cpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/Shape.cpp
@@ -11,6 +11,7 @@
 #include <pup.h>
 #include <pup_stl.h>
 #include <string>
+#include <unordered_set>
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp"
@@ -46,6 +47,10 @@ Shape::Shape(
       m_max_(m_max),
       ylm_(l_max, m_max),
       transition_func_(std::move(transition_func)) {
+  f_of_t_names_.insert(shape_f_of_t_name_);
+  if (size_f_of_t_name_.has_value()) {
+    f_of_t_names_.insert(size_f_of_t_name_.value());
+  }
   ASSERT(l_max >= 2, "The shape map requires l_max >= 2 but l_max = " << l_max);
   ASSERT(m_max >= 2, "The shape map requires m_max >= 2 but m_max = " << m_max);
   ASSERT(l_max >= m_max, "The shape map requires l_max >= m_max but l_max = "
@@ -56,6 +61,7 @@ Shape& Shape::operator=(const Shape& rhs) {
   if (*this != rhs) {
     shape_f_of_t_name_ = rhs.shape_f_of_t_name_;
     size_f_of_t_name_ = rhs.size_f_of_t_name_;
+    f_of_t_names_ = rhs.f_of_t_names_;
     center_ = rhs.center_;
     l_max_ = rhs.l_max_;
     m_max_ = rhs.m_max_;
@@ -395,8 +401,14 @@ void Shape::pup(PUP::er& p) {
     p | transition_func_;
   }
 
+  // No need to pup these because they are uniquely determined by other members
   if (p.isUnpacking()) {
     ylm_ = ylm::Spherepack(l_max_, m_max_);
+    f_of_t_names_.clear();
+    f_of_t_names_.insert(shape_f_of_t_name_);
+    if (size_f_of_t_name_.has_value()) {
+      f_of_t_names_.insert(size_f_of_t_name_.value());
+    }
   }
 }
 

--- a/src/Domain/CoordinateMaps/TimeDependent/Shape.cpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/Shape.cpp
@@ -77,12 +77,6 @@ template <typename T>
 std::array<tt::remove_cvref_wrap_t<T>, 3> Shape::operator()(
     const std::array<T, 3>& source_coords, const double time,
     const FunctionsOfTimeMap& functions_of_time) const {
-  ASSERT(functions_of_time.find(shape_f_of_t_name_) != functions_of_time.end(),
-         "Could not find function of time: '"
-             << shape_f_of_t_name_
-             << "' in functions of time. Known functions are "
-             << keys_of(functions_of_time));
-
   const auto centered_coords = center_coordinates(source_coords);
   auto theta_phis = cartesian_to_spherical(centered_coords);
   const auto interpolation_info = ylm_.set_up_interpolation_info(theta_phis);
@@ -118,12 +112,6 @@ std::array<tt::remove_cvref_wrap_t<T>, 3> Shape::operator()(
 std::optional<std::array<double, 3>> Shape::inverse(
     const std::array<double, 3>& target_coords, const double time,
     const FunctionsOfTimeMap& functions_of_time) const {
-  ASSERT(functions_of_time.find(shape_f_of_t_name_) != functions_of_time.end(),
-         "Could not find function of time: '"
-             << shape_f_of_t_name_
-             << "' in functions of time. Known functions are "
-             << keys_of(functions_of_time));
-
   const std::array<double, 3> centered_coords =
       center_coordinates(target_coords);
   const std::array<double, 2> theta_phis =
@@ -145,11 +133,6 @@ template <typename T>
 std::array<tt::remove_cvref_wrap_t<T>, 3> Shape::frame_velocity(
     const std::array<T, 3>& source_coords, const double time,
     const FunctionsOfTimeMap& functions_of_time) const {
-  ASSERT(functions_of_time.find(shape_f_of_t_name_) != functions_of_time.end(),
-         "Could not find function of time: '"
-             << shape_f_of_t_name_
-             << "' in functions of time. Known functions are "
-             << keys_of(functions_of_time));
   const auto centered_coords = center_coordinates(source_coords);
   auto theta_phis = cartesian_to_spherical(centered_coords);
   const auto interpolation_info = ylm_.set_up_interpolation_info(theta_phis);
@@ -169,12 +152,6 @@ template <typename T>
 tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame> Shape::jacobian(
     const std::array<T, 3>& source_coords, const double time,
     const FunctionsOfTimeMap& functions_of_time) const {
-  ASSERT(functions_of_time.find(shape_f_of_t_name_) != functions_of_time.end(),
-         "Could not find function of time: '"
-             << shape_f_of_t_name_
-             << "' in functions of time. Known functions are "
-             << keys_of(functions_of_time));
-
   const auto centered_coords = center_coordinates(source_coords);
 
   // The distorted radii are calculated analogously to the call operator
@@ -341,12 +318,6 @@ void Shape::check_size(const gsl::not_null<DataVector*>& coefs,
                        const FunctionsOfTimeMap& functions_of_time,
                        const double time, const bool use_deriv) const {
   if (size_f_of_t_name_.has_value()) {
-    ASSERT(functions_of_time.find(size_f_of_t_name_.value()) !=
-               functions_of_time.end(),
-           "Could not find function of time: '"
-               << size_f_of_t_name_.value()
-               << "' in functions of time. Known functions are "
-               << keys_of(functions_of_time));
     ASSERT((*coefs)[0] == 0.0,
            "When using a size function of time, the l=0 "
                << (use_deriv ? "derivative" : "component")

--- a/src/Domain/CoordinateMaps/TimeDependent/Shape.hpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/Shape.hpp
@@ -7,6 +7,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <unordered_set>
 
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/ShapeMapTransitionFunction.hpp"
@@ -195,9 +196,14 @@ class Shape {
   static bool is_identity() { return false; }
   static constexpr size_t dim = 3;
 
+  const std::unordered_set<std::string>& function_of_time_names() const {
+    return f_of_t_names_;
+  }
+
  private:
   std::string shape_f_of_t_name_;
   std::optional<std::string> size_f_of_t_name_;
+  std::unordered_set<std::string> f_of_t_names_;
   std::array<double, 3> center_{};
   size_t l_max_ = 2;
   size_t m_max_ = 2;

--- a/src/Domain/CoordinateMaps/TimeDependent/SphericalCompression.cpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/SphericalCompression.cpp
@@ -37,10 +37,6 @@ double lambda00_y00(
     const std::unordered_map<
         std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
         functions_of_time) {
-  ASSERT(functions_of_time.find(f_of_t_name) != functions_of_time.end(),
-         "Could not find function of time: '"
-             << f_of_t_name << "' in functions of time. Known functions are "
-             << keys_of(functions_of_time));
   return functions_of_time.at(f_of_t_name)->func(time)[0][0] * 0.25 *
          M_2_SQRTPI;
 }
@@ -51,10 +47,6 @@ double dt_lambda00_y00(
     const std::unordered_map<
         std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
         functions_of_time) {
-  ASSERT(functions_of_time.find(f_of_t_name) != functions_of_time.end(),
-         "Could not find function of time: '"
-             << f_of_t_name << "' in functions of time. Known functions are "
-             << keys_of(functions_of_time));
   return functions_of_time.at(f_of_t_name)->func_and_deriv(time)[1][0] * 0.25 *
          M_2_SQRTPI;
 }

--- a/src/Domain/CoordinateMaps/TimeDependent/SphericalCompression.cpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/SphericalCompression.cpp
@@ -11,6 +11,7 @@
 #include <pup_stl.h>
 #include <string>
 #include <type_traits>
+#include <unordered_set>
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp"
@@ -136,6 +137,7 @@ SphericalCompression<InteriorMap>::SphericalCompression(
     std::string function_of_time_name, const double min_radius,
     const double max_radius, const std::array<double, 3>& center)
     : f_of_t_name_(std::move(function_of_time_name)),
+      f_of_t_names_({f_of_t_name_}),
       min_radius_(min_radius),
       max_radius_(max_radius),
       center_(center) {
@@ -296,6 +298,12 @@ void SphericalCompression<InteriorMap>::pup(PUP::er& p) {
     p | max_radius_;
     p | center_;
   }
+
+  // No need to pup this because it is uniquely determined by f_of_t_name_
+  if (p.isUnpacking()) {
+    f_of_t_names_.clear();
+    f_of_t_names_.insert(f_of_t_name_);
+  }
 }
 
 #define INTERIOR_MAP(data) BOOST_PP_TUPLE_ELEM(0, data)
@@ -354,6 +362,5 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (true, false),
 GENERATE_INSTANTIATIONS(INSTANTIATE, (true, false))
 #undef INTERIOR_MAP
 #undef INSTANTIATE
-
 
 }  // namespace domain::CoordinateMaps::TimeDependent

--- a/src/Domain/CoordinateMaps/TimeDependent/SphericalCompression.hpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/SphericalCompression.hpp
@@ -10,6 +10,7 @@
 #include <optional>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Utilities/TypeTraits/RemoveReferenceWrapper.hpp"
@@ -314,6 +315,10 @@ class SphericalCompression {
 
   static bool is_identity() { return false; }
 
+  const std::unordered_set<std::string>& function_of_time_names() const {
+    return f_of_t_names_;
+  }
+
  private:
   friend bool operator==(const SphericalCompression& lhs,
                          const SphericalCompression& rhs) {
@@ -322,6 +327,7 @@ class SphericalCompression {
            lhs.max_radius_ == rhs.max_radius_ and lhs.center_ == rhs.center_;
   }
   std::string f_of_t_name_;
+  std::unordered_set<std::string> f_of_t_names_;
   double min_radius_ = std::numeric_limits<double>::signaling_NaN();
   double max_radius_ = std::numeric_limits<double>::signaling_NaN();
   std::array<double, 3> center_;

--- a/src/Domain/CoordinateMaps/TimeDependent/Translation.cpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/Translation.cpp
@@ -73,11 +73,6 @@ std::optional<std::array<double, Dim>> Translation<Dim>::inverse(
     const std::unordered_map<
         std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
         functions_of_time) const {
-  ASSERT(functions_of_time.count(f_of_t_name_) == 1,
-         "The function of time '" << f_of_t_name_
-                                  << "' is not one of the known functions of "
-                                     "time. The known functions of time are: "
-                                  << keys_of(functions_of_time));
   std::array<double, Dim> result{};
   for (size_t i = 0; i < Dim; i++) {
     gsl::at(result, i) = gsl::at(target_coords, i);
@@ -179,11 +174,6 @@ std::array<tt::remove_cvref_wrap_t<T>, Dim> Translation<Dim>::coord_helper(
         std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
         functions_of_time,
     const size_t function_or_deriv_index) const {
-  ASSERT(functions_of_time.count(f_of_t_name_) == 1,
-         "The function of time '" << f_of_t_name_
-                                  << "' is not one of the known functions of "
-                                     "time. The known functions of time are: "
-                                  << keys_of(functions_of_time));
   const auto func_or_deriv_of_time =
       gsl::at(functions_of_time.at(f_of_t_name_)->func_and_deriv(time),
               function_or_deriv_index);

--- a/src/Domain/CoordinateMaps/TimeDependent/Translation.cpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/Translation.cpp
@@ -7,6 +7,7 @@
 #include <ostream>
 #include <pup.h>
 #include <pup_stl.h>
+#include <unordered_set>
 #include <utility>
 
 #include "DataStructures/DataVector.hpp"
@@ -30,6 +31,7 @@ namespace domain::CoordinateMaps::TimeDependent {
 template <size_t Dim>
 Translation<Dim>::Translation(std::string function_of_time_name)
     : f_of_t_name_(std::move(function_of_time_name)),
+      f_of_t_names_({f_of_t_name_}),
       f_of_r_(nullptr),
       center_(make_array<Dim, double>(0.0)) {}
 
@@ -39,12 +41,14 @@ Translation<Dim>::Translation(
     std::unique_ptr<MathFunction<1, Frame::Inertial>> radial_function,
     std::array<double, Dim>& center)
     : f_of_t_name_(std::move(function_of_time_name)),
+      f_of_t_names_({f_of_t_name_}),
       f_of_r_(std::move(radial_function)),
       center_(center) {}
 
 template <size_t Dim>
 Translation<Dim>::Translation(const Translation<Dim>& Translation_Map)
     : f_of_t_name_(Translation_Map.f_of_t_name_),
+      f_of_t_names_(Translation_Map.f_of_t_names_),
       center_(Translation_Map.center_) {
   if (Translation_Map.f_of_r_ == nullptr) {
     f_of_r_ = nullptr;
@@ -259,6 +263,12 @@ void Translation<Dim>::pup(PUP::er& p) {
   } else if (p.isUnpacking()) {
     f_of_r_ = nullptr;
     center_ = make_array<Dim, double>(0.0);
+  }
+
+  // No need to pup this because it is uniquely determined by f_of_t_name_
+  if (p.isUnpacking()) {
+    f_of_t_names_.clear();
+    f_of_t_names_.insert(f_of_t_name_);
   }
 }
 

--- a/src/Domain/CoordinateMaps/TimeDependent/Translation.hpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/Translation.hpp
@@ -9,6 +9,7 @@
 #include <optional>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "PointwiseFunctions/MathFunctions/MathFunction.hpp"
@@ -162,6 +163,10 @@ class Translation {
 
   static bool is_identity() { return false; }
 
+  const std::unordered_set<std::string>& function_of_time_names() const {
+    return f_of_t_names_;
+  }
+
  private:
   template <size_t LocalDim>
   friend bool operator==(  // NOLINT(readability-redundant-declaration)
@@ -183,6 +188,7 @@ class Translation {
                      const DataVector& function_of_time) const;
 
   std::string f_of_t_name_{};
+  std::unordered_set<std::string> f_of_t_names_;
   std::unique_ptr<MathFunction<1, Frame::Inertial>> f_of_r_{};
   std::array<double, Dim> center_{};
 };

--- a/tests/Unit/Domain/CoordinateMaps/Test_Composition.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_Composition.cpp
@@ -67,6 +67,7 @@ void test_composition() {
   CHECK_FALSE(map.is_identity());
   CHECK_FALSE(map.inv_jacobian_is_time_dependent());
   CHECK_FALSE(map.jacobian_is_time_dependent());
+  CHECK(map.function_of_time_names().empty());
 
   const auto xi =
       make_with_random_values<tnsr::I<DataVector, 2, Frame::ElementLogical>>(
@@ -112,6 +113,7 @@ void test_identity() {
                   {-1., 1., -1., 1.}, {-1., 1., -1., 1.}, {-1., 1., -1., 1.}})};
 
   CHECK(map.is_identity());
+  CHECK(map.function_of_time_names().empty());
 
   const auto xi =
       make_with_random_values<tnsr::I<DataVector, 3, Frame::ElementLogical>>(
@@ -155,6 +157,7 @@ void test_3d() {
       std::make_unique<
           CoordinateMap<Frame::BlockLogical, Frame::Inertial, Wedge<3>>>(
           Wedge<3>{1., 3., 1., 1., {}, true})};
+  CHECK(map.function_of_time_names().empty());
 
   // Check some points that are easy to calculate
   // - On inner boundary

--- a/tests/Unit/Domain/CoordinateMaps/Test_CoordinateMap.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_CoordinateMap.cpp
@@ -1337,7 +1337,7 @@ void test_coords_frame_velocity_jacobians() {
   using trans_map_3d = CoordinateMaps::TimeDependent::Translation<3>;
 
   const double initial_time = 0.0;
-  const double final_time   = 2.0;
+  const double final_time = 2.0;
   const double time = 2.0;
   constexpr size_t deriv_order = 3;
 

--- a/tests/Unit/Domain/CoordinateMaps/Test_CoordinateMap.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_CoordinateMap.cpp
@@ -180,6 +180,10 @@ void test_single_coordinate_map() {
   CHECK_FALSE(affine1d_base->jacobian_is_time_dependent());
   CHECK_FALSE(affine1d_base->inv_jacobian_is_time_dependent());
 
+  CHECK(affine1d.function_of_time_names().empty());
+  CHECK(affine1d_base->function_of_time_names().empty());
+  CHECK(affine1d_base_from_inertial->function_of_time_names().empty());
+
   using rotate2d = CoordinateMaps::Rotation<2>;
 
   const auto first_rotated2d = rotate2d{M_PI_4};
@@ -242,6 +246,10 @@ void test_single_coordinate_map() {
   CHECK_FALSE(rotated2d.jacobian_is_time_dependent());
   CHECK_FALSE(rotated2d_base->jacobian_is_time_dependent());
   CHECK_FALSE(rotated2d_base->inv_jacobian_is_time_dependent());
+
+  CHECK(rotated2d.function_of_time_names().empty());
+  CHECK(rotated2d_base->function_of_time_names().empty());
+  CHECK(rotated2d_base_from_inertial->function_of_time_names().empty());
 
   using rotate3d = CoordinateMaps::Rotation<3>;
 
@@ -310,6 +318,10 @@ void test_single_coordinate_map() {
   CHECK_FALSE(rotated3d.jacobian_is_time_dependent());
   CHECK_FALSE(rotated3d_base->jacobian_is_time_dependent());
   CHECK_FALSE(rotated3d_base->inv_jacobian_is_time_dependent());
+
+  CHECK(rotated3d.function_of_time_names().empty());
+  CHECK(rotated3d_base->function_of_time_names().empty());
+  CHECK(rotated3d_base_from_inertial->function_of_time_names().empty());
 }
 
 void test_coordinate_map_with_affine_map() {
@@ -945,6 +957,9 @@ void test_coordinate_maps_are_identity() {
   CHECK_FALSE(giant_identity_map_base->inv_jacobian_is_time_dependent());
   CHECK_FALSE(giant_identity_map_base->jacobian_is_time_dependent());
 
+  CHECK(giant_identity_map.function_of_time_names().empty());
+  CHECK(giant_identity_map_base->function_of_time_names().empty());
+
   const auto wedge = make_coordinate_map<Frame::BlockLogical, Frame::Inertial>(
       CoordinateMaps::Wedge<3>(0.2, 4.0, 0.0, 1.0, OrientationMap<3>{}, true));
   const auto wedge_composed_with_giant_identity =
@@ -1102,6 +1117,11 @@ void test_time_dependent_map() {
   CHECK(time_dependent_map_first.jacobian_is_time_dependent());
   CHECK(time_dependent_map_second.inv_jacobian_is_time_dependent());
   CHECK(time_dependent_map_second.jacobian_is_time_dependent());
+
+  CHECK(time_dependent_map_first.function_of_time_names().count(
+            "Translation") == 1);
+  CHECK(time_dependent_map_second.function_of_time_names().count(
+            "Translation") == 1);
 
   const tnsr::I<double, 1, Frame::BlockLogical> tnsr_double_logical{{{3.2}}};
   const tnsr::I<DataVector, 1, Frame::BlockLogical> tnsr_datavector_logical{

--- a/tests/Unit/Domain/CoordinateMaps/TimeDependent/Test_CubicScale.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/TimeDependent/Test_CubicScale.cpp
@@ -183,8 +183,17 @@ void test(const bool linear_expansion) {
         outer_boundary, "expansion_a",
         linear_expansion ? "expansion_a"s : "expansion_b"s);
 
+    const auto check_names = [&linear_expansion](const auto& names) {
+      CHECK(names.size() == (linear_expansion ? 1_st : 2_st));
+      CHECK(names.count("expansion_a") == 1);
+      if (not linear_expansion) {
+        CHECK(names.count("expansion_b") == 1);
+      }
+    };
+    check_names(scale_map.function_of_time_names());
     // test serialized/deserialized map
     const auto scale_map_deserialized = serialize_and_deserialize(scale_map);
+    check_names(scale_map_deserialized.function_of_time_names());
 
     while (t < final_time) {
       const double a = expansion_a_base->func_and_deriv(t)[0][0];

--- a/tests/Unit/Domain/CoordinateMaps/TimeDependent/Test_ProductMaps.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/TimeDependent/Test_ProductMaps.cpp
@@ -47,6 +47,17 @@ void test_product_of_2_maps_time_dep(
       std::is_same_v<Map2, AffineMap> or std::is_same_v<Map2, TranslationMap>,
       "Map2 must be either an affine map or a translation map");
 
+  const auto& names = map2d.function_of_time_names();
+  if (std::is_same_v<Map1, TranslationMap> and
+      std::is_same_v<Map2, TranslationMap>) {
+    CHECK(names.size() == 2);
+    CHECK(names.count("translation_x") == 1);
+    CHECK(names.count("translation_y") == 1);
+  } else {
+    CHECK(names.size() == 1);
+    CHECK(names.count("translation") == 1);
+  }
+
   const std::array<double, 2> point_source_a{{x_source_a, y_source_a}};
   const std::array<double, 2> point_source_b{{x_source_b, y_source_b}};
   const std::array<double, 2> point_xi{{xi, eta}};
@@ -301,6 +312,23 @@ void test_product_of_3_maps_time_dep(
   static_assert(
       std::is_same_v<Map3, AffineMap> or std::is_same_v<Map3, TranslationMap>,
       "Map3 must be either an affine map or a translation map");
+
+  const auto& names = map3d.function_of_time_names();
+  const size_t expected_size =
+      (std::is_same_v<Map1, TranslationMap> ? 1_st : 0_st) +
+      (std::is_same_v<Map2, TranslationMap> ? 1_st : 0_st) +
+      (std::is_same_v<Map3, TranslationMap> ? 1_st : 0_st);
+  CHECK(names.size() == expected_size);
+
+  if (std::is_same_v<Map1, TranslationMap>) {
+    CHECK(names.count("translation_x") == 1);
+  }
+  if (std::is_same_v<Map2, TranslationMap>) {
+    CHECK(names.count("translation_y") == 1);
+  }
+  if (std::is_same_v<Map3, TranslationMap>) {
+    CHECK(names.count("translation_z") == 1);
+  }
 
   const std::array<double, 3> point_source_a{
       {x_source_a, y_source_a, z_source_a}};

--- a/tests/Unit/Domain/CoordinateMaps/TimeDependent/Test_Rotation.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/TimeDependent/Test_Rotation.cpp
@@ -178,8 +178,14 @@ void test_rotation_map() {
 
   const domain::CoordinateMaps::TimeDependent::Rotation<Dim> rotation_map{
       f_of_t_name};
+  const auto check_names = [&f_of_t_name](const auto& names) {
+    CHECK(names.size() == 1);
+    CHECK(names.count(f_of_t_name) == 1);
+  };
+  check_names(rotation_map.function_of_time_names());
   const auto rotation_map_deserialized =
       serialize_and_deserialize(rotation_map);
+  check_names(rotation_map_deserialized.function_of_time_names());
 
   const std::uniform_real_distribution<double> dist{0.0, 5.0};
   auto initial_unmapped_point =

--- a/tests/Unit/Domain/CoordinateMaps/TimeDependent/Test_Shape.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/TimeDependent/Test_Shape.cpp
@@ -224,6 +224,13 @@ void generate_random_map_time_and_f_of_time(
       center, l_max, m_max,
       std::make_unique<TransitionFunction>(transition_func), shape_f_of_t_name,
       lambda_00_coef.has_value() ? size_f_of_t_name : std::nullopt);
+  const auto& function_of_time_names = map->function_of_time_names();
+  const size_t expected_size = lambda_00_coef.has_value() ? 2_st : 1_st;
+  CHECK(function_of_time_names.size() == expected_size);
+  CHECK(function_of_time_names.count("Shape") == 1);
+  if (lambda_00_coef.has_value()) {
+    CHECK(function_of_time_names.count("Size") == 1);
+  }
   // Choose a random time for evaluating the FunctionOfTime
   std::uniform_real_distribution<double> time_dist{-1.0, 1.0};
   *time = time_dist(*generator);

--- a/tests/Unit/Domain/CoordinateMaps/TimeDependent/Test_SphericalCompression.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/TimeDependent/Test_SphericalCompression.cpp
@@ -493,38 +493,6 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.SphericalCompression",
                                         make_not_null(&gen), true, false);
       }()),
       Catch::Matchers::Contains("max_radius must be greater"));
-  CHECK_THROWS_WITH(
-      ([&gen]() {
-        CoordinateMaps::TimeDependent::SphericalCompression<false> map{};
-        double time{std::numeric_limits<double>::signaling_NaN()};
-        std::unordered_map<
-            std::string,
-            std::unique_ptr<::domain::FunctionsOfTime::FunctionOfTime>>
-            functions_of_time{};
-        double min_radius{std::numeric_limits<double>::signaling_NaN()};
-        double max_radius{std::numeric_limits<double>::signaling_NaN()};
-        std::array<double, 3> center{};
-        generate_map_time_and_f_of_time(
-            make_not_null(&map), make_not_null(&time),
-            make_not_null(&functions_of_time), make_not_null(&min_radius),
-            make_not_null(&max_radius), make_not_null(&center),
-            make_not_null(&gen), false, false);
-        CoordinateMaps::TimeDependent::SphericalCompression<false> bad_map{};
-        double bad_time{std::numeric_limits<double>::signaling_NaN()};
-        std::unordered_map<
-            std::string,
-            std::unique_ptr<::domain::FunctionsOfTime::FunctionOfTime>>
-            bad_functions_of_time{};
-        generate_map_time_and_f_of_time(make_not_null(&bad_map),
-                                        make_not_null(&bad_time),
-                                        make_not_null(&bad_functions_of_time),
-                                        make_not_null(&gen), false, true);
-        const std::array<double, 3> point{
-            {0.5 * (max_radius + min_radius) + center[0], center[1],
-             center[2]}};
-        map(point, 0.4, bad_functions_of_time);
-      }()),
-      Catch::Matchers::Contains("Could not find function of time"));
 #endif
 
   CHECK_THROWS_WITH(([&gen]() {

--- a/tests/Unit/Domain/CoordinateMaps/TimeDependent/Test_SphericalCompression.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/TimeDependent/Test_SphericalCompression.cpp
@@ -82,6 +82,10 @@ void generate_map_time_and_f_of_time(
       random_map{f_of_t_name, *min_radius, *max_radius, *center};
   *map = random_map;
 
+  const auto& names = map->function_of_time_names();
+  CHECK(names.size() == 1);
+  CHECK(names.count(f_of_t_name) == 1);
+
   // Choose a random time for evaluating the FunctionOfTime
   std::uniform_real_distribution<> time_dis{-1.0, 1.0};
   *time = time_dis(*generator);

--- a/tests/Unit/Domain/CoordinateMaps/TimeDependent/Test_Translation.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/TimeDependent/Test_Translation.cpp
@@ -68,12 +68,20 @@ void test_translation() {
       std::make_unique<MathFunctions::Gaussian<1, Frame::Inertial>>(
           amplitude, width, gauss_center),
       center};
+  const auto check_names = [](const auto& names) {
+    CHECK(names.size() == 1);
+    CHECK(names.count("translation") == 1);
+  };
+  check_names(translation_map.function_of_time_names());
+  check_names(radial_translation_map.function_of_time_names());
   // test serialized/deserialized map
   MathFunctions::register_derived_with_charm();
   const auto translation_map_deserialized =
       serialize_and_deserialize(translation_map);
   const auto radial_translation_map_deserialized =
       serialize_and_deserialize(radial_translation_map);
+  check_names(translation_map_deserialized.function_of_time_names());
+  check_names(radial_translation_map_deserialized.function_of_time_names());
 
   while (t < final_time) {
     std::array<double, Dim> translation{};


### PR DESCRIPTION
## Proposed changes

The CoordinateMap(Base) class is now aware of what functions of time are being used for that map. This information can then be used by elements to make decisions based on which maps they have.

Fixes #5247.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
