### PR TITLE
Enum class for grouping initial data in ForceFree system

### DIFF
--- a/src/Evolution/Systems/ForceFree/CMakeLists.txt
+++ b/src/Evolution/Systems/ForceFree/CMakeLists.txt
@@ -23,6 +23,7 @@ spectre_target_headers(
   Characteristics.hpp
   ElectricCurrentDensity.hpp
   Fluxes.hpp
+  SimulationType.hpp
   Sources.hpp
   System.hpp
   Tags.hpp

--- a/src/Evolution/Systems/ForceFree/SimulationType.hpp
+++ b/src/Evolution/Systems/ForceFree/SimulationType.hpp
@@ -1,0 +1,32 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+namespace ForceFree {
+
+/*!
+ * \brief Identify different types of GRFFE simulations.
+ *
+ * In the ForceFree evolution system, we may need to execute slightly different
+ * sets of evolution step actions depending on the specific type of initial
+ * data. The main purpose of adding this enum variable is to make grouping
+ * a specific set of initial data much easier.
+ *
+ */
+enum SimulationType {
+  //
+  // Cases that do not need any special treatments. e.g. 1D wave tests, 3D black
+  // hole tests.
+  //
+  FreeSpace,
+
+  //
+  // Simulating the magnetosphere of an isolated neutron star. In this case, we
+  // need to impose the MHD condition inside the neutron star by correcting
+  // evolved variables.
+  //
+  IsolatedNsMagnetosphere,
+};
+
+}  // namespace ForceFree

--- a/src/PointwiseFunctions/AnalyticData/ForceFree/Factory.hpp
+++ b/src/PointwiseFunctions/AnalyticData/ForceFree/Factory.hpp
@@ -3,10 +3,21 @@
 
 #pragma once
 
+#include "Evolution/Systems/ForceFree/SimulationType.hpp"
 #include "PointwiseFunctions/AnalyticData/ForceFree/FfeBreakdown.hpp"
 #include "Utilities/TMPL.hpp"
 
 namespace ForceFree::AnalyticData {
-/// \brief List of all analytic data
+/*!
+ * \brief Typelist of all analytic data of GRFFE evolution system
+ */
 using all_data = tmpl::list<FfeBreakdown>;
+
+template <SimulationType simulation_type>
+using available_data = tmpl::append<
+    tmpl::conditional_t<simulation_type == SimulationType::FreeSpace,
+                        tmpl::list<FfeBreakdown>, tmpl::list<>>,
+    tmpl::conditional_t<simulation_type ==
+                            SimulationType::IsolatedNsMagnetosphere,
+                        tmpl::list<>, tmpl::list<>>>;
 }  // namespace ForceFree::AnalyticData

--- a/src/PointwiseFunctions/AnalyticSolutions/ForceFree/Factory.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/ForceFree/Factory.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "Evolution/Systems/ForceFree/SimulationType.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/ForceFree/AlfvenWave.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/ForceFree/FastWave.hpp"
 #include "Utilities/TMPL.hpp"
@@ -12,4 +13,12 @@ namespace ForceFree::Solutions {
  * \brief Typelist of all analytic solutions of GRFFE evolution system
  */
 using all_solutions = tmpl::list<AlfvenWave, FastWave>;
+
+template <SimulationType simulation_type>
+using available_solutions = tmpl::append<
+    tmpl::conditional_t<simulation_type == SimulationType::FreeSpace,
+                        tmpl::list<AlfvenWave, FastWave>, tmpl::list<>>,
+    tmpl::conditional_t<simulation_type ==
+                            SimulationType::IsolatedNsMagnetosphere,
+                        tmpl::list<>, tmpl::list<>>>;
 }  // namespace ForceFree::Solutions


### PR DESCRIPTION
## Proposed changes

Add an enum specifying the category of initial data in ForceFree evolution system. The main purpose of this is to conveniently list a subset of initial data that requires a slightly different set of actions or treatments during evolution.

The idea is to enable something like below:
```
using InitialData = std::decay_t<decltype(*solution_or_data)>;
using single_ns_id_list = ForceFree::AnalyticData::available_data<SimulationType::IsolatedNsMagnetosphere>;

tmpl::list_contains_v<single_ns_id_list, InitialData>) {
     ... // (Apply some mutator specific to single NS simulations ..
    }
```


### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
