### PR TITLE
Add basic p-refinement criterion based on truncation error

### DIFF
--- a/src/DataStructures/DataBox/CMakeLists.txt
+++ b/src/DataStructures/DataBox/CMakeLists.txt
@@ -17,6 +17,7 @@ spectre_target_headers(
   Tag.hpp
   TagName.hpp
   TagTraits.hpp
+  ValidateSelection.hpp
   )
 
 add_subdirectory(Protocols)

--- a/src/DataStructures/DataBox/ValidateSelection.hpp
+++ b/src/DataStructures/DataBox/ValidateSelection.hpp
@@ -1,0 +1,49 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+#include "DataStructures/DataBox/TagName.hpp"
+#include "Options/Context.hpp"
+#include "Options/ParseError.hpp"
+#include "Utilities/Algorithm.hpp"
+#include "Utilities/StdHelpers.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace db {
+
+/*!
+ * \brief Validate that the selected names are a subset of the given tags.
+ *
+ * The possible choices for the selection are the `db::tag_name`s of the `Tags`.
+ *
+ * \tparam Tags List of possible tags.
+ * \param selected_names Names to validate.
+ * \param context Options context for error reporting.
+ */
+template <typename Tags>
+void validate_selection(const std::vector<std::string>& selected_names,
+                        const Options::Context& context) {
+  using ::operator<<;
+  std::unordered_set<std::string> valid_names{};
+  tmpl::for_each<Tags>([&valid_names](auto tag_v) {
+    using tag = tmpl::type_from<std::decay_t<decltype(tag_v)>>;
+    valid_names.insert(db::tag_name<tag>());
+  });
+  for (const auto& name : selected_names) {
+    if (valid_names.find(name) == valid_names.end()) {
+      PARSE_ERROR(context, "Invalid selection: " << name
+                                                 << ". Possible choices are: "
+                                                 << valid_names << ".");
+    }
+    if (alg::count(selected_names, name) != 1) {
+      PARSE_ERROR(context, name << " specified multiple times");
+    }
+  }
+}
+
+}  // namespace db

--- a/src/Executables/ExportCoordinates/ExportCoordinates.hpp
+++ b/src/Executables/ExportCoordinates/ExportCoordinates.hpp
@@ -65,6 +65,7 @@
 #include "ParallelAlgorithms/Amr/Criteria/DriveToTarget.hpp"
 #include "ParallelAlgorithms/Amr/Criteria/Random.hpp"
 #include "ParallelAlgorithms/Amr/Criteria/Tags/Criteria.hpp"
+#include "ParallelAlgorithms/Amr/Criteria/TruncationError.hpp"
 #include "ParallelAlgorithms/Amr/Protocols/AmrMetavariables.hpp"
 #include "ParallelAlgorithms/EventsAndTriggers/Completion.hpp"
 #include "ParallelAlgorithms/EventsAndTriggers/Event.hpp"
@@ -296,9 +297,13 @@ struct Metavariables {
       : tt::ConformsTo<Options::protocols::FactoryCreation> {
     using factory_classes = tmpl::map<
         tmpl::pair<DomainCreator<volume_dim>, domain_creators<volume_dim>>,
-        tmpl::pair<amr::Criterion,
-                   tmpl::list<amr::Criteria::DriveToTarget<volume_dim>,
-                              amr::Criteria::Random>>,
+        tmpl::pair<
+            amr::Criterion,
+            tmpl::list<amr::Criteria::DriveToTarget<volume_dim>,
+                       amr::Criteria::Random,
+                       amr::Criteria::TruncationError<
+                           volume_dim, tmpl::list<::domain::Tags::Coordinates<
+                                           volume_dim, Frame::Inertial>>>>>,
         tmpl::pair<
             PhaseChange,
             tmpl::list<

--- a/src/ParallelAlgorithms/Amr/Criteria/CMakeLists.txt
+++ b/src/ParallelAlgorithms/Amr/Criteria/CMakeLists.txt
@@ -10,6 +10,7 @@ spectre_target_sources(
   PRIVATE
   DriveToTarget.cpp
   Random.cpp
+  TruncationError.cpp
   )
 
 spectre_target_headers(
@@ -20,6 +21,7 @@ spectre_target_headers(
   Criterion.hpp
   DriveToTarget.hpp
   Random.hpp
+  TruncationError.hpp
   )
 
 add_dependencies(
@@ -36,6 +38,8 @@ target_link_libraries(
   Parallel
   Spectral
   Utilities
+  PRIVATE
+  LinearOperators
   )
 
 add_subdirectory(Tags)

--- a/src/ParallelAlgorithms/Amr/Criteria/TruncationError.cpp
+++ b/src/ParallelAlgorithms/Amr/Criteria/TruncationError.cpp
@@ -1,0 +1,98 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "ParallelAlgorithms/Amr/Criteria/TruncationError.hpp"
+
+#include <array>
+#include <cstddef>
+#include <optional>
+
+#include "DataStructures/DataVector.hpp"
+#include "Domain/Amr/Flag.hpp"
+#include "NumericalAlgorithms/LinearOperators/PowerMonitors.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace amr::Criteria::TruncationError_detail {
+
+template <size_t Dim>
+void max_over_components(
+    const gsl::not_null<std::array<Flag, Dim>*> result,
+    const gsl::not_null<std::array<DataVector, Dim>*> power_monitors_buffer,
+    const DataVector& tensor_component, const Mesh<Dim>& mesh,
+    const std::optional<double> target_abs_truncation_error,
+    const std::optional<double> target_rel_truncation_error) {
+  // We take the highest-priority refinement flag in each dimension, so if any
+  // tensor component has a truncation error above the target, the element will
+  // increase p refinement in that dimension. And only if all tensor components
+  // still satisfy the target with the highest mode removed will the element
+  // decrease p refinement in that dimension.
+  PowerMonitors::power_monitors(power_monitors_buffer, tensor_component, mesh);
+  for (size_t d = 0; d < Dim; ++d) {
+    // Skip this dimension if we have already decided to refine it
+    if (gsl::at(*result, d) == Flag::IncreaseResolution) {
+      continue;
+    }
+    const auto& modes = gsl::at(*power_monitors_buffer, d);
+    // Increase p refinement if the truncation error exceeds the target
+    const double rel_truncation_error =
+        pow(10, -PowerMonitors::relative_truncation_error(modes, modes.size()));
+    const double umax = max(abs(tensor_component));
+    const double abs_truncation_error = umax * rel_truncation_error;
+    if ((target_rel_truncation_error.has_value() and
+         rel_truncation_error > target_rel_truncation_error.value()) or
+        (target_abs_truncation_error.has_value() and
+         abs_truncation_error > target_abs_truncation_error.value())) {
+      gsl::at(*result, d) = Flag::IncreaseResolution;
+      continue;
+    }
+    // Dont' check if we want to (allow) decreasing p refinement if another
+    // tensor has already decided that decreasing p refinement is bad.
+    if (gsl::at(*result, d) == Flag::DoNothing) {
+      continue;
+    }
+    // The `PowerMonitors::relative_truncation_error` function requires at
+    // least two modes (and we subtract one below)
+    if (modes.size() >= 3) {
+      // Decrease p refinement if the truncation error with the highest mode
+      // removed still satisfies the target. Otherwise, request to stay at
+      // this resolution (or increase resolution if another tensor component
+      // requested that).
+      const double rel_truncation_error_coarsened = pow(
+          10,
+          -PowerMonitors::relative_truncation_error(modes, modes.size() - 1));
+      const double abs_truncation_error_coarsened =
+          umax * rel_truncation_error_coarsened;
+      if ((target_rel_truncation_error.has_value() and
+           rel_truncation_error_coarsened <=
+               target_rel_truncation_error.value()) and
+          (target_abs_truncation_error.has_value() and
+           abs_truncation_error_coarsened <= target_abs_truncation_error)) {
+        gsl::at(*result, d) = Flag::DecreaseResolution;
+      } else {
+        gsl::at(*result, d) = Flag::DoNothing;
+      }
+    } else {
+      gsl::at(*result, d) = Flag::DoNothing;
+    }
+  }
+}
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATION(_, data)                                         \
+  template void max_over_components(                                   \
+      gsl::not_null<std::array<Flag, DIM(data)>*> result,              \
+      const gsl::not_null<std::array<DataVector, DIM(data)>*>          \
+          power_monitors_buffer,                                       \
+      const DataVector& tensor_component, const Mesh<DIM(data)>& mesh, \
+      std::optional<double> target_abs_truncation_error,               \
+      std::optional<double> target_rel_truncation_error);
+
+GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
+
+#undef INSTANTIATION
+#undef DIM
+
+}  // namespace amr::Criteria::TruncationError_detail

--- a/src/ParallelAlgorithms/Amr/Criteria/TruncationError.hpp
+++ b/src/ParallelAlgorithms/Amr/Criteria/TruncationError.hpp
@@ -1,0 +1,198 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <optional>
+#include <pup.h>
+#include <string>
+#include <vector>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataBox/ValidateSelection.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/Amr/Flag.hpp"
+#include "Domain/Tags.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "Options/Context.hpp"
+#include "Options/ParseError.hpp"
+#include "Options/String.hpp"
+#include "ParallelAlgorithms/Amr/Criteria/Criterion.hpp"
+#include "Utilities/Algorithm.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+template <size_t>
+class ElementId;
+/// \endcond
+
+namespace amr::Criteria {
+
+namespace TruncationError_detail {
+/*!
+ * \brief Apply the truncation error criterion to a single tensor component
+ *
+ * The `result` is the current decision in each dimension based on the previous
+ * tensor components. This function will update the flags if necessary. It takes
+ * the "max" of the current and new flags, where the "highest" flag is
+ * `Flag::IncreaseResolution`, followed by `Flag::DoNothing`, and then
+ * `Flag::DecreaseResolution`.
+ */
+template <size_t Dim>
+void max_over_components(
+    gsl::not_null<std::array<Flag, Dim>*> result,
+    const gsl::not_null<std::array<DataVector, Dim>*> power_monitors_buffer,
+    const DataVector& tensor_component, const Mesh<Dim>& mesh,
+    std::optional<double> target_abs_truncation_error,
+    std::optional<double> target_rel_truncation_error);
+}  // namespace TruncationError_detail
+
+/*!
+ * \brief Refine the grid towards the target truncation error
+ *
+ * - If any tensor component has a truncation error above the target value, the
+ *   element will be p-refined.
+ * - If all tensor components still satisfy the target even with one mode
+ *   removed, the element will be p-coarsened.
+ *
+ * For details on how the truncation error is computed see
+ * `PowerMonitors::truncation_error`.
+ *
+ * \tparam Dim Spatial dimension of the grid
+ * \tparam TensorTags List of tags of the tensors to be monitored
+ */
+template <size_t Dim, typename TensorTags>
+class TruncationError : public Criterion {
+ public:
+  struct VariablesToMonitor {
+    using type = std::vector<std::string>;
+    static constexpr Options::String help = {
+        "The tensors to monitor the truncation error of."};
+    static size_t lower_bound_on_size() { return 1; }
+  };
+  struct AbsoluteTargetTruncationError {
+    static std::string name() { return "AbsoluteTarget"; }
+    using type = Options::Auto<double, Options::AutoLabel::None>;
+    static constexpr Options::String help = {
+        "The absolute target truncation error. If any tensor component "
+        "has a truncation error above this value, the element will be "
+        "p-refined."};
+  };
+  struct RelativeTargetTruncationError {
+    static std::string name() { return "RelativeTarget"; }
+    using type = Options::Auto<double, Options::AutoLabel::None>;
+    static constexpr Options::String help = {
+        "The relative target truncation error. If any tensor component "
+        "has a truncation error above this value, the element will be "
+        "p-refined."};
+  };
+
+  using options = tmpl::list<VariablesToMonitor, AbsoluteTargetTruncationError,
+                             RelativeTargetTruncationError>;
+
+  static constexpr Options::String help = {
+      "Refine the grid towards the target truncation error"};
+
+  TruncationError() = default;
+
+  TruncationError(std::vector<std::string> vars_to_monitor,
+                  const std::optional<double> target_abs_truncation_error,
+                  const std::optional<double> target_rel_truncation_error,
+                  const Options::Context& context = {});
+
+  /// \cond
+  explicit TruncationError(CkMigrateMessage* msg);
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(TruncationError);  // NOLINT
+  /// \endcond
+
+  using compute_tags_for_observation_box = tmpl::list<>;
+
+  using argument_tags = tmpl::list<::Tags::DataBox>;
+
+  template <typename DbTagsList, typename Metavariables>
+  std::array<Flag, Dim> operator()(const db::DataBox<DbTagsList>& box,
+                                   Parallel::GlobalCache<Metavariables>& cache,
+                                   const ElementId<Dim>& element_id) const;
+
+  void pup(PUP::er& p) override;
+
+ private:
+  std::vector<std::string> vars_to_monitor_{};
+  std::optional<double> target_abs_truncation_error_{};
+  std::optional<double> target_rel_truncation_error_{};
+};
+
+// Out-of-line definitions
+/// \cond
+
+template <size_t Dim, typename TensorTags>
+TruncationError<Dim, TensorTags>::TruncationError(
+    std::vector<std::string> vars_to_monitor,
+    const std::optional<double> target_abs_truncation_error,
+    const std::optional<double> target_rel_truncation_error,
+    const Options::Context& context)
+    : vars_to_monitor_(std::move(vars_to_monitor)),
+      target_abs_truncation_error_(target_abs_truncation_error),
+      target_rel_truncation_error_(target_rel_truncation_error) {
+  db::validate_selection<TensorTags>(vars_to_monitor_, context);
+  if (not target_abs_truncation_error.has_value() and
+      not target_rel_truncation_error.has_value()) {
+    PARSE_ERROR(context,
+                "Must specify AbsoluteTarget, RelativeTarget, or both");
+  }
+}
+
+template <size_t Dim, typename TensorTags>
+TruncationError<Dim, TensorTags>::TruncationError(CkMigrateMessage* msg)
+    : Criterion(msg) {}
+
+template <size_t Dim, typename TensorTags>
+template <typename DbTagsList, typename Metavariables>
+std::array<Flag, Dim> TruncationError<Dim, TensorTags>::operator()(
+    const db::DataBox<DbTagsList>& box,
+    Parallel::GlobalCache<Metavariables>& /*cache*/,
+    const ElementId<Dim>& /*element_id*/) const {
+  auto result = make_array<Dim>(Flag::Undefined);
+  const auto& mesh = db::get<domain::Tags::Mesh<Dim>>(box);
+  std::array<DataVector, Dim> power_monitors_buffer{};
+  // Check all tensors and all tensor components in turn
+  tmpl::for_each<TensorTags>(
+      [&result, &box, &mesh, &power_monitors_buffer, this](const auto tag_v) {
+        // Stop if we have already decided to refine every dimension
+        if (result == make_array<Dim>(Flag::IncreaseResolution)) {
+          return;
+        }
+        using tag = tmpl::type_from<std::decay_t<decltype(tag_v)>>;
+        const std::string tag_name = db::tag_name<tag>();
+        // Skip if this tensor is not being monitored
+        if (alg::find(vars_to_monitor_, tag_name) == vars_to_monitor_.end()) {
+          return;
+        }
+        const auto& tensor = db::get<tag>(box);
+        for (const DataVector& tensor_component : tensor) {
+          TruncationError_detail::max_over_components(
+              make_not_null(&result), make_not_null(&power_monitors_buffer),
+              tensor_component, mesh, target_abs_truncation_error_,
+              target_rel_truncation_error_);
+        }
+      });
+  return result;
+}
+
+template <size_t Dim, typename TensorTags>
+void TruncationError<Dim, TensorTags>::pup(PUP::er& p) {
+  p | vars_to_monitor_;
+  p | target_abs_truncation_error_;
+  p | target_rel_truncation_error_;
+}
+
+template <size_t Dim, typename TensorTags>
+PUP::able::PUP_ID TruncationError<Dim, TensorTags>::my_PUP_ID = 0;  // NOLINT
+/// \endcond
+
+}  // namespace amr::Criteria

--- a/tests/Unit/DataStructures/DataBox/CMakeLists.txt
+++ b/tests/Unit/DataStructures/DataBox/CMakeLists.txt
@@ -14,6 +14,7 @@ set(LIBRARY_SOURCES
   Test_TagName.cpp
   Test_TagTraits.cpp
   Test_TestHelpers.cpp
+  Test_ValidateSelection.cpp
   )
 
 add_test_library(
@@ -28,5 +29,6 @@ target_link_libraries(
   PRIVATE
   DataStructures
   ErrorHandling
+  Options
   Utilities
 )

--- a/tests/Unit/DataStructures/DataBox/Test_ValidateSelection.cpp
+++ b/tests/Unit/DataStructures/DataBox/Test_ValidateSelection.cpp
@@ -1,0 +1,34 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <string>
+#include <vector>
+
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/DataBox/ValidateSelection.hpp"
+#include "Options/Context.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+
+struct Tag1 : db::SimpleTag {
+  using type = int;
+};
+
+struct Tag2 : db::SimpleTag {
+  using type = int;
+  static std::string name() { return "CustomTag2"; }
+};
+
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Options.ValidateSelection", "[Unit][Options]") {
+  db::validate_selection<tmpl::list<Tag1, Tag2>>({"Tag1"}, Options::Context{});
+  CHECK_THROWS_WITH((db::validate_selection<tmpl::list<Tag1, Tag2>>(
+                        {"Tag2"}, Options::Context{})),
+                    Catch::Matchers::ContainsSubstring("Invalid selection"));
+  db::validate_selection<tmpl::list<Tag1, Tag2>>({"CustomTag2", "Tag1"},
+                                                 Options::Context{});
+}

--- a/tests/Unit/ParallelAlgorithms/Amr/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/Amr/CMakeLists.txt
@@ -17,6 +17,7 @@ set(LIBRARY_SOURCES
   Criteria/Test_Criterion.cpp
   Criteria/Test_DriveToTarget.cpp
   Criteria/Test_Random.cpp
+  Criteria/Test_TruncationError.cpp
   Projectors/Test_Mesh.cpp
   Test_Protocols.cpp
   )

--- a/tests/Unit/ParallelAlgorithms/Amr/Criteria/Test_TruncationError.cpp
+++ b/tests/Unit/ParallelAlgorithms/Amr/Criteria/Test_TruncationError.cpp
@@ -1,0 +1,86 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <memory>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/ObservationBox.hpp"
+#include "Domain/Amr/Flag.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
+#include "NumericalAlgorithms/Spectral/LogicalCoordinates.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "Options/Protocols/FactoryCreation.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "ParallelAlgorithms/Amr/Criteria/Criterion.hpp"
+#include "ParallelAlgorithms/Amr/Criteria/TruncationError.hpp"
+#include "Utilities/Serialization/RegisterDerivedClassesWithCharm.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace amr::Criteria {
+namespace {
+
+template <size_t Dim>
+struct TestVector : db::SimpleTag {
+  using type = tnsr::I<DataVector, Dim>;
+};
+
+template <size_t Dim>
+struct Metavariables {
+  static constexpr size_t volume_dim = Dim;
+  using component_list = tmpl::list<>;
+  using const_global_cache_tags = tmpl::list<>;
+  struct factory_creation
+      : tt::ConformsTo<Options::protocols::FactoryCreation> {
+    using factory_classes = tmpl::map<tmpl::pair<
+        amr::Criterion,
+        tmpl::list<TruncationError<Dim, tmpl::list<TestVector<Dim>>>>>>;
+  };
+};
+
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Amr.Criteria.TruncationError",
+                  "[Unit][ParallelAlgorithms]") {
+  static constexpr size_t Dim = 2;
+  register_factory_classes_with_charm<Metavariables<Dim>>();
+  const TruncationError<Dim, tmpl::list<TestVector<Dim>>> criterion{
+      {"TestVector"}, 1.e-3, 1.e-3};
+  const auto criterion_from_option_string = TestHelpers::test_factory_creation<
+      amr::Criterion, TruncationError<Dim, tmpl::list<TestVector<Dim>>>>(
+      "TruncationError:\n"
+      "  VariablesToMonitor: [TestVector]\n"
+      "  AbsoluteTarget: 1.e-3\n"
+      "  RelativeTarget: 1.e-3\n");
+
+  const Mesh<Dim> mesh{4, Spectral::Basis::Legendre,
+                       Spectral::Quadrature::GaussLobatto};
+  const auto logical_coords = logical_coordinates(mesh);
+  // Manufacture some test data
+  tnsr::I<DataVector, Dim> test_data{};
+  // X-component is linear in x and y, so it is exactly represented on the mesh
+  get<0>(test_data) = get<0>(logical_coords) + 2. * get<1>(logical_coords);
+  // Y-component is nonlinear in one dimension and linear in the other
+  get<1>(test_data) =
+      exp(sin(M_PI * get<0>(logical_coords))) + 2. * get<1>(logical_coords);
+
+  Parallel::GlobalCache<Metavariables<Dim>> empty_cache{};
+  const auto databox =
+      db::create<tmpl::list<::domain::Tags::Mesh<Dim>, TestVector<Dim>>>(
+          mesh, std::move(test_data));
+  ObservationBox<
+      tmpl::list<>,
+      db::DataBox<tmpl::list<::domain::Tags::Mesh<Dim>, TestVector<Dim>>>>
+      box{databox};
+
+  const auto flags = criterion.evaluate(box, empty_cache, ElementId<Dim>{0});
+  CHECK(flags[0] == amr::Flag::IncreaseResolution);
+  CHECK(flags[1] == amr::Flag::DecreaseResolution);
+}
+
+}  // namespace amr::Criteria

--- a/tests/Unit/ParallelAlgorithms/Events/Test_ObserveFields.cpp
+++ b/tests/Unit/ParallelAlgorithms/Events/Test_ObserveFields.cpp
@@ -465,8 +465,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.dG.ObserveFields", "[Unit][Evolution]") {
           "VariablesToObserve: [NotAVar]\n"
           "FloatingPointTypes: [Double]\n"
           "InterpolateToMesh: None\n"),
-      Catch::Matchers::ContainsSubstring(
-          "NotAVar is not an available variable"));
+      Catch::Matchers::ContainsSubstring("Invalid selection: NotAVar"));
 
   CHECK_THROWS_WITH(
       TestHelpers::test_creation<


### PR DESCRIPTION
## Proposed changes

Just use the `truncation_error` estimate based on power monitors to p-refine to a target error. We can improve and expand this as we go. This p-refines the `ExportCoordinates2D` executable already pretty well when using the inertial coordinates to compute truncation errors and a Sphere domain in the input file.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
