### PR TITLE
Remove DgSubcell from ParallelInterpolation

### DIFF
--- a/src/ParallelAlgorithms/Interpolation/CMakeLists.txt
+++ b/src/ParallelAlgorithms/Interpolation/CMakeLists.txt
@@ -52,7 +52,6 @@ target_link_libraries(
   Time
   Utilities
   INTERFACE
-  DgSubcell
   EventsAndTriggers
   GeneralizedHarmonic
   Observer

--- a/src/ParallelAlgorithms/Interpolation/Events/Interpolate.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Events/Interpolate.hpp
@@ -29,10 +29,12 @@ namespace Tags {
 struct Time;
 }  // namespace Tags
 namespace domain::Tags {
-template <size_t VolumeDim>
-struct Mesh;
 struct FunctionsOfTime;
 }  // namespace domain::Tags
+namespace Events::Tags {
+template <size_t Dim>
+struct ObserverMesh;
+}  // namespace Events::Tags
 /// \endcond
 
 namespace intrp {
@@ -65,9 +67,9 @@ class Interpolate<VolumeDim, InterpolationTargetTag,
 
   using compute_tags_for_observation_box = tmpl::list<>;
 
-  using argument_tags =
-      tmpl::list<typename InterpolationTargetTag::temporal_id,
-                 domain::Tags::Mesh<VolumeDim>, InterpolatorSourceVarTags...>;
+  using argument_tags = tmpl::list<typename InterpolationTargetTag::temporal_id,
+                                   ::Events::Tags::ObserverMesh<VolumeDim>,
+                                   InterpolatorSourceVarTags...>;
 
   template <typename Metavariables, typename ParallelComponent>
   void operator()(

--- a/tests/Unit/ParallelAlgorithms/Interpolation/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/CMakeLists.txt
@@ -47,6 +47,7 @@ target_link_libraries(
   Domain
   DomainCreators
   DomainStructure
+  Events
   GeneralRelativitySolutions
   H5
   Interpolation

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_Interpolate.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_Interpolate.cpp
@@ -30,6 +30,7 @@
 #include "Parallel/Phase.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"  // IWYU pragma: keep
 #include "Parallel/Tags/Metavariables.hpp"
+#include "ParallelAlgorithms/Events/Tags.hpp"
 #include "ParallelAlgorithms/Interpolation/Actions/InitializeInterpolator.hpp"
 #include "ParallelAlgorithms/Interpolation/Actions/InterpolatorRegisterElement.hpp"  // IWYU pragma: keep
 #include "ParallelAlgorithms/Interpolation/Callbacks/ObserveTimeSeriesOnSurface.hpp"
@@ -283,11 +284,11 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.InterpolateEvent",
   MockInterpolatorReceiveVolumeData::results = {};
 
   // Test the event version
-  auto box = db::create<
-      db::AddSimpleTags<Parallel::Tags::MetavariablesImpl<metavars>,
-                        metavars::InterpolatorTargetA::temporal_id,
-                        ::Tags::Time, domain::Tags::Mesh<metavars::volume_dim>,
-                        ::Tags::Variables<typename decltype(vars)::tags_list>>>(
+  auto box = db::create<db::AddSimpleTags<
+      Parallel::Tags::MetavariablesImpl<metavars>,
+      metavars::InterpolatorTargetA::temporal_id, ::Tags::Time,
+      ::Events::Tags::ObserverMesh<metavars::volume_dim>,
+      ::Tags::Variables<typename decltype(vars)::tags_list>>>(
       metavars{}, temporal_id, invalid_time, mesh, vars);
 
   metavars::event event{};

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolateWithoutInterpComponent.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolateWithoutInterpComponent.cpp
@@ -24,6 +24,7 @@
 #include "Parallel/Phase.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
 #include "Parallel/Tags/Metavariables.hpp"
+#include "ParallelAlgorithms/Events/Tags.hpp"
 #include "ParallelAlgorithms/Interpolation/Callbacks/ObserveTimeSeriesOnSurface.hpp"
 #include "ParallelAlgorithms/Interpolation/Events/InterpolateWithoutInterpComponent.hpp"
 #include "ParallelAlgorithms/Interpolation/Protocols/ComputeVarsToInterpolate.hpp"
@@ -82,7 +83,7 @@ struct initialize_elements_and_queue_simple_actions {
           Parallel::Tags::MetavariablesImpl<metavars>,
           typename metavars::InterpolationTargetA::temporal_id,
           intrp::Tags::InterpPointInfo<metavars>,
-          domain::Tags::Mesh<metavars::volume_dim>,
+          ::Events::Tags::ObserverMesh<metavars::volume_dim>,
           ::Tags::Variables<
               typename std::remove_reference_t<decltype(vars)>::tags_list>>>(
           metavars{}, temporal_id, interp_point_info, mesh, vars);


### PR DESCRIPTION
## Proposed changes

Using the `ObserverMesh` solves this problem.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
