### PR TITLE
Support subcell in importers

### DIFF
--- a/src/Evolution/DgSubcell/CMakeLists.txt
+++ b/src/Evolution/DgSubcell/CMakeLists.txt
@@ -15,6 +15,7 @@ spectre_target_headers(
   ComputeBoundaryTerms.hpp
   CorrectPackagedData.hpp
   DgSubcell.hpp
+  GetActiveTag.hpp
   GetTciDecision.hpp
   GhostData.hpp
   GhostZoneLogicalCoordinates.hpp

--- a/src/Evolution/DgSubcell/GetActiveTag.hpp
+++ b/src/Evolution/DgSubcell/GetActiveTag.hpp
@@ -1,0 +1,35 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <type_traits>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "Evolution/DgSubcell/ActiveGrid.hpp"
+#include "Evolution/DgSubcell/Tags/ActiveGrid.hpp"
+
+namespace evolution::dg::subcell {
+/// \brief Retrieve a tag from the active grid.
+template <typename DgTag, typename SubcellTag, typename DbTagsList>
+const typename DgTag::type& get_active_tag(const db::DataBox<DbTagsList>& box) {
+  static_assert(
+      std::is_same_v<typename DgTag::type, typename SubcellTag::type>);
+  if (db::get<Tags::ActiveGrid>(box) == ActiveGrid::Subcell) {
+    return db::get<SubcellTag>(box);
+  }
+  return db::get<DgTag>(box);
+}
+
+/// \brief Retrieve a tag from the inactive grid.
+template <typename DgTag, typename SubcellTag, typename DbTagsList>
+const typename DgTag::type& get_inactive_tag(
+    const db::DataBox<DbTagsList>& box) {
+  static_assert(
+      std::is_same_v<typename DgTag::type, typename SubcellTag::type>);
+  if (db::get<Tags::ActiveGrid>(box) == ActiveGrid::Subcell) {
+    return db::get<DgTag>(box);
+  }
+  return db::get<SubcellTag>(box);
+}
+}  // namespace evolution::dg::subcell

--- a/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
+++ b/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
@@ -41,6 +41,7 @@
 #include "Evolution/DgSubcell/CartesianFluxDivergence.hpp"
 #include "Evolution/DgSubcell/ComputeBoundaryTerms.hpp"
 #include "Evolution/DgSubcell/CorrectPackagedData.hpp"
+#include "Evolution/DgSubcell/GetActiveTag.hpp"
 #include "Evolution/DgSubcell/NeighborReconstructedFaceSolution.hpp"
 #include "Evolution/DgSubcell/PerssonTci.hpp"
 #include "Evolution/DgSubcell/PrepareNeighborData.hpp"

--- a/src/IO/Importers/CMakeLists.txt
+++ b/src/IO/Importers/CMakeLists.txt
@@ -29,6 +29,7 @@ target_link_libraries(
   Options
   INTERFACE
   DataStructures
+  Domain
   DomainStructure
   Initialization
   Interpolation

--- a/tests/Unit/Evolution/DgSubcell/CMakeLists.txt
+++ b/tests/Unit/Evolution/DgSubcell/CMakeLists.txt
@@ -15,6 +15,7 @@ set(LIBRARY_SOURCES
   Test_CellCenteredFlux.cpp
   Test_ComputeBoundaryTerms.cpp
   Test_CorrectPackagedData.cpp
+  Test_GetActiveTag.cpp
   Test_GetTciDecision.cpp
   Test_GhostData.cpp
   Test_GhostZoneLogicalCoordinates.cpp

--- a/tests/Unit/Evolution/DgSubcell/Test_GetActiveTag.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Test_GetActiveTag.cpp
@@ -1,0 +1,52 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+
+#include "Framework/TestingFramework.hpp"
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "Domain/Tags.hpp"
+#include "Evolution/DgSubcell/ActiveGrid.hpp"
+#include "Evolution/DgSubcell/GetActiveTag.hpp"
+#include "Evolution/DgSubcell/Tags/ActiveGrid.hpp"
+#include "Evolution/DgSubcell/Tags/Coordinates.hpp"
+#include "Utilities/Literals.hpp"
+
+SPECTRE_TEST_CASE("Unit.Evolution.Subcell.GetActiveTag", "[Evolution][Unit]") {
+  for (const auto active_grid : {evolution::dg::subcell::ActiveGrid::Dg,
+                                 evolution::dg::subcell::ActiveGrid::Subcell}) {
+    const auto box = db::create<db::AddSimpleTags<
+        domain::Tags::Coordinates<1, Frame::Inertial>,
+        evolution::dg::subcell::Tags::Coordinates<1, Frame::Inertial>,
+        evolution::dg::subcell::Tags::ActiveGrid>>(
+        tnsr::I<DataVector, 1>{10_st, 1.0}, tnsr::I<DataVector, 1>{20_st, 2.0},
+        active_grid);
+    if (active_grid == evolution::dg::subcell::ActiveGrid::Dg) {
+      CHECK(evolution::dg::subcell::get_active_tag<
+                domain::Tags::Coordinates<1, Frame::Inertial>,
+                evolution::dg::subcell::Tags::Coordinates<1, Frame::Inertial>>(
+                box) ==
+            db::get<domain::Tags::Coordinates<1, Frame::Inertial>>(box));
+      CHECK(evolution::dg::subcell::get_inactive_tag<
+                domain::Tags::Coordinates<1, Frame::Inertial>,
+                evolution::dg::subcell::Tags::Coordinates<1, Frame::Inertial>>(
+                box) ==
+            db::get<
+                evolution::dg::subcell::Tags::Coordinates<1, Frame::Inertial>>(
+                box));
+    } else {
+      CHECK(evolution::dg::subcell::get_active_tag<
+                domain::Tags::Coordinates<1, Frame::Inertial>,
+                evolution::dg::subcell::Tags::Coordinates<1, Frame::Inertial>>(
+                box) ==
+            db::get<
+                evolution::dg::subcell::Tags::Coordinates<1, Frame::Inertial>>(
+                box));
+      CHECK(evolution::dg::subcell::get_inactive_tag<
+                domain::Tags::Coordinates<1, Frame::Inertial>,
+                evolution::dg::subcell::Tags::Coordinates<1, Frame::Inertial>>(
+                box) ==
+            db::get<domain::Tags::Coordinates<1, Frame::Inertial>>(box));
+    }
+  }
+}

--- a/tests/Unit/IO/Importers/CMakeLists.txt
+++ b/tests/Unit/IO/Importers/CMakeLists.txt
@@ -46,6 +46,7 @@ function(add_algorithm_test TEST_NAME DIM)
     ${EXECUTABLE_NAME}
     PRIVATE
     DataStructures
+    DgSubcell
     Domain
     DomainCreators
     DomainStructure


### PR DESCRIPTION
## Proposed changes

Adds support for interpolating to the FD grid in the importers, which we need for BNS mergers.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
