### PR TITLE
Add PPAO reconstruction to GhGrmhd system

### DIFF
--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/CMakeLists.txt
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/CMakeLists.txt
@@ -8,6 +8,7 @@ spectre_target_sources(
   FilterOptions.cpp
   Filters.cpp
   MonotonisedCentral.cpp
+  PositivityPreservingAdaptiveOrder.cpp
   Reconstructor.cpp
   RegisterDerivedWithCharm.cpp
   )
@@ -23,6 +24,7 @@ spectre_target_headers(
   Filters.hpp
   FiniteDifference.hpp
   MonotonisedCentral.hpp
+  PositivityPreservingAdaptiveOrder.hpp
   ReconstructWork.hpp
   ReconstructWork.tpp
   Reconstructor.hpp

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/Factory.hpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/Factory.hpp
@@ -4,4 +4,5 @@
 #pragma once
 
 #include "Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/MonotonisedCentral.hpp"
+#include "Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/PositivityPreservingAdaptiveOrder.hpp"
 #include "Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/Reconstructor.hpp"

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/MonotonisedCentral.hpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/MonotonisedCentral.hpp
@@ -92,6 +92,8 @@ class MonotonisedCentralPrim : public Reconstructor {
 
   auto get_clone() const -> std::unique_ptr<Reconstructor> override;
 
+  static constexpr bool use_adaptive_order = false;
+
   void pup(PUP::er& p) override;
 
   size_t ghost_zone_size() const override { return 2; }

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/PositivityPreservingAdaptiveOrder.cpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/PositivityPreservingAdaptiveOrder.cpp
@@ -1,0 +1,485 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/PositivityPreservingAdaptiveOrder.hpp"
+
+#include <pup.h>
+
+#include <array>
+#include <boost/functional/hash.hpp>
+#include <cstddef>
+#include <memory>
+#include <tuple>
+#include <utility>
+
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/FixedHashMap.hpp"
+#include "DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/Element.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Domain/Structure/MaxNumberOfNeighbors.hpp"
+#include "Domain/Structure/Side.hpp"
+#include "Evolution/DgSubcell/GhostData.hpp"
+#include "Evolution/DiscontinuousGalerkin/Actions/NormalCovectorAndMagnitude.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
+#include "Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/ReconstructWork.tpp"
+#include "Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/Reconstructor.hpp"
+#include "Evolution/Systems/GrMhd/GhValenciaDivClean/System.hpp"
+#include "Evolution/Systems/GrMhd/GhValenciaDivClean/Tags.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/Tags.hpp"
+#include "NumericalAlgorithms/FiniteDifference/FallbackReconstructorType.hpp"
+#include "NumericalAlgorithms/FiniteDifference/MonotonicityPreserving5.hpp"
+#include "NumericalAlgorithms/FiniteDifference/NeighborDataAsVariables.hpp"
+#include "NumericalAlgorithms/FiniteDifference/PositivityPreservingAdaptiveOrder.hpp"
+#include "NumericalAlgorithms/FiniteDifference/Reconstruct.tpp"
+#include "NumericalAlgorithms/FiniteDifference/Unlimited.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "Options/ParseError.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Lapse.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Shift.hpp"
+#include "PointwiseFunctions/GeneralRelativity/SpatialMetric.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
+#include "PointwiseFunctions/Hydro/Tags.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace grmhd::GhValenciaDivClean::fd {
+PositivityPreservingAdaptiveOrderPrim::PositivityPreservingAdaptiveOrderPrim(
+    CkMigrateMessage* const msg)
+    : Reconstructor(msg) {}
+
+PositivityPreservingAdaptiveOrderPrim::PositivityPreservingAdaptiveOrderPrim(
+    const double alpha_5, const std::optional<double> alpha_7,
+    const std::optional<double> alpha_9,
+    const ::fd::reconstruction::FallbackReconstructorType
+        low_order_reconstructor,
+    const Options::Context& context)
+    : four_to_the_alpha_5_(pow(4.0, alpha_5)),
+      low_order_reconstructor_(low_order_reconstructor) {
+  if (low_order_reconstructor_ ==
+      ::fd::reconstruction::FallbackReconstructorType::None) {
+    PARSE_ERROR(context, "None is not an allowed low-order reconstructor.");
+  }
+  if (alpha_7.has_value()) {
+    six_to_the_alpha_7_ = pow(6.0, alpha_7.value());
+  }
+  if (alpha_9.has_value()) {
+    eight_to_the_alpha_9_ = pow(8.0, alpha_9.value());
+  }
+  set_function_pointers();
+}
+
+void PositivityPreservingAdaptiveOrderPrim::set_function_pointers() {
+  std::tie(reconstruct_, reconstruct_lower_neighbor_,
+           reconstruct_upper_neighbor_) = ::fd::reconstruction::
+      positivity_preserving_adaptive_order_function_pointers<3, false>(
+          false, eight_to_the_alpha_9_.has_value(),
+          six_to_the_alpha_7_.has_value(), low_order_reconstructor_);
+  std::tie(pp_reconstruct_, pp_reconstruct_lower_neighbor_,
+           pp_reconstruct_upper_neighbor_) = ::fd::reconstruction::
+      positivity_preserving_adaptive_order_function_pointers<3, true>(
+          true, eight_to_the_alpha_9_.has_value(),
+          six_to_the_alpha_7_.has_value(), low_order_reconstructor_);
+}
+
+std::unique_ptr<Reconstructor>
+PositivityPreservingAdaptiveOrderPrim::get_clone() const {
+  return std::make_unique<PositivityPreservingAdaptiveOrderPrim>(*this);
+}
+
+void PositivityPreservingAdaptiveOrderPrim::pup(PUP::er& p) {
+  Reconstructor::pup(p);
+  p | four_to_the_alpha_5_;
+  p | six_to_the_alpha_7_;
+  p | eight_to_the_alpha_9_;
+  p | low_order_reconstructor_;
+  if (p.isUnpacking()) {
+    set_function_pointers();
+  }
+}
+
+// NOLINTNEXTLINE
+PUP::able::PUP_ID PositivityPreservingAdaptiveOrderPrim::my_PUP_ID = 0;
+
+template <size_t ThermodynamicDim, typename TagsList>
+void PositivityPreservingAdaptiveOrderPrim::reconstruct(
+    const gsl::not_null<std::array<Variables<TagsList>, dim>*>
+        vars_on_lower_face,
+    const gsl::not_null<std::array<Variables<TagsList>, dim>*>
+        vars_on_upper_face,
+    const gsl::not_null<std::optional<std::array<gsl::span<std::uint8_t>, 3>>*>
+        reconstruction_order,
+    const Variables<hydro::grmhd_tags<DataVector>>& volume_prims,
+    const Variables<typename System::variables_tag::type::tags_list>&
+        volume_spacetime_and_cons_vars,
+    const EquationsOfState::EquationOfState<true, ThermodynamicDim>& eos,
+    const Element<dim>& element,
+    const FixedHashMap<maximum_number_of_neighbors(dim),
+                       std::pair<Direction<dim>, ElementId<dim>>,
+                       evolution::dg::subcell::GhostData,
+                       boost::hash<std::pair<Direction<dim>, ElementId<dim>>>>&
+        ghost_data,
+    const Mesh<dim>& subcell_mesh) const {
+  using all_tags_for_reconstruction = grmhd::GhValenciaDivClean::Tags::
+      primitive_grmhd_and_spacetime_reconstruction_tags;
+
+  FixedHashMap<maximum_number_of_neighbors(dim),
+               std::pair<Direction<dim>, ElementId<dim>>,
+               Variables<all_tags_for_reconstruction>,
+               boost::hash<std::pair<Direction<dim>, ElementId<dim>>>>
+      neighbor_variables_data{};
+  ::fd::neighbor_data_as_variables<dim>(make_not_null(&neighbor_variables_data),
+                                        ghost_data, ghost_zone_size(),
+                                        subcell_mesh);
+
+  reconstruct_prims_work<tmpl::list<gr::Tags::SpacetimeMetric<DataVector, 3>>,
+                         positivity_preserving_tags>(
+      vars_on_lower_face, vars_on_upper_face,
+      [this, &reconstruction_order](
+          auto upper_face_vars_ptr, auto lower_face_vars_ptr,
+          const auto& volume_vars, const auto& ghost_cell_vars,
+          const auto& subcell_extents, const size_t number_of_variables) {
+        pp_reconstruct_(upper_face_vars_ptr, lower_face_vars_ptr,
+                        reconstruction_order, volume_vars, ghost_cell_vars,
+                        subcell_extents, number_of_variables,
+                        four_to_the_alpha_5_,
+                        six_to_the_alpha_7_.value_or(
+                            std::numeric_limits<double>::signaling_NaN()),
+                        eight_to_the_alpha_9_.value_or(
+                            std::numeric_limits<double>::signaling_NaN()));
+      },
+      [](auto upper_face_vars_ptr, auto lower_face_vars_ptr,
+         const auto& volume_vars, const auto& ghost_cell_vars,
+         const auto& subcell_extents, const size_t number_of_variables) {
+        ::fd::reconstruction::unlimited<4>(
+            upper_face_vars_ptr, lower_face_vars_ptr, volume_vars,
+            ghost_cell_vars, subcell_extents, number_of_variables);
+      },
+      [](const auto vars_on_face_ptr) {
+        const auto& spacetime_metric =
+            get<gr::Tags::SpacetimeMetric<DataVector, 3>>(*vars_on_face_ptr);
+        auto& spatial_metric =
+            get<gr::Tags::SpatialMetric<DataVector, 3>>(*vars_on_face_ptr);
+        gr::spatial_metric(make_not_null(&spatial_metric), spacetime_metric);
+        auto& inverse_spatial_metric =
+            get<gr::Tags::InverseSpatialMetric<DataVector, 3>>(
+                *vars_on_face_ptr);
+        auto& sqrt_det_spatial_metric =
+            get<gr::Tags::SqrtDetSpatialMetric<DataVector>>(*vars_on_face_ptr);
+
+        determinant_and_inverse(make_not_null(&sqrt_det_spatial_metric),
+                                make_not_null(&inverse_spatial_metric),
+                                spatial_metric);
+        get(sqrt_det_spatial_metric) = sqrt(get(sqrt_det_spatial_metric));
+
+        auto& shift = get<gr::Tags::Shift<DataVector, 3>>(*vars_on_face_ptr);
+        gr::shift(make_not_null(&shift), spacetime_metric,
+                  inverse_spatial_metric);
+        gr::lapse(
+            make_not_null(&get<gr::Tags::Lapse<DataVector>>(*vars_on_face_ptr)),
+            shift, spacetime_metric);
+      },
+      volume_prims, volume_spacetime_and_cons_vars, eos, element,
+      neighbor_variables_data, subcell_mesh, ghost_zone_size(), false);
+
+  reconstruct_prims_work<tmpl::list<gr::Tags::SpacetimeMetric<DataVector, 3>>,
+                         non_positive_tags>(
+      vars_on_lower_face, vars_on_upper_face,
+      [this](
+          auto upper_face_vars_ptr, auto lower_face_vars_ptr,
+          const auto& volume_vars, const auto& ghost_cell_vars,
+          const auto& subcell_extents, const size_t number_of_variables) {
+        reconstruct_(upper_face_vars_ptr, lower_face_vars_ptr, volume_vars,
+                     ghost_cell_vars, subcell_extents, number_of_variables,
+                     four_to_the_alpha_5_,
+                     six_to_the_alpha_7_.value_or(
+                         std::numeric_limits<double>::signaling_NaN()),
+                     eight_to_the_alpha_9_.value_or(
+                         std::numeric_limits<double>::signaling_NaN()));
+      },
+      [](auto upper_face_vars_ptr, auto lower_face_vars_ptr,
+         const auto& volume_vars, const auto& ghost_cell_vars,
+         const auto& subcell_extents, const size_t number_of_variables) {
+        ::fd::reconstruction::unlimited<4>(
+            upper_face_vars_ptr, lower_face_vars_ptr, volume_vars,
+            ghost_cell_vars, subcell_extents, number_of_variables);
+      },
+      [](const auto vars_on_face_ptr) {
+        const auto& spacetime_metric =
+            get<gr::Tags::SpacetimeMetric<DataVector, 3>>(*vars_on_face_ptr);
+        auto& spatial_metric =
+            get<gr::Tags::SpatialMetric<DataVector, 3>>(*vars_on_face_ptr);
+        gr::spatial_metric(make_not_null(&spatial_metric), spacetime_metric);
+        auto& inverse_spatial_metric =
+            get<gr::Tags::InverseSpatialMetric<DataVector, 3>>(
+                *vars_on_face_ptr);
+        auto& sqrt_det_spatial_metric =
+            get<gr::Tags::SqrtDetSpatialMetric<DataVector>>(*vars_on_face_ptr);
+
+        determinant_and_inverse(make_not_null(&sqrt_det_spatial_metric),
+                                make_not_null(&inverse_spatial_metric),
+                                spatial_metric);
+        get(sqrt_det_spatial_metric) = sqrt(get(sqrt_det_spatial_metric));
+
+        auto& shift = get<gr::Tags::Shift<DataVector, 3>>(*vars_on_face_ptr);
+        gr::shift(make_not_null(&shift), spacetime_metric,
+                  inverse_spatial_metric);
+        gr::lapse(
+            make_not_null(&get<gr::Tags::Lapse<DataVector>>(*vars_on_face_ptr)),
+            shift, spacetime_metric);
+      },
+      volume_prims, volume_spacetime_and_cons_vars, eos, element,
+      neighbor_variables_data, subcell_mesh, ghost_zone_size(), true);
+}
+
+// The current implementation does not use positivity-preserving
+// reconstruction at Dg/Subcell boundary. PP should only be required
+// at shocks / surfaces, which should be within the subcell region
+// if the Dg/Subcell code is performing as expected.
+template <size_t ThermodynamicDim, typename TagsList>
+void PositivityPreservingAdaptiveOrderPrim::reconstruct_fd_neighbor(
+    const gsl::not_null<Variables<TagsList>*> vars_on_face,
+    const Variables<hydro::grmhd_tags<DataVector>>& subcell_volume_prims,
+    const Variables<
+        grmhd::GhValenciaDivClean::Tags::spacetime_reconstruction_tags>&
+        subcell_volume_spacetime_metric,
+    const EquationsOfState::EquationOfState<true, ThermodynamicDim>& eos,
+    const Element<dim>& element,
+    const FixedHashMap<maximum_number_of_neighbors(dim),
+                       std::pair<Direction<dim>, ElementId<dim>>,
+                       evolution::dg::subcell::GhostData,
+                       boost::hash<std::pair<Direction<dim>, ElementId<dim>>>>&
+        ghost_data,
+    const Mesh<dim>& subcell_mesh,
+    const Direction<dim> direction_to_reconstruct) const {
+  using prim_tags_for_reconstruction =
+      grmhd::GhValenciaDivClean::Tags::primitive_grmhd_reconstruction_tags;
+  using all_tags_for_reconstruction = grmhd::GhValenciaDivClean::Tags::
+      primitive_grmhd_and_spacetime_reconstruction_tags;
+  reconstruct_fd_neighbor_work<Tags::spacetime_reconstruction_tags,
+                               prim_tags_for_reconstruction,
+                               all_tags_for_reconstruction>(
+      vars_on_face,
+      [this](const auto tensor_component_on_face_ptr,
+             const auto& tensor_component_volume,
+             const auto& tensor_component_neighbor,
+             const Index<dim>& subcell_extents,
+             const Index<dim>& ghost_data_extents,
+             const Direction<dim>& local_direction_to_reconstruct) {
+        reconstruct_lower_neighbor_(
+            tensor_component_on_face_ptr, tensor_component_volume,
+            tensor_component_neighbor, subcell_extents, ghost_data_extents,
+            local_direction_to_reconstruct, four_to_the_alpha_5_,
+            six_to_the_alpha_7_.value_or(
+                std::numeric_limits<double>::signaling_NaN()),
+            eight_to_the_alpha_9_.value_or(
+                std::numeric_limits<double>::signaling_NaN()));
+      },
+      [](const auto tensor_component_on_face_ptr,
+         const auto& tensor_component_volume,
+         const auto& tensor_component_neighbor,
+         const Index<dim>& subcell_extents,
+         const Index<dim>& ghost_data_extents,
+         const Direction<dim>& local_direction_to_reconstruct) {
+        ::fd::reconstruction::reconstruct_neighbor<
+            Side::Lower,
+            ::fd::reconstruction::detail::UnlimitedReconstructor<4>>(
+            tensor_component_on_face_ptr, tensor_component_volume,
+            tensor_component_neighbor, subcell_extents, ghost_data_extents,
+            local_direction_to_reconstruct);
+      },
+      [this](const auto tensor_component_on_face_ptr,
+             const auto& tensor_component_volume,
+             const auto& tensor_component_neighbor,
+             const Index<dim>& subcell_extents,
+             const Index<dim>& ghost_data_extents,
+             const Direction<dim>& local_direction_to_reconstruct) {
+        reconstruct_upper_neighbor_(
+            tensor_component_on_face_ptr, tensor_component_volume,
+            tensor_component_neighbor, subcell_extents, ghost_data_extents,
+            local_direction_to_reconstruct, four_to_the_alpha_5_,
+            six_to_the_alpha_7_.value_or(
+                std::numeric_limits<double>::signaling_NaN()),
+            eight_to_the_alpha_9_.value_or(
+                std::numeric_limits<double>::signaling_NaN()));
+      },
+      [](const auto tensor_component_on_face_ptr,
+         const auto& tensor_component_volume,
+         const auto& tensor_component_neighbor,
+         const Index<dim>& subcell_extents,
+         const Index<dim>& ghost_data_extents,
+         const Direction<dim>& local_direction_to_reconstruct) {
+        ::fd::reconstruction::reconstruct_neighbor<
+            Side::Upper,
+            ::fd::reconstruction::detail::UnlimitedReconstructor<4>>(
+            tensor_component_on_face_ptr, tensor_component_volume,
+            tensor_component_neighbor, subcell_extents, ghost_data_extents,
+            local_direction_to_reconstruct);
+      },
+      [](const auto vars_on_face_ptr) {
+        const auto& spacetime_metric =
+            get<gr::Tags::SpacetimeMetric<DataVector, 3>>(*vars_on_face_ptr);
+        auto& spatial_metric =
+            get<gr::Tags::SpatialMetric<DataVector, 3>>(*vars_on_face_ptr);
+        gr::spatial_metric(make_not_null(&spatial_metric), spacetime_metric);
+        auto& inverse_spatial_metric =
+            get<gr::Tags::InverseSpatialMetric<DataVector, 3>>(
+                *vars_on_face_ptr);
+        auto& sqrt_det_spatial_metric =
+            get<gr::Tags::SqrtDetSpatialMetric<DataVector>>(*vars_on_face_ptr);
+
+        determinant_and_inverse(make_not_null(&sqrt_det_spatial_metric),
+                                make_not_null(&inverse_spatial_metric),
+                                spatial_metric);
+        get(sqrt_det_spatial_metric) = sqrt(get(sqrt_det_spatial_metric));
+
+        auto& shift = get<gr::Tags::Shift<DataVector, 3>>(*vars_on_face_ptr);
+        gr::shift(make_not_null(&shift), spacetime_metric,
+                  inverse_spatial_metric);
+        gr::lapse(
+            make_not_null(&get<gr::Tags::Lapse<DataVector>>(*vars_on_face_ptr)),
+            shift, spacetime_metric);
+      },
+      subcell_volume_prims, subcell_volume_spacetime_metric, eos, element,
+      ghost_data, subcell_mesh, direction_to_reconstruct, ghost_zone_size(),
+      true);
+}
+
+bool operator==(const PositivityPreservingAdaptiveOrderPrim& lhs,
+                const PositivityPreservingAdaptiveOrderPrim& rhs) {
+  // Don't check function pointers since they are set from
+  // low_order_reconstructor_
+  return lhs.four_to_the_alpha_5_ == rhs.four_to_the_alpha_5_ and
+         lhs.six_to_the_alpha_7_ == rhs.six_to_the_alpha_7_ and
+         lhs.eight_to_the_alpha_9_ == rhs.eight_to_the_alpha_9_ and
+         lhs.low_order_reconstructor_ == rhs.low_order_reconstructor_;
+}
+
+bool operator!=(const PositivityPreservingAdaptiveOrderPrim& lhs,
+                const PositivityPreservingAdaptiveOrderPrim& rhs) {
+  return not(lhs == rhs);
+}
+
+#define THERMO_DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define TAGS_LIST_FD(data)                                                    \
+  tmpl::list<gr::Tags::SpacetimeMetric<DataVector, 3>,                        \
+             gh::Tags::Pi<DataVector, 3>, gh::Tags::Phi<DataVector, 3>,       \
+             ValenciaDivClean::Tags::TildeD, ValenciaDivClean::Tags::TildeYe, \
+             ValenciaDivClean::Tags::TildeTau,                                \
+             ValenciaDivClean::Tags::TildeS<Frame::Inertial>,                 \
+             ValenciaDivClean::Tags::TildeB<Frame::Inertial>,                 \
+             ValenciaDivClean::Tags::TildePhi,                                \
+             hydro::Tags::RestMassDensity<DataVector>,                        \
+             hydro::Tags::ElectronFraction<DataVector>,                       \
+             hydro::Tags::SpecificInternalEnergy<DataVector>,                 \
+             hydro::Tags::SpatialVelocity<DataVector, 3>,                     \
+             hydro::Tags::MagneticField<DataVector, 3>,                       \
+             hydro::Tags::DivergenceCleaningField<DataVector>,                \
+             hydro::Tags::LorentzFactor<DataVector>,                          \
+             hydro::Tags::Pressure<DataVector>,                               \
+             hydro::Tags::SpecificEnthalpy<DataVector>,                       \
+             hydro::Tags::LorentzFactorTimesSpatialVelocity<DataVector, 3>,   \
+             ::Tags::Flux<ValenciaDivClean::Tags::TildeD, tmpl::size_t<3>,    \
+                          Frame::Inertial>,                                   \
+             ::Tags::Flux<ValenciaDivClean::Tags::TildeYe, tmpl::size_t<3>,   \
+                          Frame::Inertial>,                                   \
+             ::Tags::Flux<ValenciaDivClean::Tags::TildeTau, tmpl::size_t<3>,  \
+                          Frame::Inertial>,                                   \
+             ::Tags::Flux<ValenciaDivClean::Tags::TildeS<Frame::Inertial>,    \
+                          tmpl::size_t<3>, Frame::Inertial>,                  \
+             ::Tags::Flux<ValenciaDivClean::Tags::TildeB<Frame::Inertial>,    \
+                          tmpl::size_t<3>, Frame::Inertial>,                  \
+             ::Tags::Flux<ValenciaDivClean::Tags::TildePhi, tmpl::size_t<3>,  \
+                          Frame::Inertial>,                                   \
+             gr::Tags::Lapse<DataVector>, gr::Tags::Shift<DataVector, 3>,     \
+             gr::Tags::SpatialMetric<DataVector, 3>,                          \
+             gr::Tags::SqrtDetSpatialMetric<DataVector>,                      \
+             gr::Tags::InverseSpatialMetric<DataVector, 3>,                   \
+             evolution::dg::Actions::detail::NormalVector<3>>
+
+#define TAGS_LIST_DG_FD_INTERFACE(data)                                       \
+  tmpl::list<gr::Tags::SpacetimeMetric<DataVector, 3>,                        \
+             gh::Tags::Pi<DataVector, 3>, gh::Tags::Phi<DataVector, 3>,       \
+             ValenciaDivClean::Tags::TildeD, ValenciaDivClean::Tags::TildeYe, \
+             ValenciaDivClean::Tags::TildeTau,                                \
+             ValenciaDivClean::Tags::TildeS<Frame::Inertial>,                 \
+             ValenciaDivClean::Tags::TildeB<Frame::Inertial>,                 \
+             ValenciaDivClean::Tags::TildePhi,                                \
+             hydro::Tags::RestMassDensity<DataVector>,                        \
+             hydro::Tags::ElectronFraction<DataVector>,                       \
+             hydro::Tags::SpecificInternalEnergy<DataVector>,                 \
+             hydro::Tags::SpatialVelocity<DataVector, 3>,                     \
+             hydro::Tags::MagneticField<DataVector, 3>,                       \
+             hydro::Tags::DivergenceCleaningField<DataVector>,                \
+             hydro::Tags::LorentzFactor<DataVector>,                          \
+             hydro::Tags::Pressure<DataVector>,                               \
+             hydro::Tags::SpecificEnthalpy<DataVector>,                       \
+             hydro::Tags::LorentzFactorTimesSpatialVelocity<DataVector, 3>,   \
+             ::Tags::Flux<ValenciaDivClean::Tags::TildeD, tmpl::size_t<3>,    \
+                          Frame::Inertial>,                                   \
+             ::Tags::Flux<ValenciaDivClean::Tags::TildeYe, tmpl::size_t<3>,   \
+                          Frame::Inertial>,                                   \
+             ::Tags::Flux<ValenciaDivClean::Tags::TildeTau, tmpl::size_t<3>,  \
+                          Frame::Inertial>,                                   \
+             ::Tags::Flux<ValenciaDivClean::Tags::TildeS<Frame::Inertial>,    \
+                          tmpl::size_t<3>, Frame::Inertial>,                  \
+             ::Tags::Flux<ValenciaDivClean::Tags::TildeB<Frame::Inertial>,    \
+                          tmpl::size_t<3>, Frame::Inertial>,                  \
+             ::Tags::Flux<ValenciaDivClean::Tags::TildePhi, tmpl::size_t<3>,  \
+                          Frame::Inertial>,                                   \
+             gh::ConstraintDamping::Tags::ConstraintGamma1,                   \
+             gh::ConstraintDamping::Tags::ConstraintGamma2,                   \
+             gr::Tags::Lapse<DataVector>, gr::Tags::Shift<DataVector, 3>,     \
+             gr::Tags::SpatialMetric<DataVector, 3>,                          \
+             gr::Tags::SqrtDetSpatialMetric<DataVector>,                      \
+             gr::Tags::InverseSpatialMetric<DataVector, 3>,                   \
+             evolution::dg::Actions::detail::NormalVector<3>>
+
+#define INSTANTIATION(r, data)                                                 \
+  template void PositivityPreservingAdaptiveOrderPrim::reconstruct(            \
+      gsl::not_null<std::array<Variables<TAGS_LIST_FD(data)>, 3>*>             \
+          vars_on_lower_face,                                                  \
+      gsl::not_null<std::array<Variables<TAGS_LIST_FD(data)>, 3>*>             \
+          vars_on_upper_face,                                                  \
+      const gsl::not_null<                                                     \
+          std::optional<std::array<gsl::span<std::uint8_t>, 3>>*>              \
+          reconstruction_order,                                                \
+      const Variables<hydro::grmhd_tags<DataVector>>& volume_prims,            \
+      const Variables<typename System::variables_tag::type::tags_list>&        \
+          volume_spacetime_and_cons_vars,                                      \
+      const EquationsOfState::EquationOfState<true, THERMO_DIM(data)>& eos,    \
+      const Element<3>& element,                                               \
+      const FixedHashMap<maximum_number_of_neighbors(3),                       \
+                         std::pair<Direction<3>, ElementId<3>>,                \
+                         evolution::dg::subcell::GhostData,                    \
+                         boost::hash<std::pair<Direction<3>, ElementId<3>>>>&  \
+          ghost_data,                                                          \
+      const Mesh<3>& subcell_mesh) const;                                      \
+  template void                                                                \
+  PositivityPreservingAdaptiveOrderPrim::reconstruct_fd_neighbor(              \
+      gsl::not_null<Variables<TAGS_LIST_DG_FD_INTERFACE(data)>*> vars_on_face, \
+      const Variables<hydro::grmhd_tags<DataVector>>& subcell_volume_prims,    \
+      const Variables<                                                         \
+          grmhd::GhValenciaDivClean::Tags::spacetime_reconstruction_tags>&     \
+          subcell_volume_spacetime_metric,                                     \
+      const EquationsOfState::EquationOfState<true, THERMO_DIM(data)>& eos,    \
+      const Element<3>& element,                                               \
+      const FixedHashMap<maximum_number_of_neighbors(3),                       \
+                         std::pair<Direction<3>, ElementId<3>>,                \
+                         evolution::dg::subcell::GhostData,                    \
+                         boost::hash<std::pair<Direction<3>, ElementId<3>>>>&  \
+          ghost_data,                                                          \
+      const Mesh<3>& subcell_mesh,                                             \
+      const Direction<3> direction_to_reconstruct) const;
+
+GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2))
+
+#undef INSTANTIATION
+#undef TAGS_LIST
+#undef THERMO_DIM
+}  // namespace grmhd::GhValenciaDivClean::fd

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/PositivityPreservingAdaptiveOrder.hpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/PositivityPreservingAdaptiveOrder.hpp
@@ -1,0 +1,244 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <limits>
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "DataStructures/FixedHashMap.hpp"
+#include "DataStructures/Variables.hpp"
+#include "DataStructures/VariablesTag.hpp"
+#include "Domain/Structure/MaxNumberOfNeighbors.hpp"
+#include "Domain/Tags.hpp"
+#include "Evolution/DgSubcell/Tags/GhostDataForReconstruction.hpp"
+#include "Evolution/DgSubcell/Tags/Mesh.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
+#include "Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/Reconstructor.hpp"
+#include "Evolution/Systems/GrMhd/GhValenciaDivClean/System.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/Tags.hpp"
+#include "NumericalAlgorithms/FiniteDifference/FallbackReconstructorType.hpp"
+#include "Options/Auto.hpp"
+#include "Options/Context.hpp"
+#include "Options/String.hpp"
+#include "PointwiseFunctions/Hydro/Tags.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+class DataVector;
+template <size_t Dim>
+class Direction;
+template <size_t Dim>
+class Element;
+template <size_t Dim>
+class ElementId;
+namespace EquationsOfState {
+template <bool IsRelativistic, size_t ThermodynamicDim>
+class EquationOfState;
+}  // namespace EquationsOfState
+template <size_t Dim>
+class Mesh;
+namespace gsl {
+template <typename T>
+class not_null;
+}  // namespace gsl
+namespace PUP {
+class er;
+}  // namespace PUP
+namespace evolution::dg::subcell {
+class GhostData;
+}  // namespace evolution::dg::subcell
+/// \endcond
+
+namespace grmhd::GhValenciaDivClean::fd {
+/*!
+ * \brief Positivity-preserving adaptive order reconstruction. See
+ * ::fd::reconstruction::positivity_preserving_adaptive_order() for details.
+ * The rest mass density, electron fraction, and the pressure are kept positive.
+ * Use unlimited 5th order (degree 4 polynomial) reconstruction on the
+ * metric variables.
+ *
+ * Only the spacetime metric is reconstructed when we and the neighboring
+ * element in the direction are doing FD. If we are doing DG and a neighboring
+ * element is doing FD, then the spacetime metric, \f$\Phi_{iab}\f$, and
+ * \f$\Pi_{ab}\f$ are all reconstructed since the Riemann solver on the DG
+ * element also needs to solve for the metric variables.
+ */
+class PositivityPreservingAdaptiveOrderPrim : public Reconstructor {
+ private:
+  using positivity_preserving_tags =
+      tmpl::list<hydro::Tags::RestMassDensity<DataVector>,
+                 hydro::Tags::ElectronFraction<DataVector>,
+                 hydro::Tags::Pressure<DataVector>>;
+  using non_positive_tags =
+      tmpl::list<hydro::Tags::LorentzFactorTimesSpatialVelocity<DataVector, 3>,
+                 hydro::Tags::MagneticField<DataVector, 3>,
+                 hydro::Tags::DivergenceCleaningField<DataVector>>;
+
+  using FallbackReconstructorType =
+      ::fd::reconstruction::FallbackReconstructorType;
+
+ public:
+  static constexpr size_t dim = 3;
+
+  struct Alpha5 {
+    using type = double;
+    static constexpr Options::String help = {
+        "The alpha parameter in the Persson convergence measurement. 4 is the "
+        "right value, but anything in the range of 3-5 is 'reasonable'. "
+        "Smaller values allow for more oscillations."};
+  };
+  struct Alpha7 {
+    using type = Options::Auto<double, Options::AutoLabel::None>;
+    static constexpr Options::String help = {
+        "The alpha parameter in the Persson convergence measurement. 4 is the "
+        "right value, but anything in the range of 3-5 is 'reasonable'. "
+        "Smaller values allow for more oscillations. If not specified then "
+        "7th-order reconstruction is not used."};
+  };
+  struct Alpha9 {
+    using type = Options::Auto<double, Options::AutoLabel::None>;
+    static constexpr Options::String help = {
+        "The alpha parameter in the Persson convergence measurement. 4 is the "
+        "right value, but anything in the range of 3-5 is 'reasonable'. "
+        "Smaller values allow for more oscillations. If not specified then "
+        "9th-order reconstruction is not used."};
+  };
+  struct LowOrderReconstructor {
+    using type = FallbackReconstructorType;
+    static constexpr Options::String help = {
+        "The 2nd/3rd-order reconstruction scheme to use if unlimited 5th-order "
+        "isn't okay."};
+  };
+
+  using options = tmpl::list<Alpha5, Alpha7, Alpha9, LowOrderReconstructor>;
+
+  static constexpr Options::String help{
+      "Positivity-preserving adaptive-order reconstruction."};
+
+  PositivityPreservingAdaptiveOrderPrim() = default;
+  PositivityPreservingAdaptiveOrderPrim(
+      PositivityPreservingAdaptiveOrderPrim&&) = default;
+  PositivityPreservingAdaptiveOrderPrim& operator=(
+      PositivityPreservingAdaptiveOrderPrim&&) = default;
+  PositivityPreservingAdaptiveOrderPrim(
+      const PositivityPreservingAdaptiveOrderPrim&) = default;
+  PositivityPreservingAdaptiveOrderPrim& operator=(
+      const PositivityPreservingAdaptiveOrderPrim&) = default;
+  ~PositivityPreservingAdaptiveOrderPrim() override = default;
+
+  PositivityPreservingAdaptiveOrderPrim(
+      double alpha_5, std::optional<double> alpha_7,
+      std::optional<double> alpha_9,
+      FallbackReconstructorType low_order_reconstructor,
+      const Options::Context& context = {});
+
+  explicit PositivityPreservingAdaptiveOrderPrim(CkMigrateMessage* msg);
+
+  WRAPPED_PUPable_decl_base_template(Reconstructor,
+                                     PositivityPreservingAdaptiveOrderPrim);
+
+  auto get_clone() const -> std::unique_ptr<Reconstructor> override;
+
+  static constexpr bool use_adaptive_order = true;
+  bool supports_adaptive_order() const override { return use_adaptive_order; }
+
+  void pup(PUP::er& p) override;
+
+  size_t ghost_zone_size() const override {
+    return eight_to_the_alpha_9_.has_value()
+               ? 5
+               : (six_to_the_alpha_7_.has_value() ? 4 : 3);
+  }
+
+  using reconstruction_argument_tags =
+      tmpl::list<::Tags::Variables<hydro::grmhd_tags<DataVector>>,
+                 typename System::variables_tag,
+                 hydro::Tags::EquationOfStateBase, domain::Tags::Element<dim>,
+                 evolution::dg::subcell::Tags::GhostDataForReconstruction<dim>,
+                 evolution::dg::subcell::Tags::Mesh<dim>>;
+
+  template <size_t ThermodynamicDim, typename TagsList>
+  void reconstruct(
+      gsl::not_null<std::array<Variables<TagsList>, dim>*> vars_on_lower_face,
+      gsl::not_null<std::array<Variables<TagsList>, dim>*> vars_on_upper_face,
+      gsl::not_null<std::optional<std::array<gsl::span<std::uint8_t>, dim>>*>
+          reconstruction_order,
+      const Variables<hydro::grmhd_tags<DataVector>>& volume_prims,
+      const Variables<typename System::variables_tag::type::tags_list>&
+          volume_spacetime_and_cons_vars,
+      const EquationsOfState::EquationOfState<true, ThermodynamicDim>& eos,
+      const Element<dim>& element,
+      const FixedHashMap<
+          maximum_number_of_neighbors(dim),
+          std::pair<Direction<dim>, ElementId<dim>>,
+          evolution::dg::subcell::GhostData,
+          boost::hash<std::pair<Direction<dim>, ElementId<dim>>>>& ghost_data,
+      const Mesh<dim>& subcell_mesh) const;
+
+  /// Called by an element doing DG when the neighbor is doing subcell.
+  template <size_t ThermodynamicDim, typename TagsList>
+  void reconstruct_fd_neighbor(
+      gsl::not_null<Variables<TagsList>*> vars_on_face,
+      const Variables<hydro::grmhd_tags<DataVector>>& subcell_volume_prims,
+      const Variables<
+          grmhd::GhValenciaDivClean::Tags::spacetime_reconstruction_tags>&
+          subcell_volume_spacetime_metric,
+      const EquationsOfState::EquationOfState<true, ThermodynamicDim>& eos,
+      const Element<dim>& element,
+      const FixedHashMap<
+          maximum_number_of_neighbors(dim),
+          std::pair<Direction<dim>, ElementId<dim>>,
+          evolution::dg::subcell::GhostData,
+          boost::hash<std::pair<Direction<dim>, ElementId<dim>>>>& ghost_data,
+      const Mesh<dim>& subcell_mesh,
+      const Direction<dim> direction_to_reconstruct) const;
+
+ private:
+  // NOLINTNEXTLINE(readability-redundant-declaration)
+  friend bool operator==(const PositivityPreservingAdaptiveOrderPrim& lhs,
+                         const PositivityPreservingAdaptiveOrderPrim& rhs);
+
+  friend bool operator!=(const PositivityPreservingAdaptiveOrderPrim& lhs,
+                         const PositivityPreservingAdaptiveOrderPrim& rhs);
+
+  void set_function_pointers();
+
+  double four_to_the_alpha_5_ = std::numeric_limits<double>::signaling_NaN();
+  std::optional<double> six_to_the_alpha_7_{};
+  std::optional<double> eight_to_the_alpha_9_{};
+  FallbackReconstructorType low_order_reconstructor_ =
+      FallbackReconstructorType::None;
+
+  using PointerReconsOrder = void (*)(
+      gsl::not_null<std::array<gsl::span<double>, dim>*>,
+      gsl::not_null<std::array<gsl::span<double>, dim>*>,
+      gsl::not_null<std::optional<std::array<gsl::span<std::uint8_t>, dim>>*>,
+      const gsl::span<const double>&,
+      const DirectionMap<dim, gsl::span<const double>>&, const Index<dim>&,
+      size_t, double, double, double);
+  using PointerRecons =
+      void (*)(gsl::not_null<std::array<gsl::span<double>, dim>*>,
+               gsl::not_null<std::array<gsl::span<double>, dim>*>,
+               const gsl::span<const double>&,
+               const DirectionMap<dim, gsl::span<const double>>&,
+               const Index<dim>&, size_t, double, double, double);
+  PointerRecons reconstruct_ = nullptr;
+  PointerReconsOrder pp_reconstruct_ = nullptr;
+
+  using PointerNeighbor = void (*)(gsl::not_null<DataVector*>,
+                                   const DataVector&, const DataVector&,
+                                   const Index<dim>&, const Index<dim>&,
+                                   const Direction<dim>&, const double&,
+                                   const double&, const double&);
+  PointerNeighbor reconstruct_lower_neighbor_ = nullptr;
+  PointerNeighbor reconstruct_upper_neighbor_ = nullptr;
+  PointerNeighbor pp_reconstruct_lower_neighbor_ = nullptr;
+  PointerNeighbor pp_reconstruct_upper_neighbor_ = nullptr;
+};
+
+}  // namespace grmhd::GhValenciaDivClean::fd

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/Reconstructor.hpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/Reconstructor.hpp
@@ -18,6 +18,7 @@ class er;
 namespace grmhd::GhValenciaDivClean::fd {
 /// \cond
 class MonotonisedCentralPrim;
+class PositivityPreservingAdaptiveOrderPrim;
 /// \endcond
 
 /*!
@@ -37,11 +38,14 @@ class Reconstructor : public PUP::able {
   WRAPPED_PUPable_abstract(Reconstructor);  // NOLINT
   /// \endcond
 
-  using creatable_classes = tmpl::list<MonotonisedCentralPrim>;
+  using creatable_classes = tmpl::list<MonotonisedCentralPrim,
+                                       PositivityPreservingAdaptiveOrderPrim>;
 
   virtual std::unique_ptr<Reconstructor> get_clone() const = 0;
 
   virtual size_t ghost_zone_size() const = 0;
+
+  virtual bool supports_adaptive_order() const { return false; }
 
   // NOLINTNEXTLINE(google-runtime-references)
   void pup(PUP::er& p) override;

--- a/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/Test_TimeDerivative.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/Test_TimeDerivative.cpp
@@ -41,6 +41,7 @@
 #include "Evolution/DgSubcell/Tags/Jacobians.hpp"
 #include "Evolution/DgSubcell/Tags/Mesh.hpp"
 #include "Evolution/DgSubcell/Tags/OnSubcellFaces.hpp"
+#include "Evolution/DgSubcell/Tags/ReconstructionOrder.hpp"
 #include "Evolution/DiscontinuousGalerkin/MortarTags.hpp"
 #include "Evolution/DiscontinuousGalerkin/NormalVectorTags.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/BoundaryCorrections/UpwindPenalty.hpp"
@@ -259,7 +260,8 @@ double test(const size_t num_dg_pts, std::optional<double> expansion_velocity,
       neighbor_data{};
   using prims_to_reconstruct_tags = grmhd::GhValenciaDivClean::Tags::
       primitive_grmhd_and_spacetime_reconstruction_tags;
-  for (const auto& [direction, neighbors_in_direction] : element.neighbors()) {
+  for (const auto & [ direction, neighbors_in_direction ] :
+       element.neighbors()) {
     auto neighbor_logical_coords = logical_coordinates(subcell_mesh);
     neighbor_logical_coords.get(direction.dimension()) +=
         2.0 * direction.sign();
@@ -425,25 +427,24 @@ double test(const size_t num_dg_pts, std::optional<double> expansion_velocity,
             face_coords.get(i) * expansion_velocity.value();
       }
 
-      tmpl::for_each<conserved_tags>(
-          [&prims_to_reconstruct, &face_mesh_velocity](auto tag_v) {
-            using tag = tmpl::type_from<decltype(tag_v)>;
-            using flux_tag =
-                ::Tags::Flux<tag, tmpl::size_t<3>, Frame::Inertial>;
-            using FluxTensor = typename flux_tag::type;
-            const auto& var = get<tag>(prims_to_reconstruct);
-            auto& flux = get<flux_tag>(prims_to_reconstruct);
-            for (size_t storage_index = 0; storage_index < var.size();
-                 ++storage_index) {
-              const auto tensor_index = var.get_tensor_index(storage_index);
-              for (size_t j = 0; j < 3; j++) {
-                const auto flux_storage_index =
-                    FluxTensor::get_storage_index(prepend(tensor_index, j));
-                flux[flux_storage_index] -=
-                    face_mesh_velocity.value().get(j) * var[storage_index];
-              }
-            }
-          });
+      tmpl::for_each<conserved_tags>([&prims_to_reconstruct,
+                                      &face_mesh_velocity](auto tag_v) {
+        using tag = tmpl::type_from<decltype(tag_v)>;
+        using flux_tag = ::Tags::Flux<tag, tmpl::size_t<3>, Frame::Inertial>;
+        using FluxTensor = typename flux_tag::type;
+        const auto& var = get<tag>(prims_to_reconstruct);
+        auto& flux = get<flux_tag>(prims_to_reconstruct);
+        for (size_t storage_index = 0; storage_index < var.size();
+             ++storage_index) {
+          const auto tensor_index = var.get_tensor_index(storage_index);
+          for (size_t j = 0; j < 3; j++) {
+            const auto flux_storage_index =
+                FluxTensor::get_storage_index(prepend(tensor_index, j));
+            flux[flux_storage_index] -=
+                face_mesh_velocity.value().get(j) * var[storage_index];
+          }
+        }
+      });
     }
 
     (*gamma1)(
@@ -598,6 +599,8 @@ double test(const size_t num_dg_pts, std::optional<double> expansion_velocity,
       dummy_normal_covector_and_magnitude{};
   using DampingFunction =
       gh::ConstraintDamping::DampingFunction<3, Frame::Grid>;
+  typename evolution::dg::subcell::Tags::ReconstructionOrder<3>::type
+      dummy_reconstruction_order{};
 
   auto box = db::create<
       db::AddSimpleTags<
@@ -610,6 +613,7 @@ double test(const size_t num_dg_pts, std::optional<double> expansion_velocity,
           typename System::primitive_variables_tag, dt_variables_tag,
           variables_tag,
           evolution::dg::subcell::Tags::GhostDataForReconstruction<3>,
+          evolution::dg::subcell::Tags::ReconstructionOrder<3>,
           ValenciaDivClean::Tags::ConstraintDampingParameter,
           evolution::dg::Tags::MortarData<3>,
           domain::Tags::ElementMap<3, Frame::Grid>,
@@ -671,7 +675,8 @@ double test(const size_t num_dg_pts, std::optional<double> expansion_velocity,
       soln.equation_of_state().get_clone(), cell_centered_prim_vars,
       // Set incorrect size for dt variables because they should get resized.
       Variables<typename dt_variables_tag::tags_list>{}, initial_variables,
-      neighbor_data, 1.0, mortar_data, std::move(element_map),
+      neighbor_data, dummy_reconstruction_order, 1.0, mortar_data,
+      std::move(element_map),
       domain::make_coordinate_map_base<Frame::Grid, Frame::Inertial>(
           domain::CoordinateMaps::Identity<3>{}),
       std::move(domain), std::move(external_boundary_conditions),


### PR DESCRIPTION
## Proposed changes

Adds PPAO reconstructor to GhValenciaDivClean system.

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

Mainly a copy of the code in ValenciaDivClean. 
We use 4th order unlimited reconstruction for the metric.
This also required changes to the Reconstructor interface, adding the use_adaptive_order member variable.
