### PR TITLE
Add a rotating star magnetosphere initial data to ForceFree

### DIFF
--- a/docs/References.bib
+++ b/docs/References.bib
@@ -1702,6 +1702,21 @@ journal = {The Astrophysical Journal}
   year =         2014
 }
 
+@article{Most2022,
+  author  = {Most, Elias R and Philippov, Alexander A},
+  doi     = {10.1093/mnras/stac1909},
+  issn    = {0035-8711},
+  journal = {Monthly Notices of the Royal Astronomical Society},
+  month   = {07},
+  number  = {2},
+  pages   = {2710-2724},
+  title   = {{Electromagnetic precursor flares from the late inspiral of
+             neutron star binaries}},
+  url     = {https://doi.org/10.1093/mnras/stac1909},
+  volume  = {515},
+  year    = {2022}
+}
+
 @article{Moxon2020gha,
     author           = "Moxon, Jordan and Scheel, Mark A. and
                         Teukolsky, Saul A.",

--- a/src/PointwiseFunctions/AnalyticData/ForceFree/CMakeLists.txt
+++ b/src/PointwiseFunctions/AnalyticData/ForceFree/CMakeLists.txt
@@ -9,6 +9,7 @@ spectre_target_sources(
   ${LIBRARY}
   PRIVATE
   FfeBreakdown.cpp
+  RotatingDipole.cpp
   )
 
 spectre_target_headers(
@@ -18,6 +19,7 @@ spectre_target_headers(
   AnalyticData.hpp
   Factory.hpp
   FfeBreakdown.hpp
+  RotatingDipole.hpp
   )
 
 target_link_libraries(

--- a/src/PointwiseFunctions/AnalyticData/ForceFree/Factory.hpp
+++ b/src/PointwiseFunctions/AnalyticData/ForceFree/Factory.hpp
@@ -4,9 +4,10 @@
 #pragma once
 
 #include "PointwiseFunctions/AnalyticData/ForceFree/FfeBreakdown.hpp"
+#include "PointwiseFunctions/AnalyticData/ForceFree/RotatingDipole.hpp"
 #include "Utilities/TMPL.hpp"
 
 namespace ForceFree::AnalyticData {
 /// \brief List of all analytic data
-using all_data = tmpl::list<FfeBreakdown>;
+using all_data = tmpl::list<FfeBreakdown, RotatingDipole>;
 }  // namespace ForceFree::AnalyticData

--- a/src/PointwiseFunctions/AnalyticData/ForceFree/RotatingDipole.cpp
+++ b/src/PointwiseFunctions/AnalyticData/ForceFree/RotatingDipole.cpp
@@ -1,0 +1,166 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "PointwiseFunctions/AnalyticData/ForceFree/RotatingDipole.hpp"
+
+#include <cstddef>
+#include <memory>
+#include <pup.h>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Options/Options.hpp"
+#include "Options/ParseOptions.hpp"
+#include "PointwiseFunctions/InitialDataUtilities/InitialData.hpp"
+#include "Utilities/MakeWithValue.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace ForceFree::AnalyticData {
+
+RotatingDipole::RotatingDipole(const double vector_potential_amplitude,
+                               const double varpi0, const double delta,
+                               const double angular_velocity,
+                               const double tilt_angle,
+                               const Options::Context& context)
+    : vector_potential_amplitude_(vector_potential_amplitude),
+      varpi0_(varpi0),
+      delta_(delta),
+      angular_velocity_(angular_velocity),
+      tilt_angle_(tilt_angle) {
+  if (varpi0 < 0.0) {
+    PARSE_ERROR(context, "The length constant varpi0 ("
+                             << varpi0_ << ") cannot be negative");
+  }
+  if (delta < 0.0) {
+    PARSE_ERROR(context,
+                "The small number delta (" << delta_ << ") cannot be negative");
+  }
+  if (abs(angular_velocity) >= 1.0) {
+    PARSE_ERROR(context, "The rotation angular velocity ("
+                             << angular_velocity_
+                             << ") must be between -1.0 and 1.0");
+  }
+  if ((tilt_angle < 0.0) or (tilt_angle > M_PI)) {
+    PARSE_ERROR(context, "The rotator tilt angle ("
+                             << tilt_angle_ << ") must be between 0 and Pi");
+  }
+}
+
+RotatingDipole::RotatingDipole(CkMigrateMessage* msg) : InitialData(msg) {}
+
+std::unique_ptr<evolution::initial_data::InitialData>
+RotatingDipole::get_clone() const {
+  return std::make_unique<RotatingDipole>(*this);
+}
+
+void RotatingDipole::pup(PUP::er& p) {
+  InitialData::pup(p);
+  p | vector_potential_amplitude_;
+  p | varpi0_;
+  p | delta_;
+  p | angular_velocity_;
+  p | tilt_angle_;
+  p | background_spacetime_;
+}
+
+PUP::able::PUP_ID RotatingDipole::my_PUP_ID = 0;
+
+tuples::TaggedTuple<Tags::TildeE> RotatingDipole::variables(
+    const tnsr::I<DataVector, 3>& coords, tmpl::list<Tags::TildeE> /*meta*/) {
+  return {make_with_value<tnsr::I<DataVector, 3>>(coords, 0.0)};
+}
+
+tuples::TaggedTuple<Tags::TildeB> RotatingDipole::variables(
+    const tnsr::I<DataVector, 3>& coords,
+    tmpl::list<Tags::TildeB> /*meta*/) const {
+  auto result = make_with_value<tnsr::I<DataVector, 3>>(coords, 0.0);
+
+  const double sin_alpha = sin(tilt_angle_);
+  const double cos_alpha = cos(tilt_angle_);
+
+  // Coordinates and magnetic fields in the tilted axis
+  const auto& x = get<0>(coords);
+  const auto& y = get<1>(coords);
+  const auto& z = get<2>(coords);
+  const DataVector x_prime = cos_alpha * x - sin_alpha * z;
+  const DataVector z_prime = sin_alpha * x + cos_alpha * z;
+
+  auto tilde_b_prime = make_with_value<tnsr::I<DataVector, 3>>(coords, 0.0);
+
+  // Regularized dipole field
+  const DataVector r_squared = get(dot_product(coords, coords));
+  const DataVector one_over_radius_factor =
+      1.0 / pow<5>(sqrt(r_squared + square(delta_)));
+  get<0>(tilde_b_prime) = 3.0 * x_prime * z_prime * one_over_radius_factor;
+  get<1>(tilde_b_prime) = 3.0 * y * z_prime * one_over_radius_factor;
+  get<2>(tilde_b_prime) =
+      (3.0 * square(z_prime) - r_squared + 2.0 * square(delta_)) *
+      one_over_radius_factor;
+
+  // Rotation
+  get<0>(result) =
+      cos_alpha * get<0>(tilde_b_prime) + sin_alpha * get<2>(tilde_b_prime);
+  get<1>(result) = get<1>(tilde_b_prime);
+  get<2>(result) =
+      -sin_alpha * get<0>(tilde_b_prime) + cos_alpha * get<2>(tilde_b_prime);
+
+  return result;
+}
+
+tuples::TaggedTuple<Tags::TildePsi> RotatingDipole::variables(
+    const tnsr::I<DataVector, 3>& coords, tmpl::list<Tags::TildePsi> /*meta*/) {
+  return {make_with_value<Scalar<DataVector>>(coords, 0.0)};
+}
+
+tuples::TaggedTuple<Tags::TildePhi> RotatingDipole::variables(
+    const tnsr::I<DataVector, 3>& coords, tmpl::list<Tags::TildePhi> /*meta*/) {
+  return {make_with_value<Scalar<DataVector>>(coords, 0.0)};
+}
+
+tuples::TaggedTuple<Tags::TildeQ> RotatingDipole::variables(
+    const tnsr::I<DataVector, 3>& coords, tmpl::list<Tags::TildeQ> /*meta*/) {
+  return {make_with_value<Scalar<DataVector>>(coords, 0.0)};
+}
+
+std::optional<Scalar<DataVector>> RotatingDipole::interior_mask(
+    const tnsr::I<DataVector, 3>& x) {
+  std::optional<Scalar<DataVector>> result{};
+
+  DataVector r_squared = get(dot_product(x, x));
+
+  // NS radius rescaled to 1.0 on grid.
+  const double ns_radius_squared = square(1.0);
+
+  if (min(r_squared) < ns_radius_squared) {
+    // Allocate the mask vector
+    const size_t num_grid_points = get<0>(x).size();
+    result = Scalar<DataVector>{num_grid_points};
+
+    for (size_t i = 0; i < num_grid_points; ++i) {
+      if (r_squared[i] < ns_radius_squared) {
+        // Interior
+        get(result.value())[i] = -1.0;
+      } else {
+        // Exterior
+        get(result.value())[i] = +1.0;
+      }
+    }
+  }
+
+  return result;
+}
+
+bool operator==(const RotatingDipole& lhs, const RotatingDipole& rhs) {
+  return lhs.vector_potential_amplitude_ == rhs.vector_potential_amplitude_ and
+         lhs.varpi0_ == rhs.varpi0_ and lhs.delta_ == rhs.delta_ and
+         lhs.angular_velocity_ == rhs.angular_velocity_ and
+         lhs.tilt_angle_ == rhs.tilt_angle_ and
+         lhs.background_spacetime_ == rhs.background_spacetime_;
+}
+
+bool operator!=(const RotatingDipole& lhs, const RotatingDipole& rhs) {
+  return not(lhs == rhs);
+}
+
+}  // namespace ForceFree::AnalyticData

--- a/src/PointwiseFunctions/AnalyticData/ForceFree/RotatingDipole.hpp
+++ b/src/PointwiseFunctions/AnalyticData/ForceFree/RotatingDipole.hpp
@@ -1,0 +1,211 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <limits>
+#include <memory>
+#include <pup.h>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Evolution/Systems/ForceFree/Tags.hpp"
+#include "Options/Options.hpp"
+#include "PointwiseFunctions/AnalyticData/AnalyticData.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Minkowski.hpp"
+#include "PointwiseFunctions/InitialDataUtilities/InitialData.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+class DataVector;
+namespace PUP {
+class er;
+}  // namespace PUP
+/// \endcond
+
+namespace ForceFree::AnalyticData {
+
+/*!
+ * \brief The magnetosphere of an isolated rotating star with dipolar initial
+ * magnetic field in the flat spacetime. This is a toy model of a pulsar
+ * magnetosphere.
+ *
+ * \note Coordinate radius of the star is rescaled to 1.0 in code units.
+ *
+ * The vector potential of the initial magnetic field has the form
+ * \cite Most2022
+ *
+ * \begin{equation}
+ *  A_\phi = \frac{A_0 \varpi_0 (x^2+y^2)}{(r^2 + \delta^2)^{3/2}}
+ * \end{equation}
+ *
+ * where $A_0$ is the vector potential amplitude, $\varpi_0$ is a constant with
+ * the unit of length, $r^2 = x^2 + y^2 + z^2$, and $\delta$ is a small number
+ * for regularization of the dipole magnetic field at the origin ($r=0$).
+ *
+ * In the Cartesian coordinates, components of densitized magnetic fields are
+ * given as
+ *
+ * \begin{align}
+ *  \tilde{B}^x & = A_0 \varpi_0 \frac{3xz}{(r^2 + \delta^2)^{5/2}} , \\
+ *  \tilde{B}^y & = A_0 \varpi_0 \frac{3yz}{(r^2 + \delta^2)^{5/2}} , \\
+ *  \tilde{B}^z & = A_0 \varpi_0 \frac{3z^2 - r^2 + 2\delta^2}{(r^2 +
+ *                    \delta^2)^{5/2}} .
+ * \end{align}
+ *
+ * Rotation of the star is switched on at $t=0$ with the angular velocity
+ * specified in the input file. The grid points inside the star ($x^2 + y^2 +
+ * z^2 < 1.0$) are identified as the interior and masked by `interior_mask()`
+ * member function. In the masked region we impose the MHD condition
+ * $\mathbf{E} + \mathbf{v} \times \mathbf{B} = 0$, where the velocity field is
+ * given by $\mathbf{v} \equiv \Omega \hat{z} \times \mathbf{r}$. By this means,
+ * initial dipolar magnetic field is effectively "anchored" inside the star
+ * while electromagnetic fields are evolved self-consistently outside the star.
+ *
+ * \note We impose the MHD condition stated above and $q=0$ inside the masked
+ * interior region during the evolution phase. While this initial data class
+ * sets both electric field and charge density to zero at $t=0$, those variables
+ * are immediately overwritten with proper values ($\mathbf{E} =
+ * -\mathbf{v}\times\mathbf{B}$, $q=0$) once the simulation begins.
+ *
+ * When the system reaches a stationary state, magnetic field lines far from the
+ * star are opening up while the field lines close to the star are corotating.
+ * The light cylinder and the Y-point, which marks the boundary between these
+ * two regions with different magnetic field topology, are expected to be formed
+ * at $r_\text{LC} = c/\Omega$.
+ *
+ * The option `TiltAngle` controls the angle $\alpha$ between the rotation axis
+ * ($z$) and the magnetic axis of initial magnetic field on the $x-z$ plane. An
+ * aligned rotator ($\alpha = 0$) is a common test problem for FFE codes,
+ * whereas an oblique rotator ($\alpha \neq 0$) is a more realistic model of
+ * pulsars \cite Spitkovsky2006.
+ *
+ */
+class RotatingDipole : public evolution::initial_data::InitialData,
+                       public MarkAsAnalyticData {
+ public:
+  struct VectorPotentialAmplitude {
+    using type = double;
+    static constexpr Options::String help = {
+        "The vector potential amplitude A_0"};
+  };
+
+  struct Varpi0 {
+    using type = double;
+    static constexpr Options::String help = {"The length constant varpi_0"};
+    static type lower_bound() { return 0.0; }
+  };
+
+  struct Delta {
+    using type = double;
+    static constexpr Options::String help = {
+        "A small value used to regularize magnetic fields at r=0."};
+    static type lower_bound() { return 0.0; }
+  };
+
+  struct AngularVelocity {
+    using type = double;
+    static constexpr Options::String help = {
+        "Rotation angular velocity of the star."};
+    static type upper_bound() { return 1.0; }
+    static type lower_bound() { return -1.0; }
+  };
+
+  struct TiltAngle {
+    using type = double;
+    static constexpr Options::String help = {
+        "Angle between the rotation axis (z) and magnetic axis at t = 0."};
+    static type upper_bound() { return M_PI; }
+    static type lower_bound() { return 0.0; }
+  };
+
+  using options = tmpl::list<VectorPotentialAmplitude, Varpi0, Delta,
+                             AngularVelocity, TiltAngle>;
+  static constexpr Options::String help{
+      "Magnetosphere of an isolated rotating star with dipole magnetic field."};
+
+  RotatingDipole() = default;
+  RotatingDipole(const RotatingDipole&) = default;
+  RotatingDipole& operator=(const RotatingDipole&) = default;
+  RotatingDipole(RotatingDipole&&) = default;
+  RotatingDipole& operator=(RotatingDipole&&) = default;
+  ~RotatingDipole() override = default;
+
+  RotatingDipole(double vector_potential_amplitude, double varpi0, double delta,
+                 double angular_velocity, double tilt_angle,
+                 const Options::Context& context = {});
+
+  auto get_clone() const
+      -> std::unique_ptr<evolution::initial_data::InitialData> override;
+
+  /// \cond
+  explicit RotatingDipole(CkMigrateMessage* msg);
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(RotatingDipole);
+  /// \endcond
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& p) override;
+
+  /// @{
+  /// Retrieve the EM variables.
+  static auto variables(const tnsr::I<DataVector, 3>& coords,
+                        tmpl::list<Tags::TildeE> /*meta*/)
+      -> tuples::TaggedTuple<Tags::TildeE>;
+
+  auto variables(const tnsr::I<DataVector, 3>& coords,
+                 tmpl::list<Tags::TildeB> /*meta*/) const
+      -> tuples::TaggedTuple<Tags::TildeB>;
+
+  static auto variables(const tnsr::I<DataVector, 3>& coords,
+                        tmpl::list<Tags::TildePsi> /*meta*/)
+      -> tuples::TaggedTuple<Tags::TildePsi>;
+
+  static auto variables(const tnsr::I<DataVector, 3>& coords,
+                        tmpl::list<Tags::TildePhi> /*meta*/)
+      -> tuples::TaggedTuple<Tags::TildePhi>;
+
+  static auto variables(const tnsr::I<DataVector, 3>& coords,
+                        tmpl::list<Tags::TildeQ> /*meta*/)
+      -> tuples::TaggedTuple<Tags::TildeQ>;
+  /// @}
+
+  /// Retrieve a collection of EM variables at position x
+  template <typename... Tags>
+  tuples::TaggedTuple<Tags...> variables(const tnsr::I<DataVector, 3>& x,
+                                         tmpl::list<Tags...> /*meta*/) const {
+    static_assert(sizeof...(Tags) > 1,
+                  "The generic template will recurse infinitely if only one "
+                  "tag is being retrieved.");
+    return {get<Tags>(variables(x, tmpl::list<Tags>{}))...};
+  }
+
+  /// Retrieve the metric variables
+  template <typename Tag>
+  tuples::TaggedTuple<Tag> variables(const tnsr::I<DataVector, 3>& x,
+                                     tmpl::list<Tag> /*meta*/) const {
+    constexpr double dummy_time = 0.0;
+    return background_spacetime_.variables(x, dummy_time, tmpl::list<Tag>{});
+  }
+
+  // Returns the value of NS interior mask
+  static std::optional<Scalar<DataVector>> interior_mask(
+      const tnsr::I<DataVector, 3, Frame::Inertial>& x);
+
+  // Returns the value of angular velocity.
+  double angular_velocity() const { return angular_velocity_; };
+
+ private:
+  double vector_potential_amplitude_ =
+      std::numeric_limits<double>::signaling_NaN();
+  double varpi0_ = std::numeric_limits<double>::signaling_NaN();
+  double delta_ = std::numeric_limits<double>::signaling_NaN();
+  double angular_velocity_ = std::numeric_limits<double>::signaling_NaN();
+  double tilt_angle_ = std::numeric_limits<double>::signaling_NaN();
+  gr::Solutions::Minkowski<3> background_spacetime_{};
+
+  friend bool operator==(const RotatingDipole& lhs, const RotatingDipole& rhs);
+};
+
+bool operator!=(const RotatingDipole& lhs, const RotatingDipole& rhs);
+
+}  // namespace ForceFree::AnalyticData

--- a/tests/Unit/PointwiseFunctions/AnalyticData/ForceFree/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/ForceFree/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY "Test_ForceFreeAnalyticData")
 
 set(LIBRARY_SOURCES
   Test_FfeBreakdown.cpp
+  Test_RotatingDipole.cpp
   )
 
 add_test_library(${LIBRARY} "${LIBRARY_SOURCES}")

--- a/tests/Unit/PointwiseFunctions/AnalyticData/ForceFree/RotatingDipole.py
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/ForceFree/RotatingDipole.py
@@ -1,0 +1,88 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+from scipy.spatial.transform import Rotation
+
+A0 = 1.1
+varpi0 = 0.3
+delta = 0.07
+Omega = 0.123
+alpha = 0.456
+
+
+def TildeE(
+    x,
+    vector_potential_amplitude,
+    varpi0,
+    delta,
+    angular_velocity,
+    tilt_angle,
+):
+    return x * 0.0
+
+
+def TildeB(
+    x,
+    vector_potential_amplitude,
+    varpi0,
+    delta,
+    angular_velocity,
+    tilt_angle,
+):
+    tilde_b = x * 0.0
+
+    r = np.sqrt(np.einsum("a, a", x, x))
+
+    tilt = Rotation.from_rotvec(alpha * np.array([0, 1, 0]))
+    x_prime = tilt.inv().apply(x)
+    xp, yp, zp = x_prime
+
+    tilde_b[0] = 3.0 * xp * zp
+    tilde_b[1] = 3.0 * yp * zp
+    tilde_b[2] = 3.0 * zp**2 - r**2 + 2.0 * delta**2
+    tilde_b = tilde_b / (r**2 + delta**2) ** (5 / 2)
+
+    return tilt.apply(tilde_b)
+
+
+def TildePsi(
+    x,
+    vector_potential_amplitude,
+    varpi0,
+    delta,
+    angular_velocity,
+    tilt_angle,
+):
+    return 0.0
+
+
+def TildePhi(
+    x,
+    vector_potential_amplitude,
+    varpi0,
+    delta,
+    angular_velocity,
+    tilt_angle,
+):
+    return 0.0
+
+
+def TildeQ(
+    x,
+    vector_potential_amplitude,
+    varpi0,
+    delta,
+    angular_velocity,
+    tilt_angle,
+):
+    return 0.0
+
+
+def InteriorMask(x):
+    r_squared = np.einsum("a, a", x, x)
+
+    if r_squared < 1.0:
+        return -1.0
+    else:
+        return 1.0

--- a/tests/Unit/PointwiseFunctions/AnalyticData/ForceFree/Test_RotatingDipole.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/ForceFree/Test_RotatingDipole.cpp
@@ -1,0 +1,127 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <memory>
+#include <random>
+#include <utility>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Evolution/Systems/ForceFree/Tags.hpp"
+#include "Framework/CheckWithRandomValues.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "PointwiseFunctions/AnalyticData/ForceFree/RotatingDipole.hpp"
+#include "PointwiseFunctions/InitialDataUtilities/InitialData.hpp"
+#include "Utilities/Serialization/RegisterDerivedClassesWithCharm.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace {
+
+using InitialData = evolution::initial_data::InitialData;
+using RotatingDipole = ForceFree::AnalyticData::RotatingDipole;
+
+struct RotatingDipoleProxy : RotatingDipole {
+  using RotatingDipole::RotatingDipole;
+  using variables_tags =
+      tmpl::list<ForceFree::Tags::TildeE, ForceFree::Tags::TildeB,
+                 ForceFree::Tags::TildePsi, ForceFree::Tags::TildePhi,
+                 ForceFree::Tags::TildeQ>;
+
+  tuples::tagged_tuple_from_typelist<variables_tags> return_variables(
+      const tnsr::I<DataVector, 3>& x) const {
+    return this->variables(x, variables_tags{});
+  }
+};
+
+SPECTRE_TEST_CASE(
+    "Unit.PointwiseFunctions.AnalyticData.ForceFree.RotatingDipole",
+    "[Unit][PointwiseFunctions]") {
+  // test creation
+  const auto solution = TestHelpers::test_creation<RotatingDipole>(
+      "VectorPotentialAmplitude: 1.0\n"
+      "Varpi0 : 0.5\n"
+      "Delta : 0.1\n"
+      "AngularVelocity : 0.3\n"
+      "TiltAngle : 0.0");
+  CHECK(solution == RotatingDipole(1.0, 0.5, 0.1, 0.3, 0.0));
+  CHECK(solution != RotatingDipole(2.0, 0.5, 0.1, 0.3, 0.0));
+  CHECK(solution != RotatingDipole(1.0, 1.0, 0.1, 0.3, 0.0));
+  CHECK(solution != RotatingDipole(1.0, 0.5, 1.0, 0.3, 0.0));
+  CHECK(solution != RotatingDipole(1.0, 0.5, 0.1, 0.5, 0.0));
+  CHECK(solution != RotatingDipole(1.0, 0.5, 0.1, 0.3, 1.0));
+
+  CHECK_THROWS_WITH(
+      []() { const RotatingDipole soln(1.0, -0.5, 0.1, 0.3, 0.0); }(),
+      Catch::Matchers::ContainsSubstring("The length constant varpi0"));
+
+  CHECK_THROWS_WITH(
+      []() { const RotatingDipole soln(1.0, 0.5, -0.1, 0.3, 0.0); }(),
+      Catch::Matchers::ContainsSubstring("The small number delta"));
+
+  CHECK_THROWS_WITH(
+      []() { const RotatingDipole soln(1.0, 0.5, 0.1, 2.0, 0.0); }(),
+      Catch::Matchers::ContainsSubstring("must be between -1.0 and 1.0"));
+
+  CHECK_THROWS_WITH(
+      []() { const RotatingDipole soln(1.0, 0.5, 0.1, 0.3, 7.0); }(),
+      Catch::Matchers::ContainsSubstring("must be between 0 and Pi"));
+
+  // test serialize
+  test_serialization(solution);
+
+  // test move
+  test_move_semantics(RotatingDipole{1.0, 0.5, 0.1, 0.3, 0.0},
+                      RotatingDipole{1.0, 0.5, 0.1, 0.3, 0.0});
+
+  // test derived
+  register_classes_with_charm<RotatingDipole>();
+  const std::unique_ptr<InitialData> base_ptr =
+      std::make_unique<RotatingDipole>(1.0, 0.5, 0.1, 0.3, 0.0);
+  const std::unique_ptr<InitialData> deserialized_base_ptr =
+      serialize_and_deserialize(base_ptr)->get_clone();
+  CHECK(dynamic_cast<const RotatingDipole&>(*deserialized_base_ptr.get()) ==
+        dynamic_cast<const RotatingDipole&>(*base_ptr.get()));
+
+  // test solution
+  const DataVector used_for_size{10};
+
+  const double vector_potential_amplitude = 1.1;
+  const double varpi0 = 0.3;
+  const double delta = 0.07;
+  const double angular_velocity = 0.123;
+  const double tilt_angle = 0.456;
+  const auto member_variables = std::make_tuple(
+      vector_potential_amplitude, varpi0, delta, angular_velocity, tilt_angle);
+
+  RotatingDipoleProxy rotating_dipole(vector_potential_amplitude, varpi0, delta,
+                                      angular_velocity, tilt_angle);
+
+  pypp::SetupLocalPythonEnvironment local_python_env{
+      "PointwiseFunctions/AnalyticData/ForceFree"};
+
+  // Check for the EM variables
+  pypp::check_with_random_values<1>(
+      &RotatingDipoleProxy::return_variables, rotating_dipole, "RotatingDipole",
+      {"TildeE", "TildeB", "TildePsi", "TildePhi", "TildeQ"}, {{{-10.0, 10.0}}},
+      member_variables, used_for_size);
+
+  // Check the member function `angular_velocity()`
+  CHECK(solution.angular_velocity() == 0.3);
+
+  // Check the member function `interior_mask()`
+  MAKE_GENERATOR(gen);
+  std::uniform_real_distribution<> dist(-1.0, 1.0);
+  const auto random_coords =
+      make_with_random_values<tnsr::I<DataVector, 3, Frame::Inertial>>(
+          make_not_null(&gen), dist, used_for_size);
+  const Scalar<DataVector> mask_from_python{pypp::call<Scalar<DataVector>>(
+      "RotatingDipole", "InteriorMask", random_coords)};
+  CHECK(solution.interior_mask(random_coords) == mask_from_python);
+}
+}  // namespace


### PR DESCRIPTION
A rotating star with an initial dipole magnetic field. This is a toy model of a pulsar magnetosphere.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
