### PR TITLE
Add ScalarTensor stress energy test to cmake list

### DIFF
--- a/tests/Unit/Evolution/Systems/ScalarTensor/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/ScalarTensor/CMakeLists.txt
@@ -6,6 +6,7 @@ set(LIBRARY "Test_ScalarTensor")
 set(LIBRARY_SOURCES
   Test_Characteristics.cpp
   Test_Sources.cpp
+  Test_StressEnergy.cpp
   Test_Tags.cpp
   )
 

--- a/tests/Unit/Evolution/Systems/ScalarTensor/Test_StressEnergy.cpp
+++ b/tests/Unit/Evolution/Systems/ScalarTensor/Test_StressEnergy.cpp
@@ -14,7 +14,8 @@
 #include "Helpers/Domain/DomainTestHelpers.hpp"
 #include "Helpers/PointwiseFunctions/GeneralRelativity/TestHelpers.hpp"
 
-SPECTRE_TEST_CASE("Unit.ScalarTensor.StressEnergy", "[Unit][ScalarTensor]") {
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.ScalarTensor.StressEnergy",
+                  "[Unit][Evolution]") {
   pypp::SetupLocalPythonEnvironment local_python_env{
       "Evolution/Systems/ScalarTensor"};
 


### PR DESCRIPTION
## Proposed changes

There was a missing .cpp file in the tests for ScalarTensor. I also changed the name of the test to match the other tests.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
