### PR TITLE
Add a mutator initializing ForceFree::Tags::NsInteriorMask

### DIFF
--- a/src/Evolution/Executables/ForceFree/EvolveForceFree.hpp
+++ b/src/Evolution/Executables/ForceFree/EvolveForceFree.hpp
@@ -40,6 +40,7 @@
 #include "Evolution/Systems/ForceFree/BoundaryCorrections/RegisterDerived.hpp"
 #include "Evolution/Systems/ForceFree/ElectricCurrentDensity.hpp"
 #include "Evolution/Systems/ForceFree/ElectromagneticVariables.hpp"
+#include "Evolution/Systems/ForceFree/MaskNeutronStarInterior.hpp"
 #include "Evolution/Systems/ForceFree/System.hpp"
 #include "Evolution/Systems/ForceFree/Tags.hpp"
 #include "IO/Observer/Actions/RegisterEvents.hpp"
@@ -217,6 +218,9 @@ struct EvolutionMetavars {
       Initialization::Actions::ConservativeSystem<system>,
       evolution::Initialization::Actions::SetVariables<
           domain::Tags::Coordinates<3, Frame::ElementLogical>>,
+
+      Initialization::Actions::AddSimpleTags<
+          ForceFree::MaskNeutronStarInterior<EvolutionMetavars, false>>,
 
       Initialization::Actions::AddComputeTags<
           tmpl::list<ForceFree::Tags::ComputeTildeJ>>,

--- a/src/Evolution/Systems/ForceFree/CMakeLists.txt
+++ b/src/Evolution/Systems/ForceFree/CMakeLists.txt
@@ -25,6 +25,7 @@ spectre_target_headers(
   ElectricCurrentDensity.hpp
   ElectromagneticVariables.hpp
   Fluxes.hpp
+  MaskNeutronStarInterior.hpp
   Sources.hpp
   System.hpp
   Tags.hpp

--- a/src/Evolution/Systems/ForceFree/MaskNeutronStarInterior.hpp
+++ b/src/Evolution/Systems/ForceFree/MaskNeutronStarInterior.hpp
@@ -1,0 +1,77 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <optional>
+#include <type_traits>
+
+#include "DataStructures/DataBox/Protocols/Mutator.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/Tags.hpp"
+#include "Evolution/DgSubcell/Tags/Coordinates.hpp"
+#include "Evolution/DgSubcell/Tags/Inactive.hpp"
+#include "Evolution/Systems/ForceFree/Tags.hpp"
+#include "PointwiseFunctions/InitialDataUtilities/InitialData.hpp"
+#include "PointwiseFunctions/InitialDataUtilities/Tags/InitialData.hpp"
+#include "Utilities/CallWithDynamicType.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TypeTraits/CreateIsCallable.hpp"
+
+namespace ForceFree {
+namespace detail {
+CREATE_IS_CALLABLE(interior_mask)
+CREATE_IS_CALLABLE_V(interior_mask)
+CREATE_IS_CALLABLE_R_V(interior_mask)
+}  // namespace detail
+
+/*!
+ * \brief Assign the masking scalar variable (see Tags::NsInteriorMask) at the
+ * initialization phase in NS magnetosphere simulations.
+ *
+ * Run the `interior_mask()` member function of the initial data if it is
+ * callable.
+ */
+template <typename Metavariables, bool UsedForFdGrid>
+struct MaskNeutronStarInterior : tt::ConformsTo<db::protocols::Mutator> {
+  using argument_tags = tmpl::list<
+      tmpl::conditional_t<
+          UsedForFdGrid,
+          evolution::dg::subcell::Tags::Coordinates<3, Frame::Inertial>,
+          domain::Tags::Coordinates<3, Frame::Inertial>>,
+      evolution::initial_data::Tags::InitialData>;
+
+  using return_tags = tmpl::list<tmpl::conditional_t<
+      UsedForFdGrid,
+      evolution::dg::subcell::Tags::Inactive<Tags::NsInteriorMask>,
+      Tags::NsInteriorMask>>;
+
+  static void apply(
+      const gsl::not_null<std::optional<Scalar<DataVector>>*>
+          neutron_star_interior_mask,
+      const tnsr::I<DataVector, 3, Frame::Inertial>& inertial_coords,
+      const evolution::initial_data::InitialData& solution_or_data) {
+    using all_data_and_solutions =
+        tmpl::at<typename Metavariables::factory_creation::factory_classes,
+                 evolution::initial_data::InitialData>;
+
+    call_with_dynamic_type<void, all_data_and_solutions>(
+        &solution_or_data, [&neutron_star_interior_mask,
+                            &inertial_coords](const auto* initial_data_ptr) {
+          using InitialData = std::decay_t<decltype(*initial_data_ptr)>;
+
+          if constexpr (detail::is_interior_mask_callable_r_v<
+                            std::optional<Scalar<DataVector>>, InitialData,
+                            tnsr::I<DataVector, 3, Frame::Inertial>>) {
+            (*neutron_star_interior_mask) =
+                (*initial_data_ptr).interior_mask(inertial_coords);
+          }
+        });
+  }
+};
+
+}  // namespace ForceFree

--- a/tests/Unit/Evolution/Systems/ForceFree/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/ForceFree/CMakeLists.txt
@@ -19,6 +19,7 @@ set(LIBRARY_SOURCES
   Test_ElectricCurrentDensity.cpp
   Test_ElectromagneticVariables.cpp
   Test_Fluxes.cpp
+  Test_MaskNeutronStarInterior.cpp
   Test_Sources.cpp
   Test_Tags.cpp
   Test_TimeDerivativeTerms.cpp

--- a/tests/Unit/Evolution/Systems/ForceFree/TestFunctions.py
+++ b/tests/Unit/Evolution/Systems/ForceFree/TestFunctions.py
@@ -22,3 +22,16 @@ def electric_current_density_compute(tilde_j, lapse, sqrt_det_spatial_metric):
 
 
 # end functions for testing ElectromagneticVariables
+
+
+# Functions for testing MaskNeutronStarInterior
+def compute_ns_interior_mask(coords):
+    r_squared = np.einsum("a, a", coords, coords)
+
+    if r_squared < 1.0:
+        return -1.0
+    else:
+        return 1.0
+
+
+# end functions for testing MaskNeutronStarInterior

--- a/tests/Unit/Evolution/Systems/ForceFree/Test_MaskNeutronStarInterior.cpp
+++ b/tests/Unit/Evolution/Systems/ForceFree/Test_MaskNeutronStarInterior.cpp
@@ -1,0 +1,136 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <optional>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
+#include "Domain/CoordinateMaps/Identity.hpp"
+#include "Domain/ElementMap.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Domain/Tags.hpp"
+#include "Evolution/DgSubcell/Mesh.hpp"
+#include "Evolution/DgSubcell/Tags/Coordinates.hpp"
+#include "Evolution/DgSubcell/Tags/Inactive.hpp"
+#include "Evolution/Systems/ForceFree/MaskNeutronStarInterior.hpp"
+#include "Framework/Pypp.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "NumericalAlgorithms/Spectral/LogicalCoordinates.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "Options/Protocols/FactoryCreation.hpp"
+#include "PointwiseFunctions/AnalyticData/ForceFree/RotatingDipole.hpp"
+#include "PointwiseFunctions/InitialDataUtilities/InitialData.hpp"
+#include "PointwiseFunctions/InitialDataUtilities/Tags/InitialData.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace ForceFree {
+namespace {
+
+struct MetavariablesForTest {
+  using component_list = tmpl::list<>;
+  using initial_data_list = tmpl::list<ForceFree::AnalyticData::RotatingDipole>;
+
+  struct factory_creation
+      : tt::ConformsTo<Options::protocols::FactoryCreation> {
+    using factory_classes = tmpl::map<
+        tmpl::pair<evolution::initial_data::InitialData, initial_data_list>>;
+  };
+};
+
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.ForceFree.MaskNsInterior",
+                  "[Unit][Evolution]") {
+  pypp::SetupLocalPythonEnvironment local_python_env{
+      "Evolution/Systems/ForceFree"};
+
+  const size_t num_dg_pts = 5;
+
+  const Mesh<3> dg_mesh{num_dg_pts, Spectral::Basis::Legendre,
+                        Spectral::Quadrature::GaussLobatto};
+  const Mesh<3> subcell_mesh = evolution::dg::subcell::fd::mesh(dg_mesh);
+
+  const auto logical_to_grid_map = ElementMap<3, Frame::Grid>{
+      ElementId<3>{0},
+      domain::make_coordinate_map_base<Frame::BlockLogical, Frame::Grid>(
+          domain::CoordinateMaps::Identity<3>{})};
+
+  const auto grid_to_inertial_map =
+      domain::make_coordinate_map_base<Frame::Grid, Frame::Inertial>(
+          domain::CoordinateMaps::Identity<3>{});
+
+  const auto dg_logical_coords = logical_coordinates(dg_mesh);
+  const auto subcell_logical_coords = logical_coordinates(subcell_mesh);
+
+  const auto dg_inertial_coords =
+      (*grid_to_inertial_map)(logical_to_grid_map(dg_logical_coords));
+  const auto subcell_inertial_coords =
+      (*grid_to_inertial_map)(logical_to_grid_map(subcell_logical_coords));
+
+  auto box = db::create<db::AddSimpleTags<
+      domain::Tags::Coordinates<3, Frame::Inertial>,
+      evolution::dg::subcell::Tags::Coordinates<3, Frame::Inertial>,
+      Tags::NsInteriorMask,
+      evolution::dg::subcell::Tags::Inactive<Tags::NsInteriorMask>,
+      evolution::initial_data::Tags::InitialData>>(
+      dg_inertial_coords, subcell_inertial_coords,
+      std::optional<Scalar<DataVector>>{}, std::optional<Scalar<DataVector>>{},
+      AnalyticData::RotatingDipole{1.0, 0.1, 0.1, 0.1, 0.5}.get_clone());
+
+  // Apply the mutator and check the values of masking variables on both grids.
+  db::mutate_apply<MaskNeutronStarInterior<MetavariablesForTest, false>>(
+      make_not_null(&box));
+  db::mutate_apply<MaskNeutronStarInterior<MetavariablesForTest, true>>(
+      make_not_null(&box));
+
+  {
+    const auto dg_mask = get<Tags::NsInteriorMask>(box);
+    const Scalar<DataVector> dg_mask_from_python{pypp::call<Scalar<DataVector>>(
+        "TestFunctions", "compute_ns_interior_mask", dg_inertial_coords)};
+    CHECK(dg_mask == dg_mask_from_python);
+
+    const auto subcell_mask =
+        get<evolution::dg::subcell::Tags::Inactive<Tags::NsInteriorMask>>(box);
+    const Scalar<DataVector> subcell_mask_from_python{
+        pypp::call<Scalar<DataVector>>("TestFunctions",
+                                       "compute_ns_interior_mask",
+                                       subcell_inertial_coords)};
+    CHECK(subcell_mask == subcell_mask_from_python);
+  }
+
+  // Initialize the mask variables back to `null`, push the coordinates far
+  // away from the NS surface, then run the mutator again.
+  db::mutate<domain::Tags::Coordinates<3, Frame::Inertial>,
+             evolution::dg::subcell::Tags::Coordinates<3, Frame::Inertial>,
+             Tags::NsInteriorMask,
+             evolution::dg::subcell::Tags::Inactive<Tags::NsInteriorMask>>(
+      [](const auto dg_coords, const auto subcell_coords, const auto dg_mask,
+         const auto subcell_mask) {
+        for (size_t d = 0; d < 3; ++d) {
+          (*dg_coords).get(d) += 5.0;
+          (*subcell_coords).get(d) += 5.0;
+        }
+        *dg_mask = std::optional<Scalar<DataVector>>{};
+        *subcell_mask = std::optional<Scalar<DataVector>>{};
+      },
+      make_not_null(&box));
+
+  db::mutate_apply<MaskNeutronStarInterior<MetavariablesForTest, false>>(
+      make_not_null(&box));
+  db::mutate_apply<MaskNeutronStarInterior<MetavariablesForTest, true>>(
+      make_not_null(&box));
+
+  CHECK(get<Tags::NsInteriorMask>(box).has_value() == false);
+  CHECK(get<evolution::dg::subcell::Tags::Inactive<Tags::NsInteriorMask>>(box)
+            .has_value() == false);
+}
+
+}  // namespace
+}  // namespace ForceFree


### PR DESCRIPTION
## Proposed changes

This is a follow up of #5232 , a mutator assigning the `std::optional` masking tag in the initialization phase for NS magnetosphere initial data.

Apart from the last one, other commits are from : 

- [ ] #5281 

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
