### PR TITLE
Add observation of inertial center of mass for BNS

### DIFF
--- a/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
+++ b/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
@@ -446,18 +446,22 @@ struct GhValenciaDivCleanTemplateBase<
               use_control_systems,
               tmpl::list<
                   hydro::Tags::TildeDInHalfPlaneCompute<
-                      DataVector, volume_dim, ::domain::ObjectLabel::A,
+                      DataVector, volume_dim,
+                      ::hydro::HalfPlaneIntegralMask::PositiveXOnly,
                       Events::Tags::ObserverCoordinates<3, Frame::Grid>>,
                   hydro::Tags::TildeDInHalfPlaneCompute<
-                      DataVector, volume_dim, ::domain::ObjectLabel::B,
+                      DataVector, volume_dim,
+                      ::hydro::HalfPlaneIntegralMask::NegativeXOnly,
                       Events::Tags::ObserverCoordinates<3, Frame::Grid>>,
                   hydro::Tags::MassWeightedCoordsCompute<
-                      DataVector, volume_dim, ::domain::ObjectLabel::A,
+                      DataVector, volume_dim,
+                      ::hydro::HalfPlaneIntegralMask::PositiveXOnly,
                       Events::Tags::ObserverCoordinates<3, Frame::Grid>,
                       Events::Tags::ObserverCoordinates<3, Frame::Inertial>,
                       Frame::Inertial>,
                   hydro::Tags::MassWeightedCoordsCompute<
-                      DataVector, volume_dim, ::domain::ObjectLabel::B,
+                      DataVector, volume_dim,
+                      ::hydro::HalfPlaneIntegralMask::NegativeXOnly,
                       Events::Tags::ObserverCoordinates<3, Frame::Grid>,
                       Events::Tags::ObserverCoordinates<3, Frame::Inertial>,
                       Frame::Inertial>>,
@@ -469,7 +473,8 @@ struct GhValenciaDivCleanTemplateBase<
                   DataVector, volume_dim, domain_frame>,
               hydro::Tags::LowerSpatialFourVelocityCompute,
               hydro::Tags::MassWeightedCoordsCompute<
-                  DataVector, volume_dim, ::domain::ObjectLabel::None,
+                  DataVector, volume_dim,
+                  ::hydro::HalfPlaneIntegralMask::None,
                   Events::Tags::ObserverCoordinates<3, Frame::Grid>,
                   Events::Tags::ObserverCoordinates<3, Frame::Inertial>,
                   Frame::Inertial>,
@@ -512,18 +517,22 @@ struct GhValenciaDivCleanTemplateBase<
       tmpl::conditional_t<
           use_control_systems,
           tmpl::list<hydro::Tags::TildeDInHalfPlaneCompute<
-                         DataVector, volume_dim, ::domain::ObjectLabel::A,
+                         DataVector, volume_dim,
+                         ::hydro::HalfPlaneIntegralMask::PositiveXOnly,
                          Events::Tags::ObserverCoordinates<3, Frame::Grid>>,
                      hydro::Tags::TildeDInHalfPlaneCompute<
-                         DataVector, volume_dim, ::domain::ObjectLabel::B,
+                         DataVector, volume_dim,
+                         ::hydro::HalfPlaneIntegralMask::NegativeXOnly,
                          Events::Tags::ObserverCoordinates<3, Frame::Grid>>,
                      hydro::Tags::MassWeightedCoordsCompute<
-                         DataVector, volume_dim, ::domain::ObjectLabel::A,
+                         DataVector, volume_dim,
+                         ::hydro::HalfPlaneIntegralMask::PositiveXOnly,
                          Events::Tags::ObserverCoordinates<3, Frame::Grid>,
                          Events::Tags::ObserverCoordinates<3, Frame::Inertial>,
                          Frame::Inertial>,
                      hydro::Tags::MassWeightedCoordsCompute<
-                         DataVector, volume_dim, ::domain::ObjectLabel::B,
+                         DataVector, volume_dim,
+                         ::hydro::HalfPlaneIntegralMask::NegativeXOnly,
                          Events::Tags::ObserverCoordinates<3, Frame::Grid>,
                          Events::Tags::ObserverCoordinates<3, Frame::Inertial>,
                          Frame::Inertial>>,
@@ -533,7 +542,8 @@ struct GhValenciaDivCleanTemplateBase<
                  hydro::Tags::TildeDUnboundUtCriterionCompute<
                      DataVector, volume_dim, domain_frame>,
                  hydro::Tags::MassWeightedCoordsCompute<
-                     DataVector, volume_dim, ::domain::ObjectLabel::None,
+                     DataVector, volume_dim,
+                     ::hydro::HalfPlaneIntegralMask::None,
                      Events::Tags::ObserverCoordinates<3, Frame::Grid>,
                      Events::Tags::ObserverCoordinates<3, Frame::Inertial>,
                      Frame::Inertial>>>;

--- a/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
+++ b/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
@@ -442,6 +442,26 @@ struct GhValenciaDivCleanTemplateBase<
           typename system::primitive_variables_tag::tags_list,
           tmpl::conditional_t<use_numeric_initial_data, tmpl::list<>,
                               error_tags>,
+          tmpl::conditional_t<
+              use_control_systems,
+              tmpl::list<
+                  hydro::Tags::TildeDInHalfPlaneCompute<
+                      DataVector, volume_dim, ::domain::ObjectLabel::A,
+                      Events::Tags::ObserverCoordinates<3, Frame::Grid>>,
+                  hydro::Tags::TildeDInHalfPlaneCompute<
+                      DataVector, volume_dim, ::domain::ObjectLabel::B,
+                      Events::Tags::ObserverCoordinates<3, Frame::Grid>>,
+                  hydro::Tags::MassWeightedCoordsCompute<
+                      DataVector, volume_dim, ::domain::ObjectLabel::A,
+                      Events::Tags::ObserverCoordinates<3, Frame::Grid>,
+                      Events::Tags::ObserverCoordinates<3, Frame::Inertial>,
+                      Frame::Inertial>,
+                  hydro::Tags::MassWeightedCoordsCompute<
+                      DataVector, volume_dim, ::domain::ObjectLabel::B,
+                      Events::Tags::ObserverCoordinates<3, Frame::Grid>,
+                      Events::Tags::ObserverCoordinates<3, Frame::Inertial>,
+                      Frame::Inertial>>,
+              tmpl::list<>>,
           tmpl::list<
               hydro::Tags::MassWeightedInternalEnergyCompute<DataVector>,
               hydro::Tags::MassWeightedKineticEnergyCompute<DataVector>,
@@ -489,6 +509,25 @@ struct GhValenciaDivCleanTemplateBase<
                                                      Frame::Inertial>>>;
   using integrand_fields = tmpl::append<
       typename system::variables_tag::tags_list,
+      tmpl::conditional_t<
+          use_control_systems,
+          tmpl::list<hydro::Tags::TildeDInHalfPlaneCompute<
+                         DataVector, volume_dim, ::domain::ObjectLabel::A,
+                         Events::Tags::ObserverCoordinates<3, Frame::Grid>>,
+                     hydro::Tags::TildeDInHalfPlaneCompute<
+                         DataVector, volume_dim, ::domain::ObjectLabel::B,
+                         Events::Tags::ObserverCoordinates<3, Frame::Grid>>,
+                     hydro::Tags::MassWeightedCoordsCompute<
+                         DataVector, volume_dim, ::domain::ObjectLabel::A,
+                         Events::Tags::ObserverCoordinates<3, Frame::Grid>,
+                         Events::Tags::ObserverCoordinates<3, Frame::Inertial>,
+                         Frame::Inertial>,
+                     hydro::Tags::MassWeightedCoordsCompute<
+                         DataVector, volume_dim, ::domain::ObjectLabel::B,
+                         Events::Tags::ObserverCoordinates<3, Frame::Grid>,
+                         Events::Tags::ObserverCoordinates<3, Frame::Inertial>,
+                         Frame::Inertial>>,
+          tmpl::list<>>,
       tmpl::list<hydro::Tags::MassWeightedInternalEnergyCompute<DataVector>,
                  hydro::Tags::MassWeightedKineticEnergyCompute<DataVector>,
                  hydro::Tags::TildeDUnboundUtCriterionCompute<

--- a/src/PointwiseFunctions/Hydro/MassWeightedFluidItems.cpp
+++ b/src/PointwiseFunctions/Hydro/MassWeightedFluidItems.cpp
@@ -50,6 +50,24 @@ void tilde_d_unbound_ut_criterion(
   result->get() = get(tilde_d) * step_function(-1.0 - result->get());
 }
 
+template <domain::ObjectLabel Label, typename DataType, size_t Dim>
+void tilde_d_in_half_plane(
+    const gsl::not_null<Scalar<DataType>*> result,
+    const Scalar<DataType>& tilde_d,
+    const tnsr::I<DataType, Dim, Frame::Grid>& grid_coords) {
+  get(*result) = get(tilde_d);
+  switch (Label) {
+    case ::domain::ObjectLabel::A:
+      get(*result) *= step_function(get<0>(grid_coords));
+      break;
+    case ::domain::ObjectLabel::B:
+      get(*result) *= step_function(get<0>(grid_coords) * (-1.0));
+      break;
+    default:
+      break;
+  }
+}
+
 template <domain::ObjectLabel Label, typename DataType, size_t Dim, typename Fr>
 void mass_weighted_coords(
     const gsl::not_null<tnsr::I<DataType, Dim, Fr>*> result,
@@ -99,6 +117,10 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
 #define OBJECT(data) BOOST_PP_TUPLE_ELEM(1, data)
 
 #define INSTANTIATE(_, data)                                                \
+  template void tilde_d_in_half_plane<OBJECT(data)>(                        \
+      const gsl::not_null<Scalar<DataVector>*> result,                      \
+      const Scalar<DataVector>& tilde_d,                                    \
+      const tnsr::I<DataVector, DIM(data), Frame::Grid>& dg_grid_coords);   \
   template void mass_weighted_coords<OBJECT(data)>(                         \
       const gsl::not_null<tnsr::I<DataVector, DIM(data), Frame::Inertial>*> \
           result,                                                           \

--- a/src/PointwiseFunctions/Hydro/MassWeightedFluidItems.cpp
+++ b/src/PointwiseFunctions/Hydro/MassWeightedFluidItems.cpp
@@ -7,10 +7,21 @@
 #include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Utilities/ContainerHelpers.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
 
 namespace hydro {
+
+std::string name(const HalfPlaneIntegralMask mask){
+  switch(mask){
+    case HalfPlaneIntegralMask::None: return "None"; break;
+    case HalfPlaneIntegralMask::PositiveXOnly: return "PositiveXOnly"; break;
+    case HalfPlaneIntegralMask::NegativeXOnly: return "NegativeXOnly"; break;
+    default:
+      ERROR("Unknown HalfPlaneIntegralMask!");
+  }
+}
 
 template <typename DataType, size_t Dim, typename Frame>
 void u_lower_t(const gsl::not_null<Scalar<DataType>*> result,
@@ -50,17 +61,17 @@ void tilde_d_unbound_ut_criterion(
   result->get() = get(tilde_d) * step_function(-1.0 - result->get());
 }
 
-template <domain::ObjectLabel Label, typename DataType, size_t Dim>
+template <HalfPlaneIntegralMask IntegralMask, typename DataType, size_t Dim>
 void tilde_d_in_half_plane(
     const gsl::not_null<Scalar<DataType>*> result,
     const Scalar<DataType>& tilde_d,
     const tnsr::I<DataType, Dim, Frame::Grid>& grid_coords) {
   get(*result) = get(tilde_d);
-  switch (Label) {
-    case ::domain::ObjectLabel::A:
+  switch (IntegralMask) {
+    case HalfPlaneIntegralMask::PositiveXOnly:
       get(*result) *= step_function(get<0>(grid_coords));
       break;
-    case ::domain::ObjectLabel::B:
+    case HalfPlaneIntegralMask::NegativeXOnly:
       get(*result) *= step_function(get<0>(grid_coords) * (-1.0));
       break;
     default:
@@ -68,7 +79,8 @@ void tilde_d_in_half_plane(
   }
 }
 
-template <domain::ObjectLabel Label, typename DataType, size_t Dim, typename Fr>
+template <HalfPlaneIntegralMask IntegralMask, typename DataType, size_t Dim,
+          typename Fr>
 void mass_weighted_coords(
     const gsl::not_null<tnsr::I<DataType, Dim, Fr>*> result,
     const Scalar<DataType>& tilde_d,
@@ -76,11 +88,11 @@ void mass_weighted_coords(
     const tnsr::I<DataType, Dim, Fr>& compute_coords) {
   for (size_t i = 0; i < Dim; i++) {
     result->get(i) = get(tilde_d) * (compute_coords.get(i));
-    switch (Label) {
-      case ::domain::ObjectLabel::A:
+    switch (IntegralMask) {
+      case HalfPlaneIntegralMask::PositiveXOnly:
         result->get(i) *= step_function(get<0>(grid_coords));
         break;
-      case ::domain::ObjectLabel::B:
+      case HalfPlaneIntegralMask::NegativeXOnly:
         result->get(i) *= step_function(get<0>(grid_coords) * (-1.0));
         break;
       default:
@@ -114,14 +126,10 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
 #undef INSTANTIATE
 
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
-#define OBJECT(data) BOOST_PP_TUPLE_ELEM(1, data)
+#define HALFPLANE(data) BOOST_PP_TUPLE_ELEM(1, data)
 
 #define INSTANTIATE(_, data)                                                \
-  template void tilde_d_in_half_plane<OBJECT(data)>(                        \
-      const gsl::not_null<Scalar<DataVector>*> result,                      \
-      const Scalar<DataVector>& tilde_d,                                    \
-      const tnsr::I<DataVector, DIM(data), Frame::Grid>& dg_grid_coords);   \
-  template void mass_weighted_coords<OBJECT(data)>(                         \
+  template void mass_weighted_coords<HALFPLANE(data)>(                      \
       const gsl::not_null<tnsr::I<DataVector, DIM(data), Frame::Inertial>*> \
           result,                                                           \
       const Scalar<DataVector>& tilde_d,                                    \
@@ -129,8 +137,28 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
       const tnsr::I<DataVector, DIM(data), Frame::Inertial>& dg_coords);
 
 GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3),
-                        (::domain::ObjectLabel::None, ::domain::ObjectLabel::A,
-                         ::domain::ObjectLabel::B))
+                        (HalfPlaneIntegralMask::None,
+                         HalfPlaneIntegralMask::PositiveXOnly,
+                         HalfPlaneIntegralMask::NegativeXOnly))
+
+#undef DIM
+#undef OBJECT
+#undef INSTANTIATE
+
+// For tilde_d_in_half_plane, we require limiting the integrand to a half
+// plane -> Do not instantiate the function for None
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define HALFPLANE(data) BOOST_PP_TUPLE_ELEM(1, data)
+
+#define INSTANTIATE(_, data)                                                \
+  template void tilde_d_in_half_plane<HALFPLANE(data)>(                     \
+      const gsl::not_null<Scalar<DataVector>*> result,                      \
+      const Scalar<DataVector>& tilde_d,                                    \
+      const tnsr::I<DataVector, DIM(data), Frame::Grid>& dg_grid_coords);
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3),
+                        (HalfPlaneIntegralMask::PositiveXOnly,
+                         HalfPlaneIntegralMask::NegativeXOnly))
 
 #undef DIM
 #undef OBJECT

--- a/tests/Unit/PointwiseFunctions/Hydro/Test_MassWeightedFluidItems.cpp
+++ b/tests/Unit/PointwiseFunctions/Hydro/Test_MassWeightedFluidItems.cpp
@@ -8,7 +8,6 @@
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
-#include "Domain/Structure/ObjectLabel.hpp"
 #include "Framework/CheckWithRandomValues.hpp"
 #include "Framework/SetupLocalPythonEnvironment.hpp"
 #include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
@@ -32,33 +31,33 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.Hydro.MassWeightedFluidItems",
       "TestFunctions", {"tilde_d_unbound_ut_criterion"}, {{{0.0, 1.0}}},
       used_for_size);
   pypp::check_with_random_values<1>(
-      &mass_weighted_coords<::domain::ObjectLabel::None, DataVector, 1,
-                            Frame::Inertial>,
+      &mass_weighted_coords<::hydro::HalfPlaneIntegralMask::None,
+                            DataVector, 1, Frame::Inertial>,
       "TestFunctions", {"mass_weighted_coords_none"}, {{{0.0, 1.0}}},
       used_for_size);
   pypp::check_with_random_values<3>(
-      &mass_weighted_coords<::domain::ObjectLabel::None, DataVector, 3,
-                            Frame::Inertial>,
+      &mass_weighted_coords<::hydro::HalfPlaneIntegralMask::None,
+                            DataVector, 3, Frame::Inertial>,
       "TestFunctions", {"mass_weighted_coords_none"}, {{{0.0, 1.0}}},
       used_for_size);
   pypp::check_with_random_values<1>(
-      &mass_weighted_coords<::domain::ObjectLabel::A, DataVector, 1,
-                            Frame::Inertial>,
+      &mass_weighted_coords<::hydro::HalfPlaneIntegralMask::PositiveXOnly,
+                            DataVector, 1, Frame::Inertial>,
       "TestFunctions", {"mass_weighted_coords_a"}, {{{-1.0, 1.0}}},
       used_for_size);
   pypp::check_with_random_values<3>(
-      &mass_weighted_coords<::domain::ObjectLabel::A, DataVector, 3,
-                            Frame::Inertial>,
+      &mass_weighted_coords<::hydro::HalfPlaneIntegralMask::PositiveXOnly,
+                            DataVector, 3, Frame::Inertial>,
       "TestFunctions", {"mass_weighted_coords_a"}, {{{-1.0, 1.0}}},
       used_for_size);
   pypp::check_with_random_values<1>(
-      &mass_weighted_coords<::domain::ObjectLabel::B, DataVector, 1,
-                            Frame::Inertial>,
+      &mass_weighted_coords<::hydro::HalfPlaneIntegralMask::NegativeXOnly,
+                            DataVector, 1, Frame::Inertial>,
       "TestFunctions", {"mass_weighted_coords_b"}, {{{-1.0, 1.0}}},
       used_for_size);
   pypp::check_with_random_values<3>(
-      &mass_weighted_coords<::domain::ObjectLabel::B, DataVector, 3,
-                            Frame::Inertial>,
+      &mass_weighted_coords<::hydro::HalfPlaneIntegralMask::NegativeXOnly,
+                            DataVector, 3, Frame::Inertial>,
       "TestFunctions", {"mass_weighted_coords_b"}, {{{-1.0, 1.0}}},
       used_for_size);
 }


### PR DESCRIPTION
## Proposed changes

Adds to the Bns executable the calculation of the inertial center of mass. More specifically, the code will output integrals of tildeD and tildeD * x^i  with x^i in the inertial frame. The integrands are set to zero for x>0 or x<0 in the grid frame, to follow each neutron star individually.

### Upgrade instructions

None

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

This is simpler than creating a new observation event with reduction of the appropriate integrand, but does have the disadvantage of adding new quantities to the observation databox.