### PR TITLE
Drop Py3.7

### DIFF
--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -363,12 +363,6 @@ jobs:
           - compiler: gcc-10
             build_type: Debug
             TEST_TIMEOUT_FACTOR: 2
-          # Test with Python 3.7 so that we retain backwards compatibility. We
-          # keep track of Python versions on supercomputers in this issue:
-          # https://github.com/sxs-collaboration/spectre/issues/442
-          - compiler: gcc-11
-            build_type: Debug
-            PYTHON_EXECUTABLE: /usr/bin/python3.7
           # Add a test without PCH to the build matrix, which only builds core
           # libraries. Building all the tests without the PCH takes very long
           # and the most we would catch is a missing include of something that's

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,7 +53,7 @@ include(SpectreSetSiteName)
 
 # We need Python in the build system and throughout the code. Setting it up
 # early so we can rely on a consistent Python version in the build system.
-find_package(Python 3.7 REQUIRED)
+find_package(Python 3.8 REQUIRED)
 
 # Define the location of Python code in the build directory. Unit tests etc. can
 # add this location to their `PYTHONPATH`.

--- a/containers/Dockerfile.buildenv
+++ b/containers/Dockerfile.buildenv
@@ -299,16 +299,6 @@ RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - \
     && add-apt-repository 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-13 main' \
     && apt-get update -y && apt-get install -y clang-13
 
-# Python 3.7 for backwards compatibility
-COPY support/Python/requirements.txt requirements.txt
-COPY support/Python/dev_requirements.txt dev_requirements.txt
-RUN add-apt-repository ppa:deadsnakes/ppa && apt-get update -y \
-    && apt-get install -y python3.7 python3.7-dev python3.7-distutils \
-    && python3.7 -m pip --no-cache-dir install pybind11~=2.6.1 \
-    && python3.7 -m pip --no-cache-dir install \
-        -r requirements.txt -r dev_requirements.txt \
-    && rm requirements.txt dev_requirements.txt
-
 # Install OpenMPI 4.0.3
 RUN apt-get install -y openmpi-bin
 

--- a/docs/Installation/Installation.md
+++ b/docs/Installation/Installation.md
@@ -85,7 +85,7 @@ all of these dependencies.
   \cite Libxsmm
 * [yaml-cpp](https://github.com/jbeder/yaml-cpp) version 0.6.3 or later.
   Building with shared library support is also recommended. \cite Yamlcpp
-* [Python](https://www.python.org/) 3.7 or later.
+* [Python](https://www.python.org/) 3.8 or later.
 * Python dependencies listed in `support/Python/requirements.txt`.
   Install with `pip3 install -r support/Python/requirements.txt`.
   Make sure you are working in a [Python venv](https://packaging.python.org/en/latest/guides/installing-using-pip-and-virtual-environments/#creating-a-virtual-environment)

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,7 +12,7 @@ license = MIT
 [options]
 packages = find:
 install_requires = @SPECTRE_PY_DEPS_OUTPUT@
-python_requires = >=3.7
+python_requires = >=3.8
 
 [options.extras_require]
 dev = @SPECTRE_PY_DEV_DEPS_OUTPUT@

--- a/src/IO/H5/Python/IterElements.py
+++ b/src/IO/H5/Python/IterElements.py
@@ -3,6 +3,7 @@
 
 import fnmatch
 from dataclasses import dataclass
+from functools import cached_property
 from typing import Dict, Iterable, Optional, Sequence, Union
 
 import numpy as np
@@ -22,13 +23,6 @@ from spectre.Domain.CoordinateMaps import (
     CoordinateMapElementLogicalToInertial3D,
 )
 from spectre.Spectral import Mesh, logical_coordinates
-
-# functools.cached_property was added in Py 3.8. Fall back to a plain
-# `property` in Py 3.7.
-try:
-    from functools import cached_property
-except ImportError:
-    cached_property = property
 
 
 @dataclass(frozen=True)

--- a/src/Visualization/Python/TransformVolumeData.py
+++ b/src/Visualization/Python/TransformVolumeData.py
@@ -6,6 +6,7 @@ import inspect
 import logging
 import re
 from dataclasses import dataclass
+from functools import cached_property
 from pydoc import locate
 from typing import Dict, Iterable, List, Optional, Sequence, Tuple, Type, Union
 
@@ -26,13 +27,6 @@ from spectre.DataStructures.Tensor import (
 from spectre.IO.H5.IterElements import Element, iter_elements
 from spectre.NumericalAlgorithms.LinearOperators import definite_integral
 from spectre.Spectral import Mesh
-
-# functools.cached_property was added in Py 3.8. Fall back to a plain
-# `property` in Py 3.7.
-try:
-    from functools import cached_property
-except ImportError:
-    cached_property = property
 
 logger = logging.getLogger(__name__)
 

--- a/support/DevEnvironments/spack.yaml
+++ b/support/DevEnvironments/spack.yaml
@@ -58,7 +58,7 @@ spack:
   - libsharp -mpi -openmp
   - 'libxsmm@1.16.1:'
   - openblas
-  - 'python@3.7:'
+  - 'python@3.8:'
   - 'py-pybind11@2.6:'
   - yaml-cpp@0.6.3
   concretizer:

--- a/tests/Unit/Visualization/Python/Test_GenerateXdmf.py
+++ b/tests/Unit/Visualization/Python/Test_GenerateXdmf.py
@@ -58,21 +58,18 @@ class TestGenerateXdmf(unittest.TestCase):
         # bugs.
         # - Compare canonicalized XML with stripped whitespace. Pretty
         #   indentation was only added in Python 3.9.
-        # - Skip test in Python 3.7 because it doesn't preserve ordering of XML
-        #   attributes like <Tag Arg1="1" Arg2="2"> and <Tag Arg2="2" Arg1="1">.
-        if sys.version_info >= (3, 8):
-            self.assertEqual(
-                ET.canonicalize(
-                    from_file=output_filename + ".xmf", strip_text=True
-                ),
-                ET.canonicalize(
-                    from_file=os.path.join(self.data_dir, "VolTestData.xmf"),
-                    strip_text=True,
-                ).replace(
-                    "VolTestData0.h5",
-                    os.path.relpath(data_files[0], self.test_dir),
-                ),
-            )
+        self.assertEqual(
+            ET.canonicalize(
+                from_file=output_filename + ".xmf", strip_text=True
+            ),
+            ET.canonicalize(
+                from_file=os.path.join(self.data_dir, "VolTestData.xmf"),
+                strip_text=True,
+            ).replace(
+                "VolTestData0.h5",
+                os.path.relpath(data_files[0], self.test_dir),
+            ),
+        )
 
     def test_surface_generate_xdmf(self):
         data_files = [os.path.join(self.data_dir, "SurfaceTestData.h5")]


### PR DESCRIPTION
## Proposed changes

Python 3.7 reached EOL in June 2023. Kyle encountered an issue with it that's fixed in 3.8. All our clusters have 3.8.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
