### PR TITLE
Add BondiSachs to GhValencia executables

### DIFF
--- a/src/Evolution/Executables/GrMhd/GhValenciaDivClean/CMakeLists.txt
+++ b/src/Evolution/Executables/GrMhd/GhValenciaDivClean/CMakeLists.txt
@@ -22,6 +22,7 @@ function(add_ghmhd_with_horizon_executable INITIAL_DATA_NAME INITIAL_DATA LIBS_T
 endfunction(add_ghmhd_with_horizon_executable)
 
 set(LIBS_TO_LINK
+  Cce
   CoordinateMaps
   DiscontinuousGalerkin
   DomainCreators
@@ -60,13 +61,13 @@ set(LIBS_TO_LINK_WITH_CONTROL_SYSTEM
 
 add_ghmhd_executable(
   ""
-  "evolution::NumericInitialData,false"
+  "evolution::NumericInitialData,false,BondiSachs"
   "${LIBS_TO_LINK}"
   )
 
 add_ghmhd_executable(
   "Bns"
-  "evolution::NumericInitialData,true"
+  "evolution::NumericInitialData,true,BondiSachs"
   "${LIBS_TO_LINK_WITH_CONTROL_SYSTEM}"
   )
 
@@ -79,30 +80,30 @@ endif()
 
 add_ghmhd_with_horizon_executable(
   BondiHoyleAccretion
-  "gh::Solutions::WrappedGr<grmhd::AnalyticData::BondiHoyleAccretion>,false"
+  "gh::Solutions::WrappedGr<grmhd::AnalyticData::BondiHoyleAccretion>,false,BondiSachs"
   "${LIBS_TO_LINK};ApparentHorizons;ParallelInterpolation"
   )
 
 add_ghmhd_with_horizon_executable(
   MagnetizedFmDisk
-  "gh::Solutions::WrappedGr<grmhd::AnalyticData::MagnetizedFmDisk>,false"
+  "gh::Solutions::WrappedGr<grmhd::AnalyticData::MagnetizedFmDisk>,false,BondiSachs"
   "${LIBS_TO_LINK};ApparentHorizons;ParallelInterpolation"
   )
 
 add_ghmhd_with_horizon_executable(
   BondiMichel
-  "gh::Solutions::WrappedGr<grmhd::Solutions::BondiMichel>,false"
+  "gh::Solutions::WrappedGr<grmhd::Solutions::BondiMichel>,false,BondiSachs"
   "${LIBS_TO_LINK};ApparentHorizons;ParallelInterpolation"
   )
 
 add_ghmhd_with_horizon_executable(
   FishboneMoncriefDisk
-  "gh::Solutions::WrappedGr<RelativisticEuler::Solutions::FishboneMoncriefDisk>,false"
+  "gh::Solutions::WrappedGr<RelativisticEuler::Solutions::FishboneMoncriefDisk>,false,BondiSachs"
   "${LIBS_TO_LINK};ApparentHorizons;ParallelInterpolation"
   )
 
 add_ghmhd_executable(
   TovStar
-  "gh::Solutions::WrappedGr<RelativisticEuler::Solutions::TovStar>,false"
+  "gh::Solutions::WrappedGr<RelativisticEuler::Solutions::TovStar>,false,BondiSachs"
   "${LIBS_TO_LINK}"
   )

--- a/src/Evolution/Executables/GrMhd/GhValenciaDivClean/EvolveGhValenciaDivCleanFwd.hpp
+++ b/src/Evolution/Executables/GrMhd/GhValenciaDivClean/EvolveGhValenciaDivCleanFwd.hpp
@@ -43,6 +43,7 @@ class OrszagTangVortex;
 }  // namespace grmhd
 
 struct KerrHorizon;
+struct BondiSachs;
 template <typename InitialData, bool UseControlSystems,
           typename... InterpolationTargetTags>
 struct EvolutionMetavars;

--- a/src/Evolution/Executables/GrMhd/GhValenciaDivClean/EvolveGhValenciaDivCleanWithHorizon.hpp
+++ b/src/Evolution/Executables/GrMhd/GhValenciaDivClean/EvolveGhValenciaDivCleanWithHorizon.hpp
@@ -108,7 +108,7 @@ struct EvolutionMetavars : public GhValenciaDivCleanTemplateBase<
         intrp::callbacks::ObserveTimeSeriesOnSurface<tags_to_observe, AhA>>;
   };
 
-  using interpolation_target_tags = tmpl::list<AhA>;
+  using interpolation_target_tags = tmpl::list<InterpolationTargetTags..., AhA>;
   using interpolator_source_vars = tmpl::list<
       gr::Tags::SpacetimeMetric<DataVector, volume_dim, domain_frame>,
       gh::Tags::Pi<DataVector, volume_dim, domain_frame>,

--- a/src/Evolution/Executables/GrMhd/GhValenciaDivClean/EvolveGhValenciaDivCleanWithHorizonFwd.hpp
+++ b/src/Evolution/Executables/GrMhd/GhValenciaDivClean/EvolveGhValenciaDivCleanWithHorizonFwd.hpp
@@ -35,6 +35,7 @@ class MagnetizedFmDisk;
 }  // namespace grmhd
 
 struct KerrHorizon;
+struct BondiSachs;
 template <typename InitialData, bool UseControlSystems,
           typename... InterpolationTargetTags>
 struct EvolutionMetavars;

--- a/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
+++ b/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
@@ -67,6 +67,7 @@
 #include "Evolution/Initialization/NonconservativeSystem.hpp"
 #include "Evolution/Initialization/SetVariables.hpp"
 #include "Evolution/NumericInitialData.hpp"
+#include "Evolution/Systems/Cce/Callbacks/DumpBondiSachsOnWorldtube.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/AllSolutions.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Factory.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/BoundaryCorrections/Factory.hpp"
@@ -160,8 +161,10 @@
 #include "ParallelAlgorithms/Interpolation/Events/Interpolate.hpp"
 #include "ParallelAlgorithms/Interpolation/InterpolationTarget.hpp"
 #include "ParallelAlgorithms/Interpolation/Interpolator.hpp"
+#include "ParallelAlgorithms/Interpolation/Protocols/InterpolationTargetTag.hpp"
 #include "ParallelAlgorithms/Interpolation/Tags.hpp"
 #include "ParallelAlgorithms/Interpolation/Targets/KerrHorizon.hpp"
+#include "ParallelAlgorithms/Interpolation/Targets/Sphere.hpp"
 #include "PointwiseFunctions/AnalyticData/AnalyticData.hpp"
 #include "PointwiseFunctions/AnalyticData/GhGrMhd/Factory.hpp"
 #include "PointwiseFunctions/AnalyticData/GrMhd/BlastWave.hpp"
@@ -820,4 +823,19 @@ struct GhValenciaDivCleanTemplateBase<
       intrp::Interpolator<derived_metavars>,
       intrp::InterpolationTarget<derived_metavars, InterpolationTargetTags>...,
       dg_element_array_component>>;
+};
+
+struct BondiSachs : tt::ConformsTo<intrp::protocols::InterpolationTargetTag> {
+  static std::string name() { return "BondiSachsInterpolation"; }
+  using temporal_id = ::Tags::Time;
+  using vars_to_interpolate_to_target =
+      typename gh::System<3>::variables_tag::tags_list;
+  using compute_target_points =
+      intrp::TargetPoints::Sphere<BondiSachs, ::Frame::Inertial>;
+  using post_interpolation_callback =
+      intrp::callbacks::DumpBondiSachsOnWorldtube<BondiSachs>;
+  using compute_items_on_target = tmpl::list<>;
+  template <typename Metavariables>
+  using interpolating_component =
+      typename Metavariables::dg_element_array_component;
 };

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/BinaryNeutronStar.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/BinaryNeutronStar.yaml
@@ -160,6 +160,7 @@ EventsAndTriggers:
           Interval: 1
           Offset: 0
     Events:
+      - BondiSachsInterpolation
       - ObserveTimeStep:
             SubfileName: TimeSteps
             PrintTimeToTerminal: True
@@ -194,6 +195,16 @@ EventsAndTriggers:
         Value: 1.5
     Events:
       - Completion
+
+InterpolationTargets:
+  BondiSachsInterpolation:
+    LMax: 16
+    Radius: [100, 150, 200]
+    Center: [0, 0, 0]
+    AngularOrdering: Cce
+
+Cce:
+  BondiSachsOutputFilePrefix: "BondiSachs"
 
 Observers:
   VolumeFileName: "GhMhdVolume"

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdBondiMichel.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdBondiMichel.yaml
@@ -13,10 +13,7 @@ ExpectedOutput:
 
 ResourceInfo:
   AvoidGlobalProc0: false
-  Singletons:
-    AhA:
-      Proc: Auto
-      Exclusive: false
+  Singletons: Auto
 
 Evolution:
   InitialTime: 0.0
@@ -225,6 +222,16 @@ ApparentHorizons:
       DivergenceIter: 5
       MaxIts: 100
     Verbosity: Verbose
+
+InterpolationTargets:
+  BondiSachsInterpolation:
+    LMax: 16
+    Radius: [10]
+    Center: [0, 0, 0]
+    AngularOrdering: Cce
+
+Cce:
+  BondiSachsOutputFilePrefix: "BondiSachs"
 
 Observers:
   VolumeFileName: "GhMhdBondiMichelVolume"

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdTovStar.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdTovStar.yaml
@@ -13,6 +13,7 @@ ExpectedOutput:
 
 ResourceInfo:
   AvoidGlobalProc0: false
+  Singletons: Auto
 
 Evolution:
   InitialTime: 0.0
@@ -217,6 +218,16 @@ EventsAndTriggers:
           Values: [3]
     Events:
       - Completion
+
+InterpolationTargets:
+  BondiSachsInterpolation:
+    LMax: 16
+    Radius: [1]
+    Center: [0, 0, 0]
+    AngularOrdering: Cce
+
+Cce:
+  BondiSachsOutputFilePrefix: "BondiSachs"
 
 Observers:
   VolumeFileName: "GhMhdTovStarVolume"


### PR DESCRIPTION
## Proposed changes

Now all GhValenciaDivClean executables can produce waveforms if they so choose. Simply add the `BondiSachsInterpolation` event.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
All GhValenciaDivClean input files must now specify the following two blocks

```yaml
InterpolationTargets:
  BondiSachsInterpolation:
    LMax: 16
    Radius: [100, 150, 200]
    Center: [0, 0, 0]
    AngularOrdering: Cce

Cce:
  BondiSachsOutputFilePrefix: "BondiSachs"
```

Along with the `BondiSachsInterpolation` singleton in `ResourceInfo:`
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
