### PR TITLE
Make namespaces consistent for wrapped initial data lists

### DIFF
--- a/src/Evolution/Systems/GeneralizedHarmonic/AllSolutions.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/AllSolutions.hpp
@@ -23,8 +23,8 @@ using solutions_including_matter = tmpl::append<
     tmpl::conditional_t<
         Dim == 3,
         tmpl::append<gh::Solutions::RelativisticEuler::all_solutions,
-                     gh::Solutions::grmhd::all_solutions,
-                     gh::AnalyticData::grmhd::all_analytic_data,
+                     gh::grmhd::Solutions::all_solutions,
+                     gh::grmhd::AnalyticData::all_analytic_data,
                      gh::ScalarTensor::AnalyticData::all_analytic_data>,
         tmpl::list<>>>;
 }  // namespace gh

--- a/src/Evolution/Systems/GeneralizedHarmonic/AllSolutions.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/AllSolutions.hpp
@@ -22,7 +22,7 @@ using solutions_including_matter = tmpl::append<
     gh::Solutions::all_solutions<Dim>,
     tmpl::conditional_t<
         Dim == 3,
-        tmpl::append<gh::Solutions::RelativisticEuler::all_solutions,
+        tmpl::append<gh::RelativisticEuler::Solutions::all_solutions,
                      gh::grmhd::Solutions::all_solutions,
                      gh::grmhd::AnalyticData::all_analytic_data,
                      gh::ScalarTensor::AnalyticData::all_analytic_data>,

--- a/src/PointwiseFunctions/AnalyticData/GhGrMhd/Factory.hpp
+++ b/src/PointwiseFunctions/AnalyticData/GhGrMhd/Factory.hpp
@@ -9,13 +9,12 @@
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/WrappedGr.hpp"
 #include "Utilities/TMPL.hpp"
 
-namespace gh::AnalyticData {
+namespace gh::grmhd::AnalyticData {
 /// GRMHD analytic data wrapped for GH
-namespace grmhd {
+
 /// \brief List of all analytic data
 using all_analytic_data = tmpl::list<
     gh::Solutions::WrappedGr<::grmhd::AnalyticData::BondiHoyleAccretion>,
     gh::Solutions::WrappedGr<::grmhd::AnalyticData::MagnetizedFmDisk>,
     gh::Solutions::WrappedGr<::grmhd::AnalyticData::MagnetizedTovStar>>;
-}  // namespace grmhd
-}  // namespace gh::AnalyticData
+}  // namespace gh::grmhd::AnalyticData

--- a/src/PointwiseFunctions/AnalyticSolutions/GhGrMhd/Factory.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GhGrMhd/Factory.hpp
@@ -7,11 +7,11 @@
 #include "PointwiseFunctions/AnalyticSolutions/GrMhd/BondiMichel.hpp"
 #include "Utilities/TMPL.hpp"
 
-namespace gh::Solutions {
+namespace gh::grmhd::Solutions {
 /// GRMHD solutions wrapped for GH
-namespace grmhd {
+
 /// \brief List of all analytic solutions
 using all_solutions =
     tmpl::list<gh::Solutions::WrappedGr<::grmhd::Solutions::BondiMichel>>;
-}  // namespace grmhd
-}  // namespace gh::Solutions
+
+}  // namespace gh::grmhd::Solutions

--- a/src/PointwiseFunctions/AnalyticSolutions/GhRelativisticEuler/Factory.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GhRelativisticEuler/Factory.hpp
@@ -8,13 +8,13 @@
 #include "PointwiseFunctions/AnalyticSolutions/RelativisticEuler/TovStar.hpp"
 #include "Utilities/TMPL.hpp"
 
-namespace gh::Solutions {
+namespace gh::RelativisticEuler::Solutions {
 /// Relativistic hydro solutions wrapped for GH
-namespace RelativisticEuler {
+
 /// \brief List of all analytic solutions
 using all_solutions = tmpl::list<
     gh::Solutions::WrappedGr<
         ::RelativisticEuler::Solutions::FishboneMoncriefDisk>,
     gh::Solutions::WrappedGr<::RelativisticEuler::Solutions::TovStar>>;
-}  // namespace grmhd
-}  // namespace gh::Solutions
+
+}  // namespace gh::RelativisticEuler::Solutions


### PR DESCRIPTION
## Proposed changes

This issue arose in #5257. Seems like a quick fix (?).

Here I just flip the namespaces for the list containing wrapped grmhd and relativistic Euler initial data. Now all wrapped ID lists would be consistent in namespace order.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
