### PR TITLE
Use highest possible FD order when computing GH derivatives

### DIFF
--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/Derivatives.cpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/Derivatives.cpp
@@ -38,7 +38,7 @@ void spacetime_derivatives(
         maximum_number_of_neighbors(3), std::pair<Direction<3>, ElementId<3>>,
         evolution::dg::subcell::GhostData,
         boost::hash<std::pair<Direction<3>, ElementId<3>>>>& all_ghost_data,
-    const Mesh<3>& volume_mesh,
+    const size_t& deriv_order, const Mesh<3>& volume_mesh,
     const InverseJacobian<DataVector, 3, Frame::ElementLogical,
                           Frame::Inertial>&
         cell_centered_logical_to_inertial_inv_jacobian) {
@@ -92,7 +92,7 @@ void spacetime_derivatives(
 
   ::fd::partial_derivatives<gradients_tags>(
       result, volume_gh_vars, ghost_cell_vars, volume_mesh,
-      number_of_gh_components, 4,
+      number_of_gh_components, deriv_order,
       cell_centered_logical_to_inertial_inv_jacobian);
 }
 }  // namespace grmhd::GhValenciaDivClean::fd

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/Derivatives.hpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/Derivatives.hpp
@@ -35,13 +35,7 @@ namespace grmhd::GhValenciaDivClean::fd {
  * \brief Compute partial derivatives of the spacetime variables \f$g_{ab}\f$,
  * \f$\Phi_{iab}\f$, and \f$\Pi_{ab}\f$.
  *
- * The derivatives are computed using 4th-order FD. If we want the ability to
- * take higher order derivatives we can add an argument. However, we then need
- * to make sure we have enough ghost cells. 4th-order derivatives require only 2
- * ghost cells, which is also what we need for 2nd-order reconstruction.
- * 6th-order derivatives need 3 ghost cells so we would need to send more data
- * or only use higher order derivatives when higher order reconstruction is
- * used.
+ * The derivatives are computed using FD of order deriv_order
  */
 void spacetime_derivatives(
     gsl::not_null<Variables<db::wrap_tags_in<
@@ -56,7 +50,7 @@ void spacetime_derivatives(
         maximum_number_of_neighbors(3), std::pair<Direction<3>, ElementId<3>>,
         evolution::dg::subcell::GhostData,
         boost::hash<std::pair<Direction<3>, ElementId<3>>>>& all_ghost_data,
-    const Mesh<3>& volume_mesh,
+    const size_t& deriv_order, const Mesh<3>& volume_mesh,
     const InverseJacobian<DataVector, 3, Frame::ElementLogical,
                           Frame::Inertial>&
         cell_centered_logical_to_inertial_inv_jacobian);

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/TimeDerivative.hpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/TimeDerivative.hpp
@@ -546,6 +546,7 @@ struct TimeDerivative {
     // 4. Compute MHD time derivatives.
     //
     // Compute FD GH derivatives with neighbor data
+    // Use highest possible FD order for number of GZ, 2 * (ghost_zone_size)
     const auto& evolved_vars = db::get<evolved_vars_tag>(*box);
     Variables<db::wrap_tags_in<::Tags::deriv, gradients_tags, tmpl::size_t<3>,
                                Frame::Inertial>>
@@ -554,7 +555,8 @@ struct TimeDerivative {
         make_not_null(&cell_centered_gh_derivs), evolved_vars,
         db::get<evolution::dg::subcell::Tags::GhostDataForReconstruction<3>>(
             *box),
-        subcell_mesh, cell_centered_logical_to_inertial_inv_jacobian);
+        recons.ghost_zone_size()*2, subcell_mesh,
+        cell_centered_logical_to_inertial_inv_jacobian);
 
     // Now package the data and compute the correction
     //

--- a/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/Test_Derivatives.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/Test_Derivatives.cpp
@@ -34,6 +34,7 @@ SPECTRE_TEST_CASE(
     "[Unit][Evolution]") {
   const size_t points_per_dimension = 5;
   const size_t ghost_zone_size = 3;
+  const size_t fd_deriv_order = 4;
   const Mesh<3> subcell_mesh{points_per_dimension,
                              Spectral::Basis::FiniteDifference,
                              Spectral::Quadrature::CellCentered};
@@ -78,7 +79,8 @@ SPECTRE_TEST_CASE(
 
   grmhd::GhValenciaDivClean::fd::spacetime_derivatives(
       make_not_null(&deriv_of_gh_vars), volume_evolved_vars, all_ghost_data,
-      subcell_mesh, cell_centered_logical_to_inertial_inv_jacobian);
+      fd_deriv_order, subcell_mesh,
+      cell_centered_logical_to_inertial_inv_jacobian);
 
   Variables<db::wrap_tags_in<
       Tags::deriv, typename grmhd::GhValenciaDivClean::System::gradients_tags,
@@ -175,7 +177,7 @@ SPECTRE_TEST_CASE(
                number_of_independent_components};
     CHECK_THROWS_WITH(grmhd::GhValenciaDivClean::fd::spacetime_derivatives(
                           make_not_null(&deriv_of_gh_vars), volume_evolved_vars,
-                          bad_ghost_data, subcell_mesh,
+                          bad_ghost_data, fd_deriv_order, subcell_mesh,
                           cell_centered_logical_to_inertial_inv_jacobian),
                       Catch::Contains(match_string));
   }


### PR DESCRIPTION
## Proposed changes

Allow for arbitrary FD order for derivatives in GhGrmhd; choose the maximum potential order for the standard GhGrmhd code.

### Upgrade instructions

None

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

The first two set of changes in Test_TimeDerivative are just clang-format modifications.