### PR TITLE
Remove reference to duplicate CMake on CI

### DIFF
--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -396,11 +396,9 @@ jobs:
             use_xsimd: OFF
             MEMORY_ALLOCATOR: JEMALLOC
             ccache_max_size: 650M
-          # Test compatibility with oldest supported CMake version and using an
-          # mpi version of charm
+          # Test with MPI version of charm
           - compiler: clang-13
             build_type: Debug
-            CMAKE_EXECUTABLE: /opt/local/cmake/3.18.2/bin/cmake
             CHARM_ROOT: /work/charm_7_0_0/mpi-linux-x86_64-smp-clang
             # MPI running tests is a bit slower than multicore
             TEST_TIMEOUT_FACTOR: 3

--- a/containers/Dockerfile.buildenv
+++ b/containers/Dockerfile.buildenv
@@ -113,9 +113,7 @@ RUN apt-get update -y \
     && printf "if [ -f /etc/bash_completion ] && ! shopt -oq posix; then\n\
     . /etc/bash_completion\nfi\n\n" >> /root/.bashrc
 
-
-# Install cmake.  We need version 3.18.2 so that fortran builds work
-# with ninja.
+# Install minimum required CMake version so that we test compatibility with it
 RUN wget https://github.com/Kitware/CMake/releases/download/v3.18.2/cmake-3.18.2.tar.gz \
     && tar -xzf cmake-3.18.2.tar.gz \
     && cd cmake-3.18.2 \


### PR DESCRIPTION
## Proposed changes

The duplicate version was deleted in #5298. Would be good to merge this PR asap so people have a chance to rebase before the container is next pushed to Dockerhub.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
