### PR TITLE
Fix a GCC warning

### DIFF
--- a/tests/Unit/Helpers/Domain/DomainTestHelpers.cpp
+++ b/tests/Unit/Helpers/Domain/DomainTestHelpers.cpp
@@ -298,8 +298,8 @@ void check_block_face_grid_points_align(
     // block.
     // There is also a sign flip if the mapped upper direction becomes a lower
     // direction
-    if (dth_upper_direction_in_neighbor_frame.side() == Side::Lower xor
-        d == direction.dimension()) {
+    if ((dth_upper_direction_in_neighbor_frame.side() == Side::Lower) xor
+        (d == direction.dimension())) {
       xi_neighbor[dth_upper_direction_in_neighbor_frame.dimension()] *= -1.0;
     }
   }


### PR DESCRIPTION
## Proposed changes

I got this warning with a different minor version of GCC 10 and 11 than on CI.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
