### PR TITLE
Fix whitespace issues in a DataBox test

### DIFF
--- a/tests/Unit/DataStructures/DataBox/Test_DataBox.cpp
+++ b/tests/Unit/DataStructures/DataBox/Test_DataBox.cpp
@@ -4,6 +4,7 @@
 #include "Framework/TestingFramework.hpp"
 
 #include <array>
+#include <cctype>
 #include <cstddef>
 #include <functional>
 #include <memory>
@@ -2780,6 +2781,12 @@ void test_output() {
       "namespace)::test_databox_tags::Tag0, (anonymous "
       "namespace)::test_databox_tags::Tag0Reference, "
       "brigand::integral_constant<int, 1> > >;\n";
+  // Remove whitespace since it may vary between compilers
+  auto remove_whitespace = [](std::string& str) {
+    str.erase(std::remove_if(str.begin(), str.end(), ::isspace), str.end());
+  };
+  remove_whitespace(output_types);
+  remove_whitespace(expected_types);
   CHECK(output_types == expected_types);
 
   std::string output_items = box.print_items();
@@ -2814,6 +2821,8 @@ void test_output() {
   os << box;
   std::string output_stream = os.str();
   std::string expected_stream = expected_types + "\n" + expected_items+ "\n";
+  remove_whitespace(output_stream);
+  remove_whitespace(expected_stream);
   CHECK(output_stream == expected_stream);
 }
 


### PR DESCRIPTION
## Proposed changes

The whitespace can vary by compiler, so just remove the whitespace. (the test fails with AppleClang 14)

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
