### PR TITLE
Add protocols and docs for registration

### DIFF
--- a/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
+++ b/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
@@ -72,6 +72,7 @@
 #include "Parallel/PhaseControl/Factory.hpp"
 #include "Parallel/PhaseControl/VisitAndReturn.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
+#include "Parallel/Protocols/RegistrationMetavariables.hpp"
 #include "ParallelAlgorithms/Actions/AddComputeTags.hpp"
 #include "ParallelAlgorithms/Actions/InitializeItems.hpp"
 #include "ParallelAlgorithms/Actions/MutateApply.hpp"
@@ -339,11 +340,10 @@ struct EvolutionMetavars {
                          Actions::AdvanceTime,
                          PhaseControl::Actions::ExecutePhaseChange>>>>;
 
-  template <typename ParallelComponent>
-  struct registration_list {
-    using type =
-        std::conditional_t<std::is_same_v<ParallelComponent, dg_element_array>,
-                           dg_registration_list, tmpl::list<>>;
+  struct registration
+      : tt::ConformsTo<Parallel::protocols::RegistrationMetavariables> {
+    using element_registrars =
+        tmpl::map<tmpl::pair<dg_element_array, dg_registration_list>>;
   };
 
   using component_list =

--- a/src/Evolution/Executables/CurvedScalarWave/EvolveCurvedScalarWave.hpp
+++ b/src/Evolution/Executables/CurvedScalarWave/EvolveCurvedScalarWave.hpp
@@ -57,6 +57,7 @@
 #include "Parallel/PhaseControl/Factory.hpp"
 #include "Parallel/PhaseControl/VisitAndReturn.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
+#include "Parallel/Protocols/RegistrationMetavariables.hpp"
 #include "Parallel/Reduction.hpp"
 #include "ParallelAlgorithms/Actions/AddComputeTags.hpp"
 #include "ParallelAlgorithms/Actions/AddSimpleTags.hpp"
@@ -316,11 +317,10 @@ struct EvolutionMetavars {
                          Actions::AdvanceTime,
                          PhaseControl::Actions::ExecutePhaseChange>>>>;
 
-  template <typename ParallelComponent>
-  struct registration_list {
-    using type =
-        std::conditional_t<std::is_same_v<ParallelComponent, dg_element_array>,
-                           dg_registration_list, tmpl::list<>>;
+  struct registration
+      : tt::ConformsTo<Parallel::protocols::RegistrationMetavariables> {
+    using element_registrars =
+        tmpl::map<tmpl::pair<dg_element_array, dg_registration_list>>;
   };
 
   using component_list = tmpl::flatten<

--- a/src/Evolution/Executables/CurvedScalarWave/EvolveWorldtubeCurvedScalarWave.hpp
+++ b/src/Evolution/Executables/CurvedScalarWave/EvolveWorldtubeCurvedScalarWave.hpp
@@ -60,6 +60,7 @@
 #include "Parallel/PhaseControl/ExecutePhaseChange.hpp"
 #include "Parallel/PhaseControl/VisitAndReturn.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
+#include "Parallel/Protocols/RegistrationMetavariables.hpp"
 #include "Parallel/Reduction.hpp"
 #include "ParallelAlgorithms/Actions/AddComputeTags.hpp"
 #include "ParallelAlgorithms/Actions/AddSimpleTags.hpp"
@@ -325,11 +326,10 @@ struct EvolutionMetavars {
                          Actions::AdvanceTime,
                          PhaseControl::Actions::ExecutePhaseChange>>>>;
 
-  template <typename ParallelComponent>
-  struct registration_list {
-    using type =
-        std::conditional_t<std::is_same_v<ParallelComponent, dg_element_array>,
-                           dg_registration_list, tmpl::list<>>;
+  struct registration
+      : tt::ConformsTo<Parallel::protocols::RegistrationMetavariables> {
+    using element_registrars =
+        tmpl::map<tmpl::pair<dg_element_array, dg_registration_list>>;
   };
 
   using component_list = tmpl::flatten<tmpl::list<

--- a/src/Evolution/Executables/ForceFree/EvolveForceFree.hpp
+++ b/src/Evolution/Executables/ForceFree/EvolveForceFree.hpp
@@ -56,6 +56,7 @@
 #include "Parallel/PhaseControl/PhaseChange.hpp"
 #include "Parallel/PhaseControl/VisitAndReturn.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
+#include "Parallel/Protocols/RegistrationMetavariables.hpp"
 #include "ParallelAlgorithms/Actions/AddComputeTags.hpp"
 #include "ParallelAlgorithms/Actions/AddSimpleTags.hpp"
 #include "ParallelAlgorithms/Actions/InitializeItems.hpp"
@@ -249,11 +250,10 @@ struct EvolutionMetavars {
                          Actions::AdvanceTime,
                          PhaseControl::Actions::ExecutePhaseChange>>>>;
 
-  template <typename ParallelComponent>
-  struct registration_list {
-    using type = std::conditional_t<
-        std::is_same_v<ParallelComponent, dg_element_array_component>,
-        dg_registration_list, tmpl::list<>>;
+  struct registration
+      : tt::ConformsTo<Parallel::protocols::RegistrationMetavariables> {
+    using element_registrars =
+        tmpl::map<tmpl::pair<dg_element_array_component, dg_registration_list>>;
   };
 
   using component_list =

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhAndCharacteristic.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhAndCharacteristic.hpp
@@ -42,6 +42,7 @@
 #include "Options/String.hpp"
 #include "Parallel/MemoryMonitor/MemoryMonitor.hpp"
 #include "Parallel/PhaseControl/PhaseControlTags.hpp"
+#include "Parallel/Protocols/RegistrationMetavariables.hpp"
 #include "ParallelAlgorithms/Interpolation/Actions/CleanUpInterpolator.hpp"
 #include "ParallelAlgorithms/Interpolation/Actions/ElementInitInterpPoints.hpp"
 #include "ParallelAlgorithms/Interpolation/Actions/InitializeInterpolationTarget.hpp"
@@ -62,6 +63,7 @@
 #include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
 #include "Utilities/ErrorHandling/SegfaultHandler.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/Serialization/RegisterDerivedClassesWithCharm.hpp"
 
 /// \cond
@@ -215,11 +217,10 @@ struct EvolutionMetavars : public GeneralizedHarmonicTemplateBase<VolumeDim>,
   using interpolation_target_tags =
       tmpl::list<CceWorldtubeTarget<false>, CceWorldtubeTarget<true>>;
 
-  template <typename ParallelComponent>
-  struct registration_list {
-    using type = std::conditional_t<
-        std::is_same_v<ParallelComponent, gh_dg_element_array>,
-        dg_registration_list, tmpl::list<>>;
+  struct registration
+      : tt::ConformsTo<Parallel::protocols::RegistrationMetavariables> {
+    using element_registrars =
+        tmpl::map<tmpl::pair<gh_dg_element_array, dg_registration_list>>;
   };
 
   using component_list = tmpl::flatten<tmpl::list<

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
@@ -88,6 +88,7 @@
 #include "Parallel/PhaseControl/VisitAndReturn.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
 #include "Parallel/Printf.hpp"
+#include "Parallel/Protocols/RegistrationMetavariables.hpp"
 #include "Parallel/Reduction.hpp"
 #include "ParallelAlgorithms/Actions/AddComputeTags.hpp"
 #include "ParallelAlgorithms/Actions/InitializeItems.hpp"
@@ -599,11 +600,10 @@ struct EvolutionMetavars {
   using observed_reduction_data_tags = observers::collect_reduction_data_tags<
       tmpl::at<typename factory_creation::factory_classes, Event>>;
 
-  template <typename ParallelComponent>
-  struct registration_list {
-    using type = std::conditional_t<
-        std::is_same_v<ParallelComponent, gh_dg_element_array>,
-        dg_registration_list, tmpl::list<>>;
+  struct registration
+      : tt::ConformsTo<Parallel::protocols::RegistrationMetavariables> {
+    using element_registrars =
+        tmpl::map<tmpl::pair<gh_dg_element_array, dg_registration_list>>;
   };
 
   using control_components =

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhNoBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhNoBlackHole.hpp
@@ -17,11 +17,13 @@
 #include "Options/String.hpp"
 #include "Parallel/MemoryMonitor/MemoryMonitor.hpp"
 #include "Parallel/PhaseControl/PhaseControlTags.hpp"
+#include "Parallel/Protocols/RegistrationMetavariables.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/GaugeWave.hpp"
 #include "Utilities/Blas.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
 #include "Utilities/ErrorHandling/SegfaultHandler.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/Serialization/RegisterDerivedClassesWithCharm.hpp"
 
 template <size_t VolumeDim>
@@ -71,11 +73,10 @@ struct EvolutionMetavars : public GeneralizedHarmonicTemplateBase<VolumeDim> {
                          Actions::AdvanceTime,
                          PhaseControl::Actions::ExecutePhaseChange>>>>>;
 
-  template <typename ParallelComponent>
-  struct registration_list {
-    using type = std::conditional_t<
-        std::is_same_v<ParallelComponent, gh_dg_element_array>,
-        dg_registration_list, tmpl::list<>>;
+  struct registration
+      : tt::ConformsTo<Parallel::protocols::RegistrationMetavariables> {
+    using element_registrars =
+        tmpl::map<tmpl::pair<gh_dg_element_array, dg_registration_list>>;
   };
 
   using component_list =

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhSingleBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhSingleBlackHole.hpp
@@ -27,6 +27,7 @@
 #include "Options/String.hpp"
 #include "Parallel/MemoryMonitor/MemoryMonitor.hpp"
 #include "Parallel/PhaseControl/ExecutePhaseChange.hpp"
+#include "Parallel/Protocols/RegistrationMetavariables.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/Callbacks/ErrorOnFailedApparentHorizon.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/Callbacks/FindApparentHorizon.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/Callbacks/IgnoreFailedApparentHorizon.hpp"
@@ -223,11 +224,10 @@ struct EvolutionMetavars : public GeneralizedHarmonicTemplateBase<VolumeDim> {
                          Actions::AdvanceTime,
                          PhaseControl::Actions::ExecutePhaseChange>>>>>;
 
-  template <typename ParallelComponent>
-  struct registration_list {
-    using type = std::conditional_t<
-        std::is_same_v<ParallelComponent, gh_dg_element_array>,
-        dg_registration_list, tmpl::list<>>;
+  struct registration
+      : tt::ConformsTo<Parallel::protocols::RegistrationMetavariables> {
+    using element_registrars =
+        tmpl::map<tmpl::pair<gh_dg_element_array, dg_registration_list>>;
   };
 
   using component_list = tmpl::flatten<tmpl::list<

--- a/src/Evolution/Executables/GrMhd/GhValenciaDivClean/EvolveGhValenciaDivClean.hpp
+++ b/src/Evolution/Executables/GrMhd/GhValenciaDivClean/EvolveGhValenciaDivClean.hpp
@@ -44,9 +44,7 @@ struct EvolutionMetavars : public GhValenciaDivCleanTemplateBase<
       typename base::observed_reduction_data_tags;
   using component_list = typename base::component_list;
   using factory_creation = typename base::factory_creation;
-  template <typename ParallelComponent>
-  using registration_list =
-      typename base::template registration_list<ParallelComponent>;
+  using registration = typename base::registration;
 
   static constexpr Options::String help{
       "Evolve the Valencia formulation of the GRMHD system with divergence "

--- a/src/Evolution/Executables/GrMhd/GhValenciaDivClean/EvolveGhValenciaDivCleanWithHorizon.hpp
+++ b/src/Evolution/Executables/GrMhd/GhValenciaDivClean/EvolveGhValenciaDivCleanWithHorizon.hpp
@@ -143,15 +143,7 @@ struct EvolutionMetavars : public GhValenciaDivCleanTemplateBase<
   using observed_reduction_data_tags = observers::collect_reduction_data_tags<
       tmpl::at<typename factory_creation::factory_classes, Event>>;
 
-  using dg_registration_list = typename base::dg_registration_list;
-
-  template <typename ParallelComponent>
-  struct registration_list {
-    using type = std::conditional_t<
-        std::is_same_v<ParallelComponent,
-                       typename base::dg_element_array_component>,
-        dg_registration_list, tmpl::list<>>;
-  };
+  using registration = typename base::registration;
 
   using component_list =
       tmpl::push_back<typename base::component_list,

--- a/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
+++ b/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
@@ -134,6 +134,7 @@
 #include "Parallel/PhaseControl/Factory.hpp"
 #include "Parallel/PhaseControl/VisitAndReturn.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
+#include "Parallel/Protocols/RegistrationMetavariables.hpp"
 #include "Parallel/Reduction.hpp"
 #include "ParallelAlgorithms/Actions/AddComputeTags.hpp"
 #include "ParallelAlgorithms/Actions/AddSimpleTags.hpp"
@@ -881,11 +882,10 @@ struct GhValenciaDivCleanTemplateBase<
               tmpl::list<Actions::RunEventsOnFailure<Tags::Time>,
                          Parallel::Actions::TerminatePhase>>>>>;
 
-  template <typename ParallelComponent>
-  struct registration_list {
-    using type = std::conditional_t<
-        std::is_same_v<ParallelComponent, dg_element_array_component>,
-        dg_registration_list, tmpl::list<>>;
+  struct registration
+      : tt::ConformsTo<Parallel::protocols::RegistrationMetavariables> {
+    using element_registrars =
+        tmpl::map<tmpl::pair<dg_element_array_component, dg_registration_list>>;
   };
 
   using component_list = tmpl::flatten<tmpl::list<

--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
@@ -105,6 +105,7 @@
 #include "Parallel/PhaseControl/Factory.hpp"
 #include "Parallel/PhaseControl/VisitAndReturn.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
+#include "Parallel/Protocols/RegistrationMetavariables.hpp"
 #include "ParallelAlgorithms/Actions/AddComputeTags.hpp"
 #include "ParallelAlgorithms/Actions/AddSimpleTags.hpp"
 #include "ParallelAlgorithms/Actions/InitializeItems.hpp"
@@ -580,11 +581,10 @@ struct EvolutionMetavars {
                      tmpl::list<Actions::RunEventsOnFailure<Tags::Time>,
                                 Parallel::Actions::TerminatePhase>>>>;
 
-  template <typename ParallelComponent>
-  struct registration_list {
-    using type = std::conditional_t<
-        std::is_same_v<ParallelComponent, dg_element_array_component>,
-        dg_registration_list, tmpl::list<>>;
+  struct registration
+      : tt::ConformsTo<Parallel::protocols::RegistrationMetavariables> {
+    using element_registrars =
+        tmpl::map<tmpl::pair<dg_element_array_component, dg_registration_list>>;
   };
 
   using component_list = tmpl::list<

--- a/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
+++ b/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
@@ -80,6 +80,7 @@
 #include "Parallel/PhaseControl/Factory.hpp"
 #include "Parallel/PhaseControl/VisitAndReturn.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
+#include "Parallel/Protocols/RegistrationMetavariables.hpp"
 #include "ParallelAlgorithms/Actions/AddComputeTags.hpp"
 #include "ParallelAlgorithms/Actions/InitializeItems.hpp"
 #include "ParallelAlgorithms/Actions/MutateApply.hpp"
@@ -407,11 +408,10 @@ struct EvolutionMetavars {
                          Actions::AdvanceTime,
                          PhaseControl::Actions::ExecutePhaseChange>>>>;
 
-  template <typename ParallelComponent>
-  struct registration_list {
-    using type =
-        std::conditional_t<std::is_same_v<ParallelComponent, dg_element_array>,
-                           dg_registration_list, tmpl::list<>>;
+  struct registration
+      : tt::ConformsTo<Parallel::protocols::RegistrationMetavariables> {
+    using element_registrars =
+        tmpl::map<tmpl::pair<dg_element_array, dg_registration_list>>;
   };
 
   using component_list =

--- a/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveM1Grey.hpp
+++ b/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveM1Grey.hpp
@@ -54,6 +54,7 @@
 #include "Parallel/PhaseControl/Factory.hpp"
 #include "Parallel/PhaseControl/VisitAndReturn.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
+#include "Parallel/Protocols/RegistrationMetavariables.hpp"
 #include "ParallelAlgorithms/Actions/AddComputeTags.hpp"
 #include "ParallelAlgorithms/Actions/AddSimpleTags.hpp"
 #include "ParallelAlgorithms/Actions/InitializeItems.hpp"
@@ -259,11 +260,10 @@ struct EvolutionMetavars {
                          Actions::AdvanceTime,
                          PhaseControl::Actions::ExecutePhaseChange>>>>;
 
-  template <typename ParallelComponent>
-  struct registration_list {
-    using type =
-        std::conditional_t<std::is_same_v<ParallelComponent, dg_element_array>,
-                           dg_registration_list, tmpl::list<>>;
+  struct registration
+      : tt::ConformsTo<Parallel::protocols::RegistrationMetavariables> {
+    using element_registrars =
+        tmpl::map<tmpl::pair<dg_element_array, dg_registration_list>>;
   };
 
   using component_list =

--- a/src/Evolution/Executables/RelativisticEuler/Valencia/EvolveValencia.hpp
+++ b/src/Evolution/Executables/RelativisticEuler/Valencia/EvolveValencia.hpp
@@ -58,6 +58,7 @@
 #include "Parallel/PhaseControl/Factory.hpp"
 #include "Parallel/PhaseControl/VisitAndReturn.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
+#include "Parallel/Protocols/RegistrationMetavariables.hpp"
 #include "ParallelAlgorithms/Actions/AddComputeTags.hpp"
 #include "ParallelAlgorithms/Actions/AddSimpleTags.hpp"
 #include "ParallelAlgorithms/Actions/InitializeItems.hpp"
@@ -281,11 +282,10 @@ struct EvolutionMetavars {
                          Actions::AdvanceTime,
                          PhaseControl::Actions::ExecutePhaseChange>>>>;
 
-  template <typename ParallelComponent>
-  struct registration_list {
-    using type =
-        std::conditional_t<std::is_same_v<ParallelComponent, dg_element_array>,
-                           dg_registration_list, tmpl::list<>>;
+  struct registration
+      : tt::ConformsTo<Parallel::protocols::RegistrationMetavariables> {
+    using element_registrars =
+        tmpl::map<tmpl::pair<dg_element_array, dg_registration_list>>;
   };
 
   using component_list =

--- a/src/Evolution/Executables/ScalarAdvection/EvolveScalarAdvection.hpp
+++ b/src/Evolution/Executables/ScalarAdvection/EvolveScalarAdvection.hpp
@@ -75,6 +75,7 @@
 #include "Parallel/PhaseControl/Factory.hpp"
 #include "Parallel/PhaseControl/VisitAndReturn.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
+#include "Parallel/Protocols/RegistrationMetavariables.hpp"
 #include "ParallelAlgorithms/Actions/AddComputeTags.hpp"
 #include "ParallelAlgorithms/Actions/AddSimpleTags.hpp"
 #include "ParallelAlgorithms/Actions/InitializeItems.hpp"
@@ -366,11 +367,10 @@ struct EvolutionMetavars {
                          Actions::AdvanceTime,
                          PhaseControl::Actions::ExecutePhaseChange>>>>;
 
-  template <typename ParallelComponent>
-  struct registration_list {
-    using type =
-        std::conditional_t<std::is_same_v<ParallelComponent, dg_element_array>,
-                           dg_registration_list, tmpl::list<>>;
+  struct registration
+      : tt::ConformsTo<Parallel::protocols::RegistrationMetavariables> {
+    using element_registrars =
+        tmpl::map<tmpl::pair<dg_element_array, dg_registration_list>>;
   };
 
   using component_list =

--- a/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
+++ b/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
@@ -55,6 +55,7 @@
 #include "Parallel/PhaseControl/Factory.hpp"
 #include "Parallel/PhaseControl/VisitAndReturn.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
+#include "Parallel/Protocols/RegistrationMetavariables.hpp"
 #include "Parallel/Reduction.hpp"
 #include "ParallelAlgorithms/Actions/AddComputeTags.hpp"
 #include "ParallelAlgorithms/Actions/InitializeItems.hpp"
@@ -277,11 +278,10 @@ struct EvolutionMetavars {
                          Actions::AdvanceTime,
                          PhaseControl::Actions::ExecutePhaseChange>>>>;
 
-  template <typename ParallelComponent>
-  struct registration_list {
-    using type =
-        std::conditional_t<std::is_same_v<ParallelComponent, dg_element_array>,
-                           dg_registration_list, tmpl::list<>>;
+  struct registration
+      : tt::ConformsTo<Parallel::protocols::RegistrationMetavariables> {
+    using element_registrars =
+        tmpl::map<tmpl::pair<dg_element_array, dg_registration_list>>;
   };
 
   using component_list =

--- a/src/Executables/ExportCoordinates/ExportCoordinates.hpp
+++ b/src/Executables/ExportCoordinates/ExportCoordinates.hpp
@@ -51,6 +51,7 @@
 #include "Parallel/PhaseControl/ExecutePhaseChange.hpp"
 #include "Parallel/PhaseControl/VisitAndReturn.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
+#include "Parallel/Protocols/RegistrationMetavariables.hpp"
 #include "Parallel/Reduction.hpp"
 #include "ParallelAlgorithms/Actions/AddComputeTags.hpp"
 #include "ParallelAlgorithms/Actions/InitializeItems.hpp"
@@ -362,11 +363,10 @@ struct Metavariables {
                          evolution::Actions::RunEventsAndTriggers,
                          PhaseControl::Actions::ExecutePhaseChange>>>>;
 
-  template <typename ParallelComponent>
-  struct registration_list {
-    using type =
-        std::conditional_t<std::is_same_v<ParallelComponent, dg_element_array>,
-                           dg_registration_list, tmpl::list<>>;
+  struct registration
+      : tt::ConformsTo<Parallel::protocols::RegistrationMetavariables> {
+    using element_registrars =
+        tmpl::map<tmpl::pair<dg_element_array, dg_registration_list>>;
   };
 
   using component_list =

--- a/src/IO/Observer/Actions/RegisterEvents.hpp
+++ b/src/IO/Observer/Actions/RegisterEvents.hpp
@@ -17,9 +17,11 @@
 #include "Parallel/GlobalCache.hpp"
 #include "Parallel/Invoke.hpp"
 #include "Parallel/Local.hpp"
+#include "Parallel/Protocols/ElementRegistrar.hpp"
 #include "Parallel/Tags/Metavariables.hpp"
 #include "ParallelAlgorithms/EventsAndTriggers/Tags.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
 #include "Utilities/TypeTraits/CreateHasTypeAlias.hpp"
@@ -113,7 +115,8 @@ namespace Actions {
  * core. The use of separate functions is necessary to provide an interface
  * usable outside of iterable actions, e.g. in specialized `pup` functions.
  */
-struct RegisterEventsWithObservers {
+struct RegisterEventsWithObservers
+    : tt::ConformsTo<Parallel::protocols::ElementRegistrar> {
  private:
   template <typename ParallelComponent, typename RegisterOrDeregisterAction,
             typename DbTagList, typename Metavariables, typename ArrayIndex>
@@ -174,7 +177,7 @@ struct RegisterEventsWithObservers {
     }
   }
 
- public:
+ public:  // ElementRegistrar protocol
   template <typename ParallelComponent, typename DbTagList,
             typename Metavariables, typename ArrayIndex>
   static void perform_registration(const db::DataBox<DbTagList>& box,
@@ -196,6 +199,7 @@ struct RegisterEventsWithObservers {
                                                                    array_index);
   }
 
+ public:  // Iterable action
   template <typename DbTagList, typename... InboxTags, typename Metavariables,
             typename ArrayIndex, typename ActionList,
             typename ParallelComponent>

--- a/src/IO/Observer/Actions/RegisterWithObservers.hpp
+++ b/src/IO/Observer/Actions/RegisterWithObservers.hpp
@@ -18,6 +18,8 @@
 #include "Parallel/GlobalCache.hpp"
 #include "Parallel/Invoke.hpp"
 #include "Parallel/Local.hpp"
+#include "Parallel/Protocols/ElementRegistrar.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
 
 /// \cond
 template <class... Tags>
@@ -47,7 +49,8 @@ namespace observers::Actions {
  * usable outside of iterable actions, e.g. in specialized `pup` functions.
  */
 template <typename RegisterHelper>
-struct RegisterWithObservers {
+struct RegisterWithObservers
+    : tt::ConformsTo<Parallel::protocols::ElementRegistrar> {
  private:
   template <typename ParallelComponent, typename RegisterOrDeregisterAction,
             typename DbTagList, typename Metavariables, typename ArrayIndex>
@@ -69,7 +72,7 @@ struct RegisterWithObservers {
         type_of_observation);
   }
 
- public:
+ public:  // ElementRegistrar protocol
   template <typename ParallelComponent, typename DbTagList,
             typename Metavariables, typename ArrayIndex>
   static void perform_registration(db::DataBox<DbTagList>& box,
@@ -90,6 +93,7 @@ struct RegisterWithObservers {
                                                                    array_index);
   }
 
+ public:  // Iterable action
   template <typename DbTagList, typename... InboxTags, typename Metavariables,
             typename ArrayIndex, typename ActionList,
             typename ParallelComponent>

--- a/src/Parallel/Protocols/CMakeLists.txt
+++ b/src/Parallel/Protocols/CMakeLists.txt
@@ -6,4 +6,6 @@ spectre_target_headers(
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   ArrayElementsAllocator.hpp
+  ElementRegistrar.hpp
+  RegistrationMetavariables.hpp
   )

--- a/src/Parallel/Protocols/ElementRegistrar.hpp
+++ b/src/Parallel/Protocols/ElementRegistrar.hpp
@@ -1,0 +1,37 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+namespace Parallel::protocols {
+/*!
+ * \brief Conforming types register and deregister array elements with other
+ * parallel components
+ *
+ * For example, array elements may have to register and deregister with
+ * interpolators or observers when the elements get created and destroyed during
+ * AMR or migrated during load balancing. They may do so by sending messages to
+ * the parallel components that notify of the creation and destruction of the
+ * array elements.
+ *
+ * Conforming classes have the following static member functions:
+ *
+ * ```cpp
+ * static void perform_registration<ParallelComponent>(const
+ *   db::DataBox<DbTagList>& box, Parallel::GlobalCache<Metavariables>& cache,
+ *   const ArrayIndex& array_index)
+ *
+ * static void perform_deregistration<ParallelComponent>(const
+ *   db::DataBox<DbTagList>& box, Parallel::GlobalCache<Metavariables>& cache,
+ *   const ArrayIndex& array_index)
+ * ```
+ *
+ * Here is an example implementation of this protocol:
+ *
+ * \snippet RegistrationHelpers.hpp element_registrar_example
+ */
+struct ElementRegistrar {
+  template <typename ConformingType>
+  struct test {};
+};
+}  // namespace Parallel::protocols

--- a/src/Parallel/Protocols/RegistrationMetavariables.hpp
+++ b/src/Parallel/Protocols/RegistrationMetavariables.hpp
@@ -1,0 +1,41 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <type_traits>
+
+#include "Parallel/Protocols/ElementRegistrar.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace Parallel::protocols {
+/*!
+ * \brief Conforming types provide compile-time information for registering and
+ * deregistering array elements with other parallel components
+ *
+ * A class conforming to this protocol is placed in the metavariables to provide
+ * a list of element registrars for each array parallel component. The element
+ * registrars in the list must conform to the
+ * `Parallel::protocols::ElementRegistrar` protocol.
+ *
+ * The class conforming to this protocol must provide the following type alias:
+ *
+ * - `element_registrars`: A `tmpl::map` from parallel components to their list
+ *   of element registrars. The element registrars in the typelist must conform
+ *   to the `Parallel::protocols::ElementRegistrar` protocol.
+ *
+ * Here is an example implementation of this protocol:
+ *
+ * \snippet Test_InitializeParent.cpp registration_metavariables
+ *
+ * \note We may consider retrieving the list of element registrars directly from
+ * the `Parallel::Phase::Registration` phase of the parallel component instead
+ * of requiring the metavariables to provide a separate list.
+ */
+struct RegistrationMetavariables {
+  template <typename ConformingType>
+  struct test {
+    using element_registrars = typename ConformingType::element_registrars;
+  };
+};
+}  // namespace Parallel::protocols

--- a/src/ParallelAlgorithms/Interpolation/Actions/InterpolatorRegisterElement.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Actions/InterpolatorRegisterElement.hpp
@@ -10,8 +10,10 @@
 #include "Parallel/GlobalCache.hpp"
 #include "Parallel/Invoke.hpp"
 #include "Parallel/Local.hpp"
+#include "Parallel/Protocols/ElementRegistrar.hpp"
 #include "ParallelAlgorithms/Interpolation/Tags.hpp"  // IWYU pragma: keep
 #include "Utilities/Gsl.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/Requires.hpp"
 #include "Utilities/TaggedTuple.hpp"
 
@@ -102,7 +104,8 @@ struct DeregisterElement {
 /// eliminated from a core. The use of separate functions is necessary to
 /// provide an interface usable outside of iterable actions, e.g. in specialized
 /// `pup` functions.
-struct RegisterElementWithInterpolator {
+struct RegisterElementWithInterpolator
+    : tt::ConformsTo<Parallel::protocols::ElementRegistrar> {
  private:
   template <typename ParallelComponent, typename RegisterOrDeregisterAction,
             typename Metavariables, typename ArrayIndex>
@@ -115,11 +118,7 @@ struct RegisterElementWithInterpolator {
     Parallel::simple_action<RegisterOrDeregisterAction>(interpolator);
   }
 
- public:
-  // the registration functions do not use the DataBox argument, but need to
-  // keep it to conform to the interface used in the registration and
-  // deregistration procedure in Algorithm.hpp, which also supports registration
-  // and deregistration that does use the box.
+ public:  // ElementRegistrar protocol
   template <typename ParallelComponent, typename DbTagList,
             typename Metavariables, typename ArrayIndex>
   static void perform_registration(const db::DataBox<DbTagList>& /*box*/,
@@ -139,6 +138,7 @@ struct RegisterElementWithInterpolator {
         cache, array_index);
   }
 
+ public:  // Iterable action
   template <typename DbTagList, typename... InboxTags, typename Metavariables,
             typename ArrayIndex, typename ActionList,
             typename ParallelComponent>

--- a/tests/Unit/Helpers/Domain/Amr/RegistrationHelpers.hpp
+++ b/tests/Unit/Helpers/Domain/Amr/RegistrationHelpers.hpp
@@ -15,7 +15,9 @@
 #include "Parallel/Local.hpp"
 #include "Parallel/Phase.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
+#include "Parallel/Protocols/ElementRegistrar.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/TMPL.hpp"
 
 namespace TestHelpers::amr {
@@ -72,7 +74,8 @@ struct RegisterWithRegistrant {
   }
 };
 
-struct RegisterElement {
+// [element_registrar_example]
+struct RegisterElement : tt::ConformsTo<Parallel::protocols::ElementRegistrar> {
  private:
   template <typename ParallelComponent, typename RegisterOrDeregisterAction,
             typename DbTagList, typename Metavariables, typename ArrayIndex>
@@ -104,4 +107,6 @@ struct RegisterElement {
         box, cache, array_index);
   }
 };
+// [element_registrar_example]
+
 }  // namespace TestHelpers::amr

--- a/tests/Unit/ParallelAlgorithms/Amr/Actions/Test_CollectDataFromChildren.cpp
+++ b/tests/Unit/ParallelAlgorithms/Amr/Actions/Test_CollectDataFromChildren.cpp
@@ -26,8 +26,10 @@
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "Parallel/Phase.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
+#include "Parallel/Protocols/RegistrationMetavariables.hpp"
 #include "ParallelAlgorithms/Amr/Actions/CollectDataFromChildren.hpp"
 #include "Utilities/Literals.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
 
@@ -223,11 +225,11 @@ struct Metavariables {
   // NOLINTNEXTLINE(google-runtime-references)
   void pup(PUP::er& /*p*/) {}
 
-  template <typename ParallelComponent>
-  struct registration_list {
-    using type = std::conditional_t<
-        std::is_same_v<ParallelComponent, Component<Metavariables>>,
-        tmpl::list<TestHelpers::amr::RegisterElement>, tmpl::list<>>;
+  struct registration
+      : tt::ConformsTo<Parallel::protocols::RegistrationMetavariables> {
+    using element_registrars =
+        tmpl::map<tmpl::pair<Component<Metavariables>,
+                             tmpl::list<TestHelpers::amr::RegisterElement>>>;
   };
 };
 

--- a/tests/Unit/ParallelAlgorithms/Amr/Actions/Test_InitializeChild.cpp
+++ b/tests/Unit/ParallelAlgorithms/Amr/Actions/Test_InitializeChild.cpp
@@ -26,9 +26,11 @@
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "Parallel/Phase.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
+#include "Parallel/Protocols/RegistrationMetavariables.hpp"
 #include "ParallelAlgorithms/Amr/Actions/InitializeChild.hpp"
 #include "ParallelAlgorithms/Amr/Protocols/AmrMetavariables.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
 
@@ -54,11 +56,11 @@ struct Metavariables {
   static constexpr size_t volume_dim = 2;
   using component_list = tmpl::list<Component<Metavariables>,
                                     TestHelpers::amr::Registrar<Metavariables>>;
-  template <typename ParallelComponent>
-  struct registration_list {
-    using type = std::conditional_t<
-        std::is_same_v<ParallelComponent, Component<Metavariables>>,
-        tmpl::list<TestHelpers::amr::RegisterElement>, tmpl::list<>>;
+  struct registration
+      : tt::ConformsTo<Parallel::protocols::RegistrationMetavariables> {
+    using element_registrars =
+        tmpl::map<tmpl::pair<Component<Metavariables>,
+                             tmpl::list<TestHelpers::amr::RegisterElement>>>;
   };
 
   struct amr : tt::ConformsTo<::amr::protocols::AmrMetavariables> {

--- a/tests/Unit/ParallelAlgorithms/Amr/Actions/Test_InitializeParent.cpp
+++ b/tests/Unit/ParallelAlgorithms/Amr/Actions/Test_InitializeParent.cpp
@@ -26,9 +26,11 @@
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "Parallel/Phase.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
+#include "Parallel/Protocols/RegistrationMetavariables.hpp"
 #include "ParallelAlgorithms/Amr/Actions/InitializeParent.hpp"
 #include "ParallelAlgorithms/Amr/Protocols/AmrMetavariables.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
 
@@ -54,12 +56,14 @@ struct Metavariables {
   static constexpr size_t volume_dim = 3;
   using component_list = tmpl::list<Component<Metavariables>,
                                     TestHelpers::amr::Registrar<Metavariables>>;
-  template <typename ParallelComponent>
-  struct registration_list {
-    using type = std::conditional_t<
-        std::is_same_v<ParallelComponent, Component<Metavariables>>,
-        tmpl::list<TestHelpers::amr::RegisterElement>, tmpl::list<>>;
+  // [registration_metavariables]
+  struct registration
+      : tt::ConformsTo<Parallel::protocols::RegistrationMetavariables> {
+    using element_registrars =
+        tmpl::map<tmpl::pair<Component<Metavariables>,
+                             tmpl::list<TestHelpers::amr::RegisterElement>>>;
   };
+  // [registration_metavariables]
 
   struct amr : tt::ConformsTo<::amr::protocols::AmrMetavariables> {
     using projectors = tmpl::list<>;

--- a/tests/Unit/ParallelAlgorithms/Amr/Actions/Test_SendDataToChildren.cpp
+++ b/tests/Unit/ParallelAlgorithms/Amr/Actions/Test_SendDataToChildren.cpp
@@ -25,7 +25,9 @@
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "Parallel/Phase.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
+#include "Parallel/Protocols/RegistrationMetavariables.hpp"
 #include "ParallelAlgorithms/Amr/Actions/SendDataToChildren.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
 
 namespace {
 
@@ -104,11 +106,11 @@ struct Metavariables {
   // NOLINTNEXTLINE(google-runtime-references)
   void pup(PUP::er& /*p*/) {}
 
-  template <typename ParallelComponent>
-  struct registration_list {
-    using type = std::conditional_t<
-        std::is_same_v<ParallelComponent, Component<Metavariables>>,
-        tmpl::list<TestHelpers::amr::RegisterElement>, tmpl::list<>>;
+  struct registration
+      : tt::ConformsTo<Parallel::protocols::RegistrationMetavariables> {
+    using element_registrars =
+        tmpl::map<tmpl::pair<Component<Metavariables>,
+                             tmpl::list<TestHelpers::amr::RegisterElement>>>;
   };
 };
 


### PR DESCRIPTION
## Proposed changes

Document the element registration metavars, in the spirit of #3076.

The fixup commit is to help reviewers.

We can also consider retrieving the list of registrars directly from the `Parallel::Phase::Registration` phase of the parallel component.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
