### PR TITLE
Compute truncation errors in post-processing

### DIFF
--- a/src/NumericalAlgorithms/LinearOperators/PowerMonitors.cpp
+++ b/src/NumericalAlgorithms/LinearOperators/PowerMonitors.cpp
@@ -95,18 +95,31 @@ double relative_truncation_error(const DataVector& power_monitor,
 }
 
 template <size_t Dim>
-std::array<double, Dim> truncation_error(
-    const std::array<DataVector, Dim>& power_monitors_of_u,
-    const DataVector& u) {
+std::array<double, Dim> relative_truncation_error(
+    const DataVector& tensor_component, const Mesh<Dim>& mesh) {
   std::array<double, Dim> result{};
+  const auto modes = power_monitors(tensor_component, mesh);
+  for (size_t d = 0; d < Dim; ++d) {
+    const auto& modes_d = gsl::at(modes, d);
+    gsl::at(result, d) =
+        pow(10.0, -relative_truncation_error(modes_d, modes_d.size()));
+  }
+  return result;
+}
+
+template <size_t Dim>
+std::array<double, Dim> absolute_truncation_error(
+    const DataVector& tensor_component, const Mesh<Dim>& mesh) {
+  std::array<double, Dim> result{};
+  const auto modes = power_monitors(tensor_component, mesh);
   // Use infinity norm to estimate the order of magnitude of the variable
-  const double umax = max(abs(u));
+  const double umax = max(abs(tensor_component));
   double relative_truncation_error_in_d = 0.0;
   for (size_t d = 0; d < Dim; ++d) {
-    const auto& modes = gsl::at(power_monitors_of_u, d);
+    const auto& modes_d = gsl::at(modes, d);
     // Compute relative truncation error
     relative_truncation_error_in_d =
-        relative_truncation_error(modes, modes.size());
+        relative_truncation_error(modes_d, modes_d.size());
     // Compute absolute truncation error estimate
     gsl::at(result, d) =
         umax * pow(10.0, -1.0 * relative_truncation_error_in_d);
@@ -114,22 +127,22 @@ std::array<double, Dim> truncation_error(
   return result;
 }
 
-}  // namespace PowerMonitors
-
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 
-#define INSTANTIATE(_, data)                                                   \
-  template std::array<DataVector, DIM(data)>                                   \
-  PowerMonitors::power_monitors(const DataVector& u,                           \
-                                     const Mesh<DIM(data)>& mesh);             \
-  template void PowerMonitors::power_monitors(                                 \
-    const gsl::not_null<std::array<DataVector, DIM(data)>*> result,            \
-    const DataVector& u, const Mesh<DIM(data)>& mesh);                         \
-  template std::array<double, DIM(data)> PowerMonitors::truncation_error(      \
-    const std::array<DataVector, DIM(data)>& power_monitors_of_u,              \
-    const DataVector& u);
+#define INSTANTIATE(_, data)                                            \
+  template std::array<DataVector, DIM(data)> power_monitors(            \
+      const DataVector& u, const Mesh<DIM(data)>& mesh);                \
+  template void power_monitors(                                         \
+      const gsl::not_null<std::array<DataVector, DIM(data)>*> result,   \
+      const DataVector& u, const Mesh<DIM(data)>& mesh);                \
+  template std::array<double, DIM(data)> relative_truncation_error(     \
+      const DataVector& tensor_component, const Mesh<DIM(data)>& mesh); \
+  template std::array<double, DIM(data)> absolute_truncation_error(     \
+      const DataVector& tensor_component, const Mesh<DIM(data)>& mesh);
 
 GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
 
 #undef INSTANTIATE
 #undef DIM
+
+}  // namespace PowerMonitors

--- a/src/NumericalAlgorithms/LinearOperators/PowerMonitors.cpp
+++ b/src/NumericalAlgorithms/LinearOperators/PowerMonitors.cpp
@@ -69,15 +69,14 @@ double relative_truncation_error(const DataVector& power_monitor,
   double weight_value = 0.0;
   const size_t last_index = num_modes_to_use - 1;
   for (size_t index = 0; index <= last_index; ++index) {
+    const double mode = power_monitor[index];
+    if (mode == 0.) {
+      continue;
+    }
     // Compute current weight
     weight_value =
         exp(-square(index - static_cast<double>(last_index) + 0.5));
     // Add weighted power monitor
-    const double mode = power_monitor[index];
-    ASSERT(not(mode == 0.0),
-           "A power monitor is zero bitwise. If this is one of "
-           "the highest modes, reduce the number of power monitors used to "
-           "estimate the relative truncation error.");
     weighted_average += weight_value * log10(mode);
     // Add term to weighted sum
     weight_sum += weight_value;

--- a/src/NumericalAlgorithms/LinearOperators/PowerMonitors.hpp
+++ b/src/NumericalAlgorithms/LinearOperators/PowerMonitors.hpp
@@ -70,6 +70,8 @@ std::array<DataVector, Dim> power_monitors(const DataVector& u,
  * average with larger weights toward the highest modes. This number should
  * correspond to the number of digits resolved by the spectral expansion.
  *
+ * \note Modes that are identically zero are ignored in the weighted average.
+ *
  * \details The number of modes (`num_modes_to_use`) argument needs to be less
  * or equal than the total number of power monitors (`power_monitor.size()`).
  * In contrast with Ref. \cite Szilagyi2014fna, here we index the modes starting

--- a/src/NumericalAlgorithms/LinearOperators/PowerMonitors.hpp
+++ b/src/NumericalAlgorithms/LinearOperators/PowerMonitors.hpp
@@ -82,6 +82,21 @@ double relative_truncation_error(const DataVector& power_monitor,
                                  const size_t num_modes_to_use);
 /// @}
 
+/*!
+ * \brief The relative truncation error in each logical direction of the grid
+ *
+ * This overload is intended for visualization purposes only. It takes a tensor
+ * component as input, so it can be used as a kernel to post-process volume data
+ * with Python bindings (see `TransformVolumeData.py`).
+ *
+ * This function returns the relative truncation error directly, as opposed to
+ * the other overload that returns the negative log10 of the relative truncation
+ * error.
+ */
+template <size_t Dim>
+std::array<double, Dim> relative_truncation_error(
+    const DataVector& tensor_component, const Mesh<Dim>& mesh);
+
 /// @{
 /*!
  * \ingroup SpectralGroup
@@ -101,8 +116,7 @@ double relative_truncation_error(const DataVector& power_monitor,
  * \warning This estimate is intended for visualization purposes only.
  */
 template <size_t Dim>
-std::array<double, Dim> truncation_error(
-    const std::array<DataVector, Dim>& power_monitors_of_u,
-    const DataVector& u);
+std::array<double, Dim> absolute_truncation_error(
+    const DataVector& tensor_component, const Mesh<Dim>& mesh);
 /// @}
 }  // namespace PowerMonitors

--- a/src/NumericalAlgorithms/LinearOperators/Python/PowerMonitors.cpp
+++ b/src/NumericalAlgorithms/LinearOperators/Python/PowerMonitors.cpp
@@ -18,14 +18,17 @@ namespace {
 template <size_t Dim>
 void bind_power_monitors_impl(py::module& m) {  // NOLINT
   m.def("power_monitors",
-        py::overload_cast<const DataVector&, const Mesh<Dim>&> (
-          &power_monitors<Dim>),
+        py::overload_cast<const DataVector&, const Mesh<Dim>&>(
+            &power_monitors<Dim>),
         py::arg("data_vector"), py::arg("mesh"));
-  m.def(
-      "truncation_error",
-      py::overload_cast<const std::array<DataVector, Dim>&, const DataVector&>(
-          &truncation_error<Dim>),
-      py::arg("power_monitors_of_u"), py::arg("data_vector"));
+  m.def("relative_truncation_error",
+        py::overload_cast<const DataVector&, const Mesh<Dim>&>(
+            &relative_truncation_error<Dim>),
+        py::arg("tensor_component"), py::arg("mesh"));
+  m.def("absolute_truncation_error",
+        py::overload_cast<const DataVector&, const Mesh<Dim>&>(
+            &absolute_truncation_error<Dim>),
+        py::arg("tensor_component"), py::arg("mesh"));
 }
 }  // namespace
 
@@ -33,10 +36,6 @@ void bind_power_monitors(py::module& m) {
   bind_power_monitors_impl<1>(m);
   bind_power_monitors_impl<2>(m);
   bind_power_monitors_impl<3>(m);
-  m.def("relative_truncation_error",
-        py::overload_cast<const DataVector&, const size_t>(
-            &relative_truncation_error),
-        py::arg("power_monitor"), py::arg("num_modes_to_use"));
 }
 
 }  // namespace PowerMonitors::py_bindings

--- a/src/Visualization/Python/TransformVolumeData.py
+++ b/src/Visualization/Python/TransformVolumeData.py
@@ -749,9 +749,15 @@ def transform_volume_data_command(
     'parse_kernel_arg' function for all supported argument types, and
     'parse_kernel_output' for all supported return types.
 
-    The kernels can be loaded from any available Python module, such as
-    'spectre.PointwiseFunctions'. You can also execute a Python file that
-    defines kernels with the '--exec' / '-e' option.
+    The kernels can be loaded from any available Python module. Examples of
+    useful kernels:
+
+    - Anything in 'spectre.PointwiseFunctions'
+    - 'spectre.NumericalAlgorithms.LinearOperators.relative_truncation_error'
+      and 'absolute_truncation_error'
+
+    You can also execute a Python file that defines kernels with the '--exec' /
+    '-e' option.
 
     By default, the data for the input arguments are read from datasets in the
     volume files with the same names, transformed to CamelCase. For example, the

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/Test_PowerMonitors.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/Test_PowerMonitors.cpp
@@ -142,8 +142,8 @@ void test_relative_truncation_error_impl() {
                         test_relative_truncation_error);
 
   // Test truncation error
-  const double test_truncation_error = gsl::at(
-      PowerMonitors::truncation_error<1_st>(power_monitors, u_nodal), 0_st);
+  const double test_truncation_error =
+      PowerMonitors::absolute_truncation_error(u_nodal, mesh)[0];
 
   // Compare with the result from the relative truncation error
   const double expected_truncation_error_x =


### PR DESCRIPTION
## Proposed changes

Allows to use `relative_truncation_error` and `absolute_truncation_error` as kernels in `spectre transform-volume-data`. Try it like this:

```sh
spectre transform-volume-data GhBinaryBlackHoleVolumeData0.h5 -d VolumeData \
  -k spectre.NumericalAlgorithms.LinearOperators.absolute_truncation_error \
  -i tensor_component=Lapse
```

For example here's the radial truncation error of the Lapse in head-on initial data on the evolution domain (wireframe with opacity scaled linearly by the error, so low-error regions are transparent):

<img width="863" alt="Bildschirmfoto 2023-08-05 um 17 21 53" src="https://github.com/sxs-collaboration/spectre/assets/746230/6febbb97-c3d6-460b-8638-64b0b457cfbd">

AMR with #5273 is intended to use this data to p-refine the domain.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
