### PR TITLE
Allow FPEs to be caught as C++ exceptions

### DIFF
--- a/cmake/SetupCxxFlags.cmake
+++ b/cmake/SetupCxxFlags.cmake
@@ -122,8 +122,14 @@ set_property(TARGET SpectreFlags
   $<$<COMPILE_LANGUAGE:CXX>:-freciprocal-math>
   $<$<COMPILE_LANGUAGE:Fortran>:-freciprocal-math>)
 
-# By default, the LLVM optimizer assumes floating point exceptions are ignored.
-create_cxx_flag_target("-ffp-exception-behavior=maytrap" SpectreFpExceptions)
+# -ffp-exception-behavior=maytrap - By default, the LLVM optimizer assumes
+#     floating point exceptions are ignored.
+# -fnon-call-exceptions - By default, GCC does not allow signal handlers to
+#     throw exceptions.
+create_cxx_flags_target(
+  "-ffp-exception-behavior=maytrap;-fnon-call-exceptions"
+  SpectreFpExceptions
+  )
 target_link_libraries(
   SpectreFlags
   INTERFACE

--- a/src/DataStructures/Tensor/Structure.hpp
+++ b/src/DataStructures/Tensor/Structure.hpp
@@ -477,12 +477,19 @@ struct Structure {
     static_assert(sizeof...(Indices) == sizeof...(N),
                   "the number arguments must be equal to rank_");
     constexpr auto collapsed_to_storage = collapsed_to_storage_;
+#if defined(__GNUC__) and not defined(__clang__) and __GNUC__ >= 10 and __GNUC__ < 12
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
     return gsl::at(
         collapsed_to_storage,
         compute_collapsed_index(
             cpp20::array<size_t, sizeof...(N)>{{static_cast<size_t>(args)...}},
             make_cpp20_array_from_list<tmpl::conditional_t<
                 0 != sizeof...(Indices), index_list, size_t>>()));
+#if defined(__GNUC__) and not defined(__clang__) and __GNUC__ >= 10 and __GNUC__ < 12
+#pragma GCC diagnostic pop
+#endif
   }
 
   /// \brief Get the storage_index of a tensor_index


### PR DESCRIPTION
This mostly worked on clang already, but gcc needed a command line flag.

~~For some reason that I haven't investigated, FPEs end up disabled after catching the exception.  This shouldn't be a big deal because in real use this will presumably be followed immediately by the failure cleanup code, which disables FPEs anyway.~~ - fixed

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
