### PR TITLE
Fix rebase bug in CharSpeed for ObservationValue

### DIFF
--- a/src/ControlSystem/Measurements/CharSpeed.hpp
+++ b/src/ControlSystem/Measurements/CharSpeed.hpp
@@ -129,8 +129,10 @@ struct CharSpeed : tt::ConformsTo<protocols::Measurement> {
 
       Event event{};
 
+      // ObservationValue unused
       event(measurement_id, point_infos, mesh, spacetime_metric, pi, phi,
-            deriv_phi, constraint_gamma1, cache, array_index, component);
+            deriv_phi, constraint_gamma1, cache, array_index, component,
+            ::Event::ObservationValue{});
     }
   };
 


### PR DESCRIPTION
## Proposed changes

Missed in #5227 because the char speed measurement isn't compiled into any executable yet.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
