### PR TITLE
Add prefix tags for observation of CSW variables in ScalarTensor

### DIFF
--- a/src/Evolution/Systems/ScalarTensor/Tags.hpp
+++ b/src/Evolution/Systems/ScalarTensor/Tags.hpp
@@ -3,10 +3,15 @@
 
 #pragma once
 
+#include <cstddef>
+
 #include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "DataStructures/DataBox/Tag.hpp"
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "Evolution/Systems/CurvedScalarWave/Constraints.hpp"
+#include "Evolution/Systems/CurvedScalarWave/Tags.hpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
 #include "Options/String.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -58,6 +63,93 @@ struct ScalarMass : db::SimpleTag {
   static constexpr bool pass_metavariables = false;
   static double create_from_options(const double mass_psi) { return mass_psi; }
 };
+
+/*!
+ * \brief Prefix tag to avoid ambiguities when observing variables with the same
+ * name in both parent systems.
+ * \note Since we also add compute tags for these quantities, we do not make
+ * this a derived class of `Tag`. Otherwise, we would have tags with repeated
+ * base tags in the `ObservationBox`.
+ */
+template <typename Tag>
+struct Csw : db::PrefixTag, db::SimpleTag {
+  using type = typename Tag::type;
+  using tag = Tag;
+};
+
+/*!
+ * \brief Compute tag to retrieve the values of CurvedScalarWave variables
+ * with the same name as in the ::gh systems.
+ * \note Since we also add compute tags for these quantities, we do not make
+ * this a derived class of `Tag`. Otherwise, we would have tags with repeated
+ * base tags in the `ObservationBox`.
+ */
+template <typename Tag>
+struct CswCompute : Csw<Tag>, db::ComputeTag {
+  using argument_tags = tmpl::list<Tag>;
+  using base = Csw<Tag>;
+  using return_type = typename base::type;
+  static constexpr void function(const gsl::not_null<return_type*> result,
+                                 const return_type& csw_var) {
+    for (size_t i = 0; i < csw_var.size(); ++i) {
+      make_const_view(make_not_null(&std::as_const((*result)[i])), csw_var[i],
+                      0, csw_var[i].size());
+    }
+  }
+};
+
+/*!
+ * \brief Computes the scalar-wave one-index constraint.
+ * \details The one-index constraint is assigned to a wrapped tag to avoid
+ * clashes with the ::gh constraints during observation.
+ * \note We do not use ScalarTensor::Tags::CswCompute to retrieve the
+ * CurvedScalarWave constraints since we do not want to add the bare compute
+ * tags (::CurvedScalarWave::Tags::OneIndexConstraintCompute and
+ * ::CurvedScalarWave::Tags::TwoIndexConstraintCompute) directly in the
+ * ObservationBox, since that will make them observable and would lead to a
+ * clash with the ::gh constraint tags.
+ */
+template <size_t Dim>
+struct CswOneIndexConstraintCompute
+    : Csw<CurvedScalarWave::Tags::OneIndexConstraint<Dim>>,
+      db::ComputeTag {
+  using argument_tags =
+      tmpl::list<::Tags::deriv<CurvedScalarWave::Tags::Psi, tmpl::size_t<Dim>,
+                               Frame::Inertial>,
+                 CurvedScalarWave::Tags::Phi<Dim>>;
+  using return_type = tnsr::i<DataVector, Dim>;
+  static constexpr void (*function)(const gsl::not_null<return_type*> result,
+                                    const tnsr::i<DataVector, Dim>&,
+                                    const tnsr::i<DataVector, Dim>&) =
+      &CurvedScalarWave::one_index_constraint<Dim>;
+  using base = Csw<CurvedScalarWave::Tags::OneIndexConstraint<Dim>>;
+};
+
+/*!
+ * \brief Computes the scalar-wave two-index constraint.
+ * \details The two-index constraint is assigned to a wrapped tag to avoid
+ * clashes with the ::gh constraints during observation.
+ * \note We do not use ScalarTensor::Tags::CswCompute to retrieve the
+ * CurvedScalarWave constraints since we do not want to add the bare compute
+ * tags (::CurvedScalarWave::Tags::OneIndexConstraintCompute and
+ * ::CurvedScalarWave::Tags::TwoIndexConstraintCompute) directly in the
+ * ObservationBox, since that will make them observable and would lead to a
+ * clash with the ::gh constraint tags.
+ */
+template <size_t Dim>
+struct CswTwoIndexConstraintCompute
+    : Csw<CurvedScalarWave::Tags::TwoIndexConstraint<Dim>>,
+      db::ComputeTag {
+  using argument_tags =
+      tmpl::list<::Tags::deriv<CurvedScalarWave::Tags::Phi<Dim>,
+                               tmpl::size_t<Dim>, Frame::Inertial>>;
+  using return_type = tnsr::ij<DataVector, Dim>;
+  static constexpr void (*function)(const gsl::not_null<return_type*> result,
+                                    const tnsr::ij<DataVector, Dim>&) =
+      &CurvedScalarWave::two_index_constraint<Dim>;
+  using base = Csw<CurvedScalarWave::Tags::TwoIndexConstraint<Dim>>;
+};
+
 }  // namespace Tags
 
 }  // namespace ScalarTensor

--- a/tests/Unit/Evolution/Systems/ScalarTensor/Test_Tags.cpp
+++ b/tests/Unit/Evolution/Systems/ScalarTensor/Test_Tags.cpp
@@ -5,6 +5,7 @@
 
 #include <string>
 
+#include "Evolution/Systems/CurvedScalarWave/Tags.hpp"
 #include "Evolution/Systems/ScalarTensor/Tags.hpp"
 #include "Framework/TestCreation.hpp"
 #include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
@@ -18,16 +19,50 @@ void test_simple_tags() {
   TestHelpers::db::test_simple_tag<
       ScalarTensor::Tags::TraceReversedStressEnergy<DataVector, Dim, Frame>>(
       "TraceReversedStressEnergy");
+  TestHelpers::db::test_simple_tag<ScalarTensor::Tags::ScalarMass>(
+      "ScalarMass");
+  TestHelpers::db::test_simple_tag<ScalarTensor::Tags::ScalarSource>(
+      "ScalarSource");
+}
+
+template <size_t Dim>
+void test_prefix_tags() {
+  TestHelpers::db::test_prefix_tag<
+      ScalarTensor::Tags::Csw<CurvedScalarWave::Tags::Psi>>("Csw(Psi)");
+  TestHelpers::db::test_prefix_tag<
+      ScalarTensor::Tags::Csw<CurvedScalarWave::Tags::Pi>>("Csw(Pi)");
+  TestHelpers::db::test_prefix_tag<
+      ScalarTensor::Tags::Csw<CurvedScalarWave::Tags::Phi<Dim>>>("Csw(Phi)");
+}
+
+template <size_t Dim>
+void test_compute_tags() {
+  TestHelpers::db::test_compute_tag<
+      ScalarTensor::Tags::CswCompute<CurvedScalarWave::Tags::Psi>>("Csw(Psi)");
+  TestHelpers::db::test_compute_tag<
+      ScalarTensor::Tags::CswCompute<CurvedScalarWave::Tags::Pi>>("Csw(Pi)");
+  TestHelpers::db::test_compute_tag<
+      ScalarTensor::Tags::CswCompute<CurvedScalarWave::Tags::Phi<Dim>>>(
+      "Csw(Phi)");
+  TestHelpers::db::test_compute_tag<
+      ScalarTensor::Tags::CswOneIndexConstraintCompute<Dim>>(
+      "Csw(OneIndexConstraint)");
+  TestHelpers::db::test_compute_tag<
+      ScalarTensor::Tags::CswTwoIndexConstraintCompute<Dim>>(
+      "Csw(TwoIndexConstraint)");
+}
+
+template <size_t Dim>
+void test_tags() {
+  test_simple_tags<Dim, ArbitraryFrame>();
+  test_prefix_tags<Dim>();
+  test_compute_tags<Dim>();
 }
 
 SPECTRE_TEST_CASE("Unit.Evolution.Systems.ScalarTensor.Tags",
                   "[Unit][Evolution]") {
-  test_simple_tags<1_st, ArbitraryFrame>();
-  test_simple_tags<2_st, ArbitraryFrame>();
-  test_simple_tags<3_st, ArbitraryFrame>();
-  TestHelpers::db::test_simple_tag<ScalarTensor::Tags::ScalarMass>(
-      "ScalarMass");
+  test_tags<1_st>();
+  test_tags<2_st>();
+  test_tags<3_st>();
   TestHelpers::test_option_tag<ScalarTensor::OptionTags::ScalarMass>("1.0");
-  TestHelpers::db::test_simple_tag<ScalarTensor::Tags::ScalarSource>(
-      "ScalarSource");
 }


### PR DESCRIPTION
## Proposed changes

When specifying variables to observe in `ScalarTensor` input files, variables with matching names in the Generalized Harmonic and CurvedScalarWave (CSW) systems clash with each other. 

Here we write a prefix tag to wrap the CSW tags and add compute tags that retrieve the data from the CSW variables but that can be parsed with the prefix.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
