### PR TITLE
Allow overwriting H5 tensor data, add `--force` option to transform-vol CLI

### DIFF
--- a/src/IO/H5/Helpers.hpp
+++ b/src/IO/H5/Helpers.hpp
@@ -32,14 +32,15 @@ bool types_equal(hid_t dtype1, hid_t dtype2);
 template <typename T>
 void write_data(hid_t group_id, const std::vector<T>& data,
                 const std::vector<size_t>& extents,
-                const std::string& name = "scalar");
+                const std::string& name = "scalar",
+                const bool overwrite_existing = false);
 
 /*!
  * \ingroup HDF5Group
  * \brief Write a DataVector named `name` to the group `group_id`
  */
-void write_data(hid_t group_id, const DataVector& data,
-                const std::string& name);
+void write_data(hid_t group_id, const DataVector& data, const std::string& name,
+                const bool overwrite_existing = false);
 
 /*!
  * \ingroup HDF5Group

--- a/src/IO/H5/Python/VolumeData.cpp
+++ b/src/IO/H5/Python/VolumeData.cpp
@@ -26,10 +26,11 @@ void bind_h5vol(py::module& m) {
            py::arg("elements"), py::arg("serialized_domain") = std::nullopt,
            py::arg("serialized_functions_of_time") = std::nullopt)
       .def("write_tensor_component",
-           py::overload_cast<size_t, const std::string&, const DataVector&>(
-               &h5::VolumeData::write_tensor_component),
+           py::overload_cast<size_t, const std::string&, const DataVector&,
+                             bool>(&h5::VolumeData::write_tensor_component),
            py::arg("observation_id"), py::arg("component_name"),
-           py::arg("contiguous_tensor_data"))
+           py::arg("contiguous_tensor_data"),
+           py::arg("overwrite_existing") = false)
       .def("list_observation_ids", &h5::VolumeData::list_observation_ids)
       .def("get_observation_value", &h5::VolumeData::get_observation_value,
            py::arg("observation_id"))

--- a/src/IO/H5/VolumeData.cpp
+++ b/src/IO/H5/VolumeData.cpp
@@ -397,22 +397,25 @@ void VolumeData::extend_connectivity_data(
 
 void VolumeData::write_tensor_component(
     const size_t observation_id, const std::string& component_name,
-    const DataVector& contiguous_tensor_data) {
+    const DataVector& contiguous_tensor_data,
+    const bool overwrite_existing) {
   const std::string path = "ObservationId" + std::to_string(observation_id);
   detail::OpenGroup observation_group(volume_data_group_.id(), path,
                                       AccessType::ReadWrite);
-  h5::write_data(observation_group.id(), contiguous_tensor_data,
-                 component_name);
+  h5::write_data(observation_group.id(), contiguous_tensor_data, component_name,
+                 overwrite_existing);
 }
 
 void VolumeData::write_tensor_component(
     const size_t observation_id, const std::string& component_name,
-    const std::vector<float>& contiguous_tensor_data) {
+    const std::vector<float>& contiguous_tensor_data,
+    const bool overwrite_existing) {
   const std::string path = "ObservationId" + std::to_string(observation_id);
   detail::OpenGroup observation_group(volume_data_group_.id(), path,
                                       AccessType::ReadWrite);
   h5::write_data(observation_group.id(), contiguous_tensor_data,
-                 {contiguous_tensor_data.size()}, component_name);
+                 {contiguous_tensor_data.size()}, component_name,
+                 overwrite_existing);
 }
 
 std::vector<size_t> VolumeData::list_observation_ids() const {

--- a/src/IO/H5/VolumeData.hpp
+++ b/src/IO/H5/VolumeData.hpp
@@ -122,11 +122,13 @@ class VolumeData : public h5::Object {
 
   void write_tensor_component(const size_t observation_id,
                               const std::string& component_name,
-                              const DataVector& contiguous_tensor_data);
+                              const DataVector& contiguous_tensor_data,
+                              bool overwrite_existing = false);
 
   void write_tensor_component(const size_t observation_id,
                               const std::string& component_name,
-                              const std::vector<float>& contiguous_tensor_data);
+                              const std::vector<float>& contiguous_tensor_data,
+                              bool overwrite_existing = false);
 
   /// List all the integral observation ids in the subfile
   ///

--- a/src/Visualization/Python/TransformVolumeData.py
+++ b/src/Visualization/Python/TransformVolumeData.py
@@ -443,6 +443,7 @@ def transform_volume_data(
     volfiles: Union[spectre_h5.H5Vol, Iterable[spectre_h5.H5Vol]],
     kernels: Sequence[Kernel],
     integrate: bool = False,
+    force: bool = False,
 ) -> Union[None, Dict[str, Sequence[float]]]:
     """Transforms data in the 'volfiles' with a sequence of 'kernels'
 
@@ -460,6 +461,7 @@ def transform_volume_data(
         vector named 'Shift' then this function returns integrals named
         'Shift(_x,_y,_z)'. In addition, the corresponding observation values are
         returned (named 'Time'), and the inertial volume (named 'Volume').
+      force: Overwrite existing datasets in the volume files (default: False).
 
     Returns:
       None, or the volume integrals if 'integrate' is True.
@@ -609,6 +611,7 @@ def transform_volume_data(
                                 + transformed_tensor.component_suffix(i)
                             ),
                             contiguous_tensor_data=component,
+                            overwrite_existing=force,
                         )
     if integrate:
         return integrals
@@ -719,6 +722,12 @@ def parse_kernels(kernels, exec_files, map_input_names):
     "--output-subfile",
     help="Subfile name in the '--output' / '-o' file, if it is an H5 file.",
 )
+@click.option(
+    "--force",
+    "-f",
+    is_flag=True,
+    help="Overwrite existing data.",
+)
 def transform_volume_data_command(
     h5files,
     subfile_name,
@@ -728,6 +737,7 @@ def transform_volume_data_command(
     integrate,
     output,
     output_subfile,
+    force,
     **kwargs,
 ):
     """Transform volume data with Python functions
@@ -816,7 +826,11 @@ def transform_volume_data_command(
     volfiles_progress = progress.track(volfiles, task_id=task_id)
     with progress:
         integrals = transform_volume_data(
-            volfiles_progress, kernels=kernels, integrate=integrate, **kwargs
+            volfiles_progress,
+            kernels=kernels,
+            integrate=integrate,
+            force=force,
+            **kwargs,
         )
         progress.update(task_id, completed=len(volfiles))
 

--- a/src/Visualization/Python/TransformVolumeData.py
+++ b/src/Visualization/Python/TransformVolumeData.py
@@ -781,10 +781,14 @@ def transform_volume_data_command(
 
     # Print available subfile names and exit
     if not subfile_name:
-        import rich.columns
+        available_subfile_names = open_h5_files[0].all_vol_files()
+        if len(available_subfile_names) == 1:
+            subfile_name = available_subfile_names[0]
+        else:
+            import rich.columns
 
-        rich.print(rich.columns.Columns(open_h5_files[0].all_vol_files()))
-        return
+            rich.print(rich.columns.Columns())
+            return
 
     if subfile_name.endswith(".vol"):
         subfile_name = subfile_name[:-4]

--- a/tests/Unit/IO/H5/Test_H5.cpp
+++ b/tests/Unit/IO/H5/Test_H5.cpp
@@ -61,7 +61,10 @@ void test_read_data() {
   {
     const DataVector rank1_data{1.0, 2.0, 3.0};
     const std::string dataset_name{"rank1_dataset_datavector"};
-    h5::write_data(group_id, rank1_data, dataset_name);
+    h5::write_data(group_id, DataVector{4.0, 5.0}, dataset_name);
+    CHECK_THROWS_WITH(h5::write_data(group_id, rank1_data, dataset_name),
+                      Catch::Matchers::ContainsSubstring("already exists"));
+    h5::write_data(group_id, rank1_data, dataset_name, true);
     const auto rank1_data_from_file =
         h5::read_data<1, DataVector>(group_id, dataset_name);
     CHECK(rank1_data_from_file == rank1_data);
@@ -85,11 +88,21 @@ void test_read_data() {
       tmpl::list<double, int, unsigned int, long, unsigned long, long long,
                  unsigned long long>;
 
-  h5::write_data(group_id, std::vector<double>{1.0 / 3.0}, {},
+  h5::write_data(group_id, std::vector<double>{4.0}, {},
                  "scalar_dataset");
+  CHECK_THROWS_WITH((h5::write_data(group_id, std::vector<double>{1.0 / 3.0},
+                                    {}, "scalar_dataset")),
+                    Catch::Matchers::ContainsSubstring("already exists"));
+  h5::write_data(group_id, std::vector<double>{1.0 / 3.0}, {},
+                 "scalar_dataset", true);
   CHECK(h5::read_data<0, double>(group_id, "scalar_dataset") == 1.0 / 3.0);
-  h5::write_data(group_id, std::vector<float>{1.0f / 3.0f}, {},
+  h5::write_data(group_id, std::vector<float>{4.0}, {},
                  "scalar_dataset_float");
+  CHECK_THROWS_WITH((h5::write_data(group_id, std::vector<float>{1.0f / 3.0f},
+                                    {}, "scalar_dataset_float")),
+                    Catch::Matchers::ContainsSubstring("already exists"));
+  h5::write_data(group_id, std::vector<float>{1.0f / 3.0f}, {},
+                 "scalar_dataset_float", true);
   CHECK(h5::read_data<0, float>(group_id, "scalar_dataset_float") ==
         static_cast<float>(1.0 / 3.0));
 

--- a/tests/Unit/IO/H5/Test_VolumeData.cpp
+++ b/tests/Unit/IO/H5/Test_VolumeData.cpp
@@ -216,7 +216,12 @@ void test() {
           serialize(domain_creator.functions_of_time()));
       // Write another tensor component separately
       volume_file.write_tensor_component(observation_id, "U",
-                                         extra_tensor_component);
+                                         DataType{1., 2., 3.});
+      CHECK_THROWS_WITH(volume_file.write_tensor_component(
+                            observation_id, "U", extra_tensor_component),
+                        Catch::Matchers::ContainsSubstring("already exists"));
+      volume_file.write_tensor_component(observation_id, "U",
+                                         extra_tensor_component, true);
     };
     for (size_t i = 0; i < observation_ids.size(); ++i) {
       write_to_file(observation_ids[i], observation_values[i]);

--- a/tests/Unit/Visualization/Python/Test_TransformVolumeData.py
+++ b/tests/Unit/Visualization/Python/Test_TransformVolumeData.py
@@ -122,6 +122,11 @@ class TestTransformVolumeData(unittest.TestCase):
         ]
 
         transform_volume_data(volfiles=open_volfiles, kernels=kernels)
+        with self.assertRaisesRegex(RuntimeError, "already exists"):
+            transform_volume_data(volfiles=open_volfiles, kernels=kernels)
+        transform_volume_data(
+            volfiles=open_volfiles, kernels=kernels, force=True
+        )
 
         obs_id = open_volfiles[0].list_observation_ids()[0]
         result_psisq = (


### PR DESCRIPTION
## Proposed changes

Add `--force` option to `spectre transform-vol`. Needs capability to overwrite tensor data in H5 files.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
