### PR TITLE
Add cap to Lorentz factor and temperature minimum to GhGrmhd executable

### DIFF
--- a/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
+++ b/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
@@ -111,6 +111,7 @@
 #include "Evolution/TypeTraits.hpp"
 #include "Evolution/VariableFixing/Actions.hpp"
 #include "Evolution/VariableFixing/FixToAtmosphere.hpp"
+#include "Evolution/VariableFixing/LimitLorentzFactor.hpp"
 #include "Evolution/VariableFixing/Tags.hpp"
 #include "IO/Importers/Actions/ReadVolumeData.hpp"
 #include "IO/Importers/Actions/ReceiveVolumeData.hpp"
@@ -314,6 +315,8 @@ struct GhValenciaDivCleanDefaults {
               DataVector, volume_dim, domain_frame>>>,
       VariableFixing::Actions::FixVariables<
           VariableFixing::FixToAtmosphere<volume_dim>>,
+      VariableFixing::Actions::FixVariables<
+          VariableFixing::LimitLorentzFactor>,
       Actions::UpdateConservatives,
       tmpl::conditional_t<
           UseDgSubcell,
@@ -335,6 +338,8 @@ struct GhValenciaDivCleanDefaults {
 
               VariableFixing::Actions::FixVariables<
                   VariableFixing::FixToAtmosphere<volume_dim>>,
+              VariableFixing::Actions::FixVariables<
+                  VariableFixing::LimitLorentzFactor>,
               Actions::UpdateConservatives>,
           tmpl::list<>>,
       Parallel::Actions::TerminatePhase>;
@@ -712,6 +717,8 @@ struct GhValenciaDivCleanTemplateBase<
               tmpl::front<ordered_list_of_primitive_recovery_schemes>>>,
       VariableFixing::Actions::FixVariables<
           VariableFixing::FixToAtmosphere<volume_dim>>,
+      VariableFixing::Actions::FixVariables<
+          VariableFixing::LimitLorentzFactor>,
       Actions::UpdateConservatives,
       Actions::Goto<evolution::dg::subcell::Actions::Labels::EndOfSolvers>,
 
@@ -742,6 +749,8 @@ struct GhValenciaDivCleanTemplateBase<
               ordered_list_of_primitive_recovery_schemes>>,
       VariableFixing::Actions::FixVariables<
           VariableFixing::FixToAtmosphere<volume_dim>>,
+      VariableFixing::Actions::FixVariables<
+          VariableFixing::LimitLorentzFactor>,
       Actions::UpdateConservatives,
 
       Actions::Label<evolution::dg::subcell::Actions::Labels::EndOfSolvers>>>;
@@ -811,6 +820,8 @@ struct GhValenciaDivCleanTemplateBase<
               tmpl::list<::domain::Actions::CheckFunctionsOfTimeAreReady,
                          VariableFixing::Actions::FixVariables<
                              VariableFixing::FixToAtmosphere<volume_dim>>,
+                         VariableFixing::Actions::FixVariables<
+                             VariableFixing::LimitLorentzFactor>,
                          Actions::UpdateConservatives,
                          evolution::Actions::RunEventsAndTriggers,
                          Actions::ChangeSlabSize, step_actions,

--- a/src/Evolution/VariableFixing/FixToAtmosphere.hpp
+++ b/src/Evolution/VariableFixing/FixToAtmosphere.hpp
@@ -104,8 +104,9 @@ class FixToAtmosphere {
         "below TransitionDensityCutoff."};
   };
 
-  using options = tmpl::list<DensityOfAtmosphere, DensityCutoff,
-                             TransitionDensityCutoff, MaxVelocityMagnitude>;
+  using options =
+      tmpl::list<DensityOfAtmosphere, DensityCutoff, TransitionDensityCutoff,
+                 MaxVelocityMagnitude>;
   static constexpr Options::String help = {
       "If the rest mass density is below DensityCutoff, it is set\n"
       "to DensityOfAtmosphere, and the pressure, specific internal energy\n"

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/BinaryNeutronStar.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/BinaryNeutronStar.yaml
@@ -75,6 +75,9 @@ VariableFixing:
     DensityCutoff: &density_cutoff 1.0e-12
     TransitionDensityCutoff: 1.0e-11
     MaxVelocityMagnitude: 1.0e-4
+  LimitLorentzFactor:
+    MaxDensityCutoff: 1.0e-08
+    LorentzFactorCap: 10.0
 
 EvolutionSystem:
   ValenciaDivClean:

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdBondiMichel.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdBondiMichel.yaml
@@ -76,6 +76,9 @@ VariableFixing:
     DensityCutoff: 1.0e-12
     TransitionDensityCutoff: 1.0e-11
     MaxVelocityMagnitude: 1.0e-4
+  LimitLorentzFactor:
+    MaxDensityCutoff: 1.0e-12
+    LorentzFactorCap: 1.0
 
 Limiter:
   Minmod:

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdTovStar.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdTovStar.yaml
@@ -69,6 +69,9 @@ VariableFixing:
     DensityCutoff: 1.0e-12
     TransitionDensityCutoff: 1.0e-11
     MaxVelocityMagnitude: 1.0e-4
+  LimitLorentzFactor:
+    MaxDensityCutoff: 1.0e-12
+    LorentzFactorCap: 1.0
 
 EvolutionSystem:
   ValenciaDivClean:

--- a/tests/Unit/Evolution/VariableFixing/Test_FixToAtmosphere.cpp
+++ b/tests/Unit/Evolution/VariableFixing/Test_FixToAtmosphere.cpp
@@ -37,10 +37,10 @@ void test_variable_fixer(
       density, specific_internal_energy, pressure);
 
   Scalar<DataVector> lorentz_factor{
-      DataVector{5.0 / 3.0, 1.25, 1.8898223650461359}};
+      DataVector{5.0 / 3.0, 7.0710678118654752, 1.8898223650461359}};
   auto spatial_velocity =
       make_with_value<tnsr::I<DataVector, Dim, Frame::Inertial>>(density, 0.0);
-  spatial_velocity.get(0) = DataVector{0.8, 0.6, 0.6};
+  spatial_velocity.get(0) = DataVector{0.8, 0.7, 0.6};
   auto spatial_metric =
       make_with_value<tnsr::ii<DataVector, Dim, Frame::Inertial>>(density, 0.0);
   for (size_t i = 0; i < Dim; ++i) {
@@ -58,10 +58,10 @@ void test_variable_fixer(
   auto expected_specific_enthalpy = hydro::relativistic_specific_enthalpy(
       expected_density, expected_specific_internal_energy, expected_pressure);
   Scalar<DataVector> expected_lorentz_factor{
-      DataVector{1.0, 1.25, 1.0000000001020408}};
+      DataVector{1.0, 7.0710678118654752, 1.0000000001020408}};
   auto expected_spatial_velocity =
       make_with_value<tnsr::I<DataVector, Dim, Frame::Inertial>>(density, 0.0);
-  expected_spatial_velocity.get(0)[1] = 0.6;
+  expected_spatial_velocity.get(0)[1] = 0.7;
   // The [2] component of the expected velocity is:
   //     velocity *= max_velocity_magnitude_ * (rho - rho_cut) /
   //                 (trans_rho - rho_cut) / |v^i|
@@ -90,10 +90,10 @@ void test_variable_fixer(
       density, specific_internal_energy, pressure);
 
   Scalar<DataVector> lorentz_factor{
-      DataVector{5.0 / 3.0, 1.25, 1.8898223650461359}};
+      DataVector{5.0 / 3.0, 7.0710678118654752, 1.8898223650461359}};
   auto spatial_velocity =
       make_with_value<tnsr::I<DataVector, Dim, Frame::Inertial>>(density, 0.0);
-  spatial_velocity.get(0) = DataVector{0.8, 0.6, 0.6};
+  spatial_velocity.get(0) = DataVector{0.8, 0.7, 0.6};
   auto spatial_metric =
       make_with_value<tnsr::ii<DataVector, Dim, Frame::Inertial>>(density, 0.0);
   for (size_t i = 0; i < Dim; ++i) {
@@ -111,10 +111,10 @@ void test_variable_fixer(
   auto expected_specific_enthalpy = hydro::relativistic_specific_enthalpy(
       expected_density, expected_specific_internal_energy, expected_pressure);
   Scalar<DataVector> expected_lorentz_factor{
-      DataVector{1.0, 1.25, 1.0000000001020408}};
+      DataVector{1.0, 7.0710678118654752, 1.0000000001020408}};
   auto expected_spatial_velocity =
       make_with_value<tnsr::I<DataVector, Dim, Frame::Inertial>>(density, 0.0);
-  expected_spatial_velocity.get(0)[1] = 0.6;
+  expected_spatial_velocity.get(0)[1] = 0.7;
   // The [2] component of the expected velocity is:
   //     velocity *= max_velocity_magnitude_ * (rho - rho_cut) /
   //                 (trans_rho - rho_cut) / |v^i|


### PR DESCRIPTION
## Proposed changes

Add a minimum temperature of 0 in FixToAtmosphere for 2d equations of sate
Add an upper limit to the Lorentz factor as part of the atmosphere treatment for GhValenciaDivClean (using an existing action)

### Upgrade instructions

Any input file using GhValenciaDivClean  now needs to provide options of the type
`LimitLorentzFactor:
    MaxDensityCutoff: 1.0e-08
    LorentzFactorCap: 10.0`
in VariableFixing

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

While this is not strictly required for this PR, I also made the choices of v^i and W in one of the tests self-consistent (this was causing me issues in a previous version of the PR, when I was doing Lorentz factor limiting within FixToAtmosphere)
