### PR TITLE
Add density dependent limit to magnitude of tildeS

### DIFF
--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/FixConservatives.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/FixConservatives.hpp
@@ -132,19 +132,43 @@ class FixConservatives {
     using type = double;
     static type lower_bound() { return 0.0; }
     static constexpr Options::String help = {
-        "Safety factor for momentum density bound."};
+        "Safety factor for momentum density bound above density cutoff."};
   };
+  /// \brief Cutoff in \f$\rho_0 W\f$ below which we use a stricter safety
+  /// factor for the magnitude of S.
+  struct SafetyFactorForSCutoffD {
+    using type = double;
+    static type lower_bound() { return 0.0; }
+    static constexpr Options::String help = {
+        "Below this value of rest mass density time Lorentz factor, limit S "
+        "more agressively."};
+  };
+
+  /// \brief Below SafetyFactorForSCutoffD, reduce \f$\epsilon_S\f$ by
+  /// SafetyFactorForSSlope times
+  /// \f$\log_{10}(\rho_0 W / SafetyFactorForSCutoffD)\f$
+  struct SafetyFactorForSSlope {
+    using type = double;
+    static type lower_bound() { return 0.0; }
+    static constexpr Options::String help = {
+        "Slope of safety factor for momentum density bound below "
+        "SafetyFactorForSCutoffD, express as a function of log10(rho*W)."};
+  };
+
   using options = tmpl::list<MinimumValueOfD, CutoffD, MinimumValueOfYe,
-                             CutoffYe, SafetyFactorForB, SafetyFactorForS>;
+                             CutoffYe, SafetyFactorForB, SafetyFactorForS,
+                             SafetyFactorForSCutoffD, SafetyFactorForSSlope>;
   static constexpr Options::String help = {
       "Variable fixing used in Foucart's thesis.\n"};
 
-  FixConservatives(double minimum_rest_mass_density_times_lorentz_factor,
-                   double rest_mass_density_times_lorentz_factor_cutoff,
-                   double minimum_electron_fraction,
-                   double electron_fraction_cutoff,
-                   double safety_factor_for_magnetic_field,
-                   double safety_factor_for_momentum_density,
+  FixConservatives(const double minimum_rest_mass_density_times_lorentz_factor,
+                   const double rest_mass_density_times_lorentz_factor_cutoff,
+                   const double minimum_electron_fraction,
+                   const double electron_fraction_cutoff,
+                   const double safety_factor_for_magnetic_field,
+                   const double safety_factor_for_momentum_density,
+                   const double safety_factor_for_momentum_density_cutoff_d,
+                   const double safety_factor_for_momentum_density_slope,
                    const Options::Context& context = {});
 
   FixConservatives() = default;
@@ -193,6 +217,10 @@ class FixConservatives {
   double one_minus_safety_factor_for_magnetic_field_{
       std::numeric_limits<double>::signaling_NaN()};
   double one_minus_safety_factor_for_momentum_density_{
+      std::numeric_limits<double>::signaling_NaN()};
+  double safety_factor_for_momentum_density_cutoff_d_{
+      std::numeric_limits<double>::signaling_NaN()};
+  double safety_factor_for_momentum_density_slope_{
       std::numeric_limits<double>::signaling_NaN()};
 };
 

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/BinaryNeutronStar.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/BinaryNeutronStar.yaml
@@ -70,6 +70,8 @@ VariableFixing:
     MinimumValueOfYe: 0.0
     SafetyFactorForB: 1.0e-12
     SafetyFactorForS: 1.0e-12
+    SafetyFactorForSCutoffD: 1.0e-8
+    SafetyFactorForSSlope: 0.0001
   FixToAtmosphere:
     DensityOfAtmosphere: 1.0e-12
     DensityCutoff: &density_cutoff 1.0e-12

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdBondiMichel.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdBondiMichel.yaml
@@ -71,6 +71,8 @@ VariableFixing:
     MinimumValueOfYe: 0.0
     SafetyFactorForB: 1.0e-12
     SafetyFactorForS: 1.0e-12
+    SafetyFactorForSCutoffD: 1.0e-12
+    SafetyFactorForSSlope: 0.0
   FixToAtmosphere:
     DensityOfAtmosphere: 1.0e-12
     DensityCutoff: 1.0e-12

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdTovStar.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdTovStar.yaml
@@ -64,6 +64,8 @@ VariableFixing:
     MinimumValueOfYe: 0.0
     SafetyFactorForB: 1.0e-12
     SafetyFactorForS: 1.0e-12
+    SafetyFactorForSCutoffD: 1.0e-12
+    SafetyFactorForSSlope: 0.0
   FixToAtmosphere:
     DensityOfAtmosphere: 1.0e-12
     DensityCutoff: 1.0e-12

--- a/tests/InputFiles/GrMhd/ValenciaDivClean/BlastWave.yaml
+++ b/tests/InputFiles/GrMhd/ValenciaDivClean/BlastWave.yaml
@@ -95,6 +95,8 @@ VariableFixing:
     MinimumValueOfYe: 0.0
     SafetyFactorForB: 1.0e-12
     SafetyFactorForS: 1.0e-12
+    SafetyFactorForSCutoffD: 1.0e-12
+    SafetyFactorForSSlope: 0.0
   FixToAtmosphere:
     DensityOfAtmosphere: 1.0e-12
     DensityCutoff: 1.0e-12

--- a/tests/InputFiles/GrMhd/ValenciaDivClean/FishboneMoncriefDisk.yaml
+++ b/tests/InputFiles/GrMhd/ValenciaDivClean/FishboneMoncriefDisk.yaml
@@ -104,6 +104,8 @@ VariableFixing:
     MinimumValueOfYe: 0.0
     SafetyFactorForB: 1.0e-12
     SafetyFactorForS: 1.0e-12
+    SafetyFactorForSCutoffD: 1.0e-12
+    SafetyFactorForSSlope: 0.0
   FixToAtmosphere:
     DensityOfAtmosphere: 1.0e-12
     DensityCutoff: 1.0e-12

--- a/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/Test_FixConservativesAndComputePrims.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/Test_FixConservativesAndComputePrims.cpp
@@ -48,7 +48,7 @@ SPECTRE_TEST_CASE(
       sqrt(get(determinant(spatial_metric)))};
 
   const grmhd::ValenciaDivClean::FixConservatives variable_fixer{
-      1.e-7, 1.0e-7, 1.0e-10, 1.0e-10, 0.0, 0.0};
+      1.e-7, 1.0e-7, 1.0e-10, 1.0e-10, 0.0, 0.0, 1.e-7, 0.0};
   typename System::variables_tag::type cons_vars{num_pts, 0.0};
   get(get<grmhd::ValenciaDivClean::Tags::TildeD>(cons_vars))[0] = 2.e-12;
   get(get<grmhd::ValenciaDivClean::Tags::TildeYe>(cons_vars))[0] = 2.e-13;

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_FixConservativesAndComputePrims.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_FixConservativesAndComputePrims.cpp
@@ -33,7 +33,7 @@ SPECTRE_TEST_CASE(
   }
   const Scalar<DataVector> sqrt_det_spatial_metric{num_pts, 1.0};
   const grmhd::ValenciaDivClean::FixConservatives variable_fixer{
-      1.e-7, 1.0e-7, 1.0e-10, 1.0e-10, 0.0, 0.0};
+    1.e-7, 1.0e-7, 1.0e-10, 1.0e-10, 0.0, 0.0, 1.e-7, 0.0};
   typename System::variables_tag::type cons_vars{num_pts, 0.0};
   get(get<grmhd::ValenciaDivClean::Tags::TildeD>(cons_vars))[0] = 2.e-12;
   get(get<grmhd::ValenciaDivClean::Tags::TildeYe>(cons_vars))[0] = 2.e-13;

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Test_FixConservatives.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Test_FixConservatives.cpp
@@ -82,7 +82,7 @@ void test_variable_fixer(
 SPECTRE_TEST_CASE("Unit.Evolution.GrMhd.ValenciaDivClean.FixConservatives",
                   "[VariableFixing][Unit]") {
   grmhd::ValenciaDivClean::FixConservatives variable_fixer{
-      1.e-12, 1.0e-11, 1.0e-10, 1.0e-9, 0.0, 0.0};
+      1.e-12, 1.0e-11, 1.0e-10, 1.0e-9, 0.0, 0.0, 1.e-12, 0.0};
   test_variable_fixer(variable_fixer);
   test_serialization(variable_fixer);
 
@@ -93,6 +93,8 @@ SPECTRE_TEST_CASE("Unit.Evolution.GrMhd.ValenciaDivClean.FixConservatives",
           "MinimumValueOfYe: 1.0e-10\n"
           "CutoffYe: 1.0e-9\n"
           "SafetyFactorForB: 0.0\n"
-          "SafetyFactorForS: 0.0\n");
+          "SafetyFactorForS: 0.0\n"
+          "SafetyFactorForSCutoffD: 1.0e-12\n"
+          "SafetyFactorForSSlope: 0.0\n");
   test_variable_fixer(fixer_from_options);
 }


### PR DESCRIPTION
## Proposed changes

Introduces SpEC-like limits for the magnitude of the tildeS conserved variables (momentum flux). This is needed for stability of the evolution when using 2D equations of state in BNS inspiral.
The default parameters currently in the input file for BNS are what I used in my (only) run with a 2D EoS. They are likely not optimal, but they at least worked once.
All other input files using FixConservatives have been updated so that this new option does nothing. Again, this might not be the best choice, but it should hopefully minimize changes for others.

### Upgrade instructions

All input files using ValenciaDivClean or GhValenciaDivClean executables must add the new options
`SafetyFactorForSCutoffD, SafetyFactorForSSlope`
to
`FixConservatives`

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.