### PR TITLE
Fix threadsafety of PiecewisePolynomial

### DIFF
--- a/src/Domain/FunctionsOfTime/FunctionOfTimeHelpers.cpp
+++ b/src/Domain/FunctionsOfTime/FunctionOfTimeHelpers.cpp
@@ -3,7 +3,7 @@
 
 #include "Domain/FunctionsOfTime/FunctionOfTimeHelpers.hpp"
 
-#include <deque>
+#include <list>
 #include <pup.h>
 #include <pup_stl.h>
 
@@ -59,7 +59,7 @@ void reset_expiration_time(const gsl::not_null<double*> prev_expiration_time,
 template <size_t MaxDerivPlusOne, bool StoreCoefs>
 const StoredInfo<MaxDerivPlusOne, StoreCoefs>& stored_info_from_upper_bound(
     const double t,
-    const std::deque<StoredInfo<MaxDerivPlusOne, StoreCoefs>>& all_stored_infos,
+    const std::list<StoredInfo<MaxDerivPlusOne, StoreCoefs>>& all_stored_infos,
     const size_t all_info_size) {
   // this function assumes that the times in stored_info_at_update_times is
   // sorted, which is enforced by the update function of a piecewise polynomial.
@@ -68,54 +68,32 @@ const StoredInfo<MaxDerivPlusOne, StoreCoefs>& stored_info_from_upper_bound(
   // all_stored_infos because another thread may have added an entry to
   // all_stored_infos during a call to this function.
   ASSERT(all_info_size != 0,
-         "Deque of StoredInfos you are trying to access is empty. Was it "
+         "List of StoredInfos you are trying to access is empty. Was it "
          "constructed properly?");
 
-  // We can't use iterators because when a value is inserted into a std::deque,
-  // iterators are invalidated. We need this operation to be thread-safe so we
-  // only use references which are not invalidated by insertion at either end
-  // points. Because we require that `all_stored_infos` is ordered, we can
-  // safely assume that the index 0 always points to the same StoredInfo in the
-  // deque. This implementation of std::lower_bound is taken directly from
-  // https://en.cppreference.com/w/cpp/algorithm/lower_bound, replacing all
-  // iterators with size_t for indices.
-  const size_t upper_bound_stored_info_index = [&t, &all_stored_infos,
-                                                &all_info_size]() {
-    size_t first = 0;
-    size_t step = 0;
-    size_t count = all_info_size;
-    size_t current_index = 0;
-
-    while (count > 0) {
-      current_index = first;
-      step = count / 2;
-      current_index += step;
-
-      if (all_stored_infos[current_index].time < t) {
-        first = ++current_index;
-        count -= step + 1;
-      } else {
-        count = step;
-      }
+  auto upper_bound_stored_info = all_stored_infos.begin();
+  // Linear search is faster with std::list because of expensive
+  // std::advance/distance inside std::lower_bound
+  for (size_t i = 0; i < all_info_size; i++, upper_bound_stored_info++) {
+    if (not(upper_bound_stored_info->time < t)) {
+      break;
     }
+  }
 
-    return first;
-  }();
-
-  if (upper_bound_stored_info_index == 0) {
+  if (upper_bound_stored_info == all_stored_infos.begin()) {
     // all elements of times are greater than t
     // check if t is just less than the min element by roundoff
-    if (not equal_within_roundoff(all_stored_infos[0].time, t)) {
+    if (not equal_within_roundoff(upper_bound_stored_info->time, t)) {
       ERROR("requested time " << t << " precedes earliest time "
-                              << all_stored_infos[0].time << " of times.");
+                              << upper_bound_stored_info->time << " of times.");
     }
-    return all_stored_infos[0];
+    return *upper_bound_stored_info;
   }
   // t is either greater than all elements of times
   // or t is within the range of times.
-  // In both cases, 'upper_bound_deriv_info_index' is currently one greater than
+  // In both cases, 'upper_bound_stored_info' currently points to one index past
   // the desired index.
-  return all_stored_infos[upper_bound_stored_info_index - 1];
+  return *std::prev(upper_bound_stored_info);
 }
 
 template <size_t MaxDerivPlusOne, bool StoreCoefs>
@@ -168,10 +146,10 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3, 4, 5), (true, false))
 
 #undef INSTANTIATE
 
-#define INSTANTIATE(_, data)                                                   \
-  template const StoredInfo<DIM(data), STORECOEF(data)>&                       \
-  stored_info_from_upper_bound(                                                \
-      const double, const std::deque<StoredInfo<DIM(data), STORECOEF(data)>>&, \
+#define INSTANTIATE(_, data)                                                  \
+  template const StoredInfo<DIM(data), STORECOEF(data)>&                      \
+  stored_info_from_upper_bound(                                               \
+      const double, const std::list<StoredInfo<DIM(data), STORECOEF(data)>>&, \
       const size_t);
 
 GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3, 4, 5), (true, false))

--- a/src/Domain/FunctionsOfTime/FunctionOfTimeHelpers.hpp
+++ b/src/Domain/FunctionsOfTime/FunctionOfTimeHelpers.hpp
@@ -7,8 +7,8 @@
 #pragma once
 
 #include <array>
-#include <deque>
 #include <limits>
+#include <list>
 #include <ostream>
 #include <pup.h>
 
@@ -75,7 +75,7 @@ void reset_expiration_time(const gsl::not_null<double*> prev_expiration_time,
 template <size_t MaxDerivPlusOne, bool StoreCoefs>
 const StoredInfo<MaxDerivPlusOne, StoreCoefs>& stored_info_from_upper_bound(
     const double t,
-    const std::deque<StoredInfo<MaxDerivPlusOne, StoreCoefs>>& all_stored_infos,
+    const std::list<StoredInfo<MaxDerivPlusOne, StoreCoefs>>& all_stored_infos,
     const size_t all_info_size);
 
 template <size_t MaxDerivPlusOne, bool StoreCoefs>

--- a/src/Domain/FunctionsOfTime/PiecewisePolynomial.hpp
+++ b/src/Domain/FunctionsOfTime/PiecewisePolynomial.hpp
@@ -6,8 +6,8 @@
 #include <array>
 #include <atomic>
 #include <cstddef>
-#include <deque>
 #include <limits>
+#include <list>
 #include <memory>
 #include <ostream>
 #include <pup.h>
@@ -79,13 +79,13 @@ class PiecewisePolynomial : public FunctionOfTime {
   /// Returns the domain of validity of the function,
   /// including the extrapolation region.
   std::array<double, 2> time_bounds() const override {
-    return {{deriv_info_at_update_times_[0].time, expiration_time_}};
+    return {{deriv_info_at_update_times_.front().time, expiration_time_}};
   }
 
   /// Return a const reference to the stored deriv info so external classes can
   /// read the stored times and derivatives (mostly for
   /// QuaternionFunctionOfTime).
-  const std::deque<FunctionOfTimeHelpers::StoredInfo<MaxDeriv + 1>>&
+  const std::list<FunctionOfTimeHelpers::StoredInfo<MaxDeriv + 1>>&
   get_deriv_info() const {
     return deriv_info_at_update_times_;
   }
@@ -116,8 +116,8 @@ class PiecewisePolynomial : public FunctionOfTime {
 
   // In order for this class to be used in the mutable part of the global cache,
   // deriv_info_at_update_times_ must be a data type that preserves references
-  // to elements upon insertion or resizing. A deque fits this requirement
-  std::deque<FunctionOfTimeHelpers::StoredInfo<MaxDeriv + 1>>
+  // to elements upon insertion or resizing. A std::list fits this requirement
+  std::list<FunctionOfTimeHelpers::StoredInfo<MaxDeriv + 1>>
       deriv_info_at_update_times_;
   double expiration_time_{std::numeric_limits<double>::lowest()};
   alignas(64) std::atomic_uint64_t deriv_info_size_{};

--- a/src/Domain/FunctionsOfTime/QuaternionFunctionOfTime.hpp
+++ b/src/Domain/FunctionsOfTime/QuaternionFunctionOfTime.hpp
@@ -7,8 +7,8 @@
 #include <atomic>
 #include <boost/math/quaternion.hpp>
 #include <cmath>
-#include <deque>
 #include <limits>
+#include <list>
 #include <pup.h>
 #include <string>
 
@@ -159,8 +159,8 @@ class QuaternionFunctionOfTime : public FunctionOfTime {
 
   // In order for this class to be used in the mutable part of the global cache,
   // stored_quaternions_and_times_ must be a data type that preserves references
-  // to elements upon insertion or resizing. A deque fits this requirement
-  std::deque<FunctionOfTimeHelpers::StoredInfo<1, false>>
+  // to elements upon insertion or resizing. A list fits this requirement
+  std::list<FunctionOfTimeHelpers::StoredInfo<1, false>>
       stored_quaternions_and_times_;
   alignas(64) std::atomic_uint64_t stored_quaternion_size_{};
   // Pad memory to avoid false-sharing when accessing stored_quaternion_size_
@@ -175,7 +175,7 @@ class QuaternionFunctionOfTime : public FunctionOfTime {
       gsl::not_null<boost::math::quaternion<double>*> quaternion_to_integrate,
       double t0, double t) const;
 
-  /// Updates the `std::deque<StoredInfo>` to have the same number of stored
+  /// Updates the `std::list<StoredInfo>` to have the same number of stored
   /// quaternions as the `angle_f_of_t_ptr` has stored angles. This is necessary
   /// to ensure we can solve the ODE at any time `t`
   void update_stored_info();

--- a/tests/Unit/Domain/FunctionsOfTime/Test_FunctionOfTimeHelpers.cpp
+++ b/tests/Unit/Domain/FunctionsOfTime/Test_FunctionOfTimeHelpers.cpp
@@ -4,7 +4,7 @@
 #include "Framework/TestingFramework.hpp"
 
 #include <array>
-#include <deque>
+#include <list>
 
 #include "DataStructures/DataVector.hpp"
 #include "Domain/FunctionsOfTime/FunctionOfTimeHelpers.hpp"
@@ -64,7 +64,7 @@ SPECTRE_TEST_CASE("Unit.Domain.FunctionsOfTime.FunctionOfTimeHelpers",
   {
     INFO("StoredInfo From Upper Bound");
     constexpr size_t mdp1 = 1;
-    std::deque<FunctionOfTimeHelpers::StoredInfo<mdp1>> all_stored_info{
+    std::list<FunctionOfTimeHelpers::StoredInfo<mdp1>> all_stored_info{
         FunctionOfTimeHelpers::StoredInfo<mdp1>{
             0.0, std::array<DataVector, mdp1>{DataVector{1, 0.0}}}};
     for (int t = 1; t < 10; t++) {
@@ -80,25 +80,26 @@ SPECTRE_TEST_CASE("Unit.Domain.FunctionsOfTime.FunctionOfTimeHelpers",
       const auto& upper_bound_stored_info1 =
           FunctionOfTimeHelpers::stored_info_from_upper_bound(
               4.5, all_stored_info, size);
-      CHECK(upper_bound_stored_info1 == gsl::at(all_stored_info, 4));
+      CHECK(upper_bound_stored_info1 == *std::next(all_stored_info.begin(), 4));
 
       // Test at a time
       const auto& upper_bound_stored_info2 =
           FunctionOfTimeHelpers::stored_info_from_upper_bound(
               4.0, all_stored_info, size);
-      CHECK(upper_bound_stored_info2 == gsl::at(all_stored_info, 3));
+      CHECK(upper_bound_stored_info2 == *std::next(all_stored_info.begin(), 3));
 
       // Test slightly before first time
       const auto& upper_bound_stored_info3 =
           FunctionOfTimeHelpers::stored_info_from_upper_bound(
               -1.e-15, all_stored_info, size);
-      CHECK(upper_bound_stored_info3 == gsl::at(all_stored_info, 0));
+      CHECK(upper_bound_stored_info3 == *std::next(all_stored_info.begin(), 0));
 
       // Test after all times
       const auto& upper_bound_stored_info4 =
           FunctionOfTimeHelpers::stored_info_from_upper_bound(
               12.5, all_stored_info, size);
-      CHECK(upper_bound_stored_info4 == gsl::at(all_stored_info, size - 1));
+      CHECK(upper_bound_stored_info4 ==
+            *std::next(all_stored_info.begin(), static_cast<long>(size - 1)));
     };
 
     test();
@@ -124,7 +125,7 @@ SPECTRE_TEST_CASE("Unit.Domain.FunctionsOfTime.FunctionOfTimeHelpers",
   CHECK_THROWS_WITH(
       ([]() {
         constexpr size_t mdp1 = 1;
-        std::deque<FunctionOfTimeHelpers::StoredInfo<mdp1>> all_stored_info{
+        std::list<FunctionOfTimeHelpers::StoredInfo<mdp1>> all_stored_info{
             FunctionOfTimeHelpers::StoredInfo<mdp1>{
                 0.0, std::array<DataVector, mdp1>{DataVector{1, 0.0}}}};
         for (int t = 1; t < 10; t++) {
@@ -143,13 +144,13 @@ SPECTRE_TEST_CASE("Unit.Domain.FunctionsOfTime.FunctionOfTimeHelpers",
   CHECK_THROWS_WITH(
       []() {
         constexpr size_t mdp1 = 3;
-        std::deque<FunctionOfTimeHelpers::StoredInfo<mdp1>> all_stored_info;
+        std::list<FunctionOfTimeHelpers::StoredInfo<mdp1>> all_stored_info;
 
         (void)FunctionOfTimeHelpers::stored_info_from_upper_bound(
             1.0, all_stored_info, 0);
       }(),
       Catch::Matchers::ContainsSubstring(
-          "Deque of StoredInfos you are trying to access is empty. Was "
+          "List of StoredInfos you are trying to access is empty. Was "
           "it constructed properly?"));
 #endif
 }


### PR DESCRIPTION
## Proposed changes

Turns out `std::deque` didn't satisfy our requirements for thread-safety but a `std::list` does. Also changes QuaternionFunctionOfTime as well.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
