### PR TITLE
Add classes to promote 1D and 2D EoSs to 3D EoSs

### DIFF
--- a/src/PointwiseFunctions/Hydro/EquationsOfState/Barotropic3D.cpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/Barotropic3D.cpp
@@ -1,0 +1,118 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "PointwiseFunctions/Hydro/EquationsOfState/Barotropic3D.hpp"
+
+#include <memory>
+#include <utility>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/Enthalpy.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/PolytropicFluid.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/Spectral.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+
+namespace EquationsOfState {
+
+EQUATION_OF_STATE_MEMBER_DEFINITIONS(template <typename ColdEquilEos>,
+                                     Barotropic3D<ColdEquilEos>, double, 3)
+EQUATION_OF_STATE_MEMBER_DEFINITIONS(template <typename ColdEquilEos>,
+                                     Barotropic3D<ColdEquilEos>, DataVector, 3)
+
+template <typename ColdEquilEos>
+std::unique_ptr<EquationOfState<ColdEquilEos::is_relativistic, 3>>
+Barotropic3D<ColdEquilEos>::get_clone() const {
+  auto clone = std::make_unique<Barotropic3D<ColdEquilEos>>(*this);
+  return std::unique_ptr<EquationOfState<is_relativistic, 3>>(std::move(clone));
+}
+
+template <typename ColdEquilEos>
+bool Barotropic3D<ColdEquilEos>::is_equal(
+    const EquationOfState<ColdEquilEos::is_relativistic, 3>& rhs) const {
+  const auto& derived_ptr =
+      dynamic_cast<const Barotropic3D<ColdEquilEos>* const>(&rhs);
+  return derived_ptr != nullptr and *derived_ptr == *this;
+}
+
+template <typename ColdEquilEos>
+void Barotropic3D<ColdEquilEos>::pup(PUP::er& p) {
+  EquationOfState<ColdEquilEos::is_relativistic, 3>::pup(p);
+  p | underlying_eos_;
+}
+template <typename ColdEquilEos>
+Barotropic3D<ColdEquilEos>::Barotropic3D(CkMigrateMessage* msg)
+    : EquationOfState<ColdEquilEos::is_relativistic, 3>(msg) {}
+
+template <typename ColdEquilEos>
+bool Barotropic3D<ColdEquilEos>::operator==(
+    const Barotropic3D<ColdEquilEos>& rhs) const {
+  return this->underlying_eos_ == rhs.underlying_eos_;
+}
+template <typename ColdEquilEos>
+bool Barotropic3D<ColdEquilEos>::operator!=(
+    const Barotropic3D<ColdEquilEos>& rhs) const {
+  return not(*this == rhs);
+}
+
+template <typename ColdEquilEos>
+template <class DataType>
+Scalar<DataType>
+Barotropic3D<ColdEquilEos>::pressure_from_density_and_temperature_impl(
+    const Scalar<DataType>& rest_mass_density,
+    const Scalar<DataType>& /*temperature*/,
+    const Scalar<DataType>& /*electron_fraction*/) const {
+  return underlying_eos_.pressure_from_density(rest_mass_density);
+}
+template <typename ColdEquilEos>
+template <class DataType>
+Scalar<DataType>
+Barotropic3D<ColdEquilEos>::pressure_from_density_and_energy_impl(
+    const Scalar<DataType>& rest_mass_density,
+    const Scalar<DataType>& /*specific_internal_energy*/,
+    const Scalar<DataType>& /*electron_fraction*/) const {
+  return underlying_eos_.pressure_from_density(rest_mass_density);
+}
+template <typename ColdEquilEos>
+template <class DataType>
+Scalar<DataType>
+Barotropic3D<ColdEquilEos>::temperature_from_density_and_energy_impl(
+    const Scalar<DataType>& rest_mass_density,
+    const Scalar<DataType>& /*specific_internal_energy*/,
+    const Scalar<DataType>& /*electron_fraction*/) const {
+  return make_with_value<Scalar<DataType>>(rest_mass_density, 0.0);
+}
+
+template <typename ColdEquilEos>
+template <class DataType>
+Scalar<DataType> Barotropic3D<ColdEquilEos>::
+    specific_internal_energy_from_density_and_temperature_impl(
+        const Scalar<DataType>& rest_mass_density,
+        const Scalar<DataType>& /*temperature*/,
+        const Scalar<DataType>& /*electron_fraction*/) const {
+  return underlying_eos_.specific_internal_energy_from_density(
+      rest_mass_density);
+}
+template <typename ColdEquilEos>
+template <class DataType>
+Scalar<DataType> Barotropic3D<ColdEquilEos>::
+    sound_speed_squared_from_density_and_temperature_impl(
+        const Scalar<DataType>& rest_mass_density,
+        const Scalar<DataType>& /*temperature*/,
+        const Scalar<DataType>& /*electron_fraction*/) const {
+  // We have to do this to avoid dividing by zero
+  const DataType enthalpy_density =
+      get(underlying_eos_.pressure_from_density(rest_mass_density)) +
+      (1.0 + get(underlying_eos_.specific_internal_energy_from_density(
+                 rest_mass_density))) *
+          get(rest_mass_density);
+  return Scalar<DataType>{
+      get(rest_mass_density) *
+      get(underlying_eos_.chi_from_density(rest_mass_density)) /
+      enthalpy_density};
+}
+template class Barotropic3D<EquationsOfState::PolytropicFluid<true>>;
+template class Barotropic3D<Spectral>;
+template class Barotropic3D<Enthalpy<Spectral>>;
+
+}  // namespace EquationsOfState

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/Barotropic3D.hpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/Barotropic3D.hpp
@@ -1,0 +1,175 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <boost/preprocessor/arithmetic/dec.hpp>
+#include <boost/preprocessor/arithmetic/inc.hpp>
+#include <boost/preprocessor/control/expr_iif.hpp>
+#include <boost/preprocessor/list/adt.hpp>
+#include <boost/preprocessor/repetition/for.hpp>
+#include <boost/preprocessor/repetition/repeat.hpp>
+#include <boost/preprocessor/tuple/to_list.hpp>
+#include <cstddef>
+#include <limits>
+#include <memory>
+#include <pup.h>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Options/String.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
+#include "PointwiseFunctions/Hydro/Units.hpp"
+#include "Utilities/Serialization/CharmPupable.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace EquationsOfState {
+/*!
+ * \ingroup EquationsOfStateGroup
+ * \brief A 3D equation of state representing a barotropic fluid.
+ *
+ *
+ * The equation of state takes the form
+ *
+ * \f[
+ * p = p (T, rho, Y_e) = p(0, rho, Y_e= Y_{e, \beta})
+ * \f]
+ *
+ * where \f$\rho\f$ is the rest mass density, \f$T\f$  the
+ * temperatur , and \f$Y_e\f$ is the electron fraction are not
+ * used, and therefore this evaluating this EoS at any arbtirary
+ * temeperature or electron fraction is equivalent to evaluating it at
+ * temperature 0 and in beta equalibrium
+ *
+ */
+template <typename ColdEquilEos>
+class Barotropic3D : public EquationOfState<ColdEquilEos::is_relativistic, 3> {
+ public:
+  static constexpr size_t thermodynamic_dim = 3;
+  static constexpr bool is_relativistic = ColdEquilEos::is_relativistic;
+
+  static std::string name() {
+    return "Barotropic3D(" + pretty_type::name<ColdEquilEos>() + ")";
+  }
+  static constexpr Options::String help = {
+      "An 3D EoS which is independent of electron fraction and temperature. "
+      "Contains an underlying 1D EoS which is dependent only "
+      "on rest mass density."};
+  struct UnderlyingEos {
+    using type = ColdEquilEos;
+    static std::string name() {
+      return pretty_type::short_name<ColdEquilEos>();
+    }
+    static constexpr Options::String help{
+        "The underlying Eos which is being represented as a "
+        "3D Eos.  Must be a 1D EoS"};
+  };
+
+  using options = tmpl::list<UnderlyingEos>;
+
+  Barotropic3D() = default;
+  Barotropic3D(const Barotropic3D&) = default;
+  Barotropic3D& operator=(const Barotropic3D&) = default;
+  Barotropic3D(Barotropic3D&&) = default;
+  Barotropic3D& operator=(Barotropic3D&&) = default;
+  ~Barotropic3D() override = default;
+
+  explicit Barotropic3D(const ColdEquilEos& underlying_eos)
+      : underlying_eos_(underlying_eos){};
+
+  EQUATION_OF_STATE_FORWARD_DECLARE_MEMBERS(Barotropic3D, 3)
+
+  std::unique_ptr<EquationOfState<ColdEquilEos::is_relativistic, 3>> get_clone()
+      const override;
+
+  bool is_equal(const EquationOfState<ColdEquilEos::is_relativistic, 3>& rhs)
+      const override;
+
+  bool operator==(const Barotropic3D<ColdEquilEos>& rhs) const;
+
+  bool operator!=(const Barotropic3D<ColdEquilEos>& rhs) const;
+  /// @{
+  /*!
+   * Computes the electron fraction in beta-equilibrium \f$Y_e^{\rm eq}\f$ from
+   * the rest mass density \f$\rho\f$ and the temperature \f$T\f$.
+   */
+  Scalar<double> equilibrium_electron_fraction_from_density_temperature(
+      const Scalar<double>& rest_mass_density,
+      const Scalar<double>& temperature) const {
+    return underlying_eos_
+        .equilibrium_electron_fraction_from_density_temperature(
+            rest_mass_density, temperature);
+  }
+
+  Scalar<DataVector> equilibrium_electron_fraction_from_density_temperature(
+      const Scalar<DataVector>& rest_mass_density,
+      const Scalar<DataVector>& temperature) const {
+    return underlying_eos_
+        .equilibrium_electron_fraction_from_density_temperature(
+            rest_mass_density, temperature);
+  }
+  /// @}
+  //
+
+  WRAPPED_PUPable_decl_base_template(  // NOLINT
+      SINGLE_ARG(EquationOfState<ColdEquilEos::is_relativistic, 3>),
+      Barotropic3D);
+
+  /// The lower bound of the electron fraction that is valid for this EOS
+  double electron_fraction_lower_bound() const override { return 0.0; }
+
+  /// The upper bound of the electron fraction that is valid for this EOS
+  double electron_fraction_upper_bound() const override { return 1.0; }
+
+  /// The lower bound of the rest mass density that is valid for this EOS
+  double rest_mass_density_lower_bound() const override {
+    return underlying_eos_.rest_mass_density_lower_bound();
+  }
+
+  /// The upper bound of the rest mass density that is valid for this EOS
+  double rest_mass_density_upper_bound() const override {
+    return underlying_eos_.rest_mass_density_upper_bound();
+  }
+
+  /// The lower bound of the temperature that is valid for this EOS
+  double temperature_lower_bound() const override { return 0.0; }
+
+  /// The upper bound of the temperature that is valid for this EOS
+  double temperature_upper_bound() const override {
+    return std::numeric_limits<double>::max();
+  }
+
+  /// The lower bound of the specific internal energy that is valid for this EOS
+  /// at the given rest mass density \f$\rho\f$ and electron fraction \f$Y_e\f$
+  double specific_internal_energy_lower_bound(
+      const double rest_mass_density,
+      const double /*electron_fraction*/) const override {
+    return underlying_eos_.specific_internal_energy_lower_bound(
+        rest_mass_density);
+  }
+
+  /// The upper bound of the specific internal energy that is valid for this EOS
+  /// at the given rest mass density \f$\rho\f$
+  double specific_internal_energy_upper_bound(
+      const double rest_mass_density,
+      const double /*electron_fraction*/) const override {
+    return underlying_eos_.specific_internal_energy_upper_bound(
+        rest_mass_density);
+  }
+
+  /// The lower bound of the specific enthalpy that is valid for this EOS
+  double specific_enthalpy_lower_bound() const override {
+    return underlying_eos_.specific_enthalpy_lower_bound();
+  }
+
+  /// The baryon mass for this EoS
+  double baryon_mass() const override { return underlying_eos_.baryon_mass(); }
+
+ private:
+  EQUATION_OF_STATE_FORWARD_DECLARE_MEMBER_IMPLS(3)
+  ColdEquilEos underlying_eos_;
+};
+/// \cond
+template <typename ColdEquilEos>
+PUP::able::PUP_ID EquationsOfState::Barotropic3D<ColdEquilEos>::my_PUP_ID = 0;
+/// \endcond
+}  // namespace EquationsOfState

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/CMakeLists.txt
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/CMakeLists.txt
@@ -4,8 +4,10 @@
 spectre_target_sources(
   ${LIBRARY}
   PRIVATE
+  Barotropic3D.cpp
   DarkEnergyFluid.cpp
   Enthalpy.cpp
+  Equilibrium3D.cpp
   HybridEos.cpp
   IdealFluid.cpp
   PiecewisePolytropicFluid.cpp
@@ -19,8 +21,10 @@ spectre_target_headers(
   ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
+  Barotropic3D.hpp
   DarkEnergyFluid.hpp
   Enthalpy.hpp
+  Equilibrium3D.hpp
   EquationOfState.hpp
   Factory.hpp
   HybridEos.hpp

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/Equilibrium3D.cpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/Equilibrium3D.cpp
@@ -1,0 +1,132 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "PointwiseFunctions/Hydro/EquationsOfState/Equilibrium3D.hpp"
+
+#include <memory>
+#include <utility>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/Enthalpy.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/HybridEos.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/PolytropicFluid.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/Spectral.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+
+namespace EquationsOfState {
+
+EQUATION_OF_STATE_MEMBER_DEFINITIONS(template <typename EquilEos>,
+                                     Equilibrium3D<EquilEos>, double, 3)
+EQUATION_OF_STATE_MEMBER_DEFINITIONS(template <typename EquilEos>,
+                                     Equilibrium3D<EquilEos>, DataVector, 3)
+template <typename EquilEos>
+void Equilibrium3D<EquilEos>::pup(PUP::er& p) {
+  EquationOfState<EquilEos::is_relativistic, 3>::pup(p);
+  p | underlying_eos_;
+}
+template <typename EquilEos>
+Equilibrium3D<EquilEos>::Equilibrium3D(CkMigrateMessage* msg)
+    : EquationOfState<EquilEos::is_relativistic, 3>(msg) {}
+
+template <typename EquilEos>
+std::unique_ptr<EquationOfState<EquilEos::is_relativistic, 3>>
+Equilibrium3D<EquilEos>::get_clone() const {
+  auto clone = std::make_unique<Equilibrium3D<EquilEos>>(*this);
+  return std::unique_ptr<EquationOfState<is_relativistic, 3>>(std::move(clone));
+}
+
+template <typename EquilEos>
+bool Equilibrium3D<EquilEos>::is_equal(
+    const EquationOfState<EquilEos::is_relativistic, 3>& rhs) const {
+  const auto& derived_ptr =
+      dynamic_cast<const Equilibrium3D<EquilEos>* const>(&rhs);
+  return derived_ptr != nullptr and *derived_ptr == *this;
+}
+
+template <typename EquilEos>
+bool Equilibrium3D<EquilEos>::operator==(
+    const Equilibrium3D<EquilEos>& rhs) const {
+  return this->underlying_eos_ == rhs.underlying_eos_;
+}
+template <typename EquilEos>
+bool Equilibrium3D<EquilEos>::operator!=(
+    const Equilibrium3D<EquilEos>& rhs) const {
+  return !(*this == rhs);
+}
+
+template <typename EquilEos>
+template <class DataType>
+Scalar<DataType>
+Equilibrium3D<EquilEos>::pressure_from_density_and_temperature_impl(
+    const Scalar<DataType>& rest_mass_density,
+    const Scalar<DataType>& temperature,
+    const Scalar<DataType>& /*electron_fraction*/) const {
+  return underlying_eos_.pressure_from_density_and_energy(
+      rest_mass_density,
+      underlying_eos_.specific_internal_energy_from_density_and_temperature(
+          rest_mass_density, temperature));
+}
+template <typename EquilEos>
+template <class DataType>
+Scalar<DataType> Equilibrium3D<EquilEos>::pressure_from_density_and_energy_impl(
+    const Scalar<DataType>& rest_mass_density,
+    const Scalar<DataType>& specific_internal_energy,
+    const Scalar<DataType>& /*electron_fraction*/) const {
+  return underlying_eos_.pressure_from_density_and_energy(
+      rest_mass_density, specific_internal_energy);
+}
+template <typename EquilEos>
+template <class DataType>
+Scalar<DataType>
+Equilibrium3D<EquilEos>::temperature_from_density_and_energy_impl(
+    const Scalar<DataType>& rest_mass_density,
+    const Scalar<DataType>& specific_internal_energy,
+    const Scalar<DataType>& /*electron_fraction*/) const {
+  return underlying_eos_.temperature_from_density_and_energy(
+      rest_mass_density, specific_internal_energy);
+}
+
+template <typename EquilEos>
+template <class DataType>
+Scalar<DataType> Equilibrium3D<EquilEos>::
+    specific_internal_energy_from_density_and_temperature_impl(
+        const Scalar<DataType>& rest_mass_density,
+        const Scalar<DataType>& temperature,
+        const Scalar<DataType>& /*electron_fraction*/) const {
+  return underlying_eos_.specific_internal_energy_from_density_and_temperature(
+      rest_mass_density, temperature);
+}
+
+template <typename EquilEos>
+template <class DataType>
+Scalar<DataType>
+Equilibrium3D<EquilEos>::sound_speed_squared_from_density_and_temperature_impl(
+    const Scalar<DataType>& rest_mass_density,
+    const Scalar<DataType>& temperature,
+    const Scalar<DataType>& /*electron_fraction*/) const {
+  const Scalar<DataType> specific_internal_energy =
+      underlying_eos_.specific_internal_energy_from_density_and_temperature(
+          rest_mass_density, temperature);
+  const DataType pressure =
+      get(underlying_eos_.pressure_from_density_and_energy(
+          rest_mass_density, specific_internal_energy));
+  const DataType enthalpy_density =
+      pressure + (1.0 + get(specific_internal_energy)) * get(rest_mass_density);
+  // Cold part plus temperature dependent part, see the 3D EoS documentation for
+  // expression.
+  return Scalar<DataType>{
+      get(rest_mass_density) *
+          get(underlying_eos_.chi_from_density_and_energy(
+              rest_mass_density, specific_internal_energy)) /
+          enthalpy_density +
+      get(rest_mass_density) / pressure *
+          get(underlying_eos_
+                  .kappa_times_p_over_rho_squared_from_density_and_energy(
+                      rest_mass_density, specific_internal_energy))};
+}
+
+template class Equilibrium3D<HybridEos<PolytropicFluid<true>>>;
+template class Equilibrium3D<HybridEos<Spectral>>;
+template class Equilibrium3D<HybridEos<Enthalpy<Spectral>>>;
+}  // namespace EquationsOfState

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/Equilibrium3D.hpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/Equilibrium3D.hpp
@@ -1,0 +1,174 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <boost/preprocessor/arithmetic/dec.hpp>
+#include <boost/preprocessor/arithmetic/inc.hpp>
+#include <boost/preprocessor/control/expr_iif.hpp>
+#include <boost/preprocessor/list/adt.hpp>
+#include <boost/preprocessor/repetition/for.hpp>
+#include <boost/preprocessor/repetition/repeat.hpp>
+#include <boost/preprocessor/tuple/to_list.hpp>
+#include <cstddef>
+#include <limits>
+#include <memory>
+#include <pup.h>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Options/String.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
+#include "PointwiseFunctions/Hydro/Units.hpp"
+#include "Utilities/Serialization/CharmPupable.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace EquationsOfState {
+/*!
+ * \ingroup EquationsOfStateGroup
+ * \brief A 3D equation of state representing a fluid in compositional
+ * equalibrium.
+ *
+ *
+ * The equation of state takes the form
+ *
+ * \f[
+ * p = p (T, rho, Y_e) = p(T, rho, Y_e= Y_{e, \beta})
+ * \f]
+ *
+ * where \f$\rho\f$ is the rest mass density and  \f$T\f$ is the
+ * temperaturee;   \f$Y_e\f$  the electron fraction,  is not
+ * used, and therefore this evaluating this EoS at any arbtirary
+ * electron fraction is equivalent to evaluating it  in beta equalibrium
+ *
+ */
+template <typename EquilEos>
+class Equilibrium3D : public EquationOfState<EquilEos::is_relativistic, 3> {
+ public:
+  static constexpr size_t thermodynamic_dim = 3;
+  static constexpr bool is_relativistic = EquilEos::is_relativistic;
+  static std::string name() {
+    return "Equilibrium3D(" + pretty_type::name<EquilEos>() + ")";
+  }
+  static constexpr Options::String help = {
+      "An 3D EoS which is independent of electron fraction. "
+      "Contains an underlying 2D EoS which is dependent only "
+      "on rest mass density and temperature/internal energy."};
+
+  struct UnderlyingEos {
+    using type = EquilEos;
+    static std::string name() { return pretty_type::short_name<EquilEos>(); }
+    static constexpr Options::String help{
+        "The underlying Eos which is being represented as a "
+        "3D Eos.  Must be a 2D EoS"};
+  };
+
+  using options = tmpl::list<UnderlyingEos>;
+
+  Equilibrium3D() = default;
+  Equilibrium3D(const Equilibrium3D&) = default;
+  Equilibrium3D& operator=(const Equilibrium3D&) = default;
+  Equilibrium3D(Equilibrium3D&&) = default;
+  Equilibrium3D& operator=(Equilibrium3D&&) = default;
+  ~Equilibrium3D() override = default;
+
+  explicit Equilibrium3D(const EquilEos& underlying_eos)
+      : underlying_eos_(underlying_eos){};
+
+  EQUATION_OF_STATE_FORWARD_DECLARE_MEMBERS(Equilibrium3D, 3)
+
+  std::unique_ptr<EquationOfState<EquilEos::is_relativistic, 3>> get_clone()
+      const override;
+
+  bool is_equal(
+      const EquationOfState<EquilEos::is_relativistic, 3>& rhs) const override;
+
+  bool operator==(const Equilibrium3D<EquilEos>& rhs) const;
+
+  bool operator!=(const Equilibrium3D<EquilEos>& rhs) const;
+  /// @{
+  /*!
+   * Computes the electron fraction in beta-equilibrium \f$Y_e^{\rm eq}\f$ from
+   * the rest mass density \f$\rho\f$ and the temperature \f$T\f$.
+   */
+  Scalar<double> equilibrium_electron_fraction_from_density_temperature(
+      const Scalar<double>& rest_mass_density,
+      const Scalar<double>& temperature) const {
+    return underlying_eos_
+        .equilibrium_electron_fraction_from_density_temperature(
+            rest_mass_density, temperature);
+  }
+
+  Scalar<DataVector> equilibrium_electron_fraction_from_density_temperature(
+      const Scalar<DataVector>& rest_mass_density,
+      const Scalar<DataVector>& temperature) const {
+    return underlying_eos_
+        .equilibrium_electron_fraction_from_density_temperature(
+            rest_mass_density, temperature);
+  }
+  /// @}
+  //
+
+  WRAPPED_PUPable_decl_base_template(  // NOLINT
+      SINGLE_ARG(EquationOfState<EquilEos::is_relativistic, 3>), Equilibrium3D);
+
+  /// The lower bound of the electron fraction that is valid for this EOS
+  double electron_fraction_lower_bound() const override { return 0.0; }
+
+  /// The upper bound of the electron fraction that is valid for this EOS
+  double electron_fraction_upper_bound() const override { return 1.0; }
+
+  /// The lower bound of the rest mass density that is valid for this EOS
+  double rest_mass_density_lower_bound() const override {
+    return underlying_eos_.rest_mass_density_lower_bound();
+  }
+
+  /// The upper bound of the rest mass density that is valid for this EOS
+  double rest_mass_density_upper_bound() const override {
+    return underlying_eos_.rest_mass_density_upper_bound();
+  }
+
+  /// The lower bound of the temperature that is valid for this EOS
+  double temperature_lower_bound() const override {
+    return underlying_eos_.temperature_lower_bound();
+  }
+
+  /// The upper bound of the temperature that is valid for this EOS
+  double temperature_upper_bound() const override {
+    return underlying_eos_.temperature_upper_bound();
+  }
+
+  /// The lower bound of the specific internal energy that is valid for this EOS
+  /// at the given rest mass density \f$\rho\f$ and electron fraction \f$Y_e\f$
+  double specific_internal_energy_lower_bound(
+      const double rest_mass_density,
+      const double /*electron_fraction*/) const override {
+    return underlying_eos_.specific_internal_energy_lower_bound(
+        rest_mass_density);
+  }
+
+  /// The upper bound of the specific internal energy that is valid for this EOS
+  /// at the given rest mass density \f$\rho\f$
+  double specific_internal_energy_upper_bound(
+      const double rest_mass_density,
+      const double /*electron_fraction*/) const override {
+    return underlying_eos_.specific_internal_energy_upper_bound(
+        rest_mass_density);
+  }
+
+  /// The lower bound of the specific enthalpy that is valid for this EOS
+  double specific_enthalpy_lower_bound() const override {
+    return underlying_eos_.specific_enthalpy_lower_bound();
+  }
+
+  /// The baryon mass for this EoS
+  double baryon_mass() const override { return underlying_eos_.baryon_mass(); }
+
+ private:
+  EQUATION_OF_STATE_FORWARD_DECLARE_MEMBER_IMPLS(3)
+  EquilEos underlying_eos_;
+};
+/// \cond
+template <typename EquilEos>
+PUP::able::PUP_ID EquationsOfState::Equilibrium3D<EquilEos>::my_PUP_ID = 0;
+/// \endcond
+}  // namespace EquationsOfState

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/Factory.hpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/Factory.hpp
@@ -3,12 +3,14 @@
 
 #pragma once
 
+#include "PointwiseFunctions/Hydro/EquationsOfState/Barotropic3D.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/DarkEnergyFluid.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/Enthalpy.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/Equilibrium3D.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/HybridEos.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/IdealFluid.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/PiecewisePolytropicFluid.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/PolytropicFluid.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/Spectral.hpp"
-
+#include "PointwiseFunctions/Hydro/EquationsOfState/Tabulated3d.hpp"

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/HybridEos.cpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/HybridEos.cpp
@@ -7,6 +7,8 @@
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "PointwiseFunctions//Hydro/EquationsOfState/Enthalpy.hpp"
+#include "PointwiseFunctions//Hydro/EquationsOfState/Spectral.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/PolytropicFluid.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 
@@ -176,3 +178,6 @@ template class EquationsOfState::HybridEos<
     EquationsOfState::PolytropicFluid<true>>;
 template class EquationsOfState::HybridEos<
     EquationsOfState::PolytropicFluid<false>>;
+template class EquationsOfState::HybridEos<EquationsOfState::Spectral>;
+template class EquationsOfState::HybridEos<
+    EquationsOfState::Enthalpy<EquationsOfState::Spectral>>;

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/HybridEos.hpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/HybridEos.hpp
@@ -60,6 +60,9 @@ class HybridEos
   struct ColdEos {
     using type = ColdEquationOfState;
     static constexpr Options::String help = {"Cold equation of state"};
+    static std::string name() {
+      return pretty_type::short_name<ColdEquationOfState>();
+    }
   };
 
   struct ThermalAdiabaticIndex {
@@ -101,6 +104,10 @@ class HybridEos
   bool operator!=(const HybridEos<ColdEquationOfState>& rhs) const;
 
   bool is_equal(const EquationOfState<is_relativistic, 2>& rhs) const override;
+
+  static std::string name() {
+    return "HybridEos(" + pretty_type::name<ColdEquationOfState>() + ")";
+  }
 
   /// The lower bound of the rest mass density that is valid for this EOS
   double rest_mass_density_lower_bound() const override {

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/RegisterDerivedWithCharm.cpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/RegisterDerivedWithCharm.cpp
@@ -23,5 +23,7 @@ void register_derived_with_charm() {
   register_derived_subset_with_charm<false, 1>();
   register_derived_subset_with_charm<true, 2>();
   register_derived_subset_with_charm<false, 2>();
+  register_derived_subset_with_charm<true, 3>();
+  register_derived_subset_with_charm<false, 3>();
 }
 }  // namespace EquationsOfState

--- a/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/CMakeLists.txt
@@ -4,8 +4,10 @@
 set(LIBRARY "Test_EquationsOfState")
 
 set(LIBRARY_SOURCES
+  Test_Barotropic3D.cpp
   Test_DarkEnergyFluid.cpp
   Test_Enthalpy.cpp
+  Test_Equilibrium3D.cpp
   Test_HybridEos.cpp
   Test_IdealFluid.cpp
   Test_PiecewisePolytropicFluid.cpp

--- a/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_Barotropic3D.cpp
+++ b/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_Barotropic3D.cpp
@@ -1,0 +1,121 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <limits>
+#include <pup.h>
+#include <random>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/PointwiseFunctions/Hydro/EquationsOfState/TestHelpers.hpp"
+#include "Informer/InfoFromBuild.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/Barotropic3D.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/Factory.hpp"
+#include "Utilities/Serialization/RegisterDerivedClassesWithCharm.hpp"
+
+SPECTRE_TEST_CASE("Unit.PointwiseFunctions.EquationsOfState.Barotropic3D",
+                  "[Unit][EquationsOfState]") {
+  namespace EoS = EquationsOfState;
+  const EoS::PolytropicFluid<true> underlying_eos{100.0, 2.0};
+  EoS::Barotropic3D<EoS::PolytropicFluid<true>> eos{underlying_eos};
+  CHECK(eos.rest_mass_density_lower_bound() ==
+        underlying_eos.rest_mass_density_lower_bound());
+  CHECK(eos.rest_mass_density_upper_bound() ==
+        underlying_eos.rest_mass_density_upper_bound());
+  CHECK(eos.electron_fraction_lower_bound() == 0.0);
+  CHECK(eos.electron_fraction_upper_bound() == 1.0);
+  CHECK(eos.temperature_lower_bound() == 0.0);
+  CHECK(eos.temperature_upper_bound() == std::numeric_limits<double>::max());
+  {
+    // DataVector functions
+    const Scalar<DataVector> rest_mass_density{
+        DataVector{1e-10, 1e-6, 1e-4, 1e-3, 1e-2, 1.0}};
+    // temperature and electron fraction should be irrelevant
+    const Scalar<DataVector> electron_fraction{
+        DataVector{1e-10, 1e-6, 1e-4, 1e-3, 1e-2, 1.0}};
+    const Scalar<DataVector> temperature{
+        DataVector{1e-10, 1e-6, 1e-4, 1e-3, 1e-2, 1.0}};
+    const Scalar<DataVector> specific_internal_energy =
+        underlying_eos.specific_internal_energy_from_density(rest_mass_density);
+    const Scalar<DataVector> pressure =
+        underlying_eos.pressure_from_density(rest_mass_density);
+    CHECK(eos.pressure_from_density_and_temperature(
+              rest_mass_density, temperature, electron_fraction) == pressure);
+    CHECK(eos.pressure_from_density_and_energy(
+              rest_mass_density, specific_internal_energy, electron_fraction) ==
+          underlying_eos.pressure_from_density(rest_mass_density));
+    // The energy is independent of energy, so this is a garabage value, but it
+    // is taken to be zero
+    CHECK(eos.temperature_from_density_and_energy(
+              rest_mass_density, specific_internal_energy, electron_fraction) ==
+          make_with_value<Scalar<DataVector>>(rest_mass_density, 0.0));
+    DataVector enthalpy_density =
+        get(rest_mass_density) * (1.0 + get(specific_internal_energy)) +
+        get(pressure);
+    CHECK(eos.sound_speed_squared_from_density_and_temperature(
+              rest_mass_density, temperature, electron_fraction) ==
+          Scalar<DataVector>{
+              get(rest_mass_density) *
+              get(underlying_eos.chi_from_density(rest_mass_density)) /
+              enthalpy_density});
+  }
+
+  {
+    // double functions
+    const Scalar<double> rest_mass_density{{1e-10}};
+    // temperature and electron fraction should be irrelevant
+    const Scalar<double> electron_fraction{{1e-10}};
+    const Scalar<double> temperature{{1e-10}};
+    const Scalar<double> specific_internal_energy =
+        underlying_eos.specific_internal_energy_from_density(rest_mass_density);
+    const Scalar<double> pressure =
+        underlying_eos.pressure_from_density(rest_mass_density);
+    CHECK(eos.pressure_from_density_and_temperature(
+              rest_mass_density, temperature, electron_fraction) == pressure);
+    CHECK(eos.pressure_from_density_and_energy(
+              rest_mass_density, specific_internal_energy, electron_fraction) ==
+          underlying_eos.pressure_from_density(rest_mass_density));
+    // The energy is independent of energy, so this is a garabage value, but it
+    // is taken to be zero
+    CHECK(eos.temperature_from_density_and_energy(
+              rest_mass_density, specific_internal_energy, electron_fraction) ==
+          make_with_value<Scalar<double>>(rest_mass_density, 0.0));
+    double enthalpy_density =
+        get(rest_mass_density) * (1.0 + get(specific_internal_energy)) +
+        get(pressure);
+    CHECK(
+        eos.sound_speed_squared_from_density_and_temperature(
+            rest_mass_density, temperature, electron_fraction) ==
+        Scalar<double>{get(rest_mass_density) *
+                       get(underlying_eos.chi_from_density(rest_mass_density)) /
+                       enthalpy_density});
+  }
+  {
+    register_derived_classes_with_charm<EoS::EquationOfState<true, 3>>();
+    register_derived_classes_with_charm<EoS::EquationOfState<true, 1>>();
+    const auto eos_pointer = serialize_and_deserialize(
+        TestHelpers::test_creation<
+            std::unique_ptr<EoS::EquationOfState<true, 3>>>(
+            {"Barotropic3D(PolytropicFluid):\n"
+             "  PolytropicFluid:\n"
+             "    PolytropicConstant: 100.0\n"
+             "    PolytropicExponent: 2.0"}));
+    const EoS::Barotropic3D<EoS::PolytropicFluid<true>>& deserialized_eos =
+        dynamic_cast<const EoS::Barotropic3D<EoS::PolytropicFluid<true>>&>(
+            *eos_pointer);
+    TestHelpers::EquationsOfState::test_get_clone(deserialized_eos);
+
+    CHECK(eos == deserialized_eos);
+    CHECK(eos != EoS::Barotropic3D<EoS::PolytropicFluid<true>>{
+                     EoS::PolytropicFluid<true>(10.0, 2.0)});
+    CHECK(eos != EoS::Barotropic3D<EoS::PolytropicFluid<true>>{
+                     EoS::PolytropicFluid<true>(100.0, 1.0)});
+    CHECK(not eos.is_equal(EoS::Barotropic3D<EoS::Spectral>{
+        EoS::Spectral(1e-5, 1e-4, {2.0, 0.0, 0.0}, 1e-2)}));
+  }
+}

--- a/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_Equilibrium3D.cpp
+++ b/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_Equilibrium3D.cpp
@@ -1,0 +1,194 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <limits>
+#include <pup.h>
+#include <random>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/PointwiseFunctions/Hydro/EquationsOfState/TestHelpers.hpp"
+#include "Informer/InfoFromBuild.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/Equilibrium3D.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/Factory.hpp"
+#include "Utilities/Serialization/RegisterDerivedClassesWithCharm.hpp"
+
+
+SPECTRE_TEST_CASE("Unit.PointwiseFunctions.EquationsOfState.Equilibrium3D",
+                  "[Unit][EquationsOfState]") {
+  namespace EoS = EquationsOfState;
+  const EoS::PolytropicFluid<true> cold_eos{100.0, 2.0};
+  const EoS::HybridEos<EoS::PolytropicFluid<true>> underlying_eos{cold_eos,
+                                                                  2.0};
+  EoS::Equilibrium3D<EoS::HybridEos<EoS::PolytropicFluid<true>>> eos{
+      underlying_eos};
+  CHECK(eos.rest_mass_density_lower_bound() ==
+        underlying_eos.rest_mass_density_lower_bound());
+  CHECK(eos.rest_mass_density_upper_bound() ==
+        underlying_eos.rest_mass_density_upper_bound());
+  CHECK(eos.electron_fraction_lower_bound() == 0.0);
+  CHECK(eos.electron_fraction_upper_bound() == 1.0);
+  CHECK(eos.specific_enthalpy_lower_bound() ==
+        underlying_eos.specific_enthalpy_lower_bound());
+
+  {
+    const double rest_mass_density = 1e-3;
+    const double electron_fraction = 0.1;
+    const double underlying_specific_energy_lower_bound =
+        underlying_eos.specific_internal_energy_lower_bound(rest_mass_density);
+    const double underlying_specific_energy_upper_bound =
+        underlying_eos.specific_internal_energy_upper_bound(rest_mass_density);
+    CHECK(eos.specific_internal_energy_lower_bound(rest_mass_density,
+                                                   electron_fraction) ==
+          underlying_specific_energy_lower_bound);
+    CHECK(eos.specific_internal_energy_upper_bound(rest_mass_density,
+                                                   electron_fraction) ==
+          underlying_specific_energy_upper_bound);
+    CHECK(eos.temperature_lower_bound() ==
+          underlying_eos.temperature_lower_bound());
+    CHECK(eos.temperature_upper_bound() ==
+          underlying_eos.temperature_upper_bound());
+  }
+  {
+    // DataVector functions
+    const Scalar<DataVector> rest_mass_density{
+        DataVector{1e-10, 1e-6, 1e-4, 1e-3, 1e-2, 1.0}};
+    // electron fraction should be irrelevant
+    const Scalar<DataVector> electron_fraction{
+        DataVector{1e-10, 1e-6, 1e-4, 1e-3, 1e-2, 1.0}};
+    const Scalar<DataVector> temperature{
+        DataVector{1e-10, 1e-6, 1e-4, 1e-3, 1e-2, 1.0}};
+    const Scalar<DataVector> specific_internal_energy =
+        underlying_eos.specific_internal_energy_from_density_and_temperature(
+            rest_mass_density, temperature);
+    const Scalar<DataVector> pressure =
+        underlying_eos.pressure_from_density_and_energy(
+            rest_mass_density, specific_internal_energy);
+    CHECK(eos.pressure_from_density_and_temperature(
+              rest_mass_density, temperature, electron_fraction) == pressure);
+    CHECK(eos.pressure_from_density_and_energy(
+              rest_mass_density, specific_internal_energy, electron_fraction) ==
+          underlying_eos.pressure_from_density_and_energy(
+              rest_mass_density, specific_internal_energy));
+    CHECK_ITERABLE_APPROX(
+        eos.pressure_from_density_and_energy(
+            rest_mass_density, specific_internal_energy, electron_fraction),
+        pressure);
+    CHECK_ITERABLE_APPROX(
+        eos.temperature_from_density_and_energy(
+            rest_mass_density, specific_internal_energy, electron_fraction),
+        temperature);
+    const DataVector enthalpy_density =
+        get(rest_mass_density) * (1.0 + get(specific_internal_energy)) +
+        get(pressure);
+    CHECK(
+        get(eos.sound_speed_squared_from_density_and_temperature(
+            rest_mass_density, temperature, electron_fraction)) ==
+        get(rest_mass_density) *
+                get(underlying_eos.chi_from_density_and_energy(
+                    rest_mass_density, specific_internal_energy)) /
+                enthalpy_density +
+            get(rest_mass_density) / get(pressure) *
+                get(underlying_eos
+                        .kappa_times_p_over_rho_squared_from_density_and_energy(
+                            rest_mass_density, specific_internal_energy)));
+  }
+
+  {
+    // double functions
+    const Scalar<double> rest_mass_density{{1e-3}};
+    // temperature and electron fraction should be irrelevant
+    const Scalar<double> electron_fraction{{1e-1}};
+    const Scalar<double> temperature{{1e-1}};
+    const Scalar<double> specific_internal_energy =
+        underlying_eos.specific_internal_energy_from_density_and_temperature(
+            rest_mass_density, temperature);
+    const Scalar<double> pressure =
+        underlying_eos.pressure_from_density_and_energy(
+            rest_mass_density, specific_internal_energy);
+    CHECK(eos.pressure_from_density_and_temperature(
+              rest_mass_density, temperature, electron_fraction) == pressure);
+    CHECK(eos.pressure_from_density_and_energy(
+              rest_mass_density, specific_internal_energy, electron_fraction) ==
+          underlying_eos.pressure_from_density_and_energy(
+              rest_mass_density, specific_internal_energy));
+    CHECK(eos.temperature_from_density_and_energy(
+              rest_mass_density, specific_internal_energy, electron_fraction) ==
+          underlying_eos.temperature_from_density_and_energy(
+              rest_mass_density, specific_internal_energy));
+    const double enthalpy_density =
+        get(rest_mass_density) * (1.0 + get(specific_internal_energy)) +
+        get(pressure);
+    CHECK(
+        get(eos.sound_speed_squared_from_density_and_temperature(
+            rest_mass_density, temperature, electron_fraction)) ==
+        get(rest_mass_density) *
+                get(underlying_eos.chi_from_density_and_energy(
+                    rest_mass_density, specific_internal_energy)) /
+                enthalpy_density +
+            get(rest_mass_density) / get(pressure) *
+                get(underlying_eos
+                        .kappa_times_p_over_rho_squared_from_density_and_energy(
+                            rest_mass_density, specific_internal_energy)));
+    // Check that the sound speed calculation works at zero temperature
+    CHECK_ITERABLE_APPROX(
+        get(eos.sound_speed_squared_from_density_and_temperature(
+            rest_mass_density, Scalar<double>{0.0}, electron_fraction)) -
+            get(rest_mass_density) /
+                get(cold_eos.pressure_from_density(rest_mass_density)) *
+                get(underlying_eos
+                        .kappa_times_p_over_rho_squared_from_density_and_energy(
+                            rest_mass_density,
+                            cold_eos.specific_internal_energy_from_density(
+                                rest_mass_density))),
+        get(rest_mass_density) *
+            get(underlying_eos.chi_from_density_and_energy(
+                rest_mass_density,
+                cold_eos.specific_internal_energy_from_density(
+                    rest_mass_density))) /
+            (get(rest_mass_density) +
+             get(cold_eos.pressure_from_density(rest_mass_density)) +
+             get(cold_eos.specific_internal_energy_from_density(
+                 rest_mass_density)) *
+                 get(rest_mass_density)));
+  }
+  {
+    register_derived_classes_with_charm<EoS::EquationOfState<true, 3>>();
+    register_derived_classes_with_charm<EoS::EquationOfState<true, 2>>();
+    register_derived_classes_with_charm<EoS::EquationOfState<true, 1>>();
+    const auto eos_pointer = serialize_and_deserialize(
+        TestHelpers::test_creation<
+            std::unique_ptr<EoS::EquationOfState<true, 3>>>(
+            {"Equilibrium3D(HybridEos(PolytropicFluid)):\n"
+             "  HybridEos:\n"
+             "    ThermalAdiabaticIndex: 2.0\n"
+             "    PolytropicFluid:\n"
+             "      PolytropicConstant: 100.0\n"
+             "      PolytropicExponent: 2.0"}));
+    const EoS::Equilibrium3D<EoS::HybridEos<EoS::PolytropicFluid<true>>>&
+        deserialized_eos = dynamic_cast<const EoS::Equilibrium3D<
+            EoS::HybridEos<EoS::PolytropicFluid<true>>>&>(*eos_pointer);
+    TestHelpers::EquationsOfState::test_get_clone(deserialized_eos);
+
+    CHECK(eos == deserialized_eos);
+    CHECK(eos !=
+          EoS::Equilibrium3D<EoS::HybridEos<EoS::PolytropicFluid<true>>>{
+              EoS::HybridEos<EoS::PolytropicFluid<true>>({10.0, 2.0}, 2.0)});
+    CHECK(eos !=
+          EoS::Equilibrium3D<EoS::HybridEos<EoS::PolytropicFluid<true>>>{
+              EoS::HybridEos<EoS::PolytropicFluid<true>>({100.0, 1.0}, 2.0)});
+    CHECK(eos !=
+          EoS::Equilibrium3D<EoS::HybridEos<EoS::PolytropicFluid<true>>>{
+              EoS::HybridEos<EoS::PolytropicFluid<true>>({100.0, 2.0}, 1.5)});
+    EoS::Equilibrium3D<EoS::HybridEos<EoS::Spectral>> eq_spectral{
+        EoS::HybridEos<EoS::Spectral>{{1e-5, 1e-4, {2.0, 0.0, 0.0, 0.0}, 1e-2},
+                                      2.0}};
+    CHECK(eq_spectral.is_equal(eq_spectral));
+    CHECK(not(eos.is_equal(eq_spectral)));
+  }
+}


### PR DESCRIPTION
## Proposed changes

This PR adds classes to wrap existing 1-D and 2-D EoSs into 3-D EoSs.  This is the first step in unifying the Equation of state class.  This will be important for making all GR/GHMHD executables use a single EoS type, which will  eventually simplify the interface for analytic data/ numeric data/ evolution.  This PR itself changes no existing interfaces, and merely adds two additional EoSs, with implementations very similar to the existing `HybridEos` class.  

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

Looking forward, the next thing to implement with this EoS would be transferring existing initial data to use 3-D equations of state (In fact we could abstract away the EoS type itself to a `RelativisticHydroEoS`).  Making the evolution executables  themselves use a 3-D EoS would not be hard (and would simplify quite a bit of code).  One advantage of standardizing things with the 3-D EoS is that we can focus our energy on improving the interface.   