### PR TITLE
Add quick exit from cons 2 prim routine

### DIFF
--- a/src/Evolution/Executables/GrMhd/GhValenciaDivClean/EvolveGhValenciaDivCleanWithHorizon.hpp
+++ b/src/Evolution/Executables/GrMhd/GhValenciaDivClean/EvolveGhValenciaDivCleanWithHorizon.hpp
@@ -128,6 +128,7 @@ struct EvolutionMetavars : public GhValenciaDivCleanTemplateBase<
   using initial_data_tag = typename base::initial_data_tag;
 
   using const_global_cache_tags = tmpl::flatten<tmpl::list<
+      grmhd::ValenciaDivClean::Tags::PrimitiveFromConservativeOptions,
       gh::gauges::Tags::GaugeCondition,
       tmpl::conditional_t<evolution::is_numeric_initial_data_v<initial_data>,
                           tmpl::list<>, initial_data_tag>,

--- a/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
+++ b/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
@@ -625,6 +625,7 @@ struct GhValenciaDivCleanTemplateBase<
               ::Tags::VariableFixer<grmhd::ValenciaDivClean::FixConservatives>,
               grmhd::ValenciaDivClean::subcell::Tags::TciOptions>,
           tmpl::list<>>,
+      grmhd::ValenciaDivClean::Tags::PrimitiveFromConservativeOptions,
       gh::gauges::Tags::GaugeCondition,
       tmpl::conditional_t<use_numeric_initial_data, tmpl::list<>,
                           initial_data_tag>,

--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
@@ -593,6 +593,7 @@ struct EvolutionMetavars {
           tmpl::list<
               grmhd::ValenciaDivClean::fd::Tags::Reconstructor,
               ::Tags::VariableFixer<grmhd::ValenciaDivClean::FixConservatives>,
+              grmhd::ValenciaDivClean::Tags::PrimitiveFromConservativeOptions,
               grmhd::ValenciaDivClean::subcell::Tags::TciOptions>,
           tmpl::list<>>,
       initial_data_tag, equation_of_state_tag,

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/FixConservativesAndComputePrims.cpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/FixConservativesAndComputePrims.cpp
@@ -32,7 +32,9 @@ void FixConservativesAndComputePrims<OrderedListOfRecoverySchemes>::apply(
     const gsl::not_null<Variables<hydro::grmhd_tags<DataVector>>*>
         primitive_vars_ptr,
     const grmhd::ValenciaDivClean::FixConservatives& fix_conservatives,
-    const EquationsOfState::EquationOfState<true, ThermodynamicDim>& eos) {
+    const EquationsOfState::EquationOfState<true, ThermodynamicDim>& eos,
+    const grmhd::ValenciaDivClean::PrimitiveFromConservativeOptions&
+        primitive_from_conservative_options) {
   // Compute the spatial metric, inverse spatial metric, and sqrt{det{spatial
   // metric}}. Storing the allocation or the result in the DataBox might
   // actually be useful here, but unclear. We will need to profile.
@@ -91,7 +93,8 @@ void FixConservativesAndComputePrims<OrderedListOfRecoverySchemes>::apply(
           get<ValenciaDivClean::Tags::TildeB<Frame::Inertial>>(
               *conserved_vars_ptr),
           get<ValenciaDivClean::Tags::TildePhi>(*conserved_vars_ptr),
-          spatial_metric, inverse_spatial_metric, sqrt_det_spatial_metric, eos);
+          spatial_metric, inverse_spatial_metric, sqrt_det_spatial_metric, eos,
+          primitive_from_conservative_options);
 }
 
 namespace {
@@ -116,7 +119,9 @@ using KastaunThenNewmanThenPalenzuela =
       const gsl::not_null<Variables<hydro::grmhd_tags<DataVector>>*>        \
           primitive_vars_ptr,                                               \
       const grmhd::ValenciaDivClean::FixConservatives& fix_conservatives,   \
-      const EquationsOfState::EquationOfState<true, THERMO_DIM(data)>& eos);
+      const EquationsOfState::EquationOfState<true, THERMO_DIM(data)>& eos, \
+      const grmhd::ValenciaDivClean::PrimitiveFromConservativeOptions&      \
+          primitive_from_conservative_options);
 
 GENERATE_INSTANTIATIONS(
     INSTANTIATION,

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/FixConservativesAndComputePrims.hpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/FixConservativesAndComputePrims.hpp
@@ -8,6 +8,7 @@
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Evolution/Systems/GrMhd/GhValenciaDivClean/System.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/FixConservatives.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/PrimitiveFromConservativeOptions.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/Tags.hpp"
 #include "Evolution/VariableFixing/Tags.hpp"
 #include "PointwiseFunctions/Hydro/Tags.hpp"
@@ -41,7 +42,8 @@ struct FixConservativesAndComputePrims {
                                  typename System::primitive_variables_tag>;
   using argument_tags = tmpl::list<
       ::Tags::VariableFixer<grmhd::ValenciaDivClean::FixConservatives>,
-      hydro::Tags::EquationOfStateBase>;
+      hydro::Tags::EquationOfStateBase,
+      grmhd::ValenciaDivClean::Tags::PrimitiveFromConservativeOptions>;
 
   template <size_t ThermodynamicDim>
   static void apply(
@@ -50,6 +52,8 @@ struct FixConservativesAndComputePrims {
       gsl::not_null<Variables<hydro::grmhd_tags<DataVector>>*>
           primitive_vars_ptr,
       const grmhd::ValenciaDivClean::FixConservatives& fix_conservatives,
-      const EquationsOfState::EquationOfState<true, ThermodynamicDim>& eos);
+      const EquationsOfState::EquationOfState<true, ThermodynamicDim>& eos,
+      const grmhd::ValenciaDivClean::PrimitiveFromConservativeOptions&
+        primitive_from_conservative_options);
 };
 }  // namespace grmhd::GhValenciaDivClean::subcell

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/PrimsAfterRollback.cpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/PrimsAfterRollback.cpp
@@ -35,7 +35,9 @@ void PrimsAfterRollback<OrderedListOfRecoverySchemes>::apply(
     const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_b,
     const Scalar<DataVector>& tilde_phi,
     const tnsr::aa<DataVector, 3, Frame::Inertial>& spacetime_metric,
-    const EquationsOfState::EquationOfState<true, ThermodynamicDim>& eos) {
+    const EquationsOfState::EquationOfState<true, ThermodynamicDim>& eos,
+    const grmhd::ValenciaDivClean::PrimitiveFromConservativeOptions&
+        primitive_from_conservative_options) {
   if (did_rollback) {
     const size_t num_grid_points = subcell_mesh.number_of_grid_points();
     ASSERT(prim_vars->number_of_grid_points() != num_grid_points,
@@ -94,7 +96,7 @@ void PrimsAfterRollback<OrderedListOfRecoverySchemes>::apply(
                 &get<hydro::Tags::SpecificEnthalpy<DataVector>>(*prim_vars)),
             tilde_d, tilde_ye, tilde_tau, tilde_s, tilde_b, tilde_phi,
             spatial_metric, inverse_spatial_metric, sqrt_det_spatial_metric,
-            eos);
+            eos, primitive_from_conservative_options);
   }
 }
 
@@ -121,7 +123,9 @@ using KastaunThenNewmanThenPalenzuela =
       const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_b,                 \
       const Scalar<DataVector>& tilde_phi,                                    \
       const tnsr::aa<DataVector, 3, Frame::Inertial>& spacetime_metric,       \
-      const EquationsOfState::EquationOfState<true, THERMO_DIM(data)>& eos);
+      const EquationsOfState::EquationOfState<true, THERMO_DIM(data)>& eos,   \
+      const grmhd::ValenciaDivClean::PrimitiveFromConservativeOptions&        \
+          primitive_from_conservative_options);
 GENERATE_INSTANTIATIONS(
     INSTANTIATION,
     (tmpl::list<ValenciaDivClean::PrimitiveRecoverySchemes::KastaunEtAl>,

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/PrimsAfterRollback.hpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/PrimsAfterRollback.hpp
@@ -10,6 +10,7 @@
 #include "Domain/Tags.hpp"
 #include "Evolution/DgSubcell/Tags/DidRollback.hpp"
 #include "Evolution/DgSubcell/Tags/Mesh.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/PrimitiveFromConservativeOptions.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/Tags.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
 #include "PointwiseFunctions/Hydro/Tags.hpp"
@@ -44,17 +45,18 @@ template <typename OrderedListOfRecoverySchemes>
 struct PrimsAfterRollback {
   using return_tags =
       tmpl::list<::Tags::Variables<hydro::grmhd_tags<DataVector>>>;
-  using argument_tags =
-      tmpl::list<evolution::dg::subcell::Tags::DidRollback,
-                 domain::Tags::Mesh<3>, evolution::dg::subcell::Tags::Mesh<3>,
-                 grmhd::ValenciaDivClean::Tags::TildeD,
-                 grmhd::ValenciaDivClean::Tags::TildeYe,
-                 grmhd::ValenciaDivClean::Tags::TildeTau,
-                 grmhd::ValenciaDivClean::Tags::TildeS<>,
-                 grmhd::ValenciaDivClean::Tags::TildeB<>,
-                 grmhd::ValenciaDivClean::Tags::TildePhi,
-                 gr::Tags::SpacetimeMetric<DataVector, 3>,
-                 hydro::Tags::EquationOfStateBase>;
+  using argument_tags = tmpl::list<
+      evolution::dg::subcell::Tags::DidRollback, domain::Tags::Mesh<3>,
+      evolution::dg::subcell::Tags::Mesh<3>,
+      grmhd::ValenciaDivClean::Tags::TildeD,
+      grmhd::ValenciaDivClean::Tags::TildeYe,
+      grmhd::ValenciaDivClean::Tags::TildeTau,
+      grmhd::ValenciaDivClean::Tags::TildeS<>,
+      grmhd::ValenciaDivClean::Tags::TildeB<>,
+      grmhd::ValenciaDivClean::Tags::TildePhi,
+      gr::Tags::SpacetimeMetric<DataVector, 3>,
+      hydro::Tags::EquationOfStateBase,
+      grmhd::ValenciaDivClean::Tags::PrimitiveFromConservativeOptions>;
 
   template <size_t ThermodynamicDim>
   static void apply(
@@ -66,6 +68,8 @@ struct PrimsAfterRollback {
       const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_b,
       const Scalar<DataVector>& tilde_phi,
       const tnsr::aa<DataVector, 3, Frame::Inertial>& spacetime_metric,
-      const EquationsOfState::EquationOfState<true, ThermodynamicDim>& eos);
+      const EquationsOfState::EquationOfState<true, ThermodynamicDim>& eos,
+      const grmhd::ValenciaDivClean::PrimitiveFromConservativeOptions&
+          primitive_from_conservative_options);
 };
 }  // namespace grmhd::GhValenciaDivClean::subcell

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/ResizeAndComputePrimitives.cpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/ResizeAndComputePrimitives.cpp
@@ -36,7 +36,9 @@ void ResizeAndComputePrims<OrderedListOfRecoverySchemes>::apply(
     const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_b,
     const Scalar<DataVector>& tilde_phi,
     const tnsr::aa<DataVector, 3, Frame::Inertial>& spacetime_metric,
-    const EquationsOfState::EquationOfState<true, ThermodynamicDim>& eos) {
+    const EquationsOfState::EquationOfState<true, ThermodynamicDim>& eos,
+    const grmhd::ValenciaDivClean::PrimitiveFromConservativeOptions&
+      primitive_from_conservative_options) {
   if (active_grid == evolution::dg::subcell::ActiveGrid::Dg) {
     const size_t num_grid_points = dg_mesh.number_of_grid_points();
     // Reconstruct a copy of the pressure from the FD grid to the DG grid to
@@ -95,7 +97,7 @@ void ResizeAndComputePrims<OrderedListOfRecoverySchemes>::apply(
                 &get<hydro::Tags::SpecificEnthalpy<DataVector>>(*prim_vars)),
             tilde_d, tilde_ye, tilde_tau, tilde_s, tilde_b, tilde_phi,
             spatial_metric, inverse_spatial_metric, sqrt_det_spatial_metric,
-            eos);
+            eos, primitive_from_conservative_options);
   }
 }
 
@@ -124,7 +126,9 @@ using KastaunThenNewmanThenPalenzuela =
       const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_b,                \
       const Scalar<DataVector>& tilde_phi,                                   \
       const tnsr::aa<DataVector, 3, Frame::Inertial>& spacetime_metric,      \
-      const EquationsOfState::EquationOfState<true, THERMO_DIM(data)>& eos);
+      const EquationsOfState::EquationOfState<true, THERMO_DIM(data)>& eos,  \
+      const grmhd::ValenciaDivClean::PrimitiveFromConservativeOptions&       \
+          primitive_from_conservative_options);
 GENERATE_INSTANTIATIONS(
     INSTANTIATION,
     (tmpl::list<ValenciaDivClean::PrimitiveRecoverySchemes::KastaunEtAl>,

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/ResizeAndComputePrimitives.hpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/ResizeAndComputePrimitives.hpp
@@ -11,6 +11,7 @@
 #include "Evolution/DgSubcell/ActiveGrid.hpp"
 #include "Evolution/DgSubcell/Tags/ActiveGrid.hpp"
 #include "Evolution/DgSubcell/Tags/Mesh.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/PrimitiveFromConservativeOptions.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/Tags.hpp"
 #include "PointwiseFunctions/GeneralRelativity/TagsDeclarations.hpp"
 #include "PointwiseFunctions/Hydro/Tags.hpp"
@@ -59,17 +60,18 @@ template <typename OrderedListOfRecoverySchemes>
 struct ResizeAndComputePrims {
   using return_tags =
       tmpl::list<::Tags::Variables<hydro::grmhd_tags<DataVector>>>;
-  using argument_tags =
-      tmpl::list<evolution::dg::subcell::Tags::ActiveGrid,
-                 domain::Tags::Mesh<3>, evolution::dg::subcell::Tags::Mesh<3>,
-                 grmhd::ValenciaDivClean::Tags::TildeD,
-                 grmhd::ValenciaDivClean::Tags::TildeYe,
-                 grmhd::ValenciaDivClean::Tags::TildeTau,
-                 grmhd::ValenciaDivClean::Tags::TildeS<>,
-                 grmhd::ValenciaDivClean::Tags::TildeB<>,
-                 grmhd::ValenciaDivClean::Tags::TildePhi,
-                 gr::Tags::SpacetimeMetric<DataVector, 3>,
-                 hydro::Tags::EquationOfStateBase>;
+  using argument_tags = tmpl::list<
+      evolution::dg::subcell::Tags::ActiveGrid, domain::Tags::Mesh<3>,
+      evolution::dg::subcell::Tags::Mesh<3>,
+      grmhd::ValenciaDivClean::Tags::TildeD,
+      grmhd::ValenciaDivClean::Tags::TildeYe,
+      grmhd::ValenciaDivClean::Tags::TildeTau,
+      grmhd::ValenciaDivClean::Tags::TildeS<>,
+      grmhd::ValenciaDivClean::Tags::TildeB<>,
+      grmhd::ValenciaDivClean::Tags::TildePhi,
+      gr::Tags::SpacetimeMetric<DataVector, 3>,
+      hydro::Tags::EquationOfStateBase,
+      grmhd::ValenciaDivClean::Tags::PrimitiveFromConservativeOptions>;
 
   template <size_t ThermodynamicDim>
   static void apply(
@@ -81,6 +83,8 @@ struct ResizeAndComputePrims {
       const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_b,
       const Scalar<DataVector>& tilde_phi,
       const tnsr::aa<DataVector, 3, Frame::Inertial>& spacetime_metric,
-      const EquationsOfState::EquationOfState<true, ThermodynamicDim>& eos);
+      const EquationsOfState::EquationOfState<true, ThermodynamicDim>& eos,
+      const grmhd::ValenciaDivClean::PrimitiveFromConservativeOptions&
+          primitive_from_conservative_options);
 };
 }  // namespace grmhd::GhValenciaDivClean::subcell

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/CMakeLists.txt
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/CMakeLists.txt
@@ -18,6 +18,7 @@ spectre_target_sources(
   NewmanHamlin.cpp
   PalenzuelaEtAl.cpp
   PrimitiveFromConservative.cpp
+  PrimitiveFromConservativeOptions.cpp
   SetVariablesNeededFixingToFalse.cpp
   Sources.cpp
   TimeDerivativeTerms.cpp
@@ -38,6 +39,7 @@ spectre_target_headers(
   NewmanHamlin.hpp
   PalenzuelaEtAl.hpp
   PrimitiveFromConservative.hpp
+  PrimitiveFromConservativeOptions.hpp
   PrimitiveRecoveryData.hpp
   QuadrupoleFormula.hpp
   SetVariablesNeededFixingToFalse.hpp

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Flattener.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Flattener.cpp
@@ -59,7 +59,9 @@ void Flattener<RecoverySchemesList>::operator()(
     const tnsr::II<DataVector, 3, Frame::Inertial>& inv_spatial_metric,
     const Mesh<3>& mesh,
     const Scalar<DataVector>& det_logical_to_inertial_inv_jacobian,
-    const EquationsOfState::EquationOfState<true, ThermodynamicDim>& eos)
+    const EquationsOfState::EquationOfState<true, ThermodynamicDim>& eos,
+    const grmhd::ValenciaDivClean::PrimitiveFromConservativeOptions&
+        primitive_from_conservative_options)
     const {
   // Create a temporary variable for each field's cell average.
   // These temporaries live on the stack and should have minimal cost.
@@ -214,7 +216,7 @@ void Flattener<RecoverySchemesList>::operator()(
                   &get<hydro::Tags::SpecificEnthalpy<DataVector>>(temp_prims)),
               *tilde_d, *tilde_ye, *tilde_tau, *tilde_s, tilde_b, tilde_phi,
               spatial_metric, inv_spatial_metric, sqrt_det_spatial_metric,
-              eos)) {
+              eos, primitive_from_conservative_options)) {
     compute_means();
 
     get(*tilde_d) = mean_tilde_d;
@@ -248,7 +250,8 @@ void Flattener<RecoverySchemesList>::operator()(
               make_not_null(
                   &get<hydro::Tags::SpecificEnthalpy<DataVector>>(temp_prims)),
               *tilde_d, *tilde_ye, *tilde_tau, *tilde_s, tilde_b, tilde_phi,
-              spatial_metric, inv_spatial_metric, sqrt_det_spatial_metric, eos);
+              spatial_metric, inv_spatial_metric, sqrt_det_spatial_metric, eos,
+              primitive_from_conservative_options);
     }
   }
   if (recover_primitives_) {
@@ -314,8 +317,9 @@ GENERATE_INSTANTIATIONS(INSTANTIATION, ORDERED_RECOVERY_LIST)
       const tnsr::II<DataVector, 3, Frame::Inertial>& inv_spatial_metric,   \
       const Mesh<3>& mesh,                                                  \
       const Scalar<DataVector>& det_logical_to_inertial_inv_jacobian,       \
-      const EquationsOfState::EquationOfState<true, THERMO_DIM(data)>& eos) \
-      const;
+      const EquationsOfState::EquationOfState<true, THERMO_DIM(data)>& eos, \
+      const grmhd::ValenciaDivClean::PrimitiveFromConservativeOptions&      \
+        primitive_from_conservative_options) const;
 GENERATE_INSTANTIATIONS(INSTANTIATION, ORDERED_RECOVERY_LIST, (1, 2))
 #undef INSTANTIATION
 #undef THERMO_DIM

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Flattener.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Flattener.hpp
@@ -9,6 +9,7 @@
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "DataStructures/VariablesTag.hpp"
 #include "Domain/Tags.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/PrimitiveFromConservativeOptions.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/Tags.hpp"
 #include "Options/String.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
@@ -125,7 +126,8 @@ class Flattener {
       gr::Tags::SpatialMetric<DataVector, 3>,
       gr::Tags::InverseSpatialMetric<DataVector, 3>, domain::Tags::Mesh<3>,
       domain::Tags::DetInvJacobian<Frame::ElementLogical, Frame::Inertial>,
-      hydro::Tags::EquationOfStateBase>;
+      hydro::Tags::EquationOfStateBase,
+      grmhd::ValenciaDivClean::Tags::PrimitiveFromConservativeOptions>;
 
   template <size_t ThermodynamicDim>
   void operator()(
@@ -141,7 +143,9 @@ class Flattener {
       const tnsr::II<DataVector, 3, Frame::Inertial>& inv_spatial_metric,
       const Mesh<3>& mesh,
       const Scalar<DataVector>& det_logical_to_inertial_inv_jacobian,
-      const EquationsOfState::EquationOfState<true, ThermodynamicDim>& eos)
+      const EquationsOfState::EquationOfState<true, ThermodynamicDim>& eos,
+      const grmhd::ValenciaDivClean::PrimitiveFromConservativeOptions&
+        primitive_from_conservative_options)
       const;
 
  private:

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/PrimitiveFromConservative.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/PrimitiveFromConservative.hpp
@@ -6,6 +6,7 @@
 #include <cstddef>
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/PrimitiveFromConservativeOptions.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/TagsDeclarations.hpp"  // IWYU pragma: keep
 #include "PointwiseFunctions/GeneralRelativity/TagsDeclarations.hpp"  // IWYU pragma: keep
 #include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
@@ -57,18 +58,18 @@ struct PrimitiveFromConservative {
                  hydro::Tags::LorentzFactor<DataVector>,
                  hydro::Tags::Pressure<DataVector>,
                  hydro::Tags::SpecificEnthalpy<DataVector>>;
-
-  using argument_tags =
-      tmpl::list<grmhd::ValenciaDivClean::Tags::TildeD,
-                 grmhd::ValenciaDivClean::Tags::TildeYe,
-                 grmhd::ValenciaDivClean::Tags::TildeTau,
-                 grmhd::ValenciaDivClean::Tags::TildeS<>,
-                 grmhd::ValenciaDivClean::Tags::TildeB<>,
-                 grmhd::ValenciaDivClean::Tags::TildePhi,
-                 gr::Tags::SpatialMetric<DataVector, 3>,
-                 gr::Tags::InverseSpatialMetric<DataVector, 3>,
-                 gr::Tags::SqrtDetSpatialMetric<DataVector>,
-                 hydro::Tags::EquationOfStateBase>;
+  using argument_tags = tmpl::list<
+      grmhd::ValenciaDivClean::Tags::TildeD,
+      grmhd::ValenciaDivClean::Tags::TildeYe,
+      grmhd::ValenciaDivClean::Tags::TildeTau,
+      grmhd::ValenciaDivClean::Tags::TildeS<>,
+      grmhd::ValenciaDivClean::Tags::TildeB<>,
+      grmhd::ValenciaDivClean::Tags::TildePhi,
+      gr::Tags::SpatialMetric<DataVector, 3>,
+      gr::Tags::InverseSpatialMetric<DataVector, 3>,
+      gr::Tags::SqrtDetSpatialMetric<DataVector>,
+      hydro::Tags::EquationOfStateBase,
+      grmhd::ValenciaDivClean::Tags::PrimitiveFromConservativeOptions>;
 
   template <size_t ThermodynamicDim>
   static bool apply(
@@ -90,7 +91,9 @@ struct PrimitiveFromConservative {
       const tnsr::II<DataVector, 3, Frame::Inertial>& inv_spatial_metric,
       const Scalar<DataVector>& sqrt_det_spatial_metric,
       const EquationsOfState::EquationOfState<true, ThermodynamicDim>&
-          equation_of_state);
+          equation_of_state,
+      const grmhd::ValenciaDivClean::PrimitiveFromConservativeOptions&
+          primitive_from_conservative_options);
 };
 }  // namespace ValenciaDivClean
 }  // namespace grmhd

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/PrimitiveFromConservativeOptions.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/PrimitiveFromConservativeOptions.cpp
@@ -1,0 +1,34 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/PrimitiveFromConservativeOptions.hpp"
+
+#include <pup.h>
+#include <pup_stl.h>
+
+namespace grmhd::ValenciaDivClean {
+
+PrimitiveFromConservativeOptions::PrimitiveFromConservativeOptions(
+    const double cutoff_d_for_inversion,
+    const double density_when_skipping_inversion)
+    : cutoff_d_for_inversion_(cutoff_d_for_inversion),
+      density_when_skipping_inversion_(density_when_skipping_inversion) {}
+
+void PrimitiveFromConservativeOptions::pup(PUP::er& p) {
+  p | cutoff_d_for_inversion_;
+  p | density_when_skipping_inversion_;
+}
+
+bool operator==(const PrimitiveFromConservativeOptions& lhs,
+                const PrimitiveFromConservativeOptions& rhs) {
+  return (lhs.cutoff_d_for_inversion_ == rhs.cutoff_d_for_inversion_) and
+         (lhs.density_when_skipping_inversion_ ==
+          rhs.density_when_skipping_inversion_);
+}
+
+bool operator!=(const PrimitiveFromConservativeOptions& lhs,
+                const PrimitiveFromConservativeOptions& rhs) {
+  return not(lhs == rhs);
+}
+
+}  // namespace grmhd::ValenciaDivClean

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/PrimitiveFromConservativeOptions.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/PrimitiveFromConservativeOptions.hpp
@@ -1,0 +1,75 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <limits>
+#include <string>
+#include <vector>
+
+#include "Options/String.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+namespace PUP {
+class er;
+}  // namespace PUP
+/// \endcond
+
+namespace grmhd::ValenciaDivClean {
+
+/// Options to be passed to the Con2Prim algorithm.
+/// Currently, we simply set a threshold for tildeD
+/// below which the inversion is not performed and
+/// the density is set to atmosphere values.
+class PrimitiveFromConservativeOptions {
+ public:
+  struct CutoffDForInversion {
+    static std::string name() { return "CutoffDForInversion"; }
+    static constexpr Options::String help{
+        "Value of density times Lorentz factor below which we skip "
+        "conservative to primitive inversion."};
+    using type = double;
+    static type lower_bound() { return 0.0; }
+  };
+
+  struct DensityWhenSkippingInversion {
+    static std::string name() { return "DensityWhenSkippingInversion"; }
+    static constexpr Options::String help{
+        "Value of density when we skip conservative to primitive inversion."};
+    using type = double;
+    static type lower_bound() { return 0.0; }
+  };
+
+  using options = tmpl::list<CutoffDForInversion, DensityWhenSkippingInversion>;
+
+  static constexpr Options::String help{
+      "Options given to conservative to primitive inversion."};
+
+  PrimitiveFromConservativeOptions() = default;
+
+  PrimitiveFromConservativeOptions(
+      const double cutoff_d_for_inversion,
+      const double density_when_skipping_inversion);
+
+  void pup(PUP::er& p);
+
+  double cutoff_d_for_inversion() const { return cutoff_d_for_inversion_; }
+  double density_when_skipping_inversion() const {
+    return density_when_skipping_inversion_;
+  }
+
+ private:
+  friend bool operator==(const PrimitiveFromConservativeOptions& lhs,
+                         const PrimitiveFromConservativeOptions& rhs);
+
+  double cutoff_d_for_inversion_ = std::numeric_limits<double>::signaling_NaN();
+  double density_when_skipping_inversion_ =
+      std::numeric_limits<double>::signaling_NaN();
+};
+
+bool operator!=(const PrimitiveFromConservativeOptions& lhs,
+                const PrimitiveFromConservativeOptions& rhs);
+
+}  // namespace grmhd::ValenciaDivClean

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/FixConservativesAndComputePrims.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/FixConservativesAndComputePrims.cpp
@@ -32,7 +32,9 @@ void FixConservativesAndComputePrims<OrderedListOfRecoverySchemes>::apply(
     const EquationsOfState::EquationOfState<true, ThermodynamicDim>& eos,
     const tnsr::ii<DataVector, 3, Frame::Inertial>& spatial_metric,
     const tnsr::II<DataVector, 3, Frame::Inertial>& inv_spatial_metric,
-    const Scalar<DataVector>& sqrt_det_spatial_metric) {
+    const Scalar<DataVector>& sqrt_det_spatial_metric,
+    const grmhd::ValenciaDivClean::PrimitiveFromConservativeOptions&
+        primitive_from_conservative_options) {
   *needed_fixing = fix_conservatives(
       make_not_null(&get<Tags::TildeD>(*conserved_vars_ptr)),
       make_not_null(&get<Tags::TildeYe>(*conserved_vars_ptr)),
@@ -66,7 +68,8 @@ void FixConservativesAndComputePrims<OrderedListOfRecoverySchemes>::apply(
           get<Tags::TildeS<Frame::Inertial>>(*conserved_vars_ptr),
           get<Tags::TildeB<Frame::Inertial>>(*conserved_vars_ptr),
           get<Tags::TildePhi>(*conserved_vars_ptr), spatial_metric,
-          inv_spatial_metric, sqrt_det_spatial_metric, eos);
+          inv_spatial_metric, sqrt_det_spatial_metric, eos,
+          primitive_from_conservative_options);
 }
 
 namespace {
@@ -94,7 +97,9 @@ using KastaunThenNewmanThenPalenzuela =
       const EquationsOfState::EquationOfState<true, THERMO_DIM(data)>& eos, \
       const tnsr::ii<DataVector, 3, Frame::Inertial>& spatial_metric,       \
       const tnsr::II<DataVector, 3, Frame::Inertial>& inv_spatial_metric,   \
-      const Scalar<DataVector>& sqrt_det_spatial_metric);
+      const Scalar<DataVector>& sqrt_det_spatial_metric,                    \
+      const grmhd::ValenciaDivClean::PrimitiveFromConservativeOptions&      \
+          primitive_from_conservative_options);
 
 GENERATE_INSTANTIATIONS(INSTANTIATION,
                         (tmpl::list<PrimitiveRecoverySchemes::KastaunEtAl>,

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/FixConservativesAndComputePrims.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/FixConservativesAndComputePrims.hpp
@@ -7,6 +7,7 @@
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/FixConservatives.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/PrimitiveFromConservativeOptions.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/System.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/Tags.hpp"
 #include "Evolution/VariableFixing/Tags.hpp"
@@ -44,7 +45,8 @@ struct FixConservativesAndComputePrims {
       ::Tags::VariableFixer<grmhd::ValenciaDivClean::FixConservatives>,
       hydro::Tags::EquationOfStateBase, gr::Tags::SpatialMetric<DataVector, 3>,
       gr::Tags::InverseSpatialMetric<DataVector, 3>,
-      gr::Tags::SqrtDetSpatialMetric<DataVector>>;
+      gr::Tags::SqrtDetSpatialMetric<DataVector>,
+      grmhd::ValenciaDivClean::Tags::PrimitiveFromConservativeOptions>;
 
   template <size_t ThermodynamicDim>
   static void apply(
@@ -56,6 +58,8 @@ struct FixConservativesAndComputePrims {
       const EquationsOfState::EquationOfState<true, ThermodynamicDim>& eos,
       const tnsr::ii<DataVector, 3, Frame::Inertial>& spatial_metric,
       const tnsr::II<DataVector, 3, Frame::Inertial>& inv_spatial_metric,
-      const Scalar<DataVector>& sqrt_det_spatial_metric);
+      const Scalar<DataVector>& sqrt_det_spatial_metric,
+      const grmhd::ValenciaDivClean::PrimitiveFromConservativeOptions&
+        primitive_from_conservative_options);
 };
 }  // namespace grmhd::ValenciaDivClean::subcell

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/PrimsAfterRollback.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/PrimsAfterRollback.cpp
@@ -33,7 +33,9 @@ void PrimsAfterRollback<OrderedListOfRecoverySchemes>::apply(
     const tnsr::ii<DataVector, 3, Frame::Inertial>& spatial_metric,
     const tnsr::II<DataVector, 3, Frame::Inertial>& inv_spatial_metric,
     const Scalar<DataVector>& sqrt_det_spatial_metric,
-    const EquationsOfState::EquationOfState<true, ThermodynamicDim>& eos) {
+    const EquationsOfState::EquationOfState<true, ThermodynamicDim>& eos,
+    const grmhd::ValenciaDivClean::PrimitiveFromConservativeOptions&
+        primitive_from_conservative_options) {
   if (did_rollback) {
     const size_t num_grid_points = subcell_mesh.number_of_grid_points();
     ASSERT(prim_vars->number_of_grid_points() != num_grid_points,
@@ -69,7 +71,8 @@ void PrimsAfterRollback<OrderedListOfRecoverySchemes>::apply(
             make_not_null(
                 &get<hydro::Tags::SpecificEnthalpy<DataVector>>(*prim_vars)),
             tilde_d, tilde_ye, tilde_tau, tilde_s, tilde_b, tilde_phi,
-            spatial_metric, inv_spatial_metric, sqrt_det_spatial_metric, eos);
+            spatial_metric, inv_spatial_metric, sqrt_det_spatial_metric, eos,
+            primitive_from_conservative_options);
   }
 }
 
@@ -98,7 +101,9 @@ using KastaunThenNewmanThenPalenzuela =
       const tnsr::ii<DataVector, 3, Frame::Inertial>& spatial_metric,         \
       const tnsr::II<DataVector, 3, Frame::Inertial>& inv_spatial_metric,     \
       const Scalar<DataVector>& sqrt_det_spatial_metric,                      \
-      const EquationsOfState::EquationOfState<true, THERMO_DIM(data)>& eos);
+      const EquationsOfState::EquationOfState<true, THERMO_DIM(data)>& eos,   \
+      const grmhd::ValenciaDivClean::PrimitiveFromConservativeOptions&        \
+      primitive_from_conservative_options);
 GENERATE_INSTANTIATIONS(INSTANTIATION,
                         (tmpl::list<PrimitiveRecoverySchemes::KastaunEtAl>,
                          tmpl::list<PrimitiveRecoverySchemes::NewmanHamlin>,

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/PrimsAfterRollback.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/PrimsAfterRollback.hpp
@@ -10,6 +10,7 @@
 #include "Domain/Tags.hpp"
 #include "Evolution/DgSubcell/Tags/DidRollback.hpp"
 #include "Evolution/DgSubcell/Tags/Mesh.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/PrimitiveFromConservativeOptions.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/Tags.hpp"
 #include "PointwiseFunctions/GeneralRelativity/TagsDeclarations.hpp"
 #include "PointwiseFunctions/Hydro/Tags.hpp"
@@ -47,19 +48,20 @@ template <typename OrderedListOfRecoverySchemes>
 struct PrimsAfterRollback {
   using return_tags =
       tmpl::list<::Tags::Variables<hydro::grmhd_tags<DataVector>>>;
-  using argument_tags =
-      tmpl::list<evolution::dg::subcell::Tags::DidRollback,
-                 domain::Tags::Mesh<3>, evolution::dg::subcell::Tags::Mesh<3>,
-                 grmhd::ValenciaDivClean::Tags::TildeD,
-                 grmhd::ValenciaDivClean::Tags::TildeYe,
-                 grmhd::ValenciaDivClean::Tags::TildeTau,
-                 grmhd::ValenciaDivClean::Tags::TildeS<>,
-                 grmhd::ValenciaDivClean::Tags::TildeB<>,
-                 grmhd::ValenciaDivClean::Tags::TildePhi,
-                 gr::Tags::SpatialMetric<DataVector, 3>,
-                 gr::Tags::InverseSpatialMetric<DataVector, 3>,
-                 gr::Tags::SqrtDetSpatialMetric<DataVector>,
-                 hydro::Tags::EquationOfStateBase>;
+  using argument_tags = tmpl::list<
+      evolution::dg::subcell::Tags::DidRollback, domain::Tags::Mesh<3>,
+      evolution::dg::subcell::Tags::Mesh<3>,
+      grmhd::ValenciaDivClean::Tags::TildeD,
+      grmhd::ValenciaDivClean::Tags::TildeYe,
+      grmhd::ValenciaDivClean::Tags::TildeTau,
+      grmhd::ValenciaDivClean::Tags::TildeS<>,
+      grmhd::ValenciaDivClean::Tags::TildeB<>,
+      grmhd::ValenciaDivClean::Tags::TildePhi,
+      gr::Tags::SpatialMetric<DataVector, 3>,
+      gr::Tags::InverseSpatialMetric<DataVector, 3>,
+      gr::Tags::SqrtDetSpatialMetric<DataVector>,
+      hydro::Tags::EquationOfStateBase,
+      grmhd::ValenciaDivClean::Tags::PrimitiveFromConservativeOptions>;
 
   template <size_t ThermodynamicDim>
   static void apply(
@@ -73,6 +75,8 @@ struct PrimsAfterRollback {
       const tnsr::ii<DataVector, 3, Frame::Inertial>& spatial_metric,
       const tnsr::II<DataVector, 3, Frame::Inertial>& inv_spatial_metric,
       const Scalar<DataVector>& sqrt_det_spatial_metric,
-      const EquationsOfState::EquationOfState<true, ThermodynamicDim>& eos);
+      const EquationsOfState::EquationOfState<true, ThermodynamicDim>& eos,
+      const grmhd::ValenciaDivClean::PrimitiveFromConservativeOptions&
+          primitive_from_conservative_options);
 };
 }  // namespace grmhd::ValenciaDivClean::subcell

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/ResizeAndComputePrimitives.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/ResizeAndComputePrimitives.cpp
@@ -37,7 +37,9 @@ void ResizeAndComputePrims<OrderedListOfRecoverySchemes>::apply(
     const tnsr::ii<DataVector, 3, Frame::Inertial>& spatial_metric,
     const tnsr::II<DataVector, 3, Frame::Inertial>& inv_spatial_metric,
     const Scalar<DataVector>& sqrt_det_spatial_metric,
-    const EquationsOfState::EquationOfState<true, ThermodynamicDim>& eos) {
+    const EquationsOfState::EquationOfState<true, ThermodynamicDim>& eos,
+    const grmhd::ValenciaDivClean::PrimitiveFromConservativeOptions&
+        primitive_from_conservative_options) {
   if (active_grid == evolution::dg::subcell::ActiveGrid::Dg) {
     const size_t num_grid_points = dg_mesh.number_of_grid_points();
     // Reconstruct a copy of the pressure from the FD grid to the DG grid to
@@ -77,7 +79,8 @@ void ResizeAndComputePrims<OrderedListOfRecoverySchemes>::apply(
             make_not_null(
                 &get<hydro::Tags::SpecificEnthalpy<DataVector>>(*prim_vars)),
             tilde_d, tilde_ye, tilde_tau, tilde_s, tilde_b, tilde_phi,
-            spatial_metric, inv_spatial_metric, sqrt_det_spatial_metric, eos);
+            spatial_metric, inv_spatial_metric, sqrt_det_spatial_metric, eos,
+            primitive_from_conservative_options);
   }
 }
 
@@ -108,7 +111,9 @@ using KastaunThenNewmanThenPalenzuela =
       const tnsr::ii<DataVector, 3, Frame::Inertial>& spatial_metric,        \
       const tnsr::II<DataVector, 3, Frame::Inertial>& inv_spatial_metric,    \
       const Scalar<DataVector>& sqrt_det_spatial_metric,                     \
-      const EquationsOfState::EquationOfState<true, THERMO_DIM(data)>& eos);
+      const EquationsOfState::EquationOfState<true, THERMO_DIM(data)>& eos,  \
+      const grmhd::ValenciaDivClean::PrimitiveFromConservativeOptions&       \
+          primitive_from_conservative_options);
 GENERATE_INSTANTIATIONS(INSTANTIATION,
                         (tmpl::list<PrimitiveRecoverySchemes::KastaunEtAl>,
                          tmpl::list<PrimitiveRecoverySchemes::NewmanHamlin>,

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/ResizeAndComputePrimitives.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/ResizeAndComputePrimitives.hpp
@@ -11,6 +11,7 @@
 #include "Evolution/DgSubcell/ActiveGrid.hpp"
 #include "Evolution/DgSubcell/Tags/ActiveGrid.hpp"
 #include "Evolution/DgSubcell/Tags/Mesh.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/PrimitiveFromConservativeOptions.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/Tags.hpp"
 #include "PointwiseFunctions/GeneralRelativity/TagsDeclarations.hpp"
 #include "PointwiseFunctions/Hydro/Tags.hpp"
@@ -56,19 +57,20 @@ template <typename OrderedListOfRecoverySchemes>
 struct ResizeAndComputePrims {
   using return_tags =
       tmpl::list<::Tags::Variables<hydro::grmhd_tags<DataVector>>>;
-  using argument_tags =
-      tmpl::list<evolution::dg::subcell::Tags::ActiveGrid,
-                 domain::Tags::Mesh<3>, evolution::dg::subcell::Tags::Mesh<3>,
-                 grmhd::ValenciaDivClean::Tags::TildeD,
-                 grmhd::ValenciaDivClean::Tags::TildeYe,
-                 grmhd::ValenciaDivClean::Tags::TildeTau,
-                 grmhd::ValenciaDivClean::Tags::TildeS<>,
-                 grmhd::ValenciaDivClean::Tags::TildeB<>,
-                 grmhd::ValenciaDivClean::Tags::TildePhi,
-                 gr::Tags::SpatialMetric<DataVector, 3>,
-                 gr::Tags::InverseSpatialMetric<DataVector, 3>,
-                 gr::Tags::SqrtDetSpatialMetric<DataVector>,
-                 hydro::Tags::EquationOfStateBase>;
+  using argument_tags = tmpl::list<
+      evolution::dg::subcell::Tags::ActiveGrid, domain::Tags::Mesh<3>,
+      evolution::dg::subcell::Tags::Mesh<3>,
+      grmhd::ValenciaDivClean::Tags::TildeD,
+      grmhd::ValenciaDivClean::Tags::TildeYe,
+      grmhd::ValenciaDivClean::Tags::TildeTau,
+      grmhd::ValenciaDivClean::Tags::TildeS<>,
+      grmhd::ValenciaDivClean::Tags::TildeB<>,
+      grmhd::ValenciaDivClean::Tags::TildePhi,
+      gr::Tags::SpatialMetric<DataVector, 3>,
+      gr::Tags::InverseSpatialMetric<DataVector, 3>,
+      gr::Tags::SqrtDetSpatialMetric<DataVector>,
+      hydro::Tags::EquationOfStateBase,
+      grmhd::ValenciaDivClean::Tags::PrimitiveFromConservativeOptions>;
 
   template <size_t ThermodynamicDim>
   static void apply(
@@ -82,6 +84,8 @@ struct ResizeAndComputePrims {
       const tnsr::ii<DataVector, 3, Frame::Inertial>& spatial_metric,
       const tnsr::II<DataVector, 3, Frame::Inertial>& inv_spatial_metric,
       const Scalar<DataVector>& sqrt_det_spatial_metric,
-      const EquationsOfState::EquationOfState<true, ThermodynamicDim>& eos);
+      const EquationsOfState::EquationOfState<true, ThermodynamicDim>& eos,
+      const grmhd::ValenciaDivClean::PrimitiveFromConservativeOptions&
+          primitive_from_conservative_options);
 };
 }  // namespace grmhd::ValenciaDivClean::subcell

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TciOnDgGrid.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TciOnDgGrid.cpp
@@ -46,6 +46,8 @@ TciOnDgGrid<RecoveryScheme>::apply(
     const evolution::dg::subcell::RdmpTciData& past_rdmp_tci_data,
     const TciOptions& tci_options,
     const evolution::dg::subcell::SubcellOptions& subcell_options,
+    const grmhd::ValenciaDivClean::PrimitiveFromConservativeOptions&
+        primitive_from_conservative_options,
     const double persson_exponent, const bool element_stays_on_dg) {
   evolution::dg::subcell::RdmpTciData rdmp_tci_data{};
 
@@ -135,7 +137,8 @@ TciOnDgGrid<RecoveryScheme>::apply(
           make_not_null(
               &get<hydro::Tags::SpecificEnthalpy<DataVector>>(pre_tci_prims)),
           tilde_d, tilde_ye, tilde_tau, tilde_s, tilde_b, tilde_phi,
-          spatial_metric, inv_spatial_metric, sqrt_det_spatial_metric, eos);
+          spatial_metric, inv_spatial_metric, sqrt_det_spatial_metric, eos,
+          primitive_from_conservative_options);
 
   // This lambda is called before every TCI failure
   // in order to allow primitives to be updated, rather
@@ -293,6 +296,8 @@ GENERATE_INSTANTIATIONS(
       const evolution::dg::subcell::RdmpTciData& past_rdmp_tci_data,         \
       const TciOptions& tci_options,                                         \
       const evolution::dg::subcell::SubcellOptions& subcell_options,         \
+      const grmhd::ValenciaDivClean::PrimitiveFromConservativeOptions&       \
+          primitive_from_conservative_options,                               \
       const double persson_exponent, const bool element_stays_on_dg);
 
 GENERATE_INSTANTIATIONS(

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TciOnDgGrid.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TciOnDgGrid.hpp
@@ -13,6 +13,7 @@
 #include "Evolution/DgSubcell/Tags/DataForRdmpTci.hpp"
 #include "Evolution/DgSubcell/Tags/Mesh.hpp"
 #include "Evolution/DgSubcell/Tags/SubcellOptions.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/PrimitiveFromConservativeOptions.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TciOptions.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/Tags.hpp"
 #include "PointwiseFunctions/GeneralRelativity/TagsDeclarations.hpp"
@@ -134,20 +135,21 @@ class TciOnDgGrid {
  public:
   using return_tags =
       tmpl::list<::Tags::Variables<hydro::grmhd_tags<DataVector>>>;
-  using argument_tags =
-      tmpl::list<grmhd::ValenciaDivClean::Tags::TildeD,
-                 grmhd::ValenciaDivClean::Tags::TildeYe,
-                 grmhd::ValenciaDivClean::Tags::TildeTau,
-                 grmhd::ValenciaDivClean::Tags::TildeS<>,
-                 grmhd::ValenciaDivClean::Tags::TildeB<>,
-                 grmhd::ValenciaDivClean::Tags::TildePhi,
-                 gr::Tags::SpatialMetric<DataVector, 3>,
-                 gr::Tags::InverseSpatialMetric<DataVector, 3>,
-                 gr::Tags::SqrtDetSpatialMetric<DataVector>,
-                 hydro::Tags::EquationOfStateBase, domain::Tags::Mesh<3>,
-                 evolution::dg::subcell::Tags::Mesh<3>,
-                 evolution::dg::subcell::Tags::DataForRdmpTci, Tags::TciOptions,
-                 evolution::dg::subcell::Tags::SubcellOptions<3>>;
+  using argument_tags = tmpl::list<
+      grmhd::ValenciaDivClean::Tags::TildeD,
+      grmhd::ValenciaDivClean::Tags::TildeYe,
+      grmhd::ValenciaDivClean::Tags::TildeTau,
+      grmhd::ValenciaDivClean::Tags::TildeS<>,
+      grmhd::ValenciaDivClean::Tags::TildeB<>,
+      grmhd::ValenciaDivClean::Tags::TildePhi,
+      gr::Tags::SpatialMetric<DataVector, 3>,
+      gr::Tags::InverseSpatialMetric<DataVector, 3>,
+      gr::Tags::SqrtDetSpatialMetric<DataVector>,
+      hydro::Tags::EquationOfStateBase, domain::Tags::Mesh<3>,
+      evolution::dg::subcell::Tags::Mesh<3>,
+      evolution::dg::subcell::Tags::DataForRdmpTci, Tags::TciOptions,
+      evolution::dg::subcell::Tags::SubcellOptions<3>,
+      grmhd::ValenciaDivClean::Tags::PrimitiveFromConservativeOptions>;
 
   template <size_t ThermodynamicDim>
   static std::tuple<int, evolution::dg::subcell::RdmpTciData> apply(
@@ -165,6 +167,8 @@ class TciOnDgGrid {
       const evolution::dg::subcell::RdmpTciData& past_rdmp_tci_data,
       const TciOptions& tci_options,
       const evolution::dg::subcell::SubcellOptions& subcell_options,
+      const grmhd::ValenciaDivClean::PrimitiveFromConservativeOptions&
+          primitive_from_conservative_options,
       double persson_exponent, bool element_stays_on_dg);
 };
 }  // namespace grmhd::ValenciaDivClean::subcell

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Tags.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Tags.hpp
@@ -8,6 +8,7 @@
 
 #include "DataStructures/DataBox/Tag.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/PrimitiveFromConservativeOptions.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/TagsDeclarations.hpp"
 #include "Evolution/Tags.hpp"
 #include "Options/String.hpp"
@@ -87,6 +88,15 @@ struct DampingParameter {
       "Constraint damping parameter for divergence cleaning"};
   using group = ValenciaDivCleanGroup;
 };
+
+struct PrimitiveFromConservativeOptions {
+  static std::string name() { return "PrimitiveFromConservative"; }
+  using type = grmhd::ValenciaDivClean::PrimitiveFromConservativeOptions;
+  static constexpr Options::String help{
+      "Value of density times Lorentz factor below which we skip conservative "
+      "to primitive inversion."};
+};
+
 }  // namespace OptionTags
 
 namespace Tags {
@@ -100,6 +110,15 @@ struct ConstraintDampingParameter : db::SimpleTag {
     return constraint_damping_parameter;
   }
 };
+
+struct PrimitiveFromConservativeOptions : db::SimpleTag {
+  using type = grmhd::ValenciaDivClean::PrimitiveFromConservativeOptions;
+  using option_tags = tmpl::list<OptionTags::PrimitiveFromConservativeOptions>;
+
+  static constexpr bool pass_metavariables = false;
+  static type create_from_options(const type& options) { return options; }
+};
+
 }  // namespace Tags
 }  // namespace ValenciaDivClean
 }  // namespace grmhd

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/TagsDeclarations.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/TagsDeclarations.hpp
@@ -15,6 +15,7 @@ namespace ValenciaDivClean {
 namespace Tags {
 struct CharacteristicSpeeds;
 struct ConstraintDampingParameter;
+struct PrimitiveFromConservativeOptions;
 struct TildeD;
 struct TildeYe;
 struct TildeTau;

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/BinaryNeutronStar.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/BinaryNeutronStar.yaml
@@ -64,8 +64,8 @@ DomainCreator:
 
 VariableFixing:
   FixConservatives:
-    CutoffD: 1.0e-12
-    MinimumValueOfD: 1.0e-12
+    CutoffD: &CutoffD 2.0e-12
+    MinimumValueOfD: &MinimumD 1.0e-12
     CutoffYe: 0.0
     MinimumValueOfYe: 0.0
     SafetyFactorForB: 1.0e-12
@@ -80,6 +80,10 @@ VariableFixing:
   LimitLorentzFactor:
     MaxDensityCutoff: 1.0e-08
     LorentzFactorCap: 10.0
+
+PrimitiveFromConservative:
+  CutoffDForInversion: *CutoffD
+  DensityWhenSkippingInversion: *MinimumD
 
 EvolutionSystem:
   ValenciaDivClean:

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdBondiMichel.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdBondiMichel.yaml
@@ -65,8 +65,8 @@ DomainCreator:
 
 VariableFixing:
   FixConservatives:
-    CutoffD: 1.0e-12
-    MinimumValueOfD: 1.0e-12
+    CutoffD: &CutoffD 1.0e-12
+    MinimumValueOfD: &MinimumD 1.0e-12
     CutoffYe: 0.0
     MinimumValueOfYe: 0.0
     SafetyFactorForB: 1.0e-12
@@ -81,6 +81,10 @@ VariableFixing:
   LimitLorentzFactor:
     MaxDensityCutoff: 1.0e-12
     LorentzFactorCap: 1.0
+
+PrimitiveFromConservative:
+  CutoffDForInversion: *CutoffD
+  DensityWhenSkippingInversion: *MinimumD
 
 Limiter:
   Minmod:

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdTovStar.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdTovStar.yaml
@@ -58,8 +58,8 @@ DomainCreator:
 
 VariableFixing:
   FixConservatives:
-    CutoffD: 1.0e-12
-    MinimumValueOfD: 1.0e-12
+    CutoffD: &CutoffD 1.0e-12
+    MinimumValueOfD: &MinimumD 1.0e-12
     CutoffYe: 0.0
     MinimumValueOfYe: 0.0
     SafetyFactorForB: 1.0e-12
@@ -74,6 +74,10 @@ VariableFixing:
   LimitLorentzFactor:
     MaxDensityCutoff: 1.0e-12
     LorentzFactorCap: 1.0
+
+PrimitiveFromConservative:
+  CutoffDForInversion: *CutoffD
+  DensityWhenSkippingInversion: *MinimumD
 
 EvolutionSystem:
   ValenciaDivClean:

--- a/tests/InputFiles/GrMhd/ValenciaDivClean/BlastWave.yaml
+++ b/tests/InputFiles/GrMhd/ValenciaDivClean/BlastWave.yaml
@@ -89,8 +89,8 @@ EvolutionSystem:
 
 VariableFixing:
   FixConservatives:
-    CutoffD: 1.0e-12
-    MinimumValueOfD: 1.0e-12
+    CutoffD: &CutoffD 1.0e-12
+    MinimumValueOfD: &MinimumD 1.0e-12
     CutoffYe: 0.0
     MinimumValueOfYe: 0.0
     SafetyFactorForB: 1.0e-12
@@ -102,6 +102,10 @@ VariableFixing:
     DensityCutoff: 1.0e-12
     TransitionDensityCutoff: 1.0e-11
     MaxVelocityMagnitude: 1.0e-4
+
+PrimitiveFromConservative:
+  CutoffDForInversion: *CutoffD
+  DensityWhenSkippingInversion: *MinimumD
 
 Observers:
   VolumeFileName: "ValenciaDivCleanBlastWaveVolume"

--- a/tests/InputFiles/GrMhd/ValenciaDivClean/FishboneMoncriefDisk.yaml
+++ b/tests/InputFiles/GrMhd/ValenciaDivClean/FishboneMoncriefDisk.yaml
@@ -98,8 +98,8 @@ EvolutionSystem:
 
 VariableFixing:
   FixConservatives:
-    CutoffD: 1.0e-12
-    MinimumValueOfD: 1.0e-12
+    CutoffD: &CutoffD 1.0e-12
+    MinimumValueOfD: &MinimumD 1.0e-12
     CutoffYe: 0.0
     MinimumValueOfYe: 0.0
     SafetyFactorForB: 1.0e-12
@@ -111,6 +111,10 @@ VariableFixing:
     DensityCutoff: 1.0e-12
     TransitionDensityCutoff: 1.0e-11
     MaxVelocityMagnitude: 1.0e-4
+
+PrimitiveFromConservative:
+  CutoffDForInversion: *CutoffD
+  DensityWhenSkippingInversion: *MinimumD
 
 EventsAndTriggers:
   - Trigger:

--- a/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/Test_FixConservativesAndComputePrims.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/Test_FixConservativesAndComputePrims.cpp
@@ -14,6 +14,7 @@
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/FixConservatives.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/KastaunEtAl.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/PrimitiveFromConservative.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/PrimitiveFromConservativeOptions.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/Tags.hpp"
 #include "Evolution/VariableFixing/Tags.hpp"
 #include "Framework/TestHelpers.hpp"
@@ -57,17 +58,25 @@ SPECTRE_TEST_CASE(
 
   const EquationsOfState::PolytropicFluid<true> eos{100.0, 2.0};
 
+  const double cutoff_d_for_inversion = 0.0;
+  const double density_when_skipping_inversion = 0.0;
+  const grmhd::ValenciaDivClean::PrimitiveFromConservativeOptions
+    primitive_from_conservative_options(cutoff_d_for_inversion,
+                                        density_when_skipping_inversion);
+
   auto box = db::create<db::AddSimpleTags<
       grmhd::ValenciaDivClean::Tags::VariablesNeededFixing,
       typename System::variables_tag, typename System::primitive_variables_tag,
       ::Tags::VariableFixer<grmhd::ValenciaDivClean::FixConservatives>,
       hydro::Tags::EquationOfState<
-          std::unique_ptr<EquationsOfState::EquationOfState<true, 1>>>>>(
+          std::unique_ptr<EquationsOfState::EquationOfState<true, 1>>>,
+      grmhd::ValenciaDivClean::Tags::PrimitiveFromConservativeOptions>>(
       false, cons_vars,
       typename System::primitive_variables_tag::type{num_pts, 1.0e-4},
       variable_fixer,
       std::unique_ptr<EquationsOfState::EquationOfState<true, 1>>{
-          std::make_unique<EquationsOfState::PolytropicFluid<true>>(eos)});
+          std::make_unique<EquationsOfState::PolytropicFluid<true>>(eos)},
+      primitive_from_conservative_options);
 
   using recovery_schemes = tmpl::list<
       grmhd::ValenciaDivClean::PrimitiveRecoverySchemes::KastaunEtAl>;
@@ -108,7 +117,8 @@ SPECTRE_TEST_CASE(
           db::get<grmhd::ValenciaDivClean::Tags::TildeS<Frame::Inertial>>(box),
           db::get<grmhd::ValenciaDivClean::Tags::TildeB<Frame::Inertial>>(box),
           db::get<grmhd::ValenciaDivClean::Tags::TildePhi>(box), spatial_metric,
-          inverse_spatial_metric, sqrt_det_spatial_metric, eos);
+          inverse_spatial_metric, sqrt_det_spatial_metric, eos,
+          primitive_from_conservative_options);
   CHECK_VARIABLES_APPROX(db::get<typename System::primitive_variables_tag>(box),
                          expected_prims);
 }

--- a/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/Test_PrimsAfterRollback.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/Test_PrimsAfterRollback.cpp
@@ -26,6 +26,7 @@
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/NewmanHamlin.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/PalenzuelaEtAl.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/PrimitiveFromConservative.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/PrimitiveFromConservativeOptions.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/System.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/Tags.hpp"
 #include "Framework/TestHelpers.hpp"
@@ -123,15 +124,22 @@ void test(const gsl::not_null<std::mt19937*> gen,
         evolution::dg::subcell::fd::ReconstructionMethod::AllDimsAtOnce);
   }
 
+  const double cutoff_d_for_inversion = 0.0;
+  const double density_when_skipping_inversion = 0.0;
+  const grmhd::ValenciaDivClean::PrimitiveFromConservativeOptions
+    primitive_from_conservative_options(cutoff_d_for_inversion,
+                                        density_when_skipping_inversion);
+
   // The DG prims are used as an initial guess so we need to provide them
   auto box = db::create<db::AddSimpleTags<
       evolution::dg::subcell::Tags::DidRollback, cons_tag, prim_tag,
       gr::Tags::SpacetimeMetric<DataVector, 3>, ::domain::Tags::Mesh<3>,
       evolution::dg::subcell::Tags::Mesh<3>,
       hydro::Tags::EquationOfState<
-          std::unique_ptr<EquationsOfState::EquationOfState<true, 1>>>>>(
+          std::unique_ptr<EquationsOfState::EquationOfState<true, 1>>>,
+      grmhd::ValenciaDivClean::Tags::PrimitiveFromConservativeOptions>>(
       did_rollback, subcell_cons, dg_prims, spacetime_metric, dg_mesh,
-      subcell_mesh, std::move(eos));
+      subcell_mesh, std::move(eos), primitive_from_conservative_options);
 
   using recovery_schemes = tmpl::list<
       grmhd::ValenciaDivClean::PrimitiveRecoverySchemes::KastaunEtAl,
@@ -177,7 +185,8 @@ void test(const gsl::not_null<std::mt19937*> gen,
         get<grmhd::ValenciaDivClean::Tags::TildeB<Frame::Inertial>>(box),
         get<grmhd::ValenciaDivClean::Tags::TildePhi>(box), spatial_metric,
         inv_spatial_metric, sqrt_det_spatial_metric,
-        db::get<hydro::Tags::EquationOfStateBase>(box));
+        db::get<hydro::Tags::EquationOfStateBase>(box),
+        primitive_from_conservative_options);
     CHECK_VARIABLES_APPROX(db::get<prim_tag>(box), expected_subcell_prims);
   } else {
     CHECK(db::get<prim_tag>(box).number_of_grid_points() == 0);

--- a/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/Test_ResizeAndComputePrimitives.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/Test_ResizeAndComputePrimitives.cpp
@@ -27,6 +27,7 @@
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/NewmanHamlin.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/PalenzuelaEtAl.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/PrimitiveFromConservative.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/PrimitiveFromConservativeOptions.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/System.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/Tags.hpp"
 #include "Framework/TestHelpers.hpp"
@@ -145,14 +146,21 @@ void test(const gsl::not_null<std::mt19937*> gen,
     compute_cons(prim_vars);
   }
 
+  const double cutoff_d_for_inversion = 0.0;
+  const double density_when_skipping_inversion = 0.0;
+  const grmhd::ValenciaDivClean::PrimitiveFromConservativeOptions
+    primitive_from_conservative_options(cutoff_d_for_inversion,
+                                        density_when_skipping_inversion);
+
   auto box = db::create<db::AddSimpleTags<
       evolution::dg::subcell::Tags::ActiveGrid, cons_tag, prim_tag,
       gr::Tags::SpacetimeMetric<DataVector, 3>, ::domain::Tags::Mesh<3>,
       evolution::dg::subcell::Tags::Mesh<3>,
       hydro::Tags::EquationOfState<
-          std::unique_ptr<EquationsOfState::EquationOfState<true, 1>>>>>(
+          std::unique_ptr<EquationsOfState::EquationOfState<true, 1>>>,
+      grmhd::ValenciaDivClean::Tags::PrimitiveFromConservativeOptions>>(
       active_grid, cons_vars, prim_vars, spacetime_metric, dg_mesh,
-      subcell_mesh, std::move(eos));
+      subcell_mesh, std::move(eos), primitive_from_conservative_options);
 
   using recovery_schemes = tmpl::list<
       grmhd::ValenciaDivClean::PrimitiveRecoverySchemes::KastaunEtAl,
@@ -188,7 +196,8 @@ void test(const gsl::not_null<std::mt19937*> gen,
         get<grmhd::ValenciaDivClean::Tags::TildeB<Frame::Inertial>>(cons_vars),
         get<grmhd::ValenciaDivClean::Tags::TildePhi>(cons_vars), spatial_metric,
         inv_spatial_metric, sqrt_det_spatial_metric,
-        db::get<hydro::Tags::EquationOfStateBase>(box));
+        db::get<hydro::Tags::EquationOfStateBase>(box),
+        primitive_from_conservative_options);
   }
   CHECK_VARIABLES_APPROX(db::get<prim_tag>(box), prim_vars);
 }

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Test_Flattener.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Test_Flattener.cpp
@@ -10,6 +10,7 @@
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Variables.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/Flattener.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/PrimitiveFromConservativeOptions.hpp"
 #include "Framework/TestHelpers.hpp"
 #include "NumericalAlgorithms/LinearOperators/DefiniteIntegral.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
@@ -74,6 +75,12 @@ SPECTRE_TEST_CASE("Unit.GrMhd.ValenciaDivClean.Flattener", "[Unit][GrMhd]") {
             grmhd::ValenciaDivClean::PrimitiveRecoverySchemes::KastaunEtAl>>{
             true, true, false, false});
 
+  const double cutoff_d_for_inversion = 0.0;
+  const double density_when_skipping_inversion = 0.0;
+  const grmhd::ValenciaDivClean::PrimitiveFromConservativeOptions
+    primitive_from_conservative_options(cutoff_d_for_inversion,
+                                        density_when_skipping_inversion);
+
   {
     INFO("Case: NoOp");
     Scalar<DataVector> tilde_d(
@@ -99,7 +106,8 @@ SPECTRE_TEST_CASE("Unit.GrMhd.ValenciaDivClean.Flattener", "[Unit][GrMhd]") {
               make_not_null(&tilde_tau), make_not_null(&tilde_s),
               make_not_null(&prims), tilde_b, tilde_phi,
               sqrt_det_spatial_metric, spatial_metric, inverse_spatial_metric,
-              mesh, det_logical_to_inertial_jacobian, ideal_fluid);
+              mesh, det_logical_to_inertial_jacobian, ideal_fluid,
+              primitive_from_conservative_options);
 
     CHECK_ITERABLE_APPROX(tilde_d, expected_tilde_d);
     CHECK_ITERABLE_APPROX(tilde_ye, expected_tilde_ye);
@@ -160,7 +168,8 @@ SPECTRE_TEST_CASE("Unit.GrMhd.ValenciaDivClean.Flattener", "[Unit][GrMhd]") {
               make_not_null(&tilde_tau), make_not_null(&tilde_s),
               make_not_null(&prims), tilde_b, tilde_phi,
               sqrt_det_spatial_metric, spatial_metric, inverse_spatial_metric,
-              mesh, det_logical_to_inertial_jacobian, ideal_fluid);
+              mesh, det_logical_to_inertial_jacobian, ideal_fluid,
+              primitive_from_conservative_options);
 
     // check 1) action, 2) positive tilde_d, 3) all fields changed
     CHECK(min(get(tilde_d)) > 0.);
@@ -238,7 +247,8 @@ SPECTRE_TEST_CASE("Unit.GrMhd.ValenciaDivClean.Flattener", "[Unit][GrMhd]") {
               make_not_null(&tilde_tau), make_not_null(&tilde_s),
               make_not_null(&prims), tilde_b, tilde_phi,
               sqrt_det_spatial_metric, spatial_metric, inverse_spatial_metric,
-              mesh, det_logical_to_inertial_jacobian, ideal_fluid);
+              mesh, det_logical_to_inertial_jacobian, ideal_fluid,
+              primitive_from_conservative_options);
 
     CHECK(definite_integral(
               get(det_logical_to_inertial_jacobian) * get(tilde_d), mesh) /

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Test_PrimitiveFromConservative.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Test_PrimitiveFromConservative.cpp
@@ -16,6 +16,7 @@
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/NewmanHamlin.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/PalenzuelaEtAl.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/PrimitiveFromConservative.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/PrimitiveFromConservativeOptions.hpp"
 #include "Framework/TestHelpers.hpp"
 #include "Helpers/PointwiseFunctions/GeneralRelativity/TestHelpers.hpp"
 #include "Helpers/PointwiseFunctions/Hydro/TestHelpers.hpp"
@@ -110,6 +111,12 @@ void test_primitive_from_conservative_random(
       expected_magnetic_field, sqrt_det_spatial_metric, spatial_metric,
       expected_divergence_cleaning_field);
 
+  const double cutoff_d_for_inversion = 0.0;
+  const double density_when_skipping_inversion = 0.0;
+  const grmhd::ValenciaDivClean::PrimitiveFromConservativeOptions
+    primitive_from_conservative_options(cutoff_d_for_inversion,
+                                        density_when_skipping_inversion);
+
   Scalar<DataVector> rest_mass_density(number_of_points);
   Scalar<DataVector> electron_fraction(number_of_points);
   Scalar<DataVector> specific_internal_energy(number_of_points);
@@ -130,7 +137,8 @@ void test_primitive_from_conservative_random(
           make_not_null(&lorentz_factor), make_not_null(&pressure),
           make_not_null(&specific_enthalpy), tilde_d, tilde_ye, tilde_tau,
           tilde_s, tilde_b, tilde_phi, spatial_metric, inv_spatial_metric,
-          sqrt_det_spatial_metric, equation_of_state);
+          sqrt_det_spatial_metric, equation_of_state,
+          primitive_from_conservative_options);
 
   Approx larger_approx =
       Approx::custom().epsilon(std::numeric_limits<double>::epsilon() * 1.e8);
@@ -198,6 +206,12 @@ void test_primitive_from_conservative_known(const DataVector& used_for_size) {
   tnsr::I<DataVector, 3> tilde_b(number_of_points);
   Scalar<DataVector> tilde_phi(number_of_points);
 
+  const double cutoff_d_for_inversion = 0.0;
+  const double density_when_skipping_inversion = 0.0;
+  const grmhd::ValenciaDivClean::PrimitiveFromConservativeOptions
+    primitive_from_conservative_options(cutoff_d_for_inversion,
+                                        density_when_skipping_inversion);
+
   grmhd::ValenciaDivClean::ConservativeFromPrimitive::apply(
       make_not_null(&tilde_d), make_not_null(&tilde_ye),
       make_not_null(&tilde_tau), make_not_null(&tilde_s),
@@ -229,7 +243,8 @@ void test_primitive_from_conservative_known(const DataVector& used_for_size) {
           make_not_null(&lorentz_factor), make_not_null(&pressure),
           make_not_null(&specific_enthalpy), tilde_d, tilde_ye, tilde_tau,
           tilde_s, tilde_b, tilde_phi, spatial_metric, inv_spatial_metric,
-          sqrt_det_spatial_metric, ideal_fluid);
+          sqrt_det_spatial_metric, ideal_fluid,
+          primitive_from_conservative_options);
 
   CHECK_ITERABLE_APPROX(expected_rest_mass_density, rest_mass_density);
   CHECK_ITERABLE_APPROX(expected_electron_fraction, electron_fraction);


### PR DESCRIPTION
## Proposed changes

Add a new set of input files options, passed to PrimitiveFromConservative.
Currently, only use these options to skip Con2Prim recovery in the atmosphere (inverting low-density points that are later overwritten by FixAtmosphere can be costly)

### Upgrade instructions

Input files for all executables based of ValenciaDivClean and GhValenciaDivClean need to provide the new option.

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.