### PR TITLE
Preparation for adding AMR projectors

### DIFF
--- a/src/DataStructures/DataBox/DataBox.hpp
+++ b/src/DataStructures/DataBox/DataBox.hpp
@@ -275,6 +275,7 @@ class DataBox<tmpl::list<Tags...>> : private detail::Item<Tags>... {
   std::string print_types() const;
 
   /// Print the items
+  template <bool PrintImmutableItems = true>
   std::string print_items() const;
 
   /// Retrieve the tag `Tag`, should be called by the free function db::get
@@ -431,6 +432,7 @@ std::string DataBox<tmpl::list<Tags...>>::print_types() const {
 }
 
 template <typename... Tags>
+template <bool PrintImmutableItems>
 std::string DataBox<tmpl::list<Tags...>>::print_items() const {
   std::ostringstream os;
   os << "Items:\n";
@@ -448,7 +450,9 @@ std::string DataBox<tmpl::list<Tags...>>::print_items() const {
     }
   };
   tmpl::for_each<mutable_item_creation_tags>(print_item);
-  tmpl::for_each<immutable_item_creation_tags>(print_item);
+  if constexpr (PrintImmutableItems) {
+    tmpl::for_each<immutable_item_creation_tags>(print_item);
+  }
   return os.str();
 }
 

--- a/src/Executables/Examples/RandomAmr/RandomAmr.hpp
+++ b/src/Executables/Examples/RandomAmr/RandomAmr.hpp
@@ -13,7 +13,9 @@
 #include "Domain/Creators/Factory3D.hpp"
 #include "Domain/Creators/RegisterDerivedWithCharm.hpp"
 #include "Domain/Structure/ElementId.hpp"
+#include "Domain/Tags.hpp"
 #include "Evolution/DiscontinuousGalerkin/DgElementArray.hpp"
+#include "Evolution/TagsDomain.hpp"
 #include "Executables/Examples/RandomAmr/InitializeDomain.hpp"
 #include "Options/Protocols/FactoryCreation.hpp"
 #include "Options/String.hpp"
@@ -34,6 +36,7 @@
 #include "ParallelAlgorithms/Amr/Criteria/DriveToTarget.hpp"
 #include "ParallelAlgorithms/Amr/Criteria/Random.hpp"
 #include "ParallelAlgorithms/Amr/Criteria/Tags/Criteria.hpp"
+#include "ParallelAlgorithms/Amr/Projectors/DefaultInitialize.hpp"
 #include "ParallelAlgorithms/Amr/Protocols/AmrMetavariables.hpp"
 #include "ParallelAlgorithms/EventsAndTriggers/LogicalTriggers.hpp"
 #include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
@@ -110,7 +113,10 @@ struct RandomAmrMetavars {
   void pup(PUP::er& /*p*/) {}
 
   struct amr : tt::ConformsTo<::amr::protocols::AmrMetavariables> {
-    using projectors = tmpl::list<>;
+    using projectors = tmpl::list<::amr::projectors::DefaultInitialize<
+        domain::Tags::InitialExtents<Dim>,
+        domain::Tags::InitialRefinementLevels<Dim>,
+        evolution::dg::Tags::Quadrature>>;
   };
 };
 

--- a/src/Executables/ExportCoordinates/ExportCoordinates.hpp
+++ b/src/Executables/ExportCoordinates/ExportCoordinates.hpp
@@ -28,6 +28,7 @@
 #include "Evolution/DiscontinuousGalerkin/DgElementArray.hpp"
 #include "Evolution/Initialization/DgDomain.hpp"
 #include "Evolution/Initialization/Evolution.hpp"
+#include "Evolution/Initialization/Tags.hpp"
 #include "IO/Observer/Actions/RegisterWithObservers.hpp"
 #include "IO/Observer/ArrayComponentId.hpp"
 #include "IO/Observer/Helpers.hpp"
@@ -66,6 +67,7 @@
 #include "ParallelAlgorithms/Amr/Criteria/Random.hpp"
 #include "ParallelAlgorithms/Amr/Criteria/Tags/Criteria.hpp"
 #include "ParallelAlgorithms/Amr/Criteria/TruncationError.hpp"
+#include "ParallelAlgorithms/Amr/Projectors/DefaultInitialize.hpp"
 #include "ParallelAlgorithms/Amr/Protocols/AmrMetavariables.hpp"
 #include "ParallelAlgorithms/EventsAndTriggers/Completion.hpp"
 #include "ParallelAlgorithms/EventsAndTriggers/Event.hpp"
@@ -327,9 +329,16 @@ struct Metavariables {
                      Actions::FindGlobalMinimumGridSpacing>>;
 
   struct amr : tt::ConformsTo<::amr::protocols::AmrMetavariables> {
-    using projectors =
-        tmpl::list<Initialization::ProjectTimeStepping<volume_dim>,
-                   evolution::dg::Initialization::ProjectDomain<volume_dim>>;
+    using projectors = tmpl::list<
+        Initialization::ProjectTimeStepping<volume_dim>,
+        evolution::dg::Initialization::ProjectDomain<volume_dim>,
+        ::amr::projectors::DefaultInitialize<
+            Initialization::Tags::InitialTimeDelta,
+            Initialization::Tags::InitialSlabSize<local_time_stepping>,
+            ::domain::Tags::InitialExtents<Dim>,
+            ::domain::Tags::InitialRefinementLevels<Dim>,
+            evolution::dg::Tags::Quadrature,
+            evolution::dg::Tags::NeighborMesh<Dim>>>;
   };
 
   using dg_element_array = DgElementArray<

--- a/src/Parallel/Tags/CMakeLists.txt
+++ b/src/Parallel/Tags/CMakeLists.txt
@@ -6,6 +6,7 @@ spectre_target_headers(
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   ArrayIndex.hpp
+  DistributedObjectTags.hpp
   InputSource.hpp
   Metavariables.hpp
   ResourceInfo.hpp

--- a/src/Parallel/Tags/DistributedObjectTags.hpp
+++ b/src/Parallel/Tags/DistributedObjectTags.hpp
@@ -1,0 +1,28 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "Utilities/TMPL.hpp"
+
+namespace Parallel::Tags {
+/// \cond
+template <typename Index>
+struct ArrayIndexImpl;
+template <typename Metavariables>
+struct GlobalCacheProxy;
+template <typename Metavariables>
+struct MetavariablesImpl;
+/// \endcond
+
+/// \brief List of tags for mutable items that are automatically added to
+/// the DataBox of a DistributedObject
+///
+/// \details It is the responsibility of DistributedObject to initialize the
+/// mutable items corresponding to these tags.
+template <typename Metavariables, typename Index>
+using distributed_object_tags =
+    tmpl::list<Tags::MetavariablesImpl<Metavariables>,
+               Tags::ArrayIndexImpl<Index>,
+               Tags::GlobalCacheProxy<Metavariables>>;
+}  // namespace Parallel::Tags

--- a/src/ParallelAlgorithms/Amr/Projectors/CMakeLists.txt
+++ b/src/ParallelAlgorithms/Amr/Projectors/CMakeLists.txt
@@ -15,6 +15,7 @@ spectre_target_headers(
   ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
+  DefaultInitialize.hpp
   Mesh.hpp
   )
 

--- a/src/ParallelAlgorithms/Amr/Projectors/DefaultInitialize.hpp
+++ b/src/ParallelAlgorithms/Amr/Projectors/DefaultInitialize.hpp
@@ -1,0 +1,56 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <utility>
+
+#include "ParallelAlgorithms/Amr/Protocols/Projector.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+template <size_t Dim>
+class Element;
+template <size_t Dim>
+class Mesh;
+/// \endcond
+
+namespace amr::projectors {
+
+/// \brief Value initialize the items corresponding to Tags
+///
+/// There is a specialization for `DefaultInitialize<tmpl::list<Tags...>>` that
+/// can be used if a `tmpl::list` is available.
+///
+/// \details For each item corresponding to each tag, value initialize
+/// the item by setting it equal to an object constructed with an
+/// empty initializer.  This is the default state of mutable items in
+/// a DataBox if they are neither set from input file options, nor
+/// mutated by initialization actions.
+template <typename... Tags>
+struct DefaultInitialize : tt::ConformsTo<amr::protocols::Projector> {
+  using return_tags = tmpl::list<Tags...>;
+  using argument_tags = tmpl::list<>;
+
+  template <size_t Dim>
+  static void apply(
+      const gsl::not_null<typename Tags::type*>... items,
+      const std::pair<Mesh<Dim>, Element<Dim>>& /*old_mesh_and_element*/) {
+    expand_pack((*items = std::decay_t<decltype(*items)>{})...);
+  }
+
+  template <typename FinalArg>
+  static void apply(const gsl::not_null<typename Tags::type*>... /*items*/,
+                    const FinalArg& /*parent_or_children_items*/) {
+    // Mutable items on newly created elements are already value initialized
+  }
+};
+
+/// \cond
+template <typename... Tags>
+struct DefaultInitialize<tmpl::list<Tags...>>
+    : public DefaultInitialize<Tags...> {};
+/// \endcond
+}  // namespace amr::projectors

--- a/tests/Unit/DataStructures/DataBox/Test_DataBox.cpp
+++ b/tests/Unit/DataStructures/DataBox/Test_DataBox.cpp
@@ -2790,7 +2790,23 @@ void test_output() {
   remove_whitespace(expected_types);
   CHECK(output_types == expected_types);
 
-  std::string output_items = box.print_items();
+  std::string output_mutable_items = box.print_items<false>();
+  std::string expected_mutable_items =
+      "Items:\n"
+      "----------\n"
+      "Name:  (anonymous namespace)::test_databox_tags::Tag0\n"
+      "Type:  double\n"
+      "Value: 3.14\n"
+      "----------\n"
+      "Name:  (anonymous namespace)::test_databox_tags::Tag1\n"
+      "Type:  std::vector<double>\n"
+      "Value: (8.7,93.2,84.7)\n"
+      "----------\n"
+      "Name:  (anonymous namespace)::test_databox_tags::Tag2\n"
+      "Type:  std::string\n"
+      "Value: My Sample String\n";
+  CHECK(output_mutable_items == expected_mutable_items);
+  std::string output_items = box.print_items<true>();
   std::string expected_items =
       "Items:\n"
       "----------\n"

--- a/tests/Unit/ParallelAlgorithms/Amr/Actions/Test_AdjustDomain.cpp
+++ b/tests/Unit/ParallelAlgorithms/Amr/Actions/Test_AdjustDomain.cpp
@@ -31,6 +31,7 @@
 #include "ParallelAlgorithms/Amr/Actions/Component.hpp"
 #include "ParallelAlgorithms/Amr/Actions/CreateChild.hpp"
 #include "ParallelAlgorithms/Amr/Actions/CreateParent.hpp"
+#include "ParallelAlgorithms/Amr/Projectors/DefaultInitialize.hpp"
 #include "ParallelAlgorithms/Amr/Protocols/AmrMetavariables.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -117,7 +118,8 @@ struct Metavariables {
   void pup(PUP::er& /*p*/) {}
 
   struct amr : tt::ConformsTo<::amr::protocols::AmrMetavariables> {
-    using projectors = tmpl::list<>;
+    using projectors = tmpl::list<::amr::projectors::DefaultInitialize<
+        Parallel::Tags::GlobalCacheImpl<Metavariables>>>;
   };
 };
 

--- a/tests/Unit/ParallelAlgorithms/Amr/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/Amr/CMakeLists.txt
@@ -18,6 +18,7 @@ set(LIBRARY_SOURCES
   Criteria/Test_DriveToTarget.cpp
   Criteria/Test_Random.cpp
   Criteria/Test_TruncationError.cpp
+  Projectors/Test_DefaultInitialize.cpp
   Projectors/Test_Mesh.cpp
   Test_Protocols.cpp
   )

--- a/tests/Unit/ParallelAlgorithms/Amr/Projectors/Test_DefaultInitialize.cpp
+++ b/tests/Unit/ParallelAlgorithms/Amr/Projectors/Test_DefaultInitialize.cpp
@@ -1,0 +1,57 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <utility>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/Tag.hpp"
+#include "Domain/Structure/DirectionMap.hpp"
+#include "Domain/Structure/Element.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Domain/Structure/Neighbors.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "ParallelAlgorithms/Amr/Projectors/DefaultInitialize.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+struct DefaultTagInt : db::SimpleTag {
+  using type = int;
+};
+
+struct DefaultTagDouble : db::SimpleTag {
+  using type = double;
+};
+
+void test_p_refinement() {
+  const ElementId<1> element_id{0};
+  Element<1> element{element_id, DirectionMap<1, Neighbors<1>>{}};
+  const Mesh<1> mesh{2, Spectral::Basis::Legendre,
+                     Spectral::Quadrature::GaussLobatto};
+  auto box =
+      db::create<db::AddSimpleTags<DefaultTagInt, DefaultTagDouble>>(3, 4.2);
+  db::mutate_apply<
+      amr::projectors::DefaultInitialize<DefaultTagInt, DefaultTagDouble>>(
+      make_not_null(&box), std::make_pair(mesh, element));
+  CHECK(db::get<DefaultTagInt>(box) == int{});
+  CHECK(db::get<DefaultTagDouble>(box) == double{});
+}
+
+void test_h_refinement() {
+  auto box = db::DataBox<tmpl::list<DefaultTagInt, DefaultTagDouble>>{};
+  char unused_extra_arg{'Y'};
+  db::mutate_apply<amr::projectors::DefaultInitialize<
+      tmpl::list<DefaultTagInt, DefaultTagDouble>>>(make_not_null(&box),
+                                                    unused_extra_arg);
+  CHECK(db::get<DefaultTagInt>(box) == int{});
+  CHECK(db::get<DefaultTagDouble>(box) == double{});
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Amr.Projectors.DefaultInitialize", "[Domain][Unit]") {
+  test_p_refinement();
+  test_h_refinement();
+}

--- a/tests/Unit/Utilities/Test_TaggedTuple.cpp
+++ b/tests/Unit/Utilities/Test_TaggedTuple.cpp
@@ -87,9 +87,31 @@ void test_general() {
   static_assert(tuples::TaggedTuple<name, age, email>::size() == 3,
                 "Failed to test size of TaggedTuple");
   {
+    const std::string expected_output =
+      "TaggedTuple:\n"
+      "----------\n"
+      "Name:  (anonymous namespace)::name\n"
+      "Type:  std::string\n"
+      "Value: bla\n"
+      "----------\n"
+      "Name:  (anonymous namespace)::age\n"
+      "Type:  int\n"
+      "Value: 17\n"
+      "----------\n"
+      "Name:  (anonymous namespace)::email\n"
+      "Type:  std::string\n"
+      "Value: bla@bla.bla\n"
+      "----------\n"
+      "Name:  (anonymous namespace)::parents\n"
+      "Type:  std::vector<std::string>\n"
+      "Value: (Mom,Dad)\n"
+      "----------\n"
+      "Name:  (anonymous namespace)::not_streamable_tag\n"
+      "Type:  (anonymous namespace)::not_streamable\n"
+      "Value: UNSTREAMABLE\n";
     std::stringstream ss;
     ss << test;
-    CHECK(ss.str() == "(bla, 17, bla@bla.bla, (Mom,Dad), NOT STREAMABLE)");
+    CHECK(ss.str() == expected_output);
   }
   CHECK(test.size() == 5);
   // [get_example]
@@ -110,9 +132,10 @@ void test_general() {
   CHECK(17 == tuples::get<age>(test2));
 
   {
+    const std::string expected_output = "TaggedTuple:\n";
     std::stringstream ss;
     ss << tuples::TaggedTuple<>{};
-    CHECK(ss.str() == "()");
+    CHECK(ss.str() == expected_output);
   }
 
   test_serialization(test2);


### PR DESCRIPTION
## Proposed changes

- Allow printing only mutable items in a DataBox
- Print more information when streaming a TaggedTuple
- Factor out list of tags initialized in a DistributedObject
- Add an AMR projector that default initializes items
- Add check in AdjustDomain that all mutable items are projected

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

You will now need to explicitly default initialize any items that were previously default initialized implicitly.
This is done by adding `::amr::projectors::DefaultInitialize<Tag0, Tag1, ...>` to the list of `amr::projectors` in the metavariables of an executable.

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
