### PR TITLE
Move ::Tags::StepChoosers to the GlobalCache

### DIFF
--- a/src/Evolution/Initialization/Evolution.hpp
+++ b/src/Evolution/Initialization/Evolution.hpp
@@ -83,8 +83,10 @@ struct TimeStepping {
 
   /// Tags for constant items added to the GlobalCache.  These items are
   /// initialized from input file options.
-  using const_global_cache_tags =
-      tmpl::list<::Tags::TimeStepper<TimeStepperType>>;
+  using const_global_cache_tags = tmpl::conditional_t<
+      UsingLts,
+      tmpl::list<::Tags::TimeStepper<TimeStepperType>, ::Tags::StepChoosers>,
+      tmpl::list<::Tags::TimeStepper<TimeStepperType>>>;
 
   /// Tags for mutable items added to the GlobalCache.  These items are
   /// initialized from input file options.
@@ -96,10 +98,9 @@ struct TimeStepping {
                                    ::Tags::TimeStepper<TimeStepperType>>;
 
   /// Tags for simple DataBox items that are initialized from input file options
-  using simple_tags_from_options = tmpl::flatten<tmpl::list<
-      ::Tags::Time, Tags::InitialTimeDelta, Tags::InitialSlabSize<UsingLts>,
-      tmpl::conditional_t<UsingLts, tmpl::list<::Tags::StepChoosers>,
-                          tmpl::list<>>>>;
+  using simple_tags_from_options =
+      tmpl::list<::Tags::Time, Tags::InitialTimeDelta,
+                 Tags::InitialSlabSize<UsingLts>>;
 
   /// Tags for simple DataBox items that are default initialized.
   using default_initialized_simple_tags = tmpl::push_back<


### PR DESCRIPTION
The StepChoosers are the same on every Element and are never mutated after being constructed from input file options.

## Proposed changes

Move ::Tags::StepChoosers to the GlobalCache

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
