### PR TITLE
Run some input files only in one CI build

### DIFF
--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -381,10 +381,14 @@ jobs:
           # libraries. Building all the tests without the PCH takes very long
           # and the most we would catch is a missing include of something that's
           # in the PCH.
+          # Use this test also to build and test all input files with "normal"
+          # or higher priority. The other configurations only test input files
+          # with "high" priority to reduce the total build time.
           - compiler: clang-10
             build_type: Debug
             use_pch: OFF
             unit_tests: OFF
+            input_file_tests_min_priority: "normal"
             ccache_max_size: 600M
           # Full clang-10 build to catch any incompatibilities.
           - compiler: clang-10
@@ -516,6 +520,7 @@ ${{ env.CACHE_KEY_SUFFIX }}"
           USE_XSIMD=${{ matrix.use_xsimd }}
           COVERAGE=${{ matrix.COVERAGE }}
           TEST_TIMEOUT_FACTOR=${{ matrix.TEST_TIMEOUT_FACTOR }}
+          INPUT_FILE_MIN_PRIO=${{ matrix.input_file_tests_min_priority }}
 
           ${CMAKE_EXECUTABLE:-'cmake'}
           -D CMAKE_C_COMPILER=${CC}
@@ -527,6 +532,7 @@ ${{ env.CACHE_KEY_SUFFIX }}"
           -D CMAKE_BUILD_TYPE=${{ matrix.build_type }}
           -D DEBUG_SYMBOLS=OFF
           -D UNIT_TESTS_IN_TEST_EXECUTABLES=OFF
+          -D SPECTRE_INPUT_FILE_TEST_MIN_PRIORITY=${INPUT_FILE_MIN_PRIO:-'high'}
           -D STRIP_SYMBOLS=ON
           -D STUB_EXECUTABLE_OBJECT_FILES=ON
           -D STUB_LIBRARY_OBJECT_FILES=ON

--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -384,6 +384,7 @@ jobs:
           - compiler: clang-10
             build_type: Debug
             use_pch: OFF
+            unit_tests: OFF
             ccache_max_size: 600M
           # Full clang-10 build to catch any incompatibilities.
           - compiler: clang-10
@@ -552,12 +553,12 @@ ${{ env.CACHE_KEY_SUFFIX }}"
         run: |
           ! grep -A 6 "CMake Warning" ./CMakeOutput.txt
       - name: Build unit tests
-        if: matrix.use_pch != 'OFF'
+        if: matrix.unit_tests != 'OFF'
         working-directory: /work/build
         run: |
           make -j2 unit-tests
       - name: Run unit tests
-        if: matrix.use_pch != 'OFF' && matrix.COVERAGE != 'ON'
+        if: matrix.unit_tests != 'OFF' && matrix.COVERAGE != 'ON'
         working-directory: /work/build
         run: |
           # We get occasional random timeouts, repeat tests to see if

--- a/docs/DevGuide/BuildSystem.md
+++ b/docs/DevGuide/BuildSystem.md
@@ -277,6 +277,10 @@ cmake -D FLAG1=OPT1 ... -D FLAGN=OPTN <SPECTRE_ROOT>
   - Set to a path to a SpEC installation (the SpEC repository root) to link in
     SpEC libraries. In particular, the SpEC::Exporter library is linked in and
     enables loading SpEC data into SpECTRE. See \ref installation for details.
+- SPECTRE_INPUT_FILE_TEST_MIN_PRIORITY
+  - Minimum priority of input file tests to run. Possible values are: `low` (not
+    usually run on CI), `normal` (run at least once on CI), `high` (run always
+    on CI). (default is `normal`)
 - SPECTRE_TEST_RUNNER
   - Run test executables through a wrapper.  This might be `charmrun`, for
     example.  (default is to not use one)

--- a/docs/DevGuide/WritingTests.md
+++ b/docs/DevGuide/WritingTests.md
@@ -315,3 +315,6 @@ following properties are available:
 - `ExpectedExitCode` (optional): The expected exit code of the executable.
   Default: `0`. See `Parallel::ExitCode` for possible exit codes.
 - `Timeout` (optional): Timeout for the test. Default: 2 seconds.
+- `Priority` (optional): Priority of running this test on CI. Possible values
+  are: `low` (not usually run on CI), `normal` (run at least once on CI), `high`
+  (run always on CI). Default: `normal`.

--- a/tests/InputFiles/Burgers/Step.yaml
+++ b/tests/InputFiles/Burgers/Step.yaml
@@ -6,6 +6,7 @@ Testing:
   CommandLineArgs: +balancer RandCentLB +p2
   Timeout: 5
   Check: parse;execute
+  Priority: High
 
 ---
 

--- a/tests/InputFiles/Cce/AnalyticTestBouncingBlackHole.yaml
+++ b/tests/InputFiles/Cce/AnalyticTestBouncingBlackHole.yaml
@@ -5,6 +5,7 @@ Executable: AnalyticTestCharacteristicExtract
 Testing:
   Check: parse;execute_check_output
   Timeout: 10
+  Priority: High
 ExpectedOutput:
   - CharacteristicExtractReduction.h5
 OutputFileChecks:

--- a/tests/InputFiles/Cce/AnalyticTestGaugeWave.yaml
+++ b/tests/InputFiles/Cce/AnalyticTestGaugeWave.yaml
@@ -5,6 +5,7 @@ Executable: AnalyticTestCharacteristicExtract
 Testing:
   Check: parse;execute_check_output
   Timeout: 10
+  Priority: High
 ExpectedOutput:
   - CharacteristicExtractReduction.h5
 OutputFileChecks:

--- a/tests/InputFiles/Cce/AnalyticTestLinearizedBondiSachs.yaml
+++ b/tests/InputFiles/Cce/AnalyticTestLinearizedBondiSachs.yaml
@@ -5,6 +5,7 @@ Executable: AnalyticTestCharacteristicExtract
 Testing:
   Check: parse;execute_check_output
   Timeout: 10
+  Priority: High
 ExpectedOutput:
   - CharacteristicExtractReduction.h5
 OutputFileChecks:

--- a/tests/InputFiles/Cce/AnalyticTestRobinsonTrautman.yaml
+++ b/tests/InputFiles/Cce/AnalyticTestRobinsonTrautman.yaml
@@ -5,6 +5,7 @@ Executable: AnalyticTestCharacteristicExtract
 Testing:
   Check: parse;execute_check_output
   Timeout: 20
+  Priority: High
 ExpectedOutput:
   - CharacteristicExtractReduction.h5
 OutputFileChecks:

--- a/tests/InputFiles/Cce/AnalyticTestRotatingSchwarzschild.yaml
+++ b/tests/InputFiles/Cce/AnalyticTestRotatingSchwarzschild.yaml
@@ -5,6 +5,7 @@ Executable: AnalyticTestCharacteristicExtract
 Testing:
   Check: parse;execute_check_output
   Timeout: 10
+  Priority: High
 ExpectedOutput:
   - CharacteristicExtractReduction.h5
 OutputFileChecks:

--- a/tests/InputFiles/Cce/AnalyticTestTeukolskyWave.yaml
+++ b/tests/InputFiles/Cce/AnalyticTestTeukolskyWave.yaml
@@ -5,6 +5,7 @@ Executable: AnalyticTestCharacteristicExtract
 Testing:
   Check: parse;execute_check_output
   Timeout: 10
+  Priority: High
 ExpectedOutput:
   - CharacteristicExtractReduction.h5
 OutputFileChecks:

--- a/tests/InputFiles/Cce/CharacteristicExtract.yaml
+++ b/tests/InputFiles/Cce/CharacteristicExtract.yaml
@@ -4,6 +4,7 @@
 Executable: CharacteristicExtract
 Testing:
   Check: parse
+  Priority: High
 
 ---
 

--- a/tests/InputFiles/CurvedScalarWave/PlaneWaveMinkowski3D.yaml
+++ b/tests/InputFiles/CurvedScalarWave/PlaneWaveMinkowski3D.yaml
@@ -5,6 +5,7 @@ Executable: EvolveCurvedScalarWavePlaneWaveMinkowski3D
 Testing:
   Check: parse;execute_check_output
   Timeout: 15
+  Priority: High
 ExpectedOutput:
   - PlaneWaveMinkowski3DVolume0.h5
   - PlaneWaveMinkowski3DReductions.h5

--- a/tests/InputFiles/CurvedScalarWave/WorldtubeKerrSchild.yaml
+++ b/tests/InputFiles/CurvedScalarWave/WorldtubeKerrSchild.yaml
@@ -4,6 +4,7 @@
 Executable: EvolveWorldtubeCurvedScalarWaveKerrSchild3D
 Testing:
   Check: parse
+  Priority: High
 
 ---
 

--- a/tests/InputFiles/Elasticity/HalfSpaceMirror.yaml
+++ b/tests/InputFiles/Elasticity/HalfSpaceMirror.yaml
@@ -5,6 +5,7 @@ Executable: SolveElasticity3D
 Testing:
   Check: parse;execute_check_output
   Timeout: 45
+  Priority: High
 ExpectedOutput:
   - ElasticHalfSpaceMirrorReductions.h5
   - ElasticHalfSpaceMirrorVolume0.h5

--- a/tests/InputFiles/ExampleExecutables/HelloWorldNoCharm.yaml
+++ b/tests/InputFiles/ExampleExecutables/HelloWorldNoCharm.yaml
@@ -4,5 +4,6 @@
 Executable: HelloWorldNoCharm
 Testing:
   Check: parse;execute
+  Priority: High
 
 ---

--- a/tests/InputFiles/ExampleExecutables/RandomAmr1D.yaml
+++ b/tests/InputFiles/ExampleExecutables/RandomAmr1D.yaml
@@ -6,6 +6,7 @@ Testing:
   Check: parse;execute
   Timeout: 10
   ExpectedExitCode: 2
+  Priority: High
 ExpectedOutput:
   - Checkpoints/Checkpoint_0000
 

--- a/tests/InputFiles/ExampleExecutables/SingletonHelloWorld.yaml
+++ b/tests/InputFiles/ExampleExecutables/SingletonHelloWorld.yaml
@@ -4,6 +4,7 @@
 Executable: SingletonHelloWorld
 Testing:
   Check: parse;execute
+  Priority: High
 
 ---
 

--- a/tests/InputFiles/ExportCoordinates/Input1D.yaml
+++ b/tests/InputFiles/ExportCoordinates/Input1D.yaml
@@ -4,6 +4,7 @@
 Executable: ExportCoordinates1D
 Testing:
   Check: parse;execute
+  Priority: High
 ExpectedOutput:
   - ExportCoordinates1DVolume0.h5
   - ExportCoordinates1DReductions.h5

--- a/tests/InputFiles/ExportCoordinates/Input2D.yaml
+++ b/tests/InputFiles/ExportCoordinates/Input2D.yaml
@@ -4,6 +4,7 @@
 Executable: ExportCoordinates2D
 Testing:
   Check: parse;execute
+  Priority: High
 ExpectedOutput:
   - ExportCoordinates2DVolume0.h5
   - ExportCoordinates2DReductions.h5

--- a/tests/InputFiles/ExportCoordinates/Input3D.yaml
+++ b/tests/InputFiles/ExportCoordinates/Input3D.yaml
@@ -4,6 +4,7 @@
 Executable: ExportCoordinates3D
 Testing:
   Check: parse;execute
+  Priority: High
 ExpectedOutput:
   - ExportCoordinates3DVolume0.h5
   - ExportCoordinates3DReductions.h5

--- a/tests/InputFiles/ExportCoordinates/InputTimeDependent3D.yaml
+++ b/tests/InputFiles/ExportCoordinates/InputTimeDependent3D.yaml
@@ -5,6 +5,7 @@ Executable: ExportTimeDependentCoordinates3D
 Testing:
   Check: parse;execute
   Timeout: 10
+  Priority: High
 ExpectedOutput:
   - ExportTimeDependentCoordinates3DVolume0.h5
   - ExportTimeDependentCoordinates3DReductions.h5

--- a/tests/InputFiles/ExportEquationOfStateForRotNS/ExportEosForRotNS.yaml
+++ b/tests/InputFiles/ExportEquationOfStateForRotNS/ExportEosForRotNS.yaml
@@ -4,6 +4,7 @@
 Executable: ExportEquationOfStateForRotNS
 Testing:
   Check: parse;execute
+  Priority: High
 ExpectedOutput:
   - EOS.GN
 

--- a/tests/InputFiles/FindHorizons/FindHorizons3D.yaml
+++ b/tests/InputFiles/FindHorizons/FindHorizons3D.yaml
@@ -4,6 +4,7 @@
 Executable: FindHorizons3D
 Testing:
   Check: parse
+  Priority: High
 
 ---
 

--- a/tests/InputFiles/ForceFree/FastWave.yaml
+++ b/tests/InputFiles/ForceFree/FastWave.yaml
@@ -4,6 +4,7 @@
 Executable: EvolveForceFree
 Testing:
   Check: parse;execute
+  Priority: High
 
 ---
 

--- a/tests/InputFiles/GeneralizedHarmonic/BinaryBlackHole.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/BinaryBlackHole.yaml
@@ -4,6 +4,7 @@
 Executable: EvolveGhBinaryBlackHole
 Testing:
   Check: parse
+  Priority: High
 
 ---
 

--- a/tests/InputFiles/GeneralizedHarmonic/CylindricalBinaryBlackHole.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/CylindricalBinaryBlackHole.yaml
@@ -4,6 +4,7 @@
 Executable: EvolveGhBinaryBlackHole
 Testing:
   Check: parse
+  Priority: High
 
 ---
 

--- a/tests/InputFiles/GeneralizedHarmonic/GaugeWave3D.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/GaugeWave3D.yaml
@@ -5,6 +5,7 @@ Executable: EvolveGhNoBlackHole3D
 Testing:
   Check: parse;execute
   Timeout: 8
+  Priority: High
 ExpectedOutput:
   - GhGaugeWave3DVolume0.h5
   - GhGaugeWave3DReductions.h5

--- a/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
@@ -5,6 +5,7 @@ Executable: EvolveGhSingleBlackHole
 Testing:
   Check: parse;execute_check_output
   Timeout: 8
+  Priority: High
 ExpectedOutput:
   - GhKerrSchildVolume0.h5
   - GhKerrSchildReductions.h5

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/BinaryNeutronStar.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/BinaryNeutronStar.yaml
@@ -4,6 +4,7 @@
 Executable: EvolveGhValenciaDivCleanBns
 Testing:
   Check: parse
+  Priority: High
 
 ---
 

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdBondiMichel.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdBondiMichel.yaml
@@ -5,6 +5,7 @@ Executable: EvolveGhValenciaDivCleanBondiMichel
 Testing:
   Check: parse;execute
   Timeout: 8
+  Priority: High
 ExpectedOutput:
   - GhMhdBondiMichelVolume0.h5
   - GhMhdBondiMichelReductions.h5

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdTovStar.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdTovStar.yaml
@@ -5,6 +5,7 @@ Executable: EvolveGhValenciaDivCleanTovStar
 Testing:
   Check: parse;execute
   Timeout: 8
+  Priority: High
 ExpectedOutput:
   - GhMhdTovStarVolume0.h5
   - GhMhdTovStarReductions.h5

--- a/tests/InputFiles/GrMhd/ValenciaDivClean/BlastWave.yaml
+++ b/tests/InputFiles/GrMhd/ValenciaDivClean/BlastWave.yaml
@@ -4,6 +4,7 @@
 Executable: EvolveValenciaDivCleanBlastWave
 Testing:
   Check: parse;execute
+  Priority: High
 
 ---
 

--- a/tests/InputFiles/GrMhd/ValenciaDivClean/FishboneMoncriefDisk.yaml
+++ b/tests/InputFiles/GrMhd/ValenciaDivClean/FishboneMoncriefDisk.yaml
@@ -5,6 +5,7 @@ Executable: EvolveValenciaDivCleanFishboneMoncriefDisk
 Testing:
   Check: parse;execute
   Timeout: 20
+  Priority: High
 
 ---
 

--- a/tests/InputFiles/NewtonianEuler/RiemannProblem3D.yaml
+++ b/tests/InputFiles/NewtonianEuler/RiemannProblem3D.yaml
@@ -4,6 +4,7 @@
 Executable: EvolveNewtonianEulerRiemannProblem3D
 Testing:
   Check: parse;execute
+  Priority: High
 
 ---
 

--- a/tests/InputFiles/Poisson/ProductOfSinusoids3D.yaml
+++ b/tests/InputFiles/Poisson/ProductOfSinusoids3D.yaml
@@ -5,6 +5,7 @@ Executable: SolvePoisson3D
 Testing:
   Check: parse;execute_check_output
   Timeout: 10
+  Priority: High
 ExpectedOutput:
   - PoissonProductOfSinusoids3DReductions.h5
   - PoissonProductOfSinusoids3DVolume0.h5

--- a/tests/InputFiles/Punctures/MultiplePunctures.yaml
+++ b/tests/InputFiles/Punctures/MultiplePunctures.yaml
@@ -5,6 +5,7 @@ Executable: SolvePunctures
 Testing:
   Check: parse;execute
   Timeout: 20
+  Priority: High
 ExpectedOutput:
   - PuncturesReductions.h5
   - PuncturesVolume0.h5

--- a/tests/InputFiles/RadiationTransport/M1Grey/ConstantM1.yaml
+++ b/tests/InputFiles/RadiationTransport/M1Grey/ConstantM1.yaml
@@ -4,6 +4,7 @@
 Executable: EvolveM1GreyConstantM1
 Testing:
   Check: parse;execute
+  Priority: High
 ExpectedOutput:
   - M1GreyReductions.h5
 

--- a/tests/InputFiles/RelativisticEuler/Valencia/SmoothFlow3D.yaml
+++ b/tests/InputFiles/RelativisticEuler/Valencia/SmoothFlow3D.yaml
@@ -4,6 +4,7 @@
 Executable: EvolveValenciaSmoothFlow3D
 Testing:
   Check: parse;execute
+  Priority: High
 
 ---
 

--- a/tests/InputFiles/ScalarAdvection/Kuzmin2D.yaml
+++ b/tests/InputFiles/ScalarAdvection/Kuzmin2D.yaml
@@ -4,6 +4,7 @@
 Executable: EvolveScalarAdvection2D
 Testing:
   Check: parse;execute
+  Priority: High
 ExpectedOutput:
   - ScalarAdvectionKuzmin2DVolume0.h5
 

--- a/tests/InputFiles/ScalarWave/PlaneWave1D.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave1D.yaml
@@ -4,6 +4,7 @@
 Executable: EvolveScalarWave1D
 Testing:
   Check: parse;execute
+  Priority: High
 
 ---
 

--- a/tests/InputFiles/ScalarWave/PlaneWave1DEventsAndTriggersExample.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave1DEventsAndTriggersExample.yaml
@@ -4,6 +4,7 @@
 Executable: EvolveScalarWave1D
 Testing:
   Check: parse
+  Priority: High
 ExpectedOutput:
   - ScalarWavePlaneWave1DEventsAndTriggersExampleVolume.h5
 

--- a/tests/InputFiles/ScalarWave/PlaneWave1DObserveExample.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave1DObserveExample.yaml
@@ -4,6 +4,7 @@
 Executable: EvolveScalarWave1D
 Testing:
   Check: parse
+  Priority: High
 ExpectedOutput:
   - ScalarWavePlaneWave1DObserveExampleVolume.h5
   - ScalarWavePlaneWave1DObserveExampleReductions.h5

--- a/tests/InputFiles/Xcts/BinaryBlackHole.yaml
+++ b/tests/InputFiles/Xcts/BinaryBlackHole.yaml
@@ -5,6 +5,7 @@ Executable: SolveXcts
 Testing:
   Check: parse
   Timeout: 30
+  Priority: High
 
 ---
 

--- a/tests/InputFiles/Xcts/HeadOnBns.yaml
+++ b/tests/InputFiles/Xcts/HeadOnBns.yaml
@@ -5,6 +5,7 @@ Executable: SolveXcts
 Testing:
   Check: parse
   Timeout: 30
+  Priority: High
 
 ---
 

--- a/tests/InputFiles/Xcts/KerrSchild.yaml
+++ b/tests/InputFiles/Xcts/KerrSchild.yaml
@@ -5,6 +5,7 @@ Executable: SolveXcts
 Testing:
   Check: parse;execute_check_output
   Timeout: 40
+  Priority: High
 ExpectedOutput:
   - KerrSchildReductions.h5
   - KerrSchildVolume0.h5

--- a/tests/InputFiles/Xcts/TovStar.yaml
+++ b/tests/InputFiles/Xcts/TovStar.yaml
@@ -5,6 +5,7 @@ Executable: SolveXcts
 Testing:
   Check: parse;execute_check_output
   Timeout: 40
+  Priority: High
 ExpectedOutput:
   - TovStarReductions.h5
   - TovStarVolume0.h5

--- a/tests/tools/Test_ValidateInputFile.py
+++ b/tests/tools/Test_ValidateInputFile.py
@@ -21,16 +21,16 @@ class TestValidateInputFile(unittest.TestCase):
         self.test_dir = Path(unit_test_build_path(), "tools/ValidateInputFile")
         self.test_dir.mkdir(parents=True, exist_ok=True)
         self.executable = Path(
-            unit_test_build_path(), "../../bin/SolvePoisson1D"
+            unit_test_build_path(), "../../bin/SolvePoisson3D"
         )
         self.valid_input_file_path = Path(
             unit_test_src_path(),
-            "../InputFiles/Poisson/ProductOfSinusoids1D.yaml",
+            "../InputFiles/Poisson/ProductOfSinusoids3D.yaml",
         )
         self.invalid_input_file_path = self.test_dir / "InvalidInputFile.yaml"
         with open(self.valid_input_file_path, "r") as open_input_file:
             metadata, input_file = yaml.safe_load_all(open_input_file)
-        del input_file["DomainCreator"]["Interval"]["LowerBound"]
+        del input_file["DomainCreator"]["Brick"]["LowerBound"]
         with open(self.invalid_input_file_path, "w") as open_input_file:
             yaml.safe_dump_all([metadata, input_file], open_input_file)
 
@@ -53,12 +53,13 @@ class TestValidateInputFile(unittest.TestCase):
             [str(self.valid_input_file_path), "-e", str(self.executable)],
         )
         self.assertEqual(result.exit_code, 0)
-        result = runner.invoke(
-            validate_input_file_command,
-            [str(self.invalid_input_file_path), "-e", str(self.executable)],
-        )
-        self.assertEqual(result.exit_code, 1)
-        self.assertIn("LowerBound", result.output)
+        with self.assertRaisesRegex(InvalidInputFileError, "LowerBound"):
+            result = runner.invoke(
+                validate_input_file_command,
+                [str(self.invalid_input_file_path), "-e", str(self.executable)],
+                catch_exceptions=False,
+            )
+            self.assertEqual(result.exit_code, 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Proposed changes

Add "Priority: High" to input files to run always. Otherwise, it will only run in a single CI configuration to save time building the executable.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
