### PR TITLE
Add pybinding for time deriv of lapse and spatial metric

### DIFF
--- a/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/Python/Bindings.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/Python/Bindings.cpp
@@ -15,7 +15,9 @@
 #include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/Ricci.hpp"
 #include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/SpatialDerivOfLapse.hpp"
 #include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/SpatialDerivOfShift.hpp"
+#include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/TimeDerivOfLapse.hpp"
 #include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/TimeDerivOfShift.hpp"
+#include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/TimeDerivOfSpatialMetric.hpp"
 #include "Utilities/ErrorHandling/SegfaultHandler.hpp"
 
 namespace py = pybind11;
@@ -105,6 +107,14 @@ void bind_impl(py::module& m) {  // NOLINT
           const tnsr::II<DataVector, Dim>&)>(&::gh::spatial_ricci_tensor),
       py::arg("phi"), py::arg("deriv_phi"), py::arg("inverse_spatial_metric"));
 
+  m.def("time_deriv_of_lapse",
+        static_cast<Scalar<DataVector> (*)(
+            const Scalar<DataVector>&, const tnsr::I<DataVector, Dim>&,
+            const tnsr::A<DataVector, Dim>&, const tnsr::iaa<DataVector, Dim>&,
+            const tnsr::aa<DataVector, Dim>&)>(&::gh::time_deriv_of_lapse),
+        py::arg("lapse"), py::arg("shift"), py::arg("spacetime_unit_normal"),
+        py::arg("phi"), py::arg("pi"));
+
   m.def(
       "time_deriv_of_shift",
       static_cast<tnsr::I<DataVector, Dim> (*)(
@@ -114,6 +124,14 @@ void bind_impl(py::module& m) {  // NOLINT
           &::gh::time_deriv_of_shift),
       py::arg("lapse"), py::arg("shift"), py::arg("inverse_spatial_metric"),
       py::arg("spacetime_unit_normal"), py::arg("phi"), py::arg("pi"));
+
+  m.def(
+      "time_deriv_of_spatial_metric",
+      static_cast<tnsr::ii<DataVector, Dim> (*)(
+          const Scalar<DataVector>&, const tnsr::I<DataVector, Dim>&,
+          const tnsr::iaa<DataVector, Dim>&, const tnsr::aa<DataVector, Dim>&)>(
+          &::gh::time_deriv_of_spatial_metric),
+      py::arg("lapse"), py::arg("shift"), py::arg("phi"), py::arg("pi"));
 
   m.def(
       "trace_christoffel",

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Python/Test_GhBindings.py
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Python/Test_GhBindings.py
@@ -142,6 +142,20 @@ class TestBindings(unittest.TestCase):
             inverse_spatial_metric,
         )
 
+    def test_time_deriv_of_laspe(self):
+        lapse = Scalar[DataVector](num_points=1, fill=1.0)
+        shift = tnsr.I[DataVector, 3](num_points=1, fill=0.0)
+        spacetime_unit_normal = tnsr.A[DataVector, 3](num_points=1, fill=1.0)
+        phi = tnsr.iaa[DataVector, 3](num_points=1, fill=1.0)
+        pi = tnsr.aa[DataVector, 3](num_points=1, fill=1.0)
+        gh.time_deriv_of_lapse(
+            lapse,
+            shift,
+            spacetime_unit_normal,
+            phi,
+            pi,
+        )
+
     def test_time_deriv_of_shift(self):
         lapse = Scalar[DataVector](num_points=1, fill=1.0)
         shift = tnsr.I[DataVector, 3](num_points=1, fill=0.0)
@@ -154,6 +168,18 @@ class TestBindings(unittest.TestCase):
             shift,
             inverse_spatial_metric,
             spacetime_unit_normal,
+            phi,
+            pi,
+        )
+
+    def test_time_derive_of_spatial_metric(self):
+        lapse = Scalar[DataVector](num_points=1, fill=1.0)
+        shift = tnsr.I[DataVector, 3](num_points=1, fill=0.0)
+        phi = tnsr.iaa[DataVector, 3](num_points=1, fill=1.0)
+        pi = tnsr.aa[DataVector, 3](num_points=1, fill=1.0)
+        gh.time_deriv_of_spatial_metric(
+            lapse,
+            shift,
             phi,
             pi,
         )


### PR DESCRIPTION
## Proposed changes

Add pybindings for the time derivative of lapse and the time derivative of the spatial metric. 

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
