### PR TITLE
Clean up unused arguments in `add_test_library`

### DIFF
--- a/cmake/SpectreAddTestLibs.cmake
+++ b/cmake/SpectreAddTestLibs.cmake
@@ -4,13 +4,16 @@
 # Add an executable with Catch2 unit tests and register them with CTest.
 #
 # This function is named `add_test_library` although it adds an executable for
-# historical reasons. For the same reasons it takes two unused arguments. We can
-# refactor this in the future.
+# historical reasons. We can refactor this in the future. We can also switch to
+# `catch_discover_tests` instead of our own test parsing code in the future.
+# At that point we can remove the `SOURCE_FILES` argument of this function and
+# instead use the standard `target_sources` to add the source files (currently
+# the `SOURCE_FILES` are needed to parse the tests).
 #
 # Parameters:
 # - TEST_EXEC_NAME The name of the test executable to add
 # - SOURCE_FILES The source files to compile into the executable
-function(add_test_library TEST_EXEC_NAME UNUSED SOURCE_FILES UNUSED2)
+function(add_test_library TEST_EXEC_NAME SOURCE_FILES)
   cmake_parse_arguments(ARG WITH_CHARM "" "" ${ARGN})
 
   add_spectre_executable(

--- a/docs/DevGuide/CompilerLinkerErrors.md
+++ b/docs/DevGuide/CompilerLinkerErrors.md
@@ -110,7 +110,7 @@ the library name is `DataStructuresHelpers`, and `RandomUnitNormal.cpp` is in
 the list of sources for the library. Thus, linking
 `Test_GeneralizedHarmonic` against `DataStructuresHelpers` will resolve our
 error. To link against a library, you must add it to the
-`target_link_libraries`, or the last argument passed to `add_test_library`.
+`target_link_libraries`.
 
 If `random_unit_normal` had been defined in the header file, then the error
 would've indicated that we did not include the header (or `tpp`) file into

--- a/docs/DevGuide/WritingTests.md
+++ b/docs/DevGuide/WritingTests.md
@@ -62,10 +62,9 @@ below.
   Finally, in the `CMakeLists.txt` of your new library you must call
   `add_test_library`. Again, see `tests/Unit/DataStructures/CMakeLists.txt` for
   an example. The `add_test_library` function adds a test executable with the
-  name of the first argument and the source files of the third argument. The
-  second and fourth arguments are unused for historical reasons and will be
-  removed in the future. Remember to use `target_link_libraries` to link any
-  libraries your test executable uses (see \ref spectre_build_system).
+  name of the first argument and the source files of the third argument.
+  Remember to use `target_link_libraries` to link any libraries your test
+  executable uses (see \ref spectre_build_system).
 
 All tests must start with
 ```cpp

--- a/tests/Unit/ArchitectureVectorization/CMakeLists.txt
+++ b/tests/Unit/ArchitectureVectorization/CMakeLists.txt
@@ -36,12 +36,7 @@ set(SOURCES
   ../DataStructures/Test_ComplexDataVectorBinaryOperations.cpp
   )
 
-add_test_library(
-  ${EXECUTABLE}
-  "ArchitectureVectorization"
-  "${SOURCES}"
-  ""
-  )
+add_test_library(${EXECUTABLE} ${SOURCES})
 
 target_link_libraries(
   ${EXECUTABLE}

--- a/tests/Unit/ControlSystem/CMakeLists.txt
+++ b/tests/Unit/ControlSystem/CMakeLists.txt
@@ -26,12 +26,7 @@ add_subdirectory(Protocols)
 add_subdirectory(Systems)
 add_subdirectory(Tags)
 
-add_test_library(
-  ${LIBRARY}
-  "ControlSystem"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/DataStructures/CMakeLists.txt
+++ b/tests/Unit/DataStructures/CMakeLists.txt
@@ -48,12 +48,7 @@ set(LIBRARY_SOURCES
 add_subdirectory(DataBox)
 add_subdirectory(Tensor)
 
-add_test_library(
-  ${LIBRARY}
-  "DataStructures"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/DataStructures/DataBox/CMakeLists.txt
+++ b/tests/Unit/DataStructures/DataBox/CMakeLists.txt
@@ -16,12 +16,7 @@ set(LIBRARY_SOURCES
   Test_TestHelpers.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "DataStructures/DataBox"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/DataStructures/Tensor/CMakeLists.txt
+++ b/tests/Unit/DataStructures/Tensor/CMakeLists.txt
@@ -14,12 +14,7 @@ add_subdirectory(EagerMath)
 add_subdirectory(Expressions)
 add_subdirectory(Python)
 
-add_test_library(
-  ${LIBRARY}
-  "DataStructures/Tensor"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/DataStructures/Tensor/EagerMath/CMakeLists.txt
+++ b/tests/Unit/DataStructures/Tensor/EagerMath/CMakeLists.txt
@@ -13,12 +13,7 @@ set(LIBRARY_SOURCES
   Test_OrthonormalOneform.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "DataStructures/Tensor/EagerMath"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/DataStructures/Tensor/Expressions/CMakeLists.txt
+++ b/tests/Unit/DataStructures/Tensor/Expressions/CMakeLists.txt
@@ -27,12 +27,7 @@ set(LIBRARY_SOURCES
   Test_TimeIndex.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "DataStructures/Tensor/Expressions"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/Domain/Amr/CMakeLists.txt
+++ b/tests/Unit/Domain/Amr/CMakeLists.txt
@@ -13,12 +13,7 @@ set(LIBRARY_SOURCES
   Test_UpdateAmrDecision.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "Domain/Amr"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/Domain/BoundaryConditions/CMakeLists.txt
+++ b/tests/Unit/Domain/BoundaryConditions/CMakeLists.txt
@@ -9,12 +9,7 @@ set(LIBRARY_SOURCES
   Test_GetBoundaryConditionsBase.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "Domain/BoundaryConditions"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/Domain/CMakeLists.txt
+++ b/tests/Unit/Domain/CMakeLists.txt
@@ -43,12 +43,7 @@ add_subdirectory(CoordinateMaps)
 add_subdirectory(Creators)
 add_subdirectory(Structure)
 
-add_test_library(
-  ${LIBRARY}
-  "Domain"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/Domain/CoordinateMaps/CMakeLists.txt
+++ b/tests/Unit/Domain/CoordinateMaps/CMakeLists.txt
@@ -33,12 +33,7 @@ set(LIBRARY_SOURCES
   Test_Wedge3D.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "Domain/CoordinateMaps"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/Domain/CoordinateMaps/TimeDependent/CMakeLists.txt
+++ b/tests/Unit/Domain/CoordinateMaps/TimeDependent/CMakeLists.txt
@@ -14,12 +14,7 @@ set(LIBRARY_SOURCES
   Test_Translation.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "Domain/CoordinateMaps/TimeDependent"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/Domain/Creators/CMakeLists.txt
+++ b/tests/Unit/Domain/Creators/CMakeLists.txt
@@ -26,12 +26,7 @@ set(LIBRARY_SOURCES
   Test_SphereTimeDependentMaps.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "Domain/Creators"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/Domain/Creators/TimeDependence/CMakeLists.txt
+++ b/tests/Unit/Domain/Creators/TimeDependence/CMakeLists.txt
@@ -13,12 +13,7 @@ set(LIBRARY_SOURCES
   Test_UniformTranslation.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "Domain/Creators/TimeDependence"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/Domain/FunctionsOfTime/CMakeLists.txt
+++ b/tests/Unit/Domain/FunctionsOfTime/CMakeLists.txt
@@ -15,12 +15,7 @@ set(LIBRARY_SOURCES
   Test_Tags.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "Domain/FunctionsOfTime"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/Domain/Structure/CMakeLists.txt
+++ b/tests/Unit/Domain/Structure/CMakeLists.txt
@@ -24,12 +24,7 @@ set(LIBRARY_SOURCES
   Test_ZCurve.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "Domain/Structure"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/Domain/Tags/CMakeLists.txt
+++ b/tests/Unit/Domain/Tags/CMakeLists.txt
@@ -8,12 +8,7 @@ set(LIBRARY_SOURCES
   Test_SurfaceJacobian.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "Domain/Tags"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/Elliptic/Actions/CMakeLists.txt
+++ b/tests/Unit/Elliptic/Actions/CMakeLists.txt
@@ -11,12 +11,7 @@ set(LIBRARY_SOURCES
   Test_RunEventsAndTriggers.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "Elliptic/Actions/"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/Elliptic/BoundaryConditions/CMakeLists.txt
+++ b/tests/Unit/Elliptic/BoundaryConditions/CMakeLists.txt
@@ -11,12 +11,7 @@ set(LIBRARY_SOURCES
   Test_Tags.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "Elliptic/BoundaryConditions/"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/Elliptic/CMakeLists.txt
+++ b/tests/Unit/Elliptic/CMakeLists.txt
@@ -15,12 +15,7 @@ set(LIBRARY_SOURCES
   Test_Tags.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "Elliptic/"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/Actions/CMakeLists.txt
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/Actions/CMakeLists.txt
@@ -7,12 +7,7 @@ set(LIBRARY_SOURCES
   Test_InitializeDomain.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "Elliptic/DiscontinuousGalerkin/Actions/"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/CMakeLists.txt
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/CMakeLists.txt
@@ -9,12 +9,7 @@ set(LIBRARY_SOURCES
   Test_Tags.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "Elliptic/DiscontinuousGalerkin/"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/SubdomainOperator/CMakeLists.txt
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/SubdomainOperator/CMakeLists.txt
@@ -7,12 +7,7 @@ set(LIBRARY_SOURCES
   Test_SubdomainOperator.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "Elliptic/DiscontinuousGalerkin/SubdomainOperator"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/Elliptic/SubdomainPreconditioners/CMakeLists.txt
+++ b/tests/Unit/Elliptic/SubdomainPreconditioners/CMakeLists.txt
@@ -7,12 +7,7 @@ set(LIBRARY_SOURCES
   Test_MinusLaplacian.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "Elliptic/SubdomainPreconditioners/"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/Elliptic/Systems/CMakeLists.txt
+++ b/tests/Unit/Elliptic/Systems/CMakeLists.txt
@@ -7,12 +7,7 @@ set(LIBRARY_SOURCES
   Test_GetSourcesComputer.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "Elliptic/Systems/"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/Elliptic/Systems/Elasticity/BoundaryConditions/CMakeLists.txt
+++ b/tests/Unit/Elliptic/Systems/Elasticity/BoundaryConditions/CMakeLists.txt
@@ -8,12 +8,7 @@ set(LIBRARY_SOURCES
   Test_Zero.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "Elliptic/Systems/Elasticity/BoundaryConditions/"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/Elliptic/Systems/Elasticity/CMakeLists.txt
+++ b/tests/Unit/Elliptic/Systems/Elasticity/CMakeLists.txt
@@ -8,12 +8,7 @@ set(LIBRARY_SOURCES
   Test_Tags.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "Elliptic/Systems/Elasticity/"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/Elliptic/Systems/Poisson/BoundaryConditions/CMakeLists.txt
+++ b/tests/Unit/Elliptic/Systems/Poisson/BoundaryConditions/CMakeLists.txt
@@ -7,12 +7,7 @@ set(LIBRARY_SOURCES
   Test_Robin.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "Elliptic/Systems/Poisson/BoundaryConditions/"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/Elliptic/Systems/Poisson/CMakeLists.txt
+++ b/tests/Unit/Elliptic/Systems/Poisson/CMakeLists.txt
@@ -8,12 +8,7 @@ set(LIBRARY_SOURCES
   Test_Tags.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "Elliptic/Systems/Poisson/"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/Elliptic/Systems/Punctures/AmrCriteria/CMakeLists.txt
+++ b/tests/Unit/Elliptic/Systems/Punctures/AmrCriteria/CMakeLists.txt
@@ -7,12 +7,7 @@ set(LIBRARY_SOURCES
   Test_RefineAtPunctures.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "Elliptic/Systems/Punctures/AmrCriteria/"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/Elliptic/Systems/Punctures/BoundaryConditions/CMakeLists.txt
+++ b/tests/Unit/Elliptic/Systems/Punctures/BoundaryConditions/CMakeLists.txt
@@ -7,12 +7,7 @@ set(LIBRARY_SOURCES
   Test_Flatness.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "Elliptic/Systems/Punctures/BoundaryConditions/"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/Elliptic/Systems/Punctures/CMakeLists.txt
+++ b/tests/Unit/Elliptic/Systems/Punctures/CMakeLists.txt
@@ -8,12 +8,7 @@ set(LIBRARY_SOURCES
   Test_Tags.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "Elliptic/Systems/Punctures/"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/Elliptic/Systems/Xcts/BoundaryConditions/CMakeLists.txt
+++ b/tests/Unit/Elliptic/Systems/Xcts/BoundaryConditions/CMakeLists.txt
@@ -8,12 +8,7 @@ set(LIBRARY_SOURCES
   Test_Flatness.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "Elliptic/Systems/Xcts/BoundaryConditions/"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/Elliptic/Systems/Xcts/CMakeLists.txt
+++ b/tests/Unit/Elliptic/Systems/Xcts/CMakeLists.txt
@@ -9,12 +9,7 @@ set(LIBRARY_SOURCES
   Test_Tags.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "Elliptic/Systems/Xcts/"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/Elliptic/Triggers/CMakeLists.txt
+++ b/tests/Unit/Elliptic/Triggers/CMakeLists.txt
@@ -8,12 +8,7 @@ set(LIBRARY_SOURCES
   Test_HasConverged.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "Elliptic/Triggers/"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/Elliptic/Utilities/CMakeLists.txt
+++ b/tests/Unit/Elliptic/Utilities/CMakeLists.txt
@@ -7,12 +7,7 @@ set(LIBRARY_SOURCES
   Test_ApplyAt.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "Elliptic/Utilities/"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/ErrorHandling/CMakeLists.txt
+++ b/tests/Unit/ErrorHandling/CMakeLists.txt
@@ -11,11 +11,7 @@ set(LIBRARY_SOURCES
   Test_SegfaultHandler.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "ErrorHandling"
-  "${LIBRARY_SOURCES}"
-  ""
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES}
   # Run in Charm++ environment to avoid issues with the segfault handler test
   # on some systems (macOS).
   WITH_CHARM

--- a/tests/Unit/Evolution/Actions/CMakeLists.txt
+++ b/tests/Unit/Evolution/Actions/CMakeLists.txt
@@ -8,12 +8,7 @@ set(LIBRARY_SOURCES
   Test_RunEventsAndTriggers.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "Evolution/Actions/"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/Evolution/Ader/CMakeLists.txt
+++ b/tests/Unit/Evolution/Ader/CMakeLists.txt
@@ -7,12 +7,7 @@ set(LIBRARY_SOURCES
   Test_Matrices.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "Evolution/Ader/"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/Evolution/BoundaryConditions/CMakeLists.txt
+++ b/tests/Unit/Evolution/BoundaryConditions/CMakeLists.txt
@@ -7,12 +7,7 @@ set(LIBRARY_SOURCES
   Test_Type.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "Evolution/BoundaryConditions"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/Evolution/CMakeLists.txt
+++ b/tests/Unit/Evolution/CMakeLists.txt
@@ -23,12 +23,7 @@ set(LIBRARY_SOURCES
   Test_Tags.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "Evolution"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/Evolution/DgSubcell/CMakeLists.txt
+++ b/tests/Unit/Evolution/DgSubcell/CMakeLists.txt
@@ -43,12 +43,7 @@ set(LIBRARY_SOURCES
   Test_TwoMeshRdmpTci.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "Evolution/DgSubcell/"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/CMakeLists.txt
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/CMakeLists.txt
@@ -25,12 +25,7 @@ set(LIBRARY_SOURCES
   Test_UsingSubcell.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "Evolution/DiscontinuousGalerkin/"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/CMakeLists.txt
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/CMakeLists.txt
@@ -20,12 +20,7 @@ set(LIBRARY_SOURCES
   Test_WenoType.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "Evolution/DiscontinuousGalerkin/Limiters/"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Messages/CMakeLists.txt
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Messages/CMakeLists.txt
@@ -8,13 +8,7 @@ set(LIBRARY_SOURCES
   Test_InboxTags.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "Evolution/DiscontinuousGalerkin/"
-  "${LIBRARY_SOURCES}"
-  ""
-  WITH_CHARM
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES} WITH_CHARM)
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/Evolution/EventsAndDenseTriggers/CMakeLists.txt
+++ b/tests/Unit/Evolution/EventsAndDenseTriggers/CMakeLists.txt
@@ -10,12 +10,7 @@ set(LIBRARY_SOURCES
 
 add_subdirectory(DenseTriggers)
 
-add_test_library(
-  ${LIBRARY}
-  "Evolution/EventsAndDenseTriggers/"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/Evolution/Initialization/CMakeLists.txt
+++ b/tests/Unit/Evolution/Initialization/CMakeLists.txt
@@ -12,12 +12,7 @@ set(LIBRARY_SOURCES
   Test_Tags.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "Evolution/Initialization/"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/Evolution/Systems/Burgers/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/Burgers/CMakeLists.txt
@@ -26,12 +26,7 @@ set(LIBRARY_SOURCES
   Test_TimeDerivativeTerms.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "Evolution/Systems/Burgers/"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/Evolution/Systems/Cce/Actions/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/CMakeLists.txt
@@ -22,12 +22,7 @@ set(LIBRARY_SOURCES
   Test_UpdateGauge.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "Evolution/Systems/Cce/Actions/"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/Evolution/Systems/Cce/AnalyticSolutions/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/Cce/AnalyticSolutions/CMakeLists.txt
@@ -12,12 +12,7 @@ set(LIBRARY_SOURCES
   Test_TeukolskyWave.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "Evolution/Systems/Cce/AnalyticSolutions/"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/Evolution/Systems/Cce/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/Cce/CMakeLists.txt
@@ -31,12 +31,7 @@ set(LIBRARY_SOURCES
 
 add_subdirectory(Events)
 
-add_test_library(
-  ${LIBRARY}
-  "Evolution/Systems/Cce/"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/Evolution/Systems/Ccz4/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/Ccz4/CMakeLists.txt
@@ -17,12 +17,7 @@ set(LIBRARY_SOURCES
   Test_Z4Constraint.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "Evolution/Systems/Ccz4/"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/CMakeLists.txt
@@ -31,12 +31,7 @@ set(LIBRARY_SOURCES
   Worldtube/SingletonActions/Test_TimeDerivative.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "Evolution/Systems/CurvedScalarWave/"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/Evolution/Systems/ForceFree/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/ForceFree/CMakeLists.txt
@@ -21,12 +21,7 @@ set(LIBRARY_SOURCES
   Test_TimeDerivativeTerms.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "Evolution/Systems/ForceFree"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/CMakeLists.txt
@@ -23,12 +23,7 @@ set(LIBRARY_SOURCES
   Test_Tags.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "Evolution/Systems/GeneralizedHarmonic/"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/CMakeLists.txt
@@ -9,12 +9,7 @@ set(LIBRARY_SOURCES
   Test_TimeDependentTripleGaussian.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/CMakeLists.txt
@@ -13,12 +13,7 @@ set(LIBRARY_SOURCES
   Test_Tags.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/CMakeLists.txt
@@ -29,12 +29,7 @@ set(LIBRARY_SOURCES
   Test_TimeDerivativeTerms.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "Evolution/Systems/GrMhd/GhValenciaDivClean"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/CMakeLists.txt
@@ -44,12 +44,7 @@ set(LIBRARY_SOURCES
   Test_ValenciaDivClean.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "Evolution/Systems/GrMhd/ValenciaDivClean"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/CMakeLists.txt
@@ -41,12 +41,7 @@ set(LIBRARY_SOURCES
 add_subdirectory(Limiters)
 add_subdirectory(Sources)
 
-add_test_library(
-  ${LIBRARY}
-  "Evolution/Systems/NewtonianEuler/"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/Limiters/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/Limiters/CMakeLists.txt
@@ -12,12 +12,7 @@ set(LIBRARY_SOURCES
   Test_Weno.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "Evolution/Systems/NewtonianEuler/Limiters"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/Sources/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/Sources/CMakeLists.txt
@@ -9,12 +9,7 @@ set(LIBRARY_SOURCES
   Test_VortexPerturbation.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "Evolution/Systems/NewtonianEuler/Sources"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/Evolution/Systems/RadiationTransport/M1Grey/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/RadiationTransport/M1Grey/CMakeLists.txt
@@ -16,12 +16,7 @@ set(LIBRARY_SOURCES
   Test_TimeDerivativeTerms.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "Evolution/Systems/RadiationTransport/M1Grey/"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/Evolution/Systems/RelativisticEuler/Valencia/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/RelativisticEuler/Valencia/CMakeLists.txt
@@ -17,12 +17,7 @@ set(LIBRARY_SOURCES
   Test_TimeDerivativeTerms.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "Evolution/Systems/RelativisticEuler/Valencia/"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/Evolution/Systems/ScalarAdvection/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/ScalarAdvection/CMakeLists.txt
@@ -25,12 +25,7 @@ set(LIBRARY_SOURCES
   Test_VelocityField.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "Evolution/Systems/ScalarAdvection"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/Evolution/Systems/ScalarTensor/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/ScalarTensor/CMakeLists.txt
@@ -13,12 +13,7 @@ set(LIBRARY_SOURCES
   Test_TimeDerivative.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "Evolution/Systems/ScalarTensor"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/Evolution/Systems/ScalarWave/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/ScalarWave/CMakeLists.txt
@@ -18,12 +18,7 @@ set(LIBRARY_SOURCES
   Test_TimeDerivative.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "Evolution/Systems/ScalarWave/"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/Evolution/Triggers/CMakeLists.txt
+++ b/tests/Unit/Evolution/Triggers/CMakeLists.txt
@@ -7,12 +7,7 @@ set(LIBRARY_SOURCES
   Test_SeparationLessThan.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "Evolution/Triggers/"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/Evolution/VariableFixing/CMakeLists.txt
+++ b/tests/Unit/Evolution/VariableFixing/CMakeLists.txt
@@ -11,12 +11,7 @@ set(LIBRARY_SOURCES
   Test_RadiallyFallingFloor.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "Evolution/VariableFixing/"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/Framework/Tests/CMakeLists.txt
+++ b/tests/Unit/Framework/Tests/CMakeLists.txt
@@ -13,12 +13,7 @@ set(LIBRARY_SOURCES
   Test_TestingFramework.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "Framework/Tests"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/Helpers/Tests/CMakeLists.txt
+++ b/tests/Unit/Helpers/Tests/CMakeLists.txt
@@ -9,12 +9,7 @@ set(LIBRARY_SOURCES
   Test_MakeRandomVectorInMagnitudeRange.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "Helpers/Tests"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/Helpers/Tests/Domain/Amr/CMakeLists.txt
+++ b/tests/Unit/Helpers/Tests/Domain/Amr/CMakeLists.txt
@@ -7,12 +7,7 @@ set(LIBRARY_SOURCES
   Test_NeighborFlagHelpers.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "Helpers/Tests/Domain/Amr/"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/Helpers/Tests/Domain/Structure/CMakeLists.txt
+++ b/tests/Unit/Helpers/Tests/Domain/Structure/CMakeLists.txt
@@ -8,12 +8,7 @@ set(LIBRARY_SOURCES
   Test_OrientationMapHelpers.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "Helpers/Tests/Domain/Structure/"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/Helpers/Tests/IO/Observers/CMakeLists.txt
+++ b/tests/Unit/Helpers/Tests/IO/Observers/CMakeLists.txt
@@ -8,12 +8,7 @@ set(LIBRARY_SOURCES
   Test_MockWriteReductionDataRow.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "Helpers/Tests/IO/Observers"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/Helpers/Tests/PointwiseFunctions/PostNewtonian/CMakeLists.txt
+++ b/tests/Unit/Helpers/Tests/PointwiseFunctions/PostNewtonian/CMakeLists.txt
@@ -7,12 +7,7 @@ set(LIBRARY_SOURCES
   Test_BinaryTrajectories.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "Helpers/Tests/PointwiseFunctions/PostNewtonian/"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/IO/CMakeLists.txt
+++ b/tests/Unit/IO/CMakeLists.txt
@@ -8,12 +8,7 @@ set(LIBRARY_SOURCES
   Test_Connectivity.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "IO"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/IO/H5/CMakeLists.txt
+++ b/tests/Unit/IO/H5/CMakeLists.txt
@@ -16,12 +16,7 @@ set(LIBRARY_SOURCES
   Test_VolumeData.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "IO/H5/"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/IO/Importers/CMakeLists.txt
+++ b/tests/Unit/IO/Importers/CMakeLists.txt
@@ -8,12 +8,7 @@ set(LIBRARY_SOURCES
   Test_VolumeDataReaderActions.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "IO/Importers"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/IO/Logging/CMakeLists.txt
+++ b/tests/Unit/IO/Logging/CMakeLists.txt
@@ -8,12 +8,7 @@ set(LIBRARY_SOURCES
   Test_Verbosity.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "IO/Logging/"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/IO/Observers/CMakeLists.txt
+++ b/tests/Unit/IO/Observers/CMakeLists.txt
@@ -18,12 +18,7 @@ set(LIBRARY_SOURCES
   Test_WriteSimpleData.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "IO/Observers/"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/NumericalAlgorithms/Convergence/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/Convergence/CMakeLists.txt
@@ -10,12 +10,7 @@ set(LIBRARY_SOURCES
   Test_Tags.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "NumericalAlgorithms/Convergence/"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/CMakeLists.txt
@@ -18,12 +18,7 @@ set(LIBRARY_SOURCES
   Test_Tags.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "NumericalAlgorithms/DiscontinuousGalerkin/"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Tags/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Tags/CMakeLists.txt
@@ -7,12 +7,7 @@ set(LIBRARY_SOURCES
   Test_Formulation.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "NumericalAlgorithms/DiscontinuousGalerkin/Tags/"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/NumericalAlgorithms/FiniteDifference/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/FiniteDifference/CMakeLists.txt
@@ -20,12 +20,7 @@ set(LIBRARY_SOURCES
   Test_Wcns5z.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "NumericalAlgorithms/FiniteDifference/"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/NumericalAlgorithms/Integration/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/Integration/CMakeLists.txt
@@ -7,12 +7,7 @@ set(LIBRARY_SOURCES
   Test_GslQuadAdaptive.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "NumericalAlgorithms/Integration/"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/NumericalAlgorithms/Interpolation/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/CMakeLists.txt
@@ -21,12 +21,7 @@ set(LIBRARY_SOURCES
   Test_ZeroCrossingPredictor.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "NumericalAlgorithms/Interpolation/"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/NumericalAlgorithms/LinearAlgebra/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/LinearAlgebra/CMakeLists.txt
@@ -7,12 +7,7 @@ set(LIBRARY_SOURCES
   Test_FindGeneralizedEigenvalues.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "NumericalAlgorithms/LinearAlgebra/"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/CMakeLists.txt
@@ -16,12 +16,7 @@ set(LIBRARY_SOURCES
   Test_WeakDivergence.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "NumericalAlgorithms/LinearOperators/"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/NumericalAlgorithms/LinearSolver/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/LinearSolver/CMakeLists.txt
@@ -11,12 +11,7 @@ set(LIBRARY_SOURCES
   Test_Lapack.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "NumericalAlgorithms/LinearSolver/"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/NumericalAlgorithms/OdeIntegration/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/OdeIntegration/CMakeLists.txt
@@ -7,12 +7,7 @@ set(LIBRARY_SOURCES
   Test_OdeIntegration.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "NumericalAlgorithms/OdeIntegration/"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/NumericalAlgorithms/RootFinding/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/RootFinding/CMakeLists.txt
@@ -10,12 +10,7 @@ set(LIBRARY_SOURCES
   Test_TOMS748.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "NumericalAlgorithms/RootFinding/"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/NumericalAlgorithms/Spectral/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/Spectral/CMakeLists.txt
@@ -29,12 +29,7 @@ set(LIBRARY_SOURCES
   Test_SwshTransform.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "NumericalAlgorithms/Spectral/"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/NumericalAlgorithms/SphericalHarmonics/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/SphericalHarmonics/CMakeLists.txt
@@ -14,12 +14,7 @@ set(LIBRARY_SOURCES
   Test_YlmToStf.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "NumericalAlgorithms/SphericalHarmonics/"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/Options/CMakeLists.txt
+++ b/tests/Unit/Options/CMakeLists.txt
@@ -13,12 +13,7 @@ set(LIBRARY_SOURCES
   Test_StdComplex.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "Options/"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/Parallel/CMakeLists.txt
+++ b/tests/Unit/Parallel/CMakeLists.txt
@@ -170,13 +170,7 @@ set(LIBRARY_SOURCES
 
 add_subdirectory(Tags)
 
-add_test_library(
-  ${LIBRARY}
-  "Parallel"
-  "${LIBRARY_SOURCES}"
-  ""
-  WITH_CHARM
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES} WITH_CHARM)
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/Parallel/PhaseControl/CMakeLists.txt
+++ b/tests/Unit/Parallel/PhaseControl/CMakeLists.txt
@@ -11,13 +11,7 @@ set(LIBRARY_SOURCES
   Test_VisitAndReturn.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "Parallel/PhaseControl"
-  "${LIBRARY_SOURCES}"
-  ""
-  WITH_CHARM
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES} WITH_CHARM)
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/ParallelAlgorithms/Actions/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/Actions/CMakeLists.txt
@@ -15,12 +15,7 @@ set(LIBRARY_SOURCES
   Test_UpdateMessageQueue.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "ParallelAlgorithms/Actions/"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/ParallelAlgorithms/Amr/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/Amr/CMakeLists.txt
@@ -21,12 +21,7 @@ set(LIBRARY_SOURCES
   Test_Protocols.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "ParallelAlgorithms/Amr"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/CMakeLists.txt
@@ -13,12 +13,7 @@ set(LIBRARY_SOURCES
   Test_Tags.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "ParallelAlgorithms/ApparentHorizonFinder"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/ParallelAlgorithms/Events/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/Events/CMakeLists.txt
@@ -13,12 +13,7 @@ set(LIBRARY_SOURCES
   Test_Tags.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "ParallelAlgorithms/Events/"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/ParallelAlgorithms/EventsAndTriggers/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/EventsAndTriggers/CMakeLists.txt
@@ -10,12 +10,7 @@ set(LIBRARY_SOURCES
   Test_Tags.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "ParallelAlgorithms/EventsAndTriggers/"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/ParallelAlgorithms/Initialization/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/Initialization/CMakeLists.txt
@@ -7,12 +7,7 @@ set(LIBRARY_SOURCES
   Test_MutateAssign.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "ParallelAlgorithms/Initialization/"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/ParallelAlgorithms/Interpolation/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/CMakeLists.txt
@@ -30,12 +30,7 @@ set(LIBRARY_SOURCES
   Test_Tags.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "ParallelAlgorithms/Interpolation/"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Actions/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Actions/CMakeLists.txt
@@ -7,12 +7,7 @@ set(LIBRARY_SOURCES
   Test_MakeIdentityIfSkipped.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "ParallelAlgorithms/LinearSolver/Actions"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/AsynchronousSolvers/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/AsynchronousSolvers/CMakeLists.txt
@@ -7,12 +7,7 @@ set(LIBRARY_SOURCES
   Test_ElementActions.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "ParallelAlgorithms/LinearSolver/AsynchronousSolvers"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/CMakeLists.txt
@@ -7,12 +7,7 @@ set(LIBRARY_SOURCES
   Test_Tags.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "ParallelAlgorithms/LinearSolver/"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/ConjugateGradient/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/ConjugateGradient/CMakeLists.txt
@@ -8,12 +8,7 @@ set(LIBRARY_SOURCES
   Test_ResidualMonitorActions.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "ParallelAlgorithms/LinearSolver/ConjugateGradient"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/CMakeLists.txt
@@ -8,12 +8,7 @@ set(LIBRARY_SOURCES
   Test_ResidualMonitorActions.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "ParallelAlgorithms/LinearSolver/Gmres"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Multigrid/Actions/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Multigrid/Actions/CMakeLists.txt
@@ -7,12 +7,7 @@ set(LIBRARY_SOURCES
   Test_RestrictFields.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "ParallelAlgorithms/LinearSolver/Multigrid/Actions"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Multigrid/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Multigrid/CMakeLists.txt
@@ -8,12 +8,7 @@ set(LIBRARY_SOURCES
   Test_Tags.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "ParallelAlgorithms/LinearSolver/Multigrid"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Richardson/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Richardson/CMakeLists.txt
@@ -7,12 +7,7 @@ set(LIBRARY_SOURCES
   Test_Tags.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "ParallelAlgorithms/LinearSolver/Richardson"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Schwarz/Actions/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Schwarz/Actions/CMakeLists.txt
@@ -8,12 +8,7 @@ set(LIBRARY_SOURCES
   Test_ResetSubdomainSolver.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "ParallelAlgorithms/LinearSolver/Schwarz/Actions"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Schwarz/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Schwarz/CMakeLists.txt
@@ -11,12 +11,7 @@ set(LIBRARY_SOURCES
   Test_Weighting.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "ParallelAlgorithms/LinearSolver/Schwarz"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/ParallelAlgorithms/NonlinearSolver/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/NonlinearSolver/CMakeLists.txt
@@ -7,12 +7,7 @@ set(LIBRARY_SOURCES
   Test_Tags.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "ParallelAlgorithms/NonlinearSolver/"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/ParallelAlgorithms/NonlinearSolver/NewtonRaphson/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/NonlinearSolver/NewtonRaphson/CMakeLists.txt
@@ -7,12 +7,7 @@ set(LIBRARY_SOURCES
   Test_LineSearch.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "ParallelAlgorithms/NonlinearSolver/NewtonRaphson"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/ParallelAlgorithms/SurfaceFinder/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/SurfaceFinder/CMakeLists.txt
@@ -6,12 +6,7 @@ set(LIBRARY_SOURCES
   Test_SurfaceFinder.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "ParallelAlgorithms/SurfaceFinder"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/PointwiseFunctions/AnalyticData/Burgers/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/Burgers/CMakeLists.txt
@@ -7,12 +7,7 @@ set(LIBRARY_SOURCES
   Test_Sinusoid.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "PointwiseFunctions/AnalyticData/Burgers"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/PointwiseFunctions/AnalyticData/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/CMakeLists.txt
@@ -8,12 +8,7 @@ set(LIBRARY_SOURCES
   Test_Tags.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "PointwiseFunctions/AnalyticData"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/PointwiseFunctions/AnalyticData/CurvedWaveEquation/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/CurvedWaveEquation/CMakeLists.txt
@@ -8,12 +8,7 @@ set(LIBRARY_SOURCES
   Test_PureSphericalHarmonic.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "PointwiseFunctions/AnalyticData/CurvedWaveEquation/"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/PointwiseFunctions/AnalyticData/ForceFree/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/ForceFree/CMakeLists.txt
@@ -8,12 +8,7 @@ set(LIBRARY_SOURCES
   Test_FfeBreakdown.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "PointwiseFunctions/AnalyticData/ForceFree"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/PointwiseFunctions/AnalyticData/GeneralRelativity/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/GeneralRelativity/CMakeLists.txt
@@ -7,12 +7,7 @@ set(LIBRARY_SOURCES
   Test_BrillLindquist.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "PointwiseFunctions/AnalyticData/GeneralRelativity"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/PointwiseFunctions/AnalyticData/GrMhd/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/GrMhd/CMakeLists.txt
@@ -19,12 +19,7 @@ set(LIBRARY_SOURCES
   Test_SlabJet.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "PointwiseFunctions/AnalyticData/GrMhd"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/PointwiseFunctions/AnalyticData/NewtonianEuler/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/NewtonianEuler/CMakeLists.txt
@@ -9,12 +9,7 @@ set(LIBRARY_SOURCES
   Test_SodExplosion.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "PointwiseFunctions/AnalyticData/NewtonianEuler"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/PointwiseFunctions/AnalyticData/Punctures/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/Punctures/CMakeLists.txt
@@ -7,12 +7,7 @@ set(LIBRARY_SOURCES
   Test_MultiplePunctures.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "PointwiseFunctions/AnalyticData/Punctures/"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/PointwiseFunctions/AnalyticData/ScalarTensor/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/ScalarTensor/CMakeLists.txt
@@ -7,12 +7,7 @@ set(LIBRARY_SOURCES
   Test_KerrSphericalHarmonic.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "PointwiseFunctions/AnalyticData/ScalarTensor"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/PointwiseFunctions/AnalyticData/Xcts/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/Xcts/CMakeLists.txt
@@ -7,12 +7,7 @@ set(LIBRARY_SOURCES
   Test_Binary.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "PointwiseFunctions/AnalyticData/Xcts/"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Burgers/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Burgers/CMakeLists.txt
@@ -9,12 +9,7 @@ set(LIBRARY_SOURCES
   Test_Step.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "PointwiseFunctions/AnalyticSolutions/Burgers/"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/CMakeLists.txt
@@ -25,12 +25,7 @@ add_subdirectory(ScalarAdvection)
 add_subdirectory(WaveEquation)
 add_subdirectory(Xcts)
 
-add_test_library(
-  ${LIBRARY}
-  "PointwiseFunctions/AnalyticSolutions"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Elasticity/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Elasticity/CMakeLists.txt
@@ -9,12 +9,7 @@ set(LIBRARY_SOURCES
   Test_Zero.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "PointwiseFunctions/AnalyticSolutions/Elasticity/"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/ForceFree/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/ForceFree/CMakeLists.txt
@@ -8,12 +8,7 @@ set(LIBRARY_SOURCES
   Test_FastWave.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "PointwiseFunctions/AnalyticSolutions/ForceFree"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/CMakeLists.txt
@@ -13,12 +13,7 @@ set(LIBRARY_SOURCES
   Test_WrappedGr.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/GhGrMhd/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/GhGrMhd/CMakeLists.txt
@@ -7,12 +7,7 @@ set(LIBRARY_SOURCES
   Test_InstantiateWrappedGr.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "PointwiseFunctions/AnalyticSolutions/GhGrMhd"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/GhRelativisticEuler/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/GhRelativisticEuler/CMakeLists.txt
@@ -7,12 +7,7 @@ set(LIBRARY_SOURCES
   Test_InstantiateWrappedGr.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "PointwiseFunctions/AnalyticSolutions/GhRelativisticEuler"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/GrMhd/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/GrMhd/CMakeLists.txt
@@ -10,12 +10,7 @@ set(LIBRARY_SOURCES
   Test_SmoothFlow.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "PointwiseFunctions/AnalyticSolutions/GrMhd"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Hydro/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Hydro/CMakeLists.txt
@@ -7,12 +7,7 @@ set(LIBRARY_SOURCES
   Test_SmoothFlow.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "PointwiseFunctions/AnalyticSolutions/Hydro/"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/CMakeLists.txt
@@ -10,12 +10,7 @@ set(LIBRARY_SOURCES
   Test_SmoothFlow.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "PointwiseFunctions/AnalyticSolutions/NewtonianEuler/"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Poisson/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Poisson/CMakeLists.txt
@@ -11,12 +11,7 @@ set(LIBRARY_SOURCES
   Test_Zero.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "PointwiseFunctions/AnalyticSolutions/Poisson/"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Punctures/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Punctures/CMakeLists.txt
@@ -7,12 +7,7 @@ set(LIBRARY_SOURCES
   Test_Flatness.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "PointwiseFunctions/AnalyticSolutions/Punctures/"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/RadiationTransport/M1Grey/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/RadiationTransport/M1Grey/CMakeLists.txt
@@ -7,12 +7,7 @@ set(LIBRARY_SOURCES
   Test_ConstantM1.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "PointwiseFunctions/AnalyticSolutions/RadiationTransport/M1Grey"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/CMakeLists.txt
@@ -11,12 +11,7 @@ set(LIBRARY_SOURCES
   Test_TovStar.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "PointwiseFunctions/AnalyticSolutions/RelativisticEuler/"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/ScalarAdvection/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/ScalarAdvection/CMakeLists.txt
@@ -9,12 +9,7 @@ set(LIBRARY_SOURCES
   Test_Sinusoid.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "PointwiseFunctions/AnalyticSolutions/ScalarAdvection/"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/WaveEquation/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/WaveEquation/CMakeLists.txt
@@ -16,12 +16,7 @@ set(LIBRARY_SOURCES
   # Test_SemidiscretizedDg.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "PointwiseFunctions/AnalyticSolutions/WaveEquation/"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Xcts/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Xcts/CMakeLists.txt
@@ -14,12 +14,7 @@ set(LIBRARY_SOURCES
   Test_TovStar.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "PointwiseFunctions/AnalyticSolutions/Xcts/"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/PointwiseFunctions/Elasticity/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/Elasticity/CMakeLists.txt
@@ -10,12 +10,7 @@ set(LIBRARY_SOURCES
   Test_Strain.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "PointwiseFunctions/Elasticity/"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/PointwiseFunctions/Elasticity/ConstitutiveRelations/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/Elasticity/ConstitutiveRelations/CMakeLists.txt
@@ -9,12 +9,7 @@ set(LIBRARY_SOURCES
   Test_Tags.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "PointwiseFunctions/Elasticity/ConstitutiveRelations"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/CMakeLists.txt
@@ -21,12 +21,7 @@ set(LIBRARY_SOURCES
   Test_WeylTypeD1.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "PointwiseFunctions/GeneralRelativity/"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Surfaces/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Surfaces/CMakeLists.txt
@@ -9,12 +9,7 @@ set(LIBRARY_SOURCES
   Test_Tags.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "PointwiseFunctions/GeneralRelativity/Surfaces"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/PointwiseFunctions/Hydro/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/Hydro/CMakeLists.txt
@@ -19,12 +19,7 @@ set(LIBRARY_SOURCES
   Test_TestHelpers.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "PointwiseFunctions/Hydro/"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/CMakeLists.txt
@@ -16,12 +16,7 @@ set(LIBRARY_SOURCES
   Test_Tabulated3D.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "PointwiseFunctions/Hydro/EquationsOfState/"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/PointwiseFunctions/InitialDataUtilities/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/InitialDataUtilities/CMakeLists.txt
@@ -7,12 +7,7 @@ set(LIBRARY_SOURCES
   Tags/Test_InitialData.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "PointwiseFunctions/InitialDataUtilities"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/PointwiseFunctions/MathFunctions/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/MathFunctions/CMakeLists.txt
@@ -10,12 +10,7 @@ set(LIBRARY_SOURCES
   Test_TensorProduct.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "PointwiseFunctions/MathFunctions/"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/PointwiseFunctions/Punctures/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/Punctures/CMakeLists.txt
@@ -7,12 +7,7 @@ set(LIBRARY_SOURCES
   Test_AdmIntegrals.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "PointwiseFunctions/Punctures/"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/PointwiseFunctions/ScalarTensor/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/ScalarTensor/CMakeLists.txt
@@ -6,12 +6,7 @@ set(LIBRARY_SOURCES
   Test_ScalarCharge.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "PointwiseFunctions/ScalarTensor"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 target_link_libraries(
   ${LIBRARY}
   PRIVATE

--- a/tests/Unit/PointwiseFunctions/SpecialRelativity/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/SpecialRelativity/CMakeLists.txt
@@ -7,12 +7,7 @@ set(LIBRARY_SOURCES
   Test_LorentzBoostMatrix.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "PointwiseFunctions/SpecialRelativity/"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/PointwiseFunctions/Xcts/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/Xcts/CMakeLists.txt
@@ -9,12 +9,7 @@ set(LIBRARY_SOURCES
   Test_SpacetimeQuantities.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "PointwiseFunctions/Xcts/"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/Time/CMakeLists.txt
+++ b/tests/Unit/Time/CMakeLists.txt
@@ -25,12 +25,7 @@ add_subdirectory(Tags)
 add_subdirectory(TimeSteppers)
 add_subdirectory(Triggers)
 
-add_test_library(
-  ${LIBRARY}
-  "Time"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/Utilities/CMakeLists.txt
+++ b/tests/Unit/Utilities/CMakeLists.txt
@@ -55,12 +55,7 @@ add_subdirectory(TypeTraits)
 add_subdirectory(Serialization)
 add_subdirectory(System)
 
-add_test_library(
-  ${LIBRARY}
-  "Utilities"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/Utilities/System/CMakeLists.txt
+++ b/tests/Unit/Utilities/System/CMakeLists.txt
@@ -7,12 +7,7 @@ set(LIBRARY_SOURCES
   Test_Prefetch.cpp
 )
 
-add_test_library(
-  ${LIBRARY}
-  "Utilities/System"
-  "${LIBRARY_SOURCES}"
-  ""
-)
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/Utilities/TypeTraits/CMakeLists.txt
+++ b/tests/Unit/Utilities/TypeTraits/CMakeLists.txt
@@ -26,10 +26,5 @@ set(LIBRARY_SOURCES
   Test_RemoveReferenceWrapper.cpp
   )
 
-add_test_library(
-  ${LIBRARY}
-  "Utilities/TypeTraits"
-  "${LIBRARY_SOURCES}"
-  ""
-  )
+add_test_library(${LIBRARY} ${LIBRARY_SOURCES})
 


### PR DESCRIPTION
## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
Two unused arguments were removed from `add_test_library`. Change code from this:

```cmake
add_test_library(
  ${LIBRARY}
  "Evolution/Systems/Cce/"
  "${LIBRARY_SOURCES}"
  ""
  )
```

to this:

```cmake
add_test_library(${LIBRARY} "${LIBRARY_SOURCES}")
```
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
