### PR TITLE
Add h-refinement criterion based on 2nd derivs

### DIFF
--- a/docs/References.bib
+++ b/docs/References.bib
@@ -783,6 +783,19 @@ eprint = {https://doi.org/10.1137/0916035}
   url      = "https://doi.org/10.1016/j.jcp.2006.06.043",
 }
 
+@article{Dumbser2013,
+  author   = {Michael Dumbser and Arturo Hidalgo and Olindo Zanotti},
+  title    = {High order space–time adaptive {ADER-WENO} finite volume schemes
+              for non-conservative hyperbolic systems},
+  journal  = {Computer Methods in Applied Mechanics and Engineering},
+  volume   = {268},
+  pages    = {359-387},
+  year     = {2014},
+  issn     = {0045-7825},
+  doi      = {https://doi.org/10.1016/j.cma.2013.09.022},
+  url      = {https://www.sciencedirect.com/science/article/pii/S0045782513002491}
+}
+
 @article{Dumbser2014a,
   title =        "A posteriori subcell limiting of the discontinuous Galerkin
                   finite element method for hyperbolic conservation laws",
@@ -1468,6 +1481,19 @@ journal = {The Astrophysical Journal}
   SLACcitation   = "%%CITATION = GR-QC/0512093;%%"
 }
 
+@article{Loehner1987,
+  title    = {An adaptive finite element scheme for transient problems in CFD},
+  journal  = {Computer Methods in Applied Mechanics and Engineering},
+  volume   = {61},
+  number   = {3},
+  pages    = {323-338},
+  year     = {1987},
+  issn     = {0045-7825},
+  doi      = {https://doi.org/10.1016/0045-7825(87)90098-3},
+  url      = {https://www.sciencedirect.com/science/article/pii/0045782587900983},
+  author   = {Rainald Löhner}
+}
+
 @article{Loubere2014,
   title     = {A New Family of High Order Unstructured MOOD and ADER Finite
                Volume Schemes for Multidimensional Systems of Hyperbolic
@@ -1902,6 +1928,22 @@ archivePrefix = {arXiv},
   archivePrefix  = "arXiv",
   primaryClass   = "gr-qc",
   SLACcitation   = "%%CITATION = ARXIV:1611.09720;%%"
+}
+
+@article{Renkhoff2023,
+  author        = {Renkhoff, Sarah and Cors, Daniela and Hilditch, David and
+                   Br\"ugmann, Bernd},
+  title         = {Adaptive {hp} refinement for spectral elements in numerical
+                   relativity},
+  eprint        = {2302.00575},
+  archiveprefix = {arXiv},
+  primaryclass  = {gr-qc},
+  doi           = {10.1103/PhysRevD.107.104043},
+  journal       = {Phys. Rev. D},
+  volume        = {107},
+  number        = {10},
+  pages         = {104043},
+  year          = {2023}
 }
 
 @book{RezzollaBook,

--- a/src/ParallelAlgorithms/Amr/Criteria/CMakeLists.txt
+++ b/src/ParallelAlgorithms/Amr/Criteria/CMakeLists.txt
@@ -9,6 +9,7 @@ spectre_target_sources(
   ${LIBRARY}
   PRIVATE
   DriveToTarget.cpp
+  Loehner.cpp
   Random.cpp
   TruncationError.cpp
   )
@@ -20,6 +21,7 @@ spectre_target_headers(
   Criteria.hpp
   Criterion.hpp
   DriveToTarget.hpp
+  Loehner.hpp
   Random.hpp
   TruncationError.hpp
   )

--- a/src/ParallelAlgorithms/Amr/Criteria/Loehner.cpp
+++ b/src/ParallelAlgorithms/Amr/Criteria/Loehner.cpp
@@ -1,0 +1,121 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "ParallelAlgorithms/Amr/Criteria/Loehner.hpp"
+
+#include <array>
+#include <cstddef>
+
+#include "DataStructures/ApplyMatrices.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Matrix.hpp"
+#include "Domain/Amr/Flag.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/SetNumberOfGridPoints.hpp"
+
+namespace amr::Criteria {
+
+template <size_t Dim>
+double loehner_smoothness_indicator(
+    const gsl::not_null<DataVector*> first_deriv_buffer,
+    const gsl::not_null<DataVector*> second_deriv_buffer,
+    const DataVector& tensor_component, const Mesh<Dim>& mesh,
+    const size_t dimension) {
+  const size_t num_points = mesh.number_of_grid_points();
+  set_number_of_grid_points(first_deriv_buffer, num_points);
+  set_number_of_grid_points(second_deriv_buffer, num_points);
+  static const Matrix identity{};
+  // Compute second logical derivative in this dimension
+  // Possible performance optimization: pre-compute the second derivative matrix
+  // and store it either statically (like `Spectral::differentiation_matrix`)
+  // or pass it in as an argument so it's re-used for each tensor component.
+  const auto& logical_diff_matrix =
+      Spectral::differentiation_matrix(mesh.slice_through(dimension));
+  auto matrices = make_array<Dim>(std::cref(identity));
+  gsl::at(matrices, dimension) = logical_diff_matrix;
+  apply_matrices(first_deriv_buffer, matrices, tensor_component,
+                 mesh.extents());
+  apply_matrices(second_deriv_buffer, matrices, *first_deriv_buffer,
+                 mesh.extents());
+  // Take the L2 norm over all grid points
+  return blaze::l2Norm(*second_deriv_buffer) /
+         sqrt(second_deriv_buffer->size());
+}
+
+template <size_t Dim>
+std::array<double, Dim> loehner_smoothness_indicator(
+    const DataVector& tensor_component, const Mesh<Dim>& mesh) {
+  std::array<double, Dim> result{};
+  std::array<DataVector, 2> deriv_buffers{};
+  for (size_t d = 0; d < Dim; ++d) {
+    gsl::at(result, d) = loehner_smoothness_indicator(
+        make_not_null(&deriv_buffers[0]), make_not_null(&deriv_buffers[1]),
+        tensor_component, mesh, d);
+  }
+  return result;
+}
+
+namespace Loehner_detail {
+
+template <size_t Dim>
+void max_over_components(
+    const gsl::not_null<std::array<Flag, Dim>*> result,
+    const gsl::not_null<std::array<DataVector, 2>*> deriv_buffers,
+    const DataVector& tensor_component, const Mesh<Dim>& mesh,
+    const double relative_tolerance, const double absolute_tolerance,
+    const double coarsening_factor) {
+  const double umax = max(abs(tensor_component));
+  for (size_t d = 0; d < Dim; ++d) {
+    // Skip this dimension if we have already decided to refine it
+    if (gsl::at(*result, d) == Flag::Split) {
+      continue;
+    }
+    const double indicator =
+        loehner_smoothness_indicator(make_not_null(&(*deriv_buffers)[0]),
+                                     make_not_null(&(*deriv_buffers)[1]),
+                                     tensor_component, mesh, d) /
+        (relative_tolerance * umax + absolute_tolerance);
+    if (indicator > 1.) {
+      gsl::at(*result, d) = Flag::Split;
+      continue;
+    }
+    // Don't check if we want to (allow) joining elements if another
+    // tensor has already decided that joining elements is bad.
+    if (gsl::at(*result, d) == Flag::DoNothing) {
+      continue;
+    }
+    if (indicator < coarsening_factor) {
+      gsl::at(*result, d) = Flag::Join;
+    } else {
+      gsl::at(*result, d) = Flag::DoNothing;
+    }
+  }
+}
+
+}  // namespace Loehner_detail
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data)                                            \
+  template double loehner_smoothness_indicator(                         \
+      gsl::not_null<DataVector*> first_deriv_buffer,                    \
+      gsl::not_null<DataVector*> second_deriv_buffer,                   \
+      const DataVector& tensor_component, const Mesh<DIM(data)>& mesh,  \
+      size_t dimension);                                                \
+  template std::array<double, DIM(data)> loehner_smoothness_indicator(  \
+      const DataVector& tensor_component, const Mesh<DIM(data)>& mesh); \
+  template void Loehner_detail::max_over_components(                    \
+      gsl::not_null<std::array<Flag, DIM(data)>*> result,               \
+      gsl::not_null<std::array<DataVector, 2>*> deriv_buffers,          \
+      const DataVector& tensor_component, const Mesh<DIM(data)>& mesh,  \
+      double relative_tolerance, double absolute_tolerance,             \
+      double coarsening_factor);
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
+
+#undef INSTANTIATE
+#undef DIM
+
+}  // namespace amr::Criteria

--- a/src/ParallelAlgorithms/Amr/Criteria/Loehner.hpp
+++ b/src/ParallelAlgorithms/Amr/Criteria/Loehner.hpp
@@ -1,0 +1,271 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <limits>
+#include <pup.h>
+#include <string>
+#include <vector>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataBox/ValidateSelection.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/Amr/Flag.hpp"
+#include "Domain/Tags.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "Options/Context.hpp"
+#include "Options/ParseError.hpp"
+#include "Options/String.hpp"
+#include "ParallelAlgorithms/Amr/Criteria/Criterion.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+template <size_t>
+class ElementId;
+/// \endcond
+
+namespace amr::Criteria {
+
+/// @{
+/*!
+ * \brief Computes an anisotropic smoothness indicator based on the magnitude of
+ * second derivatives
+ *
+ * This smoothness indicator is simply the L2 norm of the logical second
+ * derivative of the tensor component in the given `dimension`:
+ *
+ * \begin{equation}
+ * \epsilon_k =
+ *   \sqrt{\frac{1}{N_\mathrm{points}} \sum_{p=1}^N_\mathrm{points}
+ *     \left(\partial^2 u / \partial \xi_k^2\right)^2}
+ * \end{equation}
+ *
+ * If the smoothness indicator is large in a direction, meaning the tensor
+ * component has a large second derivative in that direction, the element should
+ * be h-refined. If the smoothness indicator is small, the element should be
+ * h-coarsened. A coarsing threshold of about a third of the refinement
+ * threshold seems to work well, but this will need more testing.
+ *
+ * Note that it is not at all clear that a smoothness indicator based on the
+ * magnitude of second derivatives is useful in a DG context. Smooth functions
+ * with higher-order derivatives can be approximated just fine by higher-order
+ * DG elements without the need for h-refinement. The use of second derivatives
+ * to indicate the need for refinement originated in the finite element context
+ * with linear elements. Other smoothness indicators might prove more useful for
+ * DG elements, e.g. based on jumps or oscillations of the solution. We can also
+ * explore applying the troubled-cell indicators (TCIs) used in hydrodynamic
+ * simulations as h-refinement indicators.
+ *
+ * Specifically, this smoothness indicator is based on \cite Loehner1987 (hence
+ * the name of the function), which is popular in the finite element community
+ * and also used in a DG context by \cite Dumbser2013, Eq. (34), and by
+ * \cite Renkhoff2023, Eq. (15). We make several modifications:
+ *
+ * - The original smoothness indicator is isotropic, i.e. it computes the norm
+ *   over all (mixed) second derivatives. Here we compute an anisotropic
+ *   indicator by computing second derivatives in each dimension separately
+ *   and ignoring mixed derivatives.
+ * - The original smoothness indicator is normalized by measures of the first
+ *   derivative which don't generalize well to spectral elements. Therefore, we
+ *   simplify the normalization to a standard relative and absolute tolerance.
+ *   An alternative approach is proposed in \cite Renkhoff2023, Eq.(15), where
+ *   the authors take the absolute value of the differentiation matrix and apply
+ *   the resulting matrix to the absolute value of the data on the grid to
+ *   compute the normalization. However, this quantity can produce quite large
+ *   numbers and hence overestimates the smoothness by suppressing the second
+ *   derivative.
+ * - We compute the second derivative in logical coordinates. This seems
+ *   easiest for spectral elements, but note that \cite Renkhoff2023 seem to
+ *   use inertial coordinates.
+ *
+ * In addition to the above modifications, we can consider approximating the
+ * second derivative using finite differences, as explored in the prototype
+ * https://github.com/sxs-collaboration/dg-charm/blob/HpAmr/Evolution/HpAmr/LohnerRefiner.hpp.
+ * This would allow falling back to the normalization used by Löhner and might
+ * be cheaper to compute, but it requires an interpolation to the center and
+ * maybe also to the faces, depending on the desired stencil.
+ */
+template <size_t Dim>
+double loehner_smoothness_indicator(
+    gsl::not_null<DataVector*> first_deriv_buffer,
+    gsl::not_null<DataVector*> second_deriv_buffer,
+    const DataVector& tensor_component, const Mesh<Dim>& mesh,
+    size_t dimension);
+template <size_t Dim>
+std::array<double, Dim> loehner_smoothness_indicator(
+    const DataVector& tensor_component, const Mesh<Dim>& mesh);
+/// @}
+
+namespace Loehner_detail {
+template <size_t Dim>
+void max_over_components(
+    gsl::not_null<std::array<Flag, Dim>*> result,
+    gsl::not_null<std::array<DataVector, 2>*> deriv_buffers,
+    const DataVector& tensor_component, const Mesh<Dim>& mesh,
+    double relative_tolerance, double absolute_tolerance,
+    double coarsening_factor);
+}
+
+/*!
+ * \brief h-refine the grid based on a smoothness indicator
+ *
+ * The smoothness indicator used here is based on the magnitude of second
+ * derivatives. See `amr::Criteria::loehner_smoothness_indicator` for details
+ * and caveats.
+ *
+ * \see amr::Criteria::loehner_smoothness_indicator
+ */
+template <size_t Dim, typename TensorTags>
+class Loehner : public Criterion {
+ public:
+  struct VariablesToMonitor {
+    using type = std::vector<std::string>;
+    static constexpr Options::String help = {
+        "The tensors to monitor for h-refinement."};
+    static size_t lower_bound_on_size() { return 1; }
+  };
+  struct RelativeTolerance {
+    using type = double;
+    static constexpr Options::String help = {
+        "If any tensor component has a second derivative magnitude above this "
+        "value times the max of the absolute tensor component over the "
+        "element, the element will be h-refined in that direction. "
+        "Set to 0 to disable."};
+    static double lower_bound() { return 0.; }
+  };
+  struct AbsoluteTolerance {
+    using type = double;
+    static constexpr Options::String help = {
+        "If any tensor component has a second derivative magnitude above this "
+        "value, the element will be h-refined in that direction. "
+        "Set to 0 to disable."};
+    static double lower_bound() { return 0.; }
+  };
+  struct CoarseningFactor {
+    using type = double;
+    static constexpr Options::String help = {
+        "Factor applied to both relative and absolute tolerance to trigger "
+        "h-coarsening. Set to 0 to disable h-coarsening altogether. "
+        "Set closer to 1 to trigger h-coarsening more aggressively. "
+        "Values too close to 1 risk that coarsened elements will immediately "
+        "trigger h-refinement again. A reasonable value is 1/3."};
+    static double lower_bound() { return 0.; }
+    static double upper_bound() { return 1.; }
+  };
+
+  using options = tmpl::list<VariablesToMonitor, RelativeTolerance,
+                             AbsoluteTolerance, CoarseningFactor>;
+
+  static constexpr Options::String help = {
+      "Refine the grid towards resolving an estimated error in the second "
+      "derivative"};
+
+  Loehner() = default;
+
+  Loehner(std::vector<std::string> vars_to_monitor, double relative_tolerance,
+          double absolute_tolerance, double coarsening_factor,
+          const Options::Context& context = {});
+
+  /// \cond
+  explicit Loehner(CkMigrateMessage* msg);
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(Loehner);  // NOLINT
+  /// \endcond
+
+  using compute_tags_for_observation_box = tmpl::list<>;
+
+  using argument_tags = tmpl::list<::Tags::DataBox>;
+
+  template <typename DbTagsList, typename Metavariables>
+  std::array<Flag, Dim> operator()(const db::DataBox<DbTagsList>& box,
+                                   Parallel::GlobalCache<Metavariables>& cache,
+                                   const ElementId<Dim>& element_id) const;
+
+  void pup(PUP::er& p) override;
+
+ private:
+  std::vector<std::string> vars_to_monitor_{};
+  double relative_tolerance_ = std::numeric_limits<double>::signaling_NaN();
+  double absolute_tolerance_ = std::numeric_limits<double>::signaling_NaN();
+  double coarsening_factor_ = std::numeric_limits<double>::signaling_NaN();
+};
+
+// Out-of-line definitions
+/// \cond
+
+template <size_t Dim, typename TensorTags>
+Loehner<Dim, TensorTags>::Loehner(std::vector<std::string> vars_to_monitor,
+                                  const double relative_tolerance,
+                                  const double absolute_tolerance,
+                                  const double coarsening_factor,
+                                  const Options::Context& context)
+    : vars_to_monitor_(std::move(vars_to_monitor)),
+      relative_tolerance_(relative_tolerance),
+      absolute_tolerance_(absolute_tolerance),
+      coarsening_factor_(coarsening_factor) {
+  db::validate_selection<TensorTags>(vars_to_monitor_, context);
+  if (relative_tolerance == 0. and absolute_tolerance == 0.) {
+    PARSE_ERROR(
+        context,
+        "Must specify non-zero RelativeTolerance, AbsoluteTolerance, or both.");
+  }
+}
+
+template <size_t Dim, typename TensorTags>
+Loehner<Dim, TensorTags>::Loehner(CkMigrateMessage* msg) : Criterion(msg) {}
+
+template <size_t Dim, typename TensorTags>
+template <typename DbTagsList, typename Metavariables>
+std::array<Flag, Dim> Loehner<Dim, TensorTags>::operator()(
+    const db::DataBox<DbTagsList>& box,
+    Parallel::GlobalCache<Metavariables>& /*cache*/,
+    const ElementId<Dim>& /*element_id*/) const {
+  auto result = make_array<Dim>(Flag::Undefined);
+  const auto& mesh = db::get<domain::Tags::Mesh<Dim>>(box);
+  // Check all tensors and all tensor components in turn. We take the
+  // highest-priority refinement flag in each dimension, so if any tensor
+  // component is non-smooth, the element will split in that dimension. And only
+  // if all tensor components are smooth enough will elements join in that
+  // dimension.
+  std::array<DataVector, 2> deriv_buffers{};
+  tmpl::for_each<TensorTags>(
+      [&result, &box, &mesh, &deriv_buffers, this](const auto tag_v) {
+        // Stop if we have already decided to refine every dimension
+        if (result == make_array<Dim>(Flag::Split)) {
+          return;
+        }
+        using tag = tmpl::type_from<std::decay_t<decltype(tag_v)>>;
+        const std::string tag_name = db::tag_name<tag>();
+        // Skip if this tensor is not being monitored
+        if (not alg::found(vars_to_monitor_, tag_name)) {
+          return;
+        }
+        const auto& tensor = db::get<tag>(box);
+        for (const DataVector& tensor_component : tensor) {
+          Loehner_detail::max_over_components(
+              make_not_null(&result), make_not_null(&deriv_buffers),
+              tensor_component, mesh, relative_tolerance_, absolute_tolerance_,
+              coarsening_factor_);
+        }
+      });
+  return result;
+}
+
+template <size_t Dim, typename TensorTags>
+void Loehner<Dim, TensorTags>::pup(PUP::er& p) {
+  p | vars_to_monitor_;
+  p | relative_tolerance_;
+  p | absolute_tolerance_;
+  p | coarsening_factor_;
+}
+
+template <size_t Dim, typename TensorTags>
+PUP::able::PUP_ID Loehner<Dim, TensorTags>::my_PUP_ID = 0;  // NOLINT
+/// \endcond
+
+}  // namespace amr::Criteria

--- a/src/ParallelAlgorithms/Amr/Criteria/TruncationError.hpp
+++ b/src/ParallelAlgorithms/Amr/Criteria/TruncationError.hpp
@@ -170,7 +170,7 @@ std::array<Flag, Dim> TruncationError<Dim, TensorTags>::operator()(
         using tag = tmpl::type_from<std::decay_t<decltype(tag_v)>>;
         const std::string tag_name = db::tag_name<tag>();
         // Skip if this tensor is not being monitored
-        if (alg::find(vars_to_monitor_, tag_name) == vars_to_monitor_.end()) {
+        if (not alg::found(vars_to_monitor_, tag_name)) {
           return;
         }
         const auto& tensor = db::get<tag>(box);

--- a/tests/Unit/ParallelAlgorithms/Amr/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/Amr/CMakeLists.txt
@@ -16,6 +16,7 @@ set(LIBRARY_SOURCES
   Actions/Test_UpdateAmrDecision.cpp
   Criteria/Test_Criterion.cpp
   Criteria/Test_DriveToTarget.cpp
+  Criteria/Test_Loehner.cpp
   Criteria/Test_Random.cpp
   Criteria/Test_TruncationError.cpp
   Projectors/Test_Mesh.cpp

--- a/tests/Unit/ParallelAlgorithms/Amr/Criteria/Test_Loehner.cpp
+++ b/tests/Unit/ParallelAlgorithms/Amr/Criteria/Test_Loehner.cpp
@@ -1,0 +1,102 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <memory>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/ObservationBox.hpp"
+#include "Domain/Amr/Flag.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "NumericalAlgorithms/Spectral/LogicalCoordinates.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "Options/Protocols/FactoryCreation.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "ParallelAlgorithms/Amr/Criteria/Criterion.hpp"
+#include "ParallelAlgorithms/Amr/Criteria/Loehner.hpp"
+#include "Utilities/Serialization/RegisterDerivedClassesWithCharm.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace amr::Criteria {
+namespace {
+
+template <size_t Dim>
+struct TestVector : db::SimpleTag {
+  using type = tnsr::I<DataVector, Dim>;
+};
+
+template <size_t Dim>
+struct Metavariables {
+  static constexpr size_t volume_dim = Dim;
+  using component_list = tmpl::list<>;
+  using const_global_cache_tags = tmpl::list<>;
+  struct factory_creation
+      : tt::ConformsTo<Options::protocols::FactoryCreation> {
+    using factory_classes = tmpl::map<tmpl::pair<
+        amr::Criterion, tmpl::list<Loehner<Dim, tmpl::list<TestVector<Dim>>>>>>;
+  };
+};
+
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Amr.Criteria.Loehner", "[Unit][ParallelAlgorithms]") {
+  static constexpr size_t Dim = 2;
+  const Mesh<Dim> mesh{6, Spectral::Basis::Legendre,
+                       Spectral::Quadrature::GaussLobatto};
+  const auto logical_coords = logical_coordinates(mesh);
+
+  {
+    INFO("Linear function in both dimensions");
+    const DataVector test_data =
+        get<0>(logical_coords) + 2. * get<1>(logical_coords);
+    const auto indicator = loehner_smoothness_indicator(test_data, mesh);
+    CHECK(indicator[0] == approx(0.));
+    CHECK(indicator[1] == approx(0.));
+  }
+  {
+    INFO("Nonlinear in one dimension and linear in the other");
+    const DataVector test_data =
+        exp(-square(get<0>(logical_coords))) + 2. * get<1>(logical_coords);
+    const auto indicator = loehner_smoothness_indicator(test_data, mesh);
+    CHECK(indicator[0] == approx(1.32070910780672479));
+    CHECK(indicator[1] == approx(0.));
+  }
+
+  register_factory_classes_with_charm<Metavariables<Dim>>();
+  const auto criterion = TestHelpers::test_factory_creation<
+      amr::Criterion, Loehner<Dim, tmpl::list<TestVector<Dim>>>>(
+      "Loehner:\n"
+      "  VariablesToMonitor: [TestVector]\n"
+      "  AbsoluteTolerance: 1.e-3\n"
+      "  RelativeTolerance: 1.e-3\n"
+      "  CoarseningFactor: 0.3\n");
+
+  // Manufacture some test data
+  tnsr::I<DataVector, Dim> test_data{};
+  // X-component is linear in x and y
+  get<0>(test_data) = get<0>(logical_coords) + 2. * get<1>(logical_coords);
+  // Y-component is nonlinear in one dimension and linear in the other
+  get<1>(test_data) =
+      exp(-square(get<0>(logical_coords))) + 2. * get<1>(logical_coords);
+
+  Parallel::GlobalCache<Metavariables<Dim>> empty_cache{};
+  const auto databox =
+      db::create<tmpl::list<::domain::Tags::Mesh<Dim>, TestVector<Dim>>>(
+          mesh, std::move(test_data));
+  ObservationBox<
+      tmpl::list<>,
+      db::DataBox<tmpl::list<::domain::Tags::Mesh<Dim>, TestVector<Dim>>>>
+      box{databox};
+
+  const auto flags = criterion->evaluate(box, empty_cache, ElementId<Dim>{0});
+  CHECK(flags[0] == amr::Flag::Split);
+  CHECK(flags[1] == amr::Flag::Join);
+}
+
+}  // namespace amr::Criteria


### PR DESCRIPTION
## Proposed changes

A first simple h-refinement criterion. I'll add a Persson criterion next.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
