### PR TITLE
Add h-refinement criterion based on power in highest modes

### DIFF
--- a/src/ParallelAlgorithms/Amr/Criteria/CMakeLists.txt
+++ b/src/ParallelAlgorithms/Amr/Criteria/CMakeLists.txt
@@ -10,6 +10,7 @@ spectre_target_sources(
   PRIVATE
   DriveToTarget.cpp
   Loehner.cpp
+  Persson.cpp
   Random.cpp
   TruncationError.cpp
   )
@@ -22,6 +23,7 @@ spectre_target_headers(
   Criterion.hpp
   DriveToTarget.hpp
   Loehner.hpp
+  Persson.hpp
   Random.hpp
   TruncationError.hpp
   )

--- a/src/ParallelAlgorithms/Amr/Criteria/Persson.cpp
+++ b/src/ParallelAlgorithms/Amr/Criteria/Persson.cpp
@@ -1,0 +1,115 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "ParallelAlgorithms/Amr/Criteria/Persson.hpp"
+
+#include <array>
+#include <cstddef>
+
+#include "DataStructures/ApplyMatrices.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Matrix.hpp"
+#include "Domain/Amr/Flag.hpp"
+#include "NumericalAlgorithms/Spectral/Filtering.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/SetNumberOfGridPoints.hpp"
+
+namespace amr::Criteria {
+
+template <size_t Dim>
+double persson_smoothness_indicator(
+    const gsl::not_null<DataVector*> filtered_component_buffer,
+    const DataVector& tensor_component, const Mesh<Dim>& mesh,
+    const size_t dimension, const size_t num_highest_modes) {
+  // Zero out the lowest modes in the given dimension
+  static const Matrix identity{};
+  auto matrices = make_array<Dim>(std::cref(identity));
+  gsl::at(matrices, dimension) = Spectral::filtering::zero_lowest_modes(
+      mesh.slice_through(dimension),
+      mesh.extents(dimension) - num_highest_modes);
+  set_number_of_grid_points(filtered_component_buffer,
+                            mesh.number_of_grid_points());
+  apply_matrices(filtered_component_buffer, matrices, tensor_component,
+                 mesh.extents());
+  // Take the L2 norm over all grid points
+  return blaze::l2Norm(*filtered_component_buffer) /
+         sqrt(filtered_component_buffer->size());
+}
+
+template <size_t Dim>
+std::array<double, Dim> persson_smoothness_indicator(
+    const DataVector& tensor_component, const Mesh<Dim>& mesh,
+    const size_t num_highest_modes) {
+  std::array<double, Dim> result{};
+  DataVector buffer{};
+  for (size_t d = 0; d < Dim; ++d) {
+    gsl::at(result, d) = persson_smoothness_indicator(
+        make_not_null(&buffer), tensor_component, mesh, d, num_highest_modes);
+  }
+  return result;
+}
+
+namespace Persson_detail {
+
+template <size_t Dim>
+void max_over_components(const gsl::not_null<std::array<Flag, Dim>*> result,
+                         const gsl::not_null<DataVector*> buffer,
+                         const DataVector& tensor_component,
+                         const Mesh<Dim>& mesh, const size_t num_highest_modes,
+                         const double alpha, const double absolute_tolerance,
+                         const double coarsening_factor) {
+  const double umax = max(abs(tensor_component));
+  for (size_t d = 0; d < Dim; ++d) {
+    // Skip this dimension if we have already decided to refine it
+    if (gsl::at(*result, d) == Flag::Split) {
+      continue;
+    }
+    const double relative_tolerance =
+        pow(mesh.extents(d) - num_highest_modes, -alpha);
+    const double indicator =
+        persson_smoothness_indicator(buffer, tensor_component, mesh, d,
+                                     num_highest_modes) /
+        (relative_tolerance * umax + absolute_tolerance);
+    if (indicator > 1.) {
+      gsl::at(*result, d) = Flag::Split;
+      continue;
+    }
+    // Don't check if we want to (allow) joining elements if another
+    // tensor has already decided that joining elements is bad.
+    if (gsl::at(*result, d) == Flag::DoNothing) {
+      continue;
+    }
+    if (indicator < coarsening_factor) {
+      gsl::at(*result, d) = Flag::Join;
+    } else {
+      gsl::at(*result, d) = Flag::DoNothing;
+    }
+  }
+}
+
+}  // namespace Persson_detail
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data)                                                 \
+  template double persson_smoothness_indicator(                              \
+      gsl::not_null<DataVector*> buffer, const DataVector& tensor_component, \
+      const Mesh<DIM(data)>& mesh, size_t dimension,                         \
+      size_t num_highest_modes);                                             \
+  template std::array<double, DIM(data)> persson_smoothness_indicator(       \
+      const DataVector& tensor_component, const Mesh<DIM(data)>& mesh,       \
+      size_t num_highest_modes);                                             \
+  template void Persson_detail::max_over_components(                         \
+      gsl::not_null<std::array<Flag, DIM(data)>*> result,                    \
+      gsl::not_null<DataVector*> buffer, const DataVector& tensor_component, \
+      const Mesh<DIM(data)>& mesh, size_t num_highest_modes, double alpha,   \
+      double absolute_tolerance, double coarsening_factor);
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
+
+#undef INSTANTIATION
+#undef DIM
+
+}  // namespace amr::Criteria

--- a/src/ParallelAlgorithms/Amr/Criteria/Persson.hpp
+++ b/src/ParallelAlgorithms/Amr/Criteria/Persson.hpp
@@ -1,0 +1,234 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <limits>
+#include <pup.h>
+#include <string>
+#include <vector>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataBox/ValidateSelection.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/Amr/Flag.hpp"
+#include "Domain/Tags.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "Options/Context.hpp"
+#include "Options/ParseError.hpp"
+#include "Options/String.hpp"
+#include "ParallelAlgorithms/Amr/Criteria/Criterion.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+template <size_t>
+class ElementId;
+/// \endcond
+
+namespace amr::Criteria {
+
+/// @{
+/*!
+ * \brief Computes an anisotropic smoothness indicator based on the power in the
+ * highest modes
+ *
+ * This smoothness indicator is the L2 norm of the tensor component with the
+ * lowest N - M modes filtered out, where N is the number of grid points in the
+ * given dimension and M is `num_highest_modes`.
+ *
+ * This strategy is similar to the Persson troubled-cell indicator (see
+ * `evolution::dg::subcell::persson_tci`) with a few modifications:
+ *
+ * - The indicator is computed in each dimension separately for an anisotropic
+ *   measure.
+ * - The number of highest modes to keep can be chosen as a parameter.
+ * - We don't normalize by the L2 norm of the unfiltered data $u$ here. This
+ *   function just returns the L2 norm of the filtered data.
+ */
+template <size_t Dim>
+double persson_smoothness_indicator(
+    gsl::not_null<DataVector*> filtered_component_buffer,
+    const DataVector& tensor_component, const Mesh<Dim>& mesh, size_t dimension,
+    size_t num_highest_modes);
+template <size_t Dim>
+std::array<double, Dim> persson_smoothness_indicator(
+    const DataVector& tensor_component, const Mesh<Dim>& mesh,
+    size_t num_highest_modes);
+/// @}
+
+namespace Persson_detail {
+template <size_t Dim>
+void max_over_components(gsl::not_null<std::array<Flag, Dim>*> result,
+                         gsl::not_null<DataVector*> buffer,
+                         const DataVector& tensor_component,
+                         const Mesh<Dim>& mesh, size_t num_highest_modes,
+                         double alpha, double absolute_tolerance,
+                         double coarsening_factor);
+}
+
+/*!
+ * \brief h-refine the grid based on power in the highest modes
+ *
+ * \see persson_smoothness_indicator
+ */
+template <size_t Dim, typename TensorTags>
+class Persson : public Criterion {
+ public:
+  struct VariablesToMonitor {
+    using type = std::vector<std::string>;
+    static constexpr Options::String help = {
+        "The tensors to monitor for h-refinement."};
+    static size_t lower_bound_on_size() { return 1; }
+  };
+  struct NumHighestModes {
+    using type = size_t;
+    static constexpr Options::String help = {
+        "Number of highest modes to monitor the power of."};
+    static size_t lower_bound() { return 1; }
+  };
+  struct Exponent {
+    using type = double;
+    static constexpr Options::String help = {
+        "The exponent at which the modes should decrease. "
+        "Corresponds to a \"relative tolerance\" of N^(-alpha), where N is the "
+        "number of grid points minus 'NumHighestModes'. "
+        "If any tensor component has power in the highest modes above this "
+        "value times the max of the absolute tensor component over the "
+        "element, the element will be h-refined in that direction."};
+    static double lower_bound() { return 0.; }
+  };
+  struct AbsoluteTolerance {
+    using type = double;
+    static constexpr Options::String help = {
+        "If any tensor component has a power in the highest modes above this "
+        "value, the element will be h-refined in that direction. "
+        "Set to 0 to disable."};
+    static double lower_bound() { return 0.; }
+  };
+  struct CoarseningFactor {
+    using type = double;
+    static constexpr Options::String help = {
+        "Factor applied to both relative and absolute tolerance to trigger "
+        "h-coarsening. Set to 0 to disable h-coarsening altogether. "
+        "Set closer to 1 to trigger h-coarsening more aggressively. "
+        "Values too close to 1 risk that coarsened elements will immediately "
+        "trigger h-refinement again. A reasonable value is 0.1."};
+    static double lower_bound() { return 0.; }
+    static double upper_bound() { return 1.; }
+  };
+
+  using options = tmpl::list<VariablesToMonitor, NumHighestModes, Exponent,
+                             AbsoluteTolerance, CoarseningFactor>;
+
+  static constexpr Options::String help = {
+      "Refine the grid so the power in the highest modes stays below the "
+      "tolerance"};
+
+  Persson() = default;
+
+  Persson(std::vector<std::string> vars_to_monitor,
+          const size_t num_highest_modes, double alpha,
+          double absolute_tolerance, double coarsening_factor,
+          const Options::Context& context = {});
+
+  /// \cond
+  explicit Persson(CkMigrateMessage* msg);
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(Persson);  // NOLINT
+  /// \endcond
+
+  using compute_tags_for_observation_box = tmpl::list<>;
+
+  using argument_tags = tmpl::list<::Tags::DataBox>;
+
+  template <typename DbTagsList, typename Metavariables>
+  std::array<Flag, Dim> operator()(const db::DataBox<DbTagsList>& box,
+                                   Parallel::GlobalCache<Metavariables>& cache,
+                                   const ElementId<Dim>& element_id) const;
+
+  void pup(PUP::er& p) override;
+
+ private:
+  std::vector<std::string> vars_to_monitor_{};
+  size_t num_highest_modes_{};
+  double alpha_ = std::numeric_limits<double>::signaling_NaN();
+  double absolute_tolerance_ = std::numeric_limits<double>::signaling_NaN();
+  double coarsening_factor_ = std::numeric_limits<double>::signaling_NaN();
+};
+
+// Out-of-line definitions
+/// \cond
+
+template <size_t Dim, typename TensorTags>
+Persson<Dim, TensorTags>::Persson(std::vector<std::string> vars_to_monitor,
+                                  const size_t num_highest_modes,
+                                  const double alpha,
+                                  const double absolute_tolerance,
+                                  const double coarsening_factor,
+                                  const Options::Context& context)
+    : vars_to_monitor_(std::move(vars_to_monitor)),
+      num_highest_modes_(num_highest_modes),
+      alpha_(alpha),
+      absolute_tolerance_(absolute_tolerance),
+      coarsening_factor_(coarsening_factor) {
+  db::validate_selection<TensorTags>(vars_to_monitor_, context);
+}
+
+template <size_t Dim, typename TensorTags>
+Persson<Dim, TensorTags>::Persson(CkMigrateMessage* msg) : Criterion(msg) {}
+
+template <size_t Dim, typename TensorTags>
+template <typename DbTagsList, typename Metavariables>
+std::array<Flag, Dim> Persson<Dim, TensorTags>::operator()(
+    const db::DataBox<DbTagsList>& box,
+    Parallel::GlobalCache<Metavariables>& /*cache*/,
+    const ElementId<Dim>& /*element_id*/) const {
+  auto result = make_array<Dim>(Flag::Undefined);
+  const auto& mesh = db::get<domain::Tags::Mesh<Dim>>(box);
+  // Check all tensors and all tensor components in turn. We take the
+  // highest-priority refinement flag in each dimension, so if any tensor
+  // component is non-smooth, the element will split in that dimension. And only
+  // if all tensor components are smooth enough will elements join in that
+  // dimension.
+  DataVector buffer(mesh.number_of_grid_points());
+  tmpl::for_each<TensorTags>(
+      [&result, &box, &mesh, &buffer, this](const auto tag_v) {
+        // Stop if we have already decided to refine every dimension
+        if (result == make_array<Dim>(Flag::Split)) {
+          return;
+        }
+        using tag = tmpl::type_from<std::decay_t<decltype(tag_v)>>;
+        const std::string tag_name = db::tag_name<tag>();
+        // Skip if this tensor is not being monitored
+        if (not alg::found(vars_to_monitor_, tag_name)) {
+          return;
+        }
+        const auto& tensor = db::get<tag>(box);
+        for (const DataVector& tensor_component : tensor) {
+          Persson_detail::max_over_components(
+              make_not_null(&result), make_not_null(&buffer), tensor_component,
+              mesh, num_highest_modes_, alpha_, absolute_tolerance_,
+              coarsening_factor_);
+        }
+      });
+  return result;
+}
+
+template <size_t Dim, typename TensorTags>
+void Persson<Dim, TensorTags>::pup(PUP::er& p) {
+  p | vars_to_monitor_;
+  p | num_highest_modes_;
+  p | alpha_;
+  p | absolute_tolerance_;
+  p | coarsening_factor_;
+}
+
+template <size_t Dim, typename TensorTags>
+PUP::able::PUP_ID Persson<Dim, TensorTags>::my_PUP_ID = 0;  // NOLINT
+/// \endcond
+
+}  // namespace amr::Criteria

--- a/src/ParallelAlgorithms/Amr/Criteria/TruncationError.cpp
+++ b/src/ParallelAlgorithms/Amr/Criteria/TruncationError.cpp
@@ -29,6 +29,7 @@ void max_over_components(
   // still satisfy the target with the highest mode removed will the element
   // decrease p refinement in that dimension.
   PowerMonitors::power_monitors(power_monitors_buffer, tensor_component, mesh);
+  const double umax = max(abs(tensor_component));
   for (size_t d = 0; d < Dim; ++d) {
     // Skip this dimension if we have already decided to refine it
     if (gsl::at(*result, d) == Flag::IncreaseResolution) {
@@ -38,7 +39,6 @@ void max_over_components(
     // Increase p refinement if the truncation error exceeds the target
     const double rel_truncation_error =
         pow(10, -PowerMonitors::relative_truncation_error(modes, modes.size()));
-    const double umax = max(abs(tensor_component));
     const double abs_truncation_error = umax * rel_truncation_error;
     if ((target_rel_truncation_error.has_value() and
          rel_truncation_error > target_rel_truncation_error.value()) or

--- a/tests/Unit/ParallelAlgorithms/Amr/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/Amr/CMakeLists.txt
@@ -17,6 +17,7 @@ set(LIBRARY_SOURCES
   Criteria/Test_Criterion.cpp
   Criteria/Test_DriveToTarget.cpp
   Criteria/Test_Loehner.cpp
+  Criteria/Test_Persson.cpp
   Criteria/Test_Random.cpp
   Criteria/Test_TruncationError.cpp
   Projectors/Test_DefaultInitialize.cpp

--- a/tests/Unit/ParallelAlgorithms/Amr/Criteria/Test_Persson.cpp
+++ b/tests/Unit/ParallelAlgorithms/Amr/Criteria/Test_Persson.cpp
@@ -1,0 +1,104 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <memory>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/ObservationBox.hpp"
+#include "Domain/Amr/Flag.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "NumericalAlgorithms/Spectral/LogicalCoordinates.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "Options/Protocols/FactoryCreation.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "ParallelAlgorithms/Amr/Criteria/Criterion.hpp"
+#include "ParallelAlgorithms/Amr/Criteria/Persson.hpp"
+#include "Utilities/Serialization/RegisterDerivedClassesWithCharm.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace amr::Criteria {
+namespace {
+
+template <size_t Dim>
+struct TestVector : db::SimpleTag {
+  using type = tnsr::I<DataVector, Dim>;
+};
+
+template <size_t Dim>
+struct Metavariables {
+  static constexpr size_t volume_dim = Dim;
+  using component_list = tmpl::list<>;
+  using const_global_cache_tags = tmpl::list<>;
+  struct factory_creation
+      : tt::ConformsTo<Options::protocols::FactoryCreation> {
+    using factory_classes = tmpl::map<tmpl::pair<
+        amr::Criterion, tmpl::list<Persson<Dim, tmpl::list<TestVector<Dim>>>>>>;
+  };
+};
+
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Amr.Criteria.Persson", "[Unit][ParallelAlgorithms]") {
+  static constexpr size_t Dim = 2;
+  const Mesh<Dim> mesh{6, Spectral::Basis::Legendre,
+                       Spectral::Quadrature::GaussLobatto};
+  const auto logical_coords = logical_coordinates(mesh);
+
+  {
+    INFO("Linear function in both dimensions");
+    const DataVector test_data =
+        get<0>(logical_coords) + 2. * get<1>(logical_coords);
+    // Only the lowest 2 modes are non-zero
+    const auto indicator = persson_smoothness_indicator(test_data, mesh, 4);
+    CHECK(indicator[0] == approx(0.));
+    CHECK(indicator[1] == approx(0.));
+  }
+  {
+    INFO("Nonlinear in one dimension and linear in the other");
+    const DataVector test_data =
+        exp(-square(get<0>(logical_coords))) + 2. * get<1>(logical_coords);
+    const auto indicator = persson_smoothness_indicator(test_data, mesh, 2);
+    CHECK(indicator[0] == approx(0.04065096467876369));
+    CHECK(indicator[1] == approx(0.));
+  }
+
+  register_factory_classes_with_charm<Metavariables<Dim>>();
+  const auto criterion = TestHelpers::test_factory_creation<
+      amr::Criterion, Persson<Dim, tmpl::list<TestVector<Dim>>>>(
+      "Persson:\n"
+      "  VariablesToMonitor: [TestVector]\n"
+      "  NumHighestModes: 2\n"
+      "  AbsoluteTolerance: 1.e-3\n"
+      "  Exponent: 4\n"
+      "  CoarseningFactor: 0.1\n");
+
+  // Manufacture some test data
+  tnsr::I<DataVector, Dim> test_data{};
+  // X-component is linear in x and y
+  get<0>(test_data) = get<0>(logical_coords) + 2. * get<1>(logical_coords);
+  // Y-component is nonlinear in one dimension and linear in the other
+  get<1>(test_data) =
+      exp(-square(get<0>(logical_coords))) + 2. * get<1>(logical_coords);
+
+  Parallel::GlobalCache<Metavariables<Dim>> empty_cache{};
+  const auto databox =
+      db::create<tmpl::list<::domain::Tags::Mesh<Dim>, TestVector<Dim>>>(
+          mesh, std::move(test_data));
+  ObservationBox<
+      tmpl::list<>,
+      db::DataBox<tmpl::list<::domain::Tags::Mesh<Dim>, TestVector<Dim>>>>
+      box{databox};
+
+  const auto flags = criterion->evaluate(box, empty_cache, ElementId<Dim>{0});
+  CHECK(flags[0] == amr::Flag::Split);
+  CHECK(flags[1] == amr::Flag::Join);
+}
+
+}  // namespace amr::Criteria


### PR DESCRIPTION
## Proposed changes

Similar to the Persson TCI.

![Figure 8](https://github.com/sxs-collaboration/spectre/assets/746230/a45b0dad-a39a-47f2-a726-441fc7d26ad0)

Bottom panel are the modes in each element. Top right axis and horizontal lines in top panel show the smoothness indicator.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
