### PR TITLE
Fix running multiple random-value tests in a debugger

### DIFF
--- a/tests/Unit/Framework/SetupLocalPythonEnvironment.cpp
+++ b/tests/Unit/Framework/SetupLocalPythonEnvironment.cpp
@@ -28,11 +28,17 @@ SetupLocalPythonEnvironment::SetupLocalPythonEnvironment(
   // finished running, since there could be multiple tests run in a single
   // executable launch. This is done in TestMain(Charm).cpp.
   if (not initialized) {
+    PyStatus status;
+    PyConfig config;
+    PyConfig_InitPythonConfig(&config);
+    // Populate the Python config with the standard values
+    status = PyConfig_Read(&config);
     // Don't produce the __pycache__ dir (python 3.2 and newer) or the .pyc
     // files (python 2.7) in the tests directory to avoid cluttering the source
     // tree. The overhead of not having the compile files is <= 0.01s
-    Py_DontWriteBytecodeFlag = 1;
-    Py_Initialize();
+    config.write_bytecode = 0;
+    status = Py_InitializeFromConfig(&config);
+    PyConfig_Clear(&config);
 
     // clang-tidy: Do not use const-cast
     PyObject* pyob_old_paths =

--- a/tests/Unit/Framework/SetupLocalPythonEnvironment.cpp
+++ b/tests/Unit/Framework/SetupLocalPythonEnvironment.cpp
@@ -2,8 +2,6 @@
 // See LICENSE.txt for details.
 
 #include <boost/preprocessor.hpp>
-#include <codecvt>  // IWYU pragma: keep
-#include <locale>   // IWYU pragma: keep
 #include <string>
 #include <vector>
 
@@ -18,12 +16,27 @@
 #include "Framework/PyppFundamentals.hpp"
 #include "Framework/SetupLocalPythonEnvironment.hpp"
 #include "Informer/InfoFromBuild.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
 #include "Utilities/FileSystem.hpp"
 
+namespace {
+void prepend_python_path(const std::string& new_path) {
+  if (not file_system::check_if_dir_exists(new_path)) {
+    ERROR_NO_TRACE("Trying to add path '"
+                   << new_path
+                   << "' to the python environment during setup "
+                      "but this directory does not exist. Maybe "
+                      "you have a typo in your path?");
+  }
+  PyObject* sys_path = PySys_GetObject("path");
+  PyList_Insert(sys_path, 0, PyUnicode_FromString(new_path.c_str()));
+}
+}  // namespace
+
 namespace pypp {
 SetupLocalPythonEnvironment::SetupLocalPythonEnvironment(
-    const std::string &cur_dir_relative_to_unit_test_path) {
+    const std::string& cur_dir_relative_to_unit_test_path) {
   // We have to clean up the Python environment only after all tests have
   // finished running, since there could be multiple tests run in a single
   // executable launch. This is done in TestMain(Charm).cpp.
@@ -40,38 +53,8 @@ SetupLocalPythonEnvironment::SetupLocalPythonEnvironment(
     status = Py_InitializeFromConfig(&config);
     PyConfig_Clear(&config);
 
-    // clang-tidy: Do not use const-cast
-    PyObject* pyob_old_paths =
-        PySys_GetObject(const_cast<char*>("path"));  // NOLINT
-    const auto old_paths =
-        pypp::from_py_object<std::vector<std::string>>(pyob_old_paths);
-    std::string new_path =
-        unit_test_src_path() + cur_dir_relative_to_unit_test_path;
-    if (not file_system::check_if_dir_exists(new_path)) {
-      ERROR_NO_TRACE("Trying to add path '"
-                     << new_path
-                     << "' to the python environment during setup "
-                        "but this directory does not exist. Maybe "
-                        "you have a typo in your path?");
-    }
-
     // Add directory for installed packages (see CMakeLists.txt for details)
-    new_path += ":";
-    new_path += PYTHON_SITELIB;
-
-    for (const auto& p : old_paths) {
-      new_path += ":";
-      new_path += p;
-    }
-
-#if PY_MAJOR_VERSION == 3
-    PySys_SetPath(std::wstring_convert<std::codecvt_utf8<wchar_t>>()
-                      .from_bytes(new_path)
-                      .c_str());
-#else
-    // clang-tidy: Do not use const-cast
-    PySys_SetPath(const_cast<char*>(new_path.c_str()));  // NOLINT
-#endif
+    prepend_python_path(PYTHON_SITELIB);
 
     // On some python versions init_numpy() can throw an FPE, this occurred at
     // least with python 3.6, numpy 1.14.2.
@@ -80,6 +63,10 @@ SetupLocalPythonEnvironment::SetupLocalPythonEnvironment(
     disable_fpes.restore_exceptions();
   }
   initialized = true;
+
+  // Add test directory to the Python path
+  prepend_python_path(unit_test_src_path() +
+                      cur_dir_relative_to_unit_test_path);
 }
 
 #if PY_MAJOR_VERSION == 3


### PR DESCRIPTION
## Proposed changes

Previous behavior: running `./bin/Test_GeneralRelativity` failed because only the first random-value test registered its `PYTHONPATH`.
Now: running `./bin/Test_GeneralRelativity` works.

Also fixes #5191.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
