### PR TITLE
Add p-refinement criterion based on constraints

### DIFF
--- a/src/ParallelAlgorithms/Amr/Criteria/CMakeLists.txt
+++ b/src/ParallelAlgorithms/Amr/Criteria/CMakeLists.txt
@@ -8,6 +8,7 @@ add_spectre_library(${LIBRARY})
 spectre_target_sources(
   ${LIBRARY}
   PRIVATE
+  Constraints.cpp
   DriveToTarget.cpp
   Loehner.cpp
   Persson.cpp
@@ -19,6 +20,7 @@ spectre_target_headers(
   ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
+  Constraints.hpp
   Criteria.hpp
   Criterion.hpp
   DriveToTarget.hpp
@@ -38,6 +40,7 @@ target_link_libraries(
   PUBLIC
   Amr
   DomainStructure
+  Events
   Options
   Parallel
   Spectral

--- a/src/ParallelAlgorithms/Amr/Criteria/Constraints.cpp
+++ b/src/ParallelAlgorithms/Amr/Criteria/Constraints.cpp
@@ -1,0 +1,149 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "ParallelAlgorithms/Amr/Criteria/Constraints.hpp"
+
+#include <array>
+#include <cstddef>
+#include <optional>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/Amr/Flag.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/SetNumberOfGridPoints.hpp"
+
+namespace amr::Criteria::Constraints_detail {
+
+template <size_t Dim>
+void normalization_factor_square(
+    const gsl::not_null<tnsr::i<DataVector, Dim, Frame::ElementLogical>*>
+        result,
+    const Jacobian<DataVector, Dim, Frame::ElementLogical, Frame::Inertial>&
+        jacobian) {
+  set_number_of_grid_points(result, jacobian);
+  for (size_t k = 0; k < Dim; ++k) {
+    // Possible performance optimization: unroll first iteration of loop to
+    // avoid zeroing buffer
+    result->get(k) = 0.;
+    for (size_t i = 0; i < Dim; ++i) {
+      result->get(k) += square(jacobian.get(i, k));
+    }
+  }
+}
+
+template <size_t Dim, typename TensorType>
+void logical_constraints(
+    const gsl::not_null<tnsr::i<DataVector, Dim, Frame::ElementLogical>*>
+        result,
+    const gsl::not_null<DataVector*> buffer,
+    const TensorType& constraints_tensor,
+    const Jacobian<DataVector, Dim, Frame::ElementLogical, Frame::Inertial>&
+        jacobian,
+    const tnsr::i<DataVector, Dim, Frame::ElementLogical>&
+        normalization_factor_square) {
+  static_assert(TensorType::rank() >= 2,
+                "The constraints tensor must have rank 2 or higher.");
+  using first_index = tmpl::front<typename TensorType::index_list>;
+  static_assert(
+      first_index::index_type == IndexType::Spatial and
+          first_index::dim == Dim and first_index::ul == UpLo::Lo and
+          std::is_same_v<typename first_index::Frame, Frame::Inertial>,
+      "The first index of the constraints tensor must be a lower "
+      "spatial index (that originates from a derivative).");
+  using NonFirstIndexTensor =
+      TensorMetafunctions::remove_first_index<TensorType>;
+  set_number_of_grid_points(result, constraints_tensor);
+  set_number_of_grid_points(buffer, constraints_tensor);
+  for (size_t k = 0; k < Dim; ++k) {
+    result->get(k) = 0.;
+    for (size_t a = 0; a < NonFirstIndexTensor::size(); ++a) {
+      const auto non_first_index = NonFirstIndexTensor::get_tensor_index(a);
+      // Possible performance optimization: unroll first iteration of loop to
+      // avoid zeroing buffer
+      *buffer = 0.;
+      for (size_t i = 0; i < Dim; ++i) {
+        const auto full_index = prepend(non_first_index, i);
+        *buffer += jacobian.get(i, k) * constraints_tensor.get(full_index);
+      }
+      result->get(k) += square(*buffer);
+    }
+    result->get(k) = sqrt(result->get(k) / normalization_factor_square.get(k));
+  }
+}
+
+template <size_t Dim>
+void max_over_components(
+    const gsl::not_null<std::array<Flag, Dim>*> result,
+    const tnsr::i<DataVector, Dim, Frame::ElementLogical>& logical_constraints,
+    const double abs_target, const double coarsening_factor) {
+  // We take the highest-priority refinement flag in each dimension, so if any
+  // constraint is above the target, the element will increase p refinement in
+  // that dimension. And only if all constraints are below the coarsening
+  // threshold will the element decrease p refinement in that dimension.
+  const size_t sqrt_num_points = sqrt(logical_constraints.begin()->size());
+  for (size_t d = 0; d < Dim; ++d) {
+    // Skip this dimension if we have already decided to refine it
+    if (gsl::at(*result, d) == Flag::IncreaseResolution) {
+      continue;
+    }
+    const double constraint_norm =
+        blaze::l2Norm(logical_constraints.get(d)) / sqrt_num_points;
+    // Increase p refinement if the constraint norm exceeds the target
+    if (constraint_norm > abs_target) {
+      gsl::at(*result, d) = Flag::IncreaseResolution;
+      continue;
+    }
+    // Dont' check if we want to (allow) decreasing p refinement if another
+    // tensor has already decided that decreasing p refinement is bad.
+    if (gsl::at(*result, d) == Flag::DoNothing) {
+      continue;
+    }
+    // Decrease p refinement if the constraint norm is below the coarsening
+    // threshold. Otherwise, request to stay at this resolution (or increase
+    // resolution if another constraint requested that).
+    if (constraint_norm < coarsening_factor * abs_target) {
+      gsl::at(*result, d) = Flag::DecreaseResolution;
+    } else {
+      gsl::at(*result, d) = Flag::DoNothing;
+    }
+  }
+}
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define TNSR(data) BOOST_PP_TUPLE_ELEM(1, data)
+
+#define INSTANTIATE(_, data)                                       \
+  template void normalization_factor_square(                       \
+      const gsl::not_null<                                         \
+          tnsr::i<DataVector, DIM(data), Frame::ElementLogical>*>  \
+          result,                                                  \
+      const Jacobian<DataVector, DIM(data), Frame::ElementLogical, \
+                     Frame::Inertial>& jacobian);                  \
+  template void max_over_components(                               \
+      gsl::not_null<std::array<Flag, DIM(data)>*> result,          \
+      const tnsr::i<DataVector, DIM(data), Frame::ElementLogical>& \
+          logical_constraints,                                     \
+      double abs_target, double coarsening_factor);
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
+
+#define INSTANTIATE_TENSORS(_, data)                                          \
+  template void logical_constraints(                                          \
+      gsl::not_null<tnsr::i<DataVector, DIM(data), Frame::ElementLogical>*>   \
+          result,                                                             \
+      gsl::not_null<DataVector*> buffer, const tnsr::TNSR(data) < DataVector, \
+      DIM(data), Frame::Inertial > &constraints_tensor,                       \
+      const Jacobian<DataVector, DIM(data), Frame::ElementLogical,            \
+                     Frame::Inertial>& jacobian,                              \
+      const tnsr::i<DataVector, DIM(data), Frame::ElementLogical>&            \
+          normalization_factor_square);
+
+GENERATE_INSTANTIATIONS(INSTANTIATE_TENSORS, (1, 2, 3), (ia, iaa))
+
+#undef INSTANTIATE
+#undef INSTANTIATE_TENSORS
+#undef DIM
+
+}  // namespace amr::Criteria::Constraints_detail

--- a/src/ParallelAlgorithms/Amr/Criteria/Constraints.hpp
+++ b/src/ParallelAlgorithms/Amr/Criteria/Constraints.hpp
@@ -1,0 +1,252 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <limits>
+#include <optional>
+#include <pup.h>
+#include <string>
+#include <vector>
+
+#include "DataStructures/DataBox/ObservationBox.hpp"
+#include "DataStructures/DataBox/ValidateSelection.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tags/TempTensor.hpp"
+#include "DataStructures/TempBuffer.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/Amr/Flag.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "Options/Context.hpp"
+#include "Options/ParseError.hpp"
+#include "Options/String.hpp"
+#include "ParallelAlgorithms/Amr/Criteria/Criterion.hpp"
+#include "ParallelAlgorithms/Events/Tags.hpp"
+#include "Utilities/Algorithm.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+template <size_t>
+class ElementId;
+/// \endcond
+
+namespace amr::Criteria {
+
+namespace Constraints_detail {
+
+/*!
+ * \brief Computes the (squared) normalization factor $N_\hat{k}^2$ (see
+ * `logical_constraints` below)
+ */
+template <size_t Dim>
+void normalization_factor_square(
+    gsl::not_null<tnsr::i<DataVector, Dim, Frame::ElementLogical>*> result,
+    const Jacobian<DataVector, Dim, Frame::ElementLogical, Frame::Inertial>&
+        jacobian);
+
+/*!
+ * \brief Computes a measure of the constraints in each logical direction of the
+ * grid
+ *
+ * \requires `constraints_tensor` to be a tensor of rank 2 or higher. The first
+ * index must be a lower spatial index that originates from a derivative.
+ *
+ * We follow \cite Szilagyi2014fna, Eq. (62)-(64) to compute:
+ *
+ * \begin{align}
+ * \Epsilon_\hat{k} &= \frac{1}{N_\hat{k}} \sqrt{\sum_{a\ldots} \left(\sum_{i}
+ *   \frac{\partial x^i}{\partial x^\hat{k}} C_{ia\ldots}\right)^2} \\
+ * N_\hat{k} &= \sqrt{\sum_{i} \left(\frac{\partial x^i}{\partial x^\hat{k}}
+ *   \right)^2}
+ * \end{align}
+ *
+ * This transform the first lower spatial index of the tensor to the
+ * element-logical frame, then takes an L2 norm over all remaining indices.
+ * The (squared) normalization factor $N_\hat{k}^2$ is computed by
+ * `normalization_factor` and passed in as an argument.
+ */
+template <size_t Dim, typename TensorType>
+void logical_constraints(
+    gsl::not_null<tnsr::i<DataVector, Dim, Frame::ElementLogical>*> result,
+    gsl::not_null<DataVector*> buffer, const TensorType& constraints_tensor,
+    const Jacobian<DataVector, Dim, Frame::ElementLogical, Frame::Inertial>&
+        jacobian,
+    const tnsr::i<DataVector, Dim, Frame::ElementLogical>&
+        normalization_factor_square);
+
+/*!
+ * \brief Apply the AMR criterion to one of the constraints
+ *
+ * The `result` is the current decision in each dimension based on the previous
+ * constraints. This function will update the flags if necessary. It takes
+ * the "max" of the current and new flags, where the "highest" flag is
+ * `Flag::IncreaseResolution`, followed by `Flag::DoNothing`, and then
+ * `Flag::DecreaseResolution`.
+ */
+template <size_t Dim>
+void max_over_components(
+    gsl::not_null<std::array<Flag, Dim>*> result,
+    const tnsr::i<DataVector, Dim, Frame::ElementLogical>& logical_constraints,
+    double abs_target, double coarsening_factor);
+
+}  // namespace Constraints_detail
+
+/*!
+ * \brief Refine the grid towards the target constraint violation
+ *
+ * - If any constraint is above the target value, the element will be p-refined.
+ * - If all constraints are below the target times the "coarsening factor" the
+ *   element will be p-coarsened.
+ *
+ * This criterion is based on Sec. 6.1.4 in \cite Szilagyi2014fna .
+ *
+ * If the coarsening factor turns out to be hard to choose, then we can try to
+ * eliminate it by projecting the variables to a lower polynomial order before
+ * computing constraints, or something like that.
+ *
+ * \tparam Dim Spatial dimension of the grid
+ * \tparam TensorTags List of tags of the constraints to be monitored. These
+ * must be tensors of rank 2 or higher. The first index must be a lower spatial
+ * index that originates from a derivative.
+ */
+template <size_t Dim, typename TensorTags>
+class Constraints : public Criterion {
+ public:
+  struct ConstraintsToMonitor {
+    using type = std::vector<std::string>;
+    static constexpr Options::String help = {"The constraints to monitor."};
+    static size_t lower_bound_on_size() { return 1; }
+  };
+  struct AbsoluteTarget {
+    using type = double;
+    static constexpr Options::String help = {
+        "The absolute target constraint violation. If any constraint is above "
+        "this value, the element will be p-refined."};
+    static double lower_bound() { return 0.; }
+  };
+  struct CoarseningFactor {
+    using type = double;
+    static constexpr Options::String help = {
+        "If all constraints are below the 'AbsoluteTarget' times this factor, "
+        "the element will be p-coarsened. "
+        "A reasonable value is 0.1."};
+    static double lower_bound() { return 0.; }
+    static double upper_bound() { return 1.; }
+  };
+
+  using options =
+      tmpl::list<ConstraintsToMonitor, AbsoluteTarget, CoarseningFactor>;
+
+  static constexpr Options::String help = {
+      "Refine the grid towards the target constraint violation"};
+
+  Constraints() = default;
+
+  Constraints(std::vector<std::string> vars_to_monitor, double abs_target,
+              double coarsening_factor, const Options::Context& context = {});
+
+  /// \cond
+  explicit Constraints(CkMigrateMessage* msg);
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(Constraints);  // NOLINT
+  /// \endcond
+
+  using compute_tags_for_observation_box = TensorTags;
+
+  using argument_tags = tmpl::list<::Tags::ObservationBox>;
+
+  template <typename ComputeTagsList, typename DataBoxType,
+            typename Metavariables>
+  std::array<Flag, Dim> operator()(
+      const ObservationBox<ComputeTagsList, DataBoxType>& box,
+      Parallel::GlobalCache<Metavariables>& cache,
+      const ElementId<Dim>& element_id) const;
+
+  void pup(PUP::er& p) override;
+
+ private:
+  std::vector<std::string> vars_to_monitor_{};
+  double abs_target_ = std::numeric_limits<double>::signaling_NaN();
+  double coarsening_factor_ = std::numeric_limits<double>::signaling_NaN();
+};
+
+// Out-of-line definitions
+/// \cond
+
+template <size_t Dim, typename TensorTags>
+Constraints<Dim, TensorTags>::Constraints(
+    std::vector<std::string> vars_to_monitor, const double abs_target,
+    const double coarsening_factor, const Options::Context& context)
+    : vars_to_monitor_(std::move(vars_to_monitor)),
+      abs_target_(abs_target),
+      coarsening_factor_(coarsening_factor) {
+  db::validate_selection<TensorTags>(vars_to_monitor_, context);
+}
+
+template <size_t Dim, typename TensorTags>
+Constraints<Dim, TensorTags>::Constraints(CkMigrateMessage* msg)
+    : Criterion(msg) {}
+
+template <size_t Dim, typename TensorTags>
+template <typename ComputeTagsList, typename DataBoxType,
+          typename Metavariables>
+std::array<Flag, Dim> Constraints<Dim, TensorTags>::operator()(
+    const ObservationBox<ComputeTagsList, DataBoxType>& box,
+    Parallel::GlobalCache<Metavariables>& /*cache*/,
+    const ElementId<Dim>& /*element_id*/) const {
+  auto result = make_array<Dim>(Flag::Undefined);
+  const auto& jacobian =
+      get<Events::Tags::ObserverJacobian<Dim, Frame::ElementLogical,
+                                         Frame::Inertial>>(box);
+  // Set up memory buffers
+  const size_t num_points = jacobian.begin()->size();
+  TempBuffer<tmpl::list<::Tags::Tempi<0, Dim, Frame::ElementLogical>,
+                        ::Tags::Tempi<1, Dim, Frame::ElementLogical>,
+                        ::Tags::TempScalar<2>>>
+      buffer{num_points};
+  auto& normalization_factor_square =
+      get<::Tags::Tempi<0, Dim, Frame::ElementLogical>>(buffer);
+  auto& logical_constraints =
+      get<::Tags::Tempi<1, Dim, Frame::ElementLogical>>(buffer);
+  auto& scalar_buffer = get(get<::Tags::TempScalar<2>>(buffer));
+  Constraints_detail::normalization_factor_square(
+      make_not_null(&normalization_factor_square), jacobian);
+  // Check all constraints in turn
+  tmpl::for_each<TensorTags>([&result, &box, &jacobian,
+                              &normalization_factor_square,
+                              &logical_constraints, &scalar_buffer,
+                              this](const auto tag_v) {
+    // Stop if we have already decided to refine every dimension
+    if (result == make_array<Dim>(Flag::IncreaseResolution)) {
+      return;
+    }
+    using tag = tmpl::type_from<std::decay_t<decltype(tag_v)>>;
+    const std::string tag_name = db::tag_name<tag>();
+    // Skip if this tensor is not being monitored
+    if (not alg::found(vars_to_monitor_, tag_name)) {
+      return;
+    }
+    Constraints_detail::logical_constraints(
+        make_not_null(&logical_constraints), make_not_null(&scalar_buffer),
+        get<tag>(box), jacobian, normalization_factor_square);
+    Constraints_detail::max_over_components(make_not_null(&result),
+                                            logical_constraints, abs_target_,
+                                            coarsening_factor_);
+  });
+  return result;
+}
+
+template <size_t Dim, typename TensorTags>
+void Constraints<Dim, TensorTags>::pup(PUP::er& p) {
+  p | vars_to_monitor_;
+  p | abs_target_;
+  p | coarsening_factor_;
+}
+
+template <size_t Dim, typename TensorTags>
+PUP::able::PUP_ID Constraints<Dim, TensorTags>::my_PUP_ID = 0;  // NOLINT
+/// \endcond
+
+}  // namespace amr::Criteria

--- a/tests/Unit/ParallelAlgorithms/Amr/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/Amr/CMakeLists.txt
@@ -14,6 +14,7 @@ set(LIBRARY_SOURCES
   Actions/Test_InitializeParent.cpp
   Actions/Test_SendDataToChildren.cpp
   Actions/Test_UpdateAmrDecision.cpp
+  Criteria/Test_Constraints.cpp
   Criteria/Test_Criterion.cpp
   Criteria/Test_DriveToTarget.cpp
   Criteria/Test_Loehner.cpp

--- a/tests/Unit/ParallelAlgorithms/Amr/Criteria/Test_Constraints.cpp
+++ b/tests/Unit/ParallelAlgorithms/Amr/Criteria/Test_Constraints.cpp
@@ -1,0 +1,112 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <memory>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/ObservationBox.hpp"
+#include "Domain/Amr/Flag.hpp"
+#include "Domain/CoordinateMaps/Affine.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
+#include "Domain/CoordinateMaps/DiscreteRotation.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.tpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Domain/Structure/OrientationMap.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
+#include "NumericalAlgorithms/Spectral/LogicalCoordinates.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "Options/Protocols/FactoryCreation.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "ParallelAlgorithms/Amr/Criteria/Constraints.hpp"
+#include "ParallelAlgorithms/Amr/Criteria/Criterion.hpp"
+#include "ParallelAlgorithms/Events/Tags.hpp"
+#include "Utilities/Serialization/RegisterDerivedClassesWithCharm.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace amr::Criteria {
+namespace {
+
+template <size_t Dim>
+struct TestVector : db::SimpleTag {
+  using type = tnsr::ia<DataVector, Dim>;
+};
+
+template <size_t Dim>
+struct Metavariables {
+  static constexpr size_t volume_dim = Dim;
+  using component_list = tmpl::list<>;
+  using const_global_cache_tags = tmpl::list<>;
+  struct factory_creation
+      : tt::ConformsTo<Options::protocols::FactoryCreation> {
+    using factory_classes = tmpl::map<
+        tmpl::pair<amr::Criterion,
+                   tmpl::list<Constraints<Dim, tmpl::list<TestVector<Dim>>>>>>;
+  };
+};
+
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Amr.Criteria.Constraints",
+                  "[Unit][ParallelAlgorithms]") {
+  static constexpr size_t Dim = 2;
+  using Affine = domain::CoordinateMaps::Affine;
+  using Affine2D = domain::CoordinateMaps::ProductOf2Maps<Affine, Affine>;
+  register_factory_classes_with_charm<Metavariables<Dim>>();
+  const auto criterion = TestHelpers::test_factory_creation<
+      amr::Criterion, Constraints<Dim, tmpl::list<TestVector<Dim>>>>(
+      "Constraints:\n"
+      "  ConstraintsToMonitor: [TestVector]\n"
+      "  AbsoluteTarget: 1.e-3\n"
+      "  CoarseningFactor: 0.1\n");
+
+  // Set up a grid
+  const Mesh<Dim> mesh{4, Spectral::Basis::Legendre,
+                       Spectral::Quadrature::GaussLobatto};
+  const auto logical_coords = logical_coordinates(mesh);
+  // Logical to inertial coords is a rotation by pi/2 so the directions are
+  // swapped
+  const auto map =
+      domain::make_coordinate_map<Frame::ElementLogical, Frame::Inertial>(
+          Affine2D{Affine{-1., 1., -1., 1.}, Affine{-1., 1., -1., 1.}},
+          domain::CoordinateMaps::DiscreteRotation(OrientationMap<Dim>{
+              {{Direction<Dim>::lower_eta(), Direction<Dim>::upper_xi()}}}));
+  auto jacobian = map.jacobian(logical_coords);
+
+  // Manufacture some test data
+  tnsr::ia<DataVector, Dim> test_data{mesh.number_of_grid_points()};
+  // X-component (logical eta direction) is small
+  get<0, 0>(test_data) = 1.e-6;
+  get<0, 1>(test_data) = 1.e-7;
+  get<0, 2>(test_data) = 1.e-8;
+  // Y-component (logical xi direction) is large
+  get<1, 0>(test_data) = 1.e-1;
+  get<1, 1>(test_data) = 1.e-2;
+  get<1, 2>(test_data) = 1.e-3;
+
+  Parallel::GlobalCache<Metavariables<Dim>> empty_cache{};
+  const auto databox =
+      db::create<tmpl::list<Events::Tags::ObserverJacobian<
+                                Dim, Frame::ElementLogical, Frame::Inertial>,
+                            TestVector<Dim>>>(std::move(jacobian),
+                                              std::move(test_data));
+  ObservationBox<
+      tmpl::list<>,
+      db::DataBox<tmpl::list<Events::Tags::ObserverJacobian<
+                                 Dim, Frame::ElementLogical, Frame::Inertial>,
+                             TestVector<Dim>>>>
+      box{databox};
+
+  const auto flags = criterion->evaluate(box, empty_cache, ElementId<Dim>{0});
+  CHECK(flags[0] == amr::Flag::IncreaseResolution);
+  CHECK(flags[1] == amr::Flag::DecreaseResolution);
+}
+
+}  // namespace amr::Criteria


### PR DESCRIPTION
## Proposed changes

Based on Sec. 6.1.4 in Szilagy 2014. This should work with the GH two-index and three-index constraints. When testing this in the wild we may want to add some h-refinement criterion based on constraints, and try to eliminate the coarsening factor.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
