### PR TITLE
Add UpdateAggregator

### DIFF
--- a/src/ControlSystem/Tags/SystemTags.hpp
+++ b/src/ControlSystem/Tags/SystemTags.hpp
@@ -8,13 +8,17 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <unordered_map>
 #include <utility>
 
 #include "ControlSystem/Averager.hpp"
+#include "ControlSystem/CombinedName.hpp"
 #include "ControlSystem/Controller.hpp"
+#include "ControlSystem/Metafunctions.hpp"
 #include "ControlSystem/Protocols/ControlSystem.hpp"
 #include "ControlSystem/Tags/OptionTags.hpp"
 #include "ControlSystem/TimescaleTuner.hpp"
+#include "ControlSystem/UpdateFunctionOfTime.hpp"
 #include "DataStructures/DataBox/Tag.hpp"
 #include "Domain/Creators/DomainCreator.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/Tags.hpp"
@@ -24,9 +28,12 @@
 #include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/StdHelpers.hpp"
 #include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
 #include "Utilities/TypeTraits/CreateHasStaticMemberVariable.hpp"
 
 /// \cond
+template <class Metavariables, typename ControlSystem>
+struct ControlComponent;
 namespace control_system {
 template <typename ControlSystem>
 struct OptionHolder;
@@ -204,5 +211,48 @@ struct Verbosity : db::SimpleTag {
   static type create_from_options(const ::Verbosity verbosity) {
     return verbosity;
   }
+};
+
+/*!
+ * \brief Tag meant to be stored in the GlobalCache that stores a map between
+ * names of control systems and the "combined" name that that control system is
+ * part of.
+ *
+ * \details The "combined" name for each control system is computed using
+ * `control_system::system_to_combined_names` where the list of control systems
+ * is taken from the `component_list` type alias of the metavariables. Each
+ * "combined" name corresponds to a different
+ * `control_system::protocols::Measurement`.
+ */
+struct SystemToCombinedNames : db::SimpleTag {
+  using type = std::unordered_map<std::string, std::string>;
+
+  template <typename Metavariables>
+  using option_tags = tmpl::list<>;
+  static constexpr bool pass_metavariables = true;
+
+ private:
+  template <typename Component>
+  using system = typename Component::control_system;
+
+ public:
+  template <typename Metavariables>
+  static type create_from_options() {
+    using all_control_components =
+        metafunctions::all_control_components<Metavariables>;
+    using all_control_systems =
+        tmpl::transform<all_control_components, tmpl::bind<system, tmpl::_1>>;
+
+    return system_to_combined_names<all_control_systems>();
+  }
+};
+
+/*!
+ * \brief Map between "combined" names and the
+ * `control_system::UpdateAggregator`s that go with each.
+ */
+struct UpdateAggregators : db::SimpleTag {
+  using type =
+      std::unordered_map<std::string, control_system::UpdateAggregator>;
 };
 }  // namespace control_system::Tags

--- a/src/ControlSystem/UpdateFunctionOfTime.cpp
+++ b/src/ControlSystem/UpdateFunctionOfTime.cpp
@@ -3,13 +3,19 @@
 
 #include "ControlSystem/UpdateFunctionOfTime.hpp"
 
+#include <limits>
 #include <memory>
+#include <pup.h>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <utility>
+#include <vector>
 
 #include "DataStructures/DataVector.hpp"
 #include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "Utilities/Algorithm.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
 
 namespace control_system {
 void UpdateSingleFunctionOfTime::apply(
@@ -43,5 +49,97 @@ void ResetFunctionOfTimeExpirationTime::apply(
         f_of_t_list,
     const std::string& f_of_t_name, const double new_expiration_time) {
   (*f_of_t_list).at(f_of_t_name)->reset_expiration_time(new_expiration_time);
+}
+
+UpdateAggregator::UpdateAggregator(
+    std::string combined_name,
+    std::unordered_set<std::string> active_control_system_names)
+    : active_names_(std::move(active_control_system_names)),
+      combined_name_(std::move(combined_name)) {}
+
+void UpdateAggregator::insert(const std::string& control_system_name,
+                              const DataVector& new_measurement_timescale,
+                              const double new_measurement_expiration_time,
+                              DataVector control_signal,
+                              const double new_fot_expiration_time) {
+  ASSERT(expiration_times_.count(control_system_name) == 0,
+         "Already received expiration time data for control system '"
+             << control_system_name << "'.");
+  ASSERT(active_names_.count(control_system_name) == 1,
+         "Received expiration time data for a non-active control system '"
+             << control_system_name << "'. Active control systems are "
+             << active_names_);
+
+  expiration_times_[control_system_name] = std::make_pair(
+      std::make_pair(std::move(control_signal), new_fot_expiration_time),
+      std::make_pair(min(new_measurement_timescale),
+                     new_measurement_expiration_time));
+}
+
+bool UpdateAggregator::is_ready() const {
+  // Short circuit if one name isn't ready
+  for (const std::string& control_system_name : active_names_) {
+    if (expiration_times_.count(control_system_name) != 1) {
+      return false;
+    }
+  }
+  return true;
+}
+
+const std::string& UpdateAggregator::combined_name() const {
+  return combined_name_;
+}
+
+std::unordered_map<std::string, std::pair<DataVector, double>>
+UpdateAggregator::combined_fot_expiration_times() const {
+  ASSERT(is_ready(),
+         "Trying to get combined expiration times, but have not received "
+         "data from all control systems.");
+
+  std::unordered_map<std::string, std::pair<DataVector, double>> result{};
+
+  double min_expiration_time = std::numeric_limits<double>::infinity();
+  for (const auto& control_system_name : active_names_) {
+    min_expiration_time =
+        std::min(min_expiration_time,
+                 expiration_times_.at(control_system_name).first.second);
+  }
+
+  for (const auto& control_system_name : active_names_) {
+    result[control_system_name] =
+        expiration_times_.at(control_system_name).first;
+    result[control_system_name].second = min_expiration_time;
+  }
+
+  return result;
+}
+
+std::pair<double, double>
+UpdateAggregator::combined_measurement_expiration_time() {
+  ASSERT(is_ready(),
+         "Trying to get combined expiration times, but have not received "
+         "data from all control systems.");
+
+  double min_measurement_timescale = std::numeric_limits<double>::infinity();
+  double min_expiration_time = std::numeric_limits<double>::infinity();
+
+  for (const auto& control_system_name : active_names_) {
+    min_measurement_timescale =
+        std::min(min_measurement_timescale,
+                 expiration_times_[control_system_name].second.first);
+    min_expiration_time =
+        std::min(min_expiration_time,
+                 expiration_times_[control_system_name].second.second);
+  }
+
+  expiration_times_.clear();
+
+  return std::make_pair(min_measurement_timescale, min_expiration_time);
+}
+
+void UpdateAggregator::pup(PUP::er& p) {
+  p | expiration_times_;
+  p | active_names_;
+  p | combined_name_;
 }
 }  // namespace control_system

--- a/src/ControlSystem/UpdateFunctionOfTime.hpp
+++ b/src/ControlSystem/UpdateFunctionOfTime.hpp
@@ -4,12 +4,30 @@
 #pragma once
 
 #include <memory>
+#include <pup.h>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <utility>
 
+#include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataVector.hpp"
 #include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+/// \cond
+namespace domain::Tags {
+struct FunctionsOfTime;
+}  // namespace domain::Tags
+namespace control_system::Tags {
+struct UpdateAggregators;
+struct SystemToCombinedNames;
+struct MeasurementTimescales;
+}  // namespace control_system::Tags
+/// \endcond
 
 namespace control_system {
 /// \ingroup ControlSystemGroup
@@ -57,5 +75,171 @@ struct ResetFunctionOfTimeExpirationTime {
           std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>*>
           f_of_t_list,
       const std::string& f_of_t_name, double new_expiration_time);
+};
+
+/*!
+ * \brief A class for collecting and storing information related to updating
+ * functions of time and measurement timescales.
+ *
+ * \details This class also determines if enough data has been received in order
+ * for the functions of time and measurement timescales to be updated. There
+ * should be one `UpdateAggregator` for every group of control systems that have
+ * the same `control_system::protocols::Measurement`.
+ */
+struct UpdateAggregator {
+  UpdateAggregator() = default;
+
+  /*!
+   * \brief Construct a new UpdateAggregator using a set of active control
+   * system names and the combined name for the measurement.
+   *
+   * It is expected that all the control systems in this set use the same
+   * `control_system::protocols::Measurement`.
+   */
+  UpdateAggregator(std::string combined_name,
+                   std::unordered_set<std::string> active_control_system_names);
+
+  /*!
+   * \brief Inserts and stores information for one of the control systems that
+   * this class was constructed with.
+   *
+   * \param control_system_name Name of control system to add information for
+   * \param new_measurement_timescale DataVector of new measurement timescales
+   * calculated from a control system update.
+   * \param new_measurement_expiration_time New measurement expiration time
+   * calculated during that update.
+   * \param control_signal New highest derivative for the function of time
+   * calculated during that update (will be `std::move`ed).
+   * \param new_fot_expiration_time New function of time expiration time
+   * calculated for during that update
+   */
+  void insert(const std::string& control_system_name,
+              const DataVector& new_measurement_timescale,
+              double new_measurement_expiration_time, DataVector control_signal,
+              double new_fot_expiration_time);
+
+  /*!
+   * \brief Checks if `insert` has been called for all control systems that this
+   * class was constructed with.
+   */
+  bool is_ready() const;
+
+  /*!
+   * \brief Returns a sorted concatenation of the control system names this
+   * class was constructed with.
+   */
+  const std::string& combined_name() const;
+
+  /*!
+   * \brief Once `is_ready` is true, returns a map between the control system
+   * name and a `std::pair` containing the `control_signal` that was passed to
+   * `insert` and the minimum of all the `new_fot_expiration_time`s passed to
+   * `insert`.
+   *
+   * \details This function is expected to only be called when `is_ready` is
+   * true. It also must be called before `combined_measurement_expiration_time`.
+   */
+  std::unordered_map<std::string, std::pair<DataVector, double>>
+  combined_fot_expiration_times() const;
+
+  /*!
+   * \brief Once `is_ready` is true, returns a `std::pair` containing the
+   * minimum of all `new_measurement_timescale`s passed to `insert` and the
+   * minimum of all `new_measurement_expiration_time`s passed to `insert`.
+   *
+   * \details This function is expected to be called only when `is_ready` is
+   * true and only a single time once all control active control
+   * systems for this measurement have computed their update values. It also
+   * must be called after `combined_fot_expiration_times`. This function clears
+   * all stored data when it is called.
+   */
+  std::pair<double, double> combined_measurement_expiration_time();
+
+  /// \cond
+  void pup(PUP::er& p);
+  /// \endcond
+
+ private:
+  std::unordered_map<std::string, std::pair<std::pair<DataVector, double>,
+                                            std::pair<double, double>>>
+      expiration_times_{};
+  std::unordered_set<std::string> active_names_{};
+  std::string combined_name_{};
+};
+
+/*!
+ * \brief Simple action that updates the appropriate `UpdateAggregator` for the
+ * templated `ControlSystem`.
+ *
+ * \details The `new_measurement_timescale`, `new_measurement_expiration_time`,
+ * `control_signal`, and `new_fot_expiration_time` are passed along to the
+ * `UpdateAggregator::insert` function. The `old_measurement_expiration_time`
+ * and `old_fot_expiration_time` are only used when the
+ * `UpdateAggregator::is_ready` in order to update the functions of time and the
+ * measurement timescale.
+ *
+ * When the `UpdateAggregator::is_ready`, the measurement timescale is mutated
+ * with `UpdateSingleFunctionOfTime` and the functions of time are mutated with
+ * `UpdateMultipleFunctionsOfTime`, both using `Parallel::mutate`.
+ *
+ * The "appropriate" `UpdateAggregator` is chosen from the
+ * `control_system::Tags::SystemToCombinedNames` for the templated
+ * `ControlSystem`.
+ */
+template <typename ControlSystem>
+struct AggregateUpdate {
+  template <typename ParallelComponent, typename DbTags, typename Metavariables,
+            typename ArrayIndex>
+  static void apply(db::DataBox<DbTags>& box,
+                    Parallel::GlobalCache<Metavariables>& cache,
+                    const ArrayIndex& /*array_index*/,
+                    const DataVector& new_measurement_timescale,
+                    const double old_measurement_expiration_time,
+                    const double new_measurement_expiration_time,
+                    DataVector control_signal,
+                    const double old_fot_expiration_time,
+                    const double new_fot_expiration_time) {
+    auto& aggregators =
+        db::get_mutable_reference<Tags::UpdateAggregators>(make_not_null(&box));
+    const auto& system_to_combined_names =
+        Parallel::get<Tags::SystemToCombinedNames>(cache);
+    const std::string& control_system_name = ControlSystem::name();
+    ASSERT(system_to_combined_names.count(control_system_name) == 1,
+           "Expected name '" << control_system_name
+                             << "' to be in map of system-to-combined names, "
+                                "but it wasn't. Keys are: "
+                             << keys_of(system_to_combined_names));
+    const std::string& combined_name =
+        system_to_combined_names.at(control_system_name);
+    ASSERT(aggregators.count(combined_name) == 1,
+           "Expected combined name '" << combined_name
+                                      << "' to be in map of aggregators, "
+                                         "but it wasn't. Keys are: "
+                                      << keys_of(aggregators));
+
+    UpdateAggregator& aggregator = aggregators.at(combined_name);
+
+    aggregator.insert(control_system_name, new_measurement_timescale,
+                      new_measurement_expiration_time,
+                      std::move(control_signal), new_fot_expiration_time);
+
+    if (aggregator.is_ready()) {
+      std::unordered_map<std::string, std::pair<DataVector, double>>
+          combined_fot_expiration_times =
+              aggregator.combined_fot_expiration_times();
+      const std::pair<double, double> combined_measurement_expiration_time =
+          aggregator.combined_measurement_expiration_time();
+
+      Parallel::mutate<Tags::MeasurementTimescales, UpdateSingleFunctionOfTime>(
+          cache, combined_name, old_measurement_expiration_time,
+          DataVector{1, combined_measurement_expiration_time.first},
+          combined_measurement_expiration_time.second);
+
+      Parallel::mutate<::domain::Tags::FunctionsOfTime,
+                       UpdateMultipleFunctionsOfTime>(
+          cache, old_fot_expiration_time,
+          std::move(combined_fot_expiration_times));
+    }
+  }
 };
 }  // namespace control_system

--- a/tests/Unit/ControlSystem/Test_UpdateFunctionOfTime.cpp
+++ b/tests/Unit/ControlSystem/Test_UpdateFunctionOfTime.cpp
@@ -8,7 +8,10 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 
+#include "ControlSystem/Tags/MeasurementTimescales.hpp"
+#include "ControlSystem/Tags/SystemTags.hpp"
 #include "ControlSystem/UpdateFunctionOfTime.hpp"
 #include "DataStructures/DataVector.hpp"
 #include "Domain/Creators/Tags/FunctionsOfTime.hpp"
@@ -21,28 +24,46 @@
 #include "Framework/ActionTesting.hpp"
 #include "Parallel/Phase.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
+#include "Utilities/CloneUniquePtrs.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
 
 namespace {
-template <typename Metavariables>
+struct System1 {
+  static std::string name() { return "FoT1"; }
+};
+struct System2 {
+  static std::string name() { return "FoT2"; }
+};
+struct System3 {
+  static std::string name() { return "FoT3"; }
+};
+
+template <typename Metavariables, size_t Index = 1>
 struct TestSingleton {
+  static std::string name() { return "FoT" + get_output(Index); }
   using chare_type = ActionTesting::MockSingletonChare;
   using array_index = size_t;
   using metavariables = Metavariables;
-  using get_const_global_cache_tags = tmpl::list<>;
+  using const_global_cache_tags = tmpl::list<>;
   using mutable_global_cache_tags =
-      tmpl::list<domain::Tags::FunctionsOfTimeInitialize>;
-  using phase_dependent_action_list = tmpl::list<
-      Parallel::PhaseActions<Parallel::Phase::Initialization, tmpl::list<>>>;
+      tmpl::list<domain::Tags::FunctionsOfTimeInitialize,
+                 control_system::Tags::MeasurementTimescales,
+                 // Usually this is constant, but we have it mutable for this
+                 // test because we need to change its value to test some
+                 // ASSERTs
+                 control_system::Tags::SystemToCombinedNames>;
+  using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
+      Parallel::Phase::Initialization,
+      tmpl::list<ActionTesting::InitializeDataBox<
+          tmpl::list<control_system::Tags::UpdateAggregators>>>>>;
 };
 
 struct TestingMetavariables {
   using component_list = tmpl::list<TestSingleton<TestingMetavariables>>;
 };
 
-SPECTRE_TEST_CASE("Unit.ControlSystem.UpdateFunctionOfTime",
-                  "[Unit][ControlSystem]") {
+void test_mutates() {
   constexpr size_t deriv_order = 2;
   const double t0 = 0.0;
   const double expr_time = 1.0;
@@ -64,6 +85,9 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.UpdateFunctionOfTime",
 
   std::unordered_map<std::string,
                      std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
+      measurement_timescales{};
+  std::unordered_map<std::string,
+                     std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
       f_of_t_map{};
   f_of_t_map[pp_name] = std::make_unique<
       domain::FunctionsOfTime::PiecewisePolynomial<deriv_order>>(
@@ -76,11 +100,13 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.UpdateFunctionOfTime",
 
   // Construct mock system and set to Testing phase
   ActionTesting::MockRuntimeSystem<TestingMetavariables> runsys{
-      {}, {std::move(f_of_t_map)}};
-  ActionTesting::emplace_singleton_component<
+      {},
+      {std::move(f_of_t_map), std::move(measurement_timescales),
+       std::unordered_map<std::string, std::string>{}}};
+  ActionTesting::emplace_singleton_component_and_initialize<
       TestSingleton<TestingMetavariables>>(make_not_null(&runsys),
                                            ActionTesting::NodeId{0},
-                                           ActionTesting::LocalCoreId{0});
+                                           ActionTesting::LocalCoreId{0}, {});
   ActionTesting::set_phase(make_not_null(&runsys), Parallel::Phase::Testing);
 
   // Update functions of time in global cache with new deriv
@@ -162,5 +188,346 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.UpdateFunctionOfTime",
     CHECK(cache_pp == expected_pp);
     CHECK(cache_quatfot == expected_quatfot);
   }
+}
+
+void test_update_aggregator() {
+  // Notice the combined name has an extra state that isn't active
+  const std::string combined_name{
+      "AlaskaCaliforniaFloridaIllinoisTexasWisconsin"};
+  std::unordered_set<std::string> names{"Illinois", "California", "Wisconsin",
+                                        "Florida", "Texas"};
+  std::unordered_map<std::string, DataVector> signals{};
+  signals["Wisconsin"] = DataVector{5.0};
+  signals["Texas"] = DataVector{4.0};
+  signals["Illinois"] = DataVector{3.0};
+  signals["Florida"] = DataVector{2.0};
+  signals["California"] = DataVector{1.0};
+
+  control_system::UpdateAggregator unserialized_aggregator{combined_name,
+                                                           names};
+  control_system::UpdateAggregator aggregator =
+      serialize_and_deserialize(unserialized_aggregator);
+
+  CHECK(aggregator.combined_name() == combined_name);
+
+  aggregator.insert("Wisconsin", DataVector{1.0}, 10.0, signals.at("Wisconsin"),
+                    5.0);
+  CHECK_FALSE(aggregator.is_ready());
+  aggregator.insert("Texas", DataVector{2.0}, 9.0, signals.at("Texas"), 4.0);
+  CHECK_FALSE(aggregator.is_ready());
+  aggregator.insert("Illinois", DataVector{3.0}, 8.0, signals.at("Illinois"),
+                    3.0);
+  CHECK_FALSE(aggregator.is_ready());
+  aggregator.insert("Florida", DataVector{4.0}, 7.0, signals.at("Florida"),
+                    2.0);
+  CHECK_FALSE(aggregator.is_ready());
+#ifdef SPECTRE_DEBUG
+  CHECK_THROWS_WITH(
+      aggregator.insert("Florida", DataVector{}, 1.0, DataVector{}, 1.0),
+      Catch::Matchers::ContainsSubstring("Already received expiration time "
+                                         "data for control system 'Florida'"));
+  CHECK_THROWS_WITH(
+      aggregator.insert("Alaska", DataVector{}, 1.0, DataVector{}, 1.0),
+      Catch::Matchers::ContainsSubstring("Received expiration time data for a "
+                                         "non-active control system 'Alaska'"));
+#endif
+  aggregator.insert("California", DataVector{5.0}, 6.0,
+                    signals.at("California"), 1.0);
+  CHECK(aggregator.is_ready());
+
+  const std::unordered_map<std::string, std::pair<DataVector, double>>
+      combined_fot = aggregator.combined_fot_expiration_times();
+  CHECK(aggregator.is_ready());
+  const std::pair<double, double> combined_measurements =
+      aggregator.combined_measurement_expiration_time();
+  CHECK_FALSE(aggregator.is_ready());
+
+  CHECK(combined_fot.size() == names.size());
+  for (const auto& name : names) {
+    CAPTURE(name);
+    CHECK(combined_fot.count(name) == 1);
+    CHECK(combined_fot.at(name) == std::make_pair(signals[name], 1.0));
+  }
+
+  CHECK(combined_measurements == std::make_pair(1.0, 6.0));
+}
+
+struct AggregatorMetavariables {
+  using metavariables = AggregatorMetavariables;
+  using component_list = tmpl::list<TestSingleton<metavariables, 1>,
+                                    TestSingleton<metavariables, 2>,
+                                    TestSingleton<metavariables, 3>>;
+};
+
+struct SetSystemToCombinedNames {
+  static void apply(
+      const gsl::not_null<std::unordered_map<std::string, std::string>*>
+          cache_system_to_combined_names,
+      const std::unordered_map<std::string, std::string>&
+          new_system_to_combined_names) {
+    *cache_system_to_combined_names = new_system_to_combined_names;
+  }
+};
+
+void test_aggregate_update_action() {
+  domain::FunctionsOfTime::register_derived_with_charm();
+  using metavars = AggregatorMetavariables;
+  using component1 = TestSingleton<metavars, 1>;
+  using component2 = TestSingleton<metavars, 2>;
+  using component3 = TestSingleton<metavars, 3>;
+  const double t0 = 0.0;
+  const double old_fot_expiration13 = 4.0;
+  const double old_fot_expiration2 = 2.0;
+  const double old_measurement_expiration13 = old_fot_expiration13 - 0.5;
+  const double old_measurement_expiration2 = old_fot_expiration2 - 0.5;
+
+  std::unordered_map<std::string,
+                     std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
+      f_of_t_map{};
+  std::unordered_map<std::string,
+                     std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
+      measurement_map{};
+
+  // We must set up the functions of time and measurement timescales in a
+  // consistent state. Here FoT1 and FoT3 use the same measurement timescale,
+  // and this have the same expiration time. FoT2 uses a different measurement
+  // timescale so it has it's own expiration
+  f_of_t_map["FoT1"] =
+      std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<0>>(
+          t0, std::array{DataVector{1.0}}, old_fot_expiration13);
+  f_of_t_map["FoT2"] =
+      std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<0>>(
+          t0, std::array{DataVector{1.0}}, old_fot_expiration2);
+  f_of_t_map["FoT3"] =
+      std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<0>>(
+          t0, std::array{DataVector{1.0}}, old_fot_expiration13);
+
+  measurement_map["FoT1FoT3"] =
+      std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<0>>(
+          t0, std::array{DataVector{4.0}}, old_measurement_expiration13);
+  measurement_map["FoT2"] =
+      std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<0>>(
+          t0, std::array{DataVector{2.0}}, old_measurement_expiration2);
+
+  std::unordered_map<std::string,
+                     std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
+      expected_f_of_t_map = clone_unique_ptrs(f_of_t_map);
+  std::unordered_map<std::string,
+                     std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
+      expected_measurement_map = clone_unique_ptrs(measurement_map);
+
+  control_system::UpdateAggregator aggregator13{"FoT1FoT3", {"FoT1", "FoT3"}};
+  control_system::UpdateAggregator aggregator2{"FoT2", {"FoT2"}};
+  std::unordered_map<std::string, control_system::UpdateAggregator>
+      aggregators{};
+  aggregators["FoT1FoT3"] = aggregator13;
+  aggregators["FoT2"] = aggregator2;
+  auto aggregators_copy = aggregators;
+
+  std::unordered_map<std::string, std::string> system_to_combined_names{};
+  system_to_combined_names["FoT1"] = "FoT1FoT3";
+  system_to_combined_names["FoT2"] = "FoT2";
+  system_to_combined_names["FoT3"] = "FoT1FoT3";
+  auto system_to_combined_names_copy = system_to_combined_names;
+
+  ActionTesting::MockRuntimeSystem<metavars> runner{
+      {},
+      {std::move(f_of_t_map), std::move(measurement_map),
+       std::move(system_to_combined_names_copy)}};
+  ActionTesting::emplace_singleton_component_and_initialize<component1>(
+      make_not_null(&runner), ActionTesting::NodeId{0},
+      ActionTesting::LocalCoreId{0}, {std::move(aggregators_copy)});
+  ActionTesting::emplace_singleton_component_and_initialize<component2>(
+      make_not_null(&runner), ActionTesting::NodeId{0},
+      ActionTesting::LocalCoreId{0}, {});
+  ActionTesting::emplace_singleton_component_and_initialize<component3>(
+      make_not_null(&runner), ActionTesting::NodeId{0},
+      ActionTesting::LocalCoreId{0}, {});
+  ActionTesting::set_phase(make_not_null(&runner), Parallel::Phase::Testing);
+
+  auto& cache = ActionTesting::cache<component1>(runner, 0_st);
+  const auto& functions_of_time =
+      Parallel::get<domain::Tags::FunctionsOfTime>(cache);
+  const auto& measurement_timescales =
+      Parallel::get<control_system::Tags::MeasurementTimescales>(cache);
+
+  using tag = control_system::Tags::UpdateAggregators;
+  const std::unordered_map<std::string, control_system::UpdateAggregator>&
+      box_aggregators_component1 =
+          ActionTesting::get_databox_tag<component1, tag>(runner, 0);
+  const std::unordered_map<std::string, control_system::UpdateAggregator>&
+      box_aggregators_component2 =
+          ActionTesting::get_databox_tag<component2, tag>(runner, 0);
+  const std::unordered_map<std::string, control_system::UpdateAggregator>&
+      box_aggregators_component3 =
+          ActionTesting::get_databox_tag<component3, tag>(runner, 0);
+
+  CHECK_FALSE(box_aggregators_component1.empty());
+  CHECK(box_aggregators_component2.empty());
+  CHECK(box_aggregators_component3.empty());
+
+  const DataVector new_measurement_timescale1{2.0};
+  const DataVector new_measurement_timescale2{3.0};
+  const DataVector new_measurement_timescale3{4.0};
+  const DataVector new_measurement_timescale13{
+      std::min(new_measurement_timescale1[0], new_measurement_timescale3[0])};
+  const double new_fot_expiration1 = old_fot_expiration13 + 2.0;
+  const double new_fot_expiration2 = old_fot_expiration2 + 1.0;
+  const double new_fot_expiration3 = old_fot_expiration13 + 1.5;
+  const double new_fot_expiration13 =
+      std::min(new_fot_expiration1, new_fot_expiration3);
+  const DataVector control_signal{1.0};
+  const double new_measurement_expiration1 = new_fot_expiration1 - 0.5;
+  const double new_measurement_expiration2 = new_fot_expiration2 - 0.5;
+  const double new_measurement_expiration3 = new_fot_expiration3 - 0.5;
+  const double new_measurement_expiration13 =
+      std::min(new_measurement_expiration1, new_measurement_expiration3);
+
+#ifdef SPECTRE_DEBUG
+  {
+    auto& box =
+        ActionTesting::get_databox<component1>(make_not_null(&runner), 0);
+
+    // Set these to empty so we can trigger an ASSERT
+    Parallel::mutate<control_system::Tags::SystemToCombinedNames,
+                     SetSystemToCombinedNames>(
+        cache, std::unordered_map<std::string, std::string>{});
+
+    CHECK_THROWS_WITH(
+        (ActionTesting::simple_action<component1,
+                                      control_system::AggregateUpdate<System1>>(
+            make_not_null(&runner), 0_st, new_measurement_timescale1,
+            old_measurement_expiration13, new_measurement_expiration1,
+            control_signal, old_fot_expiration13, new_fot_expiration1)),
+        Catch::Matchers::ContainsSubstring(
+            "Expected name 'FoT1' to be in map of system-to-combined names, "
+            "but it wasn't."));
+
+    // Set these back
+    Parallel::mutate<control_system::Tags::SystemToCombinedNames,
+                     SetSystemToCombinedNames>(cache, system_to_combined_names);
+
+    // Now set the update aggregators to be empty to hit a different ASSERT
+    db::mutate<tag>(
+        [](const auto local_aggregators) { local_aggregators->clear(); },
+        make_not_null(&box));
+
+    CHECK_THROWS_WITH(
+        (ActionTesting::simple_action<component1,
+                                      control_system::AggregateUpdate<System1>>(
+            make_not_null(&runner), 0_st, new_measurement_timescale1,
+            old_measurement_expiration13, new_measurement_expiration1,
+            control_signal, old_fot_expiration13, new_fot_expiration1)),
+        Catch::Matchers::ContainsSubstring(
+            "Expected combined name 'FoT1FoT3' to be in map of aggregators, "
+            "but it wasn't."));
+
+    // Set them back so we can do the rest of the test
+    db::mutate<tag>(
+        [&aggregators](const auto local_aggregators) {
+          *local_aggregators = aggregators;
+        },
+        make_not_null(&box));
+  }
+#endif
+
+  // Note that we have to get these references *after* we do the clear() and
+  // re-assignment above in the debug build checks otherwise we get a dangling
+  // reference.
+  const control_system::UpdateAggregator& box_aggregator13 =
+      box_aggregators_component1.at("FoT1FoT3");
+  const control_system::UpdateAggregator& box_aggregator2 =
+      box_aggregators_component1.at("FoT2");
+
+  // The aggregators will never "be ready" to use because when they actually are
+  // ready, they are reset immediately during the simple action
+  CHECK_FALSE(box_aggregator13.is_ready());
+  CHECK_FALSE(box_aggregator2.is_ready());
+  CHECK(box_aggregators_component2.empty());
+  CHECK(box_aggregators_component3.empty());
+
+  // Update one of the two functions of time for the 13 measurement
+  ActionTesting::simple_action<component1,
+                               control_system::AggregateUpdate<System1>>(
+      make_not_null(&runner), 0_st, new_measurement_timescale1,
+      old_measurement_expiration13, new_measurement_expiration1, control_signal,
+      old_fot_expiration13, new_fot_expiration1);
+
+  CHECK_FALSE(box_aggregator13.is_ready());
+  CHECK_FALSE(box_aggregator2.is_ready());
+  CHECK(box_aggregators_component2.empty());
+  CHECK(box_aggregators_component3.empty());
+
+  // Update the 2 measurement and check that the function of time and
+  // measurement timescale have been updated appropriately
+  ActionTesting::simple_action<component1,
+                               control_system::AggregateUpdate<System2>>(
+      make_not_null(&runner), 0_st, new_measurement_timescale2,
+      old_measurement_expiration2, new_measurement_expiration2, control_signal,
+      old_fot_expiration2, new_fot_expiration2);
+
+  CHECK_FALSE(box_aggregator13.is_ready());
+  CHECK_FALSE(box_aggregator2.is_ready());
+  CHECK(box_aggregators_component2.empty());
+  CHECK(box_aggregators_component3.empty());
+
+  expected_f_of_t_map["FoT2"]->update(old_fot_expiration2, control_signal,
+                                      new_fot_expiration2);
+  expected_measurement_map["FoT2"]->update(old_measurement_expiration2,
+                                           new_measurement_timescale2,
+                                           new_measurement_expiration2);
+
+  const auto check_equal =
+      [](const std::string& name,
+         const std::unordered_map<
+             std::string,
+             std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>& test,
+         const std::unordered_map<
+             std::string,
+             std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+             expected) {
+        CAPTURE(name);
+        CHECK(dynamic_cast<
+                  const domain::FunctionsOfTime::PiecewisePolynomial<0>&>(
+                  *test.at(name)) ==
+              dynamic_cast<
+                  const domain::FunctionsOfTime::PiecewisePolynomial<0>&>(
+                  *expected.at(name)));
+      };
+
+  check_equal("FoT2", functions_of_time, expected_f_of_t_map);
+  check_equal("FoT2", measurement_timescales, expected_measurement_map);
+
+  // Update the second of the 13 measurement which should update both functions
+  // of time and just the one measurement timescale
+  ActionTesting::simple_action<component1,
+                               control_system::AggregateUpdate<System3>>(
+      make_not_null(&runner), 0_st, new_measurement_timescale3,
+      old_measurement_expiration13, new_measurement_expiration3, control_signal,
+      old_fot_expiration13, new_fot_expiration3);
+
+  CHECK_FALSE(box_aggregator13.is_ready());
+  CHECK_FALSE(box_aggregator2.is_ready());
+  CHECK(box_aggregators_component2.empty());
+  CHECK(box_aggregators_component3.empty());
+
+  expected_f_of_t_map["FoT1"]->update(old_fot_expiration13, control_signal,
+                                      new_fot_expiration13);
+  expected_f_of_t_map["FoT3"]->update(old_fot_expiration13, control_signal,
+                                      new_fot_expiration13);
+  expected_measurement_map["FoT1FoT3"]->update(old_measurement_expiration13,
+                                               new_measurement_timescale13,
+                                               new_measurement_expiration13);
+
+  check_equal("FoT1", functions_of_time, expected_f_of_t_map);
+  check_equal("FoT3", functions_of_time, expected_f_of_t_map);
+  check_equal("FoT1FoT3", measurement_timescales, expected_measurement_map);
+}
+
+SPECTRE_TEST_CASE("Unit.ControlSystem.UpdateFunctionOfTime",
+                  "[Unit][ControlSystem]") {
+  test_mutates();
+  test_update_aggregator();
+  test_aggregate_update_action();
 }
 }  // namespace


### PR DESCRIPTION
## Proposed changes

Adds a class and action for aggregating/collecting all function of time updates before actually calling `Parallel::mutate`.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

~Depends on and includes #5376.~

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
