### PR TITLE
Add GitHub workflow to build Docker containers

### DIFF
--- a/.github/workflows/BuildDockerContainer.yaml
+++ b/.github/workflows/BuildDockerContainer.yaml
@@ -62,3 +62,11 @@ jobs:
           target: ci
           tags: ${{ inputs.image_name }}:ci
           platforms: linux/amd64 #,linux/arm64
+
+  run_tests:
+    name: Test
+    uses: ./.github/workflows/Tests.yaml
+    needs: build_container
+    secrets: inherit
+    with:
+      container: ${{ inputs.image_name }}:ci

--- a/.github/workflows/BuildDockerContainer.yaml
+++ b/.github/workflows/BuildDockerContainer.yaml
@@ -1,0 +1,64 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+# This workflow can be run manually on any branch to build and push our Docker
+# containers.
+name: Build Docker container
+
+on:
+  workflow_dispatch:
+    inputs:
+      image_name:
+        description: >
+          Image name to push to DockerHub
+        required: true
+        default: 'sxscollaboration/spectre'
+
+jobs:
+  build_container:
+    name: Build and deploy
+    runs-on: ubuntu-latest
+    # This environment can be protected to require manual approval before
+    # deployment. On forks where you set your own secrets for authentication
+    # with DockerHub you can choose not to protect this environment.
+    environment: deploy-containers
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      # Needed once we do multi-platform builds
+      # - name: Set up emulation support
+      #   uses: docker/setup-qemu-action@v2
+      #   with:
+      #     platforms: arm64
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      # We could also push containers to GitHub instead of DockerHub
+      # - name: Login to GitHub container registry
+      #   uses: docker/login-action@v2
+      #   with:
+      #     registry: ghcr.io
+      #     username: ${{ github.actor }}
+      #     password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build dev container
+        uses: docker/build-push-action@v4
+        with:
+          push: true
+          context: .
+          file: "./containers/Dockerfile.buildenv"
+          target: dev
+          tags: ${{ inputs.image_name }}:dev
+          platforms: linux/amd64 #,linux/arm64
+      - name: Build CI container
+        uses: docker/build-push-action@v4
+        with:
+          push: true
+          context: .
+          file: "./containers/Dockerfile.buildenv"
+          target: ci
+          tags: ${{ inputs.image_name }}:ci
+          platforms: linux/amd64 #,linux/arm64

--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -50,7 +50,21 @@ on:
           Enter 'yes' without quotes to clear ccache before running
         required: false
         default: ''
-
+      container:
+        description: >
+          Container to use for builds
+        required: false
+        default: 'sxscollaboration/spectre:ci'
+  # Allow running this workflow as a job in another workflow. This is used to
+  # test a new Docker container before publishing it.
+  workflow_call:
+    inputs:
+      container:
+        description: >
+          Container to use for builds
+        required: false
+        type: string
+        default: 'sxscollaboration/spectre:ci'
 
 # Cancel all other queued or in-progress runs of this workflow when it is
 # scheduled, so repeated pushes to a branch or a PR don't block CI. Repeated
@@ -99,7 +113,7 @@ jobs:
     name: Files and formatting
     runs-on: ubuntu-latest
     container:
-      image: sxscollaboration/spectre:ci
+      image: ${{ inputs.container || 'sxscollaboration/spectre:ci' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -194,7 +208,7 @@ jobs:
       || github.ref != 'refs/heads/develop'
     runs-on: ubuntu-latest
     container:
-      image: sxscollaboration/spectre:ci
+      image: ${{ inputs.container || 'sxscollaboration/spectre:ci' }}
     strategy:
       matrix:
         build_type: [Debug, Release]
@@ -254,7 +268,7 @@ jobs:
     needs: check_files_and_formatting
     runs-on: ubuntu-latest
     container:
-      image: sxscollaboration/spectre:ci
+      image: ${{ inputs.container || 'sxscollaboration/spectre:ci' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -408,7 +422,7 @@ jobs:
             TEST_TIMEOUT_FACTOR: 3
 
     container:
-      image: sxscollaboration/spectre:ci
+      image: ${{ inputs.container || 'sxscollaboration/spectre:ci' }}
       env:
         # We run unit tests with the following compiler flags:
         # - `-Werror`: Treat warnings as error.
@@ -1042,7 +1056,7 @@ ${{ matrix.build_type }}-pch-${{ matrix.use_pch || 'ON' }}"
               "-skl;skylake" "-icx;icelake-server" "-tgl;tigerlake")
             compiler: clang-13
     container:
-      image: sxscollaboration/spectre:ci
+      image: ${{ inputs.container || 'sxscollaboration/spectre:ci' }}
       env:
         # See the unit test job for the reasons for these configuration choices
         CXXFLAGS: "-Werror"


### PR DESCRIPTION
## Proposed changes

@geoffrey4444 once #5373 works we can add ARM to the list of platforms here to automatically build and push both architectures to DockerHub.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
