### PR TITLE
Add compute tags for computing and observing force-free constraint violations

### DIFF
--- a/src/Evolution/Executables/ForceFree/EvolveForceFree.hpp
+++ b/src/Evolution/Executables/ForceFree/EvolveForceFree.hpp
@@ -40,6 +40,7 @@
 #include "Evolution/Systems/ForceFree/BoundaryCorrections/RegisterDerived.hpp"
 #include "Evolution/Systems/ForceFree/ElectricCurrentDensity.hpp"
 #include "Evolution/Systems/ForceFree/ElectromagneticVariables.hpp"
+#include "Evolution/Systems/ForceFree/ForceFreeConstraints.hpp"
 #include "Evolution/Systems/ForceFree/System.hpp"
 #include "Evolution/Systems/ForceFree/Tags.hpp"
 #include "IO/Observer/Actions/RegisterEvents.hpp"
@@ -133,7 +134,9 @@ struct EvolutionMetavars {
       ForceFree::Tags::ElectricFieldCompute,
       ForceFree::Tags::MagneticFieldCompute,
       ForceFree::Tags::ChargeDensityCompute,
-      ForceFree::Tags::ElectricCurrentDensityCompute>;
+      ForceFree::Tags::ElectricCurrentDensityCompute,
+      ForceFree::Tags::ElectricFieldDotMagneticFieldCompute,
+      ForceFree::Tags::MagneticDominanceViolationCompute>;
 
   using non_tensor_compute_tags =
       tmpl::list<::Events::Tags::ObserverMeshCompute<volume_dim>,
@@ -219,7 +222,10 @@ struct EvolutionMetavars {
           domain::Tags::Coordinates<3, Frame::ElementLogical>>,
 
       Initialization::Actions::AddComputeTags<
-          tmpl::list<ForceFree::Tags::ComputeTildeJ>>,
+          tmpl::list<ForceFree::Tags::TildeESquaredCompute,
+                     ForceFree::Tags::TildeBSquaredCompute,
+                     ForceFree::Tags::TildeEDotTildeBCompute,
+                     ForceFree::Tags::ComputeTildeJ>>,
 
       Initialization::Actions::AddComputeTags<
           StepChoosers::step_chooser_compute_tags<EvolutionMetavars,

--- a/src/Evolution/Systems/ForceFree/CMakeLists.txt
+++ b/src/Evolution/Systems/ForceFree/CMakeLists.txt
@@ -12,6 +12,7 @@ spectre_target_sources(
   ElectricCurrentDensity.cpp
   ElectromagneticVariables.cpp
   Fluxes.cpp
+  ForceFreeConstraints.cpp
   Sources.cpp
   TimeDerivativeTerms.cpp
   VolumeTermsInstantiation.cpp
@@ -25,6 +26,7 @@ spectre_target_headers(
   ElectricCurrentDensity.hpp
   ElectromagneticVariables.hpp
   Fluxes.hpp
+  ForceFreeConstraints.hpp
   Sources.hpp
   System.hpp
   Tags.hpp

--- a/src/Evolution/Systems/ForceFree/ForceFreeConstraints.cpp
+++ b/src/Evolution/Systems/ForceFree/ForceFreeConstraints.cpp
@@ -1,0 +1,56 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/ForceFree/ForceFreeConstraints.hpp"
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tags/TempTensor.hpp"
+#include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace ForceFree {
+
+void tilde_e_or_b_squared(
+    const gsl::not_null<Scalar<DataVector>*> tilde_e_or_b_squared,
+    const tnsr::I<DataVector, 3>& densitized_vector,
+    const tnsr::ii<DataVector, 3, Frame::Inertial>& spatial_metric) {
+  dot_product(tilde_e_or_b_squared, densitized_vector, densitized_vector,
+              spatial_metric);
+}
+
+void tilde_e_dot_tilde_b(
+    const gsl::not_null<Scalar<DataVector>*> tilde_e_dot_tilde_b,
+    const tnsr::I<DataVector, 3>& tilde_e,
+    const tnsr::I<DataVector, 3>& tilde_b,
+    const tnsr::ii<DataVector, 3, Frame::Inertial>& spatial_metric) {
+  dot_product(tilde_e_dot_tilde_b, tilde_e, tilde_b, spatial_metric);
+}
+
+void electric_field_dot_magnetic_field(
+    const gsl::not_null<Scalar<DataVector>*> electric_field_dot_magnetic_field,
+    const tnsr::I<DataVector, 3>& tilde_e,
+    const tnsr::I<DataVector, 3>& tilde_b,
+    const Scalar<DataVector>& sqrt_det_spatial_metric,
+    const tnsr::ii<DataVector, 3, Frame::Inertial>& spatial_metric) {
+  tilde_e_dot_tilde_b(electric_field_dot_magnetic_field, tilde_e, tilde_b,
+                      spatial_metric);
+  get(*electric_field_dot_magnetic_field) /=
+      square(get(sqrt_det_spatial_metric));
+}
+
+void magnetic_dominance_violation(
+    const gsl::not_null<Scalar<DataVector>*> magnetic_dominance_violation,
+    const Scalar<DataVector>& tilde_e_squared,
+    const Scalar<DataVector>& tilde_b_squared,
+    const Scalar<DataVector>& sqrt_det_spatial_metric) {
+  get(*magnetic_dominance_violation) =
+      max(get(tilde_e_squared) - get(tilde_b_squared), 0.0);
+
+  get(*magnetic_dominance_violation) /= square(get(sqrt_det_spatial_metric));
+}
+
+}  // namespace ForceFree

--- a/src/Evolution/Systems/ForceFree/ForceFreeConstraints.hpp
+++ b/src/Evolution/Systems/ForceFree/ForceFreeConstraints.hpp
@@ -1,0 +1,132 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Evolution/Systems/ForceFree/Tags.hpp"
+#include "PointwiseFunctions/GeneralRelativity/TagsDeclarations.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+class DataVector;
+namespace gsl {
+template <typename T>
+class not_null;
+}  // namespace gsl
+/// \endcond
+
+namespace ForceFree {
+
+/*!
+ * \brief Computes the scalar self-product $V^2 = V_i V^i$ where $V^i$ is either
+ * $\tilde{E}^i$ or $\tilde{B}^i$.
+ */
+void tilde_e_or_b_squared(
+    const gsl::not_null<Scalar<DataVector>*> tilde_e_or_b_squared,
+    const tnsr::I<DataVector, 3>& densitized_vector,
+    const tnsr::ii<DataVector, 3, Frame::Inertial>& spatial_metric);
+
+/*!
+ * \brief Computes the scalar product $\tilde{E}_i \tilde{B}^i$.
+ */
+void tilde_e_dot_tilde_b(
+    const gsl::not_null<Scalar<DataVector>*> tilde_e_dot_tilde_b,
+    const tnsr::I<DataVector, 3>& tilde_e,
+    const tnsr::I<DataVector, 3>& tilde_b,
+    const tnsr::ii<DataVector, 3, Frame::Inertial>& spatial_metric);
+
+/*!
+ * \brief Computes the scalar product $E_iB^i = \tilde{E}_i \tilde{B}^i /
+ * \gamma$, which measures the violation of the $E_iB^i = 0$ force-free
+ * condition.
+ */
+void electric_field_dot_magnetic_field(
+    const gsl::not_null<Scalar<DataVector>*> electric_field_dot_magnetic_field,
+    const tnsr::I<DataVector, 3>& tilde_e,
+    const tnsr::I<DataVector, 3>& tilde_b,
+    const Scalar<DataVector>& sqrt_det_spatial_metric,
+    const tnsr::ii<DataVector, 3, Frame::Inertial>& spatial_metric);
+
+/*!
+ * \brief Computes the violation of the magnetic dominance ($E^2 < B^2$)
+ * force-free condition.
+ */
+void magnetic_dominance_violation(
+    const gsl::not_null<Scalar<DataVector>*> magnetic_dominance_violation,
+    const Scalar<DataVector>& tilde_e_squared,
+    const Scalar<DataVector>& tilde_b_squared,
+    const Scalar<DataVector>& sqrt_det_spatial_metric);
+
+namespace Tags {
+
+/*!
+ * \brief Computes $\tilde{E}^2 = \tilde{E}_i \tilde{E}^i$.
+ */
+struct TildeESquaredCompute : TildeESquared, db::ComputeTag {
+  using argument_tags =
+      tmpl::list<TildeE, gr::Tags::SpatialMetric<DataVector, 3>>;
+  using return_type = Scalar<DataVector>;
+  using base = TildeESquared;
+
+  static constexpr auto function = &tilde_e_or_b_squared;
+};
+
+/*!
+ * \brief Computes $\tilde{B}^2 = \tilde{B}_i \tilde{B}^i$.
+ */
+struct TildeBSquaredCompute : TildeBSquared, db::ComputeTag {
+  using argument_tags =
+      tmpl::list<TildeB, gr::Tags::SpatialMetric<DataVector, 3>>;
+  using return_type = Scalar<DataVector>;
+  using base = TildeBSquared;
+
+  static constexpr auto function = &tilde_e_or_b_squared;
+};
+
+/*!
+ * \brief Computes the product $\tilde{E}_i\tilde{B}^i$.
+ */
+struct TildeEDotTildeBCompute : TildeEDotTildeB, db::ComputeTag {
+  using argument_tags =
+      tmpl::list<TildeE, TildeB, gr::Tags::SpatialMetric<DataVector, 3>>;
+  using return_type = Scalar<DataVector>;
+  using base = TildeEDotTildeB;
+
+  static constexpr auto function = &tilde_e_dot_tilde_b;
+};
+
+/*!
+ * \brief Computes the dot product of electric and magnetic fields \f$E^iB_i\f$.
+ *
+ * This quantity must vanish in the ideal force-free limit.
+ *
+ */
+struct ElectricFieldDotMagneticFieldCompute : ElectricFieldDotMagneticField,
+                                              db::ComputeTag {
+  using argument_tags =
+      tmpl::list<TildeE, TildeB, gr::Tags::SqrtDetSpatialMetric<DataVector>,
+                 gr::Tags::SpatialMetric<DataVector, 3>>;
+  using return_type = Scalar<DataVector>;
+  using base = ElectricFieldDotMagneticField;
+
+  static constexpr auto function = &electric_field_dot_magnetic_field;
+};
+
+/*!
+ * \brief Computes
+ *
+ */
+struct MagneticDominanceViolationCompute : MagneticDominanceViolation,
+                                           db::ComputeTag {
+  using argument_tags = tmpl::list<TildeESquared, TildeBSquared,
+                                   gr::Tags::SqrtDetSpatialMetric<DataVector>>;
+  using return_type = Scalar<DataVector>;
+  using base = MagneticDominanceViolation;
+
+  static constexpr auto function = &magnetic_dominance_violation;
+};
+
+}  // namespace Tags
+}  // namespace ForceFree

--- a/src/Evolution/Systems/ForceFree/Tags.hpp
+++ b/src/Evolution/Systems/ForceFree/Tags.hpp
@@ -117,6 +117,47 @@ struct LargestCharacteristicSpeed : db::SimpleTag {
   using type = double;
 };
 
+/// Some temporary quantities frequently called or used : TildeE^2, TildeB^2,
+/// TildeE.TildeB
+
+/*!
+ * \brief The product $\tilde{E}^2 = \tilde{E}_i \tilde{E}^i$.
+ */
+struct TildeESquared : db::SimpleTag {
+  using type = Scalar<DataVector>;
+};
+
+/*!
+ * \brief The product $\tilde{B}^2 = \tilde{B}_i \tilde{B}^i$.
+ */
+struct TildeBSquared : db::SimpleTag {
+  using type = Scalar<DataVector>;
+};
+
+/*!
+ * \brief The product $\tilde{E}_i \tilde{B}^i$.
+ */
+struct TildeEDotTildeB : db::SimpleTag {
+  using type = Scalar<DataVector>;
+};
+
+/// Tags for FFE condition violations : E.B, max(E^2-B^2, 0)
+
+/*!
+ * \brief The product of electric and magnetic field \f$E^iB_i\f$.
+ */
+struct ElectricFieldDotMagneticField : db::SimpleTag {
+  using type = Scalar<DataVector>;
+};
+
+/*!
+ * \brief The quantity $\max (E^2-B^2, 0)$ which monitors the violation of the
+ * magnetic dominance condition.
+ */
+struct MagneticDominanceViolation : db::SimpleTag {
+  using type = Scalar<DataVector>;
+};
+
 /*!
  * \brief An optional scalar variable used for masking the interior of neutron
  * star(s) when running neutron star magnetosphere simulations.
@@ -204,8 +245,8 @@ struct ParallelConductivity {
   static std::string name() { return "ParallelConductivity"; }
   using type = double;
   static constexpr Options::String help{
-      "Damping parameter for J^i to impose the force-free conditions, which is "
-      "physically the conductivity parallel to B field"};
+      "Damping parameter for J^i to impose the force-free conditions, which "
+      "is physically the conductivity parallel to B field"};
   using group = ForceFreeCurrentGroup;
 };
 

--- a/tests/Unit/Evolution/Systems/ForceFree/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/ForceFree/CMakeLists.txt
@@ -17,6 +17,7 @@ set(LIBRARY_SOURCES
   Test_ElectricCurrentDensity.cpp
   Test_ElectromagneticVariables.cpp
   Test_Fluxes.cpp
+  Test_ForceFreeConstraints.cpp
   Test_Sources.cpp
   Test_Tags.cpp
   Test_TimeDerivativeTerms.cpp

--- a/tests/Unit/Evolution/Systems/ForceFree/TestFunctions.py
+++ b/tests/Unit/Evolution/Systems/ForceFree/TestFunctions.py
@@ -22,3 +22,34 @@ def electric_current_density_compute(tilde_j, lapse, sqrt_det_spatial_metric):
 
 
 # end functions for testing ElectromagneticVariables
+
+
+# Functions for testing ForceFreeConstraints
+def tilde_e_or_tilde_b_squared(tilde_e_or_tilde_b, spatial_metric):
+    one_form = np.einsum("a, ia", tilde_e_or_tilde_b, spatial_metric)
+    return np.einsum("a, a", one_form, tilde_e_or_tilde_b)
+
+
+def tilde_e_dot_tilde_b_compute(tilde_e, tilde_b, spatial_metric):
+    magnetic_field_one_form = np.einsum("a, ia", tilde_b, spatial_metric)
+    return np.einsum("a, a", magnetic_field_one_form, tilde_e)
+
+
+def e_dot_b_compute(tilde_e, tilde_b, sqrt_det_spatial_metric, spatial_metric):
+    magnetic_field_one_form = np.einsum("a, ia", tilde_b, spatial_metric)
+    return (
+        np.einsum("a, a", magnetic_field_one_form, tilde_e)
+        / sqrt_det_spatial_metric**2
+    )
+
+
+def magnetic_dominance_violation_compute(
+    tilde_e_squared, tilde_b_squared, sqrt_det_spatial_metric
+):
+    return (
+        max(tilde_e_squared - tilde_b_squared, 0.0)
+        / sqrt_det_spatial_metric**2
+    )
+
+
+# end functions for testing ForceFreeConstraints

--- a/tests/Unit/Evolution/Systems/ForceFree/Test_ForceFreeConstraints.cpp
+++ b/tests/Unit/Evolution/Systems/ForceFree/Test_ForceFreeConstraints.cpp
@@ -1,0 +1,36 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include "DataStructures/DataVector.hpp"
+#include "Evolution/Systems/ForceFree/ForceFreeConstraints.hpp"
+#include "Framework/CheckWithRandomValues.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.ForceFree.ForceFreeConstraints",
+                  "[Unit][Evolution]") {
+  pypp::SetupLocalPythonEnvironment local_python_env{
+      "Evolution/Systems/ForceFree"};
+
+  pypp::check_with_random_values<1>(
+      ForceFree::Tags::TildeESquaredCompute::function, "TestFunctions",
+      {"tilde_e_or_tilde_b_squared"}, {{{-1.0, 1.0}}}, DataVector{5});
+
+  pypp::check_with_random_values<1>(
+      ForceFree::Tags::TildeBSquaredCompute::function, "TestFunctions",
+      {"tilde_e_or_tilde_b_squared"}, {{{-1.0, 1.0}}}, DataVector{5});
+
+  pypp::check_with_random_values<1>(
+      ForceFree::Tags::TildeEDotTildeBCompute::function, "TestFunctions",
+      {"tilde_e_dot_tilde_b_compute"}, {{{-1.0, 1.0}}}, DataVector{5});
+
+  pypp::check_with_random_values<1>(
+      ForceFree::Tags::ElectricFieldDotMagneticFieldCompute::function,
+      "TestFunctions", {"e_dot_b_compute"}, {{{-1.0, 1.0}}}, DataVector{5});
+
+  pypp::check_with_random_values<1>(
+      ForceFree::Tags::MagneticDominanceViolationCompute::function,
+      "TestFunctions", {"magnetic_dominance_violation_compute"},
+      {{{-1.0, 1.0}}}, DataVector{5});
+}


### PR DESCRIPTION
## Proposed changes

Add two compute tags (`E.B` and `E^2-B^2`) for observation purpose, and three compute tags (`TildeB^2`, `TildeE^2`, `TildeE.TildeB`) frequently being evaluated in evolution phase.



### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
