### PR TITLE
Use infinity for non-expiring FoT

### DIFF
--- a/src/Domain/FunctionsOfTime/FixedSpeedCubic.hpp
+++ b/src/Domain/FunctionsOfTime/FixedSpeedCubic.hpp
@@ -67,7 +67,7 @@ class FixedSpeedCubic : public FunctionOfTime {
 
   /// Returns the domain of validity of the function.
   std::array<double, 2> time_bounds() const override {
-    return {{initial_time_, std::numeric_limits<double>::max()}};
+    return {{initial_time_, std::numeric_limits<double>::infinity()}};
   }
 
   // NOLINTNEXTLINE(google-runtime-references)

--- a/src/Domain/FunctionsOfTime/SettleToConstant.hpp
+++ b/src/Domain/FunctionsOfTime/SettleToConstant.hpp
@@ -62,7 +62,7 @@ class SettleToConstant : public FunctionOfTime {
 
   /// Returns the domain of validity of the function.
   std::array<double, 2> time_bounds() const override {
-    return {{match_time_, std::numeric_limits<double>::max()}};
+    return {{match_time_, std::numeric_limits<double>::infinity()}};
   }
 
   // NOLINTNEXTLINE(google-runtime-references)

--- a/tests/Unit/Domain/FunctionsOfTime/Test_FixedSpeedCubic.cpp
+++ b/tests/Unit/Domain/FunctionsOfTime/Test_FixedSpeedCubic.cpp
@@ -59,7 +59,7 @@ void test(
   // test time_bounds function
   const auto t_bounds = f_of_t->time_bounds();
   CHECK(t_bounds[0] == initial_time);
-  CHECK(t_bounds[1] == std::numeric_limits<double>::max());
+  CHECK(t_bounds[1] == std::numeric_limits<double>::infinity());
 
   INFO("Test stream operator.");
   CHECK(


### PR DESCRIPTION
## Proposed changes

When printing out functions of time that don't expire, `inf` is easier to read than the max double:

```
FunctionsOfTime time bounds:
 Rotation: (0.0000000000000000e+00,inf)
 Expansion: (0.0000000000000000e+00,1.7976931348623157e+308)
```

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
