### PR TITLE
Add Quadrupole Moment and its first time derivative to GhValenciaDivClean

### DIFF
--- a/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
+++ b/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
@@ -101,6 +101,7 @@
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/KastaunEtAl.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/NewmanHamlin.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/PalenzuelaEtAl.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/QuadrupoleFormula.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/SetVariablesNeededFixingToFalse.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/SetInitialRdmpData.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/System.hpp"
@@ -526,7 +527,13 @@ struct GhValenciaDivCleanTemplateBase<
           evolution::dg::subcell::Tags::ObserverCoordinatesCompute<
               volume_dim, Frame::Inertial>,
           ::Events::Tags::ObserverCoordinatesCompute<volume_dim,
-                                                     Frame::Inertial>>>;
+                                                     Frame::Inertial>>,
+      grmhd::ValenciaDivClean::Tags::QuadrupoleMomentCompute<
+             DataVector, volume_dim,
+             ::Events::Tags::ObserverCoordinates<volume_dim, Frame::Inertial>>,
+      grmhd::ValenciaDivClean::Tags::QuadrupoleMomentDerivativeCompute<
+             DataVector, volume_dim,
+             ::Events::Tags::ObserverCoordinates<volume_dim, Frame::Inertial>>>;
   using integrand_fields = tmpl::append<
       typename system::variables_tag::tags_list,
       tmpl::conditional_t<

--- a/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/CMakeLists.txt
@@ -23,9 +23,9 @@ set(LIBRARY_SOURCES
   Subcell/Test_TimeDerivative.cpp
   Test_Characteristics.cpp
   Test_Constraints.cpp
-  Test_Tags.cpp
   Test_SetPiFromGauge.cpp
   Test_StressEnergy.cpp
+  Test_Tags.cpp
   Test_TimeDerivativeTerms.cpp
   )
 


### PR DESCRIPTION
## Proposed changes

<!--
At a high level, describe what this PR does.
-->

Adds compute tags and corresponding unit tests for the quadrupole moment (and first time derivative) previously implemented in `ValenciaDivClean` into `GhValenciaDivClean`.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
