### PR TITLE
Update Bond Sachs interpolation to run on GhMhd executables

### DIFF
--- a/src/ControlSystem/Measurements/CharSpeed.hpp
+++ b/src/ControlSystem/Measurements/CharSpeed.hpp
@@ -124,8 +124,7 @@ struct CharSpeed : tt::ConformsTo<protocols::Measurement> {
         const ElementId<3>& array_index,
         const ParallelComponent* const component, ControlSystems /*meta*/) {
       using Event = typename intrp::Events::InterpolateWithoutInterpComponent<
-          3, InterpolationTarget<ControlSystems>, Metavariables,
-          ::ah::source_vars<3>>;
+          3, InterpolationTarget<ControlSystems>, ::ah::source_vars<3>>;
 
       Event event{};
 

--- a/src/Evolution/Executables/CurvedScalarWave/EvolveCurvedScalarWave.hpp
+++ b/src/Evolution/Executables/CurvedScalarWave/EvolveCurvedScalarWave.hpp
@@ -201,18 +201,18 @@ struct EvolutionMetavars {
                 volume_dim>>,
         tmpl::pair<DenseTrigger, DenseTriggers::standard_dense_triggers>,
         tmpl::pair<DomainCreator<volume_dim>, domain_creators<volume_dim>>,
-        tmpl::pair<Event,
-                   tmpl::flatten<tmpl::list<
-                       Events::Completion,
-                       dg::Events::field_observations<
-                           volume_dim, observe_fields, non_tensor_compute_tags>,
-                       tmpl::conditional_t<
-                           interpolate,
-                           intrp::Events::InterpolateWithoutInterpComponent<
-                               volume_dim, SphericalSurface, EvolutionMetavars,
-                               interpolator_source_vars>,
-                           tmpl::list<>>,
-                       Events::time_events<system>>>>,
+        tmpl::pair<
+            Event,
+            tmpl::flatten<tmpl::list<
+                Events::Completion,
+                dg::Events::field_observations<volume_dim, observe_fields,
+                                               non_tensor_compute_tags>,
+                tmpl::conditional_t<
+                    interpolate,
+                    intrp::Events::InterpolateWithoutInterpComponent<
+                        volume_dim, SphericalSurface, interpolator_source_vars>,
+                    tmpl::list<>>,
+                Events::time_events<system>>>>,
         tmpl::pair<LtsTimeStepper, TimeSteppers::lts_time_steppers>,
         tmpl::pair<MathFunction<1, Frame::Inertial>,
                    MathFunctions::all_math_functions<1, Frame::Inertial>>,

--- a/src/Evolution/Executables/CurvedScalarWave/EvolveWorldtubeCurvedScalarWave.hpp
+++ b/src/Evolution/Executables/CurvedScalarWave/EvolveWorldtubeCurvedScalarWave.hpp
@@ -213,11 +213,9 @@ struct EvolutionMetavars {
             tmpl::flatten<tmpl::list<
                 Events::time_events<system>, Events::Completion,
                 intrp::Events::InterpolateWithoutInterpComponent<
-                    volume_dim, PsiAlongAxis<1>, EvolutionMetavars,
-                    interpolator_source_vars>,
+                    volume_dim, PsiAlongAxis<1>, interpolator_source_vars>,
                 intrp::Events::InterpolateWithoutInterpComponent<
-                    volume_dim, PsiAlongAxis<2>, EvolutionMetavars,
-                    interpolator_source_vars>,
+                    volume_dim, PsiAlongAxis<2>, interpolator_source_vars>,
                 dg::Events::field_observations<volume_dim, observe_fields,
                                                non_tensor_compute_tags>>>>,
         tmpl::pair<MathFunction<1, Frame::Inertial>,

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
@@ -444,13 +444,11 @@ struct EvolutionMetavars {
                 intrp::Events::Interpolate<3, AhB, interpolator_source_vars>,
                 intrp::Events::Interpolate<3, AhC, interpolator_source_vars>,
                 intrp::Events::InterpolateWithoutInterpComponent<
-                    3, BondiSachs, EvolutionMetavars, source_vars_no_deriv>,
+                    3, BondiSachs, source_vars_no_deriv>,
                 intrp::Events::InterpolateWithoutInterpComponent<
-                    3, ExcisionBoundaryA, EvolutionMetavars,
-                    interpolator_source_vars>,
+                    3, ExcisionBoundaryA, interpolator_source_vars>,
                 intrp::Events::InterpolateWithoutInterpComponent<
-                    3, ExcisionBoundaryB, EvolutionMetavars,
-                    interpolator_source_vars>,
+                    3, ExcisionBoundaryB, interpolator_source_vars>,
                 Events::MonitorMemory<3>, Events::Completion,
                 dg::Events::field_observations<volume_dim, observe_fields,
                                                non_tensor_compute_tags>,

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhSingleBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhSingleBlackHole.hpp
@@ -168,8 +168,7 @@ struct EvolutionMetavars : public GeneralizedHarmonicTemplateBase<VolumeDim> {
                                                   interpolator_source_vars>,
                        control_system::control_system_events<control_systems>,
                        intrp::Events::InterpolateWithoutInterpComponent<
-                           3, ExcisionBoundary, EvolutionMetavars,
-                           interpolator_source_vars>>>>,
+                           3, ExcisionBoundary, interpolator_source_vars>>>>,
         tmpl::pair<DenseTrigger,
                    control_system::control_system_triggers<control_systems>>>;
   };

--- a/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
+++ b/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
@@ -163,6 +163,7 @@
 #include "ParallelAlgorithms/Interpolation/Actions/TryToInterpolate.hpp"
 #include "ParallelAlgorithms/Interpolation/Callbacks/ObserveTimeSeriesOnSurface.hpp"
 #include "ParallelAlgorithms/Interpolation/Events/Interpolate.hpp"
+#include "ParallelAlgorithms/Interpolation/Events/InterpolateWithoutInterpComponent.hpp"
 #include "ParallelAlgorithms/Interpolation/InterpolationTarget.hpp"
 #include "ParallelAlgorithms/Interpolation/Interpolator.hpp"
 #include "ParallelAlgorithms/Interpolation/Protocols/InterpolationTargetTag.hpp"
@@ -635,8 +636,9 @@ struct GhValenciaDivCleanTemplateBase<
                                           non_tensor_compute_tags>,
                 Events::time_events<system>,
                 control_system::control_system_events<control_systems>,
-                intrp::Events::Interpolate<3, InterpolationTargetTags,
-                                           interpolator_source_vars>...>>>,
+                intrp::Events::InterpolateWithoutInterpComponent<
+                    volume_dim, InterpolationTargetTags,
+                    interpolator_source_vars>...>>>,
         tmpl::pair<
             grmhd::GhValenciaDivClean::BoundaryConditions::BoundaryCondition,
             boundary_conditions>,

--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
@@ -295,11 +295,11 @@ struct EvolutionMetavars {
           ::Events::Tags::ObserverCoordinatesCompute<volume_dim,
                                                      Frame::Inertial>>,
       grmhd::ValenciaDivClean::Tags::QuadrupoleMomentCompute<
-             DataVector, volume_dim,
-             ::Events::Tags::ObserverCoordinates<volume_dim, Frame::Inertial>>,
+          DataVector, volume_dim,
+          ::Events::Tags::ObserverCoordinates<volume_dim, Frame::Inertial>>,
       grmhd::ValenciaDivClean::Tags::QuadrupoleMomentDerivativeCompute<
-             DataVector, volume_dim,
-             ::Events::Tags::ObserverCoordinates<volume_dim, Frame::Inertial>>,
+          DataVector, volume_dim,
+          ::Events::Tags::ObserverCoordinates<volume_dim, Frame::Inertial>>,
       hydro::Tags::InversePlasmaBetaCompute<DataVector>>;
   using non_tensor_compute_tags = tmpl::list<
       tmpl::conditional_t<

--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
@@ -325,15 +325,15 @@ struct EvolutionMetavars {
     using factory_classes = tmpl::map<
         tmpl::pair<DenseTrigger, DenseTriggers::standard_dense_triggers>,
         tmpl::pair<DomainCreator<volume_dim>, domain_creators<volume_dim>>,
-        tmpl::pair<Event,
-                   tmpl::flatten<tmpl::list<
-                       Events::Completion,
-                       dg::Events::field_observations<
-                           volume_dim, observe_fields, non_tensor_compute_tags>,
-                       Events::time_events<system>,
-                       intrp::Events::InterpolateWithoutInterpComponent<
-                           3, InterpolationTargetTags, EvolutionMetavars,
-                           interpolator_source_vars>...>>>,
+        tmpl::pair<
+            Event,
+            tmpl::flatten<tmpl::list<
+                Events::Completion,
+                dg::Events::field_observations<volume_dim, observe_fields,
+                                               non_tensor_compute_tags>,
+                Events::time_events<system>,
+                intrp::Events::InterpolateWithoutInterpComponent<
+                    3, InterpolationTargetTags, interpolator_source_vars>...>>>,
         tmpl::pair<
             grmhd::ValenciaDivClean::BoundaryConditions::BoundaryCondition,
             grmhd::ValenciaDivClean::BoundaryConditions::

--- a/src/Evolution/Executables/ScalarTensor/EvolveScalarTensorSingleBlackHole.hpp
+++ b/src/Evolution/Executables/ScalarTensor/EvolveScalarTensorSingleBlackHole.hpp
@@ -182,10 +182,10 @@ struct EvolutionMetavars : public ScalarTensorTemplateBase<EvolutionMetavars> {
                        intrp::Events::Interpolate<volume_dim, AhA,
                                                   interpolator_source_vars>,
                        intrp::Events::InterpolateWithoutInterpComponent<
-                           volume_dim, ExcisionBoundaryA, EvolutionMetavars,
+                         volume_dim, ExcisionBoundaryA,
                            interpolator_source_vars>,
                        intrp::Events::InterpolateWithoutInterpComponent<
-                           volume_dim, SphericalSurface, EvolutionMetavars,
+                           volume_dim, SphericalSurface,
                            scalar_charge_interpolator_source_vars>>>>,
         tmpl::pair<DenseTrigger,
                    control_system::control_system_triggers<control_systems>>>;

--- a/src/Evolution/Systems/Cce/Actions/SendGhVarsToCce.hpp
+++ b/src/Evolution/Systems/Cce/Actions/SendGhVarsToCce.hpp
@@ -48,7 +48,7 @@ struct SendGhVarsToCce {
     // not used by interpolation
     const Event::ObservationValue observation_value{};
     auto interpolate_event = intrp::Events::InterpolateWithoutInterpComponent<
-        Metavariables::volume_dim, CceWorltubeTargetTag, Metavariables,
+        Metavariables::volume_dim, CceWorltubeTargetTag,
         typename CceWorltubeTargetTag::vars_to_interpolate_to_target>{};
     ::apply(
         interpolate_event,

--- a/src/ParallelAlgorithms/Interpolation/Events/InterpolateWithoutInterpComponent.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Events/InterpolateWithoutInterpComponent.hpp
@@ -45,16 +45,15 @@ struct InterpolationTarget;
 namespace intrp::Events {
 /// \cond
 template <size_t VolumeDim, typename InterpolationTargetTag,
-          typename Metavariables, typename SourceVarTags>
+          typename SourceVarTags>
 class InterpolateWithoutInterpComponent;
 /// \endcond
 
 /// Does an interpolation onto an InterpolationTargetTag by calling Actions on
 /// the InterpolationTarget component.
 template <size_t VolumeDim, typename InterpolationTargetTag,
-          typename Metavariables, typename... SourceVarTags>
+          typename... SourceVarTags>
 class InterpolateWithoutInterpComponent<VolumeDim, InterpolationTargetTag,
-                                        Metavariables,
                                         tmpl::list<SourceVarTags...>>
     : public Event {
   /// \cond
@@ -80,10 +79,10 @@ class InterpolateWithoutInterpComponent<VolumeDim, InterpolationTargetTag,
 
   using argument_tags =
       tmpl::list<typename InterpolationTargetTag::temporal_id,
-                 Tags::InterpPointInfo<Metavariables>,
+                 Tags::InterpPointInfoBase,
                  ::Events::Tags::ObserverMesh<VolumeDim>, SourceVarTags...>;
 
-  template <typename ParallelComponent>
+  template <typename ParallelComponent, typename Metavariables>
   void operator()(
       const typename InterpolationTargetTag::temporal_id::type& temporal_id,
       const typename Tags::InterpPointInfo<Metavariables>::type& point_infos,
@@ -190,7 +189,7 @@ class InterpolateWithoutInterpComponent<VolumeDim, InterpolationTargetTag,
 
   using is_ready_argument_tags = tmpl::list<>;
 
-  template <typename ArrayIndex, typename Component>
+  template <typename ArrayIndex, typename Component, typename Metavariables>
   bool is_ready(Parallel::GlobalCache<Metavariables>& /*cache*/,
                 const ArrayIndex& /*array_index*/,
                 const Component* const /*meta*/) const {
@@ -202,10 +201,11 @@ class InterpolateWithoutInterpComponent<VolumeDim, InterpolationTargetTag,
 
 /// \cond
 template <size_t VolumeDim, typename InterpolationTargetTag,
-          typename Metavariables, typename... SourceVarTags>
-PUP::able::PUP_ID InterpolateWithoutInterpComponent<
-    VolumeDim, InterpolationTargetTag, Metavariables,
-    tmpl::list<SourceVarTags...>>::my_PUP_ID = 0;  // NOLINT
+          typename... SourceVarTags>
+PUP::able::PUP_ID
+    InterpolateWithoutInterpComponent<VolumeDim, InterpolationTargetTag,
+                                      tmpl::list<SourceVarTags...>>::my_PUP_ID =
+        0;  // NOLINT
 /// \endcond
 
 }  // namespace intrp::Events

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_SendGhVarsToCce.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_SendGhVarsToCce.cpp
@@ -145,9 +145,8 @@ void run_test() {
       initialize_elements_and_queue_simple_actions<elem_component>{});
 }
 
-SPECTRE_TEST_CASE(
-    "Unit.Evolution.Systems.Cce.Actions.SendGhVarsToCce",
-    "[Unit][Cce]") {
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.Actions.SendGhVarsToCce",
+                  "[Unit][Cce]") {
   domain::creators::register_derived_with_charm();
   run_test<MockMetavariables>();
 }

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_SendGhVarsToCce.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_SendGhVarsToCce.cpp
@@ -120,12 +120,12 @@ struct MockMetavariables {
   using const_global_cache_tags = tmpl::list<domain::Tags::Domain<3>>;
   struct factory_creation
       : tt::ConformsTo<Options::protocols::FactoryCreation> {
-    using factory_classes = tmpl::map<tmpl::pair<
-        Event, tmpl::flatten<
-                   tmpl::list<intrp::Events::InterpolateWithoutInterpComponent<
-                       volume_dim, InterpolationTargetA, MockMetavariables,
-                       typename InterpolationTargetAImpl::
-                           vars_to_interpolate_to_target>>>>>;
+    using factory_classes = tmpl::map<
+        tmpl::pair<Event, tmpl::flatten<tmpl::list<
+                              intrp::Events::InterpolateWithoutInterpComponent<
+                                  volume_dim, InterpolationTargetA,
+                                  typename InterpolationTargetAImpl::
+                                      vars_to_interpolate_to_target>>>>>;
   };
 
   using interpolation_target_tags = tmpl::list<InterpolationTargetA>;

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolateWithoutInterpComponent.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolateWithoutInterpComponent.cpp
@@ -151,7 +151,7 @@ struct MockMetavariables {
                  mock_element<MockMetavariables>>;
 
   using event = intrp::Events::InterpolateWithoutInterpComponent<
-      volume_dim, InterpolationTargetA, MockMetavariables,
+      volume_dim, InterpolationTargetA,
       tmpl::list<InterpolateOnElementTestHelpers::Tags::TestSolution>>;
 
   struct factory_creation


### PR DESCRIPTION
## Proposed changes

This PR modifies  the interpolation done to compute Bondi-Sachs worldtubes in the GhMhd executable to be `InterpolateWithoutInterpComponent`.  This allows the `BondiSachsInterpolation` to run (and therefore extract waveforms from the GhMhd executables).    This PR, if it works, would close #5391.
### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
