### PR TITLE
Fix race condition inside PiecewisePolynomial

### DIFF
--- a/src/ControlSystem/UpdateFunctionOfTime.cpp
+++ b/src/ControlSystem/UpdateFunctionOfTime.cpp
@@ -43,14 +43,6 @@ void UpdateMultipleFunctionsOfTime::apply(
   }
 }
 
-void ResetFunctionOfTimeExpirationTime::apply(
-    const gsl::not_null<std::unordered_map<
-        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>*>
-        f_of_t_list,
-    const std::string& f_of_t_name, const double new_expiration_time) {
-  (*f_of_t_list).at(f_of_t_name)->reset_expiration_time(new_expiration_time);
-}
-
 UpdateAggregator::UpdateAggregator(
     std::string combined_name,
     std::unordered_set<std::string> active_control_system_names)

--- a/src/ControlSystem/UpdateFunctionOfTime.hpp
+++ b/src/ControlSystem/UpdateFunctionOfTime.hpp
@@ -65,18 +65,6 @@ struct UpdateMultipleFunctionsOfTime {
           update_args);
 };
 
-/// \ingroup ControlSystemGroup
-/// Resets the expiration time of a FunctionOfTime in the global cache. Intended
-/// to be used in Parallel::mutate.
-struct ResetFunctionOfTimeExpirationTime {
-  static void apply(
-      gsl::not_null<std::unordered_map<
-          std::string,
-          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>*>
-          f_of_t_list,
-      const std::string& f_of_t_name, double new_expiration_time);
-};
-
 /*!
  * \brief A class for collecting and storing information related to updating
  * functions of time and measurement timescales.

--- a/src/Domain/FunctionsOfTime/FunctionOfTime.hpp
+++ b/src/Domain/FunctionsOfTime/FunctionOfTime.hpp
@@ -64,12 +64,6 @@ class FunctionOfTime : public PUP::able {
     ERROR("Cannot update this FunctionOfTime.");
   }
 
-  /// Resets the expiration time to a new value. By default, the expiration time
-  /// of a FunctionOfTime cannot be reset.
-  virtual void reset_expiration_time(double /*next_expiration_time*/) {
-    ERROR("Cannot reset expiration time of this FunctionOfTime.");
-  }
-
   /// The DataVector can be of any size
   virtual std::array<DataVector, 1> func(double t) const = 0;
   /// The DataVector can be of any size

--- a/src/Domain/FunctionsOfTime/FunctionOfTimeHelpers.cpp
+++ b/src/Domain/FunctionsOfTime/FunctionOfTimeHelpers.cpp
@@ -45,17 +45,6 @@ void StoredInfo<MaxDerivPlusOne, false>::pup(PUP::er& p) {
   p | stored_quantities;
 }
 
-void reset_expiration_time(const gsl::not_null<double*> prev_expiration_time,
-                           const double next_expiration_time) {
-  if (next_expiration_time < *prev_expiration_time) {
-    ERROR("Attempted to change expiration time to "
-          << next_expiration_time
-          << ", which precedes the previous expiration time of "
-          << *prev_expiration_time << ".");
-  }
-  *prev_expiration_time = next_expiration_time;
-}
-
 template <size_t MaxDerivPlusOne, bool StoreCoefs>
 const StoredInfo<MaxDerivPlusOne, StoreCoefs>& stored_info_from_upper_bound(
     const double t,

--- a/src/Domain/FunctionsOfTime/FunctionOfTimeHelpers.hpp
+++ b/src/Domain/FunctionsOfTime/FunctionOfTimeHelpers.hpp
@@ -54,11 +54,6 @@ struct StoredInfo<MaxDerivPlusOne, false> {
   void pup(PUP::er& p);
 };
 
-/// Resets the previous expiration time if the next expiration time is after,
-/// otherwise throws an error
-void reset_expiration_time(const gsl::not_null<double*> prev_expiration_time,
-                           const double next_expiration_time);
-
 /*!
  * \brief Returns a StoredInfo corresponding to the closest element in the range
  * of `StoredInfo.time`s that is less than `t`.

--- a/src/Domain/FunctionsOfTime/PiecewisePolynomial.cpp
+++ b/src/Domain/FunctionsOfTime/PiecewisePolynomial.cpp
@@ -35,6 +35,26 @@ PiecewisePolynomial<MaxDeriv>::PiecewisePolynomial(
 
 template <size_t MaxDeriv>
 PiecewisePolynomial<MaxDeriv>::PiecewisePolynomial(
+    PiecewisePolynomial<MaxDeriv>&& rhs) {
+  *this = std::move(rhs);
+}
+
+template <size_t MaxDeriv>
+PiecewisePolynomial<MaxDeriv>& PiecewisePolynomial<MaxDeriv>::operator=(
+    PiecewisePolynomial<MaxDeriv>&& rhs) {
+  if (this == &rhs) {
+    return *this;
+  }
+  deriv_info_at_update_times_ = std::move(rhs.deriv_info_at_update_times_);
+  expiration_time_ = std::move(rhs.expiration_time_);
+  deriv_info_size_.store(
+      rhs.deriv_info_size_.exchange(0, std::memory_order_acq_rel),
+      std::memory_order_release);
+  return *this;
+}
+
+template <size_t MaxDeriv>
+PiecewisePolynomial<MaxDeriv>::PiecewisePolynomial(
     const PiecewisePolynomial<MaxDeriv>& rhs) {
   *this = rhs;
 }

--- a/src/Domain/FunctionsOfTime/PiecewisePolynomial.cpp
+++ b/src/Domain/FunctionsOfTime/PiecewisePolynomial.cpp
@@ -163,13 +163,6 @@ void PiecewisePolynomial<MaxDeriv>::update(
 }
 
 template <size_t MaxDeriv>
-void PiecewisePolynomial<MaxDeriv>::reset_expiration_time(
-    const double next_expiration_time) {
-  FunctionOfTimeHelpers::reset_expiration_time(make_not_null(&expiration_time_),
-                                               next_expiration_time);
-}
-
-template <size_t MaxDeriv>
 void PiecewisePolynomial<MaxDeriv>::pup(PUP::er& p) {
   FunctionOfTime::pup(p);
   size_t version = 2;

--- a/src/Domain/FunctionsOfTime/PiecewisePolynomial.hpp
+++ b/src/Domain/FunctionsOfTime/PiecewisePolynomial.hpp
@@ -35,8 +35,8 @@ class PiecewisePolynomial : public FunctionOfTime {
       double expiration_time);
 
   ~PiecewisePolynomial() override = default;
-  PiecewisePolynomial(PiecewisePolynomial&&) = default;
-  PiecewisePolynomial& operator=(PiecewisePolynomial&&) = default;
+  PiecewisePolynomial(PiecewisePolynomial&&);
+  PiecewisePolynomial& operator=(PiecewisePolynomial&&);
   PiecewisePolynomial(const PiecewisePolynomial&);
   PiecewisePolynomial& operator=(const PiecewisePolynomial&);
 

--- a/src/Domain/FunctionsOfTime/PiecewisePolynomial.hpp
+++ b/src/Domain/FunctionsOfTime/PiecewisePolynomial.hpp
@@ -73,9 +73,6 @@ class PiecewisePolynomial : public FunctionOfTime {
   void update(double time_of_update, DataVector updated_max_deriv,
               double next_expiration_time) override;
 
-  /// Resets the expiration time to a later time.
-  void reset_expiration_time(double next_expiration_time) override;
-
   /// Returns the domain of validity of the function,
   /// including the extrapolation region.
   std::array<double, 2> time_bounds() const override {

--- a/src/Domain/FunctionsOfTime/QuaternionFunctionOfTime.cpp
+++ b/src/Domain/FunctionsOfTime/QuaternionFunctionOfTime.cpp
@@ -36,6 +36,27 @@ QuaternionFunctionOfTime<MaxDeriv>::QuaternionFunctionOfTime(
 
 template <size_t MaxDeriv>
 QuaternionFunctionOfTime<MaxDeriv>::QuaternionFunctionOfTime(
+    QuaternionFunctionOfTime<MaxDeriv>&& rhs) {
+  *this = std::move(rhs);
+}
+
+template <size_t MaxDeriv>
+QuaternionFunctionOfTime<MaxDeriv>&
+QuaternionFunctionOfTime<MaxDeriv>::operator=(
+    QuaternionFunctionOfTime<MaxDeriv>&& rhs) {
+  if (this == &rhs) {
+    return *this;
+  }
+  stored_quaternions_and_times_ = std::move(rhs.stored_quaternions_and_times_);
+  angle_f_of_t_ = std::move(rhs.angle_f_of_t_);
+  stored_quaternion_size_.store(
+      rhs.stored_quaternion_size_.exchange(0, std::memory_order_acq_rel),
+      std::memory_order_release);
+  return *this;
+}
+
+template <size_t MaxDeriv>
+QuaternionFunctionOfTime<MaxDeriv>::QuaternionFunctionOfTime(
     const QuaternionFunctionOfTime<MaxDeriv>& rhs) {
   *this = rhs;
 }

--- a/src/Domain/FunctionsOfTime/QuaternionFunctionOfTime.cpp
+++ b/src/Domain/FunctionsOfTime/QuaternionFunctionOfTime.cpp
@@ -31,7 +31,7 @@ QuaternionFunctionOfTime<MaxDeriv>::QuaternionFunctionOfTime(
     const double expiration_time)
     : stored_quaternions_and_times_{{t, std::move(initial_quat_func)}},
       angle_f_of_t_(t, std::move(initial_angle_func), expiration_time) {
-  stored_quaternion_size_.store(1);
+  stored_quaternion_size_.store(1, std::memory_order_release);
 }
 
 template <size_t MaxDeriv>
@@ -51,7 +51,8 @@ QuaternionFunctionOfTime<MaxDeriv>::operator=(
   stored_quaternions_and_times_ = rhs.stored_quaternions_and_times_;
   angle_f_of_t_ = rhs.angle_f_of_t_;
   stored_quaternion_size_.store(
-      rhs.stored_quaternion_size_.load(std::memory_order_relaxed));
+      rhs.stored_quaternion_size_.load(std::memory_order_acquire),
+      std::memory_order_release);
   return *this;
 }
 
@@ -99,7 +100,8 @@ void QuaternionFunctionOfTime<MaxDeriv>::pup(PUP::er& p) {
       p | angle_f_of_t_;
 
       if (version == 0) {
-        stored_quaternion_size_.store(stored_quaternions_and_times_.size());
+        stored_quaternion_size_.store(stored_quaternions_and_times_.size(),
+                                      std::memory_order_release);
       } else {
         p | stored_quaternion_size_;
       }
@@ -109,10 +111,10 @@ void QuaternionFunctionOfTime<MaxDeriv>::pup(PUP::er& p) {
       p | angle_f_of_t_;
       size_t size = 0;
       p | size;
-      stored_quaternion_size_.store(size);
+      stored_quaternion_size_.store(size, std::memory_order_release);
       stored_quaternions_and_times_.clear();
       stored_quaternions_and_times_.resize(
-          stored_quaternion_size_.load(std::memory_order_relaxed));
+          stored_quaternion_size_.load(std::memory_order_acquire));
       // Using range-based loop here is ok because we won't be updating while
       // packing/unpacking
       for (auto& stored_quaternion : stored_quaternions_and_times_) {
@@ -122,7 +124,7 @@ void QuaternionFunctionOfTime<MaxDeriv>::pup(PUP::er& p) {
   } else {
     p | angle_f_of_t_;
     // This is guaranteed to be thread-safe for both packing and sizing
-    size_t size = stored_quaternion_size_.load(std::memory_order_relaxed);
+    size_t size = stored_quaternion_size_.load(std::memory_order_acquire);
     p | size;
     auto it = stored_quaternions_and_times_.begin();
     for (size_t i = 0; i < size; i++, it++) {
@@ -146,7 +148,7 @@ void QuaternionFunctionOfTime<MaxDeriv>::update_stored_info() {
 
   // We copy the size so this whole function uses the same index
   const size_t last_index =
-      stored_quaternion_size_.load(std::memory_order_relaxed);
+      stored_quaternion_size_.load(std::memory_order_acquire);
 
   ASSERT(
       angle_deriv_info.size() == last_index + 1,
@@ -232,7 +234,8 @@ boost::math::quaternion<double> QuaternionFunctionOfTime<MaxDeriv>::setup_func(
     const double t) const {
   // Get quaternion and time at closest time before t
   const auto& stored_info_at_t0 = stored_info_from_upper_bound(
-      t, stored_quaternions_and_times_, stored_quaternion_size_.load());
+      t, stored_quaternions_and_times_,
+      stored_quaternion_size_.load(std::memory_order_acquire));
   boost::math::quaternion<double> quat_to_integrate =
       datavector_to_quaternion(stored_info_at_t0.stored_quantities[0]);
 
@@ -313,7 +316,7 @@ std::ostream& operator<<(
     std::ostream& os,
     const QuaternionFunctionOfTime<MaxDeriv>& quaternion_f_of_t) {
   const size_t writable_size =
-      quaternion_f_of_t.stored_quaternion_size_.load(std::memory_order_relaxed);
+      quaternion_f_of_t.stored_quaternion_size_.load(std::memory_order_acquire);
   os << "Quaternion:\n";
   auto it = quaternion_f_of_t.stored_quaternions_and_times_.begin();
   // Can't use .end() because of thread-safety and don't want to do expensive

--- a/src/Domain/FunctionsOfTime/QuaternionFunctionOfTime.hpp
+++ b/src/Domain/FunctionsOfTime/QuaternionFunctionOfTime.hpp
@@ -68,8 +68,8 @@ class QuaternionFunctionOfTime : public FunctionOfTime {
       double expiration_time);
 
   ~QuaternionFunctionOfTime() override = default;
-  QuaternionFunctionOfTime(QuaternionFunctionOfTime&&) = default;
-  QuaternionFunctionOfTime& operator=(QuaternionFunctionOfTime&&) = default;
+  QuaternionFunctionOfTime(QuaternionFunctionOfTime&&);
+  QuaternionFunctionOfTime& operator=(QuaternionFunctionOfTime&&);
   QuaternionFunctionOfTime(const QuaternionFunctionOfTime&);
   QuaternionFunctionOfTime& operator=(const QuaternionFunctionOfTime&);
 

--- a/src/Domain/FunctionsOfTime/QuaternionFunctionOfTime.hpp
+++ b/src/Domain/FunctionsOfTime/QuaternionFunctionOfTime.hpp
@@ -9,6 +9,7 @@
 #include <cmath>
 #include <limits>
 #include <list>
+#include <mutex>
 #include <pup.h>
 #include <string>
 
@@ -85,7 +86,8 @@ class QuaternionFunctionOfTime : public FunctionOfTime {
 
   /// Returns domain of validity for the function of time
   std::array<double, 2> time_bounds() const override {
-    return angle_f_of_t_.time_bounds();
+    return std::array{stored_quaternions_and_times_.front().time,
+                      expiration_time_.load(std::memory_order_acquire)};
   }
 
   /// Updates the `MaxDeriv`th derivative of the angle piecewisepolynomial at
@@ -160,7 +162,12 @@ class QuaternionFunctionOfTime : public FunctionOfTime {
       stored_quaternions_and_times_;
   alignas(64) std::atomic_uint64_t stored_quaternion_size_{};
   // Pad memory to avoid false-sharing when accessing stored_quaternion_size_
-  char unused_padding_[64 - (sizeof(std::atomic_uint64_t) % 64)] = {};
+  char unused_padding_quat_size_[64 - (sizeof(std::atomic_uint64_t) % 64)] = {};
+  alignas(64) std::atomic<double> expiration_time_{};
+  // Pad memory to avoid false-sharing when accessing expiration_time_
+  char unused_padding_expr_time_[64 - (sizeof(std::atomic<double>) % 64)] = {};
+  // No need to pup this since a default constructed mutex is always unlocked
+  std::mutex update_mutex_{};
 
   domain::FunctionsOfTime::PiecewisePolynomial<MaxDeriv> angle_f_of_t_;
 
@@ -174,7 +181,7 @@ class QuaternionFunctionOfTime : public FunctionOfTime {
   /// Updates the `std::list<StoredInfo>` to have the same number of stored
   /// quaternions as the `angle_f_of_t_ptr` has stored angles. This is necessary
   /// to ensure we can solve the ODE at any time `t`
-  void update_stored_info();
+  void update_stored_info(double next_expiration_time);
 
   /// Does common operations to all the `func` functions such as updating stored
   /// info, solving the ODE, and returning the normalized quaternion as a boost

--- a/src/Domain/FunctionsOfTime/QuaternionFunctionOfTime.hpp
+++ b/src/Domain/FunctionsOfTime/QuaternionFunctionOfTime.hpp
@@ -83,10 +83,6 @@ class QuaternionFunctionOfTime : public FunctionOfTime {
   // clang-tidy: cppcoreguidelines-owning-memory,-warnings-as-errors
   WRAPPED_PUPable_decl_template(QuaternionFunctionOfTime<MaxDeriv>);  // NOLINT
 
-  void reset_expiration_time(const double next_expiration_time) override {
-    angle_f_of_t_.reset_expiration_time(next_expiration_time);
-  }
-
   /// Returns domain of validity for the function of time
   std::array<double, 2> time_bounds() const override {
     return angle_f_of_t_.time_bounds();

--- a/tests/Unit/ControlSystem/Test_UpdateFunctionOfTime.cpp
+++ b/tests/Unit/ControlSystem/Test_UpdateFunctionOfTime.cpp
@@ -136,31 +136,6 @@ void test_mutates() {
     CHECK(cache_pp == expected_pp);
     CHECK(cache_quatfot == expected_quatfot);
   }
-  // Update functions of time in global cache with new expiration time
-  expiration_time += 1.0;
-  for (auto& name : {pp_name, quatfot_name}) {
-    Parallel::mutate<domain::Tags::FunctionsOfTime,
-                     control_system::ResetFunctionOfTimeExpirationTime>(
-        cache, name, expiration_time);
-  }
-
-  // Update expected function of time
-  expected_pp.reset_expiration_time(expiration_time);
-  expected_quatfot.reset_expiration_time(expiration_time);
-  {
-    const auto& cache_pp = dynamic_cast<
-        const domain::FunctionsOfTime::PiecewisePolynomial<deriv_order>&>(
-        *(cache_f_of_t_map.at(pp_name)));
-    const auto& cache_quatfot = dynamic_cast<
-        const domain::FunctionsOfTime::QuaternionFunctionOfTime<deriv_order>&>(
-        *(cache_f_of_t_map.at(quatfot_name)));
-
-    // Check that the FunctionsOfTime and expiration times are what we expected
-    CHECK(cache_pp == expected_pp);
-    CHECK(cache_quatfot == expected_quatfot);
-    CHECK(cache_pp.time_bounds()[1] == expiration_time);
-    CHECK(cache_quatfot.time_bounds()[1] == expiration_time);
-  }
 
   // Check updating both at the same time
   update_time = expiration_time;

--- a/tests/Unit/Domain/FunctionsOfTime/Test_FixedSpeedCubic.cpp
+++ b/tests/Unit/Domain/FunctionsOfTime/Test_FixedSpeedCubic.cpp
@@ -174,23 +174,6 @@ void test_errors() {
         f_of_t->update(update_time, updated_deriv, next_expr_time);
       }()),
       Catch::Matchers::ContainsSubstring("Cannot update this FunctionOfTime"));
-
-  CHECK_THROWS_WITH(
-      ([]() {
-        const double initial_function_value = 1.0;
-        const double initial_time = 0.0;
-        const double velocity = -0.1;
-        const double decay_timescale = 0.0;
-        const std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime> f_of_t =
-            std::make_unique<domain::FunctionsOfTime::FixedSpeedCubic>(
-                initial_function_value, initial_time, velocity,
-                decay_timescale);
-
-        const double next_expr_time = 2.0;
-        f_of_t->reset_expiration_time(next_expr_time);
-      }()),
-      Catch::Matchers::ContainsSubstring(
-          "Cannot reset expiration time of this FunctionOfTime"));
 }
 }  // namespace
 

--- a/tests/Unit/Domain/FunctionsOfTime/Test_FunctionOfTimeHelpers.cpp
+++ b/tests/Unit/Domain/FunctionsOfTime/Test_FunctionOfTimeHelpers.cpp
@@ -111,18 +111,6 @@ SPECTRE_TEST_CASE("Unit.Domain.FunctionsOfTime.FunctionOfTimeHelpers",
   }
 
   CHECK_THROWS_WITH(
-      []() {
-        double expr_time = 4.0;
-        double next_expr_time = 3.5;
-        FunctionOfTimeHelpers::reset_expiration_time(make_not_null(&expr_time),
-                                                     next_expr_time);
-      }(),
-      Catch::Matchers::ContainsSubstring(
-          "Attempted to change expiration time to 3.5") and
-          Catch::Matchers::ContainsSubstring(
-              ", which precedes the previous expiration time of 4"));
-
-  CHECK_THROWS_WITH(
       ([]() {
         constexpr size_t mdp1 = 1;
         std::list<FunctionOfTimeHelpers::StoredInfo<mdp1>> all_stored_info{

--- a/tests/Unit/Domain/FunctionsOfTime/Test_FunctionsOfTimeAreReady.cpp
+++ b/tests/Unit/Domain/FunctionsOfTime/Test_FunctionsOfTimeAreReady.cpp
@@ -36,7 +36,11 @@ struct OtherFunctionsOfTime : db::SimpleTag {
 struct UpdateFoT {
   static void apply(const gsl::not_null<FunctionMap*> functions,
                     const std::string& name, const double expiration) {
-    (*functions).at(name)->reset_expiration_time(expiration);
+    const double current_expiration = functions->at(name)->time_bounds()[1];
+    // Update value doesn't matter
+    (*functions)
+        .at(name)
+        ->update(current_expiration, DataVector{0.0}, expiration);
   }
 };
 
@@ -79,10 +83,10 @@ SPECTRE_TEST_CASE("Unit.Domain.FunctionsOfTimeAreReady", "[Domain][Unit]") {
   FunctionMap other_functions_of_time{};
   other_functions_of_time["OtherA"] =
       std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<2>>(
-          0.0, fot_init, 0.0);
+          0.0, fot_init, 0.1);
   other_functions_of_time["OtherB"] =
       std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<2>>(
-          0.0, fot_init, 0.0);
+          0.0, fot_init, 0.1);
 
   MockRuntimeSystem runner{
       {}, {std::move(functions_of_time), std::move(other_functions_of_time)}};

--- a/tests/Unit/Domain/FunctionsOfTime/Test_PiecewisePolynomial.cpp
+++ b/tests/Unit/Domain/FunctionsOfTime/Test_PiecewisePolynomial.cpp
@@ -145,6 +145,10 @@ void check_func_and_derivs(
   CHECK(f_of_t.func(t) == q.func_and_derivs<0>(t));
   CHECK(f_of_t.func_and_deriv(t) == q.func_and_derivs<1>(t));
   CHECK(f_of_t.func_and_2_derivs(t) == q.func_and_derivs<2>(t));
+
+  test_copy_semantics(f_of_t);
+  auto f_of_t_copy = f_of_t;
+  test_move_semantics(std::move(f_of_t_copy), f_of_t);
 }
 
 void test_func_and_derivs() {

--- a/tests/Unit/Domain/FunctionsOfTime/Test_PiecewisePolynomial.cpp
+++ b/tests/Unit/Domain/FunctionsOfTime/Test_PiecewisePolynomial.cpp
@@ -384,22 +384,6 @@ SPECTRE_TEST_CASE("Unit.Domain.FunctionsOfTime.PiecewisePolynomial",
         const std::array<DataVector, deriv_order + 1> init_func{
             {{0.0, 0.0}, {0.0, 0.0}, {0.0, 2.0}, {6.0, 0.0}}};
         FunctionsOfTime::PiecewisePolynomial<deriv_order> f_of_t(0.0, init_func,
-                                                                 2.0);
-        f_of_t.reset_expiration_time(1.5);
-        f_of_t.update(2.5, {6.0, 0.0}, 2.2);
-      }()),
-      Catch::Matchers::ContainsSubstring(
-          "Attempted to change expiration time to 1.5") and
-          Catch::Matchers::ContainsSubstring(
-              ", which precedes the previous expiration time of 2"));
-
-  CHECK_THROWS_WITH(
-      ([]() {
-        // two component system (x**3 and x**2)
-        constexpr size_t deriv_order = 3;
-        const std::array<DataVector, deriv_order + 1> init_func{
-            {{0.0, 0.0}, {0.0, 0.0}, {0.0, 2.0}, {6.0, 0.0}}};
-        FunctionsOfTime::PiecewisePolynomial<deriv_order> f_of_t(0.0, init_func,
                                                                  0.1);
         f_of_t.update(1.0, {6.0, 0.0, 0.0}, 1.1);
       }()),

--- a/tests/Unit/Domain/FunctionsOfTime/Test_QuaternionFunctionOfTime.cpp
+++ b/tests/Unit/Domain/FunctionsOfTime/Test_QuaternionFunctionOfTime.cpp
@@ -65,7 +65,7 @@ SPECTRE_TEST_CASE("Unit.Domain.FunctionsOfTime.QuaternionFunctionOfTime",
   }
 
   {
-    INFO("QuaternionFunctionOfTime: pup, cloning, extra functions");
+    INFO("QuaternionFunctionOfTime: pup, cloning, extra functions, copy/move");
     DataVector init_omega{0.0, 0.0, 1.0};
     domain::FunctionsOfTime::QuaternionFunctionOfTime<2> qfot{
         0.0, std::array<DataVector, 1>{DataVector{{1.0, 0.0, 0.0, 0.0}}},
@@ -104,6 +104,9 @@ SPECTRE_TEST_CASE("Unit.Domain.FunctionsOfTime.QuaternionFunctionOfTime",
                           qfot.func(2.0));
     CHECK_ITERABLE_APPROX(qfot_serialized_deserialized.func_and_deriv(2.0),
                           qfot.func_and_deriv(2.0));
+
+    test_copy_semantics(qfot);
+    test_move_semantics(std::move(qfot_serialized_deserialized), qfot);
   }
 
   {

--- a/tests/Unit/Domain/FunctionsOfTime/Test_QuaternionFunctionOfTime.cpp
+++ b/tests/Unit/Domain/FunctionsOfTime/Test_QuaternionFunctionOfTime.cpp
@@ -15,15 +15,13 @@
 SPECTRE_TEST_CASE("Unit.Domain.FunctionsOfTime.QuaternionFunctionOfTime",
                   "[Unit][Domain]") {
   {
-    INFO("QuaternionFunctionOfTime: Expiration time and time bounds");
+    INFO("QuaternionFunctionOfTime: Time bounds");
     domain::FunctionsOfTime::QuaternionFunctionOfTime<2> qfot{
         0.0, std::array<DataVector, 1>{DataVector{4, 0.0}},
         std::array<DataVector, 3>{DataVector{3, 0.0}, DataVector{3, 0.0},
                                   DataVector{3, 0.0}},
         0.5};
     CHECK(qfot.time_bounds() == std::array<double, 2>({0.0, 0.5}));
-    qfot.reset_expiration_time(0.6);
-    CHECK(qfot.time_bounds() == std::array<double, 2>({0.0, 0.6}));
   }
 
   {

--- a/tests/Unit/Domain/FunctionsOfTime/Test_SettleToConstant.cpp
+++ b/tests/Unit/Domain/FunctionsOfTime/Test_SettleToConstant.cpp
@@ -137,12 +137,4 @@ SPECTRE_TEST_CASE("Unit.Domain.FunctionsOfTime.SettleToConstant",
           1.0}
            .update(1.0, DataVector{}, 2.0)),
       Catch::Matchers::ContainsSubstring("Cannot update this FunctionOfTime."));
-  CHECK_THROWS_WITH(
-      (domain::FunctionsOfTime::SettleToConstant{
-          {{DataVector{1, 0.0}, DataVector{1, 0.0}, DataVector{1, 0.0}}},
-          10.0,
-          1.0}
-           .reset_expiration_time(2.0)),
-      Catch::Matchers::ContainsSubstring(
-          "Cannot reset expiration time of this FunctionOfTime."));
 }

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolationTargetReceiveVars.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolationTargetReceiveVars.cpp
@@ -267,10 +267,9 @@ struct mock_interpolator {
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
           Parallel::Phase::Initialization,
-          tmpl::list<
-              intrp::Actions::InitializeInterpolator<
-                  intrp::Tags::VolumeVarsInfo<Metavariables, ::Tags::Time>,
-                  intrp::Tags::InterpolatedVarsHolders<Metavariables>>>>,
+          tmpl::list<intrp::Actions::InitializeInterpolator<
+              intrp::Tags::VolumeVarsInfo<Metavariables, ::Tags::Time>,
+              intrp::Tags::InterpolatedVarsHolders<Metavariables>>>>,
       Parallel::PhaseActions<Parallel::Phase::Testing, tmpl::list<>>>;
 
   using component_being_mocked = intrp::Interpolator<Metavariables>;
@@ -572,9 +571,12 @@ void test_interpolation_target_receive_vars() {
 
       // Now mutate the FunctionsOfTime.
       auto& cache = ActionTesting::cache<target_component>(runner, 0_st);
+      const double current_expiration_time =
+          initial_expiration_times[f_of_t_name];
       Parallel::mutate<domain::Tags::FunctionsOfTime,
-                       control_system::ResetFunctionOfTimeExpirationTime>(
-          cache, f_of_t_name, new_expiration_time);
+                       control_system::UpdateSingleFunctionOfTime>(
+          cache, f_of_t_name, current_expiration_time, DataVector{3, 0.0},
+          new_expiration_time);
 
       // The callback should have queued a single simple action,
       // VerifyTemporalIdsAndSendPoints.


### PR DESCRIPTION
## Proposed changes

A code comment inside the `PiecewisePolynomial::update` function explains how this occurred before. Also update QuaternionFunctionOfTime to fix the same issue. This became an issue once #5240 was merged, and was missed in 
#5198 and #5334.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
