### PR TITLE
Optionally write Bns control sys centers to disk

### DIFF
--- a/src/ControlSystem/Measurements/CMakeLists.txt
+++ b/src/ControlSystem/Measurements/CMakeLists.txt
@@ -29,6 +29,7 @@ target_link_libraries(
   DataStructures
   GeneralRelativity
   GeneralizedHarmonic
+  Observer
   ParallelInterpolation
   Utilities
   )


### PR DESCRIPTION
## Proposed changes

We already write center measurements to disk for BBHs, so we should also do it for the BNS. It can help with debugging control system errors by ruling out bad center measurements.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
