### PR TITLE
Put all Ylm things in namespace

### DIFF
--- a/src/ControlSystem/ControlErrors/Shape.hpp
+++ b/src/ControlSystem/ControlErrors/Shape.hpp
@@ -140,7 +140,7 @@ struct Shape : tt::ConformsTo<protocols::ControlError> {
         excision_spheres.at(detail::excision_sphere_name<Horizon>()).radius();
 
     const double Y00 = sqrt(0.25 / M_PI);
-    SpherepackIterator iter{ah.l_max(), ah.m_max()};
+    ylm::SpherepackIterator iter{ah.l_max(), ah.m_max()};
     // See above docs for why we have the sqrt(pi/2) in the denominator
     const double relative_size_factor =
         (radius_excision_sphere_grid_frame / Y00 - lambda_00_coef) /

--- a/src/ControlSystem/ControlErrors/Size.hpp
+++ b/src/ControlSystem/ControlErrors/Size.hpp
@@ -140,8 +140,8 @@ namespace ControlErrors {
  *   control error.
  * - MinDeltaR: The minimum of the `gr::surfaces::radial_distance` between the
  *   horizon and the excision surfaces.
- * - MinRelativeDeltaR: MinDeltaR divided by the `Strahlkorper::average_radius`
- *   of the horizon
+ * - MinRelativeDeltaR: MinDeltaR divided by the
+ *   `ylm::Strahlkorper::average_radius` of the horizon
  * - AvgDeltaR: Same as MinDeltaR except it's the average radii.
  * - AvgRelativeDeltaR: AvgDeltaR divided by the average radius of the horizon
  * - ControlErrorDeltaR: \f$ \dot{S}_{00} (\lambda_{00} -
@@ -278,13 +278,13 @@ struct Size : tt::ConformsTo<protocols::ControlError> {
             measurements);
 
     const double grid_frame_excision_sphere_radius = excision_sphere.radius();
-    const Strahlkorper<Frame::Distorted>& apparent_horizon =
+    const ylm::Strahlkorper<Frame::Distorted>& apparent_horizon =
         tuples::get<ylm::Tags::Strahlkorper<Frame::Distorted>>(
             horizon_quantities);
-    const Strahlkorper<Frame::Distorted>& excision_surface =
+    const ylm::Strahlkorper<Frame::Distorted>& excision_surface =
         tuples::get<QueueTags::ExcisionSurface<Frame::Distorted>>(
             excision_quantities);
-    const Strahlkorper<Frame::Distorted>& time_deriv_apparent_horizon =
+    const ylm::Strahlkorper<Frame::Distorted>& time_deriv_apparent_horizon =
         tuples::get<::Tags::dt<ylm::Tags::Strahlkorper<Frame::Distorted>>>(
             horizon_quantities);
     const Scalar<DataVector>& lapse =

--- a/src/ControlSystem/ControlErrors/Size/Error.cpp
+++ b/src/ControlSystem/ControlErrors/Size/Error.cpp
@@ -37,8 +37,8 @@ ErrorDiagnostics control_error(
         predictor_comoving_char_speed,
     const gsl::not_null<intrp::ZeroCrossingPredictor*> predictor_delta_radius,
     const double time, const double control_error_delta_r,
-    const double dt_lambda_00, const Strahlkorper<Frame>& apparent_horizon,
-    const Strahlkorper<Frame>& excision_boundary,
+    const double dt_lambda_00, const ylm::Strahlkorper<Frame>& apparent_horizon,
+    const ylm::Strahlkorper<Frame>& excision_boundary,
     const Scalar<DataVector>& lapse_on_excision_boundary,
     const tnsr::I<DataVector, 3, Frame>& frame_components_of_grid_shift,
     const tnsr::ii<DataVector, 3, Frame>& spatial_metric_on_excision_boundary,
@@ -230,8 +230,8 @@ ErrorDiagnostics control_error(
       const gsl::not_null<intrp::ZeroCrossingPredictor*>                       \
           predictor_delta_radius,                                              \
       double time, double control_error_delta_r, double dt_lambda_00,          \
-      const Strahlkorper<FRAME(data)>& apparent_horizon,                       \
-      const Strahlkorper<FRAME(data)>& excision_boundary,                      \
+      const ylm::Strahlkorper<FRAME(data)>& apparent_horizon,                  \
+      const ylm::Strahlkorper<FRAME(data)>& excision_boundary,                 \
       const Scalar<DataVector>& lapse_on_excision_boundary,                    \
       const tnsr::I<DataVector, 3, FRAME(data)>&                               \
           frame_components_of_grid_shift,                                      \

--- a/src/ControlSystem/ControlErrors/Size/Error.hpp
+++ b/src/ControlSystem/ControlErrors/Size/Error.hpp
@@ -11,8 +11,10 @@
 
 /// \cond
 class DataVector;
+namespace ylm {
 template <typename Frame>
 class Strahlkorper;
+}  // namespace ylm
 namespace domain::FunctionsOfTime {
 class FunctionOfTime;
 }  // namespace domain::FunctionsOfTime
@@ -134,8 +136,8 @@ ErrorDiagnostics control_error(
         predictor_comoving_char_speed,
     const gsl::not_null<intrp::ZeroCrossingPredictor*> predictor_delta_radius,
     double time, double control_error_delta_r, double dt_lambda_00,
-    const Strahlkorper<Frame>& apparent_horizon,
-    const Strahlkorper<Frame>& excision_boundary,
+    const ylm::Strahlkorper<Frame>& apparent_horizon,
+    const ylm::Strahlkorper<Frame>& excision_boundary,
     const Scalar<DataVector>& lapse_on_excision_boundary,
     const tnsr::I<DataVector, 3, Frame>& frame_components_of_grid_shift,
     const tnsr::ii<DataVector, 3, Frame>& spatial_metric_on_excision_boundary,

--- a/src/ControlSystem/Systems/Expansion.hpp
+++ b/src/ControlSystem/Systems/Expansion.hpp
@@ -107,7 +107,7 @@ struct Expansion : tt::ConformsTo<protocols::ControlSystem> {
     template <::domain::ObjectLabel Horizon, typename Metavariables>
     static void apply(
         measurements::BothHorizons::FindHorizon<Horizon> submeasurement,
-        const Strahlkorper<Frame::Distorted>& horizon_strahlkorper,
+        const ylm::Strahlkorper<Frame::Distorted>& horizon_strahlkorper,
         Parallel::GlobalCache<Metavariables>& cache,
         const LinkedMessageId<double>& measurement_id) {
       auto& control_sys_proxy = Parallel::get_parallel_component<

--- a/src/ControlSystem/Systems/Rotation.hpp
+++ b/src/ControlSystem/Systems/Rotation.hpp
@@ -113,7 +113,7 @@ struct Rotation : tt::ConformsTo<protocols::ControlSystem> {
     template <::domain::ObjectLabel Horizon, typename Metavariables>
     static void apply(
         measurements::BothHorizons::FindHorizon<Horizon> submeasurement,
-        const Strahlkorper<Frame::Distorted>& strahlkorper,
+        const ylm::Strahlkorper<Frame::Distorted>& strahlkorper,
         Parallel::GlobalCache<Metavariables>& cache,
         const LinkedMessageId<double>& measurement_id) {
       auto& control_sys_proxy = Parallel::get_parallel_component<

--- a/src/ControlSystem/Systems/Shape.hpp
+++ b/src/ControlSystem/Systems/Shape.hpp
@@ -69,14 +69,14 @@ struct Shape : tt::ConformsTo<protocols::ControlSystem> {
     // shape map. This is why we can divide by 2 and take the sqrt without
     // worrying about odd numbers or non-perfect squares
     const size_t l_max = -1 + sqrt(num_components / 2);
-    SpherepackIterator iter(l_max, l_max);
+    ylm::SpherepackIterator iter(l_max, l_max);
     const auto compact_index = iter.compact_index(i);
     if (compact_index.has_value()) {
       iter.set(compact_index.value());
-      const int m =
-          iter.coefficient_array() == SpherepackIterator::CoefficientArray::a
-              ? static_cast<int>(iter.m())
-              : -static_cast<int>(iter.m());
+      const int m = iter.coefficient_array() ==
+                            ylm::SpherepackIterator::CoefficientArray::a
+                        ? static_cast<int>(iter.m())
+                        : -static_cast<int>(iter.m());
       return {"l"s + get_output(iter.l()) + "m"s + get_output(m)};
     } else {
       return std::nullopt;
@@ -112,7 +112,7 @@ struct Shape : tt::ConformsTo<protocols::ControlSystem> {
     template <typename Metavariables>
     static void apply(typename measurements::SingleHorizon<
                           Horizon>::Submeasurement submeasurement,
-                      const Strahlkorper<Frame::Distorted>& strahlkorper,
+                      const ylm::Strahlkorper<Frame::Distorted>& strahlkorper,
                       Parallel::GlobalCache<Metavariables>& cache,
                       const LinkedMessageId<double>& measurement_id) {
       auto& control_sys_proxy = Parallel::get_parallel_component<
@@ -133,7 +133,7 @@ struct Shape : tt::ConformsTo<protocols::ControlSystem> {
     template <::domain::ObjectLabel MeasureHorizon, typename Metavariables>
     static void apply(
         measurements::BothHorizons::FindHorizon<MeasureHorizon> submeasurement,
-        const Strahlkorper<Frame::Distorted>& strahlkorper,
+        const ylm::Strahlkorper<Frame::Distorted>& strahlkorper,
         Parallel::GlobalCache<Metavariables>& cache,
         const LinkedMessageId<double>& measurement_id) {
       // The measurement event will call this for both horizons, but we only

--- a/src/ControlSystem/Systems/Size.hpp
+++ b/src/ControlSystem/Systems/Size.hpp
@@ -104,7 +104,7 @@ struct Size : tt::ConformsTo<protocols::ControlSystem> {
     template <typename Metavariables>
     static void apply(
         typename measurements::CharSpeed<Horizon>::Excision /*meta*/,
-        const Strahlkorper<Frame::Grid>& grid_excision_surface,
+        const ylm::Strahlkorper<Frame::Grid>& grid_excision_surface,
         const Scalar<DataVector>& lapse,
         const tnsr::I<DataVector, 3, Frame::Distorted>& shifty_quantity,
         const tnsr::ii<DataVector, 3, Frame::Distorted>&
@@ -121,7 +121,7 @@ struct Size : tt::ConformsTo<protocols::ControlSystem> {
                          name(), measurement_id);
       }
 
-      Strahlkorper<Frame::Distorted> distorted_excision_surface{};
+      ylm::Strahlkorper<Frame::Distorted> distorted_excision_surface{};
       strahlkorper_in_different_frame_aligned(
           make_not_null(&distorted_excision_surface), grid_excision_surface,
           Parallel::get<domain::Tags::Domain<3>>(cache),
@@ -141,8 +141,8 @@ struct Size : tt::ConformsTo<protocols::ControlSystem> {
     template <typename Metavariables>
     static void apply(
         typename measurements::CharSpeed<Horizon>::Horizon /*meta*/,
-        const Strahlkorper<Frame::Distorted>& horizon,
-        const Strahlkorper<Frame::Distorted>& time_deriv_horizon,
+        const ylm::Strahlkorper<Frame::Distorted>& horizon,
+        const ylm::Strahlkorper<Frame::Distorted>& time_deriv_horizon,
         Parallel::GlobalCache<Metavariables>& cache,
         const LinkedMessageId<double>& measurement_id) {
       auto& control_sys_proxy = Parallel::get_parallel_component<

--- a/src/ControlSystem/Systems/Translation.hpp
+++ b/src/ControlSystem/Systems/Translation.hpp
@@ -100,7 +100,7 @@ struct Translation : tt::ConformsTo<protocols::ControlSystem> {
     template <::domain::ObjectLabel Horizon, typename Metavariables>
     static void apply(
         measurements::BothHorizons::FindHorizon<Horizon> submeasurement,
-        const Strahlkorper<Frame::Distorted>& strahlkorper,
+        const ylm::Strahlkorper<Frame::Distorted>& strahlkorper,
         Parallel::GlobalCache<Metavariables>& cache,
         const LinkedMessageId<double>& measurement_id) {
       auto& control_sys_proxy =

--- a/src/ControlSystem/Tags/QueueTags.hpp
+++ b/src/ControlSystem/Tags/QueueTags.hpp
@@ -10,8 +10,10 @@
 
 /// \cond
 class DataVector;
+namespace ylm {
 template <typename Frame>
 class Strahlkorper;
+}  // namespace ylm
 namespace domain {
 enum class ObjectLabel;
 }  // namespace domain
@@ -36,14 +38,14 @@ struct Center {
 /// Holds a full strahlkorper from measurements that represents a horizon
 template <typename Frame>
 struct Horizon {
-  using type = ::Strahlkorper<Frame>;
+  using type = ylm::Strahlkorper<Frame>;
 };
 
 /// \ingroup ControlSystemGroup
 /// Holds a full strahlkorper from measurements for the excision surface
 template <typename Frame>
 struct ExcisionSurface {
-  using type = ::Strahlkorper<Frame>;
+  using type = ylm::Strahlkorper<Frame>;
 };
 
 /// \ingroup ControlSystemGroup

--- a/src/ControlSystem/Tags/SystemTags.hpp
+++ b/src/ControlSystem/Tags/SystemTags.hpp
@@ -17,7 +17,6 @@
 #include "ControlSystem/TimescaleTuner.hpp"
 #include "DataStructures/DataBox/Tag.hpp"
 #include "Domain/Creators/DomainCreator.hpp"
-#include "NumericalAlgorithms/SphericalHarmonics/Strahlkorper.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/Tags.hpp"
 #include "Time/OptionTags/InitialTime.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"

--- a/src/Domain/CoordinateMaps/TimeDependent/Shape.cpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/Shape.cpp
@@ -173,8 +173,8 @@ tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame> Shape::jacobian(
   // Copy over the coefficients. The additional coefficients of order `l_max_
   // +1` are zero and will only have an effect in the interpolation of the
   // cartesian gradient.
-  SpherepackIterator extended_iter(l_max_ + 1, m_max_ + 1);
-  SpherepackIterator iter(l_max_, m_max_);
+  ylm::SpherepackIterator extended_iter(l_max_ + 1, m_max_ + 1);
+  ylm::SpherepackIterator iter(l_max_, m_max_);
   for (size_t l = 0; l <= l_max_; ++l) {
     const int m_max = std::min(l, m_max_);
     for (int m = -m_max; m <= m_max; ++m) {

--- a/src/Domain/StrahlkorperTransformations.cpp
+++ b/src/Domain/StrahlkorperTransformations.cpp
@@ -93,8 +93,9 @@ void coords_to_different_frame(
 
 template <typename SrcFrame, typename DestFrame>
 void strahlkorper_in_different_frame(
-    const gsl::not_null<Strahlkorper<DestFrame>*> dest_strahlkorper,
-    const Strahlkorper<SrcFrame>& src_strahlkorper, const Domain<3>& domain,
+    const gsl::not_null<ylm::Strahlkorper<DestFrame>*> dest_strahlkorper,
+    const ylm::Strahlkorper<SrcFrame>& src_strahlkorper,
+    const Domain<3>& domain,
     const std::unordered_map<
         std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
         functions_of_time,
@@ -136,8 +137,8 @@ void strahlkorper_in_different_frame(
   // destination frame.  An average should be good enough, since this
   // is only the expansion center (not the physical center), so its
   // only requirement is that it is centered enough so that the
-  // surface is star-shaped.  If we want to re-center the strahlkorper
-  // later, we can call `change_expansion_center_of_strahlkorper_to_physical`.
+  // surface is star-shaped.  If we want to re-center the strahlkorper later, we
+  // can call `ylm::change_expansion_center_of_strahlkorper_to_physical`.
   const auto center_dest = [&dest_cartesian_coords]() {
     std::array<double, 3> center{};
     for (size_t d = 0; d < 3; ++d) {
@@ -255,15 +256,16 @@ void strahlkorper_in_different_frame(
 
   // Reset the radius and center of the destination strahlkorper.
   // Keep the same l_max() and m_max() as the source strahlkorper.
-  *dest_strahlkorper = Strahlkorper<DestFrame>(
+  *dest_strahlkorper = ylm::Strahlkorper<DestFrame>(
       src_strahlkorper.l_max(), src_strahlkorper.m_max(), radius_at_each_angle,
       center_dest);
 }
 
 template <typename SrcFrame, typename DestFrame>
 void strahlkorper_in_different_frame_aligned(
-    const gsl::not_null<Strahlkorper<DestFrame>*> dest_strahlkorper,
-    const Strahlkorper<SrcFrame>& src_strahlkorper, const Domain<3>& domain,
+    const gsl::not_null<ylm::Strahlkorper<DestFrame>*> dest_strahlkorper,
+    const ylm::Strahlkorper<SrcFrame>& src_strahlkorper,
+    const Domain<3>& domain,
     const std::unordered_map<
         std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
         functions_of_time,
@@ -304,7 +306,7 @@ void strahlkorper_in_different_frame_aligned(
   }
   // Because center and angles are preserved by the map, we can easily
   // construct the destination Strahlkorper.
-  *dest_strahlkorper = Strahlkorper<DestFrame>(
+  *dest_strahlkorper = ylm::Strahlkorper<DestFrame>(
       src_strahlkorper.l_max(), src_strahlkorper.m_max(), get(radius), center);
 }
 
@@ -312,7 +314,8 @@ template <typename SrcFrame, typename DestFrame>
 void strahlkorper_coords_in_different_frame(
     const gsl::not_null<tnsr::I<DataVector, 3, DestFrame>*>
         dest_cartesian_coords,
-    const Strahlkorper<SrcFrame>& src_strahlkorper, const Domain<3>& domain,
+    const ylm::Strahlkorper<SrcFrame>& src_strahlkorper,
+    const Domain<3>& domain,
     const std::unordered_map<
         std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
         functions_of_time,
@@ -388,29 +391,31 @@ void strahlkorper_coords_in_different_frame(
 #define SRCFRAME(data) BOOST_PP_TUPLE_ELEM(0, data)
 #define DESTFRAME(data) BOOST_PP_TUPLE_ELEM(1, data)
 
-#define INSTANTIATEGENERAL(_, data)                                          \
-  template void strahlkorper_in_different_frame(                             \
-      const gsl::not_null<Strahlkorper<DESTFRAME(data)>*> dest_strahlkorper, \
-      const Strahlkorper<SRCFRAME(data)>& src_strahlkorper,                  \
-      const Domain<3>& domain,                                               \
-      const std::unordered_map<                                              \
-          std::string,                                                       \
-          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&         \
-          functions_of_time,                                                 \
+#define INSTANTIATEGENERAL(_, data)                                  \
+  template void strahlkorper_in_different_frame(                     \
+      const gsl::not_null<ylm::Strahlkorper<DESTFRAME(data)>*>       \
+          dest_strahlkorper,                                         \
+      const ylm::Strahlkorper<SRCFRAME(data)>& src_strahlkorper,     \
+      const Domain<3>& domain,                                       \
+      const std::unordered_map<                                      \
+          std::string,                                               \
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>& \
+          functions_of_time,                                         \
       const double time);
 
 GENERATE_INSTANTIATIONS(INSTANTIATEGENERAL, (::Frame::Grid),
                         (::Frame::Inertial))
 
-#define INSTANTIATEALIGNED(_, data)                                          \
-  template void strahlkorper_in_different_frame_aligned(                     \
-      const gsl::not_null<Strahlkorper<DESTFRAME(data)>*> dest_strahlkorper, \
-      const Strahlkorper<SRCFRAME(data)>& src_strahlkorper,                  \
-      const Domain<3>& domain,                                               \
-      const std::unordered_map<                                              \
-          std::string,                                                       \
-          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&         \
-          functions_of_time,                                                 \
+#define INSTANTIATEALIGNED(_, data)                                  \
+  template void strahlkorper_in_different_frame_aligned(             \
+      const gsl::not_null<ylm::Strahlkorper<DESTFRAME(data)>*>       \
+          dest_strahlkorper,                                         \
+      const ylm::Strahlkorper<SRCFRAME(data)>& src_strahlkorper,     \
+      const Domain<3>& domain,                                       \
+      const std::unordered_map<                                      \
+          std::string,                                               \
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>& \
+          functions_of_time,                                         \
       const double time);
 
 GENERATE_INSTANTIATIONS(INSTANTIATEALIGNED, (::Frame::Grid),
@@ -420,7 +425,7 @@ GENERATE_INSTANTIATIONS(INSTANTIATEALIGNED, (::Frame::Grid),
   template void strahlkorper_coords_in_different_frame(              \
       const gsl::not_null<tnsr::I<DataVector, 3, DESTFRAME(data)>*>  \
           dest_cartesian_coords,                                     \
-      const Strahlkorper<SRCFRAME(data)>& src_strahlkorper,          \
+      const ylm::Strahlkorper<SRCFRAME(data)>& src_strahlkorper,     \
       const Domain<3>& domain,                                       \
       const std::unordered_map<                                      \
           std::string,                                               \

--- a/src/Domain/StrahlkorperTransformations.hpp
+++ b/src/Domain/StrahlkorperTransformations.hpp
@@ -10,8 +10,10 @@
 #include "DataStructures/Tensor/TypeAliases.hpp"
 
 /// \cond
+namespace ylm {
 template <typename Frame>
 class Strahlkorper;
+}  // namespace ylm
 template <size_t Dim>
 class Domain;
 namespace domain::FunctionsOfTime {
@@ -44,8 +46,9 @@ class not_null;
 /// efficient.
 template <typename SrcFrame, typename DestFrame>
 void strahlkorper_in_different_frame(
-    gsl::not_null<Strahlkorper<DestFrame>*> dest_strahlkorper,
-    const Strahlkorper<SrcFrame>& src_strahlkorper, const Domain<3>& domain,
+    gsl::not_null<ylm::Strahlkorper<DestFrame>*> dest_strahlkorper,
+    const ylm::Strahlkorper<SrcFrame>& src_strahlkorper,
+    const Domain<3>& domain,
     const std::unordered_map<
         std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
         functions_of_time,
@@ -76,8 +79,9 @@ void strahlkorper_in_different_frame(
 /// constexpr`s to call the appropriate member functions of Block.
 template <typename SrcFrame, typename DestFrame>
 void strahlkorper_in_different_frame_aligned(
-    gsl::not_null<Strahlkorper<DestFrame>*> dest_strahlkorper,
-    const Strahlkorper<SrcFrame>& src_strahlkorper, const Domain<3>& domain,
+    gsl::not_null<ylm::Strahlkorper<DestFrame>*> dest_strahlkorper,
+    const ylm::Strahlkorper<SrcFrame>& src_strahlkorper,
+    const Domain<3>& domain,
     const std::unordered_map<
         std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
         functions_of_time,
@@ -102,7 +106,8 @@ void strahlkorper_in_different_frame_aligned(
 template <typename SrcFrame, typename DestFrame>
 void strahlkorper_coords_in_different_frame(
     gsl::not_null<tnsr::I<DataVector, 3, DestFrame>*> dest_cartesian_coords,
-    const Strahlkorper<SrcFrame>& src_strahlkorper, const Domain<3>& domain,
+    const ylm::Strahlkorper<SrcFrame>& src_strahlkorper,
+    const Domain<3>& domain,
     const std::unordered_map<
         std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
         functions_of_time,

--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/ElementActions/SendToWorldtube.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/ElementActions/SendToWorldtube.hpp
@@ -195,7 +195,7 @@ struct SendToWorldtube {
       // project onto spherical harmonics
       for (size_t l = 0; l <= order; ++l) {
         for (int m = -l; m <= static_cast<int>(l); ++m, ++index) {
-          spherical_harmonic = real_spherical_harmonic(theta, phi, l, m);
+          spherical_harmonic = ylm::real_spherical_harmonic(theta, phi, l, m);
           get(get<CurvedScalarWave::Tags::Psi>(Ylm_coefs)).at(index) =
               definite_integral(psi_regular_times_det * spherical_harmonic,
                                 face_mesh);

--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonActions/ReceiveElementData.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonActions/ReceiveElementData.hpp
@@ -123,21 +123,21 @@ struct ReceiveElementData {
       ModalVector dt_psi_ylm_l1(&dt_psi_ylm_coefs[1], 3);
       psi_ylm_l1 /= wt_radius;
       dt_psi_ylm_l1 /= wt_radius;
-      psi_stf_l1 = ylm_to_stf_1<Frame::Grid>(psi_ylm_l1);
-      dt_psi_stf_l1 = ylm_to_stf_1<Frame::Grid>(dt_psi_ylm_l1);
+      psi_stf_l1 = ylm::ylm_to_stf_1<Frame::Grid>(psi_ylm_l1);
+      dt_psi_stf_l1 = ylm::ylm_to_stf_1<Frame::Grid>(dt_psi_ylm_l1);
       if (order > 1) {
         ModalVector psi_ylm_l2(&psi_ylm_coefs[4], 5);
         ModalVector dt_psi_ylm_l2(&dt_psi_ylm_coefs[4], 5);
         psi_ylm_l2 /= wt_radius * wt_radius;
         dt_psi_ylm_l2 /= wt_radius * wt_radius;
-        psi_stf_l2 = ylm_to_stf_2<Frame::Grid>(psi_ylm_l2);
-        dt_psi_stf_l2 = ylm_to_stf_2<Frame::Grid>(dt_psi_ylm_l2);
+        psi_stf_l2 = ylm::ylm_to_stf_2<Frame::Grid>(psi_ylm_l2);
+        dt_psi_stf_l2 = ylm::ylm_to_stf_2<Frame::Grid>(dt_psi_ylm_l2);
       }
     }
 
     ::Initialization::mutate_assign<simple_tags>(
-        make_not_null(&box), ylm_to_stf_0(psi_ylm_l0),
-        ylm_to_stf_0(dt_psi_ylm_l0), std::move(psi_stf_l1),
+        make_not_null(&box), ylm::ylm_to_stf_0(psi_ylm_l0),
+        ylm::ylm_to_stf_0(dt_psi_ylm_l0), std::move(psi_stf_l1),
         std::move(dt_psi_stf_l1), std::move(psi_stf_l2),
         std::move(dt_psi_stf_l2));
     inbox.erase(time_step_id);

--- a/src/NumericalAlgorithms/SphericalHarmonics/ChangeCenterOfStrahlkorper.cpp
+++ b/src/NumericalAlgorithms/SphericalHarmonics/ChangeCenterOfStrahlkorper.cpp
@@ -15,6 +15,7 @@
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeWithValue.hpp"
 
+namespace ylm {
 namespace {
 
 // Get the r_hat vector of the Strahlkorper, which defines the
@@ -152,3 +153,4 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (::Frame::Inertial))
 
 #undef INSTANTIATE
 #undef FRAME
+}  // namespace ylm

--- a/src/NumericalAlgorithms/SphericalHarmonics/ChangeCenterOfStrahlkorper.hpp
+++ b/src/NumericalAlgorithms/SphericalHarmonics/ChangeCenterOfStrahlkorper.hpp
@@ -6,14 +6,17 @@
 #include <array>
 
 /// \cond
+namespace ylm {
 template <typename Frame>
 class Strahlkorper;
+}  // namespace ylm
 namespace gsl {
 template <typename T>
 class not_null;
 }  // namespace gsl
 /// \endcond
 
+namespace ylm {
 /// Changes the expansion center of a Strahlkorper, where the
 /// expansion center is defined as the point about which the spectral
 /// basis of the Strahlkorper is expanded, which is the quantity
@@ -33,3 +36,4 @@ void change_expansion_center_of_strahlkorper(
 template <typename Frame>
 void change_expansion_center_of_strahlkorper_to_physical(
     gsl::not_null<Strahlkorper<Frame>*> strahlkorper);
+}  // namespace ylm

--- a/src/NumericalAlgorithms/SphericalHarmonics/RealSphericalHarmonics.cpp
+++ b/src/NumericalAlgorithms/SphericalHarmonics/RealSphericalHarmonics.cpp
@@ -10,6 +10,7 @@
 #include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/Gsl.hpp"
 
+namespace ylm {
 void real_spherical_harmonic(gsl::not_null<DataVector*> spherical_harmonic,
                              const DataVector& theta, const DataVector& phi,
                              size_t l, int m) {
@@ -40,3 +41,4 @@ DataVector real_spherical_harmonic(const DataVector& theta,
   real_spherical_harmonic(make_not_null(&result), theta, phi, l, m);
   return result;
 }
+}  // namespace ylm

--- a/src/NumericalAlgorithms/SphericalHarmonics/RealSphericalHarmonics.hpp
+++ b/src/NumericalAlgorithms/SphericalHarmonics/RealSphericalHarmonics.hpp
@@ -8,6 +8,7 @@
 #include "DataStructures/DataVector.hpp"
 #include "Utilities/Gsl.hpp"
 
+namespace ylm {
 /// @{
 /*!
  * \ingroup SpectralGroup
@@ -39,3 +40,4 @@ void real_spherical_harmonic(gsl::not_null<DataVector*> spherical_harmonic,
 DataVector real_spherical_harmonic(const DataVector& theta,
                                    const DataVector& phi, size_t l, int m);
 /// @}
+}  // namespace ylm

--- a/src/NumericalAlgorithms/SphericalHarmonics/SpherepackIterator.cpp
+++ b/src/NumericalAlgorithms/SphericalHarmonics/SpherepackIterator.cpp
@@ -73,6 +73,7 @@
 
 #include "NumericalAlgorithms/SphericalHarmonics/SpherepackIterator.hpp"
 
+namespace ylm {
 SpherepackIterator::SpherepackIterator(const size_t l_max_input,
                                        const size_t m_max_input,
                                        const size_t stride /*=1*/)
@@ -192,3 +193,4 @@ SpherepackIterator& SpherepackIterator::set(const size_t compact_index) {
   current_compact_index_ = compact_index;
   return *this;
 }
+}  // namespace ylm

--- a/src/NumericalAlgorithms/SphericalHarmonics/SpherepackIterator.hpp
+++ b/src/NumericalAlgorithms/SphericalHarmonics/SpherepackIterator.hpp
@@ -15,6 +15,7 @@
 
 #include "Utilities/ErrorHandling/Assert.hpp"
 
+namespace ylm {
 /*!
  * \ingroup SpectralGroup
  * \brief
@@ -159,3 +160,4 @@ inline std::ostream& operator<<(
                     ? 'a'
                     : 'b');
 }
+}  // namespace ylm

--- a/src/NumericalAlgorithms/SphericalHarmonics/Strahlkorper.cpp
+++ b/src/NumericalAlgorithms/SphericalHarmonics/Strahlkorper.cpp
@@ -17,6 +17,7 @@ struct Distorted;
 struct Inertial;
 }  // namespace Frame
 
+namespace ylm {
 template <typename Frame>
 Strahlkorper<Frame>::Strahlkorper(const size_t l_max, const size_t m_max,
                                   const double radius,
@@ -144,3 +145,4 @@ bool Strahlkorper<Frame>::point_is_contained(
 template class Strahlkorper<Frame::Inertial>;
 template class Strahlkorper<Frame::Grid>;
 template class Strahlkorper<Frame::Distorted>;
+}  // namespace ylm

--- a/src/NumericalAlgorithms/SphericalHarmonics/Strahlkorper.hpp
+++ b/src/NumericalAlgorithms/SphericalHarmonics/Strahlkorper.hpp
@@ -11,10 +11,13 @@
 #include "Options/String.hpp"
 #include "Utilities/ForceInline.hpp"
 
+/// \cond
 namespace PUP {
 class er;
 }  // namespace PUP
+/// \endcond
 
+namespace ylm {
 /// \ingroup SurfacesGroup
 /// \brief A star-shaped surface expanded in spherical harmonics.
 template <typename Frame>
@@ -170,7 +173,7 @@ namespace OptionTags {
 /// The input file tag for a Strahlkorper.
 template <typename Frame>
 struct Strahlkorper {
-  using type = ::Strahlkorper<Frame>;
+  using type = ylm::Strahlkorper<Frame>;
   static constexpr Options::String help{"A star-shaped surface"};
 };
 } // namespace OptionTags
@@ -188,3 +191,4 @@ bool operator!=(const Strahlkorper<Frame>& lhs,
                 const Strahlkorper<Frame>& rhs) {
   return not(lhs == rhs);
 }
+}  // namespace ylm

--- a/src/NumericalAlgorithms/SphericalHarmonics/StrahlkorperFunctions.cpp
+++ b/src/NumericalAlgorithms/SphericalHarmonics/StrahlkorperFunctions.cpp
@@ -35,7 +35,7 @@ void radius(const gsl::not_null<Scalar<DataVector>*> result,
 
 template <typename Fr>
 tnsr::i<DataVector, 2, ::Frame::Spherical<Fr>> theta_phi(
-    const ::Strahlkorper<Fr>& strahlkorper) {
+    const Strahlkorper<Fr>& strahlkorper) {
   tnsr::i<DataVector, 2, ::Frame::Spherical<Fr>> result{
       DataVector{strahlkorper.ylm_spherepack().physical_size()}};
   theta_phi(make_not_null(&result), strahlkorper);
@@ -46,7 +46,7 @@ template <typename Fr>
 void theta_phi(
     const gsl::not_null<tnsr::i<DataVector, 2, ::Frame::Spherical<Fr>>*>
         theta_phi,
-    const ::Strahlkorper<Fr>& strahlkorper) {
+    const Strahlkorper<Fr>& strahlkorper) {
   // If ylm_spherepack ever gets a not-null version of theta_phi_points,
   // then that can be used here to avoid an allocation.
   auto temp = strahlkorper.ylm_spherepack().theta_phi_points();
@@ -368,7 +368,7 @@ void laplacian_of_scalar(
 
 template <typename Fr>
 ylm::Tags::aliases::Jacobian<Fr> tangents(
-    const ::Strahlkorper<Fr>& strahlkorper, const Scalar<DataVector>& radius,
+    const Strahlkorper<Fr>& strahlkorper, const Scalar<DataVector>& radius,
     const tnsr::i<DataVector, 3, Fr>& r_hat,
     const ylm::Tags::aliases::Jacobian<Fr>& jac) {
   ylm::Tags::aliases::Jacobian<Fr> result{DataVector{get(radius).size()}};
@@ -378,7 +378,7 @@ ylm::Tags::aliases::Jacobian<Fr> tangents(
 
 template <typename Fr>
 void tangents(const gsl::not_null<ylm::Tags::aliases::Jacobian<Fr>*> result,
-              const ::Strahlkorper<Fr>& strahlkorper,
+              const Strahlkorper<Fr>& strahlkorper,
               const Scalar<DataVector>& radius,
               const tnsr::i<DataVector, 3, Fr>& r_hat,
               const ylm::Tags::aliases::Jacobian<Fr>& jac) {
@@ -453,7 +453,7 @@ static DataVector compute_coefs(
 template <typename Frame>
 void time_deriv_of_strahlkorper(
     gsl::not_null<Strahlkorper<Frame>*> time_deriv,
-    const std::deque<std::pair<double, ::Strahlkorper<Frame>>>&
+    const std::deque<std::pair<double, Strahlkorper<Frame>>>&
         previous_strahlkorpers) {
   std::deque<double> times{};
   std::deque<const DataVector*> coefficients{};
@@ -491,7 +491,6 @@ void time_deriv_of_strahlkorper(
 
   time_deriv->coefficients() = std::move(new_coefficients);
 }
-}  // namespace ylm
 
 #define FRAME(data) BOOST_PP_TUPLE_ELEM(0, data)
 
@@ -501,12 +500,12 @@ void time_deriv_of_strahlkorper(
   template void ylm::radius(const gsl::not_null<Scalar<DataVector>*> result,  \
                             const Strahlkorper<FRAME(data)>& strahlkorper);   \
   template tnsr::i<DataVector, 2, ::Frame::Spherical<FRAME(data)>>            \
-  ylm::theta_phi(const ::Strahlkorper<FRAME(data)>& strahlkorper);            \
+  ylm::theta_phi(const Strahlkorper<FRAME(data)>& strahlkorper);              \
   template void ylm::theta_phi(                                               \
       const gsl::not_null<                                                    \
           tnsr::i<DataVector, 2, ::Frame::Spherical<FRAME(data)>>*>           \
           theta_phi,                                                          \
-      const ::Strahlkorper<FRAME(data)>& strahlkorper);                       \
+      const Strahlkorper<FRAME(data)>& strahlkorper);                         \
   template tnsr::i<DataVector, 3, FRAME(data)> ylm::rhat(                     \
       const tnsr::i<DataVector, 2, ::Frame::Spherical<FRAME(data)>>&          \
           theta_phi);                                                         \
@@ -606,10 +605,11 @@ void time_deriv_of_strahlkorper(
       const std::vector<Strahlkorper<FRAME(data)>>& strahlkorpers);           \
   template void ylm::time_deriv_of_strahlkorper(                              \
       const gsl::not_null<Strahlkorper<FRAME(data)>*>,                        \
-      const std::deque<std::pair<double, ::Strahlkorper<FRAME(data)>>>&);
+      const std::deque<std::pair<double, Strahlkorper<FRAME(data)>>>&);
 
 GENERATE_INSTANTIATIONS(INSTANTIATE,
                         (Frame::Distorted, Frame::Grid, Frame::Inertial))
 
 #undef INSTANTIATE
 #undef FRAME
+}  // namespace ylm

--- a/src/NumericalAlgorithms/SphericalHarmonics/StrahlkorperFunctions.hpp
+++ b/src/NumericalAlgorithms/SphericalHarmonics/StrahlkorperFunctions.hpp
@@ -12,13 +12,12 @@
 
 /// \cond
 class DataVector;
-
+namespace ylm {
 template <typename Fr>
 class Strahlkorper;
-
+}  // namespace ylm
 template <typename X, typename Symm, typename IndexList>
 class Tensor;
-
 namespace gsl {
 template <typename>
 struct not_null;
@@ -39,13 +38,13 @@ namespace ylm {
  */
 template <typename Fr>
 tnsr::i<DataVector, 2, ::Frame::Spherical<Fr>> theta_phi(
-    const ::Strahlkorper<Fr>& strahlkorper);
+    const Strahlkorper<Fr>& strahlkorper);
 
 template <typename Fr>
 void theta_phi(
     const gsl::not_null<tnsr::i<DataVector, 2, ::Frame::Spherical<Fr>>*>
         theta_phi,
-    const ::Strahlkorper<Fr>& strahlkorper);
+    const Strahlkorper<Fr>& strahlkorper);
 /// @}
 
 /// @{
@@ -294,7 +293,7 @@ void laplacian_of_scalar(
  */
 template <typename Fr>
 ylm::Tags::aliases::Jacobian<Fr> tangents(
-    const ::Strahlkorper<Fr>& strahlkorper, const Scalar<DataVector>& radius,
+    const Strahlkorper<Fr>& strahlkorper, const Scalar<DataVector>& radius,
     const tnsr::i<DataVector, 3, Fr>& r_hat,
     const ylm::Tags::aliases::Jacobian<Fr>& jac);
 
@@ -309,7 +308,7 @@ ylm::Tags::aliases::Jacobian<Fr> tangents(
  */
 template <typename Fr>
 void tangents(const gsl::not_null<ylm::Tags::aliases::Jacobian<Fr>*> result,
-              const ::Strahlkorper<Fr>& strahlkorper,
+              const Strahlkorper<Fr>& strahlkorper,
               const Scalar<DataVector>& radius,
               const tnsr::i<DataVector, 3, Fr>& r_hat,
               const ylm::Tags::aliases::Jacobian<Fr>& jac);
@@ -386,6 +385,6 @@ std::vector<std::array<double, 4>> fit_ylm_coeffs(
 template <typename Frame>
 void time_deriv_of_strahlkorper(
     gsl::not_null<Strahlkorper<Frame>*> time_deriv,
-    const std::deque<std::pair<double, ::Strahlkorper<Frame>>>&
+    const std::deque<std::pair<double, Strahlkorper<Frame>>>&
         previous_strahlkorpers);
 }  // namespace ylm

--- a/src/NumericalAlgorithms/SphericalHarmonics/Tags.cpp
+++ b/src/NumericalAlgorithms/SphericalHarmonics/Tags.cpp
@@ -20,7 +20,7 @@ namespace ylm::Tags {
 template <typename Frame>
 void PhysicalCenterCompute<Frame>::function(
     const gsl::not_null<std::array<double, 3>*> physical_center,
-    const ::Strahlkorper<Frame>& strahlkorper) {
+    const ylm::Strahlkorper<Frame>& strahlkorper) {
   *physical_center = strahlkorper.physical_center();
 }
 

--- a/src/NumericalAlgorithms/SphericalHarmonics/Tags.hpp
+++ b/src/NumericalAlgorithms/SphericalHarmonics/Tags.hpp
@@ -21,13 +21,13 @@
 #include "Utilities/TMPL.hpp"
 
 /// \ingroup SurfacesGroup
-/// Holds tags and ComputeItems associated with a `::Strahlkorper`.
+/// Holds tags and ComputeItems associated with a `ylm::Strahlkorper`.
 namespace ylm::Tags {
 
-/// Tag referring to a `::Strahlkorper`
+/// Tag referring to a `ylm::Strahlkorper`
 template <typename Frame>
 struct Strahlkorper : db::SimpleTag {
-  using type = ::Strahlkorper<Frame>;
+  using type = ylm::Strahlkorper<Frame>;
 };
 
 /// @{
@@ -44,7 +44,7 @@ struct ThetaPhiCompute : ThetaPhi<Frame>, db::ComputeTag {
   using return_type = tnsr::i<DataVector, 2, ::Frame::Spherical<Frame>>;
   static constexpr auto function = static_cast<void (*)(
       const gsl::not_null<tnsr::i<DataVector, 2, ::Frame::Spherical<Frame>>*>,
-      const ::Strahlkorper<Frame>&)>(&::ylm::theta_phi<Frame>);
+      const ylm::Strahlkorper<Frame>&)>(&::ylm::theta_phi<Frame>);
   using argument_tags = tmpl::list<Strahlkorper<Frame>>;
 };
 /// @}
@@ -148,16 +148,17 @@ template <typename Frame>
 struct RadiusCompute : Radius<Frame>, db::ComputeTag {
   using base = Radius<Frame>;
   using return_type = Scalar<DataVector>;
-  static constexpr auto function = static_cast<void (*)(
-      const gsl::not_null<Scalar<DataVector>*>, const ::Strahlkorper<Frame>&)>(
-      &(::ylm::radius<Frame>));
+  static constexpr auto function =
+      static_cast<void (*)(const gsl::not_null<Scalar<DataVector>*>,
+                           const ylm::Strahlkorper<Frame>&)>(
+          &(::ylm::radius<Frame>));
   using argument_tags = tmpl::list<Strahlkorper<Frame>>;
 };
 /// @}
 
 /// @{
 /// The geometrical center of the surface.  Uses
-/// `Strahlkorper::physical_center`.
+/// `ylm::Strahlkorper::physical_center`.
 template <typename Frame>
 struct PhysicalCenter : db::SimpleTag {
   using type = std::array<double, 3>;
@@ -168,7 +169,7 @@ struct PhysicalCenterCompute : PhysicalCenter<Frame>, db::ComputeTag {
   using base = PhysicalCenter<Frame>;
   using return_type = std::array<double, 3>;
   static void function(gsl::not_null<std::array<double, 3>*> physical_center,
-                       const ::Strahlkorper<Frame>& strahlkorper);
+                       const ylm::Strahlkorper<Frame>& strahlkorper);
   using argument_tags = tmpl::list<Strahlkorper<Frame>>;
 };
 /// @}
@@ -188,7 +189,7 @@ struct CartesianCoordsCompute : CartesianCoords<Frame>, db::ComputeTag {
   using return_type = tnsr::I<DataVector, 3, Frame>;
   static constexpr auto function = static_cast<void (*)(
       const gsl::not_null<tnsr::I<DataVector, 3, Frame>*> coords,
-      const ::Strahlkorper<Frame>& strahlkorper,
+      const ylm::Strahlkorper<Frame>& strahlkorper,
       const Scalar<DataVector>& radius,
       const tnsr::i<DataVector, 3, Frame>& r_hat)>(&ylm::cartesian_coords);
   using argument_tags =
@@ -215,7 +216,7 @@ struct DxRadiusCompute : DxRadius<Frame>, db::ComputeTag {
   static constexpr auto function = static_cast<void (*)(
       const gsl::not_null<tnsr::i<DataVector, 3, Frame>*> dx_radius,
       const Scalar<DataVector>& scalar,
-      const ::Strahlkorper<Frame>& strahlkorper,
+      const ylm::Strahlkorper<Frame>& strahlkorper,
       const Scalar<DataVector>& radius_of_strahlkorper,
       const aliases::InvJacobian<Frame>& inv_jac)>(
       &ylm::cartesian_derivs_of_scalar);
@@ -244,7 +245,7 @@ struct D2xRadiusCompute : D2xRadius<Frame>, db::ComputeTag {
   static constexpr auto function = static_cast<void (*)(
       gsl::not_null<tnsr::ii<DataVector, 3, Frame>*> d2x_radius,
       const Scalar<DataVector>& scalar,
-      const ::Strahlkorper<Frame>& strahlkorper,
+      const ylm::Strahlkorper<Frame>& strahlkorper,
       const Scalar<DataVector>& radius_of_strahlkorper,
       const aliases::InvJacobian<Frame>& inv_jac,
       const aliases::InvHessian<Frame>& inv_hess)>(
@@ -271,7 +272,7 @@ struct LaplacianRadiusCompute : LaplacianRadius<Frame>, db::ComputeTag {
   static constexpr auto function = static_cast<void (*)(
       gsl::not_null<Scalar<DataVector>*> lap_radius,
       const Scalar<DataVector>& radius,
-      const ::Strahlkorper<Frame>& strahlkorper,
+      const ylm::Strahlkorper<Frame>& strahlkorper,
       const tnsr::i<DataVector, 2, ::Frame::Spherical<Frame>>& theta_phi)>(
       &ylm::laplacian_of_scalar);
   using argument_tags =
@@ -333,7 +334,7 @@ struct TangentsCompute : Tangents<Frame>, db::ComputeTag {
   using return_type = aliases::Jacobian<Frame>;
   static constexpr auto function =
       static_cast<void (*)(gsl::not_null<aliases::Jacobian<Frame>*> tangents,
-                           const ::Strahlkorper<Frame>& strahlkorper,
+                           const ylm::Strahlkorper<Frame>& strahlkorper,
                            const Scalar<DataVector>& radius,
                            const tnsr::i<DataVector, 3, Frame>& r_hat,
                            const aliases::Jacobian<Frame>& jac)>(
@@ -348,7 +349,7 @@ struct TangentsCompute : Tangents<Frame>, db::ComputeTag {
 /// and for computing the time deriv of a Strahlkorper.
 template <typename Frame>
 struct PreviousStrahlkorpers : db::SimpleTag {
-  using type = std::deque<std::pair<double, ::Strahlkorper<Frame>>>;
+  using type = std::deque<std::pair<double, ylm::Strahlkorper<Frame>>>;
 };
 
 /// @{
@@ -356,7 +357,7 @@ struct PreviousStrahlkorpers : db::SimpleTag {
 /// from a number of previous Strahlkorpers.
 template <typename Frame>
 struct TimeDerivStrahlkorper : db::SimpleTag {
-  using type = ::Strahlkorper<Frame>;
+  using type = ylm::Strahlkorper<Frame>;
 };
 
 template <typename Frame>
@@ -365,8 +366,8 @@ struct TimeDerivStrahlkorperCompute : db::ComputeTag,
   using base = TimeDerivStrahlkorper<Frame>;
   using return_type = typename base::type;
   static constexpr auto function = static_cast<void (*)(
-      gsl::not_null<::Strahlkorper<Frame>*>,
-      const std::deque<std::pair<double, ::Strahlkorper<Frame>>>&)>(
+      gsl::not_null<ylm::Strahlkorper<Frame>*>,
+      const std::deque<std::pair<double, ylm::Strahlkorper<Frame>>>&)>(
       &ylm::time_deriv_of_strahlkorper<Frame>);
 
   using argument_tags = tmpl::list<PreviousStrahlkorpers<Frame>>;

--- a/src/NumericalAlgorithms/SphericalHarmonics/YlmToStf.cpp
+++ b/src/NumericalAlgorithms/SphericalHarmonics/YlmToStf.cpp
@@ -11,6 +11,7 @@
 #include "Parallel/Printf.hpp"
 #include "Utilities/TMPL.hpp"
 
+namespace ylm {
 Scalar<double> ylm_to_stf_0(const ModalVector& l0_coefs) {
   ASSERT(l0_coefs.size() == 1,
          "Expected 1 spherical harmonic coefficient for l=0");
@@ -57,3 +58,4 @@ template tnsr::ii<double, 3, Frame::Grid> ylm_to_stf_2<Frame::Grid>(
     const ModalVector& l2_coefs);
 template tnsr::ii<double, 3, Frame::Inertial> ylm_to_stf_2<Frame::Inertial>(
     const ModalVector& l2_coefs);
+}  // namespace ylm

--- a/src/NumericalAlgorithms/SphericalHarmonics/YlmToStf.hpp
+++ b/src/NumericalAlgorithms/SphericalHarmonics/YlmToStf.hpp
@@ -9,6 +9,7 @@
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Utilities/TMPL.hpp"
 
+namespace ylm {
 /// @{
 /*!
  * \brief Converts real spherical harmonic coefficients of degree l into a
@@ -31,3 +32,4 @@ tnsr::i<double, 3, Frame> ylm_to_stf_1(const ModalVector& l1_coefs);
 template <typename Frame>
 tnsr::ii<double, 3, Frame> ylm_to_stf_2(const ModalVector& l2_coefs);
 /// @}
+}  // namespace ylm

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/Callbacks/FindApparentHorizon.hpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/Callbacks/FindApparentHorizon.hpp
@@ -51,8 +51,6 @@ template <typename Metavariables>
 struct TemporalIds;
 }  // namespace Tags
 }  // namespace intrp
-template <typename Frame>
-class Strahlkorper;
 /// \endcond
 
 namespace intrp {
@@ -167,9 +165,9 @@ struct FindApparentHorizon
       db::mutate<ylm::Tags::Strahlkorper<Frame>,
                  ylm::Tags::PreviousStrahlkorpers<Frame>>(
           [&temporal_id](
-              const gsl::not_null<::Strahlkorper<Frame>*> strahlkorper,
+              const gsl::not_null<ylm::Strahlkorper<Frame>*> strahlkorper,
               const gsl::not_null<
-                  std::deque<std::pair<double, ::Strahlkorper<Frame>>>*>
+                  std::deque<std::pair<double, ylm::Strahlkorper<Frame>>>*>
                   previous_strahlkorpers) {
             // If we have zero previous_strahlkorpers, then the
             // initial guess is already in strahlkorper, so do
@@ -238,7 +236,7 @@ struct FindApparentHorizon
       db::mutate<::ah::Tags::FastFlow, ylm::Tags::Strahlkorper<Frame>>(
           [&inv_g, &ex_curv, &christoffel, &status_and_info](
               const gsl::not_null<::FastFlow*> fast_flow,
-              const gsl::not_null<::Strahlkorper<Frame>*> strahlkorper) {
+              const gsl::not_null<ylm::Strahlkorper<Frame>*> strahlkorper) {
             status_and_info = fast_flow->template iterate_horizon_finder<Frame>(
                 strahlkorper, inv_g, ex_curv, christoffel);
           },
@@ -287,8 +285,8 @@ struct FindApparentHorizon
     // it's previous value
     if (horizon_finder_failed) {
       db::mutate<ylm::Tags::Strahlkorper<Frame>>(
-          [](const gsl::not_null<::Strahlkorper<Frame>*> strahlkorper,
-             const std::deque<std::pair<double, ::Strahlkorper<Frame>>>&
+          [](const gsl::not_null<ylm::Strahlkorper<Frame>*> strahlkorper,
+             const std::deque<std::pair<double, ylm::Strahlkorper<Frame>>>&
                  previous_strahlkorpers) {
             // Don't keep a partially-converged strahlkorper in the
             // DataBox.  Reset to either the original initial guess or
@@ -312,11 +310,11 @@ struct FindApparentHorizon
           tmpl::list<::Tags::Variables<vars_tags>>,
           tmpl::list<ylm::Tags::Strahlkorper<Frame>, ::ah::Tags::FastFlow>>(
           [](const gsl::not_null<Variables<vars_tags>*> vars,
-             const Strahlkorper<Frame>& strahlkorper,
+             const ylm::Strahlkorper<Frame>& strahlkorper,
              const FastFlow& fast_flow) {
             const size_t L_mesh = fast_flow.current_l_mesh(strahlkorper);
             const auto prolonged_strahlkorper =
-                Strahlkorper<Frame>(L_mesh, L_mesh, strahlkorper);
+                ylm::Strahlkorper<Frame>(L_mesh, L_mesh, strahlkorper);
             auto new_vars = ::Variables<vars_tags>(
                 strahlkorper.ylm_spherepack().physical_size());
 
@@ -350,7 +348,7 @@ struct FindApparentHorizon
             [&cache, &temporal_id](
                 const gsl::not_null<tnsr::I<DataVector, 3, ::Frame::Inertial>*>
                     inertial_strahlkorper_coords,
-                const Strahlkorper<Frame>& strahlkorper,
+                const ylm::Strahlkorper<Frame>& strahlkorper,
                 const Domain<Metavariables::volume_dim>& domain) {
               // Note that functions_of_time must already be up to
               // date at temporal_id because they were used in the AH
@@ -372,9 +370,9 @@ struct FindApparentHorizon
       db::mutate<ylm::Tags::Strahlkorper<Frame>,
                  ylm::Tags::PreviousStrahlkorpers<Frame>>(
           [&temporal_id](
-              const gsl::not_null<::Strahlkorper<Frame>*> strahlkorper,
+              const gsl::not_null<ylm::Strahlkorper<Frame>*> strahlkorper,
               const gsl::not_null<
-                  std::deque<std::pair<double, ::Strahlkorper<Frame>>>*>
+                  std::deque<std::pair<double, ylm::Strahlkorper<Frame>>>*>
                   previous_strahlkorpers) {
             // This is the number of previous strahlkorpers that we
             // keep around.

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/FastFlow.hpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/FastFlow.hpp
@@ -23,8 +23,10 @@ namespace gsl {
 template <class T>
 class not_null;
 }  // namespace gsl
+namespace ylm {
 template <typename>
 class Strahlkorper;
+}  // namespace ylm
 /// \endcond
 
 /// \ingroup SurfacesGroup
@@ -164,7 +166,7 @@ class FastFlow {
   /// nor `current_iteration()` is changed.
   template <typename Frame>
   std::pair<Status, IterInfo> iterate_horizon_finder(
-      gsl::not_null<Strahlkorper<Frame>*> current_strahlkorper,
+      gsl::not_null<ylm::Strahlkorper<Frame>*> current_strahlkorper,
       const tnsr::II<DataVector, 3, Frame>& upper_spatial_metric,
       const tnsr::ii<DataVector, 3, Frame>& extrinsic_curvature,
       const tnsr::Ijj<DataVector, 3, Frame>& christoffel_2nd_kind);
@@ -175,7 +177,7 @@ class FastFlow {
   /// l_surface, returns a larger value of l, l_mesh, that is used for
   /// evaluating convergence.
   template <typename Frame>
-  size_t current_l_mesh(const Strahlkorper<Frame>& strahlkorper) const;
+  size_t current_l_mesh(const ylm::Strahlkorper<Frame>& strahlkorper) const;
 
   /// Resets the finder.
   SPECTRE_ALWAYS_INLINE void reset_for_next_find() {

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/InterpolationTarget.cpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/InterpolationTarget.cpp
@@ -14,9 +14,9 @@ struct Inertial;
 
 namespace intrp::OptionHolders {
 template <typename Frame>
-ApparentHorizon<Frame>::ApparentHorizon(Strahlkorper<Frame> initial_guess_in,
-                                        ::FastFlow fast_flow_in,
-                                        ::Verbosity verbosity_in)
+ApparentHorizon<Frame>::ApparentHorizon(
+    ylm::Strahlkorper<Frame> initial_guess_in, ::FastFlow fast_flow_in,
+    ::Verbosity verbosity_in)
     : initial_guess(std::move(initial_guess_in)),
       fast_flow(std::move(fast_flow_in)),    // NOLINT
       verbosity(std::move(verbosity_in)) {}  // NOLINT

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/InterpolationTarget.hpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/InterpolationTarget.hpp
@@ -58,7 +58,7 @@ struct ApparentHorizon {
   /// See Strahlkorper for suboptions.
   struct InitialGuess {
     static constexpr Options::String help = {"Initial guess"};
-    using type = Strahlkorper<Frame>;
+    using type = ylm::Strahlkorper<Frame>;
   };
   /// See ::FastFlow for suboptions.
   struct FastFlow {
@@ -75,8 +75,8 @@ struct ApparentHorizon {
       "(Strahlkorper) and apparent-horizon-finding-algorithm (FastFlow)\n"
       "options."};
 
-  ApparentHorizon(Strahlkorper<Frame> initial_guess_in, ::FastFlow fast_flow_in,
-                  ::Verbosity verbosity_in);
+  ApparentHorizon(ylm::Strahlkorper<Frame> initial_guess_in,
+                  ::FastFlow fast_flow_in, ::Verbosity verbosity_in);
 
   ApparentHorizon() = default;
   ApparentHorizon(const ApparentHorizon& /*rhs*/) = default;
@@ -88,7 +88,7 @@ struct ApparentHorizon {
   // NOLINTNEXTLINE(google-runtime-references)
   void pup(PUP::er& p);
 
-  Strahlkorper<Frame> initial_guess{};
+  ylm::Strahlkorper<Frame> initial_guess{};
   ::FastFlow fast_flow{};
   ::Verbosity verbosity{::Verbosity::Quiet};
 };
@@ -185,7 +185,7 @@ struct ApparentHorizon : tt::ConformsTo<intrp::protocols::ComputeTargetPoints> {
     // here for ylm::Tags::Strahlkorper<::Frame::Inertial>.
     Initialization::mutate_assign<common_tags>(
         box, options.initial_guess, options.fast_flow, options.verbosity,
-        std::deque<std::pair<double, ::Strahlkorper<Frame>>>{std::make_pair(
+        std::deque<std::pair<double, ylm::Strahlkorper<Frame>>>{std::make_pair(
             std::numeric_limits<double>::quiet_NaN(), options.initial_guess)});
   }
 
@@ -199,7 +199,7 @@ struct ApparentHorizon : tt::ConformsTo<intrp::protocols::ComputeTargetPoints> {
 
     const size_t L_mesh = fast_flow.current_l_mesh(strahlkorper);
     const auto prolonged_strahlkorper =
-        Strahlkorper<Frame>(L_mesh, L_mesh, strahlkorper);
+        ylm::Strahlkorper<Frame>(L_mesh, L_mesh, strahlkorper);
 
     Variables<tmpl::list<::Tags::Tempi<0, 2, ::Frame::Spherical<Frame>>,
                          ::Tags::Tempi<1, 3, Frame>, ::Tags::TempScalar<2>>>

--- a/src/ParallelAlgorithms/Interpolation/Callbacks/ObserveSurfaceData.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Callbacks/ObserveSurfaceData.hpp
@@ -59,8 +59,7 @@ struct ObserveSurfaceData
   static void apply(const db::DataBox<DbTags>& box,
                     Parallel::GlobalCache<Metavariables>& cache,
                     const TemporalId& temporal_id) {
-    const Strahlkorper<HorizonFrame>& strahlkorper =
-        get<ylm::Tags::Strahlkorper<HorizonFrame>>(box);
+    const auto& strahlkorper = get<ylm::Tags::Strahlkorper<HorizonFrame>>(box);
     const ylm::Spherepack& ylm = strahlkorper.ylm_spherepack();
 
     // Output the inertial-frame coordinates of the Stralhlkorper.

--- a/src/ParallelAlgorithms/Interpolation/Targets/KerrHorizon.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Targets/KerrHorizon.hpp
@@ -170,7 +170,7 @@ struct KerrHorizon : tt::ConformsTo<intrp::protocols::ComputeTargetPoints> {
         Parallel::get<Tags::KerrHorizon<InterpolationTargetTag>>(cache);
 
     // Make a Strahlkorper with the correct shape.
-    ::Strahlkorper<Frame> strahlkorper(
+    ylm::Strahlkorper<Frame> strahlkorper(
         kerr_horizon.l_max, kerr_horizon.l_max,
         get(gr::Solutions::kerr_horizon_radius(
             ::ylm::Spherepack(kerr_horizon.l_max, kerr_horizon.l_max)

--- a/src/ParallelAlgorithms/Interpolation/Targets/Sphere.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Targets/Sphere.hpp
@@ -164,13 +164,13 @@ struct Sphere : tt::ConformsTo<intrp::protocols::ComputeTargetPoints> {
 
     size_t index = 0;
     for (const double radius : radii) {
-      ::Strahlkorper<Frame> strahlkorper(
+      ylm::Strahlkorper<Frame> strahlkorper(
           l_max, l_max, DataVector{(l_max + 1) * (2 * l_max + 1), radius},
           sphere.center);
 
       db::mutate<ylm::Tags::Strahlkorper<Frame>>(
-          [&strahlkorper](
-              const gsl::not_null<::Strahlkorper<Frame>*> local_strahlkorper) {
+          [&strahlkorper](const gsl::not_null<ylm::Strahlkorper<Frame>*>
+                              local_strahlkorper) {
             *local_strahlkorper = std::move(strahlkorper);
           },
           box);

--- a/src/PointwiseFunctions/GeneralRelativity/Surfaces/RadialDistance.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/Surfaces/RadialDistance.cpp
@@ -12,8 +12,8 @@
 namespace gr::surfaces {
 template <typename Frame>
 void radial_distance(const gsl::not_null<Scalar<DataVector>*> radial_distance,
-                     const Strahlkorper<Frame>& strahlkorper_a,
-                     const Strahlkorper<Frame>& strahlkorper_b) {
+                     const ylm::Strahlkorper<Frame>& strahlkorper_a,
+                     const ylm::Strahlkorper<Frame>& strahlkorper_b) {
   if (strahlkorper_a.expansion_center() != strahlkorper_b.expansion_center()) {
     ERROR(
         "Currently computing the radial distance between two Strahlkorpers "
@@ -33,12 +33,12 @@ void radial_distance(const gsl::not_null<Scalar<DataVector>*> radial_distance,
               strahlkorper_a.m_max() > strahlkorper_b.m_max())) {
     get(*radial_distance) =
         get(ylm::radius(strahlkorper_a)) -
-        get(ylm::radius(Strahlkorper<Frame>(
+        get(ylm::radius(ylm::Strahlkorper<Frame>(
             strahlkorper_a.l_max(), strahlkorper_a.m_max(), strahlkorper_b)));
   } else {
     get(*radial_distance) =
         -get(ylm::radius(strahlkorper_b)) +
-        get(ylm::radius(Strahlkorper<Frame>(
+        get(ylm::radius(ylm::Strahlkorper<Frame>(
             strahlkorper_b.l_max(), strahlkorper_b.m_max(), strahlkorper_a)));
   };
 }
@@ -48,8 +48,8 @@ void radial_distance(const gsl::not_null<Scalar<DataVector>*> radial_distance,
 #define INSTANTIATE(_, data)                                    \
   template void gr::surfaces::radial_distance<FRAME(data)>(     \
       const gsl::not_null<Scalar<DataVector>*> radial_distance, \
-      const Strahlkorper<FRAME(data)>& strahlkorper_a,          \
-      const Strahlkorper<FRAME(data)>& strahlkorper_b);
+      const ylm::Strahlkorper<FRAME(data)>& strahlkorper_a,     \
+      const ylm::Strahlkorper<FRAME(data)>& strahlkorper_b);
 GENERATE_INSTANTIATIONS(INSTANTIATE,
                         (Frame::Grid, Frame::Distorted, Frame::Inertial))
 #undef INSTANTIATE

--- a/src/PointwiseFunctions/GeneralRelativity/Surfaces/RadialDistance.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/Surfaces/RadialDistance.hpp
@@ -7,8 +7,10 @@
 
 /// \cond
 class DataVector;
+namespace ylm {
 template <typename Frame>
 class Strahlkorper;
+}  // namespace ylm
 namespace gsl {
 template <typename>
 struct not_null;
@@ -28,6 +30,6 @@ namespace gr::surfaces {
  */
 template <typename Frame>
 void radial_distance(gsl::not_null<Scalar<DataVector>*> radial_distance,
-                     const Strahlkorper<Frame>& strahlkorper_a,
-                     const Strahlkorper<Frame>& strahlkorper_b);
+                     const ylm::Strahlkorper<Frame>& strahlkorper_a,
+                     const ylm::Strahlkorper<Frame>& strahlkorper_b);
 }  // namespace gr::surfaces

--- a/src/PointwiseFunctions/GeneralRelativity/Surfaces/Spin.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/Surfaces/Spin.cpp
@@ -155,7 +155,7 @@ void get_left_and_right_eigenproblem_matrices(
   // loop over all terms with 0<l<l_max-1: each makes a column of
   // the matrices for the eigenvalue problem
   size_t column = 0;  // number which column of the matrix we are filling
-  for (auto iter_i = SpherepackIterator(ylm.l_max(), ylm.m_max()); iter_i;
+  for (auto iter_i = ylm::SpherepackIterator(ylm.l_max(), ylm.m_max()); iter_i;
        ++iter_i) {
     if (iter_i.l() > 0 and iter_i.l() < ylm.l_max() - 1 and
         iter_i.m() <= iter_i.l()) {
@@ -240,8 +240,8 @@ void get_left_and_right_eigenproblem_matrices(
       // Set the current column of the left and right matrices
       // for the eigenproblem.
       size_t row = 0;
-      for (auto iter_j = SpherepackIterator(ylm.l_max(), ylm.m_max()); iter_j;
-           ++iter_j) {
+      for (auto iter_j = ylm::SpherepackIterator(ylm.l_max(), ylm.m_max());
+           iter_j; ++iter_j) {
         if (iter_j.l() > 0 and iter_j.l() < ylm.l_max() - 1) {
           (*left_matrix)(row, column) = left_matrix_yi_spectral[iter_j()];
           (*right_matrix)(row, column) = right_matrix_yi_spectral[iter_j()];
@@ -287,7 +287,7 @@ std::array<DataVector, 3> get_eigenvectors_for_3_smallest_magnitude_eigenvalues(
 
   size_t row = 0;
 
-  for (auto iter_i = SpherepackIterator(ylm.l_max(), ylm.m_max()); iter_i;
+  for (auto iter_i = ylm::SpherepackIterator(ylm.l_max(), ylm.m_max()); iter_i;
        ++iter_i) {
     if (iter_i.l() > 0 and iter_i.l() < ylm.l_max() - 1) {
       smallest_eigenvector[iter_i()] = eigenvectors(row, index_smallest);
@@ -358,7 +358,7 @@ namespace gr::surfaces {
 template <typename Frame>
 void spin_function(const gsl::not_null<Scalar<DataVector>*> result,
                    const ylm::Tags::aliases::Jacobian<Frame>& tangents,
-                   const Strahlkorper<Frame>& strahlkorper,
+                   const ylm::Strahlkorper<Frame>& strahlkorper,
                    const tnsr::I<DataVector, 3, Frame>& unit_normal_vector,
                    const Scalar<DataVector>& area_element,
                    const tnsr::ii<DataVector, 3, Frame>& extrinsic_curvature) {
@@ -414,7 +414,7 @@ void spin_function(const gsl::not_null<Scalar<DataVector>*> result,
 template <typename Frame>
 Scalar<DataVector> spin_function(
     const ylm::Tags::aliases::Jacobian<Frame>& tangents,
-    const Strahlkorper<Frame>& strahlkorper,
+    const ylm::Strahlkorper<Frame>& strahlkorper,
     const tnsr::I<DataVector, 3, Frame>& unit_normal_vector,
     const Scalar<DataVector>& area_element,
     const tnsr::ii<DataVector, 3, Frame>& extrinsic_curvature) {
@@ -430,7 +430,7 @@ void dimensionful_spin_magnitude(
     const Scalar<DataVector>& spin_function,
     const tnsr::ii<DataVector, 3, Frame>& spatial_metric,
     const ylm::Tags::aliases::Jacobian<Frame>& tangents,
-    const Strahlkorper<Frame>& strahlkorper,
+    const ylm::Strahlkorper<Frame>& strahlkorper,
     const Scalar<DataVector>& area_element) {
   const Scalar<DataVector> sin_theta{
       sin(strahlkorper.ylm_spherepack().theta_phi_points()[0])};
@@ -477,7 +477,7 @@ double dimensionful_spin_magnitude(
     const Scalar<DataVector>& spin_function,
     const tnsr::ii<DataVector, 3, Frame>& spatial_metric,
     const ylm::Tags::aliases::Jacobian<Frame>& tangents,
-    const Strahlkorper<Frame>& strahlkorper,
+    const ylm::Strahlkorper<Frame>& strahlkorper,
     const Scalar<DataVector>& area_element) {
   double result{};
   dimensionful_spin_magnitude(make_not_null(&result), ricci_scalar,
@@ -506,7 +506,7 @@ void spin_vector(
     const Scalar<DataVector>& area_element,
     const Scalar<DataVector>& ricci_scalar,
     const Scalar<DataVector>& spin_function,
-    const Strahlkorper<MetricDataFrame>& strahlkorper,
+    const ylm::Strahlkorper<MetricDataFrame>& strahlkorper,
     const tnsr::I<DataVector, 3, MeasurementFrame>& measurement_frame_coords) {
   const auto& ylm = strahlkorper.ylm_spherepack();
 
@@ -567,7 +567,7 @@ std::array<double, 3> spin_vector(
     double spin_magnitude, const Scalar<DataVector>& area_element,
     const Scalar<DataVector>& ricci_scalar,
     const Scalar<DataVector>& spin_function,
-    const Strahlkorper<MetricDataFrame>& strahlkorper,
+    const ylm::Strahlkorper<MetricDataFrame>& strahlkorper,
     const tnsr::I<DataVector, 3, MeasurementFrame>& measurement_frame_coords) {
   std::array<double, 3> result{};
   spin_vector(make_not_null(&result), spin_magnitude, area_element,
@@ -582,13 +582,13 @@ std::array<double, 3> spin_vector(
   template void gr::surfaces::spin_function<FRAME(data)>(                 \
       const gsl::not_null<Scalar<DataVector>*> result,                    \
       const ylm::Tags::aliases::Jacobian<FRAME(data)>& tangents,          \
-      const Strahlkorper<FRAME(data)>& strahlkorper,                      \
+      const ylm::Strahlkorper<FRAME(data)>& strahlkorper,                 \
       const tnsr::I<DataVector, 3, FRAME(data)>& unit_normal_vector,      \
       const Scalar<DataVector>& area_element,                             \
       const tnsr::ii<DataVector, 3, FRAME(data)>& extrinsic_curvature);   \
   template Scalar<DataVector> gr::surfaces::spin_function<FRAME(data)>(   \
       const ylm::Tags::aliases::Jacobian<FRAME(data)>& tangents,          \
-      const Strahlkorper<FRAME(data)>& strahlkorper,                      \
+      const ylm::Strahlkorper<FRAME(data)>& strahlkorper,                 \
       const tnsr::I<DataVector, 3, FRAME(data)>& unit_normal_vector,      \
       const Scalar<DataVector>& area_element,                             \
       const tnsr::ii<DataVector, 3, FRAME(data)>& extrinsic_curvature);   \
@@ -598,14 +598,14 @@ std::array<double, 3> spin_vector(
       const Scalar<DataVector>& spin_function,                            \
       const tnsr::ii<DataVector, 3, FRAME(data)>& spatial_metric,         \
       const ylm::Tags::aliases::Jacobian<FRAME(data)>& tangents,          \
-      const Strahlkorper<FRAME(data)>& strahlkorper,                      \
+      const ylm::Strahlkorper<FRAME(data)>& strahlkorper,                 \
       const Scalar<DataVector>& area_element);                            \
   template double gr::surfaces::dimensionful_spin_magnitude<FRAME(data)>( \
       const Scalar<DataVector>& ricci_scalar,                             \
       const Scalar<DataVector>& spin_function,                            \
       const tnsr::ii<DataVector, 3, FRAME(data)>& spatial_metric,         \
       const ylm::Tags::aliases::Jacobian<FRAME(data)>& tangents,          \
-      const Strahlkorper<FRAME(data)>& strahlkorper,                      \
+      const ylm::Strahlkorper<FRAME(data)>& strahlkorper,                 \
       const Scalar<DataVector>& area_element);
 GENERATE_INSTANTIATIONS(INSTANTIATE,
                         (Frame::Grid, Frame::Distorted, Frame::Inertial))
@@ -621,7 +621,7 @@ GENERATE_INSTANTIATIONS(INSTANTIATE,
       const double spin_magnitude, const Scalar<DataVector>& area_element, \
       const Scalar<DataVector>& ricci_scalar,                              \
       const Scalar<DataVector>& spin_function,                             \
-      const Strahlkorper<METRICFRAME(data)>& strahlkorper,                 \
+      const ylm::Strahlkorper<METRICFRAME(data)>& strahlkorper,            \
       const tnsr::I<DataVector, 3, MEASUREMENTFRAME(data)>&                \
           measurement_frame_coords);                                       \
   template std::array<double, 3>                                           \
@@ -629,7 +629,7 @@ GENERATE_INSTANTIATIONS(INSTANTIATE,
       const double spin_magnitude, const Scalar<DataVector>& area_element, \
       const Scalar<DataVector>& ricci_scalar,                              \
       const Scalar<DataVector>& spin_function,                             \
-      const Strahlkorper<METRICFRAME(data)>& strahlkorper,                 \
+      const ylm::Strahlkorper<METRICFRAME(data)>& strahlkorper,            \
       const tnsr::I<DataVector, 3, MEASUREMENTFRAME(data)>&                \
           measurement_frame_coords);
 

--- a/src/PointwiseFunctions/GeneralRelativity/Surfaces/Spin.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/Surfaces/Spin.hpp
@@ -10,8 +10,10 @@
 
 /// \cond
 class DataVector;
+namespace ylm {
 template <typename Frame>
 class Strahlkorper;
+}  // namespace ylm
 namespace gsl {
 template <typename>
 struct not_null;
@@ -56,7 +58,7 @@ namespace gr::surfaces {
 template <typename Frame>
 void spin_function(gsl::not_null<Scalar<DataVector>*> result,
                    const ylm::Tags::aliases::Jacobian<Frame>& tangents,
-                   const Strahlkorper<Frame>& strahlkorper,
+                   const ylm::Strahlkorper<Frame>& strahlkorper,
                    const tnsr::I<DataVector, 3, Frame>& unit_normal_vector,
                    const Scalar<DataVector>& area_element,
                    const tnsr::ii<DataVector, 3, Frame>& extrinsic_curvature);
@@ -64,7 +66,7 @@ void spin_function(gsl::not_null<Scalar<DataVector>*> result,
 template <typename Frame>
 Scalar<DataVector> spin_function(
     const ylm::Tags::aliases::Jacobian<Frame>& tangents,
-    const Strahlkorper<Frame>& strahlkorper,
+    const ylm::Strahlkorper<Frame>& strahlkorper,
     const tnsr::I<DataVector, 3, Frame>& unit_normal_vector,
     const Scalar<DataVector>& area_element,
     const tnsr::ii<DataVector, 3, Frame>& extrinsic_curvature);
@@ -111,7 +113,7 @@ void dimensionful_spin_magnitude(
     const Scalar<DataVector>& spin_function,
     const tnsr::ii<DataVector, 3, Frame>& spatial_metric,
     const ylm::Tags::aliases::Jacobian<Frame>& tangents,
-    const Strahlkorper<Frame>& strahlkorper,
+    const ylm::Strahlkorper<Frame>& strahlkorper,
     const Scalar<DataVector>& area_element);
 
 template <typename Frame>
@@ -120,7 +122,7 @@ double dimensionful_spin_magnitude(
     const Scalar<DataVector>& spin_function,
     const tnsr::ii<DataVector, 3, Frame>& spatial_metric,
     const ylm::Tags::aliases::Jacobian<Frame>& tangents,
-    const Strahlkorper<Frame>& strahlkorper,
+    const ylm::Strahlkorper<Frame>& strahlkorper,
     const Scalar<DataVector>& area_element);
 /// @}
 
@@ -203,7 +205,7 @@ void spin_vector(
     const Scalar<DataVector>& area_element,
     const Scalar<DataVector>& ricci_scalar,
     const Scalar<DataVector>& spin_function,
-    const Strahlkorper<MetricDataFrame>& strahlkorper,
+    const ylm::Strahlkorper<MetricDataFrame>& strahlkorper,
     const tnsr::I<DataVector, 3, MeasurementFrame>& measurement_frame_coords);
 
 template <typename MetricDataFrame, typename MeasurementFrame>
@@ -211,6 +213,6 @@ std::array<double, 3> spin_vector(
     double spin_magnitude, const Scalar<DataVector>& area_element,
     const Scalar<DataVector>& ricci_scalar,
     const Scalar<DataVector>& spin_function,
-    const Strahlkorper<MetricDataFrame>& strahlkorper,
+    const ylm::Strahlkorper<MetricDataFrame>& strahlkorper,
     const tnsr::I<DataVector, 3, MeasurementFrame>& measurement_frame_coords);
 }  // namespace gr::surfaces

--- a/src/PointwiseFunctions/GeneralRelativity/Surfaces/SurfaceIntegralOfScalar.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/Surfaces/SurfaceIntegralOfScalar.cpp
@@ -10,9 +10,9 @@
 
 namespace gr::surfaces {
 template <typename Frame>
-double surface_integral_of_scalar(const Scalar<DataVector>& area_element,
-                                  const Scalar<DataVector>& scalar,
-                                  const Strahlkorper<Frame>& strahlkorper) {
+double surface_integral_of_scalar(
+    const Scalar<DataVector>& area_element, const Scalar<DataVector>& scalar,
+    const ylm::Strahlkorper<Frame>& strahlkorper) {
   const DataVector integrand = get(area_element) * get(scalar);
   return strahlkorper.ylm_spherepack().definite_integral(integrand.data());
 }
@@ -23,7 +23,7 @@ double surface_integral_of_scalar(const Scalar<DataVector>& area_element,
   template double gr::surfaces::surface_integral_of_scalar( \
       const Scalar<DataVector>& area_element,               \
       const Scalar<DataVector>& scalar,                     \
-      const Strahlkorper<FRAME(data)>& strahlkorper);
+      const ylm::Strahlkorper<FRAME(data)>& strahlkorper);
 GENERATE_INSTANTIATIONS(INSTANTIATE,
                         (Frame::Grid, Frame::Distorted, Frame::Inertial))
 #undef INSTANTIATE

--- a/src/PointwiseFunctions/GeneralRelativity/Surfaces/SurfaceIntegralOfScalar.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/Surfaces/SurfaceIntegralOfScalar.hpp
@@ -7,8 +7,10 @@
 
 /// \cond
 class DataVector;
+namespace ylm {
 template <typename Frame>
 class Strahlkorper;
+}  // namespace ylm
 /// \endcond
 
 namespace gr::surfaces {
@@ -23,5 +25,5 @@ namespace gr::surfaces {
 template <typename Frame>
 double surface_integral_of_scalar(const Scalar<DataVector>& area_element,
                                   const Scalar<DataVector>& scalar,
-                                  const Strahlkorper<Frame>& strahlkorper);
+                                  const ylm::Strahlkorper<Frame>& strahlkorper);
 }  // namespace gr::surfaces

--- a/src/PointwiseFunctions/GeneralRelativity/Surfaces/SurfaceIntegralOfVector.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/Surfaces/SurfaceIntegralOfVector.cpp
@@ -15,7 +15,7 @@ double euclidean_surface_integral_of_vector(
     const Scalar<DataVector>& area_element,
     const tnsr::I<DataVector, 3, Frame>& vector,
     const tnsr::i<DataVector, 3, Frame>& normal_one_form,
-    const Strahlkorper<Frame>& strahlkorper) {
+    const ylm::Strahlkorper<Frame>& strahlkorper) {
   const DataVector integrand =
       get(area_element) * get(dot_product(vector, normal_one_form)) /
       sqrt(get(dot_product(normal_one_form, normal_one_form)));
@@ -29,7 +29,7 @@ double euclidean_surface_integral_of_vector(
       const Scalar<DataVector>& area_element,                         \
       const tnsr::I<DataVector, 3, FRAME(data)>& vector,              \
       const tnsr::i<DataVector, 3, FRAME(data)>& normal_one_form,     \
-      const Strahlkorper<FRAME(data)>& strahlkorper);
+      const ylm::Strahlkorper<FRAME(data)>& strahlkorper);
 GENERATE_INSTANTIATIONS(INSTANTIATE,
                         (Frame::Grid, Frame::Distorted, Frame::Inertial))
 #undef INSTANTIATE

--- a/src/PointwiseFunctions/GeneralRelativity/Surfaces/SurfaceIntegralOfVector.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/Surfaces/SurfaceIntegralOfVector.hpp
@@ -7,8 +7,10 @@
 
 /// \cond
 class DataVector;
+namespace ylm {
 template <typename Frame>
 class Strahlkorper;
+}  // namespace ylm
 /// \endcond
 
 namespace gr::surfaces {
@@ -31,5 +33,5 @@ double euclidean_surface_integral_of_vector(
     const Scalar<DataVector>& area_element,
     const tnsr::I<DataVector, 3, Frame>& vector,
     const tnsr::i<DataVector, 3, Frame>& normal_one_form,
-    const Strahlkorper<Frame>& strahlkorper);
+    const ylm::Strahlkorper<Frame>& strahlkorper);
 }  // namespace gr::surfaces

--- a/src/PointwiseFunctions/GeneralRelativity/Surfaces/Tags.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/Surfaces/Tags.hpp
@@ -31,7 +31,7 @@
 #include "Utilities/TMPL.hpp"
 
 /// \ingroup SurfacesGroup
-/// Holds tags and ComputeItems associated with a `::Strahlkorper`.
+/// Holds tags and ComputeItems associated with a `ylm::Strahlkorper`.
 namespace ylm::Tags {
 /// The OneOverOneFormMagnitude is the reciprocal of the magnitude of the
 /// one-form perpendicular to the horizon
@@ -248,7 +248,7 @@ struct EuclideanSurfaceIntegralCompute
   static void function(const gsl::not_null<double*> surface_integral,
                        const Scalar<DataVector>& euclidean_area_element,
                        const Scalar<DataVector>& integrand,
-                       const ::Strahlkorper<Frame>& strahlkorper) {
+                       const ylm::Strahlkorper<Frame>& strahlkorper) {
     *surface_integral = ::gr::surfaces::surface_integral_of_scalar<Frame>(
         euclidean_area_element, integrand, strahlkorper);
   }
@@ -283,7 +283,7 @@ struct EuclideanSurfaceIntegralVectorCompute
                        const Scalar<DataVector>& euclidean_area_element,
                        const tnsr::I<DataVector, 3, Frame>& integrand,
                        const tnsr::i<DataVector, 3, Frame>& normal_one_form,
-                       const ::Strahlkorper<Frame>& strahlkorper) {
+                       const ylm::Strahlkorper<Frame>& strahlkorper) {
     *surface_integral =
         ::gr::surfaces::euclidean_surface_integral_of_vector<Frame>(
             euclidean_area_element, integrand, normal_one_form, strahlkorper);
@@ -297,7 +297,7 @@ struct EuclideanSurfaceIntegralVectorCompute
 
 namespace gr::surfaces {
 /// \ingroup SurfacesGroup
-/// Holds tags and ComputeItems associated with a `::Strahlkorper` that
+/// Holds tags and ComputeItems associated with a `ylm::Strahlkorper` that
 /// also need a metric.
 namespace Tags {
 
@@ -342,7 +342,7 @@ struct SurfaceIntegralCompute : SurfaceIntegral<IntegrandTag, Frame>,
   static void function(const gsl::not_null<double*> surface_integral,
                        const Scalar<DataVector>& area_element,
                        const Scalar<DataVector>& integrand,
-                       const ::Strahlkorper<Frame>& strahlkorper) {
+                       const ylm::Strahlkorper<Frame>& strahlkorper) {
     *surface_integral = ::gr::surfaces::surface_integral_of_scalar<Frame>(
         area_element, integrand, strahlkorper);
   }
@@ -363,7 +363,7 @@ struct AreaCompute : Area, db::ComputeTag {
   using base = Area;
   using return_type = double;
   static void function(const gsl::not_null<double*> result,
-                       const Strahlkorper<Frame>& strahlkorper,
+                       const ylm::Strahlkorper<Frame>& strahlkorper,
                        const Scalar<DataVector>& area_element) {
     *result = strahlkorper.ylm_spherepack().definite_integral(
         get(area_element).data());
@@ -403,9 +403,9 @@ struct SpinFunctionCompute : SpinFunction, db::ComputeTag {
   using base = SpinFunction;
   static constexpr auto function = static_cast<void (*)(
       gsl::not_null<Scalar<DataVector>*>,
-      const ylm::Tags::aliases::Jacobian<Frame>&, const Strahlkorper<Frame>&,
-      const tnsr::I<DataVector, 3, Frame>&, const Scalar<DataVector>&,
-      const tnsr::ii<DataVector, 3, Frame>&)>(
+      const ylm::Tags::aliases::Jacobian<Frame>&,
+      const ylm::Strahlkorper<Frame>&, const tnsr::I<DataVector, 3, Frame>&,
+      const Scalar<DataVector>&, const tnsr::ii<DataVector, 3, Frame>&)>(
       &gr::surfaces::spin_function<Frame>);
   using argument_tags =
       tmpl::list<ylm::Tags::Tangents<Frame>, ylm::Tags::Strahlkorper<Frame>,
@@ -430,8 +430,8 @@ struct DimensionfulSpinMagnitudeCompute : DimensionfulSpinMagnitude,
   static constexpr auto function = static_cast<void (*)(
       const gsl::not_null<double*>, const Scalar<DataVector>&,
       const Scalar<DataVector>&, const tnsr::ii<DataVector, 3, Frame>&,
-      const ylm::Tags::aliases::Jacobian<Frame>&, const Strahlkorper<Frame>&,
-      const Scalar<DataVector>&)>(
+      const ylm::Tags::aliases::Jacobian<Frame>&,
+      const ylm::Strahlkorper<Frame>&, const Scalar<DataVector>&)>(
       &gr::surfaces::dimensionful_spin_magnitude<Frame>);
   using argument_tags =
       tmpl::list<ylm::Tags::RicciScalar, SpinFunction,
@@ -455,7 +455,7 @@ struct DimensionfulSpinVectorCompute : DimensionfulSpinVector<MeasurementFrame>,
   static constexpr auto function = static_cast<void (*)(
       const gsl::not_null<std::array<double, 3>*>, double,
       const Scalar<DataVector>&, const Scalar<DataVector>&,
-      const Scalar<DataVector>&, const Strahlkorper<MetricDataFrame>&,
+      const Scalar<DataVector>&, const ylm::Strahlkorper<MetricDataFrame>&,
       const tnsr::I<DataVector, 3, MeasurementFrame>&)>(
       &gr::surfaces::spin_vector<MetricDataFrame, MeasurementFrame>);
   using argument_tags =

--- a/tests/Unit/ControlSystem/ControlErrors/Test_Shape.cpp
+++ b/tests/Unit/ControlSystem/ControlErrors/Test_Shape.cpp
@@ -53,7 +53,7 @@ namespace control_system {
 namespace {
 using FoTMap = std::unordered_map<
     std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>;
-using Strahlkorper = Strahlkorper<Frame::Distorted>;
+using Strahlkorper = ylm::Strahlkorper<Frame::Distorted>;
 
 void test_shape_control_error() {
   constexpr size_t deriv_order = 2;
@@ -78,7 +78,7 @@ void test_shape_control_error() {
   // numbers it doesn't matter for initial data
   auto initial_shape_func = make_array<deriv_order + 1, DataVector>(
       DataVector{fake_ah_coefs.size(), 0.0});
-  SpherepackIterator iter{fake_ah.l_max(), fake_ah.m_max()};
+  ylm::SpherepackIterator iter{fake_ah.l_max(), fake_ah.m_max()};
   std::uniform_real_distribution<double> coef_dist{-1.0, 1.0};
   for (size_t i = 0; i < initial_shape_func.size(); i++) {
     for (iter.reset(); iter; ++iter) {

--- a/tests/Unit/ControlSystem/ControlErrors/Test_SizeError.cpp
+++ b/tests/Unit/ControlSystem/ControlErrors/Test_SizeError.cpp
@@ -103,11 +103,11 @@ void test_size_error_one_step(
   const double distorted_horizon_radius = 2.00;
 
   const std::array<double, 3> center{{0.0, 0.0, 0.0}};
-  Strahlkorper<Frame::Distorted> horizon(l_max, distorted_horizon_radius,
-                                         center);
-  Strahlkorper<Frame::Distorted> excision_boundary(
+  ylm::Strahlkorper<Frame::Distorted> horizon(l_max, distorted_horizon_radius,
+                                              center);
+  ylm::Strahlkorper<Frame::Distorted> excision_boundary(
       l_max, distorted_excision_boundary_radius_initial, center);
-  Strahlkorper<Frame::Distorted> time_deriv_horizon(
+  ylm::Strahlkorper<Frame::Distorted> time_deriv_horizon(
       l_max, distorted_horizon_velocity, center);
 
   // Get Cartesian coordinates on excision boundary

--- a/tests/Unit/ControlSystem/Systems/Test_Shape.cpp
+++ b/tests/Unit/ControlSystem/Systems/Test_Shape.cpp
@@ -55,7 +55,7 @@ namespace control_system {
 namespace {
 using FoTMap = std::unordered_map<
     std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>;
-using Strahlkorper = Strahlkorper<Frame::Distorted>;
+using Strahlkorper = ylm::Strahlkorper<Frame::Distorted>;
 template <typename Metavars>
 using SystemHelper = control_system::TestHelpers::SystemHelper<Metavars>;
 
@@ -104,7 +104,7 @@ void test_shape_control(
       control_system::ControlErrors::detail::excision_sphere_name<
           ::domain::ObjectLabel::A>());
 
-  SpherepackIterator iter{l_max, l_max};
+  ylm::SpherepackIterator iter{l_max, l_max};
   const double ah_radius =
       ah_coefs_function_of_time.func(initial_time)[0][iter.set(0, 0)()];
   const tnsr::I<double, 3, Frame::Grid>& grid_center = excision_sphere.center();
@@ -181,7 +181,7 @@ void test_suite(const gsl::not_null<Generator*> generator, const size_t l_max,
 
   // Responsible for running all control system checks
   SystemHelper<metavars> system_helper{};
-  SpherepackIterator iter{l_max, l_max};
+  ylm::SpherepackIterator iter{l_max, l_max};
   const size_t num_ah_coeffs = iter.spherepack_array_size();
   std::uniform_real_distribution<double> coef_dist{-0.1, 0.1};
   // Hard code the radius to something other than 1 because shape doesn't depend
@@ -464,7 +464,7 @@ void test_names() {
   CHECK(pretty_type::name<shape>() == "ShapeA");
 
   const size_t l_max = 3;
-  SpherepackIterator iter(l_max, l_max);
+  ylm::SpherepackIterator iter(l_max, l_max);
   const size_t size = iter.spherepack_array_size();
 
   // Check known valid indices

--- a/tests/Unit/ControlSystem/Systems/Test_Size.cpp
+++ b/tests/Unit/ControlSystem/Systems/Test_Size.cpp
@@ -133,8 +133,9 @@ void test_size_process_measurement() {
   const tnsr::I<DataVector, 3, Frame::Distorted> zero_tnsr_I{};
   const tnsr::ii<DataVector, 3, Frame::Distorted> zero_tnsr_ii{};
   const tnsr::II<DataVector, 3, Frame::Distorted> zero_tnsr_II{};
-  const Strahlkorper<Frame::Distorted> horizon{};
-  const Strahlkorper<Frame::Grid> excision{2, 2.0, std::array{0.0, 0.0, 0.0}};
+  const ylm::Strahlkorper<Frame::Distorted> horizon{};
+  const ylm::Strahlkorper<Frame::Grid> excision{2, 2.0,
+                                                std::array{0.0, 0.0, 0.0}};
 
   size::process_measurement::apply<Metavars>(
       char_speed::Excision{}, excision, zero_scalar, zero_tnsr_I, zero_tnsr_ii,

--- a/tests/Unit/Domain/CoordinateMaps/TimeDependent/Test_Shape.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/TimeDependent/Test_Shape.cpp
@@ -184,7 +184,7 @@ double generate_random_00_coef(const gsl::not_null<std::mt19937*> generator) {
 DataVector convert_coefs_to_spherepack(
     const std::vector<std::vector<std::complex<double>>>& coefs, size_t l_max,
     size_t m_max) {
-  SpherepackIterator iter(l_max, m_max);
+  ylm::SpherepackIterator iter(l_max, m_max);
   auto spherepack_coefs =
       make_with_value<DataVector>(iter.spherepack_array_size(), 0.);
 

--- a/tests/Unit/Domain/Test_StrahlkorperTransformations.cpp
+++ b/tests/Unit/Domain/Test_StrahlkorperTransformations.cpp
@@ -18,7 +18,6 @@
 #include "Domain/FunctionsOfTime/RegisterDerivedWithCharm.hpp"
 #include "Domain/StrahlkorperTransformations.hpp"
 #include "Framework/TestHelpers.hpp"
-#include "NumericalAlgorithms/SphericalHarmonics/SpherepackIterator.hpp"
 #include "NumericalAlgorithms/SphericalHarmonics/Strahlkorper.hpp"
 #include "NumericalAlgorithms/SphericalHarmonics/StrahlkorperFunctions.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrHorizon.hpp"
@@ -36,8 +35,8 @@ void test_strahlkorper_in_different_frame() {
   // nonzero center.
   const std::array<double, 3> strahlkorper_grid_center = {0.03, 0.02, 0.01};
   const size_t l_max = 8;
-  const Strahlkorper<Frame::Grid> strahlkorper_grid(l_max, 2.0,
-                                                    strahlkorper_grid_center);
+  const ylm::Strahlkorper<Frame::Grid> strahlkorper_grid(
+      l_max, 2.0, strahlkorper_grid_center);
 
   // Create a Domain.
   // We choose a spherical shell domain extending from radius 1.9M to
@@ -72,7 +71,7 @@ void test_strahlkorper_in_different_frame() {
 
   // Compute strahlkorper in the destination frame.
   const double time = 0.5;
-  Strahlkorper<DestFrame> strahlkorper_dest{};
+  ylm::Strahlkorper<DestFrame> strahlkorper_dest{};
   if constexpr (Aligned) {
     strahlkorper_in_different_frame_aligned(make_not_null(&strahlkorper_dest),
                                             strahlkorper_grid, domain,
@@ -85,21 +84,21 @@ void test_strahlkorper_in_different_frame() {
   }
 
   // Now compare.
-  std::unique_ptr<Strahlkorper<DestFrame>> strahlkorper_expected;
+  std::unique_ptr<ylm::Strahlkorper<DestFrame>> strahlkorper_expected;
   if constexpr (Aligned) {
     const ylm::Spherepack ylm{l_max, l_max};
     const DataVector new_radius =
         get(gr::Solutions::kerr_schild_radius_from_boyer_lindquist(
             2.0, ylm.theta_phi_points(), 1.0,
             std::array<double, 3>{{0.1, 0.2, 0.3}}));
-    strahlkorper_expected.reset(new Strahlkorper<DestFrame>(
+    strahlkorper_expected.reset(new ylm::Strahlkorper<DestFrame>(
         l_max, l_max, new_radius, strahlkorper_grid_center));
   } else {
-    strahlkorper_expected.reset(
-        new Strahlkorper<DestFrame>(l_max, 2.0,
-                                    {{strahlkorper_grid_center[0] + 0.005,
-                                      strahlkorper_grid_center[1] + 0.01,
-                                      strahlkorper_grid_center[2] + 0.015}}));
+    strahlkorper_expected.reset(new ylm::Strahlkorper<DestFrame>(
+        l_max, 2.0,
+        {{strahlkorper_grid_center[0] + 0.005,
+          strahlkorper_grid_center[1] + 0.01,
+          strahlkorper_grid_center[2] + 0.015}}));
   }
   CHECK_ITERABLE_APPROX(strahlkorper_expected->physical_center(),
                         strahlkorper_dest.physical_center());
@@ -117,8 +116,8 @@ void test_strahlkorper_coords_in_different_frame() {
   // nonzero center.
   const std::array<double, 3> strahlkorper_src_center = {0.03, 0.02, 0.01};
   const size_t l_max = 8;
-  const Strahlkorper<SrcFrame> strahlkorper_src(l_max, 2.0,
-                                                strahlkorper_src_center);
+  const ylm::Strahlkorper<SrcFrame> strahlkorper_src(l_max, 2.0,
+                                                     strahlkorper_src_center);
 
   // Create a Domain.
   // We choose a spherical shell domain extending from radius 1.9M to

--- a/tests/Unit/Helpers/ControlSystem/SystemHelpers.hpp
+++ b/tests/Unit/Helpers/ControlSystem/SystemHelpers.hpp
@@ -465,7 +465,8 @@ grid_frame_horizon_centers_for_basic_control_systems(
 
 template <typename ElementComponent, typename Metavars, typename F,
           typename CoordMap>
-std::pair<Strahlkorper<Frame::Distorted>, Strahlkorper<Frame::Distorted>>
+std::pair<ylm::Strahlkorper<Frame::Distorted>,
+          ylm::Strahlkorper<Frame::Distorted>>
 build_horizons_for_basic_control_systems(
     const double time, ActionTesting::MockRuntimeSystem<Metavars>& runner,
     const F position_function, const CoordMap& coord_map) {
@@ -475,12 +476,12 @@ build_horizons_for_basic_control_systems(
 
   // Construct strahlkorpers to pass to control systems. Only the centers
   // matter.
-  Strahlkorper<Frame::Distorted> horizon_a{2, 2, 1.0, positions.first};
-  Strahlkorper<Frame::Distorted> horizon_b{2, 2, 1.0, positions.second};
+  ylm::Strahlkorper<Frame::Distorted> horizon_a{2, 2, 1.0, positions.first};
+  ylm::Strahlkorper<Frame::Distorted> horizon_b{2, 2, 1.0, positions.second};
 
-  return std::make_pair<Strahlkorper<Frame::Distorted>,
-                        Strahlkorper<Frame::Distorted>>(std::move(horizon_a),
-                                                        std::move(horizon_b));
+  return std::make_pair<ylm::Strahlkorper<Frame::Distorted>,
+                        ylm::Strahlkorper<Frame::Distorted>>(
+      std::move(horizon_a), std::move(horizon_b));
 }
 
 /*!
@@ -647,13 +648,13 @@ struct SystemHelper {
    * \brief Actually run the control system test
    *
    * The `horizon_function` should return a
-   * `std::pair<Strahlkorper<Frame::Distorted>, Strahlkorper<Frame::Distorted>>`
-   * representing the two horizons in the grid frame. This means the user is
-   * responsible for doing any coordinate transformations inside
-   * `horizon_function` as this function won't do any. The `number_of_horizons`
-   * is used to determine if we actually use both horizon "measurements" as some
-   * control systems may only need one. If only one horizon is used, the default
-   * is to use AhA.
+   * `std::pair<ylm::Strahlkorper<Frame::Distorted>,
+   * ylm::Strahlkorper<Frame::Distorted>>` representing the two horizons in the
+   * grid frame. This means the user is responsible for doing any coordinate
+   * transformations inside `horizon_function` as this function won't do any.
+   * The `number_of_horizons` is used to determine if we actually use both
+   * horizon "measurements" as some control systems may only need one. If only
+   * one horizon is used, the default is to use AhA.
    *
    * For the basic control systems, a common function is defined for you:
    * `control_system::TestHelpers::build_horizons_for_basic_control_systems()`.
@@ -839,8 +840,8 @@ struct SystemHelper {
 
   // Members that won't be moved out of this struct
   AllTags all_init_tags_{};
-  Strahlkorper<Frame::Distorted> horizon_a_{};
-  Strahlkorper<Frame::Distorted> horizon_b_{};
+  ylm::Strahlkorper<Frame::Distorted> horizon_a_{};
+  ylm::Strahlkorper<Frame::Distorted> horizon_b_{};
   int measurements_per_update_{};
   double initial_time_{std::numeric_limits<double>::signaling_NaN()};
 

--- a/tests/Unit/Helpers/NumericalAlgorithms/SphericalHarmonics/StrahlkorperTestHelpers.cpp
+++ b/tests/Unit/Helpers/NumericalAlgorithms/SphericalHarmonics/StrahlkorperTestHelpers.cpp
@@ -10,6 +10,7 @@
 #include "NumericalAlgorithms/SphericalHarmonics/Strahlkorper.hpp"
 #include "NumericalAlgorithms/SphericalHarmonics/SpherepackIterator.hpp"
 
+namespace ylm::TestHelpers {
 Strahlkorper<Frame::Inertial> create_strahlkorper_y11(
     const double y11_amplitude, const double radius,
     const std::array<double, 3>& center) {
@@ -26,3 +27,4 @@ Strahlkorper<Frame::Inertial> create_strahlkorper_y11(
   coefs[it.set(1, -1)()] = y11_amplitude * sqrt(0.5 / M_PI);
   return Strahlkorper<Frame::Inertial>(coefs, strahlkorper_sphere);
 }
+}  // namespace ylm::TestHelpers

--- a/tests/Unit/Helpers/NumericalAlgorithms/SphericalHarmonics/StrahlkorperTestHelpers.hpp
+++ b/tests/Unit/Helpers/NumericalAlgorithms/SphericalHarmonics/StrahlkorperTestHelpers.hpp
@@ -13,8 +13,10 @@ struct Inertial;
 }  // namespace Frame
 /// \endcond
 
+namespace ylm::TestHelpers {
 // Create a strahlkorper with a Im(Y11) dependence, with
 // a given average radius and a given center.
 Strahlkorper<Frame::Inertial> create_strahlkorper_y11(
     const double y11_amplitude, const double radius,
     const std::array<double, 3>& center);
+}  // namespace ylm::TestHelpers

--- a/tests/Unit/IO/H5/Test_VolumeData.cpp
+++ b/tests/Unit/IO/H5/Test_VolumeData.cpp
@@ -36,8 +36,8 @@ void test_strahlkorper() {
   constexpr size_t m_max = 12;
   constexpr double sphere_radius = 4.0;
   constexpr std::array<double, 3> center{{5.0, 6.0, 7.0}};
-  const Strahlkorper<Frame::Inertial> strahlkorper{l_max, m_max, sphere_radius,
-                                                   center};
+  const ylm::Strahlkorper<Frame::Inertial> strahlkorper{l_max, m_max,
+                                                        sphere_radius, center};
   const ylm::Spherepack& ylm = strahlkorper.ylm_spherepack();
   const std::array<DataVector, 2> theta_phi = ylm.theta_phi_points();
   const DataVector theta = theta_phi[0];

--- a/tests/Unit/NumericalAlgorithms/SphericalHarmonics/Test_ChangeCenterOfStrahlkorper.cpp
+++ b/tests/Unit/NumericalAlgorithms/SphericalHarmonics/Test_ChangeCenterOfStrahlkorper.cpp
@@ -17,6 +17,7 @@ namespace Frame {
 struct Inertial;
 }  // namespace Frame
 
+namespace ylm {
 namespace {
 
 Strahlkorper<Frame::Inertial> make_strahlkorper() {
@@ -103,3 +104,4 @@ SPECTRE_TEST_CASE("Unit.ApparentHorizons.Strahlkorper.ChangeCenter",
   test_change_center_of_strahlkorper_to_physical();
 }
 }  // namespace
+}  // namespace ylm

--- a/tests/Unit/NumericalAlgorithms/SphericalHarmonics/Test_RealSphericalHarmonics.cpp
+++ b/tests/Unit/NumericalAlgorithms/SphericalHarmonics/Test_RealSphericalHarmonics.cpp
@@ -11,6 +11,7 @@
 #include "NumericalAlgorithms/Spectral/SwshInterpolation.hpp"
 #include "NumericalAlgorithms/SphericalHarmonics/RealSphericalHarmonics.hpp"
 
+namespace ylm {
 SPECTRE_TEST_CASE("Unit.SphericalHarmonics.RealSphericalHarmonics",
                   "[NumericalAlgorithms][Unit]") {
   const size_t l_max = 10;
@@ -59,3 +60,4 @@ SPECTRE_TEST_CASE("Unit.SphericalHarmonics.RealSphericalHarmonics",
     }
   }
 }
+}  // namespace ylm

--- a/tests/Unit/NumericalAlgorithms/SphericalHarmonics/Test_SpherepackIterator.cpp
+++ b/tests/Unit/NumericalAlgorithms/SphericalHarmonics/Test_SpherepackIterator.cpp
@@ -13,6 +13,7 @@
 #include "Utilities/GetOutput.hpp"
 #include "Utilities/Literals.hpp"
 
+namespace ylm {
 SPECTRE_TEST_CASE("Unit.SphericalHarmonics.SpherepackIterator",
                   "[NumericalAlgorithms][Unit]") {
   const std::vector<size_t> test_l = {0, 1, 1, 2, 2, 2, 3, 3, 3, 4,
@@ -108,3 +109,4 @@ SPECTRE_TEST_CASE("Unit.SphericalHarmonics.SpherepackIterator",
   CHECK(iter_copy == iter);
   test_move_semantics(std::move(iter), iter_copy, 3_st, 2_st, 3_st);
 }
+}  // namespace ylm

--- a/tests/Unit/NumericalAlgorithms/SphericalHarmonics/Test_Strahlkorper.cpp
+++ b/tests/Unit/NumericalAlgorithms/SphericalHarmonics/Test_Strahlkorper.cpp
@@ -22,10 +22,12 @@
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
+
 namespace Frame {
 struct Inertial;
 }  // namespace Frame
 
+namespace ylm {
 namespace {
 void test_invert_spec_phys_transform() {
   const double avg_radius = 1.0;
@@ -199,3 +201,4 @@ SPECTRE_TEST_CASE("Unit.ApparentHorizons.Strahlkorper.Serialization",
   Strahlkorper<Frame::Inertial> s(4, 4, 2.0, {{1.0, 2.0, 3.0}});
   test_serialization(s);
 }
+}  // namespace ylm

--- a/tests/Unit/NumericalAlgorithms/SphericalHarmonics/Test_StrahlkorperFunctions.cpp
+++ b/tests/Unit/NumericalAlgorithms/SphericalHarmonics/Test_StrahlkorperFunctions.cpp
@@ -22,13 +22,14 @@ namespace Frame {
 struct Inertial;
 }  // namespace Frame
 
+namespace ylm {
 namespace {
 void test_radius_and_derivs() {
   const double y11_amplitude = 1.0;
   const double radius = 2.0;
   const std::array<double, 3> center = {{0.1, 0.2, 0.3}};
   const auto strahlkorper =
-      create_strahlkorper_y11(y11_amplitude, radius, center);
+      TestHelpers::create_strahlkorper_y11(y11_amplitude, radius, center);
 
   // Now construct a Y00 + Im(Y11) surface by hand.
   const auto& theta_points = strahlkorper.ylm_spherepack().theta_points();
@@ -137,7 +138,7 @@ void test_theta_phi() {
   const double radius = 2.0;
   const std::array<double, 3> center = {{0.1, 0.2, 0.3}};
   const auto strahlkorper =
-      create_strahlkorper_y11(y11_amplitude, radius, center);
+      TestHelpers::create_strahlkorper_y11(y11_amplitude, radius, center);
 
   const auto expected_theta_phi =
       strahlkorper.ylm_spherepack().theta_phi_points();
@@ -151,7 +152,7 @@ void test_rhat_jacobian_hessian() {
   const double radius = 2.0;
   const std::array<double, 3> center = {{0.1, 0.2, 0.3}};
   const auto strahlkorper =
-      create_strahlkorper_y11(y11_amplitude, radius, center);
+      TestHelpers::create_strahlkorper_y11(y11_amplitude, radius, center);
 
   const auto theta_phi = strahlkorper.ylm_spherepack().theta_phi_points();
   const auto& theta = theta_phi[0];
@@ -250,7 +251,7 @@ void test_cartesian_coords() {
   const double radius = 2.0;
   const std::array<double, 3> center = {{0.1, 0.2, 0.3}};
   const auto strahlkorper =
-      create_strahlkorper_y11(y11_amplitude, radius, center);
+      TestHelpers::create_strahlkorper_y11(y11_amplitude, radius, center);
 
   const auto theta_phi = strahlkorper.ylm_spherepack().theta_phi_points();
   const auto& theta = theta_phi[0];
@@ -279,7 +280,7 @@ void test_normals() {
   const double radius = 2.0;
   const std::array<double, 3> center = {{0.1, 0.2, 0.3}};
   const auto strahlkorper =
-      create_strahlkorper_y11(y11_amplitude, radius, center);
+      TestHelpers::create_strahlkorper_y11(y11_amplitude, radius, center);
 
   const auto theta_phi = strahlkorper.ylm_spherepack().theta_phi_points();
   const auto n_pts = theta_phi[0].size();
@@ -521,3 +522,4 @@ SPECTRE_TEST_CASE("Unit.ApparentHorizons.StrahlkorperFunctions",
   test_fit_ylm_coeffs_diff();
   test_time_deriv_strahlkorper();
 }
+}  // namespace ylm

--- a/tests/Unit/NumericalAlgorithms/SphericalHarmonics/Test_Tags.cpp
+++ b/tests/Unit/NumericalAlgorithms/SphericalHarmonics/Test_Tags.cpp
@@ -20,7 +20,6 @@
 #include "Helpers/NumericalAlgorithms/SphericalHarmonics/StrahlkorperTestHelpers.hpp"
 #include "Helpers/NumericalAlgorithms/SphericalHarmonics/YlmTestFunctions.hpp"
 #include "NumericalAlgorithms/SphericalHarmonics/Spherepack.hpp"
-#include "NumericalAlgorithms/SphericalHarmonics/SpherepackIterator.hpp"
 #include "NumericalAlgorithms/SphericalHarmonics/Strahlkorper.hpp"
 #include "NumericalAlgorithms/SphericalHarmonics/Tags.hpp"
 #include "Utilities/ConstantExpressions.hpp"
@@ -32,7 +31,7 @@ void test_average_radius() {
   // Create spherical Strahlkorper
   const std::array<double, 3> center = {{0.1, 0.2, 0.3}};
   const double r = 3.0;
-  Strahlkorper<Frame::Inertial> s(4, 4, r, center);
+  ylm::Strahlkorper<Frame::Inertial> s(4, 4, r, center);
   CHECK(s.average_radius() == approx(r));
 }
 
@@ -41,7 +40,7 @@ void test_radius_and_derivs() {
   const double radius = 2.0;
   const std::array<double, 3> center = {{0.1, 0.2, 0.3}};
   const auto strahlkorper =
-      create_strahlkorper_y11(y11_amplitude, radius, center);
+      ylm::TestHelpers::create_strahlkorper_y11(y11_amplitude, radius, center);
 
   // Now construct a Y00 + Im(Y11) surface by hand.
   const auto theta_phi = strahlkorper.ylm_spherepack().theta_phi_points();
@@ -158,7 +157,7 @@ void test_normals() {
   const double radius = 2.0;
   const std::array<double, 3> center = {{0.1, 0.2, 0.3}};
   const auto strahlkorper =
-      create_strahlkorper_y11(y11_amplitude, radius, center);
+      ylm::TestHelpers::create_strahlkorper_y11(y11_amplitude, radius, center);
 
   const auto theta_phi = strahlkorper.ylm_spherepack().theta_phi_points();
   const auto n_pts = theta_phi[0].size();

--- a/tests/Unit/NumericalAlgorithms/SphericalHarmonics/Test_YlmToStf.cpp
+++ b/tests/Unit/NumericalAlgorithms/SphericalHarmonics/Test_YlmToStf.cpp
@@ -13,6 +13,7 @@
 #include "NumericalAlgorithms/SphericalHarmonics/YlmToStf.hpp"
 #include "Utilities/Gsl.hpp"
 
+namespace ylm {
 SPECTRE_TEST_CASE("Unit.SphericalHarmonics.YlmToStf",
                   "[NumericalAlgorithms][Unit]") {
   MAKE_GENERATOR(generator);
@@ -92,3 +93,4 @@ SPECTRE_TEST_CASE("Unit.SphericalHarmonics.YlmToStf",
     CHECK_ITERABLE_APPROX(stf_l2_at_points, ylm_l2_at_points);
   }
 }
+}  // namespace ylm

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_ApparentHorizonFinder.cpp
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_ApparentHorizonFinder.cpp
@@ -309,7 +309,7 @@ void test_apparent_horizon(const gsl::not_null<size_t*> test_horizon_called,
   // Options for all InterpolationTargets.
   // The initial guess for the horizon search is a sphere of radius 2.8M.
   intrp::OptionHolders::ApparentHorizon<Frame> apparent_horizon_opts(
-      Strahlkorper<Frame>{l_max, 2.8, {{0.0, 0.0, 0.0}}},
+      ylm::Strahlkorper<Frame>{l_max, 2.8, {{0.0, 0.0, 0.0}}},
       FastFlow{FastFlow::FlowType::Fast, 1.0, 0.5, 1.e-12, 1.e-2, 1.2, 5,
                max_its},
       Verbosity::Verbose);

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_FastFlow.cpp
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_FastFlow.cpp
@@ -39,7 +39,7 @@
 namespace {
 
 FastFlow::Status do_iteration(
-    const gsl::not_null<Strahlkorper<Frame::Inertial>*> strahlkorper,
+    const gsl::not_null<ylm::Strahlkorper<Frame::Inertial>*> strahlkorper,
     const gsl::not_null<FastFlow*> flow,
     const gr::Solutions::KerrSchild& solution) {
   FastFlow::Status status = FastFlow::Status::SuccessfulIteration;
@@ -47,7 +47,7 @@ FastFlow::Status do_iteration(
   while (status == FastFlow::Status::SuccessfulIteration) {
     const auto l_mesh = flow->current_l_mesh(*strahlkorper);
     const auto prolonged_strahlkorper =
-        Strahlkorper<Frame::Inertial>(l_mesh, l_mesh, *strahlkorper);
+        ylm::Strahlkorper<Frame::Inertial>(l_mesh, l_mesh, *strahlkorper);
 
     const auto box = db::create<
         db::AddSimpleTags<ylm::Tags::items_tags<Frame::Inertial>>,
@@ -159,7 +159,7 @@ void test_ostream() {
 void test_negative_radius_error() {
   // Set initial Strahlkorper radius to negative on purpose to get
   // error exit status.
-  Strahlkorper<Frame::Inertial> strahlkorper(5, 5, -1.0, {{0, 0, 0}});
+  ylm::Strahlkorper<Frame::Inertial> strahlkorper(5, 5, -1.0, {{0, 0, 0}});
   FastFlow flow(FastFlow::FlowType::Fast, 1.0, 0.5, 1e-12, 1e-10, 1.2, 5, 100);
 
   const gr::Solutions::KerrSchild solution(1.0, {{0., 0., 0.}}, {{0., 0., 0.}});
@@ -169,7 +169,7 @@ void test_negative_radius_error() {
 }
 
 void test_too_many_iterations_error() {
-  Strahlkorper<Frame::Inertial> strahlkorper(5, 5, 3.0, {{0, 0, 0}});
+  ylm::Strahlkorper<Frame::Inertial> strahlkorper(5, 5, 3.0, {{0, 0, 0}});
   // Set number of iterations to 1 on purpose to get error exit status.
   FastFlow flow(FastFlow::FlowType::Fast, 1.0, 0.5, 1e-12, 1e-10, 1.2, 5, 1);
 
@@ -181,7 +181,7 @@ void test_too_many_iterations_error() {
 
 void test_schwarzschild(FastFlow::Flow::type type_of_flow,
                         const size_t max_iterations) {
-  Strahlkorper<Frame::Inertial> strahlkorper(5, 5, 3.0, {{0, 0, 0}});
+  ylm::Strahlkorper<Frame::Inertial> strahlkorper(5, 5, 3.0, {{0, 0, 0}});
   FastFlow flow(type_of_flow, 1.0, 0.5, 1e-12, 1e-10, 1.2, 5, max_iterations);
 
   const gr::Solutions::KerrSchild solution(1.0, {{0., 0., 0.}}, {{0., 0., 0.}});
@@ -206,18 +206,18 @@ void test_schwarzschild(FastFlow::Flow::type type_of_flow,
   // We have found the horizon once.  Now perturb the strahlkorper
   // and find the horizon again. This checks that fastflow is reset
   // correctly.
-  strahlkorper = [](const Strahlkorper<Frame::Inertial>& strahlkorper_l) {
+  strahlkorper = [](const ylm::Strahlkorper<Frame::Inertial>& strahlkorper_l) {
     MAKE_GENERATOR(generator);
     std::uniform_real_distribution<> dist(0.0, 0.1);
     auto coefs = strahlkorper_l.coefficients();
-    for (auto coef_iter =
-             SpherepackIterator(strahlkorper_l.l_max(), strahlkorper_l.l_max());
+    for (auto coef_iter = ylm::SpherepackIterator(strahlkorper_l.l_max(),
+                                                  strahlkorper_l.l_max());
          coef_iter; ++coef_iter) {
       // Change all components randomly, but make smaller changes
       // to higher-order coefficients.
       coefs[coef_iter()] *= 1.0 + dist(generator) / square(coef_iter.l() + 1.0);
     }
-    return Strahlkorper<Frame::Inertial>(coefs, strahlkorper_l);
+    return ylm::Strahlkorper<Frame::Inertial>(coefs, strahlkorper_l);
   }(strahlkorper);
 
   flow.reset_for_next_find();
@@ -226,7 +226,8 @@ void test_schwarzschild(FastFlow::Flow::type type_of_flow,
 
 void test_kerr(FastFlow::Flow::type type_of_flow, const double mass,
                const size_t max_iterations) {
-  Strahlkorper<Frame::Inertial> strahlkorper(8, 8, 2.0 * mass, {{0, 0, 0}});
+  ylm::Strahlkorper<Frame::Inertial> strahlkorper(8, 8, 2.0 * mass,
+                                                  {{0, 0, 0}});
   FastFlow flow(type_of_flow, 1.0, 0.5, 1e-12, 1e-2, 1.2, 5, max_iterations);
 
   const std::array<double, 3> spin = {{0.1, 0.2, 0.3}};

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_InterpolationTargetApparentHorizon.cpp
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_InterpolationTargetApparentHorizon.cpp
@@ -74,7 +74,7 @@ SPECTRE_TEST_CASE(
 
   // Options for ApparentHorizon
   intrp::OptionHolders::ApparentHorizon<Frame::Inertial> apparent_horizon_opts(
-      Strahlkorper<Frame::Inertial>{l_max, radius, center}, FastFlow{},
+      ylm::Strahlkorper<Frame::Inertial>{l_max, radius, center}, FastFlow{},
       Verbosity::Verbose);
 
   // Test creation of options

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_ObserveCenters.cpp
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_ObserveCenters.cpp
@@ -80,11 +80,11 @@ void test() {
                ylm::Tags::CartesianCoords<::Frame::Inertial>,
                ylm::Tags::EuclideanAreaElement<Frame>>(
         [&grid_center, &inertial_center](
-            gsl::not_null<Strahlkorper<Frame>*> box_grid_horizon,
+            gsl::not_null<ylm::Strahlkorper<Frame>*> box_grid_horizon,
             gsl::not_null<tnsr::I<DataVector, 3, ::Frame::Inertial>*>
                 box_inertial_coords,
             gsl::not_null<Scalar<DataVector>*> box_area_element) {
-          *box_grid_horizon = Strahlkorper<Frame>{10, 1.0, grid_center};
+          *box_grid_horizon = ylm::Strahlkorper<Frame>{10, 1.0, grid_center};
           const auto theta_phi = ylm::theta_phi(*box_grid_horizon);
           const auto radius = ylm::radius(*box_grid_horizon);
           const auto rhat = ylm::rhat(theta_phi);

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_Tags.cpp
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_Tags.cpp
@@ -21,7 +21,6 @@
 #include "Helpers/NumericalAlgorithms/SphericalHarmonics/StrahlkorperTestHelpers.hpp"
 #include "Helpers/NumericalAlgorithms/SphericalHarmonics/YlmTestFunctions.hpp"
 #include "NumericalAlgorithms/SphericalHarmonics/Spherepack.hpp"
-#include "NumericalAlgorithms/SphericalHarmonics/SpherepackIterator.hpp"
 #include "NumericalAlgorithms/SphericalHarmonics/Strahlkorper.hpp"
 #include "NumericalAlgorithms/SphericalHarmonics/Tags.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/Tags.hpp"
@@ -36,7 +35,7 @@ void test_normals() {
   const double radius = 2.0;
   const std::array<double, 3> center = {{0.1, 0.2, 0.3}};
   const auto strahlkorper =
-      create_strahlkorper_y11(y11_amplitude, radius, center);
+      ylm::TestHelpers::create_strahlkorper_y11(y11_amplitude, radius, center);
 
   const auto theta_phi = strahlkorper.ylm_spherepack().theta_phi_points();
   const auto n_pts = theta_phi[0].size();
@@ -125,8 +124,8 @@ void test_dimensionful_spin_vector_compute_tag() {
   const double y11_amplitude = 1.0;
   const double y11_radius = 2.0;
   const std::array<double, 3> center = {{0.1, 0.2, 0.3}};
-  const auto strahlkorper =
-      create_strahlkorper_y11(y11_amplitude, y11_radius, center);
+  const auto strahlkorper = ylm::TestHelpers::create_strahlkorper_y11(
+      y11_amplitude, y11_radius, center);
   const size_t ylm_physical_size =
       strahlkorper.ylm_spherepack().physical_size();
   const DataVector used_for_size(ylm_physical_size,

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_ObserveTimeSeriesAndSurfaceData.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_ObserveTimeSeriesAndSurfaceData.cpp
@@ -91,8 +91,8 @@ void check_surface_volume_data(const std::string& surfaces_file_prefix) {
   constexpr size_t m_max = 10;
   constexpr double sphere_radius = 2.8;
   constexpr std::array<double, 3> center{{0.01, 0.02, 0.03}};
-  const Strahlkorper<Frame::Inertial> strahlkorper{l_max, m_max, sphere_radius,
-                                                   center};
+  const ylm::Strahlkorper<Frame::Inertial> strahlkorper{l_max, m_max,
+                                                        sphere_radius, center};
   const ylm::Spherepack& ylm = strahlkorper.ylm_spherepack();
   const std::vector<size_t> extents{
       {ylm.physical_extents()[0], ylm.physical_extents()[1]}};

--- a/tests/Unit/ParallelAlgorithms/SurfaceFinder/Test_SurfaceFinder.cpp
+++ b/tests/Unit/ParallelAlgorithms/SurfaceFinder/Test_SurfaceFinder.cpp
@@ -110,7 +110,7 @@ void test_strahlkorper_input(
   const double target = 4.3;
   const auto data = magnitude(inertial_coords);
 
-  const Strahlkorper<Frame::Inertial> strahlkorper{
+  const ylm::Strahlkorper<Frame::Inertial> strahlkorper{
       5, 5, 4.5, std::array<double, 3>{0., 0., 0.}};
   const auto& ylm = strahlkorper.ylm_spherepack();
   const auto& [theta, phi] = ylm.theta_phi_points();

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Surfaces/Test_GrSurfaces.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Surfaces/Test_GrSurfaces.cpp
@@ -59,7 +59,7 @@
 namespace {
 template <typename Solution, typename Fr, typename ExpectedLambda>
 void test_expansion(const Solution& solution,
-                    const Strahlkorper<Fr>& strahlkorper,
+                    const ylm::Strahlkorper<Fr>& strahlkorper,
                     const ExpectedLambda& expected) {
   // Make databox from surface
   const auto box = db::create<
@@ -125,7 +125,7 @@ void test_minkowski() {
   const auto box = db::create<
       db::AddSimpleTags<ylm::Tags::items_tags<Frame::Inertial>>,
       db::AddComputeTags<ylm::Tags::compute_items_tags<Frame::Inertial>>>(
-      Strahlkorper<Frame::Inertial>(8, 8, 2.0, {{0.0, 0.0, 0.0}}));
+      ylm::Strahlkorper<Frame::Inertial>(8, 8, 2.0, {{0.0, 0.0, 0.0}}));
 
   const double t = 0.0;
   const auto& cart_coords =
@@ -183,7 +183,7 @@ void test_ricci_scalar(const Solution& solution,
   const auto box = db::create<
       db::AddSimpleTags<ylm::Tags::items_tags<Frame::Inertial>>,
       db::AddComputeTags<ylm::Tags::compute_items_tags<Frame::Inertial>>>(
-      Strahlkorper<Frame::Inertial>(8, 8, 2.0, {{0.0, 0.0, 0.0}}));
+      ylm::Strahlkorper<Frame::Inertial>(8, 8, 2.0, {{0.0, 0.0, 0.0}}));
 
   const double t = 0.0;
   const auto& cart_coords =
@@ -235,7 +235,8 @@ void test_area_element(const Solution& solution, const double surface_radius,
   const auto box = db::create<
       db::AddSimpleTags<ylm::Tags::items_tags<Frame::Inertial>>,
       db::AddComputeTags<ylm::Tags::compute_items_tags<Frame::Inertial>>>(
-      Strahlkorper<Frame::Inertial>(8, 8, surface_radius, {{0.0, 0.0, 0.0}}));
+      ylm::Strahlkorper<Frame::Inertial>(8, 8, surface_radius,
+                                         {{0.0, 0.0, 0.0}}));
 
   const double t = 0.0;
   const auto& cart_coords =
@@ -260,7 +261,7 @@ void test_area_element(const Solution& solution, const double surface_radius,
 }
 
 void test_euclidean_surface_integral_of_vector(
-    const Strahlkorper<Frame::Inertial>& strahlkorper) {
+    const ylm::Strahlkorper<Frame::Inertial>& strahlkorper) {
   const auto box = db::create<
       db::AddSimpleTags<ylm::Tags::items_tags<Frame::Inertial>>,
       db::AddComputeTags<ylm::Tags::compute_items_tags<Frame::Inertial>>>(
@@ -297,7 +298,7 @@ void test_euclidean_surface_integral_of_vector(
 
 template <typename Solution, typename Frame>
 void test_euclidean_surface_integral_of_vector_2(
-    const Solution& solution, const Strahlkorper<Frame>& strahlkorper,
+    const Solution& solution, const ylm::Strahlkorper<Frame>& strahlkorper,
     double expected_area) {
   // Another test:  Integrate (assuming Euclidean metric) the vector
   // V^i = s_j \delta^{ij} (s_k s_l \delta^{kl})^{-1/2} A A_euclid^{-1}
@@ -350,7 +351,7 @@ void test_euclidean_surface_integral_of_vector_2(
 }
 
 void test_euclidean_area_element(
-    const Strahlkorper<Frame::Inertial>& strahlkorper) {
+    const ylm::Strahlkorper<Frame::Inertial>& strahlkorper) {
   const auto box = db::create<
       db::AddSimpleTags<ylm::Tags::items_tags<Frame::Inertial>>,
       db::AddComputeTags<ylm::Tags::compute_items_tags<Frame::Inertial>>>(
@@ -383,8 +384,9 @@ void test_euclidean_area_element(
 }
 
 template <typename Solution, typename Fr>
-void test_area(const Solution& solution, const Strahlkorper<Fr>& strahlkorper,
-               const double expected, const double expected_irreducible_mass,
+void test_area(const Solution& solution,
+               const ylm::Strahlkorper<Fr>& strahlkorper, const double expected,
+               const double expected_irreducible_mass,
                const double dimensionful_spin_magnitude,
                const double expected_christodoulou_mass) {
   const auto box = db::create<
@@ -439,8 +441,8 @@ void test_area(const Solution& solution, const Strahlkorper<Fr>& strahlkorper,
 //
 // This tests that I_1==I_2 for an arbitrary 3-vector J^i.
 template <typename Solution, typename Frame>
-void test_integral_correspondence(const Solution& solution,
-                                  const Strahlkorper<Frame>& strahlkorper) {
+void test_integral_correspondence(
+    const Solution& solution, const ylm::Strahlkorper<Frame>& strahlkorper) {
   const auto box =
       db::create<db::AddSimpleTags<ylm::Tags::items_tags<Frame>>,
                  db::AddComputeTags<ylm::Tags::compute_items_tags<Frame>>>(
@@ -504,7 +506,7 @@ void test_integral_correspondence(const Solution& solution,
 
 template <typename Solution, typename Fr>
 void test_surface_integral_of_scalar(const Solution& solution,
-                                     const Strahlkorper<Fr>& strahlkorper,
+                                     const ylm::Strahlkorper<Fr>& strahlkorper,
                                      const double expected) {
   const auto box =
       db::create<db::AddSimpleTags<ylm::Tags::items_tags<Fr>>,
@@ -539,7 +541,7 @@ void test_surface_integral_of_scalar(const Solution& solution,
 
 template <typename Solution, typename Fr>
 void test_spin_function(const Solution& solution,
-                        const Strahlkorper<Fr>& strahlkorper,
+                        const ylm::Strahlkorper<Fr>& strahlkorper,
                         const double expected) {
   const auto box = db::create<
       db::AddSimpleTags<ylm::Tags::items_tags<Frame::Inertial>>,
@@ -607,7 +609,7 @@ void test_spin_function(const Solution& solution,
 
 template <typename Solution, typename Fr>
 void test_dimensionful_spin_magnitude(
-    const Solution& solution, const Strahlkorper<Fr>& strahlkorper,
+    const Solution& solution, const ylm::Strahlkorper<Fr>& strahlkorper,
     const double mass, const std::array<double, 3> dimensionless_spin,
     const Scalar<DataVector>& horizon_radius_with_spin_on_z_axis,
     const ylm::Spherepack& ylm_with_spin_on_z_axis, const double expected,
@@ -699,7 +701,7 @@ void test_dimensionful_spin_magnitude(
 
 template <typename Solution, typename Fr>
 void test_spin_vector(
-    const Solution& solution, const Strahlkorper<Fr>& strahlkorper,
+    const Solution& solution, const ylm::Strahlkorper<Fr>& strahlkorper,
     const double mass, const std::array<double, 3> dimensionless_spin,
     const Scalar<DataVector>& horizon_radius_with_spin_on_z_axis,
     const ylm::Spherepack& ylm_with_spin_on_z_axis) {
@@ -769,10 +771,9 @@ void test_spin_vector(
 }
 
 template <typename Solution, typename Fr>
-void test_dimensionless_spin_magnitude(const Solution& solution,
-                                       const Strahlkorper<Fr>& strahlkorper,
-                                       const double dimensionful_spin_magnitude,
-                                       const double expected) {
+void test_dimensionless_spin_magnitude(
+    const Solution& solution, const ylm::Strahlkorper<Fr>& strahlkorper,
+    const double dimensionful_spin_magnitude, const double expected) {
   const auto box = db::create<
       db::AddSimpleTags<ylm::Tags::items_tags<Frame::Inertial>>,
       db::AddComputeTags<ylm::Tags::compute_items_tags<Frame::Inertial>>>(
@@ -819,7 +820,7 @@ void test_dimensionless_spin_magnitude(const Solution& solution,
 
 SPECTRE_TEST_CASE("Unit.GrSurfaces.Expansion", "[ApparentHorizons][Unit]") {
   const auto sphere =
-      Strahlkorper<Frame::Inertial>(8, 8, 2.0, {{0.0, 0.0, 0.0}});
+      ylm::Strahlkorper<Frame::Inertial>(8, 8, 2.0, {{0.0, 0.0, 0.0}});
 
   test_expansion(
       gr::Solutions::KerrSchild{1.0, {{0.0, 0.0, 0.0}}, {{0.0, 0.0, 0.0}}},
@@ -833,13 +834,13 @@ SPECTRE_TEST_CASE("Unit.GrSurfaces.Expansion", "[ApparentHorizons][Unit]") {
   const std::array<double, 3> center{{0.0, 0.0, 0.0}};
 
   const auto horizon_radius = gr::Solutions::kerr_horizon_radius(
-      Strahlkorper<Frame::Inertial>(l_max, l_max, 2.0, center)
+      ylm::Strahlkorper<Frame::Inertial>(l_max, l_max, 2.0, center)
           .ylm_spherepack()
           .theta_phi_points(),
       mass, spin);
 
-  const auto kerr_horizon =
-      Strahlkorper<Frame::Inertial>(l_max, l_max, get(horizon_radius), center);
+  const auto kerr_horizon = ylm::Strahlkorper<Frame::Inertial>(
+      l_max, l_max, get(horizon_radius), center);
 
   test_expansion(gr::Solutions::KerrSchild{mass, spin, center}, kerr_horizon,
                  [](const size_t size) { return DataVector(size, 0.0); });
@@ -897,13 +898,13 @@ SPECTRE_TEST_CASE("Unit.GrSurfaces.AreaElement", "[ApparentHorizons][Unit]") {
       sqrt(0.5 * mass * kerr_horizon_radius);
 
   const auto horizon_radius = gr::Solutions::kerr_horizon_radius(
-      Strahlkorper<Frame::Inertial>(l_max, l_max, 2.0, center)
+      ylm::Strahlkorper<Frame::Inertial>(l_max, l_max, 2.0, center)
           .ylm_spherepack()
           .theta_phi_points(),
       mass, spin);
 
-  const auto kerr_horizon =
-      Strahlkorper<Frame::Inertial>(l_max, l_max, get(horizon_radius), center);
+  const auto kerr_horizon = ylm::Strahlkorper<Frame::Inertial>(
+      l_max, l_max, get(horizon_radius), center);
 
   test_area(gr::Solutions::KerrSchild{mass, spin, center}, kerr_horizon,
             expected_area, expected_irreducible_mass,
@@ -918,9 +919,9 @@ SPECTRE_TEST_CASE("Unit.GrSurfaces.AreaElement", "[ApparentHorizons][Unit]") {
   // Check that the two methods of computing the surface integral are
   // still equal for a surface inside and outside the horizon
   // (that is, for spacelike and timelike Strahlkorpers).
-  const auto inside_kerr_horizon = Strahlkorper<Frame::Inertial>(
+  const auto inside_kerr_horizon = ylm::Strahlkorper<Frame::Inertial>(
       l_max, l_max, 0.9 * get(horizon_radius), center);
-  const auto outside_kerr_horizon = Strahlkorper<Frame::Inertial>(
+  const auto outside_kerr_horizon = ylm::Strahlkorper<Frame::Inertial>(
       l_max, l_max, 2.0 * get(horizon_radius), center);
   test_integral_correspondence(gr::Solutions::KerrSchild{mass, spin, center},
                                inside_kerr_horizon);
@@ -949,7 +950,7 @@ SPECTRE_TEST_CASE("Unit.GrSurfaces.SurfaceIntegralOfScalar",
   const double expected_integral = 4.0 * M_PI * square(square(radius)) / 3.0;
 
   const auto horizon =
-      Strahlkorper<Frame::Inertial>(l_max, l_max, radius, center);
+      ylm::Strahlkorper<Frame::Inertial>(l_max, l_max, radius, center);
 
   test_surface_integral_of_scalar(gr::Solutions::KerrSchild{mass, spin, center},
                                   horizon, expected_integral);
@@ -963,19 +964,19 @@ SPECTRE_TEST_CASE("Unit.GrSurfaces.SpinFunction", "[ApparentHorizons][Unit]") {
   const std::array<double, 3> center{{0.0, 0.0, 0.0}};
 
   const auto horizon_radius = gr::Solutions::kerr_horizon_radius(
-      Strahlkorper<Frame::Inertial>(l_max, l_max, 2.0, center)
+      ylm::Strahlkorper<Frame::Inertial>(l_max, l_max, 2.0, center)
           .ylm_spherepack()
           .theta_phi_points(),
       mass, spin);
 
-  const auto kerr_horizon =
-      Strahlkorper<Frame::Inertial>(l_max, l_max, get(horizon_radius), center);
+  const auto kerr_horizon = ylm::Strahlkorper<Frame::Inertial>(
+      l_max, l_max, get(horizon_radius), center);
 
   // Check value of SpinFunction^2 integrated over the surface for
   // Schwarzschild. Expected result is zero.
-  test_spin_function(gr::Solutions::KerrSchild{mass, {{0.0, 0.0, 0.0}}, center},
-                     Strahlkorper<Frame::Inertial>(l_max, l_max, 8.888, center),
-                     0.0);
+  test_spin_function(
+      gr::Solutions::KerrSchild{mass, {{0.0, 0.0, 0.0}}, center},
+      ylm::Strahlkorper<Frame::Inertial>(l_max, l_max, 8.888, center), 0.0);
 
   // Check value of SpinFunction^2 integrated over the surface for
   // Kerr. Derive this by integrating the square of the imaginary
@@ -1006,11 +1007,12 @@ SPECTRE_TEST_CASE("Unit.GrSurfaces.DimensionfulSpinMagnitude",
   const std::array<double, 3> aligned_dimensionless_spin = {
       {0.0, 0.0, expected_dimensionless_spin_magnitude}};
   const auto aligned_horizon_radius = gr::Solutions::kerr_horizon_radius(
-      Strahlkorper<Frame::Inertial>(aligned_l_max, aligned_l_max, 2.0, center)
+      ylm::Strahlkorper<Frame::Inertial>(aligned_l_max, aligned_l_max, 2.0,
+                                         center)
           .ylm_spherepack()
           .theta_phi_points(),
       mass, aligned_dimensionless_spin);
-  const auto aligned_kerr_horizon = Strahlkorper<Frame::Inertial>(
+  const auto aligned_kerr_horizon = ylm::Strahlkorper<Frame::Inertial>(
       aligned_l_max, aligned_l_max, get(aligned_horizon_radius), center);
   test_dimensionful_spin_magnitude(
       gr::Solutions::KerrSchild{mass, aligned_dimensionless_spin, center},
@@ -1025,21 +1027,23 @@ SPECTRE_TEST_CASE("Unit.GrSurfaces.DimensionfulSpinMagnitude",
   const double expected_generic_spin_magnitude =
       expected_generic_dimensionless_spin_magnitude * square(mass);
   const auto generic_horizon_radius = gr::Solutions::kerr_horizon_radius(
-      Strahlkorper<Frame::Inertial>(generic_l_max, generic_l_max, 2.0, center)
+      ylm::Strahlkorper<Frame::Inertial>(generic_l_max, generic_l_max, 2.0,
+                                         center)
           .ylm_spherepack()
           .theta_phi_points(),
       mass, generic_dimensionless_spin);
-  const auto generic_kerr_horizon = Strahlkorper<Frame::Inertial>(
+  const auto generic_kerr_horizon = ylm::Strahlkorper<Frame::Inertial>(
       generic_l_max, generic_l_max, get(generic_horizon_radius), center);
 
   // Create rotated horizon radius, Strahlkorper, with same spin magnitude
   // but with spin on the z axis
   const auto rotated_horizon_radius = gr::Solutions::kerr_horizon_radius(
-      Strahlkorper<Frame::Inertial>(generic_l_max, generic_l_max, 2.0, center)
+      ylm::Strahlkorper<Frame::Inertial>(generic_l_max, generic_l_max, 2.0,
+                                         center)
           .ylm_spherepack()
           .theta_phi_points(),
       mass, aligned_dimensionless_spin);
-  const auto rotated_kerr_horizon = Strahlkorper<Frame::Inertial>(
+  const auto rotated_kerr_horizon = ylm::Strahlkorper<Frame::Inertial>(
       generic_l_max, generic_l_max, get(rotated_horizon_radius), center);
   test_dimensionful_spin_magnitude(
       gr::Solutions::KerrSchild{mass, generic_dimensionless_spin, center},
@@ -1057,21 +1061,22 @@ SPECTRE_TEST_CASE("Unit.GrSurfaces.SpinVector", "[ApparentHorizons][Unit]") {
   const std::array<double, 3> center{{0.0, 0.0, 0.0}};
 
   const auto horizon_radius = gr::Solutions::kerr_horizon_radius(
-      Strahlkorper<Frame::Inertial>(l_max, l_max, 2.0, center)
+      ylm::Strahlkorper<Frame::Inertial>(l_max, l_max, 2.0, center)
           .ylm_spherepack()
           .theta_phi_points(),
       mass, spin);
-  const auto kerr_horizon =
-      Strahlkorper<Frame::Inertial>(l_max, l_max, get(horizon_radius), center);
+  const auto kerr_horizon = ylm::Strahlkorper<Frame::Inertial>(
+      l_max, l_max, get(horizon_radius), center);
 
   const auto horizon_radius_with_spin_on_z_axis =
       gr::Solutions::kerr_horizon_radius(
-          Strahlkorper<Frame::Inertial>(l_max, l_max, 2.0, center)
+          ylm::Strahlkorper<Frame::Inertial>(l_max, l_max, 2.0, center)
               .ylm_spherepack()
               .theta_phi_points(),
           mass, {{0.0, 0.0, spin_magnitude}});
-  const auto kerr_horizon_with_spin_on_z_axis = Strahlkorper<Frame::Inertial>(
-      l_max, l_max, get(horizon_radius_with_spin_on_z_axis), center);
+  const auto kerr_horizon_with_spin_on_z_axis =
+      ylm::Strahlkorper<Frame::Inertial>(
+          l_max, l_max, get(horizon_radius_with_spin_on_z_axis), center);
 
   // Check that the gr::surfaces::spin_vector() correctly recovers the
   // chosen dimensionless spin
@@ -1090,13 +1095,13 @@ SPECTRE_TEST_CASE("Unit.GrSurfaces.DimensionlessSpinMagnitude",
   // Set up Kerr horizon
   const double l_max = 20;
   const auto horizon_radius = gr::Solutions::kerr_horizon_radius(
-      Strahlkorper<Frame::Inertial>(l_max, l_max, 2.0, center)
+      ylm::Strahlkorper<Frame::Inertial>(l_max, l_max, 2.0, center)
           .ylm_spherepack()
           .theta_phi_points(),
       mass, spin);
 
-  const auto kerr_horizon =
-      Strahlkorper<Frame::Inertial>(l_max, l_max, get(horizon_radius), center);
+  const auto kerr_horizon = ylm::Strahlkorper<Frame::Inertial>(
+      l_max, l_max, get(horizon_radius), center);
 
   // Set up dimensionful spin magnitude
   const double spin_magnitude = magnitude(spin);
@@ -1124,9 +1129,9 @@ SPECTRE_TEST_CASE("Unit.GrSurfaces.RadialDistance",
   const double radius = 2.0;
   const std::array<double, 3> center = {{0.1, 0.2, 0.3}};
   const auto strahlkorper_a =
-      create_strahlkorper_y11(y11_amplitude, radius, center);
-  const auto strahlkorper_b =
-      create_strahlkorper_y11(4.0 * y11_amplitude, radius, center);
+      ylm::TestHelpers::create_strahlkorper_y11(y11_amplitude, radius, center);
+  const auto strahlkorper_b = ylm::TestHelpers::create_strahlkorper_y11(
+      4.0 * y11_amplitude, radius, center);
   const Scalar<DataVector> expected_radial_dist_a_minus_b{
       get(ylm::radius(strahlkorper_a)) - get(ylm::radius(strahlkorper_b))};
   const Scalar<DataVector> expected_radial_dist_b_minus_a{
@@ -1142,32 +1147,33 @@ SPECTRE_TEST_CASE("Unit.GrSurfaces.RadialDistance",
   // Check cases where one has more resolution than the other
   gr::surfaces::radial_distance(
       make_not_null(&radial_dist), strahlkorper_a,
-      Strahlkorper(strahlkorper_b.l_max() - 1, strahlkorper_b.m_max() - 1,
-                   strahlkorper_b));
+      ylm::Strahlkorper(strahlkorper_b.l_max() - 1, strahlkorper_b.m_max() - 1,
+                        strahlkorper_b));
   CHECK_ITERABLE_APPROX(radial_dist, expected_radial_dist_a_minus_b);
   gr::surfaces::radial_distance(
       make_not_null(&radial_dist),
-      Strahlkorper(strahlkorper_b.l_max() - 1, strahlkorper_b.m_max() - 1,
-                   strahlkorper_b),
+      ylm::Strahlkorper(strahlkorper_b.l_max() - 1, strahlkorper_b.m_max() - 1,
+                        strahlkorper_b),
       strahlkorper_a);
   CHECK_ITERABLE_APPROX(radial_dist, expected_radial_dist_b_minus_a);
   gr::surfaces::radial_distance(
       make_not_null(&radial_dist), strahlkorper_a,
-      Strahlkorper(strahlkorper_b.l_max(), strahlkorper_b.m_max() - 1,
-                   strahlkorper_b));
+      ylm::Strahlkorper(strahlkorper_b.l_max(), strahlkorper_b.m_max() - 1,
+                        strahlkorper_b));
   CHECK_ITERABLE_APPROX(radial_dist, expected_radial_dist_a_minus_b);
   gr::surfaces::radial_distance(
       make_not_null(&radial_dist),
-      Strahlkorper(strahlkorper_b.l_max(), strahlkorper_b.m_max() - 1,
-                   strahlkorper_b),
+      ylm::Strahlkorper(strahlkorper_b.l_max(), strahlkorper_b.m_max() - 1,
+                        strahlkorper_b),
       strahlkorper_a);
   CHECK_ITERABLE_APPROX(radial_dist, expected_radial_dist_b_minus_a);
 
   CHECK_THROWS_WITH(
       ([&strahlkorper_a, &y11_amplitude, &radius, &radial_dist]() {
         const std::array<double, 3> different_center{{0.1, 0.4, 0.3}};
-        const auto strahlkorper_off_center = create_strahlkorper_y11(
-            4.0 * y11_amplitude, radius, different_center);
+        const auto strahlkorper_off_center =
+            ylm::TestHelpers::create_strahlkorper_y11(4.0 * y11_amplitude,
+                                                      radius, different_center);
         gr::surfaces::radial_distance(make_not_null(&radial_dist),
                                       strahlkorper_a, strahlkorper_off_center);
       }()),


### PR DESCRIPTION
## Proposed changes

Another item in #5282.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
All items in `NumericalAlgorithms/SphericalHarmonics/` now live in the `ylm` namespace (e.g. `ylm::Strahlkorper`).
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
