### PR TITLE
Fix issue where bounds in Tabulated3D EOS can become zero

### DIFF
--- a/src/PointwiseFunctions/Hydro/EquationsOfState/Tabulated3d.cpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/Tabulated3d.cpp
@@ -452,10 +452,25 @@ Tabulated3D<IsRelativistic>::temperature_from_density_and_energy_impl(
 
         return log_eps - interpolated_values[0];
       };
-      const auto root_from_lambda = RootFinder::toms748(
-          f, table_log_temperature_.front(),
-          upper_bound_tolerance_ * table_log_temperature_.back(), 1.0e-14,
-          1.0e-15);
+
+      // Check bounds to avoid error in TOMS748 if bracket is zero
+      bool need_root_finding = true;
+      double root_from_lambda = table_log_temperature_.front();
+      if (fabs(f(table_log_temperature_.front())) <= 1.0e-14) {
+        need_root_finding = false;
+      }
+
+      if (fabs(f(upper_bound_tolerance_ * table_log_temperature_.back())) <=
+               1.0e-14) {
+        root_from_lambda = table_log_temperature_.back();
+        need_root_finding = false;
+      }
+      if (need_root_finding) {
+        root_from_lambda = RootFinder::toms748(
+            f, table_log_temperature_.front(),
+            upper_bound_tolerance_ * table_log_temperature_.back(), 1.0e-14,
+            1.0e-15);
+      }
 
       get(temperature)[s] = exp(root_from_lambda);
     }


### PR DESCRIPTION
This should address #5401 
