### PR TITLE
Add CombineH5Dat to CLI

### DIFF
--- a/src/IO/H5/Python/CMakeLists.txt
+++ b/src/IO/H5/Python/CMakeLists.txt
@@ -16,6 +16,7 @@ spectre_python_add_module(
   PYTHON_FILES
   __init__.py
   CombineH5.py
+  CombineH5Dat.py
   DeleteSubfiles.py
   ExtendConnectivityData.py
   ExtractDatFromH5.py

--- a/src/IO/H5/Python/CombineH5Dat.py
+++ b/src/IO/H5/Python/CombineH5Dat.py
@@ -1,0 +1,100 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import logging
+import os
+import shutil
+
+import click
+import h5py
+
+from spectre.Visualization.ReadH5 import available_subfiles
+
+
+def combine_h5_dat(h5files, output, force):
+    """Combines multiple HDF5 dat files
+
+    This executable is used for combining a series of HDF5 files, each
+    containing one or more dat files, into a single HDF5 file. A typical
+    use case is to join dat-containing HDF5 files from different segments
+    of a simulation, with each segment containing values of the dat files
+    during different time intervals.
+
+    \f
+    Arguments:
+      h5files: List of H5 dat files to join
+      output: Output filename. An extension '.h5' will be added if not present.
+      force: If specified, overwrite output file if it already exists
+    """
+
+    if len(h5files) == 0:
+        return
+
+    # Copy first input file to output file
+    if not output.endswith(".h5"):
+        output += ".h5"
+    # If output file exists, exit unless the user specifies `--force`
+    if os.path.exists(output) and not force:
+        raise ValueError(f"File '{output}' exists; to overwrite, use --force")
+    shutil.copy(h5files[0], output)
+
+    # Open the output file for appending
+    with h5py.File(output, "r+") as out:
+        # Get a list of all dat file keys (keys ending in ".dat")
+        dat_file_keys = available_subfiles(out, extension=".dat")
+
+        # Loop over remaining input files, appending each dat file
+        for input_file in h5files[1:]:
+            with h5py.File(input_file, "r") as input:
+                for dat_file_key in dat_file_keys:
+                    if dat_file_key in input.keys():
+                        data_to_append = input[dat_file_key]
+                        start_size = out[dat_file_key].shape[0]
+                        append_size = input[dat_file_key].shape[0]
+                        out[dat_file_key].resize(
+                            start_size + append_size, axis=0
+                        )
+                        out[dat_file_key][start_size:] = input[dat_file_key]
+                    else:
+                        logging.warning(
+                            f"CombineH5Dat: Dat file '{dat_file_key}'"
+                            f" not found in input file '{input_file}'"
+                        )
+
+
+@click.command(name="combine-h5-dat", help=combine_h5_dat.__doc__)
+@click.argument(
+    "h5files",
+    type=click.Path(
+        exists=True,
+        file_okay=True,
+        dir_okay=False,
+        readable=True,
+    ),
+    nargs=-1,
+)
+@click.option(
+    "--output",
+    "-o",
+    required=True,
+    type=click.Path(
+        exists=False,
+        file_okay=True,
+        dir_okay=False,
+        writable=True,
+        readable=True,
+    ),
+    help="Combined output filename.",
+)
+@click.option(
+    "--force",
+    "-f",
+    is_flag=True,
+    help="If the output file already exists, overwrite it.",
+)
+def combine_h5_dat_command(**kwargs):
+    combine_h5_dat(kwargs["h5files"], kwargs["output"], kwargs["force"])
+
+
+if __name__ == "__main__":
+    combine_h5_dat_command(help_option_names=["-h", "--help"])

--- a/support/Python/__main__.py
+++ b/support/Python/__main__.py
@@ -22,6 +22,7 @@ class Cli(click.MultiCommand):
         return [
             "clean-output",
             "combine-h5",
+            "combine-h5-dat",
             "delete-subfiles",
             "extend-connectivity",
             "extract-dat",
@@ -49,6 +50,11 @@ class Cli(click.MultiCommand):
             from spectre.IO.H5.CombineH5 import combine_h5_command
 
             return combine_h5_command
+        elif name == "combine-h5-dat":
+            from spectre.IO.H5.CombineH5Dat import combine_h5_dat_command
+
+            return combine_h5_dat_command
+
         elif name == "delete-subfiles":
             from spectre.IO.H5.DeleteSubfiles import delete_subfiles_command
 

--- a/tests/Unit/IO/H5/Python/CMakeLists.txt
+++ b/tests/Unit/IO/H5/Python/CMakeLists.txt
@@ -12,6 +12,12 @@ if (NOT PY_DEV_MODE)
 endif()
 
 spectre_add_python_bindings_test(
+  "Unit.IO.H5.Python.CombineH5Dat"
+  Test_CombineH5Dat.py
+  "unit;IO;H5;python"
+  PyH5)
+
+spectre_add_python_bindings_test(
   "Unit.IO.H5.Python.ExtendConnectivity"
   Test_ExtendConnectivity.py
   "unit;IO;H5;python"

--- a/tests/Unit/IO/H5/Python/Test_CombineH5Dat.py
+++ b/tests/Unit/IO/H5/Python/Test_CombineH5Dat.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python
+
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import os
+import shutil
+import unittest
+
+import h5py
+import numpy as np
+import numpy.testing as npt
+from click.testing import CliRunner
+
+import spectre.Informer as spectre_informer
+import spectre.IO.H5 as spectre_h5
+from spectre.IO.H5.CombineH5Dat import combine_h5_dat, combine_h5_dat_command
+
+
+class TestCombineH5Dat(unittest.TestCase):
+    def setUp(self):
+        unit_test_build_dir = spectre_informer.unit_test_build_path()
+        self.test_dir = os.path.join(unit_test_build_dir, "IO/H5/Python")
+        os.makedirs(self.test_dir, exist_ok=True)
+
+        # Set up directories to hold the input files and the joined output file
+        self.input_dir = os.path.join(self.test_dir, "TestCombineH5DatInput")
+        self.output_dir = os.path.join(self.test_dir, "TestCombineH5DatOutput")
+        if os.path.exists(self.input_dir):
+            shutil.rmtree(self.input_dir)
+        if os.path.exists(self.output_dir):
+            shutil.rmtree(self.output_dir)
+        os.makedirs(self.input_dir, exist_ok=True)
+        os.makedirs(self.output_dir, exist_ok=True)
+
+        self.input_file_paths = [
+            os.path.join(self.input_dir, "TestDatSeg" + str(i) + ".h5")
+            for i in range(1, 4, 1)
+        ]
+        self.output_file_path = os.path.join(
+            self.output_dir, "TestDatSegJoined.h5"
+        )
+        self.output_file_path_cli = os.path.join(
+            self.output_dir, "TestDatSegJoinedCLI.h5"
+        )
+        self.expected_file_path = os.path.join(
+            self.output_dir, "TestDatSegExpected.h5"
+        )
+
+        # Generate sample dat data for H5 files to be joined
+        self.wave_1 = np.array(
+            [[t, np.sin(t), np.cos(t)] for t in np.arange(0, 10.0, 0.1)]
+        )
+        self.wave_2 = np.array(
+            [[t, np.sin(t), np.cos(t)] for t in np.arange(10.0, 20.0, 0.1)]
+        )
+        self.wave_3 = np.array(
+            [[t, np.sin(t), np.cos(t)] for t in np.arange(20.0, 30.0, 0.1)]
+        )
+        self.wave_joined = np.concatenate(
+            (self.wave_1, self.wave_2, self.wave_3), axis=0
+        )
+        self.pow_1 = np.array(
+            [[t, t**2, t**3, t**4] for t in np.arange(0, 10.0, 0.1)]
+        )
+        self.pow_2 = np.array(
+            [[t, t**2, t**3, t**4] for t in np.arange(10.0, 20.0, 0.1)]
+        )
+        self.pow_3 = np.array(
+            [[t, t**2, t**3, t**4] for t in np.arange(20.0, 30.0, 0.1)]
+        )
+        self.pow_joined = np.concatenate(
+            (self.pow_1, self.pow_2, self.pow_3), axis=0
+        )
+
+        # Generate 3 H5 files with two dat files inside each
+        with spectre_h5.H5File(
+            file_name=self.input_file_paths[0], mode="r+"
+        ) as h5file:
+            wave_datfile = h5file.insert_dat(
+                path="/Waves", legend=["Time", "Sin(t)", "Cos(t)"], version=0
+            )
+            wave_datfile.append(self.wave_1)
+        with spectre_h5.H5File(
+            file_name=self.input_file_paths[0], mode="r+"
+        ) as h5file:
+            pow_datfile = h5file.insert_dat(
+                path="/Powers/Pow",
+                legend=["Time", "t*t", "t*t*t", "t*t*t*t"],
+                version=0,
+            )
+            pow_datfile.append(self.pow_1)
+        with spectre_h5.H5File(
+            file_name=self.input_file_paths[1], mode="r+"
+        ) as h5file:
+            wave_datfile = h5file.insert_dat(
+                path="/Waves", legend=["Time", "Sin(t)", "Cos(t)"], version=0
+            )
+            wave_datfile.append(self.wave_2)
+        with spectre_h5.H5File(
+            file_name=self.input_file_paths[1], mode="r+"
+        ) as h5file:
+            pow_datfile = h5file.insert_dat(
+                path="/Powers/Pow",
+                legend=["Time", "t*t", "t*t*t", "t*t*t*t"],
+                version=0,
+            )
+            pow_datfile.append(self.pow_2)
+        with spectre_h5.H5File(
+            file_name=self.input_file_paths[2], mode="r+"
+        ) as h5file:
+            wave_datfile = h5file.insert_dat(
+                path="/Waves", legend=["Time", "Sin(t)", "Cos(t)"], version=0
+            )
+            wave_datfile.append(self.wave_3)
+        with spectre_h5.H5File(
+            file_name=self.input_file_paths[2], mode="r+"
+        ) as h5file:
+            pow_datfile = h5file.insert_dat(
+                path="/Powers/Pow",
+                legend=["Time", "t*t", "t*t*t", "t*t*t*t"],
+                version=0,
+            )
+            pow_datfile.append(self.pow_3)
+
+        self.test_yaml = """
+        # Distributed under the MIT License.
+        # See LICENSE.txt for details.
+        Amplitude: 1.0 # Code units
+        Frequency: 1.0 # Hz
+        Phase: 0.0     # Rad
+        Powers: [1, 2, 3, 4]
+        """
+        with h5py.File(self.input_file_paths[0], "r+") as h5file:
+            h5file.attrs.modify("InputSource.yaml", self.test_yaml)
+        with h5py.File(self.input_file_paths[1], "r+") as h5file:
+            h5file.attrs.modify("InputSource.yaml", self.test_yaml)
+        with h5py.File(self.input_file_paths[2], "r+") as h5file:
+            h5file.attrs.modify("InputSource.yaml", self.test_yaml)
+
+    def tearDown(self):
+        if os.path.exists(self.input_dir):
+            shutil.rmtree(self.input_dir)
+        if os.path.exists(self.output_dir):
+            shutil.rmtree(self.output_dir)
+
+    def test_combine_h5_dat(self):
+        combine_h5_dat(
+            output=self.output_file_path,
+            h5files=self.input_file_paths,
+            force=None,
+        )
+
+        with h5py.File(self.output_file_path) as h5file:
+            npt.assert_allclose(h5file["Waves.dat"], self.wave_joined)
+            npt.assert_allclose(h5file["Powers/Pow.dat"], self.pow_joined)
+            self.assertEqual(h5file.attrs["InputSource.yaml"], self.test_yaml)
+
+    def test_cli(self):
+        runner = CliRunner()
+        result = runner.invoke(
+            combine_h5_dat_command,
+            ["-o", self.output_file_path_cli, *self.input_file_paths],
+            catch_exceptions=False,
+        )
+        with self.assertRaisesRegex(
+            ValueError, "exists; to overwrite, use --force"
+        ):
+            runner.invoke(
+                combine_h5_dat_command,
+                ["-o", self.output_file_path_cli, *self.input_file_paths],
+                catch_exceptions=False,
+            )
+        result_force = runner.invoke(
+            combine_h5_dat_command,
+            [
+                "-o",
+                self.output_file_path_cli,
+                "--force",
+                *self.input_file_paths,
+            ],
+            catch_exceptions=False,
+        )
+        self.assertEqual(result.exit_code, 0)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Proposed changes

Adds an executable to join H5 files containing Dat files. The intended use is to join H5 data (such as reduction or CCE data) from different segments of a run, such as the segments resulting from using the `schedule` CLI.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
To join H5 dat files from different segments (e.g., the segments resulting from using `schedule`/ checkpoint & restart), you can use the new CLI command `combine-h5-dat` to combine these H5 files into a single H5 file. This is necessary before providing CCE output files to `CharacteristicExtract`.
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
