### PR TITLE
Link libxsmm only in Release mode on ARM Macs

### DIFF
--- a/src/Utilities/CMakeLists.txt
+++ b/src/Utilities/CMakeLists.txt
@@ -88,8 +88,20 @@ target_link_libraries(
   Boost::boost
   Brigand
   ErrorHandling
-  Libxsmm
   )
+
+# Libxsmm is disabled in Debug mode (see Blas.hpp).
+# As of Sep 1, 2023 libxsmm has an issue with lldb on ARM Macs (detecting
+# the CPU architecture raises SIGILL signals when loading the libxsmm dynamic
+# library). Just not linking libxsmm in Debug mode works around that.
+if (NOT ENABLE_SPECTRE_DEBUG
+    OR NOT (APPLE AND CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "arm64"))
+  target_link_libraries(
+    ${LIBRARY}
+    PUBLIC
+    Libxsmm
+    )
+endif()
 
 add_subdirectory(ErrorHandling)
 add_subdirectory(System)


### PR DESCRIPTION
## Proposed changes

libxsmm is currently disabled in Debug mode, but still linked. On my ARM Mac, libxsmm triggers SIGILL signals that makes debugging with lldb difficult. Just not linking libxsmm fixes this issue, and doesn't change any functionality because libxsmm is disabled in Debug mode anyway.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
