### PR TITLE
Write and read surface spherical harmonic data to and from disk

### DIFF
--- a/src/NumericalAlgorithms/SphericalHarmonics/CMakeLists.txt
+++ b/src/NumericalAlgorithms/SphericalHarmonics/CMakeLists.txt
@@ -49,3 +49,5 @@ target_link_libraries(
   FiniteDifference
   Interpolation
   )
+
+add_subdirectory(IO)

--- a/src/NumericalAlgorithms/SphericalHarmonics/IO/CMakeLists.txt
+++ b/src/NumericalAlgorithms/SphericalHarmonics/IO/CMakeLists.txt
@@ -1,0 +1,30 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBRARY SphericalHarmonicsIO)
+
+add_spectre_library(${LIBRARY})
+
+spectre_target_sources(
+  ${LIBRARY}
+  PRIVATE
+  ReadSurfaceYlm.cpp
+  )
+
+spectre_target_headers(
+  ${LIBRARY}
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  ReadSurfaceYlm.hpp
+  )
+
+target_link_libraries(
+  ${LIBRARY}
+  PRIVATE
+  DataStructures
+  ErrorHandling
+  H5
+  Utilities
+  PUBLIC
+  SphericalHarmonics
+  )

--- a/src/NumericalAlgorithms/SphericalHarmonics/IO/ReadSurfaceYlm.cpp
+++ b/src/NumericalAlgorithms/SphericalHarmonics/IO/ReadSurfaceYlm.cpp
@@ -1,0 +1,213 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "NumericalAlgorithms/SphericalHarmonics/IO/ReadSurfaceYlm.hpp"
+
+#include <array>
+#include <cmath>
+#include <cstddef>
+#include <numeric>
+#include <string>
+#include <vector>
+
+#include "DataStructures/Matrix.hpp"
+#include "DataStructures/ModalVector.hpp"
+#include "DataStructures/Tensor/IndexType.hpp"
+#include "IO/H5/AccessType.hpp"
+#include "IO/H5/Dat.hpp"
+#include "IO/H5/File.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/SpherepackIterator.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/Strahlkorper.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/GetOutput.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeString.hpp"
+
+namespace ylm {
+namespace {
+const size_t num_non_coef_headers = 5;
+
+// check that the headers of the legend are what we expect them to be
+template <typename Frame>
+void check_legend(const std::vector<std::string>& legend) {
+  const std::string expected_frame{get_output(Frame{})};
+
+  // check format and ordering of non-coefficient headers
+  const auto check_header = [&legend](const size_t column,
+                                      const std::string& expected_header) {
+    const std::string& read_header = gsl::at(legend, column);
+    if (read_header != expected_header) {
+      ERROR("In column " << column << " of the Ylm legend, expected header "
+                         << expected_header << " but got header " << read_header
+                         << ".");
+    }
+  };
+  check_header(0, "Time");
+  check_header(1, expected_frame + "ExpansionCenter_x");
+  check_header(2, expected_frame + "ExpansionCenter_y");
+  check_header(3, expected_frame + "ExpansionCenter_z");
+  check_header(4, "Lmax");
+
+  // check format and ordering of coefficient headers
+  int expected_l = 0;
+  int expected_m = 0;
+  size_t coef_column_number = num_non_coef_headers;
+  while (coef_column_number < legend.size()) {
+    const std::string& coefficient_header = legend[coef_column_number];
+    const std::string expected_coefficient_header = {
+        MakeString{} << "coef(" << std::to_string(expected_l) << ","
+                     << std::to_string(expected_m) << ")"};
+    if (coefficient_header != expected_coefficient_header) {
+      ERROR(MakeString{}
+            << "In column " << coef_column_number
+            << " of the Ylm legend, expected header "
+            << expected_coefficient_header << " but got header "
+            << coefficient_header
+            << ".\n\n Coefficient headers are expected to take the form "
+               "coef(l,m) and be ordered first by ascending l and then for "
+               "each l, ordered by ascending m, i.e. coef(0,0), coef(1,-1), "
+               "coef(1,0), coef(1,1), coef(2,-2), ...");
+    }
+
+    if (expected_l == expected_m) {
+      expected_l++;
+      expected_m = -expected_l;
+    } else {
+      expected_m++;
+    }
+
+    coef_column_number++;
+  }
+}
+
+// checks if a double is a nonnegative integer
+bool is_nonnegative_int(const double n) {
+  return n == abs(n) and n == floor(n);
+}
+
+template <typename Frame>
+Strahlkorper<Frame> read_surface_ylm_row(const Matrix& ylm_data,
+                                         const size_t row_number) {
+  const size_t l_max_column_number = 4;
+  const std::array<double, 3> expansion_center{{ylm_data(row_number, 1),
+                                                ylm_data(row_number, 2),
+                                                ylm_data(row_number, 3)}};
+  const double l_max_from_file = ylm_data(row_number, l_max_column_number);
+  if (not is_nonnegative_int(l_max_from_file)) {
+    ERROR("Row " << row_number << " of the Ylm data has an invalid Lmax value ("
+                 << l_max_from_file << ") in column " << l_max_column_number
+                 << ". The value of Lmax should be a nonnegative integer.");
+  }
+
+  const auto l_max = static_cast<size_t>(l_max_from_file);
+  // l_max == m_max
+  const size_t spectral_size = Spherepack::spectral_size(l_max, l_max);
+  // We only write and store half of the coefficients. This is the minimum
+  // number of coefficients needed to describe the strahlkorper given the l_max,
+  // i.e. columns of 0.0 for higher coefficients are okay
+  const size_t min_expected_num_coefficients = spectral_size / 2;
+  const size_t min_expected_num_columns =
+      min_expected_num_coefficients + num_non_coef_headers;
+  const size_t actual_num_columns = ylm_data.columns();
+
+  if (actual_num_columns < min_expected_num_columns) {
+    ERROR("Row " << row_number
+                 << " of the Ylm data does not have enough coefficients for "
+                    "the Lmax. For Lmax = "
+                 << l_max << ", expected at least "
+                 << min_expected_num_coefficients << " coefficient columns and "
+                 << min_expected_num_columns << " total columns.");
+  }
+
+  ModalVector spectral_coefficients(spectral_size, 0.0);
+  size_t coef_column_number = num_non_coef_headers;
+  SpherepackIterator iter(l_max, l_max);
+  // read in expected coefficients for the given l_max
+  for (size_t l = 0; l <= l_max; l++) {
+    for (int m = -static_cast<int>(l); m <= static_cast<int>(l); m++) {
+      iter.set(l, m);
+
+      const double coefficient = ylm_data(row_number, coef_column_number);
+      spectral_coefficients[iter()] = coefficient;
+
+      coef_column_number++;
+    }
+  }
+  // make sure any higher order coefficients (l > l_max) present in the data
+  // that was read in are 0.0
+  while (coef_column_number < actual_num_columns) {
+    if (ylm_data(row_number, coef_column_number) != 0.0) {
+      ERROR("Row " << row_number << " of the Ylm data has Lmax = " << l_max
+                   << " but non-zero coefficients for l > Lmax.");
+    }
+    coef_column_number++;
+  }
+
+  Strahlkorper<Frame> strahlkorper(l_max, l_max, spectral_coefficients,
+                                   expansion_center);
+
+  return strahlkorper;
+}
+}  // namespace
+
+template <typename Frame>
+std::vector<Strahlkorper<Frame>> read_surface_ylm(
+    const std::string& file_name, const std::string& surface_subfile_name,
+    const size_t requested_number_of_times_from_end) {
+  ASSERT(requested_number_of_times_from_end > 0,
+         "Must request to read in at least one row (time) of Ylm data.");
+
+  h5::H5File<h5::AccessType::ReadOnly> file{file_name};
+  const std::string ylm_subfile_name{std::string{"/"} + surface_subfile_name};
+  const auto& ylm_file = file.get<h5::Dat>(ylm_subfile_name);
+
+  // number of rows available to read in
+  const size_t total_number_of_times = gsl::at(ylm_file.get_dimensions(), 0);
+  if (total_number_of_times == 0) {
+    ERROR("The Ylm data to read from contain 0 rows (times) of data.");
+  }
+
+  if (requested_number_of_times_from_end > total_number_of_times) {
+    ERROR("The requested number of time values ("
+          << requested_number_of_times_from_end
+          << ") is more than the number of rows in the Ylm data that was read "
+             "in ("
+          << total_number_of_times << ")");
+  }
+
+  const auto& ylm_legend = ylm_file.get_legend();
+  check_legend<Frame>(ylm_legend);
+
+  std::vector<size_t> columns(ylm_legend.size());
+  std::iota(std::begin(columns), std::end(columns), 0);
+  // grab all columns of the last requested_number_of_times_from_end rows
+  const auto ylm_data_subset = ylm_file.get_data_subset(
+      columns, total_number_of_times - requested_number_of_times_from_end,
+      requested_number_of_times_from_end);
+
+  std::vector<Strahlkorper<Frame>> strahlkorpers(
+      requested_number_of_times_from_end);
+  for (size_t i = 0; i < requested_number_of_times_from_end; i++) {
+    strahlkorpers[i] = read_surface_ylm_row<Frame>(ylm_data_subset, i);
+  }
+
+  file.close_current_object();
+  return strahlkorpers;
+}
+}  // namespace ylm
+
+#define FRAMETYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data)                                       \
+  template std::vector<ylm::Strahlkorper<FRAMETYPE(data)>>         \
+  ylm::read_surface_ylm<>(const std::string& file_name,            \
+                          const std::string& surface_subfile_name, \
+                          size_t requested_number_of_times_from_end);
+
+GENERATE_INSTANTIATIONS(INSTANTIATE,
+                        (Frame::Grid, Frame::Inertial, Frame::Distorted))
+
+#undef INSTANTIATE
+#undef FRAMETYPE

--- a/src/NumericalAlgorithms/SphericalHarmonics/IO/ReadSurfaceYlm.hpp
+++ b/src/NumericalAlgorithms/SphericalHarmonics/IO/ReadSurfaceYlm.hpp
@@ -1,0 +1,33 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <string>
+#include <vector>
+
+#include "NumericalAlgorithms/SphericalHarmonics/Strahlkorper.hpp"
+
+namespace ylm {
+/// \ingroup SurfacesGroup
+/// \brief Returns a list of `ylm::Strahlkorper`s constructed from reading in
+/// spherical harmonic data for a surface at a requested list of times
+///
+/// \details The `ylm::Strahlkorper`s are constructed by reading in data from
+/// an H5 subfile that is expected to be in the format described by
+/// `intrp::callbacks::ObserveSurfaceData`. It is assumed that
+/// \f$l_{max} = m_{max}\f$.
+///
+/// \param file_name name of the H5 file containing the surface's spherical
+/// harmonic data
+/// \param surface_subfile_name name of the subfile (with no leading slash nor
+/// the `.dat` extension) within `file_name` that contains the surface's
+/// spherical harmonic data to read in
+/// \param requested_number_of_times_from_end the number of times to read in
+/// starting backwards from the final time found in `surface_subfile_name`
+template <typename Frame>
+std::vector<ylm::Strahlkorper<Frame>> read_surface_ylm(
+    const std::string& file_name, const std::string& surface_subfile_name,
+    size_t requested_number_of_times_from_end);
+}  // namespace ylm

--- a/src/NumericalAlgorithms/SphericalHarmonics/Strahlkorper.hpp
+++ b/src/NumericalAlgorithms/SphericalHarmonics/Strahlkorper.hpp
@@ -7,6 +7,7 @@
 #include <cstddef>
 
 #include "DataStructures/DataVector.hpp"
+#include "DataStructures/ModalVector.hpp"
 #include "NumericalAlgorithms/SphericalHarmonics/Spherepack.hpp"
 #include "Options/String.hpp"
 #include "Utilities/ForceInline.hpp"
@@ -73,9 +74,18 @@ class Strahlkorper {
   /// spectral coefficients, it is not possible to choose spectral
   /// coefficients to exactly match all points in
   /// `radius_at_collocation_points`.
-  Strahlkorper(size_t l_max, size_t m_max,
-               const DataVector& radius_at_collocation_points,
-               std::array<double, 3> center);
+  explicit Strahlkorper(size_t l_max, size_t m_max,
+                        const DataVector& radius_at_collocation_points,
+                        std::array<double, 3> center);
+
+  /// \brief Construct a Strahlkorper from a `ModalVector` containing the
+  /// spectral coefficients
+  ///
+  /// \details The spectral coefficients should be in the form defined by
+  /// `ylm::Strahlkorper::coefficients() const`.
+  explicit Strahlkorper(size_t l_max, size_t m_max,
+                        const ModalVector& spectral_coefficients,
+                        std::array<double, 3> center);
 
   /// Prolong or restrict another surface to the given `l_max` and `m_max`.
   Strahlkorper(size_t l_max, size_t m_max,

--- a/src/ParallelAlgorithms/Interpolation/CMakeLists.txt
+++ b/src/ParallelAlgorithms/Interpolation/CMakeLists.txt
@@ -37,6 +37,7 @@ target_link_libraries(
   GeneralRelativitySolutions
   Interpolation
   Logging
+  Observer
   Options
   Parallel
   Serialization
@@ -45,7 +46,6 @@ target_link_libraries(
   Utilities
   INTERFACE
   EventsAndTriggers
-  Observer
   )
 
 add_subdirectory(Actions)

--- a/src/ParallelAlgorithms/Interpolation/Callbacks/CMakeLists.txt
+++ b/src/ParallelAlgorithms/Interpolation/Callbacks/CMakeLists.txt
@@ -1,6 +1,12 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
+spectre_target_sources(
+  ${LIBRARY}
+  PRIVATE
+  ObserveSurfaceData.cpp
+  )
+
 spectre_target_headers(
   ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src

--- a/src/ParallelAlgorithms/Interpolation/Callbacks/ObserveSurfaceData.cpp
+++ b/src/ParallelAlgorithms/Interpolation/Callbacks/ObserveSurfaceData.cpp
@@ -1,0 +1,93 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "ParallelAlgorithms/Interpolation/Callbacks/ObserveSurfaceData.hpp"
+
+#include <array>
+#include <cstddef>
+#include <string>
+#include <vector>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/IndexType.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/Spherepack.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/SpherepackIterator.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/Strahlkorper.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/GetOutput.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeString.hpp"
+
+namespace intrp::callbacks::detail {
+template <typename Frame>
+void fill_ylm_legend_and_data(
+    const gsl::not_null<std::vector<std::string>*> legend,
+    const gsl::not_null<std::vector<double>*> data,
+    const ylm::Strahlkorper<Frame>& strahlkorper, const double time,
+    const size_t max_l) {
+  ASSERT(max_l >= strahlkorper.l_max(),
+         "The Lmax of the Ylm data to write ("
+             << strahlkorper.l_max()
+             << ") is larger than the maximum value that l can be (" << max_l
+             << ").");
+  const std::array<double, 3> expansion_center =
+      strahlkorper.expansion_center();
+  const std::string frame{get_output(Frame{})};
+  // we only store half and thus only write half of the coefficients
+  const size_t num_coefficients =
+      ylm::Spherepack::spectral_size(max_l, max_l) / 2;
+  // time + 3 dims of expansion center + Lmax = 5 columns
+  const size_t num_columns = num_coefficients + 5;
+
+  legend->reserve(num_columns);
+  data->reserve(num_columns);
+
+  legend->emplace_back("Time");
+  data->emplace_back(time);
+  legend->emplace_back(frame + "ExpansionCenter_x");
+  data->emplace_back(expansion_center[0]);
+  legend->emplace_back(frame + "ExpansionCenter_y");
+  data->emplace_back(expansion_center[1]);
+  legend->emplace_back(frame + "ExpansionCenter_z");
+  data->emplace_back(expansion_center[2]);
+  legend->emplace_back("Lmax");
+  data->emplace_back(strahlkorper.l_max());
+
+  const DataVector& ylm_coefficients = strahlkorper.coefficients();
+  // fill coefficients for l in [0, l_max]
+  // l_max == m_max
+  ylm::SpherepackIterator iter(strahlkorper.l_max(), strahlkorper.l_max());
+  for (size_t l = 0; l <= strahlkorper.l_max(); l++) {
+    for (int m = -static_cast<int>(l); m <= static_cast<int>(l); m++) {
+      legend->emplace_back(MakeString{} << "coef(" << l << "," << m << ")");
+
+      iter.set(l, m);
+      data->emplace_back(ylm_coefficients[iter()]);
+    }
+  }
+  // fill coefficients for l in [l_max + 1, max_l],
+  // i.e. higher order coefficients beyond this Strahlkorper's l_max == 0.0
+  data->resize(num_columns, 0.0);
+  for (size_t l = strahlkorper.l_max() + 1; l <= max_l; l++) {
+    for (int m = -static_cast<int>(l); m <= static_cast<int>(l); m++) {
+      legend->emplace_back(MakeString{} << "coef(" << l << "," << m << ")");
+    }
+  }
+}
+}  // namespace intrp::callbacks::detail
+
+#define FRAMETYPE(instantiation_data) BOOST_PP_TUPLE_ELEM(0, instantiation_data)
+
+#define INSTANTIATE(_, instantiation_data)                                  \
+  template void intrp::callbacks::detail::fill_ylm_legend_and_data(         \
+      gsl::not_null<std::vector<std::string>*> legend,                      \
+      gsl::not_null<std::vector<double>*> data,                             \
+      const ylm::Strahlkorper<FRAMETYPE(instantiation_data)>& strahlkorper, \
+      double time, size_t max_l);
+
+GENERATE_INSTANTIATIONS(INSTANTIATE,
+                        (Frame::Grid, Frame::Inertial, Frame::Distorted))
+
+#undef INSTANTIATE
+#undef FRAMETYPE

--- a/tests/Unit/NumericalAlgorithms/SphericalHarmonics/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/SphericalHarmonics/CMakeLists.txt
@@ -26,3 +26,5 @@ target_link_libraries(
   SphericalHarmonicsHelpers
   Utilities
   )
+
+  add_subdirectory(IO)

--- a/tests/Unit/NumericalAlgorithms/SphericalHarmonics/IO/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/SphericalHarmonics/IO/CMakeLists.txt
@@ -1,0 +1,22 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBRARY "Test_SphericalHarmonicsIO")
+
+set(LIBRARY_SOURCES
+  Test_ReadSurfaceYlm.cpp
+  )
+
+add_test_library(${LIBRARY} "${LIBRARY_SOURCES}")
+
+target_link_libraries(
+  ${LIBRARY}
+  PRIVATE
+  DataStructures
+  DataStructuresHelpers
+  H5
+  ParallelInterpolation
+  SphericalHarmonics
+  SphericalHarmonicsIO
+  Utilities
+  )

--- a/tests/Unit/NumericalAlgorithms/SphericalHarmonics/IO/Test_ReadSurfaceYlm.cpp
+++ b/tests/Unit/NumericalAlgorithms/SphericalHarmonics/IO/Test_ReadSurfaceYlm.cpp
@@ -1,0 +1,361 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <limits>
+#include <random>
+#include <string>
+#include <vector>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/IndexType.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "IO/H5/AccessType.hpp"
+#include "IO/H5/Dat.hpp"
+#include "IO/H5/File.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/IO/ReadSurfaceYlm.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/Strahlkorper.hpp"
+#include "ParallelAlgorithms/Interpolation/Callbacks/ObserveSurfaceData.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/FileSystem.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace {
+const size_t l_max_column_number = 4;
+
+// generate test Strahlkorpers with a random radius function and given l_maxes
+// and expansion center
+template <typename Frame, size_t NumTimes>
+std::array<ylm::Strahlkorper<Frame>, NumTimes> generate_test_strahlkorpers(
+    const std::array<double, 3> expansion_center,
+    const std::array<size_t, NumTimes> l_maxes) {
+  MAKE_GENERATOR(generator);
+  std::uniform_real_distribution<> distribution(0.1, 2.0);
+
+  std::array<ylm::Strahlkorper<Frame>, NumTimes> strahlkorpers{};
+  for (size_t i = 0; i < NumTimes; i++) {
+    const auto radius = make_with_random_values<DataVector>(
+        make_not_null(&generator), distribution,
+        DataVector(ylm::Spherepack::physical_size(gsl::at(l_maxes, i),
+                                                  gsl::at(l_maxes, i)),
+                   std::numeric_limits<double>::signaling_NaN()));
+    gsl::at(strahlkorpers, i) = ylm::Strahlkorper<Frame>(
+        gsl::at(l_maxes, i), gsl::at(l_maxes, i), radius, expansion_center);
+  }
+
+  return strahlkorpers;
+}
+
+// Generate the data to be written using the helper function for
+// ::intrp::callbacks::ObserveSurfaceData instead of spinning up the Action
+// Testing Framework (AFT) to write it since the helper function handles all
+// of the legend and data building logic and ObserveSurfaceData simply writes
+// what it generates
+template <typename Frame, size_t NumTimes>
+void write_test_strahlkorpers(
+    const std::array<ylm::Strahlkorper<Frame>, NumTimes>& strahlkorpers,
+    const std::string& test_filename, const std::string& subfile_name,
+    const std::array<double, NumTimes> times, const size_t max_l) {
+  std::vector<std::string> legend{};
+  std::vector<std::vector<double>> data(NumTimes);
+  for (size_t i = 0; i < NumTimes; i++) {
+    legend.resize(0);  // clear and reuse for next row of data
+    intrp::callbacks::detail::fill_ylm_legend_and_data(
+        make_not_null(&legend), make_not_null(&(data[i])),
+        gsl::at(strahlkorpers, i), gsl::at(times, i), max_l);
+  }
+
+  h5::H5File<h5::AccessType::ReadWrite> test_file(test_filename, true);
+  auto& file = test_file.insert<h5::Dat>("/" + subfile_name, legend);
+  file.append(data);
+  test_file.close_current_object();
+}
+
+// test reading in the n last times of data expected to have been written
+// (expected_strahlkorpers), where n = num_times_requested
+template <typename Frame, size_t NumTimes>
+void check_read_ylm_data(const std::string& test_filename,
+                         const std::string& surface_subfile_name,
+                         const size_t num_times_requested,
+                         const std::array<ylm::Strahlkorper<Frame>, NumTimes>&
+                             expected_strahlkorpers) {
+  ASSERT(
+      NumTimes >= num_times_requested,
+      "Requesting to read more rows of Ylm test data than the total number of "
+      "rows expected to be written and therefore able to be read.");
+
+  const std::vector<ylm::Strahlkorper<Frame>> strahlkorpers =
+      ylm::read_surface_ylm<Frame>(test_filename, surface_subfile_name,
+                                   num_times_requested);
+  CHECK(strahlkorpers.size() == num_times_requested);
+
+  // check n last times where n = num_times_requested
+  for (size_t i = 0, expected_row_number = NumTimes - num_times_requested;
+       i < num_times_requested; i++, expected_row_number++) {
+    const auto& expected_strahlkorper =
+        gsl::at(expected_strahlkorpers, expected_row_number);
+    const std::array<double, 3> expected_expansion_center =
+        expected_strahlkorper.expansion_center();
+    const size_t expected_l_max = expected_strahlkorper.l_max();
+    const DataVector& expected_spectral_coefficients =
+        expected_strahlkorper.coefficients();
+    const size_t expected_spectral_size = expected_spectral_coefficients.size();
+
+    const auto& strahlkorper = strahlkorpers[i];
+    CHECK(strahlkorper.expansion_center() == expected_expansion_center);
+    CHECK(strahlkorper.l_max() == expected_l_max);
+    CHECK(strahlkorper.coefficients().size() == expected_spectral_size);
+    CHECK(strahlkorper.coefficients() == expected_spectral_coefficients);
+  }
+}
+
+// Write and read in a file containing a legend or data that is expected to
+// generate an error upon attempting to read
+template <typename Frame>
+void write_error_file_and_try_to_read(
+    const std::string& filename, const std::string& subfile_name,
+    const std::vector<std::string>& legend,
+    const std::vector<std::vector<double>>& data,
+    const size_t num_times_to_read) {
+  h5::H5File<h5::AccessType::ReadWrite> test_file{filename, true};
+  auto& file = test_file.insert<h5::Dat>("/" + subfile_name, legend);
+  file.append(data);
+  test_file.close_current_object();
+
+  const auto strahlkorpers =
+      ylm::read_surface_ylm<Frame>(filename, subfile_name, num_times_to_read);
+}
+
+void test_errors() {
+  const std::vector<std::string> ylm_legend_without_coefs{
+      "Time", "InertialExpansionCenter_x", "InertialExpansionCenter_y",
+      "InertialExpansionCenter_z", "Lmax"};
+
+  const std::vector<std::string> l_max_3_coef_headers = {
+      "coef(0,0)",  "coef(1,-1)", "coef(1,0)",  "coef(1,1)",
+      "coef(2,-2)", "coef(2,-1)", "coef(2,0)",  "coef(2,1)",
+      "coef(2,2)",  "coef(3,-3)", "coef(3,-2)", "coef(3,-1)",
+      "coef(3,0)",  "coef(3,1)",  "coef(3,2)",  "coef(3,3)"};
+
+  // construct a legend that is properly formatted
+  std::vector<std::string> good_legend = ylm_legend_without_coefs;
+  good_legend.insert(good_legend.end(), l_max_3_coef_headers.begin(),
+                     l_max_3_coef_headers.end());
+
+  // construct data that is properly formatted
+  const std::array<double, 3> times{{0.1, 0.2, 0.3}};
+  const std::array<double, 3> l_maxes{{2.0, 3.0, 2.0}};
+  std::vector<std::vector<double>> good_data{
+      times.size(), std::vector<double>(good_legend.size(), 0.0)};
+  good_data[0][l_max_column_number] = gsl::at(l_maxes, 0);
+  good_data[1][l_max_column_number] = gsl::at(l_maxes, 0);
+  good_data[2][l_max_column_number] = gsl::at(l_maxes, 0);
+
+  const std::string filename{"TestReadYlmErrors.h5"};
+
+  if (file_system::check_if_file_exists(filename)) {
+    file_system::rm(filename, true);
+  }
+
+  // expansion center legend errors
+
+  CHECK_THROWS_WITH(([&filename, &good_legend, &good_data]() {
+                      std::vector<std::string> bad_legend = good_legend;
+                      bad_legend[2] = "InertialExpansionCenter_z";
+
+                      write_error_file_and_try_to_read<Frame::Inertial>(
+                          filename, "WrongCoord", bad_legend, good_data, 3);
+                    }()),
+                    Catch::Matchers::ContainsSubstring(
+                        "In column 2 of the Ylm legend, expected header "
+                        "InertialExpansionCenter_y but got header "
+                        "InertialExpansionCenter_z"));
+
+  CHECK_THROWS_WITH(
+      ([&filename, &good_legend, &good_data]() {
+        std::vector<std::string> bad_legend = good_legend;
+        bad_legend[3] = "ExpansionCenter_z";
+
+        write_error_file_and_try_to_read<Frame::Inertial>(
+            filename, "NoFrame", bad_legend, good_data, 3);
+      }()),
+      Catch::Matchers::ContainsSubstring(
+          "In column 3 of the Ylm legend, expected header "
+          "InertialExpansionCenter_z but got header ExpansionCenter_z"));
+
+  CHECK_THROWS_WITH(([&filename, &good_legend, &good_data]() {
+                      write_error_file_and_try_to_read<Frame::Grid>(
+                          filename, "WrongFrame", good_legend, good_data, 3);
+                    }()),
+                    Catch::Matchers::ContainsSubstring(
+                        "In column 1 of the Ylm legend, expected header "
+                        "GridExpansionCenter_x but got header "
+                        "InertialExpansionCenter_x"));
+
+  // coefficient legend errors
+
+  CHECK_THROWS_WITH(
+      ([&filename, &good_legend, &good_data]() {
+        std::vector<std::string> bad_legend = good_legend;
+        bad_legend[8] = "1, 1";
+
+        write_error_file_and_try_to_read<Frame::Inertial>(
+            filename, "WrongCoefFormat", bad_legend, good_data, 3);
+      }()),
+      Catch::Matchers::ContainsSubstring(
+          "In column 8 of the Ylm legend, expected header coef(1,1) but got "
+          "header 1, 1"));
+
+  CHECK_THROWS_WITH(([&filename, &good_legend, &good_data]() {
+                      std::vector<std::string> bad_legend = good_legend;
+                      bad_legend[12] = "coef(2,2)";
+
+                      write_error_file_and_try_to_read<Frame::Inertial>(
+                          filename, "WrongCoefOrder", bad_legend, good_data, 3);
+                    }()),
+                    Catch::Matchers::ContainsSubstring(
+                        "In column 12 of the Ylm legend, expected header "
+                        "coef(2,1) but got header coef(2,2)"));
+
+  // data errors
+
+  CHECK_THROWS_WITH(([&filename, &good_legend]() {
+                      const std::vector<std::vector<double>> bad_data{};
+                      write_error_file_and_try_to_read<Frame::Inertial>(
+                          filename, "EmptyData", good_legend, bad_data, 1);
+                    }()),
+                    Catch::Matchers::ContainsSubstring(
+                        "The Ylm data to read from contain 0 rows"));
+
+  CHECK_THROWS_WITH(([&filename, &good_legend, &good_data]() {
+                      write_error_file_and_try_to_read<Frame::Inertial>(
+                          filename, "NotEnoughTimesWritten", good_legend,
+                          good_data, 4);
+                    }()),
+                    Catch::Matchers::ContainsSubstring(
+                        "The requested number of time values (4) is more than "
+                        "the number of rows in the Ylm data"));
+
+  CHECK_THROWS_WITH(([&filename, &good_legend, &good_data]() {
+                      std::vector<std::vector<double>> bad_data = good_data;
+                      bad_data[0][l_max_column_number] = 1.2;
+
+                      write_error_file_and_try_to_read<Frame::Inertial>(
+                          filename, "NonIntegralLmax", good_legend, bad_data,
+                          3);
+                    }()),
+                    Catch::Matchers::ContainsSubstring(
+                        "Row 0 of the Ylm data has an invalid Lmax value"));
+
+  CHECK_THROWS_WITH(([&filename, &good_legend, &good_data]() {
+                      std::vector<std::vector<double>> bad_data = good_data;
+                      bad_data[1][l_max_column_number] = -1.0;
+
+                      write_error_file_and_try_to_read<Frame::Inertial>(
+                          filename, "NegativeLmax", good_legend, bad_data, 3);
+                    }()),
+                    Catch::Matchers::ContainsSubstring(
+                        "Row 1 of the Ylm data has an invalid Lmax value"));
+
+  CHECK_THROWS_WITH(([&filename, &good_legend, &good_data]() {
+                      std::vector<std::vector<double>> bad_data = good_data;
+                      // set an Lmax that requires more columns of data than
+                      // given, i.e. `good_legend` only has room for coefs for
+                      // l <= 3
+                      bad_data[2][l_max_column_number] = 4;
+
+                      write_error_file_and_try_to_read<Frame::Inertial>(
+                          filename, "NotEnoughColumnsForLmax", good_legend,
+                          bad_data, 3);
+                    }()),
+                    Catch::Matchers::ContainsSubstring(
+                        "Row 2 of the Ylm data does not have enough "
+                        "coefficients for the Lmax. For Lmax = 4, expected at "
+                        "least 25 coefficient columns and 30 total columns"));
+
+  CHECK_THROWS_WITH(
+      ([&filename, &good_legend, &good_data]() {
+        std::vector<std::vector<double>> bad_data = good_data;
+        bad_data[0].back() = 0.8;
+
+        write_error_file_and_try_to_read<Frame::Inertial>(
+            filename, "NonZeroHigherCoefs", good_legend, bad_data, 3);
+      }()),
+      Catch::Matchers::ContainsSubstring(
+          "Row 0 of the Ylm data has Lmax = 2 but non-zero coefficients for "
+          "l > Lmax"));
+  if (file_system::check_if_file_exists(filename)) {
+    file_system::rm(filename, true);
+  }
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.SphericalHarmonics.ReadSurfaceYlm",
+                  "[NumericalAlgorithms][Unit]") {
+  test_errors();
+
+  // Temporary file with test data to read in
+  const std::string test_filename{"TestReadYlm.h5"};
+  if (file_system::check_if_file_exists(test_filename)) {
+    file_system::rm(test_filename, true);
+  }
+
+  {
+    INFO("Test A");
+
+    // first test surface
+    using frame_a = Frame::Grid;
+    const std::string subfile_name_a = "SurfaceA_Ylm";
+    const std::array<double, 3> expansion_center_a{{-0.5, -0.1, 0.3}};
+    const size_t max_l_a = 3;
+
+    constexpr size_t number_of_times_a = 3;
+    const std::array<double, number_of_times_a> written_times_a{
+        {0.0, 0.1, 0.2}};
+    // test that a mix of different l_max values can be read from the same
+    // subfile
+    const std::array<size_t, number_of_times_a> l_maxes_a{{3, 2, 3}};
+
+    const auto strahlkorpers_a =
+        generate_test_strahlkorpers<frame_a>(expansion_center_a, l_maxes_a);
+    write_test_strahlkorpers(strahlkorpers_a, test_filename, subfile_name_a,
+                             written_times_a, max_l_a);
+
+    check_read_ylm_data<frame_a>(test_filename, subfile_name_a, 1,
+                                 strahlkorpers_a);
+    check_read_ylm_data<frame_a>(test_filename, subfile_name_a, 2,
+                                 strahlkorpers_a);
+    check_read_ylm_data<frame_a>(test_filename, subfile_name_a, 3,
+                                 strahlkorpers_a);
+  }
+
+  {
+    INFO("Test B");
+
+    // second test surface
+    using frame_b = Frame::Distorted;
+    const std::string subfile_name_b = "SurfaceB";
+    const std::array<double, 3> expansion_center_b{{0.0, 0.2, -0.6}};
+    const size_t max_l_b = 4;
+
+    // edge case: only one row written
+    constexpr size_t number_of_times_b = 1;
+    const std::array<double, number_of_times_b> written_times_b{{0.7}};
+    const std::array<size_t, number_of_times_b> l_maxes_b{{3}};
+
+    const auto strahlkorpers_b =
+        generate_test_strahlkorpers<frame_b>(expansion_center_b, l_maxes_b);
+    write_test_strahlkorpers(strahlkorpers_b, test_filename, subfile_name_b,
+                             written_times_b, max_l_b);
+
+    check_read_ylm_data<frame_b>(test_filename, subfile_name_b, 1,
+                                 strahlkorpers_b);
+  }
+
+  // Delete the temporary file created for this test
+  file_system::rm(test_filename, true);
+}


### PR DESCRIPTION
## Proposed changes
Fixes #5183

This PR implements writing and reading surface spherical harmonic data to and from disk. The writing currently assumes that `l_max` for a surface is constant but was implemented in a way to make it easy to change in the future if and when `l_max` can change over the course of the simulation. The reading, however, is already generalized to handle reading in rows of data with different `l_max` values.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
