### PR TITLE
Exit on reaching negative pressure in Newman Hamlin solver

### DIFF
--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/NewmanHamlin.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/NewmanHamlin.cpp
@@ -137,6 +137,9 @@ std::optional<PrimitiveRecoveryData> NewmanHamlin::apply(
           get(equation_of_state.pressure_from_density_and_enthalpy(
               Scalar<double>(current_rest_mass_density),
               Scalar<double>(current_specific_enthalpy)));
+      if (UNLIKELY(current_pressure <= 0.0)) {
+        return std::nullopt;
+      }
     } else if constexpr (ThermodynamicDim == 3) {
       ERROR("3d EOS not implemented");
     }


### PR DESCRIPTION
## Proposed changes

Newman-Hamlin inversion will now fail if reaching negative pressure (this can lead to FPEs)

### Upgrade instructions

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

