### PR TITLE
Don't save ccache temporary directory on CI

### DIFF
--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -432,6 +432,8 @@ jobs:
         CXXFLAGS: "-Werror"
         # We make sure to use a fixed absolute path for the ccache directory
         CCACHE_DIR: /work/ccache
+        # Use a separate temp directory to conserve cache space on GitHub
+        CCACHE_TEMPDIR: /work/ccache-tmp
         # Control the max cache size. We evict unused entries in a step below to
         # make sure that each build only uses what it need of this max size.
         CCACHE_MAXSIZE: "2G"
@@ -746,6 +748,7 @@ ${{ matrix.build_type }}-pch-${{ matrix.use_pch || 'ON' }}"
         blaze boost brigand charmpp gsl hdf5 libsharp libxsmm openblas
         py-pybind11 yaml-cpp
       CCACHE_DIR: $HOME/ccache
+      CCACHE_TEMPDIR: $HOME/ccache-tmp
       CCACHE_MAXSIZE: "2G"
       CCACHE_COMPRESS: 1
       CCACHE_COMPRESSLEVEL: 5


### PR DESCRIPTION
## Proposed changes

Conserve cache space on GitHub by not saving the temporary directory.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
