### PR TITLE
Add maximum specific thermal energy for 2d eos

### DIFF
--- a/src/Evolution/VariableFixing/FixToAtmosphere.cpp
+++ b/src/Evolution/VariableFixing/FixToAtmosphere.cpp
@@ -20,14 +20,17 @@
 namespace VariableFixing {
 
 template <size_t Dim>
-FixToAtmosphere<Dim>::FixToAtmosphere(
-    const double density_of_atmosphere, const double density_cutoff,
-    const double transition_density_cutoff, const double max_velocity_magnitude,
-    const Options::Context& context)
+FixToAtmosphere<Dim>::FixToAtmosphere(const double density_of_atmosphere,
+                                      const double density_cutoff,
+                                      const double transition_density_cutoff,
+                                      const double max_velocity_magnitude,
+                                      const double max_thermal_specific_energy,
+                                      const Options::Context& context)
     : density_of_atmosphere_(density_of_atmosphere),
       density_cutoff_(density_cutoff),
       transition_density_cutoff_(transition_density_cutoff),
-      max_velocity_magnitude_(max_velocity_magnitude) {
+      max_velocity_magnitude_(max_velocity_magnitude),
+      max_thermal_specific_energy_(max_thermal_specific_energy) {
   if (density_of_atmosphere_ > density_cutoff_) {
     PARSE_ERROR(context, "The cutoff density ("
                              << density_cutoff_
@@ -57,6 +60,7 @@ void FixToAtmosphere<Dim>::pup(PUP::er& p) {
   p | density_cutoff_;
   p | transition_density_cutoff_;
   p | max_velocity_magnitude_;
+  p | max_thermal_specific_energy_;
 }
 
 template <size_t Dim>

--- a/src/Evolution/VariableFixing/FixToAtmosphere.hpp
+++ b/src/Evolution/VariableFixing/FixToAtmosphere.hpp
@@ -106,7 +106,7 @@ class FixToAtmosphere {
   };
 
   /// \brief The maximum value of the thermal specific energy
-  /// Used for 2D equations of state
+  /// Used for 2D/3D equations of state
   ///
   /// Reasonable values still under study. Current recommended default:
   /// BNS: 1.0e4
@@ -128,7 +128,7 @@ class FixToAtmosphere {
       "equation of state, the specific internal energy is set to zero.\n"
       "In addition, the spatial velocity is set to zero, and the Lorentz\n"
       "factor is set to one. We also apply an upper bound on the thermal\n"
-      "specific energy for 2D equations of state.\n"};
+      "specific energy for 2D/3D equations of state.\n"};
 
   FixToAtmosphere(double density_of_atmosphere, double density_cutoff,
                   double transition_density_cutoff,

--- a/src/Evolution/VariableFixing/FixToAtmosphere.hpp
+++ b/src/Evolution/VariableFixing/FixToAtmosphere.hpp
@@ -105,9 +105,21 @@ class FixToAtmosphere {
         "below TransitionDensityCutoff."};
   };
 
+  /// \brief The maximum value of the thermal specific energy
+  /// Used for 2D equations of state
+  ///
+  /// Reasonable values still under study. Current recommended default:
+  /// BNS: 1.0e4
+  struct MaxThermalSpecificEnergy {
+    using type = double;
+    static type lower_bound() { return 0.0; }
+    static constexpr Options::String help = {
+        "The maximum allowed value of the thermal specific energy."};
+  };
+
   using options =
       tmpl::list<DensityOfAtmosphere, DensityCutoff, TransitionDensityCutoff,
-                 MaxVelocityMagnitude>;
+                 MaxVelocityMagnitude, MaxThermalSpecificEnergy>;
   static constexpr Options::String help = {
       "If the rest mass density is below DensityCutoff, it is set\n"
       "to DensityOfAtmosphere, and the pressure, specific internal energy\n"
@@ -115,11 +127,13 @@ class FixToAtmosphere {
       "adjusted to satisfy the equation of state. For a two-dimensional\n"
       "equation of state, the specific internal energy is set to zero.\n"
       "In addition, the spatial velocity is set to zero, and the Lorentz\n"
-      "factor is set to one.\n"};
+      "factor is set to one. We also apply an upper bound on the thermal\n"
+      "specific energy for 2D equations of state.\n"};
 
   FixToAtmosphere(double density_of_atmosphere, double density_cutoff,
                   double transition_density_cutoff,
                   double max_velocity_magnitude,
+                  double max_thermal_specific_energy,
                   const Options::Context& context = {});
 
   FixToAtmosphere() = default;
@@ -191,6 +205,8 @@ class FixToAtmosphere {
   double transition_density_cutoff_{
       std::numeric_limits<double>::signaling_NaN()};
   double max_velocity_magnitude_{std::numeric_limits<double>::signaling_NaN()};
+  double max_thermal_specific_energy_{
+      std::numeric_limits<double>::signaling_NaN()};
 };
 
 template <size_t Dim>

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/BinaryNeutronStar.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/BinaryNeutronStar.yaml
@@ -78,6 +78,7 @@ VariableFixing:
     DensityCutoff: &AtmosphereDensityCutoff 1.1e-15
     TransitionDensityCutoff: 9.0e-15
     MaxVelocityMagnitude: 1.0e-4
+    MaxThermalSpecificEnergy: 1.0e4
   LimitLorentzFactor:
     MaxDensityCutoff: 1.0e-08
     LorentzFactorCap: 10.0

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdBondiMichel.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdBondiMichel.yaml
@@ -79,6 +79,7 @@ VariableFixing:
     DensityCutoff: 1.0e-12
     TransitionDensityCutoff: 1.0e-11
     MaxVelocityMagnitude: 1.0e-4
+    MaxThermalSpecificEnergy: 1.0e4
   LimitLorentzFactor:
     MaxDensityCutoff: 1.0e-12
     LorentzFactorCap: 1.0

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdTovStar.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdTovStar.yaml
@@ -72,6 +72,7 @@ VariableFixing:
     DensityCutoff: 1.0e-12
     TransitionDensityCutoff: 1.0e-11
     MaxVelocityMagnitude: 1.0e-4
+    MaxThermalSpecificEnergy: 1.0e4
   LimitLorentzFactor:
     MaxDensityCutoff: 1.0e-12
     LorentzFactorCap: 1.0

--- a/tests/InputFiles/GrMhd/ValenciaDivClean/BlastWave.yaml
+++ b/tests/InputFiles/GrMhd/ValenciaDivClean/BlastWave.yaml
@@ -103,6 +103,7 @@ VariableFixing:
     DensityCutoff: 1.0e-12
     TransitionDensityCutoff: 1.0e-11
     MaxVelocityMagnitude: 1.0e-4
+    MaxThermalSpecificEnergy: 1.0e4
 
 PrimitiveFromConservative:
   CutoffDForInversion: *CutoffD

--- a/tests/InputFiles/GrMhd/ValenciaDivClean/FishboneMoncriefDisk.yaml
+++ b/tests/InputFiles/GrMhd/ValenciaDivClean/FishboneMoncriefDisk.yaml
@@ -112,6 +112,7 @@ VariableFixing:
     DensityCutoff: 1.0e-12
     TransitionDensityCutoff: 1.0e-11
     MaxVelocityMagnitude: 1.0e-4
+    MaxThermalSpecificEnergy: 1.0e4
 
 PrimitiveFromConservative:
   CutoffDForInversion: *CutoffD

--- a/tests/Unit/Evolution/VariableFixing/Test_FixToAtmosphere.cpp
+++ b/tests/Unit/Evolution/VariableFixing/Test_FixToAtmosphere.cpp
@@ -160,7 +160,7 @@ template <size_t Dim>
 void test_variable_fixer() {
   // Test for representative 1-d equation of state
   VariableFixing::FixToAtmosphere<Dim> variable_fixer{1.e-12, 3.e-12, 1.e-11,
-                                                      1.e-4};
+                                                      1.e-4, 1.e4};
   EquationsOfState::PolytropicFluid<true> polytrope{1.0, 2.0};
   test_variable_fixer<Dim>(variable_fixer, polytrope);
   test_serialization(variable_fixer);
@@ -170,7 +170,8 @@ void test_variable_fixer() {
           "DensityOfAtmosphere: 1.0e-12\n"
           "DensityCutoff: 3.0e-12\n"
           "TransitionDensityCutoff: 1.0e-11\n"
-          "MaxVelocityMagnitude: 1.0e-4\n");
+          "MaxVelocityMagnitude: 1.0e-4\n"
+          "MaxThermalSpecificEnergy: 1.0e4\n");
   test_variable_fixer(fixer_from_options, polytrope);
 
   // Test for representative 2-d equation of state


### PR DESCRIPTION
## Proposed changes

Add an upper bound on the thermal energy of the fluid for 2D EoS

### Upgrade instructions

Add
`MaxThermalSpecificEnergy: 1.0e4`
to the options given to `FixToAtmosphere` (or any other value appropriate to your simulation)

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.