### PR TITLE
Adds more Pybindings for GH.

### DIFF
--- a/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/Python/Bindings.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/Python/Bindings.cpp
@@ -9,16 +9,20 @@
 #include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/Christoffel.hpp"
 #include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/CovariantDerivOfExtrinsicCurvature.hpp"
 #include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/DerivSpatialMetric.hpp"
+#include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/ExtrinsicCurvature.hpp"
 #include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/GaugeSource.hpp"
 #include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/Phi.hpp"
 #include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/Pi.hpp"
 #include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/Ricci.hpp"
+#include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/SpacetimeDerivOfDetSpatialMetric.hpp"
 #include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/SpacetimeDerivOfNormOfShift.hpp"
 #include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/SpatialDerivOfLapse.hpp"
 #include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/SpatialDerivOfShift.hpp"
 #include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/TimeDerivOfLapse.hpp"
+#include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/TimeDerivOfLowerShift.hpp"
 #include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/TimeDerivOfShift.hpp"
 #include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/TimeDerivOfSpatialMetric.hpp"
+#include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/TimeDerivativeOfSpacetimeMetric.hpp"
 #include "Utilities/ErrorHandling/SegfaultHandler.hpp"
 
 namespace py = pybind11;
@@ -52,6 +56,12 @@ void bind_impl(py::module& m) {  // NOLINT
         static_cast<tnsr::ijj<DataVector, Dim> (*)(
             const tnsr::iaa<DataVector, Dim>&)>(&::gh::deriv_spatial_metric),
         py::arg("phi"));
+
+  m.def("extrinsic_curvature",
+        static_cast<tnsr::ii<DataVector, Dim> (*)(
+            const tnsr::A<DataVector, Dim>&, const tnsr::aa<DataVector, Dim>&,
+            const tnsr::iaa<DataVector, Dim>&)>(&::gh::extrinsic_curvature),
+        py::arg("spacetime_normal_vector"), py::arg("pi"), py::arg("phi"));
 
   m.def("gauge_source",
         static_cast<tnsr::a<DataVector, Dim> (*)(
@@ -87,6 +97,15 @@ void bind_impl(py::module& m) {  // NOLINT
         py::arg("dt_spatial_metric"), py::arg("phi"));
 
   m.def(
+      "spacetime_deriv_of_det_spatial_metric",
+      static_cast<tnsr::a<DataVector, Dim> (*)(
+          const Scalar<DataVector>&, const tnsr::II<DataVector, Dim>&,
+          const tnsr::ii<DataVector, Dim>&, const tnsr::iaa<DataVector, Dim>&)>(
+          &::gh::spacetime_deriv_of_det_spatial_metric),
+      py::arg("sqrt_det_spatial_metric"), py::arg("inverse_spatial_metric"),
+      py::arg("dt_spatial_metric"), py::arg("phi"));
+
+  m.def(
       "spacetime_deriv_of_norm_of_shift",
       static_cast<tnsr::a<DataVector, Dim> (*)(
           const Scalar<DataVector>&, const tnsr::I<DataVector, Dim>&,
@@ -103,6 +122,16 @@ void bind_impl(py::module& m) {  // NOLINT
             const Scalar<DataVector>&, const tnsr::A<DataVector, Dim>&,
             const tnsr::iaa<DataVector, Dim>&)>(&::gh::spatial_deriv_of_lapse),
         py::arg("lapse"), py::arg("spacetime_unit_normal"), py::arg("phi"));
+
+  m.def(
+      "time_deriv_of_lower_shift",
+      static_cast<tnsr::i<DataVector, Dim> (*)(
+          const Scalar<DataVector>&, const tnsr::I<DataVector, Dim>&,
+          const tnsr::ii<DataVector, Dim>&, const tnsr::A<DataVector, Dim>&,
+          const tnsr::iaa<DataVector, Dim>&, const tnsr::aa<DataVector, Dim>&)>(
+          &::gh::time_deriv_of_lower_shift),
+      py::arg("lapse"), py::arg("shift"), py::arg("spatial_metric"),
+      py::arg("spacetime_unit_normal"), py::arg("phi"), py::arg("pi"));
 
   m.def(
       "spatial_deriv_of_shift",
@@ -145,6 +174,14 @@ void bind_impl(py::module& m) {  // NOLINT
           const tnsr::iaa<DataVector, Dim>&, const tnsr::aa<DataVector, Dim>&)>(
           &::gh::time_deriv_of_spatial_metric),
       py::arg("lapse"), py::arg("shift"), py::arg("phi"), py::arg("pi"));
+
+  m.def(
+      "time_derivative_of_spacetime_metric",
+      static_cast<tnsr::aa<DataVector, Dim> (*)(
+          const Scalar<DataVector>&, const tnsr::I<DataVector, Dim>&,
+          const tnsr::aa<DataVector, Dim>&, const tnsr::iaa<DataVector, Dim>&)>(
+          &::gh::time_derivative_of_spacetime_metric),
+      py::arg("lapse"), py::arg("shift"), py::arg("pi"), py::arg("phi"));
 
   m.def(
       "trace_christoffel",

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Python/Test_GhBindings.py
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Python/Test_GhBindings.py
@@ -50,6 +50,12 @@ class TestBindings(unittest.TestCase):
             phi,
         )
 
+    def test_extrinsic_curvature(self):
+        spacetime_normal_vector = tnsr.A[DataVector, 3](num_points=1, fill=1.0)
+        pi = tnsr.aa[DataVector, 3](num_points=1, fill=1.0)
+        phi = tnsr.iaa[DataVector, 3](num_points=1, fill=1.0)
+        gh.extrinsic_curvature(spacetime_normal_vector, pi, phi)
+
     def test_spatial_deriv_of_shift(self):
         lapse = Scalar[DataVector](num_points=1, fill=1.0)
         inverse_spacetime_metric = tnsr.AA[DataVector, 3](
@@ -132,6 +138,18 @@ class TestBindings(unittest.TestCase):
             phi,
         )
 
+    def test_spacetime_deriv_of_det_spatial_metric(self):
+        sqrt_det_spatial_metric = Scalar[DataVector](num_points=1, fill=1.0)
+        inverse_spatial_metric = tnsr.II[DataVector, 3](num_points=1, fill=1.0)
+        dt_spatial_metric = tnsr.ii[DataVector, 3](num_points=1, fill=1.0)
+        phi = tnsr.iaa[DataVector, 3](num_points=1, fill=1.0)
+        gh.spacetime_deriv_of_det_spatial_metric(
+            sqrt_det_spatial_metric,
+            inverse_spatial_metric,
+            dt_spatial_metric,
+            phi,
+        )
+
     def test_spacetime_deriv_of_norm_of_shift(self):
         lapse = Scalar[DataVector](num_points=1, fill=1.0)
         shift = tnsr.I[DataVector, 3](num_points=1, fill=1.0)
@@ -178,6 +196,17 @@ class TestBindings(unittest.TestCase):
             pi,
         )
 
+    def test_time_deriv_of_lower_shift(self):
+        lapse = Scalar[DataVector](num_points=1, fill=1.0)
+        shift = tnsr.I[DataVector, 3](num_points=1, fill=1.0)
+        spatial_metric = tnsr.ii[DataVector, 3](num_points=1, fill=1.0)
+        spacetime_unit_normal = tnsr.A[DataVector, 3](num_points=1, fill=1.0)
+        phi = tnsr.iaa[DataVector, 3](num_points=1, fill=1.0)
+        pi = tnsr.aa[DataVector, 3](num_points=1, fill=1.0)
+        gh.time_deriv_of_lower_shift(
+            lapse, shift, spatial_metric, spacetime_unit_normal, phi, pi
+        )
+
     def test_time_deriv_of_shift(self):
         lapse = Scalar[DataVector](num_points=1, fill=1.0)
         shift = tnsr.I[DataVector, 3](num_points=1, fill=0.0)
@@ -205,6 +234,13 @@ class TestBindings(unittest.TestCase):
             phi,
             pi,
         )
+
+    def test_time_derivative_of_spacetime_metric(self):
+        lapse = Scalar[DataVector](num_points=1, fill=1.0)
+        shift = tnsr.I[DataVector, 3](num_points=1, fill=1.0)
+        pi = tnsr.aa[DataVector, 3](num_points=1, fill=1.0)
+        phi = tnsr.iaa[DataVector, 3](num_points=1, fill=1.0)
+        gh.time_derivative_of_spacetime_metric(lapse, shift, pi, phi)
 
     def test_trace_christoffel(self):
         spacetime_normal_one_form = tnsr.a[DataVector, 3](


### PR DESCRIPTION
This adds pybindings for the following in GH:
- ExtrinsicCurvature
- SpacetimeDerivOfDetSpatialMetric
- TimeDerivOfLowerShift
- TimeDerivativeOfSpacetimeMetric

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
