### PR TITLE
Drop clang-10

### DIFF
--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -405,21 +405,6 @@ jobs:
           - compiler: gcc-10
             build_type: Debug
             TEST_TIMEOUT_FACTOR: 2
-          # Add a test without PCH to the build matrix, which only builds core
-          # libraries. Building all the tests without the PCH takes very long
-          # and the most we would catch is a missing include of something that's
-          # in the PCH.
-          # Use this test also to build and test all input files with "normal"
-          # or higher priority. The other configurations only test input files
-          # with "high" priority to reduce the total build time.
-          - compiler: clang-10
-            build_type: Debug
-            use_pch: OFF
-            unit_tests: OFF
-            input_file_tests_min_priority: "normal"
-          # Full clang-10 build to catch any incompatibilities.
-          - compiler: clang-10
-            build_type: Release
           # Test with ASAN
           - compiler: clang-11
             build_type: Debug
@@ -439,12 +424,22 @@ jobs:
             BUILD_SHARED_LIBS: OFF
             use_xsimd: OFF
             MEMORY_ALLOCATOR: JEMALLOC
-          # Test with MPI version of charm
+          # Add a test without PCH to the build matrix, which only builds core
+          # libraries. Building all the tests without the PCH takes very long
+          # and the most we would catch is a missing include of something that's
+          # in the PCH.
+          # Use this test also to build and test all input files with "normal"
+          # or higher priority. The other configurations only test input files
+          # with "high" priority to reduce the total build time.
           - compiler: clang-13
             build_type: Debug
+            use_pch: OFF
+            unit_tests: OFF
+            input_file_tests_min_priority: "normal"
+          # Test with MPI version of charm
+          - compiler: clang-13
+            build_type: Release
             CHARM_ROOT: /work/charm_7_0_0/mpi-linux-x86_64-smp-clang
-            # MPI running tests is a bit slower than multicore
-            TEST_TIMEOUT_FACTOR: 3
 
     container:
       image: ${{ inputs.container || 'sxscollaboration/spectre:ci' }}
@@ -1079,7 +1074,7 @@ ${{ matrix.build_type }}-pch-${{ matrix.use_pch || 'ON' }}"
         compiler:
           - gcc-9
           - gcc-10
-          - clang-10
+          - clang-11
           - clang-13
         include:
           - sde_arch: ("-nhm;nehalem" "-snb;sandybridge" "-hsw;haswell"
@@ -1090,7 +1085,7 @@ ${{ matrix.build_type }}-pch-${{ matrix.use_pch || 'ON' }}"
             compiler: gcc-10
           - sde_arch: ("-nhm;nehalem" "-snb;sandybridge" "-hsw;haswell"
               "-skl;skylake" "-icx;icelake-server")
-            compiler: clang-10
+            compiler: clang-11
           - sde_arch: ("-nhm;nehalem" "-snb;sandybridge" "-hsw;haswell"
               "-skl;skylake" "-icx;icelake-server" "-tgl;tigerlake")
             compiler: clang-13

--- a/docs/DevGuide/QuickStartDockerVSCode.md
+++ b/docs/DevGuide/QuickStartDockerVSCode.md
@@ -153,7 +153,7 @@ the command `CMake: Select a Kit`. You should see a `Default` kit available.
 Then, open the command palette again, run `CMake: Select Variant`, and select
 either `Release` or `Debug`. For this tutorial we recommend using `Release`. If
 you want to actually develop SpECTRE, the `Debug` option would be better. This
-specific kit uses `clang-10` to build SpECTRE along with the Python bindings.
+specific kit uses `clang` to build SpECTRE along with the Python bindings.
 Finally, open the command palette once more and run `CMake: Configure` which
 will now actually run CMake.
 

--- a/docs/Installation/Installation.md
+++ b/docs/Installation/Installation.md
@@ -58,7 +58,7 @@ all of these dependencies.
 #### Required:
 
 * [GCC](https://gcc.gnu.org/) 9.1 or later,
-[Clang](https://clang.llvm.org/) 10.0 or later, or AppleClang 11.0.0 or later
+[Clang](https://clang.llvm.org/) 11.0 or later, or AppleClang 11.0.0 or later
 * [CMake](https://cmake.org/) 3.18.0 or later
 * [Charm++](http://charm.cs.illinois.edu/) 7.0.0, or later (experimental)
   \cite Charmpp1 \cite Charmpp2 \cite Charmpp3


### PR DESCRIPTION
## Proposed changes

Preparation for upgrading the container to Ubuntu 22.04 (which doesn't bundle clang-10). Also a step toward some more C++20 support.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
We don't guarantee compatibility with Clang 10 anymore. Upgrade to Clang 11+ or use GCC 9+.
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
