### PR TITLE
Add AdaptiveOrder FD reconstructor to ForceFree system

### DIFF
--- a/src/Evolution/Systems/ForceFree/FiniteDifference/AdaptiveOrder.cpp
+++ b/src/Evolution/Systems/ForceFree/FiniteDifference/AdaptiveOrder.cpp
@@ -1,0 +1,179 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/ForceFree/FiniteDifference/AdaptiveOrder.hpp"
+
+#include <array>
+#include <boost/functional/hash.hpp>
+#include <cstddef>
+#include <memory>
+#include <pup.h>
+#include <tuple>
+#include <utility>
+
+#include "Evolution/Systems/ForceFree/FiniteDifference/ReconstructWork.tpp"
+#include "Evolution/Systems/ForceFree/FiniteDifference/Reconstructor.hpp"
+#include "Evolution/Systems/ForceFree/Tags.hpp"
+#include "NumericalAlgorithms/FiniteDifference/FallbackReconstructorType.hpp"
+#include "NumericalAlgorithms/FiniteDifference/NeighborDataAsVariables.hpp"
+#include "NumericalAlgorithms/FiniteDifference/PositivityPreservingAdaptiveOrder.hpp"
+#include "NumericalAlgorithms/FiniteDifference/Reconstruct.tpp"
+#include "Options/ParseError.hpp"
+
+namespace ForceFree::fd {
+
+AdaptiveOrder::AdaptiveOrder(
+    const double alpha_5, const std::optional<double> alpha_7,
+    const std::optional<double> alpha_9,
+    const ::fd::reconstruction::FallbackReconstructorType
+        low_order_reconstructor,
+    const Options::Context& context)
+    : four_to_the_alpha_5_(pow(4.0, alpha_5)),
+      low_order_reconstructor_(low_order_reconstructor) {
+  if (low_order_reconstructor_ ==
+      ::fd::reconstruction::FallbackReconstructorType::None) {
+    PARSE_ERROR(context, "None is not an allowed low-order reconstructor.");
+  }
+  if (alpha_7.has_value()) {
+    six_to_the_alpha_7_ = pow(6.0, alpha_7.value());
+  }
+  if (alpha_9.has_value()) {
+    eight_to_the_alpha_9_ = pow(8.0, alpha_9.value());
+  }
+  set_function_pointers();
+}
+
+AdaptiveOrder::AdaptiveOrder(CkMigrateMessage* const msg)
+    : Reconstructor(msg) {}
+
+std::unique_ptr<Reconstructor> AdaptiveOrder::get_clone() const {
+  return std::make_unique<AdaptiveOrder>(*this);
+}
+
+void AdaptiveOrder::set_function_pointers() {
+  std::tie(reconstruct_, reconstruct_lower_neighbor_,
+           reconstruct_upper_neighbor_) = ::fd::reconstruction::
+      positivity_preserving_adaptive_order_function_pointers<3, false>(
+          false, eight_to_the_alpha_9_.has_value(),
+          six_to_the_alpha_7_.has_value(), low_order_reconstructor_);
+  std::tie(pp_reconstruct_, pp_reconstruct_lower_neighbor_,
+           pp_reconstruct_upper_neighbor_) = ::fd::reconstruction::
+      positivity_preserving_adaptive_order_function_pointers<3, true>(
+          true, eight_to_the_alpha_9_.has_value(),
+          six_to_the_alpha_7_.has_value(), low_order_reconstructor_);
+}
+
+void AdaptiveOrder::pup(PUP::er& p) {
+  Reconstructor::pup(p);
+  p | four_to_the_alpha_5_;
+  p | six_to_the_alpha_7_;
+  p | eight_to_the_alpha_9_;
+  p | low_order_reconstructor_;
+  if (p.isUnpacking()) {
+    set_function_pointers();
+  }
+}
+
+// NOLINTNEXTLINE
+PUP::able::PUP_ID AdaptiveOrder::my_PUP_ID = 0;
+
+void AdaptiveOrder::reconstruct(
+    const gsl::not_null<std::array<Variables<face_vars_tags>, dim>*>
+        vars_on_lower_face,
+    const gsl::not_null<std::array<Variables<face_vars_tags>, dim>*>
+        vars_on_upper_face,
+    const Variables<volume_vars_tags>& volume_vars,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_j,
+    const Element<dim>& element,
+    const FixedHashMap<maximum_number_of_neighbors(dim),
+                       std::pair<Direction<dim>, ElementId<dim>>,
+                       evolution::dg::subcell::GhostData,
+                       boost::hash<std::pair<Direction<dim>, ElementId<dim>>>>&
+        ghost_data,
+    const Mesh<dim>& subcell_mesh) const {
+  FixedHashMap<maximum_number_of_neighbors(dim),
+               std::pair<Direction<dim>, ElementId<dim>>,
+               Variables<volume_vars_tags>,
+               boost::hash<std::pair<Direction<dim>, ElementId<dim>>>>
+      neighbor_variables_data{};
+  ::fd::neighbor_data_as_variables<dim>(make_not_null(&neighbor_variables_data),
+                                        ghost_data, ghost_zone_size(),
+                                        subcell_mesh);
+
+  reconstruct_work(
+      vars_on_lower_face, vars_on_upper_face,
+      [this](auto upper_face_vars_ptr, auto lower_face_vars_ptr,
+             const auto& volume_variables, const auto& ghost_cell_vars,
+             const auto& subcell_extents, const size_t number_of_variables) {
+        reconstruct_(upper_face_vars_ptr, lower_face_vars_ptr, volume_variables,
+                     ghost_cell_vars, subcell_extents, number_of_variables,
+                     four_to_the_alpha_5_,
+                     six_to_the_alpha_7_.value_or(
+                         std::numeric_limits<double>::signaling_NaN()),
+                     eight_to_the_alpha_9_.value_or(
+                         std::numeric_limits<double>::signaling_NaN()));
+      },
+      volume_vars, tilde_j, element, ghost_data, subcell_mesh,
+      ghost_zone_size());
+}
+
+void AdaptiveOrder::reconstruct_fd_neighbor(
+    const gsl::not_null<Variables<face_vars_tags>*> vars_on_face,
+    const Variables<volume_vars_tags>& volume_vars,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_j,
+    const Element<dim>& element,
+    const FixedHashMap<maximum_number_of_neighbors(dim),
+                       std::pair<Direction<dim>, ElementId<dim>>,
+                       evolution::dg::subcell::GhostData,
+                       boost::hash<std::pair<Direction<dim>, ElementId<dim>>>>&
+        ghost_data,
+    const Mesh<dim>& subcell_mesh,
+    const Direction<dim> direction_to_reconstruct) const {
+  reconstruct_fd_neighbor_work(
+      vars_on_face,
+      [this](const auto tensor_component_on_face_ptr,
+             const auto& tensor_component_volume,
+             const auto& tensor_component_neighbor, const auto& subcell_extents,
+             const auto& ghost_data_extents,
+             const auto& local_direction_to_reconstruct) {
+        reconstruct_lower_neighbor_(
+            tensor_component_on_face_ptr, tensor_component_volume,
+            tensor_component_neighbor, subcell_extents, ghost_data_extents,
+            local_direction_to_reconstruct, four_to_the_alpha_5_,
+            six_to_the_alpha_7_.value_or(
+                std::numeric_limits<double>::signaling_NaN()),
+            eight_to_the_alpha_9_.value_or(
+                std::numeric_limits<double>::signaling_NaN()));
+      },
+      [this](const auto tensor_component_on_face_ptr,
+             const auto& tensor_component_volume,
+             const auto& tensor_component_neighbor, const auto& subcell_extents,
+             const auto& ghost_data_extents,
+             const auto& local_direction_to_reconstruct) {
+        reconstruct_upper_neighbor_(
+            tensor_component_on_face_ptr, tensor_component_volume,
+            tensor_component_neighbor, subcell_extents, ghost_data_extents,
+            local_direction_to_reconstruct, four_to_the_alpha_5_,
+            six_to_the_alpha_7_.value_or(
+                std::numeric_limits<double>::signaling_NaN()),
+            eight_to_the_alpha_9_.value_or(
+                std::numeric_limits<double>::signaling_NaN()));
+      },
+      volume_vars, tilde_j, element, ghost_data, subcell_mesh,
+      direction_to_reconstruct, ghost_zone_size());
+}
+
+bool operator==(const AdaptiveOrder& lhs, const AdaptiveOrder& rhs) {
+  // Don't check function pointers since they are set from
+  // low_order_reconstructor_
+  return lhs.four_to_the_alpha_5_ == rhs.four_to_the_alpha_5_ and
+         lhs.six_to_the_alpha_7_ == rhs.six_to_the_alpha_7_ and
+         lhs.eight_to_the_alpha_9_ == rhs.eight_to_the_alpha_9_ and
+         lhs.low_order_reconstructor_ == rhs.low_order_reconstructor_;
+}
+
+bool operator!=(const AdaptiveOrder& lhs, const AdaptiveOrder& rhs) {
+  return not(lhs == rhs);
+}
+
+}  // namespace ForceFree::fd

--- a/src/Evolution/Systems/ForceFree/FiniteDifference/AdaptiveOrder.hpp
+++ b/src/Evolution/Systems/ForceFree/FiniteDifference/AdaptiveOrder.hpp
@@ -1,0 +1,232 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <boost/functional/hash.hpp>
+#include <cstddef>
+#include <limits>
+#include <memory>
+#include <optional>
+#include <pup.h>
+#include <utility>
+
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/FixedHashMap.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "DataStructures/VariablesTag.hpp"
+#include "Domain/Structure/MaxNumberOfNeighbors.hpp"
+#include "Domain/Tags.hpp"
+#include "Evolution/DgSubcell/Tags/GhostDataForReconstruction.hpp"
+#include "Evolution/DgSubcell/Tags/Mesh.hpp"
+#include "Evolution/DiscontinuousGalerkin/Actions/NormalCovectorAndMagnitude.hpp"
+#include "Evolution/Systems/ForceFree/FiniteDifference/Reconstructor.hpp"
+#include "Evolution/Systems/ForceFree/Tags.hpp"
+#include "NumericalAlgorithms/FiniteDifference/FallbackReconstructorType.hpp"
+#include "Options/Auto.hpp"
+#include "Options/Context.hpp"
+#include "Options/String.hpp"
+#include "PointwiseFunctions/GeneralRelativity/TagsDeclarations.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+class DataVector;
+template <size_t dim>
+class Direction;
+template <size_t dim>
+class Element;
+template <size_t dim>
+class ElementId;
+template <size_t dim>
+class Mesh;
+template <typename face_vars_tags>
+class Variables;
+namespace gsl {
+template <typename>
+class not_null;
+}  // namespace gsl
+namespace PUP {
+class er;
+}  // namespace PUP
+/// \endcond
+
+namespace ForceFree::fd {
+
+/*!
+ * \brief Adaptive order FD reconstruction. See
+ * ::fd::reconstruction::positivity_preserving_adaptive_order() for details.
+ * Note that in the ForceFree evolution system no variable needs to be kept
+ * positive.
+ *
+ */
+class AdaptiveOrder : public Reconstructor {
+ private:
+  using TildeE = ForceFree::Tags::TildeE;
+  using TildeB = ForceFree::Tags::TildeB;
+  using TildePsi = ForceFree::Tags::TildePsi;
+  using TildePhi = ForceFree::Tags::TildePhi;
+  using TildeQ = ForceFree::Tags::TildeQ;
+  using TildeJ = ForceFree::Tags::TildeJ;
+
+  using volume_vars_tags =
+      tmpl::list<TildeE, TildeB, TildePsi, TildePhi, TildeQ>;
+
+  using face_vars_tags =
+      tmpl::list<TildeJ,  // we reconstruct TildeJ, not computing it from values
+                          // of reconstructed evolved variables
+                 TildeE, TildeB, TildePsi, TildePhi, TildeQ,
+                 ::Tags::Flux<TildeE, tmpl::size_t<3>, Frame::Inertial>,
+                 ::Tags::Flux<TildeB, tmpl::size_t<3>, Frame::Inertial>,
+                 ::Tags::Flux<TildePsi, tmpl::size_t<3>, Frame::Inertial>,
+                 ::Tags::Flux<TildePhi, tmpl::size_t<3>, Frame::Inertial>,
+                 ::Tags::Flux<TildeQ, tmpl::size_t<3>, Frame::Inertial>,
+                 gr::Tags::Lapse<DataVector>,
+                 gr::Tags::Shift<DataVector, 3, Frame::Inertial>,
+                 gr::Tags::SpatialMetric<DataVector, 3, Frame::Inertial>,
+                 gr::Tags::SqrtDetSpatialMetric<DataVector>,
+                 gr::Tags::InverseSpatialMetric<DataVector, 3, Frame::Inertial>,
+                 evolution::dg::Actions::detail::NormalVector<3>>;
+
+  using FallbackReconstructorType =
+      ::fd::reconstruction::FallbackReconstructorType;
+
+ public:
+  static constexpr size_t dim = 3;
+
+  struct Alpha5 {
+    using type = double;
+    static constexpr Options::String help = {
+        "The alpha parameter in the Persson convergence measurement. 4 is the "
+        "right value, but anything in the range of 3-5 is 'reasonable'. "
+        "Smaller values allow for more oscillations."};
+  };
+  struct Alpha7 {
+    using type = Options::Auto<double, Options::AutoLabel::None>;
+    static constexpr Options::String help = {
+        "The alpha parameter in the Persson convergence measurement. 4 is the "
+        "right value, but anything in the range of 3-5 is 'reasonable'. "
+        "Smaller values allow for more oscillations. If not specified then "
+        "7th-order reconstruction is not used."};
+  };
+  struct Alpha9 {
+    using type = Options::Auto<double, Options::AutoLabel::None>;
+    static constexpr Options::String help = {
+        "The alpha parameter in the Persson convergence measurement. 4 is the "
+        "right value, but anything in the range of 3-5 is 'reasonable'. "
+        "Smaller values allow for more oscillations. If not specified then "
+        "9th-order reconstruction is not used."};
+  };
+  struct LowOrderReconstructor {
+    using type = FallbackReconstructorType;
+    static constexpr Options::String help = {
+        "The 2nd/3rd-order reconstruction scheme to use if unlimited 5th-order "
+        "isn't okay."};
+  };
+
+  using options = tmpl::list<Alpha5, Alpha7, Alpha9, LowOrderReconstructor>;
+
+  static constexpr Options::String help{"Adaptive-order reconstruction."};
+  AdaptiveOrder() = default;
+  AdaptiveOrder(AdaptiveOrder&&) = default;
+  AdaptiveOrder& operator=(AdaptiveOrder&&) = default;
+  AdaptiveOrder(const AdaptiveOrder&) = default;
+  AdaptiveOrder& operator=(const AdaptiveOrder&) = default;
+  ~AdaptiveOrder() override = default;
+
+  AdaptiveOrder(double alpha_5, std::optional<double> alpha_7,
+                std::optional<double> alpha_9,
+                FallbackReconstructorType low_order_reconstructor,
+                const Options::Context& context = {});
+
+  explicit AdaptiveOrder(CkMigrateMessage* msg);
+
+  WRAPPED_PUPable_decl_base_template(Reconstructor, AdaptiveOrder);
+
+  auto get_clone() const -> std::unique_ptr<Reconstructor> override;
+
+  static constexpr bool use_adaptive_order = true;
+  bool supports_adaptive_order() const override { return use_adaptive_order; }
+
+  void pup(PUP::er& p) override;
+
+  size_t ghost_zone_size() const override {
+    return eight_to_the_alpha_9_.has_value()
+               ? 5
+               : (six_to_the_alpha_7_.has_value() ? 4 : 3);
+  }
+
+  using reconstruction_argument_tags =
+      tmpl::list<::Tags::Variables<volume_vars_tags>, TildeJ,
+                 domain::Tags::Element<dim>,
+                 evolution::dg::subcell::Tags::GhostDataForReconstruction<dim>,
+                 evolution::dg::subcell::Tags::Mesh<dim>>;
+
+  void reconstruct(
+      gsl::not_null<std::array<Variables<face_vars_tags>, dim>*>
+          vars_on_lower_face,
+      gsl::not_null<std::array<Variables<face_vars_tags>, dim>*>
+          vars_on_upper_face,
+      const Variables<volume_vars_tags>& volume_vars,
+      const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_j,
+      const Element<dim>& element,
+      const FixedHashMap<
+          maximum_number_of_neighbors(dim),
+          std::pair<Direction<dim>, ElementId<dim>>,
+          evolution::dg::subcell::GhostData,
+          boost::hash<std::pair<Direction<dim>, ElementId<dim>>>>& ghost_data,
+      const Mesh<dim>& subcell_mesh) const;
+
+  void reconstruct_fd_neighbor(
+      gsl::not_null<Variables<face_vars_tags>*> vars_on_face,
+      const Variables<volume_vars_tags>& volume_vars,
+      const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_j,
+      const Element<dim>& element,
+      const FixedHashMap<
+          maximum_number_of_neighbors(dim),
+          std::pair<Direction<dim>, ElementId<dim>>,
+          evolution::dg::subcell::GhostData,
+          boost::hash<std::pair<Direction<dim>, ElementId<dim>>>>& ghost_data,
+      const Mesh<dim>& subcell_mesh,
+      const Direction<dim> direction_to_reconstruct) const;
+
+ private:
+  // NOLINTNEXTLINE(readability-redundant-declaration)
+  friend bool operator==(const AdaptiveOrder& lhs, const AdaptiveOrder& rhs);
+  friend bool operator!=(const AdaptiveOrder& lhs, const AdaptiveOrder& rhs);
+  void set_function_pointers();
+
+  double four_to_the_alpha_5_ = std::numeric_limits<double>::signaling_NaN();
+  std::optional<double> six_to_the_alpha_7_{};
+  std::optional<double> eight_to_the_alpha_9_{};
+  FallbackReconstructorType low_order_reconstructor_ =
+      FallbackReconstructorType::None;
+
+  using PointerReconsOrder = void (*)(
+      gsl::not_null<std::array<gsl::span<double>, dim>*>,
+      gsl::not_null<std::array<gsl::span<double>, dim>*>,
+      gsl::not_null<std::optional<std::array<gsl::span<std::uint8_t>, dim>>*>,
+      const gsl::span<const double>&,
+      const DirectionMap<dim, gsl::span<const double>>&, const Index<dim>&,
+      size_t, double, double, double);
+  using PointerRecons =
+      void (*)(gsl::not_null<std::array<gsl::span<double>, dim>*>,
+               gsl::not_null<std::array<gsl::span<double>, dim>*>,
+               const gsl::span<const double>&,
+               const DirectionMap<dim, gsl::span<const double>>&,
+               const Index<dim>&, size_t, double, double, double);
+  PointerRecons reconstruct_ = nullptr;
+  PointerReconsOrder pp_reconstruct_ = nullptr;
+
+  using PointerNeighbor = void (*)(gsl::not_null<DataVector*>,
+                                   const DataVector&, const DataVector&,
+                                   const Index<dim>&, const Index<dim>&,
+                                   const Direction<dim>&, const double&,
+                                   const double&, const double&);
+  PointerNeighbor reconstruct_lower_neighbor_ = nullptr;
+  PointerNeighbor reconstruct_upper_neighbor_ = nullptr;
+  PointerNeighbor pp_reconstruct_lower_neighbor_ = nullptr;
+  PointerNeighbor pp_reconstruct_upper_neighbor_ = nullptr;
+};
+
+}  // namespace ForceFree::fd

--- a/src/Evolution/Systems/ForceFree/FiniteDifference/CMakeLists.txt
+++ b/src/Evolution/Systems/ForceFree/FiniteDifference/CMakeLists.txt
@@ -4,6 +4,7 @@
 spectre_target_sources(
   ${LIBRARY}
   PRIVATE
+  AdaptiveOrder.cpp
   MonotonisedCentral.cpp
   Reconstructor.cpp
   RegisterDerivedWithCharm.cpp
@@ -14,6 +15,7 @@ spectre_target_headers(
   ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
+  AdaptiveOrder.hpp
   Factory.hpp
   FiniteDifference.hpp
   MonotonisedCentral.hpp

--- a/src/Evolution/Systems/ForceFree/FiniteDifference/Factory.hpp
+++ b/src/Evolution/Systems/ForceFree/FiniteDifference/Factory.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "Evolution/Systems/ForceFree/FiniteDifference/AdaptiveOrder.hpp"
 #include "Evolution/Systems/ForceFree/FiniteDifference/MonotonisedCentral.hpp"
 #include "Evolution/Systems/ForceFree/FiniteDifference/Reconstructor.hpp"
 #include "Evolution/Systems/ForceFree/FiniteDifference/Wcns5z.hpp"

--- a/src/Evolution/Systems/ForceFree/FiniteDifference/Reconstructor.hpp
+++ b/src/Evolution/Systems/ForceFree/FiniteDifference/Reconstructor.hpp
@@ -12,6 +12,7 @@
 
 namespace ForceFree::fd {
 /// \cond
+class AdaptiveOrder;
 class MonotonisedCentral;
 class Wcns5z;
 /// \endcond
@@ -35,7 +36,8 @@ class Reconstructor : public PUP::able {
   WRAPPED_PUPable_abstract(Reconstructor);  // NOLINT
   /// \endcond
 
-  using creatable_classes = tmpl::list<MonotonisedCentral, Wcns5z>;
+  using creatable_classes =
+      tmpl::list<AdaptiveOrder, MonotonisedCentral, Wcns5z>;
 
   virtual std::unique_ptr<Reconstructor> get_clone() const = 0;
 

--- a/tests/Unit/Evolution/Systems/ForceFree/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/ForceFree/CMakeLists.txt
@@ -7,6 +7,7 @@ set(LIBRARY_SOURCES
   BoundaryConditions/Test_Periodic.cpp
   BoundaryConditions/Test_DirichletAnalytic.cpp
   BoundaryCorrections/Test_Rusanov.cpp
+  FiniteDifference/Test_AdaptiveOrder.cpp
   FiniteDifference/Test_MonotonisedCentral.cpp
   FiniteDifference/Test_Tags.cpp
   FiniteDifference/Test_Wcns5z.cpp

--- a/tests/Unit/Evolution/Systems/ForceFree/FiniteDifference/Test_AdaptiveOrder.cpp
+++ b/tests/Unit/Evolution/Systems/ForceFree/FiniteDifference/Test_AdaptiveOrder.cpp
@@ -1,0 +1,70 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <optional>
+
+#include "Evolution/Systems/ForceFree/FiniteDifference/AdaptiveOrder.hpp"
+#include "Evolution/Systems/ForceFree/FiniteDifference/Factory.hpp"
+#include "Evolution/Systems/ForceFree/FiniteDifference/Tags.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/Evolution/Systems/ForceFree/FiniteDifference/TestHelpers.hpp"
+#include "NumericalAlgorithms/FiniteDifference/FallbackReconstructorType.hpp"
+
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.ForceFree.Fd.AdaptiveOrder",
+                  "[Unit][Evolution]") {
+  using AdaptiveOrder = ForceFree::fd::AdaptiveOrder;
+  using Reconstructor = ForceFree::fd::Reconstructor;
+
+  auto mc = fd::reconstruction::FallbackReconstructorType::MonotonisedCentral;
+
+  TestHelpers::ForceFree::fd::test_reconstructor(
+      8, AdaptiveOrder{4.0, 4.0, 4.0, mc});
+  TestHelpers::ForceFree::fd::test_reconstructor(
+      6, AdaptiveOrder{4.0, 4.0, std::nullopt, mc});
+  TestHelpers::ForceFree::fd::test_reconstructor(
+      8, AdaptiveOrder{4.0, std::nullopt, 4.0, mc});
+
+  const AdaptiveOrder ao_recons{4.0, std::nullopt, std::nullopt, mc};
+  TestHelpers::ForceFree::fd::test_reconstructor(4, ao_recons);
+
+  const auto ao_from_options_base = TestHelpers::test_factory_creation<
+      Reconstructor, ForceFree::fd::OptionTags::Reconstructor>(
+      "AdaptiveOrder:\n"
+      "  Alpha5: 4.0\n"
+      "  Alpha7: None\n"
+      "  Alpha9: None\n"
+      "  LowOrderReconstructor: MonotonisedCentral\n");
+  auto* const ao_from_options =
+      dynamic_cast<const AdaptiveOrder*>(ao_from_options_base.get());
+  REQUIRE(ao_from_options != nullptr);
+  CHECK(*ao_from_options == ao_recons);
+
+  CHECK(ao_recons != AdaptiveOrder(4.5, std::nullopt, std::nullopt, mc));
+  CHECK(ao_recons != AdaptiveOrder(4.0, 4.0, std::nullopt, mc));
+  CHECK(AdaptiveOrder(4.0, 4.0, std::nullopt, mc) !=
+        AdaptiveOrder(4.0, 4.1, std::nullopt, mc));
+  CHECK(ao_recons != AdaptiveOrder(4.0, std::nullopt, 4.0, mc));
+  CHECK(AdaptiveOrder(4.0, std::nullopt, 4.0, mc) !=
+        AdaptiveOrder(4.0, std::nullopt, 4.1, mc));
+  CHECK(AdaptiveOrder(5.0, std::nullopt, 4.0, mc) ==
+        AdaptiveOrder(5.0, std::nullopt, 4.0, mc));
+  CHECK(AdaptiveOrder(5.0, 6.0, 4.0, mc) == AdaptiveOrder(5.0, 6.0, 4.0, mc));
+  CHECK(AdaptiveOrder(5.0, 6.0, 4.0, mc) != AdaptiveOrder(5.1, 6.0, 4.0, mc));
+  CHECK(AdaptiveOrder(5.0, 6.0, 4.0, mc) != AdaptiveOrder(5.0, 6.1, 4.0, mc));
+  CHECK(AdaptiveOrder(5.0, 6.0, 4.0, mc) != AdaptiveOrder(5.0, 6.0, 4.1, mc));
+  CHECK(AdaptiveOrder(5.0, 6.0, 4.0, mc) !=
+        AdaptiveOrder(5.0, 6.0, 4.0,
+                      fd::reconstruction::FallbackReconstructorType::Minmod));
+  CHECK(ao_recons !=
+        AdaptiveOrder(4.0, std::nullopt, std::nullopt,
+                      fd::reconstruction::FallbackReconstructorType::Minmod));
+
+  CHECK_THROWS_WITH(
+      AdaptiveOrder(4.5, std::nullopt, std::nullopt,
+                    fd::reconstruction::FallbackReconstructorType::None),
+      Catch::Matchers::ContainsSubstring(
+          "None is not an allowed low-order reconstructor."));
+}


### PR DESCRIPTION
## Proposed changes

Code (including the test) is mostly same as GRMHD PPAO, apart from that there is no positivity preserving tags.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
