### PR TITLE
Add p-projectors for Variables and Tensors

### DIFF
--- a/src/ParallelAlgorithms/Amr/Projectors/CMakeLists.txt
+++ b/src/ParallelAlgorithms/Amr/Projectors/CMakeLists.txt
@@ -17,6 +17,8 @@ spectre_target_headers(
   HEADERS
   DefaultInitialize.hpp
   Mesh.hpp
+  Tensors.hpp
+  Variables.hpp
   )
 
 target_link_libraries(

--- a/src/ParallelAlgorithms/Amr/Projectors/Tensors.hpp
+++ b/src/ParallelAlgorithms/Amr/Projectors/Tensors.hpp
@@ -1,0 +1,83 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <unordered_map>
+#include <utility>
+
+#include "DataStructures/ApplyMatrices.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/Structure/Element.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Domain/Tags.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Projection.hpp"
+#include "ParallelAlgorithms/Amr/Protocols/Projector.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace amr::projectors {
+
+/// \brief Update the Tensors corresponding to TensorTags after an AMR
+/// change
+///
+/// There is a specialization for
+/// `ProjectTensors<tmpl::list<TensorTags...>>` that can be used if a
+/// `tmpl::list` is available.
+///
+/// \details For each item corresponding to each tag in TensorTags, project
+/// the data for each tensor from the old mesh to the new mesh
+///
+/// \see ProjectVariables
+template <size_t Dim, typename... TensorTags>
+struct ProjectTensors : tt::ConformsTo<amr::protocols::Projector> {
+  using return_tags = tmpl::list<TensorTags...>;
+  using argument_tags = tmpl::list<domain::Tags::Mesh<Dim>>;
+
+  static void apply(
+      const gsl::not_null<typename TensorTags::type*>... tensors,
+      const Mesh<Dim>& new_mesh,
+      const std::pair<Mesh<Dim>, Element<Dim>>& old_mesh_and_element) {
+    const auto& old_mesh = old_mesh_and_element.first;
+    if (old_mesh == new_mesh) {
+      return;  // mesh was not refined, so no projection needed
+    }
+    const auto projection_matrices =
+        Spectral::p_projection_matrices(old_mesh, new_mesh);
+    const auto& old_extents = old_mesh.extents();
+    const auto project_tensor = [&projection_matrices,
+                                 old_extents](auto& tensor) {
+      for (size_t i = 0; i < tensor.size(); ++i) {
+        tensor[i] = apply_matrices(projection_matrices, tensor[i], old_extents);
+      }
+    };
+    EXPAND_PACK_LEFT_TO_RIGHT(project_tensor(*tensors));
+  }
+
+  template <typename... Tags>
+  static void apply(
+      const gsl::not_null<typename TensorTags::type*>... /*tensors*/,
+      const Mesh<Dim>& /*new_mesh*/,
+      const tuples::TaggedTuple<Tags...>& /*parent_items*/) {
+    ERROR("h-refinement not implemented yet");
+  }
+
+  template <typename... Tags>
+  static void apply(
+      const gsl::not_null<typename TensorTags::type*>... /*tensors*/,
+      const Mesh<Dim>& /*new_mesh*/,
+      const std::unordered_map<ElementId<Dim>, tuples::TaggedTuple<Tags...>>&
+      /*children_items*/) {
+    ERROR("h-refinement not implemented yet");
+  }
+};
+
+/// \cond
+template <size_t Dim, typename... TensorTags>
+struct ProjectTensors<Dim, tmpl::list<TensorTags...>>
+    : public ProjectTensors<Dim, TensorTags...> {};
+/// \endcond
+}  // namespace amr::projectors

--- a/src/ParallelAlgorithms/Amr/Projectors/Variables.hpp
+++ b/src/ParallelAlgorithms/Amr/Projectors/Variables.hpp
@@ -1,0 +1,78 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <unordered_map>
+#include <utility>
+
+#include "DataStructures/ApplyMatrices.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/Structure/Element.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Domain/Tags.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Projection.hpp"
+#include "ParallelAlgorithms/Amr/Protocols/Projector.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace amr::projectors {
+
+/// \brief Update the Variables corresponding to VariablesTags after an AMR
+/// change
+///
+/// There is a specialization for
+/// `ProjectVariables<tmpl::list<VariablesTags...>>` that can be used if a
+/// `tmpl::list` is available.
+///
+/// \details For each item corresponding to each tag in VariablesTags, project
+/// the data for each variable from the old mesh to the new mesh
+///
+/// \see ProjectTensors
+template <size_t Dim, typename... VariablesTags>
+struct ProjectVariables : tt::ConformsTo<amr::protocols::Projector> {
+  using return_tags = tmpl::list<VariablesTags...>;
+  using argument_tags = tmpl::list<domain::Tags::Mesh<Dim>>;
+
+  static void apply(
+      const gsl::not_null<typename VariablesTags::type*>... vars,
+      const Mesh<Dim>& new_mesh,
+      const std::pair<Mesh<Dim>, Element<Dim>>& old_mesh_and_element) {
+    const auto& old_mesh = old_mesh_and_element.first;
+    if (old_mesh == new_mesh) {
+      return;  // mesh was not refined, so no projection needed
+    }
+    const auto projection_matrices =
+        Spectral::p_projection_matrices(old_mesh, new_mesh);
+    const auto& old_extents = old_mesh.extents();
+    expand_pack(
+        (*vars = apply_matrices(projection_matrices, *vars, old_extents))...);
+  }
+
+  template <typename... Tags>
+  static void apply(
+      const gsl::not_null<typename VariablesTags::type*>... /*vars*/,
+      const Mesh<Dim>& /*new_mesh*/,
+      const tuples::TaggedTuple<Tags...>& /*parent_items*/) {
+    ERROR("h-refinement not implemented yet");
+  }
+
+  template <typename... Tags>
+  static void apply(
+      const gsl::not_null<typename VariablesTags::type*>... /*vars*/,
+      const Mesh<Dim>& /*new_mesh*/,
+      const std::unordered_map<ElementId<Dim>, tuples::TaggedTuple<Tags...>>&
+      /*children_items*/) {
+    ERROR("h-refinement not implemented yet");
+  }
+};
+
+/// \cond
+template <size_t Dim, typename... VariableTags>
+struct ProjectVariables<Dim, tmpl::list<VariableTags...>>
+    : public ProjectVariables<Dim, VariableTags...> {};
+/// \endcond
+}  // namespace amr::projectors

--- a/tests/Unit/ParallelAlgorithms/Amr/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/Amr/CMakeLists.txt
@@ -23,6 +23,8 @@ set(LIBRARY_SOURCES
   Criteria/Test_TruncationError.cpp
   Projectors/Test_DefaultInitialize.cpp
   Projectors/Test_Mesh.cpp
+  Projectors/Test_Tensors.cpp
+  Projectors/Test_Variables.cpp
   Test_Protocols.cpp
   )
 

--- a/tests/Unit/ParallelAlgorithms/Amr/Projectors/Test_Tensors.cpp
+++ b/tests/Unit/ParallelAlgorithms/Amr/Projectors/Test_Tensors.cpp
@@ -1,0 +1,112 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/IndexType.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "NumericalAlgorithms/Spectral/Basis.hpp"
+#include "NumericalAlgorithms/Spectral/LogicalCoordinates.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Quadrature.hpp"
+#include "ParallelAlgorithms/Amr/Projectors/Tensors.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+
+struct Tag0 : db::SimpleTag {
+  using type = Scalar<DataVector>;
+};
+
+template <size_t Dim>
+struct Tag1 : db::SimpleTag {
+  using type = tnsr::i<DataVector, Dim>;
+};
+
+template <size_t Dim>
+struct Tag2 : db::SimpleTag {
+  using type = tnsr::iJ<DataVector, Dim>;
+};
+
+template <typename T>
+T f(const T& x, const std::array<double, 3>& c) {
+  return c[0] + c[1] * x + c[2] * square(x);
+}
+
+template <size_t Dim>
+DataVector make_component(
+    const tnsr::I<DataVector, Dim, Frame::ElementLogical>& x,
+    const double scale) {
+  const auto number_of_points = get<0>(x).size();
+  DataVector result{number_of_points, scale};
+  const auto x_coeffs = std::array{0.75, -1.75, 2.75};
+  result *= f(x[0], x_coeffs);
+  if constexpr (Dim > 1) {
+    const auto y_coeffs = std::array{-0.25, 1.25, -2.25};
+    result *= f(x[1], y_coeffs);
+  }
+  if constexpr (Dim > 2) {
+    const auto z_coeffs = std::array{0.125, -1.625, -2.875};
+    result *= f(x[2], z_coeffs);
+  }
+  return result;
+}
+
+template <typename TensorType, size_t Dim>
+TensorType make_tensor(const tnsr::I<DataVector, Dim, Frame::ElementLogical>& x,
+                       const double tensor_scale) {
+  TensorType result = make_with_value<TensorType>(
+      x, std::numeric_limits<double>::signaling_NaN());
+  for (size_t i = 0; i < result.size(); ++i) {
+    result[i] = make_component(x, tensor_scale + i);
+  }
+  return result;
+}
+
+template <size_t Dim>
+void test_p_refine() {
+  const ElementId<Dim> element_id{0};
+  const Element<Dim> element{element_id, DirectionMap<Dim, Neighbors<Dim>>{}};
+  const Mesh<Dim> old_mesh{4, Spectral::Basis::Legendre,
+                           Spectral::Quadrature::GaussLobatto};
+  std::array<size_t, Dim> new_extents{};
+  std::iota(new_extents.begin(), new_extents.end(), 3_st);
+  const Mesh<Dim> new_mesh{new_extents, Spectral::Basis::Legendre,
+                           Spectral::Quadrature::GaussLobatto};
+  const auto x_old = logical_coordinates(old_mesh);
+  const auto x_new = logical_coordinates(new_mesh);
+  auto scalar = make_tensor<typename Tag0::type>(x_old, 1.0);
+  auto one_form = make_tensor<typename Tag1<Dim>::type>(x_old, 4.0);
+  auto deriv = make_tensor<typename Tag2<Dim>::type>(x_old, 8.0);
+  const auto expected_scalar = make_tensor<typename Tag0::type>(x_new, 1.0);
+  const auto expected_one_form =
+      make_tensor<typename Tag1<Dim>::type>(x_new, 4.0);
+  const auto expected_deriv = make_tensor<typename Tag2<Dim>::type>(x_new, 8.0);
+
+  auto box = db::create<
+      db::AddSimpleTags<domain::Tags::Mesh<Dim>, Tag0, Tag1<Dim>, Tag2<Dim>>>(
+      new_mesh, std::move(scalar), std::move(one_form), std::move(deriv));
+
+  db::mutate_apply<amr::projectors::ProjectTensors<
+      Dim, tmpl::list<Tag0, Tag1<Dim>, Tag2<Dim>>>>(
+      make_not_null(&box), std::make_pair(old_mesh, element));
+  CHECK_ITERABLE_APPROX(db::get<Tag0>(box), expected_scalar);
+  CHECK_ITERABLE_APPROX(db::get<Tag1<Dim>>(box), expected_one_form);
+  CHECK_ITERABLE_APPROX(db::get<Tag2<Dim>>(box), expected_deriv);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Amr.Projectors.Tensors", "[ParallelAlgorithms][Unit]") {
+  test_p_refine<1>();
+  test_p_refine<2>();
+  test_p_refine<3>();
+}

--- a/tests/Unit/ParallelAlgorithms/Amr/Projectors/Test_Variables.cpp
+++ b/tests/Unit/ParallelAlgorithms/Amr/Projectors/Test_Variables.cpp
@@ -1,0 +1,94 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/TestTags.hpp"
+#include "NumericalAlgorithms/Spectral/Basis.hpp"
+#include "NumericalAlgorithms/Spectral/LogicalCoordinates.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Quadrature.hpp"
+#include "ParallelAlgorithms/Amr/Projectors/Variables.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+
+using VariablesType =
+    Variables<tmpl::list<TestHelpers::Tags::Scalar<DataVector>>>;
+
+template <size_t Label>
+struct VariablesTag : db::SimpleTag {
+  using type = VariablesType;
+};
+
+template <typename T>
+T f(const T& x, const std::array<double, 3>& c) {
+  return c[0] + c[1] * x + c[2] * square(x);
+}
+
+template <size_t Dim>
+VariablesType make_vars(
+    const tnsr::I<DataVector, Dim, Frame::ElementLogical>& x,
+    const double scale) {
+  const auto number_of_points = get<0>(x).size();
+  VariablesType result{number_of_points, scale};
+  const auto x_coeffs = std::array{0.75, -1.75, 2.75};
+  DataVector& s = get(get<TestHelpers::Tags::Scalar<DataVector>>(result));
+  s *= f(x[0], x_coeffs);
+  if constexpr (Dim > 1) {
+    const auto y_coeffs = std::array{-0.25, 1.25, -2.25};
+    s *= f(x[1], y_coeffs);
+  }
+  if constexpr (Dim > 2) {
+    const auto z_coeffs = std::array{0.125, -1.625, -2.875};
+    s *= f(x[2], z_coeffs);
+  }
+  return result;
+}
+
+template <size_t Dim>
+void test_p_refine() {
+  const ElementId<Dim> element_id{0};
+  const Element<Dim> element{element_id, DirectionMap<Dim, Neighbors<Dim>>{}};
+  const Mesh<Dim> old_mesh{4, Spectral::Basis::Legendre,
+                           Spectral::Quadrature::GaussLobatto};
+  std::array<size_t, Dim> new_extents{};
+  std::iota(new_extents.begin(), new_extents.end(), 3_st);
+  const Mesh<Dim> new_mesh{new_extents, Spectral::Basis::Legendre,
+                           Spectral::Quadrature::GaussLobatto};
+  const auto x_old = logical_coordinates(old_mesh);
+  const auto x_new = logical_coordinates(new_mesh);
+  auto var_0 = make_vars(x_old, 1.0);
+  auto var_1 = make_vars(x_old, 2.0);
+  const auto expected_var_0 = make_vars(x_new, 1.0);
+  const auto expected_var_1 = make_vars(x_new, 2.0);
+
+  auto box = db::create<db::AddSimpleTags<domain::Tags::Mesh<Dim>,
+                                          VariablesTag<0>, VariablesTag<1>>>(
+      new_mesh, std::move(var_0), std::move(var_1));
+
+  db::mutate_apply<amr::projectors::ProjectVariables<
+      Dim, tmpl::list<VariablesTag<0>, VariablesTag<1>>>>(
+      make_not_null(&box), std::make_pair(old_mesh, element));
+
+  CHECK_VARIABLES_APPROX(db::get<VariablesTag<0>>(box), expected_var_0);
+  CHECK_VARIABLES_APPROX(db::get<VariablesTag<1>>(box), expected_var_1);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Amr.Projectors.Variables",
+                  "[ParallelAlgorithms][Unit]") {
+  test_p_refine<1>();
+  test_p_refine<2>();
+  test_p_refine<3>();
+}


### PR DESCRIPTION
## Proposed changes

Add amr::projectors for Variables and Tensors.
This PR only enables support for p-refinement and will ERROR for h-refinement

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
