### PR TITLE
Disentangle evolution EoS from initial data and make initial data runtime

### DIFF
--- a/src/Evolution/Executables/GrMhd/GhValenciaDivClean/CMakeLists.txt
+++ b/src/Evolution/Executables/GrMhd/GhValenciaDivClean/CMakeLists.txt
@@ -1,22 +1,22 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-function(add_ghmhd_executable INITIAL_DATA_NAME INITIAL_DATA LIBS_TO_LINK)
+function(add_ghmhd_executable NAME METAVARS LIBS_TO_LINK)
   add_spectre_parallel_executable(
-    "EvolveGhValenciaDivClean${INITIAL_DATA_NAME}"
+    "EvolveGhValenciaDivClean${NAME}"
     EvolveGhValenciaDivClean
     Evolution/Executables/GrMhd/GhValenciaDivClean
-    "EvolutionMetavars<${INITIAL_DATA}>"
+    "EvolutionMetavars<${METAVARS}>"
     "${LIBS_TO_LINK}"
     )
 endfunction(add_ghmhd_executable)
 
-function(add_ghmhd_with_horizon_executable INITIAL_DATA_NAME INITIAL_DATA LIBS_TO_LINK)
+function(add_ghmhd_with_horizon_executable NAME METAVARS LIBS_TO_LINK)
   add_spectre_parallel_executable(
-    "EvolveGhValenciaDivClean${INITIAL_DATA_NAME}"
+    "EvolveGhValenciaDivCleanWithHorizon${NAME}"
     EvolveGhValenciaDivCleanWithHorizon
     Evolution/Executables/GrMhd/GhValenciaDivClean
-    "EvolutionMetavars<${INITIAL_DATA}>"
+    "EvolutionMetavars<${METAVARS}>"
     "${LIBS_TO_LINK}"
     )
 endfunction(add_ghmhd_with_horizon_executable)
@@ -61,13 +61,13 @@ set(LIBS_TO_LINK_WITH_CONTROL_SYSTEM
 
 add_ghmhd_executable(
   ""
-  "evolution::NumericInitialData,false,BondiSachs"
+  "false,BondiSachs"
   "${LIBS_TO_LINK}"
   )
 
 add_ghmhd_executable(
   "Bns"
-  "evolution::NumericInitialData,true,BondiSachs"
+  "true,BondiSachs"
   "${LIBS_TO_LINK_WITH_CONTROL_SYSTEM}"
   )
 
@@ -79,37 +79,7 @@ if (TARGET SpEC::Exporter)
 endif()
 
 add_ghmhd_with_horizon_executable(
-  BondiHoyleAccretion
-  "gh::Solutions::WrappedGr<grmhd::AnalyticData::BondiHoyleAccretion>,false,BondiSachs"
+  ""
+  "false,BondiSachs"
   "${LIBS_TO_LINK};ApparentHorizons;ParallelInterpolation"
-  )
-
-add_ghmhd_with_horizon_executable(
-  MagnetizedFmDisk
-  "gh::Solutions::WrappedGr<grmhd::AnalyticData::MagnetizedFmDisk>,false,BondiSachs"
-  "${LIBS_TO_LINK};ApparentHorizons;ParallelInterpolation"
-  )
-
-add_ghmhd_with_horizon_executable(
-  BondiMichel
-  "gh::Solutions::WrappedGr<grmhd::Solutions::BondiMichel>,false,BondiSachs"
-  "${LIBS_TO_LINK};ApparentHorizons;ParallelInterpolation"
-  )
-
-add_ghmhd_with_horizon_executable(
-  FishboneMoncriefDisk
-  "gh::Solutions::WrappedGr<RelativisticEuler::Solutions::FishboneMoncriefDisk>,false,BondiSachs"
-  "${LIBS_TO_LINK};ApparentHorizons;ParallelInterpolation"
-  )
-
-add_ghmhd_executable(
-  CcsnCollapse
-  "gh::Solutions::WrappedGr<grmhd::AnalyticData::CcsnCollapse>,false,BondiSachs"
-  "${LIBS_TO_LINK}"
-  )
-
-add_ghmhd_executable(
-  TovStar
-  "gh::Solutions::WrappedGr<RelativisticEuler::Solutions::TovStar>,false,BondiSachs"
-  "${LIBS_TO_LINK}"
   )

--- a/src/Evolution/Executables/GrMhd/GhValenciaDivClean/EvolveGhValenciaDivClean.hpp
+++ b/src/Evolution/Executables/GrMhd/GhValenciaDivClean/EvolveGhValenciaDivClean.hpp
@@ -29,16 +29,14 @@
 #include "Utilities/Serialization/RegisterDerivedClassesWithCharm.hpp"
 #include "Utilities/TMPL.hpp"
 
-template <typename InitialData, bool UseControlSystems,
-          typename... InterpolationTargetTags>
-struct EvolutionMetavars : public GhValenciaDivCleanTemplateBase<
-                               EvolutionMetavars<InitialData, UseControlSystems,
-                                                 InterpolationTargetTags...>,
-                               true, UseControlSystems> {
+template <bool UseControlSystems, typename... InterpolationTargetTags>
+struct EvolutionMetavars
+    : public GhValenciaDivCleanTemplateBase<
+          EvolutionMetavars<UseControlSystems, InterpolationTargetTags...>,
+          true, UseControlSystems> {
   using base = GhValenciaDivCleanTemplateBase<
-      EvolutionMetavars<InitialData, UseControlSystems,
-                        InterpolationTargetTags...>,
-      true, UseControlSystems>;
+      EvolutionMetavars<UseControlSystems, InterpolationTargetTags...>, true,
+      UseControlSystems>;
   using const_global_cache_tags = typename base::const_global_cache_tags;
   using observed_reduction_data_tags =
       typename base::observed_reduction_data_tags;

--- a/src/Evolution/Executables/GrMhd/GhValenciaDivClean/EvolveGhValenciaDivCleanFwd.hpp
+++ b/src/Evolution/Executables/GrMhd/GhValenciaDivClean/EvolveGhValenciaDivCleanFwd.hpp
@@ -45,7 +45,6 @@ class OrszagTangVortex;
 
 struct KerrHorizon;
 struct BondiSachs;
-template <typename InitialData, bool UseControlSystems,
-          typename... InterpolationTargetTags>
+template <bool UseControlSystems, typename... InterpolationTargetTags>
 struct EvolutionMetavars;
 /// \endcond

--- a/src/Evolution/Executables/GrMhd/GhValenciaDivClean/EvolveGhValenciaDivCleanWithHorizon.hpp
+++ b/src/Evolution/Executables/GrMhd/GhValenciaDivClean/EvolveGhValenciaDivCleanWithHorizon.hpp
@@ -50,12 +50,11 @@
 #include "Utilities/Serialization/RegisterDerivedClassesWithCharm.hpp"
 #include "Utilities/TMPL.hpp"
 
-template <typename InitialData, bool UseControlSystems,
-          typename... InterpolationTargetTags>
-struct EvolutionMetavars : public GhValenciaDivCleanTemplateBase<
-                               EvolutionMetavars<InitialData, UseControlSystems,
-                                                 InterpolationTargetTags...>,
-                               false, false> {
+template <bool UseControlSystems, typename... InterpolationTargetTags>
+struct EvolutionMetavars
+    : public GhValenciaDivCleanTemplateBase<
+          EvolutionMetavars<UseControlSystems, InterpolationTargetTags...>,
+          false, false> {
   static_assert(not UseControlSystems,
                 "GhValenciaWithHorizon doesn't support control systems yet.");
   static constexpr bool use_dg_subcell = false;

--- a/src/Evolution/Executables/GrMhd/GhValenciaDivClean/EvolveGhValenciaDivCleanWithHorizonFwd.hpp
+++ b/src/Evolution/Executables/GrMhd/GhValenciaDivClean/EvolveGhValenciaDivCleanWithHorizonFwd.hpp
@@ -37,7 +37,6 @@ class MagnetizedFmDisk;
 
 struct KerrHorizon;
 struct BondiSachs;
-template <typename InitialData, bool UseControlSystems,
-          typename... InterpolationTargetTags>
+template <bool UseControlSystems, typename... InterpolationTargetTags>
 struct EvolutionMetavars;
 /// \endcond

--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/CMakeLists.txt
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/CMakeLists.txt
@@ -1,12 +1,12 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-function(add_grmhd_executable INITIAL_DATA_NAME INITIAL_DATA LIBS_TO_LINK)
+function(add_grmhd_executable LIBS_TO_LINK)
   add_spectre_parallel_executable(
-    "EvolveValenciaDivClean${INITIAL_DATA_NAME}"
+    "EvolveValenciaDivClean"
     EvolveValenciaDivClean
     Evolution/Executables/GrMhd/ValenciaDivClean
-    "EvolutionMetavars<${INITIAL_DATA}>"
+    "EvolutionMetavars<false>"
     "${LIBS_TO_LINK}"
     )
 endfunction(add_grmhd_executable)
@@ -39,111 +39,6 @@ set(LIBS_TO_LINK
   Utilities
   ValenciaDivClean
   )
-
-add_grmhd_executable(
-  FishboneMoncriefDisk
-  RelativisticEuler::Solutions::FishboneMoncriefDisk,KerrHorizon
-  "${LIBS_TO_LINK};ApparentHorizons;Interpolation;ParallelInterpolation"
-  )
-
-add_grmhd_executable(
-  TovStar
-  RelativisticEuler::Solutions::TovStar,CenterOfStar
-  "${LIBS_TO_LINK}"
-  )
-
-add_grmhd_executable(
-  AlfvenWave
-  grmhd::Solutions::AlfvenWave
-  "${LIBS_TO_LINK}"
-  )
-
-add_grmhd_executable(
-  BondiMichel
-  grmhd::Solutions::BondiMichel
-  "${LIBS_TO_LINK}"
-  )
-
-add_grmhd_executable(
-  KomissarovShock
-  grmhd::Solutions::KomissarovShock
-  "${LIBS_TO_LINK}"
-  )
-
-add_grmhd_executable(
-  SmoothFlow
-  grmhd::Solutions::SmoothFlow
-  "${LIBS_TO_LINK}"
-  )
-
-add_grmhd_executable(
-  BondiHoyleAccretion
-  grmhd::AnalyticData::BondiHoyleAccretion
-  "${LIBS_TO_LINK}"
-  )
-
-add_grmhd_executable(
-  BlastWave
-  grmhd::AnalyticData::BlastWave
-  "${LIBS_TO_LINK}"
-  )
-
-add_grmhd_executable(
-  CcsnCollapse
-  grmhd::AnalyticData::CcsnCollapse
-  "${LIBS_TO_LINK}"
-  )
-
-add_grmhd_executable(
-  KhInstability
-  grmhd::AnalyticData::KhInstability
-  "${LIBS_TO_LINK}"
-  )
-
-add_grmhd_executable(
-  MagneticFieldLoop
-  grmhd::AnalyticData::MagneticFieldLoop
-  "${LIBS_TO_LINK}"
-  )
-
-add_grmhd_executable(
-  MagneticRotor
-  grmhd::AnalyticData::MagneticRotor
-  "${LIBS_TO_LINK}"
-  )
-
-add_grmhd_executable(
-  MagnetizedFmDisk
-  grmhd::AnalyticData::MagnetizedFmDisk
-  "${LIBS_TO_LINK}"
-  )
-
-add_grmhd_executable(
-  MagnetizedTovStar
-  grmhd::AnalyticData::MagnetizedTovStar,CenterOfStar
-  "${LIBS_TO_LINK}"
-  )
-
-add_grmhd_executable(
-  OrszagTangVortex
-  grmhd::AnalyticData::OrszagTangVortex
-  "${LIBS_TO_LINK}"
-  )
-
-add_grmhd_executable(
-  RiemannProblem
-  grmhd::AnalyticData::RiemannProblem
-  "${LIBS_TO_LINK}"
-  )
-
-add_grmhd_executable(
-  RotatingStar
-  RelativisticEuler::Solutions::RotatingStar
-  "${LIBS_TO_LINK}"
-  )
-
-add_grmhd_executable(
-  SlabJet
-  grmhd::AnalyticData::SlabJet
+  add_grmhd_executable(
   "${LIBS_TO_LINK}"
   )

--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
@@ -56,6 +56,7 @@
 #include "Evolution/Initialization/Evolution.hpp"
 #include "Evolution/Initialization/Limiter.hpp"
 #include "Evolution/Initialization/SetVariables.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/AllSolutions.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryConditions/Factory.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryCorrections/Factory.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryCorrections/RegisterDerived.hpp"
@@ -202,39 +203,36 @@ class CProxy_GlobalCache;
 }  // namespace Parallel
 /// \endcond
 
-template <typename InitialData, typename... InterpolationTargetTags>
+template <bool UseParametrizedDeleptonization,
+          typename... InterpolationTargetTags>
 struct EvolutionMetavars {
   // The use_dg_subcell flag controls whether to use "standard" limiting (false)
   // or a DG-FD hybrid scheme (true).
+  static constexpr bool use_parametrized_deleptonization =
+      UseParametrizedDeleptonization;
   static constexpr bool use_dg_subcell = true;
   static constexpr size_t volume_dim = 3;
   static constexpr dg::Formulation dg_formulation =
       dg::Formulation::StrongInertial;
-  using initial_data = InitialData;
-  static_assert(
-      is_analytic_data_v<initial_data> xor is_analytic_solution_v<initial_data>,
-      "initial_data must be either an analytic_data or an analytic_solution");
+  using initial_data_list =
+      grmhd::ValenciaDivClean::InitialData::initial_data_list;
+
   // Boolean verifying if parameterized deleptonization will be active.  This
   // will only be active for CCSN evolution.
-  using parameterized_deleptonization = tmpl::conditional_t<
-      std::is_same_v<initial_data, grmhd::AnalyticData::CcsnCollapse>,
-      VariableFixing::Actions::FixVariables<
-          VariableFixing::ParameterizedDeleptonization>,
-      tmpl::list<>>;
-  using eos_base = typename EquationsOfState::get_eos_base<
-      typename initial_data::equation_of_state_type>;
+  using parameterized_deleptonization =
+      tmpl::conditional_t<UseParametrizedDeleptonization,
+                          VariableFixing::Actions::FixVariables<
+                              VariableFixing::ParameterizedDeleptonization>,
+                          tmpl::list<>>;
+  using eos_base = EquationsOfState::EquationOfState<true, 3>;
   using equation_of_state_type = typename std::unique_ptr<eos_base>;
+  using initial_data_tag = evolution::initial_data::Tags::InitialData;
   using system = grmhd::ValenciaDivClean::System;
   using temporal_id = Tags::TimeStepId;
   static constexpr bool local_time_stepping = false;
-  using initial_data_tag =
-      tmpl::conditional_t<is_analytic_solution_v<initial_data>,
-                          Tags::AnalyticSolution<initial_data>,
-                          Tags::AnalyticData<initial_data>>;
   using analytic_variables_tags =
       typename system::primitive_variables_tag::tags_list;
-  using equation_of_state_tag =
-      hydro::Tags::EquationOfState<equation_of_state_type>;
+  using equation_of_state_tag = hydro::evolution::grmhd::Tags::EquationOfState;
   // Do not limit the divergence-cleaning field Phi
   using limiter = Tags::Limiter<
       Limiters::Minmod<3, tmpl::list<grmhd::ValenciaDivClean::Tags::TildeD,
@@ -255,7 +253,7 @@ struct EvolutionMetavars {
   using interpolation_target_tags = tmpl::list<InterpolationTargetTags...>;
 
   using analytic_compute = evolution::Tags::AnalyticSolutionsCompute<
-      volume_dim, analytic_variables_tags, use_dg_subcell>;
+      volume_dim, analytic_variables_tags, use_dg_subcell, initial_data_list>;
   using error_compute = Tags::ErrorsCompute<analytic_variables_tags>;
   using error_tags = db::wrap_tags_in<Tags::Error, analytic_variables_tags>;
   using observe_fields = tmpl::push_back<
@@ -338,6 +336,7 @@ struct EvolutionMetavars {
             grmhd::ValenciaDivClean::BoundaryConditions::BoundaryCondition,
             grmhd::ValenciaDivClean::BoundaryConditions::
                 standard_boundary_conditions>,
+        tmpl::pair<evolution::initial_data::InitialData, initial_data_list>,
         tmpl::pair<LtsTimeStepper, TimeSteppers::lts_time_steppers>,
         tmpl::pair<PhaseChange, PhaseControl::factory_creatable_classes>,
         tmpl::pair<StepChooser<StepChooserUse::LtsStep>,
@@ -395,7 +394,7 @@ struct EvolutionMetavars {
 
   using dg_step_actions = tmpl::flatten<tmpl::list<
       Actions::MutateApply<
-          evolution::dg::BackgroundGrVars<system, EvolutionMetavars, false>>,
+          evolution::dg::BackgroundGrVars<system, EvolutionMetavars, true>>,
       evolution::dg::Actions::ComputeTimeDerivative<
           volume_dim, system, AllStepChoosers, local_time_stepping>,
       tmpl::conditional_t<
@@ -429,7 +428,7 @@ struct EvolutionMetavars {
 
       Actions::Label<evolution::dg::subcell::Actions::Labels::BeginDg>,
       Actions::MutateApply<
-          evolution::dg::BackgroundGrVars<system, EvolutionMetavars, false>>,
+          evolution::dg::BackgroundGrVars<system, EvolutionMetavars, true>>,
       evolution::dg::Actions::ComputeTimeDerivative<
           volume_dim, system, AllStepChoosers, local_time_stepping>,
       evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
@@ -452,7 +451,7 @@ struct EvolutionMetavars {
 
       Actions::Label<evolution::dg::subcell::Actions::Labels::BeginSubcell>,
       Actions::MutateApply<evolution::dg::subcell::BackgroundGrVars<
-          system, EvolutionMetavars, false, false>>,
+          system, EvolutionMetavars, true, true>>,
       Actions::MutateApply<evolution::dg::subcell::fd::CellCenteredFlux<
           system, grmhd::ValenciaDivClean::ComputeFluxes, volume_dim, false>>,
       evolution::dg::subcell::Actions::SendDataForReconstruction<
@@ -462,7 +461,7 @@ struct EvolutionMetavars {
       Actions::Label<
           evolution::dg::subcell::Actions::Labels::BeginSubcellAfterDgRollback>,
       Actions::MutateApply<evolution::dg::subcell::BackgroundGrVars<
-          system, EvolutionMetavars, false, true>>,
+          system, EvolutionMetavars, true, true>>,
       Actions::MutateApply<grmhd::ValenciaDivClean::subcell::SwapGrTags>,
       Actions::MutateApply<grmhd::ValenciaDivClean::subcell::PrimsAfterRollback<
           ordered_list_of_primitive_recovery_schemes>>,
@@ -504,7 +503,7 @@ struct EvolutionMetavars {
           evolution::dg::Initialization::Domain<3>,
           Initialization::TimeStepperHistory<EvolutionMetavars>>,
       Initialization::Actions::AddSimpleTags<
-          evolution::dg::BackgroundGrVars<system, EvolutionMetavars, false>>,
+          evolution::dg::BackgroundGrVars<system, EvolutionMetavars, true>>,
       Initialization::Actions::ConservativeSystem<system>,
 
       tmpl::conditional_t<
@@ -514,7 +513,7 @@ struct EvolutionMetavars {
                                                               system, false>,
               Initialization::Actions::AddSimpleTags<
                   evolution::dg::subcell::BackgroundGrVars<
-                      system, EvolutionMetavars, false, false>,
+                      system, EvolutionMetavars, true, false>,
                   grmhd::ValenciaDivClean::SetVariablesNeededFixingToFalse>,
               Actions::MutateApply<
                   grmhd::ValenciaDivClean::subcell::SwapGrTags>,
@@ -603,7 +602,7 @@ struct EvolutionMetavars {
               grmhd::ValenciaDivClean::Tags::PrimitiveFromConservativeOptions,
               grmhd::ValenciaDivClean::subcell::Tags::TciOptions>,
           tmpl::list<>>,
-      initial_data_tag, equation_of_state_tag,
+      equation_of_state_tag, initial_data_tag,
       grmhd::ValenciaDivClean::Tags::ConstraintDampingParameter>;
 
   static constexpr Options::String help{

--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivCleanFwd.hpp
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivCleanFwd.hpp
@@ -36,6 +36,7 @@ class SlabJet;
 
 struct CenterOfStar;
 struct KerrHorizon;
-template <typename InitialData, typename...InterpolationTargetTags>
+template <bool UseParametrizedDeleptonization,
+          typename... InterpolationTargetTags>
 struct EvolutionMetavars;
 /// \endcond

--- a/src/Evolution/Systems/GeneralizedHarmonic/AllSolutions.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/AllSolutions.hpp
@@ -6,9 +6,9 @@
 #include <cstddef>
 
 #include "PointwiseFunctions/AnalyticData/GhGrMhd/Factory.hpp"
+#include "PointwiseFunctions/AnalyticData/GhScalarTensor/Factory.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Factory.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GhGrMhd/Factory.hpp"
-#include "PointwiseFunctions/AnalyticData/GhScalarTensor/Factory.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GhRelativisticEuler/Factory.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -17,14 +17,16 @@ namespace gh {
  * \brief All solutions, including matter ones from GRMHD, etc. Used by
  * e.g. boundary conditions.
  */
+using ghmhd_solutions =
+    tmpl::append<gh::RelativisticEuler::Solutions::all_solutions,
+                 gh::grmhd::Solutions::all_solutions,
+                 gh::grmhd::AnalyticData::all_analytic_data>;
 template <size_t Dim>
 using solutions_including_matter = tmpl::append<
     gh::Solutions::all_solutions<Dim>,
     tmpl::conditional_t<
         Dim == 3,
-        tmpl::append<gh::RelativisticEuler::Solutions::all_solutions,
-                     gh::grmhd::Solutions::all_solutions,
-                     gh::grmhd::AnalyticData::all_analytic_data,
+        tmpl::append<ghmhd_solutions,
                      gh::ScalarTensor::AnalyticData::all_analytic_data>,
         tmpl::list<>>>;
 }  // namespace gh

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/Actions/SetInitialData.hpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/Actions/SetInitialData.hpp
@@ -17,6 +17,7 @@
 #include "Evolution/DgSubcell/Tags/Coordinates.hpp"
 #include "Evolution/DgSubcell/Tags/Jacobians.hpp"
 #include "Evolution/DgSubcell/Tags/Mesh.hpp"
+#include "Evolution/NumericInitialData.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/Actions/SetInitialData.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/Actions/NumericInitialData.hpp"
@@ -57,7 +58,8 @@ namespace grmhd::GhValenciaDivClean {
  * mostly combines the `gh::NumericInitialData` and
  * `grmhd::ValenciaDivClean::NumericInitialData` classes.
  */
-class NumericInitialData : public evolution::initial_data::InitialData {
+class NumericInitialData : public evolution::initial_data::InitialData,
+                           public evolution::NumericInitialData {
  private:
   using GhNumericId = gh::NumericInitialData;
   using HydroNumericId = grmhd::ValenciaDivClean::NumericInitialData;

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/AllSolutions.hpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/AllSolutions.hpp
@@ -3,12 +3,25 @@
 
 #pragma once
 
-#include "Evolution/Systems/GrMhd/GhValenciaDivClean/Actions/SetInitialData.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/AllSolutions.hpp"
+#include "Evolution/Systems/GrMhd/GhValenciaDivClean/Actions/SetInitialData.hpp"
 
-namespace grmhd::GhValenciaDivClean::InitialData {
-using analytic_solutions_and_data_list = gh::solutions_including_matter<3>;
-using initial_data_list =
-    tmpl::flatten<tmpl::list<analytic_solutions_and_data_list,
-                   tmpl::list<grmhd::GhValenciaDivClean::NumericInitialData>>>;
-} // namespace grmhd::GhValenciaDivClean::InitialData
+// Check if SpEC is linked and therefore we can load SpEC initial data
+#ifdef HAS_SPEC_EXPORTER
+#include "PointwiseFunctions/AnalyticData/GrMhd/SpecInitialData.hpp"
+using SpecInitialData =
+    tmpl::list<>;  // tmpl::list<grmhd::AnalyticData::SpecInitialData<1>>;
+                   //  grmhd::AnalyticData::SpecInitialData<2>>;
+#else
+using SpecInitialData = NoSuchType;
+#endif
+
+namespace ghmhd::GhValenciaDivClean::InitialData {
+using analytic_solutions_and_data_list = gh::ghmhd_solutions;
+using initial_data_list = tmpl::flatten<tmpl::list<
+    analytic_solutions_and_data_list,
+    tmpl::flatten<tmpl::list<
+        grmhd::GhValenciaDivClean::NumericInitialData,
+        tmpl::conditional_t<std::is_same_v<SpecInitialData, NoSuchType>,
+                            tmpl::list<>, SpecInitialData>>>>>;
+}  // namespace ghmhd::GhValenciaDivClean::InitialData

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/AllSolutions.hpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/AllSolutions.hpp
@@ -1,0 +1,14 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "Evolution/Systems/GrMhd/GhValenciaDivClean/Actions/SetInitialData.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/AllSolutions.hpp"
+
+namespace grmhd::GhValenciaDivClean::InitialData {
+using analytic_solutions_and_data_list = gh::solutions_including_matter<3>;
+using initial_data_list =
+    tmpl::flatten<tmpl::list<analytic_solutions_and_data_list,
+                   tmpl::list<grmhd::GhValenciaDivClean::NumericInitialData>>>;
+} // namespace grmhd::GhValenciaDivClean::InitialData

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/BoundaryConditions/DirichletAnalytic.cpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/BoundaryConditions/DirichletAnalytic.cpp
@@ -14,14 +14,32 @@ namespace grmhd::GhValenciaDivClean::BoundaryConditions {
 DirichletAnalytic::DirichletAnalytic(CkMigrateMessage* const msg)
     : BoundaryCondition(msg) {}
 // LCOV_EXCL_STOP
+DirichletAnalytic::DirichletAnalytic(const DirichletAnalytic& rhs)
+    : BoundaryCondition{dynamic_cast<const BoundaryCondition&>(rhs)},
+      analytic_prescription_(rhs.analytic_prescription_->get_clone()) {}
+
+DirichletAnalytic& DirichletAnalytic::operator=(const DirichletAnalytic& rhs) {
+  if (&rhs == this) {
+    return *this;
+  }
+  analytic_prescription_ = rhs.analytic_prescription_->get_clone();
+  return *this;
+}
+
+DirichletAnalytic::DirichletAnalytic(
+    std::unique_ptr<evolution::initial_data::InitialData> analytic_prescription)
+    : analytic_prescription_(std::move(analytic_prescription)) {}
 
 std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
 DirichletAnalytic::get_clone() const {
   return std::make_unique<DirichletAnalytic>(*this);
 }
 
-void DirichletAnalytic::pup(PUP::er& p) { BoundaryCondition::pup(p); }
-
+void DirichletAnalytic::pup(PUP::er& p) {
+  BoundaryCondition::pup(p);
+  p | analytic_prescription_;
+}
 // NOLINTNEXTLINE
 PUP::able::PUP_ID DirichletAnalytic::my_PUP_ID = 0;
+
 }  // namespace grmhd::GhValenciaDivClean::BoundaryConditions

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/BoundaryConditions/DirichletFreeOutflow.cpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/BoundaryConditions/DirichletFreeOutflow.cpp
@@ -8,18 +8,36 @@
 #include <pup.h>
 
 namespace grmhd::GhValenciaDivClean::BoundaryConditions {
-// LCOV_EXCL_START
 DirichletFreeOutflow::DirichletFreeOutflow(CkMigrateMessage* const msg)
     : BoundaryCondition(msg) {}
 // LCOV_EXCL_STOP
+DirichletFreeOutflow::DirichletFreeOutflow(const DirichletFreeOutflow& rhs)
+    : BoundaryCondition{dynamic_cast<const BoundaryCondition&>(rhs)},
+      analytic_prescription_(rhs.analytic_prescription_->get_clone()) {}
+
+DirichletFreeOutflow& DirichletFreeOutflow::operator=(
+    const DirichletFreeOutflow& rhs) {
+  if (&rhs == this) {
+    return *this;
+  }
+  analytic_prescription_ = rhs.analytic_prescription_->get_clone();
+  return *this;
+}
+
+DirichletFreeOutflow::DirichletFreeOutflow(
+    std::unique_ptr<evolution::initial_data::InitialData> analytic_prescription)
+    : analytic_prescription_(std::move(analytic_prescription)) {}
 
 std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
 DirichletFreeOutflow::get_clone() const {
   return std::make_unique<DirichletFreeOutflow>(*this);
 }
 
-void DirichletFreeOutflow::pup(PUP::er& p) { BoundaryCondition::pup(p); }
-
+void DirichletFreeOutflow::pup(PUP::er& p) {
+  BoundaryCondition::pup(p);
+  p | analytic_prescription_;
+}
 // NOLINTNEXTLINE
 PUP::able::PUP_ID DirichletFreeOutflow::my_PUP_ID = 0;
+
 }  // namespace grmhd::GhValenciaDivClean::BoundaryConditions

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/MonotonisedCentral.cpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/MonotonisedCentral.cpp
@@ -358,7 +358,7 @@ bool operator!=(const MonotonisedCentralPrim& lhs,
       const Mesh<3>& subcell_mesh,                                             \
       const Direction<3> direction_to_reconstruct) const;
 
-GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2))
+GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
 
 #undef INSTANTIATION
 #undef TAGS_LIST

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/PositivityPreservingAdaptiveOrder.cpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/PositivityPreservingAdaptiveOrder.cpp
@@ -479,7 +479,7 @@ bool operator!=(const PositivityPreservingAdaptiveOrderPrim& lhs,
       const Mesh<3>& subcell_mesh,                                             \
       const Direction<3> direction_to_reconstruct) const;
 
-GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2))
+GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
 
 #undef INSTANTIATION
 #undef TAGS_LIST

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/FixConservativesAndComputePrims.cpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/FixConservativesAndComputePrims.cpp
@@ -131,7 +131,7 @@ GENERATE_INSTANTIATIONS(
      tmpl::list<ValenciaDivClean::PrimitiveRecoverySchemes::NewmanHamlin>,
      tmpl::list<ValenciaDivClean::PrimitiveRecoverySchemes::PalenzuelaEtAl>,
      NewmanThenPalenzuela, KastaunThenNewmanThenPalenzuela),
-    (1, 2))
+    (1, 2, 3))
 
 #undef INSTANTIATION
 #undef THERMO_DIM

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/PrimsAfterRollback.cpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/PrimsAfterRollback.cpp
@@ -134,7 +134,7 @@ GENERATE_INSTANTIATIONS(
      tmpl::list<ValenciaDivClean::PrimitiveRecoverySchemes::NewmanHamlin>,
      tmpl::list<ValenciaDivClean::PrimitiveRecoverySchemes::PalenzuelaEtAl>,
      NewmanThenPalenzuela, KastaunThenNewmanThenPalenzuela),
-    (1, 2))
+    (1, 2, 3))
 #undef INSTANTIATION
 #undef THERMO_DIM
 #undef RECOVERY

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/ResizeAndComputePrimitives.cpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/ResizeAndComputePrimitives.cpp
@@ -137,7 +137,7 @@ GENERATE_INSTANTIATIONS(
      tmpl::list<ValenciaDivClean::PrimitiveRecoverySchemes::NewmanHamlin>,
      tmpl::list<ValenciaDivClean::PrimitiveRecoverySchemes::PalenzuelaEtAl>,
      NewmanThenPalenzuela, KastaunThenNewmanThenPalenzuela),
-    (1, 2))
+    (1, 2, 3))
 #undef INSTANTIATION
 #undef THERMO_DIM
 #undef RECOVERY

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/AllSolutions.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/AllSolutions.hpp
@@ -1,0 +1,43 @@
+
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "PointwiseFunctions/AnalyticData/GrMhd/AnalyticData.hpp"
+#include "PointwiseFunctions/AnalyticData/GrMhd/BlastWave.hpp"
+#include "PointwiseFunctions/AnalyticData/GrMhd/BondiHoyleAccretion.hpp"
+#include "PointwiseFunctions/AnalyticData/GrMhd/CcsnCollapse.hpp"
+#include "PointwiseFunctions/AnalyticData/GrMhd/KhInstability.hpp"
+#include "PointwiseFunctions/AnalyticData/GrMhd/MagneticFieldLoop.hpp"
+#include "PointwiseFunctions/AnalyticData/GrMhd/MagneticRotor.hpp"
+#include "PointwiseFunctions/AnalyticData/GrMhd/MagnetizedFmDisk.hpp"
+#include "PointwiseFunctions/AnalyticData/GrMhd/MagnetizedTovStar.hpp"
+#include "PointwiseFunctions/AnalyticData/GrMhd/OrszagTangVortex.hpp"
+#include "PointwiseFunctions/AnalyticData/GrMhd/RiemannProblem.hpp"
+#include "PointwiseFunctions/AnalyticData/GrMhd/SlabJet.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/AnalyticSolution.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GrMhd/AlfvenWave.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GrMhd/BondiMichel.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GrMhd/KomissarovShock.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GrMhd/SmoothFlow.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GrMhd/Solutions.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/RelativisticEuler/FishboneMoncriefDisk.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/RelativisticEuler/RotatingStar.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/RelativisticEuler/TovStar.hpp"
+
+
+namespace grmhd::ValenciaDivClean::InitialData {
+using initial_data_list =
+    tmpl::list<AnalyticData::BlastWave, AnalyticData::BondiHoyleAccretion,
+               AnalyticData::CcsnCollapse, AnalyticData::KhInstability,
+               AnalyticData::MagneticFieldLoop, AnalyticData::MagneticRotor,
+               AnalyticData::MagnetizedFmDisk, AnalyticData::MagnetizedTovStar,
+               AnalyticData::OrszagTangVortex, AnalyticData::RiemannProblem,
+               AnalyticData::SlabJet, //Solutions::AlfvenWave,
+               Solutions::BondiMichel,
+               //Solutions::KomissarovShock, Solutions::SmoothFlow,
+               RelativisticEuler::Solutions::FishboneMoncriefDisk,
+  //  RelativisticEuler::Solutions::RotatingStar,
+               RelativisticEuler::Solutions::TovStar>;
+    }

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryConditions/DirichletAnalytic.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryConditions/DirichletAnalytic.cpp
@@ -10,6 +10,22 @@
 #include "Utilities/GenerateInstantiations.hpp"
 
 namespace grmhd::ValenciaDivClean::BoundaryConditions {
+
+DirichletAnalytic::DirichletAnalytic(const DirichletAnalytic& rhs)
+    : BoundaryCondition{dynamic_cast<const BoundaryCondition&>(rhs)},
+      analytic_prescription_(rhs.analytic_prescription_->get_clone()) {}
+
+DirichletAnalytic& DirichletAnalytic::operator=(const DirichletAnalytic& rhs) {
+  if (&rhs == this) {
+    return *this;
+  }
+  analytic_prescription_ = rhs.analytic_prescription_->get_clone();
+  return *this;
+}
+
+DirichletAnalytic::DirichletAnalytic(
+    std::unique_ptr<evolution::initial_data::InitialData> analytic_prescription)
+    : analytic_prescription_(std::move(analytic_prescription)) {}
 DirichletAnalytic::DirichletAnalytic(CkMigrateMessage* const msg)
     : BoundaryCondition(msg) {}
 
@@ -18,8 +34,10 @@ DirichletAnalytic::get_clone() const {
   return std::make_unique<DirichletAnalytic>(*this);
 }
 
-void DirichletAnalytic::pup(PUP::er& p) { BoundaryCondition::pup(p); }
-
+void DirichletAnalytic::pup(PUP::er& p) {
+  BoundaryCondition::pup(p);
+  p | analytic_prescription_;
+}
 // NOLINTNEXTLINE
 PUP::able::PUP_ID DirichletAnalytic::my_PUP_ID = 0;
 }  // namespace grmhd::ValenciaDivClean::BoundaryConditions

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Characteristics.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Characteristics.cpp
@@ -237,7 +237,7 @@ std::array<DataVector, 9> characteristic_speeds(
       const EquationsOfState::EquationOfState<true, GET_DIM(data)>&         \
           equation_of_state);
 
-GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2))
+GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
 
 #undef GET_DIM
 #undef INSTANTIATION

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/MonotonicityPreserving5.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/MonotonicityPreserving5.cpp
@@ -204,7 +204,7 @@ bool operator!=(const MonotonicityPreserving5Prim& lhs,
       const Mesh<3>& subcell_mesh,                                            \
       const Direction<3> direction_to_reconstruct) const;
 
-GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2))
+GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
 
 #undef INSTANTIATION
 #undef TAGS_LIST

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/MonotonisedCentral.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/MonotonisedCentral.cpp
@@ -192,7 +192,7 @@ bool operator!=(const MonotonisedCentralPrim& lhs,
       const Mesh<3>& subcell_mesh,                                            \
       const Direction<3> direction_to_reconstruct) const;
 
-GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2))
+GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
 
 #undef INSTANTIATION
 #undef TAGS_LIST

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/PositivityPreservingAdaptiveOrder.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/PositivityPreservingAdaptiveOrder.cpp
@@ -312,7 +312,7 @@ bool operator!=(const PositivityPreservingAdaptiveOrderPrim& lhs,
       const Mesh<3>& subcell_mesh,                                            \
       const Direction<3> direction_to_reconstruct) const;
 
-GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2))
+GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
 
 #undef INSTANTIATION
 #undef TAGS_LIST

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/ReconstructWork.tpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/ReconstructWork.tpp
@@ -73,20 +73,27 @@ void compute_conservatives_for_reconstruction(
       get<hydro::Tags::RestMassDensity<DataVector>>(*vars_on_face);
   const auto& electron_fraction =
       get<hydro::Tags::ElectronFraction<DataVector>>(*vars_on_face);
-  const auto& pressure = get<hydro::Tags::Pressure<DataVector>>(*vars_on_face);
+  auto& pressure = get<hydro::Tags::Pressure<DataVector>>(*vars_on_face);
   auto& specific_internal_energy =
       get<hydro::Tags::SpecificInternalEnergy<DataVector>>(*vars_on_face);
-  auto& temperature = get<hydro::Tags::Temperature<DataVector>>(*vars_on_face);
-  if constexpr (ThermodynamicDim == 2) {
-    specific_internal_energy =
-        eos.specific_internal_energy_from_density_and_pressure(
-            rest_mass_density, pressure);
-    temperature = eos.temperature_from_density_and_energy(
+  const auto& temperature = get<hydro::Tags::Temperature<DataVector>>(*vars_on_face);
+  if constexpr (ThermodynamicDim == 3) {
+    specific_internal_energy=
+        eos.specific_internal_energy_from_density_and_temperature(
+            rest_mass_density, temperature, electron_fraction);
+    pressure = eos.pressure_from_density_and_energy(
+        rest_mass_density, specific_internal_energy, electron_fraction);
+  }
+  else if constexpr (ThermodynamicDim == 2) {
+      specific_internal_energy =
+        eos.specific_internal_energy_from_density_and_temperature(
+            rest_mass_density, temperature);
+    pressure = eos.temperature_from_density_and_energy(
         rest_mass_density, specific_internal_energy);
   } else {
     specific_internal_energy =
         eos.specific_internal_energy_from_density(rest_mass_density);
-    temperature = eos.temperature_from_density(rest_mass_density);
+   pressure  = eos.pressure_from_density(rest_mass_density);
   }
   auto& specific_enthalpy =
       get<hydro::Tags::SpecificEnthalpy<DataVector>>(*vars_on_face);

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/Wcns5z.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/Wcns5z.cpp
@@ -221,7 +221,7 @@ bool operator!=(const Wcns5zPrim& lhs, const Wcns5zPrim& rhs) {
       const Mesh<3>& subcell_mesh,                                            \
       const Direction<3> direction_to_reconstruct) const;
 
-GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2))
+GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
 
 #undef INSTANTIATION
 #undef TAGS_LIST

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/NewmanHamlin.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/NewmanHamlin.cpp
@@ -132,8 +132,7 @@ std::optional<PrimitiveRecoveryData> NewmanHamlin::apply(
     if constexpr (ThermodynamicDim == 1) {
       current_pressure = get(equation_of_state.pressure_from_density(
           Scalar<double>(current_rest_mass_density)));
-    } else if constexpr (ThermodynamicDim == 2) {
-      current_pressure =
+    } else if constexpr (ThermodynamicDim == 2) {      current_pressure =
           get(equation_of_state.pressure_from_density_and_enthalpy(
               Scalar<double>(current_rest_mass_density),
               Scalar<double>(current_specific_enthalpy)));
@@ -141,7 +140,11 @@ std::optional<PrimitiveRecoveryData> NewmanHamlin::apply(
         return std::nullopt;
       }
     } else if constexpr (ThermodynamicDim == 3) {
-      ERROR("3d EOS not implemented");
+      Scalar<double> local_internal_energy(current_specific_enthalpy - current_pressure /
+                                           current_rest_mass_density - 1.0);
+      current_pressure = get(equation_of_state.pressure_from_density_and_energy(
+          Scalar<double>(current_rest_mass_density), local_internal_energy,
+          Scalar<double>(electron_fraction)));
     }
 
     gsl::at(aitken_pressure, valid_entries_in_aitken_pressure++) =
@@ -187,7 +190,7 @@ std::optional<PrimitiveRecoveryData> NewmanHamlin::apply(
       const EquationsOfState::EquationOfState<true, THERMODIM(data)>&         \
           equation_of_state);
 
-GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2))
+GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
 
 #undef INSTANTIATION
 #undef THERMODIM

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/PalenzuelaEtAl.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/PalenzuelaEtAl.cpp
@@ -78,7 +78,11 @@ class FunctionOfX {
               Scalar<double>(current_rest_mass_density),
               Scalar<double>(current_specific_internal_energy)));
     } else if constexpr (ThermodynamicDim == 3) {
-      ERROR("3d EOS not implemented");
+      current_pressure =
+           get(equation_of_state_.pressure_from_density_and_energy(
+               Scalar<double>(current_rest_mass_density),
+               Scalar<double>(current_specific_internal_energy),
+               Scalar<double>(electron_fraction_)));
     }
 
     return x - (1.0 + current_specific_internal_energy +
@@ -147,7 +151,12 @@ std::optional<PrimitiveRecoveryData> PalenzuelaEtAl::apply(
         Scalar<double>(rest_mass_density),
         Scalar<double>(specific_internal_energy)));
   } else if constexpr (ThermodynamicDim == 3) {
-    ERROR("3d EOS not implemented");
+    const double specific_internal_energy = f_of_x.specific_internal_energy(
+        specific_enthalpy_times_lorentz_factor, lorentz_factor);
+     pressure = get(equation_of_state.pressure_from_density_and_energy(
+         Scalar<double>(rest_mass_density),
+         Scalar<double>(specific_internal_energy),
+         Scalar<double>(electron_fraction)));
   }
 
   return PrimitiveRecoveryData{rest_mass_density, lorentz_factor, pressure,
@@ -173,7 +182,7 @@ std::optional<PrimitiveRecoveryData> PalenzuelaEtAl::apply(
       const EquationsOfState::EquationOfState<true, THERMODIM(data)>&        \
           equation_of_state);
 
-GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2))
+GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
 
 #undef INSTANTIATION
 #undef THERMODIM

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/FixConservativesAndComputePrims.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/FixConservativesAndComputePrims.cpp
@@ -108,7 +108,7 @@ GENERATE_INSTANTIATIONS(INSTANTIATION,
                          tmpl::list<PrimitiveRecoverySchemes::NewmanHamlin>,
                          tmpl::list<PrimitiveRecoverySchemes::PalenzuelaEtAl>,
                          NewmanThenPalenzuela, KastaunThenNewmanThenPalenzuela),
-                        (1, 2))
+                        (1, 2, 3))
 
 #undef INSTANTIATION
 #undef THERMO_DIM

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/PrimsAfterRollback.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/PrimsAfterRollback.cpp
@@ -112,7 +112,7 @@ GENERATE_INSTANTIATIONS(INSTANTIATION,
                          tmpl::list<PrimitiveRecoverySchemes::PalenzuelaEtAl>,
                          NewmanThenPalenzuela,
                          KastaunThenNewmanThenPalenzuela),
-                        (1, 2))
+                        (1, 2, 3))
 #undef INSTANTIATION
 #undef THERMO_DIM
 #undef RECOVERY

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/ResizeAndComputePrimitives.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/ResizeAndComputePrimitives.cpp
@@ -121,7 +121,7 @@ GENERATE_INSTANTIATIONS(INSTANTIATION,
                          tmpl::list<PrimitiveRecoverySchemes::NewmanHamlin>,
                          tmpl::list<PrimitiveRecoverySchemes::PalenzuelaEtAl>,
                          NewmanThenPalenzuela, KastaunThenNewmanThenPalenzuela),
-                        (1, 2))
+                        (1, 2, 3))
 #undef INSTANTIATION
 #undef THERMO_DIM
 #undef RECOVERY

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TciOnDgGrid.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TciOnDgGrid.cpp
@@ -307,7 +307,7 @@ GENERATE_INSTANTIATIONS(
     (grmhd::ValenciaDivClean::PrimitiveRecoverySchemes::KastaunEtAl,
      grmhd::ValenciaDivClean::PrimitiveRecoverySchemes::NewmanHamlin,
      grmhd::ValenciaDivClean::PrimitiveRecoverySchemes::PalenzuelaEtAl),
-    (1, 2))
+    (1, 2, 3))
 #undef INSTANTIATION
 #undef THERMO_DIM
 #undef RECOVERY

--- a/src/Evolution/VariableFixing/FixToAtmosphere.cpp
+++ b/src/Evolution/VariableFixing/FixToAtmosphere.cpp
@@ -229,7 +229,7 @@ GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
       const EquationsOfState::EquationOfState<true, THERMO_DIM(data)>&        \
           equation_of_state) const;
 
-GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3), (1, 2))
+GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3), (1, 2, 3))
 
 #undef DIM
 #undef THERMO_DIM

--- a/src/Evolution/VariableFixing/ParameterizedDeleptonization.cpp
+++ b/src/Evolution/VariableFixing/ParameterizedDeleptonization.cpp
@@ -174,7 +174,7 @@ bool operator!=(const ParameterizedDeleptonization& lhs,
       const EquationsOfState::EquationOfState<true, THERMO_DIM(data)>&   \
           equation_of_state) const;
 
-GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2))
+GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
 
 #undef THERMO_DIM
 #undef INSTANTIATION

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/Barotropic3D.cpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/Barotropic3D.cpp
@@ -9,6 +9,7 @@
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/Enthalpy.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/PiecewisePolytropicFluid.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/PolytropicFluid.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/Spectral.hpp"
 #include "Utilities/ConstantExpressions.hpp"
@@ -112,7 +113,13 @@ Scalar<DataType> Barotropic3D<ColdEquilEos>::
       enthalpy_density};
 }
 template class Barotropic3D<EquationsOfState::PolytropicFluid<true>>;
+template class Barotropic3D<EquationsOfState::PolytropicFluid<false>>;
+template class Barotropic3D<PiecewisePolytropicFluid<true>>;
+template class Barotropic3D<PiecewisePolytropicFluid<false>>;
 template class Barotropic3D<Spectral>;
+template class Barotropic3D<Enthalpy<PolytropicFluid<true>>>;
 template class Barotropic3D<Enthalpy<Spectral>>;
+template class Barotropic3D<Enthalpy<Enthalpy<Spectral>>>;
+template class Barotropic3D<Enthalpy<Enthalpy<Enthalpy<Spectral>>>>;
 
 }  // namespace EquationsOfState

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/DarkEnergyFluid.cpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/DarkEnergyFluid.cpp
@@ -3,8 +3,11 @@
 
 #include "PointwiseFunctions/Hydro/EquationsOfState/DarkEnergyFluid.hpp"
 
+#include <memory>
+
 #include "DataStructures/DataVector.hpp"  // IWYU pragma: keep
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/Barotropic3D.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"
 
@@ -30,6 +33,13 @@ std::unique_ptr<EquationOfState<IsRelativistic, 2>>
 DarkEnergyFluid<IsRelativistic>::get_clone() const {
   auto clone = std::make_unique<DarkEnergyFluid<IsRelativistic>>(*this);
   return std::unique_ptr<EquationOfState<IsRelativistic, 2>>(std::move(clone));
+}
+
+template <bool IsRelativistic>
+std::unique_ptr<EquationOfState<IsRelativistic, 3>>
+DarkEnergyFluid<IsRelativistic>::promote_to_3d_eos() const {
+  return std::make_unique<Equilibrium3D<DarkEnergyFluid<IsRelativistic>>>(
+      *this);
 }
 
 template <bool IsRelativistic>

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/DarkEnergyFluid.hpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/DarkEnergyFluid.hpp
@@ -16,6 +16,7 @@
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Options/String.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"  // IWYU pragma: keep
+#include "PointwiseFunctions/Hydro/EquationsOfState/Factory.hpp"
 #include "Utilities/Serialization/CharmPupable.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -54,6 +55,9 @@ class DarkEnergyFluid : public EquationOfState<IsRelativistic, 2> {
                 "relativistic setting.");
 
   std::unique_ptr<EquationOfState<IsRelativistic, 2>> get_clone()
+      const override;
+
+  std::unique_ptr<EquationOfState<IsRelativistic, 3>> promote_to_3d_eos()
       const override;
 
   bool is_equal(const EquationOfState<IsRelativistic, 2>& rhs) const override;

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/Enthalpy.cpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/Enthalpy.cpp
@@ -4,6 +4,7 @@
 #include "PointwiseFunctions/Hydro/EquationsOfState/Enthalpy.hpp"
 
 #include <cmath>
+#include <memory>
 #include <numeric>
 #include <utility>
 
@@ -11,8 +12,10 @@
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "NumericalAlgorithms/RootFinding/TOMS748.hpp"
 #include "NumericalAlgorithms/Spectral/Clenshaw.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/Barotropic3D.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
-#include "PointwiseFunctions/Hydro/EquationsOfState/Factory.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/PolytropicFluid.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/Spectral.hpp"
 #include "PointwiseFunctions/Hydro/SpecificEnthalpy.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/MakeWithValue.hpp"
@@ -277,6 +280,13 @@ std::unique_ptr<EquationOfState<true, 1>> Enthalpy<LowDensityEoS>::get_clone()
     const {
   auto clone = std::make_unique<Enthalpy>(*this);
   return std::unique_ptr<EquationOfState<true, 1>>(std::move(clone));
+}
+
+template <typename LowDensityEoS>
+std::unique_ptr<EquationOfState<true, 3>>
+Enthalpy<LowDensityEoS>::promote_to_3d_eos() const {
+  return std::make_unique<Barotropic3D<Enthalpy<LowDensityEoS>>>(
+      Barotropic3D(*this));
 }
 
 template <typename LowDensityEoS>

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/Enthalpy.hpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/Enthalpy.hpp
@@ -227,6 +227,8 @@ class Enthalpy : public EquationOfState<true, 1> {
 
   std::unique_ptr<EquationOfState<true, 1>> get_clone() const override;
 
+  std::unique_ptr<EquationOfState<true, 3>> promote_to_3d_eos() const override;
+
   bool is_equal(const EquationOfState<true, 1>& rhs) const override;
 
   bool operator==(const Enthalpy<LowDensityEoS>& rhs) const;

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/Equilibrium3D.cpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/Equilibrium3D.cpp
@@ -8,8 +8,11 @@
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/DarkEnergyFluid.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/Enthalpy.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/Factory.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/HybridEos.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/IdealFluid.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/PolytropicFluid.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/Spectral.hpp"
 #include "Utilities/ConstantExpressions.hpp"
@@ -127,6 +130,11 @@ Equilibrium3D<EquilEos>::sound_speed_squared_from_density_and_temperature_impl(
 }
 
 template class Equilibrium3D<HybridEos<PolytropicFluid<true>>>;
+template class Equilibrium3D<HybridEos<PolytropicFluid<false>>>;
 template class Equilibrium3D<HybridEos<Spectral>>;
 template class Equilibrium3D<HybridEos<Enthalpy<Spectral>>>;
+template class Equilibrium3D<DarkEnergyFluid<true>>;
+template class Equilibrium3D<IdealFluid<true>>;
+template class Equilibrium3D<IdealFluid<false>>;
+
 }  // namespace EquationsOfState

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/HybridEos.cpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/HybridEos.cpp
@@ -3,12 +3,14 @@
 
 #include "PointwiseFunctions/Hydro/EquationsOfState/HybridEos.hpp"
 
+#include <memory>
 #include <utility>
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "PointwiseFunctions//Hydro/EquationsOfState/Enthalpy.hpp"
 #include "PointwiseFunctions//Hydro/EquationsOfState/Spectral.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/Equilibrium3D.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/PolytropicFluid.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 
@@ -31,6 +33,14 @@ std::unique_ptr<
 HybridEos<ColdEquationOfState>::get_clone() const {
   auto clone = std::make_unique<HybridEos<ColdEquationOfState>>(*this);
   return std::unique_ptr<EquationOfState<is_relativistic, 2>>(std::move(clone));
+}
+
+template <typename ColdEquationOfState>
+std::unique_ptr<
+    EquationOfState<HybridEos<ColdEquationOfState>::is_relativistic, 3>>
+HybridEos<ColdEquationOfState>::promote_to_3d_eos() const {
+  return std::make_unique<Equilibrium3D<HybridEos<ColdEquationOfState>>>(
+      Equilibrium3D(*this));
 }
 
 template <typename ColdEquationOfState>

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/HybridEos.hpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/HybridEos.hpp
@@ -99,6 +99,9 @@ class HybridEos
   std::unique_ptr<EquationOfState<is_relativistic, 2>> get_clone()
       const override;
 
+  std::unique_ptr<EquationOfState<is_relativistic, 3>> promote_to_3d_eos()
+      const override;
+
   bool operator==(const HybridEos<ColdEquationOfState>& rhs) const;
 
   bool operator!=(const HybridEos<ColdEquationOfState>& rhs) const;

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/IdealFluid.cpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/IdealFluid.cpp
@@ -7,6 +7,7 @@
 
 #include "DataStructures/DataVector.hpp"  // IWYU pragma: keep
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/Equilibrium3D.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 
 // IWYU pragma: no_forward_declare Tensor
@@ -25,6 +26,13 @@ std::unique_ptr<EquationOfState<IsRelativistic, 2>>
 IdealFluid<IsRelativistic>::get_clone() const {
   auto clone = std::make_unique<IdealFluid<IsRelativistic>>(*this);
   return std::unique_ptr<EquationOfState<IsRelativistic, 2>>(std::move(clone));
+}
+
+template <bool IsRelativistic>
+std::unique_ptr<EquationOfState<IsRelativistic, 3>>
+IdealFluid<IsRelativistic>::promote_to_3d_eos() const {
+  return std::make_unique<Equilibrium3D<IdealFluid<IsRelativistic>>>(
+      Equilibrium3D(*this));
 }
 
 template <bool IsRelativistic>

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/IdealFluid.hpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/IdealFluid.hpp
@@ -79,6 +79,9 @@ class IdealFluid : public EquationOfState<IsRelativistic, 2> {
   std::unique_ptr<EquationOfState<IsRelativistic, 2>> get_clone()
       const override;
 
+  std::unique_ptr<EquationOfState<IsRelativistic, 3>> promote_to_3d_eos()
+      const override;
+
   bool operator==(const IdealFluid<IsRelativistic>& rhs) const;
 
   bool operator!=(const IdealFluid<IsRelativistic>& rhs) const;

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/PiecewisePolytropicFluid.cpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/PiecewisePolytropicFluid.cpp
@@ -8,6 +8,8 @@
 
 #include "DataStructures/DataVector.hpp"  // IWYU pragma: keep
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/Barotropic3D.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/Factory.hpp"
 #include "Utilities/MakeWithValue.hpp"
 
 // IWYU pragma: no_forward_declare Tensor
@@ -88,6 +90,14 @@ PiecewisePolytropicFluid<IsRelativistic>::get_clone() const {
   auto clone =
       std::make_unique<PiecewisePolytropicFluid<IsRelativistic>>(*this);
   return std::unique_ptr<EquationOfState<IsRelativistic, 1>>(std::move(clone));
+}
+
+template <bool IsRelativistic>
+std::unique_ptr<EquationOfState<IsRelativistic, 3>>
+PiecewisePolytropicFluid<IsRelativistic>::promote_to_3d_eos() const {
+  return std::make_unique<
+      Barotropic3D<PiecewisePolytropicFluid<IsRelativistic>>>(
+      Barotropic3D(*this));
 }
 
 template <bool IsRelativistic>

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/PiecewisePolytropicFluid.hpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/PiecewisePolytropicFluid.hpp
@@ -124,6 +124,9 @@ class PiecewisePolytropicFluid : public EquationOfState<IsRelativistic, 1> {
   std::unique_ptr<EquationOfState<IsRelativistic, 1>> get_clone()
       const override;
 
+  std::unique_ptr<EquationOfState<IsRelativistic, 3>> promote_to_3d_eos()
+      const override;
+
   bool is_equal(const EquationOfState<IsRelativistic, 1>& rhs) const override;
 
   bool operator==(const PiecewisePolytropicFluid<IsRelativistic>& rhs) const;

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/PolytropicFluid.cpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/PolytropicFluid.cpp
@@ -5,9 +5,11 @@
 
 #include <cmath>
 #include <limits>
+#include <memory>
 
 #include "DataStructures/DataVector.hpp"  // IWYU pragma: keep
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/Barotropic3D.hpp"
 #include "Utilities/MakeWithValue.hpp"
 
 // IWYU pragma: no_forward_declare Tensor
@@ -51,6 +53,13 @@ std::unique_ptr<EquationOfState<IsRelativistic, 1>>
 PolytropicFluid<IsRelativistic>::get_clone() const {
   auto clone = std::make_unique<PolytropicFluid<IsRelativistic>>(*this);
   return std::unique_ptr<EquationOfState<IsRelativistic, 1>>(std::move(clone));
+}
+
+template <bool IsRelativistic>
+std::unique_ptr<EquationOfState<IsRelativistic, 3>>
+PolytropicFluid<IsRelativistic>::promote_to_3d_eos() const {
+  return std::make_unique<Barotropic3D<PolytropicFluid<IsRelativistic>>>(
+      Barotropic3D(*this));
 }
 
 template <bool IsRelativistic>

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/PolytropicFluid.hpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/PolytropicFluid.hpp
@@ -75,6 +75,9 @@ class PolytropicFluid : public EquationOfState<IsRelativistic, 1> {
   std::unique_ptr<EquationOfState<IsRelativistic, 1>> get_clone()
       const override;
 
+  std::unique_ptr<EquationOfState<IsRelativistic, 3>> promote_to_3d_eos()
+      const override;
+
   bool is_equal(const EquationOfState<IsRelativistic, 1>& rhs) const override;
 
   bool operator==(const PolytropicFluid<IsRelativistic>& rhs) const;

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/Spectral.cpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/Spectral.cpp
@@ -4,10 +4,13 @@
 #include "PointwiseFunctions/Hydro/EquationsOfState/Spectral.hpp"
 
 #include <cmath>
+#include <memory>
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "NumericalAlgorithms/RootFinding/TOMS748.hpp"
+
+#include "PointwiseFunctions/Hydro/EquationsOfState/Barotropic3D.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
 #include "Utilities/MakeWithValue.hpp"
 
@@ -75,6 +78,10 @@ EQUATION_OF_STATE_MEMBER_DEFINITIONS(, Spectral, DataVector, 1)
 std::unique_ptr<EquationOfState<true, 1>> Spectral::get_clone() const {
   auto clone = std::make_unique<Spectral>(*this);
   return std::unique_ptr<EquationOfState<true, 1>>(std::move(clone));
+}
+
+std::unique_ptr<EquationOfState<true, 3>> Spectral::promote_to_3d_eos() const {
+  return std::make_unique<Barotropic3D<Spectral>>(Barotropic3D(*this));
 }
 
 bool Spectral::operator==(const Spectral& rhs) const {

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/Spectral.hpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/Spectral.hpp
@@ -109,6 +109,8 @@ class Spectral : public EquationOfState<true, 1> {
 
   std::unique_ptr<EquationOfState<true, 1>> get_clone() const override;
 
+  std::unique_ptr<EquationOfState<true, 3>> promote_to_3d_eos() const override;
+
   bool operator==(const Spectral& rhs) const;
 
   bool operator!=(const Spectral& rhs) const;

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdBondiMichel.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdBondiMichel.yaml
@@ -1,7 +1,7 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-Executable: EvolveGhValenciaDivCleanBondiMichel
+Executable: EvolveGhValenciaDivClean
 Testing:
   Check: parse;execute
   Timeout: 8

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdTovStar.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdTovStar.yaml
@@ -1,7 +1,7 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-Executable: EvolveGhValenciaDivCleanTovStar
+Executable: EvolveGhValenciaDivClean
 Testing:
   Check: parse;execute
   Timeout: 8

--- a/tests/InputFiles/GrMhd/ValenciaDivClean/BlastWave.yaml
+++ b/tests/InputFiles/GrMhd/ValenciaDivClean/BlastWave.yaml
@@ -1,7 +1,7 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-Executable: EvolveValenciaDivCleanBlastWave
+Executable: EvolveValenciaDivClean
 Testing:
   Check: parse;execute
   Priority: High

--- a/tests/InputFiles/GrMhd/ValenciaDivClean/FishboneMoncriefDisk.yaml
+++ b/tests/InputFiles/GrMhd/ValenciaDivClean/FishboneMoncriefDisk.yaml
@@ -1,7 +1,7 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-Executable: EvolveValenciaDivCleanFishboneMoncriefDisk
+Executable: EvolveValenciaDivClean
 Testing:
   Check: parse;execute
   Timeout: 20


### PR DESCRIPTION
## Proposed changes

This PR makes initial data runtime by separating the EoS used for the evolution from the initial data EoS (unless the initial data EoS is requested as the evolution EoS). Additionally the tag for initial data is changed, so that at compile time the initial data type is not known.  This removes the need for having a separate executable for each initial data.  

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
