### PR TITLE
Print backtrace in FixedHashMap exceptions, abbreviate function name in ERROR

### DIFF
--- a/src/DataStructures/FixedHashMap.hpp
+++ b/src/DataStructures/FixedHashMap.hpp
@@ -15,6 +15,7 @@
 #include "Utilities/Algorithm.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/ForceInline.hpp"
 #include "Utilities/GetOutput.hpp"
 #include "Utilities/Gsl.hpp"
@@ -483,7 +484,9 @@ auto FixedHashMap<MaxSize, Key, ValueType, Hash, KeyEqual>::at(
     const key_type& key) -> mapped_type& {
   auto it = get_data_entry<false>(key);
   if (it == data_.end() or not is_set(*it)) {
-    throw std::out_of_range(get_output(key) + " not in FixedHashMap");
+    // Use `ERROR` instead of `throw` to print a backtrace.
+    // Should throw std::out_of_range once `ERROR` supports exception types.
+    ERROR(get_output(key) + " not in FixedHashMap");
   }
   return it->value().second;
 }

--- a/src/Utilities/ErrorHandling/AbortWithErrorMessage.cpp
+++ b/src/Utilities/ErrorHandling/AbortWithErrorMessage.cpp
@@ -28,8 +28,9 @@ template <bool ShowTrace>
   }
   os << "Wall time: " << sys::pretty_wall_time() << "\n"
      << "Node: " << sys::my_node() << " Proc: " << sys::my_proc() << "\n"
-     << "Line: " << line << " of " << file << "\n"
-     << "Function: " << pretty_function << "\n"
+     << abbreviated_symbol_name(std::string{pretty_function}) << " in " << file
+     << ":" << line << "\n"
+     << "\n"
      << message << "\n"
      << "############ ERROR ############\n"
      << "\n";
@@ -48,9 +49,10 @@ void abort_with_error_message(const char* expression, const char* file,
      << boost::stacktrace::stacktrace() << "\n"
      << "Wall time: " << sys::pretty_wall_time() << "\n"
      << "Node: " << sys::my_node() << " Proc: " << sys::my_proc() << "\n"
-     << "Line: " << line << " of " << file << "\n"
+     << abbreviated_symbol_name(std::string{pretty_function}) << " in " << file
+     << ":" << line << "\n"
+     << "\n"
      << "'" << expression << "' violated!\n"
-     << "Function: " << pretty_function << "\n"
      << message << "\n"
      << "############ ASSERT FAILED ############\n"
      << "\n";

--- a/src/Utilities/ErrorHandling/FormatStacktrace.cpp
+++ b/src/Utilities/ErrorHandling/FormatStacktrace.cpp
@@ -17,8 +17,6 @@
 #include <sstream>
 #include <string>
 
-namespace {
-
 std::string abbreviated_symbol_name(const std::string& symbol_name) {
   // We display the first `abbrev_length_from_start` characters of the symbol
   // name, then " [...] ", and then the last `abbrev_length_from_end` characters
@@ -42,6 +40,8 @@ std::string abbreviated_symbol_name(const std::string& symbol_name) {
          symbol_name.substr(symbol_name.size() - abbrev_length_from_end,
                             abbrev_length_from_end);
 }
+
+namespace {
 
 std::string get_stack_frame(void* addr) {
   std::unique_ptr<char*, decltype(free)*> stack_syms{

--- a/src/Utilities/ErrorHandling/FormatStacktrace.hpp
+++ b/src/Utilities/ErrorHandling/FormatStacktrace.hpp
@@ -10,5 +10,7 @@
 #include <boost/stacktrace/stacktrace_fwd.hpp>
 #include <ostream>
 
+std::string abbreviated_symbol_name(const std::string& symbol_name);
+
 std::ostream& operator<<(std::ostream& os,
                          const boost::stacktrace::stacktrace& backtrace);

--- a/tests/Unit/DataStructures/Test_FixedHashMap.cpp
+++ b/tests/Unit/DataStructures/Test_FixedHashMap.cpp
@@ -128,14 +128,12 @@ void test_direction_key() {
   CHECK(std::as_const(map).find(dir3) == map.end());
 
   const auto check_exception = [&dir3](auto& passed_map) {
-    try {
-      passed_map.at(dir3);
-      CHECK(false);
-    } catch (const std::out_of_range& e) {
-      CHECK(e.what() == get_output(dir3) + " not in FixedHashMap");
-    } catch (...) {
-      CHECK(false);
-    }
+    CHECK_THROWS_WITH(passed_map.at(dir3),
+                      Catch::Matchers::ContainsSubstring(
+                          get_output(dir3) + " not in FixedHashMap"));
+    // Can also test that the exception type is `std::out_of_range` once that's
+    // implemented:
+    // CHECK_THROWS_AS(map.at(dir3), std::out_of_range);
   };
   check_exception(map);
   check_exception(std::as_const(map));


### PR DESCRIPTION
## Proposed changes

Print backtrace in out-of-range errors that occur in commonly used containers, like `DirectionMap`.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
