### PR TITLE
Add DeltaRDriftOutward (State 5) to size control.

### DIFF
--- a/src/ControlSystem/ControlErrors/Size.cpp
+++ b/src/ControlSystem/ControlErrors/Size.cpp
@@ -34,10 +34,12 @@ double control_error_delta_r(const double horizon_00,
 
 namespace ControlErrors {
 template <size_t DerivOrder, ::domain::ObjectLabel Horizon>
-Size<DerivOrder, Horizon>::Size(const int max_times,
-                                const double smooth_avg_timescale_frac,
-                                TimescaleTuner smoother_tuner)
-    : smoother_tuner_(std::move(smoother_tuner)) {
+Size<DerivOrder, Horizon>::Size(
+    const int max_times, const double smooth_avg_timescale_frac,
+    TimescaleTuner smoother_tuner,
+    std::optional<DeltaRDriftOutwardOptions> delta_r_drift_outward_options)
+    : smoother_tuner_(std::move(smoother_tuner)),
+      delta_r_drift_outward_options_(delta_r_drift_outward_options) {
   if (not smoother_tuner_.timescales_have_been_set()) {
     smoother_tuner_.resize_timescales(1);
   }
@@ -113,6 +115,7 @@ void Size<DerivOrder, Horizon>::pup(PUP::er& p) {
   p | state_history_;
   p | legend_;
   p | subfile_name_;
+  p | delta_r_drift_outward_options_;
 }
 
 #define DERIV_ORDER(data) BOOST_PP_TUPLE_ELEM(0, data)

--- a/src/ControlSystem/ControlErrors/Size/CMakeLists.txt
+++ b/src/ControlSystem/ControlErrors/Size/CMakeLists.txt
@@ -7,6 +7,7 @@ spectre_target_sources(
   Info.cpp
   AhSpeed.cpp
   DeltaR.cpp
+  DeltaRDriftOutward.cpp
   Error.cpp
   Initial.cpp
   RegisterDerivedWithCharm.cpp
@@ -22,6 +23,7 @@ spectre_target_headers(
   StateHistory.hpp
   AhSpeed.hpp
   DeltaR.hpp
+  DeltaRDriftOutward.hpp
   Error.hpp
   Initial.hpp
   RegisterDerivedWithCharm.hpp

--- a/src/ControlSystem/ControlErrors/Size/DeltaRDriftOutward.cpp
+++ b/src/ControlSystem/ControlErrors/Size/DeltaRDriftOutward.cpp
@@ -1,0 +1,94 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "ControlSystem/ControlErrors/Size/DeltaRDriftOutward.hpp"
+
+#include <limits>
+#include <memory>
+#include <optional>
+#include <sstream>
+#include <string>
+
+#include "ControlSystem/ControlErrors/Size/AhSpeed.hpp"
+#include "ControlSystem/ControlErrors/Size/DeltaR.hpp"
+#include "Utilities/StdHelpers.hpp"
+
+namespace control_system::size::States {
+
+std::unique_ptr<State> DeltaRDriftOutward::get_clone() const {
+  return std::make_unique<DeltaRDriftOutward>(*this);
+}
+
+std::string DeltaRDriftOutward::update(
+    const gsl::not_null<Info*> info, const StateUpdateArgs& update_args,
+    const CrossingTimeInfo& crossing_time_info) const {
+  // Note that delta_radius_is_in_danger and char_speed_is_in_danger
+  // can be different for different States.
+
+  // The value of 0.99 was chosen by trial and error in SpEC.
+  // It should be slightly less than unity but nothing should be
+  // sensitive to small changes in this value.
+  constexpr double time_tolerance_for_delta_r_in_danger = 0.99;
+  const bool delta_radius_is_in_danger =
+      crossing_time_info.horizon_will_hit_excision_boundary_first and
+      crossing_time_info.t_delta_radius.value_or(
+          std::numeric_limits<double>::infinity()) <
+          info->damping_time * time_tolerance_for_delta_r_in_danger;
+  const bool char_speed_is_in_danger =
+      crossing_time_info.char_speed_will_hit_zero_first and
+      crossing_time_info.t_char_speed.value_or(
+          std::numeric_limits<double>::infinity()) < info->damping_time and
+      not delta_radius_is_in_danger;
+
+  std::stringstream ss{};
+
+  if (char_speed_is_in_danger) {
+    ss << "Current state DeltaRDriftOutward. Char speed in danger."
+       << " Switching to AhSpeed.\n";
+    // Switch to AhSpeed mode. Note that we don't check ComovingCharSpeed
+    // like we do in state DeltaR; this behavior agrees with SpEC.
+
+    // This factor prevents oscillating between states Initial and
+    // AhSpeed.  It needs to be slightly greater than unity, but the
+    // control system should not be sensitive to the exact
+    // value. The value of 1.01 was chosen arbitrarily in SpEC and
+    // never needed to be changed.
+    constexpr double non_oscillation_factor = 1.01;
+    info->discontinuous_change_has_occurred = true;
+    info->state = std::make_unique<States::AhSpeed>();
+    info->target_char_speed =
+        update_args.min_char_speed * non_oscillation_factor;
+    ss << " Target char speed = " << info->target_char_speed << "\n";
+    // If the comoving char speed is positive and is not about to
+    // cross zero, staying in DeltaRDriftOutward mode will rescue the speed
+    // automatically (since it drives char speed to comoving char
+    // speed).  But we should decrease the timescale in any case.
+    info->suggested_time_scale = crossing_time_info.t_char_speed;
+    ss << " Suggested timescale = " << info->suggested_time_scale;
+  } else if (delta_radius_is_in_danger) {
+    info->suggested_time_scale = crossing_time_info.t_delta_radius;
+    ss << "Current state DeltaRDriftOutward. Delta radius in danger. Staying "
+          "in DeltaRDriftOutward.\n";
+    ss << " Suggested timescale = " << info->suggested_time_scale;
+  } else if (update_args.average_radial_distance.has_value() and
+             update_args.average_radial_distance.value() <
+                 update_args.max_allowed_radial_distance.value()) {
+    ss << "Current state DeltaRDriftOutward. Switching to DeltaR.";
+    info->discontinuous_change_has_occurred = true;
+    info->state = std::make_unique<States::DeltaR>();
+  } else {
+    ss << "Current state DeltaRDriftOutward. No change necessary. Staying in "
+          "DeltaRDriftOutward.";
+  }
+
+  return ss.str();
+}
+
+double DeltaRDriftOutward::control_error(
+    const Info& /*info*/, const ControlErrorArgs& control_error_args) const {
+  return control_error_args.control_error_delta_r_outward.value_or(
+      std::numeric_limits<double>::signaling_NaN());
+}
+
+PUP::able::PUP_ID DeltaRDriftOutward::my_PUP_ID = 0;
+}  // namespace control_system::size::States

--- a/src/ControlSystem/ControlErrors/Size/DeltaRDriftOutward.hpp
+++ b/src/ControlSystem/ControlErrors/Size/DeltaRDriftOutward.hpp
@@ -1,0 +1,32 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <pup.h>
+#include <string>
+
+#include "ControlSystem/ControlErrors/Size/Info.hpp"
+#include "ControlSystem/ControlErrors/Size/State.hpp"
+#include "Utilities/Serialization/CharmPupable.hpp"
+
+namespace control_system::size::States {
+class DeltaRDriftOutward : public State {
+ public:
+  DeltaRDriftOutward() = default;
+  std::string name() const override { return "DeltaRDriftOutward"; }
+  size_t number() const override { return 5; }
+  std::unique_ptr<State> get_clone() const override;
+  std::string update(const gsl::not_null<Info*> info,
+                     const StateUpdateArgs& update_args,
+                     const CrossingTimeInfo& crossing_time_info) const override;
+  /// The return value is Q from Eq. 96 of \cite Hemberger2012jz, plus
+  /// an outward velocity term.
+  double control_error(
+      const Info& info,
+      const ControlErrorArgs& control_error_args) const override;
+
+  WRAPPED_PUPable_decl_template(DeltaRDriftOutward);  // NOLINT
+  explicit DeltaRDriftOutward(CkMigrateMessage* const /*msg*/) {}
+};
+}  // namespace control_system::size::States

--- a/src/ControlSystem/ControlErrors/Size/Error.hpp
+++ b/src/ControlSystem/ControlErrors/Size/Error.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <memory>
+#include <optional>
 
 #include "ControlSystem/ControlErrors/Size/State.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
@@ -64,6 +65,13 @@ struct ErrorDiagnostics {
  * \param time the current time.
  * \param control_error_delta_r the control error for the DeltaR state. This is
  *        used in other states as well.
+ * \param control_error_delta_r_outward the control error for the
+ *        DeltaRDriftOutward state.  If std::nullopt, then DeltaRDriftOutward
+ *        will not be used.
+ * \param max_allowed_radial_distance the maximum average radial distance
+ *        between the horizon and the excision boundary that is allowed without
+ *        triggering the DeltaRDriftOutward state.  If std::nullopt, then
+ *        DeltaRDriftOutward will not be used.
  * \param dt_lambda_00 the time derivative of the map parameter lambda_00
  * \param apparent_horizon the current horizon in frame Frame.
  * \param excision_boundary a Strahlkorper representing the excision
@@ -135,7 +143,9 @@ ErrorDiagnostics control_error(
     const gsl::not_null<intrp::ZeroCrossingPredictor*>
         predictor_comoving_char_speed,
     const gsl::not_null<intrp::ZeroCrossingPredictor*> predictor_delta_radius,
-    double time, double control_error_delta_r, double dt_lambda_00,
+    double time, double control_error_delta_r,
+    std::optional<double> control_error_delta_r_outward,
+    std::optional<double> max_allowed_radial_distance, double dt_lambda_00,
     const ylm::Strahlkorper<Frame>& apparent_horizon,
     const ylm::Strahlkorper<Frame>& excision_boundary,
     const Scalar<DataVector>& lapse_on_excision_boundary,

--- a/src/ControlSystem/ControlErrors/Size/RegisterDerivedWithCharm.cpp
+++ b/src/ControlSystem/ControlErrors/Size/RegisterDerivedWithCharm.cpp
@@ -8,12 +8,13 @@
 
 #include "ControlSystem/ControlErrors/Size/AhSpeed.hpp"
 #include "ControlSystem/ControlErrors/Size/DeltaR.hpp"
+#include "ControlSystem/ControlErrors/Size/DeltaRDriftOutward.hpp"
 #include "ControlSystem/ControlErrors/Size/Initial.hpp"
 #include "Utilities/Serialization/RegisterDerivedClassesWithCharm.hpp"
 
 namespace control_system::size {
 void register_derived_with_charm() {
-  register_classes_with_charm<States::Initial, States::AhSpeed,
-                              States::DeltaR>();
+  register_classes_with_charm<States::Initial, States::AhSpeed, States::DeltaR,
+                              States::DeltaRDriftOutward>();
 }
 }  // namespace control_system::size

--- a/src/ControlSystem/ControlErrors/Size/State.hpp
+++ b/src/ControlSystem/ControlErrors/Size/State.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <memory>
+#include <optional>
 #include <pup.h>
 #include <string>
 
@@ -34,6 +35,15 @@ struct StateUpdateArgs {
   /// is in state Label::DeltaR.
   /// This is Q in Eq. 96 of \cite Hemberger2012jz.
   double control_error_delta_r;
+  /// average_radial_distance is the average distance between the horizon and
+  /// the excision boundary. Used only for state DeltaRDriftOutward.
+  /// If std::nullopt, then DeltaRDriftOutward will not be used.
+  std::optional<double> average_radial_distance;
+  /// max_allowed_radial_distance is the minimum distance between the horizon
+  /// and the excision boundary that will trigger state
+  /// Label::DeltaRDriftOutward.  If std::nullopt, then DeltaRDriftOutward
+  /// will never be triggered.
+  std::optional<double> max_allowed_radial_distance;
 };
 
 /*!
@@ -43,6 +53,13 @@ struct StateUpdateArgs {
 struct ControlErrorArgs {
   double min_char_speed;
   double control_error_delta_r;
+  /*!
+   * \brief control_error_delta_r_outward is the control error in the
+   * case DeltaRDriftOutward, the state where there is an outward drift
+   * caused by too large separation between the horizon and the excision
+   * boundary.  If std::nullopt, then state DeltaRDriftOutward will not be used.
+   */
+  std::optional<double> control_error_delta_r_outward;
   /*!
    * \brief avg_distorted_normal_dot_unit_coord_vector is the average of
    * distorted_normal_dot_unit_coord_vector over the excision

--- a/src/ControlSystem/ControlErrors/Size/StateHistory.cpp
+++ b/src/ControlSystem/ControlErrors/Size/StateHistory.cpp
@@ -12,6 +12,7 @@
 
 #include "ControlSystem/ControlErrors/Size/AhSpeed.hpp"
 #include "ControlSystem/ControlErrors/Size/DeltaR.hpp"
+#include "ControlSystem/ControlErrors/Size/DeltaRDriftOutward.hpp"
 #include "ControlSystem/ControlErrors/Size/Info.hpp"
 #include "ControlSystem/ControlErrors/Size/Initial.hpp"
 #include "ControlSystem/ControlErrors/Size/State.hpp"
@@ -29,6 +30,7 @@ void StateHistory::initialize_stored_control_errors() {
   stored_control_errors_[States::Initial{}.number()];
   stored_control_errors_[States::DeltaR{}.number()];
   stored_control_errors_[States::AhSpeed{}.number()];
+  stored_control_errors_[States::DeltaRDriftOutward{}.number()];
 }
 
 void StateHistory::store(double time, const Info& info,
@@ -47,6 +49,7 @@ void StateHistory::store(double time, const Info& info,
   store_state(States::Initial{});
   store_state(States::DeltaR{});
   store_state(States::AhSpeed{});
+  store_state(States::DeltaRDriftOutward{});
 }
 
 const std::deque<std::pair<double, double>>& StateHistory::state_history(

--- a/tests/InputFiles/GeneralizedHarmonic/BinaryBlackHole.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/BinaryBlackHole.yaml
@@ -369,6 +369,7 @@ ControlSystems:
     ControlError:
       MaxNumTimesForZeroCrossingPredictor: 4
       SmoothAvgTimescaleFraction: 0.25
+      DeltaRDriftOutwardOptions: None
       SmootherTuner:
         InitialTimescales: [0.2]
         MinTimescale: 1.0e-4

--- a/tests/InputFiles/GeneralizedHarmonic/CylindricalBinaryBlackHole.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/CylindricalBinaryBlackHole.yaml
@@ -350,6 +350,7 @@ ControlSystems:
     ControlError:
       MaxNumTimesForZeroCrossingPredictor: 4
       SmoothAvgTimescaleFraction: 0.25
+      DeltaRDriftOutwardOptions: None
       SmootherTuner:
         InitialTimescales: [0.2]
         MinTimescale: 1.0e-4

--- a/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
@@ -254,6 +254,7 @@ ControlSystems:
     ControlError:
       MaxNumTimesForZeroCrossingPredictor: 4
       SmoothAvgTimescaleFraction: 0.25
+      DeltaRDriftOutwardOptions: None
       SmootherTuner:
         InitialTimescales: [0.2]
         MinTimescale: 1.0e-4

--- a/tests/Unit/ControlSystem/ControlErrors/Test_SizeError.cpp
+++ b/tests/Unit/ControlSystem/ControlErrors/Test_SizeError.cpp
@@ -7,6 +7,7 @@
 #include <cstddef>
 #include <limits>
 #include <memory>
+#include <optional>
 
 #include "ControlSystem/Averager.hpp"
 #include "ControlSystem/ControlErrors/Size.hpp"
@@ -92,6 +93,8 @@ void test_size_error_one_step(
   const double initial_damping_time = 0.1;
   const double initial_target_drift_velocity = 0.0;
   const double initial_suggested_time_scale = 0.0;
+  // Set constants so that State::DeltaROutward is turned off.
+  const std::optional<double> max_allowed_radial_distance{};
   control_system::size::Info info{std::make_unique<InitialState>(),
                                   initial_damping_time,
                                   target_char_speed,
@@ -166,9 +169,13 @@ void test_size_error_one_step(
           lambda_dt_lambda[0][0], lambda_dt_lambda[1][0],
           grid_excision_boundary_radius);
 
+  // For this test, DeltaRDriftOutward is turned off.
+  const std::optional<double> control_error_delta_r_outward{};
+
   auto error = control_system::size::control_error(
       make_not_null(&info), predictor_char_speed, predictor_comoving_char_speed,
       predictor_delta_radius, time, control_error_delta_r,
+      control_error_delta_r_outward, max_allowed_radial_distance,
       time_deriv_horizon.coefficients()[0], horizon, excision_boundary, lapse,
       shifty_quantity, spatial_metric, inverse_spatial_metric);
 
@@ -196,6 +203,7 @@ void test_size_error_one_step(
     auto error_class = TestHelpers::test_creation<size_error>(
         "MaxNumTimesForZeroCrossingPredictor: 4\n"
         "SmoothAvgTimescaleFraction: 0.25\n"
+        "DeltaRDriftOutwardOptions: None\n"
         "SmootherTuner:\n"
         "  InitialTimescales: 0.2\n"
         "  MinTimescale: 1.0e-4\n"

--- a/tests/Unit/ControlSystem/ControlErrors/Test_StateHistory.cpp
+++ b/tests/Unit/ControlSystem/ControlErrors/Test_StateHistory.cpp
@@ -12,6 +12,7 @@
 
 #include "ControlSystem/ControlErrors/Size/AhSpeed.hpp"
 #include "ControlSystem/ControlErrors/Size/DeltaR.hpp"
+#include "ControlSystem/ControlErrors/Size/DeltaRDriftOutward.hpp"
 #include "ControlSystem/ControlErrors/Size/Info.hpp"
 #include "ControlSystem/ControlErrors/Size/Initial.hpp"
 #include "ControlSystem/ControlErrors/Size/RegisterDerivedWithCharm.hpp"
@@ -25,10 +26,10 @@ void test_state_history(const size_t num_times_to_store) {
   CAPTURE(num_times_to_store);
   Info info{
       std::make_unique<States::Initial>(), 1.0, 1.0, 1.0, std::nullopt, false};
-  ControlErrorArgs control_error_args{1.0, 1.0, 1.0, 1.0};
+  ControlErrorArgs control_error_args{1.0, 1.0, 1.0, 1.0, 1.0};
 
   StateHistory state_history{num_times_to_store};
-  const std::vector<size_t> states{0, 1, 2};
+  const std::vector<size_t> states{0, 1, 2, 5};
 
   // Test that as we fill up the history, we have the expected number of stored
   // entries and that they are the correct values, for each state
@@ -54,6 +55,9 @@ void test_state_history(const size_t num_times_to_store) {
             CHECK(control_error == 0.0);
             break;
           case 2:
+            CHECK(control_error == 1.0);
+            break;
+          case 5:
             CHECK(control_error == 1.0);
             break;
           default:


### PR DESCRIPTION
This state reacts to an excision boundary too deep inside the horizon, and slowly drifts the excision boundary outward.
Input files are set so that state 5 is off by default, as in SpEC.
The tests of the logic mirror the identical tests in SpEC.

### Upgrade instructions

<!-- UPGRADE INSTRUCTIONS -->
Input files using size control need to add a new option:
 * DeltaRDriftOutwardOptions: None
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
