### PR TITLE
Add transport velocity tag to namespace Hydro and insert Temperature tag to RotatingStar

### DIFF
--- a/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
+++ b/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
@@ -210,6 +210,7 @@
 #include "PointwiseFunctions/Hydro/MassFlux.hpp"
 #include "PointwiseFunctions/Hydro/MassWeightedFluidItems.hpp"
 #include "PointwiseFunctions/Hydro/Tags.hpp"
+#include "PointwiseFunctions/Hydro/TransportVelocity.hpp"
 #include "Time/Actions/AdvanceTime.hpp"
 #include "Time/Actions/ChangeSlabSize.hpp"
 #include "Time/Actions/RecordTimeStepperData.hpp"
@@ -549,7 +550,16 @@ struct GhValenciaDivCleanTemplateBase<
               ::Events::Tags::ObserverCoordinates<volume_dim, Frame::Inertial>>,
           grmhd::ValenciaDivClean::Tags::QuadrupoleMomentDerivativeCompute<
               DataVector, volume_dim,
-              ::Events::Tags::ObserverCoordinates<volume_dim, Frame::Inertial>>,
+              ::Events::Tags::ObserverCoordinates<volume_dim, Frame::Inertial>,
+              hydro::Tags::SpatialVelocity<DataVector, volume_dim,
+                                           Frame::Inertial>>,
+          hydro::Tags::TransportVelocityCompute<DataVector, volume_dim,
+                                                               Frame::Inertial>,
+          grmhd::ValenciaDivClean::Tags::QuadrupoleMomentDerivativeCompute<
+              DataVector, volume_dim,
+              ::Events::Tags::ObserverCoordinates<volume_dim, Frame::Inertial>,
+              hydro::Tags::TransportVelocity<DataVector, volume_dim,
+                                             Frame::Inertial>>,
           ::Tags::DerivTensorCompute<
               gr::Tags::ExtrinsicCurvature<DataVector, 3>,
               ::Events::Tags::ObserverInverseJacobian<

--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
@@ -166,6 +166,7 @@
 #include "PointwiseFunctions/Hydro/MassFlux.hpp"
 #include "PointwiseFunctions/Hydro/QuadrupoleFormula.hpp"
 #include "PointwiseFunctions/Hydro/Tags.hpp"
+#include "PointwiseFunctions/Hydro/TransportVelocity.hpp"
 #include "Time/Actions/AdvanceTime.hpp"
 #include "Time/Actions/ChangeSlabSize.hpp"
 #include "Time/Actions/RecordTimeStepperData.hpp"
@@ -299,7 +300,16 @@ struct EvolutionMetavars {
           ::Events::Tags::ObserverCoordinates<volume_dim, Frame::Inertial>>,
       grmhd::ValenciaDivClean::Tags::QuadrupoleMomentDerivativeCompute<
           DataVector, volume_dim,
-          ::Events::Tags::ObserverCoordinates<volume_dim, Frame::Inertial>>,
+          ::Events::Tags::ObserverCoordinates<volume_dim, Frame::Inertial>,
+          hydro::Tags::SpatialVelocity<DataVector, volume_dim,
+                                       Frame::Inertial>>,
+      hydro::Tags::TransportVelocityCompute<DataVector, volume_dim,
+                                                               Frame::Inertial>,
+      grmhd::ValenciaDivClean::Tags::QuadrupoleMomentDerivativeCompute<
+          DataVector, volume_dim,
+          ::Events::Tags::ObserverCoordinates<volume_dim, Frame::Inertial>,
+          hydro::Tags::TransportVelocity<DataVector, volume_dim,
+                                         Frame::Inertial>>,
       hydro::Tags::InversePlasmaBetaCompute<DataVector>>;
   using non_tensor_compute_tags = tmpl::list<
       tmpl::conditional_t<

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Fluxes.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Fluxes.hpp
@@ -39,7 +39,7 @@ void fluxes_impl(
     gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> tilde_phi_flux,
 
     // Temporaries
-    gsl::not_null<Scalar<DataVector>*> transport_velocity,
+    gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> transport_velocity,
     const tnsr::i<DataVector, 3, Frame::Inertial>& lapse_b_over_w,
     const Scalar<DataVector>& magnetic_field_dot_spatial_velocity,
     const Scalar<DataVector>& pressure_star_lapse_sqrt_det_spatial_metric,

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/QuadrupoleFormula.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/QuadrupoleFormula.hpp
@@ -6,11 +6,12 @@
 #include <cstddef>
 
 #include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/DataBox/TagName.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
-#include "PointwiseFunctions/Hydro/QuadrupoleFormula.hpp"
-#include "PointwiseFunctions/Hydro/Tags.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/TagsDeclarations.hpp"  // IWYU pragma: keep
 #include "PointwiseFunctions/GeneralRelativity/TagsDeclarations.hpp"  // IWYU pragma: keep
+#include "PointwiseFunctions/Hydro/QuadrupoleFormula.hpp"
+#include "PointwiseFunctions/Hydro/Tags.hpp"
 #include "PointwiseFunctions/Hydro/TagsDeclarations.hpp"  // IWYU pragma: keep
 #include "Utilities/TMPL.hpp"
 
@@ -54,15 +55,18 @@ struct QuadrupoleMomentCompute
 /// $\gamma$ being the determinant of the spatial metric, \f$x\f$ the
 /// coordinates in Frame Fr, and \f$v\f$ the corresponding spatial velocity.
 template <typename DataType, size_t Dim, typename OutputCoordsTag,
-          typename Fr = Frame::Inertial>
+          typename VelocityTag, typename Fr = Frame::Inertial>
 struct QuadrupoleMomentDerivativeCompute
     : hydro::Tags::QuadrupoleMomentDerivative<DataType, Dim, Fr>,
       db::ComputeTag {
-  using argument_tags = tmpl::list<TildeD, OutputCoordsTag,
-                              hydro::Tags::SpatialVelocity<DataType, Dim, Fr>>;
+  using argument_tags = tmpl::list<TildeD, OutputCoordsTag, VelocityTag>;
 
   using base = hydro::Tags::QuadrupoleMomentDerivative<DataType, Dim, Fr>;
   using return_type = typename base::type;
+
+  static std::string name() {
+    return "QuadrupoleMomentDerivative(" + db::tag_name<VelocityTag>() + ")";
+  }
 
   static constexpr auto function = static_cast<void (*)(
       const gsl::not_null<tnsr::ii<DataType, Dim, Fr>*> result,

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/TimeDerivativeTerms.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/TimeDerivativeTerms.cpp
@@ -50,7 +50,8 @@ void TimeDerivativeTerms::apply(
     const gsl::not_null<Scalar<DataVector>*> pressure_star,
     const gsl::not_null<Scalar<DataVector>*>
         pressure_star_lapse_sqrt_det_spatial_metric,
-    const gsl::not_null<Scalar<DataVector>*> transport_velocity,
+    const gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*>
+        transport_velocity,
     const gsl::not_null<tnsr::i<DataVector, 3, Frame::Inertial>*>
         lapse_b_over_w,
 

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/TimeDerivativeTerms.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/TimeDerivativeTerms.hpp
@@ -9,6 +9,7 @@
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/TagsDeclarations.hpp"
 #include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
 #include "PointwiseFunctions/GeneralRelativity/TagsDeclarations.hpp"
+#include "PointwiseFunctions/Hydro/Tags.hpp"
 #include "PointwiseFunctions/Hydro/TagsDeclarations.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -42,9 +43,6 @@ struct TimeDerivativeTerms {
   struct PressureStarLapseSqrtDetSpatialMetric : db::SimpleTag {
     using type = Scalar<DataVector>;
   };
-  struct TransportVelocity : db::SimpleTag {
-    using type = Scalar<DataVector>;
-  };
   struct PressureStar : db::SimpleTag {
     using type = Scalar<DataVector>;
   };
@@ -62,7 +60,8 @@ struct TimeDerivativeTerms {
       hydro::Tags::MagneticFieldDotSpatialVelocity<DataVector>,
       hydro::Tags::MagneticFieldSquared<DataVector>,
       OneOverLorentzFactorSquared, PressureStar,
-      PressureStarLapseSqrtDetSpatialMetric, TransportVelocity,
+      PressureStarLapseSqrtDetSpatialMetric,
+      hydro::Tags::TransportVelocity<DataVector, 3, Frame::Inertial>,
       LapseTimesbOverW,
 
       // Source terms
@@ -130,7 +129,8 @@ struct TimeDerivativeTerms {
       gsl::not_null<Scalar<DataVector>*> pressure_star,
       gsl::not_null<Scalar<DataVector>*>
           pressure_star_lapse_sqrt_det_spatial_metric,
-      gsl::not_null<Scalar<DataVector>*> transport_velocity,
+      gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*>
+          transport_velocity,
       gsl::not_null<tnsr::i<DataVector, 3, Frame::Inertial>*> lapse_b_over_w,
 
       gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> tilde_s_up,

--- a/src/Evolution/Systems/RelativisticEuler/Valencia/TimeDerivativeTerms.cpp
+++ b/src/Evolution/Systems/RelativisticEuler/Valencia/TimeDerivativeTerms.cpp
@@ -19,7 +19,8 @@ void fluxes_impl(
     gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*> tilde_d_flux,
     gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*> tilde_tau_flux,
     gsl::not_null<tnsr::Ij<DataVector, Dim, Frame::Inertial>*> tilde_s_flux,
-    gsl::not_null<DataVector*> transport_velocity_I,
+    gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*>
+        transport_velocity,
     const Scalar<DataVector>& tilde_d, const Scalar<DataVector>& tilde_tau,
     const tnsr::i<DataVector, Dim, Frame::Inertial>& tilde_s,
     const Scalar<DataVector>& lapse,
@@ -62,7 +63,8 @@ void TimeDerivativeTerms<Dim>::apply(
     // For fluxes
     const gsl::not_null<Scalar<DataVector>*>
         pressure_lapse_sqrt_det_spatial_metric,
-    const gsl::not_null<Scalar<DataVector>*> transport_velocity,
+    const gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*>
+        transport_velocity,
 
     // For sources
     const gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*> tilde_s_up,
@@ -104,7 +106,7 @@ void TimeDerivativeTerms<Dim>::apply(
       get(sqrt_det_spatial_metric) * get(lapse) * get(pressure);
 
   detail::fluxes_impl(tilde_d_flux, tilde_tau_flux, tilde_s_flux,
-                      make_not_null(&get(*transport_velocity)), tilde_d,
+                      transport_velocity, tilde_d,
                       tilde_tau, tilde_s, lapse, shift, spatial_velocity,
                       get(*pressure_lapse_sqrt_det_spatial_metric));
 

--- a/src/Evolution/Systems/RelativisticEuler/Valencia/TimeDerivativeTerms.hpp
+++ b/src/Evolution/Systems/RelativisticEuler/Valencia/TimeDerivativeTerms.hpp
@@ -8,6 +8,7 @@
 #include "Evolution/Systems/RelativisticEuler/Valencia/TagsDeclarations.hpp"
 #include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
 #include "PointwiseFunctions/GeneralRelativity/TagsDeclarations.hpp"
+#include "PointwiseFunctions/Hydro/Tags.hpp"
 #include "PointwiseFunctions/Hydro/TagsDeclarations.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -30,9 +31,6 @@ struct TimeDerivativeTerms {
   struct PressureLapseSqrtDetSpatialMetric : db::SimpleTag {
     using type = Scalar<DataVector>;
   };
-  struct TransportVelocity : db::SimpleTag {
-    using type = Scalar<DataVector>;
-  };
 
   struct TildeSUp : db::SimpleTag {
     using type = tnsr::I<DataVector, Dim, Frame::Inertial>;
@@ -43,7 +41,8 @@ struct TimeDerivativeTerms {
 
   using temporary_tags = tmpl::list<
       // Flux terms
-      PressureLapseSqrtDetSpatialMetric, TransportVelocity,
+      PressureLapseSqrtDetSpatialMetric,
+      hydro::Tags::TransportVelocity<DataVector, Dim, Frame::Inertial>,
 
       // Source terms
       TildeSUp, DensitizedStress,
@@ -90,7 +89,8 @@ struct TimeDerivativeTerms {
 
       // For fluxes
       gsl::not_null<Scalar<DataVector>*> pressure_lapse_sqrt_det_spatial_metric,
-      gsl::not_null<Scalar<DataVector>*> transport_velocity,
+      gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*>
+          transport_velocity,
 
       // For sources
       gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*> tilde_s_up,

--- a/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/RotatingStar.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/RotatingStar.cpp
@@ -615,6 +615,16 @@ RotatingStar::variables(
 }
 
 template <typename DataType>
+tuples::TaggedTuple<hydro::Tags::Temperature<DataType>> RotatingStar::variables(
+    const gsl::not_null<IntermediateVariables<DataType>*> vars,
+    const tnsr::I<DataType, 3>& x,
+    tmpl::list<hydro::Tags::Temperature<DataType>> /*meta*/) const {
+  const auto rest_mass_density = get<hydro::Tags::RestMassDensity<DataType>>(
+      variables(vars, x, tmpl::list<hydro::Tags::RestMassDensity<DataType>>{}));
+  return {equation_of_state_.temperature_from_density(rest_mass_density)};
+}
+
+template <typename DataType>
 tuples::TaggedTuple<hydro::Tags::Pressure<DataType>> RotatingStar::variables(
     const gsl::not_null<IntermediateVariables<DataType>*> vars,
     const tnsr::I<DataType, 3>& x,
@@ -918,8 +928,8 @@ GENERATE_INSTANTIATIONS(
     INSTANTIATE_SCALARS, (double, DataVector),
     (hydro::Tags::RestMassDensity, hydro::Tags::ElectronFraction,
      hydro::Tags::SpecificInternalEnergy, hydro::Tags::Pressure,
-     hydro::Tags::DivergenceCleaningField, hydro::Tags::LorentzFactor,
-     hydro::Tags::SpecificEnthalpy, gr::Tags::Lapse,
+     hydro::Tags::Temperature, hydro::Tags::DivergenceCleaningField,
+     hydro::Tags::LorentzFactor, hydro::Tags::SpecificEnthalpy, gr::Tags::Lapse,
      gr::Tags::SqrtDetSpatialMetric))
 
 #undef INSTANTIATE_SCALARS

--- a/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/RotatingStar.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/RotatingStar.hpp
@@ -489,6 +489,12 @@ class RotatingStar : public virtual evolution::initial_data::InitialData,
   template <typename DataType>
   auto variables(gsl::not_null<IntermediateVariables<DataType>*> vars,
                  const tnsr::I<DataType, 3>& x,
+                 tmpl::list<hydro::Tags::Temperature<DataType>> /*meta*/) const
+      -> tuples::TaggedTuple<hydro::Tags::Temperature<DataType>>;
+
+  template <typename DataType>
+  auto variables(gsl::not_null<IntermediateVariables<DataType>*> vars,
+                 const tnsr::I<DataType, 3>& x,
                  tmpl::list<hydro::Tags::Pressure<DataType>> /*meta*/) const
       -> tuples::TaggedTuple<hydro::Tags::Pressure<DataType>>;
 

--- a/src/PointwiseFunctions/Hydro/CMakeLists.txt
+++ b/src/PointwiseFunctions/Hydro/CMakeLists.txt
@@ -18,6 +18,7 @@ spectre_target_sources(
   SoundSpeedSquared.cpp
   SpecificEnthalpy.cpp
   StressEnergy.cpp
+  TransportVelocity.cpp
   )
 
 spectre_target_headers(
@@ -37,6 +38,7 @@ spectre_target_headers(
   Tags.hpp
   TagsDeclarations.hpp
   Temperature.hpp
+  TransportVelocity.hpp
   Units.hpp
   )
 

--- a/src/PointwiseFunctions/Hydro/Tags.hpp
+++ b/src/PointwiseFunctions/Hydro/Tags.hpp
@@ -237,6 +237,16 @@ struct Temperature : db::SimpleTag {
   using type = Scalar<DataType>;
 };
 
+/// \brief Tag containing the transport velocity.
+///
+/// The transport velocity is defined as \f$v_t^i=\alpha v^i-\beta^i\f$,
+/// with $v^i$ being the spatial velocity, $\alpha$ the lapse, and
+/// $\beta^i$ the shift.
+template <typename DataType, size_t Dim, typename Fr = Frame::Inertial>
+struct TransportVelocity : db::SimpleTag {
+  using type = tnsr::I<DataType, Dim, Fr>;
+};
+
 /// The spatial components of the four-velocity one-form \f$u_i\f$.
 template <typename DataType, size_t Dim, typename Fr>
 struct LowerSpatialFourVelocity : db::SimpleTag {

--- a/src/PointwiseFunctions/Hydro/TransportVelocity.cpp
+++ b/src/PointwiseFunctions/Hydro/TransportVelocity.cpp
@@ -1,0 +1,45 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "TransportVelocity.hpp"
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/SetNumberOfGridPoints.hpp"
+
+namespace hydro {
+
+template <typename DataType, size_t Dim, typename Fr>
+void transport_velocity(const gsl::not_null<tnsr::I<DataType, Dim, Fr>*> result,
+                        const tnsr::I<DataType, Dim, Fr>& spatial_velocity,
+                        const Scalar<DataType>& lapse,
+                        const tnsr::I<DataType, Dim, Fr>& shift) {
+  set_number_of_grid_points(result, lapse);
+  for (size_t i = 0; i < Dim; i++) {
+    result->get(i) = spatial_velocity.get(i) * get(lapse) - shift.get(i);
+  }
+}
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(1, data)
+#define FRAME(data) BOOST_PP_TUPLE_ELEM(2, data)
+
+#define INSTANTIATE(_, data)                                                \
+  template void transport_velocity<DTYPE(data), DIM(data), FRAME(data)>(    \
+      const gsl::not_null<tnsr::I<DTYPE(data), DIM(data), FRAME(data)>*>    \
+          result,                                                           \
+      const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& spatial_velocity, \
+      const Scalar<DTYPE(data)>& lapse,                                     \
+      const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& shift);
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (DataVector),
+                        (Frame::Grid, Frame::Inertial))
+
+#undef DIM
+#undef DTYPE
+#undef FRAME
+#undef INSTANTIATE
+
+}  // namespace hydro

--- a/src/PointwiseFunctions/Hydro/TransportVelocity.hpp
+++ b/src/PointwiseFunctions/Hydro/TransportVelocity.hpp
@@ -1,0 +1,63 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "PointwiseFunctions/GeneralRelativity/TagsDeclarations.hpp"  // IWYU pragma: keep
+#include "PointwiseFunctions/Hydro/Tags.hpp"
+
+/// \cond
+namespace gsl {
+template <typename>
+struct not_null;
+}  // namespace gsl
+/// \endcond
+
+namespace hydro {
+
+/// \brief Function computing the transport velocity.
+///
+/// Computes the transport velocity, using
+/// \f$v_t^i=\alpha v^i-\beta^i\f$, with
+/// $v^i$ being the spatial velocity, $\alpha$ the lapse, and
+/// $\beta^i$ the shift.
+template <typename DataType, size_t Dim, typename Fr = Frame::Inertial>
+void transport_velocity(gsl::not_null<tnsr::I<DataType, Dim, Fr>*> result,
+                        const tnsr::I<DataType, Dim, Fr>& spatial_velocity,
+                        const Scalar<DataType>& lapse,
+                        const tnsr::I<DataType, Dim, Fr>& shift);
+
+namespace Tags {
+/// \brief Compute tag for the transport velocity.
+///
+/// Compute item for the transport velocity, using
+/// \f$v_t^i=\alpha v^i-\beta^i\f$, with
+/// $v^i$ being the spatial velocity, $\alpha$ the lapse, and
+/// $\beta^i$ the shift.
+template <typename DataType, size_t Dim, typename Fr = Frame::Inertial>
+struct TransportVelocityCompute
+    : hydro::Tags::TransportVelocity<DataType, Dim, Fr>,
+      db::ComputeTag {
+  using argument_tags =
+      tmpl::list<SpatialVelocity<DataType, Dim, Fr>,
+                 ::gr::Tags::Lapse<DataType>,
+                 ::gr::Tags::Shift<DataType, Dim, Fr>>;
+
+  using base = hydro::Tags::TransportVelocity<DataType, Dim, Fr>;
+  using return_type = typename base::type;
+
+  static constexpr auto function = static_cast<void (*)(
+      const gsl::not_null<tnsr::I<DataType, Dim, Fr>*> result,
+      const tnsr::I<DataType, Dim, Fr>& spatial_velocity,
+      const Scalar<DataType>& lapse, const tnsr::I<DataType, Dim, Fr>& shift)>(
+      &hydro::transport_velocity<DataType, Dim, Fr>);
+};
+
+}  // namespace Tags
+
+}  // namespace hydro

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Test_QuadrupoleFormula.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Test_QuadrupoleFormula.cpp
@@ -7,6 +7,9 @@
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/QuadrupoleFormula.hpp"
 #include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
+#include "ParallelAlgorithms/Events/Tags.hpp"
+#include "PointwiseFunctions/Hydro/Tags.hpp"
+#include "PointwiseFunctions/Hydro/TransportVelocity.hpp"
 
 SPECTRE_TEST_CASE("Unit.GrMhd.ValenciaDivClean.QuadrupoleFormula",
                   "[Unit][Evolution]") {
@@ -15,5 +18,14 @@ SPECTRE_TEST_CASE("Unit.GrMhd.ValenciaDivClean.QuadrupoleFormula",
                DataVector, 3, Frame::Inertial>>("QuadrupoleMoment");
   TestHelpers::db::test_compute_tag<
       grmhd::ValenciaDivClean::Tags::QuadrupoleMomentDerivativeCompute<
-               DataVector, 3, Frame::Inertial>>("QuadrupoleMomentDerivative");
+          DataVector, 3,
+          ::Events::Tags::ObserverCoordinates<3, Frame::Inertial>,
+          hydro::Tags::SpatialVelocity<DataVector, 3, Frame::Inertial>,
+          Frame::Inertial>>("QuadrupoleMomentDerivative(SpatialVelocity)");
+  TestHelpers::db::test_compute_tag<
+      grmhd::ValenciaDivClean::Tags::QuadrupoleMomentDerivativeCompute<
+          DataVector, 3,
+          ::Events::Tags::ObserverCoordinates<3, Frame::Inertial>,
+          hydro::Tags::TransportVelocity<DataVector, 3, Frame::Inertial>,
+          Frame::Inertial>>("QuadrupoleMomentDerivative(TransportVelocity)");
 }

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Test_TimeDerivativeTerms.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Test_TimeDerivativeTerms.cpp
@@ -85,8 +85,9 @@ void forward_to_time_deriv(
                              PressureStar>(temp)),
       make_not_null(&get<typename grmhd::ValenciaDivClean::TimeDerivativeTerms::
                              PressureStarLapseSqrtDetSpatialMetric>(temp)),
-      make_not_null(&get<typename grmhd::ValenciaDivClean::TimeDerivativeTerms::
-                             TransportVelocity>(temp)),
+      make_not_null(
+          &get<hydro::Tags::TransportVelocity<DataVector, 3, Frame::Inertial>>(
+              temp)),
       make_not_null(&get<typename grmhd::ValenciaDivClean::TimeDerivativeTerms::
                              LapseTimesbOverW>(temp)),
 

--- a/tests/Unit/Evolution/Systems/RelativisticEuler/Valencia/Test_TimeDerivativeTerms.cpp
+++ b/tests/Unit/Evolution/Systems/RelativisticEuler/Valencia/Test_TimeDerivativeTerms.cpp
@@ -59,7 +59,7 @@ void forward_to_time_deriv(
       make_not_null(&get<typename TimeDerivativeTerms<
                         Dim>::PressureLapseSqrtDetSpatialMetric>(temp)),
       make_not_null(
-          &get<typename TimeDerivativeTerms<Dim>::TransportVelocity>(temp)),
+          &get<typename hydro::Tags::TransportVelocity<DataVector, Dim>>(temp)),
       make_not_null(&get<typename TimeDerivativeTerms<Dim>::TildeSUp>(temp)),
       make_not_null(
           &get<typename TimeDerivativeTerms<Dim>::DensitizedStress>(temp)),

--- a/tests/Unit/PointwiseFunctions/Hydro/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/Hydro/CMakeLists.txt
@@ -18,6 +18,7 @@ set(LIBRARY_SOURCES
   Test_Tags.cpp
   Test_Temperature.cpp
   Test_TestHelpers.cpp
+  Test_TransportVelocity.cpp
   )
 
 add_test_library(${LIBRARY} "${LIBRARY_SOURCES}")

--- a/tests/Unit/PointwiseFunctions/Hydro/Test_Tags.cpp
+++ b/tests/Unit/PointwiseFunctions/Hydro/Test_Tags.cpp
@@ -80,6 +80,9 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.Hydro.Tags", "[Unit][Hydro]") {
       "SpecificInternalEnergy");
   TestHelpers::db::test_simple_tag<hydro::Tags::Temperature<DataVector>>(
       "Temperature");
+  TestHelpers::db::test_simple_tag<
+      hydro::Tags::TransportVelocity<DataVector, 3, Frame::Inertial>>(
+      "TransportVelocity");
   TestHelpers::db::test_simple_tag<hydro::Tags::LowerSpatialFourVelocity<
       DataVector, 3, Frame::ElementLogical>>("LowerSpatialFourVelocity");
   TestHelpers::db::test_simple_tag<

--- a/tests/Unit/PointwiseFunctions/Hydro/Test_TransportVelocity.cpp
+++ b/tests/Unit/PointwiseFunctions/Hydro/Test_TransportVelocity.cpp
@@ -1,0 +1,34 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <string>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Framework/CheckWithRandomValues.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
+#include "PointwiseFunctions/Hydro/TransportVelocity.hpp"
+
+namespace hydro {
+
+SPECTRE_TEST_CASE("Unit.PointwiseFunctions.Hydro.TransportVelocity",
+                  "[Unit][Hydro]") {
+  pypp::SetupLocalPythonEnvironment local_python_env(
+      "PointwiseFunctions/Hydro/");
+  const DataVector used_for_size(5);
+  pypp::check_with_random_values<1>(
+      &transport_velocity<DataVector, 1, Frame::Inertial>, "TransportVelocity",
+      {"transport_velocity"}, {{{0.0, 1.0}}}, used_for_size);
+  pypp::check_with_random_values<1>(
+      &transport_velocity<DataVector, 3, Frame::Inertial>, "TransportVelocity",
+      {"transport_velocity"}, {{{0.0, 1.0}}}, used_for_size);
+  TestHelpers::db::test_compute_tag<
+      Tags::TransportVelocityCompute<DataVector, 3, Frame::Inertial>>(
+      "TransportVelocity");
+}
+
+}  // namespace hydro

--- a/tests/Unit/PointwiseFunctions/Hydro/TransportVelocity.py
+++ b/tests/Unit/PointwiseFunctions/Hydro/TransportVelocity.py
@@ -1,0 +1,13 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+
+# Functions testing TransportVelocity
+
+
+def transport_velocity(spatial_velocity, lapse, shift):
+    return spatial_velocity * lapse - shift
+
+
+# End functions for testing TransportVelocity


### PR DESCRIPTION
## Proposed changes

Adds a transport velocity tag into namespace `Hydro`, and implements this as an alternative velocity for use in the first time derivative of the quadrupole moment.

In addition, previous work on the `RotatingStar` analytic solution had caused its build to crash since it expected to record a temperature tag, but its full implementation was not provided. The second commit in this PR is geared toward filling in the gap there by finishing the implementation.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [x] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [x] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [x] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments


If having two separate commits is undesirable I can combine them, but I figured their objectives were distinct enough to warrant their separation.

@ermost I believe the issue that I'm fixing with `RotatingStar` is somewhat related to #5229 (`RotatingStar` is not one of the test solutions, so it wouldn't have been caught in unit tests), so if you would be willing to confirm that I properly implemented the changes you were adding there, that would be very helpful!
