### PR TITLE
Build charm `--with-production` in container

### DIFF
--- a/containers/Dockerfile.buildenv
+++ b/containers/Dockerfile.buildenv
@@ -266,7 +266,7 @@ RUN git clone --single-branch --branch v7.0.0 --depth 1 \
     && git checkout v7.0.0 \
     && git apply /work/v7.0.0.patch \
     && ./build LIBS multicore-linux-${CHARM_ARCH} gcc \
-        ${PARALLEL_MAKE_ARG} -g -O2 --build-shared \
+        ${PARALLEL_MAKE_ARG} -g -O2 --build-shared --with-production \
     && rm -r /work/charm_7_0_0/doc /work/charm_7_0_0/examples
 ENV CHARM_ROOT="/work/charm_7_0_0/multicore-linux-${CHARM_ARCH}-gcc"
 
@@ -344,7 +344,7 @@ RUN apt-get install -y libopenmpi-dev
 # environments have charm built with mpi and we should test that.
 RUN cd /work/charm_7_0_0 \
     && ./build LIBS mpi-linux-${CHARM_ARCH}-smp clang \
-        ${PARALLEL_MAKE_ARG} -g -O2 --build-shared
+        ${PARALLEL_MAKE_ARG} -g -O2 --build-shared --with-production
 
 # Download and extract the intel Software Development Emulator binaries
 RUN wget https://downloadmirror.intel.com/684899/sde-external-9.0.0-2021-11-07-lin.tar.xz -O sde-external.tar.xz \


### PR DESCRIPTION
## Proposed changes

Should we prefer the speedup from `--with-production` over Charm++ debug settings?

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
