### PR TITLE
Improve handling of Tags::DataBox

### DIFF
--- a/src/DataStructures/DataBox/DataBox.hpp
+++ b/src/DataStructures/DataBox/DataBox.hpp
@@ -58,8 +58,10 @@ class DataBox;
 /// Equal to `true` if `Tag` can be retrieved from a `DataBox` of type
 /// `DataBoxType`.
 template <typename Tag, typename DataBoxType>
-using tag_is_retrievable = tmpl::any<typename DataBoxType::tags_list,
-                                     std::is_base_of<tmpl::pin<Tag>, tmpl::_1>>;
+using tag_is_retrievable =
+    tmpl::or_<std::is_same<Tag, ::Tags::DataBox>,
+              tmpl::any<typename DataBoxType::tags_list,
+                        std::is_base_of<tmpl::pin<Tag>, tmpl::_1>>>;
 
 template <typename Tag, typename DataBoxType>
 constexpr bool tag_is_retrievable_v =

--- a/src/DataStructures/DataBox/DataBox.hpp
+++ b/src/DataStructures/DataBox/DataBox.hpp
@@ -1135,7 +1135,12 @@ static constexpr auto apply(F&& f, const DataBox<BoxTags>& box,
                             tmpl::list<ArgumentTags...> /*meta*/,
                             Args&&... args) {
   if constexpr (is_apply_callable_v<
-                    F, const_item_type<ArgumentTags, BoxTags>..., Args...>) {
+                    F,
+                    tmpl::conditional_t<
+                        std::is_same_v<ArgumentTags, ::Tags::DataBox>,
+                        const DataBox<BoxTags>&,
+                        const_item_type<ArgumentTags, BoxTags>>...,
+                    Args...>) {
     return F::apply(::db::get<ArgumentTags>(box)...,
                     std::forward<Args>(args)...);
   } else if constexpr (::tt::is_callable_v<

--- a/tests/Unit/DataStructures/DataBox/Test_DataBox.cpp
+++ b/tests/Unit/DataStructures/DataBox/Test_DataBox.cpp
@@ -2983,6 +2983,10 @@ static_assert(
     not db::tag_is_retrievable_v<
         tags_types::DummyTag, db::DataBox<tmpl::list<tags_types::SimpleTag>>>,
     "Failed testing tag_is_retrievable_v");
+static_assert(
+    db::tag_is_retrievable_v<::Tags::DataBox,
+                             db::DataBox<tmpl::list<tags_types::SimpleTag>>>,
+    "Failed testing tag_is_retrievable_v");
 
 namespace test_creation_tag {
 struct Base : db::BaseTag {};

--- a/tests/Unit/DataStructures/DataBox/Test_DataBox.cpp
+++ b/tests/Unit/DataStructures/DataBox/Test_DataBox.cpp
@@ -1397,6 +1397,45 @@ void test_mutate_apply() {
     db::mutate_apply<PointerMutateApplyBase>(make_not_null(&box));
     CHECK(db::get<test_databox_tags::Pointer>(box) == 8);
   }
+
+  {
+    INFO("Tags::DataBox");
+    db::mutate_apply<tmpl::list<>,
+                     tmpl::list<::Tags::DataBox, test_databox_tags::Tag0>>(
+        [](const decltype(box)& /*box*/, const double& /*tag0*/) {},
+        make_not_null(&box));
+    db::mutate_apply<tmpl::list<::Tags::DataBox>,
+                     tmpl::list<test_databox_tags::Tag0>>(
+        [](const gsl::not_null<decltype(box)*> /*box*/,
+           const double& /*tag0*/) {},
+        make_not_null(&box));
+
+    struct ReadApply {
+      using return_tags = tmpl::list<>;
+      using argument_tags = tmpl::list<::Tags::DataBox>;
+      static void apply(const decltype(box)& /*box*/) {}
+    };
+    struct ReadCall {
+      using return_tags = tmpl::list<>;
+      using argument_tags = tmpl::list<::Tags::DataBox>;
+      void operator()(const decltype(box)& /*box*/) const {}
+    };
+    struct WriteApply {
+      using return_tags = tmpl::list<::Tags::DataBox>;
+      using argument_tags = tmpl::list<>;
+      static void apply(const gsl::not_null<decltype(box)*> /*box*/) {}
+    };
+    struct WriteCall {
+      using return_tags = tmpl::list<::Tags::DataBox>;
+      using argument_tags = tmpl::list<>;
+      void operator()(const gsl::not_null<decltype(box)*> /*box*/) const {}
+    };
+
+    db::mutate_apply<ReadApply>(make_not_null(&box));
+    db::mutate_apply<ReadCall>(make_not_null(&box));
+    db::mutate_apply<WriteApply>(make_not_null(&box));
+    db::mutate_apply<WriteCall>(make_not_null(&box));
+  }
 }
 
 static_assert(

--- a/tests/Unit/DataStructures/DataBox/Test_DataBox.cpp
+++ b/tests/Unit/DataStructures/DataBox/Test_DataBox.cpp
@@ -367,12 +367,19 @@ void test_get_databox() {
   CHECK(std::addressof(original_box) ==
         std::addressof(db::get<Tags::DataBox>(original_box)));
   // [databox_self_tag_example]
-  auto check_result_no_args = [](const auto& box) {
+  auto check_result_no_args = [](const decltype(original_box)& box) {
     CHECK(db::get<test_databox_tags::Tag2>(box) == "My Sample String"s);
     CHECK(db::get<test_databox_tags::Tag5>(box) == "My Sample String6.28"s);
   };
   db::apply<tmpl::list<Tags::DataBox>>(check_result_no_args, original_box);
   // [databox_self_tag_example]
+  struct CheckResultNoArgsApply {
+    static void apply(const decltype(original_box)& box) {
+      CHECK(db::get<test_databox_tags::Tag2>(box) == "My Sample String"s);
+      CHECK(db::get<test_databox_tags::Tag5>(box) == "My Sample String6.28"s);
+    }
+  };
+  db::apply<tmpl::list<Tags::DataBox>>(CheckResultNoArgsApply{}, original_box);
 }
 
 void trigger_get_databox_error() {

--- a/tests/Unit/DataStructures/DataBox/Test_DataBox.cpp
+++ b/tests/Unit/DataStructures/DataBox/Test_DataBox.cpp
@@ -518,6 +518,20 @@ void test_mutate_locked() {
           "inside the invokable passed to the mutate function"));
 }
 
+void test_mutate_box() {
+  INFO("test mutate entire box");
+  auto box = db::create<db::AddSimpleTags<test_databox_tags::Tag0>>(3.14);
+  db::mutate<Tags::DataBox>(
+      [&box](const gsl::not_null<decltype(box)*> mutate_box) {
+        CHECK(&box == &*mutate_box);
+        // Verify that the box is not locked
+        db::mutate<test_databox_tags::Tag0>(
+            [](const gsl::not_null<double*> x) { CHECK(*x == 3.14); },
+            mutate_box);
+      },
+      make_not_null(&box));
+}
+
 struct NonCopyableFunctor {
   NonCopyableFunctor() = default;
   NonCopyableFunctor(const NonCopyableFunctor&) = delete;
@@ -2938,6 +2952,7 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataBox", "[Unit][DataStructures]") {
   test_get_databox_error();
   test_mutate();
   test_mutate_locked();
+  test_mutate_box();
   test_apply();
   test_variables();
   test_variables2();


### PR DESCRIPTION
Primarily to allow full DataBox access to mutate-applyable structs.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
