### PR TITLE
Add calculation of $\Psi_1$ in the CCE volume

### DIFF
--- a/src/Evolution/Systems/Cce/Events/ObserveFields.hpp
+++ b/src/Evolution/Systems/Cce/Events/ObserveFields.hpp
@@ -84,6 +84,7 @@ std::string name() {
  * Some more fields to observe are:
  *
  * - `Cce::Tags::Psi0`
+ * - `Cce::Tags::Psi1`
  * - `Cce::Tags::ComplexInertialRetardedTime`
  * - `Cce::Tags::OneMinusY`
  * - `Cce::Tags::BondiR`
@@ -155,6 +156,7 @@ class ObserveFields : public Event {
                  zero_one_two_radial_derivs<Tags::Du<Tags::BondiJ>>,
                  Tags::BondiR,
                  Tags::Psi0,
+                 Tags::Psi1,
                  Tags::EthRDividedByR,
                  Tags::DuRDividedByR>>;
   // clang-format on
@@ -188,7 +190,8 @@ class ObserveFields : public Event {
   ObserveFields(const std::vector<std::string>& variables_to_observe,
                 const Options::Context& context = {});
 
-  using compute_tags_for_observation_box = tmpl::list<Tags::Psi0Compute>;
+  using compute_tags_for_observation_box =
+    tmpl::list<Tags::Psi0Compute, Tags::Psi1Compute>;
 
   using return_tags = tmpl::list<>;
   using argument_tags = tmpl::list<::Tags::ObservationBox>;

--- a/src/Evolution/Systems/Cce/NewmanPenrose.cpp
+++ b/src/Evolution/Systems/Cce/NewmanPenrose.cpp
@@ -37,6 +37,48 @@ void weyl_psi0_impl(
              0.5 * bondi_j * (1.0 + square(bondi_k)) * dy_j * conj(dy_j)) /
                 square(bondi_k));
 }
+
+void weyl_psi1_impl(
+    const gsl::not_null<SpinWeighted<ComplexDataVector, 1>*> psi_1,
+    const SpinWeighted<ComplexDataVector, 2>& bondi_j,
+    const SpinWeighted<ComplexDataVector, 2>& dy_j,
+    const SpinWeighted<ComplexDataVector, 0>& bondi_k,
+    const SpinWeighted<ComplexDataVector, 1>& bondi_q,
+    const SpinWeighted<ComplexDataVector, 1>& dy_q,
+    const SpinWeighted<ComplexDataVector, 0>& bondi_r,
+    const SpinWeighted<ComplexDataVector, 1>& eth_r_divided_by_r,
+    const SpinWeighted<ComplexDataVector, 0>& dy_beta,
+    const SpinWeighted<ComplexDataVector, 1>& eth_beta,
+    const SpinWeighted<ComplexDataVector, 1>& eth_dy_beta,
+    const SpinWeighted<ComplexDataVector, 0>& one_minus_y) {
+
+  const double prefac = 1./sqrt(128.); // compile time const, but
+                                       // sqrt is not constexpr yet
+  const auto one_plus_k = 1. + bondi_k;
+  const auto eth_beta_plus_half_q = eth_beta + 0.5 * bondi_q;
+  const auto conj_j_times_dy_j = conj(bondi_j) * dy_j;
+
+  const auto inner_expr =
+    bondi_j
+    * (-2. * conj(dy_q)
+       + conj(dy_j) * (2. * eth_beta_plus_half_q
+                       + bondi_j * conj(eth_beta_plus_half_q)))
+    + one_plus_k
+    * (eth_beta_plus_half_q * (conj_j_times_dy_j
+                               - conj(conj_j_times_dy_j))
+       + 2. * (dy_q + bondi_j * conj(dy_q))
+       - one_plus_k * (2. * dy_q + dy_j * conj(eth_beta_plus_half_q)));
+
+  *psi_1 = prefac * square(one_minus_y) / (square(bondi_r) * sqrt(one_plus_k))
+    * (bondi_j * conj(eth_beta_plus_half_q)
+       - one_plus_k * eth_beta_plus_half_q
+       + one_minus_y
+       * (eth_dy_beta * one_plus_k
+          - bondi_j * conj(eth_dy_beta)
+          + dy_beta * (one_plus_k * eth_r_divided_by_r
+                       - bondi_j * conj(eth_r_divided_by_r))
+          + 0.25 * inner_expr / bondi_k));
+}
 }  // namespace
 
 void VolumeWeyl<Tags::Psi0>::apply(
@@ -49,6 +91,25 @@ void VolumeWeyl<Tags::Psi0>::apply(
     const Scalar<SpinWeighted<ComplexDataVector, 0>>& one_minus_y) {
   weyl_psi0_impl(make_not_null(&get(*psi_0)), get(bondi_j), get(dy_j),
                  get(dy_dy_j), get(bondi_k), get(bondi_r), get(one_minus_y));
+}
+
+void VolumeWeyl<Tags::Psi1>::apply(
+    const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 1>>*> psi_1,
+    const Scalar<SpinWeighted<ComplexDataVector, 2>>& bondi_j,
+    const Scalar<SpinWeighted<ComplexDataVector, 2>>& dy_j,
+    const Scalar<SpinWeighted<ComplexDataVector, 0>>& bondi_k,
+    const Scalar<SpinWeighted<ComplexDataVector, 1>>& bondi_q,
+    const Scalar<SpinWeighted<ComplexDataVector, 1>>& dy_q,
+    const Scalar<SpinWeighted<ComplexDataVector, 0>>& bondi_r,
+    const Scalar<SpinWeighted<ComplexDataVector, 1>>& eth_r_divided_by_r,
+    const Scalar<SpinWeighted<ComplexDataVector, 0>>& dy_beta,
+    const Scalar<SpinWeighted<ComplexDataVector, 1>>& eth_beta,
+    const Scalar<SpinWeighted<ComplexDataVector, 1>>& eth_dy_beta,
+    const Scalar<SpinWeighted<ComplexDataVector, 0>>& one_minus_y) {
+  weyl_psi1_impl(make_not_null(&get(*psi_1)), get(bondi_j), get(dy_j),
+                 get(bondi_k), get(bondi_q), get(dy_q),
+                 get(bondi_r), get(eth_r_divided_by_r), get(dy_beta),
+                 get(eth_beta), get(eth_dy_beta), get(one_minus_y));
 }
 
 void TransformBondiJToCauchyCoords::apply(

--- a/src/Evolution/Systems/Cce/NewmanPenrose.hpp
+++ b/src/Evolution/Systems/Cce/NewmanPenrose.hpp
@@ -95,6 +95,93 @@ struct Psi0Compute : Tags::Psi0, db::ComputeTag {
 }  // namespace Tags
 
 /*!
+ * \brief Compute the Weyl scalar \f$\Psi_1\f$ in the volume according to the
+ * standard set of Newman-Penrose vectors.
+ *
+ * \details Our convention is \f$\Psi_1 =
+ * l^\alpha n^\beta l^\mu m^\nu C_{\alpha
+ * \beta \mu \nu}\f$.
+ *
+ * \f{align*}{
+ * \Psi_1 =
+ * &\frac{(1-y)^2}{\sqrt{128} \sqrt{1 + K} R^2}\Bigg\{
+ * J(\bar{\eth }\beta + \tfrac{1}{2} \bar{Q})
+ * - (1 + K) (\eth \beta + \tfrac{1}{2} Q) \\
+ * &+(1-y)\Bigg[
+ * (1 + K)\eth\partial_{y}\beta - J\bar{\eth }\partial_{y}\beta
+ * + \left(- J \frac{\bar{\eth} R}{R} + (1 + K) \frac{\eth R}{R}\right)
+ * \partial_{y}\beta \\
+ * &\quad + \frac{1}{4K}\Bigg(
+ * J\left\{
+ * -2 \partial_{y}\bar{Q} + \partial_{y}\bar{J} [2 (\eth\beta + \tfrac{1}{2}Q) +
+ * J(\bar{\eth}\beta + \tfrac{1}{2} \bar{Q})]
+ * \right\}\\
+ * &\qquad +(1+K)\Big\{
+ * 2 (\partial_{y}Q + J \partial_{y}\bar{Q}) + (\bar{J} \partial_{y}J - J
+ * \partial_{y}\bar{J}) (\eth\beta + \tfrac{1}{2} Q) \\
+ * &\qquad\quad - (1+K)
+ * [2 \partial_{y}Q + \partial _{y}J (\bar{\eth }\beta + \tfrac{1}{2} \bar{Q})]
+ * \Big\}\Bigg)\Bigg]\Bigg\}
+ * \f}
+ */
+template <>
+struct VolumeWeyl<Tags::Psi1> {
+  using return_tags = tmpl::list<Tags::Psi1>;
+  using argument_tags =
+      tmpl::list<Tags::BondiJ, Tags::Dy<Tags::BondiJ>,
+                 Tags::BondiK, Tags::BondiQ,
+                 Tags::Dy<Tags::BondiQ>, Tags::BondiR, Tags::EthRDividedByR,
+                 Tags::Dy<Tags::BondiBeta>,
+                 Spectral::Swsh::Tags::Derivative<Tags::BondiBeta,
+                                                  Spectral::Swsh::Tags::Eth>,
+                 Spectral::Swsh::Tags::Derivative<Tags::Dy<Tags::BondiBeta>,
+                                                  Spectral::Swsh::Tags::Eth>,
+                 Tags::OneMinusY>;
+  static void apply(
+      gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 1>>*> psi_1,
+      const Scalar<SpinWeighted<ComplexDataVector, 2>>& bondi_j,
+      const Scalar<SpinWeighted<ComplexDataVector, 2>>& dy_j,
+      const Scalar<SpinWeighted<ComplexDataVector, 0>>& bondi_k,
+      const Scalar<SpinWeighted<ComplexDataVector, 1>>& bondi_q,
+      const Scalar<SpinWeighted<ComplexDataVector, 1>>& dy_q,
+      const Scalar<SpinWeighted<ComplexDataVector, 0>>& bondi_r,
+      const Scalar<SpinWeighted<ComplexDataVector, 1>>& eth_r_divided_by_r,
+      const Scalar<SpinWeighted<ComplexDataVector, 0>>& dy_beta,
+      const Scalar<SpinWeighted<ComplexDataVector, 1>>& eth_beta,
+      const Scalar<SpinWeighted<ComplexDataVector, 1>>& eth_dy_beta,
+      const Scalar<SpinWeighted<ComplexDataVector, 0>>& one_minus_y);
+};
+
+namespace Tags {
+/*!
+ * \brief Compute tag for $\Psi_1$ in the volume.
+ *
+ * \details Uses `apply` function from `VolumeWeyl<Tags::Psi1>` for the
+ * computation.
+ */
+struct Psi1Compute : Tags::Psi1, db::ComputeTag {
+  using base = Tags::Psi1;
+  using return_type = typename base::type;
+  using argument_tags = typename VolumeWeyl<Tags::Psi1>::argument_tags;
+
+  static constexpr auto function = static_cast<void (*)(
+      gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 1>>*>,
+      const Scalar<SpinWeighted<ComplexDataVector, 2>>&,
+      const Scalar<SpinWeighted<ComplexDataVector, 2>>&,
+      const Scalar<SpinWeighted<ComplexDataVector, 0>>&,
+      const Scalar<SpinWeighted<ComplexDataVector, 1>>&,
+      const Scalar<SpinWeighted<ComplexDataVector, 1>>&,
+      const Scalar<SpinWeighted<ComplexDataVector, 0>>&,
+      const Scalar<SpinWeighted<ComplexDataVector, 1>>&,
+      const Scalar<SpinWeighted<ComplexDataVector, 0>>&,
+      const Scalar<SpinWeighted<ComplexDataVector, 1>>&,
+      const Scalar<SpinWeighted<ComplexDataVector, 1>>&,
+      const Scalar<SpinWeighted<ComplexDataVector, 0>>&)>(
+      &VolumeWeyl<Tags::Psi1>::apply);
+};
+}  // namespace Tags
+
+/*!
  * \brief Transform `Tags::BondiJ` from the partially flat coordinates
  * to the Cauchy coordinates.
  *

--- a/tests/InputFiles/Cce/AnalyticTestVolumeWeylScalars.yaml
+++ b/tests/InputFiles/Cce/AnalyticTestVolumeWeylScalars.yaml
@@ -1,0 +1,119 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+Executable: AnalyticTestCharacteristicExtract
+Testing:
+  Check: parse;execute_check_output
+  Timeout: 20
+  Priority: High
+ExpectedOutput:
+  - CharacteristicExtractReduction.h5
+OutputFileChecks:
+  # Redo this when we change the CCE volume format
+  - Label: "check_psi0_r2"
+    Subfile: "/Cce/VolumeData/Psi0/CompactifiedRadius_2.dat"
+    FileGlob: "CharacteristicExtractReduction.h5"
+    SkipColumns: [0] # Don't look at the time column
+    # By not specifying an expected value, we test against 0
+    AbsoluteTolerance: 1e-8
+  - Label: "check_psi0_r3"
+    Subfile: "/Cce/VolumeData/Psi0/CompactifiedRadius_3.dat"
+    FileGlob: "CharacteristicExtractReduction.h5"
+    SkipColumns: [0] # Don't look at the time column
+    # By not specifying an expected value, we test against 0
+    AbsoluteTolerance: 1e-8
+  - Label: "check_psi0_r4"
+    Subfile: "/Cce/VolumeData/Psi0/CompactifiedRadius_4.dat"
+    FileGlob: "CharacteristicExtractReduction.h5"
+    SkipColumns: [0] # Don't look at the time column
+    # By not specifying an expected value, we test against 0
+    AbsoluteTolerance: 1e-8
+  - Label: "check_psi1_r4"
+    Subfile: "/Cce/VolumeData/Psi1/CompactifiedRadius_4.dat"
+    FileGlob: "CharacteristicExtractReduction.h5"
+    SkipColumns: [0] # Don't look at the time column
+    # By not specifying an expected value, we test against 0
+    AbsoluteTolerance: 1e-8
+  - Label: "check_psi1_r5"
+    Subfile: "/Cce/VolumeData/Psi1/CompactifiedRadius_5.dat"
+    FileGlob: "CharacteristicExtractReduction.h5"
+    SkipColumns: [0] # Don't look at the time column
+    # By not specifying an expected value, we test against 0
+    AbsoluteTolerance: 1e-8
+  - Label: "check_psi1_r6"
+    Subfile: "/Cce/VolumeData/Psi1/CompactifiedRadius_6.dat"
+    FileGlob: "CharacteristicExtractReduction.h5"
+    SkipColumns: [0] # Don't look at the time column
+    # By not specifying an expected value, we test against 0
+    AbsoluteTolerance: 1e-8
+
+---
+
+Evolution:
+  InitialTimeStep: 0.01
+  MinimumTimeStep: 1e-7
+  InitialSlabSize: 0.8
+
+ResourceInfo:
+  AvoidGlobalProc0: false
+  Singletons:
+    CharacteristicEvolution:
+      Proc: Auto
+      Exclusive: false
+    AnalyticWorldtubeBoundary:
+      Proc: Auto
+      Exclusive: false
+
+Observers:
+  VolumeFileName: "CharacteristicExtractUnusedVolume"
+  ReductionFileName: "CharacteristicExtractReduction"
+
+EventsAndTriggersAtSlabs:
+  - Trigger:
+      Slabs:
+        EvenlySpaced:
+          Offset: 0
+          Interval: 1
+    Events:
+      - ObserveTimeStep:
+          SubfileName: CceTimeStep
+          PrintTimeToTerminal: false
+      - ObserveFields:
+          VariablesToObserve:
+            - Psi0
+            - Psi1
+
+EventsAndTriggersAtSteps:
+
+Cce:
+  Evolution:
+    TimeStepper:
+      AdamsBashforth:
+        Order: 3
+    StepChoosers:
+      - Constant: 0.1
+      - LimitIncrease:
+          Factor: 2
+
+  LMax: 8
+  NumberOfRadialPoints: 8
+  ObservationLMax: 8
+
+  StartTime: 0.0
+  EndTime: 0.8
+  ExtractionRadius: 30.0
+
+  AnalyticSolution:
+    BouncingBlackHole:
+      Period: 40.0
+      ExtractionRadius: 30.0
+      Mass: 1.0
+      Amplitude: 0.0
+
+  Filtering:
+    RadialFilterHalfPower: 24
+    RadialFilterAlpha: 35.0
+    FilterLMax: 6
+
+  ScriInterpOrder: 3
+  ScriOutputDensity: 1

--- a/tests/Unit/Evolution/Systems/Cce/Events/Test_ObserveFields.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Events/Test_ObserveFields.cpp
@@ -122,7 +122,13 @@ struct MockElement {
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
       Parallel::Phase::Initialization,
       tmpl::list<ActionTesting::InitializeDataBox<tmpl::push_back<
-          tmpl::remove<ObserveFields::available_tags_to_observe, Tags::Psi0>,
+          tmpl::list_difference<
+            ObserveFields::available_tags_to_observe,
+            tmpl::list<Tags::Psi0, Tags::Psi1>>,
+          Spectral::Swsh::Tags::Derivative<Tags::BondiBeta,
+                                           Spectral::Swsh::Tags::Eth>,
+          Spectral::Swsh::Tags::Derivative<Tags::Dy<Tags::BondiBeta>,
+                                           Spectral::Swsh::Tags::Eth>,
           Tags::BondiK, Tags::LMax, Tags::NumberOfRadialPoints,
           ::Tags::Time>>>>>;
 };
@@ -140,7 +146,7 @@ void test(const bool write_synchronously) {
   using element = MockElement<metavars>;
 
   const Cce::Events::ObserveFields fields{std::vector<std::string>{
-      "InertialRetardedTime", "J", "Psi0", "Dy(H)", "OneMinusY"}};
+      "InertialRetardedTime", "J", "Psi0", "Psi1", "Dy(H)", "OneMinusY"}};
   const Cce::Events::ObserveFields serialized_fields =
       serialize_and_deserialize(fields);
 
@@ -196,7 +202,14 @@ void test(const bool write_synchronously) {
   tmpl::for_each<
       tmpl::list<Tags::BondiJ, Tags::Dy<Tags::BondiH>, Tags::OneMinusY,
                  Tags::Dy<Tags::BondiJ>, Tags::Dy<Tags::Dy<Tags::BondiJ>>,
-                 Tags::BondiK, Tags::BondiR>>([&size_data](auto tag_v) {
+                 Tags::BondiK, Tags::BondiQ, Tags::Dy<Tags::BondiQ>,
+                 Tags::EthRDividedByR,
+                 Tags::Dy<Tags::BondiBeta>,
+                 Spectral::Swsh::Tags::Derivative<Tags::BondiBeta,
+                                                  Spectral::Swsh::Tags::Eth>,
+                 Spectral::Swsh::Tags::Derivative<Tags::Dy<Tags::BondiBeta>,
+                                                  Spectral::Swsh::Tags::Eth>,
+                 Tags::BondiR>>([&size_data](auto tag_v) {
     using tag = tmpl::type_from<decltype(tag_v)>;
     size_data(tag{}, num_volume_grid_points);
   });
@@ -207,7 +220,7 @@ void test(const bool write_synchronously) {
     check_h5_file(filename_prefix);
   } else {
     // 1 for InertialRetardedTime and OneMinusY and 2 for each other tag
-    const size_t expected_number_of_actions = 8;
+    const size_t expected_number_of_actions = 10;
     CHECK(ActionTesting::number_of_queued_threaded_actions<obs_writer>(
               runner, 0) == expected_number_of_actions);
     for (size_t i = 0; i < expected_number_of_actions; i++) {

--- a/tests/Unit/Evolution/Systems/Cce/NewmanPenrose.py
+++ b/tests/Unit/Evolution/Systems/Cce/NewmanPenrose.py
@@ -34,3 +34,53 @@ def psi0(bondi_j, dy_j, dy_dy_j, bondi_k, bondi_r, one_minus_y):
             / bondi_k**3
         )
     )
+
+
+def psi1(
+    bondi_j,
+    dy_j,
+    bondi_k,
+    bondi_q,
+    dy_q,
+    bondi_r,
+    eth_r_divided_by_r,
+    dy_beta,
+    eth_beta,
+    eth_dy_beta,
+    one_minus_y,
+):
+    prefac = 1.0 / np.sqrt(128.0)
+    one_plus_k = 1.0 + bondi_k
+    eth_beta_plus_half_q = eth_beta + 0.5 * bondi_q
+    conj_j_times_dy_j = np.conj(bondi_j) * dy_j
+
+    inner_expr = bondi_j * (
+        -2.0 * np.conj(dy_q)
+        + np.conj(dy_j)
+        * (2.0 * eth_beta_plus_half_q + bondi_j * np.conj(eth_beta_plus_half_q))
+    ) + one_plus_k * (
+        eth_beta_plus_half_q * (conj_j_times_dy_j - np.conj(conj_j_times_dy_j))
+        + 2.0 * (dy_q + bondi_j * np.conj(dy_q))
+        - one_plus_k * (2.0 * dy_q + dy_j * np.conj(eth_beta_plus_half_q))
+    )
+
+    return (
+        prefac
+        * one_minus_y**2
+        / (bondi_r**2 * np.sqrt(one_plus_k))
+        * (
+            bondi_j * np.conj(eth_beta_plus_half_q)
+            - one_plus_k * eth_beta_plus_half_q
+            + one_minus_y
+            * (
+                eth_dy_beta * one_plus_k
+                - bondi_j * np.conj(eth_dy_beta)
+                + dy_beta
+                * (
+                    one_plus_k * eth_r_divided_by_r
+                    - bondi_j * np.conj(eth_r_divided_by_r)
+                )
+                + 0.25 * inner_expr / bondi_k
+            )
+        )
+    )

--- a/tests/Unit/Evolution/Systems/Cce/Test_GaugeTransformBoundaryData.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_GaugeTransformBoundaryData.cpp
@@ -3,76 +3,23 @@
 
 #include "Framework/TestingFramework.hpp"
 
+#include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataBox/Prefixes.hpp"
-#include "DataStructures/DataBox/TagName.hpp"
-#include "DataStructures/VariablesTag.hpp"
-#include "Evolution/Systems/Cce/BoundaryData.hpp"
 #include "Evolution/Systems/Cce/GaugeTransformBoundaryData.hpp"
-#include "Evolution/Systems/Cce/Initialize/InitializeJ.hpp"
-#include "Evolution/Systems/Cce/OptionTags.hpp"
 #include "Evolution/Systems/Cce/PreSwshDerivatives.hpp"
 #include "Evolution/Systems/Cce/Tags.hpp"
 #include "Framework/TestHelpers.hpp"
-#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
-#include "Helpers/Evolution/Systems/Cce/BoundaryTestHelpers.hpp"
+#include "Helpers/Evolution/Systems/Cce/VolumeTestHelpers.hpp"
 #include "NumericalAlgorithms/RootFinding/TOMS748.hpp"
-#include "NumericalAlgorithms/Spectral/Basis.hpp"
-#include "NumericalAlgorithms/Spectral/Quadrature.hpp"
-#include "NumericalAlgorithms/Spectral/Spectral.hpp"
-#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/VectorAlgebra.hpp"
 
 namespace Cce {
 namespace {
-
-struct InverseCubicEvolutionGauge {
-  using boundary_tags =
-      tmpl::list<Tags::EvolutionGaugeBoundaryValue<Tags::BondiJ>,
-                 Tags::EvolutionGaugeBoundaryValue<Tags::Dr<Tags::BondiJ>>,
-                 Tags::EvolutionGaugeBoundaryValue<Tags::BondiR>>;
-
-  using mutate_tags = tmpl::list<Tags::BondiJ, Tags::CauchyCartesianCoords,
-                                 Tags::CauchyAngularCoords>;
-  using argument_tags =
-      tmpl::append<boundary_tags,
-                   tmpl::list<Tags::LMax, Tags::NumberOfRadialPoints>>;
-
-  InverseCubicEvolutionGauge() = default;
-
-  void operator()(
-      const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 2>>*> j,
-      const gsl::not_null<tnsr::i<DataVector, 3>*> /*cartesian_x_of_x_tilde*/,
-      const gsl::not_null<
-          tnsr::i<DataVector, 2, ::Frame::Spherical<::Frame::Inertial>>*>
-      /*angular_cauchy_coordinates*/,
-      const Scalar<SpinWeighted<ComplexDataVector, 2>>& boundary_j,
-      const Scalar<SpinWeighted<ComplexDataVector, 2>>& boundary_dr_j,
-      const Scalar<SpinWeighted<ComplexDataVector, 0>>& r,
-      const size_t /*l_max*/, const size_t number_of_radial_points) const {
-    const DataVector one_minus_y_collocation =
-        1.0 - Spectral::collocation_points<Spectral::Basis::Legendre,
-                                           Spectral::Quadrature::GaussLobatto>(
-                  number_of_radial_points);
-    for (size_t i = 0; i < number_of_radial_points; i++) {
-      ComplexDataVector angular_view_j{
-          get(*j).data().data() + get(boundary_j).size() * i,
-          get(boundary_j).size()};
-      // auto is acceptable here as these two values are only used once in the
-      // below computation. `auto` causes an expression template to be
-      // generated, rather than allocating.
-      const auto one_minus_y_coefficient =
-          0.25 * (3.0 * get(boundary_j).data() +
-                  get(r).data() * get(boundary_dr_j).data());
-      const auto one_minus_y_cubed_coefficient =
-          -0.0625 *
-          (get(boundary_j).data() + get(r).data() * get(boundary_dr_j).data());
-      angular_view_j =
-          one_minus_y_collocation[i] * one_minus_y_coefficient +
-          pow<3>(one_minus_y_collocation[i]) * one_minus_y_cubed_coefficient;
-    }
-  }
-};
+using coordinate_variables_tag = TestHelpers::coordinate_variables_tag;
+using spin_weighted_variables_tag = TestHelpers::spin_weighted_variables_tag;
+using volume_spin_weighted_variables_tag =
+    TestHelpers::volume_spin_weighted_variables_tag;
 
 // These gauge transforms are extremely hard to validate outside of a true
 // evolution system. Here we settle for verifying that for an
@@ -88,174 +35,8 @@ void test_gauge_transforms_via_inverse_coordinate_map(
   const size_t number_of_angular_grid_points =
       Spectral::Swsh::number_of_swsh_collocation_points(l_max);
 
-  using real_boundary_tags =
-      tmpl::list<Tags::CauchyAngularCoords, Tags::CauchyCartesianCoords,
-                 Tags::PartiallyFlatAngularCoords,
-                 Tags::PartiallyFlatCartesianCoords,
-                 ::Tags::dt<Tags::CauchyCartesianCoords>,
-                 ::Tags::dt<Tags::PartiallyFlatCartesianCoords>>;
-  using spin_weighted_boundary_tags = tmpl::flatten<tmpl::list<
-      tmpl::list<Tags::PartiallyFlatGaugeC, Tags::PartiallyFlatGaugeD,
-                 Tags::PartiallyFlatGaugeOmega, Tags::CauchyGaugeC,
-                 Tags::CauchyGaugeD, Tags::CauchyGaugeOmega,
-                 Tags::Du<Tags::PartiallyFlatGaugeOmega>,
-                 Spectral::Swsh::Tags::Derivative<Tags::PartiallyFlatGaugeOmega,
-                                                  Spectral::Swsh::Tags::Eth>,
-                 Spectral::Swsh::Tags::Derivative<Tags::CauchyGaugeOmega,
-                                                  Spectral::Swsh::Tags::Eth>,
-                 Tags::BondiUAtScri>,
-      Tags::characteristic_worldtube_boundary_tags<Tags::BoundaryValue>,
-      Tags::characteristic_worldtube_boundary_tags<
-          Tags::EvolutionGaugeBoundaryValue>>>;
-  using coordinate_variables_tag = ::Tags::Variables<real_boundary_tags>;
-  using spin_weighted_variables_tag =
-      ::Tags::Variables<spin_weighted_boundary_tags>;
-  using volume_spin_weighted_variables_tag = ::Tags::Variables<
-      tmpl::list<Tags::BondiJ, Tags::Dy<Tags::BondiJ>, Tags::BondiU>>;
-
-  auto forward_transform_box = db::create<db::AddSimpleTags<
-      coordinate_variables_tag, spin_weighted_variables_tag,
-      volume_spin_weighted_variables_tag, Tags::LMax,
-      Tags::NumberOfRadialPoints,
-      Spectral::Swsh::Tags::SwshInterpolator<Tags::CauchyAngularCoords>,
-      Spectral::Swsh::Tags::SwshInterpolator<
-          Tags::PartiallyFlatAngularCoords>>>(
-      typename coordinate_variables_tag::type{number_of_angular_grid_points},
-      typename spin_weighted_variables_tag::type{number_of_angular_grid_points},
-      typename volume_spin_weighted_variables_tag::type{
-          number_of_angular_grid_points * number_of_radial_grid_points},
-      l_max, number_of_radial_grid_points, Spectral::Swsh::SwshInterpolator{},
-      Spectral::Swsh::SwshInterpolator{});
-
-  // create analytic data for the forward transform
-  UniformCustomDistribution<double> value_dist{0.1, 0.5};
-  // first prepare the input for the modal version
-  const double mass = value_dist(*gen);
-  const std::array<double, 3> spin{
-      {value_dist(*gen), value_dist(*gen), value_dist(*gen)}};
-  const std::array<double, 3> center{
-      {value_dist(*gen), value_dist(*gen), value_dist(*gen)}};
-  const gr::Solutions::KerrSchild solution{mass, spin, center};
-
-  const double extraction_radius = 100.0;
-
-  // acceptable parameters for the fake sinusoid variation in the input
-  // parameters
-  const double frequency = 0.1 * value_dist(*gen);
-  const double amplitude = 0.1 * value_dist(*gen);
-  const double target_time = 50.0 * value_dist(*gen);
-
-  const size_t libsharp_size =
-      Spectral::Swsh::size_of_libsharp_coefficient_vector(l_max);
-  tnsr::ii<ComplexModalVector, 3> spatial_metric_coefficients{libsharp_size};
-  tnsr::ii<ComplexModalVector, 3> dt_spatial_metric_coefficients{libsharp_size};
-  tnsr::ii<ComplexModalVector, 3> dr_spatial_metric_coefficients{libsharp_size};
-  tnsr::I<ComplexModalVector, 3> shift_coefficients{libsharp_size};
-  tnsr::I<ComplexModalVector, 3> dt_shift_coefficients{libsharp_size};
-  tnsr::I<ComplexModalVector, 3> dr_shift_coefficients{libsharp_size};
-  Scalar<ComplexModalVector> lapse_coefficients{libsharp_size};
-  Scalar<ComplexModalVector> dt_lapse_coefficients{libsharp_size};
-  Scalar<ComplexModalVector> dr_lapse_coefficients{libsharp_size};
-  TestHelpers::create_fake_time_varying_data(
-      make_not_null(&spatial_metric_coefficients),
-      make_not_null(&dt_spatial_metric_coefficients),
-      make_not_null(&dr_spatial_metric_coefficients),
-      make_not_null(&shift_coefficients), make_not_null(&dt_shift_coefficients),
-      make_not_null(&dr_shift_coefficients), make_not_null(&lapse_coefficients),
-      make_not_null(&dt_lapse_coefficients),
-      make_not_null(&dr_lapse_coefficients), solution, extraction_radius,
-      amplitude, frequency, target_time, l_max, false);
-
-  db::mutate<spin_weighted_variables_tag>(
-      [&spatial_metric_coefficients, &dt_spatial_metric_coefficients,
-       &dr_spatial_metric_coefficients, &shift_coefficients,
-       &dt_shift_coefficients, &dr_shift_coefficients, &lapse_coefficients,
-       &dt_lapse_coefficients, &dr_lapse_coefficients, &extraction_radius](
-          const gsl::not_null<Variables<spin_weighted_boundary_tags>*>
-              spin_weighted_boundary_variables) {
-        create_bondi_boundary_data(
-            spin_weighted_boundary_variables, spatial_metric_coefficients,
-            dt_spatial_metric_coefficients, dr_spatial_metric_coefficients,
-            shift_coefficients, dt_shift_coefficients, dr_shift_coefficients,
-            lapse_coefficients, dt_lapse_coefficients, dr_lapse_coefficients,
-            extraction_radius, l_max);
-      },
-      make_not_null(&forward_transform_box));
-
-  // construct the coordinate transform quantities
-  const double variation_amplitude = value_dist(*gen);
-  const double variation_amplitude_inertial = value_dist(*gen);
-  db::mutate<Tags::CauchyCartesianCoords>(
-      [&l_max,
-       &variation_amplitude](const gsl::not_null<tnsr::i<DataVector, 3>*>
-                                 cauchy_cartesian_coordinates) {
-        tnsr::i<DataVector, 2> cauchy_angular_coordinates{
-            get<0>(*cauchy_cartesian_coordinates).size()};
-        // There is a bug in Clang 10.0.0 that gives a nonsensical
-        // error message for the following call to
-        // cached_collocation_metadata unless l_max is captured in
-        // this lambda. The capture should not be necessary because l_max is a
-        // const integer type that is initialized by a constant expression. Note
-        // that l_max need not be declared constexpr for its value to be
-        // retrieved inside a lambda without capturing it. This
-        // line silences the warning that says capturing l_max is not necessary.
-        (void)l_max;
-        const auto& collocation = Spectral::Swsh::cached_collocation_metadata<
-            Spectral::Swsh::ComplexRepresentation::Interleaved>(l_max);
-        for (const auto collocation_point : collocation) {
-          get<1>(cauchy_angular_coordinates)[collocation_point.offset] =
-              collocation_point.phi + 1.0e-2 * variation_amplitude *
-                                          cos(collocation_point.phi) *
-                                          sin(collocation_point.theta);
-          get<0>(cauchy_angular_coordinates)[collocation_point.offset] =
-              collocation_point.theta;
-        }
-        get<0>(*cauchy_cartesian_coordinates) =
-            sin(get<0>(cauchy_angular_coordinates)) *
-            cos(get<1>(cauchy_angular_coordinates));
-        get<1>(*cauchy_cartesian_coordinates) =
-            sin(get<0>(cauchy_angular_coordinates)) *
-            sin(get<1>(cauchy_angular_coordinates));
-        get<2>(*cauchy_cartesian_coordinates) =
-            cos(get<0>(cauchy_angular_coordinates));
-      },
-      make_not_null(&forward_transform_box));
-
-  db::mutate<Tags::PartiallyFlatCartesianCoords>(
-      [&l_max, &variation_amplitude_inertial](
-          const gsl::not_null<tnsr::i<DataVector, 3>*>
-              inertial_cartesian_coordinates) {
-        tnsr::i<DataVector, 2> inertial_angular_coordinates{
-            get<0>(*inertial_cartesian_coordinates).size()};
-        // There is a bug in Clang 10.0.0 that gives a nonsensical
-        // error message for the following call to
-        // cached_collocation_metadata unless l_max is captured in
-        // this lambda. The capture should not be necessary because l_max is a
-        // const integer type that is initialized by a constant expression. Note
-        // that l_max need not be declared constexpr for its value to be
-        // retrieved inside a lambda without capturing it. This
-        // line silences the warning that says capturing l_max is not necessary.
-        (void)l_max;
-        const auto& collocation = Spectral::Swsh::cached_collocation_metadata<
-            Spectral::Swsh::ComplexRepresentation::Interleaved>(l_max);
-        for (const auto& collocation_point : collocation) {
-          get<1>(inertial_angular_coordinates)[collocation_point.offset] =
-              collocation_point.phi + 1.0e-2 * variation_amplitude_inertial *
-                                          cos(collocation_point.phi) *
-                                          sin(collocation_point.theta);
-          get<0>(inertial_angular_coordinates)[collocation_point.offset] =
-              collocation_point.theta;
-        }
-        get<0>(*inertial_cartesian_coordinates) =
-            sin(get<0>(inertial_angular_coordinates)) *
-            cos(get<1>(inertial_angular_coordinates));
-        get<1>(*inertial_cartesian_coordinates) =
-            sin(get<0>(inertial_angular_coordinates)) *
-            sin(get<1>(inertial_angular_coordinates));
-        get<2>(*inertial_cartesian_coordinates) =
-            cos(get<0>(inertial_angular_coordinates));
-      },
-      make_not_null(&forward_transform_box));
+  auto forward_transform_box = Cce::TestHelpers::create_cce_volume_box(
+      gen, l_max, number_of_radial_grid_points, false);
 
   auto inverse_transform_box = db::create<db::AddSimpleTags<
       coordinate_variables_tag, spin_weighted_variables_tag,
@@ -270,6 +51,12 @@ void test_gauge_transforms_via_inverse_coordinate_map(
           number_of_angular_grid_points * number_of_radial_grid_points},
       l_max, number_of_radial_grid_points, Spectral::Swsh::SwshInterpolator{},
       Spectral::Swsh::SwshInterpolator{});
+
+  const double variation_amplitude =
+      db::get<Cce::TestHelpers::VariationAmplitude>(forward_transform_box);
+  const double variation_amplitude_inertial =
+      db::get<Cce::TestHelpers::InertialVariationAmplitude>(
+          forward_transform_box);
 
   db::mutate<Tags::CauchyCartesianCoords>(
       [&l_max,
@@ -626,6 +413,8 @@ void test_gauge_transforms_via_inverse_coordinate_map(
         check_gauge_adjustment_against_inverse);
   }
 
+  using InverseCubicEvolutionGauge =
+      Cce::TestHelpers::InverseCubicEvolutionGauge;
   db::mutate_apply<InverseCubicEvolutionGauge::mutate_tags,
                    InverseCubicEvolutionGauge::argument_tags>(
       InverseCubicEvolutionGauge{}, make_not_null(&forward_transform_box));

--- a/tests/Unit/Evolution/Systems/Cce/Test_NewmanPenrose.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_NewmanPenrose.cpp
@@ -28,6 +28,9 @@ void pypp_test_volume_weyl() {
   pypp::check_with_random_values<1>(&(VolumeWeyl<Tags::Psi0>::apply),
                                     "NewmanPenrose", {"psi0"}, {{{1.0, 5.0}}},
                                     DataVector{num_pts});
+  pypp::check_with_random_values<1>(&(VolumeWeyl<Tags::Psi1>::apply),
+                                    "NewmanPenrose", {"psi1"}, {{{1.0, 5.0}}},
+                                    DataVector{num_pts});
 }
 }  // namespace
 

--- a/tests/Unit/Evolution/Systems/Cce/Test_NewmanPenrose.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_NewmanPenrose.cpp
@@ -5,15 +5,9 @@
 
 #include <cstddef>
 
-#include "DataStructures/DataBox/Prefixes.hpp"
-#include "DataStructures/DataBox/TagName.hpp"
+#include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataVector.hpp"
-#include "DataStructures/VariablesTag.hpp"
-#include "Evolution/Systems/Cce/BoundaryData.hpp"
-#include "Evolution/Systems/Cce/GaugeTransformBoundaryData.hpp"
-#include "Evolution/Systems/Cce/Initialize/InitializeJ.hpp"
 #include "Evolution/Systems/Cce/NewmanPenrose.hpp"
-#include "Evolution/Systems/Cce/OptionTags.hpp"
 #include "Evolution/Systems/Cce/PreSwshDerivatives.hpp"
 #include "Evolution/Systems/Cce/PrecomputeCceDependencies.hpp"
 #include "Evolution/Systems/Cce/Tags.hpp"
@@ -21,8 +15,7 @@
 #include "Framework/SetupLocalPythonEnvironment.hpp"
 #include "Framework/TestHelpers.hpp"
 #include "Helpers/DataStructures/MakeWithRandomValues.hpp"
-#include "Helpers/Evolution/Systems/Cce/BoundaryTestHelpers.hpp"
-#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
+#include "Helpers/Evolution/Systems/Cce/VolumeTestHelpers.hpp"
 #include "Utilities/TMPL.hpp"
 
 namespace Cce {
@@ -39,55 +32,6 @@ void pypp_test_volume_weyl() {
 }  // namespace
 
 namespace {
-
-struct InverseCubicEvolutionGauge {
-  using boundary_tags =
-      tmpl::list<Tags::EvolutionGaugeBoundaryValue<Tags::BondiJ>,
-                 Tags::EvolutionGaugeBoundaryValue<Tags::Dr<Tags::BondiJ>>,
-                 Tags::EvolutionGaugeBoundaryValue<Tags::BondiR>>;
-
-  using mutate_tags = tmpl::list<Tags::BondiJ, Tags::CauchyCartesianCoords,
-                                 Tags::CauchyAngularCoords>;
-  using argument_tags =
-      tmpl::append<boundary_tags,
-                   tmpl::list<Tags::LMax, Tags::NumberOfRadialPoints>>;
-
-  InverseCubicEvolutionGauge() = default;
-
-  void operator()(
-      const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 2>>*> j,
-      const gsl::not_null<tnsr::i<DataVector, 3>*> /*cartesian_x_of_x_tilde*/,
-      const gsl::not_null<
-          tnsr::i<DataVector, 2, ::Frame::Spherical<::Frame::Inertial>>*>
-      /*angular_cauchy_coordinates*/,
-      const Scalar<SpinWeighted<ComplexDataVector, 2>>& boundary_j,
-      const Scalar<SpinWeighted<ComplexDataVector, 2>>& boundary_dr_j,
-      const Scalar<SpinWeighted<ComplexDataVector, 0>>& r,
-      const size_t /*l_max*/, const size_t number_of_radial_points) const {
-    const DataVector one_minus_y_collocation =
-        1.0 - Spectral::collocation_points<Spectral::Basis::Legendre,
-                                           Spectral::Quadrature::GaussLobatto>(
-                  number_of_radial_points);
-    for (size_t i = 0; i < number_of_radial_points; i++) {
-      ComplexDataVector angular_view_j{
-          get(*j).data().data() + get(boundary_j).size() * i,
-          get(boundary_j).size()};
-      // auto is acceptable here as these two values are only used once in the
-      // below computation. `auto` causes an expression template to be
-      // generated, rather than allocating.
-      const auto one_minus_y_coefficient =
-          0.25 * (3.0 * get(boundary_j).data() +
-                  get(r).data() * get(boundary_dr_j).data());
-      const auto one_minus_y_cubed_coefficient =
-          -0.0625 *
-          (get(boundary_j).data() + get(r).data() * get(boundary_dr_j).data());
-      angular_view_j =
-          one_minus_y_collocation[i] * one_minus_y_coefficient +
-          pow<3>(one_minus_y_collocation[i]) * one_minus_y_cubed_coefficient;
-    }
-  }
-};
-
 // This unit test is to validate the calculation of the Weyl scalar psi0 on the
 // worldtube. The structure is in parallel with Test_GaugeTransformBoundaryData
 // (most codes are copied from there). The test constructs a stationary Kerr
@@ -100,215 +44,15 @@ void compute_psi0_of_bh_on_wt(const gsl::not_null<Generator*> gen) {
   const size_t number_of_radial_grid_points = 10;
   const size_t number_of_angular_grid_points =
       Spectral::Swsh::number_of_swsh_collocation_points(l_max);
-
-  using real_boundary_tags =
-      tmpl::list<Tags::CauchyAngularCoords, Tags::CauchyCartesianCoords,
-                 Tags::PartiallyFlatAngularCoords,
-                 Tags::PartiallyFlatCartesianCoords,
-                 ::Tags::dt<Tags::CauchyCartesianCoords>,
-                 ::Tags::dt<Tags::PartiallyFlatCartesianCoords>>;
-  using spin_weighted_boundary_tags = tmpl::flatten<tmpl::list<
-      tmpl::list<Tags::PartiallyFlatGaugeC, Tags::PartiallyFlatGaugeD,
-                 Tags::PartiallyFlatGaugeOmega, Tags::CauchyGaugeC,
-                 Tags::CauchyGaugeD, Tags::CauchyGaugeOmega,
-                 Spectral::Swsh::Tags::Derivative<Tags::PartiallyFlatGaugeOmega,
-                                                  Spectral::Swsh::Tags::Eth>,
-                 Spectral::Swsh::Tags::Derivative<Tags::CauchyGaugeOmega,
-                                                  Spectral::Swsh::Tags::Eth>>,
-      Tags::characteristic_worldtube_boundary_tags<Tags::BoundaryValue>,
-      Tags::characteristic_worldtube_boundary_tags<
-          Tags::EvolutionGaugeBoundaryValue>>>;
-  using coordinate_variables_tag = ::Tags::Variables<real_boundary_tags>;
-  using spin_weighted_variables_tag =
-      ::Tags::Variables<spin_weighted_boundary_tags>;
-  using matching_variables_tag = ::Tags::Variables<
-      tmpl::list<Tags::BoundaryValue<Tags::Psi0Match>,
-                 Tags::BoundaryValue<Tags::Dlambda<Tags::Psi0Match>>>>;
-  using volume_spin_weighted_variables_tag = ::Tags::Variables<
-      tmpl::list<Tags::BondiJ, Tags::Dy<Tags::BondiJ>,
-                 Tags::BondiJCauchyView, Tags::Dy<Tags::BondiJCauchyView>,
-                 Tags::Dy<Tags::Dy<Tags::BondiJCauchyView>>, Tags::Psi0Match,
-                 Tags::OneMinusY, Tags::Dy<Tags::Psi0Match>>>;
-
-  auto box = db::create<db::AddSimpleTags<
-      coordinate_variables_tag, spin_weighted_variables_tag,
-      volume_spin_weighted_variables_tag, Tags::LMax, matching_variables_tag,
-      Tags::NumberOfRadialPoints,
-      Spectral::Swsh::Tags::SwshInterpolator<Tags::CauchyAngularCoords>,
-      Spectral::Swsh::Tags::SwshInterpolator<
-          Tags::PartiallyFlatAngularCoords>>>(
-      typename coordinate_variables_tag::type{number_of_angular_grid_points},
-      typename spin_weighted_variables_tag::type{number_of_angular_grid_points},
-      typename volume_spin_weighted_variables_tag::type{
-          number_of_angular_grid_points * number_of_radial_grid_points},
-      l_max,
-      typename matching_variables_tag::type{number_of_angular_grid_points},
-      number_of_radial_grid_points, Spectral::Swsh::SwshInterpolator{},
-      Spectral::Swsh::SwshInterpolator{});
-
-  // create analytic Cauchy data (a stationary Kerr BH)
-  UniformCustomDistribution<double> value_dist{0.1, 0.5};
-  // first prepare the input for the modal version
-  const double mass = value_dist(*gen);
-  const std::array<double, 3> spin{
-      {value_dist(*gen), value_dist(*gen), value_dist(*gen)}};
-  const std::array<double, 3> center{
-      {value_dist(*gen), value_dist(*gen), value_dist(*gen)}};
-  const gr::Solutions::KerrSchild solution{mass, spin, center};
-
-  const double extraction_radius = 100.0;
-
-  // acceptable parameters for the fake sinusoid variation in the input
-  // parameters
-  const double frequency = 0.1 * value_dist(*gen);
-  const double amplitude = 0.1 * value_dist(*gen);
-  const double target_time = 50.0 * value_dist(*gen);
-
-  const size_t libsharp_size =
-      Spectral::Swsh::size_of_libsharp_coefficient_vector(l_max);
-  tnsr::ii<ComplexModalVector, 3> spatial_metric_coefficients{libsharp_size};
-  tnsr::ii<ComplexModalVector, 3> dt_spatial_metric_coefficients{libsharp_size};
-  tnsr::ii<ComplexModalVector, 3> dr_spatial_metric_coefficients{libsharp_size};
-  tnsr::I<ComplexModalVector, 3> shift_coefficients{libsharp_size};
-  tnsr::I<ComplexModalVector, 3> dt_shift_coefficients{libsharp_size};
-  tnsr::I<ComplexModalVector, 3> dr_shift_coefficients{libsharp_size};
-  Scalar<ComplexModalVector> lapse_coefficients{libsharp_size};
-  Scalar<ComplexModalVector> dt_lapse_coefficients{libsharp_size};
-  Scalar<ComplexModalVector> dr_lapse_coefficients{libsharp_size};
-  TestHelpers::create_fake_time_varying_data(
-      make_not_null(&spatial_metric_coefficients),
-      make_not_null(&dt_spatial_metric_coefficients),
-      make_not_null(&dr_spatial_metric_coefficients),
-      make_not_null(&shift_coefficients), make_not_null(&dt_shift_coefficients),
-      make_not_null(&dr_shift_coefficients), make_not_null(&lapse_coefficients),
-      make_not_null(&dt_lapse_coefficients),
-      make_not_null(&dr_lapse_coefficients), solution, extraction_radius,
-      amplitude, frequency, target_time, l_max, false);
-
-  db::mutate<spin_weighted_variables_tag>(
-      [&spatial_metric_coefficients, &dt_spatial_metric_coefficients,
-       &dr_spatial_metric_coefficients, &shift_coefficients,
-       &dt_shift_coefficients, &dr_shift_coefficients, &lapse_coefficients,
-       &dt_lapse_coefficients, &dr_lapse_coefficients, &extraction_radius](
-          const gsl::not_null<Variables<spin_weighted_boundary_tags>*>
-              spin_weighted_boundary_variables) {
-        create_bondi_boundary_data(
-            spin_weighted_boundary_variables, spatial_metric_coefficients,
-            dt_spatial_metric_coefficients, dr_spatial_metric_coefficients,
-            shift_coefficients, dt_shift_coefficients, dr_shift_coefficients,
-            lapse_coefficients, dt_lapse_coefficients, dr_lapse_coefficients,
-            extraction_radius, l_max);
-      },
-      make_not_null(&box));
-
-  // construct the coordinate transform quantities
-  const double variation_amplitude_inertial = value_dist(*gen);
-  db::mutate<Tags::CauchyCartesianCoords>(
-      [&l_max](const gsl::not_null<tnsr::i<DataVector, 3>*>
-                   cauchy_cartesian_coordinates) {
-        tnsr::i<DataVector, 2> cauchy_angular_coordinates{
-            get<0>(*cauchy_cartesian_coordinates).size()};
-        // There is a bug in Clang 10.0.0 that gives a nonsensical
-        // error message for the following call to
-        // cached_collocation_metadata unless l_max is captured in
-        // this lambda. The capture should not be necessary because l_max is a
-        // const integer type that is initialized by a constant expression. Note
-        // that l_max need not be declared constexpr for its value to be
-        // retrieved inside a lambda without capturing it. This
-        // line silences the warning that says capturing l_max is not necessary.
-        (void)l_max;
-        const auto& collocation = Spectral::Swsh::cached_collocation_metadata<
-            Spectral::Swsh::ComplexRepresentation::Interleaved>(l_max);
-        for (const auto collocation_point : collocation) {
-          get<1>(cauchy_angular_coordinates)[collocation_point.offset] =
-              collocation_point.phi;
-          get<0>(cauchy_angular_coordinates)[collocation_point.offset] =
-              collocation_point.theta;
-        }
-        get<0>(*cauchy_cartesian_coordinates) =
-            sin(get<0>(cauchy_angular_coordinates)) *
-            cos(get<1>(cauchy_angular_coordinates));
-        get<1>(*cauchy_cartesian_coordinates) =
-            sin(get<0>(cauchy_angular_coordinates)) *
-            sin(get<1>(cauchy_angular_coordinates));
-        get<2>(*cauchy_cartesian_coordinates) =
-            cos(get<0>(cauchy_angular_coordinates));
-      },
-      make_not_null(&box));
-
-  db::mutate<Tags::PartiallyFlatCartesianCoords>(
-      [&l_max, &variation_amplitude_inertial](
-          const gsl::not_null<tnsr::i<DataVector, 3>*>
-              inertial_cartesian_coordinates) {
-        tnsr::i<DataVector, 2> inertial_angular_coordinates{
-            get<0>(*inertial_cartesian_coordinates).size()};
-        // There is a bug in Clang 10.0.0 that gives a nonsensical
-        // error message for the following call to
-        // cached_collocation_metadata unless l_max is captured in
-        // this lambda. The capture should not be necessary because l_max is a
-        // const integer type that is initialized by a constant expression. Note
-        // that l_max need not be declared constexpr for its value to be
-        // retrieved inside a lambda without capturing it. This
-        // line silences the warning that says capturing l_max is not necessary.
-        (void)l_max;
-        const auto& collocation = Spectral::Swsh::cached_collocation_metadata<
-            Spectral::Swsh::ComplexRepresentation::Interleaved>(l_max);
-        for (const auto& collocation_point : collocation) {
-          get<1>(inertial_angular_coordinates)[collocation_point.offset] =
-              collocation_point.phi + 1.0e-2 * variation_amplitude_inertial *
-                                          cos(collocation_point.phi) *
-                                          sin(collocation_point.theta);
-          get<0>(inertial_angular_coordinates)[collocation_point.offset] =
-              collocation_point.theta;
-        }
-        get<0>(*inertial_cartesian_coordinates) =
-            sin(get<0>(inertial_angular_coordinates)) *
-            cos(get<1>(inertial_angular_coordinates));
-        get<1>(*inertial_cartesian_coordinates) =
-            sin(get<0>(inertial_angular_coordinates)) *
-            sin(get<1>(inertial_angular_coordinates));
-        get<2>(*inertial_cartesian_coordinates) =
-            cos(get<0>(inertial_angular_coordinates));
-      },
-      make_not_null(&box));
-
-  // Update various auxiliary boundary variables in order to prepare the
-  // boundary data for BondiJ. Operartions are done for both Cauchy coordiantes
-  // and partially flat coordinates.
-  db::mutate_apply<GaugeUpdateAngularFromCartesian<
-      Tags::CauchyAngularCoords, Tags::CauchyCartesianCoords>>(
-      make_not_null(&box));
-  db::mutate_apply<GaugeUpdateAngularFromCartesian<
-      Tags::PartiallyFlatAngularCoords, Tags::PartiallyFlatCartesianCoords>>(
-      make_not_null(&box));
-
-  db::mutate_apply<GaugeUpdateInterpolator<Tags::CauchyAngularCoords>>(
-      make_not_null(&box));
-  db::mutate_apply<GaugeUpdateInterpolator<Tags::PartiallyFlatAngularCoords>>(
-      make_not_null(&box));
-
-  db::mutate_apply<GaugeUpdateJacobianFromCoordinates<
-      Tags::PartiallyFlatGaugeC, Tags::PartiallyFlatGaugeD,
-      Tags::CauchyAngularCoords, Tags::CauchyCartesianCoords>>(
-      make_not_null(&box));
-  db::mutate_apply<GaugeUpdateJacobianFromCoordinates<
-      Tags::CauchyGaugeC, Tags::CauchyGaugeD, Tags::PartiallyFlatAngularCoords,
-      Tags::PartiallyFlatCartesianCoords>>(make_not_null(&box));
-
-  db::mutate_apply<
-      GaugeUpdateOmega<Tags::PartiallyFlatGaugeC, Tags::PartiallyFlatGaugeD,
-                       Tags::PartiallyFlatGaugeOmega>>(make_not_null(&box));
-  db::mutate_apply<GaugeUpdateOmega<Tags::CauchyGaugeC, Tags::CauchyGaugeD,
-                                    Tags::CauchyGaugeOmega>>(
-      make_not_null(&box));
+  auto box = Cce::TestHelpers::create_cce_volume_box(
+      gen, l_max, number_of_radial_grid_points, true);
 
   // Now we need to transform the boundary data of BondiJ and BondiR from the
   // Cauchy grid to the partially flat grid.
   const auto perform_gauge_adjustment = [&box](auto tag_v) {
     using tag = typename decltype(tag_v)::type;
     INFO("computing tag : " << db::tag_name<tag>());
-    db::mutate_apply<GaugeAdjustedBoundaryValue<tag>>(
-        make_not_null(&box));
+    db::mutate_apply<GaugeAdjustedBoundaryValue<tag>>(make_not_null(&box));
   };
 
   using gauge_adjustments =
@@ -317,9 +61,9 @@ void compute_psi0_of_bh_on_wt(const gsl::not_null<Generator*> gen) {
 
   // Now we construct the volume data of BondiJ (on a null slice) based on its
   // boundary data.
-  db::mutate_apply<InverseCubicEvolutionGauge::mutate_tags,
-                   InverseCubicEvolutionGauge::argument_tags>(
-      InverseCubicEvolutionGauge{}, make_not_null(&box));
+  db::mutate_apply<Cce::TestHelpers::InverseCubicEvolutionGauge::mutate_tags,
+                   Cce::TestHelpers::InverseCubicEvolutionGauge::argument_tags>(
+      Cce::TestHelpers::InverseCubicEvolutionGauge{}, make_not_null(&box));
 
   // Then we compute psi0 on the worldtube
   db::mutate_apply<TransformBondiJToCauchyCoords>(make_not_null(&box));
@@ -331,15 +75,13 @@ void compute_psi0_of_bh_on_wt(const gsl::not_null<Generator*> gen) {
   db::mutate_apply<
       PrecomputeCceDependencies<Tags::BoundaryValue, Tags::OneMinusY>>(
       make_not_null(&box));
-  db::mutate_apply<VolumeWeyl<Tags::Psi0Match>>(
-      make_not_null(&box));
+  db::mutate_apply<VolumeWeyl<Tags::Psi0Match>>(make_not_null(&box));
   db::mutate_apply<PreSwshDerivatives<Tags::Dy<Tags::Psi0Match>>>(
       make_not_null(&box));
   db::mutate_apply<InnerBoundaryWeyl>(make_not_null(&box));
 
   // Finally, we expect the results should be consistent with 0.
-  const auto& psi0_wt =
-      db::get<Tags::BoundaryValue<Tags::Psi0Match>>(box);
+  const auto& psi0_wt = db::get<Tags::BoundaryValue<Tags::Psi0Match>>(box);
   SpinWeighted<ComplexDataVector, 2> psi0_desired{number_of_angular_grid_points,
                                                   0.0};
   Approx interpolation_approx =

--- a/tests/Unit/Helpers/Evolution/Systems/Cce/VolumeTestHelpers.hpp
+++ b/tests/Unit/Helpers/Evolution/Systems/Cce/VolumeTestHelpers.hpp
@@ -1,0 +1,306 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+
+#include "DataStructures/ComplexDataVector.hpp"
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/DataBox/TagName.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/VariablesTag.hpp"
+#include "Evolution/Systems/Cce/BoundaryData.hpp"
+#include "Evolution/Systems/Cce/GaugeTransformBoundaryData.hpp"
+#include "Evolution/Systems/Cce/Initialize/InitializeJ.hpp"
+#include "Evolution/Systems/Cce/NewmanPenrose.hpp"
+#include "Evolution/Systems/Cce/OptionTags.hpp"
+#include "Evolution/Systems/Cce/PreSwshDerivatives.hpp"
+#include "Evolution/Systems/Cce/PrecomputeCceDependencies.hpp"
+#include "Evolution/Systems/Cce/Tags.hpp"
+#include "Framework/CheckWithRandomValues.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "Helpers/Evolution/Systems/Cce/BoundaryTestHelpers.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace Cce::TestHelpers {
+struct InverseCubicEvolutionGauge {
+  using boundary_tags =
+      tmpl::list<Tags::EvolutionGaugeBoundaryValue<Tags::BondiJ>,
+                 Tags::EvolutionGaugeBoundaryValue<Tags::Dr<Tags::BondiJ>>,
+                 Tags::EvolutionGaugeBoundaryValue<Tags::BondiR>>;
+
+  using mutate_tags = tmpl::list<Tags::BondiJ, Tags::CauchyCartesianCoords,
+                                 Tags::CauchyAngularCoords>;
+  using argument_tags =
+      tmpl::append<boundary_tags,
+                   tmpl::list<Tags::LMax, Tags::NumberOfRadialPoints>>;
+
+  InverseCubicEvolutionGauge() = default;
+
+  void operator()(
+      const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 2>>*> j,
+      const gsl::not_null<tnsr::i<DataVector, 3>*> /*cartesian_x_of_x_tilde*/,
+      const gsl::not_null<
+          tnsr::i<DataVector, 2, ::Frame::Spherical<::Frame::Inertial>>*>
+      /*angular_cauchy_coordinates*/,
+      const Scalar<SpinWeighted<ComplexDataVector, 2>>& boundary_j,
+      const Scalar<SpinWeighted<ComplexDataVector, 2>>& boundary_dr_j,
+      const Scalar<SpinWeighted<ComplexDataVector, 0>>& r,
+      const size_t /*l_max*/, const size_t number_of_radial_points) const {
+    const DataVector one_minus_y_collocation =
+        1.0 - Spectral::collocation_points<Spectral::Basis::Legendre,
+                                           Spectral::Quadrature::GaussLobatto>(
+                  number_of_radial_points);
+    for (size_t i = 0; i < number_of_radial_points; i++) {
+      ComplexDataVector angular_view_j{
+          get(*j).data().data() + get(boundary_j).size() * i,
+          get(boundary_j).size()};
+      // auto is acceptable here as these two values are only used once in the
+      // below computation. `auto` causes an expression template to be
+      // generated, rather than allocating.
+      const auto one_minus_y_coefficient =
+          0.25 * (3.0 * get(boundary_j).data() +
+                  get(r).data() * get(boundary_dr_j).data());
+      const auto one_minus_y_cubed_coefficient =
+          -0.0625 *
+          (get(boundary_j).data() + get(r).data() * get(boundary_dr_j).data());
+      angular_view_j =
+          one_minus_y_collocation[i] * one_minus_y_coefficient +
+          pow<3>(one_minus_y_collocation[i]) * one_minus_y_cubed_coefficient;
+    }
+  }
+};
+
+struct VariationAmplitude : db::SimpleTag {
+  using type = double;
+};
+
+struct InertialVariationAmplitude : db::SimpleTag {
+  using type = double;
+};
+
+using real_boundary_tags =
+    tmpl::list<Tags::CauchyAngularCoords, Tags::CauchyCartesianCoords,
+               Tags::PartiallyFlatAngularCoords,
+               Tags::PartiallyFlatCartesianCoords,
+               ::Tags::dt<Tags::CauchyCartesianCoords>,
+               ::Tags::dt<Tags::PartiallyFlatCartesianCoords>>;
+using spin_weighted_boundary_tags = tmpl::flatten<tmpl::list<
+    tmpl::list<Tags::PartiallyFlatGaugeC, Tags::PartiallyFlatGaugeD,
+               Tags::PartiallyFlatGaugeOmega, Tags::CauchyGaugeC,
+               Tags::CauchyGaugeD, Tags::CauchyGaugeOmega,
+               Tags::Du<Tags::PartiallyFlatGaugeOmega>,
+               Spectral::Swsh::Tags::Derivative<Tags::PartiallyFlatGaugeOmega,
+                                                Spectral::Swsh::Tags::Eth>,
+               Spectral::Swsh::Tags::Derivative<Tags::CauchyGaugeOmega,
+                                                Spectral::Swsh::Tags::Eth>,
+               Tags::BondiUAtScri>,
+    Tags::characteristic_worldtube_boundary_tags<Tags::BoundaryValue>,
+    Tags::characteristic_worldtube_boundary_tags<
+        Tags::EvolutionGaugeBoundaryValue>>>;
+using coordinate_variables_tag = ::Tags::Variables<real_boundary_tags>;
+using spin_weighted_variables_tag =
+    ::Tags::Variables<spin_weighted_boundary_tags>;
+using matching_variables_tag = ::Tags::Variables<
+    tmpl::list<Tags::BoundaryValue<Tags::Psi0Match>,
+               Tags::BoundaryValue<Tags::Dlambda<Tags::Psi0Match>>>>;
+using volume_spin_weighted_variables_tag = ::Tags::Variables<
+    tmpl::list<Tags::BondiJ, Tags::Dy<Tags::BondiJ>, Tags::BondiJCauchyView,
+               Tags::Dy<Tags::BondiJCauchyView>,
+               Tags::Dy<Tags::Dy<Tags::BondiJCauchyView>>, Tags::Psi0Match,
+               Tags::OneMinusY, Tags::Dy<Tags::Psi0Match>, Tags::BondiU>>;
+
+template <typename Generator>
+auto create_cce_volume_box(const gsl::not_null<Generator*> generator,
+                           const size_t l_max,
+                           const size_t number_of_radial_grid_points,
+                           const bool transform_gauge) {
+  const size_t number_of_angular_grid_points =
+      Spectral::Swsh::number_of_swsh_collocation_points(l_max);
+
+  UniformCustomDistribution<double> value_dist{0.1, 0.5};
+
+  auto box = db::create<db::AddSimpleTags<
+      VariationAmplitude, InertialVariationAmplitude, coordinate_variables_tag,
+      spin_weighted_variables_tag, volume_spin_weighted_variables_tag,
+      Tags::LMax, matching_variables_tag, Tags::NumberOfRadialPoints,
+      Spectral::Swsh::Tags::SwshInterpolator<Tags::CauchyAngularCoords>,
+      Spectral::Swsh::Tags::SwshInterpolator<
+          Tags::PartiallyFlatAngularCoords>>>(
+      0.0, 0.0,
+      typename coordinate_variables_tag::type{number_of_angular_grid_points},
+      typename spin_weighted_variables_tag::type{number_of_angular_grid_points},
+      typename volume_spin_weighted_variables_tag::type{
+          number_of_angular_grid_points * number_of_radial_grid_points},
+      l_max,
+      typename matching_variables_tag::type{number_of_angular_grid_points},
+      number_of_radial_grid_points, Spectral::Swsh::SwshInterpolator{},
+      Spectral::Swsh::SwshInterpolator{});
+
+  db::mutate<VariationAmplitude, InertialVariationAmplitude>(
+      [&value_dist, &generator, &transform_gauge](
+          const gsl::not_null<double*> variation_amplitude,
+          const gsl::not_null<double*> inertial_variation_amplitude) {
+        *inertial_variation_amplitude = value_dist(*generator);
+        *variation_amplitude = transform_gauge ? 0.0 : value_dist(*generator);
+      },
+      make_not_null(&box));
+
+  // create analytic Cauchy data (a stationary Kerr BH)
+  // first prepare the input for the modal version
+  const double mass = value_dist(*generator);
+  const std::array<double, 3> spin{
+      {value_dist(*generator), value_dist(*generator), value_dist(*generator)}};
+  const std::array<double, 3> center{
+      {value_dist(*generator), value_dist(*generator), value_dist(*generator)}};
+  const gr::Solutions::KerrSchild solution{mass, spin, center};
+
+  const double extraction_radius = 100.0;
+
+  // acceptable parameters for the fake sinusoid variation in the input
+  // parameters
+  const double frequency = 0.1 * value_dist(*generator);
+  const double amplitude = 0.1 * value_dist(*generator);
+  const double target_time = 50.0 * value_dist(*generator);
+
+  const size_t libsharp_size =
+      Spectral::Swsh::size_of_libsharp_coefficient_vector(l_max);
+  tnsr::ii<ComplexModalVector, 3> spatial_metric_coefficients{libsharp_size};
+  tnsr::ii<ComplexModalVector, 3> dt_spatial_metric_coefficients{libsharp_size};
+  tnsr::ii<ComplexModalVector, 3> dr_spatial_metric_coefficients{libsharp_size};
+  tnsr::I<ComplexModalVector, 3> shift_coefficients{libsharp_size};
+  tnsr::I<ComplexModalVector, 3> dt_shift_coefficients{libsharp_size};
+  tnsr::I<ComplexModalVector, 3> dr_shift_coefficients{libsharp_size};
+  Scalar<ComplexModalVector> lapse_coefficients{libsharp_size};
+  Scalar<ComplexModalVector> dt_lapse_coefficients{libsharp_size};
+  Scalar<ComplexModalVector> dr_lapse_coefficients{libsharp_size};
+  TestHelpers::create_fake_time_varying_data(
+      make_not_null(&spatial_metric_coefficients),
+      make_not_null(&dt_spatial_metric_coefficients),
+      make_not_null(&dr_spatial_metric_coefficients),
+      make_not_null(&shift_coefficients), make_not_null(&dt_shift_coefficients),
+      make_not_null(&dr_shift_coefficients), make_not_null(&lapse_coefficients),
+      make_not_null(&dt_lapse_coefficients),
+      make_not_null(&dr_lapse_coefficients), solution, extraction_radius,
+      amplitude, frequency, target_time, l_max, false);
+
+  db::mutate<spin_weighted_variables_tag>(
+      [&l_max, &spatial_metric_coefficients, &dt_spatial_metric_coefficients,
+       &dr_spatial_metric_coefficients, &shift_coefficients,
+       &dt_shift_coefficients, &dr_shift_coefficients, &lapse_coefficients,
+       &dt_lapse_coefficients, &dr_lapse_coefficients, &extraction_radius](
+          const gsl::not_null<Variables<spin_weighted_boundary_tags>*>
+              spin_weighted_boundary_variables) {
+        create_bondi_boundary_data(
+            spin_weighted_boundary_variables, spatial_metric_coefficients,
+            dt_spatial_metric_coefficients, dr_spatial_metric_coefficients,
+            shift_coefficients, dt_shift_coefficients, dr_shift_coefficients,
+            lapse_coefficients, dt_lapse_coefficients, dr_lapse_coefficients,
+            extraction_radius, l_max);
+      },
+      make_not_null(&box));
+
+  // construct the coordinate transform quantities
+  const double variation_amplitude = db::get<VariationAmplitude>(box);
+  const double variation_amplitude_inertial =
+      db::get<InertialVariationAmplitude>(box);
+  db::mutate<Tags::CauchyCartesianCoords>(
+      [&l_max,
+       &variation_amplitude](const gsl::not_null<tnsr::i<DataVector, 3>*>
+                                 cauchy_cartesian_coordinates) {
+        tnsr::i<DataVector, 2> cauchy_angular_coordinates{
+            get<0>(*cauchy_cartesian_coordinates).size()};
+        const auto& collocation = Spectral::Swsh::cached_collocation_metadata<
+            Spectral::Swsh::ComplexRepresentation::Interleaved>(l_max);
+        for (const auto collocation_point : collocation) {
+          // Variation amplitude is 0 if transform_gauge is true
+          get<1>(cauchy_angular_coordinates)[collocation_point.offset] =
+              collocation_point.phi + 1.0e-2 * variation_amplitude *
+                                          cos(collocation_point.phi) *
+                                          sin(collocation_point.theta);
+          get<0>(cauchy_angular_coordinates)[collocation_point.offset] =
+              collocation_point.theta;
+        }
+        get<0>(*cauchy_cartesian_coordinates) =
+            sin(get<0>(cauchy_angular_coordinates)) *
+            cos(get<1>(cauchy_angular_coordinates));
+        get<1>(*cauchy_cartesian_coordinates) =
+            sin(get<0>(cauchy_angular_coordinates)) *
+            sin(get<1>(cauchy_angular_coordinates));
+        get<2>(*cauchy_cartesian_coordinates) =
+            cos(get<0>(cauchy_angular_coordinates));
+      },
+      make_not_null(&box));
+
+  db::mutate<Tags::PartiallyFlatCartesianCoords>(
+      [&l_max, &variation_amplitude_inertial](
+          const gsl::not_null<tnsr::i<DataVector, 3>*>
+              inertial_cartesian_coordinates) {
+        tnsr::i<DataVector, 2> inertial_angular_coordinates{
+            get<0>(*inertial_cartesian_coordinates).size()};
+        const auto& collocation = Spectral::Swsh::cached_collocation_metadata<
+            Spectral::Swsh::ComplexRepresentation::Interleaved>(l_max);
+        for (const auto& collocation_point : collocation) {
+          get<1>(inertial_angular_coordinates)[collocation_point.offset] =
+              collocation_point.phi + 1.0e-2 * variation_amplitude_inertial *
+                                          cos(collocation_point.phi) *
+                                          sin(collocation_point.theta);
+          get<0>(inertial_angular_coordinates)[collocation_point.offset] =
+              collocation_point.theta;
+        }
+        get<0>(*inertial_cartesian_coordinates) =
+            sin(get<0>(inertial_angular_coordinates)) *
+            cos(get<1>(inertial_angular_coordinates));
+        get<1>(*inertial_cartesian_coordinates) =
+            sin(get<0>(inertial_angular_coordinates)) *
+            sin(get<1>(inertial_angular_coordinates));
+        get<2>(*inertial_cartesian_coordinates) =
+            cos(get<0>(inertial_angular_coordinates));
+      },
+      make_not_null(&box));
+
+  if (transform_gauge) {
+    // Update various auxiliary boundary variables in order to prepare the
+    // boundary data for BondiJ. Operations are done for both Cauchy
+    // coordinates and partially flat coordinates.
+    db::mutate_apply<GaugeUpdateAngularFromCartesian<
+        Tags::CauchyAngularCoords, Tags::CauchyCartesianCoords>>(
+        make_not_null(&box));
+    db::mutate_apply<GaugeUpdateAngularFromCartesian<
+        Tags::PartiallyFlatAngularCoords, Tags::PartiallyFlatCartesianCoords>>(
+        make_not_null(&box));
+
+    db::mutate_apply<GaugeUpdateInterpolator<Tags::CauchyAngularCoords>>(
+        make_not_null(&box));
+    db::mutate_apply<GaugeUpdateInterpolator<Tags::PartiallyFlatAngularCoords>>(
+        make_not_null(&box));
+
+    db::mutate_apply<GaugeUpdateJacobianFromCoordinates<
+        Tags::PartiallyFlatGaugeC, Tags::PartiallyFlatGaugeD,
+        Tags::CauchyAngularCoords, Tags::CauchyCartesianCoords>>(
+        make_not_null(&box));
+    db::mutate_apply<GaugeUpdateJacobianFromCoordinates<
+        Tags::CauchyGaugeC, Tags::CauchyGaugeD,
+        Tags::PartiallyFlatAngularCoords, Tags::PartiallyFlatCartesianCoords>>(
+        make_not_null(&box));
+
+    db::mutate_apply<
+        GaugeUpdateOmega<Tags::PartiallyFlatGaugeC, Tags::PartiallyFlatGaugeD,
+                         Tags::PartiallyFlatGaugeOmega>>(make_not_null(&box));
+    db::mutate_apply<GaugeUpdateOmega<Tags::CauchyGaugeC, Tags::CauchyGaugeD,
+                                      Tags::CauchyGaugeOmega>>(
+        make_not_null(&box));
+  }
+
+  return box; // NRVO
+}
+}  // namespace Cce::TestHelpers


### PR DESCRIPTION
## Proposed changes

Adding another Weyl scalar to the volume (partially addresses #5463)

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [x] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [x] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [x] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
