### PR TITLE
Install Clang 15 in container, remove Clang 11

### DIFF
--- a/containers/Dockerfile.buildenv
+++ b/containers/Dockerfile.buildenv
@@ -315,7 +315,7 @@ RUN apt-get update -y \
     && apt-get install -y \
         gcc-9 g++-9 gfortran-9 \
         gcc-10 g++-10 gfortran-10 \
-        clang-11 clang-13
+        clang-13 clang-15
 
 # Install minimum required CMake version so that we test compatibility with it.
 # For this version of CMake no ARM binary is available.


### PR DESCRIPTION
## Proposed changes

We can merge this now, and wait with rebuilding the container until #5475 is merged and people have had some time to rebase (so PRs don't get disrupted with missing clang 11).

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
