### PR TITLE
Add clang-tidy annotations on CI, run only over changed lines

### DIFF
--- a/.github/problem_matchers/ClangTidy.json
+++ b/.github/problem_matchers/ClangTidy.json
@@ -1,0 +1,18 @@
+{
+  "problemMatcher": [
+    {
+      "owner": "clang-tidy",
+      "pattern": [
+        {
+          "regexp": "^(?:\\x1b\\[[\\d;]+m)*(.+):(\\d+):(\\d+):\\s(?:\\x1b\\[[\\d;]+m)*(error):\\s(?:\\x1b\\[[\\d;]+m)*(.+)\\s\\[(.+)\\](?:\\x1b\\[[\\d;]+m)*$",
+          "file": 1,
+          "line": 2,
+          "column": 3,
+          "severity": 4,
+          "message": 5,
+          "code": 6
+        }
+      ]
+    }
+  ]
+}

--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -221,6 +221,12 @@ jobs:
       - name: Trust checkout
         run: |
           git config --global --add safe.directory $GITHUB_WORKSPACE
+      - name: Configure annotations
+        # Has to be accessible outside the container, see issue:
+        # https://github.com/actions/toolkit/issues/305
+        run: |
+          cp .github/problem_matchers/ClangTidy.json "$HOME/"
+          echo "::add-matcher::$HOME/ClangTidy.json"
       - name: Fetch sxs-collaboration/spectre/develop
         run: >
           cd $GITHUB_WORKSPACE

--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -238,7 +238,6 @@ jobs:
 
           git fetch upstream develop
       - name: Configure with cmake
-        working-directory: /work
         # Notes on the build configuration:
         # - Set `BUILD_TESTING=OFF` to test a CMake configuration with tests
         #   turned off.
@@ -257,15 +256,24 @@ jobs:
           -D BUILD_PYTHON_BINDINGS=ON
           -D BUILD_TESTING=OFF
           $GITHUB_WORKSPACE
+
+          make SpectrePch
+      - name: Use new clang-tidy-diff
+        # The clang-tidy-diff tool shipped with clang 14 doesn't report exit
+        # codes, so we grab the version that does:
+        # https://github.com/llvm/llvm-project/commit/4294bca5e4f6e6e8cfdbd9fbe8751c5e5415fd47
+        run: |
+          wget https://raw.githubusercontent.com/llvm/llvm-project/4294bca5e4f6e6e8cfdbd9fbe8751c5e5415fd47/clang-tools-extra/clang-tidy/tool/clang-tidy-diff.py
+          chmod +x clang-tidy-diff.py
+          mv clang-tidy-diff.py /usr/bin/clang-tidy-diff
       - name: Check clang-tidy
-        working-directory: /work/build
         run: >
-          UPSTREAM_HASH=$(
-            cd $GITHUB_WORKSPACE && git merge-base HEAD upstream/develop)
+          UPSTREAM_HASH=$(git merge-base HEAD upstream/develop)
 
           echo "Running clang-tidy relative to: $UPSTREAM_HASH\n"
 
-          make clang-tidy-hash HASH=$UPSTREAM_HASH NUM_THREADS=2
+          git diff -U0 $UPSTREAM_HASH |
+            clang-tidy-diff -path build -p1 -use-color -j2
 
   # Build the documentation and check for problems, then upload as a workflow
   # artifact and deploy to gh-pages.


### PR DESCRIPTION
## Proposed changes

Surface clang-tidy warnings in PR diffs. Also run clang-tidy only over changed lines in the PR. This avoids noise from clang-tidy originating from lines that were not changed in the PR. In particular, this should avoid most of the annoying TOMS748 warnings from Boost.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
