### PR TITLE
Update installation instructions to include maximum version of Doxygen.

### DIFF
--- a/docs/Installation/Installation.md
+++ b/docs/Installation/Installation.md
@@ -103,7 +103,7 @@ apt), or AppleClang 13.0.0 or later
 #### Optional:
 * [Pybind11](https://pybind11.readthedocs.io) 2.6.0 or later for SpECTRE Python
   bindings \cite Pybind11
-* [Doxygen](https://www.doxygen.nl/index.html) 1.9.1 or later — to
+* [Doxygen](https://www.doxygen.nl/index.html) 1.9.1 to 1.9.6 — to
   generate documentation
 * Python dev dependencies listed in `support/Python/dev_requirements.txt`
   — for documentation pre- and post-processing, formatting code, etc.


### PR DESCRIPTION
## Proposed changes

<!--
At a high level, describe what this PR does.
-->

Currently Doxygen 1.9.7 or later breaks the documentation building procedure. Entries are made but not filled in. Until it is fixed, the installation instructions should include the maximum version 1.9.6 for Doxygen.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [x] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [x] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [x] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
