### PR TITLE
Remove some catastrophic cancellation in prim recovery

### DIFF
--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/KastaunEtAl.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/KastaunEtAl.cpp
@@ -326,12 +326,14 @@ std::optional<PrimitiveRecoveryData> KastaunEtAl::apply(
              specific_internal_energy, q_bar, r_bar_squared] =
       f_of_mu.primitives(one_over_specific_enthalpy_times_lorentz_factor);
 
-  (void)(specific_internal_energy);
   (void)(q_bar);
   (void)(r_bar_squared);
 
   return PrimitiveRecoveryData{
-      rest_mass_density, lorentz_factor, pressure,
+      rest_mass_density,
+      lorentz_factor,
+      pressure,
+      specific_internal_energy,
       rest_mass_density_times_lorentz_factor /
           one_over_specific_enthalpy_times_lorentz_factor,
       electron_fraction};

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/KastaunEtAl.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/KastaunEtAl.cpp
@@ -109,15 +109,14 @@ class AuxiliaryFunction {
 template <size_t ThermodynamicDim>
 class FunctionOfMu {
  public:
-  FunctionOfMu(const double total_energy_density,
-               const double momentum_density_squared,
+  FunctionOfMu(const double tau, const double momentum_density_squared,
                const double momentum_density_dot_magnetic_field,
                const double magnetic_field_squared,
                const double rest_mass_density_times_lorentz_factor,
                const double electron_fraction,
                const EquationsOfState::EquationOfState<true, ThermodynamicDim>&
                    equation_of_state)
-      : q_(total_energy_density / rest_mass_density_times_lorentz_factor - 1.0),
+      : q_(tau / rest_mass_density_times_lorentz_factor),
         r_squared_(momentum_density_squared /
                    square(rest_mass_density_times_lorentz_factor)),
         b_squared_(magnetic_field_squared /
@@ -286,7 +285,7 @@ double FunctionOfMu<ThermodynamicDim>::operator()(const double mu) const {
 
 template <size_t ThermodynamicDim>
 std::optional<PrimitiveRecoveryData> KastaunEtAl::apply(
-    const double /*initial_guess_pressure*/, const double total_energy_density,
+    const double /*initial_guess_pressure*/, const double tau,
     const double momentum_density_squared,
     const double momentum_density_dot_magnetic_field,
     const double magnetic_field_squared,
@@ -296,7 +295,7 @@ std::optional<PrimitiveRecoveryData> KastaunEtAl::apply(
         equation_of_state) {
   // Master function see Equation (44)
   const auto f_of_mu =
-      FunctionOfMu<ThermodynamicDim>{total_energy_density,
+      FunctionOfMu<ThermodynamicDim>{tau,
                                      momentum_density_squared,
                                      momentum_density_dot_magnetic_field,
                                      magnetic_field_squared,
@@ -340,18 +339,18 @@ std::optional<PrimitiveRecoveryData> KastaunEtAl::apply(
 }  // namespace grmhd::ValenciaDivClean::PrimitiveRecoverySchemes
 
 #define THERMODIM(data) BOOST_PP_TUPLE_ELEM(0, data)
-#define INSTANTIATION(_, data)                                                \
-  template std::optional<grmhd::ValenciaDivClean::PrimitiveRecoverySchemes::  \
-                             PrimitiveRecoveryData>                           \
-  grmhd::ValenciaDivClean::PrimitiveRecoverySchemes::KastaunEtAl::apply<      \
-      THERMODIM(data)>(                                                       \
-      const double initial_guess_pressure, const double total_energy_density, \
-      const double momentum_density_squared,                                  \
-      const double momentum_density_dot_magnetic_field,                       \
-      const double magnetic_field_squared,                                    \
-      const double rest_mass_density_times_lorentz_factor,                    \
-      const double electron_fraction,                                         \
-      const EquationsOfState::EquationOfState<true, THERMODIM(data)>&         \
+#define INSTANTIATION(_, data)                                               \
+  template std::optional<grmhd::ValenciaDivClean::PrimitiveRecoverySchemes:: \
+                             PrimitiveRecoveryData>                          \
+  grmhd::ValenciaDivClean::PrimitiveRecoverySchemes::KastaunEtAl::apply<     \
+      THERMODIM(data)>(                                                      \
+      const double initial_guess_pressure, const double tau,                 \
+      const double momentum_density_squared,                                 \
+      const double momentum_density_dot_magnetic_field,                      \
+      const double magnetic_field_squared,                                   \
+      const double rest_mass_density_times_lorentz_factor,                   \
+      const double electron_fraction,                                        \
+      const EquationsOfState::EquationOfState<true, THERMODIM(data)>&        \
           equation_of_state);
 
 GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2))

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/KastaunEtAl.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/KastaunEtAl.hpp
@@ -23,8 +23,8 @@ namespace grmhd::ValenciaDivClean::PrimitiveRecoverySchemes {
  * \brief Compute the primitive variables from the conservative variables using
  * the scheme of \cite Kastaun2020uxr.
  *
- * In the notation of the Kastaun paper, `total_energy_density` is \f$D
- * (1+q)\f$, `momentum_density_squared` is \f$r^2 D^2\f$,
+ * In the notation of the Kastaun paper, `tau` is \f$D q)\f$,
+ * `momentum_density_squared` is \f$r^2 D^2\f$,
  * `momentum_density_dot_magnetic_field` is \f$t D^{\frac{3}{2}}\f$,
  * `magnetic_field_squared` is \f$s D\f$, and
  * `rest_mass_density_times_lorentz_factor` is \f$D\f$.
@@ -51,7 +51,7 @@ class KastaunEtAl {
  public:
   template <size_t ThermodynamicDim>
   static std::optional<PrimitiveRecoveryData> apply(
-      double initial_guess_pressure, double total_energy_density,
+      double initial_guess_pressure, double tau,
       double momentum_density_squared,
       double momentum_density_dot_magnetic_field, double magnetic_field_squared,
       double rest_mass_density_times_lorentz_factor, double electron_fraction,

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/KastaunEtAlHydro.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/KastaunEtAlHydro.cpp
@@ -30,15 +30,14 @@ struct Primitives {
 template <size_t ThermodynamicDim, bool EnforcePhysicality>
 class FunctionOfZ {
  public:
-  FunctionOfZ(const double total_energy_density,
-              const double momentum_density_squared,
+  FunctionOfZ(const double tau, const double momentum_density_squared,
               const double /* momentum_density_dot_magnetic_field */,
               const double /* magnetic_field_squared */,
               const double rest_mass_density_times_lorentz_factor,
               const double electron_fraction,
               const EquationsOfState::EquationOfState<true, ThermodynamicDim>&
                   equation_of_state)
-      : q_(total_energy_density / rest_mass_density_times_lorentz_factor - 1.0),
+      : q_(tau / rest_mass_density_times_lorentz_factor),
         r_squared_(momentum_density_squared /
                    square(rest_mass_density_times_lorentz_factor)),
         r_(std::sqrt(r_squared_)),
@@ -157,7 +156,7 @@ template <bool EnforcePhysicality>
 template <size_t ThermodynamicDim>
 std::optional<PrimitiveRecoveryData>
 KastaunEtAlHydro<EnforcePhysicality>::apply(
-    const double /*initial_guess_pressure*/, const double total_energy_density,
+    const double /*initial_guess_pressure*/, const double tau,
     const double momentum_density_squared,
     const double momentum_density_dot_magnetic_field,
     const double magnetic_field_squared,
@@ -167,7 +166,7 @@ KastaunEtAlHydro<EnforcePhysicality>::apply(
         equation_of_state) {
   // Master function see Equation (44)
   auto f_of_z = FunctionOfZ<ThermodynamicDim, EnforcePhysicality>{
-      total_energy_density,
+      tau,
       momentum_density_squared,
       momentum_density_dot_magnetic_field,
       magnetic_field_squared,
@@ -213,8 +212,7 @@ KastaunEtAlHydro<EnforcePhysicality>::apply(
                              PrimitiveRecoveryData>                          \
   grmhd::ValenciaDivClean::PrimitiveRecoverySchemes::                        \
       KastaunEtAlHydro<PHYSICALITY(data)>::apply<THERMODIM(data)>(           \
-          const double initial_guess_pressure,                               \
-          const double total_energy_density,                                 \
+          const double initial_guess_pressure, const double tau,             \
           const double momentum_density_squared,                             \
           const double momentum_density_dot_magnetic_field,                  \
           const double magnetic_field_squared,                               \

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/KastaunEtAlHydro.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/KastaunEtAlHydro.cpp
@@ -45,7 +45,6 @@ class FunctionOfZ {
             rest_mass_density_times_lorentz_factor),
         electron_fraction_(electron_fraction),
         equation_of_state_(equation_of_state) {
-
     // Internal consistency check
     //
     const double rho_min =
@@ -198,7 +197,10 @@ KastaunEtAlHydro<EnforcePhysicality>::apply(
              specific_internal_energy] = f_of_z.primitives(z);
 
   return PrimitiveRecoveryData{
-      rest_mass_density, lorentz_factor, pressure,
+      rest_mass_density,
+      lorentz_factor,
+      pressure,
+      specific_internal_energy,
       (rest_mass_density * (1. + specific_internal_energy) + pressure) *
           (1. + z * z),
       electron_fraction};

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/KastaunEtAlHydro.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/KastaunEtAlHydro.hpp
@@ -24,8 +24,8 @@ struct PrimitiveRecoveryData;
  * \brief Compute the primitive variables from the conservative variables using
  * the scheme of \cite Galeazzi2013mia.
  *
- * In the notation of the Kastaun paper, `total_energy_density` is \f$D
- * (1+q)\f$, `momentum_density_squared` is \f$r^2 D^2\f$,
+ * In the notation of the Kastaun paper, `tau` is \f$D q\f$,
+ * `momentum_density_squared` is \f$r^2 D^2\f$,
  * `rest_mass_density_times_lorentz_factor` is \f$D\f$.
  * Furthermore, the algorithm iterates over \f$z\f$, which is the Lorentz factor
  * times the absolute magnetitude of the velocity.
@@ -49,7 +49,7 @@ class KastaunEtAlHydro {
  public:
   template <size_t ThermodynamicDim>
   static std::optional<PrimitiveRecoveryData> apply(
-      double initial_guess_pressure, double total_energy_density,
+      double initial_guess_pressure, double tau,
       double momentum_density_squared,
       double momentum_density_dot_magnetic_field, double magnetic_field_squared,
       double rest_mass_density_times_lorentz_factor, double electron_fraction,

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/NewmanHamlin.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/NewmanHamlin.cpp
@@ -111,9 +111,24 @@ std::optional<PrimitiveRecoveryData> NewmanHamlin::apply(
         rest_mass_density_times_lorentz_factor / current_lorentz_factor;
 
     if (converged) {
-      return PrimitiveRecoveryData{current_rest_mass_density,
-                                   current_lorentz_factor, current_pressure,
-                                   rho_h_w_squared, electron_fraction};
+      double current_specific_internal_energy{};
+      if constexpr (ThermodynamicDim == 1) {
+        current_specific_internal_energy =
+            get(equation_of_state.specific_internal_energy_from_density(
+                Scalar<double>(current_rest_mass_density)));
+      } else if constexpr (ThermodynamicDim == 2) {
+        current_specific_internal_energy =
+            get(equation_of_state
+                    .specific_internal_energy_from_density_and_pressure(
+                        Scalar<double>(current_rest_mass_density),
+                        Scalar<double>(current_pressure)));
+      } else if constexpr (ThermodynamicDim == 3) {
+        ERROR("3d EOS not implemented");
+      }
+      return PrimitiveRecoveryData{
+          current_rest_mass_density, current_lorentz_factor,
+          current_pressure,          current_specific_internal_energy,
+          rho_h_w_squared,           electron_fraction};
     }
 
     const double current_specific_enthalpy = [rho_h_w_squared,

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/NewmanHamlin.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/NewmanHamlin.cpp
@@ -20,7 +20,7 @@ namespace grmhd::ValenciaDivClean::PrimitiveRecoverySchemes {
 
 template <size_t ThermodynamicDim>
 std::optional<PrimitiveRecoveryData> NewmanHamlin::apply(
-    const double initial_guess_for_pressure, const double total_energy_density,
+    const double initial_guess_for_pressure, const double tau,
     const double momentum_density_squared,
     const double momentum_density_dot_magnetic_field,
     const double magnetic_field_squared,
@@ -28,6 +28,8 @@ std::optional<PrimitiveRecoveryData> NewmanHamlin::apply(
     const double electron_fraction,
     const EquationsOfState::EquationOfState<true, ThermodynamicDim>&
         equation_of_state) {
+  const double total_energy_density =
+      tau + rest_mass_density_times_lorentz_factor;
   // constant in cubic equation  f(eps) = eps^3 - a eps^2 + d
   // whose root is being found at each point in the iteration below
   const double d_in_cubic = [momentum_density_squared, magnetic_field_squared,
@@ -173,18 +175,18 @@ std::optional<PrimitiveRecoveryData> NewmanHamlin::apply(
 }  // namespace grmhd::ValenciaDivClean::PrimitiveRecoverySchemes
 
 #define THERMODIM(data) BOOST_PP_TUPLE_ELEM(0, data)
-#define INSTANTIATION(_, data)                                                \
-  template std::optional<grmhd::ValenciaDivClean::PrimitiveRecoverySchemes::  \
-                             PrimitiveRecoveryData>                           \
-  grmhd::ValenciaDivClean::PrimitiveRecoverySchemes::NewmanHamlin::apply<     \
-      THERMODIM(data)>(                                                       \
-      const double initial_guess_pressure, const double total_energy_density, \
-      const double momentum_density_squared,                                  \
-      const double momentum_density_dot_magnetic_field,                       \
-      const double magnetic_field_squared,                                    \
-      const double rest_mass_density_times_lorentz_factor,                    \
-      const double electron_fraction,                                         \
-      const EquationsOfState::EquationOfState<true, THERMODIM(data)>&         \
+#define INSTANTIATION(_, data)                                               \
+  template std::optional<grmhd::ValenciaDivClean::PrimitiveRecoverySchemes:: \
+                             PrimitiveRecoveryData>                          \
+  grmhd::ValenciaDivClean::PrimitiveRecoverySchemes::NewmanHamlin::apply<    \
+      THERMODIM(data)>(                                                      \
+      const double initial_guess_pressure, const double tau,                 \
+      const double momentum_density_squared,                                 \
+      const double momentum_density_dot_magnetic_field,                      \
+      const double magnetic_field_squared,                                   \
+      const double rest_mass_density_times_lorentz_factor,                   \
+      const double electron_fraction,                                        \
+      const EquationsOfState::EquationOfState<true, THERMODIM(data)>&        \
           equation_of_state);
 
 GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2))

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/NewmanHamlin.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/NewmanHamlin.hpp
@@ -21,7 +21,7 @@ namespace PrimitiveRecoverySchemes {
  * the scheme of [Newman and Hamlin, SIAM J. Sci. Comput., 36(4)
  * B661-B683 (2014)](https://epubs.siam.org/doi/10.1137/140956749).
  *
- * In the Newman and Hamlin paper, `total_energy_density` is \f$e\f$,
+ * In the Newman and Hamlin paper, `tau` is \f$e - \rho W\f$,
  * `momentum_density_squared` is\f${\cal M}^2\f$,
  * `momentum_density_dot_magnetic_field` is \f${\cal T}\f$,
  * `magnetic_field_squared` is \f${\cal B}^2\f$, and
@@ -48,7 +48,7 @@ class NewmanHamlin {
  public:
   template <size_t ThermodynamicDim>
   static std::optional<PrimitiveRecoveryData> apply(
-      double initial_guess_for_pressure, double total_energy_density,
+      double initial_guess_for_pressure, double tau,
       double momentum_density_squared,
       double momentum_density_dot_magnetic_field, double magnetic_field_squared,
       double rest_mass_density_times_lorentz_factor, double electron_fraction,

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/PalenzuelaEtAl.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/PalenzuelaEtAl.cpp
@@ -137,12 +137,15 @@ std::optional<PrimitiveRecoveryData> PalenzuelaEtAl::apply(
   const double rest_mass_density =
       rest_mass_density_times_lorentz_factor / lorentz_factor;
   double pressure = std::numeric_limits<double>::signaling_NaN();
+  double specific_internal_energy = f_of_x.specific_internal_energy(
+      specific_enthalpy_times_lorentz_factor, lorentz_factor);
   if constexpr (ThermodynamicDim == 1) {
     pressure = get(equation_of_state.pressure_from_density(
         Scalar<double>(rest_mass_density)));
+    specific_internal_energy =
+        get(equation_of_state.specific_internal_energy_from_density(
+            Scalar<double>(rest_mass_density)));
   } else if constexpr (ThermodynamicDim == 2) {
-    const double specific_internal_energy = f_of_x.specific_internal_energy(
-        specific_enthalpy_times_lorentz_factor, lorentz_factor);
     pressure = get(equation_of_state.pressure_from_density_and_energy(
         Scalar<double>(rest_mass_density),
         Scalar<double>(specific_internal_energy)));
@@ -150,7 +153,10 @@ std::optional<PrimitiveRecoveryData> PalenzuelaEtAl::apply(
     ERROR("3d EOS not implemented");
   }
 
-  return PrimitiveRecoveryData{rest_mass_density, lorentz_factor, pressure,
+  return PrimitiveRecoveryData{rest_mass_density,
+                               lorentz_factor,
+                               pressure,
+                               specific_internal_energy,
                                specific_enthalpy_times_lorentz_factor *
                                    rest_mass_density_times_lorentz_factor,
                                electron_fraction};

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/PalenzuelaEtAl.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/PalenzuelaEtAl.cpp
@@ -23,15 +23,14 @@ namespace {
 template <size_t ThermodynamicDim>
 class FunctionOfX {
  public:
-  FunctionOfX(const double total_energy_density,
-              const double momentum_density_squared,
+  FunctionOfX(const double tau, const double momentum_density_squared,
               const double momentum_density_dot_magnetic_field,
               const double magnetic_field_squared,
               const double rest_mass_density_times_lorentz_factor,
               const double electron_fraction,
               const EquationsOfState::EquationOfState<true, ThermodynamicDim>&
                   equation_of_state)
-      : q_(total_energy_density / rest_mass_density_times_lorentz_factor - 1.0),
+      : q_(tau / rest_mass_density_times_lorentz_factor),
         r_(momentum_density_squared /
            square(rest_mass_density_times_lorentz_factor)),
         s_(magnetic_field_squared / rest_mass_density_times_lorentz_factor),
@@ -100,7 +99,7 @@ class FunctionOfX {
 
 template <size_t ThermodynamicDim>
 std::optional<PrimitiveRecoveryData> PalenzuelaEtAl::apply(
-    const double /*initial_guess_pressure*/, const double total_energy_density,
+    const double /*initial_guess_pressure*/, const double tau,
     const double momentum_density_squared,
     const double momentum_density_dot_magnetic_field,
     const double magnetic_field_squared,
@@ -108,13 +107,14 @@ std::optional<PrimitiveRecoveryData> PalenzuelaEtAl::apply(
     const double electron_fraction,
     const EquationsOfState::EquationOfState<true, ThermodynamicDim>&
         equation_of_state) {
-  const double lower_bound = (total_energy_density - magnetic_field_squared) /
-                             rest_mass_density_times_lorentz_factor;
-  const double upper_bound =
-      (2.0 * total_energy_density - magnetic_field_squared) /
-      rest_mass_density_times_lorentz_factor;
+  const double lower_bound =
+      (tau - magnetic_field_squared) / rest_mass_density_times_lorentz_factor +
+      1.0;
+  const double upper_bound = (2.0 * tau - magnetic_field_squared) /
+                                 rest_mass_density_times_lorentz_factor +
+                             2.0;
   const auto f_of_x =
-      FunctionOfX<ThermodynamicDim>{total_energy_density,
+      FunctionOfX<ThermodynamicDim>{tau,
                                     momentum_density_squared,
                                     momentum_density_dot_magnetic_field,
                                     magnetic_field_squared,
@@ -163,8 +163,7 @@ std::optional<PrimitiveRecoveryData> PalenzuelaEtAl::apply(
                              PrimitiveRecoveryData>                          \
   grmhd::ValenciaDivClean::PrimitiveRecoverySchemes::PalenzuelaEtAl::apply<  \
       THERMODIM(data)>(                                                      \
-      const double /*initial_guess_pressure*/,                               \
-      const double total_energy_density,                                     \
+      const double /*initial_guess_pressure*/, const double tau,             \
       const double momentum_density_squared,                                 \
       const double momentum_density_dot_magnetic_field,                      \
       const double magnetic_field_squared,                                   \

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/PalenzuelaEtAl.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/PalenzuelaEtAl.hpp
@@ -22,8 +22,8 @@ namespace PrimitiveRecoverySchemes {
  * the scheme of [Palenzuela et al, Phys. Rev. D 92, 044045
  * (2015)](https://doi.org/10.1103/PhysRevD.92.044045).
  *
- * In the notation of the Palenzuela paper, `total_energy_density` is \f$D
- * (1+q)\f$, `momentum_density_squared` is \f$r^2 D^2\f$,
+ * In the notation of the Palenzuela paper, `tau` is \f$D q\f$,
+ * `momentum_density_squared` is \f$r^2 D^2\f$,
  * `momentum_density_dot_magnetic_field` is \f$t D^{\frac{3}{2}}\f$,
  * `magnetic_field_squared` is \f$s D\f$, and
  * `rest_mass_density_times_lorentz_factor` is \f$D\f$.
@@ -49,7 +49,7 @@ class PalenzuelaEtAl {
  public:
   template <size_t ThermodynamicDim>
   static std::optional<PrimitiveRecoveryData> apply(
-      double /*initial_guess_pressure*/, double total_energy_density,
+      double /*initial_guess_pressure*/, double tau,
       double momentum_density_squared,
       double momentum_density_dot_magnetic_field, double magnetic_field_squared,
       double rest_mass_density_times_lorentz_factor, double electron_fraction,

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/PrimitiveFromConservative.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/PrimitiveFromConservative.cpp
@@ -180,10 +180,8 @@ bool PrimitiveFromConservative<OrderedListOfPrimitiveRecoverySchemes,
 
       // Check consistency
       if (use_hydro_optimization and
-          equal_within_roundoff(
-              tau[s] + rest_mass_density_times_lorentz_factor[s],
-              get(magnetic_field_squared)[s] * 0.5 + tau[s] +
-                  rest_mass_density_times_lorentz_factor[s])) {
+          (get(magnetic_field_squared)[s] <
+           100.0 * std::numeric_limits<double>::epsilon() * tau[s])) {
         tmpl::for_each<
             tmpl::list<grmhd::ValenciaDivClean::PrimitiveRecoverySchemes::
                            KastaunEtAlHydro<EnforcePhysicality>>>(apply_scheme);

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/PrimitiveFromConservative.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/PrimitiveFromConservative.cpp
@@ -134,7 +134,11 @@ bool PrimitiveFromConservative<OrderedListOfPrimitiveRecoverySchemes,
         const double specific_enthalpy_at_point =
             1.0 + specific_energy_at_point + pressure_at_point / floorD;
         primitive_data = PrimitiveRecoverySchemes::PrimitiveRecoveryData{
-            floorD, 1.0, pressure_at_point, floorD * specific_enthalpy_at_point,
+            floorD,
+            1.0,
+            pressure_at_point,
+            specific_energy_at_point,
+            floorD * specific_enthalpy_at_point,
             get(*electron_fraction)[s]};
       }
       else if constexpr (ThermodynamicDim == 1) {
@@ -148,7 +152,11 @@ bool PrimitiveFromConservative<OrderedListOfPrimitiveRecoverySchemes,
         const double specific_enthalpy_at_point =
             1.0 + specific_energy_at_point + pressure_at_point / floorD;
         primitive_data = PrimitiveRecoverySchemes::PrimitiveRecoveryData{
-            floorD, 1.0, pressure_at_point, floorD * specific_enthalpy_at_point,
+            floorD,
+            1.0,
+            pressure_at_point,
+            specific_energy_at_point,
+            floorD * specific_enthalpy_at_point,
             get(*electron_fraction)[s]};
       }
     } else {
@@ -202,19 +210,12 @@ bool PrimitiveFromConservative<OrderedListOfPrimitiveRecoverySchemes,
       }
       get(*lorentz_factor)[s] = primitive_data.value().lorentz_factor;
       get(*pressure)[s] = primitive_data.value().pressure;
-
-      // We store rho * h here temporarily and divide by rho two lines later.
-      get(*specific_enthalpy)[s] = primitive_data.value().rho_h_w_squared /
-                                   (primitive_data.value().lorentz_factor *
-                                    primitive_data.value().lorentz_factor);
       get(*specific_internal_energy)[s] =
-          (get(*specific_enthalpy)[s] -
-           primitive_data.value().rest_mass_density -
-           primitive_data.value().pressure) /
-          primitive_data.value().rest_mass_density;
-
-      get(*specific_enthalpy)[s] /= primitive_data.value().rest_mass_density;
-
+          primitive_data.value().specific_internal_energy;
+      get(*specific_enthalpy)[s] = primitive_data.value().rho_h_w_squared /
+                                   (primitive_data.value().rest_mass_density *
+                                    primitive_data.value().lorentz_factor *
+                                    primitive_data.value().lorentz_factor);
     } else {
       if constexpr (ErrorOnFailure) {
         ERROR("All primitive inversion schemes failed at s = "

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/PrimitiveRecoveryData.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/PrimitiveRecoveryData.hpp
@@ -20,6 +20,7 @@ struct PrimitiveRecoveryData {
   double rest_mass_density;
   double lorentz_factor;
   double pressure;
+  double specific_internal_energy;
   double rho_h_w_squared;
   double electron_fraction;
 };


### PR DESCRIPTION
## Proposed changes

I'm still worried about Palenzuela+ and NewmanHamlin, but the Kastaun schemes are better anyway. With the Kastaun scheme I'm a little worried that it couldn't be improved in some limits since it does use enthalpy and the Lorentz factor, so low-density low-velocity could see precision loss, but I haven't looked at this in detail.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
