### PR TITLE
Work around boost failure to build in clang 15

### DIFF
--- a/cmake/SetupBoost.cmake
+++ b/cmake/SetupBoost.cmake
@@ -120,3 +120,13 @@ set_property(TARGET Boost::boost
   APPEND PROPERTY
   INTERFACE_COMPILE_DEFINITIONS
   $<$<COMPILE_LANGUAGE:CXX>:${BOOST_MULTI_ARRAY_TYPES_HEADER_GUARD}>)
+
+# Work around boost not building with clang 15 (fixed in boost 1.83.0)
+# (https://github.com/boostorg/functional/pull/21)
+if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND BOOST_VERSION VERSION_LESS 1.83.0)
+  if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER "15.0.0" OR
+      CMAKE_CXX_COMPILER_VERSION VERSION_EQUAL "15.0.0")
+        target_compile_definitions(Boost::boost INTERFACE _HAS_AUTO_PTR_ETC=0)
+  endif()
+endif()
+


### PR DESCRIPTION
## Proposed changes

[Workaround](https://github.com/boostorg/functional/pull/21) for boost not building with clang 15: adds `-D_HAS_AUTO_PTR_ETC=0` to `CMAKE_CXXX_FLAGS` if clang version >= 15.0.0. This fix is necessary to build with latest Xcode/AppleClang.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
