### PR TITLE
Update GrMhd Analytic Boundary Conditions

### DIFF
--- a/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
+++ b/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
@@ -77,6 +77,7 @@
 #include "Evolution/Systems/GeneralizedHarmonic/System.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
 #include "Evolution/Systems/GrMhd/GhValenciaDivClean/Actions/SetInitialData.hpp"
+#include "Evolution/Systems/GrMhd/GhValenciaDivClean/AllSolutions.hpp"
 #include "Evolution/Systems/GrMhd/GhValenciaDivClean/BoundaryConditions/Factory.hpp"
 #include "Evolution/Systems/GrMhd/GhValenciaDivClean/BoundaryCorrections/ProductOfCorrections.hpp"
 #include "Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/Tag.hpp"
@@ -91,6 +92,7 @@
 #include "Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/TimeDerivative.hpp"
 #include "Evolution/Systems/GrMhd/GhValenciaDivClean/System.hpp"
 #include "Evolution/Systems/GrMhd/GhValenciaDivClean/TimeDerivativeTerms.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/AllSolutions.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryConditions/Factory.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryCorrections/Factory.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/FixConservatives.hpp"
@@ -433,8 +435,13 @@ struct GhValenciaDivCleanTemplateBase<
       hydro::Tags::EquationOfStateFromOptions<true, thermodynamic_dim>,
       hydro::Tags::EquationOfState<std::unique_ptr<
           EquationsOfState::EquationOfState<true, thermodynamic_dim>>>>;
-
-  using initial_data_list = gh::solutions_including_matter<3>;
+  // Currently we need to register all analytic solutions and data together,
+  // (including ValenciaDivClean initial data which is needed for product
+  // boundary conditions)
+  // This will likely change once we use runtime initial data.
+  using analytic_solutions_and_data_to_register =
+      tmpl::append<gh::solutions_including_matter<3>,
+                   grmhd::ValenciaDivClean::InitialData::initial_data_list>;
 
   using initial_data_tag =
       tmpl::conditional_t<is_analytic_solution_v<initial_data>,
@@ -681,19 +688,18 @@ struct GhValenciaDivCleanTemplateBase<
                        use_control_systems,
                        tmpl::list<::domain::creators::BinaryCompactObject>,
                        domain_creators<volume_dim>>>,
-        tmpl::pair<
-            Event,
-            tmpl::flatten<tmpl::list<
-                Events::Completion,
-                dg::Events::field_observations<volume_dim, observe_fields,
-                                               non_tensor_compute_tags>,
-                Events::ObserveAtExtremum<observe_fields,
-                                          non_tensor_compute_tags>,
-                Events::time_events<system>,
-                control_system::control_system_events<control_systems>,
-                intrp::Events::InterpolateWithoutInterpComponent<
-                    volume_dim, InterpolationTargetTags,
-                    interpolator_source_vars>...>>>,
+        tmpl::pair<Event,
+                   tmpl::flatten<tmpl::list<
+                       Events::Completion,
+                       dg::Events::field_observations<
+                           volume_dim, observe_fields, non_tensor_compute_tags>,
+                       Events::ObserveAtExtremum<observe_fields,
+                                                 non_tensor_compute_tags>,
+                       Events::time_events<system>,
+                       control_system::control_system_events<control_systems>,
+                       intrp::Events::InterpolateWithoutInterpComponent<
+                           volume_dim, InterpolationTargetTags,
+                           interpolator_source_vars>...>>>,
         tmpl::pair<
             grmhd::GhValenciaDivClean::BoundaryConditions::BoundaryCondition,
             boundary_conditions>,
@@ -711,7 +717,7 @@ struct GhValenciaDivCleanTemplateBase<
                     tmpl::conditional_t<
                         std::is_same_v<FukaInitialData, NoSuchType>,
                         tmpl::list<>, FukaInitialData>>>,
-                initial_data_list>>,
+                analytic_solutions_and_data_to_register>>,
         tmpl::pair<LtsTimeStepper, TimeSteppers::lts_time_steppers>,
         tmpl::pair<PhaseChange, PhaseControl::factory_creatable_classes>,
         tmpl::pair<StepChooser<StepChooserUse::LtsStep>,

--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
@@ -53,6 +53,7 @@
 #include "Evolution/Initialization/Evolution.hpp"
 #include "Evolution/Initialization/Limiter.hpp"
 #include "Evolution/Initialization/SetVariables.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/AllSolutions.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryConditions/Factory.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryCorrections/Factory.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryCorrections/RegisterDerived.hpp"
@@ -231,6 +232,8 @@ struct EvolutionMetavars<InitialData, tmpl::list<InterpolationTargetTags...>> {
       typename system::primitive_variables_tag::tags_list;
   using equation_of_state_tag =
       hydro::Tags::EquationOfState<equation_of_state_type>;
+  using initial_data_list =
+      grmhd::ValenciaDivClean::InitialData::initial_data_list;
   // Do not limit the divergence-cleaning field Phi
   using limiter = Tags::Limiter<
       Limiters::Minmod<3, tmpl::list<grmhd::ValenciaDivClean::Tags::TildeD,
@@ -299,7 +302,7 @@ struct EvolutionMetavars<InitialData, tmpl::list<InterpolationTargetTags...>> {
           hydro::Tags::SpatialVelocity<DataVector, volume_dim,
                                        Frame::Inertial>>,
       hydro::Tags::TransportVelocityCompute<DataVector, volume_dim,
-                                                               Frame::Inertial>,
+                                            Frame::Inertial>,
       grmhd::ValenciaDivClean::Tags::QuadrupoleMomentDerivativeCompute<
           DataVector, volume_dim,
           ::Events::Tags::ObserverCoordinates<volume_dim, Frame::Inertial>,
@@ -339,6 +342,7 @@ struct EvolutionMetavars<InitialData, tmpl::list<InterpolationTargetTags...>> {
                 Events::time_events<system>,
                 intrp::Events::InterpolateWithoutInterpComponent<
                     3, InterpolationTargetTags, interpolator_source_vars>...>>>,
+        tmpl::pair<evolution::initial_data::InitialData, initial_data_list>,
         tmpl::pair<
             grmhd::ValenciaDivClean::BoundaryConditions::BoundaryCondition,
             grmhd::ValenciaDivClean::BoundaryConditions::

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/AllSolutions.hpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/AllSolutions.hpp
@@ -1,0 +1,27 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "Evolution/Systems/GeneralizedHarmonic/AllSolutions.hpp"
+#include "Evolution/Systems/GrMhd/GhValenciaDivClean/Actions/SetInitialData.hpp"
+
+// Check if SpEC is linked and therefore we can load SpEC initial data
+#ifdef HAS_SPEC_EXPORTER
+#include "PointwiseFunctions/AnalyticData/GrMhd/SpecInitialData.hpp"
+using SpecInitialDataList = tmpl::list<grmhd::AnalyticData::SpecInitialData<1>,
+                                       grmhd::AnalyticData::SpecInitialData<2>>;
+#else
+using SpecInitialDataList = NoSuchType;
+#endif
+
+namespace ghmhd::GhValenciaDivClean::InitialData {
+// These are solutions that can be used for analytic prescriptions
+using analytic_solutions_and_data_list = gh::solutions_including_matter<3>;
+using initial_data_list = tmpl::flatten<tmpl::list<
+    analytic_solutions_and_data_list,
+    tmpl::flatten<tmpl::list<
+        grmhd::GhValenciaDivClean::NumericInitialData,
+        tmpl::conditional_t<std::is_same_v<SpecInitialDataList, NoSuchType>,
+                            tmpl::list<>, SpecInitialDataList>>>>>;
+}  // namespace ghmhd::GhValenciaDivClean::InitialData

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/BoundaryConditions/DirichletAnalytic.cpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/BoundaryConditions/DirichletAnalytic.cpp
@@ -6,22 +6,336 @@
 #include <cstddef>
 #include <memory>
 #include <pup.h>
+#include <string>
+#include <type_traits>
+#include <unordered_map>
 
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/Tags.hpp"
+#include "Domain/ElementMap.hpp"
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "Domain/FunctionsOfTime/Tags.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Tags.hpp"
+#include "Evolution/BoundaryConditions/Type.hpp"
+#include "Evolution/DgSubcell/GhostZoneLogicalCoordinates.hpp"
+#include "Evolution/DgSubcell/SliceTensor.hpp"
+#include "Evolution/DgSubcell/Tags/Coordinates.hpp"
+#include "Evolution/DgSubcell/Tags/Mesh.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/Tags.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
+#include "Evolution/Systems/GrMhd/GhValenciaDivClean/AllSolutions.hpp"
+#include "Evolution/Systems/GrMhd/GhValenciaDivClean/BoundaryConditions/BoundaryCondition.hpp"
+#include "Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/Factory.hpp"
+#include "Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/Reconstructor.hpp"
+#include "Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/Tag.hpp"
+#include "Evolution/Systems/GrMhd/GhValenciaDivClean/Tags.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/ConservativeFromPrimitive.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/Fluxes.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/Tags.hpp"
+#include "Evolution/TypeTraits.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "Options/String.hpp"
+#include "PointwiseFunctions/AnalyticData/AnalyticData.hpp"
+#include "PointwiseFunctions/AnalyticData/Tags.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/AnalyticSolution.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "PointwiseFunctions/Hydro/Tags.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Serialization/CharmPupable.hpp"
+#include "Utilities/TMPL.hpp"
 
 namespace grmhd::GhValenciaDivClean::BoundaryConditions {
 // LCOV_EXCL_START
 DirichletAnalytic::DirichletAnalytic(CkMigrateMessage* const msg)
     : BoundaryCondition(msg) {}
 // LCOV_EXCL_STOP
+DirichletAnalytic::DirichletAnalytic(const DirichletAnalytic& rhs)
+    : BoundaryCondition{dynamic_cast<const BoundaryCondition&>(rhs)},
+      analytic_prescription_(rhs.analytic_prescription_->get_clone()) {}
+
+DirichletAnalytic& DirichletAnalytic::operator=(const DirichletAnalytic& rhs) {
+  if (&rhs == this) {
+    return *this;
+  }
+  analytic_prescription_ = rhs.analytic_prescription_->get_clone();
+  return *this;
+}
+
+DirichletAnalytic::DirichletAnalytic(
+    std::unique_ptr<evolution::initial_data::InitialData> analytic_prescription)
+    : analytic_prescription_(std::move(analytic_prescription)) {}
 
 std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
 DirichletAnalytic::get_clone() const {
   return std::make_unique<DirichletAnalytic>(*this);
 }
 
-void DirichletAnalytic::pup(PUP::er& p) { BoundaryCondition::pup(p); }
-
+void DirichletAnalytic::pup(PUP::er& p) {
+  BoundaryCondition::pup(p);
+  p | analytic_prescription_;
+}
 // NOLINTNEXTLINE
 PUP::able::PUP_ID DirichletAnalytic::my_PUP_ID = 0;
+
+std::optional<std::string> DirichletAnalytic::dg_ghost(
+    const gsl::not_null<tnsr::aa<DataVector, 3, Frame::Inertial>*>
+        spacetime_metric,
+    const gsl::not_null<tnsr::aa<DataVector, 3, Frame::Inertial>*> pi,
+    const gsl::not_null<tnsr::iaa<DataVector, 3, Frame::Inertial>*> phi,
+    const gsl::not_null<Scalar<DataVector>*> tilde_d,
+    const gsl::not_null<Scalar<DataVector>*> tilde_ye,
+    const gsl::not_null<Scalar<DataVector>*> tilde_tau,
+    const gsl::not_null<tnsr::i<DataVector, 3, Frame::Inertial>*> tilde_s,
+    const gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> tilde_b,
+    const gsl::not_null<Scalar<DataVector>*> tilde_phi,
+
+    const gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> tilde_d_flux,
+    const gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> tilde_ye_flux,
+    const gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*>
+        tilde_tau_flux,
+    const gsl::not_null<tnsr::Ij<DataVector, 3, Frame::Inertial>*> tilde_s_flux,
+    const gsl::not_null<tnsr::IJ<DataVector, 3, Frame::Inertial>*> tilde_b_flux,
+    const gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*>
+        tilde_phi_flux,
+
+    const gsl::not_null<Scalar<DataVector>*> gamma1,
+    const gsl::not_null<Scalar<DataVector>*> gamma2,
+    const gsl::not_null<Scalar<DataVector>*> lapse,
+    const gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> shift,
+    const gsl::not_null<tnsr::II<DataVector, 3, Frame::Inertial>*>
+        inv_spatial_metric,
+
+    const std::optional<
+        tnsr::I<DataVector, 3, Frame::Inertial>>& /*face_mesh_velocity*/,
+    const tnsr::i<DataVector, 3, Frame::Inertial>& /*normal_covector*/,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& /*normal_vector*/,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& coords,
+    const Scalar<DataVector>& interior_gamma1,
+    const Scalar<DataVector>& interior_gamma2,
+    [[maybe_unused]] const double time) const {
+  *gamma1 = interior_gamma1;
+  *gamma2 = interior_gamma2;
+
+  auto boundary_values = call_with_dynamic_type<
+      tuples::TaggedTuple<
+          hydro::Tags::RestMassDensity<DataVector>,
+          hydro::Tags::ElectronFraction<DataVector>,
+          hydro::Tags::SpecificInternalEnergy<DataVector>,
+          hydro::Tags::SpecificEnthalpy<DataVector>,
+          hydro::Tags::Pressure<DataVector>,
+          hydro::Tags::SpatialVelocity<DataVector, 3>,
+          hydro::Tags::LorentzFactor<DataVector>,
+          hydro::Tags::MagneticField<DataVector, 3>,
+          hydro::Tags::DivergenceCleaningField<DataVector>,
+          gr::Tags::SpatialMetric<DataVector, 3>,
+          gr::Tags::InverseSpatialMetric<DataVector, 3>,
+          gr::Tags::SqrtDetSpatialMetric<DataVector>,
+          gr::Tags::Lapse<DataVector>, gr::Tags::Shift<DataVector, 3>,
+          gr::Tags::SpacetimeMetric<DataVector, 3>,
+          ::gh::Tags::Pi<DataVector, 3>, ::gh::Tags::Phi<DataVector, 3>>,
+      ghmhd::GhValenciaDivClean::InitialData::analytic_solutions_and_data_list>(
+      analytic_prescription_.get(),
+      [&coords, &time](const auto* const initial_data) {
+        if constexpr (is_analytic_solution_v<
+                          std::decay_t<decltype(*initial_data)>>) {
+          return initial_data->variables(
+              coords, time,
+              tmpl::list<hydro::Tags::RestMassDensity<DataVector>,
+                         hydro::Tags::ElectronFraction<DataVector>,
+                         hydro::Tags::SpecificInternalEnergy<DataVector>,
+                         hydro::Tags::SpecificEnthalpy<DataVector>,
+                         hydro::Tags::Pressure<DataVector>,
+                         hydro::Tags::SpatialVelocity<DataVector, 3>,
+                         hydro::Tags::LorentzFactor<DataVector>,
+                         hydro::Tags::MagneticField<DataVector, 3>,
+                         hydro::Tags::DivergenceCleaningField<DataVector>,
+                         gr::Tags::SpatialMetric<DataVector, 3>,
+                         gr::Tags::InverseSpatialMetric<DataVector, 3>,
+                         gr::Tags::SqrtDetSpatialMetric<DataVector>,
+                         gr::Tags::Lapse<DataVector>,
+                         gr::Tags::Shift<DataVector, 3>,
+                         gr::Tags::SpacetimeMetric<DataVector, 3>,
+                         ::gh::Tags::Pi<DataVector, 3>,
+                         ::gh::Tags::Phi<DataVector, 3>>{});
+
+        } else if constexpr (evolution::is_numeric_initial_data_v<
+                                 std::decay_t<decltype(*initial_data)>>) {
+          ERROR(
+              "Cannot currently use numeric initial data as an analytic "
+              "prescription in boundary conditions.");
+        } else {
+          (void)time;
+          return initial_data->variables(
+              coords,
+              tmpl::list<hydro::Tags::RestMassDensity<DataVector>,
+                         hydro::Tags::ElectronFraction<DataVector>,
+                         hydro::Tags::SpecificInternalEnergy<DataVector>,
+                         hydro::Tags::SpecificEnthalpy<DataVector>,
+                         hydro::Tags::Pressure<DataVector>,
+                         hydro::Tags::SpatialVelocity<DataVector, 3>,
+                         hydro::Tags::LorentzFactor<DataVector>,
+                         hydro::Tags::MagneticField<DataVector, 3>,
+                         hydro::Tags::DivergenceCleaningField<DataVector>,
+                         gr::Tags::SpatialMetric<DataVector, 3>,
+                         gr::Tags::InverseSpatialMetric<DataVector, 3>,
+                         gr::Tags::SqrtDetSpatialMetric<DataVector>,
+                         gr::Tags::Lapse<DataVector>,
+                         gr::Tags::Shift<DataVector, 3>,
+                         gr::Tags::SpacetimeMetric<DataVector, 3>,
+                         ::gh::Tags::Pi<DataVector, 3>,
+                         ::gh::Tags::Phi<DataVector, 3>>{});
+        }
+      });
+
+  *spacetime_metric =
+      get<gr::Tags::SpacetimeMetric<DataVector, 3>>(boundary_values);
+  *pi = get<::gh::Tags::Pi<DataVector, 3>>(boundary_values);
+  *phi = get<::gh::Tags::Phi<DataVector, 3>>(boundary_values);
+  *lapse = get<gr::Tags::Lapse<DataVector>>(boundary_values);
+  *shift = get<gr::Tags::Shift<DataVector, 3>>(boundary_values);
+  *inv_spatial_metric =
+      get<gr::Tags::InverseSpatialMetric<DataVector, 3>>(boundary_values);
+
+  grmhd::ValenciaDivClean::ConservativeFromPrimitive::apply(
+      tilde_d, tilde_ye, tilde_tau, tilde_s, tilde_b, tilde_phi,
+      get<hydro::Tags::RestMassDensity<DataVector>>(boundary_values),
+      get<hydro::Tags::ElectronFraction<DataVector>>(boundary_values),
+      get<hydro::Tags::SpecificInternalEnergy<DataVector>>(boundary_values),
+      get<hydro::Tags::Pressure<DataVector>>(boundary_values),
+      get<hydro::Tags::SpatialVelocity<DataVector, 3>>(boundary_values),
+      get<hydro::Tags::LorentzFactor<DataVector>>(boundary_values),
+      get<hydro::Tags::MagneticField<DataVector, 3>>(boundary_values),
+      get<gr::Tags::SqrtDetSpatialMetric<DataVector>>(boundary_values),
+      get<gr::Tags::SpatialMetric<DataVector, 3>>(boundary_values),
+      get<hydro::Tags::DivergenceCleaningField<DataVector>>(boundary_values));
+
+  grmhd::ValenciaDivClean::ComputeFluxes::apply(
+      tilde_d_flux, tilde_ye_flux, tilde_tau_flux, tilde_s_flux, tilde_b_flux,
+      tilde_phi_flux, *tilde_d, *tilde_ye, *tilde_tau, *tilde_s, *tilde_b,
+      *tilde_phi, *lapse, *shift,
+      get<gr::Tags::SqrtDetSpatialMetric<DataVector>>(boundary_values),
+      get<gr::Tags::SpatialMetric<DataVector, 3>>(boundary_values),
+      get<gr::Tags::InverseSpatialMetric<DataVector, 3>>(boundary_values),
+      get<hydro::Tags::Pressure<DataVector>>(boundary_values),
+      get<hydro::Tags::SpatialVelocity<DataVector, 3>>(boundary_values),
+      get<hydro::Tags::LorentzFactor<DataVector>>(boundary_values),
+      get<hydro::Tags::MagneticField<DataVector, 3>>(boundary_values));
+
+  return {};
+}
+
+void DirichletAnalytic::fd_ghost(
+    const gsl::not_null<tnsr::aa<DataVector, 3, Frame::Inertial>*>
+        spacetime_metric,
+    const gsl::not_null<tnsr::aa<DataVector, 3, Frame::Inertial>*> pi,
+    const gsl::not_null<tnsr::iaa<DataVector, 3, Frame::Inertial>*> phi,
+    const gsl::not_null<Scalar<DataVector>*> rest_mass_density,
+    const gsl::not_null<Scalar<DataVector>*> electron_fraction,
+    const gsl::not_null<Scalar<DataVector>*> temperature,
+    const gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*>
+        lorentz_factor_times_spatial_velocity,
+    const gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*>
+        magnetic_field,
+    const gsl::not_null<Scalar<DataVector>*> divergence_cleaning_field,
+    const Direction<3>& direction,
+
+    // fd_interior_temporary_tags
+    const Mesh<3>& subcell_mesh,
+
+    // fd_gridless_tags
+    const double time,
+    const std::unordered_map<
+        std::string,
+        std::unique_ptr<::domain::FunctionsOfTime::FunctionOfTime>>&
+        functions_of_time,
+    const ElementMap<3, Frame::Grid>& logical_to_grid_map,
+    const domain::CoordinateMapBase<Frame::Grid, Frame::Inertial, 3>&
+        grid_to_inertial_map,
+    const fd::Reconstructor& reconstructor) const {
+  const size_t ghost_zone_size{reconstructor.ghost_zone_size()};
+
+  const auto ghost_logical_coords =
+      evolution::dg::subcell::fd::ghost_zone_logical_coordinates(
+          subcell_mesh, ghost_zone_size, direction);
+
+  const auto ghost_inertial_coords = grid_to_inertial_map(
+      logical_to_grid_map(ghost_logical_coords), time, functions_of_time);
+
+  // Compute FD ghost data with the analytic data or solution
+  auto boundary_values = call_with_dynamic_type<
+      tuples::TaggedTuple<hydro::Tags::RestMassDensity<DataVector>,
+                          hydro::Tags::ElectronFraction<DataVector>,
+                          hydro::Tags::SpecificInternalEnergy<DataVector>,
+                          hydro::Tags::SpecificEnthalpy<DataVector>,
+                          hydro::Tags::Temperature<DataVector>,
+                          hydro::Tags::SpatialVelocity<DataVector, 3>,
+                          hydro::Tags::LorentzFactor<DataVector>,
+                          hydro::Tags::MagneticField<DataVector, 3>,
+                          hydro::Tags::DivergenceCleaningField<DataVector>,
+                          gr::Tags::SpacetimeMetric<DataVector, 3>,
+                          ::gh::Tags::Pi<DataVector, 3>,
+                          ::gh::Tags::Phi<DataVector, 3>>,
+      ghmhd::GhValenciaDivClean::InitialData::analytic_solutions_and_data_list>(
+      analytic_prescription_.get(),
+      [&ghost_inertial_coords, &time](const auto* const initial_data) {
+        using hydro_and_spacetime_tags =
+            tmpl::list<hydro::Tags::RestMassDensity<DataVector>,
+                       hydro::Tags::ElectronFraction<DataVector>,
+                       hydro::Tags::SpecificInternalEnergy<DataVector>,
+                       hydro::Tags::SpecificEnthalpy<DataVector>,
+                       hydro::Tags::Temperature<DataVector>,
+                       hydro::Tags::SpatialVelocity<DataVector, 3>,
+                       hydro::Tags::LorentzFactor<DataVector>,
+                       hydro::Tags::MagneticField<DataVector, 3>,
+                       hydro::Tags::DivergenceCleaningField<DataVector>,
+                       gr::Tags::SpacetimeMetric<DataVector, 3>,
+                       ::gh::Tags::Pi<DataVector, 3>,
+                       ::gh::Tags::Phi<DataVector, 3>>;
+        if constexpr (is_analytic_solution_v<
+                          std::decay_t<decltype(*initial_data)>>) {
+          return initial_data->variables(ghost_inertial_coords, time,
+                                         hydro_and_spacetime_tags{});
+        } else if constexpr (evolution::is_numeric_initial_data_v<
+                                 std::decay_t<decltype(*initial_data)>>) {
+          ERROR(
+              "Cannot currently use numeric initial data as an analytic "
+              "prescription for boundary conditions.");
+        } else {
+          (void)time;
+          return initial_data->variables(ghost_inertial_coords,
+                                         hydro_and_spacetime_tags{});
+        }
+      });
+  *spacetime_metric =
+      get<gr::Tags::SpacetimeMetric<DataVector, 3>>(boundary_values);
+  *pi = get<::gh::Tags::Pi<DataVector, 3>>(boundary_values);
+  *phi = get<::gh::Tags::Phi<DataVector, 3>>(boundary_values);
+  *rest_mass_density =
+      get<hydro::Tags::RestMassDensity<DataVector>>(boundary_values);
+  *electron_fraction =
+      get<hydro::Tags::ElectronFraction<DataVector>>(boundary_values);
+  *temperature = get<hydro::Tags::Temperature<DataVector>>(boundary_values);
+
+  for (size_t i = 0; i < 3; ++i) {
+    auto& lorentz_factor =
+        get<hydro::Tags::LorentzFactor<DataVector>>(boundary_values);
+    auto& spatial_velocity =
+        get<hydro::Tags::SpatialVelocity<DataVector, 3>>(boundary_values);
+    (*lorentz_factor_times_spatial_velocity).get(i) =
+        get(lorentz_factor) * spatial_velocity.get(i);
+  }
+
+  *magnetic_field =
+      get<hydro::Tags::MagneticField<DataVector, 3>>(boundary_values);
+  *divergence_cleaning_field =
+      get<hydro::Tags::DivergenceCleaningField<DataVector>>(boundary_values);
+}
+
 }  // namespace grmhd::GhValenciaDivClean::BoundaryConditions

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/BoundaryConditions/DirichletAnalytic.hpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/BoundaryConditions/DirichletAnalytic.hpp
@@ -13,7 +13,6 @@
 #include "DataStructures/DataBox/Prefixes.hpp"
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
-#include "DataStructures/Variables.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/Tags.hpp"
 #include "Domain/ElementMap.hpp"
@@ -28,6 +27,7 @@
 #include "Evolution/DgSubcell/Tags/Mesh.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/Tags.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
+#include "Evolution/Systems/GrMhd/GhValenciaDivClean/AllSolutions.hpp"
 #include "Evolution/Systems/GrMhd/GhValenciaDivClean/BoundaryConditions/BoundaryCondition.hpp"
 #include "Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/Factory.hpp"
 #include "Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/Reconstructor.hpp"
@@ -36,13 +36,11 @@
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/ConservativeFromPrimitive.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/Fluxes.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/Tags.hpp"
+#include "Evolution/TypeTraits.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "Options/String.hpp"
-#include "PointwiseFunctions/AnalyticData/AnalyticData.hpp"
-#include "PointwiseFunctions/AnalyticData/Tags.hpp"
-#include "PointwiseFunctions/AnalyticSolutions/AnalyticSolution.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
-#include "PointwiseFunctions/Hydro/Tags.hpp"
+#include "PointwiseFunctions/InitialDataUtilities/InitialData.hpp"
 #include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/Serialization/CharmPupable.hpp"
@@ -65,7 +63,13 @@ namespace grmhd::GhValenciaDivClean::BoundaryConditions {
  */
 class DirichletAnalytic final : public BoundaryCondition {
  public:
-  using options = tmpl::list<>;
+  /// \brief What analytic solution/data to prescribe.
+  struct AnalyticPrescription {
+    static constexpr Options::String help =
+        "What analytic solution/data to prescribe.";
+    using type = std::unique_ptr<evolution::initial_data::InitialData>;
+  };
+  using options = tmpl::list<AnalyticPrescription>;
   static constexpr Options::String help{
       "DirichletAnalytic boundary conditions using either analytic solution or "
       "analytic data."};
@@ -73,11 +77,15 @@ class DirichletAnalytic final : public BoundaryCondition {
   DirichletAnalytic() = default;
   DirichletAnalytic(DirichletAnalytic&&) = default;
   DirichletAnalytic& operator=(DirichletAnalytic&&) = default;
-  DirichletAnalytic(const DirichletAnalytic&) = default;
-  DirichletAnalytic& operator=(const DirichletAnalytic&) = default;
+  DirichletAnalytic(const DirichletAnalytic&);
+  DirichletAnalytic& operator=(const DirichletAnalytic&);
   ~DirichletAnalytic() override = default;
 
   explicit DirichletAnalytic(CkMigrateMessage* msg);
+
+  explicit DirichletAnalytic(
+      std::unique_ptr<evolution::initial_data::InitialData>
+          analytic_prescription);
 
   WRAPPED_PUPable_decl_base_template(
       domain::BoundaryConditions::BoundaryCondition, DirichletAnalytic);
@@ -96,40 +104,31 @@ class DirichletAnalytic final : public BoundaryCondition {
                  ::gh::ConstraintDamping::Tags::ConstraintGamma1,
                  ::gh::ConstraintDamping::Tags::ConstraintGamma2>;
   using dg_interior_primitive_variables_tags = tmpl::list<>;
-  using dg_gridless_tags = tmpl::list<
-      ::Tags::Time, ::Tags::AnalyticSolutionOrData>;
+  using dg_gridless_tags = tmpl::list<::Tags::Time>;
 
-  template <typename AnalyticSolutionOrData>
   std::optional<std::string> dg_ghost(
-      const gsl::not_null<tnsr::aa<DataVector, 3, Frame::Inertial>*>
-          spacetime_metric,
-      const gsl::not_null<tnsr::aa<DataVector, 3, Frame::Inertial>*> pi,
-      const gsl::not_null<tnsr::iaa<DataVector, 3, Frame::Inertial>*> phi,
-      const gsl::not_null<Scalar<DataVector>*> tilde_d,
-      const gsl::not_null<Scalar<DataVector>*> tilde_ye,
-      const gsl::not_null<Scalar<DataVector>*> tilde_tau,
-      const gsl::not_null<tnsr::i<DataVector, 3, Frame::Inertial>*> tilde_s,
-      const gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> tilde_b,
-      const gsl::not_null<Scalar<DataVector>*> tilde_phi,
+      gsl::not_null<tnsr::aa<DataVector, 3, Frame::Inertial>*> spacetime_metric,
+      gsl::not_null<tnsr::aa<DataVector, 3, Frame::Inertial>*> pi,
+      gsl::not_null<tnsr::iaa<DataVector, 3, Frame::Inertial>*> phi,
+      gsl::not_null<Scalar<DataVector>*> tilde_d,
+      gsl::not_null<Scalar<DataVector>*> tilde_ye,
+      gsl::not_null<Scalar<DataVector>*> tilde_tau,
+      gsl::not_null<tnsr::i<DataVector, 3, Frame::Inertial>*> tilde_s,
+      gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> tilde_b,
+      gsl::not_null<Scalar<DataVector>*> tilde_phi,
 
-      const gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*>
-          tilde_d_flux,
-      const gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*>
-          tilde_ye_flux,
-      const gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*>
-          tilde_tau_flux,
-      const gsl::not_null<tnsr::Ij<DataVector, 3, Frame::Inertial>*>
-          tilde_s_flux,
-      const gsl::not_null<tnsr::IJ<DataVector, 3, Frame::Inertial>*>
-          tilde_b_flux,
-      const gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*>
-          tilde_phi_flux,
+      gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> tilde_d_flux,
+      gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> tilde_ye_flux,
+      gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> tilde_tau_flux,
+      gsl::not_null<tnsr::Ij<DataVector, 3, Frame::Inertial>*> tilde_s_flux,
+      gsl::not_null<tnsr::IJ<DataVector, 3, Frame::Inertial>*> tilde_b_flux,
+      gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> tilde_phi_flux,
 
-      const gsl::not_null<Scalar<DataVector>*> gamma1,
-      const gsl::not_null<Scalar<DataVector>*> gamma2,
-      const gsl::not_null<Scalar<DataVector>*> lapse,
-      const gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> shift,
-      const gsl::not_null<tnsr::II<DataVector, 3, Frame::Inertial>*>
+      gsl::not_null<Scalar<DataVector>*> gamma1,
+      gsl::not_null<Scalar<DataVector>*> gamma2,
+      gsl::not_null<Scalar<DataVector>*> lapse,
+      gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> shift,
+      gsl::not_null<tnsr::II<DataVector, 3, Frame::Inertial>*>
           inv_spatial_metric,
 
       const std::optional<
@@ -138,92 +137,8 @@ class DirichletAnalytic final : public BoundaryCondition {
       const tnsr::I<DataVector, 3, Frame::Inertial>& /*normal_vector*/,
       const tnsr::I<DataVector, 3, Frame::Inertial>& coords,
       const Scalar<DataVector>& interior_gamma1,
-      const Scalar<DataVector>& interior_gamma2, const double time,
-      const AnalyticSolutionOrData& analytic_solution_or_data) const {
-    *gamma1 = interior_gamma1;
-    *gamma2 = interior_gamma2;
-
-    auto boundary_values = [&analytic_solution_or_data, &coords, &time]() {
-      if constexpr (is_analytic_solution_v<AnalyticSolutionOrData>) {
-        return analytic_solution_or_data.variables(
-            coords, time,
-            tmpl::list<hydro::Tags::RestMassDensity<DataVector>,
-                       hydro::Tags::ElectronFraction<DataVector>,
-                       hydro::Tags::SpecificInternalEnergy<DataVector>,
-                       hydro::Tags::SpecificEnthalpy<DataVector>,
-                       hydro::Tags::Pressure<DataVector>,
-                       hydro::Tags::SpatialVelocity<DataVector, 3>,
-                       hydro::Tags::LorentzFactor<DataVector>,
-                       hydro::Tags::MagneticField<DataVector, 3>,
-                       hydro::Tags::DivergenceCleaningField<DataVector>,
-                       gr::Tags::SpatialMetric<DataVector, 3>,
-                       gr::Tags::InverseSpatialMetric<DataVector, 3>,
-                       gr::Tags::SqrtDetSpatialMetric<DataVector>,
-                       gr::Tags::Lapse<DataVector>,
-                       gr::Tags::Shift<DataVector, 3>,
-                       gr::Tags::SpacetimeMetric<DataVector, 3>,
-                       ::gh::Tags::Pi<DataVector, 3>,
-                       ::gh::Tags::Phi<DataVector, 3>>{});
-
-      } else {
-        (void)time;
-        return analytic_solution_or_data.variables(
-            coords, tmpl::list<hydro::Tags::RestMassDensity<DataVector>,
-                               hydro::Tags::ElectronFraction<DataVector>,
-                               hydro::Tags::SpecificInternalEnergy<DataVector>,
-                               hydro::Tags::SpecificEnthalpy<DataVector>,
-                               hydro::Tags::Pressure<DataVector>,
-                               hydro::Tags::SpatialVelocity<DataVector, 3>,
-                               hydro::Tags::LorentzFactor<DataVector>,
-                               hydro::Tags::MagneticField<DataVector, 3>,
-                               hydro::Tags::DivergenceCleaningField<DataVector>,
-                               gr::Tags::SpatialMetric<DataVector, 3>,
-                               gr::Tags::InverseSpatialMetric<DataVector, 3>,
-                               gr::Tags::SqrtDetSpatialMetric<DataVector>,
-                               gr::Tags::Lapse<DataVector>,
-                               gr::Tags::Shift<DataVector, 3>,
-                               gr::Tags::SpacetimeMetric<DataVector, 3>,
-                               ::gh::Tags::Pi<DataVector, 3>,
-                               ::gh::Tags::Phi<DataVector, 3>>{});
-      }
-    }();
-
-    *spacetime_metric =
-        get<gr::Tags::SpacetimeMetric<DataVector, 3>>(boundary_values);
-    *pi = get<::gh::Tags::Pi<DataVector, 3>>(boundary_values);
-    *phi = get<::gh::Tags::Phi<DataVector, 3>>(boundary_values);
-    *lapse = get<gr::Tags::Lapse<DataVector>>(boundary_values);
-    *shift = get<gr::Tags::Shift<DataVector, 3>>(boundary_values);
-    *inv_spatial_metric =
-        get<gr::Tags::InverseSpatialMetric<DataVector, 3>>(boundary_values);
-
-    grmhd::ValenciaDivClean::ConservativeFromPrimitive::apply(
-        tilde_d, tilde_ye, tilde_tau, tilde_s, tilde_b, tilde_phi,
-        get<hydro::Tags::RestMassDensity<DataVector>>(boundary_values),
-        get<hydro::Tags::ElectronFraction<DataVector>>(boundary_values),
-        get<hydro::Tags::SpecificInternalEnergy<DataVector>>(boundary_values),
-        get<hydro::Tags::Pressure<DataVector>>(boundary_values),
-        get<hydro::Tags::SpatialVelocity<DataVector, 3>>(boundary_values),
-        get<hydro::Tags::LorentzFactor<DataVector>>(boundary_values),
-        get<hydro::Tags::MagneticField<DataVector, 3>>(boundary_values),
-        get<gr::Tags::SqrtDetSpatialMetric<DataVector>>(boundary_values),
-        get<gr::Tags::SpatialMetric<DataVector, 3>>(boundary_values),
-        get<hydro::Tags::DivergenceCleaningField<DataVector>>(boundary_values));
-
-    grmhd::ValenciaDivClean::ComputeFluxes::apply(
-        tilde_d_flux, tilde_ye_flux, tilde_tau_flux, tilde_s_flux, tilde_b_flux,
-        tilde_phi_flux, *tilde_d, *tilde_ye, *tilde_tau, *tilde_s, *tilde_b,
-        *tilde_phi, *lapse, *shift,
-        get<gr::Tags::SqrtDetSpatialMetric<DataVector>>(boundary_values),
-        get<gr::Tags::SpatialMetric<DataVector, 3>>(boundary_values),
-        get<gr::Tags::InverseSpatialMetric<DataVector, 3>>(boundary_values),
-        get<hydro::Tags::Pressure<DataVector>>(boundary_values),
-        get<hydro::Tags::SpatialVelocity<DataVector, 3>>(boundary_values),
-        get<hydro::Tags::LorentzFactor<DataVector>>(boundary_values),
-        get<hydro::Tags::MagneticField<DataVector, 3>>(boundary_values));
-
-    return {};
-  }
+      const Scalar<DataVector>& interior_gamma2,
+      [[maybe_unused]] double time) const;
 
   using fd_interior_evolved_variables_tags = tmpl::list<>;
   using fd_interior_temporary_tags =
@@ -234,29 +149,25 @@ class DirichletAnalytic final : public BoundaryCondition {
                  domain::Tags::ElementMap<3, Frame::Grid>,
                  domain::CoordinateMaps::Tags::CoordinateMap<3, Frame::Grid,
                                                              Frame::Inertial>,
-                 fd::Tags::Reconstructor, ::Tags::AnalyticSolutionOrData>;
-
-  template <typename AnalyticSolutionOrData>
+                 fd::Tags::Reconstructor>;
   void fd_ghost(
-      const gsl::not_null<tnsr::aa<DataVector, 3, Frame::Inertial>*>
-          spacetime_metric,
-      const gsl::not_null<tnsr::aa<DataVector, 3, Frame::Inertial>*> pi,
-      const gsl::not_null<tnsr::iaa<DataVector, 3, Frame::Inertial>*> phi,
-      const gsl::not_null<Scalar<DataVector>*> rest_mass_density,
-      const gsl::not_null<Scalar<DataVector>*> electron_fraction,
-      const gsl::not_null<Scalar<DataVector>*> temperature,
-      const gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*>
+      gsl::not_null<tnsr::aa<DataVector, 3, Frame::Inertial>*> spacetime_metric,
+      gsl::not_null<tnsr::aa<DataVector, 3, Frame::Inertial>*> pi,
+      gsl::not_null<tnsr::iaa<DataVector, 3, Frame::Inertial>*> phi,
+      gsl::not_null<Scalar<DataVector>*> rest_mass_density,
+      gsl::not_null<Scalar<DataVector>*> electron_fraction,
+      gsl::not_null<Scalar<DataVector>*> temperature,
+      gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*>
           lorentz_factor_times_spatial_velocity,
-      const gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*>
-          magnetic_field,
-      const gsl::not_null<Scalar<DataVector>*> divergence_cleaning_field,
+      gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> magnetic_field,
+      gsl::not_null<Scalar<DataVector>*> divergence_cleaning_field,
       const Direction<3>& direction,
 
       // fd_interior_temporary_tags
-      const Mesh<3> subcell_mesh,
+      const Mesh<3>& subcell_mesh,
 
       // fd_gridless_tags
-      const double time,
+      double time,
       const std::unordered_map<
           std::string,
           std::unique_ptr<::domain::FunctionsOfTime::FunctionOfTime>>&
@@ -264,76 +175,9 @@ class DirichletAnalytic final : public BoundaryCondition {
       const ElementMap<3, Frame::Grid>& logical_to_grid_map,
       const domain::CoordinateMapBase<Frame::Grid, Frame::Inertial, 3>&
           grid_to_inertial_map,
-      const fd::Reconstructor& reconstructor,
-      const AnalyticSolutionOrData& analytic_solution_or_data) const {
-    const size_t ghost_zone_size{reconstructor.ghost_zone_size()};
+      const fd::Reconstructor& reconstructor) const;
 
-    const auto ghost_logical_coords =
-        evolution::dg::subcell::fd::ghost_zone_logical_coordinates(
-            subcell_mesh, ghost_zone_size, direction);
-
-    const auto ghost_inertial_coords = grid_to_inertial_map(
-        logical_to_grid_map(ghost_logical_coords), time, functions_of_time);
-
-    // Compute FD ghost data with the analytic data or solution
-    auto boundary_values = [&analytic_solution_or_data, &ghost_inertial_coords,
-                            &time]() {
-      if constexpr (std::is_base_of_v<MarkAsAnalyticData,
-                                      AnalyticSolutionOrData>) {
-        (void)time;
-        return analytic_solution_or_data.variables(
-            ghost_inertial_coords,
-            tmpl::list<hydro::Tags::RestMassDensity<DataVector>,
-                       hydro::Tags::ElectronFraction<DataVector>,
-                       hydro::Tags::Pressure<DataVector>,
-                       hydro::Tags::Temperature<DataVector>,
-                       hydro::Tags::SpatialVelocity<DataVector, 3>,
-                       hydro::Tags::LorentzFactor<DataVector>,
-                       hydro::Tags::MagneticField<DataVector, 3>,
-                       hydro::Tags::DivergenceCleaningField<DataVector>,
-                       gr::Tags::SpacetimeMetric<DataVector, 3>,
-                       ::gh::Tags::Pi<DataVector, 3>,
-                       ::gh::Tags::Phi<DataVector, 3>>{});
-      } else {
-        return analytic_solution_or_data.variables(
-            ghost_inertial_coords, time,
-            tmpl::list<hydro::Tags::RestMassDensity<DataVector>,
-                       hydro::Tags::ElectronFraction<DataVector>,
-                       hydro::Tags::Pressure<DataVector>,
-                       hydro::Tags::Temperature<DataVector>,
-                       hydro::Tags::SpatialVelocity<DataVector, 3>,
-                       hydro::Tags::LorentzFactor<DataVector>,
-                       hydro::Tags::MagneticField<DataVector, 3>,
-                       hydro::Tags::DivergenceCleaningField<DataVector>,
-                       gr::Tags::SpacetimeMetric<DataVector, 3>,
-                       ::gh::Tags::Pi<DataVector, 3>,
-                       ::gh::Tags::Phi<DataVector, 3>>{});
-      }
-    }();
-
-    *spacetime_metric =
-        get<gr::Tags::SpacetimeMetric<DataVector, 3>>(boundary_values);
-    *pi = get<::gh::Tags::Pi<DataVector, 3>>(boundary_values);
-    *phi = get<::gh::Tags::Phi<DataVector, 3>>(boundary_values);
-    *rest_mass_density =
-        get<hydro::Tags::RestMassDensity<DataVector>>(boundary_values);
-    *electron_fraction =
-        get<hydro::Tags::ElectronFraction<DataVector>>(boundary_values);
-    *temperature = get<hydro::Tags::Temperature<DataVector>>(boundary_values);
-
-    for (size_t i = 0; i < 3; ++i) {
-      auto& lorentz_factor =
-          get<hydro::Tags::LorentzFactor<DataVector>>(boundary_values);
-      auto& spatial_velocity =
-          get<hydro::Tags::SpatialVelocity<DataVector, 3>>(boundary_values);
-      (*lorentz_factor_times_spatial_velocity).get(i) =
-          get(lorentz_factor) * spatial_velocity.get(i);
-    }
-
-    *magnetic_field =
-        get<hydro::Tags::MagneticField<DataVector, 3>>(boundary_values);
-    *divergence_cleaning_field =
-        get<hydro::Tags::DivergenceCleaningField<DataVector>>(boundary_values);
-  }
+ private:
+  std::unique_ptr<evolution::initial_data::InitialData> analytic_prescription_;
 };
 }  // namespace grmhd::GhValenciaDivClean::BoundaryConditions

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/BoundaryConditions/DirichletFreeOutflow.cpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/BoundaryConditions/DirichletFreeOutflow.cpp
@@ -5,21 +5,315 @@
 
 #include <cstddef>
 #include <memory>
+#include <optional>
 #include <pup.h>
+#include <string>
+#include <type_traits>
+#include <unordered_map>
+
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/Tags.hpp"
+#include "Domain/ElementMap.hpp"
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "Domain/FunctionsOfTime/Tags.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Tags.hpp"
+#include "Evolution/BoundaryConditions/Type.hpp"
+#include "Evolution/DgSubcell/GhostZoneLogicalCoordinates.hpp"
+#include "Evolution/DgSubcell/SliceTensor.hpp"
+#include "Evolution/DgSubcell/Tags/Coordinates.hpp"
+#include "Evolution/DgSubcell/Tags/Mesh.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/Tags.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
+#include "Evolution/Systems/GrMhd/GhValenciaDivClean/AllSolutions.hpp"
+#include "Evolution/Systems/GrMhd/GhValenciaDivClean/BoundaryConditions/BoundaryCondition.hpp"
+#include "Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/Factory.hpp"
+#include "Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/Reconstructor.hpp"
+#include "Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/Tag.hpp"
+#include "Evolution/Systems/GrMhd/GhValenciaDivClean/Tags.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryConditions/HydroFreeOutflow.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/ConservativeFromPrimitive.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/Fluxes.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/Tags.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "Options/String.hpp"
+#include "PointwiseFunctions/AnalyticData/AnalyticData.hpp"
+#include "PointwiseFunctions/AnalyticData/Tags.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/AnalyticSolution.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "PointwiseFunctions/Hydro/Tags.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Serialization/CharmPupable.hpp"
+#include "Utilities/TMPL.hpp"
 
 namespace grmhd::GhValenciaDivClean::BoundaryConditions {
-// LCOV_EXCL_START
 DirichletFreeOutflow::DirichletFreeOutflow(CkMigrateMessage* const msg)
     : BoundaryCondition(msg) {}
 // LCOV_EXCL_STOP
+DirichletFreeOutflow::DirichletFreeOutflow(const DirichletFreeOutflow& rhs)
+    : BoundaryCondition{dynamic_cast<const BoundaryCondition&>(rhs)},
+      analytic_prescription_(rhs.analytic_prescription_->get_clone()) {}
+
+DirichletFreeOutflow& DirichletFreeOutflow::operator=(
+    const DirichletFreeOutflow& rhs) {
+  if (&rhs == this) {
+    return *this;
+  }
+  analytic_prescription_ = rhs.analytic_prescription_->get_clone();
+  return *this;
+}
+
+DirichletFreeOutflow::DirichletFreeOutflow(
+    std::unique_ptr<evolution::initial_data::InitialData> analytic_prescription)
+    : analytic_prescription_(std::move(analytic_prescription)) {}
 
 std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
 DirichletFreeOutflow::get_clone() const {
   return std::make_unique<DirichletFreeOutflow>(*this);
 }
 
-void DirichletFreeOutflow::pup(PUP::er& p) { BoundaryCondition::pup(p); }
-
+void DirichletFreeOutflow::pup(PUP::er& p) {
+  BoundaryCondition::pup(p);
+  p | analytic_prescription_;
+}
 // NOLINTNEXTLINE
 PUP::able::PUP_ID DirichletFreeOutflow::my_PUP_ID = 0;
+
+std::optional<std::string> DirichletFreeOutflow::dg_ghost(
+    const gsl::not_null<tnsr::aa<DataVector, 3, Frame::Inertial>*>
+        spacetime_metric,
+    const gsl::not_null<tnsr::aa<DataVector, 3, Frame::Inertial>*> pi,
+    const gsl::not_null<tnsr::iaa<DataVector, 3, Frame::Inertial>*> phi,
+    const gsl::not_null<Scalar<DataVector>*> tilde_d,
+    const gsl::not_null<Scalar<DataVector>*> tilde_ye,
+    const gsl::not_null<Scalar<DataVector>*> tilde_tau,
+    const gsl::not_null<tnsr::i<DataVector, 3, Frame::Inertial>*> tilde_s,
+    const gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> tilde_b,
+    const gsl::not_null<Scalar<DataVector>*> tilde_phi,
+
+    const gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> tilde_d_flux,
+    const gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> tilde_ye_flux,
+    const gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*>
+        tilde_tau_flux,
+    const gsl::not_null<tnsr::Ij<DataVector, 3, Frame::Inertial>*> tilde_s_flux,
+    const gsl::not_null<tnsr::IJ<DataVector, 3, Frame::Inertial>*> tilde_b_flux,
+    const gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*>
+        tilde_phi_flux,
+
+    const gsl::not_null<Scalar<DataVector>*> gamma1,
+    const gsl::not_null<Scalar<DataVector>*> gamma2,
+    const gsl::not_null<Scalar<DataVector>*> lapse,
+    const gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> shift,
+    const gsl::not_null<tnsr::II<DataVector, 3, Frame::Inertial>*>
+        inv_spatial_metric,
+
+    const std::optional<tnsr::I<DataVector, 3, Frame::Inertial>>&
+        face_mesh_velocity,
+    const tnsr::i<DataVector, 3, Frame::Inertial>& normal_covector,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& normal_vector,
+
+    const Scalar<DataVector>& interior_rest_mass_density,
+    const Scalar<DataVector>& interior_electron_fraction,
+    const Scalar<DataVector>& interior_specific_internal_energy,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& interior_spatial_velocity,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& interior_magnetic_field,
+    const Scalar<DataVector>& interior_lorentz_factor,
+    const Scalar<DataVector>& interior_pressure,
+
+    const tnsr::I<DataVector, 3, Frame::Inertial>& coords,
+    const Scalar<DataVector>& interior_gamma1,
+    const Scalar<DataVector>& interior_gamma2, const double time) const {
+  *gamma1 = interior_gamma1;
+  *gamma2 = interior_gamma2;
+
+  auto boundary_values = call_with_dynamic_type<
+      tuples::TaggedTuple<
+          gr::Tags::SpatialMetric<DataVector, 3>,
+          gr::Tags::InverseSpatialMetric<DataVector, 3>,
+          gr::Tags::SqrtDetSpatialMetric<DataVector>,
+          gr::Tags::Lapse<DataVector>, gr::Tags::Shift<DataVector, 3>,
+          gr::Tags::SpacetimeMetric<DataVector, 3>,
+          ::gh::Tags::Pi<DataVector, 3>, ::gh::Tags::Phi<DataVector, 3>>,
+      ghmhd::GhValenciaDivClean::InitialData::analytic_solutions_and_data_list>(
+      analytic_prescription_.get(),
+      [&coords, &time](const auto* const initial_data) {
+        using spacetime_tags = tmpl::list<
+            gr::Tags::SpatialMetric<DataVector, 3>,
+            gr::Tags::InverseSpatialMetric<DataVector, 3>,
+            gr::Tags::SqrtDetSpatialMetric<DataVector>,
+            gr::Tags::Lapse<DataVector>, gr::Tags::Shift<DataVector, 3>,
+            gr::Tags::SpacetimeMetric<DataVector, 3>,
+            ::gh::Tags::Pi<DataVector, 3>, ::gh::Tags::Phi<DataVector, 3>>;
+        if constexpr (is_analytic_solution_v<
+                          std::decay_t<decltype(*initial_data)>>) {
+          return initial_data->variables(coords, time, spacetime_tags{});
+        } else if constexpr (evolution::is_numeric_initial_data_v<
+                                 std::decay_t<decltype(*initial_data)>>) {
+          ERROR(
+              "Cannot currently use numeric initial data as an analytic "
+              "prescription for boundary conditions.");
+        } else {
+          (void)time;
+          return initial_data->variables(coords, spacetime_tags{});
+        }
+      });
+
+  *spacetime_metric =
+      get<gr::Tags::SpacetimeMetric<DataVector, 3>>(boundary_values);
+  *pi = get<::gh::Tags::Pi<DataVector, 3>>(boundary_values);
+  *phi = get<::gh::Tags::Phi<DataVector, 3>>(boundary_values);
+  *lapse = get<gr::Tags::Lapse<DataVector>>(boundary_values);
+  *shift = get<gr::Tags::Shift<DataVector, 3>>(boundary_values);
+  *inv_spatial_metric =
+      get<gr::Tags::InverseSpatialMetric<DataVector, 3>>(boundary_values);
+
+  return grmhd::ValenciaDivClean::BoundaryConditions::HydroFreeOutflow::
+      dg_ghost(tilde_d, tilde_ye, tilde_tau, tilde_s, tilde_b, tilde_phi,
+
+               tilde_d_flux, tilde_ye_flux, tilde_tau_flux, tilde_s_flux,
+               tilde_b_flux, tilde_phi_flux,
+
+               lapse, shift, inv_spatial_metric,
+
+               face_mesh_velocity, normal_covector, normal_vector,
+
+               interior_rest_mass_density, interior_electron_fraction,
+               interior_specific_internal_energy, interior_spatial_velocity,
+               interior_magnetic_field, interior_lorentz_factor,
+               interior_pressure,
+
+               *shift, *lapse, *inv_spatial_metric);
+}
+
+void DirichletFreeOutflow::fd_ghost(
+    const gsl::not_null<tnsr::aa<DataVector, 3, Frame::Inertial>*>
+        spacetime_metric,
+    const gsl::not_null<tnsr::aa<DataVector, 3, Frame::Inertial>*> pi,
+    const gsl::not_null<tnsr::iaa<DataVector, 3, Frame::Inertial>*> phi,
+    const gsl::not_null<Scalar<DataVector>*> rest_mass_density,
+    const gsl::not_null<Scalar<DataVector>*> electron_fraction,
+    const gsl::not_null<Scalar<DataVector>*> temperature,
+    const gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*>
+        lorentz_factor_times_spatial_velocity,
+    const gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*>
+        magnetic_field,
+    const gsl::not_null<Scalar<DataVector>*> divergence_cleaning_field,
+    const Direction<3>& direction,
+
+    // fd_interior_temporary_tags
+    const Mesh<3>& subcell_mesh,
+
+    // interior prim vars tags
+    const Scalar<DataVector>& interior_rest_mass_density,
+    const Scalar<DataVector>& interior_electron_fraction,
+    const Scalar<DataVector>& interior_temperature,
+    const Scalar<DataVector>& interior_pressure,
+    const Scalar<DataVector>& interior_specific_internal_energy,
+    const Scalar<DataVector>& interior_lorentz_factor,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& interior_spatial_velocity,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& interior_magnetic_field,
+
+    // fd_gridless_tags
+    const double time,
+    const std::unordered_map<
+        std::string,
+        std::unique_ptr<::domain::FunctionsOfTime::FunctionOfTime>>&
+        functions_of_time,
+    const ElementMap<3, Frame::Grid>& logical_to_grid_map,
+    const domain::CoordinateMapBase<Frame::Grid, Frame::Inertial, 3>&
+        grid_to_inertial_map,
+    const fd::Reconstructor& reconstructor) const {
+  const size_t ghost_zone_size{reconstructor.ghost_zone_size()};
+
+  const auto ghost_logical_coords =
+      evolution::dg::subcell::fd::ghost_zone_logical_coordinates(
+          subcell_mesh, ghost_zone_size, direction);
+
+  const auto ghost_inertial_coords = grid_to_inertial_map(
+      logical_to_grid_map(ghost_logical_coords), time, functions_of_time);
+
+  // Compute FD ghost data with the analytic data or solution
+  auto boundary_values = call_with_dynamic_type<
+      tuples::TaggedTuple<gr::Tags::SpacetimeMetric<DataVector, 3>,
+                          ::gh::Tags::Pi<DataVector, 3>,
+                          ::gh::Tags::Phi<DataVector, 3>>,
+      ghmhd::GhValenciaDivClean::InitialData::analytic_solutions_and_data_list>(
+      analytic_prescription_.get(),
+      [&ghost_inertial_coords, &time](const auto* const initial_data) {
+        using spacetime_tags =
+            tmpl::list<gr::Tags::SpacetimeMetric<DataVector, 3>,
+                       ::gh::Tags::Pi<DataVector, 3>,
+                       ::gh::Tags::Phi<DataVector, 3>>;
+        if constexpr (is_analytic_solution_v<
+                          std::decay_t<decltype(*initial_data)>>) {
+          return initial_data->variables(ghost_inertial_coords, time,
+                                         spacetime_tags{});
+        } else if constexpr (evolution::is_numeric_initial_data_v<
+                                 std::decay_t<decltype(*initial_data)>>) {
+          ERROR(
+              "Cannot currently use numeric initial data as an analytic "
+              "prescription for boundary conditions.");
+        } else {
+          (void)time;
+          return initial_data->variables(ghost_inertial_coords,
+                                         spacetime_tags{});
+        }
+      });
+
+  *spacetime_metric =
+      get<gr::Tags::SpacetimeMetric<DataVector, 3>>(boundary_values);
+  *pi = get<::gh::Tags::Pi<DataVector, 3>>(boundary_values);
+  *phi = get<::gh::Tags::Phi<DataVector, 3>>(boundary_values);
+
+  // Note: Once we support high-order fluxes with GHMHD we will need to
+  // handle this correctly.
+  std::optional<Variables<db::wrap_tags_in<
+      Flux, typename grmhd::ValenciaDivClean::System::flux_variables>>>
+      cell_centered_ghost_fluxes{std::nullopt};
+  // Dummy placeholders to call `fd_ghost_impl` but are not actually returned
+  Scalar<DataVector> pressure{};
+  Scalar<DataVector> specific_internal_energy{};
+  tnsr::I<DataVector, 3> spatial_velocity{};
+  Scalar<DataVector> lorentz_factor{};
+  const tnsr::I<DataVector, 3> interior_shift{};
+  const Scalar<DataVector> interior_lapse{};
+  const tnsr::ii<DataVector, 3> interior_spatial_metric{};
+  tnsr::ii<DataVector, 3> spatial_metric{};
+  tnsr::II<DataVector, 3> inv_spatial_metric{};
+  Scalar<DataVector> sqrt_det_spatial_metric{};
+  Scalar<DataVector> lapse{};
+  tnsr::I<DataVector, 3> shift{};
+
+  grmhd::ValenciaDivClean::BoundaryConditions::HydroFreeOutflow::fd_ghost_impl(
+      rest_mass_density, electron_fraction, temperature,
+      make_not_null(&pressure), make_not_null(&specific_internal_energy),
+      lorentz_factor_times_spatial_velocity, make_not_null(&spatial_velocity),
+      make_not_null(&lorentz_factor), magnetic_field, divergence_cleaning_field,
+
+      make_not_null(&spatial_metric), make_not_null(&inv_spatial_metric),
+      make_not_null(&sqrt_det_spatial_metric), make_not_null(&lapse),
+      make_not_null(&shift),
+
+      direction,
+
+      // fd_interior_temporary_tags
+      subcell_mesh,
+
+      // fd_interior_primitive_variables_tags
+      interior_rest_mass_density, interior_electron_fraction,
+      interior_temperature, interior_pressure,
+      interior_specific_internal_energy, interior_lorentz_factor,
+      interior_spatial_velocity, interior_magnetic_field,
+      // Note: metric vars are empty because they shouldn't be used
+      interior_spatial_metric, interior_lapse, interior_shift,
+
+      // fd_gridless_tags
+      reconstructor.ghost_zone_size(), cell_centered_ghost_fluxes.has_value());
+}
+
 }  // namespace grmhd::GhValenciaDivClean::BoundaryConditions

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/BoundaryConditions/DirichletFreeOutflow.hpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/BoundaryConditions/DirichletFreeOutflow.hpp
@@ -13,7 +13,6 @@
 #include "DataStructures/DataBox/Prefixes.hpp"
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
-#include "DataStructures/Variables.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/Tags.hpp"
 #include "Domain/ElementMap.hpp"
@@ -23,7 +22,6 @@
 #include "Domain/Tags.hpp"
 #include "Evolution/BoundaryConditions/Type.hpp"
 #include "Evolution/DgSubcell/GhostZoneLogicalCoordinates.hpp"
-#include "Evolution/DgSubcell/SliceTensor.hpp"
 #include "Evolution/DgSubcell/Tags/Coordinates.hpp"
 #include "Evolution/DgSubcell/Tags/Mesh.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/Tags.hpp"
@@ -39,11 +37,8 @@
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/Tags.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "Options/String.hpp"
-#include "PointwiseFunctions/AnalyticData/AnalyticData.hpp"
-#include "PointwiseFunctions/AnalyticData/Tags.hpp"
-#include "PointwiseFunctions/AnalyticSolutions/AnalyticSolution.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
-#include "PointwiseFunctions/Hydro/Tags.hpp"
+#include "PointwiseFunctions/InitialDataUtilities/InitialData.hpp"
 #include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/Serialization/CharmPupable.hpp"
@@ -65,21 +60,32 @@ class DirichletFreeOutflow final : public BoundaryCondition {
  private:
   template <typename T>
   using Flux = ::Tags::Flux<T, tmpl::size_t<3>, Frame::Inertial>;
+  std::unique_ptr<evolution::initial_data::InitialData> analytic_prescription_;
 
  public:
-  using options = tmpl::list<>;
+  /// \brief What analytic solution/data to prescribe.
+  struct AnalyticPrescription {
+    static constexpr Options::String help =
+        "What analytic solution/data to prescribe.";
+    using type = std::unique_ptr<evolution::initial_data::InitialData>;
+  };
+  using options = tmpl::list<AnalyticPrescription>;
   static constexpr Options::String help{
-      "DirichletAnalytic boundary conditions using either analytic solution or "
-      "analytic data for GH variables and hydro free outflow for GRMHD."};
+      "DirichletFreeOutflow boundary conditions using either analytic solution "
+      "or analytic data for GH variables and hydro free outflow for GRMHD"};
 
   DirichletFreeOutflow() = default;
   DirichletFreeOutflow(DirichletFreeOutflow&&) = default;
   DirichletFreeOutflow& operator=(DirichletFreeOutflow&&) = default;
-  DirichletFreeOutflow(const DirichletFreeOutflow&) = default;
-  DirichletFreeOutflow& operator=(const DirichletFreeOutflow&) = default;
+  DirichletFreeOutflow(const DirichletFreeOutflow&);
+  DirichletFreeOutflow& operator=(const DirichletFreeOutflow&);
   ~DirichletFreeOutflow() override = default;
 
   explicit DirichletFreeOutflow(CkMigrateMessage* msg);
+
+  explicit DirichletFreeOutflow(
+      std::unique_ptr<evolution::initial_data::InitialData>
+          analytic_prescription);
 
   WRAPPED_PUPable_decl_base_template(
       domain::BoundaryConditions::BoundaryCondition, DirichletFreeOutflow);
@@ -105,40 +111,30 @@ class DirichletFreeOutflow final : public BoundaryCondition {
                  hydro::Tags::MagneticField<DataVector, 3>,
                  hydro::Tags::LorentzFactor<DataVector>,
                  hydro::Tags::Pressure<DataVector>>;
-  using dg_gridless_tags =
-      tmpl::list<::Tags::Time, ::Tags::AnalyticSolutionOrData>;
-
-  template <typename AnalyticSolutionOrData>
+  using dg_gridless_tags = tmpl::list<::Tags::Time>;
   std::optional<std::string> dg_ghost(
-      const gsl::not_null<tnsr::aa<DataVector, 3, Frame::Inertial>*>
-          spacetime_metric,
-      const gsl::not_null<tnsr::aa<DataVector, 3, Frame::Inertial>*> pi,
-      const gsl::not_null<tnsr::iaa<DataVector, 3, Frame::Inertial>*> phi,
-      const gsl::not_null<Scalar<DataVector>*> tilde_d,
-      const gsl::not_null<Scalar<DataVector>*> tilde_ye,
-      const gsl::not_null<Scalar<DataVector>*> tilde_tau,
-      const gsl::not_null<tnsr::i<DataVector, 3, Frame::Inertial>*> tilde_s,
-      const gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> tilde_b,
-      const gsl::not_null<Scalar<DataVector>*> tilde_phi,
+      gsl::not_null<tnsr::aa<DataVector, 3, Frame::Inertial>*> spacetime_metric,
+      gsl::not_null<tnsr::aa<DataVector, 3, Frame::Inertial>*> pi,
+      gsl::not_null<tnsr::iaa<DataVector, 3, Frame::Inertial>*> phi,
+      gsl::not_null<Scalar<DataVector>*> tilde_d,
+      gsl::not_null<Scalar<DataVector>*> tilde_ye,
+      gsl::not_null<Scalar<DataVector>*> tilde_tau,
+      gsl::not_null<tnsr::i<DataVector, 3, Frame::Inertial>*> tilde_s,
+      gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> tilde_b,
+      gsl::not_null<Scalar<DataVector>*> tilde_phi,
 
-      const gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*>
-          tilde_d_flux,
-      const gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*>
-          tilde_ye_flux,
-      const gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*>
-          tilde_tau_flux,
-      const gsl::not_null<tnsr::Ij<DataVector, 3, Frame::Inertial>*>
-          tilde_s_flux,
-      const gsl::not_null<tnsr::IJ<DataVector, 3, Frame::Inertial>*>
-          tilde_b_flux,
-      const gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*>
-          tilde_phi_flux,
+      gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> tilde_d_flux,
+      gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> tilde_ye_flux,
+      gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> tilde_tau_flux,
+      gsl::not_null<tnsr::Ij<DataVector, 3, Frame::Inertial>*> tilde_s_flux,
+      gsl::not_null<tnsr::IJ<DataVector, 3, Frame::Inertial>*> tilde_b_flux,
+      gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> tilde_phi_flux,
 
-      const gsl::not_null<Scalar<DataVector>*> gamma1,
-      const gsl::not_null<Scalar<DataVector>*> gamma2,
-      const gsl::not_null<Scalar<DataVector>*> lapse,
-      const gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> shift,
-      const gsl::not_null<tnsr::II<DataVector, 3, Frame::Inertial>*>
+      gsl::not_null<Scalar<DataVector>*> gamma1,
+      gsl::not_null<Scalar<DataVector>*> gamma2,
+      gsl::not_null<Scalar<DataVector>*> lapse,
+      gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> shift,
+      gsl::not_null<tnsr::II<DataVector, 3, Frame::Inertial>*>
           inv_spatial_metric,
 
       const std::optional<tnsr::I<DataVector, 3, Frame::Inertial>>&
@@ -156,64 +152,7 @@ class DirichletFreeOutflow final : public BoundaryCondition {
 
       const tnsr::I<DataVector, 3, Frame::Inertial>& coords,
       const Scalar<DataVector>& interior_gamma1,
-      const Scalar<DataVector>& interior_gamma2, const double time,
-      const AnalyticSolutionOrData& analytic_solution_or_data) const {
-    *gamma1 = interior_gamma1;
-    *gamma2 = interior_gamma2;
-
-    auto boundary_values = [&analytic_solution_or_data, &coords, &time]() {
-      if constexpr (is_analytic_solution_v<AnalyticSolutionOrData>) {
-        return analytic_solution_or_data.variables(
-            coords, time,
-            tmpl::list<gr::Tags::SpatialMetric<DataVector, 3>,
-                       gr::Tags::InverseSpatialMetric<DataVector, 3>,
-                       gr::Tags::SqrtDetSpatialMetric<DataVector>,
-                       gr::Tags::Lapse<DataVector>,
-                       gr::Tags::Shift<DataVector, 3>,
-                       gr::Tags::SpacetimeMetric<DataVector, 3>,
-                       ::gh::Tags::Pi<DataVector, 3>,
-                       ::gh::Tags::Phi<DataVector, 3>>{});
-
-      } else {
-        (void)time;
-        return analytic_solution_or_data.variables(
-            coords, tmpl::list<gr::Tags::SpatialMetric<DataVector, 3>,
-                               gr::Tags::InverseSpatialMetric<DataVector, 3>,
-                               gr::Tags::SqrtDetSpatialMetric<DataVector>,
-                               gr::Tags::Lapse<DataVector>,
-                               gr::Tags::Shift<DataVector, 3>,
-                               gr::Tags::SpacetimeMetric<DataVector, 3>,
-                               ::gh::Tags::Pi<DataVector, 3>,
-                               ::gh::Tags::Phi<DataVector, 3>>{});
-      }
-    }();
-
-    *spacetime_metric =
-        get<gr::Tags::SpacetimeMetric<DataVector, 3>>(boundary_values);
-    *pi = get<::gh::Tags::Pi<DataVector, 3>>(boundary_values);
-    *phi = get<::gh::Tags::Phi<DataVector, 3>>(boundary_values);
-    *lapse = get<gr::Tags::Lapse<DataVector>>(boundary_values);
-    *shift = get<gr::Tags::Shift<DataVector, 3>>(boundary_values);
-    *inv_spatial_metric =
-        get<gr::Tags::InverseSpatialMetric<DataVector, 3>>(boundary_values);
-
-    return grmhd::ValenciaDivClean::BoundaryConditions::HydroFreeOutflow::
-        dg_ghost(tilde_d, tilde_ye, tilde_tau, tilde_s, tilde_b, tilde_phi,
-
-                 tilde_d_flux, tilde_ye_flux, tilde_tau_flux, tilde_s_flux,
-                 tilde_b_flux, tilde_phi_flux,
-
-                 lapse, shift, inv_spatial_metric,
-
-                 face_mesh_velocity, normal_covector, normal_vector,
-
-                 interior_rest_mass_density, interior_electron_fraction,
-                 interior_specific_internal_energy, interior_spatial_velocity,
-                 interior_magnetic_field, interior_lorentz_factor,
-                 interior_pressure,
-
-                 *shift, *lapse, *inv_spatial_metric);
-  }
+      const Scalar<DataVector>& interior_gamma2, double time) const;
 
   using fd_interior_evolved_variables_tags = tmpl::list<>;
   using fd_interior_temporary_tags =
@@ -232,26 +171,23 @@ class DirichletFreeOutflow final : public BoundaryCondition {
                  domain::Tags::ElementMap<3, Frame::Grid>,
                  domain::CoordinateMaps::Tags::CoordinateMap<3, Frame::Grid,
                                                              Frame::Inertial>,
-                 fd::Tags::Reconstructor, ::Tags::AnalyticSolutionOrData>;
-
-  template <typename AnalyticSolutionOrData>
+                 fd::Tags::Reconstructor>;
   void fd_ghost(
-      const gsl::not_null<tnsr::aa<DataVector, 3, Frame::Inertial>*>
-          spacetime_metric,
-      const gsl::not_null<tnsr::aa<DataVector, 3, Frame::Inertial>*> pi,
-      const gsl::not_null<tnsr::iaa<DataVector, 3, Frame::Inertial>*> phi,
-      const gsl::not_null<Scalar<DataVector>*> rest_mass_density,
-      const gsl::not_null<Scalar<DataVector>*> electron_fraction,
-      const gsl::not_null<Scalar<DataVector>*> temperature,
-      const gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*>
+
+      gsl::not_null<tnsr::aa<DataVector, 3, Frame::Inertial>*> spacetime_metric,
+      gsl::not_null<tnsr::aa<DataVector, 3, Frame::Inertial>*> pi,
+      gsl::not_null<tnsr::iaa<DataVector, 3, Frame::Inertial>*> phi,
+      gsl::not_null<Scalar<DataVector>*> rest_mass_density,
+      gsl::not_null<Scalar<DataVector>*> electron_fraction,
+      gsl::not_null<Scalar<DataVector>*> temperature,
+      gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*>
           lorentz_factor_times_spatial_velocity,
-      const gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*>
-          magnetic_field,
-      const gsl::not_null<Scalar<DataVector>*> divergence_cleaning_field,
+      gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> magnetic_field,
+      gsl::not_null<Scalar<DataVector>*> divergence_cleaning_field,
       const Direction<3>& direction,
 
       // fd_interior_temporary_tags
-      const Mesh<3> subcell_mesh,
+      const Mesh<3>& subcell_mesh,
 
       // interior prim vars tags
       const Scalar<DataVector>& interior_rest_mass_density,
@@ -264,7 +200,7 @@ class DirichletFreeOutflow final : public BoundaryCondition {
       const tnsr::I<DataVector, 3, Frame::Inertial>& interior_magnetic_field,
 
       // fd_gridless_tags
-      const double time,
+      double time,
       const std::unordered_map<
           std::string,
           std::unique_ptr<::domain::FunctionsOfTime::FunctionOfTime>>&
@@ -272,89 +208,6 @@ class DirichletFreeOutflow final : public BoundaryCondition {
       const ElementMap<3, Frame::Grid>& logical_to_grid_map,
       const domain::CoordinateMapBase<Frame::Grid, Frame::Inertial, 3>&
           grid_to_inertial_map,
-      const fd::Reconstructor& reconstructor,
-      const AnalyticSolutionOrData& analytic_solution_or_data) const {
-    const size_t ghost_zone_size{reconstructor.ghost_zone_size()};
-
-    const auto ghost_logical_coords =
-        evolution::dg::subcell::fd::ghost_zone_logical_coordinates(
-            subcell_mesh, ghost_zone_size, direction);
-
-    const auto ghost_inertial_coords = grid_to_inertial_map(
-        logical_to_grid_map(ghost_logical_coords), time, functions_of_time);
-
-    // Compute FD ghost data with the analytic data or solution
-    auto boundary_values = [&analytic_solution_or_data, &ghost_inertial_coords,
-                            &time]() {
-      if constexpr (std::is_base_of_v<MarkAsAnalyticData,
-                                      AnalyticSolutionOrData>) {
-        (void)time;
-        return analytic_solution_or_data.variables(
-            ghost_inertial_coords,
-            tmpl::list<gr::Tags::SpacetimeMetric<DataVector, 3>,
-                       ::gh::Tags::Pi<DataVector, 3>,
-                       ::gh::Tags::Phi<DataVector, 3>>{});
-      } else {
-        return analytic_solution_or_data.variables(
-            ghost_inertial_coords, time,
-            tmpl::list<gr::Tags::SpacetimeMetric<DataVector, 3>,
-                       ::gh::Tags::Pi<DataVector, 3>,
-                       ::gh::Tags::Phi<DataVector, 3>>{});
-      }
-    }();
-
-    *spacetime_metric =
-        get<gr::Tags::SpacetimeMetric<DataVector, 3>>(boundary_values);
-    *pi = get<::gh::Tags::Pi<DataVector, 3>>(boundary_values);
-    *phi = get<::gh::Tags::Phi<DataVector, 3>>(boundary_values);
-
-    // Note: Once we support high-order fluxes with GHMHD we will need to
-    // handle this correctly.
-    std::optional<Variables<db::wrap_tags_in<
-        Flux, typename grmhd::ValenciaDivClean::System::flux_variables>>>
-        cell_centered_ghost_fluxes{std::nullopt};
-    // Set to zero since it shouldn't be used
-    Scalar<DataVector> pressure{};
-    Scalar<DataVector> specific_internal_energy{};
-    tnsr::I<DataVector, 3> spatial_velocity{};
-    Scalar<DataVector> lorentz_factor{};
-    const tnsr::I<DataVector, 3> interior_shift{};
-    const Scalar<DataVector> interior_lapse{};
-    const tnsr::ii<DataVector, 3> interior_spatial_metric{};
-    tnsr::ii<DataVector, 3> spatial_metric{};
-    tnsr::II<DataVector, 3> inv_spatial_metric{};
-    Scalar<DataVector> sqrt_det_spatial_metric{};
-    Scalar<DataVector> lapse{};
-    tnsr::I<DataVector, 3> shift{};
-
-    grmhd::ValenciaDivClean::BoundaryConditions::HydroFreeOutflow::
-        fd_ghost_impl(
-            rest_mass_density, electron_fraction, temperature,
-            make_not_null(&pressure), make_not_null(&specific_internal_energy),
-            lorentz_factor_times_spatial_velocity,
-            make_not_null(&spatial_velocity), make_not_null(&lorentz_factor),
-            magnetic_field, divergence_cleaning_field,
-
-            make_not_null(&spatial_metric), make_not_null(&inv_spatial_metric),
-            make_not_null(&sqrt_det_spatial_metric), make_not_null(&lapse),
-            make_not_null(&shift),
-
-            direction,
-
-            // fd_interior_temporary_tags
-            subcell_mesh,
-
-            // fd_interior_primitive_variables_tags
-            interior_rest_mass_density, interior_electron_fraction,
-            interior_temperature, interior_pressure,
-            interior_specific_internal_energy, interior_lorentz_factor,
-            interior_spatial_velocity, interior_magnetic_field,
-            // Note: metric vars are empty because they shouldn't be used
-            interior_spatial_metric, interior_lapse, interior_shift,
-
-            // fd_gridless_tags
-            reconstructor.ghost_zone_size(),
-            cell_centered_ghost_fluxes.has_value());
-  }
+      const fd::Reconstructor& reconstructor) const;
 };
 }  // namespace grmhd::GhValenciaDivClean::BoundaryConditions

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/CMakeLists.txt
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/CMakeLists.txt
@@ -16,6 +16,7 @@ spectre_target_headers(
   ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
+  AllSolutions.hpp
   Characteristics.hpp
   Constraints.hpp
   SetPiAndPhiFromConstraints.hpp
@@ -34,6 +35,9 @@ target_link_libraries(
   FiniteDifference
   GeneralRelativity
   GeneralizedHarmonic
+  GhGrMhdAnalyticData
+  GhGrMhdSolutions
+  GhRelativisticEulerSolutions
   Hydro
   Serialization
   Utilities

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/AllSolutions.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/AllSolutions.hpp
@@ -1,0 +1,42 @@
+
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "PointwiseFunctions/AnalyticData/GrMhd/AnalyticData.hpp"
+#include "PointwiseFunctions/AnalyticData/GrMhd/BlastWave.hpp"
+#include "PointwiseFunctions/AnalyticData/GrMhd/BondiHoyleAccretion.hpp"
+#include "PointwiseFunctions/AnalyticData/GrMhd/CcsnCollapse.hpp"
+#include "PointwiseFunctions/AnalyticData/GrMhd/KhInstability.hpp"
+#include "PointwiseFunctions/AnalyticData/GrMhd/MagneticFieldLoop.hpp"
+#include "PointwiseFunctions/AnalyticData/GrMhd/MagneticRotor.hpp"
+#include "PointwiseFunctions/AnalyticData/GrMhd/MagnetizedFmDisk.hpp"
+#include "PointwiseFunctions/AnalyticData/GrMhd/MagnetizedTovStar.hpp"
+#include "PointwiseFunctions/AnalyticData/GrMhd/OrszagTangVortex.hpp"
+#include "PointwiseFunctions/AnalyticData/GrMhd/RiemannProblem.hpp"
+#include "PointwiseFunctions/AnalyticData/GrMhd/SlabJet.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/AnalyticSolution.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GrMhd/AlfvenWave.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GrMhd/BondiMichel.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GrMhd/KomissarovShock.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GrMhd/SmoothFlow.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GrMhd/Solutions.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/RelativisticEuler/FishboneMoncriefDisk.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/RelativisticEuler/RotatingStar.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/RelativisticEuler/TovStar.hpp"
+
+namespace grmhd::ValenciaDivClean::InitialData {
+using initial_data_list =
+    tmpl::list<AnalyticData::BlastWave, AnalyticData::BondiHoyleAccretion,
+               AnalyticData::CcsnCollapse, AnalyticData::KhInstability,
+               AnalyticData::MagneticFieldLoop, AnalyticData::MagneticRotor,
+               AnalyticData::MagnetizedFmDisk, AnalyticData::MagnetizedTovStar,
+               AnalyticData::OrszagTangVortex, AnalyticData::RiemannProblem,
+               AnalyticData::SlabJet, Solutions::AlfvenWave,
+               grmhd::Solutions::BondiMichel, Solutions::KomissarovShock,
+               Solutions::SmoothFlow,
+               RelativisticEuler::Solutions::FishboneMoncriefDisk,
+               RelativisticEuler::Solutions::RotatingStar,
+               RelativisticEuler::Solutions::TovStar>;
+}  // namespace grmhd::ValenciaDivClean::InitialData

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryConditions/DirichletAnalytic.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryConditions/DirichletAnalytic.cpp
@@ -5,11 +5,70 @@
 
 #include <cstddef>
 #include <memory>
+#include <optional>
 #include <pup.h>
+#include <string>
+#include <type_traits>
+#include <unordered_map>
 
+#include "DataStructures/DataBox/PrefixHelpers.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/Tags.hpp"
+#include "Domain/ElementMap.hpp"
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "Domain/FunctionsOfTime/Tags.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Tags.hpp"
+#include "Evolution/BoundaryConditions/Type.hpp"
+#include "Evolution/DgSubcell/GhostZoneLogicalCoordinates.hpp"
+#include "Evolution/DgSubcell/SliceTensor.hpp"
+#include "Evolution/DgSubcell/Tags/Coordinates.hpp"
+#include "Evolution/DgSubcell/Tags/Mesh.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/AllSolutions.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryConditions/BoundaryCondition.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/ConservativeFromPrimitive.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/Factory.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/Reconstructor.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/Tag.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/Fluxes.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/System.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/Tags.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "Options/String.hpp"
+#include "PointwiseFunctions/AnalyticData/AnalyticData.hpp"
+#include "PointwiseFunctions/AnalyticData/Tags.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/AnalyticSolution.hpp"
+#include "PointwiseFunctions/Hydro/Tags.hpp"
+#include "PointwiseFunctions/Hydro/Temperature.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Serialization/CharmPupable.hpp"
+#include "Utilities/TMPL.hpp"
 
 namespace grmhd::ValenciaDivClean::BoundaryConditions {
+
+DirichletAnalytic::DirichletAnalytic(const DirichletAnalytic& rhs)
+    : BoundaryCondition{dynamic_cast<const BoundaryCondition&>(rhs)},
+      analytic_prescription_(rhs.analytic_prescription_->get_clone()) {}
+
+DirichletAnalytic& DirichletAnalytic::operator=(const DirichletAnalytic& rhs) {
+  if (&rhs == this) {
+    return *this;
+  }
+  analytic_prescription_ = rhs.analytic_prescription_->get_clone();
+  return *this;
+}
+
+DirichletAnalytic::DirichletAnalytic(
+    std::unique_ptr<evolution::initial_data::InitialData> analytic_prescription)
+    : analytic_prescription_(std::move(analytic_prescription)) {}
+
 DirichletAnalytic::DirichletAnalytic(CkMigrateMessage* const msg)
     : BoundaryCondition(msg) {}
 
@@ -18,8 +77,299 @@ DirichletAnalytic::get_clone() const {
   return std::make_unique<DirichletAnalytic>(*this);
 }
 
-void DirichletAnalytic::pup(PUP::er& p) { BoundaryCondition::pup(p); }
-
+void DirichletAnalytic::pup(PUP::er& p) {
+  BoundaryCondition::pup(p);
+  p | analytic_prescription_;
+}
 // NOLINTNEXTLINE
 PUP::able::PUP_ID DirichletAnalytic::my_PUP_ID = 0;
+
+std::optional<std::string> DirichletAnalytic::dg_ghost(
+    const gsl::not_null<Scalar<DataVector>*> tilde_d,
+    const gsl::not_null<Scalar<DataVector>*> tilde_ye,
+    const gsl::not_null<Scalar<DataVector>*> tilde_tau,
+    const gsl::not_null<tnsr::i<DataVector, 3, Frame::Inertial>*> tilde_s,
+    const gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> tilde_b,
+    const gsl::not_null<Scalar<DataVector>*> tilde_phi,
+
+    const gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> tilde_d_flux,
+    const gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> tilde_ye_flux,
+    const gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*>
+        tilde_tau_flux,
+    const gsl::not_null<tnsr::Ij<DataVector, 3, Frame::Inertial>*> tilde_s_flux,
+    const gsl::not_null<tnsr::IJ<DataVector, 3, Frame::Inertial>*> tilde_b_flux,
+    const gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*>
+        tilde_phi_flux,
+
+    const gsl::not_null<Scalar<DataVector>*> lapse,
+    const gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> shift,
+    const gsl::not_null<tnsr::II<DataVector, 3, Frame::Inertial>*>
+        inv_spatial_metric,
+
+    const std::optional<
+        tnsr::I<DataVector, 3, Frame::Inertial>>& /*face_mesh_velocity*/,
+    const tnsr::i<DataVector, 3, Frame::Inertial>& /*normal_covector*/,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& /*normal_vector*/,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& coords,
+    [[maybe_unused]] const double time) const {
+  auto boundary_values = call_with_dynamic_type<
+      tuples::TaggedTuple<hydro::Tags::RestMassDensity<DataVector>,
+                          hydro::Tags::ElectronFraction<DataVector>,
+                          hydro::Tags::SpecificInternalEnergy<DataVector>,
+                          hydro::Tags::Pressure<DataVector>,
+                          hydro::Tags::SpatialVelocity<DataVector, 3>,
+                          hydro::Tags::LorentzFactor<DataVector>,
+                          hydro::Tags::MagneticField<DataVector, 3>,
+                          hydro::Tags::DivergenceCleaningField<DataVector>,
+                          gr::Tags::SpatialMetric<DataVector, 3>,
+                          gr::Tags::InverseSpatialMetric<DataVector, 3>,
+                          gr::Tags::SqrtDetSpatialMetric<DataVector>,
+                          gr::Tags::Lapse<DataVector>,
+                          gr::Tags::Shift<DataVector, 3>>,
+      grmhd::ValenciaDivClean::InitialData::initial_data_list>(
+      analytic_prescription_.get(),
+      [&coords, &time](const auto* const initial_data) {
+        if constexpr (is_analytic_solution_v<
+                          std::decay_t<decltype(*initial_data)>>) {
+          return initial_data->variables(
+              coords, time,
+              tmpl::list<hydro::Tags::RestMassDensity<DataVector>,
+                         hydro::Tags::ElectronFraction<DataVector>,
+                         hydro::Tags::SpecificInternalEnergy<DataVector>,
+                         hydro::Tags::Pressure<DataVector>,
+                         hydro::Tags::SpatialVelocity<DataVector, 3>,
+                         hydro::Tags::LorentzFactor<DataVector>,
+                         hydro::Tags::MagneticField<DataVector, 3>,
+                         hydro::Tags::DivergenceCleaningField<DataVector>,
+                         gr::Tags::SpatialMetric<DataVector, 3>,
+                         gr::Tags::InverseSpatialMetric<DataVector, 3>,
+                         gr::Tags::SqrtDetSpatialMetric<DataVector>,
+                         gr::Tags::Lapse<DataVector>,
+                         gr::Tags::Shift<DataVector, 3>>{});
+
+        } else {
+          (void)time;
+          return initial_data->variables(
+              coords,
+              tmpl::list<hydro::Tags::RestMassDensity<DataVector>,
+                         hydro::Tags::ElectronFraction<DataVector>,
+                         hydro::Tags::SpecificInternalEnergy<DataVector>,
+                         hydro::Tags::Pressure<DataVector>,
+                         hydro::Tags::SpatialVelocity<DataVector, 3>,
+                         hydro::Tags::LorentzFactor<DataVector>,
+                         hydro::Tags::MagneticField<DataVector, 3>,
+                         hydro::Tags::DivergenceCleaningField<DataVector>,
+                         gr::Tags::SpatialMetric<DataVector, 3>,
+                         gr::Tags::InverseSpatialMetric<DataVector, 3>,
+                         gr::Tags::SqrtDetSpatialMetric<DataVector>,
+                         gr::Tags::Lapse<DataVector>,
+                         gr::Tags::Shift<DataVector, 3>>{});
+        }
+      });
+  // Recover values from analytic solution/ analytic data calls
+  *lapse = get<gr::Tags::Lapse<DataVector>>(boundary_values);
+  *shift = get<gr::Tags::Shift<DataVector, 3>>(boundary_values);
+  *inv_spatial_metric =
+      get<gr::Tags::InverseSpatialMetric<DataVector, 3>>(boundary_values);
+  // Recover the conservative variables from the primitives
+  ConservativeFromPrimitive::apply(
+      tilde_d, tilde_ye, tilde_tau, tilde_s, tilde_b, tilde_phi,
+      get<hydro::Tags::RestMassDensity<DataVector>>(boundary_values),
+      get<hydro::Tags::ElectronFraction<DataVector>>(boundary_values),
+      get<hydro::Tags::SpecificInternalEnergy<DataVector>>(boundary_values),
+      get<hydro::Tags::Pressure<DataVector>>(boundary_values),
+      get<hydro::Tags::SpatialVelocity<DataVector, 3>>(boundary_values),
+      get<hydro::Tags::LorentzFactor<DataVector>>(boundary_values),
+      get<hydro::Tags::MagneticField<DataVector, 3>>(boundary_values),
+      get<gr::Tags::SqrtDetSpatialMetric<DataVector>>(boundary_values),
+      get<gr::Tags::SpatialMetric<DataVector, 3>>(boundary_values),
+      get<hydro::Tags::DivergenceCleaningField<DataVector>>(boundary_values));
+
+  ComputeFluxes::apply(
+      tilde_d_flux, tilde_ye_flux, tilde_tau_flux, tilde_s_flux, tilde_b_flux,
+      tilde_phi_flux, *tilde_d, *tilde_ye, *tilde_tau, *tilde_s, *tilde_b,
+      *tilde_phi, *lapse, *shift,
+      get<gr::Tags::SqrtDetSpatialMetric<DataVector>>(boundary_values),
+      get<gr::Tags::SpatialMetric<DataVector, 3>>(boundary_values),
+      get<gr::Tags::InverseSpatialMetric<DataVector, 3>>(boundary_values),
+      get<hydro::Tags::Pressure<DataVector>>(boundary_values),
+      get<hydro::Tags::SpatialVelocity<DataVector, 3>>(boundary_values),
+      get<hydro::Tags::LorentzFactor<DataVector>>(boundary_values),
+      get<hydro::Tags::MagneticField<DataVector, 3>>(boundary_values));
+
+  return {};
+}
+
+void DirichletAnalytic::fd_ghost(
+    const gsl::not_null<Scalar<DataVector>*> rest_mass_density,
+    const gsl::not_null<Scalar<DataVector>*> electron_fraction,
+    const gsl::not_null<Scalar<DataVector>*> temperature,
+    const gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*>
+        lorentz_factor_times_spatial_velocity,
+    const gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*>
+        magnetic_field,
+    const gsl::not_null<Scalar<DataVector>*> divergence_cleaning_field,
+
+    const gsl::not_null<std::optional<Variables<db::wrap_tags_in<
+        Flux, typename grmhd::ValenciaDivClean::System::flux_variables>>>*>
+        cell_centered_ghost_fluxes,
+
+    const Direction<3>& direction,
+
+    // fd_interior_temporary_tags
+    const Mesh<3>& subcell_mesh,
+
+    // fd_gridless_tags
+    [[maybe_unused]] const double time,
+    const std::unordered_map<
+        std::string,
+        std::unique_ptr<::domain::FunctionsOfTime::FunctionOfTime>>&
+        functions_of_time,
+    const ElementMap<3, Frame::Grid>& logical_to_grid_map,
+    const domain::CoordinateMapBase<Frame::Grid, Frame::Inertial, 3>&
+        grid_to_inertial_map,
+    const fd::Reconstructor& reconstructor) const {
+  const size_t ghost_zone_size{reconstructor.ghost_zone_size()};
+
+  const auto ghost_logical_coords =
+      evolution::dg::subcell::fd::ghost_zone_logical_coordinates(
+          subcell_mesh, ghost_zone_size, direction);
+
+  const auto ghost_inertial_coords = grid_to_inertial_map(
+      logical_to_grid_map(ghost_logical_coords), time, functions_of_time);
+
+  // Compute FD ghost data with the analytic data or solution
+  auto boundary_values = call_with_dynamic_type<
+      tuples::TaggedTuple<hydro::Tags::RestMassDensity<DataVector>,
+                          hydro::Tags::ElectronFraction<DataVector>,
+                          hydro::Tags::Pressure<DataVector>,
+                          hydro::Tags::Temperature<DataVector>,
+                          hydro::Tags::SpatialVelocity<DataVector, 3>,
+                          hydro::Tags::LorentzFactor<DataVector>,
+                          hydro::Tags::MagneticField<DataVector, 3>,
+                          hydro::Tags::DivergenceCleaningField<DataVector>,
+                          hydro::Tags::SpecificInternalEnergy<DataVector>,
+                          hydro::Tags::SpecificEnthalpy<DataVector>>,
+      grmhd::ValenciaDivClean::InitialData::initial_data_list>(
+      analytic_prescription_.get(),
+      [&ghost_inertial_coords, &time](const auto* const initial_data) {
+        using hydro_tags =
+            tmpl::list<hydro::Tags::RestMassDensity<DataVector>,
+                       hydro::Tags::ElectronFraction<DataVector>,
+                       hydro::Tags::Pressure<DataVector>,
+                       hydro::Tags::Temperature<DataVector>,
+                       hydro::Tags::SpatialVelocity<DataVector, 3>,
+                       hydro::Tags::LorentzFactor<DataVector>,
+                       hydro::Tags::MagneticField<DataVector, 3>,
+                       hydro::Tags::DivergenceCleaningField<DataVector>,
+                       hydro::Tags::SpecificInternalEnergy<DataVector>,
+                       hydro::Tags::SpecificEnthalpy<DataVector>>;
+        if constexpr (is_analytic_solution_v<
+                          std::decay_t<decltype(*initial_data)>>) {
+          return initial_data->variables(ghost_inertial_coords, time,
+                                         hydro_tags{});
+        } else {
+          (void)time;
+          return initial_data->variables(ghost_inertial_coords, hydro_tags{});
+        }
+      });
+
+  *rest_mass_density =
+      get<hydro::Tags::RestMassDensity<DataVector>>(boundary_values);
+  *electron_fraction =
+      get<hydro::Tags::ElectronFraction<DataVector>>(boundary_values);
+  *temperature = get<hydro::Tags::Temperature<DataVector>>(boundary_values);
+
+  for (size_t i = 0; i < 3; ++i) {
+    auto& lorentz_factor =
+        get<hydro::Tags::LorentzFactor<DataVector>>(boundary_values);
+    auto& spatial_velocity =
+        get<hydro::Tags::SpatialVelocity<DataVector, 3>>(boundary_values);
+    (*lorentz_factor_times_spatial_velocity).get(i) =
+        get(lorentz_factor) * spatial_velocity.get(i);
+  }
+
+  *magnetic_field =
+      get<hydro::Tags::MagneticField<DataVector, 3>>(boundary_values);
+  *divergence_cleaning_field =
+      get<hydro::Tags::DivergenceCleaningField<DataVector>>(boundary_values);
+
+  if (cell_centered_ghost_fluxes->has_value()) {
+    auto metric_boundary_values = call_with_dynamic_type<
+        tuples::TaggedTuple<gr::Tags::Lapse<DataVector>,
+                            gr::Tags::Shift<DataVector, 3>,
+                            gr::Tags::SpatialMetric<DataVector, 3>>,
+        grmhd::ValenciaDivClean::InitialData::initial_data_list>(
+        analytic_prescription_.get(),
+        [&ghost_inertial_coords, &time](const auto* const initial_data) {
+          using gr_tags = tmpl::list<gr::Tags::Lapse<DataVector>,
+                                     gr::Tags::Shift<DataVector, 3>,
+                                     gr::Tags::SpatialMetric<DataVector, 3>>;
+          if constexpr (is_analytic_solution_v<
+                            std::decay_t<decltype(*initial_data)>>) {
+            return initial_data->variables(ghost_inertial_coords, time,
+                                           gr_tags{});
+          } else {
+            (void)time;
+            return initial_data->variables(ghost_inertial_coords, gr_tags{});
+          }
+        });
+    auto [sqrt_det_spatial_metric, inverse_spatial_metric] =
+        determinant_and_inverse(get<gr::Tags::SpatialMetric<DataVector, 3>>(
+            metric_boundary_values));
+    get(sqrt_det_spatial_metric) = sqrt(get(sqrt_det_spatial_metric));
+
+    Variables<typename System::variables_tag::tags_list> conserved_vars{
+        get(*rest_mass_density).size()};
+    ConservativeFromPrimitive::apply(
+        make_not_null(&get<Tags::TildeD>(conserved_vars)),
+        make_not_null(&get<Tags::TildeYe>(conserved_vars)),
+        make_not_null(&get<Tags::TildeTau>(conserved_vars)),
+        make_not_null(&get<Tags::TildeS<>>(conserved_vars)),
+        make_not_null(&get<Tags::TildeB<>>(conserved_vars)),
+        make_not_null(&get<Tags::TildePhi>(conserved_vars)),
+
+        get<hydro::Tags::RestMassDensity<DataVector>>(boundary_values),
+        get<hydro::Tags::ElectronFraction<DataVector>>(boundary_values),
+        get<hydro::Tags::SpecificInternalEnergy<DataVector>>(boundary_values),
+        get<hydro::Tags::Pressure<DataVector>>(boundary_values),
+        get<hydro::Tags::SpatialVelocity<DataVector, 3>>(boundary_values),
+        get<hydro::Tags::LorentzFactor<DataVector>>(boundary_values),
+        get<hydro::Tags::MagneticField<DataVector, 3>>(boundary_values),
+        sqrt_det_spatial_metric,
+        get<gr::Tags::SpatialMetric<DataVector, 3>>(metric_boundary_values),
+        get<hydro::Tags::DivergenceCleaningField<DataVector>>(boundary_values));
+
+    ComputeFluxes::apply(
+        make_not_null(
+            &get<Flux<Tags::TildeD>>(cell_centered_ghost_fluxes->value())),
+        make_not_null(
+            &get<Flux<Tags::TildeYe>>(cell_centered_ghost_fluxes->value())),
+        make_not_null(
+            &get<Flux<Tags::TildeTau>>(cell_centered_ghost_fluxes->value())),
+        make_not_null(
+            &get<Flux<Tags::TildeS<>>>(cell_centered_ghost_fluxes->value())),
+        make_not_null(
+            &get<Flux<Tags::TildeB<>>>(cell_centered_ghost_fluxes->value())),
+        make_not_null(
+            &get<Flux<Tags::TildePhi>>(cell_centered_ghost_fluxes->value())),
+
+        get<Tags::TildeD>(conserved_vars), get<Tags::TildeYe>(conserved_vars),
+        get<Tags::TildeTau>(conserved_vars),
+        get<Tags::TildeS<>>(conserved_vars),
+        get<Tags::TildeB<>>(conserved_vars),
+        get<Tags::TildePhi>(conserved_vars),
+
+        get<gr::Tags::Lapse<DataVector>>(metric_boundary_values),
+        get<gr::Tags::Shift<DataVector, 3>>(metric_boundary_values),
+        sqrt_det_spatial_metric,
+        get<gr::Tags::SpatialMetric<DataVector, 3>>(metric_boundary_values),
+        inverse_spatial_metric,
+        get<hydro::Tags::Pressure<DataVector>>(boundary_values),
+        get<hydro::Tags::SpatialVelocity<DataVector, 3>>(boundary_values),
+        get<hydro::Tags::LorentzFactor<DataVector>>(boundary_values),
+        get<hydro::Tags::MagneticField<DataVector, 3>>(boundary_values));
+  }
+}
+
 }  // namespace grmhd::ValenciaDivClean::BoundaryConditions

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryConditions/DirichletAnalytic.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryConditions/DirichletAnalytic.hpp
@@ -38,10 +38,7 @@
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/Tags.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "Options/String.hpp"
-#include "PointwiseFunctions/AnalyticData/AnalyticData.hpp"
-#include "PointwiseFunctions/AnalyticData/Tags.hpp"
-#include "PointwiseFunctions/AnalyticSolutions/AnalyticSolution.hpp"
-#include "PointwiseFunctions/Hydro/Tags.hpp"
+#include "PointwiseFunctions/InitialDataUtilities/InitialData.hpp"
 #include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/Serialization/CharmPupable.hpp"
@@ -64,7 +61,13 @@ class DirichletAnalytic final : public BoundaryCondition {
   using Flux = ::Tags::Flux<T, tmpl::size_t<3>, Frame::Inertial>;
 
  public:
-  using options = tmpl::list<>;
+  /// \brief What analytic solution/data to prescribe.
+  struct AnalyticPrescription {
+    static constexpr Options::String help =
+        "What analytic solution/data to prescribe.";
+    using type = std::unique_ptr<evolution::initial_data::InitialData>;
+  };
+  using options = tmpl::list<AnalyticPrescription>;
   static constexpr Options::String help{
       "DirichletAnalytic boundary conditions using either analytic solution or "
       "analytic data."};
@@ -72,11 +75,15 @@ class DirichletAnalytic final : public BoundaryCondition {
   DirichletAnalytic() = default;
   DirichletAnalytic(DirichletAnalytic&&) = default;
   DirichletAnalytic& operator=(DirichletAnalytic&&) = default;
-  DirichletAnalytic(const DirichletAnalytic&) = default;
-  DirichletAnalytic& operator=(const DirichletAnalytic&) = default;
+  DirichletAnalytic(const DirichletAnalytic&);
+  DirichletAnalytic& operator=(const DirichletAnalytic&);
   ~DirichletAnalytic() override = default;
 
   explicit DirichletAnalytic(CkMigrateMessage* msg);
+
+  explicit DirichletAnalytic(
+      std::unique_ptr<evolution::initial_data::InitialData>
+          analytic_prescription);
 
   WRAPPED_PUPable_decl_base_template(
       domain::BoundaryConditions::BoundaryCondition, DirichletAnalytic);
@@ -93,111 +100,34 @@ class DirichletAnalytic final : public BoundaryCondition {
   using dg_interior_temporary_tags =
       tmpl::list<domain::Tags::Coordinates<3, Frame::Inertial>>;
   using dg_interior_primitive_variables_tags = tmpl::list<>;
-  using dg_gridless_tags =
-      tmpl::list<::Tags::Time, ::Tags::AnalyticSolutionOrData>;
+  using dg_gridless_tags = tmpl::list<::Tags::Time>;
 
-  template <typename AnalyticSolutionOrData>
   std::optional<std::string> dg_ghost(
-      const gsl::not_null<Scalar<DataVector>*> tilde_d,
-      const gsl::not_null<Scalar<DataVector>*> tilde_ye,
-      const gsl::not_null<Scalar<DataVector>*> tilde_tau,
-      const gsl::not_null<tnsr::i<DataVector, 3, Frame::Inertial>*> tilde_s,
-      const gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> tilde_b,
-      const gsl::not_null<Scalar<DataVector>*> tilde_phi,
+      gsl::not_null<Scalar<DataVector>*> tilde_d,
+      gsl::not_null<Scalar<DataVector>*> tilde_ye,
+      gsl::not_null<Scalar<DataVector>*> tilde_tau,
+      gsl::not_null<tnsr::i<DataVector, 3, Frame::Inertial>*> tilde_s,
+      gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> tilde_b,
+      gsl::not_null<Scalar<DataVector>*> tilde_phi,
 
-      const gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*>
-          tilde_d_flux,
-      const gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*>
-          tilde_ye_flux,
-      const gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*>
-          tilde_tau_flux,
-      const gsl::not_null<tnsr::Ij<DataVector, 3, Frame::Inertial>*>
-          tilde_s_flux,
-      const gsl::not_null<tnsr::IJ<DataVector, 3, Frame::Inertial>*>
-          tilde_b_flux,
-      const gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*>
-          tilde_phi_flux,
+      gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> tilde_d_flux,
+      gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> tilde_ye_flux,
+      gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> tilde_tau_flux,
+      gsl::not_null<tnsr::Ij<DataVector, 3, Frame::Inertial>*> tilde_s_flux,
+      gsl::not_null<tnsr::IJ<DataVector, 3, Frame::Inertial>*> tilde_b_flux,
+      gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> tilde_phi_flux,
 
-      const gsl::not_null<Scalar<DataVector>*> lapse,
-      const gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> shift,
-      const gsl::not_null<tnsr::II<DataVector, 3, Frame::Inertial>*>
+      gsl::not_null<Scalar<DataVector>*> lapse,
+      gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> shift,
+      gsl::not_null<tnsr::II<DataVector, 3, Frame::Inertial>*>
           inv_spatial_metric,
 
       const std::optional<
           tnsr::I<DataVector, 3, Frame::Inertial>>& /*face_mesh_velocity*/,
       const tnsr::i<DataVector, 3, Frame::Inertial>& /*normal_covector*/,
       const tnsr::I<DataVector, 3, Frame::Inertial>& /*normal_vector*/,
-      const tnsr::I<DataVector, 3, Frame::Inertial>& coords, const double time,
-      const AnalyticSolutionOrData& analytic_solution_or_data) const {
-    auto boundary_values = [&analytic_solution_or_data, &coords, &time]() {
-      if constexpr (is_analytic_solution_v<AnalyticSolutionOrData>) {
-        return analytic_solution_or_data.variables(
-            coords, time,
-            tmpl::list<hydro::Tags::RestMassDensity<DataVector>,
-                       hydro::Tags::ElectronFraction<DataVector>,
-                       hydro::Tags::SpecificInternalEnergy<DataVector>,
-                       hydro::Tags::Pressure<DataVector>,
-                       hydro::Tags::SpatialVelocity<DataVector, 3>,
-                       hydro::Tags::LorentzFactor<DataVector>,
-                       hydro::Tags::MagneticField<DataVector, 3>,
-                       hydro::Tags::DivergenceCleaningField<DataVector>,
-                       gr::Tags::SpatialMetric<DataVector, 3>,
-                       gr::Tags::InverseSpatialMetric<DataVector, 3>,
-                       gr::Tags::SqrtDetSpatialMetric<DataVector>,
-                       gr::Tags::Lapse<DataVector>,
-                       gr::Tags::Shift<DataVector, 3>>{});
-
-      } else {
-        (void)time;
-        return analytic_solution_or_data.variables(
-            coords, tmpl::list<hydro::Tags::RestMassDensity<DataVector>,
-                               hydro::Tags::ElectronFraction<DataVector>,
-                               hydro::Tags::SpecificInternalEnergy<DataVector>,
-                               hydro::Tags::Pressure<DataVector>,
-                               hydro::Tags::SpatialVelocity<DataVector, 3>,
-                               hydro::Tags::LorentzFactor<DataVector>,
-                               hydro::Tags::MagneticField<DataVector, 3>,
-                               hydro::Tags::DivergenceCleaningField<DataVector>,
-                               gr::Tags::SpatialMetric<DataVector, 3>,
-                               gr::Tags::InverseSpatialMetric<DataVector, 3>,
-                               gr::Tags::SqrtDetSpatialMetric<DataVector>,
-                               gr::Tags::Lapse<DataVector>,
-                               gr::Tags::Shift<DataVector, 3>>{});
-      }
-    }();
-
-    *lapse = get<gr::Tags::Lapse<DataVector>>(boundary_values);
-    *shift = get<gr::Tags::Shift<DataVector, 3>>(boundary_values);
-    *inv_spatial_metric =
-        get<gr::Tags::InverseSpatialMetric<DataVector, 3>>(boundary_values);
-
-    ConservativeFromPrimitive::apply(
-        tilde_d, tilde_ye, tilde_tau, tilde_s, tilde_b, tilde_phi,
-        get<hydro::Tags::RestMassDensity<DataVector>>(boundary_values),
-        get<hydro::Tags::ElectronFraction<DataVector>>(boundary_values),
-        get<hydro::Tags::SpecificInternalEnergy<DataVector>>(boundary_values),
-        get<hydro::Tags::Pressure<DataVector>>(boundary_values),
-        get<hydro::Tags::SpatialVelocity<DataVector, 3>>(boundary_values),
-        get<hydro::Tags::LorentzFactor<DataVector>>(boundary_values),
-        get<hydro::Tags::MagneticField<DataVector, 3>>(boundary_values),
-        get<gr::Tags::SqrtDetSpatialMetric<DataVector>>(boundary_values),
-        get<gr::Tags::SpatialMetric<DataVector, 3>>(boundary_values),
-        get<hydro::Tags::DivergenceCleaningField<DataVector>>(boundary_values));
-
-    ComputeFluxes::apply(
-        tilde_d_flux, tilde_ye_flux, tilde_tau_flux, tilde_s_flux, tilde_b_flux,
-        tilde_phi_flux, *tilde_d, *tilde_ye, *tilde_tau, *tilde_s, *tilde_b,
-        *tilde_phi, *lapse, *shift,
-        get<gr::Tags::SqrtDetSpatialMetric<DataVector>>(boundary_values),
-        get<gr::Tags::SpatialMetric<DataVector, 3>>(boundary_values),
-        get<gr::Tags::InverseSpatialMetric<DataVector, 3>>(boundary_values),
-        get<hydro::Tags::Pressure<DataVector>>(boundary_values),
-        get<hydro::Tags::SpatialVelocity<DataVector, 3>>(boundary_values),
-        get<hydro::Tags::LorentzFactor<DataVector>>(boundary_values),
-        get<hydro::Tags::MagneticField<DataVector, 3>>(boundary_values));
-
-    return {};
-  }
+      const tnsr::I<DataVector, 3, Frame::Inertial>& coords,
+      [[maybe_unused]] double time) const;
 
   using fd_interior_evolved_variables_tags = tmpl::list<>;
   using fd_interior_temporary_tags =
@@ -208,30 +138,27 @@ class DirichletAnalytic final : public BoundaryCondition {
                  domain::Tags::ElementMap<3, Frame::Grid>,
                  domain::CoordinateMaps::Tags::CoordinateMap<3, Frame::Grid,
                                                              Frame::Inertial>,
-                 fd::Tags::Reconstructor, ::Tags::AnalyticSolutionOrData>;
-
-  template <typename AnalyticSolutionOrData>
+                 fd::Tags::Reconstructor>;
   void fd_ghost(
-      const gsl::not_null<Scalar<DataVector>*> rest_mass_density,
-      const gsl::not_null<Scalar<DataVector>*> electron_fraction,
-      const gsl::not_null<Scalar<DataVector>*> temperature,
-      const gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*>
+      gsl::not_null<Scalar<DataVector>*> rest_mass_density,
+      gsl::not_null<Scalar<DataVector>*> electron_fraction,
+      gsl::not_null<Scalar<DataVector>*> temperature,
+      gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*>
           lorentz_factor_times_spatial_velocity,
-      const gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*>
-          magnetic_field,
-      const gsl::not_null<Scalar<DataVector>*> divergence_cleaning_field,
+      gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> magnetic_field,
+      gsl::not_null<Scalar<DataVector>*> divergence_cleaning_field,
 
-      const gsl::not_null<std::optional<Variables<db::wrap_tags_in<
+      gsl::not_null<std::optional<Variables<db::wrap_tags_in<
           Flux, typename grmhd::ValenciaDivClean::System::flux_variables>>>*>
           cell_centered_ghost_fluxes,
 
       const Direction<3>& direction,
 
       // fd_interior_temporary_tags
-      const Mesh<3> subcell_mesh,
+      const Mesh<3>& subcell_mesh,
 
       // fd_gridless_tags
-      const double time,
+      [[maybe_unused]] double time,
       const std::unordered_map<
           std::string,
           std::unique_ptr<::domain::FunctionsOfTime::FunctionOfTime>>&
@@ -239,135 +166,9 @@ class DirichletAnalytic final : public BoundaryCondition {
       const ElementMap<3, Frame::Grid>& logical_to_grid_map,
       const domain::CoordinateMapBase<Frame::Grid, Frame::Inertial, 3>&
           grid_to_inertial_map,
-      const fd::Reconstructor& reconstructor,
-      const AnalyticSolutionOrData& analytic_solution_or_data) const {
-    const size_t ghost_zone_size{reconstructor.ghost_zone_size()};
+      const fd::Reconstructor& reconstructor) const;
 
-    const auto ghost_logical_coords =
-        evolution::dg::subcell::fd::ghost_zone_logical_coordinates(
-            subcell_mesh, ghost_zone_size, direction);
-
-    const auto ghost_inertial_coords = grid_to_inertial_map(
-        logical_to_grid_map(ghost_logical_coords), time, functions_of_time);
-
-    // Compute FD ghost data with the analytic data or solution
-    auto boundary_values = [&analytic_solution_or_data, &ghost_inertial_coords,
-                            &time]() {
-      using hydro_tags =
-          tmpl::list<hydro::Tags::RestMassDensity<DataVector>,
-                     hydro::Tags::ElectronFraction<DataVector>,
-                     hydro::Tags::Pressure<DataVector>,
-                     hydro::Tags::Temperature<DataVector>,
-                     hydro::Tags::SpatialVelocity<DataVector, 3>,
-                     hydro::Tags::LorentzFactor<DataVector>,
-                     hydro::Tags::MagneticField<DataVector, 3>,
-                     hydro::Tags::DivergenceCleaningField<DataVector>,
-                     hydro::Tags::SpecificInternalEnergy<DataVector>,
-                     hydro::Tags::SpecificEnthalpy<DataVector>>;
-      if constexpr (std::is_base_of_v<MarkAsAnalyticData,
-                                      AnalyticSolutionOrData>) {
-        (void)time;
-        return analytic_solution_or_data.variables(ghost_inertial_coords,
-                                                   hydro_tags{});
-      } else {
-        return analytic_solution_or_data.variables(ghost_inertial_coords, time,
-                                                   hydro_tags{});
-      }
-    }();
-
-    *rest_mass_density =
-        get<hydro::Tags::RestMassDensity<DataVector>>(boundary_values);
-    *electron_fraction =
-        get<hydro::Tags::ElectronFraction<DataVector>>(boundary_values);
-    *temperature = get<hydro::Tags::Temperature<DataVector>>(boundary_values);
-
-    for (size_t i = 0; i < 3; ++i) {
-      auto& lorentz_factor =
-          get<hydro::Tags::LorentzFactor<DataVector>>(boundary_values);
-      auto& spatial_velocity =
-          get<hydro::Tags::SpatialVelocity<DataVector, 3>>(boundary_values);
-      (*lorentz_factor_times_spatial_velocity).get(i) =
-          get(lorentz_factor) * spatial_velocity.get(i);
-    }
-
-    *magnetic_field =
-        get<hydro::Tags::MagneticField<DataVector, 3>>(boundary_values);
-    *divergence_cleaning_field =
-        get<hydro::Tags::DivergenceCleaningField<DataVector>>(boundary_values);
-
-    if (cell_centered_ghost_fluxes->has_value()) {
-      auto metric_boundary_values = [&analytic_solution_or_data,
-                                     &ghost_inertial_coords, &time]() {
-        using gr_tags = tmpl::list<gr::Tags::Lapse<DataVector>,
-                                   gr::Tags::Shift<DataVector, 3>,
-                                   gr::Tags::SpatialMetric<DataVector, 3>>;
-        if constexpr (std::is_base_of_v<MarkAsAnalyticData,
-                                        AnalyticSolutionOrData>) {
-          (void)time;
-          return analytic_solution_or_data.variables(ghost_inertial_coords,
-                                                     gr_tags{});
-        } else {
-          return analytic_solution_or_data.variables(ghost_inertial_coords,
-                                                     time, gr_tags{});
-        }
-      }();
-      auto [sqrt_det_spatial_metric, inverse_spatial_metric] =
-          determinant_and_inverse(get<gr::Tags::SpatialMetric<DataVector, 3>>(
-              metric_boundary_values));
-      get(sqrt_det_spatial_metric) = sqrt(get(sqrt_det_spatial_metric));
-
-      Variables<typename System::variables_tag::tags_list> conserved_vars{
-          get(*rest_mass_density).size()};
-      ConservativeFromPrimitive::apply(
-          make_not_null(&get<Tags::TildeD>(conserved_vars)),
-          make_not_null(&get<Tags::TildeYe>(conserved_vars)),
-          make_not_null(&get<Tags::TildeTau>(conserved_vars)),
-          make_not_null(&get<Tags::TildeS<>>(conserved_vars)),
-          make_not_null(&get<Tags::TildeB<>>(conserved_vars)),
-          make_not_null(&get<Tags::TildePhi>(conserved_vars)),
-
-          get<hydro::Tags::RestMassDensity<DataVector>>(boundary_values),
-          get<hydro::Tags::ElectronFraction<DataVector>>(boundary_values),
-          get<hydro::Tags::SpecificInternalEnergy<DataVector>>(boundary_values),
-          get<hydro::Tags::Pressure<DataVector>>(boundary_values),
-          get<hydro::Tags::SpatialVelocity<DataVector, 3>>(boundary_values),
-          get<hydro::Tags::LorentzFactor<DataVector>>(boundary_values),
-          get<hydro::Tags::MagneticField<DataVector, 3>>(boundary_values),
-          sqrt_det_spatial_metric,
-          get<gr::Tags::SpatialMetric<DataVector, 3>>(metric_boundary_values),
-          get<hydro::Tags::DivergenceCleaningField<DataVector>>(
-              boundary_values));
-
-      ComputeFluxes::apply(
-          make_not_null(
-              &get<Flux<Tags::TildeD>>(cell_centered_ghost_fluxes->value())),
-          make_not_null(
-              &get<Flux<Tags::TildeYe>>(cell_centered_ghost_fluxes->value())),
-          make_not_null(
-              &get<Flux<Tags::TildeTau>>(cell_centered_ghost_fluxes->value())),
-          make_not_null(
-              &get<Flux<Tags::TildeS<>>>(cell_centered_ghost_fluxes->value())),
-          make_not_null(
-              &get<Flux<Tags::TildeB<>>>(cell_centered_ghost_fluxes->value())),
-          make_not_null(
-              &get<Flux<Tags::TildePhi>>(cell_centered_ghost_fluxes->value())),
-
-          get<Tags::TildeD>(conserved_vars), get<Tags::TildeYe>(conserved_vars),
-          get<Tags::TildeTau>(conserved_vars),
-          get<Tags::TildeS<>>(conserved_vars),
-          get<Tags::TildeB<>>(conserved_vars),
-          get<Tags::TildePhi>(conserved_vars),
-
-          get<gr::Tags::Lapse<DataVector>>(metric_boundary_values),
-          get<gr::Tags::Shift<DataVector, 3>>(metric_boundary_values),
-          sqrt_det_spatial_metric,
-          get<gr::Tags::SpatialMetric<DataVector, 3>>(metric_boundary_values),
-          inverse_spatial_metric,
-          get<hydro::Tags::Pressure<DataVector>>(boundary_values),
-          get<hydro::Tags::SpatialVelocity<DataVector, 3>>(boundary_values),
-          get<hydro::Tags::LorentzFactor<DataVector>>(boundary_values),
-          get<hydro::Tags::MagneticField<DataVector, 3>>(boundary_values));
-    }
-  }
+ private:
+  std::unique_ptr<evolution::initial_data::InitialData> analytic_prescription_;
 };
 }  // namespace grmhd::ValenciaDivClean::BoundaryConditions

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/CMakeLists.txt
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/CMakeLists.txt
@@ -30,6 +30,7 @@ spectre_target_headers(
   ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
+  AllSolutions.hpp
   Characteristics.hpp
   ComovingMagneticFieldMagnitude.hpp
   ConservativeFromPrimitive.hpp
@@ -64,11 +65,14 @@ target_link_libraries(
   Evolution
   FiniteDifference
   GeneralRelativity
+  GrMhdAnalyticData
+  GrMhdSolutions
   H5
   Hydro
   HydroHelpers
   Limiters
   Options
+  RelativisticEulerSolutions
   Utilities
   Valencia
   VariableFixing

--- a/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/WrappedGr.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/WrappedGr.hpp
@@ -65,7 +65,9 @@ class WrappedGr : public virtual evolution::initial_data::InitialData,
   static constexpr size_t volume_dim = SolutionType::volume_dim;
   using options = typename SolutionType::options;
   static constexpr Options::String help = SolutionType::help;
-  static std::string name() { return pretty_type::name<SolutionType>(); }
+  static std::string name() {
+    return "GeneralizedHarmonic(" + pretty_type::name<SolutionType>() + ")";
+  }
 
   using DerivLapse = ::Tags::deriv<gr::Tags::Lapse<DataVector>,
                                    tmpl::size_t<volume_dim>, Frame::Inertial>;

--- a/tests/InputFiles/GeneralizedHarmonic/GaugeWave1D.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/GaugeWave1D.yaml
@@ -34,7 +34,7 @@ PhaseChangeAndTriggers:
           WallclockHours: None
 
 InitialData: &InitialData
-  GaugeWave:
+  GeneralizedHarmonic(GaugeWave):
     Amplitude: 0.5
     Wavelength: 6.283185307179586
 

--- a/tests/InputFiles/GeneralizedHarmonic/GaugeWave3D.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/GaugeWave3D.yaml
@@ -35,7 +35,7 @@ PhaseChangeAndTriggers:
           WallclockHours: None
 
 InitialData: &InitialData
-  GaugeWave:
+  GeneralizedHarmonic(GaugeWave):
     Amplitude: 0.1
     Wavelength: 1.0
 

--- a/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
@@ -41,7 +41,7 @@ PhaseChangeAndTriggers:
           WallclockHours: None
 
 InitialData: &InitialData
-  KerrSchild:
+  GeneralizedHarmonic(KerrSchild):
     Mass: 1.0
     Spin: [0.0, 0.0, 0.0]
     Center: &Center [0.0, 0.0, 0.0]

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdBondiMichel.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdBondiMichel.yaml
@@ -33,7 +33,7 @@ PhaseChangeAndTriggers:
       - VisitAndReturn(LoadBalancing)
 
 AnalyticSolution: &InitialData
-  BondiMichel:
+  GeneralizedHarmonic(BondiMichel):
     Mass: 1.0
     SonicRadius: 6.0
     SonicDensity: 1.0e-5
@@ -50,6 +50,13 @@ DomainCreator:
           GeneralizedHarmonicDirichletAnalytic:
             AnalyticPrescription: *InitialData
           ValenciaDirichletAnalytic:
+            AnalyticPrescription:
+              BondiMichel:
+                Mass: 1.0
+                SonicRadius: 6.0
+                SonicDensity: 1.0e-5
+                PolytropicExponent: 1.4
+                MagFieldStrength: 1.0e-2
     InitialRefinement: 1
     InitialGridPoints: 2
     UseEquiangularMap: true
@@ -63,6 +70,13 @@ DomainCreator:
         GeneralizedHarmonicDirichletAnalytic:
           AnalyticPrescription: *InitialData
         ValenciaDirichletAnalytic:
+          AnalyticPrescription:
+            BondiMichel:
+              Mass: 1.0
+              SonicRadius: 6.0
+              SonicDensity: 1.0e-5
+              PolytropicExponent: 1.4
+              MagFieldStrength: 1.0e-2
 
 VariableFixing:
   FixConservatives:

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdTovStar.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdTovStar.yaml
@@ -33,7 +33,7 @@ PhaseChangeAndTriggers:
       - VisitAndReturn(LoadBalancing)
 
 AnalyticSolution: &InitialData
-  TovStar:
+  GeneralizedHarmonic(TovStar):
     CentralDensity: 1.28e-3
     EquationOfState:
         PolytropicFluid:
@@ -52,10 +52,13 @@ DomainCreator:
     TimeDependence: None
     BoundaryConditionInX:
       DirichletAnalytic:
+        AnalyticPrescription: *InitialData
     BoundaryConditionInY:
       DirichletAnalytic:
+        AnalyticPrescription: *InitialData
     BoundaryConditionInZ:
       DirichletAnalytic:
+        AnalyticPrescription: *InitialData
 
 VariableFixing:
   FixConservatives:

--- a/tests/InputFiles/GrMhd/ValenciaDivClean/FishboneMoncriefDisk.yaml
+++ b/tests/InputFiles/GrMhd/ValenciaDivClean/FishboneMoncriefDisk.yaml
@@ -43,6 +43,15 @@ PhaseChangeAndTriggers:
       - CheckpointAndExitAfterWallclock:
           WallclockHours: None
 
+AnalyticSolution: &initial_data
+  FishboneMoncriefDisk:
+    BhMass: &BhMass 1.0
+    BhDimlessSpin: &BhDimlessSpin 0.9375
+    InnerEdgeRadius: 6.0
+    MaxPressureRadius: 12.0
+    PolytropicConstant: 0.001
+    PolytropicExponent: 1.3333333333333333333333
+
 DomainCreator:
   Brick:
     LowerBound: [10.5, 0.0, 0.0]
@@ -50,9 +59,16 @@ DomainCreator:
     InitialRefinement: [0, 0, 0]
     InitialGridPoints: [5, 5, 5]
     TimeDependence: None
-    BoundaryConditionInX: DirichletAnalytic
-    BoundaryConditionInY: DirichletAnalytic
-    BoundaryConditionInZ: DirichletAnalytic
+    BoundaryConditionInX:
+      DirichletAnalytic:
+        AnalyticPrescription: *initial_data
+    BoundaryConditionInY:
+      DirichletAnalytic:
+        AnalyticPrescription: *initial_data
+    BoundaryConditionInZ:
+      DirichletAnalytic:
+        AnalyticPrescription: *initial_data
+
 
 SpatialDiscretization:
   BoundaryCorrection:
@@ -84,14 +100,6 @@ SpatialDiscretization:
     Reconstructor:
       MonotonisedCentralPrim:
 
-AnalyticSolution:
-  FishboneMoncriefDisk:
-    BhMass: &BhMass 1.0
-    BhDimlessSpin: &BhDimlessSpin 0.9375
-    InnerEdgeRadius: 6.0
-    MaxPressureRadius: 12.0
-    PolytropicConstant: 0.001
-    PolytropicExponent: 1.3333333333333333333333
 
 EvolutionSystem:
   ValenciaDivClean:

--- a/tests/InputFiles/ScalarTensor/KerrSchildSphericalHarmonic.yaml
+++ b/tests/InputFiles/ScalarTensor/KerrSchildSphericalHarmonic.yaml
@@ -38,7 +38,7 @@ Evolution:
 PhaseChangeAndTriggers:
 
 InitialData: &InitialData
-  KerrSphericalHarmonic:
+  GeneralizedHarmonic(KerrSphericalHarmonic):
     Mass: 1.0
     Spin: [0.0, 0.0, 0.0]
     Amplitude: 0.001

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Actions/Test_SetInitialData.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Actions/Test_SetInitialData.cpp
@@ -316,7 +316,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Gh.NumericInitialData",
   test_set_initial_data(
       gh::Solutions::WrappedGr<gr::Solutions::KerrSchild>{
           1., {{0., 0., 0.}}, {{0., 0., 0.}}},
-      "KerrSchild:\n"
+      "GeneralizedHarmonic(KerrSchild):\n"
       "  Mass: 1.\n"
       "  Spin: [0, 0, 0]\n"
       "  Center: [0, 0, 0]",

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Test_DirichletAnalytic.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Test_DirichletAnalytic.cpp
@@ -107,7 +107,7 @@ void test() {
           "constraint_gamma2", "lapse", "shift"},
       "DirichletAnalytic:\n"
       "  AnalyticPrescription:\n"
-      "    GaugeWave:\n"
+      "    GeneralizedHarmonic(GaugeWave):\n"
       "      Amplitude: 0.2\n"
       "      Wavelength: 10.0\n",
       Index<Dim - 1>{Dim == 1 ? 1 : 5}, box_analytic_soln,

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Test_AnalyticChristoffel.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Test_AnalyticChristoffel.cpp
@@ -81,11 +81,12 @@ template <size_t Dim>
 void test_gauge_wave(const Mesh<Dim>& mesh) {
   const auto gauge_condition = serialize_and_deserialize(
       TestHelpers::test_creation<std::unique_ptr<gh::gauges::GaugeCondition>,
-                                 Metavariables<Dim>>("AnalyticChristoffel:\n"
-                                                     "  AnalyticPrescription:\n"
-                                                     "    GaugeWave:\n"
-                                                     "      Amplitude: 0.0012\n"
-                                                     "      Wavelength: 1.4\n")
+                                 Metavariables<Dim>>(
+          "AnalyticChristoffel:\n"
+          "  AnalyticPrescription:\n"
+          "    GeneralizedHarmonic(GaugeWave):\n"
+          "      Amplitude: 0.0012\n"
+          "      Wavelength: 1.4\n")
           ->get_clone());
   CHECK_FALSE(gauge_condition->is_harmonic());
 
@@ -118,7 +119,7 @@ void test_ks(const Mesh<3>& mesh) {
                                  Metavariables<3>>(
           "AnalyticChristoffel:\n"
           "  AnalyticPrescription:\n"
-          "    KerrSchild:\n"
+          "    GeneralizedHarmonic(KerrSchild):\n"
           "      Mass: 1.2\n"
           "      Spin: [0.1, 0.2, 0.3]\n"
           "      Center: [-0.1, -0.2, -0.4]\n")

--- a/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/Actions/Test_SetInitialData.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/Actions/Test_SetInitialData.cpp
@@ -388,7 +388,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.GhValenciaDivClean.SetInitialData",
         TovStar{1.e-3,
                 std::make_unique<EquationsOfState::PolytropicFluid<true>>(100.,
                                                                           2.)},
-        "TovStar:\n"
+        "GeneralizedHarmonic(TovStar):\n"
         "  CentralDensity: 1.e-3\n"
         "  EquationOfState:\n"
         "    PolytropicFluid:\n"

--- a/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/Test_BoundaryConditionGhostData.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/Test_BoundaryConditionGhostData.cpp
@@ -82,8 +82,12 @@ struct EvolutionMetaVars {
   };
 };
 
+using SolutionForTest =
+    gh::Solutions::WrappedGr<RelativisticEuler::Solutions::TovStar>;
+
 template <typename BoundaryConditionType>
-void test(const BoundaryConditionType& boundary_condition) {
+void test(const BoundaryConditionType& boundary_condition,
+          const SolutionForTest& solution) {
   CAPTURE(pretty_type::name<BoundaryConditionType>());
   const size_t num_dg_pts = 4;
 
@@ -143,11 +147,6 @@ void test(const BoundaryConditionType& boundary_condition) {
           domain::CoordinateMaps::Identity<3>{});
 
   const auto subcell_logical_coords = logical_coordinates(subcell_mesh);
-
-  const gh::Solutions::WrappedGr solution{RelativisticEuler::Solutions::TovStar{
-      1.28e-3, EquationsOfState::PolytropicFluid<true>{100.0, 2.0}.get_clone(),
-      RelativisticEuler::Solutions::TovCoordinates::Schwarzschild}};
-  using SolutionForTest = std::decay_t<decltype(solution)>;
 
   // Below are tags used for testing Outflow boundary condition
   //  - volume metric and primitive variables on subcell mesh
@@ -216,10 +215,10 @@ void test(const BoundaryConditionType& boundary_condition) {
 
   get(get<RestMassDensity>(volume_prim_vars)) = 1.0;
   get(get<ElectronFraction>(volume_prim_vars)) = 0.1;
-  get(get<Pressure>(volume_prim_vars)) = 1.0;
-  get<Temperature>(volume_prim_vars) =
-      solution.equation_of_state().temperature_from_density(
-          get<RestMassDensity>(volume_prim_vars));
+  get(get<Temperature>(volume_prim_vars)) = 0.5;
+  get(get<Pressure>(volume_prim_vars)) =
+      get(solution.equation_of_state().pressure_from_density(
+          get<RestMassDensity>(volume_prim_vars)));
   get(get<LorentzFactor>(volume_prim_vars)) = 2.0;
   for (size_t i = 0; i < 3; ++i) {
     get<SpatialVelocity>(volume_prim_vars).get(i) = 0.1;
@@ -240,8 +239,7 @@ void test(const BoundaryConditionType& boundary_condition) {
       domain::Tags::ElementMap<3, Frame::Grid>,
       domain::CoordinateMaps::Tags::CoordinateMap<3, Frame::Grid,
                                                   Frame::Inertial>,
-      typename System::primitive_variables_tag,
-      ::Tags::AnalyticSolution<SolutionForTest>>>(
+      typename System::primitive_variables_tag>>(
       EvolutionMetaVars{}, std::move(domain), std::move(boundary_conditions),
       subcell_mesh, subcell_logical_coords, neighbor_data,
       std::unique_ptr<fd::Reconstructor>{
@@ -254,7 +252,7 @@ void test(const BoundaryConditionType& boundary_condition) {
               domain::CoordinateMaps::Identity<3>{})},
       domain::make_coordinate_map_base<Frame::Grid, Frame::Inertial>(
           domain::CoordinateMaps::Identity<3>{}),
-      volume_prim_vars, solution);
+      volume_prim_vars);
 
   // compute FD ghost data and retrieve the result
   fd::BoundaryConditionGhostData::apply(make_not_null(&box), element,
@@ -335,10 +333,16 @@ SPECTRE_TEST_CASE(
     "[Unit][Evolution]") {
   pypp::SetupLocalPythonEnvironment local_python_env{
       "PointwiseFunctions/AnalyticSolutions/"};
-
-  test(grmhd::GhValenciaDivClean::BoundaryConditions::DirichletAnalytic{});
+  const SolutionForTest solution{RelativisticEuler::Solutions::TovStar{
+      1.28e-3, EquationsOfState::PolytropicFluid<true>{100.0, 2.0}.get_clone(),
+      RelativisticEuler::Solutions::TovCoordinates::Schwarzschild}};
+  test(
+      grmhd::GhValenciaDivClean::BoundaryConditions::DirichletAnalytic{
+          std::make_unique<SolutionForTest>(solution)},
+      solution);
   CHECK_THROWS_WITH(test(grmhd::GhValenciaDivClean::BoundaryConditions::
-                             ConstraintPreservingFreeOutflow{}),
+                             ConstraintPreservingFreeOutflow{},
+                         solution),
                     Catch::Matchers::ContainsSubstring(
                         "Not implemented because it's not trivial "
                         "to figure out what the right way of"));
@@ -347,7 +351,8 @@ SPECTRE_TEST_CASE(
 #ifdef SPECTRE_DEBUG
   CHECK_THROWS_WITH(
       test(domain::BoundaryConditions::Periodic<
-           BoundaryConditions::BoundaryCondition>{}),
+               BoundaryConditions::BoundaryCondition>{},
+           solution),
       Catch::Matchers::ContainsSubstring("not on external boundaries"));
 #endif
 }

--- a/tests/Unit/Evolution/Systems/ScalarTensor/BoundaryConditions/Test_ProductOfConditions.cpp
+++ b/tests/Unit/Evolution/Systems/ScalarTensor/BoundaryConditions/Test_ProductOfConditions.cpp
@@ -315,7 +315,7 @@ SPECTRE_TEST_CASE(
         "ProductDirichletAnalyticAndAnalyticConstant:\n"
         "  GeneralizedHarmonicDirichletAnalytic:\n"
         "    AnalyticPrescription:\n"
-        "      KerrSphericalHarmonic:\n"
+        "      GeneralizedHarmonic(KerrSphericalHarmonic):\n"
         "        Mass: 1.5\n"
         "        Spin: [0.1, -0.2, 0.3]\n"
         "        Amplitude: 2.3\n"


### PR DESCRIPTION
## Proposed changes

The dirchlet analytic and dirichlet free outflow boundary conditions currently require an `AnalyticSolutionOrData`, and automatically inherit this from the initial data.  This PR changes the way these conditions are defined to store their own `AnalyticPrescription` which can be any `InitialData` (although currently numeric initial data is not supported because it cannot deploy `variables`).  This PR is necessary for making initial data runtime.  

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
Gh-based initial data (which uses the WrappedGr wrapper class to add Gh) will require a wrapper `GeneralizedHarmonic` in input files. For example:

`TovStar:`  
would become
`GeneralizedHarmonic(TovStar):`
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
