### PR TITLE
Optimize interpolation onto sphere targets

### DIFF
--- a/src/ControlSystem/Measurements/CharSpeed.hpp
+++ b/src/ControlSystem/Measurements/CharSpeed.hpp
@@ -45,6 +45,8 @@ class GlobalCache;
 namespace domain::Tags {
 template <size_t Dim>
 struct Mesh;
+template <size_t Dim, typename Frame>
+struct Coordinates;
 }  // namespace domain::Tags
 /// \endcond
 
@@ -106,7 +108,8 @@ struct CharSpeed : tt::ConformsTo<protocols::Measurement> {
 
     using argument_tags =
         tmpl::push_front<::ah::source_vars<3>, intrp::Tags::InterpPointInfoBase,
-                         domain::Tags::Mesh<3>>;
+                         domain::Tags::Mesh<3>,
+                         domain::Tags::Coordinates<3, ::Frame::Grid>>;
 
     template <typename Metavariables, typename ParallelComponent,
               typename ControlSystems>
@@ -114,6 +117,7 @@ struct CharSpeed : tt::ConformsTo<protocols::Measurement> {
         const typename intrp::Tags::InterpPointInfo<Metavariables>::type&
             point_infos,
         const Mesh<3>& mesh,
+        const tnsr::I<DataVector, 3, ::Frame::Grid>& grid_coords,
         const tnsr::aa<DataVector, 3, ::Frame::Inertial>& spacetime_metric,
         const tnsr::aa<DataVector, 3, ::Frame::Inertial>& pi,
         const tnsr::iaa<DataVector, 3, ::Frame::Inertial>& phi,
@@ -129,9 +133,9 @@ struct CharSpeed : tt::ConformsTo<protocols::Measurement> {
       Event event{};
 
       // ObservationValue unused
-      event(measurement_id, point_infos, mesh, spacetime_metric, pi, phi,
-            deriv_phi, constraint_gamma1, cache, array_index, component,
-            ::Event::ObservationValue{});
+      event(measurement_id, point_infos, mesh, grid_coords, spacetime_metric,
+            pi, phi, deriv_phi, constraint_gamma1, cache, array_index,
+            component, ::Event::ObservationValue{});
     }
   };
 

--- a/src/Domain/BlockLogicalCoordinates.cpp
+++ b/src/Domain/BlockLogicalCoordinates.cpp
@@ -83,13 +83,13 @@ std::vector<block_logical_coord_holder<Dim>> block_logical_coordinates(
             //    because only those Blocks have distortion maps. Thus,
             //    the Blocks that are skipped here are those that are far
             //    from horizons).
-            continue; // Not in this block
+            continue;  // Not in this block
           }
           const auto moving_inv =
               block.moving_mesh_grid_to_distorted_map().inverse(
                   x_frame, time, functions_of_time);
           if (not moving_inv.has_value()) {
-            continue; // Not in this block
+            continue;  // Not in this block
           }
           // logical to grid map is time-independent.
           const auto inv = block.moving_mesh_logical_to_grid_map().inverse(
@@ -104,7 +104,7 @@ std::vector<block_logical_coord_holder<Dim>> block_logical_coordinates(
           // Currently 'time' is unused in this branch.
           // To make the compiler happy, need to trick it to think that
           // 'time' is used.
-          (void) time;
+          (void)time;
           // Currently we only support Grid, Distorted and Inertial
           // frames in the block, so make sure Frame is
           // ::Frame::Grid. (The Inertial and Distorted cases were

--- a/src/Domain/BlockLogicalCoordinates.cpp
+++ b/src/Domain/BlockLogicalCoordinates.cpp
@@ -9,6 +9,7 @@
 #include "DataStructures/IdPair.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Domain/Block.hpp"
 #include "Domain/Domain.hpp"  // IWYU pragma: keep
 #include "Domain/Structure/BlockId.hpp"
 #include "Utilities/EqualWithinRoundoff.hpp"
@@ -26,6 +27,122 @@ using functions_of_time_type = std::unordered_map<
 }  // namespace
 
 template <size_t Dim, typename Frame>
+std::optional<tnsr::I<double, Dim, ::Frame::BlockLogical>>
+block_logical_coordinates_single_point(
+    const tnsr::I<double, Dim, Frame>& input_point, const Block<Dim>& block,
+    const double time, const functions_of_time_type& functions_of_time) {
+  std::optional<tnsr::I<double, Dim, ::Frame::BlockLogical>> logical_point{};
+  if (block.is_time_dependent()) {
+    if constexpr (std::is_same_v<Frame, ::Frame::Inertial>) {
+      // Point is in the inertial frame, so we need to map to the grid
+      // frame and then the logical frame.
+      const auto moving_inv = block.moving_mesh_grid_to_inertial_map().inverse(
+          input_point, time, functions_of_time);
+      if (not moving_inv.has_value()) {
+        return std::nullopt;
+      }
+      // logical to grid map is time-independent.
+      logical_point =
+          block.moving_mesh_logical_to_grid_map().inverse(moving_inv.value());
+    } else if constexpr (std::is_same_v<Frame, ::Frame::Distorted>) {
+      // Point is in the distorted frame, so we need to map to the grid
+      // frame and then the logical frame.
+      if (not block.has_distorted_frame()) {
+        // Note that block.has_distorted_frame() can be different for
+        // different Blocks.  However, the template parameter Frame is
+        // compile-time and is the same for all Blocks.
+        //
+        // Explanation of the logic here:
+        // 1. Recall that block_logical_coordinates loops through all the
+        //    Blocks, and skips all the Blocks except for the first Block
+        //    it finds that contains the point x.
+        // 2. If Frame is ::Frame::Distorted but
+        //    block.has_distorted_frame() is false, then this block
+        //    cannot contain the point x. Therefore, we should simply
+        //    skip this block.  If it turns out that no blocks contain
+        //    the point x, then we will get an error later.
+        //    (Note that our primary use case for ::Frame::Distorted is to
+        //    find an apparent horizon in the distorted frame. In that
+        //    case, only the Blocks near a horizon have a distorted frame
+        //    because only those Blocks have distortion maps. Thus,
+        //    the Blocks that are skipped here are those that are far
+        //    from horizons).
+        return std::nullopt;  // Not in this block
+      }
+      const auto moving_inv = block.moving_mesh_grid_to_distorted_map().inverse(
+          input_point, time, functions_of_time);
+      if (not moving_inv.has_value()) {
+        return std::nullopt;  // Not in this block
+      }
+      // logical to grid map is time-independent.
+      logical_point =
+          block.moving_mesh_logical_to_grid_map().inverse(moving_inv.value());
+    } else {
+      // frame is different than ::Frame::Inertial or ::Frame::Distorted.
+      // Currently 'time' is unused in this branch.
+      // To make the compiler happy, need to trick it to think that
+      // 'time' is used.
+      (void)time;
+      // Currently we only support Grid, Distorted and Inertial
+      // frames in the block, so make sure Frame is
+      // ::Frame::Grid. (The Inertial and Distorted cases were
+      // handled above.)
+      static_assert(std::is_same_v<Frame, ::Frame::Grid>,
+                    "Cannot convert from given frame to Grid frame");
+
+      // Point is in the grid frame, just map to logical frame.
+      logical_point =
+          block.moving_mesh_logical_to_grid_map().inverse(input_point);
+    }
+  } else {  // not block.is_time_dependent()
+    if constexpr (std::is_same_v<Frame, ::Frame::Inertial>) {
+      logical_point = block.stationary_map().inverse(input_point);
+    } else {
+      // If the map is time-independent, then the grid, distorted, and
+      // inertial frames are the same.  So if we are in the grid
+      // or distorted frames, convert to the inertial frame
+      // (this conversion is just a type conversion).
+      // Otherwise throw a static_assert.
+      static_assert(std::is_same_v<Frame, ::Frame::Grid> or
+                        std::is_same_v<Frame, ::Frame::Distorted>,
+                    "Cannot convert from given frame to Inertial frame");
+      tnsr::I<double, Dim, ::Frame::Inertial> x_inertial(0.0);
+      for (size_t d = 0; d < Dim; ++d) {
+        x_inertial.get(d) = input_point.get(d);
+      }
+      logical_point = block.stationary_map().inverse(x_inertial);
+    }
+  }
+
+  if (not logical_point.has_value()) {
+    return std::nullopt;
+  }
+
+  for (size_t d = 0; d < Dim; ++d) {
+    // Map inverses may report logical coordinates outside [-1, 1] due to
+    // numerical roundoff error. In that case we clamp them to -1 or 1 so
+    // that a consistent block is chosen here independent of roundoff error.
+    // Without this correction, points on block boundaries where both blocks
+    // report logical coordinates outside [-1, 1] by roundoff error would
+    // not be assigned to any block at all, even though they lie in the
+    // domain.
+    if (equal_within_roundoff(logical_point->get(d), 1.0)) {
+      logical_point->get(d) = 1.0;
+      continue;
+    }
+    if (equal_within_roundoff(logical_point->get(d), -1.0)) {
+      logical_point->get(d) = -1.0;
+      continue;
+    }
+    if (abs(logical_point->get(d)) > 1.0) {
+      return std::nullopt;
+    }
+  }
+
+  return logical_point;
+}
+
+template <size_t Dim, typename Frame>
 std::vector<block_logical_coord_holder<Dim>> block_logical_coordinates(
     const Domain<Dim>& domain, const tnsr::I<DataVector, Dim, Frame>& x,
     const double time, const functions_of_time_type& functions_of_time) {
@@ -36,144 +153,20 @@ std::vector<block_logical_coord_holder<Dim>> block_logical_coordinates(
     for (size_t d = 0; d < Dim; ++d) {
       x_frame.get(d) = x.get(d)[s];
     }
-    tnsr::I<double, Dim, typename ::Frame::BlockLogical> x_logical{};
     // Check which block this point is in. Each point will be in one
     // and only one block, unless it is on a shared boundary.  In that
     // case, choose the first matching block (and this block will have
     // the smallest block_id).
     for (const auto& block : domain.blocks()) {
-      if (block.is_time_dependent()) {
-        if constexpr (std::is_same_v<Frame, ::Frame::Inertial>) {
-          // Point is in the inertial frame, so we need to map to the grid
-          // frame and then the logical frame.
-          const auto moving_inv =
-              block.moving_mesh_grid_to_inertial_map().inverse(
-                  x_frame, time, functions_of_time);
-          if (not moving_inv.has_value()) {
-            continue;
-          }
-          // logical to grid map is time-independent.
-          const auto inv = block.moving_mesh_logical_to_grid_map().inverse(
-              moving_inv.value());
-          if (inv.has_value()) {
-            x_logical = inv.value();
-          } else {
-            continue;  // Not in this block
-          }
-        } else if constexpr (std::is_same_v<Frame, ::Frame::Distorted>) {
-          // Point is in the distorted frame, so we need to map to the grid
-          // frame and then the logical frame.
-          if (not block.has_distorted_frame()) {
-            // Note that block.has_distorted_frame() can be different for
-            // different Blocks.  However, the template parameter Frame is
-            // compile-time and is the same for all Blocks.
-            //
-            // Explanation of the logic here:
-            // 1. Recall that block_logical_coordinates loops through all the
-            //    Blocks, and skips all the Blocks except for the first Block
-            //    it finds that contains the point x.
-            // 2. If Frame is ::Frame::Distorted but
-            //    block.has_distorted_frame() is false, then this block
-            //    cannot contain the point x. Therefore, we should simply
-            //    skip this block.  If it turns out that no blocks contain
-            //    the point x, then we will get an error later.
-            //    (Note that our primary use case for ::Frame::Distorted is to
-            //    find an apparent horizon in the distorted frame. In that
-            //    case, only the Blocks near a horizon have a distorted frame
-            //    because only those Blocks have distortion maps. Thus,
-            //    the Blocks that are skipped here are those that are far
-            //    from horizons).
-            continue;  // Not in this block
-          }
-          const auto moving_inv =
-              block.moving_mesh_grid_to_distorted_map().inverse(
-                  x_frame, time, functions_of_time);
-          if (not moving_inv.has_value()) {
-            continue;  // Not in this block
-          }
-          // logical to grid map is time-independent.
-          const auto inv = block.moving_mesh_logical_to_grid_map().inverse(
-              moving_inv.value());
-          if (inv.has_value()) {
-            x_logical = inv.value();
-          } else {
-            continue;  // Not in this block
-          }
-        } else {
-          // frame is different than ::Frame::Inertial or ::Frame::Distorted.
-          // Currently 'time' is unused in this branch.
-          // To make the compiler happy, need to trick it to think that
-          // 'time' is used.
-          (void)time;
-          // Currently we only support Grid, Distorted and Inertial
-          // frames in the block, so make sure Frame is
-          // ::Frame::Grid. (The Inertial and Distorted cases were
-          // handled above.)
-          static_assert(std::is_same_v<Frame, ::Frame::Grid>,
-                        "Cannot convert from given frame to Grid frame");
+      std::optional<tnsr::I<double, Dim, ::Frame::BlockLogical>> x_logical =
+          block_logical_coordinates_single_point(x_frame, block, time,
+                                                 functions_of_time);
 
-          // Point is in the grid frame, just map to logical frame.
-          const auto inv =
-              block.moving_mesh_logical_to_grid_map().inverse(x_frame);
-          if (inv.has_value()) {
-            x_logical = inv.value();
-          } else {
-            continue;  // Not in this block
-          }
-        }
-      } else {  // not block.is_time_dependent()
-        if constexpr (std::is_same_v<Frame, ::Frame::Inertial>) {
-          const auto inv = block.stationary_map().inverse(x_frame);
-          if (inv.has_value()) {
-            x_logical = inv.value();
-          } else {
-            continue;  // Not in this block
-          }
-        } else {
-          // If the map is time-independent, then the grid, distorted, and
-          // inertial frames are the same.  So if we are in the grid
-          // or distorted frames, convert to the inertial frame
-          // (this conversion is just a type conversion).
-          // Otherwise throw a static_assert.
-          static_assert(std::is_same_v<Frame, ::Frame::Grid> or
-                            std::is_same_v<Frame, ::Frame::Distorted>,
-                        "Cannot convert from given frame to Inertial frame");
-          tnsr::I<double, Dim, ::Frame::Inertial> x_inertial(0.0);
-          for (size_t d = 0; d < Dim; ++d) {
-            x_inertial.get(d) = x_frame.get(d);
-          }
-          const auto inv = block.stationary_map().inverse(x_inertial);
-          if (inv.has_value()) {
-            x_logical = inv.value();
-          } else {
-            continue;  // Not in this block
-          }
-        }
-      }
-      bool is_contained = true;
-      for (size_t d = 0; d < Dim; ++d) {
-        // Map inverses may report logical coordinates outside [-1, 1] due to
-        // numerical roundoff error. In that case we clamp them to -1 or 1 so
-        // that a consistent block is chosen here independent of roundoff error.
-        // Without this correction, points on block boundaries where both blocks
-        // report logical coordinates outside [-1, 1] by roundoff error would
-        // not be assigned to any block at all, even though they lie in the
-        // domain.
-        if (equal_within_roundoff(x_logical.get(d), 1.0)) {
-          x_logical.get(d) = 1.0;
-          continue;
-        }
-        if (equal_within_roundoff(x_logical.get(d), -1.0)) {
-          x_logical.get(d) = -1.0;
-          continue;
-        }
-        is_contained = is_contained and abs(x_logical.get(d)) <= 1.0;
-      }
-      if (is_contained) {
+      if (x_logical.has_value()) {
         // Point is in this block.  Don't bother checking subsequent
         // blocks.
-        block_coord_holders[s] =
-            make_id_pair(domain::BlockId(block.id()), std::move(x_logical));
+        block_coord_holders[s] = make_id_pair(domain::BlockId(block.id()),
+                                              std::move(x_logical.value()));
         break;
       }
     }
@@ -186,6 +179,11 @@ std::vector<block_logical_coord_holder<Dim>> block_logical_coordinates(
 #define FRAME(data) BOOST_PP_TUPLE_ELEM(1, data)
 
 #define INSTANTIATE(_, data)                                                   \
+  template std::optional<tnsr::I<double, DIM(data), ::Frame::BlockLogical>>    \
+  block_logical_coordinates_single_point(                                      \
+      const tnsr::I<double, DIM(data), FRAME(data)>& input_point,              \
+      const Block<DIM(data)>& block, const double time,                        \
+      const functions_of_time_type& functions_of_time);                        \
   template std::vector<block_logical_coord_holder<DIM(data)>>                  \
   block_logical_coordinates(                                                   \
       const Domain<DIM(data)>& domain,                                         \

--- a/src/Domain/BlockLogicalCoordinates.hpp
+++ b/src/Domain/BlockLogicalCoordinates.hpp
@@ -19,8 +19,11 @@
 class DataVector;
 template <size_t VolumeDim>
 class Domain;
+template <size_t VolumeDim>
+class Block;
 /// \endcond
 
+/// @{
 /// \ingroup ComputationalDomainGroup
 ///
 /// Computes the block logical coordinates and the containing `BlockId` of
@@ -35,6 +38,11 @@ class Domain;
 /// If a point is on a shared boundary of two or more `Block`s, it is
 /// returned only once, and is considered to belong to the `Block`
 /// with the smaller `BlockId`.
+///
+/// The `block_logical_coordinates_single_point` function will search the passed
+/// in block for the passed in coordinate and return the logical coordinates of
+/// that point. It will return a `std::nullopt` if it can't find the point in
+/// that block.
 ///
 /// \warning Since map inverses can involve numerical roundoff error, care must
 /// be taken with points on shared block boundaries. They will be assigned to
@@ -61,3 +69,15 @@ auto block_logical_coordinates(
             std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>{})
     -> std::vector<std::optional<
         IdPair<domain::BlockId, tnsr::I<double, Dim, ::Frame::BlockLogical>>>>;
+
+template <size_t Dim, typename Frame>
+std::optional<tnsr::I<double, Dim, ::Frame::BlockLogical>>
+block_logical_coordinates_single_point(
+    const tnsr::I<double, Dim, Frame>& input_point, const Block<Dim>& block,
+    double time = std::numeric_limits<double>::signaling_NaN(),
+    const std::unordered_map<
+        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+        functions_of_time = std::unordered_map<
+            std::string,
+            std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>{});
+/// @}

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
@@ -537,8 +537,7 @@ struct EvolutionMetavars {
           Initialization::TimeStepperHistory<EvolutionMetavars>>,
       Initialization::Actions::NonconservativeSystem<system>,
       Initialization::Actions::AddComputeTags<tmpl::list<::Tags::DerivCompute<
-          typename system::variables_tag,
-          ::domain::Tags::Mesh<volume_dim>,
+          typename system::variables_tag, ::domain::Tags::Mesh<volume_dim>,
           ::domain::Tags::InverseJacobian<volume_dim, Frame::ElementLogical,
                                           Frame::Inertial>,
           typename system::gradient_variables>>>,

--- a/src/Evolution/Executables/GeneralizedHarmonic/GeneralizedHarmonicBase.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/GeneralizedHarmonicBase.hpp
@@ -365,8 +365,7 @@ struct GeneralizedHarmonicTemplateBase {
           Initialization::TimeStepperHistory<DerivedMetavars>>,
       Initialization::Actions::NonconservativeSystem<system>,
       Initialization::Actions::AddComputeTags<::Tags::DerivCompute<
-          typename system::variables_tag,
-          domain::Tags::Mesh<volume_dim>,
+          typename system::variables_tag, domain::Tags::Mesh<volume_dim>,
           domain::Tags::InverseJacobian<volume_dim, Frame::ElementLogical,
                                         Frame::Inertial>,
           typename system::gradient_variables>>,

--- a/src/ParallelAlgorithms/Interpolation/Events/InterpolateWithoutInterpComponent.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Events/InterpolateWithoutInterpComponent.hpp
@@ -3,32 +3,52 @@
 
 #pragma once
 
+#include <array>
 #include <cstddef>
+#include <limits>
+#include <optional>
 #include <pup.h>
+#include <set>
+#include <utility>
+#include <vector>
 
 #include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/IdPair.hpp"
+#include "DataStructures/Index.hpp"
 #include "Domain/Creators/Tags/Domain.hpp"
+#include "Domain/Domain.hpp"
 #include "Domain/ElementLogicalCoordinates.hpp"
 #include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "Domain/Structure/BlockId.hpp"
 #include "Domain/Structure/ElementId.hpp"
+#include "Domain/Tags.hpp"
 #include "NumericalAlgorithms/Interpolation/IrregularInterpolant.hpp"
 #include "Options/String.hpp"
 #include "Parallel/GlobalCache.hpp"
 #include "Parallel/Invoke.hpp"
+#include "Parallel/ParallelComponentHelpers.hpp"
 #include "ParallelAlgorithms/EventsAndTriggers/Event.hpp"
 #include "ParallelAlgorithms/Interpolation/Actions/InterpolationTargetVarsFromElement.hpp"
 #include "ParallelAlgorithms/Interpolation/Events/GetComputeItemsOnSource.hpp"
 #include "ParallelAlgorithms/Interpolation/PointInfoTag.hpp"
+#include "ParallelAlgorithms/Interpolation/Targets/Sphere.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Utilities/Algorithm.hpp"
+#include "Utilities/CartesianProduct.hpp"
+#include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/PrettyType.hpp"
 #include "Utilities/Serialization/CharmPupable.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TypeTraits/CreateGetStaticMemberVariableOrDefault.hpp"
+#include "Utilities/TypeTraits/IsA.hpp"
 
 /// \cond
 namespace Events::Tags {
 template <size_t Dim>
 struct ObserverMesh;
+template <size_t Dim, typename Fr>
+struct ObserverCoordinates;
 }  // namespace Events::Tags
 namespace Tags {
 template <typename TagsList>
@@ -49,13 +69,25 @@ template <size_t VolumeDim, typename InterpolationTargetTag,
 class InterpolateWithoutInterpComponent;
 /// \endcond
 
-/// Does an interpolation onto an InterpolationTargetTag by calling Actions on
-/// the InterpolationTarget component.
+/*!
+ * \brief Does an interpolation onto an InterpolationTargetTag by calling
+ * Actions on the InterpolationTarget component.
+ *
+ * \note The `intrp::TargetPoints::Sphere` target is handled specially because
+ * it has the potential to be very slow due to it usually having the most points
+ * out of all the stationary targets. An optimization for the future would be to
+ * have each target be responsible for intelligently computing the
+ * `block_logical_coordinates` for it's own points.
+ */
 template <size_t VolumeDim, typename InterpolationTargetTag,
           typename... SourceVarTags>
 class InterpolateWithoutInterpComponent<VolumeDim, InterpolationTargetTag,
                                         tmpl::list<SourceVarTags...>>
     : public Event {
+ private:
+  using frame = typename InterpolationTargetTag::compute_target_points::frame;
+
+ public:
   /// \cond
   explicit InterpolateWithoutInterpComponent(CkMigrateMessage* /*unused*/) {}
   using PUP::able::register_constructor;
@@ -80,25 +112,181 @@ class InterpolateWithoutInterpComponent<VolumeDim, InterpolationTargetTag,
   using argument_tags =
       tmpl::list<typename InterpolationTargetTag::temporal_id,
                  Tags::InterpPointInfoBase,
-                 ::Events::Tags::ObserverMesh<VolumeDim>, SourceVarTags...>;
+                 ::Events::Tags::ObserverMesh<VolumeDim>,
+                 // We always grab the DG coords because we use them to create a
+                 // bounding box for the sphere target optimization. DG coords
+                 // have points on the boundary, while FD coords don't. If we
+                 // had used FD coords, it's possible a target point would fall
+                 // between the outermost gridpoints of two elements. This point
+                 // would be outside our bounding box, and thus wouldn't get
+                 // interpolated to. We avoid this by always using DG coords,
+                 // even if the mesh is FD.
+                 domain::Tags::Coordinates<VolumeDim, frame>, SourceVarTags...>;
 
   template <typename ParallelComponent, typename Metavariables>
   void operator()(
       const typename InterpolationTargetTag::temporal_id::type& temporal_id,
       const typename Tags::InterpPointInfo<Metavariables>::type& point_infos,
       const Mesh<VolumeDim>& mesh,
+      const tnsr::I<DataVector, VolumeDim, frame> coordinates,
       const typename SourceVarTags::type&... source_vars_input,
       Parallel::GlobalCache<Metavariables>& cache,
       const ElementId<VolumeDim>& array_index,
       const ParallelComponent* const /*meta*/,
       const ObservationValue& /*observation_value*/) const {
-    const auto& block_logical_coords =
-        InterpolationTarget_detail::block_logical_coords<
-            InterpolationTargetTag>(
-            cache,
-            get<Vars::PointInfoTag<InterpolationTargetTag, VolumeDim>>(
-                point_infos),
-            temporal_id);
+    const tnsr::I<DataVector, VolumeDim, frame>& all_target_points =
+        get<Vars::PointInfoTag<InterpolationTargetTag, VolumeDim>>(point_infos);
+    std::vector<std::optional<IdPair<
+        domain::BlockId, tnsr::I<double, VolumeDim, ::Frame::BlockLogical>>>>
+        block_logical_coords{};
+
+    // The sphere target is special because we have a better idea of where the
+    // points will be.
+    if constexpr (tt::is_a_v<
+                      TargetPoints::Sphere,
+                      typename InterpolationTargetTag::compute_target_points>) {
+      static_assert(VolumeDim == 3,
+                    "Sphere target can only be used for VolumeDim = 3.");
+      // Extremum for x, y, z, r
+      std::array<std::pair<double, double>, 4> min_max_coordinates{};
+
+      // Calculate r^2 because sqrt is expensive
+      DataVector radii_squared{get<0>(coordinates).size(), 0.0};
+      for (size_t i = 0; i < VolumeDim; i++) {
+        radii_squared += square(coordinates.get(i));
+      }
+
+      // Compute min and max
+      {
+        const auto [min, max] = alg::minmax_element(radii_squared);
+        min_max_coordinates[3].first = *min;
+        min_max_coordinates[3].second = *max;
+      }
+
+      const auto& sphere =
+          Parallel::get<Tags::Sphere<InterpolationTargetTag>>(cache);
+      const std::set<double>& radii_of_sphere_target = sphere.radii;
+      const size_t l_max = sphere.l_max;
+
+      const size_t number_of_angular_points = (l_max + 1) * (2 * l_max + 1);
+      // first size_t = position of first radius in bounds
+      // second size_t = total bounds to use/check
+      std::optional<std::pair<size_t, size_t>> offset_and_num_points{};
+
+      // Have a very small buffer just in case of roundoff
+      double epsilon =
+          (min_max_coordinates[3].second - min_max_coordinates[3].first) *
+          std::numeric_limits<double>::epsilon() * 100.0;
+      size_t offset_index = 0;
+      // Check if any radii of the target are within the radii of our element
+      for (double radius : radii_of_sphere_target) {
+        const double square_radius = square(radius);
+        if (square_radius >=
+                (gsl::at(min_max_coordinates, 3).first - epsilon) and
+            square_radius <=
+                (gsl::at(min_max_coordinates, 3).second + epsilon)) {
+          if (offset_and_num_points.has_value()) {
+            offset_and_num_points->second += number_of_angular_points;
+          } else {
+            offset_and_num_points =
+                std::make_pair(offset_index * number_of_angular_points,
+                               number_of_angular_points);
+          }
+        }
+        offset_index++;
+      }
+
+      // If no radii pass through this element, there's nothing to do so return
+      if (not offset_and_num_points.has_value()) {
+        return;
+      }
+
+      // Get the x,y,z bounds
+      for (size_t i = 0; i < VolumeDim; i++) {
+        const auto [min, max] = alg::minmax_element(coordinates.get(i));
+        gsl::at(min_max_coordinates, i).first = *min;
+        gsl::at(min_max_coordinates, i).second = *max;
+      }
+
+      const tnsr::I<DataVector, VolumeDim, frame> target_points_to_check{};
+      // Use the offset and number of points to create a view. We assume that if
+      // there are multiple radii in this element, that they are successive
+      // radii. If this wasn't true, that'd be a really weird topology.
+      for (size_t i = 0; i < VolumeDim; i++) {
+        make_const_view(make_not_null(&target_points_to_check.get(i)),
+                        all_target_points.get(i), offset_and_num_points->first,
+                        offset_and_num_points->second);
+      }
+
+      // To break out of inner loop and skip the point
+      bool skip_point = false;
+      tnsr::I<double, VolumeDim, frame> sphere_coords_to_map{};
+      // Other code below expects block_logical_coords to be sized to the total
+      // number of points on the target (including all radii). By default these
+      // will all be nullopt and we'll only fill the ones we need
+      block_logical_coords.resize(get<0>(all_target_points).size());
+
+      const Block<VolumeDim>& block =
+          Parallel::get<domain::Tags::Domain<VolumeDim>>(cache)
+              .blocks()[array_index.block_id()];
+
+      // Now for every radius in this element, we check if their points are
+      // within the x,y,z bounds of the element. If they are, map the point to
+      // the block logical frame and add it to the vector f all block logical
+      // coordinates.
+      for (size_t index = 0; index < get<0>(target_points_to_check).size();
+           index++) {
+        skip_point = false;
+        for (size_t i = 0; i < VolumeDim; i++) {
+          const double coord = target_points_to_check.get(i)[index];
+          epsilon = (gsl::at(min_max_coordinates, i).second -
+                     gsl::at(min_max_coordinates, i).first) *
+                    std::numeric_limits<double>::epsilon() * 100.0;
+          // If a point is outside any of the bounding box, skip it
+          if (coord < (gsl::at(min_max_coordinates, i).first - epsilon) or
+              coord > (gsl::at(min_max_coordinates, i).second + epsilon)) {
+            skip_point = true;
+            break;
+          }
+
+          sphere_coords_to_map.get(i) = coord;
+        }
+
+        if (skip_point) {
+          continue;
+        }
+
+        std::optional<tnsr::I<double, VolumeDim, ::Frame::BlockLogical>>
+            block_coords_of_target_point{};
+
+        if constexpr (Parallel::is_in_global_cache<
+                          Metavariables, domain::Tags::FunctionsOfTime>) {
+          const auto& functions_of_time =
+              Parallel::get<domain::Tags::FunctionsOfTime>(cache);
+          const double time =
+              InterpolationTarget_detail::get_temporal_id_value(temporal_id);
+
+          block_coords_of_target_point = block_logical_coordinates_single_point(
+              sphere_coords_to_map, block, time, functions_of_time);
+        } else {
+          block_coords_of_target_point = block_logical_coordinates_single_point(
+              sphere_coords_to_map, block);
+        }
+
+        if (block_coords_of_target_point.has_value()) {
+          // Get index into vector of all grid points of the target. This is
+          // just the offset + index
+          block_logical_coords[offset_and_num_points->first + index] =
+              make_id_pair(domain::BlockId(array_index.block_id()),
+                           std::move(block_coords_of_target_point.value()));
+        }
+      }
+    } else {
+      (void)coordinates;
+      block_logical_coords = InterpolationTarget_detail::block_logical_coords<
+          InterpolationTargetTag>(cache, all_target_points, temporal_id);
+    }
+
     const std::vector<ElementId<VolumeDim>> element_ids{{array_index}};
     const auto element_coord_holders =
         element_logical_coordinates(element_ids, block_logical_coords);

--- a/src/Utilities/Algorithm.hpp
+++ b/src/Utilities/Algorithm.hpp
@@ -354,6 +354,22 @@ constexpr decltype(auto) min_element(const Container& c, Compare&& comp) {
   return std::min_element(begin(c), end(c), std::forward<Compare>(comp));
 }
 
+/// Convenience wrapper around std::minmax_element
+template <class Container>
+constexpr decltype(auto) minmax_element(const Container& c) {
+  using std::begin;
+  using std::end;
+  return std::minmax_element(begin(c), end(c));
+}
+
+/// Convenience wrapper around std::minmax_element
+template <class Container, class Compare>
+constexpr decltype(auto) minmax_element(const Container& c, Compare&& comp) {
+  using std::begin;
+  using std::end;
+  return std::minmax_element(begin(c), end(c), std::forward<Compare>(comp));
+}
+
 /// Convenience wrapper around std::remove
 template <class Container, class T>
 decltype(auto) remove(Container& c, const T& value) {

--- a/tests/Unit/Domain/Test_BlockAndElementLogicalCoordinates.cpp
+++ b/tests/Unit/Domain/Test_BlockAndElementLogicalCoordinates.cpp
@@ -251,7 +251,7 @@ void fuzzy_test_block_and_element_logical_coordinates_unrefined(
   // For this test, we test distorted coords only if the first block has
   // a distorted frame.  For this test, either all blocks have a distorted
   // frame or none of them do.
-  if(domain.blocks().begin()->has_distorted_frame()) {
+  if (domain.blocks().begin()->has_distorted_frame()) {
     const auto distorted_coords = [&n_pts, &domain, &block_ids, &block_coords,
                                    &time, &functions_of_time]() {
       tnsr::I<DataVector, Dim, Frame::Distorted> coords(n_pts);
@@ -361,10 +361,10 @@ void fuzzy_test_block_and_element_logical_coordinates_distorted_brick(
   const auto domain = brick.create_domain();
   const auto functions_of_time = uniform_translation.functions_of_time();
   // Test at two different times.
-  fuzzy_test_block_and_element_logical_coordinates_unrefined(
-      domain, n_pts, 0.0, functions_of_time);
-  fuzzy_test_block_and_element_logical_coordinates_unrefined(
-      domain, n_pts, 0.1, functions_of_time);
+  fuzzy_test_block_and_element_logical_coordinates_unrefined(domain, n_pts, 0.0,
+                                                             functions_of_time);
+  fuzzy_test_block_and_element_logical_coordinates_unrefined(domain, n_pts, 0.1,
+                                                             functions_of_time);
 }
 
 void fuzzy_test_block_and_element_logical_coordinates3(const size_t n_pts) {

--- a/tests/Unit/Helpers/ParallelAlgorithms/Interpolation/InterpolateOnElementTestHelpers.hpp
+++ b/tests/Unit/Helpers/ParallelAlgorithms/Interpolation/InterpolateOnElementTestHelpers.hpp
@@ -14,6 +14,7 @@
 #include "Domain/BlockLogicalCoordinates.hpp"
 #include "Domain/Creators/DomainCreator.hpp"
 #include "Domain/Creators/Sphere.hpp"
+#include "Domain/Creators/TimeDependence/RotationAboutZAxis.hpp"
 #include "Domain/Domain.hpp"
 #include "Domain/ElementLogicalCoordinates.hpp"
 #include "Domain/ElementMap.hpp"
@@ -32,6 +33,7 @@
 #include "ParallelAlgorithms/Interpolation/Protocols/ComputeVarsToInterpolate.hpp"
 #include "ParallelAlgorithms/Interpolation/Protocols/InterpolationTargetTag.hpp"
 #include "ParallelAlgorithms/Interpolation/Tags.hpp"
+#include "ParallelAlgorithms/Interpolation/Targets/Sphere.hpp"
 #include "Time/Slab.hpp"
 #include "Time/Time.hpp"
 #include "Time/TimeStepId.hpp"
@@ -126,7 +128,7 @@ struct MockInterpolationTargetVarsFromElement {
       const std::vector<std::optional<
           IdPair<domain::BlockId, tnsr::I<double, Metavariables::volume_dim,
                                           typename ::Frame::BlockLogical>>>>&
-      /*block_logical_coords*/,
+          block_logical_coords,
       const std::vector<std::vector<size_t>>& global_offsets,
       const TemporalId& /*temporal_id*/) {
     CHECK(global_offsets.size() == vars_src.size());
@@ -134,6 +136,17 @@ struct MockInterpolationTargetVarsFromElement {
     // directly from the elements; the outer vector is used only by
     // the Interpolator parallel component.
     CHECK(global_offsets.size() == 1);
+
+    if constexpr (tt::is_a_v<
+                      intrp::TargetPoints::Sphere,
+                      typename InterpolationTargetTag::compute_target_points>) {
+      for (size_t offset : global_offsets[0]) {
+        CHECK(block_logical_coords[offset].has_value());
+      }
+    } else {
+      CHECK(alg::all_of(block_logical_coords,
+                        [](const auto& t) { return t.has_value(); }));
+    }
 
     // Here we have received only some of the points.
     const size_t num_pts_received = global_offsets[0].size();
@@ -180,6 +193,10 @@ struct mock_interpolation_target {
   using component_being_mocked =
       intrp::InterpolationTarget<Metavariables, InterpolationTargetTag>;
   using simple_tags = tmpl::list<Tags::TestTargetPoints>;
+  using const_global_cache_tags = tmpl::conditional_t<
+      tt::is_a_v<intrp::TargetPoints::Sphere,
+                 typename InterpolationTargetTag::compute_target_points>,
+      tmpl::list<intrp::Tags::Sphere<InterpolationTargetTag>>, tmpl::list<>>;
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
       Parallel::Phase::Initialization,
       tmpl::list<ActionTesting::InitializeDataBox<simple_tags>>>>;
@@ -192,7 +209,8 @@ struct mock_interpolation_target {
 
 template <typename ElemComponent, bool UseTimeDependentMaps,
           typename DomainCreator, typename Runner, typename TemporalId>
-std::tuple<Variables<tmpl::list<Tags::TestSolution>>, Mesh<3>>
+std::tuple<Variables<tmpl::list<Tags::TestSolution>>, Mesh<3>,
+           tnsr::I<DataVector, 3, Frame::Inertial>>
 make_volume_data_and_mesh(const DomainCreator& domain_creator, Runner& runner,
                           const Domain<3>& domain,
                           const ElementId<3>& element_id,
@@ -201,8 +219,7 @@ make_volume_data_and_mesh(const DomainCreator& domain_creator, Runner& runner,
   Mesh<3> mesh{domain_creator.initial_extents()[element_id.block_id()],
                Spectral::Basis::Legendre, Spectral::Quadrature::GaussLobatto};
 
-  const auto inertial_coords = [&element_id, &block, &mesh, &runner,
-                                &temporal_id]() {
+  auto inertial_coords = [&element_id, &block, &mesh, &runner, &temporal_id]() {
     if constexpr (UseTimeDependentMaps) {
       const auto& functions_of_time = get<domain::Tags::FunctionsOfTime>(
           ActionTesting::cache<ElemComponent>(runner, element_id));
@@ -223,7 +240,7 @@ make_volume_data_and_mesh(const DomainCreator& domain_creator, Runner& runner,
   // create volume data
   Variables<tmpl::list<Tags::TestSolution>> vars(mesh.number_of_grid_points());
   fill_variables<Tags::TestSolution>(make_not_null(&vars), inertial_coords);
-  return std::make_tuple(std::move(vars), mesh);
+  return std::make_tuple(std::move(vars), mesh, std::move(inertial_coords));
 }
 
 // This is the main test; Takes a functor as an argument so that
@@ -232,9 +249,11 @@ template <typename Metavariables, typename elem_component, typename Functor>
 void test_interpolate_on_element(
     Functor initialize_elements_and_queue_simple_actions) {
   using metavars = Metavariables;
-  using target_component =
-      mock_interpolation_target<metavars,
-                                typename metavars::InterpolationTargetA>;
+  using target_tag = typename metavars::InterpolationTargetA;
+  constexpr bool is_sphere =
+      tt::is_a_v<intrp::TargetPoints::Sphere,
+                 typename target_tag::compute_target_points>;
+  using target_component = mock_interpolation_target<metavars, target_tag>;
 
   const auto domain_creator = []() {
     if constexpr (Metavariables::use_time_dependent_maps) {
@@ -242,9 +261,10 @@ void test_interpolate_on_element(
           0.9, 2.9, domain::creators::Sphere::Excision{}, 2_st, 7_st, false,
           std::nullopt, {}, {domain::CoordinateMaps::Distribution::Linear},
           ShellWedges::All,
+          // Rotation so points always remain in domain
           std::make_unique<
-              domain::creators::time_dependence::UniformTranslation<3>>(
-              0.0, std::array<double, 3>({{0.1, 0.2, 0.3}})));
+              domain::creators::time_dependence::RotationAboutZAxis<3>>(
+              0.0, 0.0, 0.1, 0.0));
     } else {
       return domain::creators::Sphere(
           0.9, 2.9, domain::creators::Sphere::Excision{}, 2_st, 7_st, false);
@@ -266,7 +286,8 @@ void test_interpolate_on_element(
       13.5 / 16.0;  // Arbitrary value greater than temporal_id above.
 
   // Create target points and interp_point_info
-  const size_t num_points = 10;
+  const size_t ell = 4;
+  const size_t num_points = is_sphere ? 2 * (ell + 1) * (2 * ell + 1) : 10_st;
   tnsr::I<DataVector, 3, Frame::Inertial> target_points(num_points);
   const typename intrp::Tags::InterpPointInfo<
       metavars>::type interp_point_info = [&target_points]() {
@@ -288,16 +309,32 @@ void test_interpolate_on_element(
     return interp_point_info_l;
   }();
 
+  tuples::tagged_tuple_from_typelist<tmpl::conditional_t<
+      is_sphere,
+      tmpl::list<domain::Tags::Domain<3>, intrp::Tags::Sphere<target_tag>>,
+      tmpl::list<domain::Tags::Domain<3>>>>
+      init_tuple{};
+
+  tuples::get<domain::Tags::Domain<3>>(init_tuple) =
+      std::move(domain_creator.create_domain());
+
+  if constexpr (is_sphere) {
+    tuples::get<intrp::Tags::Sphere<target_tag>>(init_tuple) =
+        intrp::OptionHolders::Sphere{ell, std::array{0.0, 0.0, 0.0},
+                                     std::vector<double>{1.0, 2.5},
+                                     intrp::AngularOrdering::Cce};
+  }
+
   // Emplace target component.
-  auto runner = [&domain_creator, &initial_expiration_times]() {
+  auto runner = [&domain_creator, &init_tuple, &initial_expiration_times]() {
     if constexpr (Metavariables::use_time_dependent_maps) {
       return ActionTesting::MockRuntimeSystem<metavars>(
-          domain_creator.create_domain(),
+          std::move(init_tuple),
           domain_creator.functions_of_time(initial_expiration_times));
     } else {
+      (void)domain_creator;
       (void)initial_expiration_times;
-      return ActionTesting::MockRuntimeSystem<metavars>(
-          domain_creator.create_domain());
+      return ActionTesting::MockRuntimeSystem<metavars>(std::move(init_tuple));
     }
   }();
 

--- a/tests/Unit/Helpers/ParallelAlgorithms/Interpolation/InterpolateOnElementTestHelpers.hpp
+++ b/tests/Unit/Helpers/ParallelAlgorithms/Interpolation/InterpolateOnElementTestHelpers.hpp
@@ -201,24 +201,24 @@ make_volume_data_and_mesh(const DomainCreator& domain_creator, Runner& runner,
   Mesh<3> mesh{domain_creator.initial_extents()[element_id.block_id()],
                Spectral::Basis::Legendre, Spectral::Quadrature::GaussLobatto};
 
-  const auto inertial_coords =
-      [&element_id, &block, &mesh, &runner, &temporal_id]() {
-        if constexpr (UseTimeDependentMaps) {
-          const auto& functions_of_time = get<domain::Tags::FunctionsOfTime>(
-              ActionTesting::cache<ElemComponent>(runner, element_id));
-          ElementMap<3, ::Frame::Grid> map_logical_to_grid{
-              element_id, block.moving_mesh_logical_to_grid_map().get_clone()};
-          return block.moving_mesh_grid_to_inertial_map()(
-              map_logical_to_grid(logical_coordinates(mesh)),
-              temporal_id.substep_time(), functions_of_time);
-        } else {
-          (void)runner;
-          (void)temporal_id;
-          ElementMap<3, Frame::Inertial> map{
-              element_id, block.stationary_map().get_clone()};
-          return map(logical_coordinates(mesh));
-        }
-      }();
+  const auto inertial_coords = [&element_id, &block, &mesh, &runner,
+                                &temporal_id]() {
+    if constexpr (UseTimeDependentMaps) {
+      const auto& functions_of_time = get<domain::Tags::FunctionsOfTime>(
+          ActionTesting::cache<ElemComponent>(runner, element_id));
+      ElementMap<3, ::Frame::Grid> map_logical_to_grid{
+          element_id, block.moving_mesh_logical_to_grid_map().get_clone()};
+      return block.moving_mesh_grid_to_inertial_map()(
+          map_logical_to_grid(logical_coordinates(mesh)),
+          temporal_id.substep_time(), functions_of_time);
+    } else {
+      (void)runner;
+      (void)temporal_id;
+      ElementMap<3, Frame::Inertial> map{element_id,
+                                         block.stationary_map().get_clone()};
+      return map(logical_coordinates(mesh));
+    }
+  }();
 
   // create volume data
   Variables<tmpl::list<Tags::TestSolution>> vars(mesh.number_of_grid_points());

--- a/tests/Unit/Utilities/Test_Algorithm.cpp
+++ b/tests/Unit/Utilities/Test_Algorithm.cpp
@@ -143,10 +143,24 @@ void test_min_max_element() {
   std::vector<int> t{3, 5, 8, -1};
   CHECK(*alg::min_element(t) == -1);
   CHECK(*alg::max_element(t) == 8);
+
+  {
+    const auto [min, max] = alg::minmax_element(t);
+    CHECK(*min == -1);
+    CHECK(*max == 8);
+  }
+
   CHECK(*alg::min_element(t, [](const int a, const int b) { return a > b; }) ==
         8);
   CHECK(*alg::max_element(t, [](const int a, const int b) { return a > b; }) ==
         -1);
+
+  {
+    const auto [min, max] =
+        alg::minmax_element(t, [](const int a, const int b) { return a > b; });
+    CHECK(*min == 8);
+    CHECK(*max == -1);
+  }
 }
 
 void test_find_related() {


### PR DESCRIPTION
## Proposed changes

Due to the internals of the `InterpolateWithoutInterpComponent` event, on every element we find the block logical coordinates of *all* target points. For the sphere target this could be a significant amount depending on the $\ell$ of the surface and the number of concentric surfaces. For a sphere target of $\ell = 16$ and 4 concentric surfaces, this amounted to a 3-25x slowdown of a BNS depending on how frequent the event was run.

In order to optimize this, the sphere target is handled specially in `InterpolateWithoutInterpComponent`. Instead of getting block logical coords for every point of the sphere target on every element, we do some checks first:

1. Check if any radii of any of the spheres are in our element. If not, then we end here and don't do an interpolation.
2. If our element contains any number of radii, build a bounding box in x, y, and z.
3. Check all points of the radii in our element. If a point is within this bounding box, get its block logical coordinates. If not, skip that point
4. Once we have all the block logical coords of the points in our element, proceed as before with the interpolation

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

In order to make this optimization, a feature had to be bypassed for the sphere target. The `InterpolateWithoutInterpComponent` event calls the `InterpolationTargetVarsFromElement` simple action, passing along the block logical coordinates. The first time `InterpolationTargetVarsFromElement` is run (for a given temporal id), it originally did a check for points outside the computational domain (invalid points). It was able to do so just once because every element computed the same block logical coordinates for all the target points, so only the first was necessary to do this check. An invalid point was represented by a `std::nullopt` rather than the block logical coordinates. So `InterpolationTargetVarsFromElement` checked for `std::nullopt`s, and if there were any, filled the variables of those specific points with NaNs (technically what value to fill with is a compile time choice, but it's almost always NaNs).

However, for the sphere target, we aren't computing the block logical coords for all target points on every element, yet we still need to pass along a vector the length of the all the target points. But with the sphere target, we only populate this vector with the block logical coords of the target points within out element. Thus, in this way, the `std::nullopt` for the rest of the target points doesn't represent invalid points, just points outside of this element. So the first vector of block logical coords that arrives at `InterpolationTargetVarsFromElement` can't be used to check for invalid points (and neither can the rest of the vectors sent from the rest of the elements).

Thus, checking for invalid points is the feature that is bypassed when using the sphere target now. This is a known bug/issue, but is only a problem if a user has a sphere target and places one of the radii outside the computational domain. I'll create a GitHub issue once this is merged, but I felt the performance gain that we get from this optimization was important enough to put off this subtlety.

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
