### PR TITLE
Fix bug in damped harmonic gauge

### DIFF
--- a/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedHarmonic.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedHarmonic.cpp
@@ -358,7 +358,7 @@ void damped_harmonic_impl(
     }
   }
 
-  // d_t lapse / lapse = 0.5 * n^a n^b (lapse Pi_{ab} - shift^i Phi_{iab})
+  // d_t lapse = lapse * (0.5 * n^a n^b (lapse Pi_{ab} - shift^i Phi_{iab}))
   get<0>(d4_muS_over_lapse) = -get<0>(shift) * get<0>(half_phi_two_normals);
   for (size_t i = 1; i < SpatialDim; ++i) {
     get<0>(d4_muS_over_lapse) -= shift.get(i) * half_phi_two_normals.get(i);
@@ -390,7 +390,7 @@ void damped_harmonic_impl(
   //  0.5 * n^a n^b Pi_{ab}
   //  0.5 * n^a n^b Phi_{iab}
   // so we reuse that work by taking them as arguments.
-  get<0>(d4_muS_over_lapse) *= -get(mu_S);
+  get<0>(d4_muS_over_lapse) *= -get(mu_S) * get(one_over_lapse);
   get<0>(d4_muS_over_lapse) += get<0>(d4_mu_S);
   get<0>(d4_muS_over_lapse) *= get(one_over_lapse);
   for (size_t i = 0; i < SpatialDim; ++i) {

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Test_DampedHarmonic.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Test_DampedHarmonic.cpp
@@ -181,7 +181,7 @@ void test_with_python(const DataVector& used_for_size) {
       "DampedHarmonic",
       {"damped_harmonic_gauge_source_function_rollon",
        "spacetime_deriv_damped_harmonic_gauge_source_function_rollon"},
-      {{{-0.01, 0.01}}}, used_for_size);
+      {{{-0.1, 0.1}}}, used_for_size);
 
   pypp::check_with_random_values<1>(
       &wrap_damped_harmonic<SpatialDim, Frame>,
@@ -189,7 +189,7 @@ void test_with_python(const DataVector& used_for_size) {
       "DampedHarmonic",
       {"damped_harmonic_gauge_source_function",
        "spacetime_deriv_damped_harmonic_gauge_source_function"},
-      {{{-0.01, 0.01}}}, used_for_size);
+      {{{-0.1, 0.1}}}, used_for_size);
 }
 
 template <size_t Dim>


### PR DESCRIPTION
## Proposed changes

Fixes a bug in the time derivative of the damped harmonic gauge source function. One term in the calculation was missing a factor of 1/lapse.

The python unit test didn't catch this because the term in question numerically was never much bigger than 1e-12, the default epsilon for `check_with_random_values`. I increased the maximum magnitude of the random inputs by a factor of 10 to catch such bugs in the future, and I verified that after this change, the unit test would fail if the missing factor of 1/lapse were removed once again.

Fixes #4594.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
