### PR TITLE
Fix Kastaun recovery for 1D EOS

### DIFF
--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/KastaunEtAlHydro.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/KastaunEtAlHydro.cpp
@@ -13,6 +13,7 @@
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/PrimitiveRecoveryData.hpp"
 #include "NumericalAlgorithms/RootFinding/TOMS748.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
+#include "PointwiseFunctions/Hydro/SpecificEnthalpy.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 
@@ -195,15 +196,31 @@ KastaunEtAlHydro<EnforcePhysicality>::apply(
 
   const auto[rest_mass_density, lorentz_factor, pressure,
              specific_internal_energy] = f_of_z.primitives(z);
-
-  return PrimitiveRecoveryData{
-      rest_mass_density,
-      lorentz_factor,
-      pressure,
-      specific_internal_energy,
-      (rest_mass_density * (1. + specific_internal_energy) + pressure) *
-          (1. + z * z),
-      electron_fraction};
+  if constexpr (ThermodynamicDim == 1) {
+    // recovered energy and enthalpy must be overridden
+    // for 1D EOS as they are not independent from rest_mass_density
+    (void)(specific_internal_energy);
+    const Scalar<double> local_epsilon =
+        (equation_of_state.specific_internal_energy_from_density(
+            Scalar<double>(rest_mass_density)));
+    return PrimitiveRecoveryData{
+        rest_mass_density,
+        lorentz_factor,
+        pressure,
+        get(local_epsilon),
+        (rest_mass_density * (1. + get(local_epsilon)) + pressure) *
+            (1. + z * z),
+        electron_fraction};
+  } else {
+    return PrimitiveRecoveryData{
+        rest_mass_density,
+        lorentz_factor,
+        pressure,
+        specific_internal_energy,
+        (rest_mass_density * (1. + specific_internal_energy) + pressure) *
+            (1. + z * z),
+        electron_fraction};
+  }
 }
 }  // namespace grmhd::ValenciaDivClean::PrimitiveRecoverySchemes
 

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/PolytropicFluid.hpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/PolytropicFluid.hpp
@@ -95,15 +95,17 @@ class PolytropicFluid : public EquationOfState<IsRelativistic, 1> {
   /// The lower bound of the specific internal energy that is valid for this EOS
   /// at the given rest mass density \f$\rho\f$
   double specific_internal_energy_lower_bound(
-      const double /* rest_mass_density */) const override {
-    return 0.0;
+      const double rest_mass_density) const override {
+    return get(specific_internal_energy_from_density_impl(
+        Scalar<double>(rest_mass_density)));
   }
 
   /// The upper bound of the specific internal energy that is valid for this EOS
   /// at the given rest mass density \f$\rho\f$
   double specific_internal_energy_upper_bound(
-      const double /* rest_mass_density */) const override {
-    return std::numeric_limits<double>::max();
+      const double rest_mass_density) const override {
+    return get(specific_internal_energy_from_density_impl(
+        Scalar<double>(rest_mass_density)));
   }
 
   /// The lower bound of the specific enthalpy that is valid for this EOS

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/PolytropicFluid.hpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/PolytropicFluid.hpp
@@ -96,7 +96,7 @@ class PolytropicFluid : public EquationOfState<IsRelativistic, 1> {
   /// at the given rest mass density \f$\rho\f$
   double specific_internal_energy_lower_bound(
       const double rest_mass_density) const override {
-    return get(specific_internal_energy_from_density_impl(
+    return get(specific_internal_energy_from_density(
         Scalar<double>(rest_mass_density)));
   }
 
@@ -104,7 +104,7 @@ class PolytropicFluid : public EquationOfState<IsRelativistic, 1> {
   /// at the given rest mass density \f$\rho\f$
   double specific_internal_energy_upper_bound(
       const double rest_mass_density) const override {
-    return get(specific_internal_energy_from_density_impl(
+    return get(specific_internal_energy_from_density(
         Scalar<double>(rest_mass_density)));
   }
 


### PR DESCRIPTION
## Proposed changes
replace the recovered $\epsilon$ (specific internal energy) and $\rho h W^2$ with values computed using the equation of state with the recovered rest mass density and Lorentz factor when using Kastaun recovery scheme for 1D equation of state.
