### PR TITLE
Add CAPTURE_FOR_ERROR to print info on failure

### DIFF
--- a/src/Utilities/ErrorHandling/AbortWithErrorMessage.cpp
+++ b/src/Utilities/ErrorHandling/AbortWithErrorMessage.cpp
@@ -11,6 +11,7 @@
 #include <stdexcept>
 
 #include "Utilities/ErrorHandling/Breakpoint.hpp"
+#include "Utilities/ErrorHandling/CaptureForError.hpp"
 #include "Utilities/ErrorHandling/Exceptions.hpp"
 #include "Utilities/ErrorHandling/FormatStacktrace.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
@@ -33,8 +34,9 @@ template <bool ShowTrace, typename ExceptionTypeToThrow>
      << abbreviated_symbol_name(std::string{pretty_function}) << " in " << file
      << ":" << line << "\n"
      << "\n"
-     << message << "\n"
-     << "############ ERROR ############\n"
+     << message << "\n";
+  print_captures_for_error(os);
+  os << "############ ERROR ############\n"
      << "\n";
   breakpoint();
   throw ExceptionTypeToThrow(os.str());
@@ -55,8 +57,9 @@ void abort_with_error_message(const char* expression, const char* file,
      << ":" << line << "\n"
      << "\n"
      << "'" << expression << "' violated!\n"
-     << message << "\n"
-     << "############ ASSERT FAILED ############\n"
+     << message << "\n";
+  print_captures_for_error(os);
+  os << "############ ASSERT FAILED ############\n"
      << "\n";
   breakpoint();
   throw SpectreAssert(os.str());

--- a/src/Utilities/ErrorHandling/CMakeLists.txt
+++ b/src/Utilities/ErrorHandling/CMakeLists.txt
@@ -10,6 +10,7 @@ spectre_target_sources(
   PRIVATE
   AbortWithErrorMessage.cpp
   Breakpoint.cpp
+  CaptureForError.cpp
   FloatingPointExceptions.cpp
   FormatStacktrace.cpp
   SegfaultHandler.cpp
@@ -22,6 +23,7 @@ spectre_target_headers(
   AbortWithErrorMessage.hpp
   Assert.hpp
   Breakpoint.hpp
+  CaptureForError.hpp
   Error.hpp
   Exceptions.hpp
   ExpectsAndEnsures.hpp

--- a/src/Utilities/ErrorHandling/CaptureForError.cpp
+++ b/src/Utilities/ErrorHandling/CaptureForError.cpp
@@ -1,0 +1,56 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Utilities/ErrorHandling/CaptureForError.hpp"
+
+#include <ostream>
+#include <vector>
+
+#include "Utilities/ErrorHandling/Assert.hpp"
+
+namespace CaptureForError_detail {
+CaptureList& CaptureList::the_list() {
+  thread_local CaptureList singleton{};
+  return singleton;
+}
+
+void CaptureList::register_self(const CaptureForErrorBase* const capture) {
+  captures_.push_back(capture);
+}
+
+void CaptureList::deregister_self(const CaptureForErrorBase* const capture) {
+  ASSERT(not captures_.empty() and captures_.back() == capture,
+         "Deregistering wrong capture.");
+  captures_.pop_back();
+}
+
+void CaptureList::print(std::ostream& stream) {
+  if (currently_printing_) {
+    // Error during an error.  Don't recurse.
+    return;
+  }
+  try {
+    currently_printing_ = true;
+    if (not captures_.empty()) {
+      stream << "\nCaptured variables:\n";
+    }
+    for (const auto& capture : captures_) {
+      capture->print(stream);
+    }
+  } catch (...) {
+    currently_printing_ = false;
+    throw;
+  }
+  currently_printing_ = false;
+}
+
+CaptureList::CaptureList() = default;
+
+CaptureList::~CaptureList() noexcept(false) {
+  ASSERT(captures_.empty(), "Not all captures deregistered.");
+}
+}  // namespace CaptureForError_detail
+
+void print_captures_for_error(std::ostream& stream) {
+  CaptureForError_detail::CaptureList::the_list().print(stream);
+}

--- a/src/Utilities/ErrorHandling/CaptureForError.hpp
+++ b/src/Utilities/ErrorHandling/CaptureForError.hpp
@@ -1,0 +1,102 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <ostream>
+#include <vector>
+
+namespace CaptureForError_detail {
+class CaptureForErrorBase {
+ protected:
+  CaptureForErrorBase() = default;
+  ~CaptureForErrorBase() = default;
+
+ public:
+  CaptureForErrorBase(CaptureForErrorBase&&) = delete;
+  CaptureForErrorBase(const CaptureForErrorBase&) = delete;
+  CaptureForErrorBase& operator=(CaptureForErrorBase&&) = delete;
+  CaptureForErrorBase& operator=(const CaptureForErrorBase&) = delete;
+
+  virtual void print(std::ostream& stream) const = 0;
+};
+
+class CaptureList {
+ public:
+  static CaptureList& the_list();
+
+  void register_self(const CaptureForErrorBase* capture);
+  void deregister_self(const CaptureForErrorBase* capture);
+
+  void print(std::ostream& stream);
+
+  CaptureList(CaptureList&&) = delete;
+  CaptureList(const CaptureList&) = delete;
+  CaptureList& operator=(CaptureList&&) = delete;
+  CaptureList& operator=(const CaptureList&) = delete;
+
+ private:
+  CaptureList();
+  ~CaptureList() noexcept(false);
+
+  std::vector<const CaptureForErrorBase*> captures_{};
+  bool currently_printing_ = false;
+};
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wnon-virtual-dtor"
+template <typename T>
+// NOLINTNEXTLINE(cppcoreguidelines-virtual-class-destructor)
+class CaptureForError : public CaptureForErrorBase {
+ public:
+  CaptureForError() = delete;
+  CaptureForError(CaptureForError&&) = delete;
+  CaptureForError(const CaptureForError&) = delete;
+  CaptureForError& operator=(CaptureForError&&) = delete;
+  CaptureForError& operator=(const CaptureForError&) = delete;
+
+  CaptureForError(const char* const name, const T& capture)
+      : name_(name), capture_(capture) {
+    CaptureList::the_list().register_self(this);
+  }
+
+  // Capturing an rvalue would lead to a dangling reference.
+  CaptureForError(const char* /*name*/, const T&& /*capture*/) = delete;
+
+  ~CaptureForError() noexcept(false) {
+    CaptureList::the_list().deregister_self(this);
+  }
+
+  void print(std::ostream& stream) const override {
+    stream << name_ << " = " << capture_ << "\n";
+  }
+
+ private:
+  const char* name_;
+  const T& capture_;
+};
+#pragma GCC diagnostic pop
+}  // namespace CaptureForError_detail
+
+/// \cond
+#define CAPTURE_FOR_ERROR_NAME2(line) capture_for_error_impl##line
+#define CAPTURE_FOR_ERROR_NAME(line) CAPTURE_FOR_ERROR_NAME2(line)
+/// \endcond
+
+/*!
+ * \brief Capture a variable to be printed on ERROR or ASSERT.
+ *
+ * The argument will be printed using its stream operator if an error
+ * occurs before the end of the current scope.  The object is captured
+ * by reference, so it must live until the end of the current scope,
+ * and any subsequent changes to it will be reflected in the error
+ * message.
+ */
+#define CAPTURE_FOR_ERROR(var)                                          \
+  const CaptureForError_detail::CaptureForError CAPTURE_FOR_ERROR_NAME( \
+      __LINE__)(#var, var)
+
+/*!
+ * \brief Stream all objects currently captured by CaptureForError.
+ */
+void print_captures_for_error(std::ostream& stream);

--- a/tests/Unit/Utilities/ErrorHandling/CMakeLists.txt
+++ b/tests/Unit/Utilities/ErrorHandling/CMakeLists.txt
@@ -6,6 +6,7 @@ set(LIBRARY "Test_ErrorHandling")
 set(LIBRARY_SOURCES
   Test_AbortWithErrorMessage.cpp
   Test_AssertAndError.cpp
+  Test_CaptureForError.cpp
   Test_Error.cpp
   Test_Exceptions.cpp
   Test_FloatingPointExceptions.cpp

--- a/tests/Unit/Utilities/ErrorHandling/Test_CaptureForError.cpp
+++ b/tests/Unit/Utilities/ErrorHandling/Test_CaptureForError.cpp
@@ -1,0 +1,57 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <vector>
+
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/ErrorHandling/CaptureForError.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/StdHelpers.hpp"
+
+SPECTRE_TEST_CASE("Unit.ErrorHandling.CaptureForError",
+                  "[Unit][ErrorHandling]") {
+  CHECK_THROWS_WITH(
+      []() { ERROR("Boom"); }(),
+      not Catch::Matchers::ContainsSubstring("Captured variables:"));
+
+  std::vector<int> vector_var{1, 2, 3};
+  const int int_var = 7;
+  CAPTURE_FOR_ERROR(vector_var);
+  CAPTURE_FOR_ERROR(int_var);
+  vector_var.push_back(4);
+  CHECK_THROWS_WITH(
+      []() { ERROR("Boom"); }(),
+      Catch::Matchers::ContainsSubstring("Captured variables:\n"
+                                         "vector_var = (1,2,3,4)\n"
+                                         "int_var = 7"));
+  // Check that the list is left in the same state.
+  CHECK_THROWS_WITH(
+      []() { ERROR("Boom"); }(),
+      Catch::Matchers::ContainsSubstring("Captured variables:\n"
+                                         "vector_var = (1,2,3,4)\n"
+                                         "int_var = 7"));
+  // Test an additional capture in a nested scope
+  CHECK_THROWS_WITH(
+      []() {
+        const int another_int = 12;
+        CAPTURE_FOR_ERROR(another_int);
+        ERROR("Boom");
+      }(),
+      Catch::Matchers::ContainsSubstring("Captured variables:\n"
+                                         "vector_var = (1,2,3,4)\n"
+                                         "int_var = 7\n"
+                                         "another_int = 12"));
+  // And make sure it's gone again.
+  CHECK_THROWS_WITH([]() { ERROR("Boom"); }(),
+                    not Catch::Matchers::ContainsSubstring("another_int"));
+
+#ifdef SPECTRE_DEBUG
+  CHECK_THROWS_WITH(
+      []() { ASSERT(false, "Boom"); }(),
+      Catch::Matchers::ContainsSubstring("Captured variables:\n"
+                                         "vector_var = (1,2,3,4)\n"
+                                         "int_var = 7"));
+#endif  // SPECTRE_DEBUG
+}


### PR DESCRIPTION
Example:
```c++
    const Scalar<DataVector> scalar{DataVector{0.0, 1.0, 5.0, 4.0}};
    const int integer = 12;
    CAPTURE_FOR_ERROR(scalar);
    CAPTURE_FOR_ERROR(integer);
    ERROR("Boom");
```
Leads to:
```
[backtrace and stuff]

Boom

Captured variables:
scalar = T()=(0,1,5,4)
integer = 12
############ ERROR ############
```

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
