### PR TITLE
Add FoTAreReady function for simple actions

### DIFF
--- a/src/ControlSystem/Event.hpp
+++ b/src/ControlSystem/Event.hpp
@@ -126,9 +126,8 @@ class Event : public ::Event {
     // measurement is being made for.  We need all of them to access
     // coordinate-dependent quantities, which almost all control
     // measurements will need.
-    const bool ready =
-        domain::functions_of_time_are_ready<domain::Tags::FunctionsOfTime>(
-            cache, array_index, component, time);
+    const bool ready = domain::functions_of_time_are_ready_algorithm_callback<
+        domain::Tags::FunctionsOfTime>(cache, array_index, component, time);
 
     if (Parallel::get<Tags::Verbosity>(cache) >= ::Verbosity::Debug) {
       Parallel::printf("%s, time = %.16f: Control system events are%s ready.\n",

--- a/src/ControlSystem/Trigger.hpp
+++ b/src/ControlSystem/Trigger.hpp
@@ -12,6 +12,7 @@
 #include <string>
 #include <type_traits>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "ControlSystem/CombinedName.hpp"
@@ -134,9 +135,11 @@ class Trigger : public DenseTrigger {
           std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
           measurement_timescales) {
     // At least one control system is active
-    const bool is_ready = domain::functions_of_time_are_ready<
-        control_system::Tags::MeasurementTimescales>(
-        cache, array_index, component, time, std::array{measurement_name_});
+    const bool is_ready =
+        domain::functions_of_time_are_ready_algorithm_callback<
+            control_system::Tags::MeasurementTimescales>(
+            cache, array_index, component, time,
+            std::unordered_set{measurement_name_});
     if (not is_ready) {
       if (Parallel::get<Tags::Verbosity>(cache) >= ::Verbosity::Debug) {
         Parallel::printf(

--- a/src/Parallel/Callback.hpp
+++ b/src/Parallel/Callback.hpp
@@ -37,9 +37,9 @@ class SimpleActionCallback : public Callback {
  public:
   WRAPPED_PUPable_decl_template(SimpleActionCallback);  // NOLINT
   SimpleActionCallback() = default;
-  SimpleActionCallback(Proxy proxy, Args&&... args)
-      : proxy_(proxy),
-        args_(std::make_tuple<Args...>(std::forward<Args>(args)...)) {}
+  // NOLINTNEXTLINE(google-explicit-constructor)
+  SimpleActionCallback(Proxy proxy, std::decay_t<Args>... args)
+      : proxy_(proxy), args_(std::move(args)...) {}
   SimpleActionCallback(CkMigrateMessage* msg) : Callback(msg) {}
   using PUP::able::register_constructor;
   void invoke() override {
@@ -56,7 +56,7 @@ class SimpleActionCallback : public Callback {
 
  private:
   Proxy proxy_{};
-  std::tuple<Args...> args_{};
+  std::tuple<std::decay_t<Args>...> args_{};
 };
 
 /// Wraps a call to a simple action without arguments.

--- a/src/ParallelAlgorithms/Interpolation/Events/Interpolate.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Events/Interpolate.hpp
@@ -97,8 +97,8 @@ class Interpolate<VolumeDim, InterpolationTargetTag,
   bool is_ready(const double time, Parallel::GlobalCache<Metavariables>& cache,
                 const ArrayIndex& array_index,
                 const Component* const component) const {
-    return domain::functions_of_time_are_ready<domain::Tags::FunctionsOfTime>(
-        cache, array_index, component, time);
+    return domain::functions_of_time_are_ready_algorithm_callback<
+        domain::Tags::FunctionsOfTime>(cache, array_index, component, time);
   }
 
   bool needs_evolved_variables() const override { return true; }

--- a/tests/Unit/Domain/FunctionsOfTime/Test_FunctionsOfTimeAreReady.cpp
+++ b/tests/Unit/Domain/FunctionsOfTime/Test_FunctionsOfTimeAreReady.cpp
@@ -18,6 +18,7 @@
 #include "Framework/MockDistributedObject.hpp"
 #include "Framework/MockRuntimeSystem.hpp"
 #include "Framework/MockRuntimeSystemFreeFunctions.hpp"
+#include "Parallel/Callback.hpp"
 #include "Parallel/GlobalCache.hpp"
 #include "Parallel/Phase.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
@@ -44,7 +45,35 @@ struct UpdateFoT {
   }
 };
 
-template <typename Metavariables>
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+size_t simple_action_no_args_call_count = 0;
+
+struct SimpleActionNoArgs {
+  template <typename ParallelComponent, typename DbTags, typename Metavariables,
+            typename ArrayIndex>
+  static void apply(db::DataBox<DbTags>& /*box*/,
+                    Parallel::GlobalCache<Metavariables>& /*cache*/,
+                    const ArrayIndex& /*array_index*/) {
+    ++simple_action_no_args_call_count;
+  }
+};
+
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+size_t simple_action_args_call_count = 0;
+
+struct SimpleActionArgs {
+  template <typename ParallelComponent, typename DbTags, typename Metavariables,
+            typename ArrayIndex>
+  static void apply(db::DataBox<DbTags>& /*box*/,
+                    Parallel::GlobalCache<Metavariables>& /*cache*/,
+                    const ArrayIndex& /*array_index*/, const size_t size,
+                    const DataVector& some_data) {
+    ++simple_action_args_call_count;
+    CHECK(some_data.size() == size);
+  }
+};
+
+template <typename Metavariables, size_t Index>
 struct Component {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
@@ -59,8 +88,17 @@ struct Component {
       tmpl::list<domain::Actions::CheckFunctionsOfTimeAreReady>>>;
 };
 
+template <typename Metavariables, size_t Index>
+struct EmptyComponent : Component<Metavariables, Index> {
+  using mutable_global_cache_tags = tmpl::list<>;
+};
+struct EmptyMetavars {
+  using component_list = tmpl::list<EmptyComponent<EmptyMetavars, 0_st>>;
+};
+
 struct Metavariables {
-  using component_list = tmpl::list<Component<Metavariables>>;
+  using component_list = tmpl::list<Component<Metavariables, 0_st>,
+                                    Component<Metavariables, 1_st>>;
 };
 }  // namespace
 
@@ -68,8 +106,10 @@ SPECTRE_TEST_CASE("Unit.Domain.FunctionsOfTimeAreReady", "[Domain][Unit]") {
   register_classes_with_charm<
       domain::FunctionsOfTime::PiecewisePolynomial<2>>();
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<Metavariables>;
-  using component = Component<Metavariables>;
-  const component* const component_p = nullptr;
+  using component0 = Component<Metavariables, 0_st>;
+  using component1 = Component<Metavariables, 1_st>;
+  const component0* const component_0_p = nullptr;
+  const component1* const component_1_p = nullptr;
 
   const std::array<DataVector, 3> fot_init{{{0.0}, {0.0}, {0.0}}};
   FunctionMap functions_of_time{};
@@ -90,59 +130,212 @@ SPECTRE_TEST_CASE("Unit.Domain.FunctionsOfTimeAreReady", "[Domain][Unit]") {
 
   MockRuntimeSystem runner{
       {}, {std::move(functions_of_time), std::move(other_functions_of_time)}};
-  ActionTesting::emplace_array_component<component>(
+  ActionTesting::emplace_array_component<component0>(
+      make_not_null(&runner), ActionTesting::NodeId{0},
+      ActionTesting::LocalCoreId{0}, 0, 2.0);
+  ActionTesting::emplace_array_component<component1>(
       make_not_null(&runner), ActionTesting::NodeId{0},
       ActionTesting::LocalCoreId{0}, 0, 2.0);
   ActionTesting::set_phase(make_not_null(&runner), Parallel::Phase::Testing);
 
-  auto& cache = ActionTesting::cache<component>(runner, 0);
+  auto& cache = ActionTesting::cache<component0>(runner, 0);
 
-  // Test the free function.  For this section of the test, the
-  // "standard" tags domain::Tags::FunctionsOfTime is ready, but this
-  // code should never examine it.
+  // Test the algorithm callback free function.  For this section of the test,
+  // the "standard" tags domain::Tags::FunctionsOfTime is ready, but this code
+  // should never examine it.
   {
     // Neither function ready
-    CHECK(not domain::functions_of_time_are_ready<OtherFunctionsOfTime>(
-        cache, 0, component_p, 0.5));
-    CHECK(not domain::functions_of_time_are_ready<OtherFunctionsOfTime>(
-        cache, 0, component_p, 0.5, std::array{"OtherA"s}));
+    CHECK(not domain::functions_of_time_are_ready_algorithm_callback<
+          OtherFunctionsOfTime>(cache, 0, component_0_p, 0.5, std::nullopt));
+    CHECK(not domain::functions_of_time_are_ready_algorithm_callback<
+          OtherFunctionsOfTime>(cache, 0, component_0_p, 0.5,
+                                std::unordered_set{"OtherA"s}));
 
     // Make OtherA ready
     Parallel::mutate<OtherFunctionsOfTime, UpdateFoT>(cache, "OtherA"s, 123.0);
 
-    CHECK(domain::functions_of_time_are_ready<OtherFunctionsOfTime>(
-        cache, 0, component_p, 0.5, std::array{"OtherA"s}));
-    CHECK(not domain::functions_of_time_are_ready<OtherFunctionsOfTime>(
-        cache, 0, component_p, 0.5, std::array{"OtherA"s, "OtherB"s}));
+    CHECK(domain::functions_of_time_are_ready_algorithm_callback<
+          OtherFunctionsOfTime>(cache, 0, component_0_p, 0.5,
+                                std::unordered_set{"OtherA"s}));
+    CHECK(not domain::functions_of_time_are_ready_algorithm_callback<
+          OtherFunctionsOfTime>(cache, 0, component_0_p, 0.5,
+                                std::unordered_set{"OtherA"s, "OtherB"s}));
 
     // Make OtherB ready
     Parallel::mutate<OtherFunctionsOfTime, UpdateFoT>(cache, "OtherB"s, 456.0);
 
-    CHECK(domain::functions_of_time_are_ready<OtherFunctionsOfTime>(
-        cache, 0, component_p, 0.5, std::array{"OtherA"s, "OtherB"s}));
-    CHECK(domain::functions_of_time_are_ready<OtherFunctionsOfTime>(
-        cache, 0, component_p, 0.5));
+    CHECK(domain::functions_of_time_are_ready_algorithm_callback<
+          OtherFunctionsOfTime>(cache, 0, component_0_p, 0.5,
+                                std::unordered_set{"OtherA"s, "OtherB"s}));
+    CHECK(domain::functions_of_time_are_ready_algorithm_callback<
+          OtherFunctionsOfTime>(cache, 0, component_0_p, 0.5, std::nullopt));
   }
 
   // Test the action.  This should automatically look at
   // domain::Tags::FunctionsOfTime.
   {
     // Neither function ready
-    CHECK(not ActionTesting::next_action_if_ready<component>(
+    CHECK(not ActionTesting::next_action_if_ready<component0>(
         make_not_null(&runner), 0));
 
     // Make OtherA ready
     Parallel::mutate<domain::Tags::FunctionsOfTime, UpdateFoT>(
         cache, "FunctionA"s, 5.0);
 
-    CHECK(not ActionTesting::next_action_if_ready<component>(
+    CHECK(not ActionTesting::next_action_if_ready<component0>(
         make_not_null(&runner), 0));
 
     // Make OtherB ready
     Parallel::mutate<domain::Tags::FunctionsOfTime, UpdateFoT>(
         cache, "FunctionB"s, 10.0);
 
-    CHECK(ActionTesting::next_action_if_ready<component>(make_not_null(&runner),
-                                                         0));
+    CHECK(ActionTesting::next_action_if_ready<component0>(
+        make_not_null(&runner), 0));
+  }
+
+  // Test simple action callback free function
+  {
+    DataVector data{6, 0.0};
+    const size_t size = data.size();
+
+    // No callbacks should be registered
+    CHECK(domain::functions_of_time_are_ready_simple_action_callback<
+          domain::Tags::FunctionsOfTime, SimpleActionNoArgs>(
+        cache, 0, component_0_p, 5.0, std::nullopt));
+    CHECK(ActionTesting::number_of_queued_simple_actions<component0>(runner,
+                                                                     0) == 0);
+    CHECK(simple_action_no_args_call_count == 0_st);
+    CHECK(domain::functions_of_time_are_ready_simple_action_callback<
+          domain::Tags::FunctionsOfTime, SimpleActionArgs>(
+        cache, 0, component_0_p, 5.0, std::nullopt, size, data));
+    CHECK(ActionTesting::number_of_queued_simple_actions<component0>(runner,
+                                                                     0) == 0);
+    CHECK(simple_action_args_call_count == 0_st);
+
+    // Again no callbacks should be registered
+    CHECK(domain::functions_of_time_are_ready_simple_action_callback<
+          domain::Tags::FunctionsOfTime, SimpleActionNoArgs>(
+        cache, 0, component_0_p, 6.0, std::unordered_set{"FunctionB"s}));
+    CHECK(ActionTesting::number_of_queued_simple_actions<component0>(runner,
+                                                                     0) == 0);
+    CHECK(simple_action_no_args_call_count == 0_st);
+    CHECK(domain::functions_of_time_are_ready_simple_action_callback<
+          domain::Tags::FunctionsOfTime, SimpleActionArgs>(
+        cache, 0, component_0_p, 6.0, std::unordered_set{"FunctionB"s}, size,
+        data));
+    CHECK(ActionTesting::number_of_queued_simple_actions<component0>(runner,
+                                                                     0) == 0);
+    CHECK(simple_action_args_call_count == 0_st);
+
+    // Evaluate at time when A isn't ready. Can't have two different
+    // callbacks on same component so we use different components
+    CHECK(not domain::functions_of_time_are_ready_simple_action_callback<
+          domain::Tags::FunctionsOfTime, SimpleActionNoArgs>(
+        cache, 0, component_0_p, 6.0, std::unordered_set{"FunctionA"s}));
+    CHECK(ActionTesting::number_of_queued_simple_actions<component0>(runner,
+                                                                     0) == 0);
+    CHECK(simple_action_no_args_call_count == 0_st);
+    CHECK(not domain::functions_of_time_are_ready_simple_action_callback<
+          domain::Tags::FunctionsOfTime, SimpleActionArgs>(
+        cache, 0, component_1_p, 6.0, std::unordered_set{"FunctionA"s}, size,
+        data));
+    CHECK(ActionTesting::number_of_queued_simple_actions<component1>(runner,
+                                                                     0) == 0);
+    CHECK(simple_action_args_call_count == 0_st);
+
+    // Make FunctionA valid again
+    Parallel::mutate<domain::Tags::FunctionsOfTime, UpdateFoT>(
+        cache, "FunctionA"s, 10.0);
+    // Both actions should have been queued
+    CHECK(ActionTesting::number_of_queued_simple_actions<component0>(runner,
+                                                                     0) == 1);
+    CHECK(ActionTesting::number_of_queued_simple_actions<component1>(runner,
+                                                                     0) == 1);
+    CHECK(simple_action_no_args_call_count == 0_st);
+    CHECK(simple_action_args_call_count == 0_st);
+    ActionTesting::invoke_queued_simple_action<component0>(
+        make_not_null(&runner), 0);
+    // Only one ran
+    CHECK(simple_action_no_args_call_count == 1_st);
+    CHECK(simple_action_args_call_count == 0_st);
+    ActionTesting::invoke_queued_simple_action<component1>(
+        make_not_null(&runner), 0);
+    // Both ran
+    CHECK(simple_action_no_args_call_count == 1_st);
+    CHECK(simple_action_args_call_count == 1_st);
+    CHECK(domain::functions_of_time_are_ready_simple_action_callback<
+          domain::Tags::FunctionsOfTime, SimpleActionNoArgs>(
+        cache, 0, component_0_p, 6.0, std::unordered_set{"FunctionA"s}));
+    CHECK(ActionTesting::number_of_queued_simple_actions<component0>(runner,
+                                                                     0) == 0);
+
+    // Evaluate at time when neither are ready.
+    CHECK(not domain::functions_of_time_are_ready_simple_action_callback<
+          domain::Tags::FunctionsOfTime, SimpleActionNoArgs>(
+        cache, 0, component_0_p, 11.0, std::nullopt));
+    CHECK(ActionTesting::number_of_queued_simple_actions<component0>(runner,
+                                                                     0) == 0);
+    CHECK(simple_action_no_args_call_count == 1_st);
+    CHECK(not domain::functions_of_time_are_ready_simple_action_callback<
+          domain::Tags::FunctionsOfTime, SimpleActionArgs>(
+        cache, 0, component_1_p, 11.0, std::nullopt, size, data));
+    CHECK(ActionTesting::number_of_queued_simple_actions<component1>(runner,
+                                                                     0) == 0);
+    CHECK(simple_action_args_call_count == 1_st);
+
+    // Make A valid
+    Parallel::mutate<domain::Tags::FunctionsOfTime, UpdateFoT>(
+        cache, "FunctionA"s, 15.0);
+    // Both actions should have been queued
+    CHECK(ActionTesting::number_of_queued_simple_actions<component0>(runner,
+                                                                     0) == 1);
+    CHECK(ActionTesting::number_of_queued_simple_actions<component1>(runner,
+                                                                     0) == 1);
+    CHECK(simple_action_no_args_call_count == 1_st);
+    CHECK(simple_action_args_call_count == 1_st);
+    ActionTesting::invoke_queued_simple_action<component0>(
+        make_not_null(&runner), 0);
+    CHECK(simple_action_no_args_call_count == 2_st);
+    CHECK(simple_action_args_call_count == 1_st);
+    ActionTesting::invoke_queued_simple_action<component1>(
+        make_not_null(&runner), 0);
+    CHECK(simple_action_no_args_call_count == 2_st);
+    CHECK(simple_action_args_call_count == 2_st);
+
+    // Make B valid. Nothing should have happened
+    Parallel::mutate<domain::Tags::FunctionsOfTime, UpdateFoT>(
+        cache, "FunctionB"s, 15.0);
+    CHECK(ActionTesting::number_of_queued_simple_actions<component0>(runner,
+                                                                     0) == 0);
+    CHECK(ActionTesting::number_of_queued_simple_actions<component1>(runner,
+                                                                     0) == 0);
+    // No actions should have run
+    CHECK(simple_action_no_args_call_count == 2_st);
+    CHECK(simple_action_args_call_count == 2_st);
+  }
+
+  // No FoTs in the cache
+  {
+    using EmptyMockRuntimeSystem =
+        ActionTesting::MockRuntimeSystem<EmptyMetavars>;
+    using empty_comp = EmptyComponent<EmptyMetavars, 0_st>;
+    const empty_comp* const empty_component_p = nullptr;
+
+    EmptyMockRuntimeSystem empty_runner{{}};
+    ActionTesting::emplace_array_component<empty_comp>(
+        make_not_null(&empty_runner), ActionTesting::NodeId{0},
+        ActionTesting::LocalCoreId{0}, 0, 2.0);
+
+    auto& empty_cache = ActionTesting::cache<empty_comp>(empty_runner, 0);
+    CHECK(domain::functions_of_time_are_ready_algorithm_callback<
+          domain::Tags::FunctionsOfTime>(empty_cache, 0, empty_component_p,
+                                         6.0));
+    CHECK(domain::functions_of_time_are_ready_simple_action_callback<
+          domain::Tags::FunctionsOfTime, SimpleActionNoArgs>(
+        empty_cache, 0, empty_component_p, 6.0, std::nullopt));
+    CHECK(domain::functions_of_time_are_ready_simple_action_callback<
+          domain::Tags::FunctionsOfTime, SimpleActionArgs>(
+        empty_cache, 0, empty_component_p, 6.0, std::nullopt, 0_st,
+        DataVector{}));
   }
 }


### PR DESCRIPTION
## Proposed changes

The previous version of `functions_of_time_are_ready()` only used a `PerformAlgorithmCallback`. But sometimes we want to use a `SimpleActionCallback`. This generalizes `functions_of_time_are_ready()` to allow both.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
