### PR TITLE
Fix sphere optimization

### DIFF
--- a/src/ParallelAlgorithms/Interpolation/Actions/InterpolatorReceiveVolumeData.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Actions/InterpolatorReceiveVolumeData.hpp
@@ -142,11 +142,14 @@ struct InterpolatorReceiveVolumeData {
         make_not_null(&box));
 
     // Try to interpolate data for all InterpolationTargets for this
-    // temporal_id.
+    // temporal_id. Also make sure this target is using the interpolator. No
+    // sense in calling this for targets that don't use it.
     tmpl::for_each<typename Metavariables::interpolation_target_tags>(
         [&box, &cache, &temporal_id](auto tag_v) {
           using tag = typename decltype(tag_v)::type;
-          if constexpr (std::is_same_v<typename tag::temporal_id, TemporalId>) {
+          if constexpr (detail::using_interpolator_component_v<Metavariables,
+                                                               tag> and
+                        std::is_same_v<typename tag::temporal_id, TemporalId>) {
             try_to_interpolate<tag>(make_not_null(&box), make_not_null(&cache),
                                     temporal_id);
           }

--- a/src/ParallelAlgorithms/Interpolation/Events/InterpolateWithoutInterpComponent.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Events/InterpolateWithoutInterpComponent.hpp
@@ -150,10 +150,14 @@ class InterpolateWithoutInterpComponent<VolumeDim, InterpolationTargetTag,
       // Extremum for x, y, z, r
       std::array<std::pair<double, double>, 4> min_max_coordinates{};
 
-      // Calculate r^2 because sqrt is expensive
+      const auto& sphere =
+          Parallel::get<Tags::Sphere<InterpolationTargetTag>>(cache);
+      const std::array<double, 3>& center = sphere.center;
+
+      // Calculate r^2 from center of sphere because sqrt is expensive
       DataVector radii_squared{get<0>(coordinates).size(), 0.0};
       for (size_t i = 0; i < VolumeDim; i++) {
-        radii_squared += square(coordinates.get(i));
+        radii_squared += square(coordinates.get(i) - gsl::at(center, i));
       }
 
       // Compute min and max
@@ -163,8 +167,6 @@ class InterpolateWithoutInterpComponent<VolumeDim, InterpolationTargetTag,
         min_max_coordinates[3].second = *max;
       }
 
-      const auto& sphere =
-          Parallel::get<Tags::Sphere<InterpolationTargetTag>>(cache);
       const std::set<double>& radii_of_sphere_target = sphere.radii;
       const size_t l_max = sphere.l_max;
 

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_SendGhVarsToCce.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_SendGhVarsToCce.cpp
@@ -143,8 +143,8 @@ template <typename MockMetavariables>
 void run_test() {
   using metavars = MockMetavariables;
   using elem_component = mock_element<metavars>;
-  InterpolateOnElementTestHelpers::test_interpolate_on_element<metavars,
-                                                               elem_component>(
+  InterpolateOnElementTestHelpers::test_interpolate_on_element<
+      metavars, elem_component, false>(
       initialize_elements_and_queue_simple_actions<elem_component>{});
 }
 

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolateWithoutInterpComponent.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolateWithoutInterpComponent.cpp
@@ -163,12 +163,12 @@ struct MockMetavariables {
   };
 };
 
-template <typename MockMetavariables>
+template <typename MockMetavariables, bool OffCenter = false>
 void run_test() {
   using metavars = MockMetavariables;
   using elem_component = mock_element<metavars>;
-  InterpolateOnElementTestHelpers::test_interpolate_on_element<metavars,
-                                                               elem_component>(
+  InterpolateOnElementTestHelpers::test_interpolate_on_element<
+      metavars, elem_component, OffCenter>(
       initialize_elements_and_queue_simple_actions<metavars, elem_component>{});
 }
 
@@ -182,5 +182,8 @@ SPECTRE_TEST_CASE(
   run_test<MockMetavariables<true, false>>();
   run_test<MockMetavariables<false, true>>();
   run_test<MockMetavariables<true, true>>();
+
+  // Off-center test
+  run_test<MockMetavariables<false, false>, true>();
 }
 }  // namespace


### PR DESCRIPTION
## Proposed changes

When calculating the radius bounds, an implicit assumption was made that the center of the sphere was the origin. This didn't show up for the BondiSachs worldtube sphere because it is centered on the origin. However, this blows up for the BBH domain which has excisions centered on each horizon. This PR fixes this. It also avoids a call to `try_to_interpolate` that is unnecessary for targets that don't use the interpolator.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
