### PR TITLE
Move internals of ThreadsafeList to a tpp file

### DIFF
--- a/src/Domain/FunctionsOfTime/CMakeLists.txt
+++ b/src/Domain/FunctionsOfTime/CMakeLists.txt
@@ -33,6 +33,7 @@ spectre_target_headers(
   SettleToConstant.hpp
   Tags.hpp
   ThreadsafeList.hpp
+  ThreadsafeList.tpp
   )
 
 target_link_libraries(

--- a/src/Domain/FunctionsOfTime/PiecewisePolynomial.cpp
+++ b/src/Domain/FunctionsOfTime/PiecewisePolynomial.cpp
@@ -18,6 +18,7 @@
 #include <vector>
 
 #include "DataStructures/DataVector.hpp"
+#include "Domain/FunctionsOfTime/ThreadsafeList.tpp"
 #include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
@@ -26,6 +27,28 @@
 
 namespace domain::FunctionsOfTime {
 template <size_t MaxDeriv>
+PiecewisePolynomial<MaxDeriv>::PiecewisePolynomial() = default;
+
+template <size_t MaxDeriv>
+PiecewisePolynomial<MaxDeriv>::PiecewisePolynomial(PiecewisePolynomial&&) =
+    default;
+
+template <size_t MaxDeriv>
+PiecewisePolynomial<MaxDeriv>::PiecewisePolynomial(const PiecewisePolynomial&) =
+    default;
+
+template <size_t MaxDeriv>
+auto PiecewisePolynomial<MaxDeriv>::operator=(PiecewisePolynomial&&)
+    -> PiecewisePolynomial& = default;
+
+template <size_t MaxDeriv>
+auto PiecewisePolynomial<MaxDeriv>::operator=(const PiecewisePolynomial&)
+    -> PiecewisePolynomial& = default;
+
+template <size_t MaxDeriv>
+PiecewisePolynomial<MaxDeriv>::~PiecewisePolynomial() = default;
+
+template <size_t MaxDeriv>
 PiecewisePolynomial<MaxDeriv>::PiecewisePolynomial(
     const double t,
     std::array<DataVector, MaxDeriv + 1> initial_func_and_derivs,
@@ -33,6 +56,10 @@ PiecewisePolynomial<MaxDeriv>::PiecewisePolynomial(
     : deriv_info_at_update_times_(t) {
   store_entry(t, std::move(initial_func_and_derivs), expiration_time);
 }
+
+template <size_t MaxDeriv>
+PiecewisePolynomial<MaxDeriv>::PiecewisePolynomial(
+    CkMigrateMessage* /*unused*/) {}
 
 template <size_t MaxDeriv>
 std::unique_ptr<FunctionOfTime> PiecewisePolynomial<MaxDeriv>::get_clone()
@@ -114,6 +141,12 @@ void PiecewisePolynomial<MaxDeriv>::update(const double time_of_update,
 
   func[MaxDeriv] = std::move(updated_max_deriv);
   store_entry(time_of_update, std::move(func), next_expiration_time);
+}
+
+template <size_t MaxDeriv>
+std::array<double, 2> PiecewisePolynomial<MaxDeriv>::time_bounds() const {
+  return {{deriv_info_at_update_times_.initial_time(),
+           deriv_info_at_update_times_.expiration_time()}};
 }
 
 template <size_t MaxDeriv>

--- a/src/Domain/FunctionsOfTime/PiecewisePolynomial.hpp
+++ b/src/Domain/FunctionsOfTime/PiecewisePolynomial.hpp
@@ -26,12 +26,18 @@ namespace FunctionsOfTime {
 template <size_t MaxDeriv>
 class PiecewisePolynomial : public FunctionOfTime {
  public:
-  PiecewisePolynomial() = default;
+  PiecewisePolynomial();
+  PiecewisePolynomial(PiecewisePolynomial&&);
+  PiecewisePolynomial(const PiecewisePolynomial&);
+  PiecewisePolynomial& operator=(PiecewisePolynomial&&);
+  PiecewisePolynomial& operator=(const PiecewisePolynomial&);
+  ~PiecewisePolynomial() override;
+
   PiecewisePolynomial(
       double t, std::array<DataVector, MaxDeriv + 1> initial_func_and_derivs,
       double expiration_time);
 
-  explicit PiecewisePolynomial(CkMigrateMessage* /*unused*/) {}
+  explicit PiecewisePolynomial(CkMigrateMessage* /*unused*/);
 
   auto get_clone() const -> std::unique_ptr<FunctionOfTime> override;
 
@@ -70,10 +76,7 @@ class PiecewisePolynomial : public FunctionOfTime {
 
   /// Returns the domain of validity of the function,
   /// including the extrapolation region.
-  std::array<double, 2> time_bounds() const override {
-    return {{deriv_info_at_update_times_.initial_time(),
-             deriv_info_at_update_times_.expiration_time()}};
-  }
+  std::array<double, 2> time_bounds() const override;
 
   // NOLINTNEXTLINE(google-runtime-references)
   void pup(PUP::er& p) override;

--- a/src/Domain/FunctionsOfTime/QuaternionFunctionOfTime.cpp
+++ b/src/Domain/FunctionsOfTime/QuaternionFunctionOfTime.cpp
@@ -25,6 +25,7 @@
 
 #include "DataStructures/DataVector.hpp"
 #include "Domain/FunctionsOfTime/QuaternionHelpers.hpp"
+#include "Domain/FunctionsOfTime/ThreadsafeList.tpp"
 #include "NumericalAlgorithms/OdeIntegration/OdeIntegration.hpp"
 #include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"
@@ -33,6 +34,28 @@
 #include "Utilities/Serialization/PupBoost.hpp"
 
 namespace domain::FunctionsOfTime {
+template <size_t MaxDeriv>
+QuaternionFunctionOfTime<MaxDeriv>::QuaternionFunctionOfTime() = default;
+
+template <size_t MaxDeriv>
+QuaternionFunctionOfTime<MaxDeriv>::QuaternionFunctionOfTime(
+    QuaternionFunctionOfTime&&) = default;
+
+template <size_t MaxDeriv>
+QuaternionFunctionOfTime<MaxDeriv>::QuaternionFunctionOfTime(
+    const QuaternionFunctionOfTime&) = default;
+
+template <size_t MaxDeriv>
+auto QuaternionFunctionOfTime<MaxDeriv>::operator=(QuaternionFunctionOfTime&&)
+    -> QuaternionFunctionOfTime& = default;
+
+template <size_t MaxDeriv>
+auto QuaternionFunctionOfTime<MaxDeriv>::operator=(
+    const QuaternionFunctionOfTime&) -> QuaternionFunctionOfTime& = default;
+
+template <size_t MaxDeriv>
+QuaternionFunctionOfTime<MaxDeriv>::~QuaternionFunctionOfTime() = default;
+
 template <size_t MaxDeriv>
 QuaternionFunctionOfTime<MaxDeriv>::QuaternionFunctionOfTime(
     const double t, const std::array<DataVector, 1>& initial_quat_func,
@@ -45,9 +68,19 @@ QuaternionFunctionOfTime<MaxDeriv>::QuaternionFunctionOfTime(
 }
 
 template <size_t MaxDeriv>
+QuaternionFunctionOfTime<MaxDeriv>::QuaternionFunctionOfTime(
+    CkMigrateMessage* /*unused*/) {}
+
+template <size_t MaxDeriv>
 std::unique_ptr<FunctionOfTime> QuaternionFunctionOfTime<MaxDeriv>::get_clone()
     const {
   return std::make_unique<QuaternionFunctionOfTime>(*this);
+}
+
+template <size_t MaxDeriv>
+std::array<double, 2> QuaternionFunctionOfTime<MaxDeriv>::time_bounds() const {
+  return std::array{stored_quaternions_and_times_.initial_time(),
+                    stored_quaternions_and_times_.expiration_time()};
 }
 
 template <size_t MaxDeriv>

--- a/src/Domain/FunctionsOfTime/QuaternionFunctionOfTime.hpp
+++ b/src/Domain/FunctionsOfTime/QuaternionFunctionOfTime.hpp
@@ -59,14 +59,20 @@ namespace domain::FunctionsOfTime {
 template <size_t MaxDeriv>
 class QuaternionFunctionOfTime : public FunctionOfTime {
  public:
-  QuaternionFunctionOfTime() = default;
+  QuaternionFunctionOfTime();
+  QuaternionFunctionOfTime(QuaternionFunctionOfTime&&);
+  QuaternionFunctionOfTime(const QuaternionFunctionOfTime&);
+  QuaternionFunctionOfTime& operator=(QuaternionFunctionOfTime&&);
+  QuaternionFunctionOfTime& operator=(const QuaternionFunctionOfTime&);
+  ~QuaternionFunctionOfTime() override;
+
   QuaternionFunctionOfTime(
       double t, const std::array<DataVector, 1>& initial_quat_func,
       std::array<DataVector, MaxDeriv + 1> initial_angle_func,
       double expiration_time);
 
   // LCOV_EXCL_START
-  explicit QuaternionFunctionOfTime(CkMigrateMessage* /*unused*/) {}
+  explicit QuaternionFunctionOfTime(CkMigrateMessage* /*unused*/);
   // LCOV_EXCL_STOP
 
   auto get_clone() const -> std::unique_ptr<FunctionOfTime> override;
@@ -76,10 +82,7 @@ class QuaternionFunctionOfTime : public FunctionOfTime {
   WRAPPED_PUPable_decl_template(QuaternionFunctionOfTime<MaxDeriv>);  // NOLINT
 
   /// Returns domain of validity for the function of time
-  std::array<double, 2> time_bounds() const override {
-    return std::array{stored_quaternions_and_times_.initial_time(),
-                      stored_quaternions_and_times_.expiration_time()};
-  }
+  std::array<double, 2> time_bounds() const override;
 
   /// Updates the `MaxDeriv`th derivative of the angle piecewisepolynomial at
   /// the given time, then updates the stored quaternions.

--- a/src/Domain/FunctionsOfTime/ThreadsafeList.tpp
+++ b/src/Domain/FunctionsOfTime/ThreadsafeList.tpp
@@ -1,0 +1,263 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "Domain/FunctionsOfTime/ThreadsafeList.hpp"
+
+#include <atomic>
+#include <memory>
+#include <pup.h>
+#include <pup_stl.h>
+#include <utility>
+
+#include "Utilities/EqualWithinRoundoff.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
+
+namespace domain::FunctionsOfTime::FunctionOfTimeHelpers {
+namespace ThreadsafeList_detail {
+template <typename T>
+struct Interval {
+  double expiration;
+  T data;
+  std::unique_ptr<Interval> previous;
+
+  void pup(PUP::er& p);
+};
+
+template <typename T>
+void Interval<T>::pup(PUP::er& p) {
+  p | expiration;
+  p | data;
+  p | previous;
+}
+}  // namespace ThreadsafeList_detail
+
+template <typename T>
+ThreadsafeList<T>::ThreadsafeList() = default;
+
+template <typename T>
+ThreadsafeList<T>::ThreadsafeList(ThreadsafeList&& other) {
+  *this = std::move(other);
+}
+
+template <typename T>
+ThreadsafeList<T>::ThreadsafeList(const ThreadsafeList& other) {
+  *this = other;
+}
+
+template <typename T>
+auto ThreadsafeList<T>::operator=(ThreadsafeList&& other) -> ThreadsafeList& {
+  if (this == &other) {
+    return *this;
+  }
+  initial_time_ = other.initial_time_;
+  interval_list_ = std::move(other.interval_list_);
+  most_recent_interval_.store(interval_list_.get(), std::memory_order_release);
+  other.most_recent_interval_.store(nullptr, std::memory_order_release);
+  return *this;
+}
+
+template <typename T>
+auto ThreadsafeList<T>::operator=(const ThreadsafeList& other)
+    -> ThreadsafeList& {
+  if (this == &other) {
+    return *this;
+  }
+  initial_time_ = other.initial_time_;
+
+  std::unique_ptr<Interval>* previous_pointer = &interval_list_;
+  for (auto&& entry : other) {
+    // make_unique doesn't work on aggregates until C++20
+    previous_pointer->reset(
+        new Interval{entry.expiration, entry.data, nullptr});
+    previous_pointer = &(*previous_pointer)->previous;
+  }
+
+  most_recent_interval_.store(interval_list_.get(), std::memory_order_release);
+  return *this;
+}
+
+template <typename T>
+ThreadsafeList<T>::~ThreadsafeList() = default;
+
+template <typename T>
+ThreadsafeList<T>::ThreadsafeList(const double initial_time)
+    : initial_time_(initial_time), most_recent_interval_(nullptr) {}
+
+template <typename T>
+void ThreadsafeList<T>::insert(const double update_time, T data,
+                               const double expiration_time) {
+  const auto* old_interval =
+      most_recent_interval_.load(std::memory_order_acquire);
+  const double old_expiration =
+      old_interval != nullptr ? old_interval->expiration : initial_time_;
+  if (old_expiration != update_time) {
+    ERROR("Tried to insert at time "
+          << update_time << ", which is not the old expiration time "
+          << old_expiration);
+  }
+  if (expiration_time <= update_time) {
+    ERROR("Expiration time " << expiration_time << " is not after update time "
+                             << update_time);
+  }
+  // make_unique doesn't work on aggregates until C++20
+  std::unique_ptr<Interval> new_interval(new Interval{
+      expiration_time, std::move(data), std::move(interval_list_)});
+  const auto* const new_interval_p = new_interval.get();
+  interval_list_ = std::move(new_interval);
+  if (not most_recent_interval_.compare_exchange_strong(
+          old_interval, new_interval_p, std::memory_order_acq_rel)) {
+    ERROR("Attempt at concurrent modification detected.");
+  }
+}
+
+template <typename T>
+auto ThreadsafeList<T>::operator()(const double time) const -> IntervalInfo {
+  if (time < initial_time_ and not equal_within_roundoff(time, initial_time_)) {
+    ERROR("Requested time " << time << " precedes earliest time "
+                            << initial_time_);
+  }
+  const auto& interval = find_interval(time, false);
+  const double start = interval.previous != nullptr
+                           ? interval.previous->expiration
+                           : initial_time_;
+  return {start, interval.data, interval.expiration};
+}
+
+template <typename T>
+double ThreadsafeList<T>::initial_time() const {
+  return initial_time_;
+}
+
+template <typename T>
+double ThreadsafeList<T>::expiration_time() const {
+  auto* interval = most_recent_interval_.load(std::memory_order_acquire);
+  return interval != nullptr ? interval->expiration : initial_time_;
+}
+
+template <typename T>
+double ThreadsafeList<T>::expiration_after(const double time) const {
+  return find_interval(time, true).expiration;
+}
+
+template <typename T>
+void ThreadsafeList<T>::pup(PUP::er& p) {
+  size_t version = 0;
+  p | version;
+  // Remember to increment the version number when making changes to this
+  // function. Retain support for unpacking data written by previous versions
+  // whenever possible. See `Domain` docs for details.
+
+  if (version != 0) {
+    ERROR("Unrecognized version " << version);
+  }
+
+  p | initial_time_;
+  if (p.isUnpacking()) {
+    bool empty{};
+    p | empty;
+    interval_list_.reset();
+    if (not empty) {
+      interval_list_ = std::make_unique<Interval>();
+      p | *interval_list_;
+    }
+    most_recent_interval_.store(interval_list_.get(),
+                                std::memory_order_release);
+  } else {
+    const Interval* const threadsafe_interval_list =
+        most_recent_interval_.load(std::memory_order_acquire);
+    bool empty = threadsafe_interval_list == nullptr;
+    p | empty;
+    if (not empty) {
+      p | const_cast<Interval&>(*threadsafe_interval_list);
+    }
+  }
+}
+
+template <typename T>
+auto ThreadsafeList<T>::iterator::operator++() -> iterator& {
+  interval_ = interval_->previous.get();
+  return *this;
+}
+
+template <typename T>
+auto ThreadsafeList<T>::iterator::operator++(int) -> iterator {
+  auto result = *this;
+  ++*this;
+  return result;
+}
+
+template <typename T>
+auto ThreadsafeList<T>::iterator::operator*() const -> reference {
+  return {interval_->previous != nullptr ? interval_->previous->expiration
+                                         : initial_time_,
+          interval_->data, interval_->expiration};
+}
+
+template <typename T>
+auto ThreadsafeList<T>::iterator::operator->() const -> pointer {
+  return {**this};
+}
+
+template <typename T>
+ThreadsafeList<T>::iterator::iterator(const double initial_time,
+                                      const Interval* const interval)
+    : initial_time_(initial_time), interval_(interval) {}
+
+template <typename T>
+auto ThreadsafeList<T>::begin() const -> iterator {
+  return {initial_time_, most_recent_interval_.load(std::memory_order_acquire)};
+}
+
+template <typename T>
+auto ThreadsafeList<T>::end() const -> iterator {
+  return {};
+}
+
+template <typename T>
+auto ThreadsafeList<T>::find_interval(const double time,
+                                      const bool interval_after_boundary) const
+    -> const Interval& {
+  auto* interval = most_recent_interval_.load(std::memory_order_acquire);
+  if (interval == nullptr) {
+    ERROR("Attempt to access an empty function of time.");
+  }
+  if (time > interval->expiration or
+      (interval_after_boundary and time == interval->expiration)) {
+    ERROR("Attempt to evaluate at time "
+          << time << ", which is after the expiration time "
+          << interval->expiration);
+  }
+  // Loop over the intervals until we find the one containing `time`,
+  // possibly at the endpoint determined by `interval_after_boundary`.
+  for (;;) {
+    const auto* const previous_interval = interval->previous.get();
+    if (previous_interval == nullptr or time > previous_interval->expiration or
+        (interval_after_boundary and time == previous_interval->expiration)) {
+      return *interval;
+    }
+    interval = previous_interval;
+  }
+}
+
+template <typename T>
+bool operator==(const ThreadsafeList<T>& a, const ThreadsafeList<T>& b) {
+  if (a.initial_time() != b.initial_time()) {
+    return false;
+  }
+  auto a_iter = a.begin();
+  auto b_iter = b.begin();
+  while (a_iter != a.end() and b_iter != b.end()) {
+    if (*a_iter++ != *b_iter++) {
+      return false;
+    }
+  }
+  return a_iter == a.end() and b_iter == b.end();
+}
+
+template <typename T>
+bool operator!=(const ThreadsafeList<T>& a, const ThreadsafeList<T>& b) {
+  return not(a == b);
+}
+}  // namespace domain::FunctionsOfTime::FunctionOfTimeHelpers

--- a/tests/Unit/Domain/FunctionsOfTime/Test_ThreadsafeList.cpp
+++ b/tests/Unit/Domain/FunctionsOfTime/Test_ThreadsafeList.cpp
@@ -6,6 +6,7 @@
 #include <utility>
 
 #include "Domain/FunctionsOfTime/ThreadsafeList.hpp"
+#include "Domain/FunctionsOfTime/ThreadsafeList.tpp"
 #include "Framework/TestHelpers.hpp"
 
 SPECTRE_TEST_CASE("Unit.Domain.FunctionsOfTime.ThreadsafeList",


### PR DESCRIPTION
I don't think this class is particularly expensive.  This was mostly an experiment into how difficult it is to move a class to a tpp when it is not used in the interface of any other class.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
