### PR TITLE
Memoize control_system::combined_name

### DIFF
--- a/src/ControlSystem/CombinedName.hpp
+++ b/src/ControlSystem/CombinedName.hpp
@@ -23,23 +23,26 @@ namespace control_system {
  * \tparam ListOfControlSystems `tmpl::list` of control systems
  */
 template <typename ListOfControlSystems>
-std::string combined_name() {
-  std::vector<std::string> control_system_names{};
-  control_system_names.reserve(tmpl::size<ListOfControlSystems>::value);
-  std::string combined_name{};
+const std::string& combined_name() {
+  static const std::string combined_name = []() {
+    std::vector<std::string> control_system_names{};
+    control_system_names.reserve(tmpl::size<ListOfControlSystems>::value);
+    std::string local_combined_name{};
 
-  tmpl::for_each<ListOfControlSystems>(
-      [&control_system_names](auto control_system_v) {
-        using control_system = tmpl::type_from<decltype(control_system_v)>;
-        control_system_names.emplace_back(control_system::name());
-      });
+    tmpl::for_each<ListOfControlSystems>(
+        [&control_system_names](auto control_system_v) {
+          using control_system = tmpl::type_from<decltype(control_system_v)>;
+          control_system_names.emplace_back(control_system::name());
+        });
 
-  alg::sort(control_system_names);
+    alg::sort(control_system_names);
 
-  for (const std::string& name : control_system_names) {
-    combined_name += name;
-  }
+    for (const std::string& name : control_system_names) {
+      local_combined_name += name;
+    }
 
+    return local_combined_name;
+  }();
   return combined_name;
 }
 
@@ -74,7 +77,7 @@ std::unordered_map<std::string, std::string> system_to_combined_names() {
                                                         auto list_v) {
     using control_systems_with_measurement = tmpl::type_from<decltype(list_v)>;
 
-    const std::string combined_name =
+    const std::string& combined_name =
         control_system::combined_name<control_systems_with_measurement>();
 
     tmpl::for_each<control_systems_with_measurement>(

--- a/src/ControlSystem/Trigger.hpp
+++ b/src/ControlSystem/Trigger.hpp
@@ -139,7 +139,8 @@ class Trigger : public DenseTrigger {
         domain::functions_of_time_are_ready_algorithm_callback<
             control_system::Tags::MeasurementTimescales>(
             cache, array_index, component, time,
-            std::unordered_set{measurement_name_});
+            std::unordered_set{
+                control_system::combined_name<ControlSystems>()});
     if (not is_ready) {
       if (Parallel::get<Tags::Verbosity>(cache) >= ::Verbosity::Debug) {
         Parallel::printf(
@@ -174,14 +175,16 @@ class Trigger : public DenseTrigger {
           std::string,
           std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
           measurement_timescales) {
+    const std::string& measurement_name =
+        control_system::combined_name<ControlSystems>();
     ASSERT(
-        measurement_timescales.count(measurement_name_) == 1,
+        measurement_timescales.count(measurement_name) == 1,
         "Control system trigger expects a measurement timescale with the name '"
-            << measurement_name_
+            << measurement_name
             << "' but could not find one. Available names are: "
             << keys_of(measurement_timescales));
     const DataVector timescale =
-        measurement_timescales.at(measurement_name_)->func(time)[0];
+        measurement_timescales.at(measurement_name)->func(time)[0];
     ASSERT(timescale.size() == 1,
            "Control system trigger assumes measurement timescale size is 1, "
            "but it is "
@@ -197,9 +200,6 @@ class Trigger : public DenseTrigger {
   }
 
   std::optional<double> next_trigger_{};
-  // No need to pup this because it can be created from the template parameter
-  std::string measurement_name_{
-      control_system::combined_name<ControlSystems>()};
 };
 
 /// \cond

--- a/tests/Unit/ControlSystem/Test_CombinedName.cpp
+++ b/tests/Unit/ControlSystem/Test_CombinedName.cpp
@@ -51,10 +51,10 @@ void test_system_to_combined_names() {
 void test_combined_name() {
   using list_of_names = tmpl::list<Name<3>, Name<0>, Name<2>, Name<1>>;
 
-  const std::string combined = control_system::combined_name<list_of_names>();
+  const std::string& combined = control_system::combined_name<list_of_names>();
   CHECK(combined == "Name0Name1Name2Name3");
 
-  const std::string empty = control_system::combined_name<tmpl::list<>>();
+  const std::string& empty = control_system::combined_name<tmpl::list<>>();
   CHECK(empty.empty());
 }
 


### PR DESCRIPTION
Non-trivial function expected to be called many times with only a handful of different parameters.

The other function in the file, system_to_combined_names, appears to only be used during initialization.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
