### PR TITLE
Install CI compilers etc on demand to reduce disk space usage on CI

### DIFF
--- a/.github/actions/parse-compiler/action.yaml
+++ b/.github/actions/parse-compiler/action.yaml
@@ -1,0 +1,36 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+name: Parse compiler
+
+description: |
+  Parse the compiler name and version from the input and set the environment
+  variables CC, CXX, FC, COMPILER_ID, and COMPILER_VERSION.
+
+inputs:
+  compiler:
+    description: Compiler to parse, e.g. 'gcc-10'
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - run: |
+        if [[ ${{ inputs.compiler }} =~ (gcc|clang)-([0-9\.]+) ]]; then
+          COMPILER_ID=${BASH_REMATCH[1]}
+          COMPILER_VERSION=${BASH_REMATCH[2]}
+          CC=${COMPILER_ID}-${COMPILER_VERSION};
+          if [[ $COMPILER_ID = gcc ]]; then
+            CXX=g++-${COMPILER_VERSION};
+            FC=gfortran-${COMPILER_VERSION};
+          else
+            CXX=clang++-${COMPILER_VERSION};
+            FC=gfortran-11;
+          fi
+        fi
+        echo "CC=$CC" >> $GITHUB_ENV
+        echo "CXX=$CXX" >> $GITHUB_ENV
+        echo "FC=$FC" >> $GITHUB_ENV
+        echo "COMPILER_ID=$COMPILER_ID" >> $GITHUB_ENV
+        echo "COMPILER_VERSION=$COMPILER_VERSION" >> $GITHUB_ENV
+      shell: bash

--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -339,7 +339,6 @@ jobs:
           -D USE_XSIMD=ON
           -D USE_CCACHE=ON
           -D BUILD_PYTHON_BINDINGS=ON
-          -D Python_EXECUTABLE=/usr/bin/python3
           -D BUILD_SHARED_LIBS=ON
           -D MEMORY_ALLOCATOR=SYSTEM
           -D BUILD_DOCS=ON
@@ -423,7 +422,7 @@ jobs:
           # https://github.com/sxs-collaboration/spectre/issues/442
           - compiler: gcc-11
             build_type: Debug
-            PYTHON_EXECUTABLE: /usr/bin/python3.8
+            PYTHON_VERSION: "3.8"
           # Disable building executable for this build for now because it
           # exceeds the available memory. See issue:
           # https://github.com/sxs-collaboration/spectre/issues/5472
@@ -540,6 +539,17 @@ jobs:
           wget -O cmake-install.sh "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-x86_64.sh"
           sh cmake-install.sh --prefix=/usr --skip-license
           rm cmake-install.sh
+      - name: Install Python version
+        if: matrix.PYTHON_VERSION
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.PYTHON_VERSION }}
+      - name: Install Python dependencies
+        if: matrix.PYTHON_VERSION
+        run: |
+          python3 -m pip install pybind11~=2.6.1
+          python3 -m pip install -r support/Python/requirements.txt \
+            -r support/Python/dev_requirements.txt
       # Assign a unique cache key for every run.
       # - We will save the cache using this unique key, but only on the develop
       #   branch. This way we regularly update the cache without filling up the
@@ -577,7 +587,6 @@ ${{ matrix.build_type }}-pch-${{ matrix.use_pch || 'ON' }}"
 
           BUILD_PYTHON_BINDINGS=${{ matrix.BUILD_PYTHON_BINDINGS }}
           BUILD_SHARED_LIBS=${{ matrix.BUILD_SHARED_LIBS }}
-          PYTHON_EXECUTABLE=${{ matrix.PYTHON_EXECUTABLE }}
           MATRIX_CHARM_ROOT=${{ matrix.CHARM_ROOT }}
           ASAN=${{ matrix.ASAN }}
           MEMORY_ALLOCATOR=${{ matrix.MEMORY_ALLOCATOR }}
@@ -612,7 +621,6 @@ ${{ matrix.build_type }}-pch-${{ matrix.use_pch || 'ON' }}"
           -D USE_CCACHE=ON
           -D COVERAGE=${COVERAGE:-'OFF'}
           -D BUILD_PYTHON_BINDINGS=${BUILD_PYTHON_BINDINGS:-'ON'}
-          -D Python_EXECUTABLE=${PYTHON_EXECUTABLE:-'/usr/bin/python3'}
           -D BUILD_SHARED_LIBS=${BUILD_SHARED_LIBS:-'ON'}
           -D ASAN=${ASAN:-'OFF'}
           -D UBSAN_UNDEFINED=${UBSAN_UNDEFINED:-'OFF'}
@@ -749,7 +757,6 @@ ${{ matrix.build_type }}-pch-${{ matrix.use_pch || 'ON' }}"
           cd build
 
           BUILD_PYTHON_BINDINGS=${{ matrix.BUILD_PYTHON_BINDINGS }}
-          PYTHON_EXECUTABLE=${{ matrix.PYTHON_EXECUTABLE }}
           MATRIX_CHARM_ROOT=${{ matrix.CHARM_ROOT }}
           MEMORY_ALLOCATOR=${{ matrix.MEMORY_ALLOCATOR }};
           USE_PCH=${{ matrix.use_pch }};
@@ -773,7 +780,6 @@ ${{ matrix.build_type }}-pch-${{ matrix.use_pch || 'ON' }}"
           -D USE_XSIMD=${USE_XSIMD:-'ON'}
           -D USE_CCACHE=ON
           -D BUILD_PYTHON_BINDINGS=${BUILD_PYTHON_BINDINGS:-'ON'}
-          -D Python_EXECUTABLE=${PYTHON_EXECUTABLE:-'/usr/bin/python3'}
           -D MEMORY_ALLOCATOR=${MEMORY_ALLOCATOR:-'SYSTEM'}
           -D BUILD_DOCS=OFF
           ..

--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -417,17 +417,19 @@ jobs:
           - compiler: gcc-10
             build_type: Debug
             TEST_TIMEOUT_FACTOR: 2
+          # Don't modify the gcc-11 Debug build so its cache can be reused for
+          # the documentation build
+          # - compiler: gcc-11
+          #   build_type: Debug
           # Test with Python 3.8 so that we retain backwards compatibility. We
           # keep track of Python versions on supercomputers in this issue:
           # https://github.com/sxs-collaboration/spectre/issues/442
           - compiler: gcc-11
-            build_type: Debug
-            PYTHON_VERSION: "3.8"
-          # Disable building executable for this build for now because it
-          # exceeds the available memory. See issue:
-          # https://github.com/sxs-collaboration/spectre/issues/5472
-          - compiler: gcc-11
             build_type: Release
+            PYTHON_VERSION: "3.8"
+            # Disable building executable for this build for now because it
+            # exceeds the available memory. See issue:
+            # https://github.com/sxs-collaboration/spectre/issues/5472
             test_executables: OFF
           # Test building with static libraries. Do so with clang in release
           # mode because these builds use up little disk space compared to GCC

--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -244,7 +244,7 @@ jobs:
           cmake
           -D CMAKE_C_COMPILER=clang
           -D CMAKE_CXX_COMPILER=clang++
-          -D CMAKE_Fortran_COMPILER=gfortran-9
+          -D CMAKE_Fortran_COMPILER=gfortran
           -D CHARM_ROOT=${CHARM_ROOT}
           -D CMAKE_BUILD_TYPE=${{ matrix.build_type }}
           -D OVERRIDE_ARCH=x86-64
@@ -518,6 +518,19 @@ jobs:
       - name: Trust checkout
         run: |
           git config --global --add safe.directory $GITHUB_WORKSPACE
+      - uses: ./.github/actions/parse-compiler
+        with:
+          compiler: ${{ matrix.compiler }}
+      # Install the selected compiler. We don't bundle all of them in the
+      # container because they take up a lot of space.
+      - name: Install compiler
+        run: |
+          apt-get update -y
+          if [[ $COMPILER_ID = gcc ]]; then
+            apt-get install -y $CC $CXX $FC
+          else
+            apt-get install -y $CC $FC
+          fi
       # Assign a unique cache key for every run.
       # - We will save the cache using this unique key, but only on the develop
       #   branch. This way we regularly update the cache without filling up the
@@ -552,17 +565,6 @@ ${{ matrix.build_type }}-pch-${{ matrix.use_pch || 'ON' }}"
         #   memory usage.
         run: >
           mkdir build && cd build
-
-          if [[ ${{ matrix.compiler }} =~ (gcc|clang)-([0-9\.]+) ]]; then
-            CC=${BASH_REMATCH[1]}-${BASH_REMATCH[2]};
-            if [[ ${BASH_REMATCH[1]} = gcc ]]; then
-              CXX=g++-${BASH_REMATCH[2]};
-              FC=gfortran-${BASH_REMATCH[2]};
-            else
-              CXX=clang++-${BASH_REMATCH[2]};
-              FC=gfortran-9;
-            fi
-          fi
 
           BUILD_PYTHON_BINDINGS=${{ matrix.BUILD_PYTHON_BINDINGS }}
           BUILD_SHARED_LIBS=${{ matrix.BUILD_SHARED_LIBS }}
@@ -735,17 +737,6 @@ ${{ matrix.build_type }}-pch-${{ matrix.use_pch || 'ON' }}"
           tar xf spectre_src.tar.gz;
           mkdir build;
           cd build
-
-          if [[ ${{ matrix.compiler }} =~ (gcc|clang)-([0-9\.]+) ]]; then
-            CC=${BASH_REMATCH[1]}-${BASH_REMATCH[2]};
-            if [[ ${BASH_REMATCH[1]} = gcc ]]; then
-              CXX=g++-${BASH_REMATCH[2]};
-              FC=gfortran-${BASH_REMATCH[2]};
-            else
-              CXX=clang++-${BASH_REMATCH[2]};
-              FC=gfortran-9;
-            fi
-          fi
 
           BUILD_PYTHON_BINDINGS=${{ matrix.BUILD_PYTHON_BINDINGS }}
           PYTHON_EXECUTABLE=${{ matrix.PYTHON_EXECUTABLE }}
@@ -1133,6 +1124,24 @@ ${{ matrix.build_type }}-pch-${{ matrix.use_pch || 'ON' }}"
       - name: Trust checkout
         run: |
           git config --global --add safe.directory $GITHUB_WORKSPACE
+      - uses: ./.github/actions/parse-compiler
+        with:
+          compiler: ${{ matrix.compiler }}
+      - name: Install compiler
+        run: |
+          apt-get update -y
+          if [[ $COMPILER_ID = gcc ]]; then
+            apt-get install -y $CC $CXX $FC
+          else
+            apt-get install -y $CC $FC
+          fi
+      - name: Install Intel SDE
+        working-directory: /work
+        run: |
+          wget -O sde-external.tar.xz https://downloadmirror.intel.com/684899/sde-external-9.0.0-2021-11-07-lin.tar.xz
+          tar -xJf sde-external.tar.xz
+          mv sde-external-* sde
+          rm sde-*
       - name: Configure, build, and run tests
         working-directory: /work
         # Notes on the build configuration:
@@ -1149,16 +1158,6 @@ ${{ matrix.build_type }}-pch-${{ matrix.use_pch || 'ON' }}"
             cd /work
             BUILD_DIR=build$OVERRIDE_ARCH
             mkdir $BUILD_DIR && cd $BUILD_DIR
-            if [[ ${{ matrix.compiler }} =~ (gcc|clang)-([0-9\.]+) ]]; then
-              CC=${BASH_REMATCH[1]}-${BASH_REMATCH[2]};
-              if [[ ${BASH_REMATCH[1]} = gcc ]]; then
-                CXX=g++-${BASH_REMATCH[2]};
-                FC=gfortran-${BASH_REMATCH[2]};
-              else
-                CXX=clang++-${BASH_REMATCH[2]};
-                FC=gfortran-9;
-              fi
-            fi
 
             cmake\
             -D CMAKE_C_COMPILER=${CC}\

--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -464,7 +464,7 @@ jobs:
           - compiler: clang-14
             build_type: Release
             # Test compatibility with oldest supported CMake version
-            CMAKE_EXECUTABLE: /opt/local/cmake/3.18.2/bin/cmake
+            CMAKE_VERSION: "3.18.2"
             # Use an MPI version of Charm
             CHARM_ROOT: /work/charm_7_0_0/mpi-linux-x86_64-smp-clang
             # MPI running tests is a bit slower than multicore
@@ -531,6 +531,15 @@ jobs:
           else
             apt-get install -y $CC $FC
           fi
+      # Install specific CMake version if requested
+      - name: Install CMake version
+        if: matrix.CMAKE_VERSION
+        working-directory: /work
+        run: |
+          CMAKE_VERSION=${{ matrix.CMAKE_VERSION }}
+          wget -O cmake-install.sh "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-x86_64.sh"
+          sh cmake-install.sh --prefix=/usr --skip-license
+          rm cmake-install.sh
       # Assign a unique cache key for every run.
       # - We will save the cache using this unique key, but only on the develop
       #   branch. This way we regularly update the cache without filling up the
@@ -569,7 +578,6 @@ ${{ matrix.build_type }}-pch-${{ matrix.use_pch || 'ON' }}"
           BUILD_PYTHON_BINDINGS=${{ matrix.BUILD_PYTHON_BINDINGS }}
           BUILD_SHARED_LIBS=${{ matrix.BUILD_SHARED_LIBS }}
           PYTHON_EXECUTABLE=${{ matrix.PYTHON_EXECUTABLE }}
-          CMAKE_EXECUTABLE=${{ matrix.CMAKE_EXECUTABLE }}
           MATRIX_CHARM_ROOT=${{ matrix.CHARM_ROOT }}
           ASAN=${{ matrix.ASAN }}
           MEMORY_ALLOCATOR=${{ matrix.MEMORY_ALLOCATOR }}
@@ -581,7 +589,9 @@ ${{ matrix.build_type }}-pch-${{ matrix.use_pch || 'ON' }}"
           TEST_TIMEOUT_FACTOR=${{ matrix.TEST_TIMEOUT_FACTOR }}
           INPUT_FILE_MIN_PRIO=${{ matrix.input_file_tests_min_priority }}
 
-          ${CMAKE_EXECUTABLE:-'cmake'}
+          cmake --version
+
+          cmake
           -D CMAKE_C_COMPILER=${CC}
           -D CMAKE_CXX_COMPILER=${CXX}
           -D CMAKE_Fortran_COMPILER=${FC}

--- a/containers/Dockerfile.buildenv
+++ b/containers/Dockerfile.buildenv
@@ -337,17 +337,6 @@ ARG TARGETARCH
 # remembered (and it doesn't hurt to redefine the env variable).
 ARG PARALLEL_MAKE_ARG=-j2
 
-# Install minmum required Python version so that we test compatibility with it.
-COPY support/Python/requirements.txt requirements.txt
-COPY support/Python/dev_requirements.txt dev_requirements.txt
-RUN add-apt-repository -y ppa:deadsnakes/ppa \
-    && apt-get update -y \
-    && apt-get install -y python3.8 python3.8-dev python3.8-distutils \
-    && python3.8 -m pip --no-cache-dir install pybind11~=2.6.1 \
-    && python3.8 -m pip --no-cache-dir install \
-        -r requirements.txt -r dev_requirements.txt \
-    && rm requirements.txt dev_requirements.txt
-
 # Install OpenMPI
 RUN apt-get install -y libopenmpi-dev
 

--- a/containers/Dockerfile.buildenv
+++ b/containers/Dockerfile.buildenv
@@ -65,9 +65,15 @@ FROM ubuntu:22.04 AS base
 # for how TARGETARCH is defined.
 ARG TARGETARCH
 
-# Install add-apt-repository
+# Install add-apt-repository and basic tools
 RUN apt-get update -y \
-    && apt-get install -y software-properties-common
+    && apt-get install -y software-properties-common wget git
+
+# Add LLVM apt repository for newer versions of clang
+RUN wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | \
+    tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc \
+    && add-apt-repository -y \
+    'deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-16 main'
 
 # Install compilers and build tools
 RUN apt-get update -y \
@@ -75,7 +81,7 @@ RUN apt-get update -y \
         gcc g++ gfortran \
         clang clang-format clang-tidy lld \
         bison flex libncurses-dev \
-        gdb git wget cmake autoconf automake ninja-build lcov
+        gdb cmake autoconf automake ninja-build lcov
 
 # Install SpECTRE dependencies that are available through apt
 #
@@ -317,26 +323,21 @@ RUN apt-get -y clean
 WORKDIR /work
 
 
-# Everything we need to run tests on CI on GitHub.
+# Everything we need to run tests on CI on GitHub. We install most things
+# on-demand on CI for a number of reasons:
+# - Smaller container size and hence less disk usage on CI, where space is very
+#   limited.
+# - Flexibility to change compilers, Python versions, etc. without rebuilding
+#   the container.
+# - There's no advantage to "pre-downloading" things available through apt here
+#   in the Dockerfile, since the amount of data to download on CI will be the
+#   same.
 FROM dev as ci
 ARG TARGETARCH
 
 # When building this image individually, the PARALLEL_MAKE_ARG from above is not
 # remembered (and it doesn't hurt to redefine the env variable).
 ARG PARALLEL_MAKE_ARG=-j2
-
-# Add LLVM apt repository for newer versions of clang
-RUN wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | \
-        tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc \
-    && add-apt-repository -y \
-        'deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-16 main'
-
-# Install all the compilers we are going to test on CI
-RUN apt-get update -y \
-    && apt-get install -y \
-        gcc-9 g++-9 gfortran-9 \
-        gcc-10 g++-10 gfortran-10 \
-        clang-13 clang-15 clang-16
 
 # Install minimum required CMake version so that we test compatibility with it.
 # For this version of CMake no ARM binary is available.
@@ -366,12 +367,6 @@ RUN apt-get install -y libopenmpi-dev
 RUN cd /work/charm_7_0_0 \
     && ./build LIBS mpi-linux-${CHARM_ARCH}-smp clang \
         ${PARALLEL_MAKE_ARG} -g -O2 --build-shared --with-production
-
-# Download and extract the intel Software Development Emulator binaries
-RUN wget https://downloadmirror.intel.com/684899/sde-external-9.0.0-2021-11-07-lin.tar.xz -O sde-external.tar.xz \
-    && tar -xJf sde-external.tar.xz \
-    && mv sde-external-* sde \
-    && rm sde-*
 
 # Remove the apt-get cache in order to reduce image size
 RUN apt-get -y clean

--- a/containers/Dockerfile.buildenv
+++ b/containers/Dockerfile.buildenv
@@ -171,12 +171,10 @@ RUN doxygen --version
 # Install software that we can't install through apt. We have to distinguish
 # between different architectures for many of those.
 FROM base AS base-amd64
-ENV CMAKE_ARCH=x86_64
 ENV CHARM_ARCH=x86_64
 ENV TEX_ARCH=x86_64
 
 FROM base AS base-arm64
-ENV CMAKE_ARCH=aarch64
 ENV CHARM_ARCH=arm8
 ENV TEX_ARCH=aarch64
 
@@ -338,15 +336,6 @@ ARG TARGETARCH
 # When building this image individually, the PARALLEL_MAKE_ARG from above is not
 # remembered (and it doesn't hurt to redefine the env variable).
 ARG PARALLEL_MAKE_ARG=-j2
-
-# Install minimum required CMake version so that we test compatibility with it.
-# For this version of CMake no ARM binary is available.
-RUN if [ "$TARGETARCH" != "arm64" ] ; then \
-        wget https://github.com/Kitware/CMake/releases/download/v3.18.2/cmake-3.18.2-linux-${CMAKE_ARCH}.sh -O cmake-install.sh \
-        && mkdir -p /opt/local/cmake/3.18.2 \
-        && sh cmake-install.sh --prefix=/opt/local/cmake/3.18.2 --skip-license \
-        && rm cmake-install.sh; \
-    fi
 
 # Install minmum required Python version so that we test compatibility with it.
 COPY support/Python/requirements.txt requirements.txt


### PR DESCRIPTION
## Proposed changes

Fixes #5517. CI container still exists, but only for the MPI build of Charm. This makes it a lot easier to add clang 15 and 16 builds to CI. Also allows installing ParaView+Python on demand for #5507.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
