### PR TITLE
Temperature updates for param delep 3D EoS

### DIFF
--- a/src/Evolution/VariableFixing/ParameterizedDeleptonization.hpp
+++ b/src/Evolution/VariableFixing/ParameterizedDeleptonization.hpp
@@ -158,7 +158,8 @@ class ParameterizedDeleptonization {
       tmpl::list<hydro::Tags::SpecificInternalEnergy<DataVector>,
                  hydro::Tags::ElectronFraction<DataVector>,
                  hydro::Tags::Pressure<DataVector>,
-                 hydro::Tags::SpecificEnthalpy<DataVector>>;
+                 hydro::Tags::SpecificEnthalpy<DataVector>,
+                 hydro::Tags::Temperature<DataVector>>;
 
   // Things you want from DataBox that won't be change and are passed in as
   // const-refs
@@ -172,6 +173,7 @@ class ParameterizedDeleptonization {
       gsl::not_null<Scalar<DataVector>*> electron_fraction,
       gsl::not_null<Scalar<DataVector>*> pressure,
       gsl::not_null<Scalar<DataVector>*> specific_enthalpy,
+      gsl::not_null<Scalar<DataVector>*> temperature,
       const Scalar<DataVector>& rest_mass_density,
       const EquationsOfState::EquationOfState<true, ThermodynamicDim>&
           equation_of_state) const;
@@ -183,6 +185,7 @@ class ParameterizedDeleptonization {
       gsl::not_null<Scalar<DataVector>*> electron_fraction,
       gsl::not_null<Scalar<DataVector>*> pressure,
       gsl::not_null<Scalar<DataVector>*> specific_enthalpy,
+      gsl::not_null<Scalar<DataVector>*> temperature,
       const Scalar<DataVector>& rest_mass_density,
       const EquationsOfState::EquationOfState<true, ThermodynamicDim>&
           equation_of_state,


### PR DESCRIPTION
## Proposed changes

Make parameterized deleptonization compatible with 3D eos and update the temperature in the 3D eos case.   Fixes 2nd half of issue #5520.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.  
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

The temperature only needs to be updated for 3D eos cases because a change in electron fraction will not affect the other primitives for 1D/2D eos cases. 

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
