### PR TITLE
Add max Lorentz factor to KastaunMHD and input file option

### DIFF
--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/KastaunEtAl.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/KastaunEtAl.cpp
@@ -288,7 +288,7 @@ double FunctionOfMu<ThermodynamicDim>::operator()(const double mu) const {
 }
 }  // namespace
 
-template <size_t ThermodynamicDim>
+template <bool EnforcePhysicality, size_t ThermodynamicDim>
 std::optional<PrimitiveRecoveryData> KastaunEtAl::apply(
     const double /*initial_guess_pressure*/, const double tau,
     const double momentum_density_squared,
@@ -346,11 +346,12 @@ std::optional<PrimitiveRecoveryData> KastaunEtAl::apply(
 }  // namespace grmhd::ValenciaDivClean::PrimitiveRecoverySchemes
 
 #define THERMODIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define PHYSICALITY(data) BOOST_PP_TUPLE_ELEM(1, data)
 #define INSTANTIATION(_, data)                                               \
   template std::optional<grmhd::ValenciaDivClean::PrimitiveRecoverySchemes:: \
                              PrimitiveRecoveryData>                          \
   grmhd::ValenciaDivClean::PrimitiveRecoverySchemes::KastaunEtAl::apply<     \
-      THERMODIM(data)>(                                                      \
+      PHYSICALITY(data), THERMODIM(data)>(                                   \
       const double initial_guess_pressure, const double tau,                 \
       const double momentum_density_squared,                                 \
       const double momentum_density_dot_magnetic_field,                      \
@@ -360,7 +361,7 @@ std::optional<PrimitiveRecoveryData> KastaunEtAl::apply(
       const EquationsOfState::EquationOfState<true, THERMODIM(data)>&        \
           equation_of_state);
 
-GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2))
+GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2), (true, false))
 
 #undef INSTANTIATION
 #undef THERMODIM

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/KastaunEtAl.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/KastaunEtAl.cpp
@@ -11,6 +11,7 @@
 #include <utility>
 
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/PrimitiveFromConservativeOptions.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/PrimitiveRecoveryData.hpp"
 #include "NumericalAlgorithms/RootFinding/TOMS748.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
@@ -326,7 +327,9 @@ std::optional<PrimitiveRecoveryData> KastaunEtAl::apply(
     const double rest_mass_density_times_lorentz_factor,
     const double electron_fraction,
     const EquationsOfState::EquationOfState<true, ThermodynamicDim>&
-        equation_of_state) {
+        equation_of_state,
+    const grmhd::ValenciaDivClean::PrimitiveFromConservativeOptions&
+        primitive_from_conservative_options) {
   // Master function see Equation (44)
   const auto f_of_mu = FunctionOfMu<EnforcePhysicality, ThermodynamicDim>{
       tau,
@@ -336,7 +339,7 @@ std::optional<PrimitiveRecoveryData> KastaunEtAl::apply(
       rest_mass_density_times_lorentz_factor,
       electron_fraction,
       equation_of_state,
-      1.e3};
+      primitive_from_conservative_options.kastaun_max_lorentz_factor()};
   if (f_of_mu.state_is_unphysical()) {
     return std::nullopt;
   }
@@ -392,7 +395,9 @@ std::optional<PrimitiveRecoveryData> KastaunEtAl::apply(
       const double rest_mass_density_times_lorentz_factor,                   \
       const double electron_fraction,                                        \
       const EquationsOfState::EquationOfState<true, THERMODIM(data)>&        \
-          equation_of_state);
+          equation_of_state,                                                 \
+      const grmhd::ValenciaDivClean::PrimitiveFromConservativeOptions&       \
+          primitive_from_conservative_options);
 
 GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2), (true, false))
 

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/KastaunEtAl.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/KastaunEtAl.cpp
@@ -35,10 +35,11 @@ double compute_r_bar_squared(const double mu, const double x,
 }
 
 // Equations (33) and (32)
-double compute_v_0_squared(const double r_squared, const double h_0) {
+double compute_v_0_squared(const double r_squared, const double h_0,
+                           const double lorentz_max) {
   const double z_0_squared = r_squared / square(h_0);
-  static constexpr double velocity_squared_upper_bound =
-      1.0 - 4.0 * std::numeric_limits<double>::epsilon();
+  const double velocity_squared_upper_bound =
+      1.0 - 1.0 / (lorentz_max * lorentz_max);
   return std::min(z_0_squared / (1.0 + z_0_squared),
                   velocity_squared_upper_bound);
 }
@@ -106,7 +107,7 @@ class AuxiliaryFunction {
 };
 
 // Master function, see Equation (44) in Sec. II.E
-template <size_t ThermodynamicDim>
+template <bool EnforcePhysicality, size_t ThermodynamicDim>
 class FunctionOfMu {
  public:
   FunctionOfMu(const double tau, const double momentum_density_squared,
@@ -115,8 +116,14 @@ class FunctionOfMu {
                const double rest_mass_density_times_lorentz_factor,
                const double electron_fraction,
                const EquationsOfState::EquationOfState<true, ThermodynamicDim>&
-                   equation_of_state)
-      : q_(tau / rest_mass_density_times_lorentz_factor),
+                   equation_of_state,
+               const double lorentz_max)
+      : q_(EnforcePhysicality
+               ? std::max(
+                     tau / rest_mass_density_times_lorentz_factor,
+                     equation_of_state.specific_internal_energy_lower_bound(
+                         rest_mass_density_times_lorentz_factor / lorentz_max))
+               : (tau / rest_mass_density_times_lorentz_factor)),
         r_squared_(momentum_density_squared /
                    square(rest_mass_density_times_lorentz_factor)),
         b_squared_(magnetic_field_squared /
@@ -128,7 +135,23 @@ class FunctionOfMu {
         electron_fraction_(electron_fraction),
         equation_of_state_(equation_of_state),
         h_0_(equation_of_state_.specific_enthalpy_lower_bound()),
-        v_0_squared_(compute_v_0_squared(r_squared_, h_0_)) {}
+        v_0_squared_(compute_v_0_squared(r_squared_, h_0_, lorentz_max)) {
+    const double r_squared_bound =
+        4.0 * v_0_squared_ * square(q_ + 1.0) / square(1.0 + v_0_squared_);
+    if constexpr (EnforcePhysicality) {
+      if (r_squared_bound < r_squared_) {
+        r_squared_ = r_squared_bound;
+        r_dot_b_squared_ *= r_squared_bound / r_squared_;
+      }
+    } else {
+      const double eps_min =
+          equation_of_state_.specific_internal_energy_lower_bound(
+              rest_mass_density_times_lorentz_factor_ / lorentz_max);
+      if (q_ < eps_min or r_squared_ > r_squared_bound) {
+        state_is_unphysical_ = true;
+      }
+    }
+  }
 
   std::pair<double, double> root_bracket(
       double rest_mass_density_times_lorentz_factor, double absolute_tolerance,
@@ -136,23 +159,27 @@ class FunctionOfMu {
 
   Primitives primitives(double mu) const;
 
-  double operator()(const double mu) const;
+  double operator()(double mu) const;
+
+  bool state_is_unphysical() const { return state_is_unphysical_; }
 
  private:
   const double q_;
-  const double r_squared_;
+  double r_squared_;
   const double b_squared_;
-  const double r_dot_b_squared_;
+  double r_dot_b_squared_;
   const double rest_mass_density_times_lorentz_factor_;
   const double electron_fraction_;
   const EquationsOfState::EquationOfState<true, ThermodynamicDim>&
       equation_of_state_;
   const double h_0_;
   const double v_0_squared_;
+  bool state_is_unphysical_ = false;
 };
 
-template <size_t ThermodynamicDim>
-std::pair<double, double> FunctionOfMu<ThermodynamicDim>::root_bracket(
+template <bool EnforcePhysicality, size_t ThermodynamicDim>
+std::pair<double, double>
+FunctionOfMu<EnforcePhysicality, ThermodynamicDim>::root_bracket(
     const double rest_mass_density_times_lorentz_factor,
     const double absolute_tolerance, const double relative_tolerance,
     const size_t max_iterations) const {
@@ -228,8 +255,9 @@ std::pair<double, double> FunctionOfMu<ThermodynamicDim>::root_bracket(
   return {lower_bound, upper_bound};
 }
 
-template <size_t ThermodynamicDim>
-Primitives FunctionOfMu<ThermodynamicDim>::primitives(const double mu) const {
+template <bool EnforcePhysicality, size_t ThermodynamicDim>
+Primitives FunctionOfMu<EnforcePhysicality, ThermodynamicDim>::primitives(
+    const double mu) const {
   // Equation (26)
   const double x = compute_x(mu, b_squared_);
   // Equations(38)
@@ -273,8 +301,9 @@ Primitives FunctionOfMu<ThermodynamicDim>::primitives(const double mu) const {
   return Primitives{rho_hat, w_hat, p_hat, epsilon_hat, q_bar, r_bar_squared};
 }
 
-template <size_t ThermodynamicDim>
-double FunctionOfMu<ThermodynamicDim>::operator()(const double mu) const {
+template <bool EnforcePhysicality, size_t ThermodynamicDim>
+double FunctionOfMu<EnforcePhysicality, ThermodynamicDim>::operator()(
+    const double mu) const {
   const auto[rho_hat, w_hat, p_hat, epsilon_hat, q_bar, r_bar_squared] =
       primitives(mu);
   // Equation (43)
@@ -299,14 +328,18 @@ std::optional<PrimitiveRecoveryData> KastaunEtAl::apply(
     const EquationsOfState::EquationOfState<true, ThermodynamicDim>&
         equation_of_state) {
   // Master function see Equation (44)
-  const auto f_of_mu =
-      FunctionOfMu<ThermodynamicDim>{tau,
-                                     momentum_density_squared,
-                                     momentum_density_dot_magnetic_field,
-                                     magnetic_field_squared,
-                                     rest_mass_density_times_lorentz_factor,
-                                     electron_fraction,
-                                     equation_of_state};
+  const auto f_of_mu = FunctionOfMu<EnforcePhysicality, ThermodynamicDim>{
+      tau,
+      momentum_density_squared,
+      momentum_density_dot_magnetic_field,
+      magnetic_field_squared,
+      rest_mass_density_times_lorentz_factor,
+      electron_fraction,
+      equation_of_state,
+      1.e3};
+  if (f_of_mu.state_is_unphysical()) {
+    return std::nullopt;
+  }
 
   // mu is 1 / (h W) see Equation (26)
   double one_over_specific_enthalpy_times_lorentz_factor =

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/KastaunEtAl.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/KastaunEtAl.hpp
@@ -15,6 +15,9 @@ namespace EquationsOfState {
 template <bool, size_t>
 class EquationOfState;
 }  // namespace EquationsOfState
+namespace grmhd::ValenciaDivClean {
+class PrimitiveFromConservativeOptions;
+}  // namespace grmhd::ValenciaDivClean
 /// \endcond
 
 namespace grmhd::ValenciaDivClean::PrimitiveRecoverySchemes {
@@ -56,7 +59,9 @@ class KastaunEtAl {
       double momentum_density_dot_magnetic_field, double magnetic_field_squared,
       double rest_mass_density_times_lorentz_factor, double electron_fraction,
       const EquationsOfState::EquationOfState<true, ThermodynamicDim>&
-          equation_of_state);
+          equation_of_state,
+      const grmhd::ValenciaDivClean::PrimitiveFromConservativeOptions&
+          primitive_from_conservative_options);
 
   static const std::string name() { return "KastaunEtAl"; }
 

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/KastaunEtAl.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/KastaunEtAl.hpp
@@ -49,7 +49,7 @@ namespace grmhd::ValenciaDivClean::PrimitiveRecoverySchemes {
  */
 class KastaunEtAl {
  public:
-  template <size_t ThermodynamicDim>
+  template <bool EnforcePhysicality, size_t ThermodynamicDim>
   static std::optional<PrimitiveRecoveryData> apply(
       double initial_guess_pressure, double tau,
       double momentum_density_squared,

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/KastaunEtAlHydro.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/KastaunEtAlHydro.cpp
@@ -39,8 +39,7 @@ class FunctionOfZ {
               const EquationsOfState::EquationOfState<true, ThermodynamicDim>&
                   equation_of_state,
               const double lorentz_max)
-      : lorentz_max_(lorentz_max),
-        q_(tau / rest_mass_density_times_lorentz_factor),
+      : q_(tau / rest_mass_density_times_lorentz_factor),
         r_squared_(momentum_density_squared /
                    square(rest_mass_density_times_lorentz_factor)),
         r_(std::sqrt(r_squared_)),
@@ -51,15 +50,17 @@ class FunctionOfZ {
     // Internal consistency check
     //
     const double rho_min =
-        rest_mass_density_times_lorentz_factor_ / lorentz_max_;
+        rest_mass_density_times_lorentz_factor_ / lorentz_max;
     const double eps_min =
         equation_of_state_.specific_internal_energy_lower_bound(rho_min);
+    const double v_0_squared = 1. - 1. / (lorentz_max * lorentz_max);
+    const double kmax = 2. * std::sqrt(v_0_squared) / (1. + v_0_squared);
 
     if constexpr (EnforcePhysicality) {
       q_ = std::max(q_, eps_min);
-      r_ = std::min(r_, kmax_ * (q_ + 1.));
+      r_ = std::min(r_, kmax * (q_ + 1.));
     } else {
-      if ((q_ < eps_min) or (r_ > kmax_ * (q_ + 1.))) {
+      if ((q_ < eps_min) or (r_ > kmax * (q_ + 1.))) {
         state_is_unphysical_ = true;
       }
     }
@@ -74,7 +75,6 @@ class FunctionOfZ {
   bool has_no_root() { return state_is_unphysical_; };
 
  private:
-  const double lorentz_max_ = 1000.;
   double q_;
   double r_squared_;
   double r_;
@@ -83,8 +83,6 @@ class FunctionOfZ {
   const double electron_fraction_;
   const EquationsOfState::EquationOfState<true, ThermodynamicDim>&
       equation_of_state_;
-  const double v_0_squared_ = 1. - 1. / (lorentz_max_ * lorentz_max_);
-  const double kmax_ = 2. * std::sqrt(v_0_squared_) / (1. + v_0_squared_);
 };
 
 template <size_t ThermodynamicDim, bool EnforcePhysicality>

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/KastaunEtAlHydro.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/KastaunEtAlHydro.cpp
@@ -156,10 +156,8 @@ double FunctionOfZ<ThermodynamicDim, EnforcePhysicality>::operator()(
 }
 }  // namespace
 
-template <bool EnforcePhysicality>
-template <size_t ThermodynamicDim>
-std::optional<PrimitiveRecoveryData>
-KastaunEtAlHydro<EnforcePhysicality>::apply(
+template <bool EnforcePhysicality, size_t ThermodynamicDim>
+std::optional<PrimitiveRecoveryData> KastaunEtAlHydro::apply(
     const double /*initial_guess_pressure*/, const double tau,
     const double momentum_density_squared,
     const double momentum_density_dot_magnetic_field,
@@ -214,19 +212,19 @@ KastaunEtAlHydro<EnforcePhysicality>::apply(
 
 #define THERMODIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 #define PHYSICALITY(data) BOOST_PP_TUPLE_ELEM(1, data)
-#define INSTANTIATION(_, data)                                               \
-  template std::optional<grmhd::ValenciaDivClean::PrimitiveRecoverySchemes:: \
-                             PrimitiveRecoveryData>                          \
-  grmhd::ValenciaDivClean::PrimitiveRecoverySchemes::                        \
-      KastaunEtAlHydro<PHYSICALITY(data)>::apply<THERMODIM(data)>(           \
-          const double initial_guess_pressure, const double tau,             \
-          const double momentum_density_squared,                             \
-          const double momentum_density_dot_magnetic_field,                  \
-          const double magnetic_field_squared,                               \
-          const double rest_mass_density_times_lorentz_factor,               \
-          const double electron_fraction,                                    \
-          const EquationsOfState::EquationOfState<true, THERMODIM(data)>&    \
-              equation_of_state);
+#define INSTANTIATION(_, data)                                                \
+  template std::optional<grmhd::ValenciaDivClean::PrimitiveRecoverySchemes::  \
+                             PrimitiveRecoveryData>                           \
+  grmhd::ValenciaDivClean::PrimitiveRecoverySchemes::KastaunEtAlHydro::apply< \
+      PHYSICALITY(data), THERMODIM(data)>(                                    \
+      const double initial_guess_pressure, const double tau,                  \
+      const double momentum_density_squared,                                  \
+      const double momentum_density_dot_magnetic_field,                       \
+      const double magnetic_field_squared,                                    \
+      const double rest_mass_density_times_lorentz_factor,                    \
+      const double electron_fraction,                                         \
+      const EquationsOfState::EquationOfState<true, THERMODIM(data)>&         \
+          equation_of_state);
 
 GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2), (true, false))
 

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/KastaunEtAlHydro.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/KastaunEtAlHydro.cpp
@@ -57,7 +57,7 @@ class FunctionOfZ {
       r_ = std::min(r_, kmax_ * (q_ + 1.));
     } else {
       if ((q_ < eps_min) or (r_ > kmax_ * (q_ + 1.))) {
-        state_is_unphysical = true;
+        state_is_unphysical_ = true;
       }
     }
   }
@@ -68,13 +68,13 @@ class FunctionOfZ {
 
   double operator()(double z) const;
 
-  bool has_no_root() { return state_is_unphysical; };
+  bool has_no_root() { return state_is_unphysical_; };
 
  private:
   double q_;
   double r_squared_;
   double r_;
-  bool state_is_unphysical = false;
+  bool state_is_unphysical_ = false;
   const double rest_mass_density_times_lorentz_factor_;
   const double electron_fraction_;
   const EquationsOfState::EquationOfState<true, ThermodynamicDim>&

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/KastaunEtAlHydro.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/KastaunEtAlHydro.hpp
@@ -14,6 +14,9 @@ namespace EquationsOfState {
 template <bool, size_t>
 class EquationOfState;
 }  // namespace EquationsOfState
+namespace grmhd::ValenciaDivClean {
+class PrimitiveFromConservativeOptions;
+}  // namespace grmhd::ValenciaDivClean
 /// \endcond
 
 namespace grmhd::ValenciaDivClean::PrimitiveRecoverySchemes {
@@ -53,7 +56,9 @@ class KastaunEtAlHydro {
       double momentum_density_dot_magnetic_field, double magnetic_field_squared,
       double rest_mass_density_times_lorentz_factor, double electron_fraction,
       const EquationsOfState::EquationOfState<true, ThermodynamicDim>&
-          equation_of_state);
+          equation_of_state,
+      const grmhd::ValenciaDivClean::PrimitiveFromConservativeOptions&
+          primitive_from_conservative_options);
 
   static const std::string name() { return "KastaunEtAlHydro"; }
 

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/KastaunEtAlHydro.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/KastaunEtAlHydro.hpp
@@ -44,10 +44,9 @@ struct PrimitiveRecoveryData;
  *
  * \note This scheme does not use the initial guess for the pressure.
  */
-template <bool EnforcePhysicality = true>
 class KastaunEtAlHydro {
  public:
-  template <size_t ThermodynamicDim>
+  template <bool EnforcePhysicality, size_t ThermodynamicDim>
   static std::optional<PrimitiveRecoveryData> apply(
       double initial_guess_pressure, double tau,
       double momentum_density_squared,

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/NewmanHamlin.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/NewmanHamlin.cpp
@@ -10,6 +10,7 @@
 
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/PrimitiveRecoveryData.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
@@ -27,7 +28,9 @@ std::optional<PrimitiveRecoveryData> NewmanHamlin::apply(
     const double rest_mass_density_times_lorentz_factor,
     const double electron_fraction,
     const EquationsOfState::EquationOfState<true, ThermodynamicDim>&
-        equation_of_state) {
+        equation_of_state,
+    const grmhd::ValenciaDivClean::PrimitiveFromConservativeOptions&
+    /*primitive_from_conservative_options*/) {
   const double total_energy_density =
       tau + rest_mass_density_times_lorentz_factor;
   // constant in cubic equation  f(eps) = eps^3 - a eps^2 + d
@@ -203,7 +206,9 @@ std::optional<PrimitiveRecoveryData> NewmanHamlin::apply(
       const double rest_mass_density_times_lorentz_factor,                   \
       const double electron_fraction,                                        \
       const EquationsOfState::EquationOfState<true, THERMODIM(data)>&        \
-          equation_of_state);
+          equation_of_state,                                                 \
+      const grmhd::ValenciaDivClean::PrimitiveFromConservativeOptions&       \
+          primitive_from_conservative_options);
 
 GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2), (true, false))
 

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/NewmanHamlin.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/NewmanHamlin.cpp
@@ -18,7 +18,7 @@
 
 namespace grmhd::ValenciaDivClean::PrimitiveRecoverySchemes {
 
-template <size_t ThermodynamicDim>
+template <bool EnforcePhysicality, size_t ThermodynamicDim>
 std::optional<PrimitiveRecoveryData> NewmanHamlin::apply(
     const double initial_guess_for_pressure, const double tau,
     const double momentum_density_squared,
@@ -190,11 +190,12 @@ std::optional<PrimitiveRecoveryData> NewmanHamlin::apply(
 }  // namespace grmhd::ValenciaDivClean::PrimitiveRecoverySchemes
 
 #define THERMODIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define PHYSICALITY(data) BOOST_PP_TUPLE_ELEM(1, data)
 #define INSTANTIATION(_, data)                                               \
   template std::optional<grmhd::ValenciaDivClean::PrimitiveRecoverySchemes:: \
                              PrimitiveRecoveryData>                          \
   grmhd::ValenciaDivClean::PrimitiveRecoverySchemes::NewmanHamlin::apply<    \
-      THERMODIM(data)>(                                                      \
+      PHYSICALITY(data), THERMODIM(data)>(                                   \
       const double initial_guess_pressure, const double tau,                 \
       const double momentum_density_squared,                                 \
       const double momentum_density_dot_magnetic_field,                      \
@@ -204,7 +205,7 @@ std::optional<PrimitiveRecoveryData> NewmanHamlin::apply(
       const EquationsOfState::EquationOfState<true, THERMODIM(data)>&        \
           equation_of_state);
 
-GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2))
+GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2), (true, false))
 
 #undef INSTANTIATION
 #undef THERMODIM

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/NewmanHamlin.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/NewmanHamlin.hpp
@@ -46,7 +46,7 @@ namespace PrimitiveRecoverySchemes {
  */
 class NewmanHamlin {
  public:
-  template <size_t ThermodynamicDim>
+  template <bool EnforcePhysicality, size_t ThermodynamicDim>
   static std::optional<PrimitiveRecoveryData> apply(
       double initial_guess_for_pressure, double tau,
       double momentum_density_squared,

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/NewmanHamlin.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/NewmanHamlin.hpp
@@ -8,13 +8,18 @@
 #include <string>
 
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/PrimitiveRecoveryData.hpp"
-#include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
 
-// IWYU pragma: no_forward_declare EquationsOfState::EquationOfState
+/// \cond
+namespace EquationsOfState {
+template <bool, size_t>
+class EquationOfState;
+}  // namespace EquationsOfState
+namespace grmhd::ValenciaDivClean {
+class PrimitiveFromConservativeOptions;
+}  // namespace grmhd::ValenciaDivClean
+/// \endcond
 
-namespace grmhd {
-namespace ValenciaDivClean {
-namespace PrimitiveRecoverySchemes {
+namespace grmhd::ValenciaDivClean::PrimitiveRecoverySchemes {
 
 /*!
  * \brief Compute the primitive variables from the conservative variables using
@@ -53,7 +58,9 @@ class NewmanHamlin {
       double momentum_density_dot_magnetic_field, double magnetic_field_squared,
       double rest_mass_density_times_lorentz_factor, double electron_fraction,
       const EquationsOfState::EquationOfState<true, ThermodynamicDim>&
-          equation_of_state);
+          equation_of_state,
+      const grmhd::ValenciaDivClean::PrimitiveFromConservativeOptions&
+          primitive_from_conservative_options);
 
   static const std::string name() { return "Newman Hamlin"; }
 
@@ -61,6 +68,4 @@ class NewmanHamlin {
   static constexpr size_t max_iterations_ = 50;
   static constexpr double relative_tolerance_ = 1.e-10;
 };
-}  // namespace PrimitiveRecoverySchemes
-}  // namespace ValenciaDivClean
-}  // namespace grmhd
+}  // namespace grmhd::ValenciaDivClean::PrimitiveRecoverySchemes

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/PalenzuelaEtAl.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/PalenzuelaEtAl.cpp
@@ -97,7 +97,7 @@ class FunctionOfX {
 };
 }  // namespace
 
-template <size_t ThermodynamicDim>
+template <bool EnforcePhysicality, size_t ThermodynamicDim>
 std::optional<PrimitiveRecoveryData> PalenzuelaEtAl::apply(
     const double /*initial_guess_pressure*/, const double tau,
     const double momentum_density_squared,
@@ -164,11 +164,12 @@ std::optional<PrimitiveRecoveryData> PalenzuelaEtAl::apply(
 }  // namespace grmhd::ValenciaDivClean::PrimitiveRecoverySchemes
 
 #define THERMODIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define PHYSICALITY(data) BOOST_PP_TUPLE_ELEM(1, data)
 #define INSTANTIATION(_, data)                                               \
   template std::optional<grmhd::ValenciaDivClean::PrimitiveRecoverySchemes:: \
                              PrimitiveRecoveryData>                          \
   grmhd::ValenciaDivClean::PrimitiveRecoverySchemes::PalenzuelaEtAl::apply<  \
-      THERMODIM(data)>(                                                      \
+      PHYSICALITY(data), THERMODIM(data)>(                                   \
       const double /*initial_guess_pressure*/, const double tau,             \
       const double momentum_density_squared,                                 \
       const double momentum_density_dot_magnetic_field,                      \
@@ -178,7 +179,7 @@ std::optional<PrimitiveRecoveryData> PalenzuelaEtAl::apply(
       const EquationsOfState::EquationOfState<true, THERMODIM(data)>&        \
           equation_of_state);
 
-GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2))
+GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2), (true, false))
 
 #undef INSTANTIATION
 #undef THERMODIM

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/PalenzuelaEtAl.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/PalenzuelaEtAl.cpp
@@ -10,10 +10,9 @@
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/PrimitiveRecoveryData.hpp"
 #include "NumericalAlgorithms/RootFinding/TOMS748.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
-
-// IWYU pragma: no_forward_declare EquationsOfState::EquationOfState
 
 namespace grmhd::ValenciaDivClean::PrimitiveRecoverySchemes {
 
@@ -106,7 +105,9 @@ std::optional<PrimitiveRecoveryData> PalenzuelaEtAl::apply(
     const double rest_mass_density_times_lorentz_factor,
     const double electron_fraction,
     const EquationsOfState::EquationOfState<true, ThermodynamicDim>&
-        equation_of_state) {
+        equation_of_state,
+    const grmhd::ValenciaDivClean::PrimitiveFromConservativeOptions&
+    /*primitive_from_conservative_options*/) {
   const double lower_bound =
       (tau - magnetic_field_squared) / rest_mass_density_times_lorentz_factor +
       1.0;
@@ -177,7 +178,9 @@ std::optional<PrimitiveRecoveryData> PalenzuelaEtAl::apply(
       const double rest_mass_density_times_lorentz_factor,                   \
       const double electron_fraction,                                        \
       const EquationsOfState::EquationOfState<true, THERMODIM(data)>&        \
-          equation_of_state);
+          equation_of_state,                                                 \
+      const grmhd::ValenciaDivClean::PrimitiveFromConservativeOptions&       \
+          primitive_from_conservative_options);
 
 GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2), (true, false))
 

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/PalenzuelaEtAl.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/PalenzuelaEtAl.hpp
@@ -9,13 +9,18 @@
 #include <string>
 
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/PrimitiveRecoveryData.hpp"
-#include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
 
-// IWYU pragma: no_forward_declare EquationsOfState::EquationOfState
+/// \cond
+namespace EquationsOfState {
+template <bool, size_t>
+class EquationOfState;
+}  // namespace EquationsOfState
+namespace grmhd::ValenciaDivClean {
+class PrimitiveFromConservativeOptions;
+}  // namespace grmhd::ValenciaDivClean
+/// \endcond
 
-namespace grmhd {
-namespace ValenciaDivClean {
-namespace PrimitiveRecoverySchemes {
+namespace grmhd::ValenciaDivClean::PrimitiveRecoverySchemes {
 
 /*!
  * \brief Compute the primitive variables from the conservative variables using
@@ -54,7 +59,9 @@ class PalenzuelaEtAl {
       double momentum_density_dot_magnetic_field, double magnetic_field_squared,
       double rest_mass_density_times_lorentz_factor, double electron_fraction,
       const EquationsOfState::EquationOfState<true, ThermodynamicDim>&
-          equation_of_state);
+          equation_of_state,
+      const grmhd::ValenciaDivClean::PrimitiveFromConservativeOptions&
+          primitive_from_conservative_options);
 
   static const std::string name() { return "PalenzuelaEtAl"; }
 
@@ -65,6 +72,4 @@ class PalenzuelaEtAl {
   static constexpr double relative_tolerance_ =
       10.0 * std::numeric_limits<double>::epsilon();
 };
-}  // namespace PrimitiveRecoverySchemes
-}  // namespace ValenciaDivClean
-}  // namespace grmhd
+}  // namespace grmhd::ValenciaDivClean::PrimitiveRecoverySchemes

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/PalenzuelaEtAl.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/PalenzuelaEtAl.hpp
@@ -47,7 +47,7 @@ namespace PrimitiveRecoverySchemes {
  */
 class PalenzuelaEtAl {
  public:
-  template <size_t ThermodynamicDim>
+  template <bool EnforcePhysicality, size_t ThermodynamicDim>
   static std::optional<PrimitiveRecoveryData> apply(
       double /*initial_guess_pressure*/, double tau,
       double momentum_density_squared,

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/PrimitiveFromConservative.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/PrimitiveFromConservative.cpp
@@ -7,6 +7,7 @@
 #include <limits>
 #include <optional>
 #include <ostream>
+#include <type_traits>
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tags/TempTensor.hpp"
@@ -140,8 +141,7 @@ bool PrimitiveFromConservative<OrderedListOfPrimitiveRecoverySchemes,
             specific_energy_at_point,
             floorD * specific_enthalpy_at_point,
             get(*electron_fraction)[s]};
-      }
-      else if constexpr (ThermodynamicDim == 1) {
+      } else if constexpr (ThermodynamicDim == 1) {
         const double specific_energy_at_point =
             get(equation_of_state
                     .specific_internal_energy_from_density(
@@ -160,6 +160,7 @@ bool PrimitiveFromConservative<OrderedListOfPrimitiveRecoverySchemes,
             get(*electron_fraction)[s]};
       }
     } else {
+      // not in atmosphere.
       auto apply_scheme =
           [&pressure, &primitive_data, &tau, &momentum_density_squared,
            &momentum_density_dot_magnetic_field, &magnetic_field_squared,
@@ -168,7 +169,8 @@ bool PrimitiveFromConservative<OrderedListOfPrimitiveRecoverySchemes,
             using primitive_recovery_scheme = tmpl::type_from<decltype(scheme)>;
             if (not primitive_data.has_value()) {
               primitive_data =
-                  primitive_recovery_scheme::template apply<ThermodynamicDim>(
+                  primitive_recovery_scheme::template apply<EnforcePhysicality,
+                                                            ThermodynamicDim>(
                       get(*pressure)[s], tau[s],
                       get(momentum_density_squared)[s],
                       get(momentum_density_dot_magnetic_field)[s],
@@ -184,7 +186,7 @@ bool PrimitiveFromConservative<OrderedListOfPrimitiveRecoverySchemes,
            100.0 * std::numeric_limits<double>::epsilon() * tau[s])) {
         tmpl::for_each<
             tmpl::list<grmhd::ValenciaDivClean::PrimitiveRecoverySchemes::
-                           KastaunEtAlHydro<EnforcePhysicality>>>(apply_scheme);
+                           KastaunEtAlHydro>>(apply_scheme);
       } else {
         tmpl::for_each<OrderedListOfPrimitiveRecoverySchemes>(apply_scheme);
       }
@@ -326,10 +328,8 @@ GENERATE_INSTANTIATIONS(
 GENERATE_INSTANTIATIONS(
     INSTANTIATION,
     (tmpl::list<grmhd::ValenciaDivClean::PrimitiveRecoverySchemes::KastaunEtAl>,
-     tmpl::list<grmhd::ValenciaDivClean::PrimitiveRecoverySchemes::
-                    KastaunEtAlHydro<true>>,
-     tmpl::list<grmhd::ValenciaDivClean::PrimitiveRecoverySchemes::
-                    KastaunEtAlHydro<false>>,
+     tmpl::list<
+         grmhd::ValenciaDivClean::PrimitiveRecoverySchemes::KastaunEtAlHydro>,
      tmpl::list<
          grmhd::ValenciaDivClean::PrimitiveRecoverySchemes::NewmanHamlin>,
      tmpl::list<

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/PrimitiveFromConservative.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/PrimitiveFromConservative.cpp
@@ -161,24 +161,26 @@ bool PrimitiveFromConservative<OrderedListOfPrimitiveRecoverySchemes,
       }
     } else {
       // not in atmosphere.
-      auto apply_scheme =
-          [&pressure, &primitive_data, &tau, &momentum_density_squared,
-           &momentum_density_dot_magnetic_field, &magnetic_field_squared,
-           &rest_mass_density_times_lorentz_factor, &equation_of_state, &s,
-           &electron_fraction](auto scheme) {
-            using primitive_recovery_scheme = tmpl::type_from<decltype(scheme)>;
-            if (not primitive_data.has_value()) {
-              primitive_data =
-                  primitive_recovery_scheme::template apply<EnforcePhysicality,
-                                                            ThermodynamicDim>(
-                      get(*pressure)[s], tau[s],
-                      get(momentum_density_squared)[s],
-                      get(momentum_density_dot_magnetic_field)[s],
-                      get(magnetic_field_squared)[s],
-                      rest_mass_density_times_lorentz_factor[s],
-                      get(*electron_fraction)[s], equation_of_state);
-            }
-          };
+      auto apply_scheme = [&pressure, &primitive_data, &tau,
+                           &momentum_density_squared,
+                           &momentum_density_dot_magnetic_field,
+                           &magnetic_field_squared,
+                           &rest_mass_density_times_lorentz_factor,
+                           &equation_of_state, &s, &electron_fraction,
+                           &primitive_from_conservative_options](auto scheme) {
+        using primitive_recovery_scheme = tmpl::type_from<decltype(scheme)>;
+        if (not primitive_data.has_value()) {
+          primitive_data =
+              primitive_recovery_scheme::template apply<EnforcePhysicality,
+                                                        ThermodynamicDim>(
+                  get(*pressure)[s], tau[s], get(momentum_density_squared)[s],
+                  get(momentum_density_dot_magnetic_field)[s],
+                  get(magnetic_field_squared)[s],
+                  rest_mass_density_times_lorentz_factor[s],
+                  get(*electron_fraction)[s], equation_of_state,
+                  primitive_from_conservative_options);
+        }
+      };
 
       // Check consistency
       if (use_hydro_optimization and

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/PrimitiveFromConservativeOptions.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/PrimitiveFromConservativeOptions.cpp
@@ -10,20 +10,24 @@ namespace grmhd::ValenciaDivClean {
 
 PrimitiveFromConservativeOptions::PrimitiveFromConservativeOptions(
     const double cutoff_d_for_inversion,
-    const double density_when_skipping_inversion)
+    const double density_when_skipping_inversion,
+    const double kastaun_max_lorentz_factor)
     : cutoff_d_for_inversion_(cutoff_d_for_inversion),
-      density_when_skipping_inversion_(density_when_skipping_inversion) {}
+      density_when_skipping_inversion_(density_when_skipping_inversion),
+      kastaun_max_lorentz_factor_(kastaun_max_lorentz_factor) {}
 
 void PrimitiveFromConservativeOptions::pup(PUP::er& p) {
   p | cutoff_d_for_inversion_;
   p | density_when_skipping_inversion_;
+  p | kastaun_max_lorentz_factor_;
 }
 
 bool operator==(const PrimitiveFromConservativeOptions& lhs,
                 const PrimitiveFromConservativeOptions& rhs) {
   return (lhs.cutoff_d_for_inversion_ == rhs.cutoff_d_for_inversion_) and
          (lhs.density_when_skipping_inversion_ ==
-          rhs.density_when_skipping_inversion_);
+          rhs.density_when_skipping_inversion_) and
+         lhs.kastaun_max_lorentz_factor_ == rhs.kastaun_max_lorentz_factor_;
 }
 
 bool operator!=(const PrimitiveFromConservativeOptions& lhs,

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/PrimitiveFromConservativeOptions.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/PrimitiveFromConservativeOptions.hpp
@@ -42,22 +42,34 @@ class PrimitiveFromConservativeOptions {
     static type lower_bound() { return 0.0; }
   };
 
-  using options = tmpl::list<CutoffDForInversion, DensityWhenSkippingInversion>;
+  struct KastaunMaxLorentzFactor {
+    static constexpr Options::String help{
+        "The maximum Lorentz allowed during primitive recovery when using the "
+        "Kastaun schemes."};
+    using type = double;
+    static type lower_bound() { return 1.0; }
+  };
+
+  using options = tmpl::list<CutoffDForInversion, DensityWhenSkippingInversion,
+                             KastaunMaxLorentzFactor>;
 
   static constexpr Options::String help{
       "Options given to conservative to primitive inversion."};
 
   PrimitiveFromConservativeOptions() = default;
 
-  PrimitiveFromConservativeOptions(
-      const double cutoff_d_for_inversion,
-      const double density_when_skipping_inversion);
+  PrimitiveFromConservativeOptions(double cutoff_d_for_inversion,
+                                   double density_when_skipping_inversion,
+                                   double kastaun_max_lorentz_factor);
 
   void pup(PUP::er& p);
 
   double cutoff_d_for_inversion() const { return cutoff_d_for_inversion_; }
   double density_when_skipping_inversion() const {
     return density_when_skipping_inversion_;
+  }
+  double kastaun_max_lorentz_factor() const {
+    return kastaun_max_lorentz_factor_;
   }
 
  private:
@@ -66,6 +78,8 @@ class PrimitiveFromConservativeOptions {
 
   double cutoff_d_for_inversion_ = std::numeric_limits<double>::signaling_NaN();
   double density_when_skipping_inversion_ =
+      std::numeric_limits<double>::signaling_NaN();
+  double kastaun_max_lorentz_factor_ =
       std::numeric_limits<double>::signaling_NaN();
 };
 

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/BinaryNeutronStar.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/BinaryNeutronStar.yaml
@@ -85,6 +85,7 @@ VariableFixing:
 PrimitiveFromConservative:
   CutoffDForInversion: *CutoffD
   DensityWhenSkippingInversion: *MinimumD
+  KastaunMaxLorentzFactor: 10.0
 
 EvolutionSystem:
   ValenciaDivClean:

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdBondiMichel.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdBondiMichel.yaml
@@ -86,6 +86,7 @@ VariableFixing:
 PrimitiveFromConservative:
   CutoffDForInversion: *CutoffD
   DensityWhenSkippingInversion: *MinimumD
+  KastaunMaxLorentzFactor: 10.0
 
 Limiter:
   Minmod:

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdTovStar.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdTovStar.yaml
@@ -79,6 +79,7 @@ VariableFixing:
 PrimitiveFromConservative:
   CutoffDForInversion: *CutoffD
   DensityWhenSkippingInversion: *MinimumD
+  KastaunMaxLorentzFactor: 10.0
 
 EvolutionSystem:
   ValenciaDivClean:

--- a/tests/InputFiles/GrMhd/ValenciaDivClean/BlastWave.yaml
+++ b/tests/InputFiles/GrMhd/ValenciaDivClean/BlastWave.yaml
@@ -107,6 +107,7 @@ VariableFixing:
 PrimitiveFromConservative:
   CutoffDForInversion: *CutoffD
   DensityWhenSkippingInversion: *MinimumD
+  KastaunMaxLorentzFactor: 10.0
 
 Observers:
   VolumeFileName: "ValenciaDivCleanBlastWaveVolume"

--- a/tests/InputFiles/GrMhd/ValenciaDivClean/FishboneMoncriefDisk.yaml
+++ b/tests/InputFiles/GrMhd/ValenciaDivClean/FishboneMoncriefDisk.yaml
@@ -116,6 +116,7 @@ VariableFixing:
 PrimitiveFromConservative:
   CutoffDForInversion: *CutoffD
   DensityWhenSkippingInversion: *MinimumD
+  KastaunMaxLorentzFactor: 10.0
 
 EventsAndTriggers:
   - Trigger:

--- a/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/Test_FixConservativesAndComputePrims.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/Test_FixConservativesAndComputePrims.cpp
@@ -61,9 +61,11 @@ SPECTRE_TEST_CASE(
 
   const double cutoff_d_for_inversion = 0.0;
   const double density_when_skipping_inversion = 0.0;
+  const double kastaun_max_lorentz = 1.0e4;
   const grmhd::ValenciaDivClean::PrimitiveFromConservativeOptions
-    primitive_from_conservative_options(cutoff_d_for_inversion,
-                                        density_when_skipping_inversion);
+      primitive_from_conservative_options(cutoff_d_for_inversion,
+                                          density_when_skipping_inversion,
+                                          kastaun_max_lorentz);
 
   auto box = db::create<db::AddSimpleTags<
       evolution::dg::subcell::Tags::Coordinates<3, Frame::Inertial>,

--- a/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/Test_PrimsAfterRollback.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/Test_PrimsAfterRollback.cpp
@@ -127,9 +127,11 @@ void test(const gsl::not_null<std::mt19937*> gen,
 
   const double cutoff_d_for_inversion = 0.0;
   const double density_when_skipping_inversion = 0.0;
+  const double kastaun_max_lorentz = 1.0e4;
   const grmhd::ValenciaDivClean::PrimitiveFromConservativeOptions
-    primitive_from_conservative_options(cutoff_d_for_inversion,
-                                        density_when_skipping_inversion);
+      primitive_from_conservative_options(cutoff_d_for_inversion,
+                                          density_when_skipping_inversion,
+                                          kastaun_max_lorentz);
 
   // The DG prims are used as an initial guess so we need to provide them
   auto box = db::create<db::AddSimpleTags<

--- a/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/Test_ResizeAndComputePrimitives.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/Test_ResizeAndComputePrimitives.cpp
@@ -149,9 +149,11 @@ void test(const gsl::not_null<std::mt19937*> gen,
 
   const double cutoff_d_for_inversion = 0.0;
   const double density_when_skipping_inversion = 0.0;
+  const double kastaun_max_lorentz = 1.0e4;
   const grmhd::ValenciaDivClean::PrimitiveFromConservativeOptions
-    primitive_from_conservative_options(cutoff_d_for_inversion,
-                                        density_when_skipping_inversion);
+      primitive_from_conservative_options(cutoff_d_for_inversion,
+                                          density_when_skipping_inversion,
+                                          kastaun_max_lorentz);
 
   auto box = db::create<db::AddSimpleTags<
       evolution::dg::subcell::Tags::ActiveGrid, cons_tag, prim_tag,

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_FixConservativesAndComputePrims.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_FixConservativesAndComputePrims.cpp
@@ -44,9 +44,11 @@ SPECTRE_TEST_CASE(
 
   const double cutoff_d_for_inversion = 0.0;
   const double density_when_skipping_inversion = 0.0;
+  const double kastaun_max_lorentz = 1.0e4;
   const grmhd::ValenciaDivClean::PrimitiveFromConservativeOptions
-    primitive_from_conservative_options(cutoff_d_for_inversion,
-                                        density_when_skipping_inversion);
+      primitive_from_conservative_options(cutoff_d_for_inversion,
+                                          density_when_skipping_inversion,
+                                          kastaun_max_lorentz);
 
   auto box = db::create<db::AddSimpleTags<
       grmhd::ValenciaDivClean::Tags::VariablesNeededFixing,

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_PrimsAfterRollback.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_PrimsAfterRollback.cpp
@@ -123,9 +123,11 @@ void test(const gsl::not_null<std::mt19937*> gen,
 
   const double cutoff_d_for_inversion = 0.0;
   const double density_when_skipping_inversion = 0.0;
+  const double kastaun_max_lorentz = 1.0e4;
   const grmhd::ValenciaDivClean::PrimitiveFromConservativeOptions
-    primitive_from_conservative_options(cutoff_d_for_inversion,
-                                        density_when_skipping_inversion);
+      primitive_from_conservative_options(cutoff_d_for_inversion,
+                                          density_when_skipping_inversion,
+                                          kastaun_max_lorentz);
 
   // The DG prims are used as an initial guess so we need to provide them
   auto box = db::create<db::AddSimpleTags<

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_ResizeAndComputePrimitives.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_ResizeAndComputePrimitives.cpp
@@ -143,9 +143,11 @@ void test(const gsl::not_null<std::mt19937*> gen,
 
   const double cutoff_d_for_inversion = 0.0;
   const double density_when_skipping_inversion = 0.0;
+  const double kastaun_max_lorentz = 1.0e4;
   const grmhd::ValenciaDivClean::PrimitiveFromConservativeOptions
-    primitive_from_conservative_options(cutoff_d_for_inversion,
-                                        density_when_skipping_inversion);
+      primitive_from_conservative_options(cutoff_d_for_inversion,
+                                          density_when_skipping_inversion,
+                                          kastaun_max_lorentz);
 
   auto box = db::create<db::AddSimpleTags<
       evolution::dg::subcell::Tags::ActiveGrid, cons_tag, prim_tag,

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_TciOnDgGrid.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_TciOnDgGrid.cpp
@@ -126,9 +126,11 @@ void test(const TestThis test_this, const int expected_tci_status,
 
   const double cutoff_d_for_inversion = 0.0;
   const double density_when_skipping_inversion = 0.0;
+  const double kastaun_max_lorentz = 1.0e4;
   const grmhd::ValenciaDivClean::PrimitiveFromConservativeOptions
-    primitive_from_conservative_options(cutoff_d_for_inversion,
-                                        density_when_skipping_inversion);
+      primitive_from_conservative_options(cutoff_d_for_inversion,
+                                          density_when_skipping_inversion,
+                                          kastaun_max_lorentz);
 
   auto box = db::create<db::AddSimpleTags<
       ::Tags::Variables<typename ConsVars::tags_list>,

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Test_Flattener.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Test_Flattener.cpp
@@ -78,9 +78,11 @@ SPECTRE_TEST_CASE("Unit.GrMhd.ValenciaDivClean.Flattener", "[Unit][GrMhd]") {
 
   const double cutoff_d_for_inversion = 0.0;
   const double density_when_skipping_inversion = 0.0;
+  const double kastaun_max_lorentz = 1.0e4;
   const grmhd::ValenciaDivClean::PrimitiveFromConservativeOptions
-    primitive_from_conservative_options(cutoff_d_for_inversion,
-                                        density_when_skipping_inversion);
+      primitive_from_conservative_options(cutoff_d_for_inversion,
+                                          density_when_skipping_inversion,
+                                          kastaun_max_lorentz);
 
   {
     INFO("Case: NoOp");

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Test_PrimitiveFromConservative.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Test_PrimitiveFromConservative.cpp
@@ -125,9 +125,11 @@ void test_primitive_from_conservative_random(
 
   const double cutoff_d_for_inversion = 0.0;
   const double density_when_skipping_inversion = 0.0;
+  const double kastaun_max_lorentz = 1.0e4;
   const grmhd::ValenciaDivClean::PrimitiveFromConservativeOptions
-    primitive_from_conservative_options(cutoff_d_for_inversion,
-                                        density_when_skipping_inversion);
+      primitive_from_conservative_options(cutoff_d_for_inversion,
+                                          density_when_skipping_inversion,
+                                          kastaun_max_lorentz);
 
   Scalar<DataVector> rest_mass_density(number_of_points);
   Scalar<DataVector> electron_fraction(number_of_points);
@@ -233,9 +235,11 @@ void test_primitive_from_conservative_known(const DataVector& used_for_size) {
 
   const double cutoff_d_for_inversion = 0.0;
   const double density_when_skipping_inversion = 0.0;
+  const double kastaun_max_lorentz = 1.0e4;
   const grmhd::ValenciaDivClean::PrimitiveFromConservativeOptions
-    primitive_from_conservative_options(cutoff_d_for_inversion,
-                                        density_when_skipping_inversion);
+      primitive_from_conservative_options(cutoff_d_for_inversion,
+                                          density_when_skipping_inversion,
+                                          kastaun_max_lorentz);
 
   grmhd::ValenciaDivClean::ConservativeFromPrimitive::apply(
       make_not_null(&tilde_d), make_not_null(&tilde_ye),

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Test_PrimitiveFromConservative.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Test_PrimitiveFromConservative.cpp
@@ -320,8 +320,8 @@ SPECTRE_TEST_CASE("Unit.GrMhd.ValenciaDivClean.PrimitiveFromConservative",
   test_primitive_from_conservative_known<tmpl::list<
       grmhd::ValenciaDivClean::PrimitiveRecoverySchemes::KastaunEtAl>>(dv);
   test_primitive_from_conservative_known<
-      tmpl::list<grmhd::ValenciaDivClean::PrimitiveRecoverySchemes::
-                     KastaunEtAlHydro<true>>,
+      tmpl::list<
+          grmhd::ValenciaDivClean::PrimitiveRecoverySchemes::KastaunEtAlHydro>,
       false>(dv);
   test_primitive_from_conservative_known<tmpl::list<
       grmhd::ValenciaDivClean::PrimitiveRecoverySchemes::NewmanHamlin>>(dv);
@@ -351,11 +351,11 @@ SPECTRE_TEST_CASE("Unit.GrMhd.ValenciaDivClean.PrimitiveFromConservative",
       2>(&generator, ideal_fluid, dv);
 
   test_primitive_from_conservative_random<
-      tmpl::list<grmhd::ValenciaDivClean::PrimitiveRecoverySchemes::
-                     KastaunEtAlHydro<true>>,
+      tmpl::list<
+          grmhd::ValenciaDivClean::PrimitiveRecoverySchemes::KastaunEtAlHydro>,
       1, false>(&generator, polytropic_fluid, dv);
   test_primitive_from_conservative_random<
-      tmpl::list<grmhd::ValenciaDivClean::PrimitiveRecoverySchemes::
-                     KastaunEtAlHydro<true>>,
+      tmpl::list<
+          grmhd::ValenciaDivClean::PrimitiveRecoverySchemes::KastaunEtAlHydro>,
       2, false>(&generator, ideal_fluid, dv);
 }


### PR DESCRIPTION
## Proposed changes

Does some unification of the interfaces between different p2c schemes and adds an upper bound to the Lorentz factor in the KastaunMHD scheme. The last commit adds an input file option to control the max Lorentz factor.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
