### PR TITLE
Clean up Sphere TimeDependentOptions

### DIFF
--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_ComputeDestVars.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_ComputeDestVars.cpp
@@ -107,8 +107,8 @@ template <typename Frame>
 void test() {
   domain::FunctionsOfTime::register_derived_with_charm();
 
-  domain::creators::sphere::TimeDependentMapOptions time_dep_opts{
-      0.0, std::nullopt, 2, std::nullopt};
+  using TDMO = domain::creators::sphere::TimeDependentMapOptions;
+  TDMO time_dep_opts{0.0, TDMO::ShapeMapOptions{2, std::nullopt}};
 
   const auto domain_creator = domain::creators::Sphere(
       0.9, 4.9, domain::creators::Sphere::Excision{}, 1_st, 7_st, false, {}, {},


### PR DESCRIPTION
Removes the ability to independently specify size coefficients because it wasn't used in practice. If we need to specify size coefficients we should do it from a file.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
To use hard coded time dependent maps with the Sphere domain creator, you no longer specify the following option

```yaml
  TimeDependentMaps:
    ...
    SizeMap:  # <-- Don't specify this
      InitialValues: [...]
```
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
