### PR TITLE
Add skeleton BBH pipeline

### DIFF
--- a/containers/Dockerfile.buildenv
+++ b/containers/Dockerfile.buildenv
@@ -139,7 +139,8 @@ RUN apt-get update -y \
     && apt-get install -y cmake clang lld wget
 # Install build dependencies for the target architecture
 RUN xx-apt-get update -y \
-    && xx-apt-get install -y libc6-dev libstdc++-10-dev bison flex
+    && xx-apt-get install -y --no-install-recommends \
+        libc6-dev libstdc++-10-dev bison flex
 # - Ccache
 RUN wget https://github.com/ccache/ccache/releases/download/v4.8.2/ccache-4.8.2.tar.gz -O ccache.tar.gz \
     && tar -xzf ccache.tar.gz \

--- a/src/Domain/CoordinateMaps/Composition.cpp
+++ b/src/Domain/CoordinateMaps/Composition.cpp
@@ -388,7 +388,7 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
 
 #undef INSTANTIATE
 
-#if defined(__clang__) && __clang_major__ >= 16
+#if defined(__clang__) && __clang_major__ >= 15
 #define INSTANTIATE2(_, data)                                                  \
   template domain::CoordinateMaps::Composition<                                \
       brigand::list<Frame::ElementLogical, Frame::BlockLogical,                \

--- a/support/Pipelines/Bbh/CMakeLists.txt
+++ b/support/Pipelines/Bbh/CMakeLists.txt
@@ -1,0 +1,25 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+spectre_python_add_module(
+  Bbh
+  MODULE_PATH Pipelines
+  PYTHON_FILES
+  __init__.py
+  InitialData.py
+  InitialData.yaml
+  Inspiral.py
+  Inspiral.yaml
+  Ringdown.py
+  Ringdown.yaml
+)
+
+# Create a target to compile all executables for this pipeline
+set(PIPELINE_TARGET bbh)
+add_custom_target(${PIPELINE_TARGET})
+add_dependencies(
+  ${PIPELINE_TARGET}
+  EvolveGhBinaryBlackHole
+  EvolveGhSingleBlackHole
+  SolveXcts
+  )

--- a/support/Pipelines/Bbh/InitialData.py
+++ b/support/Pipelines/Bbh/InitialData.py
@@ -1,0 +1,151 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import logging
+from pathlib import Path
+from typing import Union
+
+import click
+from rich.pretty import pretty_repr
+
+from spectre.support.Schedule import schedule, scheduler_options
+
+logger = logging.getLogger(__name__)
+
+ID_INPUT_FILE_TEMPLATE = Path(__file__).parent / "InitialData.yaml"
+
+
+def id_parameters(
+    mass_ratio: float,
+    separation: float,
+    orbital_angular_velocity: float,
+    refinement_level: int,
+    polynomial_order: int,
+):
+    """Determine initial data parameters from options.
+
+    These parameters fill the 'ID_INPUT_FILE_TEMPLATE'.
+
+    Arguments:
+      mass_ratio: Defined as q = M_A / M_B >= 1.
+      separation: Coordinate separation D of the black holes.
+      orbital_angular_velocity: Omega_0.
+      refinement_level: h-refinement level.
+      polynomial_order: p-refinement level.
+    """
+
+    # Sanity checks
+    assert mass_ratio >= 1.0, "Mass ratio is defined to be >= 1.0."
+
+    # Determine initial data parameters from options
+    M_A = mass_ratio / (1.0 + mass_ratio)
+    M_B = 1.0 / (1.0 + mass_ratio)
+    x_A = separation / (1.0 + mass_ratio)
+    x_B = x_A - separation
+    return {
+        "MassRight": M_A,
+        "MassLeft": M_B,
+        "XRight": x_A,
+        "XLeft": x_B,
+        "ExcisionRadiusRight": 0.89 * 2.0 * M_A,
+        "ExcisionRadiusLeft": 0.89 * 2.0 * M_B,
+        "OrbitalAngularVelocity": orbital_angular_velocity,
+        # Resolution
+        "L": refinement_level,
+        "P": polynomial_order,
+    }
+
+
+def generate_id(
+    mass_ratio: float,
+    separation: float,
+    orbital_angular_velocity: float,
+    refinement_level: int,
+    polynomial_order: int,
+    id_input_file_template: Union[str, Path] = ID_INPUT_FILE_TEMPLATE,
+    **scheduler_kwargs,
+):
+    """Generate initial data for a BBH simulation.
+
+    Parameters for the initial data will be inserted into the
+    'id_input_file_template'. The remaining options are forwarded to the
+    'schedule' command. See 'schedule' docs for details.
+    """
+    logger.warning(
+        "The BBH pipeline is still experimental. Please review the"
+        " generated input files."
+    )
+
+    # Determine initial data parameters from options
+    id_params = id_parameters(
+        mass_ratio=mass_ratio,
+        separation=separation,
+        orbital_angular_velocity=orbital_angular_velocity,
+        refinement_level=refinement_level,
+        polynomial_order=polynomial_order,
+    )
+    logger.debug(f"Initial data parameters: {pretty_repr(id_params)}")
+
+    # Schedule!
+    return schedule(id_input_file_template, **id_params, **scheduler_kwargs)
+
+
+@click.command(name="generate-id", help=generate_id.__doc__)
+@click.option(
+    "--mass-ratio",
+    "-q",
+    type=float,
+    help="Mass ratio of the binary, defined as q = M_A / M_B >= 1.",
+    required=True,
+)
+@click.option(
+    "--separation",
+    "-D",
+    type=float,
+    help="Coordinate separation D of the black holes.",
+    required=True,
+)
+@click.option(
+    "--orbital-angular-velocity",
+    "-w",
+    type=float,
+    help="Orbital angular velocity Omega_0.",
+    required=True,
+)
+@click.option(
+    "--refinement-level",
+    "-L",
+    type=int,
+    help="h-refinement level.",
+    default=0,
+    show_default=True,
+)
+@click.option(
+    "--polynomial-order",
+    "-P",
+    type=int,
+    help="p-refinement level.",
+    default=5,
+    show_default=True,
+)
+@click.option(
+    "--id-input-file-template",
+    type=click.Path(
+        exists=True,
+        file_okay=True,
+        dir_okay=False,
+        readable=True,
+        path_type=Path,
+    ),
+    default=ID_INPUT_FILE_TEMPLATE,
+    help="Input file template for the initial data.",
+    show_default=True,
+)
+@scheduler_options
+def generate_id_command(**kwargs):
+    _rich_traceback_guard = True  # Hide traceback until here
+    generate_id(**kwargs)
+
+
+if __name__ == "__main__":
+    generate_id_command(help_option_names=["-h", "--help"])

--- a/support/Pipelines/Bbh/InitialData.yaml
+++ b/support/Pipelines/Bbh/InitialData.yaml
@@ -1,0 +1,161 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+Executable: SolveXcts
+
+---
+
+Background: &background
+  Binary:
+    XCoords: [&x_left {{ XLeft }}, &x_right {{ XRight }}]
+    ObjectLeft: &kerr_left
+      KerrSchild:
+        Mass: {{ MassLeft }}
+        Spin: [0., 0., 0.]
+        Center: [0., 0., 0.]
+    ObjectRight: &kerr_right
+      KerrSchild:
+        Mass: {{ MassRight }}
+        Spin: [0., 0., 0.]
+        Center: [0., 0., 0.]
+    AngularVelocity: {{ OrbitalAngularVelocity }}
+    Expansion: 0.
+    LinearVelocity: [0., 0., 0.]
+    FalloffWidths: [4.8, 4.8]
+
+InitialGuess: *background
+
+DomainCreator:
+  BinaryCompactObject:
+    ObjectA:
+      InnerRadius: {{ ExcisionRadiusRight }}
+      OuterRadius: 4.
+      XCoord: *x_right
+      Interior:
+        ExciseWithBoundaryCondition:
+          ApparentHorizon:
+            Center: [*x_right, 0., 0.]
+            Rotation: [0., 0., 0.]
+            Lapse: *kerr_right
+            NegativeExpansion: *kerr_right
+      UseLogarithmicMap: True
+    ObjectB:
+      InnerRadius: {{ ExcisionRadiusLeft }}
+      OuterRadius: 4.
+      XCoord: *x_left
+      Interior:
+        ExciseWithBoundaryCondition:
+          ApparentHorizon:
+            Center: [*x_left, 0., 0.]
+            Rotation: [0., 0., 0.]
+            Lapse: *kerr_left
+            NegativeExpansion: *kerr_left
+      UseLogarithmicMap: True
+    Envelope:
+      Radius: &outer_shell_inner_radius 60.
+      RadialDistribution: Projective
+    OuterShell:
+      Radius: &outer_radius 1e4
+      RadialDistribution: &outer_shell_distribution Inverse
+      OpeningAngle: 120.0
+      BoundaryCondition: Flatness
+    UseEquiangularMap: True
+    InitialRefinement:
+      ObjectAShell:     [{{ L }}, {{ L }}, {{ L }}]
+      ObjectBShell:     [{{ L }}, {{ L }}, {{ L }}]
+      ObjectACube:      [{{ L }}, {{ L }}, {{ L }}]
+      ObjectBCube:      [{{ L }}, {{ L }}, {{ L }}]
+      Envelope:         [{{ L }}, {{ L }}, {{ L }}]
+      OuterShell:       [{{ L }}, {{ L }}, {{ L + 2}}]
+    # This p-refinement represents a crude manual optimization of the domain. We
+    # will need AMR to optimize the domain further.
+    InitialGridPoints:
+      ObjectAShell:   [{{ P + 1}}, {{ P + 1}}, {{ P + 5}}]
+      ObjectBShell:   [{{ P + 1}}, {{ P + 1}}, {{ P + 5}}]
+      ObjectACube:    [{{ P + 1}}, {{ P + 1}}, {{ P + 2}}]
+      ObjectBCube:    [{{ P + 1}}, {{ P + 1}}, {{ P + 2}}]
+      Envelope:       [{{ P + 1}}, {{ P + 1}}, {{ P + 1}}]
+      OuterShell:     [{{ P + 1}}, {{ P + 1}}, {{ P + 1}}]
+
+Discretization:
+  DiscontinuousGalerkin:
+    PenaltyParameter: 1.
+    Massive: True
+
+Observers:
+  VolumeFileName: "BbhVolume"
+  ReductionFileName: "BbhReductions"
+
+NonlinearSolver:
+  NewtonRaphson:
+    ConvergenceCriteria:
+      MaxIterations: 20
+      RelativeResidual: 1.e-10
+      AbsoluteResidual: 1.e-10
+    SufficientDecrease: 1.e-4
+    MaxGlobalizationSteps: 40
+    DampingFactor: 1.
+    Verbosity: Verbose
+
+LinearSolver:
+  Gmres:
+    ConvergenceCriteria:
+      MaxIterations: 100
+      RelativeResidual: 1.e-11
+      AbsoluteResidual: 1.e-11
+    Verbosity: Quiet
+
+  Multigrid:
+    Iterations: 1
+    MaxLevels: Auto
+    PreSmoothing: True
+    PostSmoothingAtBottom: True
+    Verbosity: Silent
+    OutputVolumeData: False
+
+  SchwarzSmoother:
+    MaxOverlap: 2
+    Iterations: 3
+    Verbosity: Silent
+    SubdomainSolver:
+      Gmres:
+        ConvergenceCriteria:
+          MaxIterations: 3
+          RelativeResidual: 1.e-4
+          AbsoluteResidual: 1.e-10
+        Verbosity: Silent
+        Restart: None
+        Preconditioner:
+          MinusLaplacian:
+            Solver:
+              ExplicitInverse:
+                WriteMatrixToFile: None
+            BoundaryConditions: Auto
+    SkipResets: True
+    ObservePerCoreReductions: False
+
+RadiallyCompressedCoordinates:
+  InnerRadius: *outer_shell_inner_radius
+  OuterRadius: *outer_radius
+  Compression: *outer_shell_distribution
+
+EventsAndTriggers:
+  - Trigger: HasConverged
+    Events:
+      - ObserveFields:
+          SubfileName: VolumeData
+          VariablesToObserve:
+            - ConformalFactor
+            - Lapse
+            - Shift
+            - ShiftExcess
+            - SpatialMetric
+            - ExtrinsicCurvature
+            - RadiallyCompressedCoordinates
+          InterpolateToMesh: None
+          CoordinatesFloatingPointType: Double
+          FloatingPointTypes: [Double]
+
+ResourceInfo:
+  AvoidGlobalProc0: false
+  Singletons: Auto

--- a/support/Pipelines/Bbh/Inspiral.py
+++ b/support/Pipelines/Bbh/Inspiral.py
@@ -1,0 +1,163 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import logging
+from pathlib import Path
+from typing import Optional, Union
+
+import click
+import yaml
+from rich.pretty import pretty_repr
+
+from spectre.support.Schedule import schedule, scheduler_options
+
+logger = logging.getLogger(__name__)
+
+INSPIRAL_INPUT_FILE_TEMPLATE = Path(__file__).parent / "Inspiral.yaml"
+
+
+def inspiral_parameters(
+    id_input_file: dict,
+    id_run_dir: Union[str, Path],
+    refinement_level: int,
+    polynomial_order: int,
+) -> dict:
+    """Determine inspiral parameters from initial data.
+
+    These parameters fill the 'INSPIRAL_INPUT_FILE_TEMPLATE'.
+
+    Arguments:
+      id_input_file: Initial data input file as a dictionary.
+      id_run_dir: Directory of the initial data run. Paths in the input file
+        are relative to this directory.
+      refinement_level: h-refinement level.
+      polynomial_order: p-refinement level.
+    """
+    id_domain_creator = id_input_file["DomainCreator"]["BinaryCompactObject"]
+    id_binary = id_input_file["Background"]["Binary"]
+    return {
+        # Initial data files
+        "IdFileGlob": str(
+            Path(id_run_dir).resolve()
+            / (id_input_file["Observers"]["VolumeFileName"] + "*.h5")
+        ),
+        # Domain geometry
+        "ExcisionRadiusA": id_domain_creator["ObjectA"]["InnerRadius"],
+        "ExcisionRadiusB": id_domain_creator["ObjectB"]["InnerRadius"],
+        "XCoordA": id_domain_creator["ObjectA"]["XCoord"],
+        "XCoordB": id_domain_creator["ObjectB"]["XCoord"],
+        # Initial functions of time
+        "InitialAngularVelocity": id_binary["AngularVelocity"],
+        # Resolution
+        "L": refinement_level,
+        "P": polynomial_order,
+    }
+
+
+def start_inspiral(
+    id_input_file_path: Union[str, Path],
+    refinement_level: int,
+    polynomial_order: int,
+    id_run_dir: Optional[Union[str, Path]] = None,
+    inspiral_input_file_template: Union[
+        str, Path
+    ] = INSPIRAL_INPUT_FILE_TEMPLATE,
+    **scheduler_kwargs,
+):
+    """Schedule an inspiral simulation from initial data.
+
+    Point the ID_INPUT_FILE_PATH to the input file of your initial data run.
+    Also specify 'id_run_dir' if the initial data was run in a different
+    directory than where the input file is. Parameters for the inspiral will be
+    determined from the initial data and inserted into the
+    'inspiral_input_file_template'. The remaining options are forwarded to the
+    'schedule' command. See 'schedule' docs for details.
+    """
+    logger.warning(
+        "The BBH pipeline is still experimental. Please review the"
+        " generated input files."
+    )
+
+    # Determine inspiral parameters from initial data
+    with open(id_input_file_path, "r") as open_input_file:
+        _, id_input_file = yaml.safe_load_all(open_input_file)
+    if id_run_dir is None:
+        id_run_dir = Path(id_input_file_path).resolve().parent
+    inspiral_params = inspiral_parameters(
+        id_input_file,
+        id_run_dir,
+        refinement_level=refinement_level,
+        polynomial_order=polynomial_order,
+    )
+    logger.debug(f"Inspiral parameters: {pretty_repr(inspiral_params)}")
+
+    # Schedule!
+    return schedule(
+        inspiral_input_file_template, **inspiral_params, **scheduler_kwargs
+    )
+
+
+@click.command(name="start-inspiral", help=start_inspiral.__doc__)
+@click.argument(
+    "id_input_file_path",
+    type=click.Path(
+        exists=True,
+        file_okay=True,
+        dir_okay=False,
+        readable=True,
+        path_type=Path,
+    ),
+)
+@click.option(
+    "-i",
+    "--id-run-dir",
+    type=click.Path(
+        exists=True,
+        file_okay=False,
+        dir_okay=True,
+        readable=True,
+        path_type=Path,
+    ),
+    help=(
+        "Directory of the initial data run. Paths in the input file are"
+        " relative to this directory."
+    ),
+    show_default="directory of the ID_INPUT_FILE_PATH",
+)
+@click.option(
+    "--inspiral-input-file-template",
+    type=click.Path(
+        exists=True,
+        file_okay=True,
+        dir_okay=False,
+        readable=True,
+        path_type=Path,
+    ),
+    default=INSPIRAL_INPUT_FILE_TEMPLATE,
+    help="Input file template for the inspiral.",
+    show_default=True,
+)
+@click.option(
+    "--refinement-level",
+    "-L",
+    type=int,
+    help="h-refinement level.",
+    default=0,
+    show_default=True,
+)
+@click.option(
+    "--polynomial-order",
+    "-P",
+    type=int,
+    help="p-refinement level.",
+    default=5,
+    show_default=True,
+)
+@scheduler_options
+def start_inspiral_command(**kwargs):
+    _rich_traceback_guard = True  # Hide traceback until here
+    start_inspiral(**kwargs)
+
+
+if __name__ == "__main__":
+    start_inspiral_command(help_option_names=["-h", "--help"])

--- a/support/Pipelines/Bbh/Inspiral.yaml
+++ b/support/Pipelines/Bbh/Inspiral.yaml
@@ -1,0 +1,380 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+Executable: EvolveGhBinaryBlackHole
+
+---
+
+InitialData:
+  NumericInitialData:
+    FileGlob: "{{ IdFileGlob }}"
+    Subgroup: "VolumeData"
+    ObservationValue: Last
+    Interpolate: True
+    Variables:
+      Lapse: Lapse
+      # Load a shift that is not corotating. See `docs/Examples/BbhInitialData`
+      # for details.
+      Shift: ShiftExcess
+      SpatialMetric: SpatialMetric
+      ExtrinsicCurvature: ExtrinsicCurvature
+
+DomainCreator:
+  BinaryCompactObject:
+    ObjectA:
+      InnerRadius: &ExcisionRadiusA {{ ExcisionRadiusA }}
+      OuterRadius: 6.683
+      XCoord: &XCoordA {{ XCoordA }}
+      Interior:
+        ExciseWithBoundaryCondition:
+          DemandOutgoingCharSpeeds:
+      UseLogarithmicMap: true
+    ObjectB:
+      InnerRadius: &ExcisionRadiusB {{ ExcisionRadiusB }}
+      OuterRadius: 6.683
+      XCoord: &XCoordB {{ XCoordB }}
+      Interior:
+        ExciseWithBoundaryCondition:
+          DemandOutgoingCharSpeeds:
+      UseLogarithmicMap: true
+    Envelope:
+      Radius: 100.0
+      RadialDistribution: Projective
+    OuterShell:
+      Radius: 1493.0
+      RadialDistribution: Logarithmic
+      OpeningAngle: 120.0
+      BoundaryCondition:
+        ConstraintPreservingBjorhus:
+          Type: ConstraintPreservingPhysical
+    UseEquiangularMap: True
+    InitialRefinement:
+      ObjectAShell:   [{{ L + 2 }}, {{ L + 2 }}, {{ L + 3 }}]
+      ObjectACube:    [{{ L + 1 }}, {{ L + 1 }}, {{ L     }}]
+      ObjectBShell:   [{{ L + 2 }}, {{ L + 2 }}, {{ L + 3 }}]
+      ObjectBCube:    [{{ L + 1 }}, {{ L + 1 }}, {{ L     }}]
+      Envelope:       [{{ L + 1 }}, {{ L + 1 }}, {{ L + 2 }}]
+      OuterShell:     [{{ L + 1 }}, {{ L + 1 }}, {{ L + 4 }}]
+    InitialGridPoints: {{ P + 1 }}
+    TimeDependentMaps:
+      InitialTime: 0.0
+      ExpansionMap:
+        InitialValues: [1.0, 0.0]
+        AsymptoticVelocityOuterBoundary: -1.0e-6
+        DecayTimescaleOuterBoundaryVelocity: 50.0
+      RotationMap:
+        InitialAngularVelocity: [0.0, 0.0, {{ InitialAngularVelocity }}]
+      ShapeMapA:
+        LMax: &LMax 10
+        SizeInitialValues: [0.0, 0.0, 0.0]
+      ShapeMapB:
+        LMax: *LMax
+        SizeInitialValues: [0.0, 0.0, 0.0]
+
+Evolution:
+  InitialTime: 0.0
+  InitialTimeStep: 0.0002
+  InitialSlabSize: 0.25
+  StepChoosers:
+    - Increase:
+        Factor: 2
+    - ElementSizeCfl:
+        SafetyFactor: 0.5
+    - ErrorControl:
+        AbsoluteTolerance: 1e-8
+        RelativeTolerance: 1e-6
+        MaxFactor: 2
+        MinFactor: 0.25
+        SafetyFactor: 0.95
+  TimeStepper:
+    AdamsBashforth:
+      Order: 5
+
+# Set gauge and constraint damping parameters.
+# The values here are chosen empirically based on values that proved
+# sucessful in SpEC evolutions of binary black holes.
+# Note: Gaussian width = W / sqrt(34.54), so exp(-W^2/w^2) = 1e-15 at x=W,
+# is used in the damped-harmonic gauge parameters.
+# In SpEC, GaugeItems.input set what spectre calls W and spec calls
+# SecondaryWeightRmax. See
+# EvolutionSystems/GeneralizedHarmonic/DampedHarmonicGaugeItems.cpp
+# line 463 in https://github.com/sxs-collaboration/spec for where the Gaussian
+# is actually computed in SpEC.
+EvolutionSystem:
+  GeneralizedHarmonic:
+    GaugeCondition:
+      DampedHarmonic:
+        SpatialDecayWidth: 17.0152695482514 # From SpEC run: 100.0 / sqrt(34.54)
+        Amplitudes: [1.0, 1.0, 1.0]         # From SpEC run: damped harmonic
+        Exponents: [2, 2, 2]                # From SpEC run
+    DampingFunctionGamma0:
+      TimeDependentTripleGaussian:
+        Constant: 0.001             # 0.001 / (m_A + m_B)
+        Gaussian1:
+          Amplitude: 8.0             # 4.0 / m_A
+          Width: 3.5                 # 7.0 * m_A
+          Center: [*XCoordA, 0.0, 0.0] # [x_A, 0, 0]
+        Gaussian2:
+          Amplitude: 8.0             # 4.0 / m_B
+          Width: 3.5                 # 7.0 * m_B
+          Center: [*XCoordB, 0.0, 0.0]  # [x_B, 0, 0]
+        Gaussian3:
+          Amplitude: 0.075            # 0.075 / (m_A + m_B)
+          Width: 38.415              # 2.5 * (x_B - x_A)
+          Center: [0.0, 0.0, 0.0]
+    DampingFunctionGamma1:
+      GaussianPlusConstant:
+        Constant: -0.999
+        Amplitude: 0.999
+        Width: 153.66                # 10.0 * (x_B - x_A)
+        Center: [0.0, 0.0, 0.0]
+    DampingFunctionGamma2:
+      TimeDependentTripleGaussian:
+        Constant: 0.001              # 0.001 / (m_A + m_B)
+        Gaussian1:
+          Amplitude: 8.0             # 4.0 / m_A
+          Width: 3.5                 # 7.0 * m_A
+          Center: [*XCoordA, 0.0, 0.0] # [x_A, 0, 0]
+        Gaussian2:
+          Amplitude: 8.0             # 4.0 / m_B
+          Width: 3.5                 # 7.0 * m_B
+          Center: [*XCoordB, 0.0, 0.0]  # [x_B, 0, 0]
+        Gaussian3:
+          Amplitude: 0.075            # 0.075 / (m_A + m_B)
+          Width: 38.415              # 2.5 * (x_B - x_A)
+          Center: [0.0, 0.0, 0.0]
+
+Filtering:
+  ExpFilter0:
+    Alpha: 36.0
+    HalfPower: 24
+    Enable: false
+    BlocksToFilter: All
+
+SpatialDiscretization:
+  BoundaryCorrection:
+    UpwindPenalty:
+  DiscontinuousGalerkin:
+    Formulation: StrongInertial
+    Quadrature: GaussLobatto
+
+Observers:
+  VolumeFileName: "BbhVolume"
+  ReductionFileName: "BbhReductions"
+  SurfaceFileName: "BbhSurfaces"
+
+Cce:
+  BondiSachsOutputFilePrefix: "BondiSachs"
+
+PhaseChangeAndTriggers:
+  - Trigger:
+      Slabs:
+        EvenlySpaced:
+          # Current implementation checks wallclock at these global syncs
+          Interval: 100
+          Offset: 0
+    PhaseChanges:
+      - CheckpointAndExitAfterWallclock:
+          WallclockHours: 23.5
+
+EventsAndTriggers:
+  - Trigger:
+      Slabs:
+        EvenlySpaced:
+          Interval: 1
+          Offset: 0
+    Events:
+      - ObserveTimeStep:
+          SubfileName: TimeSteps
+          PrintTimeToTerminal: True
+          ObservePerCore: False
+      - ObserveNorms:
+          SubfileName: Norms
+          TensorsToObserve:
+          - Name: Lapse
+            NormType: L2Norm
+            Components: Individual
+          - Name: PointwiseL2Norm(GaugeConstraint)
+            NormType: L2Norm
+            Components: Sum
+          - Name: PointwiseL2Norm(ThreeIndexConstraint)
+            NormType: L2Norm
+            Components: Sum
+          - Name: PointwiseL2Norm(FourIndexConstraint)
+            NormType: L2Norm
+            Components: Sum
+  - Trigger:
+      Slabs:
+        EvenlySpaced:
+          Interval: 100
+          Offset: 0
+    Events:
+      - ObserveFields:
+          SubfileName: VolumeData
+          VariablesToObserve:
+            - SpacetimeMetric
+            - Pi
+            - Phi
+            - Lapse
+            - Shift
+            - PointwiseL2Norm(GaugeConstraint)
+            - PointwiseL2Norm(ThreeIndexConstraint)
+            - PointwiseL2Norm(FourIndexConstraint)
+          InterpolateToMesh: None
+          CoordinatesFloatingPointType: Double
+          FloatingPointTypes: [Double]
+      - ObservationAhA
+      - ObservationAhB
+      - ObservationExcisionBoundaryA
+      - ObservationExcisionBoundaryB
+  - Trigger:
+      SeparationLessThan:
+        Value: 2.0
+    Events:
+      - ObservationAhC
+  # Never terminate... run until something fails!
+
+EventsAndDenseTriggers:
+
+Interpolator:
+  DumpVolumeDataOnFailure: false
+
+ApparentHorizons:
+  ObservationAhA: &AhA
+    InitialGuess:
+      LMax: *LMax
+      Radius: {{ ExcisionRadiusA * 1.5 }}
+      Center: [*XCoordA, 0.0, 0.0]
+    FastFlow: &DefaultFastFlow
+      Flow: Fast
+      Alpha: 1.0
+      Beta: 0.5
+      AbsTol: 1e-12
+      TruncationTol: 1e-2
+      DivergenceTol: 1.2
+      DivergenceIter: 5
+      MaxIts: 100
+    Verbosity: Verbose
+  ObservationAhB: &AhB
+    InitialGuess:
+      LMax: *LMax
+      Radius: {{ ExcisionRadiusB * 1.5 }}
+      Center: [*XCoordB, 0.0, 0.0]
+    FastFlow: *DefaultFastFlow
+    Verbosity: Verbose
+  ObservationAhC:
+    InitialGuess:
+      LMax: 20
+      Radius: 10.0
+      Center: [0.0, 0.0, 0.0]
+    FastFlow: *DefaultFastFlow
+    Verbosity: Verbose
+  ControlSystemAhA: *AhA
+  ControlSystemAhB: *AhB
+  ControlSystemCharSpeedAhA: *AhA
+  ControlSystemCharSpeedAhB: *AhB
+
+InterpolationTargets:
+  BondiSachsInterpolation:
+    LMax: 16
+    Radius: [100, 150, 200]
+    Center: [0, 0, 0]
+    AngularOrdering: Cce
+  ObservationExcisionBoundaryA: &ExBdryA
+    LMax: *LMax
+    Center: [*XCoordA, 0., 0.]
+    Radius: *ExcisionRadiusA
+    AngularOrdering: "Strahlkorper"
+  ObservationExcisionBoundaryB: &ExBdryB
+    LMax: *LMax
+    Center: [*XCoordB, 0., 0.]
+    Radius: *ExcisionRadiusB
+    AngularOrdering: "Strahlkorper"
+  ControlSystemCharSpeedExcisionA: *ExBdryA
+  ControlSystemCharSpeedExcisionB: *ExBdryB
+
+ControlSystems:
+  WriteDataToDisk: true
+  MeasurementsPerUpdate: 4
+  Verbosity: Silent
+  Expansion:
+    IsActive: true
+    Averager:
+      AverageTimescaleFraction: 0.25
+      Average0thDeriv: false
+    Controller:
+      UpdateFraction: 0.03
+    TimescaleTuner:
+      InitialTimescales: [0.2]
+      MinTimescale: 1.0e-2
+      MaxTimescale: 10.0
+      IncreaseThreshold: 2.5e-4
+      DecreaseThreshold: 1.0e-3
+      IncreaseFactor: 1.01
+      DecreaseFactor: 0.98
+    ControlError:
+  Rotation:
+    IsActive: true
+    Averager:
+      AverageTimescaleFraction: 0.25
+      Average0thDeriv: false
+    Controller:
+      UpdateFraction: 0.03
+    TimescaleTuner:
+      InitialTimescales: [0.2, 0.2, 0.2]
+      MinTimescale: 1.0e-2
+      MaxTimescale: 10.0
+      IncreaseThreshold: 2.5e-4
+      DecreaseThreshold: 1.0e-3
+      IncreaseFactor: 1.01
+      DecreaseFactor: 0.98
+    ControlError:
+  ShapeA: &ShapeControl
+    IsActive: true
+    Averager:
+      AverageTimescaleFraction: 0.25
+      Average0thDeriv: false
+    Controller:
+      UpdateFraction: 0.03
+    TimescaleTuner:
+      InitialTimescales: 2.0
+      MinTimescale: 1.0e-2
+      MaxTimescale: 10.0
+      IncreaseThreshold: 2.5e-4
+      DecreaseThreshold: 1.0e-3
+      IncreaseFactor: 1.01
+      DecreaseFactor: 0.98
+    ControlError:
+  ShapeB: *ShapeControl
+  SizeA: &SizeControl
+    IsActive: true
+    Averager:
+      AverageTimescaleFraction: 0.25
+      Average0thDeriv: true
+    Controller:
+      UpdateFraction: 0.06
+    TimescaleTuner:
+      InitialTimescales: 0.2
+      MinTimescale: 1.0e-4
+      MaxTimescale: 20.0
+      IncreaseThreshold: 2.5e-4
+      DecreaseThreshold: 1.0e-3
+      IncreaseFactor: 1.01
+      DecreaseFactor: 1.0
+    ControlError:
+      MaxNumTimesForZeroCrossingPredictor: 4
+      SmoothAvgTimescaleFraction: 0.25
+      DeltaRDriftOutwardOptions: None
+      SmootherTuner:
+        InitialTimescales: [0.2]
+        MinTimescale: 1.0e-4
+        MaxTimescale: 20.0
+        IncreaseThreshold: 2.5e-4
+        DecreaseThreshold: 1.0e-3
+        IncreaseFactor: 1.01
+        DecreaseFactor: 0.9
+  SizeB: *SizeControl
+
+ResourceInfo:
+  AvoidGlobalProc0: false
+  Singletons: Auto

--- a/support/Pipelines/Bbh/Ringdown.py
+++ b/support/Pipelines/Bbh/Ringdown.py
@@ -1,0 +1,154 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import logging
+from pathlib import Path
+from typing import Optional, Union
+
+import click
+import yaml
+from rich.pretty import pretty_repr
+
+from spectre.support.Schedule import schedule, scheduler_options
+
+logger = logging.getLogger(__name__)
+
+RINGDOWN_INPUT_FILE_TEMPLATE = Path(__file__).parent / "Ringdown.yaml"
+
+
+def ringdown_parameters(
+    inspiral_input_file: dict,
+    inspiral_run_dir: Union[str, Path],
+    refinement_level: int,
+    polynomial_order: int,
+) -> dict:
+    """Determine ringdown parameters from the inspiral.
+
+    These parameters fill the 'RINGDOWN_INPUT_FILE_TEMPLATE'.
+
+    Arguments:
+      inspiral_input_file: Inspiral input file as a dictionary.
+      id_run_dir: Directory of the inspiral run. Paths in the input file
+        are relative to this directory.
+      refinement_level: h-refinement level.
+      polynomial_order: p-refinement level.
+    """
+    return {
+        # Initial data files
+        "IdFileGlob": str(
+            Path(inspiral_run_dir).resolve()
+            / (inspiral_input_file["Observers"]["VolumeFileName"] + "*.h5")
+        ),
+        # Resolution
+        "L": refinement_level,
+        "P": polynomial_order,
+    }
+
+
+def start_ringdown(
+    inspiral_input_file_path: Union[str, Path],
+    refinement_level: int,
+    polynomial_order: int,
+    inspiral_run_dir: Optional[Union[str, Path]] = None,
+    ringdown_input_file_template: Union[
+        str, Path
+    ] = RINGDOWN_INPUT_FILE_TEMPLATE,
+    **scheduler_kwargs,
+):
+    """Schedule a ringdown simulation from the inspiral.
+
+    Point the INSPIRAL_INPUT_FILE_PATH to the input file of the last inspiral
+    segment. Also specify 'inspiral_run_dir' if the simulation was run in a
+    different directory than where the input file is. Parameters for the
+    ringdown will be determined from the inspiral and inserted into the
+    'ringdown_input_file_template'. The remaining options are forwarded to the
+    'schedule' command. See 'schedule' docs for details.
+    """
+    logger.warning(
+        "The BBH pipeline is still experimental. Please review the"
+        " generated input files."
+    )
+
+    # Determine ringdown parameters from inspiral
+    with open(inspiral_input_file_path, "r") as open_input_file:
+        _, inspiral_input_file = yaml.safe_load_all(open_input_file)
+    if inspiral_run_dir is None:
+        inspiral_run_dir = Path(inspiral_input_file_path).resolve().parent
+    ringdown_params = ringdown_parameters(
+        inspiral_input_file,
+        inspiral_run_dir,
+        refinement_level=refinement_level,
+        polynomial_order=polynomial_order,
+    )
+    logger.debug(f"Ringdown parameters: {pretty_repr(ringdown_params)}")
+
+    # Schedule!
+    return schedule(
+        ringdown_input_file_template, **ringdown_params, **scheduler_kwargs
+    )
+
+
+@click.command(name="start-ringdown", help=start_ringdown.__doc__)
+@click.argument(
+    "inspiral_input_file_path",
+    type=click.Path(
+        exists=True,
+        file_okay=True,
+        dir_okay=False,
+        readable=True,
+        path_type=Path,
+    ),
+)
+@click.option(
+    "-i",
+    "--inspiral-run-dir",
+    type=click.Path(
+        exists=True,
+        file_okay=False,
+        dir_okay=True,
+        readable=True,
+        path_type=Path,
+    ),
+    help=(
+        "Directory of the last inspiral segment. Paths in the input file are"
+        " relative to this directory."
+    ),
+    show_default="directory of the INSPIRAL_INPUT_FILE_PATH",
+)
+@click.option(
+    "--ringdown-input-file-template",
+    type=click.Path(
+        exists=True,
+        file_okay=True,
+        dir_okay=False,
+        readable=True,
+        path_type=Path,
+    ),
+    default=RINGDOWN_INPUT_FILE_TEMPLATE,
+    help="Input file template for the ringdown.",
+    show_default=True,
+)
+@click.option(
+    "--refinement-level",
+    "-L",
+    type=int,
+    help="h-refinement level.",
+    default=0,
+    show_default=True,
+)
+@click.option(
+    "--polynomial-order",
+    "-P",
+    type=int,
+    help="p-refinement level.",
+    default=5,
+    show_default=True,
+)
+@scheduler_options
+def start_ringdown_command(**kwargs):
+    _rich_traceback_guard = True  # Hide traceback until here
+    start_ringdown(**kwargs)
+
+
+if __name__ == "__main__":
+    start_ringdown_command(help_option_names=["-h", "--help"])

--- a/support/Pipelines/Bbh/Ringdown.yaml
+++ b/support/Pipelines/Bbh/Ringdown.yaml
@@ -1,0 +1,241 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+Executable: EvolveGhSingleBlackHole
+
+---
+
+# Note: most of the parameters in this file are just made up. They should be
+# replaced with values that make sense once we have a better idea of the
+# transition to ringdown.
+
+InitialData:
+  NumericInitialData:
+    FileGlob: "{{ IdFileGlob }}"
+    Subgroup: "VolumeData"
+    ObservationValue: Last
+    Interpolate: True
+    Variables:
+      SpacetimeMetric: SpacetimeMetric
+      Pi: Pi
+
+DomainCreator:
+  Sphere:
+    InnerRadius: &InnerRadius 2.0
+    OuterRadius: 1000.0
+    Interior:
+      ExciseWithBoundaryCondition:
+        DemandOutgoingCharSpeeds:
+    InitialRefinement:
+      Shell0: [{{ L }}, {{ L }}, {{ L }}]
+      Shell1: [{{ L }}, {{ L }}, {{ L + 2 }}]
+    InitialGridPoints: {{ P + 1 }}
+    UseEquiangularMap: True
+    EquatorialCompression: None
+    RadialPartitioning: [30.0]
+    RadialDistribution: [Logarithmic, Linear]
+    WhichWedges: All
+    TimeDependentMaps: None
+    OuterBoundaryCondition:
+      ConstraintPreservingBjorhus:
+        Type: ConstraintPreservingPhysical
+
+Evolution:
+  InitialTime: 0.0
+  InitialTimeStep: 0.01
+  TimeStepper:
+    AdamsBashforth:
+      Order: 1
+
+EvolutionSystem:
+  GeneralizedHarmonic:
+    GaugeCondition:
+      DampedHarmonic:
+        SpatialDecayWidth: 17.0152695482514
+        Amplitudes: [1.0, 1.0, 1.0]
+        Exponents: [2, 2, 2]
+    # The parameter choices here come from our experience with the Spectral
+    # Einstein Code (SpEC). They should be suitable for evolutions of a
+    # perturbation of a Kerr-Schild black hole.
+    DampingFunctionGamma0:
+      GaussianPlusConstant:
+        Constant: 0.001
+        Amplitude: 3.0
+        Width: 11.313708499
+        Center: [0.0, 0.0, 0.0]
+    DampingFunctionGamma1:
+      GaussianPlusConstant:
+        Constant: -1.0
+        Amplitude: 0.0
+        Width: 11.313708499
+        Center: [0.0, 0.0, 0.0]
+    DampingFunctionGamma2:
+      GaussianPlusConstant:
+        Constant: 0.001
+        Amplitude: 1.0
+        Width: 11.313708499
+        Center: [0.0, 0.0, 0.0]
+
+Filtering:
+  ExpFilter0:
+    Alpha: 36.0
+    HalfPower: 24
+    Enable: false
+    BlocksToFilter: All
+
+SpatialDiscretization:
+  BoundaryCorrection:
+    UpwindPenalty:
+  DiscontinuousGalerkin:
+    Formulation: StrongInertial
+    Quadrature: GaussLobatto
+
+Observers:
+  VolumeFileName: "BbhVolume"
+  ReductionFileName: "BbhReductions"
+  SurfaceFileName: "BbhSurfaces"
+
+PhaseChangeAndTriggers:
+  - Trigger:
+      Slabs:
+       EvenlySpaced:
+         # Current implementation checks wallclock at these global syncs
+         Interval: 100
+         Offset: 0
+    PhaseChanges:
+      - CheckpointAndExitAfterWallclock:
+          WallclockHours: 23.5
+
+EventsAndTriggers:
+  - Trigger:
+      Slabs:
+        EvenlySpaced:
+          Interval: 1
+          Offset: 0
+    Events:
+      - ObserveTimeStep:
+          SubfileName: TimeSteps
+          PrintTimeToTerminal: True
+          ObservePerCore: False
+      - ObserveNorms:
+          SubfileName: Norms
+          TensorsToObserve:
+          - Name: Lapse
+            NormType: L2Norm
+            Components: Individual
+          - Name: PointwiseL2Norm(GaugeConstraint)
+            NormType: L2Norm
+            Components: Sum
+          - Name: PointwiseL2Norm(ThreeIndexConstraint)
+            NormType: L2Norm
+            Components: Sum
+          - Name: PointwiseL2Norm(FourIndexConstraint)
+            NormType: L2Norm
+            Components: Sum
+  - Trigger:
+      Slabs:
+        EvenlySpaced:
+          Interval: 100
+          Offset: 0
+    Events:
+      - ObserveFields:
+          SubfileName: VolumeData
+          VariablesToObserve:
+            - SpacetimeMetric
+            - Pi
+            - Phi
+            - Lapse
+            - Shift
+            - PointwiseL2Norm(GaugeConstraint)
+            - PointwiseL2Norm(ThreeIndexConstraint)
+            - PointwiseL2Norm(FourIndexConstraint)
+          InterpolateToMesh: None
+          CoordinatesFloatingPointType: Double
+          FloatingPointTypes: [Double]
+      - ApparentHorizon
+      - ExcisionBoundary
+  # Never terminate... run until something fails!
+
+EventsAndDenseTriggers:
+
+Interpolator:
+  DumpVolumeDataOnFailure: false
+
+ApparentHorizons:
+  ApparentHorizon: &Ah
+    InitialGuess:
+      LMax: &LMax 4
+      Radius: 2.2
+      Center: [0., 0., 0.]
+    FastFlow:
+      Flow: Fast
+      Alpha: 1.0
+      Beta: 0.5
+      AbsTol: 1e-12
+      TruncationTol: 1e-2
+      DivergenceTol: 1.2
+      DivergenceIter: 5
+      MaxIts: 100
+    Verbosity: Verbose
+  ControlSystemSingleAh: *Ah
+  ControlSystemCharSpeedAh: *Ah
+
+InterpolationTargets:
+  ExcisionBoundary: &ExBdry
+    LMax: *LMax
+    Center: [0., 0., 0.]
+    Radius: *InnerRadius
+    AngularOrdering: "Strahlkorper"
+  ControlSystemCharSpeedExcision: *ExBdry
+
+ControlSystems:
+  WriteDataToDisk: false
+  MeasurementsPerUpdate: 4
+  Verbosity: Silent
+  Shape:
+    IsActive: false
+    Averager:
+      AverageTimescaleFraction: 0.25
+      Average0thDeriv: false
+    Controller:
+      UpdateFraction: 0.03
+    TimescaleTuner:
+      InitialTimescales: 0.2
+      MinTimescale: 1.0e-2
+      MaxTimescale: 10.0
+      IncreaseThreshold: 2.5e-4
+      DecreaseThreshold: 1.0e-3
+      IncreaseFactor: 1.01
+      DecreaseFactor: 0.98
+    ControlError:
+  Size:
+    IsActive: false
+    Averager:
+      AverageTimescaleFraction: 0.25
+      Average0thDeriv: true
+    Controller:
+      UpdateFraction: 0.06
+    TimescaleTuner:
+      InitialTimescales: 0.2
+      MinTimescale: 1.0e-4
+      MaxTimescale: 20.0
+      IncreaseThreshold: 2.5e-4
+      DecreaseThreshold: 1.0e-3
+      IncreaseFactor: 1.01
+      DecreaseFactor: 1.0
+    ControlError:
+      MaxNumTimesForZeroCrossingPredictor: 4
+      SmoothAvgTimescaleFraction: 0.25
+      DeltaRDriftOutwardOptions: None
+      SmootherTuner:
+        InitialTimescales: [0.2]
+        MinTimescale: 1.0e-4
+        MaxTimescale: 20.0
+        IncreaseThreshold: 2.5e-4
+        DecreaseThreshold: 1.0e-3
+        IncreaseFactor: 1.01
+        DecreaseFactor: 0.9
+
+ResourceInfo:
+  AvoidGlobalProc0: false
+  Singletons: Auto

--- a/support/Pipelines/Bbh/__init__.py
+++ b/support/Pipelines/Bbh/__init__.py
@@ -1,0 +1,22 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import click
+
+from .InitialData import generate_id_command
+from .Inspiral import start_inspiral_command
+from .Ringdown import start_ringdown_command
+
+
+@click.group(name="bbh")
+def bbh_pipeline():
+    """Pipeline for binary black hole simulations."""
+    pass
+
+
+bbh_pipeline.add_command(generate_id_command)
+bbh_pipeline.add_command(start_inspiral_command)
+bbh_pipeline.add_command(start_ringdown_command)
+
+if __name__ == "__main__":
+    bbh_pipeline(help_option_names=["-h", "--help"])

--- a/support/Pipelines/CMakeLists.txt
+++ b/support/Pipelines/CMakeLists.txt
@@ -1,5 +1,4 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-add_subdirectory(Pipelines)
-add_subdirectory(Python)
+add_subdirectory(Bbh)

--- a/support/Python/__main__.py
+++ b/support/Python/__main__.py
@@ -20,6 +20,7 @@ logger = logging.getLogger(__name__)
 class Cli(click.MultiCommand):
     def list_commands(self, ctx):
         return [
+            "bbh",
             "clean-output",
             "combine-h5",
             "delete-subfiles",
@@ -41,6 +42,10 @@ class Cli(click.MultiCommand):
         ]
 
     def get_command(self, ctx, name):
+        if name == "bbh":
+            from spectre.Pipelines.Bbh import bbh_pipeline
+
+            return bbh_pipeline
         if name == "clean-output":
             from spectre.tools.CleanOutput import clean_output_command
 

--- a/tests/support/CMakeLists.txt
+++ b/tests/support/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
+add_subdirectory(Pipelines)
 add_subdirectory(Python)

--- a/tests/support/Pipelines/Bbh/CMakeLists.txt
+++ b/tests/support/Pipelines/Bbh/CMakeLists.txt
@@ -1,0 +1,32 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+spectre_add_python_bindings_test(
+  "support.Pipelines.Bbh.InitialData"
+  Test_InitialData.py
+  "Python"
+  None)
+
+spectre_add_python_bindings_test(
+  "support.Pipelines.Bbh.Inspiral"
+  Test_Inspiral.py
+  "Python"
+  None)
+
+spectre_add_python_bindings_test(
+  "support.Pipelines.Bbh.Ringdown"
+  Test_Ringdown.py
+  "Python"
+  None)
+
+if (BUILD_PYTHON_BINDINGS)
+  set_tests_properties(
+    "support.Pipelines.Bbh.InitialData"
+    PROPERTIES TIMEOUT 40)
+  set_tests_properties(
+    "support.Pipelines.Bbh.Inspiral"
+    PROPERTIES TIMEOUT 40)
+  set_tests_properties(
+    "support.Pipelines.Bbh.Ringdown"
+    PROPERTIES TIMEOUT 40)
+endif()

--- a/tests/support/Pipelines/Bbh/Test_InitialData.py
+++ b/tests/support/Pipelines/Bbh/Test_InitialData.py
@@ -1,0 +1,81 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import logging
+import shutil
+import unittest
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from spectre.Informer import unit_test_build_path
+from spectre.Pipelines.Bbh.InitialData import generate_id_command, id_parameters
+
+
+class TestInitialData(unittest.TestCase):
+    def setUp(self):
+        self.test_dir = Path(
+            unit_test_build_path(), "support/Pipelines/Bbh/InitialData"
+        )
+        shutil.rmtree(self.test_dir, ignore_errors=True)
+        self.test_dir.mkdir(parents=True, exist_ok=True)
+        self.bin_dir = Path(unit_test_build_path(), "../../bin").resolve()
+
+    def tearDown(self):
+        shutil.rmtree(self.test_dir, ignore_errors=True)
+
+    def test_generate_id(self):
+        params = id_parameters(
+            mass_ratio=1.5,
+            separation=20.0,
+            orbital_angular_velocity=0.01,
+            refinement_level=1,
+            polynomial_order=5,
+        )
+        self.assertEqual(params["MassRight"], 0.6)
+        self.assertEqual(params["MassLeft"], 0.4)
+        self.assertEqual(params["XRight"], 8.0)
+        self.assertEqual(params["XLeft"], -12.0)
+        self.assertAlmostEqual(params["ExcisionRadiusRight"], 1.068)
+        self.assertAlmostEqual(params["ExcisionRadiusLeft"], 0.712)
+        self.assertEqual(params["OrbitalAngularVelocity"], 0.01)
+        self.assertEqual(params["L"], 1)
+        self.assertEqual(params["P"], 5)
+        # COM is zero
+        self.assertAlmostEqual(
+            params["MassRight"] * params["XRight"]
+            + params["MassLeft"] * params["XLeft"],
+            0.0,
+        )
+
+    def test_cli(self):
+        # Not using `CliRunner.invoke()` because it runs in an isolated
+        # environment and doesn't work with MPI in the container.
+        try:
+            generate_id_command(
+                [
+                    "--mass-ratio",
+                    "1.5",
+                    "--separation",
+                    "20",
+                    "--orbital-angular-velocity",
+                    "0.01",
+                    "--refinement-level",
+                    "1",
+                    "--polynomial-order",
+                    "5",
+                    "-o",
+                    str(self.test_dir),
+                    "--no-submit",
+                    "-e",
+                    str(self.bin_dir / "SolveXcts"),
+                ]
+            )
+        except SystemExit as e:
+            self.assertEqual(e.code, 0)
+        self.assertTrue((self.test_dir / "InitialData.yaml").exists())
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.DEBUG)
+    unittest.main(verbosity=2)

--- a/tests/support/Pipelines/Bbh/Test_Inspiral.py
+++ b/tests/support/Pipelines/Bbh/Test_Inspiral.py
@@ -1,0 +1,92 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import logging
+import shutil
+import unittest
+from pathlib import Path
+
+import yaml
+from click.testing import CliRunner
+
+from spectre.Informer import unit_test_build_path
+from spectre.Pipelines.Bbh.InitialData import generate_id
+from spectre.Pipelines.Bbh.Inspiral import (
+    inspiral_parameters,
+    start_inspiral_command,
+)
+
+
+class TestInspiral(unittest.TestCase):
+    def setUp(self):
+        self.test_dir = Path(
+            unit_test_build_path(), "support/Pipelines/Bbh/Inspiral"
+        )
+        shutil.rmtree(self.test_dir, ignore_errors=True)
+        self.test_dir.mkdir(parents=True, exist_ok=True)
+        self.bin_dir = Path(unit_test_build_path(), "../../bin").resolve()
+        generate_id(
+            mass_ratio=1.5,
+            separation=20.0,
+            orbital_angular_velocity=0.01,
+            refinement_level=1,
+            polynomial_order=5,
+            run_dir=self.test_dir / "ID",
+            scheduler=None,
+            submit=False,
+            executable=str(self.bin_dir / "SolveXcts"),
+        )
+        self.id_dir = self.test_dir / "ID"
+
+    def tearDown(self):
+        shutil.rmtree(self.test_dir, ignore_errors=True)
+
+    def test_inspiral_parameters(self):
+        with open(self.id_dir / "InitialData.yaml") as open_input_file:
+            _, id_input_file = yaml.safe_load_all(open_input_file)
+        params = inspiral_parameters(
+            id_input_file=id_input_file,
+            id_run_dir=self.id_dir,
+            refinement_level=1,
+            polynomial_order=5,
+        )
+        self.assertEqual(
+            params["IdFileGlob"],
+            str((self.id_dir).resolve() / "BbhVolume*.h5"),
+        )
+        self.assertAlmostEqual(params["ExcisionRadiusA"], 1.068)
+        self.assertAlmostEqual(params["ExcisionRadiusB"], 0.712)
+        self.assertEqual(params["XCoordA"], 8.0)
+        self.assertEqual(params["XCoordB"], -12.0)
+        self.assertEqual(params["InitialAngularVelocity"], 0.01)
+        self.assertEqual(params["L"], 1)
+        self.assertEqual(params["P"], 5)
+
+    def test_cli(self):
+        # Not using `CliRunner.invoke()` because it runs in an isolated
+        # environment and doesn't work with MPI in the container.
+        try:
+            start_inspiral_command(
+                [
+                    str(self.id_dir / "InitialData.yaml"),
+                    "--refinement-level",
+                    "1",
+                    "--polynomial-order",
+                    "5",
+                    "-O",
+                    str(self.test_dir / "Inspiral"),
+                    "--no-submit",
+                    "-e",
+                    str(self.bin_dir / "EvolveGhBinaryBlackHole"),
+                ]
+            )
+        except SystemExit as e:
+            self.assertEqual(e.code, 0)
+        self.assertTrue(
+            (self.test_dir / "Inspiral/Segment_0000/Inspiral.yaml").exists()
+        )
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.DEBUG)
+    unittest.main(verbosity=2)

--- a/tests/support/Pipelines/Bbh/Test_Ringdown.py
+++ b/tests/support/Pipelines/Bbh/Test_Ringdown.py
@@ -1,0 +1,98 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import logging
+import shutil
+import unittest
+from pathlib import Path
+
+import yaml
+from click.testing import CliRunner
+
+from spectre.Informer import unit_test_build_path
+from spectre.Pipelines.Bbh.InitialData import generate_id
+from spectre.Pipelines.Bbh.Inspiral import start_inspiral
+from spectre.Pipelines.Bbh.Ringdown import (
+    ringdown_parameters,
+    start_ringdown_command,
+)
+
+
+class TestInitialData(unittest.TestCase):
+    def setUp(self):
+        self.test_dir = Path(
+            unit_test_build_path(), "support/Pipelines/Bbh/Ringdown"
+        )
+        shutil.rmtree(self.test_dir, ignore_errors=True)
+        self.test_dir.mkdir(parents=True, exist_ok=True)
+        self.bin_dir = Path(unit_test_build_path(), "../../bin").resolve()
+        generate_id(
+            mass_ratio=1.5,
+            separation=20.0,
+            orbital_angular_velocity=0.01,
+            refinement_level=1,
+            polynomial_order=5,
+            run_dir=self.test_dir / "ID",
+            scheduler=None,
+            submit=False,
+            executable=str(self.bin_dir / "SolveXcts"),
+        )
+        self.id_dir = self.test_dir / "ID"
+        start_inspiral(
+            id_input_file_path=self.test_dir / "ID" / "InitialData.yaml",
+            refinement_level=1,
+            polynomial_order=5,
+            segments_dir=self.test_dir / "Inspiral",
+            scheduler=None,
+            submit=False,
+            executable=str(self.bin_dir / "EvolveGhBinaryBlackHole"),
+        )
+        self.inspiral_dir = self.test_dir / "Inspiral" / "Segment_0000"
+
+    def tearDown(self):
+        shutil.rmtree(self.test_dir, ignore_errors=True)
+
+    def test_id_parameters(self):
+        with open(self.inspiral_dir / "Inspiral.yaml") as open_input_file:
+            _, inspiral_input_file = yaml.safe_load_all(open_input_file)
+        params = ringdown_parameters(
+            inspiral_input_file,
+            self.inspiral_dir,
+            refinement_level=1,
+            polynomial_order=5,
+        )
+        self.assertEqual(
+            params["IdFileGlob"],
+            str((self.inspiral_dir).resolve() / "BbhVolume*.h5"),
+        )
+        self.assertEqual(params["L"], 1)
+        self.assertEqual(params["P"], 5)
+
+    def test_cli(self):
+        # Not using `CliRunner.invoke()` because it runs in an isolated
+        # environment and doesn't work with MPI in the container.
+        try:
+            start_ringdown_command(
+                [
+                    str(self.inspiral_dir / "Inspiral.yaml"),
+                    "--refinement-level",
+                    "1",
+                    "--polynomial-order",
+                    "5",
+                    "-O",
+                    str(self.test_dir / "Ringdown"),
+                    "--no-submit",
+                    "-e",
+                    str(self.bin_dir / "EvolveGhSingleBlackHole"),
+                ]
+            )
+        except SystemExit as e:
+            self.assertEqual(e.code, 0)
+        self.assertTrue(
+            (self.test_dir / "Ringdown/Segment_0000/Ringdown.yaml").exists()
+        )
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.DEBUG)
+    unittest.main(verbosity=2)

--- a/tests/support/Pipelines/CMakeLists.txt
+++ b/tests/support/Pipelines/CMakeLists.txt
@@ -1,5 +1,4 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-add_subdirectory(Pipelines)
-add_subdirectory(Python)
+add_subdirectory(Bbh)

--- a/tests/support/Python/Test_Schedule.py
+++ b/tests/support/Python/Test_Schedule.py
@@ -24,7 +24,7 @@ from spectre.support.Schedule import (
 
 class TestSchedule(unittest.TestCase):
     def setUp(self):
-        self.test_dir = Path(unit_test_build_path(), "Schedule")
+        self.test_dir = Path(unit_test_build_path(), "Schedule").resolve()
         self.test_dir.mkdir(parents=True, exist_ok=True)
         self.spectre_cli = (
             Path(unit_test_build_path()).parent.parent / "bin/spectre"


### PR DESCRIPTION
## Proposed changes

Tools to `generate-id` > `start-inspiral` > `start-ringdown`. No automation yet and barely any smart parameter choices, but this should provide a good starting point to flesh out the transition from inspiral to ringdown. See https://github.com/sxs-collaboration/spectre/issues/5021 for details on future plans.

Try it like this:

```sh
./bin/spectre bbh generate-id -q 1 -D 20 -w 0.015 -o ./ID
# wait...
./bin/spectre bbh start-inspiral ./ID/InitialData.yaml -O ./Ev/
# wait...
./bin/spectre bbh start-ringdown ./Ev/Inspiral.yaml -O ./Ringdown/
```

(this won't really work yet because the inspiral won't finish properly, but that's #4600)

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
