### PR TITLE
Fix status CLI if user directory can't be read

### DIFF
--- a/tools/Status/Status.py
+++ b/tools/Status/Status.py
@@ -290,6 +290,8 @@ def render_status(
     if not show_deleted:
         deleted_jobs = job_data[~job_data["WorkDir"].map(os.path.exists)]
         job_data.drop(deleted_jobs.index, inplace=True)
+        if len(job_data) == 0:
+            return
 
     # Keep only latest in a series of segments
     job_data[["SegmentsDir", "SegmentId"]] = [
@@ -313,6 +315,8 @@ def render_status(
                 & (job_data["SegmentId"] != latest_segment_id)
             ]
             job_data.drop(drop_segment_jobs.index, inplace=True)
+        if len(job_data) == 0:
+            return
 
     # Rename columns from SLURM name to user name
     job_data.rename(columns=AVAILABLE_COLUMNS, inplace=True)


### PR DESCRIPTION
## Proposed changes

Some early returns were missing if job list is empty after dropping some jobs. Fixes #5549.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
