### PR TITLE
Add TCI options to FFE subcell and fix TCI criteria for TildeQ 

### DIFF
--- a/src/Evolution/Systems/ForceFree/Subcell/CMakeLists.txt
+++ b/src/Evolution/Systems/ForceFree/Subcell/CMakeLists.txt
@@ -10,6 +10,7 @@ spectre_target_sources(
   SetInitialRdmpData.cpp
   TciOnDgGrid.cpp
   TciOnFdGrid.cpp
+  TciOptions.cpp
   )
 
 spectre_target_headers(
@@ -21,4 +22,5 @@ spectre_target_headers(
   Subcell.hpp
   TciOnDgGrid.hpp
   TciOnFdGrid.hpp
+  TciOptions.hpp
   )

--- a/src/Evolution/Systems/ForceFree/Subcell/SetInitialRdmpData.cpp
+++ b/src/Evolution/Systems/ForceFree/Subcell/SetInitialRdmpData.cpp
@@ -16,7 +16,6 @@ void SetInitialRdmpData::apply(
     const gsl::not_null<evolution::dg::subcell::RdmpTciData*> rdmp_tci_data,
     const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_e,
     const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_b,
-    const Scalar<DataVector>& tilde_q,
     const evolution::dg::subcell::ActiveGrid active_grid,
     const Mesh<3>& dg_mesh, const Mesh<3>& subcell_mesh) {
   if (active_grid == evolution::dg::subcell::ActiveGrid::Subcell) {
@@ -24,11 +23,9 @@ void SetInitialRdmpData::apply(
     const Scalar<DataVector> tilde_b_magnitude = magnitude(tilde_b);
 
     rdmp_tci_data->max_variables_values =
-        DataVector{max(get(tilde_e_magnitude)), max(get(tilde_b_magnitude)),
-                   max(get(tilde_q))};
+        DataVector{max(get(tilde_e_magnitude)), max(get(tilde_b_magnitude))};
     rdmp_tci_data->min_variables_values =
-        DataVector{min(get(tilde_e_magnitude)), min(get(tilde_b_magnitude)),
-                   min(get(tilde_q))};
+        DataVector{min(get(tilde_e_magnitude)), min(get(tilde_b_magnitude))};
   } else {
     using std::max;
     using std::min;
@@ -38,17 +35,13 @@ void SetInitialRdmpData::apply(
         get(tilde_e_magnitude), dg_mesh, subcell_mesh.extents());
     const auto subcell_tilde_b_mag = evolution::dg::subcell::fd::project(
         get(tilde_b_magnitude), dg_mesh, subcell_mesh.extents());
-    const auto subcell_tilde_q = evolution::dg::subcell::fd::project(
-        get(tilde_q), dg_mesh, subcell_mesh.extents());
 
     rdmp_tci_data->max_variables_values =
         DataVector{max(max(get(tilde_e_magnitude)), max(subcell_tilde_e_mag)),
-                   max(max(get(tilde_b_magnitude)), max(subcell_tilde_b_mag)),
-                   max(max(get(tilde_q)), max(subcell_tilde_q))};
+                   max(max(get(tilde_b_magnitude)), max(subcell_tilde_b_mag))};
     rdmp_tci_data->min_variables_values =
         DataVector{min(min(get(tilde_e_magnitude)), min(subcell_tilde_e_mag)),
-                   min(min(get(tilde_b_magnitude)), min(subcell_tilde_b_mag)),
-                   min(min(get(tilde_q)), min(subcell_tilde_q))};
+                   min(min(get(tilde_b_magnitude)), min(subcell_tilde_b_mag))};
   }
 }
 

--- a/src/Evolution/Systems/ForceFree/Subcell/SetInitialRdmpData.hpp
+++ b/src/Evolution/Systems/ForceFree/Subcell/SetInitialRdmpData.hpp
@@ -30,17 +30,17 @@ namespace ForceFree::subcell {
  * Used on the subcells after the TCI marked the DG solution as inadmissible.
  */
 struct SetInitialRdmpData {
-  using argument_tags = tmpl::list<
-      ForceFree::Tags::TildeE, ForceFree::Tags::TildeB, ForceFree::Tags::TildeQ,
-      evolution::dg::subcell::Tags::ActiveGrid, ::domain::Tags::Mesh<3>,
-      evolution::dg::subcell::Tags::Mesh<3>>;
+  using argument_tags =
+      tmpl::list<ForceFree::Tags::TildeE, ForceFree::Tags::TildeB,
+                 evolution::dg::subcell::Tags::ActiveGrid,
+                 ::domain::Tags::Mesh<3>,
+                 evolution::dg::subcell::Tags::Mesh<3>>;
   using return_tags = tmpl::list<evolution::dg::subcell::Tags::DataForRdmpTci>;
 
   static void apply(
       gsl::not_null<evolution::dg::subcell::RdmpTciData*> rdmp_tci_data,
       const tnsr::I<DataVector, 3, Frame::Inertial>& subcell_tilde_e,
       const tnsr::I<DataVector, 3, Frame::Inertial>& subcell_tilde_b,
-      const Scalar<DataVector>& subcell_tilde_q,
       evolution::dg::subcell::ActiveGrid active_grid, const Mesh<3>& dg_mesh,
       const Mesh<3>& subcell_mesh);
 };

--- a/src/Evolution/Systems/ForceFree/Subcell/TciOnDgGrid.hpp
+++ b/src/Evolution/Systems/ForceFree/Subcell/TciOnDgGrid.hpp
@@ -12,6 +12,7 @@
 #include "Evolution/DgSubcell/Tags/DataForRdmpTci.hpp"
 #include "Evolution/DgSubcell/Tags/Mesh.hpp"
 #include "Evolution/DgSubcell/Tags/SubcellOptions.hpp"
+#include "Evolution/Systems/ForceFree/Subcell/TciOptions.hpp"
 #include "Evolution/Systems/ForceFree/Tags.hpp"
 #include "PointwiseFunctions/GeneralRelativity/TagsDeclarations.hpp"
 #include "Utilities/TMPL.hpp"
@@ -43,7 +44,9 @@ namespace ForceFree::subcell {
  * <tr><td> apply the Persson TCI to magnitude of `TildeB`
  * <td> `-2`
  *
- * <tr><td> apply the Persson TCI to `TildeQ`
+ * <tr><td> apply the Persson TCI to `TildeQ` if \f$\max(|\tilde{q}|)\f$ is
+ * greater than `tci_options.tilde_q_cutoff`.
+ * Check is skipped if `tci_options.tilde_q_cutoff == DoNotCheckTildeQ`.
  * <td> `-3`
  *
  * <tr><td> apply the RDMP TCI to magnitude of `TildeE`
@@ -51,9 +54,6 @@ namespace ForceFree::subcell {
  *
  * <tr><td> apply the RDMP TCI to magnitude of `TildeB`
  * <td> `-5`
- *
- * <tr><td> apply the RDMP TCI to `TildeQ`
- * <td> `-6`
  *
  * </table>
  *
@@ -80,9 +80,10 @@ class TciOnDgGrid {
  public:
   using return_tags = tmpl::list<>;
   using argument_tags =
-      tmpl::list<Tags::TildeE, Tags::TildeB, Tags::TildeQ,
-                 domain::Tags::Mesh<3>, evolution::dg::subcell::Tags::Mesh<3>,
-                 evolution::dg::subcell::Tags::DataForRdmpTci,
+      tmpl::list<ForceFree::Tags::TildeE, ForceFree::Tags::TildeB,
+                 ForceFree::Tags::TildeQ, domain::Tags::Mesh<3>,
+                 evolution::dg::subcell::Tags::Mesh<3>,
+                 evolution::dg::subcell::Tags::DataForRdmpTci, Tags::TciOptions,
                  evolution::dg::subcell::Tags::SubcellOptions<3>>;
 
   static std::tuple<int, evolution::dg::subcell::RdmpTciData> apply(
@@ -91,6 +92,7 @@ class TciOnDgGrid {
       const Scalar<DataVector>& tilde_q, const Mesh<3>& dg_mesh,
       const Mesh<3>& subcell_mesh,
       const evolution::dg::subcell::RdmpTciData& past_rdmp_tci_data,
+      const TciOptions& tci_options,
       const evolution::dg::subcell::SubcellOptions& subcell_options,
       double persson_exponent, bool /*element_stays_on_dg*/);
 };

--- a/src/Evolution/Systems/ForceFree/Subcell/TciOnFdGrid.hpp
+++ b/src/Evolution/Systems/ForceFree/Subcell/TciOnFdGrid.hpp
@@ -12,6 +12,7 @@
 #include "Evolution/DgSubcell/Tags/DataForRdmpTci.hpp"
 #include "Evolution/DgSubcell/Tags/Mesh.hpp"
 #include "Evolution/DgSubcell/Tags/SubcellOptions.hpp"
+#include "Evolution/Systems/ForceFree/Subcell/TciOptions.hpp"
 #include "Evolution/Systems/ForceFree/Tags.hpp"
 #include "PointwiseFunctions/GeneralRelativity/TagsDeclarations.hpp"
 #include "Utilities/TMPL.hpp"
@@ -44,7 +45,9 @@ namespace ForceFree::subcell {
  * <tr><td> apply the Persson TCI to magnitude of `TildeB`
  * <td> `+2`
  *
- * <tr><td> apply the Persson TCI to `TildeQ`
+ * <tr><td> apply the Persson TCI to `TildeQ` if \f$\max(|\tilde{q}|)\f$ is
+ * larger than `tci_options.cutoff_tilde_q`.
+ * Check is skipped if `tci_options.tilde_q_cutoff == DoNotCheckTildeQ`.
  * <td> `+3`
  *
  * <tr><td> apply the RDMP TCI to magnitude of `TildeE`
@@ -52,9 +55,6 @@ namespace ForceFree::subcell {
  *
  * <tr><td> apply the RDMP TCI to magnitude of `TildeB`
  * <td> `+5`
- *
- * <tr><td> apply the RDMP TCI to `TildeQ`
- * <td> `+6`
  *
  * </table>
  *
@@ -81,9 +81,10 @@ class TciOnFdGrid {
  public:
   using return_tags = tmpl::list<>;
   using argument_tags =
-      tmpl::list<Tags::TildeE, Tags::TildeB, Tags::TildeQ,
-                 domain::Tags::Mesh<3>, evolution::dg::subcell::Tags::Mesh<3>,
-                 evolution::dg::subcell::Tags::DataForRdmpTci,
+      tmpl::list<ForceFree::Tags::TildeE, ForceFree::Tags::TildeB,
+                 ForceFree::Tags::TildeQ, domain::Tags::Mesh<3>,
+                 evolution::dg::subcell::Tags::Mesh<3>,
+                 evolution::dg::subcell::Tags::DataForRdmpTci, Tags::TciOptions,
                  evolution::dg::subcell::Tags::SubcellOptions<3>>;
 
   static std::tuple<int, evolution::dg::subcell::RdmpTciData> apply(
@@ -92,6 +93,7 @@ class TciOnFdGrid {
       const Scalar<DataVector>& subcell_tilde_q, const Mesh<3>& dg_mesh,
       const Mesh<3>& subcell_mesh,
       const evolution::dg::subcell::RdmpTciData& past_rdmp_tci_data,
+      const TciOptions& tci_options,
       const evolution::dg::subcell::SubcellOptions& subcell_options,
       double persson_exponent, bool need_rdmp_data_only);
 };

--- a/src/Evolution/Systems/ForceFree/Subcell/TciOptions.cpp
+++ b/src/Evolution/Systems/ForceFree/Subcell/TciOptions.cpp
@@ -1,0 +1,12 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/ForceFree/Subcell/TciOptions.hpp"
+
+#include <pup.h>
+
+#include "Utilities/Serialization/PupStlCpp17.hpp"
+
+namespace ForceFree::subcell {
+void TciOptions::pup(PUP::er& p) { p | tilde_q_cutoff; }
+}  // namespace ForceFree::subcell

--- a/src/Evolution/Systems/ForceFree/Subcell/TciOptions.hpp
+++ b/src/Evolution/Systems/ForceFree/Subcell/TciOptions.hpp
@@ -1,0 +1,75 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <limits>
+#include <optional>
+
+#include "DataStructures/DataBox/Tag.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Tags/OptionsGroup.hpp"
+#include "Options/Auto.hpp"
+#include "Options/String.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+namespace PUP {
+class er;
+}  // namespace PUP
+/// \endcond
+
+namespace ForceFree::subcell {
+
+struct TciOptions {
+ private:
+  struct DoNotCheckTildeQ {};
+
+ public:
+  /*!
+   * \brief The cutoff of the absolute value of the generalized charge density
+   * \f$\tilde{Q}\f$ in an element to apply the Persson TCI.
+   *
+   * If maximum absolute value of \f$\tilde{Q}\f$ is below this option value,
+   * the Persson TCI is not triggered for it.
+   */
+  struct TildeQCutoff {
+    using type = Options::Auto<double, DoNotCheckTildeQ>;
+    static constexpr Options::String help = {
+        "If maximum absolute value of TildeQ in an element is below this value "
+        "we do not apply the Persson TCI to TildeQ. To disable the check, set "
+        "this option to 'DoNotCheckTildeQ'."};
+  };
+
+  using options = tmpl::list<TildeQCutoff>;
+
+  static constexpr Options::String help = {
+      "Options for the troubled-cell indicator"};
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& /*p*/);
+
+  std::optional<double> tilde_q_cutoff{
+      std::numeric_limits<double>::signaling_NaN()};
+};
+
+namespace OptionTags {
+struct TciOptions {
+  using type = subcell::TciOptions;
+  static constexpr Options::String help = "TCI options for ForceFree system";
+  using group = ::dg::OptionTags::DiscontinuousGalerkinGroup;
+};
+}  // namespace OptionTags
+
+namespace Tags {
+struct TciOptions : db::SimpleTag {
+  using type = subcell::TciOptions;
+  using option_tags = tmpl::list<typename OptionTags::TciOptions>;
+
+  static constexpr bool pass_metavariables = false;
+  static type create_from_options(const type& tci_options) {
+    return tci_options;
+  }
+};
+}  // namespace Tags
+}  // namespace ForceFree::subcell

--- a/tests/Unit/Evolution/Systems/ForceFree/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/ForceFree/CMakeLists.txt
@@ -16,6 +16,7 @@ set(LIBRARY_SOURCES
   Subcell/Test_SetInitialRdmpData.cpp
   Subcell/Test_TciOnDgGrid.cpp
   Subcell/Test_TciOnFdGrid.cpp
+  Subcell/Test_TciOptions.cpp
   Test_Characteristics.cpp
   Test_ElectricCurrentDensity.cpp
   Test_ElectromagneticVariables.cpp

--- a/tests/Unit/Evolution/Systems/ForceFree/Subcell/Test_SetInitialRdmpData.cpp
+++ b/tests/Unit/Evolution/Systems/ForceFree/Subcell/Test_SetInitialRdmpData.cpp
@@ -42,14 +42,12 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.ForceFree.Subcell.SetInitialRdmpData",
   ForceFree::subcell::SetInitialRdmpData::apply(
       make_not_null(&rdmp_data), get<ForceFree::Tags::TildeE>(dg_vars),
       get<ForceFree::Tags::TildeB>(dg_vars),
-      get<ForceFree::Tags::TildeQ>(dg_vars),
       evolution::dg::subcell::ActiveGrid::Dg, dg_mesh, subcell_mesh);
 
   const auto& dg_tilde_e_magnitude =
       magnitude(get<ForceFree::Tags::TildeE>(dg_vars));
   const auto dg_tilde_b_magnitude =
       magnitude(get<ForceFree::Tags::TildeB>(dg_vars));
-  const auto& dg_tilde_q = get<ForceFree::Tags::TildeQ>(dg_vars);
 
   const auto projected_subcell_tilde_e_magnitude =
       Scalar<DataVector>(evolution::dg::subcell::fd::project(
@@ -57,7 +55,6 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.ForceFree.Subcell.SetInitialRdmpData",
   const auto projected_subcell_tilde_b_magnitude =
       Scalar<DataVector>(evolution::dg::subcell::fd::project(
           get(dg_tilde_b_magnitude), dg_mesh, subcell_mesh.extents()));
-  const auto& subcell_tilde_q = get<ForceFree::Tags::TildeQ>(subcell_vars);
 
   evolution::dg::subcell::RdmpTciData expected_dg_rdmp_data{};
   using std::max;
@@ -66,21 +63,18 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.ForceFree.Subcell.SetInitialRdmpData",
       DataVector{max(max(get(dg_tilde_e_magnitude)),
                      max(get(projected_subcell_tilde_e_magnitude))),
                  max(max(get(dg_tilde_b_magnitude)),
-                     max(get(projected_subcell_tilde_b_magnitude))),
-                 max(max(get(dg_tilde_q)), max(get(subcell_tilde_q)))};
+                     max(get(projected_subcell_tilde_b_magnitude)))};
   expected_dg_rdmp_data.min_variables_values =
       DataVector{min(min(get(dg_tilde_e_magnitude)),
                      min(get(projected_subcell_tilde_e_magnitude))),
                  min(min(get(dg_tilde_b_magnitude)),
-                     min(get(projected_subcell_tilde_b_magnitude))),
-                 min(min(get(dg_tilde_q)), min(get(subcell_tilde_q)))};
+                     min(get(projected_subcell_tilde_b_magnitude)))};
 
   CHECK(rdmp_data == expected_dg_rdmp_data);
 
   ForceFree::subcell::SetInitialRdmpData::apply(
       make_not_null(&rdmp_data), get<ForceFree::Tags::TildeE>(subcell_vars),
       get<ForceFree::Tags::TildeB>(subcell_vars),
-      get<ForceFree::Tags::TildeQ>(subcell_vars),
       evolution::dg::subcell::ActiveGrid::Subcell, dg_mesh, subcell_mesh);
 
   const auto subcell_tilde_e_magnitude =
@@ -90,11 +84,9 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.ForceFree.Subcell.SetInitialRdmpData",
 
   evolution::dg::subcell::RdmpTciData expected_subcell_rdmp_data{};
   expected_subcell_rdmp_data.max_variables_values = DataVector{
-      max(get(subcell_tilde_e_magnitude)), max(get(subcell_tilde_b_magnitude)),
-      max(get(subcell_tilde_q))};
+      max(get(subcell_tilde_e_magnitude)), max(get(subcell_tilde_b_magnitude))};
   expected_subcell_rdmp_data.min_variables_values = DataVector{
-      min(get(subcell_tilde_e_magnitude)), min(get(subcell_tilde_b_magnitude)),
-      min(get(subcell_tilde_q))};
+      min(get(subcell_tilde_e_magnitude)), min(get(subcell_tilde_b_magnitude))};
 
   CHECK(rdmp_data == expected_subcell_rdmp_data);
 }

--- a/tests/Unit/Evolution/Systems/ForceFree/Subcell/Test_TciOnFdGrid.cpp
+++ b/tests/Unit/Evolution/Systems/ForceFree/Subcell/Test_TciOnFdGrid.cpp
@@ -20,6 +20,7 @@
 #include "Evolution/DgSubcell/Tags/Mesh.hpp"
 #include "Evolution/DgSubcell/Tags/SubcellOptions.hpp"
 #include "Evolution/Systems/ForceFree/Subcell/TciOnFdGrid.hpp"
+#include "Evolution/Systems/ForceFree/Subcell/TciOptions.hpp"
 #include "Evolution/Systems/ForceFree/System.hpp"
 #include "Evolution/Systems/ForceFree/Tags.hpp"
 #include "NumericalAlgorithms/Spectral/Basis.hpp"
@@ -34,9 +35,10 @@ enum class TestThis {
   PerssonMagTildeE,
   PerssonMagTildeB,
   PerssonTildeQ,
+  PerssonTildeQBelowCutoff,
+  PerssonTildeQDoNotCheck,
   RdmpMagTildeE,
-  RdmpMagTildeB,
-  RdmpTildeQ
+  RdmpMagTildeB
 };
 
 void test(const TestThis test_this, const int expected_tci_status) {
@@ -76,12 +78,15 @@ void test(const TestThis test_this, const int expected_tci_status) {
       std::nullopt,
       fd::DerivativeOrder::Two};
 
+  const ForceFree::subcell::TciOptions tci_options{1.0e-10};
+
   auto box = db::create<db::AddSimpleTags<
       ::Tags::Variables<VarsForTciTest::tags_list>, ::domain::Tags::Mesh<3>,
       ::evolution::dg::subcell::Tags::Mesh<3>,
+      ForceFree::subcell::Tags::TciOptions,
       evolution::dg::subcell::Tags::SubcellOptions<3>,
       evolution::dg::subcell::Tags::DataForRdmpTci>>(
-      subcell_vars, dg_mesh, subcell_mesh, subcell_options,
+      subcell_vars, dg_mesh, subcell_mesh, tci_options, subcell_options,
       evolution::dg::subcell::RdmpTciData{});
 
   const size_t point_to_change = subcell_mesh.number_of_grid_points() / 2;
@@ -108,6 +113,20 @@ void test(const TestThis test_this, const int expected_tci_status) {
           get(*tilde_q_ptr)[point_to_change] *= 10.0;
         },
         make_not_null(&box));
+  } else if (test_this == TestThis::PerssonTildeQBelowCutoff) {
+    db::mutate<TildeQ>(
+        [point_to_change](const auto tilde_q_ptr) {
+          get(*tilde_q_ptr)[point_to_change] *= 10.0;
+          get(*tilde_q_ptr) *= 1e-20;
+        },
+        make_not_null(&box));
+  } else if (test_this == TestThis::PerssonTildeQDoNotCheck) {
+    db::mutate<TildeQ, ForceFree::subcell::Tags::TciOptions>(
+        [point_to_change](const auto tilde_q_ptr, const auto tci_options_ptr) {
+          get(*tilde_q_ptr)[point_to_change] *= 10.0;
+          tci_options_ptr->tilde_q_cutoff = std::nullopt;
+        },
+        make_not_null(&box));
   }
 
   // Set the RDMP TCI past data.
@@ -123,26 +142,22 @@ void test(const TestThis test_this, const int expected_tci_status) {
       subcell_mag_tilde_e, dg_mesh, subcell_mesh.extents(), DimByDim);
   const auto dg_mag_tilde_b = evolution::dg::subcell::fd::reconstruct(
       subcell_mag_tilde_b, dg_mesh, subcell_mesh.extents(), DimByDim);
-  const auto dg_tilde_q = evolution::dg::subcell::fd::reconstruct(
-      subcell_tilde_q, dg_mesh, subcell_mesh.extents(), DimByDim);
 
   evolution::dg::subcell::RdmpTciData past_rdmp_tci_data{};
   past_rdmp_tci_data.max_variables_values =
       DataVector{max(max(dg_mag_tilde_e), max(subcell_mag_tilde_e)),
-                 max(max(dg_mag_tilde_b), max(subcell_mag_tilde_b)),
-                 max(max(dg_tilde_q), max(subcell_tilde_q))};
+                 max(max(dg_mag_tilde_b), max(subcell_mag_tilde_b))};
   past_rdmp_tci_data.min_variables_values =
       DataVector{min(min(dg_mag_tilde_e), min(subcell_mag_tilde_e)),
-                 min(min(dg_mag_tilde_b), min(subcell_mag_tilde_b)),
-                 min(min(dg_tilde_q), min(subcell_tilde_q))};
+                 min(min(dg_mag_tilde_b), min(subcell_mag_tilde_b))};
 
   // Note : RDMP TCI data consists of max and min of subcell variables only when
   // using FD grid
   evolution::dg::subcell::RdmpTciData expected_rdmp_tci_data{};
-  expected_rdmp_tci_data.max_variables_values = DataVector{
-      max(subcell_mag_tilde_e), max(subcell_mag_tilde_b), max(subcell_tilde_q)};
-  expected_rdmp_tci_data.min_variables_values = DataVector{
-      min(subcell_mag_tilde_e), min(subcell_mag_tilde_b), min(subcell_tilde_q)};
+  expected_rdmp_tci_data.max_variables_values =
+      DataVector{max(subcell_mag_tilde_e), max(subcell_mag_tilde_b)};
+  expected_rdmp_tci_data.min_variables_values =
+      DataVector{min(subcell_mag_tilde_e), min(subcell_mag_tilde_b)};
 
   // Modify past data if we are expecting an RDMP TCI failure.
   db::mutate<evolution::dg::subcell::Tags::DataForRdmpTci>(
@@ -153,8 +168,6 @@ void test(const TestThis test_this, const int expected_tci_status) {
           rdmp_tci_data_ptr->min_variables_values[0] *= 1.01;
         } else if (test_this == TestThis::RdmpMagTildeB) {
           rdmp_tci_data_ptr->min_variables_values[1] *= 1.01;
-        } else if (test_this == TestThis::RdmpTildeQ) {
-          rdmp_tci_data_ptr->min_variables_values[2] *= 1.01;
         }
       },
       make_not_null(&box));
@@ -173,13 +186,14 @@ void test(const TestThis test_this, const int expected_tci_status) {
 }
 }  // namespace
 
-SPECTRE_TEST_CASE("Unit.Evolution.ForceFree.Subcell.TciOnFdGrid",
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.ForceFree.Subcell.TciOnFdGrid",
                   "[Unit][Evolution]") {
   test(TestThis::AllGood, 0);
   test(TestThis::PerssonMagTildeE, 1);
   test(TestThis::PerssonMagTildeB, 2);
   test(TestThis::PerssonTildeQ, 3);
+  test(TestThis::PerssonTildeQBelowCutoff, 0);
+  test(TestThis::PerssonTildeQDoNotCheck, 0);
   test(TestThis::RdmpMagTildeE, 4);
   test(TestThis::RdmpMagTildeB, 5);
-  test(TestThis::RdmpTildeQ, 6);
 }

--- a/tests/Unit/Evolution/Systems/ForceFree/Subcell/Test_TciOptions.cpp
+++ b/tests/Unit/Evolution/Systems/ForceFree/Subcell/Test_TciOptions.cpp
@@ -1,0 +1,17 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include "Evolution/Systems/ForceFree/Subcell/TciOptions.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Framework/TestHelpers.hpp"
+
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.ForceFree.Subcell.TciOptions",
+                  "[Unit][Evolution]") {
+  const auto tci_options_from_opts =
+      TestHelpers::test_option_tag<ForceFree::subcell::OptionTags::TciOptions>(
+          "TildeQCutoff: 1.0e-10\n");
+  const auto tci_options = serialize_and_deserialize(tci_options_from_opts);
+  CHECK(tci_options.tilde_q_cutoff  == 1.0e-10);
+}


### PR DESCRIPTION
## Proposed changes

Through months of experiments I reached to a conclusion that ignoring matter related variables (`TildeQ`, `TildeJ`) leads to a cleaner solution when using DG-Subcell. Just in case for a future use, the PerssonTci check for TildeQ is left as optional. RDMP TCI for TildeQ is removed.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
