### PR TITLE
Disable building executables on gcc 11 Release

### DIFF
--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -424,6 +424,12 @@ jobs:
           - compiler: gcc-11
             build_type: Debug
             PYTHON_EXECUTABLE: /usr/bin/python3.8
+          # Disable building executable for this build for now because it
+          # exceeds the available memory. See issue:
+          # https://github.com/sxs-collaboration/spectre/issues/5472
+          - compiler: gcc-11
+            build_type: Release
+            test_executables: OFF
           # Test building with static libraries. Do so with clang in release
           # mode because these builds use up little disk space compared to GCC
           # builds or clang Debug builds
@@ -647,7 +653,7 @@ ${{ matrix.build_type }}-pch-${{ matrix.use_pch || 'ON' }}"
       # Build the executables in a single thread to reduce memory usage
       # sufficiently so they compile on the GitHub-hosted runners
       - name: Build executables
-        if: matrix.COVERAGE != 'ON'
+        if: matrix.COVERAGE != 'ON' && matrix.test_executables != 'OFF'
         working-directory: build
         run: |
           make test-executables
@@ -676,7 +682,7 @@ ${{ matrix.build_type }}-pch-${{ matrix.use_pch || 'ON' }}"
         run: |
           ccache -s
       - name: Run non-unit tests
-        if: matrix.COVERAGE != 'ON'
+        if: matrix.COVERAGE != 'ON' && matrix.test_executables != 'OFF'
         working-directory: build
         run: |
           # We get occasional random timeouts, repeat tests to see if


### PR DESCRIPTION
## Proposed changes

Avoid running out of memory. Fixing this should be a priority though because gcc 11 Release is a production build that we need to test. See issue: https://github.com/sxs-collaboration/spectre/issues/5472

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
