### PR TITLE
Add 3D EoS Promotion

### DIFF
--- a/src/PointwiseFunctions/Hydro/EquationsOfState/Barotropic3D.cpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/Barotropic3D.cpp
@@ -9,6 +9,7 @@
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/Enthalpy.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/PiecewisePolytropicFluid.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/PolytropicFluid.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/Spectral.hpp"
 #include "Utilities/ConstantExpressions.hpp"
@@ -112,7 +113,13 @@ Scalar<DataType> Barotropic3D<ColdEquilEos>::
       enthalpy_density};
 }
 template class Barotropic3D<EquationsOfState::PolytropicFluid<true>>;
+template class Barotropic3D<EquationsOfState::PolytropicFluid<false>>;
+template class Barotropic3D<PiecewisePolytropicFluid<true>>;
+template class Barotropic3D<PiecewisePolytropicFluid<false>>;
 template class Barotropic3D<Spectral>;
+template class Barotropic3D<Enthalpy<PolytropicFluid<true>>>;
 template class Barotropic3D<Enthalpy<Spectral>>;
+template class Barotropic3D<Enthalpy<Enthalpy<Spectral>>>;
+template class Barotropic3D<Enthalpy<Enthalpy<Enthalpy<Spectral>>>>;
 
 }  // namespace EquationsOfState

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/DarkEnergyFluid.cpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/DarkEnergyFluid.cpp
@@ -3,8 +3,11 @@
 
 #include "PointwiseFunctions/Hydro/EquationsOfState/DarkEnergyFluid.hpp"
 
+#include <memory>
+
 #include "DataStructures/DataVector.hpp"  // IWYU pragma: keep
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/Barotropic3D.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"
 
@@ -30,6 +33,13 @@ std::unique_ptr<EquationOfState<IsRelativistic, 2>>
 DarkEnergyFluid<IsRelativistic>::get_clone() const {
   auto clone = std::make_unique<DarkEnergyFluid<IsRelativistic>>(*this);
   return std::unique_ptr<EquationOfState<IsRelativistic, 2>>(std::move(clone));
+}
+
+template <bool IsRelativistic>
+std::unique_ptr<EquationOfState<IsRelativistic, 3>>
+DarkEnergyFluid<IsRelativistic>::promote_to_3d_eos() const {
+  return std::make_unique<Equilibrium3D<DarkEnergyFluid<IsRelativistic>>>(
+      *this);
 }
 
 template <bool IsRelativistic>

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/DarkEnergyFluid.hpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/DarkEnergyFluid.hpp
@@ -16,6 +16,7 @@
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Options/String.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"  // IWYU pragma: keep
+#include "PointwiseFunctions/Hydro/EquationsOfState/Factory.hpp"
 #include "Utilities/Serialization/CharmPupable.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -54,6 +55,9 @@ class DarkEnergyFluid : public EquationOfState<IsRelativistic, 2> {
                 "relativistic setting.");
 
   std::unique_ptr<EquationOfState<IsRelativistic, 2>> get_clone()
+      const override;
+
+  std::unique_ptr<EquationOfState<IsRelativistic, 3>> promote_to_3d_eos()
       const override;
 
   bool is_equal(const EquationOfState<IsRelativistic, 2>& rhs) const override;

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/Enthalpy.cpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/Enthalpy.cpp
@@ -4,6 +4,7 @@
 #include "PointwiseFunctions/Hydro/EquationsOfState/Enthalpy.hpp"
 
 #include <cmath>
+#include <memory>
 #include <numeric>
 #include <utility>
 
@@ -11,8 +12,10 @@
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "NumericalAlgorithms/RootFinding/TOMS748.hpp"
 #include "NumericalAlgorithms/Spectral/Clenshaw.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/Barotropic3D.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
-#include "PointwiseFunctions/Hydro/EquationsOfState/Factory.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/PolytropicFluid.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/Spectral.hpp"
 #include "PointwiseFunctions/Hydro/SpecificEnthalpy.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/MakeWithValue.hpp"
@@ -277,6 +280,13 @@ std::unique_ptr<EquationOfState<true, 1>> Enthalpy<LowDensityEoS>::get_clone()
     const {
   auto clone = std::make_unique<Enthalpy>(*this);
   return std::unique_ptr<EquationOfState<true, 1>>(std::move(clone));
+}
+
+template <typename LowDensityEoS>
+std::unique_ptr<EquationOfState<true, 3>>
+Enthalpy<LowDensityEoS>::promote_to_3d_eos() const {
+  return std::make_unique<Barotropic3D<Enthalpy<LowDensityEoS>>>(
+      Barotropic3D(*this));
 }
 
 template <typename LowDensityEoS>

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/Enthalpy.hpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/Enthalpy.hpp
@@ -227,6 +227,8 @@ class Enthalpy : public EquationOfState<true, 1> {
 
   std::unique_ptr<EquationOfState<true, 1>> get_clone() const override;
 
+  std::unique_ptr<EquationOfState<true, 3>> promote_to_3d_eos() const override;
+
   bool is_equal(const EquationOfState<true, 1>& rhs) const override;
 
   bool operator==(const Enthalpy<LowDensityEoS>& rhs) const;

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp
@@ -13,6 +13,7 @@
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "PointwiseFunctions/Hydro/Units.hpp"
+#include "Utilities/CallWithDynamicType.hpp"
 #include "Utilities/Serialization/CharmPupable.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TypeTraits.hpp"
@@ -81,12 +82,20 @@ struct DerivedClasses<true, 3> {
                  Barotropic3D<Spectral>, Barotropic3D<Enthalpy<Spectral>>,
                  Equilibrium3D<HybridEos<PolytropicFluid<true>>>,
                  Equilibrium3D<HybridEos<Spectral>>,
-                 Equilibrium3D<HybridEos<Enthalpy<Spectral>>>>;
+                 Equilibrium3D<HybridEos<Enthalpy<Spectral>>>,
+                 Equilibrium3D<DarkEnergyFluid<true>>,
+                 Equilibrium3D<IdealFluid<true>>,
+                 Barotropic3D<PiecewisePolytropicFluid<true>>,
+                 Barotropic3D<Enthalpy<Enthalpy<Spectral>>>,
+                 Barotropic3D<Enthalpy<Enthalpy<Enthalpy<Spectral>>>>>;
 };
 
 template <>
 struct DerivedClasses<false, 3> {
-  using type = tmpl::list<Tabulated3D<false>>;
+  using type = tmpl::list<Tabulated3D<false>, Equilibrium3D<IdealFluid<false>>,
+                          Barotropic3D<PiecewisePolytropicFluid<false>>,
+                          Equilibrium3D<HybridEos<PolytropicFluid<false>>>,
+                          Barotropic3D<PolytropicFluid<false>>>;
 };
 
 }  // namespace detail
@@ -151,7 +160,8 @@ class EquationOfState<IsRelativistic, 1> : public PUP::able {
 
   virtual bool is_equal(
       const EquationOfState<IsRelativistic, 1>& rhs) const = 0;
-
+  virtual std::unique_ptr<EquationOfState<IsRelativistic, 3>>
+  promote_to_3d_eos() const = 0;
   /// @{
   /*!
    * Computes the electron fraction in beta-equilibrium \f$Y_e^{\rm eq}\f$ from
@@ -272,6 +282,13 @@ class EquationOfState<IsRelativistic, 1> : public PUP::able {
   /// The upper bound of the rest mass density that is valid for this EOS
   virtual double rest_mass_density_upper_bound() const = 0;
 
+  /// The lower bound of the temperature that is valid for this EOS
+  virtual double temperature_lower_bound() const { return 0.0; };
+
+  /// The upper bound of the temperature that is valid for this EOS
+  virtual double temperature_upper_bound() const {
+    return std::numeric_limits<double>::max();
+  };
   /// The lower bound of the specific internal energy that is valid for this EOS
   /// at the given rest mass density \f$\rho\f$
   virtual double specific_internal_energy_lower_bound(
@@ -284,14 +301,6 @@ class EquationOfState<IsRelativistic, 1> : public PUP::able {
 
   /// The lower bound of the specific enthalpy that is valid for this EOS
   virtual double specific_enthalpy_lower_bound() const = 0;
-
-  /// The lower bound of the temperature that is valid for this EOS
-  virtual double temperature_lower_bound() const { return 0.0; };
-
-  /// The upper bound of the temperature that is valid for this EOS
-  virtual double temperature_upper_bound() const {
-    return std::numeric_limits<double>::max();
-  };
 
   /// The vacuum mass of a baryon for this EOS
   virtual double baryon_mass() const {
@@ -331,6 +340,9 @@ class EquationOfState<IsRelativistic, 2> : public PUP::able {
 
   virtual bool is_equal(
       const EquationOfState<IsRelativistic, 2>& rhs) const = 0;
+
+  virtual std::unique_ptr<EquationOfState<IsRelativistic, 3>>
+  promote_to_3d_eos() const = 0;
 
   /// @{
   /*!
@@ -523,6 +535,12 @@ class EquationOfState<IsRelativistic, 3> : public PUP::able {
 
   virtual bool is_equal(
       const EquationOfState<IsRelativistic, 3>& rhs) const = 0;
+
+  virtual std::unique_ptr<EquationOfState<IsRelativistic, 3>>
+  promote_to_3d_eos() {
+    return this->get_clone();
+  }
+
   /// @{
   /*!
    * Computes the pressure \f$p\f$ from the rest mass density \f$\rho\f$, the

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/Equilibrium3D.cpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/Equilibrium3D.cpp
@@ -8,8 +8,11 @@
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/DarkEnergyFluid.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/Enthalpy.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/Factory.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/HybridEos.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/IdealFluid.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/PolytropicFluid.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/Spectral.hpp"
 #include "Utilities/ConstantExpressions.hpp"
@@ -127,6 +130,11 @@ Equilibrium3D<EquilEos>::sound_speed_squared_from_density_and_temperature_impl(
 }
 
 template class Equilibrium3D<HybridEos<PolytropicFluid<true>>>;
+template class Equilibrium3D<HybridEos<PolytropicFluid<false>>>;
 template class Equilibrium3D<HybridEos<Spectral>>;
 template class Equilibrium3D<HybridEos<Enthalpy<Spectral>>>;
+template class Equilibrium3D<DarkEnergyFluid<true>>;
+template class Equilibrium3D<IdealFluid<true>>;
+template class Equilibrium3D<IdealFluid<false>>;
+
 }  // namespace EquationsOfState

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/HybridEos.cpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/HybridEos.cpp
@@ -3,12 +3,14 @@
 
 #include "PointwiseFunctions/Hydro/EquationsOfState/HybridEos.hpp"
 
+#include <memory>
 #include <utility>
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "PointwiseFunctions//Hydro/EquationsOfState/Enthalpy.hpp"
 #include "PointwiseFunctions//Hydro/EquationsOfState/Spectral.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/Equilibrium3D.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/PolytropicFluid.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 
@@ -31,6 +33,14 @@ std::unique_ptr<
 HybridEos<ColdEquationOfState>::get_clone() const {
   auto clone = std::make_unique<HybridEos<ColdEquationOfState>>(*this);
   return std::unique_ptr<EquationOfState<is_relativistic, 2>>(std::move(clone));
+}
+
+template <typename ColdEquationOfState>
+std::unique_ptr<
+    EquationOfState<HybridEos<ColdEquationOfState>::is_relativistic, 3>>
+HybridEos<ColdEquationOfState>::promote_to_3d_eos() const {
+  return std::make_unique<Equilibrium3D<HybridEos<ColdEquationOfState>>>(
+      Equilibrium3D(*this));
 }
 
 template <typename ColdEquationOfState>

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/HybridEos.hpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/HybridEos.hpp
@@ -99,6 +99,9 @@ class HybridEos
   std::unique_ptr<EquationOfState<is_relativistic, 2>> get_clone()
       const override;
 
+  std::unique_ptr<EquationOfState<is_relativistic, 3>> promote_to_3d_eos()
+      const override;
+
   bool operator==(const HybridEos<ColdEquationOfState>& rhs) const;
 
   bool operator!=(const HybridEos<ColdEquationOfState>& rhs) const;

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/IdealFluid.cpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/IdealFluid.cpp
@@ -7,6 +7,7 @@
 
 #include "DataStructures/DataVector.hpp"  // IWYU pragma: keep
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/Equilibrium3D.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 
 // IWYU pragma: no_forward_declare Tensor
@@ -25,6 +26,13 @@ std::unique_ptr<EquationOfState<IsRelativistic, 2>>
 IdealFluid<IsRelativistic>::get_clone() const {
   auto clone = std::make_unique<IdealFluid<IsRelativistic>>(*this);
   return std::unique_ptr<EquationOfState<IsRelativistic, 2>>(std::move(clone));
+}
+
+template <bool IsRelativistic>
+std::unique_ptr<EquationOfState<IsRelativistic, 3>>
+IdealFluid<IsRelativistic>::promote_to_3d_eos() const {
+  return std::make_unique<Equilibrium3D<IdealFluid<IsRelativistic>>>(
+      Equilibrium3D(*this));
 }
 
 template <bool IsRelativistic>

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/IdealFluid.hpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/IdealFluid.hpp
@@ -79,6 +79,9 @@ class IdealFluid : public EquationOfState<IsRelativistic, 2> {
   std::unique_ptr<EquationOfState<IsRelativistic, 2>> get_clone()
       const override;
 
+  std::unique_ptr<EquationOfState<IsRelativistic, 3>> promote_to_3d_eos()
+      const override;
+
   bool operator==(const IdealFluid<IsRelativistic>& rhs) const;
 
   bool operator!=(const IdealFluid<IsRelativistic>& rhs) const;

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/PiecewisePolytropicFluid.cpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/PiecewisePolytropicFluid.cpp
@@ -8,6 +8,8 @@
 
 #include "DataStructures/DataVector.hpp"  // IWYU pragma: keep
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/Barotropic3D.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/Factory.hpp"
 #include "Utilities/MakeWithValue.hpp"
 
 // IWYU pragma: no_forward_declare Tensor
@@ -88,6 +90,14 @@ PiecewisePolytropicFluid<IsRelativistic>::get_clone() const {
   auto clone =
       std::make_unique<PiecewisePolytropicFluid<IsRelativistic>>(*this);
   return std::unique_ptr<EquationOfState<IsRelativistic, 1>>(std::move(clone));
+}
+
+template <bool IsRelativistic>
+std::unique_ptr<EquationOfState<IsRelativistic, 3>>
+PiecewisePolytropicFluid<IsRelativistic>::promote_to_3d_eos() const {
+  return std::make_unique<
+      Barotropic3D<PiecewisePolytropicFluid<IsRelativistic>>>(
+      Barotropic3D(*this));
 }
 
 template <bool IsRelativistic>

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/PiecewisePolytropicFluid.hpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/PiecewisePolytropicFluid.hpp
@@ -124,6 +124,9 @@ class PiecewisePolytropicFluid : public EquationOfState<IsRelativistic, 1> {
   std::unique_ptr<EquationOfState<IsRelativistic, 1>> get_clone()
       const override;
 
+  std::unique_ptr<EquationOfState<IsRelativistic, 3>> promote_to_3d_eos()
+      const override;
+
   bool is_equal(const EquationOfState<IsRelativistic, 1>& rhs) const override;
 
   bool operator==(const PiecewisePolytropicFluid<IsRelativistic>& rhs) const;

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/PolytropicFluid.cpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/PolytropicFluid.cpp
@@ -5,9 +5,11 @@
 
 #include <cmath>
 #include <limits>
+#include <memory>
 
 #include "DataStructures/DataVector.hpp"  // IWYU pragma: keep
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/Barotropic3D.hpp"
 #include "Utilities/MakeWithValue.hpp"
 
 // IWYU pragma: no_forward_declare Tensor
@@ -51,6 +53,13 @@ std::unique_ptr<EquationOfState<IsRelativistic, 1>>
 PolytropicFluid<IsRelativistic>::get_clone() const {
   auto clone = std::make_unique<PolytropicFluid<IsRelativistic>>(*this);
   return std::unique_ptr<EquationOfState<IsRelativistic, 1>>(std::move(clone));
+}
+
+template <bool IsRelativistic>
+std::unique_ptr<EquationOfState<IsRelativistic, 3>>
+PolytropicFluid<IsRelativistic>::promote_to_3d_eos() const {
+  return std::make_unique<Barotropic3D<PolytropicFluid<IsRelativistic>>>(
+      Barotropic3D(*this));
 }
 
 template <bool IsRelativistic>

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/PolytropicFluid.hpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/PolytropicFluid.hpp
@@ -75,6 +75,9 @@ class PolytropicFluid : public EquationOfState<IsRelativistic, 1> {
   std::unique_ptr<EquationOfState<IsRelativistic, 1>> get_clone()
       const override;
 
+  std::unique_ptr<EquationOfState<IsRelativistic, 3>> promote_to_3d_eos()
+      const override;
+
   bool is_equal(const EquationOfState<IsRelativistic, 1>& rhs) const override;
 
   bool operator==(const PolytropicFluid<IsRelativistic>& rhs) const;

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/Spectral.cpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/Spectral.cpp
@@ -4,10 +4,13 @@
 #include "PointwiseFunctions/Hydro/EquationsOfState/Spectral.hpp"
 
 #include <cmath>
+#include <memory>
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "NumericalAlgorithms/RootFinding/TOMS748.hpp"
+
+#include "PointwiseFunctions/Hydro/EquationsOfState/Barotropic3D.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
 #include "Utilities/MakeWithValue.hpp"
 
@@ -75,6 +78,10 @@ EQUATION_OF_STATE_MEMBER_DEFINITIONS(, Spectral, DataVector, 1)
 std::unique_ptr<EquationOfState<true, 1>> Spectral::get_clone() const {
   auto clone = std::make_unique<Spectral>(*this);
   return std::unique_ptr<EquationOfState<true, 1>>(std::move(clone));
+}
+
+std::unique_ptr<EquationOfState<true, 3>> Spectral::promote_to_3d_eos() const {
+  return std::make_unique<Barotropic3D<Spectral>>(Barotropic3D(*this));
 }
 
 bool Spectral::operator==(const Spectral& rhs) const {

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/Spectral.hpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/Spectral.hpp
@@ -109,6 +109,8 @@ class Spectral : public EquationOfState<true, 1> {
 
   std::unique_ptr<EquationOfState<true, 1>> get_clone() const override;
 
+  std::unique_ptr<EquationOfState<true, 3>> promote_to_3d_eos() const override;
+
   bool operator==(const Spectral& rhs) const;
 
   bool operator!=(const Spectral& rhs) const;

--- a/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_DarkEnergyFluid.cpp
+++ b/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_DarkEnergyFluid.cpp
@@ -13,6 +13,7 @@
 #include "Helpers/PointwiseFunctions/Hydro/EquationsOfState/TestHelpers.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/DarkEnergyFluid.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/Equilibrium3D.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/Factory.hpp"
 #include "PointwiseFunctions/Hydro/Units.hpp"
 #include "Utilities/Serialization/RegisterDerivedClassesWithCharm.hpp"
@@ -45,6 +46,8 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.EquationsOfState.DarkEnergyFluid",
   CHECK(eos == eos);
   CHECK(eos != other_eos);
   CHECK(eos != other_type_eos);
+  CHECK(*eos.promote_to_3d_eos() ==
+        EoS::Equilibrium3D<EoS::DarkEnergyFluid<true>>(eos));
   TestHelpers::EquationsOfState::test_get_clone(
       EoS::DarkEnergyFluid<true>(1.0));
 

--- a/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_Enthalpy.cpp
+++ b/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_Enthalpy.cpp
@@ -12,6 +12,7 @@
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Framework/TestCreation.hpp"
 #include "Helpers/PointwiseFunctions/Hydro/EquationsOfState/TestHelpers.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/Barotropic3D.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/Enthalpy.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/Factory.hpp"
@@ -85,6 +86,7 @@ void check_exact() {
     CHECK(eos != other_eos);
     CHECK(eos != other_type_eos);
     CHECK(other_low_eos != other_type_eos);
+    CHECK(*eos.promote_to_3d_eos() == Barotropic3D<Enthalpy<Spectral>>(eos));
     CHECK(eos.baryon_mass() ==
           approx(hydro::units::geometric::default_baryon_mass));
   }

--- a/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_Equilibrium3D.cpp
+++ b/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_Equilibrium3D.cpp
@@ -86,9 +86,9 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.EquationsOfState.Equilibrium3D",
     const DataVector enthalpy_density =
         get(rest_mass_density) * (1.0 + get(specific_internal_energy)) +
         get(pressure);
-    CHECK(
+    CHECK_ITERABLE_APPROX(
         get(eos.sound_speed_squared_from_density_and_temperature(
-            rest_mass_density, temperature, electron_fraction)) ==
+            rest_mass_density, temperature, electron_fraction)),
         get(rest_mass_density) *
                 get(underlying_eos.chi_from_density_and_energy(
                     rest_mass_density, specific_internal_energy)) /
@@ -127,14 +127,15 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.EquationsOfState.Equilibrium3D",
     CHECK(
         get(eos.sound_speed_squared_from_density_and_temperature(
             rest_mass_density, temperature, electron_fraction)) ==
-        get(rest_mass_density) *
+        approx(
+            get(rest_mass_density) *
                 get(underlying_eos.chi_from_density_and_energy(
                     rest_mass_density, specific_internal_energy)) /
                 enthalpy_density +
             get(rest_mass_density) / get(pressure) *
                 get(underlying_eos
                         .kappa_times_p_over_rho_squared_from_density_and_energy(
-                            rest_mass_density, specific_internal_energy)));
+                            rest_mass_density, specific_internal_energy))));
     // Check that the sound speed calculation works at zero temperature
     CHECK_ITERABLE_APPROX(
         get(eos.sound_speed_squared_from_density_and_temperature(

--- a/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_HybridEos.cpp
+++ b/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_HybridEos.cpp
@@ -12,7 +12,10 @@
 #include "Framework/TestCreation.hpp"
 #include "Helpers/PointwiseFunctions/Hydro/EquationsOfState/TestHelpers.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/Equilibrium3D.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/Factory.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/HybridEos.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/PolytropicFluid.hpp"
 #include "PointwiseFunctions/Hydro/SpecificEnthalpy.hpp"
 #include "PointwiseFunctions/Hydro/Units.hpp"
 #include "Utilities/Serialization/RegisterDerivedClassesWithCharm.hpp"
@@ -71,6 +74,9 @@ void check_exact_polytrope() {
   CHECK(eos == eos);
   CHECK(eos != other_eos);
   CHECK(eos != other_type_eos);
+  CHECK(*eos.promote_to_3d_eos() ==
+        EquationsOfState::Equilibrium3D<EquationsOfState::HybridEos<
+            EquationsOfState::PolytropicFluid<IsRelativistic>>>(eos));
   const Scalar<double> eps{5.0};
   const auto p = eos.pressure_from_density_and_energy(rho, eps);
   CHECK(get(p) == 34.0);

--- a/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_IdealFluid.cpp
+++ b/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_IdealFluid.cpp
@@ -14,6 +14,7 @@
 #include "Framework/TestHelpers.hpp"
 #include "Helpers/PointwiseFunctions/Hydro/EquationsOfState/TestHelpers.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/Equilibrium3D.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/Factory.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/IdealFluid.hpp"
 #include "PointwiseFunctions/Hydro/Units.hpp"
@@ -78,6 +79,8 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.EquationsOfState.IdealFluid",
   CHECK(eos == eos);
   CHECK(eos != other_eos);
   CHECK(eos != other_type_eos);
+  CHECK(*eos.promote_to_3d_eos() ==
+        EoS::Equilibrium3D<EoS::IdealFluid<true>>(eos));
 
   TestHelpers::EquationsOfState::check(EoS::IdealFluid<true>{5.0 / 3.0},
                                        "IdealFluid", "ideal_fluid", d_for_size,

--- a/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_PiecewisePolytropicFluid.cpp
+++ b/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_PiecewisePolytropicFluid.cpp
@@ -13,6 +13,7 @@
 #include "Framework/TestCreation.hpp"
 #include "Framework/TestHelpers.hpp"
 #include "Helpers/PointwiseFunctions/Hydro/EquationsOfState/TestHelpers.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/Barotropic3D.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/Factory.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/PiecewisePolytropicFluid.hpp"
@@ -89,7 +90,7 @@ void check_exact() {
         polytropic_constant_hi / (polytropic_exponent_hi - 1.0) *
                 pow(2.0 * transition_density, polytropic_exponent_hi - 1.0) +
             eint_hi_constant}};
-    CHECK(eint == eint_expected);
+    CHECK_ITERABLE_APPROX(eint, eint_expected);
 
     // chi
     // Note the sound speeds at the transition density are different depending
@@ -159,7 +160,7 @@ void check_exact() {
         polytropic_constant_hi / (polytropic_exponent_hi - 1.0) *
             pow(get(rho), polytropic_exponent_hi - 1.0) +
         eint_hi_constant;
-    CHECK(get(eint) == eint_expected);
+    CHECK(get(eint) == approx(eint_expected));
 
     // chi
     const auto chi = eos.chi_from_density(rho);
@@ -338,6 +339,9 @@ SPECTRE_TEST_CASE(
   CHECK(eos != other_eos);
   // Different eos types should NOT match
   CHECK(eos != other_type_eos);
+  // Check the correct 3D EoS is got
+  CHECK(*eos.promote_to_3d_eos() ==
+        EoS::Barotropic3D<EoS::PiecewisePolytropicFluid<true>>(eos));
   // Check baryon density
   CHECK(eos.baryon_mass() ==
         approx(hydro::units::geometric::default_baryon_mass));

--- a/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_PolytropicFluid.cpp
+++ b/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_PolytropicFluid.cpp
@@ -13,6 +13,7 @@
 #include "Framework/TestCreation.hpp"
 #include "Framework/TestHelpers.hpp"
 #include "Helpers/PointwiseFunctions/Hydro/EquationsOfState/TestHelpers.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/Barotropic3D.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/Factory.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/PolytropicFluid.hpp"
@@ -77,6 +78,8 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.EquationsOfState.PolytropicFluid",
   CHECK(eos == eos);
   CHECK(eos != other_eos);
   CHECK(eos != other_type_eos);
+  CHECK(*eos.promote_to_3d_eos() ==
+        EoS::Barotropic3D<EoS::PolytropicFluid<true>>(eos));
   const double d_for_size = std::numeric_limits<double>::signaling_NaN();
   const DataVector dv_for_size(5);
   TestHelpers::EquationsOfState::check(EoS::PolytropicFluid<true>{100.0, 2.0},

--- a/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_SpectralEoS.cpp
+++ b/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_SpectralEoS.cpp
@@ -10,6 +10,7 @@
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Framework/TestCreation.hpp"
 #include "Helpers/PointwiseFunctions/Hydro/EquationsOfState/TestHelpers.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/Barotropic3D.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/Factory.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/Spectral.hpp"
@@ -40,6 +41,8 @@ void check_exact() {
   CHECK(eos == eos);
   CHECK(eos != other_eos);
   CHECK(eos != other_type_eos);
+  CHECK(*eos.promote_to_3d_eos() ==
+        EquationsOfState::Barotropic3D<EquationsOfState::Spectral>(eos));
   // Test DataVector functions
   {
     const Scalar<DataVector> rho{DataVector{


### PR DESCRIPTION
## Proposed changes

This PR adds a function which allows any EoS to be promoted to a 3D EoS for use in evolutions.  Variables which are not necessary for EoS evaluation (i.e. composition for 2d EoSs, and composition and temperature for 1d EoSs).  

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
