### PR TITLE
Remove unnecessary tags in ForceFree FD reconstructors

### DIFF
--- a/src/Evolution/Systems/ForceFree/FiniteDifference/AdaptiveOrder.cpp
+++ b/src/Evolution/Systems/ForceFree/FiniteDifference/AdaptiveOrder.cpp
@@ -78,9 +78,9 @@ void AdaptiveOrder::pup(PUP::er& p) {
 PUP::able::PUP_ID AdaptiveOrder::my_PUP_ID = 0;
 
 void AdaptiveOrder::reconstruct(
-    const gsl::not_null<std::array<Variables<face_vars_tags>, dim>*>
+    const gsl::not_null<std::array<Variables<recons_tags>, dim>*>
         vars_on_lower_face,
-    const gsl::not_null<std::array<Variables<face_vars_tags>, dim>*>
+    const gsl::not_null<std::array<Variables<recons_tags>, dim>*>
         vars_on_upper_face,
     const Variables<volume_vars_tags>& volume_vars,
     const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_j,
@@ -118,7 +118,7 @@ void AdaptiveOrder::reconstruct(
 }
 
 void AdaptiveOrder::reconstruct_fd_neighbor(
-    const gsl::not_null<Variables<face_vars_tags>*> vars_on_face,
+    const gsl::not_null<Variables<recons_tags>*> vars_on_face,
     const Variables<volume_vars_tags>& volume_vars,
     const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_j,
     const Element<dim>& element,

--- a/src/Evolution/Systems/ForceFree/FiniteDifference/AdaptiveOrder.hpp
+++ b/src/Evolution/Systems/ForceFree/FiniteDifference/AdaptiveOrder.hpp
@@ -22,6 +22,7 @@
 #include "Evolution/DgSubcell/Tags/Mesh.hpp"
 #include "Evolution/DiscontinuousGalerkin/Actions/NormalCovectorAndMagnitude.hpp"
 #include "Evolution/Systems/ForceFree/FiniteDifference/Reconstructor.hpp"
+#include "Evolution/Systems/ForceFree/FiniteDifference/Tags.hpp"
 #include "Evolution/Systems/ForceFree/Tags.hpp"
 #include "NumericalAlgorithms/FiniteDifference/FallbackReconstructorType.hpp"
 #include "Options/Auto.hpp"
@@ -40,7 +41,7 @@ template <size_t dim>
 class ElementId;
 template <size_t dim>
 class Mesh;
-template <typename face_vars_tags>
+template <typename recons_tags>
 class Variables;
 namespace gsl {
 template <typename>
@@ -72,21 +73,7 @@ class AdaptiveOrder : public Reconstructor {
   using volume_vars_tags =
       tmpl::list<TildeE, TildeB, TildePsi, TildePhi, TildeQ>;
 
-  using face_vars_tags =
-      tmpl::list<TildeJ,  // we reconstruct TildeJ, not computing it from values
-                          // of reconstructed evolved variables
-                 TildeE, TildeB, TildePsi, TildePhi, TildeQ,
-                 ::Tags::Flux<TildeE, tmpl::size_t<3>, Frame::Inertial>,
-                 ::Tags::Flux<TildeB, tmpl::size_t<3>, Frame::Inertial>,
-                 ::Tags::Flux<TildePsi, tmpl::size_t<3>, Frame::Inertial>,
-                 ::Tags::Flux<TildePhi, tmpl::size_t<3>, Frame::Inertial>,
-                 ::Tags::Flux<TildeQ, tmpl::size_t<3>, Frame::Inertial>,
-                 gr::Tags::Lapse<DataVector>,
-                 gr::Tags::Shift<DataVector, 3, Frame::Inertial>,
-                 gr::Tags::SpatialMetric<DataVector, 3, Frame::Inertial>,
-                 gr::Tags::SqrtDetSpatialMetric<DataVector>,
-                 gr::Tags::InverseSpatialMetric<DataVector, 3, Frame::Inertial>,
-                 evolution::dg::Actions::detail::NormalVector<3>>;
+  using recons_tags = ForceFree::fd::tags_list_for_reconstruction;
 
   using FallbackReconstructorType =
       ::fd::reconstruction::FallbackReconstructorType;
@@ -163,9 +150,9 @@ class AdaptiveOrder : public Reconstructor {
                  evolution::dg::subcell::Tags::Mesh<dim>>;
 
   void reconstruct(
-      gsl::not_null<std::array<Variables<face_vars_tags>, dim>*>
+      gsl::not_null<std::array<Variables<recons_tags>, dim>*>
           vars_on_lower_face,
-      gsl::not_null<std::array<Variables<face_vars_tags>, dim>*>
+      gsl::not_null<std::array<Variables<recons_tags>, dim>*>
           vars_on_upper_face,
       const Variables<volume_vars_tags>& volume_vars,
       const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_j,
@@ -178,7 +165,7 @@ class AdaptiveOrder : public Reconstructor {
       const Mesh<dim>& subcell_mesh) const;
 
   void reconstruct_fd_neighbor(
-      gsl::not_null<Variables<face_vars_tags>*> vars_on_face,
+      gsl::not_null<Variables<recons_tags>*> vars_on_face,
       const Variables<volume_vars_tags>& volume_vars,
       const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_j,
       const Element<dim>& element,

--- a/src/Evolution/Systems/ForceFree/FiniteDifference/MonotonisedCentral.cpp
+++ b/src/Evolution/Systems/ForceFree/FiniteDifference/MonotonisedCentral.cpp
@@ -41,9 +41,9 @@ void MonotonisedCentral::pup(PUP::er& p) { Reconstructor::pup(p); }
 PUP::able::PUP_ID MonotonisedCentral::my_PUP_ID = 0;
 
 void MonotonisedCentral::reconstruct(
-    const gsl::not_null<std::array<Variables<face_vars_tags>, dim>*>
+    const gsl::not_null<std::array<Variables<recons_tags>, dim>*>
         vars_on_lower_face,
-    const gsl::not_null<std::array<Variables<face_vars_tags>, dim>*>
+    const gsl::not_null<std::array<Variables<recons_tags>, dim>*>
         vars_on_upper_face,
     const Variables<volume_vars_tags>& volume_vars,
     const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_j,
@@ -77,7 +77,7 @@ void MonotonisedCentral::reconstruct(
 }
 
 void MonotonisedCentral::reconstruct_fd_neighbor(
-    const gsl::not_null<Variables<face_vars_tags>*> vars_on_face,
+    const gsl::not_null<Variables<recons_tags>*> vars_on_face,
     const Variables<volume_vars_tags>& volume_vars,
     const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_j,
     const Element<dim>& element,

--- a/src/Evolution/Systems/ForceFree/FiniteDifference/MonotonisedCentral.hpp
+++ b/src/Evolution/Systems/ForceFree/FiniteDifference/MonotonisedCentral.hpp
@@ -38,7 +38,7 @@ template <size_t dim>
 class ElementId;
 template <size_t dim>
 class Mesh;
-template <typename face_vars_tags>
+template <typename recons_tags>
 class Variables;
 namespace gsl {
 template <typename>
@@ -68,21 +68,7 @@ class MonotonisedCentral : public Reconstructor {
   using volume_vars_tags =
       tmpl::list<TildeE, TildeB, TildePsi, TildePhi, TildeQ>;
 
-  using face_vars_tags =
-      tmpl::list<TildeJ,  // we reconstruct TildeJ, not computing it from values
-                          // of reconstructed evolved variables
-                 TildeE, TildeB, TildePsi, TildePhi, TildeQ,
-                 ::Tags::Flux<TildeE, tmpl::size_t<3>, Frame::Inertial>,
-                 ::Tags::Flux<TildeB, tmpl::size_t<3>, Frame::Inertial>,
-                 ::Tags::Flux<TildePsi, tmpl::size_t<3>, Frame::Inertial>,
-                 ::Tags::Flux<TildePhi, tmpl::size_t<3>, Frame::Inertial>,
-                 ::Tags::Flux<TildeQ, tmpl::size_t<3>, Frame::Inertial>,
-                 gr::Tags::Lapse<DataVector>,
-                 gr::Tags::Shift<DataVector, 3, Frame::Inertial>,
-                 gr::Tags::SpatialMetric<DataVector, 3, Frame::Inertial>,
-                 gr::Tags::SqrtDetSpatialMetric<DataVector>,
-                 gr::Tags::InverseSpatialMetric<DataVector, 3, Frame::Inertial>,
-                 evolution::dg::Actions::detail::NormalVector<3>>;
+  using recons_tags = ForceFree::fd::tags_list_for_reconstruction;
 
  public:
   static constexpr size_t dim = 3;
@@ -117,9 +103,9 @@ class MonotonisedCentral : public Reconstructor {
                  evolution::dg::subcell::Tags::Mesh<dim>>;
 
   void reconstruct(
-      gsl::not_null<std::array<Variables<face_vars_tags>, dim>*>
+      gsl::not_null<std::array<Variables<recons_tags>, dim>*>
           vars_on_lower_face,
-      gsl::not_null<std::array<Variables<face_vars_tags>, dim>*>
+      gsl::not_null<std::array<Variables<recons_tags>, dim>*>
           vars_on_upper_face,
       const Variables<volume_vars_tags>& volume_vars,
       const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_j,
@@ -132,7 +118,7 @@ class MonotonisedCentral : public Reconstructor {
       const Mesh<dim>& subcell_mesh) const;
 
   void reconstruct_fd_neighbor(
-      gsl::not_null<Variables<face_vars_tags>*> vars_on_face,
+      gsl::not_null<Variables<recons_tags>*> vars_on_face,
       const Variables<volume_vars_tags>& volume_vars,
       const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_j,
       const Element<dim>& element,

--- a/src/Evolution/Systems/ForceFree/FiniteDifference/Wcns5z.cpp
+++ b/src/Evolution/Systems/ForceFree/FiniteDifference/Wcns5z.cpp
@@ -59,9 +59,9 @@ void Wcns5z::pup(PUP::er& p) {
 PUP::able::PUP_ID Wcns5z::my_PUP_ID = 0;
 
 void Wcns5z::reconstruct(
-    const gsl::not_null<std::array<Variables<face_vars_tags>, dim>*>
+    const gsl::not_null<std::array<Variables<recons_tags>, dim>*>
         vars_on_lower_face,
-    const gsl::not_null<std::array<Variables<face_vars_tags>, dim>*>
+    const gsl::not_null<std::array<Variables<recons_tags>, dim>*>
         vars_on_upper_face,
     const Variables<volume_vars_tags>& volume_vars,
     const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_j,
@@ -95,7 +95,7 @@ void Wcns5z::reconstruct(
 }
 
 void Wcns5z::reconstruct_fd_neighbor(
-    const gsl::not_null<Variables<face_vars_tags>*> vars_on_face,
+    const gsl::not_null<Variables<recons_tags>*> vars_on_face,
     const Variables<volume_vars_tags>& volume_vars,
     const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_j,
     const Element<dim>& element,

--- a/src/Evolution/Systems/ForceFree/FiniteDifference/Wcns5z.hpp
+++ b/src/Evolution/Systems/ForceFree/FiniteDifference/Wcns5z.hpp
@@ -39,7 +39,7 @@ template <size_t dim>
 class ElementId;
 template <size_t dim>
 class Mesh;
-template <typename face_vars_tags>
+template <typename recons_tags>
 class Variables;
 namespace gsl {
 template <typename>
@@ -68,21 +68,7 @@ class Wcns5z : public Reconstructor {
   using volume_vars_tags =
       tmpl::list<TildeE, TildeB, TildePsi, TildePhi, TildeQ>;
 
-  using face_vars_tags =
-      tmpl::list<TildeJ,  // we reconstruct TildeJ, not computing it from values
-                          // of reconstructed evolved variables
-                 TildeE, TildeB, TildePsi, TildePhi, TildeQ,
-                 ::Tags::Flux<TildeE, tmpl::size_t<3>, Frame::Inertial>,
-                 ::Tags::Flux<TildeB, tmpl::size_t<3>, Frame::Inertial>,
-                 ::Tags::Flux<TildePsi, tmpl::size_t<3>, Frame::Inertial>,
-                 ::Tags::Flux<TildePhi, tmpl::size_t<3>, Frame::Inertial>,
-                 ::Tags::Flux<TildeQ, tmpl::size_t<3>, Frame::Inertial>,
-                 gr::Tags::Lapse<DataVector>,
-                 gr::Tags::Shift<DataVector, 3, Frame::Inertial>,
-                 gr::Tags::SpatialMetric<DataVector, 3, Frame::Inertial>,
-                 gr::Tags::SqrtDetSpatialMetric<DataVector>,
-                 gr::Tags::InverseSpatialMetric<DataVector, 3, Frame::Inertial>,
-                 evolution::dg::Actions::detail::NormalVector<3>>;
+  using recons_tags = ForceFree::fd::tags_list_for_reconstruction;
 
   using FallbackReconstructorType =
       ::fd::reconstruction::FallbackReconstructorType;
@@ -152,9 +138,9 @@ class Wcns5z : public Reconstructor {
                  evolution::dg::subcell::Tags::Mesh<dim>>;
 
   void reconstruct(
-      gsl::not_null<std::array<Variables<face_vars_tags>, dim>*>
+      gsl::not_null<std::array<Variables<recons_tags>, dim>*>
           vars_on_lower_face,
-      gsl::not_null<std::array<Variables<face_vars_tags>, dim>*>
+      gsl::not_null<std::array<Variables<recons_tags>, dim>*>
           vars_on_upper_face,
       const Variables<volume_vars_tags>& volume_vars,
       const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_j,
@@ -167,7 +153,7 @@ class Wcns5z : public Reconstructor {
       const Mesh<dim>& subcell_mesh) const;
 
   void reconstruct_fd_neighbor(
-      gsl::not_null<Variables<face_vars_tags>*> vars_on_face,
+      gsl::not_null<Variables<recons_tags>*> vars_on_face,
       const Variables<volume_vars_tags>& volume_vars,
       const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_j,
       const Element<dim>& element,


### PR DESCRIPTION
## Proposed changes

Remove unnecessary tags in reconstructed face variables, such as Fluxes and GR tags. Not sure why I have implemented in this way at first.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
