### PR TITLE
Add option to output subdomain matrices in elliptic solver

### DIFF
--- a/src/DataStructures/DynamicMatrix.hpp
+++ b/src/DataStructures/DynamicMatrix.hpp
@@ -75,3 +75,20 @@ struct Options::create_from_yaml<blaze::DynamicMatrix<Type, SO, Alloc, Tag>> {
     return result;
   }
 };
+
+/// Write a `blaze::DynamicMatrix` to a CSV file.
+template <typename Type, bool SO, typename Alloc, typename Tag>
+std::ostream& write_csv(
+    std::ostream& os, const blaze::DynamicMatrix<Type, SO, Alloc, Tag>& matrix,
+    const std::string& delimiter = ",") {
+  for (size_t i = 0; i < matrix.rows(); ++i) {
+    for (size_t j = 0; j < matrix.columns(); ++j) {
+      os << matrix(i, j);
+      if (j + 1 != matrix.columns()) {
+        os << delimiter;
+      }
+    }
+    os << '\n';
+  }
+  return os;
+}

--- a/tests/InputFiles/Elasticity/BentBeam.yaml
+++ b/tests/InputFiles/Elasticity/BentBeam.yaml
@@ -75,7 +75,9 @@ LinearSolver:
     Iterations: 3
     MaxOverlap: 2
     Verbosity: Quiet
-    SubdomainSolver: ExplicitInverse
+    SubdomainSolver:
+      ExplicitInverse:
+        WriteMatrixToFile: None
     ObservePerCoreReductions: False
 
 EventsAndTriggers:

--- a/tests/InputFiles/Elasticity/HalfSpaceMirror.yaml
+++ b/tests/InputFiles/Elasticity/HalfSpaceMirror.yaml
@@ -101,7 +101,9 @@ LinearSolver:
         Restart: None
         Preconditioner:
           MinusLaplacian:
-            Solver: ExplicitInverse
+            Solver:
+              ExplicitInverse:
+                WriteMatrixToFile: None
             BoundaryConditions: Auto
     ObservePerCoreReductions: False
 

--- a/tests/InputFiles/Poisson/ProductOfSinusoids1D.yaml
+++ b/tests/InputFiles/Poisson/ProductOfSinusoids1D.yaml
@@ -8,6 +8,8 @@ Testing:
 ExpectedOutput:
   - PoissonProductOfSinusoids1DReductions.h5
   - PoissonProductOfSinusoids1DVolume0.h5
+  - SubdomainMatrix_[B0,(L1I0)].txt
+  - SubdomainMatrix_[B0,(L1I1)].txt
 OutputFileChecks:
   - Label: Discretization error
     Subfile: /ErrorNorms.dat
@@ -75,7 +77,9 @@ LinearSolver:
     Iterations: 3
     MaxOverlap: 2
     Verbosity: Quiet
-    SubdomainSolver: ExplicitInverse
+    SubdomainSolver:
+      ExplicitInverse:
+        WriteMatrixToFile: "SubdomainMatrix"
     ObservePerCoreReductions: False
 
 RadiallyCompressedCoordinates: None

--- a/tests/InputFiles/Poisson/ProductOfSinusoids2D.yaml
+++ b/tests/InputFiles/Poisson/ProductOfSinusoids2D.yaml
@@ -69,7 +69,9 @@ LinearSolver:
     Iterations: 3
     MaxOverlap: 2
     Verbosity: Quiet
-    SubdomainSolver: ExplicitInverse
+    SubdomainSolver:
+      ExplicitInverse:
+        WriteMatrixToFile: None
     ObservePerCoreReductions: False
 
 RadiallyCompressedCoordinates: None

--- a/tests/InputFiles/Poisson/ProductOfSinusoids3D.yaml
+++ b/tests/InputFiles/Poisson/ProductOfSinusoids3D.yaml
@@ -76,7 +76,9 @@ LinearSolver:
     Iterations: 3
     MaxOverlap: 2
     Verbosity: Quiet
-    SubdomainSolver: ExplicitInverse
+    SubdomainSolver:
+      ExplicitInverse:
+        WriteMatrixToFile: None
     ObservePerCoreReductions: False
 
 RadiallyCompressedCoordinates: None

--- a/tests/InputFiles/Punctures/MultiplePunctures.yaml
+++ b/tests/InputFiles/Punctures/MultiplePunctures.yaml
@@ -92,7 +92,9 @@ LinearSolver:
         Restart: None
         Preconditioner:
           MinusLaplacian:
-            Solver: ExplicitInverse
+            Solver:
+              ExplicitInverse:
+                WriteMatrixToFile: None
             BoundaryConditions: Auto
     SkipResets: True
     ObservePerCoreReductions: False

--- a/tests/InputFiles/Xcts/BinaryBlackHole.yaml
+++ b/tests/InputFiles/Xcts/BinaryBlackHole.yaml
@@ -156,7 +156,9 @@ LinearSolver:
         Restart: None
         Preconditioner:
           MinusLaplacian:
-            Solver: ExplicitInverse
+            Solver:
+              ExplicitInverse:
+                WriteMatrixToFile: None
             BoundaryConditions: Auto
     SkipResets: True
     ObservePerCoreReductions: False

--- a/tests/InputFiles/Xcts/HeadOnBns.yaml
+++ b/tests/InputFiles/Xcts/HeadOnBns.yaml
@@ -150,7 +150,9 @@ LinearSolver:
         Restart: None
         Preconditioner:
           MinusLaplacian:
-            Solver: ExplicitInverse
+            Solver:
+              ExplicitInverse:
+                WriteMatrixToFile: None
             BoundaryConditions: Auto
     SkipResets: True
     ObservePerCoreReductions: False

--- a/tests/InputFiles/Xcts/KerrSchild.yaml
+++ b/tests/InputFiles/Xcts/KerrSchild.yaml
@@ -107,7 +107,9 @@ LinearSolver:
         Restart: None
         Preconditioner:
           MinusLaplacian:
-            Solver: ExplicitInverse
+            Solver:
+              ExplicitInverse:
+                WriteMatrixToFile: None
             BoundaryConditions: Auto
     SkipResets: True
     ObservePerCoreReductions: False

--- a/tests/InputFiles/Xcts/TovStar.yaml
+++ b/tests/InputFiles/Xcts/TovStar.yaml
@@ -103,7 +103,9 @@ LinearSolver:
         Restart: None
         Preconditioner:
           MinusLaplacian:
-            Solver: ExplicitInverse
+            Solver:
+              ExplicitInverse:
+                WriteMatrixToFile: None
             BoundaryConditions: Auto
     SkipResets: True
     ObservePerCoreReductions: False

--- a/tests/Unit/DataStructures/Test_BlazeInteroperability.cpp
+++ b/tests/Unit/DataStructures/Test_BlazeInteroperability.cpp
@@ -100,6 +100,12 @@ SPECTRE_TEST_CASE("Unit.DataStructures.BlazeInteroperability",
               "[[0., 1., 2.], [3., 0., 4.]]") ==
           blaze::DynamicMatrix<double, blaze::rowMajor>{{0., 1., 2.},
                                                         {3., 0., 4.}});
+    // Test `write_csv`
+    std::stringstream ss{};
+    blaze::DynamicMatrix<double, blaze::columnMajor> matrix{{0., 1., 2.},
+                                                            {3., 0., 4.}};
+    write_csv(ss, matrix);
+    CHECK(ss.str() == "0,1,2\n3,0,4\n");
   }
   {
     INFO("CompressedMatrix");

--- a/tests/Unit/Elliptic/SubdomainPreconditioners/Test_MinusLaplacian.cpp
+++ b/tests/Unit/Elliptic/SubdomainPreconditioners/Test_MinusLaplacian.cpp
@@ -422,7 +422,9 @@ SPECTRE_TEST_CASE("Unit.Elliptic.SubdomainPreconditioners.MinusLaplacian",
     const auto created =
         TestHelpers::test_creation<std::unique_ptr<LinearSolverType>>(
             "MinusLaplacian:\n"
-            "  Solver: ExplicitInverse\n"
+            "  Solver:\n"
+            "    ExplicitInverse:\n"
+            "      WriteMatrixToFile: None\n"
             "  BoundaryConditions: Auto");
     const auto serialized = serialize_and_deserialize(created);
     const auto cloned = serialized->get_clone();

--- a/tests/Unit/NumericalAlgorithms/LinearSolver/Test_ExplicitInverse.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearSolver/Test_ExplicitInverse.cpp
@@ -42,12 +42,16 @@ SPECTRE_TEST_CASE("Unit.LinearSolver.Serial.ExplicitInverse",
     const blaze::DynamicVector<double> source{1., 2.};
     const blaze::DynamicVector<double> expected_solution{-1., 5.};
     blaze::DynamicVector<double> solution(2);
-    const ExplicitInverse<> solver{};
+    const ExplicitInverse<> solver{"Matrix"};
     const auto has_converged =
         solver.solve(make_not_null(&solution), linear_operator, source);
     REQUIRE(has_converged);
     CHECK_MATRIX_APPROX(solver.matrix_representation(), blaze::inv(matrix));
     CHECK_ITERABLE_APPROX(solution, expected_solution);
+    std::ifstream matrix_file("Matrix.txt");
+    std::string matrix_csv((std::istreambuf_iterator<char>(matrix_file)),
+                           std::istreambuf_iterator<char>());
+    CHECK(matrix_csv == "4 1\n3 1\n");
     {
       INFO("Resetting");
       ExplicitInverse<> resetting_solver{};

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Schwarz/Test_SchwarzAlgorithm.yaml
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Schwarz/Test_SchwarzAlgorithm.yaml
@@ -68,7 +68,8 @@ SchwarzSmoother:
       Preconditioner:
         # Preconditioning with the explicitly-built inverse matrix, so all
         # subdomain solves should converge immediately
-        ExplicitInverse
+        ExplicitInverse:
+          WriteMatrixToFile: None
   ObservePerCoreReductions: False
 
 ConvergenceReason: NumIterations


### PR DESCRIPTION
## Proposed changes

Similar to #5540 but outputs the subdomain matrix from each element. Here's an example for a Poisson problem on a Sphere domain with 2 shells (first two rows) and an inner cube (last row):

![530ea7f7-0b47-41a2-8278-84f34f754ca2](https://github.com/sxs-collaboration/spectre/assets/746230/c260b7e1-9519-4f73-860a-7d279368a8b7)

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
In input files for elliptic executable, change the option `ExplicitInverse` to:

```yaml
ExplicitInverse:
  WriteMatrixToFile: None
```

You can set this option to a filename to output the subdomain matrices for debugging or analysis.
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
