### PR TITLE
Pass around neighbor meshes when determining AMR decisions

### DIFF
--- a/src/Domain/Amr/CMakeLists.txt
+++ b/src/Domain/Amr/CMakeLists.txt
@@ -10,6 +10,7 @@ spectre_target_sources(
   PRIVATE
   Flag.cpp
   Helpers.cpp
+  Info.cpp
   NeighborsOfChild.cpp
   NeighborsOfParent.cpp
   NewNeighborIds.cpp
@@ -23,6 +24,7 @@ spectre_target_headers(
   Amr.hpp
   Flag.hpp
   Helpers.hpp
+  Info.hpp
   NeighborsOfChild.hpp
   NeighborsOfParent.hpp
   NewNeighborIds.hpp

--- a/src/Domain/Amr/Flag.cpp
+++ b/src/Domain/Amr/Flag.cpp
@@ -2,14 +2,15 @@
 // See LICENSE.txt for details.
 
 #include "Domain/Amr/Flag.hpp"
+
+#include <ostream>
+#include <vector>
+
 #include "Options/Options.hpp"
 #include "Options/ParseOptions.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/GetOutput.hpp"
 #include "Utilities/StdHelpers.hpp"
-
-#include <ostream>
-#include <vector>
 
 namespace {
 std::vector<amr::Flag> known_amr_flags() {

--- a/src/Domain/Amr/Info.cpp
+++ b/src/Domain/Amr/Info.cpp
@@ -1,0 +1,55 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Domain/Amr/Flag.hpp"
+
+#include <array>
+#include <ostream>
+#include <pup.h>
+#include <pup_stl.h>
+
+#include "Domain/Amr/Info.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/StdHelpers.hpp"
+
+namespace amr {
+template <size_t VolumeDim>
+void Info<VolumeDim>::pup(PUP::er& p) {
+  p | flags;
+  p | new_mesh;
+}
+
+template <size_t VolumeDim>
+std::ostream& operator<<(std::ostream& os, const amr::Info<VolumeDim>& info) {
+  using ::operator<<;
+  os << "Flags: " << info.flags << " New mesh: " << info.new_mesh;
+  return os;
+}
+
+template <size_t VolumeDim>
+bool operator==(const Info<VolumeDim>& lhs, const Info<VolumeDim>& rhs) {
+  return lhs.flags == rhs.flags and lhs.new_mesh == rhs.new_mesh;
+}
+
+template <size_t VolumeDim>
+bool operator!=(const amr::Info<VolumeDim>& lhs,
+                const amr::Info<VolumeDim>& rhs) {
+  return not(lhs == rhs);
+}
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define GEN_OP(op, dim) \
+  template bool operator op(const Info<dim>& lhs, const Info<dim>& rhs);
+#define INSTANTIATE(_, data)                          \
+  template struct Info<DIM(data)>;                    \
+  GEN_OP(==, DIM(data))                               \
+  GEN_OP(!=, DIM(data))                               \
+  template std::ostream& operator<<(std::ostream& os, \
+                                    const Info<DIM(data)>& info);
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
+#undef INSTANTIATE
+#undef GEN_OP
+#undef DIM
+}  // namespace amr

--- a/src/Domain/Amr/Info.hpp
+++ b/src/Domain/Amr/Info.hpp
@@ -1,0 +1,39 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <iosfwd>
+
+#include "Domain/Amr/Flag.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+
+/// \cond
+namespace PUP {
+class er;
+}  // namespace PUP
+/// \endcond
+
+namespace amr {
+template <size_t VolumeDim>
+struct Info {
+  std::array<Flag, VolumeDim> flags;
+  Mesh<VolumeDim> new_mesh;
+
+  /// Serialization for Charm++
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& p);
+};
+
+/// Output operator for an Info.
+template <size_t VolumeDim>
+std::ostream& operator<<(std::ostream& os, const Info<VolumeDim>& info);
+
+template <size_t VolumeDim>
+bool operator==(const Info<VolumeDim>& lhs, const Info<VolumeDim>& rhs);
+
+template <size_t VolumeDim>
+bool operator!=(const Info<VolumeDim>& lhs, const Info<VolumeDim>& rhs);
+}  // namespace amr

--- a/src/Domain/Amr/NeighborsOfChild.cpp
+++ b/src/Domain/Amr/NeighborsOfChild.cpp
@@ -10,6 +10,7 @@
 
 #include "Domain/Amr/Flag.hpp"
 #include "Domain/Amr/Helpers.hpp"
+#include "Domain/Amr/Info.hpp"
 #include "Domain/Amr/NewNeighborIds.hpp"
 #include "Domain/Structure/Direction.hpp"
 #include "Domain/Structure/DirectionMap.hpp"
@@ -26,8 +27,8 @@ template <size_t VolumeDim>
 DirectionMap<VolumeDim, Neighbors<VolumeDim>> neighbors_of_child(
     const Element<VolumeDim>& parent,
     const std::array<Flag, VolumeDim>& parent_flags,
-    const std::unordered_map<ElementId<VolumeDim>, std::array<Flag, VolumeDim>>&
-        parent_neighbor_flags,
+    const std::unordered_map<ElementId<VolumeDim>, Info<VolumeDim>>&
+        parent_neighbor_info,
     const ElementId<VolumeDim>& child_id) {
   DirectionMap<VolumeDim, Neighbors<VolumeDim>> result;
 
@@ -48,7 +49,7 @@ DirectionMap<VolumeDim, Neighbors<VolumeDim>> neighbors_of_child(
       result.emplace(direction,
                      Neighbors<VolumeDim>{
                          new_neighbor_ids(child_id, direction, old_neighbors,
-                                          parent_neighbor_flags),
+                                          parent_neighbor_info),
                          old_neighbors.orientation()});
     }
   }
@@ -70,9 +71,8 @@ DirectionMap<VolumeDim, Neighbors<VolumeDim>> neighbors_of_child(
   template DirectionMap<DIM(data), Neighbors<DIM(data)>> neighbors_of_child( \
       const Element<DIM(data)>& parent,                                      \
       const std::array<Flag, DIM(data)>& parent_flags,                       \
-      const std::unordered_map<ElementId<DIM(data)>,                         \
-                               std::array<Flag, DIM(data)>>&                 \
-          parent_neighbor_flags,                                             \
+      const std::unordered_map<ElementId<DIM(data)>, Info<DIM(data)>>&       \
+          parent_neighbor_info,                                              \
       const ElementId<DIM(data)>& child_id);
 
 GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))

--- a/src/Domain/Amr/NeighborsOfChild.hpp
+++ b/src/Domain/Amr/NeighborsOfChild.hpp
@@ -10,6 +10,10 @@
 #include "Domain/Amr/Flag.hpp"
 
 /// \cond
+namespace amr {
+template <size_t VolumeDim>
+struct Info;
+}  // namespace amr
 template <size_t VolumeDim, typename T>
 class DirectionMap;
 template <size_t VolumeDim>
@@ -24,12 +28,12 @@ namespace amr {
 /// \ingroup AmrGroup
 /// \brief returns the neighbors of the Element with ElementId `child_id`,
 /// whose parent Element is `parent` which has refinement flags `parent_flags`
-/// and neighbor flags `parent_neighbor_flags`
+/// and neighbor Info `parent_neighbor_info`
 template <size_t VolumeDim>
 DirectionMap<VolumeDim, Neighbors<VolumeDim>> neighbors_of_child(
     const Element<VolumeDim>& parent,
     const std::array<Flag, VolumeDim>& parent_flags,
-    const std::unordered_map<ElementId<VolumeDim>, std::array<Flag, VolumeDim>>&
-        parent_neighbor_flags,
+    const std::unordered_map<ElementId<VolumeDim>, Info<VolumeDim>>&
+        parent_neighbor_info,
     const ElementId<VolumeDim>& child_id);
 }  // namespace amr

--- a/src/Domain/Amr/NeighborsOfParent.hpp
+++ b/src/Domain/Amr/NeighborsOfParent.hpp
@@ -9,9 +9,11 @@
 #include <unordered_map>
 #include <vector>
 
-#include "Domain/Amr/Flag.hpp"
-
 /// \cond
+namespace amr {
+template <size_t VolumeDim>
+struct Info;
+}  // namespace amr
 template <size_t VolumeDim, typename T>
 class DirectionMap;
 template <size_t VolumeDim>
@@ -25,13 +27,12 @@ class Neighbors;
 namespace amr {
 /// \ingroup AmrGroup
 /// \brief returns the neighbors of the Element with ElementId `parent_id`,
-/// that is created from its `children_elements_and_neighbor_flags`
+/// that is created from its `children_elements_and_neighbor_info`
 template <size_t VolumeDim>
 DirectionMap<VolumeDim, Neighbors<VolumeDim>> neighbors_of_parent(
     const ElementId<VolumeDim>& parent_id,
-    const std::vector<
-        std::tuple<const Element<VolumeDim>&,
-                   const std::unordered_map<ElementId<VolumeDim>,
-                                            std::array<Flag, VolumeDim>>&>>&
-        children_elements_and_neighbor_flags);
+    const std::vector<std::tuple<
+        const Element<VolumeDim>&,
+        const std::unordered_map<ElementId<VolumeDim>, Info<VolumeDim>>&>>&
+        children_elements_and_neighbor_info);
 }  // namespace amr

--- a/src/Domain/Amr/NewNeighborIds.cpp
+++ b/src/Domain/Amr/NewNeighborIds.cpp
@@ -10,7 +10,9 @@
 
 #include "DataStructures/Index.hpp"
 #include "DataStructures/IndexIterator.hpp"
+#include "Domain/Amr/Flag.hpp"
 #include "Domain/Amr/Helpers.hpp"
+#include "Domain/Amr/Info.hpp"
 #include "Domain/Structure/Direction.hpp"
 #include "Domain/Structure/ElementId.hpp"
 #include "Domain/Structure/Neighbors.hpp"
@@ -40,9 +42,8 @@ template <size_t VolumeDim>
 std::unordered_set<ElementId<VolumeDim>> new_neighbor_ids(
     const ElementId<VolumeDim>& my_id, const Direction<VolumeDim>& direction,
     const Neighbors<VolumeDim>& previous_neighbors_in_direction,
-    const std::unordered_map<ElementId<VolumeDim>,
-                             std::array<amr::Flag, VolumeDim>>&
-        previous_neighbors_amr_flags) {
+    const std::unordered_map<ElementId<VolumeDim>, Info<VolumeDim>>&
+        previous_neighbors_amr_info) {
   std::unordered_set<ElementId<VolumeDim>> new_neighbors_in_direction;
 
   const OrientationMap<VolumeDim>& orientation_map_from_me_to_neighbors =
@@ -55,7 +56,7 @@ std::unordered_set<ElementId<VolumeDim>> new_neighbor_ids(
     const ElementId<1>& previous_neighbor_id =
         *(previous_neighbors_in_direction.ids().begin());
     const amr::Flag neighbor_flag =
-        previous_neighbors_amr_flags.at(previous_neighbor_id)[0];
+        previous_neighbors_amr_info.at(previous_neighbor_id).flags[0];
     SegmentId previous_segment_id = previous_neighbor_id.segment_ids()[0];
     SegmentId new_segment_id =
         (amr::Flag::Join == neighbor_flag
@@ -88,7 +89,7 @@ std::unordered_set<ElementId<VolumeDim>> new_neighbor_ids(
     const auto neighbor_segment_ids = previous_neighbor_id.segment_ids();
     for (size_t d = 0; d < VolumeDim; ++d) {
       const amr::Flag neighbor_flag =
-          previous_neighbors_amr_flags.at(previous_neighbor_id)[d];
+          previous_neighbors_amr_info.at(previous_neighbor_id).flags.at(d);
       const SegmentId neighbor_segment_id = gsl::at(neighbor_segment_ids, d);
       if (dim_of_direction_to_me_in_neighbor_frame == d) {
         // This is the normal direction.  I know my previous neighbor touched
@@ -176,14 +177,13 @@ std::unordered_set<ElementId<VolumeDim>> new_neighbor_ids(
 
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 
-#define INSTANTIATE(_, data)                                          \
-  template std::unordered_set<ElementId<DIM(data)>> new_neighbor_ids( \
-      const ElementId<DIM(data)>& my_id,                              \
-      const Direction<DIM(data)>& direction,                          \
-      const Neighbors<DIM(data)>& previous_neighbors_in_direction,    \
-      const std::unordered_map<ElementId<DIM(data)>,                  \
-                               std::array<amr::Flag, DIM(data)>>&     \
-          previous_neighbors_amr_flags);
+#define INSTANTIATE(_, data)                                           \
+  template std::unordered_set<ElementId<DIM(data)>> new_neighbor_ids(  \
+      const ElementId<DIM(data)>& my_id,                               \
+      const Direction<DIM(data)>& direction,                           \
+      const Neighbors<DIM(data)>& previous_neighbors_in_direction,     \
+      const std::unordered_map<ElementId<DIM(data)>, Info<DIM(data)>>& \
+          previous_neighbors_amr_info);
 
 GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
 

--- a/src/Domain/Amr/NewNeighborIds.hpp
+++ b/src/Domain/Amr/NewNeighborIds.hpp
@@ -8,9 +8,11 @@
 #include <unordered_map>
 #include <unordered_set>
 
-#include "Domain/Amr/Flag.hpp"
-
 /// \cond
+namespace amr {
+template <size_t VolumeDim>
+struct Info;
+}  // namespace amr
 template <size_t VolumeDim>
 class Direction;
 template <size_t VolumeDim>
@@ -29,13 +31,12 @@ namespace amr {
 /// child) of the Element with `my_id` if `my_id` corresponds to a newly created
 /// child (or parent) Element.
 ///
-/// \note `previous_neighbors_amr_flags` may contain flags from neighbors in
+/// \note `previous_neighbors_amr_info` may contain info from neighbors in
 /// directions other than `direction`
 template <size_t VolumeDim>
 std::unordered_set<ElementId<VolumeDim>> new_neighbor_ids(
     const ElementId<VolumeDim>& my_id, const Direction<VolumeDim>& direction,
     const Neighbors<VolumeDim>& previous_neighbors_in_direction,
-    const std::unordered_map<ElementId<VolumeDim>,
-                             std::array<amr::Flag, VolumeDim>>&
-        previous_neighbors_amr_flags);
+    const std::unordered_map<ElementId<VolumeDim>, Info<VolumeDim>>&
+        previous_neighbors_amr_info);
 }  // namespace amr

--- a/src/Domain/Amr/Tags/Flags.hpp
+++ b/src/Domain/Amr/Tags/Flags.hpp
@@ -3,17 +3,22 @@
 
 #pragma once
 
-#include <array>
 #include <cstddef>
 
 #include "DataStructures/DataBox/Tag.hpp"
-#include "Domain/Amr/Flag.hpp"
+
+/// \cond
+namespace amr {
+template <size_t VolumeDim>
+struct Info;
+}  // namespace amr
+/// \endcond
 
 namespace amr::Tags {
-/// amr::Flag%s for an Element.
+/// amr::Info for an Element.
 template <size_t VolumeDim>
-struct Flags : db::SimpleTag {
-  using type = std::array<amr::Flag, VolumeDim>;
+struct Info : db::SimpleTag {
+  using type = amr::Info<VolumeDim>;
 };
 
 }  // namespace amr::Tags

--- a/src/Domain/Amr/Tags/NeighborFlags.hpp
+++ b/src/Domain/Amr/Tags/NeighborFlags.hpp
@@ -3,24 +3,25 @@
 
 #pragma once
 
-#include <array>
 #include <cstddef>
 #include <unordered_map>
 
 #include "DataStructures/DataBox/Tag.hpp"
-#include "Domain/Amr/Flag.hpp"
 
 /// \cond
+namespace amr {
+template <size_t VolumeDim>
+struct Info;
+}  // namespace amr
 template <size_t VolumeDim>
 class ElementId;
 /// \endcond
 
 namespace amr::Tags {
-/// amr::Flag%s for the neighbors of an Element.
+/// amr::Info for the neighbors of an Element.
 template <size_t VolumeDim>
-struct NeighborFlags : db::SimpleTag {
-  using type = std::unordered_map<ElementId<VolumeDim>,
-                                  std::array<amr::Flag, VolumeDim>>;
+struct NeighborInfo : db::SimpleTag {
+  using type = std::unordered_map<ElementId<VolumeDim>, amr::Info<VolumeDim>>;
 };
 
 }  // namespace amr::Tags

--- a/src/Domain/Amr/UpdateAmrDecision.cpp
+++ b/src/Domain/Amr/UpdateAmrDecision.cpp
@@ -3,6 +3,7 @@
 
 #include "Domain/Amr/UpdateAmrDecision.hpp"
 
+#include "Domain/Amr/Flag.hpp"
 #include "Domain/Amr/Helpers.hpp"
 #include "Domain/Structure/Direction.hpp"
 #include "Domain/Structure/Element.hpp"    // IWYU pragma: keep

--- a/src/Domain/Amr/UpdateAmrDecision.hpp
+++ b/src/Domain/Amr/UpdateAmrDecision.hpp
@@ -6,9 +6,10 @@
 #include <array>
 #include <cstddef>
 
-#include "Domain/Amr/Flag.hpp"
-
 /// \cond
+namespace amr {
+enum class Flag;
+}  // namespace amr
 namespace gsl {
 template <typename T>
 class not_null;

--- a/src/Evolution/Initialization/Evolution.hpp
+++ b/src/Evolution/Initialization/Evolution.hpp
@@ -16,6 +16,7 @@
 #include "DataStructures/DataBox/Prefixes.hpp"
 #include "Domain/Amr/Flag.hpp"
 #include "Domain/Amr/Helpers.hpp"
+#include "Domain/Amr/Info.hpp"
 #include "Domain/Amr/Tags/Flags.hpp"
 #include "Domain/Structure/ElementId.hpp"
 #include "Domain/Tags.hpp"
@@ -204,7 +205,8 @@ struct ProjectTimeStepping : tt::ConformsTo<amr::protocols::Projector> {
     // step quantities to belong to the first child
     const auto& parent_diagnostics =
         get<::Tags::AdaptiveSteppingDiagnostics>(parent_items);
-    const auto& parent_amr_flags = get<amr::Tags::Flags<Dim>>(parent_items);
+    const auto& parent_amr_flags =
+        get<amr::Tags::Info<Dim>>(parent_items).flags;
     const auto& parent_id =
         get<Parallel::Tags::ArrayIndexImpl<ElementId<Dim>>>(parent_items);
     auto children_ids = amr::ids_of_children(parent_id, parent_amr_flags);

--- a/src/ParallelAlgorithms/Amr/Actions/CollectDataFromChildren.hpp
+++ b/src/ParallelAlgorithms/Amr/Actions/CollectDataFromChildren.hpp
@@ -92,7 +92,7 @@ struct CollectDataFromChildren {
     // This is necessary because AMR flags are only communicated to face
     // neighbors.
     const auto& element = db::get<::domain::Tags::Element<volume_dim>>(box);
-    const auto& my_amr_flags = db::get<amr::Tags::Flags<volume_dim>>(box);
+    const auto& my_amr_flags = db::get<amr::Tags::Info<volume_dim>>(box).flags;
     auto ids_to_join = amr::ids_of_joining_neighbors(element, my_amr_flags);
     for (const auto& id_to_check : ids_to_join) {
       if (alg::count(sibling_ids_to_collect, id_to_check) == 0 and

--- a/src/ParallelAlgorithms/Amr/Actions/Initialize.hpp
+++ b/src/ParallelAlgorithms/Amr/Actions/Initialize.hpp
@@ -7,6 +7,7 @@
 #include <cstddef>
 
 #include "Domain/Amr/Flag.hpp"
+#include "Domain/Amr/Info.hpp"
 #include "Domain/Amr/Tags/Flags.hpp"
 #include "Domain/Amr/Tags/NeighborFlags.hpp"
 #include "Utilities/Gsl.hpp"
@@ -25,17 +26,16 @@ struct Initialize {
   using simple_tags_from_options = tmpl::list<>;
 
   using argument_tags = tmpl::list<>;
-  using return_tags = tmpl::list<amr::Tags::Flags<Dim>>;
+  using return_tags = tmpl::list<amr::Tags::Info<Dim>>;
   using simple_tags =
-      tmpl::push_back<return_tags, amr::Tags::NeighborFlags<Dim>>;
+      tmpl::push_back<return_tags, amr::Tags::NeighborInfo<Dim>>;
 
   using compute_tags = tmpl::list<>;
 
   /// Given the items fetched from a DataBox by the argument_tags, mutate
   /// the items in the DataBox corresponding to return_tags
-  static void apply(
-      const gsl::not_null<std::array<amr::Flag, Dim>*> amr_flags) {
-    *amr_flags = make_array<Dim>(amr::Flag::Undefined);
+  static void apply(const gsl::not_null<amr::Info<Dim>*> amr_info) {
+    amr_info->flags = make_array<Dim>(amr::Flag::Undefined);
   }
 };
 }  // namespace amr::Initialization

--- a/src/ParallelAlgorithms/Amr/Actions/InitializeChild.hpp
+++ b/src/ParallelAlgorithms/Amr/Actions/InitializeChild.hpp
@@ -56,18 +56,18 @@ struct InitializeChild {
     const auto& parent =
         tuples::get<::domain::Tags::Element<volume_dim>>(parent_items);
     const auto& parent_flags =
-        tuples::get<amr::Tags::Flags<volume_dim>>(parent_items);
-    const auto& parent_neighbor_flags =
-        tuples::get<amr::Tags::NeighborFlags<volume_dim>>(parent_items);
+        tuples::get<amr::Tags::Info<volume_dim>>(parent_items).flags;
+    const auto& parent_neighbor_info =
+        tuples::get<amr::Tags::NeighborInfo<volume_dim>>(parent_items);
     const auto& parent_mesh =
         tuples::get<::domain::Tags::Mesh<volume_dim>>(parent_items);
     auto neighbors = amr::neighbors_of_child(parent, parent_flags,
-                                             parent_neighbor_flags, child_id);
+                                             parent_neighbor_info, child_id);
     Element<volume_dim> child(child_id, std::move(neighbors));
     Mesh<volume_dim> child_mesh =
         amr::projectors::mesh(parent_mesh, parent_flags);
 
-    // Default initialization of amr::Tags::Flags and amr::Tags::NeighborFlags
+    // Default initialization of amr::Tags::Info and amr::Tags::NeighborInfo
     // is okay
     ::Initialization::mutate_assign<tmpl::list<
         ::domain::Tags::Element<volume_dim>, ::domain::Tags::Mesh<volume_dim>>>(

--- a/src/ParallelAlgorithms/Amr/Projectors/CMakeLists.txt
+++ b/src/ParallelAlgorithms/Amr/Projectors/CMakeLists.txt
@@ -26,5 +26,6 @@ target_link_libraries(
   PRIVATE
   Amr
   DataStructures
+  DomainStructure
   Spectral
   )

--- a/src/ParallelAlgorithms/Amr/Projectors/Mesh.hpp
+++ b/src/ParallelAlgorithms/Amr/Projectors/Mesh.hpp
@@ -5,11 +5,19 @@
 
 #include <array>
 #include <cstddef>
+#include <unordered_map>
 #include <vector>
 
-#include "Domain/Amr/Flag.hpp"
-
 /// \cond
+namespace amr {
+enum class Flag;
+template <size_t>
+struct Info;
+}  // namespace amr
+template <size_t>
+class Element;
+template <size_t>
+class ElementId;
 template <size_t>
 class Mesh;
 /// \endcond
@@ -27,4 +35,16 @@ Mesh<Dim> mesh(const Mesh<Dim>& old_mesh,
 /// maximum over the extents of each child Mesh
 template <size_t Dim>
 Mesh<Dim> parent_mesh(const std::vector<Mesh<Dim>>& children_meshes);
+
+/// \brief Computes the new Mesh of an Element after AMR
+///
+/// \details The returned Mesh will be that of either `element` or its parent or
+/// children depending upon the `flags`.  If an Element is joining, the returned
+/// Mesh will be that given by amr::projectors::parent_mesh; otherwise it will
+/// be given by amr::projectors::mesh
+template <size_t Dim>
+Mesh<Dim> new_mesh(
+    const Mesh<Dim>& current_mesh, const std::array<Flag, Dim>& flags,
+    const Element<Dim>& element,
+    const std::unordered_map<ElementId<Dim>, Info<Dim>>& neighbors_info);
 }  // namespace amr::projectors

--- a/tests/Unit/Domain/Amr/CMakeLists.txt
+++ b/tests/Unit/Domain/Amr/CMakeLists.txt
@@ -6,6 +6,7 @@ set(LIBRARY "Test_Amr")
 set(LIBRARY_SOURCES
   Test_Flag.cpp
   Test_Helpers.cpp
+  Test_Info.cpp
   Test_NeighborsOfChild.cpp
   Test_NeighborsOfParent.cpp
   Test_NewNeighborIds.cpp

--- a/tests/Unit/Domain/Amr/Test_Info.cpp
+++ b/tests/Unit/Domain/Amr/Test_Info.cpp
@@ -1,0 +1,33 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <vector>
+
+#include "Domain/Amr/Flag.hpp"
+#include "Domain/Amr/Info.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "Utilities/GetOutput.hpp"
+#include "Utilities/MakeString.hpp"
+
+SPECTRE_TEST_CASE("Unit.Domain.Amr.Info", "[Domain][Unit]") {
+  amr::Info<1> info_0{std::array{amr::Flag::Join},
+                      Mesh<1>{3_st, Spectral::Basis::Legendre,
+                              Spectral::Quadrature::GaussLobatto}};
+  amr::Info<1> info_1{std::array{amr::Flag::Split},
+                      Mesh<1>{3_st, Spectral::Basis::Legendre,
+                              Spectral::Quadrature::GaussLobatto}};
+  amr::Info<1> info_2{std::array{amr::Flag::Split},
+                      Mesh<1>{4_st, Spectral::Basis::Legendre,
+                              Spectral::Quadrature::GaussLobatto}};
+  test_serialization(info_0);
+  CHECK(info_0 != info_1);
+  CHECK(info_1 != info_2);
+  CHECK(info_0 != info_2);
+  std::string expected_output = MakeString{}
+                                << "Flags: " << info_0.flags
+                                << " New mesh: " << info_0.new_mesh;
+  CHECK(get_output(info_0) == expected_output);
+}

--- a/tests/Unit/Domain/Amr/Test_NeighborsOfChild.cpp
+++ b/tests/Unit/Domain/Amr/Test_NeighborsOfChild.cpp
@@ -12,6 +12,7 @@
 
 #include "Domain/Amr/Flag.hpp"
 #include "Domain/Amr/Helpers.hpp"
+#include "Domain/Amr/Info.hpp"
 #include "Domain/Amr/NeighborsOfChild.hpp"
 #include "Domain/Amr/NewNeighborIds.hpp"
 #include "Domain/Structure/Direction.hpp"
@@ -121,22 +122,22 @@ std::vector<std::array<amr::Flag, 3>> valid_parent_flags<3>() {
 }
 
 template <size_t Dim>
-TestHelpers::amr::valid_flags_t<Dim> valid_parent_neighbor_flags(
+TestHelpers::amr::valid_info_t<Dim> valid_parent_neighbor_info(
     const Element<Dim>& element,
     const std::array<::amr::Flag, Dim>& element_flags) {
-  TestHelpers::amr::valid_flags_t<Dim> result{};
-  const auto valid_lower_xi_neighbor_flags =
-      TestHelpers::amr::valid_neighbor_flags(
+  TestHelpers::amr::valid_info_t<Dim> result{};
+  const auto valid_lower_xi_neighbor_info =
+      TestHelpers::amr::valid_neighbor_info(
           element.id(), element_flags,
           element.neighbors().at(Direction<Dim>::lower_xi()));
-  const auto valid_upper_xi_neighbor_flags =
-      TestHelpers::amr::valid_neighbor_flags(
+  const auto valid_upper_xi_neighbor_info =
+      TestHelpers::amr::valid_neighbor_info(
           element.id(), element_flags,
           element.neighbors().at(Direction<Dim>::upper_xi()));
-  for (const auto& lower_xi_neighbor_flags : valid_lower_xi_neighbor_flags) {
-    for (const auto& upper_xi_neighbor_flags : valid_upper_xi_neighbor_flags) {
-      auto joined_flags = lower_xi_neighbor_flags;
-      for (const auto& flags : upper_xi_neighbor_flags) {
+  for (const auto& lower_xi_neighbor_info : valid_lower_xi_neighbor_info) {
+    for (const auto& upper_xi_neighbor_info : valid_upper_xi_neighbor_info) {
+      auto joined_flags = lower_xi_neighbor_info;
+      for (const auto& flags : upper_xi_neighbor_info) {
         joined_flags.emplace(flags);
       }
       result.emplace_back(joined_flags);
@@ -155,15 +156,15 @@ void test(const gsl::not_null<std::mt19937*> generator) {
       CAPTURE(parent);
       for (const auto& parent_flags : valid_parent_flags<Dim>()) {
         CAPTURE(parent_flags);
-        for (const auto& parent_neighbor_flags :
-             random_sample(3, valid_parent_neighbor_flags(parent, parent_flags),
+        for (const auto& parent_neighbor_info :
+             random_sample(3, valid_parent_neighbor_info(parent, parent_flags),
                            generator)) {
-          CAPTURE(parent_neighbor_flags);
+          CAPTURE(parent_neighbor_info);
           for (const auto& child_id :
                amr::ids_of_children(parent_id, parent_flags)) {
             CAPTURE(child_id);
             const auto new_neighbors = amr::neighbors_of_child(
-                parent, parent_flags, parent_neighbor_flags, child_id);
+                parent, parent_flags, parent_neighbor_info, child_id);
             for (const auto& direction : std::vector{
                      Direction<Dim>::lower_xi(), Direction<Dim>::upper_xi()}) {
               TestHelpers::domain::check_neighbors(new_neighbors.at(direction),

--- a/tests/Unit/Domain/Amr/Test_NewNeighborIds.cpp
+++ b/tests/Unit/Domain/Amr/Test_NewNeighborIds.cpp
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include "Domain/Amr/Flag.hpp"
+#include "Domain/Amr/Info.hpp"
 #include "Domain/Amr/NewNeighborIds.hpp"
 #include "Domain/Structure/Direction.hpp"
 #include "Domain/Structure/ElementId.hpp"
@@ -77,17 +78,17 @@ void test(const gsl::not_null<std::mt19937*> generator) {
                                  generator, element_id, direction, face_type),
                              generator)) {
             CAPTURE(neighbors);
-            for (const auto& neighbor_flags : random_sample(
+            for (const auto& neighbor_info : random_sample(
                      5,
-                     TestHelpers::amr::valid_neighbor_flags(
+                     TestHelpers::amr::valid_neighbor_info(
                          element_id,
                          make_array<Dim>(::amr::Flag::IncreaseResolution),
                          neighbors),
                      generator)) {
-              CAPTURE(neighbor_flags);
+              CAPTURE(neighbor_info);
               const auto new_neighbors =
                   Neighbors<Dim>{new_neighbor_ids(element_id, direction,
-                                                  neighbors, neighbor_flags),
+                                                  neighbors, neighbor_info),
                                  neighbors.orientation()};
               CAPTURE(new_neighbors);
               TestHelpers::domain::check_neighbors(new_neighbors, element_id,
@@ -102,17 +103,17 @@ void test(const gsl::not_null<std::mt19937*> generator) {
                                generator, element_id, direction),
                            generator)) {
           CAPTURE(neighbors);
-          for (const auto& neighbor_flags : random_sample(
+          for (const auto& neighbor_info : random_sample(
                    5,
-                   TestHelpers::amr::valid_neighbor_flags(
+                   TestHelpers::amr::valid_neighbor_info(
                        element_id,
                        make_array<Dim>(::amr::Flag::IncreaseResolution),
                        neighbors),
                    generator)) {
-            CAPTURE(neighbor_flags);
+            CAPTURE(neighbor_info);
             const auto new_neighbors =
                 Neighbors<Dim>{new_neighbor_ids(element_id, direction,
-                                                neighbors, neighbor_flags),
+                                                neighbors, neighbor_info),
                                neighbors.orientation()};
             CAPTURE(new_neighbors);
             TestHelpers::domain::check_neighbors(new_neighbors, element_id,

--- a/tests/Unit/Domain/Amr/Test_Tags.cpp
+++ b/tests/Unit/Domain/Amr/Test_Tags.cpp
@@ -10,9 +10,9 @@
 namespace {
 template <size_t Dim>
 void test() {
-  TestHelpers::db::test_simple_tag<amr::Tags::Flags<Dim>>("Flags");
-  TestHelpers::db::test_simple_tag<amr::Tags::NeighborFlags<Dim>>(
-      "NeighborFlags");
+  TestHelpers::db::test_simple_tag<amr::Tags::Info<Dim>>("Info");
+  TestHelpers::db::test_simple_tag<amr::Tags::NeighborInfo<Dim>>(
+      "NeighborInfo");
 }
 }  // namespace
 

--- a/tests/Unit/Evolution/Initialization/Test_Evolution.cpp
+++ b/tests/Unit/Evolution/Initialization/Test_Evolution.cpp
@@ -155,7 +155,7 @@ using parent_items_type =
                         ::Tags::TimeStepId, ::Tags::Next<::Tags::TimeStepId>,
                         ::Tags::TimeStep, ::Tags::Next<::Tags::TimeStep>,
                         ::Tags::Time, ::Tags::AdaptiveSteppingDiagnostics,
-                        ::amr::Tags::Flags<1>>;
+                        ::amr::Tags::Info<1>>;
 
 template <typename DbTagList>
 void check(const db::DataBox<DbTagList>& box,
@@ -221,10 +221,14 @@ void test_split() {
   const AdaptiveSteppingDiagnostics diagnostics{7, 2, 13, 4, 5};
 
   const parent_items_type parent_items{
-      parent_id,         time_step_id,
-      next_time_step_id, time_step,
-      next_time_step,    time,
-      diagnostics,       std::array{::amr::Flag::Split}};
+      parent_id,
+      time_step_id,
+      next_time_step_id,
+      time_step,
+      next_time_step,
+      time,
+      diagnostics,
+      ::amr::Info<1>{std::array{::amr::Flag::Split}, Mesh<1>{}}};
 
   auto child_1_box = db::create<
       db::AddSimpleTags<Parallel::Tags::ArrayIndexImpl<ElementId<1>>,

--- a/tests/Unit/Helpers/Domain/Amr/NeighborFlagHelpers.hpp
+++ b/tests/Unit/Helpers/Domain/Amr/NeighborFlagHelpers.hpp
@@ -8,9 +8,12 @@
 #include <unordered_map>
 #include <vector>
 
-#include "Domain/Amr/Flag.hpp"
-
 /// \cond
+namespace amr {
+enum class Flag;
+template <size_t VolumeDim>
+struct Info;
+}  // namespace amr
 template <size_t Dim>
 class ElementId;
 template <size_t Dim>
@@ -19,16 +22,15 @@ class Neighbors;
 
 namespace TestHelpers::amr {
 template <size_t Dim>
-using neighbor_flags_t =
-    std::unordered_map<ElementId<Dim>, std::array<::amr::Flag, Dim>>;
+using neighbor_info_t = std::unordered_map<ElementId<Dim>, ::amr::Info<Dim>>;
 
 template <size_t Dim>
-using valid_flags_t = std::vector<neighbor_flags_t<Dim>>;
+using valid_info_t = std::vector<neighbor_info_t<Dim>>;
 
 /// Returns all permutations of valid flags for the `neighbors` (in a single
 /// direction) of an Element with `element_id` and `element_flags`
 template <size_t Dim>
-valid_flags_t<Dim> valid_neighbor_flags(
+valid_info_t<Dim> valid_neighbor_info(
     const ElementId<Dim>& element_id,
     const std::array<::amr::Flag, Dim>& element_flags,
     const Neighbors<Dim>& neighbors);

--- a/tests/Unit/Helpers/Tests/Domain/Amr/Test_NeighborFlagHelpers.cpp
+++ b/tests/Unit/Helpers/Tests/Domain/Amr/Test_NeighborFlagHelpers.cpp
@@ -7,17 +7,19 @@
 
 #include "Domain/Amr/Flag.hpp"
 #include "Domain/Amr/Helpers.hpp"
+#include "Domain/Amr/Info.hpp"
 #include "Domain/Structure/ElementId.hpp"
 #include "Domain/Structure/Neighbors.hpp"
 #include "Domain/Structure/OrientationMap.hpp"
 #include "Domain/Structure/SegmentId.hpp"
 #include "Helpers/Domain/Amr/NeighborFlagHelpers.hpp"
 #include "Helpers/Domain/Structure/NeighborHelpers.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "Utilities/StdHelpers.hpp"
 
 namespace TestHelpers::amr {
 namespace {
-void test_valid_neighbor_flags_1d() {
+void test_valid_neighbor_info_1d() {
   const ElementId<1> root{0};
   const ElementId<1> neighbor_root{2};
   const ElementId<1> lower_child{0, std::array{SegmentId{1, 0}}};
@@ -27,54 +29,55 @@ void test_valid_neighbor_flags_1d() {
   const auto split = std::array{::amr::Flag::Split};
   const auto join = std::array{::amr::Flag::Join};
   const auto stay = std::array{::amr::Flag::IncreaseResolution};
-  const auto all_allowed = [&join, &stay,
-                            &split](const ElementId<1>& neighbor_id) {
-    return std::vector{neighbor_flags_t<1>{{neighbor_id, join}},
-                       neighbor_flags_t<1>{{neighbor_id, stay}},
-                       neighbor_flags_t<1>{{neighbor_id, split}}};
+  const Mesh<1> mesh;
+  const auto all_allowed = [&join, &stay, &split,
+                            &mesh](const ElementId<1>& neighbor_id) {
+    return std::vector{neighbor_info_t<1>{{neighbor_id, {join, mesh}}},
+                       neighbor_info_t<1>{{neighbor_id, {stay, mesh}}},
+                       neighbor_info_t<1>{{neighbor_id, {split, mesh}}}};
   };
-  const auto join_not_allowed = [&stay,
-                                 &split](const ElementId<1>& neighbor_id) {
-    return std::vector{neighbor_flags_t<1>{{neighbor_id, stay}},
-                       neighbor_flags_t<1>{{neighbor_id, split}}};
+  const auto join_not_allowed = [&stay, &split,
+                                 &mesh](const ElementId<1>& neighbor_id) {
+    return std::vector{neighbor_info_t<1>{{neighbor_id, {stay, mesh}}},
+                       neighbor_info_t<1>{{neighbor_id, {split, mesh}}}};
   };
-  const auto split_not_allowed = [&join,
-                                  &stay](const ElementId<1>& neighbor_id) {
-    return std::vector{neighbor_flags_t<1>{{neighbor_id, join}},
-                       neighbor_flags_t<1>{{neighbor_id, stay}}};
+  const auto split_not_allowed = [&join, &stay,
+                                  &mesh](const ElementId<1>& neighbor_id) {
+    return std::vector{neighbor_info_t<1>{{neighbor_id, {join, mesh}}},
+                       neighbor_info_t<1>{{neighbor_id, {stay, mesh}}}};
   };
   const OrientationMap<1> aligned{};
-  CHECK(valid_neighbor_flags(
+  CHECK(valid_neighbor_info(
             root, stay,
             Neighbors<1>{std::unordered_set{neighbor_root}, aligned}) ==
         join_not_allowed(neighbor_root));
-  CHECK(valid_neighbor_flags(
+  CHECK(valid_neighbor_info(
             upper_child, stay,
             Neighbors<1>{std::unordered_set{neighbor_root}, aligned}) ==
         join_not_allowed(neighbor_root));
-  CHECK(valid_neighbor_flags(
+  CHECK(valid_neighbor_info(
             lower_child, stay,
             Neighbors<1>{std::unordered_set{upper_child}, aligned}) ==
         join_not_allowed(upper_child));
-  CHECK(valid_neighbor_flags(
+  CHECK(valid_neighbor_info(
             lower_child, stay,
             Neighbors<1>{std::unordered_set{abutting_nibling}, aligned}) ==
         split_not_allowed(abutting_nibling));
-  CHECK(valid_neighbor_flags(
+  CHECK(valid_neighbor_info(
             root, stay,
             Neighbors<1>{std::unordered_set{neighbor_child}, aligned}) ==
         split_not_allowed(neighbor_child));
-  CHECK(valid_neighbor_flags(
+  CHECK(valid_neighbor_info(
             upper_child, stay,
             Neighbors<1>{std::unordered_set{neighbor_child}, aligned}) ==
         all_allowed(neighbor_child));
-  CHECK(valid_neighbor_flags(
+  CHECK(valid_neighbor_info(
             abutting_nibling, stay,
             Neighbors<1>{std::unordered_set{lower_child}, aligned}) ==
         join_not_allowed(lower_child));
 }
 
-void test_valid_neighbor_flags_2d() {
+void test_valid_neighbor_info_2d() {
   ElementId<2> element_id{0, std::array{SegmentId{2, 3}, SegmentId{3, 4}}};
   const auto join_join = std::array{::amr::Flag::Join, ::amr::Flag::Join};
   const auto join_stay =
@@ -93,63 +96,67 @@ void test_valid_neighbor_flags_2d() {
   const Neighbors<2> neighbors_0{std::unordered_set{neighbor_0}, aligned};
   ::TestHelpers::domain::check_neighbors(neighbors_0, element_id,
                                          Direction<2>::upper_xi());
-  CHECK(valid_neighbor_flags(element_id, stay_stay, neighbors_0) ==
-        std::vector{neighbor_flags_t<2>{{neighbor_0, join_join}},
-                    neighbor_flags_t<2>{{neighbor_0, join_stay}},
-                    neighbor_flags_t<2>{{neighbor_0, stay_join}},
-                    neighbor_flags_t<2>{{neighbor_0, stay_stay}},
-                    neighbor_flags_t<2>{{neighbor_0, stay_split}},
-                    neighbor_flags_t<2>{{neighbor_0, split_stay}},
-                    neighbor_flags_t<2>{{neighbor_0, split_split}}});
+  const Mesh<2> mesh;
+  CHECK(valid_neighbor_info(element_id, stay_stay, neighbors_0) ==
+        std::vector{neighbor_info_t<2>{{neighbor_0, {join_join, mesh}}},
+                    neighbor_info_t<2>{{neighbor_0, {join_stay, mesh}}},
+                    neighbor_info_t<2>{{neighbor_0, {stay_join, mesh}}},
+                    neighbor_info_t<2>{{neighbor_0, {stay_stay, mesh}}},
+                    neighbor_info_t<2>{{neighbor_0, {stay_split, mesh}}},
+                    neighbor_info_t<2>{{neighbor_0, {split_stay, mesh}}},
+                    neighbor_info_t<2>{{neighbor_0, {split_split, mesh}}}});
   ElementId<2> neighbor_1{1, std::array{SegmentId{2, 0}, SegmentId{4, 8}}};
   ElementId<2> neighbor_2{1, std::array{SegmentId{2, 0}, SegmentId{4, 9}}};
   const Neighbors<2> neighbors_1_2{std::unordered_set{neighbor_1, neighbor_2},
                                    aligned};
   ::TestHelpers::domain::check_neighbors(neighbors_1_2, element_id,
                                          Direction<2>::upper_xi());
-  CHECK(
-      valid_neighbor_flags(element_id, stay_stay, neighbors_1_2) ==
-      std::vector{
-          neighbor_flags_t<2>{{neighbor_1, join_join}, {neighbor_2, join_join}},
-          neighbor_flags_t<2>{{neighbor_1, join_stay}, {neighbor_2, join_stay}},
-          neighbor_flags_t<2>{{neighbor_1, join_stay}, {neighbor_2, stay_stay}},
-          neighbor_flags_t<2>{{neighbor_1, stay_join}, {neighbor_2, stay_join}},
-          neighbor_flags_t<2>{{neighbor_1, stay_stay}, {neighbor_2, stay_stay}},
-          neighbor_flags_t<2>{{neighbor_1, stay_stay},
-                              {neighbor_2, split_stay}},
-          neighbor_flags_t<2>{{neighbor_1, split_stay},
-                              {neighbor_2, stay_stay}},
-          neighbor_flags_t<2>{{neighbor_1, split_stay},
-                              {neighbor_2, split_stay}}});
+  CHECK(valid_neighbor_info(element_id, stay_stay, neighbors_1_2) ==
+        std::vector{neighbor_info_t<2>{{neighbor_1, {join_join, mesh}},
+                                       {neighbor_2, {join_join, mesh}}},
+                    neighbor_info_t<2>{{neighbor_1, {join_stay, mesh}},
+                                       {neighbor_2, {join_stay, mesh}}},
+                    neighbor_info_t<2>{{neighbor_1, {join_stay, mesh}},
+                                       {neighbor_2, {stay_stay, mesh}}},
+                    neighbor_info_t<2>{{neighbor_1, {stay_join, mesh}},
+                                       {neighbor_2, {stay_join, mesh}}},
+                    neighbor_info_t<2>{{neighbor_1, {stay_stay, mesh}},
+                                       {neighbor_2, {stay_stay, mesh}}},
+                    neighbor_info_t<2>{{neighbor_1, {stay_stay, mesh}},
+                                       {neighbor_2, {split_stay, mesh}}},
+                    neighbor_info_t<2>{{neighbor_1, {split_stay, mesh}},
+                                       {neighbor_2, {stay_stay, mesh}}},
+                    neighbor_info_t<2>{{neighbor_1, {split_stay, mesh}},
+                                       {neighbor_2, {split_stay, mesh}}}});
   ElementId<2> neighbor_3{1, std::array{SegmentId{2, 0}, SegmentId{2, 2}}};
   const Neighbors<2> neighbors_3{std::unordered_set{neighbor_3}, aligned};
   ::TestHelpers::domain::check_neighbors(neighbors_3, element_id,
                                          Direction<2>::upper_xi());
-  CHECK(valid_neighbor_flags(element_id, stay_stay, neighbors_3) ==
-        std::vector{neighbor_flags_t<2>{{neighbor_3, join_stay}},
-                    neighbor_flags_t<2>{{neighbor_3, stay_stay}},
-                    neighbor_flags_t<2>{{neighbor_3, stay_split}},
-                    neighbor_flags_t<2>{{neighbor_3, split_stay}},
-                    neighbor_flags_t<2>{{neighbor_3, split_split}}});
+  CHECK(valid_neighbor_info(element_id, stay_stay, neighbors_3) ==
+        std::vector{neighbor_info_t<2>{{neighbor_3, {join_stay, mesh}}},
+                    neighbor_info_t<2>{{neighbor_3, {stay_stay, mesh}}},
+                    neighbor_info_t<2>{{neighbor_3, {stay_split, mesh}}},
+                    neighbor_info_t<2>{{neighbor_3, {split_stay, mesh}}},
+                    neighbor_info_t<2>{{neighbor_3, {split_split, mesh}}}});
   ElementId<2> neighbor_4{1, std::array{SegmentId{2, 2}, SegmentId{2, 3}}};
   const OrientationMap<2> rotated{
       std::array{Direction<2>::lower_eta(), Direction<2>::upper_xi()}};
   const Neighbors<2> neighbors_4{std::unordered_set{neighbor_4}, rotated};
   ::TestHelpers::domain::check_neighbors(neighbors_4, element_id,
                                          Direction<2>::upper_xi());
-  CHECK(valid_neighbor_flags(element_id, stay_stay, neighbors_4) ==
-        std::vector{neighbor_flags_t<2>{{neighbor_4, stay_join}},
-                    neighbor_flags_t<2>{{neighbor_4, stay_stay}},
-                    neighbor_flags_t<2>{{neighbor_4, stay_split}},
-                    neighbor_flags_t<2>{{neighbor_4, split_stay}},
-                    neighbor_flags_t<2>{{neighbor_4, split_split}}});
+  CHECK(valid_neighbor_info(element_id, stay_stay, neighbors_4) ==
+        std::vector{neighbor_info_t<2>{{neighbor_4, {stay_join, mesh}}},
+                    neighbor_info_t<2>{{neighbor_4, {stay_stay, mesh}}},
+                    neighbor_info_t<2>{{neighbor_4, {stay_split, mesh}}},
+                    neighbor_info_t<2>{{neighbor_4, {split_stay, mesh}}},
+                    neighbor_info_t<2>{{neighbor_4, {split_split, mesh}}}});
 }
 }  // namespace
 
 SPECTRE_TEST_CASE("TestHelpers.Domain.Amr.NeighborFlagHelpers",
                   "[Domain][Unit]") {
-  test_valid_neighbor_flags_1d();
-  test_valid_neighbor_flags_2d();
+  test_valid_neighbor_info_1d();
+  test_valid_neighbor_info_2d();
   // testing 3d does not test anything new
 }
 }  // namespace TestHelpers::amr

--- a/tests/Unit/ParallelAlgorithms/Amr/Actions/Test_CollectDataFromChildren.cpp
+++ b/tests/Unit/ParallelAlgorithms/Amr/Actions/Test_CollectDataFromChildren.cpp
@@ -10,7 +10,9 @@
 #include <unordered_set>
 #include <vector>
 
+#include "Domain/Amr/Flag.hpp"
 #include "Domain/Amr/Helpers.hpp"
+#include "Domain/Amr/Info.hpp"
 #include "Domain/Amr/Tags/Flags.hpp"
 #include "Domain/Amr/Tags/NeighborFlags.hpp"
 #include "Domain/Structure/Direction.hpp"
@@ -34,14 +36,17 @@
 #include "Utilities/TaggedTuple.hpp"
 
 namespace {
-ElementId<2> parent_id{0, std::array{SegmentId{0, 0}, SegmentId{0, 0}}};
-ElementId<2> child_1_id{0, std::array{SegmentId{1, 0}, SegmentId{1, 0}}};
-ElementId<2> child_2_id{0, std::array{SegmentId{1, 1}, SegmentId{1, 0}}};
-ElementId<2> child_3_id{0, std::array{SegmentId{1, 0}, SegmentId{1, 1}}};
-ElementId<2> child_4_id{0, std::array{SegmentId{1, 1}, SegmentId{1, 1}}};
-ElementId<2> neighbor_1_id{1, std::array{SegmentId{1, 1}, SegmentId{0, 0}}};
-ElementId<2> neighbor_2_id{2, std::array{SegmentId{1, 0}, SegmentId{0, 0}}};
-ElementId<2> neighbor_3_id{2, std::array{SegmentId{1, 1}, SegmentId{1, 1}}};
+const ElementId<2> parent_id{0, std::array{SegmentId{0, 0}, SegmentId{0, 0}}};
+const ElementId<2> child_1_id{0, std::array{SegmentId{1, 0}, SegmentId{1, 0}}};
+const ElementId<2> child_2_id{0, std::array{SegmentId{1, 1}, SegmentId{1, 0}}};
+const ElementId<2> child_3_id{0, std::array{SegmentId{1, 0}, SegmentId{1, 1}}};
+const ElementId<2> child_4_id{0, std::array{SegmentId{1, 1}, SegmentId{1, 1}}};
+const ElementId<2> neighbor_1_id{1,
+                                 std::array{SegmentId{1, 1}, SegmentId{0, 0}}};
+const ElementId<2> neighbor_2_id{2,
+                                 std::array{SegmentId{0, 0}, SegmentId{1, 0}}};
+const ElementId<2> neighbor_3_id{2,
+                                 std::array{SegmentId{1, 0}, SegmentId{1, 1}}};
 
 auto child_1_mesh() {
   return Mesh<2>{std::array{3_st, 3_st}, Spectral::Basis::Legendre,
@@ -60,9 +65,39 @@ auto child_4_mesh() {
                  Spectral::Quadrature::GaussLobatto};
 }
 
-auto child_flags() { return std::array{amr::Flag::Join, amr::Flag::Join}; }
-auto neighbor_1_flags() {
-  return std::array{amr::Flag::Join, amr::Flag::DoNothing};
+auto neighbor_1_mesh() {
+  return Mesh<2>{std::array{5_st, 4_st}, Spectral::Basis::Legendre,
+                 Spectral::Quadrature::GaussLobatto};
+}
+
+auto neighbor_2_mesh() {
+  return Mesh<2>{std::array{2_st, 3_st}, Spectral::Basis::Legendre,
+                 Spectral::Quadrature::GaussLobatto};
+}
+
+auto neighbor_3_mesh() {
+  return Mesh<2>{std::array{3_st, 5_st}, Spectral::Basis::Legendre,
+                 Spectral::Quadrature::GaussLobatto};
+}
+
+auto child_info() {
+  return amr::Info<2>{std::array{amr::Flag::Join, amr::Flag::Join},
+                      child_4_mesh()};
+}
+
+auto neighbor_1_info() {
+  return amr::Info<2>{std::array{amr::Flag::Join, amr::Flag::DoNothing},
+                      neighbor_1_mesh()};
+}
+
+auto neighbor_2_info() {
+  return amr::Info<2>{std::array{amr::Flag::Split, amr::Flag::DoNothing},
+                      neighbor_2_mesh()};
+}
+
+auto neighbor_3_info() {
+  return amr::Info<2>{std::array{amr::Flag::Join, amr::Flag::DoNothing},
+                      neighbor_3_mesh()};
 }
 
 Element<2> child_1() {
@@ -133,31 +168,31 @@ Element<2> child_4() {
   return result;
 }
 
-auto child_1_neighbor_flags() {
-  return std::unordered_map<ElementId<2>, std::array<amr::Flag, 2>>{
-      {neighbor_1_id, neighbor_1_flags()},
-      {child_2_id, child_flags()},
-      {child_3_id, child_flags()}};
+auto child_1_neighbor_info() {
+  return std::unordered_map<ElementId<2>, amr::Info<2>>{
+      {neighbor_1_id, neighbor_1_info()},
+      {child_2_id, child_info()},
+      {child_3_id, child_info()}};
 }
 
-auto child_2_neighbor_flags() {
-  return std::unordered_map<ElementId<2>, std::array<amr::Flag, 2>>{
-      {child_1_id, child_flags()},
-      {child_4_id, child_flags()},
-      {neighbor_2_id, std::array{amr::Flag::DoNothing, amr::Flag::Split}}};
+auto child_2_neighbor_info() {
+  return std::unordered_map<ElementId<2>, amr::Info<2>>{
+      {child_1_id, child_info()},
+      {child_4_id, child_info()},
+      {neighbor_2_id, neighbor_2_info()}};
 }
 
-auto child_3_neighbor_flags() {
-  return std::unordered_map<ElementId<2>, std::array<amr::Flag, 2>>{
-      {neighbor_1_id, neighbor_1_flags()},
-      {child_1_id, child_flags()},
-      {child_4_id, child_flags()}};
+auto child_3_neighbor_info() {
+  return std::unordered_map<ElementId<2>, amr::Info<2>>{
+      {neighbor_1_id, neighbor_1_info()},
+      {child_1_id, child_info()},
+      {child_4_id, child_info()}};
 }
-auto child_4_neighbor_flags() {
-  return std::unordered_map<ElementId<2>, std::array<amr::Flag, 2>>{
-      {child_2_id, child_flags()},
-      {child_3_id, child_flags()},
-      {neighbor_3_id, std::array{amr::Flag::DoNothing, amr::Flag::Join}}};
+auto child_4_neighbor_info() {
+  return std::unordered_map<ElementId<2>, amr::Info<2>>{
+      {child_2_id, child_info()},
+      {child_3_id, child_info()},
+      {neighbor_3_id, neighbor_3_info()}};
 }
 
 struct MockInitializeParent {
@@ -172,30 +207,30 @@ struct MockInitializeParent {
     const auto& child_1_items = children_items.at(child_1_id);
     CHECK(get<domain::Tags::Element<2>>(child_1_items) == child_1());
     CHECK(get<domain::Tags::Mesh<2>>(child_1_items) == child_1_mesh());
-    CHECK(get<amr::Tags::Flags<2>>(child_1_items) == child_flags());
-    CHECK(get<amr::Tags::NeighborFlags<2>>(child_1_items) ==
-          child_1_neighbor_flags());
+    CHECK(get<amr::Tags::Info<2>>(child_1_items) == child_info());
+    CHECK(get<amr::Tags::NeighborInfo<2>>(child_1_items) ==
+          child_1_neighbor_info());
 
     const auto& child_2_items = children_items.at(child_2_id);
     CHECK(get<domain::Tags::Element<2>>(child_2_items) == child_2());
     CHECK(get<domain::Tags::Mesh<2>>(child_2_items) == child_2_mesh());
-    CHECK(get<amr::Tags::Flags<2>>(child_2_items) == child_flags());
-    CHECK(get<amr::Tags::NeighborFlags<2>>(child_2_items) ==
-          child_2_neighbor_flags());
+    CHECK(get<amr::Tags::Info<2>>(child_2_items) == child_info());
+    CHECK(get<amr::Tags::NeighborInfo<2>>(child_2_items) ==
+          child_2_neighbor_info());
 
     const auto& child_3_items = children_items.at(child_3_id);
     CHECK(get<domain::Tags::Element<2>>(child_3_items) == child_3());
     CHECK(get<domain::Tags::Mesh<2>>(child_3_items) == child_3_mesh());
-    CHECK(get<amr::Tags::Flags<2>>(child_3_items) == child_flags());
-    CHECK(get<amr::Tags::NeighborFlags<2>>(child_3_items) ==
-          child_3_neighbor_flags());
+    CHECK(get<amr::Tags::Info<2>>(child_3_items) == child_info());
+    CHECK(get<amr::Tags::NeighborInfo<2>>(child_3_items) ==
+          child_3_neighbor_info());
 
     const auto& child_4_items = children_items.at(child_4_id);
     CHECK(get<domain::Tags::Element<2>>(child_4_items) == child_4());
     CHECK(get<domain::Tags::Mesh<2>>(child_4_items) == child_4_mesh());
-    CHECK(get<amr::Tags::Flags<2>>(child_4_items) == child_flags());
-    CHECK(get<amr::Tags::NeighborFlags<2>>(child_4_items) ==
-          child_4_neighbor_flags());
+    CHECK(get<amr::Tags::Info<2>>(child_4_items) == child_info());
+    CHECK(get<amr::Tags::NeighborInfo<2>>(child_4_items) ==
+          child_4_neighbor_info());
   }
 };
 
@@ -208,8 +243,8 @@ struct Component {
   using const_global_cache_tags = tmpl::list<>;
   using simple_tags =
       tmpl::list<domain::Tags::Element<volume_dim>,
-                 domain::Tags::Mesh<volume_dim>, amr::Tags::Flags<volume_dim>,
-                 amr::Tags::NeighborFlags<volume_dim>>;
+                 domain::Tags::Mesh<volume_dim>, amr::Tags::Info<volume_dim>,
+                 amr::Tags::NeighborInfo<volume_dim>>;
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
       Parallel::Phase::Initialization,
       tmpl::list<ActionTesting::InitializeDataBox<simple_tags>>>>;
@@ -240,16 +275,16 @@ void test() {
   ActionTesting::MockRuntimeSystem<Metavariables> runner{{}};
   ActionTesting::emplace_component_and_initialize<array_component>(
       &runner, child_1_id,
-      {child_1(), child_1_mesh(), child_flags(), child_1_neighbor_flags()});
+      {child_1(), child_1_mesh(), child_info(), child_1_neighbor_info()});
   ActionTesting::emplace_component_and_initialize<array_component>(
       &runner, child_2_id,
-      {child_2(), child_2_mesh(), child_flags(), child_2_neighbor_flags()});
+      {child_2(), child_2_mesh(), child_info(), child_2_neighbor_info()});
   ActionTesting::emplace_component_and_initialize<array_component>(
       &runner, child_3_id,
-      {child_3(), child_3_mesh(), child_flags(), child_3_neighbor_flags()});
+      {child_3(), child_3_mesh(), child_info(), child_3_neighbor_info()});
   ActionTesting::emplace_component_and_initialize<array_component>(
       &runner, child_4_id,
-      {child_4(), child_4_mesh(), child_flags(), child_4_neighbor_flags()});
+      {child_4(), child_4_mesh(), child_info(), child_4_neighbor_info()});
   ActionTesting::emplace_component<array_component>(&runner, parent_id);
   ActionTesting::emplace_group_component_and_initialize<registrar>(
       &runner,

--- a/tests/Unit/ParallelAlgorithms/Amr/Actions/Test_Initialize.cpp
+++ b/tests/Unit/ParallelAlgorithms/Amr/Actions/Test_Initialize.cpp
@@ -20,13 +20,13 @@ namespace {
 template <size_t Dim>
 void test() {
   auto box = db::create<
-      db::AddSimpleTags<amr::Tags::Flags<Dim>, amr::Tags::NeighborFlags<Dim>>>(
-      std::array<amr::Flag, Dim>{},
-      std::unordered_map<ElementId<Dim>, std::array<amr::Flag, Dim>>{});
+      db::AddSimpleTags<amr::Tags::Info<Dim>, amr::Tags::NeighborInfo<Dim>>>(
+      amr::Info<Dim>{}, std::unordered_map<ElementId<Dim>, amr::Info<Dim>>{});
   db::mutate_apply<amr::Initialization::Initialize<Dim>>(make_not_null(&box));
-  CHECK(db::get<amr::Tags::Flags<Dim>>(box) ==
+  CHECK(db::get<amr::Tags::Info<Dim>>(box).flags ==
         make_array<Dim>(amr::Flag::Undefined));
-  CHECK(db::get<amr::Tags::NeighborFlags<Dim>>(box).empty());
+  CHECK(db::get<amr::Tags::Info<Dim>>(box).new_mesh == Mesh<Dim>{});
+  CHECK(db::get<amr::Tags::NeighborInfo<Dim>>(box).empty());
 }
 }  // namespace
 

--- a/tests/Unit/ParallelAlgorithms/Amr/Actions/Test_UpdateAmrDecision.cpp
+++ b/tests/Unit/ParallelAlgorithms/Amr/Actions/Test_UpdateAmrDecision.cpp
@@ -10,6 +10,9 @@
 
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "Domain/Amr/Flag.hpp"
+#include "Domain/Amr/Info.hpp"
+#include "Domain/Amr/Tags/Flags.hpp"
+#include "Domain/Amr/Tags/NeighborFlags.hpp"
 #include "Domain/Structure/Direction.hpp"
 #include "Domain/Structure/Element.hpp"
 #include "Domain/Structure/ElementId.hpp"
@@ -17,6 +20,7 @@
 #include "Domain/Structure/OrientationMap.hpp"
 #include "Domain/Tags.hpp"
 #include "Framework/ActionTesting.hpp"
+#include "Framework/TestHelpers.hpp"
 #include "Parallel/Phase.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
 #include "ParallelAlgorithms/Amr/Actions/UpdateAmrDecision.hpp"
@@ -33,9 +37,10 @@ struct Component {
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = ElementId<volume_dim>;
   using const_global_cache_tags = tmpl::list<>;
-  using simple_tags = tmpl::list<domain::Tags::Element<volume_dim>,
-                                 amr::Tags::Flags<volume_dim>,
-                                 amr::Tags::NeighborFlags<volume_dim>>;
+  using simple_tags =
+      tmpl::list<domain::Tags::Mesh<volume_dim>,
+                 domain::Tags::Element<volume_dim>, amr::Tags::Info<volume_dim>,
+                 amr::Tags::NeighborInfo<volume_dim>>;
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
       Parallel::Phase::Initialization,
       tmpl::list<ActionTesting::InitializeDataBox<simple_tags>>>>;
@@ -47,32 +52,31 @@ struct Metavariables {
 };
 
 void check(const ActionTesting::MockRuntimeSystem<Metavariables>& runner,
-           const ElementId<1>& id,
-           const std::array<amr::Flag, 1>& expected_flags,
-           const std::unordered_map<ElementId<1>, std::array<amr::Flag, 1>>&
-               expected_neighbor_flags,
+           const ElementId<1>& id, const amr::Info<1>& expected_info,
+           const std::unordered_map<ElementId<1>, amr::Info<1>>&
+               expected_neighbor_info,
            const size_t expected_queued_actions) {
   using my_component = Component<Metavariables>;
-  CHECK(ActionTesting::get_databox_tag<my_component, amr::Tags::Flags<1>>(
-            runner, id) == expected_flags);
+  CHECK(ActionTesting::get_databox_tag<my_component, amr::Tags::Info<1>>(
+            runner, id) == expected_info);
   CHECK(
-      ActionTesting::get_databox_tag<my_component, amr::Tags::NeighborFlags<1>>(
-          runner, id) == expected_neighbor_flags);
+      ActionTesting::get_databox_tag<my_component, amr::Tags::NeighborInfo<1>>(
+          runner, id) == expected_neighbor_info);
   CHECK(ActionTesting::number_of_queued_simple_actions<my_component>(
             runner, id) == expected_queued_actions);
 }
 
 // When AMR is run, the simple action EvaluateAmrCriteria is run on each
 // Element.  EvaluateAmrCriteria evaluates the criteria which determine the
-// amr::Tags::Flags of the Element, and then calls the simple action
+// amr::Tags::Info of the Element, and then calls the simple action
 // UpdateAmrDecision on each neighboring Element of the Element sending the
-// Flags. UpdateAmrDecision checks to see if an Elements Flags need to change
-// based on the received NeighborFlags (e.g. if and element wants to join, but
+// Info. UpdateAmrDecision checks to see if an Elements Info need to change
+// based on the received NeighborInfo (e.g. if and element wants to join, but
 // its sibling does not the element must change its decision to do nothing).  If
-// the element's Flags are changed, then it calls UpdateAmrDecision on its
+// the element's Info are changed, then it calls UpdateAmrDecision on its
 // neighbors, and the process continues until no Element wants to change its
 // decision.   This test manually runs this process on three elements assuming
-// each Element has already evaluted its own Flags with the ones passed to
+// each Element has already evaluted its own Info with the ones passed to
 // emplace_component_and_initialize.
 void test() {
   using my_component = Component<Metavariables>;
@@ -80,9 +84,10 @@ void test() {
   const ElementId<1> self_id(0, {{{2, 1}}});
   const ElementId<1> sibling_id(0, {{{2, 0}}});
   const ElementId<1> cousin_id(1, {{{2, 2}}});
+  const Mesh<1> mesh{2_st, Spectral::Basis::Legendre,
+                     Spectral::Quadrature::GaussLobatto};
 
-  std::unordered_map<ElementId<1>, std::array<amr::Flag, 1>>
-      initial_neighbor_flags{};
+  std::unordered_map<ElementId<1>, amr::Info<1>> initial_neighbor_info{};
 
   ActionTesting::MockRuntimeSystem<Metavariables> runner{{}};
 
@@ -91,98 +96,108 @@ void test() {
                           {Direction<1>::upper_xi(), {{cousin_id}, {}}}}});
   ActionTesting::emplace_component_and_initialize<my_component>(
       &runner, self_id,
-      {self, std::array{amr::Flag::Join}, initial_neighbor_flags});
+      {mesh, self, amr::Info<1>{std::array{amr::Flag::Join}, mesh},
+       initial_neighbor_info});
 
   const Element<1> sibling(sibling_id,
                            {{{Direction<1>::upper_xi(), {{self_id}, {}}}}});
   ActionTesting::emplace_component_and_initialize<my_component>(
       &runner, sibling_id,
-      {sibling, std::array{amr::Flag::Join}, initial_neighbor_flags});
+      {mesh, sibling, amr::Info<1>{std::array{amr::Flag::Join}, mesh},
+       initial_neighbor_info});
 
   const Element<1> cousin(cousin_id,
                           {{{Direction<1>::lower_xi(), {{self_id}, {}}}}});
   ActionTesting::emplace_component_and_initialize<my_component>(
       &runner, cousin_id,
-      {cousin, std::array{amr::Flag::Split}, initial_neighbor_flags});
+      {mesh, cousin, amr::Info<1>{std::array{amr::Flag::Split}, mesh},
+       initial_neighbor_info});
 
-  check(runner, self_id, {{amr::Flag::Join}}, {}, 0);
-  check(runner, sibling_id, {{amr::Flag::Join}}, {}, 0);
-  check(runner, cousin_id, {{amr::Flag::Split}}, {}, 0);
+  check(runner, self_id, {{{amr::Flag::Join}}, mesh}, {}, 0);
+  check(runner, sibling_id, {{{amr::Flag::Join}}, mesh}, {}, 0);
+  check(runner, cousin_id, {{{amr::Flag::Split}}, mesh}, {}, 0);
 
   ActionTesting::simple_action<my_component, amr::Actions::UpdateAmrDecision>(
-      make_not_null(&runner), self_id, sibling_id, std::array{amr::Flag::Join});
+      make_not_null(&runner), self_id, sibling_id,
+      amr::Info<1>{std::array{amr::Flag::Join}, mesh});
   // sibling told self it wants to join, no further action triggered
-  check(runner, self_id, {{amr::Flag::Join}},
-        {{sibling_id, {{amr::Flag::Join}}}}, 0);
-  check(runner, sibling_id, {{amr::Flag::Join}}, {}, 0);
-  check(runner, cousin_id, {{amr::Flag::Split}}, {}, 0);
+  check(runner, self_id, {{{amr::Flag::Join}}, mesh},
+        {{sibling_id, {{{amr::Flag::Join}}, mesh}}}, 0);
+  check(runner, sibling_id, {{{amr::Flag::Join}}, mesh}, {}, 0);
+  check(runner, cousin_id, {{{amr::Flag::Split}}, mesh}, {}, 0);
 
   ActionTesting::simple_action<my_component, amr::Actions::UpdateAmrDecision>(
-      make_not_null(&runner), sibling_id, self_id, std::array{amr::Flag::Join});
+      make_not_null(&runner), sibling_id, self_id,
+      amr::Info<1>{std::array{amr::Flag::Join}, mesh});
   // self told sibling it wants to join, no further action triggered
-  check(runner, self_id, {{amr::Flag::Join}},
-        {{sibling_id, {{amr::Flag::Join}}}}, 0);
-  check(runner, sibling_id, {{amr::Flag::Join}},
-        {{self_id, {{amr::Flag::Join}}}}, 0);
-  check(runner, cousin_id, {{amr::Flag::Split}}, {}, 0);
+  check(runner, self_id, {{{amr::Flag::Join}}, mesh},
+        {{sibling_id, {{{amr::Flag::Join}}, mesh}}}, 0);
+  check(runner, sibling_id, {{{amr::Flag::Join}}, mesh},
+        {{self_id, {{{amr::Flag::Join}}, mesh}}}, 0);
+  check(runner, cousin_id, {{{amr::Flag::Split}}, mesh}, {}, 0);
 
   ActionTesting::simple_action<my_component, amr::Actions::UpdateAmrDecision>(
-      make_not_null(&runner), cousin_id, self_id, std::array{amr::Flag::Join});
+      make_not_null(&runner), cousin_id, self_id,
+      amr::Info<1>{std::array{amr::Flag::Join}, mesh});
   // self told cousin it wants to join, no further action triggered
-  check(runner, self_id, {{amr::Flag::Join}},
-        {{sibling_id, {{amr::Flag::Join}}}}, 0);
-  check(runner, sibling_id, {{amr::Flag::Join}},
-        {{self_id, {{amr::Flag::Join}}}}, 0);
-  check(runner, cousin_id, {{amr::Flag::Split}},
-        {{self_id, {{amr::Flag::Join}}}}, 0);
+  check(runner, self_id, {{{amr::Flag::Join}}, mesh},
+        {{sibling_id, {{{amr::Flag::Join}}, mesh}}}, 0);
+  check(runner, sibling_id, {{{amr::Flag::Join}}, mesh},
+        {{self_id, {{{amr::Flag::Join}}, mesh}}}, 0);
+  check(runner, cousin_id, {{{amr::Flag::Split}}, mesh},
+        {{self_id, {{{amr::Flag::Join}}, mesh}}}, 0);
 
   ActionTesting::simple_action<my_component, amr::Actions::UpdateAmrDecision>(
-      make_not_null(&runner), self_id, cousin_id, std::array{amr::Flag::Split});
+      make_not_null(&runner), self_id, cousin_id,
+      amr::Info<1>{std::array{amr::Flag::Split}, mesh});
   // cousin told self it wants to split; in order to maintain 2:1 refinement,
   // self changes its decision to DoNothing and triggers actions to notify its
   // neighbors
-  check(runner, self_id, {{amr::Flag::DoNothing}},
-        {{sibling_id, {{amr::Flag::Join}}}, {cousin_id, {{amr::Flag::Split}}}},
+  check(runner, self_id, {{{amr::Flag::DoNothing}}, mesh},
+        {{sibling_id, {{{amr::Flag::Join}}, mesh}},
+         {cousin_id, {{{amr::Flag::Split}}, mesh}}},
         0);
-  check(runner, sibling_id, {{amr::Flag::Join}},
-        {{self_id, {{amr::Flag::Join}}}}, 1);
-  check(runner, cousin_id, {{amr::Flag::Split}},
-        {{self_id, {{amr::Flag::Join}}}}, 1);
+  check(runner, sibling_id, {{{amr::Flag::Join}}, mesh},
+        {{self_id, {{{amr::Flag::Join}}, mesh}}}, 1);
+  check(runner, cousin_id, {{{amr::Flag::Split}}, mesh},
+        {{self_id, {{{amr::Flag::Join}}, mesh}}}, 1);
 
   ActionTesting::invoke_queued_simple_action<my_component>(
       make_not_null(&runner), sibling_id);
   // self told sibling it wants to DoNothing, so sibling changes its decision to
   // DoNothing and triggers actions to notify its neighbors
-  check(runner, self_id, {{amr::Flag::DoNothing}},
-        {{sibling_id, {{amr::Flag::Join}}}, {cousin_id, {{amr::Flag::Split}}}},
+  check(runner, self_id, {{{amr::Flag::DoNothing}}, mesh},
+        {{sibling_id, {{{amr::Flag::Join}}, mesh}},
+         {cousin_id, {{{amr::Flag::Split}}, mesh}}},
         1);
-  check(runner, sibling_id, {{amr::Flag::DoNothing}},
-        {{self_id, {{amr::Flag::DoNothing}}}}, 0);
-  check(runner, cousin_id, {{amr::Flag::Split}},
-        {{self_id, {{amr::Flag::Join}}}}, 1);
+  check(runner, sibling_id, {{{amr::Flag::DoNothing}}, mesh},
+        {{self_id, {{{amr::Flag::DoNothing}}, mesh}}}, 0);
+  check(runner, cousin_id, {{{amr::Flag::Split}}, mesh},
+        {{self_id, {{{amr::Flag::Join}}, mesh}}}, 1);
 
   ActionTesting::invoke_queued_simple_action<my_component>(
       make_not_null(&runner), cousin_id);
   // self told cousin it wants to DoNothing, no further action triggered
-  check(runner, self_id, {{amr::Flag::DoNothing}},
-        {{sibling_id, {{amr::Flag::Join}}}, {cousin_id, {{amr::Flag::Split}}}},
+  check(runner, self_id, {{{amr::Flag::DoNothing}}, mesh},
+        {{sibling_id, {{{amr::Flag::Join}}, mesh}},
+         {cousin_id, {{{amr::Flag::Split}}, mesh}}},
         1);
-  check(runner, sibling_id, {{amr::Flag::DoNothing}},
-        {{self_id, {{amr::Flag::DoNothing}}}}, 0);
-  check(runner, cousin_id, {{amr::Flag::Split}},
-        {{self_id, {{amr::Flag::DoNothing}}}}, 0);
+  check(runner, sibling_id, {{{amr::Flag::DoNothing}}, mesh},
+        {{self_id, {{{amr::Flag::DoNothing}}, mesh}}}, 0);
+  check(runner, cousin_id, {{{amr::Flag::Split}}, mesh},
+        {{self_id, {{{amr::Flag::DoNothing}}, mesh}}}, 0);
 
   ActionTesting::invoke_queued_simple_action<my_component>(
       make_not_null(&runner), self_id);
   // sibling told self it wants to DoNothing, no further action triggered
-  check(runner, self_id, {{amr::Flag::DoNothing}},
-        {{sibling_id, {{amr::Flag::DoNothing}}},
-         {cousin_id, {{amr::Flag::Split}}}},
+  check(runner, self_id, {{{amr::Flag::DoNothing}}, mesh},
+        {{sibling_id, {{{amr::Flag::DoNothing}}, mesh}},
+         {cousin_id, {{{amr::Flag::Split}}, mesh}}},
         0);
-  check(runner, sibling_id, {{amr::Flag::DoNothing}},
-        {{self_id, {{amr::Flag::DoNothing}}}}, 0);
-  check(runner, cousin_id, {{amr::Flag::Split}},
-        {{self_id, {{amr::Flag::DoNothing}}}}, 0);
+  check(runner, sibling_id, {{{amr::Flag::DoNothing}}, mesh},
+        {{self_id, {{{amr::Flag::DoNothing}}, mesh}}}, 0);
+  check(runner, cousin_id, {{{amr::Flag::Split}}, mesh},
+        {{self_id, {{{amr::Flag::DoNothing}}, mesh}}}, 0);
 }
 
 // This test checks that asynchronus execution of simple actions is handled
@@ -196,9 +211,10 @@ void test_race_conditions() {
   const ElementId<1> self_id(0, {{{2, 1}}});
   const ElementId<1> sibling_id(0, {{{2, 0}}});
   const ElementId<1> cousin_id(1, {{{2, 2}}});
+  const Mesh<1> mesh{2_st, Spectral::Basis::Legendre,
+                     Spectral::Quadrature::GaussLobatto};
 
-  std::unordered_map<ElementId<1>, std::array<amr::Flag, 1>>
-      initial_neighbor_flags{};
+  std::unordered_map<ElementId<1>, amr::Info<1>> initial_neighbor_info{};
 
   ActionTesting::MockRuntimeSystem<Metavariables> runner{{}};
 
@@ -207,49 +223,209 @@ void test_race_conditions() {
                           {Direction<1>::upper_xi(), {{cousin_id}, {}}}}});
   ActionTesting::emplace_component_and_initialize<my_component>(
       &runner, self_id,
-      {self, std::array{amr::Flag::Split},
-       std::unordered_map<ElementId<1>, std::array<amr::Flag, 1>>{
-           {cousin_id, {{amr::Flag::Split}}}}});
+      {mesh, self, amr::Info<1>{std::array{amr::Flag::Split}, mesh},
+       std::unordered_map<ElementId<1>, amr::Info<1>>{
+           {cousin_id, {{{amr::Flag::Split}}, mesh}}}});
 
   const Element<1> sibling(sibling_id,
                            {{{Direction<1>::upper_xi(), {{self_id}, {}}}}});
   ActionTesting::emplace_component_and_initialize<my_component>(
       &runner, sibling_id,
-      {sibling, std::array{amr::Flag::Undefined}, initial_neighbor_flags});
+      {mesh, sibling, amr::Info<1>{std::array{amr::Flag::Undefined}, Mesh<1>{}},
+       initial_neighbor_info});
 
   const Element<1> cousin(cousin_id,
                           {{{Direction<1>::lower_xi(), {{self_id}, {}}}}});
   ActionTesting::emplace_component_and_initialize<my_component>(
       &runner, cousin_id,
-      {cousin, std::array{amr::Flag::Split}, initial_neighbor_flags});
+      {mesh, cousin, amr::Info<1>{std::array{amr::Flag::Split}, mesh},
+       initial_neighbor_info});
 
   ActionTesting::simple_action<my_component, amr::Actions::UpdateAmrDecision>(
       make_not_null(&runner), sibling_id, self_id,
-      std::array{amr::Flag::Split});
+      amr::Info<1>{std::array{amr::Flag::Split}, mesh});
   // self told sibling it wants to split, but sibling hasn't evaluated its own
   // flags, store the received flags and exit
-  check(runner, sibling_id, {{amr::Flag::Undefined}},
-        {{self_id, {{amr::Flag::Split}}}}, 0);
-  check(runner, self_id, {{amr::Flag::Split}},
-        {{cousin_id, {{amr::Flag::Split}}}}, 0);
-  check(runner, cousin_id, {{amr::Flag::Split}}, initial_neighbor_flags, 0);
+  check(runner, sibling_id, {{{amr::Flag::Undefined}}, Mesh<1>{}},
+        {{self_id, {{{amr::Flag::Split}}, mesh}}}, 0);
+  check(runner, self_id, {{{amr::Flag::Split}}, mesh},
+        {{cousin_id, {{{amr::Flag::Split}}, mesh}}}, 0);
+  check(runner, cousin_id, {{{amr::Flag::Split}}, mesh}, initial_neighbor_info,
+        0);
 
   ActionTesting::simple_action<my_component, amr::Actions::UpdateAmrDecision>(
       make_not_null(&runner), self_id, cousin_id,
-      std::array{amr::Flag::DoNothing});
+      amr::Info<1>{std::array{amr::Flag::DoNothing}, mesh});
   // cousin first chose to do nothing, then chose to split, but the messages
   // were received in the reverse order. Therefore we ignore the lower priority
   // message of doing nothing.
-  check(runner, sibling_id, {{amr::Flag::Undefined}},
-        {{self_id, {{amr::Flag::Split}}}}, 0);
-  check(runner, self_id, {{amr::Flag::Split}},
-        {{cousin_id, {{amr::Flag::Split}}}}, 0);
-  check(runner, cousin_id, {{amr::Flag::Split}}, initial_neighbor_flags, 0);
+  check(runner, sibling_id, {{{amr::Flag::Undefined}}, Mesh<1>{}},
+        {{self_id, {{{amr::Flag::Split}}, mesh}}}, 0);
+  check(runner, self_id, {{{amr::Flag::Split}}, mesh},
+        {{cousin_id, {{{amr::Flag::Split}}, mesh}}}, 0);
+  check(runner, cousin_id, {{{amr::Flag::Split}}, mesh}, initial_neighbor_info,
+        0);
+}
+
+// When AMR is run, the simple action EvaluateAmrCriteria is run on
+// each Element.  EvaluateAmrCriteria evaluates the criteria which
+// determine the amr::Tags::Info of the Element, and then calls the
+// simple action UpdateAmrDecision on each neighboring Element of the
+// Element sending the Info. UpdateAmrDecision checks to see if an
+// Elements Info need to change based on the received NeighborInfo
+// (e.g. if and element wants to join, but its sibling does not the
+// element must change its decision to do nothing).  If the element's
+// Info are changed, then it calls UpdateAmrDecision on its neighbors,
+// and the process continues until no Element wants to change its
+// decision.  This test manually runs this process on a set of
+// elements assuming each Element has already evaluted its own Info
+// with the ones passed to emplace_component_and_initialize.
+//
+// - We will create 7 elements in 1D labeled by Ids 0-6 from left to right
+// - N is the number of grid points of the initial element
+// - NewN is number of grid points the element (or its child/parent) will have
+//   after refinement
+// - Initial F is the amr::Flag corresponding to that chosen by
+//   EvaluateRefinementCriteria (which is assumed to have already been done)
+// - Final F is the amr::Flag the element should have after the chain of
+//   UpdateAmrDecision actions are executed
+// - J = Join, DR = DecreaseResolution, DN = DoNothing,
+//   IR = IncreaseResolution, S = Split
+//
+// Initial   Final state  Note
+// Id N F    NewN F
+//  0 7 DR    6   DR
+//  1 4 S     4   S
+//  2 6 J     6   DN      2 and 3 cannot join at Lev0 as 1 split into Lev2
+//  3 5 J     5   DN
+//  4 2 J     4   J       Joined 4 and 5 gets larger Mesh of the two
+//  5 4 J     4   J
+//  6 4 IR    5   IR
+template <typename Generator>
+void test_mesh_update(gsl::not_null<Generator*> generator) {
+  using my_component = Component<Metavariables>;
+
+  const auto join = std::array{amr::Flag::Join};
+  const auto restrict = std::array{amr::Flag::DecreaseResolution};
+  const auto stay = std::array{amr::Flag::DoNothing};
+  const auto prolong = std::array{amr::Flag::IncreaseResolution};
+  const auto split = std::array{amr::Flag::Split};
+
+  // seven elements, first six at refinement level 1, last at level 0
+  const std::vector<ElementId<1>> ids{
+      {0, {{{1, 0}}}}, {0, {{{1, 1}}}}, {1, {{{1, 0}}}}, {1, {{{1, 1}}}},
+      {2, {{{1, 0}}}}, {2, {{{1, 1}}}}, {3, {{{0, 0}}}}};
+
+  std::vector<Element<1>> elements;
+  elements.reserve(7_st);
+  elements.emplace_back(
+      Element<1>(ids[0], {{{Direction<1>::upper_xi(), {{ids[1]}, {}}}}}));
+  for (size_t i = 1; i < 6; ++i) {
+    elements.emplace_back(
+        Element<1>(ids[i], {{{Direction<1>::lower_xi(), {{ids[i - 1]}, {}}},
+                             {Direction<1>::upper_xi(), {{ids[i + 1]}, {}}}}}));
+  }
+  elements.emplace_back(
+      Element<1>(ids[6], {{{Direction<1>::lower_xi(), {{ids[5]}, {}}}}}));
+
+  const auto initial_extents =
+      std::vector{7_st, 4_st, 6_st, 5_st, 2_st, 4_st, 4_st};
+
+  std::vector<Mesh<1>> initial_meshes;
+  initial_meshes.reserve(7_st);
+  for (size_t i = 0; i < 7; ++i) {
+    initial_meshes.emplace_back(initial_extents[i], Spectral::Basis::Legendre,
+                                Spectral::Quadrature::GaussLobatto);
+  }
+
+  const auto initial_flags =
+      std::vector{restrict, split, join, join, join, join, prolong};
+
+  std::vector<amr::Info<1>> initial_infos;
+  initial_infos.reserve(7_st);
+  // first element is restricted, so needs mesh with extent 6
+  initial_infos.emplace_back(amr::Info<1>{initial_flags[0], initial_meshes[2]});
+  for (size_t i = 1; i < 6; ++i) {
+    initial_infos.emplace_back(
+        amr::Info<1>{initial_flags[i], initial_meshes[i]});
+  }
+  // last element is prolonged, so needs new_mesh with extent 5
+  initial_infos.emplace_back(amr::Info<1>{initial_flags[6], initial_meshes[3]});
+
+  std::unordered_map<ElementId<1>, amr::Info<1>> initial_neighbor_info;
+
+  ActionTesting::MockRuntimeSystem<Metavariables> runner{{}};
+
+  // initialize components assuming EvaluateAmrCriteria has been executed
+  for (size_t i = 0; i < 7; ++i) {
+    ActionTesting::emplace_component_and_initialize<my_component>(
+        &runner, ids[i],
+        {initial_meshes[i], elements[i], initial_infos[i],
+         initial_neighbor_info});
+  }
+
+  // manually queue the actions that EvaluateAmrCriteria would have called
+  // this sends the amr::Info of an element to its neighbors
+  for (size_t i = 1; i < 7; ++i) {
+    ActionTesting::queue_simple_action<my_component,
+                                       amr::Actions::UpdateAmrDecision>(
+        make_not_null(&runner), ids[i], ids[i - 1], initial_infos[i - 1]);
+    ActionTesting::queue_simple_action<my_component,
+                                       amr::Actions::UpdateAmrDecision>(
+        make_not_null(&runner), ids[i - 1], ids[i], initial_infos[i]);
+  }
+
+  // Now execute a random queued action on a random component until no component
+  // has queued actions
+  auto array_indices_with_queued_simple_actions =
+      ActionTesting::array_indices_with_queued_simple_actions<
+          typename Metavariables::component_list>(make_not_null(&runner));
+
+  while (ActionTesting::number_of_elements_with_queued_simple_actions<
+             typename Metavariables::component_list>(
+             array_indices_with_queued_simple_actions) > 0) {
+    ActionTesting::invoke_random_queued_simple_action<
+        typename Metavariables::component_list>(
+        make_not_null(&runner), generator,
+        array_indices_with_queued_simple_actions);
+    array_indices_with_queued_simple_actions =
+        ActionTesting::array_indices_with_queued_simple_actions<
+            typename Metavariables::component_list>(make_not_null(&runner));
+  }
+
+  // check the final state of the info and neighbor info on each element
+  const auto expected_new_extents =
+      std::vector{6_st, 4_st, 6_st, 5_st, 4_st, 4_st, 5_st};
+  const auto expected_flags =
+      std::vector{restrict, split, stay, stay, join, join, prolong};
+  std::vector<amr::Info<1>> expected_infos;
+  expected_infos.reserve(7_st);
+  for (size_t i = 0; i < 7; ++i) {
+    expected_infos.emplace_back(
+        amr::Info<1>{expected_flags[i],
+                     Mesh<1>(expected_new_extents[i], Spectral::Basis::Legendre,
+                             Spectral::Quadrature::GaussLobatto)});
+  }
+
+  std::vector<std::unordered_map<ElementId<1>, amr::Info<1>>>
+      expected_neighbor_infos{7_st};
+  for (size_t i = 1; i < 7; ++i) {
+    expected_neighbor_infos[i - 1].emplace(ids[i], expected_infos[i]);
+    expected_neighbor_infos[i].emplace(ids[i - 1], expected_infos[i - 1]);
+  }
+
+  for (size_t i = 0; i < 7; ++i) {
+    check(runner, ids[i], expected_infos[i], expected_neighbor_infos[i], 0);
+  }
 }
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Amr.Actions.UpdateAmrDecision",
                   "[Unit][ParallelAlgorithms]") {
+  MAKE_GENERATOR(generator);
   test();
   test_race_conditions();
+  for (size_t i = 0; i < 1000; ++i) {
+    test_mesh_update(make_not_null(&generator));
+  }
 }


### PR DESCRIPTION
## Proposed changes

In addition to passing an Element's AMR decisions, pass along what its new Mesh will be.
This will enable the mortar mesh to be initialized when adjusting the Domain during AMR.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
