### PR TITLE
Bump min Catch2 version to 3.4.0

### DIFF
--- a/cmake/SetupCatch.cmake
+++ b/cmake/SetupCatch.cmake
@@ -1,7 +1,7 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-find_package(Catch2 3.0.1 REQUIRED)
+find_package(Catch2 3.4.0 REQUIRED)
 
 message(STATUS "Catch version: ${Catch2_VERSION}")
 

--- a/docs/Installation/Installation.md
+++ b/docs/Installation/Installation.md
@@ -72,7 +72,7 @@ apt), or AppleClang 13.0.0 or later
 * [Boost](http://www.boost.org/) 1.60.0 or later
 * [Brigand](https://github.com/edouarda/brigand) at commit
   1c398e4f1e817ab195e4cd6fbb03c18cb386eea3 (late 2020) or later
-* [Catch2](https://github.com/catchorg/Catch2) 3.0.1 or later. Install from your
+* [Catch2](https://github.com/catchorg/Catch2) 3.4.0 or later. Install from your
   package manager or do a standard CMake build and installation (as detailed
   in the [Catch2 docs](https://github.com/catchorg/Catch2/blob/devel/docs/cmake-integration.md#installing-catch2-from-git-repository)).
   Compile with `CMAKE_POSITION_INDEPENDENT_CODE=ON`.

--- a/support/DevEnvironments/spack.yaml
+++ b/support/DevEnvironments/spack.yaml
@@ -45,7 +45,7 @@ spack:
   - blaze@3.8
   - 'boost@1.60:+math+program_options'
   - brigand@master
-  - 'catch2@3.0.1:3'
+  - 'catch2@3.4.0:3'
   # Charm++:
   # - The 'multicore' backend runs with shared memory on a single node. On
   #   clusters you should choose one of the multi-node backends instead.


### PR DESCRIPTION
## Proposed changes

We used some features introduced in v3.3.0 by accident.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
Building unit tests requires Catch2 v3.4.0 now. See the [Catch2 docs](https://github.com/catchorg/Catch2/blob/devel/docs/cmake-integration.md#installing-catch2-from-git-repository) for installation instructions (it's a standard CMake configure-build-install).
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
