### PR TITLE
Skip compiling executables in demo container when emulating

### DIFF
--- a/.github/workflows/DemoContainer.yaml
+++ b/.github/workflows/DemoContainer.yaml
@@ -17,6 +17,7 @@ jobs:
   docker:
     name: Build and push 'demo' image to DockerHub
     runs-on: ubuntu-latest
+    environment: deploy-containers
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/containers/Dockerfile.buildenv
+++ b/containers/Dockerfile.buildenv
@@ -362,6 +362,7 @@ WORKDIR /work
 # FROM dev AS demo
 # Either way works, we just chose to build from remote instead.
 FROM sxscollaboration/spectre:dev AS demo
+ARG BUILDARCH
 ARG TARGETARCH
 
 # When building this image individually, the PARALLEL_MAKE_ARG from above is not
@@ -405,10 +406,15 @@ RUN mkdir spectre/build && cd spectre/build \
         -D DEBUG_SYMBOLS=OFF \
         -D BUILD_PYTHON_BINDINGS=ON \
         -D MEMORY_ALLOCATOR=SYSTEM \
-        .. \
-    && make ${PARALLEL_MAKE_ARG} ExportTimeDependentCoordinates3D \
-    && make ${PARALLEL_MAKE_ARG} EvolveScalarAdvection2D \
-    && make ${PARALLEL_MAKE_ARG} all-pybindings
+        ..
+# Skip compiling the executables if we are emulating the target architecture
+# because that takes a long time. They can be compiled on-demand.
+RUN if [ "$TARGETARCH" = "$BUILDARCH" ] ; then \
+        cd spectre/build \
+        && make ${PARALLEL_MAKE_ARG} ExportTimeDependentCoordinates3D \
+        && make ${PARALLEL_MAKE_ARG} EvolveScalarAdvection2D \
+        && make ${PARALLEL_MAKE_ARG} all-pybindings; \
+    fi
 
 RUN pip3 --no-cache-dir install jupyterlab
 

--- a/docs/Tutorials/BeginnersTutorial.md
+++ b/docs/Tutorials/BeginnersTutorial.md
@@ -90,32 +90,49 @@ identical to the one if you hadn't used VSCode.
 container. If you'd like your changes to persist, get rid of the `--rm` flag in
 the `docker create` command.
 
-## Running ExportTimeDependentCoordinates3D
-
-One of the pre-built executables inside the container is the
-`ExportTimeDependentCoordinates3D` executable. All executables are located in
-the `/work/spectre/build/bin` directory.
+## Compiling the code
 
 \note From here on out, all paths are assumed to be inside the container unless
 specified otherwise.
 
-Make a directory where you will run everything.
+The container already has a SpECTRE build pre-configured. Go to the build
+directory and compile the executables that we will use in this tutorial:
+
+```sh
+cd /work/spectre/build
+make -j2 ExportTimeDependentCoordinates3D EvolveScalarAdvection2D all-pybindings
+```
+
+This will compile the code on two cores. If you'd like to use more cores, use
+the `-j N` option where `N` is the number of cores.
+
+Once the executables are compiled they will be available in the
+`/work/spectre/build/bin` directory. The container already has this directory
+added to the `PATH` environment variable, so you can run executables from the
+command line right away:
+
+```sh
+spectre --help
+```
+
+## Running ExportTimeDependentCoordinates3D
+
+First we will run the `ExportTimeDependentCoordinates3D` executable to visualize
+the coordinates of a binary black hole domain.
+Make a directory where you will run everything:
 
 ```
 mkdir /work/runs
+cd /work/runs
 ```
 
 Copy over the input file
 `/work/spectre/tests/InputFiles/ExportCoordinates/InputTimeDependent3D.yaml`
-into your `/work/runs` directory. We will be visualizing the coordinates of a
-binary black hole domain. To run the executable, do
+into your `/work/runs` directory. To run the executable, do
 
 ```
 spectre run InputTimeDependent3D.yaml
 ```
-
-\note The container already has the `/work/spectre/build/bin` directory added to
-the PATH environment variable, so no need to copy/link executables.
 
 This will run it on one core. If you'd like to use more cores, add the `-j N`
 option where `N` is the number of cores. After this finishes you should


### PR DESCRIPTION
## Proposed changes

It takes over 6 hours to compile these executables when emulating ARM on GitHub Actions runners. They can be compiled on the host architecture by the person running the container; updated to the tutorial to reflect that. On x86 machines the executables are pre-compiled so `make` completes in seconds, and on Apple Silicon Macs the compilation should be very fast when run on a couple of cores.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
