### PR TITLE
Allow multiple post interpolation callbacks

### DIFF
--- a/src/ControlSystem/Measurements/BothHorizons.hpp
+++ b/src/ControlSystem/Measurements/BothHorizons.hpp
@@ -78,9 +78,9 @@ struct BothHorizons : tt::ConformsTo<protocols::Measurement> {
       using compute_target_points =
           intrp::TargetPoints::ApparentHorizon<InterpolationTarget,
                                                ::Frame::Distorted>;
-      using post_interpolation_callback =
-          intrp::callbacks::FindApparentHorizon<InterpolationTarget,
-                                                ::Frame::Distorted>;
+      using post_interpolation_callbacks =
+          tmpl::list<intrp::callbacks::FindApparentHorizon<InterpolationTarget,
+                                                           ::Frame::Distorted>>;
       using horizon_find_failure_callback =
           intrp::callbacks::ErrorOnFailedApparentHorizon;
       using post_horizon_find_callbacks =

--- a/src/ControlSystem/Measurements/CharSpeed.hpp
+++ b/src/ControlSystem/Measurements/CharSpeed.hpp
@@ -92,8 +92,8 @@ struct CharSpeed : tt::ConformsTo<protocols::Measurement> {
               DataVector, 3, Frame::Distorted>>;
       using compute_target_points =
           intrp::TargetPoints::Sphere<InterpolationTarget, ::Frame::Grid>;
-      using post_interpolation_callback =
-          control_system::RunCallbacks<Excision, ControlSystems>;
+      using post_interpolation_callbacks =
+          tmpl::list<control_system::RunCallbacks<Excision, ControlSystems>>;
 
       template <typename Metavariables>
       using interpolating_component =
@@ -169,9 +169,9 @@ struct CharSpeed : tt::ConformsTo<protocols::Measurement> {
       using compute_target_points =
           intrp::TargetPoints::ApparentHorizon<InterpolationTarget,
                                                ::Frame::Distorted>;
-      using post_interpolation_callback =
-          intrp::callbacks::FindApparentHorizon<InterpolationTarget,
-                                                ::Frame::Distorted>;
+      using post_interpolation_callbacks =
+          tmpl::list<intrp::callbacks::FindApparentHorizon<InterpolationTarget,
+                                                           ::Frame::Distorted>>;
       using horizon_find_failure_callback =
           intrp::callbacks::ErrorOnFailedApparentHorizon;
       using post_horizon_find_callbacks =

--- a/src/ControlSystem/Measurements/SingleHorizon.hpp
+++ b/src/ControlSystem/Measurements/SingleHorizon.hpp
@@ -79,9 +79,9 @@ struct SingleHorizon : tt::ConformsTo<protocols::Measurement> {
       using compute_target_points =
           intrp::TargetPoints::ApparentHorizon<InterpolationTarget,
                                                ::Frame::Distorted>;
-      using post_interpolation_callback =
-          intrp::callbacks::FindApparentHorizon<InterpolationTarget,
-                                                ::Frame::Distorted>;
+      using post_interpolation_callbacks =
+          tmpl::list<intrp::callbacks::FindApparentHorizon<InterpolationTarget,
+                                                           ::Frame::Distorted>>;
       using horizon_find_failure_callback =
           intrp::callbacks::ErrorOnFailedApparentHorizon;
       using post_horizon_find_callbacks = tmpl::list<

--- a/src/Evolution/Executables/CurvedScalarWave/EvolveCurvedScalarWave.hpp
+++ b/src/Evolution/Executables/CurvedScalarWave/EvolveCurvedScalarWave.hpp
@@ -170,11 +170,11 @@ struct EvolutionMetavars {
                        CurvedScalarWave::Tags::PsiSquared, ::Frame::Inertial>>;
     using compute_target_points =
         intrp::TargetPoints::Sphere<SphericalSurface, ::Frame::Inertial>;
-    using post_interpolation_callback =
-        intrp::callbacks::ObserveTimeSeriesOnSurface<
+    using post_interpolation_callbacks =
+        tmpl::list<intrp::callbacks::ObserveTimeSeriesOnSurface<
             tmpl::list<gr::surfaces::Tags::SurfaceIntegralCompute<
                 CurvedScalarWave::Tags::PsiSquared, ::Frame::Inertial>>,
-            SphericalSurface>;
+            SphericalSurface>>;
     template <typename metavariables>
     using interpolating_component = typename metavariables::dg_element_array;
   };

--- a/src/Evolution/Executables/CurvedScalarWave/EvolveWorldtubeCurvedScalarWave.hpp
+++ b/src/Evolution/Executables/CurvedScalarWave/EvolveWorldtubeCurvedScalarWave.hpp
@@ -180,9 +180,9 @@ struct EvolutionMetavars {
     using compute_target_points =
         intrp::TargetPoints::LineSegment<PsiAlongAxis<Number>, volume_dim,
                                          Frame::Grid>;
-    using post_interpolation_callback =
-        intrp::callbacks::ObserveLineSegment<vars_to_interpolate_to_target,
-                                             PsiAlongAxis<Number>>;
+    using post_interpolation_callbacks =
+        tmpl::list<intrp::callbacks::ObserveLineSegment<
+            vars_to_interpolate_to_target, PsiAlongAxis<Number>>>;
     template <typename metavariables>
     using interpolating_component = typename metavariables::dg_element_array;
   };

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhAndCharacteristic.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhAndCharacteristic.hpp
@@ -196,9 +196,10 @@ struct EvolutionMetavars : public GeneralizedHarmonicTemplateBase<3>,
     using compute_items_on_target = tmpl::list<>;
     using compute_target_points =
         intrp::TargetPoints::Sphere<CceWorldtubeTarget, ::Frame::Inertial>;
-    using post_interpolation_callback = intrp::callbacks::SendGhWorldtubeData<
-        Cce::CharacteristicEvolution<EvolutionMetavars>, CceWorldtubeTarget,
-        DuringSelfStart, local_time_stepping>;
+    using post_interpolation_callbacks =
+        tmpl::list<intrp::callbacks::SendGhWorldtubeData<
+            Cce::CharacteristicEvolution<EvolutionMetavars>, CceWorldtubeTarget,
+            DuringSelfStart, local_time_stepping>>;
     using vars_to_interpolate_to_target = interpolator_source_vars;
     template <typename Metavariables>
     using interpolating_component = gh_dg_element_array;

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
@@ -248,8 +248,8 @@ struct EvolutionMetavars {
         ::ah::compute_items_on_target<volume_dim, Frame>;
     using compute_target_points =
         intrp::TargetPoints::ApparentHorizon<Ah, Frame>;
-    using post_interpolation_callback =
-        intrp::callbacks::FindApparentHorizon<Ah, Frame>;
+    using post_interpolation_callbacks =
+        tmpl::list<intrp::callbacks::FindApparentHorizon<Ah, Frame>>;
     using horizon_find_failure_callback =
         intrp::callbacks::IgnoreFailedApparentHorizon;
     using post_horizon_find_callbacks = tmpl::list<
@@ -288,8 +288,9 @@ struct EvolutionMetavars {
         gh::CharacteristicSpeedsOnStrahlkorperCompute<3, Frame::Grid>>>;
     using compute_target_points =
         intrp::TargetPoints::Sphere<ExcisionBoundary<Excision>, ::Frame::Grid>;
-    using post_interpolation_callback = intrp::callbacks::ObserveSurfaceData<
-        tags_to_observe, ExcisionBoundary<Excision>, ::Frame::Grid>;
+    using post_interpolation_callbacks =
+        tmpl::list<intrp::callbacks::ObserveSurfaceData<
+            tags_to_observe, ExcisionBoundary<Excision>, ::Frame::Grid>>;
     // run_callbacks
     template <typename metavariables>
     using interpolating_component = typename metavariables::gh_dg_element_array;
@@ -578,8 +579,8 @@ struct EvolutionMetavars {
     using vars_to_interpolate_to_target = source_vars_no_deriv;
     using compute_target_points =
         intrp::TargetPoints::Sphere<BondiSachs, ::Frame::Inertial>;
-    using post_interpolation_callback =
-        intrp::callbacks::DumpBondiSachsOnWorldtube<BondiSachs>;
+    using post_interpolation_callbacks =
+        tmpl::list<intrp::callbacks::DumpBondiSachsOnWorldtube<BondiSachs>>;
     using compute_items_on_target = tmpl::list<>;
     template <typename Metavariables>
     using interpolating_component = gh_dg_element_array;

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhSingleBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhSingleBlackHole.hpp
@@ -83,9 +83,9 @@ struct EvolutionMetavars : public GeneralizedHarmonicTemplateBase<3> {
     using compute_target_points =
         intrp::TargetPoints::ApparentHorizon<ApparentHorizon,
                                              ::Frame::Inertial>;
-    using post_interpolation_callback =
-        intrp::callbacks::FindApparentHorizon<ApparentHorizon,
-                                              ::Frame::Inertial>;
+    using post_interpolation_callbacks =
+        tmpl::list<intrp::callbacks::FindApparentHorizon<ApparentHorizon,
+                                                         ::Frame::Inertial>>;
     using horizon_find_failure_callback =
         intrp::callbacks::IgnoreFailedApparentHorizon;
     using post_horizon_find_callbacks = tmpl::list<
@@ -117,9 +117,9 @@ struct EvolutionMetavars : public GeneralizedHarmonicTemplateBase<3> {
         gh::CharacteristicSpeedsOnStrahlkorperCompute<3, Frame::Grid>>>;
     using compute_target_points =
         intrp::TargetPoints::Sphere<ExcisionBoundary, ::Frame::Grid>;
-    using post_interpolation_callback =
-        intrp::callbacks::ObserveSurfaceData<tags_to_observe, ExcisionBoundary,
-                                             ::Frame::Grid>;
+    using post_interpolation_callbacks =
+        tmpl::list<intrp::callbacks::ObserveSurfaceData<
+            tags_to_observe, ExcisionBoundary, ::Frame::Grid>>;
     // run_callbacks
     template <typename metavariables>
     using interpolating_component = typename metavariables::gh_dg_element_array;
@@ -167,7 +167,7 @@ struct EvolutionMetavars : public GeneralizedHarmonicTemplateBase<3> {
       observers::collect_reduction_data_tags<tmpl::push_back<
           tmpl::at<typename factory_creation::factory_classes, Event>,
           typename ApparentHorizon::post_horizon_find_callbacks,
-          typename ExcisionBoundary::post_interpolation_callback>>;
+          typename ExcisionBoundary::post_interpolation_callbacks>>;
 
   using dg_registration_list =
       tmpl::push_back<typename gh_base::dg_registration_list,

--- a/src/Evolution/Executables/GrMhd/GhValenciaDivClean/EvolveGhValenciaDivCleanWithHorizon.hpp
+++ b/src/Evolution/Executables/GrMhd/GhValenciaDivClean/EvolveGhValenciaDivCleanWithHorizon.hpp
@@ -89,8 +89,8 @@ struct EvolutionMetavars : public GhValenciaDivCleanTemplateBase<
         tags_to_observe>;
     using compute_target_points =
         intrp::TargetPoints::ApparentHorizon<AhA, ::Frame::Inertial>;
-    using post_interpolation_callback =
-        intrp::callbacks::FindApparentHorizon<AhA, ::Frame::Inertial>;
+    using post_interpolation_callbacks = tmpl::list<
+        intrp::callbacks::FindApparentHorizon<AhA, ::Frame::Inertial>>;
     using horizon_find_failure_callback =
         intrp::callbacks::ErrorOnFailedApparentHorizon;
     using post_horizon_find_callbacks = tmpl::list<

--- a/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
+++ b/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
@@ -975,8 +975,8 @@ struct BondiSachs : tt::ConformsTo<intrp::protocols::InterpolationTargetTag> {
       typename gh::System<3>::variables_tag::tags_list;
   using compute_target_points =
       intrp::TargetPoints::Sphere<BondiSachs, ::Frame::Inertial>;
-  using post_interpolation_callback =
-      intrp::callbacks::DumpBondiSachsOnWorldtube<BondiSachs>;
+  using post_interpolation_callbacks =
+      tmpl::list<intrp::callbacks::DumpBondiSachsOnWorldtube<BondiSachs>>;
   using compute_items_on_target = tmpl::list<>;
   template <typename Metavariables>
   using interpolating_component =

--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
@@ -645,9 +645,9 @@ struct CenterOfStar : tt::ConformsTo<intrp::protocols::InterpolationTargetTag> {
       tmpl::list<MaxOfScalarCompute<hydro::Tags::RestMassDensity<DataVector>>>;
   using vars_to_interpolate_to_target =
       tmpl::list<hydro::Tags::RestMassDensity<DataVector>>;
-  using post_interpolation_callback =
-      intrp::callbacks::ObserveTimeSeriesOnSurface<tags_to_observe,
-                                                   CenterOfStar>;
+  using post_interpolation_callbacks =
+      tmpl::list<intrp::callbacks::ObserveTimeSeriesOnSurface<tags_to_observe,
+                                                              CenterOfStar>>;
   using compute_target_points =
       intrp::TargetPoints::SpecifiedPoints<CenterOfStar, 3>;
   using compute_items_on_target = tags_to_observe;
@@ -674,9 +674,9 @@ struct KerrHorizon : tt::ConformsTo<intrp::protocols::InterpolationTargetTag> {
       hydro::Tags::MassFluxCompute<DataVector, 3, ::Frame::Inertial>>;
   using compute_target_points =
       intrp::TargetPoints::KerrHorizon<KerrHorizon, ::Frame::Inertial>;
-  using post_interpolation_callback =
-      intrp::callbacks::ObserveTimeSeriesOnSurface<tags_to_observe,
-                                                   KerrHorizon>;
+  using post_interpolation_callbacks =
+      tmpl::list<intrp::callbacks::ObserveTimeSeriesOnSurface<tags_to_observe,
+                                                              KerrHorizon>>;
 
   template <typename Metavariables>
   using interpolating_component =

--- a/src/Evolution/Executables/ScalarTensor/EvolveScalarTensorSingleBlackHole.hpp
+++ b/src/Evolution/Executables/ScalarTensor/EvolveScalarTensorSingleBlackHole.hpp
@@ -80,8 +80,8 @@ struct EvolutionMetavars : public ScalarTensorTemplateBase<EvolutionMetavars> {
         ::ah::compute_items_on_target<volume_dim, Frame::Inertial>;
     using compute_target_points =
         intrp::TargetPoints::ApparentHorizon<AhA, ::Frame::Inertial>;
-    using post_interpolation_callback =
-        intrp::callbacks::FindApparentHorizon<AhA, ::Frame::Inertial>;
+    using post_interpolation_callbacks = tmpl::list<
+        intrp::callbacks::FindApparentHorizon<AhA, ::Frame::Inertial>>;
     using horizon_find_failure_callback =
         intrp::callbacks::IgnoreFailedApparentHorizon;
     using post_horizon_find_callbacks = tmpl::list<
@@ -115,9 +115,9 @@ struct EvolutionMetavars : public ScalarTensorTemplateBase<EvolutionMetavars> {
                                                                  Frame::Grid>>>;
     using compute_target_points =
         intrp::TargetPoints::Sphere<ExcisionBoundaryA, ::Frame::Grid>;
-    using post_interpolation_callback =
-        intrp::callbacks::ObserveSurfaceData<tags_to_observe, ExcisionBoundaryA,
-                                             ::Frame::Grid>;
+    using post_interpolation_callbacks =
+        tmpl::list<intrp::callbacks::ObserveSurfaceData<
+            tags_to_observe, ExcisionBoundaryA, ::Frame::Grid>>;
     // run_callbacks
     template <typename metavariables>
     using interpolating_component = typename metavariables::st_dg_element_array;
@@ -133,10 +133,10 @@ struct EvolutionMetavars : public ScalarTensorTemplateBase<EvolutionMetavars> {
         detail::ObserverTags::scalar_charge_compute_items_on_target;
     using compute_target_points =
         intrp::TargetPoints::Sphere<SphericalSurface, ::Frame::Inertial>;
-    using post_interpolation_callback =
-        intrp::callbacks::ObserveTimeSeriesOnSurface<
+    using post_interpolation_callbacks =
+        tmpl::list<intrp::callbacks::ObserveTimeSeriesOnSurface<
             detail::ObserverTags::scalar_charge_surface_obs_tags,
-            SphericalSurface>;
+            SphericalSurface>>;
     template <typename metavariables>
     using interpolating_component = typename metavariables::st_dg_element_array;
   };

--- a/src/Executables/FindHorizons/FindHorizons.hpp
+++ b/src/Executables/FindHorizons/FindHorizons.hpp
@@ -201,8 +201,8 @@ struct ApparentHorizon
   using temporal_id = ::Tags::Time;
   using compute_target_points =
       intrp::TargetPoints::ApparentHorizon<ApparentHorizon, Frame::Inertial>;
-  using post_interpolation_callback =
-      intrp::callbacks::FindApparentHorizon<ApparentHorizon, Frame::Inertial>;
+  using post_interpolation_callbacks = tmpl::list<
+      intrp::callbacks::FindApparentHorizon<ApparentHorizon, Frame::Inertial>>;
   using horizon_find_failure_callback =
       intrp::callbacks::ErrorOnFailedApparentHorizon;
   using post_horizon_find_callbacks = tmpl::list<

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/Callbacks/FindApparentHorizon.hpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/Callbacks/FindApparentHorizon.hpp
@@ -95,7 +95,7 @@ namespace callbacks {
 ///   - `::ah::Tags::FastFlow`
 ///   - `ylm::Tags::Strahlkorper<Frame>`
 ///
-/// This is an InterpolationTargetTag::post_interpolation_callback;
+/// This can be used in InterpolationTargetTag::post_interpolation_callbacks;
 /// see intrp::protocols::InterpolationTargetTag for details on
 /// InterpolationTargetTag.
 ///

--- a/src/ParallelAlgorithms/Interpolation/Actions/InterpolationTargetReceiveVars.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Actions/InterpolationTargetReceiveVars.hpp
@@ -53,7 +53,7 @@ namespace Actions {
 /// - Checks if functions of time are ready (if there are any). If they are not
 ///   ready, register a simple action callback with the GlobalCache to this
 ///   action.
-/// - Calls `InterpolationTargetTag::post_interpolation_callback`
+/// - Calls `InterpolationTargetTag::post_interpolation_callbacks`
 /// - Tells `Interpolator`s that the interpolation is complete
 ///  (by calling
 ///  `Actions::CleanUpInterpolator<InterpolationTargetTag>`)
@@ -154,7 +154,7 @@ struct InterpolationTargetReceiveVars {
         return;
       }
 
-      if (InterpolationTarget_detail::call_callback<InterpolationTargetTag>(
+      if (InterpolationTarget_detail::call_callbacks<InterpolationTargetTag>(
               make_not_null(&box), make_not_null(&cache), temporal_id)) {
         InterpolationTarget_detail::clean_up_interpolation_target<
             InterpolationTargetTag>(make_not_null(&box), temporal_id);

--- a/src/ParallelAlgorithms/Interpolation/Actions/InterpolationTargetVarsFromElement.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Actions/InterpolationTargetVarsFromElement.hpp
@@ -35,7 +35,7 @@ namespace Actions {
 /// - Checks if functions of time are ready (if there are any). If they are not
 ///   ready, register a simple action callback with the GlobalCache to this
 ///   action.
-/// - Calls `InterpolationTargetTag::post_interpolation_callback`
+/// - Calls `InterpolationTargetTag::post_interpolation_callbacks`
 /// - Removes the finished `temporal_id` from `Tags::TemporalIds<TemporalId>`
 ///   and adds it to `Tags::CompletedTemporalIds<TemporalId>`
 /// - Removes `Tags::InterpolatedVars<InterpolationTargetTag,TemporalId>`,
@@ -167,10 +167,10 @@ struct InterpolationTargetVarsFromElement {
         return;
       }
       // All the valid points have been interpolated.
-      // We throw away the return value of call_callback in this case
+      // We throw away the return value of call_callbacks in this case
       // (it is known to be always true; it can be false only for
       //  sequential interpolations, which is static-asserted against above).
-      InterpolationTarget_detail::call_callback<InterpolationTargetTag>(
+      InterpolationTarget_detail::call_callbacks<InterpolationTargetTag>(
           make_not_null(&box), make_not_null(&cache), temporal_id);
       InterpolationTarget_detail::clean_up_interpolation_target<
           InterpolationTargetTag>(make_not_null(&box), temporal_id);

--- a/src/ParallelAlgorithms/Interpolation/InterpolationTarget.hpp
+++ b/src/ParallelAlgorithms/Interpolation/InterpolationTarget.hpp
@@ -265,9 +265,10 @@ struct InterpolationTarget {
   }
   using chare_type = ::Parallel::Algorithms::Singleton;
   using const_global_cache_tags =
-      Parallel::get_const_global_cache_tags_from_actions<tmpl::list<
-          typename InterpolationTargetTag::compute_target_points,
-          typename InterpolationTargetTag::post_interpolation_callback>>;
+      Parallel::get_const_global_cache_tags_from_actions<
+          tmpl::flatten<tmpl::list<
+              typename InterpolationTargetTag::compute_target_points,
+              typename InterpolationTargetTag::post_interpolation_callbacks>>>;
   using metavariables = Metavariables;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<

--- a/src/ParallelAlgorithms/Interpolation/Protocols/InterpolationTargetTag.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Protocols/InterpolationTargetTag.hpp
@@ -61,8 +61,13 @@ constexpr bool if_alias_exists_assert_conforms_to_v =
  *   intrp::protocols::ComputeTargetPoints protocol. This will compute the
  *   points on the surface that we are interpolating onto.
  *
- * - a type alias `post_interpolation_callback` that conforms to the
- *   intrp::protocols::PostInterpolationCallback protocol. After the
+ * - a type alias `post_interpolation_callbacks` which is a `tmpl::list` where
+ *   every element of that list conforms to the
+ *   intrp::protocols::PostInterpolationCallback protocol. Only one callback
+ *   with the signature with `gsl::not_null` for both the DataBox and
+ *   GlobalCache (see `intrp::protocols::PostInterpolationCallback`) is allowed
+ *   in this list. Furthermore, if a callback with this signature is in the
+ *   list, it must also be the *only* callback in the list. After the
  *   interpolation is complete, call this struct's `apply` function.
  *
  * A struct conforming to this protocol can also optionally have
@@ -104,10 +109,11 @@ struct InterpolationTargetTag {
     static_assert(
         tt::assert_conforms_to_v<compute_target_points, ComputeTargetPoints>);
 
-    using post_interpolation_callback =
-        typename ConformingType::post_interpolation_callback;
-    static_assert(tt::assert_conforms_to_v<post_interpolation_callback,
-                                           PostInterpolationCallback>);
+    using post_interpolation_callbacks =
+        typename ConformingType::post_interpolation_callbacks;
+    static_assert(tmpl::all<post_interpolation_callbacks,
+                            tt::assert_conforms_to<
+                                tmpl::_1, PostInterpolationCallback>>::value);
   };
 };
 }  // namespace intrp::protocols

--- a/src/ParallelAlgorithms/Interpolation/Protocols/PostInterpolationCallback.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Protocols/PostInterpolationCallback.hpp
@@ -79,7 +79,7 @@ struct has_signature_3<
 }  // namespace detail
 
 /*!
- * \brief A protocol for the type alias `post_interpolation_callback` found in
+ * \brief A protocol for the type alias `post_interpolation_callbacks` found in
  * an InterpolationTargetTag.
  *
  * \details A struct conforming to the `PostInterpolationCallback` protocol must

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_SendGhVarsToCce.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_SendGhVarsToCce.cpp
@@ -112,7 +112,8 @@ struct InterpolationTargetAImpl
   using vars_to_interpolate_to_target =
       tmpl::list<InterpolateOnElementTestHelpers::Tags::TestSolution>;
   using compute_target_points = MockComputeTargetPoints;
-  using post_interpolation_callback = MockPostInterpolationCallback;
+  using post_interpolation_callbacks =
+      tmpl::list<MockPostInterpolationCallback>;
   using compute_items_on_target = tmpl::list<>;
 };
 

--- a/tests/Unit/Helpers/ParallelAlgorithms/Interpolation/Examples.hpp
+++ b/tests/Unit/Helpers/ParallelAlgorithms/Interpolation/Examples.hpp
@@ -183,7 +183,8 @@ struct ExampleInterpolationTargetTag
 
   using compute_target_points = ExampleComputeTargetPoints;
 
-  using post_interpolation_callback = ExamplePostInterpolationCallback;
+  using post_interpolation_callbacks =
+      tmpl::list<ExamplePostInterpolationCallback>;
 };
 /// [InterpolationTargetTag]
 }  // namespace intrp::TestHelpers

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_SendGhWorldtubeData.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_SendGhWorldtubeData.cpp
@@ -112,9 +112,10 @@ struct test_metavariables {
                                            Target>::simple_tags;
     using compute_target_points =
         intrp::TargetPoints::Sphere<Target, ::Frame::Inertial>;
-    using post_interpolation_callback = intrp::callbacks::SendGhWorldtubeData<
-        Cce::CharacteristicEvolution<test_metavariables>, Target, false,
-        LocalTimeStepping>;
+    using post_interpolation_callbacks =
+        tmpl::list<intrp::callbacks::SendGhWorldtubeData<
+            Cce::CharacteristicEvolution<test_metavariables>, Target, false,
+            LocalTimeStepping>>;
     using compute_items_on_target = tmpl::list<>;
   };
 

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_ApparentHorizonFinder.cpp
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_ApparentHorizonFinder.cpp
@@ -229,9 +229,10 @@ struct mock_interpolation_target {
   using chare_type = ActionTesting::MockSingletonChare;
   using array_index = int;
   using const_global_cache_tags =
-      Parallel::get_const_global_cache_tags_from_actions<tmpl::list<
-          typename InterpolationTargetTag::compute_target_points,
-          typename InterpolationTargetTag::post_interpolation_callback>>;
+      Parallel::get_const_global_cache_tags_from_actions<
+          tmpl::flatten<tmpl::list<
+              typename InterpolationTargetTag::compute_target_points,
+              typename InterpolationTargetTag::post_interpolation_callbacks>>>;
   using mutable_global_cache_tags =
       tmpl::list<domain::Tags::FunctionsOfTimeInitialize>;
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
@@ -271,8 +272,8 @@ struct MockMetavariables {
     using compute_items_on_target = tmpl::list<>;
     using compute_target_points =
         intrp::TargetPoints::ApparentHorizon<AhA, TargetFrame>;
-    using post_interpolation_callback =
-        intrp::callbacks::FindApparentHorizon<AhA, TargetFrame>;
+    using post_interpolation_callbacks =
+        tmpl::list<intrp::callbacks::FindApparentHorizon<AhA, TargetFrame>>;
     using post_horizon_find_callbacks = PostHorizonFindCallbacks;
     using horizon_find_failure_callback = TestHorizonFindFailureCallback;
   };
@@ -303,9 +304,10 @@ void test_apparent_horizon(const gsl::not_null<size_t*> test_horizon_called,
       mock_interpolation_target<metavars, typename metavars::AhA>;
 
   // Assert that the FindApparentHorizon callback conforms to the protocol
-  static_assert(tt::assert_conforms_to_v<
-                typename metavars::AhA::post_interpolation_callback,
-                intrp::protocols::PostInterpolationCallback>);
+  static_assert(
+      tt::assert_conforms_to_v<
+          tmpl::front<typename metavars::AhA::post_interpolation_callbacks>,
+          intrp::protocols::PostInterpolationCallback>);
 
   // Options for all InterpolationTargets.
   // The initial guess for the horizon search is a sphere of radius 2.8M.

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_InterpolationTargetApparentHorizon.cpp
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_InterpolationTargetApparentHorizon.cpp
@@ -44,9 +44,9 @@ struct MockMetavariables {
     using compute_target_points =
         ::intrp::TargetPoints::ApparentHorizon<InterpolationTargetA,
                                                ::Frame::Inertial>;
-    using post_interpolation_callback =
-        intrp::callbacks::ObserveTimeSeriesOnSurface<tmpl::list<>,
-                                                     InterpolationTargetA>;
+    using post_interpolation_callbacks =
+        tmpl::list<intrp::callbacks::ObserveTimeSeriesOnSurface<
+            tmpl::list<>, InterpolationTargetA>>;
   };
   static constexpr size_t volume_dim = 3;
   using interpolator_source_vars = tmpl::list<gr::Tags::Lapse<DataVector>>;

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_AddTemporalIdsToInterpolationTarget.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_AddTemporalIdsToInterpolationTarget.cpp
@@ -129,9 +129,9 @@ struct MockMetavariables {
     using vars_to_interpolate_to_target =
         tmpl::list<gr::Tags::Lapse<DataVector>>;
     using compute_items_on_target = tmpl::list<>;
-    using post_interpolation_callback =
-        intrp::callbacks::ObserveTimeSeriesOnSurface<tmpl::list<>,
-                                                     InterpolationTargetA>;
+    using post_interpolation_callbacks =
+        tmpl::list<intrp::callbacks::ObserveTimeSeriesOnSurface<
+            tmpl::list<>, InterpolationTargetA>>;
     using compute_target_points = MockComputeTargetPoints<IsSequential>;
   };
   static constexpr bool use_time_dependent_maps = IsTimeDependent::value;

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_ElementReceiveInterpPoints.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_ElementReceiveInterpPoints.cpp
@@ -88,9 +88,9 @@ struct MockMetavariables {
     using compute_target_points =
         ::intrp::TargetPoints::LineSegment<InterpolationTargetA, 3,
                                            Frame::Inertial>;
-    using post_interpolation_callback =
-        intrp::callbacks::ObserveTimeSeriesOnSurface<tmpl::list<>,
-                                                     InterpolationTargetA>;
+    using post_interpolation_callbacks =
+        tmpl::list<intrp::callbacks::ObserveTimeSeriesOnSurface<
+            tmpl::list<>, InterpolationTargetA>>;
     template <typename Metavariables>
     using interpolating_component = mock_element<Metavariables>;
   };
@@ -102,9 +102,9 @@ struct MockMetavariables {
     using compute_target_points =
         ::intrp::TargetPoints::LineSegment<InterpolationTargetB, 3,
                                            Frame::Inertial>;
-    using post_interpolation_callback =
-        intrp::callbacks::ObserveTimeSeriesOnSurface<tmpl::list<>,
-                                                     InterpolationTargetA>;
+    using post_interpolation_callbacks =
+        tmpl::list<intrp::callbacks::ObserveTimeSeriesOnSurface<
+            tmpl::list<>, InterpolationTargetA>>;
     template <typename Metavariables>
     using interpolating_component = mock_element<Metavariables>;
   };

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_InitializeInterpolationTarget.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_InitializeInterpolationTarget.cpp
@@ -56,9 +56,9 @@ struct Metavariables {
     using vars_to_interpolate_to_target =
         tmpl::list<gr::Tags::Lapse<DataVector>>;
     using compute_items_on_target = tmpl::list<>;
-    using post_interpolation_callback =
-        intrp::callbacks::ObserveTimeSeriesOnSurface<tmpl::list<>,
-                                                     InterpolationTargetA>;
+    using post_interpolation_callbacks =
+        tmpl::list<intrp::callbacks::ObserveTimeSeriesOnSurface<
+            tmpl::list<>, InterpolationTargetA>>;
     using compute_target_points =
         ::intrp::TargetPoints::LineSegment<InterpolationTargetA, 3,
                                            Frame::Inertial>;

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_Interpolate.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_Interpolate.cpp
@@ -187,9 +187,9 @@ struct MockMetavariables {
     using compute_target_points =
         ::intrp::TargetPoints::LineSegment<InterpolatorTargetA, 3,
                                            Frame::Inertial>;
-    using post_interpolation_callback =
-        intrp::callbacks::ObserveTimeSeriesOnSurface<tmpl::list<>,
-                                                     InterpolatorTargetA>;
+    using post_interpolation_callbacks =
+        tmpl::list<intrp::callbacks::ObserveTimeSeriesOnSurface<
+            tmpl::list<>, InterpolatorTargetA>>;
   };
   static constexpr size_t volume_dim = 3;
   using interpolator_source_vars = tmpl::list<Tags::Lapse>;

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolateWithoutInterpComponent.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolateWithoutInterpComponent.cpp
@@ -123,9 +123,9 @@ struct MockMetavariables {
     // conform to the protocol.
     using compute_target_points = ::intrp::TargetPoints::LineSegment<
         InterpolationTargetAWithComputeVarsToInterpolate, 3, Frame::Inertial>;
-    using post_interpolation_callback =
-        intrp::callbacks::ObserveTimeSeriesOnSurface<
-            tmpl::list<>, InterpolationTargetAWithComputeVarsToInterpolate>;
+    using post_interpolation_callbacks =
+        tmpl::list<intrp::callbacks::ObserveTimeSeriesOnSurface<
+            tmpl::list<>, InterpolationTargetAWithComputeVarsToInterpolate>>;
   };
   struct InterpolationTargetAWithoutComputeVarsToInterpolate
       : tt::ConformsTo<intrp::protocols::InterpolationTargetTag> {
@@ -137,9 +137,9 @@ struct MockMetavariables {
     // conform to the protocol.
     using compute_target_points = ::intrp::TargetPoints::Sphere<
         InterpolationTargetAWithoutComputeVarsToInterpolate, Frame::Inertial>;
-    using post_interpolation_callback =
-        intrp::callbacks::ObserveTimeSeriesOnSurface<
-            tmpl::list<>, InterpolationTargetAWithoutComputeVarsToInterpolate>;
+    using post_interpolation_callbacks =
+        tmpl::list<intrp::callbacks::ObserveTimeSeriesOnSurface<
+            tmpl::list<>, InterpolationTargetAWithoutComputeVarsToInterpolate>>;
   };
   using InterpolationTargetA =
       tmpl::conditional_t<HaveComputeVarsToInterpolate,

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolationTargetKerrHorizon.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolationTargetKerrHorizon.cpp
@@ -43,9 +43,9 @@ struct MockMetavariables {
     using compute_target_points =
         ::intrp::TargetPoints::KerrHorizon<InterpolationTargetA,
                                            ::Frame::Inertial>;
-    using post_interpolation_callback =
-        intrp::callbacks::ObserveTimeSeriesOnSurface<tmpl::list<>,
-                                                     InterpolationTargetA>;
+    using post_interpolation_callbacks =
+        tmpl::list<intrp::callbacks::ObserveTimeSeriesOnSurface<
+            tmpl::list<>, InterpolationTargetA>>;
   };
   static constexpr size_t volume_dim = 3;
   using interpolator_source_vars = tmpl::list<gr::Tags::Lapse<DataVector>>;

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolationTargetLineSegment.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolationTargetLineSegment.cpp
@@ -37,9 +37,9 @@ struct MockMetavariables {
     using compute_items_on_target = tmpl::list<>;
     using compute_target_points =
         ::intrp::TargetPoints::LineSegment<InterpolationTargetA, 3, Frame>;
-    using post_interpolation_callback =
-        intrp::callbacks::ObserveTimeSeriesOnSurface<tmpl::list<>,
-                                                     InterpolationTargetA>;
+    using post_interpolation_callbacks =
+        tmpl::list<intrp::callbacks::ObserveTimeSeriesOnSurface<
+            tmpl::list<>, InterpolationTargetA>>;
   };
   static constexpr size_t volume_dim = 3;
   using interpolator_source_vars = tmpl::list<gr::Tags::Lapse<DataVector>>;

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolationTargetReceiveVars.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolationTargetReceiveVars.cpp
@@ -311,7 +311,7 @@ struct MockMetavariables {
     using vars_to_interpolate_to_target =
         tmpl::list<gr::Tags::Lapse<DataVector>>;
     using compute_target_points = MockComputeTargetPoints;
-    using post_interpolation_callback = MockCallBackType;
+    using post_interpolation_callbacks = tmpl::list<MockCallBackType>;
     using compute_items_on_target = tmpl::list<Tags::SquareCompute>;
   };
   using interpolator_source_vars = tmpl::list<gr::Tags::Lapse<DataVector>>;
@@ -492,7 +492,7 @@ void test_interpolation_target_receive_vars() {
         first_time / 2.0);
   }
 
-  // This will try to call InterpolationTargetA::post_interpolation_callback
+  // This will try to call InterpolationTargetA::post_interpolation_callbacks
   // where we check that the points are correct.
   ActionTesting::simple_action<target_component,
                                intrp::Actions::InterpolationTargetReceiveVars<

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolationTargetSpecifiedPoints.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolationTargetSpecifiedPoints.cpp
@@ -39,9 +39,9 @@ struct MockMetavariables {
     using compute_items_on_target = tmpl::list<>;
     using compute_target_points =
         ::intrp::TargetPoints::SpecifiedPoints<InterpolationTargetA, Dim>;
-    using post_interpolation_callback =
-        intrp::callbacks::ObserveTimeSeriesOnSurface<tmpl::list<>,
-                                                     InterpolationTargetA>;
+    using post_interpolation_callbacks =
+        tmpl::list<intrp::callbacks::ObserveTimeSeriesOnSurface<
+            tmpl::list<>, InterpolationTargetA>>;
   };
   static constexpr size_t volume_dim = Dim;
   using interpolator_source_vars = tmpl::list<gr::Tags::Lapse<DataVector>>;

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolationTargetSphere.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolationTargetSphere.cpp
@@ -47,9 +47,9 @@ struct MockMetavariables {
     using compute_items_on_target = tmpl::list<>;
     using compute_target_points =
         ::intrp::TargetPoints::Sphere<InterpolationTargetA, ::Frame::Inertial>;
-    using post_interpolation_callback =
-        intrp::callbacks::ObserveTimeSeriesOnSurface<tmpl::list<>,
-                                                     InterpolationTargetA>;
+    using post_interpolation_callbacks =
+        tmpl::list<intrp::callbacks::ObserveTimeSeriesOnSurface<
+            tmpl::list<>, InterpolationTargetA>>;
   };
   static constexpr size_t volume_dim = 3;
   using interpolator_source_vars = tmpl::list<gr::Tags::Lapse<DataVector>>;

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolationTargetWedgeSectionTorus.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolationTargetWedgeSectionTorus.cpp
@@ -40,9 +40,9 @@ struct MockMetavariables {
     using compute_items_on_target = tmpl::list<>;
     using compute_target_points =
         ::intrp::TargetPoints::WedgeSectionTorus<InterpolationTargetA>;
-    using post_interpolation_callback =
-        intrp::callbacks::ObserveTimeSeriesOnSurface<tmpl::list<>,
-                                                     InterpolationTargetA>;
+    using post_interpolation_callbacks =
+        tmpl::list<intrp::callbacks::ObserveTimeSeriesOnSurface<
+            tmpl::list<>, InterpolationTargetA>>;
   };
   static constexpr size_t volume_dim = 3;
   using interpolator_source_vars = tmpl::list<gr::Tags::Lapse<DataVector>>;

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolatorReceiveAndDumpVolumeData.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolatorReceiveAndDumpVolumeData.cpp
@@ -321,9 +321,9 @@ struct MockMetavariables {
     using compute_target_points =
         ::intrp::TargetPoints::LineSegment<InterpolationTargetA, 3,
                                            Frame::Inertial>;
-    using post_interpolation_callback =
-        intrp::callbacks::ObserveTimeSeriesOnSurface<tmpl::list<>,
-                                                     InterpolationTargetA>;
+    using post_interpolation_callbacks =
+        tmpl::list<intrp::callbacks::ObserveTimeSeriesOnSurface<
+            tmpl::list<>, InterpolationTargetA>>;
   };
   // Want the same temporal id. Other type alias are arbitrary for this test
   struct InterpolationTargetB : public InterpolationTargetA {

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolatorReceivePoints.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolatorReceivePoints.cpp
@@ -211,9 +211,9 @@ struct Metavariables {
     using compute_items_on_target = tmpl::list<>;
     using compute_target_points =
         SequentialLineSegment<InterpolationTargetA, Frame::Inertial>;
-    using post_interpolation_callback =
-        intrp::callbacks::ObserveTimeSeriesOnSurface<tmpl::list<>,
-                                                     InterpolationTargetA>;
+    using post_interpolation_callbacks =
+        tmpl::list<intrp::callbacks::ObserveTimeSeriesOnSurface<
+            tmpl::list<>, InterpolationTargetA>>;
   };
   using interpolator_source_vars = tmpl::list<gr::Tags::Lapse<DataVector>>;
   using interpolation_target_tags = tmpl::list<InterpolationTargetA>;

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_ObserveTimeSeriesAndSurfaceData.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_ObserveTimeSeriesAndSurfaceData.cpp
@@ -362,9 +362,10 @@ struct MockInterpolationTarget {
   using chare_type = ActionTesting::MockSingletonChare;
   using array_index = size_t;
   using const_global_cache_tags = tmpl::flatten<tmpl::append<
-      Parallel::get_const_global_cache_tags_from_actions<tmpl::list<
-          typename InterpolationTargetTag::compute_target_points,
-          typename InterpolationTargetTag::post_interpolation_callback>>,
+      Parallel::get_const_global_cache_tags_from_actions<
+          tmpl::flatten<tmpl::list<
+              typename InterpolationTargetTag::compute_target_points,
+              typename InterpolationTargetTag::post_interpolation_callbacks>>>,
       tmpl::list<domain::Tags::Domain<Metavariables::volume_dim>>>>;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
@@ -407,11 +408,11 @@ struct MockMetavariables {
                        Tags::Square, ::Frame::Inertial>>;
     using compute_target_points =
         intrp::TargetPoints::KerrHorizon<SurfaceA, ::Frame::Inertial>;
-    using post_interpolation_callback =
-        intrp::callbacks::ObserveTimeSeriesOnSurface<
+    using post_interpolation_callbacks =
+        tmpl::list<intrp::callbacks::ObserveTimeSeriesOnSurface<
             tmpl::list<gr::surfaces::Tags::SurfaceIntegral<Tags::Square,
                                                            ::Frame::Inertial>>,
-            SurfaceA>;
+            SurfaceA>>;
   };
   struct SurfaceB : tt::ConformsTo<intrp::protocols::InterpolationTargetTag> {
     using temporal_id = ::Tags::TimeStepId;
@@ -426,13 +427,13 @@ struct MockMetavariables {
                                                               Frame::Inertial>>;
     using compute_target_points =
         intrp::TargetPoints::KerrHorizon<SurfaceB, ::Frame::Inertial>;
-    using post_interpolation_callback =
-        intrp::callbacks::ObserveTimeSeriesOnSurface<
+    using post_interpolation_callbacks =
+        tmpl::list<intrp::callbacks::ObserveTimeSeriesOnSurface<
             tmpl::list<gr::surfaces::Tags::SurfaceIntegral<Tags::Square,
                                                            ::Frame::Inertial>,
                        gr::surfaces::Tags::SurfaceIntegral<Tags::Negate,
                                                            ::Frame::Inertial>>,
-            SurfaceB>;
+            SurfaceB>>;
   };
   struct SurfaceC : tt::ConformsTo<intrp::protocols::InterpolationTargetTag> {
     using temporal_id = ::Tags::TimeStepId;
@@ -445,11 +446,11 @@ struct MockMetavariables {
                        Tags::Negate, ::Frame::Inertial>>;
     using compute_target_points =
         intrp::TargetPoints::KerrHorizon<SurfaceC, ::Frame::Inertial>;
-    using post_interpolation_callback =
-        intrp::callbacks::ObserveTimeSeriesOnSurface<
+    using post_interpolation_callbacks =
+        tmpl::list<intrp::callbacks::ObserveTimeSeriesOnSurface<
             tmpl::list<gr::surfaces::Tags::SurfaceIntegral<Tags::Negate,
                                                            ::Frame::Inertial>>,
-            SurfaceC>;
+            SurfaceC>>;
   };
 
   struct SurfaceD : tt::ConformsTo<intrp::protocols::InterpolationTargetTag> {
@@ -463,9 +464,9 @@ struct MockMetavariables {
                        Tags::Square, ::Frame::Inertial>>;
     using compute_target_points =
         intrp::TargetPoints::KerrHorizon<SurfaceD, ::Frame::Inertial>;
-    using post_interpolation_callback =
-        intrp::callbacks::ObserveSurfaceData<tmpl::list<Tags::Square>, SurfaceD,
-                                             ::Frame::Inertial>;
+    using post_interpolation_callbacks =
+        tmpl::list<intrp::callbacks::ObserveSurfaceData<
+            tmpl::list<Tags::Square>, SurfaceD, ::Frame::Inertial>>;
   };
 
   struct SurfaceE : tt::ConformsTo<intrp::protocols::InterpolationTargetTag> {
@@ -479,9 +480,9 @@ struct MockMetavariables {
                        Tags::Square, ::Frame::Inertial>>;
     using compute_target_points =
         intrp::TargetPoints::KerrHorizon<SurfaceE, ::Frame::Inertial>;
-    using post_interpolation_callback =
-        intrp::callbacks::ObserveSurfaceData<tmpl::list<Tags::Square>, SurfaceE,
-                                             ::Frame::Inertial>;
+    using post_interpolation_callbacks =
+        tmpl::list<intrp::callbacks::ObserveSurfaceData<
+            tmpl::list<Tags::Square>, SurfaceE, ::Frame::Inertial>>;
   };
 
   using observed_reduction_data_tags = tmpl::list<>;
@@ -521,16 +522,16 @@ SPECTRE_TEST_CASE(
   }
 
   // Test That ObserveTimeSeriesOnSurface indeed does conform to its protocol
-  using callback_A =
-      typename MockMetavariables::SurfaceA::post_interpolation_callback;
-  using callback_B =
-      typename MockMetavariables::SurfaceB::post_interpolation_callback;
-  using callback_C =
-      typename MockMetavariables::SurfaceC::post_interpolation_callback;
-  using callback_D =
-      typename MockMetavariables::SurfaceD::post_interpolation_callback;
-  using callback_E =
-      typename MockMetavariables::SurfaceE::post_interpolation_callback;
+  using callback_A = tmpl::front<
+      typename MockMetavariables::SurfaceA::post_interpolation_callbacks>;
+  using callback_B = tmpl::front<
+      typename MockMetavariables::SurfaceB::post_interpolation_callbacks>;
+  using callback_C = tmpl::front<
+      typename MockMetavariables::SurfaceC::post_interpolation_callbacks>;
+  using callback_D = tmpl::front<
+      typename MockMetavariables::SurfaceD::post_interpolation_callbacks>;
+  using callback_E = tmpl::front<
+      typename MockMetavariables::SurfaceE::post_interpolation_callbacks>;
   using protocol = intrp::protocols::PostInterpolationCallback;
   static_assert(tt::assert_conforms_to_v<callback_A, protocol>);
   static_assert(tt::assert_conforms_to_v<callback_B, protocol>);

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_ParallelInterpolator.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_ParallelInterpolator.cpp
@@ -243,8 +243,8 @@ struct MockMetavariables {
     using compute_target_points =
         intrp::TargetPoints::LineSegment<InterpolationTargetA, 3,
                                          Frame::Inertial>;
-    using post_interpolation_callback =
-        TestFunction<InterpolationTargetA, Tags::Square>;
+    using post_interpolation_callbacks =
+        tmpl::list<TestFunction<InterpolationTargetA, Tags::Square>>;
   };
   struct InterpolationTargetB
       : tt::ConformsTo<intrp::protocols::InterpolationTargetTag> {
@@ -255,8 +255,8 @@ struct MockMetavariables {
     using compute_target_points =
         intrp::TargetPoints::LineSegment<InterpolationTargetB, 3,
                                          Frame::Inertial>;
-    using post_interpolation_callback =
-        TestFunction<InterpolationTargetB, Tags::Negate>;
+    using post_interpolation_callbacks =
+        tmpl::list<TestFunction<InterpolationTargetB, Tags::Negate>>;
   };
   struct InterpolationTargetC
       : tt::ConformsTo<intrp::protocols::InterpolationTargetTag> {
@@ -266,7 +266,7 @@ struct MockMetavariables {
     using compute_target_points =
         intrp::TargetPoints::KerrHorizon<InterpolationTargetC,
                                          ::Frame::Inertial>;
-    using post_interpolation_callback = TestKerrHorizonIntegral;
+    using post_interpolation_callbacks = tmpl::list<TestKerrHorizonIntegral>;
   };
 
   using interpolator_source_vars = tmpl::list<Tags::TestSolution>;


### PR DESCRIPTION
## Proposed changes

Doesn't actually add any, but adds support for adding more.

For reviewers, most of the important logic changes are in `InterpolationTargetDetail.hpp`. The rest is mostly just changing the name of the type alias and wrapping them in a `tmpl::list<>` .

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
