### PR TITLE
Use smaller values in scalar wave char test

### DIFF
--- a/tests/Unit/Evolution/Systems/ScalarWave/Test_Characteristics.cpp
+++ b/tests/Unit/Evolution/Systems/ScalarWave/Test_Characteristics.cpp
@@ -132,19 +132,19 @@ void test_characteristic_fields() {
   // VPsi
   pypp::check_with_random_values<1>(field_with_tag<ScalarWave::Tags::VPsi, Dim>,
                                     "Characteristics", "char_field_vpsi",
-                                    {{{-100., 100.}}}, used_for_size);
+                                    {{{-10., 10.}}}, used_for_size);
   // VZero
   pypp::check_with_random_values<1>(
       field_with_tag<ScalarWave::Tags::VZero<Dim>, Dim>, "Characteristics",
-      "char_field_vzero", {{{-100., 100.}}}, used_for_size, 1.e-11);
+      "char_field_vzero", {{{-10., 10.}}}, used_for_size, 1.e-11);
   // VPlus
   pypp::check_with_random_values<1>(
       field_with_tag<ScalarWave::Tags::VPlus, Dim>, "Characteristics",
-      "char_field_vplus", {{{-100., 100.}}}, used_for_size);
+      "char_field_vplus", {{{-10., 10.}}}, used_for_size);
   // VMinus
   pypp::check_with_random_values<1>(
       field_with_tag<ScalarWave::Tags::VMinus, Dim>, "Characteristics",
-      "char_field_vminus", {{{-100., 100.}}}, used_for_size);
+      "char_field_vminus", {{{-10., 10.}}}, used_for_size);
 }
 
 // Test return-by-reference char fields by comparing to analytic solution
@@ -251,15 +251,15 @@ void test_evolved_from_characteristic_fields() {
   // Psi
   pypp::check_with_random_values<1>(
       evol_field_with_tag<ScalarWave::Tags::Psi, Dim>, "Characteristics",
-      "evol_field_psi", {{{-100., 100.}}}, used_for_size);
+      "evol_field_psi", {{{-10., 10.}}}, used_for_size);
   // Pi
   pypp::check_with_random_values<1>(
       evol_field_with_tag<ScalarWave::Tags::Pi, Dim>, "Characteristics",
-      "evol_field_pi", {{{-100., 100.}}}, used_for_size);
+      "evol_field_pi", {{{-10., 10.}}}, used_for_size);
   // Phi
   pypp::check_with_random_values<1>(
       evol_field_with_tag<ScalarWave::Tags::Phi<Dim>, Dim>, "Characteristics",
-      "evol_field_phi", {{{-100., 100.}}}, used_for_size);
+      "evol_field_phi", {{{-10., 10.}}}, used_for_size);
 }
 
 // Test return-by-reference evolved fields by comparing to analytic solution


### PR DESCRIPTION
## Proposed changes

Fixes #5570. The random values of the tensors were too large so they were off by roundoff. Ran the test 10k times and didn't have an issue.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
