### PR TITLE
Enable p-refinement for ScalarWave executables

### DIFF
--- a/src/Evolution/Executables/ScalarWave/CMakeLists.txt
+++ b/src/Evolution/Executables/ScalarWave/CMakeLists.txt
@@ -3,6 +3,9 @@
 
 set(LIBS_TO_LINK
   Charmxx::main
+  Amr
+  AmrCriteria
+  AmrProjectors
   CoordinateMaps
   DiscontinuousGalerkin
   DomainCreators

--- a/src/Evolution/Executables/ScalarWave/EvolveScalarWave.cpp
+++ b/src/Evolution/Executables/ScalarWave/EvolveScalarWave.cpp
@@ -10,6 +10,7 @@
 #include "Domain/FunctionsOfTime/RegisterDerivedWithCharm.hpp"
 #include "Evolution/Systems/ScalarWave/BoundaryCorrections/RegisterDerived.hpp"
 #include "Parallel/CharmMain.tpp"
+#include "ParallelAlgorithms/Amr/Actions/RegisterCallbacks.hpp"
 #include "Utilities/Serialization/RegisterDerivedClassesWithCharm.hpp"
 
 // Chosen in CMakeLists.txt
@@ -22,6 +23,8 @@ extern "C" void CkRegisterMainModule() {
        &domain::creators::time_dependence::register_derived_with_charm,
        &domain::FunctionsOfTime::register_derived_with_charm,
        &ScalarWave::BoundaryCorrections::register_derived_with_charm,
-       &register_factory_classes_with_charm<metavariables>},
+       &register_factory_classes_with_charm<metavariables>,
+       &amr::register_callbacks<metavariables,
+                                typename metavariables::dg_element_array>},
       {});
 }

--- a/src/Parallel/PhaseControl/Factory.hpp
+++ b/src/Parallel/PhaseControl/Factory.hpp
@@ -10,7 +10,10 @@
 
 namespace PhaseControl {
 using factory_creatable_classes =
-    tmpl::list<VisitAndReturn<Parallel::Phase::LoadBalancing>,
+    tmpl::list<VisitAndReturn<Parallel::Phase::EvaluateAmrCriteria>,
+               VisitAndReturn<Parallel::Phase::AdjustDomain>,
+               VisitAndReturn<Parallel::Phase::CheckDomain>,
+               VisitAndReturn<Parallel::Phase::LoadBalancing>,
                VisitAndReturn<Parallel::Phase::WriteCheckpoint>,
                CheckpointAndExitAfterWallclock>;
 }

--- a/tests/InputFiles/ScalarWave/PlaneWave1D.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave1D.yaml
@@ -10,6 +10,7 @@ Testing:
 
 ResourceInfo:
   AvoidGlobalProc0: false
+  Singletons: Auto
 
 InitialData: &InitialData
   PlaneWave:
@@ -21,25 +22,31 @@ InitialData: &InitialData
         Wavenumber: 1.0
         Phase: 0.0
 
+Amr:
+  Criteria:
+    - TruncationError:
+        VariablesToMonitor: [Psi]
+        AbsoluteTarget: 1.e-6
+        RelativeTarget: 1.0
+  Verbosity: Verbose
+
 PhaseChangeAndTriggers:
+  - Trigger:
+      Slabs:
+        EvenlySpaced:
+          Interval: 1
+          Offset: 0
+    PhaseChanges:
+      - VisitAndReturn(EvaluateAmrCriteria)
+      - VisitAndReturn(AdjustDomain)
+      - VisitAndReturn(CheckDomain)
 
 Evolution:
   InitialTime: 0.0
   InitialTimeStep: 0.001
-  InitialSlabSize: 0.1
   TimeStepper:
     AdamsBashforth:
       Order: 3
-  StepChoosers:
-    - PreventRapidIncrease
-    - Increase:
-        Factor: 2
-    - ErrorControl:
-        AbsoluteTolerance: 1.0e-5
-        RelativeTolerance: 1.0e-5
-        MaxFactor: 10000.0
-        MinFactor: 0.0
-        SafetyFactor: 0.9
 
 DomainCreator:
   RotatedIntervals:

--- a/tests/InputFiles/ScalarWave/PlaneWave1DEventsAndTriggersExample.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave1DEventsAndTriggersExample.yaml
@@ -12,6 +12,7 @@ ExpectedOutput:
 
 ResourceInfo:
   AvoidGlobalProc0: false
+  Singletons: Auto
 
 InitialData:
   PlaneWave:
@@ -23,17 +24,31 @@ InitialData:
         Wavenumber: 1.0
         Phase: 0.0
 
+Amr:
+  Criteria:
+    - TruncationError:
+        VariablesToMonitor: [Psi]
+        AbsoluteTarget: 1.e-6
+        RelativeTarget: 1.0
+  Verbosity: Verbose
+
 PhaseChangeAndTriggers:
+  - Trigger:
+      Slabs:
+        EvenlySpaced:
+          Interval: 1
+          Offset: 0
+    PhaseChanges:
+      - VisitAndReturn(EvaluateAmrCriteria)
+      - VisitAndReturn(AdjustDomain)
+      - VisitAndReturn(CheckDomain)
 
 Evolution:
   InitialTime: 0.0
   InitialTimeStep: 0.001
-  InitialSlabSize: 0.01
   TimeStepper:
     AdamsBashforth:
       Order: 3
-  StepChoosers:
-    - Constant: 0.001
 
 DomainCreator:
   Interval:

--- a/tests/InputFiles/ScalarWave/PlaneWave1DObserveExample.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave1DObserveExample.yaml
@@ -13,6 +13,7 @@ ExpectedOutput:
 
 ResourceInfo:
   AvoidGlobalProc0: false
+  Singletons: Auto
 
 InitialData:
   PlaneWave:
@@ -24,22 +25,32 @@ InitialData:
         Wavenumber: 1.0
         Phase: 0.0
 
+Amr:
+  Criteria:
+    - TruncationError:
+        VariablesToMonitor: [Psi]
+        AbsoluteTarget: 1.e-6
+        RelativeTarget: 1.0
+  Verbosity: Verbose
+
 PhaseChangeAndTriggers:
+  - Trigger:
+      Slabs:
+        EvenlySpaced:
+          Interval: 10
+          Offset: 0
+    PhaseChanges:
+      - VisitAndReturn(EvaluateAmrCriteria)
+      - VisitAndReturn(AdjustDomain)
+      - VisitAndReturn(CheckDomain)
 
 Evolution:
   InitialTime: &InitialTime
     0.0
   InitialTimeStep: 0.001
-  InitialSlabSize: 0.01
   TimeStepper:
     AdamsBashforth:
       Order: 3
-  StepChoosers:
-    - Constant: 0.05
-    - Increase:
-        Factor: 2
-    - Cfl:
-        SafetyFactor: 0.2
 
 DomainCreator:
   Interval:

--- a/tests/InputFiles/ScalarWave/PlaneWave2D.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave2D.yaml
@@ -11,6 +11,7 @@ ExpectedOutput:
 
 ResourceInfo:
   AvoidGlobalProc0: false
+  Singletons: Auto
 
 InitialData:
   PlaneWave:
@@ -22,27 +23,18 @@ InitialData:
         Wavenumber: 1.0
         Phase: 0.0
 
+Amr:
+  Criteria:
+  Verbosity: Verbose
+
 PhaseChangeAndTriggers:
 
 Evolution:
   InitialTime: &initial_time 0.0
   InitialTimeStep: 0.001
-  InitialSlabSize: 0.01
   TimeStepper:
     AdamsBashforth:
       Order: 3
-  StepChoosers:
-    - Constant: 0.05
-    - Increase:
-        Factor: 2
-    - ElementSizeCfl:
-        SafetyFactor: 0.5
-    - ErrorControl:
-        AbsoluteTolerance: 1e-6
-        RelativeTolerance: 1e-4
-        MaxFactor: 2
-        MinFactor: 0.25
-        SafetyFactor: 0.95
 
 
 DomainCreator:

--- a/tests/InputFiles/ScalarWave/PlaneWave3D.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave3D.yaml
@@ -9,6 +9,7 @@ Testing:
 
 ResourceInfo:
   AvoidGlobalProc0: false
+  Singletons: Auto
 
 InitialData:
   PlaneWave:
@@ -20,22 +21,19 @@ InitialData:
         Wavenumber: 1.0
         Phase: 0.0
 
+Amr:
+  Criteria:
+  Verbosity: Verbose
+
 PhaseChangeAndTriggers:
 
 Evolution:
   InitialTime: 0.0
   # Test backwards evolution in an integration test
   InitialTimeStep: -0.001
-  InitialSlabSize: 0.01
   TimeStepper:
     AdamsBashforth:
       Order: 3
-  StepChoosers:
-    - Constant: 0.05
-    - Increase:
-        Factor: 2
-    - Cfl:
-        SafetyFactor: 0.2
 
 DomainCreator:
   Brick:


### PR DESCRIPTION
## Proposed changes

Enable p-refinement for ScalarWave executables.
Currently only works for global time-stepping.
Only the example input files for 1D actually do AMR during the evolution.  See them if you want to use AMR in 2D or 3D.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
ScalarWave input files need to have additional options, as well as now using global time-steppers instead of local time-steppers.  (See the diff of `tests/InputFiles/ScalarWave/PlaneWave1D.yaml`)
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
