### PR TITLE
Fix regex for iterable actions in charm traces

### DIFF
--- a/tools/CharmSimplifyTraces.py
+++ b/tools/CharmSimplifyTraces.py
@@ -55,6 +55,11 @@ def generic_replacements(text):
             matches = re.findall(
                 ", std::integral_constant<unsigned long, [0-9]+>", text[i]
             )
+            if len(matches) == 0:
+                matches = re.findall(
+                    ", std::integral_constant<long unsigned int, [0-9]+>",
+                    text[i],
+                )
             text[i] = text[i].replace("invoke_iterable_action<", "")
             text[i] = text[i].replace(str(matches[-1]), "")
             text[i] = text[i].replace(str(matches[-2]), "")


### PR DESCRIPTION
## Proposed changes

No clue why this changed. Maybe the old version used charm v6.10 and the output got switched in v7? Left both in just in case.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
