### PR TITLE
Support domain deformations in elliptic solver

### DIFF
--- a/cmake/SetupCxxFlags.cmake
+++ b/cmake/SetupCxxFlags.cmake
@@ -103,6 +103,16 @@ set_property(TARGET SpectreFlags
   INTERFACE_COMPILE_OPTIONS
   $<$<COMPILE_LANGUAGE:CXX>:-ftemplate-backtrace-limit=0>)
 
+# Increase bracket depth for fold expressions
+# (see also https://github.com/llvm/llvm-project/issues/48973)
+if (CMAKE_CXX_COMPILER_ID MATCHES "Clang"
+    AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 12.0)
+  set_property(TARGET SpectreFlags
+    APPEND PROPERTY
+    INTERFACE_COMPILE_OPTIONS
+    $<$<COMPILE_LANGUAGE:CXX>:-fbracket-depth=1024>)
+endif()
+
 # Disable cmath setting the error flag. This allows the compiler to more
 # aggressively vectorize code since it doesn't need to respect some global
 # state.

--- a/src/Domain/CMakeLists.txt
+++ b/src/Domain/CMakeLists.txt
@@ -70,6 +70,7 @@ target_link_libraries(
   DomainBoundaryConditions
   DomainStructure
   ErrorHandling
+  FunctionsOfTime
   Options
   Spectral
   Utilities
@@ -77,8 +78,6 @@ target_link_libraries(
   LinearOperators
   RootFinding
   SphericalHarmonics
-  INTERFACE
-  FunctionsOfTime
 )
 
 add_subdirectory(Amr)

--- a/src/Domain/CoordinateMaps/Composition.cpp
+++ b/src/Domain/CoordinateMaps/Composition.cpp
@@ -366,6 +366,15 @@ bool Composition<Frames, Dim, std::index_sequence<Is...>>::is_equal_to(
 
 #define INSTANTIATE(_, data)                                                   \
   template class Composition<                                                  \
+      tmpl::list<Frame::BlockLogical, Frame::Grid, Frame::Inertial>,           \
+      DIM(data)>;                                                              \
+  template class Composition<                                                  \
+      tmpl::list<Frame::BlockLogical, Frame::Grid, Frame::Distorted>,          \
+      DIM(data)>;                                                              \
+  template class Composition<tmpl::list<Frame::BlockLogical, Frame::Grid,      \
+                                        Frame::Distorted, Frame::Inertial>,    \
+                             DIM(data)>;                                       \
+  template class Composition<                                                  \
       tmpl::list<Frame::ElementLogical, Frame::BlockLogical, Frame::Inertial>, \
       DIM(data)>;                                                              \
   template class Composition<                                                  \
@@ -390,6 +399,48 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
 
 #if defined(__clang__) && __clang_major__ >= 15
 #define INSTANTIATE2(_, data)                                                  \
+  template domain::CoordinateMaps::Composition<                                \
+      brigand::list<Frame::BlockLogical, Frame::Grid, Frame::Distorted>,       \
+      DIM(data), std::integer_sequence<unsigned long, 0ul, 1ul>>::             \
+      Composition(                                                             \
+          std::unique_ptr<domain::CoordinateMapBase<Frame::BlockLogical,       \
+                                                    Frame::Grid, DIM(data)>,   \
+                          std::default_delete<domain::CoordinateMapBase<       \
+                              Frame::BlockLogical, Frame::Grid, DIM(data)>>>,  \
+          std::unique_ptr<domain::CoordinateMapBase<                           \
+                              Frame::Grid, Frame::Distorted, DIM(data)>,       \
+                          std::default_delete<domain::CoordinateMapBase<       \
+                              Frame::Grid, Frame::Distorted, DIM(data)>>>);    \
+  template domain::CoordinateMaps::Composition<                                \
+      brigand::list<Frame::BlockLogical, Frame::Grid, Frame::Inertial>,        \
+      DIM(data), std::integer_sequence<unsigned long, 0ul, 1ul>>::             \
+      Composition(                                                             \
+          std::unique_ptr<domain::CoordinateMapBase<Frame::BlockLogical,       \
+                                                    Frame::Grid, DIM(data)>,   \
+                          std::default_delete<domain::CoordinateMapBase<       \
+                              Frame::BlockLogical, Frame::Grid, DIM(data)>>>,  \
+          std::unique_ptr<domain::CoordinateMapBase<                           \
+                              Frame::Grid, Frame::Inertial, DIM(data)>,        \
+                          std::default_delete<domain::CoordinateMapBase<       \
+                              Frame::Grid, Frame::Inertial, DIM(data)>>>);     \
+  template domain::CoordinateMaps::Composition<                                \
+      brigand::list<Frame::BlockLogical, Frame::Grid, Frame::Distorted,        \
+                    Frame::Inertial>,                                          \
+      DIM(data), std::integer_sequence<unsigned long, 0ul, 1ul, 2ul>>::        \
+      Composition(                                                             \
+          std::unique_ptr<domain::CoordinateMapBase<Frame::BlockLogical,       \
+                                                    Frame::Grid, DIM(data)>,   \
+                          std::default_delete<domain::CoordinateMapBase<       \
+                              Frame::BlockLogical, Frame::Grid, DIM(data)>>>,  \
+          std::unique_ptr<domain::CoordinateMapBase<                           \
+                              Frame::Grid, Frame::Distorted, DIM(data)>,       \
+                          std::default_delete<domain::CoordinateMapBase<       \
+                              Frame::Grid, Frame::Distorted, DIM(data)>>>,     \
+          std::unique_ptr<                                                     \
+              domain::CoordinateMapBase<Frame::Distorted, Frame::Inertial,     \
+                                        DIM(data)>,                            \
+              std::default_delete<domain::CoordinateMapBase<                   \
+                  Frame::Distorted, Frame::Inertial, DIM(data)>>>);            \
   template domain::CoordinateMaps::Composition<                                \
       brigand::list<Frame::ElementLogical, Frame::BlockLogical,                \
                     Frame::Inertial>,                                          \

--- a/src/Domain/ElementDistribution.cpp
+++ b/src/Domain/ElementDistribution.cpp
@@ -63,10 +63,7 @@ double get_num_points_and_grid_spacing_cost(
       initial_extents, element_id, quadrature);
   Element<Dim> element = ::domain::Initialization::create_initial_element(
       element_id, block, initial_refinement_levels);
-  ElementMap<Dim, Frame::Grid> element_map{
-      element_id, block.is_time_dependent()
-                      ? block.moving_mesh_logical_to_grid_map().get_clone()
-                      : block.stationary_map().get_to_grid_frame()};
+  ElementMap<Dim, Frame::Grid> element_map{element_id, block};
   const tnsr::I<DataVector, Dim, Frame::ElementLogical> logical_coords =
       logical_coordinates(mesh);
   const tnsr::I<DataVector, Dim, Frame::Grid> grid_coords =

--- a/src/Domain/ElementMap.hpp
+++ b/src/Domain/ElementMap.hpp
@@ -11,6 +11,7 @@
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/Block.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
 #include "Domain/Structure/ElementId.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeArray.hpp"
@@ -63,17 +64,23 @@ class ElementMap {
 
   template <typename T>
   tnsr::I<T, Dim, TargetFrame> operator()(
-      const tnsr::I<T, Dim, Frame::ElementLogical>& source_point) const {
+      const tnsr::I<T, Dim, Frame::ElementLogical>& source_point,
+      const double time = std::numeric_limits<double>::signaling_NaN(),
+      const domain::FunctionsOfTimeMap& functions_of_time = {}) const {
     auto block_source_point =
         apply_affine_transformation_to_point(source_point);
-    return block_map_->operator()(std::move(block_source_point));
+    return block_map_->operator()(std::move(block_source_point), time,
+                                  functions_of_time);
   }
 
   template <typename T>
   tnsr::I<T, Dim, Frame::ElementLogical> inverse(
-      tnsr::I<T, Dim, TargetFrame> target_point) const {
+      tnsr::I<T, Dim, TargetFrame> target_point,
+      const double time = std::numeric_limits<double>::signaling_NaN(),
+      const domain::FunctionsOfTimeMap& functions_of_time = {}) const {
     auto block_source_point{
-        block_map_->inverse(std::move(target_point)).value()};
+        block_map_->inverse(std::move(target_point), time, functions_of_time)
+            .value()};
     // Apply the affine map to the points
     tnsr::I<T, Dim, Frame::ElementLogical> source_point;
     for (size_t d = 0; d < Dim; ++d) {
@@ -86,11 +93,13 @@ class ElementMap {
 
   template <typename T>
   InverseJacobian<T, Dim, Frame::ElementLogical, TargetFrame> inv_jacobian(
-      const tnsr::I<T, Dim, Frame::ElementLogical>& source_point) const {
+      const tnsr::I<T, Dim, Frame::ElementLogical>& source_point,
+      const double time = std::numeric_limits<double>::signaling_NaN(),
+      const domain::FunctionsOfTimeMap& functions_of_time = {}) const {
     auto block_source_point =
         apply_affine_transformation_to_point(source_point);
-    auto block_inv_jac =
-        block_map_->inv_jacobian(std::move(block_source_point));
+    auto block_inv_jac = block_map_->inv_jacobian(std::move(block_source_point),
+                                                  time, functions_of_time);
     InverseJacobian<T, Dim, Frame::ElementLogical, TargetFrame> inv_jac;
     for (size_t d = 0; d < Dim; ++d) {
       for (size_t i = 0; i < Dim; ++i) {
@@ -103,10 +112,13 @@ class ElementMap {
 
   template <typename T>
   Jacobian<T, Dim, Frame::ElementLogical, TargetFrame> jacobian(
-      const tnsr::I<T, Dim, Frame::ElementLogical>& source_point) const {
+      const tnsr::I<T, Dim, Frame::ElementLogical>& source_point,
+      const double time = std::numeric_limits<double>::signaling_NaN(),
+      const domain::FunctionsOfTimeMap& functions_of_time = {}) const {
     auto block_source_point =
         apply_affine_transformation_to_point(source_point);
-    auto block_jac = block_map_->jacobian(std::move(block_source_point));
+    auto block_jac = block_map_->jacobian(std::move(block_source_point), time,
+                                          functions_of_time);
     Jacobian<T, Dim, Frame::ElementLogical, TargetFrame> jac;
     for (size_t d = 0; d < Dim; ++d) {
       for (size_t i = 0; i < Dim; ++i) {

--- a/src/Domain/ElementMap.hpp
+++ b/src/Domain/ElementMap.hpp
@@ -9,6 +9,7 @@
 #include <memory>
 
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/Block.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/Structure/ElementId.hpp"
 #include "Utilities/Gsl.hpp"
@@ -44,6 +45,14 @@ class ElementMap {
              std::unique_ptr<domain::CoordinateMapBase<Frame::BlockLogical,
                                                        TargetFrame, Dim>>
                  block_map);
+
+  /// Construct from an `element_id` within the `block`. The (affine)
+  /// ElementLogical to BlockLogical map is determined by the `element_id`. The
+  /// BlockLogical to TargetFrame map is determined by the `block`:
+  /// - If the block is time-independent: the `block.stationary_map()` is used.
+  /// - If the block is time-dependent: The `block.moving_mesh_*_map()` maps
+  ///   are used. Which maps are used depends on the TargetFrame.
+  ElementMap(ElementId<Dim> element_id, const Block<Dim>& block);
 
   const domain::CoordinateMapBase<Frame::BlockLogical, TargetFrame, Dim>&
   block_map() const {

--- a/src/Domain/FaceNormal.cpp
+++ b/src/Domain/FaceNormal.cpp
@@ -198,32 +198,40 @@ GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3),
 
 #undef INSTANTIATION
 
-#define INSTANTIATION(_, data)                                              \
-  template void unnormalized_face_normal(                                   \
-      const gsl::not_null<                                                  \
-          tnsr::i<DataVector, GET_DIM(data), Frame::Inertial>*>             \
-          result,                                                           \
-      const Mesh<GET_DIM(data) - 1>& interface_mesh,                        \
-      const ElementMap<GET_DIM(data), Frame::Grid>& logical_to_grid_map,    \
-      const domain::CoordinateMapBase<Frame::Grid, Frame::Inertial,         \
-                                      GET_DIM(data)>& grid_to_inertial_map, \
-      const double time,                                                    \
-      const std::unordered_map<                                             \
-          std::string,                                                      \
-          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&        \
-          functions_of_time,                                                \
-      const Direction<GET_DIM(data)>& direction);                           \
-  template tnsr::i<DataVector, GET_DIM(data), Frame::Inertial>              \
-  unnormalized_face_normal(                                                 \
-      const Mesh<GET_DIM(data) - 1>& interface_mesh,                        \
-      const ElementMap<GET_DIM(data), Frame::Grid>& logical_to_grid_map,    \
-      const domain::CoordinateMapBase<Frame::Grid, Frame::Inertial,         \
-                                      GET_DIM(data)>& grid_to_inertial_map, \
-      const double time,                                                    \
-      const std::unordered_map<                                             \
-          std::string,                                                      \
-          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&        \
-          functions_of_time,                                                \
+#define INSTANTIATION(_, data)                                                \
+  template void unnormalized_face_normal(                                     \
+      const gsl::not_null<                                                    \
+          tnsr::i<DataVector, GET_DIM(data), Frame::Inertial>*>               \
+          result,                                                             \
+      const Mesh<GET_DIM(data) - 1>& interface_mesh,                          \
+      const ElementMap<GET_DIM(data), Frame::Grid>& logical_to_grid_map,      \
+      const domain::CoordinateMapBase<Frame::Grid, Frame::Inertial,           \
+                                      GET_DIM(data)>& grid_to_inertial_map,   \
+      const double time,                                                      \
+      const std::unordered_map<                                               \
+          std::string,                                                        \
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&          \
+          functions_of_time,                                                  \
+      const Direction<GET_DIM(data)>& direction);                             \
+  template void unnormalized_face_normal(                                     \
+      const gsl::not_null<                                                    \
+          tnsr::i<DataVector, GET_DIM(data), Frame::Inertial>*>               \
+          result,                                                             \
+      const Mesh<GET_DIM(data) - 1>& interface_mesh,                          \
+      const InverseJacobian<DataVector, GET_DIM(data), Frame::ElementLogical, \
+                            Frame::Inertial>& inv_jacobian_on_interface,      \
+      const Direction<GET_DIM(data)>& direction);                             \
+  template tnsr::i<DataVector, GET_DIM(data), Frame::Inertial>                \
+  unnormalized_face_normal(                                                   \
+      const Mesh<GET_DIM(data) - 1>& interface_mesh,                          \
+      const ElementMap<GET_DIM(data), Frame::Grid>& logical_to_grid_map,      \
+      const domain::CoordinateMapBase<Frame::Grid, Frame::Inertial,           \
+                                      GET_DIM(data)>& grid_to_inertial_map,   \
+      const double time,                                                      \
+      const std::unordered_map<                                               \
+          std::string,                                                        \
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&          \
+          functions_of_time,                                                  \
       const Direction<GET_DIM(data)>& direction);
 
 GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))

--- a/src/Domain/FunctionsOfTime/FunctionOfTime.hpp
+++ b/src/Domain/FunctionsOfTime/FunctionOfTime.hpp
@@ -84,4 +84,8 @@ class FunctionOfTime : public PUP::able {
   WRAPPED_PUPable_abstract(FunctionOfTime);  // NOLINT
 };
 }  // namespace FunctionsOfTime
+
+using FunctionsOfTimeMap = std::unordered_map<
+    std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>;
+
 }  // namespace domain

--- a/src/Domain/FunctionsOfTime/FunctionsOfTimeAreReady.hpp
+++ b/src/Domain/FunctionsOfTime/FunctionsOfTimeAreReady.hpp
@@ -46,7 +46,7 @@ bool functions_of_time_are_ready_impl(
     const Component* /*meta*/, const double time,
     const std::optional<std::unordered_set<std::string>>& functions_to_check,
     Args&&... args) {
-  if constexpr (Parallel::is_in_global_cache<Metavariables, CacheTag>) {
+  if constexpr (Parallel::is_in_mutable_global_cache<Metavariables, CacheTag>) {
     const auto& proxy =
         ::Parallel::get_parallel_component<Component>(cache)[array_index];
     const Parallel::ArrayComponentId array_component_id =

--- a/src/Elliptic/DiscontinuousGalerkin/Actions/ApplyOperator.hpp
+++ b/src/Elliptic/DiscontinuousGalerkin/Actions/ApplyOperator.hpp
@@ -17,6 +17,7 @@
 #include "Domain/Creators/Tags/ExternalBoundaryConditions.hpp"
 #include "Domain/Creators/Tags/InitialExtents.hpp"
 #include "Domain/FaceNormal.hpp"
+#include "Domain/FunctionsOfTime/Tags.hpp"
 #include "Domain/Structure/Direction.hpp"
 #include "Domain/Structure/DirectionMap.hpp"
 #include "Domain/Structure/Element.hpp"
@@ -117,7 +118,8 @@ struct InitializeFacesMortarsAndBackground {
       db::mutate_apply<typename InitializeFacesAndMortars::return_tags,
                        typename InitializeFacesAndMortars::argument_tags>(
           InitializeFacesAndMortars{}, make_not_null(&box),
-          db::get<domain::Tags::InitialExtents<Dim>>(box), background,
+          db::get<domain::Tags::InitialExtents<Dim>>(box),
+          db::get<domain::Tags::FunctionsOfTime>(box), background,
           background_classes{});
       // Initialize background fields
       db::mutate_apply<typename InitializeBackground::return_tags,
@@ -129,7 +131,8 @@ struct InitializeFacesMortarsAndBackground {
       db::mutate_apply<typename InitializeFacesAndMortars::return_tags,
                        typename InitializeFacesAndMortars::argument_tags>(
           InitializeFacesAndMortars{}, make_not_null(&box),
-          db::get<domain::Tags::InitialExtents<Dim>>(box));
+          db::get<domain::Tags::InitialExtents<Dim>>(box),
+          db::get<domain::Tags::FunctionsOfTime>(box));
     }
     return {Parallel::AlgorithmExecution::Continue, std::nullopt};
   }

--- a/src/Elliptic/DiscontinuousGalerkin/Actions/InitializeDomain.hpp
+++ b/src/Elliptic/DiscontinuousGalerkin/Actions/InitializeDomain.hpp
@@ -10,6 +10,7 @@
 
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "Domain/Creators/Tags/Domain.hpp"
+#include "Domain/Creators/Tags/FunctionsOfTime.hpp"
 #include "Domain/Creators/Tags/InitialExtents.hpp"
 #include "Domain/Creators/Tags/InitialRefinementLevels.hpp"
 #include "Elliptic/DiscontinuousGalerkin/Initialization.hpp"
@@ -40,6 +41,8 @@ namespace elliptic::dg::Actions {
  *   - `domain::Tags::Domain<Dim, Frame::Inertial>`
  *   - `domain::Tags::InitialExtents<Dim>`
  *   - `domain::Tags::InitialRefinementLevels<Dim>`
+ *   - `domain::Tags::FunctionsOfTime` (Parameters for maps that distort the
+ *     domain. These are always evaluated at t=0.)
  * - Adds:
  *   - `domain::Tags::Mesh<Dim>`
  *   - `domain::Tags::Element<Dim>`
@@ -61,6 +64,8 @@ struct InitializeDomain {
                  domain::Tags::InitialRefinementLevels<Dim>>;
   using simple_tags = typename InitializeGeometry::return_tags;
   using compute_tags = tmpl::list<>;
+  using const_global_cache_tags =
+      tmpl::list<domain::Tags::FunctionsOfTimeInitialize>;
 
   template <typename DbTagsList, typename... InboxTags, typename Metavariables,
             typename ActionList, typename ParallelComponent>

--- a/src/Elliptic/DiscontinuousGalerkin/CMakeLists.txt
+++ b/src/Elliptic/DiscontinuousGalerkin/CMakeLists.txt
@@ -31,6 +31,7 @@ target_link_libraries(
   Domain
   DomainStructure
   ErrorHandling
+  FunctionsOfTime
   LinearOperators
   Spectral
   Utilities

--- a/src/Elliptic/DiscontinuousGalerkin/SubdomainOperator/CMakeLists.txt
+++ b/src/Elliptic/DiscontinuousGalerkin/SubdomainOperator/CMakeLists.txt
@@ -26,6 +26,7 @@ target_link_libraries(
   DataStructures
   DomainStructure
   DiscontinuousGalerkin
+  FunctionsOfTime
   ParallelSchwarz
   Spectral
   Utilities

--- a/src/Elliptic/Executables/Elasticity/CMakeLists.txt
+++ b/src/Elliptic/Executables/Elasticity/CMakeLists.txt
@@ -18,6 +18,7 @@ set(LIBS_TO_LINK
   EllipticSubdomainPreconditioners
   Events
   EventsAndTriggers
+  FunctionsOfTime
   Informer
   LinearOperators
   Observer

--- a/src/Elliptic/Executables/Elasticity/SolveElasticity.cpp
+++ b/src/Elliptic/Executables/Elasticity/SolveElasticity.cpp
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include "Domain/Creators/RegisterDerivedWithCharm.hpp"
+#include "Domain/FunctionsOfTime/RegisterDerivedWithCharm.hpp"
 #include "Elliptic/SubdomainPreconditioners/RegisterDerived.hpp"
 #include "Parallel/CharmMain.tpp"
 #include "Utilities/Serialization/RegisterDerivedClassesWithCharm.hpp"
@@ -17,6 +18,7 @@ extern "C" void CkRegisterMainModule() {
   Parallel::charmxx::register_main_module<metavariables>();
   Parallel::charmxx::register_init_node_and_proc(
       {&domain::creators::register_derived_with_charm,
+       &domain::FunctionsOfTime::register_derived_with_charm,
        &register_derived_classes_with_charm<
            metavariables::schwarz_smoother::subdomain_solver>,
        &elliptic::subdomain_preconditioners::register_derived_with_charm,

--- a/src/Elliptic/Executables/Poisson/CMakeLists.txt
+++ b/src/Elliptic/Executables/Poisson/CMakeLists.txt
@@ -12,6 +12,7 @@ set(LIBS_TO_LINK
   EllipticDgSubdomainOperator
   Events
   EventsAndTriggers
+  FunctionsOfTime
   Informer
   LinearOperators
   MathFunctions

--- a/src/Elliptic/Executables/Poisson/SolvePoisson.cpp
+++ b/src/Elliptic/Executables/Poisson/SolvePoisson.cpp
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include "Domain/Creators/RegisterDerivedWithCharm.hpp"
+#include "Domain/FunctionsOfTime/RegisterDerivedWithCharm.hpp"
 #include "Parallel/CharmMain.tpp"
 #include "Utilities/Serialization/RegisterDerivedClassesWithCharm.hpp"
 
@@ -16,6 +17,7 @@ extern "C" void CkRegisterMainModule() {
   Parallel::charmxx::register_main_module<metavariables>();
   Parallel::charmxx::register_init_node_and_proc(
       {&domain::creators::register_derived_with_charm,
+       &domain::FunctionsOfTime::register_derived_with_charm,
        &register_derived_classes_with_charm<
            metavariables::schwarz_smoother::subdomain_solver>,
        &register_factory_classes_with_charm<metavariables>},

--- a/src/Elliptic/Executables/Punctures/CMakeLists.txt
+++ b/src/Elliptic/Executables/Punctures/CMakeLists.txt
@@ -26,6 +26,7 @@ target_link_libraries(
   ErrorHandling
   Events
   EventsAndTriggers
+  FunctionsOfTime
   Informer
   Initialization
   LinearOperators

--- a/src/Elliptic/Executables/Punctures/SolvePunctures.cpp
+++ b/src/Elliptic/Executables/Punctures/SolvePunctures.cpp
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include "Domain/Creators/RegisterDerivedWithCharm.hpp"
+#include "Domain/FunctionsOfTime/RegisterDerivedWithCharm.hpp"
 #include "Elliptic/SubdomainPreconditioners/RegisterDerived.hpp"
 #include "Parallel/CharmMain.tpp"
 #include "Utilities/Serialization/RegisterDerivedClassesWithCharm.hpp"
@@ -14,6 +15,7 @@ extern "C" void CkRegisterMainModule() {
   Parallel::charmxx::register_main_module<Metavariables>();
   Parallel::charmxx::register_init_node_and_proc(
       {&domain::creators::register_derived_with_charm,
+       &domain::FunctionsOfTime::register_derived_with_charm,
        &register_derived_classes_with_charm<
            Metavariables::solver::schwarz_smoother::subdomain_solver>,
        &elliptic::subdomain_preconditioners::register_derived_with_charm,

--- a/src/Elliptic/Executables/Xcts/CMakeLists.txt
+++ b/src/Elliptic/Executables/Xcts/CMakeLists.txt
@@ -26,6 +26,7 @@ target_link_libraries(
   ErrorHandling
   Events
   EventsAndTriggers
+  FunctionsOfTime
   Hydro
   Informer
   Initialization

--- a/src/Elliptic/Executables/Xcts/SolveXcts.cpp
+++ b/src/Elliptic/Executables/Xcts/SolveXcts.cpp
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include "Domain/Creators/RegisterDerivedWithCharm.hpp"
+#include "Domain/FunctionsOfTime/RegisterDerivedWithCharm.hpp"
 #include "Elliptic/SubdomainPreconditioners/RegisterDerived.hpp"
 #include "Parallel/CharmMain.tpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/RegisterDerivedWithCharm.hpp"
@@ -14,9 +15,8 @@
 extern "C" void CkRegisterMainModule() {
   Parallel::charmxx::register_main_module<Metavariables>();
   Parallel::charmxx::register_init_node_and_proc(
-      {&setup_error_handling, &setup_memory_allocation_failure_reporting,
-       &disable_openblas_multithreading,
-       &domain::creators::register_derived_with_charm,
+      {&domain::creators::register_derived_with_charm,
+       &domain::FunctionsOfTime::register_derived_with_charm,
        &register_derived_classes_with_charm<
            Metavariables::solver::schwarz_smoother::subdomain_solver>,
        &elliptic::subdomain_preconditioners::register_derived_with_charm,

--- a/src/Evolution/Initialization/DgDomain.hpp
+++ b/src/Evolution/Initialization/DgDomain.hpp
@@ -151,10 +151,7 @@ struct Domain {
         initial_extents, element_id, quadrature);
     *element = ::domain::Initialization::create_initial_element(
         element_id, my_block, initial_refinement);
-    *element_map = ElementMap<Dim, Frame::Grid>{
-        element_id, my_block.is_time_dependent()
-                        ? my_block.moving_mesh_logical_to_grid_map().get_clone()
-                        : my_block.stationary_map().get_to_grid_frame()};
+    *element_map = ElementMap<Dim, Frame::Grid>{element_id, my_block};
 
     if (my_block.is_time_dependent()) {
       *grid_to_inertial_map =
@@ -197,10 +194,7 @@ struct ProjectDomain : tt::ConformsTo<amr::protocols::Projector> {
       const ParentOrChildrenItemsType& /*parent_or_children_items*/) {
     const ElementId<Dim>& element_id = element.id();
     const auto& my_block = domain.blocks()[element_id.block_id()];
-    *element_map = ElementMap<Dim, Frame::Grid>{
-        element_id, my_block.is_time_dependent()
-                        ? my_block.moving_mesh_logical_to_grid_map().get_clone()
-                        : my_block.stationary_map().get_to_grid_frame()};
+    *element_map = ElementMap<Dim, Frame::Grid>{element_id, my_block};
     if (my_block.is_time_dependent()) {
       *grid_to_inertial_map =
           my_block.moving_mesh_grid_to_inertial_map().get_clone();

--- a/src/Executables/FindHorizons/CMakeLists.txt
+++ b/src/Executables/FindHorizons/CMakeLists.txt
@@ -7,6 +7,7 @@ set(LIBS_TO_LINK
   CoordinateMaps
   DomainCreators
   EllipticDg
+  FunctionsOfTime
   GeneralRelativity
   GrSurfaces
   Informer

--- a/src/Executables/FindHorizons/FindHorizons.cpp
+++ b/src/Executables/FindHorizons/FindHorizons.cpp
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include "Domain/Creators/RegisterDerivedWithCharm.hpp"
+#include "Domain/FunctionsOfTime/RegisterDerivedWithCharm.hpp"
 #include "Parallel/CharmMain.tpp"
 #include "Utilities/Serialization/RegisterDerivedClassesWithCharm.hpp"
 
@@ -16,6 +17,7 @@ extern "C" void CkRegisterMainModule() {
   Parallel::charmxx::register_main_module<metavariables>();
   Parallel::charmxx::register_init_node_and_proc(
       {&domain::creators::register_derived_with_charm,
+       &domain::FunctionsOfTime::register_derived_with_charm,
        &register_factory_classes_with_charm<metavariables>},
       {});
 }

--- a/src/ParallelAlgorithms/Interpolation/InterpolationTargetDetail.hpp
+++ b/src/ParallelAlgorithms/Interpolation/InterpolationTargetDetail.hpp
@@ -533,8 +533,8 @@ auto block_logical_coords(
   }
 
   if (domain.is_time_dependent()) {
-    if constexpr (Parallel::is_in_mutable_global_cache<
-                      Metavariables, domain::Tags::FunctionsOfTime>) {
+    if constexpr (Parallel::is_in_global_cache<Metavariables,
+                                               domain::Tags::FunctionsOfTime>) {
       // Whoever calls block_logical_coords when the maps are
       // time-dependent is responsible for ensuring
       // that functions_of_time are up to date at temporal_id.

--- a/tests/InputFiles/Xcts/KerrSchild.yaml
+++ b/tests/InputFiles/Xcts/KerrSchild.yaml
@@ -24,15 +24,17 @@ ResourceInfo:
 
 Background: &solution
   KerrSchild:
-    Mass: 1.
-    Spin: [0., 0., 0.]
+    Mass: &KerrMass 1.
+    Spin: &KerrSpin [0., 0., 0.6]
     Center: [0., 0., 0.]
 
 InitialGuess: Flatness
 
 DomainCreator:
   Sphere:
-    InnerRadius: 1.9
+    # Boyer-Lindquist radius a bit inside the horizon:
+    # 0.89 * (M + sqrt(M^2 - a^2))
+    InnerRadius: 1.602
     OuterRadius: 10.
     Interior:
       ExciseWithBoundaryCondition:
@@ -48,7 +50,13 @@ DomainCreator:
     WhichWedges: All
     RadialPartitioning: []
     RadialDistribution: [Logarithmic]
-    TimeDependentMaps: None
+    TimeDependentMaps:
+      InitialTime: 0.
+      ShapeMap:
+        LMax: 20
+        InitialValues:
+          Mass: *KerrMass
+          Spin: *KerrSpin
     OuterBoundaryCondition:
       AnalyticSolution:
         Solution: *solution
@@ -68,10 +76,10 @@ Observers:
 NonlinearSolver:
   NewtonRaphson:
     ConvergenceCriteria:
-      # Stop after 1 iteration so this test runs quickly. Set MaxIterations to
+      # Stop after 2 iteration so this test runs quickly. Set MaxIterations to
       # ~20 for runs at higher resolution (most nonlinear problems need ~5
       # iterations, so 20 is a safe setting).
-      MaxIterations: 1
+      MaxIterations: 2
       RelativeResidual: 0.
       AbsoluteResidual: 1.e-10
     SufficientDecrease: 1.e-4
@@ -161,6 +169,9 @@ EventsAndTriggers:
             - ExtrinsicCurvature
             - HamiltonianConstraint
             - MomentumConstraint
+            - Error(ConformalFactor)
+            - Error(LapseTimesConformalFactor)
+            - Error(ShiftExcess)
           InterpolateToMesh: None
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double]

--- a/tests/Unit/Elliptic/Actions/Test_InitializeBackgroundFields.cpp
+++ b/tests/Unit/Elliptic/Actions/Test_InitializeBackgroundFields.cpp
@@ -88,7 +88,8 @@ SPECTRE_TEST_CASE("Unit.Elliptic.Actions.InitializeBackgroundFields",
 
   using element_array = ElementArray<Metavariables>;
   ActionTesting::MockRuntimeSystem<Metavariables> runner{
-      {std::make_unique<Background>(), domain_creator.create_domain()}};
+      {std::make_unique<Background>(), domain_creator.create_domain(),
+       domain_creator.functions_of_time()}};
   ActionTesting::emplace_component_and_initialize<element_array>(
       &runner, element_id,
       {domain_creator.initial_refinement_levels(),

--- a/tests/Unit/Elliptic/Actions/Test_InitializeFields.cpp
+++ b/tests/Unit/Elliptic/Actions/Test_InitializeFields.cpp
@@ -116,7 +116,8 @@ SPECTRE_TEST_CASE("Unit.Elliptic.Actions.InitializeFields",
 
   using element_array = ElementArray<Metavariables>;
   ActionTesting::MockRuntimeSystem<Metavariables> runner{
-      {std::make_unique<InitialGuess>(), domain_creator.create_domain()}};
+      {std::make_unique<InitialGuess>(), domain_creator.create_domain(),
+       domain_creator.functions_of_time()}};
   ActionTesting::emplace_component_and_initialize<element_array>(
       &runner, element_id,
       {domain_creator.initial_refinement_levels(),

--- a/tests/Unit/Elliptic/Actions/Test_InitializeFixedSources.cpp
+++ b/tests/Unit/Elliptic/Actions/Test_InitializeFixedSources.cpp
@@ -16,6 +16,7 @@
 #include "Domain/Creators/Interval.hpp"
 #include "Domain/Creators/RegisterDerivedWithCharm.hpp"
 #include "Domain/Creators/Tags/Domain.hpp"
+#include "Domain/Creators/Tags/FunctionsOfTime.hpp"
 #include "Domain/Creators/Tags/InitialExtents.hpp"
 #include "Domain/Creators/Tags/InitialRefinementLevels.hpp"
 #include "Domain/Structure/ElementId.hpp"
@@ -114,8 +115,10 @@ SPECTRE_TEST_CASE("Unit.Elliptic.Actions.InitializeFixedSources",
   using element_array = ElementArray<Metavariables>;
   ActionTesting::MockRuntimeSystem<Metavariables> runner{tuples::TaggedTuple<
       elliptic::Tags::Background<elliptic::analytic_data::Background>,
-      domain::Tags::Domain<1>, elliptic::dg::Tags::Massive>{
-      std::make_unique<Background>(), domain_creator.create_domain(), false}};
+      domain::Tags::Domain<1>, domain::Tags::FunctionsOfTimeInitialize,
+      elliptic::dg::Tags::Massive>{std::make_unique<Background>(),
+                                   domain_creator.create_domain(),
+                                   domain_creator.functions_of_time(), false}};
   ActionTesting::emplace_component_and_initialize<element_array>(
       &runner, element_id,
       {domain_creator.initial_refinement_levels(),

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/SubdomainOperator/Test_SubdomainOperator.cpp
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/SubdomainOperator/Test_SubdomainOperator.cpp
@@ -32,6 +32,7 @@
 #include "Domain/Creators/RotatedRectangles.hpp"
 #include "Domain/Creators/Tags/Domain.hpp"
 #include "Domain/Creators/Tags/ExternalBoundaryConditions.hpp"
+#include "Domain/Creators/Tags/FunctionsOfTime.hpp"
 #include "Domain/Creators/Tags/InitialExtents.hpp"
 #include "Domain/Creators/Tags/InitialRefinementLevels.hpp"
 #include "Domain/Structure/ElementId.hpp"
@@ -486,12 +487,13 @@ void test_subdomain_operator(
     CAPTURE(element_ids.size());
 
     ActionTesting::MockRuntimeSystem<metavariables> runner{tuples::TaggedTuple<
-        domain::Tags::Domain<Dim>,
+        domain::Tags::Domain<Dim>, domain::Tags::FunctionsOfTimeInitialize,
         domain::Tags::ExternalBoundaryConditions<Dim>,
         elliptic::Tags::Background<elliptic::analytic_data::Background>,
         LinearSolver::Schwarz::Tags::MaxOverlap<DummyOptionsGroup>,
         elliptic::dg::Tags::PenaltyParameter, elliptic::dg::Tags::Massive>{
-        std::move(domain), std::move(boundary_conditions),
+        std::move(domain), domain_creator.functions_of_time(),
+        std::move(boundary_conditions),
         std::make_unique<RandomBackground<Dim>>(), overlap, penalty_parameter,
         use_massive_dg_operator}};
 

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_DgOperator.cpp
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_DgOperator.cpp
@@ -18,6 +18,7 @@
 #include "Domain/Creators/RegisterDerivedWithCharm.hpp"
 #include "Domain/Creators/Tags/Domain.hpp"
 #include "Domain/Creators/Tags/ExternalBoundaryConditions.hpp"
+#include "Domain/Creators/Tags/FunctionsOfTime.hpp"
 #include "Domain/Creators/Tags/InitialExtents.hpp"
 #include "Domain/Creators/Tags/InitialRefinementLevels.hpp"
 #include "Domain/FaceNormal.hpp"
@@ -219,10 +220,12 @@ void test_dg_operator(
   }
 
   ActionTesting::MockRuntimeSystem<Metavars> runner{tuples::TaggedTuple<
-      domain::Tags::Domain<Dim>, domain::Tags::ExternalBoundaryConditions<Dim>,
+      domain::Tags::Domain<Dim>, domain::Tags::FunctionsOfTimeInitialize,
+      domain::Tags::ExternalBoundaryConditions<Dim>,
       ::elliptic::dg::Tags::PenaltyParameter, ::elliptic::dg::Tags::Massive,
       ::Tags::AnalyticSolution<AnalyticSolution>>{
-      std::move(domain), std::move(boundary_conditions), penalty_parameter,
+      std::move(domain), domain_creator.functions_of_time(),
+      std::move(boundary_conditions), penalty_parameter,
       use_massive_dg_operator, analytic_solution}};
 
   // DataBox shortcuts


### PR DESCRIPTION
## Proposed changes

This enables horizon-conforming (ellipsoidal) excision surfaces for spinning BH initial data. It will also allow for surface-fitting coordinates for BNS initial data. For reference, here's my thesis branch that had this implemented in a different way (using static deformed maps, not time dependence): https://github.com/sxs-collaboration/spectre/compare/develop...nilsvu:spectre:thesis

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
