### PR TITLE
Enable time dependent translation with transition for Sphere domain

### DIFF
--- a/src/Domain/CoordinateMaps/TimeDependent/Translation.cpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/Translation.cpp
@@ -359,7 +359,8 @@ std::array<tt::remove_cvref_wrap_t<T>, Dim> Translation<Dim>::piecewise_helper(
       for (size_t i = 0; i < Dim; i++) {
         get_element(gsl::at(result, i), k) += gsl::at(func_or_deriv_of_time, i);
       }
-      ASSERT(max(magnitude(result)) <= outer_radius_.value(),
+      const double eps = std::numeric_limits<double>::epsilon() * 100.0;
+      ASSERT(max(magnitude(result)) - eps <= outer_radius_.value(),
              "Coordinates translated outside outer radius, This should not "
              "happen");
     } else if (get_element(radius, k) > inner_radius_.value() and
@@ -373,7 +374,8 @@ std::array<tt::remove_cvref_wrap_t<T>, Dim> Translation<Dim>::piecewise_helper(
         get_element(gsl::at(result, i), k) +=
             gsl::at(func_or_deriv_of_time, i) * radial_falloff_factor;
       }
-      ASSERT(max(magnitude(result)) <= outer_radius_.value(),
+      const double eps = std::numeric_limits<double>::epsilon() * 100.0;
+      ASSERT(max(magnitude(result)) - eps <= outer_radius_.value(),
              "Coordinates translated outside outer radius, This should not "
              "happen");
     }

--- a/src/Domain/Creators/Sphere.cpp
+++ b/src/Domain/Creators/Sphere.cpp
@@ -267,11 +267,23 @@ Sphere::Sphere(
       // Build the maps. We only apply the maps in the inner-most shell. The
       // inner radius is what's passed in, but the outer radius is the outer
       // radius of the inner-most shell so we have to see how many shells we
-      // have
+      // have.
+      // The translation map linear transition occurs only in the outer-most
+      // shell, such that the outer boundary is not translated. Require at least
+      // one radial partition, as the transition requires spherical shape.
+
+      if (radial_partitioning_.empty()) {
+        PARSE_ERROR(context,
+                    "The hard-coded translation map requires at least two "
+                    "shells. Use at least one radial partition.");
+      }
+
       std::get<sphere::TimeDependentMapOptions>(time_dependent_options_.value())
           .build_maps(std::array{0.0, 0.0, 0.0}, inner_radius_,
-                      radial_partitioning_.empty() ? outer_radius_
-                                                   : radial_partitioning_[0]);
+                      radial_partitioning_[0],
+                      // Translation inner radius
+                      std::pair<double, double>{radial_partitioning_.back(),
+                                                outer_radius_});
     }
   }
 }
@@ -374,9 +386,14 @@ Domain<3> Sphere::create_domain() const {
               time_dependent_options_.value());
 
       // First shell gets the distorted maps.
+      // Last shell gets translation with transition region
       for (size_t block_id = 0; block_id < num_blocks_; block_id++) {
         const bool include_distorted_map_in_first_shell =
             block_id < num_blocks_per_shell_;
+        // False if block_id is in the last shell
+        const bool use_rigid_translation =
+            block_id + num_blocks_per_shell_ + (fill_interior_ ? 1 : 0) <
+            num_blocks_;
         block_maps_grid_to_distorted[block_id] =
             hard_coded_options.grid_to_distorted_map(
                 include_distorted_map_in_first_shell);
@@ -385,7 +402,7 @@ Domain<3> Sphere::create_domain() const {
                 include_distorted_map_in_first_shell);
         block_maps_grid_to_inertial[block_id] =
             hard_coded_options.grid_to_inertial_map(
-                include_distorted_map_in_first_shell);
+                include_distorted_map_in_first_shell, use_rigid_translation);
       }
     } else {
       const auto& time_dependence = std::get<std::unique_ptr<

--- a/src/Domain/Creators/SphereTimeDependentMaps.cpp
+++ b/src/Domain/Creators/SphereTimeDependentMaps.cpp
@@ -26,11 +26,14 @@
 #include "Utilities/ErrorHandling/Error.hpp"
 
 namespace domain::creators::sphere {
+
 TimeDependentMapOptions::TimeDependentMapOptions(
-    const double initial_time, const ShapeMapOptions& shape_map_options)
+    const double initial_time, const ShapeMapOptions& shape_map_options,
+    const TranslationMapOptions& translation_map_options)
     : initial_time_(initial_time),
       initial_l_max_(shape_map_options.l_max),
-      initial_shape_values_(shape_map_options.initial_values) {}
+      initial_shape_values_(shape_map_options.initial_values),
+      initial_translation_values_(translation_map_options.initial_values) {}
 
 std::unordered_map<std::string,
                    std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
@@ -46,7 +49,8 @@ TimeDependentMapOptions::create_functions_of_time(
   // their initial expiration time to infinity (i.e. not expiring)
   std::unordered_map<std::string, double> expiration_times{
       {size_name, std::numeric_limits<double>::infinity()},
-      {shape_name, std::numeric_limits<double>::infinity()}};
+      {shape_name, std::numeric_limits<double>::infinity()},
+      {translation_name, std::numeric_limits<double>::infinity()}};
 
   // If we have control systems, overwrite these expiration times with the ones
   // supplied by the control system
@@ -101,12 +105,32 @@ TimeDependentMapOptions::create_functions_of_time(
                                  {0.0}}},
       expiration_times.at(size_name));
 
+  DataVector initial_translation_center_temp{3, 0.0};
+  DataVector initial_translation_velocity_temp{3, 0.0};
+  for (size_t i = 0; i < 3; i++) {
+    initial_translation_center_temp[i] =
+        gsl::at(initial_translation_values_.front(), i);
+    initial_translation_velocity_temp[i] =
+        gsl::at(initial_translation_values_.back(), i);
+  }
+
+  // TranslationMap FunctionOfTime
+  result[translation_name] =
+      std::make_unique<FunctionsOfTime::PiecewisePolynomial<2>>(
+          initial_time_,
+          std::array<DataVector, 3>{
+              {std::move(initial_translation_center_temp),
+               std::move(initial_translation_velocity_temp),
+               {3, 0.0}}},
+          expiration_times.at(translation_name));
+
   return result;
 }
 
-void TimeDependentMapOptions::build_maps(const std::array<double, 3>& center,
-                                         const double inner_radius,
-                                         const double outer_radius) {
+void TimeDependentMapOptions::build_maps(
+    const std::array<double, 3>& center, const double inner_radius,
+    const double outer_radius,
+    std::pair<double, double> translation_transition_radii) {
   std::unique_ptr<domain::CoordinateMaps::ShapeMapTransitionFunctions::
                       ShapeMapTransitionFunction>
       transition_func =
@@ -115,17 +139,22 @@ void TimeDependentMapOptions::build_maps(const std::array<double, 3>& center,
   shape_map_ = ShapeMap{center,         initial_l_max_,
                         initial_l_max_, std::move(transition_func),
                         shape_name,     size_name};
+
+  rigid_translation_map_ = TranslationMap{translation_name};
+
+  linear_falloff_translation_map_ =
+      TranslationMap{translation_name, translation_transition_radii.first,
+                     translation_transition_radii.second};
 }
 
 // If you edit any of the functions below, be sure to update the documentation
 // in the Sphere domain creator as well as this class' documentation.
 TimeDependentMapOptions::MapType<Frame::Distorted, Frame::Inertial>
 TimeDependentMapOptions::distorted_to_inertial_map(
-    const bool include_distorted_map) {
+    const bool include_distorted_map) const {
   if (include_distorted_map) {
-    return std::make_unique<
-        IdentityForComposition<Frame::Distorted, Frame::Inertial>>(
-        IdentityMap{});
+    return std::make_unique<DistortedToInertialComposition>(
+        rigid_translation_map_);
   } else {
     return nullptr;
   }
@@ -143,12 +172,15 @@ TimeDependentMapOptions::grid_to_distorted_map(
 
 TimeDependentMapOptions::MapType<Frame::Grid, Frame::Inertial>
 TimeDependentMapOptions::grid_to_inertial_map(
-    const bool include_distorted_map) const {
+    const bool include_distorted_map, const bool use_rigid_translation) const {
   if (include_distorted_map) {
-    return std::make_unique<GridToInertialComposition>(shape_map_);
+    return std::make_unique<GridToInertialComposition>(shape_map_,
+                                                       rigid_translation_map_);
+  } else if (use_rigid_translation) {
+    return std::make_unique<GridToInertialSimple>(rigid_translation_map_);
   } else {
-    return std::make_unique<
-        IdentityForComposition<Frame::Grid, Frame::Inertial>>(IdentityMap{});
+    return std::make_unique<GridToInertialSimple>(
+        linear_falloff_translation_map_);
   }
 }
 }  // namespace domain::creators::sphere

--- a/src/Domain/Creators/SphereTimeDependentMaps.hpp
+++ b/src/Domain/Creators/SphereTimeDependentMaps.hpp
@@ -14,6 +14,7 @@
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/Identity.hpp"
 #include "Domain/CoordinateMaps/TimeDependent/Shape.hpp"
+#include "Domain/CoordinateMaps/TimeDependent/Translation.hpp"
 #include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
 #include "Options/Auto.hpp"
 #include "Options/String.hpp"
@@ -81,6 +82,7 @@ struct TimeDependentMapOptions {
   using IdentityMap = domain::CoordinateMaps::Identity<3>;
   // Time-dependent maps
   using ShapeMap = domain::CoordinateMaps::TimeDependent::Shape;
+  using TranslationMap = domain::CoordinateMaps::TimeDependent::Translation<3>;
 
   template <typename SourceFrame, typename TargetFrame>
   using IdentityForComposition =
@@ -88,14 +90,20 @@ struct TimeDependentMapOptions {
   using GridToDistortedComposition =
       domain::CoordinateMap<Frame::Grid, Frame::Distorted, ShapeMap>;
   using GridToInertialComposition =
-      domain::CoordinateMap<Frame::Grid, Frame::Inertial, ShapeMap>;
+      domain::CoordinateMap<Frame::Grid, Frame::Inertial, ShapeMap,
+                            TranslationMap>;
+  using GridToInertialSimple =
+      domain::CoordinateMap<Frame::Grid, Frame::Inertial, TranslationMap>;
+  using DistortedToInertialComposition =
+      domain::CoordinateMap<Frame::Distorted, Frame::Inertial, TranslationMap>;
 
  public:
   using maps_list =
       tmpl::list<IdentityForComposition<Frame::Grid, Frame::Inertial>,
                  IdentityForComposition<Frame::Grid, Frame::Distorted>,
                  IdentityForComposition<Frame::Distorted, Frame::Inertial>,
-                 GridToDistortedComposition, GridToInertialComposition>;
+                 GridToDistortedComposition, GridToInertialSimple,
+                 GridToInertialComposition, DistortedToInertialComposition>;
 
   /// \brief The initial time of the functions of time.
   struct InitialTime {
@@ -131,7 +139,26 @@ struct TimeDependentMapOptions {
     std::optional<std::variant<KerrSchildFromBoyerLindquist>> initial_values{};
   };
 
-  using options = tmpl::list<InitialTime, ShapeMapOptions>;
+  struct TranslationMapOptions {
+    using type = TranslationMapOptions;
+    static std::string name() { return "TranslationMap"; }
+    static constexpr Options::String help = {
+        "Options for a time-dependent translation map in that keeps the outer "
+        "boundary fixed."};
+
+    struct InitialValues {
+      using type = std::array<std::array<double, 3>, 2>;
+      static constexpr Options::String help = {
+          "Initial values for the translation map."};
+    };
+
+    using options = tmpl::list<InitialValues>;
+
+    std::array<std::array<double, 3>, 2> initial_values{};
+  };
+
+  using options =
+      tmpl::list<InitialTime, ShapeMapOptions, TranslationMapOptions>;
   static constexpr Options::String help{
       "The options for all the hard-coded time dependent maps in the Sphere "
       "domain."};
@@ -139,7 +166,8 @@ struct TimeDependentMapOptions {
   TimeDependentMapOptions() = default;
 
   TimeDependentMapOptions(double initial_time,
-                          const ShapeMapOptions& shape_map_options);
+                          const ShapeMapOptions& shape_map_options,
+                          const TranslationMapOptions& translation_map_options);
 
   /*!
    * \brief Create the function of time map using the options that were
@@ -149,6 +177,7 @@ struct TimeDependentMapOptions {
    *
    * - Size: `PiecewisePolynomial<3>`
    * - Shape: `PiecewisePolynomial<2>`
+   * - Translation: `PiecewisePolynomial<2>`
    */
   std::unordered_map<std::string,
                      std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
@@ -162,19 +191,22 @@ struct TimeDependentMapOptions {
    * Currently, this constructs a:
    *
    * - Shape: `Shape` (with a size function of time)
+   * - Translation: `Translation`
    */
-  void build_maps(const std::array<double, 3>& center, double inner_radius,
-                  double outer_radius);
+  void build_maps(
+      const std::array<double, 3>& center, double inner_radius,
+      double outer_radius,
+      std::pair<double, double> translation_transition_radii);
 
   /*!
    * \brief This will construct the map from `Frame::Distorted` to
    * `Frame::Inertial`.
    *
-   * If the argument `include_distorted_map` is true, then this will be an
-   * identity map. If it is false, then this returns `nullptr`.
+   * If the argument `include_distorted_map` is true, then this will be a
+   * translation map. If it is false, then this returns `nullptr`.
    */
-  static MapType<Frame::Distorted, Frame::Inertial> distorted_to_inertial_map(
-      bool include_distorted_map);
+  MapType<Frame::Distorted, Frame::Inertial> distorted_to_inertial_map(
+      bool include_distorted_map) const;
 
   /*!
    * \brief This will construct the map from `Frame::Grid` to
@@ -195,16 +227,20 @@ struct TimeDependentMapOptions {
    * only be an identity map.
    */
   MapType<Frame::Grid, Frame::Inertial> grid_to_inertial_map(
-      bool include_distorted_map) const;
+      bool include_distorted_map, bool use_rigid_translation) const;
 
   inline static const std::string size_name{"Size"};
   inline static const std::string shape_name{"Shape"};
+  inline static const std::string translation_name{"Translation"};
 
  private:
   double initial_time_{std::numeric_limits<double>::signaling_NaN()};
   size_t initial_l_max_{};
   ShapeMap shape_map_{};
+  TranslationMap rigid_translation_map_{};
+  TranslationMap linear_falloff_translation_map_{};
   std::optional<std::variant<KerrSchildFromBoyerLindquist>>
       initial_shape_values_{};
+  std::array<std::array<double, 3>, 2> initial_translation_values_{};
 };
 }  // namespace domain::creators::sphere

--- a/tests/InputFiles/Xcts/KerrSchild.yaml
+++ b/tests/InputFiles/Xcts/KerrSchild.yaml
@@ -26,7 +26,7 @@ Background: &solution
   KerrSchild:
     Mass: &KerrMass 1.
     Spin: &KerrSpin [0., 0., 0.6]
-    Center: [0., 0., 0.]
+    Center: &Center [0., 0., 0.]
 
 InitialGuess: Flatness
 
@@ -44,12 +44,12 @@ DomainCreator:
           LapseTimesConformalFactor: Dirichlet
           ShiftExcess: Dirichlet
     InitialRefinement: 0
-    InitialGridPoints: 4
+    InitialGridPoints: 3
     UseEquiangularMap: True
     EquatorialCompression: None
     WhichWedges: All
-    RadialPartitioning: []
-    RadialDistribution: [Logarithmic]
+    RadialPartitioning: [3.0]
+    RadialDistribution: [Linear, Logarithmic]
     TimeDependentMaps:
       InitialTime: 0.
       ShapeMap:
@@ -57,6 +57,8 @@ DomainCreator:
         InitialValues:
           Mass: *KerrMass
           Spin: *KerrSpin
+      TranslationMap:
+        InitialValues: [*Center, [0., 0., 0.]]
     OuterBoundaryCondition:
       AnalyticSolution:
         Solution: *solution

--- a/tests/InputFiles/Xcts/KerrSchild.yaml
+++ b/tests/InputFiles/Xcts/KerrSchild.yaml
@@ -4,7 +4,7 @@
 Executable: SolveXcts
 Testing:
   Check: parse;execute_check_output
-  Timeout: 40
+  Timeout: 50
   Priority: High
 ExpectedOutput:
   - KerrSchildReductions.h5
@@ -44,7 +44,7 @@ DomainCreator:
           LapseTimesConformalFactor: Dirichlet
           ShiftExcess: Dirichlet
     InitialRefinement: 0
-    InitialGridPoints: 3
+    InitialGridPoints: 4
     UseEquiangularMap: True
     EquatorialCompression: None
     WhichWedges: All

--- a/tests/Unit/Domain/Creators/Test_SphereTimeDependentMaps.cpp
+++ b/tests/Unit/Domain/Creators/Test_SphereTimeDependentMaps.cpp
@@ -34,25 +34,29 @@ std::string create_option_string(const bool use_non_zero_shape) {
          (use_non_zero_shape ? "  InitialValues:\n"
                                "    Mass: 1.0\n"
                                "    Spin: [0.0, 0.0, 0.0]\n"s
-                             : "  InitialValues: Spherical\n"s);
+                             : "  InitialValues: Spherical\n"s) +
+         "TranslationMap:\n"
+         "  InitialValues: [[0.1, -3.2, 1.1], [-0.3, 0.5, -0.7]]\n"s;
 }
 void test(const bool use_non_zero_shape) {
   CAPTURE(use_non_zero_shape);
   const double initial_time = 1.5;
   const size_t l_max = 8;
 
-  TimeDependentMapOptions time_dep_options =
-      TestHelpers::test_creation<TimeDependentMapOptions>(
-          create_option_string(use_non_zero_shape));
+  auto time_dep_options = TestHelpers::test_creation<TimeDependentMapOptions>(
+      create_option_string(use_non_zero_shape));
 
   std::unordered_map<std::string, double> expiration_times{
       {TimeDependentMapOptions::shape_name, 15.5},
       {TimeDependentMapOptions::size_name,
+       std::numeric_limits<double>::infinity()},
+      {TimeDependentMapOptions::translation_name,
        std::numeric_limits<double>::infinity()}};
 
   // These are hard-coded so this is just a regression test
   CHECK(TimeDependentMapOptions::size_name == "Size"s);
   CHECK(TimeDependentMapOptions::shape_name == "Shape"s);
+  CHECK(TimeDependentMapOptions::translation_name == "Translation"s);
 
   using PP2 = domain::FunctionsOfTime::PiecewisePolynomial<2>;
   using PP3 = domain::FunctionsOfTime::PiecewisePolynomial<3>;
@@ -70,9 +74,19 @@ void test(const bool use_non_zero_shape) {
       std::array<DataVector, 3>{shape_zeros, shape_zeros, shape_zeros},
       expiration_times.at(TimeDependentMapOptions::shape_name)};
 
+  DataVector initial_translation_center{{0.1, -3.2, 1.1}};
+  DataVector initial_velocity{{-0.3, 0.5, -0.7}};
+  PP2 translation_non_zero{
+      initial_time,
+      std::array<DataVector, 3>{
+          {initial_translation_center, initial_velocity, {3, 0.0}}},
+      expiration_times.at(TimeDependentMapOptions::translation_name)};
+
   const std::array<double, 3> center{-5.0, -0.01, -0.02};
   const double inner_radius = 0.5;
   const double outer_radius = 2.1;
+  const double translation_inner_radius = 3.1;
+  const double translation_outer_radius = 3.9;
 
   const auto functions_of_time =
       time_dep_options.create_functions_of_time(inner_radius, expiration_times);
@@ -86,35 +100,48 @@ void test(const bool use_non_zero_shape) {
             *functions_of_time.at(TimeDependentMapOptions::shape_name).get()) ==
         shape_all_zero);
 
+  CHECK(dynamic_cast<PP2&>(
+            *functions_of_time.at(TimeDependentMapOptions::translation_name)
+                 .get()) == translation_non_zero);
+
   for (const bool include_distorted : make_array(true, false)) {
-    time_dep_options.build_maps(center, inner_radius, outer_radius);
+    for (const bool use_rigid_translation : make_array(true, false)) {
+      time_dep_options.build_maps(
+          center, inner_radius, outer_radius,
+          std::pair<double, double>{translation_inner_radius,
+                                    translation_outer_radius});
 
-    const auto grid_to_distorted_map =
-        time_dep_options.grid_to_distorted_map(include_distorted);
-    const auto grid_to_inertial_map =
-        time_dep_options.grid_to_inertial_map(include_distorted);
-    const auto distorted_to_inertial_map =
-        time_dep_options.distorted_to_inertial_map(include_distorted);
+      const auto grid_to_distorted_map =
+          time_dep_options.grid_to_distorted_map(include_distorted);
+      const auto grid_to_inertial_map = time_dep_options.grid_to_inertial_map(
+          include_distorted, use_rigid_translation);
+      const auto distorted_to_inertial_map =
+          time_dep_options.distorted_to_inertial_map(include_distorted);
 
-    // All of these maps are tested individually. Rather than going through the
-    // effort of coming up with a source coordinate and calculating analytically
-    // what we would get after it's mapped, we just check that whether it's
-    // supposed to be a nullptr and if it's not, if it's the identity and that
-    // the jacobians are time dependent.
-    const auto check_map = [](const auto& map, const bool is_null,
-                              const bool is_identity) {
-      if (is_null) {
-        CHECK(map == nullptr);
-      } else {
-        CHECK(map->is_identity() == is_identity);
-        CHECK(map->inv_jacobian_is_time_dependent() == not is_identity);
-        CHECK(map->jacobian_is_time_dependent() == not is_identity);
-      }
-    };
+      // All of these maps are tested individually. Rather than going through
+      // the effort of coming up with a source coordinate and calculating
+      // analytically what we would get after it's mapped, we just check that
+      // whether it's supposed to be a nullptr and if it's not, if it's the
+      // identity and that the jacobians are time dependent.
+      const auto check_map = [](const auto& map, const bool is_null,
+                                const bool is_identity) {
+        if (is_null) {
+          CHECK(map == nullptr);
+        } else {
+          CHECK(map->is_identity() == is_identity);
+          CHECK(map->inv_jacobian_is_time_dependent() == not is_identity);
+          CHECK(map->jacobian_is_time_dependent() == not is_identity);
+        }
+      };
 
-    check_map(grid_to_inertial_map, false, not include_distorted);
-    check_map(grid_to_distorted_map, not include_distorted, false);
-    check_map(distorted_to_inertial_map, not include_distorted, true);
+      // There is no null pointer in the grid to inertial map
+      check_map(grid_to_inertial_map, false, false);
+
+      check_map(grid_to_distorted_map, not include_distorted, false);
+
+      // If no shape distortion, there is only the translation
+      check_map(distorted_to_inertial_map, not include_distorted, false);
+    }
   }
 }
 

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_ComputeDestVars.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_ComputeDestVars.cpp
@@ -108,11 +108,18 @@ void test() {
   domain::FunctionsOfTime::register_derived_with_charm();
 
   using TDMO = domain::creators::sphere::TimeDependentMapOptions;
-  TDMO time_dep_opts{0.0, TDMO::ShapeMapOptions{2, std::nullopt}};
+  TDMO time_dep_opts{
+      0.0, TDMO::ShapeMapOptions{2, std::nullopt},
+      TDMO::TranslationMapOptions{std::array<double, 3>{0.0, 0.0, 0.0},
+                                  std::array<double, 3>{0.0, 0.0, 0.0}}};
 
   const auto domain_creator = domain::creators::Sphere(
-      0.9, 4.9, domain::creators::Sphere::Excision{}, 1_st, 7_st, false, {}, {},
-      {}, {}, time_dep_opts);
+      0.9, 4.9, domain::creators::Sphere::Excision{}, 1_st, 7_st, false, {},
+      std::vector<double>{2.0},
+      std::vector<domain::CoordinateMaps::Distribution>{
+          {domain::CoordinateMaps::Distribution::Linear,
+           domain::CoordinateMaps::Distribution::Linear}},
+      {}, time_dep_opts);
   const Domain<3> domain = domain_creator.create_domain();
 
   Parallel::GlobalCache<Metavars> cache{{domain_creator.functions_of_time()}};


### PR DESCRIPTION
## Proposed changes

Add a translation map acting on the outer most shell of the spherical domain. If there is no radial partition, apply a uniform translation (since the inner boundary of the translation needs to be spherical and the shape map could also be active).

Note: The test `Unit.Domain.Creators.Sphere` failed because of roundoff error in assets 

`ASSERT(max(magnitude(result)) <= outer_radius_.value(),
             "Coordinates translated outside outer radius, This should not "
             "happen");`

 in https://github.com/sxs-collaboration/spectre/blob/06b239527bec8f6e2bfb6464ec881a98adf2af2b/src/Domain/CoordinateMaps/TimeDependent/Translation.cpp#L376

When I printed the values during a test, the assert failed by a factor of order 10e-15 of the `outer_radius_` and seemed to remain of the same order in time. Changed the assert to allow for roundoff error.

Update: issue above fixed in #5601

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
