### PR TITLE
Fix boundary condition bugs for temperature reconstruction

### DIFF
--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/BoundaryConditions/DirichletFreeOutflow.hpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/BoundaryConditions/DirichletFreeOutflow.hpp
@@ -221,6 +221,7 @@ class DirichletFreeOutflow final : public BoundaryCondition {
   using fd_interior_primitive_variables_tags =
       tmpl::list<hydro::Tags::RestMassDensity<DataVector>,
                  hydro::Tags::ElectronFraction<DataVector>,
+                 hydro::Tags::Temperature<DataVector>,
                  hydro::Tags::Pressure<DataVector>,
                  hydro::Tags::SpecificInternalEnergy<DataVector>,
                  hydro::Tags::LorentzFactor<DataVector>,
@@ -241,7 +242,7 @@ class DirichletFreeOutflow final : public BoundaryCondition {
       const gsl::not_null<tnsr::iaa<DataVector, 3, Frame::Inertial>*> phi,
       const gsl::not_null<Scalar<DataVector>*> rest_mass_density,
       const gsl::not_null<Scalar<DataVector>*> electron_fraction,
-      const gsl::not_null<Scalar<DataVector>*> pressure,
+      const gsl::not_null<Scalar<DataVector>*> temperature,
       const gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*>
           lorentz_factor_times_spatial_velocity,
       const gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*>
@@ -255,6 +256,7 @@ class DirichletFreeOutflow final : public BoundaryCondition {
       // interior prim vars tags
       const Scalar<DataVector>& interior_rest_mass_density,
       const Scalar<DataVector>& interior_electron_fraction,
+      const Scalar<DataVector>& interior_temperature,
       const Scalar<DataVector>& interior_pressure,
       const Scalar<DataVector>& interior_specific_internal_energy,
       const Scalar<DataVector>& interior_lorentz_factor,
@@ -312,6 +314,7 @@ class DirichletFreeOutflow final : public BoundaryCondition {
         Flux, typename grmhd::ValenciaDivClean::System::flux_variables>>>
         cell_centered_ghost_fluxes{std::nullopt};
     // Set to zero since it shouldn't be used
+    Scalar<DataVector> pressure{};
     Scalar<DataVector> specific_internal_energy{};
     tnsr::I<DataVector, 3> spatial_velocity{};
     Scalar<DataVector> lorentz_factor{};
@@ -326,8 +329,8 @@ class DirichletFreeOutflow final : public BoundaryCondition {
 
     grmhd::ValenciaDivClean::BoundaryConditions::HydroFreeOutflow::
         fd_ghost_impl(
-            rest_mass_density, electron_fraction, pressure,
-            make_not_null(&specific_internal_energy),
+            rest_mass_density, electron_fraction, temperature,
+            make_not_null(&pressure), make_not_null(&specific_internal_energy),
             lorentz_factor_times_spatial_velocity,
             make_not_null(&spatial_velocity), make_not_null(&lorentz_factor),
             magnetic_field, divergence_cleaning_field,
@@ -343,9 +346,9 @@ class DirichletFreeOutflow final : public BoundaryCondition {
 
             // fd_interior_primitive_variables_tags
             interior_rest_mass_density, interior_electron_fraction,
-            interior_pressure, interior_specific_internal_energy,
-            interior_lorentz_factor, interior_spatial_velocity,
-            interior_magnetic_field,
+            interior_temperature, interior_pressure,
+            interior_specific_internal_energy, interior_lorentz_factor,
+            interior_spatial_velocity, interior_magnetic_field,
             // Note: metric vars are empty because they shouldn't be used
             interior_spatial_metric, interior_lapse, interior_shift,
 

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryConditions/HydroFreeOutflow.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryConditions/HydroFreeOutflow.hpp
@@ -20,6 +20,7 @@
 #include "Options/String.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
 #include "PointwiseFunctions/Hydro/Tags.hpp"
+#include "PointwiseFunctions/Hydro/Temperature.hpp"
 #include "Utilities/TMPL.hpp"
 
 /// \cond
@@ -62,6 +63,7 @@ class HydroFreeOutflow final : public BoundaryCondition {
  private:
   using RestMassDensity = hydro::Tags::RestMassDensity<DataVector>;
   using ElectronFraction = hydro::Tags::ElectronFraction<DataVector>;
+  using Temperature = hydro::Tags::Temperature<DataVector>;
   using Pressure = hydro::Tags::Pressure<DataVector>;
   using LorentzFactorTimesSpatialVelocity =
       hydro::Tags::LorentzFactorTimesSpatialVelocity<DataVector, 3>;
@@ -79,7 +81,7 @@ class HydroFreeOutflow final : public BoundaryCondition {
   using Shift = gr::Tags::Shift<DataVector, 3>;
 
   using prim_tags_for_reconstruction =
-      tmpl::list<RestMassDensity, ElectronFraction, Pressure,
+      tmpl::list<RestMassDensity, ElectronFraction, Temperature,
                  LorentzFactorTimesSpatialVelocity, MagneticField,
                  DivergenceCleaningField>;
 
@@ -175,16 +177,18 @@ class HydroFreeOutflow final : public BoundaryCondition {
       tmpl::list<evolution::dg::subcell::Tags::Mesh<3>, Shift, Lapse,
                  SpatialMetric>;
   using fd_interior_primitive_variables_tags =
-      tmpl::list<RestMassDensity, ElectronFraction, Pressure,
+      tmpl::list<RestMassDensity, ElectronFraction, Temperature,
+                 hydro::Tags::Pressure<DataVector>,
                  hydro::Tags::SpecificInternalEnergy<DataVector>,
                  hydro::Tags::LorentzFactor<DataVector>,
                  hydro::Tags::SpatialVelocity<DataVector, 3>, MagneticField>;
+
   using fd_gridless_tags = tmpl::list<fd::Tags::Reconstructor>;
 
   static void fd_ghost(
       gsl::not_null<Scalar<DataVector>*> rest_mass_density,
       gsl::not_null<Scalar<DataVector>*> electron_fraction,
-      gsl::not_null<Scalar<DataVector>*> pressure,
+      gsl::not_null<Scalar<DataVector>*> temperature,
       gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*>
           lorentz_factor_times_spatial_velocity,
       gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> magnetic_field,
@@ -205,6 +209,7 @@ class HydroFreeOutflow final : public BoundaryCondition {
       // interior prim vars tags
       const Scalar<DataVector>& interior_rest_mass_density,
       const Scalar<DataVector>& interior_electron_fraction,
+      const Scalar<DataVector>& interior_temperature,
       const Scalar<DataVector>& interior_pressure,
       const Scalar<DataVector>& interior_specific_internal_energy,
       const Scalar<DataVector>& interior_lorentz_factor,
@@ -218,6 +223,7 @@ class HydroFreeOutflow final : public BoundaryCondition {
   static void fd_ghost_impl(
       gsl::not_null<Scalar<DataVector>*> rest_mass_density,
       gsl::not_null<Scalar<DataVector>*> electron_fraction,
+      gsl::not_null<Scalar<DataVector>*> temperature,
       gsl::not_null<Scalar<DataVector>*> pressure,
       gsl::not_null<Scalar<DataVector>*> specific_internal_energy,
       gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*>
@@ -241,6 +247,7 @@ class HydroFreeOutflow final : public BoundaryCondition {
       // fd_interior_primitive_variables_tags
       const Scalar<DataVector>& interior_rest_mass_density,
       const Scalar<DataVector>& interior_electron_fraction,
+      const Scalar<DataVector>& interior_temperature,
       const Scalar<DataVector>& interior_pressure,
       const Scalar<DataVector>& interior_specific_internal_energy,
       const Scalar<DataVector>& interior_lorentz_factor,

--- a/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/BoundaryConditions/Test_DirichletFreeOutflow.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/BoundaryConditions/Test_DirichletFreeOutflow.cpp
@@ -98,6 +98,7 @@ void test_dg(const gsl::not_null<std::mt19937*> generator,
   using PrimVars =
       Variables<tmpl::list<hydro::Tags::RestMassDensity<DataVector>,
                            hydro::Tags::ElectronFraction<DataVector>,
+                           hydro::Tags::Pressure<DataVector>,
                            hydro::Tags::SpecificInternalEnergy<DataVector>,
                            hydro::Tags::SpecificEnthalpy<DataVector>,
                            hydro::Tags::Temperature<DataVector>,
@@ -122,23 +123,22 @@ void test_dg(const gsl::not_null<std::mt19937*> generator,
 
     PrimVars local_prim_vars{num_points};
 
-    using tags =
-        tmpl::list<hydro::Tags::RestMassDensity<DataVector>,
-                   hydro::Tags::ElectronFraction<DataVector>,
-                   hydro::Tags::SpecificInternalEnergy<DataVector>,
-                   hydro::Tags::SpecificEnthalpy<DataVector>,
-                   hydro::Tags::Temperature<DataVector>,
-                   hydro::Tags::SpatialVelocity<DataVector, 3>,
-                   hydro::Tags::LorentzFactor<DataVector>,
-                   hydro::Tags::MagneticField<DataVector, 3>,
-                   hydro::Tags::DivergenceCleaningField<DataVector>,
-                   gr::Tags::SpatialMetric<DataVector, 3>,
-                   gr::Tags::InverseSpatialMetric<DataVector, 3>,
-                   gr::Tags::SqrtDetSpatialMetric<DataVector>,
-                   gr::Tags::Lapse<DataVector>, gr::Tags::Shift<DataVector, 3>,
-                   gr::Tags::SpacetimeMetric<DataVector, 3>,
-                   ::gh::Tags::Pi<DataVector, 3>,
-                   ::gh::Tags::Phi<DataVector, 3>>;
+    using tags = tmpl::list<
+        hydro::Tags::RestMassDensity<DataVector>,
+        hydro::Tags::ElectronFraction<DataVector>,
+        hydro::Tags::SpecificInternalEnergy<DataVector>,
+        hydro::Tags::SpecificEnthalpy<DataVector>,
+        hydro::Tags::Temperature<DataVector>, hydro::Tags::Pressure<DataVector>,
+        hydro::Tags::SpatialVelocity<DataVector, 3>,
+        hydro::Tags::LorentzFactor<DataVector>,
+        hydro::Tags::MagneticField<DataVector, 3>,
+        hydro::Tags::DivergenceCleaningField<DataVector>,
+        gr::Tags::SpatialMetric<DataVector, 3>,
+        gr::Tags::InverseSpatialMetric<DataVector, 3>,
+        gr::Tags::SqrtDetSpatialMetric<DataVector>, gr::Tags::Lapse<DataVector>,
+        gr::Tags::Shift<DataVector, 3>,
+        gr::Tags::SpacetimeMetric<DataVector, 3>, ::gh::Tags::Pi<DataVector, 3>,
+        ::gh::Tags::Phi<DataVector, 3>>;
 
     tuples::tagged_tuple_from_typelist<tags> analytic_vars{};
 
@@ -165,7 +165,7 @@ void test_dg(const gsl::not_null<std::mt19937*> generator,
         get<hydro::Tags::RestMassDensity<DataVector>>(analytic_vars),
         get<hydro::Tags::ElectronFraction<DataVector>>(analytic_vars),
         get<hydro::Tags::SpecificInternalEnergy<DataVector>>(analytic_vars),
-        get<hydro::Tags::Temperature<DataVector>>(analytic_vars),
+        get<hydro::Tags::Pressure<DataVector>>(analytic_vars),
         get<hydro::Tags::SpatialVelocity<DataVector, 3>>(analytic_vars),
         get<hydro::Tags::LorentzFactor<DataVector>>(analytic_vars),
         get<hydro::Tags::MagneticField<DataVector, 3>>(analytic_vars),
@@ -181,7 +181,7 @@ void test_dg(const gsl::not_null<std::mt19937*> generator,
         get<gr::Tags::SqrtDetSpatialMetric<DataVector>>(analytic_vars),
         get<gr::Tags::SpatialMetric<DataVector, 3>>(analytic_vars),
         get<gr::Tags::InverseSpatialMetric<DataVector, 3>>(analytic_vars),
-        get<hydro::Tags::Temperature<DataVector>>(analytic_vars),
+        get<hydro::Tags::Pressure<DataVector>>(analytic_vars),
         get<hydro::Tags::SpatialVelocity<DataVector, 3>>(analytic_vars),
         get<hydro::Tags::LorentzFactor<DataVector>>(analytic_vars),
         get<hydro::Tags::MagneticField<DataVector, 3>>(analytic_vars));
@@ -321,6 +321,7 @@ void test_fd(const U& boundary_condition, const T& analytic_solution_or_data) {
   using PrimVars =
       Variables<tmpl::list<hydro::Tags::RestMassDensity<DataVector>,
                            hydro::Tags::ElectronFraction<DataVector>,
+                           hydro::Tags::Pressure<DataVector>,
                            hydro::Tags::SpecificInternalEnergy<DataVector>,
                            hydro::Tags::SpecificEnthalpy<DataVector>,
                            hydro::Tags::Temperature<DataVector>,
@@ -355,16 +356,16 @@ void test_fd(const U& boundary_condition, const T& analytic_solution_or_data) {
     const auto ghost_inertial_coords = grid_to_inertial_map(
         logical_to_grid_map(ghost_logical_coords), time, functions_of_time);
 
-    using tags = tmpl::list<hydro::Tags::RestMassDensity<DataVector>,
-                            hydro::Tags::ElectronFraction<DataVector>,
-                            hydro::Tags::Temperature<DataVector>,
-                            hydro::Tags::SpatialVelocity<DataVector, 3>,
-                            hydro::Tags::LorentzFactor<DataVector>,
-                            hydro::Tags::MagneticField<DataVector, 3>,
-                            hydro::Tags::DivergenceCleaningField<DataVector>,
-                            gr::Tags::SpacetimeMetric<DataVector, 3>,
-                            ::gh::Tags::Pi<DataVector, 3>,
-                            ::gh::Tags::Phi<DataVector, 3>>;
+    using tags = tmpl::list<
+        hydro::Tags::RestMassDensity<DataVector>,
+        hydro::Tags::ElectronFraction<DataVector>,
+        hydro::Tags::Temperature<DataVector>, hydro::Tags::Pressure<DataVector>,
+        hydro::Tags::SpatialVelocity<DataVector, 3>,
+        hydro::Tags::LorentzFactor<DataVector>,
+        hydro::Tags::MagneticField<DataVector, 3>,
+        hydro::Tags::DivergenceCleaningField<DataVector>,
+        gr::Tags::SpacetimeMetric<DataVector, 3>, ::gh::Tags::Pi<DataVector, 3>,
+        ::gh::Tags::Phi<DataVector, 3>>;
 
     tuples::tagged_tuple_from_typelist<tags> analytic_vars{};
 
@@ -420,6 +421,7 @@ void test_fd(const U& boundary_condition, const T& analytic_solution_or_data) {
   // Set to zero since it shouldn't be used
   Scalar<DataVector> interior_specific_internal_energy{};
   Scalar<DataVector> specific_internal_energy{};
+  Scalar<DataVector> pressure{};
   tnsr::I<DataVector, 3> spatial_velocity{};
   Scalar<DataVector> lorentz_factor{};
   const tnsr::I<DataVector, 3> interior_shift{};
@@ -443,6 +445,7 @@ void test_fd(const U& boundary_condition, const T& analytic_solution_or_data) {
       get<hydro::Tags::RestMassDensity<DataVector>>(prim_vars),
       get<hydro::Tags::ElectronFraction<DataVector>>(prim_vars),
       get<hydro::Tags::Temperature<DataVector>>(prim_vars),
+      get<hydro::Tags::Pressure<DataVector>>(prim_vars),
       interior_specific_internal_energy,
       get<hydro::Tags::LorentzFactor<DataVector>>(prim_vars),
       get<hydro::Tags::SpatialVelocity<DataVector, 3>>(prim_vars),
@@ -462,7 +465,7 @@ void test_fd(const U& boundary_condition, const T& analytic_solution_or_data) {
   grmhd_free_outflow.fd_ghost_impl(
       make_not_null(&rest_mass_density_expected),
       make_not_null(&electron_fraction_expected),
-      make_not_null(&temperature_expected),
+      make_not_null(&temperature_expected), make_not_null(&pressure),
       make_not_null(&specific_internal_energy),
       make_not_null(&lorentz_factor_times_spatial_velocity_expected),
       make_not_null(&spatial_velocity), make_not_null(&lorentz_factor),
@@ -478,6 +481,7 @@ void test_fd(const U& boundary_condition, const T& analytic_solution_or_data) {
       get<hydro::Tags::RestMassDensity<DataVector>>(prim_vars),
       get<hydro::Tags::ElectronFraction<DataVector>>(prim_vars),
       get<hydro::Tags::Temperature<DataVector>>(prim_vars),
+      get<hydro::Tags::Pressure<DataVector>>(prim_vars),
       interior_specific_internal_energy,
       get<hydro::Tags::LorentzFactor<DataVector>>(prim_vars),
       get<hydro::Tags::SpatialVelocity<DataVector, 3>>(prim_vars),

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/Test_BoundaryConditionGhostData.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/Test_BoundaryConditionGhostData.cpp
@@ -190,7 +190,8 @@ void test(const BoundaryConditionType& boundary_condition,
   get(get<ElectronFraction>(volume_prim_vars)) = 0.1;
   get(get<Pressure>(volume_prim_vars)) = 1.0;
   get(get<LorentzFactor>(volume_prim_vars)) = 2.0;
-  get(get<SpecificInternalEnergy>(volume_prim_vars)) = 0.3;
+  // This quantity is fixed by the equation of state given P and rho
+  get(get<SpecificInternalEnergy>(volume_prim_vars)) = 1.0 / (1.4 - 1.0);
   get<Temperature>(volume_prim_vars) =
       solution.equation_of_state().temperature_from_density_and_energy(
           get<RestMassDensity>(volume_prim_vars),


### PR DESCRIPTION
## Proposed changes

There are a few places were temperature needs to be exchanged with pressure, (and vice versa) left over from moving from temperature to pressure reconstruction.  This PR changes them for `HydroFreeOutflow` and the related `DirichletFreeOutflow` boundary conditions

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
