### PR TITLE
Add compute tag for the second time derivative of the spacetime metric.

### DIFF
--- a/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
+++ b/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
@@ -121,6 +121,7 @@
 #include "NumericalAlgorithms/DiscontinuousGalerkin/Tags.hpp"
 #include "NumericalAlgorithms/LinearOperators/ExponentialFilter.hpp"
 #include "NumericalAlgorithms/LinearOperators/FilterAction.hpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
 #include "Options/Protocols/FactoryCreation.hpp"
 #include "Options/String.hpp"
 #include "Parallel/Algorithms/AlgorithmSingleton.hpp"
@@ -191,6 +192,7 @@
 #include "PointwiseFunctions/GeneralRelativity/DetAndInverseSpatialMetric.hpp"
 #include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/ConstraintGammas.hpp"
 #include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/ExtrinsicCurvature.hpp"
+#include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/SecondTimeDerivOfSpacetimeMetric.hpp"
 #include "PointwiseFunctions/GeneralRelativity/IndexManipulation.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Lapse.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Psi4Real.hpp"
@@ -554,12 +556,18 @@ struct GhValenciaDivCleanTemplateBase<
               hydro::Tags::SpatialVelocity<DataVector, volume_dim,
                                            Frame::Inertial>>,
           hydro::Tags::TransportVelocityCompute<DataVector, volume_dim,
-                                                               Frame::Inertial>,
+                                                Frame::Inertial>,
           grmhd::ValenciaDivClean::Tags::QuadrupoleMomentDerivativeCompute<
               DataVector, volume_dim,
               ::Events::Tags::ObserverCoordinates<volume_dim, Frame::Inertial>,
               hydro::Tags::TransportVelocity<DataVector, volume_dim,
                                              Frame::Inertial>>,
+          gh::Tags::TimeDerivLapseCompute<volume_dim, Frame::Inertial>,
+          gh::Tags::TimeDerivShiftCompute<volume_dim, Frame::Inertial>,
+          ::Tags::dt<gh::Tags::Phi<DataVector, volume_dim, Frame::Inertial>>,
+          ::Tags::dt<gh::Tags::Pi<DataVector, volume_dim, Frame::Inertial>>,
+          gh::Tags::SecondTimeDerivOfSpacetimeMetricCompute<
+              volume_dim, Frame::Inertial>,
           ::Tags::DerivTensorCompute<
               gr::Tags::ExtrinsicCurvature<DataVector, 3>,
               ::Events::Tags::ObserverInverseJacobian<

--- a/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/CMakeLists.txt
+++ b/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/CMakeLists.txt
@@ -12,6 +12,7 @@ spectre_target_sources(
   Phi.cpp
   Pi.cpp
   Ricci.cpp
+  SecondTimeDerivOfSpacetimeMetric.cpp
   SpacetimeDerivOfDetSpatialMetric.cpp
   SpacetimeDerivOfNormOfShift.cpp
   SpacetimeDerivativeOfSpacetimeMetric.cpp
@@ -37,6 +38,7 @@ spectre_target_headers(
   Phi.hpp
   Pi.hpp
   Ricci.hpp
+  SecondTimeDerivOfSpacetimeMetric.hpp
   SpacetimeDerivOfDetSpatialMetric.hpp
   SpacetimeDerivOfNormOfShift.hpp
   SpacetimeDerivativeOfSpacetimeMetric.hpp

--- a/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/SecondTimeDerivOfSpacetimeMetric.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/SecondTimeDerivOfSpacetimeMetric.cpp
@@ -1,0 +1,94 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/SecondTimeDerivOfSpacetimeMetric.hpp"
+
+#include <cstddef>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Domain/Tags.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/ContainerHelpers.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+
+// IWYU pragma: no_forward_declare Tensor
+
+namespace gh {
+
+template <typename DataType, size_t SpatialDim, typename Frame>
+void second_time_deriv_of_spacetime_metric(
+    gsl::not_null<tnsr::aa<DataType, SpatialDim, Frame>*> d2t2_spacetime_metric,
+    const Scalar<DataType>& lapse, const Scalar<DataType>& dt_lapse,
+    const tnsr::I<DataType, SpatialDim, Frame>& shift,
+    const tnsr::I<DataType, SpatialDim, Frame>& dt_shift,
+    const tnsr::iaa<DataType, SpatialDim, Frame>& phi,
+    const tnsr::iaa<DataType, SpatialDim, Frame>& dt_phi,
+    const tnsr::aa<DataType, SpatialDim, Frame>& pi,
+    const tnsr::aa<DataType, SpatialDim, Frame>& dt_pi) {
+  if (UNLIKELY(get_size(get<0, 0>(*d2t2_spacetime_metric)) !=
+               get_size(get<0, 0>(pi)))) {
+    *d2t2_spacetime_metric =
+        tnsr::aa<DataType, SpatialDim, Frame>(get_size(get<0, 0>(pi)));
+  }
+  for (size_t a = 0; a < SpatialDim + 1; ++a) {
+    for (size_t b = a; b < SpatialDim + 1; ++b) {
+      d2t2_spacetime_metric->get(a, b) = -get(dt_lapse) * pi.get(a, b);
+      d2t2_spacetime_metric->get(a, b) -= get(lapse) * dt_pi.get(a, b);
+      for (size_t i = 0; i < SpatialDim; ++i) {
+        d2t2_spacetime_metric->get(a, b) += dt_shift.get(i) * phi.get(i, a, b);
+        d2t2_spacetime_metric->get(a, b) += shift.get(i) * dt_phi.get(i, a, b);
+      }
+    }
+  }
+}
+
+template <typename DataType, size_t SpatialDim, typename Frame>
+tnsr::aa<DataType, SpatialDim, Frame> second_time_deriv_of_spacetime_metric(
+    const Scalar<DataType>& lapse, const Scalar<DataType>& dt_lapse,
+    const tnsr::I<DataType, SpatialDim, Frame>& shift,
+    const tnsr::I<DataType, SpatialDim, Frame>& dt_shift,
+    const tnsr::iaa<DataType, SpatialDim, Frame>& phi,
+    const tnsr::iaa<DataType, SpatialDim, Frame>& dt_phi,
+    const tnsr::aa<DataType, SpatialDim, Frame>& pi,
+    const tnsr::aa<DataType, SpatialDim, Frame>& dt_pi) {
+  tnsr::aa<DataType, SpatialDim, Frame> d2t2_spacetime_metric{};
+  gh::second_time_deriv_of_spacetime_metric(
+      make_not_null(&d2t2_spacetime_metric), lapse, dt_lapse, shift, dt_shift,
+      phi, dt_phi, pi, dt_pi);
+  return d2t2_spacetime_metric;
+}
+}  // namespace gh
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(1, data)
+#define FRAME(data) BOOST_PP_TUPLE_ELEM(2, data)
+
+#define INSTANTIATE(_, data)                                                 \
+  template void gh::second_time_deriv_of_spacetime_metric(                   \
+      const gsl::not_null<tnsr::aa<DTYPE(data), DIM(data), FRAME(data)>*>    \
+          d2t2_spacetime_metric,                                             \
+      const Scalar<DTYPE(data)>& lapse, const Scalar<DTYPE(data)>& dt_lapse, \
+      const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& shift,             \
+      const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& dt_shift,          \
+      const tnsr::iaa<DTYPE(data), DIM(data), FRAME(data)>& phi,             \
+      const tnsr::iaa<DTYPE(data), DIM(data), FRAME(data)>& dt_phi,          \
+      const tnsr::aa<DTYPE(data), DIM(data), FRAME(data)>& pi,               \
+      const tnsr::aa<DTYPE(data), DIM(data), FRAME(data)>& dt_pi);           \
+  template tnsr::aa<DTYPE(data), DIM(data), FRAME(data)>                     \
+  gh::second_time_deriv_of_spacetime_metric(                                 \
+      const Scalar<DTYPE(data)>& lapse, const Scalar<DTYPE(data)>& dt_lapse, \
+      const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& shift,             \
+      const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& dt_shift,          \
+      const tnsr::iaa<DTYPE(data), DIM(data), FRAME(data)>& phi,             \
+      const tnsr::iaa<DTYPE(data), DIM(data), FRAME(data)>& dt_phi,          \
+      const tnsr::aa<DTYPE(data), DIM(data), FRAME(data)>& pi,               \
+      const tnsr::aa<DTYPE(data), DIM(data), FRAME(data)>& dt_pi);
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (double, DataVector),
+                        (Frame::Grid, Frame::Inertial))
+
+#undef DIM
+#undef DTYPE
+#undef FRAME
+#undef INSTANTIATE

--- a/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/SecondTimeDerivOfSpacetimeMetric.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/SecondTimeDerivOfSpacetimeMetric.hpp
@@ -1,0 +1,115 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/Tags.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Utilities/ContainerHelpers.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+class DataVector;
+template <typename X, typename Symm, typename IndexList>
+class Tensor;
+/// \endcond
+
+namespace gh {
+/// @{
+/*!
+ * \ingroup GeneralRelativityGroup
+ * \brief Computes the second time derivative of the spacetime metric from the
+ * generalized harmonic variables, lapse, shift, and the spacetime unit normal
+ * 1-form.
+ *
+ * \details Let the generalized harmonic conjugate momentum and spatial
+ * derivative variables be \f$\Pi_{ab} = -n^c \partial_c g_{ab} \f$ and
+ * \f$\Phi_{iab} = \partial_i g_{ab} \f$.
+ *
+ * Using eq.(35) of \cite Lindblom2005qh (with \f$\gamma_1 = -1\f$) the first
+ * time derivative of the spacetime metric may be expressed in terms of the
+ * above variables:
+ *
+ * \f[
+ * \partial_0 g_{ab} = - \alpha \Pi_{ab} + \beta^k \Phi_{kab}
+ * \f]
+ *
+ * As such, its second time derivative is simply the following:
+ *
+ * \f[
+ * \partial^2_0 g_{ab}
+ *   = - (\partial_0 \alpha) \Pi_{ab} - \alpha \partial_0 \Pi_{ab}
+ *     + (\partial_0 \beta^k) \Phi_{kab} + \beta^k \partial_0 \Phi_{kab}
+ * \f]
+ *
+ */
+template <typename DataType, size_t SpatialDim, typename Frame>
+void second_time_deriv_of_spacetime_metric(
+    gsl::not_null<tnsr::aa<DataType, SpatialDim, Frame>*> d2t2_spacetime_metric,
+    const Scalar<DataType>& lapse, const Scalar<DataType>& dt_lapse,
+    const tnsr::I<DataType, SpatialDim, Frame>& shift,
+    const tnsr::I<DataType, SpatialDim, Frame>& dt_shift,
+    const tnsr::iaa<DataType, SpatialDim, Frame>& phi,
+    const tnsr::iaa<DataType, SpatialDim, Frame>& dt_phi,
+    const tnsr::aa<DataType, SpatialDim, Frame>& pi,
+    const tnsr::aa<DataType, SpatialDim, Frame>& dt_pi);
+
+template <typename DataType, size_t SpatialDim, typename Frame>
+tnsr::aa<DataType, SpatialDim, Frame> second_time_deriv_of_spacetime_metric(
+    const Scalar<DataType>& lapse, const Scalar<DataType>& dt_lapse,
+    const tnsr::I<DataType, SpatialDim, Frame>& shift,
+    const tnsr::I<DataType, SpatialDim, Frame>& dt_shift,
+    const tnsr::iaa<DataType, SpatialDim, Frame>& phi,
+    const tnsr::iaa<DataType, SpatialDim, Frame>& dt_phi,
+    const tnsr::aa<DataType, SpatialDim, Frame>& pi,
+    const tnsr::aa<DataType, SpatialDim, Frame>& dt_pi);
+/// @}
+
+namespace Tags {
+/*!
+ * \brief Compute item to get second time derivative of the spacetime metric
+ *        from generalized harmonic and geometric variables
+ *
+ * \details See `second_time_deriv_of_spacetime_metric()`. Can be retrieved
+ * using `gr::Tags::SpacetimeMetric` wrapped in `Tags::dt<Tags::dt>>`.
+ */
+template <size_t SpatialDim, typename Frame>
+struct SecondTimeDerivOfSpacetimeMetricCompute
+    : ::Tags::dt<
+          ::Tags::dt<gr::Tags::SpacetimeMetric<DataVector, SpatialDim, Frame>>>,
+      db::ComputeTag {
+  using argument_tags =
+      tmpl::list<gr::Tags::Lapse<DataVector>,
+                 ::Tags::dt<gr::Tags::Lapse<DataVector>>,
+                 gr::Tags::Shift<DataVector, SpatialDim, Frame>,
+                 ::Tags::dt<gr::Tags::Shift<DataVector, SpatialDim, Frame>>,
+                 Phi<DataVector, SpatialDim, Frame>,
+                 ::Tags::dt<Phi<DataVector, SpatialDim, Frame>>,
+                 Pi<DataVector, SpatialDim, Frame>,
+                 ::Tags::dt<Pi<DataVector, SpatialDim, Frame>>>;
+
+  using base = ::Tags::dt<
+      ::Tags::dt<gr::Tags::SpacetimeMetric<DataVector, SpatialDim, Frame>>>;
+  using return_type = typename base::type;
+
+  static constexpr auto function = static_cast<void (*)(
+      gsl::not_null<tnsr::aa<DataVector, SpatialDim, Frame>*>,
+      const Scalar<DataVector>&, const Scalar<DataVector>&,
+      const tnsr::I<DataVector, SpatialDim, Frame>&,
+      const tnsr::I<DataVector, SpatialDim, Frame>&,
+      const tnsr::iaa<DataVector, SpatialDim, Frame>&,
+      const tnsr::iaa<DataVector, SpatialDim, Frame>&,
+      const tnsr::aa<DataVector, SpatialDim, Frame>&,
+      const tnsr::aa<DataVector, SpatialDim, Frame>&)>(
+      &second_time_deriv_of_spacetime_metric<DataVector, SpatialDim, Frame>);
+};
+}  // namespace Tags
+}  // namespace gh

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/ComputeGhQuantities.py
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/ComputeGhQuantities.py
@@ -158,6 +158,17 @@ def gh_dt_spacetime_metric(lapse, shift, pi, phi):
     return -lapse * pi + np.einsum("k,kab", shift, phi)
 
 
+def gh_d2t2_spacetime_metric(
+    lapse, dt_lapse, shift, dt_shift, phi, dt_phi, pi, dt_pi
+):
+    return (
+        -dt_lapse * pi
+        - lapse * dt_pi
+        + np.einsum("k,kab", dt_shift, phi)
+        + np.einsum("k,kab", shift, dt_phi)
+    )
+
+
 def spacetime_deriv_detg(
     sqrt_det_spatial_metric, inverse_spatial_metric, dt_spatial_metric, phi
 ):


### PR DESCRIPTION
## Proposed changes

<!--
At a high level, describe what this PR does.
-->

Adds a compute tag for the second time derivative of the spacetime metric in namespace `gh`. Computes this quantity in `EvolveGhValenciaDivClean`.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [x] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [x] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [x] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
