### PR TITLE
Allow timescale tuner to not decrease timescale

### DIFF
--- a/src/ControlSystem/CalculateMeasurementTimescales.cpp
+++ b/src/ControlSystem/CalculateMeasurementTimescales.cpp
@@ -6,21 +6,31 @@
 #include "ControlSystem/Controller.hpp"
 #include "ControlSystem/TimescaleTuner.hpp"
 #include "DataStructures/DataVector.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
 
 namespace control_system {
-template <size_t DerivOrder>
+template <size_t DerivOrder, bool AllowDecrease>
 DataVector calculate_measurement_timescales(
-    const ::Controller<DerivOrder>& controller, const ::TimescaleTuner& tuner,
+    const ::Controller<DerivOrder>& controller,
+    const ::TimescaleTuner<AllowDecrease>& tuner,
     const int measurements_per_update) {
   return tuner.current_timescale() * controller.get_update_fraction() /
          static_cast<double>(measurements_per_update);
 }
 
-template DataVector calculate_measurement_timescales<2>(
-    const ::Controller<2>& controller, const ::TimescaleTuner& tuner,
-    const int measurements_per_update);
-template DataVector calculate_measurement_timescales<3>(
-    const ::Controller<3>& controller, const ::TimescaleTuner& tuner,
-    const int measurements_per_update);
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define ALLOWDECREASE(data) BOOST_PP_TUPLE_ELEM(1, data)
+
+#define INSTANTIATE(_, data)                              \
+  template DataVector calculate_measurement_timescales(   \
+      const ::Controller<DIM(data)>& controller,          \
+      const ::TimescaleTuner<ALLOWDECREASE(data)>& tuner, \
+      const int measurements_per_update);
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (true, false))
+
+#undef INSTANTIATE
+#undef DIM
+#undef ALLOWDECREASE
 
 }  // namespace control_system

--- a/src/ControlSystem/CalculateMeasurementTimescales.hpp
+++ b/src/ControlSystem/CalculateMeasurementTimescales.hpp
@@ -9,6 +9,7 @@
 template <size_t DerivOrder>
 class Controller;
 class DataVector;
+template <bool AllowDecrease>
 class TimescaleTuner;
 /// \endcond
 
@@ -29,8 +30,9 @@ namespace control_system {
  * we calculate the measurement timescales as \f$\tau_\mathrm{m} =
  * \tau_\mathrm{update} / N\f$ where \f$N\f$ is `measurements_per_update`.
  */
-template <size_t DerivOrder>
+template <size_t DerivOrder, bool AllowDecrease>
 DataVector calculate_measurement_timescales(
-    const ::Controller<DerivOrder>& controller, const ::TimescaleTuner& tuner,
+    const ::Controller<DerivOrder>& controller,
+    const ::TimescaleTuner<AllowDecrease>& tuner,
     const int measurements_per_update);
 }  // namespace control_system

--- a/src/ControlSystem/ControlErrors/Expansion.hpp
+++ b/src/ControlSystem/ControlErrors/Expansion.hpp
@@ -75,7 +75,7 @@ struct Expansion : tt::ConformsTo<protocols::ControlError> {
   void pup(PUP::er& /*p*/) {}
 
   template <typename Metavariables, typename... TupleTags>
-  DataVector operator()(const ::TimescaleTuner& /*unused*/,
+  DataVector operator()(const ::TimescaleTuner<true>& /*unused*/,
                         const Parallel::GlobalCache<Metavariables>& cache,
                         const double time,
                         const std::string& function_of_time_name,

--- a/src/ControlSystem/ControlErrors/Rotation.hpp
+++ b/src/ControlSystem/ControlErrors/Rotation.hpp
@@ -71,7 +71,7 @@ struct Rotation : tt::ConformsTo<protocols::ControlError> {
   void pup(PUP::er& /*p*/) {}
 
   template <typename Metavariables, typename... TupleTags>
-  DataVector operator()(const ::TimescaleTuner& /*unused*/,
+  DataVector operator()(const ::TimescaleTuner<true>& /*unused*/,
                         const Parallel::GlobalCache<Metavariables>& cache,
                         const double /*time*/,
                         const std::string& /*function_of_time_name*/,

--- a/src/ControlSystem/ControlErrors/Shape.hpp
+++ b/src/ControlSystem/ControlErrors/Shape.hpp
@@ -105,7 +105,7 @@ struct Shape : tt::ConformsTo<protocols::ControlError> {
   void pup(PUP::er& /*p*/) {}
 
   template <typename Metavariables, typename... TupleTags>
-  DataVector operator()(const ::TimescaleTuner& /*unused*/,
+  DataVector operator()(const ::TimescaleTuner<true>& /*unused*/,
                         const Parallel::GlobalCache<Metavariables>& cache,
                         const double time,
                         const std::string& function_of_time_name,

--- a/src/ControlSystem/ControlErrors/Size.cpp
+++ b/src/ControlSystem/ControlErrors/Size.cpp
@@ -36,7 +36,7 @@ namespace ControlErrors {
 template <size_t DerivOrder, ::domain::ObjectLabel Horizon>
 Size<DerivOrder, Horizon>::Size(
     const int max_times, const double smooth_avg_timescale_frac,
-    TimescaleTuner smoother_tuner,
+    TimescaleTuner<true> smoother_tuner,
     std::optional<DeltaRDriftOutwardOptions> delta_r_drift_outward_options)
     : smoother_tuner_(std::move(smoother_tuner)),
       delta_r_drift_outward_options_(delta_r_drift_outward_options) {

--- a/src/ControlSystem/ControlErrors/Size.hpp
+++ b/src/ControlSystem/ControlErrors/Size.hpp
@@ -185,7 +185,7 @@ struct Size : tt::ConformsTo<protocols::ControlError> {
   };
 
   struct SmootherTuner {
-    using type = TimescaleTuner;
+    using type = TimescaleTuner<true>;
     static constexpr Options::String help{
         "TimescaleTuner for smoothing horizon measurements."};
   };
@@ -250,7 +250,7 @@ struct Size : tt::ConformsTo<protocols::ControlError> {
    * is moved inside this class.
    */
   Size(const int max_times, const double smooth_avg_timescale_frac,
-       TimescaleTuner smoother_tuner,
+       TimescaleTuner<true> smoother_tuner,
        std::optional<DeltaRDriftOutwardOptions> delta_r_drift_outward_options);
 
   /// Returns the internal `control_system::size::Info::suggested_time_scale`. A
@@ -299,7 +299,7 @@ struct Size : tt::ConformsTo<protocols::ControlError> {
    * \return DataVector should be of size 1
    */
   template <typename Metavariables, typename... TupleTags>
-  DataVector operator()(const ::TimescaleTuner& tuner,
+  DataVector operator()(const ::TimescaleTuner<false>& tuner,
                         const Parallel::GlobalCache<Metavariables>& cache,
                         const double time,
                         const std::string& function_of_time_name,
@@ -471,7 +471,7 @@ struct Size : tt::ConformsTo<protocols::ControlError> {
   }
 
  private:
-  TimescaleTuner smoother_tuner_{};
+  TimescaleTuner<true> smoother_tuner_{};
   Averager<DerivOrder> horizon_coef_averager_{};
   size::Info info_{};
   intrp::ZeroCrossingPredictor char_speed_predictor_{};

--- a/src/ControlSystem/ControlErrors/Size/Update.hpp
+++ b/src/ControlSystem/ControlErrors/Size/Update.hpp
@@ -83,7 +83,7 @@ void update_averager(
  */
 template <size_t DerivOrder, ::domain::ObjectLabel Horizon,
           typename Metavariables>
-void update_tuner(const gsl::not_null<TimescaleTuner*> tuner,
+void update_tuner(const gsl::not_null<TimescaleTuner<false>*> tuner,
                   const gsl::not_null<ControlErrors::Size<DerivOrder, Horizon>*>
                       control_error,
                   const Parallel::GlobalCache<Metavariables>& cache,

--- a/src/ControlSystem/ControlErrors/Translation.hpp
+++ b/src/ControlSystem/ControlErrors/Translation.hpp
@@ -84,7 +84,7 @@ struct Translation : tt::ConformsTo<protocols::ControlError> {
   void pup(PUP::er& /*p*/) {}
 
   template <typename Metavariables, typename... TupleTags>
-  DataVector operator()(const ::TimescaleTuner& tuner,
+  DataVector operator()(const ::TimescaleTuner<true>& tuner,
                         const Parallel::GlobalCache<Metavariables>& cache,
                         const double time,
                         const std::string& /*function_of_time_name*/,

--- a/src/ControlSystem/IsSize.hpp
+++ b/src/ControlSystem/IsSize.hpp
@@ -3,8 +3,16 @@
 
 #pragma once
 
-#include "ControlSystem/Systems/Size.hpp"
+#include <cstddef>
+
 #include "Domain/Structure/ObjectLabel.hpp"
+
+/// \cond
+namespace control_system::Systems {
+template <::domain::ObjectLabel Horizon, size_t DerivOrder>
+struct Size;
+}  // namespace control_system::Systems
+/// \endcond
 
 namespace control_system::size {
 // tt::is_a doesn't work because of domain::ObjectLabel and size_t

--- a/src/ControlSystem/Protocols/ControlError.hpp
+++ b/src/ControlSystem/Protocols/ControlError.hpp
@@ -12,9 +12,26 @@
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
 
+template <bool AllowDecrease>
 struct TimescaleTuner;
 
 namespace control_system::protocols {
+namespace detail {
+
+struct DummyMetavariables {
+  using component_list = tmpl::list<>;
+};
+struct DummyTupleTags {
+  using type = int;
+};
+
+template <typename T, bool AllowDecrease>
+struct has_signature
+    : std::is_invocable_r<DataVector, T, const ::TimescaleTuner<AllowDecrease>&,
+                          const Parallel::GlobalCache<DummyMetavariables>&,
+                          const double, const std::string&,
+                          const tuples::TaggedTuple<DummyTupleTags>&> {};
+}  // namespace detail
 /// \brief Definition of a control error
 ///
 /// A control error is used within a control system to compute how far off the
@@ -31,29 +48,20 @@ namespace control_system::protocols {
 ///   `domain::Tags::ObjectCenter`s tags to be in the GlobalCache for this
 ///   control system to work.
 ///
+/// \note The TimescaleTuner can have it's template parameter be either `true`
+/// or `false`.
 ///
 ///   \snippet Helpers/ControlSystem/Examples.hpp ControlError
 struct ControlError {
   template <typename ConformingType>
   struct test {
-    struct DummyMetavariables;
-    struct DummyTupleTags;
-
     static constexpr size_t expected_number_of_excisions =
         ConformingType::expected_number_of_excisions;
 
     using object_centers = typename ConformingType::object_centers;
 
-    static_assert(
-        std::is_same_v<
-            DataVector,
-            decltype(ConformingType{}(
-                std::declval<const ::TimescaleTuner&>(),
-                std::declval<
-                    const Parallel::GlobalCache<DummyMetavariables>&>(),
-                std::declval<const double>(),
-                std::declval<const std::string&>(),
-                std::declval<const tuples::TaggedTuple<DummyTupleTags>&>()))>);
+    static_assert(detail::has_signature<ConformingType, true>::value or
+                  detail::has_signature<ConformingType, false>::value);
   };
 };
 }  // namespace control_system::protocols

--- a/src/ControlSystem/Tags/MeasurementTimescales.hpp
+++ b/src/ControlSystem/Tags/MeasurementTimescales.hpp
@@ -126,8 +126,9 @@ struct MeasurementTimescales : db::SimpleTag {
           const std::string& combined_name = map_of_names[control_system_name];
 
           auto tuner = option_holder.tuner;
-          Tags::detail::initialize_tuner(make_not_null(&tuner), domain_creator,
-                                         initial_time, control_system_name);
+          ::control_system::Tags::detail::initialize_tuner(
+              make_not_null(&tuner), domain_creator, initial_time,
+              control_system_name);
 
           const auto& controller = option_holder.controller;
           DataVector measurement_timescales = calculate_measurement_timescales(

--- a/src/ControlSystem/Tags/OptionTags.hpp
+++ b/src/ControlSystem/Tags/OptionTags.hpp
@@ -8,6 +8,7 @@
 
 #include "ControlSystem/Averager.hpp"
 #include "ControlSystem/Controller.hpp"
+#include "ControlSystem/IsSize.hpp"
 #include "ControlSystem/Protocols/ControlSystem.hpp"
 #include "ControlSystem/TimescaleTuner.hpp"
 #include "IO/Logging/Verbosity.hpp"
@@ -24,6 +25,11 @@ namespace control_system {
 /// their public member names and assigned to their corresponding DataBox tags.
 template <typename ControlSystem>
 struct OptionHolder {
+ private:
+  static constexpr bool is_size =
+      ::control_system::size::is_size_v<ControlSystem>;
+
+ public:
   static_assert(tt::assert_conforms_to_v<
                 ControlSystem, control_system::protocols::ControlSystem>);
   using control_system = ControlSystem;
@@ -51,7 +57,7 @@ struct OptionHolder {
   };
 
   struct TimescaleTuner {
-    using type = ::TimescaleTuner;
+    using type = ::TimescaleTuner<not is_size>;
     static constexpr Options::String help = {
         "Keeps track of the damping timescales for the control system upon "
         "which other timescales are based of off."};
@@ -71,7 +77,7 @@ struct OptionHolder {
   OptionHolder(const bool input_is_active,
                ::Averager<deriv_order - 1> input_averager,
                ::Controller<deriv_order> input_controller,
-               ::TimescaleTuner input_tuner,
+               ::TimescaleTuner<not is_size> input_tuner,
                typename ControlSystem::control_error input_control_error)
       : is_active(input_is_active),
         averager(std::move(input_averager)),
@@ -100,7 +106,7 @@ struct OptionHolder {
   bool is_active{true};
   ::Averager<deriv_order - 1> averager{};
   ::Controller<deriv_order> controller{};
-  ::TimescaleTuner tuner{};
+  ::TimescaleTuner<not is_size> tuner{};
   typename ControlSystem::control_error control_error{};
 };
 

--- a/src/ControlSystem/Tags/SystemTags.cpp
+++ b/src/ControlSystem/Tags/SystemTags.cpp
@@ -7,9 +7,9 @@
 #include "Utilities/GenerateInstantiations.hpp"
 
 namespace control_system::Tags::detail {
-template <size_t Dim>
+template <bool AllowDecrease, size_t Dim>
 void initialize_tuner(
-    const gsl::not_null<::TimescaleTuner*> tuner,
+    const gsl::not_null<::TimescaleTuner<AllowDecrease>*> tuner,
     const std::unique_ptr<::DomainCreator<Dim>>& domain_creator,
     const double initial_time, const std::string& name) {
   // We get the functions of time in order to get the number of components
@@ -51,17 +51,19 @@ void initialize_tuner(
   }
 }
 
-#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define ALLOWDECREASE(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define DIM(data) BOOST_PP_TUPLE_ELEM(1, data)
 
 #define INSTANTIATE(_, data)                                             \
   template void initialize_tuner(                                        \
-      const gsl::not_null<::TimescaleTuner*> tuner,                      \
+      const gsl::not_null<::TimescaleTuner<ALLOWDECREASE(data)>*> tuner, \
       const std::unique_ptr<::DomainCreator<DIM(data)>>& domain_creator, \
       const double initial_time, const std::string& name);
 
-GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
+GENERATE_INSTANTIATIONS(INSTANTIATE, (true, false), (1, 2, 3))
 
 #undef INSTANTIATE
+#undef ALLOWDECREASE
 #undef DIM
 
 }  // namespace control_system::Tags::detail

--- a/support/Pipelines/Bbh/Inspiral.yaml
+++ b/support/Pipelines/Bbh/Inspiral.yaml
@@ -358,9 +358,7 @@ ControlSystems:
       MinTimescale: 1.0e-4
       MaxTimescale: 20.0
       IncreaseThreshold: 2.5e-4
-      DecreaseThreshold: 1.0e-3
       IncreaseFactor: 1.01
-      DecreaseFactor: 1.0
     ControlError:
       MaxNumTimesForZeroCrossingPredictor: 4
       SmoothAvgTimescaleFraction: 0.25

--- a/support/Pipelines/Bbh/Ringdown.yaml
+++ b/support/Pipelines/Bbh/Ringdown.yaml
@@ -220,9 +220,7 @@ ControlSystems:
       MinTimescale: 1.0e-4
       MaxTimescale: 20.0
       IncreaseThreshold: 2.5e-4
-      DecreaseThreshold: 1.0e-3
       IncreaseFactor: 1.01
-      DecreaseFactor: 1.0
     ControlError:
       MaxNumTimesForZeroCrossingPredictor: 4
       SmoothAvgTimescaleFraction: 0.25

--- a/tests/InputFiles/GeneralizedHarmonic/BinaryBlackHole.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/BinaryBlackHole.yaml
@@ -363,9 +363,7 @@ ControlSystems:
       MinTimescale: 1.0e-4
       MaxTimescale: 20.0
       IncreaseThreshold: 2.5e-4
-      DecreaseThreshold: 1.0e-3
       IncreaseFactor: 1.01
-      DecreaseFactor: 1.0
     ControlError:
       MaxNumTimesForZeroCrossingPredictor: 4
       SmoothAvgTimescaleFraction: 0.25

--- a/tests/InputFiles/GeneralizedHarmonic/CylindricalBinaryBlackHole.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/CylindricalBinaryBlackHole.yaml
@@ -344,9 +344,7 @@ ControlSystems:
       MinTimescale: 1.0e-4
       MaxTimescale: 20.0
       IncreaseThreshold: 2.5e-4
-      DecreaseThreshold: 1.0e-3
       IncreaseFactor: 1.01
-      DecreaseFactor: 1.0
     ControlError:
       MaxNumTimesForZeroCrossingPredictor: 4
       SmoothAvgTimescaleFraction: 0.25

--- a/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
@@ -248,9 +248,7 @@ ControlSystems:
       MinTimescale: 1.0e-4
       MaxTimescale: 20.0
       IncreaseThreshold: 2.5e-4
-      DecreaseThreshold: 1.0e-3
       IncreaseFactor: 1.01
-      DecreaseFactor: 1.0
     ControlError:
       MaxNumTimesForZeroCrossingPredictor: 4
       SmoothAvgTimescaleFraction: 0.25

--- a/tests/Unit/ControlSystem/Actions/Test_Initialization.cpp
+++ b/tests/Unit/ControlSystem/Actions/Test_Initialization.cpp
@@ -98,8 +98,8 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.Initialization",
   int current_measurement{};
 
   const double damping_time = 1.0;
-  TimescaleTuner tuner{
-      std::vector<double>{damping_time}, 10.0, 0.1, 2.0, 0.1, 1.01, 0.99};
+  TimescaleTuner<true> tuner{
+      std::vector<double>{damping_time}, 10.0, 0.1, 0.1, 1.01, 2.0, 0.99};
   Controller<order> controller{0.3};
 
   std::unordered_map<std::string,

--- a/tests/Unit/ControlSystem/ControlErrors/Test_Expansion.cpp
+++ b/tests/Unit/ControlSystem/ControlErrors/Test_Expansion.cpp
@@ -114,8 +114,8 @@ void test_expansion_control_error() {
   // This is before the first expiration time
   const double check_time = 0.1;
   const DataVector control_error =
-      ControlError{}(::TimescaleTuner{}, cache, check_time, expansion_name,
-                     fake_measurement_tuple);
+      ControlError{}(::TimescaleTuner<true>{}, cache, check_time,
+                     expansion_name, fake_measurement_tuple);
 
   const auto& expansion_f_of_t =
       dynamic_cast<domain::FunctionsOfTime::PiecewisePolynomial<deriv_order>&>(

--- a/tests/Unit/ControlSystem/ControlErrors/Test_Rotation.cpp
+++ b/tests/Unit/ControlSystem/ControlErrors/Test_Rotation.cpp
@@ -114,7 +114,7 @@ void test_rotation_control_error() {
   // This is before the first expiration time
   const double check_time = 0.1;
   const DataVector control_error =
-      ControlError{}(::TimescaleTuner{}, cache, check_time, rotation_name,
+      ControlError{}(::TimescaleTuner<true>{}, cache, check_time, rotation_name,
                      fake_measurement_tuple);
 
   // Calculated error = (grid_diff cross pos_diff) / (grid_diff dot pos_diff) by

--- a/tests/Unit/ControlSystem/ControlErrors/Test_Shape.cpp
+++ b/tests/Unit/ControlSystem/ControlErrors/Test_Shape.cpp
@@ -176,7 +176,7 @@ void test_shape_control_error() {
   QueueTuple fake_measurement_tuple{fake_ah};
 
   const DataVector control_error =
-      ControlError{}(::TimescaleTuner{}, cache, check_time, shape_name,
+      ControlError{}(::TimescaleTuner<true>{}, cache, check_time, shape_name,
                      fake_measurement_tuple);
 
   const auto lambda_00_coef =

--- a/tests/Unit/ControlSystem/ControlErrors/Test_SizeError.cpp
+++ b/tests/Unit/ControlSystem/ControlErrors/Test_SizeError.cpp
@@ -216,8 +216,8 @@ void test_size_error_one_step(
     CHECK_FALSE(error_class.get_suggested_timescale().has_value());
     CHECK_FALSE(error_class.discontinuous_change_has_occurred());
 
-    TimescaleTuner tuner{
-        std::vector<double>{0.1}, 1.0, 0.01, 1.0e-3, 1.0e-4, 1.01, 0.98};
+    TimescaleTuner<false> tuner{std::vector<double>{0.1}, 1.0, 0.01, 1.0e-4,
+                                1.01};
     std::unordered_map<std::string,
                        std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
         functions_of_time{};

--- a/tests/Unit/ControlSystem/ControlErrors/Test_Translation.cpp
+++ b/tests/Unit/ControlSystem/ControlErrors/Test_Translation.cpp
@@ -117,8 +117,8 @@ void test_translation_control_error() {
   // This is before the first expiration time
   const double check_time = 0.1;
   const DataVector control_error =
-      ControlError{}(::TimescaleTuner{}, cache, check_time, translation_name,
-                     fake_measurement_tuple);
+      ControlError{}(::TimescaleTuner<true>{}, cache, check_time,
+                     translation_name, fake_measurement_tuple);
 
   // Calculated errors from other basic control systems
   const DataVector rotation_control_error =

--- a/tests/Unit/ControlSystem/Tags/Test_FunctionsOfTimeInitialize.cpp
+++ b/tests/Unit/ControlSystem/Tags/Test_FunctionsOfTimeInitialize.cpp
@@ -207,10 +207,10 @@ void test_functions_of_time_tag() {
   // time between the two expiration times used above in the TestCreator
   const double timescale = 27.0;
   const double timescale2 = 0.1;
-  const TimescaleTuner tuner1(std::vector<double>{timescale}, 10.0, 1.0e-3,
-                              1.0e-2, 1.0e-4, 1.01, 0.99);
-  const TimescaleTuner tuner2(timescale2, 10.0, 1.0e-3, 1.0e-2, 1.0e-4, 1.01,
-                              0.99);
+  const TimescaleTuner<true> tuner1(std::vector<double>{timescale}, 10.0,
+                                    1.0e-3, 1.0e-4, 1.01, 1.0e-2, 0.99);
+  const TimescaleTuner<true> tuner2(timescale2, 10.0, 1.0e-3, 1.0e-4, 1.01,
+                                    1.0e-2, 0.99);
   const Averager<1> averager(0.25, true);
   const double update_fraction = 0.3;
   const Controller<2> controller(update_fraction);
@@ -280,8 +280,8 @@ using Creator = std::unique_ptr<::DomainCreator<1>>;
 void not_controlling(const bool is_active) {
   const Creator creator = std::make_unique<TestCreator>(true);
 
-  const TimescaleTuner tuner(std::vector<double>{1.0}, 10.0, 1.0e-3, 1.0e-2,
-                             1.0e-4, 1.01, 0.99);
+  const TimescaleTuner<true> tuner(std::vector<double>{1.0}, 10.0, 1.0e-3,
+                                   1.0e-4, 1.01, 1.0e-2, 0.99);
   const Averager<1> averager(0.25, true);
   const double update_fraction = 0.3;
   const Controller<2> controller(update_fraction);
@@ -305,8 +305,8 @@ void not_controlling(const bool is_active) {
 void incompatible(const bool is_active) {
   const Creator creator = std::make_unique<BadCreator>();
 
-  const TimescaleTuner tuner(std::vector<double>{1.0}, 10.0, 1.0e-3, 1.0e-2,
-                             1.0e-4, 1.01, 0.99);
+  const TimescaleTuner<true> tuner(std::vector<double>{1.0}, 10.0, 1.0e-3,
+                                   1.0e-4, 1.01, 1.0e-2, 0.99);
   const Averager<1> averager(0.25, true);
   const double update_fraction = 0.3;
   const Controller<2> controller(update_fraction);

--- a/tests/Unit/ControlSystem/Tags/Test_MeasurementTimescales.cpp
+++ b/tests/Unit/ControlSystem/Tags/Test_MeasurementTimescales.cpp
@@ -71,8 +71,8 @@ template <size_t DerivOrder>
 void test_calculate_measurement_timescales() {
   INFO("Test calculate measurement timescales");
   const double timescale = 20.0;
-  const TimescaleTuner tuner(std::vector<double>{timescale}, 10.0, 1.0e-3,
-                             1.0e-2, 1.0e-4, 1.01, 0.99);
+  const TimescaleTuner<true> tuner(std::vector<double>{timescale}, 10.0, 1.0e-3,
+                                   1.0e-4, 1.01, 1.0e-2, 0.99);
   const double update_fraction = 0.25;
   const Controller<DerivOrder> controller(update_fraction);
 
@@ -108,16 +108,16 @@ void test_measurement_tag() {
     const control_system::TestHelpers::ControlError<1> control_error{};
 
     const double timescale_long = 27.0;
-    const TimescaleTuner tuner1(
+    const TimescaleTuner<true> tuner1(
         std::vector<double>{timescale_long, timescale_long * 2.0}, 10.0, 1.0e-3,
-        1.0e-2, 1.0e-4, 1.01, 0.99);
+        1.0e-4, 1.01, 1.0e-2, 0.99);
     const double timescale_short = 0.5;
-    TimescaleTuner tuner2(timescale_short, 10.0, 1.0e-3, 1.0e-2, 1.0e-4, 1.01,
-                          0.99);
+    TimescaleTuner<true> tuner2(timescale_short, 10.0, 1.0e-3, 1.0e-4, 1.01,
+                                1.0e-2, 0.99);
     tuner2.resize_timescales(2);
-    const TimescaleTuner tuner4 = tuner2;
-    const TimescaleTuner& tuner5 = tuner1;
-    const TimescaleTuner& tuner6 = tuner1;
+    const TimescaleTuner<true> tuner4 = tuner2;
+    const TimescaleTuner<true>& tuner5 = tuner1;
+    const TimescaleTuner<true>& tuner6 = tuner1;
 
     OptionHolder<1> option_holder1(true, averager, controller, tuner1,
                                    control_error);
@@ -201,10 +201,10 @@ void test_measurement_tag() {
 
   CHECK_THROWS_WITH(
       ([]() {
-        const TimescaleTuner tuner1(std::vector<double>{27.0}, 10.0, 1.0e-3,
-                                    1.0e-2, 1.0e-4, 1.01, 0.99);
-        const TimescaleTuner tuner2(std::vector<double>{0.1}, 10.0, 1.0e-3,
-                                    1.0e-2, 1.0e-4, 1.01, 0.99);
+        const TimescaleTuner<true> tuner1(std::vector<double>{27.0}, 10.0,
+                                          1.0e-3, 1.0e-4, 1.01, 1.0e-2, 0.99);
+        const TimescaleTuner<true> tuner2(std::vector<double>{0.1}, 10.0,
+                                          1.0e-3, 1.0e-4, 1.01, 1.0e-2, 0.99);
         const Averager<1> averager(0.25, true);
         const Controller<2> controller(0.3);
         const control_system::TestHelpers::ControlError<1> control_error{};

--- a/tests/Unit/ControlSystem/Test_Controller.cpp
+++ b/tests/Unit/ControlSystem/Test_Controller.cpp
@@ -29,10 +29,10 @@ void test_controller() {
   const double min_timescale = 1.0e-3;
   const double initial_timescale = 1.0e-2;
 
-  TimescaleTuner tst(std::vector<double>{initial_timescale}, max_timescale,
-                     min_timescale, decrease_timescale_threshold,
-                     increase_timescale_threshold, increase_factor,
-                     decrease_factor);
+  TimescaleTuner<true> tst(std::vector<double>{initial_timescale},
+                           max_timescale, min_timescale,
+                           increase_timescale_threshold, increase_factor,
+                           decrease_timescale_threshold, decrease_factor);
 
   // test following a sinusoidal target function
   double t = 0.1;
@@ -101,10 +101,10 @@ void test_timeoffsets() {
   const double min_timescale = 1.0e-3;
   const double initial_timescale = 1.0e-2;
 
-  TimescaleTuner tst(std::vector<double>{initial_timescale}, max_timescale,
-                     min_timescale, decrease_timescale_threshold,
-                     increase_timescale_threshold, increase_factor,
-                     decrease_factor);
+  TimescaleTuner<true> tst(std::vector<double>{initial_timescale},
+                           max_timescale, min_timescale,
+                           increase_timescale_threshold, increase_factor,
+                           decrease_timescale_threshold, decrease_factor);
 
   // test following a sinusoidal target function
   double t = 0.1;
@@ -193,10 +193,10 @@ void test_timeoffsets_noaverageq() {
   const double min_timescale = 1.0e-3;
   const double initial_timescale = 1.0e-2;
 
-  TimescaleTuner tst(std::vector<double>{initial_timescale}, max_timescale,
-                     min_timescale, decrease_timescale_threshold,
-                     increase_timescale_threshold, increase_factor,
-                     decrease_factor);
+  TimescaleTuner<true> tst(std::vector<double>{initial_timescale},
+                           max_timescale, min_timescale,
+                           increase_timescale_threshold, increase_factor,
+                           decrease_timescale_threshold, decrease_factor);
 
   // test following a sinusoidal target function
   double t = 0.1;

--- a/tests/Unit/ControlSystem/Test_ExpirationTimes.cpp
+++ b/tests/Unit/ControlSystem/Test_ExpirationTimes.cpp
@@ -65,9 +65,9 @@ void test_expiration_time_construction() {
   constexpr int measurements_per_update = 4;
 
   const double timescale = 2.0;
-  const TimescaleTuner tuner1(std::vector<double>{timescale}, 10.0, 1.0e-3,
-                              1.0e-2, 1.0e-4, 1.01, 0.99);
-  TimescaleTuner tuner2(0.1, 10.0, 1.0e-3, 1.0e-2, 1.0e-4, 1.01, 0.99);
+  const TimescaleTuner<true> tuner1(std::vector<double>{timescale}, 10.0,
+                                    1.0e-3, 1.0e-4, 1.01, 1.0e-2, 0.99);
+  TimescaleTuner<true> tuner2(0.1, 10.0, 1.0e-3, 1.0e-4, 1.01, 1.0e-2, 0.99);
   tuner2.resize_timescales(2);
   const Averager<1> averager(0.25, true);
   const double update_fraction = 0.3;

--- a/tests/Unit/ControlSystem/Test_Tags.cpp
+++ b/tests/Unit/ControlSystem/Test_Tags.cpp
@@ -94,10 +94,10 @@ void test_control_sys_inputs() {
   const double decrease_factor = 0.99;
   const double max_timescale = 10.0;
   const double min_timescale = 1.0e-3;
-  const TimescaleTuner expected_tuner(
+  const TimescaleTuner<true> expected_tuner(
       std::vector<double>{1.}, max_timescale, min_timescale,
-      decrease_timescale_threshold, increase_timescale_threshold,
-      increase_factor, decrease_factor);
+      increase_timescale_threshold, increase_factor,
+      decrease_timescale_threshold, decrease_factor);
   const Averager<1> expected_averager(0.25, true);
   const Controller<2> expected_controller(0.3);
   const std::string expected_name{"LabelA"};
@@ -143,13 +143,13 @@ void test_individual_tags() {
     const double decrease_factor = 0.99;
     const double max_timescale = 10.0;
     const double min_timescale = 1.0e-3;
-    return TimescaleTuner{std::vector<double>(num_components, 1.0),
-                          max_timescale,
-                          min_timescale,
-                          decrease_timescale_threshold,
-                          increase_timescale_threshold,
-                          increase_factor,
-                          decrease_factor};
+    return TimescaleTuner<true>{std::vector<double>(num_components, 1.0),
+                                max_timescale,
+                                min_timescale,
+                                increase_timescale_threshold,
+                                increase_factor,
+                                decrease_timescale_threshold,
+                                decrease_factor};
   };
 
   const auto tuner_str = [](const bool is_active) -> std::string {
@@ -195,12 +195,12 @@ void test_individual_tags() {
       std::make_unique<FakeCreator>(std::unordered_map<std::string, size_t>{},
                                     1);
 
-  const TimescaleTuner created_tuner =
+  const TimescaleTuner<true> created_tuner =
       tuner_tag::create_from_options<MetavarsEmpty>(holder, creator, 0.0);
-  const TimescaleTuner quat_created_tuner =
+  const TimescaleTuner<true> quat_created_tuner =
       quat_tuner_tag::create_from_options<MetavarsEmpty>(quat_holder, creator,
                                                          0.0);
-  const TimescaleTuner inactive_created_tuner =
+  const TimescaleTuner<true> inactive_created_tuner =
       tuner_tag::create_from_options<MetavarsEmpty>(inactive_holder,
                                                     creator_empty, 0.0);
 

--- a/tests/Unit/Helpers/ControlSystem/Examples.hpp
+++ b/tests/Unit/Helpers/ControlSystem/Examples.hpp
@@ -122,7 +122,7 @@ struct ExampleControlError
   void pup(PUP::er& /*p*/) {}
 
   template <typename Metavariables, typename... QueueTags>
-  DataVector operator()(const ::TimescaleTuner& tuner,
+  DataVector operator()(const ::TimescaleTuner<true>& tuner,
                         const Parallel::GlobalCache<Metavariables>& cache,
                         const double time,
                         const std::string& function_of_time_name,

--- a/tests/Unit/Helpers/ControlSystem/TestStructs.hpp
+++ b/tests/Unit/Helpers/ControlSystem/TestStructs.hpp
@@ -43,7 +43,7 @@ struct ControlError : tt::ConformsTo<control_system::protocols::ControlError> {
 
   template <typename Metavariables, typename... QueueTags>
   DataVector operator()(
-      const ::TimescaleTuner& /*tuner*/,
+      const ::TimescaleTuner<true>& /*tuner*/,
       const Parallel::GlobalCache<Metavariables>& /*cache*/,
       const double /*time*/, const std::string& /*function_of_time_name*/,
       const tuples::TaggedTuple<QueueTags...>& /*measurements*/) {


### PR DESCRIPTION
## Proposed changes

For size control, the `DecreaseFactor` of the `TimescaleTuner` has to be 1.0 because other logic takes care of decreasing the timescale. If it isn't 1.0, the run will crash almost instantly. Therefore, it doesn't really make sense to allow this as an option for size control. This PR templates `TimescaleTuner` on a bool to `AllowDecrease`. All other control systems have this bool as `true`, but size control has it as `false`.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
If your executable has a Size control system, remove the `DecreaseThreshold:` and `DecreaseFactor:` options from the TimescaleTuner of the Size control systems. Note that you should *keep* these options for the `SmootherTuner` option of Size control.
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
