### PR TITLE
Add spherical shell coord maps

### DIFF
--- a/src/Domain/CoordinateMaps/CMakeLists.txt
+++ b/src/Domain/CoordinateMaps/CMakeLists.txt
@@ -30,8 +30,10 @@ spectre_target_sources(
   Identity.cpp
   Interval.cpp
   KerrHorizonConforming.cpp
+  PolarAngle.cpp
   Rotation.cpp
   SpecialMobius.cpp
+  SphericalToCartesian.cpp
   UniformCylindricalEndcap.cpp
   UniformCylindricalFlatEndcap.cpp
   UniformCylindricalSide.cpp
@@ -68,10 +70,12 @@ spectre_target_headers(
   Interval.hpp
   KerrHorizonConforming.hpp
   MapInstantiationMacros.hpp
+  PolarAngle.hpp
   ProductMaps.hpp
   ProductMaps.tpp
   Rotation.hpp
   SpecialMobius.hpp
+  SphericalToCartesian.hpp
   Tags.hpp
   TimeDependentHelpers.hpp
   UniformCylindricalEndcap.hpp

--- a/src/Domain/CoordinateMaps/PolarAngle.cpp
+++ b/src/Domain/CoordinateMaps/PolarAngle.cpp
@@ -1,0 +1,77 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Domain/CoordinateMaps/PolarAngle.hpp"
+
+#include <cmath>
+#include <cstddef>
+#include <pup.h>
+
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/DereferenceWrapper.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/MakeWithValue.hpp"
+
+namespace domain::CoordinateMaps {
+
+template <typename T>
+std::array<tt::remove_cvref_wrap_t<T>, 1> PolarAngle::operator()(
+    const std::array<T, 1>& xi) const {
+  return {{acos(-xi[0])}};
+}
+
+std::optional<std::array<double, 1>> PolarAngle::inverse(
+    const std::array<double, 1>& theta) const {
+  return {{-cos(theta[0])}};
+}
+
+template <typename T>
+tnsr::Ij<tt::remove_cvref_wrap_t<T>, 1, Frame::NoFrame> PolarAngle::jacobian(
+    const std::array<T, 1>& xi) const {
+  using ReturnType = tt::remove_cvref_wrap_t<T>;
+  tnsr::Ij<ReturnType, 1, Frame::NoFrame> result{};
+  get<0, 0>(result) = 1. / sqrt(1. - square(xi[0]));
+  return result;
+}
+
+template <typename T>
+tnsr::Ij<tt::remove_cvref_wrap_t<T>, 1, Frame::NoFrame>
+PolarAngle::inv_jacobian(const std::array<T, 1>& xi) const {
+  using ReturnType = tt::remove_cvref_wrap_t<T>;
+  tnsr::Ij<ReturnType, 1, Frame::NoFrame> result{};
+  get<0, 0>(result) = sqrt(1. - square(xi[0]));
+  return result;
+}
+
+void PolarAngle::pup(PUP::er& p) {
+  size_t version = 0;
+  p | version;
+  // Remember to increment the version number when making changes to this
+  // function. Retain support for unpacking data written by previous versions
+  // whenever possible. See `Domain` docs for details.
+}
+
+bool operator!=(const PolarAngle& lhs, const PolarAngle& rhs) {
+  return not(lhs == rhs);
+}
+
+// Explicit instantiations
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE_DTYPE(_, data)                                           \
+  template std::array<tt::remove_cvref_wrap_t<DTYPE(data)>, 1>               \
+  PolarAngle::operator()(const std::array<DTYPE(data), 1>& xi) const;        \
+  template tnsr::Ij<tt::remove_cvref_wrap_t<DTYPE(data)>, 1, Frame::NoFrame> \
+  PolarAngle::jacobian(const std::array<DTYPE(data), 1>& xi) const;          \
+  template tnsr::Ij<tt::remove_cvref_wrap_t<DTYPE(data)>, 1, Frame::NoFrame> \
+  PolarAngle::inv_jacobian(const std::array<DTYPE(data), 1>& xi) const;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE_DTYPE,
+                        (double, DataVector,
+                         std::reference_wrapper<const double>,
+                         std::reference_wrapper<const DataVector>))
+
+#undef DTYPE
+#undef INSTANTIATE_DTYPE
+}  // namespace domain::CoordinateMaps

--- a/src/Domain/CoordinateMaps/PolarAngle.hpp
+++ b/src/Domain/CoordinateMaps/PolarAngle.hpp
@@ -1,0 +1,68 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <optional>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Domain/CoordinateMaps/Wedge.hpp"
+#include "Utilities/TypeTraits/RemoveReferenceWrapper.hpp"
+
+/// \cond
+namespace PUP {
+class er;
+}  // namespace PUP
+/// \endcond
+
+namespace domain::CoordinateMaps {
+
+/*!
+ * \ingroup CoordinateMapsGroup
+ * \brief Map from the logical interval $\xi \in [-1, 1]$ to the polar angle
+ * $\theta \in [0, \pi]$, where $\xi = -\cos(\theta)$ as used by
+ * `ylm::Spherepack`.
+ *
+ * \warning The Jacobian of this map is ill-defined at the endpoints
+ * $\xi = -1, 1$, which correspond to the poles $\theta = 0, \pi$.
+ * Therefore it is typically used with Gauss-Legendre collocation points.
+ */
+class PolarAngle {
+ public:
+  static constexpr size_t dim = 1;
+
+  PolarAngle() = default;
+  ~PolarAngle() = default;
+  PolarAngle(PolarAngle&&) = default;
+  PolarAngle(const PolarAngle&) = default;
+  PolarAngle& operator=(const PolarAngle&) = default;
+  PolarAngle& operator=(PolarAngle&&) = default;
+
+  template <typename T>
+  std::array<tt::remove_cvref_wrap_t<T>, 1> operator()(
+      const std::array<T, 1>& source_coords) const;
+
+  std::optional<std::array<double, 1>> inverse(
+      const std::array<double, 1>& target_coords) const;
+
+  template <typename T>
+  tnsr::Ij<tt::remove_cvref_wrap_t<T>, 1, Frame::NoFrame> jacobian(
+      const std::array<T, 1>& source_coords) const;
+
+  template <typename T>
+  tnsr::Ij<tt::remove_cvref_wrap_t<T>, 1, Frame::NoFrame> inv_jacobian(
+      const std::array<T, 1>& source_coords) const;
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& p);
+
+  static constexpr bool is_identity() { return false; }
+};
+
+inline bool operator==(const PolarAngle& /*lhs*/, const PolarAngle& /*rhs*/) {
+  return true;
+}
+bool operator!=(const PolarAngle& lhs, const PolarAngle& rhs);
+}  // namespace domain::CoordinateMaps

--- a/src/Domain/CoordinateMaps/SphericalToCartesian.cpp
+++ b/src/Domain/CoordinateMaps/SphericalToCartesian.cpp
@@ -1,0 +1,180 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Domain/CoordinateMaps/SphericalToCartesian.hpp"
+
+#include <cmath>
+#include <cstddef>
+#include <pup.h>
+
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/DereferenceWrapper.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/MakeWithValue.hpp"
+
+namespace domain::CoordinateMaps {
+
+template <size_t Dim>
+template <typename T>
+std::array<tt::remove_cvref_wrap_t<T>, Dim>
+SphericalToCartesian<Dim>::operator()(
+    const std::array<T, Dim>& spherical_coords) const {
+  if constexpr (Dim == 2) {
+    const auto& r = spherical_coords[radial_coord];
+    const auto& phi = spherical_coords[polar_coord];
+    return {{r * cos(phi), r * sin(phi)}};
+  } else {
+    const auto& r = spherical_coords[radial_coord];
+    const auto& theta = spherical_coords[polar_coord];
+    const auto& phi = spherical_coords[azimuth_coord];
+    return {
+        {r * sin(theta) * cos(phi), r * sin(theta) * sin(phi), r * cos(theta)}};
+  }
+}
+
+template <size_t Dim>
+std::optional<std::array<double, Dim>> SphericalToCartesian<Dim>::inverse(
+    const std::array<double, Dim>& cartesian_coords) const {
+  std::array<double, Dim> spherical_coords{};
+  if constexpr (Dim == 2) {
+    const auto& [x, y] = cartesian_coords;
+    auto& r = spherical_coords[radial_coord];
+    auto& phi = spherical_coords[polar_coord];
+    r = sqrt(square(x) + square(y));
+    phi = atan2(y, x);
+    if (phi < 0.) {
+      phi += 2. * M_PI;
+    }
+  } else {
+    const auto& [x, y, z] = cartesian_coords;
+    auto& r = spherical_coords[radial_coord];
+    auto& theta = spherical_coords[polar_coord];
+    auto& phi = spherical_coords[azimuth_coord];
+    r = sqrt(square(x) + square(y) + square(z));
+    theta = acos(z / r);
+    phi = atan2(y, x);
+    if (phi < 0.) {
+      phi += 2. * M_PI;
+    }
+  }
+  return {std::move(spherical_coords)};
+}
+
+template <size_t Dim>
+template <typename T>
+tnsr::Ij<tt::remove_cvref_wrap_t<T>, Dim, Frame::NoFrame>
+SphericalToCartesian<Dim>::jacobian(
+    const std::array<T, Dim>& spherical_coords) const {
+  using ReturnType = tt::remove_cvref_wrap_t<T>;
+  auto jacobian_matrix =
+      make_with_value<tnsr::Ij<ReturnType, Dim, Frame::NoFrame>>(
+          spherical_coords[0], 0.);
+  if constexpr (Dim == 2) {
+    const auto& r = spherical_coords[radial_coord];
+    const auto& phi = spherical_coords[polar_coord];
+    get<0, radial_coord>(jacobian_matrix) = cos(phi);
+    get<1, radial_coord>(jacobian_matrix) = sin(phi);
+    get<0, polar_coord>(jacobian_matrix) = -r * sin(phi);
+    get<1, polar_coord>(jacobian_matrix) = r * cos(phi);
+  } else {
+    const auto& r = spherical_coords[radial_coord];
+    const auto& theta = spherical_coords[polar_coord];
+    const auto& phi = spherical_coords[azimuth_coord];
+    get<0, radial_coord>(jacobian_matrix) = sin(theta) * cos(phi);
+    get<1, radial_coord>(jacobian_matrix) = sin(theta) * sin(phi);
+    get<2, radial_coord>(jacobian_matrix) = cos(theta);
+    get<0, polar_coord>(jacobian_matrix) = r * cos(theta) * cos(phi);
+    get<1, polar_coord>(jacobian_matrix) = r * cos(theta) * sin(phi);
+    get<2, polar_coord>(jacobian_matrix) = -r * sin(theta);
+    get<0, azimuth_coord>(jacobian_matrix) = -r * sin(theta) * sin(phi);
+    get<1, azimuth_coord>(jacobian_matrix) = r * sin(theta) * cos(phi);
+    get<2, azimuth_coord>(jacobian_matrix) = 0.;
+  }
+  return jacobian_matrix;
+}
+
+template <size_t Dim>
+template <typename T>
+tnsr::Ij<tt::remove_cvref_wrap_t<T>, Dim, Frame::NoFrame>
+SphericalToCartesian<Dim>::inv_jacobian(
+    const std::array<T, Dim>& spherical_coords) const {
+  using ReturnType = tt::remove_cvref_wrap_t<T>;
+  auto inv_jacobian_matrix =
+      make_with_value<tnsr::Ij<ReturnType, Dim, Frame::NoFrame>>(
+          spherical_coords[0], 0.);
+  if constexpr (Dim == 2) {
+    const auto& r = spherical_coords[radial_coord];
+    const auto& phi = spherical_coords[polar_coord];
+    get<radial_coord, 0>(inv_jacobian_matrix) = cos(phi);
+    get<radial_coord, 1>(inv_jacobian_matrix) = sin(phi);
+    get<polar_coord, 0>(inv_jacobian_matrix) = -r * sin(phi);
+    get<polar_coord, 1>(inv_jacobian_matrix) = r * cos(phi);
+  } else {
+    const auto& r = spherical_coords[radial_coord];
+    const auto [x, y, z] = operator()(spherical_coords);
+    get<radial_coord, 0>(inv_jacobian_matrix) = x / r;
+    get<radial_coord, 1>(inv_jacobian_matrix) = y / r;
+    get<radial_coord, 2>(inv_jacobian_matrix) = z / r;
+    const auto rho_square = square(x) + square(y);
+    const auto denominator = square(r) * sqrt(rho_square);
+    get<polar_coord, 0>(inv_jacobian_matrix) = x * z / denominator;
+    get<polar_coord, 1>(inv_jacobian_matrix) = y * z / denominator;
+    get<polar_coord, 2>(inv_jacobian_matrix) = -rho_square / denominator;
+    get<azimuth_coord, 0>(inv_jacobian_matrix) = -y / rho_square;
+    get<azimuth_coord, 1>(inv_jacobian_matrix) = x / rho_square;
+    get<azimuth_coord, 2>(inv_jacobian_matrix) = 0.;
+  }
+  return inv_jacobian_matrix;
+}
+
+template <size_t Dim>
+void SphericalToCartesian<Dim>::pup(PUP::er& p) {
+  size_t version = 0;
+  p | version;
+  // Remember to increment the version number when making changes to this
+  // function. Retain support for unpacking data written by previous versions
+  // whenever possible. See `Domain` docs for details.
+}
+
+template <size_t Dim>
+bool operator!=(const SphericalToCartesian<Dim>& lhs,
+                const SphericalToCartesian<Dim>& rhs) {
+  return not(lhs == rhs);
+}
+
+// Explicit instantiations
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(1, data)
+
+#define INSTANTIATE_DIM(_, data)                                        \
+  template class SphericalToCartesian<DIM(data)>;                       \
+  template bool operator==(const SphericalToCartesian<DIM(data)>& lhs,  \
+                           const SphericalToCartesian<DIM(data)>& rhs); \
+  template bool operator!=(const SphericalToCartesian<DIM(data)>& lhs,  \
+                           const SphericalToCartesian<DIM(data)>& rhs);
+
+#define INSTANTIATE_DTYPE(_, data)                                     \
+  template std::array<tt::remove_cvref_wrap_t<DTYPE(data)>, DIM(data)> \
+  SphericalToCartesian<DIM(data)>::operator()(                         \
+      const std::array<DTYPE(data), DIM(data)>& source_coords) const;  \
+  template tnsr::Ij<tt::remove_cvref_wrap_t<DTYPE(data)>, DIM(data),   \
+                    Frame::NoFrame>                                    \
+  SphericalToCartesian<DIM(data)>::jacobian(                           \
+      const std::array<DTYPE(data), DIM(data)>& source_coords) const;  \
+  template tnsr::Ij<tt::remove_cvref_wrap_t<DTYPE(data)>, DIM(data),   \
+                    Frame::NoFrame>                                    \
+  SphericalToCartesian<DIM(data)>::inv_jacobian(                       \
+      const std::array<DTYPE(data), DIM(data)>& source_coords) const;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE_DIM, (2, 3))
+GENERATE_INSTANTIATIONS(INSTANTIATE_DTYPE, (2, 3),
+                        (double, DataVector,
+                         std::reference_wrapper<const double>,
+                         std::reference_wrapper<const DataVector>))
+
+#undef DIM
+#undef DTYPE
+#undef INSTANTIATE_DIM
+#undef INSTANTIATE_DTYPE
+}  // namespace domain::CoordinateMaps

--- a/src/Domain/CoordinateMaps/SphericalToCartesian.hpp
+++ b/src/Domain/CoordinateMaps/SphericalToCartesian.hpp
@@ -1,0 +1,90 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <optional>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Domain/CoordinateMaps/Wedge.hpp"
+#include "Utilities/TypeTraits/RemoveReferenceWrapper.hpp"
+
+/// \cond
+namespace PUP {
+class er;
+}  // namespace PUP
+/// \endcond
+
+namespace domain::CoordinateMaps {
+
+/*!
+ * \ingroup CoordinateMapsGroup
+ * \brief Map from spherical to Cartesian coordinates
+ *
+ * The expected order of the input spherical coordinates is the same as in
+ * `domain::CoordinateMaps::Wedge`: [theta, phi, r] in 3D and [r, phi] in 2D.
+ *
+ * To map a logical cube to a spherical shell consistent with `ylm::Spherepack`,
+ * prepend the following maps:
+ * - `r`: Any 1D radial map that maps [-1, 1] to [inner_radius, outer_radius],
+ *   such as `domain::CoordinateMaps::Interval`.
+ * - `theta`: `domain::CoordinateMaps::PolarAngle` to map [-1, 1] to [0, pi]
+ *   with the relation $\xi = cos(\theta)$.
+ * - `phi`: Affine map [-1, 1] to [0, 2pi), e.g.
+ *   `domain::CoordinateMaps::Affine` or `domain::CoordinateMaps::Interval`
+ */
+template <size_t Dim>
+class SphericalToCartesian {
+ public:
+  static constexpr size_t dim = Dim;
+  static_assert(Dim == 2 or Dim == 3,
+                "The spherical shell map is implemented in 2D and 3D");
+
+  SphericalToCartesian() = default;
+  ~SphericalToCartesian() = default;
+  SphericalToCartesian(SphericalToCartesian&&) = default;
+  SphericalToCartesian(const SphericalToCartesian&) = default;
+  SphericalToCartesian& operator=(const SphericalToCartesian&) = default;
+  SphericalToCartesian& operator=(SphericalToCartesian&&) = default;
+
+  template <typename T>
+  std::array<tt::remove_cvref_wrap_t<T>, Dim> operator()(
+      const std::array<T, Dim>& source_coords) const;
+
+  std::optional<std::array<double, Dim>> inverse(
+      const std::array<double, Dim>& target_coords) const;
+
+  template <typename T>
+  tnsr::Ij<tt::remove_cvref_wrap_t<T>, Dim, Frame::NoFrame> jacobian(
+      const std::array<T, Dim>& source_coords) const;
+
+  template <typename T>
+  tnsr::Ij<tt::remove_cvref_wrap_t<T>, Dim, Frame::NoFrame> inv_jacobian(
+      const std::array<T, Dim>& source_coords) const;
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& p);
+
+  static constexpr bool is_identity() { return false; }
+
+ private:
+  // maps between 2D and 3D choices for coordinate axis orientations
+  static constexpr size_t radial_coord =
+      detail::WedgeCoordOrientation<Dim>::radial_coord;
+  static constexpr size_t polar_coord =
+      detail::WedgeCoordOrientation<Dim>::polar_coord;
+  static constexpr size_t azimuth_coord =
+      detail::WedgeCoordOrientation<Dim>::azimuth_coord;
+};
+
+template <size_t Dim>
+bool operator==(const SphericalToCartesian<Dim>& /*lhs*/,
+                const SphericalToCartesian<Dim>& /*rhs*/) {
+  return true;
+}
+template <size_t Dim>
+bool operator!=(const SphericalToCartesian<Dim>& lhs,
+                const SphericalToCartesian<Dim>& rhs);
+}  // namespace domain::CoordinateMaps

--- a/tests/Unit/Domain/CoordinateMaps/CMakeLists.txt
+++ b/tests/Unit/Domain/CoordinateMaps/CMakeLists.txt
@@ -23,6 +23,7 @@ set(LIBRARY_SOURCES
   Test_ProductMaps.cpp
   Test_Rotation.cpp
   Test_SpecialMobius.cpp
+  Test_SphericalShell.cpp
   Test_Tags.cpp
   Test_TimeDependentHelpers.cpp
   Test_UniformCylindricalEndcap.cpp

--- a/tests/Unit/Domain/CoordinateMaps/Test_SphericalShell.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_SphericalShell.cpp
@@ -1,0 +1,110 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cmath>
+#include <random>
+
+#include "Domain/CoordinateMaps/Affine.hpp"
+#include "Domain/CoordinateMaps/PolarAngle.hpp"
+#include "Domain/CoordinateMaps/SphericalToCartesian.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "Helpers/Domain/CoordinateMaps/TestMapHelpers.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/Spherepack.hpp"
+
+namespace domain {
+
+SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.SphericalShell",
+                  "[Domain][Unit]") {
+  MAKE_GENERATOR(generator);
+  {
+    INFO("Test PolarAngle map");
+    const CoordinateMaps::PolarAngle map{};
+    std::uniform_real_distribution<> dist(-1., 1.);
+    const auto sample_points = make_with_random_values<std::array<double, 10>>(
+        make_not_null(&generator), make_not_null(&dist));
+    for (double scalar : sample_points) {
+      const std::array<double, 1> random_point{{scalar}};
+      test_coordinate_map_argument_types(map, random_point);
+      test_inverse_map(map, random_point);
+      test_jacobian(map, random_point);
+      test_inv_jacobian(map, random_point);
+    }
+    const std::array<double, 1> endpoint_left{{-1.}};
+    const std::array<double, 1> endpoint_right{{1.}};
+    CHECK(get<0>(map(endpoint_left)) == approx(0.));
+    CHECK(get<0>(map(endpoint_right)) == approx(M_PI));
+    CHECK_FALSE(map != map);
+    test_serialization(map);
+    CHECK(not map.is_identity());
+  }
+  {
+    INFO("Consistency with ylm::Spherepack");
+    const size_t l_max = 6;
+    const size_t m_max = 3;
+    // Theta: Gauss-Legendre points in cos(theta)
+    const auto logical_theta =
+        Spectral::collocation_points<Spectral::Basis::Legendre,
+                                     Spectral::Quadrature::Gauss>(l_max + 1);
+    const CoordinateMaps::PolarAngle theta_map{};
+    const auto theta =
+        get<0>(theta_map(std::array<DataVector, 1>{{logical_theta}}));
+    // Phi: equidistant points in [0, 2pi)
+    DataVector logical_phi(2 * m_max + 1);
+    const double spacing = 2. / logical_phi.size();
+    for (size_t i = 0; i < logical_phi.size(); ++i) {
+      logical_phi[i] = -1. + i * spacing;
+    }
+    const CoordinateMaps::Affine phi_map{-1., 1., 0., 2. * M_PI};
+    const auto phi = get<0>(phi_map(std::array<DataVector, 1>{{logical_phi}}));
+    // Check consistency with ylm::Spherepack
+    const ylm::Spherepack ylm{l_max, m_max};
+    DataVector ylm_theta(ylm.theta_points().size());
+    std::copy(ylm.theta_points().begin(), ylm.theta_points().end(),
+              ylm_theta.begin());
+    DataVector ylm_phi(ylm.phi_points().size());
+    std::copy(ylm.phi_points().begin(), ylm.phi_points().end(),
+              ylm_phi.begin());
+    CHECK_ITERABLE_APPROX(theta, ylm_theta);
+    CHECK_ITERABLE_APPROX(phi, ylm_phi);
+  }
+  {
+    INFO("Test SphericalToCartesian map");
+    const CoordinateMaps::SphericalToCartesian<3> map{};
+    std::uniform_real_distribution<> dist_r(0.5, 3.);
+    std::uniform_real_distribution<> dist_theta(0., M_PI);
+    std::uniform_real_distribution<> dist_phi(0., 2. * M_PI - 0.01);
+    const size_t num_points = 10;
+    const auto sample_r = make_with_random_values<DataVector>(
+        make_not_null(&generator), make_not_null(&dist_r), num_points);
+    const auto sample_theta = make_with_random_values<DataVector>(
+        make_not_null(&generator), make_not_null(&dist_theta), num_points);
+    const auto sample_phi = make_with_random_values<DataVector>(
+        make_not_null(&generator), make_not_null(&dist_phi), num_points);
+    const std::array<DataVector, 3> random_points{
+        {sample_theta, sample_phi, sample_r}};
+    for (size_t i = 0; i < num_points; ++i) {
+      const std::array<double, 3> random_point{
+          {sample_theta[i], sample_phi[i], sample_r[i]}};
+      test_coordinate_map_argument_types(map, random_point);
+      test_inverse_map(map, random_point);
+      test_jacobian(map, random_point);
+      test_inv_jacobian(map, random_point);
+    }
+    const std::array<double, 3> x_axis{{M_PI_2, 0., 10.}};
+    CHECK_ITERABLE_APPROX(map(x_axis), (std::array<double, 3>{{10., 0., 0.}}));
+    const std::array<double, 3> y_axis{{M_PI_2, M_PI_2, 10.}};
+    CHECK_ITERABLE_APPROX(map(y_axis), (std::array<double, 3>{{0., 10., 0.}}));
+    const std::array<double, 3> z_axis{{0., 0., 10.}};
+    CHECK_ITERABLE_APPROX(map(z_axis), (std::array<double, 3>{{0., 0., 10.}}));
+    CHECK_FALSE(map != map);
+    test_serialization(map);
+    CHECK(not map.is_identity());
+  }
+}
+
+}  // namespace domain

--- a/tests/Unit/Helpers/Domain/CoordinateMaps/TestMapHelpers.hpp
+++ b/tests/Unit/Helpers/Domain/CoordinateMaps/TestMapHelpers.hpp
@@ -531,7 +531,9 @@ void test_inverse_map(const Map& map,
                       const std::array<T, Map::dim>& test_point) {
   INFO("Test inverse map");
   CAPTURE(test_point);
-  const auto expected_test_point = map.inverse(map(test_point));
+  const auto mapped_point = map(test_point);
+  CAPTURE(mapped_point);
+  const auto expected_test_point = map.inverse(mapped_point);
   REQUIRE(expected_test_point.has_value());
   CHECK_ITERABLE_APPROX(test_point, expected_test_point.value());
 }


### PR DESCRIPTION
## Proposed changes

First steps towards spherical shells. These maps will be used to map the logical axes [-1, 1] to ${\theta, \phi, r}$ and then to Cartesian coordinates.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
