### PR TITLE
Limit time step to prevent control-system deadlocks

### DIFF
--- a/src/ControlSystem/Actions/CMakeLists.txt
+++ b/src/ControlSystem/Actions/CMakeLists.txt
@@ -7,5 +7,6 @@ spectre_target_headers(
   HEADERS
   Initialization.hpp
   InitializeMeasurements.hpp
+  LimitTimeStep.hpp
   PrintCurrentMeasurement.hpp
   )

--- a/src/ControlSystem/Actions/LimitTimeStep.hpp
+++ b/src/ControlSystem/Actions/LimitTimeStep.hpp
@@ -1,0 +1,248 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <algorithm>
+#include <memory>
+#include <optional>
+
+#include "ControlSystem/CombinedName.hpp"
+#include "ControlSystem/Metafunctions.hpp"
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "Parallel/AlgorithmExecution.hpp"
+#include "Parallel/ArrayComponentId.hpp"
+#include "Parallel/Callback.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "Time/ChangeSlabSize.hpp"
+#include "Time/Tags/HistoryEvolvedVariables.hpp"
+#include "Time/Tags/TimeStepper.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+namespace Tags {
+struct TimeStep;
+struct TimeStepId;
+}  // namespace Tags
+namespace control_system::Tags {
+template <typename ControlSystems>
+struct FutureMeasurements;
+struct MeasurementTimescales;
+}  // namespace control_system::Tags
+namespace domain::Tags {
+struct FunctionsOfTime;
+}  // namespace domain::Tags
+namespace tuples {
+template <typename... Tags>
+class TaggedTuple;
+}  // namespace tuples
+/// \endcond
+
+namespace control_system::Actions {
+/// \ingroup ControlSystemsGroup
+/// \brief Limit the step size in a GTS evolution to prevent deadlocks from
+/// control system measurements.
+///
+/// \details Most time steppers require evaluations of the coordinates
+/// at several times during the step before they can produce dense
+/// output.  If any of those evaluations require a function-of-time
+/// update depending on a measurement within the step, the evolution
+/// will deadlock.  This action reduces the step size if necessary to
+/// prevent that from happening.
+///
+/// Specifically:
+/// 1. The chosen step will never be longer than the unmodified step,
+///    and will be short enough to avoid relevant function-of-time
+///    expirations.
+/// 2. Given the previous, the step will cover as many control-system
+///    updates as possible.
+/// 3. If the next step is likely to be limited by this action, adjust
+///    the length of the current step so that this step and the next
+///    step will be as close as possible to the same size.
+template <typename ControlSystems>
+struct LimitTimeStep {
+ private:
+  using control_system_groups =
+      tmpl::transform<metafunctions::measurements_t<ControlSystems>,
+                      metafunctions::control_systems_with_measurement<
+                          tmpl::pin<ControlSystems>, tmpl::_1>>;
+
+  template <typename Group>
+  struct GroupExpiration {
+    using type = double;
+  };
+
+ public:
+  template <typename DbTagsList, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent>
+  static Parallel::iterable_action_return_t apply(
+      db::DataBox<DbTagsList>& box,
+      const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+      Parallel::GlobalCache<Metavariables>& cache,
+      const ArrayIndex& array_index, ActionList /*meta*/,
+      const ParallelComponent* const /*meta*/) {
+    static_assert(not Metavariables::local_time_stepping,
+                  "The control system LimitTimeStep action is only for global "
+                  "time stepping.");
+    const auto& time_step_id = db::get<::Tags::TimeStepId>(box);
+    if (time_step_id.substep() != 0) {
+      return {Parallel::AlgorithmExecution::Continue, std::nullopt};
+    }
+
+    const auto& time_stepper = db::get<::Tags::TimeStepper<>>(box);
+    if (time_stepper.number_of_substeps() == 1) {
+      // If there are no substeps, there is no reason to limit the
+      // step size so substeps can be evaluated.  Single-substep FSAL
+      // methods could be problematic, but we don't have any of those.
+      return {Parallel::AlgorithmExecution::Continue, std::nullopt};
+    }
+
+    const auto& this_proxy =
+        ::Parallel::get_parallel_component<ParallelComponent>(
+            cache)[array_index];
+
+    // Minimum expiration time for any FoT in the measurement group.
+    tmpl::wrap<tmpl::transform<control_system_groups,
+                               tmpl::bind<GroupExpiration, tmpl::_1>>,
+               tuples::TaggedTuple>
+        group_expiration_times{};
+
+    bool ready = true;
+    // Calculate group_expiration_times
+    tmpl::for_each<control_system_groups>([&](auto group_v) {
+      if (not ready) {
+        return;
+      }
+      using group = tmpl::type_from<decltype(group_v)>;
+
+      auto& future_measurements =
+          db::get_mutable_reference<Tags::FutureMeasurements<group>>(
+              make_not_null(&box));
+
+      std::optional<double> group_update = future_measurements.next_update();
+      if (not group_update.has_value()) {
+        Parallel::mutable_cache_item_is_ready<
+            control_system::Tags::MeasurementTimescales>(
+            cache,
+            Parallel::make_array_component_id<ParallelComponent>(array_index),
+            [&](const auto& measurement_timescales) {
+              const auto& group_timescale =
+                  *measurement_timescales.at(combined_name<group>());
+              future_measurements.update(group_timescale);
+              group_update = future_measurements.next_update();
+              ready = group_update.has_value();
+              return ready ? std::unique_ptr<Parallel::Callback>{}
+                           : std::unique_ptr<Parallel::Callback>(
+                                 new Parallel::PerformAlgorithmCallback(
+                                     this_proxy));
+            });
+        if (not ready) {
+          return;
+        }
+      }
+
+      auto& group_expiration =
+          get<GroupExpiration<group>>(group_expiration_times);
+      group_expiration = std::numeric_limits<double>::infinity();
+
+      if (*group_update == std::numeric_limits<double>::infinity()) {
+        // Control measurement is not active.
+        return;
+      }
+
+      // Calculate group_expiration
+      Parallel::mutable_cache_item_is_ready<domain::Tags::FunctionsOfTime>(
+          cache,
+          Parallel::make_array_component_id<ParallelComponent>(array_index),
+          [&](const auto& functions_of_time) {
+            tmpl::for_each<group>([&](auto system) {
+              using System = tmpl::type_from<decltype(system)>;
+              if (not ready) {
+                return;
+              }
+              const auto& fot = *functions_of_time.at(System::name());
+              ready = fot.time_bounds()[1] > *group_update;
+              if (ready) {
+                group_expiration = std::min(
+                    group_expiration, fot.expiration_after(*group_update));
+              }
+            });
+            return ready ? std::unique_ptr<Parallel::Callback>{}
+                         : std::unique_ptr<Parallel::Callback>(
+                               new Parallel::PerformAlgorithmCallback(
+                                   this_proxy));
+          });
+    });
+    if (not ready) {
+      return {Parallel::AlgorithmExecution::Retry, std::nullopt};
+    }
+
+    const double orig_step_start = time_step_id.step_time().value();
+    const double orig_step_end =
+        (time_step_id.step_time() + db::get<::Tags::TimeStep>(box)).value();
+
+    // Smallest of the current step end and the FoT expirations.  We
+    // can't step any farther than this.
+    const double latest_valid_step =
+        tmpl::as_pack<control_system_groups>([&](auto... groups) {
+          return std::min(
+              {orig_step_end,
+               get<GroupExpiration<tmpl::type_from<decltype(groups)>>>(
+                   group_expiration_times)...});
+        });
+
+    if (not time_stepper.can_change_step_size(
+            time_step_id, db::get<::Tags::HistoryEvolvedVariables<>>(box))) {
+      if (orig_step_end > latest_valid_step) {
+        ERROR(
+            "Step must be decreased to avoid control-system deadlock, but "
+            "time-stepper requires a fixed step size.");
+      }
+      return {Parallel::AlgorithmExecution::Continue, std::nullopt};
+    }
+    ASSERT(db::get<::Tags::TimeStep>(box).fraction() == 1,
+           "Trying to change GTS step, but it isn't a full slab.  Non-slab "
+           "steps should only happen during self-start, but the preceding "
+           "check should have ended the action if this is self-start.");
+
+    // The last update that we can perform on the next step.  Don't
+    // shrink the step past this time since that will force another
+    // step to take the measurement.
+    double last_update_time = orig_step_start;
+    // Step time that produces a balanced step with the following
+    // step, ignoring the restrictions on the current step.
+    double preferred_step_time = orig_step_end;
+
+    tmpl::for_each<control_system_groups>([&](auto group_v) {
+      using group = tmpl::type_from<decltype(group_v)>;
+
+      // This was used above, so it is not nullopt.
+      const double group_update =
+          db::get<Tags::FutureMeasurements<group>>(box).next_update().value();
+      if (group_update <= latest_valid_step) {
+        // We've satisfied this measurement.
+        last_update_time = std::max(last_update_time, group_update);
+      } else {
+        // We can't make it far enough to do the final measurement.
+        // Try to avoid a small step by choosing two equal-sized steps
+        // to the expiration time.
+        const double equal_step_time =
+            0.5 * (orig_step_start +
+                   get<GroupExpiration<group>>(group_expiration_times));
+        preferred_step_time = std::min(preferred_step_time, equal_step_time);
+      }
+    });
+
+    const double new_step_end =
+        std::clamp(preferred_step_time, last_update_time, latest_valid_step);
+
+    change_slab_size(make_not_null(&box), new_step_end);
+
+    return {Parallel::AlgorithmExecution::Continue, std::nullopt};
+  }
+};
+}  // namespace control_system::Actions

--- a/src/Domain/FunctionsOfTime/ThreadsafeList.tpp
+++ b/src/Domain/FunctionsOfTime/ThreadsafeList.tpp
@@ -224,7 +224,8 @@ auto ThreadsafeList<T>::find_interval(const double time,
     ERROR("Attempt to access an empty function of time.");
   }
   if (time > interval->expiration or
-      (interval_after_boundary and time == interval->expiration)) {
+      (interval_after_boundary and time == interval->expiration and
+       interval->expiration < std::numeric_limits<double>::infinity())) {
     ERROR("Attempt to evaluate at time "
           << time << ", which is after the expiration time "
           << interval->expiration);

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
@@ -7,6 +7,7 @@
 #include <vector>
 
 #include "ControlSystem/Actions/InitializeMeasurements.hpp"
+#include "ControlSystem/Actions/LimitTimeStep.hpp"
 #include "ControlSystem/Actions/PrintCurrentMeasurement.hpp"
 #include "ControlSystem/Component.hpp"
 #include "ControlSystem/Event.hpp"
@@ -512,6 +513,7 @@ struct EvolutionMetavars {
               Actions::RecordTimeStepperData<system>,
               evolution::Actions::RunEventsAndDenseTriggers<tmpl::list<
                   ::domain::CheckFunctionsOfTimeAreReadyPostprocessor>>,
+              control_system::Actions::LimitTimeStep<control_systems>,
               Actions::UpdateU<system>>>,
       dg::Actions::Filter<
           Filters::Exponential<0>,

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhNoBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhNoBlackHole.hpp
@@ -28,8 +28,9 @@ struct EvolutionMetavars : public GeneralizedHarmonicTemplateBase<VolumeDim> {
                                                         false>;
   using typename gh_base::initialize_initial_data_dependent_quantities_actions;
   using typename gh_base::observed_reduction_data_tags;
-  using typename gh_base::step_actions;
   using typename gh_base::system;
+
+  using step_actions = typename gh_base::template step_actions<tmpl::list<>>;
 
   using gh_dg_element_array = DgElementArray<
       EvolutionMetavars,

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhSingleBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhSingleBlackHole.hpp
@@ -173,7 +173,7 @@ struct EvolutionMetavars : public GeneralizedHarmonicTemplateBase<3> {
       tmpl::push_back<typename gh_base::dg_registration_list,
                       intrp::Actions::RegisterElementWithInterpolator>;
 
-  using typename gh_base::step_actions;
+  using step_actions = typename gh_base::template step_actions<control_systems>;
 
   using initialization_actions = tmpl::push_back<
       tmpl::pop_back<typename gh_base::template initialization_actions<

--- a/src/Evolution/Executables/GeneralizedHarmonic/GeneralizedHarmonicBase.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/GeneralizedHarmonicBase.hpp
@@ -6,6 +6,7 @@
 #include <cstddef>
 #include <vector>
 
+#include "ControlSystem/Actions/LimitTimeStep.hpp"
 #include "DataStructures/DataBox/PrefixHelpers.hpp"
 #include "DataStructures/DataBox/Tag.hpp"
 #include "Domain/Creators/Factory1D.hpp"
@@ -328,6 +329,7 @@ struct GeneralizedHarmonicTemplateBase {
        Parallel::Phase::Register, Parallel::Phase::InitializeTimeStepperHistory,
        Parallel::Phase::Evolve, Parallel::Phase::Exit}};
 
+  template <typename ControlSystems>
   using step_actions = tmpl::list<
       evolution::dg::Actions::ComputeTimeDerivative<
           volume_dim, system, AllStepChoosers, local_time_stepping>,
@@ -344,6 +346,7 @@ struct GeneralizedHarmonicTemplateBase {
                   system, volume_dim, false>,
               Actions::RecordTimeStepperData<system>,
               evolution::Actions::RunEventsAndDenseTriggers<tmpl::list<>>,
+              control_system::Actions::LimitTimeStep<ControlSystems>,
               Actions::UpdateU<system>,
               dg::Actions::Filter<
                   Filters::Exponential<0>,

--- a/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
+++ b/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
@@ -7,6 +7,7 @@
 #include <vector>
 
 #include "ControlSystem/Actions/InitializeMeasurements.hpp"
+#include "ControlSystem/Actions/LimitTimeStep.hpp"
 #include "ControlSystem/Component.hpp"
 #include "ControlSystem/Event.hpp"
 #include "ControlSystem/Measurements/BNSCenterOfMass.hpp"
@@ -828,6 +829,7 @@ struct GhValenciaDivCleanTemplateBase<
           tmpl::list<Actions::RecordTimeStepperData<system>,
                      evolution::Actions::RunEventsAndDenseTriggers<
                          events_and_dense_triggers_subcell_postprocessors>,
+                     control_system::Actions::LimitTimeStep<control_systems>,
                      Actions::UpdateU<system>>>,
       // Note: The primitive variables are computed as part of the TCI.
       evolution::dg::subcell::Actions::TciAndRollback<
@@ -856,6 +858,7 @@ struct GhValenciaDivCleanTemplateBase<
       Actions::RecordTimeStepperData<system>,
       evolution::Actions::RunEventsAndDenseTriggers<
           events_and_dense_triggers_subcell_postprocessors>,
+      control_system::Actions::LimitTimeStep<control_systems>,
       Actions::UpdateU<system>,
       Actions::MutateApply<
           grmhd::GhValenciaDivClean::subcell::FixConservativesAndComputePrims<

--- a/src/Evolution/Executables/ScalarTensor/EvolveScalarTensorSingleBlackHole.hpp
+++ b/src/Evolution/Executables/ScalarTensor/EvolveScalarTensorSingleBlackHole.hpp
@@ -192,7 +192,7 @@ struct EvolutionMetavars : public ScalarTensorTemplateBase<EvolutionMetavars> {
       tmpl::push_back<typename st_base::dg_registration_list,
                       intrp::Actions::RegisterElementWithInterpolator>;
 
-  using typename st_base::step_actions;
+  using step_actions = typename st_base::template step_actions<control_systems>;
 
   using initialization_actions = tmpl::push_back<
       tmpl::pop_back<typename st_base::template initialization_actions<

--- a/src/Evolution/Executables/ScalarTensor/ScalarTensorBase.hpp
+++ b/src/Evolution/Executables/ScalarTensor/ScalarTensorBase.hpp
@@ -6,6 +6,7 @@
 #include <cstddef>
 #include <vector>
 
+#include "ControlSystem/Actions/LimitTimeStep.hpp"
 #include "DataStructures/DataBox/PrefixHelpers.hpp"
 #include "DataStructures/DataBox/Tag.hpp"
 #include "Domain/Creators/Factory1D.hpp"
@@ -419,6 +420,7 @@ struct ScalarTensorTemplateBase {
   static constexpr auto default_phase_order =
       detail::make_default_phase_order();
 
+  template <typename ControlSystems>
   using step_actions = tmpl::list<
       evolution::dg::Actions::ComputeTimeDerivative<
           volume_dim, system, AllStepChoosers, local_time_stepping>,
@@ -442,6 +444,7 @@ struct ScalarTensorTemplateBase {
                   system, volume_dim, false>,
               Actions::RecordTimeStepperData<system>,
               evolution::Actions::RunEventsAndDenseTriggers<tmpl::list<>>,
+              control_system::Actions::LimitTimeStep<ControlSystems>,
               Actions::UpdateU<system>,
               // We allow for separate filtering of the system variables
               dg::Actions::Filter<Filters::Exponential<0>,

--- a/src/Time/CMakeLists.txt
+++ b/src/Time/CMakeLists.txt
@@ -27,6 +27,7 @@ spectre_target_headers(
   AdaptiveSteppingDiagnostics.hpp
   ApproximateTime.hpp
   BoundaryHistory.hpp
+  ChangeSlabSize.hpp
   ChooseLtsStepSize.hpp
   EvolutionOrdering.hpp
   History.hpp

--- a/src/Time/ChangeSlabSize.hpp
+++ b/src/Time/ChangeSlabSize.hpp
@@ -1,0 +1,98 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "Time/AdaptiveSteppingDiagnostics.hpp"
+#include "Time/Slab.hpp"
+#include "Time/Tags/HistoryEvolvedVariables.hpp"
+#include "Time/Tags/TimeStepper.hpp"
+#include "Time/Time.hpp"
+#include "Time/TimeStepId.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+namespace Tags {
+struct AdaptiveSteppingDiagnostics;
+template <typename Tag>
+struct Next;
+struct TimeStep;
+struct TimeStepId;
+}  // namespace Tags
+/// \endcond
+
+/// \ingroup TimeGroup
+/// Change the slab size, updating all quantities in the DataBox
+/// depending on it.
+///
+/// The end of the slab (in the appropriate direction for the
+/// evolution's flow of time) will be set to \p new_slab_end.  The
+/// time step is set to the same fraction of the new slab as it was of
+/// the old.
+template <typename DbTags>
+void change_slab_size(const gsl::not_null<db::DataBox<DbTags>*> box,
+                      const double new_slab_end) {
+  const TimeStepId& old_time_step_id = db::get<Tags::TimeStepId>(*box);
+
+  ASSERT(old_time_step_id.is_at_slab_boundary(),
+         "Cannot change slab size in middle of slab: " << old_time_step_id);
+
+  const Slab old_slab = old_time_step_id.step_time().slab();
+  const double old_slab_end = old_time_step_id.time_runs_forward()
+                                  ? old_slab.end().value()
+                                  : old_slab.start().value();
+
+  if (new_slab_end == old_slab_end) {
+    return;
+  }
+
+  const TimeDelta& old_time_step = db::get<Tags::TimeStep>(*box);
+
+  const Slab new_slab = old_time_step_id.time_runs_forward()
+                            ? Slab(old_slab.start().value(), new_slab_end)
+                            : Slab(new_slab_end, old_slab.end().value());
+  // We are at a slab boundary, so the substep is 0.
+  const TimeStepId new_time_step_id(
+      old_time_step_id.time_runs_forward(), old_time_step_id.slab_number(),
+      old_time_step_id.step_time().with_slab(new_slab));
+  const auto new_time_step = old_time_step.with_slab(new_slab);
+
+  const auto new_next_time_step_id =
+      db::get<Tags::TimeStepper<>>(*box).next_time_id(new_time_step_id,
+                                                      new_time_step);
+
+  db::mutate_apply<
+      tmpl::push_front<Tags::get_all_history_tags<DbTags>,
+                       ::Tags::Next<::Tags::TimeStepId>, ::Tags::TimeStep,
+                       ::Tags::Next<::Tags::TimeStep>, ::Tags::TimeStepId,
+                       ::Tags::AdaptiveSteppingDiagnostics>,
+      tmpl::list<>>(
+      [&new_next_time_step_id, &new_time_step, &new_time_step_id](
+          const gsl::not_null<TimeStepId*> next_time_step_id,
+          const gsl::not_null<TimeDelta*> time_step,
+          const gsl::not_null<TimeDelta*> next_time_step,
+          const gsl::not_null<TimeStepId*> local_time_step_id,
+          const gsl::not_null<AdaptiveSteppingDiagnostics*> diags,
+          const auto... histories) {
+        const auto update_history = [&](const auto history) {
+          if (not history->empty() and
+              history->back().time_step_id == *local_time_step_id) {
+            ASSERT(history->at_step_start(),
+                   "Cannot change step size with substep data.");
+            history->back().time_step_id = new_time_step_id;
+          }
+          return 0;
+        };
+        expand_pack(update_history(histories)...);
+
+        *next_time_step_id = new_next_time_step_id;
+        *time_step = new_time_step;
+        *next_time_step = new_time_step;
+        *local_time_step_id = new_time_step_id;
+        ++diags->number_of_slab_size_changes;
+      },
+      box);
+}

--- a/src/Time/TimeSteppers/AdamsMoultonPc.cpp
+++ b/src/Time/TimeSteppers/AdamsMoultonPc.cpp
@@ -202,10 +202,11 @@ bool AdamsMoultonPc::can_change_step_size_impl(
   // complete.  We need to wait during the main evolution so we don't
   // increase the step size and step to a time still in use from
   // self-start, as that would cause the coefficients to diverge.
-  const evolution_less<Time> less{time_id.time_runs_forward()};
+  const evolution_less_equal<Time> less_equal{time_id.time_runs_forward()};
   return not ::SelfStart::is_self_starting(time_id) and
          alg::all_of(history, [&](const auto& record) {
-           return less(record.time_step_id.step_time(), time_id.step_time());
+           return less_equal(record.time_step_id.step_time(),
+                             time_id.step_time());
          });
 }
 

--- a/tests/Unit/ControlSystem/Actions/CMakeLists.txt
+++ b/tests/Unit/ControlSystem/Actions/CMakeLists.txt
@@ -5,4 +5,5 @@ set(LIBRARY_SOURCES
   ${LIBRARY_SOURCES}
   Actions/Test_Initialization.cpp
   Actions/Test_InitializeMeasurements.cpp
+  Actions/Test_LimitTimeStep.cpp
   PARENT_SCOPE)

--- a/tests/Unit/ControlSystem/Actions/Test_LimitTimeStep.cpp
+++ b/tests/Unit/ControlSystem/Actions/Test_LimitTimeStep.cpp
@@ -1,0 +1,333 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <limits>
+#include <memory>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "ControlSystem/Actions/LimitTimeStep.hpp"
+#include "ControlSystem/FutureMeasurements.hpp"
+#include "ControlSystem/Tags/FutureMeasurements.hpp"
+#include "ControlSystem/Tags/MeasurementTimescales.hpp"
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "Domain/FunctionsOfTime/PiecewisePolynomial.hpp"
+#include "Domain/FunctionsOfTime/Tags.hpp"
+#include "Framework/ActionTesting.hpp"
+#include "Helpers/ControlSystem/TestStructs.hpp"
+#include "Parallel/Phase.hpp"
+#include "Parallel/PhaseDependentActionList.hpp"
+#include "Time/History.hpp"
+#include "Time/Slab.hpp"
+#include "Time/Tags/AdaptiveSteppingDiagnostics.hpp"
+#include "Time/Tags/HistoryEvolvedVariables.hpp"
+#include "Time/Tags/TimeStep.hpp"
+#include "Time/Tags/TimeStepId.hpp"
+#include "Time/Tags/TimeStepper.hpp"
+#include "Time/Time.hpp"
+#include "Time/TimeStepId.hpp"
+#include "Time/TimeSteppers/AdamsBashforth.hpp"
+#include "Time/TimeSteppers/AdamsMoultonPc.hpp"
+#include "Time/TimeSteppers/Rk3HesthavenSsp.hpp"
+#include "Time/TimeSteppers/TimeStepper.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Serialization/RegisterDerivedClassesWithCharm.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+struct LabelA {};
+struct LabelB {};
+struct LabelC {};
+
+using MeasurementA = control_system::TestHelpers::Measurement<LabelA>;
+using MeasurementB = control_system::TestHelpers::Measurement<LabelB>;
+
+using systemsA =
+    tmpl::list<control_system::TestHelpers::System<0, LabelA, MeasurementA>>;
+using systemsB =
+    tmpl::list<control_system::TestHelpers::System<0, LabelB, MeasurementB>,
+               control_system::TestHelpers::System<0, LabelC, MeasurementB>>;
+
+using control_systems = tmpl::append<systemsA, systemsB>;
+
+struct Var : db::SimpleTag {
+  using type = double;
+};
+
+struct FunctionsOfTimeTag : domain::Tags::FunctionsOfTime, db::SimpleTag {
+  using type = std::unordered_map<
+      std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>;
+};
+
+template <typename Metavariables>
+struct Component {
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = int;
+  using mutable_global_cache_tags =
+      tmpl::list<control_system::Tags::MeasurementTimescales,
+                 FunctionsOfTimeTag>;
+  using simple_tags = db::AddSimpleTags<
+      control_system::Tags::FutureMeasurements<systemsA>,
+      control_system::Tags::FutureMeasurements<systemsB>,
+      Tags::TimeStepper<TimeStepper>, Tags::TimeStepId,
+      Tags::Next<Tags::TimeStepId>, Tags::TimeStep, Tags::Next<Tags::TimeStep>,
+      Tags::AdaptiveSteppingDiagnostics, Tags::HistoryEvolvedVariables<Var>>;
+  using compute_tags = db::AddComputeTags<>;
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<Parallel::Phase::Initialization,
+                             tmpl::list<ActionTesting::InitializeDataBox<
+                                 simple_tags, compute_tags>>>,
+      Parallel::PhaseActions<
+          Parallel::Phase::Testing,
+          tmpl::list<control_system::Actions::LimitTimeStep<control_systems>>>>;
+};
+
+struct Metavariables {
+  static constexpr bool local_time_stepping = false;
+  using component_list = tmpl::list<Component<Metavariables>>;
+};
+
+void test(const std::string& test_label, const double initial_time,
+          const double initial_step_end,
+          const std::optional<double>& expected_step_end,
+          const std::vector<std::pair<double, double>>& measurement_updatesA,
+          const std::vector<std::pair<double, double>>& fot_updatesA,
+          const std::vector<std::pair<double, double>>& measurement_updatesBC,
+          const std::vector<std::pair<double, double>>& fot_updatesB,
+          const std::vector<std::pair<double, double>>& fot_updatesC,
+          std::unique_ptr<TimeStepper> stepper =
+              std::make_unique<TimeSteppers::Rk3HesthavenSsp>(),
+          TimeSteppers::History<Var::type> history = {}) {
+  INFO(test_label);
+  ASSERT(measurement_updatesA.size() > 1, "Bad argument");
+  ASSERT(measurement_updatesBC.size() > 1, "Bad argument");
+  ASSERT(fot_updatesA.size() > 1, "Bad argument");
+  ASSERT(fot_updatesB.size() > 1, "Bad argument");
+  ASSERT(fot_updatesC.size() > 1, "Bad argument");
+
+  const Slab initial_slab(initial_time, initial_step_end);
+  const TimeStepId initial_id(true, 0, initial_slab.start());
+
+  const size_t measurements_per_update = 3;
+
+  const auto setup_fot =
+      [](const std::vector<std::pair<double, double>>& updates) {
+        auto fot =
+            std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<0>>(
+                updates.front().first,
+                std::array{DataVector{updates.front().second}},
+                updates[1].first);
+        for (size_t i = 1; i < updates.size() - 1; ++i) {
+          fot->update(updates[i].first, DataVector{updates[i].second},
+                      updates[i + 1].first);
+        }
+        return fot;
+      };
+
+  control_system::Tags::MeasurementTimescales::type timescales{};
+  timescales["LabelA"] = setup_fot(measurement_updatesA);
+  timescales["LabelBLabelC"] = setup_fot(measurement_updatesBC);
+  FunctionsOfTimeTag::type functions_of_time{};
+  functions_of_time["LabelA"] = setup_fot(fot_updatesA);
+  functions_of_time["LabelB"] = setup_fot(fot_updatesB);
+  functions_of_time["LabelC"] = setup_fot(fot_updatesC);
+
+  const auto setup_measurements =
+      [&initial_time](
+          const domain::FunctionsOfTime::FunctionOfTime& timescale) {
+        if (timescale.func(0.0)[0][0] ==
+            std::numeric_limits<double>::infinity()) {
+          return control_system::FutureMeasurements(
+              1, std::numeric_limits<double>::infinity());
+        }
+
+        control_system::FutureMeasurements measurements(measurements_per_update,
+                                                        0.0);
+        measurements.update(timescale);
+        while (measurements.next_measurement().value_or(
+                   std::numeric_limits<double>::infinity()) <= initial_time) {
+          measurements.pop_front();
+        }
+        return measurements;
+      };
+
+  auto measurementsA = setup_measurements(*timescales["LabelA"]);
+  auto measurementsBC = setup_measurements(*timescales["LabelBLabelC"]);
+
+  using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<Metavariables>;
+  using component = Component<Metavariables>;
+  MockRuntimeSystem runner{
+      {}, {std::move(timescales), std::move(functions_of_time)}};
+  ActionTesting::emplace_array_component_and_initialize<component>(
+      make_not_null(&runner), ActionTesting::NodeId{0},
+      ActionTesting::LocalCoreId{0}, 0,
+      {std::move(measurementsA), std::move(measurementsBC), std::move(stepper),
+       initial_id, TimeStepId{}, initial_slab.duration(), TimeDelta{},
+       AdaptiveSteppingDiagnostics{}, std::move(history)});
+
+  ActionTesting::set_phase(make_not_null(&runner), Parallel::Phase::Testing);
+  const bool ready =
+      ActionTesting::next_action_if_ready<component>(make_not_null(&runner), 0);
+  if (ready and expected_step_end.has_value()) {
+    const Slab expected_slab(initial_time, *expected_step_end);
+    CHECK(ActionTesting::get_databox_tag<component, Tags::TimeStep>(
+              runner, 0) == expected_slab.duration());
+  } else {
+    CHECK(not ready);
+    CHECK(not expected_step_end.has_value());
+  }
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.ControlSystem.Actions.LimitTimeStep",
+                  "[Unit][ControlSystem]") {
+  register_classes_with_charm<
+      TimeSteppers::AdamsBashforth, TimeSteppers::AdamsMoultonPc,
+      TimeSteppers::Rk3HesthavenSsp,
+      domain::FunctionsOfTime::PiecewisePolynomial<0>>();
+  const double infinity = std::numeric_limits<double>::infinity();
+  const double nan = std::numeric_limits<double>::signaling_NaN();
+  const double arbitrary = -1234.0;
+
+  // For each active control system below, the interval from the
+  // measurement triggering the update to the FoT expiration time is
+  // indicated as the goal interval.  A step must occur in this
+  // interval to avoid a deadlock.
+
+  // clang-format off
+  test("No control systems", 1.0, 5.0, 5.0,
+       {{0.0, infinity}, {infinity, nan}},
+       {{0.0, arbitrary}, {infinity, nan}},
+       {{0.0, infinity}, {infinity, nan}},
+       {{0.0, arbitrary}, {infinity, nan}},
+       {{0.0, arbitrary}, {infinity, nan}});
+  test("Step much shorter than limit", 1.0, 5.0, 5.0,
+       {{0.0, 10.0}, {50.0, nan}},
+       {{0.0, arbitrary}, {50.0, nan}},  // goal range [20, 50]
+       {{0.0, infinity}, {infinity, nan}},
+       {{0.0, arbitrary}, {infinity, nan}},
+       {{0.0, arbitrary}, {infinity, nan}});
+  test("Limited by expiration", 1.0, 5.0, 4.0,
+       {{0.0, 1.0}, {5.0, nan}},
+       {{0.0, arbitrary}, {4.0, nan}},  // goal range [2, 4]
+       {{0.0, infinity}, {infinity, nan}},
+       {{0.0, arbitrary}, {infinity, nan}},
+       {{0.0, arbitrary}, {infinity, nan}});
+  test("Adjusted to keep steps even", 1.0, 8.0, 6.0,
+       {{0.0, 5.0}, {20.0, nan}},
+       {{0.0, arbitrary}, {11.0, nan}},  // goal range [10, 11]
+       {{0.0, infinity}, {infinity, nan}},
+       {{0.0, arbitrary}, {infinity, nan}},
+       {{0.0, arbitrary}, {infinity, nan}});
+  test("Past update but not to expiration", 1.0, 8.0, 8.0,
+       {{0.0, 3.0}, {20.0, nan}},
+       {{0.0, arbitrary}, {11.0, nan}},  // goal range [6, 11]
+       {{0.0, infinity}, {infinity, nan}},
+       {{0.0, arbitrary}, {infinity, nan}},
+       {{0.0, arbitrary}, {infinity, nan}});
+  test("Limited by expiration, 2 systems", 1.0, 7.0, 5.0,
+       {{0.0, infinity}, {infinity, nan}},
+       {{0.0, arbitrary}, {infinity, nan}},
+       {{0.0, 1.0}, {5.0, nan}},
+       {{0.0, arbitrary}, {5.0, nan}},  // goal range [2, 5]
+       {{0.0, arbitrary}, {6.0, nan}});  // goal range [2, 6]
+  test("Limited by expiration, 2 measurements", 1.0, 6.0, 5.0,
+       {{0.0, 2.0}, {10.0, nan}},
+       {{0.0, arbitrary}, {6.0, nan}},  // goal range [4, 6]
+       {{0.0, 1.0}, {5.0, nan}},
+       {{0.0, arbitrary}, {5.0, nan}},  // goal range [2, 5]
+       {{0.0, arbitrary}, {infinity, nan}});
+  test("Adjusted to keep steps even, 2 systems", 1.0, 11.0, 7.0,
+       {{0.0, 6.0}, {20.0, nan}},
+       {{0.0, arbitrary}, {13.0, nan}},  // goal range [12, 13]
+       {{0.0, 2.0}, {20.0, nan}},
+       {{0.0, arbitrary}, {15.0, nan}},  // goal range [4, 15]
+       {{0.0, arbitrary}, {infinity, nan}});
+  test("Adjusted to keep steps even, limited by update", 1.0, 11.0, 8.0,
+       {{0.0, 6.0}, {20.0, nan}},
+       {{0.0, arbitrary}, {13.0, nan}},  // goal range [12, 13]
+       {{0.0, 4.0}, {20.0, nan}},
+       {{0.0, arbitrary}, {15.0, nan}},  // goal range [8, 15]
+       {{0.0, arbitrary}, {infinity, nan}});
+  test("Would be limited by expiration as of now", 1.0, 5.0, 5.0,
+       {{0.0, 2.0}, {5.0, nan}},
+       {{0.0, arbitrary}, {2.0, arbitrary}, {20.0, nan}},  // goal range [4, 20]
+       {{0.0, infinity}, {infinity, nan}},
+       {{0.0, arbitrary}, {infinity, nan}},
+       {{0.0, arbitrary}, {infinity, nan}});
+  test("Insufficient timescale data", 1.0, 5.0, std::nullopt,
+       {{0.0, 10.0}, {5.0, nan}},
+       {{0.0, arbitrary}, {50.0, nan}},  // goal range [?, ?]
+       {{0.0, infinity}, {infinity, nan}},
+       {{0.0, arbitrary}, {infinity, nan}},
+       {{0.0, arbitrary}, {infinity, nan}});
+  test("Barely sufficient timescale data", 1.0, 5.0, 5.0,
+       {{0.0, 10.0}, {10.0, nan}},
+       {{0.0, arbitrary}, {50.0, nan}},  // goal range [20, 50]
+       {{0.0, infinity}, {infinity, nan}},
+       {{0.0, arbitrary}, {infinity, nan}},
+       {{0.0, arbitrary}, {infinity, nan}});
+  test("Insufficient FoT data", 1.0, 5.0, std::nullopt,
+       {{0.0, 10.0}, {50.0, nan}},
+       {{0.0, arbitrary}, {15.0, nan}},  // goal range [20, ?]
+       {{0.0, infinity}, {infinity, nan}},
+       {{0.0, arbitrary}, {infinity, nan}},
+       {{0.0, arbitrary}, {infinity, nan}});
+  test("Barely insufficient FoT data", 1.0, 5.0, std::nullopt,
+       {{0.0, 10.0}, {50.0, nan}},
+       {{0.0, arbitrary}, {20.0, nan}},  // goal range [20, ?]
+       {{0.0, infinity}, {infinity, nan}},
+       {{0.0, arbitrary}, {infinity, nan}},
+       {{0.0, arbitrary}, {infinity, nan}});
+
+  test("Does nothing with Adams-Bashforth", 1.0, 5.0, 5.0,
+       {{0.0, 1.0}, {5.0, nan}},
+       {{0.0, arbitrary}, {3.0, nan}},  // goal range [2, 3]
+       {{0.0, infinity}, {infinity, nan}},
+       {{0.0, arbitrary}, {infinity, nan}},
+       {{0.0, arbitrary}, {infinity, nan}},
+       std::make_unique<TimeSteppers::AdamsBashforth>(4));
+  test("Doesn't need data with Adams-Bashforth", 1.0, 5.0, 5.0,
+       {{0.0, 10.0}, {5.0, nan}},
+       {{0.0, arbitrary}, {50.0, nan}},  // goal range [?, ?]
+       {{0.0, infinity}, {infinity, nan}},
+       {{0.0, arbitrary}, {infinity, nan}},
+       {{0.0, arbitrary}, {infinity, nan}},
+       std::make_unique<TimeSteppers::AdamsBashforth>(4));
+
+  TimeSteppers::History<Var::type> history{};
+  history.insert(TimeStepId(true, -1, Time(Slab(1.0, 5.0), {1, 2})), {}, {});
+  history.insert(TimeStepId(true, 0, Slab(1.0, 5.0).start()), {}, {});
+  test("Step can't change but is OK", 1.0, 5.0, 5.0,
+       {{0.0, 10.0}, {50.0, nan}},
+       {{0.0, arbitrary}, {50.0, nan}},  // goal range [20, 50]
+       {{0.0, infinity}, {infinity, nan}},
+       {{0.0, arbitrary}, {infinity, nan}},
+       {{0.0, arbitrary}, {infinity, nan}},
+       std::make_unique<TimeSteppers::AdamsMoultonPc>(4), history);
+  CHECK_THROWS_WITH(
+      test("Step can't change but is not OK", 1.0, 5.0, 0.0,
+           {{0.0, 1.0}, {5.0, nan}},
+           {{0.0, arbitrary}, {4.0, nan}},  // goal range [2, 4]
+           {{0.0, infinity}, {infinity, nan}},
+           {{0.0, arbitrary}, {infinity, nan}},
+           {{0.0, arbitrary}, {infinity, nan}},
+           std::make_unique<TimeSteppers::AdamsMoultonPc>(4), history),
+      Catch::Matchers::ContainsSubstring(
+          "Step must be decreased to avoid control-system deadlock, but "
+          "time-stepper requires a fixed step size."));
+  // clang-format on
+}

--- a/tests/Unit/Domain/FunctionsOfTime/Test_ThreadsafeList.cpp
+++ b/tests/Unit/Domain/FunctionsOfTime/Test_ThreadsafeList.cpp
@@ -3,6 +3,7 @@
 
 #include "Framework/TestingFramework.hpp"
 
+#include <limits>
 #include <utility>
 
 #include "Domain/FunctionsOfTime/ThreadsafeList.hpp"
@@ -129,6 +130,16 @@ SPECTRE_TEST_CASE("Unit.Domain.FunctionsOfTime.ThreadsafeList",
     ++it;
     CHECK(it == list.end());
     CHECK_FALSE(it != list.end());
+  }
+
+  {
+    ThreadsafeList<int> infinite_list(0.0);
+    infinite_list.insert(0.0, 1, std::numeric_limits<double>::infinity());
+    CHECK(infinite_list.expiration_after(
+              std::numeric_limits<double>::infinity()) ==
+          std::numeric_limits<double>::infinity());
+    CHECK(infinite_list.expiration_after(1.0) ==
+          std::numeric_limits<double>::infinity());
   }
 
   CHECK_THROWS_WITH(

--- a/tests/Unit/Time/CMakeLists.txt
+++ b/tests/Unit/Time/CMakeLists.txt
@@ -7,6 +7,7 @@ set(LIBRARY_SOURCES
   Test_AdaptiveSteppingDiagnostics.cpp
   Test_ApproximateTime.cpp
   Test_BoundaryHistory.cpp
+  Test_ChangeSlabSize.cpp
   Test_ChooseLtsStepSize.cpp
   Test_EvolutionOrdering.cpp
   Test_History.cpp

--- a/tests/Unit/Time/Test_ChangeSlabSize.cpp
+++ b/tests/Unit/Time/Test_ChangeSlabSize.cpp
@@ -1,0 +1,171 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <utility>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataBox/Tag.hpp"
+#include "Time/AdaptiveSteppingDiagnostics.hpp"
+#include "Time/ChangeSlabSize.hpp"
+#include "Time/History.hpp"
+#include "Time/Slab.hpp"
+#include "Time/Tags/AdaptiveSteppingDiagnostics.hpp"
+#include "Time/Tags/HistoryEvolvedVariables.hpp"
+#include "Time/Tags/TimeStep.hpp"
+#include "Time/Tags/TimeStepId.hpp"
+#include "Time/Tags/TimeStepper.hpp"
+#include "Time/Time.hpp"
+#include "Time/TimeStepId.hpp"
+#include "Time/TimeSteppers/AdamsBashforth.hpp"
+#include "Time/TimeSteppers/Rk3HesthavenSsp.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace {
+struct Vars1 : db::SimpleTag {
+  using type = double;
+};
+
+struct Vars2 : db::SimpleTag {
+  using type = double;
+};
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Time.ChangeSlabSize", "[Unit][Time]") {
+  // Forward in time, no substeps
+  {
+    const TimeSteppers::AdamsBashforth time_stepper(1);
+    const Slab initial_slab(2.0, 3.0);
+    const TimeStepId initial_id(true, 5, initial_slab.start());
+    const TimeDelta initial_step = initial_slab.duration();
+    const TimeStepId next_id =
+        time_stepper.next_time_id(initial_id, initial_step);
+    const TimeDelta next_step{};  // overwritten by function
+    const AdaptiveSteppingDiagnostics diagnostics{20, 30, 40, 50, 60};
+    TimeSteppers::History<Vars1::type> history1{};
+    TimeSteppers::History<Vars2::type> history2{};
+    history2.insert(initial_id, 1.23, 4.56);
+
+    auto box = db::create<db::AddSimpleTags<
+        Tags::TimeStepper<TimeSteppers::AdamsBashforth>, Tags::TimeStepId,
+        Tags::TimeStep, Tags::Next<Tags::TimeStepId>,
+        Tags::Next<Tags::TimeStep>, Tags::AdaptiveSteppingDiagnostics,
+        Tags::HistoryEvolvedVariables<Vars1>,
+        Tags::HistoryEvolvedVariables<Vars2>>>(
+        std::make_unique<TimeSteppers::AdamsBashforth>(time_stepper),
+        initial_id, initial_step, next_id, next_step, diagnostics,
+        std::move(history1), std::move(history2));
+
+    change_slab_size(make_not_null(&box), 5.0);
+
+    const Slab new_slab(2.0, 5.0);
+    const TimeStepId expected_id(true, 5, new_slab.start());
+    const TimeDelta expected_step = new_slab.duration();
+    const TimeStepId expected_next_id =
+        time_stepper.next_time_id(expected_id, expected_step);
+    const TimeDelta expected_next_step = expected_step;
+    auto expected_diagnostics = diagnostics;
+    ++expected_diagnostics.number_of_slab_size_changes;
+    TimeSteppers::History<Vars1::type> expected_history1{};
+    TimeSteppers::History<Vars2::type> expected_history2{};
+    expected_history2.insert(expected_id, 1.23, 4.56);
+
+    CHECK(db::get<Tags::TimeStepId>(box) == expected_id);
+    CHECK(db::get<Tags::TimeStep>(box) == expected_step);
+    CHECK(db::get<Tags::Next<Tags::TimeStepId>>(box) == expected_next_id);
+    CHECK(db::get<Tags::Next<Tags::TimeStep>>(box) == expected_next_step);
+    CHECK(db::get<Tags::AdaptiveSteppingDiagnostics>(box) ==
+          expected_diagnostics);
+    CHECK(db::get<Tags::HistoryEvolvedVariables<Vars1>>(box) ==
+          expected_history1);
+    CHECK(db::get<Tags::HistoryEvolvedVariables<Vars2>>(box) ==
+          expected_history2);
+  }
+
+  // Backward in time, substep method
+  {
+    const TimeSteppers::Rk3HesthavenSsp time_stepper{};
+    const Slab initial_slab(2.0, 3.0);
+    const TimeStepId initial_id(false, 5, initial_slab.end());
+    const TimeDelta initial_step = -initial_slab.duration();
+    const TimeStepId next_id =
+        time_stepper.next_time_id(initial_id, initial_step);
+    const TimeDelta next_step{};  // overwritten by function
+    const AdaptiveSteppingDiagnostics diagnostics{20, 30, 40, 50, 60};
+    TimeSteppers::History<Vars1::type> history1{};
+    TimeSteppers::History<Vars2::type> history2{};
+    history2.insert(initial_id, 1.23, 4.56);
+
+    auto box = db::create<db::AddSimpleTags<
+        Tags::TimeStepper<TimeSteppers::Rk3HesthavenSsp>, Tags::TimeStepId,
+        Tags::TimeStep, Tags::Next<Tags::TimeStepId>,
+        Tags::Next<Tags::TimeStep>, Tags::AdaptiveSteppingDiagnostics,
+        Tags::HistoryEvolvedVariables<Vars1>,
+        Tags::HistoryEvolvedVariables<Vars2>>>(
+        std::make_unique<TimeSteppers::Rk3HesthavenSsp>(time_stepper),
+        initial_id, initial_step, next_id, next_step, diagnostics,
+        std::move(history1), std::move(history2));
+
+    change_slab_size(make_not_null(&box), -1.0);
+
+    const Slab new_slab(-1.0, 3.0);
+    const TimeStepId expected_id(false, 5, new_slab.end());
+    const TimeDelta expected_step = -new_slab.duration();
+    const TimeStepId expected_next_id =
+        time_stepper.next_time_id(expected_id, expected_step);
+    const TimeDelta expected_next_step = expected_step;
+    auto expected_diagnostics = diagnostics;
+    ++expected_diagnostics.number_of_slab_size_changes;
+    TimeSteppers::History<Vars1::type> expected_history1{};
+    TimeSteppers::History<Vars2::type> expected_history2{};
+    expected_history2.insert(expected_id, 1.23, 4.56);
+
+    CHECK(db::get<Tags::TimeStepId>(box) == expected_id);
+    CHECK(db::get<Tags::TimeStep>(box) == expected_step);
+    CHECK(db::get<Tags::Next<Tags::TimeStepId>>(box) == expected_next_id);
+    CHECK(db::get<Tags::Next<Tags::TimeStep>>(box) == expected_next_step);
+    CHECK(db::get<Tags::AdaptiveSteppingDiagnostics>(box) ==
+          expected_diagnostics);
+    CHECK(db::get<Tags::HistoryEvolvedVariables<Vars1>>(box) ==
+          expected_history1);
+    CHECK(db::get<Tags::HistoryEvolvedVariables<Vars2>>(box) ==
+          expected_history2);
+  }
+
+  // No change
+  {
+    const TimeSteppers::AdamsBashforth time_stepper(1);
+    const Slab initial_slab(2.0, 3.0);
+    const TimeStepId initial_id(true, 5, initial_slab.start());
+    const TimeDelta initial_step = initial_slab.duration();
+    const TimeStepId next_id =
+        time_stepper.next_time_id(initial_id, initial_step);
+    const TimeDelta next_step = initial_step / 2;
+    const AdaptiveSteppingDiagnostics diagnostics{20, 30, 40, 50, 60};
+    TimeSteppers::History<Vars1::type> history1{};
+    TimeSteppers::History<Vars2::type> history2{};
+    history2.insert(initial_id, 1.23, 4.56);
+
+    auto box = db::create<db::AddSimpleTags<
+        Tags::TimeStepper<TimeSteppers::AdamsBashforth>, Tags::TimeStepId,
+        Tags::TimeStep, Tags::Next<Tags::TimeStepId>,
+        Tags::Next<Tags::TimeStep>, Tags::AdaptiveSteppingDiagnostics,
+        Tags::HistoryEvolvedVariables<Vars1>,
+        Tags::HistoryEvolvedVariables<Vars2>>>(
+        std::make_unique<TimeSteppers::AdamsBashforth>(time_stepper),
+        initial_id, initial_step, next_id, next_step, diagnostics, history1,
+        history2);
+
+    change_slab_size(make_not_null(&box), 3.0);
+
+    CHECK(db::get<Tags::TimeStepId>(box) == initial_id);
+    CHECK(db::get<Tags::TimeStep>(box) == initial_step);
+    CHECK(db::get<Tags::Next<Tags::TimeStepId>>(box) == next_id);
+    CHECK(db::get<Tags::Next<Tags::TimeStep>>(box) == next_step);
+    CHECK(db::get<Tags::AdaptiveSteppingDiagnostics>(box) == diagnostics);
+    CHECK(db::get<Tags::HistoryEvolvedVariables<Vars1>>(box) == history1);
+    CHECK(db::get<Tags::HistoryEvolvedVariables<Vars2>>(box) == history2);
+  }
+}

--- a/tests/Unit/Time/TimeSteppers/Test_AdamsMoultonPc.cpp
+++ b/tests/Unit/Time/TimeSteppers/Test_AdamsMoultonPc.cpp
@@ -78,6 +78,8 @@ SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.AdamsMoultonPc", "[Unit][Time]") {
   CHECK_FALSE(can_change(true, mid, end, start));
   CHECK_FALSE(can_change(true, end, start, mid));
   CHECK_FALSE(can_change(true, end, mid, start));
+  CHECK(can_change(true, start, mid, mid));
+  CHECK_FALSE(can_change(true, start, mid, start));
 
   CHECK(can_change(false, end, mid, start));
   CHECK_FALSE(can_change(false, end, start, mid));
@@ -85,6 +87,8 @@ SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.AdamsMoultonPc", "[Unit][Time]") {
   CHECK_FALSE(can_change(false, mid, start, end));
   CHECK_FALSE(can_change(false, start, end, mid));
   CHECK_FALSE(can_change(false, start, mid, end));
+  CHECK(can_change(false, end, mid, mid));
+  CHECK_FALSE(can_change(false, end, mid, end));
 
   {
     TimeSteppers::AdamsMoultonPc am4(4);


### PR DESCRIPTION
## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
Executables with control systems and global time-stepping will now work with any time stepper, not just AdamsBashforth.  When using a non-AdamsBashforth time stepper the step size will gradually decrease, so you should include the ChangeSlabSize event to increase it again.
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
