### PR TITLE
Print more info on AHfinder failure.

### DIFF
--- a/src/ParallelAlgorithms/ApparentHorizonFinder/Callbacks/ErrorOnFailedApparentHorizon.hpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/Callbacks/ErrorOnFailedApparentHorizon.hpp
@@ -3,7 +3,12 @@
 
 #pragma once
 
+#include <sstream>
+
+#include "DataStructures/DataBox/DataBox.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/FastFlow.hpp"
+#include "ParallelAlgorithms/Interpolation/InterpolationTargetDetail.hpp"
+#include "ParallelAlgorithms/Interpolation/Tags.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/PrettyType.hpp"
 
@@ -24,13 +29,41 @@ namespace intrp::callbacks {
 struct ErrorOnFailedApparentHorizon {
   template <typename InterpolationTargetTag, typename DbTags,
             typename Metavariables, typename TemporalId>
-  static void apply(const db::DataBox<DbTags>& /*box*/,
+  static void apply(const db::DataBox<DbTags>& box,
                     const Parallel::GlobalCache<Metavariables>& /*cache*/,
-                    const TemporalId& /*temporal_id*/,
+                    const TemporalId& temporal_id,
                     const FastFlow::Status failure_reason) {
+    if (failure_reason == FastFlow::Status::InterpolationFailure) {
+      const auto& invalid_indices =
+          db::get<::intrp::Tags::IndicesOfInvalidInterpPoints<TemporalId>>(box);
+      if (invalid_indices.find(temporal_id) != invalid_indices.end() and
+          not invalid_indices.at(temporal_id).empty()) {
+        // There are invalid points (i.e. points that could not be
+        // interpolated). Print info about those points.
+
+        // First get the actual points
+        const auto coords =
+            InterpolationTargetTag::compute_target_points::points(
+                box, tmpl::type_<Metavariables>{}, temporal_id);
+
+        // Now output some information about them
+        std::ostringstream os;
+        os << "\nInvalid points (in Strahlkorper frame) at time "
+           << InterpolationTarget_detail::get_temporal_id_value(temporal_id)
+           << " are:\n";
+        for (const auto index : invalid_indices.at(temporal_id)) {
+          os << "(" << get<0>(coords)[index] << "," << get<1>(coords)[index]
+             << "," << get<2>(coords)[index] << ")\n";
+        }
+        ERROR("Apparent horizon finder "
+              << pretty_type::name<InterpolationTargetTag>()
+              << " failed, reason = " << failure_reason << os.str());
+      }
+    }
     ERROR("Apparent horizon finder "
           << pretty_type::name<InterpolationTargetTag>()
-          << " failed, reason = " << failure_reason);
+          << " failed, reason = " << failure_reason << " at time "
+          << InterpolationTarget_detail::get_temporal_id_value(temporal_id));
   }
 };
 


### PR DESCRIPTION
## Proposed changes

If the AH finder fails because it cannot interpolate to some points, now it prints the
points that it cannot interpolate to.

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
