### PR TITLE
Add function for contracting the first N indices of two Tensors

### DIFF
--- a/src/DataStructures/Tensor/CMakeLists.txt
+++ b/src/DataStructures/Tensor/CMakeLists.txt
@@ -5,6 +5,7 @@ spectre_target_headers(
   ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
+  ContractFirstNIndices.hpp
   Identity.hpp
   IndexType.hpp
   Metafunctions.hpp

--- a/src/DataStructures/Tensor/ContractFirstNIndices.hpp
+++ b/src/DataStructures/Tensor/ContractFirstNIndices.hpp
@@ -1,0 +1,288 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <tuple>
+#include <utility>
+
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/MakeWithValue.hpp"
+#include "Utilities/TMPL.hpp"
+
+template <typename X, typename Symm, typename IndexList>
+class Tensor;
+
+namespace detail {
+// Get the values that encode the generic tensor indices for the first operand,
+// second operand, and result tensor so that the first NumIndicesToContract
+// indices will contract and the TensorExpression written with them will be
+// valid
+//
+// Note: Implementation assumes that the indices in the index pairs to contract
+// have the same type (spatial or spacetime)
+template <size_t NumIndicesToContract, size_t NumIndices1, size_t NumIndices2>
+constexpr auto
+get_tensor_index_values_for_tensors_to_contract_and_result_tensor(
+    const std::array<bool, NumIndices1>& index_type_is_spacetime1,
+    const std::array<bool, NumIndices1>& valence_is_lower1,
+    const std::array<bool, NumIndices2>& index_type_is_spacetime2,
+    const std::array<bool, NumIndices2>& valence_is_lower2) {
+  constexpr size_t num_result_indices =
+      NumIndices1 + NumIndices2 - 2 * NumIndicesToContract;
+
+  // (first op index values, second op index values, result tensor index values)
+  std::tuple<std::array<size_t, NumIndices1>, std::array<size_t, NumIndices2>,
+             std::array<size_t, num_result_indices>>
+      tensor_index_values{};
+
+  // the next lower spacetime index value that we have not yet used
+  size_t next_lower_spacetime_value = 0;
+  // the next lower spatial index value that we have not yet used
+  size_t next_lower_spatial_value = tenex::TensorIndex_detail::spatial_sentinel;
+
+  // assign first operand's tensor index values
+  for (size_t i = 0; i < NumIndices1; i++) {
+    const bool index1_is_spacetime = gsl::at(index_type_is_spacetime1, i);
+    const bool index1_is_lower = gsl::at(valence_is_lower1, i);
+    if (index1_is_spacetime) {
+      gsl::at(std::get<0>(tensor_index_values), i) =
+          index1_is_lower ? next_lower_spacetime_value
+                          : tenex::get_tensorindex_value_with_opposite_valence(
+                                next_lower_spacetime_value);
+      next_lower_spacetime_value++;
+    } else {
+      gsl::at(std::get<0>(tensor_index_values), i) =
+          index1_is_lower ? next_lower_spatial_value
+                          : tenex::get_tensorindex_value_with_opposite_valence(
+                                next_lower_spatial_value);
+      next_lower_spatial_value++;
+    }
+  }
+
+  // assign the first NumIndicesToContract index values of the second operand so
+  // that they will contract with the first NumIndicesToContract indices of the
+  // first operand
+  for (size_t i = 0; i < NumIndicesToContract; i++) {
+    gsl::at(std::get<1>(tensor_index_values), i) =
+        tenex::get_tensorindex_value_with_opposite_valence(
+            gsl::at(std::get<0>(tensor_index_values), i));
+  }
+
+  // assign the remaining index values of the second operand so that they are
+  // not duplicates of any previously-used indices
+  for (size_t i = NumIndicesToContract; i < NumIndices2; i++) {
+    const bool index2_is_spacetime = gsl::at(index_type_is_spacetime2, i);
+    const bool index2_is_lower = gsl::at(valence_is_lower2, i);
+    if (index2_is_spacetime) {
+      gsl::at(std::get<1>(tensor_index_values), i) =
+          index2_is_lower ? next_lower_spacetime_value
+                          : tenex::get_tensorindex_value_with_opposite_valence(
+                                next_lower_spacetime_value);
+      next_lower_spacetime_value++;
+    } else {
+      gsl::at(std::get<1>(tensor_index_values), i) =
+          index2_is_lower ? next_lower_spatial_value
+                          : tenex::get_tensorindex_value_with_opposite_valence(
+                                next_lower_spatial_value);
+      next_lower_spatial_value++;
+    }
+  }
+
+  // assign the free indices of the first operand to the result tensor indices
+  for (size_t i = 0; i < NumIndices1 - NumIndicesToContract; i++) {
+    gsl::at(std::get<2>(tensor_index_values), i) =
+        gsl::at(std::get<0>(tensor_index_values), i + NumIndicesToContract);
+  }
+
+  // assign the free indices of the second operand to the result tensor indices
+  for (size_t i = 0; i < NumIndices2 - NumIndicesToContract; i++) {
+    gsl::at(std::get<2>(tensor_index_values),
+            i + NumIndices1 - NumIndicesToContract) =
+        gsl::at(std::get<1>(tensor_index_values), i + NumIndicesToContract);
+  }
+
+  return tensor_index_values;
+}
+
+// \brief Helper struct for contracting the first `NumIndicesToContract`
+// indices of two `Tensor`s
+//
+// \tparam NumIndicesToContract the number of indices to contract
+// \param T1 the type of the first `Tensor` of the two to contract
+// \param T2 the type of the second `Tensor` of the two to contract
+template <size_t NumIndicesToContract, typename T1, typename T2,
+          size_t NumIndices1 = tmpl::size<typename T1::symmetry>::value,
+          size_t NumIndices2 = tmpl::size<typename T2::symmetry>::value,
+          size_t NumResultIndices =
+              NumIndices1 + NumIndices2 - 2 * NumIndicesToContract,
+          typename ContractedIndicesSeq =
+              std::make_index_sequence<NumIndicesToContract>,
+          typename TensorIndices1Seq = std::make_index_sequence<NumIndices1>,
+          typename TensorIndices2Seq = std::make_index_sequence<NumIndices2>,
+          typename ResultIndicesSeq =
+              std::make_index_sequence<NumResultIndices>>
+struct contract_first_n_indices_impl;
+
+template <size_t NumIndicesToContract, typename X1, typename Symm1,
+          typename... Indices1, typename X2, typename Symm2,
+          typename... Indices2, size_t NumIndices1, size_t NumIndices2,
+          size_t NumResultIndices, size_t... ContractedIndicesInts,
+          size_t... Ints1, size_t... Ints2, size_t... ResultInts>
+struct contract_first_n_indices_impl<
+    NumIndicesToContract, Tensor<X1, Symm1, tmpl::list<Indices1...>>,
+    Tensor<X2, Symm2, tmpl::list<Indices2...>>, NumIndices1, NumIndices2,
+    NumResultIndices, std::index_sequence<ContractedIndicesInts...>,
+    std::index_sequence<Ints1...>, std::index_sequence<Ints2...>,
+    std::index_sequence<ResultInts...>> {
+  static_assert(NumIndicesToContract <= sizeof...(Indices1) and
+                    NumIndicesToContract <= sizeof...(Indices2),
+                "Cannot request to contract more indices than indices in "
+                "either of the two Tensors to contract.");
+
+  static constexpr std::array<bool, NumIndices1> valence_is_lower1 = {
+      {(Indices1::ul == UpLo::Lo)...}};
+  static constexpr std::array<bool, NumIndices2> valence_is_lower2 = {
+      {(Indices2::ul == UpLo::Lo)...}};
+  static constexpr std::array<bool, NumIndices1> index_type_is_spacetime1 = {
+      {(Indices1::index_type == IndexType::Spacetime)...}};
+  static constexpr std::array<bool, NumIndices2> index_type_is_spacetime2 = {
+      {(Indices2::index_type == IndexType::Spacetime)...}};
+
+  // if this is removed and support for automatic contraction of a spatial index
+  // with a spacetime index is wanted, the implementation of
+  // get_tensor_index_values_for_tensors_to_contract_and_result_tensor() also
+  // needs to be updated to support this
+  static_assert(
+      (... and (index_type_is_spacetime1[ContractedIndicesInts] ==
+                index_type_is_spacetime2[ContractedIndicesInts])),
+      "You are trying to automatically contract a spatial index with a "
+      "spacetime index, but this is not supported for "
+      "contract_first_n_indices().");
+
+  // the values of the generic indices (i.e. `TensorIndex::value`s) that
+  // uniquely identify different generic indices
+  static constexpr auto tensor_index_values =
+      get_tensor_index_values_for_tensors_to_contract_and_result_tensor<
+          NumIndicesToContract>(index_type_is_spacetime1, valence_is_lower1,
+                                index_type_is_spacetime2, valence_is_lower2);
+  static constexpr std::array<size_t, NumIndices1> tensor_index_values1 =
+      std::get<0>(tensor_index_values);
+  static constexpr std::array<size_t, NumIndices2> tensor_index_values2 =
+      std::get<1>(tensor_index_values);
+  static constexpr std::array<size_t, NumResultIndices>
+      result_tensor_index_values = std::get<2>(tensor_index_values);
+
+  using lhs_tensorindex_list =
+      tmpl::list<TensorIndex<result_tensor_index_values[ResultInts]>...>;
+
+  // \brief Contract first N indices by evaluating a `TensorExpression`
+  //
+  // \param lhs_tensor the result LHS `Tensor`
+  // \param tensor1 the first `Tensor` of the two to contract
+  // \param tensor2 the second `Tensor` of the two to contract
+  template <typename LhsTensor>
+  static void apply(const gsl::not_null<LhsTensor*> lhs_tensor,
+                    const Tensor<X1, Symm1, tmpl::list<Indices1...>>& tensor1,
+                    const Tensor<X2, Symm2, tmpl::list<Indices2...>>& tensor2) {
+    constexpr bool evaluate_subtrees =
+        decltype(tensor1(TensorIndex<tensor_index_values1[Ints1]>{}...) *
+                 tensor2(TensorIndex<tensor_index_values2[Ints2]>{}...))::
+            primary_subtree_contains_primary_start;
+    // Calls `evaluate_impl()` instead of `evaluate()` because `evaluate()`
+    // takes `TensorIndex` lvalue references as template parameters, but here we
+    // have `TensorIndex` types, and `evaluate()` cannot be overloaded to accept
+    // both the former and the latter, so we simply circumvent the "top level"
+    // `evaluate()` call that is normally used when evaluating the result of a
+    // `TensorExpression`
+    tenex::detail::evaluate_impl<
+        evaluate_subtrees,
+        TensorIndex<result_tensor_index_values[ResultInts]>...>(
+        lhs_tensor, tensor1(TensorIndex<tensor_index_values1[Ints1]>{}...) *
+                        tensor2(TensorIndex<tensor_index_values2[Ints2]>{}...));
+  }
+
+  // \brief Contract first N indices by evaluating a `TensorExpression`
+  //
+  // \param tensor1 the first `Tensor` of the two to contract
+  // \param tensor2 the second `Tensor` of the two to contract
+  static auto apply(const Tensor<X1, Symm1, tmpl::list<Indices1...>>& tensor1,
+                    const Tensor<X2, Symm2, tmpl::list<Indices2...>>& tensor2) {
+    using rhs_expression =
+        decltype(tensor1(TensorIndex<tensor_index_values1[Ints1]>{}...) *
+                 tensor2(TensorIndex<tensor_index_values2[Ints2]>{}...));
+    using rhs_tensorindex_list = typename rhs_expression::args_list;
+    using rhs_symmetry = typename rhs_expression::symmetry;
+    using rhs_tensorindextype_list = typename rhs_expression::index_list;
+
+    using lhs_tensor_symm_and_indices =
+        tenex::LhsTensorSymmAndIndices<rhs_tensorindex_list,
+                                       lhs_tensorindex_list, rhs_symmetry,
+                                       rhs_tensorindextype_list>;
+
+    Tensor<typename rhs_expression::type,
+           typename lhs_tensor_symm_and_indices::symmetry,
+           typename lhs_tensor_symm_and_indices::tensorindextype_list>
+        lhs_tensor{};
+
+    apply(make_not_null(&lhs_tensor), tensor1, tensor2);
+
+    return lhs_tensor;
+  }
+};
+}  // namespace detail
+
+/// \ingroup TensorGroup
+/// \brief Contract the first N indices of two `Tensor`s
+///
+/// \details
+/// The indices of `lhs_tensor` should be the concatenation of the uncontracted
+/// indices of `tensor1` and the uncontracted indices of `tensor2`, in this
+/// order. For example, if `tensor1` is rank 3, `tensor2` is rank 4, and we want
+/// to contract the first two indices, the indices of `lhs_tensor` need to be
+/// the last index of `tensor1` followed by the 3rd index and then the 4th index
+/// of `tensor2`.
+///
+/// The index types (spatial or spacetime) must be the same for the two indices
+/// in a pair of indices being contracted. Support can be added to this function
+/// to automatically contract the spatial indices of a spacetime index with a
+/// spatial index.
+///
+/// \tparam NumIndicesToContract the number of indices to contract
+/// \param lhs_tensor the result LHS `Tensor`
+/// \param tensor1 the first `Tensor` of the two to contract
+/// \param tensor2 the second `Tensor` of the two to contract
+template <size_t NumIndicesToContract, typename LhsTensor, typename T1,
+          typename T2>
+void contract_first_n_indices(const gsl::not_null<LhsTensor*> lhs_tensor,
+                              const T1& tensor1, const T2& tensor2) {
+  detail::contract_first_n_indices_impl<NumIndicesToContract, T1, T2>::apply(
+      lhs_tensor, tensor1, tensor2);
+}
+
+/// \ingroup TensorGroup
+/// \brief Contract the first N indices of two `Tensor`s
+///
+/// \details
+/// The indices of the returned `Tensor` will be the concatenation of the
+/// uncontracted indices of `tensor1` and the uncontracted indices of `tensor2`,
+/// in this order. For example, if `tensor1` is rank 3, `tensor2` is rank 4, and
+/// we want to contract the first two indices, the indices of the returned
+/// `Tensor` will be the last index of `tensor1` followed by the 3rd index and
+/// then the 4th index of `tensor2`.
+///
+/// The index types (spatial or spacetime) must be the same for the two indices
+/// in a pair of indices being contracted. Support can be added to this function
+/// to automatically contract the spatial indices of a spacetime index with a
+/// spatial index.
+///
+/// \tparam NumIndicesToContract the number of indices to contract
+/// \param tensor1 the first `Tensor` of the two to contract
+/// \param tensor2 the second `Tensor` of the two to contract
+template <size_t NumIndicesToContract, typename T1, typename T2>
+auto contract_first_n_indices(const T1& tensor1, const T2& tensor2) {
+  return detail::contract_first_n_indices_impl<NumIndicesToContract, T1,
+                                               T2>::apply(tensor1, tensor2);
+}

--- a/tests/Unit/DataStructures/Tensor/CMakeLists.txt
+++ b/tests/Unit/DataStructures/Tensor/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY "Test_Tensor")
 
 set(LIBRARY_SOURCES
+  Test_ContractFirstNIndices.cpp
   Test_Identity.cpp
   Test_Metafunctions.cpp
   Test_Slice.cpp

--- a/tests/Unit/DataStructures/Tensor/Test_ContractFirstNIndices.cpp
+++ b/tests/Unit/DataStructures/Tensor/Test_ContractFirstNIndices.cpp
@@ -1,0 +1,153 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <climits>
+#include <cstddef>
+#include <random>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/ContractFirstNIndices.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeWithValue.hpp"
+
+namespace {
+
+template <typename Generator, typename DataType>
+void test(const gsl::not_null<Generator*> generator,
+          const DataType& used_for_size) {
+  std::uniform_real_distribution<> distribution(-1.0, 1.0);
+
+  const auto U = make_with_random_values<tnsr::i<DataType, 3, Frame::Grid>>(
+      generator, distribution, used_for_size);
+  const auto V = make_with_random_values<tnsr::ii<DataType, 3, Frame::Grid>>(
+      generator, distribution, used_for_size);
+
+  using UV_type = tnsr::ijj<DataType, 3, Frame::Grid>;
+  // contract 0 indices
+  const UV_type UV_returned = contract_first_n_indices<0>(U, V);
+  UV_type UV_filled{};
+  contract_first_n_indices<0>(make_not_null(&UV_filled), U, V);
+
+  for (size_t i = 0; i < 3; i++) {
+    for (size_t j = 0; j < 3; j++) {
+      for (size_t k = j; k < 3; k++) {
+        const auto expected_result = U.get(i) * V.get(j, k);
+
+        CHECK_ITERABLE_APPROX(UV_returned.get(i, j, k), expected_result);
+        CHECK_ITERABLE_APPROX(UV_filled.get(i, j, k), expected_result);
+      }
+    }
+  }
+
+  const auto R =
+      make_with_random_values<tnsr::abc<DataType, 3, Frame::Inertial>>(
+          generator, distribution, used_for_size);
+  const auto S =
+      make_with_random_values<tnsr::ABc<DataType, 3, Frame::Inertial>>(
+          generator, distribution, used_for_size);
+
+  // tnsr::abCd
+  using RS1_type =
+      Tensor<DataType, Symmetry<4, 3, 2, 1>,
+             index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>,
+                        SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>,
+                        SpacetimeIndex<3, UpLo::Up, Frame::Inertial>,
+                        SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>>>;
+  // contract first index (spacetime)
+  const RS1_type RS1_returned = contract_first_n_indices<1>(R, S);
+  RS1_type RS1_filled{};
+  contract_first_n_indices<1>(make_not_null(&RS1_filled), R, S);
+
+  for (size_t b = 0; b < 4; b++) {
+    for (size_t c = 0; c < 4; c++) {
+      for (size_t d = 0; d < 4; d++) {
+        for (size_t e = 0; e < 4; e++) {
+          DataType expected_sum = make_with_value<DataType>(used_for_size, 0.0);
+          for (size_t a = 0; a < 4; a++) {
+            expected_sum += R.get(a, b, c) * S.get(a, d, e);
+          }
+
+          CHECK_ITERABLE_APPROX(RS1_returned.get(b, c, d, e), expected_sum);
+          CHECK_ITERABLE_APPROX(RS1_filled.get(b, c, d, e), expected_sum);
+        }
+      }
+    }
+  }
+
+  using RS2_type = tnsr::ab<DataType, 3, Frame::Inertial>;
+  // contract first two indices (both spacetime)
+  const RS2_type RS2_returned = contract_first_n_indices<2>(R, S);
+  RS2_type RS2_filled{};
+  contract_first_n_indices<2>(make_not_null(&RS2_filled), R, S);
+
+  for (size_t c = 0; c < 4; c++) {
+    for (size_t d = 0; d < 4; d++) {
+      DataType expected_sum = make_with_value<DataType>(used_for_size, 0.0);
+      for (size_t a = 0; a < 4; a++) {
+        for (size_t b = 0; b < 4; b++) {
+          expected_sum += R.get(a, b, c) * S.get(a, b, d);
+        }
+      }
+
+      CHECK_ITERABLE_APPROX(RS2_returned.get(c, d), expected_sum);
+      CHECK_ITERABLE_APPROX(RS2_filled.get(c, d), expected_sum);
+    }
+  }
+
+  const auto G =
+      make_with_random_values<tnsr::Ijaa<DataType, 3, Frame::Inertial>>(
+          generator, distribution, used_for_size);
+  // tnsr::iJA
+  const auto H = make_with_random_values<
+      Tensor<DataType, Symmetry<3, 2, 1>,
+             index_list<SpatialIndex<3, UpLo::Lo, Frame::Inertial>,
+                        SpatialIndex<3, UpLo::Up, Frame::Inertial>,
+                        SpacetimeIndex<3, UpLo::Up, Frame::Inertial>>>>(
+      generator, distribution, used_for_size);
+
+  using GH_type = tnsr::aaB<DataType, 3, Frame::Inertial>;
+  // contract first two indices (both spatial) of two tensors of different rank
+  const GH_type GH_returned = contract_first_n_indices<2>(G, H);
+  GH_type GH_filled{};
+  contract_first_n_indices<2>(make_not_null(&GH_filled), G, H);
+
+  using HG_type = tnsr::Abb<DataType, 3, Frame::Inertial>;
+  // for checking that opposite order of operands gives us the "same" result
+  // mathematically (though the LHS index order will be different)
+  const HG_type HG_returned = contract_first_n_indices<2>(H, G);
+  HG_type HG_filled{};
+  contract_first_n_indices<2>(make_not_null(&HG_filled), H, G);
+
+  for (size_t a = 0; a < 4; a++) {
+    for (size_t b = 0; b < 4; b++) {
+      for (size_t c = 0; c < 4; c++) {
+        DataType expected_sum = make_with_value<DataType>(used_for_size, 0.0);
+        for (size_t i = 0; i < 3; i++) {
+          for (size_t j = 0; j < 3; j++) {
+            expected_sum += G.get(i, j, a, b) * H.get(i, j, c);
+          }
+        }
+
+        CHECK_ITERABLE_APPROX(GH_returned.get(a, b, c), expected_sum);
+        CHECK_ITERABLE_APPROX(GH_filled.get(a, b, c), expected_sum);
+        CHECK_ITERABLE_APPROX(HG_returned.get(c, a, b), expected_sum);
+        CHECK_ITERABLE_APPROX(HG_filled.get(c, a, b), expected_sum);
+      }
+    }
+  }
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.ContractFirstNIndices",
+                  "[DataStructures][Unit]") {
+  MAKE_GENERATOR(generator);
+
+  test(make_not_null(&generator), std::numeric_limits<double>::signaling_NaN());
+  test(make_not_null(&generator),
+       DataVector(5, std::numeric_limits<double>::signaling_NaN()));
+}


### PR DESCRIPTION
## Proposed changes

This PR adds a function that contracts the first N indices of two `Tensor`s

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
