### PR TITLE
Register derived parallel callbacks

### DIFF
--- a/src/Parallel/GlobalCache.hpp
+++ b/src/Parallel/GlobalCache.hpp
@@ -466,6 +466,7 @@ bool GlobalCache<Metavariables>::mutable_cache_item_is_ready(
   };
 
   if (callback_was_registered()) {
+    optional_callback->register_with_charm();
     // Second mutex is for vector of callbacks
     std::mutex& mutex = tuples::get<MutexTag<tag>>(mutexes_).second;
     {

--- a/tests/Unit/Parallel/Test_GlobalCache.cpp
+++ b/tests/Unit/Parallel/Test_GlobalCache.cpp
@@ -224,6 +224,8 @@ class UseCkCallbackAsCallback : public Parallel::Callback {
   using PUP::able::register_constructor;
   void invoke() override { callback_.send(nullptr); }
   void pup(PUP::er& p) override { p | callback_; }
+  // We shouldn't be pupping so registration doesn't matter
+  void register_with_charm() override {}
 
  private:
   CkCallback callback_;


### PR DESCRIPTION
## Proposed changes

The GlobalCache never really gets pupped, but it is sized by the MemoryMonitor. Therefore, all it's members need to be registered with charm. Before the derived callbacks weren't registered, so we got the `Unrecognized PUP::able::PUP_ID` error. This PR will register the callbacks only once so that doesn't happen.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
