### PR TITLE
Add boost to KerrSchild

### DIFF
--- a/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/CMakeLists.txt
+++ b/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/CMakeLists.txt
@@ -44,6 +44,7 @@ target_link_libraries(
   GeneralRelativity
   Interpolation
   Serialization
+  SpecialRelativity
   )
 
 add_subdirectory(Python)

--- a/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.cpp
@@ -20,8 +20,11 @@
 #include "PointwiseFunctions/GeneralRelativity/ExtrinsicCurvature.hpp"
 #include "PointwiseFunctions/GeneralRelativity/InverseSpacetimeMetric.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "PointwiseFunctions/GeneralRelativity/TimeDerivativeOfSpatialMetric.hpp"
+#include "PointwiseFunctions/SpecialRelativity/LorentzBoostMatrix.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/ContainerHelpers.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeWithValue.hpp"
@@ -34,13 +37,14 @@ KerrSchild::KerrSchild(CkMigrateMessage* /*msg*/) {}
 KerrSchild::KerrSchild(const double mass,
                        const std::array<double, 3>& dimensionless_spin,
                        const std::array<double, 3>& center,
+                       const std::array<double, 3>& boost_velocity,
                        const Options::Context& context)
     : mass_(mass),
-      // clang-tidy: do not std::move trivial types.
-      dimensionless_spin_(dimensionless_spin),  // NOLINT
-      // clang-tidy: do not std::move trivial types.
+      dimensionless_spin_(dimensionless_spin),
       center_(center),
-      zero_spin_(dimensionless_spin_ == std::array<double, 3>{{0., 0., 0.}}) {
+      boost_velocity_(boost_velocity),
+      zero_spin_(dimensionless_spin_ == std::array<double, 3>{{0., 0., 0.}}),
+      zero_velocity_(boost_velocity_ == std::array<double, 3>{{0., 0., 0.}}) {
   const double spin_magnitude = magnitude(dimensionless_spin_);
   if (spin_magnitude > 1.0) {
     PARSE_ERROR(context, "Spin magnitude must be < 1. Given spin: "
@@ -56,7 +60,9 @@ void KerrSchild::pup(PUP::er& p) {
   p | mass_;
   p | dimensionless_spin_;
   p | center_;
+  p | boost_velocity_;
   p | zero_spin_;
+  p | zero_velocity_;
 }
 
 template <typename DataType, typename Frame>
@@ -68,11 +74,23 @@ template <typename DataType, typename Frame>
 void KerrSchild::IntermediateComputer<DataType, Frame>::operator()(
     const gsl::not_null<tnsr::I<DataType, 3, Frame>*> x_minus_center,
     const gsl::not_null<CachedBuffer*> /*cache*/,
-    internal_tags::x_minus_center<DataType, Frame> /*meta*/) const {
+    internal_tags::x_minus_center_unboosted<DataType, Frame> /*meta*/) const {
   *x_minus_center = x_;
   for (size_t d = 0; d < 3; ++d) {
     x_minus_center->get(d) -= gsl::at(solution_.center(), d);
   }
+}
+
+template <typename DataType, typename Frame>
+void KerrSchild::IntermediateComputer<DataType, Frame>::operator()(
+    const gsl::not_null<tnsr::I<DataType, 3, Frame>*> x_minus_center_boosted,
+    const gsl::not_null<CachedBuffer*> cache,
+    internal_tags::x_minus_center<DataType, Frame> /*meta*/) const {
+  const auto& x_minus_center = cache->get_var(
+      *this, internal_tags::x_minus_center_unboosted<DataType, Frame>{});
+  // Boost the coordinates to the rest frame
+  sr::lorentz_boost(x_minus_center_boosted, x_minus_center, 0.,
+                    solution_.boost_velocity());
 }
 
 template <typename DataType, typename Frame>
@@ -251,9 +269,9 @@ void KerrSchild::IntermediateComputer<DataType, Frame>::operator()(
 
 template <typename DataType, typename Frame>
 void KerrSchild::IntermediateComputer<DataType, Frame>::operator()(
-    const gsl::not_null<tnsr::i<DataType, 3, Frame>*> deriv_H,
+    const gsl::not_null<tnsr::a<DataType, 3, Frame>*> deriv_H,
     const gsl::not_null<CachedBuffer*> cache,
-    internal_tags::deriv_H<DataType, Frame> /*meta*/) const {
+    internal_tags::deriv_H_unboosted<DataType, Frame> /*meta*/) const {
   const auto& deriv_log_r =
       cache->get_var(*this, internal_tags::deriv_log_r<DataType, Frame>{});
   const auto& deriv_H_temp1 =
@@ -262,10 +280,21 @@ void KerrSchild::IntermediateComputer<DataType, Frame>::operator()(
       get(cache->get_var(*this, internal_tags::deriv_H_temp2<DataType>{}));
 
   const auto spin_a = solution_.dimensionless_spin() * solution_.mass();
+  get<0>(*deriv_H) = 0.;
   for (size_t i = 0; i < 3; ++i) {
-    deriv_H->get(i) =
+    deriv_H->get(i + 1) =
         deriv_H_temp1 * deriv_log_r.get(i) - deriv_H_temp2 * gsl::at(spin_a, i);
   }
+}
+
+template <typename DataType, typename Frame>
+void KerrSchild::IntermediateComputer<DataType, Frame>::operator()(
+    const gsl::not_null<tnsr::a<DataType, 3, Frame>*> deriv_H_boosted,
+    const gsl::not_null<CachedBuffer*> cache,
+    internal_tags::deriv_H<DataType, Frame> /*meta*/) const {
+  const auto& deriv_H = cache->get_var(
+      *this, internal_tags::deriv_H_unboosted<DataType, Frame>{});
+  sr::lorentz_boost(deriv_H_boosted, deriv_H, -solution_.boost_velocity());
 }
 
 template <typename DataType, typename Frame>
@@ -297,9 +326,9 @@ void KerrSchild::IntermediateComputer<DataType, Frame>::operator()(
 
 template <typename DataType, typename Frame>
 void KerrSchild::IntermediateComputer<DataType, Frame>::operator()(
-    const gsl::not_null<tnsr::i<DataType, 3, Frame>*> null_form,
+    const gsl::not_null<tnsr::a<DataType, 3, Frame>*> null_form,
     const gsl::not_null<CachedBuffer*> cache,
-    internal_tags::null_form<DataType, Frame> /*meta*/) const {
+    internal_tags::null_form_unboosted<DataType, Frame> /*meta*/) const {
   const auto& a_dot_x_over_r =
       get(cache->get_var(*this, internal_tags::a_dot_x_over_r<DataType>{}));
   const auto& r = get(cache->get_var(*this, internal_tags::r<DataType>{}));
@@ -309,53 +338,69 @@ void KerrSchild::IntermediateComputer<DataType, Frame>::operator()(
       get(cache->get_var(*this, internal_tags::denom<DataType>{}));
 
   const auto spin_a = solution_.dimensionless_spin() * solution_.mass();
+  get<0>(*null_form) = 1.;
   for (size_t i = 0; i < 3; ++i) {
     const size_t cross_product_index_1 = (i + 1) % 3;
     const size_t cross_product_index_2 = (i + 2) % 3;
-    null_form->get(i) = denom * (r * x_minus_center.get(i) -
-                                 gsl::at(spin_a, cross_product_index_1) *
-                                     x_minus_center.get(cross_product_index_2) +
-                                 gsl::at(spin_a, cross_product_index_2) *
-                                     x_minus_center.get(cross_product_index_1) +
-                                 a_dot_x_over_r * gsl::at(spin_a, i));
+    null_form->get(i + 1) =
+        denom * (r * x_minus_center.get(i) -
+                 gsl::at(spin_a, cross_product_index_1) *
+                     x_minus_center.get(cross_product_index_2) +
+                 gsl::at(spin_a, cross_product_index_2) *
+                     x_minus_center.get(cross_product_index_1) +
+                 a_dot_x_over_r * gsl::at(spin_a, i));
   }
 }
 
 template <typename DataType, typename Frame>
 void KerrSchild::IntermediateComputer<DataType, Frame>::operator()(
-    const gsl::not_null<tnsr::ij<DataType, 3, Frame>*> deriv_null_form,
+    const gsl::not_null<tnsr::a<DataType, 3, Frame>*> null_form_boosted,
     const gsl::not_null<CachedBuffer*> cache,
-    internal_tags::deriv_null_form<DataType, Frame> /*meta*/) const {
+    internal_tags::null_form<DataType, Frame> /*meta*/) const {
+  const auto& null_form = cache->get_var(
+      *this, internal_tags::null_form_unboosted<DataType, Frame>{});
+  sr::lorentz_boost(null_form_boosted, null_form, -solution_.boost_velocity());
+}
+
+template <typename DataType, typename Frame>
+void KerrSchild::IntermediateComputer<DataType, Frame>::operator()(
+    const gsl::not_null<tnsr::ab<DataType, 3, Frame>*> deriv_null_form,
+    const gsl::not_null<CachedBuffer*> cache,
+    internal_tags::deriv_null_form_unboosted<DataType, Frame> /*meta*/) const {
   const auto spin_a = solution_.dimensionless_spin() * solution_.mass();
   const auto& denom =
       get(cache->get_var(*this, internal_tags::denom<DataType>{}));
   const auto& r = get(cache->get_var(*this, internal_tags::r<DataType>{}));
   const auto& x_minus_center =
       cache->get_var(*this, internal_tags::x_minus_center<DataType, Frame>{});
-  const auto& null_form =
-      cache->get_var(*this, internal_tags::null_form<DataType, Frame>{});
+  const auto& null_form = cache->get_var(
+      *this, internal_tags::null_form_unboosted<DataType, Frame>{});
   const auto& a_dot_x_over_rsquared = get(
       cache->get_var(*this, internal_tags::a_dot_x_over_rsquared<DataType>{}));
   const auto& deriv_log_r =
       cache->get_var(*this, internal_tags::deriv_log_r<DataType, Frame>{});
 
+  for (size_t d = 0; d < 4; ++d) {
+    deriv_null_form->get(d, 0) = 0.;
+    deriv_null_form->get(0, d) = 0.;
+  }
   for (size_t i = 0; i < 3; i++) {
     for (size_t j = 0; j < 3; j++) {
-      deriv_null_form->get(j, i) =
+      deriv_null_form->get(j + 1, i + 1) =
           denom * (gsl::at(spin_a, i) * gsl::at(spin_a, j) / r +
-                   (x_minus_center.get(i) - 2.0 * r * null_form.get(i) -
+                   (x_minus_center.get(i) - 2.0 * r * null_form.get(i + 1) -
                     a_dot_x_over_rsquared * gsl::at(spin_a, i)) *
                        deriv_log_r.get(j) * r);
       if (i == j) {
-        deriv_null_form->get(j, i) += denom * r;
+        deriv_null_form->get(j + 1, i + 1) += denom * r;
       } else {  //  add denom*epsilon^ijk a_k
         size_t k = (j + 1) % 3;
         if (k == i) {  // j+1 = i (cyclic), so choose minus sign
           k++;
           k = k % 3;  // and set k to be neither i nor j
-          deriv_null_form->get(j, i) -= denom * gsl::at(spin_a, k);
+          deriv_null_form->get(j + 1, i + 1) -= denom * gsl::at(spin_a, k);
         } else {  // i+1 = j (cyclic), so choose plus sign
-          deriv_null_form->get(j, i) += denom * gsl::at(spin_a, k);
+          deriv_null_form->get(j + 1, i + 1) += denom * gsl::at(spin_a, k);
         }
       }
     }
@@ -364,16 +409,31 @@ void KerrSchild::IntermediateComputer<DataType, Frame>::operator()(
 
 template <typename DataType, typename Frame>
 void KerrSchild::IntermediateComputer<DataType, Frame>::operator()(
+    const gsl::not_null<tnsr::ab<DataType, 3, Frame>*> deriv_null_form_boosted,
+    const gsl::not_null<CachedBuffer*> cache,
+    internal_tags::deriv_null_form<DataType, Frame> /*meta*/) const {
+  const auto& deriv_null_form = cache->get_var(
+      *this, internal_tags::deriv_null_form_unboosted<DataType, Frame>{});
+  // Inverse-boost the first index, because it represents the derivative which
+  // is given in the boosted frame
+  sr::lorentz_boost(deriv_null_form_boosted, deriv_null_form,
+                    -solution_.boost_velocity());
+}
+
+template <typename DataType, typename Frame>
+void KerrSchild::IntermediateComputer<DataType, Frame>::operator()(
     const gsl::not_null<Scalar<DataType>*> lapse_squared,
     const gsl::not_null<CachedBuffer*> cache,
     internal_tags::lapse_squared<DataType> /*meta*/) const {
-  if (solution_.zero_spin()) {
+  if (solution_.zero_spin() and solution_.zero_velocity()) {
     const auto& r = get(cache->get_var(*this, internal_tags::r<DataType>{}));
     get(*lapse_squared) = 1.0 / (1.0 + 2.0 * solution_.mass() / r);
     return;
   }
   const auto& H = get(cache->get_var(*this, internal_tags::H<DataType>{}));
-  get(*lapse_squared) = 1.0 / (1.0 + 2.0 * square(null_vector_0_) * H);
+  const auto& null_form =
+      cache->get_var(*this, internal_tags::null_form<DataType, Frame>{});
+  get(*lapse_squared) = 1.0 / (1.0 + 2.0 * square(get<0>(null_form)) * H);
 }
 
 template <typename DataType, typename Frame>
@@ -394,8 +454,7 @@ void KerrSchild::IntermediateComputer<DataType, Frame>::operator()(
   const auto& lapse = get(cache->get_var(*this, gr::Tags::Lapse<DataType>{}));
   const auto& lapse_squared =
       get(cache->get_var(*this, internal_tags::lapse_squared<DataType>{}));
-  get(*deriv_lapse_multiplier) =
-      -square(null_vector_0_) * lapse * lapse_squared;
+  get(*deriv_lapse_multiplier) = -lapse * lapse_squared;
 }
 
 template <typename DataType, typename Frame>
@@ -404,10 +463,12 @@ void KerrSchild::IntermediateComputer<DataType, Frame>::operator()(
     const gsl::not_null<CachedBuffer*> cache,
     internal_tags::shift_multiplier<DataType> /*meta*/) const {
   const auto& H = get(cache->get_var(*this, internal_tags::H<DataType>{}));
+  const auto& null_form =
+      cache->get_var(*this, internal_tags::null_form<DataType, Frame>{});
   const auto& lapse_squared =
       get(cache->get_var(*this, internal_tags::lapse_squared<DataType>{}));
 
-  get(*shift_multiplier) = -2.0 * null_vector_0_ * H * lapse_squared;
+  get(*shift_multiplier) = 2.0 * get<0>(null_form) * H * lapse_squared;
 }
 
 template <typename DataType, typename Frame>
@@ -415,7 +476,7 @@ void KerrSchild::IntermediateComputer<DataType, Frame>::operator()(
     const gsl::not_null<tnsr::I<DataType, 3, Frame>*> shift,
     const gsl::not_null<CachedBuffer*> cache,
     gr::Tags::Shift<DataType, 3, Frame> /*meta*/) const {
-  if (solution_.zero_spin()) {
+  if (solution_.zero_spin() and solution_.zero_velocity()) {
     const auto& x_minus_center =
         cache->get_var(*this, internal_tags::x_minus_center<DataType, Frame>{});
     const auto& r_squared =
@@ -434,7 +495,7 @@ void KerrSchild::IntermediateComputer<DataType, Frame>::operator()(
       get(cache->get_var(*this, internal_tags::shift_multiplier<DataType>{}));
 
   for (size_t i = 0; i < 3; ++i) {
-    shift->get(i) = shift_multiplier * null_form.get(i);
+    shift->get(i) = shift_multiplier * null_form.get(i + 1);
   }
 }
 
@@ -443,7 +504,7 @@ void KerrSchild::IntermediateComputer<DataType, Frame>::operator()(
     const gsl::not_null<tnsr::iJ<DataType, 3, Frame>*> deriv_shift,
     const gsl::not_null<CachedBuffer*> cache,
     DerivShift<DataType, Frame> /*meta*/) const {
-  if (solution_.zero_spin()) {
+  if (solution_.zero_spin() and solution_.zero_velocity()) {
     const auto& x_minus_center =
         cache->get_var(*this, internal_tags::x_minus_center<DataType, Frame>{});
     const auto& r = get(cache->get_var(*this, internal_tags::r<DataType>{}));
@@ -476,12 +537,15 @@ void KerrSchild::IntermediateComputer<DataType, Frame>::operator()(
 
   for (size_t m = 0; m < 3; ++m) {
     for (size_t i = 0; i < 3; ++i) {
-      deriv_shift->get(m, i) = 4.0 * cube(null_vector_0_) * H *
-                                   null_form.get(i) * square(lapse_squared) *
-                                   deriv_H.get(m) -
-                               2.0 * null_vector_0_ * lapse_squared *
-                                   (null_form.get(i) * deriv_H.get(m) +
-                                    H * deriv_null_form.get(m, i));
+      deriv_shift->get(m, i) =
+          2.0 * lapse_squared *
+              (get<0>(null_form) * null_form.get(i + 1) * deriv_H.get(m + 1) +
+               H * get<0>(null_form) * deriv_null_form.get(m + 1, i + 1) +
+               H * null_form.get(i + 1) * deriv_null_form.get(m + 1, 0)) -
+          4.0 * H * get<0>(null_form) * null_form.get(i + 1) *
+              square(lapse_squared) *
+              (square(get<0>(null_form)) * deriv_H.get(m + 1) +
+               2. * H * get<0>(null_form) * deriv_null_form.get(m + 1, 0));
     }
   }
 }
@@ -491,7 +555,7 @@ void KerrSchild::IntermediateComputer<DataType, Frame>::operator()(
     const gsl::not_null<tnsr::ii<DataType, 3, Frame>*> spatial_metric,
     const gsl::not_null<CachedBuffer*> cache,
     gr::Tags::SpatialMetric<DataType, 3, Frame> /*meta*/) const {
-  if (solution_.zero_spin()) {
+  if (solution_.zero_spin() and solution_.zero_velocity()) {
     const auto& x_minus_center =
         cache->get_var(*this, internal_tags::x_minus_center<DataType, Frame>{});
     const auto& r = get(cache->get_var(*this, internal_tags::r<DataType>{}));
@@ -516,7 +580,7 @@ void KerrSchild::IntermediateComputer<DataType, Frame>::operator()(
     spatial_metric->get(i, i) = 1.;
     for (size_t j = i; j < 3; ++j) {  // Symmetry
       spatial_metric->get(i, j) +=
-          2.0 * H * null_form.get(i) * null_form.get(j);
+          2.0 * H * null_form.get(i + 1) * null_form.get(j + 1);
     }
   }
 }
@@ -531,7 +595,7 @@ void KerrSchild::IntermediateComputer<DataType, Frame>::operator()(
       get(cache->get_var(*this, internal_tags::lapse_squared<DataType>{}));
   const auto& null_form =
       cache->get_var(*this, internal_tags::null_form<DataType, Frame>{});
-  if (solution_.zero_spin()) {
+  if (solution_.zero_spin() and solution_.zero_velocity()) {
     const auto& x_minus_center =
         cache->get_var(*this, internal_tags::x_minus_center<DataType, Frame>{});
     const auto& r = get(cache->get_var(*this, internal_tags::r<DataType>{}));
@@ -551,8 +615,9 @@ void KerrSchild::IntermediateComputer<DataType, Frame>::operator()(
 
   for (size_t i = 0; i < 3; ++i) {
     for (size_t j = i; j < 3; ++j) {  // Symmetry
-      inverse_spatial_metric->get(i, j) =
-          -2.0 * H * lapse_squared * null_form.get(i) * null_form.get(j);
+      inverse_spatial_metric->get(i, j) = -2.0 * H * lapse_squared *
+                                          null_form.get(i + 1) *
+                                          null_form.get(j + 1);
     }
     inverse_spatial_metric->get(i, i) += 1.;
   }
@@ -575,10 +640,11 @@ void KerrSchild::IntermediateComputer<DataType, Frame>::operator()(
     for (size_t j = i; j < 3; ++j) {  // Symmetry
       for (size_t m = 0; m < 3; ++m) {
         deriv_spatial_metric->get(m, i, j) =
-            2.0 * null_form.get(i) * null_form.get(j) * deriv_H.get(m) +
+            2.0 * null_form.get(i + 1) * null_form.get(j + 1) *
+                deriv_H.get(m + 1) +
             2.0 * H *
-                (null_form.get(i) * deriv_null_form.get(m, j) +
-                 null_form.get(j) * deriv_null_form.get(m, i));
+                (null_form.get(i + 1) * deriv_null_form.get(m + 1, j + 1) +
+                 null_form.get(j + 1) * deriv_null_form.get(m + 1, i + 1));
       }
     }
   }
@@ -587,9 +653,62 @@ void KerrSchild::IntermediateComputer<DataType, Frame>::operator()(
 template <typename DataType, typename Frame>
 void KerrSchild::IntermediateComputer<DataType, Frame>::operator()(
     const gsl::not_null<tnsr::ii<DataType, 3, Frame>*> dt_spatial_metric,
-    const gsl::not_null<CachedBuffer*> /*cache*/,
+    const gsl::not_null<CachedBuffer*> cache,
     ::Tags::dt<gr::Tags::SpatialMetric<DataType, 3, Frame>> /*meta*/) const {
-  std::fill(dt_spatial_metric->begin(), dt_spatial_metric->end(), 0.);
+  if (solution_.zero_velocity()) {
+    std::fill(dt_spatial_metric->begin(), dt_spatial_metric->end(), 0.);
+    return;
+  }
+  const auto& ex_curvature =
+      cache->get_var(*this, gr::Tags::ExtrinsicCurvature<DataType, 3, Frame>{});
+  const auto& lapse = cache->get_var(*this, gr::Tags::Lapse<DataType>{});
+  const auto& shift =
+      cache->get_var(*this, gr::Tags::Shift<DataType, 3, Frame>{});
+  const auto& deriv_shift =
+      cache->get_var(*this, DerivShift<DataType, Frame>{});
+  const auto& spatial_metric =
+      cache->get_var(*this, gr::Tags::SpatialMetric<DataType, 3, Frame>{});
+  const auto& deriv_spatial_metric =
+      cache->get_var(*this, DerivSpatialMetric<DataType, Frame>{});
+    // Reconstruct from the extrinsic curvature and shift
+    gr::time_derivative_of_spatial_metric(dt_spatial_metric, lapse, shift,
+                                          deriv_shift, spatial_metric,
+                                          deriv_spatial_metric, ex_curvature);
+}
+
+template <typename DataType, typename Frame>
+void KerrSchild::IntermediateComputer<DataType, Frame>::operator()(
+    const gsl::not_null<Scalar<DataType>*> null_form_dot_deriv_H,
+    const gsl::not_null<CachedBuffer*> cache,
+    internal_tags::null_form_dot_deriv_H<DataType> /*meta*/) const {
+  const auto& deriv_H =
+      cache->get_var(*this, internal_tags::deriv_H<DataType, Frame>{});
+  const auto& null_form =
+      cache->get_var(*this, internal_tags::null_form<DataType, Frame>{});
+  get(*null_form_dot_deriv_H) = 0.0;
+  for (size_t i = 0; i < 3; ++i) {
+    get(*null_form_dot_deriv_H) += null_form.get(i + 1) * deriv_H.get(i + 1);
+  }
+}
+
+template <typename DataType, typename Frame>
+void KerrSchild::IntermediateComputer<DataType, Frame>::operator()(
+    const gsl::not_null<tnsr::i<DataType, 3, Frame>*>
+        null_form_dot_deriv_null_form,
+    const gsl::not_null<CachedBuffer*> cache,
+    internal_tags::null_form_dot_deriv_null_form<DataType, Frame> /*meta*/)
+    const {
+  const auto& deriv_null_form =
+      cache->get_var(*this, internal_tags::deriv_null_form<DataType, Frame>{});
+  const auto& null_form =
+      cache->get_var(*this, internal_tags::null_form<DataType, Frame>{});
+  for (size_t j = 0; j < 3; ++j) {
+    null_form_dot_deriv_null_form->get(j) = 0.0;
+    for (size_t i = 0; i < 3; ++i) {
+      null_form_dot_deriv_null_form->get(j) +=
+          null_form.get(i + 1) * deriv_null_form.get(i + 1, j + 1);
+    }
+  }
 }
 
 template <typename DataType, typename Frame>
@@ -597,14 +716,52 @@ void KerrSchild::IntermediateComputer<DataType, Frame>::operator()(
     const gsl::not_null<tnsr::ii<DataType, 3, Frame>*> extrinsic_curvature,
     const gsl::not_null<CachedBuffer*> cache,
     gr::Tags::ExtrinsicCurvature<DataType, 3, Frame> /*meta*/) const {
-  gr::extrinsic_curvature(
-      extrinsic_curvature, cache->get_var(*this, gr::Tags::Lapse<DataType>{}),
-      cache->get_var(*this, gr::Tags::Shift<DataType, 3, Frame>{}),
-      cache->get_var(*this, DerivShift<DataType, Frame>{}),
-      cache->get_var(*this, gr::Tags::SpatialMetric<DataType, 3, Frame>{}),
-      cache->get_var(*this,
-                     ::Tags::dt<gr::Tags::SpatialMetric<DataType, 3, Frame>>{}),
-      cache->get_var(*this, DerivSpatialMetric<DataType, Frame>{}));
+  const auto& lapse = cache->get_var(*this, gr::Tags::Lapse<DataType>{});
+  const auto& H = cache->get_var(*this, internal_tags::H<DataType>{});
+  const auto& deriv_H =
+      cache->get_var(*this, internal_tags::deriv_H<DataType, Frame>{});
+  const auto& null_form =
+      cache->get_var(*this, internal_tags::null_form<DataType, Frame>{});
+  const auto& deriv_null_form =
+      cache->get_var(*this, internal_tags::deriv_null_form<DataType, Frame>{});
+  const auto& null_form_dot_deriv_H =
+      cache->get_var(*this, internal_tags::null_form_dot_deriv_H<DataType>{});
+  const auto& null_form_dot_deriv_null_form = cache->get_var(
+      *this, internal_tags::null_form_dot_deriv_null_form<DataType, Frame>{});
+  // We use a formula with l^0. However, since we actually use l_0, there is a
+  // sign difference. This can be seen by lowering the index with the
+  // Minkowski metric, which can be done for the null form given the form of the
+  // KerrSchild metric.
+  const double l0_relative_sign = -1.0;
+  for (size_t i = 0; i < 3; ++i) {
+    for (size_t j = i; j < 3; ++j) {
+      extrinsic_curvature->get(i, j) =
+          (-1.0 / get(lapse)) *
+              (null_form.get(i + 1) * null_form.get(j + 1) * get<0>(deriv_H) +
+               get(H) *
+                   (null_form.get(i + 1) * deriv_null_form.get(0, j + 1) +
+                    null_form.get(j + 1) * deriv_null_form.get(0, i + 1))) -
+          get(lapse) *
+              (get(H) *
+                   (l0_relative_sign * null_form.get(i + 1) *
+                        deriv_null_form.get(j + 1, 0) +
+                    l0_relative_sign * null_form.get(j + 1) *
+                        deriv_null_form.get(i + 1, 0) +
+                    l0_relative_sign * get<0>(null_form) *
+                        (deriv_null_form.get(i + 1, j + 1) +
+                         deriv_null_form.get(j + 1, i + 1) +
+                         2.0 * get(H) *
+                             (null_form.get(i + 1) *
+                                  null_form_dot_deriv_null_form.get(j) +
+                              null_form.get(j + 1) *
+                                  null_form_dot_deriv_null_form.get(i)) +
+                         2.0 * null_form.get(i + 1) * null_form.get(j + 1) *
+                             get(null_form_dot_deriv_H))) +
+               l0_relative_sign * get<0>(null_form) *
+                   (null_form.get(i + 1) * deriv_H.get(j + 1) +
+                    null_form.get(j + 1) * deriv_H.get(i + 1)));
+    }
+  }
 }
 
 template <typename DataType, typename Frame>
@@ -640,7 +797,7 @@ tnsr::i<DataType, 3, Frame>
 KerrSchild::IntermediateVars<DataType, Frame>::get_var(
     const IntermediateComputer<DataType, Frame>& computer,
     DerivLapse<DataType, Frame> /*meta*/) {
-  if (computer.solution().zero_spin()) {
+  if (computer.solution().zero_spin() and computer.solution().zero_velocity()) {
     const auto& x_minus_center =
         get_var(computer, internal_tags::x_minus_center<DataType, Frame>{});
     const auto& r = get(get_var(computer, internal_tags::r<DataType>{}));
@@ -659,13 +816,21 @@ KerrSchild::IntermediateVars<DataType, Frame>::get_var(
     return d_lapse;
   }
   tnsr::i<DataType, 3, Frame> result{};
+  const auto& H = get_var(computer, internal_tags::H<DataType>{});
   const auto& deriv_H =
       get_var(computer, internal_tags::deriv_H<DataType, Frame>{});
   const auto& deriv_lapse_multiplier =
       get(get_var(computer, internal_tags::deriv_lapse_multiplier<DataType>{}));
+  const auto& null_form =
+      get_var(computer, internal_tags::null_form<DataType, Frame>{});
+  const auto& deriv_null_form =
+      get_var(computer, internal_tags::deriv_null_form<DataType, Frame>{});
 
   for (size_t i = 0; i < 3; ++i) {
-    result.get(i) = deriv_lapse_multiplier * deriv_H.get(i);
+    result.get(i) =
+        deriv_lapse_multiplier *
+        (square(get<0>(null_form)) * deriv_H.get(i + 1) +
+         2. * get(H) * get<0>(null_form) * deriv_null_form.get(i + 1, 0));
   }
   return result;
 }
@@ -702,11 +867,13 @@ KerrSchild::IntermediateVars<DataType, Frame>::get_var(
     gr::Tags::DerivDetSpatialMetric<DataType, 3, Frame> /*meta*/) {
   const auto& deriv_H =
       get_var(computer, internal_tags::deriv_H<DataType, Frame>{});
+  const auto& null_form =
+      get_var(computer, internal_tags::null_form<DataType, Frame>{});
 
   auto result =
       make_with_value<tnsr::i<DataType, 3, Frame>>(get<0>(deriv_H), 0.);
   for (size_t i = 0; i < 3; ++i) {
-    result.get(i) = 2.0 * square(null_vector_0_) * deriv_H.get(i);
+    result.get(i) = 2.0 * square(get<0>(null_form)) * deriv_H.get(i + 1);
   }
 
   return result;
@@ -716,7 +883,7 @@ template <typename DataType, typename Frame>
 Scalar<DataType> KerrSchild::IntermediateVars<DataType, Frame>::get_var(
     const IntermediateComputer<DataType, Frame>& computer,
     gr::Tags::TraceExtrinsicCurvature<DataType> /*meta*/) {
-  if (computer.solution().zero_spin()) {
+  if (computer.solution().zero_spin() and computer.solution().zero_velocity()) {
     const double m = computer.solution().mass();
     const auto& r = get(get_var(computer, internal_tags::r<DataType>{}));
     Scalar<DataType> result(get_size(r));
@@ -735,7 +902,7 @@ tnsr::I<DataType, 3, Frame>
 KerrSchild::IntermediateVars<DataType, Frame>::get_var(
     const IntermediateComputer<DataType, Frame>& computer,
     gr::Tags::TraceSpatialChristoffelSecondKind<DataType, 3, Frame> /*meta*/) {
-  if (computer.solution().zero_spin()) {
+  if (computer.solution().zero_spin() and computer.solution().zero_velocity()) {
     const double m = computer.solution().mass();
     const auto& r = get(get_var(computer, internal_tags::r<DataType>{}));
     const auto& r_squared =
@@ -763,6 +930,10 @@ tnsr::Abb<DataType, 3, Frame>
 KerrSchild::IntermediateVars<DataType, Frame>::get_var(
     const IntermediateComputer<DataType, Frame>& computer,
     gr::Tags::SpacetimeChristoffelSecondKind<DataType, 3, Frame> /*meta*/) {
+  ASSERT(
+      computer.solution().zero_velocity(),
+      "The tag gr::Tags::SpacetimeChristoffelSecondKind is not supported for a "
+      "boosted KerrSchild solution.");
   const auto& lapse = get_var(computer, gr::Tags::Lapse<DataType>{});
   const auto& shift = get_var(computer, gr::Tags::Shift<DataType, 3, Frame>{});
   const auto& spatial_metric =

--- a/src/PointwiseFunctions/GeneralRelativity/TimeDerivativeOfSpatialMetric.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/TimeDerivativeOfSpatialMetric.cpp
@@ -81,7 +81,7 @@ tnsr::ii<DataType, SpatialDim, Frame> time_derivative_of_spatial_metric(
           extrinsic_curvature);
 
 GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (double, DataVector),
-                        (Frame::Grid, Frame::Inertial))
+                        (Frame::Grid, Frame::Distorted, Frame::Inertial))
 
 #undef DIM
 #undef DTYPE

--- a/src/PointwiseFunctions/SpecialRelativity/LorentzBoostMatrix.hpp
+++ b/src/PointwiseFunctions/SpecialRelativity/LorentzBoostMatrix.hpp
@@ -3,9 +3,12 @@
 
 #pragma once
 
+#include <array>
 #include <cstddef>
 
-#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeArray.hpp"
 
 /// \cond
 namespace gsl {
@@ -53,5 +56,43 @@ template <size_t SpatialDim>
 void lorentz_boost_matrix(
     gsl::not_null<tnsr::Ab<double, SpatialDim, Frame::NoFrame>*> boost_matrix,
     const tnsr::I<double, SpatialDim, Frame::NoFrame>& velocity);
+
+template <size_t SpatialDim>
+tnsr::Ab<double, SpatialDim, Frame::NoFrame> lorentz_boost_matrix(
+    const std::array<double, SpatialDim>& velocity);
+/// @}
+
+/// @{
+/*!
+ * \ingroup SpecialRelativityGroup
+ * \brief Apply a Lorentz boost to the spatial part of a vector.
+ * \details This requires passing the 0th component of the vector as an
+ * additional argument.
+ */
+template <typename DataType, size_t SpatialDim, typename Frame>
+void lorentz_boost(gsl::not_null<tnsr::I<DataType, SpatialDim, Frame>*> result,
+                   const tnsr::I<DataType, SpatialDim, Frame>& vector,
+                   double vector_component_0,
+                   const std::array<double, SpatialDim>& velocity);
+
+/*!
+ * \brief Apply a Lorentz boost to a one form.
+ */
+template <typename DataType, size_t SpatialDim, typename Frame>
+void lorentz_boost(
+    gsl::not_null<tnsr::a<DataType, SpatialDim, Frame>*> result,
+    const tnsr::a<DataType, SpatialDim, Frame>& one_form,
+    const std::array<double, SpatialDim>& velocity);
+
+/*!
+ * \brief Apply a Lorentz boost to each component of a rank-2 tensor with
+ * lower or covariant indices.
+ * \note In the future we might want to write a single function capable to boost
+ * a tensor of arbitrary rank.
+ */
+template <typename DataType, size_t SpatialDim, typename Frame>
+void lorentz_boost(gsl::not_null<tnsr::ab<DataType, SpatialDim, Frame>*> result,
+                   const tnsr::ab<DataType, SpatialDim, Frame>& tensor,
+                   const std::array<double, SpatialDim>& velocity);
 /// @}
 }  // namespace sr

--- a/support/Pipelines/Bbh/InitialData.yaml
+++ b/support/Pipelines/Bbh/InitialData.yaml
@@ -34,6 +34,7 @@ Background: &background
           - {{ DimensionlessSpinLeft_y }}
           - {{ DimensionlessSpinLeft_z }}
         Center: [0., 0., 0.]
+        Velocity: [0., 0., 0.]
     ObjectRight: &kerr_right
       KerrSchild:
         Mass: &mass_right {{ MassRight }}
@@ -42,6 +43,7 @@ Background: &background
           - {{ DimensionlessSpinRight_y }}
           - {{ DimensionlessSpinRight_z }}
         Center: [0., 0., 0.]
+        Velocity: [0., 0., 0.]
     AngularVelocity: {{ OrbitalAngularVelocity }}
     Expansion: {{ RadialExpansionVelocity }}
     LinearVelocity: [0., 0., 0.]

--- a/tests/InputFiles/CurvedScalarWave/WorldtubeKerrSchild.yaml
+++ b/tests/InputFiles/CurvedScalarWave/WorldtubeKerrSchild.yaml
@@ -26,6 +26,7 @@ BackgroundSpacetime:
     Mass: 1.
     Center: [0., 0., 0.]
     Spin: [0., 0., 0.]
+    Velocity: [0., 0., 0.]
 
 ResourceInfo:
   AvoidGlobalProc0: false

--- a/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
@@ -74,6 +74,7 @@ InitialData: &InitialData
     Mass: 1.0
     Spin: [0.0, 0.0, 0.0]
     Center: &Center [0.0, 0.0, 0.0]
+    Velocity: [0.0, 0.0, 0.0]
 
 DomainCreator:
   Sphere:

--- a/tests/InputFiles/Xcts/BinaryBlackHole.yaml
+++ b/tests/InputFiles/Xcts/BinaryBlackHole.yaml
@@ -84,11 +84,13 @@ Background: &background
         Mass: 0.4229
         Spin: [0., 0., 0.]
         Center: [0., 0., 0.]
+        Velocity: [0., 0., 0.]
     ObjectRight: &kerr_right
       KerrSchild:
         Mass: 0.4229
         Spin: [0., 0., 0.]
         Center: [0., 0., 0.]
+        Velocity: [0., 0., 0.]
     AngularVelocity: 0.0144
     Expansion: 0.
     LinearVelocity: [0., 0., 0.]

--- a/tests/InputFiles/Xcts/KerrSchild.yaml
+++ b/tests/InputFiles/Xcts/KerrSchild.yaml
@@ -71,6 +71,7 @@ Background: &solution
     Mass: &KerrMass 1.
     Spin: &KerrSpin [0., 0., 0.6]
     Center: &KerrCenter [0., 0., 0.]
+    Velocity: [0., 0., 0.]
 
 InitialGuess: Flatness
 

--- a/tests/Unit/Elliptic/Systems/Xcts/BoundaryConditions/Test_ApparentHorizon.cpp
+++ b/tests/Unit/Elliptic/Systems/Xcts/BoundaryConditions/Test_ApparentHorizon.cpp
@@ -411,7 +411,8 @@ void test_consistency_with_kerr(const bool compute_expansion) {
   std::array<double, 3> rotation =
       -0.5 * dimensionless_spin / horizon_kerrschild_radius;
   CAPTURE(rotation);
-  const KerrSchild solution{mass, dimensionless_spin, {{0., 0., 0.}}};
+  const KerrSchild solution{
+      mass, dimensionless_spin, {{0., 0., 0.}}, {{0., 0., 0.}}};
   const ApparentHorizon<Xcts::Geometry::Curved> kerr_horizon{
       center, rotation, std::make_unique<KerrSchild>(solution),
       // Check with and without the negative-expansion condition. Either the
@@ -579,8 +580,8 @@ SPECTRE_TEST_CASE("Unit.Xcts.BoundaryConditions.ApparentHorizon",
                 "  Lapse: Auto\n"
                 "  NegativeExpansion: None\n");
   test_creation({{1., 2., 3.}}, {{0.1, 0.2, 0.3}},
-                {{2.3, {{0.4, 0.5, 0.6}}, {{0., 0., 0.}}}},
-                {{3.4, {{0.3, 0.2, 0.1}}, {{0., 0., 0.}}}},
+                {{2.3, {{0.4, 0.5, 0.6}}, {{0., 0., 0.}}, {{0., 0., 0.}}}},
+                {{3.4, {{0.3, 0.2, 0.1}}, {{0., 0., 0.}}, {{0., 0., 0.}}}},
                 "ApparentHorizon:\n"
                 "  Center: [1., 2., 3.]\n"
                 "  Rotation: [0.1, 0.2, 0.3]\n"
@@ -589,11 +590,13 @@ SPECTRE_TEST_CASE("Unit.Xcts.BoundaryConditions.ApparentHorizon",
                 "      Mass: 2.3\n"
                 "      Spin: [0.4, 0.5, 0.6]\n"
                 "      Center: [0., 0., 0.]\n"
+                "      Velocity: [0., 0., 0.]\n"
                 "  NegativeExpansion:\n"
                 "    KerrSchild:\n"
                 "      Mass: 3.4\n"
                 "      Spin: [0.3, 0.2, 0.1]\n"
-                "      Center: [0., 0., 0.]\n");
+                "      Center: [0., 0., 0.]\n"
+                "      Velocity: [0., 0., 0.]\n");
   test_with_random_values();
   test_consistency_with_kerr(false);
   test_consistency_with_kerr(true);

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Test_BackgroundSpacetime.cpp
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Test_BackgroundSpacetime.cpp
@@ -37,7 +37,8 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.CurvedScalarWave.BackgroundSpacetime",
   const auto ks_background =
       gr::Solutions::KerrSchild(0.5, {{0.1, 0.2, 0.3}}, {{1.0, 3.0, 2.0}});
   const std::string& ks_option_string =
-      "Mass: 0.5\nSpin: [0.1,0.2,0.3]\nCenter: [1.0,3.0,2.0]";
+      "Mass: 0.5\nSpin: [0.1,0.2,0.3]\nCenter: [1.0,3.0,2.0]\nVelocity: "
+      "[0.0,0.0,0.0]";
   test_option_parsing(ks_background, ks_option_string);
 
   const auto spherical_ks_background = gr::Solutions::SphericalKerrSchild(

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Actions/Test_SetInitialData.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Actions/Test_SetInitialData.cpp
@@ -319,7 +319,8 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Gh.NumericInitialData",
       "GeneralizedHarmonic(KerrSchild):\n"
       "  Mass: 1.\n"
       "  Spin: [0, 0, 0]\n"
-      "  Center: [0, 0, 0]",
+      "  Center: [0, 0, 0]\n"
+      "  Velocity: [0, 0, 0]",
       false);
 }
 

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Test_AnalyticChristoffel.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Test_AnalyticChristoffel.cpp
@@ -122,7 +122,8 @@ void test_ks(const Mesh<3>& mesh) {
           "    GeneralizedHarmonic(KerrSchild):\n"
           "      Mass: 1.2\n"
           "      Spin: [0.1, 0.2, 0.3]\n"
-          "      Center: [-0.1, -0.2, -0.4]\n")
+          "      Center: [-0.1, -0.2, -0.4]\n"
+          "      Velocity: [0.0, 0.0, 0.0]\n")
           ->get_clone());
   CHECK_FALSE(gauge_condition->is_harmonic());
 

--- a/tests/Unit/Helpers/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/VerifyGrSolution.hpp
+++ b/tests/Unit/Helpers/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/VerifyGrSolution.hpp
@@ -426,5 +426,55 @@ void verify_consistency(const Solution& solution, const double time,
                                               derivative_delta),
       derivative_approx);
 }
+
+/// Check the consistency of quantities dependent on other metric quantities
+/// returned by a solution.  This includes checking pointwise relations such as
+/// consistency of the metric and inverse and comparing returned and
+/// numerical derivatives.
+template <typename Solution, typename Frame>
+void verify_spatial_consistency(const Solution& solution, const double time,
+                                const tnsr::I<double, 3, Frame>& position,
+                                const double derivative_delta,
+                                const double derivative_tolerance) {
+  using Lapse = gr::Tags::Lapse<double>;
+  using Shift = gr::Tags::Shift<double, 3, Frame>;
+  using SpatialMetric = gr::Tags::SpatialMetric<double, 3, Frame>;
+  using SqrtDetSpatialMetric = gr::Tags::SqrtDetSpatialMetric<double>;
+  using InverseSpatialMetric = gr::Tags::InverseSpatialMetric<double, 3, Frame>;
+  using ExtrinsicCurvature = gr::Tags::ExtrinsicCurvature<double, 3, Frame>;
+  using tags =
+      tmpl::list<SpatialMetric, SqrtDetSpatialMetric, InverseSpatialMetric,
+                 ExtrinsicCurvature, Lapse, Shift, detail::deriv<Shift, Frame>,
+                 Tags::dt<SpatialMetric>, detail::deriv<SpatialMetric, Frame>,
+                 Tags::dt<Lapse>, Tags::dt<Shift>, detail::deriv<Lapse, Frame>>;
+
+  auto derivative_approx = approx.epsilon(derivative_tolerance);
+
+  const auto vars = solution.variables(position, time, tags{});
+
+  const auto numerical_metric_det_and_inverse =
+      determinant_and_inverse(get<SpatialMetric>(vars));
+  CHECK_ITERABLE_APPROX(get(get<SqrtDetSpatialMetric>(vars)),
+                        sqrt(get(numerical_metric_det_and_inverse.first)));
+  CHECK_ITERABLE_APPROX(get<InverseSpatialMetric>(vars),
+                        numerical_metric_det_and_inverse.second);
+
+  CHECK_ITERABLE_CUSTOM_APPROX(
+      SINGLE_ARG(get<detail::deriv<Lapse, Frame>>(vars)),
+      detail::space_derivative<Lapse>(solution, position, time,
+                                      derivative_delta),
+      derivative_approx);
+  CHECK_ITERABLE_CUSTOM_APPROX(
+      SINGLE_ARG(get<detail::deriv<Shift, Frame>>(vars)),
+      detail::space_derivative<Shift>(solution, position, time,
+                                      derivative_delta),
+      derivative_approx);
+  CHECK_ITERABLE_CUSTOM_APPROX(
+      SINGLE_ARG(get<detail::deriv<SpatialMetric, Frame>>(vars)),
+      detail::space_derivative<SpatialMetric>(solution, position, time,
+                                              derivative_delta),
+      derivative_approx);
+}
+
 }  // namespace VerifyGrSolution
 }  // namespace TestHelpers

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Test_KerrSchild.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Test_KerrSchild.cpp
@@ -33,6 +33,7 @@
 #include "NumericalAlgorithms/Spectral/Quadrature.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "PointwiseFunctions/SpecialRelativity/LorentzBoostMatrix.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/MakeWithValue.hpp"
 #include "Utilities/TMPL.hpp"
@@ -307,39 +308,64 @@ void test_tag_retrieval(const DataType& used_for_size) {
   const double mass = 1.234;
   const std::array<double, 3> spin{{0.1, -0.2, 0.3}};
   const std::array<double, 3> center{{1.0, 2.0, 3.0}};
+  const std::array<double, 3> boost_velocity{{0.2, -0.3, 0.1}};
   const auto x = spatial_coords<Frame>(used_for_size);
   const double t = 1.3;
 
+  using all_tags = typename gr::Solutions::KerrSchild::tags<DataType, Frame>;
+
+  // We test gr::Tags::SpacetimeChristoffelSecondKind<DataType, 3, Frame>
+  // separately as it is not supported for the boosted solution.
+  using tags_for_zero_boost =
+      tmpl::list<gr::Tags::SpacetimeChristoffelSecondKind<DataType, 3, Frame>>;
+  using regular_tags = tmpl::remove<
+      all_tags, gr::Tags::SpacetimeChristoffelSecondKind<DataType, 3, Frame>>;
+
   // Evaluate solution
-  const gr::Solutions::KerrSchild solution(mass, spin, center);
-  TestHelpers::AnalyticSolutions::test_tag_retrieval(
-      solution, x, t,
-      typename gr::Solutions::KerrSchild::template tags<DataType, Frame>{});
+  const gr::Solutions::KerrSchild solution(mass, spin, center, boost_velocity);
+  TestHelpers::AnalyticSolutions::test_tag_retrieval(solution, x, t,
+                                                     regular_tags{});
+
+  const gr::Solutions::KerrSchild solution_zero_boost(mass, spin, center);
+  TestHelpers::AnalyticSolutions::test_tag_retrieval(solution_zero_boost, x, t,
+                                                     tags_for_zero_boost{});
 }
 
 template <typename Frame>
-void test_einstein_solution() {
+void test_einstein_solution(const bool use_non_zero_velocity) {
+  INFO("Verify KerrSchild solution satisfies Einstein equations");
   // Parameters
   //   ...for KerrSchild solution
   const double mass = 1.7;
   const std::array<double, 3> spin{{0.1, 0.2, 0.3}};
   const std::array<double, 3> center{{0.3, 0.2, 0.4}};
+   const std::array<double, 3> boost_velocity{{0.4, -0.51, -0.5}};
   //   ...for grid
   const std::array<double, 3> lower_bound{{0.8, 1.22, 1.30}};
   const double time = -2.8;
 
-  gr::Solutions::KerrSchild solution(mass, spin, center);
-  TestHelpers::VerifyGrSolution::verify_consistency(
-      solution, time, tnsr::I<double, 3, Frame>{lower_bound}, 0.01, 1.0e-10);
-  if constexpr (std::is_same_v<Frame, ::Frame::Inertial>) {
-    // Don't look at time-independent solution in other than the inertial
-    // frame.
-    const size_t grid_size = 8;
-    const std::array<double, 3> upper_bound{{0.82, 1.24, 1.32}};
-    TestHelpers::VerifyGrSolution::verify_time_independent_einstein_solution(
-        solution, grid_size, lower_bound, upper_bound,
-        std::numeric_limits<double>::epsilon() * 1.e5);
+  if (use_non_zero_velocity) {
+    gr::Solutions::KerrSchild solution(mass, spin, center, boost_velocity);
+    // Time derivatives are non zero. However we do not code up the time
+    // dependence of the boosted solution for simplicity. Hence we only check
+    // consistency in the spatial derivatives.
+    TestHelpers::VerifyGrSolution::verify_spatial_consistency(
+        solution, time, tnsr::I<double, 3, Frame>{lower_bound}, 0.01, 1.0e-10);
+  } else {
+    gr::Solutions::KerrSchild solution(mass, spin, center);
+    TestHelpers::VerifyGrSolution::verify_consistency(
+        solution, time, tnsr::I<double, 3, Frame>{lower_bound}, 0.01, 1.0e-10);
+    if constexpr (std::is_same_v<Frame, ::Frame::Inertial>) {
+      // Don't look at time-independent solution in other than the inertial
+      // frame.
+      const size_t grid_size = 8;
+      const std::array<double, 3> upper_bound{{0.82, 1.24, 1.32}};
+      TestHelpers::VerifyGrSolution::verify_time_independent_einstein_solution(
+          solution, grid_size, lower_bound, upper_bound,
+          std::numeric_limits<double>::epsilon() * 1.e5);
+    }
   }
+
 }
 
 template <typename Frame, typename DataType>
@@ -366,13 +392,127 @@ void test_zero_spin_optimization(const DataType& used_for_size) {
       });
 }
 
+template <typename Frame, typename DataType>
+void test_boosted_for_zero_velocity(const DataType& used_for_size) {
+  const double epsilon = std::numeric_limits<double>::epsilon();
+  const std::array<double, 3> boost_velocity{{0.0, 0.0, epsilon}};
+
+  gr::Solutions::KerrSchild solution_zero_velocity(
+      3.0, {{0., 0., 0.}}, {{0.2, 0.3, 0.2}});
+  gr::Solutions::KerrSchild solution_tiny_velocity(
+      3.0, {{0., 0., 1e-50}}, {{0.2, 0.3, 0.2}}, boost_velocity);
+  CHECK(solution_zero_velocity.zero_velocity());
+  CHECK(not solution_tiny_velocity.zero_velocity());
+  const auto x = spatial_coords<Frame>(used_for_size);
+
+  // We do not test gr::Tags::SpacetimeChristoffelSecondKind<DataType, 3, Frame>
+  // as it is not supported for the boosted solution.
+  using all_tags = typename gr::Solutions::KerrSchild::tags<DataType, Frame>;
+  using tags_to_test = tmpl::remove<
+      all_tags, gr::Tags::SpacetimeChristoffelSecondKind<DataType, 3, Frame>>;
+
+  const auto all_tags_zero_velocity =
+      solution_zero_velocity.variables(x, 0., tags_to_test{});
+  const auto all_tags_tiny_velocity =
+      solution_tiny_velocity.variables(x, 0., tags_to_test{});
+  tmpl::for_each<tags_to_test>(
+      [&all_tags_zero_velocity, &all_tags_tiny_velocity](auto tag_v) {
+        using tag = tmpl::type_from<decltype(tag_v)>;
+        CHECK_ITERABLE_APPROX(get<tag>(all_tags_zero_velocity),
+                              get<tag>(all_tags_tiny_velocity));
+      });
+}
+
+template <typename Frame, typename DataType>
+void test_boosted_spacetime_metric(const DataType& used_for_size) {
+  // Test that the spacetime metric of the boosted solution indeed
+  // corresponds to the boosted spacetime metric tensor
+
+  const auto x = spatial_coords<Frame>(used_for_size);
+  const double t = 0.0;
+
+  // KerrSchild solution
+  const double mass = 1.0;
+  const std::array<double, 3> spin{{0.0, 0.0, 0.0}};
+  const std::array<double, 3> center{{0.0, 0.0, 0.0}};
+  gr::Solutions::KerrSchild solution(mass, spin, center);
+
+  // Boosted KerrSchild solution
+  const std::array<double, 3> velocity{{0.5, 0.0, 0.0}};
+  gr::Solutions::KerrSchild boosted_solution(mass, spin, center, velocity);
+
+  // Need to evaluate at the boosted coordinates
+  // Boost coordinates
+  tnsr::I<DataType, 3, Frame> x_boosted;
+  sr::lorentz_boost(make_not_null(&x_boosted), x, 0., -velocity);
+
+  // We do not test gr::Tags::SpacetimeChristoffelSecondKind<DataType, 3, Frame>
+  // as it is not supported for the boosted solution.
+  using all_tags = typename gr::Solutions::KerrSchild::tags<DataType, Frame>;
+  using tags_to_test = tmpl::remove<
+      all_tags, gr::Tags::SpacetimeChristoffelSecondKind<DataType, 3, Frame>>;
+
+  const auto vars = solution.variables(x_boosted, t, tags_to_test{});
+  const auto& lapse = get<typename gr::Tags::Lapse<DataType>>(vars);
+  const auto& shift = get<typename gr::Tags::Shift<DataType, 3, Frame>>(vars);
+  const auto& spatial_metric =
+      get<typename gr::Tags::SpatialMetric<DataType, 3, Frame>>(vars);
+
+  // Compute spacetime metric
+  tnsr::aa<DataType, 3, Frame> spacetime_metric;
+  gr::spacetime_metric(make_not_null(&spacetime_metric), lapse, shift,
+                       spatial_metric);
+
+  auto spacetime_metric_as_asymmetric_tensor =
+      make_with_value<tnsr::ab<DataType, 3, Frame>>(x, 0.0);
+  for (size_t a = 0; a < 4; ++a) {
+    for (size_t b = 0; b < 4; ++b) {
+      spacetime_metric_as_asymmetric_tensor.get(a, b) =
+          spacetime_metric.get(a, b);
+    }
+  }
+
+  tnsr::ab<DataType, 3, Frame> expected_boosted_spacetime_metric;
+  sr::lorentz_boost(make_not_null(&expected_boosted_spacetime_metric),
+                    spacetime_metric_as_asymmetric_tensor, -velocity);
+
+  // Boosted metric quantities
+  const auto boosted_vars = boosted_solution.variables(x, t, tags_to_test{});
+  const auto& lapse_from_boosted_solution =
+      get<typename gr::Tags::Lapse<DataType>>(boosted_vars);
+  const auto& shift_from_boosted_solution =
+      get<typename gr::Tags::Shift<DataType, 3, Frame>>(boosted_vars);
+  const auto& spatial_metric_from_boosted_solution =
+      get<typename gr::Tags::SpatialMetric<DataType, 3, Frame>>(boosted_vars);
+
+  tnsr::aa<DataType, 3, Frame> spacetime_metric_from_boosted_solution;
+  gr::spacetime_metric(make_not_null(&spacetime_metric_from_boosted_solution),
+                       lapse_from_boosted_solution, shift_from_boosted_solution,
+                       spatial_metric_from_boosted_solution);
+
+  auto spacetime_metric_from_boosted_solution_as_asymmetric_tensor =
+      make_with_value<tnsr::ab<DataType, 3, Frame>>(x, 0.0);
+  for (size_t a = 0; a < 4; ++a) {
+    for (size_t b = 0; b < 4; ++b) {
+      spacetime_metric_from_boosted_solution_as_asymmetric_tensor.get(a, b) =
+          spacetime_metric_from_boosted_solution.get(a, b);
+    }
+  }
+
+  CHECK_ITERABLE_APPROX(
+      expected_boosted_spacetime_metric,
+      spacetime_metric_from_boosted_solution_as_asymmetric_tensor);
+}
+
 void test_serialize() {
-  gr::Solutions::KerrSchild solution(3.0, {{0.2, 0.3, 0.2}}, {{0.0, 3.0, 4.0}});
+  gr::Solutions::KerrSchild solution(3.0, {{0.2, 0.3, 0.2}}, {{0.0, 3.0, 4.0}},
+                                     {{0.1, 0.2, 0.3}});
   test_serialization(solution);
 }
 
 void test_copy_and_move() {
-  gr::Solutions::KerrSchild solution(3.0, {{0.2, 0.3, 0.2}}, {{0.0, 3.0, 4.0}});
+  gr::Solutions::KerrSchild solution(3.0, {{0.2, 0.3, 0.2}}, {{0.0, 3.0, 4.0}},
+                                     {{0.1, 0.2, 0.3}});
   test_copy_semantics(solution);
   auto solution_copy = solution;
   // clang-tidy: std::move of trivially copyable type
@@ -383,9 +523,11 @@ void test_construct_from_options() {
   const auto created = TestHelpers::test_creation<gr::Solutions::KerrSchild>(
       "Mass: 0.5\n"
       "Spin: [0.1,0.2,0.3]\n"
-      "Center: [1.0,3.0,2.0]");
-  CHECK(created ==
-        gr::Solutions::KerrSchild(0.5, {{0.1, 0.2, 0.3}}, {{1.0, 3.0, 2.0}}));
+      "Center: [1.0,3.0,2.0]\n"
+      "Velocity: [0.5,0.4,0.3]");
+  CHECK(created == gr::Solutions::KerrSchild(0.5, {{0.1, 0.2, 0.3}},
+                                             {{1.0, 3.0, 2.0}},
+                                             {{0.5, 0.4, 0.3}}));
 }
 
 }  // namespace
@@ -401,18 +543,26 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.AnalyticSolutions.Gr.KerrSchild",
   test_numerical_deriv_det_spatial_metric<Frame::Inertial>(DataVector(5));
   test_tag_retrieval<Frame::Inertial>(DataVector(5));
   test_tag_retrieval<Frame::Inertial>(0.0);
-  test_einstein_solution<Frame::Inertial>();
+  test_einstein_solution<Frame::Inertial>(true);
+  test_einstein_solution<Frame::Inertial>(false);
   test_zero_spin_optimization<Frame::Inertial>(DataVector(5));
   test_zero_spin_optimization<Frame::Inertial>(0.0);
+  test_boosted_for_zero_velocity<Frame::Inertial>(DataVector(5));
+  test_boosted_for_zero_velocity<Frame::Inertial>(0.0);
+  test_boosted_spacetime_metric<Frame::Inertial, double>(0.0);
 
   test_schwarzschild<Frame::Grid>(DataVector(5));
   test_schwarzschild<Frame::Grid>(0.0);
   test_numerical_deriv_det_spatial_metric<Frame::Grid>(DataVector(5));
   test_tag_retrieval<Frame::Grid>(DataVector(5));
   test_tag_retrieval<Frame::Grid>(0.0);
-  test_einstein_solution<Frame::Grid>();
+  test_einstein_solution<Frame::Grid>(true);
+  test_einstein_solution<Frame::Grid>(false);
   test_zero_spin_optimization<Frame::Grid>(DataVector(5));
   test_zero_spin_optimization<Frame::Grid>(0.0);
+  test_boosted_for_zero_velocity<Frame::Grid>(DataVector(5));
+  test_boosted_for_zero_velocity<Frame::Grid>(0.0);
+  test_boosted_spacetime_metric<Frame::Grid, double>(0.0);
 
   CHECK_THROWS_WITH(
       []() {
@@ -429,13 +579,15 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.AnalyticSolutions.Gr.KerrSchild",
   CHECK_THROWS_WITH(TestHelpers::test_creation<gr::Solutions::KerrSchild>(
                         "Mass: -0.5\n"
                         "Spin: [0.1,0.2,0.3]\n"
-                        "Center: [1.0,3.0,2.0]"),
+                        "Center: [1.0,3.0,2.0]\n"
+                        "Velocity: [0,0,0]"),
                     Catch::Matchers::ContainsSubstring(
                         "Value -0.5 is below the lower bound of 0"));
   CHECK_THROWS_WITH(
       TestHelpers::test_creation<gr::Solutions::KerrSchild>(
           "Mass: 0.5\n"
           "Spin: [1.1,0.9,0.3]\n"
-          "Center: [1.0,3.0,2.0]"),
+          "Center: [1.0,3.0,2.0]\n"
+          "Velocity: [0,0,0]"),
       Catch::Matchers::ContainsSubstring("Spin magnitude must be < 1"));
 }

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Test_WrappedGr.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Test_WrappedGr.cpp
@@ -44,10 +44,9 @@ void compare_different_wrapped_solutions(const double mass,
 template <typename SolutionType>
 void test_copy_and_move(const SolutionType& solution) {
   test_copy_semantics(solution);
-  auto solution_copy = solution;
   auto solution_copy2 = solution;
   // clang-tidy: std::move of trivially copyable type
-  test_move_semantics(std::move(solution_copy2), solution_copy);  // NOLINT
+  test_move_semantics(std::move(solution_copy2), solution);  // NOLINT
 }
 
 template <typename SolutionType, typename... Args>
@@ -136,8 +135,27 @@ void test_construct_from_options() {
   const double mass = 0.5;
   const std::array<double, 3> spin{{0.1, 0.2, 0.3}};
   const std::array<double, 3> center{{1.0, 3.0, 2.0}};
+
   CHECK(created == gh::Solutions::WrappedGr<SolutionType>(mass, spin, center));
 }
+
+template <>
+void test_construct_from_options<gr::Solutions::KerrSchild>() {
+  const auto created = TestHelpers::test_creation<
+      gh::Solutions::WrappedGr<gr::Solutions::KerrSchild>>(
+      "Mass: 0.5\n"
+      "Spin: [0.1,0.2,0.3]\n"
+      "Center: [1.0,3.0,2.0]\n"
+      "Velocity: [0.1,-0.3,0.5]");
+  const double mass = 0.5;
+  const std::array<double, 3> spin{{0.1, 0.2, 0.3}};
+  const std::array<double, 3> center{{1.0, 3.0, 2.0}};
+    const std::array<double, 3> velocity{{0.1, -0.3, 0.5}};
+
+  CHECK(created == gh::Solutions::WrappedGr<gr::Solutions::KerrSchild>(
+                       mass, spin, center, velocity));
+}
+
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.PointwiseFunctions.AnalyticSolutions.Gr.WrappedGr",

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Xcts/Test_Kerr.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Xcts/Test_Kerr.cpp
@@ -59,7 +59,8 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.AnalyticSolutions.Xcts.Kerr",
                 "KerrSchild:\n"
                 "  Mass: 0.43\n"
                 "  Spin: [0.1, 0.2, 0.3]\n"
-                "  Center: [1., 2., 3.]");
+                "  Center: [1., 2., 3.]\n"
+                "  Velocity: [0., 0., 0.]");
 }
 
 }  // namespace Xcts::Solutions

--- a/tests/Unit/PointwiseFunctions/SpecialRelativity/Test_LorentzBoostMatrix.cpp
+++ b/tests/Unit/PointwiseFunctions/SpecialRelativity/Test_LorentzBoostMatrix.cpp
@@ -60,6 +60,97 @@ void test_lorentz_boost_matrix_analytic(const double& velocity_squared) {
   }
   CHECK_ITERABLE_APPROX(inverse_check, identity_matrix);
 }
+
+template <typename DataType, size_t SpatialDim, typename Frame>
+void test_lorentz_boost(const std::array<double, SpatialDim> velocity) {
+  const DataVector used_for_size{3., 4., 5.};
+
+  MAKE_GENERATOR(generator);
+  std::uniform_real_distribution<> distribution(-0.2, 0.2);
+
+  auto covariant_vector =
+      make_with_random_values<tnsr::a<DataType, SpatialDim, Frame>>(
+          make_not_null(&generator), make_not_null(&distribution),
+          used_for_size);
+
+  tnsr::a<DataType, SpatialDim, Frame> boosted_covariant_vector;
+  sr::lorentz_boost<DataType, SpatialDim, Frame>(
+      make_not_null(&boosted_covariant_vector), covariant_vector, velocity);
+
+  // Check that applying the inverse boost returns the original vector
+  tnsr::a<DataType, SpatialDim, Frame> unboosted_covariant_vector;
+  sr::lorentz_boost<DataType, SpatialDim, Frame>(
+      make_not_null(&unboosted_covariant_vector), boosted_covariant_vector,
+      -velocity);
+  CHECK_ITERABLE_APPROX(unboosted_covariant_vector, covariant_vector);
+
+  // Check boost of the spatial vector
+  auto contravariant_vector =
+      make_with_random_values<tnsr::a<DataType, SpatialDim, Frame>>(
+          make_not_null(&generator), make_not_null(&distribution),
+          used_for_size);
+  tnsr::I<DataType, SpatialDim, Frame> spatial_vector =
+      make_with_value<tnsr::I<DataType, SpatialDim, Frame>>(used_for_size, 0.0);
+  for (size_t i = 0; i < SpatialDim; ++i) {
+    spatial_vector.get(i) = contravariant_vector.get(i + 1);
+  }
+  // Lower index, i.e. v_0
+  const double vector_component_0 = get<0>(contravariant_vector);
+
+  tnsr::I<DataType, SpatialDim, Frame> boosted_spatial_vector =
+      make_with_value<tnsr::I<DataType, SpatialDim, Frame>>(used_for_size, 0.0);
+  sr::lorentz_boost<DataType, SpatialDim, Frame>(
+      make_not_null(&boosted_spatial_vector), spatial_vector,
+      vector_component_0, velocity);
+
+  // We don't have an overload of the Lorentz boost for 4d vectors (just for one
+  // forms). But we can just change the sign of the velocity to boost it with
+  // the inverse Lorentz matrix for testing
+  tnsr::a<DataType, SpatialDim, Frame> boosted_contravariant_vector;
+  sr::lorentz_boost<DataType, SpatialDim, Frame>(
+      make_not_null(&boosted_contravariant_vector), contravariant_vector,
+      -velocity);
+  tnsr::I<DataType, SpatialDim, Frame> expected_spatial_vector =
+      make_with_value<tnsr::I<DataType, SpatialDim, Frame>>(used_for_size, 0.0);
+  for (size_t i = 0; i < SpatialDim; ++i) {
+    expected_spatial_vector.get(i) = boosted_contravariant_vector.get(i + 1);
+  }
+  CHECK_ITERABLE_APPROX(expected_spatial_vector, boosted_spatial_vector);
+
+  // Check boost on rank-2 matrix by constructing one with an outer tensor
+  // product, i.e. T_{ab} = v_{a} u_{b}
+  tnsr::ab<DataType, SpatialDim, Frame> tensor =
+      make_with_value<tnsr::ab<DataType, SpatialDim, Frame>>(used_for_size,
+                                                             0.0);
+  tnsr::ab<DataType, SpatialDim, Frame> boosted_tensor =
+      make_with_value<tnsr::ab<DataType, SpatialDim, Frame>>(used_for_size,
+                                                             0.0);
+  tnsr::ab<DataType, SpatialDim, Frame> expected_tensor =
+      make_with_value<tnsr::ab<DataType, SpatialDim, Frame>>(used_for_size,
+                                                             0.0);
+  // We need a second covariant vector
+  auto covariant_vector_2 =
+      make_with_random_values<tnsr::a<DataType, SpatialDim, Frame>>(
+          make_not_null(&generator), make_not_null(&distribution),
+          used_for_size);
+  // We boost it as well
+  tnsr::a<DataType, SpatialDim, Frame> boosted_covariant_vector_2;
+  sr::lorentz_boost<DataType, SpatialDim, Frame>(
+      make_not_null(&boosted_covariant_vector_2), covariant_vector_2, velocity);
+
+  for (size_t i = 0; i < SpatialDim + 1; ++i) {
+    for (size_t j = 0; j < SpatialDim + 1; ++j) {
+      tensor.get(i, j) = covariant_vector.get(i) * covariant_vector_2.get(j);
+      expected_tensor.get(i, j) =
+          boosted_covariant_vector.get(i) * boosted_covariant_vector_2.get(j);
+    }
+  }
+
+  sr::lorentz_boost<DataType, SpatialDim, Frame>(make_not_null(&boosted_tensor),
+                                                 tensor, velocity);
+  CHECK_ITERABLE_APPROX(expected_tensor, boosted_tensor);
+}
+
 }  // namespace
 
 SPECTRE_TEST_CASE(
@@ -85,4 +176,7 @@ SPECTRE_TEST_CASE(
 
   d = large_velocity_squared;
   CHECK_FOR_DOUBLES(test_lorentz_boost_matrix_analytic, (1, 2, 3));
+
+  const std::array<double, 3> velocity{{0.1, -0.4, 0.3}};
+  test_lorentz_boost<double, 3, Frame::Inertial>(velocity);
 }


### PR DESCRIPTION
## Proposed changes

Add a boost to the KerrSchild solution. This is done by boosting the coordinates, null form and derivatives of the H function defining the KerrSchild solution. (For the case when there is a boost the solution depends on time as well, but we don't code up the time dependence of the coordinates for simplicity.)

Evolving this solution will require time dependent translation maps to keep the excision surface inside the apparent horizon (#5576)

This reuses items from https://github.com/sxs-collaboration/spectre/compare/develop...nilsvu:spectre:kerr_boost


<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
