### PR TITLE
Enable different upper and lower BCs for Brick.

### DIFF
--- a/src/Domain/Creators/Brick.cpp
+++ b/src/Domain/Creators/Brick.cpp
@@ -45,9 +45,12 @@ Brick::Brick(
       initial_number_of_grid_points_in_xyz_(                 // NOLINT
           std::move(initial_number_of_grid_points_in_xyz)),  // NOLINT
       time_dependence_(std::move(time_dependence)),
-      boundary_condition_in_x_(nullptr),
-      boundary_condition_in_y_(nullptr),
-      boundary_condition_in_z_(nullptr) {
+      boundary_condition_in_lower_x_(nullptr),
+      boundary_condition_in_upper_x_(nullptr),
+      boundary_condition_in_lower_y_(nullptr),
+      boundary_condition_in_upper_y_(nullptr),
+      boundary_condition_in_lower_z_(nullptr),
+      boundary_condition_in_upper_z_(nullptr) {
   if (time_dependence_ == nullptr) {
     time_dependence_ =
         std::make_unique<domain::creators::time_dependence::None<3>>();
@@ -59,11 +62,17 @@ Brick::Brick(
     typename InitialRefinement::type initial_refinement_level_xyz,
     typename InitialGridPoints::type initial_number_of_grid_points_in_xyz,
     std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
-        boundary_condition_in_x,
+        boundary_condition_in_lower_x,
     std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
-        boundary_condition_in_y,
+        boundary_condition_in_upper_x,
     std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
-        boundary_condition_in_z,
+        boundary_condition_in_lower_y,
+    std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
+        boundary_condition_in_upper_y,
+    std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
+        boundary_condition_in_lower_z,
+    std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
+        boundary_condition_in_upper_z,
     std::unique_ptr<domain::creators::time_dependence::TimeDependence<3>>
         time_dependence,
     const Options::Context& context)
@@ -76,33 +85,58 @@ Brick::Brick(
       initial_number_of_grid_points_in_xyz_(                 // NOLINT
           std::move(initial_number_of_grid_points_in_xyz)),  // NOLINT
       time_dependence_(std::move(time_dependence)),
-      boundary_condition_in_x_(std::move(boundary_condition_in_x)),
-      boundary_condition_in_y_(std::move(boundary_condition_in_y)),
-      boundary_condition_in_z_(std::move(boundary_condition_in_z)) {
+      boundary_condition_in_lower_x_(std::move(boundary_condition_in_lower_x)),
+      boundary_condition_in_upper_x_(std::move(boundary_condition_in_upper_x)),
+      boundary_condition_in_lower_y_(std::move(boundary_condition_in_lower_y)),
+      boundary_condition_in_upper_y_(std::move(boundary_condition_in_upper_y)),
+      boundary_condition_in_lower_z_(std::move(boundary_condition_in_lower_z)),
+      boundary_condition_in_upper_z_(std::move(boundary_condition_in_upper_z)) {
   if (time_dependence_ == nullptr) {
     time_dependence_ =
         std::make_unique<domain::creators::time_dependence::None<3>>();
   }
   using domain::BoundaryConditions::is_none;
-  ASSERT(boundary_condition_in_x_ != nullptr and
-             boundary_condition_in_y_ != nullptr and
-             boundary_condition_in_z_ != nullptr,
+  ASSERT(boundary_condition_in_lower_x_ != nullptr and
+             boundary_condition_in_upper_x_ != nullptr and
+             boundary_condition_in_lower_y_ != nullptr and
+             boundary_condition_in_upper_y_ != nullptr and
+             boundary_condition_in_lower_z_ != nullptr and
+             boundary_condition_in_upper_z_ != nullptr,
          "None of the boundary conditions can be nullptr.");
-  if (is_none(boundary_condition_in_x_) or is_none(boundary_condition_in_y_) or
-      is_none(boundary_condition_in_z_)) {
+  if (is_none(boundary_condition_in_lower_x_) or
+      is_none(boundary_condition_in_upper_x_) or
+      is_none(boundary_condition_in_lower_y_) or
+      is_none(boundary_condition_in_upper_y_) or
+      is_none(boundary_condition_in_lower_z_) or
+      is_none(boundary_condition_in_lower_z_)) {
     PARSE_ERROR(
         context,
         "None boundary condition is not supported. If you would like an "
         "outflow-type boundary condition, you must use that.");
   }
   using domain::BoundaryConditions::is_periodic;
-  if (is_periodic(boundary_condition_in_x_)) {
+
+  if ((is_periodic(boundary_condition_in_lower_x_) !=
+       is_periodic(boundary_condition_in_upper_x_)) or
+      (is_periodic(boundary_condition_in_lower_y_) !=
+       is_periodic(boundary_condition_in_upper_y_)) or
+      (is_periodic(boundary_condition_in_lower_z_) !=
+       is_periodic(boundary_condition_in_lower_z_))) {
+    PARSE_ERROR(context,
+                "Pierodic boundary condition must be applied for both "
+                "upper and lower direction.");
+  }
+
+  if (is_periodic(boundary_condition_in_lower_x_) and
+      is_periodic(boundary_condition_in_upper_x_)) {
     is_periodic_in_xyz_[0] = true;
   }
-  if (is_periodic(boundary_condition_in_y_)) {
+  if (is_periodic(boundary_condition_in_lower_y_) and
+      is_periodic(boundary_condition_in_upper_y_)) {
     is_periodic_in_xyz_[1] = true;
   }
-  if (is_periodic(boundary_condition_in_z_)) {
+  if (is_periodic(boundary_condition_in_lower_z_) and
+      is_periodic(boundary_condition_in_upper_z_)) {
     is_periodic_in_xyz_[2] = true;
   }
 }
@@ -143,28 +177,35 @@ Domain<3> Brick::create_domain() const {
 std::vector<DirectionMap<
     3, std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>>
 Brick::external_boundary_conditions() const {
-  if (boundary_condition_in_x_ == nullptr) {
-    ASSERT(boundary_condition_in_y_ == nullptr and
-               boundary_condition_in_z_ == nullptr,
+  if (boundary_condition_in_lower_x_ == nullptr) {
+    ASSERT(boundary_condition_in_upper_x_ == nullptr and
+               boundary_condition_in_lower_y_ == nullptr and
+               boundary_condition_in_upper_y_ == nullptr and
+               boundary_condition_in_lower_z_ == nullptr and
+               boundary_condition_in_upper_z_ == nullptr,
            "Boundary conditions must be specified in all or no directions");
     return {};
   }
   std::vector<DirectionMap<
       3, std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>>
       boundary_conditions{1};
-  for (const auto& side : {Side::Lower, Side::Upper}) {
-    if (not is_periodic_in_xyz_[0]) {
-      boundary_conditions[0][Direction<3>{0, side}] =
-          boundary_condition_in_x_->get_clone();
-    }
-    if (not is_periodic_in_xyz_[1]) {
-      boundary_conditions[0][Direction<3>{1, side}] =
-          boundary_condition_in_y_->get_clone();
-    }
-    if (not is_periodic_in_xyz_[2]) {
-      boundary_conditions[0][Direction<3>{2, side}] =
-          boundary_condition_in_z_->get_clone();
-    }
+  if (not is_periodic_in_xyz_[0]) {
+    boundary_conditions[0][Direction<3>{0, Side::Lower}] =
+        boundary_condition_in_lower_x_->get_clone();
+    boundary_conditions[0][Direction<3>{0, Side::Upper}] =
+        boundary_condition_in_upper_x_->get_clone();
+  }
+  if (not is_periodic_in_xyz_[1]) {
+    boundary_conditions[0][Direction<3>{1, Side::Lower}] =
+        boundary_condition_in_lower_y_->get_clone();
+    boundary_conditions[0][Direction<3>{1, Side::Upper}] =
+        boundary_condition_in_upper_y_->get_clone();
+  }
+  if (not is_periodic_in_xyz_[2]) {
+    boundary_conditions[0][Direction<3>{2, Side::Lower}] =
+        boundary_condition_in_lower_z_->get_clone();
+    boundary_conditions[0][Direction<3>{2, Side::Upper}] =
+        boundary_condition_in_upper_z_->get_clone();
   }
   return boundary_conditions;
 }

--- a/tests/Unit/Domain/Creators/Test_Brick.cpp
+++ b/tests/Unit/Domain/Creators/Test_Brick.cpp
@@ -92,7 +92,7 @@ std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
 create_boundary_condition() {
   return std::make_unique<
       TestHelpers::domain::BoundaryConditions::TestBoundaryCondition<3>>(
-      Direction<3>::upper_zeta(), 2);
+      Direction<3>::lower_xi(), 2);
 }
 
 void test_brick() {
@@ -117,15 +117,20 @@ void test_brick() {
                                {Direction<3>::upper_eta()},
                                {Direction<3>::lower_zeta()},
                                {Direction<3>::upper_zeta()}}});
+  using VariantType = std::variant<
+      std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>,
+      creators::Brick::LowerUpperBoundaryCondition<
+          domain::BoundaryConditions::BoundaryCondition>>;
 
-  const creators::Brick brick_boundary_condition{lower_bound,
-                                                 upper_bound,
-                                                 refinement_level[0],
-                                                 grid_points[0],
-                                                 create_boundary_condition(),
-                                                 create_boundary_condition(),
-                                                 create_boundary_condition(),
-                                                 {}};
+  const creators::Brick brick_boundary_condition{
+      lower_bound,
+      upper_bound,
+      refinement_level[0],
+      grid_points[0],
+      VariantType{create_boundary_condition()},
+      VariantType{create_boundary_condition()},
+      VariantType{create_boundary_condition()},
+      {}};
   test_brick_construction(brick_boundary_condition, lower_bound, upper_bound,
                           grid_points, refinement_level,
                           std::vector<DirectionMap<3, BlockNeighbor<3>>>{{}},
@@ -182,11 +187,11 @@ void test_brick() {
            {Direction<3>::upper_eta()}}});
   test_brick_construction(
       creators::Brick{lower_bound, upper_bound, refinement_level[0],
-                      grid_points[0], create_boundary_condition(),
-                      create_boundary_condition(),
-                      TestHelpers::domain::BoundaryConditions::
-                          TestPeriodicBoundaryCondition<3>{}
-                              .get_clone()},
+                      grid_points[0], VariantType{create_boundary_condition()},
+                      VariantType{create_boundary_condition()},
+                      VariantType{TestHelpers::domain::BoundaryConditions::
+                                      TestPeriodicBoundaryCondition<3>{}
+                                          .get_clone()}},
       lower_bound, upper_bound, grid_points, refinement_level,
       std::vector<DirectionMap<3, BlockNeighbor<3>>>{
           {{Direction<3>::lower_zeta(), {0, aligned_orientation}},
@@ -201,10 +206,11 @@ void test_brick() {
   test_brick_construction(
       creators::Brick{lower_bound, upper_bound, refinement_level[0],
                       grid_points[0],
-                      TestHelpers::domain::BoundaryConditions::
-                          TestPeriodicBoundaryCondition<3>{}
-                              .get_clone(),
-                      create_boundary_condition(), create_boundary_condition()},
+                      VariantType{TestHelpers::domain::BoundaryConditions::
+                                      TestPeriodicBoundaryCondition<3>{}
+                                          .get_clone()},
+                      VariantType{create_boundary_condition()},
+                      VariantType{create_boundary_condition()}},
       lower_bound, upper_bound, grid_points, refinement_level,
       std::vector<DirectionMap<3, BlockNeighbor<3>>>{
           {{Direction<3>::lower_xi(), {0, aligned_orientation}},
@@ -218,11 +224,11 @@ void test_brick() {
   // Periodic in y
   test_brick_construction(
       creators::Brick{lower_bound, upper_bound, refinement_level[0],
-                      grid_points[0], create_boundary_condition(),
-                      TestHelpers::domain::BoundaryConditions::
-                          TestPeriodicBoundaryCondition<3>{}
-                              .get_clone(),
-                      create_boundary_condition()},
+                      grid_points[0], VariantType{create_boundary_condition()},
+                      VariantType{TestHelpers::domain::BoundaryConditions::
+                                      TestPeriodicBoundaryCondition<3>{}
+                                          .get_clone()},
+                      VariantType{create_boundary_condition()}},
       lower_bound, upper_bound, grid_points, refinement_level,
       std::vector<DirectionMap<3, BlockNeighbor<3>>>{
           {{Direction<3>::lower_eta(), {0, aligned_orientation}},
@@ -249,13 +255,13 @@ void test_brick() {
   test_brick_construction(
       creators::Brick{lower_bound, upper_bound, refinement_level[0],
                       grid_points[0],
-                      TestHelpers::domain::BoundaryConditions::
-                          TestPeriodicBoundaryCondition<3>{}
-                              .get_clone(),
-                      TestHelpers::domain::BoundaryConditions::
-                          TestPeriodicBoundaryCondition<3>{}
-                              .get_clone(),
-                      create_boundary_condition()},
+                      VariantType{TestHelpers::domain::BoundaryConditions::
+                                      TestPeriodicBoundaryCondition<3>{}
+                                          .get_clone()},
+                      VariantType{TestHelpers::domain::BoundaryConditions::
+                                      TestPeriodicBoundaryCondition<3>{}
+                                          .get_clone()},
+                      VariantType{create_boundary_condition()}},
       lower_bound, upper_bound, grid_points, refinement_level,
       std::vector<DirectionMap<3, BlockNeighbor<3>>>{
           {{Direction<3>::lower_xi(), {0, aligned_orientation}},
@@ -284,13 +290,13 @@ void test_brick() {
       }});
   test_brick_construction(
       creators::Brick{lower_bound, upper_bound, refinement_level[0],
-                      grid_points[0], create_boundary_condition(),
-                      TestHelpers::domain::BoundaryConditions::
-                          TestPeriodicBoundaryCondition<3>{}
-                              .get_clone(),
-                      TestHelpers::domain::BoundaryConditions::
-                          TestPeriodicBoundaryCondition<3>{}
-                              .get_clone()},
+                      grid_points[0], VariantType{create_boundary_condition()},
+                      VariantType{TestHelpers::domain::BoundaryConditions::
+                                      TestPeriodicBoundaryCondition<3>{}
+                                          .get_clone()},
+                      VariantType{TestHelpers::domain::BoundaryConditions::
+                                      TestPeriodicBoundaryCondition<3>{}
+                                          .get_clone()}},
       lower_bound, upper_bound, grid_points, refinement_level,
       std::vector<DirectionMap<3, BlockNeighbor<3>>>{
           {{Direction<3>::lower_eta(), {0, aligned_orientation}},
@@ -317,13 +323,13 @@ void test_brick() {
   test_brick_construction(
       creators::Brick{lower_bound, upper_bound, refinement_level[0],
                       grid_points[0],
-                      TestHelpers::domain::BoundaryConditions::
-                          TestPeriodicBoundaryCondition<3>{}
-                              .get_clone(),
-                      create_boundary_condition(),
-                      TestHelpers::domain::BoundaryConditions::
-                          TestPeriodicBoundaryCondition<3>{}
-                              .get_clone()},
+                      VariantType{TestHelpers::domain::BoundaryConditions::
+                                      TestPeriodicBoundaryCondition<3>{}
+                                          .get_clone()},
+                      VariantType{create_boundary_condition()},
+                      VariantType{TestHelpers::domain::BoundaryConditions::
+                                      TestPeriodicBoundaryCondition<3>{}
+                                          .get_clone()}},
       lower_bound, upper_bound, grid_points, refinement_level,
       std::vector<DirectionMap<3, BlockNeighbor<3>>>{
           {{Direction<3>::lower_xi(), {0, aligned_orientation}},
@@ -354,15 +360,15 @@ void test_brick() {
       upper_bound,
       refinement_level[0],
       grid_points[0],
-      TestHelpers::domain::BoundaryConditions::TestPeriodicBoundaryCondition<
-          3>{}
-          .get_clone(),
-      TestHelpers::domain::BoundaryConditions::TestPeriodicBoundaryCondition<
-          3>{}
-          .get_clone(),
-      TestHelpers::domain::BoundaryConditions::TestPeriodicBoundaryCondition<
-          3>{}
-          .get_clone()};
+      VariantType{TestHelpers::domain::BoundaryConditions::
+                      TestPeriodicBoundaryCondition<3>{}
+                          .get_clone()},
+      VariantType{TestHelpers::domain::BoundaryConditions::
+                      TestPeriodicBoundaryCondition<3>{}
+                          .get_clone()},
+      VariantType{TestHelpers::domain::BoundaryConditions::
+                      TestPeriodicBoundaryCondition<3>{}
+                          .get_clone()}};
   test_brick_construction(
       periodic_brick_boundary_conditions, lower_bound, upper_bound, grid_points,
       refinement_level,
@@ -390,41 +396,41 @@ void test_brick() {
                  *serialize_and_deserialize(base_map));
 
   CHECK_THROWS_WITH(
-      creators::Brick(lower_bound, upper_bound, refinement_level[0],
-                      grid_points[0],
-                      std::make_unique<TestHelpers::domain::BoundaryConditions::
-                                           TestNoneBoundaryCondition<3>>(),
-                      std::make_unique<TestHelpers::domain::BoundaryConditions::
-                                           TestPeriodicBoundaryCondition<3>>(),
-                      std::make_unique<TestHelpers::domain::BoundaryConditions::
-                                           TestPeriodicBoundaryCondition<3>>(),
-                      nullptr, Options::Context{false, {}, 1, 1}),
+      creators::Brick(
+          lower_bound, upper_bound, refinement_level[0], grid_points[0],
+          VariantType{std::make_unique<TestHelpers::domain::BoundaryConditions::
+                                           TestNoneBoundaryCondition<3>>()},
+          VariantType{std::make_unique<TestHelpers::domain::BoundaryConditions::
+                                           TestPeriodicBoundaryCondition<3>>()},
+          VariantType{std::make_unique<TestHelpers::domain::BoundaryConditions::
+                                           TestPeriodicBoundaryCondition<3>>()},
+          nullptr, Options::Context{false, {}, 1, 1}),
       Catch::Matchers::ContainsSubstring(
           "None boundary condition is not supported. If you would like an "
           "outflow-type boundary condition, you must use that."));
   CHECK_THROWS_WITH(
-      creators::Brick(lower_bound, upper_bound, refinement_level[0],
-                      grid_points[0],
-                      std::make_unique<TestHelpers::domain::BoundaryConditions::
-                                           TestPeriodicBoundaryCondition<3>>(),
-                      std::make_unique<TestHelpers::domain::BoundaryConditions::
-                                           TestNoneBoundaryCondition<3>>(),
-                      std::make_unique<TestHelpers::domain::BoundaryConditions::
-                                           TestPeriodicBoundaryCondition<3>>(),
-                      nullptr, Options::Context{false, {}, 1, 1}),
+      creators::Brick(
+          lower_bound, upper_bound, refinement_level[0], grid_points[0],
+          VariantType{std::make_unique<TestHelpers::domain::BoundaryConditions::
+                                           TestPeriodicBoundaryCondition<3>>()},
+          VariantType{std::make_unique<TestHelpers::domain::BoundaryConditions::
+                                           TestNoneBoundaryCondition<3>>()},
+          VariantType{std::make_unique<TestHelpers::domain::BoundaryConditions::
+                                           TestPeriodicBoundaryCondition<3>>()},
+          nullptr, Options::Context{false, {}, 1, 1}),
       Catch::Matchers::ContainsSubstring(
           "None boundary condition is not supported. If you would like an "
           "outflow-type boundary condition, you must use that."));
   CHECK_THROWS_WITH(
-      creators::Brick(lower_bound, upper_bound, refinement_level[0],
-                      grid_points[0],
-                      std::make_unique<TestHelpers::domain::BoundaryConditions::
-                                           TestPeriodicBoundaryCondition<3>>(),
-                      std::make_unique<TestHelpers::domain::BoundaryConditions::
-                                           TestPeriodicBoundaryCondition<3>>(),
-                      std::make_unique<TestHelpers::domain::BoundaryConditions::
-                                           TestNoneBoundaryCondition<3>>(),
-                      nullptr, Options::Context{false, {}, 1, 1}),
+      creators::Brick(
+          lower_bound, upper_bound, refinement_level[0], grid_points[0],
+          VariantType{std::make_unique<TestHelpers::domain::BoundaryConditions::
+                                           TestPeriodicBoundaryCondition<3>>()},
+          VariantType{std::make_unique<TestHelpers::domain::BoundaryConditions::
+                                           TestPeriodicBoundaryCondition<3>>()},
+          VariantType{std::make_unique<TestHelpers::domain::BoundaryConditions::
+                                           TestNoneBoundaryCondition<3>>()},
+          nullptr, Options::Context{false, {}, 1, 1}),
       Catch::Matchers::ContainsSubstring(
           "None boundary condition is not supported. If you would like an "
           "outflow-type boundary condition, you must use that."));

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/SubdomainOperator/Test_SubdomainOperator.cpp
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/SubdomainOperator/Test_SubdomainOperator.cpp
@@ -679,6 +679,12 @@ struct InitializeConstitutiveRelation {
 // handles all of these geometries correctly.
 // [[TimeOut, 25]]
 SPECTRE_TEST_CASE("Unit.Elliptic.DG.SubdomainOperator", "[Unit][Elliptic]") {
+  // Needed for Brick
+  using VariantType = std::variant<
+      std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>,
+      domain::creators::Brick::LowerUpperBoundaryCondition<
+          domain::BoundaryConditions::BoundaryCondition>>;
+
   domain::creators::register_derived_with_charm();
   {
     INFO("Rectilinear and aligned");
@@ -725,12 +731,12 @@ SPECTRE_TEST_CASE("Unit.Elliptic.DG.SubdomainOperator", "[Unit][Elliptic]") {
           {{2., 1., 1.}},
           {{1, 0, 1}},
           {{3, 3, 3}},
-          make_boundary_condition<system>(
-              elliptic::BoundaryConditionType::Dirichlet),
-          make_boundary_condition<system>(
-              elliptic::BoundaryConditionType::Dirichlet),
-          make_boundary_condition<system>(
-              elliptic::BoundaryConditionType::Dirichlet),
+          VariantType{make_boundary_condition<system>(
+              elliptic::BoundaryConditionType::Dirichlet)},
+          VariantType{make_boundary_condition<system>(
+              elliptic::BoundaryConditionType::Dirichlet)},
+          VariantType{make_boundary_condition<system>(
+              elliptic::BoundaryConditionType::Dirichlet)},
           nullptr};
       test_subdomain_operator<system>(domain_creator);
     }
@@ -910,12 +916,12 @@ SPECTRE_TEST_CASE("Unit.Elliptic.DG.SubdomainOperator", "[Unit][Elliptic]") {
         {{2., 1., 1.}},
         {{1, 1, 1}},
         {{3, 3, 3}},
-        make_boundary_condition<system>(
-            elliptic::BoundaryConditionType::Dirichlet),
-        make_boundary_condition<system>(
-            elliptic::BoundaryConditionType::Dirichlet),
-        make_boundary_condition<system>(
-            elliptic::BoundaryConditionType::Dirichlet),
+        VariantType{make_boundary_condition<system>(
+            elliptic::BoundaryConditionType::Dirichlet)},
+        VariantType{make_boundary_condition<system>(
+            elliptic::BoundaryConditionType::Dirichlet)},
+        VariantType{make_boundary_condition<system>(
+            elliptic::BoundaryConditionType::Dirichlet)},
         nullptr};
     test_subdomain_operator<
         system, tmpl::list<InitializeConstitutiveRelation<3>>,

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_DgOperator.cpp
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_DgOperator.cpp
@@ -412,6 +412,12 @@ void test_dg_operator(
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Elliptic.DG.Operator", "[Unit][Elliptic]") {
+  // Needed for Brick
+  using VariantType = std::variant<
+      std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>,
+      domain::creators::Brick::LowerUpperBoundaryCondition<
+          domain::BoundaryConditions::BoundaryCondition>>;
+
   domain::creators::register_derived_with_charm();
   // This is what the tests below check:
   //
@@ -677,18 +683,18 @@ SPECTRE_TEST_CASE("Unit.Elliptic.DG.Operator", "[Unit][Elliptic]") {
           {{1.5, 1., 3.}},
           {{1, 1, 1}},
           {{2, 3, 4}},
-          std::make_unique<
+          VariantType{std::make_unique<
               elliptic::BoundaryConditions::AnalyticSolution<system>>(
               analytic_solution.get_clone(),
-              elliptic::BoundaryConditionType::Dirichlet),
-          std::make_unique<
+              elliptic::BoundaryConditionType::Dirichlet)},
+          VariantType{std::make_unique<
               elliptic::BoundaryConditions::AnalyticSolution<system>>(
               analytic_solution.get_clone(),
-              elliptic::BoundaryConditionType::Dirichlet),
-          std::make_unique<
+              elliptic::BoundaryConditionType::Dirichlet)},
+          VariantType{std::make_unique<
               elliptic::BoundaryConditions::AnalyticSolution<system>>(
               analytic_solution.get_clone(),
-              elliptic::BoundaryConditionType::Dirichlet),
+              elliptic::BoundaryConditionType::Dirichlet)},
           nullptr};
       const ElementId<3> self_id{0, {{{1, 0}, {1, 0}, {1, 0}}}};
       const ElementId<3> neighbor_id_xi{0, {{{1, 1}, {1, 0}, {1, 0}}}};
@@ -775,18 +781,18 @@ SPECTRE_TEST_CASE("Unit.Elliptic.DG.Operator", "[Unit][Elliptic]") {
           {{1.5, 1., 3.}},
           {{1, 1, 1}},
           {{12, 12, 12}},
-          std::make_unique<
+          VariantType{std::make_unique<
               elliptic::BoundaryConditions::AnalyticSolution<system>>(
               analytic_solution.get_clone(),
-              elliptic::BoundaryConditionType::Dirichlet),
-          std::make_unique<
+              elliptic::BoundaryConditionType::Dirichlet)},
+          VariantType{std::make_unique<
               elliptic::BoundaryConditions::AnalyticSolution<system>>(
               analytic_solution.get_clone(),
-              elliptic::BoundaryConditionType::Dirichlet),
-          std::make_unique<
+              elliptic::BoundaryConditionType::Dirichlet)},
+          VariantType{std::make_unique<
               elliptic::BoundaryConditions::AnalyticSolution<system>>(
               analytic_solution.get_clone(),
-              elliptic::BoundaryConditionType::Dirichlet),
+              elliptic::BoundaryConditionType::Dirichlet)},
           nullptr};
       Approx analytic_solution_aux_approx =
           Approx::custom().epsilon(1.e-4).scale(M_PI);

--- a/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/Test_BoundaryConditionGhostData.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/Test_BoundaryConditionGhostData.cpp
@@ -93,11 +93,16 @@ void test(const BoundaryConditionType& boundary_condition) {
   const std::array<size_t, 3> refinement_levels{0, 0, 0};
   const std::array<size_t, 3> number_of_grid_points{num_dg_pts, num_dg_pts,
                                                     num_dg_pts};
+  using VariantType = std::variant<
+      std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>,
+      domain::creators::Brick::LowerUpperBoundaryCondition<
+          domain::BoundaryConditions::BoundaryCondition>>;
   const auto brick = domain::creators::Brick(
       lower_bounds, upper_bounds, refinement_levels, number_of_grid_points,
-      std::make_unique<BoundaryConditionType>(boundary_condition),
-      std::make_unique<BoundaryConditionType>(boundary_condition),
-      std::make_unique<BoundaryConditionType>(boundary_condition), nullptr);
+      VariantType{std::make_unique<BoundaryConditionType>(boundary_condition)},
+      VariantType{std::make_unique<BoundaryConditionType>(boundary_condition)},
+      VariantType{std::make_unique<BoundaryConditionType>(boundary_condition)},
+      nullptr);
   auto domain = brick.create_domain();
   auto boundary_conditions = brick.external_boundary_conditions();
   const auto element = domain::Initialization::create_initial_element(

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/Test_BoundaryConditionGhostData.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/Test_BoundaryConditionGhostData.cpp
@@ -88,11 +88,16 @@ void test(const BoundaryConditionType& boundary_condition,
   const std::array<size_t, 3> refinement_levels{0, 0, 0};
   const std::array<size_t, 3> number_of_grid_points{num_dg_pts, num_dg_pts,
                                                     num_dg_pts};
+  using VariantType = std::variant<
+      std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>,
+      domain::creators::Brick::LowerUpperBoundaryCondition<
+          domain::BoundaryConditions::BoundaryCondition>>;
   const auto brick = domain::creators::Brick(
       lower_bounds, upper_bounds, refinement_levels, number_of_grid_points,
-      std::make_unique<BoundaryConditionType>(boundary_condition),
-      std::make_unique<BoundaryConditionType>(boundary_condition),
-      std::make_unique<BoundaryConditionType>(boundary_condition), nullptr);
+      VariantType{std::make_unique<BoundaryConditionType>(boundary_condition)},
+      VariantType{std::make_unique<BoundaryConditionType>(boundary_condition)},
+      VariantType{std::make_unique<BoundaryConditionType>(boundary_condition)},
+      nullptr);
   auto domain = brick.create_domain();
   auto boundary_conditions = brick.external_boundary_conditions();
   const auto element = domain::Initialization::create_initial_element(


### PR DESCRIPTION
## Proposed changes
Enable different upper and lower boundary conditions in Brick.


