### PR TITLE
Add wedge transition for shape map

### DIFF
--- a/src/Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/CMakeLists.txt
+++ b/src/Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/CMakeLists.txt
@@ -6,6 +6,7 @@ spectre_target_sources(
   PRIVATE
   RegisterDerivedWithCharm.cpp
   SphereTransition.cpp
+  Wedge.cpp
 )
 
 spectre_target_headers(
@@ -15,4 +16,5 @@ spectre_target_headers(
   RegisterDerivedWithCharm.hpp
   ShapeMapTransitionFunction.hpp
   SphereTransition.hpp
+  Wedge.hpp
 )

--- a/src/Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/RegisterDerivedWithCharm.cpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/RegisterDerivedWithCharm.cpp
@@ -4,10 +4,11 @@
 #include "Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/RegisterDerivedWithCharm.hpp"
 
 #include "Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/SphereTransition.hpp"
+#include "Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/Wedge.hpp"
 #include "Utilities/Serialization/RegisterDerivedClassesWithCharm.hpp"
 
 namespace domain::CoordinateMaps::ShapeMapTransitionFunctions {
 void register_derived_with_charm() {
-  register_classes_with_charm<SphereTransition>();
+  register_classes_with_charm<SphereTransition, Wedge>();
 }
 }  // namespace domain::CoordinateMaps::ShapeMapTransitionFunctions

--- a/src/Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/Wedge.cpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/Wedge.cpp
@@ -1,0 +1,342 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/Wedge.hpp"
+
+#include <array>
+#include <cmath>
+#include <optional>
+#include <pup.h>
+
+#include "Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/ShapeMapTransitionFunction.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "NumericalAlgorithms/RootFinding/QuadraticEquation.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/ContainerHelpers.hpp"
+#include "Utilities/EqualWithinRoundoff.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/ErrorHandling/CaptureForError.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/MakeArray.hpp"
+#include "Utilities/MakeWithValue.hpp"
+#include "Utilities/StdArrayHelpers.hpp"
+#include "Utilities/StdHelpers.hpp"
+
+namespace domain::CoordinateMaps::ShapeMapTransitionFunctions {
+template <typename T>
+T Wedge::Surface::distance(const std::array<T, 3>& coords) const {
+  // Short circuit if it's a sphere. Then the distance is trivially the radius
+  // of this surface
+  if (sphericity == 1.0) {
+    return make_with_value<T>(coords[0], radius);
+  }
+
+  ASSERT(coords[2] != 0.0,
+         "For wedge transition, rotated coords cannot have z component equal "
+         "to zero.");
+
+  // D = R * [ (1 - s) / (sqrt(3) * cos(theta)) + s]
+  // cos(theta) = z / r
+  return radius *
+         ((1.0 - sphericity) / (coords[2] * sqrt(3.0)) * magnitude(coords) +
+          sphericity);
+}
+
+void Wedge::Surface::pup(PUP::er& p) {
+  p | radius;
+  p | sphericity;
+}
+
+bool Wedge::Surface::operator==(const Wedge::Surface& other) const {
+  return radius == other.radius and sphericity == other.sphericity;
+}
+
+bool Wedge::Surface::operator!=(const Wedge::Surface& other) const {
+  return not(*this == other);
+}
+
+Wedge::Wedge(double inner_radius, double outer_radius, double inner_sphericity,
+             double outer_sphericity, OrientationMap<3> orientation_map)
+    : inner_surface_(Surface{inner_radius, inner_sphericity}),
+      outer_surface_(Surface{outer_radius, outer_sphericity}),
+      orientation_map_(std::move(orientation_map)),
+      direction_(orientation_map_.inverse_map()(Direction<3>::upper_zeta())) {}
+
+double Wedge::operator()(const std::array<double, 3>& source_coords) const {
+  return call_impl<double>(source_coords);
+}
+DataVector Wedge::operator()(
+    const std::array<DataVector, 3>& source_coords) const {
+  return call_impl<DataVector>(source_coords);
+}
+
+std::optional<double> Wedge::original_radius_over_radius(
+    const std::array<double, 3>& target_coords, double distorted_radius) const {
+  const double radius = magnitude(target_coords);
+  CAPTURE_FOR_ERROR(target_coords);
+  CAPTURE_FOR_ERROR(distorted_radius);
+  CAPTURE_FOR_ERROR(radius);
+  CAPTURE_FOR_ERROR(orientation_map_);
+  CAPTURE_FOR_ERROR(direction_);
+
+  // Couple protections that would make a point completely outside of the domain
+  // of validity for any wedge
+  if (equal_within_roundoff(radius, 0.0) or
+      equal_within_roundoff(distorted_radius, 1.0) or distorted_radius > 1.0) {
+    return std::nullopt;
+  }
+
+  // First we check the extremal case of being outside the outermost radius. We
+  // can check the outermost radius because its surface doesn't move. We can't
+  // check the innermost surface because the inner bound is the origin which we
+  // already checked above.
+  if (radius - eps_ > outer_surface_.radius) {
+    return std::nullopt;
+  }
+
+  // Rotate the coordinates so they are aligned with +z. This makes checking if
+  // the target_coord is in the proper wedge very simple since we only have to
+  // check if the target coord is in the direction of the +z wedge
+  const std::array<double, 3> rotated_coords =
+      discrete_rotation(orientation_map_.inverse_map(), target_coords);
+  CAPTURE_FOR_ERROR(rotated_coords);
+
+  // This comparison only works because the opening angle of the wedge is pi/2
+  // in both x and y
+  if (rotated_coords[2] <
+      std::max(abs(rotated_coords[0]), abs(rotated_coords[1]))) {
+    return std::nullopt;
+  }
+
+  // If distorted radius is 0, this means the map is the identity so the radius
+  // and the original radius are equal. Also we don't want to divide by 0 below
+  if (equal_within_roundoff(distorted_radius, 0.0)) {
+    return std::optional{1.0};
+  }
+
+  const double outer_distance = outer_surface_.distance(rotated_coords);
+  const double inner_distance = inner_surface_.distance(rotated_coords);
+  const double distance_difference = outer_distance - inner_distance;
+
+  // If we are at the overall outer distance, then the transition function is 0
+  // so the map is again the identity so the radius and original radius are
+  // equal. We can't check the overall inner distance because that has been
+  // distorted so we don't know where the mapped inner distance is.
+  if (equal_within_roundoff(radius, outer_distance)) {
+    return std::optional{1.0};
+  }
+
+  // Solving equation of the form rtil*x^2 + ((D_o - D_i)/SumYlm - D_o)*x - (D_o
+  // - D_i)/SumYlm = 0
+  const double a = radius;
+  const double c = -distance_difference / distorted_radius;
+  const double b = -c - outer_distance;
+
+  std::optional<std::array<double, 2>> roots = real_roots(a, b, c);
+
+  if (roots.has_value()) {
+    for (const double root : roots.value()) {
+      // Check if the root is positive and within the inner and outer distance
+      // (divided by the mapped radius)
+      if (root > 0.0 and root + eps_ >= inner_distance / radius and
+          root - eps_ <= outer_distance / radius) {
+        return std::optional{root};
+      }
+    }
+    return std::nullopt;
+  } else {
+    return std::nullopt;
+  }
+}
+
+double Wedge::map_over_radius(
+    const std::array<double, 3>& source_coords) const {
+  return map_over_radius_impl<double>(source_coords);
+}
+DataVector Wedge::map_over_radius(
+    const std::array<DataVector, 3>& source_coords) const {
+  return map_over_radius_impl<DataVector>(source_coords);
+}
+
+std::array<double, 3> Wedge::gradient(
+    const std::array<double, 3>& source_coords) const {
+  return gradient_impl<double>(source_coords);
+}
+std::array<DataVector, 3> Wedge::gradient(
+    const std::array<DataVector, 3>& source_coords) const {
+  return gradient_impl<DataVector>(source_coords);
+}
+
+template <typename T>
+T Wedge::call_impl(const std::array<T, 3>& source_coords) const {
+  const std::array<T, 3> rotated_coords =
+      discrete_rotation(orientation_map_.inverse_map(), source_coords);
+  check_distances(rotated_coords);
+  T outer_distance = outer_surface_.distance(rotated_coords);
+
+  return (outer_distance - magnitude(rotated_coords)) /
+         (outer_distance - inner_surface_.distance(rotated_coords));
+}
+
+template <typename T>
+T Wedge::map_over_radius_impl(const std::array<T, 3>& source_coords) const {
+  const std::array<T, 3> rotated_coords =
+      discrete_rotation(orientation_map_.inverse_map(), source_coords);
+  check_distances(rotated_coords);
+  const T radius = magnitude(rotated_coords);
+  const T outer_distance = outer_surface_.distance(rotated_coords);
+
+  return (outer_distance - radius) /
+         ((outer_distance - inner_surface_.distance(rotated_coords)) * radius);
+}
+
+template <typename T>
+std::array<T, 3> Wedge::gradient_impl(
+    const std::array<T, 3>& source_coords) const {
+  // If both surfaces are spherical then we short circuit because the distances
+  // are constant and we only need to take a derivative of r.
+  // (grad f)_i = -(x_i/r)/(D_out - D_in)
+  const std::array<T, 3> rotated_coords =
+      discrete_rotation(orientation_map_.inverse_map(), source_coords);
+  check_distances(rotated_coords);
+  if (inner_surface_.sphericity == 1.0 and outer_surface_.sphericity == 1.0) {
+    const T one_over_denom = 1.0 / (magnitude(rotated_coords) *
+                                    (outer_surface_.distance(rotated_coords) -
+                                     inner_surface_.distance(rotated_coords)));
+
+    return discrete_rotation(orientation_map_,
+                             -rotated_coords * one_over_denom);
+  }
+
+  const T radius = magnitude(rotated_coords);
+
+  const T one_over_radius = 1.0 / radius;
+  T outer_distance = outer_surface_.distance(rotated_coords);
+  const T one_over_denom =
+      1.0 / (outer_distance - inner_surface_.distance(rotated_coords));
+  T& outer_distance_minus_radius_over_denom = outer_distance;
+  outer_distance_minus_radius_over_denom -= radius;
+  outer_distance_minus_radius_over_denom *= one_over_denom;
+
+  // Avoid small negative numbers if we are at outer boundary
+  for (size_t i = 0; i < get_size(radius); i++) {
+    if (equal_within_roundoff(
+            get_element(outer_distance_minus_radius_over_denom, i), 0.0)) {
+      get_element(outer_distance_minus_radius_over_denom, i) = 0.0;
+    }
+  }
+
+  // Regardless of the sphericities below, we always need this factor in the
+  // first term so we calculate it now.
+  std::array<T, 3> result = -1.0 * rotated_coords * one_over_radius;
+
+  const auto make_factor = [&one_over_radius](const Surface& surface) -> T {
+    return (1.0 - surface.sphericity) * surface.radius * cube(one_over_radius) /
+           sqrt(3.0);
+  };
+
+  // We can make some simplifications if either of the surfaces are spherical
+  // because then the derivative of the distance is zero since it's constant. In
+  // the first two branches, it's safe to assume the other sphericity isn't 1
+  // because of the above check.
+  if (outer_surface_.sphericity == 1.0) {
+    T total_factor = make_factor(inner_surface_);
+    total_factor *= outer_distance_minus_radius_over_denom;
+
+    for (size_t i = 0; i < 2; i++) {
+      gsl::at(result, i) -=
+          total_factor * rotated_coords[2] * gsl::at(rotated_coords, i);
+    }
+
+    result[2] += total_factor * (square(radius) - square(rotated_coords[2]));
+  } else if (inner_surface_.sphericity == 1.0) {
+    T total_factor = make_factor(outer_surface_);
+    total_factor *= (1.0 - outer_distance_minus_radius_over_denom);
+
+    for (size_t i = 0; i < 2; i++) {
+      gsl::at(result, i) -=
+          total_factor * rotated_coords[2] * gsl::at(rotated_coords, i);
+    }
+
+    result[2] += total_factor * (square(radius) - square(rotated_coords[2]));
+  } else {
+    T inner_total_factor = make_factor(inner_surface_);
+    inner_total_factor *= outer_distance_minus_radius_over_denom;
+    T outer_total_factor = make_factor(outer_surface_);
+    outer_total_factor *= (1.0 - outer_distance_minus_radius_over_denom);
+
+    for (size_t i = 0; i < 2; i++) {
+      gsl::at(result, i) -= (inner_total_factor + outer_total_factor) *
+                            rotated_coords[2] * gsl::at(rotated_coords, i);
+    }
+
+    result[2] += (outer_total_factor + inner_total_factor) *
+                 (square(radius) - square(rotated_coords[2]));
+  }
+
+  // Finally, need one more factor of D_out - D_in in the denominator and to
+  // rotate it back to the proper orientation
+  return discrete_rotation(orientation_map_, result * one_over_denom);
+}
+
+bool Wedge::operator==(const ShapeMapTransitionFunction& other) const {
+  if (dynamic_cast<const Wedge*>(&other) == nullptr) {
+    return false;
+  }
+  const Wedge& other_ref = *dynamic_cast<const Wedge*>(&other);
+  return inner_surface_ == other_ref.inner_surface_ and
+         outer_surface_ == other_ref.outer_surface_ and
+         orientation_map_ == other_ref.orientation_map_;
+}
+
+bool Wedge::operator!=(const ShapeMapTransitionFunction& other) const {
+  return not(*this == other);
+}
+
+// checks that the magnitudes are all between `r_min_` and `r_max_`
+template <typename T>
+void Wedge::check_distances([
+    [maybe_unused]] const std::array<T, 3>& coords) const {
+#ifdef SPECTRE_DEBUG
+  const T mag = magnitude(coords);
+  const T inner_distance = inner_surface_.distance(coords);
+  const T outer_distance = outer_surface_.distance(coords);
+  for (size_t i = 0; i < get_size(mag); ++i) {
+    if (get_element(mag, i) + eps_ < get_element(inner_distance, i) or
+        get_element(mag, i) - eps_ > get_element(outer_distance, i)) {
+      ERROR(
+          "The Wedge transition map was called with coordinates outside "
+          "the set inner and outer surfaces. The inner radius and sphericity "
+          "are (r="
+          << inner_surface_.radius << ",s=" << inner_surface_.sphericity
+          << ") and the outer radius and sphericity are (r="
+          << outer_surface_.radius << ",s=" << outer_surface_.sphericity
+          << "). The inner distance is " << get_element(inner_distance, i)
+          << ", the outer distance is " << get_element(outer_distance, i)
+          << ". The requested point has radius: " << get_element(mag, i));
+    }
+  }
+#endif  // SPECTRE_DEBUG
+}
+
+void Wedge::pup(PUP::er& p) {
+  ShapeMapTransitionFunction::pup(p);
+  size_t version = 0;
+  p | version;
+  // Remember to increment the version number when making changes to this
+  // function. Retain support for unpacking data written by previous versions
+  // whenever possible. See `Domain` docs for details.
+  if (version >= 0) {
+    p | inner_surface_;
+    p | outer_surface_;
+    p | orientation_map_;
+    p | direction_;
+  }
+}
+
+Wedge::Wedge(CkMigrateMessage* const msg) : ShapeMapTransitionFunction(msg) {}
+
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+PUP::able::PUP_ID Wedge::my_PUP_ID = 0;
+
+}  // namespace domain::CoordinateMaps::ShapeMapTransitionFunctions

--- a/src/Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/Wedge.hpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/Wedge.hpp
@@ -1,0 +1,239 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <limits>
+#include <memory>
+#include <optional>
+#include <pup.h>
+
+#include "DataStructures/DataVector.hpp"
+#include "Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/ShapeMapTransitionFunction.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/OrientationMap.hpp"
+
+namespace domain::CoordinateMaps::ShapeMapTransitionFunctions {
+
+/*!
+ * \brief A transition function that falls off linearly from an inner surface of
+ * a wedge to an outer surface of a wedge. Meant to be used in
+ * `domain::CoordinateMaps::Wedge` blocks.
+ *
+ * \details The functional form of this transition is
+ *
+ * \begin{equation}
+ * f(r, \theta, \phi) = \frac{D_{\text{out}}(r, \theta, \phi) -
+ * r}{D_{\text{out}}(r, \theta, \phi) - D_{\text{in}}(r, \theta, \phi)},
+ * \label{eq:transition_func}
+ * \end{equation}
+ *
+ * where
+ *
+ * \begin{equation}
+ * D(r, \theta, \phi) = R\left(\frac{1 - s}{\sqrt{3}\cos{\theta}} + s\right),
+ * \end{equation}
+ *
+ * and $s$ is the sphericity of the surface which goes from 0 (flat) to 1
+ * (spherical), $R$ is the radius of the spherical surface, $\text{out}$ is the
+ * outer surface, and $\text{in}$ is the inner surface. If the sphericity is 1,
+ * then the surface is a sphere so $D = R$. If the sphericity is 0, then the
+ * surface is a cube. This cube is circumscribed by a sphere of radius $R$. See
+ * `domain::CoordinateMaps::Wedge` for more of an explanation of these boundary
+ * surfaces and their sphericities.
+ *
+ * \note Because the shape map distorts only radii and does not affect angles,
+ * $D$ is only a function of $\theta$ so we have that $D(r,\theta,\phi) =
+ * D(\theta)$.
+ *
+ * There are several assumptions made for this mapping:
+ *
+ * - The `domain::CoordinateMaps::Wedge`s have an opening angle of
+ *   $\frac{\pi}{2}$ in each direction.
+ * - The coordinates $r, \theta, \phi$ are assumed to be from the center of the
+ *   wedge, not the center of the computational domain.
+ * - The wedges are concentric. (see the constructor)
+ * - Eq. $\ref{eq:transition_func}$ assumes it is in a wedge that is aligned
+ *   with the +z direction. Therefore, $\cos{\theta} = \hat{r} \cdot \hat{z} =
+ *   \frac{\vec{r}}{r} \cdot \hat{z} = \frac{z}{r}$. For the wedges aligned with
+ *   the other axes, the coordinates are first rotated so they align with +z,
+ *   then the computation is done.
+ *
+ * ## Gradient
+ *
+ * The cartesian gradient of the transition function is
+ *
+ * \begin{equation}
+ * \frac{\partial f}{\partial x_i} = \frac{\frac{\partial
+ * D_{\text{out}}}{\partial x_i} - \frac{x_i}{r}}{D_{\text{out}} -
+ * D_{\text{in}}} - \frac{\left(D_{\text{out}} - r\right)\left(\frac{\partial
+ * D_{\text{out}}}{\partial x_i} - \frac{\partial
+ * D_{\text{in}}}{\partial x_i} \right)}{\left(D_{\text{out}} -
+ * D_{\text{in}}\right)^2}
+ * \end{equation}
+ *
+ * where
+ *
+ * \f{align}{
+ * \frac{\partial D}{\partial z} &= \frac{R\left(1-s\right)}{\sqrt{3}}
+ * \frac{\partial}{\partial z} \left(\frac{z}{r} \right) =
+ * \frac{R\left(1-s\right)}{\sqrt{3}} \left(\frac{r^2 - z^2}{r^3} \right), \\
+ * \frac{\partial D}{\partial x} &= \frac{R\left(1-s\right)}{\sqrt{3}}
+ * \frac{\partial}{\partial x} \left(\frac{z}{r} \right) =
+ * -\frac{R\left(1-s\right)}{\sqrt{3}} \left(\frac{xz}{r^3} \right), \\
+ * \frac{\partial D}{\partial y} &= \frac{\partial D}{\partial x} \left(x
+ * \rightarrow y \right),
+ * \f}
+ *
+ * making use of the fact that this wedge is aligned with the +z axis so that
+ * $\cos{\theta} = \frac{z}{r}$.
+ *
+ * ## Original radius divided by mapped radius
+ *
+ * Given an already mapped point and the distorted radius $\Sigma(\theta, \phi)
+ * = \sum_{\ell,m}\lambda_{\ell,m}Y_{\ell,m}(\theta, \phi)$, we can figure out
+ * the ratio of the original radius $r$ to the mapped $\tilde{r}$ by solving
+ *
+ * \begin{equation}
+ * \frac{r}{\tilde{r}} = \frac{1}{1-f(r,\theta,\phi)\Sigma(\theta,\phi)}
+ * \end{equation}
+ *
+ * Because this is a linear transition, this will result in is having to solve a
+ * quadratic equation of the form
+ *
+ * \begin{equation}
+ * \tilde{r} x^2 + \left(\frac{D_{\text{out}} -
+ * D_{\text{in}}}{\Sigma(\theta,\phi)} - D_{\text{out}}\right) x -
+ * \frac{D_{\text{out}} - D_{\text{in}}}{\Sigma(\theta,\phi)} = 0
+ * \label{eq:r_over_rtil}
+ * \end{equation}
+ *
+ * where $x = \frac{r}{\tilde{r}}$.
+ *
+ * \note Since $D$ is not a function of the radius, we can treat it as a
+ * constant in Eq. $\ref{eq:r_over_rtil}$ and compute the angles using
+ * $\tilde{r}$.
+ *
+ * ## Special cases
+ *
+ * The equations above become simpler if the inner boundary, outer boundary, or
+ * both are spherical ($s = 1$). If a boundary is spherical, then $D = R$ and
+ * $\frac{\partial D}{\partial x_i} = 0$. Since $D$ can be held constant when
+ * solving $\ref{eq:r_over_rtil}$, the quadratic equation itself doesn't
+ * simplify, only the computation of $D$.
+ *
+ * If the inner boundary is spherical (but not the outer boundary), then the
+ * gradient of $f$ becomes
+ *
+ * \begin{equation}
+ * \frac{\partial f}{\partial x_i} = \frac{\frac{\partial
+ * D_{\text{out}}}{\partial x_i} - \frac{x_i}{r}}{D_{\text{out}} -
+ * D_{\text{in}}} - \frac{\left(D_{\text{out}} - r\right) - \left(\frac{\partial
+ * D_{\text{out}}}{\partial x_i} \right)}{\left(D_{\text{out}} -
+ * D_{\text{in}}\right)^2}.
+ * \end{equation}
+ *
+ * If the outer boundary is spherical (but not the inner boundary), then the
+ * gradient of $f$ becomes
+ *
+ * \begin{equation}
+ * \frac{\partial f}{\partial x_i} = \frac{-\frac{x_i}{r}}{D_{\text{out}} -
+ * D_{\text{in}}} - \frac{\left(D_{\text{out}} - r\right) + \left(\frac{\partial
+ * D_{\text{in}}}{\partial x_i} \right)}{\left(D_{\text{out}} -
+ * D_{\text{in}}\right)^2}
+ * \end{equation}
+ *
+ * If the both boundaries are spherical, then the gradient of $f$ simplifies
+ * greatly to
+ *
+ * \begin{equation}
+ * \frac{\partial f}{\partial x_i} = \frac{-\frac{x_i}{r}}{D_{\text{out}} -
+ * D_{\text{in}}}
+ * \end{equation}
+ */
+class Wedge final : public ShapeMapTransitionFunction {
+  struct Surface {
+    double radius{};
+    double sphericity{};
+
+    // This is the distance from the center (assumed to be 0,0,0) to this
+    // surface in the same direction as coords.
+    template <typename T>
+    T distance(const std::array<T, 3>& coords) const;
+
+    void pup(PUP::er& p);
+
+    bool operator==(const Surface& other) const;
+    bool operator!=(const Surface& other) const;
+  };
+
+ public:
+  explicit Wedge() = default;
+
+  /*!
+   * \brief Construct a Wedge transition for a wedge block in a given direction.
+   *
+   * \details Many concentric wedges can be part of the same falloff from 1 at
+   * the inner boundary of the innermost wedge, to 0 at the outer boundary of
+   * the outermost wedge.
+   *
+   * \param inner_radius Inner radius of innermost wedge
+   * \param outer_radius Outermost radius of outermost wedge
+   * \param inner_sphericity Sphericity of innermost surface of innermost wedge
+   * \param outer_sphericity Sphericity of outermost surface of outermost wedge
+   * \param orientation_map The same orientation map that was passed into the
+   * corresponding `domain::CoordinateMaps::Wedge` block.
+   */
+  Wedge(double inner_radius, double outer_radius, double inner_sphericity,
+        double outer_sphericity, OrientationMap<3> orientation_map);
+
+  double operator()(const std::array<double, 3>& source_coords) const override;
+  DataVector operator()(
+      const std::array<DataVector, 3>& source_coords) const override;
+
+  std::optional<double> original_radius_over_radius(
+      const std::array<double, 3>& target_coords,
+      double distorted_radius) const override;
+
+  double map_over_radius(
+      const std::array<double, 3>& source_coords) const override;
+  DataVector map_over_radius(
+      const std::array<DataVector, 3>& source_coords) const override;
+
+  std::array<double, 3> gradient(
+      const std::array<double, 3>& source_coords) const override;
+  std::array<DataVector, 3> gradient(
+      const std::array<DataVector, 3>& source_coords) const override;
+
+  WRAPPED_PUPable_decl_template(Wedge);
+  explicit Wedge(CkMigrateMessage* msg);
+  void pup(PUP::er& p) override;
+
+  std::unique_ptr<ShapeMapTransitionFunction> get_clone() const override {
+    return std::make_unique<Wedge>(*this);
+  }
+
+  bool operator==(const ShapeMapTransitionFunction& other) const override;
+  bool operator!=(const ShapeMapTransitionFunction& other) const override;
+
+ private:
+  template <typename T>
+  T call_impl(const std::array<T, 3>& source_coords) const;
+
+  template <typename T>
+  T map_over_radius_impl(const std::array<T, 3>& source_coords) const;
+
+  template <typename T>
+  std::array<T, 3> gradient_impl(const std::array<T, 3>& source_coords) const;
+
+  template <typename T>
+  void check_distances(const std::array<T, 3>& coords) const;
+
+  Surface inner_surface_{};
+  Surface outer_surface_{};
+  OrientationMap<3> orientation_map_{};
+  Direction<3> direction_{};
+  static constexpr double eps_ = std::numeric_limits<double>::epsilon() * 100;
+};
+}  // namespace domain::CoordinateMaps::ShapeMapTransitionFunctions

--- a/src/Domain/DomainHelpers.cpp
+++ b/src/Domain/DomainHelpers.cpp
@@ -550,12 +550,7 @@ void set_identified_boundaries(
   }
 }
 
-namespace {
-// A Block or Blocks can be wrapped in an outer layer of Blocks surrounding
-// the original Block(s). In the BBH Domain, this occurs several times, using
-// both Wedges and Frustums. The simplest example in which wrapping is used is
-// Sphere, where the central Block is wrapped with six Wedge<3>s.
-std::array<OrientationMap<3>, 6> orientations_for_wrappings() {
+std::array<OrientationMap<3>, 6> orientations_for_sphere_wrappings() {
   return {{
       // Upper Z
       OrientationMap<3>{},
@@ -581,7 +576,6 @@ std::array<OrientationMap<3>, 6> orientations_for_wrappings() {
            Direction<3>::upper_eta()}}),
   }};
 }
-}  // namespace
 
 size_t which_wedge_index(const ShellWedges& which_wedges) {
   switch (which_wedges) {
@@ -614,7 +608,7 @@ std::vector<domain::CoordinateMaps::Wedge<3>> sph_wedge_coordinate_maps(
              << radial_distribution.size() << " items, but the domain has "
              << 1 + radial_partitioning.size() << " shells.");
 
-  const auto wedge_orientations = orientations_for_wrappings();
+  const auto wedge_orientations = orientations_for_sphere_wrappings();
 
   using Wedge3DMap = domain::CoordinateMaps::Wedge<3>;
   using Halves = Wedge3DMap::WedgeHalves;
@@ -702,7 +696,7 @@ std::vector<domain::CoordinateMaps::Frustum> frustum_coordinate_maps(
               0.5 * length_outer_cube,
       "The current choice for `origin_preimage` results in the inner cubes "
       "piercing the surface of the outer cube.");
-  const auto frustum_orientations = orientations_for_wrappings();
+  const auto frustum_orientations = orientations_for_sphere_wrappings();
   const double lower = 0.5 * length_inner_cube;
   const double top = 0.5 * length_outer_cube;
 

--- a/src/Domain/DomainHelpers.hpp
+++ b/src/Domain/DomainHelpers.hpp
@@ -123,6 +123,15 @@ auto corners_for_rectilinear_domains(
     -> std::vector<std::array<size_t, two_to_the(VolumeDim)>>;
 
 /// \ingroup ComputationalDomainGroup
+/// \brief An array of the orientations of the six blocks that make up a Sphere.
+///
+/// A Block or Blocks can be wrapped in an outer layer of Blocks surrounding
+/// the original Block(s). In the BBH Domain, this occurs several times, using
+/// both Wedges and Frustums. This standardizes the ordering of the orientations
+/// for both.
+std::array<OrientationMap<3>, 6> orientations_for_sphere_wrappings();
+
+/// \ingroup ComputationalDomainGroup
 /// The number of wedges to include in the Sphere domain.
 enum class ShellWedges {
   /// Use the entire shell

--- a/tests/Unit/Domain/CoordinateMaps/TimeDependent/CMakeLists.txt
+++ b/tests/Unit/Domain/CoordinateMaps/TimeDependent/CMakeLists.txt
@@ -4,7 +4,6 @@
 set(LIBRARY "Test_CoordinateMapsTimeDependent")
 
 set(LIBRARY_SOURCES
-  ShapeMapTransitionFunctions/Test_SphereTransition.cpp
   Test_CubicScale.cpp
   Test_ProductMaps.cpp
   Test_Rotation.cpp
@@ -13,6 +12,8 @@ set(LIBRARY_SOURCES
   Test_SphericalCompression.cpp
   Test_Translation.cpp
   )
+
+add_subdirectory(ShapeMapTransitionFunctions)
 
 add_test_library(${LIBRARY} "${LIBRARY_SOURCES}")
 

--- a/tests/Unit/Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/CMakeLists.txt
+++ b/tests/Unit/Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/CMakeLists.txt
@@ -4,4 +4,5 @@
 set(LIBRARY_SOURCES
   ${LIBRARY_SOURCES}
   ShapeMapTransitionFunctions/Test_SphereTransition.cpp
+  ShapeMapTransitionFunctions/Test_Wedge.cpp
   PARENT_SCOPE)

--- a/tests/Unit/Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/CMakeLists.txt
+++ b/tests/Unit/Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/CMakeLists.txt
@@ -1,0 +1,7 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBRARY_SOURCES
+  ${LIBRARY_SOURCES}
+  ShapeMapTransitionFunctions/Test_SphereTransition.cpp
+  PARENT_SCOPE)

--- a/tests/Unit/Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/Test_Wedge.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/Test_Wedge.cpp
@@ -1,0 +1,321 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cmath>
+#include <limits>
+#include <memory>
+#include <optional>
+#include <random>
+#include <string>
+#include <unordered_map>
+
+#include "Domain/CoordinateMaps/TimeDependent/Shape.hpp"
+#include "Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/ShapeMapTransitionFunction.hpp"
+#include "Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/Wedge.hpp"
+#include "Domain/DomainHelpers.hpp"
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "Domain/FunctionsOfTime/PiecewisePolynomial.hpp"
+#include "Domain/Structure/OrientationMap.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "Utilities/CartesianProduct.hpp"
+#include "Utilities/StdArrayHelpers.hpp"
+
+namespace domain::CoordinateMaps::ShapeMapTransitionFunctions {
+namespace {
+std::array<double, 3> sph_to_cart(const double radius, const double theta,
+                                  const double phi) {
+  return std::array{radius * sin(theta) * cos(phi),
+                    radius * sin(theta) * sin(phi), radius * cos(theta)};
+}
+
+// Since this is hard to test for general points without just reimplementing the
+// function, we test for specific points where it's easier to calculate
+void test_gradient() {
+  INFO("Test gradient");
+  const double inner_radius = 0.5;
+  const double outer_radius = 10.0;
+  const OrientationMap<3> orientation_map{};
+
+  const auto make_wedge = [&](const double inner_sphericity,
+                              const double outer_sphericity) {
+    return Wedge{inner_radius, outer_radius, inner_sphericity, outer_sphericity,
+                 orientation_map};
+  };
+
+  // The extra grad factors should be 0 or 1 for spherical or flat boundaries
+  // (this is opposite of their sphericity)
+  const auto compute_gradient =
+      [&](const double radius, const std::array<double, 3>& point,
+          const double inner_distance, const double outer_distance,
+          const double extra_inner_grad_factor,
+          const double extra_outer_grad_factor) {
+        const double distance_difference = outer_distance - inner_distance;
+        const std::array<double, 3> grad_base =
+            1.0 / (sqrt(3.0) * cube(radius)) *
+            std::array{-point[0] * point[2], -point[1] * point[2],
+                       square(radius) - square(point[2])};
+        const std::array<double, 3> inner_grad =
+            extra_inner_grad_factor * inner_radius * grad_base;
+        const std::array<double, 3> outer_grad =
+            extra_outer_grad_factor * outer_radius * grad_base;
+        return (outer_grad - point / radius) / distance_difference -
+               (outer_distance - radius) * (outer_grad - inner_grad) /
+                   square(distance_difference);
+      };
+
+  const auto test_z_axis = [&](const double inner_sphericity,
+                               const double outer_sphericity) {
+    INFO("Test z-axis");
+    const Wedge wedge = make_wedge(inner_sphericity, outer_sphericity);
+    double inner_distance = inner_radius;
+    double outer_distance = outer_radius;
+    if (inner_sphericity == 0.0) {
+      inner_distance /= sqrt(3.0);
+    }
+    if (outer_sphericity == 0.0) {
+      outer_distance /= sqrt(3.0);
+    }
+
+    for (const double radius : {inner_distance, outer_distance,
+                                0.5 * (inner_distance + outer_distance)}) {
+      CAPTURE(radius);
+      const std::array point{0.0, 0.0, radius};
+      CAPTURE(point);
+
+      CHECK_ITERABLE_APPROX(
+          wedge.gradient(point),
+          (compute_gradient(radius, point, inner_distance, outer_distance,
+                            1.0 - inner_sphericity, 1.0 - outer_sphericity)));
+    }
+  };
+
+  const auto test_corners = [&](const double inner_sphericity,
+                                const double outer_sphericity) {
+    INFO("Test corners");
+    const Wedge wedge = make_wedge(inner_sphericity, outer_sphericity);
+    // Corners will always be at sphere radius
+    for (const double radius :
+         {inner_radius, outer_radius, 0.5 * (outer_radius + outer_radius)}) {
+      for (const double phi :
+           {M_PI_4, 3.0 * M_PI_4, 5.0 * M_PI_4, 7.0 * M_PI_4}) {
+        CAPTURE(radius);
+        CAPTURE(phi * 180.0 / M_PI);
+        const std::array point =
+            sph_to_cart(radius, acos(1.0 / sqrt(3.0)), phi);
+        CAPTURE(point);
+
+        CHECK_ITERABLE_APPROX(
+            wedge.gradient(point),
+            (compute_gradient(radius, point, inner_radius, outer_radius,
+                              1.0 - inner_sphericity, 1.0 - outer_sphericity)));
+      }
+    }
+  };
+
+  {
+    INFO("Both boundaries spherical");
+    test_z_axis(1.0, 1.0);
+    test_corners(1.0, 1.0);
+  }
+  {
+    INFO("Inner boundary spherical, outer boundary flat");
+    test_z_axis(1.0, 0.0);
+    test_corners(1.0, 0.0);
+  }
+  {
+    INFO("Inner boundary flat, outer boundary spherical");
+    test_z_axis(0.0, 1.0);
+    test_corners(0.0, 1.0);
+  }
+  {
+    INFO("Both boundaries flat");
+    test_z_axis(0.0, 0.0);
+    test_corners(0.0, 0.0);
+  }
+}
+
+void test_only_transition() {
+  const double inner_radius = 0.5;
+  const double outer_radius = 10.0;
+  const double inner_sphericity = 1.0;
+  const double outer_sphericity = 0.0;
+  const OrientationMap<3> orientation_map{};
+
+  const Wedge wedge{inner_radius, outer_radius, inner_sphericity,
+                    outer_sphericity, orientation_map};
+
+  const double inner_distance = 0.5;
+  const double outer_distance = outer_radius / sqrt(3.0);
+  const double distance_difference = outer_distance - inner_distance;
+
+  std::array<double, 3> point{0.0, 0.0, 4.0};
+  const double function_value = (outer_distance - 4.0) / distance_difference;
+
+  CHECK(wedge(point) == approx(function_value));
+  CHECK(wedge.map_over_radius(point) == approx(function_value / 4.0));
+  CHECK_ITERABLE_APPROX(wedge.gradient(point),
+                        (std::array{0.0, 0.0, -1.0 / distance_difference}));
+
+  std::optional<double> orig_rad_over_rad{};
+  const auto set_orig_rad_over_rad =
+      [&](const std::array<double, 3>& mapped_point,
+          const double distorted_radii) {
+        orig_rad_over_rad =
+            wedge.original_radius_over_radius(mapped_point, distorted_radii);
+      };
+
+  // Test actual values
+  set_orig_rad_over_rad(point, 0.0);
+  CHECK(orig_rad_over_rad.has_value());
+  CHECK(orig_rad_over_rad.value() == approx(1.0));
+  set_orig_rad_over_rad(point * (1.0 - function_value * 0.5), 0.5);
+  CHECK(orig_rad_over_rad.has_value());
+  CHECK(orig_rad_over_rad.value() ==
+        approx(4.0 / magnitude(point * (1.0 - function_value * 0.5))));
+  set_orig_rad_over_rad(point * (1.0 + function_value * 0.5), -0.5);
+  CHECK(orig_rad_over_rad.has_value());
+  CHECK(orig_rad_over_rad.value() ==
+        approx(4.0 / magnitude(point * (1.0 + function_value * 0.5))));
+  // Hit some internal checks
+  set_orig_rad_over_rad(point * 0.0, 0.0);
+  CHECK_FALSE(orig_rad_over_rad.has_value());
+  set_orig_rad_over_rad(point, 1.0);
+  CHECK_FALSE(orig_rad_over_rad.has_value());
+  set_orig_rad_over_rad(point, 15.0);
+  CHECK_FALSE(orig_rad_over_rad.has_value());
+  set_orig_rad_over_rad(point * 15.0, 0.0);
+  CHECK_FALSE(orig_rad_over_rad.has_value());
+  // Wedge is in +z direction. Check other directions
+  set_orig_rad_over_rad(std::array{0.0, 0.0, -4.0}, 0.0);
+  CHECK_FALSE(orig_rad_over_rad.has_value());
+  set_orig_rad_over_rad(std::array{4.0, 0.0, 0.0}, 0.0);
+  CHECK_FALSE(orig_rad_over_rad.has_value());
+  set_orig_rad_over_rad(std::array{-4.0, 0.0, 0.0}, 0.0);
+  CHECK_FALSE(orig_rad_over_rad.has_value());
+  set_orig_rad_over_rad(std::array{0.0, 4.0, 0.0}, 0.0);
+  CHECK_FALSE(orig_rad_over_rad.has_value());
+  set_orig_rad_over_rad(std::array{0.0, -4.0, 0.0}, 0.0);
+  CHECK_FALSE(orig_rad_over_rad.has_value());
+  // At overall inner boundary.
+  set_orig_rad_over_rad(std::array{0.0, 0.0, 0.5 * inner_radius}, 0.5);
+  CHECK(orig_rad_over_rad.has_value());
+  CHECK(orig_rad_over_rad.value() == 2.0);
+
+  test_gradient();
+}
+
+void test_in_shape_map() {
+  INFO("Test using shape map");
+  MAKE_GENERATOR(generator, 3360591650);
+  std::uniform_real_distribution<double> coef_dist{-0.01, 0.01};
+
+  const double initial_time = 1.0;
+  const size_t l_max = 4;
+  const size_t num_coefs = 2 * square(l_max + 1);
+  const std::array center{0.1, -0.2, 0.3};
+  const std::string fot_name{"TheBean"};
+
+  std::unordered_map<std::string,
+                     std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
+      functions_of_time{};
+  auto coefs = make_with_random_values<DataVector>(make_not_null(&generator),
+                                                   make_not_null(&coef_dist),
+                                                   DataVector{num_coefs});
+  functions_of_time[fot_name] =
+      std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<0>>(
+          initial_time, std::array{std::move(coefs)},
+          std::numeric_limits<double>::infinity());
+
+  // We'll keep the radii the same since they don't really matter
+  const double inner_radius = 0.5;
+  const double outer_radius = 10.0;
+
+  std::uniform_real_distribution<double> theta_dist{0.0, M_PI_4};
+  std::uniform_real_distribution<double> phi_dist{0.0, 2.0 * M_PI};
+
+  for (const auto& [inner_sphericity, outer_sphericity, orientation] :
+       cartesian_product(std::array{1.0, 0.0}, std::array{1.0, 0.0},
+                         orientations_for_sphere_wrappings())) {
+    CAPTURE(inner_sphericity);
+    CAPTURE(outer_sphericity);
+    CAPTURE(orientation);
+    // This guarantees the radius of the point is within the wedge
+    std::uniform_real_distribution<double> radial_dist{
+        inner_radius, outer_radius / sqrt(3.0)};
+
+    std::unique_ptr<ShapeMapTransitionFunction> wedge =
+        std::make_unique<Wedge>(inner_radius, outer_radius, inner_sphericity,
+                                outer_sphericity, orientation);
+
+    TimeDependent::Shape shape{center, l_max, l_max, std::move(wedge),
+                               fot_name};
+
+    // Test 10 points for each sphericity and orientation
+    for (size_t i = 0; i < 10; i++) {
+      const double radius = radial_dist(generator);
+      const double theta = theta_dist(generator);
+      const double phi = phi_dist(generator);
+
+      CAPTURE(radius);
+      CAPTURE(theta);
+      CAPTURE(phi);
+
+      const std::array<double, 3> centered_z_aligned_point =
+          sph_to_cart(radius, theta, phi);
+      const std::array<double, 3> centered_point =
+          discrete_rotation(orientation, centered_z_aligned_point);
+      const std::array<double, 3> point = centered_point + center;
+      CAPTURE(centered_z_aligned_point);
+      CAPTURE(centered_point);
+      CAPTURE(point);
+
+      const std::array<double, 3> mapped_point =
+          shape(point, initial_time, functions_of_time);
+      const std::optional<std::array<double, 3>> inverse_mapped_point =
+          shape.inverse(mapped_point, initial_time, functions_of_time);
+
+      CAPTURE(mapped_point);
+      CAPTURE(inverse_mapped_point);
+
+      CHECK(inverse_mapped_point.has_value());
+      CHECK_ITERABLE_APPROX(point, inverse_mapped_point.value());
+
+      const auto check_bad_point = [&](const std::string& info,
+                                       const double inner_bound,
+                                       const double outer_bound) {
+        INFO(info);
+        std::uniform_real_distribution<double> bad_radial_dist{inner_bound,
+                                                               outer_bound};
+        // Want theta to be from 0 to pi, so just use phi and divide by 2
+        const double random_theta = phi_dist(generator) / 2.0;
+        const double random_phi = phi_dist(generator);
+        const double bad_radius = bad_radial_dist(generator);
+
+        CAPTURE(bad_radius);
+
+        const std::array<double, 3> bad_point =
+            sph_to_cart(bad_radius, random_theta, random_phi) + center;
+
+        CAPTURE(bad_point);
+        CHECK_FALSE(shape.inverse(bad_point, initial_time, functions_of_time)
+                        .has_value());
+      };
+
+      // The 0.9 factor guarantees that we are inside the mapped inner radius
+      check_bad_point("Too small radius", 0.01, 0.9 * inner_radius / sqrt(3.0));
+      check_bad_point("Too big radius", outer_radius * 10.0,
+                      outer_radius * 50.0);
+    }
+  }
+}
+
+SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Shape.Wedge", "[Domain][Unit]") {
+  test_only_transition();
+  test_in_shape_map();
+}
+}  // namespace
+}  // namespace domain::CoordinateMaps::ShapeMapTransitionFunctions


### PR DESCRIPTION
## Proposed changes

A new transition function for the shape map that is to be used in concentric wedge blocks. The inner and outer boundaries of these wedges can be spherical, flat, or in-between just like the Wedge coordinate map. This transition will mostly be used for the rectangular BinaryCompactObject domain for the shells and cubes around each object (PR to come for that).

Needed for #5600.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
