### PR TITLE
Use wedge shape map transition in BCO domain

### DIFF
--- a/src/Domain/Creators/BinaryCompactObject.hpp
+++ b/src/Domain/Creators/BinaryCompactObject.hpp
@@ -134,6 +134,8 @@ namespace creators {
  * its options. Otherwise specify `None` for that map. You can also turn off
  * time dependent maps all together by specifying `None` for the
  * `TimeDependentMaps` option. See
+ * `domain::creators::bco::TimeDependentMapOptions`. This class must pass a
+ * template parameter of `false` to
  * `domain::creators::bco::TimeDependentMapOptions`.
  */
 class BinaryCompactObject : public DomainCreator<3> {
@@ -166,7 +168,7 @@ class BinaryCompactObject : public DomainCreator<3> {
                             CoordinateMaps::Wedge<3>>,
       domain::CoordinateMap<Frame::BlockLogical, Frame::Inertial,
                             CoordinateMaps::Wedge<3>, Translation>,
-      bco::TimeDependentMapOptions::maps_list>>;
+      bco::TimeDependentMapOptions<false>::maps_list>>;
 
   /// Options for an excision region in the domain
   struct Excision {
@@ -393,9 +395,10 @@ class BinaryCompactObject : public DomainCreator<3> {
 
   // This is for optional time dependent maps
   struct TimeDependentMaps {
-    using type =
-        Options::Auto<bco::TimeDependentMapOptions, Options::AutoLabel::None>;
-    static constexpr Options::String help = bco::TimeDependentMapOptions::help;
+    using type = Options::Auto<bco::TimeDependentMapOptions<false>,
+                               Options::AutoLabel::None>;
+    static constexpr Options::String help =
+        bco::TimeDependentMapOptions<false>::help;
   };
 
   template <typename Metavariables>
@@ -469,7 +472,7 @@ class BinaryCompactObject : public DomainCreator<3> {
   // Metavariables::domain::enable_time_dependent_maps == true),
   // with an additional parameter
   BinaryCompactObject(
-      std::optional<bco::TimeDependentMapOptions> time_dependent_options,
+      std::optional<bco::TimeDependentMapOptions<false>> time_dependent_options,
       typename ObjectA::type object_A, typename ObjectB::type object_B,
       double envelope_radius, double outer_radius,
       const typename InitialRefinement::type& initial_refinement,
@@ -555,7 +558,7 @@ class BinaryCompactObject : public DomainCreator<3> {
   bool is_excised_b_ = false;
   bool use_single_block_a_ = false;
   bool use_single_block_b_ = false;
-  std::optional<bco::TimeDependentMapOptions> time_dependent_options_{};
+  std::optional<bco::TimeDependentMapOptions<false>> time_dependent_options_{};
   double opening_angle_ = std::numeric_limits<double>::signaling_NaN();
 };
 }  // namespace creators

--- a/src/Domain/Creators/CylindricalBinaryCompactObject.cpp
+++ b/src/Domain/Creators/CylindricalBinaryCompactObject.cpp
@@ -5,6 +5,7 @@
 
 #include <cmath>
 #include <memory>
+#include <optional>
 #include <utility>
 #include <vector>
 
@@ -386,7 +387,7 @@ CylindricalBinaryCompactObject::CylindricalBinaryCompactObject(
 }
 
 CylindricalBinaryCompactObject::CylindricalBinaryCompactObject(
-    std::optional<bco::TimeDependentMapOptions> time_dependent_options,
+    std::optional<bco::TimeDependentMapOptions<true>> time_dependent_options,
     std::array<double, 3> center_A, std::array<double, 3> center_B,
     double radius_A, double radius_B, bool include_inner_sphere_A,
     bool include_inner_sphere_B, bool include_outer_sphere, double outer_radius,
@@ -423,8 +424,8 @@ CylindricalBinaryCompactObject::CylindricalBinaryCompactObject(
     time_dependent_options_->build_maps(
         std::array{rotate_from_z_to_x_axis(center_A_),
                    rotate_from_z_to_x_axis(center_B_)},
-        std::make_pair(radius_A_, outer_radius_A_),
-        std::make_pair(radius_B_, outer_radius_B_), outer_radius_);
+        std::array{radius_A_, outer_radius_A_},
+        std::array{radius_B_, outer_radius_B_}, outer_radius_);
   }
 }
 
@@ -936,7 +937,8 @@ Domain<3> CylindricalBinaryCompactObject::create_domain() const {
         time_dependent_options_->grid_to_distorted_map<domain::ObjectLabel::A>(
             true);
     distorted_to_inertial_block_maps[46] =
-        time_dependent_options_->distorted_to_inertial_map(true);
+        time_dependent_options_
+            ->distorted_to_inertial_map<domain::ObjectLabel::A>(true);
 
     grid_to_inertial_block_maps[60] =
         time_dependent_options_->grid_to_inertial_map<domain::ObjectLabel::B>(
@@ -945,7 +947,8 @@ Domain<3> CylindricalBinaryCompactObject::create_domain() const {
         time_dependent_options_->grid_to_distorted_map<domain::ObjectLabel::B>(
             true);
     distorted_to_inertial_block_maps[60] =
-        time_dependent_options_->distorted_to_inertial_map(true);
+        time_dependent_options_
+            ->distorted_to_inertial_map<domain::ObjectLabel::B>(true);
 
     for (size_t block = 1; block < number_of_blocks_; ++block) {
       if (block == 46 or block == 60) {

--- a/src/Domain/Creators/CylindricalBinaryCompactObject.hpp
+++ b/src/Domain/Creators/CylindricalBinaryCompactObject.hpp
@@ -146,6 +146,8 @@ namespace domain::creators {
  * its options. Otherwise specify `None` for that map. You can also turn off
  * time dependent maps all together by specifying `None` for the
  * `TimeDependentMaps` option. See
+ * `domain::creators::bco::TimeDependentMapOptions`. This class must pass a
+ * template parameter of `true` to
  * `domain::creators::bco::TimeDependentMapOptions`.
  */
 class CylindricalBinaryCompactObject : public DomainCreator<3> {
@@ -183,7 +185,7 @@ class CylindricalBinaryCompactObject : public DomainCreator<3> {
                                                     CoordinateMaps::Interval>,
                      CoordinateMaps::UniformCylindricalSide,
                      CoordinateMaps::DiscreteRotation<3>>,
-                 bco::TimeDependentMapOptions::maps_list>>;
+                 bco::TimeDependentMapOptions<true>::maps_list>>;
 
   struct CenterA {
     using type = std::array<double, 3>;
@@ -279,9 +281,10 @@ class CylindricalBinaryCompactObject : public DomainCreator<3> {
   };
 
   struct TimeDependentMaps {
-    using type =
-        Options::Auto<bco::TimeDependentMapOptions, Options::AutoLabel::None>;
-    static constexpr Options::String help = bco::TimeDependentMapOptions::help;
+    using type = Options::Auto<bco::TimeDependentMapOptions<true>,
+                               Options::AutoLabel::None>;
+    static constexpr Options::String help =
+        bco::TimeDependentMapOptions<true>::help;
   };
 
   using time_independent_options =
@@ -329,7 +332,7 @@ class CylindricalBinaryCompactObject : public DomainCreator<3> {
       const Options::Context& context = {});
 
   CylindricalBinaryCompactObject(
-      std::optional<bco::TimeDependentMapOptions> time_dependent_options,
+      std::optional<bco::TimeDependentMapOptions<true>> time_dependent_options,
       std::array<double, 3> center_A, std::array<double, 3> center_B,
       double radius_A, double radius_B, bool include_inner_sphere_A,
       bool include_inner_sphere_B, bool include_outer_sphere,
@@ -419,6 +422,6 @@ class CylindricalBinaryCompactObject : public DomainCreator<3> {
   std::unordered_map<std::string, tnsr::I<double, 3, Frame::Grid>>
       grid_anchors_{};
   // FunctionsOfTime options
-  std::optional<bco::TimeDependentMapOptions> time_dependent_options_{};
+  std::optional<bco::TimeDependentMapOptions<true>> time_dependent_options_{};
 };
 }  // namespace domain::creators

--- a/support/Pipelines/Bbh/Inspiral.yaml
+++ b/support/Pipelines/Bbh/Inspiral.yaml
@@ -67,9 +67,11 @@ DomainCreator:
       ShapeMapA:
         LMax: &LMax 10
         SizeInitialValues: [0.0, 0.0, 0.0]
+        TransitionEndsAtCube: true
       ShapeMapB:
         LMax: *LMax
         SizeInitialValues: [0.0, 0.0, 0.0]
+        TransitionEndsAtCube: true
 
 Evolution:
   InitialTime: 0.0

--- a/tests/InputFiles/CurvedScalarWave/WorldtubeKerrSchild.yaml
+++ b/tests/InputFiles/CurvedScalarWave/WorldtubeKerrSchild.yaml
@@ -73,9 +73,11 @@ DomainCreator:
       ShapeMapA:
         LMax: 8
         SizeInitialValues: [0., 0., 0.]
+        TransitionEndsAtCube: false
       ShapeMapB:
         LMax: 8
         SizeInitialValues: [0., 0., 0.]
+        TransitionEndsAtCube: false
 
 SpatialDiscretization:
   BoundaryCorrection:

--- a/tests/InputFiles/ExportCoordinates/InputTimeDependent3D.yaml
+++ b/tests/InputFiles/ExportCoordinates/InputTimeDependent3D.yaml
@@ -65,9 +65,11 @@ DomainCreator:
       ShapeMapA:
         LMax: 8
         SizeInitialValues: [0.0, 0.0, 0.0]
+        TransitionEndsAtCube: true
       ShapeMapB:
         LMax: 8
         SizeInitialValues: [0.0, 0.0, 0.0]
+        TransitionEndsAtCube: true
 
 SpatialDiscretization:
   ActiveGrid: Dg

--- a/tests/InputFiles/GeneralizedHarmonic/BinaryBlackHole.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/BinaryBlackHole.yaml
@@ -79,9 +79,11 @@ DomainCreator:
       ShapeMapA:
         LMax: &LMax 10
         SizeInitialValues: [0.0, 0.0, 0.0]
+        TransitionEndsAtCube: true
       ShapeMapB:
         LMax: *LMax
         SizeInitialValues: [0.0, 0.0, 0.0]
+        TransitionEndsAtCube: true
 
 EventsAndDenseTriggers:
 

--- a/tests/Unit/Domain/Creators/Test_BinaryCompactObject.cpp
+++ b/tests/Unit/Domain/Creators/Test_BinaryCompactObject.cpp
@@ -377,12 +377,15 @@ std::string create_option_string(
                        (excise_A
                             ? "    ShapeMapA:\n"
                               "      LMax: 8\n"
-                              "      SizeInitialValues: [0.0, -0.1, 0.01]\n"s
+                              "      SizeInitialValues: [0.0, -0.1, 0.01]\n"
+                              "      TransitionEndsAtCube: false\n"s
                             : "    ShapeMapA: None\n"s) +
-                       (excise_B ? "    ShapeMapB:\n"
-                                   "      LMax: 8\n"
-                                   "      SizeInitialValues: [0.0, -0.2, 0.02]"s
-                                 : "    ShapeMapB: None"s)
+                       (excise_B
+                            ? "    ShapeMapB:\n"
+                              "      LMax: 8\n"
+                              "      SizeInitialValues: [0.0, -0.2, 0.02]\n"
+                              "      TransitionEndsAtCube: true"s
+                            : "    ShapeMapB: None"s)
                  : "  TimeDependentMaps: None")
           : ""};
   const std::string interior_A{

--- a/tests/Unit/Domain/Creators/Test_CylindricalBinaryCompactObject.cpp
+++ b/tests/Unit/Domain/Creators/Test_CylindricalBinaryCompactObject.cpp
@@ -47,7 +47,7 @@
 namespace {
 using ExpirationTimeMap = std::unordered_map<std::string, double>;
 using CylBCO = ::domain::creators::CylindricalBinaryCompactObject;
-using TimeDepOptions = domain::creators::bco::TimeDependentMapOptions;
+using TimeDepOptions = domain::creators::bco::TimeDependentMapOptions<true>;
 
 std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
 create_inner_boundary_condition() {

--- a/tests/Unit/Domain/Test_Domain.cpp
+++ b/tests/Unit/Domain/Test_Domain.cpp
@@ -655,7 +655,11 @@ Domain<3> create_serialized_domain() {
   Domain<3> domain{std::move(maps), std::move(excision_spheres), block_names,
                    block_groups};
 
-  using TimeDepOps = domain::creators::bco::TimeDependentMapOptions;
+  // We have IsCylindrical = true even though this is the rectangular domain
+  // because the cylindrical domain uses the SphereTransition transition
+  // function for the shape map which is what is serialized. The rectangular
+  // domain uses the Wedge transition function.
+  using TimeDepOps = domain::creators::bco::TimeDependentMapOptions<true>;
   TimeDepOps time_dependent_options{
       0.,
       TimeDepOps::ExpansionMapOptions{
@@ -664,10 +668,10 @@ Domain<3> create_serialized_domain() {
       TimeDepOps::ShapeMapOptions<domain::ObjectLabel::A>{8, {0., 0., 0.}},
       TimeDepOps::ShapeMapOptions<domain::ObjectLabel::B>{8, {0., 0., 0.}}};
 
-  const std::optional<std::pair<double, double>> inner_outer_radii_A =
-      std::make_pair(object_A.inner_radius, object_A.outer_radius);
-  const std::optional<std::pair<double, double>> inner_outer_radii_B =
-      std::make_pair(object_B.inner_radius, object_B.outer_radius);
+  const std::optional<std::array<double, 2>> inner_outer_radii_A =
+      std::array{object_A.inner_radius, object_A.outer_radius};
+  const std::optional<std::array<double, 2>> inner_outer_radii_B =
+      std::array{object_B.inner_radius, object_B.outer_radius};
   const std::array<std::array<double, 3>, 2> centers{
       std::array{x_coord_a, 0.0, 0.0}, std::array{x_coord_b, 0.0, 0.0}};
 
@@ -696,7 +700,8 @@ Domain<3> create_serialized_domain() {
       time_dependent_options.grid_to_distorted_map<domain::ObjectLabel::A>(
           true);
   distorted_to_inertial_block_maps[0] =
-      time_dependent_options.distorted_to_inertial_map(true);
+      time_dependent_options.distorted_to_inertial_map<domain::ObjectLabel::A>(
+          true);
 
   const size_t first_block_object_B = 12;
   grid_to_inertial_block_maps[first_block_object_B] =
@@ -705,7 +710,8 @@ Domain<3> create_serialized_domain() {
       time_dependent_options.grid_to_distorted_map<domain::ObjectLabel::B>(
           true);
   distorted_to_inertial_block_maps[first_block_object_B] =
-      time_dependent_options.distorted_to_inertial_map(true);
+      time_dependent_options.distorted_to_inertial_map<domain::ObjectLabel::B>(
+          true);
 
   for (size_t block = 1; block < number_of_blocks - 1; ++block) {
     if (block < 6) {

--- a/tests/Unit/Helpers/Evolution/Systems/CurvedScalarWave/Worldtube/TestHelpers.cpp
+++ b/tests/Unit/Helpers/Evolution/Systems/CurvedScalarWave/Worldtube/TestHelpers.cpp
@@ -71,9 +71,11 @@ std::unique_ptr<DomainCreator<3>> worldtube_binary_compact_object(
       "    ShapeMapA:\n"
       "      LMax: 8\n"
       "      SizeInitialValues: [0.0, 0.0, 0.0]\n"
+      "      TransitionEndsAtCube: false\n"
       "    ShapeMapB:\n"
       "      LMax: 8\n"
-      "      SizeInitialValues: [0.0, 0.0, 0.0]\n";
+      "      SizeInitialValues: [0.0, 0.0, 0.0]\n"
+      "      TransitionEndsAtCube: false\n";
   return ::TestHelpers::test_option_tag<::domain::OptionTags::DomainCreator<3>,
                                         Metavariables>(
       binary_compact_object_options);


### PR DESCRIPTION
## Proposed changes

Adds the ability to use the wedge transition in the sphere and cube blocks around each object in the BCO domain. This option is not added for the cylindrical BCO domain because different transition functions would be required.

Fixes #5600.
<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
For the `BinaryCompactObject` domain creator, you must add the following two options to each of the shape map blocks

```yaml
BinaryCompactObject:
  ...
  TimeDependentMaps:
    ...
    ShapeMapA:
      ...
      TransitionEndsAtCube: true
    ShapeMapB: #Same as A
```
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

~Depends on and includes #5616.~

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
