### PR TITLE
Change behavior of sphere shape transition function

### DIFF
--- a/src/Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/SphereTransition.cpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/SphereTransition.cpp
@@ -26,8 +26,8 @@ SphereTransition::SphereTransition(const double r_min, const double r_max)
         "r_max =  "
         << r_max << ", and r_min = " << r_min);
   }
-  a_ = -r_min / (r_max - r_min);
-  b_ = r_min * r_max / (r_max - r_min);
+  a_ = -1.0 / (r_max - r_min);
+  b_ = -a_ * r_max;
 }
 
 double SphereTransition::operator()(

--- a/src/Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/SphereTransition.hpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/SphereTransition.hpp
@@ -14,9 +14,19 @@ namespace domain::CoordinateMaps::ShapeMapTransitionFunctions {
 
 /*!
  * \ingroup CoordMapsTimeDependentGroup
- * \brief A transition function that falls off as \f$f(r) = (ar + b) / r\f$. The
- * coefficients \f$a\f$ and \f$b\f$ are chosen so that the map falls off
- * linearly from 1 at `r_min` to 0 at `r_max`.
+ * \brief A transition function that falls off as $f(r) = g(r) / r$ where $g(r)
+ * = ar + b$.
+ *
+ * \details The coefficients $a$ and $b$ are chosen so that the function $g(r) =
+ * ar + b$ falls off linearly from 1 at `r_min` to 0 at `r_max`. This means that
+ * $f(r)$ falls off from $1/r_{\text{min}}$ at `r_min` to 0 at `r_max`. The
+ * coefficients are
+ *
+ * \f{align}{
+ * a &= \frac{-1}{r_{\text{max}} - r_{\text{min}}} \\
+ * b &= \frac{r_{\text{max}}}{r_{\text{max}} - r_{\text{min}}} = -a
+ * r_{\text{max}}
+ * \f}
  */
 class SphereTransition final : public ShapeMapTransitionFunction {
  public:

--- a/tests/Unit/Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/Test_SphereTransition.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/Test_SphereTransition.cpp
@@ -15,11 +15,11 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Shape.SphereTransition",
   SphereTransition sphere_transition{2., 4.};
   constexpr double eps = std::numeric_limits<double>::epsilon() * 100;
   const std::array<double, 3> lower_bound{{2., 0., 0.}};
-  CHECK(sphere_transition(lower_bound) == approx(1.));
+  CHECK(sphere_transition(lower_bound) == approx(0.5));
   const std::array<double, 3> lower_bound_eps{{2. - eps, 0., 0.}};
-  CHECK(sphere_transition(lower_bound_eps) == approx(1.));
+  CHECK(sphere_transition(lower_bound_eps) == approx(0.5));
   const std::array<double, 3> midpoint{{3., 0., 0.}};
-  CHECK(sphere_transition(midpoint) == approx(1. / 3.));
+  CHECK(sphere_transition(midpoint) == approx(1. / 6.));
   const std::array<double, 3> upper_bound{{4., 0., 0.}};
   CHECK(sphere_transition(upper_bound) == approx(0.));
   const std::array<double, 3> upper_bound_eps{{4. + eps, 0., 0.}};

--- a/tests/Unit/Domain/Creators/TimeDependence/Test_Shape.cpp
+++ b/tests/Unit/Domain/Creators/TimeDependence/Test_Shape.cpp
@@ -125,8 +125,7 @@ void test_r_theta_phi(const tnsr::I<double, 3, SourceFrame>& input,
           operator()({{magnitude(input_centered).get(), 0.0, 0.0}});
   const double expected_output_centered_spherical =
       input_centered_spherical[0] *
-      (1.0 +
-       transition_factor * (kerr_schild_radius - inner_radius) / inner_radius);
+      (1.0 + transition_factor * (kerr_schild_radius - inner_radius));
   CHECK(output_centered_spherical[0] ==
         approx(expected_output_centered_spherical));
 }


### PR DESCRIPTION
## Proposed changes

In SpEC, the shape map is (for centered coordinates)

$$
x^i = \xi^i \left(1 - \frac{f(r, \theta, \phi)}{r} \sum_{\ell,m} \lambda_{\ell m}Y_{\ell m}(\theta, \phi)\right)
$$

However, in SpECTRE, the shape map currently is

$$
x^i = \xi^i \left(1 - h(r, \theta, \phi) \sum_{\ell,m} \lambda_{\ell m}Y_{\ell m}(\theta, \phi)\right)
$$

In SpEC, we have that $0 \leq f(r, \theta, \phi) \leq 1$, while in SpECTRE we have $0 \leq h(r, \theta, \phi) \leq 1$. This slight difference of a factor of $r$ is a fundamentally different coordinate mapping.

The actual solution to this is to change our shape coordinate mapping to match the one in SpEC. All of the control systems in SpECTRE make/use assumptions based on the SpEC formula because I thought the shape map in SpECTRE was implemented exactly the same in SpEC. I will make this actual change in a future PR, because it's more involved.

This PR is simply a band-aid fix in the meantime. We can actually make use of the fact that the current `SphereTransition` transition function (which is $h(r, \theta, \phi)$ ) that is used in SpECTRE is

$$
h(r, \theta, \phi) = \frac{ar+b}{r}
$$

which can be rewritten in the SpEC way as

$$
h(r, \theta, \phi) = \frac{ar+b}{r} = \frac{f(r, \theta, \phi)}{r}
$$

The coefficients $a$ and $b$ in the `SphereTransition` class are chosen so $h$ is 1 at the excision boundary and 0 at the outer radius of the inner shell around the excision. However, if we just tweak the coefficients a little, we can make it so that $f$ is 1 at the excision boundary and falls off to 0 while $h$ is $1/r_{\text{Ex}}$ at the excision boundary and falls off to 0. This then makes the SpECTRE coordinate mapping identical to the SpEC one.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
