### PR TITLE
Make shape map exactly like the one in SpEC

### DIFF
--- a/src/Domain/CoordinateMaps/TimeDependent/Shape.cpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/Shape.cpp
@@ -94,7 +94,8 @@ std::array<tt::remove_cvref_wrap_t<T>, 3> Shape::operator()(
 #ifdef SPECTRE_DEBUG
   using ReturnType = tt::remove_cvref_wrap_t<T>;
   const ReturnType shift_radii =
-      distorted_radii * transition_func_->operator()(centered_coords);
+      distorted_radii * transition_func_->operator()(centered_coords) *
+      check_and_compute_one_over_radius(centered_coords);
   if constexpr (std::is_same_v<ReturnType, double>) {
     ASSERT(shift_radii < 1., "Coordinates mapped through the center!");
   } else {
@@ -104,9 +105,11 @@ std::array<tt::remove_cvref_wrap_t<T>, 3> Shape::operator()(
   }
 #endif  // SPECTRE_DEBUG
 
-  return center_ + centered_coords *
-                       (1. - distorted_radii *
-                                 transition_func_->operator()(centered_coords));
+  return center_ +
+         centered_coords *
+             (1. - distorted_radii *
+                       transition_func_->operator()(centered_coords) *
+                       check_and_compute_one_over_radius(centered_coords));
 }
 
 std::optional<std::array<double, 3>> Shape::inverse(
@@ -145,7 +148,8 @@ std::array<tt::remove_cvref_wrap_t<T>, 3> Shape::frame_velocity(
   ylm_.interpolate_from_coefs(make_not_null(&radii_velocities), coef_derivs,
                               interpolation_info);
   return -centered_coords * radii_velocities *
-         transition_func_->operator()(centered_coords);
+         transition_func_->operator()(centered_coords) *
+         check_and_compute_one_over_radius(centered_coords);
 }
 
 template <typename T>
@@ -243,52 +247,82 @@ tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame> Shape::jacobian(
                            get<2>(cartesian_gradient).data(),
                            interpolation_info);
 
+  // No auto here to avoid DVExpressions
+  using ReturnType = tt::remove_cvref_wrap_t<T>;
+  const ReturnType one_over_radius =
+      check_and_compute_one_over_radius(centered_coords);
+  const ReturnType transition_func_over_radius =
+      transition_func_->operator()(centered_coords) * one_over_radius;
+  const ReturnType transition_func_over_square_radius =
+      transition_func_over_radius * one_over_radius;
+  const ReturnType transition_func_over_cube_radius =
+      transition_func_over_square_radius * one_over_radius;
+  const std::array<ReturnType, 3> transition_func_gradient_over_radius =
+      transition_func_->gradient(centered_coords) * one_over_radius;
+
   // re-use allocation
-  auto& transition_func = get<1>(theta_phis);
-  transition_func = transition_func_->operator()(centered_coords);
-  // leave it to the domain specific transition function to divide by the radii
-  // as it can safely do this
-  const auto transition_func_over_radius =
-      transition_func_->map_over_radius(centered_coords);
+  auto& target_gradient_x_times_spatial_part = target_gradient_x;
+  auto& target_gradient_y_times_spatial_part = target_gradient_y;
+  auto& target_gradient_z_times_spatial_part = target_gradient_z;
+  target_gradient_x_times_spatial_part *= transition_func_over_square_radius;
+  target_gradient_y_times_spatial_part *= transition_func_over_square_radius;
+  target_gradient_z_times_spatial_part *= transition_func_over_square_radius;
 
-  const auto transition_func_gradient =
-      transition_func_->gradient(centered_coords);
-
-  const auto& [x_transition_gradient, y_transition_gradient,
-               z_transition_gradient] = transition_func_gradient;
+  const auto& [x_transition_gradient_over_radius,
+               y_transition_gradient_over_radius,
+               z_transition_gradient_over_radius] =
+      transition_func_gradient_over_radius;
   const auto& [x_centered, y_centered, z_centered] = centered_coords;
 
   get<0, 0>(result) =
-      -x_centered * (x_transition_gradient * distorted_radii +
-                     target_gradient_x * transition_func_over_radius);
+      -x_centered * ((x_transition_gradient_over_radius -
+                      x_centered * transition_func_over_cube_radius) *
+                         distorted_radii +
+                     target_gradient_x_times_spatial_part);
   get<0, 1>(result) =
-      -x_centered * (y_transition_gradient * distorted_radii +
-                     target_gradient_y * transition_func_over_radius);
+      -x_centered * ((y_transition_gradient_over_radius -
+                      y_centered * transition_func_over_cube_radius) *
+                         distorted_radii +
+                     target_gradient_y_times_spatial_part);
   get<0, 2>(result) =
-      -x_centered * (z_transition_gradient * distorted_radii +
-                     target_gradient_z * transition_func_over_radius);
+      -x_centered * ((z_transition_gradient_over_radius -
+                      z_centered * transition_func_over_cube_radius) *
+                         distorted_radii +
+                     target_gradient_z_times_spatial_part);
   get<1, 0>(result) =
-      -y_centered * (x_transition_gradient * distorted_radii +
-                     target_gradient_x * transition_func_over_radius);
+      -y_centered * ((x_transition_gradient_over_radius -
+                      x_centered * transition_func_over_cube_radius) *
+                         distorted_radii +
+                     target_gradient_x_times_spatial_part);
   get<1, 1>(result) =
-      -y_centered * (y_transition_gradient * distorted_radii +
-                     target_gradient_y * transition_func_over_radius);
+      -y_centered * ((y_transition_gradient_over_radius -
+                      y_centered * transition_func_over_cube_radius) *
+                         distorted_radii +
+                     target_gradient_y_times_spatial_part);
   get<1, 2>(result) =
-      -y_centered * (z_transition_gradient * distorted_radii +
-                     target_gradient_z * transition_func_over_radius);
+      -y_centered * ((z_transition_gradient_over_radius -
+                      z_centered * transition_func_over_cube_radius) *
+                         distorted_radii +
+                     target_gradient_z_times_spatial_part);
   get<2, 0>(result) =
-      -z_centered * (x_transition_gradient * distorted_radii +
-                     target_gradient_x * transition_func_over_radius);
+      -z_centered * ((x_transition_gradient_over_radius -
+                      x_centered * transition_func_over_cube_radius) *
+                         distorted_radii +
+                     target_gradient_x_times_spatial_part);
   get<2, 1>(result) =
-      -z_centered * (y_transition_gradient * distorted_radii +
-                     target_gradient_y * transition_func_over_radius);
+      -z_centered * ((y_transition_gradient_over_radius -
+                      y_centered * transition_func_over_cube_radius) *
+                         distorted_radii +
+                     target_gradient_y_times_spatial_part);
   get<2, 2>(result) =
-      -z_centered * (z_transition_gradient * distorted_radii +
-                     target_gradient_z * transition_func_over_radius);
+      -z_centered * ((z_transition_gradient_over_radius -
+                      z_centered * transition_func_over_cube_radius) *
+                         distorted_radii +
+                     target_gradient_z_times_spatial_part);
 
-  get<0, 0>(result) += 1. - distorted_radii * transition_func;
-  get<1, 1>(result) += 1. - distorted_radii * transition_func;
-  get<2, 2>(result) += 1. - distorted_radii * transition_func;
+  get<0, 0>(result) += 1. - distorted_radii * transition_func_over_radius;
+  get<1, 1>(result) += 1. - distorted_radii * transition_func_over_radius;
+  get<2, 2>(result) += 1. - distorted_radii * transition_func_over_radius;
 
   return result;
 }
@@ -341,6 +375,24 @@ void Shape::check_size(const gsl::not_null<DataVector*>& coefs,
     // Need to multiply lambda_00 by sqrt(2/pi)
     (*coefs)[0] = M_SQRT1_2 * M_2_SQRTPI * l0m0_spherical_harmonic_coef;
   }
+}
+
+template <typename T>
+T Shape::check_and_compute_one_over_radius(
+    const std::array<T, 3>& centered_coords) const {
+  const T radius = magnitude(centered_coords);
+#ifdef SPECTRE_DEBUG
+  for (size_t i = 0; i < get_size(radius); ++i) {
+    if (get_element(radius, i) == 0.0) {
+      ERROR(
+          "The shape map does not support a (centered) point with radius zero. "
+          "All centered coordinates: "
+          << centered_coords);
+    }
+  }
+#endif  // SPECTRE_DEBUG
+
+  return 1.0 / radius;
 }
 
 bool operator==(const Shape& lhs, const Shape& rhs) {

--- a/src/Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/ShapeMapTransitionFunction.hpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/ShapeMapTransitionFunction.hpp
@@ -87,18 +87,6 @@ class ShapeMapTransitionFunction : public PUP::able {
   virtual std::optional<double> original_radius_over_radius(
       const std::array<double, 3>& target_coords,
       double distorted_radius) const = 0;
-  /*!
-   * Evaluate the transition function at the Cartesian coordinates divided by
-   * the radius. All divisions over the radius which could potentially be zero
-   * divisions are left to the transition function which uses its knowledge
-   * of the domain to do this safely or throw an appropriate error.
-   */
-  /// @{
-  virtual double map_over_radius(
-      const std::array<double, 3>& source_coords) const = 0;
-  virtual DataVector map_over_radius(
-      const std::array<DataVector, 3>& source_coords) const = 0;
-  /// @}
 
   /*!
    * Evaluate the gradient of the transition function with respect to the

--- a/src/Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/SphereTransition.cpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/SphereTransition.cpp
@@ -55,15 +55,6 @@ std::optional<double> SphereTransition::original_radius_over_radius(
              : std::nullopt;
 }
 
-double SphereTransition::map_over_radius(
-    const std::array<double, 3>& source_coords) const {
-  return map_over_radius_impl<double>(source_coords);
-}
-DataVector SphereTransition::map_over_radius(
-    const std::array<DataVector, 3>& source_coords) const {
-  return map_over_radius_impl<DataVector>(source_coords);
-}
-
 std::array<double, 3> SphereTransition::gradient(
     const std::array<double, 3>& source_coords) const {
   return gradient_impl<double>(source_coords);
@@ -77,15 +68,7 @@ template <typename T>
 T SphereTransition::call_impl(const std::array<T, 3>& source_coords) const {
   const T mag = magnitude(source_coords);
   check_magnitudes(mag);
-  return a_ + b_ / mag;
-}
-
-template <typename T>
-T SphereTransition::map_over_radius_impl(
-    const std::array<T, 3>& source_coords) const {
-  const T mag = magnitude(source_coords);
-  check_magnitudes(mag);
-  return a_ / mag + b_ / square(mag);
+  return a_ * mag + b_;
 }
 
 template <typename T>
@@ -93,7 +76,7 @@ std::array<T, 3> SphereTransition::gradient_impl(
     const std::array<T, 3>& source_coords) const {
   const T mag = magnitude(source_coords);
   check_magnitudes(mag);
-  return -b_ * source_coords / cube(mag);
+  return a_ * source_coords / mag;
 }
 
 bool SphereTransition::operator==(

--- a/src/Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/SphereTransition.hpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/SphereTransition.hpp
@@ -41,11 +41,6 @@ class SphereTransition final : public ShapeMapTransitionFunction {
       const std::array<double, 3>& target_coords,
       double distorted_radius) const override;
 
-  double map_over_radius(
-      const std::array<double, 3>& source_coords) const override;
-  DataVector map_over_radius(
-      const std::array<DataVector, 3>& source_coords) const override;
-
   std::array<double, 3> gradient(
       const std::array<double, 3>& source_coords) const override;
   std::array<DataVector, 3> gradient(
@@ -65,9 +60,6 @@ class SphereTransition final : public ShapeMapTransitionFunction {
  private:
   template <typename T>
   T call_impl(const std::array<T, 3>& source_coords) const;
-
-  template <typename T>
-  T map_over_radius_impl(const std::array<T, 3>& source_coords) const;
 
   template <typename T>
   std::array<T, 3> gradient_impl(const std::array<T, 3>& source_coords) const;

--- a/src/Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/Wedge.cpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/Wedge.cpp
@@ -126,36 +126,20 @@ std::optional<double> Wedge::original_radius_over_radius(
     return std::optional{1.0};
   }
 
-  // Solving equation of the form rtil*x^2 + ((D_o - D_i)/SumYlm - D_o)*x - (D_o
-  // - D_i)/SumYlm = 0
-  const double a = radius;
-  const double c = -distance_difference / distorted_radius;
-  const double b = -c - outer_distance;
+  const double linear_a = -1.0 / distance_difference;
+  const double linear_b = -linear_a * outer_distance;
 
-  std::optional<std::array<double, 2>> roots = real_roots(a, b, c);
-
-  if (roots.has_value()) {
-    for (const double root : roots.value()) {
-      // Check if the root is positive and within the inner and outer distance
-      // (divided by the mapped radius)
-      if (root > 0.0 and root + eps_ >= inner_distance / radius and
-          root - eps_ <= outer_distance / radius) {
-        return std::optional{root};
-      }
-    }
-    return std::nullopt;
-  } else {
+  const double denom = 1. - distorted_radius * linear_a;
+  // prevent zero division
+  if (equal_within_roundoff(denom, 0.)) {
     return std::nullopt;
   }
-}
+  const double original_radius = (radius + distorted_radius * linear_b) / denom;
 
-double Wedge::map_over_radius(
-    const std::array<double, 3>& source_coords) const {
-  return map_over_radius_impl<double>(source_coords);
-}
-DataVector Wedge::map_over_radius(
-    const std::array<DataVector, 3>& source_coords) const {
-  return map_over_radius_impl<DataVector>(source_coords);
+  return (original_radius + eps_) >= inner_distance and
+                 (original_radius - eps_) <= outer_distance
+             ? std::optional<double>{original_radius / radius}
+             : std::nullopt;
 }
 
 std::array<double, 3> Wedge::gradient(
@@ -176,18 +160,6 @@ T Wedge::call_impl(const std::array<T, 3>& source_coords) const {
 
   return (outer_distance - magnitude(rotated_coords)) /
          (outer_distance - inner_surface_.distance(rotated_coords));
-}
-
-template <typename T>
-T Wedge::map_over_radius_impl(const std::array<T, 3>& source_coords) const {
-  const std::array<T, 3> rotated_coords =
-      discrete_rotation(orientation_map_.inverse_map(), source_coords);
-  check_distances(rotated_coords);
-  const T radius = magnitude(rotated_coords);
-  const T outer_distance = outer_surface_.distance(rotated_coords);
-
-  return (outer_distance - radius) /
-         ((outer_distance - inner_surface_.distance(rotated_coords)) * radius);
 }
 
 template <typename T>

--- a/src/Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/Wedge.cpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/Wedge.cpp
@@ -24,22 +24,38 @@
 
 namespace domain::CoordinateMaps::ShapeMapTransitionFunctions {
 template <typename T>
-T Wedge::Surface::distance(const std::array<T, 3>& coords) const {
+T Wedge::Surface::distance(const std::array<T, 3>& coords,
+                           const std::optional<size_t>& axis) const {
   // Short circuit if it's a sphere. Then the distance is trivially the radius
   // of this surface
   if (sphericity == 1.0) {
     return make_with_value<T>(coords[0], radius);
   }
 
-  ASSERT(coords[2] != 0.0,
-         "For wedge transition, rotated coords cannot have z component equal "
-         "to zero.");
+  T non_spherical_contribution =
+      (1.0 - sphericity) / sqrt(3.0) * magnitude(coords);
 
-  // D = R * [ (1 - s) / (sqrt(3) * cos(theta)) + s]
-  // cos(theta) = z / r
-  return radius *
-         ((1.0 - sphericity) / (coords[2] * sqrt(3.0)) * magnitude(coords) +
-          sphericity);
+  if (axis.has_value()) {
+#ifdef SPECTRE_DEBUG
+    for (size_t i = 0; i < get_size(coords[0]); i++) {
+      if (get_element(gsl::at(coords, axis.value()), i) == 0.0) {
+        ERROR(
+            "The Wedge transition map was called with coordinates outside of "
+            "its wedge. The "
+            << (axis.value() == 0_st ? "x" : (axis.value() == 1_st ? "y" : "z"))
+            << "-coordinate shouldn't be 0 but it is. Coordinate: ("
+            << get_element(coords[0], i) << "," << get_element(coords[1], i)
+            << "," << get_element(coords[2], i) << ")");
+      }
+    }
+#endif
+    non_spherical_contribution /= abs(gsl::at(coords, axis.value()));
+  } else {
+    non_spherical_contribution /=
+        blaze::max(abs(coords[0]), abs(coords[1]), abs(coords[2]));
+  }
+
+  return radius * (non_spherical_contribution + sphericity);
 }
 
 void Wedge::Surface::pup(PUP::er& p) {
@@ -56,11 +72,10 @@ bool Wedge::Surface::operator!=(const Wedge::Surface& other) const {
 }
 
 Wedge::Wedge(double inner_radius, double outer_radius, double inner_sphericity,
-             double outer_sphericity, OrientationMap<3> orientation_map)
+             double outer_sphericity, const size_t axis)
     : inner_surface_(Surface{inner_radius, inner_sphericity}),
       outer_surface_(Surface{outer_radius, outer_sphericity}),
-      orientation_map_(std::move(orientation_map)),
-      direction_(orientation_map_.inverse_map()(Direction<3>::upper_zeta())) {}
+      axis_{axis} {}
 
 double Wedge::operator()(const std::array<double, 3>& source_coords) const {
   return call_impl<double>(source_coords);
@@ -76,8 +91,6 @@ std::optional<double> Wedge::original_radius_over_radius(
   CAPTURE_FOR_ERROR(target_coords);
   CAPTURE_FOR_ERROR(distorted_radius);
   CAPTURE_FOR_ERROR(radius);
-  CAPTURE_FOR_ERROR(orientation_map_);
-  CAPTURE_FOR_ERROR(direction_);
 
   // Couple protections that would make a point completely outside of the domain
   // of validity for any wedge
@@ -94,28 +107,14 @@ std::optional<double> Wedge::original_radius_over_radius(
     return std::nullopt;
   }
 
-  // Rotate the coordinates so they are aligned with +z. This makes checking if
-  // the target_coord is in the proper wedge very simple since we only have to
-  // check if the target coord is in the direction of the +z wedge
-  const std::array<double, 3> rotated_coords =
-      discrete_rotation(orientation_map_.inverse_map(), target_coords);
-  CAPTURE_FOR_ERROR(rotated_coords);
-
-  // This comparison only works because the opening angle of the wedge is pi/2
-  // in both x and y
-  if (rotated_coords[2] <
-      std::max(abs(rotated_coords[0]), abs(rotated_coords[1]))) {
-    return std::nullopt;
-  }
-
   // If distorted radius is 0, this means the map is the identity so the radius
   // and the original radius are equal. Also we don't want to divide by 0 below
   if (equal_within_roundoff(distorted_radius, 0.0)) {
     return std::optional{1.0};
   }
 
-  const double outer_distance = outer_surface_.distance(rotated_coords);
-  const double inner_distance = inner_surface_.distance(rotated_coords);
+  const double outer_distance = outer_surface_.distance(target_coords);
+  const double inner_distance = inner_surface_.distance(target_coords);
   const double distance_difference = outer_distance - inner_distance;
 
   // If we are at the overall outer distance, then the transition function is 0
@@ -126,15 +125,15 @@ std::optional<double> Wedge::original_radius_over_radius(
     return std::optional{1.0};
   }
 
-  const double linear_a = -1.0 / distance_difference;
-  const double linear_b = -linear_a * outer_distance;
+  const double distorted_times_a = -distorted_radius / distance_difference;
+  const double distorted_times_b = -distorted_times_a * outer_distance;
 
-  const double denom = 1. - distorted_radius * linear_a;
+  const double denom = 1. - distorted_times_a;
   // prevent zero division
   if (equal_within_roundoff(denom, 0.)) {
     return std::nullopt;
   }
-  const double original_radius = (radius + distorted_radius * linear_b) / denom;
+  const double original_radius = (radius + distorted_times_b) / denom;
 
   return (original_radius + eps_) >= inner_distance and
                  (original_radius - eps_) <= outer_distance
@@ -153,13 +152,11 @@ std::array<DataVector, 3> Wedge::gradient(
 
 template <typename T>
 T Wedge::call_impl(const std::array<T, 3>& source_coords) const {
-  const std::array<T, 3> rotated_coords =
-      discrete_rotation(orientation_map_.inverse_map(), source_coords);
-  check_distances(rotated_coords);
-  T outer_distance = outer_surface_.distance(rotated_coords);
+  check_distances(source_coords);
+  T outer_distance = outer_surface_.distance(source_coords, axis_);
 
-  return (outer_distance - magnitude(rotated_coords)) /
-         (outer_distance - inner_surface_.distance(rotated_coords));
+  return (outer_distance - magnitude(source_coords)) /
+         (outer_distance - inner_surface_.distance(source_coords, axis_));
 }
 
 template <typename T>
@@ -168,87 +165,54 @@ std::array<T, 3> Wedge::gradient_impl(
   // If both surfaces are spherical then we short circuit because the distances
   // are constant and we only need to take a derivative of r.
   // (grad f)_i = -(x_i/r)/(D_out - D_in)
-  const std::array<T, 3> rotated_coords =
-      discrete_rotation(orientation_map_.inverse_map(), source_coords);
-  check_distances(rotated_coords);
+  check_distances(source_coords);
+  const T outer_distance = outer_surface_.distance(source_coords, axis_);
+  const T inner_distance = inner_surface_.distance(source_coords, axis_);
   if (inner_surface_.sphericity == 1.0 and outer_surface_.sphericity == 1.0) {
-    const T one_over_denom = 1.0 / (magnitude(rotated_coords) *
-                                    (outer_surface_.distance(rotated_coords) -
-                                     inner_surface_.distance(rotated_coords)));
+    const T one_over_denom =
+        1.0 / (magnitude(source_coords) * (outer_distance - inner_distance));
 
-    return discrete_rotation(orientation_map_,
-                             -rotated_coords * one_over_denom);
+    return -source_coords * one_over_denom;
   }
 
-  const T radius = magnitude(rotated_coords);
-
+  const T radius = magnitude(source_coords);
   const T one_over_radius = 1.0 / radius;
-  T outer_distance = outer_surface_.distance(rotated_coords);
-  const T one_over_denom =
-      1.0 / (outer_distance - inner_surface_.distance(rotated_coords));
-  T& outer_distance_minus_radius_over_denom = outer_distance;
-  outer_distance_minus_radius_over_denom -= radius;
-  outer_distance_minus_radius_over_denom *= one_over_denom;
 
-  // Avoid small negative numbers if we are at outer boundary
-  for (size_t i = 0; i < get_size(radius); i++) {
-    if (equal_within_roundoff(
-            get_element(outer_distance_minus_radius_over_denom, i), 0.0)) {
-      get_element(outer_distance_minus_radius_over_denom, i) = 0.0;
+  const auto surface_gradient = [&](const Surface& surface) {
+    if (surface.sphericity == 1.0) {
+      return make_array<3, T>(make_with_value<T>(source_coords[0], 0.0));
     }
-  }
 
-  // Regardless of the sphericities below, we always need this factor in the
-  // first term so we calculate it now.
-  std::array<T, 3> result = -1.0 * rotated_coords * one_over_radius;
+    const size_t axis_plus_one = (axis_ + 1) % 3;
+    const size_t axis_plus_two = (axis_ + 2) % 3;
 
-  const auto make_factor = [&one_over_radius](const Surface& surface) -> T {
-    return (1.0 - surface.sphericity) * surface.radius * cube(one_over_radius) /
-           sqrt(3.0);
+    const T& axis_coord = gsl::at(source_coords, axis_);
+
+    const double factor =
+        surface.radius * (1.0 - surface.sphericity) / sqrt(3.0);
+
+    std::array<T, 3> grad =
+        make_array<3, T>(factor * one_over_radius / abs(axis_coord));
+
+    // Dividing by axis_coord here takes care of the sgn(axis_coord) that would
+    // have been necessary
+    gsl::at(grad, axis_) *= -(square(radius) - square(axis_coord)) / axis_coord;
+    gsl::at(grad, axis_plus_one) *= gsl::at(source_coords, axis_plus_one);
+    gsl::at(grad, axis_plus_two) *= gsl::at(source_coords, axis_plus_two);
+
+    return grad;
   };
 
-  // We can make some simplifications if either of the surfaces are spherical
-  // because then the derivative of the distance is zero since it's constant. In
-  // the first two branches, it's safe to assume the other sphericity isn't 1
-  // because of the above check.
-  if (outer_surface_.sphericity == 1.0) {
-    T total_factor = make_factor(inner_surface_);
-    total_factor *= outer_distance_minus_radius_over_denom;
+  const T one_over_distance_difference =
+      1.0 / (outer_distance - inner_distance);
 
-    for (size_t i = 0; i < 2; i++) {
-      gsl::at(result, i) -=
-          total_factor * rotated_coords[2] * gsl::at(rotated_coords, i);
-    }
+  const std::array<T, 3> outer_gradient = surface_gradient(outer_surface_);
+  const std::array<T, 3> inner_gradient = surface_gradient(inner_surface_);
 
-    result[2] += total_factor * (square(radius) - square(rotated_coords[2]));
-  } else if (inner_surface_.sphericity == 1.0) {
-    T total_factor = make_factor(outer_surface_);
-    total_factor *= (1.0 - outer_distance_minus_radius_over_denom);
-
-    for (size_t i = 0; i < 2; i++) {
-      gsl::at(result, i) -=
-          total_factor * rotated_coords[2] * gsl::at(rotated_coords, i);
-    }
-
-    result[2] += total_factor * (square(radius) - square(rotated_coords[2]));
-  } else {
-    T inner_total_factor = make_factor(inner_surface_);
-    inner_total_factor *= outer_distance_minus_radius_over_denom;
-    T outer_total_factor = make_factor(outer_surface_);
-    outer_total_factor *= (1.0 - outer_distance_minus_radius_over_denom);
-
-    for (size_t i = 0; i < 2; i++) {
-      gsl::at(result, i) -= (inner_total_factor + outer_total_factor) *
-                            rotated_coords[2] * gsl::at(rotated_coords, i);
-    }
-
-    result[2] += (outer_total_factor + inner_total_factor) *
-                 (square(radius) - square(rotated_coords[2]));
-  }
-
-  // Finally, need one more factor of D_out - D_in in the denominator and to
-  // rotate it back to the proper orientation
-  return discrete_rotation(orientation_map_, result * one_over_denom);
+  return (outer_gradient - source_coords * one_over_radius -
+          (outer_distance - radius) * (outer_gradient - inner_gradient) *
+              one_over_distance_difference) *
+         one_over_distance_difference;
 }
 
 bool Wedge::operator==(const ShapeMapTransitionFunction& other) const {
@@ -258,7 +222,7 @@ bool Wedge::operator==(const ShapeMapTransitionFunction& other) const {
   const Wedge& other_ref = *dynamic_cast<const Wedge*>(&other);
   return inner_surface_ == other_ref.inner_surface_ and
          outer_surface_ == other_ref.outer_surface_ and
-         orientation_map_ == other_ref.orientation_map_;
+         axis_ == other_ref.axis_;
 }
 
 bool Wedge::operator!=(const ShapeMapTransitionFunction& other) const {
@@ -271,8 +235,8 @@ void Wedge::check_distances([
     [maybe_unused]] const std::array<T, 3>& coords) const {
 #ifdef SPECTRE_DEBUG
   const T mag = magnitude(coords);
-  const T inner_distance = inner_surface_.distance(coords);
-  const T outer_distance = outer_surface_.distance(coords);
+  const T inner_distance = inner_surface_.distance(coords, axis_);
+  const T outer_distance = outer_surface_.distance(coords, axis_);
   for (size_t i = 0; i < get_size(mag); ++i) {
     if (get_element(mag, i) + eps_ < get_element(inner_distance, i) or
         get_element(mag, i) - eps_ > get_element(outer_distance, i)) {
@@ -301,8 +265,7 @@ void Wedge::pup(PUP::er& p) {
   if (version >= 0) {
     p | inner_surface_;
     p | outer_surface_;
-    p | orientation_map_;
-    p | direction_;
+    p | axis_;
   }
 }
 

--- a/src/Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/Wedge.hpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/Wedge.hpp
@@ -96,20 +96,18 @@ namespace domain::CoordinateMaps::ShapeMapTransitionFunctions {
  * the ratio of the original radius $r$ to the mapped $\tilde{r}$ by solving
  *
  * \begin{equation}
- * \frac{r}{\tilde{r}} = \frac{1}{1-f(r,\theta,\phi)\Sigma(\theta,\phi)}
+ * \frac{r}{\tilde{r}} =
+ * \frac{1}{1-\frac{f(r,\theta,\phi)}{r}\Sigma(\theta,\phi)}
  * \end{equation}
  *
- * Because this is a linear transition, this will result in is having to solve a
- * quadratic equation of the form
+ * After plugging in the transition and solving, we get
  *
  * \begin{equation}
- * \tilde{r} x^2 + \left(\frac{D_{\text{out}} -
- * D_{\text{in}}}{\Sigma(\theta,\phi)} - D_{\text{out}}\right) x -
- * \frac{D_{\text{out}} - D_{\text{in}}}{\Sigma(\theta,\phi)} = 0
+ * \frac{r}{\tilde{r}} = \frac{1 + \frac{D_{\text{out}}\Sigma(\theta,
+ * \phi)}{\tilde{r}(D_{\text{out}} - D_{\text{in}})}}{1 + \frac{\Sigma(\theta,
+ * \phi)}{D_{\text{out}} - D_{\text{in}}}}
  * \label{eq:r_over_rtil}
  * \end{equation}
- *
- * where $x = \frac{r}{\tilde{r}}$.
  *
  * \note Since $D$ is not a function of the radius, we can treat it as a
  * constant in Eq. $\ref{eq:r_over_rtil}$ and compute the angles using
@@ -196,11 +194,6 @@ class Wedge final : public ShapeMapTransitionFunction {
       const std::array<double, 3>& target_coords,
       double distorted_radius) const override;
 
-  double map_over_radius(
-      const std::array<double, 3>& source_coords) const override;
-  DataVector map_over_radius(
-      const std::array<DataVector, 3>& source_coords) const override;
-
   std::array<double, 3> gradient(
       const std::array<double, 3>& source_coords) const override;
   std::array<DataVector, 3> gradient(
@@ -220,9 +213,6 @@ class Wedge final : public ShapeMapTransitionFunction {
  private:
   template <typename T>
   T call_impl(const std::array<T, 3>& source_coords) const;
-
-  template <typename T>
-  T map_over_radius_impl(const std::array<T, 3>& source_coords) const;
 
   template <typename T>
   std::array<T, 3> gradient_impl(const std::array<T, 3>& source_coords) const;

--- a/src/Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/Wedge.hpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/Wedge.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <array>
+#include <cstddef>
 #include <limits>
 #include <memory>
 #include <optional>
@@ -11,11 +12,8 @@
 
 #include "DataStructures/DataVector.hpp"
 #include "Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/ShapeMapTransitionFunction.hpp"
-#include "Domain/Structure/Direction.hpp"
-#include "Domain/Structure/OrientationMap.hpp"
 
 namespace domain::CoordinateMaps::ShapeMapTransitionFunctions {
-
 /*!
  * \brief A transition function that falls off linearly from an inner surface of
  * a wedge to an outer surface of a wedge. Meant to be used in
@@ -32,10 +30,13 @@ namespace domain::CoordinateMaps::ShapeMapTransitionFunctions {
  * where
  *
  * \begin{equation}
- * D(r, \theta, \phi) = R\left(\frac{1 - s}{\sqrt{3}\cos{\theta}} + s\right),
+ * D(r, \theta, \phi) = R\left(\frac{1 -
+ * s}{\sqrt{3}\max(|\sin{\theta}\cos{\phi}|,|\sin{\theta}\sin{\phi}|,
+ * |\cos{\theta}|)} + s\right),
+ * \label{eq:distance}
  * \end{equation}
  *
- * and $s$ is the sphericity of the surface which goes from 0 (flat) to 1
+ * where $s$ is the sphericity of the surface which goes from 0 (flat) to 1
  * (spherical), $R$ is the radius of the spherical surface, $\text{out}$ is the
  * outer surface, and $\text{in}$ is the inner surface. If the sphericity is 1,
  * then the surface is a sphere so $D = R$. If the sphericity is 0, then the
@@ -44,8 +45,8 @@ namespace domain::CoordinateMaps::ShapeMapTransitionFunctions {
  * surfaces and their sphericities.
  *
  * \note Because the shape map distorts only radii and does not affect angles,
- * $D$ is only a function of $\theta$ so we have that $D(r,\theta,\phi) =
- * D(\theta)$.
+ * $D$ is not a function of $r$ so we have that $D(r,\theta,\phi) =
+ * D(\theta, \phi)$.
  *
  * There are several assumptions made for this mapping:
  *
@@ -54,11 +55,9 @@ namespace domain::CoordinateMaps::ShapeMapTransitionFunctions {
  * - The coordinates $r, \theta, \phi$ are assumed to be from the center of the
  *   wedge, not the center of the computational domain.
  * - The wedges are concentric. (see the constructor)
- * - Eq. $\ref{eq:transition_func}$ assumes it is in a wedge that is aligned
- *   with the +z direction. Therefore, $\cos{\theta} = \hat{r} \cdot \hat{z} =
- *   \frac{\vec{r}}{r} \cdot \hat{z} = \frac{z}{r}$. For the wedges aligned with
- *   the other axes, the coordinates are first rotated so they align with +z,
- *   then the computation is done.
+ * - The $\max$ in the denominator of $\ref{eq:distance}$ can be simplified a
+ *   bit to $\max(|x|, |y|, |z|)/r$. It was written the other way in
+ *   $\ref{eq:distance}$ to emphasize that $D$ has no radial dependence.
  *
  * ## Gradient
  *
@@ -70,29 +69,30 @@ namespace domain::CoordinateMaps::ShapeMapTransitionFunctions {
  * D_{\text{in}}} - \frac{\left(D_{\text{out}} - r\right)\left(\frac{\partial
  * D_{\text{out}}}{\partial x_i} - \frac{\partial
  * D_{\text{in}}}{\partial x_i} \right)}{\left(D_{\text{out}} -
- * D_{\text{in}}\right)^2}
+ * D_{\text{in}}\right)^2}.
  * \end{equation}
  *
- * where
+ * The computation of the gradient of $D$ depends on the result of the $\max$ in
+ * the denominator of $\ref{eq:distance}$. To simplify the expression, let $j
+ * \in \{0,1,2\}$ correspond to the $\max(|x|, |y|, |z|)$ such that $j=0$ if
+ * $|x|$ is the $\max$, and so on. Then we can write the gradient of $D$ as
  *
  * \f{align}{
- * \frac{\partial D}{\partial z} &= \frac{R\left(1-s\right)}{\sqrt{3}}
- * \frac{\partial}{\partial z} \left(\frac{z}{r} \right) =
- * \frac{R\left(1-s\right)}{\sqrt{3}} \left(\frac{r^2 - z^2}{r^3} \right), \\
- * \frac{\partial D}{\partial x} &= \frac{R\left(1-s\right)}{\sqrt{3}}
- * \frac{\partial}{\partial x} \left(\frac{z}{r} \right) =
- * -\frac{R\left(1-s\right)}{\sqrt{3}} \left(\frac{xz}{r^3} \right), \\
- * \frac{\partial D}{\partial y} &= \frac{\partial D}{\partial x} \left(x
- * \rightarrow y \right),
+ * \frac{\partial D}{\partial x_j} &= -\text{sgn}(x_j)\frac{R(1-s)\left(r^2 -
+ * x_j^2\right)}{r x_j^2 \sqrt{3}} \\
+ * \frac{\partial D}{\partial x_{j+1}} &= \frac{R(1-s)x_{j+1}}{r |x_j| \sqrt{3}}
+ * \\
+ * \frac{\partial D}{\partial x_{j+2}} &= \frac{R(1-s)x_{j+2}}{r |x_j| \sqrt{3}}
  * \f}
  *
- * making use of the fact that this wedge is aligned with the +z axis so that
- * $\cos{\theta} = \frac{z}{r}$.
+ * where $j+1$ and $j+2$ are understood to be $\mod 3$. Also since we don't
+ * allow points at the origin of these wedges, we can be assured that for
+ * whichever $j$ is max, that $x_j$ won't be zero.
  *
  * ## Original radius divided by mapped radius
  *
  * Given an already mapped point and the distorted radius $\Sigma(\theta, \phi)
- * = \sum_{\ell,m}\lambda_{\ell,m}Y_{\ell,m}(\theta, \phi)$, we can figure out
+ * = \sum_{\ell,m}\lambda_{\ell m}Y_{\ell m}(\theta, \phi)$, we can figure out
  * the ratio of the original radius $r$ to the mapped $\tilde{r}$ by solving
  *
  * \begin{equation}
@@ -109,46 +109,15 @@ namespace domain::CoordinateMaps::ShapeMapTransitionFunctions {
  * \label{eq:r_over_rtil}
  * \end{equation}
  *
- * \note Since $D$ is not a function of the radius, we can treat it as a
- * constant in Eq. $\ref{eq:r_over_rtil}$ and compute the angles using
- * $\tilde{r}$.
+ * \note Since $D$ is not a function of the radius, we can compute the angles
+ * using $\tilde{r}$ in Eq. $\ref{eq:r_over_rtil}$.
  *
  * ## Special cases
  *
  * The equations above become simpler if the inner boundary, outer boundary, or
  * both are spherical ($s = 1$). If a boundary is spherical, then $D = R$ and
- * $\frac{\partial D}{\partial x_i} = 0$. Since $D$ can be held constant when
- * solving $\ref{eq:r_over_rtil}$, the quadratic equation itself doesn't
- * simplify, only the computation of $D$.
- *
- * If the inner boundary is spherical (but not the outer boundary), then the
- * gradient of $f$ becomes
- *
- * \begin{equation}
- * \frac{\partial f}{\partial x_i} = \frac{\frac{\partial
- * D_{\text{out}}}{\partial x_i} - \frac{x_i}{r}}{D_{\text{out}} -
- * D_{\text{in}}} - \frac{\left(D_{\text{out}} - r\right) - \left(\frac{\partial
- * D_{\text{out}}}{\partial x_i} \right)}{\left(D_{\text{out}} -
- * D_{\text{in}}\right)^2}.
- * \end{equation}
- *
- * If the outer boundary is spherical (but not the inner boundary), then the
- * gradient of $f$ becomes
- *
- * \begin{equation}
- * \frac{\partial f}{\partial x_i} = \frac{-\frac{x_i}{r}}{D_{\text{out}} -
- * D_{\text{in}}} - \frac{\left(D_{\text{out}} - r\right) + \left(\frac{\partial
- * D_{\text{in}}}{\partial x_i} \right)}{\left(D_{\text{out}} -
- * D_{\text{in}}\right)^2}
- * \end{equation}
- *
- * If the both boundaries are spherical, then the gradient of $f$ simplifies
- * greatly to
- *
- * \begin{equation}
- * \frac{\partial f}{\partial x_i} = \frac{-\frac{x_i}{r}}{D_{\text{out}} -
- * D_{\text{in}}}
- * \end{equation}
+ * $\frac{\partial D}{\partial x_i} = 0$. This simplifies the expanded form of
+ * the gradient significantly.
  */
 class Wedge final : public ShapeMapTransitionFunction {
   struct Surface {
@@ -156,9 +125,11 @@ class Wedge final : public ShapeMapTransitionFunction {
     double sphericity{};
 
     // This is the distance from the center (assumed to be 0,0,0) to this
-    // surface in the same direction as coords.
+    // surface in the same direction as coords. The calculation is cheaper if
+    // you know the axis ahead of time
     template <typename T>
-    T distance(const std::array<T, 3>& coords) const;
+    T distance(const std::array<T, 3>& coords,
+               const std::optional<size_t>& axis = std::nullopt) const;
 
     void pup(PUP::er& p);
 
@@ -180,11 +151,11 @@ class Wedge final : public ShapeMapTransitionFunction {
    * \param outer_radius Outermost radius of outermost wedge
    * \param inner_sphericity Sphericity of innermost surface of innermost wedge
    * \param outer_sphericity Sphericity of outermost surface of outermost wedge
-   * \param orientation_map The same orientation map that was passed into the
-   * corresponding `domain::CoordinateMaps::Wedge` block.
+   * \param axis The direction that this wedge is in. Both the positive and
+   * negative direction get the same axis.
    */
   Wedge(double inner_radius, double outer_radius, double inner_sphericity,
-        double outer_sphericity, OrientationMap<3> orientation_map);
+        double outer_sphericity, size_t axis);
 
   double operator()(const std::array<double, 3>& source_coords) const override;
   DataVector operator()(
@@ -222,8 +193,7 @@ class Wedge final : public ShapeMapTransitionFunction {
 
   Surface inner_surface_{};
   Surface outer_surface_{};
-  OrientationMap<3> orientation_map_{};
-  Direction<3> direction_{};
+  size_t axis_{};
   static constexpr double eps_ = std::numeric_limits<double>::epsilon() * 100;
 };
 }  // namespace domain::CoordinateMaps::ShapeMapTransitionFunctions

--- a/tests/Unit/Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/Test_SphereTransition.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/Test_SphereTransition.cpp
@@ -15,11 +15,11 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Shape.SphereTransition",
   SphereTransition sphere_transition{2., 4.};
   constexpr double eps = std::numeric_limits<double>::epsilon() * 100;
   const std::array<double, 3> lower_bound{{2., 0., 0.}};
-  CHECK(sphere_transition(lower_bound) == approx(0.5));
+  CHECK(sphere_transition(lower_bound) == approx(1.0));
   const std::array<double, 3> lower_bound_eps{{2. - eps, 0., 0.}};
-  CHECK(sphere_transition(lower_bound_eps) == approx(0.5));
+  CHECK(sphere_transition(lower_bound_eps) == approx(1.0));
   const std::array<double, 3> midpoint{{3., 0., 0.}};
-  CHECK(sphere_transition(midpoint) == approx(1. / 6.));
+  CHECK(sphere_transition(midpoint) == approx(0.5));
   const std::array<double, 3> upper_bound{{4., 0., 0.}};
   CHECK(sphere_transition(upper_bound) == approx(0.));
   const std::array<double, 3> upper_bound_eps{{4. + eps, 0., 0.}};

--- a/tests/Unit/Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/Test_Wedge.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/Test_Wedge.cpp
@@ -156,7 +156,6 @@ void test_only_transition() {
   const double function_value = (outer_distance - 4.0) / distance_difference;
 
   CHECK(wedge(point) == approx(function_value));
-  CHECK(wedge.map_over_radius(point) == approx(function_value / 4.0));
   CHECK_ITERABLE_APPROX(wedge.gradient(point),
                         (std::array{0.0, 0.0, -1.0 / distance_difference}));
 
@@ -172,14 +171,14 @@ void test_only_transition() {
   set_orig_rad_over_rad(point, 0.0);
   CHECK(orig_rad_over_rad.has_value());
   CHECK(orig_rad_over_rad.value() == approx(1.0));
-  set_orig_rad_over_rad(point * (1.0 - function_value * 0.5), 0.5);
+  set_orig_rad_over_rad(point * (1.0 - 0.25 * function_value * 0.5), 0.5);
   CHECK(orig_rad_over_rad.has_value());
   CHECK(orig_rad_over_rad.value() ==
-        approx(4.0 / magnitude(point * (1.0 - function_value * 0.5))));
-  set_orig_rad_over_rad(point * (1.0 + function_value * 0.5), -0.5);
+        approx(4.0 / magnitude(point * (1.0 - 0.25 * function_value * 0.5))));
+  set_orig_rad_over_rad(point * (1.0 + 0.25 * function_value * 0.5), -0.5);
   CHECK(orig_rad_over_rad.has_value());
   CHECK(orig_rad_over_rad.value() ==
-        approx(4.0 / magnitude(point * (1.0 + function_value * 0.5))));
+        approx(4.0 / magnitude(point * (1.0 + 0.25 * function_value * 0.5))));
   // Hit some internal checks
   set_orig_rad_over_rad(point * 0.0, 0.0);
   CHECK_FALSE(orig_rad_over_rad.has_value());
@@ -201,9 +200,9 @@ void test_only_transition() {
   set_orig_rad_over_rad(std::array{0.0, -4.0, 0.0}, 0.0);
   CHECK_FALSE(orig_rad_over_rad.has_value());
   // At overall inner boundary.
-  set_orig_rad_over_rad(std::array{0.0, 0.0, 0.5 * inner_radius}, 0.5);
+  set_orig_rad_over_rad(std::array{0.0, 0.0, 0.2 * inner_radius}, 0.4);
   CHECK(orig_rad_over_rad.has_value());
-  CHECK(orig_rad_over_rad.value() == 2.0);
+  CHECK(orig_rad_over_rad.value() == approx(5.0));
 
   test_gradient();
 }

--- a/tests/Unit/Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/Test_Wedge.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/Test_Wedge.cpp
@@ -21,6 +21,7 @@
 #include "Domain/Structure/OrientationMap.hpp"
 #include "Framework/TestHelpers.hpp"
 #include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "Helpers/Domain/CoordinateMaps/TestMapHelpers.hpp"
 #include "Utilities/CartesianProduct.hpp"
 #include "Utilities/StdArrayHelpers.hpp"
 
@@ -38,12 +39,11 @@ void test_gradient() {
   INFO("Test gradient");
   const double inner_radius = 0.5;
   const double outer_radius = 10.0;
-  const OrientationMap<3> orientation_map{};
 
   const auto make_wedge = [&](const double inner_sphericity,
                               const double outer_sphericity) {
     return Wedge{inner_radius, outer_radius, inner_sphericity, outer_sphericity,
-                 orientation_map};
+                 2_st};
   };
 
   // The extra grad factors should be 0 or 1 for spherical or flat boundaries
@@ -55,9 +55,10 @@ void test_gradient() {
           const double extra_outer_grad_factor) {
         const double distance_difference = outer_distance - inner_distance;
         const std::array<double, 3> grad_base =
-            1.0 / (sqrt(3.0) * cube(radius)) *
-            std::array{-point[0] * point[2], -point[1] * point[2],
-                       square(radius) - square(point[2])};
+            1.0 / (sqrt(3.0) * radius) *
+            std::array{point[0], point[1],
+                       -(square(radius) - square(point[2])) / point[2]} /
+            point[2];
         const std::array<double, 3> inner_grad =
             extra_inner_grad_factor * inner_radius * grad_base;
         const std::array<double, 3> outer_grad =
@@ -143,21 +144,20 @@ void test_only_transition() {
   const double outer_radius = 10.0;
   const double inner_sphericity = 1.0;
   const double outer_sphericity = 0.0;
-  const OrientationMap<3> orientation_map{};
 
   const Wedge wedge{inner_radius, outer_radius, inner_sphericity,
-                    outer_sphericity, orientation_map};
+                    outer_sphericity, 0_st};
 
   const double inner_distance = 0.5;
   const double outer_distance = outer_radius / sqrt(3.0);
   const double distance_difference = outer_distance - inner_distance;
 
-  std::array<double, 3> point{0.0, 0.0, 4.0};
+  std::array<double, 3> point{4.0, 0.0, 0.0};
   const double function_value = (outer_distance - 4.0) / distance_difference;
 
   CHECK(wedge(point) == approx(function_value));
   CHECK_ITERABLE_APPROX(wedge.gradient(point),
-                        (std::array{0.0, 0.0, -1.0 / distance_difference}));
+                        (std::array{-1.0 / distance_difference, 0.0, 0.0}));
 
   std::optional<double> orig_rad_over_rad{};
   const auto set_orig_rad_over_rad =
@@ -188,17 +188,18 @@ void test_only_transition() {
   CHECK_FALSE(orig_rad_over_rad.has_value());
   set_orig_rad_over_rad(point * 15.0, 0.0);
   CHECK_FALSE(orig_rad_over_rad.has_value());
-  // Wedge is in +z direction. Check other directions
-  set_orig_rad_over_rad(std::array{0.0, 0.0, -4.0}, 0.0);
-  CHECK_FALSE(orig_rad_over_rad.has_value());
-  set_orig_rad_over_rad(std::array{4.0, 0.0, 0.0}, 0.0);
-  CHECK_FALSE(orig_rad_over_rad.has_value());
-  set_orig_rad_over_rad(std::array{-4.0, 0.0, 0.0}, 0.0);
-  CHECK_FALSE(orig_rad_over_rad.has_value());
-  set_orig_rad_over_rad(std::array{0.0, 4.0, 0.0}, 0.0);
-  CHECK_FALSE(orig_rad_over_rad.has_value());
-  set_orig_rad_over_rad(std::array{0.0, -4.0, 0.0}, 0.0);
-  CHECK_FALSE(orig_rad_over_rad.has_value());
+  // Wedge is in x direction. Check other directions
+  const auto check_other_directions =
+      [&](const std::array<double, 3>& mapped_point) {
+        set_orig_rad_over_rad(mapped_point, 0.0);
+        CHECK(orig_rad_over_rad.has_value());
+        CHECK(orig_rad_over_rad.value() == 1.0);
+      };
+  check_other_directions(std::array{-4.0, 0.0, 0.0});
+  check_other_directions(std::array{0.0, 0.0, 4.0});
+  check_other_directions(std::array{4.0, 0.0, -4.0});
+  check_other_directions(std::array{0.0, 4.0, 0.0});
+  check_other_directions(std::array{0.0, -4.0, 0.0});
   // At overall inner boundary.
   set_orig_rad_over_rad(std::array{0.0, 0.0, 0.2 * inner_radius}, 0.4);
   CHECK(orig_rad_over_rad.has_value());
@@ -209,10 +210,11 @@ void test_only_transition() {
 
 void test_in_shape_map() {
   INFO("Test using shape map");
-  MAKE_GENERATOR(generator, 3360591650);
+  MAKE_GENERATOR(generator);
   std::uniform_real_distribution<double> coef_dist{-0.01, 0.01};
 
   const double initial_time = 1.0;
+  const double check_time = 2.0;
   const size_t l_max = 4;
   const size_t num_coefs = 2 * square(l_max + 1);
   const std::array center{0.1, -0.2, 0.3};
@@ -233,81 +235,55 @@ void test_in_shape_map() {
   const double inner_radius = 0.5;
   const double outer_radius = 10.0;
 
-  std::uniform_real_distribution<double> theta_dist{0.0, M_PI_4};
-  std::uniform_real_distribution<double> phi_dist{0.0, 2.0 * M_PI};
+  std::uniform_real_distribution<double> angle_dist{0.0, 2.0 * M_PI};
 
-  for (const auto& [inner_sphericity, outer_sphericity, orientation] :
-       cartesian_product(std::array{1.0, 0.0}, std::array{1.0, 0.0},
-                         orientations_for_sphere_wrappings())) {
+  for (const auto& [inner_sphericity, outer_sphericity] :
+       cartesian_product(std::array{1.0, 0.0}, std::array{1.0, 0.0})) {
     CAPTURE(inner_sphericity);
     CAPTURE(outer_sphericity);
-    CAPTURE(orientation);
     // This guarantees the radius of the point is within the wedge
     std::uniform_real_distribution<double> radial_dist{
         inner_radius, outer_radius / sqrt(3.0)};
 
-    std::unique_ptr<ShapeMapTransitionFunction> wedge =
-        std::make_unique<Wedge>(inner_radius, outer_radius, inner_sphericity,
-                                outer_sphericity, orientation);
-
-    TimeDependent::Shape shape{center, l_max, l_max, std::move(wedge),
-                               fot_name};
+    std::unique_ptr<ShapeMapTransitionFunction> wedge{};
 
     // Test 10 points for each sphericity and orientation
     for (size_t i = 0; i < 10; i++) {
       const double radius = radial_dist(generator);
-      const double theta = theta_dist(generator);
-      const double phi = phi_dist(generator);
+      const double theta = 0.5 * angle_dist(generator);
+      const double phi = angle_dist(generator);
 
       CAPTURE(radius);
       CAPTURE(theta);
       CAPTURE(phi);
 
-      const std::array<double, 3> centered_z_aligned_point =
-          sph_to_cart(radius, theta, phi);
       const std::array<double, 3> centered_point =
-          discrete_rotation(orientation, centered_z_aligned_point);
+          sph_to_cart(radius, theta, phi);
+
+      size_t axis = 0;
+      double max = abs(centered_point[0]);
+      for (size_t j = 1; j < 3; j++) {
+        if (const double maybe_max = abs(gsl::at(centered_point, j));
+            maybe_max > max) {
+          axis = j;
+          max = maybe_max;
+        }
+      }
+
+      wedge = std::make_unique<Wedge>(inner_radius, outer_radius,
+                                      inner_sphericity, outer_sphericity, axis);
+
+      TimeDependent::Shape shape{center, l_max, l_max, std::move(wedge),
+                                 fot_name};
+
       const std::array<double, 3> point = centered_point + center;
-      CAPTURE(centered_z_aligned_point);
-      CAPTURE(centered_point);
-      CAPTURE(point);
 
-      const std::array<double, 3> mapped_point =
-          shape(point, initial_time, functions_of_time);
-      const std::optional<std::array<double, 3>> inverse_mapped_point =
-          shape.inverse(mapped_point, initial_time, functions_of_time);
-
-      CAPTURE(mapped_point);
-      CAPTURE(inverse_mapped_point);
-
-      CHECK(inverse_mapped_point.has_value());
-      CHECK_ITERABLE_APPROX(point, inverse_mapped_point.value());
-
-      const auto check_bad_point = [&](const std::string& info,
-                                       const double inner_bound,
-                                       const double outer_bound) {
-        INFO(info);
-        std::uniform_real_distribution<double> bad_radial_dist{inner_bound,
-                                                               outer_bound};
-        // Want theta to be from 0 to pi, so just use phi and divide by 2
-        const double random_theta = phi_dist(generator) / 2.0;
-        const double random_phi = phi_dist(generator);
-        const double bad_radius = bad_radial_dist(generator);
-
-        CAPTURE(bad_radius);
-
-        const std::array<double, 3> bad_point =
-            sph_to_cart(bad_radius, random_theta, random_phi) + center;
-
-        CAPTURE(bad_point);
-        CHECK_FALSE(shape.inverse(bad_point, initial_time, functions_of_time)
-                        .has_value());
-      };
-
-      // The 0.9 factor guarantees that we are inside the mapped inner radius
-      check_bad_point("Too small radius", 0.01, 0.9 * inner_radius / sqrt(3.0));
-      check_bad_point("Too big radius", outer_radius * 10.0,
-                      outer_radius * 50.0);
+      test_coordinate_map_argument_types(shape, point, check_time,
+                                         functions_of_time);
+      test_inverse_map(shape, point, check_time, functions_of_time);
+      test_frame_velocity(shape, point, check_time, functions_of_time);
+      test_jacobian(shape, point, check_time, functions_of_time);
+      test_inv_jacobian(shape, point, check_time, functions_of_time);
     }
   }
 }

--- a/tests/Unit/Domain/CoordinateMaps/TimeDependent/Test_Shape.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/TimeDependent/Test_Shape.cpp
@@ -154,20 +154,17 @@ std::vector<std::vector<std::complex<double>>> generate_random_coefs(
     size_t l_max, size_t m_max, gsl::not_null<std::mt19937*> generator) {
   std::vector<std::vector<std::complex<double>>> coefs{};
   // if the coefficients are made too large, the map has a good chance of
-  // mapping through the center, causing the test to fail which is why we damp
-  // higher mode coefficients by `8 * l * l + 1`. This damping factor was found
-  // empirically by trial and error.
-  std::uniform_real_distribution<double> coef_dist{0., 1.};
+  // mapping through the center, causing the test to fail which is why we limit
+  // the coefficients to a magnitude of at most 0.01
+  std::uniform_real_distribution<double> coef_dist{0., 0.01};
 
   for (size_t l = 0; l <= l_max; ++l) {
     // m=0 is real
     std::vector<std::complex<double>> tmp{
-        make_with_random_values<double>(generator, coef_dist, 1) /
-        double(8 * l * l + 1)};
+        make_with_random_values<double>(generator, coef_dist, 1)};
     for (size_t m = 1; m <= std::min(l, m_max); ++m) {
       tmp.emplace_back(make_with_random_values<std::complex<double>>(
-                           generator, coef_dist, 2) /
-                       double(8 * l * l + 1));
+          generator, coef_dist, 2));
     }
     coefs.emplace_back(tmp);
   }
@@ -176,7 +173,7 @@ std::vector<std::vector<std::complex<double>>> generate_random_coefs(
 }
 
 double generate_random_00_coef(const gsl::not_null<std::mt19937*> generator) {
-  std::uniform_real_distribution<double> coef_dist{0., 1.};
+  std::uniform_real_distribution<double> coef_dist{0., 0.01};
   return coef_dist(*generator);
 }
 

--- a/tests/Unit/Domain/CoordinateMaps/TimeDependent/Test_Shape.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/TimeDependent/Test_Shape.cpp
@@ -337,7 +337,8 @@ std::array<DataVector, 3> calculate_analytical_map(
         identity, gsl::at(target_thetas, i), gsl::at(target_phis, i), coefs,
         lambda_00_coef, l_max, m_max);
   }
-  const auto spatial_part = transition_func(centered_coords);
+  const DataVector spatial_part =
+      transition_func(centered_coords) / magnitude(centered_coords);
   return target_points - centered_coords * angular_part * spatial_part;
 }
 
@@ -418,17 +419,18 @@ tnsr::Ij<DataVector, 3, Frame::NoFrame> calculate_analytical_jacobian(
   cartesian_gradient[2] = -theta_gradient;
 
   // this part essentially duplicates the code from the map
-  const auto spatial_part = transition_func(centered_coords);
-  const auto spatial_gradient = transition_func.gradient(centered_coords);
-  const auto spatial_part_over_radius =
-      transition_func.map_over_radius(centered_coords);
+  const DataVector radius = magnitude(centered_coords);
+  const DataVector spatial_part = transition_func(centered_coords) / radius;
+  const std::array<DataVector, 3> spatial_gradient =
+      transition_func.gradient(centered_coords) / radius -
+      centered_coords * spatial_part / square(radius);
   tnsr::Ij<DataVector, 3, Frame::NoFrame> result(num_points);
   for (size_t i = 0; i < 3; ++i) {
     for (size_t j = 0; j < 3; ++j) {
       result.get(i, j) =
           -gsl::at(centered_coords, i) *
           (angular_part * gsl::at(spatial_gradient, j) +
-           gsl::at(cartesian_gradient, j) * spatial_part_over_radius);
+           gsl::at(cartesian_gradient, j) * spatial_part / radius);
     }
     result.get(i, i) += 1. - angular_part * spatial_part;
   }

--- a/tests/Unit/Domain/Creators/TimeDependence/Test_Shape.cpp
+++ b/tests/Unit/Domain/Creators/TimeDependence/Test_Shape.cpp
@@ -119,10 +119,12 @@ void test_r_theta_phi(const tnsr::I<double, 3, SourceFrame>& input,
       gr::Solutions::kerr_schild_radius_from_boyer_lindquist(
           inner_radius, input_theta_phi, mass, spin)
           .get();
+  const double radius = magnitude(input_centered).get();
   const double transition_factor =
       std::make_unique<Transition>(Transition{inner_radius, outer_radius})
           ->
-          operator()({{magnitude(input_centered).get(), 0.0, 0.0}});
+          operator()({radius, 0.0, 0.0}) /
+      radius;
   const double expected_output_centered_spherical =
       input_centered_spherical[0] *
       (1.0 + transition_factor * (kerr_schild_radius - inner_radius));

--- a/tools/FileTestDefs.sh
+++ b/tools/FileTestDefs.sh
@@ -258,7 +258,9 @@ long_lines_exclude() {
         grep -v '\\image' | \
         grep -v 'a href=' | \
         grep -v '"""' | \
-        grep -v 'import'
+        grep -v 'import' | \
+        grep -v '\\link' | \
+        grep -v '\\endlink'
 }
 long_lines() {
     whitelist "$1" \
@@ -311,6 +313,8 @@ long_lines_test() {
     test_check pass foo.cpp "// NOLINTNEXTLINE(${eighty})"$'\n'
     test_check pass foo.cpp "// \\snippet ${eighty}"$'\n'
     test_check pass foo.cpp "// \\image ${eighty}"$'\n'
+    test_check pass foo.cpp "// \\link ${eighty}"$'\n'
+    test_check pass foo.cpp "// \\endlink ${eighty}"$'\n'
 }
 standard_checks+=(long_lines)
 


### PR DESCRIPTION
## Proposed changes

This is a follow up to #5627.

In SpEC, the shape map is (for centered coordinates)

$$
x^i = \xi^i \left(1 - \frac{f(r, \theta, \phi)}{r} \sum_{\ell,m} \lambda_{\ell m}Y_{\ell m}(\theta, \phi)\right)
$$

However, in SpECTRE, the shape map currently is

$$
x^i = \xi^i \left(1 - h(r, \theta, \phi) \sum_{\ell,m} \lambda_{\ell m}Y_{\ell m}(\theta, \phi)\right)
$$

In SpEC, we have that $0 \leq f(r, \theta, \phi) \leq 1$, while in SpECTRE we have $0 \leq h(r, \theta, \phi) \leq 1$. This slight difference of a factor of $r$ is a fundamentally different coordinate mapping.

This PR edits the shape map to be identical to the one in SpEC and consequently edits both of the transition functions to be from 1 to 0.

The wedge transition map also has additional edits that fixes some issues it had before.

This PR also fixes #5635.


<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
