### PR TITLE
WorldtubeBufferUpdater and WorldtubeDataManager for CCE

### DIFF
--- a/src/Evolution/Executables/Cce/CharacteristicExtract.cpp
+++ b/src/Evolution/Executables/Cce/CharacteristicExtract.cpp
@@ -25,7 +25,9 @@ extern "C" void CkRegisterMainModule() {
            Cce::WorldtubeBufferUpdater<Cce::cce_metric_input_tags>>,
        &register_derived_classes_with_charm<
            Cce::WorldtubeBufferUpdater<Cce::cce_bondi_input_tags>>,
-       &register_derived_classes_with_charm<Cce::WorldtubeDataManager>,
+       &register_derived_classes_with_charm<Cce::WorldtubeDataManager<
+           Cce::Tags::characteristic_worldtube_boundary_tags<
+               Cce::Tags::BoundaryValue>>>,
        &register_derived_classes_with_charm<intrp::SpanInterpolator>,
        &register_derived_classes_with_charm<Cce::Solutions::WorldtubeData>,
        &register_factory_classes_with_charm<metavariables>},

--- a/src/Evolution/Systems/Cce/Actions/BoundaryComputeAndSendToEvolution.hpp
+++ b/src/Evolution/Systems/Cce/Actions/BoundaryComputeAndSendToEvolution.hpp
@@ -103,7 +103,9 @@ struct BoundaryComputeAndSendToEvolution<H5WorldtubeBoundary<Metavariables>,
                ::Tags::Variables<
                    typename Metavariables::cce_boundary_communication_tags>>(
         [&successfully_populated, &time, &hdf5_lock](
-            const gsl::not_null<std::unique_ptr<Cce::WorldtubeDataManager>*>
+            const gsl::not_null<std::unique_ptr<Cce::WorldtubeDataManager<
+                Tags::characteristic_worldtube_boundary_tags<
+                    Tags::BoundaryValue>>>*>
                 worldtube_data_manager,
             const gsl::not_null<Variables<
                 typename Metavariables::cce_boundary_communication_tags>*>

--- a/src/Evolution/Systems/Cce/OptionTags.hpp
+++ b/src/Evolution/Systems/Cce/OptionTags.hpp
@@ -281,7 +281,8 @@ struct CceEvolutionPrefix : Tag {
 
 /// A tag that constructs a `MetricWorldtubeDataManager` from options
 struct H5WorldtubeBoundaryDataManager : db::SimpleTag {
-  using type = std::unique_ptr<WorldtubeDataManager>;
+  using type = std::unique_ptr<WorldtubeDataManager<
+      Tags::characteristic_worldtube_boundary_tags<Tags::BoundaryValue>>>;
   using option_tags =
       tmpl::list<OptionTags::LMax, OptionTags::BoundaryDataFilename,
                  OptionTags::H5LookaheadTimes, OptionTags::H5Interpolator,

--- a/src/Evolution/Systems/Cce/WorldtubeBufferUpdater.hpp
+++ b/src/Evolution/Systems/Cce/WorldtubeBufferUpdater.hpp
@@ -81,6 +81,22 @@ std::string dataset_name_for_component(std::string base_name,
 std::pair<size_t, size_t> create_span_for_time_value(
     double time, size_t pad, size_t interpolator_length, size_t lower_bound,
     size_t upper_bound, const DataVector& time_buffer);
+
+// retrieves the extraction radius from the specified file.
+// We assume that the filename has the extraction radius encoded as an
+// integer between the last occurrence of 'R' and the last occurrence of
+// '.'. This is the format provided by SpEC.
+std::string get_text_radius(const std::string& cce_data_filename);
+
+// retrieves time stamps and lmax the from the specified file.
+void set_time_buffer_and_lmax(gsl::not_null<DataVector*> time_buffer,
+                              size_t& l_max, const h5::Dat& data);
+
+// retrieves modal data from Bondi or Klein-Gordon worldtube H5 file.
+void update_buffer_with_modal_data(
+    gsl::not_null<ComplexModalVector*> buffer_to_update,
+    const h5::Dat& read_data, size_t computation_l_max, size_t l_max,
+    size_t time_span_start, size_t time_span_end, bool is_real);
 }  // namespace detail
 
 /// the full set of tensors to be extracted from the worldtube h5 file

--- a/src/Evolution/Systems/Cce/WorldtubeDataManager.cpp
+++ b/src/Evolution/Systems/Cce/WorldtubeDataManager.cpp
@@ -234,8 +234,9 @@ bool MetricWorldtubeDataManager::populate_hypersurface_boundary_data(
   return true;
 }
 
-std::unique_ptr<WorldtubeDataManager> MetricWorldtubeDataManager::get_clone()
-    const {
+std::unique_ptr<WorldtubeDataManager<
+    Tags::characteristic_worldtube_boundary_tags<Tags::BoundaryValue>>>
+MetricWorldtubeDataManager::get_clone() const {
   return std::make_unique<MetricWorldtubeDataManager>(
       buffer_updater_->get_clone(), l_max_, buffer_depth_,
       interpolator_->get_clone(), fix_spec_normalization_);
@@ -419,8 +420,9 @@ bool BondiWorldtubeDataManager::populate_hypersurface_boundary_data(
   return true;
 }
 
-std::unique_ptr<WorldtubeDataManager> BondiWorldtubeDataManager::get_clone()
-    const {
+std::unique_ptr<WorldtubeDataManager<
+    Tags::characteristic_worldtube_boundary_tags<Tags::BoundaryValue>>>
+BondiWorldtubeDataManager::get_clone() const {
   return std::make_unique<BondiWorldtubeDataManager>(
       buffer_updater_->get_clone(), l_max_, buffer_depth_,
       interpolator_->get_clone());

--- a/src/Evolution/Systems/Cce/WorldtubeDataManager.hpp
+++ b/src/Evolution/Systems/Cce/WorldtubeDataManager.hpp
@@ -20,6 +20,23 @@
 
 namespace Cce {
 
+namespace detail {
+
+template <typename InputTags>
+void set_non_pupped_members(
+    gsl::not_null<size_t*> time_span_start,
+    gsl::not_null<size_t*> time_span_end,
+    gsl::not_null<Variables<InputTags>*> coefficients_buffers,
+    gsl::not_null<Variables<InputTags>*> interpolated_coefficients,
+    size_t buffer_depth, size_t interpolator_length, size_t l_max);
+
+template <typename InputTags>
+void initialize_buffers(
+    gsl::not_null<size_t*> buffer_depth,
+    gsl::not_null<Variables<InputTags>*> coefficients_buffers,
+    size_t buffer_size, size_t interpolator_length, size_t l_max);
+}  // namespace detail
+
 /// \cond
 class MetricWorldtubeDataManager;
 class BondiWorldtubeDataManager;

--- a/src/Evolution/Systems/Cce/WorldtubeDataManager.hpp
+++ b/src/Evolution/Systems/Cce/WorldtubeDataManager.hpp
@@ -28,7 +28,7 @@ class BondiWorldtubeDataManager;
 /*!
  *  \brief Abstract base class for managers of CCE worldtube data that is
  * provided in large time-series chunks, especially the type provided by input
- * h5 files.
+ * h5 files. `BoundaryTags` is a `tmpl::list` of tags on the worldtube boundary.
  *
  *  \details The methods that are required to be overridden in the derived
  * classes are:
@@ -48,6 +48,7 @@ class BondiWorldtubeDataManager;
  *   underlying data source. This is primarily used for monitoring the frequency
  *   and size of the buffer updates.
  */
+template <typename BoundaryTags>
 class WorldtubeDataManager : public PUP::able {
  public:
   using creatable_classes =
@@ -56,9 +57,7 @@ class WorldtubeDataManager : public PUP::able {
   WRAPPED_PUPable_abstract(WorldtubeDataManager);  // NOLINT
 
   virtual bool populate_hypersurface_boundary_data(
-      gsl::not_null<Variables<
-          Tags::characteristic_worldtube_boundary_tags<Tags::BoundaryValue>>*>
-          boundary_data_variables,
+      gsl::not_null<Variables<BoundaryTags>*> boundary_data_variables,
       double time, gsl::not_null<Parallel::NodeLock*> hdf5_lock) const = 0;
 
   virtual std::unique_ptr<WorldtubeDataManager> get_clone() const = 0;
@@ -81,7 +80,9 @@ class WorldtubeDataManager : public PUP::able {
  * `WorldtubeDataManager::populate_hypersurface_boundary_data()` member
  * function that handles buffer updating and boundary computation.
  */
-class MetricWorldtubeDataManager : public WorldtubeDataManager {
+class MetricWorldtubeDataManager
+    : public WorldtubeDataManager<
+          Tags::characteristic_worldtube_boundary_tags<Tags::BoundaryValue>> {
  public:
   // charm needs an empty constructor.
   MetricWorldtubeDataManager() = default;
@@ -174,7 +175,9 @@ class MetricWorldtubeDataManager : public WorldtubeDataManager {
  * handled by `WorldtubeDataManager`. The set of 9 scalars is a far leaner
  * (factor of ~4) data storage format.
  */
-class BondiWorldtubeDataManager : public WorldtubeDataManager {
+class BondiWorldtubeDataManager
+    : public WorldtubeDataManager<
+          Tags::characteristic_worldtube_boundary_tags<Tags::BoundaryValue>> {
  public:
   // charm needs an empty constructor.
   BondiWorldtubeDataManager() = default;

--- a/tests/Unit/Evolution/Systems/Cce/Test_WorldtubeData.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_WorldtubeData.cpp
@@ -788,7 +788,9 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.ReadBoundaryDataH5",
       Cce::WorldtubeBufferUpdater<cce_metric_input_tags>>();
   register_derived_classes_with_charm<
       Cce::WorldtubeBufferUpdater<cce_bondi_input_tags>>();
-  register_derived_classes_with_charm<Cce::WorldtubeDataManager>();
+  register_derived_classes_with_charm<Cce::WorldtubeDataManager<
+      Cce::Tags::characteristic_worldtube_boundary_tags<
+          Cce::Tags::BoundaryValue>>>();
   register_derived_classes_with_charm<intrp::SpanInterpolator>();
   MAKE_GENERATOR(gen);
   {


### PR DESCRIPTION
## Proposed changes

<!--
At a high level, describe what this PR does.
-->

This PR aims to pave the path for dealing with the worldtube data of the Klein-Gordon CCE system. Two major changes are introduced to the current infrastructure

1. The current `WorldtubeDataManager` is hard-coded to handle `Tags::characteristic_worldtube_boundary_tags<Tags::BoundaryValue>`. This can be relaxed so that it can be used to deal with other worldtube data (say a scalar field).
2. There are repeated contents in `WorldtubeBufferUpdater` and `WorldtubeDataManager`, and will be more once they are extended to handle the Klein-Gordon system. I extract some common parts into functions to avoid more copy and paste.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
