### PR TITLE
Add option for runtime element distribution

### DIFF
--- a/src/Domain/ElementDistribution.hpp
+++ b/src/Domain/ElementDistribution.hpp
@@ -11,6 +11,8 @@
 #include <utility>
 #include <vector>
 
+#include "Options/Options.hpp"
+
 /// \cond
 template <size_t Dim>
 class Block;
@@ -40,6 +42,8 @@ enum class ElementWeight {
   /// details)
   NumGridPointsAndGridSpacing
 };
+
+std::ostream& operator<<(std::ostream& os, ElementWeight weight);
 
 /// \brief Get the cost of each `Element` in a list of `Block`s where
 /// `element_weight` specifies which weight distribution scheme to use
@@ -133,6 +137,8 @@ std::unordered_map<ElementId<Dim>, double> get_element_costs(
  */
 template <size_t Dim>
 struct BlockZCurveProcDistribution {
+  BlockZCurveProcDistribution() = default;
+
   /// The `number_of_procs_with_elements` argument represents how many procs
   /// will have elements. This is not necessarily equal to the total number of
   /// procs because some global procs may be ignored by the sixth argument
@@ -166,3 +172,16 @@ struct BlockZCurveProcDistribution {
       block_element_distribution_;
 };
 }  // namespace domain
+
+template <>
+struct Options::create_from_yaml<domain::ElementWeight> {
+  template <typename Metavariables>
+  static domain::ElementWeight create(const Options::Option& options) {
+    return create<void>(options);
+  }
+};
+
+template <>
+domain::ElementWeight
+Options::create_from_yaml<domain::ElementWeight>::create<void>(
+    const Options::Option& options);

--- a/src/Domain/Tags/CMakeLists.txt
+++ b/src/Domain/Tags/CMakeLists.txt
@@ -5,6 +5,7 @@ spectre_target_headers(
   ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
+  ElementDistribution.hpp
   FaceNormal.hpp
   Faces.hpp
   SurfaceJacobian.hpp

--- a/src/Domain/Tags/ElementDistribution.hpp
+++ b/src/Domain/Tags/ElementDistribution.hpp
@@ -1,0 +1,48 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <memory>
+#include <optional>
+
+#include "DataStructures/DataBox/Tag.hpp"
+#include "Domain/Domain.hpp"
+#include "Domain/ElementDistribution.hpp"
+#include "Options/Auto.hpp"
+#include "Options/String.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+namespace Parallel::OptionTags {
+struct Parallelization;
+}  // namespace Parallel::OptionTags
+/// \endcond
+
+namespace domain {
+namespace OptionTags {
+/// \ingroup OptionTagsGroup
+/// \ingroup ComputationalDomainGroup
+struct ElementDistribution {
+  struct RoundRobin {};
+  using type = Options::Auto<ElementWeight, RoundRobin>;
+  static constexpr Options::String help = {
+      "Weighting pattern to use for ZCurve element distribution. Specify "
+      "RoundRobin to just place each element on the next core."};
+  using group = Parallel::OptionTags::Parallelization;
+};
+}  // namespace OptionTags
+
+namespace Tags {
+struct ElementDistribution : db::SimpleTag {
+  using type = std::optional<ElementWeight>;
+  using option_tags = tmpl::list<OptionTags::ElementDistribution>;
+
+  static constexpr bool pass_metavariables = false;
+  static type create_from_options(const type& element_distribution) {
+    return element_distribution;
+  }
+};
+}  // namespace Tags
+}  // namespace domain

--- a/src/Evolution/CMakeLists.txt
+++ b/src/Evolution/CMakeLists.txt
@@ -45,6 +45,7 @@ target_link_libraries(
   LinearOperators
   INTERFACE
   Observer
+  Parallel
   SystemUtilities
   )
 

--- a/src/Parallel/Tags/CMakeLists.txt
+++ b/src/Parallel/Tags/CMakeLists.txt
@@ -9,6 +9,7 @@ spectre_target_headers(
   DistributedObjectTags.hpp
   InputSource.hpp
   Metavariables.hpp
+  Parallelization.hpp
   ResourceInfo.hpp
   Section.hpp
 )

--- a/src/Parallel/Tags/Parallelization.hpp
+++ b/src/Parallel/Tags/Parallelization.hpp
@@ -1,0 +1,20 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "Options/String.hpp"
+
+namespace Parallel::OptionTags {
+/*!
+ * \brief Option group for all things related to parallelization.
+ *
+ * It is possible this group will need to be used in a library that cannot
+ * depend on the `Parallel` library. In that case, this struct should just be
+ * forward declared.
+ */
+struct Parallelization {
+  static constexpr Options::String help = {
+      "Options related to parallelization aspects of the simulation."};
+};
+}  // namespace Parallel::OptionTags

--- a/support/Pipelines/Bbh/InitialData.yaml
+++ b/support/Pipelines/Bbh/InitialData.yaml
@@ -5,6 +5,9 @@ Executable: SolveXcts
 
 ---
 
+Parallelization:
+  ElementDistribution: NumGridPoints
+
 Background: &background
   Binary:
     XCoords: [&x_left {{ XLeft }}, &x_right {{ XRight }}]

--- a/support/Pipelines/Bbh/Inspiral.yaml
+++ b/support/Pipelines/Bbh/Inspiral.yaml
@@ -5,6 +5,9 @@ Executable: EvolveGhBinaryBlackHole
 
 ---
 
+Parallelization:
+  ElementDistribution: NumGridPointsAndGridSpacing
+
 InitialData:
   NumericInitialData:
     FileGlob: "{{ IdFileGlob }}"

--- a/support/Pipelines/Bbh/Ringdown.yaml
+++ b/support/Pipelines/Bbh/Ringdown.yaml
@@ -5,6 +5,9 @@ Executable: EvolveGhSingleBlackHole
 
 ---
 
+Parallelization:
+  ElementDistribution: NumGridPoints
+
 # Note: most of the parameters in this file are just made up. They should be
 # replaced with values that make sense once we have a better idea of the
 # transition to ringdown.

--- a/tests/InputFiles/Burgers/Step.yaml
+++ b/tests/InputFiles/Burgers/Step.yaml
@@ -10,6 +10,9 @@ Testing:
 
 ---
 
+Parallelization:
+  ElementDistribution: NumGridPoints
+
 ResourceInfo:
   AvoidGlobalProc0: false
 

--- a/tests/InputFiles/CurvedScalarWave/PlaneWaveMinkowski1D.yaml
+++ b/tests/InputFiles/CurvedScalarWave/PlaneWaveMinkowski1D.yaml
@@ -7,6 +7,9 @@ Testing:
 
 ---
 
+Parallelization:
+  ElementDistribution: NumGridPoints
+
 ResourceInfo:
   AvoidGlobalProc0: false
 

--- a/tests/InputFiles/CurvedScalarWave/PlaneWaveMinkowski2D.yaml
+++ b/tests/InputFiles/CurvedScalarWave/PlaneWaveMinkowski2D.yaml
@@ -7,6 +7,9 @@ Testing:
 
 ---
 
+Parallelization:
+  ElementDistribution: NumGridPoints
+
 ResourceInfo:
   AvoidGlobalProc0: false
 

--- a/tests/InputFiles/CurvedScalarWave/PlaneWaveMinkowski3D.yaml
+++ b/tests/InputFiles/CurvedScalarWave/PlaneWaveMinkowski3D.yaml
@@ -18,6 +18,9 @@ OutputFileChecks:
 
 ---
 
+Parallelization:
+  ElementDistribution: NumGridPoints
+
 ResourceInfo:
   AvoidGlobalProc0: false
   Singletons:

--- a/tests/InputFiles/CurvedScalarWave/WorldtubeKerrSchild.yaml
+++ b/tests/InputFiles/CurvedScalarWave/WorldtubeKerrSchild.yaml
@@ -8,6 +8,9 @@ Testing:
 
 ---
 
+Parallelization:
+  ElementDistribution: NumGridPoints
+
 AnalyticData:
   PlaneWave:
     WaveVector: [0., 0., 0.]

--- a/tests/InputFiles/Elasticity/BentBeam.yaml
+++ b/tests/InputFiles/Elasticity/BentBeam.yaml
@@ -16,6 +16,9 @@ OutputFileChecks:
 
 ---
 
+Parallelization:
+  ElementDistribution: NumGridPoints
+
 ResourceInfo:
   AvoidGlobalProc0: false
   Singletons: Auto

--- a/tests/InputFiles/Elasticity/HalfSpaceMirror.yaml
+++ b/tests/InputFiles/Elasticity/HalfSpaceMirror.yaml
@@ -18,6 +18,9 @@ OutputFileChecks:
 
 ---
 
+Parallelization:
+  ElementDistribution: NumGridPoints
+
 ResourceInfo:
   AvoidGlobalProc0: false
   Singletons: Auto

--- a/tests/InputFiles/ExampleExecutables/RandomAmr1D.yaml
+++ b/tests/InputFiles/ExampleExecutables/RandomAmr1D.yaml
@@ -12,6 +12,9 @@ ExpectedOutput:
 
 ---
 
+Parallelization:
+  ElementDistribution: NumGridPoints
+
 Amr:
   Criteria:
     - Random:

--- a/tests/InputFiles/ExportCoordinates/Input1D.yaml
+++ b/tests/InputFiles/ExportCoordinates/Input1D.yaml
@@ -11,6 +11,9 @@ ExpectedOutput:
 
 ---
 
+Parallelization:
+  ElementDistribution: NumGridPoints
+
 Amr:
   Criteria:
     - Random:

--- a/tests/InputFiles/ExportCoordinates/Input2D.yaml
+++ b/tests/InputFiles/ExportCoordinates/Input2D.yaml
@@ -11,6 +11,9 @@ ExpectedOutput:
 
 ---
 
+Parallelization:
+  ElementDistribution: NumGridPoints
+
 Amr:
   Criteria:
   Verbosity: Quiet

--- a/tests/InputFiles/ExportCoordinates/Input3D.yaml
+++ b/tests/InputFiles/ExportCoordinates/Input3D.yaml
@@ -11,6 +11,9 @@ ExpectedOutput:
 
 ---
 
+Parallelization:
+  ElementDistribution: NumGridPoints
+
 Amr:
   Criteria:
   Verbosity: Quiet

--- a/tests/InputFiles/ExportCoordinates/InputTimeDependent3D.yaml
+++ b/tests/InputFiles/ExportCoordinates/InputTimeDependent3D.yaml
@@ -12,6 +12,9 @@ ExpectedOutput:
 
 ---
 
+Parallelization:
+  ElementDistribution: NumGridPointsAndGridSpacing
+
 Amr:
   Criteria:
   Verbosity: Quiet

--- a/tests/InputFiles/FindHorizons/FindHorizons3D.yaml
+++ b/tests/InputFiles/FindHorizons/FindHorizons3D.yaml
@@ -8,6 +8,9 @@ Testing:
 
 ---
 
+Parallelization:
+  ElementDistribution: NumGridPoints
+
 ResourceInfo:
   AvoidGlobalProc0: false
   Singletons:

--- a/tests/InputFiles/ForceFree/FastWave.yaml
+++ b/tests/InputFiles/ForceFree/FastWave.yaml
@@ -8,6 +8,9 @@ Testing:
 
 ---
 
+Parallelization:
+  ElementDistribution: NumGridPoints
+
 ResourceInfo:
   AvoidGlobalProc0: false
 

--- a/tests/InputFiles/GeneralizedHarmonic/BinaryBlackHole.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/BinaryBlackHole.yaml
@@ -8,6 +8,9 @@ Testing:
 
 ---
 
+Parallelization:
+  ElementDistribution: NumGridPointsAndGridSpacing
+
 ResourceInfo:
   AvoidGlobalProc0: false
   Singletons: Auto

--- a/tests/InputFiles/GeneralizedHarmonic/CylindricalBinaryBlackHole.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/CylindricalBinaryBlackHole.yaml
@@ -8,6 +8,9 @@ Testing:
 
 ---
 
+Parallelization:
+  ElementDistribution: NumGridPointsAndGridSpacing
+
 ResourceInfo:
   AvoidGlobalProc0: false
   Singletons: Auto

--- a/tests/InputFiles/GeneralizedHarmonic/GaugeWave1D.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/GaugeWave1D.yaml
@@ -11,6 +11,9 @@ ExpectedOutput:
 
 ---
 
+Parallelization:
+  ElementDistribution: NumGridPoints
+
 ResourceInfo:
   AvoidGlobalProc0: false
   Singletons: Auto

--- a/tests/InputFiles/GeneralizedHarmonic/GaugeWave3D.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/GaugeWave3D.yaml
@@ -12,6 +12,9 @@ ExpectedOutput:
 
 ---
 
+Parallelization:
+  ElementDistribution: NumGridPoints
+
 ResourceInfo:
   AvoidGlobalProc0: false
   Singletons: Auto

--- a/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
@@ -18,6 +18,9 @@ OutputFileChecks:
 
 ---
 
+Parallelization:
+  ElementDistribution: NumGridPoints
+
 ResourceInfo:
   AvoidGlobalProc0: false
   Singletons: Auto

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/BinaryNeutronStar.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/BinaryNeutronStar.yaml
@@ -8,6 +8,9 @@ Testing:
 
 ---
 
+Parallelization:
+  ElementDistribution: NumGridPoints
+
 ResourceInfo:
   AvoidGlobalProc0: false
   Singletons: Auto

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdBondiMichel.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdBondiMichel.yaml
@@ -12,6 +12,9 @@ ExpectedOutput:
 
 ---
 
+Parallelization:
+  ElementDistribution: NumGridPoints
+
 ResourceInfo:
   AvoidGlobalProc0: false
   Singletons: Auto

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdTovStar.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdTovStar.yaml
@@ -12,6 +12,9 @@ ExpectedOutput:
 
 ---
 
+Parallelization:
+  ElementDistribution: NumGridPoints
+
 ResourceInfo:
   AvoidGlobalProc0: false
   Singletons: Auto

--- a/tests/InputFiles/GrMhd/ValenciaDivClean/BlastWave.yaml
+++ b/tests/InputFiles/GrMhd/ValenciaDivClean/BlastWave.yaml
@@ -8,6 +8,9 @@ Testing:
 
 ---
 
+Parallelization:
+  ElementDistribution: NumGridPoints
+
 ResourceInfo:
   AvoidGlobalProc0: false
 

--- a/tests/InputFiles/GrMhd/ValenciaDivClean/FishboneMoncriefDisk.yaml
+++ b/tests/InputFiles/GrMhd/ValenciaDivClean/FishboneMoncriefDisk.yaml
@@ -9,6 +9,9 @@ Testing:
 
 ---
 
+Parallelization:
+  ElementDistribution: NumGridPoints
+
 ResourceInfo:
   AvoidGlobalProc0: false
   Singletons:

--- a/tests/InputFiles/NewtonianEuler/RiemannProblem1D.yaml
+++ b/tests/InputFiles/NewtonianEuler/RiemannProblem1D.yaml
@@ -7,6 +7,9 @@ Testing:
 
 ---
 
+Parallelization:
+  ElementDistribution: NumGridPoints
+
 ResourceInfo:
   AvoidGlobalProc0: false
 

--- a/tests/InputFiles/NewtonianEuler/RiemannProblem2D.yaml
+++ b/tests/InputFiles/NewtonianEuler/RiemannProblem2D.yaml
@@ -7,6 +7,9 @@ Testing:
 
 ---
 
+Parallelization:
+  ElementDistribution: NumGridPoints
+
 ResourceInfo:
   AvoidGlobalProc0: false
 

--- a/tests/InputFiles/NewtonianEuler/RiemannProblem3D.yaml
+++ b/tests/InputFiles/NewtonianEuler/RiemannProblem3D.yaml
@@ -8,6 +8,9 @@ Testing:
 
 ---
 
+Parallelization:
+  ElementDistribution: NumGridPoints
+
 ResourceInfo:
   AvoidGlobalProc0: false
 

--- a/tests/InputFiles/Poisson/ProductOfSinusoids1D.yaml
+++ b/tests/InputFiles/Poisson/ProductOfSinusoids1D.yaml
@@ -19,6 +19,9 @@ OutputFileChecks:
 
 ---
 
+Parallelization:
+  ElementDistribution: NumGridPoints
+
 ResourceInfo:
   AvoidGlobalProc0: false
   Singletons: Auto

--- a/tests/InputFiles/Poisson/ProductOfSinusoids2D.yaml
+++ b/tests/InputFiles/Poisson/ProductOfSinusoids2D.yaml
@@ -17,6 +17,9 @@ OutputFileChecks:
 
 ---
 
+Parallelization:
+  ElementDistribution: NumGridPoints
+
 ResourceInfo:
   AvoidGlobalProc0: false
   Singletons: Auto

--- a/tests/InputFiles/Poisson/ProductOfSinusoids3D.yaml
+++ b/tests/InputFiles/Poisson/ProductOfSinusoids3D.yaml
@@ -18,6 +18,9 @@ OutputFileChecks:
 
 ---
 
+Parallelization:
+  ElementDistribution: NumGridPoints
+
 ResourceInfo:
   AvoidGlobalProc0: false
   Singletons: Auto

--- a/tests/InputFiles/Punctures/MultiplePunctures.yaml
+++ b/tests/InputFiles/Punctures/MultiplePunctures.yaml
@@ -12,6 +12,9 @@ ExpectedOutput:
 
 ---
 
+Parallelization:
+  ElementDistribution: NumGridPoints
+
 ResourceInfo:
   AvoidGlobalProc0: false
   Singletons: Auto

--- a/tests/InputFiles/RadiationTransport/M1Grey/ConstantM1.yaml
+++ b/tests/InputFiles/RadiationTransport/M1Grey/ConstantM1.yaml
@@ -10,6 +10,9 @@ ExpectedOutput:
 
 ---
 
+Parallelization:
+  ElementDistribution: NumGridPoints
+
 ResourceInfo:
   AvoidGlobalProc0: false
 

--- a/tests/InputFiles/ScalarAdvection/Krivodonova1D.yaml
+++ b/tests/InputFiles/ScalarAdvection/Krivodonova1D.yaml
@@ -9,6 +9,9 @@ ExpectedOutput:
 
 ---
 
+Parallelization:
+  ElementDistribution: NumGridPoints
+
 ResourceInfo:
   AvoidGlobalProc0: false
 

--- a/tests/InputFiles/ScalarAdvection/Kuzmin2D.yaml
+++ b/tests/InputFiles/ScalarAdvection/Kuzmin2D.yaml
@@ -10,6 +10,9 @@ ExpectedOutput:
 
 ---
 
+Parallelization:
+  ElementDistribution: NumGridPoints
+
 ResourceInfo:
   AvoidGlobalProc0: false
 

--- a/tests/InputFiles/ScalarAdvection/Sinusoid1D.yaml
+++ b/tests/InputFiles/ScalarAdvection/Sinusoid1D.yaml
@@ -9,6 +9,9 @@ ExpectedOutput:
 
 ---
 
+Parallelization:
+  ElementDistribution: NumGridPoints
+
 ResourceInfo:
   AvoidGlobalProc0: false
 

--- a/tests/InputFiles/ScalarTensor/KerrSchildSphericalHarmonic.yaml
+++ b/tests/InputFiles/ScalarTensor/KerrSchildSphericalHarmonic.yaml
@@ -17,6 +17,9 @@ OutputFileChecks:
 
 ---
 
+Parallelization:
+  ElementDistribution: NumGridPoints
+
 ResourceInfo:
   AvoidGlobalProc0: false
   Singletons: Auto

--- a/tests/InputFiles/ScalarWave/PlaneWave1D.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave1D.yaml
@@ -8,6 +8,9 @@ Testing:
 
 ---
 
+Parallelization:
+  ElementDistribution: NumGridPoints
+
 ResourceInfo:
   AvoidGlobalProc0: false
   Singletons: Auto

--- a/tests/InputFiles/ScalarWave/PlaneWave1DEventsAndTriggersExample.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave1DEventsAndTriggersExample.yaml
@@ -10,6 +10,9 @@ ExpectedOutput:
 
 ---
 
+Parallelization:
+  ElementDistribution: NumGridPoints
+
 ResourceInfo:
   AvoidGlobalProc0: false
   Singletons: Auto

--- a/tests/InputFiles/ScalarWave/PlaneWave1DObserveExample.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave1DObserveExample.yaml
@@ -11,6 +11,9 @@ ExpectedOutput:
 
 ---
 
+Parallelization:
+  ElementDistribution: NumGridPoints
+
 ResourceInfo:
   AvoidGlobalProc0: false
   Singletons: Auto

--- a/tests/InputFiles/ScalarWave/PlaneWave2D.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave2D.yaml
@@ -9,6 +9,9 @@ ExpectedOutput:
 
 ---
 
+Parallelization:
+  ElementDistribution: NumGridPoints
+
 ResourceInfo:
   AvoidGlobalProc0: false
   Singletons: Auto

--- a/tests/InputFiles/ScalarWave/PlaneWave3D.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave3D.yaml
@@ -7,6 +7,9 @@ Testing:
 
 ---
 
+Parallelization:
+  ElementDistribution: NumGridPoints
+
 ResourceInfo:
   AvoidGlobalProc0: false
   Singletons: Auto

--- a/tests/InputFiles/Xcts/BinaryBlackHole.yaml
+++ b/tests/InputFiles/Xcts/BinaryBlackHole.yaml
@@ -9,6 +9,9 @@ Testing:
 
 ---
 
+Parallelization:
+  ElementDistribution: NumGridPoints
+
 ResourceInfo:
   AvoidGlobalProc0: false
   Singletons: Auto

--- a/tests/InputFiles/Xcts/HeadOnBns.yaml
+++ b/tests/InputFiles/Xcts/HeadOnBns.yaml
@@ -9,6 +9,9 @@ Testing:
 
 ---
 
+Parallelization:
+  ElementDistribution: NumGridPoints
+
 ResourceInfo:
   AvoidGlobalProc0: false
   Singletons: Auto

--- a/tests/InputFiles/Xcts/KerrSchild.yaml
+++ b/tests/InputFiles/Xcts/KerrSchild.yaml
@@ -18,6 +18,9 @@ OutputFileChecks:
 
 ---
 
+Parallelization:
+  ElementDistribution: NumGridPoints
+
 ResourceInfo:
   AvoidGlobalProc0: false
   Singletons: Auto

--- a/tests/InputFiles/Xcts/TovStar.yaml
+++ b/tests/InputFiles/Xcts/TovStar.yaml
@@ -18,6 +18,9 @@ OutputFileChecks:
 
 ---
 
+Parallelization:
+  ElementDistribution: NumGridPoints
+
 ResourceInfo:
   AvoidGlobalProc0: false
   Singletons: Auto

--- a/tests/Unit/Domain/Tags/CMakeLists.txt
+++ b/tests/Unit/Domain/Tags/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY "Test_DomainTags")
 
 set(LIBRARY_SOURCES
+  Test_ElementDistribution.cpp
   Test_Faces.cpp
   Test_SurfaceJacobian.cpp
   )
@@ -17,5 +18,6 @@ target_link_libraries(
   Domain
   DomainHelpers
   DomainStructure
+  Parallel
   Utilities
   )

--- a/tests/Unit/Domain/Tags/Test_ElementDistribution.cpp
+++ b/tests/Unit/Domain/Tags/Test_ElementDistribution.cpp
@@ -1,0 +1,30 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <optional>
+#include <string>
+
+#include "Domain/ElementDistribution.hpp"
+#include "Domain/Tags/ElementDistribution.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
+#include "Parallel/Tags/Parallelization.hpp"
+
+SPECTRE_TEST_CASE("Unit.Domain.Tags.ElementDistribution", "[Unit][Domain]") {
+  TestHelpers::db::test_simple_tag<domain::Tags::ElementDistribution>(
+      "ElementDistribution");
+  const auto make_option = [](const std::string& option_string)
+      -> std::optional<domain::ElementWeight> {
+    return TestHelpers::test_option_tag<
+        domain::OptionTags::ElementDistribution>(option_string);
+  };
+  CHECK(make_option("Uniform") ==
+        std::optional{domain::ElementWeight::Uniform});
+  CHECK(make_option("NumGridPoints") ==
+        std::optional{domain::ElementWeight::NumGridPoints});
+  CHECK(make_option("NumGridPointsAndGridSpacing") ==
+        std::optional{domain::ElementWeight::NumGridPointsAndGridSpacing});
+  CHECK(make_option("RoundRobin") == std::nullopt);
+}

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Actions/Test_BuildMatrix.yaml
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Actions/Test_BuildMatrix.yaml
@@ -15,6 +15,9 @@ Description: |
 
 ---
 
+Parallelization:
+  ElementDistribution: NumGridPoints
+
 DomainCreator:
   Interval:
     LowerBound: [0]
@@ -47,6 +50,10 @@ Source:  # Unused
 BuildMatrix:
   Verbosity: Debug
   MatrixSubfileName: Matrix
+
+Discretization:
+  DiscontinuousGalerkin:
+    Quadrature: GaussLobatto
 
 Observers:
   VolumeFileName: "Test_BuildMatrix_Volume"

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/ConjugateGradient/Test_DistributedConjugateGradientAlgorithm.yaml
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/ConjugateGradient/Test_DistributedConjugateGradientAlgorithm.yaml
@@ -14,6 +14,9 @@ Description: |
 
 ---
 
+Parallelization:
+  ElementDistribution: NumGridPoints
+
 ResourceInfo:
   AvoidGlobalProc0: false
   Singletons: Auto
@@ -50,6 +53,10 @@ Source:
 ExpectedResult:
   - [-0.0363482510397858,  0.7235793356729757,  0.9928055333486293]
   - [ 0.9928055333486292,  0.7235793356729758, -0.0363482510397858]
+
+Discretization:
+  DiscontinuousGalerkin:
+    Quadrature: GaussLobatto
 
 Observers:
   VolumeFileName: "Test_DistributedConjugateGradientAlgorithm_Volume"

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/Test_DistributedGmresAlgorithm.yaml
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/Test_DistributedGmresAlgorithm.yaml
@@ -15,6 +15,9 @@ Description: |
 
 ---
 
+Parallelization:
+  ElementDistribution: NumGridPoints
+
 ResourceInfo:
   AvoidGlobalProc0: false
   Singletons: Auto
@@ -51,6 +54,10 @@ Source:
 ExpectedResult:
   - [-0.0363482510397858,  0.7235793356729757,  0.9928055333486293]
   - [ 0.9928055333486292,  0.7235793356729758, -0.0363482510397858]
+
+Discretization:
+  DiscontinuousGalerkin:
+    Quadrature: GaussLobatto
 
 Observers:
   VolumeFileName: "Test_DistributedGmresAlgorithm_Volume"

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/Test_DistributedGmresPreconditionedAlgorithm.yaml
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/Test_DistributedGmresPreconditionedAlgorithm.yaml
@@ -16,6 +16,9 @@ Description: |
 
 ---
 
+Parallelization:
+  ElementDistribution: NumGridPoints
+
 ResourceInfo:
   AvoidGlobalProc0: false
   Singletons: Auto
@@ -52,6 +55,10 @@ Source:
 ExpectedResult:
   - [-0.0363482510397858,  0.7235793356729757,  0.9928055333486293]
   - [ 0.9928055333486292,  0.7235793356729758, -0.0363482510397858]
+
+Discretization:
+  DiscontinuousGalerkin:
+    Quadrature: GaussLobatto
 
 Observers:
   VolumeFileName: "Test_DistributedGmresPreconditionedAlgorithm_Volume"

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Multigrid/Test_MultigridAlgorithm.yaml
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Multigrid/Test_MultigridAlgorithm.yaml
@@ -17,6 +17,9 @@ Description: |
 
 ---
 
+Parallelization:
+  ElementDistribution: NumGridPoints
+
 ResourceInfo:
   AvoidGlobalProc0: false
   Singletons: Auto
@@ -58,6 +61,10 @@ ExpectedResult:
   - [0.9928055333486303, 0.7253224709680011, -0.04332079221988417]
 
 OperatorIsMassive: False
+
+Discretization:
+  DiscontinuousGalerkin:
+    Quadrature: GaussLobatto
 
 Observers:
   VolumeFileName: "Test_MultigridAlgorithm_Volume"

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Multigrid/Test_MultigridAlgorithmMassive.yaml
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Multigrid/Test_MultigridAlgorithmMassive.yaml
@@ -8,6 +8,9 @@ Description: |
 
 ---
 
+Parallelization:
+  ElementDistribution: NumGridPoints
+
 ResourceInfo:
   AvoidGlobalProc0: false
   Singletons: Auto
@@ -49,6 +52,10 @@ ExpectedResult:
   - [0.9928055333486303, 0.7253224709680011, -0.04332079221988417]
 
 OperatorIsMassive: True
+
+Discretization:
+  DiscontinuousGalerkin:
+    Quadrature: GaussLobatto
 
 Observers:
   VolumeFileName: "Test_MultigridAlgorithmMassive_Volume"

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Multigrid/Test_MultigridPreconditionedGmresAlgorithm.yaml
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Multigrid/Test_MultigridPreconditionedGmresAlgorithm.yaml
@@ -8,6 +8,9 @@ Description: |
 
 ---
 
+Parallelization:
+  ElementDistribution: NumGridPoints
+
 ResourceInfo:
   AvoidGlobalProc0: false
   Singletons: Auto
@@ -49,6 +52,10 @@ ExpectedResult:
   - [0.9928055333486303, 0.7253224709680011, -0.04332079221988417]
 
 OperatorIsMassive: True
+
+Discretization:
+  DiscontinuousGalerkin:
+    Quadrature: GaussLobatto
 
 Observers:
   VolumeFileName: "Test_MultigridPreconditionedGmresAlgorithm_Volume"

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Richardson/Test_DistributedRichardsonAlgorithm.yaml
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Richardson/Test_DistributedRichardsonAlgorithm.yaml
@@ -14,6 +14,9 @@ Description: |
 
 ---
 
+Parallelization:
+  ElementDistribution: NumGridPoints
+
 ResourceInfo:
   AvoidGlobalProc0: false
   Singletons: Auto
@@ -50,6 +53,10 @@ Source:
 ExpectedResult:
   - [-0.0363482510397858,  0.7235793356729757,  0.9928055333486293]
   - [ 0.9928055333486292,  0.7235793356729758, -0.0363482510397858]
+
+Discretization:
+  DiscontinuousGalerkin:
+    Quadrature: GaussLobatto
 
 Observers:
   VolumeFileName: "Test_DistributedRichardsonAlgorithm_Volume"

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Schwarz/Test_SchwarzAlgorithm.yaml
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Schwarz/Test_SchwarzAlgorithm.yaml
@@ -15,6 +15,9 @@ Description: |
 
 ---
 
+Parallelization:
+  ElementDistribution: NumGridPoints
+
 ResourceInfo:
   AvoidGlobalProc0: false
   Singletons: Auto
@@ -73,6 +76,10 @@ SchwarzSmoother:
   ObservePerCoreReductions: False
 
 ConvergenceReason: NumIterations
+
+Discretization:
+  DiscontinuousGalerkin:
+    Quadrature: GaussLobatto
 
 Observers:
   VolumeFileName: "Test_SchwarzAlgorithm_Volume"


### PR DESCRIPTION
## Proposed changes

Now we can choose how we distribute elements at runtime so you can experiment with what is best for your runs. Currently all the options are different weights for a space-filling curve except for a round-robin distribution. The distributions I added to each of the input files is exactly what it was before, so in practice the distribution should be the same as before.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
Evolution and elliptic executables must now have a new option in the input file called
```yaml
Parallelization:
  ElementDistribution: NumGridPoints
```

An exception to this are the `*CharacteristicExtract` executables. They do not need this new option.
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
