### PR TITLE
Worldtube buffer updater for Klein-Gordon

### DIFF
--- a/src/Evolution/Systems/Cce/WorldtubeBufferUpdater.hpp
+++ b/src/Evolution/Systems/Cce/WorldtubeBufferUpdater.hpp
@@ -134,9 +134,14 @@ using cce_bondi_input_tags =
                Spectral::Swsh::Tags::SwshTransform<Tags::BondiR>,
                Spectral::Swsh::Tags::SwshTransform<Tags::Du<Tags::BondiR>>>;
 
+using klein_gordon_input_tags =
+    tmpl::list<Spectral::Swsh::Tags::SwshTransform<Tags::KleinGordonPsi>,
+               Spectral::Swsh::Tags::SwshTransform<Tags::KleinGordonPi>>;
+
 /// \cond
 class MetricWorldtubeH5BufferUpdater;
 class BondiWorldtubeH5BufferUpdater;
+class KleinGordonWorldtubeH5BufferUpdater;
 /// \endcond
 
 /*!
@@ -174,7 +179,8 @@ template <typename BufferTags>
 class WorldtubeBufferUpdater : public PUP::able {
  public:
   using creatable_classes =
-      tmpl::list<MetricWorldtubeH5BufferUpdater, BondiWorldtubeH5BufferUpdater>;
+      tmpl::list<MetricWorldtubeH5BufferUpdater, BondiWorldtubeH5BufferUpdater,
+                 KleinGordonWorldtubeH5BufferUpdater>;
 
   WRAPPED_PUPable_abstract(WorldtubeBufferUpdater);  // NOLINT
 
@@ -326,7 +332,7 @@ class BondiWorldtubeH5BufferUpdater
   /// retrieves the extraction radius. In most normal circumstances, this will
   /// not be needed for Bondi data.
   double get_extraction_radius() const override {
-    if (not static_cast<bool>(extraction_radius_)) {
+    if (not extraction_radius_.has_value()) {
       ERROR(
           "Extraction radius has not been set, and was not successfully parsed "
           "from the filename. The extraction radius has been used, so must be "
@@ -363,6 +369,98 @@ class BondiWorldtubeH5BufferUpdater
 
   tuples::tagged_tuple_from_typelist<
       db::wrap_tags_in<Tags::detail::InputDataSet, cce_bondi_input_tags>>
+      dataset_names_;
+
+  // stores all the times in the input file
+  DataVector time_buffer_;
+};
+
+/// A `WorldtubeBufferUpdater` specialized to the Klein-Gordon input worldtube
+/// H5 file produced by the SpEC format. We assume the scalar field is
+/// real-valued.
+class KleinGordonWorldtubeH5BufferUpdater
+    : public WorldtubeBufferUpdater<klein_gordon_input_tags> {
+ public:
+  // charm needs the empty constructor
+  KleinGordonWorldtubeH5BufferUpdater() = default;
+
+  /// The constructor takes the filename of the SpEC h5 file that will be used
+  /// for boundary data. The extraction radius can either be passed in directly,
+  /// or if it takes the value `std::nullopt`, then the extraction radius is
+  /// retrieved as an integer in the filename.
+  explicit KleinGordonWorldtubeH5BufferUpdater(
+      const std::string& cce_data_filename,
+      std::optional<double> extraction_radius = std::nullopt);
+
+  WRAPPED_PUPable_decl_template(KleinGordonWorldtubeH5BufferUpdater);  // NOLINT
+
+  explicit KleinGordonWorldtubeH5BufferUpdater(CkMigrateMessage* /*unused*/) {}
+
+  /// update the `buffers`, `time_span_start`, and `time_span_end` with
+  /// time-varies-fastest, Goldberg modal data and the start and end index in
+  /// the member `time_buffer_` covered by the newly updated `buffers`.
+  double update_buffers_for_time(
+      gsl::not_null<Variables<klein_gordon_input_tags>*> buffers,
+      gsl::not_null<size_t*> time_span_start,
+      gsl::not_null<size_t*> time_span_end, double time,
+      size_t computation_l_max, size_t interpolator_length,
+      size_t buffer_depth) const override;
+
+  std::unique_ptr<WorldtubeBufferUpdater<klein_gordon_input_tags>> get_clone()
+      const override {
+    return std::make_unique<KleinGordonWorldtubeH5BufferUpdater>(filename_);
+  }
+
+  /// The time can only be supported in the buffer update if it is between the
+  /// first and last time of the input file.
+  bool time_is_outside_range(const double time) const override {
+    return time < time_buffer_[0] or
+           time > time_buffer_[time_buffer_.size() - 1];
+  }
+
+  /// retrieves the l_max of the input file
+  size_t get_l_max() const override { return l_max_; }
+
+  /// retrieves the extraction radius. In most normal circumstances, this will
+  /// not be needed for Klein-Gordon data.
+  double get_extraction_radius() const override {
+    if (not static_cast<bool>(extraction_radius_)) {
+      ERROR(
+          "Extraction radius has not been set, and was not successfully parsed "
+          "from the filename. The extraction radius has been used, so must be "
+          "set either by the input file or via the filename.");
+    }
+    return *extraction_radius_;
+  }
+
+  /// The time buffer is supplied by non-const reference to allow views to
+  /// easily point into the buffer.
+  ///
+  /// \warning Altering this buffer outside of the constructor of this class
+  /// results in undefined behavior! This should be supplied by const reference
+  /// once there is a convenient method of producing a const view of a vector
+  /// type.
+  DataVector& get_time_buffer() override { return time_buffer_; }
+
+  bool has_version_history() const override { return true; }
+
+  /// Serialization for Charm++.
+  void pup(PUP::er& p) override;
+
+ private:
+  // The scalar field is assumed to be real-valued.
+  void update_buffer(gsl::not_null<ComplexModalVector*> buffer_to_update,
+                     const h5::Dat& read_data, size_t computation_l_max,
+                     size_t time_span_start, size_t time_span_end) const;
+
+  std::optional<double> extraction_radius_ = std::nullopt;
+  size_t l_max_ = 0;
+
+  h5::H5File<h5::AccessType::ReadOnly> cce_data_file_;
+  std::string filename_;
+
+  tuples::tagged_tuple_from_typelist<
+      db::wrap_tags_in<Tags::detail::InputDataSet, klein_gordon_input_tags>>
       dataset_names_;
 
   // stores all the times in the input file

--- a/src/Evolution/Systems/Cce/WorldtubeBufferUpdater.hpp
+++ b/src/Evolution/Systems/Cce/WorldtubeBufferUpdater.hpp
@@ -97,6 +97,20 @@ void update_buffer_with_modal_data(
     gsl::not_null<ComplexModalVector*> buffer_to_update,
     const h5::Dat& read_data, size_t computation_l_max, size_t l_max,
     size_t time_span_start, size_t time_span_end, bool is_real);
+
+// updates `time_span_start` and `time_span_end` based on the provided `time`,
+// and inserts the cooresponding modal data (for `InputTags`) from worldtube H5
+// file into `buffers`. The function is used by Bondi and Klein-Gordon systems.
+template <typename InputTags>
+double update_buffers_for_time(
+    gsl::not_null<Variables<InputTags>*> buffers,
+    gsl::not_null<size_t*> time_span_start,
+    gsl::not_null<size_t*> time_span_end, double time, size_t computation_l_max,
+    size_t l_max, size_t interpolator_length, size_t buffer_depth,
+    const DataVector& time_buffer,
+    const tuples::tagged_tuple_from_typelist<
+        db::wrap_tags_in<Tags::detail::InputDataSet, InputTags>>& dataset_names,
+    const h5::H5File<h5::AccessType::ReadOnly>& cce_data_file);
 }  // namespace detail
 
 /// the full set of tensors to be extracted from the worldtube h5 file

--- a/tests/Unit/Evolution/Systems/Cce/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/Cce/CMakeLists.txt
@@ -16,6 +16,7 @@ set(LIBRARY_SOURCES
   Test_Equations.cpp
   Test_GaugeTransformBoundaryData.cpp
   Test_InitializeCce.cpp
+  Test_KleinGordonWorldtubeData.cpp
   Test_LinearOperators.cpp
   Test_LinearSolve.cpp
   Test_NewmanPenrose.cpp

--- a/tests/Unit/Evolution/Systems/Cce/Test_KleinGordonWorldtubeData.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_KleinGordonWorldtubeData.cpp
@@ -1,0 +1,363 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+
+#include "Evolution/Systems/Cce/ReducedWorldtubeModeRecorder.hpp"
+#include "Evolution/Systems/Cce/WorldtubeBufferUpdater.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "Helpers/Evolution/Systems/Cce/BoundaryTestHelpers.hpp"
+#include "NumericalAlgorithms/Spectral/SwshCollocation.hpp"
+#include "Utilities/Serialization/RegisterDerivedClassesWithCharm.hpp"
+
+namespace Cce::TestHelpers {
+
+namespace {
+// The nodal data for the scalar field psi reads
+//
+// psi = sin(r - t)
+//
+// where r is a time-dependent radius
+//
+// r = (1 + A * sin ft) * R
+//
+// Its time derivative is given by
+//
+// dr/dt = A * f * cos ft * R
+//       =  r / (1 + A * sin ft) * A * f * cos ft
+void create_fake_time_varying_klein_gordon_data(
+    const gsl::not_null<Scalar<ComplexModalVector>*> kg_psi_modal,
+    const gsl::not_null<Scalar<ComplexModalVector>*> kg_pi_modal,
+    const gsl::not_null<Scalar<DataVector>*> kg_psi_nodal,
+    const gsl::not_null<Scalar<DataVector>*> kg_pi_nodal,
+    const double extraction_radius, const double amplitude,
+    const double frequency, const double time, const size_t l_max) {
+  const size_t number_of_angular_points =
+      Spectral::Swsh::number_of_swsh_collocation_points(l_max);
+  tnsr::I<DataVector, 3> collocation_points{number_of_angular_points};
+
+  const auto& collocation = Spectral::Swsh::cached_collocation_metadata<
+      Spectral::Swsh::ComplexRepresentation::Interleaved>(l_max);
+  for (const auto collocation_point : collocation) {
+    get<0>(collocation_points)[collocation_point.offset] =
+        extraction_radius * (1.0 + amplitude * sin(frequency * time)) *
+        sin(collocation_point.theta) * cos(collocation_point.phi);
+    get<1>(collocation_points)[collocation_point.offset] =
+        extraction_radius * (1.0 + amplitude * sin(frequency * time)) *
+        sin(collocation_point.theta) * sin(collocation_point.phi);
+    get<2>(collocation_points)[collocation_point.offset] =
+        extraction_radius * (1.0 + amplitude * sin(frequency * time)) *
+        cos(collocation_point.theta);
+  }
+
+  const DataVector r = sqrt(square(get<0>(collocation_points)) +
+                            square(get<1>(collocation_points)) +
+                            square(get<2>(collocation_points)));
+  const DataVector dr_dt = r / (1.0 + amplitude * sin(frequency * time)) *
+                           amplitude * frequency * cos(frequency * time);
+
+  // Nodal data
+  get(*kg_psi_nodal) = sin(r - time);
+  get(*kg_pi_nodal) = cos(r - time) * (dr_dt - 1.0);
+
+  // Transform to modal data
+  *kg_psi_modal =
+      TestHelpers::tensor_to_goldberg_coefficients(*kg_psi_nodal, l_max);
+  *kg_pi_modal =
+      TestHelpers::tensor_to_goldberg_coefficients(*kg_pi_nodal, l_max);
+}
+}  // namespace
+
+}  // namespace Cce::TestHelpers
+
+namespace Cce {
+
+// A dummy buffer updater that holds reference worldtube data to compare with
+class KleinGordonDummyBufferUpdater
+    : public WorldtubeBufferUpdater<klein_gordon_input_tags> {
+ public:
+  KleinGordonDummyBufferUpdater(DataVector time_buffer,
+                                const std::optional<double> extraction_radius,
+                                const double coordinate_amplitude,
+                                const double coordinate_frequency,
+                                const size_t l_max)
+      : time_buffer_{std::move(time_buffer)},
+        extraction_radius_{extraction_radius},
+        coordinate_amplitude_{coordinate_amplitude},
+        coordinate_frequency_{coordinate_frequency},
+        l_max_{l_max} {}
+
+  WRAPPED_PUPable_decl_template(KleinGordonDummyBufferUpdater);  // NOLINT
+
+  explicit KleinGordonDummyBufferUpdater(CkMigrateMessage* /*unused*/) {}
+
+  double update_buffers_for_time(
+      const gsl::not_null<Variables<klein_gordon_input_tags>*> buffers,
+      const gsl::not_null<size_t*> time_span_start,
+      const gsl::not_null<size_t*> time_span_end, const double time,
+      const size_t l_max, const size_t interpolator_length,
+      const size_t buffer_depth) const override {
+    if (*time_span_end > interpolator_length and
+        time_buffer_[*time_span_end - interpolator_length + 1] > time) {
+      // the next time an update will be required
+      return time_buffer_[*time_span_end - interpolator_length + 1];
+    }
+    // find the time spans that are needed
+    auto new_span_pair = detail::create_span_for_time_value(
+        time, buffer_depth, interpolator_length, 0, time_buffer_.size(),
+        time_buffer_);
+    *time_span_start = new_span_pair.first;
+    *time_span_end = new_span_pair.second;
+
+    Scalar<ComplexModalVector> kg_psi_modal;
+    Scalar<ComplexModalVector> kg_pi_modal;
+    Scalar<DataVector> kg_psi_nodal;
+    Scalar<DataVector> kg_pi_nodal;
+
+    for (size_t time_index = 0; time_index < *time_span_end - *time_span_start;
+         ++time_index) {
+      TestHelpers::create_fake_time_varying_klein_gordon_data(
+          make_not_null(&kg_psi_modal), make_not_null(&kg_pi_modal),
+          make_not_null(&kg_psi_nodal), make_not_null(&kg_pi_nodal),
+          extraction_radius_.value_or(default_extraction_radius_),
+          coordinate_amplitude_, coordinate_frequency_,
+          time_buffer_[time_index + *time_span_start], l_max);
+
+      this->update_buffer_with_scalar_at_time_index(
+          make_not_null(&get<Spectral::Swsh::Tags::SwshTransform<
+                            Cce::Tags::KleinGordonPsi>>(*buffers)),
+          kg_psi_modal, time_index, *time_span_end - *time_span_start);
+
+      this->update_buffer_with_scalar_at_time_index(
+          make_not_null(&get<Spectral::Swsh::Tags::SwshTransform<
+                            Cce::Tags::KleinGordonPi>>(*buffers)),
+          kg_pi_modal, time_index, *time_span_end - *time_span_start);
+    }
+    return time_buffer_[*time_span_end - interpolator_length + 1];
+  }
+
+  std::unique_ptr<WorldtubeBufferUpdater<klein_gordon_input_tags>> get_clone()
+      const override {
+    return std::make_unique<KleinGordonDummyBufferUpdater>(*this);
+  }
+
+  bool time_is_outside_range(const double time) const override {
+    return time < time_buffer_[0] or
+           time > time_buffer_[time_buffer_.size() - 1];
+  }
+
+  size_t get_l_max() const override { return l_max_; }
+
+  double get_extraction_radius() const override {
+    return extraction_radius_.value_or(default_extraction_radius_);
+  }
+
+  DataVector& get_time_buffer() override { return time_buffer_; }
+  bool has_version_history() const override { return true; }
+  void pup(PUP::er& p) override {
+    p | time_buffer_;
+    p | extraction_radius_;
+    p | coordinate_amplitude_;
+    p | coordinate_frequency_;
+    p | l_max_;
+  }
+
+ private:
+  template <int Spin>
+  void update_buffer_with_scalar_at_time_index(
+      const gsl::not_null<Scalar<SpinWeighted<ComplexModalVector, Spin>>*>
+          scalar_buffer,
+      const Scalar<ComplexModalVector>& spin_weighted_at_time,
+      const size_t time_index, const size_t time_span_extent) const {
+    for (size_t k = 0; k < get(spin_weighted_at_time).size(); ++k) {
+      get(*scalar_buffer).data()[time_index + k * time_span_extent] =
+          get(spin_weighted_at_time)[k];
+    }
+  }
+
+  DataVector time_buffer_;
+  std::optional<double> extraction_radius_;
+  double default_extraction_radius_ = 100.0;
+  double coordinate_amplitude_ = 0.0;
+  double coordinate_frequency_ = 0.0;
+  size_t l_max_ = 0;
+};
+
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+PUP::able::PUP_ID Cce::KleinGordonDummyBufferUpdater::my_PUP_ID = 0;
+
+namespace {
+
+// This function tests `KleinGordonWorldtubeH5BufferUpdater`, which handles
+// worldtube data of the Klein-Gordon system for CCE.
+// The testing procedure involves the creation of synthetic modal data for the
+// scalar field and its first time derivative, followed by the storage of this
+// data in an HDF5 file. Subsequently, the `KleinGordonWorldtubeH5BufferUpdater`
+// is used to read the worldtube data and verify that the loaded data matches
+// the originally generated data.
+//
+// The test involves three buffer updaters
+// (1) buffer_updater: a `KleinGordonWorldtubeH5BufferUpdater` object, built
+//     from a HDF5 file to be written.
+// (2) serialized_and_deserialized_updater: serialized-deserialized
+//     buffer_updater.
+// (3) dummy_buffer_updater: an object of `KleinGordonDummyBufferUpdater`
+//     defined above.
+//
+// In the test, we treat `dummy_buffer_updater` as a reference object, whose
+// stored modal data are to be compared with. For `buffer_updater` and
+// `serialized_and_deserialized_updater`, we check:
+//
+// (1) The extraction radius is correctly retrieved.
+// (2) The time stamps are the same as the ones we generate.
+// (3) The worldtube data are the same as `dummy_buffer_updater`.
+template <typename Generator>
+void test_klein_gordon_worldtube_buffer_updater(
+    const gsl::not_null<Generator*> gen,
+    const bool extraction_radius_in_filename) {
+  UniformCustomDistribution<double> value_dist{0.1, 0.5};
+
+  const double extraction_radius = 100.0;
+
+  const double frequency = 0.1 * value_dist(*gen);
+  const double amplitude = 0.1 * value_dist(*gen);
+  const double target_time = 50.0 * value_dist(*gen);
+
+  const size_t buffer_size = 4;
+  const size_t interpolator_length = 3;
+  const size_t file_l_max = 8;
+  const size_t computation_l_max = 10;
+
+  const std::string filename = extraction_radius_in_filename
+                                   ? "BoundaryDataH5Test_CceR0100.h5"
+                                   : "BoundaryDataH5Test.h5";
+  if (file_system::check_if_file_exists(filename)) {
+    file_system::rm(filename, true);
+  }
+
+  // Generate fake modal data and write to `filename`
+  {
+    // scoped to close the file
+    Scalar<ComplexModalVector> kg_psi_modal;
+    Scalar<ComplexModalVector> kg_pi_modal;
+    Scalar<DataVector> kg_psi_nodal;
+    Scalar<DataVector> kg_pi_nodal;
+
+    Cce::ReducedWorldtubeModeRecorder recorder{filename};
+    for (size_t t = 0; t < 20; ++t) {
+      const double time = 0.01 * static_cast<double>(t) + target_time - 0.1;
+
+      TestHelpers::create_fake_time_varying_klein_gordon_data(
+          make_not_null(&kg_psi_modal), make_not_null(&kg_pi_modal),
+          make_not_null(&kg_psi_nodal), make_not_null(&kg_pi_nodal),
+          extraction_radius, amplitude, frequency, time, file_l_max);
+
+      recorder.append_worldtube_mode_data("/KGPsi", time, get(kg_psi_modal),
+                                          file_l_max, true);
+      recorder.append_worldtube_mode_data("/dtKGPsi", time, get(kg_pi_modal),
+                                          file_l_max, true);
+    }
+  }
+
+  // Create a `KleinGordonWorldtubeH5BufferUpdater` object `buffer_updater`
+  // from the HDF5 file `filename` written above.
+  // Then examine its extraction radius and time stamps.
+  auto buffer_updater =
+      extraction_radius_in_filename
+          ? KleinGordonWorldtubeH5BufferUpdater{filename}
+          : KleinGordonWorldtubeH5BufferUpdater{filename, extraction_radius};
+
+  size_t time_span_start = 0;
+  size_t time_span_end = 0;
+  Variables<klein_gordon_input_tags> coefficients_buffers_from_file{
+      (buffer_size + 2 * interpolator_length) * square(computation_l_max + 1)};
+  buffer_updater.update_buffers_for_time(
+      make_not_null(&coefficients_buffers_from_file),
+      make_not_null(&time_span_start), make_not_null(&time_span_end),
+      target_time, computation_l_max, interpolator_length, buffer_size);
+
+  const auto& time_buffer = buffer_updater.get_time_buffer();
+  for (size_t i = 0; i < time_buffer.size(); ++i) {
+    CHECK(time_buffer[i] == approx(target_time - 0.1 + 0.01 * i));
+  }
+  CHECK(buffer_updater.get_extraction_radius() == 100.0);
+
+  // Test the `pup` function of `KleinGordonWorldtubeH5BufferUpdater`.
+  // Serialize and deserialize `buffer_updater` and repeat the checks above.
+  auto serialized_and_deserialized_updater =
+      serialize_and_deserialize(buffer_updater);
+
+  Variables<klein_gordon_input_tags> coefficients_buffers_from_serialized{
+      (buffer_size + 2 * interpolator_length) * square(computation_l_max + 1)};
+  size_t time_span_start_from_serialized = 0;
+  size_t time_span_end_from_serialized = 0;
+  serialized_and_deserialized_updater.update_buffers_for_time(
+      make_not_null(&coefficients_buffers_from_serialized),
+      make_not_null(&time_span_start_from_serialized),
+      make_not_null(&time_span_end_from_serialized), target_time,
+      computation_l_max, interpolator_length, buffer_size);
+
+  const auto& time_buffer_from_serialized =
+      serialized_and_deserialized_updater.get_time_buffer();
+  for (size_t i = 0; i < time_buffer.size(); ++i) {
+    CHECK(time_buffer_from_serialized[i] ==
+          approx(target_time - 0.1 + 0.01 * i));
+  }
+  CHECK(serialized_and_deserialized_updater.get_extraction_radius() == 100.0);
+
+  // Compare the modal data of `buffer_updater` and
+  // `serialized_and_deserialized_updater`, which goes through the write-read
+  // process, with what we generated earilier. The fiducial modal data are
+  // stored in an object of `KleinGordonDummyBufferUpdater`.
+  time_span_start = 0;
+  time_span_end = 0;
+  const KleinGordonDummyBufferUpdater dummy_buffer_updater{
+      time_buffer, extraction_radius, amplitude, frequency, computation_l_max};
+  Variables<klein_gordon_input_tags> expected_coefficients_buffers{
+      (buffer_size + 2 * interpolator_length) * square(computation_l_max + 1)};
+  dummy_buffer_updater.update_buffers_for_time(
+      make_not_null(&expected_coefficients_buffers),
+      make_not_null(&time_span_start), make_not_null(&time_span_end),
+      target_time, computation_l_max, interpolator_length, buffer_size);
+
+  Approx modal_approx =
+      Approx::custom()
+          .epsilon(std::numeric_limits<double>::epsilon() * 1.0e3)
+          .scale(1.0);
+
+  tmpl::for_each<klein_gordon_input_tags>(
+      [&expected_coefficients_buffers, &coefficients_buffers_from_file,
+       &coefficients_buffers_from_serialized, &modal_approx](auto tag_v) {
+        using tag = typename decltype(tag_v)::type;
+        INFO(db::tag_name<tag>());
+        const auto& expected_coefs = get<tag>(expected_coefficients_buffers);
+        const auto& kg_coefs = get<tag>(coefficients_buffers_from_file);
+        CHECK_ITERABLE_CUSTOM_APPROX(expected_coefs, kg_coefs, modal_approx);
+        const auto& serialized_kg_coefs =
+            get<tag>(coefficients_buffers_from_serialized);
+        CHECK_ITERABLE_CUSTOM_APPROX(expected_coefs, serialized_kg_coefs,
+                                     modal_approx);
+      });
+
+  // Finally remove the generated file
+  if (file_system::check_if_file_exists(filename)) {
+    file_system::rm(filename, true);
+  }
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.ReadKleinGordonBoundaryDataH5",
+                  "[Unit][Cce]") {
+  register_derived_classes_with_charm<
+      Cce::WorldtubeBufferUpdater<klein_gordon_input_tags>>();
+  MAKE_GENERATOR(gen);
+  {
+    INFO("Testing Klein-Gordon buffer updaters");
+    test_klein_gordon_worldtube_buffer_updater(make_not_null(&gen), true);
+    test_klein_gordon_worldtube_buffer_updater(make_not_null(&gen), false);
+  }
+}
+}  // namespace Cce


### PR DESCRIPTION
## Proposed changes

<!--
At a high level, describe what this PR does.
-->

This PR adds a worldtube buffer updater for Klein-Gordon, and the corresponding unit test. The first four commits are from #5640  to be merged.

The new `KleinGordonWorldtubeH5BufferUpdater` class follows `BondiWorldtubeH5BufferUpdater`. Its unit test follows `Test_WorldtubeData.cpp`.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
