### PR TITLE
Reduce compilation memory of executables

### DIFF
--- a/src/DataStructures/DataBox/DataBox.hpp
+++ b/src/DataStructures/DataBox/DataBox.hpp
@@ -651,10 +651,11 @@ db::DataBox<tmpl::list<Tags...>>::reset_compute_items_after_mutate(
   using current_tags_to_reset = tmpl::list<TagsOfImmutableItemsToReset...>;
   using next_compute_tags_to_reset = tmpl::list_difference<
       tmpl::remove_duplicates<tmpl::transform<
-          tmpl::append<
-              tmpl::filter<typename DataBox<tmpl::list<Tags...>>::edge_list,
-                           std::is_same<tmpl::pin<TagsOfImmutableItemsToReset>,
-                                        tmpl::get_source<tmpl::_1>>>...>,
+          tmpl::filter<
+              typename DataBox<tmpl::list<Tags...>>::edge_list,
+              tmpl::lazy::list_contains<
+                  tmpl::pin<tmpl::list<TagsOfImmutableItemsToReset...>>,
+                  tmpl::get_source<tmpl::_1>>>,
           tmpl::get_destination<tmpl::_1>>>,
       current_tags_to_reset>;
   reset_compute_items_after_mutate(next_compute_tags_to_reset{});

--- a/src/Options/ParseOptions.hpp
+++ b/src/Options/ParseOptions.hpp
@@ -647,8 +647,7 @@ std::string Parser<OptionList, Group>::help() const {
   ss << "\n==== Description of expected options:\n" << help_text_;
   if (tmpl::size<TagsAndSubgroups>::value > 0) {
     ss << "\n\nOptions:\n"
-       << tmpl::for_each<TagsAndSubgroups>(Options_detail::print<OptionList>{})
-              .value;
+       << Options_detail::print<OptionList, TagsAndSubgroups>::apply("  ");
   } else {
     ss << "\n\n<No options>\n";
   }

--- a/src/Parallel/CMakeLists.txt
+++ b/src/Parallel/CMakeLists.txt
@@ -12,6 +12,7 @@ spectre_target_sources(
   ${LIBRARY}
   PRIVATE
   ArrayComponentId.cpp
+  CharmRegistration.cpp
   InitializationFunctions.cpp
   NodeLock.cpp
   Phase.cpp

--- a/src/Parallel/CharmRegistration.cpp
+++ b/src/Parallel/CharmRegistration.cpp
@@ -1,0 +1,40 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Parallel/CharmRegistration.hpp"
+
+#include <algorithm>
+#include <cstddef>
+#include <string>
+
+namespace Parallel::charmxx {
+std::string get_template_parameters_as_string_impl(
+    const std::string& function_name) {
+  std::string template_params =
+      function_name.substr(function_name.find(std::string("Args = ")) + 8);
+  template_params.erase(template_params.end() - 2, template_params.end());
+  size_t pos = 0;
+  while ((pos = template_params.find(" >")) != std::string::npos) {
+    template_params.replace(pos, 1, ">");
+    template_params.erase(pos + 1, 1);
+  }
+  pos = 0;
+  while ((pos = template_params.find(", ", pos)) != std::string::npos) {
+    template_params.erase(pos + 1, 1);
+  }
+  pos = 0;
+  while ((pos = template_params.find('>', pos + 2)) != std::string::npos) {
+    template_params.replace(pos, 1, " >");
+  }
+  std::replace(template_params.begin(), template_params.end(), '%', '>');
+  // GCC's __PRETTY_FUNCTION__ adds the return type at the end, so we remove it.
+  if (template_params.find('}') != std::string::npos) {
+    template_params.erase(template_params.find('}'), template_params.size());
+  }
+  // Remove all spaces
+  const auto new_end =
+      std::remove(template_params.begin(), template_params.end(), ' ');
+  template_params.erase(new_end, template_params.end());
+  return template_params;
+}
+}  // namespace Parallel::charmxx

--- a/src/Parallel/CharmRegistration.hpp
+++ b/src/Parallel/CharmRegistration.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include <algorithm>
 #include <cstddef>
 #include <memory>
 #include <string>
@@ -64,6 +63,9 @@ extern size_t charm_register_list_capacity;
 extern size_t charm_register_list_size;
 /// \endcond
 
+std::string get_template_parameters_as_string_impl(
+    const std::string& function_name);
+
 /*!
  * \ingroup CharmExtensionsGroup
  * \brief Returns the template parameter as a `std::string`
@@ -76,32 +78,7 @@ extern size_t charm_register_list_size;
 template <class... Args>
 std::string get_template_parameters_as_string() {
   std::string function_name(static_cast<char const*>(__PRETTY_FUNCTION__));
-  std::string template_params =
-      function_name.substr(function_name.find(std::string("Args = ")) + 8);
-  template_params.erase(template_params.end() - 2, template_params.end());
-  size_t pos = 0;
-  while ((pos = template_params.find(" >")) != std::string::npos) {
-    template_params.replace(pos, 1, ">");
-    template_params.erase(pos + 1, 1);
-  }
-  pos = 0;
-  while ((pos = template_params.find(", ", pos)) != std::string::npos) {
-    template_params.erase(pos + 1, 1);
-  }
-  pos = 0;
-  while ((pos = template_params.find('>', pos + 2)) != std::string::npos) {
-    template_params.replace(pos, 1, " >");
-  }
-  std::replace(template_params.begin(), template_params.end(), '%', '>');
-  // GCC's __PRETTY_FUNCTION__ adds the return type at the end, so we remove it.
-  if (template_params.find('}') != std::string::npos) {
-    template_params.erase(template_params.find('}'), template_params.size());
-  }
-  // Remove all spaces
-  const auto new_end =
-      std::remove(template_params.begin(), template_params.end(), ' ');
-  template_params.erase(new_end, template_params.end());
-  return template_params;
+  return get_template_parameters_as_string_impl(function_name);
 }
 
 /*!

--- a/src/ParallelAlgorithms/Events/CMakeLists.txt
+++ b/src/ParallelAlgorithms/Events/CMakeLists.txt
@@ -9,6 +9,7 @@ spectre_target_sources(
   ${LIBRARY}
   PRIVATE
   ObserveAdaptiveSteppingDiagnostics.cpp
+  ObserveNorms.cpp
   )
 
 spectre_target_headers(
@@ -30,6 +31,7 @@ target_link_libraries(
   ${LIBRARY}
   PUBLIC
   Charmxx::pup
+  LinearOperators
   Observer
   Options
   Parallel
@@ -44,6 +46,5 @@ target_link_libraries(
   EventsAndTriggers
   H5
   Interpolation
-  LinearOperators
   Spectral
   )

--- a/src/ParallelAlgorithms/Events/ObserveNorms.cpp
+++ b/src/ParallelAlgorithms/Events/ObserveNorms.cpp
@@ -1,0 +1,127 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "ParallelAlgorithms/Events/ObserveNorms.hpp"
+
+#include <algorithm>
+#include <cstddef>
+#include <limits>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "DataStructures/DataVector.hpp"
+#include "NumericalAlgorithms/LinearOperators/DefiniteIntegral.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Numeric.hpp"
+
+namespace Events::ObserveNorms_impl {
+void check_norm_is_observable(const std::string& tensor_name,
+                              const bool tag_has_value) {
+  if (UNLIKELY(not tag_has_value)) {
+    ERROR("Cannot observe a norm of '"
+          << tensor_name
+          << "' because it is a std::optional and wasn't able to be "
+             "computed. This can happen when you try to observe errors "
+             "without an analytic solution.");
+  }
+}
+
+template <size_t Dim>
+void fill_norm_values_and_names(
+    const gsl::not_null<std::unordered_map<
+        std::string, std::pair<std::vector<double>, std::vector<std::string>>>*>
+        norm_values_and_names,
+    const std::pair<std::vector<std::string>, std::vector<DataVector>>&
+        names_and_components,
+    const Mesh<Dim>& mesh, const DataVector& det_jacobian,
+    const std::string& tensor_name, const std::string& tensor_norm_type,
+    const std::string& tensor_component, const size_t number_of_points) {
+  auto& [values, names] = (*norm_values_and_names)[tensor_norm_type];
+  const auto& components = names_and_components.second;
+  if (components[0].size() != number_of_points) {
+    ERROR("The number of grid points of the mesh is "
+          << number_of_points << " but the tensor '" << tensor_name << "' has "
+          << components[0].size()
+          << " points. This means you're computing norms of tensors over "
+             "different grids, which will give the wrong answer for "
+             "norms that use the grid points.");
+  }
+
+  const auto& component_names = names_and_components.first;
+  if (tensor_component == "Individual") {
+    for (size_t storage_index = 0; storage_index < component_names.size();
+         ++storage_index) {
+      if (tensor_norm_type == "Max") {
+        values.push_back(max(components[storage_index]));
+      } else if (tensor_norm_type == "Min") {
+        values.push_back(min(components[storage_index]));
+      } else if (tensor_norm_type == "L2Norm") {
+        values.push_back(
+            alg::accumulate(square(components[storage_index]), 0.0));
+      } else if (tensor_norm_type == "L2IntegralNorm") {
+        values.push_back(definite_integral(
+            square(components[storage_index]) * det_jacobian, mesh));
+      } else if (tensor_norm_type == "VolumeIntegral") {
+        values.push_back(
+            definite_integral(components[storage_index] * det_jacobian, mesh));
+      }
+      names.push_back(
+          tensor_norm_type + "(" +
+          (component_names.size() == 1
+               ? tensor_name
+               : (tensor_name + "_" + component_names[storage_index])) +
+          ")");
+    }
+  } else if (tensor_component == "Sum") {
+    double value = 0.0;
+    if (tensor_norm_type == "Max") {
+      value = std::numeric_limits<double>::min();
+    } else if (tensor_norm_type == "Min") {
+      value = std::numeric_limits<double>::max();
+    }
+    for (size_t storage_index = 0; storage_index < component_names.size();
+         ++storage_index) {
+      if (tensor_norm_type == "Max") {
+        value = std::max(value, max(components[storage_index]));
+      } else if (tensor_norm_type == "Min") {
+        value = std::min(value, min(components[storage_index]));
+      } else if (tensor_norm_type == "L2Norm") {
+        value += alg::accumulate(square(components[storage_index]), 0.0);
+      } else if (tensor_norm_type == "L2IntegralNorm") {
+        value += definite_integral(
+            square(components[storage_index]) * det_jacobian, mesh);
+      } else if (tensor_norm_type == "VolumeIntegral") {
+        value +=
+            definite_integral(components[storage_index] * det_jacobian, mesh);
+      }
+    }
+
+    names.push_back(tensor_norm_type + "(" + tensor_name + ")");
+    values.push_back(value);
+  }
+}
+}  // namespace Events::ObserveNorms_impl
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data)                                               \
+  template void Events::ObserveNorms_impl::fill_norm_values_and_names(     \
+      gsl::not_null<std::unordered_map<                                    \
+          std::string,                                                     \
+          std::pair<std::vector<double>, std::vector<std::string>>>*>      \
+          norm_values_and_names,                                           \
+      const std::pair<std::vector<std::string>, std::vector<DataVector>>&  \
+          names_and_components,                                            \
+      const Mesh<DIM(data)>& mesh, const DataVector& det_jacobian,         \
+      const std::string& tensor_name, const std::string& tensor_norm_type, \
+      const std::string& tensor_component, size_t number_of_points);
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
+
+#undef DIM
+#undef INSTANTIATE


### PR DESCRIPTION
Addresses #5472

## Proposed changes

This PR includes several changes that were found to decrease peak RAM usage during compilation of `EvolveGhBinaryBlackHole`. See **Further comments** below for details on the compilation impact of each commit and overall.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments
**Effects of changes on compiling `EvolveGhBinaryBlackHole`:**
The original commits that generated the stats below are backed up on [this branch](https://github.com/macedo22/spectre/tree/bbh_compilation_improvements_1_og_pr), where **clang-13 Release** and **gcc-9 Release** were used to compile on wheeler014.

Each commit below is applied on top of the one above it, so the relative effect of one commit applied on top of the ones before it is the difference from the commit above it. For example, applying `32a2f1d` after `9769906` saved an additional 0.2 GB of RAM for clang and 1.54 GB for gcc.

```
Modification                                    | Commit hash | clang peak RAM (GB) | gcc peak RAM (GB) | clang user time (mm:ss) | gcc user time (mm:ss)
---------------------------------------------------------------------------------------------------------------------------------------------------------
(baseline)                                        b479ee1       11.36                 19.00                8:32                     13:50
Factor ObserveNorms::operator()                   9769906       11.15                 18.84                8:07                     13:22
Rework Databox::reset_compute_items_after_mutate  32a2f1d       10.95                 17.30                8:05                     13:37
Factor get_template_parameters_as_string          8bb55a9       10.85                 17.14                7:52                     13:38
Rework Options help text printing                 3448d08       10.69                 16.38                7:49                     13:21
Factor Options::Parser::parse                     3ad5784        9.98                 15.60                6:55                     11:04
---------------------------------------------------------------------------------------------------------------------------------------------------------
Total saved from baseline commit                                 1.38                  3.40                1:37                      2:46
```

**Effects of changes on CI:**
Some build times and the sizes of the build directories improved a little. See effects on CI recorded [here](https://docs.google.com/spreadsheets/d/1bDai4-JoYYlcjl3hmTEDeO5DF6p1GnmdyAKcXmoiM2o/edit#gid=1692422746).
