### PR TITLE
Add function for the spacetime derivative of goth(g)

### DIFF
--- a/src/PointwiseFunctions/GeneralRelativity/CMakeLists.txt
+++ b/src/PointwiseFunctions/GeneralRelativity/CMakeLists.txt
@@ -21,6 +21,7 @@ spectre_target_sources(
   Psi4Real.cpp
   Ricci.cpp
   Shift.cpp
+  SpacetimeDerivativeOfGothG.cpp
   SpacetimeMetric.cpp
   SpacetimeNormalOneForm.cpp
   SpacetimeNormalVector.cpp
@@ -52,6 +53,7 @@ spectre_target_headers(
   Psi4.hpp
   Psi4Real.hpp
   Shift.hpp
+  SpacetimeDerivativeOfGothG.hpp
   SpacetimeMetric.hpp
   SpacetimeNormalOneForm.hpp
   SpacetimeNormalVector.hpp

--- a/src/PointwiseFunctions/GeneralRelativity/SpacetimeDerivativeOfGothG.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/SpacetimeDerivativeOfGothG.cpp
@@ -1,0 +1,109 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "PointwiseFunctions/GeneralRelativity/SpacetimeDerivativeOfGothG.hpp"
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Expressions/TensorExpression.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "DataStructures/VectorImpl.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/ContainerHelpers.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace gr {
+template <typename DataType, size_t SpatialDim, typename Frame>
+void spacetime_deriv_of_goth_g(
+    gsl::not_null<tnsr::aBB<DataType, SpatialDim, Frame>*> da_goth_g,
+    const tnsr::AA<DataType, SpatialDim, Frame>& inverse_spacetime_metric,
+    const tnsr::abb<DataType, SpatialDim, Frame>& da_spacetime_metric,
+    const Scalar<DataType>& lapse,
+    const Scalar<DataType>& dt_lapse,
+    const tnsr::i<DataType, SpatialDim, Frame>& deriv_lapse,
+    const Scalar<DataType>& sqrt_det_spatial_metric,
+    const tnsr::a<DataType, SpatialDim, Frame>& da_det_spatial_metric) {
+  set_number_of_grid_points(da_goth_g, da_spacetime_metric);
+
+  tnsr::a<DataType, SpatialDim, Frame> da_lapse{};
+  if constexpr (std::is_same_v<DataType, DataVector>) {
+    make_const_view(make_not_null(&std::as_const(da_lapse.get(0))),
+                                     get(dt_lapse), 0, get(dt_lapse).size());
+    for (size_t i = 0; i < SpatialDim; ++i) {
+      make_const_view(make_not_null(&std::as_const(da_lapse.get(i + 1))),
+                              deriv_lapse.get(i), 0, deriv_lapse.get(0).size());
+    }
+  }
+  else {
+    da_lapse.get(0) = get(dt_lapse);
+    for (size_t i = 0; i < SpatialDim; ++i) {
+      da_lapse.get(i + 1) = deriv_lapse.get(i);
+    }
+  }
+
+  tenex::evaluate<ti::a, ti::B, ti::C>(da_goth_g,
+    (da_lapse(ti::a) * sqrt_det_spatial_metric()
+        + 0.5 * lapse() * da_det_spatial_metric(ti::a)
+        / sqrt_det_spatial_metric()) * inverse_spacetime_metric(ti::B, ti::C)
+     - lapse() * sqrt_det_spatial_metric()
+                                    * inverse_spacetime_metric(ti::B, ti::D)
+                                    * inverse_spacetime_metric(ti::C, ti::E)
+                                    * da_spacetime_metric(ti::a, ti::d, ti::e));
+}
+
+template <typename DataType, size_t SpatialDim, typename Frame>
+tnsr::aBB<DataType, SpatialDim, Frame> spacetime_deriv_of_goth_g(
+    const tnsr::AA<DataType, SpatialDim, Frame>& inverse_spacetime_metric,
+    const tnsr::abb<DataType, SpatialDim, Frame>& da_spacetime_metric,
+    const Scalar<DataType>& lapse,
+    const Scalar<DataType>& dt_lapse,
+    const tnsr::i<DataType, SpatialDim, Frame>& deriv_lapse,
+    const Scalar<DataType>& sqrt_det_spatial_metric,
+    const tnsr::a<DataType, SpatialDim, Frame>& da_det_spatial_metric) {
+  tnsr::aBB<DataType, SpatialDim, Frame> da_goth_g{};
+  gr::spacetime_deriv_of_goth_g(make_not_null(&da_goth_g),
+          inverse_spacetime_metric, da_spacetime_metric, lapse, dt_lapse,
+                   deriv_lapse, sqrt_det_spatial_metric, da_det_spatial_metric);
+  return da_goth_g;
+}
+}  // namespace gr
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(1, data)
+#define FRAME(data) BOOST_PP_TUPLE_ELEM(2, data)
+
+#define INSTANTIATE(_, data)                                              \
+  template void gr::spacetime_deriv_of_goth_g(                            \
+      const gsl::not_null<tnsr::aBB<DTYPE(data), DIM(data), FRAME(data)>*>\
+          da_goth_g,                                                      \
+      const tnsr::AA<DTYPE(data), DIM(data), FRAME(data)>&                \
+          inverse_spacetime_metric,                                       \
+      const tnsr::abb<DTYPE(data), DIM(data), FRAME(data)>&               \
+          da_spacetime_metric,                                            \
+      const Scalar<DTYPE(data)>& lapse,                                   \
+      const Scalar<DTYPE(data)>& dt_lapse,                                \
+      const tnsr::i<DTYPE(data), DIM(data), FRAME(data)>& deriv_lapse,    \
+      const Scalar<DTYPE(data)>& sqrt_det_spatial_metric,                 \
+      const tnsr::a<DTYPE(data), DIM(data), FRAME(data)>&                 \
+          da_det_spatial_metric);                                         \
+  template tnsr::aBB<DTYPE(data), DIM(data), FRAME(data)>                 \
+  gr::spacetime_deriv_of_goth_g(                                          \
+      const tnsr::AA<DTYPE(data), DIM(data), FRAME(data)>&                \
+          inverse_spacetime_metric,                                       \
+      const tnsr::abb<DTYPE(data), DIM(data), FRAME(data)>&               \
+          da_spacetime_metric,                                            \
+      const Scalar<DTYPE(data)>& lapse,                                   \
+      const Scalar<DTYPE(data)>& dt_lapse,                                \
+      const tnsr::i<DTYPE(data), DIM(data), FRAME(data)>& deriv_lapse,    \
+      const Scalar<DTYPE(data)>& sqrt_det_spatial_metric,                 \
+      const tnsr::a<DTYPE(data), DIM(data), FRAME(data)>&                 \
+          da_det_spatial_metric);
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (double, DataVector),
+                        (Frame::Grid, Frame::Inertial))
+
+#undef DIM
+#undef DTYPE
+#undef FRAME
+#undef INSTANTIATE

--- a/src/PointwiseFunctions/GeneralRelativity/SpacetimeDerivativeOfGothG.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/SpacetimeDerivativeOfGothG.hpp
@@ -1,0 +1,53 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/ContainerHelpers.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace gr {
+/// @{
+/*!
+ * \ingroup GeneralRelativityGroup
+ * \brief Computes spacetime derivative of
+ * \f$ \mathfrak{g}^{ab}\equiv (-g)^{1/2} g^{ab} \f$.
+ *
+ * \details Computes the spacetime derivative of
+ * \f$ \mathfrak{g}^{ab}\equiv (-g)^{1/2} g^{ab} \f$, defined
+ * in \cite Misner1973. Using \f$ (-g)^{1/2} = \alpha (\gamma)^{1/2} \f$, where
+ * \f$ \alpha \f$ is the lapse and \f$ \gamma \f$ is the determinant of the
+ * spatial metric (\cite BaumgarteShapiro), the derivative of
+ * \f$ \mathfrak{g}^{ab} \f$ expands out to
+ * \f{align}{
+ *   \partial_c \mathfrak{g}^{ab} &= \left[\partial_c \alpha \gamma^{1/2}
+ *   + \frac{1}{2} \alpha \partial_c \gamma \gamma^{-1/2} \right] g^{ab}
+ *   - \alpha \gamma^{1/2} g^{ad} g^{be} \partial_c g_{de}.
+ * \f}
+ */
+template <typename DataType, size_t SpatialDim, typename Frame>
+void spacetime_deriv_of_goth_g(
+    gsl::not_null<tnsr::aBB<DataType, SpatialDim, Frame>*> da_goth_g,
+    const tnsr::AA<DataType, SpatialDim, Frame>& inverse_spacetime_metric,
+    const tnsr::abb<DataType, SpatialDim, Frame>& da_spacetime_metric,
+    const Scalar<DataType>& lapse,
+    const Scalar<DataType>& dt_lapse,
+    const tnsr::i<DataType, SpatialDim, Frame>& deriv_lapse,
+    const Scalar<DataType>& sqrt_det_spatial_metric,
+    const tnsr::a<DataType, SpatialDim, Frame>& da_det_spatial_metric);
+
+template <typename DataType, size_t SpatialDim, typename Frame>
+tnsr::aBB<DataType, SpatialDim, Frame> spacetime_deriv_of_goth_g(
+    const tnsr::AA<DataType, SpatialDim, Frame>& inverse_spacetime_metric,
+    const tnsr::abb<DataType, SpatialDim, Frame>& da_spacetime_metric,
+    const Scalar<DataType>& lapse,
+    const Scalar<DataType>& dt_lapse,
+    const tnsr::i<DataType, SpatialDim, Frame>& deriv_lapse,
+    const Scalar<DataType>& sqrt_det_spatial_metric,
+    const tnsr::a<DataType, SpatialDim, Frame>& da_det_spatial_metric);
+/// @}
+}  // namespace gr

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/CMakeLists.txt
@@ -12,6 +12,7 @@ set(LIBRARY_SOURCES
   Test_ProjectionOperators.cpp
   Test_Psi4.cpp
   Test_Ricci.cpp
+  Test_SpacetimeDerivativeOfGothG.cpp
   Test_Tags.cpp
   Test_Transform.cpp
   Test_WeylElectric.cpp

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/SpacetimeDerivativeOfGothG.py
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/SpacetimeDerivativeOfGothG.py
@@ -1,0 +1,34 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+
+# Functions testing SpacetimeDerivativeOfGothG
+
+
+def spacetime_deriv_of_goth_g(
+    inverse_spacetime_metric,
+    da_spacetime_metric,
+    lapse,
+    dt_lapse,
+    deriv_lapse,
+    sqrt_det_spatial_metric,
+    da_det_spatial_metric,
+):
+    da_lapse = np.array([dt_lapse])
+    for d_lapse in deriv_lapse:
+        da_lapse = np.append(da_lapse, d_lapse)
+    return np.tensordot(
+        da_lapse * sqrt_det_spatial_metric
+        + 0.5 * lapse * da_det_spatial_metric / sqrt_det_spatial_metric,
+        inverse_spacetime_metric,
+        axes=0,
+    ) - lapse * sqrt_det_spatial_metric * np.einsum(
+        "im,jn,hmn",
+        inverse_spacetime_metric,
+        inverse_spacetime_metric,
+        da_spacetime_metric,
+    )
+
+
+# End functions for testing SpacetimeDerivativeOfGothG

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_SpacetimeDerivativeOfGothG.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_SpacetimeDerivativeOfGothG.cpp
@@ -1,0 +1,44 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <string>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Framework/CheckWithRandomValues.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
+#include "PointwiseFunctions/GeneralRelativity/SpacetimeDerivativeOfGothG.hpp"
+
+namespace gr {
+
+template <typename DataType, size_t SpatialDim>
+void test_compute_spacetime_deriv_of_goth_g(const DataType& used_for_size) {
+  pypp::check_with_random_values<1>(
+      static_cast<tnsr::aBB<DataVector, SpatialDim, Frame::Inertial> (*)(
+          const tnsr::AA<DataType, SpatialDim, Frame::Inertial>&,
+          const tnsr::abb<DataType, SpatialDim, Frame::Inertial>&,
+          const Scalar<DataType>&,
+          const Scalar<DataType>&,
+          const tnsr::i<DataType, SpatialDim, Frame::Inertial>&,
+          const Scalar<DataType>&,
+          const tnsr::a<DataType, SpatialDim, Frame::Inertial>&)>(
+          &spacetime_deriv_of_goth_g<DataType, SpatialDim, Frame::Inertial>),
+      "SpacetimeDerivativeOfGothG", "spacetime_deriv_of_goth_g",
+      {{{0.0, 1.0}}}, used_for_size);
+}
+
+SPECTRE_TEST_CASE(
+    "Unit.PointwiseFunctions.GeneralRelativity.SpacetimeDerivativeOfGothG",
+    "[PointwiseFunctions][Unit]") {
+  pypp::SetupLocalPythonEnvironment local_python_env(
+      "PointwiseFunctions/GeneralRelativity/");
+  const DataVector used_for_size(5);
+  test_compute_spacetime_deriv_of_goth_g<DataVector, 1>(used_for_size);
+  test_compute_spacetime_deriv_of_goth_g<DataVector, 3>(used_for_size);
+}
+
+}  // namespace gr


### PR DESCRIPTION
## Proposed changes

<!--
At a high level, describe what this PR does.
-->

Adds a function to compute the spacetime derivative of goth(g), defined as the product of the spacetime metric and square root of the absolute value of its determinant.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [x] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [x] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [x] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

This quantity is defined on p. 466 in Misner, Thorne, and Wheeler, _Gravitation_.

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
