### PR TITLE
Add MortarSize hash and pup function to inbox tag

### DIFF
--- a/src/Evolution/DiscontinuousGalerkin/InboxTags.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/InboxTags.hpp
@@ -199,6 +199,8 @@ struct BoundaryCorrectionAndGhostCellsInbox {
 
     return ss.str();
   }
+
+  void pup(PUP::er& /*p*/) {}
 };
 
 /*!

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/MortarHelpers.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/MortarHelpers.hpp
@@ -24,6 +24,7 @@
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "NumericalAlgorithms/Spectral/Projection.hpp"
 #include "Utilities/Algorithm.hpp"
+#include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeArray.hpp"
@@ -127,5 +128,38 @@ Variables<Tags> project_from_mortar(const Variables<Tags>& vars,
                       mortar_size);
   return result;
 }
+/// @}
+
+/// @{
+/// \brief Performs a perfect hash of the mortars into $2^{d-1}$ slots on the
+/// range $[0, 2^{d-1})$.
+///
+/// This is particularly useful when hashing into statically-sized maps based
+/// on the number of dimensions.
+template <size_t DimMinusOne>
+size_t hash(const std::array<Spectral::ChildSize, DimMinusOne>& mortar_size) {
+  if constexpr (DimMinusOne == 2) {
+    return static_cast<size_t>(mortar_size[0]) % 2 +
+           2 * (static_cast<size_t>(mortar_size[1]) % 2);
+  } else if constexpr (DimMinusOne == 1) {
+    return static_cast<size_t>(mortar_size[0]) % 2;
+  } else if constexpr (DimMinusOne == 0) {
+    (void)mortar_size;
+    return 0;
+  } else {
+    static_assert(DimMinusOne == 2 or DimMinusOne == 1 or DimMinusOne == 0);
+  }
+}
+
+template <size_t Dim>
+struct MortarSizeHash {
+  template <size_t MaxSize>
+  static constexpr bool is_perfect = MaxSize == two_to_the(Dim);
+
+  size_t operator()(
+      const std::array<Spectral::ChildSize, Dim - 1>& mortar_size) {
+    return hash(mortar_size);
+  }
+};
 /// @}
 }  // namespace dg

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Test_MortarHelpers.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Test_MortarHelpers.cpp
@@ -317,11 +317,40 @@ void test_projections() {
     }
   }
 }
+
+void test_hash() {
+  CHECK(dg::MortarSizeHash<1>{}({}) == 0);
+
+  CHECK(dg::MortarSizeHash<2>{}({Spectral::ChildSize::LowerHalf}) == 0);
+  CHECK(dg::MortarSizeHash<2>{}({Spectral::ChildSize::Full}) == 0);
+  CHECK(dg::MortarSizeHash<2>{}({Spectral::ChildSize::UpperHalf}) == 1);
+
+  CHECK(dg::MortarSizeHash<3>{}({Spectral::ChildSize::LowerHalf,
+                                 Spectral::ChildSize::LowerHalf}) == 0);
+  CHECK(dg::MortarSizeHash<3>{}({Spectral::ChildSize::UpperHalf,
+                                 Spectral::ChildSize::LowerHalf}) == 1);
+  CHECK(dg::MortarSizeHash<3>{}(
+            {Spectral::ChildSize::Full, Spectral::ChildSize::LowerHalf}) == 0);
+
+  CHECK(dg::MortarSizeHash<3>{}({Spectral::ChildSize::LowerHalf,
+                                 Spectral::ChildSize::UpperHalf}) == 2);
+  CHECK(dg::MortarSizeHash<3>{}({Spectral::ChildSize::UpperHalf,
+                                 Spectral::ChildSize::UpperHalf}) == 3);
+  CHECK(dg::MortarSizeHash<3>{}(
+            {Spectral::ChildSize::Full, Spectral::ChildSize::UpperHalf}) == 2);
+
+  CHECK(dg::MortarSizeHash<3>{}(
+            {Spectral::ChildSize::LowerHalf, Spectral::ChildSize::Full}) == 0);
+  CHECK(dg::MortarSizeHash<3>{}(
+            {Spectral::ChildSize::UpperHalf, Spectral::ChildSize::Full}) == 1);
+  CHECK(dg::MortarSizeHash<3>{}(
+            {Spectral::ChildSize::Full, Spectral::ChildSize::Full}) == 0);
+}
 }  // namespace
 
-SPECTRE_TEST_CASE("Unit.DG.MortarHelpers",
-                  "[Unit][NumericalAlgorithms]") {
+SPECTRE_TEST_CASE("Unit.DG.MortarHelpers", "[Unit][NumericalAlgorithms]") {
   test_mortar_mesh();
   test_mortar_size();
   test_projections();
+  test_hash();
 }

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Test_MortarHelpers.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Test_MortarHelpers.cpp
@@ -39,10 +39,8 @@ Mesh<Dim> lgl_mesh(const std::array<size_t, Dim>& extents) {
   return {extents, Spectral::Basis::Legendre,
           Spectral::Quadrature::GaussLobatto};
 }
-}  // namespace
 
-SPECTRE_TEST_CASE("Unit.DG.MortarHelpers.mortar_mesh",
-                  "[Unit][NumericalAlgorithms]") {
+void test_mortar_mesh() {
   CHECK(dg::mortar_mesh(lgl_mesh<0>({}), lgl_mesh<0>({})) == lgl_mesh<0>({}));
   CHECK(dg::mortar_mesh(lgl_mesh<1>({{3}}), lgl_mesh<1>({{5}})) ==
         lgl_mesh<1>({{5}}));
@@ -50,8 +48,7 @@ SPECTRE_TEST_CASE("Unit.DG.MortarHelpers.mortar_mesh",
         lgl_mesh<2>({{3, 5}}));
 }
 
-SPECTRE_TEST_CASE("Unit.DG.MortarHelpers.mortar_size",
-                  "[Unit][NumericalAlgorithms]") {
+void test_mortar_size() {
   CHECK(dg::mortar_size(ElementId<1>(0, {{{0, 0}}}),
                         ElementId<1>(0, {{{5, 2}}}), 0, {}) ==
         std::array<Spectral::MortarSize, 0>{});
@@ -135,7 +132,6 @@ SPECTRE_TEST_CASE("Unit.DG.MortarHelpers.mortar_size",
             {Spectral::MortarSize::UpperHalf, Spectral::MortarSize::Full}});
 }
 
-namespace {
 struct Var : db::SimpleTag {
   using type = Scalar<DataVector>;
 };
@@ -172,10 +168,8 @@ DataVector basis6(const DataVector& coords) {
          (-5. + square(coords) *
                     (105. + square(coords) * (-315. + square(coords) * 231.)));
 }
-}  // namespace
 
-SPECTRE_TEST_CASE("Unit.DG.MortarHelpers.projections",
-                  "[Unit][NumericalAlgorithms]") {
+void test_projections() {
   using Spectral::MortarSize;
   const auto all_mortar_sizes = {MortarSize::Full, MortarSize::LowerHalf,
                                  MortarSize::UpperHalf};
@@ -322,4 +316,12 @@ SPECTRE_TEST_CASE("Unit.DG.MortarHelpers.projections",
       }
     }
   }
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.DG.MortarHelpers",
+                  "[Unit][NumericalAlgorithms]") {
+  test_mortar_mesh();
+  test_mortar_size();
+  test_projections();
 }


### PR DESCRIPTION
## Proposed changes

- pup is needed for some type inference things so I don't have to write more code into Charm headers.
- the hash is needed for having waitfree neighbor communication within a node.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
