### PR TITLE
Add copy of vector of EaDT from options to cache

### DIFF
--- a/src/Evolution/Actions/RunEventsAndDenseTriggers.hpp
+++ b/src/Evolution/Actions/RunEventsAndDenseTriggers.hpp
@@ -310,7 +310,7 @@ struct InitializeRunEventsAndDenseTriggers {
       const ArrayIndex& /*array_index*/, const ActionList /*meta*/,
       const ParallelComponent* const /*component*/) {
     ::Initialization::mutate_assign<simple_tags>(make_not_null(&box),
-                                               std::nullopt);
+                                                 std::nullopt);
     return {Parallel::AlgorithmExecution::Continue, std::nullopt};
   }
 };

--- a/src/Evolution/Actions/RunEventsAndDenseTriggers.hpp
+++ b/src/Evolution/Actions/RunEventsAndDenseTriggers.hpp
@@ -300,6 +300,8 @@ struct InitializeRunEventsAndDenseTriggers {
   using simple_tags_from_options =
       tmpl::list<evolution::Tags::EventsAndDenseTriggers>;
   using simple_tags = tmpl::list<Tags::PreviousTriggerTime>;
+  using mutable_global_cache_tags =
+      tmpl::list<evolution::Tags::EventsAndDenseTriggersOptions>;
 
   template <typename DbTags, typename... InboxTags, typename Metavariables,
             typename ArrayIndex, typename ActionList,

--- a/src/Evolution/EventsAndDenseTriggers/EventsAndDenseTriggers.cpp
+++ b/src/Evolution/EventsAndDenseTriggers/EventsAndDenseTriggers.cpp
@@ -10,6 +10,11 @@
 #include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
 
 namespace evolution {
+void DenseTriggerAndEventsConstruction::pup(PUP::er& p) {
+  p | trigger;
+  p | events;
+}
+
 void EventsAndDenseTriggers::TriggerRecord::pup(PUP::er& p) {
   p | next_check;
   p | is_triggered;

--- a/src/Evolution/EventsAndDenseTriggers/EventsAndDenseTriggers.hpp
+++ b/src/Evolution/EventsAndDenseTriggers/EventsAndDenseTriggers.hpp
@@ -329,7 +329,7 @@ struct Options::create_from_yaml<evolution::EventsAndDenseTriggers> {
   using type = evolution::EventsAndDenseTriggers;
   template <typename Metavariables>
   static type create(const Options::Option& options) {
-    return type(options.parse_as<typename type::ConstructionType,
-                                 Metavariables>());
+    return type(
+        options.parse_as<typename type::ConstructionType, Metavariables>());
   }
 };

--- a/src/Evolution/EventsAndDenseTriggers/EventsAndDenseTriggers.hpp
+++ b/src/Evolution/EventsAndDenseTriggers/EventsAndDenseTriggers.hpp
@@ -51,6 +51,29 @@ struct PreviousTriggerTime : db::SimpleTag {
 };
 }  // namespace Tags
 
+/*!
+ * \brief Struct for holding a single DenseTrigger and Event%s to be run on that
+ * trigger.
+ */
+struct DenseTriggerAndEventsConstruction {
+  struct Trigger {
+    using type = std::unique_ptr<::DenseTrigger>;
+    static constexpr Options::String help = "Determines when the Events run.";
+  };
+  struct Events {
+    using type = std::vector<std::unique_ptr<::Event>>;
+    static constexpr Options::String help =
+        "These events run when the Trigger fires.";
+  };
+  static constexpr Options::String help =
+      "Events that run when the Trigger fires.";
+  using options = tmpl::list<Trigger, Events>;
+  void pup(PUP::er& p);
+
+  std::unique_ptr<::DenseTrigger> trigger;
+  std::vector<std::unique_ptr<::Event>> events;
+};
+
 /// \ingroup EventsAndTriggersGroup
 /// Class that checks dense triggers and runs events
 class EventsAndDenseTriggers {
@@ -61,28 +84,7 @@ class EventsAndDenseTriggers {
   };
 
  public:
-  struct TriggerAndEvents {
-    struct Trigger {
-      using type = std::unique_ptr<::DenseTrigger>;
-      static constexpr Options::String help = "Determines when the Events run.";
-    };
-    struct Events {
-      using type = std::vector<std::unique_ptr<::Event>>;
-      static constexpr Options::String help =
-          "These events run when the Trigger fires.";
-    };
-    static constexpr Options::String help =
-        "Events that run when the Trigger fires.";
-    using options = tmpl::list<Trigger, Events>;
-    void pup(PUP::er& p) {
-      p | trigger;
-      p | events;
-    }
-    std::unique_ptr<::DenseTrigger> trigger;
-    std::vector<std::unique_ptr<::Event>> events;
-  };
-
-  using ConstructionType = std::vector<TriggerAndEvents>;
+  using ConstructionType = std::vector<DenseTriggerAndEventsConstruction>;
 
  private:
   struct TriggerRecord {

--- a/src/Evolution/EventsAndDenseTriggers/Tags.hpp
+++ b/src/Evolution/EventsAndDenseTriggers/Tags.hpp
@@ -17,7 +17,7 @@ namespace OptionTags {
  * OptionTags::EventsAndTriggers
  */
 struct EventsAndDenseTriggers {
-  using type = evolution::EventsAndDenseTriggers;
+  using type = std::vector<evolution::DenseTriggerAndEventsConstruction>;
   static constexpr Options::String help = "Events to run at arbitrary times";
 };
 }  // namespace OptionTags
@@ -31,8 +31,43 @@ struct EventsAndDenseTriggers : db::SimpleTag {
   using type = evolution::EventsAndDenseTriggers;
   using option_tags = tmpl::list<OptionTags::EventsAndDenseTriggers>;
   static constexpr bool pass_metavariables = false;
-  static type create_from_options(const type& events_and_triggers) {
-    return deserialize<type>(serialize(events_and_triggers).data());
+  static type create_from_options(
+      const std::vector<evolution::DenseTriggerAndEventsConstruction>&
+          construction) {
+    // The deserialize(serialize()) is to deal with unique_ptrs in the data
+    // structures since we don't have `get_clone` implemented for
+    // triggers/events
+    return deserialize<type>(
+        serialize(
+            type{deserialize<
+                std::vector<evolution::DenseTriggerAndEventsConstruction>>(
+                serialize(construction).data())})
+            .data());
+  }
+};
+
+/*!
+ * \brief Vector of DenseTrigger%s and Event%s used to construct
+ * `evolution::Tags::EventsAndDenseTriggers`.
+ *
+ * \warning Upon option construction, this tag will NOT necessarily contain all
+ * of the DenseTrigger%s and Event%s that will be used in the evolution. Some
+ * may be added during other `Parallel::Phase`s of the execution using the
+ * `evolution::EventsAndDenseTrigger::add_trigger_and_events` method. Therefore,
+ * this tag should likely be placed in the `mutable_global_cache_tags` rather
+ * than the `const_global_cache_tags`.
+ */
+struct EventsAndDenseTriggersOptions : db::SimpleTag {
+  using type = std::vector<evolution::DenseTriggerAndEventsConstruction>;
+  using option_tags = tmpl::list<OptionTags::EventsAndDenseTriggers>;
+  static constexpr bool pass_metavariables = false;
+  static type create_from_options(const type& option) {
+    // The deserialize(serialize()) is to deal with unique_ptrs in the data
+    // structures since we don't have `get_clone` implemented for
+    // triggers/events
+    return deserialize<
+        std::vector<evolution::DenseTriggerAndEventsConstruction>>(
+        serialize(option).data());
   }
 };
 }  // namespace Tags

--- a/tests/Unit/ControlSystem/Actions/Test_InitializeMeasurements.cpp
+++ b/tests/Unit/ControlSystem/Actions/Test_InitializeMeasurements.cpp
@@ -222,8 +222,11 @@ void test_initialize_measurements(const bool ab_active, const bool c_active) {
   functions.emplace("B", timescale->get_clone());
   functions.emplace("C", timescale->get_clone());
 
-  MockRuntimeSystem runner{{::Verbosity::Silent, measurements_per_update},
-                           {std::move(functions), std::move(timescales)}};
+  MockRuntimeSystem runner{
+      {::Verbosity::Silent, measurements_per_update},
+      {std::move(functions),
+       std::vector<evolution::DenseTriggerAndEventsConstruction>{},
+       std::move(timescales)}};
   ActionTesting::emplace_array_component_and_initialize<component>(
       make_not_null(&runner), ActionTesting::NodeId{0},
       ActionTesting::LocalCoreId{0}, 0,

--- a/tests/Unit/Evolution/EventsAndDenseTriggers/Test_EventsAndDenseTriggers.cpp
+++ b/tests/Unit/Evolution/EventsAndDenseTriggers/Test_EventsAndDenseTriggers.cpp
@@ -390,7 +390,7 @@ struct MutatingMetavariables {
 
 void test_mutating_trigger() {
   evolution::EventsAndDenseTriggers events_and_dense_triggers(
-      make_vector(evolution::EventsAndDenseTriggers::TriggerAndEvents{
+      make_vector(evolution::DenseTriggerAndEventsConstruction{
           std::make_unique<MutatingTrigger>(),
           make_vector<std::unique_ptr<Event>>(
               std::make_unique<TestEvent<EventLabels::A>>())}));

--- a/tests/Unit/Evolution/EventsAndDenseTriggers/Test_Tags.cpp
+++ b/tests/Unit/Evolution/EventsAndDenseTriggers/Test_Tags.cpp
@@ -12,4 +12,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.EventsAndDenseTriggers.Tags",
                   "[Unit][Evolution]") {
   TestHelpers::db::test_simple_tag<evolution::Tags::EventsAndDenseTriggers>(
       "EventsAndDenseTriggers");
+  TestHelpers::db::test_simple_tag<
+      evolution::Tags::EventsAndDenseTriggersOptions>(
+      "EventsAndDenseTriggersOptions");
 }


### PR DESCRIPTION
## Proposed changes

Even though the EventsAndDenseTriggers object itself is mutated inside the element DataBox, the actual dense triggers and events aren't changed and can therefore, in theory, be available in the GlobalCache. This PR adds a new mutable cache tag that stores the vector of dense triggers and events. The reason it is mutable is because EaDT has a method `add_trigger_and_events` where you can add more triggers/events during execution. This means that in order to keep the cache tag up to date, it will have to be mutated. The mutation is left to whatever adds the new triggers/events. Currently, this PR doesn't add any of the special mutations that are needed (basically the control system triggers/events).

This PR will be needed for interpolation framework changes.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
