### PR TITLE
Switch elliptic DG to a primal formulation 

### DIFF
--- a/src/Domain/Tags.hpp
+++ b/src/Domain/Tags.hpp
@@ -213,6 +213,34 @@ struct DetInvJacobianCompute : db::ComputeTag,
 
 /// \ingroup DataBoxTagsGroup
 /// \ingroup ComputationalDomainGroup
+/// \brief The determinant of the Jacobian from the source frame to the target
+/// frame.
+template <typename SourceFrame, typename TargetFrame>
+struct DetJacobian : db::SimpleTag {
+  using type = Scalar<DataVector>;
+  static std::string name() {
+    return "DetJacobian(" + get_output(SourceFrame{}) + "," +
+           get_output(TargetFrame{}) + ")";
+  }
+};
+
+/// \ingroup DataBoxTagsGroup
+/// \ingroup ComputationalDomainGroup
+/// \brief The inverse Jacobian times the determinant of the Jacobian.
+///
+/// This quantity is divergence-free analytically. See
+/// `::dg::metric_identity_det_jac_times_inv_jac` for more information.
+template <size_t Dim, typename SourceFrame, typename TargetFrame>
+struct DetTimesInvJacobian : db::SimpleTag {
+  using type = ::InverseJacobian<DataVector, Dim, SourceFrame, TargetFrame>;
+  static std::string name() {
+    return "DetTimesInvJacobian(" + get_output(SourceFrame{}) + "," +
+           get_output(TargetFrame{}) + ")";
+  }
+};
+
+/// \ingroup DataBoxTagsGroup
+/// \ingroup ComputationalDomainGroup
 /// Base tag for boundary data needed for updating the variables.
 struct VariablesBoundaryData : db::BaseTag {};
 

--- a/src/Elliptic/DiscontinuousGalerkin/Actions/ApplyOperator.hpp
+++ b/src/Elliptic/DiscontinuousGalerkin/Actions/ApplyOperator.hpp
@@ -408,6 +408,9 @@ struct ReceiveMortarDataAndApplyOperator<
         db::get<domain::Tags::Faces<
             Dim, domain::Tags::DetSurfaceJacobian<Frame::ElementLogical,
                                                   Frame::Inertial>>>(box),
+        db::get<domain::Tags::Faces<
+            Dim, domain::Tags::DetTimesInvJacobian<Dim, Frame::ElementLogical,
+                                                   Frame::Inertial>>>(box),
         db::get<::Tags::Mortars<domain::Tags::Mesh<Dim - 1>, Dim>>(box),
         db::get<::Tags::Mortars<::Tags::MortarSize<Dim - 1>, Dim>>(box),
         db::get<::Tags::Mortars<domain::Tags::DetSurfaceJacobian<
@@ -601,6 +604,9 @@ struct ImposeInhomogeneousBoundaryConditionsOnSource<
         db::get<domain::Tags::Faces<
             Dim, domain::Tags::DetSurfaceJacobian<Frame::ElementLogical,
                                                   Frame::Inertial>>>(box),
+        db::get<domain::Tags::Faces<
+            Dim, domain::Tags::DetTimesInvJacobian<Dim, Frame::ElementLogical,
+                                                   Frame::Inertial>>>(box),
         db::get<::Tags::Mortars<domain::Tags::Mesh<Dim - 1>, Dim>>(box),
         db::get<::Tags::Mortars<::Tags::MortarSize<Dim - 1>, Dim>>(box),
         db::get<elliptic::dg::Tags::PenaltyParameter>(box),

--- a/src/Elliptic/DiscontinuousGalerkin/SubdomainOperator/SubdomainOperator.hpp
+++ b/src/Elliptic/DiscontinuousGalerkin/SubdomainOperator/SubdomainOperator.hpp
@@ -162,6 +162,9 @@ struct SubdomainOperator
                           domain::Tags::UnnormalizedFaceNormalMagnitude<Dim>>,
       domain::Tags::Faces<Dim, domain::Tags::DetSurfaceJacobian<
                                    Frame::ElementLogical, Frame::Inertial>>,
+      domain::Tags::Faces<
+          Dim, domain::Tags::DetTimesInvJacobian<Dim, Frame::ElementLogical,
+                                                 Frame::Inertial>>,
       ::Tags::Mortars<domain::Tags::Mesh<Dim - 1>, Dim>,
       ::Tags::Mortars<::Tags::MortarSize<Dim - 1>, Dim>,
       ::Tags::Mortars<domain::Tags::DetSurfaceJacobian<Frame::ElementLogical,

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/ApplyMassMatrix.cpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/ApplyMassMatrix.cpp
@@ -13,6 +13,14 @@
 namespace dg::detail {
 
 template <>
+void apply_mass_matrix_impl<0>(const gsl::not_null<double*> /*data*/,
+                               const Mesh<0>& /*mesh*/) {}
+
+template <>
+void apply_inverse_mass_matrix_impl<0>(const gsl::not_null<double*> /*data*/,
+                                       const Mesh<0>& /*mesh*/) {}
+
+template <>
 void apply_mass_matrix_impl<1>(const gsl::not_null<double*> data,
                                const Mesh<1>& mesh) {
   const size_t x_size = mesh.extents(0);

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/MetricIdentityJacobian.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/MetricIdentityJacobian.hpp
@@ -35,7 +35,7 @@ namespace dg {
  * We want to compute \f$J\partial\xi^{\hat{\imath}}/\partial x^i\f$ in such a
  * way that the above metric identity is satisfied numerically/discretely. We
  * refer to the inverse Jacobian computed this way as the "metric
- * indentity-satisfying inverse Jacobian".
+ * identity-satisfying inverse Jacobian".
  *
  * The discretized form, with the Jacobian determinant \f$J\f$ expanded, is
  * given by

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/Tags/OptionsGroup.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/Tags/OptionsGroup.hpp
@@ -22,7 +22,7 @@ struct DiscontinuousGalerkinGroup {
       "Options controlling the discontinuous Galerkin spatial discretization "
       "of the PDE system.\n\n"
       "Contains options such as whether to use the strong or weak form, what "
-      "boundary correction/numerical flud to use, and which quadrature rule to "
+      "boundary correction/numerical flux to use, and which quadrature rule to "
       "use."};
   using group = SpatialDiscretization::OptionTags::SpatialDiscretizationGroup;
 };

--- a/src/NumericalAlgorithms/LinearOperators/CMakeLists.txt
+++ b/src/NumericalAlgorithms/LinearOperators/CMakeLists.txt
@@ -17,6 +17,7 @@ spectre_target_sources(
   PartialDerivatives.cpp
   MeanValue.cpp
   PowerMonitors.cpp
+  WeakDivergence.cpp
   )
 
 spectre_target_headers(

--- a/src/NumericalAlgorithms/LinearOperators/WeakDivergence.cpp
+++ b/src/NumericalAlgorithms/LinearOperators/WeakDivergence.cpp
@@ -1,0 +1,56 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "NumericalAlgorithms/LinearOperators/WeakDivergence.hpp"
+
+#include <cstddef>
+
+#include "DataStructures/ApplyMatrices.hpp"
+#include "DataStructures/Matrix.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+
+template <typename ResultTensor, typename FluxTensor, size_t Dim>
+void logical_weak_divergence(const gsl::not_null<ResultTensor*> div_flux,
+                             const FluxTensor& flux, const Mesh<Dim>& mesh) {
+  // Note: This function hasn't been optimized much at all. Feel free to
+  // optimize if needed!
+  static const Matrix identity_matrix{};
+  for (size_t d = 0; d < Dim; ++d) {
+    auto matrices = make_array<Dim>(std::cref(identity_matrix));
+    gsl::at(matrices, d) =
+        Spectral::differentiation_matrix_transpose(mesh.slice_through(d));
+    for (size_t storage_index = 0; storage_index < div_flux->size();
+         ++storage_index) {
+      const auto div_flux_index = div_flux->get_tensor_index(storage_index);
+      const auto flux_index = prepend(div_flux_index, d);
+      div_flux->get(div_flux_index) +=
+          apply_matrices(matrices, flux.get(flux_index), mesh.extents());
+    }
+  }
+}
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define TENSOR(data) BOOST_PP_TUPLE_ELEM(1, data)
+
+#define INSTANTIATION_SCALAR(r, data)                                    \
+  template void logical_weak_divergence(                                 \
+      const gsl::not_null<Scalar<DataVector>*> div_flux,                 \
+      const tnsr::I<DataVector, DIM(data), Frame::ElementLogical>& flux, \
+      const Mesh<DIM(data)>& mesh);
+#define INSTANTIATION_TENSOR(r, data)                                   \
+  template void logical_weak_divergence(                                \
+      const gsl::not_null<tnsr::TENSOR(data) < DataVector, DIM(data),   \
+                          Frame::Inertial>* > div_flux,                 \
+      const TensorMetafunctions::prepend_spatial_index<                 \
+          tnsr::TENSOR(data) < DataVector, DIM(data), Frame::Inertial>, \
+      DIM(data), UpLo::Up, Frame::ElementLogical > &flux,               \
+      const Mesh<DIM(data)>& mesh);
+
+GENERATE_INSTANTIATIONS(INSTANTIATION_SCALAR, (1, 2, 3))
+GENERATE_INSTANTIATIONS(INSTANTIATION_TENSOR, (1, 2, 3), (i, I))
+
+#undef INSTANTIATION

--- a/src/NumericalAlgorithms/LinearOperators/WeakDivergence.hpp
+++ b/src/NumericalAlgorithms/LinearOperators/WeakDivergence.hpp
@@ -246,3 +246,52 @@ void weak_divergence(
     }
   }
 }
+
+/// @{
+/*!
+ * \brief Compute the weak divergence of fluxes in logical coordinates
+ *
+ * Applies the transpose logical differentiation matrix to the fluxes in each
+ * dimension and sums over dimensions.
+ *
+ * \see weak_divergence
+ */
+template <typename ResultTensor, typename FluxTensor, size_t Dim>
+void logical_weak_divergence(gsl::not_null<ResultTensor*> div_flux,
+                             const FluxTensor& flux, const Mesh<Dim>& mesh);
+
+/*!
+ * \param divergence_of_fluxes Result buffer. Will be resized if necessary.
+ * \param fluxes The fluxes to take the divergence of. Their first index must be
+ * an upper spatial index in element-logical coordinates.
+ * \param mesh The element mesh.
+ * \param add_to_buffer If `true`, add the divergence to the existing values in
+ * `divergence_of_fluxes`. Otherwise, overwrite the existing values.
+ */
+template <typename... ResultTags, typename... FluxTags, size_t Dim>
+void logical_weak_divergence(
+    const gsl::not_null<Variables<tmpl::list<ResultTags...>>*>
+        divergence_of_fluxes,
+    const Variables<tmpl::list<FluxTags...>>& fluxes, const Mesh<Dim>& mesh,
+    const bool add_to_buffer = false) {
+  static_assert(
+      (... and
+       std::is_same_v<tmpl::front<typename FluxTags::type::index_list>,
+                      SpatialIndex<Dim, UpLo::Up, Frame::ElementLogical>>),
+      "The first index of each flux must be an upper spatial index in "
+      "element-logical coordinates.");
+  static_assert(
+      (... and
+       std::is_same_v<
+           typename ResultTags::type,
+           TensorMetafunctions::remove_first_index<typename FluxTags::type>>),
+      "The result tensors must have the same type as the flux tensors with "
+      "their first index removed.");
+  if (not add_to_buffer) {
+    divergence_of_fluxes->initialize(mesh.number_of_grid_points(), 0.);
+  }
+  EXPAND_PACK_LEFT_TO_RIGHT(logical_weak_divergence(
+      make_not_null(&get<ResultTags>(*divergence_of_fluxes)),
+      get<FluxTags>(fluxes), mesh));
+}
+/// @}

--- a/src/NumericalAlgorithms/LinearOperators/WeakDivergence.hpp
+++ b/src/NumericalAlgorithms/LinearOperators/WeakDivergence.hpp
@@ -52,8 +52,8 @@
  * This function computes the volume term:
  *
  * \f{align*}{
- * \int_{\Omega}d^n x\,F^i_{\breve{\jmath}} \phi_{\breve{\jmath}} \partial_i
- *    \phi_{\breve{\imath}}
+ * \frac{1}{w_\breve{\imath}} \int_{\Omega}d^n x \,
+ *   F^i_{\breve{\jmath}} \phi_{\breve{\jmath}} \partial_i \phi_{\breve{\imath}}
  * \f}
  *
  * \note When using Gauss-Lobatto points the numerical values of the

--- a/src/NumericalAlgorithms/Spectral/Spectral.cpp
+++ b/src/NumericalAlgorithms/Spectral/Spectral.cpp
@@ -448,6 +448,17 @@ struct DifferentiationMatrixGenerator {
 };
 
 template <Basis BasisType, Quadrature QuadratureType>
+struct DifferentiationMatrixTransposeGenerator {
+  Matrix operator()(const size_t num_points) const {
+    Matrix diff_matrix_transpose =
+        DifferentiationMatrixGenerator<BasisType, QuadratureType>{}.operator()(
+            num_points);
+    blaze::transpose(diff_matrix_transpose);
+    return diff_matrix_transpose;
+  }
+};
+
+template <Basis BasisType, Quadrature QuadratureType>
 struct WeakFluxDifferentiationMatrixGenerator {
   Matrix operator()(const size_t num_points) const {
     if (BasisType != Basis::Legendre) {
@@ -595,6 +606,8 @@ const DataVector& quadrature_weights(const size_t num_points) {
 
 PRECOMPUTED_SPECTRAL_QUANTITY(differentiation_matrix, Matrix,
                               DifferentiationMatrixGenerator)
+PRECOMPUTED_SPECTRAL_QUANTITY(differentiation_matrix_transpose, Matrix,
+                              DifferentiationMatrixTransposeGenerator)
 PRECOMPUTED_SPECTRAL_QUANTITY(weak_flux_differentiation_matrix, Matrix,
                               WeakFluxDifferentiationMatrixGenerator)
 PRECOMPUTED_SPECTRAL_QUANTITY(integration_matrix, Matrix,
@@ -852,6 +865,7 @@ decltype(auto) get_spectral_quantity_for_mesh(F&& f, const Mesh<1>& mesh) {
 SPECTRAL_QUANTITY_FOR_MESH(collocation_points, DataVector)
 SPECTRAL_QUANTITY_FOR_MESH(quadrature_weights, DataVector)
 SPECTRAL_QUANTITY_FOR_MESH(differentiation_matrix, Matrix)
+SPECTRAL_QUANTITY_FOR_MESH(differentiation_matrix_transpose, Matrix)
 SPECTRAL_QUANTITY_FOR_MESH(weak_flux_differentiation_matrix, Matrix)
 SPECTRAL_QUANTITY_FOR_MESH(integration_matrix, Matrix)
 SPECTRAL_QUANTITY_FOR_MESH(modal_to_nodal_matrix, Matrix)

--- a/src/NumericalAlgorithms/Spectral/Spectral.hpp
+++ b/src/NumericalAlgorithms/Spectral/Spectral.hpp
@@ -220,6 +220,13 @@ const Matrix& differentiation_matrix(const Mesh<1>& mesh);
 /*!
  * \brief %Matrix used to compute the divergence of the flux in weak form.
  *
+ * This is the transpose of the differentiation matrix multiplied by quadrature
+ * weights that appear in DG integrals:
+ *
+ * \begin{equation}
+ * \frac{D^T_{ij}} \frac{w_j}{w_i}
+ * \end{equation}
+ *
  * \param num_points The number of collocation points
  */
 template <Basis BasisType, Quadrature QuadratureType>

--- a/src/NumericalAlgorithms/Spectral/Spectral.hpp
+++ b/src/NumericalAlgorithms/Spectral/Spectral.hpp
@@ -192,6 +192,7 @@ const DataVector& quadrature_weights(size_t num_points);
  */
 const DataVector& quadrature_weights(const Mesh<1>& mesh);
 
+/// @{
 /*!
  * \brief %Matrix used to compute the derivative of a function.
  *
@@ -209,13 +210,19 @@ const DataVector& quadrature_weights(const Mesh<1>& mesh);
  */
 template <Basis BasisType, Quadrature QuadratureType>
 const Matrix& differentiation_matrix(size_t num_points);
+template <Basis BasisType, Quadrature QuadratureType>
+const Matrix& differentiation_matrix_transpose(size_t num_points);
+/// @}
 
+/// @{
 /*!
  * \brief Differentiation matrix for a one-dimensional mesh.
  *
  * \see differentiation_matrix(size_t)
  */
 const Matrix& differentiation_matrix(const Mesh<1>& mesh);
+const Matrix& differentiation_matrix_transpose(const Mesh<1>& mesh);
+/// @}
 
 /*!
  * \brief %Matrix used to compute the divergence of the flux in weak form.

--- a/tests/InputFiles/Elasticity/HalfSpaceMirror.yaml
+++ b/tests/InputFiles/Elasticity/HalfSpaceMirror.yaml
@@ -14,7 +14,7 @@ OutputFileChecks:
     Subfile: /ErrorNorms.dat
     FileGlob: ElasticHalfSpaceMirrorReductions.h5
     SkipColumns: [0, 1, 2]
-    AbsoluteTolerance: 5.e-4
+    AbsoluteTolerance: 6.e-4
 
 ---
 

--- a/tests/InputFiles/Poisson/ProductOfSinusoids1D.yaml
+++ b/tests/InputFiles/Poisson/ProductOfSinusoids1D.yaml
@@ -15,7 +15,7 @@ OutputFileChecks:
     Subfile: /ErrorNorms.dat
     FileGlob: PoissonProductOfSinusoids1DReductions.h5
     SkipColumns: [0, 1, 2]
-    AbsoluteTolerance: 0.004
+    AbsoluteTolerance: 0.005
 
 ---
 

--- a/tests/InputFiles/Poisson/ProductOfSinusoids2D.yaml
+++ b/tests/InputFiles/Poisson/ProductOfSinusoids2D.yaml
@@ -13,7 +13,7 @@ OutputFileChecks:
     Subfile: /ErrorNorms.dat
     FileGlob: PoissonProductOfSinusoids2DReductions.h5
     SkipColumns: [0, 1, 2]
-    AbsoluteTolerance: 0.007
+    AbsoluteTolerance: 0.005
 
 ---
 

--- a/tests/InputFiles/Poisson/ProductOfSinusoids3D.yaml
+++ b/tests/InputFiles/Poisson/ProductOfSinusoids3D.yaml
@@ -14,7 +14,7 @@ OutputFileChecks:
     Subfile: /ErrorNorms.dat
     FileGlob: PoissonProductOfSinusoids3DReductions.h5
     SkipColumns: [0, 1, 2]
-    AbsoluteTolerance: 0.004
+    AbsoluteTolerance: 0.005
 
 ---
 
@@ -57,7 +57,7 @@ DomainCreator:
 Discretization:
   DiscontinuousGalerkin:
     PenaltyParameter: 1.
-    Massive: True
+    Massive: False
     Quadrature: GaussLobatto
 
 Observers:

--- a/tests/InputFiles/Xcts/BinaryBlackHole.yaml
+++ b/tests/InputFiles/Xcts/BinaryBlackHole.yaml
@@ -6,6 +6,9 @@ Testing:
   Check: parse
   Timeout: 30
   Priority: High
+ExpectedOutput:
+  - BbhReductions.h5
+  - BbhVolume0.h5
 
 ---
 

--- a/tests/InputFiles/Xcts/KerrSchild.yaml
+++ b/tests/InputFiles/Xcts/KerrSchild.yaml
@@ -14,7 +14,7 @@ OutputFileChecks:
     Subfile: /ErrorNorms.dat
     FileGlob: KerrSchildReductions.h5
     SkipColumns: [0, 1, 2]
-    AbsoluteTolerance: 0.08
+    AbsoluteTolerance: 0.04
 
 ---
 
@@ -83,7 +83,7 @@ NonlinearSolver:
       # Stop after 2 iteration so this test runs quickly. Set MaxIterations to
       # ~20 for runs at higher resolution (most nonlinear problems need ~5
       # iterations, so 20 is a safe setting).
-      MaxIterations: 2
+      MaxIterations: 20
       RelativeResidual: 0.
       AbsoluteResidual: 1.e-10
     SufficientDecrease: 1.e-4

--- a/tests/InputFiles/Xcts/TovStar.yaml
+++ b/tests/InputFiles/Xcts/TovStar.yaml
@@ -14,7 +14,7 @@ OutputFileChecks:
     Subfile: /ErrorNorms.dat
     FileGlob: TovStarReductions.h5
     SkipColumns: [0, 1, 2]
-    AbsoluteTolerance: 1e-6
+    AbsoluteTolerance: 2.e-6
 
 ---
 

--- a/tests/Unit/Domain/Test_Tags.cpp
+++ b/tests/Unit/Domain/Test_Tags.cpp
@@ -50,6 +50,12 @@ void test_simple_tags() {
   TestHelpers::db::test_simple_tag<
       Tags::DetInvJacobian<Frame::ElementLogical, Frame::Inertial>>(
       "DetInvJacobian(ElementLogical,Inertial)");
+  TestHelpers::db::test_simple_tag<
+      Tags::DetJacobian<Frame::ElementLogical, Frame::Inertial>>(
+      "DetJacobian(ElementLogical,Inertial)");
+  TestHelpers::db::test_simple_tag<
+      Tags::DetTimesInvJacobian<Dim, Frame::ElementLogical, Frame::Inertial>>(
+      "DetTimesInvJacobian(ElementLogical,Inertial)");
   TestHelpers::db::test_simple_tag<Tags::InternalDirections<Dim>>(
       "InternalDirections");
   TestHelpers::db::test_simple_tag<Tags::BoundaryDirectionsInterior<Dim>>(

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_DgOperator.cpp
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_DgOperator.cpp
@@ -503,12 +503,12 @@ SPECTRE_TEST_CASE("Unit.Elliptic.DG.Operator", "[Unit][Elliptic]") {
       OperatorVars expected_operator_vars_rnd_left{4};
       get(get<DgOperatorAppliedTo<Var<Poisson::Tags::Field>>>(
           expected_operator_vars_rnd_left)) =
-          DataVector{1785.7616039198579, 41.55242721423977, -41.54933376905333,
-                     -80.83628748342855};
+          DataVector{1384.5953530154895, 41.55242721423977, -41.54933376905333,
+                     -32.40787768105913};
       OperatorVars expected_operator_vars_rnd_right{4};
       get(get<DgOperatorAppliedTo<Var<Poisson::Tags::Field>>>(
           expected_operator_vars_rnd_right)) =
-          DataVector{-299.00214422311404, -37.924582769790135,
+          DataVector{-215.34463496424186, -37.924582769790135,
                      2.1993037260176997, 51.85418137198471};
       // Large tolerances for the comparison to the analytic solution because
       // this regression test runs at very low resolution. Below is another
@@ -621,8 +621,8 @@ SPECTRE_TEST_CASE("Unit.Elliptic.DG.Operator", "[Unit][Elliptic]") {
       OperatorVars expected_operator_vars_rnd{6};
       get(get<DgOperatorAppliedTo<Var<Poisson::Tags::Field>>>(
           expected_operator_vars_rnd)) =
-          DataVector{203.56354715945108, 9.40868981828554,  -2.818657740285368,
-                     111.70107437132107, 35.80427083086546, 65.53029015630551};
+          DataVector{164.82044058319110, 9.68580366789113,  -2.370110768729976,
+                     91.310963425225239, 30.31342257245155, 56.03237239864831};
       // Large tolerances for the comparison to the analytic solution because
       // this regression test runs at very low resolution. Below is another
       // analytic-solution test at higher resolution. The hard-coded numbers
@@ -746,14 +746,14 @@ SPECTRE_TEST_CASE("Unit.Elliptic.DG.Operator", "[Unit][Elliptic]") {
       OperatorVars expected_operator_vars_rnd{24};
       get(get<DgOperatorAppliedTo<Var<Poisson::Tags::Field>>>(
           expected_operator_vars_rnd)) = DataVector{
-          618.6142450194411,  269.8213716601356,   49.33225265133292,
-          103.71967654882658, 219.4353476547795,   -14.237023651828594,
-          731.9842766450536,  490.9303825979318,   32.18932195031287,
-          13.87090223491767,  -13.954381736466516, 130.61721549991918,
-          331.75024822120696, 55.511704965231125,  17.52350289937635,
-          23.878697549520762, -183.34493489042083, -171.66677910143915,
-          390.19201603025016, 410.25585855100763,  53.690124372228034,
-          82.23683297149915,  53.091014251828675,  117.36921898587735};
+          490.4639148694344,  218.0462676038626,   40.25819450876480,
+          83.251427119123945, 176.2577516255026,   -15.624072102187602,
+          586.8311752841304,  391.1570577346553,   30.26559434437542,
+          13.73062841146597,  -15.356914932182377, 100.25724641399877,
+          266.84155600862254, 48.507637035283153,  15.93132587805462,
+          23.036282532293448, -149.02371403160321, -142.12061361346408,
+          314.95846885876898, 329.52673640830761,  46.245499085300622,
+          70.51403818198222,  45.264231133848220,  90.061981328724073};
       // Large tolerances for the comparison to the analytic solution because
       // this regression test runs at very low resolution. Below is another
       // analytic-solution test at higher resolution. The hard-coded numbers
@@ -882,13 +882,13 @@ SPECTRE_TEST_CASE("Unit.Elliptic.DG.Operator", "[Unit][Elliptic]") {
       OperatorVars expected_operator_vars_rnd_lowerleft{6};
       get(get<DgOperatorAppliedTo<Var<Poisson::Tags::Field>>>(
           expected_operator_vars_rnd_lowerleft)) = DataVector{
-          16.79306542717521111, 7.74239738894839835, 0.12965837830820104,
-          5.52397488236783918,  0.6884385606128971,  0.92375936190340657};
+          13.52385143255982491, 6.82929107083524833, 0.04527695301629676,
+          4.39834760568600736,  0.65041277314590373, 0.78222246779709226};
       OperatorVars expected_operator_vars_rnd_right{6};
       get(get<DgOperatorAppliedTo<Var<Poisson::Tags::Field>>>(
           expected_operator_vars_rnd_right)) = DataVector{
-          2.08951711777856541, 5.07404320722327817, 19.63622686309961551,
-          5.16363816253272567, 6.36875690348678791, 18.87810118239165291};
+          1.60618450837350557, 4.71949148249203443, 15.72408761869980509,
+          4.06376669069456398, 5.88578668691303086, 15.11012286654655945};
       // Large tolerances for the comparison to the analytic solution because
       // this regression test runs at very low resolution. Below is another
       // analytic-solution test at higher resolution. The hard-coded numbers


### PR DESCRIPTION
## Proposed changes

Handle auxiliary boundary corrections through a weak divergence rather than a Schur complement. This changes how Jacobians are applied on boundaries. It turns out this primal formulation is more stable when the Jacobians are large (for large outer boundaries).

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
