### PR TITLE
Change worldtube scheme to inertial frame

### DIFF
--- a/src/Evolution/Executables/CurvedScalarWave/EvolveWorldtubeCurvedScalarWave.hpp
+++ b/src/Evolution/Executables/CurvedScalarWave/EvolveWorldtubeCurvedScalarWave.hpp
@@ -293,7 +293,7 @@ struct EvolutionMetavars {
           CurvedScalarWave::Worldtube::Tags::ParticlePositionVelocityCompute<
               volume_dim>,
           CurvedScalarWave::Worldtube::Tags::FaceCoordinatesCompute<
-              volume_dim, Frame::Grid, true>,
+              volume_dim, Frame::Inertial, true>,
           CurvedScalarWave::Worldtube::Tags::FaceCoordinatesCompute<
               volume_dim, Frame::Inertial, false>,
           CurvedScalarWave::Worldtube::Tags::PunctureFieldCompute<volume_dim>,

--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/Inboxes.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/Inboxes.hpp
@@ -66,18 +66,15 @@ struct SphericalHarmonicsInbox
 };
 
 /*!
- * \brief Inbox of the element chares that contains the regular field $\Psi^R$
- * as well as its time and spatial derivative evaluated at the grid points of
- * abutting element faces.
+ * \brief Inbox of the element chares that contains the coefficients of a Taylor
+ * Series of the regular field $\Psi^R$ as well as its time derivative. The
+ * elements may evaluate the coefficients at their inertial coordinates.
  */
 template <size_t Dim>
 struct RegularFieldInbox
     : Parallel::InboxInserters::Value<RegularFieldInbox<Dim>> {
-  using tags_to_send =
-      tmpl::list<CurvedScalarWave::Tags::Psi,
-                 ::Tags::dt<CurvedScalarWave::Tags::Psi>,
-                 ::Tags::deriv<CurvedScalarWave::Tags::Psi, tmpl::size_t<Dim>,
-                               Frame::Grid>>;
+  using tags_to_send = tmpl::list<CurvedScalarWave::Tags::Psi,
+                                  ::Tags::dt<CurvedScalarWave::Tags::Psi>>;
   using temporal_id = TimeStepId;
   using type = std::map<temporal_id, Variables<tags_to_send>>;
 

--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonActions/ObserveWorldtubeSolution.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonActions/ObserveWorldtubeSolution.hpp
@@ -56,10 +56,11 @@ struct ObserveWorldtubeSolution {
     if (db::get<Tags::ObserveCoefficientsTrigger>(box).is_triggered(box)) {
       const size_t expansion_order = db::get<Tags::ExpansionOrder>(box);
       const auto& psi_monopole = db::get<
-          Stf::Tags::StfTensor<Tags::PsiWorldtube, 0, Dim, Frame::Grid>>(box);
+          Stf::Tags::StfTensor<Tags::PsiWorldtube, 0, Dim, Frame::Inertial>>(
+          box);
       const auto& dt_psi_monopole =
           db::get<Stf::Tags::StfTensor<::Tags::dt<Tags::PsiWorldtube>, 0, Dim,
-                                       Frame::Grid>>(box);
+                                       Frame::Inertial>>(box);
 
       // number of components in Taylor series
       const size_t num_coefs = ((expansion_order + 3) * (expansion_order + 2) *
@@ -71,10 +72,11 @@ struct ObserveWorldtubeSolution {
 
       if (expansion_order > 0) {
         const auto& psi_dipole = db::get<
-            Stf::Tags::StfTensor<Tags::PsiWorldtube, 1, Dim, Frame::Grid>>(box);
+            Stf::Tags::StfTensor<Tags::PsiWorldtube, 1, Dim, Frame::Inertial>>(
+            box);
         const auto& dt_psi_dipole =
             db::get<Stf::Tags::StfTensor<::Tags::dt<Tags::PsiWorldtube>, 1, Dim,
-                                         Frame::Grid>>(box);
+                                         Frame::Inertial>>(box);
         for (size_t i = 0; i < Dim; ++i) {
           psi_coefs[1 + i] = psi_dipole.get(i);
           psi_coefs[num_coefs + 1 + i] = dt_psi_dipole.get(i);

--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonActions/ReceiveElementData.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonActions/ReceiveElementData.hpp
@@ -51,15 +51,12 @@ namespace CurvedScalarWave::Worldtube::Actions {
  *    - `Worldtube::Tags::ElementFacesGridCoordinates`
  *    - `Tags::TimeStepId`
  * - Mutates:
- *    - `Stf::Tags::StfTensor<Tags::PsiWorldtube, 0, Dim, Frame::Grid>`
+ *    - `Stf::Tags::StfTensor<Tags::PsiWorldtube, 0, Dim, Frame::Inertial>`
  *    - `Stf::Tags::StfTensor<::Tags::dt<Tags::PsiWorldtube>, 0, Dim,
- *                                     Frame::Grid>`
- *    - `Stf::Tags::StfTensor<Tags::PsiWorldtube, 1, Dim, Frame::Grid>`
+ *                                     Frame::Inertial>`
+ *    - `Stf::Tags::StfTensor<Tags::PsiWorldtube, 1, Dim, Frame::Inertial>`
  *    - `Stf::Tags::StfTensor<::Tags::dt<Tags::PsiWorldtube>, 1, Dim,
- *                                     Frame::Grid>`
- *    - `Stf::Tags::StfTensor<Tags::PsiWorldtube, 2, Dim, Frame::Grid>`
- *    - `Stf::Tags::StfTensor<::Tags::dt<Tags::PsiWorldtube>, 2, Dim,
- *                                     Frame::Grid>`
+ *                                     Frame::Inertial>`
  */
 struct ReceiveElementData {
   static constexpr size_t Dim = 3;
@@ -68,11 +65,12 @@ struct ReceiveElementData {
   using inbox_tags = tmpl::list<
       ::CurvedScalarWave::Worldtube::Tags::SphericalHarmonicsInbox<Dim>>;
   using simple_tags = tmpl::list<
-      Stf::Tags::StfTensor<Tags::PsiWorldtube, 0, Dim, Frame::Grid>,
-      Stf::Tags::StfTensor<::Tags::dt<Tags::PsiWorldtube>, 0, Dim, Frame::Grid>,
-      Stf::Tags::StfTensor<Tags::PsiWorldtube, 1, Dim, Frame::Grid>,
+      Stf::Tags::StfTensor<Tags::PsiWorldtube, 0, Dim, Frame::Inertial>,
+      Stf::Tags::StfTensor<::Tags::dt<Tags::PsiWorldtube>, 0, Dim,
+                           Frame::Inertial>,
+      Stf::Tags::StfTensor<Tags::PsiWorldtube, 1, Dim, Frame::Inertial>,
       Stf::Tags::StfTensor<::Tags::dt<Tags::PsiWorldtube>, 1, Dim,
-                           Frame::Grid>>;
+                           Frame::Inertial>>;
 
   template <typename DbTagsList, typename... InboxTags, typename Metavariables,
             typename ArrayIndex, typename ActionList,
@@ -112,15 +110,15 @@ struct ReceiveElementData {
 
     const ModalVector psi_ylm_l0(&psi_ylm_coefs[0], 1);
     const ModalVector dt_psi_ylm_l0(&dt_psi_ylm_coefs[0], 1);
-    tnsr::i<double, Dim, Frame::Grid> psi_stf_l1{};
-    tnsr::i<double, Dim, Frame::Grid> dt_psi_stf_l1{};
+    tnsr::i<double, Dim, Frame::Inertial> psi_stf_l1{};
+    tnsr::i<double, Dim, Frame::Inertial> dt_psi_stf_l1{};
     if (order > 0) {
       ModalVector psi_ylm_l1(&psi_ylm_coefs[1], 3);
       ModalVector dt_psi_ylm_l1(&dt_psi_ylm_coefs[1], 3);
       psi_ylm_l1 /= wt_radius;
       dt_psi_ylm_l1 /= wt_radius;
-      psi_stf_l1 = ylm::ylm_to_stf_1<Frame::Grid>(psi_ylm_l1);
-      dt_psi_stf_l1 = ylm::ylm_to_stf_1<Frame::Grid>(dt_psi_ylm_l1);
+      psi_stf_l1 = ylm::ylm_to_stf_1<Frame::Inertial>(psi_ylm_l1);
+      dt_psi_stf_l1 = ylm::ylm_to_stf_1<Frame::Inertial>(dt_psi_ylm_l1);
     }
 
     ::Initialization::mutate_assign<simple_tags>(

--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/Tags.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/Tags.hpp
@@ -306,15 +306,6 @@ struct PunctureFieldCompute : PunctureField<Dim>, db::ComputeTag {
 /// @}
 
 /*!
- * \brief Holds the advection term that is the scalar product of the
- * mesh velocity with the spatial derivative of the regular scalar field.
- */
-template <size_t Dim>
-struct RegularFieldAdvectiveTerm : db::SimpleTag {
-  using type = Scalar<DataVector>;
-};
-
-/*!
  * \brief A map that holds the grid coordinates centered on the worldtube of
  * all element faces abutting the worldtube with the corresponding ElementIds.
  */

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonActions/Test_ObserveWorldtubeSolution.cpp
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonActions/Test_ObserveWorldtubeSolution.cpp
@@ -50,12 +50,14 @@ struct MockWorldtubeSingleton {
               db::AddSimpleTags<
                   ::Tags::Time, Tags::ObserveCoefficientsTrigger, Tags::Psi0,
                   Tags::dtPsi0,
-                  Stf::Tags::StfTensor<Tags::PsiWorldtube, 0, Dim, Frame::Grid>,
+                  Stf::Tags::StfTensor<Tags::PsiWorldtube, 0, Dim,
+                                       Frame::Inertial>,
                   Stf::Tags::StfTensor<::Tags::dt<Tags::PsiWorldtube>, 0, Dim,
-                                       Frame::Grid>,
-                  Stf::Tags::StfTensor<Tags::PsiWorldtube, 1, Dim, Frame::Grid>,
+                                       Frame::Inertial>,
+                  Stf::Tags::StfTensor<Tags::PsiWorldtube, 1, Dim,
+                                       Frame::Inertial>,
                   Stf::Tags::StfTensor<::Tags::dt<Tags::PsiWorldtube>, 1, Dim,
-                                       Frame::Grid>,
+                                       Frame::Inertial>,
                   Tags::ExcisionSphere<Dim>>,
               db::AddComputeTags<>>>>,
       Parallel::PhaseActions<Parallel::Phase::Testing,
@@ -97,11 +99,11 @@ void check_observe_worldtube_solution(
   const auto dt_psi_monopole =
       make_with_random_values<Scalar<double>>(generator, dist, 1);
   const auto psi_dipole =
-      make_with_random_values<tnsr::i<double, Dim, Frame::Grid>>(generator,
-                                                                 dist, 1);
+      make_with_random_values<tnsr::i<double, Dim, Frame::Inertial>>(generator,
+                                                                     dist, 1);
   const auto dt_psi_dipole =
-      make_with_random_values<tnsr::i<double, Dim, Frame::Grid>>(generator,
-                                                                 dist, 1);
+      make_with_random_values<tnsr::i<double, Dim, Frame::Inertial>>(generator,
+                                                                     dist, 1);
   const double wt_radius = 1.5;
   const ExcisionSphere<Dim> excision_sphere(
       wt_radius, tnsr::I<double, Dim, Frame::Grid>{{0., 0., 0.}}, {});

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/Test_Tags.cpp
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/Test_Tags.cpp
@@ -479,8 +479,6 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.CurvedScalarWave.Worldtube.Tags",
   TestHelpers::db::test_simple_tag<Tags::PunctureField<3>>("PunctureField");
   TestHelpers::db::test_simple_tag<
       Tags::CheckInputFile<3, gr::Solutions::KerrSchild>>("CheckInputFile");
-  TestHelpers::db::test_simple_tag<Tags::RegularFieldAdvectiveTerm<3>>(
-      "RegularFieldAdvectiveTerm");
   TestHelpers::db::test_simple_tag<Tags::ObserveCoefficientsTrigger>(
       "ObserveCoefficientsTrigger");
   test_excision_sphere_tag();


### PR DESCRIPTION
Changes the internal worldtube solution from the grid frame to the inertial frame which is required for the inspiral evolution.
The singleton component now sends the _coefficients_ of the series of the regular field (required for the boundary conditions) and each element evaluates the series on their own inertial coordinates. Previously, the worldtube singleton would evaluate the coefficients on the element faces and send the evaluated fields. This change should also make the worldtube scheme compatible with p-refinement.

~depends on #5666~
