### PR TITLE
Observe BBH individual horizons in distorted frame

### DIFF
--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
@@ -267,8 +267,8 @@ struct EvolutionMetavars {
     }
   };
 
-  using AhA = Ah<::domain::ObjectLabel::A, ::Frame::Grid>;
-  using AhB = Ah<::domain::ObjectLabel::B, ::Frame::Grid>;
+  using AhA = Ah<::domain::ObjectLabel::A, ::Frame::Distorted>;
+  using AhB = Ah<::domain::ObjectLabel::B, ::Frame::Distorted>;
   using AhC = Ah<::domain::ObjectLabel::C, ::Frame::Inertial>;
 
   template <::domain::ObjectLabel Excision>


### PR DESCRIPTION
## Proposed changes

In binary black hole evolutions, the horizon finders assume that the maps are smooth, which they aren't when using a GridToDistorted map with a transition function that is 1 on the excision surface and zero on the cubes. To handle this case, this PR changes EvolveGhBinaryBlackHole so that the horizon observations are performed in the distorted frame.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
