### PR TITLE
Generalize `InertialParticlePosition` compute tag

### DIFF
--- a/src/Evolution/Executables/CurvedScalarWave/EvolveWorldtubeCurvedScalarWave.hpp
+++ b/src/Evolution/Executables/CurvedScalarWave/EvolveWorldtubeCurvedScalarWave.hpp
@@ -288,7 +288,7 @@ struct EvolutionMetavars {
           StepChoosers::step_chooser_compute_tags<EvolutionMetavars,
                                                   local_time_stepping>>,
       Initialization::Actions::AddComputeTags<tmpl::list<
-          CurvedScalarWave::Worldtube::Tags::InertialParticlePositionCompute<
+          CurvedScalarWave::Worldtube::Tags::ParticlePositionVelocityCompute<
               volume_dim>,
           CurvedScalarWave::Worldtube::Tags::FaceCoordinatesCompute<
               volume_dim, Frame::Grid, true>,


### PR DESCRIPTION
The compute tag was fixed for circular orbits. Here, I generalize it to output the position and velocity for arbitrary orbits by calling the functions of time on the grid coordinates of the particle.
