### PR TITLE
Combine time and spatial derivative in spacetime_deriv_of_goth_g into…

### DIFF
--- a/src/PointwiseFunctions/GeneralRelativity/SpacetimeDerivativeOfGothG.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/SpacetimeDerivativeOfGothG.cpp
@@ -20,27 +20,10 @@ void spacetime_deriv_of_goth_g(
     const tnsr::AA<DataType, SpatialDim, Frame>& inverse_spacetime_metric,
     const tnsr::abb<DataType, SpatialDim, Frame>& da_spacetime_metric,
     const Scalar<DataType>& lapse,
-    const Scalar<DataType>& dt_lapse,
-    const tnsr::i<DataType, SpatialDim, Frame>& deriv_lapse,
+    const tnsr::a<DataType, SpatialDim, Frame>& da_lapse,
     const Scalar<DataType>& sqrt_det_spatial_metric,
     const tnsr::a<DataType, SpatialDim, Frame>& da_det_spatial_metric) {
   set_number_of_grid_points(da_goth_g, da_spacetime_metric);
-
-  tnsr::a<DataType, SpatialDim, Frame> da_lapse{};
-  if constexpr (std::is_same_v<DataType, DataVector>) {
-    make_const_view(make_not_null(&std::as_const(da_lapse.get(0))),
-                                     get(dt_lapse), 0, get(dt_lapse).size());
-    for (size_t i = 0; i < SpatialDim; ++i) {
-      make_const_view(make_not_null(&std::as_const(da_lapse.get(i + 1))),
-                              deriv_lapse.get(i), 0, deriv_lapse.get(0).size());
-    }
-  }
-  else {
-    da_lapse.get(0) = get(dt_lapse);
-    for (size_t i = 0; i < SpatialDim; ++i) {
-      da_lapse.get(i + 1) = deriv_lapse.get(i);
-    }
-  }
 
   tenex::evaluate<ti::a, ti::B, ti::C>(da_goth_g,
     (da_lapse(ti::a) * sqrt_det_spatial_metric()
@@ -57,14 +40,13 @@ tnsr::aBB<DataType, SpatialDim, Frame> spacetime_deriv_of_goth_g(
     const tnsr::AA<DataType, SpatialDim, Frame>& inverse_spacetime_metric,
     const tnsr::abb<DataType, SpatialDim, Frame>& da_spacetime_metric,
     const Scalar<DataType>& lapse,
-    const Scalar<DataType>& dt_lapse,
-    const tnsr::i<DataType, SpatialDim, Frame>& deriv_lapse,
+    const tnsr::a<DataType, SpatialDim, Frame>& da_lapse,
     const Scalar<DataType>& sqrt_det_spatial_metric,
     const tnsr::a<DataType, SpatialDim, Frame>& da_det_spatial_metric) {
   tnsr::aBB<DataType, SpatialDim, Frame> da_goth_g{};
   gr::spacetime_deriv_of_goth_g(make_not_null(&da_goth_g),
-          inverse_spacetime_metric, da_spacetime_metric, lapse, dt_lapse,
-                   deriv_lapse, sqrt_det_spatial_metric, da_det_spatial_metric);
+          inverse_spacetime_metric, da_spacetime_metric, lapse, da_lapse,
+                   sqrt_det_spatial_metric, da_det_spatial_metric);
   return da_goth_g;
 }
 }  // namespace gr
@@ -82,8 +64,7 @@ tnsr::aBB<DataType, SpatialDim, Frame> spacetime_deriv_of_goth_g(
       const tnsr::abb<DTYPE(data), DIM(data), FRAME(data)>&               \
           da_spacetime_metric,                                            \
       const Scalar<DTYPE(data)>& lapse,                                   \
-      const Scalar<DTYPE(data)>& dt_lapse,                                \
-      const tnsr::i<DTYPE(data), DIM(data), FRAME(data)>& deriv_lapse,    \
+      const tnsr::a<DTYPE(data), DIM(data), FRAME(data)>& da_lapse,       \
       const Scalar<DTYPE(data)>& sqrt_det_spatial_metric,                 \
       const tnsr::a<DTYPE(data), DIM(data), FRAME(data)>&                 \
           da_det_spatial_metric);                                         \
@@ -94,8 +75,7 @@ tnsr::aBB<DataType, SpatialDim, Frame> spacetime_deriv_of_goth_g(
       const tnsr::abb<DTYPE(data), DIM(data), FRAME(data)>&               \
           da_spacetime_metric,                                            \
       const Scalar<DTYPE(data)>& lapse,                                   \
-      const Scalar<DTYPE(data)>& dt_lapse,                                \
-      const tnsr::i<DTYPE(data), DIM(data), FRAME(data)>& deriv_lapse,    \
+      const tnsr::a<DTYPE(data), DIM(data), FRAME(data)>& da_lapse,       \
       const Scalar<DTYPE(data)>& sqrt_det_spatial_metric,                 \
       const tnsr::a<DTYPE(data), DIM(data), FRAME(data)>&                 \
           da_det_spatial_metric);

--- a/src/PointwiseFunctions/GeneralRelativity/SpacetimeDerivativeOfGothG.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/SpacetimeDerivativeOfGothG.hpp
@@ -35,8 +35,7 @@ void spacetime_deriv_of_goth_g(
     const tnsr::AA<DataType, SpatialDim, Frame>& inverse_spacetime_metric,
     const tnsr::abb<DataType, SpatialDim, Frame>& da_spacetime_metric,
     const Scalar<DataType>& lapse,
-    const Scalar<DataType>& dt_lapse,
-    const tnsr::i<DataType, SpatialDim, Frame>& deriv_lapse,
+    const tnsr::a<DataType, SpatialDim, Frame>& da_lapse,
     const Scalar<DataType>& sqrt_det_spatial_metric,
     const tnsr::a<DataType, SpatialDim, Frame>& da_det_spatial_metric);
 
@@ -45,8 +44,7 @@ tnsr::aBB<DataType, SpatialDim, Frame> spacetime_deriv_of_goth_g(
     const tnsr::AA<DataType, SpatialDim, Frame>& inverse_spacetime_metric,
     const tnsr::abb<DataType, SpatialDim, Frame>& da_spacetime_metric,
     const Scalar<DataType>& lapse,
-    const Scalar<DataType>& dt_lapse,
-    const tnsr::i<DataType, SpatialDim, Frame>& deriv_lapse,
+    const tnsr::a<DataType, SpatialDim, Frame>& da_lapse,
     const Scalar<DataType>& sqrt_det_spatial_metric,
     const tnsr::a<DataType, SpatialDim, Frame>& da_det_spatial_metric);
 /// @}

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/SpacetimeDerivativeOfGothG.py
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/SpacetimeDerivativeOfGothG.py
@@ -10,14 +10,10 @@ def spacetime_deriv_of_goth_g(
     inverse_spacetime_metric,
     da_spacetime_metric,
     lapse,
-    dt_lapse,
-    deriv_lapse,
+    da_lapse,
     sqrt_det_spatial_metric,
     da_det_spatial_metric,
 ):
-    da_lapse = np.array([dt_lapse])
-    for d_lapse in deriv_lapse:
-        da_lapse = np.append(da_lapse, d_lapse)
     return np.tensordot(
         da_lapse * sqrt_det_spatial_metric
         + 0.5 * lapse * da_det_spatial_metric / sqrt_det_spatial_metric,

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_SpacetimeDerivativeOfGothG.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_SpacetimeDerivativeOfGothG.cpp
@@ -22,8 +22,7 @@ void test_compute_spacetime_deriv_of_goth_g(const DataType& used_for_size) {
           const tnsr::AA<DataType, SpatialDim, Frame::Inertial>&,
           const tnsr::abb<DataType, SpatialDim, Frame::Inertial>&,
           const Scalar<DataType>&,
-          const Scalar<DataType>&,
-          const tnsr::i<DataType, SpatialDim, Frame::Inertial>&,
+          const tnsr::a<DataType, SpatialDim, Frame::Inertial>&,
           const Scalar<DataType>&,
           const tnsr::a<DataType, SpatialDim, Frame::Inertial>&)>(
           &spacetime_deriv_of_goth_g<DataType, SpatialDim, Frame::Inertial>),


### PR DESCRIPTION
… a spacetime derivative in function input.

## Proposed changes

Currently `spacetime_deriv_of_goth_g` takes the time and spatial derivatives of the lapse as inputs and combines them into a spacetime derivative. We now plan to do this earlier in the process, so this part of the function is being removed.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [x] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [x] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [x] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
