### PR TITLE
Add BondiSachs and deadlock analysis to SingleBH

### DIFF
--- a/src/Evolution/Executables/GeneralizedHarmonic/CMakeLists.txt
+++ b/src/Evolution/Executables/GeneralizedHarmonic/CMakeLists.txt
@@ -61,6 +61,7 @@ target_link_libraries(
   PRIVATE
   ${LIBS_TO_LINK}
   ApparentHorizonFinder
+  Cce
   ControlSystem
   )
 

--- a/src/Evolution/Executables/GeneralizedHarmonic/CMakeLists.txt
+++ b/src/Evolution/Executables/GeneralizedHarmonic/CMakeLists.txt
@@ -63,6 +63,7 @@ target_link_libraries(
   ApparentHorizonFinder
   Cce
   ControlSystem
+  Deadlock
   )
 
 # BBH

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhSingleBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhSingleBlackHole.hpp
@@ -17,6 +17,7 @@
 #include "Domain/Structure/ObjectLabel.hpp"
 #include "Evolution/Actions/RunEventsAndTriggers.hpp"
 #include "Evolution/Executables/GeneralizedHarmonic/GeneralizedHarmonicBase.hpp"
+#include "Evolution/Systems/Cce/Callbacks/DumpBondiSachsOnWorldtube.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/Actions/SetInitialData.hpp"
 #include "Options/FactoryHelpers.hpp"
 #include "Options/Protocols/FactoryCreation.hpp"
@@ -135,10 +136,29 @@ struct EvolutionMetavars : public GeneralizedHarmonicTemplateBase<3> {
   static constexpr bool use_control_systems =
       tmpl::size<control_systems>::value > 0;
 
+  struct BondiSachs;
+
   using interpolation_target_tags = tmpl::push_back<
       control_system::metafunctions::interpolation_target_tags<control_systems>,
-      ApparentHorizon, ExcisionBoundary>;
+      ApparentHorizon, ExcisionBoundary, BondiSachs>;
   using interpolator_source_vars = ::ah::source_vars<volume_dim>;
+  using source_vars_no_deriv =
+      tmpl::list<gr::Tags::SpacetimeMetric<DataVector, volume_dim>,
+                 gh::Tags::Pi<DataVector, volume_dim>,
+                 gh::Tags::Phi<DataVector, volume_dim>>;
+
+  struct BondiSachs : tt::ConformsTo<intrp::protocols::InterpolationTargetTag> {
+    static std::string name() { return "BondiSachsInterpolation"; }
+    using temporal_id = ::Tags::Time;
+    using vars_to_interpolate_to_target = source_vars_no_deriv;
+    using compute_target_points =
+        intrp::TargetPoints::Sphere<BondiSachs, ::Frame::Inertial>;
+    using post_interpolation_callbacks =
+        tmpl::list<intrp::callbacks::DumpBondiSachsOnWorldtube<BondiSachs>>;
+    using compute_items_on_target = tmpl::list<>;
+    template <typename Metavariables>
+    using interpolating_component = typename Metavariables::gh_dg_element_array;
+  };
 
   // The interpolator_source_vars need to be the same in both the Interpolate
   // event and the InterpolateWithoutInterpComponent event.  The Interpolate
@@ -155,6 +175,8 @@ struct EvolutionMetavars : public GeneralizedHarmonicTemplateBase<3> {
                        intrp::Events::Interpolate<3, ApparentHorizon,
                                                   interpolator_source_vars>,
                        control_system::control_system_events<control_systems>,
+                       intrp::Events::InterpolateWithoutInterpComponent<
+                           3, BondiSachs, source_vars_no_deriv>,
                        intrp::Events::InterpolateWithoutInterpComponent<
                            3, ExcisionBoundary, interpolator_source_vars>>>>,
         tmpl::pair<DenseTrigger,

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhSingleBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhSingleBlackHole.hpp
@@ -4,9 +4,11 @@
 #pragma once
 
 #include <cstdint>
+#include <string>
 #include <vector>
 
 #include "ControlSystem/Actions/InitializeMeasurements.hpp"
+#include "ControlSystem/Actions/PrintCurrentMeasurement.hpp"
 #include "ControlSystem/Component.hpp"
 #include "ControlSystem/Event.hpp"
 #include "ControlSystem/Measurements/SingleHorizon.hpp"
@@ -14,16 +16,22 @@
 #include "ControlSystem/Systems/Size.hpp"
 #include "ControlSystem/Trigger.hpp"
 #include "Domain/FunctionsOfTime/FunctionsOfTimeAreReady.hpp"
+#include "Domain/FunctionsOfTime/OutputTimeBounds.hpp"
+#include "Domain/FunctionsOfTime/Tags.hpp"
 #include "Domain/Structure/ObjectLabel.hpp"
 #include "Evolution/Actions/RunEventsAndTriggers.hpp"
+#include "Evolution/Deadlock/PrintDgElementArray.hpp"
 #include "Evolution/Executables/GeneralizedHarmonic/GeneralizedHarmonicBase.hpp"
 #include "Evolution/Systems/Cce/Callbacks/DumpBondiSachsOnWorldtube.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/Actions/SetInitialData.hpp"
 #include "Options/FactoryHelpers.hpp"
 #include "Options/Protocols/FactoryCreation.hpp"
 #include "Options/String.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "Parallel/Invoke.hpp"
 #include "Parallel/MemoryMonitor/MemoryMonitor.hpp"
 #include "Parallel/PhaseControl/ExecutePhaseChange.hpp"
+#include "Parallel/Printf.hpp"
 #include "Parallel/Protocols/RegistrationMetavariables.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/Callbacks/ErrorOnFailedApparentHorizon.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/Callbacks/FindApparentHorizon.hpp"
@@ -57,7 +65,9 @@
 #include "Time/Actions/SelfStartActions.hpp"
 #include "Time/StepChoosers/Factory.hpp"
 #include "Time/Tags/Time.hpp"
+#include "Utilities/Algorithm.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/PrettyType.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
 
 struct EvolutionMetavars : public GeneralizedHarmonicTemplateBase<3> {
@@ -243,13 +253,40 @@ struct EvolutionMetavars : public GeneralizedHarmonicTemplateBase<3> {
         tmpl::map<tmpl::pair<gh_dg_element_array, dg_registration_list>>;
   };
 
+  using control_components =
+      control_system::control_components<EvolutionMetavars, control_systems>;
+
+  static void run_deadlock_analysis_simple_actions(
+      Parallel::GlobalCache<EvolutionMetavars>& cache,
+      const std::vector<std::string>& deadlocked_components) {
+    const auto& functions_of_time =
+        Parallel::get<::domain::Tags::FunctionsOfTime>(cache);
+
+    const std::string time_bounds =
+        ::domain::FunctionsOfTime::ouput_time_bounds(functions_of_time);
+
+    Parallel::printf("%s\n", time_bounds);
+
+    if (alg::count(deadlocked_components,
+                   pretty_type::name<gh_dg_element_array>()) == 1) {
+      tmpl::for_each<control_components>([&cache](auto component_v) {
+        using component = tmpl::type_from<decltype(component_v)>;
+        Parallel::simple_action<
+            control_system::Actions::PrintCurrentMeasurement>(
+            Parallel::get_parallel_component<component>(cache));
+      });
+
+      Parallel::simple_action<deadlock::PrintElementInfo>(
+          Parallel::get_parallel_component<gh_dg_element_array>(cache));
+    }
+  }
+
   using component_list = tmpl::flatten<tmpl::list<
       observers::Observer<EvolutionMetavars>,
       observers::ObserverWriter<EvolutionMetavars>,
       mem_monitor::MemoryMonitor<EvolutionMetavars>,
       importers::ElementDataReader<EvolutionMetavars>, gh_dg_element_array,
-      intrp::Interpolator<EvolutionMetavars>,
-      control_system::control_components<EvolutionMetavars, control_systems>,
+      intrp::Interpolator<EvolutionMetavars>, control_components,
       tmpl::transform<interpolation_target_tags,
                       tmpl::bind<intrp::InterpolationTarget,
                                  tmpl::pin<EvolutionMetavars>, tmpl::_1>>>>;

--- a/support/Pipelines/Bbh/Ringdown.yaml
+++ b/support/Pipelines/Bbh/Ringdown.yaml
@@ -184,12 +184,20 @@ ApparentHorizons:
   ControlSystemCharSpeedAh: *Ah
 
 InterpolationTargets:
+  BondiSachsInterpolation:
+    LMax: 16
+    Radius: [100, 150, 200]
+    Center: [0, 0, 0]
+    AngularOrdering: Cce
   ExcisionBoundary: &ExBdry
     LMax: *LMax
     Center: [0., 0., 0.]
     Radius: *InnerRadius
     AngularOrdering: "Strahlkorper"
   ControlSystemCharSpeedExcision: *ExBdry
+
+Cce:
+  BondiSachsOutputFilePrefix: "BondiSachs"
 
 ControlSystems:
   WriteDataToDisk: false

--- a/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
@@ -212,12 +212,20 @@ ApparentHorizons:
   ControlSystemCharSpeedAh: *Ah
 
 InterpolationTargets:
+  BondiSachsInterpolation:
+    LMax: 16
+    Radius: [100, 150, 200]
+    Center: [0, 0, 0]
+    AngularOrdering: Cce
   ExcisionBoundary: &ExBdry
     LMax: *LMax
     Center: *Center
     Radius: *InnerRadius
     AngularOrdering: "Strahlkorper"
   ControlSystemCharSpeedExcision: *ExBdry
+
+Cce:
+  BondiSachsOutputFilePrefix: "BondiSachs"
 
 ControlSystems:
   WriteDataToDisk: false


### PR DESCRIPTION
## Proposed changes

BondiSachs is going to be needed for waveforms. Deadlock analysis is just a good thing to have and it makes it in line with the BBH executable.

Fixes #5672.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
