### PR TITLE
Boundary component for Klein-Gordon CCE

### DIFF
--- a/src/Evolution/Systems/Cce/Actions/InitializeWorldtubeBoundary.hpp
+++ b/src/Evolution/Systems/Cce/Actions/InitializeWorldtubeBoundary.hpp
@@ -45,13 +45,13 @@ namespace Actions {
 
 namespace detail {
 template <typename Initializer, typename ManagerTags,
-          typename BoundaryCommunicationTagsList>
+          typename... BoundaryCommunicationTagsList>
 struct InitializeWorldtubeBoundaryBase {
   using simple_tags_from_options = ManagerTags;
   using const_global_cache_tags = tmpl::list<Tags::LMax>;
 
   using simple_tags =
-      tmpl::list<::Tags::Variables<BoundaryCommunicationTagsList>>;
+      tmpl::list<::Tags::Variables<BoundaryCommunicationTagsList>...>;
 
   template <typename DataBoxTagsList, typename... InboxTags,
             typename ArrayIndex, typename Metavariables, typename ActionList,
@@ -78,11 +78,11 @@ struct InitializeWorldtubeBoundaryBase {
       }
     }
     const size_t l_max = db::get<Tags::LMax>(box);
-    Variables<BoundaryCommunicationTagsList> boundary_variables{
-        Spectral::Swsh::number_of_swsh_collocation_points(l_max)};
 
-    Initialization::mutate_assign<simple_tags>(make_not_null(&box),
-                                               std::move(boundary_variables));
+    Initialization::mutate_assign<simple_tags>(
+        make_not_null(&box),
+        Variables<BoundaryCommunicationTagsList>{
+            Spectral::Swsh::number_of_swsh_collocation_points(l_max)}...);
     return {Parallel::AlgorithmExecution::Continue, std::nullopt};
   }
 };

--- a/src/Evolution/Systems/Cce/Actions/InitializeWorldtubeBoundary.hpp
+++ b/src/Evolution/Systems/Cce/Actions/InitializeWorldtubeBoundary.hpp
@@ -39,6 +39,8 @@ struct H5WorldtubeBoundary;
 template <typename Metavariables>
 struct AnalyticWorldtubeBoundary;
 template <typename Metavariables>
+struct KleinGordonH5WorldtubeBoundary;
+template <typename Metavariables>
 struct GhWorldtubeBoundary;
 /// \endcond
 namespace Actions {
@@ -125,6 +127,51 @@ struct InitializeWorldtubeBoundary<H5WorldtubeBoundary<Metavariables>>
       InitializeWorldtubeBoundary<H5WorldtubeBoundary<Metavariables>>,
       tmpl::list<Tags::H5WorldtubeBoundaryDataManager>,
       typename Metavariables::cce_boundary_communication_tags>;
+  using base_type::apply;
+  using typename base_type::simple_tags;
+  using const_global_cache_tags =
+      tmpl::list<Tags::LMax, Tags::EndTimeFromFile, Tags::StartTimeFromFile>;
+  using typename base_type::simple_tags_from_options;
+};
+
+/*!
+ * \ingroup ActionsGroup
+ * \brief Initializes a KleinGordonH5WorldtubeBoundary
+ *
+ * \details Uses:
+ * - simple tags from options
+ * `Cce::Tags::H5WorldtubeBoundaryDataManager`,
+ * `Cce::Tags::KleinGordonH5WorldtubeBoundaryDataManager`.
+ * - const global cache tag `Cce::Tags::LMax`.
+ *
+ * Databox changes:
+ * - Adds:
+ *   - `Cce::Tags::H5WorldtubeBoundaryDataManager`
+ *   - `Cce::Tags::KleinGordonH5WorldtubeBoundaryDataManager`
+ *   - `Tags::Variables<typename
+ * Metavariables::cce_boundary_communication_tags>`
+ *   - `Tags::Variables<typename
+ * Metavariables::klein_gordon_boundary_communication_tags>`
+ * - Removes: nothing
+ * - Modifies: nothing
+ */
+template <typename Metavariables>
+struct InitializeWorldtubeBoundary<
+    KleinGordonH5WorldtubeBoundary<Metavariables>>
+    : public detail::InitializeWorldtubeBoundaryBase<
+          InitializeWorldtubeBoundary<
+              KleinGordonH5WorldtubeBoundary<Metavariables>>,
+          tmpl::list<Tags::H5WorldtubeBoundaryDataManager,
+                     Tags::KleinGordonH5WorldtubeBoundaryDataManager>,
+          typename Metavariables::cce_boundary_communication_tags,
+          typename Metavariables::klein_gordon_boundary_communication_tags> {
+  using base_type = detail::InitializeWorldtubeBoundaryBase<
+      InitializeWorldtubeBoundary<
+          KleinGordonH5WorldtubeBoundary<Metavariables>>,
+      tmpl::list<Tags::H5WorldtubeBoundaryDataManager,
+                 Tags::KleinGordonH5WorldtubeBoundaryDataManager>,
+      typename Metavariables::cce_boundary_communication_tags,
+      typename Metavariables::klein_gordon_boundary_communication_tags>;
   using base_type::apply;
   using typename base_type::simple_tags;
   using const_global_cache_tags =

--- a/src/Evolution/Systems/Cce/Actions/InitializeWorldtubeBoundary.hpp
+++ b/src/Evolution/Systems/Cce/Actions/InitializeWorldtubeBoundary.hpp
@@ -103,7 +103,7 @@ struct InitializeWorldtubeBoundary;
  * \brief Initializes a H5WorldtubeBoundary
  *
  * \details Uses:
- * - initialization tag
+ * - simple tags from options
  * `Cce::Tags::H5WorldtubeBoundaryDataManager`,
  * - const global cache tag `Cce::Tags::LMax`.
  *
@@ -137,7 +137,7 @@ struct InitializeWorldtubeBoundary<H5WorldtubeBoundary<Metavariables>>
  * \brief Initializes a GhWorldtubeBoundary
  *
  * \details Uses:
- * - initialization tags
+ * - simple tags from options
  * `Cce::Tags::GhWorldtubeBoundaryDataManager`, `Tags::GhInterfaceManager`
  * - const global cache tags `Tags::LMax`, `Tags::ExtractionRadius`.
  *
@@ -173,7 +173,7 @@ struct InitializeWorldtubeBoundary<GhWorldtubeBoundary<Metavariables>>
  * \brief Initializes an AnalyticWorldtubeBoundary
  *
  * \details Uses:
- * - initialization tag
+ * - simple tags from options
  * `Cce::Tags::AnalyticBoundaryDataManager`,
  * - const global cache tags `Tags::LMax`,
  * `Tags::ExtractionRadius`.

--- a/src/Evolution/Systems/Cce/Components/WorldtubeBoundary.hpp
+++ b/src/Evolution/Systems/Cce/Components/WorldtubeBoundary.hpp
@@ -93,6 +93,50 @@ struct H5WorldtubeBoundary
 };
 
 /*!
+ * \brief Component that supplies scalar-tensor worldtube boundary data.
+ *
+ * \details The \ref DataBoxGroup associated with the worldtube boundary
+ * component contains two data managers (`WorldtubeDataManager`) linked to
+ * one or two H5 files (scalar and tensor sectors, respectively). The data
+ * managers handle buffering and interpolating to desired target time points
+ * when requested via the simple action `BoundaryComputeAndSendToEvolution`, at
+ * which point they will send the required collection of boundary quantities to
+ * the identified `KleinGordonCharacteristicEvolution` component. It is assumed
+ * that the simple action `BoundaryComputeAndSendToEvolution` will only be
+ * called during the `Evolve` phase.
+ *
+ * Uses const global tags:
+ * - `Tags::LMax`
+ *
+ * `Metavariables` must contain:
+ * - the `enum` `Phase` with at least `Initialization` and `Evolve` phases.
+ * - a type alias `cce_boundary_communication_tags` for the set of tensor tags
+ * to send from the worldtube to the evolution component. This will typically be
+ * `Cce::Tags::characteristic_worldtube_boundary_tags<Tags::BoundaryValue>`.
+ * - a type alias `klein_gordon_boundary_communication_tags` for the set of
+ * scalar tags to send from the worldtube to the evolution component. This will
+ * typically be `Cce::Tags::klein_gordon_worldtube_boundary_tags`.
+ */
+template <class Metavariables>
+struct KleinGordonH5WorldtubeBoundary
+    : public WorldtubeComponentBase<
+          KleinGordonH5WorldtubeBoundary<Metavariables>, Metavariables> {
+  using base_type =
+      WorldtubeComponentBase<KleinGordonH5WorldtubeBoundary<Metavariables>,
+                             Metavariables>;
+  using base_type::execute_next_phase;
+  using base_type::initialize;
+  using typename base_type::chare_type;
+  using const_global_cache_tags =
+      tmpl::list<Tags::InitializeJ<Metavariables::evolve_ccm>>;
+  using typename base_type::metavariables;
+  using typename base_type::options;
+  using typename base_type::phase_dependent_action_list;
+  using typename base_type::simple_tags_from_options;
+  using end_time_tag = Tags::EndTimeFromFile;
+};
+
+/*!
  * \brief Component that supplies CCE worldtube boundary data sourced from an
  * analytic solution.
  *

--- a/tests/Unit/Evolution/Systems/Cce/Actions/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/CMakeLists.txt
@@ -13,6 +13,7 @@ set(LIBRARY_SOURCES
   Test_GhBoundaryCommunication.cpp
   Test_H5BoundaryCommunication.cpp
   Test_InitializeCharacteristicEvolution.cpp
+  Test_InitializeKleinGordonWorldtubeBoundary.cpp
   Test_InitializeWorldtubeBoundary.cpp
   Test_Psi0Matching.cpp
   Test_RequestBoundaryData.cpp
@@ -28,6 +29,7 @@ target_link_libraries(
   ${LIBRARY}
   PRIVATE
   Cce
+  CceHelpers
   GeneralRelativitySolutions
   Interpolation
   )

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_InitializeKleinGordonWorldtubeBoundary.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_InitializeKleinGordonWorldtubeBoundary.cpp
@@ -1,0 +1,155 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "Helpers/Evolution/Systems/Cce/Actions/WorldtubeBoundaryMocking.hpp"
+#include "Helpers/Evolution/Systems/Cce/KleinGordonBoundaryTestHelpers.hpp"
+#include "NumericalAlgorithms/Interpolation/BarycentricRationalSpanInterpolator.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace Cce {
+
+namespace {
+
+struct KleinGordonH5Metavariables {
+  using cce_boundary_communication_tags =
+      Tags::characteristic_worldtube_boundary_tags<Tags::BoundaryValue>;
+  using klein_gordon_boundary_communication_tags =
+      Tags::klein_gordon_worldtube_boundary_tags;
+  using component_list = tmpl::list<
+      mock_klein_gordon_h5_worldtube_boundary<KleinGordonH5Metavariables>>;
+
+  static constexpr bool evolve_ccm = false;
+};
+
+// This function tests the action
+// `InitializeWorldtubeBoundary<KleinGordonH5WorldtubeBoundary<Metavariables>>`.
+// The action is responsible for initializing the tags
+// `Metavariables::cce_boundary_communication_tags` and
+// `Metavariables::klein_gordon_boundary_communication_tags` for the boundary
+// component. The initialization process involves reading tensor and scalar data
+// separately from an HDF5 file. This is handled by two managers:
+// `Tags::H5WorldtubeBoundaryDataManager` and
+// `Tags::KleinGordonH5WorldtubeBoundaryDataManager`.
+//
+// The function begins by generating and storing some scalar and tensor data
+// into an HDF5 file named `filename` using `write_scalar_tensor_test_file`.
+// Subsequently, it initializes a mocked worldtube boundary component that
+// contains two optional tags: `Tags::H5WorldtubeBoundaryDataManager` and
+// `Tags::KleinGordonH5WorldtubeBoundaryDataManager`.
+// The function then invokes the action under examination within the
+// initialize-action list to initialize the specified tags. Finally, it tests
+// whether the tags are in the expected state.
+template <typename Generator>
+void test_klein_gordon_h5_initialization(const gsl::not_null<Generator*> gen) {
+  using component =
+      mock_klein_gordon_h5_worldtube_boundary<KleinGordonH5Metavariables>;
+  const size_t l_max = 8;
+  const size_t end_time = 100.0;
+  const size_t start_time = 0.0;
+
+  const size_t buffer_size = 8;
+  const std::string filename =
+      "InitializeKleinGordonWorldtubeBoundaryTest_CceR0100.h5";
+
+  // create the test file, because on initialization the manager will need to
+  // get basic data out of the file
+  UniformCustomDistribution<double> value_dist{0.1, 0.5};
+  const double mass = value_dist(*gen);
+  const std::array<double, 3> spin{
+      {value_dist(*gen), value_dist(*gen), value_dist(*gen)}};
+  const std::array<double, 3> center{
+      {value_dist(*gen), value_dist(*gen), value_dist(*gen)}};
+  gr::Solutions::KerrSchild solution{mass, spin, center};
+
+  const double extraction_radius = 100.0;
+  const double frequency = 0.1 * value_dist(*gen);
+  const double amplitude = 0.1 * value_dist(*gen);
+  const double target_time = 50.0 * value_dist(*gen);
+  TestHelpers::write_scalar_tensor_test_file(solution, filename, target_time,
+                                             extraction_radius, frequency,
+                                             amplitude, l_max);
+
+  // tests start here
+  ActionTesting::MockRuntimeSystem<KleinGordonH5Metavariables> runner{
+      tuples::tagged_tuple_from_typelist<
+          Parallel::get_const_global_cache_tags<KleinGordonH5Metavariables>>{
+          l_max, end_time, start_time}};
+  ActionTesting::set_phase(make_not_null(&runner),
+                           Parallel::Phase::Initialization);
+  ActionTesting::emplace_component<component>(
+      &runner, 0,
+      Tags::H5WorldtubeBoundaryDataManager::create_from_options(
+          l_max, filename, buffer_size,
+          std::make_unique<intrp::BarycentricRationalSpanInterpolator>(3u, 4u),
+          false, false, std::optional<double>{}),
+      Tags::KleinGordonH5WorldtubeBoundaryDataManager::create_from_options(
+          l_max, filename, buffer_size,
+          std::make_unique<intrp::BarycentricRationalSpanInterpolator>(3u, 4u),
+          std::optional<double>{}));
+
+  // go through the initialization list
+  for (size_t i = 0; i < 2; ++i) {
+    ActionTesting::next_action<component>(make_not_null(&runner), 0);
+  }
+  ActionTesting::set_phase(make_not_null(&runner), Parallel::Phase::Evolve);
+
+  // The tensor part:
+  //
+  // check that the tensor data manager copied out of the databox has the
+  // correct properties
+  const auto& tensor_data_manager =
+      ActionTesting::get_databox_tag<component,
+                                     Tags::H5WorldtubeBoundaryDataManager>(
+          runner, 0);
+  CHECK(tensor_data_manager.get_l_max() == l_max);
+  const auto tensor_time_span = tensor_data_manager.get_time_span();
+  CHECK(tensor_time_span.first == 0);
+  CHECK(tensor_time_span.second == 0);
+
+  // check that the tensor Variables is in the expected state (here we just make
+  // sure it has the right size - it shouldn't have been written to yet)
+  const auto& tensor_variables = ActionTesting::get_databox_tag<
+      component, ::Tags::Variables<typename KleinGordonH5Metavariables::
+                                       cce_boundary_communication_tags>>(runner,
+                                                                         0);
+  CHECK(
+      get(get<Tags::BoundaryValue<Tags::BondiBeta>>(tensor_variables)).size() ==
+      Spectral::Swsh::number_of_swsh_collocation_points(l_max));
+
+  // then we repeat the tests for the scalar (Klein-Gordon) part
+  const auto& scalar_data_manager = ActionTesting::get_databox_tag<
+      component, Tags::KleinGordonH5WorldtubeBoundaryDataManager>(runner, 0);
+  CHECK(scalar_data_manager.get_l_max() == l_max);
+  const auto scalar_time_span = scalar_data_manager.get_time_span();
+  CHECK(scalar_time_span.first == 0);
+  CHECK(scalar_time_span.second == 0);
+
+  // check that the scalar Variables is in the expected state (here we just make
+  // sure it has the right size - it shouldn't have been written to yet)
+  const auto& scalar_variables = ActionTesting::get_databox_tag<
+      component,
+      ::Tags::Variables<typename KleinGordonH5Metavariables::
+                            klein_gordon_boundary_communication_tags>>(runner,
+                                                                       0);
+  CHECK(get(get<Tags::BoundaryValue<Tags::KleinGordonPsi>>(scalar_variables))
+            .size() ==
+        Spectral::Swsh::number_of_swsh_collocation_points(l_max));
+
+  if (file_system::check_if_file_exists(filename)) {
+    file_system::rm(filename, true);
+  }
+}
+}  // namespace
+
+SPECTRE_TEST_CASE(
+    "Unit.Evolution.Systems.Cce.Actions.InitializeKleinGordonWorldtubeBoundary",
+    "[Unit][Cce]") {
+  MAKE_GENERATOR(gen);
+  test_klein_gordon_h5_initialization(make_not_null(&gen));
+}
+}  // namespace Cce

--- a/tests/Unit/Evolution/Systems/Cce/Test_KleinGordonWorldtubeData.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_KleinGordonWorldtubeData.cpp
@@ -11,71 +11,12 @@
 #include "Framework/TestHelpers.hpp"
 #include "Helpers/DataStructures/MakeWithRandomValues.hpp"
 #include "Helpers/Evolution/Systems/Cce/BoundaryTestHelpers.hpp"
+#include "Helpers/Evolution/Systems/Cce/KleinGordonBoundaryTestHelpers.hpp"
 #include "NumericalAlgorithms/Interpolation/BarycentricRationalSpanInterpolator.hpp"
 #include "NumericalAlgorithms/Interpolation/CubicSpanInterpolator.hpp"
 #include "NumericalAlgorithms/Interpolation/LinearSpanInterpolator.hpp"
 #include "NumericalAlgorithms/Spectral/SwshCollocation.hpp"
 #include "Utilities/Serialization/RegisterDerivedClassesWithCharm.hpp"
-
-namespace Cce::TestHelpers {
-
-namespace {
-// The nodal data for the scalar field psi reads
-//
-// psi = sin(r - t)
-//
-// where r is a time-dependent radius
-//
-// r = (1 + A * sin ft) * R
-//
-// Its time derivative is given by
-//
-// dr/dt = A * f * cos ft * R
-//       =  r / (1 + A * sin ft) * A * f * cos ft
-void create_fake_time_varying_klein_gordon_data(
-    const gsl::not_null<Scalar<ComplexModalVector>*> kg_psi_modal,
-    const gsl::not_null<Scalar<ComplexModalVector>*> kg_pi_modal,
-    const gsl::not_null<Scalar<DataVector>*> kg_psi_nodal,
-    const gsl::not_null<Scalar<DataVector>*> kg_pi_nodal,
-    const double extraction_radius, const double amplitude,
-    const double frequency, const double time, const size_t l_max) {
-  const size_t number_of_angular_points =
-      Spectral::Swsh::number_of_swsh_collocation_points(l_max);
-  tnsr::I<DataVector, 3> collocation_points{number_of_angular_points};
-
-  const auto& collocation = Spectral::Swsh::cached_collocation_metadata<
-      Spectral::Swsh::ComplexRepresentation::Interleaved>(l_max);
-  for (const auto collocation_point : collocation) {
-    get<0>(collocation_points)[collocation_point.offset] =
-        extraction_radius * (1.0 + amplitude * sin(frequency * time)) *
-        sin(collocation_point.theta) * cos(collocation_point.phi);
-    get<1>(collocation_points)[collocation_point.offset] =
-        extraction_radius * (1.0 + amplitude * sin(frequency * time)) *
-        sin(collocation_point.theta) * sin(collocation_point.phi);
-    get<2>(collocation_points)[collocation_point.offset] =
-        extraction_radius * (1.0 + amplitude * sin(frequency * time)) *
-        cos(collocation_point.theta);
-  }
-
-  const DataVector r = sqrt(square(get<0>(collocation_points)) +
-                            square(get<1>(collocation_points)) +
-                            square(get<2>(collocation_points)));
-  const DataVector dr_dt = r / (1.0 + amplitude * sin(frequency * time)) *
-                           amplitude * frequency * cos(frequency * time);
-
-  // Nodal data
-  get(*kg_psi_nodal) = sin(r - time);
-  get(*kg_pi_nodal) = cos(r - time) * (dr_dt - 1.0);
-
-  // Transform to modal data
-  *kg_psi_modal =
-      TestHelpers::tensor_to_goldberg_coefficients(*kg_psi_nodal, l_max);
-  *kg_pi_modal =
-      TestHelpers::tensor_to_goldberg_coefficients(*kg_pi_nodal, l_max);
-}
-}  // namespace
-
-}  // namespace Cce::TestHelpers
 
 namespace Cce {
 

--- a/tests/Unit/Helpers/Evolution/Systems/Cce/Actions/WorldtubeBoundaryMocking.hpp
+++ b/tests/Unit/Helpers/Evolution/Systems/Cce/Actions/WorldtubeBoundaryMocking.hpp
@@ -91,4 +91,26 @@ struct mock_gh_worldtube_boundary {
       Parallel::get_const_global_cache_tags_from_actions<
     phase_dependent_action_list>;
 };
+
+template <typename Metavariables>
+struct mock_klein_gordon_h5_worldtube_boundary {
+  using component_being_mocked = KleinGordonH5WorldtubeBoundary<Metavariables>;
+
+  using initialize_action_list =
+      tmpl::list<Actions::InitializeWorldtubeBoundary<
+                     KleinGordonH5WorldtubeBoundary<Metavariables>>,
+                 Parallel::Actions::TerminatePhase>;
+  using simple_tags_from_options =
+      Parallel::get_simple_tags_from_options<initialize_action_list>;
+
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = size_t;
+
+  using simple_tags = tmpl::list<>;
+  using phase_dependent_action_list =
+      tmpl::list<Parallel::PhaseActions<Parallel::Phase::Initialization,
+                                        initialize_action_list>,
+                 Parallel::PhaseActions<Parallel::Phase::Evolve, tmpl::list<>>>;
+};
 }  // namespace Cce

--- a/tests/Unit/Helpers/Evolution/Systems/Cce/CMakeLists.txt
+++ b/tests/Unit/Helpers/Evolution/Systems/Cce/CMakeLists.txt
@@ -7,9 +7,17 @@ set(LIBRARY "CceHelpers")
 
 set(LIBRARY_SOURCES
   CceComputationTestHelpers.cpp
+  KleinGordonBoundaryTestHelpers.cpp
   )
 
 add_spectre_library(${LIBRARY} ${SPECTRE_TEST_LIBS_TYPE} ${LIBRARY_SOURCES})
+
+spectre_target_headers(
+  ${LIBRARY}
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/tests/Unit
+  HEADERS
+  KleinGordonBoundaryTestHelpers.hpp
+  )
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Unit/Helpers/Evolution/Systems/Cce/KleinGordonBoundaryTestHelpers.cpp
+++ b/tests/Unit/Helpers/Evolution/Systems/Cce/KleinGordonBoundaryTestHelpers.cpp
@@ -1,0 +1,50 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Helpers/Evolution/Systems/Cce/KleinGordonBoundaryTestHelpers.hpp"
+
+namespace Cce::TestHelpers {
+
+void create_fake_time_varying_klein_gordon_data(
+    const gsl::not_null<Scalar<ComplexModalVector>*> kg_psi_modal,
+    const gsl::not_null<Scalar<ComplexModalVector>*> kg_pi_modal,
+    const gsl::not_null<Scalar<DataVector>*> kg_psi_nodal,
+    const gsl::not_null<Scalar<DataVector>*> kg_pi_nodal,
+    const double extraction_radius, const double amplitude,
+    const double frequency, const double time, const size_t l_max) {
+  const size_t number_of_angular_points =
+      Spectral::Swsh::number_of_swsh_collocation_points(l_max);
+  tnsr::I<DataVector, 3> collocation_points{number_of_angular_points};
+
+  const auto& collocation = Spectral::Swsh::cached_collocation_metadata<
+      Spectral::Swsh::ComplexRepresentation::Interleaved>(l_max);
+  for (const auto collocation_point : collocation) {
+    get<0>(collocation_points)[collocation_point.offset] =
+        extraction_radius * (1.0 + amplitude * sin(frequency * time)) *
+        sin(collocation_point.theta) * cos(collocation_point.phi);
+    get<1>(collocation_points)[collocation_point.offset] =
+        extraction_radius * (1.0 + amplitude * sin(frequency * time)) *
+        sin(collocation_point.theta) * sin(collocation_point.phi);
+    get<2>(collocation_points)[collocation_point.offset] =
+        extraction_radius * (1.0 + amplitude * sin(frequency * time)) *
+        cos(collocation_point.theta);
+  }
+
+  const DataVector r = sqrt(square(get<0>(collocation_points)) +
+                            square(get<1>(collocation_points)) +
+                            square(get<2>(collocation_points)));
+  const DataVector dr_dt = r / (1.0 + amplitude * sin(frequency * time)) *
+                           amplitude * frequency * cos(frequency * time);
+
+  // Nodal data
+  get(*kg_psi_nodal) = sin(r - time);
+  get(*kg_pi_nodal) = cos(r - time) * (dr_dt - 1.0);
+
+  // Transform to modal data
+  *kg_psi_modal =
+      TestHelpers::tensor_to_goldberg_coefficients(*kg_psi_nodal, l_max);
+  *kg_pi_modal =
+      TestHelpers::tensor_to_goldberg_coefficients(*kg_pi_nodal, l_max);
+}
+
+}  // namespace Cce::TestHelpers

--- a/tests/Unit/Helpers/Evolution/Systems/Cce/KleinGordonBoundaryTestHelpers.hpp
+++ b/tests/Unit/Helpers/Evolution/Systems/Cce/KleinGordonBoundaryTestHelpers.hpp
@@ -1,0 +1,29 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "Helpers/Evolution/Systems/Cce/BoundaryTestHelpers.hpp"
+
+namespace Cce::TestHelpers {
+
+// The nodal data for the scalar field psi reads
+//
+// psi = sin(r - t)
+//
+// where r is a time-dependent radius
+//
+// r = (1 + A * sin ft) * R
+//
+// Its time derivative is given by
+//
+// dr/dt = A * f * cos ft * R
+//       =  r / (1 + A * sin ft) * A * f * cos ft
+void create_fake_time_varying_klein_gordon_data(
+    gsl::not_null<Scalar<ComplexModalVector>*> kg_psi_modal,
+    gsl::not_null<Scalar<ComplexModalVector>*> kg_pi_modal,
+    gsl::not_null<Scalar<DataVector>*> kg_psi_nodal,
+    gsl::not_null<Scalar<DataVector>*> kg_pi_nodal, double extraction_radius,
+    double amplitude, double frequency, double time, size_t l_max);
+
+}  // namespace Cce::TestHelpers

--- a/tests/Unit/Helpers/Evolution/Systems/Cce/KleinGordonBoundaryTestHelpers.hpp
+++ b/tests/Unit/Helpers/Evolution/Systems/Cce/KleinGordonBoundaryTestHelpers.hpp
@@ -26,4 +26,101 @@ void create_fake_time_varying_klein_gordon_data(
     gsl::not_null<Scalar<DataVector>*> kg_pi_nodal, double extraction_radius,
     double amplitude, double frequency, double time, size_t l_max);
 
+// Dump tensor+scalar data into a specified HDF5 file named `filename`.
+// The tensor part comes from `AnalyticSolution` whereas the scalar part
+// from `create_fake_time_varying_klein_gordon_data`.
+template <typename AnalyticSolution>
+void write_scalar_tensor_test_file(const AnalyticSolution& solution,
+                                   const std::string& filename,
+                                   const double target_time,
+                                   const double extraction_radius,
+                                   const double frequency,
+                                   const double amplitude, const size_t l_max) {
+  const size_t goldberg_size = square(l_max + 1);
+  tnsr::ii<ComplexModalVector, 3> spatial_metric_coefficients{goldberg_size};
+  tnsr::ii<ComplexModalVector, 3> dt_spatial_metric_coefficients{goldberg_size};
+  tnsr::ii<ComplexModalVector, 3> dr_spatial_metric_coefficients{goldberg_size};
+  tnsr::I<ComplexModalVector, 3> shift_coefficients{goldberg_size};
+  tnsr::I<ComplexModalVector, 3> dt_shift_coefficients{goldberg_size};
+  tnsr::I<ComplexModalVector, 3> dr_shift_coefficients{goldberg_size};
+  Scalar<ComplexModalVector> lapse_coefficients{goldberg_size};
+  Scalar<ComplexModalVector> dt_lapse_coefficients{goldberg_size};
+  Scalar<ComplexModalVector> dr_lapse_coefficients{goldberg_size};
+
+  Scalar<ComplexModalVector> kg_psi_modal{goldberg_size};
+  Scalar<ComplexModalVector> kg_pi_modal{goldberg_size};
+  Scalar<DataVector> kg_psi_nodal;
+  Scalar<DataVector> kg_pi_nodal;
+
+  if (file_system::check_if_file_exists(filename)) {
+    file_system::rm(filename, true);
+  }
+  // scoped to close the file
+  {
+    TestHelpers::WorldtubeModeRecorder recorder{filename, l_max};
+    // write times to file for several steps before and after the target time
+    for (size_t t = 0; t < 30; ++t) {
+      const double time = 0.1 * static_cast<double>(t) + target_time - 1.5;
+      // create tensor data
+      TestHelpers::create_fake_time_varying_modal_data(
+          make_not_null(&spatial_metric_coefficients),
+          make_not_null(&dt_spatial_metric_coefficients),
+          make_not_null(&dr_spatial_metric_coefficients),
+          make_not_null(&shift_coefficients),
+          make_not_null(&dt_shift_coefficients),
+          make_not_null(&dr_shift_coefficients),
+          make_not_null(&lapse_coefficients),
+          make_not_null(&dt_lapse_coefficients),
+          make_not_null(&dr_lapse_coefficients), solution, extraction_radius,
+          amplitude, frequency, time, l_max);
+
+      // create scalar data
+      TestHelpers::create_fake_time_varying_klein_gordon_data(
+          make_not_null(&kg_psi_modal), make_not_null(&kg_pi_modal),
+          make_not_null(&kg_psi_nodal), make_not_null(&kg_pi_nodal),
+          extraction_radius, amplitude, frequency, time, l_max);
+
+      // write tensor data
+      for (size_t i = 0; i < 3; ++i) {
+        for (size_t j = i; j < 3; ++j) {
+          recorder.append_worldtube_mode_data(
+              detail::dataset_name_for_component("/g", i, j), time,
+              spatial_metric_coefficients.get(i, j), l_max);
+          recorder.append_worldtube_mode_data(
+              detail::dataset_name_for_component("/Drg", i, j), time,
+              dr_spatial_metric_coefficients.get(i, j), l_max);
+          recorder.append_worldtube_mode_data(
+              detail::dataset_name_for_component("/Dtg", i, j), time,
+              dt_spatial_metric_coefficients.get(i, j), l_max);
+        }
+        recorder.append_worldtube_mode_data(
+            detail::dataset_name_for_component("/Shift", i), time,
+            shift_coefficients.get(i), l_max);
+        recorder.append_worldtube_mode_data(
+            detail::dataset_name_for_component("/DrShift", i), time,
+            dr_shift_coefficients.get(i), l_max);
+        recorder.append_worldtube_mode_data(
+            detail::dataset_name_for_component("/DtShift", i), time,
+            dt_shift_coefficients.get(i), l_max);
+      }
+      recorder.append_worldtube_mode_data(
+          detail::dataset_name_for_component("/Lapse"), time,
+          get(lapse_coefficients), l_max);
+      recorder.append_worldtube_mode_data(
+          detail::dataset_name_for_component("/DrLapse"), time,
+          get(dr_lapse_coefficients), l_max);
+      recorder.append_worldtube_mode_data(
+          detail::dataset_name_for_component("/DtLapse"), time,
+          get(dt_lapse_coefficients), l_max);
+
+      // write scalar data
+      recorder.append_worldtube_mode_data(
+          detail::dataset_name_for_component("/KGPsi"), time, get(kg_psi_modal),
+          l_max);
+      recorder.append_worldtube_mode_data(
+          detail::dataset_name_for_component("/dtKGPsi"), time,
+          get(kg_pi_modal), l_max);
+    }
+  }
+}
 }  // namespace Cce::TestHelpers


### PR DESCRIPTION
## Proposed changes

<!--
At a high level, describe what this PR does.
-->

This PR adds a boundary parallel component `KleinGordonH5WorldtubeBoundary` for Klein-Gordon CCE. The component has a single initialization action `Actions::InitializeWorldtubeBoundary<KleinGordonH5WorldtubeBoundary<Metavariables>>`, which initializes two tag lists `Metavariables::cce_boundary_communication_tags` and `Metavariables::klein_gordon_boundary_communication_tags` ( the metavariable will be added in the next PR). The third and fourth commits of this PR add the initialization action and the component respectively.

The initialization action is constructed from a base class `InitializeWorldtubeBoundaryBase`, which currently holds a single tag list. This is fine for the current CCE system since the code treats `Metavariables::cce_boundary_communication_tags` as one `::Tags::Variables`. However, for the upcoming Klein-Gordon CCE system, we want to handle `Metavariables::cce_boundary_communication_tags` and `Metavariables::klein_gordon_boundary_communication_tags` separately, so we initialize them as two different chunks of `::Tags::Variables`. In the first commit, a tag pack is added to `InitializeWorldtubeBoundaryBase` for this purpose.

The second commit is a minor change. The function `create_fake_time_varying_klein_gordon_data` is moved to a new file so that it can be used by other unit tests.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
