### PR TITLE
Remove duplicate entries in clang-format.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -112,9 +112,4 @@ AllowShortIfStatementsOnASingleLine: false
 AllowShortLoopsOnASingleLine: false
 PointerAlignment: Left
 DerivePointerAlignment: false
-IncludeCategories:
-  - Regex:           '^<.*'
-    Priority:        1
-  - Regex:           '.*'
-    Priority:        2
 ...


### PR DESCRIPTION
## Proposed changes

<!--
At a high level, describe what this PR does.
-->

A recent update in `llvm` causes `clang-tidy` to throw an error if duplicate entries are found in the config file (see https://github.com/llvm/llvm-project/commit/388d679c1dfa7c0cb5c9ee6cd0b8592c3c3d09ef). The default behavior prior to this change _seems_ as though it takes the first entry and ignores the duplicate, so I deleted the duplicate. (In our case, it doesn't really matter, since the first builds on what the duplicate has.)

This would probably also be a good opportunity to review the file to make sure there are no other erroneous lines in the file.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [x] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [x] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [x] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
