### PR TITLE
Add a radial expansion to the BBH ID pipeline

### DIFF
--- a/support/Pipelines/Bbh/InitialData.py
+++ b/support/Pipelines/Bbh/InitialData.py
@@ -19,6 +19,7 @@ def id_parameters(
     mass_ratio: float,
     separation: float,
     orbital_angular_velocity: float,
+    radial_expansion_velocity: float,
     refinement_level: int,
     polynomial_order: int,
 ):
@@ -30,6 +31,7 @@ def id_parameters(
       mass_ratio: Defined as q = M_A / M_B >= 1.
       separation: Coordinate separation D of the black holes.
       orbital_angular_velocity: Omega_0.
+      radial_expansion_velocity: adot_0.
       refinement_level: h-refinement level.
       polynomial_order: p-refinement level.
     """
@@ -50,6 +52,7 @@ def id_parameters(
         "ExcisionRadiusRight": 0.89 * 2.0 * M_A,
         "ExcisionRadiusLeft": 0.89 * 2.0 * M_B,
         "OrbitalAngularVelocity": orbital_angular_velocity,
+        "RadialExpansionVelocity": radial_expansion_velocity,
         # Resolution
         "L": refinement_level,
         "P": polynomial_order,
@@ -60,6 +63,7 @@ def generate_id(
     mass_ratio: float,
     separation: float,
     orbital_angular_velocity: float,
+    radial_expansion_velocity: float,
     refinement_level: int,
     polynomial_order: int,
     id_input_file_template: Union[str, Path] = ID_INPUT_FILE_TEMPLATE,
@@ -81,6 +85,7 @@ def generate_id(
         mass_ratio=mass_ratio,
         separation=separation,
         orbital_angular_velocity=orbital_angular_velocity,
+        radial_expansion_velocity=radial_expansion_velocity,
         refinement_level=refinement_level,
         polynomial_order=polynomial_order,
     )
@@ -110,6 +115,15 @@ def generate_id(
     "-w",
     type=float,
     help="Orbital angular velocity Omega_0.",
+    required=True,
+)
+@click.option(
+    "--radial-expansion-velocity",
+    "-a",
+    type=float,
+    help=(
+        "Radial expansion velocity adot0 which is radial velocity over radius."
+    ),
     required=True,
 )
 @click.option(

--- a/support/Pipelines/Bbh/InitialData.yaml
+++ b/support/Pipelines/Bbh/InitialData.yaml
@@ -22,7 +22,7 @@ Background: &background
         Spin: [0., 0., 0.]
         Center: [0., 0., 0.]
     AngularVelocity: {{ OrbitalAngularVelocity }}
-    Expansion: 0.
+    Expansion: {{ RadialExpansionVelocity }}
     LinearVelocity: [0., 0., 0.]
     FalloffWidths: [4.8, 4.8]
 

--- a/support/Pipelines/Bbh/Inspiral.py
+++ b/support/Pipelines/Bbh/Inspiral.py
@@ -48,6 +48,7 @@ def inspiral_parameters(
         "XCoordB": id_domain_creator["ObjectB"]["XCoord"],
         # Initial functions of time
         "InitialAngularVelocity": id_binary["AngularVelocity"],
+        "RadialExpansionVelocity": float(id_binary["Expansion"]),
         # Resolution
         "L": refinement_level,
         "P": polynomial_order,

--- a/support/Pipelines/Bbh/Inspiral.yaml
+++ b/support/Pipelines/Bbh/Inspiral.yaml
@@ -62,7 +62,7 @@ DomainCreator:
     TimeDependentMaps:
       InitialTime: 0.0
       ExpansionMap:
-        InitialValues: [1.0, 0.0]
+        InitialValues: [1.0, {{ RadialExpansionVelocity }}]
         AsymptoticVelocityOuterBoundary: -1.0e-6
         DecayTimescaleOuterBoundaryVelocity: 50.0
       RotationMap:

--- a/tests/support/Pipelines/Bbh/Test_InitialData.py
+++ b/tests/support/Pipelines/Bbh/Test_InitialData.py
@@ -29,6 +29,7 @@ class TestInitialData(unittest.TestCase):
             mass_ratio=1.5,
             separation=20.0,
             orbital_angular_velocity=0.01,
+            radial_expansion_velocity=-1.0e-5,
             refinement_level=1,
             polynomial_order=5,
         )
@@ -39,6 +40,7 @@ class TestInitialData(unittest.TestCase):
         self.assertAlmostEqual(params["ExcisionRadiusRight"], 1.068)
         self.assertAlmostEqual(params["ExcisionRadiusLeft"], 0.712)
         self.assertEqual(params["OrbitalAngularVelocity"], 0.01)
+        self.assertEqual(params["RadialExpansionVelocity"], -1.0e-5)
         self.assertEqual(params["L"], 1)
         self.assertEqual(params["P"], 5)
         # COM is zero
@@ -60,6 +62,8 @@ class TestInitialData(unittest.TestCase):
                     "20",
                     "--orbital-angular-velocity",
                     "0.01",
+                    "--radial-expansion-velocity",
+                    "-1.0e-5",
                     "--refinement-level",
                     "1",
                     "--polynomial-order",

--- a/tests/support/Pipelines/Bbh/Test_Inspiral.py
+++ b/tests/support/Pipelines/Bbh/Test_Inspiral.py
@@ -29,6 +29,7 @@ class TestInspiral(unittest.TestCase):
             mass_ratio=1.5,
             separation=20.0,
             orbital_angular_velocity=0.01,
+            radial_expansion_velocity=-1.0e-5,
             refinement_level=1,
             polynomial_order=5,
             run_dir=self.test_dir / "ID",
@@ -59,6 +60,7 @@ class TestInspiral(unittest.TestCase):
         self.assertEqual(params["XCoordA"], 8.0)
         self.assertEqual(params["XCoordB"], -12.0)
         self.assertEqual(params["InitialAngularVelocity"], 0.01)
+        self.assertEqual(params["RadialExpansionVelocity"], -1.0e-5)
         self.assertEqual(params["L"], 1)
         self.assertEqual(params["P"], 5)
 

--- a/tests/support/Pipelines/Bbh/Test_Ringdown.py
+++ b/tests/support/Pipelines/Bbh/Test_Ringdown.py
@@ -30,6 +30,7 @@ class TestInitialData(unittest.TestCase):
             mass_ratio=1.5,
             separation=20.0,
             orbital_angular_velocity=0.01,
+            radial_expansion_velocity=-1.0e-5,
             refinement_level=1,
             polynomial_order=5,
             run_dir=self.test_dir / "ID",


### PR DESCRIPTION
## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
For the `spectre bbh generate-id` command, you must now also specify the radial expansion velocity with `--radial-expansion-velocity/-a`.
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
