### PR TITLE
Add RotScaleTrans Map and Tests

### DIFF
--- a/src/Domain/CoordinateMaps/TimeDependent/CMakeLists.txt
+++ b/src/Domain/CoordinateMaps/TimeDependent/CMakeLists.txt
@@ -7,6 +7,7 @@ spectre_target_sources(
   CubicScale.cpp
   Rotation.cpp
   RotationMatrixHelpers.cpp
+  RotScaleTrans.cpp
   Shape.cpp
   SphericalCompression.cpp
   Translation.cpp
@@ -21,6 +22,7 @@ spectre_target_headers(
   ProductMaps.tpp
   Rotation.hpp
   RotationMatrixHelpers.hpp
+  RotScaleTrans.hpp
   Shape.hpp
   SphericalCompression.hpp
   Translation.hpp

--- a/src/Domain/CoordinateMaps/TimeDependent/RotScaleTrans.cpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/RotScaleTrans.cpp
@@ -1,0 +1,993 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Domain/CoordinateMaps/TimeDependent/RotScaleTrans.hpp"
+
+#include <array>
+#include <cstddef>
+#include <memory>
+#include <optional>
+#include <ostream>
+#include <pup.h>
+#include <pup_stl.h>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Matrix.hpp"
+#include "DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp"
+#include "DataStructures/Tensor/Identity.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/CoordinateMaps/TimeDependent/RotationMatrixHelpers.hpp"
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "NumericalAlgorithms/RootFinding/QuadraticEquation.hpp"
+#include "NumericalAlgorithms/RootFinding/TOMS748.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/ContainerHelpers.hpp"
+#include "Utilities/DereferenceWrapper.hpp"
+#include "Utilities/EqualWithinRoundoff.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeArray.hpp"
+#include "Utilities/MakeWithValue.hpp"
+#include "Utilities/Serialization/PupStlCpp17.hpp"
+#include "Utilities/StdArrayHelpers.hpp"
+#include "Utilities/StdHelpers.hpp"
+#include "Utilities/TypeTraits/RemoveReferenceWrapper.hpp"
+
+namespace domain::CoordinateMaps::TimeDependent {
+
+template <size_t Dim>
+RotScaleTrans<Dim>::RotScaleTrans(
+    std::optional<std::pair<std::string, std::string>> scale_f_of_t_names,
+    std::optional<std::string> rot_f_of_t_name,
+    std::optional<std::string> trans_f_of_t_name, double inner_radius,
+    double outer_radius, BlockRegion region)
+    : inner_radius_(inner_radius),
+      outer_radius_(outer_radius),
+      region_(region) {
+  if (scale_f_of_t_names.has_value()) {
+    scale_f_of_t_a_ = std::move(scale_f_of_t_names.value().first);
+    scale_f_of_t_b_ = std::move(scale_f_of_t_names.value().second);
+    f_of_t_names_.insert(scale_f_of_t_a_.value());
+    f_of_t_names_.insert(scale_f_of_t_b_.value());
+  }
+  if (rot_f_of_t_name.has_value()) {
+    rot_f_of_t_ = std::move(rot_f_of_t_name.value());
+    f_of_t_names_.insert(rot_f_of_t_.value());
+  }
+  if (trans_f_of_t_name.has_value()) {
+    trans_f_of_t_ = std::move(trans_f_of_t_name.value());
+    f_of_t_names_.insert(trans_f_of_t_.value());
+  }
+}
+
+template <size_t Dim>
+template <typename T>
+std::array<tt::remove_cvref_wrap_t<T>, Dim> RotScaleTrans<Dim>::operator()(
+    const std::array<T, Dim>& source_coords, const double time,
+    const std::unordered_map<
+        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+        functions_of_time) const {
+  std::array<tt::remove_cvref_wrap_t<T>, Dim> result{};
+  for (size_t i = 0; i < Dim; i++) {
+    gsl::at(result, i) = gsl::at(source_coords, i);
+  }
+  const tt::remove_cvref_wrap_t<T> radius = magnitude(result);
+  // Rotation Map
+  if (rot_f_of_t_.has_value()) {
+    const Matrix rot_matrix = rotation_matrix<Dim>(
+        time, *(functions_of_time.at(rot_f_of_t_.value())));
+    for (size_t i = 0; i < Dim; i++) {
+      gsl::at(result, i) = rot_matrix(i, 0) * source_coords[0];
+      for (size_t j = 1; j < Dim; j++) {
+        gsl::at(result, i) += rot_matrix(i, j) * gsl::at(source_coords, j);
+      }
+    }
+  }
+  // Expansion Map
+  if (scale_f_of_t_a_.has_value()) {
+    const double scale_a_of_t =
+        functions_of_time.at(scale_f_of_t_a_.value())->func(time)[0][0];
+    const double scale_b_of_t =
+        functions_of_time.at(scale_f_of_t_b_.value())->func(time)[0][0];
+    if (region_ == BlockRegion::Inner) {
+      for (size_t i = 0; i < Dim; i++) {
+        gsl::at(result, i) *= scale_a_of_t;
+      }
+    } else if (region_ == BlockRegion::Transition) {
+      for (size_t k = 0; k < get_size(radius); k++) {
+        // Optimization from SpEC to reduce roundoff.
+        // Closer to outer radius
+        if (1.0 - get_element(radius, k) / (inner_radius_ + outer_radius_) <
+            .5) {
+          // Expansion falloff factor w_E in the documentation of the form
+          // w_E = \frac{R_{in}(R_{out} - r)(E_{a}(t) - E_{b}(t))}{r(R_{out} -
+          // R_{in})}
+          double radial_scaling_factor =
+              ((outer_radius_ - get_element(radius, k)) *
+               (scale_a_of_t - scale_b_of_t) * inner_radius_) /
+              ((outer_radius_ - inner_radius_) * get_element(radius, k));
+          for (size_t i = 0; i < Dim; i++) {
+            get_element(gsl::at(result, i), k) *=
+                (scale_b_of_t + radial_scaling_factor);
+          }
+          // Closer to inner radius
+        } else {
+          // Expansion falloff factor w_E in the documentation of the form
+          // w_E = \frac{R_{out}(R_{in} - r)(E_{a}(t) - E_{b}(t))}{r(R_{out} -
+          // R_{in})}
+          double radial_scaling_factor =
+              ((inner_radius_ - get_element(radius, k)) *
+               (scale_a_of_t - scale_b_of_t) * outer_radius_) /
+              ((outer_radius_ - inner_radius_) * get_element(radius, k));
+          for (size_t i = 0; i < Dim; i++) {
+            get_element(gsl::at(result, i), k) *=
+                (scale_a_of_t + radial_scaling_factor);
+          }
+        }
+      }
+    } else {
+      for (size_t i = 0; i < Dim; i++) {
+        gsl::at(result, i) *= scale_b_of_t;
+      }
+    }
+  }
+  // Translation map
+  if (trans_f_of_t_.has_value()) {
+    const DataVector trans_func_of_time =
+        functions_of_time.at(trans_f_of_t_.value())->func(time)[0];
+    ASSERT(trans_func_of_time.size() == Dim,
+           "The dimension of the function of time ("
+               << trans_func_of_time.size()
+               << ") does not match the dimension of the map (" << Dim << ").");
+    if (region_ == BlockRegion::Inner) {
+      for (size_t i = 0; i < Dim; i++) {
+        gsl::at(result, i) += gsl::at(trans_func_of_time, i);
+      }
+    } else if (region_ == BlockRegion::Transition) {
+      for (size_t k = 0; k < get_size(radius); k++) {
+        // closer to outer radius
+        if (1.0 - get_element(radius, k) / (inner_radius_ + outer_radius_) <
+            .5) {
+          // Translation falloff factor w_T in the documentation of the
+          // form w_T = (R_{out} - r) / (R_{out} - R_{in})
+          const double radial_translation_factor =
+              (outer_radius_ - get_element(radius, k)) /
+              (outer_radius_ - inner_radius_);
+          for (size_t i = 0; i < Dim; i++) {
+            get_element(gsl::at(result, i), k) +=
+                gsl::at(trans_func_of_time, i) * radial_translation_factor;
+          }
+        } else {
+          // Translation falloff factor w_T in the documentation of the
+          // form w_T = (R_{in} - r) / (R_{out} - R_{in})
+          const double radial_translation_factor =
+              (inner_radius_ - get_element(radius, k)) /
+                  (outer_radius_ - inner_radius_) +
+              1.0;
+          for (size_t i = 0; i < Dim; i++) {
+            get_element(gsl::at(result, i), k) +=
+                gsl::at(trans_func_of_time, i) * radial_translation_factor;
+          }
+        }
+      }
+      ASSERT(max(magnitude(result)) <= outer_radius_ or
+                 equal_within_roundoff(max(magnitude(result)), outer_radius_),
+             "Coordinates translated outside outer radius, this should "
+             "not happen: "
+                 << max(magnitude(result))
+                 << " outer radius: " << outer_radius_);
+    }
+  }
+  return result;
+}
+
+template <size_t Dim>
+std::optional<std::array<double, Dim>> RotScaleTrans<Dim>::inverse(
+    const std::array<double, Dim>& target_coords, double time,
+    const std::unordered_map<
+        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+        functions_of_time) const {
+  std::array<double, Dim> result{};
+  for (size_t i = 0; i < Dim; i++) {
+    gsl::at(result, i) = gsl::at(target_coords, i);
+  }
+  const double radius = magnitude(result);
+  // This variable is used when taking the inverse of rotation which needs the
+  // source coords after the inverse expansion and translation have been done.
+  std::array<double, Dim> pre_rotation_result = result;
+
+  // Inverse translation without expansion
+  if (trans_f_of_t_.has_value() and not scale_f_of_t_a_.has_value()) {
+    const DataVector trans_func_of_time =
+        functions_of_time.at(trans_f_of_t_.value())->func(time)[0];
+    ASSERT(trans_func_of_time.size() == Dim,
+           "The dimension of the function of time ("
+               << trans_func_of_time.size()
+               << ") does not match the dimension of the map (" << Dim << ").");
+      double non_translated_radius_squared = 0.;
+      for (size_t i = 0; i < Dim; i++) {
+        non_translated_radius_squared +=
+            square(gsl::at(target_coords, i) - gsl::at(trans_func_of_time, i));
+      }
+      if (radius >= outer_radius_) {
+        // no translation applied
+      } else if (non_translated_radius_squared <= square(inner_radius_)) {
+        for (size_t i = 0; i < Dim; i++) {
+          gsl::at(pre_rotation_result, i) -= gsl::at(trans_func_of_time, i);
+        }
+      } else {
+        // We need to solve a quadratic of the form w^2a + wb + c where
+        // a, b, and c change if you're closer to the inner radius. This
+        // is an optimization to reduce roundoff from SpEC.
+        double a = 0.;
+        double b = 0.;
+        double c = 0.;
+        double radial_translation_factor = 0.;
+        for (size_t i = 0; i < Dim; i++) {
+          a += square(gsl::at(trans_func_of_time, i));
+        }
+        a -= square(outer_radius_ - inner_radius_);
+        // When closer to the outer radius the quadratic has the form
+        // a = T(t)^2 - (R_{out} - R_{in})^2,
+        // b = 2(R_{out}(R_{out} - R_{in}) - T(t)\vec{\bar{\xi}}), and
+        // c = \vec{\bar{\xi}}^2 - R_{out}^2
+        if (1.0 - radius / (inner_radius_ + outer_radius_) < .5) {
+          c = square(radius) - square(outer_radius_);
+          for (size_t i = 0; i < Dim; i++) {
+            b -= 2.0 * gsl::at(trans_func_of_time, i) *
+                 gsl::at(target_coords, i);
+          }
+          b += 2.0 * outer_radius_ * (outer_radius_ - inner_radius_);
+          std::optional<std::array<double, 2>> roots = real_roots(a, b, c);
+          radial_translation_factor = root_helper(roots);
+          for (size_t i = 0; i < Dim; i++) {
+            gsl::at(pre_rotation_result, i) -=
+                gsl::at(trans_func_of_time, i) * radial_translation_factor;
+          }
+        }
+        // When closer to the inner radius, the quadratic has the form
+        // a = T(t)^2 - (R_{out} - R_{in})^2,
+        // b = -2 (T(t)(T(t) - \vec{\bar{\xi}}) + R_{in}(R_{out} - R_{in}),
+        // c = (T(t) - \vec{\bar{\xi}})^2 - R_{in}^2
+        else {
+          c = -square(inner_radius_);
+          for (size_t i = 0; i < Dim; i++) {
+            b -= 2.0 * gsl::at(trans_func_of_time, i) *
+                 (gsl::at(trans_func_of_time, i) - gsl::at(target_coords, i));
+            c += square(gsl::at(trans_func_of_time, i) -
+                        gsl::at(target_coords, i));
+          }
+          b -= 2.0 * inner_radius_ * (outer_radius_ - inner_radius_);
+          std::optional<std::array<double, 2>> roots = real_roots(a, b, c);
+          radial_translation_factor = root_helper(roots);
+          for (size_t i = 0; i < Dim; i++) {
+            gsl::at(pre_rotation_result, i) -=
+                gsl::at(trans_func_of_time, i) *
+                (1.0 - radial_translation_factor);
+          }
+        }
+      }
+  }
+  // Inverse expansion without translation
+  else if (scale_f_of_t_a_.has_value() and not trans_f_of_t_.has_value()) {
+    const double scale_a_of_t =
+        functions_of_time.at(scale_f_of_t_a_.value())->func(time)[0][0];
+    const double scale_b_of_t =
+        functions_of_time.at(scale_f_of_t_b_.value())->func(time)[0][0];
+    ASSERT(scale_a_of_t != 0.0 and scale_b_of_t != 0.0,
+           "An expansion map "
+           "value was set to 0.0, this will cause an FPE. Expansion a: "
+               << scale_a_of_t << " expansion b: " << scale_b_of_t);
+    if (radius >= scale_b_of_t * outer_radius_) {
+      for (size_t i = 0; i < Dim; i++) {
+        gsl::at(pre_rotation_result, i) /= scale_b_of_t;
+      }
+    } else if (radius <= scale_a_of_t * inner_radius_) {
+      for (size_t i = 0; i < Dim; i++) {
+        gsl::at(pre_rotation_result, i) /= scale_a_of_t;
+      }
+    } else {
+      // We need to solve a quadratic of the form w^2a + wb + c where
+      // a, b, and c change if you're closer to the inner radius. This
+      // is an optimization to reduce roundoff from SpEC.
+      double a =
+          square(scale_a_of_t * inner_radius_ - scale_b_of_t * outer_radius_);
+      double b = 0.;
+      double c = 0.;
+      double radial_scaling_factor = 0.;
+      double scaled_radius = 0.;
+      double root = 0.;
+      double radius_squared = square(radius);
+      // When closer to the inner radius the quadratic has the form
+      // a = (E_{a}(t)R_{in} - E_{b}(t)R_{out})^2,
+      // b = 2E{b}(t)R_{out}(E_{a}(t)R_{in} - E_{b}(t)R_{out}),
+      // c = E_{b}(t)^2 R_{out}^2 - \bar{\xi}^2
+      if (1.0 - radius / (inner_radius_ * scale_a_of_t +
+                          outer_radius_ * scale_b_of_t) <
+          .5) {
+        scaled_radius = scale_b_of_t * outer_radius_;
+        b = 2.0 * scaled_radius *
+            (scale_a_of_t * inner_radius_ - scaled_radius);
+        c = square(scale_b_of_t * outer_radius_) - radius_squared;
+        std::optional<std::array<double, 2>> roots = real_roots(a, b, c);
+        root = root_helper(roots);
+        radial_scaling_factor =
+            (root * inner_radius_ * scale_a_of_t +
+             (1.0 - root) * outer_radius_ * scale_b_of_t) /
+            (root * inner_radius_ + (1.0 - root) * outer_radius_);
+      }
+      // When closer to the inner radius the quadratic has the form
+      // a = (E_{a}(t)R_{in} - E_{b}(t)R_{out})^2,
+      // b = 2E{a}(t)R_{in}(E_{b}(t)R_{out} - E_{a}(t)R_{in}),
+      // c = E_{a}(t)^2 R_{in}^2 - \bar{\xi}^2
+      else {
+        scaled_radius = scale_b_of_t * outer_radius_;
+        b = 2.0 * scale_a_of_t * inner_radius_ *
+            (scaled_radius - scale_a_of_t * inner_radius_);
+        c = square(scale_a_of_t * inner_radius_) - radius_squared;
+        std::optional<std::array<double, 2>> roots = real_roots(a, b, c);
+        root = root_helper(roots);
+        radial_scaling_factor =
+            ((1.0 - root) * inner_radius_ * scale_a_of_t +
+             root * outer_radius_ * scale_b_of_t) /
+            ((1.0 - root) * inner_radius_ + root * outer_radius_);
+      }
+      pre_rotation_result /= radial_scaling_factor;
+    }
+  }
+
+  // Inverse expansion and translation
+  else if (trans_f_of_t_.has_value() and scale_f_of_t_a_.has_value()) {
+    const DataVector trans_func_of_time =
+        functions_of_time.at(trans_f_of_t_.value())->func(time)[0];
+    ASSERT(trans_func_of_time.size() == Dim,
+           "The dimension of the function of time ("
+               << trans_func_of_time.size()
+               << ") does not match the dimension of the map (" << Dim << ").");
+    const double scale_a_of_t =
+        functions_of_time.at(scale_f_of_t_a_.value())->func(time)[0][0];
+    const double scale_b_of_t =
+        functions_of_time.at(scale_f_of_t_b_.value())->func(time)[0][0];
+    ASSERT(scale_a_of_t != 0.0 and scale_b_of_t != 0.0,
+           "An expansion map "
+           "value was set to 0.0, this will cause an FPE. Expansion a: "
+               << scale_a_of_t << " expansion b: " << scale_b_of_t);
+      double non_translated_radius_squared = 0.;
+      for (size_t i = 0; i < Dim; i++) {
+        non_translated_radius_squared +=
+            square(gsl::at(target_coords, i) - gsl::at(trans_func_of_time, i));
+      }
+      if (radius >= scale_b_of_t * outer_radius_) {
+        pre_rotation_result /= scale_b_of_t;
+      } else if (non_translated_radius_squared <=
+                 square(scale_a_of_t * inner_radius_)) {
+        for (size_t i = 0; i < Dim; i++) {
+          gsl::at(pre_rotation_result, i) -= gsl::at(trans_func_of_time, i);
+        }
+        pre_rotation_result /= scale_a_of_t;
+      } else {
+        // We need to solve a quadratic of the form w^2a + wb + c where
+        // a, b, and c change if you're closer to the inner radius. This
+        // is an optimization to reduce roundoff from SpEC.
+        double a =
+            square(scale_a_of_t * inner_radius_ - scale_b_of_t * outer_radius_);
+        for (size_t i = 0; i < Dim; i++) {
+          a -= square(gsl::at(trans_func_of_time, i));
+        }
+        double b = 0.;
+        double c = 0.;
+        double radial_translation_factor = 0.;
+        double radial_scaling_factor = 0.;
+        // When closer to the outer radius, the quadratic has the form
+        // a = (E_{a}(t)R_{in} - E_{b}(t)R_{out})^2 - T(t)^2,
+        // b = 2(E_{b}(t)R_{out}(E_{a}(t)R_{in} - E_{b}(t)R_{out}) +
+        // T(t)\vec{\bar{\xi}}), and
+        // c = E_{b}(t)^2 R_{out}^2 - \vec{\bar{\xi}}^2
+        if (1.0 - radius / (scale_a_of_t * inner_radius_ +
+                            scale_b_of_t * outer_radius_) <
+            .5) {
+          b = 2.0 *
+              (scale_b_of_t * outer_radius_ *
+               (scale_a_of_t * inner_radius_ - scale_b_of_t * outer_radius_));
+          for (size_t i = 0; i < Dim; i++) {
+            b += 2.0 * gsl::at(trans_func_of_time, i) *
+                 gsl::at(target_coords, i);
+          }
+          c = square(scale_b_of_t * outer_radius_) - square(radius);
+          std::optional<std::array<double, 2>> roots = real_roots(a, b, c);
+          radial_translation_factor = root_helper(roots);
+          for (size_t i = 0; i < Dim; i++) {
+            gsl::at(pre_rotation_result, i) -=
+                gsl::at(trans_func_of_time, i) * radial_translation_factor;
+          }
+          radial_scaling_factor =
+              (radial_translation_factor * inner_radius_ * scale_a_of_t +
+               (1.0 - radial_translation_factor) * outer_radius_ *
+                   scale_b_of_t) /
+              (radial_translation_factor * inner_radius_ +
+               (1.0 - radial_translation_factor) * outer_radius_);
+        }
+        // When closer to the inner radius, the quadratic has the form
+        // a = (E_{a}(t)R_{in} - E_{b}(t)R_{out})^2 - T(t)^2,
+        // b = 2(E_{a}(t)R_{in}(E_{b}(t)R_{out} - E_{a}(t)R_{in}) +
+        // T(t)(T(t) - \vec{\bar{\xi}})), and
+        // c = E_{a}(t)^2 R_{in}^2 - (\vec{\bar{\xi}} - T(t))^2
+        else {
+          b = 2.0 *
+              (scale_a_of_t * inner_radius_ *
+               (scale_b_of_t * outer_radius_ - scale_a_of_t * inner_radius_));
+          c = square(scale_a_of_t * inner_radius_) -
+              non_translated_radius_squared;
+          for (size_t i = 0; i < Dim; i++) {
+            b += 2.0 * gsl::at(trans_func_of_time, i) *
+                 (gsl::at(trans_func_of_time, i) - gsl::at(target_coords, i));
+          }
+          std::optional<std::array<double, 2>> roots = real_roots(a, b, c);
+          radial_translation_factor = root_helper(roots);
+          for (size_t i = 0; i < Dim; i++) {
+            gsl::at(pre_rotation_result, i) -=
+                gsl::at(trans_func_of_time, i) *
+                (1.0 - radial_translation_factor);
+          }
+          radial_scaling_factor =
+              ((1.0 - radial_translation_factor) * inner_radius_ *
+                   scale_a_of_t +
+               radial_translation_factor * outer_radius_ * scale_b_of_t) /
+              ((1.0 - radial_translation_factor) * inner_radius_ +
+               radial_translation_factor * outer_radius_);
+        }
+        pre_rotation_result /= radial_scaling_factor;
+      }
+  }
+
+  // Inverse rotation is the transpose of the original rotation matrix.
+  if (rot_f_of_t_.has_value()) {
+    const Matrix rot_matrix = rotation_matrix<Dim>(
+        time, *(functions_of_time.at(rot_f_of_t_.value())));
+    for (size_t i = 0; i < Dim; i++) {
+      gsl::at(result, i) = rot_matrix(0, i) * gsl::at(pre_rotation_result, 0);
+      for (size_t j = 1; j < Dim; j++) {
+        gsl::at(result, i) +=
+            rot_matrix(j, i) * gsl::at(pre_rotation_result, j);
+      }
+    }
+    return result;
+  } else {
+    return pre_rotation_result;
+  }
+}
+
+template <size_t Dim>
+template <typename T>
+std::array<tt::remove_cvref_wrap_t<T>, Dim> RotScaleTrans<Dim>::frame_velocity(
+    const std::array<T, Dim>& source_coords, double time,
+    const std::unordered_map<
+        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+        functions_of_time) const {
+  std::array<tt::remove_cvref_wrap_t<T>, Dim> result =
+      make_with_value<std::array<tt::remove_cvref_wrap_t<T>, Dim>>(
+          dereference_wrapper(source_coords[0]), 0.0);
+  tt::remove_cvref_wrap_t<T> radius =
+      square(dereference_wrapper(source_coords[0]));
+  for (size_t i = 1; i < Dim; ++i) {
+    radius += square(dereference_wrapper(gsl::at(source_coords, i)));
+  }
+  radius = sqrt(radius);
+  // Rotation map with no expansion
+  if (rot_f_of_t_.has_value() and not scale_f_of_t_a_.has_value()) {
+    const Matrix rot_matrix_deriv = rotation_matrix_deriv<Dim>(
+        time, *(functions_of_time.at(rot_f_of_t_.value())));
+    for (size_t i = 0; i < Dim; i++) {
+      for (size_t j = 0; j < Dim; j++) {
+        gsl::at(result, i) +=
+            rot_matrix_deriv(i, j) * gsl::at(source_coords, j);
+      }
+    }
+  }
+  // Expansion map with no rotation
+  else if (scale_f_of_t_a_.has_value() and not rot_f_of_t_.has_value()) {
+    const double dt_a_of_t = functions_of_time.at(scale_f_of_t_a_.value())
+                                 ->func_and_deriv(time)[1][0];
+    const double dt_b_of_t = functions_of_time.at(scale_f_of_t_b_.value())
+                                 ->func_and_deriv(time)[1][0];
+    if (region_ == BlockRegion::Inner) {
+      for (size_t i = 0; i < Dim; i++) {
+        gsl::at(result, i) +=
+            dereference_wrapper(gsl::at(source_coords, i)) * (dt_a_of_t);
+      }
+    } else if (region_ == BlockRegion::Transition) {
+      for (size_t k = 0; k < get_size(radius); k++) {
+        double deriv_radial_scaling_factor = 0;
+        // Optimization from SpEC to reduce roundoff.
+        // Closer to outer radius
+        if (1.0 - get_element(radius, k) / (inner_radius_ + outer_radius_) <
+            .5) {
+          deriv_radial_scaling_factor =
+              ((outer_radius_ - get_element(radius, k)) *
+               (dt_a_of_t - dt_b_of_t) * inner_radius_) /
+              ((outer_radius_ - inner_radius_) * get_element(radius, k));
+          for (size_t i = 0; i < Dim; i++) {
+            get_element(gsl::at(result, i), k) +=
+                get_element(dereference_wrapper(gsl::at(source_coords, i)), k) *
+                (dt_b_of_t + deriv_radial_scaling_factor);
+          }
+          // Closer to inner radius
+        } else {
+          deriv_radial_scaling_factor =
+              ((inner_radius_ - get_element(radius, k)) *
+               (dt_a_of_t - dt_b_of_t) * outer_radius_) /
+              ((outer_radius_ - inner_radius_) * get_element(radius, k));
+          for (size_t i = 0; i < Dim; i++) {
+            get_element(gsl::at(result, i), k) +=
+                get_element(dereference_wrapper(gsl::at(source_coords, i)), k) *
+                (dt_a_of_t + deriv_radial_scaling_factor);
+          }
+        }
+      }
+    } else {
+      for (size_t i = 0; i < Dim; i++) {
+        gsl::at(result, i) +=
+            dereference_wrapper(gsl::at(source_coords, i)) * (dt_b_of_t);
+      }
+    }
+  }
+  // Rotation and expansion map
+  else if (scale_f_of_t_a_.has_value() and rot_f_of_t_.has_value()) {
+    const Matrix rot_matrix = rotation_matrix<Dim>(
+        time, *(functions_of_time.at(rot_f_of_t_.value())));
+    const Matrix rot_matrix_deriv = rotation_matrix_deriv<Dim>(
+        time, *(functions_of_time.at(rot_f_of_t_.value())));
+    std::array<DataVector, 2> scale_a_func_and_deriv =
+        functions_of_time.at(scale_f_of_t_a_.value())->func_and_deriv(time);
+    std::array<DataVector, 2> scale_b_func_and_deriv =
+        functions_of_time.at(scale_f_of_t_b_.value())->func_and_deriv(time);
+    const double scale_a_of_t = scale_a_func_and_deriv[0][0];
+    const double scale_b_of_t = scale_b_func_and_deriv[0][0];
+    const double dt_a_of_t = scale_a_func_and_deriv[1][0];
+    const double dt_b_of_t = scale_b_func_and_deriv[1][0];
+    if (region_ == BlockRegion::Inner) {
+      for (size_t i = 0; i < Dim; i++) {
+        for (size_t j = 0; j < Dim; j++) {
+          gsl::at(result, i) += dereference_wrapper(gsl::at(source_coords, j)) *
+                                (scale_a_of_t * rot_matrix_deriv(i, j) +
+                                 dt_a_of_t * rot_matrix(i, j));
+        }
+      }
+    } else if (region_ == BlockRegion::Transition) {
+      for (size_t k = 0; k < get_size(radius); k++) {
+        double radial_scaling_factor = 0;
+        double deriv_radial_scaling_factor = 0;
+        // Optimization from SpEC to reduce roundoff.
+        // Closer to outer radius
+        if (1.0 - get_element(radius, k) / (inner_radius_ + outer_radius_) <
+            .5) {
+          radial_scaling_factor =
+              ((outer_radius_ - get_element(radius, k)) *
+               (scale_a_of_t - scale_b_of_t) * inner_radius_) /
+              ((outer_radius_ - inner_radius_) * get_element(radius, k));
+          deriv_radial_scaling_factor =
+              ((outer_radius_ - get_element(radius, k)) *
+               (dt_a_of_t - dt_b_of_t) * inner_radius_) /
+              ((outer_radius_ - inner_radius_) * get_element(radius, k));
+          for (size_t i = 0; i < Dim; i++) {
+            for (size_t j = 0; j < Dim; j++) {
+              get_element(gsl::at(result, i), k) +=
+                  get_element(dereference_wrapper(gsl::at(source_coords, j)),
+                              k) *
+                  (rot_matrix_deriv(i, j) *
+                       (scale_b_of_t + radial_scaling_factor) +
+                   rot_matrix(i, j) *
+                       (dt_b_of_t + deriv_radial_scaling_factor));
+            }
+          }
+          // Closer to inner radius
+        } else {
+          radial_scaling_factor =
+              ((inner_radius_ - get_element(radius, k)) *
+               (scale_a_of_t - scale_b_of_t) * outer_radius_) /
+              ((outer_radius_ - inner_radius_) * get_element(radius, k));
+          deriv_radial_scaling_factor =
+              ((inner_radius_ - get_element(radius, k)) *
+               (dt_a_of_t - dt_b_of_t) * outer_radius_) /
+              ((outer_radius_ - inner_radius_) * get_element(radius, k));
+          for (size_t i = 0; i < Dim; i++) {
+            for (size_t j = 0; j < Dim; j++) {
+              get_element(gsl::at(result, i), k) +=
+                  get_element(dereference_wrapper(gsl::at(source_coords, j)),
+                              k) *
+                  (rot_matrix_deriv(i, j) *
+                       (scale_a_of_t + radial_scaling_factor) +
+                   rot_matrix(i, j) *
+                       (dt_a_of_t + deriv_radial_scaling_factor));
+            }
+          }
+        }
+      }
+    } else {
+      for (size_t i = 0; i < Dim; i++) {
+        for (size_t j = 0; j < Dim; j++) {
+          gsl::at(result, i) += dereference_wrapper(gsl::at(source_coords, j)) *
+                                (scale_b_of_t * rot_matrix_deriv(i, j) +
+                                 dt_b_of_t * rot_matrix(i, j));
+        }
+      }
+    }
+  }
+  // Translation map
+  if (trans_f_of_t_.has_value()) {
+    const DataVector deriv_trans_func_of_time =
+        functions_of_time.at(trans_f_of_t_.value())->func_and_deriv(time)[1];
+    ASSERT(deriv_trans_func_of_time.size() == Dim,
+           "The dimension of the function of time ("
+               << deriv_trans_func_of_time.size()
+               << ") does not match the dimension of the map (" << Dim << ").");
+    if (region_ == BlockRegion::Inner) {
+      for (size_t i = 0; i < Dim; i++) {
+        gsl::at(result, i) += gsl::at(deriv_trans_func_of_time, i);
+      }
+    } else if (region_ == BlockRegion::Transition) {
+      for (size_t k = 0; k < get_size(radius); k++) {
+        // this is the linear falloff factor w in the documentation of the
+        // form w = (R_{out} - r) / (R_{out} - R_{in})
+        if (1.0 - get_element(radius, k) / (inner_radius_ + outer_radius_) <
+            .5) {
+          const double radial_translation_factor =
+              (outer_radius_ - get_element(radius, k)) /
+              (outer_radius_ - inner_radius_);
+          for (size_t i = 0; i < Dim; i++) {
+            get_element(gsl::at(result, i), k) +=
+                gsl::at(deriv_trans_func_of_time, i) *
+                radial_translation_factor;
+          }
+        } else {
+          const double radial_translation_factor =
+              (inner_radius_ - get_element(radius, k)) /
+                  (outer_radius_ - inner_radius_) +
+              1.0;
+          for (size_t i = 0; i < Dim; i++) {
+            get_element(gsl::at(result, i), k) +=
+                gsl::at(deriv_trans_func_of_time, i) *
+                radial_translation_factor;
+          }
+        }
+      }
+    }
+  }
+  return result;
+}
+
+template <size_t Dim>
+template <typename T>
+tnsr::Ij<tt::remove_cvref_wrap_t<T>, Dim, Frame::NoFrame>
+RotScaleTrans<Dim>::jacobian(
+    const std::array<T, Dim>& source_coords, double time,
+    const std::unordered_map<
+        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+        functions_of_time) const {
+  auto result = make_with_value<
+      tnsr::Ij<tt::remove_cvref_wrap_t<T>, Dim, Frame::NoFrame>>(
+      dereference_wrapper(source_coords[0]), 0.0);
+  // Making the identity in case rotation isn't specified.
+  for (size_t i = 0; i < Dim; i++) {
+    result.get(i, i) = 1;
+  }
+  const tt::remove_cvref_wrap_t<T> radius = magnitude(source_coords);
+  // Rotation map with no expansion
+  if (rot_f_of_t_.has_value() and not scale_f_of_t_a_.has_value()) {
+    const Matrix rot_matrix = rotation_matrix<Dim>(
+        time, *(functions_of_time.at(rot_f_of_t_.value())));
+
+    for (size_t i = 0; i < Dim; i++) {
+      for (size_t j = 0; j < Dim; j++) {
+        result.get(i, j) = rot_matrix(i, j);
+      }
+    }
+  }
+  // Expansion map with no rotation
+  else if (scale_f_of_t_a_.has_value() and not rot_f_of_t_.has_value()) {
+    const double scale_a_of_t =
+        functions_of_time.at(scale_f_of_t_a_.value())->func(time)[0][0];
+    const double scale_b_of_t =
+        functions_of_time.at(scale_f_of_t_b_.value())->func(time)[0][0];
+    if (region_ == BlockRegion::Inner) {
+      for (size_t i = 0; i < Dim; i++) {
+        result.get(i, i) = scale_a_of_t;
+      }
+    } else if (region_ == BlockRegion::Transition) {
+      for (size_t k = 0; k < get_size(radius); k++) {
+        const double alpha = inner_radius_ * outer_radius_ /
+                             (square((get_element(radius, k))) *
+                              (inner_radius_ - outer_radius_));
+        // Optimization from SpEC to reduce roundoff.
+        // Closer to outer radius
+        if (1.0 - get_element(radius, k) / (inner_radius_ + outer_radius_) <
+            .5) {
+          double radial_scaling_factor =
+              ((outer_radius_ - get_element(radius, k)) *
+               (scale_a_of_t - scale_b_of_t) * inner_radius_) /
+              ((outer_radius_ - inner_radius_) * get_element(radius, k));
+          for (size_t i = 0; i < Dim; i++) {
+            for (size_t j = 0; j < Dim; j++) {
+              get_element(result.get(i, j), k) =
+                  alpha *
+                  get_element(dereference_wrapper(gsl::at(source_coords, i)),
+                              k) *
+                  (scale_a_of_t - scale_b_of_t) *
+                  get_element(dereference_wrapper(gsl::at(source_coords, j)),
+                              k) /
+                  get_element(radius, k);
+            }
+            get_element(result.get(i, i), k) +=
+                scale_b_of_t + radial_scaling_factor;
+          }
+          // Closer to inner radius
+        } else {
+          double radial_scaling_factor =
+              ((inner_radius_ - get_element(radius, k)) *
+               (scale_a_of_t - scale_b_of_t) * outer_radius_) /
+              ((outer_radius_ - inner_radius_) * get_element(radius, k));
+          for (size_t i = 0; i < Dim; i++) {
+            for (size_t j = 0; j < Dim; j++) {
+              get_element(result.get(i, j), k) =
+                  alpha *
+                  get_element(dereference_wrapper(gsl::at(source_coords, i)),
+                              k) *
+                  (scale_a_of_t - scale_b_of_t) *
+                  get_element(dereference_wrapper(gsl::at(source_coords, j)),
+                              k) /
+                  get_element(radius, k);
+            }
+            get_element(result.get(i, i), k) +=
+                scale_a_of_t + radial_scaling_factor;
+          }
+        }
+      }
+    } else {
+      for (size_t i = 0; i < Dim; i++) {
+        result.get(i, i) = scale_b_of_t;
+      }
+    }
+  }
+  // Rotation and expansion map
+  else if (scale_f_of_t_a_.has_value() and rot_f_of_t_.has_value()) {
+    const Matrix rot_matrix = rotation_matrix<Dim>(
+        time, *(functions_of_time.at(rot_f_of_t_.value())));
+    const double scale_a_of_t =
+        functions_of_time.at(scale_f_of_t_a_.value())->func(time)[0][0];
+    const double scale_b_of_t =
+        functions_of_time.at(scale_f_of_t_b_.value())->func(time)[0][0];
+    if (region_ == BlockRegion::Inner) {
+      for (size_t i = 0; i < Dim; i++) {
+        for (size_t j = 0; j < Dim; j++) {
+          result.get(i, j) = scale_a_of_t * rot_matrix(i, j);
+        }
+      }
+    } else if (region_ == BlockRegion::Transition) {
+      for (size_t k = 0; k < get_size(radius); k++) {
+        const double alpha = inner_radius_ * outer_radius_ /
+                             (square((get_element(radius, k))) *
+                              (inner_radius_ - outer_radius_));
+        // Optimization from SpEC to reduce roundoff.
+        // Closer to outer radius
+        if (1.0 - get_element(radius, k) / (inner_radius_ + outer_radius_) <
+            .5) {
+          double radial_scaling_factor =
+              ((outer_radius_ - get_element(radius, k)) *
+               (scale_a_of_t - scale_b_of_t) * inner_radius_) /
+              ((outer_radius_ - inner_radius_) * get_element(radius, k));
+          for (size_t i = 0; i < Dim; i++) {
+            double rotated_coords = 0;
+            for (size_t l = 0; l < Dim; l++) {
+              rotated_coords +=
+                  rot_matrix(i, l) *
+                  get_element(dereference_wrapper(gsl::at(source_coords, l)),
+                              k);
+            }
+            for (size_t j = 0; j < Dim; j++) {
+              get_element(result.get(i, j), k) =
+                  scale_b_of_t * rot_matrix(i, j) +
+                  alpha * rotated_coords * (scale_a_of_t - scale_b_of_t) *
+                      get_element(
+                          dereference_wrapper(gsl::at(source_coords, j)), k) /
+                      get_element(radius, k) +
+                  rot_matrix(i, j) * radial_scaling_factor;
+            }
+          }
+          // Closer to inner radius
+        } else {
+          double radial_scaling_factor =
+              ((inner_radius_ - get_element(radius, k)) *
+               (scale_a_of_t - scale_b_of_t) * outer_radius_) /
+              ((outer_radius_ - inner_radius_) * get_element(radius, k));
+          for (size_t i = 0; i < Dim; i++) {
+            double rotated_coords = 0;
+            for (size_t l = 0; l < Dim; l++) {
+              rotated_coords +=
+                  rot_matrix(i, l) *
+                  get_element(dereference_wrapper(gsl::at(source_coords, l)),
+                              k);
+            }
+            for (size_t j = 0; j < Dim; j++) {
+              get_element(result.get(i, j), k) =
+                  scale_a_of_t * rot_matrix(i, j) +
+                  alpha * rotated_coords * (scale_a_of_t - scale_b_of_t) *
+                      get_element(
+                          dereference_wrapper(gsl::at(source_coords, j)), k) /
+                      get_element(radius, k) +
+                  rot_matrix(i, j) * radial_scaling_factor;
+            }
+          }
+        }
+      }
+    } else {
+      for (size_t i = 0; i < Dim; i++) {
+        for (size_t j = 0; j < Dim; j++) {
+          result.get(i, j) = scale_b_of_t * rot_matrix(i, j);
+        }
+      }
+    }
+  }
+  // Translation map
+  if (trans_f_of_t_.has_value()) {
+      const DataVector trans_func_of_time =
+          functions_of_time.at(trans_f_of_t_.value())->func_and_deriv(time)[0];
+      for (size_t i = 0; i < Dim; i++) {
+        const double deriv_translation_factor =
+            (-gsl::at(trans_func_of_time, i) / (outer_radius_ - inner_radius_));
+        for (size_t j = 0; j < Dim; j++) {
+          for (size_t k = 0; k < get_size(radius); k++) {
+            // The jacobian is the identity for the translation map in regions
+            // not between the inner and outer radius.
+            if (region_ == BlockRegion::Transition) {
+              // using the derivative of the radial falloff factor as
+              // \frac{dw}{dr} = \frac{-1.0}{R_{out} - R{in}}
+              get_element(result.get(i, j), k) +=
+                  deriv_translation_factor *
+                  get_element(dereference_wrapper(gsl::at(source_coords, j)),
+                              k) /
+                  get_element(radius, k);
+            }
+          }
+        }
+      }
+  }
+  return result;
+}
+
+template <size_t Dim>
+template <typename T>
+tnsr::Ij<tt::remove_cvref_wrap_t<T>, Dim, Frame::NoFrame>
+RotScaleTrans<Dim>::inv_jacobian(
+    const std::array<T, Dim>& source_coords, const double time,
+    const std::unordered_map<
+        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+        functions_of_time) const {
+  return determinant_and_inverse(
+             jacobian(source_coords, time, functions_of_time))
+      .second;
+}
+
+template <size_t Dim>
+double RotScaleTrans<Dim>::root_helper(
+    const std::optional<std::array<double, 2>> roots) const {
+  ASSERT(roots.has_value(), "No roots found");
+  if (roots.value()[0] >= 0 and roots.value()[0] <= 1.0) {
+    ASSERT(roots.value()[1] > 1.0 or roots.value()[1] < 0.0,
+           "Singular map: two solutions between 0 and 1");
+    return roots.value()[0];
+  } else if (roots.value()[1] >= 0 and roots.value()[1] <= 1.0) {
+    return roots.value()[1];
+  } else if (equal_within_roundoff(roots.value()[0], 1.0) or
+
+             equal_within_roundoff(roots.value()[1], 1.0)) {
+    return 1.0;
+  } else if (equal_within_roundoff(roots.value()[0], 0.0) or
+
+             equal_within_roundoff(roots.value()[1], 0.0)) {
+    return 0.0;
+  }
+  ERROR("Root helper couldn't find the correct root");
+  return 0.0;
+}
+
+template <size_t Dim>
+void RotScaleTrans<Dim>::pup(PUP::er& p) {
+  size_t version = 0;
+  p | version;
+  // Remember to increment the version number when making changes to this
+  // function. Retain support for unpacking data written by previous versions
+  // whenever possible. See `Domain` docs for details.
+  if (version >= 0) {
+    p | scale_f_of_t_a_;
+    p | scale_f_of_t_b_;
+    p | rot_f_of_t_;
+    p | trans_f_of_t_;
+    p | inner_radius_;
+    p | outer_radius_;
+    p | region_;
+  }
+  // No need to pup this because it is uniquely determined by f_of_t_names_
+  if (p.isUnpacking()) {
+    f_of_t_names_.clear();
+    if (rot_f_of_t_.has_value()) {
+      f_of_t_names_.insert(rot_f_of_t_.value());
+    }
+    if (scale_f_of_t_a_.has_value() and scale_f_of_t_b_.has_value()) {
+      f_of_t_names_.insert(scale_f_of_t_a_.value());
+      f_of_t_names_.insert(scale_f_of_t_b_.value());
+    }
+    if (trans_f_of_t_.has_value()) {
+      f_of_t_names_.insert(trans_f_of_t_.value());
+    }
+  }
+}
+
+template <size_t Dim>
+bool operator==(const RotScaleTrans<Dim>& lhs, const RotScaleTrans<Dim>& rhs) {
+  return lhs.scale_f_of_t_a_ == rhs.scale_f_of_t_a_ and
+         lhs.scale_f_of_t_b_ == rhs.scale_f_of_t_b_ and
+         lhs.rot_f_of_t_ == rhs.rot_f_of_t_ and
+         lhs.trans_f_of_t_ == rhs.trans_f_of_t_ and
+         lhs.inner_radius_ == rhs.inner_radius_ and
+         lhs.outer_radius_ == rhs.outer_radius_ and lhs.region_ == rhs.region_;
+}
+
+// Explicit instantiations
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data)                                \
+  template class RotScaleTrans<DIM(data)>;                  \
+  template bool operator==(const RotScaleTrans<DIM(data)>&, \
+                           const RotScaleTrans<DIM(data)>&);
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (2, 3))
+
+#undef INSTANTIATE
+
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(1, data)
+
+#define INSTANTIATE(_, data)                                                \
+  template std::array<tt::remove_cvref_wrap_t<DTYPE(data)>, DIM(data)>      \
+  RotScaleTrans<DIM(data)>::operator()(                                     \
+      const std::array<DTYPE(data), DIM(data)>& source_coords, double time, \
+      const std::unordered_map<                                             \
+          std::string,                                                      \
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&        \
+          functions_of_time) const;                                         \
+  template std::array<tt::remove_cvref_wrap_t<DTYPE(data)>, DIM(data)>      \
+  RotScaleTrans<DIM(data)>::frame_velocity(                                 \
+      const std::array<DTYPE(data), DIM(data)>& source_coords, double time, \
+      const std::unordered_map<                                             \
+          std::string,                                                      \
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&        \
+          functions_of_time) const;                                         \
+  template tnsr::Ij<tt::remove_cvref_wrap_t<DTYPE(data)>, DIM(data),        \
+                    Frame::NoFrame>                                         \
+  RotScaleTrans<DIM(data)>::jacobian(                                       \
+      const std::array<DTYPE(data), DIM(data)>& source_coords, double time, \
+      const std::unordered_map<                                             \
+          std::string,                                                      \
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&        \
+          functions_of_time) const;                                         \
+  template tnsr::Ij<tt::remove_cvref_wrap_t<DTYPE(data)>, DIM(data),        \
+                    Frame::NoFrame>                                         \
+  RotScaleTrans<DIM(data)>::inv_jacobian(                                   \
+      const std::array<DTYPE(data), DIM(data)>& source_coords, double time, \
+      const std::unordered_map<                                             \
+          std::string,                                                      \
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&        \
+          functions_of_time) const;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (2, 3),
+                        (double, DataVector,
+                         std::reference_wrapper<const double>,
+                         std::reference_wrapper<const DataVector>))
+#undef DIM
+#undef DTYPE
+#undef INSTANTIATE
+}  // namespace domain::CoordinateMaps::TimeDependent

--- a/src/Domain/CoordinateMaps/TimeDependent/RotScaleTrans.hpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/RotScaleTrans.hpp
@@ -1,0 +1,365 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <memory>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "PointwiseFunctions/MathFunctions/MathFunction.hpp"
+#include "Utilities/TypeTraits/RemoveReferenceWrapper.hpp"
+
+/// \cond
+namespace domain::FunctionsOfTime {
+class FunctionOfTime;
+}  // namespace domain::FunctionsOfTime
+namespace PUP {
+class er;
+}  // namespace PUP
+/// \endcond
+
+namespace domain::CoordinateMaps::TimeDependent {
+/*!
+ * \ingroup CoordMapsTimeDependentGroup
+ * \brief RotScaleTrans map which applies a combination of rotation, expansion,
+ * and translation based on which maps are supplied.
+ *
+ * \details This map adds a rotation, expansion and translation based on what
+ * types of maps are needed. Translation and expansion have piecewise functions
+ * that map the coordinates $\vec{\xi}$ based on what region
+ * $|\vec{\xi}|$ is in. Coordinates within the inner radius are translated by
+ * the translation function of time $\vec{T}(t)$ and expanded by the inner
+ * expansion function of time $E_{a}(t)$. Coordinates in between the inner
+ * radius and outer radius have a linear radial falloff applied to them.
+ * Coordinates at or beyond the outer radius have no translation applied and are
+ * expanded by the outer expansion function of time $E_{b}(t)$. This map assumes
+ * that the center of the map is at (0., 0., 0.). There is an enum class to set
+ * which region your block is in. Specifying RotScaleTrans::BlockRegion::Inner
+ * treats coordinates as if they're inside the inner radius, setting
+ * RotScaleTrans::BlockRegion::Transition treats the points as if they're
+ * between the inner and outer radius, and setting
+ * RotScaleTrans::BlockRegion::Outer treats points as if they're on or beyond
+ * the outer boundary.
+ *
+ * \note $E_{a}(t)$ and $E_{b}(t)$ are $a(t)$ and $b(t)$ from the CubicScale
+ * documentation.
+ *
+ * ## Mapped Coordinates
+ * The RotScaleTrans map takes the coordinates $\vec{\xi}$ to the target
+ * coordinates $\vec{\bar{\xi}}$ through
+ * \f{equation}{
+ * \vec{\bar{\xi}} = \left\{\begin{array}{ll}E_{a}(t)R(t)\vec{\xi} + \vec{T}(t),
+ * & |\vec{\xi}| \leq R_{in}, \\ (w_{E} + E_{a}(t))R(t)\vec{\xi} + (1 +
+ * w_{T})\vec{T}(t), & R_{in} < |\vec{\xi}| \leq 0.5(R_{in} + R_{out}),
+ * \\ (w_{E} + E_{b}(t))R(t)\vec{\xi} + w_{T}\vec{T}(t), & 0.5(R_{in} + R_{out})
+ * < |\vec{\xi}| < R_{out}, \\ E_{b}(t)R(t)\vec{\xi}, & |\vec{\xi}| \geq R_{out}
+ * \end{array}\right.
+ * \f}
+ *
+ * Where $R_{in}$ is the inner radius, $R_{out}$ is the outer radius, and
+ * $w_{T}$ is the translation falloff factor and $w_{E}$ is the expansion
+ * falloff factor found through
+ * \f{equation}{
+ * w_{E} = \left\{\begin{array}{ll}\frac{R_{in}(R_{out} - |\vec{\xi}|)(E_{a}(t)
+ * - E_{b}(t))}{|\vec{\xi}|(R_{out} - R_{in})}, & R_{in} < |\vec{\xi}| \leq
+ * 0.5(R_{in} + R_{out}), \\ \frac{R_{out}(R_{in} - |\vec{\xi}|)(E_{a}(t)
+ * - E_{b}(t))}{|\vec{\xi}|(R_{out} - R_{in})}, & 0.5(R_{in} + R_{out}) <
+ * |\vec{\xi}| < R_{out} \end{array}\right.
+ * \f}
+ *
+ * and
+ *
+ * \f{equation}{
+ * w_{T} = \left\{\begin{array}{ll}\frac{R_{in} - |\vec{\xi}|}{R_{out} -
+ * R_{in}}, & R_{in} < |\vec{\xi}| \leq 0.5(R_{in} + R_{out}), \\ \frac{R_{out}
+ * - |\vec{\xi}|}{R_{out} - R_{in}}, & 0.5(R_{in} + R_{out}) < |\vec{\xi}| <
+ * R_{out} \end{array}\right.
+ * \f}
+ *
+ * $w_{E}$ and $w_{T}$ are calculated differently based on if you're closer
+ * to the inner radius or outer radius to reduce roundoff error.
+ *
+ * ## Inverse
+ * The inverse function maps the coordinates $\vec{\bar{\xi}}$ back to the
+ * original coordinates $\vec{\xi}$ through different equations based on
+ * which maps are supplied.
+ *
+ * If Rotation, Expansion, and Translation Maps are supplied then the
+ * inverse is given by
+ *
+ * \f{equation}{
+ * \label{eq:full_inverse}
+ * \vec{\xi} = \left\{\begin{array}{ll}R^{T}(t)(\frac{(\vec{\bar{\xi}} -
+ * \vec{T}(t))}{E_{a}(t)}), & |\vec{\bar{\xi}}| \leq R_{in}E_{a}(t),
+ * \\ R^{T}(t)\frac{\vec{\bar{\xi}} - w_{T}\vec{T}(t)}{w_{E}},
+ * & R_{in}E_{a}(t) < |\vec{\bar{\xi}}| \leq 0.5(R_{in}E_{a}(t) +
+ * R_{out}E_{b}(t)), \\ R^{T}(t)\frac{\vec{\bar{\xi}} - (1.0 -
+ * w_{T})\vec{T}(t)}{w_{E}}, & 0.5(R_{in}E_{a}(t) + R_{out}E_{b}(t)) <
+ * |\vec{\bar{\xi}}| < R_{out}E_{b}(t),
+ * \\ R^{T}(t)\frac{\vec{\bar{\xi}}}{E_{b}(t)}, & |\vec{\bar{\xi}}| \geq
+ * R_{out}E_{b}(t) \end{array}\right.
+ * \f}
+ *
+ * Where $w_{T}$ and $w_{E}$ are found through different quadratic solves.
+ *
+ * When closer to $R_{in}$ the quadratic has the form
+ * \f{equation}{
+ * w_{T}^2((E_{a}(t)R_{in} - E_{b}(t)R_{out})^2 - T(t)^2) +
+ * 2w_{T}(E_{a}(t)R_{in}(E_{b}(t)R_{out} - E_{a}(t)R_{in}) + \vec{T}(t) \cdot
+ * (\vec{T}(t) - \vec{\bar{\xi}})) + \vec{T}(t) \cdot \vec{\bar{\xi}})
+ * + E_{a}(t)^2 R_{in}^2 - (\vec{\bar{\xi}} - \vec{T}(t))^2
+ * \f}
+ *
+ * where $w_{E} = \frac{(1.0 - w_{T})R_{in}E_{a}(t) +
+ * w_{T}R_{out}E_{b}(t)}{(1.0 - w_{T})R_{in} + w_{T}R_{out}}$
+ *
+ * When closer to $R_{out}$ the quadratic has the form
+ * \f{equation}{
+ * w_{T}^2((E_{a}(t)R_{in} - E_{b}(t)R_{out})^2 - T(t)^2) +
+ * 2w_{T}(E_{b}(t)R_{out}(E_{a}(t)R_{in} - E_{b}(t)R_{out}) +
+ * \vec{T}(t) \cdot \vec{\bar{\xi}})
+ * + E_{b}(t)^2 R_{out}^2 - \vec{\bar{\xi}}^2
+ * \f}
+ *
+ * where $w_{E} = \frac{w_{T}R_{in}E_{a}(t) + (1.0 -
+ * w_{T})R_{out}E_{b}(t)}{w_{T}R_{in} + (1.0 - w_{T})R_{out}}$
+ *
+ * If Rotation and Expansion are supplied then the inverse is given by
+ *
+ * \f{equation}{
+ * \vec{\xi} =
+ * \left\{\begin{array}{ll}R^{T}(t)(\frac{\vec{\bar{\xi}}}{E_{a}(t)}), &
+ * |\vec{\bar{\xi}}| \leq R_{in}E_{a}(t),
+ * \\ R^{T}(t)\frac{\vec{\bar{\xi}}}{w_{E}}, & R_{in}E_{a}(t) <
+ * |\vec{\bar{\xi}}| \leq 0.5(R_{in}E_{a}(t) + R_{out}E_{b}(t)),
+ * \\ R^{T}(t)\frac{\vec{\bar{\xi}}}{w_{E}}, & 0.5(R_{in}E_{a}(t)
+ * + R_{out}E_{b}(t)) < |\vec{\bar{\xi}}| < R_{out}E_{b}(t),
+ * \\ R^{T}(t)\frac{\vec{\bar{\xi}}}{E_{b}(t)}, & |\vec{\bar{\xi}}| \geq
+ * R_{out}E_{b}(t) \end{array}\right.
+ * \f}
+ *
+ * Where $w_{E}$ is found through different quadratic solves.
+ *
+ * When closer to $R_{in}$ the quadratic has the form
+ * \f{equation}{
+ * w^2(E_{a}(t)R_{in} - E_{b}(t)R_{out})^2 +
+ * 2wE_{a}(t)R_{in}(E_{b}(t)R_{out} - E_{a}(t)R_{in})
+ * + (E_{a}(t) R_{in})^2 - \bar{\xi}^2
+ * \f}
+ * with $w_{E} = \frac{E_{a}(t)R_{in}(1.0 - w) + wE_{b}(t)R_{out}}{R_{in}(1.0 -
+ * w) + wR_{out}}$
+ *
+ * When closer to $R_{out}$ the quadratic has the form
+ * \f{equation}{
+ * w^2(E_{a}(t)R_{in} - E_{b}(t)R_{out})^2 +
+ * 2wE_{b}(t)R_{out}(E_{a}(t)R_{in} - E_{b}(t)R_{out})
+ * + (E_{b}(t) R_{out})^2 - \bar{\xi}^2
+ * \f}
+ * with $w_{E} = \frac{wE_{a}(t)R_{in} + E_{b}(t)R_{out}(1.0 - w)}{wR_{in} +
+ * R_{out}(1.0 - w)}$
+ *
+ * If Rotation and Translation are supplied, then the inverse is given by
+ *
+ * \f{equation}{
+ * \vec{\xi} = \left\{\begin{array}{ll}R^{T}(t)(\vec{\bar{\xi}} -
+ * \vec{T}(t)), & |\vec{\bar{\xi}}| \leq R_{in},
+ * \\ R^{T}(t)(\vec{\bar{\xi}} - w_{T}\vec{T}(t)), & R_{in} < |\vec{\bar{\xi}}|
+ * \leq 0.5(R_{in} + R_{out}), \\ R^{T}(t)(\vec{\bar{\xi}} - (1.0 -
+ * w_{T})\vec{T}(t)), & 0.5(R_{in} + R_{out}) < |\vec{\bar{\xi}}| < R_{out},
+ * \\ R^{T}(t)\vec{\bar{\xi}}, & |\vec{\bar{\xi}}| \geq R_{out}
+ * \end{array}\right.
+ * \f}
+ *
+ * Where $w_{T}$ is found through different quadratic solves.
+ *
+ * When closer to $R_{in}$ the quadratic has the form
+ * \f{equation}{
+ * w_{T}^2(T(t)^2 - (R_{out} - R_{in})^2) - 2w_{T}(\vec{T}(t) \cdot
+ * (\vec{T}(t) - \vec{\bar{\xi}}) + R_{in}(R_{out} - R_{in})
+ * + (\vec{T}(t) - \vec{\bar{\xi}})^2 - R_{in}^2
+ * \f}
+ *
+ * When closer to $R_{out}$ the quadratic has the form
+ * \f{equation}{
+ * w_{T}^2(T(t)^2 - (R_{out} - R_{in})^2) +
+ * 2w_{T}(R_{out}(R_{out} - R_{in}) - \vec{T}(t) \cdot \vec{\bar{\xi}})
+ * + \vec{\bar{\xi}}^2 - R_{out}^2
+ * \f}
+ *
+ * If Expansion and Translation are supplied, then the inverse is given by
+ * Eq. $\ref{eq:full_inverse}$, with no transpose of rotation applied.
+ *
+ * \note For all the maps with rotation, the inverse of rotation is the
+ * transpose of the original rotation. For maps with translation, the inverse
+ * map also assumes that if $\vec{\bar{\xi}} - \vec{T}(t) \leq R_{in}$ then the
+ * translated point originally came from within the inner radius so it'll be
+ * translated back without a quadratic solve.
+ *
+ * ## Frame Velocity
+ * The Frame Velocity is found through different equations based on which maps
+ * are supplied.
+ *
+ * If Rotation, Expansion, and Translation are supplied then the frame
+ * velocity is found through
+ *
+ * \f{equation}{
+ * \vec{v} = \left\{\begin{array}{ll}(E_{a}(t)dR(t) +
+ * dE_{a}(t)R(t))\vec{\xi} + d \vec{T}(t), & |\vec{\xi}| \leq R_{in},
+ * \\ ((E_{a}(t) + w_{E})dR(t) + (dE_{a}(t) + dw_{E})R(t))\vec{\xi} + (1 +
+ * w_{T})d \vec{T}(t), & R_{in} < |\vec{\xi}| \leq 0.5(R_{in} + R_{out}),
+ * \\ ((E_{b}(t) + w_{E})dR(t) + (dE_{b}(t) + dw_{E})R(t))\vec{\xi} + w_{T}d
+ * \vec{T}(t), & 0.5(R_{in} + R_{out}) < |\vec{\xi}| < R_{out},
+ * \\ (E_{b}(t)dR(t) + dE_{b}(t)R(t))\vec{\xi}, & |\vec{\xi}| \geq R_{out}
+ * \end{array}\right.
+ * \f}
+ *
+ * where $dw_{E}$ is the derivative of the $w_{E}$ given by
+ *
+ * \f{equation}{
+ * dw_{E} = \left\{\begin{array}{ll}\frac{R_{out}(R_{in} -
+ * |\vec{\xi}|)(dE_{a}(t)
+ * - dE_{b}(t))}{|\vec{\xi}|(R_{out} - R_{in})}, & R_{in} < |\vec{\xi}| \leq
+ * 0.5(R_{in} + R_{out}), \\ \frac{R_{in}(R_{out} - |\vec{\xi}|)(dE_{a}(t) -
+ * dE_{b}(t))}{|\vec{\xi}|(R_{out} - R_{in})}, & 0.5(R_{in} + R_{out}) <
+ * |\vec{\xi}| < R_{out} \end{array}\right.
+ * \f}
+ *
+ * ## Jacobian
+ * The jacobian is also found through different equations based on which maps
+ * are supplied.
+ *
+ * If Rotation, Expansion and Translation maps are supplied then the
+ * jacobian is found through
+ *
+ * \f{equation}{
+ * {J^{i}}_{j} = \left\{\begin{array}{ll}E_{a}(t){R^{i}}_{j}(t), & |\vec{\xi}|
+ * \leq R_{in}, \\ {R^{i}}_{j}(t)E_{a}(t) + \frac{\alpha
+ * {R^{i}}_{l}(t)\vec{\xi}^{l}\vec{\xi}_{j}(E_{A}(t) - E_{B}(t))}{|\vec{\xi}|} +
+ * w_{E}{R^{i}}_{j}(t) + \frac{dw_{T}T^{i}\xi_{j}}{|\vec{\xi}|}, & R_{in} <
+ * |\vec{\xi}| \leq 0.5(R_{in} + R_{out}), \\ {R^{i}}_{j}(t)E_{b}(t) +
+ * \frac{\alpha {R^{i}}_{l}(t)\vec{\xi}^{l}\vec{\xi}_{j}(E_{A}(t) -
+ * E_{B}(t))}{|\vec{\xi}|} + w_{E}{R^{i}}_{j}(t) +
+ * \frac{dw_{T}T^{i}\xi_{j}}{|\vec{\xi}|}, & 0.5(R_{in} + R_{out}) < |\vec{\xi}|
+ * < R_{out}, \\ E_{b}(t){R^{i}}_{j}(t), & |\vec{\xi}| \geq R_{out}
+ * \end{array}\right.
+ * \f}
+ *
+ * where $\alpha = \frac{R_{in}R_{out}}{\vec{\xi}^2(R_{in} - R_{out})}$ and
+ * $dw_{T} = \frac{-1.0}{R_{out} - R_{in}}$
+ *
+ * \note For the translation map, the map returns the identity for all regions
+ * except between $R_{in}$ and $R_{out}$
+ *
+ * ## Inverse Jacobian
+ * The inverse jacobian is computed numerically by inverting the jacobian.
+ */
+template <size_t Dim>
+class RotScaleTrans {
+ public:
+  enum class BlockRegion {
+    /// Within the inner radius
+    Inner,
+    /// Between inner and outer radius
+    Transition,
+    /// At or beyond outer boundary
+    Outer
+  };
+
+  static constexpr size_t dim = Dim;
+
+  explicit RotScaleTrans(
+      std::optional<std::pair<std::string, std::string>> scale_f_of_t_names,
+      std::optional<std::string> rot_f_of_t_name,
+      std::optional<std::string> trans_f_of_t_name, double inner_radius,
+      double outer_radius, BlockRegion region);
+
+  RotScaleTrans() = default;
+  ~RotScaleTrans() = default;
+  RotScaleTrans(const RotScaleTrans<Dim>& RotScaleTrans_Map) = default;
+  RotScaleTrans(RotScaleTrans&&) = default;
+  RotScaleTrans& operator=(RotScaleTrans&&) = default;
+  RotScaleTrans& operator=(const RotScaleTrans& RotScaleTrans_Map) = default;
+
+  template <typename T>
+  std::array<tt::remove_cvref_wrap_t<T>, Dim> operator()(
+      const std::array<T, Dim>& source_coords, double time,
+      const std::unordered_map<
+          std::string,
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+          functions_of_time) const;
+
+  /// The inverse function is only callable with doubles because the inverse
+  /// might fail if called for a point out of range, and it is unclear
+  /// what should happen if the inverse were to succeed for some points in a
+  /// DataVector but fail for other points.
+  std::optional<std::array<double, Dim>> inverse(
+      const std::array<double, Dim>& target_coords, double time,
+      const std::unordered_map<
+          std::string,
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+          functions_of_time) const;
+
+  template <typename T>
+  std::array<tt::remove_cvref_wrap_t<T>, Dim> frame_velocity(
+      const std::array<T, Dim>& source_coords, double time,
+      const std::unordered_map<
+          std::string,
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+          functions_of_time) const;
+
+  template <typename T>
+  tnsr::Ij<tt::remove_cvref_wrap_t<T>, Dim, Frame::NoFrame> inv_jacobian(
+      const std::array<T, Dim>& source_coords, double time,
+      const std::unordered_map<
+          std::string,
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+          functions_of_time) const;
+
+  template <typename T>
+  tnsr::Ij<tt::remove_cvref_wrap_t<T>, Dim, Frame::NoFrame> jacobian(
+      const std::array<T, Dim>& source_coords, double time,
+      const std::unordered_map<
+          std::string,
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+          functions_of_time) const;
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& p);
+
+  static bool is_identity() { return false; }
+
+  const std::unordered_set<std::string>& function_of_time_names() const {
+    return f_of_t_names_;
+  }
+
+ private:
+  template <size_t LocalDim>
+  friend bool operator==(  // NOLINT(readability-redundant-declaration)
+      const RotScaleTrans<LocalDim>& lhs, const RotScaleTrans<LocalDim>& rhs);
+
+  // The root helper returns the correct root of the roots found during the
+  // quadratic solve in the inverse function.
+  double root_helper(std::optional<std::array<double, 2>> roots) const;
+
+  std::optional<std::string> scale_f_of_t_a_{};
+  std::optional<std::string> scale_f_of_t_b_{};
+  std::optional<std::string> rot_f_of_t_{};
+  std::optional<std::string> trans_f_of_t_{};
+  std::unordered_set<std::string> f_of_t_names_;
+  double inner_radius_{std::numeric_limits<double>::signaling_NaN()};
+  double outer_radius_{std::numeric_limits<double>::signaling_NaN()};
+  BlockRegion region_ = BlockRegion::Inner;
+};
+
+template <size_t Dim>
+bool operator!=(const RotScaleTrans<Dim>& lhs, const RotScaleTrans<Dim>& rhs) {
+  return not(lhs == rhs);
+}
+
+}  // namespace domain::CoordinateMaps::TimeDependent

--- a/tests/Unit/Domain/CoordinateMaps/TimeDependent/CMakeLists.txt
+++ b/tests/Unit/Domain/CoordinateMaps/TimeDependent/CMakeLists.txt
@@ -8,6 +8,7 @@ set(LIBRARY_SOURCES
   Test_ProductMaps.cpp
   Test_Rotation.cpp
   Test_RotationMatrixHelpers.cpp
+  Test_RotScaleTrans.cpp
   Test_Shape.cpp
   Test_SphericalCompression.cpp
   Test_Translation.cpp

--- a/tests/Unit/Domain/CoordinateMaps/TimeDependent/Test_RotScaleTrans.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/TimeDependent/Test_RotScaleTrans.cpp
@@ -1,0 +1,605 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <memory>
+#include <optional>
+#include <string>
+#include <unordered_map>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Matrix.hpp"
+#include "DataStructures/Tensor/Identity.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
+#include "Domain/CoordinateMaps/Identity.hpp"
+#include "Domain/CoordinateMaps/TimeDependent/CubicScale.hpp"
+#include "Domain/CoordinateMaps/TimeDependent/ProductMaps.hpp"
+#include "Domain/CoordinateMaps/TimeDependent/ProductMaps.tpp"
+#include "Domain/CoordinateMaps/TimeDependent/RotScaleTrans.hpp"
+#include "Domain/CoordinateMaps/TimeDependent/Rotation.hpp"
+#include "Domain/CoordinateMaps/TimeDependent/RotationMatrixHelpers.hpp"
+#include "Domain/CoordinateMaps/TimeDependent/Translation.hpp"
+#include "Domain/FunctionsOfTime/PiecewisePolynomial.hpp"
+#include "Domain/FunctionsOfTime/QuaternionFunctionOfTime.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "Helpers/Domain/CoordinateMaps/TestMapHelpers.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/GetOutput.hpp"
+
+template <size_t Dim>
+void test_RotScaleTrans() {
+  MAKE_GENERATOR(gen);
+  // define vars for FunctionOfTime::PiecewisePolynomial f(t) = t**2.
+  double initial_t = -1.0;
+  double t = -0.9;
+  const double dt = 0.3;
+  const double final_time = 2.0;
+  constexpr size_t deriv_order = 3;
+  const double inner_radius = 1.0;
+  const double outer_radius = 50.0;
+  const double angle = 1.0;
+  const double omega = -2.0;
+  const double dtomega = 2.0;
+  const double d2tomega = 0.0;
+
+  using Polynomial = domain::FunctionsOfTime::PiecewisePolynomial<deriv_order>;
+  using FoftPtr = std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>;
+  using QuatFoT =
+      domain::FunctionsOfTime::QuaternionFunctionOfTime<deriv_order>;
+  using BlockRegion =
+      typename domain::CoordinateMaps::TimeDependent::RotScaleTrans<
+          Dim>::BlockRegion;
+  std::unordered_map<std::string, FoftPtr> f_of_t_list{};
+  std::array<DataVector, deriv_order + 1> init_func{};
+  const std::array<DataVector, deriv_order + 1> init_func_trans{
+      {{Dim, 1.0}, {Dim, -2.0}, {Dim, 2.0}, {Dim, 0.0}}};
+  const std::array<DataVector, deriv_order + 1> init_func_a{
+      {{0.58}, {0.0}, {0.0}, {0.0}}};
+  const std::array<DataVector, deriv_order + 1> init_func_b{
+      {{0.96}, {0.0}, {0.0}, {0.0}}};
+  const std::string rot_f_of_t_name{"rotation_angle"};
+  // custom_approx will be redifined multiple times below.
+  Approx custom_approx = Approx::custom().epsilon(1.0).scale(1.0);
+
+  if constexpr (Dim == 2) {
+    init_func = {{{angle}, {omega}, {dtomega}, {d2tomega}}};
+    f_of_t_list[rot_f_of_t_name] =
+        std::make_unique<Polynomial>(initial_t, init_func, final_time + dt);
+    custom_approx = Approx::custom().epsilon(5.0e-13).scale(1.0);
+  } else {
+    // Axis of rotation nhat = (1.0, -1.0, 1.0) / sqrt(3.0)
+    DataVector axis{{1.0, -1.0, 1.0}};
+    axis /= sqrt(3.0);
+    init_func = {axis * angle, axis * omega, axis * dtomega, axis * d2tomega};
+    // initial quaternion is (cos(angle/2), nhat*sin(angle/2))
+    const std::array<DataVector, 1> init_quat{
+        DataVector{{cos(angle / 2.0), axis[0] * sin(angle / 2.0),
+                    axis[1] * sin(angle / 2.0), axis[2] * sin(angle / 2.0)}}};
+    f_of_t_list[rot_f_of_t_name] = std::make_unique<QuatFoT>(
+        initial_t, init_quat, init_func, final_time + dt);
+    custom_approx = Approx::custom().epsilon(5.0e-11).scale(1.0);
+  }
+  f_of_t_list["expansion_a"] =
+      std::make_unique<Polynomial>(initial_t, init_func_a, final_time);
+  f_of_t_list["expansion_b"] =
+      std::make_unique<Polynomial>(initial_t, init_func_b, final_time);
+  f_of_t_list["translation"] =
+      std::make_unique<Polynomial>(initial_t, init_func_trans, final_time + dt);
+
+  const FoftPtr& scale_a_of_t = f_of_t_list.at("expansion_a");
+  const FoftPtr& scale_b_of_t = f_of_t_list.at("expansion_b");
+  const std::pair<std::string, std::string> scale_pair{"expansion_a",
+                                                       "expansion_b"};
+
+  const auto map_serialize_and_deserialize =
+      [&](const auto scaling, const auto rotation, const auto translation,
+          const auto region) {
+        domain::CoordinateMaps::TimeDependent::RotScaleTrans<Dim> map{
+            scaling, rotation, translation, inner_radius, outer_radius, region};
+        return serialize_and_deserialize(map);
+      };
+  // Rotation, Scaling, Translation Inner
+  domain::CoordinateMaps::TimeDependent::RotScaleTrans<Dim>
+      rot_scale_trans_map_inner = map_serialize_and_deserialize(
+          scale_pair, "rotation_angle", "translation", BlockRegion::Inner);
+
+  // Rotation, Scaling, Translation Transition
+  domain::CoordinateMaps::TimeDependent::RotScaleTrans<Dim>
+      rot_scale_trans_map_transition = map_serialize_and_deserialize(
+          scale_pair, "rotation_angle", "translation", BlockRegion::Transition);
+
+  // Rotation, Scaling, Translation Outer
+  domain::CoordinateMaps::TimeDependent::RotScaleTrans<Dim>
+      rot_scale_trans_map_outer = map_serialize_and_deserialize(
+          scale_pair, "rotation_angle", "translation", BlockRegion::Outer);
+
+  // Rotation, Scaling Inner
+  domain::CoordinateMaps::TimeDependent::RotScaleTrans<Dim>
+      rot_scale_map_inner = map_serialize_and_deserialize(
+          scale_pair, "rotation_angle", std::nullopt, BlockRegion::Inner);
+
+  // Rotation, Scaling Transition
+  domain::CoordinateMaps::TimeDependent::RotScaleTrans<Dim>
+      rot_scale_map_transition = map_serialize_and_deserialize(
+          scale_pair, "rotation_angle", std::nullopt, BlockRegion::Transition);
+
+  // Rotation, Scaling Outer
+  domain::CoordinateMaps::TimeDependent::RotScaleTrans<Dim>
+      rot_scale_map_outer = map_serialize_and_deserialize(
+          scale_pair, "rotation_angle", std::nullopt, BlockRegion::Outer);
+
+  // Rotation, Translation Inner
+  domain::CoordinateMaps::TimeDependent::RotScaleTrans<Dim>
+      rot_trans_map_inner = map_serialize_and_deserialize(
+          std::nullopt, "rotation_angle", "translation", BlockRegion::Inner);
+
+  // Rotation, Translation Transition
+  domain::CoordinateMaps::TimeDependent::RotScaleTrans<Dim>
+      rot_trans_map_transition =
+          map_serialize_and_deserialize(std::nullopt, "rotation_angle",
+                                        "translation", BlockRegion::Transition);
+
+  // Rotation, Translation Outer
+  domain::CoordinateMaps::TimeDependent::RotScaleTrans<Dim>
+      rot_trans_map_outer = map_serialize_and_deserialize(
+          std::nullopt, "rotation_angle", "translation", BlockRegion::Outer);
+
+  // Scaling, Translation Inner
+  domain::CoordinateMaps::TimeDependent::RotScaleTrans<Dim>
+      scale_trans_map_inner = map_serialize_and_deserialize(
+          scale_pair, std::nullopt, "translation", BlockRegion::Inner);
+
+  // Scaling, Translation Transition
+  domain::CoordinateMaps::TimeDependent::RotScaleTrans<Dim>
+      scale_trans_map_transition = map_serialize_and_deserialize(
+          scale_pair, std::nullopt, "translation", BlockRegion::Transition);
+
+  // Scaling, Translation Outer
+  domain::CoordinateMaps::TimeDependent::RotScaleTrans<Dim>
+      scale_trans_map_outer = map_serialize_and_deserialize(
+          scale_pair, std::nullopt, "translation", BlockRegion::Outer);
+
+  // Rotation (doesn't matter which region you use)
+  domain::CoordinateMaps::TimeDependent::RotScaleTrans<Dim> rot_map =
+      map_serialize_and_deserialize(std::nullopt, "rotation_angle",
+                                    std::nullopt, BlockRegion::Inner);
+
+  // Scaling Inner
+  domain::CoordinateMaps::TimeDependent::RotScaleTrans<Dim> scale_map_inner =
+      map_serialize_and_deserialize(scale_pair, std::nullopt, std::nullopt,
+                                    BlockRegion::Inner);
+
+  // Scaling Transition
+  domain::CoordinateMaps::TimeDependent::RotScaleTrans<Dim>
+      scale_map_transition = map_serialize_and_deserialize(
+          scale_pair, std::nullopt, std::nullopt, BlockRegion::Transition);
+
+  // Scaling Outer
+  domain::CoordinateMaps::TimeDependent::RotScaleTrans<Dim> scale_map_outer =
+      map_serialize_and_deserialize(scale_pair, std::nullopt, std::nullopt,
+                                    BlockRegion::Outer);
+
+  // Translation Inner
+  domain::CoordinateMaps::TimeDependent::RotScaleTrans<Dim> trans_map_inner =
+      map_serialize_and_deserialize(std::nullopt, std::nullopt, "translation",
+                                    BlockRegion::Inner);
+
+  // Translation Transition
+  domain::CoordinateMaps::TimeDependent::RotScaleTrans<Dim>
+      trans_map_transition = map_serialize_and_deserialize(
+          std::nullopt, std::nullopt, "translation", BlockRegion::Transition);
+
+  // Translation Outer
+  domain::CoordinateMaps::TimeDependent::RotScaleTrans<Dim> trans_map_outer =
+      map_serialize_and_deserialize(std::nullopt, std::nullopt, "translation",
+                                    BlockRegion::Outer);
+
+  const double far_double_1 = Dim == 2 ? 30.0 : 25.0;
+  const double far_double_2 = Dim == 2 ? 35.36 : 28.87;
+  UniformCustomDistribution<double> dist_double{-10.0, 10.0};
+  UniformCustomDistribution<double> far_dist_double{far_double_1, far_double_2};
+  std::array<double, Dim> point_xi{};
+  std::array<DataVector, Dim> point_xi_dv{};
+  std::array<double, Dim> far_point_xi{};
+  fill_with_random_values(make_not_null(&point_xi), make_not_null(&gen),
+                          make_not_null(&dist_double));
+  fill_with_random_values(make_not_null(&far_point_xi), make_not_null(&gen),
+                          make_not_null(&far_dist_double));
+  for (size_t i = 0; i < Dim; i++) {
+    auto points = make_with_random_values<DataVector>(
+        make_not_null(&gen), make_not_null(&dist_double), DataVector(5));
+    gsl::at(point_xi_dv, i) = points;
+  }
+
+  while (t < final_time) {
+    std::array<double, Dim> translation{};
+    std::array<double, Dim> expected_rotation{};
+    std::array<DataVector, Dim> expected_rotation_dv{};
+    std::array<double, Dim> far_expected_rotation{};
+    const double radius = magnitude(point_xi);
+    const DataVector radius_dv = magnitude(point_xi_dv);
+    const double far_radius = magnitude(far_point_xi);
+    const Matrix rot_matrix =
+        rotation_matrix<Dim>(t, *(f_of_t_list[rot_f_of_t_name]));
+    const Matrix deriv_rot_matrix =
+        rotation_matrix_deriv<Dim>(t, *(f_of_t_list[rot_f_of_t_name]));
+    const double scale_a = scale_a_of_t->func_and_deriv(t)[0][0];
+    const double scale_b = scale_b_of_t->func_and_deriv(t)[0][0];
+    double radial_scaling_factor = 0.0;
+    double radial_translation_factor = 0.0;
+    custom_approx = Approx::custom().epsilon(1e-9).scale(1.0);
+    for (size_t i = 0; i < Dim; i++) {
+      gsl::at(translation, i) = square(t);
+      for (size_t j = 0; j < Dim; j++) {
+        gsl::at(expected_rotation, i) +=
+            rot_matrix(i, j) * gsl::at(point_xi, j);
+        gsl::at(far_expected_rotation, i) +=
+            rot_matrix(i, j) * gsl::at(far_point_xi, j);
+      }
+    }
+    for (size_t i = 0; i < Dim; i++) {
+      gsl::at(expected_rotation_dv, i) = rot_matrix(i, 0) * point_xi_dv[0];
+      for (size_t j = 1; j < Dim; j++) {
+        gsl::at(expected_rotation_dv, i) +=
+            rot_matrix(i, j) * gsl::at(point_xi_dv, j);
+      }
+    }
+    // Operator
+    CHECK_ITERABLE_APPROX(trans_map_inner(point_xi, t, f_of_t_list),
+                          point_xi + translation);
+    CHECK_ITERABLE_APPROX(scale_map_inner(point_xi, t, f_of_t_list),
+                          point_xi * scale_a);
+    CHECK_ITERABLE_APPROX(rot_map(point_xi, t, f_of_t_list), expected_rotation);
+    CHECK_ITERABLE_APPROX(rot_scale_map_inner(point_xi, t, f_of_t_list),
+                          expected_rotation * scale_a);
+    CHECK_ITERABLE_APPROX(rot_trans_map_inner(point_xi, t, f_of_t_list),
+                          expected_rotation + translation);
+    CHECK_ITERABLE_APPROX(scale_trans_map_inner(point_xi, t, f_of_t_list),
+                          point_xi * scale_a + translation);
+    CHECK_ITERABLE_APPROX(rot_scale_trans_map_inner(point_xi, t, f_of_t_list),
+                          expected_rotation * scale_a + translation);
+    // Operator DataVector
+    CHECK_ITERABLE_APPROX(
+        rot_scale_trans_map_inner(point_xi_dv, t, f_of_t_list),
+        expected_rotation_dv * scale_a + translation);
+
+    // Testing points close to inner radius
+    radial_scaling_factor =
+        ((inner_radius - radius) * (scale_a - scale_b) * outer_radius) /
+        ((outer_radius - inner_radius) * radius);
+    radial_translation_factor =
+        (inner_radius - radius) / (outer_radius - inner_radius);
+    CHECK_ITERABLE_APPROX(scale_map_transition(point_xi, t, f_of_t_list),
+                          point_xi * (radial_scaling_factor + scale_a));
+    CHECK_ITERABLE_APPROX(
+        trans_map_transition(point_xi, t, f_of_t_list),
+        point_xi + translation + translation * radial_translation_factor);
+    CHECK_ITERABLE_APPROX(
+        rot_scale_map_transition(point_xi, t, f_of_t_list),
+        expected_rotation * (radial_scaling_factor + scale_a));
+    CHECK_ITERABLE_APPROX(rot_trans_map_transition(point_xi, t, f_of_t_list),
+                          expected_rotation + translation +
+                              translation * radial_translation_factor);
+    CHECK_ITERABLE_APPROX(scale_trans_map_transition(point_xi, t, f_of_t_list),
+                          point_xi * (radial_scaling_factor + scale_a) +
+                              translation +
+                              translation * radial_translation_factor);
+    CHECK_ITERABLE_APPROX(
+        rot_scale_trans_map_transition(point_xi, t, f_of_t_list),
+        expected_rotation * (radial_scaling_factor + scale_a) + translation +
+            translation * radial_translation_factor);
+    // Testing far points close to outer radius.
+    if (far_radius < outer_radius) {
+      radial_scaling_factor =
+          ((outer_radius - far_radius) * (scale_a - scale_b) * inner_radius) /
+          ((outer_radius - inner_radius) * far_radius);
+      radial_translation_factor =
+          (outer_radius - far_radius) / (outer_radius - inner_radius);
+      CHECK_ITERABLE_APPROX(scale_map_transition(far_point_xi, t, f_of_t_list),
+                            far_point_xi * (radial_scaling_factor + scale_b));
+      CHECK_ITERABLE_APPROX(
+          trans_map_transition(far_point_xi, t, f_of_t_list),
+          far_point_xi + translation * radial_translation_factor);
+      CHECK_ITERABLE_APPROX(
+          rot_scale_map_transition(far_point_xi, t, f_of_t_list),
+          far_expected_rotation * (radial_scaling_factor + scale_b));
+      CHECK_ITERABLE_APPROX(
+          rot_trans_map_transition(far_point_xi, t, f_of_t_list),
+          far_expected_rotation + translation * radial_translation_factor);
+      CHECK_ITERABLE_APPROX(
+          scale_trans_map_transition(far_point_xi, t, f_of_t_list),
+          far_point_xi * (radial_scaling_factor + scale_b) +
+              translation * radial_translation_factor);
+      CHECK_ITERABLE_APPROX(
+          rot_scale_trans_map_transition(far_point_xi, t, f_of_t_list),
+          far_expected_rotation * (radial_scaling_factor + scale_b) +
+              translation * radial_translation_factor);
+    } else {
+      CHECK_ITERABLE_APPROX(scale_map_outer(far_point_xi, t, f_of_t_list),
+                            far_point_xi * scale_b);
+      CHECK_ITERABLE_APPROX(trans_map_outer(far_point_xi, t, f_of_t_list),
+                            far_point_xi);
+      CHECK_ITERABLE_APPROX(rot_scale_map_outer(far_point_xi, t, f_of_t_list),
+                            far_expected_rotation * scale_b);
+      CHECK_ITERABLE_APPROX(rot_trans_map_outer(far_point_xi, t, f_of_t_list),
+                            far_expected_rotation);
+      CHECK_ITERABLE_APPROX(scale_trans_map_outer(far_point_xi, t, f_of_t_list),
+                            far_point_xi * scale_b);
+      CHECK_ITERABLE_APPROX(
+          rot_scale_trans_map_outer(far_point_xi, t, f_of_t_list),
+          expected_rotation * scale_b);
+    }
+
+    const auto check_inner_maps_inverse = [&](const auto& point_to_check) {
+      test_inverse_map(rot_map, point_to_check, t, f_of_t_list);
+      test_inverse_map(scale_map_inner, point_to_check, t, f_of_t_list);
+      test_inverse_map(trans_map_inner, point_to_check, t, f_of_t_list);
+      test_inverse_map(rot_scale_map_inner, point_to_check, t, f_of_t_list);
+      test_inverse_map(rot_trans_map_inner, point_to_check, t, f_of_t_list);
+      test_inverse_map(scale_trans_map_inner, point_to_check, t, f_of_t_list);
+      test_inverse_map(rot_scale_trans_map_inner, point_to_check, t,
+                       f_of_t_list);
+    };
+    const auto check_transition_maps_inverse = [&](const auto& point_to_check) {
+      test_inverse_map(rot_map, point_to_check, t, f_of_t_list);
+      test_inverse_map(scale_map_transition, point_to_check, t, f_of_t_list);
+      test_inverse_map(trans_map_transition, point_to_check, t, f_of_t_list);
+      test_inverse_map(rot_scale_map_transition, point_to_check, t,
+                       f_of_t_list);
+      test_inverse_map(rot_trans_map_transition, point_to_check, t,
+                       f_of_t_list);
+      test_inverse_map(scale_trans_map_transition, point_to_check, t,
+                       f_of_t_list);
+      test_inverse_map(rot_scale_trans_map_transition, point_to_check, t,
+                       f_of_t_list);
+    };
+    const auto check_outer_maps_inverse = [&](const auto& point_to_check) {
+      test_inverse_map(rot_map, point_to_check, t, f_of_t_list);
+      test_inverse_map(scale_map_outer, point_to_check, t, f_of_t_list);
+      test_inverse_map(trans_map_outer, point_to_check, t, f_of_t_list);
+      test_inverse_map(rot_scale_map_outer, point_to_check, t, f_of_t_list);
+      test_inverse_map(rot_trans_map_outer, point_to_check, t, f_of_t_list);
+      test_inverse_map(scale_trans_map_outer, point_to_check, t, f_of_t_list);
+      test_inverse_map(rot_scale_trans_map_outer, point_to_check, t,
+                       f_of_t_list);
+    };
+    const auto check_all_maps_frame_velocity = [&](const auto& point_to_check) {
+      test_frame_velocity(rot_map, point_to_check, t, f_of_t_list,
+                          custom_approx);
+      test_frame_velocity(scale_map_inner, point_to_check, t, f_of_t_list);
+      test_frame_velocity(trans_map_inner, point_to_check, t, f_of_t_list);
+      test_frame_velocity(rot_scale_map_inner, point_to_check, t, f_of_t_list,
+                          custom_approx);
+      test_frame_velocity(rot_trans_map_inner, point_to_check, t, f_of_t_list,
+                          custom_approx);
+      test_frame_velocity(scale_trans_map_inner, point_to_check, t,
+                          f_of_t_list);
+      test_frame_velocity(rot_scale_trans_map_inner, point_to_check, t,
+                          f_of_t_list, custom_approx);
+      test_frame_velocity(scale_map_transition, point_to_check, t, f_of_t_list);
+      test_frame_velocity(trans_map_transition, point_to_check, t, f_of_t_list);
+      test_frame_velocity(rot_scale_map_transition, point_to_check, t,
+                          f_of_t_list, custom_approx);
+      test_frame_velocity(rot_trans_map_transition, point_to_check, t,
+                          f_of_t_list, custom_approx);
+      test_frame_velocity(scale_trans_map_transition, point_to_check, t,
+                          f_of_t_list);
+      test_frame_velocity(rot_scale_trans_map_transition, point_to_check, t,
+                          f_of_t_list, custom_approx);
+      test_frame_velocity(scale_map_outer, point_to_check, t, f_of_t_list);
+      test_frame_velocity(trans_map_outer, point_to_check, t, f_of_t_list);
+      test_frame_velocity(rot_scale_map_outer, point_to_check, t, f_of_t_list,
+                          custom_approx);
+      test_frame_velocity(rot_trans_map_outer, point_to_check, t, f_of_t_list,
+                          custom_approx);
+      test_frame_velocity(scale_trans_map_outer, point_to_check, t,
+                          f_of_t_list);
+      test_frame_velocity(rot_scale_trans_map_outer, point_to_check, t,
+                          f_of_t_list, custom_approx);
+    };
+    const auto check_all_maps_jacobian = [&](const auto& point_to_check) {
+      test_jacobian(rot_map, point_to_check, t, f_of_t_list, custom_approx);
+      test_inv_jacobian(rot_map, point_to_check, t, f_of_t_list);
+      test_jacobian(scale_map_inner, point_to_check, t, f_of_t_list,
+                    custom_approx);
+      test_inv_jacobian(scale_map_inner, point_to_check, t, f_of_t_list);
+      test_jacobian(scale_map_transition, point_to_check, t, f_of_t_list,
+                    custom_approx);
+      test_inv_jacobian(scale_map_transition, point_to_check, t, f_of_t_list);
+      test_jacobian(scale_map_outer, point_to_check, t, f_of_t_list,
+                    custom_approx);
+      test_inv_jacobian(scale_map_outer, point_to_check, t, f_of_t_list);
+      test_jacobian(trans_map_inner, point_to_check, t, f_of_t_list,
+                    custom_approx);
+      test_inv_jacobian(trans_map_inner, point_to_check, t, f_of_t_list);
+      test_jacobian(trans_map_transition, point_to_check, t, f_of_t_list,
+                    custom_approx);
+      test_inv_jacobian(trans_map_transition, point_to_check, t, f_of_t_list);
+      test_jacobian(trans_map_outer, point_to_check, t, f_of_t_list,
+                    custom_approx);
+      test_inv_jacobian(trans_map_outer, point_to_check, t, f_of_t_list);
+      test_jacobian(rot_scale_map_inner, point_to_check, t, f_of_t_list,
+                    custom_approx);
+      test_inv_jacobian(rot_scale_map_inner, point_to_check, t, f_of_t_list);
+      test_jacobian(rot_scale_map_transition, point_to_check, t, f_of_t_list,
+                    custom_approx);
+      test_inv_jacobian(rot_scale_map_transition, point_to_check, t,
+                        f_of_t_list);
+      test_jacobian(rot_scale_map_outer, point_to_check, t, f_of_t_list,
+                    custom_approx);
+      test_inv_jacobian(rot_scale_map_outer, point_to_check, t, f_of_t_list);
+      test_jacobian(rot_trans_map_inner, point_to_check, t, f_of_t_list,
+                    custom_approx);
+      test_inv_jacobian(rot_trans_map_inner, point_to_check, t, f_of_t_list);
+      test_jacobian(rot_trans_map_transition, point_to_check, t, f_of_t_list,
+                    custom_approx);
+      test_inv_jacobian(rot_trans_map_transition, point_to_check, t,
+                        f_of_t_list);
+      test_jacobian(rot_trans_map_outer, point_to_check, t, f_of_t_list,
+                    custom_approx);
+      test_inv_jacobian(rot_trans_map_outer, point_to_check, t, f_of_t_list);
+      test_jacobian(scale_trans_map_inner, point_to_check, t, f_of_t_list,
+                    custom_approx);
+      test_inv_jacobian(scale_trans_map_inner, point_to_check, t, f_of_t_list);
+      test_jacobian(scale_trans_map_transition, point_to_check, t, f_of_t_list,
+                    custom_approx);
+      test_inv_jacobian(scale_trans_map_transition, point_to_check, t,
+                        f_of_t_list);
+      test_jacobian(scale_trans_map_outer, point_to_check, t, f_of_t_list,
+                    custom_approx);
+      test_inv_jacobian(scale_trans_map_outer, point_to_check, t, f_of_t_list);
+      test_jacobian(rot_scale_trans_map_inner, point_to_check, t, f_of_t_list,
+                    custom_approx);
+      test_inv_jacobian(rot_scale_trans_map_inner, point_to_check, t,
+                        f_of_t_list);
+      test_jacobian(rot_scale_trans_map_transition, point_to_check, t,
+                    f_of_t_list, custom_approx);
+      test_inv_jacobian(rot_scale_trans_map_transition, point_to_check, t,
+                        f_of_t_list);
+      test_jacobian(rot_scale_trans_map_outer, point_to_check, t, f_of_t_list,
+                    custom_approx);
+      test_inv_jacobian(rot_scale_trans_map_outer, point_to_check, t,
+                        f_of_t_list);
+    };
+
+    if (radius <= inner_radius) {
+      check_inner_maps_inverse(point_xi);
+    } else {
+      check_transition_maps_inverse(point_xi);
+    }
+    check_all_maps_frame_velocity(point_xi);
+    check_all_maps_jacobian(point_xi);
+    check_all_maps_jacobian(point_xi_dv);
+
+    if (far_radius <= outer_radius) {
+      check_transition_maps_inverse(far_point_xi);
+    } else {
+      check_outer_maps_inverse(far_point_xi);
+    }
+    check_all_maps_frame_velocity(far_point_xi);
+    check_all_maps_jacobian(far_point_xi);
+
+    t += dt;
+  }
+
+  // test serialized/deserialized map and names
+  const auto rot_map_deserialized = serialize_and_deserialize(rot_map);
+  const auto scale_map_inner_deserialized =
+      serialize_and_deserialize(scale_map_inner);
+  const auto scale_map_transition_deserialized =
+      serialize_and_deserialize(scale_map_transition);
+  const auto scale_map_outer_deserialized =
+      serialize_and_deserialize(scale_map_outer);
+  const auto trans_map_inner_deserialized =
+      serialize_and_deserialize(trans_map_inner);
+  const auto trans_map_transition_deserialized =
+      serialize_and_deserialize(trans_map_transition);
+  const auto trans_map_outer_deserialized =
+      serialize_and_deserialize(trans_map_outer);
+  const auto rot_scale_map_inner_deserialized =
+      serialize_and_deserialize(rot_scale_map_inner);
+  const auto rot_scale_map_transition_deserialized =
+      serialize_and_deserialize(rot_scale_map_transition);
+  const auto rot_scale_map_outer_deserialized =
+      serialize_and_deserialize(rot_scale_map_outer);
+  const auto rot_trans_map_inner_deserialized =
+      serialize_and_deserialize(rot_trans_map_inner);
+  const auto rot_trans_map_transition_deserialized =
+      serialize_and_deserialize(rot_trans_map_transition);
+  const auto rot_trans_map_outer_deserialized =
+      serialize_and_deserialize(rot_trans_map_outer);
+  const auto scale_trans_map_inner_deserialized =
+      serialize_and_deserialize(scale_trans_map_inner);
+  const auto scale_trans_map_transition_deserialized =
+      serialize_and_deserialize(scale_trans_map_transition);
+  const auto scale_trans_map_outer_deserialized =
+      serialize_and_deserialize(scale_trans_map_outer);
+  const auto rot_scale_trans_map_inner_deserialized =
+      serialize_and_deserialize(rot_scale_trans_map_inner);
+  const auto rot_scale_trans_map_transition_deserialized =
+      serialize_and_deserialize(rot_scale_trans_map_transition);
+  const auto rot_scale_trans_map_outer_deserialized =
+      serialize_and_deserialize(rot_scale_trans_map_outer);
+
+  CHECK(rot_map == rot_map_deserialized);
+  CHECK(scale_map_inner == scale_map_inner_deserialized);
+  CHECK(scale_map_transition == scale_map_transition_deserialized);
+  CHECK(scale_map_outer == scale_map_outer_deserialized);
+  CHECK(trans_map_inner == trans_map_inner_deserialized);
+  CHECK(trans_map_transition == trans_map_transition_deserialized);
+  CHECK(trans_map_outer == trans_map_outer_deserialized);
+  CHECK(rot_scale_map_inner == rot_scale_map_inner_deserialized);
+  CHECK(rot_scale_map_transition == rot_scale_map_transition_deserialized);
+  CHECK(rot_scale_map_outer == rot_scale_map_outer_deserialized);
+  CHECK(rot_trans_map_inner == rot_trans_map_inner_deserialized);
+  CHECK(rot_trans_map_transition == rot_trans_map_transition_deserialized);
+  CHECK(rot_trans_map_outer == rot_trans_map_outer_deserialized);
+  CHECK(scale_trans_map_inner == scale_trans_map_inner_deserialized);
+  CHECK(scale_trans_map_transition == scale_trans_map_transition_deserialized);
+  CHECK(scale_trans_map_outer == scale_trans_map_outer_deserialized);
+  CHECK(rot_scale_trans_map_inner == rot_scale_trans_map_inner_deserialized);
+  CHECK(rot_scale_trans_map_transition ==
+        rot_scale_trans_map_transition_deserialized);
+  CHECK(rot_scale_trans_map_outer == rot_scale_trans_map_outer_deserialized);
+
+  const auto check_names1 = [](const auto& names) {
+    CHECK(names.size() == 1);
+    CHECK((names.count("rotation_angle") == 1 or
+           names.count("translation") == 1));
+  };
+  const auto check_names2 = [](const auto& names) {
+    CHECK(names.size() == 2);
+    CHECK((
+        (names.count("rotation_angle") == 1 and
+         names.count("translation") == 1) or
+        (names.count("expansion_a") == 1 and names.count("expansion_b") == 1)));
+  };
+  const auto check_names3 = [](const auto& names) {
+    CHECK(names.size() == 3);
+    CHECK((
+        (names.count("rotation_angle") == 1 and
+         names.count("expansion_a") == 1 and names.count("expansion_b") == 1) or
+        (names.count("translation") == 1 and names.count("expansion_a") == 1 and
+         names.count("expansion_b") == 1)));
+  };
+  const auto check_names4 = [](const auto& names) {
+    CHECK(names.size() == 4);
+    CHECK((names.count("rotation_angle") == 1 and
+           names.count("expansion_a") == 1 and
+           names.count("expansion_b") == 1 and
+           names.count("translation") == 1));
+  };
+  check_names1(rot_map.function_of_time_names());
+  check_names1(trans_map_inner.function_of_time_names());
+  check_names1(trans_map_transition.function_of_time_names());
+  check_names1(trans_map_outer.function_of_time_names());
+  check_names2(scale_map_inner.function_of_time_names());
+  check_names2(scale_map_transition.function_of_time_names());
+  check_names2(scale_map_outer.function_of_time_names());
+  check_names2(rot_trans_map_inner.function_of_time_names());
+  check_names2(rot_trans_map_transition.function_of_time_names());
+  check_names2(rot_trans_map_outer.function_of_time_names());
+  check_names3(rot_scale_map_inner.function_of_time_names());
+  check_names3(rot_scale_map_transition.function_of_time_names());
+  check_names3(rot_scale_map_outer.function_of_time_names());
+  check_names3(scale_trans_map_inner.function_of_time_names());
+  check_names3(scale_trans_map_transition.function_of_time_names());
+  check_names3(scale_trans_map_outer.function_of_time_names());
+  check_names4(rot_scale_trans_map_inner.function_of_time_names());
+  check_names4(rot_scale_trans_map_transition.function_of_time_names());
+  check_names4(rot_scale_trans_map_outer.function_of_time_names());
+}
+namespace domain {
+// [[Timeout, 45]]
+SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.TimeDependent.RotScaleTrans",
+                  "[Domain][Unit]") {
+  test_RotScaleTrans<2>();
+  test_RotScaleTrans<3>();
+}
+}  // namespace domain

--- a/tests/Unit/Helpers/Domain/CoordinateMaps/TestMapHelpers.hpp
+++ b/tests/Unit/Helpers/Domain/CoordinateMaps/TestMapHelpers.hpp
@@ -126,7 +126,8 @@ void test_jacobian(
     const double time,
     const std::unordered_map<
         std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
-        functions_of_time) {
+        functions_of_time,
+    Approx local_approx = Approx::custom().epsilon(1e-10).scale(1.0)) {
   INFO("Test time-dependent Jacobian");
   CAPTURE(test_point);
   CAPTURE(time);
@@ -135,8 +136,6 @@ void test_jacobian(
        &functions_of_time](const std::array<double, Map::dim>& point) {
         return map(point, time, functions_of_time);
       };
-  // Our default approx value is too stringent for this test
-  Approx local_approx = Approx::custom().epsilon(1e-10).scale(1.0);
   const double dx = 1e-4;
   const auto jacobian = map.jacobian(test_point, time, functions_of_time);
   for (size_t i = 0; i < Map::dim; ++i) {
@@ -177,7 +176,8 @@ void test_jacobian(
     const double time,
     const std::unordered_map<
         std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
-        functions_of_time) {
+        functions_of_time,
+    Approx local_approx = Approx::custom().epsilon(1e-10).scale(1.0)) {
   INFO("Test time-dependent Jacobian");
   CAPTURE(test_point);
   CAPTURE(time);
@@ -186,8 +186,6 @@ void test_jacobian(
        &functions_of_time](const std::array<double, Map::dim>& point) {
         return map(point, time, functions_of_time);
       };
-  // Our default approx value is too stringent for this test
-  Approx local_approx = Approx::custom().epsilon(1e-10).scale(1.0);
   const double dx = 1e-4;
   const auto jacobian = map.jacobian(test_point, time, functions_of_time);
   std::array<std::array<double, Map::dim>, 5> dv_to_double_array{};
@@ -371,13 +369,12 @@ void test_frame_velocity(
     const double time,
     const std::unordered_map<
         std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
-        functions_of_time) {
+        functions_of_time,
+    Approx local_approx = Approx::custom().epsilon(1e-10).scale(1.0)) {
   const auto compute_map_point = [&map, &test_point, &functions_of_time](
                                      const std::array<double, 1>& time_point) {
     return map(test_point, time_point[0], functions_of_time);
   };
-  // Our default approx value is too stringent for this test
-  Approx local_approx = Approx::custom().epsilon(1e-10).scale(1.0);
   const double dt = 1e-4;
 
   const auto frame_velocity =


### PR DESCRIPTION
## Proposed changes

Adds the RotScaleTrans map from SpEC. Currently, this map can be used for any combination of rotation, expansion and translation. 

### Upgrade instructions

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments


