### PR TITLE
Fix ordering of IncludeCategories in clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -63,12 +63,10 @@ ForEachMacros:
   - Q_FOREACH
   - BOOST_FOREACH
 IncludeCategories:
-  - Regex:           '^<.*\.h>'
-    Priority:        1
   - Regex:           '^<.*'
-    Priority:        2
+    Priority:        1
   - Regex:           '.*'
-    Priority:        3
+    Priority:        2
 IncludeIsMainRegex: '([-_](test|unittest))?$'
 IndentCaseLabels: true
 IndentWidth:     2


### PR DESCRIPTION
## Proposed changes

A previous PR (https://github.com/sxs-collaboration/spectre/pull/5690) had removed the duplicate entry of `IncludeCategories` in `clang-format`, assuming that the first one was being read. That assumption was incorrect, and the current version of `IncludeCategories` causes a conflict with the formatting options in `clang-tidy`. Although this version was added more recently to the file, it was decided that the other one was more preferable anyway, so this update switches the two. This removes the preference that pushes includes ending in `.h` to the beginning of the list.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [x] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [x] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [x] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
