### PR TITLE
Add 'status' CLI formatter for elliptic executables

### DIFF
--- a/tests/tools/Test_Status.py
+++ b/tests/tools/Test_Status.py
@@ -88,6 +88,25 @@ class TestExecutableStatus(unittest.TestCase):
                 "/Norms", legend=["L2Norm(ConstraintEnergy)"], version=0
             )
             constraints_subfile.append([1.0e-3])
+            open_h5_file.close_current_object()
+            # Elliptic solver residuals
+            residuals_subfile = open_h5_file.insert_dat(
+                "/NewtonRaphsonResiduals",
+                legend=["Iteration", "Residual"],
+                version=0,
+            )
+            residuals_subfile.append([0.0, 1.0e-1])
+            residuals_subfile.append([1.0, 1.0e-4])
+            open_h5_file.close_current_object()
+            residuals_subfile = open_h5_file.insert_dat(
+                "/GmresResiduals",
+                legend=["Iteration", "Residual"],
+                version=0,
+            )
+            residuals_subfile.append([0.0, 1.0e-1])
+            residuals_subfile.append([1.0, 1.0e-4])
+            residuals_subfile.append([0.0, 1.0e-2])
+            residuals_subfile.append([1.0, 1.0e-5])
 
     def tearDown(self):
         shutil.rmtree(self.work_dir, ignore_errors=True)
@@ -114,6 +133,38 @@ class TestExecutableStatus(unittest.TestCase):
         self.assertEqual(status["Time"], 2.0)
         self.assertEqual(status["Speed"], 2640.0)
         self.assertEqual(status["Constraint Energy"], 1.0e-3)
+
+    def test_elliptic_status(self):
+        executable_status = match_executable_status("SolveSomething")
+        status = executable_status.status(self.input_file, self.work_dir)
+        self.assertEqual(status, {"Iteration": 1.0, "Residual": 1.0e-4})
+        self.assertEqual(executable_status.format("Iteration", 1.0), "1")
+        self.assertEqual(
+            executable_status.format("Residual", 1.0e-4), "1.0e-04"
+        )
+
+    def test_xcts_status(self):
+        executable_status = match_executable_status("SolveXcts")
+        status = executable_status.status(self.input_file, self.work_dir)
+        self.assertEqual(
+            status,
+            {
+                "Nonlinear iteration": 1,
+                "Nonlinear residual": 1.0e-4,
+                "Linear iteration": 2,
+                "Linear residual": 1.0e-5,
+            },
+        )
+        self.assertEqual(
+            executable_status.format("Nonlinear iteration", 1.0), "1"
+        )
+        self.assertEqual(executable_status.format("Linear iteration", 1.0), "1")
+        self.assertEqual(
+            executable_status.format("Nonlinear residual", 1.0e-4), "1.0e-04"
+        )
+        self.assertEqual(
+            executable_status.format("Linear residual", 1.0e-4), "1.0e-04"
+        )
 
 
 class TestStatus(unittest.TestCase):

--- a/tools/Status/ExecutableStatus/CMakeLists.txt
+++ b/tools/Status/ExecutableStatus/CMakeLists.txt
@@ -9,4 +9,5 @@ spectre_python_add_module(
   EvolveGhBinaryBlackHole.py
   EvolveGhSingleBlackHole.py
   ExecutableStatus.py
+  SolveXcts.py
 )

--- a/tools/Status/ExecutableStatus/SolveXcts.py
+++ b/tools/Status/ExecutableStatus/SolveXcts.py
@@ -1,0 +1,51 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import logging
+import os
+
+import h5py
+
+from .ExecutableStatus import EllipticStatus
+
+logger = logging.getLogger(__name__)
+
+
+class SolveXcts(EllipticStatus):
+    executable_name_patterns = [r"^SolveXcts"]
+    fields = {
+        "Nonlinear iteration": None,
+        "Nonlinear residual": None,
+        "Linear iteration": None,
+        "Linear residual": None,
+    }
+
+    def status(self, input_file, work_dir):
+        try:
+            reductions_file = input_file["Observers"]["ReductionFileName"]
+            open_reductions_file = h5py.File(
+                os.path.join(work_dir, reductions_file + ".h5"), "r"
+            )
+        except:
+            logger.debug("Unable to open reductions file.", exc_info=True)
+            return {}
+        with open_reductions_file:
+            nonlinear_status = self.solver_status(
+                input_file, open_reductions_file, solver_name="NewtonRaphson"
+            )
+            linear_status = self.solver_status(
+                input_file, open_reductions_file, solver_name="Gmres"
+            )
+        result = {
+            "Nonlinear iteration": nonlinear_status["Iteration"],
+            "Nonlinear residual": nonlinear_status["Residual"],
+            "Linear iteration": linear_status["Iteration"],
+            "Linear residual": linear_status["Residual"],
+        }
+        return result
+
+    def format(self, field, value):
+        if "iteration" in field:
+            return super().format("Iteration", value)
+        elif "residual" in field:
+            return super().format("Residual", value)

--- a/tools/Status/ExecutableStatus/__init__.py
+++ b/tools/Status/ExecutableStatus/__init__.py
@@ -6,7 +6,8 @@ import re
 
 from .EvolveGhBinaryBlackHole import EvolveGhBinaryBlackHole
 from .EvolveGhSingleBlackHole import EvolveGhSingleBlackHole
-from .ExecutableStatus import EvolutionStatus, ExecutableStatus
+from .ExecutableStatus import EllipticStatus, EvolutionStatus, ExecutableStatus
+from .SolveXcts import SolveXcts
 
 logger = logging.getLogger(__name__)
 
@@ -15,6 +16,8 @@ executable_status_subclasses = [
     EvolveGhBinaryBlackHole,
     EvolveGhSingleBlackHole,
     EvolutionStatus,
+    SolveXcts,
+    EllipticStatus,
 ]
 
 


### PR DESCRIPTION
## Proposed changes

Shows status of elliptic executables when running `spectre status` on a cluster.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
