### PR TITLE
Reimplement array_allocation_tags

### DIFF
--- a/docs/DevGuide/CreatingExecutables.md
+++ b/docs/DevGuide/CreatingExecutables.md
@@ -51,7 +51,7 @@ and action structs), to construct items in the db::DataBox of
 components during initialization (by specifying tags in the
 `simple_tags_from_options` type alias of action struct), or be passed to
 the `allocate_array` function of an array component (by specifying
-tags in the `allocation_tags` type alias of the component).
+tags in the `array_allocation_tags` type alias of the component).
 `SingletonHelloWorld` specifies a single option
 
 \snippet SingletonHelloWorld.cpp executable_example_options

--- a/docs/DevGuide/Parallelization.md
+++ b/docs/DevGuide/Parallelization.md
@@ -244,6 +244,10 @@ Each %Parallel Component struct must have the following type aliases:
    that correspond to mutable items that are stored in the
    Parallel::GlobalCache (of which there is one copy per Charm++
    core).  The alias can be omitted if the list is empty.
+7. `array_allocation_tags` is set to a `tmpl::list` of tags that will be
+   constructed from options and will only be used in the `allocate_array`
+   function of an array component. This type alias is only required for array
+   components.
 
 \parblock
 \note Array parallel components must also specify the type alias `using
@@ -272,13 +276,19 @@ static void allocate_array(
     Parallel::CProxy_GlobalCache<metavariables>& global_cache,
     const tuples::tagged_tuple_from_typelist<simple_tags_from_options>&
     initialization_items,
+    const tuples::tagged_tuple_from_typelist<array_allocation_tags>&
+    array_allocation_items,
     const std::unordered_set<size_t>& procs_to_ignore);
 \endcode
 The `allocate_array` function is called by the Main parallel component
 when the execution starts and will typically insert elements into
 array parallel components. If the `allocate_array` function depends
-upon input options that are not in the GlobalCache, the array component must
-include the appropriate tag in the `simple_tags_from_options` type alias.
+upon input options that are not in the GlobalCache, those tags should be
+added to the `array_allocation_tags` type alias. A TaggedTuple is constructed
+from this type alias and its input options and is only available in the
+`allocate_array` function. All other tags that will be constructed from options
+and used during the %Initialization phase should be placed in the
+`simple_tags_from_options` type alias.
 This type alias is a `tmpl::list` of tags which
 are db::SimpleTag%s that have have a `using option_tags` type alias
 and a static function `create_from_options`. They only need to be explicitly

--- a/src/Elliptic/DiscontinuousGalerkin/DgElementArray.hpp
+++ b/src/Elliptic/DiscontinuousGalerkin/DgElementArray.hpp
@@ -67,6 +67,10 @@ struct DefaultElementsAllocator
   static void apply(
       Parallel::CProxy_GlobalCache<Metavariables>& global_cache,
       const tuples::TaggedTuple<InitializationTags...>& initialization_items,
+      const tuples::tagged_tuple_from_typelist<
+          typename ParallelComponent::array_allocation_tags>&
+      /*array_allocation_items*/
+      = {},
       const std::unordered_set<size_t>& procs_to_ignore = {}) {
     auto& local_cache = *Parallel::local_branch(global_cache);
     auto& element_array =
@@ -205,9 +209,12 @@ struct DgElementArray {
       Parallel::CProxy_GlobalCache<Metavariables>& global_cache,
       const tuples::tagged_tuple_from_typelist<simple_tags_from_options>&
           initialization_items,
+      const tuples::tagged_tuple_from_typelist<array_allocation_tags>&
+          array_allocation_items = {},
       const std::unordered_set<size_t>& procs_to_ignore = {}) {
     ElementsAllocator::template apply<DgElementArray>(
-        global_cache, initialization_items, procs_to_ignore);
+        global_cache, initialization_items, array_allocation_items,
+        procs_to_ignore);
   }
 
   static void execute_next_phase(

--- a/src/Evolution/DiscontinuousGalerkin/DgElementArray.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/DgElementArray.hpp
@@ -79,10 +79,14 @@ struct DgElementArray {
   using simple_tags_from_options = Parallel::get_simple_tags_from_options<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
 
+  using array_allocation_tags = tmpl::list<>;
+
   static void allocate_array(
       Parallel::CProxy_GlobalCache<Metavariables>& global_cache,
       const tuples::tagged_tuple_from_typelist<simple_tags_from_options>&
           initialization_items,
+      const tuples::tagged_tuple_from_typelist<array_allocation_tags>&
+          array_allocation_items = {},
       const std::unordered_set<size_t>& procs_to_ignore = {});
 
   static void execute_next_phase(
@@ -99,6 +103,8 @@ void DgElementArray<Metavariables, PhaseDepActionList>::allocate_array(
     Parallel::CProxy_GlobalCache<Metavariables>& global_cache,
     const tuples::tagged_tuple_from_typelist<simple_tags_from_options>&
         initialization_items,
+    const tuples::tagged_tuple_from_typelist<array_allocation_tags>&
+    /*array_allocation_items*/,
     const std::unordered_set<size_t>& procs_to_ignore) {
   auto& local_cache = *Parallel::local_branch(global_cache);
   auto& dg_element_array =

--- a/src/Parallel/Main.hpp
+++ b/src/Parallel/Main.hpp
@@ -668,6 +668,8 @@ void Main<Metavariables>::
         global_cache_proxy_,
         Parallel::create_from_options<Metavariables>(
             options_, typename parallel_component::simple_tags_from_options{}),
+        Parallel::create_from_options<Metavariables>(
+            options_, typename parallel_component::array_allocation_tags{}),
         resource_info_.procs_to_ignore());
   });
 

--- a/src/ParallelAlgorithms/LinearSolver/Multigrid/ElementsAllocator.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Multigrid/ElementsAllocator.hpp
@@ -86,6 +86,10 @@ struct ElementsAllocator
   static void apply(Parallel::CProxy_GlobalCache<Metavariables>& global_cache,
                     const tuples::TaggedTuple<InitializationTags...>&
                         original_initialization_items,
+                    const tuples::tagged_tuple_from_typelist<
+                        typename ElementArray::
+                            array_allocation_tags>& /*array_allocation_items*/
+                    = {},
                     const std::unordered_set<size_t>& procs_to_ignore = {}) {
     // Copy the initialization items so we can adjust them on each refinement
     // level

--- a/tests/Unit/Helpers/ParallelAlgorithms/LinearSolver/LinearSolverAlgorithmTestHelpers.hpp
+++ b/tests/Unit/Helpers/ParallelAlgorithms/LinearSolver/LinearSolverAlgorithmTestHelpers.hpp
@@ -295,11 +295,15 @@ struct ElementArray {
       Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
   using const_global_cache_tags =
       tmpl::list<LinearOperator, Source, InitialGuess, ExpectedResult>;
+  using array_allocation_tags = tmpl::list<>;
 
   static void allocate_array(
       Parallel::CProxy_GlobalCache<Metavariables>& global_cache,
       const tuples::tagged_tuple_from_typelist<simple_tags_from_options>&
           initialization_items,
+      const tuples::tagged_tuple_from_typelist<array_allocation_tags>&
+      /*array_allocation_items*/
+      = {},
       const std::unordered_set<size_t>& /*procs_to_ignore*/ = {}) {
     auto& local_component = Parallel::get_parallel_component<ElementArray>(
         *Parallel::local_branch(global_cache));

--- a/tests/Unit/Helpers/ParallelAlgorithms/NonlinearSolver/Algorithm.hpp
+++ b/tests/Unit/Helpers/ParallelAlgorithms/NonlinearSolver/Algorithm.hpp
@@ -159,10 +159,15 @@ struct ElementArray {
   using simple_tags_from_options = Parallel::get_simple_tags_from_options<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
 
+  using array_allocation_tags = tmpl::list<>;
+
   static void allocate_array(
       Parallel::CProxy_GlobalCache<Metavariables>& global_cache,
       const tuples::tagged_tuple_from_typelist<simple_tags_from_options>&
           initialization_items,
+      const tuples::tagged_tuple_from_typelist<array_allocation_tags>&
+      /*array_allocation_items*/
+      = {},
       const std::unordered_set<size_t>& /*procs_to_ignore*/ = {}) {
     auto& local_component = Parallel::get_parallel_component<ElementArray>(
         *Parallel::local_branch(global_cache));

--- a/tests/Unit/IO/Importers/Test_VolumeDataReaderAlgorithm.hpp
+++ b/tests/Unit/IO/Importers/Test_VolumeDataReaderAlgorithm.hpp
@@ -396,6 +396,7 @@ struct ElementArray {
   using array_index = ElementId<Dim>;
   using metavariables = Metavariables;
   using simple_tags_from_options = tmpl::list<>;
+  using array_allocation_tags = tmpl::list<>;
 
   using import_fields = tmpl::list<ScalarFieldTag, VectorFieldTag<Dim>>;
 
@@ -423,6 +424,9 @@ struct ElementArray {
       Parallel::CProxy_GlobalCache<Metavariables>& global_cache,
       const tuples::tagged_tuple_from_typelist<simple_tags_from_options>&
           initialization_items,
+      const tuples::tagged_tuple_from_typelist<array_allocation_tags>&
+      /*array_allocation_items*/
+      = {},
       const std::unordered_set<size_t>& procs_to_ignore = {}) {
     auto& local_cache = *Parallel::local_branch(global_cache);
     auto& element_array =

--- a/tests/Unit/Parallel/Test_AlgorithmCore.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmCore.cpp
@@ -673,11 +673,15 @@ struct ReceiveComponent {
                      Parallel::Actions::TerminatePhase>>>;
   using simple_tags_from_options = Parallel::get_simple_tags_from_options<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
+  using array_allocation_tags = tmpl::list<>;
 
   static void allocate_array(
       Parallel::CProxy_GlobalCache<metavariables>& global_cache,
       const tuples::tagged_tuple_from_typelist<simple_tags_from_options>&
           initialization_items,
+      const tuples::tagged_tuple_from_typelist<array_allocation_tags>&
+      /*array_allocation_items*/
+      = {},
       const std::unordered_set<size_t>& procs_to_ignore = {}) {
     TestHelpers::Parallel::assign_array_elements_round_robin_style(
         Parallel::get_parallel_component<ReceiveComponent>(

--- a/tests/Unit/Parallel/Test_AlgorithmLocalSyncAction.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmLocalSyncAction.cpp
@@ -206,11 +206,15 @@ struct ArrayComponent {
       tmpl::list<TestSyncActionIncrement, Parallel::Actions::TerminatePhase>>>;
   using simple_tags_from_options = Parallel::get_simple_tags_from_options<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
+  using array_allocation_tags = tmpl::list<>;
 
   static void allocate_array(
       Parallel::CProxy_GlobalCache<Metavariables>& global_cache,
       const tuples::tagged_tuple_from_typelist<simple_tags_from_options>&
       /*initialization_items*/,
+      const tuples::tagged_tuple_from_typelist<array_allocation_tags>&
+      /*array_allocation_items*/
+      = {},
       const std::unordered_set<size_t>& /*procs_to_ignore*/ = {}) {
     auto& local_cache = *Parallel::local_branch(global_cache);
     auto& array_proxy =

--- a/tests/Unit/Parallel/Test_AlgorithmMessages.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmMessages.cpp
@@ -376,12 +376,16 @@ struct ArrayParallelComponent {
           tmpl::list<CheckMessage, Parallel::Actions::TerminatePhase>>>;
   using simple_tags_from_options = Parallel::get_simple_tags_from_options<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
+  using array_allocation_tags = tmpl::list<>;
   using array_index = int;
 
   static void allocate_array(
       Parallel::CProxy_GlobalCache<Metavariables>& global_cache,
       const tuples::tagged_tuple_from_typelist<simple_tags_from_options>&
       /*initialization_items*/,
+      const tuples::tagged_tuple_from_typelist<array_allocation_tags>&
+      /*array_allocation_items*/
+      = {},
       const std::unordered_set<size_t>& /*procs_to_ignore*/ = {}) {
     auto& local_cache = *Parallel::local_branch(global_cache);
     auto& array_proxy =

--- a/tests/Unit/Parallel/Test_AlgorithmNodelock.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmNodelock.cpp
@@ -240,11 +240,15 @@ struct ArrayParallelComponent {
       Parallel::PhaseActions<Parallel::Phase::Execute, tmpl::list<>>>;
   using simple_tags_from_options = Parallel::get_simple_tags_from_options<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
+  using array_allocation_tags = tmpl::list<>;
 
   static void allocate_array(
       Parallel::CProxy_GlobalCache<Metavariables>& global_cache,
       const tuples::tagged_tuple_from_typelist<simple_tags_from_options>&
       /*initialization_items*/,
+      const tuples::tagged_tuple_from_typelist<array_allocation_tags>&
+      /*array_allocation_items*/
+      = {},
       const std::unordered_set<size_t>& procs_to_ignore = {}) {
     auto& local_cache = *Parallel::local_branch(global_cache);
     auto& array_proxy =

--- a/tests/Unit/Parallel/Test_AlgorithmParallel.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmParallel.cpp
@@ -535,12 +535,16 @@ struct ArrayParallelComponent {
                              tmpl::list<ArrayActions::CheckWasUnpacked>>>;
   using simple_tags_from_options = Parallel::get_simple_tags_from_options<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
+  using array_allocation_tags = tmpl::list<>;
   using array_index = int;
 
   static void allocate_array(
       Parallel::CProxy_GlobalCache<Metavariables>& global_cache,
       const tuples::tagged_tuple_from_typelist<simple_tags_from_options>&
       /*initialization_items*/,
+      const tuples::tagged_tuple_from_typelist<array_allocation_tags>&
+      /*array_allocation_items*/
+      = {},
       const std::unordered_set<size_t>& procs_to_ignore = {}) {
     auto& local_cache = *Parallel::local_branch(global_cache);
     auto& array_proxy =

--- a/tests/Unit/Parallel/Test_AlgorithmPhaseControl.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmPhaseControl.cpp
@@ -131,11 +131,15 @@ struct ComponentAlpha {
 
   using simple_tags_from_options = Parallel::get_simple_tags_from_options<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
+  using array_allocation_tags = tmpl::list<>;
 
   static void allocate_array(
       Parallel::CProxy_GlobalCache<Metavariables>& global_cache,
       const tuples::tagged_tuple_from_typelist<simple_tags_from_options>&
       /*initialization_items*/,
+      const tuples::tagged_tuple_from_typelist<array_allocation_tags>&
+      /*array_allocation_items*/
+      = {},
       const std::unordered_set<size_t>& /*procs_to_ignore*/ = {}) {
     auto& local_cache = *Parallel::local_branch(global_cache);
     auto& array_proxy =

--- a/tests/Unit/Parallel/Test_AlgorithmReduction.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmReduction.cpp
@@ -228,11 +228,15 @@ struct ArrayParallelComponent {
       Parallel::PhaseActions<Parallel::Phase::Initialization, tmpl::list<>>>;
   using simple_tags_from_options = Parallel::get_simple_tags_from_options<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
+  using array_allocation_tags = tmpl::list<>;
 
   static void allocate_array(
       Parallel::CProxy_GlobalCache<Metavariables>& global_cache,
       const tuples::tagged_tuple_from_typelist<simple_tags_from_options>&
       /*initialization_items*/,
+      const tuples::tagged_tuple_from_typelist<array_allocation_tags>&
+      /*array_allocation_items*/
+      = {},
       const std::unordered_set<size_t>& procs_to_ignore = {}) {
     auto& local_cache = *Parallel::local_branch(global_cache);
     auto& array_proxy =

--- a/tests/Unit/Parallel/Test_Callback.cpp
+++ b/tests/Unit/Parallel/Test_Callback.cpp
@@ -126,11 +126,15 @@ struct TestArray {
                                         tmpl::list<DoubleValueOfElement0>>>;
   using simple_tags_from_options = Parallel::get_simple_tags_from_options<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
+  using array_allocation_tags = tmpl::list<>;
 
   static void allocate_array(
       Parallel::CProxy_GlobalCache<Metavariables>& global_cache,
       const tuples::tagged_tuple_from_typelist<simple_tags_from_options>&
       /*initialization_items*/,
+      const tuples::tagged_tuple_from_typelist<array_allocation_tags>&
+      /*array_allocation_items*/
+      = {},
       const std::unordered_set<size_t>& procs_to_ignore = {}) {
     auto& local_cache = *Parallel::local_branch(global_cache);
     auto& array_proxy =

--- a/tests/Unit/Parallel/Test_CheckpointRestart.cpp
+++ b/tests/Unit/Parallel/Test_CheckpointRestart.cpp
@@ -121,11 +121,15 @@ struct ArrayComponent {
       Parallel::PhaseActions<Parallel::Phase::Testing, tmpl::list<CheckLog>>>;
   using simple_tags_from_options = Parallel::get_simple_tags_from_options<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
+  using array_allocation_tags = tmpl::list<>;
 
   static void allocate_array(
       Parallel::CProxy_GlobalCache<Metavariables>& global_cache,
       const tuples::tagged_tuple_from_typelist<simple_tags_from_options>&
       /*initialization_items*/,
+      const tuples::tagged_tuple_from_typelist<array_allocation_tags>&
+      /*array_allocation_items*/
+      = {},
       const std::unordered_set<size_t>& procs_to_ignore = {}) {
     auto& local_cache = *Parallel::local_branch(global_cache);
     auto& array_proxy =

--- a/tests/Unit/Parallel/Test_DetectHangArray.cpp
+++ b/tests/Unit/Parallel/Test_DetectHangArray.cpp
@@ -153,11 +153,15 @@ struct ArrayComponent {
       Parallel::PhaseActions<Parallel::Phase::Evolve, tmpl::list<Hang>>>;
   using simple_tags_from_options = Parallel::get_simple_tags_from_options<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
+  using array_allocation_tags = tmpl::list<>;
 
   static void allocate_array(
       Parallel::CProxy_GlobalCache<Metavariables>& global_cache,
       const tuples::tagged_tuple_from_typelist<simple_tags_from_options>&
       /*initialization_items*/,
+      const tuples::tagged_tuple_from_typelist<array_allocation_tags>&
+      /*array_allocation_items*/
+      = {},
       const std::unordered_set<size_t>& /*procs_to_ignore*/ = {}) {
     auto& local_cache = *Parallel::local_branch(global_cache);
     auto& array_proxy =

--- a/tests/Unit/Parallel/Test_DynamicInsertion.cpp
+++ b/tests/Unit/Parallel/Test_DynamicInsertion.cpp
@@ -295,11 +295,15 @@ struct TestArray {
                                         tmpl::list<InitializeValue>>>;
   using simple_tags_from_options = Parallel::get_simple_tags_from_options<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
+  using array_allocation_tags = tmpl::list<>;
 
   static void allocate_array(
       Parallel::CProxy_GlobalCache<Metavariables>& global_cache,
       const tuples::tagged_tuple_from_typelist<simple_tags_from_options>&
       /*initialization_items*/,
+      const tuples::tagged_tuple_from_typelist<array_allocation_tags>&
+      /*array_allocation_items*/
+      = {},
       const std::unordered_set<size_t>& procs_to_ignore = {}) {
     auto& local_cache = *Parallel::local_branch(global_cache);
     auto& array_proxy =

--- a/tests/Unit/Parallel/Test_DynamicInsertionState.cpp
+++ b/tests/Unit/Parallel/Test_DynamicInsertionState.cpp
@@ -290,11 +290,15 @@ struct TestArray {
                      DoubleValue<1>, CheckForTermination>>>;
   using simple_tags_from_options = Parallel::get_simple_tags_from_options<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
+  using array_allocation_tags = tmpl::list<>;
 
   static void allocate_array(
       Parallel::CProxy_GlobalCache<Metavariables>& global_cache,
       const tuples::tagged_tuple_from_typelist<simple_tags_from_options>&
       /*initialization_items*/,
+      const tuples::tagged_tuple_from_typelist<array_allocation_tags>&
+      /*array_allocation_items*/
+      = {},
       const std::unordered_set<size_t>& procs_to_ignore = {}) {
     auto& local_cache = *Parallel::local_branch(global_cache);
     auto& array_proxy =

--- a/tests/Unit/Parallel/Test_ParallelComponentHelpers.cpp
+++ b/tests/Unit/Parallel/Test_ParallelComponentHelpers.cpp
@@ -81,6 +81,37 @@ struct ComponentInitAndExecute {
       Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
 };
 
+struct ComponentInitWithAllocate {
+  using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
+      Parallel::Phase::Initialization,
+      tmpl::list<InitAction0, InitAction1, InitAction2>>>;
+  using array_allocation_tags = tmpl::list<InitTag4, InitTag5>;
+  using simple_tags_from_options = Parallel::get_simple_tags_from_options<
+      Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
+  using const_global_cache_tags = tmpl::list<Tag1, Tag5, Tag7>;
+};
+
+struct ComponentExecuteWithAllocate {
+  using phase_dependent_action_list =
+      tmpl::list<Parallel::PhaseActions<Parallel::Phase::Execute,
+                                        tmpl::list<Action0, Action1>>>;
+  using array_allocation_tags = tmpl::list<InitTag6, InitTag7>;
+  using simple_tags_from_options = Parallel::get_simple_tags_from_options<
+      Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
+};
+
+struct ComponentInitAndExecuteWithAllocate {
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<Parallel::Phase::Initialization,
+                             tmpl::list<InitAction3>>,
+      Parallel::PhaseActions<Parallel::Phase::Execute,
+                             tmpl::list<InitAction2, Action0, Action2>>>;
+  using array_allocation_tags = tmpl::list<InitTag3, InitTag4>;
+  using simple_tags_from_options = Parallel::get_simple_tags_from_options<
+      Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
+  using const_global_cache_tags = tmpl::list<Tag2, Tag4>;
+};
+
 struct Metavariables0 {
   using component_list = tmpl::list<ComponentInit>;
 };
@@ -90,6 +121,15 @@ struct Metavariables1 {
   using component_list = tmpl::list<>;
 };
 
+struct Metavariables2 {
+  using component_list = tmpl::list<ComponentInitWithAllocate>;
+};
+
+struct Metavariables3 {
+  using const_global_cache_tags = tmpl::list<Tag0, Tag4>;
+  using component_list = tmpl::list<ComponentInitWithAllocate>;
+};
+
 struct Metavariables4 {
   using component_list = tmpl::list<ComponentInitAndExecute>;
 };
@@ -97,6 +137,15 @@ struct Metavariables4 {
 struct Metavariables5 {
   using const_global_cache_tags = tmpl::list<Tag0, Tag4>;
   using component_list = tmpl::list<ComponentInitAndExecute>;
+};
+
+struct Metavariables6 {
+  using component_list = tmpl::list<ComponentInitAndExecuteWithAllocate>;
+};
+
+struct Metavariables7 {
+  using const_global_cache_tags = tmpl::list<Tag0, Tag4>;
+  using component_list = tmpl::list<ComponentInitAndExecuteWithAllocate>;
 };
 
 static_assert(
@@ -116,6 +165,16 @@ static_assert(
     "Failed testing get_const_global_cache_tags");
 
 static_assert(
+    std::is_same_v<Parallel::get_const_global_cache_tags<Metavariables2>,
+                   tmpl::list<Tag1, Tag5, Tag7>>,
+    "Failed testing get_const_global_cache_tags");
+
+static_assert(
+    std::is_same_v<Parallel::get_const_global_cache_tags<Metavariables3>,
+                   tmpl::list<Tag0, Tag4, Tag1, Tag5, Tag7>>,
+    "Failed testing get_const_global_cache_tags");
+
+static_assert(
     std::is_same_v<Parallel::get_const_global_cache_tags<Metavariables4>,
                    tmpl::list<Tag6>>,
     "Failed testing get_const_global_cache_tags");
@@ -123,6 +182,16 @@ static_assert(
 static_assert(
     std::is_same_v<Parallel::get_const_global_cache_tags<Metavariables5>,
                    tmpl::list<Tag0, Tag4, Tag6>>,
+    "Failed testing get_const_global_cache_tags");
+
+static_assert(
+    std::is_same_v<Parallel::get_const_global_cache_tags<Metavariables6>,
+                   tmpl::list<Tag2, Tag4, Tag6>>,
+    "Failed testing get_const_global_cache_tags");
+
+static_assert(
+    std::is_same_v<Parallel::get_const_global_cache_tags<Metavariables7>,
+                   tmpl::list<Tag0, Tag4, Tag2, Tag6>>,
     "Failed testing get_const_global_cache_tags");
 
 static_assert(std::is_same_v<Parallel::get_initialization_actions_list<
@@ -151,6 +220,21 @@ static_assert(
 
 static_assert(std::is_same_v<ComponentInitAndExecute::simple_tags_from_options,
                              tmpl::list<InitTag0, InitTag1, InitTag3>>,
+              "Failed testing get_simple_tags_from_options");
+
+static_assert(
+    std::is_same_v<ComponentInitWithAllocate::simple_tags_from_options,
+                   tmpl::list<InitTag0, InitTag1, InitTag2>>,
+    "Failed testing get_simple_tags_from_options");
+
+static_assert(
+    std::is_same_v<ComponentExecuteWithAllocate::simple_tags_from_options,
+                   tmpl::list<>>,
+    "Failed testing get_simple_tags_from_options");
+
+static_assert(std::is_same_v<
+                  ComponentInitAndExecuteWithAllocate::simple_tags_from_options,
+                  tmpl::list<InitTag0, InitTag1, InitTag3>>,
               "Failed testing get_simple_tags_from_options");
 
 namespace OptionTags {
@@ -210,7 +294,7 @@ struct FullGreeting {
   static std::string create_from_options(const std::string& greeting,
                                          const std::string& name) {
     if (std::is_same<Metavariables, MetavariablesGreeting>::value) {
-      return "A special " +  greeting + ' ' + name;
+      return "A special " + greeting + ' ' + name;
     } else {
       return greeting + ' ' + name;
     }
@@ -264,7 +348,6 @@ void check_initialization_items(
             options, simple_tags_from_options{}) == expected_items);
 }
 }  // namespace
-
 
 SPECTRE_TEST_CASE("Unit.Parallel.ComponentHelpers", "[Unit][Parallel]") {
   Options::Parser<all_option_tags> all_options("");

--- a/tests/Unit/Parallel/Test_PhaseChangeMain.cpp
+++ b/tests/Unit/Parallel/Test_PhaseChangeMain.cpp
@@ -167,11 +167,15 @@ struct ArrayComponent {
           tmpl::list<IncrementStep, ReportArrayPhaseControlDataAndTerminate>>>;
   using simple_tags_from_options = Parallel::get_simple_tags_from_options<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
+  using array_allocation_tags = tmpl::list<>;
 
   static void allocate_array(
       Parallel::CProxy_GlobalCache<Metavariables>& global_cache,
       const tuples::tagged_tuple_from_typelist<simple_tags_from_options>&
       /*initialization_items*/,
+      const tuples::tagged_tuple_from_typelist<array_allocation_tags>&
+      /*array_allocation_items*/
+      = {},
       const std::unordered_set<size_t>& procs_to_ignore = {}) {
     auto& local_cache = *Parallel::local_branch(global_cache);
     auto& array_proxy =

--- a/tests/Unit/Parallel/Test_SectionReductions.cpp
+++ b/tests/Unit/Parallel/Test_SectionReductions.cpp
@@ -149,6 +149,9 @@ struct ArrayComponent {
       Parallel::CProxy_GlobalCache<Metavariables>& global_cache,
       tuples::tagged_tuple_from_typelist<simple_tags_from_options>
           initialization_items,
+      const tuples::tagged_tuple_from_typelist<array_allocation_tags>&
+      /*array_allocation_items*/
+      = {},
       const std::unordered_set<size_t>& procs_to_ignore = {}) {
     auto& local_cache = *Parallel::local_branch(global_cache);
     auto& array_proxy =


### PR DESCRIPTION
## Proposed changes

Now array components can specify a separate list of tags from options that can be used during array allocation. These tags can be from any parallel component.

This is re-implemented slightly differently than #4456. In that PR, the array allocation tags were originally lumped in with the simple tags from options. In this PR, I add another argument to the `allocate_array` function corresponding to the new `array_allocation_tags` list.

I will need this feature for interpolation framework changes.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
