### PR TITLE
Add SettleToConstantQuaternion

### DIFF
--- a/src/Domain/FunctionsOfTime/CMakeLists.txt
+++ b/src/Domain/FunctionsOfTime/CMakeLists.txt
@@ -15,6 +15,7 @@ spectre_target_sources(
   QuaternionHelpers.cpp
   RegisterDerivedWithCharm.cpp
   SettleToConstant.cpp
+  SettleToConstantQuaternion.cpp
   )
 
 spectre_target_headers(
@@ -31,6 +32,7 @@ spectre_target_headers(
   QuaternionHelpers.hpp
   RegisterDerivedWithCharm.hpp
   SettleToConstant.hpp
+  SettleToConstantQuaternion.hpp
   Tags.hpp
   ThreadsafeList.hpp
   ThreadsafeList.tpp

--- a/src/Domain/FunctionsOfTime/RegisterDerivedWithCharm.cpp
+++ b/src/Domain/FunctionsOfTime/RegisterDerivedWithCharm.cpp
@@ -12,6 +12,7 @@
 #include "Domain/FunctionsOfTime/PiecewisePolynomial.hpp"
 #include "Domain/FunctionsOfTime/QuaternionFunctionOfTime.hpp"
 #include "Domain/FunctionsOfTime/SettleToConstant.hpp"
+#include "Domain/FunctionsOfTime/SettleToConstantQuaternion.hpp"
 #include "Utilities/PrettyType.hpp"
 #include "Utilities/Serialization/RegisterDerivedClassesWithCharm.hpp"
 #include "Utilities/TMPL.hpp"
@@ -27,6 +28,7 @@ void register_derived_with_charm() {
                               FunctionsOfTime::QuaternionFunctionOfTime<2>,
                               FunctionsOfTime::QuaternionFunctionOfTime<3>,
                               FunctionsOfTime::QuaternionFunctionOfTime<4>,
-                              FunctionsOfTime::SettleToConstant>();
+                              FunctionsOfTime::SettleToConstant,
+                              FunctionsOfTime::SettleToConstantQuaternion>();
 }
 }  // namespace domain::FunctionsOfTime

--- a/src/Domain/FunctionsOfTime/SettleToConstantQuaternion.cpp
+++ b/src/Domain/FunctionsOfTime/SettleToConstantQuaternion.cpp
@@ -1,0 +1,140 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Domain/FunctionsOfTime/SettleToConstantQuaternion.hpp"
+
+#include <cmath>
+#include <limits>
+#include <memory>
+
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/EqualWithinRoundoff.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeArray.hpp"
+#include "Utilities/StdArrayHelpers.hpp"
+
+namespace {
+template <size_t MaxDerivReturned>
+std::array<double, MaxDerivReturned + 1> quat_norm_and_derivs(
+    const std::array<DataVector, MaxDerivReturned + 1>&
+        unnormalized_func_and_derivs) {
+  std::array<double, MaxDerivReturned + 1> result =
+      make_array<MaxDerivReturned + 1>(0.0);
+  gsl::at(result, 0) = norm(gsl::at(unnormalized_func_and_derivs, 0));
+  if constexpr (MaxDerivReturned > 0) {
+    gsl::at(result, 1) = sum(gsl::at(unnormalized_func_and_derivs, 0) *
+                             gsl::at(unnormalized_func_and_derivs, 1)) /
+                         gsl::at(result, 0);
+    if constexpr (MaxDerivReturned > 1) {
+      gsl::at(result, 2) =
+          sum(square(gsl::at(unnormalized_func_and_derivs, 1)) +
+              gsl::at(unnormalized_func_and_derivs, 0) *
+                  gsl::at(unnormalized_func_and_derivs, 2)) /
+          gsl::at(result, 0);
+    }
+  }
+  return result;
+}
+}  // namespace
+
+namespace domain::FunctionsOfTime {
+SettleToConstantQuaternion::SettleToConstantQuaternion(
+    const std::array<DataVector, 3>& initial_func_and_derivs,
+    const double match_time, const double decay_time)
+    : unnormalized_function_of_time_(initial_func_and_derivs, match_time,
+                                     decay_time),
+      match_time_(match_time),
+      decay_time_(decay_time) {
+  if (initial_func_and_derivs[0].size() != 4) {
+    ERROR(
+        "SettleToConstantQuaternion requires the initial function and its time "
+        "derivatives to be quaternions stored as DataVectors of size 4, not "
+        "size "
+        << initial_func_and_derivs[0].size());
+  }
+  if (not equal_within_roundoff(
+          gsl::at(quat_norm_and_derivs<2>(initial_func_and_derivs), 0), 1.0)) {
+    ERROR(
+        "SettleToConstantQuaternion requires that the initial quaternion "
+        "should be a quaternion with a norm of 1.0, not "
+        << gsl::at(quat_norm_and_derivs<2>(initial_func_and_derivs), 0));
+  }
+}
+
+std::unique_ptr<FunctionOfTime> SettleToConstantQuaternion::get_clone() const {
+  return std::make_unique<SettleToConstantQuaternion>(*this);
+}
+
+template <size_t MaxDerivReturned>
+std::array<DataVector, MaxDerivReturned + 1>
+SettleToConstantQuaternion::func_and_derivs(const double t) const {
+  static_assert(MaxDerivReturned < 3, "The maximum available derivative is 2.");
+
+  std::array<DataVector, MaxDerivReturned + 1> result{};
+  if constexpr (MaxDerivReturned == 0) {
+    result = unnormalized_function_of_time_.func(t);
+  } else if constexpr (MaxDerivReturned == 1) {
+    result = unnormalized_function_of_time_.func_and_deriv(t);
+  } else if constexpr (MaxDerivReturned == 2) {
+    result = unnormalized_function_of_time_.func_and_2_derivs(t);
+  }
+  std::array<double, MaxDerivReturned + 1> norm_and_derivs =
+      quat_norm_and_derivs<MaxDerivReturned>(result);
+  result /= gsl::at(norm_and_derivs, 0);
+  if constexpr (MaxDerivReturned > 0) {
+    gsl::at(result, 1) -= gsl::at(result, 0) * gsl::at(norm_and_derivs, 1) /
+                          gsl::at(norm_and_derivs, 0);
+    if constexpr (MaxDerivReturned > 1) {
+      gsl::at(result, 2) -= gsl::at(result, 1) * 2.0 *
+                            gsl::at(norm_and_derivs, 1) /
+                            gsl::at(norm_and_derivs, 0);
+      gsl::at(result, 2) -= gsl::at(result, 0) * gsl::at(norm_and_derivs, 2) /
+                            gsl::at(norm_and_derivs, 0);
+    }
+  }
+
+  return result;
+}
+
+void SettleToConstantQuaternion::pup(PUP::er& p) {
+  FunctionOfTime::pup(p);
+  size_t version = 0;
+  p | version;
+  // Remember to increment the version number when making changes to this
+  // function. Retain support for unpacking data written by previous versions
+  // whenever possible. See `Domain` docs for details.
+  if (version >= 0) {
+    p | unnormalized_function_of_time_;
+    p | match_time_;
+    p | decay_time_;
+  }
+}
+
+bool operator==(const SettleToConstantQuaternion& lhs,
+                const SettleToConstantQuaternion& rhs) {
+  return lhs.unnormalized_function_of_time_ ==
+             rhs.unnormalized_function_of_time_ and
+         lhs.match_time_ == rhs.match_time_ and
+         lhs.decay_time_ == rhs.decay_time_;
+}
+
+bool operator!=(const SettleToConstantQuaternion& lhs,
+                const SettleToConstantQuaternion& rhs) {
+  return not(lhs == rhs);
+}
+
+PUP::able::PUP_ID SettleToConstantQuaternion::my_PUP_ID = 0;  // NOLINT
+
+#define DERIV(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data)                                             \
+  template std::array<DataVector, DERIV(data) + 1>                       \
+  SettleToConstantQuaternion::func_and_derivs<DERIV(data)>(const double) \
+      const;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (0, 1, 2))
+
+#undef DERIV
+#undef INSTANTIATE
+}  // namespace domain::FunctionsOfTime

--- a/src/Domain/FunctionsOfTime/SettleToConstantQuaternion.hpp
+++ b/src/Domain/FunctionsOfTime/SettleToConstantQuaternion.hpp
@@ -1,0 +1,91 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <limits>
+#include <memory>
+#include <pup.h>
+
+#include "DataStructures/DataVector.hpp"
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "Domain/FunctionsOfTime/SettleToConstant.hpp"
+#include "Utilities/Serialization/CharmPupable.hpp"
+
+namespace domain::FunctionsOfTime {
+/// \ingroup ControlSystemGroup
+/// \brief Given an initial function of time that is a unit quaternion,
+/// transitions to a constant-in-time unit quaternion.
+///
+/// Given an initial unit quaternion \f$\mathbf{f}(t)\f$ and its first two
+/// derivatives at the matching time \f$t_0\f$, return a function of time
+/// \f$\mathbf{g}(t)\f$ satisfies \f$\mathbf{g}(t=t_0)=\mathbf{f}f(t=t_0)\f$ and
+/// approaches a constant value for \f$t > t_0\f$ on a timescale of \f$\tau\f$.
+/// This is done by internally holding a `SettleToConstant` function of time
+/// initialized from \f$\mathbf{f}(t)\f$ and its first two derivatives at the
+/// matching time, but then ensuring that \f$\mathbf{g}(t)\f$ remains
+/// a unit quaternion.
+class SettleToConstantQuaternion : public FunctionOfTime {
+ public:
+  SettleToConstantQuaternion() = default;
+  SettleToConstantQuaternion(
+      const std::array<DataVector, 3>& initial_func_and_derivs,
+      double match_time, double decay_time);
+
+  ~SettleToConstantQuaternion() override = default;
+  SettleToConstantQuaternion(SettleToConstantQuaternion&&) = default;
+  SettleToConstantQuaternion& operator=(SettleToConstantQuaternion&&) = default;
+  SettleToConstantQuaternion(const SettleToConstantQuaternion&) = default;
+  SettleToConstantQuaternion& operator=(const SettleToConstantQuaternion&) =
+      default;
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  WRAPPED_PUPable_decl_template(SettleToConstantQuaternion);
+
+  explicit SettleToConstantQuaternion(CkMigrateMessage* /*unused*/) {}
+
+  auto get_clone() const -> std::unique_ptr<FunctionOfTime> override;
+
+  /// Returns the function at an arbitrary time `t`.
+  std::array<DataVector, 1> func(const double t) const override {
+    return func_and_derivs<0>(t);
+  }
+  /// Returns the function and its first derivative at an arbitrary time `t`.
+  std::array<DataVector, 2> func_and_deriv(const double t) const override {
+    return func_and_derivs<1>(t);
+  }
+  /// Returns the function and the first two derivatives at an arbitrary time
+  /// `t`.
+  std::array<DataVector, 3> func_and_2_derivs(const double t) const override {
+    return func_and_derivs<2>(t);
+  }
+
+  /// Returns the domain of validity of the function.
+  std::array<double, 2> time_bounds() const override {
+    return {{match_time_, std::numeric_limits<double>::infinity()}};
+  }
+
+  double expiration_after(const double /*time*/) const override {
+    return std::numeric_limits<double>::infinity();
+  }
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& p) override;
+
+ private:
+  friend bool operator==(const SettleToConstantQuaternion& lhs,
+                         const SettleToConstantQuaternion& rhs);
+
+  template <size_t MaxDerivReturned = 2>
+  std::array<DataVector, MaxDerivReturned + 1> func_and_derivs(double t) const;
+
+  SettleToConstant unnormalized_function_of_time_;
+  double match_time_{std::numeric_limits<double>::signaling_NaN()};
+  double decay_time_{std::numeric_limits<double>::signaling_NaN()};
+};
+
+bool operator!=(const SettleToConstantQuaternion& lhs,
+                const SettleToConstantQuaternion& rhs);
+}  // namespace domain::FunctionsOfTime

--- a/tests/Unit/Domain/FunctionsOfTime/CMakeLists.txt
+++ b/tests/Unit/Domain/FunctionsOfTime/CMakeLists.txt
@@ -12,6 +12,7 @@ set(LIBRARY_SOURCES
   Test_QuaternionFunctionOfTime.cpp
   Test_QuaternionHelpers.cpp
   Test_SettleToConstant.cpp
+  Test_SettleToConstantQuaternion.cpp
   Test_Tags.cpp
   )
 

--- a/tests/Unit/Domain/FunctionsOfTime/Test_SettleToConstantQuaternion.cpp
+++ b/tests/Unit/Domain/FunctionsOfTime/Test_SettleToConstantQuaternion.cpp
@@ -1,0 +1,194 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <memory>
+
+#include "DataStructures/DataVector.hpp"
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "Domain/FunctionsOfTime/RegisterDerivedWithCharm.hpp"
+#include "Domain/FunctionsOfTime/SettleToConstantQuaternion.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+
+namespace {
+void test(
+    const std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>& f_of_t,
+    const double match_time, const double decay_time, const DataVector& f_t0,
+    const DataVector& dtf_t0, const DataVector& d2tf_t0, const DataVector& A) {
+  // check that values agree at the matching time
+  const auto lambdas0 = f_of_t->func_and_2_derivs(match_time);
+  CHECK_ITERABLE_APPROX(lambdas0[0], f_t0);
+  CHECK_ITERABLE_APPROX(lambdas0[1], dtf_t0);
+  CHECK_ITERABLE_APPROX(lambdas0[2], d2tf_t0);
+
+  const auto lambdas1 = f_of_t->func_and_deriv(match_time);
+  CHECK_ITERABLE_APPROX(lambdas1[0], f_t0);
+  CHECK_ITERABLE_APPROX(lambdas1[1], dtf_t0);
+
+  const auto lambdas2 = f_of_t->func(match_time);
+  CHECK_ITERABLE_APPROX(lambdas2[0], f_t0);
+
+  // check that asymptotic values approach f = A/|A| = const.
+  const auto lambdas3 = f_of_t->func_and_2_derivs(1.0e5);
+  const DataVector zero{0.0, 0.0, 0.0, 0.0};
+  const DataVector normalized_A = A / norm(A);
+  CHECK_ITERABLE_APPROX(lambdas3[0], normalized_A);
+  CHECK_ITERABLE_APPROX(lambdas3[1], zero);
+  CHECK_ITERABLE_APPROX(lambdas3[2], zero);
+
+  const auto lambdas4 = f_of_t->func_and_deriv(1.0e5);
+  CHECK_ITERABLE_APPROX(lambdas4[0], normalized_A);
+  CHECK_ITERABLE_APPROX(lambdas4[1], zero);
+
+  const auto lambdas5 = f_of_t->func(1.0e5);
+  CHECK_ITERABLE_APPROX(lambdas5[0], normalized_A);
+
+  // Check that function of time remains a unit quaternion
+  const auto lambdas6 = f_of_t->func(match_time + decay_time * 0.34);
+  const double lambdas6_norm = norm(lambdas6[0]);
+  CHECK(approx(lambdas6_norm) == 1.0);
+
+  // test time_bounds function
+  const auto t_bounds = f_of_t->time_bounds();
+  CHECK(t_bounds[0] == match_time);
+  CHECK(t_bounds[1] == std::numeric_limits<double>::infinity());
+  CHECK(f_of_t->expiration_after(match_time) ==
+        std::numeric_limits<double>::infinity());
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Domain.FunctionsOfTime.SettleToConstantQuaternion",
+                  "[Domain][Unit]") {
+  using SettleToConstantQuaternion =
+      domain::FunctionsOfTime::SettleToConstantQuaternion;
+
+  domain::FunctionsOfTime::register_derived_with_charm();
+
+  const double match_time = 10.0;
+  const double decay_time = 5.0;
+  // Choose for an initial quaternion
+  // q = (cos \theta/2, \hat{n} \sin \theta/2), where
+  // \theta = \Omega(t-t_0) + \alpha(t-t_0)^2/2 + \phi
+  // \hat{n}_x = \cos \Phi
+  // \hat{n}_y = 0
+  // \hat{n}_z = \sin \Phi
+  // \Phi = \omega(t-t_0) + \varphi
+  // This is an accelerating, precessing rotation.
+  // For the constants, choose
+  // \Omega = 0.1, \alpha=0.05, \omega = 0.01, \phi = 0.2, \varphi = 0.4
+  const DataVector f_t0{0.9950041652780258, 0.09195266597143172, 0.0,
+                        0.03887696361761665};
+  const DataVector dtf_t0{-0.004991670832341408, 0.04543420663922331, 0.0,
+                          0.02029317029135289};
+  const DataVector d2tf_t0{-0.004983345829365769, 0.022284938333541247, 0.0,
+                           0.01050220123592147};
+
+  // compute coefficients for check
+  const DataVector C = -(decay_time * d2tf_t0 + dtf_t0);
+  const DataVector B = decay_time * (C - dtf_t0);
+  const DataVector A = f_t0 - B;
+  const std::array<DataVector, 3> init_func{{f_t0, dtf_t0, d2tf_t0}};
+
+  INFO("Test with base class construction.");
+  const std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime> f_of_t =
+      std::make_unique<domain::FunctionsOfTime::SettleToConstantQuaternion>(
+          init_func, match_time, decay_time);
+  test(f_of_t, match_time, decay_time, f_t0, dtf_t0, d2tf_t0, A);
+
+  const std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime> f_of_t2 =
+      serialize_and_deserialize(f_of_t);
+  test(f_of_t2, match_time, decay_time, f_t0, dtf_t0, d2tf_t0, A);
+
+  const std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime> f_of_t3 =
+      f_of_t->get_clone();
+  test(f_of_t3, match_time, decay_time, f_t0, dtf_t0, d2tf_t0, A);
+
+  {
+    INFO("Test operator==");
+    CHECK(SettleToConstantQuaternion{init_func, match_time, decay_time} ==
+          SettleToConstantQuaternion{init_func, match_time, decay_time});
+    CHECK_FALSE(SettleToConstantQuaternion{init_func, match_time, decay_time} !=
+                SettleToConstantQuaternion{init_func, match_time, decay_time});
+
+    CHECK(SettleToConstantQuaternion{init_func, match_time, decay_time} !=
+          SettleToConstantQuaternion{init_func, match_time, 2.0 * decay_time});
+    CHECK_FALSE(
+        SettleToConstantQuaternion{init_func, match_time, decay_time} ==
+        SettleToConstantQuaternion{init_func, match_time, 2.0 * decay_time});
+
+    CHECK(SettleToConstantQuaternion{init_func, match_time, decay_time} !=
+          SettleToConstantQuaternion{init_func, 2.0 * match_time, decay_time});
+    CHECK_FALSE(
+        SettleToConstantQuaternion{init_func, match_time, decay_time} ==
+        SettleToConstantQuaternion{init_func, 2.0 * match_time, decay_time});
+
+    // Test == for different initial quaternions; both must be unit
+    // quaternions.
+    const DataVector another_f_t0{0.9928086358538663, 0.10830981865238282, 0.0,
+                                  0.050990153534512375};
+    const DataVector another_dtf_t0{-0.008379854510224357, 0.062163306368871823,
+                                    0.0, 0.031117684009928405};
+    const DataVector another_d2tf_t0{
+        -0.008096991912484768, 0.022871837603575258, 0.0, 0.01291837713635158};
+    const std::array<DataVector, 3> another_init_func{
+        {another_f_t0, another_dtf_t0, another_d2tf_t0}};
+    CHECK(
+        SettleToConstantQuaternion{init_func, match_time, decay_time} !=
+        SettleToConstantQuaternion{another_init_func, match_time, decay_time});
+    CHECK_FALSE(
+        SettleToConstantQuaternion{init_func, match_time, decay_time} ==
+        SettleToConstantQuaternion{another_init_func, match_time, decay_time});
+
+    CHECK(SettleToConstantQuaternion{init_func, match_time, decay_time} !=
+          SettleToConstantQuaternion{
+              {{init_func[0], init_func[1] + 1.0, init_func[2]}},
+              match_time,
+              decay_time});
+    CHECK_FALSE(SettleToConstantQuaternion{init_func, match_time, decay_time} ==
+                SettleToConstantQuaternion{
+                    {{init_func[0], init_func[1] + 1.0, init_func[2]}},
+                    match_time,
+                    decay_time});
+
+    CHECK(SettleToConstantQuaternion{init_func, match_time, decay_time} !=
+          SettleToConstantQuaternion{
+              {{init_func[0], init_func[1], init_func[2] + 1.0}},
+              match_time,
+              decay_time});
+    CHECK_FALSE(SettleToConstantQuaternion{init_func, match_time, decay_time} ==
+                SettleToConstantQuaternion{
+                    {{init_func[0], init_func[1], init_func[2] + 1.0}},
+                    match_time,
+                    decay_time});
+  }
+
+  CHECK_THROWS_WITH((domain::FunctionsOfTime::SettleToConstantQuaternion{
+                        {{DataVector{1.0, 0.0, 0.0, 0.0, 0.0},
+                          DataVector{1.0, 0.0, 0.0, 0.0, 0.0},
+                          DataVector{1.0, 0.0, 0.0, 0.0, 0.0}}},
+                        10.0,
+                        1.0}
+                         .update(1.0, DataVector{}, 2.0)),
+                    Catch::Matchers::ContainsSubstring(
+                        "stored as DataVectors of size 4, not"));
+  CHECK_THROWS_WITH(
+      (domain::FunctionsOfTime::SettleToConstantQuaternion{
+          {{DataVector{4.0, 0.0, 0.0, 0.0}, DataVector{1.0, 0.0, 0.0, 0.0},
+            DataVector{1.0, 0.0, 0.0, 0.0}}},
+          10.0,
+          1.0}
+           .update(1.0, DataVector{}, 2.0)),
+      Catch::Matchers::ContainsSubstring(
+          "should be a quaternion with a norm of 1.0, not"));
+  CHECK_THROWS_WITH(
+      (domain::FunctionsOfTime::SettleToConstantQuaternion{
+          {{DataVector{1.0, 0.0, 0.0, 0.0}, DataVector{1.0, 0.0, 0.0, 0.0},
+            DataVector{1.0, 0.0, 0.0, 0.0}}},
+          10.0,
+          1.0}
+           .update(1.0, DataVector{}, 2.0)),
+      Catch::Matchers::ContainsSubstring("Cannot update this FunctionOfTime."));
+}


### PR DESCRIPTION
## Proposed changes

Add new function of time like SettleToConstant but for quaternions; the function of time always returned a unit quaternion (i.e., a rotation).

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
