### PR TITLE
Initialize Klein-Gordon CCE variables

### DIFF
--- a/src/Evolution/Systems/Cce/Actions/CMakeLists.txt
+++ b/src/Evolution/Systems/Cce/Actions/CMakeLists.txt
@@ -19,6 +19,7 @@ spectre_target_headers(
   InitializeCharacteristicEvolutionTime.hpp
   InitializeCharacteristicEvolutionVariables.hpp
   InitializeFirstHypersurface.hpp
+  InitializeKleinGordonVariables.hpp
   InitializeWorldtubeBoundary.hpp
   InsertInterpolationScriData.hpp
   Psi0Matching.hpp

--- a/src/Evolution/Systems/Cce/Actions/InitializeKleinGordonVariables.hpp
+++ b/src/Evolution/Systems/Cce/Actions/InitializeKleinGordonVariables.hpp
@@ -1,0 +1,65 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "Evolution/Systems/Cce/OptionTags.hpp"
+#include "ParallelAlgorithms/Initialization/MutateAssign.hpp"
+
+namespace Cce::Actions {
+
+/*!
+ * \ingroup ActionsGroup
+ * \brief Initialize the data storage for the scalar field in the
+ * `KleinGordonCharacteristicExtract` component, which is the singleton that
+ * handles the main evolution system for Klein-Gordon CCE computations.
+ *
+ * \details Sets up the \ref DataBoxGroup to be ready to take data from the
+ * worldtube component, calculate initial data, and start the hypersurface
+ * computations.
+ *
+ * \ref DataBoxGroup changes:
+ * - Modifies: nothing
+ * - Adds:
+ *  - `Tags::Variables<metavariables::klein_gordon_boundary_communication_tags>`
+ *  - `Tags::Variables<metavariables::klein_gordon_gauge_boundary_tags>`
+ *  - `Tags::Variables<metavariables::klein_gordon_scri_tags>`
+ * - Removes: nothing
+ */
+template <typename Metavariables>
+struct InitializeKleinGordonVariables {
+  using const_global_cache_tags =
+      tmpl::list<Tags::LMax, Tags::NumberOfRadialPoints>;
+
+  using klein_gordon_boundary_communication_tags = ::Tags::Variables<
+      typename Metavariables::klein_gordon_boundary_communication_tags>;
+  using klein_gordon_gauge_boundary_tags = ::Tags::Variables<
+      typename Metavariables::klein_gordon_gauge_boundary_tags>;
+  using klein_gordon_scri_tags =
+      ::Tags::Variables<typename Metavariables::klein_gordon_scri_tags>;
+
+  using simple_tags =
+      tmpl::list<klein_gordon_boundary_communication_tags,
+                 klein_gordon_gauge_boundary_tags, klein_gordon_scri_tags>;
+
+  template <typename DbTags, typename... InboxTags, typename ArrayIndex,
+            typename ActionList, typename ParallelComponent>
+  static Parallel::iterable_action_return_t apply(
+      db::DataBox<DbTags>& box,
+      const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+      const Parallel::GlobalCache<Metavariables>& /*cache*/,
+      const ArrayIndex& /*array_index*/, const ActionList /*meta*/,
+      const ParallelComponent* const /*meta*/) {
+    const size_t l_max = db::get<Spectral::Swsh::Tags::LMaxBase>(box);
+    const size_t boundary_size =
+        Spectral::Swsh::number_of_swsh_collocation_points(l_max);
+
+    Initialization::mutate_assign<simple_tags>(
+        make_not_null(&box),
+        typename klein_gordon_boundary_communication_tags::type{boundary_size},
+        typename klein_gordon_gauge_boundary_tags::type{boundary_size},
+        typename klein_gordon_scri_tags::type{boundary_size});
+    return {Parallel::AlgorithmExecution::Continue, std::nullopt};
+  }
+};
+}  // namespace Cce::Actions

--- a/src/Evolution/Systems/Cce/Components/KleinGordonCharacteristicEvolution.hpp
+++ b/src/Evolution/Systems/Cce/Components/KleinGordonCharacteristicEvolution.hpp
@@ -5,6 +5,7 @@
 
 #include <type_traits>
 
+#include "Evolution/Systems/Cce/Actions/InitializeKleinGordonVariables.hpp"
 #include "Evolution/Systems/Cce/Components/CharacteristicEvolution.hpp"
 #include "Evolution/Systems/Cce/KleinGordonSystem.hpp"
 #include "Parallel/GlobalCache.hpp"
@@ -49,7 +50,9 @@ struct KleinGordonCharacteristicEvolution
   using cce_system = Cce::KleinGordonSystem<evolve_ccm>;
 
   using cce_base = CharacteristicEvolution<Metavariables>;
-  using typename cce_base::initialize_action_list;
+  using initialize_action_list = tmpl::append<
+      tmpl::list<Actions::InitializeKleinGordonVariables<Metavariables>>,
+      typename cce_base::initialize_action_list>;
 
   template <typename BondiTag>
   using hypersurface_computation =

--- a/tests/Unit/Evolution/Systems/Cce/Actions/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/CMakeLists.txt
@@ -13,6 +13,7 @@ set(LIBRARY_SOURCES
   Test_GhBoundaryCommunication.cpp
   Test_H5BoundaryCommunication.cpp
   Test_InitializeCharacteristicEvolution.cpp
+  Test_InitializeKleinGordonCharacteristicEvolution.cpp
   Test_InitializeKleinGordonWorldtubeBoundary.cpp
   Test_InitializeWorldtubeBoundary.cpp
   Test_Psi0Matching.cpp

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_InitializeCharacteristicEvolution.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_InitializeCharacteristicEvolution.cpp
@@ -22,6 +22,7 @@
 #include "Framework/ActionTesting.hpp"
 #include "Framework/TestHelpers.hpp"
 #include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "Helpers/Evolution/Systems/Cce/Actions/CharacteristicInitialization.hpp"
 #include "Helpers/Evolution/Systems/Cce/BoundaryTestHelpers.hpp"
 #include "NumericalAlgorithms/Interpolation/BarycentricRationalSpanInterpolator.hpp"
 #include "NumericalAlgorithms/Spectral/SwshCollocation.hpp"
@@ -202,122 +203,8 @@ SPECTRE_TEST_CASE(
   }
   ActionTesting::set_phase(make_not_null(&runner), Parallel::Phase::Evolve);
 
-  // the tags inserted in the `EvolutionTags` step
-  const auto& time_step_id =
-      ActionTesting::get_databox_tag<component, ::Tags::TimeStepId>(runner, 0);
-  CHECK(time_step_id.substep_time() == start_time);
-  const auto& next_time_step_id =
-      ActionTesting::get_databox_tag<component,
-                                     ::Tags::Next<::Tags::TimeStepId>>(runner,
-                                                                       0);
-  CHECK(next_time_step_id.substep_time() ==
-        approx(start_time + target_step_size * 0.75));
-  const auto& time_step =
-      ActionTesting::get_databox_tag<component, ::Tags::TimeStep>(runner, 0);
-  CHECK(time_step.value() == approx(target_step_size * 0.75));
-  const auto& coordinates_history = ActionTesting::get_databox_tag<
-      component,
-      ::Tags::HistoryEvolvedVariables<
-          typename metavariables::evolved_coordinates_variables_tag>>(runner,
-                                                                      0);
-  CHECK(coordinates_history.size() == 0);
-  const auto& evolved_swsh_history = ActionTesting::get_databox_tag<
-      component, ::Tags::HistoryEvolvedVariables<::Tags::Variables<
-                     typename metavariables::evolved_swsh_tags>>>(runner, 0);
-  CHECK(evolved_swsh_history.size() == 0);
-
-  // the tensor storage variables inserted during the `CharacteristicTags` step
-  const auto& boundary_variables = ActionTesting::get_databox_tag<
-      component, ::Tags::Variables<tmpl::append<
-                     typename metavariables::cce_boundary_communication_tags,
-                     typename metavariables::cce_gauge_boundary_tags>>>(runner,
-                                                                        0);
-  CHECK(boundary_variables.number_of_grid_points() ==
-        Spectral::Swsh::number_of_swsh_collocation_points(l_max));
-
-  const auto& coordinate_variables = ActionTesting::get_databox_tag<
-      component, typename metavariables::evolved_coordinates_variables_tag>(
-      runner, 0);
-  CHECK(coordinate_variables.number_of_grid_points() ==
-        Spectral::Swsh::number_of_swsh_collocation_points(l_max));
-
-  const auto& dt_coordinate_variables = ActionTesting::get_databox_tag<
-      component,
-      db::add_tag_prefix<::Tags::dt, typename metavariables::
-                                         evolved_coordinates_variables_tag>>(
-      runner, 0);
-  CHECK(dt_coordinate_variables.number_of_grid_points() ==
-        Spectral::Swsh::number_of_swsh_collocation_points(l_max));
-
-  const auto& angular_coordinates_variables = ActionTesting::get_databox_tag<
-      component,
-      ::Tags::Variables<typename metavariables::cce_angular_coordinate_tags>>(
-      runner, 0);
-  CHECK(angular_coordinates_variables.number_of_grid_points() ==
-        Spectral::Swsh::number_of_swsh_collocation_points(l_max));
-  const auto& scri_variables = ActionTesting::get_databox_tag<
-      component, ::Tags::Variables<typename metavariables::cce_scri_tags>>(
-      runner, 0);
-  CHECK(scri_variables.number_of_grid_points() ==
-        Spectral::Swsh::number_of_swsh_collocation_points(l_max));
-
-  const auto& volume_variables = ActionTesting::get_databox_tag<
-      component, ::Tags::Variables<tmpl::append<
-                     typename metavariables::cce_integrand_tags,
-                     typename metavariables::cce_integration_independent_tags,
-                     typename metavariables::cce_temporary_equations_tags>>>(
-      runner, 0);
-  CHECK(volume_variables.number_of_grid_points() ==
-        Spectral::Swsh::number_of_swsh_collocation_points(l_max) *
-            number_of_radial_points);
-
-  const auto& evolved_swsh_variables = ActionTesting::get_databox_tag<
-      component, ::Tags::Variables<typename metavariables::evolved_swsh_tags>>(
-      runner, 0);
-  CHECK(evolved_swsh_variables.number_of_grid_points() ==
-        Spectral::Swsh::number_of_swsh_collocation_points(l_max) *
-            number_of_radial_points);
-
-  const auto& evolved_swsh_dt_variables = ActionTesting::get_databox_tag<
-      component,
-      ::Tags::Variables<typename metavariables::evolved_swsh_dt_tags>>(runner,
-                                                                       0);
-  CHECK(evolved_swsh_dt_variables.number_of_grid_points() ==
-        Spectral::Swsh::number_of_swsh_collocation_points(l_max) *
-            number_of_radial_points);
-
-  const auto& pre_swsh_derivatives_variables = ActionTesting::get_databox_tag<
-      component,
-      ::Tags::Variables<typename metavariables::cce_pre_swsh_derivatives_tags>>(
-      runner, 0);
-  const Variables<typename metavariables::cce_pre_swsh_derivatives_tags>
-      expected_zeroed_pre_swsh_derivatives{
-          Spectral::Swsh::number_of_swsh_collocation_points(l_max) *
-              number_of_radial_points,
-          0.0};
-  CHECK(pre_swsh_derivatives_variables == expected_zeroed_pre_swsh_derivatives);
-
-  const auto& transform_buffer_variables = ActionTesting::get_databox_tag<
-      component,
-      ::Tags::Variables<typename metavariables::cce_transform_buffer_tags>>(
-      runner, 0);
-  const Variables<typename metavariables::cce_transform_buffer_tags>
-      expected_zeroed_transform_buffer{
-          Spectral::Swsh::size_of_libsharp_coefficient_vector(l_max) *
-              number_of_radial_points,
-          0.0};
-  CHECK(transform_buffer_variables == expected_zeroed_transform_buffer);
-
-  const auto& swsh_derivatives_variables = ActionTesting::get_databox_tag<
-      component,
-      ::Tags::Variables<typename metavariables::cce_swsh_derivative_tags>>(
-      runner, 0);
-  const Variables<typename metavariables::cce_swsh_derivative_tags>
-      expected_zeroed_swsh_derivatives{
-          Spectral::Swsh::number_of_swsh_collocation_points(l_max) *
-              number_of_radial_points,
-          0.0};
-  CHECK(swsh_derivatives_variables == expected_zeroed_swsh_derivatives);
+  TestHelpers::check_characteristic_initialization<component>(
+      runner, start_time, target_step_size, l_max, number_of_radial_points);
 
   if (file_system::check_if_file_exists(filename)) {
     file_system::rm(filename, true);

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_InitializeKleinGordonCharacteristicEvolution.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_InitializeKleinGordonCharacteristicEvolution.cpp
@@ -1,0 +1,192 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include "Evolution/Executables/Cce/CharacteristicExtractBase.hpp"
+#include "Evolution/Systems/Cce/Components/KleinGordonCharacteristicEvolution.hpp"
+#include "Framework/ActionTesting.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "Helpers/Evolution/Systems/Cce/Actions/CharacteristicInitialization.hpp"
+#include "Helpers/Evolution/Systems/Cce/KleinGordonBoundaryTestHelpers.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
+#include "Time/TimeSteppers/AdamsBashforth.hpp"
+#include "Time/TimeSteppers/LtsTimeStepper.hpp"
+#include "Utilities/MakeVector.hpp"
+
+namespace Cce {
+namespace {
+
+template <typename Metavariables>
+struct mock_klein_gordon_characteristic_evolution {
+  using component_being_mocked =
+      KleinGordonCharacteristicEvolution<Metavariables>;
+
+  using initialize_action_list = tmpl::list<
+      Actions::InitializeKleinGordonVariables<Metavariables>,
+      Actions::InitializeCharacteristicEvolutionVariables<Metavariables>,
+      Actions::InitializeCharacteristicEvolutionTime<
+          typename Metavariables::evolved_coordinates_variables_tag,
+          typename Metavariables::evolved_swsh_tags, false>,
+      // advance the time so that the current `TimeStepId` is valid without
+      // having to perform self-start.
+      ::Actions::AdvanceTime,
+      Actions::InitializeCharacteristicEvolutionScri<
+          typename Metavariables::scri_values_to_observe, NoSuchType>,
+      Parallel::Actions::TerminatePhase>;
+  using simple_tags_from_options =
+      Parallel::get_simple_tags_from_options<initialize_action_list>;
+
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = size_t;
+
+  using phase_dependent_action_list =
+      tmpl::list<Parallel::PhaseActions<Parallel::Phase::Initialization,
+                                        initialize_action_list>,
+                 Parallel::PhaseActions<Parallel::Phase::Evolve, tmpl::list<>>>;
+  using const_global_cache_tags =
+      Parallel::get_const_global_cache_tags_from_actions<
+          phase_dependent_action_list>;
+};
+
+struct metavariables : CharacteristicExtractDefaults<false> {
+  using cce_base = CharacteristicExtractDefaults<false>;
+  using evolved_swsh_tags = tmpl::append<cce_base::evolved_swsh_tags,
+                                         tmpl::list<Cce::Tags::KleinGordonPsi>>;
+  using evolved_swsh_dt_tags =
+      tmpl::append<cce_base::evolved_swsh_dt_tags,
+                   tmpl::list<Cce::Tags::KleinGordonPi>>;
+  using cce_step_choosers = tmpl::list<>;
+  using scri_values_to_observe = tmpl::list<>;
+  using klein_gordon_boundary_communication_tags =
+      Cce::Tags::klein_gordon_worldtube_boundary_tags;
+  using klein_gordon_gauge_boundary_tags = tmpl::list<
+      Cce::Tags::EvolutionGaugeBoundaryValue<Cce::Tags::KleinGordonPsi>,
+      Cce::Tags::EvolutionGaugeBoundaryValue<Cce::Tags::KleinGordonPi>>;
+
+  using klein_gordon_scri_tags =
+      tmpl::list<Cce::Tags::ScriPlus<Cce::Tags::KleinGordonPsi>,
+                 Cce::Tags::ScriPlus<Cce::Tags::KleinGordonPi>>;
+
+  using const_global_cache_tags = tmpl::list<Tags::SpecifiedStartTime>;
+  struct factory_creation
+      : tt::ConformsTo<Options::protocols::FactoryCreation> {
+    using factory_classes = tmpl::map<
+        tmpl::pair<StepChooser<StepChooserUse::LtsStep>, tmpl::list<>>>;
+  };
+
+  using component_list =
+      tmpl::list<mock_klein_gordon_characteristic_evolution<metavariables>>;
+};
+
+// This function tests the `initialize_action_list` of the
+// `KleinGordonCharacteristicEvolution` component, which initializes the data
+// storage for all tags of the component.
+//
+// The function begins by generating and storing some scalar and tensor data
+// into an HDF5 file named `filename` using `write_scalar_tensor_test_file`.
+// Subsequently, it initializes a mocked evolution component
+// `mock_klein_gordon_characteristic_evolution<Metavariables>` defined above
+// that has the same `initialize_action_list` as
+// `KleinGordonCharacteristicEvolution`. The function then goes through the
+// action list and finally checks whether the tags are in the expected state.
+template <typename Generator>
+void test_klein_gordon_cce_initialization(const gsl::not_null<Generator*> gen) {
+  using component = mock_klein_gordon_characteristic_evolution<metavariables>;
+  const size_t number_of_radial_points = 10;
+  const size_t l_max = 8;
+
+  const std::string filename =
+      "InitializeKleinGordonCharacteristicEvolutionTest_CceR0100.h5";
+
+  // create the test file, because on initialization the manager will need to
+  // get basic data out of the file
+  UniformCustomDistribution<double> value_dist{0.1, 0.5};
+  // first prepare the input for the modal version
+  const double mass = value_dist(*gen);
+  const std::array<double, 3> spin{
+      {value_dist(*gen), value_dist(*gen), value_dist(*gen)}};
+  const std::array<double, 3> center{
+      {value_dist(*gen), value_dist(*gen), value_dist(*gen)}};
+  gr::Solutions::KerrSchild solution{mass, spin, center};
+
+  const double extraction_radius = 100.0;
+  const double frequency = 0.1 * value_dist(*gen);
+  const double amplitude = 0.1 * value_dist(*gen);
+  const double target_time = 50.0 * value_dist(*gen);
+  if (file_system::check_if_file_exists(filename)) {
+    file_system::rm(filename, true);
+  }
+  TestHelpers::write_scalar_tensor_test_file(solution, filename, target_time,
+                                             extraction_radius, frequency,
+                                             amplitude, l_max);
+
+  const double start_time = value_dist(*gen);
+  const double target_step_size = 0.01 * value_dist(*gen);
+  const size_t scri_plus_interpolation_order = 3;
+
+  // tests start here
+  ActionTesting::MockRuntimeSystem<metavariables> runner{
+      {start_time, l_max, number_of_radial_points}};
+
+  ActionTesting::set_phase(make_not_null(&runner),
+                           Parallel::Phase::Initialization);
+  ActionTesting::emplace_component<component>(
+      &runner, 0, target_step_size * 0.75,
+      static_cast<std::unique_ptr<LtsTimeStepper>>(
+          std::make_unique<::TimeSteppers::AdamsBashforth>(3)),
+      make_vector<std::unique_ptr<StepChooser<StepChooserUse::LtsStep>>>(),
+      target_step_size, scri_plus_interpolation_order);
+
+  // go through the action list
+  for (size_t i = 0; i < 7; ++i) {
+    ActionTesting::next_action<component>(make_not_null(&runner), 0);
+  }
+  ActionTesting::set_phase(make_not_null(&runner), Parallel::Phase::Evolve);
+
+  // The tensor part:
+  //
+  // check that the tags are in the expected state (here we just make
+  // sure it has the right size - it shouldn't have been written to yet).
+  // This part is the same as `Test_InitializeCharacteristicEvolution.cpp`
+  TestHelpers::check_characteristic_initialization<component>(
+      runner, start_time, target_step_size, l_max, number_of_radial_points);
+
+  // then we repeat the tests for the scalar (Klein-Gordon) part
+  const auto& kg_boundary_communication_tags = ActionTesting::get_databox_tag<
+      component,
+      ::Tags::Variables<
+          typename metavariables::klein_gordon_boundary_communication_tags>>(
+      runner, 0);
+  CHECK(kg_boundary_communication_tags.number_of_grid_points() ==
+        Spectral::Swsh::number_of_swsh_collocation_points(l_max));
+
+  const auto& kg_gauge_boundary_tags = ActionTesting::get_databox_tag<
+      component,
+      ::Tags::Variables<
+          typename metavariables::klein_gordon_gauge_boundary_tags>>(
+      runner, 0);
+  CHECK(kg_gauge_boundary_tags.number_of_grid_points() ==
+        Spectral::Swsh::number_of_swsh_collocation_points(l_max));
+
+  const auto& kg_scri_tags = ActionTesting::get_databox_tag<
+      component,
+      ::Tags::Variables<typename metavariables::klein_gordon_scri_tags>>(runner,
+                                                                         0);
+  CHECK(kg_scri_tags.number_of_grid_points() ==
+        Spectral::Swsh::number_of_swsh_collocation_points(l_max));
+
+  if (file_system::check_if_file_exists(filename)) {
+    file_system::rm(filename, true);
+  }
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.Actions.InitializeKleinGordonCce",
+                  "[Unit][Cce]") {
+  MAKE_GENERATOR(gen);
+  test_klein_gordon_cce_initialization(make_not_null(&gen));
+}
+}  // namespace Cce

--- a/tests/Unit/Helpers/Evolution/Systems/Cce/Actions/CharacteristicInitialization.hpp
+++ b/tests/Unit/Helpers/Evolution/Systems/Cce/Actions/CharacteristicInitialization.hpp
@@ -1,0 +1,143 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "Framework/ActionTesting.hpp"
+#include "NumericalAlgorithms/Spectral/SwshCoefficients.hpp"
+#include "NumericalAlgorithms/Spectral/SwshCollocation.hpp"
+#include "Time/Tags/HistoryEvolvedVariables.hpp"
+#include "Time/Tags/TimeStep.hpp"
+#include "Time/Tags/TimeStepId.hpp"
+
+namespace Cce::TestHelpers {
+
+template <typename EvolutionComponent, typename Metavariables>
+void check_characteristic_initialization(
+    ActionTesting::MockRuntimeSystem<Metavariables>& runner,
+    const double start_time, const double target_step_size, const size_t l_max,
+    const size_t number_of_radial_points) {
+  // the tags inserted in the `EvolutionTags` step
+  const auto& time_step_id =
+      ActionTesting::get_databox_tag<EvolutionComponent, ::Tags::TimeStepId>(
+          runner, 0);
+  CHECK(time_step_id.substep_time() == start_time);
+  const auto& next_time_step_id =
+      ActionTesting::get_databox_tag<EvolutionComponent,
+                                     ::Tags::Next<::Tags::TimeStepId>>(runner,
+                                                                       0);
+  CHECK(next_time_step_id.substep_time() ==
+        approx(start_time + target_step_size * 0.75));
+  const auto& time_step =
+      ActionTesting::get_databox_tag<EvolutionComponent, ::Tags::TimeStep>(
+          runner, 0);
+  CHECK(time_step.value() == approx(target_step_size * 0.75));
+  const auto& coordinates_history = ActionTesting::get_databox_tag<
+      EvolutionComponent,
+      ::Tags::HistoryEvolvedVariables<
+          typename Metavariables::evolved_coordinates_variables_tag>>(runner,
+                                                                      0);
+  CHECK(coordinates_history.size() == 0);
+  const auto& evolved_swsh_history = ActionTesting::get_databox_tag<
+      EvolutionComponent, ::Tags::HistoryEvolvedVariables<::Tags::Variables<
+                              typename Metavariables::evolved_swsh_tags>>>(
+      runner, 0);
+  CHECK(evolved_swsh_history.size() == 0);
+
+  // the tensor storage variables inserted during the `CharacteristicTags` step
+  const auto& boundary_variables = ActionTesting::get_databox_tag<
+      EvolutionComponent,
+      ::Tags::Variables<
+          tmpl::append<typename Metavariables::cce_boundary_communication_tags,
+                       typename Metavariables::cce_gauge_boundary_tags>>>(
+      runner, 0);
+  CHECK(boundary_variables.number_of_grid_points() ==
+        Spectral::Swsh::number_of_swsh_collocation_points(l_max));
+
+  const auto& coordinate_variables = ActionTesting::get_databox_tag<
+      EvolutionComponent,
+      typename Metavariables::evolved_coordinates_variables_tag>(runner, 0);
+  CHECK(coordinate_variables.number_of_grid_points() ==
+        Spectral::Swsh::number_of_swsh_collocation_points(l_max));
+
+  const auto& dt_coordinate_variables = ActionTesting::get_databox_tag<
+      EvolutionComponent,
+      db::add_tag_prefix<::Tags::dt, typename Metavariables::
+                                         evolved_coordinates_variables_tag>>(
+      runner, 0);
+  CHECK(dt_coordinate_variables.number_of_grid_points() ==
+        Spectral::Swsh::number_of_swsh_collocation_points(l_max));
+
+  const auto& angular_coordinates_variables = ActionTesting::get_databox_tag<
+      EvolutionComponent,
+      ::Tags::Variables<typename Metavariables::cce_angular_coordinate_tags>>(
+      runner, 0);
+  CHECK(angular_coordinates_variables.number_of_grid_points() ==
+        Spectral::Swsh::number_of_swsh_collocation_points(l_max));
+  const auto& scri_variables = ActionTesting::get_databox_tag<
+      EvolutionComponent,
+      ::Tags::Variables<typename Metavariables::cce_scri_tags>>(runner, 0);
+  CHECK(scri_variables.number_of_grid_points() ==
+        Spectral::Swsh::number_of_swsh_collocation_points(l_max));
+
+  const auto& volume_variables = ActionTesting::get_databox_tag<
+      EvolutionComponent,
+      ::Tags::Variables<
+          tmpl::append<typename Metavariables::cce_integrand_tags,
+                       typename Metavariables::cce_integration_independent_tags,
+                       typename Metavariables::cce_temporary_equations_tags>>>(
+      runner, 0);
+  CHECK(volume_variables.number_of_grid_points() ==
+        Spectral::Swsh::number_of_swsh_collocation_points(l_max) *
+            number_of_radial_points);
+
+  const auto& evolved_swsh_variables = ActionTesting::get_databox_tag<
+      EvolutionComponent,
+      ::Tags::Variables<typename Metavariables::evolved_swsh_tags>>(runner, 0);
+  CHECK(evolved_swsh_variables.number_of_grid_points() ==
+        Spectral::Swsh::number_of_swsh_collocation_points(l_max) *
+            number_of_radial_points);
+
+  const auto& evolved_swsh_dt_variables = ActionTesting::get_databox_tag<
+      EvolutionComponent,
+      ::Tags::Variables<typename Metavariables::evolved_swsh_dt_tags>>(runner,
+                                                                       0);
+  CHECK(evolved_swsh_dt_variables.number_of_grid_points() ==
+        Spectral::Swsh::number_of_swsh_collocation_points(l_max) *
+            number_of_radial_points);
+
+  const auto& pre_swsh_derivatives_variables = ActionTesting::get_databox_tag<
+      EvolutionComponent,
+      ::Tags::Variables<typename Metavariables::cce_pre_swsh_derivatives_tags>>(
+      runner, 0);
+  const Variables<typename Metavariables::cce_pre_swsh_derivatives_tags>
+      expected_zeroed_pre_swsh_derivatives{
+          Spectral::Swsh::number_of_swsh_collocation_points(l_max) *
+              number_of_radial_points,
+          0.0};
+  CHECK(pre_swsh_derivatives_variables == expected_zeroed_pre_swsh_derivatives);
+
+  const auto& transform_buffer_variables = ActionTesting::get_databox_tag<
+      EvolutionComponent,
+      ::Tags::Variables<typename Metavariables::cce_transform_buffer_tags>>(
+      runner, 0);
+  const Variables<typename Metavariables::cce_transform_buffer_tags>
+      expected_zeroed_transform_buffer{
+          Spectral::Swsh::size_of_libsharp_coefficient_vector(l_max) *
+              number_of_radial_points,
+          0.0};
+  CHECK(transform_buffer_variables == expected_zeroed_transform_buffer);
+
+  const auto& swsh_derivatives_variables = ActionTesting::get_databox_tag<
+      EvolutionComponent,
+      ::Tags::Variables<typename Metavariables::cce_swsh_derivative_tags>>(
+      runner, 0);
+  const Variables<typename Metavariables::cce_swsh_derivative_tags>
+      expected_zeroed_swsh_derivatives{
+          Spectral::Swsh::number_of_swsh_collocation_points(l_max) *
+              number_of_radial_points,
+          0.0};
+  CHECK(swsh_derivatives_variables == expected_zeroed_swsh_derivatives);
+}
+}  // namespace Cce::TestHelpers


### PR DESCRIPTION
## Proposed changes

<!--
At a high level, describe what this PR does.
-->

This PR adds an action to initialize Klein-Gordon CCE variables on the evolution component. The corresponding unit test is also included. The unit test examines all the initialization actions on the component, including both the tensor and scalar parts. The test for tensor variables is the same as the existing CCE system, so I move it to a function in the first commit.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
