### PR TITLE
Remove boost::rational from FractionUtilities test

### DIFF
--- a/src/Utilities/Rational.cpp
+++ b/src/Utilities/Rational.cpp
@@ -121,6 +121,8 @@ bool operator>(const Rational& a, const Rational& b) { return b < a; }
 bool operator<=(const Rational& a, const Rational& b) { return not(b < a); }
 bool operator>=(const Rational& a, const Rational& b) { return not(a < b); }
 
+Rational abs(const Rational& r) { return r.numerator() >= 0 ? r : -r; }
+
 std::ostream& operator<<(std::ostream& os, const Rational& r) {
   return os << r.numerator() << '/' << r.denominator();
 }

--- a/src/Utilities/Rational.hpp
+++ b/src/Utilities/Rational.hpp
@@ -72,6 +72,8 @@ bool operator>(const Rational& a, const Rational& b);
 bool operator<=(const Rational& a, const Rational& b);
 bool operator>=(const Rational& a, const Rational& b);
 
+Rational abs(const Rational& r);
+
 std::ostream& operator<<(std::ostream& os, const Rational& r);
 
 size_t hash_value(const Rational& r);

--- a/tests/Unit/Utilities/Test_FractionUtilities.cpp
+++ b/tests/Unit/Utilities/Test_FractionUtilities.cpp
@@ -3,7 +3,6 @@
 
 #include "Framework/TestingFramework.hpp"
 
-#include <boost/rational.hpp>
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
@@ -15,6 +14,7 @@
 #include "Framework/TestHelpers.hpp"
 #include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/FractionUtilities.hpp"
+#include "Utilities/Rational.hpp"
 
 namespace {
 template <typename Source>
@@ -30,9 +30,7 @@ std::vector<typename Source::value_type> collect(
 
 SPECTRE_TEST_CASE("Unit.Utilities.FractionUtilities.ContinuedFraction",
                   "[Utilities][Unit]") {
-  using Rational = boost::rational<int64_t>;
-
-  CHECK((std::vector<int64_t>{1, 2, 4, 2}) ==
+  CHECK((std::vector<int32_t>{1, 2, 4, 2}) ==
         collect(ContinuedFraction<Rational>(Rational(29, 20))));
   CHECK((std::vector<int64_t>{0, 8}) ==
         collect(ContinuedFraction<double>(0.125)));
@@ -40,7 +38,7 @@ SPECTRE_TEST_CASE("Unit.Utilities.FractionUtilities.ContinuedFraction",
         collect(ContinuedFraction<double>(-0.125)));
   CHECK(std::vector<int64_t>(20, 1) ==
         collect(ContinuedFraction<double>(0.5 * (1. + sqrt(5.))), 20));
-  CHECK((std::vector<int64_t>{0}) ==
+  CHECK((std::vector<int32_t>{0}) ==
         collect(ContinuedFraction<Rational>(Rational(0))));
   CHECK((std::vector<int64_t>{0}) == collect(ContinuedFraction<double>(0.)));
 
@@ -72,7 +70,7 @@ SPECTRE_TEST_CASE("Unit.Utilities.FractionUtilities.ContinuedFraction",
     for (ContinuedFraction<double> source(value); source; ++source) {
       summer.insert(*source);
       terms.push_back(*source);
-      convergents.push_back(boost::rational_cast<double>(summer.value()));
+      convergents.push_back(summer.value().value());
       CAPTURE(terms);
       CAPTURE(convergents);
 
@@ -95,8 +93,6 @@ SPECTRE_TEST_CASE("Unit.Utilities.FractionUtilities.ContinuedFraction",
 
 SPECTRE_TEST_CASE("Unit.Utilities.FractionUtilities.ContinuedFractionSummer",
                   "[Utilities][Unit]") {
-  using Rational = boost::rational<int>;
-
   const auto check = [](const int num, const int denom) {
     const Rational value(num, denom);
     ContinuedFractionSummer<Rational> summer;
@@ -117,8 +113,6 @@ SPECTRE_TEST_CASE("Unit.Utilities.FractionUtilities.ContinuedFractionSummer",
 SPECTRE_TEST_CASE(
     "Unit.Utilities.FractionUtilities.simplest_fraction_in_interval",
     "[Utilities][Unit]") {
-  using Rational = boost::rational<int>;
-
   const int denom_max = 20;
 
   std::set<Rational> fractions;

--- a/tests/Unit/Utilities/Test_Rational.cpp
+++ b/tests/Unit/Utilities/Test_Rational.cpp
@@ -49,6 +49,10 @@ SPECTRE_TEST_CASE("Unit.Utilities.Rational", "[Unit][Utilities]") {
   CHECK_OP(Rational(3, 4), /, Rational(2, 5), Rational(15, 8));
   CHECK_OP(Rational(3, 4), /, Rational(3, 2), Rational(1, 2));
 
+  CHECK(abs(Rational(3, 4)) == Rational(3, 4));
+  CHECK(abs(Rational(-3, 4)) == Rational(3, 4));
+  CHECK(abs(Rational(0)) == Rational(0));
+
   const auto hash = std::hash<Rational>{};
   CHECK(hash(Rational(1, 2)) != hash(Rational(1, 3)));
   CHECK(hash(Rational(1, 2)) != hash(Rational(3, 2)));


### PR DESCRIPTION
Causing issues with C++20 on some systems for unclear reasons.

@nilsdeppe See if this solves things.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
