### PR TITLE
Databox runtime retrieval

### DIFF
--- a/src/DataStructures/DataBox/Access.hpp
+++ b/src/DataStructures/DataBox/Access.hpp
@@ -1,0 +1,95 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <string>
+
+#include "DataStructures/DataBox/TagName.hpp"
+#include "Utilities/CleanupRoutine.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/ForceInline.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/PrettyType.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace db {
+/*!
+ * \brief A class for retrieving items from a DataBox without needing to know
+ * all the tags in the box.
+ *
+ * Retrieval is handled using a virtual function call but still uses Tags
+ * rather than strings to ensure automatic handling of casting to the expected
+ * type.
+ */
+class Access {
+ public:
+  virtual ~Access() = default;
+
+  /// Print the expanded type aliases of the derived `db::DataBox`
+  virtual std::string print_types() const = 0;
+
+ private:
+  template <typename Tag>
+  friend const auto& get(const Access& box);
+  template <typename... MutateTags, typename Invokable, typename... Args>
+  friend decltype(auto) mutate(Invokable&& invokable,
+                               gsl::not_null<Access*> box, Args&&... args);
+  virtual void* mutate_item_by_name(const std::string& tag_name) = 0;
+  virtual const void* get_item_by_name(const std::string& tag_name) const = 0;
+  virtual bool lock_box_for_mutate() = 0;
+  virtual void unlock_box_after_mutate() = 0;
+  virtual void mutate_mutable_subitems(const std::string& tag_name) = 0;
+  virtual void reset_compute_items_after_mutate(
+      const std::string& tag_name) = 0;
+
+  template <typename Tag>
+  auto mutate() -> gsl::not_null<typename Tag::type*> {
+    static const std::string tag_name = pretty_type::get_name<Tag>();
+    return {
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+        reinterpret_cast<typename Tag::type*>(mutate_item_by_name(tag_name))};
+  }
+};
+
+/// \brief Retrieve a tag from a `db::Access`
+template <typename Tag>
+SPECTRE_ALWAYS_INLINE const auto& get(const Access& box) {
+  static const std::string tag_name = pretty_type::get_name<Tag>();
+  if constexpr (tt::is_a_v<std::unique_ptr, typename Tag::type>) {
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    return *reinterpret_cast<const typename Tag::type::element_type*>(
+        box.get_item_by_name(tag_name));
+  } else {
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    return *reinterpret_cast<const typename Tag::type*>(
+        box.get_item_by_name(tag_name));
+  }
+}
+
+/// \brief Mutate a tag in a `db::Access`.
+template <typename... MutateTags, typename Invokable, typename... Args>
+decltype(auto) mutate(Invokable&& invokable, const gsl::not_null<Access*> box,
+                      Args&&... args) {
+  static_assert((... and (not is_base_tag_v<MutateTags>)),
+                "Cannot mutate base tags with only a db::Access");
+
+  if (UNLIKELY(box->lock_box_for_mutate())) {
+    ERROR(
+        "Unable to mutate a DataBox that is already being mutated. This "
+        "error occurs when mutating a DataBox from inside the invokable "
+        "passed to the mutate function.");
+  }
+
+  const CleanupRoutine unlock_box = [&box]() {
+    box->unlock_box_after_mutate();
+    EXPAND_PACK_LEFT_TO_RIGHT([&box]() {
+      static const std::string tag_name = pretty_type::get_name<MutateTags>();
+      box->mutate_mutable_subitems(tag_name);
+      box->reset_compute_items_after_mutate(tag_name);
+    }());
+  };
+  return invokable(box->template mutate<MutateTags>()...,
+                   std::forward<Args>(args)...);
+}
+}  // namespace db

--- a/src/DataStructures/DataBox/AsAccess.hpp
+++ b/src/DataStructures/DataBox/AsAccess.hpp
@@ -1,0 +1,22 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "DataStructures/DataBox/Access.hpp"
+#include "DataStructures/DataBox/DataBox.hpp"
+
+namespace db {
+/// @{
+/// \brief Convert a `db::DataBox` to a `db::Access`.
+template <typename TagsList>
+const Access& as_access(const DataBox<TagsList>& box) {
+  return static_cast<const Access&>(box);
+}
+
+template <typename TagsList>
+Access& as_access(DataBox<TagsList>& box) {
+  return static_cast<Access&>(box);
+}
+/// @}
+}  // namespace db

--- a/src/DataStructures/DataBox/CMakeLists.txt
+++ b/src/DataStructures/DataBox/CMakeLists.txt
@@ -5,6 +5,8 @@ spectre_target_headers(
   ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
+  Access.hpp
+  AsAccess.hpp
   DataBox.hpp
   DataBoxTag.hpp
   DataOnSlice.hpp

--- a/tests/Unit/DataStructures/DataBox/Test_DataBox.cpp
+++ b/tests/Unit/DataStructures/DataBox/Test_DataBox.cpp
@@ -15,6 +15,8 @@
 #include <utility>
 #include <vector>
 
+#include "DataStructures/DataBox/Access.hpp"
+#include "DataStructures/DataBox/AsAccess.hpp"
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "DataStructures/DataBox/DataOnSlice.hpp"
@@ -221,17 +223,33 @@ void test_databox() {
     CHECK(db::get<test_databox_tags::Tag0>(box) == 0.);
     CHECK(db::get<test_databox_tags::Tag1>(box).empty());
     CHECK(db::get<test_databox_tags::Tag2>(box).empty());
+    CHECK(db::get<test_databox_tags::Tag4>(db::as_access(box)) == 0.);
+    // Mutate box via db::Access
     db::mutate<test_databox_tags::Tag0, test_databox_tags::Tag2>(
         [](const gsl::not_null<double*> val,
            const gsl::not_null<std::string*> str) {
           *val = 1.5;
           *str = "My Sample String";
         },
+        make_not_null(&db::as_access(box)));
+    CHECK(db::get<test_databox_tags::Tag3>(db::as_access(box)).empty());
+    CHECK(db::get<test_databox_tags::Tag0>(db::as_access(box)) == 1.5);
+    CHECK(db::get<test_databox_tags::Tag2>(db::as_access(box)) ==
+          "My Sample String"s);
+    CHECK(db::get<test_databox_tags::Tag4>(db::as_access(box)) == 3.);
+
+    // Mutate box directly
+    db::mutate<test_databox_tags::Tag0, test_databox_tags::Tag2>(
+        [](const gsl::not_null<double*> val,
+           const gsl::not_null<std::string*> str) {
+          *val = 2.5;
+          *str = "My Sample String 2";
+        },
         make_not_null(&box));
     CHECK(db::get<test_databox_tags::Tag3>(box).empty());
-    CHECK(db::get<test_databox_tags::Tag0>(box) == 1.5);
-    CHECK(db::get<test_databox_tags::Tag2>(box) == "My Sample String"s);
-    CHECK(db::get<test_databox_tags::Tag4>(box) == 3.);
+    CHECK(db::get<test_databox_tags::Tag0>(box) == 2.5);
+    CHECK(db::get<test_databox_tags::Tag2>(box) == "My Sample String 2"s);
+    CHECK(db::get<test_databox_tags::Tag4>(box) == 5.);
   }
   {
     const auto original_box = create_original_box();
@@ -273,6 +291,7 @@ void test_databox() {
                        db::const_item_type<test_databox_tags::Pointer, DbTags>>,
         "Wrong type for get on unique_ptr simple item");
     CHECK(db::get<test_databox_tags::Pointer>(box) == 3);
+    CHECK(db::get<test_databox_tags::Pointer>(db::as_access(box)) == 3);
 
     static_assert(
         std::is_same_v<
@@ -297,6 +316,8 @@ void test_databox() {
             db::const_item_type<test_databox_tags::PointerToCounter, DbTags>>,
         "Wrong type for get on unique_ptr compute item");
     CHECK(db::get<test_databox_tags::PointerToCounter>(box) == 4);
+    CHECK(db::get<test_databox_tags::PointerToCounter>(db::as_access(box)) ==
+          4);
 
     static_assert(
         std::is_same_v<db::const_item_type<
@@ -322,6 +343,7 @@ void test_databox() {
             db::const_item_type<test_databox_tags::PointerToSum, DbTags>>,
         "Wrong type for get on unique_ptr");
     CHECK(db::get<test_databox_tags::PointerToSum>(box) == 8);
+    CHECK(db::get<test_databox_tags::PointerToSum>(db::as_access(box)) == 8);
   }
 }
 
@@ -354,6 +376,12 @@ void test_create_argument_types() {
   CHECK(db::get<ArgumentTypeTags::String<1>>(box) == "const");
   CHECK(db::get<ArgumentTypeTags::String<2>>(box) == "move");
   CHECK(db::get<ArgumentTypeTags::String<3>>(box) == "const move");
+
+  CHECK(db::get<ArgumentTypeTags::String<0>>(db::as_access(box)) == "mutable");
+  CHECK(db::get<ArgumentTypeTags::String<1>>(db::as_access(box)) == "const");
+  CHECK(db::get<ArgumentTypeTags::String<2>>(db::as_access(box)) == "move");
+  CHECK(db::get<ArgumentTypeTags::String<3>>(db::as_access(box)) ==
+        "const move");
 }
 
 void test_get_databox() {
@@ -408,15 +436,8 @@ void test_get_databox_error() {
           "restriction exists to avoid complexity."));
 }
 
-void test_mutate() {
-  INFO("test mutate");
-  auto original_box = db::create<
-      db::AddSimpleTags<test_databox_tags::Tag0, test_databox_tags::Tag1,
-                        test_databox_tags::Tag2, test_databox_tags::Pointer>,
-      db::AddComputeTags<test_databox_tags::Tag4Compute,
-                         test_databox_tags::Tag5Compute>>(
-      3.14, std::vector<double>{8.7, 93.2, 84.7}, "My Sample String"s,
-      std::make_unique<int>(3));
+template <typename T>
+void test_mutate(T& original_box) {
   CHECK(approx(db::get<test_databox_tags::Tag4>(original_box)) == 3.14 * 2.0);
   // [databox_mutate_example]
   db::mutate<test_databox_tags::Tag0, test_databox_tags::Tag1>(
@@ -466,6 +487,29 @@ void test_mutate() {
       },
       make_not_null(&original_box));
   CHECK(db::get<test_databox_tags::Pointer>(original_box) == 5);
+}
+
+void test_mutate() {
+  INFO("test mutate");
+  const auto create_box = []() {
+    return db::create<
+        db::AddSimpleTags<test_databox_tags::Tag0, test_databox_tags::Tag1,
+                          test_databox_tags::Tag2, test_databox_tags::Pointer>,
+        db::AddComputeTags<test_databox_tags::Tag4Compute,
+                           test_databox_tags::Tag5Compute>>(
+        3.14, std::vector<double>{8.7, 93.2, 84.7}, "My Sample String"s,
+        std::make_unique<int>(3));
+  };
+  {
+    INFO("Using DataBox");
+    auto box = create_box();
+    test_mutate(box);
+  }
+  {
+    INFO("Using db::Access");
+    auto box = create_box();
+    test_mutate(db::as_access(box));
+  }
 }
 
 void trigger_mutate_locked_get() {
@@ -877,20 +921,10 @@ struct MultiplyVariablesByTwoCompute : MultiplyVariablesByTwo, db::ComputeTag {
 };
 }  // namespace test_databox_tags
 
-void test_variables() {
-  INFO("test variables");
+template <typename T>
+void test_variables(T& box) {
   using vars_tag = Tags::Variables<
       tmpl::list<test_databox_tags::ScalarTag, test_databox_tags::VectorTag>>;
-  auto box = db::create<
-      db::AddSimpleTags<vars_tag>,
-      db::AddComputeTags<test_databox_tags::MultiplyScalarByTwoCompute,
-                         test_databox_tags::MultiplyScalarByFourCompute,
-                         test_databox_tags::MultiplyScalarByThreeCompute,
-                         test_databox_tags::DivideScalarByThreeCompute,
-                         test_databox_tags::DivideScalarByTwoCompute,
-                         test_databox_tags::MultiplyVariablesByTwoCompute>>(
-      Variables<tmpl::list<test_databox_tags::ScalarTag,
-                           test_databox_tags::VectorTag>>(2, 3.));
   const auto check_references_match = [&box]() {
     const auto& vars_original = db::get<vars_tag>(box);
     CHECK(get(db::get<test_databox_tags::ScalarTag>(box)).data() ==
@@ -1075,6 +1109,34 @@ void test_variables() {
   check_references_match();
 }
 
+void test_variables() {
+  INFO("test variables");
+  using vars_tag = Tags::Variables<
+      tmpl::list<test_databox_tags::ScalarTag, test_databox_tags::VectorTag>>;
+  const auto create_box = []() {
+    return db::create<
+        db::AddSimpleTags<vars_tag>,
+        db::AddComputeTags<test_databox_tags::MultiplyScalarByTwoCompute,
+                           test_databox_tags::MultiplyScalarByFourCompute,
+                           test_databox_tags::MultiplyScalarByThreeCompute,
+                           test_databox_tags::DivideScalarByThreeCompute,
+                           test_databox_tags::DivideScalarByTwoCompute,
+                           test_databox_tags::MultiplyVariablesByTwoCompute>>(
+        Variables<tmpl::list<test_databox_tags::ScalarTag,
+                             test_databox_tags::VectorTag>>(2, 3.));
+  };
+  {
+    INFO("Using DataBox");
+    auto box = create_box();
+    test_variables(box);
+  }
+  {
+    INFO("Using db::Access");
+    auto box = create_box();
+    test_variables(db::as_access(box));
+  }
+}
+
 struct Tag1 : db::SimpleTag {
   using type = Scalar<DataVector>;
 };
@@ -1082,33 +1144,35 @@ struct Tag2 : db::SimpleTag {
   using type = Scalar<DataVector>;
 };
 
-void test_variables2() {
-  INFO("test variables2");
-  auto box =
-      db::create<db::AddSimpleTags<Tags::Variables<tmpl::list<Tag1, Tag2>>>>(
-          Variables<tmpl::list<Tag1, Tag2>>(1, 1.));
-
+template <typename T>
+void test_variables2(T& box) {
   db::mutate<Tags::Variables<tmpl::list<Tag1, Tag2>>>(
       [](const auto vars) { *vars = Variables<tmpl::list<Tag1, Tag2>>(1, 2.); },
       make_not_null(&box));
   CHECK(db::get<Tag1>(box) == Scalar<DataVector>(DataVector(1, 2.)));
 }
 
-void test_reset_compute_items() {
-  INFO("test reset compute items");
-  auto box = db::create<
-      db::AddSimpleTags<
-          test_databox_tags::Tag0, test_databox_tags::Tag1,
-          test_databox_tags::Tag2,
-          Tags::Variables<tmpl::list<test_databox_tags::ScalarTag,
-                                     test_databox_tags::VectorTag>>>,
-      db::AddComputeTags<test_databox_tags::Tag4Compute,
-                         test_databox_tags::Tag5Compute,
-                         test_databox_tags::MultiplyScalarByTwoCompute,
-                         test_databox_tags::MultiplyVariablesByTwoCompute>>(
-      3.14, std::vector<double>{8.7, 93.2, 84.7}, "My Sample String"s,
-      Variables<tmpl::list<test_databox_tags::ScalarTag,
-                           test_databox_tags::VectorTag>>(2, 3.));
+void test_variables2() {
+  INFO("test variables2");
+  const auto create_box = []() {
+    return db::create<
+        db::AddSimpleTags<Tags::Variables<tmpl::list<Tag1, Tag2>>>>(
+        Variables<tmpl::list<Tag1, Tag2>>(1, 1.));
+  };
+  {
+    INFO("Using DataBox");
+    auto box = create_box();
+    test_variables2(box);
+  }
+  {
+    INFO("Using db::Access");
+    auto box = create_box();
+    test_variables2(db::as_access(box));
+  }
+}
+
+template <typename T>
+void test_reset_compute_items(T& box) {
   CHECK(approx(db::get<test_databox_tags::Tag4>(box)) == 3.14 * 2.0);
   CHECK(db::get<test_databox_tags::Tag5>(box) == "My Sample String6.28");
   CHECK(db::get<test_databox_tags::ScalarTag>(box) ==
@@ -1172,6 +1236,35 @@ void test_reset_compute_items() {
   db::mutate<>([]() {}, make_not_null(&box));
 }
 
+void test_reset_compute_items() {
+  INFO("test reset compute items");
+  const auto create_box = []() {
+    return db::create<
+        db::AddSimpleTags<
+            test_databox_tags::Tag0, test_databox_tags::Tag1,
+            test_databox_tags::Tag2,
+            Tags::Variables<tmpl::list<test_databox_tags::ScalarTag,
+                                       test_databox_tags::VectorTag>>>,
+        db::AddComputeTags<test_databox_tags::Tag4Compute,
+                           test_databox_tags::Tag5Compute,
+                           test_databox_tags::MultiplyScalarByTwoCompute,
+                           test_databox_tags::MultiplyVariablesByTwoCompute>>(
+        3.14, std::vector<double>{8.7, 93.2, 84.7}, "My Sample String"s,
+        Variables<tmpl::list<test_databox_tags::ScalarTag,
+                             test_databox_tags::VectorTag>>(2, 3.));
+  };
+  {
+    INFO("DataBox");
+    auto box = create_box();
+    test_reset_compute_items(box);
+  }
+  {
+    INFO("Access");
+    auto box = create_box();
+    test_reset_compute_items(db::as_access(box));
+  }
+}
+
 namespace ExtraResetTags {
 struct Var : db::SimpleTag {
   using type = Scalar<DataVector>;
@@ -1185,28 +1278,49 @@ struct CheckReset : db::SimpleTag {
 struct CheckResetCompute : CheckReset, db::ComputeTag {
   using base = CheckReset;
   using return_type = int;
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+  static bool first_call;
   static auto function(const gsl::not_null<int*> result,
                        const ::Variables<tmpl::list<Var>>& /*unused*/) {
-    static bool first_call = true;
     CHECK(first_call);
     first_call = false;
     *result = 0;
   }
   using argument_tags = tmpl::list<Tags::Variables<tmpl::list<Var>>>;
 };
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+bool CheckResetCompute::first_call = true;
 }  // namespace ExtraResetTags
 
-void test_variables_extra_reset() {
-  INFO("test variables extra reset");
-  auto box = db::create<
-      db::AddSimpleTags<ExtraResetTags::Int,
-                        Tags::Variables<tmpl::list<ExtraResetTags::Var>>>,
-      db::AddComputeTags<ExtraResetTags::CheckResetCompute>>(
-      1, Variables<tmpl::list<ExtraResetTags::Var>>(2, 3.));
+template <typename T>
+void test_variables_extra_reset(T& box) {
   CHECK(db::get<ExtraResetTags::CheckReset>(box) == 0);
   db::mutate<ExtraResetTags::Int>([](const gsl::not_null<int*> /*unused*/) {},
                                   make_not_null(&box));
   CHECK(db::get<ExtraResetTags::CheckReset>(box) == 0);
+}
+
+void test_variables_extra_reset() {
+  INFO("test variables extra reset");
+  const auto create_box = []() {
+    return db::create<
+        db::AddSimpleTags<ExtraResetTags::Int,
+                          Tags::Variables<tmpl::list<ExtraResetTags::Var>>>,
+        db::AddComputeTags<ExtraResetTags::CheckResetCompute>>(
+        1, Variables<tmpl::list<ExtraResetTags::Var>>(2, 3.));
+  };
+  {
+    ExtraResetTags::CheckResetCompute::first_call = true;
+    INFO("Using DataBox");
+    auto box = create_box();
+    test_variables_extra_reset(box);
+  }
+  {
+    ExtraResetTags::CheckResetCompute::first_call = true;
+    INFO("Using db::Access");
+    auto box = create_box();
+    test_variables_extra_reset(db::as_access(box));
+  }
 }
 
 // [mutate_apply_struct_definition_example]
@@ -1565,16 +1679,8 @@ struct MutateVariablesCompute : MutateVariables, db::ComputeTag {
 // [databox_mutating_compute_item_tag]
 }  // namespace test_databox_tags
 
-void test_mutating_compute_item() {
-  INFO("test mutating compute item");
-  auto original_box = db::create<
-      db::AddSimpleTags<test_databox_tags::Tag0, test_databox_tags::Tag1,
-                        test_databox_tags::Tag2>,
-      db::AddComputeTags<test_databox_tags::MutateTag0Compute,
-                         test_databox_tags::MutateVariablesCompute,
-                         test_databox_tags::Tag4Compute,
-                         test_databox_tags::Tag5Compute>>(
-      3.14, std::vector<double>{8.7, 93.2, 84.7}, "My Sample String"s);
+template <typename T>
+void test_mutating_compute_item(T& original_box) {
   const double* const initial_data_location_mutating =
       db::get<test_databox_tags::MutateTag0>(original_box).data();
   const std::array<const double* const, 4>
@@ -1656,6 +1762,30 @@ void test_mutating_compute_item() {
                  get<test_databox_tags::VectorTag>(
                      db::get<test_databox_tags::MutateVariables>(original_box)))
                  .data()}}));
+}
+
+void test_mutating_compute_item() {
+  INFO("test mutating compute item");
+  const auto create_box = []() {
+    return db::create<
+        db::AddSimpleTags<test_databox_tags::Tag0, test_databox_tags::Tag1,
+                          test_databox_tags::Tag2>,
+        db::AddComputeTags<test_databox_tags::MutateTag0Compute,
+                           test_databox_tags::MutateVariablesCompute,
+                           test_databox_tags::Tag4Compute,
+                           test_databox_tags::Tag5Compute>>(
+        3.14, std::vector<double>{8.7, 93.2, 84.7}, "My Sample String"s);
+  };
+  {
+    INFO("DataBox");
+    auto box = create_box();
+    test_mutating_compute_item(box);
+  }
+  {
+    INFO("Access");
+    auto box = create_box();
+    test_mutating_compute_item(db::as_access(box));
+  }
 }
 
 namespace DataBoxTest_detail {
@@ -2130,21 +2260,8 @@ struct TemplateCompute : Template<ArgumentTag>, db::ComputeTag {
 // [overload_compute_tag_template]
 }  // namespace test_databox_tags
 
-void test_overload_compute_tags() {
-  INFO("testing overload compute tags.");
-  auto box = db::create<
-      db::AddSimpleTags<test_databox_tags::Tag0, test_databox_tags::Tag0Int>,
-      db::AddComputeTags<
-          test_databox_tags::OverloadTypeCompute<test_databox_tags::Tag0>,
-          test_databox_tags::OverloadTypeCompute<test_databox_tags::Tag0Int>,
-          test_databox_tags::OverloadNumberOfArgsCompute<
-              test_databox_tags::Tag0>,
-          test_databox_tags::OverloadNumberOfArgsCompute<
-              test_databox_tags::Tag0,
-              test_databox_tags::OverloadType<test_databox_tags::Tag0>>,
-          test_databox_tags::TemplateCompute<test_databox_tags::Tag0>,
-          test_databox_tags::TemplateCompute<test_databox_tags::Tag0Int>>>(8.4,
-                                                                           -3);
+template <typename T>
+void test_overload_compute_tags(T& box) {
   CHECK(db::get<test_databox_tags::OverloadType<test_databox_tags::Tag0>>(
             box) == 8.4 * 3.2);
   CHECK(db::get<test_databox_tags::OverloadType<test_databox_tags::Tag0Int>>(
@@ -2160,6 +2277,35 @@ void test_overload_compute_tags() {
         8.4 * 5.0);
   CHECK(db::get<test_databox_tags::Template<test_databox_tags::Tag0Int>>(box) ==
         -3 * 5);
+}
+
+void test_overload_compute_tags() {
+  INFO("testing overload compute tags.");
+  const auto create_box = []() {
+    return db::create<
+        db::AddSimpleTags<test_databox_tags::Tag0, test_databox_tags::Tag0Int>,
+        db::AddComputeTags<
+            test_databox_tags::OverloadTypeCompute<test_databox_tags::Tag0>,
+            test_databox_tags::OverloadTypeCompute<test_databox_tags::Tag0Int>,
+            test_databox_tags::OverloadNumberOfArgsCompute<
+                test_databox_tags::Tag0>,
+            test_databox_tags::OverloadNumberOfArgsCompute<
+                test_databox_tags::Tag0,
+                test_databox_tags::OverloadType<test_databox_tags::Tag0>>,
+            test_databox_tags::TemplateCompute<test_databox_tags::Tag0>,
+            test_databox_tags::TemplateCompute<test_databox_tags::Tag0Int>>>(
+        8.4, -3);
+  };
+  {
+    INFO("Using DataBox");
+    auto box = create_box();
+    test_overload_compute_tags(box);
+  }
+  {
+    INFO("Using db::Access");
+    auto box = create_box();
+    test_overload_compute_tags(db::as_access(box));
+  }
 }
 
 namespace TestTags {
@@ -2750,28 +2896,11 @@ struct Tag0OrVar0TimesTwoCompute : Tag0OrVar0TimesTwo,
 
 }  // namespace test_databox_tags
 
-void test_reference_item() {
-  INFO("test reference item");
+template <typename T>
+void test_reference_item(T& box) {
   using tuple_tag = test_databox_tags::TaggedTuple<
       test_databox_tags::Tag0, test_databox_tags::Tag1, test_databox_tags::Tag2,
       test_databox_tags::Tag4>;
-  using vars_tag = Tags::Variables<tmpl::list<test_databox_tags::Var0>>;
-  auto box = db::create<
-      db::AddSimpleTags<tuple_tag, vars_tag, test_databox_tags::SwitchTag>,
-      db::AddComputeTags<test_databox_tags::FromTaggedTuple<
-                             test_databox_tags::Tag0, tuple_tag>,
-                         test_databox_tags::FromTaggedTuple<
-                             test_databox_tags::Tag1, tuple_tag>,
-                         test_databox_tags::FromTaggedTuple<
-                             test_databox_tags::Tag2, tuple_tag>,
-                         test_databox_tags::FromTaggedTuple<
-                             test_databox_tags::Tag4, tuple_tag>,
-                         test_databox_tags::Tag0OrVar0Reference,
-                         test_databox_tags::Tag0OrVar0TimesTwoCompute>>(
-      tuples::TaggedTuple<test_databox_tags::Tag0, test_databox_tags::Tag1,
-                          test_databox_tags::Tag2, test_databox_tags::Tag4>{
-          3.14, std::vector<double>{8.7, 93.2, 84.7}, "My Sample String"s, 1.},
-      Variables<tmpl::list<test_databox_tags::Var0>>{1, 1.}, true);
   const auto& tagged_tuple = get<tuple_tag>(box);
   CHECK(get<test_databox_tags::Tag0>(tagged_tuple) == 3.14);
   CHECK(get<test_databox_tags::Tag1>(tagged_tuple) ==
@@ -2800,6 +2929,43 @@ void test_reference_item() {
       },
       make_not_null(&box));
   CHECK(get<test_databox_tags::Tag0OrVar0TimesTwo>(box) == 1.);
+}
+
+void test_reference_item() {
+  INFO("test reference item");
+  using tuple_tag = test_databox_tags::TaggedTuple<
+      test_databox_tags::Tag0, test_databox_tags::Tag1, test_databox_tags::Tag2,
+      test_databox_tags::Tag4>;
+  using vars_tag = Tags::Variables<tmpl::list<test_databox_tags::Var0>>;
+  const auto create_box = []() {
+    return db::create<
+        db::AddSimpleTags<tuple_tag, vars_tag, test_databox_tags::SwitchTag>,
+        db::AddComputeTags<test_databox_tags::FromTaggedTuple<
+                               test_databox_tags::Tag0, tuple_tag>,
+                           test_databox_tags::FromTaggedTuple<
+                               test_databox_tags::Tag1, tuple_tag>,
+                           test_databox_tags::FromTaggedTuple<
+                               test_databox_tags::Tag2, tuple_tag>,
+                           test_databox_tags::FromTaggedTuple<
+                               test_databox_tags::Tag4, tuple_tag>,
+                           test_databox_tags::Tag0OrVar0Reference,
+                           test_databox_tags::Tag0OrVar0TimesTwoCompute>>(
+        tuples::TaggedTuple<test_databox_tags::Tag0, test_databox_tags::Tag1,
+                            test_databox_tags::Tag2, test_databox_tags::Tag4>{
+            3.14, std::vector<double>{8.7, 93.2, 84.7}, "My Sample String"s,
+            1.},
+        Variables<tmpl::list<test_databox_tags::Var0>>{1, 1.}, true);
+  };
+  {
+    INFO("Using DataBox");
+    auto box = create_box();
+    test_reference_item(box);
+  }
+  {
+    INFO("Using db::Access");
+    auto box = create_box();
+    test_reference_item(db::as_access(box));
+  }
 }
 
 void test_get_mutable_reference() {
@@ -2841,7 +3007,7 @@ void test_output() {
                          test_databox_tags::Tag5Compute,
                          test_databox_tags::Tag0Reference>>(
       3.14, std::vector<double>{8.7, 93.2, 84.7}, "My Sample String"s);
-  std::string output_types = box.print_types();
+  std::string output_types = db::as_access(box).print_types();
   std::string expected_types =
       "DataBox type aliases:\n"
       "using tags_list = brigand::list<(anonymous "

--- a/tests/Unit/ParallelAlgorithms/Actions/Test_InitializeItems.cpp
+++ b/tests/Unit/ParallelAlgorithms/Actions/Test_InitializeItems.cpp
@@ -58,9 +58,18 @@ struct Duplicate : db::SimpleTag {
   using type = int;
 };
 
+struct DuplicateConstGlobalCache : db::SimpleTag {
+  using type = int;
+};
+
+struct DuplicateMutableGlobalCache : db::SimpleTag {
+  using type = int;
+};
+
 struct InitializeThree {
-  using const_global_cache_tags = tmpl::list<TagOne, Duplicate>;
-  using mutable_global_cache_tags = tmpl::list<TagTwo, Duplicate>;
+  using const_global_cache_tags = tmpl::list<TagOne, DuplicateConstGlobalCache>;
+  using mutable_global_cache_tags =
+      tmpl::list<TagTwo, DuplicateMutableGlobalCache>;
   using simple_tags_from_options = tmpl::list<>;
   using simple_tags = tmpl::list<Three, Duplicate>;
   using compute_tags = tmpl::list<>;
@@ -71,8 +80,9 @@ struct InitializeThree {
 };
 
 struct InitializeTwo {
-  using const_global_cache_tags = tmpl::list<TagThree, Duplicate>;
-  using mutable_global_cache_tags = tmpl::list<Duplicate>;
+  using const_global_cache_tags =
+      tmpl::list<TagThree, DuplicateConstGlobalCache>;
+  using mutable_global_cache_tags = tmpl::list<DuplicateMutableGlobalCache>;
   using simple_tags_from_options = tmpl::list<Two>;
   using simple_tags = tmpl::list<Duplicate>;
   using compute_tags = tmpl::list<FiveCompute>;
@@ -82,8 +92,8 @@ struct InitializeTwo {
 };
 
 struct InitializeTen {
-  using const_global_cache_tags = tmpl::list<Duplicate>;
-  using mutable_global_cache_tags = tmpl::list<Duplicate>;
+  using const_global_cache_tags = tmpl::list<DuplicateConstGlobalCache>;
+  using mutable_global_cache_tags = tmpl::list<DuplicateMutableGlobalCache>;
   using simple_tags_from_options = tmpl::list<Two>;
   using simple_tags = tmpl::list<Ten, Duplicate>;
   using compute_tags = tmpl::list<FiveCompute>;
@@ -110,14 +120,16 @@ struct Component {
       tmpl::list<Parallel::PhaseActions<Parallel::Phase::Initialization,
                                         tmpl::list<initialization_action>>>;
 
-  static_assert(std::is_same_v<
-                tmpl::count_if<initialization_action::const_global_cache_tags,
-                               std::is_same<tmpl::_1, Duplicate>>,
-                tmpl::size_t<1>>);
-  static_assert(std::is_same_v<
-                tmpl::count_if<initialization_action::mutable_global_cache_tags,
-                               std::is_same<tmpl::_1, Duplicate>>,
-                tmpl::size_t<1>>);
+  static_assert(
+      std::is_same_v<
+          tmpl::count_if<initialization_action::const_global_cache_tags,
+                         std::is_same<tmpl::_1, DuplicateConstGlobalCache>>,
+          tmpl::size_t<1>>);
+  static_assert(
+      std::is_same_v<
+          tmpl::count_if<initialization_action::mutable_global_cache_tags,
+                         std::is_same<tmpl::_1, DuplicateMutableGlobalCache>>,
+          tmpl::size_t<1>>);
   static_assert(std::is_same_v<
                 tmpl::count_if<initialization_action::simple_tags_from_options,
                                std::is_same<tmpl::_1, Two>>,
@@ -146,9 +158,10 @@ SPECTRE_TEST_CASE("Unit.ParallelAlgorithms.Actions.InitializeItems",
                   "[Unit][ParallelAlgorithms]") {
   using component = Component<Metavariables>;
 
-  tuples::TaggedTuple<TagOne, TagThree, Duplicate> const_cache_items{7, -4.,
-                                                                     8.};
-  tuples::TaggedTuple<TagTwo, Duplicate> mutable_cache_items{"bla", 9.};
+  tuples::TaggedTuple<TagOne, TagThree, DuplicateConstGlobalCache>
+      const_cache_items{7, -4., 8.};
+  tuples::TaggedTuple<TagTwo, DuplicateMutableGlobalCache> mutable_cache_items{
+      "bla", 9.};
 
   ActionTesting::MockRuntimeSystem<Metavariables> runner{const_cache_items,
                                                          mutable_cache_items};


### PR DESCRIPTION
## Proposed changes

This adds a method of getting a type-erased DataBox. Some retrieval errors become runtime, but this will allow us to move more code into cpp files, which will hopefully decrease compile time.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
