### PR TITLE
Add exporter library

### DIFF
--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -339,6 +339,7 @@ jobs:
           -D USE_PCH=ON
           -D USE_XSIMD=ON
           -D USE_CCACHE=ON
+          -D ENABLE_OPENMP=ON
           -D BUILD_PYTHON_BINDINGS=ON
           -D BUILD_SHARED_LIBS=ON
           -D MEMORY_ALLOCATOR=SYSTEM
@@ -644,6 +645,7 @@ ${{ matrix.build_type }}-pch-${{ matrix.use_pch || 'ON' }}"
           -D USE_PCH=${USE_PCH:-'ON'}
           -D USE_XSIMD=${USE_XSIMD:-'ON'}
           -D USE_CCACHE=ON
+          -D ENABLE_OPENMP=ON
           -D COVERAGE=${COVERAGE:-'OFF'}
           -D BUILD_PYTHON_BINDINGS=${BUILD_PYTHON_BINDINGS:-'ON'}
           -D BUILD_SHARED_LIBS=${BUILD_SHARED_LIBS:-'ON'}
@@ -783,8 +785,8 @@ ${{ matrix.build_type }}-pch-${{ matrix.use_pch || 'ON' }}"
           mv spectre_src.tar.gz spectre_src;
           cd spectre_src;
           tar xf spectre_src.tar.gz;
-          mkdir build;
-          cd build
+          mkdir build-formaline;
+          cd build-formaline
 
           BUILD_PYTHON_BINDINGS=${{ matrix.BUILD_PYTHON_BINDINGS }}
           MATRIX_CHARM_ROOT=${{ matrix.CHARM_ROOT }}
@@ -817,6 +819,21 @@ ${{ matrix.build_type }}-pch-${{ matrix.use_pch || 'ON' }}"
           make EvolveBurgers -j2
 
           ctest -j2 -R InputFiles.Burgers.Step.yaml --output-on-failure
+
+          cd .. && rm -r build-formaline
+      - name: Test bundled exporter
+        if: matrix.ASAN != 'ON'
+        working-directory: build
+        run: |
+          make -j2 BundledExporter
+          mkdir build-test-exporter && cd build-test-exporter
+          cmake -D SPECTRE_ROOT=$GITHUB_WORKSPACE/build \
+            $GITHUB_WORKSPACE/tests/Unit/IO/Exporter/BundledExporter
+          make -j2
+          ./TestSpectreExporter \
+            $GITHUB_WORKSPACE/tests/Unit/Visualization/Python/VolTestData0.h5 \
+            element_data 0 Psi 0 0 0 -0.07059806932542323
+          cd .. && rm -r build-test-exporter
       - name: Diagnose ccache
         run: |
           ccache -s

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,6 +143,7 @@ include(SetupStl)
 include(SetupLibsharp)
 include(SetupXsimd)
 include(SetupYamlCpp)
+include(SetupOpenMP)
 
 include(SetupLIBCXXCharm)
 # The precompiled header must be setup after all libraries have been found

--- a/cmake/SetupOpenMP.cmake
+++ b/cmake/SetupOpenMP.cmake
@@ -1,0 +1,8 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+option(ENABLE_OPENMP "Enable OpenMP in some parts of the code" OFF)
+
+if (ENABLE_OPENMP)
+  find_package(OpenMP COMPONENTS CXX)
+endif()

--- a/docs/DevGuide/BuildSystem.md
+++ b/docs/DevGuide/BuildSystem.md
@@ -240,6 +240,10 @@ cmake -D FLAG1=OPT1 ... -D FLAGN=OPTN <SPECTRE_ROOT>
   - Whether or not to use debug symbols (default is `ON`)
   - Disabling debug symbols will reduce compile time and total size of the build
     directory.
+- ENABLE_OPENMP
+  - Enable OpenMP parallelization in some parts of the code, such as Python
+    bindings and interpolating volume data files. Note that simulations do not
+    typically use OpenMP parallelization, so this flag only applies to tools.
 - ENABLE_PROFILING
   - Enables various options to make profiling SpECTRE easier
     (default is `OFF`)

--- a/src/Domain/CoordinateMaps/Composition.cpp
+++ b/src/Domain/CoordinateMaps/Composition.cpp
@@ -397,7 +397,7 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
 
 #undef INSTANTIATE
 
-#if defined(__clang__) && __clang_major__ >= 15
+#if defined(__clang__) && __clang_major__ >= 15 && __clang_major__ < 17
 #define INSTANTIATE2(_, data)                                                  \
   template domain::CoordinateMaps::Composition<                                \
       brigand::list<Frame::BlockLogical, Frame::Grid, Frame::Distorted>,       \

--- a/src/IO/CMakeLists.txt
+++ b/src/IO/CMakeLists.txt
@@ -31,6 +31,7 @@ target_link_libraries(
   Utilities
   )
 
+add_subdirectory(Exporter)
 add_subdirectory(External)
 add_subdirectory(H5)
 add_subdirectory(Logging)

--- a/src/IO/Exporter/BundledExporter.cpp
+++ b/src/IO/Exporter/BundledExporter.cpp
@@ -1,0 +1,33 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+// This file defines some symbols for compatibility with InfoAtLink and Charm++
+// when the BundledExporter library is linked into an external program.
+
+#include "Informer/InfoFromBuild.hpp"
+#include "Utilities/Formaline.hpp"
+
+std::string link_date() { return "Unavailable"; }
+
+std::string executable_name() { return "Unavailable"; }
+
+std::string git_description() { return "Unavailable"; }
+
+std::string git_branch() { return "Unavailable"; }
+
+namespace formaline {
+std::vector<char> get_archive() {
+  return {'N', 'o', 't', ' ', 's', 'u', 'p', 'p', 'o', 'r', 't', 'e', 'd'};
+}
+
+std::string get_environment_variables() { return "Unavailable"; }
+
+std::string get_build_info() { return "Unavailable"; }
+
+std::string get_paths() { return "Unavailable."; }
+}  // namespace formaline
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmissing-declarations"
+extern "C" void CkRegisterMainModule() {}
+#pragma GCC diagnostic pop

--- a/src/IO/Exporter/CMakeLists.txt
+++ b/src/IO/Exporter/CMakeLists.txt
@@ -1,0 +1,42 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBRARY Exporter)
+
+# Use 'add_library' rather than 'add_spectre_library' for multiple reasons:
+# - Don't build with PCH, because otherwise we'd have to depend the PCH on
+#   OpenMP (would probably be fine, but then _everything_ would link with OpenMP
+#   and it's probably better to avoid that).
+# - Don't try to stub the object files because the BundledExporter library
+#   (defined below) uses them.
+add_library(${LIBRARY})
+
+spectre_target_sources(
+  ${LIBRARY}
+  PRIVATE
+  Exporter.cpp
+  )
+
+spectre_target_headers(
+  ${LIBRARY}
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  Exporter.hpp
+  )
+
+target_link_libraries(
+  ${LIBRARY}
+  PRIVATE
+  Domain
+  DomainCreators
+  FunctionsOfTime
+  H5
+  Interpolation
+  Serialization
+  Utilities
+  )
+
+# Link OpenMP if available
+if(TARGET OpenMP::OpenMP_CXX)
+  target_link_libraries(${LIBRARY} PRIVATE OpenMP::OpenMP_CXX)
+endif()

--- a/src/IO/Exporter/CMakeLists.txt
+++ b/src/IO/Exporter/CMakeLists.txt
@@ -40,3 +40,5 @@ target_link_libraries(
 if(TARGET OpenMP::OpenMP_CXX)
   target_link_libraries(${LIBRARY} PRIVATE OpenMP::OpenMP_CXX)
 endif()
+
+add_subdirectory(Python)

--- a/src/IO/Exporter/CMakeLists.txt
+++ b/src/IO/Exporter/CMakeLists.txt
@@ -42,3 +42,40 @@ if(TARGET OpenMP::OpenMP_CXX)
 endif()
 
 add_subdirectory(Python)
+
+# Create a library that can be linked into an external program. Notes:
+# - This is still experimental. The bundled library works (see
+#   Test_BundledExporter.cpp), but building the library on one system and then
+#   distributing it to another (i.e. making the library relocatable) will likely
+#   require some more work. Linking in external dependencies statically would
+#   probably help, so they don't have to be installed on the target system (e.g.
+#   HDF5, yaml-cpp, etc).
+# - A shared library seems to work better than a static library, since it
+#   includes symbols from linked static libs.
+# - The `TARGET_OBJECTS` generator expression links in the objects from the
+#   Exporter library, because otherwise they wouldn't be used and therefore
+#   wouldn't be linked in.
+# - The `EXPORTER_LINKED_LIBS` are needed to resolve the symbols for the
+#   `TARGET_OBJECTS`, just like in the Exporter library (of which this library
+#   is basically an extended copy).
+# - The `BundledExporter.cpp` file and the `CharmModuleInit` object library
+#   define some symbols for compatility with Charm++ and InfoAtLink.
+set(BUNDLED_EXPORTER_LIB BundledExporter)
+add_library(${BUNDLED_EXPORTER_LIB} SHARED
+  BundledExporter.cpp)
+get_target_property(EXPORTER_LINKED_LIBS ${LIBRARY} LINK_LIBRARIES)
+target_link_libraries(
+  ${BUNDLED_EXPORTER_LIB}
+  PRIVATE
+  $<TARGET_OBJECTS:${LIBRARY}>
+  ${EXPORTER_LINKED_LIBS}
+  Informer
+  CharmModuleInit
+  Charmxx::charmxx
+  )
+add_dependencies(${BUNDLED_EXPORTER_LIB} ${LIBRARY})
+# Also export the public header so that external programs can include it
+configure_file(
+  Exporter.hpp
+  ${CMAKE_BINARY_DIR}/include/spectre/Exporter.hpp
+  COPYONLY)

--- a/src/IO/Exporter/Exporter.cpp
+++ b/src/IO/Exporter/Exporter.cpp
@@ -1,0 +1,276 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "IO/Exporter/Exporter.hpp"
+
+#include <csignal>  // For Blaze error handling without PCH
+#ifdef _OPENMP
+#include <omp.h>
+#endif  // _OPENMP
+
+#include "Domain/BlockLogicalCoordinates.hpp"
+#include "Domain/Creators/RegisterDerivedWithCharm.hpp"
+#include "Domain/Creators/TimeDependence/RegisterDerivedWithCharm.hpp"
+#include "Domain/Domain.hpp"
+#include "Domain/ElementLogicalCoordinates.hpp"
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "Domain/FunctionsOfTime/RegisterDerivedWithCharm.hpp"
+#include "IO/H5/File.hpp"
+#include "IO/H5/TensorData.hpp"
+#include "IO/H5/VolumeData.hpp"
+#include "NumericalAlgorithms/Interpolation/IrregularInterpolant.hpp"
+#include "Utilities/FileSystem.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/GetOutput.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Overloader.hpp"
+#include "Utilities/Serialization/Serialize.hpp"
+
+// Ignore OpenMP pragmas when OpenMP is not enabled
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunknown-pragmas"
+
+namespace spectre::Exporter {
+
+namespace {
+template <size_t Dim>
+void interpolate_to_points(
+    const gsl::not_null<std::vector<std::vector<double>>*> result,
+    const gsl::not_null<std::vector<bool>*> filled_data,
+    const std::string& filename, const std::string& subfile_name,
+    const size_t obs_id, const std::vector<std::string>& tensor_components,
+    const std::vector<std::optional<
+        IdPair<domain::BlockId, tnsr::I<double, Dim, Frame::BlockLogical>>>>&
+        block_logical_coords) {
+  std::vector<std::string> grid_names;
+  std::vector<std::vector<size_t>> all_extents;
+  std::vector<std::vector<Spectral::Basis>> all_bases;
+  std::vector<std::vector<Spectral::Quadrature>> all_quadratures;
+  std::vector<DataVector> tensor_data{};
+  tensor_data.reserve(tensor_components.size());
+  // HDF5 is not generally thread-safe, so we make sure only one thread is doing
+  // HDF5 operations at a time
+#pragma omp critical
+  {
+    const h5::H5File<h5::AccessType::ReadOnly> h5file(filename);
+    const auto& volfile = h5file.get<h5::VolumeData>(subfile_name);
+    grid_names = volfile.get_grid_names(obs_id);
+    all_extents = volfile.get_extents(obs_id);
+    all_bases = volfile.get_bases(obs_id);
+    all_quadratures = volfile.get_quadratures(obs_id);
+    // Load the tensor data for all grids in the file because it's stored
+    // contiguously
+    for (const auto& tensor_component : tensor_components) {
+      auto component_data =
+          volfile.get_tensor_component(obs_id, tensor_component).data;
+      if (std::holds_alternative<DataVector>(component_data)) {
+        tensor_data.push_back(std::get<DataVector>(std::move(component_data)));
+      } else {
+        // Possible optimization: do single-precision interpolation if the
+        // volume data is single-precision
+        const auto& float_component_data =
+            std::get<std::vector<float>>(component_data);
+        DataVector double_component_data(float_component_data.size());
+        for (size_t i = 0; i < float_component_data.size(); ++i) {
+          double_component_data[i] = float_component_data[i];
+        }
+      }
+    }
+  }
+  // Reconstruct element IDs & meshes in the volume data file.
+  // This can be simplified by using ElementId and Mesh in the VolumeData class.
+  std::vector<ElementId<Dim>> element_ids{};
+  std::unordered_map<ElementId<Dim>, Mesh<Dim>> meshes{};
+  element_ids.reserve(grid_names.size());
+  for (const auto& grid_name : grid_names) {
+    const ElementId<Dim> element_id(grid_name);
+    element_ids.push_back(element_id);
+    meshes[element_id] = h5::mesh_for_grid<Dim>(
+        grid_name, grid_names, all_extents, all_bases, all_quadratures);
+  }
+  // Map the target points to element-logical coordinates. This selects the
+  // subset of target points that are in the volume data file's elements.
+  const auto element_logical_coords =
+      element_logical_coordinates(element_ids, block_logical_coords);
+  DataVector interpolated_data{};
+  for (const auto& [element_id, point] : element_logical_coords) {
+    const auto [offset, length] = h5::offset_and_length_for_grid(
+        get_output(element_id), grid_names, all_extents);
+    // Interpolate!
+    // Possible optimization: rather than interpolating each tensor component
+    // separately, we could interpolate all components at once. This would need
+    // an offset and stride to be passed to the interpolator, since the tensor
+    // components for all elements are stored contiguously.
+    const intrp::Irregular<Dim> interpolant(meshes[element_id],
+                                            point.element_logical_coords);
+    const size_t num_element_target_points =
+        point.element_logical_coords.begin()->size();
+    if (interpolated_data.size() < num_element_target_points) {
+      interpolated_data.destructive_resize(num_element_target_points);
+    }
+    for (size_t i = 0; i < tensor_components.size(); ++i) {
+      auto output_data =
+          gsl::make_span(interpolated_data.data(), num_element_target_points);
+      const auto input_data =
+          gsl::make_span(tensor_data[i].data() + offset, length);
+      interpolant.interpolate(make_not_null(&output_data), input_data);
+      for (size_t j = 0; j < num_element_target_points; ++j) {
+        (*result)[i][point.offsets[j]] = interpolated_data[j];
+        (*filled_data)[point.offsets[j]] = true;
+      }
+    }
+  }
+}
+}  // namespace
+
+template <size_t Dim>
+std::vector<std::vector<double>> interpolate_to_points(
+    const std::variant<std::vector<std::string>, std::string>&
+        volume_files_or_glob,
+    std::string subfile_name, int observation_step,
+    const std::vector<std::string>& tensor_components,
+    const std::array<std::vector<double>, Dim>& target_points,
+    const std::optional<size_t> num_threads) {
+  domain::creators::register_derived_with_charm();
+  domain::creators::time_dependence::register_derived_with_charm();
+  domain::FunctionsOfTime::register_derived_with_charm();
+
+  // Get the list of volume data files
+  const std::vector<std::string> filenames =
+      std::visit(Overloader{[](const std::vector<std::string>& volume_files) {
+                              return volume_files;
+                            },
+                            [](const std::string& volume_files_glob) {
+                              return file_system::glob(volume_files_glob);
+                            }},
+                 volume_files_or_glob);
+  if (filenames.empty()) {
+    ERROR_NO_TRACE("No volume files found. Specify at least one volume file.");
+  }
+
+  // Normalize subfile name
+  if (subfile_name.size() > 4 &&
+      subfile_name.substr(subfile_name.size() - 4) == ".vol") {
+    subfile_name = subfile_name.substr(0, subfile_name.size() - 4);
+  }
+  if (subfile_name.front() != '/') {
+    subfile_name = '/' + subfile_name;
+  }
+
+  // Retrieve info from the first volume file
+  const h5::H5File<h5::AccessType::ReadOnly> first_h5file(filenames.front());
+  const auto& first_volfile = first_h5file.get<h5::VolumeData>(subfile_name);
+  const auto dim = first_volfile.get_dimension();
+  if (dim != Dim) {
+    ERROR_NO_TRACE("Mismatched dimensions: expected "
+                   << Dim << "D volume data, but got " << dim << "D.");
+  }
+  // Get observation ID. This currently assumes that all volume files contain
+  // the same observations. For generalizing to volume files across multiple
+  // segments, see the Python function `Visualization.ReadH5:select_observation`
+  // and possibly move it to C++.
+  const auto obs_ids = first_volfile.list_observation_ids();
+  if (observation_step < 0) {
+    observation_step += static_cast<int>(obs_ids.size());
+  }
+  if (observation_step < 0 or
+      static_cast<size_t>(observation_step) >= obs_ids.size()) {
+    ERROR_NO_TRACE("Invalid observation step: "
+                   << observation_step << ". There are " << obs_ids.size()
+                   << " observations in the file.");
+  }
+  const size_t obs_id = obs_ids[static_cast<size_t>(observation_step)];
+  // Get domain, time, functions of time
+  const auto domain =
+      deserialize<Domain<Dim>>(first_volfile.get_domain(obs_id)->data());
+  const auto [time, functions_of_time] = [&first_volfile, &obs_id, &domain]() {
+    if (domain.is_time_dependent()) {
+      return std::make_pair(
+          first_volfile.get_observation_value(obs_id),
+          deserialize<domain::FunctionsOfTimeMap>(
+              first_volfile.get_functions_of_time(obs_id)->data()));
+    } else {
+      return std::make_pair(0., domain::FunctionsOfTimeMap{});
+    }
+  }();
+  first_h5file.close();
+
+  // Look up block logical coordinates for all target points by mapping them
+  // through the domain
+  tnsr::I<DataVector, Dim, Frame::Inertial> inertial_coords{};
+  const size_t num_target_points = target_points[0].size();
+  for (size_t d = 0; d < Dim; ++d) {
+    const auto& target_coord = gsl::at(target_points, d);
+    if (target_coord.size() != num_target_points) {
+      ERROR_NO_TRACE("Mismatched number of target points: coordinate 0 has "
+                     << num_target_points << " points, but coordinate " << d
+                     << " has " << target_coord.size() << " points.");
+    }
+    inertial_coords.get(d).set_data_ref(
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
+        const_cast<double*>(target_coord.data()), num_target_points);
+  }
+  const auto block_logical_coords = block_logical_coordinates(
+      domain, inertial_coords, time, functions_of_time);
+
+  // Allocate memory for result
+  std::vector<std::vector<double>> result{};
+  result.reserve(tensor_components.size());
+  for (size_t i = 0; i < tensor_components.size(); ++i) {
+    result.emplace_back(num_target_points,
+                        std::numeric_limits<double>::signaling_NaN());
+  }
+  std::vector<bool> filled_data(num_target_points, false);
+
+  // Process all volume files. Parallelized with OpenMP if available.
+  // Note: `break` is not allowed in OpenMP loops, so we use a shared bool to
+  // skip the remaining iterations.
+  bool all_data_filled = false;
+#ifdef _OPENMP
+  const size_t resolved_num_threads =
+      num_threads.value_or(omp_get_max_threads());
+#else
+  if (num_threads.has_value()) {
+    ERROR_NO_TRACE(
+        "OpenMP is not available, so num_threads cannot be specified.");
+  }
+#endif  // _OPENMP
+#pragma omp parallel for num_threads(resolved_num_threads) \
+    shared(all_data_filled)
+  for (const auto& filename : filenames) {
+    if (all_data_filled) {
+      continue;
+    }
+    interpolate_to_points(make_not_null(&result), make_not_null(&filled_data),
+                          filename, subfile_name, obs_id, tensor_components,
+                          block_logical_coords);
+    // Terminate early if all data has been filled
+    if (std::all_of(filled_data.begin(), filled_data.end(),
+                    [](const bool filled) { return filled; })) {
+      all_data_filled = true;
+    }
+  }
+  return result;
+}
+
+// Generate instantiations
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data)                                                  \
+  template std::vector<std::vector<double>> interpolate_to_points<DIM(data)>( \
+      const std::variant<std::vector<std::string>, std::string>&              \
+          volume_files_or_glob,                                               \
+      std::string subfile_name, int observation_step,                         \
+      const std::vector<std::string>& tensor_components,                      \
+      const std::array<std::vector<double>, DIM(data)>& target_points,        \
+      const std::optional<size_t> num_threads);
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
+
+#undef INSTANTIATE
+#undef DIM
+
+}  // namespace spectre::Exporter
+
+#pragma GCC diagnostic pop

--- a/src/IO/Exporter/Exporter.hpp
+++ b/src/IO/Exporter/Exporter.hpp
@@ -1,0 +1,52 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+/// \file
+/// Declares functions for interpolating data in volume files to target points.
+/// This file is intended to be included in external programs, so it
+/// intentionally has no dependencies on any other headers.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <optional>
+#include <string>
+#include <variant>
+#include <vector>
+
+namespace spectre::Exporter {
+
+/*!
+ * \brief Interpolate data in volume files to target points
+ *
+ * \tparam Dim Dimension of the domain
+ * \param volume_files_or_glob The list of H5 files, or a glob pattern
+ * \param subfile_name The name of the subfile in the H5 files containing the
+ * volume data
+ * \param observation_step The index of the observation in the volume files
+ * to interpolate. A value of 0 would be the first observation, and a value of
+ * -1 would be the last observation.
+ * \param tensor_components The tensor components to interpolate, e.g.
+ * "Lapse", "Shift_x", "Shift_y", "Shift_z", "SpatialMetric_xx", etc.
+ * Look into the H5 file to see what components are available.
+ * \param target_points The points to interpolate to, in inertial coordinates.
+ * \param num_threads The number of threads to use if OpenMP is linked in. If
+ * not specified, OpenMP will determine the number of threads automatically.
+ * It's also possible to set the number of threads using the environment
+ * variable OMP_NUM_THREADS. It's an error to specify num_threads if OpenMP is
+ * not linked in. Set num_threads to 1 to disable OpenMP.
+ * \return std::vector<std::vector<double>> The interpolated data. The first
+ * dimension corresponds to the selected tensor components, and the second
+ * dimension corresponds to the target points.
+ */
+template <size_t Dim>
+std::vector<std::vector<double>> interpolate_to_points(
+    const std::variant<std::vector<std::string>, std::string>&
+        volume_files_or_glob,
+    std::string subfile_name, int observation_step,
+    const std::vector<std::string>& tensor_components,
+    const std::array<std::vector<double>, Dim>& target_points,
+    std::optional<size_t> num_threads = std::nullopt);
+
+}  // namespace spectre::Exporter

--- a/src/IO/Exporter/Python/Bindings.cpp
+++ b/src/IO/Exporter/Python/Bindings.cpp
@@ -1,0 +1,55 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include <pybind11/numpy.h>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include "IO/Exporter/Exporter.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/ErrorHandling/SegfaultHandler.hpp"
+#include "Utilities/MakeArray.hpp"
+
+namespace py = pybind11;
+
+PYBIND11_MODULE(_Pybindings, m) {  // NOLINT
+  enable_segfault_handler();
+  m.def(
+      "interpolate_to_points",
+      [](const std::variant<std::vector<std::string>, std::string>&
+             volume_files_or_glob,
+         const std::string& subfile_name, int observation_step,
+         const std::vector<std::string>& tensor_components,
+         std::vector<std::vector<double>> target_points,
+         const std::optional<size_t>& num_threads) {
+        const size_t dim = target_points.size();
+        if (dim == 1) {
+          return spectre::Exporter::interpolate_to_points(
+              volume_files_or_glob, subfile_name, observation_step,
+              tensor_components,
+              make_array<std::vector<double>, 1>(std::move(target_points)),
+              num_threads);
+        } else if (dim == 2) {
+          return spectre::Exporter::interpolate_to_points(
+              volume_files_or_glob, subfile_name, observation_step,
+              tensor_components,
+              make_array<std::vector<double>, 2>(std::move(target_points)),
+              num_threads);
+        } else if (dim == 3) {
+          return spectre::Exporter::interpolate_to_points(
+              volume_files_or_glob, subfile_name, observation_step,
+              tensor_components,
+              make_array<std::vector<double>, 3>(std::move(target_points)),
+              num_threads);
+        } else {
+          ERROR("Invalid dimension of target points: "
+                << dim
+                << ". Must be 1, 2, or 3. The first dimension of the "
+                   "target points must the spatial dimension of the volume "
+                   "data, and the second dimension is the number of points.");
+        }
+      },
+      py::arg("volume_files_or_glob"), py::arg("subfile_name"),
+      py::arg("observation_step"), py::arg("tensor_components"),
+      py::arg("target_points"), py::arg("num_threads") = std::nullopt);
+}

--- a/src/IO/Exporter/Python/CMakeLists.txt
+++ b/src/IO/Exporter/Python/CMakeLists.txt
@@ -11,6 +11,7 @@ spectre_python_add_module(
   Bindings.cpp
   PYTHON_FILES
   __init__.py
+  InterpolateToPoints.py
 )
 
 spectre_python_link_libraries(

--- a/src/IO/Exporter/Python/CMakeLists.txt
+++ b/src/IO/Exporter/Python/CMakeLists.txt
@@ -1,0 +1,23 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBRARY "PyExporter")
+
+spectre_python_add_module(
+  Exporter
+  MODULE_PATH "IO"
+  LIBRARY_NAME ${LIBRARY}
+  SOURCES
+  Bindings.cpp
+  PYTHON_FILES
+  __init__.py
+)
+
+spectre_python_link_libraries(
+  ${LIBRARY}
+  PRIVATE
+  ErrorHandling
+  Exporter
+  pybind11::module
+  Utilities
+  )

--- a/src/IO/Exporter/Python/InterpolateToPoints.py
+++ b/src/IO/Exporter/Python/InterpolateToPoints.py
@@ -25,7 +25,7 @@ def parse_points(ctx, param, values):
     return np.array(points)
 
 
-@click.command(name="interpolate-to-coords")
+@click.command(name="interpolate-to-points")
 @click.argument(
     "h5_files",
     nargs=-1,
@@ -112,7 +112,7 @@ def parse_points(ctx, param, values):
         " has an effect if multiple files are specified."
     ),
 )
-def interpolate_to_coords_command(
+def interpolate_to_points_command(
     h5_files,
     subfile_name,
     list_vars,
@@ -228,4 +228,4 @@ def interpolate_to_coords_command(
 
 
 if __name__ == "__main__":
-    interpolate_to_coords_command(help_option_names=["-h", "--help"])
+    interpolate_to_points_command(help_option_names=["-h", "--help"])

--- a/src/IO/Exporter/Python/__init__.py
+++ b/src/IO/Exporter/Python/__init__.py
@@ -1,0 +1,4 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+from ._Pybindings import *

--- a/src/Visualization/Python/CMakeLists.txt
+++ b/src/Visualization/Python/CMakeLists.txt
@@ -8,7 +8,6 @@ spectre_python_add_module(
   PYTHON_FILES
   __init__.py
   GenerateXdmf.py
-  InterpolateToCoords.py
   InterpolateToMesh.py
   PlotDatFile.py
   PlotPowerMonitors.py

--- a/support/Python/__main__.py
+++ b/support/Python/__main__.py
@@ -28,8 +28,8 @@ class Cli(click.MultiCommand):
             "extract-dat",
             "extract-input",
             "generate-xdmf",
-            "interpolate-to-coords",
             "interpolate-to-mesh",
+            "interpolate-to-points",
             "plot-dat",
             "plot-power-monitors",
             "render-1d",
@@ -80,12 +80,12 @@ class Cli(click.MultiCommand):
             from spectre.Visualization.GenerateXdmf import generate_xdmf_command
 
             return generate_xdmf_command
-        elif name == "interpolate-to-coords":
-            from spectre.Visualization.InterpolateToCoords import (
-                interpolate_to_coords_command,
+        elif name in ["interpolate-to-points", "interpolate-to-coords"]:
+            from spectre.IO.Exporter.InterpolateToPoints import (
+                interpolate_to_points_command,
             )
 
-            return interpolate_to_coords_command
+            return interpolate_to_points_command
         elif name == "interpolate-to-mesh":
             from spectre.Visualization.InterpolateToMesh import (
                 interpolate_to_mesh_command,

--- a/tests/Unit/IO/CMakeLists.txt
+++ b/tests/Unit/IO/CMakeLists.txt
@@ -19,6 +19,7 @@ target_link_libraries(
   Utilities
   )
 
+add_subdirectory(Exporter)
 add_subdirectory(External)
 add_subdirectory(H5)
 add_subdirectory(Importers)

--- a/tests/Unit/IO/Exporter/BundledExporter/CMakeLists.txt
+++ b/tests/Unit/IO/Exporter/BundledExporter/CMakeLists.txt
@@ -1,0 +1,48 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+# This is a standalone CMake project to test the SpECTRE exporter library in an
+# external project. It is not part of the SpECTRE build system.
+#
+# Instructions to build this project:
+# - Configure a build directory and set the `SPECTRE_ROOT` variable to the
+#   directory containing the compiled SpECTRE libraries, e.g. the build
+#   directory of the SpECTRE project:
+#
+#   mkdir build && cd build
+#   cmake -D SPECTRE_ROOT=/path/to/spectre/build/directory /path/to/this/project
+#
+# - Build and run the test executable:
+#
+#   make
+#   ./TestSpectreExporter --help
+
+cmake_minimum_required(VERSION 3.18)
+project(TestSpectreExporter)
+
+set(CMAKE_CXX_STANDARD 17)
+
+# Find SpECTRE exporter lib
+find_library(
+  SPECTRE_EXPORTER_LIB
+  NAMES BundledExporter
+  PATH_SUFFIXES lib
+  PATHS ${SPECTRE_ROOT})
+find_path(
+  SPECTRE_EXPORTER_INCLUDE_DIR
+  NAMES spectre/Exporter.hpp
+  PATH_SUFFIXES include
+  PATHS ${SPECTRE_ROOT})
+add_library(spectre::Exporter UNKNOWN IMPORTED)
+set_target_properties(
+  spectre::Exporter
+  PROPERTIES IMPORTED_LOCATION ${SPECTRE_EXPORTER_LIB}
+             INTERFACE_INCLUDE_DIRECTORIES ${SPECTRE_EXPORTER_INCLUDE_DIR})
+
+# Find external libs
+find_package(HDF5 REQUIRED COMPONENTS C)
+find_package(BLAS REQUIRED)
+
+# Define test executable
+add_executable(TestSpectreExporter Test_BundledExporter.cpp)
+target_link_libraries(TestSpectreExporter PRIVATE spectre::Exporter)

--- a/tests/Unit/IO/Exporter/BundledExporter/Test_BundledExporter.cpp
+++ b/tests/Unit/IO/Exporter/BundledExporter/Test_BundledExporter.cpp
@@ -1,0 +1,40 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include <cmath>
+#include <iostream>
+#include <string>
+
+#include <spectre/Exporter.hpp>
+
+int main(int argc, char** argv) {
+  // Parse CLI arguments
+  // NOLINTBEGIN(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+  if (argc != 9) {
+    std::cerr << "Usage: " << argv[0]
+              << " FILES_GLOB_PATTERN SUBFILE_NAME STEP FIELD X Y Z EXPECTED"
+              << std::endl;
+    return 1;
+  }
+  const std::string files_glob_pattern = argv[1];
+  const std::string subfile_name = argv[2];
+  const int step = std::stoi(argv[3]);
+  const std::string field = argv[4];
+  const double x = std::stod(argv[5]);
+  const double y = std::stod(argv[6]);
+  const double z = std::stod(argv[7]);
+  const double expected = std::stod(argv[8]);
+  // NOLINTEND(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+  // Interpolate data
+  const auto interpolated_data = spectre::Exporter::interpolate_to_points<3>(
+      files_glob_pattern, subfile_name, step, {field}, {{{x}, {y}, {z}}});
+  const double result = interpolated_data[0][0];
+  // Check result
+  if (std::abs(result - expected) < 1.e-10) {
+    std::cout << "SUCCESS" << std::endl;
+    return 0;
+  } else {
+    std::cerr << "FAILURE. Result is: " << result << std::endl;
+    return 1;
+  }
+}

--- a/tests/Unit/IO/Exporter/CMakeLists.txt
+++ b/tests/Unit/IO/Exporter/CMakeLists.txt
@@ -15,3 +15,5 @@ target_link_libraries(
   Exporter
   Informer
   )
+
+add_subdirectory(Python)

--- a/tests/Unit/IO/Exporter/CMakeLists.txt
+++ b/tests/Unit/IO/Exporter/CMakeLists.txt
@@ -1,0 +1,17 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBRARY "Test_Exporter")
+
+set(LIBRARY_SOURCES
+  Test_Exporter.cpp
+  )
+
+add_test_library(${LIBRARY} "${LIBRARY_SOURCES}")
+
+target_link_libraries(
+  ${LIBRARY}
+  PRIVATE
+  Exporter
+  Informer
+  )

--- a/tests/Unit/IO/Exporter/Python/CMakeLists.txt
+++ b/tests/Unit/IO/Exporter/Python/CMakeLists.txt
@@ -1,0 +1,8 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+spectre_add_python_bindings_test(
+  "Unit.IO.Exporter.Python.InterpolateToPoints"
+  Test_InterpolateToPoints.py
+  "unit;python"
+  PyExporter)

--- a/tests/Unit/IO/Exporter/Python/Test_InterpolateToPoints.py
+++ b/tests/Unit/IO/Exporter/Python/Test_InterpolateToPoints.py
@@ -10,15 +10,15 @@ import numpy.testing as npt
 from click.testing import CliRunner
 
 from spectre.Informer import unit_test_build_path, unit_test_src_path
-from spectre.Visualization.InterpolateToCoords import (
-    interpolate_to_coords_command,
+from spectre.IO.Exporter.InterpolateToPoints import (
+    interpolate_to_points_command,
 )
 
 
-class TestInterpolateToCoords(unittest.TestCase):
+class TestInterpolateToPoints(unittest.TestCase):
     def setUp(self):
         self.test_dir = os.path.join(
-            unit_test_build_path(), "Visualization", "InterpolateToCoords"
+            unit_test_build_path(), "Visualization", "InterpolateToPoints"
         )
         self.h5_filename = os.path.join(
             unit_test_src_path(), "Visualization/Python", "VolTestData0.h5"
@@ -31,7 +31,7 @@ class TestInterpolateToCoords(unittest.TestCase):
     def test_cli(self):
         runner = CliRunner()
         result = runner.invoke(
-            interpolate_to_coords_command,
+            interpolate_to_points_command,
             [
                 self.h5_filename,
                 "-d",
@@ -53,7 +53,7 @@ class TestInterpolateToCoords(unittest.TestCase):
         np.savetxt(coords_file, coords)
         result_file = os.path.join(self.test_dir, "result.txt")
         result = runner.invoke(
-            interpolate_to_coords_command,
+            interpolate_to_points_command,
             [
                 self.h5_filename,
                 "-d",

--- a/tests/Unit/IO/Exporter/Test_Exporter.cpp
+++ b/tests/Unit/IO/Exporter/Test_Exporter.cpp
@@ -1,0 +1,26 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include "IO/Exporter/Exporter.hpp"
+#include "Informer/InfoFromBuild.hpp"
+
+namespace spectre::Exporter {
+
+SPECTRE_TEST_CASE("Unit.IO.Exporter", "[Unit]") {
+  const auto interpolated_data = interpolate_to_points<3>(
+      unit_test_src_path() + "/Visualization/Python/VolTestData*.h5",
+      "element_data", 0, {"Psi", "Phi_x", "Phi_y", "Phi_z"},
+      {{{0.0, 1.0, 0.0}, {0.0, 0.0, 1.0}, {0.0, 0.0, 0.0}}});
+  const auto& psi = interpolated_data[0];
+  CHECK(psi[0] == approx(-0.07059806932542323));
+  CHECK(psi[1] == approx(0.7869554122196492));
+  CHECK(psi[2] == approx(0.9876185584100299));
+  const auto& phi_y = interpolated_data[2];
+  CHECK(phi_y[0] == approx(1.0569673471948728));
+  CHECK(phi_y[1] == approx(0.6741524090220188));
+  CHECK(phi_y[2] == approx(0.2629752479142838));
+}
+
+}  // namespace spectre::Exporter

--- a/tests/Unit/Visualization/Python/CMakeLists.txt
+++ b/tests/Unit/Visualization/Python/CMakeLists.txt
@@ -61,12 +61,6 @@ if(${BUILD_PYTHON_BINDINGS})
 endif()
 
 spectre_add_python_bindings_test(
-  "Unit.Visualization.Python.InterpolateToCoords"
-  Test_InterpolateToCoords.py
-  "unit;visualization;python"
-  None)
-
-spectre_add_python_bindings_test(
   "Unit.Visualization.Python.InterpolateToMesh"
   Test_InterpolateToMesh.py
   "unit;visualization;python"

--- a/tests/Unit/Visualization/Python/Test_InterpolateToCoords.py
+++ b/tests/Unit/Visualization/Python/Test_InterpolateToCoords.py
@@ -9,10 +9,8 @@ import numpy as np
 import numpy.testing as npt
 from click.testing import CliRunner
 
-import spectre.IO.H5 as spectre_h5
 from spectre.Informer import unit_test_build_path, unit_test_src_path
 from spectre.Visualization.InterpolateToCoords import (
-    interpolate_to_coords,
     interpolate_to_coords_command,
 )
 
@@ -29,20 +27,6 @@ class TestInterpolateToCoords(unittest.TestCase):
 
     def tearDown(self):
         shutil.rmtree(self.test_dir)
-
-    def test_interpolate_to_coords(self):
-        open_h5_file = spectre_h5.H5File(self.h5_filename, "r")
-        volfile = open_h5_file.get_vol("/element_data")
-        obs_id = volfile.list_observation_ids()[0]
-        # Domain is [0, 2 pi]^3, so we check the endpoints
-        coords = np.array([3 * [0.0], 3 * [2 * np.pi]])
-        (psi,) = interpolate_to_coords(
-            volfile,
-            obs_id=obs_id,
-            tensor_components=["Psi"],
-            target_coords=coords,
-        )
-        npt.assert_allclose(psi, [-0.07059807, -0.06781784])
 
     def test_cli(self):
         runner = CliRunner()

--- a/tools/CheckFiles.sh
+++ b/tools/CheckFiles.sh
@@ -27,7 +27,10 @@ ci_checks=()
 # Check for iostream header
 # (Checked in CI only to allow local debugging-related commits)
 iostream() {
-    is_c++ "$1" && grep -q '#include <iostream>' "$1"
+    is_c++ "$1" \
+     && whitelist "$1" \
+                  'tests/Unit/IO/Exporter/BundledExporter/Test_BundledExporter.cpp$' \
+     && grep -q '#include <iostream>' "$1"
 }
 iostream_report() {
     echo "Found iostream header:"
@@ -122,6 +125,7 @@ check_cmakelists_for_extra_cxx() {
                                                         'tests' \
                                                         'tools' \
                                                         'Executables' \
+                                                        'Exporter' \
                                                         'Python'; then
         matches=$(grep -E "^  .*\.[cht]pp" $1)
         for match in $matches; do


### PR DESCRIPTION
## Proposed changes

Adds a function to interpolate volume data files to arbitrary points, which has two use cases:

1. Replaces the Python function with the same functionality. It's been used for things like generating data for paper plots. The new C++ implementation supports OpenMP parallelization over data files, which should make it faster for large data sets (@yoonso0-0 has complained about this). I haven't done a speed test yet. Happy to do so if someone has a suitable data set (@yoonso0-0?).
2. The library can be linked into external programs to load SpECTRE data, e.g. to load SpECTRE initial data into SpEC or other codes.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
The Python module `Visualization.InterpolateToCoords` has moved to `IO.Exporter.InterpolateToPoints`. It has a slightly different (easier) interface, is implemented in C++ now, and supports parallelization, which should make it considerably faster.
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
