### PR TITLE
Small Tov documentation typos

### DIFF
--- a/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/TovStar.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/TovStar.hpp
@@ -291,7 +291,7 @@ struct TovVariables {
  * \f{align*}
  * \alpha &= e^{\Phi_t} \\
  * \beta^i &= 0 \\
- * \gamma_{ij} &= \delta_{ij} e^{2 \Phi_r} + \delta_{im} \delta_{jn}
+ * \gamma_{ij} &= \delta_{ij} e^{2 \Phi_\Omega} + \delta_{im} \delta_{jn}
  * \frac{x^m x^n}{r^2} \left( e^{2 \Phi_r} - e^{2 \Phi_\Omega} \right)
  * \f}
  *
@@ -302,7 +302,7 @@ struct TovVariables {
  * potentials are
  *
  * \f{align}
- * e^{\Phi_r} &= \left(1 - \frac{2m}{r}\right)^{-1} \\
+ * e^{\Phi_r} &= \left(1 - \frac{2m}{r}\right)^{-1/2} \\
  * e^{\Phi_\Omega} &= 1
  * \f}
  *


### PR DESCRIPTION
## Proposed changes
In the TovStar documentation, this PR fixes an exponent for the expression of the radial metric potential (see Eq. 26.37 of Thorne & Blandford) and the expression of the spatial metric in Cartesian coordinates in terms of the angular metric potential, to match the calculations in TovStar.cpp.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
