### PR TITLE
Add CLI to plot size control diagnostics

### DIFF
--- a/src/Visualization/Python/CMakeLists.txt
+++ b/src/Visualization/Python/CMakeLists.txt
@@ -12,6 +12,7 @@ spectre_python_add_module(
   InterpolateToMesh.py
   PlotDatFile.py
   PlotPowerMonitors.py
+  PlotSizeControl.py
   plots.mplstyle
   ReadH5.py
   ReadInputFile.py

--- a/src/Visualization/Python/PlotSizeControl.py
+++ b/src/Visualization/Python/PlotSizeControl.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python
+
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import logging
+import os
+from typing import Optional, Sequence
+
+import click
+import h5py
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+
+from spectre.Visualization.ReadH5 import available_subfiles, to_dataframe
+
+logger = logging.getLogger(__name__)
+
+
+@click.command(name="plot-size-control")
+@click.argument(
+    "reduction_files",
+    type=click.Path(exists=True, file_okay=True, dir_okay=False, readable=True),
+    nargs=-1,
+)
+@click.option(
+    "--object-label",
+    "-d",
+    required=True,
+    help=(
+        "Which object to plot. This is either 'A', 'B', or 'None'. 'None' is"
+        " used when there is only one black hole in the simulation."
+    ),
+)
+@click.option(
+    "--output",
+    "-o",
+    type=click.Path(file_okay=True, dir_okay=False, writable=True),
+    help=(
+        "Name of the output image. The '--object-label' will be added"
+        " automatically to the end of the output. Also the suffix '.pdf' will"
+        " be added if necessary. If unspecified, the plot is shown"
+        " interactively, which only works on machines with a window server."
+    ),
+)
+# Plotting options
+@click.option(
+    "--x-bounds",
+    type=float,
+    nargs=2,
+    help="The lower and upper bounds of the x-axis.",
+)
+@click.option(
+    "--x-label",
+    help="The label on the x-axis.",
+)
+@click.option(
+    "--title",
+    "-t",
+    help="Title of the graph.",
+)
+@click.option(
+    "--stylesheet",
+    "-s",
+    type=click.Path(exists=True, file_okay=True, dir_okay=False, readable=True),
+    envvar="SPECTRE_MPL_STYLESHEET",
+    help=(
+        "Select a matplotlib stylesheet for customization of the plot, such "
+        "as linestyle cycles, linewidth, fontsize, legend, etc. "
+        "The stylesheet can also be set with the 'SPECTRE_MPL_STYLESHEET' "
+        "environment variable."
+    ),
+)
+def plot_size_control_command(
+    reduction_files: Sequence[str],
+    object_label: str,
+    output: Optional[str],
+    x_bounds: Optional[Sequence[float]],
+    x_label: Optional[str],
+    title: Optional[str],
+    stylesheet,
+):
+    """
+    Plot diagnostic information regarding the Size control system.
+
+    This tool assumes there is a subfile in each of the "reduction-files" with
+    the path `/ControlSystems/Size{LABEL}/Diagnostics.dat`, where `{LABEL}` is
+    replaced with the "object-label" input option.
+    """
+    object_label = (
+        "" if object_label.lower() == "none" else object_label.upper()
+    )
+
+    def check_diagnostics_file(h5_filename):
+        with h5py.File(h5_filename, "r") as h5file:
+            # See src/ControlSystem/ControlErrors/Size.cpp for path
+            diagnostics_file_name = (
+                f"ControlSystems/Size{object_label}/Diagnostics.dat"
+            )
+            diagnostics_data = h5file.get(diagnostics_file_name)
+            if diagnostics_data is None:
+                raise click.UsageError(
+                    f"Unable to open diagnostic file '{diagnostics_file_name}'"
+                    f" from h5 file {h5_filename}. Available subfiles are:\n"
+                    f" {available_subfiles(h5file, extension='.dat')}"
+                )
+
+            return to_dataframe(diagnostics_data)
+
+    data = pd.concat(
+        check_diagnostics_file(reduction_file)
+        for reduction_file in reduction_files
+    )
+
+    # Restrict data to bounds
+    if x_bounds:
+        data = data[
+            (data["Time"] >= x_bounds[0]) & (data["Time"] <= x_bounds[1])
+        ]
+
+    # Apply stylesheet
+    if stylesheet is not None:
+        plt.style.use(stylesheet)
+
+    # Set up plots
+    fig, axes = plt.subplots(7, 1, sharex=True)
+
+    # Plot the selected quantities. Groupings are based both on relationship
+    # of quantities and also relative scales of quantities
+    times = data["Time"]
+    axes = list(axes)
+    # Damping times are sort of the odd ones out. Put it with control error but
+    # on a different y-axis
+    top1 = axes[0].plot(times, data["ControlError"], label="Control Error")
+    axes.append(axes[0].twinx())
+    top2 = axes[-1].plot(
+        times, data["DampingTime"], color="C1", label="Damping time"
+    )
+    top3 = axes[-1].plot(
+        times,
+        data["SmootherTimescale"],
+        color="C2",
+        label="Smooth damping time",
+    )
+    top_lines = top1 + top2 + top3
+    top_labels = [l.get_label() for l in top_lines]
+    axes[0].tick_params(axis="y", labelcolor="C0")
+
+    # State, and delta R
+    axes[1].plot(times, data["StateNumber"], label="State")
+    axes[1].plot(times, data["MinDeltaR"], label="Min Delta R")
+    axes[1].plot(times, data["AvgDeltaR"], label="Average Delta R")
+
+    # Relative delta R
+    axes[2].plot(times, data["MinRelativeDeltaR"], label="Min relative Delta R")
+    axes[2].plot(
+        times, data["AvgRelativeDeltaR"], label="Average relative Delta R"
+    )
+
+    # Char speeds
+    axes[3].plot(times, data["MinCharSpeed"], label="Min char speed")
+    axes[3].plot(
+        times, data["MinComovingCharSpeed"], label="Min comoving char speed"
+    )
+    axes[3].plot(times, data["TargetCharSpeed"], label="Target char speed")
+
+    # Zero crossing predictors
+    axes[4].plot(
+        times, data["CharSpeedCrossingTime"], label="Char speed crossing time"
+    )
+    axes[4].plot(
+        times,
+        data["ComovingCharSpeedCrossingTime"],
+        label="Comoving char speed crossing time",
+    )
+    axes[4].plot(
+        times, data["DeltaRCrossingTime"], label="Delta R crossing time"
+    )
+
+    # Lambda and horizon
+    axes[5].plot(times, data["FunctionOfTime"], label="Function of time")
+    axes[5].plot(times, data["HorizonCoef00"], label="Horizon coef 00")
+
+    # Time deriv of lambda and horizon
+    axes[6].plot(times, data["DtFunctionOfTime"], label="dtFunction of time")
+    axes[6].plot(
+        times, data["RawDtHorizonCoef00"], label="Raw dtHorizon coef 00"
+    )
+    axes[6].plot(
+        times, data["AveragedDtHorizonCoef00"], label="Avg dtHorizon coef 00"
+    )
+
+    # Configure the axes and legends
+    fig.set_size_inches(10, len(axes) * 2)
+    if x_label:
+        # Bottom plot. -1 is the second y-axis for top plot
+        axes[-2].set_xlabel(x_label)
+    if title:
+        plt.title(title)
+    for i in range(len(axes) - 1):
+        if i == 0:
+            axes[i].legend(
+                top_lines,
+                top_labels,
+                loc="center left",
+                bbox_to_anchor=(1.03, 0.5),
+            )
+        else:
+            axes[i].legend(loc="center left", bbox_to_anchor=(1, 0.5))
+
+    if output:
+        output = output.split(".pdf")[0]
+        if not output.endswith(f"{object_label}"):
+            output += f"{object_label}"
+        output += ".pdf"
+        fig.savefig(output, format="pdf", bbox_inches="tight")
+    else:
+        if not os.environ.get("DISPLAY"):
+            logger.warning(
+                "No 'DISPLAY' environment variable is configured so plotting "
+                "interactively is unlikely to work. Write the plot to a file "
+                "with the --output/-o option."
+            )
+        plt.show()
+
+
+if __name__ == "__main__":
+    plot_size_control_command(help_option_names=["-h", "--help"])

--- a/support/Python/__main__.py
+++ b/support/Python/__main__.py
@@ -32,6 +32,7 @@ class Cli(click.MultiCommand):
             "interpolate-to-mesh",
             "plot-dat",
             "plot-power-monitors",
+            "plot-size-control",
             "render-1d",
             "render-3d",
             "resubmit",
@@ -102,6 +103,12 @@ class Cli(click.MultiCommand):
             )
 
             return plot_power_monitors_command
+        elif name in ["plot-size", "plot-size-control"]:
+            from spectre.Visualization.PlotSizeControl import (
+                plot_size_control_command,
+            )
+
+            return plot_size_control_command
         elif name == "render-1d":
             from spectre.Visualization.Render1D import render_1d_command
 

--- a/tests/Unit/Visualization/Python/CMakeLists.txt
+++ b/tests/Unit/Visualization/Python/CMakeLists.txt
@@ -19,6 +19,12 @@ spectre_add_python_bindings_test(
   "unit;visualization;python"
   None)
 
+spectre_add_python_bindings_test(
+  "Unit.Visualization.Python.PlotSizeControl"
+  Test_PlotSizeControl.py
+  "unit;visualization;python"
+  None)
+
 if(${BUILD_PYTHON_BINDINGS})
   # Test is a bit slow because it writes a bunch of plot files to verify
   # the argument handling works.
@@ -29,6 +35,11 @@ if(${BUILD_PYTHON_BINDINGS})
     )
   set_tests_properties(
     "Unit.Visualization.Python.PlotPowerMonitors"
+    PROPERTIES
+    TIMEOUT 10
+    )
+  set_tests_properties(
+    "Unit.Visualization.Python.PlotSizeControl"
     PROPERTIES
     TIMEOUT 10
     )

--- a/tests/Unit/Visualization/Python/Test_PlotSizeControl.py
+++ b/tests/Unit/Visualization/Python/Test_PlotSizeControl.py
@@ -1,0 +1,128 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import os
+import shutil
+import unittest
+
+import numpy as np
+from click.testing import CliRunner
+
+import spectre.IO.H5 as spectre_h5
+from spectre.Informer import unit_test_build_path
+from spectre.Visualization.PlotSizeControl import plot_size_control_command
+
+
+class TestPlotSizeControl(unittest.TestCase):
+    def setUp(self):
+        self.work_dir = os.path.join(
+            unit_test_build_path(), "Visualization/PlotSize"
+        )
+        self.reductions_file_names = [
+            f"TestSizeReductions{i}.h5" for i in range(2)
+        ]
+        self.diagnostic_subfile_name = "/ControlSystems/SizeB/Diagnostics.dat"
+
+        shutil.rmtree(self.work_dir, ignore_errors=True)
+        os.makedirs(self.work_dir, exist_ok=True)
+
+        # Taken from src/ControlSystem/ControlErrors/Size.cpp
+        legend = [
+            "Time",
+            "ControlError",
+            "StateNumber",
+            "DiscontinuousChangeHasOccurred",
+            "FunctionOfTime",
+            "DtFunctionOfTime",
+            "HorizonCoef00",
+            "AveragedDtHorizonCoef00",
+            "RawDtHorizonCoef00",
+            "SmootherTimescale",
+            "MinDeltaR",
+            "MinRelativeDeltaR",
+            "AvgDeltaR",
+            "AvgRelativeDeltaR",
+            "ControlErrorDeltaR",
+            "TargetCharSpeed",
+            "MinCharSpeed",
+            "MinComovingCharSpeed",
+            "CharSpeedCrossingTime",
+            "ComovingCharSpeedCrossingTime",
+            "DeltaRCrossingTime",
+            "SuggestedTimescale",
+            "DampingTime",
+        ]
+        for reduction_file_name in self.reductions_file_names:
+            with spectre_h5.H5File(
+                os.path.join(self.work_dir, reduction_file_name), "w"
+            ) as open_h5_file:
+                diagnostic_subfile = open_h5_file.insert_dat(
+                    self.diagnostic_subfile_name,
+                    legend=legend,
+                    version=0,
+                )
+                # The numbers here don't have to be meaningful. We're just
+                # testing the plotting
+                for i in range(4):
+                    data = np.random.rand(len(legend))
+                    data[0] = float(i)
+                    diagnostic_subfile.append(data)
+
+        self.runner = CliRunner()
+
+    def tearDown(self):
+        shutil.rmtree(self.work_dir, ignore_errors=True)
+
+    def test_plot_size(self):
+        # Just one h5 file
+        result = self.runner.invoke(
+            plot_size_control_command,
+            [
+                os.path.join(self.work_dir, self.reductions_file_names[0]),
+                "-d",
+                "B",
+                "-o",
+                os.path.join(self.work_dir, "SingleFile"),
+                "--x-bounds",
+                "0.0",
+                "3.0",
+                "--x-label",
+                "Time (M)",
+                "--title",
+                "Size Control First File",
+            ],
+            catch_exceptions=False,
+        )
+
+        output_file_name = os.path.join(self.work_dir, "SingleFileB.pdf")
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertTrue(os.path.exists(output_file_name))
+
+        # Multiple h5 files
+        result = self.runner.invoke(
+            plot_size_control_command,
+            [
+                os.path.join(self.work_dir, self.reductions_file_names[0]),
+                os.path.join(self.work_dir, self.reductions_file_names[1]),
+                "-d",
+                "B",
+                "-o",
+                os.path.join(self.work_dir, "MultiFileB"),
+                "--x-bounds",
+                "0.0",
+                "3.0",
+                "--x-label",
+                "Time (M)",
+                "--title",
+                "Size Control Both Files",
+            ],
+            catch_exceptions=False,
+        )
+
+        output_file_name = os.path.join(self.work_dir, "MultiFileB.pdf")
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertTrue(os.path.exists(output_file_name))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Proposed changes

This is just a quick utility that plots most of the size control diagnostics necessary to quickly see what has gone wrong in a simulation. Not intended for a super detailed analysis, but you can change the x-range on the plot to zoom in on a specific time (and have the y-axes of all plots rescale accordingly)


To quickly plot size control diagnostics, try
```
spectre plot-size-control --object-label A --output SizeControlDiag --x-label "Time (M)" --title "AhA size control diagnostics" ReductionsFile.h5
```

This gives the result of [SizeControlDiagA.pdf](https://github.com/sxs-collaboration/spectre/files/14091278/SizeControlDiagA.pdf)


<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
