### PR TITLE
Add a executable to check if Parallel::printf is atomic

### DIFF
--- a/src/Parallel/Main.hpp
+++ b/src/Parallel/Main.hpp
@@ -160,15 +160,6 @@ class Main : public CBase_Main<Metavariables> {
   // current_termination_check_index_
   void check_if_component_terminated_correctly();
 
-  template <typename ParallelComponent>
-  using parallel_component_options = Parallel::get_option_tags<
-      typename ParallelComponent::simple_tags_from_options, Metavariables>;
-  using option_list = tmpl::remove_duplicates<tmpl::flatten<tmpl::list<
-      Parallel::OptionTags::ResourceInfo<Metavariables>,
-      Parallel::get_option_tags<const_global_cache_tags, Metavariables>,
-      Parallel::get_option_tags<mutable_global_cache_tags, Metavariables>,
-      tmpl::transform<component_list,
-                      tmpl::bind<parallel_component_options, tmpl::_1>>>>>;
   // Lists of all parallel component types
   using group_component_list =
       tmpl::filter<component_list, tmpl::or_<Parallel::is_group<tmpl::_1>,
@@ -185,6 +176,23 @@ class Main : public CBase_Main<Metavariables> {
                               Parallel::is_bound_array<tmpl::_1>>>;
   using singleton_component_list =
       tmpl::filter<component_list, Parallel::is_singleton<tmpl::_1>>;
+
+  template <typename ParallelComponent>
+  using parallel_component_options = Parallel::get_option_tags<
+      typename ParallelComponent::simple_tags_from_options, Metavariables>;
+  template <typename ArrayComponent>
+  using array_component_allocation_options =
+      Parallel::get_option_tags<typename ArrayComponent::array_allocation_tags,
+                                Metavariables>;
+  using option_list = tmpl::remove_duplicates<tmpl::flatten<tmpl::list<
+      Parallel::OptionTags::ResourceInfo<Metavariables>,
+      Parallel::get_option_tags<const_global_cache_tags, Metavariables>,
+      Parallel::get_option_tags<mutable_global_cache_tags, Metavariables>,
+      tmpl::transform<component_list,
+                      tmpl::bind<parallel_component_options, tmpl::_1>>,
+      tmpl::transform<
+          all_array_component_list,
+          tmpl::bind<array_component_allocation_options, tmpl::_1>>>>>;
 
   Parallel::Phase current_phase_{Parallel::Phase::Initialization};
   CProxy_GlobalCache<Metavariables> global_cache_proxy_;

--- a/tests/Unit/Parallel/CMakeLists.txt
+++ b/tests/Unit/Parallel/CMakeLists.txt
@@ -135,6 +135,8 @@ add_algorithm_test("DetectHangArray"
   "This means the executable stopped because of a hang/deadlock\.")
 add_algorithm_test("DynamicInsertion")
 add_algorithm_test("PhaseChangeMain")
+add_algorithm_test("AtomicPrintf"
+  INPUT_FILE "Test_AtomicPrintf.yaml")
 add_algorithm_test(
   "SectionReductions"
   REGEX_TO_MATCH

--- a/tests/Unit/Parallel/Test_AtomicPrintf.cpp
+++ b/tests/Unit/Parallel/Test_AtomicPrintf.cpp
@@ -1,0 +1,133 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include <array>
+
+#include "DataStructures/DataBox/Tag.hpp"
+#include "Helpers/Parallel/RoundRobinArrayElements.hpp"
+#include "Options/String.hpp"
+#include "Parallel/Algorithms/AlgorithmArray.hpp"
+#include "Parallel/CharmMain.tpp"
+#include "Parallel/GlobalCache.hpp"
+#include "Parallel/Phase.hpp"
+#include "Parallel/PhaseDependentActionList.hpp"
+#include "Parallel/Printf.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+namespace OptionTags {
+struct Lines {
+  using type = int;
+  static constexpr Options::String help{"Number of lines printed"};
+};
+struct NumberOfElements {
+  using type = int;
+  static constexpr Options::String help{"Number of elements"};
+};
+}  // namespace OptionTags
+
+namespace Tags {
+struct Lines : db::SimpleTag {
+  using type = int;
+  using option_tags = tmpl::list<OptionTags::Lines>;
+
+  static constexpr bool pass_metavariables = false;
+  static int create_from_options(const int lines) { return lines; }
+};
+struct NumberOfElements : db::SimpleTag {
+  using type = int;
+  using option_tags = tmpl::list<OptionTags::NumberOfElements>;
+
+  static constexpr bool pass_metavariables = false;
+  static int create_from_options(const int number_of_elements) {
+    return number_of_elements;
+  }
+};
+}  // namespace Tags
+
+namespace Actions {
+struct PrintMessage {
+  template <typename ParallelComponent, typename DbTags, typename Metavariables,
+            typename ArrayIndex>
+  static void apply(db::DataBox<DbTags>& box,
+                    const Parallel::GlobalCache<Metavariables>& cache,
+                    const ArrayIndex& /*array_index*/) {
+    std::stringstream ss{};
+    const auto id = db::get<Parallel::Tags::ArrayIndex>(box);
+    const auto lines = Parallel::get<Tags::Lines>(cache);
+    const auto my_proc = sys::my_proc();
+    const auto my_node = sys::my_node();
+    ss << "Begin atomic print by " << id << " on process " << my_proc
+       << " on node " << my_node << "\n";
+    for (int i = 0; i < lines; ++i) {
+      ss << "Print by " << id << " on process " << my_proc << " on node "
+         << my_node << "\n";
+    }
+    ss << "End atomic print by " << id << " on process " << my_proc
+       << " on node " << my_node << "\n";
+    Parallel::printf("\n%s\n", ss.str());
+  }
+};
+}  // namespace Actions
+
+template <class Metavariables>
+struct TestArray {
+  using chare_type = Parallel::Algorithms::Array;
+  using metavariables = Metavariables;
+  using array_index = int;
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<Parallel::Phase::Initialization, tmpl::list<>>>;
+  using simple_tags_from_options = Parallel::get_simple_tags_from_options<
+      Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
+  using array_allocation_tags = tmpl::list<Tags::NumberOfElements>;
+
+  static void allocate_array(
+      Parallel::CProxy_GlobalCache<Metavariables>& global_cache,
+      const tuples::tagged_tuple_from_typelist<simple_tags_from_options>&
+      /*initialization_items*/,
+      const tuples::tagged_tuple_from_typelist<array_allocation_tags>&
+          array_allocation_items = {},
+      const std::unordered_set<size_t>& procs_to_ignore = {}) {
+    auto& local_cache = *Parallel::local_branch(global_cache);
+    auto& array_proxy =
+        Parallel::get_parallel_component<TestArray>(local_cache);
+    const auto number_of_elements =
+        tuples::get<Tags::NumberOfElements>(array_allocation_items);
+    TestHelpers::Parallel::assign_array_elements_round_robin_style(
+        array_proxy, static_cast<size_t>(number_of_elements),
+        static_cast<size_t>(sys::number_of_procs()), {}, global_cache,
+        procs_to_ignore);
+  }
+
+  static void execute_next_phase(
+      const Parallel::Phase next_phase,
+      Parallel::CProxy_GlobalCache<Metavariables>& global_cache) {
+    auto& local_cache = *Parallel::local_branch(global_cache);
+    auto& my_proxy = Parallel::get_parallel_component<TestArray>(local_cache);
+    my_proxy.start_phase(next_phase);
+    if (next_phase == Parallel::Phase::Execute) {
+      Parallel::simple_action<Actions::PrintMessage>(my_proxy);
+    }
+  }
+};
+
+struct TestMetavariables {
+  using component_list = tmpl::list<TestArray<TestMetavariables>>;
+  using const_global_cache_tags = tmpl::list<Tags::Lines>;
+
+  static constexpr Options::String help =
+      "An executable for testing atomic printing in parallel.";
+
+  static constexpr auto default_phase_order =
+      std::array{Parallel::Phase::Initialization, Parallel::Phase::Execute,
+                 Parallel::Phase::Exit};
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& /*p*/) {}
+};
+}  // namespace
+
+extern "C" void CkRegisterMainModule() {
+  Parallel::charmxx::register_main_module<TestMetavariables>();
+  Parallel::charmxx::register_init_node_and_proc({}, {});
+}

--- a/tests/Unit/Parallel/Test_AtomicPrintf.yaml
+++ b/tests/Unit/Parallel/Test_AtomicPrintf.yaml
@@ -1,0 +1,12 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+---
+---
+
+ResourceInfo:
+  AvoidGlobalProc0: false
+
+Lines: 100
+
+NumberOfElements: 40


### PR DESCRIPTION
## Proposed changes

Also fix a bug when using `array_allocation_tags`

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

- runs as expected in parallel on my desktop for small numbers of lines/elements
- needs a script to check the output
- could easily be extended to multiple components