### PR TITLE
Add LTO support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,6 +99,7 @@ include(SetupFormaline)
 include(SetupGitHooks)
 include(SetBuildType)
 include(SetupPic)
+include(SetupLinkTimeOptimization)
 include(SetCxxStandard)
 include(StripSymbols)
 # We need Boost for InfoAtLink

--- a/cmake/SetupLinkTimeOptimization.cmake
+++ b/cmake/SetupLinkTimeOptimization.cmake
@@ -1,0 +1,22 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+option(SPECTRE_LTO "Use link-time optimization if available" OFF)
+
+include(CheckIPOSupported)
+check_ipo_supported(RESULT _RESULT OUTPUT _OUTPUT)
+if(_RESULT AND SPECTRE_LTO)
+  option(SPECTRE_LTO_CORES "Number of cores to use for LTO" OFF)
+  if (NOT SPECTRE_LTO_CORES)
+    set(SPECTRE_LTO_CORES "auto")
+  endif()
+  target_link_options(SpectreFlags
+    INTERFACE
+    -flto=${SPECTRE_LTO_CORES})
+  message(STATUS "Link-time optimizations enabled with ${SPECTRE_LTO_CORES}")
+else()
+  target_link_options(SpectreFlags
+    INTERFACE
+    -fno-lto)
+  message(STATUS "Link-time optimizations disable (no LTO)")
+endif()

--- a/docs/DevGuide/BuildSystem.md
+++ b/docs/DevGuide/BuildSystem.md
@@ -286,6 +286,12 @@ cmake -D FLAG1=OPT1 ... -D FLAGN=OPTN <SPECTRE_ROOT>
   - Minimum priority of input file tests to run. Possible values are: `low` (not
     usually run on CI), `normal` (run at least once on CI), `high` (run always
     on CI). (default is `normal`)
+- SPECTRE_LTO
+  - Enable link-time optimization if the compiler supports it.
+- SPECTRE_LTO_CORES
+  - Specifies the number of cores to use for parallelizing LTO. Must be a
+    positive integer or "auto". This is only available when `SPECTRE_LTO=ON` and
+    the compiler supports LTO.
 - SPECTRE_TEST_RUNNER
   - Run test executables through a wrapper.  This might be `charmrun`, for
     example.  (default is to not use one)


### PR DESCRIPTION
## Proposed changes

Explicitly disabling LTO silences warnings, and with this we can still explicitly enable LTO when we want it.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
