### PR TITLE
Fix bug in using allocation_array_tags

### DIFF
--- a/src/Parallel/Main.hpp
+++ b/src/Parallel/Main.hpp
@@ -160,15 +160,6 @@ class Main : public CBase_Main<Metavariables> {
   // current_termination_check_index_
   void check_if_component_terminated_correctly();
 
-  template <typename ParallelComponent>
-  using parallel_component_options = Parallel::get_option_tags<
-      typename ParallelComponent::simple_tags_from_options, Metavariables>;
-  using option_list = tmpl::remove_duplicates<tmpl::flatten<tmpl::list<
-      Parallel::OptionTags::ResourceInfo<Metavariables>,
-      Parallel::get_option_tags<const_global_cache_tags, Metavariables>,
-      Parallel::get_option_tags<mutable_global_cache_tags, Metavariables>,
-      tmpl::transform<component_list,
-                      tmpl::bind<parallel_component_options, tmpl::_1>>>>>;
   // Lists of all parallel component types
   using group_component_list =
       tmpl::filter<component_list, tmpl::or_<Parallel::is_group<tmpl::_1>,
@@ -185,6 +176,23 @@ class Main : public CBase_Main<Metavariables> {
                               Parallel::is_bound_array<tmpl::_1>>>;
   using singleton_component_list =
       tmpl::filter<component_list, Parallel::is_singleton<tmpl::_1>>;
+
+  template <typename ParallelComponent>
+  using parallel_component_options = Parallel::get_option_tags<
+      typename ParallelComponent::simple_tags_from_options, Metavariables>;
+  template <typename ArrayComponent>
+  using array_component_allocation_options =
+      Parallel::get_option_tags<typename ArrayComponent::array_allocation_tags,
+                                Metavariables>;
+  using option_list = tmpl::remove_duplicates<tmpl::flatten<tmpl::list<
+      Parallel::OptionTags::ResourceInfo<Metavariables>,
+      Parallel::get_option_tags<const_global_cache_tags, Metavariables>,
+      Parallel::get_option_tags<mutable_global_cache_tags, Metavariables>,
+      tmpl::transform<component_list,
+                      tmpl::bind<parallel_component_options, tmpl::_1>>,
+      tmpl::transform<
+          all_array_component_list,
+          tmpl::bind<array_component_allocation_options, tmpl::_1>>>>>;
 
   Parallel::Phase current_phase_{Parallel::Phase::Initialization};
   CProxy_GlobalCache<Metavariables> global_cache_proxy_;

--- a/tests/Unit/Parallel/CMakeLists.txt
+++ b/tests/Unit/Parallel/CMakeLists.txt
@@ -124,7 +124,8 @@ add_algorithm_test(
 from inside of an Action. This is only possible if the simple_action \
 function is not invoked via a proxy, which we do not allow.")
 add_algorithm_test("AlgorithmNodelock")
-add_algorithm_test("AlgorithmParallel")
+add_algorithm_test("AlgorithmParallel"
+  INPUT_FILE "Test_AlgorithmParallel.yaml")
 add_algorithm_test("AlgorithmReduction")
 add_algorithm_test("Callback")
 add_algorithm_test("DetectHangArray"

--- a/tests/Unit/Parallel/Test_AlgorithmParallel.yaml
+++ b/tests/Unit/Parallel/Test_AlgorithmParallel.yaml
@@ -1,0 +1,11 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+---
+---
+
+NumberOfElements: 14
+
+ResourceInfo:
+  AvoidGlobalProc0: false
+  Singletons: Auto


### PR DESCRIPTION
Add the allocation_array_tags to the list of options to be parsed, and modify a test so it would have caught the bug.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
