### PR TITLE
Terminate parallel GMRES when it diverges

### DIFF
--- a/src/DataStructures/DataBox/Prefixes.hpp
+++ b/src/DataStructures/DataBox/Prefixes.hpp
@@ -110,6 +110,15 @@ struct NormalDotNumericalFlux : db::PrefixTag, db::SimpleTag {
 };
 
 /// \ingroup DataBoxTagsGroup
+/// \brief Prefix indicating the value a quantity took in the previous iteration
+/// of the algorithm.
+template <typename Tag>
+struct Previous : db::PrefixTag, db::SimpleTag {
+  using type = typename Tag::type;
+  using tag = Tag;
+};
+
+/// \ingroup DataBoxTagsGroup
 /// \brief Prefix indicating the value a quantity will take on the
 /// next iteration of the algorithm.
 ///

--- a/src/NumericalAlgorithms/Convergence/Reason.cpp
+++ b/src/NumericalAlgorithms/Convergence/Reason.cpp
@@ -23,6 +23,8 @@ std::ostream& operator<<(std::ostream& os, const Reason& reason) {
       return os << "AbsoluteResidual";
     case Reason::RelativeResidual:
       return os << "RelativeResidual";
+    case Reason::Error:
+      return os << "Error";
     default:
       ERROR("Unknown convergence reason");
   }
@@ -43,13 +45,15 @@ Options::create_from_yaml<Convergence::Reason>::create<void>(
     return Convergence::Reason::AbsoluteResidual;
   } else if (type_read == get_output(Convergence::Reason::RelativeResidual)) {
     return Convergence::Reason::RelativeResidual;
+  } else if (type_read == get_output(Convergence::Reason::Error)) {
+    return Convergence::Reason::Error;
   }
   PARSE_ERROR(options.context(),
               "Failed to convert \""
-                  << type_read << "\" to Convergence::Reason. Must be one of '"
+                  << type_read << "\" to Convergence::Reason. Must be one of: '"
                   << get_output(Convergence::Reason::NumIterations) << "', '"
                   << get_output(Convergence::Reason::MaxIterations) << "', '"
-                  << get_output(Convergence::Reason::AbsoluteResidual)
-                  << "' or '"
-                  << get_output(Convergence::Reason::RelativeResidual) << "'.");
+                  << get_output(Convergence::Reason::AbsoluteResidual) << "', '"
+                  << get_output(Convergence::Reason::RelativeResidual) << "', '"
+                  << get_output(Convergence::Reason::Error) << "'.");
 }

--- a/src/NumericalAlgorithms/Convergence/Reason.hpp
+++ b/src/NumericalAlgorithms/Convergence/Reason.hpp
@@ -16,7 +16,7 @@ struct create_from_yaml;
 namespace Convergence {
 
 /*!
- * \brief The reason the algorithm has converged.
+ * \brief The reason the algorithm has converged or terminated.
  *
  * \see Convergence::Criteria
  */
@@ -29,7 +29,9 @@ enum class Reason {
   /// Residual converged below absolute tolerance
   AbsoluteResidual,
   /// Residual converged below relative tolerance
-  RelativeResidual
+  RelativeResidual,
+  /// An error occurred during the algorithm
+  Error
 };
 
 std::ostream& operator<<(std::ostream& os, const Reason& reason);

--- a/tests/Unit/DataStructures/DataBox/Test_DataBoxPrefixes.cpp
+++ b/tests/Unit/DataStructures/DataBox/Test_DataBoxPrefixes.cpp
@@ -54,6 +54,7 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataBox.Prefixes",
   TestHelpers::db::test_prefix_tag<Tags::NormalDotNumericalFlux<Tag>>(
       "NormalDotNumericalFlux(Tag)");
   // [normal_dot_numerical_flux_name]
+  TestHelpers::db::test_prefix_tag<Tags::Previous<Tag>>("Previous(Tag)");
   // [next_name]
   TestHelpers::db::test_prefix_tag<Tags::Next<Tag>>("Next(Tag)");
   // [next_name]

--- a/tests/Unit/NumericalAlgorithms/Convergence/Test_HasConverged.cpp
+++ b/tests/Unit/NumericalAlgorithms/Convergence/Test_HasConverged.cpp
@@ -98,6 +98,21 @@ SPECTRE_TEST_CASE("Unit.Numerical.Convergence.HasConverged",
     test_copy_semantics(has_converged);
   }
 
+  {
+    INFO("HasConverged - error");
+    const Convergence::HasConverged has_converged{Convergence::Reason::Error,
+                                                  "Something went wrong!", 2};
+    CHECK(has_converged);
+    CHECK(has_converged.reason() == Convergence::Reason::Error);
+    CHECK(has_converged.error_message() == "Something went wrong!");
+    CHECK(has_converged.num_iterations() == 2);
+    test_serialization(has_converged);
+    test_copy_semantics(has_converged);
+    CHECK_THROWS_WITH(
+        has_converged.check_for_error(),
+        Catch::Matchers::ContainsSubstring("Something went wrong!"));
+  }
+
 #ifdef SPECTRE_DEBUG
   CHECK_THROWS_WITH(
       ([]() {

--- a/tests/Unit/NumericalAlgorithms/Convergence/Test_Reason.cpp
+++ b/tests/Unit/NumericalAlgorithms/Convergence/Test_Reason.cpp
@@ -27,11 +27,13 @@ SPECTRE_TEST_CASE("Unit.Numerical.Convergence.Reason",
         "AbsoluteResidual");
   CHECK(get_output(Convergence::Reason::RelativeResidual) ==
         "RelativeResidual");
+  CHECK(get_output(Convergence::Reason::Error) == "Error");
 
   test_construct_from_options<Convergence::Reason::NumIterations>();
   test_construct_from_options<Convergence::Reason::MaxIterations>();
   test_construct_from_options<Convergence::Reason::AbsoluteResidual>();
   test_construct_from_options<Convergence::Reason::RelativeResidual>();
+  test_construct_from_options<Convergence::Reason::Error>();
 
   CHECK_THROWS_WITH(
       (TestHelpers::test_creation<Convergence::Reason>("Miracle")),


### PR DESCRIPTION
## Proposed changes

GMRES is guaranteed to decrease the residual monotonically, so it's an error when the residual increases.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
