### PR TITLE
Find ParaView properly in build system

### DIFF
--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -571,6 +571,7 @@ jobs:
           tar -xzf paraview.tar.gz
           rm paraview.tar.gz
           mv ParaView-* /opt/paraview
+          echo "/opt/paraview/bin" >> $GITHUB_PATH
           # Make 'paraview' Python package available
           PYTHONPATH=/opt/paraview/lib/python3.9/site-packages:$PYTHONPATH
           # Give system-installed Python packages priority over ParaView's

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,6 +145,7 @@ include(SetupLibsharp)
 include(SetupXsimd)
 include(SetupYamlCpp)
 include(SetupOpenMP)
+include(SetupParaView)
 
 include(SetupLIBCXXCharm)
 # The precompiled header must be setup after all libraries have been found

--- a/cmake/FindParaView.cmake
+++ b/cmake/FindParaView.cmake
@@ -1,0 +1,47 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+find_program(PVPYTHON_EXEC pvpython)
+
+# Get version and runtime environment variables
+if (PVPYTHON_EXEC)
+  execute_process(
+    COMMAND ${PVPYTHON_EXEC} --print --version
+    OUTPUT_VARIABLE _OUTPUT
+    ERROR_VARIABLE _OUTPUT
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_STRIP_TRAILING_WHITESPACE)
+  string(REPLACE "\n" ";" _OUTPUT "${_OUTPUT}")
+  list(LENGTH _OUTPUT _OUTPUT_LENGTH)
+  if (_OUTPUT_LENGTH EQUAL 1)
+    # '--print' is not supported, just get the version
+    list(GET _OUTPUT 0 PARAVIEW_VERSION)
+  elseif(_OUTPUT_LENGTH EQUAL 2)
+    # '--print' is supported, get the version and environment variables
+    list(GET _OUTPUT 0 PARAVIEW_PYTHON_ENV_VARS)
+    list(GET _OUTPUT 1 PARAVIEW_VERSION)
+  endif()
+  string(REPLACE "paraview version " "" PARAVIEW_VERSION "${PARAVIEW_VERSION}")
+endif()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(ParaView
+  REQUIRED_VARS PVPYTHON_EXEC
+  VERSION_VAR PARAVIEW_VERSION)
+
+# Get Python environment variables
+execute_process(
+  COMMAND ${PVPYTHON_EXEC} -m paraview.inspect
+  OUTPUT_VARIABLE _OUTPUT
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+  RESULT_VARIABLE _RESULT
+  ERROR_QUIET)
+if (_RESULT EQUAL 0)
+  string(REPLACE "\n" ";" _OUTPUT "${_OUTPUT}")
+  list(GET _OUTPUT 0 PARAVIEW_PYTHON_VERSION)
+  list(GET _OUTPUT 1 PARAVIEW_PYTHONPATH)
+  string(REPLACE "version: " ""
+    PARAVIEW_PYTHON_VERSION "${PARAVIEW_PYTHON_VERSION}")
+  string(REPLACE "pythonpath entry: " ""
+    PARAVIEW_PYTHONPATH "${PARAVIEW_PYTHONPATH}")
+endif()

--- a/cmake/SetupDoxygen.cmake
+++ b/cmake/SetupDoxygen.cmake
@@ -77,9 +77,9 @@ function correctly. Use Doxygen version 1.9.3 or higher.")
     )
 
   include(FindPythonModule)
-  find_python_module(bs4 FALSE)
-  find_python_module(pybtex FALSE)
-  if (PY_BS4 AND PY_PYBTEX)
+  find_python_module(bs4)
+  find_python_module(pybtex)
+  if (PY_bs4_FOUND AND PY_pybtex_FOUND)
     # Construct the command that runs the postprocessing over the Doxygen HTML
     # output
     set(
@@ -104,17 +104,17 @@ ${CMAKE_SOURCE_DIR}/docs/Dependencies.bib"
 generate_docs_exit=$?\n\
 ${DOCS_POST_PROCESS_COMMAND} && exit \${generate_docs_exit}\n"
       )
-  else (PY_BS4 AND PY_PYBTEX)
+  else()
     message(WARNING "Doxygen documentation postprocessing is disabled because"
     " Python dependencies were not found:")
-    if (NOT PY_BS4)
+    if (NOT PY_bs4_FOUND)
       message(WARNING "BeautifulSoup4 missing. "
         "Install with: pip install beautifulsoup4")
     endif()
-    if (NOT PY_PYBTEX)
+    if (NOT PY_pybtex_FOUND)
       message(WARNING "Pybtex missing. Install with: pip install pybtex")
     endif()
-  endif (PY_BS4 AND PY_PYBTEX)
+  endif()
 
   # Parse the command into a CMake list for the `add_custom_target`
   separate_arguments(GENERATE_DOCS_COMMAND)
@@ -169,8 +169,8 @@ ${DOCS_POST_PROCESS_COMMAND} && exit \${generate_docs_exit}\n"
 
   # Use [coverxygen](https://github.com/psycofdj/coverxygen) to check the level
   # of documentation coverage.
-  find_python_module(coverxygen FALSE)
-  if (LCOV AND GENHTML AND SED AND PY_COVERXYGEN
+  find_python_module(coverxygen)
+  if (LCOV AND GENHTML AND SED AND PY_coverxygen_FOUND
       AND EXISTS ${CMAKE_SOURCE_DIR}/.git AND Git_FOUND)
     set(DOX_COVERAGE_OUTPUT "${CMAKE_BINARY_DIR}/docs/html/doc_coverage/")
     add_custom_target(
@@ -236,8 +236,7 @@ ${DOCS_POST_PROCESS_COMMAND} && exit \${generate_docs_exit}\n"
 
       COMMENT "SpECTRE Documentation Coverage"
       )
-  endif(LCOV AND GENHTML AND SED AND PY_COVERXYGEN
-    AND EXISTS ${CMAKE_SOURCE_DIR}/.git AND Git_FOUND)
+  endif()
 else(DOXYGEN_FOUND)
   message(WARNING "Doxygen is needed to build the documentation.")
 endif (DOXYGEN_FOUND)

--- a/cmake/SetupParaView.cmake
+++ b/cmake/SetupParaView.cmake
@@ -1,0 +1,13 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+option(ENABLE_PARAVIEW "Try to find ParaView to enable 3D rendering tools" ON)
+
+if (ENABLE_PARAVIEW)
+  find_package(ParaView)
+endif()
+
+# Help `find_python_module` find ParaView
+if (PARAVIEW_PYTHONPATH)
+  set(PY_paraview_LOCATION ${PARAVIEW_PYTHONPATH}/paraview)
+endif()

--- a/cmake/SetupPypp.cmake
+++ b/cmake/SetupPypp.cmake
@@ -24,7 +24,7 @@ file(APPEND
 
 # Also check that SciPy is installed
 include(FindPythonModule)
-find_python_module(scipy TRUE)
+find_python_module(scipy REQUIRED)
 
 add_library(Python::NumPy INTERFACE IMPORTED)
 set_property(TARGET Python::NumPy PROPERTY

--- a/cmake/SpectrePythonExecutable.sh
+++ b/cmake/SpectrePythonExecutable.sh
@@ -3,5 +3,5 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-PYTHONPATH="@PYTHONPATH@" @JEMALLOC_PRELOAD@ @Python_EXECUTABLE@ \
+PYTHONPATH="@PYTHONPATH@" @PYTHON_EXEC_ENV_VARS@ @Python_EXECUTABLE@ \
   @PYTHON_EXE_COMMAND@ "$@"

--- a/cmake/SpectreSetupPythonPackage.cmake
+++ b/cmake/SpectreSetupPythonPackage.cmake
@@ -32,9 +32,13 @@ configure_or_symlink_py_file(
 )
 # Also link the main entry point to bin/
 set(PYTHON_EXE_COMMAND "-m spectre")
-set(JEMALLOC_PRELOAD "")
+set(PYTHON_EXEC_ENV_VARS "")
 if(BUILD_PYTHON_BINDINGS AND "${JEMALLOC_LIB_TYPE}" STREQUAL SHARED)
-  set(JEMALLOC_PRELOAD "LD_PRELOAD=\${LD_PRELOAD}\${LD_PRELOAD:+:}${JEMALLOC_LIBRARIES}")
+  string(APPEND PYTHON_EXEC_ENV_VARS
+    " LD_PRELOAD=\${LD_PRELOAD}\${LD_PRELOAD:+:}${JEMALLOC_LIBRARIES}")
+endif()
+if(PARAVIEW_PYTHON_ENV_VARS)
+  string(APPEND PYTHON_EXEC_ENV_VARS " ${PARAVIEW_PYTHON_ENV_VARS}")
 endif()
 configure_file(
   "${CMAKE_SOURCE_DIR}/cmake/SpectrePythonExecutable.sh"

--- a/docs/DevGuide/BuildSystem.md
+++ b/docs/DevGuide/BuildSystem.md
@@ -244,6 +244,8 @@ cmake -D FLAG1=OPT1 ... -D FLAGN=OPTN <SPECTRE_ROOT>
   - Enable OpenMP parallelization in some parts of the code, such as Python
     bindings and interpolating volume data files. Note that simulations do not
     typically use OpenMP parallelization, so this flag only applies to tools.
+- ENABLE_PARAVIEW
+  - Try to find ParaView to enable 3D rendering tools (default is `ON`)
 - ENABLE_PROFILING
   - Enables various options to make profiling SpECTRE easier
     (default is `OFF`)

--- a/tests/Unit/Visualization/Python/Render3D/CMakeLists.txt
+++ b/tests/Unit/Visualization/Python/Render3D/CMakeLists.txt
@@ -1,10 +1,10 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-find_python_module(paraview FALSE)
+find_python_module(paraview)
 
 # Skip tests if ParaView is not found
-if (NOT PY_PARAVIEW)
+if (NOT PY_paraview_FOUND)
   message(STATUS "ParaView not found, skipping 'Render3D' tests")
   return()
 endif()


### PR DESCRIPTION
## Proposed changes

This fixes an issue with ParaView when using the new CaltechHPC environment from #5725. Specifically, it makes sure that ParaView uses its bundled libraries rather than the ones from the spectre build.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
