### PR TITLE
Fix a minus sign in puncture equations

### DIFF
--- a/src/Elliptic/Systems/Punctures/Sources.cpp
+++ b/src/Elliptic/Systems/Punctures/Sources.cpp
@@ -15,7 +15,7 @@ void add_sources(const gsl::not_null<Scalar<DataVector>*> puncture_equation,
                  const Scalar<DataVector>& alpha,
                  const Scalar<DataVector>& beta,
                  const Scalar<DataVector>& field) {
-  get(*puncture_equation) +=
+  get(*puncture_equation) -=
       get(beta) / pow<7>(get(alpha) * (get(field) + 1.) + 1.);
 }
 
@@ -24,7 +24,7 @@ void add_linearized_sources(
     const Scalar<DataVector>& alpha, const Scalar<DataVector>& beta,
     const Scalar<DataVector>& field,
     const Scalar<DataVector>& field_correction) {
-  get(*linearized_puncture_equation) -=
+  get(*linearized_puncture_equation) +=
       7. * get(alpha) * get(beta) /
       pow<8>(get(alpha) * (get(field) + 1.) + 1.) * get(field_correction);
 }

--- a/src/Elliptic/Systems/Punctures/Sources.hpp
+++ b/src/Elliptic/Systems/Punctures/Sources.hpp
@@ -22,7 +22,7 @@ namespace Punctures {
 /*!
  * \brief Add the nonlinear sources for the puncture equation.
  *
- * Adds $\beta \left(\alpha \left(1 + u\right) + 1\right)^{-7}$.
+ * Adds $-\beta \left(\alpha \left(1 + u\right) + 1\right)^{-7}$.
  *
  * \see Punctures
  */
@@ -34,7 +34,7 @@ void add_sources(gsl::not_null<Scalar<DataVector>*> puncture_equation,
 /*!
  * \brief Add the linearized sources for the puncture equation.
  *
- * Adds $\frac{d}{du}(\beta \left(\alpha \left(1 + u\right) + 1\right)^{-7})$.
+ * Adds $-\frac{d}{du}(\beta \left(\alpha \left(1 + u\right) + 1\right)^{-7})$.
  *
  * \see Punctures
  */

--- a/tests/Unit/Elliptic/Systems/Punctures/Equations.py
+++ b/tests/Unit/Elliptic/Systems/Punctures/Equations.py
@@ -3,12 +3,12 @@
 
 
 def sources(alpha, beta, field):
-    return beta * (alpha * (1.0 + field) + 1.0) ** (-7)
+    return -beta * (alpha * (1.0 + field) + 1.0) ** (-7)
 
 
 def linearized_sources(alpha, beta, field, field_correction):
     return (
-        -7.0
+        7.0
         * alpha
         * beta
         * (alpha * (1.0 + field) + 1.0) ** (-8)


### PR DESCRIPTION
## Proposed changes

The docs have the correct equation: Eq. (1) here https://spectre-code.org/namespacePunctures.html#details
The source term is moved to the LHS (because it depends on the field $u$ that is being solved for), so the term should have a minus sign.
I found this when comparing to the TwoPunctures code https://arxiv.org/abs/gr-qc/0404056. Can't really catch this in a unit test I think.
I can pretty easily reproduce their Fig. 5 now with nice exponential convergence.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
