### PR TITLE
Switch to C++ 20 (partially)

### DIFF
--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -848,12 +848,12 @@ ${{ matrix.build_type }}-pch-${{ matrix.use_pch || 'ON' }}"
       # We install some low-level dependencies with Homebrew. They get picked up
       # by `spack external find`.
       SPECTRE_BREW_DEPS: >-  # Line breaks are spaces, no trailing newline
-        autoconf automake catch2 ccache cmake pkg-config
+        autoconf automake catch2 ccache cmake pkg-config boost
       # We install these packages with Spack and cache them. The full specs are
       # listed in support/DevEnvironments/spack.yaml. This list is only needed
       # to create the cache.
       SPECTRE_SPACK_DEPS: >-
-        blaze boost brigand charmpp gsl hdf5 libsharp libxsmm openblas
+        blaze brigand charmpp gsl hdf5 libsharp libxsmm openblas
         py-pybind11 yaml-cpp
       CCACHE_DIR: $HOME/ccache
       CCACHE_TEMPDIR: $HOME/ccache-tmp
@@ -911,7 +911,7 @@ ${{ matrix.build_type }}-pch-${{ matrix.use_pch || 'ON' }}"
           source $HOME/spack/share/spack/setup-env.sh
           spack env create spectre support/DevEnvironments/spack.yaml
           spack env activate spectre
-          spack remove catch2 doxygen jemalloc
+          spack remove catch2 doxygen jemalloc boost
           spack concretize --reuse
           spack install --no-check-signature
           spack find -v

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [//]: # (See LICENSE.txt for details.)
 
 [![license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/sxs-collaboration/spectre/blob/develop/LICENSE.txt)
-[![Standard](https://img.shields.io/badge/c%2B%2B-17-blue.svg)](https://en.wikipedia.org/wiki/C%2B%2B#Standardization)
+[![Standard](https://img.shields.io/badge/c%2B%2B-20-blue.svg)](https://en.wikipedia.org/wiki/C%2B%2B#Standardization)
 [![Build Status](https://github.com/sxs-collaboration/spectre/workflows/Tests/badge.svg?branch=develop)](https://github.com/sxs-collaboration/spectre/actions)
 [![Coverage Status](https://coveralls.io/repos/github/sxs-collaboration/spectre/badge.svg?branch=develop)](https://coveralls.io/github/sxs-collaboration/spectre?branch=develop)
 [![codecov](https://codecov.io/gh/sxs-collaboration/spectre/branch/develop/graph/badge.svg)](https://codecov.io/gh/sxs-collaboration/spectre)

--- a/cmake/EnableWarnings.cmake
+++ b/cmake/EnableWarnings.cmake
@@ -44,6 +44,7 @@ if(${ENABLE_WARNINGS})
 -Wstack-protector;\
 -Wswitch-default;\
 -Wunreachable-code;\
+-Wno-gnu-zero-variadic-macro-arguments;\
 -Wwrite-strings" SpectreWarnings)
 endif()
 

--- a/cmake/SetCxxStandard.cmake
+++ b/cmake/SetCxxStandard.cmake
@@ -1,6 +1,6 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)

--- a/src/Evolution/Systems/Cce/AnalyticSolutions/RotatingSchwarzschild.hpp
+++ b/src/Evolution/Systems/Cce/AnalyticSolutions/RotatingSchwarzschild.hpp
@@ -67,10 +67,12 @@ struct RotatingSchwarzschild : public SphericalMetricData {
 
   // clang doesn't manage to use = default correctly in this case
   // NOLINTNEXTLINE(modernize-use-equals-default)
-  RotatingSchwarzschild(){};
+  RotatingSchwarzschild() {}
 
   RotatingSchwarzschild(double extraction_radius, double mass,
                         double frequency);
+
+  ~RotatingSchwarzschild() override = default;
 
   std::unique_ptr<WorldtubeData> get_clone() const override;
 

--- a/src/Evolution/Systems/Cce/AnalyticSolutions/SphericalMetricData.hpp
+++ b/src/Evolution/Systems/Cce/AnalyticSolutions/SphericalMetricData.hpp
@@ -50,6 +50,8 @@ struct SphericalMetricData : public WorldtubeData {
   explicit SphericalMetricData(const double extraction_radius)
       : WorldtubeData{extraction_radius} {}
 
+  ~SphericalMetricData() override = default;
+
   /*!
    * Computes the Jacobian
    * \f$\partial x_{\mathrm{Cartesian}}^j / \partial x_{\mathrm{spherical}}^i\f$

--- a/src/Evolution/Systems/Cce/AnalyticSolutions/WorldtubeData.hpp
+++ b/src/Evolution/Systems/Cce/AnalyticSolutions/WorldtubeData.hpp
@@ -94,12 +94,14 @@ struct WorldtubeData : public PUP::able {
 
   // clang doesn't manage to use = default correctly in this case
   // NOLINTNEXTLINE(modernize-use-equals-default)
-  WorldtubeData(){};
+  WorldtubeData() {}
 
   explicit WorldtubeData(const double extraction_radius)
       : extraction_radius_{extraction_radius} {}
 
   explicit WorldtubeData(CkMigrateMessage* msg) : PUP::able(msg) {}
+
+  ~WorldtubeData() override = default;
 
   virtual std::unique_ptr<WorldtubeData> get_clone() const = 0;
 

--- a/src/Time/TimeSteppers/LtsTimeStepper.hpp
+++ b/src/Time/TimeSteppers/LtsTimeStepper.hpp
@@ -50,14 +50,14 @@ class LtsTimeStepper : public virtual TimeStepper {
   template <typename LocalVars, typename RemoteVars, typename Coupling>
   using BoundaryHistoryType = TimeSteppers::BoundaryHistory<
       LocalVars, RemoteVars,
-      std::result_of_t<const Coupling&(LocalVars, RemoteVars)>>;
+      std::invoke_result_t<const Coupling&, LocalVars, RemoteVars>>;
 
   /// Return type of boundary-related functions.  The coupling returns
   /// the derivative of the variables, but this is multiplied by the
   /// time step so the return type should not have `dt` prefixes.
   template <typename LocalVars, typename RemoteVars, typename Coupling>
   using BoundaryReturn = db::unprefix_variables<
-      std::result_of_t<const Coupling&(LocalVars, RemoteVars)>>;
+      std::invoke_result_t<const Coupling&, LocalVars, RemoteVars>>;
 
 /// \cond
 #define LTS_TIME_STEPPER_DECLARE_VIRTUALS_IMPL(_, data)              \

--- a/src/Utilities/CachedFunction.hpp
+++ b/src/Utilities/CachedFunction.hpp
@@ -51,7 +51,7 @@ class CachedFunction {
 template <typename Input, template <typename...> class Map = std::unordered_map,
           typename... MapArgs, typename Function, typename... PassedMapArgs>
 auto make_cached_function(Function function, PassedMapArgs... map_args) {
-  using output = std::result_of_t<Function&(const Input&)>;
+  using output = std::invoke_result_t<Function&, const Input&>;
   return CachedFunction<Function, Map<std::decay_t<Input>,
                                       std::decay_t<output>,
                                       MapArgs...>>(

--- a/tests/Unit/DataStructures/DataBox/Test_DataBox.cpp
+++ b/tests/Unit/DataStructures/DataBox/Test_DataBox.cpp
@@ -3354,12 +3354,12 @@ struct BaseConsumerSimple : BaseConsumer, db::SimpleTag {
 struct BaseConsumerComputeFromSimple : BaseConsumerSimple, db::ComputeTag {
   using base = BaseConsumerSimple;
   using argument_tags = tmpl::list<BaseProviderSimple>;
-  static void function(gsl::not_null<int*>, int);
+  static void function(gsl::not_null<int*> /*result*/, int /*base_consumer*/) {}
 };
 struct BaseConsumerComputeFromBase : BaseConsumerSimple, db::ComputeTag {
   using base = BaseConsumerSimple;
   using argument_tags = tmpl::list<BaseProvider>;
-  static void function(gsl::not_null<int*>, int);
+  static void function(gsl::not_null<int*> /*result*/, int /*base_consumer*/) {}
 };
 struct ChainedConsumer : db::SimpleTag {
   using type = int;
@@ -3367,7 +3367,7 @@ struct ChainedConsumer : db::SimpleTag {
 struct ChainedConsumerCompute : ChainedConsumer, db::ComputeTag {
   using base = ChainedConsumer;
   using argument_tags = tmpl::list<BaseConsumer>;
-  static void function(gsl::not_null<int*>, int);
+  static void function(gsl::not_null<int*> /*result*/, int /*base_consumer*/) {}
 };
 
 using SimpleBox =

--- a/tests/Unit/Domain/Structure/Test_Direction.cpp
+++ b/tests/Unit/Domain/Structure/Test_Direction.cpp
@@ -104,12 +104,12 @@ void test_semantics() {
   check_cmp(Direction<3>::lower_eta(), Direction<3>::upper_eta());
   check_cmp(Direction<3>::upper_eta(), Direction<3>::lower_zeta());
   check_cmp(Direction<3>::lower_zeta(), Direction<3>::upper_zeta());
-  std::is_sorted(Direction<1>::all_directions().begin(),
-                 Direction<1>::all_directions().end());
-  std::is_sorted(Direction<2>::all_directions().begin(),
-                 Direction<2>::all_directions().end());
-  std::is_sorted(Direction<3>::all_directions().begin(),
-                 Direction<3>::all_directions().end());
+  CHECK(std::is_sorted(Direction<1>::all_directions().begin(),
+                       Direction<1>::all_directions().end()));
+  CHECK(std::is_sorted(Direction<2>::all_directions().begin(),
+                       Direction<2>::all_directions().end()));
+  CHECK(std::is_sorted(Direction<3>::all_directions().begin(),
+                       Direction<3>::all_directions().end()));
 }
 
 void test_helper_functions() {

--- a/tests/Unit/Framework/TestHelpers.hpp
+++ b/tests/Unit/Framework/TestHelpers.hpp
@@ -287,7 +287,7 @@ void check_cmp(const T& less, const U& greater) {
  * \requires direction be between 0 and VolumeDim
  */
 template <typename Invocable, size_t VolumeDim>
-std::result_of_t<const Invocable&(const std::array<double, VolumeDim>&)>
+std::invoke_result_t<const Invocable&, const std::array<double, VolumeDim>&>
 numerical_derivative(const Invocable& function,
                      const std::array<double, VolumeDim>& x,
                      const size_t direction, const double delta) {

--- a/tests/Unit/Utilities/ErrorHandling/Test_FloatingPointExceptions.cpp
+++ b/tests/Unit/Utilities/ErrorHandling/Test_FloatingPointExceptions.cpp
@@ -21,6 +21,7 @@
 // the arm64 architecture, so when building on Apple Silicon,
 // directly call the fpe_signal_handler in these tests so that they pass.
 
+#if not (defined(__APPLE__) and defined(__arm64__))
 namespace {
 // Compilers (both gcc and clang) seem prone to deciding that these
 // can't actually throw exceptions and then optimizing away the
@@ -53,6 +54,7 @@ namespace {
   throw std::runtime_error("wrong");
 }
 }  // namespace
+#endif
 
 SPECTRE_TEST_CASE("Unit.ErrorHandling.FloatingPointExceptions",
                   "[ErrorHandling][Unit]") {

--- a/tools/CharmModulePatches/src/Evolution/DiscontinuousGalerkin/Messages/BoundaryMessage_v7.0.0.decl.h.patch
+++ b/tools/CharmModulePatches/src/Evolution/DiscontinuousGalerkin/Messages/BoundaryMessage_v7.0.0.decl.h.patch
@@ -1,0 +1,13 @@
+diff --git a/src/Evolution/DiscontinuousGalerkin/Messages/BoundaryMessage.decl.h b/src/Evolution/DiscontinuousGalerkin/Messages/BoundaryMessage.decl.h
+index 7444066..317d095 100644
+--- a/src/Evolution/DiscontinuousGalerkin/Messages/BoundaryMessage.decl.h
++++ b/src/Evolution/DiscontinuousGalerkin/Messages/BoundaryMessage.decl.h
+@@ -38,7 +38,7 @@ template <size_t Dim> class CMessage_BoundaryMessage:public CkMessage{
+     void operator delete(void*p, size_t){dealloc(p);}
+     static void* alloc(int,size_t, int*, int, GroupDepNum);
+     static void dealloc(void *p);
+-    CMessage_BoundaryMessage <Dim> ();
++    CMessage_BoundaryMessage ();
+     static void *pack(BoundaryMessage <Dim>  *p);
+     static BoundaryMessage <Dim> * unpack(void* p);
+     void *operator new(size_t, const int);


### PR DESCRIPTION
## Proposed changes

- Small changes needed to be C++20 compatible
- Switch to C++20 as the standard
- We can't use all C++20 features because compilers haven't implemented them all yet. However, with our current requirements most features will be available.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
