### PR TITLE
Fix error in FindPythonModule

### DIFF
--- a/cmake/FindPythonModule.cmake
+++ b/cmake/FindPythonModule.cmake
@@ -31,7 +31,7 @@ function(find_python_module module)
   endif()
   # Make `find_package_handle_standard_args` error if the package is not found
   if(ARG_REQUIRED)
-    set(${module}_FIND_REQUIRED TRUE)
+    set(PY_${module}_FIND_REQUIRED TRUE)
   endif()
   find_package_handle_standard_args(PY_${module}
     REQUIRED_VARS PY_${module}_LOCATION)


### PR DESCRIPTION
Name of the variable was wrong, so
`find_package_handle_standard_args` didn't throw the error correctly.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
