### PR TITLE
Construct Klein-Gordon Cce data on the first hypersurface

### DIFF
--- a/src/Evolution/Systems/Cce/Actions/CMakeLists.txt
+++ b/src/Evolution/Systems/Cce/Actions/CMakeLists.txt
@@ -19,6 +19,7 @@ spectre_target_headers(
   InitializeCharacteristicEvolutionTime.hpp
   InitializeCharacteristicEvolutionVariables.hpp
   InitializeFirstHypersurface.hpp
+  InitializeKleinGordonFirstHypersurface.hpp
   InitializeKleinGordonVariables.hpp
   InitializeWorldtubeBoundary.hpp
   InsertInterpolationScriData.hpp

--- a/src/Evolution/Systems/Cce/Actions/InitializeKleinGordonFirstHypersurface.hpp
+++ b/src/Evolution/Systems/Cce/Actions/InitializeKleinGordonFirstHypersurface.hpp
@@ -1,0 +1,80 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "Evolution/Systems/Cce/OptionTags.hpp"
+#include "Evolution/Systems/Cce/Tags.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "Parallel/AlgorithmExecution.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "Time/Tags/TimeStepId.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace Cce::Actions {
+
+/*!
+ * \ingroup ActionsGroup
+ * \brief Given initial boundary data for the Klein-Gordon variable \f$\Psi\f$,
+ * computes its initial hypersurface data.
+ *
+ * \details This action is to be called after boundary data has been received,
+ * but before the time-stepping evolution loop. So, it should be either late in
+ * an initialization phase or early (before a `Actions::Goto` loop or similar)
+ * in the `Evolve` phase.
+ */
+struct InitializeKleinGordonFirstHypersurface {
+  using const_global_cache_tags =
+      tmpl::list<Tags::LMax, Tags::NumberOfRadialPoints>;
+
+  template <typename DbTags, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent>
+  static Parallel::iterable_action_return_t apply(
+      db::DataBox<DbTags>& box,
+      const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+      Parallel::GlobalCache<Metavariables>& /*cache*/,
+      const ArrayIndex& /*array_index*/, const ActionList /*meta*/,
+      const ParallelComponent* const /*meta*/) {
+    // In some contexts, this action may get re-run (e.g. self-start procedure)
+    // In those cases, we do not want to alter the existing hypersurface data,
+    // so we just exit. However, we do want to re-run the action each time
+    // the self start 'reset's from the beginning
+    if (db::get<::Tags::TimeStepId>(box).slab_number() > 0 or
+        not db::get<::Tags::TimeStepId>(box).is_at_slab_boundary()) {
+      return {Parallel::AlgorithmExecution::Continue, std::nullopt};
+    }
+
+    db::mutate<Tags::KleinGordonPsi>(
+        [](const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 0>>*>
+               kg_psi_volume,
+           const Scalar<SpinWeighted<ComplexDataVector, 0>>& boundary_kg_psi,
+           const size_t l_max, const size_t number_of_radial_points) {
+          const DataVector one_minus_y_collocation =
+              1.0 -
+              Spectral::collocation_points<Spectral::Basis::Legendre,
+                                           Spectral::Quadrature::GaussLobatto>(
+                  number_of_radial_points);
+
+          const size_t boundary_size =
+              Spectral::Swsh::number_of_swsh_collocation_points(l_max);
+
+          for (size_t i = 0; i < number_of_radial_points; i++) {
+            ComplexDataVector angular_view_kg_psi{
+                get(*kg_psi_volume).data().data() + boundary_size * i,
+                boundary_size};
+
+            // this gives psi = (boundary value) / r
+            angular_view_kg_psi =
+                get(boundary_kg_psi).data() * one_minus_y_collocation[i] / 2.;
+          }
+        },
+        make_not_null(&box),
+        db::get<Tags::BoundaryValue<Tags::KleinGordonPsi>>(box),
+        db::get<Tags::LMax>(box), db::get<Tags::NumberOfRadialPoints>(box));
+
+    return {Parallel::AlgorithmExecution::Continue, std::nullopt};
+  }
+};
+}  // namespace Cce::Actions

--- a/src/Evolution/Systems/Cce/Components/KleinGordonCharacteristicEvolution.hpp
+++ b/src/Evolution/Systems/Cce/Components/KleinGordonCharacteristicEvolution.hpp
@@ -5,6 +5,7 @@
 
 #include <type_traits>
 
+#include "Evolution/Systems/Cce/Actions/InitializeKleinGordonFirstHypersurface.hpp"
 #include "Evolution/Systems/Cce/Actions/InitializeKleinGordonVariables.hpp"
 #include "Evolution/Systems/Cce/Components/CharacteristicEvolution.hpp"
 #include "Evolution/Systems/Cce/KleinGordonSystem.hpp"
@@ -68,6 +69,7 @@ struct KleinGordonCharacteristicEvolution
       // iterations immediately following restarts
       Actions::InitializeFirstHypersurface<
           evolve_ccm, typename Metavariables::cce_boundary_component>,
+      Actions::InitializeKleinGordonFirstHypersurface,
       tmpl::conditional_t<
           tt::is_a_v<AnalyticWorldtubeBoundary,
                      typename Metavariables::cce_boundary_component>,
@@ -94,6 +96,7 @@ struct KleinGordonCharacteristicEvolution
                           evolution::Actions::RunEventsAndTriggers>,
       Actions::InitializeFirstHypersurface<
           evolve_ccm, typename Metavariables::cce_boundary_component>,
+      Actions::InitializeKleinGordonFirstHypersurface,
       tmpl::conditional_t<
           tt::is_a_v<AnalyticWorldtubeBoundary,
                      typename Metavariables::cce_boundary_component>,

--- a/tests/Unit/Evolution/Systems/Cce/Actions/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/CMakeLists.txt
@@ -14,6 +14,7 @@ set(LIBRARY_SOURCES
   Test_H5BoundaryCommunication.cpp
   Test_InitializeCharacteristicEvolution.cpp
   Test_InitializeKleinGordonCharacteristicEvolution.cpp
+  Test_InitializeKleinGordonFirstHypersurface.cpp
   Test_InitializeKleinGordonWorldtubeBoundary.cpp
   Test_InitializeWorldtubeBoundary.cpp
   Test_Psi0Matching.cpp

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_InitializeKleinGordonFirstHypersurface.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_InitializeKleinGordonFirstHypersurface.cpp
@@ -1,0 +1,118 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include "Evolution/Systems/Cce/Actions/InitializeKleinGordonFirstHypersurface.hpp"
+#include "Framework/ActionTesting.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "Helpers/NumericalAlgorithms/Spectral/SwshTestHelpers.hpp"
+#include "NumericalAlgorithms/Spectral/SwshFiltering.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace Cce {
+namespace {
+template <typename Metavariables>
+struct mock_kg_characteristic_evolution {
+  using simple_tags = db::AddSimpleTags<
+      ::Tags::Variables<tmpl::list<Tags::BoundaryValue<Tags::KleinGordonPsi>>>,
+      ::Tags::Variables<tmpl::list<Tags::KleinGordonPsi>>, ::Tags::TimeStepId>;
+
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = size_t;
+
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<
+          Parallel::Phase::Initialization,
+          tmpl::list<ActionTesting::InitializeDataBox<simple_tags>>>,
+      Parallel::PhaseActions<
+          Parallel::Phase::Evolve,
+          tmpl::list<Actions::InitializeKleinGordonFirstHypersurface>>>;
+};
+
+struct metavariables {
+  using component_list =
+      tmpl::list<mock_kg_characteristic_evolution<metavariables>>;
+};
+
+// This function tests that the action
+// `Actions::InitializeKleinGordonFirstHypersurface` can be correctly invoked.
+//
+// The action is invoked by a mock run time system, then the function checks
+// that the constructed hypersurface data (`computed_psi`) agree with what we
+// expect.
+template <typename Generator>
+void test_klein_gordon_first_hypersurface(const gsl::not_null<Generator*> gen) {
+  UniformCustomDistribution<size_t> sdist{7, 10};
+  const size_t l_max = sdist(*gen);
+  const size_t number_of_radial_points = sdist(*gen);
+  UniformCustomDistribution<double> coefficient_distribution{-2.0, 2.0};
+
+  using component = mock_kg_characteristic_evolution<metavariables>;
+
+  // generate boundary data for the Klein-Gordon variable
+  // (`kg_boundary_variable`)
+  SpinWeighted<ComplexModalVector, 0> generated_kg_boundary_modes{
+      Spectral::Swsh::size_of_libsharp_coefficient_vector(l_max)};
+  SpinWeighted<ComplexDataVector, 0> generated_kg_boundary_data{
+      Spectral::Swsh::size_of_libsharp_coefficient_vector(l_max)};
+  Spectral::Swsh::TestHelpers::generate_swsh_modes<0>(
+      make_not_null(&generated_kg_boundary_modes.data()), gen,
+      make_not_null(&coefficient_distribution), 1, l_max);
+  Spectral::Swsh::inverse_swsh_transform(
+      l_max, 1, make_not_null(&generated_kg_boundary_data),
+      generated_kg_boundary_modes);
+  // aggressive filter to make the uniformly generated random modes
+  // somewhat reasonable
+  Spectral::Swsh::filter_swsh_boundary_quantity(
+      make_not_null(&generated_kg_boundary_data), l_max, l_max / 2);
+
+  Variables<tmpl::list<Tags::BoundaryValue<Tags::KleinGordonPsi>>>
+      kg_boundary_variable{real(generated_kg_boundary_data.data())};
+
+  const size_t boundary_size =
+      Spectral::Swsh::number_of_swsh_collocation_points(l_max);
+  Variables<tmpl::list<Tags::KleinGordonPsi>> kg_variable_to_compute{
+      boundary_size * number_of_radial_points};
+
+  // required by the action
+  TimeStepId time_step_id{true, 0, Time{Slab{1.0, 2.0}, {0, 1}}};
+
+  // tests start here
+  ActionTesting::MockRuntimeSystem<metavariables> runner{
+      {l_max, number_of_radial_points}};
+  ActionTesting::emplace_component_and_initialize<component>(
+      &runner, 0, {kg_boundary_variable, kg_variable_to_compute, time_step_id});
+
+  runner.set_phase(Parallel::Phase::Evolve);
+  ActionTesting::next_action<component>(make_not_null(&runner), 0);
+  auto computed_psi =
+      ActionTesting::get_databox_tag<component, Tags::KleinGordonPsi>(runner,
+                                                                      0);
+
+  const DataVector one_minus_y_collocation =
+      1.0 - Spectral::collocation_points<Spectral::Basis::Legendre,
+                                         Spectral::Quadrature::GaussLobatto>(
+                number_of_radial_points);
+
+  // compare with the expected values
+  for (size_t i = 0; i < number_of_radial_points; i++) {
+    ComplexDataVector angular_view_of_computed_psi{
+        get(computed_psi).data().data() + boundary_size * i, boundary_size};
+
+    auto expected_psi = real(generated_kg_boundary_data.data()) *
+                        one_minus_y_collocation[i] / 2.;
+    CHECK(angular_view_of_computed_psi == expected_psi);
+  }
+}
+}  // namespace
+
+SPECTRE_TEST_CASE(
+    "Unit.Evolution.Systems.Cce.Actions.InitializeKleinGordonFirstHypersurface",
+    "[Unit][Cce]") {
+  MAKE_GENERATOR(gen);
+  test_klein_gordon_first_hypersurface(make_not_null(&gen));
+}
+}  // namespace Cce


### PR DESCRIPTION
## Proposed changes

<!--
At a high level, describe what this PR does.
-->

This PR adds an action to construct the data for `Cce::Tags::KleinGordonPsi` on the first Cce hypersurface.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
