### PR TITLE
Add uniform p-refinement criterion

### DIFF
--- a/src/ParallelAlgorithms/Amr/Criteria/CMakeLists.txt
+++ b/src/ParallelAlgorithms/Amr/Criteria/CMakeLists.txt
@@ -10,6 +10,7 @@ spectre_target_sources(
   PRIVATE
   Constraints.cpp
   DriveToTarget.cpp
+  IncreaseResolution.cpp
   Loehner.cpp
   Persson.cpp
   Random.cpp
@@ -24,6 +25,7 @@ spectre_target_headers(
   Criteria.hpp
   Criterion.hpp
   DriveToTarget.hpp
+  IncreaseResolution.hpp
   Loehner.hpp
   Persson.hpp
   Random.hpp

--- a/src/ParallelAlgorithms/Amr/Criteria/IncreaseResolution.cpp
+++ b/src/ParallelAlgorithms/Amr/Criteria/IncreaseResolution.cpp
@@ -1,0 +1,16 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "ParallelAlgorithms/Amr/Criteria/IncreaseResolution.hpp"
+
+namespace amr::Criteria {
+
+template <size_t Dim>
+IncreaseResolution<Dim>::IncreaseResolution(CkMigrateMessage* msg)
+    : Criterion(msg) {}
+
+template class IncreaseResolution<1>;
+template class IncreaseResolution<2>;
+template class IncreaseResolution<3>;
+
+}  // namespace amr::Criteria

--- a/src/ParallelAlgorithms/Amr/Criteria/IncreaseResolution.hpp
+++ b/src/ParallelAlgorithms/Amr/Criteria/IncreaseResolution.hpp
@@ -1,0 +1,54 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <pup.h>
+
+#include "Domain/Amr/Flag.hpp"
+#include "ParallelAlgorithms/Amr/Criteria/Criterion.hpp"
+#include "Utilities/MakeArray.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace amr::Criteria {
+/*!
+ * \brief Uniformly increases the number of grid points by one
+ *
+ * Useful to do uniform p-refinement, possibly alongside a nontrivial
+ * h-refinement criterion.
+ */
+template <size_t Dim>
+class IncreaseResolution : public Criterion {
+ public:
+  using options = tmpl::list<>;
+
+  static constexpr Options::String help = {
+      "Uniformly increases the number of grid points by one."};
+
+  IncreaseResolution() = default;
+
+  /// \cond
+  explicit IncreaseResolution(CkMigrateMessage* msg);
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(IncreaseResolution);  // NOLINT
+  /// \endcond
+
+  using compute_tags_for_observation_box = tmpl::list<>;
+  using argument_tags = tmpl::list<>;
+
+  template <typename Metavariables>
+  std::array<Flag, Dim> operator()(
+      Parallel::GlobalCache<Metavariables>& /*cache*/,
+      const ElementId<Dim>& /*element_id*/) const {
+    return make_array<Dim>(Flag::IncreaseResolution);
+  }
+};
+
+/// \cond
+template <size_t Dim>
+PUP::able::PUP_ID IncreaseResolution<Dim>::my_PUP_ID = 0;  // NOLINT
+/// \endcond
+
+}  // namespace amr::Criteria

--- a/tests/Unit/ParallelAlgorithms/Amr/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/Amr/CMakeLists.txt
@@ -17,6 +17,7 @@ set(LIBRARY_SOURCES
   Criteria/Test_Constraints.cpp
   Criteria/Test_Criterion.cpp
   Criteria/Test_DriveToTarget.cpp
+  Criteria/Test_IncreaseResolution.cpp
   Criteria/Test_Loehner.cpp
   Criteria/Test_Persson.cpp
   Criteria/Test_Random.cpp

--- a/tests/Unit/ParallelAlgorithms/Amr/Criteria/Test_IncreaseResolution.cpp
+++ b/tests/Unit/ParallelAlgorithms/Amr/Criteria/Test_IncreaseResolution.cpp
@@ -1,0 +1,50 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <memory>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/ObservationBox.hpp"
+#include "Domain/Amr/Flag.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Options/Protocols/FactoryCreation.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "ParallelAlgorithms/Amr/Criteria/Criterion.hpp"
+#include "ParallelAlgorithms/Amr/Criteria/IncreaseResolution.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeArray.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace amr::Criteria {
+namespace {
+template <size_t Dim>
+struct Metavariables {
+  static constexpr size_t volume_dim = Dim;
+  using component_list = tmpl::list<>;
+  using const_global_cache_tags = tmpl::list<>;
+  struct factory_creation
+      : tt::ConformsTo<Options::protocols::FactoryCreation> {
+    using factory_classes = tmpl::map<
+        tmpl::pair<amr::Criterion, tmpl::list<IncreaseResolution<Dim>>>>;
+  };
+};
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Amr.Criteria.IncreaseResolution",
+                  "[Unit][ParallelAlgorithms]") {
+  const auto criterion =
+      TestHelpers::test_factory_creation<amr::Criterion, IncreaseResolution<2>>(
+          "IncreaseResolution");
+  Parallel::GlobalCache<Metavariables<2>> empty_cache{};
+  auto databox = db::create<tmpl::list<>>();
+  ObservationBox<tmpl::list<>, db::DataBox<tmpl::list<>>> box{
+      make_not_null(&databox)};
+  const ElementId<2> element_id{0};
+  const auto flags = criterion->evaluate(box, empty_cache, element_id);
+  CHECK(flags == make_array<2>(amr::Flag::IncreaseResolution));
+}
+}  // namespace amr::Criteria


### PR DESCRIPTION
## Proposed changes

Useful to do uniform p-refinement, possibly alongside a nontrivial h-refinement criterion.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
