### PR TITLE
Turn finding ParaView off by default

### DIFF
--- a/cmake/SetupParaView.cmake
+++ b/cmake/SetupParaView.cmake
@@ -1,11 +1,13 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-option(ENABLE_PARAVIEW "Try to find ParaView to enable 3D rendering tools" ON)
+option(ENABLE_PARAVIEW "Try to find ParaView to enable 3D rendering tools" OFF)
 
-if (ENABLE_PARAVIEW)
-  find_package(ParaView)
+if (NOT ENABLE_PARAVIEW)
+  return()
 endif()
+
+find_package(ParaView)
 
 # Help `find_python_module` find ParaView
 if (PARAVIEW_PYTHONPATH)

--- a/docs/DevGuide/BuildSystem.md
+++ b/docs/DevGuide/BuildSystem.md
@@ -245,7 +245,7 @@ cmake -D FLAG1=OPT1 ... -D FLAGN=OPTN <SPECTRE_ROOT>
     bindings and interpolating volume data files. Note that simulations do not
     typically use OpenMP parallelization, so this flag only applies to tools.
 - ENABLE_PARAVIEW
-  - Try to find ParaView to enable 3D rendering tools (default is `ON`)
+  - Try to find ParaView to enable 3D rendering tools (default is `OFF`)
 - ENABLE_PROFILING
   - Enables various options to make profiling SpECTRE easier
     (default is `OFF`)

--- a/support/Environments/caltech_hpc_gcc_icelake.sh
+++ b/support/Environments/caltech_hpc_gcc_icelake.sh
@@ -43,6 +43,7 @@ spectre_run_cmake() {
           -D MACHINE=CaltechHpcIcelake \
           -D OVERRIDE_ARCH=icelake-server \
           -D BLA_VENDOR=OpenBLAS \
+          -D ENABLE_PARAVIEW=ON \
           "$@" \
           $SPECTRE_HOME
 }

--- a/support/Environments/caltech_hpc_gcc_skylake.sh
+++ b/support/Environments/caltech_hpc_gcc_skylake.sh
@@ -42,6 +42,7 @@ spectre_run_cmake() {
           -D BUILD_PYTHON_BINDINGS=ON \
           -D MACHINE=CaltechHpcSkylake \
           -D OVERRIDE_ARCH=skylake \
+          -D ENABLE_PARAVIEW=ON \
           "$@" \
           $SPECTRE_HOME
 }


### PR DESCRIPTION
## Proposed changes

Makes it easier to opt-in on clusters (specifically, Wheeler).
ParaView can be error-prone to compile and configure.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
