### PR TITLE
Enables AMR to be used in GH executables with one or two black holes

### DIFF
--- a/src/ControlSystem/FutureMeasurements.cpp
+++ b/src/ControlSystem/FutureMeasurements.cpp
@@ -64,4 +64,14 @@ void FutureMeasurements::pup(PUP::er& p) {
   p | measurements_until_update_;
   p | measurements_per_update_;
 }
+
+bool operator==(const FutureMeasurements& lhs, const FutureMeasurements& rhs) {
+  return lhs.measurements_ == rhs.measurements_ and
+         lhs.measurements_until_update_ == rhs.measurements_until_update_ and
+         lhs.measurements_per_update_ == rhs.measurements_per_update_;
+}
+
+bool operator!=(const FutureMeasurements& lhs, const FutureMeasurements& rhs) {
+  return not(lhs == rhs);
+}
 }  // namespace control_system

--- a/src/ControlSystem/FutureMeasurements.hpp
+++ b/src/ControlSystem/FutureMeasurements.hpp
@@ -52,6 +52,9 @@ class FutureMeasurements {
 
   void pup(PUP::er& p);
 
+  friend bool operator==(const FutureMeasurements& lhs,
+                         const FutureMeasurements& rhs);
+
  private:
   // This stores the most recent (or current) measurement time,
   // followed by some future measurement times.  We need to keep one
@@ -63,4 +66,6 @@ class FutureMeasurements {
   size_t measurements_until_update_{};
   size_t measurements_per_update_{};
 };
+
+bool operator!=(const FutureMeasurements& lhs, const FutureMeasurements& rhs);
 }  // namespace control_system

--- a/src/Evolution/DiscontinuousGalerkin/Initialization/Mortars.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Initialization/Mortars.hpp
@@ -207,8 +207,9 @@ struct ProjectMortars : tt::ConformsTo<amr::protocols::Projector> {
       const Mesh<dim>& new_mesh, const Element<dim>& new_element,
       const std::unordered_map<ElementId<dim>, amr::Info<dim>>& neighbor_info,
       const std::pair<Mesh<dim>, Element<dim>>& /*old_mesh_and_element*/) {
-    static_assert(not Metavariables::local_time_stepping,
-                  "AMR with local time-stepping is not yet supported");
+    if (Metavariables::local_time_stepping) {
+      ERROR("AMR with local time-stepping is not yet supported");
+    }
 
     mortar_data->clear();
     mortar_mesh->clear();

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
@@ -575,33 +575,6 @@ struct EvolutionMetavars {
       control_system::Actions::InitializeMeasurements<control_systems>,
       Parallel::Actions::TerminatePhase>;
 
-  struct amr : tt::ConformsTo<::amr::protocols::AmrMetavariables> {
-    using projectors = tmpl::list<
-        Initialization::ProjectTimeStepping<volume_dim>,
-        evolution::dg::Initialization::ProjectDomain<volume_dim>,
-        Initialization::ProjectTimeStepperHistory<EvolutionMetavars>,
-        ::amr::projectors::ProjectVariables<volume_dim,
-                                            typename system::variables_tag>,
-        evolution::dg::Initialization::ProjectMortars<EvolutionMetavars>,
-        evolution::Actions::ProjectRunEventsAndDenseTriggers,
-        ::amr::projectors::DefaultInitialize<
-            Initialization::Tags::InitialTimeDelta,
-            Initialization::Tags::InitialSlabSize<local_time_stepping>,
-            ::domain::Tags::InitialExtents<volume_dim>,
-            ::domain::Tags::InitialRefinementLevels<volume_dim>,
-            evolution::dg::Tags::Quadrature,
-            Tags::StepperError<typename system::variables_tag>,
-            Tags::PreviousStepperError<typename system::variables_tag>,
-            Tags::StepperErrorUpdated,
-            SelfStart::Tags::InitialValue<typename system::variables_tag>,
-            SelfStart::Tags::InitialValue<Tags::TimeStep>,
-            SelfStart::Tags::InitialValue<Tags::Next<Tags::TimeStep>>>,
-        ::amr::projectors::CopyFromCreatorOrLeaveAsIs<tmpl::push_back<
-            typename control_system::Actions::InitializeMeasurements<
-                control_systems>::simple_tags,
-            intrp::Tags::InterpPointInfo<EvolutionMetavars>>>>;
-  };
-
   using gh_dg_element_array = DgElementArray<
       EvolutionMetavars,
       tmpl::flatten<tmpl::list<
@@ -690,7 +663,33 @@ struct EvolutionMetavars {
     }
   }
 
-  using dg_element_array = gh_dg_element_array;
+  struct amr : tt::ConformsTo<::amr::protocols::AmrMetavariables> {
+    using element_array = gh_dg_element_array;
+    using projectors = tmpl::list<
+        Initialization::ProjectTimeStepping<volume_dim>,
+        evolution::dg::Initialization::ProjectDomain<volume_dim>,
+        Initialization::ProjectTimeStepperHistory<EvolutionMetavars>,
+        ::amr::projectors::ProjectVariables<volume_dim,
+                                            typename system::variables_tag>,
+        evolution::dg::Initialization::ProjectMortars<EvolutionMetavars>,
+        evolution::Actions::ProjectRunEventsAndDenseTriggers,
+        ::amr::projectors::DefaultInitialize<
+            Initialization::Tags::InitialTimeDelta,
+            Initialization::Tags::InitialSlabSize<local_time_stepping>,
+            ::domain::Tags::InitialExtents<volume_dim>,
+            ::domain::Tags::InitialRefinementLevels<volume_dim>,
+            evolution::dg::Tags::Quadrature,
+            Tags::StepperError<typename system::variables_tag>,
+            Tags::PreviousStepperError<typename system::variables_tag>,
+            Tags::StepperErrorUpdated,
+            SelfStart::Tags::InitialValue<typename system::variables_tag>,
+            SelfStart::Tags::InitialValue<Tags::TimeStep>,
+            SelfStart::Tags::InitialValue<Tags::Next<Tags::TimeStep>>>,
+        ::amr::projectors::CopyFromCreatorOrLeaveAsIs<tmpl::push_back<
+            typename control_system::Actions::InitializeMeasurements<
+                control_systems>::simple_tags,
+            intrp::Tags::InterpPointInfo<EvolutionMetavars>>>>;
+  };
 
   using component_list = tmpl::flatten<tmpl::list<
       ::amr::Component<EvolutionMetavars>,

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhNoBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhNoBlackHole.hpp
@@ -30,28 +30,6 @@ struct EvolutionMetavars : public GeneralizedHarmonicTemplateBase<VolumeDim> {
   using typename gh_base::observed_reduction_data_tags;
   using typename gh_base::system;
   static constexpr bool local_time_stepping = gh_base::local_time_stepping;
-  struct amr : tt::ConformsTo<::amr::protocols::AmrMetavariables> {
-    using projectors = tmpl::list<
-        Initialization::ProjectTimeStepping<volume_dim>,
-        evolution::dg::Initialization::ProjectDomain<volume_dim>,
-        Initialization::ProjectTimeStepperHistory<EvolutionMetavars>,
-        ::amr::projectors::ProjectVariables<volume_dim,
-                                            typename system::variables_tag>,
-        evolution::dg::Initialization::ProjectMortars<EvolutionMetavars>,
-        evolution::Actions::ProjectRunEventsAndDenseTriggers,
-        ::amr::projectors::DefaultInitialize<
-            Initialization::Tags::InitialTimeDelta,
-            Initialization::Tags::InitialSlabSize<local_time_stepping>,
-            ::domain::Tags::InitialExtents<volume_dim>,
-            ::domain::Tags::InitialRefinementLevels<volume_dim>,
-            evolution::dg::Tags::Quadrature,
-            Tags::StepperError<typename system::variables_tag>,
-            Tags::PreviousStepperError<typename system::variables_tag>,
-            Tags::StepperErrorUpdated,
-            SelfStart::Tags::InitialValue<typename system::variables_tag>,
-            SelfStart::Tags::InitialValue<Tags::TimeStep>,
-            SelfStart::Tags::InitialValue<Tags::Next<Tags::TimeStep>>>>;
-  };
 
   using step_actions = typename gh_base::template step_actions<tmpl::list<>>;
 
@@ -90,7 +68,31 @@ struct EvolutionMetavars : public GeneralizedHarmonicTemplateBase<VolumeDim> {
                          Actions::ChangeSlabSize, step_actions,
                          Actions::AdvanceTime,
                          PhaseControl::Actions::ExecutePhaseChange>>>>>;
-  using dg_element_array = gh_dg_element_array;
+
+  struct amr : tt::ConformsTo<::amr::protocols::AmrMetavariables> {
+    using element_array = gh_dg_element_array;
+
+    using projectors = tmpl::list<
+        Initialization::ProjectTimeStepping<volume_dim>,
+        evolution::dg::Initialization::ProjectDomain<volume_dim>,
+        Initialization::ProjectTimeStepperHistory<EvolutionMetavars>,
+        ::amr::projectors::ProjectVariables<volume_dim,
+                                            typename system::variables_tag>,
+        evolution::dg::Initialization::ProjectMortars<EvolutionMetavars>,
+        evolution::Actions::ProjectRunEventsAndDenseTriggers,
+        ::amr::projectors::DefaultInitialize<
+            Initialization::Tags::InitialTimeDelta,
+            Initialization::Tags::InitialSlabSize<local_time_stepping>,
+            ::domain::Tags::InitialExtents<volume_dim>,
+            ::domain::Tags::InitialRefinementLevels<volume_dim>,
+            evolution::dg::Tags::Quadrature,
+            Tags::StepperError<typename system::variables_tag>,
+            Tags::PreviousStepperError<typename system::variables_tag>,
+            Tags::StepperErrorUpdated,
+            SelfStart::Tags::InitialValue<typename system::variables_tag>,
+            SelfStart::Tags::InitialValue<Tags::TimeStep>,
+            SelfStart::Tags::InitialValue<Tags::Next<Tags::TimeStep>>>>;
+  };
 
   struct registration
       : tt::ConformsTo<Parallel::protocols::RegistrationMetavariables> {

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhSingleBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhSingleBlackHole.hpp
@@ -187,33 +187,6 @@ struct EvolutionMetavars : public GeneralizedHarmonicTemplateBase<3> {
 
   using typename gh_base::const_global_cache_tags;
 
-  struct amr : tt::ConformsTo<::amr::protocols::AmrMetavariables> {
-    using projectors = tmpl::list<
-        Initialization::ProjectTimeStepping<volume_dim>,
-        evolution::dg::Initialization::ProjectDomain<volume_dim>,
-        Initialization::ProjectTimeStepperHistory<EvolutionMetavars>,
-        ::amr::projectors::ProjectVariables<volume_dim,
-                                            typename system::variables_tag>,
-        evolution::dg::Initialization::ProjectMortars<EvolutionMetavars>,
-        evolution::Actions::ProjectRunEventsAndDenseTriggers,
-        ::amr::projectors::DefaultInitialize<
-            Initialization::Tags::InitialTimeDelta,
-            Initialization::Tags::InitialSlabSize<local_time_stepping>,
-            ::domain::Tags::InitialExtents<volume_dim>,
-            ::domain::Tags::InitialRefinementLevels<volume_dim>,
-            evolution::dg::Tags::Quadrature,
-            Tags::StepperError<typename system::variables_tag>,
-            Tags::PreviousStepperError<typename system::variables_tag>,
-            Tags::StepperErrorUpdated,
-            SelfStart::Tags::InitialValue<typename system::variables_tag>,
-            SelfStart::Tags::InitialValue<Tags::TimeStep>,
-            SelfStart::Tags::InitialValue<Tags::Next<Tags::TimeStep>>>,
-        ::amr::projectors::CopyFromCreatorOrLeaveAsIs<tmpl::push_back<
-            typename control_system::Actions::InitializeMeasurements<
-                control_systems>::simple_tags,
-            intrp::Tags::InterpPointInfo<EvolutionMetavars>>>>;
-  };
-
   using observed_reduction_data_tags =
       observers::collect_reduction_data_tags<tmpl::push_back<
           tmpl::at<typename factory_creation::factory_classes, Event>,
@@ -269,7 +242,34 @@ struct EvolutionMetavars : public GeneralizedHarmonicTemplateBase<3> {
                          Actions::AdvanceTime,
                          PhaseControl::Actions::ExecutePhaseChange>>>>>;
 
-  using dg_element_array = gh_dg_element_array;
+  struct amr : tt::ConformsTo<::amr::protocols::AmrMetavariables> {
+    using element_array = gh_dg_element_array;
+
+    using projectors = tmpl::list<
+        Initialization::ProjectTimeStepping<volume_dim>,
+        evolution::dg::Initialization::ProjectDomain<volume_dim>,
+        Initialization::ProjectTimeStepperHistory<EvolutionMetavars>,
+        ::amr::projectors::ProjectVariables<volume_dim,
+                                            typename system::variables_tag>,
+        evolution::dg::Initialization::ProjectMortars<EvolutionMetavars>,
+        evolution::Actions::ProjectRunEventsAndDenseTriggers,
+        ::amr::projectors::DefaultInitialize<
+            Initialization::Tags::InitialTimeDelta,
+            Initialization::Tags::InitialSlabSize<local_time_stepping>,
+            ::domain::Tags::InitialExtents<volume_dim>,
+            ::domain::Tags::InitialRefinementLevels<volume_dim>,
+            evolution::dg::Tags::Quadrature,
+            Tags::StepperError<typename system::variables_tag>,
+            Tags::PreviousStepperError<typename system::variables_tag>,
+            Tags::StepperErrorUpdated,
+            SelfStart::Tags::InitialValue<typename system::variables_tag>,
+            SelfStart::Tags::InitialValue<Tags::TimeStep>,
+            SelfStart::Tags::InitialValue<Tags::Next<Tags::TimeStep>>>,
+        ::amr::projectors::CopyFromCreatorOrLeaveAsIs<tmpl::push_back<
+            typename control_system::Actions::InitializeMeasurements<
+                control_systems>::simple_tags,
+            intrp::Tags::InterpPointInfo<EvolutionMetavars>>>>;
+  };
 
   struct registration
       : tt::ConformsTo<Parallel::protocols::RegistrationMetavariables> {

--- a/src/Evolution/Executables/GeneralizedHarmonic/GeneralizedHarmonicBase.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/GeneralizedHarmonicBase.hpp
@@ -71,11 +71,13 @@
 #include "ParallelAlgorithms/Amr/Actions/CreateChild.hpp"
 #include "ParallelAlgorithms/Amr/Actions/Initialize.hpp"
 #include "ParallelAlgorithms/Amr/Actions/SendAmrDiagnostics.hpp"
+#include "ParallelAlgorithms/Amr/Criteria/Constraints.hpp"
 #include "ParallelAlgorithms/Amr/Criteria/Criterion.hpp"
 #include "ParallelAlgorithms/Amr/Criteria/DriveToTarget.hpp"
 #include "ParallelAlgorithms/Amr/Criteria/Random.hpp"
 #include "ParallelAlgorithms/Amr/Criteria/Tags/Criteria.hpp"
 #include "ParallelAlgorithms/Amr/Criteria/TruncationError.hpp"
+#include "ParallelAlgorithms/Amr/Projectors/CopyFromCreatorOrLeaveAsIs.hpp"
 #include "ParallelAlgorithms/Amr/Projectors/DefaultInitialize.hpp"
 #include "ParallelAlgorithms/Amr/Projectors/Tensors.hpp"
 #include "ParallelAlgorithms/Amr/Projectors/Variables.hpp"
@@ -272,11 +274,15 @@ struct FactoryCreation : tt::ConformsTo<Options::protocols::FactoryCreation> {
   using system = gh::System<volume_dim>;
 
   using factory_classes = tmpl::map<
-      tmpl::pair<amr::Criterion,
-                 tmpl::list<amr::Criteria::DriveToTarget<volume_dim>,
-                            amr::Criteria::TruncationError<
-                                volume_dim,
-                                typename system::variables_tag::tags_list>>>,
+      tmpl::pair<
+          amr::Criterion,
+          tmpl::list<
+              amr::Criteria::DriveToTarget<volume_dim>,
+              amr::Criteria::Constraints<
+                  volume_dim, tmpl::list<gh::Tags::ThreeIndexConstraintCompute<
+                                  volume_dim, Frame::Inertial>>>,
+              amr::Criteria::TruncationError<
+                  volume_dim, typename system::variables_tag::tags_list>>>,
       tmpl::pair<DenseTrigger, DenseTriggers::standard_dense_triggers>,
       tmpl::pair<DomainCreator<volume_dim>, domain_creators<volume_dim>>,
       tmpl::pair<

--- a/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
+++ b/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
@@ -219,31 +219,6 @@ struct EvolutionMetavars {
   // wave system, the user should determine whether this filter can be removed.
   static constexpr bool use_filtering = (2 == volume_dim);
 
-  struct amr : tt::ConformsTo<::amr::protocols::AmrMetavariables> {
-    using projectors = tmpl::list<
-        Initialization::ProjectTimeStepping<volume_dim>,
-        evolution::dg::Initialization::ProjectDomain<volume_dim>,
-        Initialization::ProjectTimeStepperHistory<EvolutionMetavars>,
-        ::amr::projectors::ProjectVariables<volume_dim,
-                                            typename system::variables_tag>,
-        ::amr::projectors::ProjectTensors<volume_dim,
-                                          ::ScalarWave::Tags::ConstraintGamma2>,
-        evolution::dg::Initialization::ProjectMortars<EvolutionMetavars>,
-        evolution::Actions::ProjectRunEventsAndDenseTriggers,
-        ::amr::projectors::DefaultInitialize<
-            Initialization::Tags::InitialTimeDelta,
-            Initialization::Tags::InitialSlabSize<local_time_stepping>,
-            ::domain::Tags::InitialExtents<volume_dim>,
-            ::domain::Tags::InitialRefinementLevels<volume_dim>,
-            evolution::dg::Tags::Quadrature,
-            Tags::StepperError<typename system::variables_tag>,
-            Tags::PreviousStepperError<typename system::variables_tag>,
-            Tags::StepperErrorUpdated,
-            SelfStart::Tags::InitialValue<typename system::variables_tag>,
-            SelfStart::Tags::InitialValue<Tags::TimeStep>,
-            SelfStart::Tags::InitialValue<Tags::Next<Tags::TimeStep>>>>;
-  };
-
   using step_actions = tmpl::flatten<tmpl::list<
       evolution::dg::Actions::ComputeTimeDerivative<
           volume_dim, system, AllStepChoosers, local_time_stepping>,
@@ -315,6 +290,33 @@ struct EvolutionMetavars {
                          Actions::ChangeSlabSize, step_actions,
                          Actions::AdvanceTime,
                          PhaseControl::Actions::ExecutePhaseChange>>>>;
+
+  struct amr : tt::ConformsTo<::amr::protocols::AmrMetavariables> {
+    using element_array = dg_element_array;
+
+    using projectors = tmpl::list<
+        Initialization::ProjectTimeStepping<volume_dim>,
+        evolution::dg::Initialization::ProjectDomain<volume_dim>,
+        Initialization::ProjectTimeStepperHistory<EvolutionMetavars>,
+        ::amr::projectors::ProjectVariables<volume_dim,
+                                            typename system::variables_tag>,
+        ::amr::projectors::ProjectTensors<volume_dim,
+                                          ::ScalarWave::Tags::ConstraintGamma2>,
+        evolution::dg::Initialization::ProjectMortars<EvolutionMetavars>,
+        evolution::Actions::ProjectRunEventsAndDenseTriggers,
+        ::amr::projectors::DefaultInitialize<
+            Initialization::Tags::InitialTimeDelta,
+            Initialization::Tags::InitialSlabSize<local_time_stepping>,
+            ::domain::Tags::InitialExtents<volume_dim>,
+            ::domain::Tags::InitialRefinementLevels<volume_dim>,
+            evolution::dg::Tags::Quadrature,
+            Tags::StepperError<typename system::variables_tag>,
+            Tags::PreviousStepperError<typename system::variables_tag>,
+            Tags::StepperErrorUpdated,
+            SelfStart::Tags::InitialValue<typename system::variables_tag>,
+            SelfStart::Tags::InitialValue<Tags::TimeStep>,
+            SelfStart::Tags::InitialValue<Tags::Next<Tags::TimeStep>>>>;
+  };
 
   struct registration
       : tt::ConformsTo<Parallel::protocols::RegistrationMetavariables> {

--- a/src/Executables/Examples/RandomAmr/RandomAmr.hpp
+++ b/src/Executables/Examples/RandomAmr/RandomAmr.hpp
@@ -105,6 +105,8 @@ struct RandomAmrMetavars {
   void pup(PUP::er& /*p*/) {}
 
   struct amr : tt::ConformsTo<::amr::protocols::AmrMetavariables> {
+    using element_array = dg_element_array;
+
     using projectors = tmpl::list<::amr::projectors::DefaultInitialize<
         domain::Tags::InitialExtents<Dim>,
         domain::Tags::InitialRefinementLevels<Dim>,

--- a/src/Executables/ExportCoordinates/ExportCoordinates.hpp
+++ b/src/Executables/ExportCoordinates/ExportCoordinates.hpp
@@ -317,18 +317,6 @@ struct Metavariables {
                  observers::Actions::RegisterWithObservers<
                      Actions::FindGlobalMinimumGridSpacing>>;
 
-  struct amr : tt::ConformsTo<::amr::protocols::AmrMetavariables> {
-    using projectors = tmpl::list<
-        Initialization::ProjectTimeStepping<volume_dim>,
-        evolution::dg::Initialization::ProjectDomain<volume_dim>,
-        ::amr::projectors::DefaultInitialize<
-            Initialization::Tags::InitialTimeDelta,
-            Initialization::Tags::InitialSlabSize<local_time_stepping>,
-            ::domain::Tags::InitialExtents<Dim>,
-            ::domain::Tags::InitialRefinementLevels<Dim>,
-            evolution::dg::Tags::Quadrature>>;
-  };
-
   using dg_element_array = DgElementArray<
       Metavariables,
       tmpl::list<
@@ -358,6 +346,19 @@ struct Metavariables {
                          Actions::FindGlobalMinimumGridSpacing,
                          evolution::Actions::RunEventsAndTriggers,
                          PhaseControl::Actions::ExecutePhaseChange>>>>;
+
+  struct amr : tt::ConformsTo<::amr::protocols::AmrMetavariables> {
+    using element_array = dg_element_array;
+    using projectors = tmpl::list<
+        Initialization::ProjectTimeStepping<volume_dim>,
+        evolution::dg::Initialization::ProjectDomain<volume_dim>,
+        ::amr::projectors::DefaultInitialize<
+            Initialization::Tags::InitialTimeDelta,
+            Initialization::Tags::InitialSlabSize<local_time_stepping>,
+            ::domain::Tags::InitialExtents<Dim>,
+            ::domain::Tags::InitialRefinementLevels<Dim>,
+            evolution::dg::Tags::Quadrature>>;
+  };
 
   struct registration
       : tt::ConformsTo<Parallel::protocols::RegistrationMetavariables> {

--- a/src/ParallelAlgorithms/Amr/Actions/Component.hpp
+++ b/src/ParallelAlgorithms/Amr/Actions/Component.hpp
@@ -48,12 +48,12 @@ struct Component {
     if (Parallel::Phase::EvaluateAmrCriteria == next_phase) {
       Parallel::simple_action<::amr::Actions::EvaluateRefinementCriteria>(
           Parallel::get_parallel_component<
-              typename metavariables::dg_element_array>(local_cache));
+              typename metavariables::amr::element_array>(local_cache));
     }
     if (Parallel::Phase::AdjustDomain == next_phase) {
       Parallel::simple_action<::amr::Actions::AdjustDomain>(
           Parallel::get_parallel_component<
-              typename metavariables::dg_element_array>(local_cache));
+              typename metavariables::amr::element_array>(local_cache));
     }
   }
 };

--- a/src/ParallelAlgorithms/Amr/Actions/EvaluateRefinementCriteria.hpp
+++ b/src/ParallelAlgorithms/Amr/Actions/EvaluateRefinementCriteria.hpp
@@ -87,12 +87,10 @@ struct EvaluateRefinementCriteria {
     constexpr size_t volume_dim = Metavariables::volume_dim;
     auto overall_decision = make_array<volume_dim>(amr::Flag::Undefined);
 
-    using compute_tags = tmpl::remove_duplicates<tmpl::filter<
-        tmpl::flatten<tmpl::transform<
-            tmpl::at<typename Metavariables::factory_creation::factory_classes,
-                     Criterion>,
-            detail::get_tags<tmpl::_1>>>,
-        db::is_compute_tag<tmpl::_1>>>;
+    using compute_tags = tmpl::remove_duplicates<tmpl::flatten<tmpl::transform<
+        tmpl::at<typename Metavariables::factory_creation::factory_classes,
+                 Criterion>,
+        detail::get_tags<tmpl::_1>>>>;
     auto observation_box =
         make_observation_box<compute_tags>(make_not_null(&box));
 

--- a/src/ParallelAlgorithms/Amr/Criteria/Constraints.hpp
+++ b/src/ParallelAlgorithms/Amr/Criteria/Constraints.hpp
@@ -153,7 +153,11 @@ class Constraints : public Criterion {
   WRAPPED_PUPable_decl_template(Constraints);  // NOLINT
   /// \endcond
 
-  using compute_tags_for_observation_box = TensorTags;
+  using compute_tags_for_observation_box = tmpl::append<
+      TensorTags, tmpl::list<domain::Tags::JacobianCompute<
+                                 Dim, Frame::ElementLogical, Frame::Inertial>,
+                             Events::Tags::ObserverJacobianCompute<
+                                 Dim, Frame::ElementLogical, Frame::Inertial>>>;
 
   using argument_tags = tmpl::list<::Tags::ObservationBox>;
 

--- a/src/ParallelAlgorithms/Amr/Projectors/CMakeLists.txt
+++ b/src/ParallelAlgorithms/Amr/Projectors/CMakeLists.txt
@@ -15,6 +15,7 @@ spectre_target_headers(
   ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
+  CopyFromCreatorOrLeaveAsIs.hpp
   DefaultInitialize.hpp
   Mesh.hpp
   Tensors.hpp

--- a/src/ParallelAlgorithms/Amr/Projectors/CopyFromCreatorOrLeaveAsIs.hpp
+++ b/src/ParallelAlgorithms/Amr/Projectors/CopyFromCreatorOrLeaveAsIs.hpp
@@ -1,0 +1,83 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <iterator>
+#include <unordered_map>
+#include <utility>
+
+#include "ParallelAlgorithms/Amr/Protocols/Projector.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+/// \cond
+template <size_t Dim>
+class Element;
+template <size_t Dim>
+class ElementId;
+template <size_t Dim>
+class Mesh;
+/// \endcond
+
+namespace amr::projectors {
+
+/// \brief For h-refinement copy the items from the parent/child, while for
+/// p-refinement leave the items unchanged
+///
+/// There is a specialization for
+/// `CopyFromCreatorOrLeaveAsIs<tmpl::list<Tags...>>` that can be used if a
+/// `tmpl::list` is available.
+///
+/// \details For each item corresponding to each tag:
+/// - When changing resolution (p-refinement), leave unchanged
+/// - When splitting, copy the value from the parent to the child
+/// - When joining, check that the children have the same value, and copy to
+///   the parent
+template <typename... Tags>
+struct CopyFromCreatorOrLeaveAsIs : tt::ConformsTo<amr::protocols::Projector> {
+  using return_tags = tmpl::list<Tags...>;
+  using argument_tags = tmpl::list<>;
+
+  template <size_t Dim>
+  static void apply(
+      const gsl::not_null<typename Tags::type*>... /*items*/,
+      const std::pair<Mesh<Dim>, Element<Dim>>& /*old_mesh_and_element*/) {
+    // do nothing, i.e. leave the items unchanged
+  }
+
+  template <typename... ParentTags>
+  static void apply(const gsl::not_null<typename Tags::type*>... items,
+                    const tuples::TaggedTuple<ParentTags...>& parent_items) {
+    ::expand_pack((*items = tuples::get<Tags>(parent_items))...);
+  }
+
+  template <size_t Dim, typename... ChildrenTags>
+  static void apply(const gsl::not_null<typename Tags::type*>... items,
+                    const std::unordered_map<
+                        ElementId<Dim>, tuples::TaggedTuple<ChildrenTags...>>&
+                        children_items) {
+    const auto& first_child_items = children_items.begin();
+#ifdef SPECTRE_DEBUG
+    for (auto it = std::next(first_child_items); it != children_items.end();
+         ++it) {
+      const bool children_agree =
+          ((tuples::get<Tags>(first_child_items->second) ==
+            tuples::get<Tags>(it->second)) and
+           ...);
+      ASSERT(children_agree, "Children do not agree on all items!");
+    }
+#endif  // #ifdef SPECTRE_DEBUG
+    ::expand_pack((*items = tuples::get<Tags>(first_child_items->second))...);
+  }
+};
+
+/// \cond
+template <typename... Tags>
+struct CopyFromCreatorOrLeaveAsIs<tmpl::list<Tags...>>
+    : public CopyFromCreatorOrLeaveAsIs<Tags...> {};
+/// \endcond
+}  // namespace amr::projectors

--- a/src/ParallelAlgorithms/Amr/Protocols/AmrMetavariables.hpp
+++ b/src/ParallelAlgorithms/Amr/Protocols/AmrMetavariables.hpp
@@ -6,18 +6,21 @@
 #include <type_traits>
 
 #include "ParallelAlgorithms/Amr/Protocols/Projector.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
+#include "Utilities/TMPL.hpp"
 
 namespace amr::protocols {
 /// \brief Compile-time information for AMR projectors
 ///
 /// A class conforming to this protocol is placed in the metavariables to
-/// provide the list of AMR projectors (each of which must conform to
-/// amr::protocols::Projector) that will be applied by:
-/// - amr::Actions::InitializeChild and amr::Actions::InitializeParent in order
-///   to initialize data on newly created elements.
-/// - amr::Actions::AdjustDomain in order to update data on existing elements in
-///   case their Mesh or neighbors have changed.
-///
+/// provide the following:
+/// - `element_array`: The array component on which AMR is performed.
+/// - `projectors`: A type list of AMR projectors (each of which must conform to
+///   amr::protocols::Projector) that will be applied by:
+///     - amr::Actions::InitializeChild and amr::Actions::InitializeParent in
+///       order to initialize data on newly created elements.
+///     - amr::Actions::AdjustDomain in order to update data on existing
+///       elements in case their Mesh or neighbors have changed.
 ///
 /// Here is an example for a class conforming to this protocol:
 ///
@@ -25,6 +28,7 @@ namespace amr::protocols {
 struct AmrMetavariables {
   template <typename ConformingType>
   struct test {
+    using element_array = typename ConformingType::element_array;
     using projectors = typename ConformingType::projectors;
     static_assert(
         tmpl::all<projectors,

--- a/support/Pipelines/Bbh/Inspiral.yaml
+++ b/support/Pipelines/Bbh/Inspiral.yaml
@@ -185,6 +185,12 @@ Observers:
 Cce:
   BondiSachsOutputFilePrefix: "BondiSachs"
 
+Amr:
+  Criteria:
+  Policies:
+    Isotropy: Anisotropic
+  Verbosity: Quiet
+
 PhaseChangeAndTriggers:
   - Trigger:
       Slabs:

--- a/support/Pipelines/Bbh/Ringdown.yaml
+++ b/support/Pipelines/Bbh/Ringdown.yaml
@@ -98,6 +98,12 @@ Observers:
   ReductionFileName: "BbhReductions"
   SurfaceFileName: "BbhSurfaces"
 
+Amr:
+  Criteria:
+  Policies:
+    Isotropy: Anisotropic
+  Verbosity: Quiet
+
 PhaseChangeAndTriggers:
   - Trigger:
       Slabs:

--- a/tests/InputFiles/GeneralizedHarmonic/BinaryBlackHole.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/BinaryBlackHole.yaml
@@ -144,6 +144,12 @@ EvolutionSystem:
           Width: 38.415              # 2.5 * (x_B - x_A)
           Center: [0.0, 0.0, 0.0]
 
+Amr:
+  Criteria:
+  Policies:
+    Isotropy: Anisotropic
+  Verbosity: Quiet
+
 PhaseChangeAndTriggers:
   - Trigger:
       Slabs:

--- a/tests/InputFiles/GeneralizedHarmonic/CylindricalBinaryBlackHole.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/CylindricalBinaryBlackHole.yaml
@@ -124,6 +124,12 @@ EvolutionSystem:
           Width: 38.415              # 2.5 * (x_B - x_A)
           Center: [0.0, 0.0, 0.0]
 
+Amr:
+  Criteria:
+  Policies:
+    Isotropy: Anisotropic
+  Verbosity: Quiet
+
 PhaseChangeAndTriggers:
   - Trigger:
       Slabs:

--- a/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
@@ -32,6 +32,12 @@ Evolution:
     AdamsBashforth:
       Order: 1
 
+Amr:
+  Criteria:
+  Policies:
+    Isotropy: Anisotropic
+  Verbosity: Quiet
+
 PhaseChangeAndTriggers:
   - Trigger:
       Slabs:

--- a/tests/Unit/ControlSystem/Test_FutureMeasurements.cpp
+++ b/tests/Unit/ControlSystem/Test_FutureMeasurements.cpp
@@ -76,4 +76,5 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.FutureMeasurements",
   const auto measurements_copy = serialize_and_deserialize(measurements);
   REQUIRE(measurements_copy.next_measurement() == std::optional(8.0));
   REQUIRE(measurements_copy.next_update() == std::optional(10.0));
+  REQUIRE(measurements == measurements_copy);
 }

--- a/tests/Unit/ParallelAlgorithms/Amr/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/Amr/CMakeLists.txt
@@ -22,9 +22,10 @@ set(LIBRARY_SOURCES
   Criteria/Test_Persson.cpp
   Criteria/Test_Random.cpp
   Criteria/Test_TruncationError.cpp
-  Policies/Test_Isotropy.cpp
   Policies/Test_EnforcePolicies.cpp
+  Policies/Test_Isotropy.cpp
   Policies/Test_Policies.cpp
+  Projectors/Test_CopyFromCreatorOrLeaveAsIs.cpp
   Projectors/Test_DefaultInitialize.cpp
   Projectors/Test_Mesh.cpp
   Projectors/Test_Tensors.cpp

--- a/tests/Unit/ParallelAlgorithms/Amr/Projectors/Test_CopyFromCreatorOrLeaveAsIs.cpp
+++ b/tests/Unit/ParallelAlgorithms/Amr/Projectors/Test_CopyFromCreatorOrLeaveAsIs.cpp
@@ -1,0 +1,100 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <unordered_map>
+#include <utility>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/Tag.hpp"
+#include "Domain/Structure/DirectionMap.hpp"
+#include "Domain/Structure/Element.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Domain/Structure/Neighbors.hpp"
+#include "NumericalAlgorithms/Spectral/Basis.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Quadrature.hpp"
+#include "ParallelAlgorithms/Amr/Projectors/CopyFromCreatorOrLeaveAsIs.hpp"
+#include "ParallelAlgorithms/Amr/Protocols/Projector.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace {
+struct TagInt : db::SimpleTag {
+  using type = int;
+};
+
+struct TagDouble : db::SimpleTag {
+  using type = double;
+};
+
+void test_p_refinement() {
+  const ElementId<1> element_id{0};
+  Element<1> element{element_id, DirectionMap<1, Neighbors<1>>{}};
+  const Mesh<1> mesh{2, Spectral::Basis::Legendre,
+                     Spectral::Quadrature::GaussLobatto};
+  auto box = db::create<db::AddSimpleTags<TagInt, TagDouble>>(3, 4.2);
+  db::mutate_apply<
+      amr::projectors::CopyFromCreatorOrLeaveAsIs<TagInt, TagDouble>>(
+      make_not_null(&box), std::make_pair(mesh, element));
+  CHECK(db::get<TagInt>(box) == 3);
+  CHECK(db::get<TagDouble>(box) == 4.2);
+}
+
+void test_splitting() {
+  auto box = db::DataBox<tmpl::list<TagInt, TagDouble>>{};
+  tuples::TaggedTuple<TagInt, TagDouble> parent_items{3, 4.2};
+  db::mutate_apply<amr::projectors::CopyFromCreatorOrLeaveAsIs<
+      tmpl::list<TagInt, TagDouble>>>(make_not_null(&box),
+                                                    parent_items);
+  CHECK(db::get<TagInt>(box) == 3);
+  CHECK(db::get<TagDouble>(box) == 4.2);
+}
+
+void test_joining() {
+  auto box = db::DataBox<tmpl::list<TagInt, TagDouble>>{};
+  tuples::TaggedTuple<TagInt, TagDouble> child_one_items{3, 4.2};
+  tuples::TaggedTuple<TagInt, TagDouble> child_two_items{3, 4.2};
+  const std::unordered_map<ElementId<1>, tuples::TaggedTuple<TagInt, TagDouble>>
+      children_items{{ElementId<1>{0}, child_one_items},
+                     {ElementId<1>{1}, child_two_items}};
+  db::mutate_apply<amr::projectors::CopyFromCreatorOrLeaveAsIs<
+      tmpl::list<TagInt, TagDouble>>>(make_not_null(&box), children_items);
+  CHECK(db::get<TagInt>(box) == 3);
+  CHECK(db::get<TagDouble>(box) == 4.2);
+}
+
+void test_joining_assert() {
+#ifdef SPECTRE_DEBUG
+  CHECK_THROWS_WITH(
+      ([]() {
+        auto box = db::DataBox<tmpl::list<TagInt, TagDouble>>{};
+        tuples::TaggedTuple<TagInt, TagDouble> child_one_items{3, 4.2};
+        tuples::TaggedTuple<TagInt, TagDouble> child_two_items{3, 4.1};
+        const std::unordered_map<ElementId<1>,
+                                 tuples::TaggedTuple<TagInt, TagDouble>>
+            children_items{{ElementId<1>{0}, child_one_items},
+                           {ElementId<1>{1}, child_two_items}};
+        db::mutate_apply<amr::projectors::CopyFromCreatorOrLeaveAsIs<
+            tmpl::list<TagInt, TagDouble>>>(make_not_null(&box),
+                                            children_items);
+      })(),
+      Catch::Matchers::ContainsSubstring("Children do not agree"));
+#endif  // #ifdef SPECTRE_DEBUG
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Amr.Projectors.CopyFromCreatorOrLeaveAsIs",
+                  "[Domain][Unit]") {
+  static_assert(
+      tt::assert_conforms_to_v<amr::projectors::CopyFromCreatorOrLeaveAsIs<
+                                   tmpl::list<TagInt, TagDouble>>,
+                               amr::protocols::Projector>);
+  test_p_refinement();
+  test_splitting();
+  test_joining();
+  test_joining_assert();
+}

--- a/tests/Unit/ParallelAlgorithms/Amr/Test_Protocols.cpp
+++ b/tests/Unit/ParallelAlgorithms/Amr/Test_Protocols.cpp
@@ -8,9 +8,12 @@
 #include "Utilities/TMPL.hpp"
 
 namespace {
+struct ElementArray;
+
 struct Metavariables {
   // [amr_projectors]
   struct amr : tt::ConformsTo<::amr::protocols::AmrMetavariables> {
+    using element_array = ElementArray;
     using projectors =
         tmpl::list<Initialization::ProjectTimeStepping<1>,
                    evolution::dg::Initialization::ProjectDomain<1>>;


### PR DESCRIPTION
## Proposed changes

This adds the code that will hook AMR into the single/binary black hole executables.
Currently only will work for p-refinement with global time-stepping (otherwise will runtime error when an AMR change is triggered).  The example GH input files do not trigger refinement.

### Upgrade instructions

Input files for these executables will need to specify
```
Amr:
  Criteria:
  Verbosity: Quiet
```
in order to run, but do no AMR.

<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments
This should be considered as experimental support not yet ready for adoption.  My plan is to work on the following, the first two to be done ASAP so others can more easily experiment:
- Allow AMR policies (such as isotropic vs anisotropic refinement) to be set via the input file
- An AMR tutorial with documentation on how to enable and control AMR, and how to add it to other evolution systems
- enable support for local time-stepping with p-refinement
- enable support for h-refinement

