### PR TITLE
Add rotation, expansion and translation maps to Sphere domain

### DIFF
--- a/src/Domain/Creators/SphereTimeDependentMaps.cpp
+++ b/src/Domain/Creators/SphereTimeDependentMaps.cpp
@@ -21,16 +21,24 @@
 #include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
 #include "Domain/FunctionsOfTime/PiecewisePolynomial.hpp"
 #include "Domain/FunctionsOfTime/QuaternionFunctionOfTime.hpp"
+#include "Domain/FunctionsOfTime/SettleToConstant.hpp"
+#include "Domain/FunctionsOfTime/SettleToConstantQuaternion.hpp"
 #include "NumericalAlgorithms/SphericalHarmonics/Spherepack.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrHorizon.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"
 
 namespace domain::creators::sphere {
+
 TimeDependentMapOptions::TimeDependentMapOptions(
-    const double initial_time, const ShapeMapOptions& shape_map_options)
+    const double initial_time, const ShapeMapOptions& shape_map_options,
+    std::optional<RotationMapOptions> rotation_map_options,
+    std::optional<ExpansionMapOptions> expansion_map_options,
+    std::optional<TranslationMapOptions> translation_map_options)
     : initial_time_(initial_time),
-      initial_l_max_(shape_map_options.l_max),
-      initial_shape_values_(shape_map_options.initial_values) {}
+      shape_map_options_(shape_map_options),
+      rotation_map_options_(rotation_map_options),
+      expansion_map_options_(expansion_map_options),
+      translation_map_options_(translation_map_options) {}
 
 std::unordered_map<std::string,
                    std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
@@ -46,7 +54,8 @@ TimeDependentMapOptions::create_functions_of_time(
   // their initial expiration time to infinity (i.e. not expiring)
   std::unordered_map<std::string, double> expiration_times{
       {size_name, std::numeric_limits<double>::infinity()},
-      {shape_name, std::numeric_limits<double>::infinity()}};
+      {shape_name, std::numeric_limits<double>::infinity()},
+      {translation_name, std::numeric_limits<double>::infinity()}};
 
   // If we have control systems, overwrite these expiration times with the ones
   // supplied by the control system
@@ -55,16 +64,19 @@ TimeDependentMapOptions::create_functions_of_time(
   }
 
   DataVector shape_zeros{
-      ylm::Spherepack::spectral_size(initial_l_max_, initial_l_max_), 0.0};
+      ylm::Spherepack::spectral_size(shape_map_options_.l_max,
+                                     shape_map_options_.l_max),
+      0.0};
   DataVector shape_func{};
   DataVector size_func{1, 0.0};
 
-  if (initial_shape_values_.has_value()) {
+  if (shape_map_options_.initial_values.has_value()) {
     if (std::holds_alternative<KerrSchildFromBoyerLindquist>(
-            initial_shape_values_.value())) {
-      const ylm::Spherepack ylm{initial_l_max_, initial_l_max_};
-      const auto& mass_and_spin =
-          std::get<KerrSchildFromBoyerLindquist>(initial_shape_values_.value());
+            shape_map_options_.initial_values.value())) {
+      const ylm::Spherepack ylm{shape_map_options_.l_max,
+                                shape_map_options_.l_max};
+      const auto& mass_and_spin = std::get<KerrSchildFromBoyerLindquist>(
+          shape_map_options_.initial_values.value());
       const DataVector radial_distortion =
           1.0 - get(gr::Solutions::kerr_schild_radius_from_boyer_lindquist(
                     inner_radius, ylm.theta_phi_points(), mass_and_spin.mass,
@@ -101,31 +113,143 @@ TimeDependentMapOptions::create_functions_of_time(
                                  {0.0}}},
       expiration_times.at(size_name));
 
+  // ExpansionMap FunctionOfTime
+  if (expansion_map_options_.has_value()) {
+    result[expansion_name] =
+        std::make_unique<FunctionsOfTime::SettleToConstant>(
+            std::array<DataVector, 3>{
+                {{gsl::at(expansion_map_options_.value().initial_values, 0)},
+                 {gsl::at(expansion_map_options_.value().initial_values, 1)},
+                 {gsl::at(expansion_map_options_.value().initial_values, 2)}}},
+            initial_time_, expansion_map_options_.value().decay_timescale);
+
+    // ExpansionMap in the Outer regionFunctionOfTime
+    result[expansion_outer_boundary_name] = std::make_unique<
+        FunctionsOfTime::SettleToConstant>(
+        std::array<DataVector, 3>{
+            {{gsl::at(
+                 expansion_map_options_.value().initial_values_outer_boundary,
+                 0)},
+             {gsl::at(
+                 expansion_map_options_.value().initial_values_outer_boundary,
+                 1)},
+             {gsl::at(
+                 expansion_map_options_.value().initial_values_outer_boundary,
+                 2)}}},
+        initial_time_,
+        expansion_map_options_.value().decay_timescale_outer_boundary);
+  }
+
+  DataVector initial_quaternion_value{4, 0.0};
+  DataVector initial_quaternion_first_derivative_value{4, 0.0};
+  DataVector initial_quaternion_second_derivative_value{4, 0.0};
+
+  // RotationMap FunctionOfTime
+  if (rotation_map_options_.has_value()) {
+    for (size_t i = 0; i < 3; i++) {
+      initial_quaternion_value[i] =
+          gsl::at(gsl::at(rotation_map_options_.value().initial_values, 0), i);
+      initial_quaternion_first_derivative_value[i] =
+          gsl::at(gsl::at(rotation_map_options_.value().initial_values, 1), i);
+      initial_quaternion_second_derivative_value[i] =
+          gsl::at(gsl::at(rotation_map_options_.value().initial_values, 2), i);
+    }
+    result[rotation_name] =
+        std::make_unique<FunctionsOfTime::SettleToConstantQuaternion>(
+            std::array<DataVector, 3>{
+                std::move(initial_quaternion_value),
+                std::move(initial_quaternion_first_derivative_value),
+                std::move(initial_quaternion_second_derivative_value)},
+            initial_time_, rotation_map_options_.value().decay_timescale);
+  }
+
+  DataVector initial_translation_center{3, 0.0};
+  DataVector initial_translation_velocity{3, 0.0};
+  DataVector initial_translation_acceleration{3, 0.0};
+
+  // Translation FunctionOfTime
+  if (translation_map_options_.has_value()) {
+    for (size_t i = 0; i < 3; i++) {
+      initial_translation_center[i] = gsl::at(
+          gsl::at(translation_map_options_.value().initial_values, 0), i);
+      initial_translation_velocity[i] = gsl::at(
+          gsl::at(translation_map_options_.value().initial_values, 1), i);
+      initial_translation_acceleration[i] = gsl::at(
+          gsl::at(translation_map_options_.value().initial_values, 2), i);
+    }
+    result[translation_name] =
+        std::make_unique<FunctionsOfTime::PiecewisePolynomial<2>>(
+            initial_time_,
+            std::array<DataVector, 3>{
+                {std::move(initial_translation_center),
+                 std::move(initial_translation_velocity),
+                 std::move(initial_translation_acceleration)}},
+            expiration_times.at(translation_name));
+  }
+
   return result;
 }
 
-void TimeDependentMapOptions::build_maps(const std::array<double, 3>& center,
-                                         const double inner_radius,
-                                         const double outer_radius) {
+void TimeDependentMapOptions::build_maps(
+    const std::array<double, 3>& center,
+    std::pair<double, double> inner_shell_radii,
+    std::pair<double, double> outer_shell_radii) {
   std::unique_ptr<domain::CoordinateMaps::ShapeMapTransitionFunctions::
                       ShapeMapTransitionFunction>
       transition_func =
           std::make_unique<domain::CoordinateMaps::ShapeMapTransitionFunctions::
-                               SphereTransition>(inner_radius, outer_radius);
-  shape_map_ = ShapeMap{center,         initial_l_max_,
-                        initial_l_max_, std::move(transition_func),
-                        shape_name,     size_name};
+                               SphereTransition>(inner_shell_radii.first,
+                                                 inner_shell_radii.second);
+  shape_map_ = ShapeMap{center,
+                        shape_map_options_.l_max,
+                        shape_map_options_.l_max,
+                        std::move(transition_func),
+                        shape_name,
+                        size_name};
+
+  inner_rot_scale_trans_map_ = RotScaleTransMap{
+      expansion_map_options_.has_value()
+          ? std::optional<std::pair<
+                std::string, std::string>>{{expansion_name,
+                                            expansion_outer_boundary_name}}
+          : std::nullopt,
+      rotation_map_options_.has_value()
+          ? std::optional<std::string>{rotation_name}
+          : std::nullopt,
+      translation_map_options_.has_value()
+          ? std::optional<std::string>{translation_name}
+          : std::nullopt,
+      outer_shell_radii.first,
+      outer_shell_radii.second,
+      domain::CoordinateMaps::TimeDependent::RotScaleTrans<
+          3>::BlockRegion::Inner};
+
+  transition_rot_scale_trans_map_ = RotScaleTransMap{
+      expansion_map_options_.has_value()
+          ? std::optional<std::pair<
+                std::string, std::string>>{{expansion_name,
+                                            expansion_outer_boundary_name}}
+          : std::nullopt,
+      rotation_map_options_.has_value()
+          ? std::optional<std::string>{rotation_name}
+          : std::nullopt,
+      translation_map_options_.has_value()
+          ? std::optional<std::string>{translation_name}
+          : std::nullopt,
+      outer_shell_radii.first,
+      outer_shell_radii.second,
+      domain::CoordinateMaps::TimeDependent::RotScaleTrans<
+          3>::BlockRegion::Transition};
 }
 
 // If you edit any of the functions below, be sure to update the documentation
 // in the Sphere domain creator as well as this class' documentation.
 TimeDependentMapOptions::MapType<Frame::Distorted, Frame::Inertial>
 TimeDependentMapOptions::distorted_to_inertial_map(
-    const bool include_distorted_map) {
+    const bool include_distorted_map) const {
   if (include_distorted_map) {
-    return std::make_unique<
-        IdentityForComposition<Frame::Distorted, Frame::Inertial>>(
-        IdentityMap{});
+    return std::make_unique<DistortedToInertialComposition>(
+        inner_rot_scale_trans_map_);
   } else {
     return nullptr;
   }
@@ -142,13 +266,16 @@ TimeDependentMapOptions::grid_to_distorted_map(
 }
 
 TimeDependentMapOptions::MapType<Frame::Grid, Frame::Inertial>
-TimeDependentMapOptions::grid_to_inertial_map(
-    const bool include_distorted_map) const {
+TimeDependentMapOptions::grid_to_inertial_map(const bool include_distorted_map,
+                                              const bool use_rigid) const {
   if (include_distorted_map) {
-    return std::make_unique<GridToInertialComposition>(shape_map_);
+    return std::make_unique<GridToInertialComposition>(
+        shape_map_, inner_rot_scale_trans_map_);
+  } else if (use_rigid) {
+    return std::make_unique<GridToInertialSimple>(inner_rot_scale_trans_map_);
   } else {
-    return std::make_unique<
-        IdentityForComposition<Frame::Grid, Frame::Inertial>>(IdentityMap{});
+    return std::make_unique<GridToInertialSimple>(
+        transition_rot_scale_trans_map_);
   }
 }
 }  // namespace domain::creators::sphere

--- a/src/Domain/Creators/SphereTimeDependentMaps.hpp
+++ b/src/Domain/Creators/SphereTimeDependentMaps.hpp
@@ -13,7 +13,9 @@
 
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/Identity.hpp"
+#include "Domain/CoordinateMaps/TimeDependent/RotScaleTrans.hpp"
 #include "Domain/CoordinateMaps/TimeDependent/Shape.hpp"
+#include "Domain/CoordinateMaps/TimeDependent/Translation.hpp"
 #include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
 #include "Options/Auto.hpp"
 #include "Options/String.hpp"
@@ -81,6 +83,8 @@ struct TimeDependentMapOptions {
   using IdentityMap = domain::CoordinateMaps::Identity<3>;
   // Time-dependent maps
   using ShapeMap = domain::CoordinateMaps::TimeDependent::Shape;
+  using RotScaleTransMap =
+      domain::CoordinateMaps::TimeDependent::RotScaleTrans<3>;
 
   template <typename SourceFrame, typename TargetFrame>
   using IdentityForComposition =
@@ -88,6 +92,14 @@ struct TimeDependentMapOptions {
   using GridToDistortedComposition =
       domain::CoordinateMap<Frame::Grid, Frame::Distorted, ShapeMap>;
   using GridToInertialComposition =
+      domain::CoordinateMap<Frame::Grid, Frame::Inertial, ShapeMap,
+                            RotScaleTransMap>;
+  using GridToInertialSimple =
+      domain::CoordinateMap<Frame::Grid, Frame::Inertial, RotScaleTransMap>;
+  using DistortedToInertialComposition =
+      domain::CoordinateMap<Frame::Distorted, Frame::Inertial,
+                            RotScaleTransMap>;
+  using GridToInertialShapeMap =
       domain::CoordinateMap<Frame::Grid, Frame::Inertial, ShapeMap>;
 
  public:
@@ -95,7 +107,9 @@ struct TimeDependentMapOptions {
       tmpl::list<IdentityForComposition<Frame::Grid, Frame::Inertial>,
                  IdentityForComposition<Frame::Grid, Frame::Distorted>,
                  IdentityForComposition<Frame::Distorted, Frame::Inertial>,
-                 GridToDistortedComposition, GridToInertialComposition>;
+                 GridToDistortedComposition, GridToInertialShapeMap,
+                 GridToInertialSimple, GridToInertialComposition,
+                 DistortedToInertialComposition>;
 
   /// \brief The initial time of the functions of time.
   struct InitialTime {
@@ -131,15 +145,116 @@ struct TimeDependentMapOptions {
     std::optional<std::variant<KerrSchildFromBoyerLindquist>> initial_values{};
   };
 
-  using options = tmpl::list<InitialTime, ShapeMapOptions>;
+  struct RotationMapOptions {
+    using type = Options::Auto<RotationMapOptions, Options::AutoLabel::None>;
+    static std::string name() { return "RotationMap"; }
+    static constexpr Options::String help = {
+        "Options for a time-dependent rotation map about an arbitrary axis. "
+        "Specify 'None' to not use this map."};
+
+    struct InitialValues {
+      using type = std::array<std::array<double, 4>, 3>;
+      static constexpr Options::String help = {
+          "The initial values for the quaternion function and its first two "
+          "derivatives."};
+    };
+
+    struct DecayTimescaleRotation {
+      using type = double;
+      static constexpr Options::String help = {
+          "The timescale for how fast the rotation approaches its asymptotic "
+          "value."};
+    };
+
+    using options = tmpl::list<InitialValues, DecayTimescaleRotation>;
+
+    std::array<std::array<double, 4>, 3> initial_values{};
+    double decay_timescale{
+        std::numeric_limits<double>::signaling_NaN()};
+  };
+
+  struct ExpansionMapOptions {
+    using type = Options::Auto<ExpansionMapOptions, Options::AutoLabel::None>;
+    static std::string name() { return "ExpansionMap"; }
+    static constexpr Options::String help = {
+        "Options for the expansion map. Specify 'None' to not use this map."};
+
+    struct InitialValues {
+      using type = std::array<double, 3>;
+      static constexpr Options::String help = {
+          "Initial value and first two derivatives of expansion."};
+    };
+
+    struct DecayTimescaleExpansion {
+      using type = double;
+      static constexpr Options::String help = {
+          "The timescale for how fast the expansion approaches "
+          "its asymptotic value."};
+    };
+
+    struct InitialValuesOuterBoundary {
+      using type = std::array<double, 3>;
+      static constexpr Options::String help = {
+          "Initial value and first two derivatives of expansion outside the "
+          "transition region."};
+    };
+
+    struct DecayTimescaleExpansionOuterBoundary {
+      using type = double;
+      static constexpr Options::String help = {
+          "The timescale for how fast the expansion approaches "
+          "its asymptotic value outside the transition region."};
+    };
+
+    using options = tmpl::list<InitialValues, DecayTimescaleExpansion,
+                               InitialValuesOuterBoundary,
+                               DecayTimescaleExpansionOuterBoundary>;
+
+    std::array<double, 3> initial_values{
+        std::numeric_limits<double>::signaling_NaN(),
+        std::numeric_limits<double>::signaling_NaN(),
+        std::numeric_limits<double>::signaling_NaN()};
+    double decay_timescale{std::numeric_limits<double>::signaling_NaN()};
+    std::array<double, 3> initial_values_outer_boundary{
+        std::numeric_limits<double>::signaling_NaN(),
+        std::numeric_limits<double>::signaling_NaN(),
+        std::numeric_limits<double>::signaling_NaN()};
+    double decay_timescale_outer_boundary{
+        std::numeric_limits<double>::signaling_NaN()};
+  };
+
+  struct TranslationMapOptions {
+    using type = Options::Auto<TranslationMapOptions, Options::AutoLabel::None>;
+    static std::string name() { return "TranslationMap"; }
+    static constexpr Options::String help = {
+        "Options for a time-dependent translation map in that keeps the "
+        "outer boundary fixed. Specify 'None' to not use this map."};
+
+    struct InitialValues {
+      using type = std::array<std::array<double, 3>, 3>;
+      static constexpr Options::String help = {
+          "Initial values for the translation map, its velocity and "
+          "acceleration."};
+    };
+
+    using options = tmpl::list<InitialValues>;
+
+    std::array<std::array<double, 3>, 3> initial_values{};
+  };
+
+  using options = tmpl::list<InitialTime, ShapeMapOptions, RotationMapOptions,
+                             ExpansionMapOptions, TranslationMapOptions>;
   static constexpr Options::String help{
-      "The options for all the hard-coded time dependent maps in the Sphere "
-      "domain."};
+      "The options for all the hard-coded time dependent maps in the "
+      "Sphere domain."};
 
   TimeDependentMapOptions() = default;
 
-  TimeDependentMapOptions(double initial_time,
-                          const ShapeMapOptions& shape_map_options);
+  TimeDependentMapOptions(
+      double initial_time, const ShapeMapOptions& shape_map_options,
+      std::optional<RotationMapOptions> rotation_map_options,
+      std::optional<ExpansionMapOptions> expansion_map_options,
+      std::optional<TranslationMapOptions> translation_map_options);
 
   /*!
    * \brief Create the function of time map using the options that were
@@ -149,6 +264,10 @@ struct TimeDependentMapOptions {
    *
    * - Size: `PiecewisePolynomial<3>`
    * - Shape: `PiecewisePolynomial<2>`
+   * - Rotation: `SettleToConstantQuaternion`
+   * - Expansion: `SettleToConstant`
+   * - ExpansionOuterBoundary: `PiecewisePolynomial<2>`
+   * - Translation: `PiecewisePolynomial<2>`
    */
   std::unordered_map<std::string,
                      std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
@@ -162,19 +281,24 @@ struct TimeDependentMapOptions {
    * Currently, this constructs a:
    *
    * - Shape: `Shape` (with a size function of time)
+   * - Rotation: `Rotation`
+   * - Expansion: `Expansion`
+   * - Expansion outside the transition region: `ExpansionOuterBoundary`
+   * - Translation: `Translation`
    */
-  void build_maps(const std::array<double, 3>& center, double inner_radius,
-                  double outer_radius);
+  void build_maps(const std::array<double, 3>& center,
+                  std::pair<double, double> inner_shell_radii,
+                  std::pair<double, double> outer_shell_radii);
 
   /*!
    * \brief This will construct the map from `Frame::Distorted` to
    * `Frame::Inertial`.
    *
-   * If the argument `include_distorted_map` is true, then this will be an
-   * identity map. If it is false, then this returns `nullptr`.
+   * If the argument `include_distorted_map` is true, then this will be a
+   * RotScaleTrans map. If it is false, then this returns `nullptr`.
    */
-  static MapType<Frame::Distorted, Frame::Inertial> distorted_to_inertial_map(
-      bool include_distorted_map);
+  MapType<Frame::Distorted, Frame::Inertial> distorted_to_inertial_map(
+      bool include_distorted_map) const;
 
   /*!
    * \brief This will construct the map from `Frame::Grid` to
@@ -188,23 +312,34 @@ struct TimeDependentMapOptions {
       bool include_distorted_map) const;
 
   /*!
-   * \brief This will construct the map from `Frame::Grid` to `Frame::Inertial`.
+   * \brief This will construct the map from `Frame::Grid` to
+   * `Frame::Inertial`.
    *
-   * If the argument `include_distorted_map` is true, then this map will have a
-   * `Shape` map (with a size function of time). If it is false, then there will
-   * only be an identity map.
+   * If the argument `include_distorted_map` is true, then this map will
+   * have a `Shape` map (with a size function of time). If it is false, then
+   * there will be a RotScaleTrans map in either the inner region or in the
+   * transition region.
    */
   MapType<Frame::Grid, Frame::Inertial> grid_to_inertial_map(
-      bool include_distorted_map) const;
+      bool include_distorted_map, bool use_rigid) const;
 
   inline static const std::string size_name{"Size"};
   inline static const std::string shape_name{"Shape"};
+  inline static const std::string rotation_name{"Rotation"};
+  inline static const std::string expansion_name{"Expansion"};
+  inline static const std::string expansion_outer_boundary_name{
+      "ExpansionOuterBoundary"};
+  inline static const std::string translation_name{"Translation"};
 
  private:
   double initial_time_{std::numeric_limits<double>::signaling_NaN()};
-  size_t initial_l_max_{};
   ShapeMap shape_map_{};
-  std::optional<std::variant<KerrSchildFromBoyerLindquist>>
-      initial_shape_values_{};
+  RotScaleTransMap inner_rot_scale_trans_map_{};
+  RotScaleTransMap transition_rot_scale_trans_map_{};
+
+  ShapeMapOptions shape_map_options_{};
+  std::optional<RotationMapOptions> rotation_map_options_{};
+  std::optional<ExpansionMapOptions> expansion_map_options_{};
+  std::optional<TranslationMapOptions> translation_map_options_{};
 };
 }  // namespace domain::creators::sphere

--- a/tests/InputFiles/Xcts/KerrSchild.yaml
+++ b/tests/InputFiles/Xcts/KerrSchild.yaml
@@ -29,7 +29,7 @@ Background: &solution
   KerrSchild:
     Mass: &KerrMass 1.
     Spin: &KerrSpin [0., 0., 0.6]
-    Center: [0., 0., 0.]
+    Center: &KerrCenter [0., 0., 0.]
 
 InitialGuess: Flatness
 
@@ -39,8 +39,8 @@ DomainCreator:
   Sphere:
     # Boyer-Lindquist radius a bit inside the horizon:
     # 0.89 * (M + sqrt(M^2 - a^2))
-    InnerRadius: 1.602
-    OuterRadius: 10.
+    InnerRadius: &InnerRadius 1.602
+    OuterRadius: &OuterRadius 10.
     Interior:
       ExciseWithBoundaryCondition:
         AnalyticSolution:
@@ -56,12 +56,14 @@ DomainCreator:
     RadialPartitioning: []
     RadialDistribution: [Logarithmic]
     TimeDependentMaps:
-      InitialTime: 0.
-      ShapeMap:
+      Shape:
+        InitialTime: 0.
         LMax: 20
-        InitialValues:
-          Mass: *KerrMass
-          Spin: *KerrSpin
+        Mass: *KerrMass
+        Spin: *KerrSpin
+        Center: *KerrCenter
+        InnerRadius: *InnerRadius
+        OuterRadius: *OuterRadius
     OuterBoundaryCondition:
       AnalyticSolution:
         Solution: *solution

--- a/tests/Unit/Domain/Creators/Test_Sphere.cpp
+++ b/tests/Unit/Domain/Creators/Test_Sphere.cpp
@@ -139,6 +139,11 @@ std::string option_string(
                               "    ShapeMap:\n"
                               "      LMax: 10\n"
                               "      InitialValues: Spherical\n"
+                              "    RotationMap: None\n"
+                              "    ExpansionMap: None\n"
+                              "    TranslationMap:\n"
+                              "      InitialValues: [[0.0, 0.0, 0.0],"
+                              " [0.001, -0.003, 0.005], [0.0, 0.0, 0.0]]\n"
                             : "  TimeDependentMaps:\n"
                               "    UniformTranslation:\n"
                               "      InitialTime: 1.0\n"
@@ -235,7 +240,8 @@ void test_sphere_construction(
     const bool expect_boundary_conditions = true,
     const std::vector<double>& times = {0.},
     const std::array<double, 3>& velocity = {{0., 0., 0.}},
-    const std::array<double, 3>& size_values = {{0., 0., 0.}}) {
+    const std::array<double, 3>& size_values = {{0., 0., 0.}},
+    const bool use_hard_coded_maps = true) {
   // check consistency of domain
   const auto domain = TestHelpers::domain::creators::test_domain_creator(
       sphere, expect_boundary_conditions, false, times);
@@ -306,8 +312,8 @@ void test_sphere_construction(
         const double corner_distance_from_origin =
             [&block, &coords_on_spherical_partition, &current_time, &block_id,
              &num_blocks_per_shell, &inner_radius, &outer_radius,
-             &radial_partitioning, &size_values, &functions_of_time,
-             &velocity]() -> double {
+             &radial_partitioning, &size_values, &functions_of_time, &velocity,
+             &is_inner_cube, &num_blocks, &use_hard_coded_maps]() -> double {
           // use stationary map if independent of time
           if (not block.is_time_dependent()) {
             return get(magnitude(
@@ -324,32 +330,76 @@ void test_sphere_construction(
                 get(magnitude(inertial_location_time_dep));
             const double delta_t = current_time - 1.0;
 
-            // Only when using hard coded time dependent maps do we have
-            // distorted maps in the inner shell.
-            if (block.has_distorted_frame()) {
-              CHECK(block_id < num_blocks_per_shell);
-              // This is the calculation of the inverse of the
-              // SphericalCompression map since the shape map is the identity
-              // currently
-              const double min_radius = inner_radius;
-              const double max_radius = radial_partitioning.size() > 0
-                                            ? radial_partitioning[0]
-                                            : outer_radius;
-              const double func =
-                  gsl::at(size_values, 0) + gsl::at(size_values, 1) * delta_t +
-                  0.5 * gsl::at(size_values, 2) * square(delta_t);
-              const double func_Y00 = func / sqrt(4.0 * M_PI);
-              const double max_minus_min = max_radius - min_radius;
-              const double scale =
-                  (max_minus_min + func_Y00 * max_radius / target_radius) /
-                  (max_minus_min + func_Y00);
+            double temp_radius = target_radius;
+            if (use_hard_coded_maps) {
+              // Undo the translation
+              if (block_id + num_blocks_per_shell < num_blocks and
+                  not is_inner_cube) {
+                // For inner shells we are using a translation time dependence.
+                // origin in inertial frame (need to shift inertial
+                // coord by velocity * (final_time - initial_time))
 
-              return target_radius * scale;
-            } else if (block.moving_mesh_grid_to_inertial_map().is_identity()) {
-              // This happens in our test if we have hard coded time dependent
-              // maps, but we aren't in the first shell. Then it's just the
-              // identity map
-              return target_radius;
+                temp_radius = sqrt(square(get<0>(inertial_location_time_dep) -
+                                          velocity[0] * (delta_t)) +
+                                   square(get<1>(inertial_location_time_dep) -
+                                          velocity[1] * (delta_t)) +
+                                   square(get<2>(inertial_location_time_dep) -
+                                          velocity[2] * (delta_t)));
+              } else {
+                // For the outer shell there is a linear transition that leaves
+                // the outer boundary fixed
+                const double min_radius = radial_partitioning.back();
+                const double max_radius = outer_radius;
+                // The radial falloff factor is determined with respect to the
+                // grid frame
+                const auto grid_location_time_dep =
+                    block.moving_mesh_logical_to_grid_map()(
+                        coords_on_spherical_partition, current_time,
+                        functions_of_time);
+                const double grid_target_radius =
+                    get(magnitude(grid_location_time_dep));
+                const double radial_falloff_factor =
+                    (max_radius - grid_target_radius) /
+                    (max_radius - min_radius);
+
+                temp_radius = sqrt(
+                    square(get<0>(inertial_location_time_dep) -
+                           radial_falloff_factor * velocity[0] * (delta_t)) +
+                    square(get<1>(inertial_location_time_dep) -
+                           radial_falloff_factor * velocity[1] * (delta_t)) +
+                    square(get<2>(inertial_location_time_dep) -
+                           radial_falloff_factor * velocity[2] * (delta_t)));
+              }
+
+              // Only when using hard coded time dependent maps do we have
+              // distorted maps in the inner shell.
+              if (block.has_distorted_frame()) {
+                CHECK(block_id < num_blocks_per_shell);
+                // This is the calculation of the inverse of the
+                // SphericalCompression map since the shape map is the identity
+                // currently
+                const double min_radius = inner_radius;
+                const double max_radius = not radial_partitioning.empty()
+                                              ? radial_partitioning[0]
+                                              : outer_radius;
+                const double func =
+                    gsl::at(size_values, 0) +
+                    gsl::at(size_values, 1) * delta_t +
+                    0.5 * gsl::at(size_values, 2) * square(delta_t);
+                const double func_Y00 = func / sqrt(4.0 * M_PI);
+                const double max_minus_min = max_radius - min_radius;
+                const double scale =
+                    (max_minus_min + func_Y00 * max_radius / target_radius) /
+                    (max_minus_min + func_Y00);
+
+                return temp_radius * scale;
+              } else {
+                // This happens in our test if we have hard coded time dependent
+                // maps, but we aren't in the first shell. Then it's just the
+                // identity map
+                return temp_radius;
+              }
+
             } else {
               // This means we are using a translation time dependence.
               // origin in inertial frame (need to shift inertial
@@ -535,11 +585,17 @@ void test_parse_errors() {
           "an outflow-type boundary condition, you must use that."));
   using TDMO = domain::creators::sphere::TimeDependentMapOptions;
   CHECK_THROWS_WITH(
-      creators::Sphere(
-          inner_radius, outer_radius, inner_cube, refinement, initial_extents,
-          use_equiangular_map, equatorial_compression, radial_partitioning,
-          radial_distribution, which_wedges,
-          TDMO{1.0, TDMO::ShapeMapOptions{5, std::nullopt}}, nullptr),
+      creators::Sphere(inner_radius, outer_radius, inner_cube, refinement,
+                       initial_extents, use_equiangular_map,
+                       equatorial_compression, radial_partitioning,
+                       radial_distribution, which_wedges,
+                       TDMO{1.0, TDMO::ShapeMapOptions{5, std::nullopt},
+                            std::nullopt, std::nullopt,
+                            TDMO::TranslationMapOptions{
+                                std::array<double, 3>{0.0, 0.0, 0.0},
+                                std::array<double, 3>{0.001, -0.003, 0.005},
+                                std::array<double, 3>{0.0, 0.0, 0.0}}},
+                       nullptr),
       Catch::Matchers::ContainsSubstring(
           "Currently cannot use hard-coded time dependent maps with an inner "
           "cube. Use a TimeDependence instead."));
@@ -580,7 +636,7 @@ void test_sphere() {
   const size_t l_max = 10;
   const std::vector<double> times{1., 10.};
 
-  for (auto [interior_index, equiangular, equatorial_compression, array_index,
+  for (auto [interior_index, equiangular, equatorial_compression, index,
              which_wedges, time_dependent, use_hard_coded_time_dep_options,
              with_boundary_conditions] :
        random_sample<5>(
@@ -601,8 +657,6 @@ void test_sphere() {
     CAPTURE(fill_interior);
     CAPTURE(equiangular);
     CAPTURE(equatorial_compression.has_value());  // Whether map is present.
-    CAPTURE(radial_partitioning[array_index]);
-    CAPTURE(radial_distribution[array_index]);
     CAPTURE(which_wedges);
     CAPTURE(time_dependent);
     CAPTURE(with_boundary_conditions);
@@ -614,28 +668,48 @@ void test_sphere() {
     }
     CAPTURE(use_hard_coded_time_dep_options);
 
+    // If we are using hard coded maps, we need at least two shells (or one
+    // radial partition) for the translation map.
+    const auto array_index =
+        (use_hard_coded_time_dep_options and
+                 gsl::at(radial_partitioning, index).empty()
+             ? index + 1
+             : index);
+    CAPTURE(gsl::at(radial_partitioning, array_index));
+    CAPTURE(gsl::at(radial_distribution, array_index));
+
     if (which_wedges != ShellWedges::All and with_boundary_conditions) {
       continue;
     }
 
     creators::Sphere::RadialDistribution::type radial_distribution_variant;
-    if (radial_distribution[array_index].size() == 1) {
-      radial_distribution_variant = radial_distribution[array_index][0];
+    if (gsl::at(radial_distribution, array_index).size() == 1) {
+      radial_distribution_variant =
+          gsl::at(radial_distribution, array_index)[0];
     } else {
-      radial_distribution_variant = radial_distribution[array_index];
+      radial_distribution_variant = gsl::at(radial_distribution, array_index);
     }
 
     std::optional<creators::Sphere::TimeDepOptionType> time_dependent_options{};
 
+    auto translation_velocity = std::array<double, 3>{{0., 0., 0.}};
+
     if (time_dependent) {
       if (use_hard_coded_time_dep_options) {
+        translation_velocity = std::array<double, 3>{{0.001, -0.003, 0.005}};
         time_dependent_options = creators::sphere::TimeDependentMapOptions(
-            1.0, creators::sphere::TimeDependentMapOptions::ShapeMapOptions{
-                     l_max, std::nullopt});
+            1.0,
+            creators::sphere::TimeDependentMapOptions::ShapeMapOptions{
+                l_max, std::nullopt},
+            std::nullopt, std::nullopt,
+            creators::sphere::TimeDependentMapOptions::TranslationMapOptions{
+                std::array<double, 3>{0.0, 0.0, 0.0}, translation_velocity,
+                std::array<double, 3>{0.0, 0.0, 0.0}});
       } else {
         time_dependent_options = std::make_unique<
             domain::creators::time_dependence::UniformTranslation<3, 0>>(
             1.0, velocity);
+        translation_velocity = velocity;
       }
     }
 
@@ -647,23 +721,22 @@ void test_sphere() {
         initial_extents,
         equiangular,
         equatorial_compression,
-        radial_partitioning[array_index],
+        gsl::at(radial_partitioning, array_index),
         radial_distribution_variant,
         which_wedges,
         std::move(time_dependent_options),
         with_boundary_conditions ? create_boundary_condition(true) : nullptr};
-    test_sphere_construction(
-        sphere, inner_radius, outer_radius, fill_interior,
-        radial_partitioning[array_index], which_wedges,
-        with_boundary_conditions,
-        time_dependent ? times : std::vector<double>{0.},
-        time_dependent ? velocity : std::array<double, 3>{{0., 0., 0.}},
-        size_values);
+    test_sphere_construction(sphere, inner_radius, outer_radius, fill_interior,
+                             gsl::at(radial_partitioning, array_index),
+                             which_wedges, with_boundary_conditions,
+                             time_dependent ? times : std::vector<double>{0.},
+                             translation_velocity, size_values,
+                             use_hard_coded_time_dep_options);
     TestHelpers::domain::creators::test_creation(
         option_string(inner_radius, outer_radius, interior, initial_refinement,
                       initial_extents, equiangular, equatorial_compression,
-                      radial_partitioning[array_index],
-                      radial_distribution[array_index], which_wedges,
+                      gsl::at(radial_partitioning, array_index),
+                      gsl::at(radial_distribution, array_index), which_wedges,
                       time_dependent, use_hard_coded_time_dep_options,
                       with_boundary_conditions),
         sphere, with_boundary_conditions);

--- a/tests/Unit/Domain/Creators/Test_SphereTimeDependentMaps.cpp
+++ b/tests/Unit/Domain/Creators/Test_SphereTimeDependentMaps.cpp
@@ -34,25 +34,36 @@ std::string create_option_string(const bool use_non_zero_shape) {
          (use_non_zero_shape ? "  InitialValues:\n"
                                "    Mass: 1.0\n"
                                "    Spin: [0.0, 0.0, 0.0]\n"s
-                             : "  InitialValues: Spherical\n"s);
+                             : "  InitialValues: Spherical\n"s) +
+         "RotationMap: None\n"
+         "ExpansionMap: None\n"
+         "TranslationMap:\n"
+         "  InitialValues: [[0.1, -3.2, 1.1], [-0.3, 0.5, -0.7],"
+         " [0.1, -0.4, 0.02]]\n"s;
 }
 void test(const bool use_non_zero_shape) {
   CAPTURE(use_non_zero_shape);
   const double initial_time = 1.5;
   const size_t l_max = 8;
 
-  TimeDependentMapOptions time_dep_options =
-      TestHelpers::test_creation<TimeDependentMapOptions>(
-          create_option_string(use_non_zero_shape));
+  auto time_dep_options = TestHelpers::test_creation<TimeDependentMapOptions>(
+      create_option_string(use_non_zero_shape));
 
   std::unordered_map<std::string, double> expiration_times{
       {TimeDependentMapOptions::shape_name, 15.5},
       {TimeDependentMapOptions::size_name,
+       std::numeric_limits<double>::infinity()},
+      {TimeDependentMapOptions::translation_name,
        std::numeric_limits<double>::infinity()}};
 
   // These are hard-coded so this is just a regression test
   CHECK(TimeDependentMapOptions::size_name == "Size"s);
   CHECK(TimeDependentMapOptions::shape_name == "Shape"s);
+  CHECK(TimeDependentMapOptions::rotation_name == "Rotation"s);
+  CHECK(TimeDependentMapOptions::expansion_name == "Expansion"s);
+  CHECK(TimeDependentMapOptions::expansion_outer_boundary_name ==
+        "ExpansionOuterBoundary"s);
+  CHECK(TimeDependentMapOptions::translation_name == "Translation"s);
 
   using PP2 = domain::FunctionsOfTime::PiecewisePolynomial<2>;
   using PP3 = domain::FunctionsOfTime::PiecewisePolynomial<3>;
@@ -70,9 +81,20 @@ void test(const bool use_non_zero_shape) {
       std::array<DataVector, 3>{shape_zeros, shape_zeros, shape_zeros},
       expiration_times.at(TimeDependentMapOptions::shape_name)};
 
+  DataVector initial_translation_center{{0.1, -3.2, 1.1}};
+  DataVector initial_velocity{{-0.3, 0.5, -0.7}};
+  DataVector initial_translation_acceleration{{0.1, -0.4, 0.02}};
+  PP2 translation_non_zero{
+      initial_time,
+      std::array<DataVector, 3>{{initial_translation_center, initial_velocity,
+                                 initial_translation_acceleration}},
+      expiration_times.at(TimeDependentMapOptions::translation_name)};
+
   const std::array<double, 3> center{-5.0, -0.01, -0.02};
   const double inner_radius = 0.5;
   const double outer_radius = 2.1;
+  const double transition_inner_radius = 3.1;
+  const double transition_outer_radius = 3.9;
 
   const auto functions_of_time =
       time_dep_options.create_functions_of_time(inner_radius, expiration_times);
@@ -86,35 +108,49 @@ void test(const bool use_non_zero_shape) {
             *functions_of_time.at(TimeDependentMapOptions::shape_name).get()) ==
         shape_all_zero);
 
+  CHECK(dynamic_cast<PP2&>(
+            *functions_of_time.at(TimeDependentMapOptions::translation_name)
+                 .get()) == translation_non_zero);
+
   for (const bool include_distorted : make_array(true, false)) {
-    time_dep_options.build_maps(center, inner_radius, outer_radius);
+    for (const bool use_rigid : make_array(true, false)) {
+      time_dep_options.build_maps(
+          center, std::pair<double, double>{inner_radius, outer_radius},
+          std::pair<double, double>{transition_inner_radius,
+                                    transition_outer_radius});
 
-    const auto grid_to_distorted_map =
-        time_dep_options.grid_to_distorted_map(include_distorted);
-    const auto grid_to_inertial_map =
-        time_dep_options.grid_to_inertial_map(include_distorted);
-    const auto distorted_to_inertial_map =
-        time_dep_options.distorted_to_inertial_map(include_distorted);
+      const auto grid_to_distorted_map =
+          time_dep_options.grid_to_distorted_map(include_distorted);
+      const auto grid_to_inertial_map =
+          time_dep_options.grid_to_inertial_map(include_distorted, use_rigid);
+      const auto distorted_to_inertial_map =
+          time_dep_options.distorted_to_inertial_map(include_distorted);
 
-    // All of these maps are tested individually. Rather than going through the
-    // effort of coming up with a source coordinate and calculating analytically
-    // what we would get after it's mapped, we just check that whether it's
-    // supposed to be a nullptr and if it's not, if it's the identity and that
-    // the jacobians are time dependent.
-    const auto check_map = [](const auto& map, const bool is_null,
-                              const bool is_identity) {
-      if (is_null) {
-        CHECK(map == nullptr);
-      } else {
-        CHECK(map->is_identity() == is_identity);
-        CHECK(map->inv_jacobian_is_time_dependent() == not is_identity);
-        CHECK(map->jacobian_is_time_dependent() == not is_identity);
-      }
-    };
+      // All of these maps are tested individually. Rather than going through
+      // the effort of coming up with a source coordinate and calculating
+      // analytically what we would get after it's mapped, we just check that
+      // whether it's supposed to be a nullptr and if it's not, if it's the
+      // identity and that the jacobians are time dependent.
+      const auto check_map = [](const auto& map, const bool is_null,
+                                const bool is_identity) {
+        if (is_null) {
+          CHECK(map == nullptr);
+        } else {
+          CHECK(map->is_identity() == is_identity);
+          CHECK(map->inv_jacobian_is_time_dependent() == not is_identity);
+          CHECK(map->jacobian_is_time_dependent() == not is_identity);
+        }
+      };
 
-    check_map(grid_to_inertial_map, false, not include_distorted);
-    check_map(grid_to_distorted_map, not include_distorted, false);
-    check_map(distorted_to_inertial_map, not include_distorted, true);
+      // There is no null pointer in the grid to inertial map
+      check_map(grid_to_inertial_map, false, false);
+
+      check_map(grid_to_distorted_map, not include_distorted, false);
+
+      // If no shape distortion, there is only the rotation, expansion and
+      // translation maps
+      check_map(distorted_to_inertial_map, not include_distorted, false);
+    }
   }
 }
 

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_ComputeDestVars.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_ComputeDestVars.cpp
@@ -108,11 +108,16 @@ void test() {
   domain::FunctionsOfTime::register_derived_with_charm();
 
   using TDMO = domain::creators::sphere::TimeDependentMapOptions;
-  TDMO time_dep_opts{0.0, TDMO::ShapeMapOptions{2, std::nullopt}};
+  TDMO time_dep_opts{0.0, TDMO::ShapeMapOptions{2, std::nullopt}, std::nullopt,
+                     std::nullopt, std::nullopt};
 
   const auto domain_creator = domain::creators::Sphere(
-      0.9, 4.9, domain::creators::Sphere::Excision{}, 1_st, 7_st, false, {}, {},
-      {}, {}, time_dep_opts);
+      0.9, 4.9, domain::creators::Sphere::Excision{}, 1_st, 7_st, false, {},
+      std::vector<double>{2.0},
+      std::vector<domain::CoordinateMaps::Distribution>{
+          {domain::CoordinateMaps::Distribution::Linear,
+           domain::CoordinateMaps::Distribution::Linear}},
+      {}, time_dep_opts);
   const Domain<3> domain = domain_creator.create_domain();
 
   Parallel::GlobalCache<Metavars> cache{{domain_creator.functions_of_time()}};


### PR DESCRIPTION
## Proposed changes

We add the RotScaleTrans time-dependent maps as options for the Sphere domain

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
