### PR TITLE
Add pound symbols to the check for an error message in the validate CLI

### DIFF
--- a/tools/ValidateInputFile.py
+++ b/tools/ValidateInputFile.py
@@ -124,7 +124,7 @@ def validate_input_file(
             elif line.startswith("While operating factory for"):
                 # remove "unique_ptr" entry from path
                 path.pop()
-            elif "ERROR" in line:
+            elif "# ERROR #" in line:
                 break
             else:
                 msg.append(line)


### PR DESCRIPTION
The ErrorIfDataTooBig event has the word "ERROR" in the message so the validate CLI exited early and didn't show all the options.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
