### PR TITLE
Introduce AMR policies

### DIFF
--- a/src/Evolution/Executables/GeneralizedHarmonic/CMakeLists.txt
+++ b/src/Evolution/Executables/GeneralizedHarmonic/CMakeLists.txt
@@ -2,9 +2,6 @@
 # See LICENSE.txt for details.
 
 set(LIBS_TO_LINK
-  Amr
-  AmrCriteria
-  AmrProjectors
   Charmxx::main
   CoordinateMaps
   DiscontinuousGalerkin
@@ -25,6 +22,7 @@ set(LIBS_TO_LINK
   Observer
   Options
   Parallel
+  ParallelAmr
   ParallelInterpolation
   PhaseControl
   Serialization

--- a/src/Evolution/Executables/GeneralizedHarmonic/GeneralizedHarmonicBase.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/GeneralizedHarmonicBase.hpp
@@ -347,8 +347,7 @@ struct GeneralizedHarmonicTemplateBase {
                  gh::ConstraintDamping::Tags::DampingFunctionGamma1<
                      volume_dim, Frame::Grid>,
                  gh::ConstraintDamping::Tags::DampingFunctionGamma2<
-                     volume_dim, Frame::Grid>,
-                 ::amr::Criteria::Tags::Criteria>;
+                     volume_dim, Frame::Grid>>;
 
   using dg_registration_list =
       tmpl::list<observers::Actions::RegisterEventsWithObservers>;

--- a/src/Evolution/Executables/ScalarWave/CMakeLists.txt
+++ b/src/Evolution/Executables/ScalarWave/CMakeLists.txt
@@ -3,9 +3,6 @@
 
 set(LIBS_TO_LINK
   Charmxx::main
-  Amr
-  AmrCriteria
-  AmrProjectors
   CoordinateMaps
   DiscontinuousGalerkin
   DomainCreators
@@ -20,6 +17,7 @@ set(LIBS_TO_LINK
   Observer
   Options
   Parallel
+  ParallelAmr
   PhaseControl
   Serialization
   Time

--- a/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
+++ b/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
@@ -269,8 +269,7 @@ struct EvolutionMetavars {
           tmpl::list<>>>>;
 
   using const_global_cache_tags =
-      tmpl::list<evolution::initial_data::Tags::InitialData,
-                 ::amr::Criteria::Tags::Criteria>;
+      tmpl::list<evolution::initial_data::Tags::InitialData>;
 
   using dg_registration_list =
       tmpl::list<observers::Actions::RegisterEventsWithObservers>;

--- a/src/Executables/Examples/RandomAmr/CMakeLists.txt
+++ b/src/Executables/Examples/RandomAmr/CMakeLists.txt
@@ -2,14 +2,12 @@
 # See LICENSE.txt for details.
 
 set(LIBS_TO_LINK
-  Amr
-  AmrCriteria
-  AmrProjectors
   Charmxx::main
   DomainCreators
   Informer
   Logging
   Options
+  ParallelAmr
   PhaseControl
   Spectral
   Utilities

--- a/src/Executables/Examples/RandomAmr/RandomAmr.hpp
+++ b/src/Executables/Examples/RandomAmr/RandomAmr.hpp
@@ -77,8 +77,6 @@ struct RandomAmrMetavars {
         tmpl::pair<Trigger, tmpl::list<Triggers::Always>>>;
   };
 
-  using const_global_cache_tags = tmpl::list<amr::Criteria::Tags::Criteria>;
-
   static constexpr auto default_phase_order =
       std::array{Parallel::Phase::Initialization, Parallel::Phase::CheckDomain,
                  Parallel::Phase::Evolve, Parallel::Phase::Exit};

--- a/src/Executables/ExportCoordinates/CMakeLists.txt
+++ b/src/Executables/ExportCoordinates/CMakeLists.txt
@@ -2,9 +2,6 @@
 # See LICENSE.txt for details.
 
 set(LIBS_TO_LINK
-  Amr
-  AmrCriteria
-  AmrProjectors
   Charmxx::main
   CoordinateMaps
   DgSubcell
@@ -18,6 +15,7 @@ set(LIBS_TO_LINK
   Observer
   Options
   Parallel
+  ParallelAmr
   PhaseControl
   Spectral
   Time

--- a/src/Executables/ExportCoordinates/ExportCoordinates.hpp
+++ b/src/Executables/ExportCoordinates/ExportCoordinates.hpp
@@ -277,8 +277,6 @@ struct Metavariables {
     static constexpr bool enable_time_dependent_maps = EnableTimeDependentMaps;
   };
 
-  using const_global_cache_tags = tmpl::list<amr::Criteria::Tags::Criteria>;
-
   static constexpr Options::String help{
       "Export the inertial coordinates of the Domain specified in the input "
       "file. The output can be used to compute initial data externally, for "

--- a/src/ParallelAlgorithms/Amr/Actions/Component.hpp
+++ b/src/ParallelAlgorithms/Amr/Actions/Component.hpp
@@ -29,6 +29,8 @@ struct Component {
 
   using chare_type = Parallel::Algorithms::Singleton;
 
+  using const_global_cache_tags = tmpl::list<amr::Criteria::Tags::Criteria>;
+
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<Parallel::Phase::Initialization, tmpl::list<>>>;
 
@@ -41,19 +43,15 @@ struct Component {
     auto& local_cache = *Parallel::local_branch(global_cache_proxy);
     Parallel::get_parallel_component<Component>(local_cache)
         .start_phase(next_phase);
-    if constexpr (tmpl::list_contains_v<typename Parallel::GlobalCache<
-                                            Metavariables>::const_tags_list,
-                                        amr::Criteria::Tags::Criteria>) {
-      if (Parallel::Phase::EvaluateAmrCriteria == next_phase) {
-        Parallel::simple_action<::amr::Actions::EvaluateRefinementCriteria>(
-            Parallel::get_parallel_component<
-                typename metavariables::dg_element_array>(local_cache));
-      }
-      if (Parallel::Phase::AdjustDomain == next_phase) {
-        Parallel::simple_action<::amr::Actions::AdjustDomain>(
-            Parallel::get_parallel_component<
-                typename metavariables::dg_element_array>(local_cache));
-      }
+    if (Parallel::Phase::EvaluateAmrCriteria == next_phase) {
+      Parallel::simple_action<::amr::Actions::EvaluateRefinementCriteria>(
+          Parallel::get_parallel_component<
+              typename metavariables::dg_element_array>(local_cache));
+    }
+    if (Parallel::Phase::AdjustDomain == next_phase) {
+      Parallel::simple_action<::amr::Actions::AdjustDomain>(
+          Parallel::get_parallel_component<
+              typename metavariables::dg_element_array>(local_cache));
     }
   }
 };

--- a/src/ParallelAlgorithms/Amr/Actions/Component.hpp
+++ b/src/ParallelAlgorithms/Amr/Actions/Component.hpp
@@ -11,6 +11,7 @@
 #include "ParallelAlgorithms/Amr/Actions/AdjustDomain.hpp"
 #include "ParallelAlgorithms/Amr/Actions/EvaluateRefinementCriteria.hpp"
 #include "ParallelAlgorithms/Amr/Criteria/Tags/Criteria.hpp"
+#include "ParallelAlgorithms/Amr/Policies/Tags.hpp"
 #include "Utilities/TMPL.hpp"
 
 /// \ingroup AmrGroup
@@ -29,7 +30,8 @@ struct Component {
 
   using chare_type = Parallel::Algorithms::Singleton;
 
-  using const_global_cache_tags = tmpl::list<amr::Criteria::Tags::Criteria>;
+  using const_global_cache_tags =
+      tmpl::list<amr::Criteria::Tags::Criteria, amr::Tags::Policies>;
 
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<Parallel::Phase::Initialization, tmpl::list<>>>;

--- a/src/ParallelAlgorithms/Amr/CMakeLists.txt
+++ b/src/ParallelAlgorithms/Amr/CMakeLists.txt
@@ -25,5 +25,6 @@ target_link_libraries(
 
 add_subdirectory(Actions)
 add_subdirectory(Criteria)
+add_subdirectory(Policies)
 add_subdirectory(Projectors)
 add_subdirectory(Protocols)

--- a/src/ParallelAlgorithms/Amr/CMakeLists.txt
+++ b/src/ParallelAlgorithms/Amr/CMakeLists.txt
@@ -16,6 +16,9 @@ target_link_libraries(
   ${LIBRARY}
   INTERFACE
   Amr
+  AmrCriteria
+  AmrPolicies
+  AmrProjectors
   DataStructures
   Initialization
   Logging

--- a/src/ParallelAlgorithms/Amr/Policies/CMakeLists.txt
+++ b/src/ParallelAlgorithms/Amr/Policies/CMakeLists.txt
@@ -20,6 +20,7 @@ spectre_target_headers(
   EnforcePolicies.hpp
   Isotropy.hpp
   Policies.hpp
+  Tags.hpp
   )
 
 target_link_libraries(

--- a/src/ParallelAlgorithms/Amr/Policies/CMakeLists.txt
+++ b/src/ParallelAlgorithms/Amr/Policies/CMakeLists.txt
@@ -8,6 +8,7 @@ add_spectre_library(${LIBRARY})
 spectre_target_sources(
   ${LIBRARY}
   PRIVATE
+  EnforcePolicies.cpp
   Isotropy.cpp
   Policies.cpp
   )
@@ -16,6 +17,7 @@ spectre_target_headers(
   ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
+  EnforcePolicies.hpp
   Isotropy.hpp
   Policies.hpp
   )

--- a/src/ParallelAlgorithms/Amr/Policies/CMakeLists.txt
+++ b/src/ParallelAlgorithms/Amr/Policies/CMakeLists.txt
@@ -9,6 +9,7 @@ spectre_target_sources(
   ${LIBRARY}
   PRIVATE
   Isotropy.cpp
+  Policies.cpp
   )
 
 spectre_target_headers(
@@ -16,6 +17,7 @@ spectre_target_headers(
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   Isotropy.hpp
+  Policies.hpp
   )
 
 target_link_libraries(

--- a/src/ParallelAlgorithms/Amr/Policies/CMakeLists.txt
+++ b/src/ParallelAlgorithms/Amr/Policies/CMakeLists.txt
@@ -1,0 +1,25 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBRARY AmrPolicies)
+
+add_spectre_library(${LIBRARY})
+
+spectre_target_sources(
+  ${LIBRARY}
+  PRIVATE
+  Isotropy.cpp
+  )
+
+spectre_target_headers(
+  ${LIBRARY}
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  Isotropy.hpp
+  )
+
+target_link_libraries(
+  ${LIBRARY}
+  PUBLIC
+  Options
+  )

--- a/src/ParallelAlgorithms/Amr/Policies/EnforcePolicies.cpp
+++ b/src/ParallelAlgorithms/Amr/Policies/EnforcePolicies.cpp
@@ -1,0 +1,32 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "ParallelAlgorithms/Amr/Policies/EnforcePolicies.hpp"
+
+#include "Domain/Amr/Flag.hpp"
+#include "ParallelAlgorithms/Amr/Policies/Policies.hpp"
+#include "Utilities/Algorithm.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeArray.hpp"
+
+namespace amr {
+template <size_t Dim>
+void enforce_policies(const gsl::not_null<std::array<Flag, Dim>*> amr_decision,
+                      const amr::Policies& amr_policies) {
+  if (amr_policies.isotropy() == amr::Isotropy::Isotropic) {
+    *amr_decision = make_array<Dim>(*alg::max_element(*amr_decision));
+  }
+}
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define INSTANTIATE(_, data)                                    \
+  template void enforce_policies(                               \
+      gsl::not_null<std::array<Flag, DIM(data)>*> amr_decision, \
+      const amr::Policies& amr_policies);
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
+
+#undef INSTANTIATE
+#undef DIM
+}  // namespace amr

--- a/src/ParallelAlgorithms/Amr/Policies/EnforcePolicies.hpp
+++ b/src/ParallelAlgorithms/Amr/Policies/EnforcePolicies.hpp
@@ -1,0 +1,25 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+
+/// \cond
+namespace amr {
+enum class Flag;
+class Policies;
+}  // namespace amr
+namespace gsl {
+template <typename T>
+class not_null;
+}  // namespace gsl
+/// \endcond
+
+namespace amr {
+/// \brief Updates amr_decision so that it satisfies amr_policies
+template <size_t Dim>
+void enforce_policies(gsl::not_null<std::array<Flag, Dim>*> amr_decision,
+                      const amr::Policies& amr_policies);
+}  // namespace amr

--- a/src/ParallelAlgorithms/Amr/Policies/Isotropy.cpp
+++ b/src/ParallelAlgorithms/Amr/Policies/Isotropy.cpp
@@ -1,0 +1,52 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "ParallelAlgorithms/Amr/Policies/Isotropy.hpp"
+
+#include <ostream>
+#include <vector>
+
+#include "Options/Options.hpp"
+#include "Options/ParseOptions.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/GetOutput.hpp"
+#include "Utilities/StdHelpers.hpp"
+
+namespace {
+std::vector<amr::Isotropy> known_amr_isotropies() {
+  return std::vector{amr::Isotropy::Anisotropic, amr::Isotropy::Isotropic};
+}
+}  // namespace
+
+namespace amr {
+
+std::ostream& operator<<(std::ostream& os, const Isotropy& isotropy) {
+  switch (isotropy) {
+    case Isotropy::Anisotropic:
+      os << "Anisotropic";
+      break;
+    case Isotropy::Isotropic:
+      os << "Isotropic";
+      break;
+    default:
+      ERROR("An undefined isotropy was passed to the stream operator.");
+  }
+  return os;
+}
+}  // namespace amr
+
+template <>
+amr::Isotropy Options::create_from_yaml<amr::Isotropy>::create<void>(
+    const Options::Option& options) {
+  const auto type_read = options.parse_as<std::string>();
+  for (const auto isotropy : known_amr_isotropies()) {
+    if (type_read == get_output(isotropy)) {
+      return isotropy;
+    }
+  }
+  using ::operator<<;
+  PARSE_ERROR(options.context(), "Failed to convert \""
+                                     << type_read
+                                     << "\" to amr::Isotropy.\nMust be one of "
+                                     << known_amr_isotropies() << ".");
+}

--- a/src/ParallelAlgorithms/Amr/Policies/Isotropy.hpp
+++ b/src/ParallelAlgorithms/Amr/Policies/Isotropy.hpp
@@ -1,0 +1,42 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+/// \file
+/// Defines enum class amr::Isotropy.
+
+#pragma once
+
+#include <iosfwd>
+
+/// \cond
+namespace Options {
+class Option;
+template <typename T>
+struct create_from_yaml;
+}  // namespace Options
+/// \endcond
+
+namespace amr {
+
+/// \ingroup AmrGroup
+/// \brief Isotropy of adaptive mesh refinement
+enum class Isotropy {
+  Anisotropic, /**< each dimension can be refined independently */
+  Isotropic    /**< all dimensions must be refined the same */
+};
+
+/// Output operator for isotropy.
+std::ostream& operator<<(std::ostream& os, const Isotropy& isotropy);
+}  // namespace amr
+
+template <>
+struct Options::create_from_yaml<amr::Isotropy> {
+  template <typename Metavariables>
+  static amr::Isotropy create(const Options::Option& options) {
+    return create<void>(options);
+  }
+};
+
+template <>
+amr::Isotropy Options::create_from_yaml<amr::Isotropy>::create<void>(
+    const Options::Option& options);

--- a/src/ParallelAlgorithms/Amr/Policies/Policies.cpp
+++ b/src/ParallelAlgorithms/Amr/Policies/Policies.cpp
@@ -1,0 +1,22 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "ParallelAlgorithms/Amr/Policies/Policies.hpp"
+
+#include <pup.h>
+#include <pup_stl.h>
+
+namespace amr {
+Policies::Policies(const amr::Isotropy isotropy) : isotropy_(isotropy) {}
+
+void Policies::pup(PUP::er& p) { p | isotropy_; }
+
+bool operator==(const Policies& lhs, const Policies& rhs) {
+  return lhs.isotropy() == rhs.isotropy();
+}
+
+bool operator!=(const Policies& lhs, const Policies& rhs) {
+  return not(lhs == rhs);
+}
+
+}  // namespace amr

--- a/src/ParallelAlgorithms/Amr/Policies/Policies.hpp
+++ b/src/ParallelAlgorithms/Amr/Policies/Policies.hpp
@@ -1,0 +1,48 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "Options/String.hpp"
+#include "ParallelAlgorithms/Amr/Policies/Isotropy.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+namespace PUP {
+class er;
+}  // namespace PUP
+/// \endcond
+
+namespace amr {
+/// \brief A set of runtime policies controlling adaptive mesh refinement
+class Policies {
+ public:
+  /// The isotropy of AMR
+  struct Isotropy {
+    using type = amr::Isotropy;
+    static constexpr Options::String help = {
+        "Isotropy of adaptive mesh refinement (whether or not each dimension "
+        "can be refined independently)."};
+  };
+
+  using options = tmpl::list<Isotropy>;
+
+  static constexpr Options::String help = {
+      "Policies controlling adaptive mesh refinement."};
+
+  Policies() = default;
+
+  explicit Policies(amr::Isotropy isotropy);
+
+  amr::Isotropy isotropy() const { return isotropy_; }
+
+  void pup(PUP::er& p);
+
+ private:
+  amr::Isotropy isotropy_{amr::Isotropy::Anisotropic};
+};
+
+bool operator==(const Policies& lhs, const Policies& rhs);
+
+bool operator!=(const Policies& lhs, const Policies& rhs);
+}  // namespace amr

--- a/src/ParallelAlgorithms/Amr/Policies/Tags.hpp
+++ b/src/ParallelAlgorithms/Amr/Policies/Tags.hpp
@@ -1,0 +1,38 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <memory>
+#include <unordered_set>
+#include <vector>
+
+#include "DataStructures/DataBox/Tag.hpp"
+#include "Options/String.hpp"
+#include "ParallelAlgorithms/Amr/Policies/Policies.hpp"
+#include "ParallelAlgorithms/Amr/Tags.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace amr {
+/// Option tags for AMR polocies
+namespace OptionTags {
+/// \ingroup OptionTagsGroup
+/// Options for AMR policies
+struct Policies {
+  static constexpr Options::String help = "Options for AMR policies";
+  using type = amr::Policies;
+  using group = amr::OptionTags::AmrGroup;
+};
+}  // namespace OptionTags
+
+namespace Tags {
+/// The policies for adaptive mesh refinement
+struct Policies : db::SimpleTag {
+  using type = amr::Policies;
+  using option_tags = tmpl::list<amr::OptionTags::Policies>;
+
+  static constexpr bool pass_metavariables = false;
+  static type create_from_options(const type& value) { return value; }
+};
+}  // namespace Tags
+}  // namespace amr

--- a/support/Pipelines/Bbh/Ringdown.yaml
+++ b/support/Pipelines/Bbh/Ringdown.yaml
@@ -98,9 +98,6 @@ Observers:
   ReductionFileName: "BbhReductions"
   SurfaceFileName: "BbhSurfaces"
 
-Amr:
-  Criteria:
-
 PhaseChangeAndTriggers:
   - Trigger:
       Slabs:

--- a/tests/InputFiles/ExampleExecutables/RandomAmr1D.yaml
+++ b/tests/InputFiles/ExampleExecutables/RandomAmr1D.yaml
@@ -20,6 +20,8 @@ Amr:
     - Random:
         ChangeRefinementFraction: 0.8
         MaximumRefinementLevel: 8
+  Policies:
+    Isotropy: Anisotropic
   Verbosity: Verbose
 
 DomainCreator:

--- a/tests/InputFiles/ExportCoordinates/Input1D.yaml
+++ b/tests/InputFiles/ExportCoordinates/Input1D.yaml
@@ -19,6 +19,8 @@ Amr:
     - Random:
         ChangeRefinementFraction: 0.8
         MaximumRefinementLevel: 4
+  Policies:
+    Isotropy: Anisotropic
   Verbosity: Verbose
 
 ResourceInfo:

--- a/tests/InputFiles/ExportCoordinates/Input2D.yaml
+++ b/tests/InputFiles/ExportCoordinates/Input2D.yaml
@@ -16,6 +16,8 @@ Parallelization:
 
 Amr:
   Criteria:
+  Policies:
+    Isotropy: Anisotropic
   Verbosity: Quiet
 
 ResourceInfo:

--- a/tests/InputFiles/ExportCoordinates/Input3D.yaml
+++ b/tests/InputFiles/ExportCoordinates/Input3D.yaml
@@ -16,6 +16,8 @@ Parallelization:
 
 Amr:
   Criteria:
+  Policies:
+    Isotropy: Anisotropic
   Verbosity: Quiet
 
 ResourceInfo:

--- a/tests/InputFiles/ExportCoordinates/InputTimeDependent3D.yaml
+++ b/tests/InputFiles/ExportCoordinates/InputTimeDependent3D.yaml
@@ -17,6 +17,8 @@ Parallelization:
 
 Amr:
   Criteria:
+  Policies:
+    Isotropy: Anisotropic
   Verbosity: Quiet
 
 ResourceInfo:

--- a/tests/InputFiles/GeneralizedHarmonic/GaugeWave1D.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/GaugeWave1D.yaml
@@ -27,6 +27,8 @@ Evolution:
 
 Amr:
   Criteria:
+  Policies:
+    Isotropy: Anisotropic
   Verbosity: Quiet
 
 PhaseChangeAndTriggers:

--- a/tests/InputFiles/GeneralizedHarmonic/GaugeWave3D.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/GaugeWave3D.yaml
@@ -28,6 +28,8 @@ Evolution:
 
 Amr:
   Criteria:
+  Policies:
+    Isotropy: Anisotropic
   Verbosity: Quiet
 
 PhaseChangeAndTriggers:

--- a/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
@@ -31,8 +31,6 @@ Evolution:
   TimeStepper:
     AdamsBashforth:
       Order: 1
-Amr:
-  Criteria:
 
 PhaseChangeAndTriggers:
   - Trigger:

--- a/tests/InputFiles/ScalarWave/PlaneWave1D.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave1D.yaml
@@ -31,6 +31,8 @@ Amr:
         VariablesToMonitor: [Psi]
         AbsoluteTarget: 1.e-6
         RelativeTarget: 1.0
+  Policies:
+    Isotropy: Anisotropic
   Verbosity: Verbose
 
 PhaseChangeAndTriggers:

--- a/tests/InputFiles/ScalarWave/PlaneWave1DEventsAndTriggersExample.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave1DEventsAndTriggersExample.yaml
@@ -33,6 +33,8 @@ Amr:
         VariablesToMonitor: [Psi]
         AbsoluteTarget: 1.e-6
         RelativeTarget: 1.0
+  Policies:
+    Isotropy: Anisotropic
   Verbosity: Verbose
 
 PhaseChangeAndTriggers:

--- a/tests/InputFiles/ScalarWave/PlaneWave1DObserveExample.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave1DObserveExample.yaml
@@ -34,6 +34,8 @@ Amr:
         VariablesToMonitor: [Psi]
         AbsoluteTarget: 1.e-6
         RelativeTarget: 1.0
+  Policies:
+    Isotropy: Anisotropic
   Verbosity: Verbose
 
 PhaseChangeAndTriggers:

--- a/tests/InputFiles/ScalarWave/PlaneWave2D.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave2D.yaml
@@ -28,6 +28,8 @@ InitialData:
 
 Amr:
   Criteria:
+  Policies:
+    Isotropy: Anisotropic
   Verbosity: Verbose
 
 PhaseChangeAndTriggers:

--- a/tests/InputFiles/ScalarWave/PlaneWave3D.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave3D.yaml
@@ -26,6 +26,8 @@ InitialData:
 
 Amr:
   Criteria:
+  Policies:
+    Isotropy: Anisotropic
   Verbosity: Verbose
 
 PhaseChangeAndTriggers:

--- a/tests/Unit/ParallelAlgorithms/Amr/Actions/Test_EvaluateRefinementCriteria.cpp
+++ b/tests/Unit/ParallelAlgorithms/Amr/Actions/Test_EvaluateRefinementCriteria.cpp
@@ -25,6 +25,7 @@
 #include "ParallelAlgorithms/Amr/Criteria/DriveToTarget.hpp"
 #include "ParallelAlgorithms/Amr/Criteria/Random.hpp"
 #include "ParallelAlgorithms/Amr/Criteria/Tags/Criteria.hpp"
+#include "ParallelAlgorithms/Amr/Policies/Tags.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/Serialization/RegisterDerivedClassesWithCharm.hpp"
@@ -53,7 +54,8 @@ struct Component {
   static constexpr size_t volume_dim = Metavariables::volume_dim;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = ElementId<volume_dim>;
-  using const_global_cache_tags = tmpl::list<amr::Criteria::Tags::Criteria>;
+  using const_global_cache_tags =
+      tmpl::list<amr::Criteria::Tags::Criteria, amr::Tags::Policies>;
   using simple_tags =
       tmpl::list<domain::Tags::Element<volume_dim>,
                  domain::Tags::Mesh<volume_dim>, amr::Tags::Info<volume_dim>,
@@ -111,7 +113,7 @@ void evaluate_criteria(std::vector<std::unique_ptr<amr::Criterion>> criteria,
   std::unordered_map<ElementId<1>, amr::Info<1>> initial_neighbor_info;
 
   ActionTesting::MockRuntimeSystem<Metavariables<1>> runner{
-      {std::move(criteria)}};
+      {std::move(criteria), amr::Policies{amr::Isotropy::Anisotropic}}};
 
   const Element<1> self(self_id, {{{Direction<1>::lower_xi(), {{lo_id}, {}}},
                                    {Direction<1>::upper_xi(), {{up_id}, {}}}}});
@@ -249,7 +251,7 @@ void check_split_while_join_is_avoided() {
   // But we do not allow an Element to simultaneously split and join so the
   // action should change the flags to (DoNothing, Split)
   ActionTesting::MockRuntimeSystem<Metavariables<2>> runner{
-      {std::move(criteria)}};
+      {std::move(criteria), amr::Policies{amr::Isotropy::Anisotropic}}};
 
   const Element<2> self(self_id, {});
   ActionTesting::emplace_component_and_initialize<my_component>(

--- a/tests/Unit/ParallelAlgorithms/Amr/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/Amr/CMakeLists.txt
@@ -22,6 +22,7 @@ set(LIBRARY_SOURCES
   Criteria/Test_Random.cpp
   Criteria/Test_TruncationError.cpp
   Policies/Test_Isotropy.cpp
+  Policies/Test_EnforcePolicies.cpp
   Policies/Test_Policies.cpp
   Projectors/Test_DefaultInitialize.cpp
   Projectors/Test_Mesh.cpp

--- a/tests/Unit/ParallelAlgorithms/Amr/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/Amr/CMakeLists.txt
@@ -22,6 +22,7 @@ set(LIBRARY_SOURCES
   Criteria/Test_Random.cpp
   Criteria/Test_TruncationError.cpp
   Policies/Test_Isotropy.cpp
+  Policies/Test_Policies.cpp
   Projectors/Test_DefaultInitialize.cpp
   Projectors/Test_Mesh.cpp
   Projectors/Test_Tensors.cpp

--- a/tests/Unit/ParallelAlgorithms/Amr/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/Amr/CMakeLists.txt
@@ -21,6 +21,7 @@ set(LIBRARY_SOURCES
   Criteria/Test_Persson.cpp
   Criteria/Test_Random.cpp
   Criteria/Test_TruncationError.cpp
+  Policies/Test_Isotropy.cpp
   Projectors/Test_DefaultInitialize.cpp
   Projectors/Test_Mesh.cpp
   Projectors/Test_Tensors.cpp
@@ -35,6 +36,7 @@ target_link_libraries(
   PRIVATE
   Amr
   AmrCriteria
+  AmrPolicies
   AmrProjectors
   CoordinateMaps
   Domain

--- a/tests/Unit/ParallelAlgorithms/Amr/Policies/Test_EnforcePolicies.cpp
+++ b/tests/Unit/ParallelAlgorithms/Amr/Policies/Test_EnforcePolicies.cpp
@@ -1,0 +1,142 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <vector>
+
+#include "Domain/Amr/Flag.hpp"
+#include "ParallelAlgorithms/Amr/Policies/EnforcePolicies.hpp"
+#include "ParallelAlgorithms/Amr/Policies/Isotropy.hpp"
+#include "ParallelAlgorithms/Amr/Policies/Policies.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace {
+template <size_t Dim>
+void test_decision(const std::array<amr::Flag, Dim>& original_decision,
+                   const amr::Policies& amr_policies,
+                   const std::array<amr::Flag, Dim>& expected_decision) {
+  auto decision = original_decision;
+  enforce_policies(make_not_null(&decision), amr_policies);
+  CHECK(decision == expected_decision);
+}
+
+void test_1d() {
+  const auto split = std::array{amr::Flag::Split};
+  const auto increase = std::array{amr::Flag::IncreaseResolution};
+  const auto stay = std::array{amr::Flag::DoNothing};
+  const auto decrease = std::array{amr::Flag::DecreaseResolution};
+  const auto join = std::array{amr::Flag::Join};
+  const auto all_flags = std::vector{split, increase, stay, decrease, join};
+
+  amr::Policies isotropic{amr::Isotropy::Isotropic};
+  amr::Policies anisotropic{amr::Isotropy::Anisotropic};
+  const auto policies = std::array{anisotropic, isotropic};
+
+  for (const auto flags : all_flags) {
+    for (const auto policy : policies) {
+      test_decision(flags, policy, flags);
+    }
+  }
+}
+
+void test_2d() {
+  const auto split_split = std::array{amr::Flag::Split, amr::Flag::Split};
+  const auto increase_split =
+      std::array{amr::Flag::IncreaseResolution, amr::Flag::Split};
+  const auto stay_split = std::array{amr::Flag::DoNothing, amr::Flag::Split};
+  const auto decrease_split =
+      std::array{amr::Flag::DecreaseResolution, amr::Flag::Split};
+  const auto join_split = std::array{amr::Flag::Join, amr::Flag::Split};
+  const auto split_increase =
+      std::array{amr::Flag::Split, amr::Flag::IncreaseResolution};
+  const auto increase_increase =
+      std::array{amr::Flag::IncreaseResolution, amr::Flag::IncreaseResolution};
+  const auto stay_increase =
+      std::array{amr::Flag::DoNothing, amr::Flag::IncreaseResolution};
+  const auto decrease_increase =
+      std::array{amr::Flag::DecreaseResolution, amr::Flag::IncreaseResolution};
+  const auto join_increase =
+      std::array{amr::Flag::Join, amr::Flag::IncreaseResolution};
+  const auto split_stay = std::array{amr::Flag::Split, amr::Flag::DoNothing};
+  const auto increase_stay =
+      std::array{amr::Flag::IncreaseResolution, amr::Flag::DoNothing};
+  const auto stay_stay = std::array{amr::Flag::DoNothing, amr::Flag::DoNothing};
+  const auto decrease_stay =
+      std::array{amr::Flag::DecreaseResolution, amr::Flag::DoNothing};
+  const auto join_stay = std::array{amr::Flag::Join, amr::Flag::DoNothing};
+  const auto split_decrease =
+      std::array{amr::Flag::Split, amr::Flag::DecreaseResolution};
+  const auto increase_decrease =
+      std::array{amr::Flag::IncreaseResolution, amr::Flag::DecreaseResolution};
+  const auto stay_decrease =
+      std::array{amr::Flag::DoNothing, amr::Flag::DecreaseResolution};
+  const auto decrease_decrease =
+      std::array{amr::Flag::DecreaseResolution, amr::Flag::DecreaseResolution};
+  const auto join_decrease =
+      std::array{amr::Flag::Join, amr::Flag::DecreaseResolution};
+  const auto split_join = std::array{amr::Flag::Split, amr::Flag::Join};
+  const auto increase_join =
+      std::array{amr::Flag::IncreaseResolution, amr::Flag::Join};
+  const auto stay_join = std::array{amr::Flag::DoNothing, amr::Flag::Join};
+  const auto decrease_join =
+      std::array{amr::Flag::DecreaseResolution, amr::Flag::Join};
+  const auto join_join = std::array{amr::Flag::Join, amr::Flag::Join};
+
+  const auto all_flags = std::vector{
+      split_split,       increase_split, stay_split,        decrease_split,
+      join_split,        split_increase, increase_increase, stay_increase,
+      decrease_increase, join_increase,  split_stay,        increase_stay,
+      stay_stay,         decrease_stay,  join_stay,         split_decrease,
+      increase_decrease, stay_decrease,  decrease_decrease, join_decrease,
+      split_join,        increase_join,  stay_join,         decrease_join,
+      join_join};
+
+  amr::Policies isotropic{amr::Isotropy::Isotropic};
+  amr::Policies anisotropic{amr::Isotropy::Anisotropic};
+
+  for (const auto flags : all_flags) {
+    test_decision(flags, anisotropic, flags);
+  }
+
+  for (const auto flags : std::vector{
+           split_split, increase_split, stay_split, decrease_split, join_split,
+           split_increase, split_stay, split_decrease, split_join}) {
+    test_decision(flags, isotropic, split_split);
+  }
+  for (const auto flags : std::vector{
+           increase_increase, stay_increase, decrease_increase, join_increase,
+           increase_stay, increase_decrease, increase_join}) {
+    test_decision(flags, isotropic, increase_increase);
+  }
+  for (const auto flags : std::vector{stay_stay, stay_decrease, stay_join,
+                                      decrease_stay, join_stay}) {
+    test_decision(flags, isotropic, stay_stay);
+  }
+  for (const auto flags :
+       std::vector{decrease_decrease, decrease_join, join_decrease}) {
+    test_decision(flags, isotropic, decrease_decrease);
+  }
+  test_decision(join_join, isotropic, join_join);
+}
+
+void test_3d() {
+  const auto stay_split_split =
+      std::array{amr::Flag::DoNothing, amr::Flag::Split, amr::Flag::Split};
+  const auto split_split_split =
+      std::array{amr::Flag::Split, amr::Flag::Split, amr::Flag::Split};
+  amr::Policies isotropic{amr::Isotropy::Isotropic};
+  amr::Policies anisotropic{amr::Isotropy::Anisotropic};
+  test_decision(stay_split_split, anisotropic, stay_split_split);
+  test_decision(stay_split_split, isotropic, split_split_split);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.ParallelAlgorithms.Amr.EnforcePolicies",
+                  "[ParallelAlgorithms][Unit]") {
+  test_1d();
+  test_2d();
+  test_3d();
+}

--- a/tests/Unit/ParallelAlgorithms/Amr/Policies/Test_Isotropy.cpp
+++ b/tests/Unit/ParallelAlgorithms/Amr/Policies/Test_Isotropy.cpp
@@ -1,0 +1,34 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <vector>
+
+#include "Framework/TestCreation.hpp"
+#include "ParallelAlgorithms/Amr/Policies/Isotropy.hpp"
+#include "Utilities/GetOutput.hpp"
+#include "Utilities/MakeString.hpp"
+
+SPECTRE_TEST_CASE("Unit.ParallelAlgorithms.Amr.Isotropy",
+                  "[ParallelAlgorithms][Unit]") {
+  CHECK(get_output(amr::Isotropy::Anisotropic) == "Anisotropic");
+  CHECK(get_output(amr::Isotropy::Isotropic) == "Isotropic");
+
+  const std::vector known_amr_isotropies{amr::Isotropy::Anisotropic,
+                                         amr::Isotropy::Isotropic};
+
+  for (const auto isotropy : known_amr_isotropies) {
+    CHECK(isotropy ==
+          TestHelpers::test_creation<amr::Isotropy>(get_output(isotropy)));
+  }
+
+  CHECK_THROWS_WITH(
+      ([]() {
+        TestHelpers::test_creation<amr::Isotropy>("Bad isotropy name");
+      }()),
+      Catch::Matchers::ContainsSubstring(
+          MakeString{} << "Failed to convert \"Bad isotropy name\" to "
+                          "amr::Isotropy.\nMust be one of "
+                       << known_amr_isotropies << "."));
+}

--- a/tests/Unit/ParallelAlgorithms/Amr/Policies/Test_Policies.cpp
+++ b/tests/Unit/ParallelAlgorithms/Amr/Policies/Test_Policies.cpp
@@ -1,0 +1,48 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <sstream>
+
+#include "Framework/TestCreation.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "ParallelAlgorithms/Amr/Policies/Isotropy.hpp"
+#include "ParallelAlgorithms/Amr/Policies/Policies.hpp"
+
+namespace {
+void test_equality() {
+  INFO("Equality");
+  CHECK(amr::Policies{amr::Isotropy::Anisotropic} ==
+        amr::Policies{amr::Isotropy::Anisotropic});
+  CHECK(amr::Policies{amr::Isotropy::Anisotropic} !=
+        amr::Policies{amr::Isotropy::Isotropic});
+}
+
+void test_pup() {
+  INFO("Serialization");
+  test_serialization(amr::Policies{amr::Isotropy::Anisotropic});
+}
+
+void test_option_parsing() {
+  INFO("Option Parsing creation");
+  const auto isotropies =
+      std::array{amr::Isotropy::Anisotropic, amr::Isotropy::Isotropic};
+  for (const auto isotropy : isotropies) {
+    std::ostringstream creation_string;
+    creation_string << "Isotropy: " << isotropy;
+    const auto policies =
+        TestHelpers::test_creation<amr::Policies>(creation_string.str());
+    CHECK(policies == amr::Policies{isotropy});
+  }
+}
+
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.ParallelAlgorithms.Amr.Policies",
+                  "[ParallelAlgorithms][Unit]") {
+  test_equality();
+  test_pup();
+  test_option_parsing();
+}


### PR DESCRIPTION
## Proposed changes

Adds `amr::Policies`,  a class that will allow run-time control over adaptive mesh refinement features.

This PR adds the ability to control whether refinement is isotropic or anisotropic (i.e. whether each dimension can refine independently).

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
