### PR TITLE
Make Auto parsing failure print the Label

### DIFF
--- a/tests/Unit/Options/Test_Auto.cpp
+++ b/tests/Unit/Options/Test_Auto.cpp
@@ -200,10 +200,30 @@ void test_use_as_option() {
   // Make sure this compiles.
   TestHelpers::test_creation<NonCopyableArgument>("AutoArg: Auto");
 }
+
+struct LabelThatShouldPrint {
+  static std::string name() { return "PrintedName"; }
+};
+
+void test_error_message() {
+  CHECK_THROWS_WITH(
+      (TestHelpers::test_creation<Options::Auto<double, LabelThatShouldPrint>>(
+          "NotValid")),
+      Catch::Matchers::ContainsSubstring("PrintedName") and
+          Catch::Matchers::ContainsSubstring("to type double") and
+          Catch::Matchers::ContainsSubstring("NotValid"));
+  CHECK_THROWS_WITH((TestHelpers::test_creation<
+                        Options::Auto<std::string, LabelThatShouldPrint>>(
+                        "[not, a, string]")),
+                    Catch::Matchers::ContainsSubstring("PrintedName") and
+                        Catch::Matchers::ContainsSubstring("to type string") and
+                        Catch::Matchers::ContainsSubstring("not, a, string"));
+}
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Options.Auto", "[Unit][Options]") {
   test_class();
   test_parsing();
   test_use_as_option();
+  test_error_message();
 }


### PR DESCRIPTION
Example output:
```
In group SpatialDiscretization:
In group DiscontinuousGalerkin:
While parsing option TciOptions:
While creating a TciOptions:
While parsing option MagneticFieldCutoff:
While creating a Auto:
While creating a variant:
At line 67 column 28:
Failed to convert value to type AutoLabel or double: bla

Possible errors:

While creating a variant:
While creating a AutoLabel:
At line 67 column 28:
Failed to parse as Auto label "DoNotCheckMagneticField"

While creating a variant:
At line 67 column 28:
Failed to convert value to type double: bla
############ ERROR ############
```

This is not quite the issue from #2654, which is about the displayed name rather than the error message.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
