### PR TITLE
Support older control system output in size plotting

### DIFF
--- a/src/ControlSystem/ControlErrors/Size.cpp
+++ b/src/ControlSystem/ControlErrors/Size.cpp
@@ -26,6 +26,10 @@ double control_error_delta_r(const double horizon_00,
   const double Y00 = 0.25 * M_2_SQRTPI;
 
   // This corresponds to 'DeltaRPolicy=Relative' in SpEC.
+  // Notice that both horizon_00 and dt_horizon_00 are actually spherepack
+  // coefs, not spherical harmonic coefs. However, they only show up in this
+  // expression as a ratio, so the spherepack factor cancels out, thus we don't
+  // add it in here.
   return dt_horizon_00 * (lambda_00 - grid_frame_excision_sphere_radius / Y00) /
              horizon_00 -
          dt_lambda_00;

--- a/src/Visualization/Python/PlotSizeControl.py
+++ b/src/Visualization/Python/PlotSizeControl.py
@@ -137,13 +137,19 @@ def plot_size_control_command(
     top2 = axes[-1].plot(
         times, data["DampingTime"], color="C1", label="Damping time"
     )
-    top3 = axes[-1].plot(
-        times,
-        data["SmootherTimescale"],
-        color="C2",
-        label="Smooth damping time",
-    )
-    top_lines = top1 + top2 + top3
+    # Support an older version of control system output that didn't have the
+    # smoother timescale
+    if "SmootherTimescale" in data.columns:
+        top3 = axes[-1].plot(
+            times,
+            data["SmootherTimescale"],
+            color="C2",
+            label="Smooth damping time",
+        )
+        top_lines = top1 + top2 + top3
+    else:
+        top_lines = top1 + top2
+
     top_labels = [l.get_label() for l in top_lines]
     axes[0].tick_params(axis="y", labelcolor="C0")
 


### PR DESCRIPTION
## Proposed changes

Also add a missing SPHEREPACK factor to the calculation of the average delta R (and a comment explainin why).

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
