### PR TITLE
Prevent NumGridPointsAndGridSpacing element dist when using GTS

### DIFF
--- a/src/Domain/ElementDistribution.cpp
+++ b/src/Domain/ElementDistribution.cpp
@@ -28,7 +28,6 @@
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "NumericalAlgorithms/Spectral/Quadrature.hpp"
 #include "Options/Options.hpp"
-#include "Options/ParseError.hpp"
 #include "Options/ParseOptions.hpp"
 #include "Utilities/Algorithm.hpp"
 #include "Utilities/ConstantExpressions.hpp"
@@ -343,20 +342,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
 #undef GET_DIM
 #undef INSTANTIATION
 }  // namespace domain
-
-template <>
-domain::ElementWeight
-Options::create_from_yaml<domain::ElementWeight>::create<void>(
-    const Options::Option& options) {
-  const auto ordering = options.parse_as<std::string>();
-  if (ordering == "Uniform") {
-    return domain::ElementWeight::Uniform;
-  } else if (ordering == "NumGridPoints") {
-    return domain::ElementWeight::NumGridPoints;
-  } else if (ordering == "NumGridPointsAndGridSpacing") {
-    return domain::ElementWeight::NumGridPointsAndGridSpacing;
-  }
-  PARSE_ERROR(options.context(),
-              "ElementWeight must be 'Uniform', 'NumGridPoints', or, "
-              "'NumGridPointsAndGridSpacing'");
-}

--- a/src/Domain/Tags/ElementDistribution.hpp
+++ b/src/Domain/Tags/ElementDistribution.hpp
@@ -35,6 +35,15 @@ struct ElementDistribution {
 }  // namespace OptionTags
 
 namespace Tags {
+/// \ingroup DataBoxTagsGroup
+/// \ingroup ComputationalDomainGroup
+/// Tag that holds method for how to distribute the elements on the given
+/// resources.
+///
+/// \note When not using local time stepping (LTS), a user cannot choose the
+/// NumGridPointsAndGridSpacing element distribution because grid spacing does
+/// not affect the computational cost at all. Therefore, if a user does choose
+/// NumGridPointsAndGridSpacing when not using LTS, an error will occur.
 struct ElementDistribution : db::SimpleTag {
   using type = std::optional<ElementWeight>;
   using option_tags = tmpl::list<OptionTags::ElementDistribution>;

--- a/tests/InputFiles/ExportCoordinates/InputTimeDependent3D.yaml
+++ b/tests/InputFiles/ExportCoordinates/InputTimeDependent3D.yaml
@@ -13,7 +13,7 @@ ExpectedOutput:
 ---
 
 Parallelization:
-  ElementDistribution: NumGridPointsAndGridSpacing
+  ElementDistribution: NumGridPoints
 
 Amr:
   Criteria:

--- a/tests/Unit/Domain/Tags/Test_ElementDistribution.cpp
+++ b/tests/Unit/Domain/Tags/Test_ElementDistribution.cpp
@@ -12,19 +12,57 @@
 #include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
 #include "Parallel/Tags/Parallelization.hpp"
 
+namespace {
+template <bool UseLTS>
+struct TestMetavars {
+  static constexpr bool local_time_stepping = UseLTS;
+};
+
+template <bool UseLTS>
+std::optional<domain::ElementWeight> make_option(
+    const std::string& option_string) {
+  return TestHelpers::test_option_tag<domain::OptionTags::ElementDistribution,
+                                      TestMetavars<UseLTS>>(option_string);
+}
+
+std::optional<domain::ElementWeight> make_option_without_lts_metavars(
+    const std::string& option_string) {
+  return TestHelpers::test_option_tag<domain::OptionTags::ElementDistribution>(
+      option_string);
+}
+}  // namespace
+
 SPECTRE_TEST_CASE("Unit.Domain.Tags.ElementDistribution", "[Unit][Domain]") {
   TestHelpers::db::test_simple_tag<domain::Tags::ElementDistribution>(
       "ElementDistribution");
-  const auto make_option = [](const std::string& option_string)
-      -> std::optional<domain::ElementWeight> {
-    return TestHelpers::test_option_tag<
-        domain::OptionTags::ElementDistribution>(option_string);
-  };
-  CHECK(make_option("Uniform") ==
+  CHECK(make_option<true>("Uniform") ==
         std::optional{domain::ElementWeight::Uniform});
-  CHECK(make_option("NumGridPoints") ==
+  CHECK(make_option<true>("NumGridPoints") ==
         std::optional{domain::ElementWeight::NumGridPoints});
-  CHECK(make_option("NumGridPointsAndGridSpacing") ==
+  CHECK(make_option<true>("NumGridPointsAndGridSpacing") ==
         std::optional{domain::ElementWeight::NumGridPointsAndGridSpacing});
-  CHECK(make_option("RoundRobin") == std::nullopt);
+  CHECK(make_option<true>("RoundRobin") == std::nullopt);
+
+  CHECK(make_option<false>("Uniform") ==
+        std::optional{domain::ElementWeight::Uniform});
+  CHECK(make_option<false>("NumGridPoints") ==
+        std::optional{domain::ElementWeight::NumGridPoints});
+  CHECK_THROWS_WITH(make_option<false>("NumGridPointsAndGridSpacing"),
+                    Catch::Matchers::ContainsSubstring(
+                        "When not using local time stepping") and
+                        Catch::Matchers::ContainsSubstring(
+                            "Please choose another element distribution."));
+  CHECK(make_option<false>("RoundRobin") == std::nullopt);
+
+  CHECK(make_option_without_lts_metavars("Uniform") ==
+        std::optional{domain::ElementWeight::Uniform});
+  CHECK(make_option_without_lts_metavars("NumGridPoints") ==
+        std::optional{domain::ElementWeight::NumGridPoints});
+  CHECK_THROWS_WITH(
+      make_option_without_lts_metavars("NumGridPointsAndGridSpacing"),
+      Catch::Matchers::ContainsSubstring(
+          "When not using local time stepping") and
+          Catch::Matchers::ContainsSubstring(
+              "Please choose another element distribution."));
+  CHECK(make_option_without_lts_metavars("RoundRobin") == std::nullopt);
 }


### PR DESCRIPTION
## Proposed changes

Also prevent using NumGridPointsAndGridSpacing in the elliptic code as well.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
