### PR TITLE
Mc logical coordinates

### DIFF
--- a/src/Evolution/Particles/MonteCarlo/EvolveMonteCarloPackets.hpp
+++ b/src/Evolution/Particles/MonteCarlo/EvolveMonteCarloPackets.hpp
@@ -37,6 +37,9 @@ void evolve_single_packet_on_geodesic(
     const tnsr::iJ<DataVector, 3, Frame::Inertial>& d_shift,
     const tnsr::iJJ<DataVector, 3, Frame::Inertial>& d_inv_spatial_metric,
     const tnsr::II<DataVector, 3, Frame::Inertial>& inv_spatial_metric,
+    const std::optional<tnsr::I<DataVector, 3, Frame::Inertial>>& mesh_velocity,
+    const InverseJacobian<DataVector, 3, Frame::ElementLogical,
+                          Frame::Inertial>& inverse_jacobian,
     const size_t& closest_point_index);
 
 }  // namespace detail
@@ -46,12 +49,15 @@ struct Packet;
 void evolve_packets(
     gsl::not_null<std::vector<Packet>*> packets, const double& time_step,
     const Mesh<3>& mesh,
-    const tnsr::I<DataVector, 3, Frame::Inertial>& mesh_coordinates,
+    const tnsr::I<DataVector, 3, Frame::ElementLogical>& mesh_coordinates,
     const Scalar<DataVector>& lapse,
     const tnsr::I<DataVector, 3, Frame::Inertial>& shift,
     const tnsr::i<DataVector, 3, Frame::Inertial>& d_lapse,
     const tnsr::iJ<DataVector, 3, Frame::Inertial>& d_shift,
     const tnsr::iJJ<DataVector, 3, Frame::Inertial>& d_inv_spatial_metric,
-    const tnsr::II<DataVector, 3, Frame::Inertial>& inv_spatial_metric);
+    const tnsr::II<DataVector, 3, Frame::Inertial>& inv_spatial_metric,
+    const std::optional<tnsr::I<DataVector, 3, Frame::Inertial>>& mesh_velocity,
+    const InverseJacobian<DataVector, 3, Frame::ElementLogical,
+                          Frame::Inertial>& inverse_jacobian);
 
 }  // namespace Particles::MonteCarlo

--- a/src/Evolution/Particles/MonteCarlo/EvolveMonteCarloPackets.hpp
+++ b/src/Evolution/Particles/MonteCarlo/EvolveMonteCarloPackets.hpp
@@ -25,8 +25,7 @@ void time_derivative_momentum_geodesic(
     const Scalar<DataVector>& lapse,
     const tnsr::i<DataVector, 3, Frame::Inertial>& d_lapse,
     const tnsr::iJ<DataVector, 3, Frame::Inertial>& d_shift,
-    const tnsr::iJJ<DataVector, 3, Frame::Inertial>& d_inv_spatial_metric,
-    const size_t& closest_point_index);
+    const tnsr::iJJ<DataVector, 3, Frame::Inertial>& d_inv_spatial_metric);
 
 // Advances a single packet by time time_step along a geodesic
 void evolve_single_packet_on_geodesic(
@@ -39,12 +38,9 @@ void evolve_single_packet_on_geodesic(
     const tnsr::II<DataVector, 3, Frame::Inertial>& inv_spatial_metric,
     const std::optional<tnsr::I<DataVector, 3, Frame::Inertial>>& mesh_velocity,
     const InverseJacobian<DataVector, 3, Frame::ElementLogical,
-                          Frame::Inertial>& inverse_jacobian,
-    const size_t& closest_point_index);
+                          Frame::Inertial>& inverse_jacobian);
 
 }  // namespace detail
-
-struct Packet;
 
 void evolve_packets(
     gsl::not_null<std::vector<Packet>*> packets, const double& time_step,

--- a/src/Evolution/Particles/MonteCarlo/MonteCarloPacket.cpp
+++ b/src/Evolution/Particles/MonteCarlo/MonteCarloPacket.cpp
@@ -7,15 +7,17 @@ namespace Particles::MonteCarlo {
 
 void Packet::renormalize_momentum(
     const tnsr::II<DataVector, 3, Frame::Inertial>& inv_spatial_metric,
-    const Scalar<DataVector>& lapse, const size_t& closest_point_index) {
+    const Scalar<DataVector>& lapse) {
   momentum_upper_t = 0.0;
   for (size_t i = 0; i < 3; i++) {
     for (size_t j = 0; j < 3; j++) {
-      momentum_upper_t += inv_spatial_metric.get(i, j)[closest_point_index] *
-                          momentum[i] * momentum[j];
+      momentum_upper_t +=
+          inv_spatial_metric.get(i, j)[index_of_closest_grid_point] *
+          momentum[i] * momentum[j];
     }
   }
-  momentum_upper_t = sqrt(momentum_upper_t) / get(lapse)[closest_point_index];
+  momentum_upper_t =
+      sqrt(momentum_upper_t) / get(lapse)[index_of_closest_grid_point];
 }
 
 }  // namespace Particles::MonteCarlo

--- a/src/Evolution/Particles/MonteCarlo/MonteCarloPacket.hpp
+++ b/src/Evolution/Particles/MonteCarlo/MonteCarloPacket.hpp
@@ -34,7 +34,7 @@ struct Packet {
   double momentum_upper_t;
 
   // Coordinates of the packet, currently in Inertial coordinates
-  tnsr::I<double, 3, Frame::Inertial> coordinates;
+  tnsr::I<double, 3, Frame::ElementLogical> coordinates;
 
   // Spatial components of the 4-momentum, also in Inertial coordinates
   tnsr::i<double, 3, Frame::Inertial> momentum;

--- a/src/Evolution/Particles/MonteCarlo/MonteCarloPacket.hpp
+++ b/src/Evolution/Particles/MonteCarlo/MonteCarloPacket.hpp
@@ -15,10 +15,15 @@ namespace Particles::MonteCarlo {
 
 struct Packet {
   // Constructor
-  Packet(const double& time_, const double& coord_x_, const double& coord_y_,
-         const double& coord_z_, const double& p_upper_t_, const double& p_x_,
-         const double& p_y_, const double& p_z_)
-      : time(time_), momentum_upper_t(p_upper_t_) {
+  Packet(const double& number_of_neutrinos_,
+         const size_t& index_of_closest_grid_point_, const double& time_,
+         const double& coord_x_, const double& coord_y_, const double& coord_z_,
+         const double& p_upper_t_, const double& p_x_, const double& p_y_,
+         const double& p_z_)
+      : number_of_neutrinos(number_of_neutrinos_),
+        index_of_closest_grid_point(index_of_closest_grid_point_),
+        time(time_),
+        momentum_upper_t(p_upper_t_) {
     coordinates[0] = coord_x_;
     coordinates[1] = coord_y_;
     coordinates[2] = coord_z_;
@@ -26,6 +31,16 @@ struct Packet {
     momentum[1] = p_y_;
     momentum[2] = p_z_;
   }
+
+  // Number of neutrinos represented by current packet
+  // Note that this number is rescaled so that
+  // Energy_of_packet = N * Energy_of_neutrinos
+  // with the packet energy in G=Msun=c=1 units but
+  // the neutrino energy in MeV!
+  double number_of_neutrinos;
+
+  // Index of the closest point on the FD grid.
+  size_t index_of_closest_grid_point;
 
   // Current time
   double time;
@@ -42,7 +57,7 @@ struct Packet {
   // Recalculte p^t using the fact that the 4-momentum is a null vector
   void renormalize_momentum(
       const tnsr::II<DataVector, 3, Frame::Inertial>& inv_spatial_metric,
-      const Scalar<DataVector>& lapse, const size_t& closest_point_index);
+      const Scalar<DataVector>& lapse);
 };
 
 }  // namespace Particles::MonteCarlo

--- a/tests/Unit/Evolution/Particles/MonteCarlo/Test_MonteCarloPacket.cpp
+++ b/tests/Unit/Evolution/Particles/MonteCarlo/Test_MonteCarloPacket.cpp
@@ -9,9 +9,6 @@
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 
 SPECTRE_TEST_CASE("Unit.Evolution.Particles.MonteCarlo", "[Unit][Evolution]") {
-  Particles::MonteCarlo::Packet packet(0.0, -1.0, -1.0, -1.0, 1.0, 1.0, 0.0,
-                                       0.0);
-
   const Mesh<3> mesh(2, Spectral::Basis::FiniteDifference,
                      Spectral::Quadrature::CellCentered);
 
@@ -53,21 +50,24 @@ SPECTRE_TEST_CASE("Unit.Evolution.Particles.MonteCarlo", "[Unit][Evolution]") {
   mesh_coordinates.get(1) = DataVector{-1., -1., 1., 1., -1., -1., 1., 1.};
   mesh_coordinates.get(2) = DataVector{-1., -1., -1., -1., 1., 1., 1., 1.};
 
-  const size_t closest_point_index = 0;
+  Particles::MonteCarlo::Packet packet(1.0, 0, 0.0, -1.0, -1.0, -1.0, 1.0, 1.0,
+                                       0.0, 0.0);
 
-  packet.renormalize_momentum(inv_spatial_metric, lapse, closest_point_index);
+  packet.renormalize_momentum(inv_spatial_metric, lapse);
   CHECK(packet.momentum_upper_t == 1.0);
 
   std::vector<Particles::MonteCarlo::Packet> packets{packet};
   Particles::MonteCarlo::evolve_packets(
-      &packets, 1.0, mesh, mesh_coordinates, lapse, shift, d_lapse, d_shift,
+      &packets, 1.5, mesh, mesh_coordinates, lapse, shift, d_lapse, d_shift,
       d_inv_spatial_metric, inv_spatial_metric, mesh_velocity,
       inverse_jacobian);
-  CHECK(packets[0].coordinates.get(0) == 0.0);
+  CHECK(packets[0].coordinates.get(0) == 0.5);
   CHECK(packets[0].coordinates.get(1) == -1.0);
   CHECK(packets[0].coordinates.get(2) == -1.0);
   CHECK(packets[0].momentum.get(0) == 1.0);
   CHECK(packets[0].momentum.get(1) == 0.0);
   CHECK(packets[0].momentum.get(2) == 0.0);
-  CHECK(packets[0].time == 1.0);
+  CHECK(packets[0].time == 1.5);
+  CHECK(packets[0].index_of_closest_grid_point == 1);
+  CHECK(packets[0].number_of_neutrinos == 1.0);
 }

--- a/tests/Unit/Evolution/Particles/MonteCarlo/Test_MonteCarloPacket.cpp
+++ b/tests/Unit/Evolution/Particles/MonteCarlo/Test_MonteCarloPacket.cpp
@@ -9,7 +9,8 @@
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 
 SPECTRE_TEST_CASE("Unit.Evolution.Particles.MonteCarlo", "[Unit][Evolution]") {
-  Particles::MonteCarlo::Packet packet(0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0);
+  Particles::MonteCarlo::Packet packet(0.0, -1.0, -1.0, -1.0, 1.0, 1.0, 0.0,
+                                       0.0);
 
   const Mesh<3> mesh(2, Spectral::Basis::FiniteDifference,
                      Spectral::Quadrature::CellCentered);
@@ -32,12 +33,25 @@ SPECTRE_TEST_CASE("Unit.Evolution.Particles.MonteCarlo", "[Unit][Evolution]") {
   tnsr::iJJ<DataVector, 3, Frame::Inertial> d_inv_spatial_metric =
       make_with_value<tnsr::iJJ<DataVector, 3, Frame::Inertial>>(lapse, 0.0);
 
+  // Mesh velocity set to std::null for now
+  const std::optional<tnsr::I<DataVector, 3, Frame::Inertial>> mesh_velocity =
+      std::nullopt;
+  // Jacobian set to identity for now
+  InverseJacobian<DataVector, 3, Frame::ElementLogical, Frame::Inertial>
+      inverse_jacobian =
+          make_with_value<InverseJacobian<DataVector, 3, Frame::ElementLogical,
+                                          Frame::Inertial>>(lapse, 0.0);
+  inverse_jacobian.get(0, 0) = 1.0;
+  inverse_jacobian.get(1, 1) = 1.0;
+  inverse_jacobian.get(2, 2) = 1.0;
+
   // Coordinates
-  tnsr::I<DataVector, 3, Frame::Inertial> mesh_coordinates =
-      make_with_value<tnsr::I<DataVector, 3, Frame::Inertial>>(lapse, 0.0);
-  mesh_coordinates.get(0) = DataVector{0., 1., 0., 1., 0., 1., 0., 1.};
-  mesh_coordinates.get(1) = DataVector{0., 0., 1., 1., 0., 0., 1., 1.};
-  mesh_coordinates.get(2) = DataVector{0., 0., 0., 0., 1., 1., 1., 1.};
+  tnsr::I<DataVector, 3, Frame::ElementLogical> mesh_coordinates =
+      make_with_value<tnsr::I<DataVector, 3, Frame::ElementLogical>>(lapse,
+                                                                     0.0);
+  mesh_coordinates.get(0) = DataVector{-1., 1., -1., 1., -1., 1., -1., 1.};
+  mesh_coordinates.get(1) = DataVector{-1., -1., 1., 1., -1., -1., 1., 1.};
+  mesh_coordinates.get(2) = DataVector{-1., -1., -1., -1., 1., 1., 1., 1.};
 
   const size_t closest_point_index = 0;
 
@@ -47,10 +61,11 @@ SPECTRE_TEST_CASE("Unit.Evolution.Particles.MonteCarlo", "[Unit][Evolution]") {
   std::vector<Particles::MonteCarlo::Packet> packets{packet};
   Particles::MonteCarlo::evolve_packets(
       &packets, 1.0, mesh, mesh_coordinates, lapse, shift, d_lapse, d_shift,
-      d_inv_spatial_metric, inv_spatial_metric);
-  CHECK(packets[0].coordinates.get(0) == 1.0);
-  CHECK(packets[0].coordinates.get(1) == 0.0);
-  CHECK(packets[0].coordinates.get(2) == 0.0);
+      d_inv_spatial_metric, inv_spatial_metric, mesh_velocity,
+      inverse_jacobian);
+  CHECK(packets[0].coordinates.get(0) == 0.0);
+  CHECK(packets[0].coordinates.get(1) == -1.0);
+  CHECK(packets[0].coordinates.get(2) == -1.0);
   CHECK(packets[0].momentum.get(0) == 1.0);
   CHECK(packets[0].momentum.get(1) == 0.0);
   CHECK(packets[0].momentum.get(2) == 0.0);


### PR DESCRIPTION
## Proposed changes

MC packets use logical coordinates instead of inertial coordinates.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

This will make is easier to determine which cell a packet belongs to when using curved meshes.
