### PR TITLE
Fix a few bugs related to step-size changing

### DIFF
--- a/src/Time/TimeSteppers/AdamsMoultonPc.cpp
+++ b/src/Time/TimeSteppers/AdamsMoultonPc.cpp
@@ -209,6 +209,7 @@ bool AdamsMoultonPc::can_change_step_size_impl(
   // just force that until we've passed all the self-start times.
   const evolution_less_equal<Time> less_equal{time_id.time_runs_forward()};
   return not ::SelfStart::is_self_starting(time_id) and
+         time_id.substep() == 0 and
          alg::all_of(history, [&](const auto& record) {
            return less_equal(record.time_step_id.step_time(),
                              time_id.step_time());

--- a/tests/Unit/Time/Actions/Test_AdvanceTime.cpp
+++ b/tests/Unit/Time/Actions/Test_AdvanceTime.cpp
@@ -102,6 +102,11 @@ void check(std::unique_ptr<TimeStepper> time_stepper,
             db::get<Tags::TimeStepId>(box).substep_time());
       runner.next_action<component>(0);
     }
+    auto& box =
+        ActionTesting::get_databox<component>(make_not_null(&runner), 0);
+    db::mutate<Tags::Next<Tags::TimeStep>>(
+        [](const gsl::not_null<TimeDelta*> next_step) { *next_step /= 2; },
+        make_not_null(&box));
   }
 
   const auto& box = ActionTesting::get_databox<component>(runner, 0);
@@ -111,10 +116,10 @@ void check(std::unique_ptr<TimeStepper> time_stepper,
   CHECK(final_time_id ==
         TimeStepId(time_step.is_positive(), 8, start + 2 * time_step));
   CHECK(db::get<Tags::Time>(box) == final_time_id.substep_time());
-  CHECK(db::get<Tags::TimeStep>(box) == time_step.with_slab(expected_slab));
+  CHECK(db::get<Tags::TimeStep>(box) == time_step.with_slab(expected_slab) / 2);
   CHECK(db::get<Tags::AdaptiveSteppingDiagnostics>(box) ==
         AdaptiveSteppingDiagnostics{
-            1 + static_cast<uint64_t>(final_time_id.slab_number() - 8), 2, 5, 4,
+            1 + static_cast<uint64_t>(final_time_id.slab_number() - 8), 2, 5, 5,
             5});
 }
 }  // namespace

--- a/tests/Unit/Time/Actions/Test_ChangeStepSize.cpp
+++ b/tests/Unit/Time/Actions/Test_ChangeStepSize.cpp
@@ -17,6 +17,7 @@
 #include "ParallelAlgorithms/Actions/Goto.hpp"
 #include "Time/Actions/ChangeStepSize.hpp"
 #include "Time/AdaptiveSteppingDiagnostics.hpp"
+#include "Time/History.hpp"
 #include "Time/Slab.hpp"
 #include "Time/StepChoosers/Constant.hpp"
 #include "Time/StepChoosers/StepChooser.hpp"
@@ -71,8 +72,6 @@ struct Var : db::SimpleTag {
   using type = double;
 };
 
-using history_tag = Tags::HistoryEvolvedVariables<Var>;
-
 struct System {
   using variables_tag = Var;
 };
@@ -90,7 +89,8 @@ struct Component {
       tmpl::list<Tags::TimeStepId, Tags::Next<Tags::TimeStepId>, Tags::TimeStep,
                  Tags::Next<Tags::TimeStep>, ::Tags::StepChoosers,
                  Tags::IsUsingTimeSteppingErrorControl,
-                 Tags::AdaptiveSteppingDiagnostics, history_tag,
+                 Tags::AdaptiveSteppingDiagnostics,
+                 Tags::HistoryEvolvedVariables<Var>,
                  typename System::variables_tag>;
   using compute_tags = time_stepper_ref_tags<LtsTimeStepper>;
   using phase_dependent_action_list = tmpl::list<
@@ -124,7 +124,8 @@ struct Metavariables {
 
 template <typename StepChoosersToUse = AllStepChoosers>
 void check(const bool time_runs_forward,
-           std::unique_ptr<LtsTimeStepper> time_stepper, const Time& time,
+           std::unique_ptr<LtsTimeStepper> time_stepper,
+           TimeSteppers::History<double> history, const Time& time,
            const double request, const TimeDelta& expected_step,
            const bool reject_step) {
   CAPTURE(time);
@@ -156,8 +157,8 @@ void check(const bool time_runs_forward,
                  std::make_unique<Constant>(2. * request),
                  std::make_unique<Constant>(request),
                  std::make_unique<Constant>(2. * request)),
-       false, AdaptiveSteppingDiagnostics{1, 2, 3, 4, 5},
-       typename history_tag::type{}, 1.});
+       false, AdaptiveSteppingDiagnostics{1, 2, 3, 4, 5}, std::move(history),
+       1.});
 
   ActionTesting::set_phase(make_not_null(&runner), Parallel::Phase::Testing);
   runner.template next_action<component>(0);
@@ -185,23 +186,34 @@ SPECTRE_TEST_CASE("Unit.Time.Actions.ChangeStepSize", "[Unit][Time][Actions]") {
   const Slab slab(-5., -2.);
   const double slab_length = slab.duration().value();
   for (auto reject_step : {true, false}) {
-    check(true, std::make_unique<TimeSteppers::AdamsBashforth>(1),
+    check(true, std::make_unique<TimeSteppers::AdamsBashforth>(1), {},
           slab.start() + slab.duration() / 4, slab_length / 5.,
           slab.duration() / 8, reject_step);
-    check(true, std::make_unique<TimeSteppers::AdamsBashforth>(1),
+    check(true, std::make_unique<TimeSteppers::AdamsBashforth>(1), {},
           slab.start() + slab.duration() / 4, slab_length, slab.duration() / 4,
           reject_step);
-    check(false, std::make_unique<TimeSteppers::AdamsBashforth>(1),
+    check(false, std::make_unique<TimeSteppers::AdamsBashforth>(1), {},
           slab.end() - slab.duration() / 4, slab_length / 5.,
           -slab.duration() / 8, reject_step);
-    check(false, std::make_unique<TimeSteppers::AdamsBashforth>(1),
+    check(false, std::make_unique<TimeSteppers::AdamsBashforth>(1), {},
           slab.end() - slab.duration() / 4, slab_length, -slab.duration() / 4,
           reject_step);
   }
+
+  {
+    // History out of order, as if just after self-start.
+    TimeSteppers::History<double> history{};
+    history.insert(TimeStepId(true, -1, slab.start() + slab.duration() / 8),
+                   0.0, 0.0);
+    check(true, std::make_unique<TimeSteppers::AdamsBashforth>(1),
+          std::move(history), slab.start() + slab.duration() / 4, 1.0e-3,
+          slab.duration() / 4, false);
+  }
+
   CHECK_THROWS_WITH(
       ([&slab, &slab_length]() {
         check<tmpl::list<StepChoosers::Constant<StepChooserUse::LtsStep>>>(
-            true, std::make_unique<TimeSteppers::AdamsBashforth>(1),
+            true, std::make_unique<TimeSteppers::AdamsBashforth>(1), {},
             slab.start() + slab.duration() / 4, slab_length / 5.,
             slab.duration() / 8, true);
       })(),

--- a/tests/Unit/Time/Actions/Test_ChangeStepSize.cpp
+++ b/tests/Unit/Time/Actions/Test_ChangeStepSize.cpp
@@ -130,8 +130,9 @@ void check(const bool time_runs_forward,
   CAPTURE(time);
   CAPTURE(request);
 
-  const TimeDelta initial_step_size =
-      (time_runs_forward ? 1 : -1) * time.slab().duration();
+  const TimeDelta initial_step_size = (time_runs_forward ? 1 : -1) *
+                                      time.slab().duration() /
+                                      time.fraction().denominator();
 
   using component = Component<Metavariables<StepChoosersToUse>>;
   using MockRuntimeSystem =
@@ -142,10 +143,8 @@ void check(const bool time_runs_forward,
   // Initialize the component
   ActionTesting::emplace_component_and_initialize<component>(
       &runner, 0,
-      {TimeStepId(
-           time_runs_forward, -1,
-           (time_runs_forward ? time.slab().end() : time.slab().start()) -
-               initial_step_size),
+      {TimeStepId(time_runs_forward, 0,
+                  time_runs_forward ? time.slab().start() : time.slab().end()),
        TimeStepId(time_runs_forward, 0, time), initial_step_size,
        initial_step_size,
        reject_step

--- a/tests/Unit/Time/TimeSteppers/Test_AdamsMoultonPc.cpp
+++ b/tests/Unit/Time/TimeSteppers/Test_AdamsMoultonPc.cpp
@@ -93,6 +93,17 @@ SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.AdamsMoultonPc", "[Unit][Time]") {
   CHECK_FALSE(can_change(false, end, mid, end));
 
   {
+    const auto time_step = slab.duration() / 2;
+    const TimeStepId step_id(true, 1, slab.start() + time_step);
+    const TimeSteppers::AdamsMoultonPc stepper(2);
+    TimeSteppers::History<double> history(2);
+    history.insert(TimeStepId(true, 1, slab.start()), 0., 0.);
+    history.insert(step_id, 0., 0.);
+    CHECK_FALSE(stepper.can_change_step_size(
+        step_id.next_substep(time_step, 1.0), history));
+  }
+
+  {
     TimeSteppers::AdamsMoultonPc am4(4);
     TimeSteppers::AdamsMoultonPc am2(2);
     CHECK(am4 == am4);


### PR DESCRIPTION
Tracked down while testing LTS Adams-Moulton, but at least "Use correct id to check can_change_step_size" can be hit on develop.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
