### PR TITLE
Add `InitialPositionVelocity` tag

### DIFF
--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonChare.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonChare.hpp
@@ -73,8 +73,8 @@ struct WorldtubeSingleton {
   struct worldtube_system {
     static constexpr size_t volume_dim = Dim;
     static constexpr bool has_primitive_and_conservative_vars = false;
-    using variables_tag =
-        ::Tags::Variables<tmpl::list<Tags::Psi0, Tags::dtPsi0>>;
+    using variables_tag = ::Tags::Variables<
+        tmpl::list<Tags::EvolvedPosition<Dim>, Tags::EvolvedVelocity<Dim>>>;
   };
   using step_actions =
       tmpl::list<Actions::ChangeSlabSize, Actions::ReceiveElementData,

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonActions/Test_InitializeEvolvedVariables.cpp
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonActions/Test_InitializeEvolvedVariables.cpp
@@ -3,9 +3,11 @@
 
 #include "Framework/TestingFramework.hpp"
 
+#include <array>
 #include <memory>
 
 #include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
 #include "Evolution/Systems/CurvedScalarWave/Worldtube/SingletonActions/InitializeEvolvedVariables.hpp"
 #include "Time/Tags/HistoryEvolvedVariables.hpp"
 #include "Time/Tags/TimeStepper.hpp"
@@ -18,22 +20,31 @@ namespace {
 SPECTRE_TEST_CASE(
     "Unit.Evolution.Systems.CSW.Worldtube.InitializeEvolvedVariables",
     "[Unit][Evolution]") {
-  using variables_tag = ::Tags::Variables<tmpl::list<Tags::Psi0, Tags::dtPsi0>>;
+  using variables_tag = ::Tags::Variables<
+      tmpl::list<Tags::EvolvedPosition<3>, Tags::EvolvedVelocity<3>>>;
   using dt_variables_tag = db::add_tag_prefix<::Tags::dt, variables_tag>;
-
+  const tnsr::I<double, 3> initial_pos{{1., 2., 3.}};
+  const tnsr::I<double, 3> initial_vel{{4., 5., 6.}};
   auto box = db::create<
       db::AddSimpleTags<variables_tag, dt_variables_tag,
                         ::Tags::HistoryEvolvedVariables<variables_tag>,
-                        ::Tags::ConcreteTimeStepper<TimeStepper>>,
+                        ::Tags::ConcreteTimeStepper<TimeStepper>,
+                        Tags::InitialPositionAndVelocity>,
       time_stepper_ref_tags<TimeStepper>>(
       variables_tag::type{}, dt_variables_tag::type{},
       TimeSteppers::History<variables_tag::type>{},
       static_cast<std::unique_ptr<TimeStepper>>(
-          std::make_unique<TimeSteppers::AdamsBashforth>(4)));
+          std::make_unique<TimeSteppers::AdamsBashforth>(4)),
+      std::array<tnsr::I<double, 3>, 2>{{initial_pos, initial_vel}});
 
   db::mutate_apply<Initialization::InitializeEvolvedVariables>(
       make_not_null(&box));
-  CHECK(db::get<variables_tag>(box) == variables_tag::type(size_t(1), 0.));
+
+  const auto vars = db::get<variables_tag>(box);
+  for (size_t i = 0; i < 3; ++i) {
+    CHECK(get<Tags::EvolvedPosition<3>>(vars).get(i)[0] == initial_pos.get(i));
+    CHECK(get<Tags::EvolvedVelocity<3>>(vars).get(i)[0] == initial_vel.get(i));
+  }
   CHECK(db::get<dt_variables_tag>(box) ==
         dt_variables_tag::type(size_t(1), 0.));
   CHECK(db::get<::Tags::HistoryEvolvedVariables<variables_tag>>(box) ==

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/Test_Tags.cpp
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/Test_Tags.cpp
@@ -63,6 +63,19 @@ void test_excision_sphere_tag() {
           "Available excision spheres are: (ExcisionSphere)"));
 }
 
+void test_initial_position_velocity_tag() {
+  const double orbital_radius = 7.;
+  const double angular_vel = 0.1;
+  const auto domain_creator =
+      TestHelpers::CurvedScalarWave::Worldtube::worldtube_binary_compact_object(
+          orbital_radius, 0.2, angular_vel);
+  const tnsr::I<double, 3> expected_pos{{orbital_radius, 0., 0.}};
+  const tnsr::I<double, 3> expected_vel{{0., angular_vel * orbital_radius, 0.}};
+  CHECK(Tags::InitialPositionAndVelocity::create_from_options(
+            domain_creator, "ExcisionSphereA", 0.) ==
+        std::array<tnsr::I<double, 3>, 2>{{expected_pos, expected_vel}});
+}
+
 void test_compute_face_coordinates_grid() {
   static constexpr size_t Dim = 3;
   ::TestHelpers::db::test_compute_tag<
@@ -540,6 +553,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.CurvedScalarWave.Worldtube.Tags",
   TestHelpers::db::test_simple_tag<Tags::GeodesicAcceleration<3>>(
       "GeodesicAcceleration");
   test_excision_sphere_tag();
+  test_initial_position_velocity_tag();
   test_compute_face_coordinates_grid();
   test_compute_face_coordinates();
   test_particle_position_velocity_compute();


### PR DESCRIPTION
Adds the `InitialPositionAndVelocity` tag. Also, the worldtube system is changed to evolve the position and velocity by using the new tag to initialize them.

~depends on #5774 #5775~
