### PR TITLE
Disable paraview rendering tests on CI temporarily

### DIFF
--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -420,7 +420,8 @@ jobs:
             build_type: Debug
             TEST_TIMEOUT_FACTOR: 2
             # Test 3D rendering with ParaView
-            test_3d_rendering: ON
+            # Note: currently disabled because of some unknown upstream issue
+            # test_3d_rendering: ON
             # Need Python version consistent with ParaView
             PYTHON_VERSION: "3.9"
           # Don't modify the gcc-11 Debug build so its cache can be reused for

--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -532,6 +532,7 @@ jobs:
       # container because they take up a lot of space.
       - name: Install compiler
         run: |
+          apt-get update -y
           if [[ $COMPILER_ID = gcc ]]; then
             apt-get install -y $CC $CXX $FC
           else
@@ -1192,6 +1193,7 @@ ${{ matrix.build_type }}-pch-${{ matrix.use_pch || 'ON' }}"
           compiler: ${{ matrix.compiler }}
       - name: Install compiler
         run: |
+          apt-get update -y
           if [[ $COMPILER_ID = gcc ]]; then
             apt-get install -y $CC $CXX $FC
           else


### PR DESCRIPTION
## Proposed changes

Turns out #5773 didn't actually fix this issue, it just introduced a new one. I figure let's just temporarily disable the tests until we can actually figure things out so we can get CI working again.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
