### PR TITLE
Allow random hp AMR for testing

### DIFF
--- a/src/ParallelAlgorithms/Amr/Criteria/Random.cpp
+++ b/src/ParallelAlgorithms/Amr/Criteria/Random.cpp
@@ -3,14 +3,18 @@
 
 #include "ParallelAlgorithms/Amr/Criteria/Random.hpp"
 
+#include <cstddef>
 #include <random>
+#include <unordered_map>
 
 #include "Domain/Amr/Flag.hpp"
+#include "Utilities/Algorithm.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
 
 namespace amr::Criteria {
-Random::Random(const double do_something_fraction,
+Random::Random(std::unordered_map<amr::Flag, size_t> probability_weights,
                const size_t maximum_refinement_level)
-    : do_something_fraction_(do_something_fraction),
+    : probability_weights_(std::move(probability_weights)),
       maximum_refinement_level_(maximum_refinement_level) {}
 
 Random::Random(CkMigrateMessage* msg) : Criterion(msg) {}
@@ -18,27 +22,41 @@ Random::Random(CkMigrateMessage* msg) : Criterion(msg) {}
 // NOLINTNEXTLINE(google-runtime-references)
 void Random::pup(PUP::er& p) {
   Criterion::pup(p);
-  p | do_something_fraction_;
+  p | probability_weights_;
   p | maximum_refinement_level_;
 }
 
-amr::Flag Random::random_flag(const size_t current_refinement_level) const {
+namespace detail {
+amr::Flag random_flag(
+    const std::unordered_map<amr::Flag, size_t>& probability_weights) {
+  const size_t total_weight =
+      alg::accumulate(probability_weights, 0_st,
+                      [](const size_t total, const auto& flag_and_weight) {
+                        return total + flag_and_weight.second;
+                      });
+  if (total_weight == 0) {
+    return amr::Flag::DoNothing;
+  }
+  if (probability_weights.size() == 1) {
+    return probability_weights.begin()->first;
+  }
+
   static std::random_device r;
   static const auto seed = r();
   static std::mt19937 generator(seed);
-  static std::uniform_real_distribution<> distribution(0.0, 1.0);
+  std::uniform_int_distribution<size_t> distribution{0, total_weight - 1};
 
-  const double random_number = distribution(generator);
-  if (random_number > do_something_fraction_) {
-    return amr::Flag::DoNothing;
+  const size_t random_number = distribution(generator);
+  size_t cumulative_weight = 0;
+  for (const auto& [flag, probability_weight] : probability_weights) {
+    cumulative_weight += probability_weight;
+    if (random_number < cumulative_weight) {
+      return flag;
+    }
   }
-  const double join_fraction =
-      current_refinement_level / static_cast<double>(maximum_refinement_level_);
-  if (random_number < join_fraction * do_something_fraction_) {
-    return amr::Flag::Join;
-  }
-  return amr::Flag::Split;
+  ERROR("Should never reach here");
 }
+}  // namespace detail
 
 PUP::able::PUP_ID Random::my_PUP_ID = 0;  // NOLINT
 }  // namespace amr::Criteria

--- a/tests/InputFiles/ExampleExecutables/RandomAmr1D.yaml
+++ b/tests/InputFiles/ExampleExecutables/RandomAmr1D.yaml
@@ -18,7 +18,10 @@ Parallelization:
 Amr:
   Criteria:
     - Random:
-        ChangeRefinementFraction: 0.8
+        ProbabilityWeights:
+          Split: 2
+          Join: 1
+          DoNothing: 1
         MaximumRefinementLevel: 8
   Policies:
     Isotropy: Anisotropic

--- a/tests/InputFiles/ExportCoordinates/Input1D.yaml
+++ b/tests/InputFiles/ExportCoordinates/Input1D.yaml
@@ -17,7 +17,10 @@ Parallelization:
 Amr:
   Criteria:
     - Random:
-        ChangeRefinementFraction: 0.8
+        ProbabilityWeights:
+          Split: 2
+          Join: 1
+          DoNothing: 1
         MaximumRefinementLevel: 4
   Policies:
     Isotropy: Anisotropic


### PR DESCRIPTION
Support triggering any of the AMR flags with a specified probability, rather than only h-refinement. Simplifies the reasoning of the AMR criterion and gives more control over the types of refinement. Still enforces a maximum refinement level, which can be deleted once it's enforced globally with an AMR policy.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
