### PR TITLE
Add some self-force option tags

### DIFF
--- a/src/Evolution/Executables/CurvedScalarWave/EvolveWorldtubeCurvedScalarWave.hpp
+++ b/src/Evolution/Executables/CurvedScalarWave/EvolveWorldtubeCurvedScalarWave.hpp
@@ -269,6 +269,7 @@ struct EvolutionMetavars {
       Tags::AnalyticData<InitialData>,
       CurvedScalarWave::Worldtube::Tags::ExcisionSphere<volume_dim>,
       CurvedScalarWave::Worldtube::Tags::ExpansionOrder,
+      CurvedScalarWave::Worldtube::Tags::Charge,
       CurvedScalarWave::Worldtube::Tags::ObserveCoefficientsTrigger>;
 
   using dg_registration_list =

--- a/src/Evolution/Executables/CurvedScalarWave/EvolveWorldtubeCurvedScalarWave.hpp
+++ b/src/Evolution/Executables/CurvedScalarWave/EvolveWorldtubeCurvedScalarWave.hpp
@@ -271,6 +271,7 @@ struct EvolutionMetavars {
       CurvedScalarWave::Worldtube::Tags::ExpansionOrder,
       CurvedScalarWave::Worldtube::Tags::Charge,
       CurvedScalarWave::Worldtube::Tags::Mass,
+      CurvedScalarWave::Worldtube::Tags::ApplySelfForce,
       CurvedScalarWave::Worldtube::Tags::ObserveCoefficientsTrigger>;
 
   using dg_registration_list =

--- a/src/Evolution/Executables/CurvedScalarWave/EvolveWorldtubeCurvedScalarWave.hpp
+++ b/src/Evolution/Executables/CurvedScalarWave/EvolveWorldtubeCurvedScalarWave.hpp
@@ -270,6 +270,7 @@ struct EvolutionMetavars {
       CurvedScalarWave::Worldtube::Tags::ExcisionSphere<volume_dim>,
       CurvedScalarWave::Worldtube::Tags::ExpansionOrder,
       CurvedScalarWave::Worldtube::Tags::Charge,
+      CurvedScalarWave::Worldtube::Tags::Mass,
       CurvedScalarWave::Worldtube::Tags::ObserveCoefficientsTrigger>;
 
   using dg_registration_list =

--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/Tags.cpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/Tags.cpp
@@ -112,7 +112,7 @@ void PunctureFieldCompute<Dim>::function(
         inertial_face_coords_centered,
     const std::array<tnsr::I<double, Dim, ::Frame::Inertial>, 2>&
         particle_position_velocity,
-    const tnsr::I<double, Dim>& particle_acceleration,
+    const tnsr::I<double, Dim>& particle_acceleration, const double charge,
     const size_t expansion_order) {
   if (inertial_face_coords_centered.has_value()) {
     if (not result->has_value()) {
@@ -122,6 +122,7 @@ void PunctureFieldCompute<Dim>::function(
                    inertial_face_coords_centered.value(),
                    particle_position_velocity[0], particle_position_velocity[1],
                    particle_acceleration, 1., expansion_order);
+    result->value() *= charge;
   } else {
     result->reset();
   }

--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/Tags.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/Tags.hpp
@@ -64,6 +64,14 @@ struct Charge {
 };
 
 /*!
+ * \brief Options for the scalar self-force
+ */
+struct SelfForceOptions {
+  static constexpr Options::String help = {"Options for the scalar self-force"};
+  using group = Worldtube;
+};
+
+/*!
  * \brief Name of the excision sphere designated to act as a worldtube
  */
 struct ExcisionSphere {

--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/Tags.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/Tags.hpp
@@ -82,6 +82,17 @@ struct Mass {
   using group = SelfForceOptions;
 };
 
+/*!
+ * \brief Whether to apply the acceleration due to the scalar self-force to the
+ * particle
+ */
+struct ApplySelfForce {
+  using type = bool;
+  static constexpr Options::String help{
+      "Whether to apply the acceleration due to the scalar self-force to the "
+      "particle"};
+  using group = SelfForceOptions;
+};
 
 /*!
  * \brief Name of the excision sphere designated to act as a worldtube
@@ -242,6 +253,18 @@ struct Mass : db::SimpleTag {
   static double create_from_options(const double mass) { return mass; };
 };
 
+/*!
+ * \brief Whether to apply the acceleration due to the scalar self-force to the
+ * particle
+ */
+struct ApplySelfForce : db::SimpleTag {
+  using type = bool;
+  using option_tags = tmpl::list<OptionTags::ApplySelfForce>;
+  static constexpr bool pass_metavariables = false;
+  static bool create_from_options(const bool apply_self_force) {
+    return apply_self_force;
+  };
+};
 
 /*!
  * \brief The initial position and velocity of the scalar charge in inertial

--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/Tags.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/Tags.hpp
@@ -72,6 +72,18 @@ struct SelfForceOptions {
 };
 
 /*!
+ * \brief The mass of the scalar particle in units of the black hole mass M.
+ */
+struct Mass {
+  using type = double;
+  static constexpr Options::String help{
+      "The mass of the scalar particlein units of the black hole mass M."};
+  static double lower_bound() { return 0.; }
+  using group = SelfForceOptions;
+};
+
+
+/*!
  * \brief Name of the excision sphere designated to act as a worldtube
  */
 struct ExcisionSphere {
@@ -218,6 +230,16 @@ struct Charge : db::SimpleTag {
   using option_tags = tmpl::list<OptionTags::Charge>;
   static constexpr bool pass_metavariables = false;
   static double create_from_options(const double charge) { return charge; };
+};
+
+/*!
+ * \brief The mass of the particle.
+ */
+struct Mass : db::SimpleTag {
+  using type = double;
+  using option_tags = tmpl::list<OptionTags::Mass>;
+  static constexpr bool pass_metavariables = false;
+  static double create_from_options(const double mass) { return mass; };
 };
 
 

--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/Tags.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/Tags.hpp
@@ -54,6 +54,16 @@ struct Worldtube {
 };
 
 /*!
+ * \brief The value of the scalar charge in units of the black hole mass M.
+ */
+struct Charge {
+  using type = double;
+  static constexpr Options::String help{
+      "The value of the scalar charge in units of the black hole mass M."};
+  using group = Worldtube;
+};
+
+/*!
  * \brief Name of the excision sphere designated to act as a worldtube
  */
 struct ExcisionSphere {
@@ -191,6 +201,17 @@ struct ObserveCoefficientsTrigger : db::SimpleTag {
     return deserialize<type>(serialize<type>(trigger).data());
   }
 };
+
+/*!
+ * \brief The value of the scalar charge
+ */
+struct Charge : db::SimpleTag {
+  using type = double;
+  using option_tags = tmpl::list<OptionTags::Charge>;
+  static constexpr bool pass_metavariables = false;
+  static double create_from_options(const double charge) { return charge; };
+};
+
 
 /*!
  * \brief The initial position and velocity of the scalar charge in inertial
@@ -383,9 +404,10 @@ struct PunctureField : db::SimpleTag {
 template <size_t Dim>
 struct PunctureFieldCompute : PunctureField<Dim>, db::ComputeTag {
   using base = PunctureField<Dim>;
-  using argument_tags = tmpl::list<FaceCoordinates<Dim, Frame::Inertial, true>,
-                                   ParticlePositionVelocity<Dim>,
-                                   GeodesicAcceleration<Dim>, ExpansionOrder>;
+  using argument_tags =
+      tmpl::list<FaceCoordinates<Dim, Frame::Inertial, true>,
+                 ParticlePositionVelocity<Dim>, GeodesicAcceleration<Dim>,
+                 Charge, ExpansionOrder>;
   using return_type = std::optional<Variables<tmpl::list<
       CurvedScalarWave::Tags::Psi, ::Tags::dt<CurvedScalarWave::Tags::Psi>,
       ::Tags::deriv<CurvedScalarWave::Tags::Psi, tmpl::size_t<3>,
@@ -396,7 +418,7 @@ struct PunctureFieldCompute : PunctureField<Dim>, db::ComputeTag {
           inertial_face_coords_centered,
       const std::array<tnsr::I<double, Dim, ::Frame::Inertial>, 2>&
           particle_position_velocity,
-      const tnsr::I<double, Dim>& particle_acceleration,
+      const tnsr::I<double, Dim>& particle_acceleration, double charge,
       const size_t expansion_order);
 };
 /// @}

--- a/tests/InputFiles/CurvedScalarWave/WorldtubeKerrSchild.yaml
+++ b/tests/InputFiles/CurvedScalarWave/WorldtubeKerrSchild.yaml
@@ -133,6 +133,8 @@ Worldtube:
   ExcisionSphere: ExcisionSphereA
   ExpansionOrder: 1
   Charge: 0.5
+  SelfForceOptions:
+    Mass: 0.5
   ObserveCoefficientsTrigger:
     Slabs:
       EvenlySpaced:

--- a/tests/InputFiles/CurvedScalarWave/WorldtubeKerrSchild.yaml
+++ b/tests/InputFiles/CurvedScalarWave/WorldtubeKerrSchild.yaml
@@ -132,6 +132,7 @@ EventsAndTriggers:
 Worldtube:
   ExcisionSphere: ExcisionSphereA
   ExpansionOrder: 1
+  Charge: 0.5
   ObserveCoefficientsTrigger:
     Slabs:
       EvenlySpaced:

--- a/tests/InputFiles/CurvedScalarWave/WorldtubeKerrSchild.yaml
+++ b/tests/InputFiles/CurvedScalarWave/WorldtubeKerrSchild.yaml
@@ -134,6 +134,7 @@ Worldtube:
   ExpansionOrder: 1
   Charge: 0.5
   SelfForceOptions:
+    ApplySelfForce: false
     Mass: 0.5
   ObserveCoefficientsTrigger:
     Slabs:

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/Test_Tags.cpp
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/Test_Tags.cpp
@@ -534,11 +534,15 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.CurvedScalarWave.Worldtube.Tags",
             CurvedScalarWave::Worldtube::OptionTags::ExpansionOrder>("0") == 0);
   CHECK(TestHelpers::test_option_tag<
             CurvedScalarWave::Worldtube::OptionTags::Charge>("1.") == 1.);
+  CHECK(TestHelpers::test_option_tag<
+            CurvedScalarWave::Worldtube::OptionTags::Mass>("1.") == 1.);
   TestHelpers::db::test_simple_tag<Tags::ExcisionSphere<3>>("ExcisionSphere");
   TestHelpers::db::test_simple_tag<
       CurvedScalarWave::Worldtube::Tags::ExpansionOrder>("ExpansionOrder");
   TestHelpers::db::test_simple_tag<CurvedScalarWave::Worldtube::Tags::Charge>(
       "Charge");
+  TestHelpers::db::test_simple_tag<CurvedScalarWave::Worldtube::Tags::Mass>(
+      "Mass");
   TestHelpers::db::test_simple_tag<Tags::ElementFacesGridCoordinates<3>>(
       "ElementFacesGridCoordinates");
   TestHelpers::db::test_simple_tag<Tags::FaceCoordinates<3, Frame::Grid, true>>(

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/Test_Tags.cpp
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/Test_Tags.cpp
@@ -415,6 +415,7 @@ void test_puncture_field() {
   const tnsr::I<double, Dim, Frame::Inertial> charge_pos{{7.1, 0., 0.}};
   const tnsr::I<double, Dim, Frame::Inertial> charge_vel{{0.1, 0.2, 0.}};
   const tnsr::I<double, Dim, Frame::Inertial> charge_acc{{0.1, 0.2, 0.}};
+  const double charge = 0.1;
   const std::array<tnsr::I<double, Dim, Frame::Inertial>, 2> pos_vel{
       {charge_pos, charge_vel}};
 
@@ -427,11 +428,12 @@ void test_puncture_field() {
   const auto box_abutting = db::create<
       db::AddSimpleTags<Tags::FaceCoordinates<Dim, Frame::Inertial, true>,
                         Tags::ParticlePositionVelocity<Dim>,
-                        Tags::GeodesicAcceleration<Dim>, Tags::ExpansionOrder>,
+                        Tags::GeodesicAcceleration<Dim>, Tags::ExpansionOrder,
+                        Tags::Charge>,
       db::AddComputeTags<Tags::PunctureFieldCompute<Dim>>>(
       std::make_optional<tnsr::I<DataVector, Dim, Frame::Inertial>>(
           random_points),
-      pos_vel, charge_acc, order);
+      pos_vel, charge_acc, order, charge);
 
   const auto singular_field = get<Tags::PunctureField<Dim>>(box_abutting);
 
@@ -443,14 +445,16 @@ void test_puncture_field() {
       expected{};
   puncture_field(make_not_null(&expected), random_points, charge_pos,
                  charge_vel, charge_acc, 1., order);
+  expected *= charge;
   CHECK_VARIABLES_APPROX(singular_field.value(), expected);
   std::optional<tnsr::I<DataVector, Dim, Frame::Inertial>> nullopt{};
   const auto box_not_abutting = db::create<
       db::AddSimpleTags<Tags::FaceCoordinates<Dim, Frame::Inertial, true>,
                         Tags::ParticlePositionVelocity<Dim>,
-                        Tags::GeodesicAcceleration<Dim>, Tags::ExpansionOrder>,
-      db::AddComputeTags<Tags::PunctureFieldCompute<Dim>>>(nullopt, pos_vel,
-                                                           charge_acc, order);
+                        Tags::GeodesicAcceleration<Dim>, Tags::ExpansionOrder,
+                        Tags::Charge>,
+      db::AddComputeTags<Tags::PunctureFieldCompute<Dim>>>(
+      nullopt, pos_vel, charge_acc, order, charge);
   const auto puncture_field_nullopt =
       get<Tags::PunctureField<Dim>>(box_not_abutting);
   CHECK(not puncture_field_nullopt.has_value());
@@ -528,9 +532,13 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.CurvedScalarWave.Worldtube.Tags",
         "Worldtube");
   CHECK(TestHelpers::test_option_tag<
             CurvedScalarWave::Worldtube::OptionTags::ExpansionOrder>("0") == 0);
+  CHECK(TestHelpers::test_option_tag<
+            CurvedScalarWave::Worldtube::OptionTags::Charge>("1.") == 1.);
   TestHelpers::db::test_simple_tag<Tags::ExcisionSphere<3>>("ExcisionSphere");
   TestHelpers::db::test_simple_tag<
       CurvedScalarWave::Worldtube::Tags::ExpansionOrder>("ExpansionOrder");
+  TestHelpers::db::test_simple_tag<CurvedScalarWave::Worldtube::Tags::Charge>(
+      "Charge");
   TestHelpers::db::test_simple_tag<Tags::ElementFacesGridCoordinates<3>>(
       "ElementFacesGridCoordinates");
   TestHelpers::db::test_simple_tag<Tags::FaceCoordinates<3, Frame::Grid, true>>(

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/Test_Tags.cpp
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/Test_Tags.cpp
@@ -536,6 +536,9 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.CurvedScalarWave.Worldtube.Tags",
             CurvedScalarWave::Worldtube::OptionTags::Charge>("1.") == 1.);
   CHECK(TestHelpers::test_option_tag<
             CurvedScalarWave::Worldtube::OptionTags::Mass>("1.") == 1.);
+  CHECK(TestHelpers::test_option_tag<
+            CurvedScalarWave::Worldtube::OptionTags::ApplySelfForce>("true") ==
+        true);
   TestHelpers::db::test_simple_tag<Tags::ExcisionSphere<3>>("ExcisionSphere");
   TestHelpers::db::test_simple_tag<
       CurvedScalarWave::Worldtube::Tags::ExpansionOrder>("ExpansionOrder");
@@ -543,6 +546,8 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.CurvedScalarWave.Worldtube.Tags",
       "Charge");
   TestHelpers::db::test_simple_tag<CurvedScalarWave::Worldtube::Tags::Mass>(
       "Mass");
+  TestHelpers::db::test_simple_tag<
+      CurvedScalarWave::Worldtube::Tags::ApplySelfForce>("ApplySelfForce");
   TestHelpers::db::test_simple_tag<Tags::ElementFacesGridCoordinates<3>>(
       "ElementFacesGridCoordinates");
   TestHelpers::db::test_simple_tag<Tags::FaceCoordinates<3, Frame::Grid, true>>(


### PR DESCRIPTION
Adds the tags `Charge`, `Mass` and `ApplySelfForce` which are needed to compute the value of the scalar self-force onto the particle

~depends on #5777~