### PR TITLE
Add `BackgroundQuantities` tag

### DIFF
--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -270,7 +270,9 @@ jobs:
           echo "Running clang-tidy relative to: $UPSTREAM_HASH\n"
 
           git diff -U0 $UPSTREAM_HASH |
-            clang-tidy-diff -path build -p1 -use-color
+            clang-tidy-diff -path build -p1 -use-color \
+            -extra-arg=-I/usr/include/hdf5/serial
+
 
   # Build the documentation and check for problems, then upload as a workflow
   # artifact and deploy to gh-pages.

--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonChare.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonChare.hpp
@@ -73,7 +73,8 @@ struct WorldtubeSingleton {
           Initialization::InitializeElementFacesGridCoordinates<Dim>>,
       ::Initialization::Actions::AddComputeTags<
           tmpl::list<Tags::EvolvedParticlePositionVelocityCompute<Dim>,
-                     Tags::GeodesicAccelerationCompute<Dim>>>,
+                     Tags::GeodesicAccelerationCompute<Dim>,
+                     Tags::BackgroundQuantitiesCompute<Dim>>>,
       Parallel::Actions::TerminatePhase>;
 
   struct worldtube_system {

--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/Tags.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/Tags.hpp
@@ -31,6 +31,7 @@
 #include "Utilities/EqualWithinRoundoff.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/Serialization/Serialize.hpp"
+#include "Utilities/TaggedTuple.hpp"
 
 /// \cond
 namespace Tags {
@@ -392,6 +393,35 @@ struct TimeDilationFactor : db::SimpleTag {
   using type = Scalar<double>;
 };
 
+/// @{
+/*!
+ * \brief A tuple of Tensors evaluated at the charge depending only the
+ * background and the particle's position and velocity. These values are
+ * effectively cached between different iterations of the worldtube scheme.
+ */
+template <size_t Dim>
+struct BackgroundQuantities : db::SimpleTag {
+  using type =
+      tuples::TaggedTuple<gr::Tags::SpacetimeMetric<double, Dim>,
+                          gr::Tags::InverseSpacetimeMetric<double, Dim>,
+                          Tags::TimeDilationFactor>;
+};
+
+template <size_t Dim>
+struct BackgroundQuantitiesCompute : BackgroundQuantities<Dim>, db::ComputeTag {
+  using base = BackgroundQuantities<Dim>;
+  using return_type =
+      tuples::TaggedTuple<gr::Tags::SpacetimeMetric<double, Dim>,
+                          gr::Tags::InverseSpacetimeMetric<double, Dim>,
+                          Tags::TimeDilationFactor>;
+
+  using argument_tags = tmpl::list<
+      ParticlePositionVelocity<Dim>,
+      CurvedScalarWave::Tags::BackgroundSpacetime<gr::Solutions::KerrSchild>>;
+  static void function(gsl::not_null<return_type*> result,
+                       const std::array<tnsr::I<double, Dim, Frame::Inertial>,
+                                        2>& position_velocity,
+                       const gr::Solutions::KerrSchild& background_spacetime);
 };
 /// @}
 

--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/Tags.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/Tags.hpp
@@ -384,6 +384,17 @@ struct GeodesicAccelerationCompute : GeodesicAcceleration<Dim>, db::ComputeTag {
 };
 /// @}
 
+/*!
+ * \brief The coordinate time dilation factor of the scalar charge, i.e. the 0th
+ * component of its 4-velocity.
+ */
+struct TimeDilationFactor : db::SimpleTag {
+  using type = Scalar<double>;
+};
+
+};
+/// @}
+
 /// @{
 /*!
  * \brief An optional that holds the coordinates of an element face abutting the

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/Test_Tags.cpp
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/Test_Tags.cpp
@@ -569,6 +569,8 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.CurvedScalarWave.Worldtube.Tags",
       "ObserveCoefficientsTrigger");
   TestHelpers::db::test_simple_tag<Tags::GeodesicAcceleration<3>>(
       "GeodesicAcceleration");
+  TestHelpers::db::test_simple_tag<Tags::TimeDilationFactor>(
+      "TimeDilationFactor");
   test_excision_sphere_tag();
   test_initial_position_velocity_tag();
   test_compute_face_coordinates_grid();


### PR DESCRIPTION
Adds a `TimeDilationFactor` simple  tag as well as a `BackgroundQuantities` compute tag. The worldtube will run an iterative scheme when it applies the scalar self-force, where several iterations of computations are done each time step (to be added shortly). The  `BackgroundQuantities` tag is there to cache all the quantities that do not change between iterations, i.e. only depend on the position and velocity of the scalar charge.

~depends on #5785~