### PR TITLE
Wrap RotatingStar to be usable in GhValenciaDivClean

### DIFF
--- a/src/PointwiseFunctions/AnalyticSolutions/GhRelativisticEuler/Factory.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GhRelativisticEuler/Factory.hpp
@@ -5,6 +5,7 @@
 
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/WrappedGr.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/RelativisticEuler/FishboneMoncriefDisk.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/RelativisticEuler/RotatingStar.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/RelativisticEuler/TovStar.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -15,6 +16,7 @@ namespace gh::RelativisticEuler::Solutions {
 using all_solutions = tmpl::list<
     gh::Solutions::WrappedGr<
         ::RelativisticEuler::Solutions::FishboneMoncriefDisk>,
+    gh::Solutions::WrappedGr<::RelativisticEuler::Solutions::RotatingStar>,
     gh::Solutions::WrappedGr<::RelativisticEuler::Solutions::TovStar>>;
 
 }  // namespace gh::RelativisticEuler::Solutions

--- a/src/PointwiseFunctions/AnalyticSolutions/GhRelativisticEuler/InstantiateWrappedGr.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GhRelativisticEuler/InstantiateWrappedGr.cpp
@@ -5,10 +5,12 @@
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/WrappedGr.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/WrappedGr.tpp"
 #include "PointwiseFunctions/AnalyticSolutions/RelativisticEuler/FishboneMoncriefDisk.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/RelativisticEuler/RotatingStar.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/RelativisticEuler/TovStar.hpp"
 #include "PointwiseFunctions/Hydro/Tags.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 
 GENERATE_INSTANTIATIONS(WRAPPED_GR_INSTANTIATE,
                         (RelativisticEuler::Solutions::FishboneMoncriefDisk,
+                         RelativisticEuler::Solutions::RotatingStar,
                          RelativisticEuler::Solutions::TovStar))

--- a/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/RotatingStar.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/RotatingStar.cpp
@@ -770,6 +770,15 @@ RotatingStar::variables(
 
 template <typename DataType>
 auto RotatingStar::variables(
+    const gsl::not_null<IntermediateVariables<DataType>*> /*vars*/,
+    const tnsr::I<DataType, 3>& x,
+    tmpl::list<::Tags::dt<gr::Tags::Lapse<DataType>>> /*meta*/) const
+    -> tuples::TaggedTuple<::Tags::dt<gr::Tags::Lapse<DataType>>> {
+  return make_with_value<Scalar<DataType>>(get<0>(x), 0.0);
+}
+
+template <typename DataType>
+auto RotatingStar::variables(
     const gsl::not_null<IntermediateVariables<DataType>*> vars,
     const tnsr::I<DataType, 3>& x,
     tmpl::list<DerivLapse<DataType>> /*meta*/) const
@@ -789,6 +798,15 @@ auto RotatingStar::variables(
         (0.5 / vars->delta_r) * (get(lapse_upper) - get(lapse_lower));
   }
   return deriv_lapse;
+}
+
+template <typename DataType>
+auto RotatingStar::variables(
+    const gsl::not_null<IntermediateVariables<DataType>*> /*vars*/,
+    const tnsr::I<DataType, 3>& x,
+    tmpl::list<::Tags::dt<gr::Tags::Shift<DataType, 3>>> /*meta*/) const
+    -> tuples::TaggedTuple<::Tags::dt<gr::Tags::Shift<DataType, 3>>> {
+  return make_with_value<tnsr::I<DataType, 3, Frame::Inertial>>(get<0>(x), 0.0);
 }
 
 template <typename DataType>
@@ -816,6 +834,16 @@ auto RotatingStar::variables(
     }
   }
   return deriv_shift;
+}
+
+template <typename DataType>
+auto RotatingStar::variables(
+    const gsl::not_null<IntermediateVariables<DataType>*> /*vars*/,
+    const tnsr::I<DataType, 3>& x,
+    tmpl::list<::Tags::dt<gr::Tags::SpatialMetric<DataType, 3>>> /*meta*/) const
+    -> tuples::TaggedTuple<::Tags::dt<gr::Tags::SpatialMetric<DataType, 3>>> {
+  return make_with_value<tnsr::ii<DataType, 3, Frame::Inertial>>(get<0>(x),
+                                                                 0.0);
 }
 
 template <typename DataType>
@@ -973,6 +1001,37 @@ GENERATE_INSTANTIATIONS(INSTANTIATE_METRIC_DERIVS, (double, DataVector),
                         (DerivLapse, DerivShift, DerivSpatialMetric))
 
 #undef INSTANTIATE_METRIC_DERIVS
+
+#define INSTANTIATE_METRIC_TIME_DERIVS_SCALARS(_, data)                 \
+  template auto RotatingStar::variables(                                \
+      const gsl::not_null<IntermediateVariables<DTYPE(data)>*> /*vars*/,\
+      const tnsr::I<DTYPE(data), 3>& x,                                 \
+      tmpl::list < ::Tags::dt < TAG(data) < DTYPE(data) >>>             \
+      /*meta*/) const                                                   \
+      -> tuples::TaggedTuple < ::Tags::dt < TAG(data) < DTYPE(data) >>> \
+      ;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE_METRIC_TIME_DERIVS_SCALARS,
+                        (double, DataVector), (gr::Tags::Lapse))
+
+#undef INSTANTIATE_METRIC_TIME_DERIVS_SCALARS
+
+#define INSTANTIATE_METRIC_TIME_DERIVS_TENSORS(_, data)              \
+  template auto RotatingStar::variables(                             \
+      const gsl::not_null<IntermediateVariables<DTYPE(data)>*>       \
+      /*vars*/,                                                      \
+      const tnsr::I<DTYPE(data), 3>& x,                              \
+      tmpl::list < ::Tags::dt < TAG(data) < DTYPE(data), 3 >>>       \
+      /*meta*/) const                                                \
+      -> tuples::TaggedTuple < ::Tags::dt < TAG(data) < DTYPE(data), \
+      3 >>>                                                          \
+      ;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE_METRIC_TIME_DERIVS_TENSORS,
+                        (double, DataVector),
+                        (gr::Tags::Shift, gr::Tags::SpatialMetric))
+
+#undef INSTANTIATE_METRIC_TIME_DERIVS_TENSORS
 
 #undef TAG
 #undef DTYPE

--- a/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/RotatingStar.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/RotatingStar.hpp
@@ -564,14 +564,34 @@ class RotatingStar : public virtual evolution::initial_data::InitialData,
   template <typename DataType>
   auto variables(gsl::not_null<IntermediateVariables<DataType>*> vars,
                  const tnsr::I<DataType, 3>& x,
+                 tmpl::list<::Tags::dt<gr::Tags::Lapse<DataType>>> /*meta*/)
+      const -> tuples::TaggedTuple<::Tags::dt<gr::Tags::Lapse<DataType>>>;
+
+  template <typename DataType>
+  auto variables(gsl::not_null<IntermediateVariables<DataType>*> vars,
+                 const tnsr::I<DataType, 3>& x,
                  tmpl::list<DerivLapse<DataType>> /*meta*/) const
       -> tuples::TaggedTuple<DerivLapse<DataType>>;
 
   template <typename DataType>
   auto variables(gsl::not_null<IntermediateVariables<DataType>*> vars,
                  const tnsr::I<DataType, 3>& x,
+                 tmpl::list<::Tags::dt<gr::Tags::Shift<DataType, 3>>> /*meta*/)
+      const -> tuples::TaggedTuple<::Tags::dt<gr::Tags::Shift<DataType, 3>>>;
+
+  template <typename DataType>
+  auto variables(gsl::not_null<IntermediateVariables<DataType>*> vars,
+                 const tnsr::I<DataType, 3>& x,
                  tmpl::list<DerivShift<DataType>> /*meta*/) const
       -> tuples::TaggedTuple<DerivShift<DataType>>;
+
+  template <typename DataType>
+  auto variables(
+      gsl::not_null<IntermediateVariables<DataType>*> vars,
+      const tnsr::I<DataType, 3>& x,
+      tmpl::list<::Tags::dt<gr::Tags::SpatialMetric<DataType, 3>>> /*meta*/)
+      const
+      -> tuples::TaggedTuple<::Tags::dt<gr::Tags::SpatialMetric<DataType, 3>>>;
 
   template <typename DataType>
   auto variables(gsl::not_null<IntermediateVariables<DataType>*> vars,


### PR DESCRIPTION
## Proposed changes

<!--
At a high level, describe what this PR does.
-->

Adds the `RelativisticEuler` solution for `RotatingStar` to the list of `WrappedGR` solutions usable in `GhValenciaDivClean`. Adds time derivatives to the solution (all of which identically 0) to allow it to be compatible with this function.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [x] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [x] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [x] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
