### PR TITLE
Add regression tests to elliptic input files

### DIFF
--- a/tests/InputFiles/Elasticity/HalfSpaceMirror.yaml
+++ b/tests/InputFiles/Elasticity/HalfSpaceMirror.yaml
@@ -11,10 +11,11 @@ ExpectedOutput:
   - ElasticHalfSpaceMirrorVolume0.h5
 OutputFileChecks:
   - Label: Discretization error
-    Subfile: /ErrorNorms.dat
+    Subfile: ErrorNorms.dat
     FileGlob: ElasticHalfSpaceMirrorReductions.h5
-    SkipColumns: [0, 1, 2]
-    AbsoluteTolerance: 6.e-4
+    ExpectedData:
+      - [1, 171, 3.39481799202234e-01, 5.94500292306939e-04]
+    AbsoluteTolerance: 1e-12
 
 ---
 
@@ -36,10 +37,7 @@ Background: &solution
     RelativeTolerance: 1e-10
 
 Material:
-  Layer0:
-    IsotropicHomogeneous: *fused_silica
-  Layer1:
-    IsotropicHomogeneous: *fused_silica
+  IsotropicHomogeneous: *fused_silica
 
 InitialGuess: Zero
 
@@ -55,9 +53,9 @@ DomainCreator:
     InitialGridPoints: [2, 3, 3]
     UseEquiangularMap: True
     RadialPartitioning: []
-    PartitioningInZ: [0.1]
+    PartitioningInZ: []
     RadialDistribution: [Linear]
-    DistributionInZ: [Linear, Linear]
+    DistributionInZ: [Linear]
     BoundaryConditions:
       LowerZ:
         AnalyticSolution:
@@ -86,7 +84,7 @@ Observers:
 LinearSolver:
   Gmres:
     ConvergenceCriteria:
-      MaxIterations: 2
+      MaxIterations: 1
       RelativeResidual: 1.e-4
       AbsoluteResidual: 1.e-12
     Verbosity: Quiet
@@ -122,20 +120,18 @@ LinearSolver:
 EventsAndTriggers:
   - Trigger: HasConverged
     Events:
-      - ObserveNorms: &error_norms
+      - ObserveNorms:
           SubfileName: ErrorNorms
           TensorsToObserve:
             - Name: Error(Displacement)
               NormType: L2Norm
               Components: Sum
-      - ObserveNorms: &volume_integrals
+      - ObserveNorms:
           SubfileName: VolumeIntegrals
           TensorsToObserve:
             - Name: PotentialEnergyDensity
               NormType: VolumeIntegral
               Components: Individual
-      - ObserveNormsPerLayer: *error_norms
-      - ObserveNormsPerLayer: *volume_integrals
       - ObserveFields:
           SubfileName: VolumeData
           VariablesToObserve:

--- a/tests/InputFiles/Poisson/Lorentzian.yaml
+++ b/tests/InputFiles/Poisson/Lorentzian.yaml
@@ -11,10 +11,24 @@ ExpectedOutput:
   - LorentzianVolume0.h5
 OutputFileChecks:
   - Label: Discretization error
-    Subfile: /ErrorNorms.dat
+    Subfile: ErrorNorms.dat
     FileGlob: LorentzianReductions.h5
-    SkipColumns: [0, 1, 2]
-    AbsoluteTolerance: 0.05
+    ExpectedData:
+      - [6, 2808, 2.09439617691359e+34, 4.06585234592450e-02]
+    AbsoluteTolerance: 0.
+    RelativeTolerance: 1e-12
+  - Label: Linear solver convergence
+    Subfile: GmresResiduals.dat
+    FileGlob: LorentzianReductions.h5
+    ExpectedData:
+      - [0, 1.65600110447685e+00]
+      - [1, 2.10813044818694e-01]
+      - [2, 1.78150596490335e-01]
+      - [3, 1.49290348080966e-01]
+      - [4, 1.67729890706225e-02]
+      - [5, 1.99526909375260e-03]
+      - [6, 3.92043529725646e-04]
+    AbsoluteTolerance: 1e-10
 
 ---
 

--- a/tests/InputFiles/Poisson/ProductOfSinusoids1D.yaml
+++ b/tests/InputFiles/Poisson/ProductOfSinusoids1D.yaml
@@ -12,10 +12,20 @@ ExpectedOutput:
   - SubdomainMatrix_[B0,(L1I1)].txt
 OutputFileChecks:
   - Label: Discretization error
-    Subfile: /ErrorNorms.dat
+    Subfile: ErrorNorms.dat
     FileGlob: PoissonProductOfSinusoids1DReductions.h5
-    SkipColumns: [0, 1, 2]
-    AbsoluteTolerance: 0.005
+    ExpectedData:
+      - [3, 8, 4.71238898038469e+00, 4.14037391064113e-03]
+    AbsoluteTolerance: 1e-12
+  - Label: Linear solver convergence
+    Subfile: GmresResiduals.dat
+    FileGlob: PoissonProductOfSinusoids1DReductions.h5
+    ExpectedData:
+      - [0, 1.21812092038592e+01]
+      - [1, 1.57971714780159e-03]
+      - [2, 2.51555146884164e-07]
+      - [3, 0.]
+    AbsoluteTolerance: 1e-12
 
 ---
 

--- a/tests/InputFiles/Poisson/ProductOfSinusoids2D.yaml
+++ b/tests/InputFiles/Poisson/ProductOfSinusoids2D.yaml
@@ -10,10 +10,18 @@ ExpectedOutput:
   - PoissonProductOfSinusoids2DVolume0.h5
 OutputFileChecks:
   - Label: Discretization error
-    Subfile: /ErrorNorms.dat
+    Subfile: ErrorNorms.dat
     FileGlob: PoissonProductOfSinusoids2DReductions.h5
-    SkipColumns: [0, 1, 2]
-    AbsoluteTolerance: 0.005
+    ExpectedData:
+      - [1, 24, 7.40220330081702e+00, 3.70906457380056e-03]
+    AbsoluteTolerance: 1e-12
+  - Label: Linear solver convergence
+    Subfile: GmresResiduals.dat
+    FileGlob: PoissonProductOfSinusoids2DReductions.h5
+    ExpectedData:
+      - [0, 2.30405926122538e+01]
+      - [1, 0.]
+    AbsoluteTolerance: 1e-12
 
 ---
 

--- a/tests/InputFiles/Poisson/ProductOfSinusoids3D.yaml
+++ b/tests/InputFiles/Poisson/ProductOfSinusoids3D.yaml
@@ -11,10 +11,18 @@ ExpectedOutput:
   - PoissonProductOfSinusoids3DVolume0.h5
 OutputFileChecks:
   - Label: Discretization error
-    Subfile: /ErrorNorms.dat
+    Subfile: ErrorNorms.dat
     FileGlob: PoissonProductOfSinusoids3DReductions.h5
-    SkipColumns: [0, 1, 2]
-    AbsoluteTolerance: 0.005
+    ExpectedData:
+      - [1, 120, 2.32547075102249e+01, 4.28138911064402e-03]
+    AbsoluteTolerance: 1e-12
+  - Label: Linear solver convergence
+    Subfile: GmresResiduals.dat
+    FileGlob: PoissonProductOfSinusoids3DReductions.h5
+    ExpectedData:
+      - [0, 1.56746105639827e+02]
+      - [1, 1.12740301193524e-11]
+    AbsoluteTolerance: 1e-12
 
 ---
 

--- a/tests/InputFiles/Punctures/MultiplePunctures.yaml
+++ b/tests/InputFiles/Punctures/MultiplePunctures.yaml
@@ -9,6 +9,22 @@ Testing:
 ExpectedOutput:
   - PuncturesReductions.h5
   - PuncturesVolume0.h5
+OutputFileChecks:
+  - Label: Volume integrals
+    Subfile: VolumeIntegrals.dat
+    FileGlob: PuncturesReductions.h5
+    ExpectedData:
+      - [3, 448, 4.18881285829836e+03, 4.20735900800792e-02]
+    AbsoluteTolerance: 1e-12
+  - Label: Nonlinear solver convergence
+    Subfile: NewtonRaphsonResiduals.dat
+    FileGlob: PuncturesReductions.h5
+    ExpectedData:
+      - [0, 0, 7.19994010733799e-02, 1.]
+      - [1, 0, 3.39170331580851e-04, 1.]
+      - [2, 0, 5.94195185937208e-09, 1.]
+      - [3, 0, 0., 1.]
+    AbsoluteTolerance: 1e-12
 
 ---
 

--- a/tests/InputFiles/Xcts/BinaryBlackHole.yaml
+++ b/tests/InputFiles/Xcts/BinaryBlackHole.yaml
@@ -9,9 +9,38 @@ Testing:
 ExpectedOutput:
   - BbhReductions.h5
   - BbhVolume0.h5
+OutputFileChecks:
+  - Label: Norms
+    Subfile: Norms.dat
+    FileGlob: BbhReductions.h5
+    ExpectedData:
+      - [
+          5,
+          20304,
+          1.74532762048460e+33,
+          1.10996259399346e+00,
+          8.68051629831159e-01,
+          6.28127905852040e-01,
+          4.94959532218436e-03,
+          1.25936870550045e-03,
+          1.29835755854743e-03,
+          1.26478484974052e-03,
+        ]
+    AbsoluteTolerance: 0.
+    RelativeTolerance: 1e-9
+  - Label: Nonlinear solver convergence
+    Subfile: NewtonRaphsonResiduals.dat
+    FileGlob: BbhReductions.h5
+    ExpectedData:
+      - [0, 0, 9.58836468792872e+00, 1.]
+      - [1, 0, 2.56744819082553e+00, 1.]
+      - [2, 0, 6.92792186565806e-03, 1.]
+      - [3, 0, 1.21895158596328e-03, 1.]
+      - [4, 0, 7.97507362468631e-07, 1.]
+      - [5, 0, 7.12541536160998e-10, 1.]
+    AbsoluteTolerance: 1e-6
 
 ---
-
 Parallelization:
   ElementDistribution: NumGridPoints
 
@@ -73,37 +102,16 @@ DomainCreator:
     OuterShell:
       Radius: &outer_radius 1.e9
       RadialDistribution: &outer_shell_distribution Inverse
-      OpeningAngle: 90.0
+      OpeningAngle: 120.0
       BoundaryCondition: Flatness
     UseEquiangularMap: True
-    # This h-refinement is set up so spherical wedges have equal angular size.
-    # Once the domain supports equatorial compression (or similar) this
-    # h-refinement will simplify considerably.
     InitialRefinement:
-      ObjectAShell:               [1, 1, 1]
-      ObjectBShell:               [1, 1, 1]
-      ObjectACube:                [1, 1, 1]
-      ObjectBCube:                [1, 1, 1]
-      EnvelopeUpperZLeft:         [1, 1, 1]
-      EnvelopeLowerZLeft:         [1, 1, 1]
-      EnvelopeUpperYLeft:         [1, 1, 1]
-      EnvelopeLowerYLeft:         [1, 1, 1]
-      EnvelopeLowerX:             [1, 1, 1]
-      EnvelopeUpperZRight:        [1, 1, 1]
-      EnvelopeLowerZRight:        [1, 1, 1]
-      EnvelopeUpperYRight:        [1, 1, 1]
-      EnvelopeLowerYRight:        [1, 1, 1]
-      EnvelopeUpperX:             [1, 1, 1]
-      OuterShellUpperZLeft:       [0, 1, 0]
-      OuterShellLowerZLeft:       [0, 1, 0]
-      OuterShellUpperYLeft:       [0, 1, 0]
-      OuterShellLowerYLeft:       [0, 1, 0]
-      OuterShellLowerX:           [1, 1, 0]
-      OuterShellUpperZRight:      [0, 1, 0]
-      OuterShellLowerZRight:      [0, 1, 0]
-      OuterShellUpperYRight:      [0, 1, 0]
-      OuterShellLowerYRight:      [0, 1, 0]
-      OuterShellUpperX:           [1, 1, 0]
+      ObjectAShell:     [0, 0, 0]
+      ObjectBShell:     [0, 0, 0]
+      ObjectACube:      [0, 0, 0]
+      ObjectBCube:      [0, 0, 0]
+      Envelope:         [0, 0, 1]
+      OuterShell:       [0, 0, 2]
     # This p-refinement represents a crude manual optimization of the domain. We
     # will need AMR to optimize the domain further.
     InitialGridPoints:

--- a/tests/InputFiles/Xcts/KerrSchild.yaml
+++ b/tests/InputFiles/Xcts/KerrSchild.yaml
@@ -11,10 +11,32 @@ ExpectedOutput:
   - KerrSchildVolume0.h5
 OutputFileChecks:
   - Label: Discretization error
-    Subfile: /ErrorNorms.dat
+    Subfile: ErrorNorms.dat
     FileGlob: KerrSchildReductions.h5
-    SkipColumns: [0, 1, 2]
-    AbsoluteTolerance: 0.04
+    ExpectedData:
+      - [
+          5,
+          384,
+          4.20277018789526e+03,
+          1.09488565564726e-03,
+          5.31467293519265e-03,
+          1.17765764073955e-02,
+          2.00607960424956e-03,
+          4.80423457412180e-03,
+          2.39573111152042e-02,
+        ]
+    AbsoluteTolerance: 1e-10
+  - Label: Nonlinear solver convergence
+    Subfile: NewtonRaphsonResiduals.dat
+    FileGlob: KerrSchildReductions.h5
+    ExpectedData:
+      - [0, 0, 6.86317921700308e+01, 1.]
+      - [1, 0, 2.54081356038966e+00, 1.]
+      - [2, 0, 1.06821671508785e-01, 1.]
+      - [3, 0, 5.29758557594090e-04, 1.]
+      - [4, 0, 1.23004570709784e-08, 1.]
+      - [5, 0, 7.83806401935946e-13, 1.]
+    AbsoluteTolerance: 1e-10
 
 ---
 


### PR DESCRIPTION
## Proposed changes

This reproduces the issue mentioned in #5756: the test added to `BinaryBlackHole.yaml` passed before #5709 and fails now on develop. Note that the test takes too long to run on CI, so CI still passes.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
