### PR TITLE
Log Distribution Fix

### DIFF
--- a/src/Domain/CoordinateMaps/Frustum.hpp
+++ b/src/Domain/CoordinateMaps/Frustum.hpp
@@ -335,6 +335,7 @@ class Frustum {
   bool with_equiangular_map_{false};
   bool is_identity_{false};
   Distribution zeta_distribution_ = Distribution::Linear;
+  double zeta_distribution_value_{std::numeric_limits<double>::signaling_NaN()};
   double sigma_x_{std::numeric_limits<double>::signaling_NaN()};
   double delta_x_zeta_{std::numeric_limits<double>::signaling_NaN()};
   double delta_x_xi_{std::numeric_limits<double>::signaling_NaN()};

--- a/src/Domain/Creators/BinaryCompactObject.cpp
+++ b/src/Domain/Creators/BinaryCompactObject.cpp
@@ -441,7 +441,8 @@ Domain<3> BinaryCompactObject::create_domain() const {
       radial_distribution_envelope_ ==
               domain::CoordinateMaps::Distribution::Projective
           ? std::optional<double>(length_inner_cube_ / length_outer_cube_)
-          : std::nullopt,
+          : std::optional<double>(-(length_outer_cube_ + length_inner_cube_) /
+                                  (length_outer_cube_ - length_inner_cube_)),
       1.0, opening_angle_));
   std::move(maps_frustums.begin(), maps_frustums.end(),
             std::back_inserter(maps));

--- a/tests/Unit/Domain/CoordinateMaps/Test_Frustum.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_Frustum.cpp
@@ -111,7 +111,7 @@ void test_suite_for_frustum(
     // to fail in extreme cases.
     const CoordinateMaps::Frustum frustum_map(
         face_vertices, lower_z, upper_z, map_i(), with_equiangular_map,
-        zeta_distribution, 1.0, 1.0, opening_angle);
+        zeta_distribution, std::nullopt, 1.0, 1.0, opening_angle);
     test_suite_for_map_on_unit_cube(frustum_map);
   }
 }


### PR DESCRIPTION
## Proposed changes

Changes the Interval in Log Distribution for frustums to be the even if the x-coord of the objects aren't the same. This was causing parts of the envelope to not line up properly for unequal mass runs (shown below) which caused bad constraints even at t=0. The second pic is with the fix.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

![image](https://github.com/sxs-collaboration/spectre/assets/47013010/2ebae577-f09d-40eb-984f-46db43eb1b55)
![image](https://github.com/sxs-collaboration/spectre/assets/47013010/d24a9144-2fcd-49f8-9949-d736719656f9)

