### PR TITLE
Remove p-refinement from punctures AMR criterion

### DIFF
--- a/src/Elliptic/Systems/Punctures/AmrCriteria/RefineAtPunctures.cpp
+++ b/src/Elliptic/Systems/Punctures/AmrCriteria/RefineAtPunctures.cpp
@@ -39,11 +39,11 @@ std::array<amr::Flag, 3> RefineAtPunctures::impl(
       block_logical_coordinates(domain, puncture_positions);
   const auto element_logical_coords =
       element_logical_coordinates({element_id}, block_logical_coords);
-  // Split (h-refine) the element if it contains a puncture, else p-refine
+  // Split (h-refine) the element if it contains a puncture
   if (element_logical_coords.find(element_id) != element_logical_coords.end()) {
     return make_array<3>(amr::Flag::Split);
   } else {
-    return make_array<3>(amr::Flag::IncreaseResolution);
+    return make_array<3>(amr::Flag::DoNothing);
   }
 }
 

--- a/src/Elliptic/Systems/Punctures/AmrCriteria/RefineAtPunctures.hpp
+++ b/src/Elliptic/Systems/Punctures/AmrCriteria/RefineAtPunctures.hpp
@@ -23,8 +23,7 @@
 namespace Punctures::AmrCriteria {
 
 /*!
- * \brief h-refine (split) elements containing a puncture, and p-refine
- * everywhere else.
+ * \brief h-refine (split) elements containing a puncture
  *
  * This refinement scheme is expected to yield exponential convergence, despite
  * the presence of the C^2 punctures.
@@ -34,8 +33,7 @@ class RefineAtPunctures : public amr::Criterion {
   using options = tmpl::list<>;
 
   static constexpr Options::String help = {
-      "h-refine (split) elements containing a puncture, and p-refine "
-      "everywhere else."};
+      "h-refine (split) elements containing a puncture."};
 
   RefineAtPunctures() = default;
 

--- a/tests/Unit/Elliptic/Systems/Punctures/AmrCriteria/Test_RefineAtPunctures.cpp
+++ b/tests/Unit/Elliptic/Systems/Punctures/AmrCriteria/Test_RefineAtPunctures.cpp
@@ -94,7 +94,7 @@ SPECTRE_TEST_CASE("Unit.Punctures.AmrCriteria.RefineAtPunctures",
     {
       INFO("Element without puncture");
       const ElementId<3> element_id{0, {{{1, 1}, {1, 0}, {1, 0}}}};
-      const auto expected_flags = make_array<3>(amr::Flag::IncreaseResolution);
+      const auto expected_flags = make_array<3>(amr::Flag::DoNothing);
       auto flags = criterion.evaluate(box, empty_cache, element_id);
       CHECK(flags == expected_flags);
     }


### PR DESCRIPTION
Can use one of the p-refinement criteria instead.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
