### PR TITLE
Enforce limits on refinement levels and resolution during AMR

### DIFF
--- a/src/ParallelAlgorithms/Amr/Actions/EvaluateRefinementCriteria.hpp
+++ b/src/ParallelAlgorithms/Amr/Actions/EvaluateRefinementCriteria.hpp
@@ -104,7 +104,8 @@ struct EvaluateRefinementCriteria {
     }
 
     amr::enforce_policies(make_not_null(&overall_decision),
-                          db::get<amr::Tags::Policies>(box));
+                          db::get<amr::Tags::Policies>(box), element_id,
+                          get<::domain::Tags::Mesh<volume_dim>>(box));
 
     // An element cannot join if it is splitting in another dimension.
     // Update the flags now before sending to neighbors as each time

--- a/src/ParallelAlgorithms/Amr/Criteria/Random.cpp
+++ b/src/ParallelAlgorithms/Amr/Criteria/Random.cpp
@@ -12,10 +12,8 @@
 #include "Utilities/ErrorHandling/Error.hpp"
 
 namespace amr::Criteria {
-Random::Random(std::unordered_map<amr::Flag, size_t> probability_weights,
-               const size_t maximum_refinement_level)
-    : probability_weights_(std::move(probability_weights)),
-      maximum_refinement_level_(maximum_refinement_level) {}
+Random::Random(std::unordered_map<amr::Flag, size_t> probability_weights)
+    : probability_weights_(std::move(probability_weights)) {}
 
 Random::Random(CkMigrateMessage* msg) : Criterion(msg) {}
 
@@ -23,7 +21,6 @@ Random::Random(CkMigrateMessage* msg) : Criterion(msg) {}
 void Random::pup(PUP::er& p) {
   Criterion::pup(p);
   p | probability_weights_;
-  p | maximum_refinement_level_;
 }
 
 namespace detail {

--- a/src/ParallelAlgorithms/Amr/Policies/CMakeLists.txt
+++ b/src/ParallelAlgorithms/Amr/Policies/CMakeLists.txt
@@ -10,6 +10,7 @@ spectre_target_sources(
   PRIVATE
   EnforcePolicies.cpp
   Isotropy.cpp
+  Limits.cpp
   Policies.cpp
   )
 
@@ -19,6 +20,7 @@ spectre_target_headers(
   HEADERS
   EnforcePolicies.hpp
   Isotropy.hpp
+  Limits.hpp
   Policies.hpp
   Tags.hpp
   )

--- a/src/ParallelAlgorithms/Amr/Policies/EnforcePolicies.cpp
+++ b/src/ParallelAlgorithms/Amr/Policies/EnforcePolicies.cpp
@@ -4,6 +4,11 @@
 #include "ParallelAlgorithms/Amr/Policies/EnforcePolicies.hpp"
 
 #include "Domain/Amr/Flag.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "ParallelAlgorithms/Amr/Policies/Isotropy.hpp"
+#include "ParallelAlgorithms/Amr/Policies/Limits.hpp"
 #include "ParallelAlgorithms/Amr/Policies/Policies.hpp"
 #include "Utilities/Algorithm.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
@@ -13,9 +18,34 @@
 namespace amr {
 template <size_t Dim>
 void enforce_policies(const gsl::not_null<std::array<Flag, Dim>*> amr_decision,
-                      const amr::Policies& amr_policies) {
+                      const amr::Policies& amr_policies,
+                      const ElementId<Dim>& element_id, const Mesh<Dim>& mesh) {
   if (amr_policies.isotropy() == amr::Isotropy::Isotropic) {
     *amr_decision = make_array<Dim>(*alg::max_element(*amr_decision));
+  }
+
+  const auto& limits = amr_policies.limits();
+  const auto& levels = element_id.refinement_levels();
+  for (size_t d = 0; d < Dim; ++d) {
+    if (gsl::at(*amr_decision, d) == Flag::Join and
+        gsl::at(levels, d) <= limits.minimum_refinement_level()) {
+      gsl::at(*amr_decision, d) = Flag::DoNothing;
+    }
+    if (gsl::at(*amr_decision, d) == Flag::Split and
+        gsl::at(levels, d) >= limits.maximum_refinement_level()) {
+      gsl::at(*amr_decision, d) = Flag::DoNothing;
+    }
+    const size_t minimum_resolution = std::max(
+        limits.minimum_resolution(), Spectral::detail::minimum_number_of_points(
+                                         mesh.basis(d), mesh.quadrature(d)));
+    if (gsl::at(*amr_decision, d) == Flag::DecreaseResolution and
+        mesh.extents(d) <= minimum_resolution) {
+      gsl::at(*amr_decision, d) = Flag::DoNothing;
+    }
+    if (gsl::at(*amr_decision, d) == Flag::IncreaseResolution and
+        mesh.extents(d) >= limits.maximum_resolution()) {
+      gsl::at(*amr_decision, d) = Flag::DoNothing;
+    }
   }
 }
 
@@ -23,7 +53,8 @@ void enforce_policies(const gsl::not_null<std::array<Flag, Dim>*> amr_decision,
 #define INSTANTIATE(_, data)                                    \
   template void enforce_policies(                               \
       gsl::not_null<std::array<Flag, DIM(data)>*> amr_decision, \
-      const amr::Policies& amr_policies);
+      const amr::Policies& amr_policies,                        \
+      const ElementId<DIM(data)>& element_id, const Mesh<DIM(data)>& mesh);
 
 GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
 

--- a/src/ParallelAlgorithms/Amr/Policies/EnforcePolicies.hpp
+++ b/src/ParallelAlgorithms/Amr/Policies/EnforcePolicies.hpp
@@ -11,15 +11,28 @@ namespace amr {
 enum class Flag;
 class Policies;
 }  // namespace amr
+template <size_t Dim>
+class ElementId;
 namespace gsl {
 template <typename T>
 class not_null;
 }  // namespace gsl
+template <size_t Dim>
+class Mesh;
 /// \endcond
 
 namespace amr {
 /// \brief Updates amr_decision so that it satisfies amr_policies
+///
+/// \details
+/// - If amr_policies.isotropy() is Isotropic, the Flag%s are changed to all be
+///   the same as the maximum priority flag
+/// - If any Flag would cause the refinement levels or resolution to violate
+///   their bounds, the Flag is changed to DoNothing.  Note that the minimum
+///   resolution is Basis and Quadrature dependent, so may be higher than the
+///   given amr_policies.refinement_limits().minimum_resolution()
 template <size_t Dim>
 void enforce_policies(gsl::not_null<std::array<Flag, Dim>*> amr_decision,
-                      const amr::Policies& amr_policies);
+                      const amr::Policies& amr_policies,
+                      const ElementId<Dim>& element_id, const Mesh<Dim>& mesh);
 }  // namespace amr

--- a/src/ParallelAlgorithms/Amr/Policies/Limits.cpp
+++ b/src/ParallelAlgorithms/Amr/Policies/Limits.cpp
@@ -1,0 +1,132 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "ParallelAlgorithms/Amr/Policies/Limits.hpp"
+
+#include <pup.h>
+#include <string>
+
+#include "Domain/Structure/ElementId.hpp"
+#include "NumericalAlgorithms/Spectral/Basis.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "Options/ParseError.hpp"
+
+namespace amr {
+
+Limits::Limits()
+    : maximum_refinement_level_(ElementId<1>::max_refinement_level),
+      maximum_resolution_(
+          Spectral::maximum_number_of_points<Spectral::Basis::Legendre>) {}
+
+Limits::Limits(
+    const std::optional<std::array<size_t, 2>>& refinement_level_bounds,
+    const std::optional<std::array<size_t, 2>>& resolution_bounds,
+    const Options::Context& context)
+    : minimum_refinement_level_(refinement_level_bounds.has_value()
+                                    ? refinement_level_bounds.value()[0]
+                                    : 0),
+      maximum_refinement_level_(refinement_level_bounds.has_value()
+                                    ? refinement_level_bounds.value()[1]
+                                    : ElementId<1>::max_refinement_level),
+      minimum_resolution_(
+          resolution_bounds.has_value() ? resolution_bounds.value()[0] : 1),
+      maximum_resolution_(
+          resolution_bounds.has_value()
+              ? resolution_bounds.value()[1]
+              : Spectral::maximum_number_of_points<Spectral::Basis::Legendre>) {
+  if (minimum_refinement_level_ > ElementId<1>::max_refinement_level) {
+    PARSE_ERROR(context,
+                "RefinementLevel lower bound '" +
+                    std::to_string(minimum_refinement_level_) +
+                    "' cannot be larger than '" +
+                    std::to_string(ElementId<1>::max_refinement_level) + "'.");
+  }
+  if (maximum_refinement_level_ > ElementId<1>::max_refinement_level) {
+    PARSE_ERROR(context,
+                "RefinementLevel upper bound '" +
+                    std::to_string(maximum_refinement_level_) +
+                    "' cannot be larger than '" +
+                    std::to_string(ElementId<1>::max_refinement_level) + "'.");
+  }
+  if (minimum_resolution_ < 1) {
+    PARSE_ERROR(context, "NumGridPoints lower bound '" +
+                             std::to_string(minimum_resolution_) +
+                             "' cannot be smaller than '1'.");
+  }
+  if (maximum_resolution_ < 1) {
+    PARSE_ERROR(context, "NumGridPoints upper bound '" +
+                             std::to_string(maximum_resolution_) +
+                             "' cannot be smaller than '1'.");
+  }
+  if (minimum_resolution_ >
+      Spectral::maximum_number_of_points<Spectral::Basis::Legendre>) {
+    PARSE_ERROR(
+        context,
+        "NumGridPoints lower bound '" + std::to_string(minimum_resolution_) +
+            "' cannot be larger than '" +
+            std::to_string(
+                Spectral::maximum_number_of_points<Spectral::Basis::Legendre>) +
+            "'.");
+  }
+  if (maximum_resolution_ >
+      Spectral::maximum_number_of_points<Spectral::Basis::Legendre>) {
+    PARSE_ERROR(
+        context,
+        "NumGridPoints upper bound '" + std::to_string(maximum_resolution_) +
+            "' cannot be larger than '" +
+            std::to_string(
+                Spectral::maximum_number_of_points<Spectral::Basis::Legendre>) +
+            "'.");
+  }
+  if (minimum_refinement_level_ > maximum_refinement_level_) {
+    PARSE_ERROR(context,
+                "RefinementLevel lower bound '" +
+                    std::to_string(minimum_refinement_level_) +
+                    "' cannot be larger than RefinementLevel upper bound '" +
+                    std::to_string(maximum_refinement_level_) + "'.");
+  }
+  if (minimum_resolution_ > maximum_resolution_) {
+    PARSE_ERROR(context,
+                "NumGridPoints lower bound '" +
+                    std::to_string(minimum_resolution_) +
+                    "' cannot be larger than NumGridPoints upper bound '" +
+                    std::to_string(maximum_resolution_) + "'.");
+  }
+}
+
+Limits::Limits(size_t minimum_refinement_level, size_t maximum_refinement_level,
+               size_t minimum_resolution, size_t maximum_resolution)
+    : minimum_refinement_level_(minimum_refinement_level),
+      maximum_refinement_level_(maximum_refinement_level),
+      minimum_resolution_(minimum_resolution),
+      maximum_resolution_(maximum_resolution) {
+  ASSERT(minimum_refinement_level_ <= maximum_refinement_level_,
+         "The minimum refinement level '" +
+             std::to_string(minimum_refinement_level_) +
+             "' cannot be larger than the maximum refinement level '" +
+             std::to_string(maximum_refinement_level_) + "'.");
+  ASSERT(minimum_resolution_ <= maximum_resolution_,
+         "The minimum resolution '" + std::to_string(minimum_resolution_) +
+             "' cannot be larger than the maximum resolution '" +
+             std::to_string(maximum_resolution_) + "'.");
+}
+
+void Limits::pup(PUP::er& p) {
+  p | minimum_refinement_level_;
+  p | maximum_refinement_level_;
+  p | minimum_resolution_;
+  p | maximum_resolution_;
+}
+
+bool operator==(const Limits& lhs, const Limits& rhs) {
+  return lhs.minimum_refinement_level() == rhs.minimum_refinement_level() and
+         lhs.maximum_refinement_level() == rhs.maximum_refinement_level() and
+         lhs.minimum_resolution() == rhs.minimum_resolution() and
+         lhs.maximum_resolution() == rhs.maximum_resolution();
+}
+
+bool operator!=(const Limits& lhs, const Limits& rhs) {
+  return not(lhs == rhs);
+}
+
+}  // namespace amr

--- a/src/ParallelAlgorithms/Amr/Policies/Limits.hpp
+++ b/src/ParallelAlgorithms/Amr/Policies/Limits.hpp
@@ -1,0 +1,84 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <optional>
+
+#include "Options/Auto.hpp"
+#include "Options/Context.hpp"
+#include "Options/String.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+namespace PUP {
+class er;
+}  // namespace PUP
+/// \endcond
+
+namespace amr {
+/// \brief The limits on refinement level and resolution for AMR
+///
+/// \details
+/// - For a default constructed Limits, the refinement level is
+///   bounded between 0 and ElementId<Dim>::max_refinement_level, and the
+///   resolution is bounded between 1 and
+///   Spectral::maximum_number_of_points<Spectral::Basis::Legendre>
+///   which are limits based on the implementation details of ElementId and
+///   Mesh.
+/// - If you specify the limits on the refinement levels and resolutions, they
+///   must respect the above limits.
+/// - Depending upon which Spectral::Basis is chosen, the actual minimum
+///   resolution may be higher (usually 2), but this is automatically enforced
+///   by EnforcePolicies.
+class Limits {
+ public:
+  /// Inclusive bounds on the refinement level
+  struct RefinementLevel {
+    using type = Options::Auto<std::array<size_t, 2>>;
+    static constexpr Options::String help = {
+        "Inclusive bounds on the refinement level for AMR."};
+  };
+
+  /// Inclusive bounds on the number of grid points per dimension
+  struct NumGridPoints {
+    using type = Options::Auto<std::array<size_t, 2>>;
+    static constexpr Options::String help = {
+        "Inclusive bounds on the number of grid points per dimension for AMR."};
+  };
+
+  using options = tmpl::list<RefinementLevel, NumGridPoints>;
+
+  static constexpr Options::String help = {
+      "Limits on refinement level and resolution for adaptive mesh "
+      "refinement."};
+
+  Limits();
+
+  Limits(const std::optional<std::array<size_t, 2>>& refinement_level_bounds,
+         const std::optional<std::array<size_t, 2>>& resolution_bounds,
+         const Options::Context& context = {});
+
+  Limits(size_t minimum_refinement_level, size_t maximum_refinement_level,
+         size_t minimum_resolution, size_t maximum_resolution);
+
+  size_t minimum_refinement_level() const { return minimum_refinement_level_; }
+  size_t maximum_refinement_level() const { return maximum_refinement_level_; }
+  size_t minimum_resolution() const { return minimum_resolution_; }
+  size_t maximum_resolution() const { return maximum_resolution_; }
+
+  void pup(PUP::er& p);
+
+ private:
+  size_t minimum_refinement_level_{0};
+  size_t maximum_refinement_level_{16};
+  size_t minimum_resolution_{1};
+  size_t maximum_resolution_{20};
+};
+
+bool operator==(const Limits& lhs, const Limits& rhs);
+
+bool operator!=(const Limits& lhs, const Limits& rhs);
+}  // namespace amr

--- a/src/ParallelAlgorithms/Amr/Policies/Policies.cpp
+++ b/src/ParallelAlgorithms/Amr/Policies/Policies.cpp
@@ -4,15 +4,18 @@
 #include "ParallelAlgorithms/Amr/Policies/Policies.hpp"
 
 #include <pup.h>
-#include <pup_stl.h>
 
 namespace amr {
-Policies::Policies(const amr::Isotropy isotropy) : isotropy_(isotropy) {}
+Policies::Policies(const amr::Isotropy isotropy, const amr::Limits& limits)
+    : isotropy_(isotropy), limits_(limits) {}
 
-void Policies::pup(PUP::er& p) { p | isotropy_; }
+void Policies::pup(PUP::er& p) {
+  p | isotropy_;
+  p | limits_;
+}
 
 bool operator==(const Policies& lhs, const Policies& rhs) {
-  return lhs.isotropy() == rhs.isotropy();
+  return lhs.isotropy() == rhs.isotropy() and lhs.limits() == rhs.limits();
 }
 
 bool operator!=(const Policies& lhs, const Policies& rhs) {

--- a/src/ParallelAlgorithms/Amr/Policies/Policies.hpp
+++ b/src/ParallelAlgorithms/Amr/Policies/Policies.hpp
@@ -5,6 +5,7 @@
 
 #include "Options/String.hpp"
 #include "ParallelAlgorithms/Amr/Policies/Isotropy.hpp"
+#include "ParallelAlgorithms/Amr/Policies/Limits.hpp"
 #include "Utilities/TMPL.hpp"
 
 /// \cond
@@ -25,21 +26,32 @@ class Policies {
         "can be refined independently)."};
   };
 
-  using options = tmpl::list<Isotropy>;
+  /// The limits on refinement level and resolution for AMR
+  struct Limits {
+    using type = amr::Limits;
+    static constexpr Options::String help = {
+        "Limits on refinement level and resolution for adaptive mesh "
+        "refinement."};
+  };
+
+  using options = tmpl::list<Isotropy, Limits>;
 
   static constexpr Options::String help = {
       "Policies controlling adaptive mesh refinement."};
 
   Policies() = default;
 
-  explicit Policies(amr::Isotropy isotropy);
+  Policies(amr::Isotropy isotropy, const amr::Limits& limits);
 
   amr::Isotropy isotropy() const { return isotropy_; }
+
+  amr::Limits limits() const { return limits_; }
 
   void pup(PUP::er& p);
 
  private:
   amr::Isotropy isotropy_{amr::Isotropy::Anisotropic};
+  amr::Limits limits_{};
 };
 
 bool operator==(const Policies& lhs, const Policies& rhs);

--- a/support/Pipelines/Bbh/Inspiral.yaml
+++ b/support/Pipelines/Bbh/Inspiral.yaml
@@ -189,6 +189,9 @@ Amr:
   Criteria:
   Policies:
     Isotropy: Anisotropic
+    Limits:
+      RefinementLevel: Auto
+      NumGridPoints: Auto
   Verbosity: Quiet
 
 PhaseChangeAndTriggers:

--- a/support/Pipelines/Bbh/Ringdown.yaml
+++ b/support/Pipelines/Bbh/Ringdown.yaml
@@ -102,6 +102,9 @@ Amr:
   Criteria:
   Policies:
     Isotropy: Anisotropic
+    Limits:
+      RefinementLevel: Auto
+      NumGridPoints: Auto
   Verbosity: Quiet
 
 PhaseChangeAndTriggers:

--- a/tests/InputFiles/ExampleExecutables/RandomAmr1D.yaml
+++ b/tests/InputFiles/ExampleExecutables/RandomAmr1D.yaml
@@ -22,7 +22,6 @@ Amr:
           Split: 2
           Join: 1
           DoNothing: 1
-        MaximumRefinementLevel: 8
   Policies:
     Isotropy: Anisotropic
     Limits:

--- a/tests/InputFiles/ExampleExecutables/RandomAmr1D.yaml
+++ b/tests/InputFiles/ExampleExecutables/RandomAmr1D.yaml
@@ -25,6 +25,9 @@ Amr:
         MaximumRefinementLevel: 8
   Policies:
     Isotropy: Anisotropic
+    Limits:
+      RefinementLevel: [0, 8]
+      NumGridPoints: Auto
   Verbosity: Verbose
 
 DomainCreator:

--- a/tests/InputFiles/ExportCoordinates/Input1D.yaml
+++ b/tests/InputFiles/ExportCoordinates/Input1D.yaml
@@ -21,7 +21,6 @@ Amr:
           Split: 2
           Join: 1
           DoNothing: 1
-        MaximumRefinementLevel: 4
   Policies:
     Isotropy: Anisotropic
     Limits:

--- a/tests/InputFiles/ExportCoordinates/Input1D.yaml
+++ b/tests/InputFiles/ExportCoordinates/Input1D.yaml
@@ -24,6 +24,9 @@ Amr:
         MaximumRefinementLevel: 4
   Policies:
     Isotropy: Anisotropic
+    Limits:
+      RefinementLevel: [0, 4]
+      NumGridPoints: Auto
   Verbosity: Verbose
 
 ResourceInfo:

--- a/tests/InputFiles/ExportCoordinates/Input2D.yaml
+++ b/tests/InputFiles/ExportCoordinates/Input2D.yaml
@@ -18,6 +18,9 @@ Amr:
   Criteria:
   Policies:
     Isotropy: Anisotropic
+    Limits:
+      RefinementLevel: Auto
+      NumGridPoints: Auto
   Verbosity: Quiet
 
 ResourceInfo:

--- a/tests/InputFiles/ExportCoordinates/Input3D.yaml
+++ b/tests/InputFiles/ExportCoordinates/Input3D.yaml
@@ -18,6 +18,9 @@ Amr:
   Criteria:
   Policies:
     Isotropy: Anisotropic
+    Limits:
+      RefinementLevel: Auto
+      NumGridPoints: Auto
   Verbosity: Quiet
 
 ResourceInfo:

--- a/tests/InputFiles/ExportCoordinates/InputTimeDependent3D.yaml
+++ b/tests/InputFiles/ExportCoordinates/InputTimeDependent3D.yaml
@@ -19,6 +19,9 @@ Amr:
   Criteria:
   Policies:
     Isotropy: Anisotropic
+    Limits:
+      RefinementLevel: Auto
+      NumGridPoints: Auto
   Verbosity: Quiet
 
 ResourceInfo:

--- a/tests/InputFiles/GeneralizedHarmonic/BinaryBlackHole.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/BinaryBlackHole.yaml
@@ -148,6 +148,9 @@ Amr:
   Criteria:
   Policies:
     Isotropy: Anisotropic
+    Limits:
+      RefinementLevel: Auto
+      NumGridPoints: Auto
   Verbosity: Quiet
 
 PhaseChangeAndTriggers:

--- a/tests/InputFiles/GeneralizedHarmonic/CylindricalBinaryBlackHole.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/CylindricalBinaryBlackHole.yaml
@@ -128,6 +128,9 @@ Amr:
   Criteria:
   Policies:
     Isotropy: Anisotropic
+    Limits:
+      RefinementLevel: Auto
+      NumGridPoints: Auto
   Verbosity: Quiet
 
 PhaseChangeAndTriggers:

--- a/tests/InputFiles/GeneralizedHarmonic/GaugeWave1D.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/GaugeWave1D.yaml
@@ -29,6 +29,9 @@ Amr:
   Criteria:
   Policies:
     Isotropy: Anisotropic
+    Limits:
+      RefinementLevel: Auto
+      NumGridPoints: Auto
   Verbosity: Quiet
 
 PhaseChangeAndTriggers:

--- a/tests/InputFiles/GeneralizedHarmonic/GaugeWave3D.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/GaugeWave3D.yaml
@@ -30,6 +30,9 @@ Amr:
   Criteria:
   Policies:
     Isotropy: Anisotropic
+    Limits:
+      RefinementLevel: Auto
+      NumGridPoints: Auto
   Verbosity: Quiet
 
 PhaseChangeAndTriggers:

--- a/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
@@ -36,6 +36,9 @@ Amr:
   Criteria:
   Policies:
     Isotropy: Anisotropic
+    Limits:
+      RefinementLevel: Auto
+      NumGridPoints: Auto
   Verbosity: Quiet
 
 PhaseChangeAndTriggers:

--- a/tests/InputFiles/ScalarWave/PlaneWave1D.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave1D.yaml
@@ -33,6 +33,9 @@ Amr:
         RelativeTarget: 1.0
   Policies:
     Isotropy: Anisotropic
+    Limits:
+      RefinementLevel: Auto
+      NumGridPoints: Auto
   Verbosity: Verbose
 
 PhaseChangeAndTriggers:

--- a/tests/InputFiles/ScalarWave/PlaneWave1DEventsAndTriggersExample.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave1DEventsAndTriggersExample.yaml
@@ -35,6 +35,9 @@ Amr:
         RelativeTarget: 1.0
   Policies:
     Isotropy: Anisotropic
+    Limits:
+      RefinementLevel: Auto
+      NumGridPoints: Auto
   Verbosity: Verbose
 
 PhaseChangeAndTriggers:

--- a/tests/InputFiles/ScalarWave/PlaneWave1DObserveExample.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave1DObserveExample.yaml
@@ -36,6 +36,9 @@ Amr:
         RelativeTarget: 1.0
   Policies:
     Isotropy: Anisotropic
+    Limits:
+      RefinementLevel: Auto
+      NumGridPoints: Auto
   Verbosity: Verbose
 
 PhaseChangeAndTriggers:

--- a/tests/InputFiles/ScalarWave/PlaneWave2D.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave2D.yaml
@@ -30,6 +30,9 @@ Amr:
   Criteria:
   Policies:
     Isotropy: Anisotropic
+    Limits:
+      RefinementLevel: Auto
+      NumGridPoints: Auto
   Verbosity: Verbose
 
 PhaseChangeAndTriggers:

--- a/tests/InputFiles/ScalarWave/PlaneWave3D.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave3D.yaml
@@ -28,6 +28,9 @@ Amr:
   Criteria:
   Policies:
     Isotropy: Anisotropic
+    Limits:
+      RefinementLevel: Auto
+      NumGridPoints: Auto
   Verbosity: Verbose
 
 PhaseChangeAndTriggers:

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/SubdomainOperator/Test_SubdomainOperator.cpp
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/SubdomainOperator/Test_SubdomainOperator.cpp
@@ -68,6 +68,8 @@
 #include "ParallelAlgorithms/Amr/Actions/Initialize.hpp"
 #include "ParallelAlgorithms/Amr/Criteria/Random.hpp"
 #include "ParallelAlgorithms/Amr/Policies/Isotropy.hpp"
+#include "ParallelAlgorithms/Amr/Policies/Limits.hpp"
+#include "ParallelAlgorithms/Amr/Policies/Policies.hpp"
 #include "ParallelAlgorithms/Amr/Policies/Tags.hpp"
 #include "ParallelAlgorithms/Amr/Projectors/CopyFromCreatorOrLeaveAsIs.hpp"
 #include "ParallelAlgorithms/Amr/Protocols/AmrMetavariables.hpp"
@@ -592,7 +594,8 @@ void test_subdomain_operator(
         std::make_unique<RandomBackground<Dim>>(), overlap,
         ::Verbosity::Verbose, penalty_parameter, use_massive_dg_operator,
         quadrature, ::dg::Formulation::StrongInertial, std::move(amr_criteria),
-        ::amr::Policies{::amr::Isotropy::Anisotropic}, ::Verbosity::Debug}};
+        ::amr::Policies{::amr::Isotropy::Anisotropic, ::amr::Limits{}},
+        ::Verbosity::Debug}};
 
     // Initialize all elements, generating random subdomain data
     for (const auto& element_id : element_ids) {

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_DgOperator.cpp
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_DgOperator.cpp
@@ -52,6 +52,8 @@
 #include "ParallelAlgorithms/Amr/Actions/Initialize.hpp"
 #include "ParallelAlgorithms/Amr/Criteria/Random.hpp"
 #include "ParallelAlgorithms/Amr/Policies/Isotropy.hpp"
+#include "ParallelAlgorithms/Amr/Policies/Limits.hpp"
+#include "ParallelAlgorithms/Amr/Policies/Policies.hpp"
 #include "ParallelAlgorithms/Amr/Policies/Tags.hpp"
 #include "ParallelAlgorithms/Amr/Protocols/AmrMetavariables.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/Poisson/ProductOfSinusoids.hpp"
@@ -329,7 +331,8 @@ void test_dg_operator(
       std::move(boundary_conditions), penalty_parameter,
       use_massive_dg_operator, quadrature, ::dg::Formulation::StrongInertial,
       analytic_solution, std::move(amr_criteria),
-      ::amr::Policies{::amr::Isotropy::Anisotropic}, ::Verbosity::Debug}};
+      ::amr::Policies{::amr::Isotropy::Anisotropic, ::amr::Limits{}},
+      ::Verbosity::Debug}};
 
   // DataBox shortcuts
   const auto get_tag =

--- a/tests/Unit/ParallelAlgorithms/Amr/Actions/Test_EvaluateRefinementCriteria.cpp
+++ b/tests/Unit/ParallelAlgorithms/Amr/Actions/Test_EvaluateRefinementCriteria.cpp
@@ -27,6 +27,9 @@
 #include "ParallelAlgorithms/Amr/Criteria/DriveToTarget.hpp"
 #include "ParallelAlgorithms/Amr/Criteria/Random.hpp"
 #include "ParallelAlgorithms/Amr/Criteria/Tags/Criteria.hpp"
+#include "ParallelAlgorithms/Amr/Policies/Isotropy.hpp"
+#include "ParallelAlgorithms/Amr/Policies/Limits.hpp"
+#include "ParallelAlgorithms/Amr/Policies/Policies.hpp"
 #include "ParallelAlgorithms/Amr/Policies/Tags.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
@@ -116,7 +119,8 @@ void evaluate_criteria(std::vector<std::unique_ptr<amr::Criterion>> criteria,
   std::unordered_map<ElementId<1>, amr::Info<1>> initial_neighbor_info;
 
   ActionTesting::MockRuntimeSystem<Metavariables<1>> runner{
-      {std::move(criteria), amr::Policies{amr::Isotropy::Anisotropic}}};
+      {std::move(criteria),
+       amr::Policies{amr::Isotropy::Anisotropic, amr::Limits{}}}};
 
   const Element<1> self(self_id, {{{Direction<1>::lower_xi(), {{lo_id}, {}}},
                                    {Direction<1>::upper_xi(), {{up_id}, {}}}}});
@@ -254,7 +258,8 @@ void check_split_while_join_is_avoided() {
   // But we do not allow an Element to simultaneously split and join so the
   // action should change the flags to (DoNothing, Split)
   ActionTesting::MockRuntimeSystem<Metavariables<2>> runner{
-      {std::move(criteria), amr::Policies{amr::Isotropy::Anisotropic}}};
+      {std::move(criteria),
+       amr::Policies{amr::Isotropy::Anisotropic, amr::Limits{}}}};
 
   const Element<2> self(self_id, {});
   ActionTesting::emplace_component_and_initialize<my_component>(

--- a/tests/Unit/ParallelAlgorithms/Amr/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/Amr/CMakeLists.txt
@@ -24,6 +24,7 @@ set(LIBRARY_SOURCES
   Criteria/Test_TruncationError.cpp
   Policies/Test_EnforcePolicies.cpp
   Policies/Test_Isotropy.cpp
+  Policies/Test_Limits.cpp
   Policies/Test_Policies.cpp
   Projectors/Test_CopyFromCreatorOrLeaveAsIs.cpp
   Projectors/Test_DefaultInitialize.cpp

--- a/tests/Unit/ParallelAlgorithms/Amr/Criteria/Test_Random.cpp
+++ b/tests/Unit/ParallelAlgorithms/Amr/Criteria/Test_Random.cpp
@@ -124,8 +124,7 @@ void test() {
           "Random:\n"
           "  ProbabilityWeights:\n"
           "    Split: 4\n"
-          "    DoNothing: 1\n"
-          "  MaximumRefinementLevel: 5\n");
+          "    DoNothing: 1\n");
   test_criterion<VolumeDim>(*criterion);
   test_criterion<VolumeDim>(*serialize_and_deserialize(criterion));
 }

--- a/tests/Unit/ParallelAlgorithms/Amr/Policies/Test_Limits.cpp
+++ b/tests/Unit/ParallelAlgorithms/Amr/Policies/Test_Limits.cpp
@@ -1,0 +1,143 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <string>
+
+#include "Domain/Structure/ElementId.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "NumericalAlgorithms/Spectral/Basis.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "ParallelAlgorithms/Amr/Policies/Limits.hpp"
+
+namespace {
+void test_equality() {
+  INFO("Equality");
+  CHECK(amr::Limits{0, 3, 1, 5} == amr::Limits{0, 3, 1, 5});
+  CHECK(amr::Limits{0, 3, 1, 5} != amr::Limits{1, 3, 1, 5});
+  CHECK(amr::Limits{0, 3, 1, 5} != amr::Limits{0, 4, 1, 5});
+  CHECK(amr::Limits{0, 3, 1, 5} != amr::Limits{0, 3, 2, 5});
+  CHECK(amr::Limits{0, 3, 1, 5} != amr::Limits{0, 3, 1, 6});
+}
+
+void test_pup() {
+  INFO("Serialization");
+  test_serialization(amr::Limits{0, 3, 1, 5});
+}
+
+void test_option_parsing() {
+  INFO("Option Parsing creation");
+  {
+    std::string creation_string_1 =
+        "RefinementLevel: [0, 3]\n"
+        "NumGridPoints: [1, 5]\n";
+    const auto limits =
+        TestHelpers::test_creation<amr::Limits>(creation_string_1);
+    CHECK(limits == amr::Limits{0, 3, 1, 5});
+  }
+
+  {
+    std::string creation_string_2 =
+        "RefinementLevel: Auto\n"
+        "NumGridPoints: [1, 5]\n";
+    const auto limits =
+        TestHelpers::test_creation<amr::Limits>(creation_string_2);
+    CHECK(limits == amr::Limits{0, ElementId<1>::max_refinement_level, 1, 5});
+  }
+
+  {
+    std::string creation_string_3 =
+        "RefinementLevel: [0, 3]\n"
+        "NumGridPoints: Auto\n";
+    const auto limits =
+        TestHelpers::test_creation<amr::Limits>(creation_string_3);
+    CHECK(limits ==
+          amr::Limits{
+              0, 3, 1,
+              Spectral::maximum_number_of_points<Spectral::Basis::Legendre>});
+  }
+
+  {
+    std::string creation_string_4 =
+        "RefinementLevel: Auto\n"
+        "NumGridPoints: Auto\n";
+    const auto limits =
+        TestHelpers::test_creation<amr::Limits>(creation_string_4);
+    CHECK(limits == amr::Limits{});
+  }
+
+  std::string bad_creation_string_1 =
+      "RefinementLevel: [255, 3]\n"
+      "NumGridPoints: [1, 5]\n";
+  CHECK_THROWS_WITH(
+      TestHelpers::test_creation<amr::Limits>(bad_creation_string_1),
+      Catch::Matchers::ContainsSubstring(
+          "RefinementLevel lower bound '255' cannot be larger than '"));
+
+  std::string bad_creation_string_2 =
+      "RefinementLevel: [1, 255]\n"
+      "NumGridPoints: [1, 5]\n";
+  CHECK_THROWS_WITH(
+      TestHelpers::test_creation<amr::Limits>(bad_creation_string_2),
+      Catch::Matchers::ContainsSubstring(
+          "RefinementLevel upper bound '255' cannot be larger than '"));
+
+  std::string bad_creation_string_3 =
+      "RefinementLevel: [0, 3]\n"
+      "NumGridPoints: [0, 5]\n";
+  CHECK_THROWS_WITH(
+      TestHelpers::test_creation<amr::Limits>(bad_creation_string_3),
+      Catch::Matchers::ContainsSubstring(
+          "NumGridPoints lower bound '0' cannot be smaller than '1'."));
+
+  std::string bad_creation_string_4 =
+      "RefinementLevel: [1, 3]\n"
+      "NumGridPoints: [255, 5]\n";
+  CHECK_THROWS_WITH(
+      TestHelpers::test_creation<amr::Limits>(bad_creation_string_4),
+      Catch::Matchers::ContainsSubstring(
+          "NumGridPoints lower bound '255' cannot be larger than '"));
+
+  std::string bad_creation_string_5 =
+      "RefinementLevel: [1, 3]\n"
+      "NumGridPoints: [1, 0]\n";
+  CHECK_THROWS_WITH(
+      TestHelpers::test_creation<amr::Limits>(bad_creation_string_5),
+      Catch::Matchers::ContainsSubstring(
+          "NumGridPoints upper bound '0' cannot be smaller than '1'."));
+
+  std::string bad_creation_string_6 =
+      "RefinementLevel: [1, 3]\n"
+      "NumGridPoints: [1, 255]\n";
+  CHECK_THROWS_WITH(
+      TestHelpers::test_creation<amr::Limits>(bad_creation_string_6),
+      Catch::Matchers::ContainsSubstring(
+          "NumGridPoints upper bound '255' cannot be larger than '"));
+}
+
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.ParallelAlgorithms.Amr.Limits",
+                  "[ParallelAlgorithms][Unit]") {
+  test_equality();
+  test_pup();
+  test_option_parsing();
+#ifdef SPECTRE_DEBUG
+  CHECK_THROWS_WITH(
+      ([]() {
+        amr::Limits limits{2, 1, 1, 5};
+      }()),
+      Catch::Matchers::ContainsSubstring(
+          "The minimum refinement level '2' cannot be larger than "
+          "the maximum refinement level '1'"));
+  CHECK_THROWS_WITH(([]() {
+                      amr::Limits limits{0, 3, 6, 4};
+                    }()),
+                    Catch::Matchers::ContainsSubstring(
+                        "The minimum resolution '6' cannot be larger than the "
+                        "maximum resolution '4'"));
+#endif  // SPECTRE_DEBUG
+}

--- a/tests/Unit/ParallelAlgorithms/Amr/Policies/Test_Policies.cpp
+++ b/tests/Unit/ParallelAlgorithms/Amr/Policies/Test_Policies.cpp
@@ -9,32 +9,53 @@
 #include "Framework/TestCreation.hpp"
 #include "Framework/TestHelpers.hpp"
 #include "ParallelAlgorithms/Amr/Policies/Isotropy.hpp"
+#include "ParallelAlgorithms/Amr/Policies/Limits.hpp"
 #include "ParallelAlgorithms/Amr/Policies/Policies.hpp"
 
 namespace {
 void test_equality() {
   INFO("Equality");
-  CHECK(amr::Policies{amr::Isotropy::Anisotropic} ==
-        amr::Policies{amr::Isotropy::Anisotropic});
-  CHECK(amr::Policies{amr::Isotropy::Anisotropic} !=
-        amr::Policies{amr::Isotropy::Isotropic});
+  CHECK(amr::Policies{amr::Isotropy::Anisotropic, amr::Limits{}} ==
+        amr::Policies{amr::Isotropy::Anisotropic, amr::Limits{}});
+  CHECK(amr::Policies{amr::Isotropy::Anisotropic, amr::Limits{}} !=
+        amr::Policies{amr::Isotropy::Isotropic, amr::Limits{}});
 }
 
 void test_pup() {
   INFO("Serialization");
-  test_serialization(amr::Policies{amr::Isotropy::Anisotropic});
+  test_serialization(amr::Policies{amr::Isotropy::Anisotropic, amr::Limits{}});
 }
 
 void test_option_parsing() {
   INFO("Option Parsing creation");
   const auto isotropies =
       std::array{amr::Isotropy::Anisotropic, amr::Isotropy::Isotropic};
+  const amr::Limits default_limits{};
+  const amr::Limits specified_limits{1, 5, 3, 7};
   for (const auto isotropy : isotropies) {
-    std::ostringstream creation_string;
-    creation_string << "Isotropy: " << isotropy;
-    const auto policies =
-        TestHelpers::test_creation<amr::Policies>(creation_string.str());
-    CHECK(policies == amr::Policies{isotropy});
+    CAPTURE(isotropy);
+    {
+      INFO("specified limits");
+      std::ostringstream creation_string;
+      creation_string << "Isotropy: " << isotropy << "\n";
+      creation_string << "Limits:\n"
+                      << "  RefinementLevel: [1, 5]\n"
+                      << "  NumGridPoints: [3, 7]\n";
+      const auto policies =
+          TestHelpers::test_creation<amr::Policies>(creation_string.str());
+      CHECK(policies == amr::Policies{isotropy, specified_limits});
+    }
+    {
+      INFO("default limits");
+      std::ostringstream creation_string;
+      creation_string << "Isotropy: " << isotropy << "\n";
+      creation_string << "Limits:\n"
+                      << "  RefinementLevel: Auto\n"
+                      << "  NumGridPoints: Auto\n";
+      const auto policies =
+          TestHelpers::test_creation<amr::Policies>(creation_string.str());
+      CHECK(policies == amr::Policies{isotropy, default_limits});
+    }
   }
 }
 


### PR DESCRIPTION
The default is to limit these to the limits required by the implementation details of ElementId and Spectral.

Fixes https://github.com/sxs-collaboration/spectre/issues/5797

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
In input files, the you will need to specify a new sub-option to the Amr Policies that specifies the
Limits with sub-options RefinementLevel and NumGridPoints.  The suggested value for these two options is Auto unless you want to limit refinement further.
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
