### PR TITLE
Update ocean charm module for move to C++20

### DIFF
--- a/support/Environments/ocean_gcc.sh
+++ b/support/Environments/ocean_gcc.sh
@@ -40,7 +40,7 @@ spectre_unload_modules() {
     module unload hdf5-1.12.2-gcc-11.3.0-dly2yyu
     module unload binutils-2.38-gcc-11.3.0-fmchbp7
     module unload libxsmm/1.16.1
-    module unload charm-7.0.0-gnu11-clang-smp-patch
+    module unload charm-7.0.0-gnu11-022324
     module unload git/2.19.6
     module unload doxygen/1.9.5
     module unload fftw-3.3.10-gcc-11.3.0-g2odatg
@@ -72,7 +72,7 @@ spectre_load_modules() {
     module load hdf5-1.12.2-gcc-11.3.0-dly2yyu
     module load binutils-2.38-gcc-11.3.0-fmchbp7
     module load libxsmm/1.16.1
-    module load charm-7.0.0-gnu11-clang-smp-patch
+    module load charm-7.0.0-gnu11-022324
     module load git/2.19.6
     module load doxygen/1.9.5
     module load fftw-3.3.10-gcc-11.3.0-g2odatg


### PR DESCRIPTION
## Proposed changes

Since partially moving to C++20, SpECTRE doesn't build on ocean, but this new module fixes this

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
