### PR TITLE
Fix a typo in elliptic status CLI

### DIFF
--- a/tools/Status/ExecutableStatus/ExecutableStatus.py
+++ b/tools/Status/ExecutableStatus/ExecutableStatus.py
@@ -224,7 +224,7 @@ class EllipticStatus(ExecutableStatus):
             # Try these solver names in turn and report the status of the first
             # that exists. Create a subclass to customize this behavior for
             # a specific executable (e.g. if it has multiple solvers).
-            for solver_name in ["NewtonRaphson", "GMRES"]:
+            for solver_name in ["NewtonRaphson", "Gmres"]:
                 solver_status = self.solver_status(
                     input_file, open_reductions_file, solver_name=solver_name
                 )


### PR DESCRIPTION
This catch-all status didn't match anymore with
recent changes to the elliptic input files.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
