### PR TITLE
Allow calling the TCI on the FD grid only every N steps, to wait M steps after rollback, and/or have K clear TCIs before going back to DG

### DIFF
--- a/src/Evolution/DgSubcell/SubcellOptions.cpp
+++ b/src/Evolution/DgSubcell/SubcellOptions.cpp
@@ -26,7 +26,10 @@ SubcellOptions::SubcellOptions(
     double rdmp_delta0, double rdmp_epsilon, bool always_use_subcells,
     fd::ReconstructionMethod recons_method, bool use_halo,
     std::optional<std::vector<std::string>> only_dg_block_and_group_names,
-    ::fd::DerivativeOrder finite_difference_derivative_order)
+    ::fd::DerivativeOrder finite_difference_derivative_order,
+    const size_t number_of_steps_between_tci_calls,
+    const size_t min_tci_calls_after_rollback,
+    const size_t min_clear_tci_before_dg)
     : persson_exponent_(persson_exponent),
       persson_num_highest_modes_(persson_num_highest_modes),
       rdmp_delta0_(rdmp_delta0),
@@ -35,10 +38,19 @@ SubcellOptions::SubcellOptions(
       reconstruction_method_(recons_method),
       use_halo_(use_halo),
       only_dg_block_and_group_names_(std::move(only_dg_block_and_group_names)),
-      finite_difference_derivative_order_(finite_difference_derivative_order) {
+      finite_difference_derivative_order_(finite_difference_derivative_order),
+      number_of_steps_between_tci_calls_(number_of_steps_between_tci_calls),
+      min_tci_calls_after_rollback_(min_tci_calls_after_rollback),
+      min_clear_tci_before_dg_(min_clear_tci_before_dg) {
   if (not only_dg_block_and_group_names_.has_value()) {
     only_dg_block_ids_ = std::vector<size_t>{};
   }
+  ASSERT(number_of_steps_between_tci_calls_ > 0,
+         "number_of_steps_between_tci_calls_ must be greater than zero.");
+  ASSERT(min_tci_calls_after_rollback_ > 0,
+         "min_tci_calls_after_rollback_ must be greater than zero.");
+  ASSERT(min_clear_tci_before_dg_ > 0,
+         "min_clear_tci_before_dg_ must be greater than zero.");
 }
 
 template <size_t Dim>
@@ -76,6 +88,9 @@ void SubcellOptions::pup(PUP::er& p) {
   p | only_dg_block_and_group_names_;
   p | only_dg_block_ids_;
   p | finite_difference_derivative_order_;
+  p | number_of_steps_between_tci_calls_;
+  p | min_tci_calls_after_rollback_;
+  p | min_clear_tci_before_dg_;
 }
 
 bool operator==(const SubcellOptions& lhs, const SubcellOptions& rhs) {
@@ -90,7 +105,12 @@ bool operator==(const SubcellOptions& lhs, const SubcellOptions& rhs) {
              rhs.only_dg_block_and_group_names_ and
          lhs.only_dg_block_ids_ == rhs.only_dg_block_ids_ and
          lhs.finite_difference_derivative_order_ ==
-             rhs.finite_difference_derivative_order_;
+             rhs.finite_difference_derivative_order_ and
+         lhs.number_of_steps_between_tci_calls_ ==
+             rhs.number_of_steps_between_tci_calls_ and
+         lhs.min_tci_calls_after_rollback_ ==
+             rhs.min_tci_calls_after_rollback_ and
+         lhs.min_clear_tci_before_dg_ == rhs.min_clear_tci_before_dg_;
 }
 
 bool operator!=(const SubcellOptions& lhs, const SubcellOptions& rhs) {

--- a/tests/InputFiles/Burgers/Step.yaml
+++ b/tests/InputFiles/Burgers/Step.yaml
@@ -62,15 +62,21 @@ SpatialDiscretization:
     Formulation: StrongInertial
     Quadrature: GaussLobatto
     Subcell:
-      PerssonTci:
-        Exponent: 4.0
-        NumHighestModes: 1
-      RdmpDelta0: 1.0e-7
-      RdmpEpsilon: 1.0e-3
-      AlwaysUseSubcells: false
+      TroubledCellIndicator:
+        PerssonTci:
+          Exponent: 4.0
+          NumHighestModes: 1
+        RdmpTci:
+          Delta0: 1.0e-7
+          Epsilon: 1.0e-3
+        FdToDgTci:
+          NumberOfStepsBetweenTciCalls: 1
+          MinTciCallsAfterRollback: 1
+          MinimumClearTcis: 1
+        AlwaysUseSubcells: false
+        UseHalo: false
+        OnlyDgBlocksAndGroups: None
       SubcellToDgReconstructionMethod: DimByDim
-      UseHalo: false
-      OnlyDgBlocksAndGroups: None
       FiniteDifferenceDerivativeOrder: 2
   SubcellSolver:
     Reconstructor: MonotonisedCentral

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/BinaryNeutronStar.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/BinaryNeutronStar.yaml
@@ -152,15 +152,21 @@ SpatialDiscretization:
     Formulation: StrongInertial
     Quadrature: GaussLobatto
     Subcell:
-      PerssonTci:
-        Exponent: 4.0
-        NumHighestModes: 1
-      RdmpDelta0: 1.0e-7
-      RdmpEpsilon: 1.0e-3
-      AlwaysUseSubcells: False
+      TroubledCellIndicator:
+        PerssonTci:
+          Exponent: 4.0
+          NumHighestModes: 1
+        RdmpTci:
+          Delta0: 1.0e-7
+          Epsilon: 1.0e-3
+        FdToDgTci:
+          NumberOfStepsBetweenTciCalls: 1
+          MinTciCallsAfterRollback: 1
+          MinimumClearTcis: 1
+        AlwaysUseSubcells: false
+        UseHalo: false
+        OnlyDgBlocksAndGroups: None
       SubcellToDgReconstructionMethod: DimByDim
-      UseHalo: True
-      OnlyDgBlocksAndGroups: []
       FiniteDifferenceDerivativeOrder: 2
     TciOptions:
       MinimumValueOfD: 1.0e-20

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdTovStar.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdTovStar.yaml
@@ -132,15 +132,21 @@ SpatialDiscretization:
     Formulation: StrongInertial
     Quadrature: GaussLobatto
     Subcell:
-      PerssonTci:
-        Exponent: 4.0
-        NumHighestModes: 1
-      RdmpDelta0: 1.0e-7
-      RdmpEpsilon: 1.0e-3
-      AlwaysUseSubcells: true
+      TroubledCellIndicator:
+        PerssonTci:
+          Exponent: 4.0
+          NumHighestModes: 1
+        RdmpTci:
+          Delta0: 1.0e-7
+          Epsilon: 1.0e-3
+        FdToDgTci:
+          NumberOfStepsBetweenTciCalls: 1
+          MinTciCallsAfterRollback: 1
+          MinimumClearTcis: 1
+        AlwaysUseSubcells: false
+        UseHalo: false
+        OnlyDgBlocksAndGroups: None
       SubcellToDgReconstructionMethod: DimByDim
-      UseHalo: false
-      OnlyDgBlocksAndGroups: None
       FiniteDifferenceDerivativeOrder: 2
     TciOptions:
       MinimumValueOfD: 1.0e-20

--- a/tests/InputFiles/GrMhd/ValenciaDivClean/BlastWave.yaml
+++ b/tests/InputFiles/GrMhd/ValenciaDivClean/BlastWave.yaml
@@ -48,15 +48,21 @@ SpatialDiscretization:
     Formulation: StrongInertial
     Quadrature: GaussLobatto
     Subcell:
-      PerssonTci:
-        Exponent: 4.0
-        NumHighestModes: 1
-      RdmpDelta0: 1.0e-7
-      RdmpEpsilon: 1.0e-3
-      AlwaysUseSubcells: false
+      TroubledCellIndicator:
+        PerssonTci:
+          Exponent: 4.0
+          NumHighestModes: 1
+        RdmpTci:
+          Delta0: 1.0e-7
+          Epsilon: 1.0e-3
+        FdToDgTci:
+          NumberOfStepsBetweenTciCalls: 1
+          MinTciCallsAfterRollback: 1
+          MinimumClearTcis: 1
+        AlwaysUseSubcells: false
+        UseHalo: false
+        OnlyDgBlocksAndGroups: None
       SubcellToDgReconstructionMethod: DimByDim
-      UseHalo: false
-      OnlyDgBlocksAndGroups: None
       FiniteDifferenceDerivativeOrder: 2
     TciOptions:
       MinimumValueOfD: 1.0e-20

--- a/tests/InputFiles/GrMhd/ValenciaDivClean/FishboneMoncriefDisk.yaml
+++ b/tests/InputFiles/GrMhd/ValenciaDivClean/FishboneMoncriefDisk.yaml
@@ -83,15 +83,21 @@ SpatialDiscretization:
     Formulation: StrongInertial
     Quadrature: GaussLobatto
     Subcell:
-      PerssonTci:
-        Exponent: 4.0
-        NumHighestModes: 1
-      RdmpDelta0: 1.0e-7
-      RdmpEpsilon: 1.0e-3
-      AlwaysUseSubcells: false
+      TroubledCellIndicator:
+        PerssonTci:
+          Exponent: 4.0
+          NumHighestModes: 1
+        RdmpTci:
+          Delta0: 1.0e-7
+          Epsilon: 1.0e-3
+        FdToDgTci:
+          NumberOfStepsBetweenTciCalls: 1
+          MinTciCallsAfterRollback: 1
+          MinimumClearTcis: 1
+        AlwaysUseSubcells: false
+        UseHalo: false
+        OnlyDgBlocksAndGroups: None
       SubcellToDgReconstructionMethod: DimByDim
-      UseHalo: false
-      OnlyDgBlocksAndGroups: None
       FiniteDifferenceDerivativeOrder: 2
     TciOptions:
       MinimumValueOfD: 1.0e-20

--- a/tests/InputFiles/NewtonianEuler/RiemannProblem1D.yaml
+++ b/tests/InputFiles/NewtonianEuler/RiemannProblem1D.yaml
@@ -41,15 +41,21 @@ SpatialDiscretization:
     Formulation: StrongInertial
     Quadrature: GaussLobatto
     Subcell:
-      PerssonTci:
-        Exponent: 4.0
-        NumHighestModes: 1
-      RdmpDelta0: 1.0e-7
-      RdmpEpsilon: 1.0e-3
-      AlwaysUseSubcells: false
+      TroubledCellIndicator:
+        PerssonTci:
+          Exponent: 4.0
+          NumHighestModes: 1
+        RdmpTci:
+          Delta0: 1.0e-7
+          Epsilon: 1.0e-3
+        FdToDgTci:
+          NumberOfStepsBetweenTciCalls: 1
+          MinTciCallsAfterRollback: 1
+          MinimumClearTcis: 1
+        AlwaysUseSubcells: false
+        UseHalo: false
+        OnlyDgBlocksAndGroups: None
       SubcellToDgReconstructionMethod: DimByDim
-      UseHalo: false
-      OnlyDgBlocksAndGroups: None
       FiniteDifferenceDerivativeOrder: 2
   SubcellSolver:
     Reconstructor:

--- a/tests/InputFiles/NewtonianEuler/RiemannProblem2D.yaml
+++ b/tests/InputFiles/NewtonianEuler/RiemannProblem2D.yaml
@@ -37,15 +37,21 @@ SpatialDiscretization:
     Formulation: StrongInertial
     Quadrature: GaussLobatto
     Subcell:
-      PerssonTci:
-        Exponent: 4.0
-        NumHighestModes: 1
-      RdmpDelta0: 1.0e-7
-      RdmpEpsilon: 1.0e-3
-      AlwaysUseSubcells: false
+      TroubledCellIndicator:
+        PerssonTci:
+          Exponent: 4.0
+          NumHighestModes: 1
+        RdmpTci:
+          Delta0: 1.0e-7
+          Epsilon: 1.0e-3
+        FdToDgTci:
+          NumberOfStepsBetweenTciCalls: 1
+          MinTciCallsAfterRollback: 1
+          MinimumClearTcis: 1
+        AlwaysUseSubcells: false
+        UseHalo: false
+        OnlyDgBlocksAndGroups: None
       SubcellToDgReconstructionMethod: DimByDim
-      UseHalo: false
-      OnlyDgBlocksAndGroups: None
       FiniteDifferenceDerivativeOrder: 2
   SubcellSolver:
     Reconstructor:

--- a/tests/InputFiles/NewtonianEuler/RiemannProblem3D.yaml
+++ b/tests/InputFiles/NewtonianEuler/RiemannProblem3D.yaml
@@ -40,15 +40,21 @@ SpatialDiscretization:
     Formulation: StrongInertial
     Quadrature: GaussLobatto
     Subcell:
-      PerssonTci:
-        Exponent: 4.0
-        NumHighestModes: 1
-      RdmpDelta0: 1.0e-7
-      RdmpEpsilon: 1.0e-3
-      AlwaysUseSubcells: false
+      TroubledCellIndicator:
+        PerssonTci:
+          Exponent: 4.0
+          NumHighestModes: 1
+        RdmpTci:
+          Delta0: 1.0e-7
+          Epsilon: 1.0e-3
+        FdToDgTci:
+          NumberOfStepsBetweenTciCalls: 1
+          MinTciCallsAfterRollback: 1
+          MinimumClearTcis: 1
+        AlwaysUseSubcells: false
+        UseHalo: false
+        OnlyDgBlocksAndGroups: None
       SubcellToDgReconstructionMethod: DimByDim
-      UseHalo: false
-      OnlyDgBlocksAndGroups: None
       FiniteDifferenceDerivativeOrder: 2
   SubcellSolver:
     Reconstructor:

--- a/tests/InputFiles/ScalarAdvection/Krivodonova1D.yaml
+++ b/tests/InputFiles/ScalarAdvection/Krivodonova1D.yaml
@@ -42,15 +42,21 @@ SpatialDiscretization:
     Formulation: StrongInertial
     Quadrature: GaussLobatto
     Subcell:
-      PerssonTci:
-        Exponent: 4.0
-        NumHighestModes: 1
-      RdmpDelta0: 1.0e-7
-      RdmpEpsilon: 1.0e-3
-      AlwaysUseSubcells: false
+      TroubledCellIndicator:
+        PerssonTci:
+          Exponent: 4.0
+          NumHighestModes: 1
+        RdmpTci:
+          Delta0: 1.0e-7
+          Epsilon: 1.0e-3
+        FdToDgTci:
+          NumberOfStepsBetweenTciCalls: 1
+          MinTciCallsAfterRollback: 1
+          MinimumClearTcis: 1
+        AlwaysUseSubcells: false
+        UseHalo: false
+        OnlyDgBlocksAndGroups: None
       SubcellToDgReconstructionMethod: DimByDim
-      UseHalo: false
-      OnlyDgBlocksAndGroups: None
       FiniteDifferenceDerivativeOrder: 2
     TciOptions:
       UCutoff: 1.0e-10

--- a/tests/InputFiles/ScalarAdvection/Kuzmin2D.yaml
+++ b/tests/InputFiles/ScalarAdvection/Kuzmin2D.yaml
@@ -39,15 +39,21 @@ SpatialDiscretization:
     Formulation: StrongInertial
     Quadrature: GaussLobatto
     Subcell:
-      PerssonTci:
-        Exponent: 4.0
-        NumHighestModes: 1
-      RdmpDelta0: 1.0e-7
-      RdmpEpsilon: 1.0e-3
-      AlwaysUseSubcells: false
+      TroubledCellIndicator:
+        PerssonTci:
+          Exponent: 4.0
+          NumHighestModes: 1
+        RdmpTci:
+          Delta0: 1.0e-7
+          Epsilon: 1.0e-3
+        FdToDgTci:
+          NumberOfStepsBetweenTciCalls: 1
+          MinTciCallsAfterRollback: 1
+          MinimumClearTcis: 1
+        AlwaysUseSubcells: false
+        UseHalo: false
+        OnlyDgBlocksAndGroups: None
       SubcellToDgReconstructionMethod: DimByDim
-      UseHalo: false
-      OnlyDgBlocksAndGroups: None
       FiniteDifferenceDerivativeOrder: 2
     TciOptions:
       UCutoff: 1.0e-10

--- a/tests/InputFiles/ScalarAdvection/Sinusoid1D.yaml
+++ b/tests/InputFiles/ScalarAdvection/Sinusoid1D.yaml
@@ -42,15 +42,21 @@ SpatialDiscretization:
     Formulation: StrongInertial
     Quadrature: GaussLobatto
     Subcell:
-      PerssonTci:
-        Exponent: 4.0
-        NumHighestModes: 1
-      RdmpDelta0: 1.0e-7
-      RdmpEpsilon: 1.0e-3
-      AlwaysUseSubcells: false
+      TroubledCellIndicator:
+        PerssonTci:
+          Exponent: 4.0
+          NumHighestModes: 1
+        RdmpTci:
+          Delta0: 1.0e-7
+          Epsilon: 1.0e-3
+        FdToDgTci:
+          NumberOfStepsBetweenTciCalls: 1
+          MinTciCallsAfterRollback: 1
+          MinimumClearTcis: 1
+        AlwaysUseSubcells: false
+        UseHalo: false
+        OnlyDgBlocksAndGroups: None
       SubcellToDgReconstructionMethod: DimByDim
-      UseHalo: false
-      OnlyDgBlocksAndGroups: None
       FiniteDifferenceDerivativeOrder: 2
     TciOptions:
       UCutoff: 1.0e-10

--- a/tests/Unit/Evolution/DgSubcell/Actions/Test_Initialize.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Actions/Test_Initialize.cpp
@@ -250,7 +250,7 @@ void test(const bool always_use_subcell, const bool interior_element,
                allow_subcell_in_block
                    ? std::optional<std::vector<std::string>>{}
                    : std::optional{std::vector<std::string>{"Block0"}},
-               ::fd::DerivativeOrder::Two},
+               ::fd::DerivativeOrder::Two, 1, 1, 1},
            TestCreator<Dim>{}}}};
   metavars::FdInitialDataTci::invoked = false;
   metavars::SetInitialRdmpData::invoked = false;

--- a/tests/Unit/Evolution/DgSubcell/Actions/Test_TciAndRollback.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Actions/Test_TciAndRollback.cpp
@@ -285,7 +285,7 @@ void test_impl(const bool rdmp_fails, const bool tci_fails,
               disable_subcell_in_block
                   ? std::optional{std::vector<std::string>{"Block1"}}
                   : std::optional<std::vector<std::string>>{},
-              ::fd::DerivativeOrder::Two},
+              ::fd::DerivativeOrder::Two, 1, 1, 1},
           TestCreator<Dim>{}};
 
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<metavars>;

--- a/tests/Unit/Evolution/DgSubcell/Test_CellCenteredFlux.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Test_CellCenteredFlux.cpp
@@ -82,7 +82,7 @@ void test(const fd::DerivativeOrder derivative_order, const bool did_rollback) {
           evolution::dg::subcell::SubcellOptions{
               4.0, 1_st, 1.0e-3, 1.0e-4, false,
               evolution::dg::subcell::fd::ReconstructionMethod::DimByDim, false,
-              std::nullopt, derivative_order},
+              std::nullopt, derivative_order, 1, 1, 1},
           subcell_mesh, typename CellCenteredFluxTag::type{}, dg_mesh,
           dg_mesh_velocity,
           Variables<flux_variables>{subcell_mesh.number_of_grid_points(), 1.0});

--- a/tests/Unit/Evolution/DgSubcell/Test_PrepareNeighborData.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Test_PrepareNeighborData.cpp
@@ -212,7 +212,7 @@ void test(const bool all_neighbors_are_doing_dg,
               all_neighbors_are_doing_dg
                   ? std::optional{std::vector<std::string>{"Block1"}}
                   : std::optional<std::vector<std::string>>{},
-              fd_derivative_order},
+              fd_derivative_order, 1, 1, 1},
           TestCreator<Dim>{}};
 
   Interps fd_to_fd_neighbor_interpolants{};

--- a/tests/Unit/Evolution/DgSubcell/Test_SubcellOptions.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Test_SubcellOptions.cpp
@@ -27,69 +27,94 @@ void test_impl(const std::vector<double>& expected_values,
   CHECK(SubcellOptions(
             expected_values[0], static_cast<size_t>(expected_values[1]),
             expected_values[2], expected_values[3], false, recons_method, false,
-            std::nullopt, ::fd::DerivativeOrder::Two) !=
+            std::nullopt, ::fd::DerivativeOrder::Two, 1, 1, 1) !=
         SubcellOptions(values[0], static_cast<size_t>(values[1]), values[2],
                        values[3], false, recons_method, false, std::nullopt,
-                       ::fd::DerivativeOrder::Two));
+                       ::fd::DerivativeOrder::Two, 1, 1, 1));
   CHECK_FALSE(SubcellOptions(
                   expected_values[0], static_cast<size_t>(expected_values[1]),
                   expected_values[2], expected_values[3], false, recons_method,
-                  false, std::nullopt, ::fd::DerivativeOrder::Two) ==
+                  false, std::nullopt, ::fd::DerivativeOrder::Two, 1, 1, 1) ==
               SubcellOptions(values[0], static_cast<size_t>(values[1]),
                              values[2], values[3], false, recons_method, false,
-                             std::nullopt, ::fd::DerivativeOrder::Two));
+                             std::nullopt, ::fd::DerivativeOrder::Two, 1, 1,
+                             1));
 
   CHECK(SubcellOptions(
             expected_values[0], static_cast<size_t>(expected_values[1]),
             expected_values[2], expected_values[3], false, recons_method, false,
-            std::nullopt, ::fd::DerivativeOrder::Two) !=
+            std::nullopt, ::fd::DerivativeOrder::Two, 1, 1, 1) !=
         SubcellOptions(
             expected_values[0], static_cast<size_t>(expected_values[1]),
             expected_values[2], expected_values[3], true, recons_method, false,
-            std::nullopt, ::fd::DerivativeOrder::Two));
+            std::nullopt, ::fd::DerivativeOrder::Two, 1, 1, 1));
   CHECK_FALSE(SubcellOptions(
                   expected_values[0], static_cast<size_t>(expected_values[1]),
                   expected_values[2], expected_values[3], false, recons_method,
-                  false, std::nullopt, ::fd::DerivativeOrder::Two) ==
+                  false, std::nullopt, ::fd::DerivativeOrder::Two, 1, 1, 1) ==
               SubcellOptions(
                   expected_values[0], static_cast<size_t>(expected_values[1]),
                   expected_values[2], expected_values[3], true, recons_method,
-                  false, std::nullopt, ::fd::DerivativeOrder::Two));
+                  false, std::nullopt, ::fd::DerivativeOrder::Two, 1, 1, 1));
 
   CHECK(SubcellOptions(
             expected_values[0], static_cast<size_t>(expected_values[1]),
             expected_values[2], expected_values[3], false, recons_method, false,
-            std::nullopt, ::fd::DerivativeOrder::Two) !=
+            std::nullopt, ::fd::DerivativeOrder::Two, 1, 1, 1) !=
         SubcellOptions(expected_values[0],
                        static_cast<size_t>(expected_values[1]),
                        expected_values[2], expected_values[3], false,
                        fd::ReconstructionMethod::DimByDim, false, std::nullopt,
-                       ::fd::DerivativeOrder::Two));
+                       ::fd::DerivativeOrder::Two, 1, 1, 1));
   CHECK_FALSE(SubcellOptions(
                   expected_values[0], static_cast<size_t>(expected_values[1]),
                   expected_values[2], expected_values[3], false, recons_method,
-                  false, std::nullopt, ::fd::DerivativeOrder::Two) ==
-              SubcellOptions(expected_values[0],
-                             static_cast<size_t>(expected_values[1]),
-                             expected_values[2], expected_values[3], false,
-                             fd::ReconstructionMethod::DimByDim, false,
-                             std::nullopt, ::fd::DerivativeOrder::Two));
+                  false, std::nullopt, ::fd::DerivativeOrder::Two, 1, 1, 1) ==
+              SubcellOptions(
+                  expected_values[0], static_cast<size_t>(expected_values[1]),
+                  expected_values[2], expected_values[3], false,
+                  fd::ReconstructionMethod::DimByDim, false, std::nullopt,
+                  ::fd::DerivativeOrder::Two, 1, 1, 1));
   CHECK_FALSE(SubcellOptions(
                   expected_values[0], static_cast<size_t>(expected_values[1]),
                   expected_values[2], expected_values[3], false, recons_method,
-                  false, std::nullopt, ::fd::DerivativeOrder::Two) ==
+                  false, std::nullopt, ::fd::DerivativeOrder::Two, 1, 1, 1) ==
               SubcellOptions(
                   expected_values[0], static_cast<size_t>(expected_values[1]),
                   expected_values[2], expected_values[3], false, recons_method,
-                  true, std::nullopt, ::fd::DerivativeOrder::Two));
+                  true, std::nullopt, ::fd::DerivativeOrder::Two, 1, 1, 1));
   CHECK_FALSE(SubcellOptions(
                   expected_values[0], static_cast<size_t>(expected_values[1]),
                   expected_values[2], expected_values[3], false, recons_method,
-                  false, std::nullopt, ::fd::DerivativeOrder::Four) ==
+                  false, std::nullopt, ::fd::DerivativeOrder::Four, 1, 1, 1) ==
               SubcellOptions(
                   expected_values[0], static_cast<size_t>(expected_values[1]),
                   expected_values[2], expected_values[3], false, recons_method,
-                  false, std::nullopt, ::fd::DerivativeOrder::Two));
+                  false, std::nullopt, ::fd::DerivativeOrder::Two, 1, 1, 1));
+  CHECK_FALSE(SubcellOptions(
+                  expected_values[0], static_cast<size_t>(expected_values[1]),
+                  expected_values[2], expected_values[3], false, recons_method,
+                  false, std::nullopt, ::fd::DerivativeOrder::Two, 2, 1, 1) ==
+              SubcellOptions(
+                  expected_values[0], static_cast<size_t>(expected_values[1]),
+                  expected_values[2], expected_values[3], false, recons_method,
+                  false, std::nullopt, ::fd::DerivativeOrder::Two, 1, 1, 1));
+  CHECK_FALSE(SubcellOptions(
+                  expected_values[0], static_cast<size_t>(expected_values[1]),
+                  expected_values[2], expected_values[3], false, recons_method,
+                  false, std::nullopt, ::fd::DerivativeOrder::Two, 1, 2, 1) ==
+              SubcellOptions(
+                  expected_values[0], static_cast<size_t>(expected_values[1]),
+                  expected_values[2], expected_values[3], false, recons_method,
+                  false, std::nullopt, ::fd::DerivativeOrder::Two, 1, 1, 1));
+  CHECK_FALSE(SubcellOptions(
+                  expected_values[0], static_cast<size_t>(expected_values[1]),
+                  expected_values[2], expected_values[3], false, recons_method,
+                  false, std::nullopt, ::fd::DerivativeOrder::Two, 1, 1, 2) ==
+              SubcellOptions(
+                  expected_values[0], static_cast<size_t>(expected_values[1]),
+                  expected_values[2], expected_values[3], false, recons_method,
+                  false, std::nullopt, ::fd::DerivativeOrder::Two, 1, 1, 1));
 }
 
 SPECTRE_TEST_CASE("Unit.Evolution.Subcell.SubcellOptions",
@@ -100,58 +125,72 @@ SPECTRE_TEST_CASE("Unit.Evolution.Subcell.SubcellOptions",
     test_impl(expected_values, i);
   }
 
-  const SubcellOptions options(expected_values[0],
-                               static_cast<size_t>(expected_values[1]),
-                               expected_values[2], expected_values[3], true,
-                               fd::ReconstructionMethod::DimByDim, true,
-                               std::nullopt, ::fd::DerivativeOrder::Four);
+  const SubcellOptions options(
+      expected_values[0], static_cast<size_t>(expected_values[1]),
+      expected_values[2], expected_values[3], true,
+      fd::ReconstructionMethod::DimByDim, true, std::nullopt,
+      ::fd::DerivativeOrder::Four, 1, 1, 1);
   const SubcellOptions deserialized_options =
       serialize_and_deserialize(options);
   CHECK(options == deserialized_options);
 
   CHECK(options == TestHelpers::test_option_tag<OptionTags::SubcellOptions>(
-                       "PerssonTci:\n"
-                       "  Exponent: 4.0\n"
-                       "  NumHighestModes: 1\n"
-                       "RdmpDelta0: 2.0e-3\n"
-                       "RdmpEpsilon: 2.0e-4\n"
-                       "AlwaysUseSubcells: true\n"
+                       "TroubledCellIndicator:\n"
+                       "  PerssonTci:\n"
+                       "    Exponent: 4.0\n"
+                       "    NumHighestModes: 1\n"
+                       "  RdmpTci:\n"
+                       "    Delta0: 2.0e-3\n"
+                       "    Epsilon: 2.0e-4\n"
+                       "  FdToDgTci:\n"
+                       "    NumberOfStepsBetweenTciCalls: 1\n"
+                       "    MinTciCallsAfterRollback: 1\n"
+                       "    MinimumClearTcis: 1\n"
+                       "  AlwaysUseSubcells: true\n"
+                       "  UseHalo: true\n"
+                       "  OnlyDgBlocksAndGroups: None\n"
                        "SubcellToDgReconstructionMethod: DimByDim\n"
-                       "UseHalo: true\n"
-                       "OnlyDgBlocksAndGroups: None\n"
                        "FiniteDifferenceDerivativeOrder: 4\n"));
 
   INFO("Test with block names and groups");
   const domain::creators::Cylinder cylinder{2.0,   10.0, 1.0,  8.0,
                                             false, 0_st, 5_st, false};
   const std::string opts_no_blocks =
-      "PerssonTci:\n"
-      "  Exponent: 4.0\n"
-      "  NumHighestModes: 1\n"
-      "RdmpDelta0: 2.0e-3\n"
-      "RdmpEpsilon: 2.0e-4\n"
-      "AlwaysUseSubcells: true\n"
+      "TroubledCellIndicator:\n"
+      "  PerssonTci:\n"
+      "    Exponent: 4.0\n"
+      "    NumHighestModes: 1\n"
+      "  RdmpTci:\n"
+      "    Delta0: 2.0e-3\n"
+      "    Epsilon: 2.0e-4\n"
+      "  FdToDgTci:\n"
+      "    NumberOfStepsBetweenTciCalls: 1\n"
+      "    MinTciCallsAfterRollback: 1\n"
+      "    MinimumClearTcis: 1\n"
+      "  AlwaysUseSubcells: true\n"
+      "  UseHalo: true\n";
+  const std::string opts_end =
       "SubcellToDgReconstructionMethod: DimByDim\n"
-      "UseHalo: true\n"
       "FiniteDifferenceDerivativeOrder: 4\n";
   CHECK_THROWS_WITH(
-      SubcellOptions(TestHelpers::test_option_tag<OptionTags::SubcellOptions>(
-                         opts_no_blocks + "OnlyDgBlocksAndGroups: [blah]\n"),
-                     cylinder),
+      SubcellOptions(
+          TestHelpers::test_option_tag<OptionTags::SubcellOptions>(
+              opts_no_blocks + "  OnlyDgBlocksAndGroups: [blah]\n" + opts_end),
+          cylinder),
       Catch::Matchers::ContainsSubstring("The block or group 'blah'"));
 
-  CHECK(SubcellOptions{
-            TestHelpers::test_option_tag<OptionTags::SubcellOptions>(
-                opts_no_blocks + "OnlyDgBlocksAndGroups: [InnerCube]\n"),
-            cylinder}
+  CHECK(SubcellOptions{TestHelpers::test_option_tag<OptionTags::SubcellOptions>(
+                           opts_no_blocks +
+                           "  OnlyDgBlocksAndGroups: [InnerCube]\n" + opts_end),
+                       cylinder}
             .only_dg_block_ids()
             .size() == 1);
-  CHECK(
-      SubcellOptions{TestHelpers::test_option_tag<OptionTags::SubcellOptions>(
-                         opts_no_blocks + "OnlyDgBlocksAndGroups: [Wedges]\n"),
-                     cylinder}
-          .only_dg_block_ids()
-          .size() == 4);
+  CHECK(SubcellOptions{TestHelpers::test_option_tag<OptionTags::SubcellOptions>(
+                           opts_no_blocks +
+                           "  OnlyDgBlocksAndGroups: [Wedges]\n" + opts_end),
+                       cylinder}
+            .only_dg_block_ids()
+            .size() == 4);
 }
 }  // namespace
 }  // namespace evolution::dg::subcell

--- a/tests/Unit/Evolution/DgSubcell/Test_Tags.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Test_Tags.cpp
@@ -257,7 +257,10 @@ void test(const bool moving_mesh) {
           evolution::dg::subcell::fd::ReconstructionMethod::DimByDim,
           false,
           {},
-          ::fd::DerivativeOrder::Two});
+          ::fd::DerivativeOrder::Two,
+          1,
+          1,
+          1});
   const auto check_box = [&active_coords_box, &grid_to_inertial_map,
                           &moving_mesh,
                           &tci_decision](const Mesh<Dim>& expected_mesh) {

--- a/tests/Unit/Evolution/Systems/Burgers/Subcell/Test_TciOnDgGrid.cpp
+++ b/tests/Unit/Evolution/Systems/Burgers/Subcell/Test_TciOnDgGrid.cpp
@@ -59,7 +59,10 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Burgers.Subcell.TciOnDgGrid",
         evolution::dg::subcell::fd::ReconstructionMethod::DimByDim,
         false,
         std::nullopt,
-        fd::DerivativeOrder::Two};
+        fd::DerivativeOrder::Two,
+        1,
+        1,
+        1};
 
     const bool element_stays_on_dg = false;
     const std::tuple<bool, evolution::dg::subcell::RdmpTciData> result =

--- a/tests/Unit/Evolution/Systems/Burgers/Subcell/Test_TciOnFdGrid.cpp
+++ b/tests/Unit/Evolution/Systems/Burgers/Subcell/Test_TciOnFdGrid.cpp
@@ -66,7 +66,10 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Burgers.Subcell.TciOnFdGrid",
         evolution::dg::subcell::fd::ReconstructionMethod::DimByDim,
         false,
         std::nullopt,
-        fd::DerivativeOrder::Two};
+        fd::DerivativeOrder::Two,
+        1,
+        1,
+        1};
     const std::tuple<bool, evolution::dg::subcell::RdmpTciData> result =
         Burgers::subcell::TciOnFdGrid::apply(
             u, dg_mesh, subcell_mesh, past_rdmp_tci_data, subcell_options,

--- a/tests/Unit/Evolution/Systems/ForceFree/Subcell/Test_NeighborPackagedData.cpp
+++ b/tests/Unit/Evolution/Systems/ForceFree/Subcell/Test_NeighborPackagedData.cpp
@@ -301,7 +301,7 @@ void test_neighbor_packaged_data(const gsl::not_null<std::mt19937*> gen) {
       evolution::dg::subcell::SubcellOptions{
           4.0, 1_st, 1.0e-3, 1.0e-4, false,
           evolution::dg::subcell::fd::ReconstructionMethod::DimByDim, false,
-          std::nullopt, ::fd::DerivativeOrder::Two});
+          std::nullopt, ::fd::DerivativeOrder::Two, 1, 1, 1});
 
   // Compute the packaged data
   std::vector<DirectionalId<3>> mortars_to_reconstruct_to{};

--- a/tests/Unit/Evolution/Systems/ForceFree/Subcell/Test_TciOnDgGrid.cpp
+++ b/tests/Unit/Evolution/Systems/ForceFree/Subcell/Test_TciOnDgGrid.cpp
@@ -86,7 +86,10 @@ void test(const TestThis test_this, const int expected_tci_status) {
       evolution::dg::subcell::fd::ReconstructionMethod::DimByDim,
       false,
       std::nullopt,
-      fd::DerivativeOrder::Two};
+      fd::DerivativeOrder::Two,
+      1,
+      1,
+      1};
 
   const ForceFree::subcell::TciOptions tci_options{1.0e-10};
 

--- a/tests/Unit/Evolution/Systems/ForceFree/Subcell/Test_TciOnFdGrid.cpp
+++ b/tests/Unit/Evolution/Systems/ForceFree/Subcell/Test_TciOnFdGrid.cpp
@@ -74,7 +74,10 @@ void test(const TestThis test_this, const int expected_tci_status) {
       evolution::dg::subcell::fd::ReconstructionMethod::DimByDim,
       false,
       std::nullopt,
-      fd::DerivativeOrder::Two};
+      fd::DerivativeOrder::Two,
+      1,
+      1,
+      1};
 
   const ForceFree::subcell::TciOptions tci_options{1.0e-10};
 

--- a/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/Test_NeighborPackagedData.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/Test_NeighborPackagedData.cpp
@@ -324,7 +324,7 @@ double test(const size_t num_dg_pts) {
       evolution::dg::subcell::SubcellOptions{
           4.0, 1_st, 1.0e-3, 1.0e-4, false,
           evolution::dg::subcell::fd::ReconstructionMethod::DimByDim, false,
-          std::nullopt, ::fd::DerivativeOrder::Two});
+          std::nullopt, ::fd::DerivativeOrder::Two, 1, 1, 1});
 
   db::mutate_apply<ValenciaDivClean::ConservativeFromPrimitive>(
       make_not_null(&box));

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_NeighborPackagedData.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_NeighborPackagedData.cpp
@@ -275,7 +275,7 @@ double test(const size_t num_dg_pts) {
       evolution::dg::subcell::SubcellOptions{
           4.0, 1_st, 1.0e-3, 1.0e-4, false,
           evolution::dg::subcell::fd::ReconstructionMethod::DimByDim, false,
-          std::nullopt, ::fd::DerivativeOrder::Two});
+          std::nullopt, ::fd::DerivativeOrder::Two, 1, 1, 1});
   db::mutate_apply<ConservativeFromPrimitive>(make_not_null(&box));
 
   std::vector<DirectionalId<3>> mortars_to_reconstruct_to{};

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_TciOnDgGrid.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_TciOnDgGrid.cpp
@@ -114,7 +114,10 @@ void test(const TestThis test_this, const int expected_tci_status,
       evolution::dg::subcell::fd::ReconstructionMethod::DimByDim,
       false,
       std::nullopt,
-      fd::DerivativeOrder::Two};
+      fd::DerivativeOrder::Two,
+      1,
+      1,
+      1};
 
   const double cutoff_d_for_inversion = 0.0;
   const double density_when_skipping_inversion = 0.0;

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_TciOnFdGrid.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_TciOnFdGrid.cpp
@@ -65,7 +65,10 @@ void test(const TestThis test_this, const int expected_tci_status) {
       evolution::dg::subcell::fd::ReconstructionMethod::DimByDim,
       false,
       std::nullopt,
-      fd::DerivativeOrder::Two};
+      fd::DerivativeOrder::Two,
+      1,
+      1,
+      1};
 
   auto box = db::create<db::AddSimpleTags<
       grmhd::ValenciaDivClean::Tags::TildeD,

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_TimeDerivative.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_TimeDerivative.cpp
@@ -468,7 +468,7 @@ std::array<double, 5> test(const size_t num_dg_pts,
       evolution::dg::subcell::SubcellOptions{
           4.0, 1_st, 1.0e-3, 1.0e-4, false,
           evolution::dg::subcell::fd::ReconstructionMethod::DimByDim, false,
-          std::nullopt, fd_derivative_order},
+          std::nullopt, fd_derivative_order, 1, 1, 1},
       typename evolution::dg::subcell::Tags::ReconstructionOrder<3>::type{});
 
   db::mutate_apply<ConservativeFromPrimitive>(make_not_null(&box));

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/Subcell/Test_NeighborPackagedData.cpp
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/Subcell/Test_NeighborPackagedData.cpp
@@ -259,7 +259,7 @@ double test(const size_t num_dg_pts) {
       evolution::dg::subcell::SubcellOptions{
           4.0, 1_st, 1.0e-3, 1.0e-4, false,
           evolution::dg::subcell::fd::ReconstructionMethod::DimByDim, false,
-          std::nullopt, ::fd::DerivativeOrder::Two});
+          std::nullopt, ::fd::DerivativeOrder::Two, 1, 1, 1});
 
   db::mutate_apply<NewtonianEuler::ConservativeFromPrimitive<Dim>>(
       make_not_null(&box));

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/Subcell/Test_TciOnDgGrid.cpp
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/Subcell/Test_TciOnDgGrid.cpp
@@ -88,7 +88,10 @@ void test(const TestThis test_this) {
       evolution::dg::subcell::fd::ReconstructionMethod::DimByDim,
       false,
       std::nullopt,
-      fd::DerivativeOrder::Two};
+      fd::DerivativeOrder::Two,
+      1,
+      1,
+      1};
 
   auto box = db::create<db::AddSimpleTags<
       ::Tags::Variables<cons_tags>, ::Tags::Variables<prim_tags>,

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/Subcell/Test_TciOnFdGrid.cpp
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/Subcell/Test_TciOnFdGrid.cpp
@@ -72,7 +72,10 @@ void test(const TestThis test_this) {
       evolution::dg::subcell::fd::ReconstructionMethod::DimByDim,
       false,
       std::nullopt,
-      fd::DerivativeOrder::Two};
+      fd::DerivativeOrder::Two,
+      1,
+      1,
+      1};
 
   if (test_this == TestThis::PerssonEnergyDensity) {
     get(get<Pressure>(subcell_prim))[subcell_mesh.number_of_grid_points() / 2] =

--- a/tests/Unit/Evolution/Systems/ScalarAdvection/Subcell/Test_NeighborPackagedData.cpp
+++ b/tests/Unit/Evolution/Systems/ScalarAdvection/Subcell/Test_NeighborPackagedData.cpp
@@ -205,7 +205,7 @@ void test_neighbor_packaged_data(const size_t num_dg_pts_per_dimension,
       evolution::dg::subcell::SubcellOptions{
           4.0, 1_st, 1.0e-3, 1.0e-4, false,
           evolution::dg::subcell::fd::ReconstructionMethod::DimByDim, false,
-          std::nullopt, ::fd::DerivativeOrder::Two});
+          std::nullopt, ::fd::DerivativeOrder::Two, 1, 1, 1});
 
   // Compute face-centered velocity field and add it to the box. This action
   // needs to be called in prior since NeighborPackagedData::apply() internally

--- a/tests/Unit/Evolution/Systems/ScalarAdvection/Subcell/Test_TciOnDgGrid.cpp
+++ b/tests/Unit/Evolution/Systems/ScalarAdvection/Subcell/Test_TciOnDgGrid.cpp
@@ -68,7 +68,10 @@ void test(const TestThis& test_this) {
       evolution::dg::subcell::fd::ReconstructionMethod::DimByDim,
       false,
       std::nullopt,
-      fd::DerivativeOrder::Two};
+      fd::DerivativeOrder::Two,
+      1,
+      1,
+      1};
 
   const bool element_stays_on_dg = false;
   const std::tuple<bool, evolution::dg::subcell::RdmpTciData> result =

--- a/tests/Unit/Evolution/Systems/ScalarAdvection/Subcell/Test_TciOnFdGrid.cpp
+++ b/tests/Unit/Evolution/Systems/ScalarAdvection/Subcell/Test_TciOnFdGrid.cpp
@@ -74,7 +74,10 @@ void test(const TestThis& test_this) {
       evolution::dg::subcell::fd::ReconstructionMethod::DimByDim,
       false,
       std::nullopt,
-      fd::DerivativeOrder::Two};
+      fd::DerivativeOrder::Two,
+      1,
+      1,
+      1};
 
   const std::tuple<bool, evolution::dg::subcell::RdmpTciData> result =
       ScalarAdvection::subcell::TciOnFdGrid<Dim>::apply(

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_Psi4.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_Psi4.cpp
@@ -66,7 +66,8 @@ void test_compute_item_in_databox(const RealDataType& used_for_size_real) {
   const auto expected = gr::psi_4_real(
       spatial_ricci, extrinsic_curvature, cov_deriv_extrinsic_curvature,
       spatial_metric, inv_spatial_metric, inertial_coords);
-  CHECK((db::get<gr::Tags::Psi4Real<RealDataType>>(box)) == expected);
+  CHECK_ITERABLE_APPROX((db::get<gr::Tags::Psi4Real<RealDataType>>(box)),
+                        expected);
 }
 
 template <typename RealDataType, typename ComplexDataType>


### PR DESCRIPTION
## Proposed changes

I split this into a few `fixup` commits that I will squash together. Changing `SubcellOptions` is a bit tedious so it's easier to do it in one commit. However, I still wanted to keep this easy to review.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
The TCI options now look like:

```yaml
    Subcell:
      TroubledCellIndicator:
        PerssonTci:
          Exponent: 4.0
          NumHighestModes: 1
        RdmpTci:
          Delta0: 1.0e-7
          Epsilon: 1.0e-3
        FdToDgTci:
          NumberOfStepsBetweenTciCalls: 1
          MinTciCallsAfterRollback: 1
          MinimumClearTcis: 1
        AlwaysUseSubcells: false
        UseHalo: false
        OnlyDgBlocksAndGroups: None
      SubcellToDgReconstructionMethod: DimByDim
      FiniteDifferenceDerivativeOrder: 2
```
Specifically, all the TCI-related options have been moved into a group called `TroubledCellIndicator`. The RDMP TCI options are now also in their own group. A new `FdToDgTci:` group controls when we try to go back to DG, e.g. every N steps, to wait M steps after rollback, or to have at least K clear TCIs before going back to DG. This is to allow reducing TCI overhead on FD and to allow additional smoothing by the FD solver before going back.

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
