### PR TITLE
Add AMR to elliptic executables

### DIFF
--- a/src/Elliptic/Amr/Actions.hpp
+++ b/src/Elliptic/Amr/Actions.hpp
@@ -1,0 +1,155 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "Domain/Structure/Element.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "IO/Logging/Tags.hpp"
+#include "IO/Logging/Verbosity.hpp"
+#include "NumericalAlgorithms/Convergence/HasConverged.hpp"
+#include "NumericalAlgorithms/Convergence/Tags.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "Parallel/AlgorithmExecution.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "Parallel/Printf.hpp"
+#include "ParallelAlgorithms/Amr/Protocols/Projector.hpp"
+#include "ParallelAlgorithms/Amr/Tags.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+/// Actions to control the elliptic AMR algorithm
+namespace elliptic::amr::Actions {
+
+/*!
+ * \brief Initializes items for the elliptic AMR algorithm projector
+ *
+ * When projecting these items during h-AMR, they are copied from the parent or
+ * children to retain the AMR state.
+ */
+struct Initialize : tt::ConformsTo<::amr::protocols::Projector> {
+ private:
+  using iteration_id_tag =
+      Convergence::Tags::IterationId<::amr::OptionTags::AmrGroup>;
+  using num_iterations_tag =
+      Convergence::Tags::Iterations<::amr::OptionTags::AmrGroup>;
+  using has_converged_tag =
+      Convergence::Tags::HasConverged<::amr::OptionTags::AmrGroup>;
+
+ public:  // Initialization mutator
+  using simple_tags = tmpl::list<iteration_id_tag, has_converged_tag>;
+  using compute_tags = tmpl::list<>;
+  using simple_tags_from_options = tmpl::list<>;
+  using const_global_cache_tags = tmpl::list<num_iterations_tag>;
+  using mutable_global_cache_tags = tmpl::list<>;
+  using return_tags = simple_tags;
+  using argument_tags = tmpl::list<num_iterations_tag>;
+
+  static void apply(
+      const gsl::not_null<size_t*> amr_iteration_id,
+      const gsl::not_null<Convergence::HasConverged*> amr_has_converged,
+      const size_t num_iterations) {
+    *amr_iteration_id = 0;
+    *amr_has_converged = Convergence::HasConverged{num_iterations, 0};
+  }
+
+ public:  // amr::protocols::Projector
+  // p-refinement
+  template <size_t Dim>
+  static void apply(
+      const gsl::not_null<size_t*> /*amr_iteration_id*/,
+      const gsl::not_null<Convergence::HasConverged*> /*amr_has_converged*/,
+      const size_t /*num_iterations*/,
+      const std::pair<Mesh<Dim>, Element<Dim>>& /*old_mesh_and_element*/) {}
+
+  // h-refinement
+  template <typename... ParentTags>
+  static void apply(
+      const gsl::not_null<size_t*> amr_iteration_id,
+      const gsl::not_null<Convergence::HasConverged*> amr_has_converged,
+      const size_t /*num_iterations*/,
+      const tuples::TaggedTuple<ParentTags...>& parent_items) {
+    *amr_iteration_id = get<iteration_id_tag>(parent_items);
+    *amr_has_converged = get<has_converged_tag>(parent_items);
+  }
+
+  // h-coarsening
+  template <size_t Dim, typename... ChildTags>
+  static void apply(
+      const gsl::not_null<size_t*> amr_iteration_id,
+      const gsl::not_null<Convergence::HasConverged*> amr_has_converged,
+      const size_t /*num_iterations*/,
+      const std::unordered_map<
+          ElementId<Dim>, tuples::TaggedTuple<ChildTags...>>& children_items) {
+    *amr_iteration_id = get<iteration_id_tag>(children_items.begin()->second);
+    *amr_has_converged = get<has_converged_tag>(children_items.begin()->second);
+  }
+};
+
+/// Increment the AMR iteration ID and determine convergence
+struct IncrementIterationId {
+ private:
+  using iteration_id_tag =
+      Convergence::Tags::IterationId<::amr::OptionTags::AmrGroup>;
+  using num_iterations_tag =
+      Convergence::Tags::Iterations<::amr::OptionTags::AmrGroup>;
+  using has_converged_tag =
+      Convergence::Tags::HasConverged<::amr::OptionTags::AmrGroup>;
+
+ public:
+  template <typename DataBox, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent>
+  static Parallel::iterable_action_return_t apply(
+      DataBox& box, const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+      const Parallel::GlobalCache<Metavariables>& /*cache*/,
+      const ArrayIndex& element_id, const ActionList /*meta*/,
+      const ParallelComponent* const /*meta*/) {
+    const size_t num_iterations = get<num_iterations_tag>(box);
+    // Increment AMR iteration id and determine convergence
+    db::mutate<iteration_id_tag, has_converged_tag>(
+        [&num_iterations](
+            const gsl::not_null<size_t*> iteration_id,
+            const gsl::not_null<Convergence::HasConverged*> has_converged) {
+          ++(*iteration_id);
+          *has_converged =
+              Convergence::HasConverged{num_iterations, *iteration_id};
+        },
+        make_not_null(&box));
+    // Do some logging
+    if (db::get<logging::Tags::Verbosity<::amr::OptionTags::AmrGroup>>(box) >=
+        ::Verbosity::Debug) {
+      Parallel::printf("%s AMR iteration %zu / %zu\n", element_id,
+                       db::get<iteration_id_tag>(box), num_iterations);
+    }
+    return {Parallel::AlgorithmExecution::Continue, std::nullopt};
+  }
+};
+
+/// Stop the algorithm if it has converged
+struct StopAmr {
+ private:
+  using has_converged_tag =
+      Convergence::Tags::HasConverged<::amr::OptionTags::AmrGroup>;
+
+ public:
+  template <typename DataBox, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent>
+  static Parallel::iterable_action_return_t apply(
+      DataBox& box, const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+      const Parallel::GlobalCache<Metavariables>& /*cache*/,
+      const ArrayIndex& /*element_id*/, const ActionList /*meta*/,
+      const ParallelComponent* const /*meta*/) {
+    return {db::get<has_converged_tag>(box)
+                ? Parallel::AlgorithmExecution::Pause
+                : Parallel::AlgorithmExecution::Continue,
+            std::nullopt};
+  }
+};
+
+}  // namespace elliptic::amr::Actions

--- a/src/Elliptic/Amr/CMakeLists.txt
+++ b/src/Elliptic/Amr/CMakeLists.txt
@@ -1,0 +1,9 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+spectre_target_headers(
+  ${LIBRARY}
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  Actions.hpp
+  )

--- a/src/Elliptic/CMakeLists.txt
+++ b/src/Elliptic/CMakeLists.txt
@@ -29,6 +29,7 @@ target_link_libraries(
   )
 
 add_subdirectory(Actions)
+add_subdirectory(Amr)
 add_subdirectory(BoundaryConditions)
 add_subdirectory(DiscontinuousGalerkin)
 add_subdirectory(Executables)

--- a/src/Elliptic/DiscontinuousGalerkin/SubdomainOperator/SubdomainOperator.hpp
+++ b/src/Elliptic/DiscontinuousGalerkin/SubdomainOperator/SubdomainOperator.hpp
@@ -229,6 +229,10 @@ struct SubdomainOperator
                                const BoundaryConditionsBase&,
                                boost::hash<std::pair<size_t, Direction<Dim>>>>&
           override_boundary_conditions = {}) const {
+    result->destructive_resize(operand);
+    central_mortar_data_.clear();
+    neighbors_mortar_data_.clear();
+
     // Used to retrieve items out of the DataBox to forward to functions. This
     // replaces a long series of db::get calls.
     const auto get_items = [](const auto&... args) {

--- a/src/Elliptic/Executables/Elasticity/CMakeLists.txt
+++ b/src/Elliptic/Executables/Elasticity/CMakeLists.txt
@@ -2,6 +2,7 @@
 # See LICENSE.txt for details.
 
 set(LIBS_TO_LINK
+  AmrCriteria
   Charmxx::main
   ConstitutiveRelations
   Convergence
@@ -25,6 +26,7 @@ set(LIBS_TO_LINK
   Observer
   Options
   Parallel
+  ParallelAmr
   ParallelLinearSolver
   ParallelMultigrid
   ParallelSchwarz

--- a/src/Elliptic/Executables/Elasticity/SolveElasticity.cpp
+++ b/src/Elliptic/Executables/Elasticity/SolveElasticity.cpp
@@ -9,6 +9,7 @@
 #include "Domain/FunctionsOfTime/RegisterDerivedWithCharm.hpp"
 #include "Elliptic/SubdomainPreconditioners/RegisterDerived.hpp"
 #include "Parallel/CharmMain.tpp"
+#include "ParallelAlgorithms/Amr/Actions/RegisterCallbacks.hpp"
 #include "Utilities/Serialization/RegisterDerivedClassesWithCharm.hpp"
 
 // Parameters chosen in CMakeLists.txt
@@ -22,6 +23,8 @@ extern "C" void CkRegisterMainModule() {
        &register_derived_classes_with_charm<
            metavariables::solver::schwarz_smoother::subdomain_solver>,
        &elliptic::subdomain_preconditioners::register_derived_with_charm,
-       &register_factory_classes_with_charm<metavariables>},
+       &register_factory_classes_with_charm<metavariables>,
+       &::amr::register_callbacks<metavariables,
+                                  typename metavariables::amr::element_array>},
       {});
 }

--- a/src/Elliptic/Executables/Poisson/CMakeLists.txt
+++ b/src/Elliptic/Executables/Poisson/CMakeLists.txt
@@ -3,6 +3,7 @@
 
 set(LIBS_TO_LINK
   Charmxx::main
+  AmrCriteria
   Convergence
   CoordinateMaps
   DiscontinuousGalerkin
@@ -20,6 +21,7 @@ set(LIBS_TO_LINK
   Observer
   Options
   Parallel
+  ParallelAmr
   ParallelLinearSolver
   ParallelMultigrid
   ParallelSchwarz

--- a/src/Elliptic/Executables/Poisson/SolvePoisson.cpp
+++ b/src/Elliptic/Executables/Poisson/SolvePoisson.cpp
@@ -9,6 +9,7 @@
 #include "Domain/FunctionsOfTime/RegisterDerivedWithCharm.hpp"
 #include "Elliptic/SubdomainPreconditioners/RegisterDerived.hpp"
 #include "Parallel/CharmMain.tpp"
+#include "ParallelAlgorithms/Amr/Actions/RegisterCallbacks.hpp"
 #include "Utilities/Serialization/RegisterDerivedClassesWithCharm.hpp"
 
 // Parameters chosen in CMakeLists.txt
@@ -22,6 +23,8 @@ extern "C" void CkRegisterMainModule() {
        &register_derived_classes_with_charm<
            metavariables::solver::schwarz_smoother::subdomain_solver>,
        &elliptic::subdomain_preconditioners::register_derived_with_charm,
-       &register_factory_classes_with_charm<metavariables>},
+       &register_factory_classes_with_charm<metavariables>,
+       &::amr::register_callbacks<metavariables,
+                                  typename metavariables::amr::element_array>},
       {});
 }

--- a/src/Elliptic/Executables/Punctures/CMakeLists.txt
+++ b/src/Elliptic/Executables/Punctures/CMakeLists.txt
@@ -12,6 +12,7 @@ add_spectre_executable(
 target_link_libraries(
   ${EXECUTABLE}
   PRIVATE
+  AmrCriteria
   Charmxx::main
   Convergence
   CoordinateMaps
@@ -34,14 +35,16 @@ target_link_libraries(
   Observer
   Options
   Parallel
+  ParallelAmr
   ParallelLinearSolver
   ParallelMultigrid
   ParallelNonlinearSolver
   ParallelSchwarz
-  Utilities
   Punctures
+  PuncturesAmrCriteria
   PuncturesAnalyticData
   PuncturesBoundaryConditions
   PuncturesPointwiseFunctions
   PuncturesSolutions
+  Utilities
   )

--- a/src/Elliptic/Executables/Punctures/SolvePunctures.cpp
+++ b/src/Elliptic/Executables/Punctures/SolvePunctures.cpp
@@ -9,6 +9,7 @@
 #include "Domain/FunctionsOfTime/RegisterDerivedWithCharm.hpp"
 #include "Elliptic/SubdomainPreconditioners/RegisterDerived.hpp"
 #include "Parallel/CharmMain.tpp"
+#include "ParallelAlgorithms/Amr/Actions/RegisterCallbacks.hpp"
 #include "Utilities/Serialization/RegisterDerivedClassesWithCharm.hpp"
 
 extern "C" void CkRegisterMainModule() {
@@ -19,6 +20,8 @@ extern "C" void CkRegisterMainModule() {
        &register_derived_classes_with_charm<
            Metavariables::solver::schwarz_smoother::subdomain_solver>,
        &elliptic::subdomain_preconditioners::register_derived_with_charm,
-       &register_factory_classes_with_charm<Metavariables>},
+       &register_factory_classes_with_charm<Metavariables>,
+       &::amr::register_callbacks<Metavariables,
+                                  typename Metavariables::amr::element_array>},
       {});
 }

--- a/src/Elliptic/Executables/Punctures/SolvePunctures.hpp
+++ b/src/Elliptic/Executables/Punctures/SolvePunctures.hpp
@@ -12,6 +12,7 @@
 #include "Elliptic/Actions/RunEventsAndTriggers.hpp"
 #include "Elliptic/DiscontinuousGalerkin/DgElementArray.hpp"
 #include "Elliptic/Executables/Solver.hpp"
+#include "Elliptic/Systems/Punctures/AmrCriteria/RefineAtPunctures.hpp"
 #include "Elliptic/Systems/Punctures/BoundaryConditions/Flatness.hpp"
 #include "Elliptic/Systems/Punctures/FirstOrderSystem.hpp"
 #include "Elliptic/Triggers/Factory.hpp"
@@ -22,9 +23,14 @@
 #include "Options/String.hpp"
 #include "Parallel/GlobalCache.hpp"
 #include "Parallel/Phase.hpp"
+#include "Parallel/PhaseControl/VisitAndReturn.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
 #include "Parallel/Protocols/RegistrationMetavariables.hpp"
 #include "ParallelAlgorithms/Actions/TerminatePhase.hpp"
+#include "ParallelAlgorithms/Amr/Actions/SendAmrDiagnostics.hpp"
+#include "ParallelAlgorithms/Amr/Criteria/Factory.hpp"
+#include "ParallelAlgorithms/Amr/Protocols/AmrMetavariables.hpp"
+#include "ParallelAlgorithms/Amr/Tags.hpp"
 #include "ParallelAlgorithms/Events/Factory.hpp"
 #include "ParallelAlgorithms/Events/Tags.hpp"
 #include "ParallelAlgorithms/EventsAndTriggers/Completion.hpp"
@@ -74,15 +80,25 @@ struct Metavariables {
         tmpl::pair<elliptic::BoundaryConditions::BoundaryCondition<volume_dim>,
                    tmpl::list<Punctures::BoundaryConditions::Flatness>>,
         tmpl::pair<
-            Event,
-            tmpl::flatten<tmpl::list<
-                Events::Completion,
-                dg::Events::field_observations<
-                    volume_dim, observe_fields, observer_compute_tags,
-                    LinearSolver::multigrid::Tags::IsFinestGrid>>>>,
-        tmpl::pair<Trigger,
-                   elliptic::Triggers::all_triggers<
-                       typename solver::nonlinear_solver::options_group>>>;
+            ::amr::Criterion,
+            tmpl::push_back<::amr::Criteria::standard_criteria<
+                                volume_dim, tmpl::list<Punctures::Tags::Field>>,
+                            Punctures::AmrCriteria::RefineAtPunctures>>,
+        tmpl::pair<Event,
+                   tmpl::flatten<tmpl::list<
+                       Events::Completion,
+                       dg::Events::field_observations<
+                           volume_dim, observe_fields, observer_compute_tags,
+                           LinearSolver::multigrid::Tags::IsFinestGrid>>>>,
+        tmpl::pair<Trigger, elliptic::Triggers::all_triggers<
+                                ::amr::OptionTags::AmrGroup>>,
+        tmpl::pair<
+            PhaseChange,
+            tmpl::list<
+                PhaseControl::VisitAndReturn<
+                    Parallel::Phase::EvaluateAmrCriteria>,
+                PhaseControl::VisitAndReturn<Parallel::Phase::AdjustDomain>,
+                PhaseControl::VisitAndReturn<Parallel::Phase::CheckDomain>>>>;
   };
 
   // Additional items to store in the global cache
@@ -102,12 +118,7 @@ struct Metavariables {
       tmpl::push_back<typename solver::register_actions,
                       observers::Actions::RegisterEventsWithObservers>;
 
-  using step_actions = tmpl::list<elliptic::Actions::RunEventsAndTriggers<
-      solver::nonlinear_solver_iteration_id>>;
-
-  using solve_actions =
-      tmpl::push_back<typename solver::template solve_actions<step_actions>,
-                      Parallel::Actions::TerminatePhase>;
+  using solve_actions = typename solver::template solve_actions<tmpl::list<>>;
 
   using dg_element_array = elliptic::DgElementArray<
       Metavariables,
@@ -117,9 +128,18 @@ struct Metavariables {
                      Parallel::Phase::Register,
                      tmpl::push_back<register_actions,
                                      Parallel::Actions::TerminatePhase>>,
-                 Parallel::PhaseActions<Parallel::Phase::Solve, solve_actions>>,
+                 Parallel::PhaseActions<Parallel::Phase::Solve, solve_actions>,
+                 Parallel::PhaseActions<
+                     Parallel::Phase::CheckDomain,
+                     tmpl::list<::amr::Actions::SendAmrDiagnostics,
+                                Parallel::Actions::TerminatePhase>>>,
       LinearSolver::multigrid::ElementsAllocator<
           volume_dim, typename solver::multigrid::options_group>>;
+
+  struct amr : tt::ConformsTo<::amr::protocols::AmrMetavariables> {
+    using element_array = dg_element_array;
+    using projectors = typename solver::amr_projectors;
+  };
 
   struct registration
       : tt::ConformsTo<Parallel::protocols::RegistrationMetavariables> {

--- a/src/Elliptic/Executables/Solver.hpp
+++ b/src/Elliptic/Executables/Solver.hpp
@@ -147,7 +147,7 @@ struct Solver {
 
   /// Precondition each linear solver iteration with a multigrid V-cycle
   using multigrid = LinearSolver::multigrid::Multigrid<
-      volume_dim, typename linear_solver::operand_tag,
+      Metavariables, typename linear_solver::operand_tag,
       OptionTags::MultigridGroup, elliptic::dg::Tags::Massive,
       typename linear_solver::preconditioner_source_tag>;
 

--- a/src/Elliptic/Executables/Solver.hpp
+++ b/src/Elliptic/Executables/Solver.hpp
@@ -13,6 +13,8 @@
 #include "Elliptic/Actions/InitializeAnalyticSolution.hpp"
 #include "Elliptic/Actions/InitializeFields.hpp"
 #include "Elliptic/Actions/InitializeFixedSources.hpp"
+#include "Elliptic/Actions/RunEventsAndTriggers.hpp"
+#include "Elliptic/Amr/Actions.hpp"
 #include "Elliptic/BoundaryConditions/Tags/BoundaryFields.hpp"
 #include "Elliptic/DiscontinuousGalerkin/Actions/ApplyOperator.hpp"
 #include "Elliptic/DiscontinuousGalerkin/Actions/InitializeDomain.hpp"
@@ -26,8 +28,15 @@
 #include "IO/Observer/Helpers.hpp"
 #include "NumericalAlgorithms/Convergence/Tags.hpp"
 #include "Options/String.hpp"
+#include "Parallel/PhaseControl/ExecutePhaseChange.hpp"
 #include "ParallelAlgorithms/Actions/AddComputeTags.hpp"
+#include "ParallelAlgorithms/Actions/InitializeItems.hpp"
 #include "ParallelAlgorithms/Actions/RandomizeVariables.hpp"
+#include "ParallelAlgorithms/Amr/Actions/Component.hpp"
+#include "ParallelAlgorithms/Amr/Actions/Initialize.hpp"
+#include "ParallelAlgorithms/Amr/Projectors/DefaultInitialize.hpp"
+#include "ParallelAlgorithms/Amr/Projectors/Variables.hpp"
+#include "ParallelAlgorithms/Amr/Tags.hpp"
 #include "ParallelAlgorithms/LinearSolver/Actions/BuildMatrix.hpp"
 #include "ParallelAlgorithms/LinearSolver/Actions/MakeIdentityIfSkipped.hpp"
 #include "ParallelAlgorithms/LinearSolver/Gmres/Gmres.hpp"
@@ -123,6 +132,10 @@ struct Solver {
       // needs a few minor changes to the parallel linear solver algorithm.
       db::add_tag_prefix<LinearSolver::Tags::OperatorAppliedTo, fields_tag>,
       db::add_tag_prefix<NonlinearSolver::Tags::OperatorAppliedTo, fields_tag>>;
+
+  // For AMR iterations
+  using amr_iteration_id =
+      Convergence::Tags::IterationId<::amr::OptionTags::AmrGroup>;
 
   /// The nonlinear solver algorithm
   using nonlinear_solver = NonlinearSolver::newton_raphson::NewtonRaphson<
@@ -229,6 +242,9 @@ struct Solver {
       typename linear_solver::initialize_element,
       typename multigrid::initialize_element,
       typename schwarz_smoother::initialize_element,
+      Initialization::Actions::InitializeItems<
+          ::amr::Initialization::Initialize<volume_dim>,
+          elliptic::amr::Actions::Initialize>,
       elliptic::Actions::InitializeFields<system, initial_guess_tag>,
       ::Actions::RandomizeVariables<fields_tag, RandomizeInitialGuess>,
       elliptic::Actions::InitializeFixedSources<system, background_tag>,
@@ -318,13 +334,22 @@ struct Solver {
 
   template <typename StepActions>
   using solve_actions = tmpl::flatten<tmpl::list<
+      // Observe initial state
+      elliptic::Actions::RunEventsAndTriggers<amr_iteration_id>,
+      // Stop AMR iterations if complete
+      elliptic::amr::Actions::StopAmr,
+      // Run AMR or other phase changes if requested
+      PhaseControl::Actions::ExecutePhaseChange, StepActions,
+      // Increment AMR iteration ID
+      elliptic::amr::Actions::IncrementIterationId,
       // Communicate subdomain geometry and initialize subdomain to account for
       // domain changes
       LinearSolver::Schwarz::Actions::SendOverlapFields<
-          subdomain_init_tags, typename schwarz_smoother::options_group, false>,
+          subdomain_init_tags, typename schwarz_smoother::options_group, false,
+          amr_iteration_id>,
       LinearSolver::Schwarz::Actions::ReceiveOverlapFields<
           volume_dim, subdomain_init_tags,
-          typename schwarz_smoother::options_group, false>,
+          typename schwarz_smoother::options_group, false, amr_iteration_id>,
       init_subdomain_action,
       // Linear or nonlinear solve
       tmpl::conditional_t<
@@ -341,16 +366,51 @@ struct Solver {
                   ImposeInhomogeneousBoundaryConditionsOnSource<
                       system, fixed_sources_tag>,
               // Krylov solve
-              linear_solve_actions<StepActions>>,
+              linear_solve_actions<tmpl::list<>>>,
           // Nonlinear solve
-          nonlinear_solve_actions<StepActions>>>>;
+          nonlinear_solve_actions<tmpl::list<>>>>>;
+
+  template <typename Tag>
+  using overlaps_tag =
+      LinearSolver::Schwarz::Tags::Overlaps<Tag, volume_dim,
+                                            OptionTags::SchwarzSmootherGroup>;
+
+  using amr_projectors = tmpl::flatten<tmpl::list<
+      elliptic::dg::ProjectGeometry<volume_dim>,
+      tmpl::conditional_t<is_linear, tmpl::list<>,
+                          typename nonlinear_solver::amr_projectors>,
+      typename linear_solver::amr_projectors,
+      typename multigrid::amr_projectors,
+      typename schwarz_smoother::amr_projectors,
+      ::amr::projectors::DefaultInitialize<tmpl::append<
+          tmpl::list<domain::Tags::InitialExtents<volume_dim>,
+                     domain::Tags::InitialRefinementLevels<volume_dim>>,
+          // Tags communicated on subdomain overlaps. No need to project
+          // these during AMR because they will be communicated.
+          db::wrap_tags_in<
+              overlaps_tag,
+              tmpl::append<subdomain_init_tags,
+                           tmpl::conditional_t<is_linear, tmpl::list<>,
+                                               communicated_overlap_tags>>>,
+          // Tags initialized on subdomains. No need to project these during
+          // AMR because they will get re-initialized after communication.
+          typename init_subdomain_action::simple_tags>>,
+      ::amr::projectors::ProjectVariables<volume_dim, fields_tag>,
+      elliptic::Actions::InitializeFixedSources<system, background_tag>,
+      init_analytic_solution_action,
+      elliptic::dg::Actions::amr_projectors<system, background_tag>,
+      typename dg_operator<true>::amr_projectors,
+      tmpl::conditional_t<is_linear, typename build_matrix::amr_projectors,
+                          typename dg_operator<false>::amr_projectors>,
+      elliptic::amr::Actions::Initialize>>;
 
   using component_list = tmpl::flatten<
       tmpl::list<tmpl::conditional_t<is_linear, tmpl::list<>,
                                      typename nonlinear_solver::component_list>,
                  typename linear_solver::component_list,
                  typename multigrid::component_list,
-                 typename schwarz_smoother::component_list>>;
+                 typename schwarz_smoother::component_list,
+                 ::amr::Component<Metavariables>>>;
 };
 
 }  // namespace elliptic

--- a/src/Elliptic/Executables/Xcts/CMakeLists.txt
+++ b/src/Elliptic/Executables/Xcts/CMakeLists.txt
@@ -12,6 +12,7 @@ add_spectre_executable(
 target_link_libraries(
   ${EXECUTABLE}
   PRIVATE
+  AmrCriteria
   Charmxx::main
   Convergence
   CoordinateMaps
@@ -35,6 +36,7 @@ target_link_libraries(
   Observer
   Options
   Parallel
+  ParallelAmr
   ParallelLinearSolver
   ParallelMultigrid
   ParallelNonlinearSolver

--- a/src/Elliptic/Executables/Xcts/SolveXcts.cpp
+++ b/src/Elliptic/Executables/Xcts/SolveXcts.cpp
@@ -9,6 +9,7 @@
 #include "Domain/FunctionsOfTime/RegisterDerivedWithCharm.hpp"
 #include "Elliptic/SubdomainPreconditioners/RegisterDerived.hpp"
 #include "Parallel/CharmMain.tpp"
+#include "ParallelAlgorithms/Amr/Actions/RegisterCallbacks.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/RegisterDerivedWithCharm.hpp"
 #include "Utilities/Serialization/RegisterDerivedClassesWithCharm.hpp"
 
@@ -21,6 +22,8 @@ extern "C" void CkRegisterMainModule() {
            Metavariables::solver::schwarz_smoother::subdomain_solver>,
        &elliptic::subdomain_preconditioners::register_derived_with_charm,
        &EquationsOfState::register_derived_with_charm,
-       &register_factory_classes_with_charm<Metavariables>},
+       &register_factory_classes_with_charm<Metavariables>,
+       &::amr::register_callbacks<Metavariables,
+                                  typename Metavariables::amr::element_array>},
       {});
 }

--- a/src/Elliptic/Executables/Xcts/SolveXcts.hpp
+++ b/src/Elliptic/Executables/Xcts/SolveXcts.hpp
@@ -25,10 +25,15 @@
 #include "Options/String.hpp"
 #include "Parallel/GlobalCache.hpp"
 #include "Parallel/Phase.hpp"
+#include "Parallel/PhaseControl/VisitAndReturn.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
 #include "Parallel/Protocols/RegistrationMetavariables.hpp"
 #include "Parallel/Reduction.hpp"
 #include "ParallelAlgorithms/Actions/TerminatePhase.hpp"
+#include "ParallelAlgorithms/Amr/Actions/SendAmrDiagnostics.hpp"
+#include "ParallelAlgorithms/Amr/Criteria/Factory.hpp"
+#include "ParallelAlgorithms/Amr/Protocols/AmrMetavariables.hpp"
+#include "ParallelAlgorithms/Amr/Tags.hpp"
 #include "ParallelAlgorithms/Events/Factory.hpp"
 #include "ParallelAlgorithms/Events/Tags.hpp"
 #include "ParallelAlgorithms/EventsAndTriggers/Completion.hpp"
@@ -60,8 +65,7 @@ struct Metavariables {
   static constexpr Options::String help{
       "Find the solution to an XCTS problem."};
 
-  using analytic_solution_fields = tmpl::append<typename system::primal_fields,
-                                                typename system::primal_fluxes>;
+  using analytic_solution_fields = tmpl::append<typename system::primal_fields>;
   using spacetime_quantities_compute = Xcts::Tags::SpacetimeQuantitiesCompute<
       tmpl::list<Xcts::Tags::ConformalFactor<DataVector>,
                  Xcts::Tags::LapseTimesConformalFactor<DataVector>,
@@ -119,15 +123,24 @@ struct Metavariables {
         tmpl::pair<
             elliptic::BoundaryConditions::BoundaryCondition<volume_dim>,
             Xcts::BoundaryConditions::standard_boundary_conditions<system>>,
+        tmpl::pair<::amr::Criterion,
+                   ::amr::Criteria::standard_criteria<
+                       volume_dim, typename system::primal_fields>>,
         tmpl::pair<Event,
                    tmpl::flatten<tmpl::list<
                        Events::Completion,
                        dg::Events::field_observations<
                            volume_dim, observe_fields, observer_compute_tags,
                            LinearSolver::multigrid::Tags::IsFinestGrid>>>>,
-        tmpl::pair<Trigger,
-                   elliptic::Triggers::all_triggers<
-                       typename solver::nonlinear_solver::options_group>>>;
+        tmpl::pair<Trigger, elliptic::Triggers::all_triggers<
+                                ::amr::OptionTags::AmrGroup>>,
+        tmpl::pair<
+            PhaseChange,
+            tmpl::list<
+                PhaseControl::VisitAndReturn<
+                    Parallel::Phase::EvaluateAmrCriteria>,
+                PhaseControl::VisitAndReturn<Parallel::Phase::AdjustDomain>,
+                PhaseControl::VisitAndReturn<Parallel::Phase::CheckDomain>>>>;
   };
 
   // Collect all reduction tags for observers
@@ -143,12 +156,7 @@ struct Metavariables {
       tmpl::push_back<typename solver::register_actions,
                       observers::Actions::RegisterEventsWithObservers>;
 
-  using step_actions = tmpl::list<elliptic::Actions::RunEventsAndTriggers<
-      solver::nonlinear_solver_iteration_id>>;
-
-  using solve_actions =
-      tmpl::push_back<typename solver::template solve_actions<step_actions>,
-                      Parallel::Actions::TerminatePhase>;
+  using solve_actions = typename solver::template solve_actions<tmpl::list<>>;
 
   using dg_element_array = elliptic::DgElementArray<
       Metavariables,
@@ -158,9 +166,18 @@ struct Metavariables {
                      Parallel::Phase::Register,
                      tmpl::push_back<register_actions,
                                      Parallel::Actions::TerminatePhase>>,
-                 Parallel::PhaseActions<Parallel::Phase::Solve, solve_actions>>,
+                 Parallel::PhaseActions<Parallel::Phase::Solve, solve_actions>,
+                 Parallel::PhaseActions<
+                     Parallel::Phase::CheckDomain,
+                     tmpl::list<::amr::Actions::SendAmrDiagnostics,
+                                Parallel::Actions::TerminatePhase>>>,
       LinearSolver::multigrid::ElementsAllocator<
           volume_dim, typename solver::multigrid::options_group>>;
+
+  struct amr : tt::ConformsTo<::amr::protocols::AmrMetavariables> {
+    using element_array = dg_element_array;
+    using projectors = typename solver::amr_projectors;
+  };
 
   struct registration
       : tt::ConformsTo<Parallel::protocols::RegistrationMetavariables> {

--- a/src/Elliptic/SubdomainPreconditioners/MinusLaplacian.hpp
+++ b/src/Elliptic/SubdomainPreconditioners/MinusLaplacian.hpp
@@ -468,6 +468,7 @@ MinusLaplacian<Dim, OptionsGroup, Solver, LinearSolverRegistrars>::solve(
                      << " boundary-condition signatures (one per tensor "
                         "component), but got "
                      << bc_signatures.size() << ".");
+  // Possible optimization: elide when num_components is 1
   for (size_t component = 0; component < num_components; ++component) {
     detail::assign_component(make_not_null(&source_), source, 0, component);
     detail::assign_component(make_not_null(&initial_guess_in_solution_out_),

--- a/src/ParallelAlgorithms/Amr/Actions/AdjustDomain.hpp
+++ b/src/ParallelAlgorithms/Amr/Actions/AdjustDomain.hpp
@@ -243,7 +243,7 @@ struct AdjustDomain {
                                           old_mesh_and_element);
             } catch (std::exception& e) {
               ERROR("Error in AMR projector '"
-                    << pretty_type::short_name<projector>() << "':\n"
+                    << pretty_type::get_name<projector>() << "':\n"
                     << e.what());
             }
           });

--- a/src/ParallelAlgorithms/Amr/Actions/InitializeChild.hpp
+++ b/src/ParallelAlgorithms/Amr/Actions/InitializeChild.hpp
@@ -80,7 +80,13 @@ struct InitializeChild {
     tmpl::for_each<typename Metavariables::amr::projectors>(
         [&box, &parent_items](auto projector_v) {
           using projector = typename decltype(projector_v)::type;
-          db::mutate_apply<projector>(make_not_null(&box), parent_items);
+          try {
+            db::mutate_apply<projector>(make_not_null(&box), parent_items);
+          } catch (std::exception& e) {
+            ERROR("Error in AMR projector '"
+                  << pretty_type::get_name<projector>() << "':\n"
+                  << e.what());
+          }
         });
 
     Parallel::register_element<ParallelComponent>(box, cache, child_id);

--- a/src/ParallelAlgorithms/Amr/Actions/InitializeParent.hpp
+++ b/src/ParallelAlgorithms/Amr/Actions/InitializeParent.hpp
@@ -98,7 +98,13 @@ struct InitializeParent {
     tmpl::for_each<typename Metavariables::amr::projectors>(
         [&box, &children_items](auto projector_v) {
           using projector = typename decltype(projector_v)::type;
-          db::mutate_apply<projector>(make_not_null(&box), children_items);
+          try {
+            db::mutate_apply<projector>(make_not_null(&box), children_items);
+          } catch (std::exception& e) {
+            ERROR("Error in AMR projector '"
+                  << pretty_type::get_name<projector>() << "':\n"
+                  << e.what());
+          }
         });
 
     Parallel::register_element<ParallelComponent>(box, cache, parent_id);

--- a/src/ParallelAlgorithms/Amr/Criteria/CMakeLists.txt
+++ b/src/ParallelAlgorithms/Amr/Criteria/CMakeLists.txt
@@ -25,6 +25,7 @@ spectre_target_headers(
   Criteria.hpp
   Criterion.hpp
   DriveToTarget.hpp
+  Factory.hpp
   IncreaseResolution.hpp
   Loehner.hpp
   Persson.hpp

--- a/src/ParallelAlgorithms/Amr/Criteria/Factory.hpp
+++ b/src/ParallelAlgorithms/Amr/Criteria/Factory.hpp
@@ -1,0 +1,35 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "ParallelAlgorithms/Amr/Criteria/DriveToTarget.hpp"
+#include "ParallelAlgorithms/Amr/Criteria/IncreaseResolution.hpp"
+#include "ParallelAlgorithms/Amr/Criteria/Loehner.hpp"
+#include "ParallelAlgorithms/Amr/Criteria/Persson.hpp"
+#include "ParallelAlgorithms/Amr/Criteria/Random.hpp"
+#include "ParallelAlgorithms/Amr/Criteria/TruncationError.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace amr::Criteria {
+
+/*!
+ * \brief AMR criteria that are generally applicable
+ *
+ * \tparam Dim the spatial dimension
+ * \tparam TensorTags the tensor fields to monitor
+ */
+template <size_t Dim, typename TensorTags>
+using standard_criteria = tmpl::list<
+    // p-AMR criteria
+    ::amr::Criteria::IncreaseResolution<Dim>,
+    ::amr::Criteria::TruncationError<Dim, TensorTags>,
+    // h-AMR criteria
+    ::amr::Criteria::Loehner<Dim, TensorTags>,
+    ::amr::Criteria::Persson<Dim, TensorTags>,
+    // Criteria for testing or experimenting
+    ::amr::Criteria::DriveToTarget<Dim>, ::amr::Criteria::Random>;
+
+}  // namespace amr::Criteria

--- a/src/ParallelAlgorithms/LinearSolver/CMakeLists.txt
+++ b/src/ParallelAlgorithms/LinearSolver/CMakeLists.txt
@@ -19,6 +19,7 @@ target_link_libraries(
   Convergence
   Initialization
   LinearSolver
+  ParallelAmr
   Serialization
   SystemUtilities
   PUBLIC

--- a/src/ParallelAlgorithms/LinearSolver/Gmres/Gmres.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Gmres/Gmres.hpp
@@ -127,6 +127,8 @@ struct Gmres {
 
   using register_element = tmpl::list<>;
 
+  using amr_projectors = initialize_element;
+
   template <typename ApplyOperatorActions,
             typename ObserveActions = tmpl::list<>,
             typename Label = OptionsGroup>

--- a/src/ParallelAlgorithms/LinearSolver/Multigrid/CMakeLists.txt
+++ b/src/ParallelAlgorithms/LinearSolver/Multigrid/CMakeLists.txt
@@ -17,6 +17,7 @@ spectre_target_headers(
   HEADERS
   ElementActions.hpp
   ElementsAllocator.hpp
+  ElementsRegistration.hpp
   Hierarchy.hpp
   Multigrid.hpp
   ObserveVolumeData.hpp

--- a/src/ParallelAlgorithms/LinearSolver/Multigrid/ElementsRegistration.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Multigrid/ElementsRegistration.hpp
@@ -1,0 +1,252 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+/// \file
+/// The parallel component and actions in this file keep track of all element
+/// IDs during AMR and update the array sections for the multigrid hierarchy.
+
+#pragma once
+
+#include <algorithm>
+#include <charm++.h>
+#include <cstddef>
+#include <optional>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include "Domain/Structure/ElementId.hpp"
+#include "Parallel/AlgorithmExecution.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "Parallel/Local.hpp"
+#include "Parallel/Printf.hpp"
+#include "Parallel/Protocols/ElementRegistrar.hpp"
+#include "Parallel/Section.hpp"
+#include "Parallel/Tags/Section.hpp"
+#include "ParallelAlgorithms/Amr/Protocols/Projector.hpp"
+#include "ParallelAlgorithms/LinearSolver/Multigrid/Tags.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace LinearSolver::multigrid {
+
+namespace Tags {
+// All element IDs grouped by multigrid level are stored in this tag on the
+// singleton component below. The element IDs are registered and deregistered
+// during AMR.
+template <size_t Dim>
+struct AllElementIds : db::SimpleTag {
+  using type = std::unordered_map<size_t, std::unordered_set<ElementId<Dim>>>;
+};
+}  // namespace Tags
+
+namespace detail {
+
+// The projector for the sections does nothing, as the sections are updated by a
+// simple action broadcast below.
+template <typename Metavariables>
+struct ProjectMultigridSections : tt::ConformsTo<amr::protocols::Projector> {
+ private:
+  using element_array = typename Metavariables::amr::element_array;
+
+ public:
+  using argument_tags = tmpl::list<>;
+  using return_tags =
+      tmpl::list<Parallel::Tags::Section<element_array, Tags::MultigridLevel>,
+                 Parallel::Tags::Section<element_array, Tags::IsFinestGrid>>;
+
+  template <typename AmrData>
+  static void apply(
+      const gsl::not_null<std::optional<
+          Parallel::Section<element_array, Tags::MultigridLevel>>*>
+      /*multigrid_level_section*/,
+      const gsl::not_null<
+          std::optional<Parallel::Section<element_array, Tags::IsFinestGrid>>*>
+      /*finest_grid_section*/,
+      const AmrData& /*amr_data*/) {}
+};
+
+template <size_t Dim>
+struct InitializeElementsRegistration {
+  using simple_tags = tmpl::list<Tags::AllElementIds<Dim>>;
+  using compute_tags = tmpl::list<>;
+
+  template <typename DbTagsList, typename... InboxTags, typename ArrayIndex,
+            typename Metavariables, typename ActionList,
+            typename ParallelComponent>
+  static Parallel::iterable_action_return_t apply(
+      db::DataBox<DbTagsList>& /*box*/,
+      const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+      const Parallel::GlobalCache<Metavariables>& /*cache*/,
+      const ArrayIndex& /*array_index*/, const ActionList /*meta*/,
+      const ParallelComponent* const /*meta*/) {
+    return {Parallel::AlgorithmExecution::Pause, std::nullopt};
+  }
+};
+
+struct RegisterOrDeregisterElement {
+  template <typename ParallelComponent, typename DbTagsList,
+            typename Metavariables, typename ArrayIndex, size_t Dim>
+  static void apply(db::DataBox<DbTagsList>& box,
+                    const Parallel::GlobalCache<Metavariables>& /*cache*/,
+                    const ArrayIndex& /*array_index*/,
+                    const ElementId<Dim>& element_id,
+                    const bool register_or_deregister) {
+    db::mutate<Tags::AllElementIds<Dim>>(
+        [&element_id, register_or_deregister](const auto all_element_ids) {
+          auto& element_ids = (*all_element_ids)[element_id.grid_index()];
+          if (register_or_deregister) {
+            element_ids.insert(element_id);
+          } else {
+            element_ids.erase(element_id);
+          }
+        },
+        make_not_null(&box));
+  }
+};
+
+struct UpdateSectionsOnElement {
+  template <typename ParallelComponent, typename DbTagsList,
+            typename Metavariables, size_t Dim>
+  static void apply(
+      db::DataBox<DbTagsList>& box,
+      const Parallel::GlobalCache<Metavariables>& /*cache*/,
+      const ElementId<Dim>& element_id,
+      Parallel::Section<ParallelComponent, Tags::MultigridLevel>
+          multigrid_level_section,
+      std::optional<Parallel::Section<ParallelComponent, Tags::IsFinestGrid>>
+          finest_grid_section) {
+    if (multigrid_level_section.id() != element_id.grid_index()) {
+      // Discard broadcast to elements that are not part of the section. This
+      // happens because we broadcast to all elements, not just to the section.
+      // Broadcasting to the section fails with a segfault for some reason.
+      return;
+    }
+    db::mutate<Parallel::Tags::Section<ParallelComponent, Tags::MultigridLevel>,
+               Parallel::Tags::Section<ParallelComponent, Tags::IsFinestGrid>>(
+        [&multigrid_level_section, &finest_grid_section](
+            const auto stored_multigrid_level_section,
+            const auto stored_finest_grid_section) {
+          *stored_multigrid_level_section = std::move(multigrid_level_section);
+          *stored_finest_grid_section = std::move(finest_grid_section);
+        },
+        make_not_null(&box));
+  }
+};
+
+template <size_t Dim, typename ElementArray, typename OptionsGroup>
+struct UpdateSections {
+  template <typename DbTagList, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent>
+  static Parallel::iterable_action_return_t apply(
+      db::DataBox<DbTagList>& box,
+      const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+      Parallel::GlobalCache<Metavariables>& cache,
+      const ArrayIndex& /*array_index*/, const ActionList /*meta*/,
+      const ParallelComponent* const /*meta*/) {
+    const auto& all_element_ids = db::get<Tags::AllElementIds<Dim>>(box);
+    auto& element_array = Parallel::get_parallel_component<ElementArray>(cache);
+    for (const auto& [multigrid_level, element_ids] : all_element_ids) {
+      Parallel::printf("%s level %zu has %zu elements.\n",
+                       pretty_type::name<OptionsGroup>(), multigrid_level,
+                       element_ids.size());
+      std::vector<CkArrayIndex> array_indices(element_ids.size());
+      std::transform(
+          element_ids.begin(), element_ids.end(), array_indices.begin(),
+          [](const ElementId<Dim>& local_element_id) {
+            return Parallel::ArrayIndex<ElementId<Dim>>(local_element_id);
+          });
+      using MultigridLevelSection =
+          Parallel::Section<ElementArray, Tags::MultigridLevel>;
+      const MultigridLevelSection multigrid_level_section{
+          multigrid_level, MultigridLevelSection::cproxy_section::ckNew(
+                               element_array.ckGetArrayID(),
+                               array_indices.data(), array_indices.size())};
+      using FinestGridSection =
+          Parallel::Section<ElementArray, Tags::IsFinestGrid>;
+      const std::optional<FinestGridSection> finest_grid_section =
+          multigrid_level == 0
+              ? std::make_optional(FinestGridSection{
+                    true, FinestGridSection::cproxy_section::ckNew(
+                              element_array.ckGetArrayID(),
+                              array_indices.data(), array_indices.size())})
+              : std::nullopt;
+      // Send new sections to all elements. Broadcasting to the section fails
+      // with a segfault for some reason.
+      Parallel::simple_action<UpdateSectionsOnElement>(
+          element_array, multigrid_level_section, finest_grid_section);
+    }
+    return {Parallel::AlgorithmExecution::Pause, std::nullopt};
+  }
+};
+
+template <typename Metavariables, typename OptionsGroup>
+struct ElementsRegistrationComponent {
+  using chare_type = Parallel::Algorithms::Singleton;
+  using const_global_cache_tags = tmpl::list<>;
+  using metavariables = Metavariables;
+  static constexpr size_t Dim = metavariables::volume_dim;
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<Parallel::Phase::Initialization,
+                             tmpl::list<InitializeElementsRegistration<Dim>>>,
+      Parallel::PhaseActions<
+          // Update sections in the `CheckDomain` phase, which runs after the
+          // AMR phase.
+          Parallel::Phase::CheckDomain,
+          tmpl::list<UpdateSections<
+              Dim, typename metavariables::amr::element_array, OptionsGroup>>>>;
+  using simple_tags_from_options = Parallel::get_simple_tags_from_options<
+      Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
+
+  static void execute_next_phase(
+      const Parallel::Phase next_phase,
+      Parallel::CProxy_GlobalCache<Metavariables>& global_cache) {
+    auto& local_cache = *Parallel::local_branch(global_cache);
+    Parallel::get_parallel_component<ElementsRegistrationComponent>(local_cache)
+        .start_phase(next_phase);
+  }
+};
+
+template <size_t Dim, typename OptionsGroup>
+struct RegisterElement : tt::ConformsTo<Parallel::protocols::ElementRegistrar> {
+ public:  // ElementRegistrar protocol
+  template <typename ParallelComponent, typename DbTagList,
+            typename Metavariables>
+  static void perform_registration(const db::DataBox<DbTagList>& /*box*/,
+                                   Parallel::GlobalCache<Metavariables>& cache,
+                                   const ElementId<Dim>& element_id) {
+    Parallel::simple_action<RegisterOrDeregisterElement>(
+        Parallel::get_parallel_component<
+            ElementsRegistrationComponent<Metavariables, OptionsGroup>>(cache),
+        element_id, true);
+  }
+
+  template <typename ParallelComponent, typename DbTagList,
+            typename Metavariables>
+  static void perform_deregistration(
+      const db::DataBox<DbTagList>& /*box*/,
+      Parallel::GlobalCache<Metavariables>& cache,
+      const ElementId<Dim>& element_id) {
+    Parallel::simple_action<RegisterOrDeregisterElement>(
+        Parallel::get_parallel_component<
+            ElementsRegistrationComponent<Metavariables, OptionsGroup>>(cache),
+        element_id, false);
+  }
+
+ public:  // Iterable action
+  template <typename DbTagList, typename... InboxTags, typename Metavariables,
+            typename ActionList, typename ParallelComponent>
+  static Parallel::iterable_action_return_t apply(
+      db::DataBox<DbTagList>& box,
+      const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+      Parallel::GlobalCache<Metavariables>& cache,
+      const ElementId<Dim>& element_id, const ActionList /*meta*/,
+      const ParallelComponent* const /*meta*/) {
+    perform_registration<ParallelComponent>(box, cache, element_id);
+    return {Parallel::AlgorithmExecution::Continue, std::nullopt};
+  }
+};
+
+}  // namespace detail
+}  // namespace LinearSolver::multigrid

--- a/src/ParallelAlgorithms/LinearSolver/Multigrid/Multigrid.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Multigrid/Multigrid.hpp
@@ -142,6 +142,10 @@ struct Multigrid {
       async_solvers::InitializeElement<FieldsTag, OptionsGroup, SourceTag>,
       detail::InitializeElement<Dim, FieldsTag, OptionsGroup, SourceTag>>;
 
+  using amr_projectors =
+      tmpl::list<initialize_element,
+                 detail::ProjectMultigridSections<Metavariables>>;
+
   using register_element =
       tmpl::list<detail::RegisterElement<Dim, OptionsGroup>,
                  async_solvers::RegisterElement<FieldsTag, OptionsGroup,

--- a/src/ParallelAlgorithms/LinearSolver/Multigrid/Multigrid.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Multigrid/Multigrid.hpp
@@ -11,6 +11,7 @@
 #include "ParallelAlgorithms/Actions/Goto.hpp"
 #include "ParallelAlgorithms/LinearSolver/AsynchronousSolvers/ElementActions.hpp"
 #include "ParallelAlgorithms/LinearSolver/Multigrid/ElementActions.hpp"
+#include "ParallelAlgorithms/LinearSolver/Multigrid/ElementsRegistration.hpp"
 #include "ParallelAlgorithms/LinearSolver/Multigrid/ObserveVolumeData.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -109,12 +110,19 @@ struct VcycleUpLabel {};
  * top-most finest grid (the "original" grid that represents the overall
  * solution) the algorithm applies the smoothing and the corrections from the
  * coarser grids directly to the solution fields.
+ *
+ * \par AMR
+ * AMR is not yet fully supported by the multigrid solver. When AMR is enabled,
+ * only a single multigrid level can be used (the finest grid). To support AMR
+ * fully, we have to send AMR decisions to coarser grids to refine those as
+ * well.
  */
-template <size_t Dim, typename FieldsTag, typename OptionsGroup,
+template <typename Metavariables, typename FieldsTag, typename OptionsGroup,
           typename ResidualIsMassiveTag,
           typename SourceTag =
               db::add_tag_prefix<::Tags::FixedSource, FieldsTag>>
 struct Multigrid {
+  static constexpr size_t Dim = Metavariables::volume_dim;
   using fields_tag = FieldsTag;
   using options_group = OptionsGroup;
   using source_tag = SourceTag;
@@ -124,7 +132,8 @@ struct Multigrid {
   using smooth_source_tag = source_tag;
   using smooth_fields_tag = fields_tag;
 
-  using component_list = tmpl::list<>;
+  using component_list = tmpl::list<
+      detail::ElementsRegistrationComponent<Metavariables, OptionsGroup>>;
 
   using observed_reduction_data_tags = observers::make_reduction_data_tags<
       tmpl::list<async_solvers::reduction_data>>;
@@ -134,7 +143,8 @@ struct Multigrid {
       detail::InitializeElement<Dim, FieldsTag, OptionsGroup, SourceTag>>;
 
   using register_element =
-      tmpl::list<async_solvers::RegisterElement<FieldsTag, OptionsGroup,
+      tmpl::list<detail::RegisterElement<Dim, OptionsGroup>,
+                 async_solvers::RegisterElement<FieldsTag, OptionsGroup,
                                                 SourceTag, Tags::IsFinestGrid>,
                  observers::Actions::RegisterWithObservers<
                      detail::RegisterWithVolumeObserver<OptionsGroup>>>;

--- a/src/ParallelAlgorithms/LinearSolver/Schwarz/CMakeLists.txt
+++ b/src/ParallelAlgorithms/LinearSolver/Schwarz/CMakeLists.txt
@@ -44,6 +44,7 @@ target_link_libraries(
   Observer
   Options
   Parallel
+  ParallelAmr
   ParallelLinearSolver
   Spectral
   )

--- a/src/ParallelAlgorithms/LinearSolver/Schwarz/ElementCenteredSubdomainData.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Schwarz/ElementCenteredSubdomainData.hpp
@@ -85,6 +85,16 @@ struct ElementCenteredSubdomainData {
       element_data.initialize(
           used_for_size.element_data.number_of_grid_points());
     }
+    // Erase overlaps that don't exist in `used_for_size`
+    for (auto it = overlap_data.cbegin(); it != overlap_data.cend();) {
+      if (used_for_size.overlap_data.find(it->first) ==
+          used_for_size.overlap_data.end()) {
+        it = overlap_data.erase(it);
+      } else {
+        ++it;
+      }
+    }
+    // Insert or resize overlaps to match `used_for_size`
     for (const auto& [overlap_id, used_for_overlap_size] :
          used_for_size.overlap_data) {
       if (UNLIKELY(overlap_data[overlap_id].number_of_grid_points() !=

--- a/src/ParallelAlgorithms/LinearSolver/Schwarz/Schwarz.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Schwarz/Schwarz.hpp
@@ -172,6 +172,8 @@ struct Schwarz {
       detail::InitializeElement<FieldsTag, OptionsGroup, SubdomainOperator,
                                 SubdomainPreconditioners>>;
 
+  using amr_projectors = initialize_element;
+
   using register_element =
       tmpl::list<async_solvers::RegisterElement<FieldsTag, OptionsGroup,
                                                 SourceTag, ArraySectionIdTag>,

--- a/src/ParallelAlgorithms/NonlinearSolver/CMakeLists.txt
+++ b/src/ParallelAlgorithms/NonlinearSolver/CMakeLists.txt
@@ -27,6 +27,7 @@ target_link_libraries(
   Observer
   Options
   Parallel
+  ParallelAmr
   ParallelLinearSolver
   Serialization
   SystemUtilities

--- a/src/ParallelAlgorithms/NonlinearSolver/NewtonRaphson/NewtonRaphson.hpp
+++ b/src/ParallelAlgorithms/NonlinearSolver/NewtonRaphson/NewtonRaphson.hpp
@@ -99,6 +99,8 @@ struct NewtonRaphson {
 
   using register_element = tmpl::list<>;
 
+  using amr_projectors = initialize_element;
+
   template <typename ApplyNonlinearOperator, typename SolveLinearization,
             typename ObserveActions = tmpl::list<>,
             typename Label = OptionsGroup>

--- a/support/Pipelines/Bbh/InitialData.yaml
+++ b/support/Pipelines/Bbh/InitialData.yaml
@@ -95,6 +95,18 @@ DomainCreator:
       Envelope:       [{{ P + 1}}, {{ P + 1}}, {{ P + 1}}]
       OuterShell:     [{{ P + 1}}, {{ P + 1}}, {{ P + 1}}]
 
+Amr:
+  Verbosity: Verbose
+  Criteria: []
+  Policies:
+    Isotropy: Anisotropic
+    Limits:
+      NumGridPoints: Auto
+      RefinementLevel: Auto
+  Iterations: 1
+
+PhaseChangeAndTriggers: []
+
 Discretization:
   DiscontinuousGalerkin:
     PenaltyParameter: 1.
@@ -111,9 +123,9 @@ NonlinearSolver:
     ConvergenceCriteria:
       MaxIterations: 20
       RelativeResidual: 0.
-      AbsoluteResidual: 1.e-10
+      AbsoluteResidual: 1.e-8
     SufficientDecrease: 1.e-4
-    MaxGlobalizationSteps: 40
+    MaxGlobalizationSteps: 10
     DampingFactor: 1.
     Verbosity: Verbose
 
@@ -122,7 +134,7 @@ LinearSolver:
     ConvergenceCriteria:
       MaxIterations: 100
       RelativeResidual: 1.e-3
-      AbsoluteResidual: 1.e-11
+      AbsoluteResidual: 1.e-10
     Verbosity: Quiet
 
   Multigrid:

--- a/tests/InputFiles/Elasticity/BentBeam.yaml
+++ b/tests/InputFiles/Elasticity/BentBeam.yaml
@@ -105,7 +105,17 @@ EventsAndTriggers:
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double]
 
-PhaseChangeAndTriggers:
+Amr:
+  Verbosity: Quiet
+  Criteria: []
+  Policies:
+    Isotropy: Anisotropic
+    Limits:
+      NumGridPoints: Auto
+      RefinementLevel: Auto
+  Iterations: 1
+
+PhaseChangeAndTriggers: []
 
 BuildMatrix:
   MatrixSubfileName: Matrix

--- a/tests/InputFiles/Elasticity/HalfSpaceMirror.yaml
+++ b/tests/InputFiles/Elasticity/HalfSpaceMirror.yaml
@@ -143,7 +143,17 @@ EventsAndTriggers:
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double]
 
-PhaseChangeAndTriggers:
+Amr:
+  Verbosity: Quiet
+  Criteria: []
+  Policies:
+    Isotropy: Anisotropic
+    Limits:
+      NumGridPoints: Auto
+      RefinementLevel: Auto
+  Iterations: 1
+
+PhaseChangeAndTriggers: []
 
 BuildMatrix:
   MatrixSubfileName: Matrix

--- a/tests/InputFiles/Elasticity/SingleCoatingMirror.yaml
+++ b/tests/InputFiles/Elasticity/SingleCoatingMirror.yaml
@@ -160,7 +160,17 @@ EventsAndTriggers:
           CoordinatesFloatingPointType: Float
           FloatingPointTypes: [Float]
 
-PhaseChangeAndTriggers:
+Amr:
+  Verbosity: Quiet
+  Criteria: []
+  Policies:
+    Isotropy: Anisotropic
+    Limits:
+      NumGridPoints: Auto
+      RefinementLevel: Auto
+  Iterations: 1
+
+PhaseChangeAndTriggers: []
 
 Parallelization:
   ElementDistribution: NumGridPoints

--- a/tests/InputFiles/Poisson/Lorentzian.yaml
+++ b/tests/InputFiles/Poisson/Lorentzian.yaml
@@ -4,7 +4,7 @@
 Executable: SolvePoisson3D
 Testing:
   Check: parse;execute_check_output
-  Timeout: 40
+  Timeout: 60
   Priority: High
 ExpectedOutput:
   - LorentzianReductions.h5
@@ -14,21 +14,11 @@ OutputFileChecks:
     Subfile: ErrorNorms.dat
     FileGlob: LorentzianReductions.h5
     ExpectedData:
-      - [6, 2808, 2.09439617691359e+34, 4.06585234592450e-02]
+      - [0, 1625, 3.14162705992265e+34, 1.28010014008500e-01]
+      - [1, 1625, 3.14162705992265e+34, 7.44115187323337e-02]
+      - [2, 2808, 2.09439617691359e+34, 1.40173310841862e-02]
     AbsoluteTolerance: 0.
-    RelativeTolerance: 1e-12
-  - Label: Linear solver convergence
-    Subfile: GmresResiduals.dat
-    FileGlob: LorentzianReductions.h5
-    ExpectedData:
-      - [0, 1.65600110447685e+00]
-      - [1, 2.10813044818694e-01]
-      - [2, 1.78150596490335e-01]
-      - [3, 1.49290348080966e-01]
-      - [4, 1.67729890706225e-02]
-      - [5, 1.99526909375260e-03]
-      - [6, 3.92043529725646e-04]
-    AbsoluteTolerance: 1e-10
+    RelativeTolerance: 1e-4
 
 ---
 
@@ -42,12 +32,12 @@ RandomizeInitialGuess: None
 
 DomainCreator:
   Sphere:
-    InnerRadius: 10
+    InnerRadius: 5.
     OuterRadius: &outer_radius 1e9
     Interior:
       FillWithSphericity: 0.
     InitialRefinement: 0
-    InitialGridPoints: 6
+    InitialGridPoints: 5
     UseEquiangularMap: True
     EquatorialCompression: None
     RadialPartitioning: [&outer_shell_inner_radius 20.]
@@ -58,6 +48,28 @@ DomainCreator:
       AnalyticSolution:
         Solution: *solution
         Field: Dirichlet
+
+Amr:
+  Verbosity: Verbose
+  Criteria:
+    - IncreaseResolution
+  Policies:
+    Isotropy: Anisotropic
+    Limits:
+      NumGridPoints: Auto
+      RefinementLevel: Auto
+  Iterations: 2
+
+PhaseChangeAndTriggers:
+  # Run AMR in every iteration, but not on the initial guess
+  - Trigger:
+      EveryNIterations:
+        N: 1
+        Offset: 1
+    PhaseChanges:
+      - VisitAndReturn(EvaluateAmrCriteria)
+      - VisitAndReturn(AdjustDomain)
+      - VisitAndReturn(CheckDomain)
 
 Discretization:
   DiscontinuousGalerkin:
@@ -73,9 +85,9 @@ Observers:
 LinearSolver:
   Gmres:
     ConvergenceCriteria:
-      MaxIterations: 10
+      MaxIterations: 100
       RelativeResidual: 0.
-      AbsoluteResidual: 1.e-3
+      AbsoluteResidual: 1.e-5
     Verbosity: Quiet
 
   Multigrid:
@@ -84,7 +96,7 @@ LinearSolver:
     PreSmoothing: True
     PostSmoothingAtBottom: False
     Verbosity: Silent
-    OutputVolumeData: True
+    OutputVolumeData: False
 
   SchwarzSmoother:
     Iterations: 3
@@ -101,7 +113,7 @@ RadiallyCompressedCoordinates:
   Compression: *outer_shell_distribution
 
 EventsAndTriggers:
-  - Trigger: HasConverged
+  - Trigger: Always
     Events:
       - ObserveNorms:
           SubfileName: ErrorNorms
@@ -119,8 +131,6 @@ EventsAndTriggers:
           InterpolateToMesh: None
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double]
-
-PhaseChangeAndTriggers:
 
 BuildMatrix:
   MatrixSubfileName: Matrix

--- a/tests/InputFiles/Poisson/ProductOfSinusoids1D.yaml
+++ b/tests/InputFiles/Poisson/ProductOfSinusoids1D.yaml
@@ -10,22 +10,44 @@ ExpectedOutput:
   - PoissonProductOfSinusoids1DVolume0.h5
   - SubdomainMatrix_[B0,(L1I0)].txt
   - SubdomainMatrix_[B0,(L1I1)].txt
+  - SubdomainMatrix_[B0,(L2I0)].txt
+  - SubdomainMatrix_[B0,(L2I1)].txt
+  - SubdomainMatrix_[B0,(L2I2)].txt
+  - SubdomainMatrix_[B0,(L2I3)].txt
 OutputFileChecks:
   - Label: Discretization error
     Subfile: ErrorNorms.dat
     FileGlob: PoissonProductOfSinusoids1DReductions.h5
     ExpectedData:
-      - [3, 8, 4.71238898038469e+00, 4.14037391064113e-03]
-    AbsoluteTolerance: 1e-12
+      - [0, 8, 4.71238898038469e+00, 7.07106781186548e-01]
+      - [1, 8, 4.71238898038469e+00, 4.14037391064113e-03]
+      - [2, 16, 4.71238898038469e+00, 1.96421037243931e-04]
+      - [3, 20, 4.71238898038469e+00, 1.47125554015345e-05]
+    AbsoluteTolerance: 1e-8
   - Label: Linear solver convergence
     Subfile: GmresResiduals.dat
     FileGlob: PoissonProductOfSinusoids1DReductions.h5
     ExpectedData:
+      # AMR iteration 0
       - [0, 1.21812092038592e+01]
-      - [1, 1.57971714780159e-03]
-      - [2, 2.51555146884164e-07]
-      - [3, 0.]
-    AbsoluteTolerance: 1e-12
+      - [1, 2.13145442174570e-01]
+      - [2, 5.92367126759950e-03]
+      - [3, 3.20539282132934e-08]
+      # AMR iteration 1
+      - [0, 2.09447729412913e-01]
+      - [1, 2.46546953964650e-03]
+      - [2, 8.48550910654618e-04]
+      - [3, 2.44047574357982e-04]
+      - [4, 2.63835241157592e-05]
+      - [5, 2.07844911429961e-07]
+      # AMR iteration 2
+      - [0, 3.15882858760581e-02]
+      - [1, 7.82175835835042e-04]
+      - [2, 1.13099440899420e-04]
+      - [3, 5.55444538380480e-05]
+      - [4, 1.11628047012794e-05]
+      - [5, 1.65458379564807e-08]
+    AbsoluteTolerance: 1e-8
 
 ---
 
@@ -64,6 +86,40 @@ DomainCreator:
           Solution: *solution
           Field: Neumann
 
+Amr:
+  Verbosity: Debug
+  Criteria:
+    - DriveToTarget:
+        # First AMR iteration will split the 2 elements in 4
+        TargetRefinementLevels: [2]
+        # Second AMR iteration will increase num points from 4 to 5
+        TargetNumberOfGridPoints: [5]
+        OscillationAtTarget: [DoNothing]
+  Policies:
+    Isotropy: Anisotropic
+    Limits:
+      NumGridPoints: Auto
+      RefinementLevel: Auto
+  Iterations: 3
+
+PhaseChangeAndTriggers:
+  # Build explicit matrix representation for initial domain
+  - Trigger:
+      EveryNIterations:
+        N: 100
+        Offset: 0
+    PhaseChanges:
+      - VisitAndReturn(BuildMatrix)
+  # Run AMR in every iteration, but not on the initial guess
+  - Trigger:
+      EveryNIterations:
+        N: 1
+        Offset: 1
+    PhaseChanges:
+      - VisitAndReturn(EvaluateAmrCriteria)
+      - VisitAndReturn(AdjustDomain)
+      - VisitAndReturn(CheckDomain)
+
 Discretization:
   DiscontinuousGalerkin:
     PenaltyParameter: 1.
@@ -78,23 +134,23 @@ Observers:
 LinearSolver:
   Gmres:
     ConvergenceCriteria:
-      MaxIterations: 3
+      MaxIterations: 10
       RelativeResidual: 1.e-10
-      AbsoluteResidual: 1.e-10
+      AbsoluteResidual: 1.e-6
     Verbosity: Verbose
 
   Multigrid:
     Iterations: 1
-    MaxLevels: Auto
+    MaxLevels: 1
     PreSmoothing: True
     PostSmoothingAtBottom: False
-    Verbosity: Quiet
+    Verbosity: Silent
     OutputVolumeData: True
 
   SchwarzSmoother:
     Iterations: 3
     MaxOverlap: 2
-    Verbosity: Quiet
+    Verbosity: Silent
     SubdomainSolver:
       ExplicitInverse:
         WriteMatrixToFile: "SubdomainMatrix"
@@ -103,7 +159,7 @@ LinearSolver:
 RadiallyCompressedCoordinates: None
 
 EventsAndTriggers:
-  - Trigger: HasConverged
+  - Trigger: Always
     Events:
       - ObserveNorms:
           SubfileName: ErrorNorms
@@ -117,11 +173,6 @@ EventsAndTriggers:
           InterpolateToMesh: None
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double]
-
-PhaseChangeAndTriggers:
-  - Trigger: Always
-    PhaseChanges:
-      - VisitAndReturn(BuildMatrix)
 
 BuildMatrix:
   MatrixSubfileName: Matrix

--- a/tests/InputFiles/Poisson/ProductOfSinusoids2D.yaml
+++ b/tests/InputFiles/Poisson/ProductOfSinusoids2D.yaml
@@ -107,7 +107,17 @@ EventsAndTriggers:
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double]
 
-PhaseChangeAndTriggers:
+Amr:
+  Verbosity: Quiet
+  Criteria: []
+  Policies:
+    Isotropy: Anisotropic
+    Limits:
+      NumGridPoints: Auto
+      RefinementLevel: Auto
+  Iterations: 1
+
+PhaseChangeAndTriggers: []
 
 BuildMatrix:
   MatrixSubfileName: Matrix

--- a/tests/InputFiles/Poisson/ProductOfSinusoids3D.yaml
+++ b/tests/InputFiles/Poisson/ProductOfSinusoids3D.yaml
@@ -116,7 +116,17 @@ EventsAndTriggers:
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double]
 
-PhaseChangeAndTriggers:
+Amr:
+  Verbosity: Quiet
+  Criteria: []
+  Policies:
+    Isotropy: Anisotropic
+    Limits:
+      NumGridPoints: Auto
+      RefinementLevel: Auto
+  Iterations: 1
+
+PhaseChangeAndTriggers: []
 
 BuildMatrix:
   MatrixSubfileName: Matrix

--- a/tests/InputFiles/Punctures/MultiplePunctures.yaml
+++ b/tests/InputFiles/Punctures/MultiplePunctures.yaml
@@ -4,7 +4,7 @@
 Executable: SolvePunctures
 Testing:
   Check: parse;execute
-  Timeout: 20
+  Timeout: 40
   Priority: High
 ExpectedOutput:
   - PuncturesReductions.h5
@@ -14,16 +14,22 @@ OutputFileChecks:
     Subfile: VolumeIntegrals.dat
     FileGlob: PuncturesReductions.h5
     ExpectedData:
-      - [3, 448, 4.18881285829836e+03, 4.20735900800792e-02]
+      - [0, 448, 4.18881285829836e+03, 4.55724627651079e-02]
+      - [1, 448, 4.18881285829836e+03, 4.19621052692138e-02]
+      - [2, 1262, 4.18883545625731e+03, 5.07147168589194e-02]
     AbsoluteTolerance: 1e-12
   - Label: Nonlinear solver convergence
     Subfile: NewtonRaphsonResiduals.dat
     FileGlob: PuncturesReductions.h5
     ExpectedData:
-      - [0, 0, 7.19994010733799e-02, 1.]
-      - [1, 0, 3.39170331580851e-04, 1.]
-      - [2, 0, 5.94195185937208e-09, 1.]
-      - [3, 0, 0., 1.]
+      # AMR iteration 0
+      - [0, 0, 7.32123992463425e-02, 1.]
+      - [1, 0, 3.51364804783180e-04, 1.]
+      - [2, 0, 6.28169780068392e-09, 1.]
+      # AMR iteration 1
+      - [0, 0, 1.10970183155322e-01, 1.]
+      - [0, 0, 3.36432810360753e-05, 1.]
+      - [0, 0, 1.05116741194963e-09, 1.]
     AbsoluteTolerance: 1e-12
 
 ---
@@ -38,7 +44,8 @@ ResourceInfo:
 Background:
   MultiplePunctures:
     Punctures:
-      - Position: [0., 0., 0.]
+      # Offset from center so the puncture doesn't coincide with a grid point
+      - Position: [0.1, 0.1, 0.1]
         Mass: 1.
         Momentum: [0., 0., 0.]
         Spin: [0.1, 0.2, 0.3]
@@ -63,6 +70,30 @@ DomainCreator:
     TimeDependentMaps: None
     OuterBoundaryCondition: Flatness
 
+Amr:
+  Verbosity: Verbose
+  Criteria:
+    # h-refine (split) elements at the punctures, and p-refine everywhere else
+    - RefineAtPunctures
+    - IncreaseResolution
+  Policies:
+    Isotropy: Anisotropic
+    Limits:
+      NumGridPoints: Auto
+      RefinementLevel: Auto
+  Iterations: 2
+
+PhaseChangeAndTriggers:
+  # Run AMR in every iteration, but not on the initial guess
+  - Trigger:
+      EveryNIterations:
+        N: 1
+        Offset: 1
+    PhaseChanges:
+      - VisitAndReturn(EvaluateAmrCriteria)
+      - VisitAndReturn(AdjustDomain)
+      - VisitAndReturn(CheckDomain)
+
 Discretization:
   DiscontinuousGalerkin:
     PenaltyParameter: 1.
@@ -79,7 +110,7 @@ NonlinearSolver:
     ConvergenceCriteria:
       MaxIterations: 20
       RelativeResidual: 0.
-      AbsoluteResidual: 1.e-10
+      AbsoluteResidual: 1.e-8
     SufficientDecrease: 1.e-4
     MaxGlobalizationSteps: 40
     DampingFactor: 1.
@@ -95,7 +126,7 @@ LinearSolver:
 
   Multigrid:
     Iterations: 1
-    MaxLevels: Auto
+    MaxLevels: 1
     PreSmoothing: True
     PostSmoothingAtBottom: False
     Verbosity: Silent
@@ -125,7 +156,7 @@ LinearSolver:
 RadiallyCompressedCoordinates: None
 
 EventsAndTriggers:
-  - Trigger: HasConverged
+  - Trigger: Always
     Events:
       - ObserveFields:
           SubfileName: VolumeData

--- a/tests/InputFiles/Xcts/BinaryBlackHole.yaml
+++ b/tests/InputFiles/Xcts/BinaryBlackHole.yaml
@@ -26,18 +26,45 @@ OutputFileChecks:
           1.29835755854743e-03,
           1.26478484974052e-03,
         ]
+      - [
+          5,
+          20304,
+          1.74532762048460e+33,
+          1.10996259399346e+00,
+          8.68051629831159e-01,
+          6.28127905852040e-01,
+          4.94959532218436e-03,
+          1.25936870550045e-03,
+          1.29835755854743e-03,
+          1.26478484974052e-03,
+        ]
+      - [
+          5,
+          20304,
+          1.74532762048460e+33,
+          1.10996259399346e+00,
+          8.68051629831159e-01,
+          6.28127905852040e-01,
+          4.94959532218436e-03,
+          1.25936870550045e-03,
+          1.29835755854743e-03,
+          1.26478484974052e-03,
+        ]
     AbsoluteTolerance: 0.
     RelativeTolerance: 1e-9
   - Label: Nonlinear solver convergence
     Subfile: NewtonRaphsonResiduals.dat
     FileGlob: BbhReductions.h5
     ExpectedData:
+      # AMR iteration 0
       - [0, 0, 9.58836468792872e+00, 1.]
       - [1, 0, 2.56744819082553e+00, 1.]
       - [2, 0, 6.92792186565806e-03, 1.]
       - [3, 0, 1.21895158596328e-03, 1.]
       - [4, 0, 7.97507362468631e-07, 1.]
       - [5, 0, 7.12541536160998e-10, 1.]
+      # AMR iteration 1
+
     AbsoluteTolerance: 1e-6
 
 ---
@@ -122,6 +149,18 @@ DomainCreator:
       Envelope:       [6, 6, 6]
       OuterShell:     [6, 6, 6]
 
+Amr:
+  Verbosity: Verbose
+  Criteria: []
+  Policies:
+    Isotropy: Anisotropic
+    Limits:
+      NumGridPoints: Auto
+      RefinementLevel: Auto
+  Iterations: 1
+
+PhaseChangeAndTriggers: []
+
 Discretization:
   DiscontinuousGalerkin:
     PenaltyParameter: 1.
@@ -187,7 +226,7 @@ RadiallyCompressedCoordinates:
   Compression: *outer_shell_distribution
 
 EventsAndTriggers:
-  - Trigger: HasConverged
+  - Trigger: Always
     Events:
       - ObserveNorms:
           SubfileName: Norms

--- a/tests/InputFiles/Xcts/HeadOnBns.yaml
+++ b/tests/InputFiles/Xcts/HeadOnBns.yaml
@@ -218,3 +218,15 @@ EventsAndTriggers:
           InterpolateToMesh: None
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double]
+
+Amr:
+  Verbosity: Quiet
+  Criteria: []
+  Policies:
+    Isotropy: Anisotropic
+    Limits:
+      NumGridPoints: Auto
+      RefinementLevel: Auto
+  Iterations: 1
+
+PhaseChangeAndTriggers: []

--- a/tests/InputFiles/Xcts/KerrSchild.yaml
+++ b/tests/InputFiles/Xcts/KerrSchild.yaml
@@ -4,7 +4,7 @@
 Executable: SolveXcts
 Testing:
   Check: parse;execute_check_output
-  Timeout: 40
+  Timeout: 90
   Priority: High
 ExpectedOutput:
   - KerrSchildReductions.h5
@@ -15,27 +15,45 @@ OutputFileChecks:
     FileGlob: KerrSchildReductions.h5
     ExpectedData:
       - [
-          5,
+          0,
           384,
           4.20277018789526e+03,
-          1.09488565564726e-03,
-          5.31467293519265e-03,
-          1.17765764073955e-02,
-          2.00607960424956e-03,
-          4.80423457412180e-03,
-          2.39573111152042e-02,
+          0.00000000000000e+00,
+          2.16998022741518e-01,
+          3.75478040264121e-01,
+        ]
+      - [
+          1,
+          384,
+          4.20277018789526e+03,
+          1.09488566071970e-03,
+          5.31467285484924e-03,
+          1.17765764810308e-02,
+        ]
+      - [
+          2,
+          750,
+          4.17021935018685e+03,
+          1.00730328853184e-04,
+          4.72781860739432e-04,
+          1.17830554422638e-03,
         ]
     AbsoluteTolerance: 1e-10
   - Label: Nonlinear solver convergence
     Subfile: NewtonRaphsonResiduals.dat
     FileGlob: KerrSchildReductions.h5
     ExpectedData:
+      # AMR iteration 0
       - [0, 0, 6.86317921700308e+01, 1.]
       - [1, 0, 2.54081356038966e+00, 1.]
       - [2, 0, 1.06821671508785e-01, 1.]
       - [3, 0, 5.29758557594090e-04, 1.]
       - [4, 0, 1.23004570709784e-08, 1.]
-      - [5, 0, 7.83806401935946e-13, 1.]
+      # AMR iteration 1
+      - [0, 0, 3.22212957410157e+00, 1.]
+      - [1, 0, 2.70099316920737e-02, 1.]
+      - [2, 0, 2.09933729188050e-06, 1.]
+      - [3, 0, 3.13426600315318e-11, 1.]
     AbsoluteTolerance: 1e-10
 
 ---
@@ -93,6 +111,28 @@ DomainCreator:
         LapseTimesConformalFactorMinusOne: Dirichlet
         ShiftExcess: Dirichlet
 
+Amr:
+  Verbosity: Verbose
+  Criteria:
+    - IncreaseResolution
+  Policies:
+    Isotropy: Anisotropic
+    Limits:
+      NumGridPoints: Auto
+      RefinementLevel: Auto
+  Iterations: 2
+
+PhaseChangeAndTriggers:
+  # Run AMR in every iteration, but not on the initial guess
+  - Trigger:
+      EveryNIterations:
+        N: 1
+        Offset: 1
+    PhaseChanges:
+      - VisitAndReturn(EvaluateAmrCriteria)
+      - VisitAndReturn(AdjustDomain)
+      - VisitAndReturn(CheckDomain)
+
 Discretization:
   DiscontinuousGalerkin:
     PenaltyParameter: 1.
@@ -112,7 +152,7 @@ NonlinearSolver:
       # iterations, so 20 is a safe setting).
       MaxIterations: 20
       RelativeResidual: 0.
-      AbsoluteResidual: 1.e-10
+      AbsoluteResidual: 1.e-6
     SufficientDecrease: 1.e-4
     MaxGlobalizationSteps: 40
     DampingFactor: 1.
@@ -128,7 +168,7 @@ LinearSolver:
 
   Multigrid:
     Iterations: 1
-    MaxLevels: Auto
+    MaxLevels: 1
     PreSmoothing: True
     PostSmoothingAtBottom: False
     Verbosity: Silent
@@ -158,7 +198,7 @@ LinearSolver:
 RadiallyCompressedCoordinates: None
 
 EventsAndTriggers:
-  - Trigger: HasConverged
+  - Trigger: Always
     Events:
       - ObserveNorms:
           SubfileName: ErrorNorms
@@ -172,15 +212,8 @@ EventsAndTriggers:
             - Name: Error(ShiftExcess)
               NormType: L2Norm
               Components: Sum
-            - Name: Error(Flux(ConformalFactorMinusOne))
-              NormType: L2Norm
-              Components: Sum
-            - Name: Error(Flux(LapseTimesConformalFactorMinusOne))
-              NormType: L2Norm
-              Components: Sum
-            - Name: Error(LongitudinalShiftExcess)
-              NormType: L2Norm
-              Components: Sum
+  - Trigger: HasConverged
+    Events:
       - ObserveNorms:
           SubfileName: Norms
           TensorsToObserve:

--- a/tests/InputFiles/Xcts/TovStar.yaml
+++ b/tests/InputFiles/Xcts/TovStar.yaml
@@ -4,7 +4,7 @@
 Executable: SolveXcts
 Testing:
   Check: parse;execute_check_output
-  Timeout: 40
+  Timeout: 60
   Priority: High
 ExpectedOutput:
   - TovStarReductions.h5
@@ -157,3 +157,15 @@ EventsAndTriggers:
           InterpolateToMesh: None
           CoordinatesFloatingPointType: Float
           FloatingPointTypes: [Float]
+
+Amr:
+  Verbosity: Quiet
+  Criteria: []
+  Policies:
+    Isotropy: Anisotropic
+    Limits:
+      NumGridPoints: Auto
+      RefinementLevel: Auto
+  Iterations: 1
+
+PhaseChangeAndTriggers: []

--- a/tests/Unit/Helpers/ParallelAlgorithms/LinearSolver/Multigrid/Helpers.hpp
+++ b/tests/Unit/Helpers/ParallelAlgorithms/LinearSolver/Multigrid/Helpers.hpp
@@ -90,8 +90,8 @@ struct InitializeElement {
                  elliptic::dg::Tags::Quadrature>;
   using simple_tags =
       tmpl::list<::domain::Tags::Mesh<1>,
-                 ::domain::Tags::Coordinates<1, Frame::Inertial>, fields_tag,
-                 sources_tag>;
+                 ::domain::Tags::Coordinates<1, Frame::Inertial>,
+                 ::domain::Tags::Element<1>, fields_tag, sources_tag>;
   using compute_tags = tmpl::list<>;
 
   template <typename DbTagsList, typename... InboxTags, typename Metavariables,
@@ -114,10 +114,12 @@ struct InitializeElement {
     const ElementMap<1, Frame::Inertial> element_map{
         element_id, block.stationary_map().get_clone()};
     auto inertial_coords = element_map(logical_coords);
+    // Only needed for element ID, so don't initialize neighbors
+    Element<1> element{element_id, {}};
     // Initialize data
     const size_t element_index = helpers_distributed::get_index(element_id);
     const size_t multigrid_level = element_id.grid_index();
-    const auto& source =
+    auto source =
         multigrid_level == 0
             ? typename sources_tag::type(
                   gsl::at(get<helpers_distributed::Source>(box), element_index))
@@ -126,7 +128,7 @@ struct InitializeElement {
     auto initial_fields = typename fields_tag::type{num_points, 0.};
     Initialization::mutate_assign<simple_tags>(
         make_not_null(&box), std::move(mesh), std::move(inertial_coords),
-        std::move(initial_fields), std::move(source));
+        std::move(element), std::move(initial_fields), std::move(source));
     return {Parallel::AlgorithmExecution::Continue, std::nullopt};
   }
 };

--- a/tests/Unit/ParallelAlgorithms/Amr/Projectors/Test_Variables.cpp
+++ b/tests/Unit/ParallelAlgorithms/Amr/Projectors/Test_Variables.cpp
@@ -115,9 +115,10 @@ void test_h_refine() {
   db::mutate_apply<amr::projectors::ProjectVariables<
       Dim, tmpl::list<VariablesTag<0>, VariablesTag<1>>>>(
       make_not_null(&box),
-      tuples::TaggedTuple<domain::Tags::Element<Dim>, VariablesTag<0>,
-                          VariablesTag<1>>(
-          parent_element, std::move(parent_var_0), std::move(parent_var_1)));
+      tuples::TaggedTuple<domain::Tags::Element<Dim>, domain::Tags::Mesh<Dim>,
+                          VariablesTag<0>, VariablesTag<1>>(
+          parent_element, mesh, std::move(parent_var_0),
+          std::move(parent_var_1)));
 
   CHECK_VARIABLES_APPROX(db::get<VariablesTag<0>>(box), child_var_0);
   CHECK_VARIABLES_APPROX(db::get<VariablesTag<1>>(box), child_var_1);

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Schwarz/Test_ElementCenteredSubdomainData.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Schwarz/Test_ElementCenteredSubdomainData.cpp
@@ -93,6 +93,17 @@ SPECTRE_TEST_CASE("Unit.ParallelSchwarz.ElementCenteredSubdomainData",
               subdomain_data1, 1.) ==
           make_subdomain_data({1., 1., 1.}, {1., 1.}, {1.}));
   }
+  SECTION("Resizing") {
+    const DirectionalId<1> extra_id{Direction<1>::upper_xi(),
+                                    ElementId<1>{1, {{{2, 2}}}}};
+    subdomain_data1.overlap_data.erase(west_id);
+    subdomain_data1.overlap_data.emplace(extra_id, 3);
+    subdomain_data1.destructive_resize(subdomain_data2);
+    CHECK(subdomain_data1.overlap_data.size() == 2);
+    CHECK(subdomain_data1.overlap_data.count(extra_id) == 0);
+    CHECK(subdomain_data1.overlap_data.count(west_id) == 1);
+    CHECK(subdomain_data1.overlap_data.count(east_id) == 1);
+  }
 }
 
 }  // namespace LinearSolver::Schwarz

--- a/tests/support/Pipelines/Bbh/CMakeLists.txt
+++ b/tests/support/Pipelines/Bbh/CMakeLists.txt
@@ -22,11 +22,11 @@ spectre_add_python_bindings_test(
 if (BUILD_PYTHON_BINDINGS)
   set_tests_properties(
     "support.Pipelines.Bbh.InitialData"
-    PROPERTIES TIMEOUT 40)
+    PROPERTIES TIMEOUT 60)
   set_tests_properties(
     "support.Pipelines.Bbh.Inspiral"
-    PROPERTIES TIMEOUT 40)
+    PROPERTIES TIMEOUT 60)
   set_tests_properties(
     "support.Pipelines.Bbh.Ringdown"
-    PROPERTIES TIMEOUT 40)
+    PROPERTIES TIMEOUT 60)
 endif()

--- a/tests/tools/CMakeLists.txt
+++ b/tests/tools/CMakeLists.txt
@@ -30,6 +30,6 @@ if(${BUILD_PYTHON_BINDINGS})
   set_tests_properties(
     "tools.ValidateInputFile"
     PROPERTIES
-    TIMEOUT 10
+    TIMEOUT 20
     )
 endif()


### PR DESCRIPTION
## Proposed changes

Enables AMR for all elliptic executables!

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
You'll have to add an `Amr` section to elliptic input files, as well as a `PhaseChangeAndTriggers` section to trigger AMR. See the input files in this PR for examples.
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
