### PR TITLE
Calculate packet energy for Monte-Carlo

### DIFF
--- a/src/Evolution/Particles/MonteCarlo/EvolvePackets.hpp
+++ b/src/Evolution/Particles/MonteCarlo/EvolvePackets.hpp
@@ -38,7 +38,8 @@ void evolve_single_packet_on_geodesic(
     const tnsr::II<DataVector, 3, Frame::Inertial>& inv_spatial_metric,
     const std::optional<tnsr::I<DataVector, 3, Frame::Inertial>>& mesh_velocity,
     const InverseJacobian<DataVector, 3, Frame::ElementLogical,
-                          Frame::Inertial>& inverse_jacobian);
+                          Frame::Inertial>&
+        inverse_jacobian_logical_to_inertial);
 
 // Functions to be implemented to complete implementation of Monte-Carlo
 // time step
@@ -57,6 +58,8 @@ void evolve_packets(
     gsl::not_null<std::vector<Packet>*> packets, const double& time_step,
     const Mesh<3>& mesh,
     const tnsr::I<DataVector, 3, Frame::ElementLogical>& mesh_coordinates,
+    const Scalar<DataVector>& lorentz_factor,
+    const tnsr::i<DataVector, 3, Frame::Inertial>& lower_spatial_four_velocity,
     const Scalar<DataVector>& lapse,
     const tnsr::I<DataVector, 3, Frame::Inertial>& shift,
     const tnsr::i<DataVector, 3, Frame::Inertial>& d_lapse,
@@ -65,6 +68,7 @@ void evolve_packets(
     const tnsr::II<DataVector, 3, Frame::Inertial>& inv_spatial_metric,
     const std::optional<tnsr::I<DataVector, 3, Frame::Inertial>>& mesh_velocity,
     const InverseJacobian<DataVector, 3, Frame::ElementLogical,
-                          Frame::Inertial>& inverse_jacobian);
+                          Frame::Inertial>&
+        inverse_jacobian_logical_to_inertial);
 
 }  // namespace Particles::MonteCarlo

--- a/src/Evolution/Particles/MonteCarlo/Packet.cpp
+++ b/src/Evolution/Particles/MonteCarlo/Packet.cpp
@@ -20,4 +20,22 @@ void Packet::renormalize_momentum(
       sqrt(momentum_upper_t) / get(lapse)[index_of_closest_grid_point];
 }
 
+double compute_fluid_frame_energy(
+    const Packet& packet, const Scalar<DataVector>& lorentz_factor,
+    const tnsr::i<DataVector, 3, Frame::Inertial>& lower_spatial_four_velocity,
+    const Scalar<DataVector>& lapse,
+    const tnsr::II<DataVector, 3, Frame::Inertial>& inv_spatial_metric) {
+  const size_t idx = packet.index_of_closest_grid_point;
+  double fluid_frame_energy =
+      get(lorentz_factor)[idx] * get(lapse)[idx] * packet.momentum_upper_t;
+  for (size_t i = 0; i < 3; i++) {
+    for (size_t j = 0; j < 3; j++) {
+      fluid_frame_energy -= inv_spatial_metric.get(i, j)[idx] *
+                            lower_spatial_four_velocity.get(i)[idx] *
+                            packet.momentum[j];
+    }
+  }
+  return fluid_frame_energy;
+}
+
 }  // namespace Particles::MonteCarlo

--- a/src/Evolution/Particles/MonteCarlo/Packet.hpp
+++ b/src/Evolution/Particles/MonteCarlo/Packet.hpp
@@ -61,10 +61,28 @@ struct Packet {
   /// Spatial components of the 4-momentum \f$p_i\f$, in Inertial coordinates
   tnsr::i<double, 3, Frame::Inertial> momentum;
 
-  /// Recalculte \f$p^t\f$ using the fact that the 4-momentum is a null vector
+  /*!
+   * Recalculte \f$p^t\f$ using the fact that the 4-momentum is a null vector
+   * \f{align}{
+   * p^t = \sqrt{\gamma^{ij} p_i p_j}/\alpha
+   * \f}
+   */
   void renormalize_momentum(
       const tnsr::II<DataVector, 3, Frame::Inertial>& inv_spatial_metric,
       const Scalar<DataVector>& lapse);
 };
+
+/*!
+ * Calculate energy of neutrinos in a frame comoving with the fluid
+ *
+ * \f{align}{
+ * E = W \alpha p^t - \gamma^{ij} u_i p_j
+ * \f}
+ */
+double compute_fluid_frame_energy(
+    const Packet& packet, const Scalar<DataVector>& lorentz_factor,
+    const tnsr::i<DataVector, 3, Frame::Inertial>& lower_spatial_four_velocity,
+    const Scalar<DataVector>& lapse,
+    const tnsr::II<DataVector, 3, Frame::Inertial>& inv_spatial_metric);
 
 }  // namespace Particles::MonteCarlo

--- a/tests/Unit/Evolution/Particles/MonteCarlo/Test_Packet.cpp
+++ b/tests/Unit/Evolution/Particles/MonteCarlo/Test_Packet.cpp
@@ -9,12 +9,82 @@
 #include "Evolution/Particles/MonteCarlo/Packet.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 
+namespace {
+
+void check_packet() {
+  const double epsilon_approx = 1.e-15;
+
+  const size_t dv_size = 5;
+  Scalar<DataVector> lapse(dv_size, 1.0);
+  Scalar<DataVector> lorentz_factor(dv_size, 1.0);
+  tnsr::i<DataVector, 3, Frame::Inertial> lower_spatial_four_velocity =
+      make_with_value<tnsr::i<DataVector, 3, Frame::Inertial>>(lapse, 0.0);
+  tnsr::II<DataVector, 3, Frame::Inertial> inv_spatial_metric =
+      make_with_value<tnsr::II<DataVector, 3, Frame::Inertial>>(lapse, 0.0);
+
+  const size_t pos = 3;
+  Particles::MonteCarlo::Packet packet(1, 2.0, pos, 0.0, -1.0, -0.5, -0.2, 0.9,
+                                       -0.3, 0.2, 0.1);
+  // The values below are wildly inconsistent, but we only want to check the
+  // math
+  get(lapse)[pos] = 0.8;
+  get(lorentz_factor)[pos] = 1.3;
+  lower_spatial_four_velocity.get(0)[pos] = 0.3;
+  lower_spatial_four_velocity.get(1)[pos] = 0.4;
+  lower_spatial_four_velocity.get(2)[pos] = 0.5;
+  inv_spatial_metric.get(0, 0) = 1.1;
+  inv_spatial_metric.get(1, 1) = 1.2;
+  inv_spatial_metric.get(2, 2) = 1.3;
+  inv_spatial_metric.get(0, 1) = 0.1;
+  inv_spatial_metric.get(0, 2) = 0.2;
+  inv_spatial_metric.get(1, 2) = 0.3;
+
+  // p^t = \sqrt{\gamma^{ij} p_i p_j}/\alpha
+  const double expected_momentum_upper_t =
+      sqrt(1.1 * 0.3 * 0.3 + 1.2 * 0.2 * 0.2 + 1.3 * 0.1 * 0.1 +
+           2.0 * 0.1 * (-0.3) * 0.2 + 2.0 * 0.2 * (-0.3) * 0.1 +
+           2.0 * 0.3 * 0.2 * 0.1) /
+      0.8;
+  packet.renormalize_momentum(inv_spatial_metric, lapse);
+  CHECK(fabs(packet.momentum_upper_t - expected_momentum_upper_t) <
+        epsilon_approx);
+
+  // E = W \alpha p^t - \gamma^{ij} u_i p_j
+  const double expected_energy =
+      0.8 * 1.3 * expected_momentum_upper_t - 1.1 * (-0.3) * 0.3 -
+      1.2 * 0.2 * 0.4 - 1.3 * 0.1 * 0.5 - 0.1 * (-0.3) * 0.4 -
+      0.1 * (0.2) * (0.3) - 0.2 * (-0.3) * 0.5 - 0.2 * 0.1 * 0.3 -
+      0.3 * 0.2 * 0.5 - 0.3 * 0.1 * 0.4;
+  const double computed_energy =
+      Particles::MonteCarlo::compute_fluid_frame_energy(
+          packet, lorentz_factor, lower_spatial_four_velocity, lapse,
+          inv_spatial_metric);
+  CHECK(fabs(expected_energy - computed_energy) < epsilon_approx);
+
+  CHECK(packet.species == 1);
+  CHECK(packet.coordinates.get(0) == -1.0);
+  CHECK(packet.coordinates.get(1) == -0.5);
+  CHECK(packet.coordinates.get(2) == -0.2);
+  CHECK(packet.momentum.get(0) == -0.3);
+  CHECK(packet.momentum.get(1) == 0.2);
+  CHECK(packet.momentum.get(2) == 0.1);
+  CHECK(packet.time == 0.0);
+  CHECK(packet.index_of_closest_grid_point == pos);
+  CHECK(packet.number_of_neutrinos == 2.0);
+}
+
+}  // namespace
+
 SPECTRE_TEST_CASE("Unit.Evolution.Particles.MonteCarlo", "[Unit][Evolution]") {
+  check_packet();
+
   const Mesh<3> mesh(2, Spectral::Basis::FiniteDifference,
                      Spectral::Quadrature::CellCentered);
 
   // Minkowski metric
   Scalar<DataVector> lapse{DataVector{1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0}};
+  Scalar<DataVector> lorentz_factor{
+      DataVector{1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0}};
 
   tnsr::II<DataVector, 3, Frame::Inertial> inv_spatial_metric =
       make_with_value<tnsr::II<DataVector, 3, Frame::Inertial>>(lapse, 0.0);
@@ -24,6 +94,8 @@ SPECTRE_TEST_CASE("Unit.Evolution.Particles.MonteCarlo", "[Unit][Evolution]") {
 
   tnsr::I<DataVector, 3, Frame::Inertial> shift =
       make_with_value<tnsr::I<DataVector, 3, Frame::Inertial>>(lapse, 0.0);
+  tnsr::i<DataVector, 3, Frame::Inertial> lower_spatial_four_velocity =
+      make_with_value<tnsr::i<DataVector, 3, Frame::Inertial>>(lapse, 0.0);
   tnsr::i<DataVector, 3, Frame::Inertial> d_lapse =
       make_with_value<tnsr::i<DataVector, 3, Frame::Inertial>>(lapse, 0.0);
   tnsr::iJ<DataVector, 3, Frame::Inertial> d_shift =
@@ -59,10 +131,10 @@ SPECTRE_TEST_CASE("Unit.Evolution.Particles.MonteCarlo", "[Unit][Evolution]") {
 
   std::vector<Particles::MonteCarlo::Packet> packets{packet};
   Particles::MonteCarlo::evolve_packets(
-      &packets, 1.5, mesh, mesh_coordinates, lapse, shift, d_lapse, d_shift,
+      &packets, 1.5, mesh, mesh_coordinates, lorentz_factor,
+      lower_spatial_four_velocity, lapse, shift, d_lapse, d_shift,
       d_inv_spatial_metric, inv_spatial_metric, mesh_velocity,
       inverse_jacobian);
-  CHECK(packets[0].species == 2);
   CHECK(packets[0].coordinates.get(0) == 0.5);
   CHECK(packets[0].coordinates.get(1) == -1.0);
   CHECK(packets[0].coordinates.get(2) == -1.0);
@@ -71,5 +143,4 @@ SPECTRE_TEST_CASE("Unit.Evolution.Particles.MonteCarlo", "[Unit][Evolution]") {
   CHECK(packets[0].momentum.get(2) == 0.0);
   CHECK(packets[0].time == 1.5);
   CHECK(packets[0].index_of_closest_grid_point == 1);
-  CHECK(packets[0].number_of_neutrinos == 1.0);
 }


### PR DESCRIPTION
## Proposed changes

Add on-the-fly calculation of neutrino energy in fluid frame (needed to calculate interaction rates and perform scattering).

### Upgrade instructions

NA

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.