### PR TITLE
Fix primitive recovery with barotropic 3d EOS and use GRMHD EOS tag

### DIFF
--- a/src/Evolution/DiscontinuousGalerkin/Actions/ApplyBoundaryCorrections.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Actions/ApplyBoundaryCorrections.hpp
@@ -67,15 +67,15 @@ struct TimeStepper;
 namespace evolution::dg::subcell {
 // We use a forward declaration instead of including a header file to avoid
 // coupling to the DG-subcell libraries for executables that don't use subcell.
-template <typename Metavariables, typename DbTagsList>
+template <size_t VolumeDim, typename DgComputeSubcellNeighborPackagedData,
+          typename DbTagsList>
 void neighbor_reconstructed_face_solution(
     gsl::not_null<db::DataBox<DbTagsList>*> box,
     gsl::not_null<std::pair<
         const TimeStepId,
         DirectionalIdMap<
-            Metavariables::volume_dim,
-            std::tuple<Mesh<Metavariables::volume_dim>,
-                       Mesh<Metavariables::volume_dim - 1>,
+            VolumeDim,
+            std::tuple<Mesh<VolumeDim>, Mesh<VolumeDim - 1>,
                        std::optional<DataVector>, std::optional<DataVector>,
                        ::TimeStepId, int>>>*>
         received_temporal_id_and_data);
@@ -129,7 +129,9 @@ bool receive_boundary_data_global_time_stepping(
 
   // Move inbox contents into the DataBox
   if constexpr (using_subcell_v<Metavariables>) {
-    evolution::dg::subcell::neighbor_reconstructed_face_solution<Metavariables>(
+    evolution::dg::subcell::neighbor_reconstructed_face_solution<
+        volume_dim, typename Metavariables::SubcellOptions::
+                        DgComputeSubcellNeighborPackagedData>(
         box, make_not_null(&*received_temporal_id_and_data));
     evolution::dg::subcell::neighbor_tci_decision<volume_dim>(
         box, *received_temporal_id_and_data);

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/FixConservativesAndComputePrims.cpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/FixConservativesAndComputePrims.cpp
@@ -26,7 +26,6 @@
 
 namespace grmhd::GhValenciaDivClean::subcell {
 template <typename OrderedListOfRecoverySchemes>
-template <size_t ThermodynamicDim>
 void FixConservativesAndComputePrims<OrderedListOfRecoverySchemes>::apply(
     const gsl::not_null<bool*> needed_fixing,
     const gsl::not_null<typename System::variables_tag::type*>
@@ -35,7 +34,7 @@ void FixConservativesAndComputePrims<OrderedListOfRecoverySchemes>::apply(
         primitive_vars_ptr,
     const tnsr::I<DataVector, 3, Frame::Inertial>& subcell_coords,
     const grmhd::ValenciaDivClean::FixConservatives& fix_conservatives,
-    const EquationsOfState::EquationOfState<true, ThermodynamicDim>& eos,
+    const EquationsOfState::EquationOfState<true, 3>& eos,
     const grmhd::ValenciaDivClean::PrimitiveFromConservativeOptions&
         primitive_from_conservative_options) {
   CAPTURE_FOR_ERROR(subcell_coords);
@@ -122,31 +121,17 @@ using KastaunThenNewmanThenPalenzuela =
 }  // namespace
 
 #define RECOVERY(data) BOOST_PP_TUPLE_ELEM(0, data)
-#define THERMO_DIM(data) BOOST_PP_TUPLE_ELEM(1, data)
 
-#define INSTANTIATION(r, data)                                              \
-  template void                                                             \
-  FixConservativesAndComputePrims<RECOVERY(data)>::apply<THERMO_DIM(data)>( \
-      const gsl::not_null<bool*> needed_fixing,                             \
-      const gsl::not_null<typename System::variables_tag::type*>            \
-          conserved_vars_ptr,                                               \
-      const gsl::not_null<Variables<hydro::grmhd_tags<DataVector>>*>        \
-          primitive_vars_ptr,                                               \
-      const tnsr::I<DataVector, 3, Frame::Inertial>& subcell_coords,        \
-      const grmhd::ValenciaDivClean::FixConservatives& fix_conservatives,   \
-      const EquationsOfState::EquationOfState<true, THERMO_DIM(data)>& eos, \
-      const grmhd::ValenciaDivClean::PrimitiveFromConservativeOptions&      \
-          primitive_from_conservative_options);
+#define INSTANTIATION(r, data) \
+  template struct FixConservativesAndComputePrims<RECOVERY(data)>;
 
 GENERATE_INSTANTIATIONS(
     INSTANTIATION,
     (tmpl::list<ValenciaDivClean::PrimitiveRecoverySchemes::KastaunEtAl>,
      tmpl::list<ValenciaDivClean::PrimitiveRecoverySchemes::NewmanHamlin>,
      tmpl::list<ValenciaDivClean::PrimitiveRecoverySchemes::PalenzuelaEtAl>,
-     NewmanThenPalenzuela, KastaunThenNewmanThenPalenzuela),
-    (1, 2, 3))
+     NewmanThenPalenzuela, KastaunThenNewmanThenPalenzuela))
 
 #undef INSTANTIATION
-#undef THERMO_DIM
 #undef RECOVERY
 }  // namespace grmhd::GhValenciaDivClean::subcell

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/FixConservativesAndComputePrims.hpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/FixConservativesAndComputePrims.hpp
@@ -44,10 +44,9 @@ struct FixConservativesAndComputePrims {
   using argument_tags = tmpl::list<
       evolution::dg::subcell::Tags::Coordinates<3, Frame::Inertial>,
       ::Tags::VariableFixer<grmhd::ValenciaDivClean::FixConservatives>,
-      hydro::Tags::EquationOfStateBase,
+      hydro::Tags::GrmhdEquationOfState,
       grmhd::ValenciaDivClean::Tags::PrimitiveFromConservativeOptions>;
 
-  template <size_t ThermodynamicDim>
   static void apply(
       gsl::not_null<bool*> needed_fixing,
       gsl::not_null<typename System::variables_tag::type*> conserved_vars_ptr,
@@ -55,7 +54,7 @@ struct FixConservativesAndComputePrims {
           primitive_vars_ptr,
       const tnsr::I<DataVector, 3, Frame::Inertial>& subcell_coords,
       const grmhd::ValenciaDivClean::FixConservatives& fix_conservatives,
-      const EquationsOfState::EquationOfState<true, ThermodynamicDim>& eos,
+      const EquationsOfState::EquationOfState<true, 3>& eos,
       const grmhd::ValenciaDivClean::PrimitiveFromConservativeOptions&
           primitive_from_conservative_options);
 };

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/PrimsAfterRollback.cpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/PrimsAfterRollback.cpp
@@ -25,7 +25,6 @@
 
 namespace grmhd::GhValenciaDivClean::subcell {
 template <typename OrderedListOfRecoverySchemes>
-template <size_t ThermodynamicDim>
 void PrimsAfterRollback<OrderedListOfRecoverySchemes>::apply(
     const gsl::not_null<Variables<hydro::grmhd_tags<DataVector>>*> prim_vars,
     const bool did_rollback, const Mesh<3>& dg_mesh,
@@ -35,7 +34,7 @@ void PrimsAfterRollback<OrderedListOfRecoverySchemes>::apply(
     const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_b,
     const Scalar<DataVector>& tilde_phi,
     const tnsr::aa<DataVector, 3, Frame::Inertial>& spacetime_metric,
-    const EquationsOfState::EquationOfState<true, ThermodynamicDim>& eos,
+    const EquationsOfState::EquationOfState<true, 3>& eos,
     const grmhd::ValenciaDivClean::PrimitiveFromConservativeOptions&
         primitive_from_conservative_options) {
   if (did_rollback) {
@@ -111,9 +110,8 @@ using KastaunThenNewmanThenPalenzuela =
 }  // namespace
 
 #define RECOVERY(data) BOOST_PP_TUPLE_ELEM(0, data)
-#define THERMO_DIM(data) BOOST_PP_TUPLE_ELEM(1, data)
 #define INSTANTIATION(r, data)                                                \
-  template void PrimsAfterRollback<RECOVERY(data)>::apply<THERMO_DIM(data)>(  \
+  template void PrimsAfterRollback<RECOVERY(data)>::apply(                    \
       const gsl::not_null<Variables<hydro::grmhd_tags<DataVector>>*>          \
           prim_vars,                                                          \
       bool did_rollback, const Mesh<3>& dg_mesh, const Mesh<3>& subcell_mesh, \
@@ -123,7 +121,7 @@ using KastaunThenNewmanThenPalenzuela =
       const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_b,                 \
       const Scalar<DataVector>& tilde_phi,                                    \
       const tnsr::aa<DataVector, 3, Frame::Inertial>& spacetime_metric,       \
-      const EquationsOfState::EquationOfState<true, THERMO_DIM(data)>& eos,   \
+      const EquationsOfState::EquationOfState<true, 3>& eos,                  \
       const grmhd::ValenciaDivClean::PrimitiveFromConservativeOptions&        \
           primitive_from_conservative_options);
 GENERATE_INSTANTIATIONS(
@@ -131,8 +129,7 @@ GENERATE_INSTANTIATIONS(
     (tmpl::list<ValenciaDivClean::PrimitiveRecoverySchemes::KastaunEtAl>,
      tmpl::list<ValenciaDivClean::PrimitiveRecoverySchemes::NewmanHamlin>,
      tmpl::list<ValenciaDivClean::PrimitiveRecoverySchemes::PalenzuelaEtAl>,
-     NewmanThenPalenzuela, KastaunThenNewmanThenPalenzuela),
-    (1, 2, 3))
+     NewmanThenPalenzuela, KastaunThenNewmanThenPalenzuela))
 #undef INSTANTIATION
 #undef THERMO_DIM
 #undef RECOVERY

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/PrimsAfterRollback.hpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/PrimsAfterRollback.hpp
@@ -55,10 +55,9 @@ struct PrimsAfterRollback {
       grmhd::ValenciaDivClean::Tags::TildeB<>,
       grmhd::ValenciaDivClean::Tags::TildePhi,
       gr::Tags::SpacetimeMetric<DataVector, 3>,
-      hydro::Tags::EquationOfStateBase,
+      hydro::Tags::GrmhdEquationOfState,
       grmhd::ValenciaDivClean::Tags::PrimitiveFromConservativeOptions>;
 
-  template <size_t ThermodynamicDim>
   static void apply(
       gsl::not_null<Variables<hydro::grmhd_tags<DataVector>>*> prim_vars,
       bool did_rollback, const Mesh<3>& dg_mesh, const Mesh<3>& subcell_mesh,
@@ -68,7 +67,7 @@ struct PrimsAfterRollback {
       const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_b,
       const Scalar<DataVector>& tilde_phi,
       const tnsr::aa<DataVector, 3, Frame::Inertial>& spacetime_metric,
-      const EquationsOfState::EquationOfState<true, ThermodynamicDim>& eos,
+      const EquationsOfState::EquationOfState<true, 3>& eos,
       const grmhd::ValenciaDivClean::PrimitiveFromConservativeOptions&
           primitive_from_conservative_options);
 };

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/ResizeAndComputePrimitives.cpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/ResizeAndComputePrimitives.cpp
@@ -25,7 +25,6 @@
 
 namespace grmhd::GhValenciaDivClean::subcell {
 template <typename OrderedListOfRecoverySchemes>
-template <size_t ThermodynamicDim>
 void ResizeAndComputePrims<OrderedListOfRecoverySchemes>::apply(
     const gsl::not_null<Variables<hydro::grmhd_tags<DataVector>>*> prim_vars,
     const evolution::dg::subcell::ActiveGrid active_grid,
@@ -36,9 +35,9 @@ void ResizeAndComputePrims<OrderedListOfRecoverySchemes>::apply(
     const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_b,
     const Scalar<DataVector>& tilde_phi,
     const tnsr::aa<DataVector, 3, Frame::Inertial>& spacetime_metric,
-    const EquationsOfState::EquationOfState<true, ThermodynamicDim>& eos,
+    const EquationsOfState::EquationOfState<true, 3>& eos,
     const grmhd::ValenciaDivClean::PrimitiveFromConservativeOptions&
-      primitive_from_conservative_options) {
+        primitive_from_conservative_options) {
   if (active_grid == evolution::dg::subcell::ActiveGrid::Dg) {
     const size_t num_grid_points = dg_mesh.number_of_grid_points();
     // Reconstruct a copy of the pressure from the FD grid to the DG grid to
@@ -112,31 +111,16 @@ using KastaunThenNewmanThenPalenzuela =
 }  // namespace
 
 #define RECOVERY(data) BOOST_PP_TUPLE_ELEM(0, data)
-#define THERMO_DIM(data) BOOST_PP_TUPLE_ELEM(1, data)
-#define INSTANTIATION(r, data)                                               \
-  template void                                                              \
-  ResizeAndComputePrims<RECOVERY(data)>::apply<THERMO_DIM(data)>(            \
-      const gsl::not_null<Variables<hydro::grmhd_tags<DataVector>>*>         \
-          prim_vars,                                                         \
-      const evolution::dg::subcell::ActiveGrid active_grid,                  \
-      const Mesh<3>& dg_mesh, const Mesh<3>& subcell_mesh,                   \
-      const Scalar<DataVector>& tilde_d, const Scalar<DataVector>& tilde_ye, \
-      const Scalar<DataVector>& tilde_tau,                                   \
-      const tnsr::i<DataVector, 3, Frame::Inertial>& tilde_s,                \
-      const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_b,                \
-      const Scalar<DataVector>& tilde_phi,                                   \
-      const tnsr::aa<DataVector, 3, Frame::Inertial>& spacetime_metric,      \
-      const EquationsOfState::EquationOfState<true, THERMO_DIM(data)>& eos,  \
-      const grmhd::ValenciaDivClean::PrimitiveFromConservativeOptions&       \
-          primitive_from_conservative_options);
+#define INSTANTIATION(r, data) \
+  template struct ResizeAndComputePrims<RECOVERY(data)>;
+
 GENERATE_INSTANTIATIONS(
     INSTANTIATION,
     (tmpl::list<ValenciaDivClean::PrimitiveRecoverySchemes::KastaunEtAl>,
      tmpl::list<ValenciaDivClean::PrimitiveRecoverySchemes::NewmanHamlin>,
      tmpl::list<ValenciaDivClean::PrimitiveRecoverySchemes::PalenzuelaEtAl>,
-     NewmanThenPalenzuela, KastaunThenNewmanThenPalenzuela),
-    (1, 2, 3))
+     NewmanThenPalenzuela, KastaunThenNewmanThenPalenzuela))
+
 #undef INSTANTIATION
-#undef THERMO_DIM
 #undef RECOVERY
 }  // namespace grmhd::GhValenciaDivClean::subcell

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/ResizeAndComputePrimitives.hpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/ResizeAndComputePrimitives.hpp
@@ -70,10 +70,9 @@ struct ResizeAndComputePrims {
       grmhd::ValenciaDivClean::Tags::TildeB<>,
       grmhd::ValenciaDivClean::Tags::TildePhi,
       gr::Tags::SpacetimeMetric<DataVector, 3>,
-      hydro::Tags::EquationOfStateBase,
+      hydro::Tags::GrmhdEquationOfState,
       grmhd::ValenciaDivClean::Tags::PrimitiveFromConservativeOptions>;
 
-  template <size_t ThermodynamicDim>
   static void apply(
       gsl::not_null<Variables<hydro::grmhd_tags<DataVector>>*> prim_vars,
       evolution::dg::subcell::ActiveGrid active_grid, const Mesh<3>& dg_mesh,
@@ -83,7 +82,7 @@ struct ResizeAndComputePrims {
       const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_b,
       const Scalar<DataVector>& tilde_phi,
       const tnsr::aa<DataVector, 3, Frame::Inertial>& spacetime_metric,
-      const EquationsOfState::EquationOfState<true, ThermodynamicDim>& eos,
+      const EquationsOfState::EquationOfState<true, 3>& eos,
       const grmhd::ValenciaDivClean::PrimitiveFromConservativeOptions&
           primitive_from_conservative_options);
 };

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/CMakeLists.txt
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/CMakeLists.txt
@@ -14,10 +14,6 @@ spectre_target_sources(
   FixConservatives.cpp
   Flattener.cpp
   Fluxes.cpp
-  KastaunEtAl.cpp
-  KastaunEtAlHydro.cpp
-  NewmanHamlin.cpp
-  PalenzuelaEtAl.cpp
   PrimitiveFromConservative.cpp
   PrimitiveFromConservativeOptions.cpp
   SetVariablesNeededFixingToFalse.cpp
@@ -38,9 +34,13 @@ spectre_target_headers(
   Flattener.hpp
   Fluxes.hpp
   KastaunEtAl.hpp
+  KastaunEtAl.tpp
   KastaunEtAlHydro.hpp
+  KastaunEtAlHydro.tpp
   NewmanHamlin.hpp
+  NewmanHamlin.tpp
   PalenzuelaEtAl.hpp
+  PalenzuelaEtAl.tpp
   PrimitiveFromConservative.hpp
   PrimitiveFromConservativeOptions.hpp
   PrimitiveRecoveryData.hpp

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Flattener.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Flattener.cpp
@@ -45,7 +45,6 @@ void Flattener<RecoverySchemesList>::pup(PUP::er& p) {
 }
 
 template <typename RecoverySchemesList>
-template <size_t ThermodynamicDim>
 void Flattener<RecoverySchemesList>::operator()(
     const gsl::not_null<Scalar<DataVector>*> tilde_d,
     const gsl::not_null<Scalar<DataVector>*> tilde_ye,
@@ -59,10 +58,9 @@ void Flattener<RecoverySchemesList>::operator()(
     const tnsr::II<DataVector, 3, Frame::Inertial>& inv_spatial_metric,
     const Mesh<3>& mesh,
     const Scalar<DataVector>& det_logical_to_inertial_inv_jacobian,
-    const EquationsOfState::EquationOfState<true, ThermodynamicDim>& eos,
+    const EquationsOfState::EquationOfState<true, 3>& eos,
     const grmhd::ValenciaDivClean::PrimitiveFromConservativeOptions&
-        primitive_from_conservative_options)
-    const {
+        primitive_from_conservative_options) const {
   // Create a temporary variable for each field's cell average.
   // These temporaries live on the stack and should have minimal cost.
   double mean_tilde_d = std::numeric_limits<double>::signaling_NaN();
@@ -302,26 +300,6 @@ using KastaunThenNewmanThenPalenzuela =
 GENERATE_INSTANTIATIONS(INSTANTIATION, ORDERED_RECOVERY_LIST)
 #undef INSTANTIATION
 
-#define THERMO_DIM(data) BOOST_PP_TUPLE_ELEM(1, data)
-#define INSTANTIATION(r, data)                                              \
-  template void Flattener<RECOVERY(data)>::operator()<THERMO_DIM(data)>(    \
-      gsl::not_null<Scalar<DataVector>*> tilde_d,                           \
-      gsl::not_null<Scalar<DataVector>*> tilde_ye,                          \
-      gsl::not_null<Scalar<DataVector>*> tilde_tau,                         \
-      gsl::not_null<tnsr::i<DataVector, 3>*> tilde_s,                       \
-      gsl::not_null<Variables<hydro::grmhd_tags<DataVector>>*> primitives,  \
-      const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_b,               \
-      const Scalar<DataVector>& tilde_phi,                                  \
-      const Scalar<DataVector>& sqrt_det_spatial_metric,                    \
-      const tnsr::ii<DataVector, 3, Frame::Inertial>& spatial_metric,       \
-      const tnsr::II<DataVector, 3, Frame::Inertial>& inv_spatial_metric,   \
-      const Mesh<3>& mesh,                                                  \
-      const Scalar<DataVector>& det_logical_to_inertial_inv_jacobian,       \
-      const EquationsOfState::EquationOfState<true, THERMO_DIM(data)>& eos, \
-      const grmhd::ValenciaDivClean::PrimitiveFromConservativeOptions&      \
-        primitive_from_conservative_options) const;
-GENERATE_INSTANTIATIONS(INSTANTIATION, ORDERED_RECOVERY_LIST, (1, 2))
-#undef INSTANTIATION
 #undef THERMO_DIM
 #undef RECOVERY
 #undef ORDERED_RECOVERY_LIST

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Flattener.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Flattener.hpp
@@ -126,10 +126,9 @@ class Flattener {
       gr::Tags::SpatialMetric<DataVector, 3>,
       gr::Tags::InverseSpatialMetric<DataVector, 3>, domain::Tags::Mesh<3>,
       domain::Tags::DetInvJacobian<Frame::ElementLogical, Frame::Inertial>,
-      hydro::Tags::EquationOfStateBase,
+      hydro::Tags::GrmhdEquationOfState,
       grmhd::ValenciaDivClean::Tags::PrimitiveFromConservativeOptions>;
 
-  template <size_t ThermodynamicDim>
   void operator()(
       gsl::not_null<Scalar<DataVector>*> tilde_d,
       gsl::not_null<Scalar<DataVector>*> tilde_ye,
@@ -143,10 +142,9 @@ class Flattener {
       const tnsr::II<DataVector, 3, Frame::Inertial>& inv_spatial_metric,
       const Mesh<3>& mesh,
       const Scalar<DataVector>& det_logical_to_inertial_inv_jacobian,
-      const EquationsOfState::EquationOfState<true, ThermodynamicDim>& eos,
+      const EquationsOfState::EquationOfState<true, 3>& eos,
       const grmhd::ValenciaDivClean::PrimitiveFromConservativeOptions&
-        primitive_from_conservative_options)
-      const;
+          primitive_from_conservative_options) const;
 
  private:
   template <typename LocalRecoverySchemesList>

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/KastaunEtAl.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/KastaunEtAl.hpp
@@ -52,14 +52,13 @@ namespace grmhd::ValenciaDivClean::PrimitiveRecoverySchemes {
  */
 class KastaunEtAl {
  public:
-  template <bool EnforcePhysicality, size_t ThermodynamicDim>
+  template <bool EnforcePhysicality, typename EosType>
   static std::optional<PrimitiveRecoveryData> apply(
       double initial_guess_pressure, double tau,
       double momentum_density_squared,
       double momentum_density_dot_magnetic_field, double magnetic_field_squared,
       double rest_mass_density_times_lorentz_factor, double electron_fraction,
-      const EquationsOfState::EquationOfState<true, ThermodynamicDim>&
-          equation_of_state,
+      const EosType& equation_of_state,
       const grmhd::ValenciaDivClean::PrimitiveFromConservativeOptions&
           primitive_from_conservative_options);
 

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/KastaunEtAlHydro.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/KastaunEtAlHydro.hpp
@@ -49,14 +49,13 @@ struct PrimitiveRecoveryData;
  */
 class KastaunEtAlHydro {
  public:
-  template <bool EnforcePhysicality, size_t ThermodynamicDim>
+  template <bool EnforcePhysicality, typename EosType>
   static std::optional<PrimitiveRecoveryData> apply(
       double initial_guess_pressure, double tau,
       double momentum_density_squared,
       double momentum_density_dot_magnetic_field, double magnetic_field_squared,
       double rest_mass_density_times_lorentz_factor, double electron_fraction,
-      const EquationsOfState::EquationOfState<true, ThermodynamicDim>&
-          equation_of_state,
+      const EosType& equation_of_state,
       const grmhd::ValenciaDivClean::PrimitiveFromConservativeOptions&
           primitive_from_conservative_options);
 

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/NewmanHamlin.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/NewmanHamlin.hpp
@@ -51,14 +51,13 @@ namespace grmhd::ValenciaDivClean::PrimitiveRecoverySchemes {
  */
 class NewmanHamlin {
  public:
-  template <bool EnforcePhysicality, size_t ThermodynamicDim>
+  template <bool EnforcePhysicality, typename EosType>
   static std::optional<PrimitiveRecoveryData> apply(
       double initial_guess_for_pressure, double tau,
       double momentum_density_squared,
       double momentum_density_dot_magnetic_field, double magnetic_field_squared,
       double rest_mass_density_times_lorentz_factor, double electron_fraction,
-      const EquationsOfState::EquationOfState<true, ThermodynamicDim>&
-          equation_of_state,
+      const EosType& equation_of_state,
       const grmhd::ValenciaDivClean::PrimitiveFromConservativeOptions&
           primitive_from_conservative_options);
 

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/PalenzuelaEtAl.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/PalenzuelaEtAl.hpp
@@ -52,14 +52,13 @@ namespace grmhd::ValenciaDivClean::PrimitiveRecoverySchemes {
  */
 class PalenzuelaEtAl {
  public:
-  template <bool EnforcePhysicality, size_t ThermodynamicDim>
+  template <bool EnforcePhysicality, typename EosType>
   static std::optional<PrimitiveRecoveryData> apply(
       double /*initial_guess_pressure*/, double tau,
       double momentum_density_squared,
       double momentum_density_dot_magnetic_field, double magnetic_field_squared,
       double rest_mass_density_times_lorentz_factor, double electron_fraction,
-      const EquationsOfState::EquationOfState<true, ThermodynamicDim>&
-          equation_of_state,
+      const EosType& equation_of_state,
       const grmhd::ValenciaDivClean::PrimitiveFromConservativeOptions&
           primitive_from_conservative_options);
 

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/PrimitiveFromConservative.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/PrimitiveFromConservative.hpp
@@ -7,15 +7,11 @@
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/PrimitiveFromConservativeOptions.hpp"
-#include "Evolution/Systems/GrMhd/ValenciaDivClean/TagsDeclarations.hpp"  // IWYU pragma: keep
-#include "PointwiseFunctions/GeneralRelativity/TagsDeclarations.hpp"  // IWYU pragma: keep
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/TagsDeclarations.hpp"
+#include "PointwiseFunctions/GeneralRelativity/TagsDeclarations.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
-#include "PointwiseFunctions/Hydro/TagsDeclarations.hpp"  // IWYU pragma: keep
+#include "PointwiseFunctions/Hydro/TagsDeclarations.hpp"
 #include "Utilities/TMPL.hpp"
-
-// IWYU pragma: no_include "Evolution/Systems/GrMhd/ValenciaDivClean/Tags.hpp"
-// IWYU pragma: no_include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
-// IWYU pragma: no_include "PointwiseFunctions/Hydro/Tags.hpp"
 
 /// \cond
 namespace gsl {
@@ -73,10 +69,10 @@ struct PrimitiveFromConservative {
       gr::Tags::SpatialMetric<DataVector, 3>,
       gr::Tags::InverseSpatialMetric<DataVector, 3>,
       gr::Tags::SqrtDetSpatialMetric<DataVector>,
-      hydro::Tags::EquationOfStateBase,
+      hydro::Tags::GrmhdEquationOfState,
       grmhd::ValenciaDivClean::Tags::PrimitiveFromConservativeOptions>;
 
-  template <bool EnforcePhysicality = true, size_t ThermodynamicDim>
+  template <bool EnforcePhysicality = true>
   static bool apply(
       gsl::not_null<Scalar<DataVector>*> rest_mass_density,
       gsl::not_null<Scalar<DataVector>*> electron_fraction,
@@ -95,12 +91,34 @@ struct PrimitiveFromConservative {
       const tnsr::ii<DataVector, 3, Frame::Inertial>& spatial_metric,
       const tnsr::II<DataVector, 3, Frame::Inertial>& inv_spatial_metric,
       const Scalar<DataVector>& sqrt_det_spatial_metric,
-      const EquationsOfState::EquationOfState<true, ThermodynamicDim>&
-          equation_of_state,
+      const EquationsOfState::EquationOfState<true, 3>& equation_of_state,
       const grmhd::ValenciaDivClean::PrimitiveFromConservativeOptions&
           primitive_from_conservative_options);
 
  private:
+  template <bool EnforcePhysicality, typename EosType>
+  static bool impl(
+      gsl::not_null<Scalar<DataVector>*> rest_mass_density,
+      gsl::not_null<Scalar<DataVector>*> electron_fraction,
+      gsl::not_null<Scalar<DataVector>*> specific_internal_energy,
+      gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> spatial_velocity,
+      gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> magnetic_field,
+      gsl::not_null<Scalar<DataVector>*> divergence_cleaning_field,
+      gsl::not_null<Scalar<DataVector>*> lorentz_factor,
+      gsl::not_null<Scalar<DataVector>*> pressure,
+      gsl::not_null<Scalar<DataVector>*> temperature,
+      const Scalar<DataVector>& tilde_d, const Scalar<DataVector>& tilde_ye,
+      const Scalar<DataVector>& tilde_tau,
+      const tnsr::i<DataVector, 3, Frame::Inertial>& tilde_s,
+      const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_b,
+      const Scalar<DataVector>& tilde_phi,
+      const tnsr::ii<DataVector, 3, Frame::Inertial>& spatial_metric,
+      const tnsr::II<DataVector, 3, Frame::Inertial>& inv_spatial_metric,
+      const Scalar<DataVector>& sqrt_det_spatial_metric,
+      const EosType& equation_of_state,
+      const grmhd::ValenciaDivClean::PrimitiveFromConservativeOptions&
+          primitive_from_conservative_options);
+
   // Use Kastaun hydro inversion if B is dynamically unimportant
   static constexpr bool use_hydro_optimization = true;
 };

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/FixConservativesAndComputePrims.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/FixConservativesAndComputePrims.cpp
@@ -21,7 +21,6 @@
 
 namespace grmhd::ValenciaDivClean::subcell {
 template <typename OrderedListOfRecoverySchemes>
-template <size_t ThermodynamicDim>
 void FixConservativesAndComputePrims<OrderedListOfRecoverySchemes>::apply(
     const gsl::not_null<bool*> needed_fixing,
     const gsl::not_null<typename System::variables_tag::type*>
@@ -29,7 +28,7 @@ void FixConservativesAndComputePrims<OrderedListOfRecoverySchemes>::apply(
     const gsl::not_null<Variables<hydro::grmhd_tags<DataVector>>*>
         primitive_vars_ptr,
     const grmhd::ValenciaDivClean::FixConservatives& fix_conservatives,
-    const EquationsOfState::EquationOfState<true, ThermodynamicDim>& eos,
+    const EquationsOfState::EquationOfState<true, 3>& eos,
     const tnsr::ii<DataVector, 3, Frame::Inertial>& spatial_metric,
     const tnsr::II<DataVector, 3, Frame::Inertial>& inv_spatial_metric,
     const Scalar<DataVector>& sqrt_det_spatial_metric,
@@ -83,30 +82,15 @@ using KastaunThenNewmanThenPalenzuela =
 }  // namespace
 
 #define RECOVERY(data) BOOST_PP_TUPLE_ELEM(0, data)
-#define THERMO_DIM(data) BOOST_PP_TUPLE_ELEM(1, data)
 
-#define INSTANTIATION(r, data)                                              \
-  template void                                                             \
-  FixConservativesAndComputePrims<RECOVERY(data)>::apply<THERMO_DIM(data)>( \
-      const gsl::not_null<bool*> needed_fixing,                             \
-      const gsl::not_null<typename System::variables_tag::type*>            \
-          conserved_vars_ptr,                                               \
-      const gsl::not_null<Variables<hydro::grmhd_tags<DataVector>>*>        \
-          primitive_vars_ptr,                                               \
-      const grmhd::ValenciaDivClean::FixConservatives& fix_conservatives,   \
-      const EquationsOfState::EquationOfState<true, THERMO_DIM(data)>& eos, \
-      const tnsr::ii<DataVector, 3, Frame::Inertial>& spatial_metric,       \
-      const tnsr::II<DataVector, 3, Frame::Inertial>& inv_spatial_metric,   \
-      const Scalar<DataVector>& sqrt_det_spatial_metric,                    \
-      const grmhd::ValenciaDivClean::PrimitiveFromConservativeOptions&      \
-          primitive_from_conservative_options);
+#define INSTANTIATION(r, data) \
+  template struct FixConservativesAndComputePrims<RECOVERY(data)>;
 
 GENERATE_INSTANTIATIONS(INSTANTIATION,
                         (tmpl::list<PrimitiveRecoverySchemes::KastaunEtAl>,
                          tmpl::list<PrimitiveRecoverySchemes::NewmanHamlin>,
                          tmpl::list<PrimitiveRecoverySchemes::PalenzuelaEtAl>,
-                         NewmanThenPalenzuela, KastaunThenNewmanThenPalenzuela),
-                        (1, 2, 3))
+                         NewmanThenPalenzuela, KastaunThenNewmanThenPalenzuela))
 
 #undef INSTANTIATION
 #undef THERMO_DIM

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/FixConservativesAndComputePrims.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/FixConservativesAndComputePrims.hpp
@@ -43,23 +43,22 @@ struct FixConservativesAndComputePrims {
                                  typename System::primitive_variables_tag>;
   using argument_tags = tmpl::list<
       ::Tags::VariableFixer<grmhd::ValenciaDivClean::FixConservatives>,
-      hydro::Tags::EquationOfStateBase, gr::Tags::SpatialMetric<DataVector, 3>,
+      hydro::Tags::GrmhdEquationOfState, gr::Tags::SpatialMetric<DataVector, 3>,
       gr::Tags::InverseSpatialMetric<DataVector, 3>,
       gr::Tags::SqrtDetSpatialMetric<DataVector>,
       grmhd::ValenciaDivClean::Tags::PrimitiveFromConservativeOptions>;
 
-  template <size_t ThermodynamicDim>
   static void apply(
       gsl::not_null<bool*> needed_fixing,
       gsl::not_null<typename System::variables_tag::type*> conserved_vars_ptr,
       gsl::not_null<Variables<hydro::grmhd_tags<DataVector>>*>
           primitive_vars_ptr,
       const grmhd::ValenciaDivClean::FixConservatives& fix_conservatives,
-      const EquationsOfState::EquationOfState<true, ThermodynamicDim>& eos,
+      const EquationsOfState::EquationOfState<true, 3>& eos,
       const tnsr::ii<DataVector, 3, Frame::Inertial>& spatial_metric,
       const tnsr::II<DataVector, 3, Frame::Inertial>& inv_spatial_metric,
       const Scalar<DataVector>& sqrt_det_spatial_metric,
       const grmhd::ValenciaDivClean::PrimitiveFromConservativeOptions&
-        primitive_from_conservative_options);
+          primitive_from_conservative_options);
 };
 }  // namespace grmhd::ValenciaDivClean::subcell

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/PrimsAfterRollback.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/PrimsAfterRollback.cpp
@@ -21,7 +21,6 @@
 
 namespace grmhd::ValenciaDivClean::subcell {
 template <typename OrderedListOfRecoverySchemes>
-template <size_t ThermodynamicDim>
 void PrimsAfterRollback<OrderedListOfRecoverySchemes>::apply(
     const gsl::not_null<Variables<hydro::grmhd_tags<DataVector>>*> prim_vars,
     const bool did_rollback, const Mesh<3>& dg_mesh,
@@ -33,7 +32,7 @@ void PrimsAfterRollback<OrderedListOfRecoverySchemes>::apply(
     const tnsr::ii<DataVector, 3, Frame::Inertial>& spatial_metric,
     const tnsr::II<DataVector, 3, Frame::Inertial>& inv_spatial_metric,
     const Scalar<DataVector>& sqrt_det_spatial_metric,
-    const EquationsOfState::EquationOfState<true, ThermodynamicDim>& eos,
+    const EquationsOfState::EquationOfState<true, 3>& eos,
     const grmhd::ValenciaDivClean::PrimitiveFromConservativeOptions&
         primitive_from_conservative_options) {
   if (did_rollback) {
@@ -87,9 +86,8 @@ using KastaunThenNewmanThenPalenzuela =
 }  // namespace
 
 #define RECOVERY(data) BOOST_PP_TUPLE_ELEM(0, data)
-#define THERMO_DIM(data) BOOST_PP_TUPLE_ELEM(1, data)
 #define INSTANTIATION(r, data)                                                \
-  template void PrimsAfterRollback<RECOVERY(data)>::apply<THERMO_DIM(data)>(  \
+  template void PrimsAfterRollback<RECOVERY(data)>::apply(                    \
       const gsl::not_null<Variables<hydro::grmhd_tags<DataVector>>*>          \
           prim_vars,                                                          \
       bool did_rollback, const Mesh<3>& dg_mesh, const Mesh<3>& subcell_mesh, \
@@ -101,15 +99,14 @@ using KastaunThenNewmanThenPalenzuela =
       const tnsr::ii<DataVector, 3, Frame::Inertial>& spatial_metric,         \
       const tnsr::II<DataVector, 3, Frame::Inertial>& inv_spatial_metric,     \
       const Scalar<DataVector>& sqrt_det_spatial_metric,                      \
-      const EquationsOfState::EquationOfState<true, THERMO_DIM(data)>& eos,   \
+      const EquationsOfState::EquationOfState<true, 3>& eos,                  \
       const grmhd::ValenciaDivClean::PrimitiveFromConservativeOptions&        \
-      primitive_from_conservative_options);
+          primitive_from_conservative_options);
 GENERATE_INSTANTIATIONS(INSTANTIATION,
                         (tmpl::list<PrimitiveRecoverySchemes::KastaunEtAl>,
                          tmpl::list<PrimitiveRecoverySchemes::NewmanHamlin>,
                          tmpl::list<PrimitiveRecoverySchemes::PalenzuelaEtAl>,
-                         NewmanThenPalenzuela, KastaunThenNewmanThenPalenzuela),
-                        (1, 2, 3))
+                         NewmanThenPalenzuela, KastaunThenNewmanThenPalenzuela))
 #undef INSTANTIATION
 #undef THERMO_DIM
 #undef RECOVERY

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/PrimsAfterRollback.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/PrimsAfterRollback.hpp
@@ -60,10 +60,9 @@ struct PrimsAfterRollback {
       gr::Tags::SpatialMetric<DataVector, 3>,
       gr::Tags::InverseSpatialMetric<DataVector, 3>,
       gr::Tags::SqrtDetSpatialMetric<DataVector>,
-      hydro::Tags::EquationOfStateBase,
+      hydro::Tags::GrmhdEquationOfState,
       grmhd::ValenciaDivClean::Tags::PrimitiveFromConservativeOptions>;
 
-  template <size_t ThermodynamicDim>
   static void apply(
       gsl::not_null<Variables<hydro::grmhd_tags<DataVector>>*> prim_vars,
       bool did_rollback, const Mesh<3>& dg_mesh, const Mesh<3>& subcell_mesh,
@@ -75,7 +74,7 @@ struct PrimsAfterRollback {
       const tnsr::ii<DataVector, 3, Frame::Inertial>& spatial_metric,
       const tnsr::II<DataVector, 3, Frame::Inertial>& inv_spatial_metric,
       const Scalar<DataVector>& sqrt_det_spatial_metric,
-      const EquationsOfState::EquationOfState<true, ThermodynamicDim>& eos,
+      const EquationsOfState::EquationOfState<true, 3>& eos,
       const grmhd::ValenciaDivClean::PrimitiveFromConservativeOptions&
           primitive_from_conservative_options);
 };

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/ResizeAndComputePrimitives.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/ResizeAndComputePrimitives.cpp
@@ -24,7 +24,6 @@
 
 namespace grmhd::ValenciaDivClean::subcell {
 template <typename OrderedListOfRecoverySchemes>
-template <size_t ThermodynamicDim>
 void ResizeAndComputePrims<OrderedListOfRecoverySchemes>::apply(
     const gsl::not_null<Variables<hydro::grmhd_tags<DataVector>>*> prim_vars,
     const evolution::dg::subcell::ActiveGrid active_grid,
@@ -37,7 +36,7 @@ void ResizeAndComputePrims<OrderedListOfRecoverySchemes>::apply(
     const tnsr::ii<DataVector, 3, Frame::Inertial>& spatial_metric,
     const tnsr::II<DataVector, 3, Frame::Inertial>& inv_spatial_metric,
     const Scalar<DataVector>& sqrt_det_spatial_metric,
-    const EquationsOfState::EquationOfState<true, ThermodynamicDim>& eos,
+    const EquationsOfState::EquationOfState<true, 3>& eos,
     const grmhd::ValenciaDivClean::PrimitiveFromConservativeOptions&
         primitive_from_conservative_options) {
   if (active_grid == evolution::dg::subcell::ActiveGrid::Dg) {
@@ -95,31 +94,14 @@ using KastaunThenNewmanThenPalenzuela =
 }  // namespace
 
 #define RECOVERY(data) BOOST_PP_TUPLE_ELEM(0, data)
-#define THERMO_DIM(data) BOOST_PP_TUPLE_ELEM(1, data)
-#define INSTANTIATION(r, data)                                               \
-  template void                                                              \
-  ResizeAndComputePrims<RECOVERY(data)>::apply<THERMO_DIM(data)>(            \
-      const gsl::not_null<Variables<hydro::grmhd_tags<DataVector>>*>         \
-          prim_vars,                                                         \
-      const evolution::dg::subcell::ActiveGrid active_grid,                  \
-      const Mesh<3>& dg_mesh, const Mesh<3>& subcell_mesh,                   \
-      const Scalar<DataVector>& tilde_d, const Scalar<DataVector>& tilde_ye, \
-      const Scalar<DataVector>& tilde_tau,                                   \
-      const tnsr::i<DataVector, 3, Frame::Inertial>& tilde_s,                \
-      const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_b,                \
-      const Scalar<DataVector>& tilde_phi,                                   \
-      const tnsr::ii<DataVector, 3, Frame::Inertial>& spatial_metric,        \
-      const tnsr::II<DataVector, 3, Frame::Inertial>& inv_spatial_metric,    \
-      const Scalar<DataVector>& sqrt_det_spatial_metric,                     \
-      const EquationsOfState::EquationOfState<true, THERMO_DIM(data)>& eos,  \
-      const grmhd::ValenciaDivClean::PrimitiveFromConservativeOptions&       \
-          primitive_from_conservative_options);
+#define INSTANTIATION(r, data) \
+  template struct ResizeAndComputePrims<RECOVERY(data)>;
+
 GENERATE_INSTANTIATIONS(INSTANTIATION,
                         (tmpl::list<PrimitiveRecoverySchemes::KastaunEtAl>,
                          tmpl::list<PrimitiveRecoverySchemes::NewmanHamlin>,
                          tmpl::list<PrimitiveRecoverySchemes::PalenzuelaEtAl>,
-                         NewmanThenPalenzuela, KastaunThenNewmanThenPalenzuela),
-                        (1, 2, 3))
+                         NewmanThenPalenzuela, KastaunThenNewmanThenPalenzuela))
 #undef INSTANTIATION
 #undef THERMO_DIM
 #undef RECOVERY

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/ResizeAndComputePrimitives.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/ResizeAndComputePrimitives.hpp
@@ -69,10 +69,9 @@ struct ResizeAndComputePrims {
       gr::Tags::SpatialMetric<DataVector, 3>,
       gr::Tags::InverseSpatialMetric<DataVector, 3>,
       gr::Tags::SqrtDetSpatialMetric<DataVector>,
-      hydro::Tags::EquationOfStateBase,
+      hydro::Tags::GrmhdEquationOfState,
       grmhd::ValenciaDivClean::Tags::PrimitiveFromConservativeOptions>;
 
-  template <size_t ThermodynamicDim>
   static void apply(
       gsl::not_null<Variables<hydro::grmhd_tags<DataVector>>*> prim_vars,
       evolution::dg::subcell::ActiveGrid active_grid, const Mesh<3>& dg_mesh,
@@ -84,7 +83,7 @@ struct ResizeAndComputePrims {
       const tnsr::ii<DataVector, 3, Frame::Inertial>& spatial_metric,
       const tnsr::II<DataVector, 3, Frame::Inertial>& inv_spatial_metric,
       const Scalar<DataVector>& sqrt_det_spatial_metric,
-      const EquationsOfState::EquationOfState<true, ThermodynamicDim>& eos,
+      const EquationsOfState::EquationOfState<true, 3>& eos,
       const grmhd::ValenciaDivClean::PrimitiveFromConservativeOptions&
           primitive_from_conservative_options);
 };

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TciOnDgGrid.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TciOnDgGrid.cpp
@@ -29,7 +29,6 @@
 
 namespace grmhd::ValenciaDivClean::subcell {
 template <typename RecoveryScheme>
-template <size_t ThermodynamicDim>
 std::tuple<int, evolution::dg::subcell::RdmpTciData>
 TciOnDgGrid<RecoveryScheme>::apply(
     const gsl::not_null<Variables<hydro::grmhd_tags<DataVector>>*> dg_prim_vars,
@@ -41,7 +40,7 @@ TciOnDgGrid<RecoveryScheme>::apply(
     const tnsr::ii<DataVector, 3, Frame::Inertial>& spatial_metric,
     const tnsr::II<DataVector, 3, Frame::Inertial>& inv_spatial_metric,
     const Scalar<DataVector>& sqrt_det_spatial_metric,
-    const EquationsOfState::EquationOfState<true, ThermodynamicDim>& eos,
+    const EquationsOfState::EquationOfState<true, 3>& eos,
     const Mesh<3>& dg_mesh, const Mesh<3>& subcell_mesh,
     const evolution::dg::subcell::RdmpTciData& past_rdmp_tci_data,
     const TciOptions& tci_options,
@@ -285,37 +284,5 @@ GENERATE_INSTANTIATIONS(
      grmhd::ValenciaDivClean::PrimitiveRecoverySchemes::NewmanHamlin,
      grmhd::ValenciaDivClean::PrimitiveRecoverySchemes::PalenzuelaEtAl))
 #undef INSTANTIATION
-
-#define THERMO_DIM(data) BOOST_PP_TUPLE_ELEM(1, data)
-#define INSTANTIATION(r, data)                                               \
-  template std::tuple<int, evolution::dg::subcell::RdmpTciData>              \
-  TciOnDgGrid<RECOVERY(data)>::apply<THERMO_DIM(data)>(                      \
-      const gsl::not_null<Variables<hydro::grmhd_tags<DataVector>>*>         \
-          dg_prim_vars,                                                      \
-      const Scalar<DataVector>& tilde_d, const Scalar<DataVector>& tilde_ye, \
-      const Scalar<DataVector>& tilde_tau,                                   \
-      const tnsr::i<DataVector, 3, Frame::Inertial>& tilde_s,                \
-      const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_b,                \
-      const Scalar<DataVector>& tilde_phi,                                   \
-      const tnsr::ii<DataVector, 3, Frame::Inertial>& spatial_metric,        \
-      const tnsr::II<DataVector, 3, Frame::Inertial>& inv_spatial_metric,    \
-      const Scalar<DataVector>& sqrt_det_spatial_metric,                     \
-      const EquationsOfState::EquationOfState<true, THERMO_DIM(data)>& eos,  \
-      const Mesh<3>& dg_mesh, const Mesh<3>& subcell_mesh,                   \
-      const evolution::dg::subcell::RdmpTciData& past_rdmp_tci_data,         \
-      const TciOptions& tci_options,                                         \
-      const evolution::dg::subcell::SubcellOptions& subcell_options,         \
-      const grmhd::ValenciaDivClean::PrimitiveFromConservativeOptions&       \
-          primitive_from_conservative_options,                               \
-      const double persson_exponent, const bool element_stays_on_dg);
-
-GENERATE_INSTANTIATIONS(
-    INSTANTIATION,
-    (grmhd::ValenciaDivClean::PrimitiveRecoverySchemes::KastaunEtAl,
-     grmhd::ValenciaDivClean::PrimitiveRecoverySchemes::NewmanHamlin,
-     grmhd::ValenciaDivClean::PrimitiveRecoverySchemes::PalenzuelaEtAl),
-    (1, 2, 3))
-#undef INSTANTIATION
-#undef THERMO_DIM
 #undef RECOVERY
 }  // namespace grmhd::ValenciaDivClean::subcell

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TciOnDgGrid.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TciOnDgGrid.hpp
@@ -145,13 +145,12 @@ class TciOnDgGrid {
       gr::Tags::SpatialMetric<DataVector, 3>,
       gr::Tags::InverseSpatialMetric<DataVector, 3>,
       gr::Tags::SqrtDetSpatialMetric<DataVector>,
-      hydro::Tags::EquationOfStateBase, domain::Tags::Mesh<3>,
+      hydro::Tags::GrmhdEquationOfState, domain::Tags::Mesh<3>,
       evolution::dg::subcell::Tags::Mesh<3>,
       evolution::dg::subcell::Tags::DataForRdmpTci, Tags::TciOptions,
       evolution::dg::subcell::Tags::SubcellOptions<3>,
       grmhd::ValenciaDivClean::Tags::PrimitiveFromConservativeOptions>;
 
-  template <size_t ThermodynamicDim>
   static std::tuple<int, evolution::dg::subcell::RdmpTciData> apply(
       gsl::not_null<Variables<hydro::grmhd_tags<DataVector>>*> dg_prim_vars,
       const Scalar<DataVector>& tilde_d, const Scalar<DataVector>& tilde_ye,
@@ -162,7 +161,7 @@ class TciOnDgGrid {
       const tnsr::ii<DataVector, 3, Frame::Inertial>& spatial_metric,
       const tnsr::II<DataVector, 3, Frame::Inertial>& inv_spatial_metric,
       const Scalar<DataVector>& sqrt_det_spatial_metric,
-      const EquationsOfState::EquationOfState<true, ThermodynamicDim>& eos,
+      const EquationsOfState::EquationOfState<true, 3>& eos,
       const Mesh<3>& dg_mesh, const Mesh<3>& subcell_mesh,
       const evolution::dg::subcell::RdmpTciData& past_rdmp_tci_data,
       const TciOptions& tci_options,

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/Barotropic3D.hpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/Barotropic3D.hpp
@@ -84,6 +84,9 @@ class Barotropic3D : public EquationOfState<ColdEquilEos::is_relativistic, 3> {
   bool is_equal(const EquationOfState<ColdEquilEos::is_relativistic, 3>& rhs)
       const override;
 
+  /// \brief Returns `true` if the EOS is barotropic
+  bool is_barotropic() const override { return true; }
+
   bool operator==(const Barotropic3D<ColdEquilEos>& rhs) const;
 
   bool operator!=(const Barotropic3D<ColdEquilEos>& rhs) const;

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/DarkEnergyFluid.hpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/DarkEnergyFluid.hpp
@@ -62,6 +62,9 @@ class DarkEnergyFluid : public EquationOfState<IsRelativistic, 2> {
 
   bool is_equal(const EquationOfState<IsRelativistic, 2>& rhs) const override;
 
+  /// \brief Returns `true` if the EOS is barotropic
+  bool is_barotropic() const override { return false; }
+
   bool operator==(const DarkEnergyFluid<IsRelativistic>& rhs) const;
 
   bool operator!=(const DarkEnergyFluid<IsRelativistic>& rhs) const;

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp
@@ -162,6 +162,8 @@ class EquationOfState<IsRelativistic, 1> : public PUP::able {
       const EquationOfState<IsRelativistic, 1>& rhs) const = 0;
   virtual std::unique_ptr<EquationOfState<IsRelativistic, 3>>
   promote_to_3d_eos() const = 0;
+  /// \brief Returns `true` if the EOS is barotropic
+  bool is_barotropic() const { return true; }
   /// @{
   /*!
    * Computes the electron fraction in beta-equilibrium \f$Y_e^{\rm eq}\f$ from
@@ -343,6 +345,9 @@ class EquationOfState<IsRelativistic, 2> : public PUP::able {
 
   virtual std::unique_ptr<EquationOfState<IsRelativistic, 3>>
   promote_to_3d_eos() const = 0;
+
+  /// \brief Returns `true` if the EOS is barotropic
+  virtual bool is_barotropic() const = 0;
 
   /// @{
   /*!
@@ -540,6 +545,9 @@ class EquationOfState<IsRelativistic, 3> : public PUP::able {
   promote_to_3d_eos() {
     return this->get_clone();
   }
+
+  /// \brief Returns `true` if the EOS is barotropic
+  virtual bool is_barotropic() const = 0;
 
   /// @{
   /*!

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/Equilibrium3D.hpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/Equilibrium3D.hpp
@@ -82,6 +82,9 @@ class Equilibrium3D : public EquationOfState<EquilEos::is_relativistic, 3> {
   bool is_equal(
       const EquationOfState<EquilEos::is_relativistic, 3>& rhs) const override;
 
+  /// \brief Returns `true` if the EOS is barotropic
+  bool is_barotropic() const override { return false; }
+
   bool operator==(const Equilibrium3D<EquilEos>& rhs) const;
 
   bool operator!=(const Equilibrium3D<EquilEos>& rhs) const;

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/HybridEos.hpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/HybridEos.hpp
@@ -102,6 +102,9 @@ class HybridEos
   std::unique_ptr<EquationOfState<is_relativistic, 3>> promote_to_3d_eos()
       const override;
 
+  /// \brief Returns `true` if the EOS is barotropic
+  bool is_barotropic() const override { return false; }
+
   bool operator==(const HybridEos<ColdEquationOfState>& rhs) const;
 
   bool operator!=(const HybridEos<ColdEquationOfState>& rhs) const;

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/IdealFluid.hpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/IdealFluid.hpp
@@ -82,6 +82,9 @@ class IdealFluid : public EquationOfState<IsRelativistic, 2> {
   std::unique_ptr<EquationOfState<IsRelativistic, 3>> promote_to_3d_eos()
       const override;
 
+  /// \brief Returns `true` if the EOS is barotropic
+  bool is_barotropic() const override { return false; }
+
   bool operator==(const IdealFluid<IsRelativistic>& rhs) const;
 
   bool operator!=(const IdealFluid<IsRelativistic>& rhs) const;

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/Tabulated3d.hpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/Tabulated3d.hpp
@@ -126,6 +126,9 @@ class Tabulated3D : public EquationOfState<IsRelativistic, 3> {
 
   bool is_equal(const EquationOfState<IsRelativistic, 3>& rhs) const override;
 
+  /// \brief Returns `true` if the EOS is barotropic
+  bool is_barotropic() const override { return false; }
+
   bool operator==(const Tabulated3D<IsRelativistic>& rhs) const;
 
   bool operator!=(const Tabulated3D<IsRelativistic>& rhs) const;

--- a/src/PointwiseFunctions/Hydro/TagsDeclarations.hpp
+++ b/src/PointwiseFunctions/Hydro/TagsDeclarations.hpp
@@ -32,6 +32,7 @@ struct ElectronFraction;
 struct EquationOfStateBase;
 template <typename EquationOfStateType>
 struct EquationOfState;
+struct GrmhdEquationOfState;
 template <typename DataType>
 struct InversePlasmaBeta;
 template <typename DataType>

--- a/tests/Unit/Evolution/DgSubcell/Test_NeighborReconstructedFaceSolution.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Test_NeighborReconstructedFaceSolution.cpp
@@ -127,7 +127,9 @@ void test() {
                           std::nullopt,   {},           4};
     }
   }
-  evolution::dg::subcell::neighbor_reconstructed_face_solution<metavars>(
+  evolution::dg::subcell::neighbor_reconstructed_face_solution<
+      Dim,
+      typename metavars::SubcellOptions::DgComputeSubcellNeighborPackagedData>(
       make_not_null(&box), make_not_null(&mortar_data_from_neighbors));
   for (size_t d = 0; d < Dim; ++d) {
     CAPTURE(d);

--- a/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/Test_FixConservativesAndComputePrims.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/Test_FixConservativesAndComputePrims.cpp
@@ -76,8 +76,7 @@ void test(const EquationOfStateType& eos) {
       grmhd::ValenciaDivClean::Tags::VariablesNeededFixing,
       typename System::variables_tag, typename System::primitive_variables_tag,
       ::Tags::VariableFixer<grmhd::ValenciaDivClean::FixConservatives>,
-      hydro::Tags::EquationOfState<std::unique_ptr<
-          typename EquationsOfState::get_eos_base<EquationOfStateType>>>,
+      hydro::Tags::GrmhdEquationOfState,
       grmhd::ValenciaDivClean::Tags::PrimitiveFromConservativeOptions>>(
       subcell_coords, false, cons_vars,
       typename System::primitive_variables_tag::type{num_pts, 1.0e-4},
@@ -135,7 +134,6 @@ void test(const EquationOfStateType& eos) {
 SPECTRE_TEST_CASE(
     "Unit.Evolution.Systems.GhValenciaDivClean.Subcell.FixConsAndComputePrims",
     "[Unit][Evolution]") {
-  test(EquationsOfState::PolytropicFluid<true>(100.0, 2.0));
   test(EquationsOfState::Barotropic3D(
       EquationsOfState::PolytropicFluid<true>(100.0, 2.0)));
 }

--- a/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/Test_PrimsAfterRollback.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/Test_PrimsAfterRollback.cpp
@@ -148,12 +148,11 @@ void test(const gsl::not_null<std::mt19937*> gen,
   auto box = db::create<db::AddSimpleTags<
       evolution::dg::subcell::Tags::DidRollback, cons_tag, prim_tag,
       gr::Tags::SpacetimeMetric<DataVector, 3>, ::domain::Tags::Mesh<3>,
-      evolution::dg::subcell::Tags::Mesh<3>,
-      hydro::Tags::EquationOfState<
-          std::unique_ptr<EquationsOfState::get_eos_base<EquationOfStateType>>>,
+      evolution::dg::subcell::Tags::Mesh<3>, hydro::Tags::GrmhdEquationOfState,
       grmhd::ValenciaDivClean::Tags::PrimitiveFromConservativeOptions>>(
       did_rollback, subcell_cons, dg_prims, spacetime_metric, dg_mesh,
-      subcell_mesh, std::move(eos), primitive_from_conservative_options);
+      subcell_mesh, eos->promote_to_3d_eos(),
+      primitive_from_conservative_options);
 
   using recovery_schemes = tmpl::list<
       grmhd::ValenciaDivClean::PrimitiveRecoverySchemes::KastaunEtAl,

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_FixConservativesAndComputePrims.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_FixConservativesAndComputePrims.cpp
@@ -45,7 +45,8 @@ SPECTRE_TEST_CASE(
   get(get<grmhd::ValenciaDivClean::Tags::TildeYe>(cons_vars))[0] = 2.e-13;
   get(get<grmhd::ValenciaDivClean::Tags::TildeTau>(cons_vars))[0] = 1.e-7;
 
-  const EquationsOfState::PolytropicFluid<true> eos{100.0, 2.0};
+  const EquationsOfState::Barotropic3D eos{
+      EquationsOfState::PolytropicFluid<true>{100.0, 2.0}};
 
   const double cutoff_d_for_inversion = 0.0;
   const double density_when_skipping_inversion = 0.0;
@@ -59,19 +60,14 @@ SPECTRE_TEST_CASE(
       grmhd::ValenciaDivClean::Tags::VariablesNeededFixing,
       typename System::variables_tag, typename System::primitive_variables_tag,
       ::Tags::VariableFixer<grmhd::ValenciaDivClean::FixConservatives>,
-      hydro::Tags::EquationOfState<
-          std::unique_ptr<EquationsOfState::EquationOfState<true, 1>>>,
-      gr::Tags::SpatialMetric<DataVector, 3>,
+      hydro::Tags::GrmhdEquationOfState, gr::Tags::SpatialMetric<DataVector, 3>,
       gr::Tags::InverseSpatialMetric<DataVector, 3>,
       gr::Tags::SqrtDetSpatialMetric<DataVector>,
       grmhd::ValenciaDivClean::Tags::PrimitiveFromConservativeOptions>>(
       false, cons_vars,
       typename System::primitive_variables_tag::type{num_pts, 1.0e-4},
-      variable_fixer,
-      std::unique_ptr<EquationsOfState::EquationOfState<true, 1>>{
-          std::make_unique<EquationsOfState::PolytropicFluid<true>>(eos)},
-      spatial_metric, inverse_spatial_metric, sqrt_det_spatial_metric,
-      primitive_from_conservative_options);
+      variable_fixer, eos.get_clone(), spatial_metric, inverse_spatial_metric,
+      sqrt_det_spatial_metric, primitive_from_conservative_options);
 
   using recovery_schemes = tmpl::list<
       grmhd::ValenciaDivClean::PrimitiveRecoverySchemes::KastaunEtAl>;

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_PrimsAfterRollback.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_PrimsAfterRollback.cpp
@@ -129,12 +129,10 @@ void test(const gsl::not_null<std::mt19937*> gen,
       gr::Tags::SpatialMetric<DataVector, 3>,
       gr::Tags::InverseSpatialMetric<DataVector, 3>,
       gr::Tags::SqrtDetSpatialMetric<DataVector>, ::domain::Tags::Mesh<3>,
-      evolution::dg::subcell::Tags::Mesh<3>,
-      hydro::Tags::EquationOfState<
-          std::unique_ptr<EquationsOfState::EquationOfState<true, 1>>>,
+      evolution::dg::subcell::Tags::Mesh<3>, hydro::Tags::GrmhdEquationOfState,
       grmhd::ValenciaDivClean::Tags::PrimitiveFromConservativeOptions>>(
       did_rollback, subcell_cons, dg_prims, spatial_metric, inv_spatial_metric,
-      sqrt_det_spatial_metric, dg_mesh, subcell_mesh, std::move(eos),
+      sqrt_det_spatial_metric, dg_mesh, subcell_mesh, eos->promote_to_3d_eos(),
       primitive_from_conservative_options);
 
   using recovery_schemes = tmpl::list<

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Test_Flattener.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Test_Flattener.cpp
@@ -32,7 +32,8 @@ SPECTRE_TEST_CASE("Unit.GrMhd.ValenciaDivClean.Flattener", "[Unit][GrMhd]") {
                      Spectral::Quadrature::GaussLobatto);
   const size_t num_points = mesh.number_of_grid_points();
 
-  EquationsOfState::IdealFluid<true> ideal_fluid(4.0 / 3.0);
+  const EquationsOfState::Equilibrium3D ideal_fluid{
+      EquationsOfState::IdealFluid<true>{4.0 / 3.0}};
   const Scalar<DataVector> tilde_phi(num_points, 0.);
   tnsr::I<DataVector, 3> tilde_b;
   get<0>(tilde_b) = DataVector(num_points, 0.02);


### PR DESCRIPTION
## Proposed changes

I found this while trying to give access to volume tags in the `dg_boundary_terms` function of our boundary corrections, which is why some metavariables rework is also in here. 

- Reduces the use of `Metavariables` in some of the boundary corrections code. This will allow us to do more explicit instantiations and also just reduces the amount we "reach up" into the metavariables.
- Use the `GrmhdEquationOfState` tag in more places
- Add `is_barotropic` function to EOSes
- Fix using barotropic EOS in evolution

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
