### PR TITLE
Add `FaceQuantitiesCompute` tag

### DIFF
--- a/src/Evolution/Executables/CurvedScalarWave/EvolveWorldtubeCurvedScalarWave.hpp
+++ b/src/Evolution/Executables/CurvedScalarWave/EvolveWorldtubeCurvedScalarWave.hpp
@@ -301,6 +301,7 @@ struct EvolutionMetavars {
               volume_dim, Frame::Inertial, true>,
           CurvedScalarWave::Worldtube::Tags::GeodesicAccelerationCompute<3>,
           CurvedScalarWave::Worldtube::Tags::PunctureFieldCompute<volume_dim>,
+          CurvedScalarWave::Worldtube::Tags::FaceQuantitiesCompute,
           ::domain::Tags::GridToInertialInverseJacobian<volume_dim>>>,
       ::evolution::dg::Initialization::Mortars<volume_dim, system>,
       intrp::Actions::ElementInitInterpPoints<

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/ElementActions/Test_SendToWorldtube.cpp
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/ElementActions/Test_SendToWorldtube.cpp
@@ -70,7 +70,8 @@ struct MockElementArray {
                   typename CurvedScalarWave::System<Dim>::variables_tag,
                   ::Tags::TimeStepId, Tags::ParticlePositionVelocity<Dim>>,
               db::AddComputeTags<
-                  Tags::FaceCoordinatesCompute<Dim, Frame::Inertial, true>>>>>,
+                  Tags::FaceCoordinatesCompute<Dim, Frame::Inertial, true>,
+                  Tags::FaceQuantitiesCompute>>>>,
       Parallel::PhaseActions<Parallel::Phase::Testing,
                              tmpl::list<Actions::SendToWorldtube>>>;
 };


### PR DESCRIPTION
In the iterative scheme that I will open PRs for shortly, the puncture field needs to be evaluated several times each time step and `Actions::SendToWorldtube` is run each time. This new compute tag caches all the quantities on the element faces adjacent to the worldtube that do not need to be re-computed. Doing so, it simplifies the action `SendToWorldtube` quite a bit by off-loading the work to the compute tag.

It also uses the C++20 feature of templated lambdas because we can now ;)