### PR TITLE
Add pybinding for WeylTypeD1 

### DIFF
--- a/src/PointwiseFunctions/GeneralRelativity/Python/Bindings.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/Python/Bindings.cpp
@@ -26,6 +26,7 @@
 #include "PointwiseFunctions/GeneralRelativity/WeylElectric.hpp"
 #include "PointwiseFunctions/GeneralRelativity/WeylMagnetic.hpp"
 #include "PointwiseFunctions/GeneralRelativity/WeylPropagating.hpp"
+#include "PointwiseFunctions/GeneralRelativity/WeylTypeD1.hpp"
 #include "Utilities/ErrorHandling/SegfaultHandler.hpp"
 
 namespace py = pybind11;
@@ -251,6 +252,22 @@ void bind_impl(py::module& m) {  // NOLINT
         py::arg("cov_deriv_extrinsic_curvature"),
         py::arg("unit_interface_normal_vector"), py::arg("projection_IJ"),
         py::arg("projection_ij"), py::arg("projection_Ij"), py::arg("sign"));
+
+  m.def(
+      "weyl_type_D1",
+      static_cast<tnsr::ii<DataVector, 3, Frame::Inertial> (*)(
+          const tnsr::ii<DataVector, 3, Frame::Inertial>&,
+          const tnsr::ii<DataVector, 3, Frame::Inertial>&,
+          const tnsr::II<DataVector, 3, Frame::Inertial>&)>(&gr::weyl_type_D1),
+      py::arg("weyl_electric"), py::arg("spatial_metric"),
+      py::arg("inverse_spatial_metric"));
+
+  m.def("weyl_type_D1_scalar",
+        static_cast<Scalar<DataVector> (*)(
+            const tnsr::ii<DataVector, 3, Frame::Inertial>&,
+            const tnsr::II<DataVector, 3, Frame::Inertial>&)>(
+            &gr::weyl_type_D1_scalar),
+        py::arg("weyl_type_D1"), py::arg("inverse_spatial_metric"));
 }
 }  // namespace
 

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Python/Test_Bindings.py
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Python/Test_Bindings.py
@@ -267,6 +267,23 @@ class TestBindings(unittest.TestCase):
         )
         npt.assert_allclose(weyl_mag_scalar, 0)
 
+    def test_weyl_type_D1(self):
+        weyl_electric = tnsr.ii[DataVector, 3](num_points=1, fill=-1.0)
+        spatial_metric = tnsr.ii[DataVector, 3](num_points=1, fill=0.0)
+        inverse_spatial_metric = tnsr.II[DataVector, 3](num_points=1, fill=-1.0)
+        weyl_D1 = weyl_type_D1(
+            weyl_electric, spatial_metric, inverse_spatial_metric
+        )
+        npt.assert_allclose(weyl_D1, 0)
+
+    def test_weyl_type_D1_scalar(self):
+        weyl_type_D1 = tnsr.ii[DataVector, 3](num_points=1, fill=1.0)
+        inverse_spatial_metric = tnsr.II[DataVector, 3](num_points=1, fill=0.0)
+        weyl_D1_scalar = weyl_type_D1_scalar(
+            weyl_type_D1, inverse_spatial_metric
+        )
+        npt.assert_allclose(weyl_D1_scalar, 0)
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Proposed changes

Add the pybinding for the weyl type D1 and weyl type D1 scalar. 

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
