### PR TITLE
Add gallery to docs

### DIFF
--- a/docs/Doxyfile.in
+++ b/docs/Doxyfile.in
@@ -98,6 +98,7 @@ INPUT = @PROJECT_SOURCE_DIR@/docs/Installation \
         @PROJECT_SOURCE_DIR@/docs/Examples \
         @PROJECT_SOURCE_DIR@/docs/Contributing \
         @PROJECT_SOURCE_DIR@/docs/DevGuide \
+        @PROJECT_SOURCE_DIR@/docs/Gallery.md \
         @PROJECT_SOURCE_DIR@/docs/PublicationPolicy.md \
         @PROJECT_SOURCE_DIR@/docs/Changelog.md \
         @PROJECT_SOURCE_DIR@/docs \

--- a/docs/Gallery.md
+++ b/docs/Gallery.md
@@ -1,0 +1,37 @@
+\cond NEVER
+Distributed under the MIT License.
+See LICENSE.txt for details.
+\endcond
+
+\cond NEVER
+Instructions for adding images or videos:
+
+1. Send your media files to a SpECTRE core dev (see CONTRIBUTING.md for details
+   and communication channels). They will place the files in this public Google
+   Drive folder:
+   https://drive.google.com/drive/folders/1xvLplF_pPlkADGfgFNaW_ByVATFv61m-
+2. Open the media files in Google Drive and get their file IDs. To do this,
+   select [...] > Open in new window > Copy the <FILE_ID> in the URL of the form
+   https://drive.google.com/file/d/<FILE_ID>/view.
+3. Add a section to this page.
+   - Embed images like this:
+     <img src="https://drive.google.com/thumbnail?id=<FILE_ID>&sz=w<WIDTH>"/>
+     Replace <WIDTH> with the width you want your image to have on the page.
+     Google Drive will automatically provide an image of this size.
+   - Embed videos like this:
+     \htmlonly
+     <iframe src="https://drive.google.com/file/d/18KIEoK8oH6WDifx0cyFkl2ncKijNtaxs/preview" width="640" height="480" allow="autoplay" allowfullscreen></iframe>
+     \endhtmlonly
+4. Open a pull request to contribute your changes (see CONTRIBUTING.md for
+   details).
+\endcond
+
+# Gallery {#gallery}
+
+This page highlights some visualizations of SpECTRE simulations.
+
+## Adaptive mesh refinement
+
+Here's an image of an adaptively refined mesh:
+
+<img src="https://drive.google.com/thumbnail?id=1ivR2Wbu_RYvHih098waKi6jqx637pSUn&sz=w600"/>


### PR DESCRIPTION
## Proposed changes

Adds a gallery page so we can start collecting some nice visualizations. We can move this to a nicer landing page later. It currently looks like this:

![Bildschirmfoto 2024-03-07 um 12 13 20](https://github.com/sxs-collaboration/spectre/assets/746230/e8ae89a1-d0c4-4ed2-a8cc-4f9de9e7fa1e)

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
