### PR TITLE
Fix Puncture AMR criterion at element boundaries

### DIFF
--- a/src/Domain/ElementLogicalCoordinates.hpp
+++ b/src/Domain/ElementLogicalCoordinates.hpp
@@ -21,6 +21,23 @@ template <typename IdType, typename DataType>
 class IdPair;
 /// \endcond
 
+/*!
+ * \brief Map block logical coordinates to element logical coordinates
+ *
+ * If the point is outside the element, returns std::nullopt. Otherwise, returns
+ * the element logical coordinates of the point.
+ *
+ * Points on the element boundary are considered to be in the element and will
+ * have element logical coordinates of -1 or 1. See the other function overload
+ * for handling multiple points and disambiguating points on shared element
+ * boundaries.
+ */
+template <size_t Dim>
+std::optional<tnsr::I<double, Dim, Frame::ElementLogical>>
+element_logical_coordinates(
+    const tnsr::I<double, Dim, Frame::BlockLogical>& x_block_logical,
+    const ElementId<Dim>& element_id);
+
 /// \ingroup ComputationalDomainGroup
 ///
 /// Holds element logical coordinates of an arbitrary set of points on

--- a/src/Domain/Python/ElementLogicalCoordinates.cpp
+++ b/src/Domain/Python/ElementLogicalCoordinates.cpp
@@ -31,12 +31,23 @@ namespace domain::py_bindings {
 namespace {
 template <size_t Dim>
 void bind_element_logical_coordinates_impl(py::module& m) {  // NOLINT
+  m.def("element_logical_coordinates",
+        py::overload_cast<const tnsr::I<double, Dim, Frame::BlockLogical>&,
+                          const ElementId<Dim>&>(
+            &element_logical_coordinates<Dim>),
+        py::arg("x_block_logical"), py::arg("element_id"));
   py::class_<ElementLogicalCoordHolder<Dim>>(
       m, ("ElementLogicalCoordHolder" + get_output(Dim) + "D").c_str())
       .def_readonly("element_logical_coords",
                     &ElementLogicalCoordHolder<Dim>::element_logical_coords)
       .def_readonly("offsets", &ElementLogicalCoordHolder<Dim>::offsets);
-  m.def("element_logical_coordinates", &element_logical_coordinates<Dim>,
+  m.def("element_logical_coordinates",
+        py::overload_cast<
+            const std::vector<ElementId<Dim>>&,
+            const std::vector<std::optional<
+                IdPair<domain::BlockId,
+                       tnsr::I<double, Dim, typename Frame::BlockLogical>>>>&>(
+            &element_logical_coordinates<Dim>),
         py::arg("element_ids"), py::arg("block_coord_holders"));
 }
 }  // namespace

--- a/tests/Unit/Domain/Python/Test_BlockAndElementLogicalCoordinates.py
+++ b/tests/Unit/Domain/Python/Test_BlockAndElementLogicalCoordinates.py
@@ -5,6 +5,7 @@ import os
 import unittest
 
 import numpy as np
+import numpy.testing as npt
 
 import spectre.IO.H5 as spectre_h5
 from spectre.DataStructures import DataVector
@@ -20,6 +21,22 @@ from spectre.Informer import unit_test_src_path
 
 
 class TestBlockAndElementLogicalCoordinates(unittest.TestCase):
+    def test_element_logical_coordinates(self):
+        block_logical_coords = tnsr.I[float, 3, Frame.BlockLogical](
+            [0.0, -0.5, 0.25]
+        )
+        self.assertIsNone(
+            element_logical_coordinates(
+                block_logical_coords, ElementId[3]("[B0,(L1I0,L1I1,L1I1)]")
+            )
+        )
+        logical_coords = np.array(
+            element_logical_coordinates(
+                block_logical_coords, ElementId[3]("[B0,(L1I0,L1I0,L1I1)]")
+            )
+        )
+        npt.assert_allclose(logical_coords, [1.0, 0.0, -0.5])
+
     def test_block_and_element_logical_coordinates(self):
         volfile_name = os.path.join(
             unit_test_src_path(), "Visualization/Python/VolTestData0.h5"

--- a/tests/Unit/Domain/Test_BlockAndElementLogicalCoordinates.cpp
+++ b/tests/Unit/Domain/Test_BlockAndElementLogicalCoordinates.cpp
@@ -41,6 +41,39 @@
 
 namespace {
 
+void test_element_logical_coordinates() {
+  CHECK(element_logical_coordinates(
+            tnsr::I<double, 1, Frame::BlockLogical>{{{0.5}}},
+            ElementId<1>{0, {{{1, 0}}}}) == std::nullopt);
+  CHECK(element_logical_coordinates(
+            tnsr::I<double, 1, Frame::BlockLogical>{{{0.5}}},
+            ElementId<1>{0, {{{1, 1}}}}) ==
+        tnsr::I<double, 1, Frame::ElementLogical>{{{0.}}});
+  CHECK(element_logical_coordinates(
+            tnsr::I<double, 1, Frame::BlockLogical>{{{0.}}},
+            ElementId<1>{0, {{{1, 0}}}}) ==
+        tnsr::I<double, 1, Frame::ElementLogical>{{{1.}}});
+  CHECK(element_logical_coordinates(
+            tnsr::I<double, 1, Frame::BlockLogical>{{{0.}}},
+            ElementId<1>{0, {{{1, 1}}}}) ==
+        tnsr::I<double, 1, Frame::ElementLogical>{{{-1.}}});
+  CHECK(element_logical_coordinates(
+            tnsr::I<double, 2, Frame::BlockLogical>{{{-0.5, -0.5}}},
+            ElementId<2>{0, {{{1, 0}, {1, 0}}}}) ==
+        tnsr::I<double, 2, Frame::ElementLogical>{{{0., 0.}}});
+  CHECK(element_logical_coordinates(
+            tnsr::I<double, 2, Frame::BlockLogical>{{{-0.5, -0.5}}},
+            ElementId<2>{0, {{{1, 0}, {1, 1}}}}) == std::nullopt);
+  CHECK(element_logical_coordinates(
+            tnsr::I<double, 2, Frame::BlockLogical>{{{0., 0.5}}},
+            ElementId<2>{0, {{{1, 0}, {1, 1}}}}) ==
+        tnsr::I<double, 2, Frame::ElementLogical>{{{1., 0.}}});
+  CHECK(element_logical_coordinates(
+            tnsr::I<double, 3, Frame::BlockLogical>{{{0., 0.5, 1.}}},
+            ElementId<3>{0, {{{1, 0}, {1, 1}, {1, 1}}}}) ==
+        tnsr::I<double, 3, Frame::ElementLogical>{{{1., 0., 1.}}});
+}
+
 template <size_t Dim>
 void fuzzy_test_block_and_element_logical_coordinates(
     const Domain<Dim>& domain,
@@ -792,6 +825,7 @@ void test_block_logical_coordinates_with_roundoff_error() {
 
 SPECTRE_TEST_CASE("Unit.Domain.BlockAndElementLogicalCoords",
                   "[Domain][Unit]") {
+  test_element_logical_coordinates();
   test_block_and_element_logical_coordinates1();
   test_block_and_element_logical_coordinates3();
   fuzzy_test_block_and_element_logical_coordinates3(20);


### PR DESCRIPTION
## Proposed changes

Before, if the puncture is on a shared element boundary, only one of the abutting
elements was refined. This was because the `{block,element}_logical_coordinates`
functions disambiguate points on element boundaries so they always map to one
unique element. This is not the expected behavior for the AMR criterion.
Now, all abutting elements are refined.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
