### PR TITLE
Add initial data executable to release container

### DIFF
--- a/.github/workflows/DemoContainer.yaml
+++ b/.github/workflows/DemoContainer.yaml
@@ -5,6 +5,17 @@ name: Deploy containers
 
 on:
   workflow_dispatch:
+    inputs:
+      image_name:
+        description: >
+          Image name to push to DockerHub
+        required: true
+        default: 'sxscollaboration/spectre'
+      build_arm:
+        type: boolean
+        description: >
+          Build ARM container in addition to x86_64
+        default: true
 
   workflow_call:
     secrets:
@@ -39,8 +50,10 @@ jobs:
           context: .
           file: "./containers/Dockerfile.buildenv"
           target: deploy
-          tags: sxscollaboration/spectre:deploy,sxscollaboration/spectre:latest
-          platforms: linux/amd64,linux/arm64
+          tags: ${{ inputs.image_name }}:deploy,${{ inputs.image_name }}:latest
+          platforms: >
+            ${{ inputs.build_arm && 'linux/amd64,linux/arm64'
+            || 'linux/amd64' }}
       - name: Build and push demo container
         uses: docker/build-push-action@v3
         with:
@@ -48,6 +61,8 @@ jobs:
           context: .
           file: "./containers/Dockerfile.buildenv"
           target: demo
-          tags: sxscollaboration/spectre:demo
-          platforms: linux/amd64,linux/arm64
+          tags: ${{ inputs.image_name }}:demo
+          platforms: >
+            ${{ inputs.build_arm && 'linux/amd64,linux/arm64'
+            || 'linux/amd64' }}
 

--- a/containers/Dockerfile.buildenv
+++ b/containers/Dockerfile.buildenv
@@ -387,6 +387,7 @@ RUN if [ "$TARGETARCH" = "$BUILDARCH" ] ; then \
         cd spectre/build \
         && make ${PARALLEL_MAKE_ARG} cli \
         && make ${PARALLEL_MAKE_ARG} CharacteristicExtract \
+        && make ${PARALLEL_MAKE_ARG} SolveXcts \
     ; fi
 
 ENV SPECTRE_HOME /work/spectre

--- a/containers/Dockerfile.buildenv
+++ b/containers/Dockerfile.buildenv
@@ -394,6 +394,9 @@ ENV SPECTRE_HOME /work/spectre
 ENV PATH $SPECTRE_HOME/build/bin:$PATH
 ENV PYTHONPATH $SPECTRE_HOME/build/bin/python:$PYTHONPATH
 
+# Set the CLI as entrypoint
+ENTRYPOINT ["spectre"]
+CMD ["--help"]
 
 # Build a demo image with extra software used in the tutorials.
 FROM deploy AS demo


### PR DESCRIPTION
## Proposed changes

Compile the initial data executable into the container that gets built at every release. This will allow generating initial data on any machine without having to install anything (at least on 1 node, I haven't tried containerized multi-node runs recently). Example:

```sh
# Works on Linux. Doesn't work on macOS because the macOS container
# doesn't come with precompiled executables.
docker run sxscollaboration/spectre bbh generate-id -q 1 -D 16 -w 0.015 -a 0 -o ID
```

Also works on a cluster with Apptainer/Singularity:

```sh
# On CaltechHPC:
module purge
module load apptainer/1.1.9-gcc-11.3.1-mbji4yi
apptainer run docker://sxscollaboration/spectre bbh generate-id -q 1 -D 16 -w 0.015 -a 0 -o ID
# Then do a quick plot:
apptainer run docker://sxscollaboration/spectre plot slice ID/BbhVolume*.h5 -y ConformalFactor -o plot.pdf -C 8,0,0 -n 0,0,1 -u 0,1,0 -X 5 5
```

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
