### PR TITLE
Add tags for worldtube iterations

### DIFF
--- a/src/Evolution/Executables/CurvedScalarWave/EvolveWorldtubeCurvedScalarWave.hpp
+++ b/src/Evolution/Executables/CurvedScalarWave/EvolveWorldtubeCurvedScalarWave.hpp
@@ -267,7 +267,7 @@ struct EvolutionMetavars {
       CurvedScalarWave::Worldtube::Tags::ExpansionOrder,
       CurvedScalarWave::Worldtube::Tags::Charge,
       CurvedScalarWave::Worldtube::Tags::Mass,
-      CurvedScalarWave::Worldtube::Tags::ApplySelfForce,
+      CurvedScalarWave::Worldtube::Tags::MaxIterations,
       CurvedScalarWave::Worldtube::Tags::ObserveCoefficientsTrigger>;
 
   using dg_registration_list =

--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/ElementActions/CMakeLists.txt
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/ElementActions/CMakeLists.txt
@@ -12,6 +12,7 @@ spectre_target_headers(
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   InitializeConstraintGammas.hpp
+  InitializeCurrentIteration.hpp
   ReceiveWorldtubeData.hpp
   SendToWorldtube.hpp
 )

--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/ElementActions/InitializeCurrentIteration.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/ElementActions/InitializeCurrentIteration.hpp
@@ -1,0 +1,30 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/DataBox/Protocols/Mutator.hpp"
+#include "Evolution/Systems/CurvedScalarWave/Worldtube/Tags.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
+
+namespace CurvedScalarWave::Worldtube::Initialization {
+
+/*!
+ * \brief Sets the initial value of `CurrentIteration to 0.
+ */
+struct InitializeCurrentIteration : tt::ConformsTo<db::protocols::Mutator> {
+  using return_tags =
+      tmpl::list<CurvedScalarWave::Worldtube::Tags::CurrentIteration>;
+  using argument_tags = tmpl::list<>;
+  using simple_tags = return_tags;
+  using compute_tags = tmpl::list<>;
+  using simple_tags_from_options = tmpl::list<>;
+  using const_global_cache_tags = tmpl::list<>;
+  using mutable_global_cache_tags = tmpl::list<>;
+  static void apply(const gsl::not_null<size_t*> current_iteration) {
+    *current_iteration = 0;
+  }
+};
+}  // namespace CurvedScalarWave::Worldtube::Initialization

--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonActions/InitializeEvolvedVariables.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonActions/InitializeEvolvedVariables.hpp
@@ -2,9 +2,7 @@
 // See LICENSE.txt for details.
 
 #pragma once
-
 #include <cstddef>
-
 #include "DataStructures/DataBox/Prefixes.hpp"
 #include "DataStructures/Variables.hpp"
 #include "DataStructures/VariablesTag.hpp"
@@ -12,18 +10,16 @@
 #include "Time/Tags/HistoryEvolvedVariables.hpp"
 #include "Time/TimeSteppers/TimeStepper.hpp"
 #include "Utilities/Gsl.hpp"
-
 /// \cond
 namespace Tags {
 template <typename StepperInterface>
 struct TimeStepper;
 }  // namespace Tags
 /// \endcond
-
 namespace CurvedScalarWave::Worldtube::Initialization {
 /*!
  * \brief Initializes the time stepper and evolved variables used by the
- * worldtube system.
+ * worldtube system. Also sets `Tags::CurrentIteration` to 0.
  *
  * \details Sets the initial position and velocity of the particle to the values
  * specified in the input file. The time stepper history is set analogous to the
@@ -36,7 +32,7 @@ struct InitializeEvolvedVariables {
   using dt_variables_tag = db::add_tag_prefix<::Tags::dt, variables_tag>;
 
   using simple_tags =
-      tmpl::list<variables_tag, dt_variables_tag,
+      tmpl::list<variables_tag, dt_variables_tag, Tags::CurrentIteration,
                  ::Tags::HistoryEvolvedVariables<variables_tag>>;
   using return_tags = simple_tags;
 
@@ -54,11 +50,12 @@ struct InitializeEvolvedVariables {
           Variables<tmpl::list<::Tags::dt<Tags::EvolvedPosition<Dim>>,
                                ::Tags::dt<Tags::EvolvedVelocity<Dim>>>>*>
           dt_evolved_vars,
+      const gsl::not_null<size_t*> current_iteration,
       const gsl::not_null<::Tags::HistoryEvolvedVariables<variables_tag>::type*>
           time_stepper_history,
       const TimeStepper& time_stepper,
-
       const std::array<tnsr::I<double, Dim>, 2>& initial_pos_and_vel) {
+    *current_iteration = 0;
     const size_t starting_order =
         time_stepper.number_of_past_steps() == 0 ? time_stepper.order() : 1;
     *time_stepper_history =

--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonActions/UpdateAcceleration.cpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonActions/UpdateAcceleration.cpp
@@ -24,7 +24,8 @@ void UpdateAcceleration::apply(
     const tnsr::I<double, Dim, Frame::Inertial>& geodesic_acc,
     const Scalar<double>& dt_psi_monopole,
     const tnsr::i<double, Dim, Frame::Inertial>& psi_dipole,
-    const double charge, const double mass, const bool apply_self_force) {
+    const double charge, const std::optional<double> mass,
+    const bool apply_self_force) {
   tnsr::I<double, Dim> self_force_acc(0.);
   const auto& particle_velocity = pos_vel.at(1);
   if (apply_self_force) {
@@ -32,7 +33,7 @@ void UpdateAcceleration::apply(
         get<gr::Tags::InverseSpacetimeMetric<double, Dim>>(background);
     const auto& dilation_factor = get<Tags::TimeDilationFactor>(background);
     self_force_acceleration(make_not_null(&self_force_acc), dt_psi_monopole,
-                            psi_dipole, particle_velocity, charge, mass,
+                            psi_dipole, particle_velocity, charge, mass.value(),
                             inverse_metric, dilation_factor);
   }
   for (size_t i = 0; i < Dim; ++i) {

--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonActions/UpdateAcceleration.cpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonActions/UpdateAcceleration.cpp
@@ -25,10 +25,10 @@ void UpdateAcceleration::apply(
     const Scalar<double>& dt_psi_monopole,
     const tnsr::i<double, Dim, Frame::Inertial>& psi_dipole,
     const double charge, const std::optional<double> mass,
-    const bool apply_self_force) {
+    const size_t max_iterations) {
   tnsr::I<double, Dim> self_force_acc(0.);
   const auto& particle_velocity = pos_vel.at(1);
-  if (apply_self_force) {
+  if (max_iterations > 0) {
     const auto& inverse_metric =
         get<gr::Tags::InverseSpacetimeMetric<double, Dim>>(background);
     const auto& dilation_factor = get<Tags::TimeDilationFactor>(background);

--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonActions/UpdateAcceleration.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonActions/UpdateAcceleration.hpp
@@ -52,7 +52,7 @@ struct UpdateAcceleration {
       const tnsr::I<double, Dim, Frame::Inertial>& geodesic_acc,
       const Scalar<double>& dt_psi_monopole,
       const tnsr::i<double, Dim, Frame::Inertial>& psi_dipole, double charge,
-      double mass, bool apply_self_force);
+      std::optional<double> mass, bool apply_self_force);
 };
 
 }  // namespace CurvedScalarWave::Worldtube

--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonActions/UpdateAcceleration.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonActions/UpdateAcceleration.hpp
@@ -21,7 +21,7 @@ namespace CurvedScalarWave::Worldtube {
 
 /*!
  * \brief Computes the final acceleration of the particle at this time step.
- * \details If `apply_self_force` is `false`, the acceleration will simply be
+ * \details If `max_iterations` is 0, the acceleration will simply be
  * geodesic, see `gr::geodesic_acceleration`.  Otherwise, the acceleration due
  * to the scalar self-force is additionally applied to it, see
  * `self_force_acceleration`. This mutator is run on the worldtube
@@ -39,7 +39,7 @@ struct UpdateAcceleration {
       Stf::Tags::StfTensor<::Tags::dt<Tags::PsiWorldtube>, 0, Dim,
                            Frame::Inertial>,
       Stf::Tags::StfTensor<Tags::PsiWorldtube, 1, Dim, Frame::Inertial>,
-      Tags::Charge, Tags::Mass, Tags::ApplySelfForce>;
+      Tags::Charge, Tags::Mass, Tags::MaxIterations>;
   static void apply(
       gsl::not_null<
           Variables<tmpl::list<::Tags::dt<Tags::EvolvedPosition<Dim>>,
@@ -52,7 +52,7 @@ struct UpdateAcceleration {
       const tnsr::I<double, Dim, Frame::Inertial>& geodesic_acc,
       const Scalar<double>& dt_psi_monopole,
       const tnsr::i<double, Dim, Frame::Inertial>& psi_dipole, double charge,
-      std::optional<double> mass, bool apply_self_force);
+      std::optional<double> mass, size_t max_iterations);
 };
 
 }  // namespace CurvedScalarWave::Worldtube

--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/Tags.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/Tags.hpp
@@ -281,6 +281,13 @@ struct MaxIterations : db::SimpleTag {
     return self_force_options.has_value() ? self_force_options->iterations : 0;
   }
 };
+
+/*!
+ * \brief The current number of iterations that has been applied to the
+ * acceleration of the particle.
+ */
+struct CurrentIteration : db::SimpleTag {
+  using type = size_t;
 };
 
 /*!

--- a/tests/InputFiles/CurvedScalarWave/WorldtubeKerrSchild.yaml
+++ b/tests/InputFiles/CurvedScalarWave/WorldtubeKerrSchild.yaml
@@ -135,9 +135,7 @@ Worldtube:
   ExcisionSphere: ExcisionSphereA
   ExpansionOrder: 1
   Charge: 0.5
-  SelfForceOptions:
-    ApplySelfForce: false
-    Mass: 0.5
+  SelfForceOptions: None
   ObserveCoefficientsTrigger:
     Slabs:
       EvenlySpaced:

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/CMakeLists.txt
@@ -11,6 +11,7 @@ set(LIBRARY_SOURCES
   ElementActions/Test_SendToWorldtube.cpp
   ElementActions/Test_ReceiveWorldtubeData.cpp
   ElementActions/Test_InitializeConstraintGammas.cpp
+  ElementActions/Test_InitializeCurrentIteration.cpp
   SingletonActions/Test_ChangeSlabSize.cpp
   SingletonActions/Test_InitializeElementFacesGridCoordinates.cpp
   SingletonActions/Test_InitializeEvolvedVariables.cpp

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/ElementActions/Test_InitializeCurrentIteration.cpp
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/ElementActions/Test_InitializeCurrentIteration.cpp
@@ -1,0 +1,25 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include <array>
+#include <memory>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "Evolution/Systems/CurvedScalarWave/Worldtube/ElementActions/InitializeCurrentIteration.hpp"
+#include "Evolution/Systems/CurvedScalarWave/Worldtube/Tags.hpp"
+#include "Framework/TestingFramework.hpp"
+
+namespace CurvedScalarWave::Worldtube {
+namespace {
+SPECTRE_TEST_CASE(
+    "Unit.Evolution.Systems.CSW.Worldtube.InitializeCurrentIteration",
+    "[Unit][Evolution]") {
+  const size_t current_iteration = 77;
+  auto box =
+      db::create<db::AddSimpleTags<Tags::CurrentIteration>>(current_iteration);
+  db::mutate_apply<Initialization::InitializeCurrentIteration>(
+      make_not_null(&box));
+  CHECK(get<Tags::CurrentIteration>(box) == 0);
+}
+}  // namespace
+}  // namespace CurvedScalarWave::Worldtube

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonActions/Test_InitializeEvolvedVariables.cpp
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonActions/Test_InitializeEvolvedVariables.cpp
@@ -1,22 +1,17 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
-
-#include "Framework/TestingFramework.hpp"
-
 #include <array>
 #include <memory>
-
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Evolution/Systems/CurvedScalarWave/Worldtube/SingletonActions/InitializeEvolvedVariables.hpp"
+#include "Framework/TestingFramework.hpp"
 #include "Time/Tags/HistoryEvolvedVariables.hpp"
 #include "Time/Tags/TimeStepper.hpp"
 #include "Time/TimeSteppers/AdamsBashforth.hpp"
 #include "Time/TimeSteppers/TimeStepper.hpp"
-
 namespace CurvedScalarWave::Worldtube {
 namespace {
-
 SPECTRE_TEST_CASE(
     "Unit.Evolution.Systems.CSW.Worldtube.InitializeEvolvedVariables",
     "[Unit][Evolution]") {
@@ -25,21 +20,23 @@ SPECTRE_TEST_CASE(
   using dt_variables_tag = db::add_tag_prefix<::Tags::dt, variables_tag>;
   const tnsr::I<double, 3> initial_pos{{1., 2., 3.}};
   const tnsr::I<double, 3> initial_vel{{4., 5., 6.}};
-  auto box = db::create<
-      db::AddSimpleTags<variables_tag, dt_variables_tag,
-                        ::Tags::HistoryEvolvedVariables<variables_tag>,
-                        ::Tags::ConcreteTimeStepper<TimeStepper>,
-                        Tags::InitialPositionAndVelocity>,
-      time_stepper_ref_tags<TimeStepper>>(
-      variables_tag::type{}, dt_variables_tag::type{},
-      TimeSteppers::History<variables_tag::type>{},
-      static_cast<std::unique_ptr<TimeStepper>>(
-          std::make_unique<TimeSteppers::AdamsBashforth>(4)),
-      std::array<tnsr::I<double, 3>, 2>{{initial_pos, initial_vel}});
+  const size_t current_iteration = 77;
+  auto box =
+      db::create<db::AddSimpleTags<
+                     variables_tag, dt_variables_tag,
+                     ::Tags::HistoryEvolvedVariables<variables_tag>,
+                     ::Tags::ConcreteTimeStepper<TimeStepper>,
+                     Tags::InitialPositionAndVelocity, Tags::CurrentIteration>,
+                 time_stepper_ref_tags<TimeStepper>>(
+          variables_tag::type{}, dt_variables_tag::type{},
+          TimeSteppers::History<variables_tag::type>{},
+          static_cast<std::unique_ptr<TimeStepper>>(
+              std::make_unique<TimeSteppers::AdamsBashforth>(4)),
+          std::array<tnsr::I<double, 3>, 2>{{initial_pos, initial_vel}},
+          current_iteration);
 
   db::mutate_apply<Initialization::InitializeEvolvedVariables>(
       make_not_null(&box));
-
   const auto vars = db::get<variables_tag>(box);
   for (size_t i = 0; i < 3; ++i) {
     CHECK(get<Tags::EvolvedPosition<3>>(vars).get(i)[0] == initial_pos.get(i));
@@ -49,6 +46,7 @@ SPECTRE_TEST_CASE(
         dt_variables_tag::type(size_t(1), 0.));
   CHECK(db::get<::Tags::HistoryEvolvedVariables<variables_tag>>(box) ==
         TimeSteppers::History<variables_tag::type>(1));
+  CHECK(get<Tags::CurrentIteration>(box) == 0);
 }
 }  // namespace
 }  // namespace CurvedScalarWave::Worldtube

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonActions/Test_UpdateAcceleration.cpp
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonActions/Test_UpdateAcceleration.cpp
@@ -65,7 +65,8 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.CSW.Worldtube.UpdateAcceleration",
       Stf::Tags::StfTensor<Tags::PsiWorldtube, 1, Dim, Frame::Inertial>,
       Tags::Charge, Tags::Mass, Tags::ApplySelfForce>>(
       std::move(dt_evolved_vars), pos_vel, background_quantities, geodesic_acc,
-      dt_psi_monopole, psi_dipole, 1., 1., apply_self_force);
+      dt_psi_monopole, psi_dipole, 1., std::make_optional(1.),
+      apply_self_force);
 
   db::mutate_apply<UpdateAcceleration>(make_not_null(&box));
   const auto& dt_vars = db::get<dt_variables_tag>(box);

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonActions/Test_UpdateAcceleration.cpp
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonActions/Test_UpdateAcceleration.cpp
@@ -56,17 +56,16 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.CSW.Worldtube.UpdateAcceleration",
       make_with_random_values<Scalar<double>>(make_not_null(&gen), dist, 1);
   const auto psi_dipole = make_with_random_values<tnsr::i<double, Dim>>(
       make_not_null(&gen), dist, 1);
-  const bool apply_self_force = false;
+  const size_t max_iterations = 0;
   auto box = db::create<db::AddSimpleTags<
       dt_variables_tag, Tags::ParticlePositionVelocity<Dim>,
       Tags::BackgroundQuantities<Dim>, Tags::GeodesicAcceleration<Dim>,
       Stf::Tags::StfTensor<::Tags::dt<Tags::PsiWorldtube>, 0, Dim,
                            Frame::Inertial>,
       Stf::Tags::StfTensor<Tags::PsiWorldtube, 1, Dim, Frame::Inertial>,
-      Tags::Charge, Tags::Mass, Tags::ApplySelfForce>>(
+      Tags::Charge, Tags::Mass, Tags::MaxIterations>>(
       std::move(dt_evolved_vars), pos_vel, background_quantities, geodesic_acc,
-      dt_psi_monopole, psi_dipole, 1., std::make_optional(1.),
-      apply_self_force);
+      dt_psi_monopole, psi_dipole, 1., std::make_optional(1.), max_iterations);
 
   db::mutate_apply<UpdateAcceleration>(make_not_null(&box));
   const auto& dt_vars = db::get<dt_variables_tag>(box);
@@ -77,9 +76,9 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.CSW.Worldtube.UpdateAcceleration",
           geodesic_acc.get(i));
   }
 
-  db::mutate<Tags::ApplySelfForce>(
-      [](const gsl::not_null<bool*> apply_self_force_arg) {
-        *apply_self_force_arg = true;
+  db::mutate<Tags::MaxIterations>(
+      [](const gsl::not_null<size_t*> max_iterations_arg) {
+        *max_iterations_arg = 1;
       },
       make_not_null(&box));
 

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/Test_Tags.cpp
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/Test_Tags.cpp
@@ -678,6 +678,12 @@ void test_check_input_file() {
   }
 }
 
+void test_self_force_options() {
+  const auto options = TestHelpers::test_creation<OptionTags::SelfForceOptions>(
+      "Mass: 0.1");
+  CHECK(options.mass == 0.1);
+}
+
 }  // namespace
 
 // [[TimeOut, 15]]
@@ -689,11 +695,6 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.CurvedScalarWave.Worldtube.Tags",
             CurvedScalarWave::Worldtube::OptionTags::ExpansionOrder>("0") == 0);
   CHECK(TestHelpers::test_option_tag<
             CurvedScalarWave::Worldtube::OptionTags::Charge>("1.") == 1.);
-  CHECK(TestHelpers::test_option_tag<
-            CurvedScalarWave::Worldtube::OptionTags::Mass>("1.") == 1.);
-  CHECK(TestHelpers::test_option_tag<
-            CurvedScalarWave::Worldtube::OptionTags::ApplySelfForce>("true") ==
-        true);
   TestHelpers::db::test_simple_tag<Tags::ExcisionSphere<3>>("ExcisionSphere");
   TestHelpers::db::test_simple_tag<
       CurvedScalarWave::Worldtube::Tags::ExpansionOrder>("ExpansionOrder");
@@ -729,6 +730,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.CurvedScalarWave.Worldtube.Tags",
   TestHelpers::db::test_simple_tag<Tags::BackgroundQuantities<3>>(
       "BackgroundQuantities");
   test_excision_sphere_tag();
+  test_self_force_options();
   test_initial_position_velocity_tag();
   test_compute_face_coordinates_grid();
   test_compute_face_coordinates();

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/Test_Tags.cpp
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/Test_Tags.cpp
@@ -680,8 +680,10 @@ void test_check_input_file() {
 
 void test_self_force_options() {
   const auto options = TestHelpers::test_creation<OptionTags::SelfForceOptions>(
-      "Mass: 0.1");
+      "Mass: 0.1\n"
+      "Iterations: 3");
   CHECK(options.mass == 0.1);
+  CHECK(options.iterations == 3);
 }
 
 }  // namespace
@@ -703,7 +705,9 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.CurvedScalarWave.Worldtube.Tags",
   TestHelpers::db::test_simple_tag<CurvedScalarWave::Worldtube::Tags::Mass>(
       "Mass");
   TestHelpers::db::test_simple_tag<
-      CurvedScalarWave::Worldtube::Tags::ApplySelfForce>("ApplySelfForce");
+      CurvedScalarWave::Worldtube::Tags::MaxIterations>("MaxIterations");
+  TestHelpers::db::test_simple_tag<
+      CurvedScalarWave::Worldtube::Tags::CurrentIteration>("CurrentIteration");
   TestHelpers::db::test_simple_tag<Tags::ElementFacesGridCoordinates<3>>(
       "ElementFacesGridCoordinates");
   TestHelpers::db::test_simple_tag<Tags::FaceCoordinates<3, Frame::Grid, true>>(


### PR DESCRIPTION
Changes the self force options to an `Auto` class and introduces the tags `MaxIterations` and `CurrentIteration` which will be required for the iterative scheme of the worldtube.

~depends on #5831~