### PR TITLE
Don't ignore quat InitialValues[3] in SphereTimeDependentMaps

### DIFF
--- a/src/Domain/Creators/SphereTimeDependentMaps.cpp
+++ b/src/Domain/Creators/SphereTimeDependentMaps.cpp
@@ -146,7 +146,7 @@ TimeDependentMapOptions::create_functions_of_time(
 
   // RotationMap FunctionOfTime
   if (rotation_map_options_.has_value()) {
-    for (size_t i = 0; i < 3; i++) {
+    for (size_t i = 0; i < 4; i++) {
       initial_quaternion_value[i] =
           gsl::at(gsl::at(rotation_map_options_.value().initial_values, 0), i);
       initial_quaternion_first_derivative_value[i] =


### PR DESCRIPTION
## Proposed changes

When copying the initial values for quaternions from std::array to DataVectors, the code was not copying the last component. The bug was caused by the wrong limit in a for loop.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
