### PR TITLE
Add RotScaleTrans Map to BCO

### DIFF
--- a/src/Domain/Creators/BinaryCompactObject.cpp
+++ b/src/Domain/Creators/BinaryCompactObject.cpp
@@ -243,19 +243,26 @@ BinaryCompactObject::BinaryCompactObject(
       }
     }
   };
+  // Finding the first block of outer shell
+  first_outer_shell_block_ = 0;
   if (use_single_block_a_) {
     block_names_.emplace_back("ObjectA");
+    first_outer_shell_block_ += 1;
   } else {
     add_object_region("ObjectA", "Shell");  // 6 blocks
     add_object_region("ObjectA", "Cube");   // 6 blocks
+    first_outer_shell_block_ += 12;
   }
   if (use_single_block_b_) {
     block_names_.emplace_back("ObjectB");
+    first_outer_shell_block_ += 1;
   } else {
     add_object_region("ObjectB", "Shell");  // 6 blocks
     add_object_region("ObjectB", "Cube");   // 6 blocks
+    first_outer_shell_block_ += 12;
   }
   add_outer_region("Envelope");    // 10 blocks
+  first_outer_shell_block_ += 10;
   add_outer_region("OuterShell");  // 10 blocks
 
   if ((not use_single_block_a_) and (not is_excised_a_)) {
@@ -305,7 +312,7 @@ BinaryCompactObject::BinaryCompactObject(
     time_dependent_options_->build_maps(
         std::array{std::array{x_coord_a_, 0.0, 0.0},
                    std::array{x_coord_b_, 0.0, 0.0}},
-        radii_A, radii_B, outer_radius_);
+        radii_A, radii_B, envelope_radius_, outer_radius_);
   }
 }
 
@@ -552,29 +559,52 @@ Domain<3> BinaryCompactObject::create_domain() const {
     // distinct combinations of time-dependent maps that will be applied. This
     // should largely be taken care of by the TimeDependentOptions.
 
+    // Single blocks are added after the outer shell if an object's interior is
+    // not excised, so to find the final outer shell block, subtract the single
+    // blocks that may have been added.
+    size_t final_block_outer_shell = number_of_blocks_ - 1;
+    if ((not use_single_block_a_) and (not is_excised_a_)) {
+      --final_block_outer_shell;
+    }
+    if ((not use_single_block_b_) and (not is_excised_b_)) {
+      --final_block_outer_shell;
+    }
+
     // All blocks except possibly the first 6 or 12 blocks of each object get
     // the same map from the Grid to the Inertial frame, so initialize the final
     // block with the "base" map (here a composition of an expansion and a
     // rotation). When covering the inner regions with cubes, all blocks will
     // use the same time-dependent map instead.
-    grid_to_inertial_block_maps[number_of_blocks_ - 1] =
+    grid_to_inertial_block_maps[final_block_outer_shell] =
         time_dependent_options_
-            ->grid_to_inertial_map<domain::ObjectLabel::None>(std::nullopt);
+            ->grid_to_inertial_map<domain::ObjectLabel::None>(std::nullopt,
+                                                              false);
+    if (final_block_outer_shell < number_of_blocks_ - 1) {
+      grid_to_inertial_block_maps[number_of_blocks_ - 1] =
+          time_dependent_options_
+              ->grid_to_inertial_map<domain::ObjectLabel::None>(std::nullopt,
+                                                                true);
+    }
+    size_t final_block_envelope = first_outer_shell_block_ - 1;
 
-    // Inside the excision sphere we add the grid to inertial map from the outer
-    // shell. This allows the center of the excisions/horizons to be mapped
+    grid_to_inertial_block_maps[final_block_envelope] =
+        time_dependent_options_
+            ->grid_to_inertial_map<domain::ObjectLabel::None>(std::nullopt,
+                                                              true);
+    // Inside the excision sphere we add the grid to inertial map from the
+    // envelope. This allows the center of the excisions/horizons to be mapped
     // properly to the inertial frame.
     if (is_excised_a_ and
         grid_to_inertial_block_maps[number_of_blocks_ - 1] != nullptr) {
       domain.inject_time_dependent_map_for_excision_sphere(
           "ExcisionSphereA",
-          grid_to_inertial_block_maps[number_of_blocks_ - 1]->get_clone());
+          grid_to_inertial_block_maps[final_block_envelope]->get_clone());
     }
     if (is_excised_b_ and
         grid_to_inertial_block_maps[number_of_blocks_ - 1] != nullptr) {
       domain.inject_time_dependent_map_for_excision_sphere(
           "ExcisionSphereB",
-          grid_to_inertial_block_maps[number_of_blocks_ - 1]->get_clone());
+          grid_to_inertial_block_maps[final_block_envelope]->get_clone());
     }
 
     const size_t first_block_object_B = use_single_block_a_ ? 1 : 12;
@@ -596,7 +626,7 @@ Domain<3> BinaryCompactObject::create_domain() const {
         grid_to_inertial_block_maps[block] =
             time_dependent_options_
                 ->grid_to_inertial_map<domain::ObjectLabel::A>(
-                    block_for_distorted_frame);
+                    block_for_distorted_frame, true);
         grid_to_distorted_block_maps[block] =
             time_dependent_options_
                 ->grid_to_distorted_map<domain::ObjectLabel::A>(
@@ -604,7 +634,7 @@ Domain<3> BinaryCompactObject::create_domain() const {
         distorted_to_inertial_block_maps[block] =
             time_dependent_options_
                 ->distorted_to_inertial_map<domain::ObjectLabel::A>(
-                    block_for_distorted_frame);
+                    block_for_distorted_frame, true);
       } else if ((not use_single_block_b_) and block >= first_block_object_B and
                  block < first_block_object_B + 12) {
         const std::optional<size_t> block_for_distorted_frame =
@@ -613,7 +643,7 @@ Domain<3> BinaryCompactObject::create_domain() const {
         grid_to_inertial_block_maps[block] =
             time_dependent_options_
                 ->grid_to_inertial_map<domain::ObjectLabel::B>(
-                    block_for_distorted_frame);
+                    block_for_distorted_frame, true);
         grid_to_distorted_block_maps[block] =
             time_dependent_options_
                 ->grid_to_distorted_map<domain::ObjectLabel::B>(
@@ -621,12 +651,32 @@ Domain<3> BinaryCompactObject::create_domain() const {
         distorted_to_inertial_block_maps[block] =
             time_dependent_options_
                 ->distorted_to_inertial_map<domain::ObjectLabel::B>(
-                    block_for_distorted_frame);
+                    block_for_distorted_frame, true);
+        // check if block is less than outer shell block for rigid
+        // expansion/translation, but no distorted map
+      } else if (block < first_outer_shell_block_ and
+                 grid_to_inertial_block_maps[number_of_blocks_ - 1] !=
+                     nullptr) {
+        grid_to_inertial_block_maps[block] =
+            grid_to_inertial_block_maps[final_block_envelope]->get_clone();
+      } else if (block > final_block_outer_shell and
+                 grid_to_inertial_block_maps[number_of_blocks_ - 1] !=
+                     nullptr) {
+        // the inner cube blocks are after outershell and we want to copy the
+        // corresponding object blocks.
+        if ((not use_single_block_a_) and (not is_excised_a_)) {
+          grid_to_inertial_block_maps[block] =
+              grid_to_inertial_block_maps[0]->get_clone();
+        }
+        if ((not use_single_block_b_) and (not is_excised_b_)) {
+          grid_to_inertial_block_maps[block] =
+              grid_to_inertial_block_maps[first_block_object_B]->get_clone();
+        }
       } else if (grid_to_inertial_block_maps[number_of_blocks_ - 1] !=
                  nullptr) {
         // No distorted frame
         grid_to_inertial_block_maps[block] =
-            grid_to_inertial_block_maps[number_of_blocks_ - 1]->get_clone();
+            grid_to_inertial_block_maps[final_block_outer_shell]->get_clone();
       }
     }
     // Finally, inject the time dependent maps into the corresponding blocks

--- a/src/Domain/Creators/BinaryCompactObject.hpp
+++ b/src/Domain/Creators/BinaryCompactObject.hpp
@@ -114,10 +114,10 @@ namespace creators {
  * \par Time dependence:
  * The following time-dependent maps are applied:
  *
- * - A `CubicScale` expansion and a `Rotation` applied to all blocks from the
- *   Grid to the Inertial frame. However, if there is a size map in the block
- *   (defined below), then the expansion and rotation maps go from the Distorted
- *   to the Inertial frame.
+ * - A piecewise `Expansion`, a `Rotation` and a piecewise `Translation` is
+ * applied to all blocks from the Grid to the Inertial frame. However, if there
+ * is a shape map in the block (defined below), then the expansion, rotation,
+ * and translation maps go from the Distorted to the Inertial frame.
  * - If an object is excised, then the corresponding shell has a
  *   `Shape` map. The shape map goes from the Grid to the Distorted frame.
  *
@@ -504,6 +504,7 @@ class BinaryCompactObject : public DomainCreator<3> {
   double length_inner_cube_{};
   double length_outer_cube_{};
   size_t number_of_blocks_{};
+  size_t first_outer_shell_block_{};
   std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
       outer_boundary_condition_;
   std::vector<std::string> block_names_{};

--- a/src/Domain/Creators/BinaryCompactObjectHelpers.cpp
+++ b/src/Domain/Creators/BinaryCompactObjectHelpers.cpp
@@ -49,16 +49,19 @@ TimeDependentMapOptions<IsCylindrical>::TimeDependentMapOptions(
     double initial_time,
     std::optional<ExpansionMapOptions> expansion_map_options,
     std::optional<RotationMapOptions> rotation_options,
+    std::optional<TranslationMapOptions> translation_map_options,
     std::optional<ShapeMapOptions<domain::ObjectLabel::A>> shape_options_A,
     std::optional<ShapeMapOptions<domain::ObjectLabel::B>> shape_options_B,
     const Options::Context& context)
     : initial_time_(initial_time),
       expansion_map_options_(expansion_map_options),
       rotation_options_(rotation_options),
+      translation_options_(translation_map_options),
       shape_options_A_(shape_options_A),
       shape_options_B_(shape_options_B) {
   if (not(expansion_map_options_.has_value() or rotation_options_.has_value() or
-          shape_options_A_.has_value() or shape_options_B_.has_value())) {
+          translation_options_.has_value() or shape_options_A_.has_value() or
+          shape_options_B_.has_value())) {
     PARSE_ERROR(context,
                 "Time dependent map options were specified, but all options "
                 "were 'None'. If you don't want time dependent maps, specify "
@@ -94,6 +97,7 @@ TimeDependentMapOptions<IsCylindrical>::create_functions_of_time(
   std::unordered_map<std::string, double> expiration_times{
       {expansion_name, std::numeric_limits<double>::infinity()},
       {rotation_name, std::numeric_limits<double>::infinity()},
+      {translation_name, std::numeric_limits<double>::infinity()},
       {gsl::at(size_names, 0), std::numeric_limits<double>::infinity()},
       {gsl::at(size_names, 1), std::numeric_limits<double>::infinity()},
       {gsl::at(shape_names, 0), std::numeric_limits<double>::infinity()},
@@ -106,7 +110,7 @@ TimeDependentMapOptions<IsCylindrical>::create_functions_of_time(
   }
 
   // ExpansionMap FunctionOfTime for the function \f$a(t)\f$ in the
-  // domain::CoordinateMaps::TimeDependent::CubicScale map
+  // domain::CoordinateMaps::TimeDependent::RotScaleTrans map
   if (expansion_map_options_.has_value()) {
     result[expansion_name] =
         std::make_unique<FunctionsOfTime::PiecewisePolynomial<2>>(
@@ -118,7 +122,7 @@ TimeDependentMapOptions<IsCylindrical>::create_functions_of_time(
             expiration_times.at(expansion_name));
 
     // ExpansionMap FunctionOfTime for the function \f$b(t)\f$ in the
-    // domain::CoordinateMaps::TimeDependent::CubicScale map
+    // domain::CoordinateMaps::TimeDependent::RotScaleTrans map
     result[expansion_outer_boundary_name] =
         std::make_unique<FunctionsOfTime::FixedSpeedCubic>(
             1.0, initial_time_,
@@ -145,6 +149,24 @@ TimeDependentMapOptions<IsCylindrical>::create_functions_of_time(
              {3, 0.0},
              {3, 0.0}}},
         expiration_times.at(rotation_name));
+  }
+
+  // TranslationMap FunctionOfTime
+  if (translation_options_.has_value()) {
+    result[translation_name] =
+        std::make_unique<FunctionsOfTime::PiecewisePolynomial<2>>(
+            initial_time_,
+            std::array<DataVector, 3>{
+                {{gsl::at(translation_options_.value().initial_values, 0)[0],
+                  gsl::at(translation_options_.value().initial_values, 0)[1],
+                  gsl::at(translation_options_.value().initial_values, 0)[2]},
+                 {gsl::at(translation_options_.value().initial_values, 1)[0],
+                  gsl::at(translation_options_.value().initial_values, 1)[1],
+                  gsl::at(translation_options_.value().initial_values, 1)[2]},
+                 {gsl::at(translation_options_.value().initial_values, 2)[0],
+                  gsl::at(translation_options_.value().initial_values, 2)[1],
+                  gsl::at(translation_options_.value().initial_values, 2)[2]}}},
+            expiration_times.at(translation_name));
   }
 
   // Size and Shape FunctionOfTime for objects A and B
@@ -195,13 +217,32 @@ void TimeDependentMapOptions<IsCylindrical>::build_maps(
         object_A_radii,
     const std::optional<std::array<double, IsCylindrical ? 2 : 3>>&
         object_B_radii,
-    const double domain_outer_radius) {
-  if (expansion_map_options_.has_value()) {
-    expansion_map_ = Expansion{domain_outer_radius, expansion_name,
-                               expansion_outer_boundary_name};
-  }
-  if (rotation_options_.has_value()) {
-    rotation_map_ = Rotation{rotation_name};
+    const double envelope_radius, const double domain_outer_radius) {
+  if (expansion_map_options_.has_value() or rotation_options_.has_value() or
+      translation_options_.has_value()) {
+    rot_scale_trans_map_ = std::make_pair(
+        RotScaleTrans{
+            expansion_map_options_.has_value()
+                ? std::make_pair(expansion_name, expansion_outer_boundary_name)
+                : std::optional<std::pair<std::string, std::string>>{},
+            rotation_options_.has_value() ? rotation_name
+                                          : std::optional<std::string>{},
+            translation_options_.has_value() ? translation_name
+                                             : std::optional<std::string>{},
+            envelope_radius, domain_outer_radius,
+            domain::CoordinateMaps::TimeDependent::RotScaleTrans<
+                3>::BlockRegion::Inner},
+        RotScaleTrans{
+            expansion_map_options_.has_value()
+                ? std::make_pair(expansion_name, expansion_outer_boundary_name)
+                : std::optional<std::pair<std::string, std::string>>{},
+            rotation_options_.has_value() ? rotation_name
+                                          : std::optional<std::string>{},
+            translation_options_.has_value() ? translation_name
+                                             : std::optional<std::string>{},
+            envelope_radius, domain_outer_radius,
+            domain::CoordinateMaps::TimeDependent::RotScaleTrans<
+                3>::BlockRegion::Transition});
   }
 
   for (size_t i = 0; i < 2; i++) {
@@ -292,7 +333,8 @@ template <domain::ObjectLabel Object>
 typename TimeDependentMapOptions<IsCylindrical>::template MapType<
     Frame::Distorted, Frame::Inertial>
 TimeDependentMapOptions<IsCylindrical>::distorted_to_inertial_map(
-    const IncludeDistortedMapType& include_distorted_map) const {
+    const IncludeDistortedMapType& include_distorted_map,
+    const bool use_rigid_map) const {
   bool block_has_shape_map = false;
 
   if constexpr (IsCylindrical) {
@@ -307,15 +349,15 @@ TimeDependentMapOptions<IsCylindrical>::distorted_to_inertial_map(
         (transition_ends_at_cube or include_distorted_map.value() < 6);
   }
 
+  const auto& rot_scale_trans = rot_scale_trans_map_.has_value()
+                                    ? use_rigid_map
+                                          ? rot_scale_trans_map_->first
+                                          : rot_scale_trans_map_->second
+                                    : RotScaleTrans{};
+
   if (block_has_shape_map) {
-    if (expansion_map_.has_value() and rotation_map_.has_value()) {
-      return std::make_unique<detail::di_map<Expansion, Rotation>>(
-          expansion_map_.value(), rotation_map_.value());
-    } else if (expansion_map_.has_value()) {
-      return std::make_unique<detail::di_map<Expansion>>(
-          expansion_map_.value());
-    } else if (rotation_map_.has_value()) {
-      return std::make_unique<detail::di_map<Rotation>>(rotation_map_.value());
+    if (rot_scale_trans_map_.has_value()) {
+      return std::make_unique<detail::di_map<RotScaleTrans>>(rot_scale_trans);
     } else {
       return std::make_unique<detail::di_map<Identity>>(Identity{});
     }
@@ -375,7 +417,8 @@ template <domain::ObjectLabel Object>
 typename TimeDependentMapOptions<IsCylindrical>::template MapType<
     Frame::Grid, Frame::Inertial>
 TimeDependentMapOptions<IsCylindrical>::grid_to_inertial_map(
-    const IncludeDistortedMapType& include_distorted_map) const {
+    const IncludeDistortedMapType& include_distorted_map,
+    const bool use_rigid_map) const {
   bool block_has_shape_map = false;
 
   if constexpr (IsCylindrical) {
@@ -389,6 +432,12 @@ TimeDependentMapOptions<IsCylindrical>::grid_to_inertial_map(
         include_distorted_map.has_value() and
         (transition_ends_at_cube or include_distorted_map.value() < 6);
   }
+
+  const auto& rot_scale_trans = rot_scale_trans_map_.has_value()
+                                    ? use_rigid_map
+                                          ? rot_scale_trans_map_->first
+                                          : rot_scale_trans_map_->second
+                                    : RotScaleTrans{};
 
   if (block_has_shape_map) {
     const size_t index = get_index(Object);
@@ -410,27 +459,15 @@ TimeDependentMapOptions<IsCylindrical>::grid_to_inertial_map(
           "Requesting grid to inertial map with distorted frame but shape map "
           "options were not specified.");
     }
-    if (expansion_map_.has_value() and rotation_map_.has_value()) {
-      return std::make_unique<detail::gi_map<Shape, Expansion, Rotation>>(
-          shape->value(), expansion_map_.value(), rotation_map_.value());
-    } else if (expansion_map_.has_value()) {
-      return std::make_unique<detail::gi_map<Shape, Expansion>>(
-          shape->value(), expansion_map_.value());
-    } else if (rotation_map_.has_value()) {
-      return std::make_unique<detail::gi_map<Shape, Rotation>>(
-          shape->value(), rotation_map_.value());
+    if (rot_scale_trans_map_.has_value()) {
+      return std::make_unique<detail::gi_map<Shape, RotScaleTrans>>(
+          shape->value(), rot_scale_trans);
     } else {
       return std::make_unique<detail::gi_map<Shape>>(shape->value());
     }
   } else {
-    if (expansion_map_.has_value() and rotation_map_.has_value()) {
-      return std::make_unique<detail::gi_map<Expansion, Rotation>>(
-          expansion_map_.value(), rotation_map_.value());
-    } else if (expansion_map_.has_value()) {
-      return std::make_unique<detail::gi_map<Expansion>>(
-          expansion_map_.value());
-    } else if (rotation_map_.has_value()) {
-      return std::make_unique<detail::gi_map<Rotation>>(rotation_map_.value());
+    if (rot_scale_trans_map_.has_value()) {
+      return std::make_unique<detail::gi_map<RotScaleTrans>>(rot_scale_trans);
     } else {
       return nullptr;
     }
@@ -457,8 +494,8 @@ template class TimeDependentMapOptions<false>;
                                                          Frame::Inertial>    \
   TimeDependentMapOptions<ISCYL(data)>::distorted_to_inertial_map<OBJECT(    \
       data)>(                                                                \
-      const TimeDependentMapOptions<ISCYL(data)>::IncludeDistortedMapType&)  \
-      const;                                                                 \
+      const TimeDependentMapOptions<ISCYL(data)>::IncludeDistortedMapType&,  \
+      const bool) const;                                                     \
   template TimeDependentMapOptions<ISCYL(data)>::MapType<Frame::Grid,        \
                                                          Frame::Distorted>   \
   TimeDependentMapOptions<ISCYL(data)>::grid_to_distorted_map<OBJECT(data)>( \
@@ -467,8 +504,8 @@ template class TimeDependentMapOptions<false>;
   template TimeDependentMapOptions<ISCYL(data)>::MapType<Frame::Grid,        \
                                                          Frame::Inertial>    \
   TimeDependentMapOptions<ISCYL(data)>::grid_to_inertial_map<OBJECT(data)>(  \
-      const TimeDependentMapOptions<ISCYL(data)>::IncludeDistortedMapType&)  \
-      const;
+      const TimeDependentMapOptions<ISCYL(data)>::IncludeDistortedMapType&,  \
+      const bool) const;
 
 GENERATE_INSTANTIATIONS(INSTANTIATE, (true, false),
                         (domain::ObjectLabel::A, domain::ObjectLabel::B,

--- a/src/Domain/Creators/CylindricalBinaryCompactObject.cpp
+++ b/src/Domain/Creators/CylindricalBinaryCompactObject.cpp
@@ -278,6 +278,8 @@ CylindricalBinaryCompactObject::CylindricalBinaryCompactObject(
   // 4 blocks: 42 thru 45
   add_cylinder_name("CB", "Outer");
 
+  first_outer_shell_block = 46;
+
   if (include_inner_sphere_A) {
     // 5 blocks
     add_filled_cylinder_name("InnerSphereEA", "InnerSphereA");
@@ -285,6 +287,7 @@ CylindricalBinaryCompactObject::CylindricalBinaryCompactObject(
     add_filled_cylinder_name("InnerSphereMA", "InnerSphereA");
     // 4 blocks
     add_cylinder_name("InnerSphereEA", "InnerSphereA");
+    first_outer_shell_block += 14;
   }
   if (include_inner_sphere_B) {
     // 5 blocks
@@ -293,6 +296,7 @@ CylindricalBinaryCompactObject::CylindricalBinaryCompactObject(
     add_filled_cylinder_name("InnerSphereMB", "InnerSphereB");
     // 4 blocks
     add_cylinder_name("InnerSphereEB", "InnerSphereB");
+    first_outer_shell_block += 14;
   }
   if (include_outer_sphere) {
     // 5 blocks
@@ -392,21 +396,28 @@ CylindricalBinaryCompactObject::CylindricalBinaryCompactObject(
   // needs to start and stop at certain radii around each excision. If the inner
   // spheres aren't included, the outer radii would have to be in the middle of
   // a block. With the inner spheres, the outer radii can be at block
-  // boundaries.
+  // boundaries. The outer sphere must be specified because the time-dependent
+  // maps use piecewise functions for `Expansion` and `Translation`. This means
+  // an inner common radius must be specified for the piecewise bounds.
   if (time_dependent_options_.has_value() and
-      not(include_inner_sphere_A and include_inner_sphere_B)) {
+      not(include_inner_sphere_A and include_inner_sphere_B) and
+      not include_outer_sphere) {
     PARSE_ERROR(context,
                 "To use the CylindricalBBH domain with time-dependent maps, "
-                "you must include the inner spheres for both objects. "
-                "Currently, one or both objects is missing the inner spheres.");
+                "you must include the inner spheres for both objects and "
+                "the outer sphere. "
+                "Currently, one or both objects is missing the inner spheres or"
+                " the outer sphere is missing.");
   }
 
   if (time_dependent_options_.has_value()) {
+    const double inner_common_radius = 3.0 * (center_A_[2] - center_B_[2]);
     time_dependent_options_->build_maps(
         std::array{rotate_from_z_to_x_axis(center_A_),
                    rotate_from_z_to_x_axis(center_B_)},
         std::array{radius_A_, outer_radius_A_},
-        std::array{radius_B_, outer_radius_B_}, outer_radius_);
+        std::array{radius_B_, outer_radius_B_}, inner_common_radius,
+        outer_radius_);
   }
 }
 
@@ -891,45 +902,53 @@ Domain<3> CylindricalBinaryCompactObject::create_domain() const {
         domain::CoordinateMapBase<Frame::Distorted, Frame::Inertial, 3>>>
         distorted_to_inertial_block_maps{number_of_blocks_};
 
-    // The 0th block always exists and will only need an expansion + rotation
-    // map from the grid to inertial frame. No maps to the distorted frame
+    // The 0th block always exists and will only need an rigid expansion +
+    // rotation + translation map from the grid to inertial frame. No maps to
+    // the distorted frame
     grid_to_inertial_block_maps[0] =
         time_dependent_options_
-            ->grid_to_inertial_map<domain::ObjectLabel::None>(false);
+            ->grid_to_inertial_map<domain::ObjectLabel::None>(false, true);
 
-    // Inside the excision sphere we add the grid to inertial map from the outer
-    // shell. This allows the center of the excisions/horizons to be mapped
-    // properly to the inertial frame.
+    // The first block in the outer shell needs the transition expansion +
+    // rotation + translation map from the grid to inertial frame. No maps to
+    // the distorted frame
+    grid_to_inertial_block_maps[first_outer_shell_block] =
+        time_dependent_options_
+            ->grid_to_inertial_map<domain::ObjectLabel::None>(false, false);
+
+    // Inside the excision sphere we add the grid to inertial map from the
+    // outer shell. This allows the center of the excisions/horizons to be
+    // mapped properly to the inertial frame.
     domain.inject_time_dependent_map_for_excision_sphere(
         "ExcisionSphereA", grid_to_inertial_block_maps[0]->get_clone());
     domain.inject_time_dependent_map_for_excision_sphere(
         "ExcisionSphereB", grid_to_inertial_block_maps[0]->get_clone());
 
     // Because we require that both objects have inner shells, object A
-    // corresponds to blocks 46-59 and object B corresponds to blocks 60-73. If
-    // we have extra outer shells, those will have the same maps as
-    // block 0, and will start at block 74. The `true` being passed to
-    // the functions specifies that the size map *should* be included in the
-    // distorted frame.
+    // corresponds to blocks 46-59 and object B corresponds to blocks 60-73.
+    // If we have extra outer shells, those will have the same maps as block
+    // 0, and will start at block 74. The `true` being passed to the functions
+    // specifies that the size map *should* be included in the distorted
+    // frame.
     grid_to_inertial_block_maps[46] =
         time_dependent_options_->grid_to_inertial_map<domain::ObjectLabel::A>(
-            true);
+            true, true);
     grid_to_distorted_block_maps[46] =
         time_dependent_options_->grid_to_distorted_map<domain::ObjectLabel::A>(
             true);
     distorted_to_inertial_block_maps[46] =
         time_dependent_options_
-            ->distorted_to_inertial_map<domain::ObjectLabel::A>(true);
+            ->distorted_to_inertial_map<domain::ObjectLabel::A>(true, true);
 
     grid_to_inertial_block_maps[60] =
         time_dependent_options_->grid_to_inertial_map<domain::ObjectLabel::B>(
-            true);
+            true, true);
     grid_to_distorted_block_maps[60] =
         time_dependent_options_->grid_to_distorted_map<domain::ObjectLabel::B>(
             true);
     distorted_to_inertial_block_maps[60] =
         time_dependent_options_
-            ->distorted_to_inertial_map<domain::ObjectLabel::B>(true);
+            ->distorted_to_inertial_map<domain::ObjectLabel::B>(true, true);
 
     for (size_t block = 1; block < number_of_blocks_; ++block) {
       if (block == 46 or block == 60) {
@@ -952,6 +971,9 @@ Domain<3> CylindricalBinaryCompactObject::create_domain() const {
           distorted_to_inertial_block_maps[block] =
               distorted_to_inertial_block_maps[60]->get_clone();
         }
+      } else if (block > 74) {
+        grid_to_inertial_block_maps[block] =
+            grid_to_inertial_block_maps[first_outer_shell_block]->get_clone();
       } else {
         grid_to_inertial_block_maps[block] =
             grid_to_inertial_block_maps[0]->get_clone();

--- a/src/Domain/Creators/CylindricalBinaryCompactObject.hpp
+++ b/src/Domain/Creators/CylindricalBinaryCompactObject.hpp
@@ -393,6 +393,7 @@ class CylindricalBinaryCompactObject : public DomainCreator<3> {
   // https://arxiv.org/abs/1206.3015 (but rotated to the z-axis).
   double z_cutting_plane_{};
   size_t number_of_blocks_{};
+  size_t first_outer_shell_block{};
   std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
       inner_boundary_condition_;
   std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
@@ -18,6 +18,7 @@
 #include "ControlSystem/Systems/Rotation.hpp"
 #include "ControlSystem/Systems/Shape.hpp"
 #include "ControlSystem/Systems/Size.hpp"
+#include "ControlSystem/Systems/Translation.hpp"
 #include "ControlSystem/Trigger.hpp"
 #include "DataStructures/DataBox/PrefixHelpers.hpp"
 #include "DataStructures/DataBox/Tag.hpp"
@@ -317,6 +318,7 @@ struct EvolutionMetavars {
   using control_systems =
       tmpl::list<control_system::Systems::Rotation<3, both_horizons>,
                  control_system::Systems::Expansion<2, both_horizons>,
+                 control_system::Systems::Translation<2, both_horizons>,
                  control_system::Systems::Shape<::domain::ObjectLabel::A, 2,
                                                 both_horizons>,
                  control_system::Systems::Shape<::domain::ObjectLabel::B, 2,

--- a/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
+++ b/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
@@ -13,6 +13,7 @@
 #include "ControlSystem/Metafunctions.hpp"
 #include "ControlSystem/Systems/Expansion.hpp"
 #include "ControlSystem/Systems/Rotation.hpp"
+#include "ControlSystem/Systems/Translation.hpp"
 #include "ControlSystem/Trigger.hpp"
 #include "DataStructures/DataBox/PrefixHelpers.hpp"
 #include "DataStructures/DataBox/Tag.hpp"
@@ -368,7 +369,8 @@ struct GhValenciaDivCleanTemplateBase<
   using control_systems = tmpl::conditional_t<
       use_control_systems,
       tmpl::list<control_system::Systems::Rotation<3, measurement>,
-                 control_system::Systems::Expansion<2, measurement>>,
+                 control_system::Systems::Expansion<2, measurement>,
+                 control_system::Systems::Translation<2, measurement>>,
       tmpl::list<>>;
 
   using interpolator_source_vars =

--- a/support/Pipelines/Bbh/InitialData.yaml
+++ b/support/Pipelines/Bbh/InitialData.yaml
@@ -115,6 +115,7 @@ DomainCreator:
       InitialTime: 0.
       ExpansionMap: None
       RotationMap: None
+      TranslationMap: None
       ShapeMapA:
         LMax: 20
         InitialValues:

--- a/support/Pipelines/Bbh/Inspiral.yaml
+++ b/support/Pipelines/Bbh/Inspiral.yaml
@@ -361,6 +361,22 @@ ControlSystems:
       IncreaseFactor: 1.01
       DecreaseFactor: 0.98
     ControlError:
+  Translation:
+    IsActive: false
+    Averager:
+      AverageTimescaleFraction: 0.25
+      Average0thDeriv: false
+    Controller:
+      UpdateFraction: 0.3
+    TimescaleTuner:
+      InitialTimescales: [0.2, 0.2, 0.2]
+      MinTimescale: 1.0e-2
+      MaxTimescale: 20.0
+      IncreaseThreshold: 2.5e-4
+      DecreaseThreshold: 1.0e-3
+      IncreaseFactor: 1.01
+      DecreaseFactor: 0.98
+    ControlError:
   ShapeA: &ShapeControl
     IsActive: true
     Averager:

--- a/support/Pipelines/Bbh/Inspiral.yaml
+++ b/support/Pipelines/Bbh/Inspiral.yaml
@@ -81,6 +81,8 @@ DomainCreator:
         DecayTimescaleOuterBoundaryVelocity: 50.0
       RotationMap:
         InitialAngularVelocity: [0.0, 0.0, {{ InitialAngularVelocity }}]
+      TranslationMap:
+        InitialValues: [[0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]]
       ShapeMapA:
         LMax: &LMax 10
         InitialValues: Spherical

--- a/tests/InputFiles/CurvedScalarWave/WorldtubeKerrSchild.yaml
+++ b/tests/InputFiles/CurvedScalarWave/WorldtubeKerrSchild.yaml
@@ -73,6 +73,8 @@ DomainCreator:
         DecayTimescaleOuterBoundaryVelocity: 1.
       RotationMap:
         InitialAngularVelocity: [0., 0., 0.08944271909999159]
+      TranslationMap:
+        InitialValues: [[0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]]
       ShapeMapA:
         LMax: 8
         InitialValues: Spherical

--- a/tests/InputFiles/ExportCoordinates/InputTimeDependent3D.yaml
+++ b/tests/InputFiles/ExportCoordinates/InputTimeDependent3D.yaml
@@ -70,6 +70,8 @@ DomainCreator:
         DecayTimescaleOuterBoundaryVelocity: 50.0
       RotationMap:
         InitialAngularVelocity: [0.0, 0.0, 1.5264577062000000e-02]
+      TranslationMap:
+        InitialValues: [[0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]]
       ShapeMapA:
         LMax: 8
         InitialValues: Spherical

--- a/tests/InputFiles/GeneralizedHarmonic/BinaryBlackHole.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/BinaryBlackHole.yaml
@@ -79,6 +79,8 @@ DomainCreator:
         DecayTimescaleOuterBoundaryVelocity: 50.0
       RotationMap:
         InitialAngularVelocity: [0.0, 0.0, 0.0]
+      TranslationMap:
+        InitialValues: [[0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]]
       ShapeMapA:
         LMax: &LMax 10
         InitialValues: Spherical

--- a/tests/InputFiles/GeneralizedHarmonic/BinaryBlackHole.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/BinaryBlackHole.yaml
@@ -352,6 +352,22 @@ ControlSystems:
       IncreaseFactor: 1.01
       DecreaseFactor: 0.98
     ControlError:
+  Translation:
+    IsActive: false
+    Averager:
+      AverageTimescaleFraction: 0.25
+      Average0thDeriv: false
+    Controller:
+      UpdateFraction: 0.3
+    TimescaleTuner:
+      InitialTimescales: [0.2, 0.2, 0.2]
+      MinTimescale: 1.0e-2
+      MaxTimescale: 20.0
+      IncreaseThreshold: 2.5e-4
+      DecreaseThreshold: 1.0e-3
+      IncreaseFactor: 1.01
+      DecreaseFactor: 0.98
+    ControlError:
   ShapeA: &ShapeControl
     IsActive: true
     Averager:

--- a/tests/InputFiles/GeneralizedHarmonic/CylindricalBinaryBlackHole.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/CylindricalBinaryBlackHole.yaml
@@ -61,6 +61,8 @@ DomainCreator:
         DecayTimescaleOuterBoundaryVelocity: 50.0
       RotationMap:
         InitialAngularVelocity: [0.0, 0.0, 1.5264577062000000e-02]
+      TranslationMap:
+        InitialValues: [[0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]]
       ShapeMapA:
         LMax: &LMax 10
         InitialValues: Spherical

--- a/tests/InputFiles/GeneralizedHarmonic/CylindricalBinaryBlackHole.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/CylindricalBinaryBlackHole.yaml
@@ -331,6 +331,22 @@ ControlSystems:
       IncreaseFactor: 1.01
       DecreaseFactor: 0.98
     ControlError:
+  Translation:
+    IsActive: false
+    Averager:
+      AverageTimescaleFraction: 0.25
+      Average0thDeriv: false
+    Controller:
+      UpdateFraction: 0.3
+    TimescaleTuner:
+      InitialTimescales: [0.2, 0.2, 0.2]
+      MinTimescale: 1.0e-2
+      MaxTimescale: 20.0
+      IncreaseThreshold: 2.5e-4
+      DecreaseThreshold: 1.0e-3
+      IncreaseFactor: 1.01
+      DecreaseFactor: 0.98
+    ControlError:
   ShapeA: &ShapeControl
     IsActive: true
     Averager:

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/BinaryNeutronStar.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/BinaryNeutronStar.yaml
@@ -66,6 +66,8 @@ DomainCreator:
         DecayTimescaleOuterBoundaryVelocity: 50.0
       RotationMap:
         InitialAngularVelocity: [0.0, 0.0, 0.00826225]
+      TranslationMap:
+        InitialValues: [[0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]]
       ShapeMapA: None
       ShapeMapB: None
 

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/BinaryNeutronStar.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/BinaryNeutronStar.yaml
@@ -397,6 +397,22 @@ ControlSystems:
       IncreaseFactor: 1.01
       DecreaseFactor: 0.98
     ControlError:
+  Translation:
+    IsActive: false
+    Averager:
+      AverageTimescaleFraction: 0.25
+      Average0thDeriv: false
+    Controller:
+      UpdateFraction: 0.3
+    TimescaleTuner:
+      InitialTimescales: [0.2, 0.2, 0.2]
+      MinTimescale: 1.0e-2
+      MaxTimescale: 20.0
+      IncreaseThreshold: 2.5e-4
+      DecreaseThreshold: 1.0e-3
+      IncreaseFactor: 1.01
+      DecreaseFactor: 0.98
+    ControlError:
 
 InitialData:
   # SpecInitialData:

--- a/tests/Unit/Domain/Creators/Test_BinaryCompactObject.cpp
+++ b/tests/Unit/Domain/Creators/Test_BinaryCompactObject.cpp
@@ -369,7 +369,10 @@ std::string create_option_string(
             "      AsymptoticVelocityOuterBoundary: -0.1\n"
             "      DecayTimescaleOuterBoundaryVelocity: 5.0\n"
             "    RotationMap:\n"
-            "      InitialAngularVelocity: [0.0, 0.0, -0.2]\n"s +
+            "      InitialAngularVelocity: [0.0, 0.0, -0.2]\n"
+            "    TranslationMap:\n"
+            "      InitialValues: [[0.0, 0.0, 0.0], [0.0, 0.0, 0.0], "
+            "      [0.0, 0.0, 0.0]]\n"s +
                 (excise_A ? "    ShapeMapA:\n"
                             "      LMax: 8\n"
                             "      InitialValues: Spherical\n"
@@ -564,7 +567,7 @@ void test_bbh_time_dependent_factory(const bool with_boundary_conditions,
       *binary_compact_object, with_boundary_conditions, false, times_to_check);
 
   const auto& blocks = domain.blocks();
-  const auto& final_block = blocks[blocks.size() - 1];
+  const auto& final_envelope_block = excise_B ? blocks[33] : blocks[21];
 
   std::unordered_map<std::string, ExcisionSphere<3>>
       expected_excision_spheres{};
@@ -581,7 +584,8 @@ void test_bbh_time_dependent_factory(const bool with_boundary_conditions,
   if (with_time_dependence) {
     expected_excision_spheres.at("ExcisionSphereA")
         .inject_time_dependent_maps(
-            final_block.moving_mesh_grid_to_inertial_map().get_clone());
+            final_envelope_block.moving_mesh_grid_to_inertial_map()
+                .get_clone());
   }
   if (excise_B) {
     expected_excision_spheres.emplace(
@@ -597,7 +601,8 @@ void test_bbh_time_dependent_factory(const bool with_boundary_conditions,
     if (with_time_dependence) {
       expected_excision_spheres.at("ExcisionSphereB")
           .inject_time_dependent_maps(
-              final_block.moving_mesh_grid_to_inertial_map().get_clone());
+              final_envelope_block.moving_mesh_grid_to_inertial_map()
+                  .get_clone());
     }
   }
 
@@ -788,6 +793,7 @@ void test_kerr_horizon_conforming() {
       120.,
       domain::creators::bco::TimeDependentMapOptions<false>{
           0.,
+          std::nullopt,
           std::nullopt,
           std::nullopt,
           {{32_st,

--- a/tests/Unit/Domain/Creators/Test_CylindricalBinaryCompactObject.cpp
+++ b/tests/Unit/Domain/Creators/Test_CylindricalBinaryCompactObject.cpp
@@ -245,6 +245,7 @@ std::string create_option_string(
                             "    ExpansionMap: None\n"
                             "    RotationMap:\n"
                             "      InitialAngularVelocity: [0.0, 0.0, -0.2]\n"
+                            "    TranslationMap: None\n"
                             "    ShapeMapA:\n"
                             "      LMax: 8\n"
                             "      InitialValues: Spherical\n"
@@ -397,10 +398,12 @@ TimeDepOptions construct_time_dependent_options() {
 
   // No expansion map options because of above option string
   return TimeDepOptions{
-      expected_time, std::nullopt,
+      expected_time,
+      std::nullopt,
       TimeDepOptions::RotationMapOptions{{initial_angular_velocity[0],
                                           initial_angular_velocity[1],
                                           initial_angular_velocity[2]}},
+      std::nullopt,
       TimeDepOptions::ShapeMapOptions<domain::ObjectLabel::A>{
           8_st,
           std::nullopt,
@@ -475,7 +478,7 @@ void test_parse_errors() {
           TimeDepOptions{
               0.0, std::nullopt,
               TimeDepOptions::RotationMapOptions{std::array{0.0, 0.0, 0.0}},
-              std::nullopt, std::nullopt},
+              std::nullopt, std::nullopt, std::nullopt},
           create_inner_boundary_condition(), create_outer_boundary_condition(),
           Options::Context{false, {}, 1, 1}),
       Catch::Matchers::ContainsSubstring(
@@ -578,6 +581,7 @@ void test_cylindrical_bbh() {
     if (with_time_dependence) {
       include_inner_sphere_A = true;
       include_inner_sphere_B = true;
+      include_outer_sphere = true;
     } else {
       // With no time dependence, can't have control systems
       with_control_systems = false;

--- a/tests/Unit/Helpers/Evolution/Systems/CurvedScalarWave/Worldtube/TestHelpers.cpp
+++ b/tests/Unit/Helpers/Evolution/Systems/CurvedScalarWave/Worldtube/TestHelpers.cpp
@@ -68,6 +68,9 @@ std::unique_ptr<DomainCreator<3>> worldtube_binary_compact_object(
       "      InitialAngularVelocity: [0.0, 0.0," +
       angular_velocity_stream.str() +
       "]\n"
+      "    TranslationMap:\n"
+      "      InitialValues: [[0.0, 0.0, 0.0], [0.0, 0.0, 0.], [0.0, 0.0, "
+      "0.0]]\n"
       "    ShapeMapA:\n"
       "      LMax: 8\n"
       "      InitialValues: Spherical\n"


### PR DESCRIPTION
## Proposed changes

Adds the RotScaleTrans map to the BCO domain. Also enables the translation control and translation options in the BBH/BNS executable.

### Upgrade instructions

Will need to add the translation map options in the TimeDependentMaps portion of the yamls using the BCO domain as well as add the control system for it.
```yaml
      TranslationMap:  # in domain options
        InitialValues:
          - [0.0, 0.0, 0.0]
          - [0.0, 0.0, 0.0]
          - [0.0, 0.0, 0.0]
# ...
  Translation:  # in control system options
    IsActive: true
    Averager:
      AverageTimescaleFraction: 0.25
      Average0thDeriv: false
    Controller:
      UpdateFraction: 0.3
    TimescaleTuner:
      InitialTimescales: [0.2, 0.2, 0.2]
      MinTimescale: 1.0e-2
      MaxTimescale: 20.0
      IncreaseThreshold: 2.5e-4
      DecreaseThreshold: 1.0e-3
      IncreaseFactor: 1.01
      DecreaseFactor: 0.98
    ControlError:
```
### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments
