### PR TITLE
Add Barotropic2D EOS

### DIFF
--- a/src/PointwiseFunctions/Hydro/EquationsOfState/Barotropic2D.cpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/Barotropic2D.cpp
@@ -1,0 +1,137 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "PointwiseFunctions/Hydro/EquationsOfState/Barotropic2D.hpp"
+
+#include <memory>
+#include <utility>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/Barotropic3D.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/Enthalpy.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/PiecewisePolytropicFluid.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/PolytropicFluid.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/Spectral.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+
+namespace EquationsOfState {
+
+EQUATION_OF_STATE_MEMBER_DEFINITIONS(template <typename ColdEos>,
+                                     Barotropic2D<ColdEos>, double, 2)
+EQUATION_OF_STATE_MEMBER_DEFINITIONS(template <typename ColdEos>,
+                                     Barotropic2D<ColdEos>, DataVector, 2)
+
+template <typename ColdEos>
+std::unique_ptr<EquationOfState<ColdEos::is_relativistic, 2>>
+Barotropic2D<ColdEos>::get_clone() const {
+  auto clone = std::make_unique<Barotropic2D<ColdEos>>(*this);
+  return std::unique_ptr<EquationOfState<is_relativistic, 2>>(std::move(clone));
+}
+
+template <typename ColdEos>
+std::unique_ptr<EquationOfState<ColdEos::is_relativistic, 3>>
+Barotropic2D<ColdEos>::promote_to_3d_eos() const {
+  return std::make_unique<Barotropic3D<ColdEos>>(underlying_eos_);
+}
+
+template <typename ColdEos>
+bool Barotropic2D<ColdEos>::is_equal(
+    const EquationOfState<ColdEos::is_relativistic, 2>& rhs) const {
+  const auto& derived_ptr =
+      dynamic_cast<const Barotropic2D<ColdEos>* const>(&rhs);
+  return derived_ptr != nullptr and *derived_ptr == *this;
+}
+
+template <typename ColdEos>
+void Barotropic2D<ColdEos>::pup(PUP::er& p) {
+  EquationOfState<ColdEos::is_relativistic, 2>::pup(p);
+  p | underlying_eos_;
+}
+template <typename ColdEos>
+Barotropic2D<ColdEos>::Barotropic2D(CkMigrateMessage* msg)
+    : EquationOfState<ColdEos::is_relativistic, 2>(msg) {}
+
+template <typename ColdEos>
+bool Barotropic2D<ColdEos>::operator==(const Barotropic2D<ColdEos>& rhs) const {
+  return this->underlying_eos_ == rhs.underlying_eos_;
+}
+template <typename ColdEos>
+bool Barotropic2D<ColdEos>::operator!=(const Barotropic2D<ColdEos>& rhs) const {
+  return not(*this == rhs);
+}
+
+template <typename ColdEos>
+template <class DataType>
+Scalar<DataType> Barotropic2D<ColdEos>::pressure_from_density_and_energy_impl(
+    const Scalar<DataType>& rest_mass_density,
+    const Scalar<DataType>& /*specific_internal_energy*/) const {
+  return underlying_eos_.pressure_from_density(rest_mass_density);
+}
+
+template <typename ColdEos>
+template <class DataType>
+Scalar<DataType> Barotropic2D<ColdEos>::pressure_from_density_and_enthalpy_impl(
+    const Scalar<DataType>& rest_mass_density,
+    const Scalar<DataType>& /*specific_enthalpy*/) const {
+  return underlying_eos_.pressure_from_density(rest_mass_density);
+}
+
+template <typename ColdEos>
+template <class DataType>
+Scalar<DataType>
+Barotropic2D<ColdEos>::specific_internal_energy_from_density_and_pressure_impl(
+    const Scalar<DataType>& rest_mass_density,
+    const Scalar<DataType>& /*pressure*/) const {
+  return underlying_eos_.specific_internal_energy_from_density(
+      rest_mass_density);
+}
+
+template <typename ColdEos>
+template <class DataType>
+Scalar<DataType>
+Barotropic2D<ColdEos>::temperature_from_density_and_energy_impl(
+    const Scalar<DataType>& rest_mass_density,
+    const Scalar<DataType>& /*specific_internal_energy*/) const {
+  return make_with_value<Scalar<DataType>>(rest_mass_density, 0.0);
+}
+
+template <typename ColdEos>
+template <class DataType>
+Scalar<DataType> Barotropic2D<ColdEos>::
+    specific_internal_energy_from_density_and_temperature_impl(
+        const Scalar<DataType>& rest_mass_density,
+        const Scalar<DataType>& /*temperature*/) const {
+  return underlying_eos_.specific_internal_energy_from_density(
+      rest_mass_density);
+}
+
+template <typename ColdEos>
+template <class DataType>
+Scalar<DataType> Barotropic2D<ColdEos>::chi_from_density_and_energy_impl(
+    const Scalar<DataType>& rest_mass_density,
+    const Scalar<DataType>& /*specific_internal_energy*/) const {
+  return underlying_eos_.chi_from_density(rest_mass_density);
+}
+
+template <typename ColdEos>
+template <class DataType>
+Scalar<DataType> Barotropic2D<ColdEos>::
+    kappa_times_p_over_rho_squared_from_density_and_energy_impl(
+        const Scalar<DataType>& rest_mass_density,
+        const Scalar<DataType>& /*specific_internal_energy*/) const {
+  return underlying_eos_.kappa_times_p_over_rho_squared_from_density(
+      rest_mass_density);
+}
+
+template class Barotropic2D<EquationsOfState::PolytropicFluid<true>>;
+template class Barotropic2D<EquationsOfState::PolytropicFluid<false>>;
+template class Barotropic2D<PiecewisePolytropicFluid<true>>;
+template class Barotropic2D<PiecewisePolytropicFluid<false>>;
+template class Barotropic2D<Spectral>;
+template class Barotropic2D<Enthalpy<PolytropicFluid<true>>>;
+template class Barotropic2D<Enthalpy<Spectral>>;
+template class Barotropic2D<Enthalpy<Enthalpy<Spectral>>>;
+template class Barotropic2D<Enthalpy<Enthalpy<Enthalpy<Spectral>>>>;
+
+}  // namespace EquationsOfState

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/Barotropic2D.hpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/Barotropic2D.hpp
@@ -1,0 +1,175 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <boost/preprocessor/arithmetic/dec.hpp>
+#include <boost/preprocessor/arithmetic/inc.hpp>
+#include <boost/preprocessor/control/expr_iif.hpp>
+#include <boost/preprocessor/list/adt.hpp>
+#include <boost/preprocessor/repetition/for.hpp>
+#include <boost/preprocessor/repetition/repeat.hpp>
+#include <boost/preprocessor/tuple/to_list.hpp>
+#include <cstddef>
+#include <limits>
+#include <memory>
+#include <pup.h>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Options/String.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
+#include "PointwiseFunctions/Hydro/Units.hpp"
+#include "Utilities/Serialization/CharmPupable.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace EquationsOfState {
+/*!
+ * \ingroup EquationsOfStateGroup
+ * \brief A 2D equation of state representing a barotropic fluid.
+ *
+ *
+ * The equation of state takes the form
+ *
+ * \f[
+ * p = p (\rho , T, Y_e) = p(\rho, 0, Y_e= Y_{e, \beta})
+ * \f]
+ *
+ * where \f$\rho\f$ is the rest mass density, \f$T\f$  the
+ * temperature , and \f$Y_e\f$ the electron fraction. The temperature and
+ * electron fraction are not used, so evaluating this EoS at any arbtirary
+ * temeperature or electron fraction is equivalent to evaluating it at
+ * zero temperature and in beta equalibrium.
+ */
+template <typename ColdEos>
+class Barotropic2D : public EquationOfState<ColdEos::is_relativistic, 2> {
+ public:
+  static constexpr size_t thermodynamic_dim = 2;
+  static constexpr bool is_relativistic = ColdEos::is_relativistic;
+
+  static std::string name() {
+    return "Barotropic2D(" + pretty_type::name<ColdEos>() + ")";
+  }
+  static constexpr Options::String help = {
+      "A 2D EoS which is independent of electron fraction and temperature. "
+      "Contains an underlying 1D EoS which is dependent only "
+      "on rest mass density."};
+  struct UnderlyingEos {
+    using type = ColdEos;
+    static std::string name() { return pretty_type::short_name<ColdEos>(); }
+    static constexpr Options::String help{
+        "The underlying EoS which is being represented as a 2D EoS.  Must be a "
+        "1D EoS"};
+  };
+
+  using options = tmpl::list<UnderlyingEos>;
+
+  Barotropic2D() = default;
+  Barotropic2D(const Barotropic2D&) = default;
+  Barotropic2D& operator=(const Barotropic2D&) = default;
+  Barotropic2D(Barotropic2D&&) = default;
+  Barotropic2D& operator=(Barotropic2D&&) = default;
+  ~Barotropic2D() override = default;
+
+  explicit Barotropic2D(const ColdEos& underlying_eos)
+      : underlying_eos_(underlying_eos){};
+
+  EQUATION_OF_STATE_FORWARD_DECLARE_MEMBERS(Barotropic2D, 2)
+
+  std::unique_ptr<EquationOfState<ColdEos::is_relativistic, 2>> get_clone()
+      const override;
+
+  std::unique_ptr<EquationOfState<ColdEos::is_relativistic, 3>>
+  promote_to_3d_eos() const override;
+
+  bool is_equal(
+      const EquationOfState<ColdEos::is_relativistic, 2>& rhs) const override;
+
+  /// \brief Returns `true` if the EOS is barotropic
+  bool is_barotropic() const override { return true; }
+
+  bool operator==(const Barotropic2D<ColdEos>& rhs) const;
+
+  bool operator!=(const Barotropic2D<ColdEos>& rhs) const;
+  /// @{
+  /*!
+   * Computes the electron fraction in beta-equilibrium \f$Y_e^{\rm eq}\f$ from
+   * the rest mass density \f$\rho\f$ and the temperature \f$T\f$.
+   */
+  Scalar<double> equilibrium_electron_fraction_from_density_temperature(
+      const Scalar<double>& rest_mass_density,
+      const Scalar<double>& temperature) const override {
+    return underlying_eos_
+        .equilibrium_electron_fraction_from_density_temperature(
+            rest_mass_density, temperature);
+  }
+
+  Scalar<DataVector> equilibrium_electron_fraction_from_density_temperature(
+      const Scalar<DataVector>& rest_mass_density,
+      const Scalar<DataVector>& temperature) const override {
+    return underlying_eos_
+        .equilibrium_electron_fraction_from_density_temperature(
+            rest_mass_density, temperature);
+  }
+  /// @}
+
+  WRAPPED_PUPable_decl_base_template(  // NOLINT
+      SINGLE_ARG(EquationOfState<ColdEos::is_relativistic, 2>), Barotropic2D);
+
+  /// The lower bound of the electron fraction that is valid for this EOS
+  double electron_fraction_lower_bound() const override { return 0.0; }
+
+  /// The upper bound of the electron fraction that is valid for this EOS
+  double electron_fraction_upper_bound() const override { return 1.0; }
+
+  /// The lower bound of the rest mass density that is valid for this EOS
+  double rest_mass_density_lower_bound() const override {
+    return underlying_eos_.rest_mass_density_lower_bound();
+  }
+
+  /// The upper bound of the rest mass density that is valid for this EOS
+  double rest_mass_density_upper_bound() const override {
+    return underlying_eos_.rest_mass_density_upper_bound();
+  }
+
+  /// The lower bound of the temperature that is valid for this EOS
+  double temperature_lower_bound() const override { return 0.0; }
+
+  /// The upper bound of the temperature that is valid for this EOS
+  double temperature_upper_bound() const override {
+    return std::numeric_limits<double>::max();
+  }
+
+  /// The lower bound of the specific internal energy that is valid for this EOS
+  /// at the given rest mass density \f$\rho\f$ and electron fraction \f$Y_e\f$
+  double specific_internal_energy_lower_bound(
+      const double rest_mass_density) const override {
+    return underlying_eos_.specific_internal_energy_lower_bound(
+        rest_mass_density);
+  }
+
+  /// The upper bound of the specific internal energy that is valid for this EOS
+  /// at the given rest mass density \f$\rho\f$
+  double specific_internal_energy_upper_bound(
+      const double rest_mass_density) const override {
+    return underlying_eos_.specific_internal_energy_upper_bound(
+        rest_mass_density);
+  }
+
+  /// The lower bound of the specific enthalpy that is valid for this EOS
+  double specific_enthalpy_lower_bound() const override {
+    return underlying_eos_.specific_enthalpy_lower_bound();
+  }
+
+  /// The baryon mass for this EoS
+  double baryon_mass() const override { return underlying_eos_.baryon_mass(); }
+
+ private:
+  EQUATION_OF_STATE_FORWARD_DECLARE_MEMBER_IMPLS(2)
+  ColdEos underlying_eos_;
+};
+/// \cond
+template <typename ColdEos>
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+PUP::able::PUP_ID EquationsOfState::Barotropic2D<ColdEos>::my_PUP_ID = 0;
+/// \endcond
+}  // namespace EquationsOfState

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/Barotropic3D.hpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/Barotropic3D.hpp
@@ -31,15 +31,14 @@ namespace EquationsOfState {
  * The equation of state takes the form
  *
  * \f[
- * p = p (T, rho, Y_e) = p(0, rho, Y_e= Y_{e, \beta})
+ * p = p (\rho , T, Y_e) = p(\rho, 0, Y_e= Y_{e, \beta})
  * \f]
  *
  * where \f$\rho\f$ is the rest mass density, \f$T\f$  the
- * temperatur , and \f$Y_e\f$ is the electron fraction are not
- * used, and therefore this evaluating this EoS at any arbtirary
+ * temperature , and \f$Y_e\f$ the electron fraction. The temperature and
+ * electron fraction are not used, so evaluating this EoS at any arbtirary
  * temeperature or electron fraction is equivalent to evaluating it at
- * temperature 0 and in beta equalibrium
- *
+ * zero temperature and in beta equalibrium.
  */
 template <typename ColdEquilEos>
 class Barotropic3D : public EquationOfState<ColdEquilEos::is_relativistic, 3> {

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/CMakeLists.txt
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/CMakeLists.txt
@@ -4,6 +4,7 @@
 spectre_target_sources(
   ${LIBRARY}
   PRIVATE
+  Barotropic2D.cpp
   Barotropic3D.cpp
   DarkEnergyFluid.cpp
   Enthalpy.cpp
@@ -21,6 +22,7 @@ spectre_target_headers(
   ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
+  Barotropic2D.hpp
   Barotropic3D.hpp
   DarkEnergyFluid.hpp
   Enthalpy.hpp

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/Enthalpy.cpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/Enthalpy.cpp
@@ -12,6 +12,7 @@
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "NumericalAlgorithms/RootFinding/TOMS748.hpp"
 #include "NumericalAlgorithms/Spectral/Clenshaw.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/Barotropic2D.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/Barotropic3D.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/PolytropicFluid.hpp"
@@ -285,8 +286,13 @@ std::unique_ptr<EquationOfState<true, 1>> Enthalpy<LowDensityEoS>::get_clone()
 template <typename LowDensityEoS>
 std::unique_ptr<EquationOfState<true, 3>>
 Enthalpy<LowDensityEoS>::promote_to_3d_eos() const {
-  return std::make_unique<Barotropic3D<Enthalpy<LowDensityEoS>>>(
-      Barotropic3D(*this));
+  return std::make_unique<Barotropic3D<Enthalpy<LowDensityEoS>>>(*this);
+}
+
+template <typename LowDensityEoS>
+std::unique_ptr<EquationOfState<true, 2>>
+Enthalpy<LowDensityEoS>::promote_to_2d_eos() const {
+  return std::make_unique<Barotropic2D<Enthalpy<LowDensityEoS>>>(*this);
 }
 
 template <typename LowDensityEoS>

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/Enthalpy.hpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/Enthalpy.hpp
@@ -229,6 +229,8 @@ class Enthalpy : public EquationOfState<true, 1> {
 
   std::unique_ptr<EquationOfState<true, 3>> promote_to_3d_eos() const override;
 
+  std::unique_ptr<EquationOfState<true, 2>> promote_to_2d_eos() const override;
+
   bool is_equal(const EquationOfState<true, 1>& rhs) const override;
 
   bool operator==(const Enthalpy<LowDensityEoS>& rhs) const;

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp
@@ -20,6 +20,8 @@
 
 /// \cond
 namespace EquationsOfState {
+template <typename ColdEos>
+class Barotropic2D;
 template <typename ColdEquilEos>
 class Barotropic3D;
 template <bool IsRelativistic>
@@ -65,14 +67,22 @@ struct DerivedClasses<false, 1> {
 
 template <>
 struct DerivedClasses<true, 2> {
-  using type = tmpl::list<DarkEnergyFluid<true>, IdealFluid<true>,
-                          HybridEos<PolytropicFluid<true>>, HybridEos<Spectral>,
-                          HybridEos<Enthalpy<Spectral>>>;
+  using type =
+      tmpl::list<Barotropic2D<PolytropicFluid<true>>, Barotropic2D<Spectral>,
+                 Barotropic2D<Enthalpy<Spectral>>,
+                 Barotropic2D<PiecewisePolytropicFluid<true>>,
+                 Barotropic2D<Enthalpy<Enthalpy<Spectral>>>,
+                 Barotropic2D<Enthalpy<Enthalpy<Enthalpy<Spectral>>>>,
+                 DarkEnergyFluid<true>, IdealFluid<true>,
+                 HybridEos<PolytropicFluid<true>>, HybridEos<Spectral>,
+                 HybridEos<Enthalpy<Spectral>>>;
 };
 
 template <>
 struct DerivedClasses<false, 2> {
-  using type = tmpl::list<IdealFluid<false>, HybridEos<PolytropicFluid<false>>>;
+  using type = tmpl::list<Barotropic2D<PolytropicFluid<false>>,
+                          Barotropic2D<PiecewisePolytropicFluid<false>>,
+                          IdealFluid<false>, HybridEos<PolytropicFluid<false>>>;
 };
 
 template <>
@@ -80,14 +90,14 @@ struct DerivedClasses<true, 3> {
   using type =
       tmpl::list<Tabulated3D<true>, Barotropic3D<PolytropicFluid<true>>,
                  Barotropic3D<Spectral>, Barotropic3D<Enthalpy<Spectral>>,
+                 Barotropic3D<PiecewisePolytropicFluid<true>>,
+                 Barotropic3D<Enthalpy<Enthalpy<Spectral>>>,
+                 Barotropic3D<Enthalpy<Enthalpy<Enthalpy<Spectral>>>>,
                  Equilibrium3D<HybridEos<PolytropicFluid<true>>>,
                  Equilibrium3D<HybridEos<Spectral>>,
                  Equilibrium3D<HybridEos<Enthalpy<Spectral>>>,
                  Equilibrium3D<DarkEnergyFluid<true>>,
-                 Equilibrium3D<IdealFluid<true>>,
-                 Barotropic3D<PiecewisePolytropicFluid<true>>,
-                 Barotropic3D<Enthalpy<Enthalpy<Spectral>>>,
-                 Barotropic3D<Enthalpy<Enthalpy<Enthalpy<Spectral>>>>>;
+                 Equilibrium3D<IdealFluid<true>>>;
 };
 
 template <>

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp
@@ -170,8 +170,15 @@ class EquationOfState<IsRelativistic, 1> : public PUP::able {
 
   virtual bool is_equal(
       const EquationOfState<IsRelativistic, 1>& rhs) const = 0;
+
+  /// Create a 3D EOS from the 1D EOS
   virtual std::unique_ptr<EquationOfState<IsRelativistic, 3>>
   promote_to_3d_eos() const = 0;
+
+  /// Create a 2D EOS from the 1D EOS
+  virtual std::unique_ptr<EquationOfState<IsRelativistic, 2>>
+  promote_to_2d_eos() const = 0;
+
   /// \brief Returns `true` if the EOS is barotropic
   bool is_barotropic() const { return true; }
   /// @{
@@ -352,6 +359,11 @@ class EquationOfState<IsRelativistic, 2> : public PUP::able {
 
   virtual bool is_equal(
       const EquationOfState<IsRelativistic, 2>& rhs) const = 0;
+
+  virtual std::unique_ptr<EquationOfState<IsRelativistic, 2>>
+  promote_to_2d_eos() const {
+    return this->get_clone();
+  }
 
   virtual std::unique_ptr<EquationOfState<IsRelativistic, 3>>
   promote_to_3d_eos() const = 0;

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/Factory.hpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/Factory.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "PointwiseFunctions/Hydro/EquationsOfState/Barotropic2D.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/Barotropic3D.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/DarkEnergyFluid.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/Enthalpy.hpp"

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/PiecewisePolytropicFluid.cpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/PiecewisePolytropicFluid.cpp
@@ -8,6 +8,7 @@
 
 #include "DataStructures/DataVector.hpp"  // IWYU pragma: keep
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/Barotropic2D.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/Barotropic3D.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/Factory.hpp"
 #include "Utilities/MakeWithValue.hpp"
@@ -96,8 +97,14 @@ template <bool IsRelativistic>
 std::unique_ptr<EquationOfState<IsRelativistic, 3>>
 PiecewisePolytropicFluid<IsRelativistic>::promote_to_3d_eos() const {
   return std::make_unique<
-      Barotropic3D<PiecewisePolytropicFluid<IsRelativistic>>>(
-      Barotropic3D(*this));
+      Barotropic3D<PiecewisePolytropicFluid<IsRelativistic>>>(*this);
+}
+
+template <bool IsRelativistic>
+std::unique_ptr<EquationOfState<IsRelativistic, 2>>
+PiecewisePolytropicFluid<IsRelativistic>::promote_to_2d_eos() const {
+  return std::make_unique<
+      Barotropic2D<PiecewisePolytropicFluid<IsRelativistic>>>(*this);
 }
 
 template <bool IsRelativistic>

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/PiecewisePolytropicFluid.hpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/PiecewisePolytropicFluid.hpp
@@ -127,6 +127,9 @@ class PiecewisePolytropicFluid : public EquationOfState<IsRelativistic, 1> {
   std::unique_ptr<EquationOfState<IsRelativistic, 3>> promote_to_3d_eos()
       const override;
 
+  std::unique_ptr<EquationOfState<IsRelativistic, 2>> promote_to_2d_eos()
+      const override;
+
   bool is_equal(const EquationOfState<IsRelativistic, 1>& rhs) const override;
 
   bool operator==(const PiecewisePolytropicFluid<IsRelativistic>& rhs) const;

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/PolytropicFluid.cpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/PolytropicFluid.cpp
@@ -9,6 +9,7 @@
 
 #include "DataStructures/DataVector.hpp"  // IWYU pragma: keep
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/Barotropic2D.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/Barotropic3D.hpp"
 #include "Utilities/MakeWithValue.hpp"
 
@@ -58,8 +59,13 @@ PolytropicFluid<IsRelativistic>::get_clone() const {
 template <bool IsRelativistic>
 std::unique_ptr<EquationOfState<IsRelativistic, 3>>
 PolytropicFluid<IsRelativistic>::promote_to_3d_eos() const {
-  return std::make_unique<Barotropic3D<PolytropicFluid<IsRelativistic>>>(
-      Barotropic3D(*this));
+  return std::make_unique<Barotropic3D<PolytropicFluid<IsRelativistic>>>(*this);
+}
+
+template <bool IsRelativistic>
+std::unique_ptr<EquationOfState<IsRelativistic, 2>>
+PolytropicFluid<IsRelativistic>::promote_to_2d_eos() const {
+  return std::make_unique<Barotropic2D<PolytropicFluid<IsRelativistic>>>(*this);
 }
 
 template <bool IsRelativistic>

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/PolytropicFluid.hpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/PolytropicFluid.hpp
@@ -78,6 +78,9 @@ class PolytropicFluid : public EquationOfState<IsRelativistic, 1> {
   std::unique_ptr<EquationOfState<IsRelativistic, 3>> promote_to_3d_eos()
       const override;
 
+  std::unique_ptr<EquationOfState<IsRelativistic, 2>> promote_to_2d_eos()
+      const override;
+
   bool is_equal(const EquationOfState<IsRelativistic, 1>& rhs) const override;
 
   bool operator==(const PolytropicFluid<IsRelativistic>& rhs) const;

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/Spectral.cpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/Spectral.cpp
@@ -9,7 +9,7 @@
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "NumericalAlgorithms/RootFinding/TOMS748.hpp"
-
+#include "PointwiseFunctions/Hydro/EquationsOfState/Barotropic2D.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/Barotropic3D.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
 #include "Utilities/MakeWithValue.hpp"
@@ -81,7 +81,11 @@ std::unique_ptr<EquationOfState<true, 1>> Spectral::get_clone() const {
 }
 
 std::unique_ptr<EquationOfState<true, 3>> Spectral::promote_to_3d_eos() const {
-  return std::make_unique<Barotropic3D<Spectral>>(Barotropic3D(*this));
+  return std::make_unique<Barotropic3D<Spectral>>(*this);
+}
+
+std::unique_ptr<EquationOfState<true, 2>> Spectral::promote_to_2d_eos() const {
+  return std::make_unique<Barotropic2D<Spectral>>(*this);
 }
 
 bool Spectral::operator==(const Spectral& rhs) const {

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/Spectral.hpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/Spectral.hpp
@@ -111,6 +111,8 @@ class Spectral : public EquationOfState<true, 1> {
 
   std::unique_ptr<EquationOfState<true, 3>> promote_to_3d_eos() const override;
 
+  std::unique_ptr<EquationOfState<true, 2>> promote_to_2d_eos() const override;
+
   bool operator==(const Spectral& rhs) const;
 
   bool operator!=(const Spectral& rhs) const;

--- a/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY "Test_EquationsOfState")
 
 set(LIBRARY_SOURCES
+  Test_Barotropic2D.cpp
   Test_Barotropic3D.cpp
   Test_DarkEnergyFluid.cpp
   Test_Enthalpy.cpp

--- a/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_Barotropic2D.cpp
+++ b/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_Barotropic2D.cpp
@@ -1,0 +1,127 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <limits>
+#include <pup.h>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/PointwiseFunctions/Hydro/EquationsOfState/TestHelpers.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/Barotropic2D.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/Factory.hpp"
+#include "PointwiseFunctions/Hydro/SpecificEnthalpy.hpp"
+#include "Utilities/Serialization/RegisterDerivedClassesWithCharm.hpp"
+
+SPECTRE_TEST_CASE("Unit.PointwiseFunctions.EquationsOfState.Barotropic2D",
+                  "[Unit][EquationsOfState]") {
+  namespace EoS = EquationsOfState;
+  const EoS::PolytropicFluid<true> underlying_eos{100.0, 2.0};
+  EoS::Barotropic2D<EoS::PolytropicFluid<true>> eos{underlying_eos};
+  CHECK(eos.rest_mass_density_lower_bound() ==
+        underlying_eos.rest_mass_density_lower_bound());
+  CHECK(eos.rest_mass_density_upper_bound() ==
+        underlying_eos.rest_mass_density_upper_bound());
+  CHECK(eos.electron_fraction_lower_bound() == 0.0);
+  CHECK(eos.electron_fraction_upper_bound() == 1.0);
+  CHECK(eos.temperature_lower_bound() == 0.0);
+  CHECK(eos.temperature_upper_bound() == std::numeric_limits<double>::max());
+  {
+    // DataVector functions
+    const Scalar<DataVector> rest_mass_density{
+        DataVector{1e-10, 1e-6, 1e-4, 1e-2, 1e-2, 1.0}};
+    // temperature and electron fraction should be irrelevant
+    const Scalar<DataVector> temperature{
+        DataVector{1e-10, 1e-6, 1e-4, 1e-2, 1e-2, 1.0}};
+    const Scalar<DataVector> specific_internal_energy =
+        underlying_eos.specific_internal_energy_from_density(rest_mass_density);
+    const Scalar<DataVector> pressure =
+        underlying_eos.pressure_from_density(rest_mass_density);
+    CHECK(eos.pressure_from_density_and_enthalpy(
+              rest_mass_density,
+              hydro::relativistic_specific_enthalpy(
+                  rest_mass_density, specific_internal_energy, pressure)) ==
+          pressure);
+    CHECK(eos.pressure_from_density_and_energy(rest_mass_density,
+                                               specific_internal_energy) ==
+          underlying_eos.pressure_from_density(rest_mass_density));
+    CHECK(eos.specific_internal_energy_from_density_and_pressure(
+              rest_mass_density, specific_internal_energy) ==
+          underlying_eos.specific_internal_energy_from_density(
+              rest_mass_density));
+    CHECK(eos.chi_from_density_and_energy(rest_mass_density,
+                                          specific_internal_energy) ==
+          underlying_eos.chi_from_density(rest_mass_density));
+    CHECK(eos.kappa_times_p_over_rho_squared_from_density_and_energy(
+              rest_mass_density, specific_internal_energy) ==
+          underlying_eos.kappa_times_p_over_rho_squared_from_density(
+              rest_mass_density));
+    // The energy is independent of energy, so this is a garabage value, but it
+    // is taken to be zero
+    CHECK(eos.temperature_from_density_and_energy(rest_mass_density,
+                                                  specific_internal_energy) ==
+          make_with_value<Scalar<DataVector>>(rest_mass_density, 0.0));
+  }
+
+  {
+    // double functions
+    const Scalar<double> rest_mass_density{{1e-10}};
+    // temperature should be irrelevant
+    const Scalar<double> temperature{{1e-10}};
+    const Scalar<double> specific_internal_energy =
+        underlying_eos.specific_internal_energy_from_density(rest_mass_density);
+    const Scalar<double> pressure =
+        underlying_eos.pressure_from_density(rest_mass_density);
+    CHECK(eos.pressure_from_density_and_enthalpy(
+              rest_mass_density,
+              hydro::relativistic_specific_enthalpy(
+                  rest_mass_density, specific_internal_energy, pressure)) ==
+          pressure);
+    CHECK(eos.pressure_from_density_and_energy(rest_mass_density,
+                                               specific_internal_energy) ==
+          underlying_eos.pressure_from_density(rest_mass_density));
+    CHECK(eos.specific_internal_energy_from_density_and_pressure(
+              rest_mass_density, specific_internal_energy) ==
+          underlying_eos.specific_internal_energy_from_density(
+              rest_mass_density));
+    CHECK(eos.chi_from_density_and_energy(rest_mass_density,
+                                          specific_internal_energy) ==
+          underlying_eos.chi_from_density(rest_mass_density));
+    CHECK(eos.kappa_times_p_over_rho_squared_from_density_and_energy(
+              rest_mass_density, specific_internal_energy) ==
+          underlying_eos.kappa_times_p_over_rho_squared_from_density(
+              rest_mass_density));
+    // The energy is independent of energy, so this is a garabage value, but it
+    // is taken to be zero
+    CHECK(eos.temperature_from_density_and_energy(rest_mass_density,
+                                                  specific_internal_energy) ==
+          make_with_value<Scalar<double>>(rest_mass_density, 0.0));
+  }
+  {
+    register_derived_classes_with_charm<EoS::EquationOfState<true, 2>>();
+    register_derived_classes_with_charm<EoS::EquationOfState<true, 1>>();
+    const auto eos_pointer = serialize_and_deserialize(
+        TestHelpers::test_creation<
+            std::unique_ptr<EoS::EquationOfState<true, 2>>>(
+            {"Barotropic2D(PolytropicFluid):\n"
+             "  PolytropicFluid:\n"
+             "    PolytropicConstant: 100.0\n"
+             "    PolytropicExponent: 2.0"}));
+    const auto& deserialized_eos =
+        dynamic_cast<const EoS::Barotropic2D<EoS::PolytropicFluid<true>>&>(
+            *eos_pointer);
+    TestHelpers::EquationsOfState::test_get_clone(deserialized_eos);
+
+    CHECK(eos == deserialized_eos);
+    CHECK(eos != EoS::Barotropic2D<EoS::PolytropicFluid<true>>{
+                     EoS::PolytropicFluid<true>(10.0, 2.0)});
+    CHECK(eos != EoS::Barotropic2D<EoS::PolytropicFluid<true>>{
+                     EoS::PolytropicFluid<true>(100.0, 1.0)});
+    CHECK(not eos.is_equal(EoS::Barotropic2D<EoS::Spectral>{
+        EoS::Spectral(1e-5, 1e-4, {2.0, 0.0, 0.0}, 1e-2)}));
+  }
+}

--- a/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_Enthalpy.cpp
+++ b/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_Enthalpy.cpp
@@ -12,6 +12,7 @@
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Framework/TestCreation.hpp"
 #include "Helpers/PointwiseFunctions/Hydro/EquationsOfState/TestHelpers.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/Barotropic2D.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/Barotropic3D.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/Enthalpy.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
@@ -87,6 +88,7 @@ void check_exact() {
     CHECK(eos != other_type_eos);
     CHECK(other_low_eos != other_type_eos);
     CHECK(*eos.promote_to_3d_eos() == Barotropic3D<Enthalpy<Spectral>>(eos));
+    CHECK(*eos.promote_to_2d_eos() == Barotropic2D<Enthalpy<Spectral>>(eos));
     CHECK(eos.baryon_mass() ==
           approx(hydro::units::geometric::default_baryon_mass));
   }

--- a/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_PiecewisePolytropicFluid.cpp
+++ b/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_PiecewisePolytropicFluid.cpp
@@ -13,6 +13,7 @@
 #include "Framework/TestCreation.hpp"
 #include "Framework/TestHelpers.hpp"
 #include "Helpers/PointwiseFunctions/Hydro/EquationsOfState/TestHelpers.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/Barotropic2D.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/Barotropic3D.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/Factory.hpp"
@@ -339,9 +340,12 @@ SPECTRE_TEST_CASE(
   CHECK(eos != other_eos);
   // Different eos types should NOT match
   CHECK(eos != other_type_eos);
-  // Check the correct 3D EoS is got
+  // Check the correct 3D EoS is obtained
   CHECK(*eos.promote_to_3d_eos() ==
         EoS::Barotropic3D<EoS::PiecewisePolytropicFluid<true>>(eos));
+  // Check the correct 2D EoS is obtained
+  CHECK(*eos.promote_to_2d_eos() ==
+        EoS::Barotropic2D<EoS::PiecewisePolytropicFluid<true>>(eos));
   // Check baryon density
   CHECK(eos.baryon_mass() ==
         approx(hydro::units::geometric::default_baryon_mass));

--- a/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_PolytropicFluid.cpp
+++ b/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_PolytropicFluid.cpp
@@ -13,6 +13,7 @@
 #include "Framework/TestCreation.hpp"
 #include "Framework/TestHelpers.hpp"
 #include "Helpers/PointwiseFunctions/Hydro/EquationsOfState/TestHelpers.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/Barotropic2D.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/Barotropic3D.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/Factory.hpp"
@@ -80,6 +81,8 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.EquationsOfState.PolytropicFluid",
   CHECK(eos != other_type_eos);
   CHECK(*eos.promote_to_3d_eos() ==
         EoS::Barotropic3D<EoS::PolytropicFluid<true>>(eos));
+  CHECK(*eos.promote_to_2d_eos() ==
+        EoS::Barotropic2D<EoS::PolytropicFluid<true>>(eos));
   const double d_for_size = std::numeric_limits<double>::signaling_NaN();
   const DataVector dv_for_size(5);
   TestHelpers::EquationsOfState::check(EoS::PolytropicFluid<true>{100.0, 2.0},

--- a/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_SpectralEoS.cpp
+++ b/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_SpectralEoS.cpp
@@ -10,6 +10,7 @@
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Framework/TestCreation.hpp"
 #include "Helpers/PointwiseFunctions/Hydro/EquationsOfState/TestHelpers.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/Barotropic2D.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/Barotropic3D.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/Factory.hpp"
@@ -43,6 +44,8 @@ void check_exact() {
   CHECK(eos != other_type_eos);
   CHECK(*eos.promote_to_3d_eos() ==
         EquationsOfState::Barotropic3D<EquationsOfState::Spectral>(eos));
+  CHECK(*eos.promote_to_2d_eos() ==
+        EquationsOfState::Barotropic2D<EquationsOfState::Spectral>(eos));
   // Test DataVector functions
   {
     const Scalar<DataVector> rho{DataVector{


### PR DESCRIPTION
## Proposed changes

Will be used in Newtonian Euler so that the EOS can be runtime and is always 2d.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
