### PR TITLE
Add Random StepChooser for debugging

### DIFF
--- a/src/Time/CMakeLists.txt
+++ b/src/Time/CMakeLists.txt
@@ -45,6 +45,7 @@ target_link_libraries(
   PUBLIC
   Boost::boost
   DataStructures
+  Domain
   ErrorHandling
   EventsAndTriggers
   Options

--- a/src/Time/StepChoosers/CMakeLists.txt
+++ b/src/Time/StepChoosers/CMakeLists.txt
@@ -5,6 +5,7 @@ spectre_target_sources(
   ${LIBRARY}
   PRIVATE
   Constant.cpp
+  Random.cpp
   StepToTimes.cpp
   )
 
@@ -20,6 +21,7 @@ spectre_target_headers(
   Factory.hpp
   Increase.hpp
   PreventRapidIncrease.hpp
+  Random.hpp
   StepChooser.hpp
   StepToTimes.hpp
   )

--- a/src/Time/StepChoosers/Random.cpp
+++ b/src/Time/StepChoosers/Random.cpp
@@ -1,0 +1,83 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Time/StepChoosers/Random.hpp"
+
+#include <boost/functional/hash.hpp>
+#include <cmath>
+#include <cstddef>
+#include <pup.h>
+#include <random>
+#include <utility>
+
+#include "Domain/Structure/Element.hpp"
+#include "Options/Context.hpp"
+#include "Options/ParseError.hpp"
+#include "Time/StepChoosers/StepChooser.hpp"
+#include "Time/TimeStepId.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+
+namespace StepChoosers {
+
+template <typename StepChooserUse, size_t VolumeDim>
+Random<StepChooserUse, VolumeDim>::Random() = default;
+
+template <typename StepChooserUse, size_t VolumeDim>
+Random<StepChooserUse, VolumeDim>::Random(CkMigrateMessage* /*unused*/) {}
+
+template <typename StepChooserUse, size_t VolumeDim>
+Random<StepChooserUse, VolumeDim>::Random(const double minimum,
+                                          const double maximum,
+                                          const size_t seed,
+                                          const Options::Context& context)
+    : minimum_(minimum), maximum_(maximum), seed_(seed) {
+  if (minimum_ >= maximum_) {
+    PARSE_ERROR(context, "Must have Minimum < Maximum");
+  }
+}
+
+template <typename StepChooserUse, size_t VolumeDim>
+std::pair<double, bool> Random<StepChooserUse, VolumeDim>::operator()(
+    const Element<VolumeDim>& element, const TimeStepId& time_step_id,
+    const double /*last_step_magnitude*/) const {
+  size_t local_seed = seed_;
+  boost::hash_combine(local_seed, element.id());
+  boost::hash_combine(local_seed, time_step_id);
+  std::mt19937_64 rng(local_seed);
+  std::uniform_real_distribution<> dist(log(minimum_), log(maximum_));
+  for (;;) {
+    const double step = exp(dist(rng));
+    // Don't produce out-of-range values because of roundoff.
+    if (step >= minimum_ and step <= maximum_) {
+      return {step, true};
+    }
+  }
+}
+
+template <typename StepChooserUse, size_t VolumeDim>
+bool Random<StepChooserUse, VolumeDim>::uses_local_data() const {
+  return true;
+}
+
+template <typename StepChooserUse, size_t VolumeDim>
+void Random<StepChooserUse, VolumeDim>::pup(PUP::er& p) {
+  p | minimum_;
+  p | maximum_;
+  p | seed_;
+}
+
+template <typename StepChooserUse, size_t VolumeDim>
+PUP::able::PUP_ID Random<StepChooserUse, VolumeDim>::my_PUP_ID = 0;  // NOLINT
+
+#define USE(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define DIM(data) BOOST_PP_TUPLE_ELEM(1, data)
+
+#define INSTANTIATE(_, data) \
+  template class Random<StepChooserUse::USE(data), DIM(data)>;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (Slab, LtsStep), (1, 2, 3))
+
+#undef INSTANTIATE
+#undef DIM
+#undef USE
+}  // namespace StepChoosers

--- a/src/Time/StepChoosers/Random.hpp
+++ b/src/Time/StepChoosers/Random.hpp
@@ -1,0 +1,84 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <limits>
+#include <pup.h>
+#include <utility>
+
+#include "Options/Context.hpp"
+#include "Options/String.hpp"
+#include "Time/StepChoosers/StepChooser.hpp"
+#include "Utilities/Serialization/CharmPupable.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+template <size_t VolumeDim>
+class Element;
+class TimeStepId;
+namespace Tags {
+struct TimeStepId;
+}  // namespace Tags
+namespace domain::Tags {
+template <size_t VolumeDim>
+struct Element;
+}  // namespace domain::Tags
+/// \endcond
+
+namespace StepChoosers {
+/// Changes the step size pseudo-randomly.  Values are distributed
+/// uniformly in $\log(dt)$.  The current step is always accepted.
+template <typename StepChooserUse, size_t VolumeDim>
+class Random : public StepChooser<StepChooserUse> {
+ public:
+  /// \cond
+  Random();
+  explicit Random(CkMigrateMessage* /*unused*/);
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(Random);  // NOLINT
+  /// \endcond
+
+  struct Minimum {
+    using type = double;
+    static constexpr Options::String help{"Minimum value to suggest"};
+    static type lower_bound() { return 0.0; }
+  };
+
+  struct Maximum {
+    using type = double;
+    static constexpr Options::String help{"Maximum value to suggest"};
+    static type lower_bound() { return 0.0; }
+  };
+
+  struct Seed {
+    using type = size_t;
+    static constexpr Options::String help{"RNG seed"};
+  };
+
+  static constexpr Options::String help =
+      "Changes the step size pseudo-randomly.";
+  using options = tmpl::list<Minimum, Maximum, Seed>;
+
+  Random(double minimum, double maximum, size_t seed,
+         const Options::Context& context = {});
+
+  using argument_tags =
+      tmpl::list<domain::Tags::Element<VolumeDim>, Tags::TimeStepId>;
+
+  std::pair<double, bool> operator()(const Element<VolumeDim>& element,
+                                     const TimeStepId& time_step_id,
+                                     double last_step_magnitude) const;
+
+  bool uses_local_data() const override;
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& p) override;
+
+ private:
+  double minimum_ = std::numeric_limits<double>::signaling_NaN();
+  double maximum_ = std::numeric_limits<double>::signaling_NaN();
+  size_t seed_ = 0;
+};
+}  // namespace StepChoosers

--- a/tests/Unit/Time/StepChoosers/CMakeLists.txt
+++ b/tests/Unit/Time/StepChoosers/CMakeLists.txt
@@ -10,5 +10,6 @@ set(LIBRARY_SOURCES
   StepChoosers/Test_ErrorControl.cpp
   StepChoosers/Test_Increase.cpp
   StepChoosers/Test_PreventRapidIncrease.cpp
+  StepChoosers/Test_Random.cpp
   StepChoosers/Test_StepToTimes.cpp
   PARENT_SCOPE)

--- a/tests/Unit/Time/StepChoosers/Test_Random.cpp
+++ b/tests/Unit/Time/StepChoosers/Test_Random.cpp
@@ -1,0 +1,117 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <iomanip>
+#include <memory>
+#include <random>
+#include <unordered_set>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "Domain/Structure/Element.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Domain/Tags.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Options/Protocols/FactoryCreation.hpp"
+#include "Parallel/Tags/Metavariables.hpp"
+#include "Time/Slab.hpp"
+#include "Time/StepChoosers/Random.hpp"
+#include "Time/StepChoosers/StepChooser.hpp"
+#include "Time/Tags/TimeStepId.hpp"
+#include "Time/TimeStepId.hpp"
+#include "Utilities/MakeString.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
+#include "Utilities/Serialization/RegisterDerivedClassesWithCharm.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+constexpr size_t volume_dim = 2;
+
+struct Metavariables {
+  struct factory_creation
+      : tt::ConformsTo<Options::protocols::FactoryCreation> {
+    using factory_classes =
+        tmpl::map<tmpl::pair<StepChooser<StepChooserUse::LtsStep>,
+                             tmpl::list<StepChoosers::Random<
+                                 StepChooserUse::LtsStep, volume_dim>>>,
+                  tmpl::pair<StepChooser<StepChooserUse::Slab>,
+                             tmpl::list<StepChoosers::Random<
+                                 StepChooserUse::Slab, volume_dim>>>>;
+  };
+  using component_list = tmpl::list<>;
+};
+
+template <typename Use>
+double get_suggestion(const double min, const double max, const size_t seed,
+                      const Element<volume_dim>& element,
+                      const TimeStepId& time_step_id) {
+  using Random = StepChoosers::Random<Use, volume_dim>;
+
+  auto box = db::create<
+      db::AddSimpleTags<Parallel::Tags::MetavariablesImpl<Metavariables>,
+                        Tags::TimeStepId, domain::Tags::Element<volume_dim>>>(
+      Metavariables{}, time_step_id, element);
+
+  // Not used.
+  const double current_step = 1.23;
+
+  const Random random(min, max, seed);
+  const std::unique_ptr<StepChooser<Use>> random_base =
+      TestHelpers::test_factory_creation<StepChooser<Use>, Random>(
+          MakeString{} << std::setprecision(19) << "Random:\n"
+                       << "  Minimum: " << min << "\n"
+                       << "  Maximum: " << max << "\n"
+                       << "  Seed: " << seed);
+
+  CHECK(random.uses_local_data());
+
+  const auto result = random(element, time_step_id, current_step);
+  // Should be deterministic
+  CHECK(result == random(element, time_step_id, current_step));
+
+  CHECK(result.second);
+
+  CHECK(result.first >= min);
+  CHECK(result.first <= max);
+
+  CHECK(serialize_and_deserialize(random)(element, time_step_id,
+                                          current_step) == result);
+  CHECK(random_base->desired_step(current_step, box) == result);
+  CHECK(
+      serialize_and_deserialize(random_base)->desired_step(current_step, box) ==
+      result);
+
+  return result.first;
+}
+
+template <typename Use>
+void test_random() {
+  const Element<volume_dim> element1(ElementId<volume_dim>(1), {});
+  const Element<volume_dim> element2(ElementId<volume_dim>(2), {});
+  const TimeStepId time1(true, 0, Slab(0.0, 1.0).start());
+  const TimeStepId time2(true, 0, Slab(0.0, 1.0).end());
+
+  MAKE_GENERATOR(gen);
+  const double min = std::uniform_real_distribution(1.0e-6, 1.0)(gen);
+  const double max = min * std::uniform_real_distribution(1.1, 10.0)(gen);
+  const size_t seed = gen();
+
+  std::unordered_set<double> results{};
+  for (const auto& element : {element1, element2}) {
+    for (const auto& time : {time1, time2}) {
+      CHECK(results.insert(get_suggestion<Use>(min, max, seed, element, time))
+                .second);
+    }
+  }
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Time.StepChoosers.Random", "[Unit][Time]") {
+  register_factory_classes_with_charm<Metavariables>();
+
+  test_random<StepChooserUse::LtsStep>();
+  test_random<StepChooserUse::Slab>();
+}


### PR DESCRIPTION
Not added to the default list of available StepChoosers.

The dependence of Time on Domain is unpleasant, but it was already there and just didn't trigger an error before.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
