### PR TITLE
Add scalar self force and derivatives calculations

### DIFF
--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/SelfForce.cpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/SelfForce.cpp
@@ -113,6 +113,26 @@ tnsr::A<double, Dim> Du_self_force_per_mass(
                                     four_velocity(ti::B) * self_force(ti::C));
 }
 
+template <size_t Dim>
+tnsr::A<double, Dim> dt_Du_self_force_per_mass(
+    const tnsr::A<double, Dim>& self_force,
+    const tnsr::A<double, Dim>& dt_self_force,
+    const tnsr::A<double, Dim>& dt2_self_force,
+    const tnsr::A<double, Dim>& four_velocity,
+    const tnsr::A<double, Dim>& dt_four_velocity,
+    const tnsr::Abb<double, Dim>& christoffel,
+    const tnsr::Abb<double, Dim>& dt_christoffel) {
+  return tenex::evaluate<ti::A>(
+      dt2_self_force(ti::A) * get<0>(four_velocity) +
+      dt_self_force(ti::A) * get<0>(dt_four_velocity) +
+      dt_christoffel(ti::A, ti::b, ti::c) * four_velocity(ti::B) *
+          self_force(ti::C) +
+      christoffel(ti::A, ti::b, ti::c) * dt_four_velocity(ti::B) *
+          self_force(ti::C) +
+      christoffel(ti::A, ti::b, ti::c) * four_velocity(ti::B) *
+          dt_self_force(ti::C));
+}
+
 // Instantiations
 template void self_force_acceleration(
     gsl::not_null<tnsr::I<double, 3>*> self_force_acc,
@@ -154,4 +174,13 @@ template tnsr::A<double, 3> Du_self_force_per_mass(
     const tnsr::A<double, 3>& dt_self_force,
     const tnsr::A<double, 3>& four_velocity,
     const tnsr::Abb<double, 3>& christoffel);
+
+template tnsr::A<double, 3> dt_Du_self_force_per_mass(
+    const tnsr::A<double, 3>& self_force,
+    const tnsr::A<double, 3>& dt_self_force,
+    const tnsr::A<double, 3>& dt2_self_force,
+    const tnsr::A<double, 3>& four_velocity,
+    const tnsr::A<double, 3>& dt_four_velocity,
+    const tnsr::Abb<double, 3>& christoffel,
+    const tnsr::Abb<double, 3>& dt_christoffel);
 }  // namespace CurvedScalarWave::Worldtube

--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/SelfForce.cpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/SelfForce.cpp
@@ -77,6 +77,31 @@ tnsr::A<double, Dim> dt_self_force_per_mass(
            dt_d_psi(ti::b)));
 }
 
+template <size_t Dim>
+tnsr::A<double, Dim> dt2_self_force_per_mass(
+    const tnsr::a<double, Dim>& d_psi, const tnsr::a<double, Dim>& dt_d_psi,
+    const tnsr::a<double, Dim>& dt2_d_psi,
+    const tnsr::A<double, Dim>& four_velocity,
+    const tnsr::A<double, Dim>& dt_four_velocity,
+    const tnsr::A<double, Dim>& dt2_four_velocity, double particle_charge,
+    double particle_mass, const tnsr::AA<double, Dim>& inverse_metric,
+    const tnsr::AA<double, Dim>& dt_inverse_metric,
+    const tnsr::AA<double, Dim>& dt2_inverse_metric) {
+  return tenex::evaluate<ti::A>(
+      particle_charge / particle_mass *
+      ((dt2_inverse_metric(ti::A, ti::B) +
+        dt2_four_velocity(ti::A) * four_velocity(ti::B) +
+        dt2_four_velocity(ti::B) * four_velocity(ti::A) +
+        2. * dt_four_velocity(ti::A) * dt_four_velocity(ti::B)) *
+           d_psi(ti::b) +
+       2. * dt_d_psi(ti::b) *
+           (dt_inverse_metric(ti::A, ti::B) +
+            dt_four_velocity(ti::A) * four_velocity(ti::B) +
+            dt_four_velocity(ti::B) * four_velocity(ti::A)) +
+       dt2_d_psi(ti::b) * (inverse_metric(ti::A, ti::B) +
+                           four_velocity(ti::A) * four_velocity(ti::B))));
+}
+
 // Instantiations
 template void self_force_acceleration(
     gsl::not_null<tnsr::I<double, 3>*> self_force_acc,
@@ -102,4 +127,14 @@ template tnsr::A<double, 3> dt_self_force_per_mass(
     const tnsr::A<double, 3>& dt_four_velocity, double particle_charge,
     double particle_mass, const tnsr::AA<double, 3>& inverse_metric,
     const tnsr::AA<double, 3>& dt_inverse_metric);
+
+template tnsr::A<double, 3> dt2_self_force_per_mass(
+    const tnsr::a<double, 3>& d_psi, const tnsr::a<double, 3>& dt_d_psi,
+    const tnsr::a<double, 3>& dt2_d_psi,
+    const tnsr::A<double, 3>& four_velocity,
+    const tnsr::A<double, 3>& dt_four_velocity,
+    const tnsr::A<double, 3>& dt2_four_velocity, double particle_charge,
+    double particle_mass, const tnsr::AA<double, 3>& inverse_metric,
+    const tnsr::AA<double, 3>& dt_inverse_metric,
+    const tnsr::AA<double, 3>& dt2_inverse_metric);
 }  // namespace CurvedScalarWave::Worldtube

--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/SelfForce.cpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/SelfForce.cpp
@@ -49,6 +49,16 @@ tnsr::I<double, Dim> self_force_acceleration(
   return self_force_acc;
 }
 
+template <size_t Dim>
+tnsr::A<double, Dim> self_force_per_mass(
+    const tnsr::a<double, Dim>& d_psi,
+    const tnsr::A<double, Dim>& four_velocity, const double particle_charge,
+    const double particle_mass, const tnsr::AA<double, Dim>& inverse_metric) {
+  return tenex::evaluate<ti::B>(particle_charge / particle_mass * d_psi(ti::a) *
+                                (inverse_metric(ti::A, ti::B) +
+                                 four_velocity(ti::A) * four_velocity(ti::B)));
+}
+
 // Instantiations
 template void self_force_acceleration(
     gsl::not_null<tnsr::I<double, 3>*> self_force_acc,
@@ -62,4 +72,10 @@ template tnsr::I<double, 3> self_force_acceleration(
     const tnsr::I<double, 3>& particle_velocity, const double particle_charge,
     const double particle_mass, const tnsr::AA<double, 3>& inverse_metric,
     const Scalar<double>& dilation_factor);
+
+template tnsr::A<double, 3> self_force_per_mass(
+    const tnsr::a<double, 3>& d_psi, const tnsr::A<double, 3>& four_velocity,
+    const double particle_charge, const double particle_mass,
+    const tnsr::AA<double, 3>& inverse_metric);
+
 }  // namespace CurvedScalarWave::Worldtube

--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/SelfForce.cpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/SelfForce.cpp
@@ -102,6 +102,17 @@ tnsr::A<double, Dim> dt2_self_force_per_mass(
                            four_velocity(ti::A) * four_velocity(ti::B))));
 }
 
+template <size_t Dim>
+tnsr::A<double, Dim> Du_self_force_per_mass(
+    const tnsr::A<double, Dim>& self_force,
+    const tnsr::A<double, Dim>& dt_self_force,
+    const tnsr::A<double, Dim>& four_velocity,
+    const tnsr::Abb<double, Dim>& christoffel) {
+  return tenex::evaluate<ti::A>(dt_self_force(ti::A) * get<0>(four_velocity) +
+                                christoffel(ti::A, ti::b, ti::c) *
+                                    four_velocity(ti::B) * self_force(ti::C));
+}
+
 // Instantiations
 template void self_force_acceleration(
     gsl::not_null<tnsr::I<double, 3>*> self_force_acc,
@@ -137,4 +148,10 @@ template tnsr::A<double, 3> dt2_self_force_per_mass(
     double particle_mass, const tnsr::AA<double, 3>& inverse_metric,
     const tnsr::AA<double, 3>& dt_inverse_metric,
     const tnsr::AA<double, 3>& dt2_inverse_metric);
+
+template tnsr::A<double, 3> Du_self_force_per_mass(
+    const tnsr::A<double, 3>& self_force,
+    const tnsr::A<double, 3>& dt_self_force,
+    const tnsr::A<double, 3>& four_velocity,
+    const tnsr::Abb<double, 3>& christoffel);
 }  // namespace CurvedScalarWave::Worldtube

--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/SelfForce.cpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/SelfForce.cpp
@@ -59,6 +59,24 @@ tnsr::A<double, Dim> self_force_per_mass(
                                  four_velocity(ti::A) * four_velocity(ti::B)));
 }
 
+template <size_t Dim>
+tnsr::A<double, Dim> dt_self_force_per_mass(
+    const tnsr::a<double, Dim>& d_psi, const tnsr::a<double, Dim>& dt_d_psi,
+    const tnsr::A<double, Dim>& four_velocity,
+    const tnsr::A<double, Dim>& dt_four_velocity, double particle_charge,
+    double particle_mass, const tnsr::AA<double, Dim>& inverse_metric,
+    const tnsr::AA<double, Dim>& dt_inverse_metric) {
+  return tenex::evaluate<ti::A>(
+      particle_charge / particle_mass *
+      ((dt_inverse_metric(ti::A, ti::B) +
+        four_velocity(ti::A) * dt_four_velocity(ti::B) +
+        dt_four_velocity(ti::A) * four_velocity(ti::B)) *
+           d_psi(ti::b) +
+       (inverse_metric(ti::A, ti::B) +
+        four_velocity(ti::A) * four_velocity(ti::B)) *
+           dt_d_psi(ti::b)));
+}
+
 // Instantiations
 template void self_force_acceleration(
     gsl::not_null<tnsr::I<double, 3>*> self_force_acc,
@@ -78,4 +96,10 @@ template tnsr::A<double, 3> self_force_per_mass(
     const double particle_charge, const double particle_mass,
     const tnsr::AA<double, 3>& inverse_metric);
 
+template tnsr::A<double, 3> dt_self_force_per_mass(
+    const tnsr::a<double, 3>& d_psi, const tnsr::a<double, 3>& dt_d_psi,
+    const tnsr::A<double, 3>& four_velocity,
+    const tnsr::A<double, 3>& dt_four_velocity, double particle_charge,
+    double particle_mass, const tnsr::AA<double, 3>& inverse_metric,
+    const tnsr::AA<double, 3>& dt_inverse_metric);
 }  // namespace CurvedScalarWave::Worldtube

--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/SelfForce.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/SelfForce.hpp
@@ -105,4 +105,19 @@ tnsr::A<double, Dim> Du_self_force_per_mass(
     const tnsr::A<double, Dim>& dt_self_force,
     const tnsr::A<double, Dim>& four_velocity,
     const tnsr::Abb<double, Dim>& christoffel);
+/*!
+ * \brief Computes the time derivative of the covariant derivative of the scalar
+ * self-force per unit mass $f^\alpha$, see `Du_self_force_per_mass`, along the
+ * four velocity $u^\beta$, i.e.
+ * $\frac{d}{dt}u^\beta \nabla_\beta f^\alpha$.
+ */
+template <size_t Dim>
+tnsr::A<double, Dim> dt_Du_self_force_per_mass(
+    const tnsr::A<double, Dim>& self_force,
+    const tnsr::A<double, Dim>& dt_self_force,
+    const tnsr::A<double, Dim>& dt2_self_force,
+    const tnsr::A<double, Dim>& four_velocity,
+    const tnsr::A<double, Dim>& dt_four_velocity,
+    const tnsr::Abb<double, Dim>& christoffel,
+    const tnsr::Abb<double, Dim>& dt_christoffel);
 }  // namespace CurvedScalarWave::Worldtube

--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/SelfForce.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/SelfForce.hpp
@@ -93,4 +93,16 @@ tnsr::A<double, Dim> dt2_self_force_per_mass(
     double particle_mass, const tnsr::AA<double, Dim>& inverse_metric,
     const tnsr::AA<double, Dim>& dt_inverse_metric,
     const tnsr::AA<double, Dim>& dt2_inverse_metric);
+
+/*!
+ * \brief Computes the covariant derivative of the scalar self-force per unit
+ * mass $f^\alpha$, see `self_force_per_mass`, along the four velocity
+ * $u^\beta$, i.e. $u^\beta \nabla_\beta f^\alpha$.
+ */
+template <size_t Dim>
+tnsr::A<double, Dim> Du_self_force_per_mass(
+    const tnsr::A<double, Dim>& self_force,
+    const tnsr::A<double, Dim>& dt_self_force,
+    const tnsr::A<double, Dim>& four_velocity,
+    const tnsr::Abb<double, Dim>& christoffel);
 }  // namespace CurvedScalarWave::Worldtube

--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/SelfForce.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/SelfForce.hpp
@@ -48,4 +48,22 @@ tnsr::I<double, Dim> self_force_acceleration(
     const Scalar<double>& dilation_factor);
 
 /// @}
+/*!
+ * \brief Computes the scalar self-force per unit mass
+ *
+ * \details It is given by
+ * \begin{equation}
+ * f^\alpha = \frac{q}{\mu} (g^{\alpha \beta} + u^\alpha u^\beta) \partial_\beta
+ * \Psi^R
+ * \end{equation}
+ * where $\Psi^R$ is the regular field at the position of the particle, $q$ is
+ * the particle's charge, $\mu$ is the particle's mass, $u^\alpha$ is the
+ * four-velocity and $g^{\alpha \beta}$ is the inverse spacetime metric in the
+ * inertial frame, evaluated at the position of the particle.
+ */
+template <size_t Dim>
+tnsr::A<double, Dim> self_force_per_mass(
+    const tnsr::a<double, Dim>& d_psi,
+    const tnsr::A<double, Dim>& four_velocity, double particle_charge,
+    double particle_mass, const tnsr::AA<double, Dim>& inverse_metric);
 }  // namespace CurvedScalarWave::Worldtube

--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/SelfForce.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/SelfForce.hpp
@@ -66,4 +66,17 @@ tnsr::A<double, Dim> self_force_per_mass(
     const tnsr::a<double, Dim>& d_psi,
     const tnsr::A<double, Dim>& four_velocity, double particle_charge,
     double particle_mass, const tnsr::AA<double, Dim>& inverse_metric);
+
+/*!
+ * \brief Computes the first time derivative of scalar self-force per unit mass,
+ * see `self_force_per_mass`, by applying the chain rule.
+ */
+template <size_t Dim>
+tnsr::A<double, Dim> dt_self_force_per_mass(
+    const tnsr::a<double, Dim>& d_psi, const tnsr::a<double, Dim>& dt_d_psi,
+    const tnsr::A<double, Dim>& four_velocity,
+    const tnsr::A<double, Dim>& dt_four_velocity, double particle_charge,
+    double particle_mass, const tnsr::AA<double, Dim>& inverse_metric,
+    const tnsr::AA<double, Dim>& dt_inverse_metric);
+
 }  // namespace CurvedScalarWave::Worldtube

--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/SelfForce.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/SelfForce.hpp
@@ -79,4 +79,18 @@ tnsr::A<double, Dim> dt_self_force_per_mass(
     double particle_mass, const tnsr::AA<double, Dim>& inverse_metric,
     const tnsr::AA<double, Dim>& dt_inverse_metric);
 
+/*!
+ * \brief Computes the second time derivative of scalar self-force per unit
+ * mass, see `self_force_per_mass`, by applying the chain rule.
+ */
+template <size_t Dim>
+tnsr::A<double, Dim> dt2_self_force_per_mass(
+    const tnsr::a<double, Dim>& d_psi, const tnsr::a<double, Dim>& dt_d_psi,
+    const tnsr::a<double, Dim>& dt2_d_psi,
+    const tnsr::A<double, Dim>& four_velocity,
+    const tnsr::A<double, Dim>& dt_four_velocity,
+    const tnsr::A<double, Dim>& dt2_four_velocity, double particle_charge,
+    double particle_mass, const tnsr::AA<double, Dim>& inverse_metric,
+    const tnsr::AA<double, Dim>& dt_inverse_metric,
+    const tnsr::AA<double, Dim>& dt2_inverse_metric);
 }  // namespace CurvedScalarWave::Worldtube

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/SelfForce.py
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/SelfForce.py
@@ -89,3 +89,14 @@ def dt2_self_force_per_mass(
     )
     return charge / mass * dt2_self_force_per_mass
 
+
+def Du_self_force_per_mass(
+    self_force, dt_self_force, four_velocity, christoffel
+):
+    Du_self_force_per_mass = four_velocity[0] * dt_self_force
+    Du_self_force_per_mass += np.einsum(
+        "ijk,j,k", christoffel, four_velocity, self_force
+    )
+    return Du_self_force_per_mass
+
+

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/SelfForce.py
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/SelfForce.py
@@ -100,3 +100,25 @@ def Du_self_force_per_mass(
     return Du_self_force_per_mass
 
 
+def dt_Du_self_force_per_mass(
+    self_force,
+    dt_self_force,
+    dt2_self_force,
+    four_velocity,
+    dt_four_velocity,
+    christoffel,
+    dt_christoffel,
+):
+    dt_Du_self_force_per_mass = (
+        dt_four_velocity[0] * dt_self_force + dt2_self_force * four_velocity[0]
+    )
+    dt_Du_self_force_per_mass += np.einsum(
+        "ijk,j,k", dt_christoffel, four_velocity, self_force
+    )
+    dt_Du_self_force_per_mass += np.einsum(
+        "ijk,j,k", christoffel, dt_four_velocity, self_force
+    )
+    dt_Du_self_force_per_mass += np.einsum(
+        "ijk,j,k", christoffel, four_velocity, dt_self_force
+    )
+    return dt_Du_self_force_per_mass

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/SelfForce.py
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/SelfForce.py
@@ -49,3 +49,43 @@ def dt_self_force_per_mass(
     )
     return charge / mass * dt_self_force_per_mass
 
+
+def dt2_self_force_per_mass(
+    d_psi,
+    dt_d_psi,
+    dt2_d_psi,
+    four_velocity,
+    dt_four_velocity,
+    dt2_four_velocity,
+    charge,
+    mass,
+    inverse_metric,
+    dt_inverse_metric,
+    dt2_inverse_metric,
+):
+    dt2_self_force_per_mass = np.einsum("ij,j", dt2_inverse_metric, d_psi)
+    dt2_self_force_per_mass += 2.0 * np.einsum(
+        "ij,j", dt_inverse_metric, dt_d_psi
+    )
+    dt2_self_force_per_mass += np.einsum("ij,j", inverse_metric, dt2_d_psi)
+
+    dt2_self_force_per_mass += np.einsum(
+        "i,j,j", dt2_four_velocity, four_velocity, d_psi
+    )
+    dt2_self_force_per_mass += 2.0 * np.einsum(
+        "i,j,j", dt_four_velocity, dt_four_velocity, d_psi
+    )
+    dt2_self_force_per_mass += 2.0 * np.einsum(
+        "i,j,j", dt_four_velocity, four_velocity, dt_d_psi
+    )
+    dt2_self_force_per_mass += 2.0 * np.einsum(
+        "i,j,j", four_velocity, dt_four_velocity, dt_d_psi
+    )
+    dt2_self_force_per_mass += np.einsum(
+        "i,j,j", four_velocity, dt2_four_velocity, d_psi
+    )
+    dt2_self_force_per_mass += np.einsum(
+        "i,j,j", four_velocity, four_velocity, dt2_d_psi
+    )
+    return charge / mass * dt2_self_force_per_mass
+

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/SelfForce.py
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/SelfForce.py
@@ -24,3 +24,28 @@ def self_force_per_mass(d_psi, four_velocity, charge, mass, inverse_metric):
     )
     return charge / mass * self_force_per_mass
 
+
+def dt_self_force_per_mass(
+    d_psi,
+    dt_d_psi,
+    four_velocity,
+    dt_four_velocity,
+    charge,
+    mass,
+    inverse_metric,
+    dt_inverse_metric,
+):
+    dt_self_force_per_mass = np.einsum("ij,j", dt_inverse_metric, d_psi)
+    dt_self_force_per_mass += np.einsum("ij,j", inverse_metric, dt_d_psi)
+
+    dt_self_force_per_mass += np.einsum(
+        "i,j,j", dt_four_velocity, four_velocity, d_psi
+    )
+    dt_self_force_per_mass += np.einsum(
+        "i,j,j", four_velocity, dt_four_velocity, d_psi
+    )
+    dt_self_force_per_mass += np.einsum(
+        "i,j,j", four_velocity, four_velocity, dt_d_psi
+    )
+    return charge / mass * dt_self_force_per_mass
+

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/SelfForce.py
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/SelfForce.py
@@ -5,13 +5,7 @@ import numpy as np
 
 
 def self_force_acceleration(
-    dt_psi_monopole,
-    psi_dipole,
-    vel,
-    charge,
-    mass,
-    inverse_metric,
-    dilation,
+    dt_psi_monopole, psi_dipole, vel, charge, mass, inverse_metric, dilation
 ):
     # Prepend extra value so dimensions work out for einsum.
     # The 0th component does not affect the final result
@@ -21,3 +15,12 @@ def self_force_acceleration(
     self_force_acc -= np.einsum("i,j,j", four_vel, inverse_metric[0], d_psi)
     self_force_acc *= charge / mass / dilation**2
     return self_force_acc[1:]
+
+
+def self_force_per_mass(d_psi, four_velocity, charge, mass, inverse_metric):
+    self_force_per_mass = np.einsum("ij,j", inverse_metric, d_psi)
+    self_force_per_mass += np.einsum(
+        "i,j,j", four_velocity, four_velocity, d_psi
+    )
+    return charge / mass * self_force_per_mass
+

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/Test_SelfForce.cpp
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/Test_SelfForce.cpp
@@ -43,6 +43,17 @@ void test_dt_self_force_per_mass() {
       "SelfForce", "dt_self_force_per_mass", {{{-2.0, 2.0}}}, 1);
 }
 
+void test_dt2_self_force_per_mass() {
+  pypp::check_with_random_values<1>(
+      static_cast<tnsr::A<double, 3> (*)(
+          const tnsr::a<double, 3>&, const tnsr::a<double, 3>&,
+          const tnsr::a<double, 3>&, const tnsr::A<double, 3>&,
+          const tnsr::A<double, 3>&, const tnsr::A<double, 3>&, const double,
+          const double, const tnsr::AA<double, 3>&, const tnsr::AA<double, 3>&,
+          const tnsr::AA<double, 3>&)>(dt2_self_force_per_mass<3>),
+      "SelfForce", "dt2_self_force_per_mass", {{{-2.0, 2.0}}}, 1);
+}
+
 SPECTRE_TEST_CASE("Unit.Evolution.Systems.CSW.Worldtube.SelfForce",
                   "[Unit][Evolution]") {
   pypp::SetupLocalPythonEnvironment local_python_env{
@@ -50,6 +61,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.CSW.Worldtube.SelfForce",
   test_self_force_acceleration();
   test_self_force_per_mass();
   test_dt_self_force_per_mass();
+  test_dt2_self_force_per_mass();
 }
 }  // namespace
 }  // namespace CurvedScalarWave::Worldtube

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/Test_SelfForce.cpp
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/Test_SelfForce.cpp
@@ -54,6 +54,16 @@ void test_dt2_self_force_per_mass() {
       "SelfForce", "dt2_self_force_per_mass", {{{-2.0, 2.0}}}, 1);
 }
 
+void test_Du_self_force_per_mass() {
+  pypp::check_with_random_values<1>(
+      static_cast<tnsr::A<double, 3> (*)(
+          const tnsr::A<double, 3>&, const tnsr::A<double, 3>&,
+          const tnsr::A<double, 3>&, const tnsr::Abb<double, 3>&)>(
+          Du_self_force_per_mass<3>),
+      "SelfForce", "Du_self_force_per_mass", {{{-2.0, 2.0}}}, 1);
+}
+
+
 SPECTRE_TEST_CASE("Unit.Evolution.Systems.CSW.Worldtube.SelfForce",
                   "[Unit][Evolution]") {
   pypp::SetupLocalPythonEnvironment local_python_env{
@@ -62,6 +72,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.CSW.Worldtube.SelfForce",
   test_self_force_per_mass();
   test_dt_self_force_per_mass();
   test_dt2_self_force_per_mass();
+  test_Du_self_force_per_mass();
 }
 }  // namespace
 }  // namespace CurvedScalarWave::Worldtube

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/Test_SelfForce.cpp
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/Test_SelfForce.cpp
@@ -33,6 +33,15 @@ void test_self_force_per_mass() {
       "SelfForce", "self_force_per_mass", {{{-2.0, 2.0}}}, 1);
 }
 
+void test_dt_self_force_per_mass() {
+  pypp::check_with_random_values<1>(
+      static_cast<tnsr::A<double, 3> (*)(
+          const tnsr::a<double, 3>&, const tnsr::a<double, 3>&,
+          const tnsr::A<double, 3>&, const tnsr::A<double, 3>&, const double,
+          const double, const tnsr::AA<double, 3>&,
+          const tnsr::AA<double, 3>&)>(dt_self_force_per_mass<3>),
+      "SelfForce", "dt_self_force_per_mass", {{{-2.0, 2.0}}}, 1);
+}
 
 SPECTRE_TEST_CASE("Unit.Evolution.Systems.CSW.Worldtube.SelfForce",
                   "[Unit][Evolution]") {
@@ -40,6 +49,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.CSW.Worldtube.SelfForce",
       "Evolution/Systems/CurvedScalarWave/Worldtube"};
   test_self_force_acceleration();
   test_self_force_per_mass();
+  test_dt_self_force_per_mass();
 }
 }  // namespace
 }  // namespace CurvedScalarWave::Worldtube

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/Test_SelfForce.cpp
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/Test_SelfForce.cpp
@@ -63,6 +63,15 @@ void test_Du_self_force_per_mass() {
       "SelfForce", "Du_self_force_per_mass", {{{-2.0, 2.0}}}, 1);
 }
 
+void test_dt_Du_self_force_per_mass() {
+  pypp::check_with_random_values<1>(
+      static_cast<tnsr::A<double, 3> (*)(
+          const tnsr::A<double, 3>&, const tnsr::A<double, 3>&,
+          const tnsr::A<double, 3>&, const tnsr::A<double, 3>&,
+          const tnsr::A<double, 3>&, const tnsr::Abb<double, 3>&,
+          const tnsr::Abb<double, 3>&)>(dt_Du_self_force_per_mass<3>),
+      "SelfForce", "dt_Du_self_force_per_mass", {{{-2.0, 2.0}}}, 1);
+}
 
 SPECTRE_TEST_CASE("Unit.Evolution.Systems.CSW.Worldtube.SelfForce",
                   "[Unit][Evolution]") {
@@ -73,6 +82,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.CSW.Worldtube.SelfForce",
   test_dt_self_force_per_mass();
   test_dt2_self_force_per_mass();
   test_Du_self_force_per_mass();
+  test_dt_Du_self_force_per_mass();
 }
 }  // namespace
 }  // namespace CurvedScalarWave::Worldtube

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/Test_SelfForce.cpp
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/Test_SelfForce.cpp
@@ -16,8 +16,6 @@ namespace CurvedScalarWave::Worldtube {
 namespace {
 
 void test_self_force_acceleration() {
-  pypp::SetupLocalPythonEnvironment local_python_env{
-      "Evolution/Systems/CurvedScalarWave/Worldtube"};
   pypp::check_with_random_values<1>(
       static_cast<tnsr::I<double, 3> (*)(
           const Scalar<double>&, const tnsr::i<double, 3>&,
@@ -27,9 +25,21 @@ void test_self_force_acceleration() {
       "SelfForce", "self_force_acceleration", {{{-2.0, 2.0}}}, 1);
 }
 
+void test_self_force_per_mass() {
+  pypp::check_with_random_values<1>(
+      static_cast<tnsr::A<double, 3> (*)(
+          const tnsr::a<double, 3>&, const tnsr::A<double, 3>&, const double,
+          const double, const tnsr::AA<double, 3>&)>(self_force_per_mass<3>),
+      "SelfForce", "self_force_per_mass", {{{-2.0, 2.0}}}, 1);
+}
+
+
 SPECTRE_TEST_CASE("Unit.Evolution.Systems.CSW.Worldtube.SelfForce",
                   "[Unit][Evolution]") {
+  pypp::SetupLocalPythonEnvironment local_python_env{
+      "Evolution/Systems/CurvedScalarWave/Worldtube"};
   test_self_force_acceleration();
+  test_self_force_per_mass();
 }
 }  // namespace
 }  // namespace CurvedScalarWave::Worldtube


### PR DESCRIPTION
These quantities are mostly longer derivatives computed analytically by applying the chain rule several times. They are needed for the computing the acceleration terms of the puncture  field.
