### PR TITLE
Allow Strahlkorper construction from different frame

### DIFF
--- a/src/NumericalAlgorithms/SphericalHarmonics/Strahlkorper.cpp
+++ b/src/NumericalAlgorithms/SphericalHarmonics/Strahlkorper.cpp
@@ -66,44 +66,6 @@ Strahlkorper<Frame>::Strahlkorper(const size_t l_max, const size_t m_max,
 }
 
 template <typename Frame>
-Strahlkorper<Frame>::Strahlkorper(const size_t l_max, const size_t m_max,
-                                  const Strahlkorper& another_strahlkorper)
-    : l_max_(l_max),
-      m_max_(m_max),
-      ylm_(l_max, m_max),
-      center_(another_strahlkorper.center_),
-      strahlkorper_coefs_(another_strahlkorper.ylm_.prolong_or_restrict(
-          another_strahlkorper.strahlkorper_coefs_, ylm_)) {}
-
-template <typename Frame>
-Strahlkorper<Frame>::Strahlkorper(DataVector coefs,
-                                  const Strahlkorper& another_strahlkorper)
-    : l_max_(another_strahlkorper.l_max_),
-      m_max_(another_strahlkorper.m_max_),
-      ylm_(another_strahlkorper.ylm_),
-      center_(another_strahlkorper.center_),
-      strahlkorper_coefs_(std::move(coefs)) {
-  ASSERT(
-      strahlkorper_coefs_.size() == another_strahlkorper.ylm_.spectral_size(),
-      "Bad size " << strahlkorper_coefs_.size() << ", expected "
-                  << another_strahlkorper.ylm_.spectral_size());
-}
-
-template <typename Frame>
-Strahlkorper<Frame>::Strahlkorper(DataVector coefs,
-                                  Strahlkorper&& another_strahlkorper)
-    : l_max_(another_strahlkorper.l_max_),
-      m_max_(another_strahlkorper.m_max_),
-      ylm_(std::move(another_strahlkorper.ylm_)),
-      // clang-tidy: do not std::move trivially constructable types
-      center_(std::move(another_strahlkorper.center_)),  // NOLINT
-      strahlkorper_coefs_(std::move(coefs)) {
-  ASSERT(strahlkorper_coefs_.size() == ylm_.spectral_size(),
-         "Bad size " << strahlkorper_coefs_.size() << ", expected "
-                     << ylm_.spectral_size());
-}
-
-template <typename Frame>
 void Strahlkorper<Frame>::pup(PUP::er& p) {
   p | l_max_;
   p | m_max_;

--- a/tests/Unit/NumericalAlgorithms/SphericalHarmonics/Test_Strahlkorper.cpp
+++ b/tests/Unit/NumericalAlgorithms/SphericalHarmonics/Test_Strahlkorper.cpp
@@ -196,6 +196,32 @@ void test_construct_from_options() {
         Strahlkorper<Frame::Inertial>(6, 6, 4.5, {{1., 2., 3.}}));
 }
 
+void test_strahlkorper_from_other_strahlkorper() {
+  const Strahlkorper<Frame::Inertial> inertial_strahlkorper{
+      4_st, 1.2, std::array{1.0, 2.0, 3.0}};
+  Strahlkorper<Frame::Grid> grid_strahlkorper{inertial_strahlkorper};
+
+  const auto check_equal = [](const auto& s1, const auto& s2) {
+    CHECK(s1.coefficients() == s2.coefficients());
+    CHECK(s1.l_max() == s2.l_max());
+    CHECK(s1.m_max() == s2.m_max());
+    CHECK(s1.expansion_center() == s2.expansion_center());
+  };
+
+  check_equal(inertial_strahlkorper, grid_strahlkorper);
+
+  grid_strahlkorper = Strahlkorper<Frame::Grid>{
+      inertial_strahlkorper.coefficients(), inertial_strahlkorper};
+
+  check_equal(inertial_strahlkorper, grid_strahlkorper);
+
+  grid_strahlkorper =
+      Strahlkorper<Frame::Grid>{8_st, 8_st, inertial_strahlkorper};
+
+  check_equal(Strahlkorper<Frame::Grid>(8_st, 1.2, std::array{1.0, 2.0, 3.0}),
+              grid_strahlkorper);
+}
+
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.ApparentHorizonFinder.Strahlkorper",
@@ -225,11 +251,10 @@ SPECTRE_TEST_CASE("Unit.ApparentHorizonFinder.Strahlkorper",
         return Strahlkorper<Frame::Inertial>(std::move(sk));
       });
   test_construct_from_options();
-}
-
-SPECTRE_TEST_CASE("Unit.ApparentHorizonFinder.Strahlkorper.Serialization",
-                  "[ApparentHorizonFinder][Unit]") {
-  Strahlkorper<Frame::Inertial> s(4, 4, 2.0, {{1.0, 2.0, 3.0}});
-  test_serialization(s);
+  test_strahlkorper_from_other_strahlkorper();
+  {
+    Strahlkorper<Frame::Inertial> s(4, 4, 2.0, {{1.0, 2.0, 3.0}});
+    test_serialization(s);
+  }
 }
 }  // namespace ylm

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Surfaces/Test_GrSurfaces.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Surfaces/Test_GrSurfaces.cpp
@@ -1152,24 +1152,25 @@ SPECTRE_TEST_CASE("Unit.GrSurfaces.RadialDistance",
   // Check cases where one has more resolution than the other
   gr::surfaces::radial_distance(
       make_not_null(&radial_dist), strahlkorper_a,
-      ylm::Strahlkorper(strahlkorper_b.l_max() - 1, strahlkorper_b.m_max() - 1,
-                        strahlkorper_b));
+      ylm::Strahlkorper<Frame::Inertial>(strahlkorper_b.l_max() - 1,
+                                         strahlkorper_b.m_max() - 1,
+                                         strahlkorper_b));
   CHECK_ITERABLE_APPROX(radial_dist, expected_radial_dist_a_minus_b);
-  gr::surfaces::radial_distance(
-      make_not_null(&radial_dist),
-      ylm::Strahlkorper(strahlkorper_b.l_max() - 1, strahlkorper_b.m_max() - 1,
-                        strahlkorper_b),
-      strahlkorper_a);
+  gr::surfaces::radial_distance(make_not_null(&radial_dist),
+                                ylm::Strahlkorper<Frame::Inertial>(
+                                    strahlkorper_b.l_max() - 1,
+                                    strahlkorper_b.m_max() - 1, strahlkorper_b),
+                                strahlkorper_a);
   CHECK_ITERABLE_APPROX(radial_dist, expected_radial_dist_b_minus_a);
   gr::surfaces::radial_distance(
       make_not_null(&radial_dist), strahlkorper_a,
-      ylm::Strahlkorper(strahlkorper_b.l_max(), strahlkorper_b.m_max() - 1,
-                        strahlkorper_b));
+      ylm::Strahlkorper<Frame::Inertial>(
+          strahlkorper_b.l_max(), strahlkorper_b.m_max() - 1, strahlkorper_b));
   CHECK_ITERABLE_APPROX(radial_dist, expected_radial_dist_a_minus_b);
   gr::surfaces::radial_distance(
       make_not_null(&radial_dist),
-      ylm::Strahlkorper(strahlkorper_b.l_max(), strahlkorper_b.m_max() - 1,
-                        strahlkorper_b),
+      ylm::Strahlkorper<Frame::Inertial>(
+          strahlkorper_b.l_max(), strahlkorper_b.m_max() - 1, strahlkorper_b),
       strahlkorper_a);
   CHECK_ITERABLE_APPROX(radial_dist, expected_radial_dist_b_minus_a);
 


### PR DESCRIPTION
This is helpful for both runtime choosing of frames and for transition to ringdown

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
