### PR TITLE
Fix workflow to deploy containers on release

### DIFF
--- a/.github/workflows/DemoContainer.yaml
+++ b/.github/workflows/DemoContainer.yaml
@@ -7,17 +7,22 @@ on:
   workflow_dispatch:
     inputs:
       image_name:
-        description: >
-          Image name to push to DockerHub
-        required: true
+        description: Image name to push to DockerHub
         default: 'sxscollaboration/spectre'
       build_arm:
         type: boolean
-        description: >
-          Build ARM container in addition to x86_64
+        description: Build ARM container in addition to x86_64
         default: true
 
   workflow_call:
+    inputs:
+      image_name:
+        description: Image name to push to DockerHub
+        default: 'sxscollaboration/spectre'
+      build_arm:
+        type: boolean
+        description: Build ARM container in addition to x86_64
+        default: true
     secrets:
       DOCKERHUB_USERNAME:
         required: true


### PR DESCRIPTION
## Proposed changes

Apparently the default from the `workflow_call` isn't used when `workflow_dispatch` is used. It needs to specify the inputs as well.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
