### PR TITLE
Add pretty-printer for Variables, VectorImpls, gsl::span, Tensor for GDB

### DIFF
--- a/docs/DevGuide/DebuggingTips.md
+++ b/docs/DevGuide/DebuggingTips.md
@@ -16,3 +16,6 @@ Learn how to use a debugger such as gdb.
   case you also try setting a breakpoint on the constructor of the exception
   type, `break std::out_of_range::out_of_range`)
 
+- SpECTRE has pretty printing facilities for various custom types. In order to
+  enable these you must add
+  `add-auto-load-safe-path /path/to/spectre/` to your `~/.gdbinit` file.

--- a/src/DataStructures/Tensor/Tensor.hpp
+++ b/src/DataStructures/Tensor/Tensor.hpp
@@ -455,10 +455,11 @@ class Tensor<X, Symm, IndexList<Indices...>> {
 
   static std::string component_suffix(
       const size_t storage_index,
-      const std::array<std::string, rank()>& axis_labels =
-          make_array<rank()>(std::string(""))) {
+      const std::array<std::string, rank()>& axis_labels) {
     return component_suffix(get_tensor_index(storage_index), axis_labels);
   }
+
+  static std::string component_suffix(size_t storage_index);
   /// @}
 
   /// Copy tensor data into an `std::vector<X>` along with the
@@ -487,6 +488,18 @@ class Tensor<X, Symm, IndexList<Indices...>> {
 // ================================================================
 // Template Definitions - Variadic templates must be in header
 // ================================================================
+
+template <typename X, typename Symm, template <typename...> class IndexList,
+          typename... Indices>
+// Implementation note: we explicitly prevent inlining and mark the function
+// as used so that GDB's pretty printing facilities have access to this
+// function.
+__attribute__((noinline)) __attribute__((used)) std::string
+Tensor<X, Symm, IndexList<Indices...>>::component_suffix(
+    const size_t storage_index) {
+  return component_suffix(get_tensor_index(storage_index),
+                          make_array<rank()>(std::string("")));
+}
 
 template <typename X, typename Symm, template <typename...> class IndexList,
           typename... Indices>

--- a/src/Informer/InfoAtCompile.cpp
+++ b/src/Informer/InfoAtCompile.cpp
@@ -32,3 +32,24 @@ std::string info_from_build() {
 #endif
   return os.str();
 }
+
+#ifndef __APPLE__
+/* Set up a pretty print script for GDB to print spectre types in GDB in a
+ * more readable manner.
+ *
+ *
+ * Note: The "MS" section flags are to remove duplicates.
+ */
+#define DEFINE_GDB_PY_SCRIPT(script_name) \
+  asm("\
+.pushsection \".debug_gdb_scripts\", \"MS\",@progbits,1\n\
+.byte 1 /* Python */\n\
+.asciz \"" script_name                    \
+      "\"\n\
+.popsection \n\
+");
+
+DEFINE_GDB_PY_SCRIPT("@CMAKE_SOURCE_DIR@/tools/SpectrePrettyPrinters.py")
+
+#undef DEFINE_GDB_PY_SCRIPT
+#endif // ndef __APPLE__

--- a/tools/Hooks/pre-commit.sh
+++ b/tools/Hooks/pre-commit.sh
@@ -85,7 +85,8 @@ if [ ${#python_files[@]} -ne 0 ]; then
         if [ $? -ne 0 ]; then
             found_error=1
             printf "Found unsorted Python imports.\n"
-            printf "Please run 'isort .' in the repository.\n"
+            printf "Please run '@Python_EXECUTABLE@ -m isort .' in the "
+            printf "repository.\n"
         fi
     else
         printf "Could not find 'isort' Python formatter. Install with:\n"

--- a/tools/SpectrePrettyPrinters.py
+++ b/tools/SpectrePrettyPrinters.py
@@ -1,0 +1,263 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import itertools
+import re
+import sys
+
+import gdb
+
+if sys.version_info[0] > 2:
+    Iterator = object
+    imap = map
+    izip = zip
+    long = int
+else:
+    ### Python 2 stuff
+    class Iterator:
+        """Compatibility mixin for iterators
+
+        Instead of writing next() methods for iterators, write
+        __next__() methods and use this mixin to make them work in
+        Python 2 as well as Python 3.
+
+        Idea stolen from the "six" documentation:
+        <http://pythonhosted.org/six/#six.Iterator>
+        """
+
+        def next(self):
+            return self.__next__()
+
+    from itertools import imap, izip
+
+
+class VectorImplPrinter:
+    """Print a VectorImpl, including DataVector, ComplexDataVector and their
+    modal counterparts
+    """
+
+    class _iterator(Iterator):
+        def __init__(self, start, num_entries):
+            self.item = start
+            self.finish = start + num_entries
+            self.count = 0
+
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            count = self.count
+            self.count = self.count + 1
+            if self.item == self.finish:
+                raise StopIteration
+            elt = self.item.dereference()
+            self.item = self.item + 1
+            return ("[%d]" % count, elt)
+
+    def __init__(self, val):
+        self.val = val
+
+    def children(self):
+        return self._iterator(self.val["v_"], self.val["size_"])
+
+    def to_string(self):
+        return (
+            str(self.val.type.tag)
+            + " owning: "
+            + str(self.val["owning_"])
+            + " size: "
+            + str(self.val["size_"])
+            + " values "
+        )
+
+    def display_hint(self):
+        return "array"
+
+
+class GslSpanPrinter:
+    "Print a gsl::span"
+
+    class _iterator(Iterator):
+        def __init__(self, start, num_entries):
+            self.item = start
+            self.finish = start + num_entries
+            self.count = 0
+
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            count = self.count
+            self.count = self.count + 1
+            if self.item == self.finish:
+                raise StopIteration
+            elt = self.item.dereference()
+            self.item = self.item + 1
+            return ("[%d]" % count, elt)
+
+    def __init__(self, val):
+        self.val = val
+
+    def children(self):
+        return self._iterator(
+            self.val["storage_"]["data_"], self.val["storage_"]["size_"]
+        )
+
+    def to_string(self):
+        return (
+            str(self.val.type.strip_typedefs().name).replace(", -1l", "")
+            + " size: "
+            + str(self.val["storage_"]["size_"])
+            + " values "
+        )
+
+    def display_hint(self):
+        return "array"
+
+
+class TensorPrinter:
+    "Print a Tensor"
+
+    class _iterator(Iterator):
+        def __init__(self, component_suffix_eval_string, start, num_entries):
+            self.component_suffix_eval_string = component_suffix_eval_string
+            self.item = start
+            self.finish = start + int(num_entries)
+            self.count = 0
+
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            count = self.count
+            self.count = self.count + 1
+            if self.item == self.finish:
+                raise StopIteration
+            elt = self.item.dereference()
+            self.item = self.item + 1
+            index = str(
+                gdb.parse_and_eval(
+                    self.component_suffix_eval_string + str(count) + ")"
+                )
+            )[2:-1]
+            return ("\n[%s]" % index, elt)
+
+    def children(self):
+        array_name = str(
+            self.val["data_"].type.strip_typedefs().fields()[0].name
+        )
+        return self._iterator(
+            str(self.val.type.strip_typedefs()) + "::component_suffix(",
+            self.val["data_"][array_name]
+            .cast(self.val["data_"][array_name].type.strip_typedefs())[0]
+            .address,
+            int(
+                self.val["data_"]
+                .type.strip_typedefs()
+                .fields()[0]
+                .type.strip_typedefs()
+                .range()[1]
+            )
+            + 1,
+        )
+
+    def __init__(self, val):
+        if val.type.code == gdb.TYPE_CODE_TYPEDEF:
+            self.typename = val.type.name
+        else:
+            self.typename = "Tensor"
+        self.val = val
+
+    def to_string(self):
+        return self.typename
+
+
+class VariablesPrinter:
+    "Print a Variables"
+
+    class _iterator(Iterator):
+        def __init__(self, head, empty):
+            self.head = head
+            self.count = 0
+            self.empty = empty
+
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            if self.empty or self.count == len(self.head.type.fields()):
+                raise StopIteration
+            count = self.count
+            self.count = self.count + 1
+
+            elet = self.head.cast(
+                self.head.type.fields()[count].type.strip_typedefs()
+            )["value_"]
+            return (
+                "[%s]"
+                % str(self.head.type.fields()[count].type.strip_typedefs().name)
+                .replace("tuples::tuples_detail::TaggedTupleLeaf<", "")
+                .replace(", false>", "")
+                .replace(", true>", ""),
+                elet.cast(elet.type.strip_typedefs()),
+            )
+
+    def children(self):
+        if self.is_empty:
+            return self._iterator("", True)
+        else:
+            return self._iterator(
+                self.val["reference_variable_data_"].cast(
+                    self.val["reference_variable_data_"].type.strip_typedefs()
+                ),
+                False,
+            )
+
+    def __init__(self, val):
+        self.typename = "Variables"
+        self.val = val
+        self.is_empty = False
+        try:
+            str(self.val["owning_"])
+        except:
+            self.is_empty = True
+
+    def to_string(self):
+        if self.is_empty:
+            return "Variables<list<>>"
+        else:
+            return (
+                "Variables: (owning:"
+                + str(self.val["owning_"])
+                + ",Tags:"
+                + str(self.val["number_of_variables"])
+                + ","
+                + str(self.val["number_of_independent_components"])
+                + "x"
+                + str(self.val["number_of_grid_points_"])
+                + ") "
+            )
+
+
+def spectre_build_pretty_printer():
+    pp = gdb.printing.RegexpCollectionPrettyPrinter("spectre")
+    pp.add_printer("DataVector", "^DataVector$", VectorImplPrinter)
+    pp.add_printer(
+        "ComplexDataVector", "^ComplexDataVector$", VectorImplPrinter
+    )
+    pp.add_printer("ModalVector", "^ModalVector$", VectorImplPrinter)
+    pp.add_printer(
+        "ComplexModalVector", "^ComplexModalVector$", VectorImplPrinter
+    )
+    pp.add_printer("gsl::span", "^gsl::span<.*-1.*>$", GslSpanPrinter)
+    pp.add_printer("Scalar", "^Scalar<.*>$", TensorPrinter)
+    pp.add_printer("tnsr", "^tnsr::.*>$", TensorPrinter)
+    pp.add_printer("Tensor", "^Tensor<.*>$", TensorPrinter)
+    pp.add_printer("Variables", "^Variables<.*>$", VariablesPrinter)
+    return pp
+
+
+if __name__ == "__main__":
+    gdb.printing.register_pretty_printer(
+        gdb.current_objfile(), spectre_build_pretty_printer()
+    )


### PR DESCRIPTION
## Proposed changes

Allows GDB to print some of our data structures in a format that's easier to read. For example, currently we print a `gsl::span` and `DataVector` as:

```
 $1 = {static extent = <optimized out>, storage_ = {<gsl::detail::extent_type<-1l>> = {size_ = 2},
 data_ = 0x7fffef622020}}
 $2 = {<VectorImpl<double, DataVector, 0ul>> = {<blaze::CustomVector<double, blaze::unaligned, blaze::unpadded, false, blaze::GroupTag<0ul>, DataVector>> = {<blaze::DenseVector<blaze::CustomVector<double, blaze::unaligned, blaze::unpadde\
 d, false, blaze::GroupTag<0ul>, DataVector>, false>> = {<blaze::Vector<blaze::CustomVector<double, blaze::unaligned, blaze::unpadded, false, blaze::GroupTag<0ul>, DataVector>, false>> = {
 static transposeFlag = false}, <No data fields>}, static simdEnabled = <optimized out>,
 static smpAssignable = <optimized out>, static SIMDSIZE = <optimized out>, size_ = 2,
 v_ = 0x7fffef622020}, <MarkAsVectorImpl> = {<No data fields>}, static transpose_flag = false,
 static static_size = <optimized out>, owned_data_ = std::unique_ptr<double []> = {get() = 0x7fffef622020},
     static_owned_data_ = {_M_elems = {<No data fields>}}, owning_ = true}, <No data fields>}
```

With the changes this becomes:

```
$1 = gsl::span<double> size: 2 values  = {10, 10}
$2 = DataVector owning: true size: 2 values  = {10, 10}
```

Variables are printed as:

```
 $1 = Variables: (true,2,11x2)  = {[hydro::Tags::RestMassDensity<DataVector>] = Tensor = {
 [] = DataVector owning: false size: 2 values  = {10, 10}},
 [gr::Tags::SpacetimeMetric<DataVector, 3ul, Frame::Inertial>] = Tensor = {
 [tt] = DataVector owning: false size: 2 values  = {10, 10},
 [xt] = DataVector owning: false size: 2 values  = {10, 10},
 [yt] = DataVector owning: false size: 2 values  = {10, 10},
 [zt] = DataVector owning: false size: 2 values  = {10, 10},
 [xx] = DataVector owning: false size: 2 values  = {10, 10},
 [yx] = DataVector owning: false size: 2 values  = {10, 10},
 [zx] = DataVector owning: false size: 2 values  = {10, 10},
 [yy] = DataVector owning: false size: 2 values  = {10, 10},
 [zy] = DataVector owning: false size: 2 values  = {10, 10},
 [zz] = DataVector owning: false size: 2 values  = {10, 10}}}
```

Note: You will need to add

```
add-auto-load-safe-path /path/to/spectre/
```

to your `~/.gdbinit` file. GDB will yell at you that you are trying to load an untrusted file otherwise.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
