### PR TITLE
Add IrrotationalBNS Pointwise Functions

### DIFF
--- a/src/PointwiseFunctions/Hydro/CMakeLists.txt
+++ b/src/PointwiseFunctions/Hydro/CMakeLists.txt
@@ -58,3 +58,5 @@ target_link_libraries(
   )
 
 add_subdirectory(EquationsOfState)
+
+add_subdirectory(InitialData)

--- a/src/PointwiseFunctions/Hydro/InitialData/CMakeLists.txt
+++ b/src/PointwiseFunctions/Hydro/InitialData/CMakeLists.txt
@@ -1,0 +1,15 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+spectre_target_sources(
+  ${LIBRARY}
+  PRIVATE
+  IrrotationalBns.cpp
+  )
+
+spectre_target_headers(
+  ${LIBRARY}
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  IrrotationalBns.hpp
+  )

--- a/src/PointwiseFunctions/Hydro/InitialData/IrrotationalBns.cpp
+++ b/src/PointwiseFunctions/Hydro/InitialData/IrrotationalBns.cpp
@@ -1,0 +1,222 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "PointwiseFunctions/Hydro/InitialData/IrrotationalBns.hpp"
+
+#include <cmath>
+#include <cstddef>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Expressions/TensorExpression.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/SetNumberOfGridPoints.hpp"
+
+namespace hydro::initial_data::irrotational_bns {
+template <typename DataType>
+void rotational_shift(
+    const gsl::not_null<tnsr::I<DataType, 3>*> result,
+    const tnsr::I<DataType, 3>& shift,
+    const tnsr::I<DataType, 3>& spatial_rotational_killing_vector) {
+  ::tenex::evaluate<ti::I>(
+      result, shift(ti::I) + spatial_rotational_killing_vector(ti::I));
+}
+
+template <typename DataType>
+tnsr::I<DataType, 3> rotational_shift(
+    const tnsr::I<DataType, 3>& shift,
+    const tnsr::I<DataType, 3>& spatial_rotational_killing_vector) {
+  tnsr::I<DataType, 3> buffer{};
+  rotational_shift(make_not_null(&buffer), shift,
+                   spatial_rotational_killing_vector);
+  return buffer;
+}
+
+template <typename DataType>
+void rotational_shift_stress(const gsl::not_null<tnsr::II<DataType, 3>*> result,
+                             const tnsr::I<DataType, 3>& rotational_shift,
+                             const Scalar<DataType>& lapse) {
+  ::tenex::evaluate<ti::I, ti::J>(
+      result,
+      rotational_shift(ti::I) * rotational_shift(ti::J) / square(lapse()));
+}
+
+template <typename DataType>
+tnsr::II<DataType, 3> rotational_shift_stress(
+    const tnsr::I<DataType, 3>& rotational_shift,
+    const Scalar<DataType>& lapse) {
+  tnsr::II<DataType, 3> buffer{};
+  rotational_shift_stress(make_not_null(&buffer), rotational_shift, lapse);
+  return buffer;
+}
+
+template <typename DataType>
+void derivative_rotational_shift_over_lapse_squared(
+    const gsl::not_null<tnsr::iJ<DataType, 3>*> result,
+    const tnsr::I<DataType, 3>& rotational_shift,
+    const tnsr::iJ<DataType, 3>& deriv_of_shift, const Scalar<DataType>& lapse,
+    const tnsr::i<DataType, 3>& deriv_of_lapse,
+    const tnsr::iJ<DataType, 3>& deriv_of_spatial_rotational_killing_vector) {
+  ::tenex::evaluate<ti::i, ti::J>(
+      result, (deriv_of_shift(ti::i, ti::J) +
+               deriv_of_spatial_rotational_killing_vector(ti::i, ti::J)) /
+                      square(lapse()) -
+                  2.0 * rotational_shift(ti::J) * deriv_of_lapse(ti::i) /
+                      cube(lapse()));
+}
+
+template <typename DataType>
+tnsr::iJ<DataType, 3> derivative_rotational_shift_over_lapse_squared(
+    const tnsr::I<DataType, 3>& rotational_shift,
+    const tnsr::iJ<DataType, 3>& deriv_of_shift, const Scalar<DataType>& lapse,
+    const tnsr::i<DataType, 3>& deriv_of_lapse,
+    const tnsr::iJ<DataType, 3>& deriv_of_spatial_rotational_killing_vector) {
+  tnsr::iJ<DataType, 3> buffer{};
+  derivative_rotational_shift_over_lapse_squared(
+      make_not_null(&buffer), rotational_shift, deriv_of_shift, lapse,
+      deriv_of_lapse, deriv_of_spatial_rotational_killing_vector);
+  return buffer;
+}
+
+template <typename DataType>
+void specific_enthalpy_squared(
+    const gsl::not_null<Scalar<DataType>*> result,
+    const tnsr::I<DataType, 3>& rotational_shift, const Scalar<DataType>& lapse,
+    const tnsr::i<DataType, 3>& velocity_potential_gradient,
+    const tnsr::II<DataType, 3>& inverse_spatial_metric,
+    const double euler_enthalpy_constant) {
+  return tenex::evaluate<>(
+      result,
+      square((euler_enthalpy_constant +
+              rotational_shift(ti::I) * velocity_potential_gradient(ti::i)) /
+             lapse()) -
+          velocity_potential_gradient(ti::i) *
+              velocity_potential_gradient(ti::j) *
+              inverse_spatial_metric(ti::I, ti::J));
+}
+
+template <typename DataType>
+Scalar<DataType> specific_enthalpy_squared(
+    const tnsr::I<DataType, 3>& rotational_shift, const Scalar<DataType>& lapse,
+    const tnsr::i<DataType, 3>& velocity_potential_gradient,
+    const tnsr::II<DataType, 3>& inverse_spatial_metric,
+    const double euler_enthalpy_constant) {
+  Scalar<DataType> buffer{};
+  specific_enthalpy_squared(make_not_null(&buffer), rotational_shift, lapse,
+                            velocity_potential_gradient, inverse_spatial_metric,
+                            euler_enthalpy_constant);
+  return buffer;
+}
+
+template <typename DataType>
+void spatial_rotational_killing_vector(
+    const gsl::not_null<tnsr::I<DataType, 3>*> result,
+    const tnsr::I<DataType, 3>& x, const double orbital_angular_velocity,
+    const Scalar<DataType>& sqrt_det_spatial_metric) {
+  // Cross product involves volume element in arbitrary coordinates
+  set_number_of_grid_points(result, sqrt_det_spatial_metric);
+  get<0>(*result) =
+      -get(sqrt_det_spatial_metric) * get<1>(x) * orbital_angular_velocity;
+  get<1>(*result) =
+      get(sqrt_det_spatial_metric) * get<0>(x) * orbital_angular_velocity;
+  get<2>(*result) = 0.0;
+}
+
+template <typename DataType>
+tnsr::I<DataType, 3> spatial_rotational_killing_vector(
+    const tnsr::I<DataType, 3>& x, const double orbital_angular_velocity,
+    const Scalar<DataType>& sqrt_det_spatial_metric) {
+  tnsr::I<DataType, 3> buffer{};
+  spatial_rotational_killing_vector(make_not_null(&buffer), x,
+                                    orbital_angular_velocity,
+                                    sqrt_det_spatial_metric);
+  return buffer;
+}
+
+template <typename DataType>
+void divergence_spatial_rotational_killing_vector(
+    const gsl::not_null<Scalar<DataType>*> result,
+    const tnsr::I<DataType, 3>& x, const double /*orbital_angular_velocity*/,
+    const Scalar<DataType>& /*sqrt_det_spatial_metric*/) {
+  set_number_of_grid_points(result, x);
+  std::fill(result->begin(), result->end(), 0.0);
+}
+
+template <typename DataType>
+Scalar<DataType> divergence_spatial_rotational_killing_vector(
+    const tnsr::I<DataType, 3>& x, const double orbital_angular_velocity,
+    const Scalar<DataType>& sqrt_det_spatial_metric) {
+  Scalar<DataType> buffer{};
+  divergence_spatial_rotational_killing_vector(make_not_null(&buffer), x,
+                                               orbital_angular_velocity,
+                                               sqrt_det_spatial_metric);
+  return buffer;
+}
+
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define INSTANTIATION(r, data)                                               \
+  template void rotational_shift(                                            \
+      gsl::not_null<tnsr::I<DTYPE(data), 3>*> result,                        \
+      const tnsr::I<DTYPE(data), 3>& shift,                                  \
+      const tnsr::I<DTYPE(data), 3>& spatial_rotational_killing_vector);     \
+  template tnsr::I<DTYPE(data), 3> rotational_shift(                         \
+      const tnsr::I<DTYPE(data), 3>& shift,                                  \
+      const tnsr::I<DTYPE(data), 3>& spatial_rotational_killing_vector);     \
+  template void rotational_shift_stress(                                     \
+      gsl::not_null<tnsr::II<DTYPE(data), 3>*> result,                       \
+      const tnsr::I<DTYPE(data), 3>& rotational_shift,                       \
+      const Scalar<DTYPE(data)>& lapse);                                     \
+  template tnsr::II<DTYPE(data), 3> rotational_shift_stress(                 \
+      const tnsr::I<DTYPE(data), 3>& rotational_shift,                       \
+      const Scalar<DTYPE(data)>& lapse);                                     \
+  template void derivative_rotational_shift_over_lapse_squared(              \
+      gsl::not_null<tnsr::iJ<DTYPE(data), 3>*> result,                       \
+      const tnsr::I<DTYPE(data), 3>& rotational_shift,                       \
+      const tnsr::iJ<DTYPE(data), 3>& deriv_of_shift,                        \
+      const Scalar<DTYPE(data)>& lapse,                                      \
+      const tnsr::i<DTYPE(data), 3>& deriv_of_lapse,                         \
+      const tnsr::iJ<DTYPE(data), 3>&                                        \
+          deriv_of_spatial_rotational_killing_vector);                       \
+  template tnsr::iJ<DTYPE(data), 3>                                          \
+  derivative_rotational_shift_over_lapse_squared(                            \
+      const tnsr::I<DTYPE(data), 3>& rotational_shift,                       \
+      const tnsr::iJ<DTYPE(data), 3>& deriv_of_shift,                        \
+      const Scalar<DTYPE(data)>& lapse,                                      \
+      const tnsr::i<DTYPE(data), 3>& deriv_of_lapse,                         \
+      const tnsr::iJ<DTYPE(data), 3>&                                        \
+          deriv_of_spatial_rotational_killing_vector);                       \
+  template void specific_enthalpy_squared(                                   \
+      gsl::not_null<Scalar<DTYPE(data)>*> result,                            \
+      const tnsr::I<DTYPE(data), 3>& rotational_shift,                       \
+      const Scalar<DTYPE(data)>& lapse,                                      \
+      const tnsr::i<DTYPE(data), 3>& velocity_potential_gradient,            \
+      const tnsr::II<DTYPE(data), 3>& inverse_spatial_metric,                \
+      double euler_enthalpy_constant);                                       \
+  template Scalar<DTYPE(data)> specific_enthalpy_squared(                    \
+      const tnsr::I<DTYPE(data), 3>& rotational_shift,                       \
+      const Scalar<DTYPE(data)>& lapse,                                      \
+      const tnsr::i<DTYPE(data), 3>& velocity_potential_gradient,            \
+      const tnsr::II<DTYPE(data), 3>& inverse_spatial_metric,                \
+      double euler_enthalpy_constant);                                       \
+  template void spatial_rotational_killing_vector(                           \
+      gsl::not_null<tnsr::I<DTYPE(data), 3>*> result,                        \
+      const tnsr::I<DTYPE(data), 3>& x, double orbital_angular_velocity,     \
+      const Scalar<DTYPE(data)>& determinant_spatial_metric);                \
+  template tnsr::I<DTYPE(data), 3> spatial_rotational_killing_vector(        \
+      const tnsr::I<DTYPE(data), 3>& x, double orbital_angular_velocity,     \
+      const Scalar<DTYPE(data)>& sqrt_det_spatial_metric);                   \
+  template void divergence_spatial_rotational_killing_vector(                \
+      gsl::not_null<Scalar<DTYPE(data)>*> result,                            \
+      const tnsr::I<DTYPE(data), 3>& x, double orbital_angular_velocity,     \
+      const Scalar<DTYPE(data)>& determinant_spatial_metric);                \
+  template Scalar<DTYPE(data)> divergence_spatial_rotational_killing_vector( \
+      const tnsr::I<DTYPE(data), 3>& x, double orbital_angular_velocity,     \
+      const Scalar<DTYPE(data)>& sqrt_det_spatial_metric);
+
+GENERATE_INSTANTIATIONS(INSTANTIATION, (double, DataVector))
+
+#undef DTYPE
+#undef INSTANTIATION
+
+}  // namespace hydro::initial_data::irrotational_bns

--- a/src/PointwiseFunctions/Hydro/InitialData/IrrotationalBns.hpp
+++ b/src/PointwiseFunctions/Hydro/InitialData/IrrotationalBns.hpp
@@ -1,0 +1,138 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Utilities/Gsl.hpp"
+
+/*!
+ * \ingroup HydroInitialDataGroup
+ * \brief Items related to solving for irrotational bns initial data
+ * See e.g. \cite BaumgarteShapiro Ch. 15 (P. 523)
+ */
+namespace hydro::initial_data::irrotational_bns {
+/// @{
+/// \brief Compute the  shift plus a spatial vector \f$ k^i\f$ representing
+/// the local binary rotation \f$B^i = \beta^i + k^i\f$
+///
+template <typename DataType>
+void rotational_shift(
+    gsl::not_null<tnsr::I<DataType, 3>*> result,
+    const tnsr::I<DataType, 3>& shift,
+    const tnsr::I<DataType, 3>& spatial_rotational_killing_vector);
+
+template <typename DataType>
+tnsr::I<DataType, 3> rotational_shift(
+    const tnsr::I<DataType, 3>& shift,
+    const tnsr::I<DataType, 3>& spatial_rotational_killing_vector);
+/// @}
+
+/// @{
+/// \brief Compute the  stress-energy corresponding to the rotation shift.
+/// (this has no corresponding equation number in \cite BaumgarteShapiro, it
+/// is defined for convenience in evaluating fluxes and sources for the DG
+/// scheme.)
+///
+///
+/// \f[\Sigma^i_j = \frac{1}{2}\frac{B^iB_j}{\alpha^2}\f]
+///
+template <typename DataType>
+void rotational_shift_stress(gsl::not_null<tnsr::II<DataType, 3>*> result,
+                             const tnsr::I<DataType, 3>& rotational_shift,
+                             const Scalar<DataType>& lapse);
+template <typename DataType>
+tnsr::II<DataType, 3> rotational_shift_stress(
+    const tnsr::I<DataType, 3>& rotational_shift,
+    const Scalar<DataType>& lapse);
+/// @}
+
+/// @{
+/// \brief  Compute derivative  \f$ \partial_i (B^j / \alpha^2) \f$
+///
+/// Here \f$ \partial_i \f$ is the spatial partial derivative, \f$ \alpha\f$ is
+/// the lapse and \f$B^i\f$ the rotational shift).  The derivatives passed as
+/// arguments should be spatial partial derivatives.
+template <typename DataType>
+void derivative_rotational_shift_over_lapse_squared(
+    gsl::not_null<tnsr::iJ<DataType, 3>*> result,
+    const tnsr::I<DataType, 3>& rotational_shift,
+    const tnsr::iJ<DataType, 3>& deriv_of_shift, const Scalar<DataType>& lapse,
+    const tnsr::i<DataType, 3>& deriv_of_lapse,
+    const tnsr::iJ<DataType, 3>& deriv_of_spatial_rotational_killing_vector);
+template <typename DataType>
+tnsr::iJ<DataType, 3> derivative_rotational_shift_over_lapse_squared(
+    const tnsr::I<DataType, 3>& rotational_shift,
+    const tnsr::iJ<DataType, 3>& deriv_of_shift, const Scalar<DataType>& lapse,
+    const tnsr::i<DataType, 3>& deriv_of_lapse,
+    const tnsr::iJ<DataType, 3>& deriv_of_spatial_rotational_killing_vector);
+/// @}
+
+/// @{
+/// \brief Compute the specific enthalpy squared from other hydro variables and
+/// the spacetime
+///
+/// The eqn. is identical in content to \cite BaumgarteShapiro 15.76, it
+/// computes the specific enthalpy \f$ h \f$
+/*!
+   \f[
+   h^2 = \frac{1}{\alpha^2} \left(C + B^i D_i \Phi\right)^2 - D_i
+   \Phi D^i \Phi
+   \f]
+*/
+/// Where \f$\Phi \f$ is the velocity potential, and \f$C\f$ is the
+/// Euler-constant, which in a slowly rotating, slowly orbiting configuration
+/// becomes the central specific enthalpy times the central lapse
+template <typename DataType>
+void specific_enthalpy_squared(
+    gsl::not_null<Scalar<DataType>*> result,
+    const tnsr::I<DataType, 3>& rotational_shift, const Scalar<DataType>& lapse,
+    const tnsr::i<DataType, 3>& velocity_potential_gradient,
+    const tnsr::II<DataType, 3>& inverse_spatial_metric,
+    double euler_enthalpy_constant);
+template <typename DataType>
+Scalar<DataType> specific_enthalpy_squared(
+    const tnsr::I<DataType, 3>& rotational_shift, const Scalar<DataType>& lapse,
+    const tnsr::i<DataType, 3>& velocity_potential_gradient,
+    const tnsr::II<DataType, 3>& inverse_spatial_metric,
+    double euler_enthalpy_constant);
+/// @}
+
+/// @{
+/// \brief Compute the spatial rotational killing vector associated with uniform
+/// rotation around the z-axis.
+///
+/// Taking \f$\Omega_j\f$ to be the uniform rotation axis (assumed in the
+/// z-direction) and \f$ \epsilon^{ijk}\f$ to be the Levi-Civita tensor
+/// (\f$\epsilon_{ijk} = \sqrt{\gamma} e_{ijk}\f$, with \f$e_{ijk}\f$ totally
+/// antisymmetric with \f$ e_{123} = 1\f$) , then
+/// the killing vector is given by  (\cite BaumgarteShapiro 15.13) :
+/*!
+  \f[ k^i = \epsilon^{ijk}\Omega_j x_k \f]
+ */
+template <typename DataType>
+void spatial_rotational_killing_vector(
+    gsl::not_null<tnsr::I<DataType, 3>*> result, const tnsr::I<DataType, 3>& x,
+    double orbital_angular_velocity,
+    const Scalar<DataType>& sqrt_det_spatial_metric);
+template <typename DataType>
+tnsr::I<DataType, 3> spatial_rotational_killing_vector(
+    const tnsr::I<DataType, 3>& x, double orbital_angular_velocity,
+    const Scalar<DataType>& sqrt_det_spatial_metric);
+/// @}
+
+/// @{
+/// \brief The spatial derivative of the spatial rotational killing vector
+///
+/// As for `spatial_rotational_killing_vector`, assumes uniform rotation around
+/// the z-axis
+template <typename DataType>
+void divergence_spatial_rotational_killing_vector(
+    gsl::not_null<Scalar<DataType>*> result, const tnsr::I<DataType, 3>& x,
+    double orbital_angular_velocity,
+    const Scalar<DataType>& sqrt_det_spatial_metric);
+template <typename DataType>
+Scalar<DataType> divergence_spatial_rotational_killing_vector(
+    const tnsr::I<DataType, 3>& x, double orbital_angular_velocity,
+    const Scalar<DataType>& sqrt_det_spatial_metric);
+}  // namespace hydro::initial_data::irrotational_bns

--- a/tests/Unit/PointwiseFunctions/Hydro/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/Hydro/CMakeLists.txt
@@ -2,6 +2,7 @@
 # See LICENSE.txt for details.
 
 add_subdirectory(EquationsOfState)
+add_subdirectory(InitialData)
 
 set(LIBRARY "Test_Hydro")
 

--- a/tests/Unit/PointwiseFunctions/Hydro/InitialData/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/Hydro/InitialData/CMakeLists.txt
@@ -1,0 +1,17 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBRARY "Test_HydroInitialData")
+
+set(LIBRARY_SOURCES
+  Test_IrrotationalBns.cpp
+  )
+
+add_test_library(${LIBRARY} "${LIBRARY_SOURCES}")
+
+target_link_libraries(
+  ${LIBRARY}
+  PRIVATE
+  DataStructures
+  Hydro
+  )

--- a/tests/Unit/PointwiseFunctions/Hydro/InitialData/IrrotationalBns.py
+++ b/tests/Unit/PointwiseFunctions/Hydro/InitialData/IrrotationalBns.py
@@ -1,0 +1,58 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+import numpy as np
+
+
+def rotational_shift(shift, spatial_rotational_killing_vector):
+    return shift + spatial_rotational_killing_vector
+
+
+def rotational_shift_stress(rotational_shift, lapse):
+    return np.outer(rotational_shift, rotational_shift) / lapse**2
+
+
+def derivative_rotational_shift_over_lapse_squared(
+    rotational_shift,
+    deriv_of_shift,
+    lapse,
+    deriv_of_lapse,
+    deriv_of_spatial_rotational_killing_vector,
+):
+    return (
+        deriv_of_shift + deriv_of_spatial_rotational_killing_vector
+    ) / lapse**2 - 2 * np.outer(deriv_of_lapse / lapse**3, rotational_shift)
+
+
+def specific_enthalpy_squared(
+    rotational_shift,
+    lapse,
+    velocity_potential_gradient,
+    inverse_spatial_metric,
+    euler_enthalpy_constant,
+):
+    return 1 / lapse**2 * (
+        euler_enthalpy_constant
+        + np.einsum("i, i", rotational_shift, velocity_potential_gradient)
+    ) ** 2 - np.einsum(
+        "i, i",
+        velocity_potential_gradient,
+        np.einsum("ij, j", inverse_spatial_metric, velocity_potential_gradient),
+    )
+
+
+def spatial_rotational_killing_vector(
+    x, local_angular_velocity_around_z, sqrt_det_spatial_metric
+):
+    return sqrt_det_spatial_metric * np.cross(
+        local_angular_velocity_around_z
+        * np.array(
+            [np.zeros_like(x[0]), np.zeros_like(x[0]), np.ones_like(x[0])]
+        ),
+        x,
+    )
+
+
+def divergence_spatial_rotational_killing_vector(
+    x, local_angular_velocity_around_z, sqrt_det_spatial_metric
+):
+    return 0.0

--- a/tests/Unit/PointwiseFunctions/Hydro/InitialData/Test_IrrotationalBns.cpp
+++ b/tests/Unit/PointwiseFunctions/Hydro/InitialData/Test_IrrotationalBns.cpp
@@ -1,0 +1,60 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <string>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Framework/CheckWithRandomValues.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "PointwiseFunctions/Hydro/InitialData/IrrotationalBns.hpp"
+
+namespace hydro::initial_data::irrotational_bns {
+SPECTRE_TEST_CASE("Unit.PointwiseFunctions.Hydro.InitialData.IrrotationalBns",
+                  "[Unit][Hydro][Elliptic]") {
+  pypp::SetupLocalPythonEnvironment local_python_env(
+      "PointwiseFunctions/Hydro/InitialData");
+  const DataVector used_for_size(5);
+  pypp::check_with_random_values<1>(
+      static_cast<tnsr::I<DataVector, 3> (*)(const tnsr::I<DataVector, 3>&,
+                                             const tnsr::I<DataVector, 3>&)>(
+          &rotational_shift),
+      "IrrotationalBns", "rotational_shift", {{{0.0, 1.0}}}, used_for_size);
+  pypp::check_with_random_values<1>(
+      static_cast<tnsr::II<DataVector, 3> (*)(const tnsr::I<DataVector, 3>&,
+                                              const Scalar<DataVector>&)>(
+          &rotational_shift_stress),
+      "IrrotationalBns", "rotational_shift_stress", {{{0.0, 1.0}}},
+      used_for_size);
+  pypp::check_with_random_values<1>(
+      static_cast<tnsr::iJ<DataVector, 3> (*)(
+          const tnsr::I<DataVector, 3>&, const tnsr::iJ<DataVector, 3>&,
+          const Scalar<DataVector>&, const tnsr::i<DataVector, 3>&,
+          const tnsr::iJ<DataVector, 3>&)>(
+          &derivative_rotational_shift_over_lapse_squared),
+      "IrrotationalBns", "derivative_rotational_shift_over_lapse_squared",
+      {{{0.0, 1.0}}}, used_for_size);
+  pypp::check_with_random_values<1>(
+      static_cast<Scalar<DataVector> (*)(
+          const tnsr::I<DataVector, 3>&, const Scalar<DataVector>&,
+          const tnsr::i<DataVector, 3>&, const tnsr::II<DataVector, 3>&,
+          double)>(&specific_enthalpy_squared),
+      "IrrotationalBns", "specific_enthalpy_squared", {{{0.0, 1.0}}},
+      used_for_size);
+  pypp::check_with_random_values<1>(
+      static_cast<tnsr::I<DataVector, 3> (*)(
+          const tnsr::I<DataVector, 3>&, double, const Scalar<DataVector>&)>(
+          &spatial_rotational_killing_vector),
+      "IrrotationalBns", "spatial_rotational_killing_vector", {{{0.0, 1.0}}},
+      used_for_size);
+  pypp::check_with_random_values<1>(
+      static_cast<Scalar<DataVector> (*)(const tnsr::I<DataVector, 3>&, double,
+                                         const Scalar<DataVector>&)>(
+          &divergence_spatial_rotational_killing_vector),
+      "IrrotationalBns", "divergence_spatial_rotational_killing_vector",
+      {{{0.0, 1.0}}}, used_for_size);
+}
+}  // namespace hydro::initial_data::irrotational_bns


### PR DESCRIPTION
## Proposed changes

This PR adds the point wise functions necessary to compute the needed quantities for use in solving Irrotational BNS initial data (which will be added in a future pull request)

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
