### PR TITLE
Hypersurface calculations for Klein-Gordon Cce 

### DIFF
--- a/src/Evolution/Systems/Cce/Components/KleinGordonCharacteristicEvolution.hpp
+++ b/src/Evolution/Systems/Cce/Components/KleinGordonCharacteristicEvolution.hpp
@@ -106,6 +106,7 @@ struct KleinGordonCharacteristicEvolution
                       tmpl::bind<hypersurface_computation, tmpl::_1>>,
       klein_gordon_hypersurface_computation,
       Actions::FilterSwshVolumeQuantity<Tags::BondiH>,
+      Actions::FilterSwshVolumeQuantity<Tags::KleinGordonPi>,
       ::Actions::MutateApply<
           CalculateScriPlusValue<::Tags::dt<Tags::InertialRetardedTime>>>,
       Actions::CalculateScriInputs,
@@ -148,6 +149,7 @@ struct KleinGordonCharacteristicEvolution
                       tmpl::bind<hypersurface_computation, tmpl::_1>>,
       klein_gordon_hypersurface_computation,
       Actions::FilterSwshVolumeQuantity<Tags::BondiH>,
+      Actions::FilterSwshVolumeQuantity<Tags::KleinGordonPi>,
       compute_scri_quantities_and_observe,
       ::Actions::RecordTimeStepperData<cce_system>,
       ::Actions::UpdateU<cce_system>,

--- a/src/Evolution/Systems/Cce/Components/KleinGordonCharacteristicEvolution.hpp
+++ b/src/Evolution/Systems/Cce/Components/KleinGordonCharacteristicEvolution.hpp
@@ -61,6 +61,9 @@ struct KleinGordonCharacteristicEvolution
   using hypersurface_computation =
       typename cce_base::template hypersurface_computation<BondiTag>;
 
+  using klein_gordon_hypersurface_computation = tmpl::list<
+      ::Actions::MutateApply<GaugeAdjustedBoundaryValue<Tags::KleinGordonPi>>>;
+
   using simple_tags_from_options =
       Parallel::get_simple_tags_from_options<initialize_action_list>;
 
@@ -96,6 +99,7 @@ struct KleinGordonCharacteristicEvolution
                      tmpl::bind<ComputeKleinGordonSource, tmpl::_1>>>,
       tmpl::transform<bondi_hypersurface_step_tags,
                       tmpl::bind<hypersurface_computation, tmpl::_1>>,
+      klein_gordon_hypersurface_computation,
       Actions::FilterSwshVolumeQuantity<Tags::BondiH>,
       ::Actions::MutateApply<
           CalculateScriPlusValue<::Tags::dt<Tags::InertialRetardedTime>>>,
@@ -137,6 +141,7 @@ struct KleinGordonCharacteristicEvolution
                      tmpl::bind<ComputeKleinGordonSource, tmpl::_1>>>,
       tmpl::transform<bondi_hypersurface_step_tags,
                       tmpl::bind<hypersurface_computation, tmpl::_1>>,
+      klein_gordon_hypersurface_computation,
       Actions::FilterSwshVolumeQuantity<Tags::BondiH>,
       compute_scri_quantities_and_observe,
       ::Actions::RecordTimeStepperData<cce_system>,

--- a/src/Evolution/Systems/Cce/Components/KleinGordonCharacteristicEvolution.hpp
+++ b/src/Evolution/Systems/Cce/Components/KleinGordonCharacteristicEvolution.hpp
@@ -63,7 +63,11 @@ struct KleinGordonCharacteristicEvolution
 
   using klein_gordon_hypersurface_computation = tmpl::list<
       ::Actions::MutateApply<GaugeAdjustedBoundaryValue<Tags::KleinGordonPi>>,
-      Actions::CalculateIntegrandInputsForTag<Tags::KleinGordonPi>>;
+      Actions::CalculateIntegrandInputsForTag<Tags::KleinGordonPi>,
+      tmpl::transform<
+          integrand_terms_to_compute_for_bondi_variable<Tags::KleinGordonPi>,
+          tmpl::bind<::Actions::MutateApply,
+                     tmpl::bind<ComputeBondiIntegrand, tmpl::_1>>>>;
 
   using simple_tags_from_options =
       Parallel::get_simple_tags_from_options<initialize_action_list>;

--- a/src/Evolution/Systems/Cce/Components/KleinGordonCharacteristicEvolution.hpp
+++ b/src/Evolution/Systems/Cce/Components/KleinGordonCharacteristicEvolution.hpp
@@ -62,7 +62,8 @@ struct KleinGordonCharacteristicEvolution
       typename cce_base::template hypersurface_computation<BondiTag>;
 
   using klein_gordon_hypersurface_computation = tmpl::list<
-      ::Actions::MutateApply<GaugeAdjustedBoundaryValue<Tags::KleinGordonPi>>>;
+      ::Actions::MutateApply<GaugeAdjustedBoundaryValue<Tags::KleinGordonPi>>,
+      Actions::CalculateIntegrandInputsForTag<Tags::KleinGordonPi>>;
 
   using simple_tags_from_options =
       Parallel::get_simple_tags_from_options<initialize_action_list>;

--- a/src/Evolution/Systems/Cce/GaugeTransformBoundaryData.hpp
+++ b/src/Evolution/Systems/Cce/GaugeTransformBoundaryData.hpp
@@ -520,6 +520,37 @@ struct GaugeAdjustedBoundaryValue<Tags::BondiH> {
 };
 
 /*!
+ * \brief Computes the evolution gauge quantity \f$\hat \Pi\f$ for the scalar
+ * field on the worldtube.
+ *
+ * \details The evolution gauge \f$\hat \Pi\f$ obeys
+ * \f{align*}{
+ *   \hat \Pi = \partial_{t^\prime} \psi + \Re
+ *   \left(\mathcal{U}^{(0)}\bar{\eth}\psi\right)
+ * \f}
+ *
+ * where \f$\partial_{t^\prime} \psi\f$ comes from the Cauchy evolution.
+ */
+template <>
+struct GaugeAdjustedBoundaryValue<Tags::KleinGordonPi> {
+  using return_tags =
+      tmpl::list<Tags::EvolutionGaugeBoundaryValue<Tags::KleinGordonPi>>;
+  using argument_tags = tmpl::list<
+      Tags::BoundaryValue<Tags::KleinGordonPi>, Tags::BondiUAtScri,
+      Spectral::Swsh::Tags::SwshInterpolator<Tags::CauchyAngularCoords>,
+      Tags::LMax, Tags::KleinGordonPsi>;
+
+  static void apply(
+      gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 0>>*>
+          evolution_kg_pi,
+      const Scalar<SpinWeighted<ComplexDataVector, 0>>& cauchy_kg_pi,
+      const Scalar<SpinWeighted<ComplexDataVector, 1>>&
+          evolution_gauge_u_at_scri,
+      const Spectral::Swsh::SwshInterpolator& interpolator, size_t l_max,
+      const Scalar<SpinWeighted<ComplexDataVector, 0>>& volume_psi);
+};
+
+/*!
  * \brief Update the Cauchy gauge cartesian coordinate derivative \f$\partial_u
  * x(\hat x)\f$, as well as remaining gauge quantities \f$\mathcal U^{(0)}\f$,
  * \f$\hat U \equiv \mathcal U - \mathcal U^{(0)}\f$, and \f$\partial_{\hat u}

--- a/src/Evolution/Systems/Cce/IntegrandInputSteps.hpp
+++ b/src/Evolution/Systems/Cce/IntegrandInputSteps.hpp
@@ -172,6 +172,26 @@ struct TagsToComputeForImpl<Tags::KleinGordonSource<Tags::BondiQ>> {
                                                   Spectral::Swsh::Tags::Eth>>;
   using second_swsh_derivative_tags = tmpl::list<>;
 };
+
+template <>
+struct TagsToComputeForImpl<Tags::KleinGordonPi> {
+  using pre_swsh_derivative_tags =
+      tmpl::list<Tags::Dy<Tags::Dy<Tags::KleinGordonPsi>>>;
+  using second_swsh_derivative_tags =
+      tmpl::list<Spectral::Swsh::Tags::Derivative<Tags::KleinGordonPsi,
+                                                  Spectral::Swsh::Tags::EthEth>,
+                 Spectral::Swsh::Tags::Derivative<
+                     Tags::KleinGordonPsi, Spectral::Swsh::Tags::EthEthbar>>;
+  using swsh_derivative_tags = tmpl::list<
+      Spectral::Swsh::Tags::Derivative<Tags::Dy<Tags::KleinGordonPsi>,
+                                       Spectral::Swsh::Tags::Eth>,
+      Spectral::Swsh::Tags::Derivative<Tags::Dy<Tags::KleinGordonPsi>,
+                                       Spectral::Swsh::Tags::Ethbar>,
+      Spectral::Swsh::Tags::Derivative<Tags::KleinGordonPsi,
+                                       Spectral::Swsh::Tags::Eth>,
+      Spectral::Swsh::Tags::Derivative<Tags::KleinGordonPsi,
+                                       Spectral::Swsh::Tags::Ethbar>>;
+};
 }  // namespace detail
 
 /*!

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_KleinGordonCceCalculations.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_KleinGordonCceCalculations.cpp
@@ -22,8 +22,12 @@ using real_volume_tags_to_generate = tmpl::list<Tags::OneMinusY>;
 using swsh_volume_tags_to_generate =
     tmpl::list<Tags::Exp2Beta, Tags::BondiR, Tags::BondiK, Tags::BondiJ,
                Tags::Dy<Tags::KleinGordonPsi>,
+               Tags::KleinGordonPsi,
                Spectral::Swsh::Tags::Derivative<Tags::KleinGordonPsi,
                                                 Spectral::Swsh::Tags::Eth>>;
+
+using swsh_boundary_tags_to_generate =
+    tmpl::list<Tags::BoundaryValue<Tags::KleinGordonPi>, Tags::BondiUAtScri>;
 
 using swsh_volume_tags_to_compute =
     tmpl::list<Tags::KleinGordonSource<Tags::BondiBeta>,
@@ -32,11 +36,18 @@ using swsh_volume_tags_to_compute =
                Tags::KleinGordonSource<Tags::BondiW>,
                Tags::KleinGordonSource<Tags::BondiH>>;
 
+using swsh_boundary_tags_to_compute =
+    tmpl::list<Tags::EvolutionGaugeBoundaryValue<Tags::KleinGordonPi>>;
+
 template <typename Metavariables>
 struct mock_kg_characteristic_evolution {
-  using simple_tags = db::AddSimpleTags<::Tags::Variables<
-      tmpl::append<real_volume_tags_to_generate, swsh_volume_tags_to_generate,
-                   swsh_volume_tags_to_compute>>>;
+  using simple_tags = db::AddSimpleTags<
+      ::Tags::Variables<tmpl::append<real_volume_tags_to_generate,
+                                     swsh_volume_tags_to_generate,
+                                     swsh_volume_tags_to_compute>>,
+      ::Tags::Variables<tmpl::append<swsh_boundary_tags_to_generate,
+                                     swsh_boundary_tags_to_compute>>,
+      Spectral::Swsh::Tags::SwshInterpolator<Tags::CauchyAngularCoords>>;
 
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
@@ -48,10 +59,13 @@ struct mock_kg_characteristic_evolution {
           tmpl::list<ActionTesting::InitializeDataBox<simple_tags>>>,
       Parallel::PhaseActions<
           Parallel::Phase::Evolve,
-          tmpl::list<tmpl::transform<
-              bondi_hypersurface_step_tags,
-              tmpl::bind<::Actions::MutateApply,
-                         tmpl::bind<ComputeKleinGordonSource, tmpl::_1>>>>>>;
+          tmpl::list<
+              tmpl::transform<
+                  bondi_hypersurface_step_tags,
+                  tmpl::bind<::Actions::MutateApply,
+                             tmpl::bind<ComputeKleinGordonSource, tmpl::_1>>>,
+              ::Actions::MutateApply<
+                  GaugeAdjustedBoundaryValue<Tags::KleinGordonPi>>>>>;
 
   using const_global_cache_tags =
       tmpl::list<Tags::LMax, Tags::NumberOfRadialPoints>;
@@ -63,8 +77,8 @@ struct metavariables {
 };
 
 // This unit test is to validate the automatic calling chain of Klein-Gordon Cce
-// calculations, including the mutators `ComputeKleinGordonSource`. The test
-// involves
+// calculations, including the mutators `ComputeKleinGordonSource` and
+// `GaugeAdjustedBoundaryValue<Tags::KleinGordonPi>`. The test involves
 // (a) Fills a bunch of variables with random numbers (filtered so that there is
 // no aliasing in highest modes).
 // (b) Puts those variables in two places: the MockRuntimeSystem runner and a
@@ -88,6 +102,11 @@ void test_klein_gordon_cce_source(const gsl::not_null<Generator*> gen) {
           Spectral::Swsh::number_of_swsh_collocation_points(l_max) *
           number_of_radial_points};
 
+  Variables<tmpl::append<swsh_boundary_tags_to_generate,
+                         swsh_boundary_tags_to_compute>>
+      component_boundary_variables{
+          Spectral::Swsh::number_of_swsh_collocation_points(l_max)};
+
   tmpl::for_each<swsh_volume_tags_to_generate>(
       [&component_volume_variables, &gen, &coefficient_distribution,
        &number_of_radial_points, &l_max](auto tag_v) {
@@ -109,6 +128,35 @@ void test_klein_gordon_cce_source(const gsl::not_null<Generator*> gen) {
             l_max / 2, 32.0, 8);
       });
 
+  tmpl::for_each<swsh_boundary_tags_to_generate>(
+      [&component_boundary_variables, &gen, &coefficient_distribution,
+       &l_max](auto tag_v) {
+        using tag = typename decltype(tag_v)::type;
+        SpinWeighted<ComplexModalVector, tag::type::type::spin> generated_modes{
+            Spectral::Swsh::size_of_libsharp_coefficient_vector(l_max)};
+        Spectral::Swsh::TestHelpers::generate_swsh_modes<tag::type::type::spin>(
+            make_not_null(&generated_modes.data()), gen,
+            make_not_null(&coefficient_distribution), 1, l_max);
+        get(get<tag>(component_boundary_variables)) =
+            Spectral::Swsh::inverse_swsh_transform(l_max, 1, generated_modes);
+        // aggressive filter to make the uniformly generated random modes
+        // somewhat reasonable
+        Spectral::Swsh::filter_swsh_boundary_quantity(
+            make_not_null(&get(get<tag>(component_boundary_variables))), l_max,
+            l_max / 2);
+      });
+
+  tnsr::i<DataVector, 3> cartesian_cauchy_coordinates;
+  tnsr::i<DataVector, 2, ::Frame::Spherical<::Frame::Inertial>>
+      angular_cauchy_coordinates;
+
+  Spectral::Swsh::create_angular_and_cartesian_coordinates(
+      make_not_null(&cartesian_cauchy_coordinates),
+      make_not_null(&angular_cauchy_coordinates), l_max);
+  Spectral::Swsh::SwshInterpolator interpolator(
+      get<0>(angular_cauchy_coordinates), get<1>(angular_cauchy_coordinates),
+      l_max);
+
   PrecomputeCceDependencies<Tags::EvolutionGaugeBoundaryValue,
                             Tags::OneMinusY>::
       apply(make_not_null(&get<Tags::OneMinusY>(component_volume_variables)),
@@ -122,15 +170,17 @@ void test_klein_gordon_cce_source(const gsl::not_null<Generator*> gen) {
           Parallel::get_const_global_cache_tags<metavariables>>{
           l_max, number_of_radial_points}};
   ActionTesting::emplace_component_and_initialize<component>(
-      &runner, 0, {component_volume_variables});
+      &runner, 0,
+      {component_volume_variables, component_boundary_variables, interpolator});
   auto expected_box = db::create<
       tmpl::append<component::simple_tags,
                    db::AddSimpleTags<Tags::LMax, Tags::NumberOfRadialPoints>>>(
-      component_volume_variables, l_max, number_of_radial_points);
+      component_volume_variables, component_boundary_variables, interpolator,
+      l_max, number_of_radial_points);
 
   runner.set_phase(Parallel::Phase::Evolve);
 
-  for (int i = 0; i < 5; i++) {
+  for (int i = 0; i < 6; i++) {
     ActionTesting::next_action<component>(make_not_null(&runner), 0);
   }
 
@@ -148,6 +198,20 @@ void test_klein_gordon_cce_source(const gsl::not_null<Generator*> gen) {
     auto expected_result = db::get<Tags::KleinGordonSource<tag>>(expected_box);
     CHECK(computed_result == expected_result);
   });
+
+  // tests for `GaugeAdjustedBoundaryValue<Tags::KleinGordonPi>`
+  {
+    db::mutate_apply<GaugeAdjustedBoundaryValue<Tags::KleinGordonPi>>(
+        make_not_null(&expected_box));
+    auto computed_result = ActionTesting::get_databox_tag<
+        component, Tags::EvolutionGaugeBoundaryValue<Tags::KleinGordonPi>>(
+        runner, 0);
+
+    auto expected_result =
+        db::get<Tags::EvolutionGaugeBoundaryValue<Tags::KleinGordonPi>>(
+            expected_box);
+    CHECK(computed_result == expected_result);
+  }
 }
 }  // namespace
 


### PR DESCRIPTION
## Proposed changes

<!--
At a high level, describe what this PR does.
-->

This PR performs hypersurface calculations for Klein-Gordon Cce. 

The first commit does a worldtube transformation to convert the Cauchy variable $\partial_{t^\prime}\psi$ to the characteristic variable $\Pi$ (`Cce::Tags::KleinGordonPi`).

The third commit adds actions to compute the right-hand side of the hypersurface equation for $\Pi$. The equation reads

$(1 - y) \partial_y \Pi + \Pi = A_\Pi + (1 - y) B_\Pi$.

The second commit prepares necessary inputs to compute $A_\Pi$ and $B_\Pi$.
### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
