### PR TITLE
Use 2d EOS in Newtonian Euler, stop using EOS base tag in Newtonian Euler

### DIFF
--- a/src/Evolution/Executables/NewtonianEuler/CMakeLists.txt
+++ b/src/Evolution/Executables/NewtonianEuler/CMakeLists.txt
@@ -1,38 +1,6 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-# We can't do the instantiations for NewtonianEuler in the NewtonianEuler
-# library because the TimeDerivativeTerms and system depend on the analytic
-# solution/data being used, which causes a cyclic dependency since the solutions
-# depend on the system for the tags. This cyclic dependency is already present
-# in the code, but currently only through header files. The same cyclic
-# dependency exists between NewtonianEulerSources and NewtonianEuler. To resolve
-# these, we will need to factor the NewtonianEuler tags into a separate library.
-# fter the NewtonianEuler tags are factored in this way, the instantiation
-# source file should be moved to the NewtonianEuler library.
-set(LIBRARY NewtonianEulerInstantiations)
-
-add_spectre_library(${LIBRARY})
-
-spectre_target_sources(
-  ${LIBRARY}
-  PRIVATE
-  VolumeTermsInstantiation.cpp
-  )
-
-target_link_libraries(
-  ${LIBRARY}
-  PUBLIC
-  DataStructures
-  Evolution
-  FiniteDifference
-  NewtonianEuler
-  NewtonianEulerAnalyticData
-  NewtonianEulerSolutions
-  NewtonianEulerSources
-  Utilities
-  )
-
 set(LIBS_TO_LINK
   Actions
   Charmxx::main
@@ -50,7 +18,6 @@ set(LIBS_TO_LINK
   MathFunctions
   NewtonianEuler
   NewtonianEulerAnalyticData
-  NewtonianEulerInstantiations
   NewtonianEulerLimiters
   NewtonianEulerSolutions
   NewtonianEulerSources

--- a/src/Evolution/Executables/NewtonianEuler/CMakeLists.txt
+++ b/src/Evolution/Executables/NewtonianEuler/CMakeLists.txt
@@ -63,8 +63,8 @@ set(LIBS_TO_LINK
   Utilities
   )
 
-function(add_newtonian_euler_executable SUFFIX DIM INITIAL_DATA)
-  set(EXECUTABLE "EvolveNewtonianEuler${SUFFIX}${DIM}D")
+function(add_newtonian_euler_executable DIM)
+  set(EXECUTABLE "EvolveNewtonianEuler${DIM}D")
   add_spectre_executable(
     ${EXECUTABLE}
     EXCLUDE_FROM_ALL
@@ -74,63 +74,10 @@ function(add_newtonian_euler_executable SUFFIX DIM INITIAL_DATA)
     ${EXECUTABLE}
     PRIVATE
     DIM=${DIM}
-    INITIAL_DATA=${INITIAL_DATA}
     )
   target_link_libraries(${EXECUTABLE} PRIVATE ${LIBS_TO_LINK})
 endfunction()
 
-function(add_riemann_problem_executable DIM)
-  add_newtonian_euler_executable(
-    RiemannProblem
-    ${DIM}
-    NewtonianEuler::Solutions::RiemannProblem<${DIM}>
-    )
-endfunction(add_riemann_problem_executable)
-
-add_riemann_problem_executable(1)
-add_riemann_problem_executable(2)
-add_riemann_problem_executable(3)
-
-function(add_isentropic_vortex_executable DIM)
-  add_newtonian_euler_executable(
-    IsentropicVortex
-    ${DIM}
-    NewtonianEuler::Solutions::IsentropicVortex<${DIM}>
-    )
-endfunction(add_isentropic_vortex_executable)
-
-add_isentropic_vortex_executable(2)
-add_isentropic_vortex_executable(3)
-
-function(add_lane_emden_executable)
-  add_newtonian_euler_executable(
-    LaneEmdenStar
-    3
-    NewtonianEuler::Solutions::LaneEmdenStar
-    )
-endfunction(add_lane_emden_executable)
-
-add_lane_emden_executable()
-
-function(add_kh_instability_executable DIM)
-  add_newtonian_euler_executable(
-    KhInstability
-    ${DIM}
-    NewtonianEuler::AnalyticData::KhInstability<${DIM}>
-    )
-endfunction(add_kh_instability_executable)
-
-add_kh_instability_executable(2)
-add_kh_instability_executable(3)
-
-function(add_smooth_flow_executable DIM)
-  add_newtonian_euler_executable(
-    SmoothFlow
-    ${DIM}
-    NewtonianEuler::Solutions::SmoothFlow<${DIM}>
-    )
-endfunction(add_smooth_flow_executable)
-
-add_smooth_flow_executable(1)
-add_smooth_flow_executable(2)
-add_smooth_flow_executable(3)
+add_newtonian_euler_executable(1)
+add_newtonian_euler_executable(2)
+add_newtonian_euler_executable(3)

--- a/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.cpp
+++ b/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.cpp
@@ -15,7 +15,7 @@
 #include "Utilities/Serialization/RegisterDerivedClassesWithCharm.hpp"
 
 // Parameters chosen in CMakeLists.txt
-using metavariables = EvolutionMetavars<DIM, INITIAL_DATA>;
+using metavariables = EvolutionMetavars<DIM>;
 
 extern "C" void CkRegisterMainModule() {
   Parallel::charmxx::register_main_module<metavariables>();

--- a/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
+++ b/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
@@ -126,7 +126,7 @@ class CProxy_GlobalCache;
 }  // namespace Parallel
 /// \endcond
 
-template <size_t Dim, typename InitialData>
+template <size_t Dim>
 struct EvolutionMetavars {
   static constexpr size_t volume_dim = Dim;
   // The use_dg_subcell flag controls whether to use "standard" limiting (false)
@@ -134,15 +134,6 @@ struct EvolutionMetavars {
   static constexpr bool use_dg_subcell = true;
   static constexpr dg::Formulation dg_formulation =
       dg::Formulation::StrongInertial;
-
-  using initial_data = InitialData;
-  static_assert(
-      is_analytic_data_v<initial_data> xor is_analytic_solution_v<initial_data>,
-      "initial_data must be either an analytic_data or an analytic_solution");
-
-  using eos_base = EquationsOfState::get_eos_base<
-      typename initial_data::equation_of_state_type>;
-  using equation_of_state_type = typename std::unique_ptr<eos_base>;
 
   using system = NewtonianEuler::System<Dim>;
 
@@ -153,13 +144,12 @@ struct EvolutionMetavars {
       TimeStepperBase::local_time_stepping;
 
   using initial_data_tag = evolution::initial_data::Tags::InitialData;
-  using initial_data_list = tmpl::list<initial_data>;
+  using initial_data_list = NewtonianEuler::InitialData::initial_data_list<Dim>;
 
   using analytic_variables_tags =
       typename system::primitive_variables_tag::tags_list;
 
-  using equation_of_state_tag =
-      hydro::Tags::EquationOfState<false, eos_base::thermodynamic_dim>;
+  using equation_of_state_tag = hydro::Tags::EquationOfState<false, 2>;
 
   using limiter = Tags::Limiter<NewtonianEuler::Limiters::Minmod<Dim>>;
 

--- a/src/Evolution/Systems/NewtonianEuler/BoundaryConditions/DemandOutgoingCharSpeeds.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/BoundaryConditions/DemandOutgoingCharSpeeds.hpp
@@ -71,7 +71,7 @@ class DemandOutgoingCharSpeeds final : public BoundaryCondition<Dim> {
       tmpl::list<hydro::Tags::RestMassDensity<DataVector>,
                  hydro::Tags::SpatialVelocity<DataVector, Dim, Frame::Inertial>,
                  hydro::Tags::SpecificInternalEnergy<DataVector>>;
-  using dg_gridless_tags = tmpl::list<hydro::Tags::EquationOfStateBase>;
+  using dg_gridless_tags = tmpl::list<hydro::Tags::EquationOfState<false, 2>>;
 
   template <size_t ThermodynamicDim>
   static std::optional<std::string> dg_demand_outgoing_char_speeds(

--- a/src/Evolution/Systems/NewtonianEuler/BoundaryCorrections/Hll.cpp
+++ b/src/Evolution/Systems/NewtonianEuler/BoundaryCorrections/Hll.cpp
@@ -34,7 +34,6 @@ void Hll<Dim>::pup(PUP::er& p) {
 }
 
 template <size_t Dim>
-template <size_t ThermodynamicDim>
 double Hll<Dim>::dg_package_data(
     const gsl::not_null<Scalar<DataVector>*> packaged_mass_density,
     const gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*>
@@ -66,8 +65,8 @@ double Hll<Dim>::dg_package_data(
     const std::optional<tnsr::I<DataVector, Dim, Frame::Inertial>>&
     /*mesh_velocity*/,
     const std::optional<Scalar<DataVector>>& normal_dot_mesh_velocity,
-    const EquationsOfState::EquationOfState<false, ThermodynamicDim>&
-        equation_of_state) const {
+    const EquationsOfState::EquationOfState<false, 2>& equation_of_state)
+    const {
   {
     // Compute sound speed
     Scalar<DataVector>& sound_speed = *packaged_mass_density;
@@ -212,48 +211,5 @@ PUP::able::PUP_ID Hll<Dim>::my_PUP_ID = 0;
 GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
 
 #undef INSTANTIATION
-
-#define THERMODIM(data) BOOST_PP_TUPLE_ELEM(1, data)
-
-#define INSTANTIATION(_, data)                                                 \
-  template double Hll<DIM(data)>::dg_package_data<THERMODIM(data)>(            \
-      gsl::not_null<Scalar<DataVector>*> packaged_mass_density,                \
-      gsl::not_null<tnsr::I<DataVector, DIM(data), Frame::Inertial>*>          \
-          packaged_momentum_density,                                           \
-      gsl::not_null<Scalar<DataVector>*> packaged_energy_density,              \
-      gsl::not_null<Scalar<DataVector>*>                                       \
-          packaged_normal_dot_flux_mass_density,                               \
-      gsl::not_null<tnsr::I<DataVector, DIM(data), Frame::Inertial>*>          \
-          packaged_normal_dot_flux_momentum_density,                           \
-      gsl::not_null<Scalar<DataVector>*>                                       \
-          packaged_normal_dot_flux_energy_density,                             \
-      gsl::not_null<Scalar<DataVector>*> packaged_largest_outgoing_char_speed, \
-      gsl::not_null<Scalar<DataVector>*> packaged_largest_ingoing_char_speed,  \
-                                                                               \
-      const Scalar<DataVector>& mass_density,                                  \
-      const tnsr::I<DataVector, DIM(data), Frame::Inertial>& momentum_density, \
-      const Scalar<DataVector>& energy_density,                                \
-                                                                               \
-      const tnsr::I<DataVector, DIM(data), Frame::Inertial>&                   \
-          flux_mass_density,                                                   \
-      const tnsr::IJ<DataVector, DIM(data), Frame::Inertial>&                  \
-          flux_momentum_density,                                               \
-      const tnsr::I<DataVector, DIM(data), Frame::Inertial>&                   \
-          flux_energy_density,                                                 \
-                                                                               \
-      const tnsr::I<DataVector, DIM(data), Frame::Inertial>& velocity,         \
-      const Scalar<DataVector>& specific_internal_energy,                      \
-                                                                               \
-      const tnsr::i<DataVector, DIM(data), Frame::Inertial>& normal_covector,  \
-      const std::optional<tnsr::I<DataVector, DIM(data), Frame::Inertial>>&    \
-          mesh_velocity,                                                       \
-      const std::optional<Scalar<DataVector>>& normal_dot_mesh_velocity,       \
-      const EquationsOfState::EquationOfState<false, THERMODIM(data)>&         \
-          equation_of_state) const;
-
-GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3), (1, 2))
-
-#undef INSTANTIATION
-#undef THERMODIM
 #undef DIM
 }  // namespace NewtonianEuler::BoundaryCorrections

--- a/src/Evolution/Systems/NewtonianEuler/BoundaryCorrections/Hll.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/BoundaryCorrections/Hll.hpp
@@ -122,9 +122,8 @@ class Hll final : public BoundaryCorrection<Dim> {
       tmpl::list<hydro::Tags::SpatialVelocity<DataVector, Dim>,
                  hydro::Tags::SpecificInternalEnergy<DataVector>>;
   using dg_package_data_volume_tags =
-      tmpl::list<hydro::Tags::EquationOfStateBase>;
+      tmpl::list<hydro::Tags::EquationOfState<false, 2>>;
 
-  template <size_t ThermodynamicDim>
   double dg_package_data(
       gsl::not_null<Scalar<DataVector>*> packaged_mass_density,
       gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*>
@@ -153,8 +152,8 @@ class Hll final : public BoundaryCorrection<Dim> {
       const std::optional<tnsr::I<DataVector, Dim, Frame::Inertial>>&
       /*mesh_velocity*/,
       const std::optional<Scalar<DataVector>>& normal_dot_mesh_velocity,
-      const EquationsOfState::EquationOfState<false, ThermodynamicDim>&
-          equation_of_state) const;
+      const EquationsOfState::EquationOfState<false, 2>& equation_of_state)
+      const;
 
   void dg_boundary_terms(
       gsl::not_null<Scalar<DataVector>*> boundary_correction_mass_density,

--- a/src/Evolution/Systems/NewtonianEuler/BoundaryCorrections/Hllc.cpp
+++ b/src/Evolution/Systems/NewtonianEuler/BoundaryCorrections/Hllc.cpp
@@ -34,7 +34,6 @@ void Hllc<Dim>::pup(PUP::er& p) {
 }
 
 template <size_t Dim>
-template <size_t ThermodynamicDim>
 double Hllc<Dim>::dg_package_data(
     const gsl::not_null<Scalar<DataVector>*> packaged_mass_density,
     const gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*>
@@ -70,17 +69,12 @@ double Hllc<Dim>::dg_package_data(
     const std::optional<tnsr::I<DataVector, Dim, Frame::Inertial>>&
     /*mesh_velocity*/,
     const std::optional<Scalar<DataVector>>& normal_dot_mesh_velocity,
-    const EquationsOfState::EquationOfState<false, ThermodynamicDim>&
-        equation_of_state) const {
+    const EquationsOfState::EquationOfState<false, 2>& equation_of_state)
+    const {
   {
     // Compute pressure
-    if constexpr (ThermodynamicDim == 1) {
-      *packaged_pressure =
-          equation_of_state.pressure_from_density(mass_density);
-    } else if constexpr (ThermodynamicDim == 2) {
-      *packaged_pressure = equation_of_state.pressure_from_density_and_energy(
-          mass_density, specific_internal_energy);
-    }
+    *packaged_pressure = equation_of_state.pressure_from_density_and_energy(
+        mass_density, specific_internal_energy);
 
     // Compute sound speed
     Scalar<DataVector>& sound_speed = *packaged_mass_density;
@@ -313,52 +307,5 @@ PUP::able::PUP_ID Hllc<Dim>::my_PUP_ID = 0;
 GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
 
 #undef INSTANTIATION
-
-#define THERMODIM(data) BOOST_PP_TUPLE_ELEM(1, data)
-
-#define INSTANTIATION(_, data)                                                 \
-  template double Hllc<DIM(data)>::dg_package_data<THERMODIM(data)>(           \
-      gsl::not_null<Scalar<DataVector>*> packaged_mass_density,                \
-      gsl::not_null<tnsr::I<DataVector, DIM(data), Frame::Inertial>*>          \
-          packaged_momentum_density,                                           \
-      gsl::not_null<Scalar<DataVector>*> packaged_energy_density,              \
-      gsl::not_null<Scalar<DataVector>*> packaged_pressure,                    \
-      gsl::not_null<Scalar<DataVector>*>                                       \
-          packaged_normal_dot_flux_mass_density,                               \
-      gsl::not_null<tnsr::I<DataVector, DIM(data), Frame::Inertial>*>          \
-          packaged_normal_dot_flux_momentum_density,                           \
-      gsl::not_null<Scalar<DataVector>*>                                       \
-          packaged_normal_dot_flux_energy_density,                             \
-      gsl::not_null<tnsr::i<DataVector, DIM(data), Frame::Inertial>*>          \
-          packaged_interface_unit_normal,                                      \
-      gsl::not_null<Scalar<DataVector>*> packaged_normal_dot_velocity,         \
-      gsl::not_null<Scalar<DataVector>*> packaged_largest_outgoing_char_speed, \
-      gsl::not_null<Scalar<DataVector>*> packaged_largest_ingoing_char_speed,  \
-                                                                               \
-      const Scalar<DataVector>& mass_density,                                  \
-      const tnsr::I<DataVector, DIM(data), Frame::Inertial>& momentum_density, \
-      const Scalar<DataVector>& energy_density,                                \
-                                                                               \
-      const tnsr::I<DataVector, DIM(data), Frame::Inertial>&                   \
-          flux_mass_density,                                                   \
-      const tnsr::IJ<DataVector, DIM(data), Frame::Inertial>&                  \
-          flux_momentum_density,                                               \
-      const tnsr::I<DataVector, DIM(data), Frame::Inertial>&                   \
-          flux_energy_density,                                                 \
-                                                                               \
-      const tnsr::I<DataVector, DIM(data), Frame::Inertial>& velocity,         \
-      const Scalar<DataVector>& specific_internal_energy,                      \
-                                                                               \
-      const tnsr::i<DataVector, DIM(data), Frame::Inertial>& normal_covector,  \
-      const std::optional<tnsr::I<DataVector, DIM(data), Frame::Inertial>>&    \
-          mesh_velocity,                                                       \
-      const std::optional<Scalar<DataVector>>& normal_dot_mesh_velocity,       \
-      const EquationsOfState::EquationOfState<false, THERMODIM(data)>&         \
-          equation_of_state) const;
-
-GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3), (1, 2))
-
-#undef INSTANTIATION
-#undef THERMODIM
 #undef DIM
 }  // namespace NewtonianEuler::BoundaryCorrections

--- a/src/Evolution/Systems/NewtonianEuler/BoundaryCorrections/Hllc.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/BoundaryCorrections/Hllc.hpp
@@ -218,9 +218,8 @@ class Hllc final : public BoundaryCorrection<Dim> {
       tmpl::list<hydro::Tags::SpatialVelocity<DataVector, Dim>,
                  hydro::Tags::SpecificInternalEnergy<DataVector>>;
   using dg_package_data_volume_tags =
-      tmpl::list<hydro::Tags::EquationOfStateBase>;
+      tmpl::list<hydro::Tags::EquationOfState<false, 2>>;
 
-  template <size_t ThermodynamicDim>
   double dg_package_data(
       gsl::not_null<Scalar<DataVector>*> packaged_mass_density,
       gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*>
@@ -253,8 +252,8 @@ class Hllc final : public BoundaryCorrection<Dim> {
       const std::optional<tnsr::I<DataVector, Dim, Frame::Inertial>>&
       /*mesh_velocity*/,
       const std::optional<Scalar<DataVector>>& normal_dot_mesh_velocity,
-      const EquationsOfState::EquationOfState<false, ThermodynamicDim>&
-          equation_of_state) const;
+      const EquationsOfState::EquationOfState<false, 2>& equation_of_state)
+      const;
 
   void dg_boundary_terms(
       gsl::not_null<Scalar<DataVector>*> boundary_correction_mass_density,

--- a/src/Evolution/Systems/NewtonianEuler/BoundaryCorrections/Rusanov.cpp
+++ b/src/Evolution/Systems/NewtonianEuler/BoundaryCorrections/Rusanov.cpp
@@ -31,7 +31,6 @@ void Rusanov<Dim>::pup(PUP::er& p) {
 }
 
 template <size_t Dim>
-template <size_t ThermodynamicDim>
 double Rusanov<Dim>::dg_package_data(
     const gsl::not_null<Scalar<DataVector>*> packaged_mass_density,
     const gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*>
@@ -60,8 +59,8 @@ double Rusanov<Dim>::dg_package_data(
     const std::optional<tnsr::I<DataVector, Dim, Frame::Inertial>>&
     /*mesh_velocity*/,
     const std::optional<Scalar<DataVector>>& normal_dot_mesh_velocity,
-    const EquationsOfState::EquationOfState<false, ThermodynamicDim>&
-        equation_of_state) const {
+    const EquationsOfState::EquationOfState<false, 2>& equation_of_state)
+    const {
   {
     // Compute sound speed
     Scalar<DataVector>& sound_speed = *packaged_mass_density;
@@ -170,47 +169,5 @@ PUP::able::PUP_ID Rusanov<Dim>::my_PUP_ID = 0;
 GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
 
 #undef INSTANTIATION
-
-#define THERMODIM(data) BOOST_PP_TUPLE_ELEM(1, data)
-
-#define INSTANTIATION(_, data)                                                 \
-  template double Rusanov<DIM(data)>::dg_package_data<THERMODIM(data)>(        \
-      gsl::not_null<Scalar<DataVector>*> packaged_mass_density,                \
-      gsl::not_null<tnsr::I<DataVector, DIM(data), Frame::Inertial>*>          \
-          packaged_momentum_density,                                           \
-      gsl::not_null<Scalar<DataVector>*> packaged_energy_density,              \
-      gsl::not_null<Scalar<DataVector>*>                                       \
-          packaged_normal_dot_flux_mass_density,                               \
-      gsl::not_null<tnsr::I<DataVector, DIM(data), Frame::Inertial>*>          \
-          packaged_normal_dot_flux_momentum_density,                           \
-      gsl::not_null<Scalar<DataVector>*>                                       \
-          packaged_normal_dot_flux_energy_density,                             \
-      gsl::not_null<Scalar<DataVector>*> packaged_abs_char_speed,              \
-                                                                               \
-      const Scalar<DataVector>& mass_density,                                  \
-      const tnsr::I<DataVector, DIM(data), Frame::Inertial>& momentum_density, \
-      const Scalar<DataVector>& energy_density,                                \
-                                                                               \
-      const tnsr::I<DataVector, DIM(data), Frame::Inertial>&                   \
-          flux_mass_density,                                                   \
-      const tnsr::IJ<DataVector, DIM(data), Frame::Inertial>&                  \
-          flux_momentum_density,                                               \
-      const tnsr::I<DataVector, DIM(data), Frame::Inertial>&                   \
-          flux_energy_density,                                                 \
-                                                                               \
-      const tnsr::I<DataVector, DIM(data), Frame::Inertial>& velocity,         \
-      const Scalar<DataVector>& specific_internal_energy,                      \
-                                                                               \
-      const tnsr::i<DataVector, DIM(data), Frame::Inertial>& normal_covector,  \
-      const std::optional<tnsr::I<DataVector, DIM(data), Frame::Inertial>>&    \
-          mesh_velocity,                                                       \
-      const std::optional<Scalar<DataVector>>& normal_dot_mesh_velocity,       \
-      const EquationsOfState::EquationOfState<false, THERMODIM(data)>&         \
-          equation_of_state) const;
-
-GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3), (1, 2))
-
-#undef INSTANTIATION
-#undef THERMODIM
 #undef DIM
 }  // namespace NewtonianEuler::BoundaryCorrections

--- a/src/Evolution/Systems/NewtonianEuler/BoundaryCorrections/Rusanov.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/BoundaryCorrections/Rusanov.hpp
@@ -101,9 +101,8 @@ class Rusanov final : public BoundaryCorrection<Dim> {
       tmpl::list<hydro::Tags::SpatialVelocity<DataVector, Dim>,
                  hydro::Tags::SpecificInternalEnergy<DataVector>>;
   using dg_package_data_volume_tags =
-      tmpl::list<hydro::Tags::EquationOfStateBase>;
+      tmpl::list<hydro::Tags::EquationOfState<false, 2>>;
 
-  template <size_t ThermodynamicDim>
   double dg_package_data(
       gsl::not_null<Scalar<DataVector>*> packaged_mass_density,
       gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*>
@@ -131,8 +130,8 @@ class Rusanov final : public BoundaryCorrection<Dim> {
       const std::optional<tnsr::I<DataVector, Dim, Frame::Inertial>>&
       /*mesh_velocity*/,
       const std::optional<Scalar<DataVector>>& normal_dot_mesh_velocity,
-      const EquationsOfState::EquationOfState<false, ThermodynamicDim>&
-          equation_of_state) const;
+      const EquationsOfState::EquationOfState<false, 2>& equation_of_state)
+      const;
 
   void dg_boundary_terms(
       gsl::not_null<Scalar<DataVector>*> boundary_correction_mass_density,

--- a/src/Evolution/Systems/NewtonianEuler/CMakeLists.txt
+++ b/src/Evolution/Systems/NewtonianEuler/CMakeLists.txt
@@ -18,6 +18,7 @@ spectre_target_sources(
   RamPressure.cpp
   SoundSpeedSquared.cpp
   SpecificKineticEnergy.cpp
+  VolumeTermsInstantiation.cpp
   )
 
 spectre_target_headers(
@@ -48,6 +49,7 @@ target_link_libraries(
   DgSubcell
   Domain
   ErrorHandling
+  Evolution
   Hydro
   Options
   Serialization

--- a/src/Evolution/Systems/NewtonianEuler/FiniteDifference/AoWeno.cpp
+++ b/src/Evolution/Systems/NewtonianEuler/FiniteDifference/AoWeno.cpp
@@ -69,14 +69,14 @@ template <size_t Dim>
 PUP::able::PUP_ID AoWeno53Prim<Dim>::my_PUP_ID = 0;
 
 template <size_t Dim>
-template <size_t ThermodynamicDim, typename TagsList>
+template <typename TagsList>
 void AoWeno53Prim<Dim>::reconstruct(
     const gsl::not_null<std::array<Variables<TagsList>, Dim>*>
         vars_on_lower_face,
     const gsl::not_null<std::array<Variables<TagsList>, Dim>*>
         vars_on_upper_face,
     const Variables<prims_tags>& volume_prims,
-    const EquationsOfState::EquationOfState<false, ThermodynamicDim>& eos,
+    const EquationsOfState::EquationOfState<false, 2>& eos,
     const Element<Dim>& element,
     const DirectionalIdMap<Dim, evolution::dg::subcell::GhostData>& ghost_data,
     const Mesh<Dim>& subcell_mesh) const {
@@ -93,11 +93,11 @@ void AoWeno53Prim<Dim>::reconstruct(
 }
 
 template <size_t Dim>
-template <size_t ThermodynamicDim, typename TagsList>
+template <typename TagsList>
 void AoWeno53Prim<Dim>::reconstruct_fd_neighbor(
     const gsl::not_null<Variables<TagsList>*> vars_on_face,
     const Variables<prims_tags>& subcell_volume_prims,
-    const EquationsOfState::EquationOfState<false, ThermodynamicDim>& eos,
+    const EquationsOfState::EquationOfState<false, 2>& eos,
     const Element<Dim>& element,
     const DirectionalIdMap<Dim, evolution::dg::subcell::GhostData>& ghost_data,
     const Mesh<Dim>& subcell_mesh,
@@ -140,7 +140,6 @@ bool operator==(const AoWeno53Prim<Dim>& lhs, const AoWeno53Prim<Dim>& rhs) {
 }
 
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
-#define THERMO_DIM(data) BOOST_PP_TUPLE_ELEM(1, data)
 #define TAGS_LIST(data)                                                     \
   tmpl::list<Tags::MassDensityCons, Tags::MomentumDensity<DIM(data)>,       \
              Tags::EnergyDensity, hydro::Tags::RestMassDensity<DataVector>, \
@@ -161,32 +160,31 @@ bool operator==(const AoWeno53Prim<Dim>& lhs, const AoWeno53Prim<Dim>& rhs) {
 GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
 #undef INSTANTIATION
 
-#define INSTANTIATION(r, data)                                               \
-  template void AoWeno53Prim<DIM(data)>::reconstruct(                        \
-      gsl::not_null<std::array<Variables<TAGS_LIST(data)>, DIM(data)>*>      \
-          vars_on_lower_face,                                                \
-      gsl::not_null<std::array<Variables<TAGS_LIST(data)>, DIM(data)>*>      \
-          vars_on_upper_face,                                                \
-      const Variables<prims_tags>& volume_prims,                             \
-      const EquationsOfState::EquationOfState<false, THERMO_DIM(data)>& eos, \
-      const Element<DIM(data)>& element,                                     \
-      const DirectionalIdMap<DIM(data), evolution::dg::subcell::GhostData>&  \
-          ghost_data,                                                        \
-      const Mesh<DIM(data)>& subcell_mesh) const;                            \
-  template void AoWeno53Prim<DIM(data)>::reconstruct_fd_neighbor(            \
-      gsl::not_null<Variables<TAGS_LIST(data)>*> vars_on_face,               \
-      const Variables<prims_tags>& subcell_volume_prims,                     \
-      const EquationsOfState::EquationOfState<false, THERMO_DIM(data)>& eos, \
-      const Element<DIM(data)>& element,                                     \
-      const DirectionalIdMap<DIM(data), evolution::dg::subcell::GhostData>&  \
-          ghost_data,                                                        \
-      const Mesh<DIM(data)>& subcell_mesh,                                   \
+#define INSTANTIATION(r, data)                                              \
+  template void AoWeno53Prim<DIM(data)>::reconstruct(                       \
+      gsl::not_null<std::array<Variables<TAGS_LIST(data)>, DIM(data)>*>     \
+          vars_on_lower_face,                                               \
+      gsl::not_null<std::array<Variables<TAGS_LIST(data)>, DIM(data)>*>     \
+          vars_on_upper_face,                                               \
+      const Variables<prims_tags>& volume_prims,                            \
+      const EquationsOfState::EquationOfState<false, 2>& eos,               \
+      const Element<DIM(data)>& element,                                    \
+      const DirectionalIdMap<DIM(data), evolution::dg::subcell::GhostData>& \
+          ghost_data,                                                       \
+      const Mesh<DIM(data)>& subcell_mesh) const;                           \
+  template void AoWeno53Prim<DIM(data)>::reconstruct_fd_neighbor(           \
+      gsl::not_null<Variables<TAGS_LIST(data)>*> vars_on_face,              \
+      const Variables<prims_tags>& subcell_volume_prims,                    \
+      const EquationsOfState::EquationOfState<false, 2>& eos,               \
+      const Element<DIM(data)>& element,                                    \
+      const DirectionalIdMap<DIM(data), evolution::dg::subcell::GhostData>& \
+          ghost_data,                                                       \
+      const Mesh<DIM(data)>& subcell_mesh,                                  \
       const Direction<DIM(data)> direction_to_reconstruct) const;
 
-GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3), (1, 2))
+GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
 
 #undef INSTANTIATION
 #undef TAGS_LIST
-#undef THERMO_DIM
 #undef DIM
 }  // namespace NewtonianEuler::fd

--- a/src/Evolution/Systems/NewtonianEuler/FiniteDifference/AoWeno.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/FiniteDifference/AoWeno.hpp
@@ -101,27 +101,28 @@ class AoWeno53Prim : public Reconstructor<Dim> {
 
   using reconstruction_argument_tags =
       tmpl::list<::Tags::Variables<prims_tags>,
-                 hydro::Tags::EquationOfStateBase, domain::Tags::Element<Dim>,
+                 hydro::Tags::EquationOfState<false, 2>,
+                 domain::Tags::Element<Dim>,
                  evolution::dg::subcell::Tags::GhostDataForReconstruction<Dim>,
                  evolution::dg::subcell::Tags::Mesh<Dim>>;
 
-  template <size_t ThermodynamicDim, typename TagsList>
+  template <typename TagsList>
   void reconstruct(
       gsl::not_null<std::array<Variables<TagsList>, Dim>*> vars_on_lower_face,
       gsl::not_null<std::array<Variables<TagsList>, Dim>*> vars_on_upper_face,
       const Variables<prims_tags>& volume_prims,
-      const EquationsOfState::EquationOfState<false, ThermodynamicDim>& eos,
+      const EquationsOfState::EquationOfState<false, 2>& eos,
       const Element<Dim>& element,
       const DirectionalIdMap<Dim, evolution::dg::subcell::GhostData>&
           ghost_data,
       const Mesh<Dim>& subcell_mesh) const;
 
   /// Called by an element doing DG when the neighbor is doing subcell.
-  template <size_t ThermodynamicDim, typename TagsList>
+  template <typename TagsList>
   void reconstruct_fd_neighbor(
       gsl::not_null<Variables<TagsList>*> vars_on_face,
       const Variables<prims_tags>& subcell_volume_prims,
-      const EquationsOfState::EquationOfState<false, ThermodynamicDim>& eos,
+      const EquationsOfState::EquationOfState<false, 2>& eos,
       const Element<Dim>& element,
       const DirectionalIdMap<Dim, evolution::dg::subcell::GhostData>&
           ghost_data,

--- a/src/Evolution/Systems/NewtonianEuler/FiniteDifference/MonotonisedCentral.cpp
+++ b/src/Evolution/Systems/NewtonianEuler/FiniteDifference/MonotonisedCentral.cpp
@@ -45,14 +45,14 @@ template <size_t Dim>
 PUP::able::PUP_ID MonotonisedCentralPrim<Dim>::my_PUP_ID = 0;
 
 template <size_t Dim>
-template <size_t ThermodynamicDim, typename TagsList>
+template <typename TagsList>
 void MonotonisedCentralPrim<Dim>::reconstruct(
     const gsl::not_null<std::array<Variables<TagsList>, Dim>*>
         vars_on_lower_face,
     const gsl::not_null<std::array<Variables<TagsList>, Dim>*>
         vars_on_upper_face,
     const Variables<prims_tags>& volume_prims,
-    const EquationsOfState::EquationOfState<false, ThermodynamicDim>& eos,
+    const EquationsOfState::EquationOfState<false, 2>& eos,
     const Element<Dim>& element,
     const DirectionalIdMap<Dim, evolution::dg::subcell::GhostData>& ghost_data,
     const Mesh<Dim>& subcell_mesh) const {
@@ -69,11 +69,11 @@ void MonotonisedCentralPrim<Dim>::reconstruct(
 }
 
 template <size_t Dim>
-template <size_t ThermodynamicDim, typename TagsList>
+template <typename TagsList>
 void MonotonisedCentralPrim<Dim>::reconstruct_fd_neighbor(
     const gsl::not_null<Variables<TagsList>*> vars_on_face,
     const Variables<prims_tags>& subcell_volume_prims,
-    const EquationsOfState::EquationOfState<false, ThermodynamicDim>& eos,
+    const EquationsOfState::EquationOfState<false, 2>& eos,
     const Element<Dim>& element,
     const DirectionalIdMap<Dim, evolution::dg::subcell::GhostData>& ghost_data,
     const Mesh<Dim>& subcell_mesh,
@@ -111,7 +111,6 @@ void MonotonisedCentralPrim<Dim>::reconstruct_fd_neighbor(
 }
 
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
-#define THERMO_DIM(data) BOOST_PP_TUPLE_ELEM(1, data)
 #define TAGS_LIST(data)                                                     \
   tmpl::list<Tags::MassDensityCons, Tags::MomentumDensity<DIM(data)>,       \
              Tags::EnergyDensity, hydro::Tags::RestMassDensity<DataVector>, \
@@ -129,32 +128,31 @@ void MonotonisedCentralPrim<Dim>::reconstruct_fd_neighbor(
 GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
 #undef INSTANTIATION
 
-#define INSTANTIATION(r, data)                                               \
-  template void MonotonisedCentralPrim<DIM(data)>::reconstruct(              \
-      gsl::not_null<std::array<Variables<TAGS_LIST(data)>, DIM(data)>*>      \
-          vars_on_lower_face,                                                \
-      gsl::not_null<std::array<Variables<TAGS_LIST(data)>, DIM(data)>*>      \
-          vars_on_upper_face,                                                \
-      const Variables<prims_tags>& volume_prims,                             \
-      const EquationsOfState::EquationOfState<false, THERMO_DIM(data)>& eos, \
-      const Element<DIM(data)>& element,                                     \
-      const DirectionalIdMap<DIM(data), evolution::dg::subcell::GhostData>&  \
-          ghost_data,                                                        \
-      const Mesh<DIM(data)>& subcell_mesh) const;                            \
-  template void MonotonisedCentralPrim<DIM(data)>::reconstruct_fd_neighbor(  \
-      gsl::not_null<Variables<TAGS_LIST(data)>*> vars_on_face,               \
-      const Variables<prims_tags>& subcell_volume_prims,                     \
-      const EquationsOfState::EquationOfState<false, THERMO_DIM(data)>& eos, \
-      const Element<DIM(data)>& element,                                     \
-      const DirectionalIdMap<DIM(data), evolution::dg::subcell::GhostData>&  \
-          ghost_data,                                                        \
-      const Mesh<DIM(data)>& subcell_mesh,                                   \
+#define INSTANTIATION(r, data)                                              \
+  template void MonotonisedCentralPrim<DIM(data)>::reconstruct(             \
+      gsl::not_null<std::array<Variables<TAGS_LIST(data)>, DIM(data)>*>     \
+          vars_on_lower_face,                                               \
+      gsl::not_null<std::array<Variables<TAGS_LIST(data)>, DIM(data)>*>     \
+          vars_on_upper_face,                                               \
+      const Variables<prims_tags>& volume_prims,                            \
+      const EquationsOfState::EquationOfState<false, 2>& eos,               \
+      const Element<DIM(data)>& element,                                    \
+      const DirectionalIdMap<DIM(data), evolution::dg::subcell::GhostData>& \
+          ghost_data,                                                       \
+      const Mesh<DIM(data)>& subcell_mesh) const;                           \
+  template void MonotonisedCentralPrim<DIM(data)>::reconstruct_fd_neighbor( \
+      gsl::not_null<Variables<TAGS_LIST(data)>*> vars_on_face,              \
+      const Variables<prims_tags>& subcell_volume_prims,                    \
+      const EquationsOfState::EquationOfState<false, 2>& eos,               \
+      const Element<DIM(data)>& element,                                    \
+      const DirectionalIdMap<DIM(data), evolution::dg::subcell::GhostData>& \
+          ghost_data,                                                       \
+      const Mesh<DIM(data)>& subcell_mesh,                                  \
       const Direction<DIM(data)> direction_to_reconstruct) const;
 
-GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3), (1, 2))
+GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
 
 #undef INSTANTIATION
 #undef TAGS_LIST
-#undef THERMO_DIM
 #undef DIM
 }  // namespace NewtonianEuler::fd

--- a/src/Evolution/Systems/NewtonianEuler/FiniteDifference/MonotonisedCentral.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/FiniteDifference/MonotonisedCentral.hpp
@@ -99,16 +99,17 @@ class MonotonisedCentralPrim : public Reconstructor<Dim> {
 
   using reconstruction_argument_tags =
       tmpl::list<::Tags::Variables<prims_tags>,
-                 hydro::Tags::EquationOfStateBase, domain::Tags::Element<Dim>,
+                 hydro::Tags::EquationOfState<false, 2>,
+                 domain::Tags::Element<Dim>,
                  evolution::dg::subcell::Tags::GhostDataForReconstruction<Dim>,
                  evolution::dg::subcell::Tags::Mesh<Dim>>;
 
-  template <size_t ThermodynamicDim, typename TagsList>
+  template <typename TagsList>
   void reconstruct(
       gsl::not_null<std::array<Variables<TagsList>, Dim>*> vars_on_lower_face,
       gsl::not_null<std::array<Variables<TagsList>, Dim>*> vars_on_upper_face,
       const Variables<prims_tags>& volume_prims,
-      const EquationsOfState::EquationOfState<false, ThermodynamicDim>& eos,
+      const EquationsOfState::EquationOfState<false, 2>& eos,
       const Element<Dim>& element,
       const DirectionalIdMap<Dim, evolution::dg::subcell::GhostData>&
           ghost_data,
@@ -120,11 +121,11 @@ class MonotonisedCentralPrim : public Reconstructor<Dim> {
   /// neighbor would have sent had we instead used a two a two-communication
   /// subcell solver (first communication for reconstruction, second for
   /// fluxes).
-  template <size_t ThermodynamicDim, typename TagsList>
+  template <typename TagsList>
   void reconstruct_fd_neighbor(
       gsl::not_null<Variables<TagsList>*> vars_on_face,
       const Variables<prims_tags>& subcell_volume_prims,
-      const EquationsOfState::EquationOfState<false, ThermodynamicDim>& eos,
+      const EquationsOfState::EquationOfState<false, 2>& eos,
       const Element<Dim>& element,
       const DirectionalIdMap<Dim, evolution::dg::subcell::GhostData>&
           ghost_data,

--- a/src/Evolution/Systems/NewtonianEuler/FiniteDifference/ReconstructWork.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/FiniteDifference/ReconstructWork.hpp
@@ -40,13 +40,12 @@ namespace NewtonianEuler::fd {
  * the specific internal energy and conserved variables. All results are written
  * into `vars_on_lower_face` and `vars_on_upper_face`.
  */
-template <typename PrimsTags, typename TagsList, size_t Dim,
-          size_t ThermodynamicDim, typename F>
+template <typename PrimsTags, typename TagsList, size_t Dim, typename F>
 void reconstruct_prims_work(
     gsl::not_null<std::array<Variables<TagsList>, Dim>*> vars_on_lower_face,
     gsl::not_null<std::array<Variables<TagsList>, Dim>*> vars_on_upper_face,
     const F& reconstruct, const Variables<PrimsTags>& volume_prims,
-    const EquationsOfState::EquationOfState<false, ThermodynamicDim>& eos,
+    const EquationsOfState::EquationOfState<false, 2>& eos,
     const Element<Dim>& element,
     const DirectionalIdMap<Dim, evolution::dg::subcell::GhostData>& ghost_data,
     const Mesh<Dim>& subcell_mesh, size_t ghost_zone_size);
@@ -59,13 +58,13 @@ void reconstruct_prims_work(
  * This is used on DG elements to reconstruct their subcell neighbors' solution
  * on the shared faces.
  */
-template <typename TagsList, typename PrimsTags, size_t Dim,
-          size_t ThermodynamicDim, typename F0, typename F1>
+template <typename TagsList, typename PrimsTags, size_t Dim, typename F0,
+          typename F1>
 void reconstruct_fd_neighbor_work(
     gsl::not_null<Variables<TagsList>*> vars_on_face,
     const F0& reconstruct_lower_neighbor, const F1& reconstruct_upper_neighbor,
     const Variables<PrimsTags>& subcell_volume_prims,
-    const EquationsOfState::EquationOfState<false, ThermodynamicDim>& eos,
+    const EquationsOfState::EquationOfState<false, 2>& eos,
     const Element<Dim>& element,
     const DirectionalIdMap<Dim, evolution::dg::subcell::GhostData>& ghost_data,
     const Mesh<Dim>& subcell_mesh,

--- a/src/Evolution/Systems/NewtonianEuler/Limiters/CharacteristicHelpers.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/Limiters/CharacteristicHelpers.hpp
@@ -34,13 +34,12 @@ namespace NewtonianEuler::Limiters {
  * Wraps calls to `NewtonianEuler::right_eigenvectors` and
  * `NewtonianEuler::left_eigenvectors`.
  */
-template <size_t VolumeDim, size_t ThermodynamicDim>
+template <size_t VolumeDim>
 std::pair<Matrix, Matrix> right_and_left_eigenvectors(
     const Scalar<double>& mean_density,
     const tnsr::I<double, VolumeDim>& mean_momentum,
     const Scalar<double>& mean_energy,
-    const EquationsOfState::EquationOfState<false, ThermodynamicDim>&
-        equation_of_state,
+    const EquationsOfState::EquationOfState<false, 2>& equation_of_state,
     const tnsr::i<double, VolumeDim>& unit_vector,
     bool compute_char_transformation_numerically = false);
 
@@ -138,14 +137,13 @@ void conserved_fields_from_characteristic_fields(
 /// The limiter to apply is passed in via a lambda which is responsible for
 /// converting any neighbor data to the characteristic representation, and then
 /// applying the limiter to all NewtonianEuler characteristic fields.
-template <size_t VolumeDim, size_t ThermodynamicDim, typename LimiterLambda>
+template <size_t VolumeDim, typename LimiterLambda>
 bool apply_limiter_to_characteristic_fields_in_all_directions(
     const gsl::not_null<Scalar<DataVector>*> mass_density_cons,
     const gsl::not_null<tnsr::I<DataVector, VolumeDim>*> momentum_density,
     const gsl::not_null<Scalar<DataVector>*> energy_density,
     const Mesh<VolumeDim>& mesh,
-    const EquationsOfState::EquationOfState<false, ThermodynamicDim>&
-        equation_of_state,
+    const EquationsOfState::EquationOfState<false, 2>& equation_of_state,
     const LimiterLambda& prepare_and_apply_limiter,
     const bool compute_char_transformation_numerically = false) {
   // Temp variables for calculations

--- a/src/Evolution/Systems/NewtonianEuler/Limiters/Flattener.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/Limiters/Flattener.hpp
@@ -53,14 +53,13 @@ enum class FlattenerAction {
 /// (this is equivalent to \f$\theta = 0\f$ in the scaling form above).
 /// In principle, a less aggressive scaling could be used, but solving for the
 /// correct \f$\theta\f$ in this case is more involved.
-template <size_t VolumeDim, size_t ThermodynamicDim>
+template <size_t VolumeDim>
 FlattenerAction flatten_solution(
     gsl::not_null<Scalar<DataVector>*> mass_density_cons,
     gsl::not_null<tnsr::I<DataVector, VolumeDim>*> momentum_density,
     gsl::not_null<Scalar<DataVector>*> energy_density,
     const Mesh<VolumeDim>& mesh,
     const Scalar<DataVector>& det_logical_to_inertial_jacobian,
-    const EquationsOfState::EquationOfState<false, ThermodynamicDim>&
-        equation_of_state);
+    const EquationsOfState::EquationOfState<false, 2>& equation_of_state);
 
 }  // namespace NewtonianEuler::Limiters

--- a/src/Evolution/Systems/NewtonianEuler/Limiters/Minmod.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/Limiters/Minmod.hpp
@@ -151,7 +151,6 @@ class Minmod {
       ::hydro::Tags::EquationOfStateBase>;
 
   /// \brief Limits the solution on the element.
-  template <size_t ThermodynamicDim>
   bool operator()(
       gsl::not_null<Scalar<DataVector>*> mass_density_cons,
       gsl::not_null<tnsr::I<DataVector, VolumeDim>*> momentum_density,
@@ -161,8 +160,7 @@ class Minmod {
           logical_coords,
       const std::array<double, VolumeDim>& element_size,
       const Scalar<DataVector>& det_inv_logical_to_inertial_jacobian,
-      const EquationsOfState::EquationOfState<false, ThermodynamicDim>&
-          equation_of_state,
+      const EquationsOfState::EquationOfState<false, 2>& equation_of_state,
       const std::unordered_map<DirectionalId<VolumeDim>, PackagedData,
                                boost::hash<DirectionalId<VolumeDim>>>&
           neighbor_data) const;

--- a/src/Evolution/Systems/NewtonianEuler/Limiters/Minmod.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/Limiters/Minmod.hpp
@@ -148,7 +148,7 @@ class Minmod {
       domain::Tags::Coordinates<VolumeDim, Frame::ElementLogical>,
       domain::Tags::SizeOfElement<VolumeDim>,
       domain::Tags::DetInvJacobian<Frame::ElementLogical, Frame::Inertial>,
-      ::hydro::Tags::EquationOfStateBase>;
+      ::hydro::Tags::EquationOfState<false, 2>>;
 
   /// \brief Limits the solution on the element.
   bool operator()(

--- a/src/Evolution/Systems/NewtonianEuler/Limiters/Weno.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/Limiters/Weno.hpp
@@ -167,7 +167,7 @@ class Weno {
       domain::Tags::SizeOfElement<VolumeDim>,
       domain::Tags::DetInvJacobian<Frame::ElementLogical, Frame::Inertial>,
       evolution::dg::Tags::NormalCovectorAndMagnitude<VolumeDim>,
-      ::hydro::Tags::EquationOfStateBase>;
+      ::hydro::Tags::EquationOfState<false, 2>>;
 
   /// \brief Limit the solution on the element
   bool operator()(

--- a/src/Evolution/Systems/NewtonianEuler/Limiters/Weno.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/Limiters/Weno.hpp
@@ -170,7 +170,6 @@ class Weno {
       ::hydro::Tags::EquationOfStateBase>;
 
   /// \brief Limit the solution on the element
-  template <size_t ThermodynamicDim>
   bool operator()(
       gsl::not_null<Scalar<DataVector>*> mass_density_cons,
       gsl::not_null<tnsr::I<DataVector, VolumeDim>*> momentum_density,
@@ -180,8 +179,7 @@ class Weno {
       const Scalar<DataVector>& det_inv_logical_to_inertial_jacobian,
       const typename evolution::dg::Tags::NormalCovectorAndMagnitude<
           VolumeDim>::type& normals_and_magnitudes,
-      const EquationsOfState::EquationOfState<false, ThermodynamicDim>&
-          equation_of_state,
+      const EquationsOfState::EquationOfState<false, 2>& equation_of_state,
       const std::unordered_map<DirectionalId<VolumeDim>, PackagedData,
                                boost::hash<DirectionalId<VolumeDim>>>&
           neighbor_data) const;

--- a/src/Evolution/Systems/NewtonianEuler/PrimitiveFromConservative.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/PrimitiveFromConservative.hpp
@@ -50,7 +50,7 @@ struct PrimitiveFromConservative {
 
   using argument_tags =
       tmpl::list<Tags::MassDensityCons, Tags::MomentumDensity<Dim>,
-                 Tags::EnergyDensity, hydro::Tags::EquationOfStateBase>;
+                 Tags::EnergyDensity, hydro::Tags::EquationOfState<false, 2>>;
 
   template <size_t ThermodynamicDim>
   static void apply(

--- a/src/Evolution/Systems/NewtonianEuler/SoundSpeedSquared.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/SoundSpeedSquared.hpp
@@ -67,7 +67,7 @@ struct SoundSpeedSquaredCompute : hydro::Tags::SoundSpeedSquared<DataType>,
   using argument_tags =
       tmpl::list<hydro::Tags::RestMassDensity<DataType>,
                  hydro::Tags::SpecificInternalEnergy<DataType>,
-                 hydro::Tags::EquationOfStateBase>;
+                 hydro::Tags::EquationOfState<false, 2>>;
 
   using return_type = Scalar<DataType>;
 

--- a/src/Evolution/Systems/NewtonianEuler/Subcell/NeighborPackagedData.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/Subcell/NeighborPackagedData.hpp
@@ -126,7 +126,7 @@ struct NeighborPackagedData {
                          dg_package_data_temporary_tags>;
 
         const auto& element = db::get<domain::Tags::Element<Dim>>(box);
-        const auto& eos = get<hydro::Tags::EquationOfStateBase>(box);
+        const auto& eos = get<hydro::Tags::EquationOfState<false, 2>>(box);
 
         using dg_package_field_tags =
             typename DerivedCorrection::dg_package_field_tags;

--- a/src/Evolution/Systems/NewtonianEuler/Subcell/PrimsAfterRollback.cpp
+++ b/src/Evolution/Systems/NewtonianEuler/Subcell/PrimsAfterRollback.cpp
@@ -18,7 +18,6 @@
 
 namespace NewtonianEuler::subcell {
 template <size_t Dim>
-template <size_t ThermodynamicDim>
 void PrimsAfterRollback<Dim>::apply(
     const gsl::not_null<Variables<
         tmpl::list<MassDensity, Velocity, SpecificInternalEnergy, Pressure>>*>
@@ -27,8 +26,7 @@ void PrimsAfterRollback<Dim>::apply(
     const Scalar<DataVector>& mass_density_cons,
     const tnsr::I<DataVector, Dim>& momentum_density,
     const Scalar<DataVector>& energy_density,
-    const EquationsOfState::EquationOfState<false, ThermodynamicDim>&
-        equation_of_state) {
+    const EquationsOfState::EquationOfState<false, 2>& equation_of_state) {
   if (did_rollback) {
     const size_t num_grid_points = subcell_mesh.number_of_grid_points();
     if (prim_vars->number_of_grid_points() != num_grid_points) {
@@ -47,21 +45,5 @@ void PrimsAfterRollback<Dim>::apply(
 #define INSTANTIATION(r, data) template class PrimsAfterRollback<DIM(data)>;
 GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
 #undef INSTANTIATION
-
-#define THERMO_DIM(data) BOOST_PP_TUPLE_ELEM(1, data)
-#define INSTANTIATION(r, data)                                                \
-  template void PrimsAfterRollback<DIM(data)>::apply<THERMO_DIM(data)>(       \
-      gsl::not_null<Variables<tmpl::list<MassDensity, Velocity,               \
-                                         SpecificInternalEnergy, Pressure>>*> \
-          prim_vars,                                                          \
-      bool did_rollback, const Mesh<DIM(data)>& subcell_mesh,                 \
-      const Scalar<DataVector>& mass_density_cons,                            \
-      const tnsr::I<DataVector, DIM(data)>& momentum_density,                 \
-      const Scalar<DataVector>& energy_density,                               \
-      const EquationsOfState::EquationOfState<false, THERMO_DIM(data)>&       \
-          equation_of_state);
-GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3), (1, 2))
-#undef INSTANTIATION
-#undef THERMO_DIM
 #undef DIM
 }  // namespace NewtonianEuler::subcell

--- a/src/Evolution/Systems/NewtonianEuler/Subcell/PrimsAfterRollback.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/Subcell/PrimsAfterRollback.hpp
@@ -58,7 +58,6 @@ struct PrimsAfterRollback {
                  Tags::MomentumDensity<Dim>, Tags::EnergyDensity,
                  hydro::Tags::EquationOfStateBase>;
 
-  template <size_t ThermodynamicDim>
   static void apply(
       gsl::not_null<Variables<
           tmpl::list<MassDensity, Velocity, SpecificInternalEnergy, Pressure>>*>
@@ -67,7 +66,6 @@ struct PrimsAfterRollback {
       const Scalar<DataVector>& mass_density_cons,
       const tnsr::I<DataVector, Dim>& momentum_density,
       const Scalar<DataVector>& energy_density,
-      const EquationsOfState::EquationOfState<false, ThermodynamicDim>&
-          equation_of_state);
+      const EquationsOfState::EquationOfState<false, 2>& equation_of_state);
 };
 }  // namespace NewtonianEuler::subcell

--- a/src/Evolution/Systems/NewtonianEuler/Subcell/PrimsAfterRollback.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/Subcell/PrimsAfterRollback.hpp
@@ -56,7 +56,7 @@ struct PrimsAfterRollback {
       tmpl::list<evolution::dg::subcell::Tags::DidRollback,
                  evolution::dg::subcell::Tags::Mesh<Dim>, Tags::MassDensityCons,
                  Tags::MomentumDensity<Dim>, Tags::EnergyDensity,
-                 hydro::Tags::EquationOfStateBase>;
+                 hydro::Tags::EquationOfState<false, 2>>;
 
   static void apply(
       gsl::not_null<Variables<

--- a/src/Evolution/Systems/NewtonianEuler/Subcell/ResizeAndComputePrimitives.cpp
+++ b/src/Evolution/Systems/NewtonianEuler/Subcell/ResizeAndComputePrimitives.cpp
@@ -18,7 +18,6 @@
 
 namespace NewtonianEuler::subcell {
 template <size_t Dim>
-template <size_t ThermodynamicDim>
 void ResizeAndComputePrims<Dim>::apply(
     const gsl::not_null<Variables<
         tmpl::list<MassDensity, Velocity, SpecificInternalEnergy, Pressure>>*>
@@ -28,8 +27,7 @@ void ResizeAndComputePrims<Dim>::apply(
     const Scalar<DataVector>& mass_density_cons,
     const tnsr::I<DataVector, Dim>& momentum_density,
     const Scalar<DataVector>& energy_density,
-    const EquationsOfState::EquationOfState<false, ThermodynamicDim>&
-        equation_of_state) {
+    const EquationsOfState::EquationOfState<false, 2>& equation_of_state) {
   const size_t num_grid_points =
       (active_grid == evolution::dg::subcell::ActiveGrid::Dg ? dg_mesh
                                                              : subcell_mesh)
@@ -49,22 +47,5 @@ void ResizeAndComputePrims<Dim>::apply(
 #define INSTANTIATION(r, data) template class ResizeAndComputePrims<DIM(data)>;
 GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
 #undef INSTANTIATION
-
-#define THERMO_DIM(data) BOOST_PP_TUPLE_ELEM(1, data)
-#define INSTANTIATION(r, data)                                                \
-  template void ResizeAndComputePrims<DIM(data)>::apply<THERMO_DIM(data)>(    \
-      gsl::not_null<Variables<tmpl::list<MassDensity, Velocity,               \
-                                         SpecificInternalEnergy, Pressure>>*> \
-          prim_vars,                                                          \
-      evolution::dg::subcell::ActiveGrid active_grid,                         \
-      const Mesh<DIM(data)>& dg_mesh, const Mesh<DIM(data)>& subcell_mesh,    \
-      const Scalar<DataVector>& mass_density_cons,                            \
-      const tnsr::I<DataVector, DIM(data)>& momentum_density,                 \
-      const Scalar<DataVector>& energy_density,                               \
-      const EquationsOfState::EquationOfState<false, THERMO_DIM(data)>&       \
-          equation_of_state);
-GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3), (1, 2))
-#undef INSTANTIATION
-#undef THERMO_DIM
 #undef DIM
 }  // namespace NewtonianEuler::subcell

--- a/src/Evolution/Systems/NewtonianEuler/Subcell/ResizeAndComputePrimitives.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/Subcell/ResizeAndComputePrimitives.hpp
@@ -64,7 +64,6 @@ struct ResizeAndComputePrims {
                  Tags::MomentumDensity<Dim>, Tags::EnergyDensity,
                  hydro::Tags::EquationOfStateBase>;
 
-  template <size_t ThermodynamicDim>
   static void apply(
       gsl::not_null<Variables<
           tmpl::list<MassDensity, Velocity, SpecificInternalEnergy, Pressure>>*>
@@ -74,7 +73,6 @@ struct ResizeAndComputePrims {
       const Scalar<DataVector>& mass_density_cons,
       const tnsr::I<DataVector, Dim>& momentum_density,
       const Scalar<DataVector>& energy_density,
-      const EquationsOfState::EquationOfState<false, ThermodynamicDim>&
-          equation_of_state);
+      const EquationsOfState::EquationOfState<false, 2>& equation_of_state);
 };
 }  // namespace NewtonianEuler::subcell

--- a/src/Evolution/Systems/NewtonianEuler/Subcell/ResizeAndComputePrimitives.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/Subcell/ResizeAndComputePrimitives.hpp
@@ -62,7 +62,7 @@ struct ResizeAndComputePrims {
                  domain::Tags::Mesh<Dim>,
                  evolution::dg::subcell::Tags::Mesh<Dim>, Tags::MassDensityCons,
                  Tags::MomentumDensity<Dim>, Tags::EnergyDensity,
-                 hydro::Tags::EquationOfStateBase>;
+                 hydro::Tags::EquationOfState<false, 2>>;
 
   static void apply(
       gsl::not_null<Variables<

--- a/src/Evolution/Systems/NewtonianEuler/Subcell/TciOnDgGrid.cpp
+++ b/src/Evolution/Systems/NewtonianEuler/Subcell/TciOnDgGrid.cpp
@@ -21,14 +21,13 @@
 
 namespace NewtonianEuler::subcell {
 template <size_t Dim>
-template <size_t ThermodynamicDim>
 std::tuple<bool, evolution::dg::subcell::RdmpTciData> TciOnDgGrid<Dim>::apply(
     const gsl::not_null<Variables<
         tmpl::list<MassDensity, Velocity, SpecificInternalEnergy, Pressure>>*>
         dg_prim_vars,
     const Variables<
         tmpl::list<MassDensityCons, MomentumDensity, EnergyDensity>>& dg_vars,
-    const EquationsOfState::EquationOfState<false, ThermodynamicDim>& eos,
+    const EquationsOfState::EquationOfState<false, 2>& eos,
     const Mesh<Dim>& dg_mesh, const Mesh<Dim>& subcell_mesh,
     const evolution::dg::subcell::RdmpTciData& past_rdmp_tci_data,
     const evolution::dg::subcell::SubcellOptions& subcell_options,
@@ -84,25 +83,5 @@ std::tuple<bool, evolution::dg::subcell::RdmpTciData> TciOnDgGrid<Dim>::apply(
 #define INSTANTIATION(r, data) template class TciOnDgGrid<DIM(data)>;
 GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
 #undef INSTANTIATION
-
-#define THERMO_DIM(data) BOOST_PP_TUPLE_ELEM(1, data)
-#define INSTANTIATION(r, data)                                                \
-  template std::tuple<bool, evolution::dg::subcell::RdmpTciData>              \
-  TciOnDgGrid<DIM(data)>::apply<THERMO_DIM(data)>(                            \
-      gsl::not_null<Variables<tmpl::list<MassDensity, Velocity,               \
-                                         SpecificInternalEnergy, Pressure>>*> \
-          dg_prim_vars,                                                       \
-      const Variables<                                                        \
-          tmpl::list<NewtonianEuler::Tags::MassDensityCons,                   \
-                     NewtonianEuler::Tags::MomentumDensity<DIM(data)>,        \
-                     NewtonianEuler::Tags::EnergyDensity>>& dg_vars,          \
-      const EquationsOfState::EquationOfState<false, THERMO_DIM(data)>& eos,  \
-      const Mesh<DIM(data)>& dg_mesh, const Mesh<DIM(data)>& subcell_mesh,    \
-      const evolution::dg::subcell::RdmpTciData& past_rdmp_tci_data,          \
-      const evolution::dg::subcell::SubcellOptions& subcell_options,          \
-      double persson_exponent, const bool element_stays_on_dg);
-GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3), (1, 2))
-#undef INSTANTIATION
-#undef THERMO_DIM
 #undef DIM
 }  // namespace NewtonianEuler::subcell

--- a/src/Evolution/Systems/NewtonianEuler/Subcell/TciOnDgGrid.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/Subcell/TciOnDgGrid.hpp
@@ -75,14 +75,13 @@ class TciOnDgGrid {
                  evolution::dg::subcell::Tags::DataForRdmpTci,
                  evolution::dg::subcell::Tags::SubcellOptions<Dim>>;
 
-  template <size_t ThermodynamicDim>
   static std::tuple<bool, evolution::dg::subcell::RdmpTciData> apply(
       gsl::not_null<Variables<
           tmpl::list<MassDensity, Velocity, SpecificInternalEnergy, Pressure>>*>
           dg_prim_vars,
       const Variables<
           tmpl::list<MassDensityCons, MomentumDensity, EnergyDensity>>& dg_vars,
-      const EquationsOfState::EquationOfState<false, ThermodynamicDim>& eos,
+      const EquationsOfState::EquationOfState<false, 2>& eos,
       const Mesh<Dim>& dg_mesh, const Mesh<Dim>& subcell_mesh,
       const evolution::dg::subcell::RdmpTciData& past_rdmp_tci_data,
       const evolution::dg::subcell::SubcellOptions& subcell_options,

--- a/src/Evolution/Systems/NewtonianEuler/Subcell/TciOnDgGrid.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/Subcell/TciOnDgGrid.hpp
@@ -67,13 +67,13 @@ class TciOnDgGrid {
  public:
   using return_tags = tmpl::list<::Tags::Variables<
       tmpl::list<MassDensity, Velocity, SpecificInternalEnergy, Pressure>>>;
-  using argument_tags =
-      tmpl::list<::Tags::Variables<tmpl::list<MassDensityCons, MomentumDensity,
-                                              EnergyDensity>>,
-                 hydro::Tags::EquationOfStateBase, domain::Tags::Mesh<Dim>,
-                 evolution::dg::subcell::Tags::Mesh<Dim>,
-                 evolution::dg::subcell::Tags::DataForRdmpTci,
-                 evolution::dg::subcell::Tags::SubcellOptions<Dim>>;
+  using argument_tags = tmpl::list<
+      ::Tags::Variables<
+          tmpl::list<MassDensityCons, MomentumDensity, EnergyDensity>>,
+      hydro::Tags::EquationOfState<false, 2>, domain::Tags::Mesh<Dim>,
+      evolution::dg::subcell::Tags::Mesh<Dim>,
+      evolution::dg::subcell::Tags::DataForRdmpTci,
+      evolution::dg::subcell::Tags::SubcellOptions<Dim>>;
 
   static std::tuple<bool, evolution::dg::subcell::RdmpTciData> apply(
       gsl::not_null<Variables<

--- a/src/Evolution/Systems/NewtonianEuler/Subcell/TciOnFdGrid.cpp
+++ b/src/Evolution/Systems/NewtonianEuler/Subcell/TciOnFdGrid.cpp
@@ -21,14 +21,13 @@
 
 namespace NewtonianEuler::subcell {
 template <size_t Dim>
-template <size_t ThermodynamicDim>
 std::tuple<bool, evolution::dg::subcell::RdmpTciData> TciOnFdGrid<Dim>::apply(
     const gsl::not_null<Variables<
         tmpl::list<MassDensity, Velocity, SpecificInternalEnergy, Pressure>>*>
         subcell_grid_prim_vars,
     const Variables<tmpl::list<MassDensityCons, MomentumDensity,
                                EnergyDensity>>& subcell_vars,
-    const EquationsOfState::EquationOfState<false, ThermodynamicDim>& eos,
+    const EquationsOfState::EquationOfState<false, 2>& eos,
     const Mesh<Dim>& dg_mesh, const Mesh<Dim>& subcell_mesh,
     const evolution::dg::subcell::RdmpTciData& past_rdmp_tci_data,
     const evolution::dg::subcell::SubcellOptions& subcell_options,
@@ -105,25 +104,5 @@ std::tuple<bool, evolution::dg::subcell::RdmpTciData> TciOnFdGrid<Dim>::apply(
 #define INSTANTIATION(r, data) template class TciOnFdGrid<DIM(data)>;
 GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
 #undef INSTANTIATION
-
-#define THERMO_DIM(data) BOOST_PP_TUPLE_ELEM(1, data)
-#define INSTANTIATION(r, data)                                                \
-  template std::tuple<bool, evolution::dg::subcell::RdmpTciData>              \
-  TciOnFdGrid<DIM(data)>::apply<THERMO_DIM(data)>(                            \
-      gsl::not_null<Variables<tmpl::list<MassDensity, Velocity,               \
-                                         SpecificInternalEnergy, Pressure>>*> \
-          subcell_grid_prim_vars,                                             \
-      const Variables<                                                        \
-          tmpl::list<NewtonianEuler::Tags::MassDensityCons,                   \
-                     NewtonianEuler::Tags::MomentumDensity<DIM(data)>,        \
-                     NewtonianEuler::Tags::EnergyDensity>>& subcell_vars,     \
-      const EquationsOfState::EquationOfState<false, THERMO_DIM(data)>& eos,  \
-      const Mesh<DIM(data)>& dg_mesh, const Mesh<DIM(data)>& subcell_mesh,    \
-      const evolution::dg::subcell::RdmpTciData& past_rdmp_tci_data,          \
-      const evolution::dg::subcell::SubcellOptions& subcell_options,          \
-      double persson_exponent, bool need_rdmp_data_only);
-GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3), (1, 2))
-#undef INSTANTIATION
-#undef THERMO_DIM
 #undef DIM
 }  // namespace NewtonianEuler::subcell

--- a/src/Evolution/Systems/NewtonianEuler/Subcell/TciOnFdGrid.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/Subcell/TciOnFdGrid.hpp
@@ -81,14 +81,13 @@ class TciOnFdGrid {
                  evolution::dg::subcell::Tags::DataForRdmpTci,
                  evolution::dg::subcell::Tags::SubcellOptions<Dim>>;
 
-  template <size_t ThermodynamicDim>
   static std::tuple<bool, evolution::dg::subcell::RdmpTciData> apply(
       gsl::not_null<Variables<
           tmpl::list<MassDensity, Velocity, SpecificInternalEnergy, Pressure>>*>
           subcell_grid_prim_vars,
       const Variables<tmpl::list<MassDensityCons, MomentumDensity,
                                  EnergyDensity>>& subcell_vars,
-      const EquationsOfState::EquationOfState<false, ThermodynamicDim>& eos,
+      const EquationsOfState::EquationOfState<false, 2>& eos,
       const Mesh<Dim>& dg_mesh, const Mesh<Dim>& subcell_mesh,
       const evolution::dg::subcell::RdmpTciData& past_rdmp_tci_data,
       const evolution::dg::subcell::SubcellOptions& subcell_options,

--- a/src/Evolution/Systems/NewtonianEuler/Subcell/TciOnFdGrid.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/Subcell/TciOnFdGrid.hpp
@@ -73,13 +73,13 @@ class TciOnFdGrid {
  public:
   using return_tags = tmpl::list<::Tags::Variables<
       tmpl::list<MassDensity, Velocity, SpecificInternalEnergy, Pressure>>>;
-  using argument_tags =
-      tmpl::list<::Tags::Variables<tmpl::list<MassDensityCons, MomentumDensity,
-                                              EnergyDensity>>,
-                 hydro::Tags::EquationOfStateBase, domain::Tags::Mesh<Dim>,
-                 evolution::dg::subcell::Tags::Mesh<Dim>,
-                 evolution::dg::subcell::Tags::DataForRdmpTci,
-                 evolution::dg::subcell::Tags::SubcellOptions<Dim>>;
+  using argument_tags = tmpl::list<
+      ::Tags::Variables<
+          tmpl::list<MassDensityCons, MomentumDensity, EnergyDensity>>,
+      hydro::Tags::EquationOfState<false, 2>, domain::Tags::Mesh<Dim>,
+      evolution::dg::subcell::Tags::Mesh<Dim>,
+      evolution::dg::subcell::Tags::DataForRdmpTci,
+      evolution::dg::subcell::Tags::SubcellOptions<Dim>>;
 
   static std::tuple<bool, evolution::dg::subcell::RdmpTciData> apply(
       gsl::not_null<Variables<

--- a/src/Evolution/Systems/NewtonianEuler/Subcell/TimeDerivative.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/Subcell/TimeDerivative.hpp
@@ -231,16 +231,14 @@ struct TimeDerivative {
         [&num_pts, &boundary_corrections, &subcell_mesh, &one_over_delta_xi,
          &cell_centered_logical_to_grid_inv_jacobian =
              db::get<evolution::dg::subcell::fd::Tags::
-                         InverseJacobianLogicalToGrid<Dim>>(
-                 *box)]<size_t ThermodynamicDim>(
+                         InverseJacobianLogicalToGrid<Dim>>(*box)](
             const auto dt_vars_ptr, const Scalar<DataVector>& mass_density_cons,
             const tnsr::I<DataVector, Dim>& momentum_density,
             const Scalar<DataVector>& energy_density,
             const tnsr::I<DataVector, Dim>& velocity,
             const Scalar<DataVector>& pressure,
             const Scalar<DataVector>& specific_internal_energy,
-            const EquationsOfState::EquationOfState<false, ThermodynamicDim>&
-                eos,
+            const EquationsOfState::EquationOfState<false, 2>& eos,
             const tnsr::I<DataVector, Dim>& coords, const double time,
             const Sources::Source<Dim>& source) {
           dt_vars_ptr->initialize(num_pts, 0.0);

--- a/src/Evolution/Systems/NewtonianEuler/Subcell/TimeDerivative.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/Subcell/TimeDerivative.hpp
@@ -224,7 +224,7 @@ struct TimeDerivative {
         hydro::Tags::SpatialVelocity<DataVector, Dim>,
         hydro::Tags::Pressure<DataVector>,
         hydro::Tags::SpecificInternalEnergy<DataVector>,
-        hydro::Tags::EquationOfStateBase,
+        hydro::Tags::EquationOfState<false, 2>,
         evolution::dg::subcell::Tags::Coordinates<Dim, Frame::Inertial>,
         ::Tags::Time, NewtonianEuler::Tags::SourceTerm<Dim>>;
     db::mutate_apply<tmpl::list<dt_variables_tag>, source_argument_tags>(

--- a/src/Evolution/Systems/NewtonianEuler/TimeDerivativeTerms.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/TimeDerivativeTerms.hpp
@@ -56,11 +56,10 @@ struct TimeDerivativeTerms {
                  hydro::Tags::SpatialVelocity<DataVector, Dim>,
                  hydro::Tags::Pressure<DataVector>,
                  hydro::Tags::SpecificInternalEnergy<DataVector>,
-                 hydro::Tags::EquationOfStateBase,
+                 hydro::Tags::EquationOfState<false, 2>,
                  domain::Tags::Coordinates<Dim, Frame::Inertial>, ::Tags::Time,
                  NewtonianEuler::Tags::SourceTerm<Dim>>;
 
-  template <size_t ThermodynamicDim>
   static void apply(
       // Time derivatives returned by reference. All the tags in the
       // variables_tag in the system struct.
@@ -85,7 +84,7 @@ struct TimeDerivativeTerms {
       const tnsr::I<DataVector, Dim>& velocity,
       const Scalar<DataVector>& pressure,
       const Scalar<DataVector>& specific_internal_energy,
-      const EquationsOfState::EquationOfState<false, ThermodynamicDim>& eos,
+      const EquationsOfState::EquationOfState<false, 2>& eos,
       const tnsr::I<DataVector, Dim>& coords, const double time,
       const Sources::Source<Dim>& source) {
     detail::fluxes_impl(mass_density_cons_flux, momentum_density_flux,

--- a/src/Evolution/Systems/NewtonianEuler/VolumeTermsInstantiation.cpp
+++ b/src/Evolution/Systems/NewtonianEuler/VolumeTermsInstantiation.cpp
@@ -1,14 +1,12 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
-#include <boost/preprocessor/control/if.hpp>
+#include <optional>
 
 #include "DataStructures/DataBox/PrefixHelpers.hpp"
 #include "DataStructures/DataBox/Prefixes.hpp"
 #include "Evolution/DiscontinuousGalerkin/Actions/VolumeTermsImpl.tpp"
 #include "Evolution/Systems/NewtonianEuler/System.hpp"
-#include "Evolution/Systems/NewtonianEuler/TimeDerivativeTerms.hpp"
-#include "PointwiseFunctions/AnalyticData/NewtonianEuler/KhInstability.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 
 namespace evolution::dg::Actions::detail {

--- a/src/Evolution/Systems/NewtonianEuler/VolumeTermsInstantiation.cpp
+++ b/src/Evolution/Systems/NewtonianEuler/VolumeTermsInstantiation.cpp
@@ -11,7 +11,6 @@
 
 namespace evolution::dg::Actions::detail {
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
-#define TDIM(data) BOOST_PP_TUPLE_ELEM(1, data)
 
 #define INSTANTIATION(r, data)                                                \
   template void                                                               \
@@ -58,11 +57,11 @@ namespace evolution::dg::Actions::detail {
       const tnsr::I<DataVector, DIM(data)>& velocity,                         \
       const Scalar<DataVector>& pressure,                                     \
       const Scalar<DataVector>& specific_internal_energy,                     \
-      const EquationsOfState::EquationOfState<false, TDIM(data)>& eos,        \
+      const EquationsOfState::EquationOfState<false, 2>& eos,                 \
       const tnsr::I<DataVector, DIM(data)>& coords, const double& time,       \
       const ::NewtonianEuler::Sources::Source<DIM(data)>& source);
 
-GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3), (1, 2))
+GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
 
 #undef INSTANTIATION
 #undef SYSTEM

--- a/tests/InputFiles/NewtonianEuler/RiemannProblem1D.yaml
+++ b/tests/InputFiles/NewtonianEuler/RiemannProblem1D.yaml
@@ -1,7 +1,7 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-Executable: EvolveNewtonianEulerRiemannProblem1D
+Executable: EvolveNewtonianEuler1D
 Testing:
   Check: parse;execute
 

--- a/tests/InputFiles/NewtonianEuler/RiemannProblem2D.yaml
+++ b/tests/InputFiles/NewtonianEuler/RiemannProblem2D.yaml
@@ -1,7 +1,7 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-Executable: EvolveNewtonianEulerRiemannProblem2D
+Executable: EvolveNewtonianEuler2D
 Testing:
   Check: parse;execute
 

--- a/tests/InputFiles/NewtonianEuler/RiemannProblem3D.yaml
+++ b/tests/InputFiles/NewtonianEuler/RiemannProblem3D.yaml
@@ -1,7 +1,7 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-Executable: EvolveNewtonianEulerRiemannProblem3D
+Executable: EvolveNewtonianEuler3D
 Testing:
   Check: parse;execute
   Priority: High

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/BoundaryCorrections/Test_Hll.cpp
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/BoundaryCorrections/Test_Hll.cpp
@@ -24,28 +24,6 @@
 #include "Utilities/TaggedTuple.hpp"
 
 namespace {
-struct ConvertPolytropic {
-  using unpacked_container = bool;
-  using packed_container = EquationsOfState::EquationOfState<false, 1>;
-  using packed_type = bool;
-
-  static inline unpacked_container unpack(const packed_container& /*packed*/,
-                                          const size_t /*grid_point_index*/) {
-    return true;
-  }
-
-  [[noreturn]] static inline void pack(
-      const gsl::not_null<packed_container*> /*packed*/,
-      const unpacked_container& /*unpacked*/,
-      const size_t /*grid_point_index*/) {
-    ERROR("Should not be converting an EOS from an unpacked to a packed type");
-  }
-
-  static inline size_t get_size(const packed_container& /*packed*/) {
-    return 1;
-  }
-};
-
 struct ConvertIdeal {
   using unpacked_container = bool;
   using packed_container = EquationsOfState::EquationOfState<false, 2>;
@@ -95,8 +73,8 @@ void test(const gsl::not_null<std::mt19937*> gen, const size_t num_pts,
                     Spectral::Quadrature::Gauss},
       volume_data, ranges);
 
-  helpers::test_boundary_correction_with_python<
-      NewtonianEuler::System<Dim>, tmpl::list<ConvertPolytropic, ConvertIdeal>>(
+  helpers::test_boundary_correction_with_python<NewtonianEuler::System<Dim>,
+                                                tmpl::list<ConvertIdeal>>(
       gen, "Hll", "dg_package_data", "dg_boundary_terms",
       NewtonianEuler::BoundaryCorrections::Hll<Dim>{},
       Mesh<Dim - 1>{num_pts, Spectral::Basis::Legendre,
@@ -106,8 +84,8 @@ void test(const gsl::not_null<std::mt19937*> gen, const size_t num_pts,
   const auto hll = TestHelpers::test_creation<std::unique_ptr<
       NewtonianEuler::BoundaryCorrections::BoundaryCorrection<Dim>>>("Hll:");
 
-  helpers::test_boundary_correction_with_python<
-      NewtonianEuler::System<Dim>, tmpl::list<ConvertPolytropic, ConvertIdeal>>(
+  helpers::test_boundary_correction_with_python<NewtonianEuler::System<Dim>,
+                                                tmpl::list<ConvertIdeal>>(
       gen, "Hll", "dg_package_data", "dg_boundary_terms",
       dynamic_cast<const NewtonianEuler::BoundaryCorrections::Hll<Dim>&>(*hll),
       Mesh<Dim - 1>{num_pts, Spectral::Basis::Legendre,
@@ -125,13 +103,6 @@ SPECTRE_TEST_CASE("Unit.NewtonianEuler.BoundaryCorrections.Hll",
   pypp::SetupLocalPythonEnvironment local_python_env{
       "Evolution/Systems/NewtonianEuler/BoundaryCorrections"};
   MAKE_GENERATOR(gen);
-
-  test<1>(make_not_null(&gen), 1,
-          EquationsOfState::PolytropicFluid<false>{1.0e-3, 2.0});
-  test<2>(make_not_null(&gen), 5,
-          EquationsOfState::PolytropicFluid<false>{1.0e-3, 2.0});
-  test<3>(make_not_null(&gen), 5,
-          EquationsOfState::PolytropicFluid<false>{1.0e-3, 2.0});
 
   test<1>(make_not_null(&gen), 1, EquationsOfState::IdealFluid<false>{1.3});
   test<2>(make_not_null(&gen), 5, EquationsOfState::IdealFluid<false>{1.3});

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/BoundaryCorrections/Test_Hllc.cpp
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/BoundaryCorrections/Test_Hllc.cpp
@@ -24,28 +24,6 @@
 #include "Utilities/TaggedTuple.hpp"
 
 namespace {
-struct ConvertPolytropic {
-  using unpacked_container = bool;
-  using packed_container = EquationsOfState::EquationOfState<false, 1>;
-  using packed_type = bool;
-
-  static inline unpacked_container unpack(const packed_container& /*packed*/,
-                                          const size_t /*grid_point_index*/) {
-    return true;
-  }
-
-  [[noreturn]] static inline void pack(
-      const gsl::not_null<packed_container*> /*packed*/,
-      const unpacked_container& /*unpacked*/,
-      const size_t /*grid_point_index*/) {
-    ERROR("Should not be converting an EOS from an unpacked to a packed type");
-  }
-
-  static inline size_t get_size(const packed_container& /*packed*/) {
-    return 1;
-  }
-};
-
 struct ConvertIdeal {
   using unpacked_container = bool;
   using packed_container = EquationsOfState::EquationOfState<false, 2>;
@@ -95,8 +73,8 @@ void test(const gsl::not_null<std::mt19937*> gen, const size_t num_pts,
                     Spectral::Quadrature::Gauss},
       volume_data, ranges);
 
-  helpers::test_boundary_correction_with_python<
-      NewtonianEuler::System<Dim>, tmpl::list<ConvertPolytropic, ConvertIdeal>>(
+  helpers::test_boundary_correction_with_python<NewtonianEuler::System<Dim>,
+                                                tmpl::list<ConvertIdeal>>(
       gen, "Hllc", "dg_package_data", "dg_boundary_terms",
       NewtonianEuler::BoundaryCorrections::Hllc<Dim>{},
       Mesh<Dim - 1>{num_pts, Spectral::Basis::Legendre,
@@ -106,8 +84,8 @@ void test(const gsl::not_null<std::mt19937*> gen, const size_t num_pts,
   const auto hllc = TestHelpers::test_creation<std::unique_ptr<
       NewtonianEuler::BoundaryCorrections::BoundaryCorrection<Dim>>>("Hllc:");
 
-  helpers::test_boundary_correction_with_python<
-      NewtonianEuler::System<Dim>, tmpl::list<ConvertPolytropic, ConvertIdeal>>(
+  helpers::test_boundary_correction_with_python<NewtonianEuler::System<Dim>,
+                                                tmpl::list<ConvertIdeal>>(
       gen, "Hllc", "dg_package_data", "dg_boundary_terms",
       dynamic_cast<const NewtonianEuler::BoundaryCorrections::Hllc<Dim>&>(
           *hllc),
@@ -126,13 +104,6 @@ SPECTRE_TEST_CASE("Unit.NewtonianEuler.BoundaryCorrections.Hllc",
   pypp::SetupLocalPythonEnvironment local_python_env{
       "Evolution/Systems/NewtonianEuler/BoundaryCorrections"};
   MAKE_GENERATOR(gen);
-
-  test<1>(make_not_null(&gen), 1,
-          EquationsOfState::PolytropicFluid<false>{1.0e-3, 2.0});
-  test<2>(make_not_null(&gen), 5,
-          EquationsOfState::PolytropicFluid<false>{1.0e-3, 2.0});
-  test<3>(make_not_null(&gen), 5,
-          EquationsOfState::PolytropicFluid<false>{1.0e-3, 2.0});
 
   test<1>(make_not_null(&gen), 1, EquationsOfState::IdealFluid<false>{1.3});
   test<2>(make_not_null(&gen), 5, EquationsOfState::IdealFluid<false>{1.3});

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/BoundaryCorrections/Test_Rusanov.cpp
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/BoundaryCorrections/Test_Rusanov.cpp
@@ -24,28 +24,6 @@
 #include "Utilities/TaggedTuple.hpp"
 
 namespace {
-struct ConvertPolytropic {
-  using unpacked_container = bool;
-  using packed_container = EquationsOfState::EquationOfState<false, 1>;
-  using packed_type = bool;
-
-  static inline unpacked_container unpack(const packed_container& /*packed*/,
-                                          const size_t /*grid_point_index*/) {
-    return true;
-  }
-
-  [[noreturn]] static inline void pack(
-      const gsl::not_null<packed_container*> /*packed*/,
-      const unpacked_container& /*unpacked*/,
-      const size_t /*grid_point_index*/) {
-    ERROR("Should not be converting an EOS from an unpacked to a packed type");
-  }
-
-  static inline size_t get_size(const packed_container& /*packed*/) {
-    return 1;
-  }
-};
-
 struct ConvertIdeal {
   using unpacked_container = bool;
   using packed_container = EquationsOfState::EquationOfState<false, 2>;
@@ -96,8 +74,8 @@ void test(const gsl::not_null<std::mt19937*> gen, const size_t num_pts,
                     Spectral::Quadrature::Gauss},
       volume_data, ranges);
 
-  helpers::test_boundary_correction_with_python<
-      NewtonianEuler::System<Dim>, tmpl::list<ConvertPolytropic, ConvertIdeal>>(
+  helpers::test_boundary_correction_with_python<NewtonianEuler::System<Dim>,
+                                                tmpl::list<ConvertIdeal>>(
       gen, "Rusanov", "dg_package_data", "dg_boundary_terms",
       NewtonianEuler::BoundaryCorrections::Rusanov<Dim>{},
       Mesh<Dim - 1>{num_pts, Spectral::Basis::Legendre,
@@ -108,8 +86,8 @@ void test(const gsl::not_null<std::mt19937*> gen, const size_t num_pts,
       NewtonianEuler::BoundaryCorrections::BoundaryCorrection<Dim>>>(
       "Rusanov:");
 
-  helpers::test_boundary_correction_with_python<
-      NewtonianEuler::System<Dim>, tmpl::list<ConvertPolytropic, ConvertIdeal>>(
+  helpers::test_boundary_correction_with_python<NewtonianEuler::System<Dim>,
+                                                tmpl::list<ConvertIdeal>>(
       gen, "Rusanov", "dg_package_data", "dg_boundary_terms",
       dynamic_cast<const NewtonianEuler::BoundaryCorrections::Rusanov<Dim>&>(
           *rusanov),
@@ -128,13 +106,6 @@ SPECTRE_TEST_CASE("Unit.NewtonianEuler.BoundaryCorrections.Rusanov",
   pypp::SetupLocalPythonEnvironment local_python_env{
       "Evolution/Systems/NewtonianEuler/BoundaryCorrections"};
   MAKE_GENERATOR(gen);
-
-  test<1>(make_not_null(&gen), 1,
-          EquationsOfState::PolytropicFluid<false>{1.0e-3, 2.0});
-  test<2>(make_not_null(&gen), 5,
-          EquationsOfState::PolytropicFluid<false>{1.0e-3, 2.0});
-  test<3>(make_not_null(&gen), 5,
-          EquationsOfState::PolytropicFluid<false>{1.0e-3, 2.0});
 
   test<1>(make_not_null(&gen), 1, EquationsOfState::IdealFluid<false>{1.3});
   test<2>(make_not_null(&gen), 5, EquationsOfState::IdealFluid<false>{1.3});

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/Subcell/Test_PrimsAfterRollback.cpp
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/Subcell/Test_PrimsAfterRollback.cpp
@@ -58,15 +58,15 @@ void test(const gsl::not_null<std::mt19937*> gen,
       gen, dist, subcell_mesh.number_of_grid_points());
   PrimVars expected_prim_vars{};
 
-  std::unique_ptr<EquationsOfState::EquationOfState<false, 1>> eos =
-      std::make_unique<EquationsOfState::PolytropicFluid<false>>(1.4,
-                                                                 5.0 / 3.0);
+  std::unique_ptr<EquationsOfState::EquationOfState<false, 2>> eos =
+      EquationsOfState::PolytropicFluid<false>{1.4, 5.0 / 3.0}
+          .promote_to_2d_eos();
 
   auto box = db::create<db::AddSimpleTags<
       evolution::dg::subcell::Tags::DidRollback, ::Tags::Variables<cons_tags>,
       ::Tags::Variables<prim_tags>, ::domain::Tags::Mesh<Dim>,
       evolution::dg::subcell::Tags::Mesh<Dim>,
-      hydro::Tags::EquationOfState<false, 1>>>(did_rollback, cons_vars,
+      hydro::Tags::EquationOfState<false, 2>>>(did_rollback, cons_vars,
                                                expected_prim_vars, dg_mesh,
                                                subcell_mesh, std::move(eos));
 

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/Subcell/Test_ResizeAndComputePrimitives.cpp
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/Subcell/Test_ResizeAndComputePrimitives.cpp
@@ -65,15 +65,15 @@ void test(const gsl::not_null<std::mt19937*> gen,
     prim_vars.initialize(subcell_mesh.number_of_grid_points(), 1.0);
   }
 
-  std::unique_ptr<EquationsOfState::EquationOfState<false, 1>> eos =
-      std::make_unique<EquationsOfState::PolytropicFluid<false>>(1.4,
-                                                                 5.0 / 3.0);
+  std::unique_ptr<EquationsOfState::EquationOfState<false, 2>> eos =
+      EquationsOfState::PolytropicFluid<false>{1.4, 5.0 / 3.0}
+          .promote_to_2d_eos();
 
   auto box = db::create<db::AddSimpleTags<
       evolution::dg::subcell::Tags::ActiveGrid, ::Tags::Variables<cons_tags>,
       ::Tags::Variables<prim_tags>, ::domain::Tags::Mesh<Dim>,
       evolution::dg::subcell::Tags::Mesh<Dim>,
-      hydro::Tags::EquationOfState<false, 1>>>(
+      hydro::Tags::EquationOfState<false, 2>>>(
       active_grid, cons_vars, prim_vars, dg_mesh, subcell_mesh, std::move(eos));
 
   db::mutate_apply<NewtonianEuler::subcell::ResizeAndComputePrims<Dim>>(

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/Subcell/Test_TimeDerivative.cpp
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/Subcell/Test_TimeDerivative.cpp
@@ -155,7 +155,6 @@ std::array<double, 3> test(const size_t num_dg_pts) {
   using metavariables = Metavariables;
   static constexpr size_t dim = metavariables::volume_dim;
   using solution = typename metavariables::initial_data;
-  using eos = typename solution::equation_of_state_type;
   using system = typename metavariables::system;
   const auto element = make_element<dim>();
   const ElementMap<dim, Frame::Grid> element_map{
@@ -235,7 +234,7 @@ std::array<double, 3> test(const size_t num_dg_pts) {
           domain::Tags::ElementMap<dim, Frame::Grid>,
           evolution::dg::subcell::Tags::Mesh<dim>, fd::Tags::Reconstructor<dim>,
           evolution::Tags::BoundaryCorrection<system>,
-          hydro::Tags::EquationOfState<false, eos::thermodynamic_dim>,
+          hydro::Tags::EquationOfState<false, 2>,
           typename system::primitive_variables_tag, dt_variables_tag,
           variables_tag,
           evolution::dg::subcell::Tags::GhostDataForReconstruction<dim>,
@@ -290,7 +289,7 @@ std::array<double, 3> test(const size_t num_dg_pts) {
       std::unique_ptr<
           NewtonianEuler::BoundaryCorrections::BoundaryCorrection<dim>>{
           std::make_unique<NewtonianEuler::BoundaryCorrections::Hll<dim>>()},
-      soln.equation_of_state().get_clone(), cell_centered_prim_vars,
+      soln.equation_of_state().promote_to_2d_eos(), cell_centered_prim_vars,
       Variables<typename dt_variables_tag::tags_list>{
           subcell_mesh.number_of_grid_points()},
       typename variables_tag::type{}, neighbor_data,

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/Test_MachNumber.cpp
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/Test_MachNumber.cpp
@@ -37,14 +37,13 @@ void test_in_databox(const Scalar<DataType>& mass_density,
       db::AddSimpleTags<hydro::Tags::RestMassDensity<DataType>,
                         hydro::Tags::SpatialVelocity<DataType, Dim>,
                         hydro::Tags::SpecificInternalEnergy<DataType>,
-                        hydro::Tags::EquationOfState<
-                            false, EquationOfStateType::thermodynamic_dim>>,
+                        hydro::Tags::EquationOfState<false, 2>>,
       db::AddComputeTags<
           NewtonianEuler::Tags::SoundSpeedSquaredCompute<DataType>,
           NewtonianEuler::Tags::SoundSpeedCompute<DataType>,
           NewtonianEuler::Tags::MachNumberCompute<DataType, Dim>>>(
       mass_density, velocity, specific_internal_energy,
-      equation_of_state.get_clone());
+      equation_of_state.promote_to_2d_eos());
 
   const auto expected_sound_speed_squared = NewtonianEuler::sound_speed_squared(
       mass_density, specific_internal_energy, equation_of_state);

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/Test_SoundSpeedSquared.cpp
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/Test_SoundSpeedSquared.cpp
@@ -39,12 +39,12 @@ void test_in_databox(const Scalar<DataType>& mass_density,
   const auto box = db::create<
       db::AddSimpleTags<hydro::Tags::RestMassDensity<DataType>,
                         hydro::Tags::SpecificInternalEnergy<DataType>,
-                        hydro::Tags::EquationOfState<
-                            false, EquationOfStateType::thermodynamic_dim>>,
+                        hydro::Tags::EquationOfState<false, 2>>,
       db::AddComputeTags<
           NewtonianEuler::Tags::SoundSpeedSquaredCompute<DataType>,
           NewtonianEuler::Tags::SoundSpeedCompute<DataType>>>(
-      mass_density, specific_internal_energy, equation_of_state.get_clone());
+      mass_density, specific_internal_energy,
+      equation_of_state.promote_to_2d_eos());
 
   const auto expected_sound_speed_squared = NewtonianEuler::sound_speed_squared(
       mass_density, specific_internal_energy, equation_of_state);


### PR DESCRIPTION
## Proposed changes

A number of simplifications to the NE executables made by hard coding a 2d EOS. 

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
