### PR TITLE
Observe KleinGordonPsi at future null infinity

### DIFF
--- a/src/Evolution/Executables/Cce/KleinGordonCharacteristicExtract.hpp
+++ b/src/Evolution/Executables/Cce/KleinGordonCharacteristicExtract.hpp
@@ -53,8 +53,7 @@ struct EvolutionMetavars : CharacteristicExtractDefaults<false> {
       Cce::Tags::EvolutionGaugeBoundaryValue<Cce::Tags::KleinGordonPi>>;
 
   using klein_gordon_scri_tags =
-      tmpl::list<Cce::Tags::ScriPlus<Cce::Tags::KleinGordonPsi>,
-                 Cce::Tags::ScriPlus<Cce::Tags::KleinGordonPi>>;
+      tmpl::list<Cce::Tags::ScriPlus<Cce::Tags::KleinGordonPi>>;
 
   using cce_step_choosers =
       tmpl::list<StepChoosers::Constant<StepChooserUse::LtsStep>,
@@ -108,6 +107,14 @@ struct EvolutionMetavars : CharacteristicExtractDefaults<false> {
   using klein_gordon_cce_integrand_tags =
       tmpl::list<Cce::Tags::PoleOfIntegrand<Cce::Tags::KleinGordonPi>,
                  Cce::Tags::RegularIntegrand<Cce::Tags::KleinGordonPi>>;
+
+  using scri_values_to_observe =
+      tmpl::append<cce_base::scri_values_to_observe,
+                   tmpl::list<Cce::Tags::ScriPlus<Cce::Tags::KleinGordonPsi>>>;
+
+  using cce_scri_tags =
+      tmpl::append<cce_base::cce_scri_tags,
+                   tmpl::list<Cce::Tags::ScriPlus<Cce::Tags::KleinGordonPsi>>>;
 
   using component_list =
       tmpl::list<observers::ObserverWriter<EvolutionMetavars>,

--- a/src/Evolution/Systems/Cce/ScriPlusValues.cpp
+++ b/src/Evolution/Systems/Cce/ScriPlusValues.cpp
@@ -364,4 +364,21 @@ void CalculateScriPlusValue<::Tags::dt<Tags::InertialRetardedTime>>::apply(
                   get(*dt_inertial_time).size());
   get(*dt_inertial_time) = real(exp_2_beta_at_scri.data());
 }
+
+void CalculateScriPlusValue<Tags::ScriPlus<Tags::KleinGordonPsi>>::apply(
+    const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 0>>*>
+        kg_psi_scri,
+    const Scalar<SpinWeighted<ComplexDataVector, 0>>& dy_kg_psi,
+    const Scalar<SpinWeighted<ComplexDataVector, 0>>& boundary_r, size_t l_max,
+    size_t number_of_radial_points) {
+  const size_t number_of_angular_points =
+      Spectral::Swsh::number_of_swsh_collocation_points(l_max);
+
+  const SpinWeighted<ComplexDataVector, 0> dy_kg_psi_scri;
+  make_const_view(make_not_null(&dy_kg_psi_scri), get(dy_kg_psi),
+                  (number_of_radial_points - 1) * number_of_angular_points,
+                  number_of_angular_points);
+
+  get(*kg_psi_scri) = -2. * get(boundary_r) * dy_kg_psi_scri;
+}
 }  // namespace Cce

--- a/src/Evolution/Systems/Cce/ScriPlusValues.hpp
+++ b/src/Evolution/Systems/Cce/ScriPlusValues.hpp
@@ -407,6 +407,37 @@ struct CalculateScriPlusValue<Tags::EthInertialRetardedTime> {
       size_t l_max);
 };
 
+/*!
+ * \brief Computes the leading part of the scalar field \f$\psi\f$ near
+ * \f$\mathcal I^+\f$.
+ *
+ * \details The value \f$\psi\f$ scales asymptotically as \f$r^{-1}\f$. Assuming
+ * \f$\psi^{(n)}\f$ is the \f$1/r^n\f$ part of \f$\psi\f$ evaluated at
+ * \f$\mathcal I^+\f$, so for any \f$\psi\f$,
+ *
+ * \f{align*}{
+ * \psi^{(1)} = (- 2 R \partial_y \psi)|_{y = 1},
+ * \f}
+ *
+ * where the expansion is determined by the conversion between Bondi and
+ * numerical radii \f$r = 2 R / (1 - y)\f$.
+ */
+template <>
+struct CalculateScriPlusValue<Tags::ScriPlus<Tags::KleinGordonPsi>> {
+  using return_tags = tmpl::list<Tags::ScriPlus<Tags::KleinGordonPsi>>;
+  using tensor_argument_tags =
+      tmpl::list<Tags::Dy<Tags::KleinGordonPsi>,
+                 Tags::EvolutionGaugeBoundaryValue<Tags::BondiR>>;
+  using argument_tags = tmpl::push_back<tensor_argument_tags, Tags::LMax,
+                                        Tags::NumberOfRadialPoints>;
+
+  static void apply(
+      gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 0>>*> kg_psi_scri,
+      const Scalar<SpinWeighted<ComplexDataVector, 0>>& dy_kg_psi,
+      const Scalar<SpinWeighted<ComplexDataVector, 0>>& boundary_r,
+      size_t l_max, size_t number_of_radial_points);
+};
+
 /// Initialize the \f$\mathcal I^+\f$ value `Tag` for the first hypersurface.
 template <typename Tag>
 struct InitializeScriPlusValue;

--- a/tests/Unit/Evolution/Systems/Cce/ScriPlusValues.py
+++ b/tests/Unit/Evolution/Systems/Cce/ScriPlusValues.py
@@ -133,3 +133,7 @@ def strain(dy_bondi_j, eth_eth_retarded_time, boundary_r):
     return -2.0 * np.conj(boundary_r * dy_bondi_j) + np.conj(
         eth_eth_retarded_time
     )
+
+
+def klein_gordon_psi(dy_kg_psi, boundary_r):
+    return -2.0 * boundary_r * dy_kg_psi

--- a/tests/Unit/Evolution/Systems/Cce/Test_ScriPlusValues.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_ScriPlusValues.cpp
@@ -90,6 +90,13 @@ void pypp_test_scri_plus_computation_steps() {
           CalculateScriPlusValue<Tags::ScriPlus<Tags::Strain>>>::apply,
       "ScriPlusValues", {"strain"}, {{{0.1, 1.0}}},
       DataVector{Spectral::Swsh::number_of_swsh_collocation_points(l_max)});
+
+  pypp::check_with_random_values<1>(
+      &WrapScriPlusComputation<
+          l_max, number_of_radial_points,
+          CalculateScriPlusValue<Tags::ScriPlus<Tags::KleinGordonPsi>>>::apply,
+      "ScriPlusValues", {"klein_gordon_psi"}, {{{0.1, 1.0}}},
+      DataVector{Spectral::Swsh::number_of_swsh_collocation_points(l_max)});
 }
 
 void check_inertial_retarded_time_utilities() {


### PR DESCRIPTION
## Proposed changes

<!--
At a high level, describe what this PR does.
-->

This PR adds an action to dump the `KleinGordonPsi` data at future null infinity.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
