### PR TITLE
Add ability to specify initial state for size control

### DIFF
--- a/src/ControlSystem/ControlErrors/Size.cpp
+++ b/src/ControlSystem/ControlErrors/Size.cpp
@@ -10,6 +10,9 @@
 #include <vector>
 
 #include "ControlSystem/Averager.hpp"
+#include "ControlSystem/ControlErrors/Size/AhSpeed.hpp"
+#include "ControlSystem/ControlErrors/Size/DeltaR.hpp"
+#include "ControlSystem/ControlErrors/Size/DeltaRDriftOutward.hpp"
 #include "ControlSystem/ControlErrors/Size/Info.hpp"
 #include "ControlSystem/ControlErrors/Size/Initial.hpp"
 #include "Domain/Structure/ObjectLabel.hpp"
@@ -41,6 +44,7 @@ template <size_t DerivOrder, ::domain::ObjectLabel Horizon>
 Size<DerivOrder, Horizon>::Size(
     const int max_times, const double smooth_avg_timescale_frac,
     TimescaleTuner<true> smoother_tuner,
+    std::unique_ptr<size::State> initial_state,
     std::optional<DeltaRDriftOutwardOptions> delta_r_drift_outward_options)
     : smoother_tuner_(std::move(smoother_tuner)),
       delta_r_drift_outward_options_(delta_r_drift_outward_options) {
@@ -50,7 +54,7 @@ Size<DerivOrder, Horizon>::Size(
   const auto max_times_size_t = static_cast<size_t>(max_times);
   horizon_coef_averager_ =
       Averager<DerivOrder>{smooth_avg_timescale_frac, true};
-  info_.state = std::make_unique<size::States::Initial>();
+  info_.state = std::move(initial_state);
   char_speed_predictor_ = intrp::ZeroCrossingPredictor{3, max_times_size_t};
   comoving_char_speed_predictor_ =
       intrp::ZeroCrossingPredictor{3, max_times_size_t};

--- a/src/ControlSystem/ControlErrors/Size.hpp
+++ b/src/ControlSystem/ControlErrors/Size.hpp
@@ -191,6 +191,11 @@ struct Size : tt::ConformsTo<protocols::ControlError> {
         "TimescaleTuner for smoothing horizon measurements."};
   };
 
+  struct InitialState {
+    using type = std::unique_ptr<size::State>;
+    static constexpr Options::String help{"Initial state to start in."};
+  };
+
   struct DeltaRDriftOutwardOptions {
     using type =
         Options::Auto<DeltaRDriftOutwardOptions, Options::AutoLabel::None>;
@@ -230,7 +235,7 @@ struct Size : tt::ConformsTo<protocols::ControlError> {
 
   using options = tmpl::list<MaxNumTimesForZeroCrossingPredictor,
                              SmoothAvgTimescaleFraction, SmootherTuner,
-                             DeltaRDriftOutwardOptions>;
+                             InitialState, DeltaRDriftOutwardOptions>;
   static constexpr Options::String help{
       "Computes the control error for size control. Will also write a "
       "diagnostics file if the control systems are allowed to write data to "
@@ -252,6 +257,7 @@ struct Size : tt::ConformsTo<protocols::ControlError> {
    */
   Size(const int max_times, const double smooth_avg_timescale_frac,
        TimescaleTuner<true> smoother_tuner,
+       std::unique_ptr<size::State> initial_state,
        std::optional<DeltaRDriftOutwardOptions> delta_r_drift_outward_options);
 
   /// Returns the internal `control_system::size::Info::suggested_time_scale`. A

--- a/src/ControlSystem/ControlErrors/Size/AhSpeed.hpp
+++ b/src/ControlSystem/ControlErrors/Size/AhSpeed.hpp
@@ -8,11 +8,17 @@
 
 #include "ControlSystem/ControlErrors/Size/Info.hpp"
 #include "ControlSystem/ControlErrors/Size/State.hpp"
+#include "Options/String.hpp"
 #include "Utilities/Serialization/CharmPupable.hpp"
+#include "Utilities/TMPL.hpp"
 
 namespace control_system::size::States {
 class AhSpeed : public State {
  public:
+  using options = tmpl::list<>;
+  static constexpr Options::String help{
+      "Controls the velocity of the excision surface to avoid incoming "
+      "characteristic speeds. This is state 1 in SpEC."};
   AhSpeed() = default;
   std::string name() const override { return "AhSpeed"; }
   size_t number() const override { return 1; }

--- a/src/ControlSystem/ControlErrors/Size/CMakeLists.txt
+++ b/src/ControlSystem/ControlErrors/Size/CMakeLists.txt
@@ -25,6 +25,7 @@ spectre_target_headers(
   DeltaR.hpp
   DeltaRDriftOutward.hpp
   Error.hpp
+  Factory.hpp
   Initial.hpp
   RegisterDerivedWithCharm.hpp
   Update.hpp

--- a/src/ControlSystem/ControlErrors/Size/DeltaR.hpp
+++ b/src/ControlSystem/ControlErrors/Size/DeltaR.hpp
@@ -8,11 +8,18 @@
 
 #include "ControlSystem/ControlErrors/Size/Info.hpp"
 #include "ControlSystem/ControlErrors/Size/State.hpp"
+#include "Options/String.hpp"
 #include "Utilities/Serialization/CharmPupable.hpp"
+#include "Utilities/TMPL.hpp"
 
 namespace control_system::size::States {
 class DeltaR : public State {
  public:
+  using options = tmpl::list<>;
+  static constexpr Options::String help{
+      "Controls the velocity of the excision surface to maintain a constant "
+      "separation between the excision surface and the horizon surface. This "
+      "is state 2 in SpEC."};
   DeltaR() = default;
   std::string name() const override { return "DeltaR"; }
   size_t number() const override { return 2; }
@@ -25,7 +32,7 @@ class DeltaR : public State {
       const Info& info,
       const ControlErrorArgs& control_error_args) const override;
 
-  WRAPPED_PUPable_decl_template(DeltaR); // NOLINT
+  WRAPPED_PUPable_decl_template(DeltaR);  // NOLINT
   explicit DeltaR(CkMigrateMessage* const /*msg*/) {}
 };
 }  // namespace control_system::size::States

--- a/src/ControlSystem/ControlErrors/Size/DeltaRDriftOutward.hpp
+++ b/src/ControlSystem/ControlErrors/Size/DeltaRDriftOutward.hpp
@@ -8,11 +8,18 @@
 
 #include "ControlSystem/ControlErrors/Size/Info.hpp"
 #include "ControlSystem/ControlErrors/Size/State.hpp"
+#include "Options/String.hpp"
 #include "Utilities/Serialization/CharmPupable.hpp"
+#include "Utilities/TMPL.hpp"
 
 namespace control_system::size::States {
 class DeltaRDriftOutward : public State {
  public:
+  using options = tmpl::list<>;
+  static constexpr Options::String help{
+      "Controls the velocity of the excision surface to maintain a constant "
+      "separation between the excision surface and the horizon surface with a "
+      "small outward radial velocity. This is state 5 in SpEC."};
   DeltaRDriftOutward() = default;
   std::string name() const override { return "DeltaRDriftOutward"; }
   size_t number() const override { return 5; }

--- a/src/ControlSystem/ControlErrors/Size/Factory.hpp
+++ b/src/ControlSystem/ControlErrors/Size/Factory.hpp
@@ -1,0 +1,15 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "ControlSystem/ControlErrors/Size/AhSpeed.hpp"
+#include "ControlSystem/ControlErrors/Size/DeltaR.hpp"
+#include "ControlSystem/ControlErrors/Size/DeltaRDriftOutward.hpp"
+#include "ControlSystem/ControlErrors/Size/Initial.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace control_system::size::States {
+using factory_creatable_states =
+    tmpl::list<AhSpeed, DeltaR, DeltaRDriftOutward, Initial>;
+}  // namespace control_system::size::States

--- a/src/ControlSystem/ControlErrors/Size/Initial.hpp
+++ b/src/ControlSystem/ControlErrors/Size/Initial.hpp
@@ -8,11 +8,17 @@
 
 #include "ControlSystem/ControlErrors/Size/Info.hpp"
 #include "ControlSystem/ControlErrors/Size/State.hpp"
+#include "Options/String.hpp"
 #include "Utilities/Serialization/CharmPupable.hpp"
+#include "Utilities/TMPL.hpp"
 
 namespace control_system::size::States {
 class Initial : public State {
  public:
+  using options = tmpl::list<>;
+  static constexpr Options::String help{
+      "A temporary state for the beginning of a simulation. This is state 0 in "
+      "SpEC."};
   Initial() = default;
   std::string name() const override { return "Initial"; }
   size_t number() const override { return 0; }
@@ -24,7 +30,7 @@ class Initial : public State {
       const Info& info,
       const ControlErrorArgs& control_error_args) const override;
 
-  WRAPPED_PUPable_decl_template(Initial); // NOLINT
+  WRAPPED_PUPable_decl_template(Initial);  // NOLINT
   explicit Initial(CkMigrateMessage* const /*msg*/) {}
 };
 }  // namespace control_system::size::States

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
@@ -10,6 +10,8 @@
 #include "ControlSystem/Actions/LimitTimeStep.hpp"
 #include "ControlSystem/Actions/PrintCurrentMeasurement.hpp"
 #include "ControlSystem/Component.hpp"
+#include "ControlSystem/ControlErrors/Size/Factory.hpp"
+#include "ControlSystem/ControlErrors/Size/State.hpp"
 #include "ControlSystem/Measurements/BothHorizons.hpp"
 #include "ControlSystem/Metafunctions.hpp"
 #include "ControlSystem/Systems/Expansion.hpp"
@@ -473,6 +475,8 @@ struct EvolutionMetavars {
                 control_system::metafunctions::control_system_events<
                     control_systems>,
                 Events::time_events<system>>>>,
+        tmpl::pair<control_system::size::State,
+                   control_system::size::States::factory_creatable_states>,
         tmpl::pair<
             gh::BoundaryConditions::BoundaryCondition<volume_dim>,
             tmpl::list<

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhSingleBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhSingleBlackHole.hpp
@@ -10,6 +10,8 @@
 #include "ControlSystem/Actions/InitializeMeasurements.hpp"
 #include "ControlSystem/Actions/PrintCurrentMeasurement.hpp"
 #include "ControlSystem/Component.hpp"
+#include "ControlSystem/ControlErrors/Size/Factory.hpp"
+#include "ControlSystem/ControlErrors/Size/State.hpp"
 #include "ControlSystem/Measurements/SingleHorizon.hpp"
 #include "ControlSystem/Metafunctions.hpp"
 #include "ControlSystem/Systems/Shape.hpp"
@@ -182,7 +184,9 @@ struct EvolutionMetavars : public GeneralizedHarmonicTemplateBase<3> {
                        intrp::Events::InterpolateWithoutInterpComponent<
                            3, ExcisionBoundary, interpolator_source_vars>>>>,
         tmpl::pair<DenseTrigger,
-                   control_system::control_system_triggers<control_systems>>>;
+                   control_system::control_system_triggers<control_systems>>,
+        tmpl::pair<control_system::size::State,
+                   control_system::size::States::factory_creatable_states>>;
   };
 
   using typename gh_base::const_global_cache_tags;

--- a/support/Pipelines/Bbh/Inspiral.yaml
+++ b/support/Pipelines/Bbh/Inspiral.yaml
@@ -391,6 +391,7 @@ ControlSystems:
       MaxNumTimesForZeroCrossingPredictor: 4
       SmoothAvgTimescaleFraction: 0.25
       DeltaRDriftOutwardOptions: None
+      InitialState: Initial
       SmootherTuner:
         InitialTimescales: [0.2]
         MinTimescale: 1.0e-4

--- a/support/Pipelines/Bbh/Ringdown.yaml
+++ b/support/Pipelines/Bbh/Ringdown.yaml
@@ -245,6 +245,7 @@ ControlSystems:
       MaxNumTimesForZeroCrossingPredictor: 4
       SmoothAvgTimescaleFraction: 0.25
       DeltaRDriftOutwardOptions: None
+      InitialState: DeltaR
       SmootherTuner:
         InitialTimescales: [0.2]
         MinTimescale: 1.0e-4

--- a/tests/InputFiles/GeneralizedHarmonic/BinaryBlackHole.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/BinaryBlackHole.yaml
@@ -382,6 +382,7 @@ ControlSystems:
       MaxNumTimesForZeroCrossingPredictor: 4
       SmoothAvgTimescaleFraction: 0.25
       DeltaRDriftOutwardOptions: None
+      InitialState: Initial
       SmootherTuner:
         InitialTimescales: [0.2]
         MinTimescale: 1.0e-4

--- a/tests/InputFiles/GeneralizedHarmonic/CylindricalBinaryBlackHole.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/CylindricalBinaryBlackHole.yaml
@@ -361,6 +361,7 @@ ControlSystems:
       MaxNumTimesForZeroCrossingPredictor: 4
       SmoothAvgTimescaleFraction: 0.25
       DeltaRDriftOutwardOptions: None
+      InitialState: Initial
       SmootherTuner:
         InitialTimescales: [0.2]
         MinTimescale: 1.0e-4

--- a/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
@@ -273,6 +273,7 @@ ControlSystems:
       MaxNumTimesForZeroCrossingPredictor: 4
       SmoothAvgTimescaleFraction: 0.25
       DeltaRDriftOutwardOptions: None
+      InitialState: DeltaR
       SmootherTuner:
         InitialTimescales: [0.2]
         MinTimescale: 1.0e-4

--- a/tests/Unit/ControlSystem/ControlErrors/Test_SizeControlStates.cpp
+++ b/tests/Unit/ControlSystem/ControlErrors/Test_SizeControlStates.cpp
@@ -10,10 +10,12 @@
 #include "ControlSystem/ControlErrors/Size/AhSpeed.hpp"
 #include "ControlSystem/ControlErrors/Size/DeltaR.hpp"
 #include "ControlSystem/ControlErrors/Size/DeltaRDriftOutward.hpp"
+#include "ControlSystem/ControlErrors/Size/Factory.hpp"
 #include "ControlSystem/ControlErrors/Size/Info.hpp"
 #include "ControlSystem/ControlErrors/Size/Initial.hpp"
 #include "ControlSystem/ControlErrors/Size/RegisterDerivedWithCharm.hpp"
 #include "ControlSystem/ControlErrors/Size/State.hpp"
+#include "Framework/TestCreation.hpp"
 #include "Framework/TestHelpers.hpp"
 #include "Utilities/Gsl.hpp"
 
@@ -71,12 +73,14 @@ void do_test(const TestParams& test_params,
       test_params.min_char_speed, test_params.min_comoving_char_speed,
       test_params.control_err_delta_r, test_params.average_radial_distance,
       test_params.max_allowed_radial_distance};
-  control_system::size::Info info{std::make_unique<InitialState>(),
-                                  test_params.damping_time,
-                                  test_params.original_target_char_speed,
-                                  target_drift_velocity,
-                                  original_suggested_time_scale,
-                                  original_discontinuous_change_has_occurred};
+  control_system::size::Info info{
+      TestHelpers::test_factory_creation<control_system::size::State,
+                                         InitialState>(initial_state),
+      test_params.damping_time,
+      test_params.original_target_char_speed,
+      target_drift_velocity,
+      original_suggested_time_scale,
+      original_discontinuous_change_has_occurred};
 
   // Check serialization of info
   const auto info_copy = serialize_and_deserialize(info);

--- a/tests/Unit/ControlSystem/ControlErrors/Test_SizeError.cpp
+++ b/tests/Unit/ControlSystem/ControlErrors/Test_SizeError.cpp
@@ -15,6 +15,7 @@
 #include "ControlSystem/ControlErrors/Size/DeltaR.hpp"
 #include "ControlSystem/ControlErrors/Size/DeltaRDriftOutward.hpp"
 #include "ControlSystem/ControlErrors/Size/Error.hpp"
+#include "ControlSystem/ControlErrors/Size/Factory.hpp"
 #include "ControlSystem/ControlErrors/Size/Info.hpp"
 #include "ControlSystem/ControlErrors/Size/Initial.hpp"
 #include "ControlSystem/ControlErrors/Size/RegisterDerivedWithCharm.hpp"
@@ -34,6 +35,7 @@
 #include "NumericalAlgorithms/Interpolation/ZeroCrossingPredictor.hpp"
 #include "NumericalAlgorithms/SphericalHarmonics/Strahlkorper.hpp"
 #include "NumericalAlgorithms/SphericalHarmonics/Tags.hpp"
+#include "Options/Protocols/FactoryCreation.hpp"
 #include "Parallel/GlobalCache.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
@@ -57,6 +59,13 @@ struct Metavars {
   using observed_reduction_data_tags = tmpl::list<>;
   using component_list = tmpl::list<observers::ObserverWriter<Metavars>>;
   void pup(PUP::er& /*p*/) {}
+
+  struct factory_creation
+      : public tt::ConformsTo<Options::protocols::FactoryCreation> {
+    using factory_classes = tmpl::map<
+        tmpl::pair<control_system::size::State,
+                   control_system::size::States::factory_creatable_states>>;
+  };
 };
 
 void test_control_error_delta_r() {
@@ -210,10 +219,11 @@ void test_size_error_one_step(
         tt::assert_conforms_to_v<size_error,
                                  control_system::protocols::ControlError>);
 
-    auto error_class = TestHelpers::test_creation<size_error>(
+    auto error_class = TestHelpers::test_creation<size_error, Metavars>(
         "MaxNumTimesForZeroCrossingPredictor: 4\n"
         "SmoothAvgTimescaleFraction: 0.25\n"
         "DeltaRDriftOutwardOptions: None\n"
+        "InitialState: Initial\n"
         "SmootherTuner:\n"
         "  InitialTimescales: 0.2\n"
         "  MinTimescale: 1.0e-4\n"


### PR DESCRIPTION
## Proposed changes

This is needed for Ringdown transition. Previously it was hard-coded to use `Initial`. Now you can specify any of the ones coded up.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
