### PR TITLE
Print remark when AH finder fails for verbosity >= quiet

### DIFF
--- a/src/ParallelAlgorithms/ApparentHorizonFinder/Callbacks/IgnoreFailedApparentHorizon.hpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/Callbacks/IgnoreFailedApparentHorizon.hpp
@@ -34,7 +34,7 @@ struct IgnoreFailedApparentHorizon {
                     const FastFlow::Status failure_reason) {
     const auto& verbosity =
         db::get<logging::Tags::Verbosity<InterpolationTargetTag>>(box);
-    if (verbosity > ::Verbosity::Quiet) {
+    if (verbosity >= ::Verbosity::Quiet) {
       Parallel::printf("Remark: Horizon finder %s failed, reason = %s\n",
                        pretty_type::name<InterpolationTargetTag>(),
                        failure_reason);


### PR DESCRIPTION
## Proposed changes

Usually we set AH verbosity to Quiet, which prints one line to stdout on success. If AH finder fails, we would also like a 1-line warning to print, instead of nothing.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
