### PR TITLE
Do not serialize compute items of a DataBox

### DIFF
--- a/src/DataStructures/DataBox/Item.hpp
+++ b/src/DataStructures/DataBox/Item.hpp
@@ -114,14 +114,6 @@ class Item<Tag, ItemType::Compute> {
     evaluated_ = true;
   }
 
-  // NOLINTNEXTLINE(google-runtime-references)
-  void pup(PUP::er& p) {
-    p | evaluated_;
-    if (evaluated_) {
-      p | value_;
-    }
-  }
-
  private:
   // NOLINTNEXTLINE(spectre-mutable)
   mutable value_type value_{};
@@ -148,9 +140,6 @@ class Item<Tag, ItemType::Reference> {
   constexpr Item& operator=(Item const&) = default;
   constexpr Item& operator=(Item&&) = default;
   ~Item() = default;
-
-  // NOLINTNEXTLINE(google-runtime-references)
-  void pup(PUP::er& /*p*/) {}
 };
 }  // namespace db::detail
 /// \endcond

--- a/src/DataStructures/VectorImpl.hpp
+++ b/src/DataStructures/VectorImpl.hpp
@@ -463,6 +463,9 @@ void VectorImpl<T, VectorType, StaticSize>::clear() {
 
 template <typename T, typename VectorType, size_t StaticSize>
 void VectorImpl<T, VectorType, StaticSize>::pup(PUP::er& p) {  // NOLINT
+  if (not owning_ and p.isSizing()) {
+    return;
+  }
   ASSERT(owning_, "Cannot pup a non-owning vector!");
   auto my_size = size();
   p | my_size;

--- a/tests/InputFiles/ExportCoordinates/InputTimeDependent3D.yaml
+++ b/tests/InputFiles/ExportCoordinates/InputTimeDependent3D.yaml
@@ -98,9 +98,20 @@ EventsAndTriggers:
         Value: 0.5
     Events:
       - Completion
+  - Trigger: Always
+    Events:
+      - MonitorMemory:
+          ComponentsToMonitor: All
 
 Observers:
   VolumeFileName: "ExportTimeDependentCoordinates3DVolume"
   ReductionFileName: "ExportTimeDependentCoordinates3DReductions"
 
+# Intentionally after the completion time to avoid writing checkpoints on CI
 PhaseChangeAndTriggers:
+  - Trigger:
+      SlabCompares:
+        Comparison: EqualTo
+        Value: 2
+    PhaseChanges:
+      - VisitAndReturn(WriteCheckpoint)

--- a/tests/Unit/DataStructures/DataBox/Test_DataBox.cpp
+++ b/tests/Unit/DataStructures/DataBox/Test_DataBox.cpp
@@ -2791,17 +2791,17 @@ void serialization_subitem_compute_items() {  // NOLINT
         before_counting_tag0);
 
   CHECK(db::get<CountingTag<0>>(deserialized_serialization_test_box) == 8.2);
-  CHECK(CountingFunc<0>::count == 1);
+  CHECK(CountingFunc<0>::count == 2);
   CHECK(CountingFunc<1>::count == 0);
   CHECK(&db::get<CountingTag<0>>(deserialized_serialization_test_box) !=
         before_counting_tag0);
-  CHECK(CountingFunc<0>::count == 1);
+  CHECK(CountingFunc<0>::count == 2);
   CHECK(CountingFunc<1>::count == 0);
   CHECK(db::get<CountingTag<1>>(deserialized_serialization_test_box) == 8.2);
-  CHECK(CountingFunc<0>::count == 1);
+  CHECK(CountingFunc<0>::count == 2);
   CHECK(CountingFunc<1>::count == 1);
   CHECK(db::get<CountingTag<1>>(serialization_test_box) == 8.2);
-  CHECK(CountingFunc<0>::count == 1);
+  CHECK(CountingFunc<0>::count == 2);
   CHECK(CountingFunc<1>::count == 2);
   CHECK(&db::get<CountingTag<1>>(serialization_test_box) !=
         &db::get<CountingTag<1>>(deserialized_serialization_test_box));
@@ -2826,7 +2826,7 @@ void serialization_subitem_compute_items() {  // NOLINT
         -9.0);
   CHECK(*db::get<First<2>>(deserialized_serialization_test_box) == 10);
   CHECK(*db::get<Second<2>>(deserialized_serialization_test_box) == -9.0);
-  CHECK(ParentCompute<2>::count == 1);
+  CHECK(ParentCompute<2>::count == 2);
   CHECK(ParentCompute<3>::count == 0);
   CHECK(&db::get<Parent<2>>(deserialized_serialization_test_box) !=
         before_parent2);
@@ -2846,23 +2846,23 @@ void serialization_subitem_compute_items() {  // NOLINT
         &*db::get<Second<2>>(serialization_test_box));
 
   CHECK(*(db::get<Parent<3>>(serialization_test_box).first) == 11);
-  CHECK(ParentCompute<2>::count == 1);
+  CHECK(ParentCompute<2>::count == 2);
   CHECK(ParentCompute<3>::count == 1);
   CHECK(*(db::get<Parent<3>>(serialization_test_box).second) == -18.0);
-  CHECK(ParentCompute<2>::count == 1);
+  CHECK(ParentCompute<2>::count == 2);
   CHECK(ParentCompute<3>::count == 1);
   CHECK(*db::get<First<3>>(serialization_test_box) == 11);
   CHECK(*db::get<Second<3>>(serialization_test_box) == -18.0);
-  CHECK(ParentCompute<2>::count == 1);
+  CHECK(ParentCompute<2>::count == 2);
   CHECK(ParentCompute<3>::count == 1);
   CHECK(*(db::get<Parent<3>>(deserialized_serialization_test_box).first) == 11);
-  CHECK(ParentCompute<2>::count == 1);
+  CHECK(ParentCompute<2>::count == 2);
   CHECK(ParentCompute<3>::count == 2);
   CHECK(*(db::get<Parent<3>>(deserialized_serialization_test_box).second) ==
         -18.0);
   CHECK(*db::get<First<3>>(deserialized_serialization_test_box) == 11);
   CHECK(*db::get<Second<3>>(deserialized_serialization_test_box) == -18.0);
-  CHECK(ParentCompute<2>::count == 1);
+  CHECK(ParentCompute<2>::count == 2);
   CHECK(ParentCompute<3>::count == 2);
 
   // Check that all the Parent<3> related objects point to the right place
@@ -2888,7 +2888,7 @@ void serialization_subitem_compute_items() {  // NOLINT
         -9.0 * 6.0);
   CHECK(before_compute_tag2 !=
         &db::get<CountingTagDouble<2>>(deserialized_serialization_test_box));
-  CHECK(CountingTagDoubleCompute<2>::count == 1);
+  CHECK(CountingTagDoubleCompute<2>::count == 2);
 
   CHECK(CountingTagDoubleCompute<3>::count == 0);
   CHECK(db::get<CountingTagDouble<3>>(serialization_test_box) == -18.0 * 6.0);
@@ -2901,34 +2901,34 @@ void serialization_subitem_compute_items() {  // NOLINT
   // Mutate subitems 1 in deserialized to see that changes propagate correctly
   db::mutate<Second<1>>([](const gsl::not_null<double**> x) { **x = 12.; },
                         make_not_null(&serialization_test_box));
-  CHECK(ParentCompute<2>::count == 1);
-  CHECK(CountingTagDoubleCompute<2>::count == 1);
-  CHECK(db::get<CountingTagDouble<2>>(serialization_test_box) == 24.0 * 6.0);
   CHECK(ParentCompute<2>::count == 2);
   CHECK(CountingTagDoubleCompute<2>::count == 2);
+  CHECK(db::get<CountingTagDouble<2>>(serialization_test_box) == 24.0 * 6.0);
+  CHECK(ParentCompute<2>::count == 3);
+  CHECK(CountingTagDoubleCompute<2>::count == 3);
   CHECK(CountingTagDoubleCompute<3>::count == 2);
   CHECK(db::get<CountingTagDouble<3>>(serialization_test_box) == 48.0 * 6.0);
   CHECK(CountingTagDoubleCompute<3>::count == 3);
 
   db::mutate<Second<1>>([](const gsl::not_null<double**> x) { **x = -7.; },
                         make_not_null(&deserialized_serialization_test_box));
-  CHECK(ParentCompute<2>::count == 2);
-  CHECK(CountingTagDoubleCompute<2>::count == 2);
-  CHECK(db::get<CountingTagDouble<2>>(deserialized_serialization_test_box) ==
-        -14.0 * 6.0);
   CHECK(ParentCompute<2>::count == 3);
   CHECK(CountingTagDoubleCompute<2>::count == 3);
+  CHECK(db::get<CountingTagDouble<2>>(deserialized_serialization_test_box) ==
+        -14.0 * 6.0);
+  CHECK(ParentCompute<2>::count == 4);
+  CHECK(CountingTagDoubleCompute<2>::count == 4);
   CHECK(CountingTagDoubleCompute<3>::count == 3);
   CHECK(db::get<CountingTagDouble<3>>(deserialized_serialization_test_box) ==
         -28.0 * 6.0);
   CHECK(CountingTagDoubleCompute<3>::count == 4);
 
   // Check things didn't get modified in the original DataBox
-  CHECK(ParentCompute<2>::count == 3);
-  CHECK(CountingTagDoubleCompute<2>::count == 3);
+  CHECK(ParentCompute<2>::count == 4);
+  CHECK(CountingTagDoubleCompute<2>::count == 4);
   CHECK(db::get<CountingTagDouble<2>>(serialization_test_box) == 24.0 * 6.0);
-  CHECK(ParentCompute<2>::count == 3);
-  CHECK(CountingTagDoubleCompute<2>::count == 3);
+  CHECK(ParentCompute<2>::count == 4);
+  CHECK(CountingTagDoubleCompute<2>::count == 4);
   CHECK(CountingTagDoubleCompute<3>::count == 4);
   CHECK(db::get<CountingTagDouble<3>>(serialization_test_box) == 48.0 * 6.0);
   CHECK(CountingTagDoubleCompute<3>::count == 4);

--- a/tests/Unit/DataStructures/Test_VectorImplTestHelper.cpp
+++ b/tests/Unit/DataStructures/Test_VectorImplTestHelper.cpp
@@ -10,12 +10,20 @@
 #include "DataStructures/DataVector.hpp"  // IWYU pragma: keep
 #include "Helpers/DataStructures/VectorImplTestHelper.hpp"
 #include "Utilities/ContainerHelpers.hpp"
+#include "Utilities/Serialization/Serialize.hpp"
 
 namespace TestHelpers {
 namespace VectorImpl {
 
 SPECTRE_TEST_CASE("Unit.DataStructures.VectorImplTestHelper",
                   "[DataStructures][Unit]") {
+  // Test PUP size of owning and non-owning objects
+  DataVector owning{1.0, 4.0};
+  CHECK(size_of_object_in_bytes(owning) == 24);
+  DataVector non_owning{owning.data(), owning.size()};
+  REQUIRE(not non_owning.is_owning());
+  CHECK(size_of_object_in_bytes(non_owning) == 0);
+
   // testing size utility
   std::array<DataVector, 3> array_of_vectors = {
       {{{1.0, 4.0}}, {{2.0, 5.0}}, {{3.0, 6.0}}}};


### PR DESCRIPTION
## Proposed changes

- Do not serialize compute items of a DataBox
- Allow a sizing PUP to succeed for non-owning VectorImpl (with a size of 0)
- Test MemoryMonitor on a CompactBinaryObject Domain with ExportCoordinates.  (This would trigger an ASSERT if done without the previous change.)

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
