### PR TITLE
Fix memory leak in Observer

### DIFF
--- a/src/IO/Observer/VolumeActions.hpp
+++ b/src/IO/Observer/VolumeActions.hpp
@@ -140,6 +140,7 @@ struct ContributeVolumeData {
                     array_index),
                 subfile_name, std::move((*volume_data)[observation_id]));
             volume_data->erase(observation_id);
+            contributed_volume_data_ids->erase(observation_id);
           }
         },
         make_not_null(&box),


### PR DESCRIPTION
The map holding ContributorsOfTensorData was not erased after all volume data was received and forwarded to the ObserverWriter. (The volume data was erased.)

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
