### PR TITLE
Error if doing barycentric interpolation for FiniteDifference

### DIFF
--- a/src/NumericalAlgorithms/Spectral/Spectral.cpp
+++ b/src/NumericalAlgorithms/Spectral/Spectral.cpp
@@ -623,6 +623,11 @@ PRECOMPUTED_SPECTRAL_QUANTITY(linear_filter_matrix, Matrix,
 
 template <Basis BasisType, Quadrature QuadratureType, typename T>
 Matrix interpolation_matrix(const size_t num_points, const T& target_points) {
+  if constexpr (BasisType == Spectral::Basis::FiniteDifference) {
+    ERROR(
+        "Cannot do barycentric interpolation with Basis::FiniteDifference.  "
+        "Use an IrregularInterpolant");
+  }
   constexpr size_t max_num_points =
       Spectral::maximum_number_of_points<BasisType>;
   constexpr size_t min_num_points =

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_Spectral.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_Spectral.cpp
@@ -544,6 +544,19 @@ void test_double_instantiation() {
       mesh1d, std::vector<double>{interpolation_target});
   CHECK_ITERABLE_APPROX(double_matrix, vector_matrix);
 }
+
+void test_fd_interpolation_fails() {
+  CHECK_THROWS_WITH(
+      ([]() {
+        const Mesh<1> fd_mesh{5, Spectral::Basis::FiniteDifference,
+                              Spectral::Quadrature::CellCentered};
+        const double interpolation_target = 0.2;
+        const auto matrix =
+            Spectral::interpolation_matrix(fd_mesh, interpolation_target);
+      }()),
+      Catch::Matchers::ContainsSubstring(
+          "Cannot do barycentric interpolation with Basis::FiniteDifference"));
+}
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Numerical.Spectral",
@@ -556,4 +569,5 @@ SPECTRE_TEST_CASE("Unit.Numerical.Spectral",
   test_spectral_quantities_for_mesh();
   test_gauss_points_boundary_interpolation_and_lifting();
   test_double_instantiation();
+  test_fd_interpolation_fails();
 }


### PR DESCRIPTION
Barycentric interpolation is unstable for finite difference.  Lower-order interpolation should be used instead.  Currently this is handled by IrregularInterpolant doing linear interpolation.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
