### PR TITLE
Add option for monotonic AdamsMoulton dense output

### DIFF
--- a/src/ControlSystem/Actions/LimitTimeStep.hpp
+++ b/src/ControlSystem/Actions/LimitTimeStep.hpp
@@ -96,10 +96,9 @@ struct LimitTimeStep {
     }
 
     const auto& time_stepper = db::get<::Tags::TimeStepper<TimeStepper>>(box);
-    if (time_stepper.number_of_substeps() == 1) {
-      // If there are no substeps, there is no reason to limit the
-      // step size so substeps can be evaluated.  Single-substep FSAL
-      // methods could be problematic, but we don't have any of those.
+    if (time_stepper.monotonic()) {
+      // Monotonic steppers order operations in the same manner at the
+      // control system, so they cannot introduce deadlocks.
       return {Parallel::AlgorithmExecution::Continue, std::nullopt};
     }
 

--- a/src/Executables/TimeStepperSummary/TimeStepperSummary.cpp
+++ b/src/Executables/TimeStepperSummary/TimeStepperSummary.cpp
@@ -26,6 +26,7 @@ class ImexTimeStepper;
 class LtsTimeStepper;
 namespace TimeSteppers {
 class AdamsBashforth;
+template <bool Monotonic>
 class AdamsMoultonPc;
 }  // namespace TimeSteppers
 
@@ -35,7 +36,9 @@ extern "C" void CkRegisterMainModule(void) {}
 
 namespace {
 using time_steppers_taking_order =
-    tmpl::list<TimeSteppers::AdamsBashforth, TimeSteppers::AdamsMoultonPc>;
+    tmpl::list<TimeSteppers::AdamsBashforth,
+               TimeSteppers::AdamsMoultonPc<false>,
+               TimeSteppers::AdamsMoultonPc<true>>;
 
 const char* const program_help =
     "Print various properties about SpECTRE's time steppers.  Abbreviations\n"

--- a/src/Time/TimeSteppers/AdamsBashforth.cpp
+++ b/src/Time/TimeSteppers/AdamsBashforth.cpp
@@ -101,6 +101,8 @@ double AdamsBashforth::stable_step() const {
   return 1. / invstep;
 }
 
+bool AdamsBashforth::monotonic() const { return true; }
+
 TimeStepId AdamsBashforth::next_time_id(const TimeStepId& current_id,
                                         const TimeDelta& time_step) const {
   ASSERT(current_id.substep() == 0, "Adams-Bashforth should not have substeps");

--- a/src/Time/TimeSteppers/AdamsBashforth.hpp
+++ b/src/Time/TimeSteppers/AdamsBashforth.hpp
@@ -225,6 +225,8 @@ class AdamsBashforth : public LtsTimeStepper {
 
   double stable_step() const override;
 
+  bool monotonic() const override;
+
   TimeStepId next_time_id(const TimeStepId& current_id,
                           const TimeDelta& time_step) const override;
 

--- a/src/Time/TimeSteppers/AdamsMoultonPc.cpp
+++ b/src/Time/TimeSteppers/AdamsMoultonPc.cpp
@@ -126,6 +126,8 @@ double AdamsMoultonPc::stable_step() const {
   }
 }
 
+bool AdamsMoultonPc::monotonic() const { return false; }
+
 TimeStepId AdamsMoultonPc::next_time_id(const TimeStepId& current_id,
                                         const TimeDelta& time_step) const {
   switch (current_id.substep()) {

--- a/src/Time/TimeSteppers/AdamsMoultonPc.hpp
+++ b/src/Time/TimeSteppers/AdamsMoultonPc.hpp
@@ -36,6 +36,12 @@ namespace TimeSteppers {
  * An \f$N\$th order Adams-Moulton predictor-corrector method using an
  * \$(N - 1)\$th order Adams-Bashforth predictor.
  *
+ * If \p Monotonic is true, dense output is performed using the
+ * predictor stage, otherwise the corrector is used.  The corrector
+ * results are more accurate (but still formally the same order), but
+ * require a RHS evaluation at the end of the step before dense output
+ * can be performed.
+ *
  * The stable step size factors for different orders are (to
  * approximately 4-5 digits):
  *
@@ -74,8 +80,13 @@ namespace TimeSteppers {
  *  </tr>
  * </table>
  */
+template <bool Monotonic>
 class AdamsMoultonPc : public TimeStepper {
  public:
+  static std::string name() {
+    return Monotonic ? "AdamsMoultonPcMonotonic" : "AdamsMoultonPc";
+  }
+
   static constexpr size_t minimum_order = 2;
   static constexpr size_t maximum_order = 8;
 
@@ -86,8 +97,11 @@ class AdamsMoultonPc : public TimeStepper {
     static type upper_bound() { return maximum_order; }
   };
   using options = tmpl::list<Order>;
-  static constexpr Options::String help = {
-      "An Adams-Moulton predictor-corrector time-stepper."};
+  static constexpr Options::String help =
+      Monotonic
+          ? "An Adams-Moulton predictor-corrector time-stepper with monotonic "
+            "dense output."
+          : "An Adams-Moulton predictor-corrector time-stepper.";
 
   AdamsMoultonPc() = default;
   explicit AdamsMoultonPc(size_t order);
@@ -148,6 +162,10 @@ class AdamsMoultonPc : public TimeStepper {
   size_t order_{};
 };
 
-bool operator==(const AdamsMoultonPc& lhs, const AdamsMoultonPc& rhs);
-bool operator!=(const AdamsMoultonPc& lhs, const AdamsMoultonPc& rhs);
+template <bool Monotonic>
+bool operator==(const AdamsMoultonPc<Monotonic>& lhs,
+                const AdamsMoultonPc<Monotonic>& rhs);
+template <bool Monotonic>
+bool operator!=(const AdamsMoultonPc<Monotonic>& lhs,
+                const AdamsMoultonPc<Monotonic>& rhs);
 }  // namespace TimeSteppers

--- a/src/Time/TimeSteppers/AdamsMoultonPc.hpp
+++ b/src/Time/TimeSteppers/AdamsMoultonPc.hpp
@@ -109,6 +109,8 @@ class AdamsMoultonPc : public TimeStepper {
 
   double stable_step() const override;
 
+  bool monotonic() const override;
+
   TimeStepId next_time_id(const TimeStepId& current_id,
                           const TimeDelta& time_step) const override;
 

--- a/src/Time/TimeSteppers/Factory.hpp
+++ b/src/Time/TimeSteppers/Factory.hpp
@@ -21,7 +21,9 @@
 namespace TimeSteppers {
 /// Typelist of available TimeSteppers
 using time_steppers =
-    tmpl::list<TimeSteppers::AdamsBashforth, TimeSteppers::AdamsMoultonPc,
+    tmpl::list<TimeSteppers::AdamsBashforth,
+               TimeSteppers::AdamsMoultonPc<false>,
+               TimeSteppers::AdamsMoultonPc<true>,
                TimeSteppers::ClassicalRungeKutta4, TimeSteppers::DormandPrince5,
                TimeSteppers::Heun2, TimeSteppers::Rk3HesthavenSsp,
                TimeSteppers::Rk3Kennedy, TimeSteppers::Rk3Owren,

--- a/src/Time/TimeSteppers/Rk3HesthavenSsp.cpp
+++ b/src/Time/TimeSteppers/Rk3HesthavenSsp.cpp
@@ -23,6 +23,8 @@ double Rk3HesthavenSsp::stable_step() const {
   return 0.5 * (1. + cbrt(4. + sqrt(17.)) - 1. / cbrt(4. + sqrt(17.)));
 }
 
+bool Rk3HesthavenSsp::monotonic() const { return false; }
+
 uint64_t Rk3HesthavenSsp::number_of_substeps() const { return 3; }
 
 uint64_t Rk3HesthavenSsp::number_of_substeps_for_error() const { return 3; }

--- a/src/Time/TimeSteppers/Rk3HesthavenSsp.hpp
+++ b/src/Time/TimeSteppers/Rk3HesthavenSsp.hpp
@@ -59,6 +59,8 @@ class Rk3HesthavenSsp : public TimeStepper {
 
   double stable_step() const override;
 
+  bool monotonic() const override;
+
   uint64_t number_of_substeps() const override;
 
   uint64_t number_of_substeps_for_error() const override;

--- a/src/Time/TimeSteppers/RungeKutta.cpp
+++ b/src/Time/TimeSteppers/RungeKutta.cpp
@@ -25,6 +25,8 @@ uint64_t RungeKutta::number_of_substeps_for_error() const {
 
 size_t RungeKutta::number_of_past_steps() const { return 0; }
 
+bool RungeKutta::monotonic() const { return false; }
+
 namespace {
 TimeStepId next_time_id_from_substeps(
     const TimeStepId& current_id, const TimeDelta& time_step,

--- a/src/Time/TimeSteppers/RungeKutta.hpp
+++ b/src/Time/TimeSteppers/RungeKutta.hpp
@@ -84,6 +84,8 @@ class RungeKutta : public virtual TimeStepper {
 
   size_t number_of_past_steps() const override;
 
+  bool monotonic() const override;
+
   TimeStepId next_time_id(const TimeStepId& current_id,
                           const TimeDelta& time_step) const override;
 

--- a/src/Time/TimeSteppers/TimeStepper.hpp
+++ b/src/Time/TimeSteppers/TimeStepper.hpp
@@ -27,6 +27,7 @@ namespace TimeSteppers {}
 /// \cond
 #define TIME_STEPPER_WRAPPED_TYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
 #define TIME_STEPPER_DERIVED_CLASS(data) BOOST_PP_TUPLE_ELEM(1, data)
+#define TIME_STEPPER_DERIVED_CLASS_TEMPLATE(data) BOOST_PP_TUPLE_ELEM(2, data)
 /// \endcond
 
 /// \ingroup TimeSteppersGroup
@@ -242,6 +243,7 @@ class TimeStepper : public PUP::able {
           data)>& history) const override;
 
 #define TIME_STEPPER_DEFINE_OVERLOADS_IMPL(_, data)                        \
+  TIME_STEPPER_DERIVED_CLASS_TEMPLATE(data)                                \
   void TIME_STEPPER_DERIVED_CLASS(data)::update_u_forward(                 \
       const gsl::not_null<TIME_STEPPER_WRAPPED_TYPE(data)*> u,             \
       const TimeSteppers::MutableUntypedHistory<TIME_STEPPER_WRAPPED_TYPE( \
@@ -249,6 +251,7 @@ class TimeStepper : public PUP::able {
       const TimeDelta& time_step) const {                                  \
     return update_u_impl(u, history, time_step);                           \
   }                                                                        \
+  TIME_STEPPER_DERIVED_CLASS_TEMPLATE(data)                                \
   bool TIME_STEPPER_DERIVED_CLASS(data)::update_u_forward(                 \
       const gsl::not_null<TIME_STEPPER_WRAPPED_TYPE(data)*> u,             \
       const gsl::not_null<TIME_STEPPER_WRAPPED_TYPE(data)*> u_error,       \
@@ -257,6 +260,7 @@ class TimeStepper : public PUP::able {
       const TimeDelta& time_step) const {                                  \
     return update_u_impl(u, u_error, history, time_step);                  \
   }                                                                        \
+  TIME_STEPPER_DERIVED_CLASS_TEMPLATE(data)                                \
   bool TIME_STEPPER_DERIVED_CLASS(data)::dense_update_u_forward(           \
       const gsl::not_null<TIME_STEPPER_WRAPPED_TYPE(data)*> u,             \
       const TimeSteppers::ConstUntypedHistory<TIME_STEPPER_WRAPPED_TYPE(   \
@@ -264,6 +268,7 @@ class TimeStepper : public PUP::able {
       const double time) const {                                           \
     return dense_update_u_impl(u, history, time);                          \
   }                                                                        \
+  TIME_STEPPER_DERIVED_CLASS_TEMPLATE(data)                                \
   bool TIME_STEPPER_DERIVED_CLASS(data)::can_change_step_size_forward(     \
       const TimeStepId& time_id,                                           \
       const TimeSteppers::ConstUntypedHistory<TIME_STEPPER_WRAPPED_TYPE(   \
@@ -284,6 +289,12 @@ class TimeStepper : public PUP::able {
 /// Macro defining overloaded detail methods in classes derived from
 /// TimeStepper.  Must be placed in the cpp file for the derived
 /// class.
+/// @{
 #define TIME_STEPPER_DEFINE_OVERLOADS(derived_class)          \
   GENERATE_INSTANTIATIONS(TIME_STEPPER_DEFINE_OVERLOADS_IMPL, \
-                          (MATH_WRAPPER_TYPES), (derived_class))
+                          (MATH_WRAPPER_TYPES), (derived_class), ())
+#define TIME_STEPPER_DEFINE_OVERLOADS_TEMPLATED(derived_class, template_args) \
+  GENERATE_INSTANTIATIONS(TIME_STEPPER_DEFINE_OVERLOADS_IMPL,                 \
+                          (MATH_WRAPPER_TYPES), (derived_class),              \
+                          (template <template_args>))
+/// @}

--- a/src/Time/TimeSteppers/TimeStepper.hpp
+++ b/src/Time/TimeSteppers/TimeStepper.hpp
@@ -173,6 +173,21 @@ class TimeStepper : public PUP::able {
   /// stably as a multiple of the step for Euler's method.
   virtual double stable_step() const = 0;
 
+  /// Whether computational and temporal orderings of operations
+  /// match.
+  ///
+  /// If this method returns true, then, for two time-stepper
+  /// operations occurring at different simulation times, the
+  /// temporally earlier operation will be performed first.  These
+  /// operations include RHS evaluation, dense output, and neighbor
+  /// communication.  In particular, dense output never requires
+  /// performing a RHS evaluation later than the output time, so
+  /// control systems measurements cannot cause deadlocks.
+  ///
+  /// \warning This guarantee only holds if the time steps themselves
+  /// are monotonic, which can be violated during initialization.
+  virtual bool monotonic() const = 0;
+
   /// The TimeStepId after the current substep
   virtual TimeStepId next_time_id(const TimeStepId& current_id,
                                   const TimeDelta& time_step) const = 0;

--- a/tests/Unit/ControlSystem/Actions/Test_LimitTimeStep.cpp
+++ b/tests/Unit/ControlSystem/Actions/Test_LimitTimeStep.cpp
@@ -195,7 +195,7 @@ void test(const std::string& test_label, const double initial_time,
 SPECTRE_TEST_CASE("Unit.ControlSystem.Actions.LimitTimeStep",
                   "[Unit][ControlSystem]") {
   register_classes_with_charm<
-      TimeSteppers::AdamsBashforth, TimeSteppers::AdamsMoultonPc,
+      TimeSteppers::AdamsBashforth, TimeSteppers::AdamsMoultonPc<false>,
       TimeSteppers::Rk3HesthavenSsp,
       domain::FunctionsOfTime::PiecewisePolynomial<0>>();
   const double infinity = std::numeric_limits<double>::infinity();
@@ -317,7 +317,7 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.Actions.LimitTimeStep",
        {{0.0, infinity}, {infinity, nan}},
        {{0.0, arbitrary}, {infinity, nan}},
        {{0.0, arbitrary}, {infinity, nan}},
-       std::make_unique<TimeSteppers::AdamsMoultonPc>(4), history);
+       std::make_unique<TimeSteppers::AdamsMoultonPc<false>>(4), history);
   CHECK_THROWS_WITH(
       test("Step can't change but is not OK", 1.0, 5.0, 0.0,
            {{0.0, 1.0}, {5.0, nan}},
@@ -325,7 +325,7 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.Actions.LimitTimeStep",
            {{0.0, infinity}, {infinity, nan}},
            {{0.0, arbitrary}, {infinity, nan}},
            {{0.0, arbitrary}, {infinity, nan}},
-           std::make_unique<TimeSteppers::AdamsMoultonPc>(4), history),
+           std::make_unique<TimeSteppers::AdamsMoultonPc<false>>(4), history),
       Catch::Matchers::ContainsSubstring(
           "Step must be decreased to avoid control-system deadlock, but "
           "time-stepper requires a fixed step size."));

--- a/tests/Unit/Helpers/Time/TimeSteppers/TimeStepperTestUtils.cpp
+++ b/tests/Unit/Helpers/Time/TimeSteppers/TimeStepperTestUtils.cpp
@@ -368,6 +368,7 @@ void check_dense_output(
             return y - *history.complete_step_start().value;
           }
           REQUIRE(not before(time, time_id.step_time().value()));
+          CHECK(not stepper.monotonic());
         }
         y = std::numeric_limits<double>::signaling_NaN();
         if (use_error_methods) {

--- a/tests/Unit/Helpers/Time/TimeSteppers/TimeStepperTestUtils.hpp
+++ b/tests/Unit/Helpers/Time/TimeSteppers/TimeStepperTestUtils.hpp
@@ -93,7 +93,8 @@ void check_convergence_order(const TimeStepper& stepper,
 
 void check_dense_output(
     const TimeStepper& stepper, size_t history_integration_order,
-    const std::pair<int32_t, int32_t>& convergence_step_range);
+    const std::pair<int32_t, int32_t>& convergence_step_range, int32_t stride,
+    bool check_backward_continuity);
 
 void check_strong_stability_preservation(const TimeStepper& stepper,
                                          double step_size);

--- a/tests/Unit/Time/TimeSteppers/Test_AdamsBashforth.cpp
+++ b/tests/Unit/Time/TimeSteppers/Test_AdamsBashforth.cpp
@@ -35,6 +35,7 @@ SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.AdamsBashforth", "[Unit][Time]") {
     CAPTURE(order);
     const TimeSteppers::AdamsBashforth stepper(order);
     TimeStepperTestUtils::check_multistep_properties(stepper);
+    CHECK(stepper.monotonic());
     for (size_t start_points = 0; start_points < order; ++start_points) {
       CAPTURE(start_points);
       const double epsilon = std::max(std::pow(1e-3, start_points + 1), 1e-14);

--- a/tests/Unit/Time/TimeSteppers/Test_AdamsBashforth.cpp
+++ b/tests/Unit/Time/TimeSteppers/Test_AdamsBashforth.cpp
@@ -57,7 +57,7 @@ SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.AdamsBashforth", "[Unit][Time]") {
     for(size_t history_order = 1; history_order <= order; ++history_order){
       CAPTURE(history_order);
       TimeStepperTestUtils::check_dense_output(stepper, history_order,
-                                               {10, 30});
+                                               {10, 30}, 1, true);
     }
 
     CHECK(stepper.order() == order);

--- a/tests/Unit/Time/TimeSteppers/Test_ClassicalRungeKutta4.cpp
+++ b/tests/Unit/Time/TimeSteppers/Test_ClassicalRungeKutta4.cpp
@@ -33,7 +33,7 @@ SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.ClassicalRungeKutta4",
   TimeStepperTestUtils::integrate_variable_test(stepper, 4, 0, 1.0e-9);
   TimeStepperTestUtils::check_convergence_order(stepper, {10, 50});
   TimeStepperTestUtils::stability_test(stepper);
-  TimeStepperTestUtils::check_dense_output(stepper, 4_st, {10, 30});
+  TimeStepperTestUtils::check_dense_output(stepper, 4_st, {10, 30}, 1, true);
 
   TestHelpers::test_factory_creation<TimeStepper,
                                      TimeSteppers::ClassicalRungeKutta4>(

--- a/tests/Unit/Time/TimeSteppers/Test_DormandPrince5.cpp
+++ b/tests/Unit/Time/TimeSteppers/Test_DormandPrince5.cpp
@@ -32,7 +32,7 @@ SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.DormandPrince5", "[Unit][Time]") {
   TimeStepperTestUtils::integrate_variable_test(stepper, 5, 0, 1.0e-9);
   TimeStepperTestUtils::check_convergence_order(stepper, {10, 50});
   TimeStepperTestUtils::stability_test(stepper);
-  TimeStepperTestUtils::check_dense_output(stepper, 5_st, {10, 30});
+  TimeStepperTestUtils::check_dense_output(stepper, 5_st, {10, 30}, 1, true);
 
   TestHelpers::test_factory_creation<TimeStepper, TimeSteppers::DormandPrince5>(
       "DormandPrince5");

--- a/tests/Unit/Time/TimeSteppers/Test_Heun2.cpp
+++ b/tests/Unit/Time/TimeSteppers/Test_Heun2.cpp
@@ -33,7 +33,7 @@ SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.Heun2", "[Unit][Time]") {
   TimeStepperTestUtils::integrate_variable_test(stepper, 2, 0, 1.0e-6);
   TimeStepperTestUtils::stability_test(stepper);
   TimeStepperTestUtils::check_convergence_order(stepper, {10, 50});
-  TimeStepperTestUtils::check_dense_output(stepper, 2_st, {10, 100});
+  TimeStepperTestUtils::check_dense_output(stepper, 2_st, {10, 100}, 1, true);
 
   TimeStepperTestUtils::imex::check_convergence_order(stepper, {10, 50});
   TimeStepperTestUtils::imex::check_bounded_dense_output(stepper);

--- a/tests/Unit/Time/TimeSteppers/Test_Rk3HesthavenSsp.cpp
+++ b/tests/Unit/Time/TimeSteppers/Test_Rk3HesthavenSsp.cpp
@@ -31,7 +31,7 @@ SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.Rk3HesthavenSsp", "[Unit][Time]") {
   TimeStepperTestUtils::integrate_variable_test(stepper, 3, 0, 1e-9);
   TimeStepperTestUtils::stability_test(stepper);
   TimeStepperTestUtils::check_convergence_order(stepper, {10, 50});
-  TimeStepperTestUtils::check_dense_output(stepper, 3_st, {10, 30});
+  TimeStepperTestUtils::check_dense_output(stepper, 3_st, {10, 30}, 1, true);
 
   TimeStepperTestUtils::check_strong_stability_preservation(stepper, 1.0);
 

--- a/tests/Unit/Time/TimeSteppers/Test_Rk3Kennedy.cpp
+++ b/tests/Unit/Time/TimeSteppers/Test_Rk3Kennedy.cpp
@@ -33,7 +33,7 @@ SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.Rk3Kennedy", "[Unit][Time]") {
   TimeStepperTestUtils::integrate_variable_test(stepper, 3, 0, 1.0e-9);
   TimeStepperTestUtils::stability_test(stepper);
   TimeStepperTestUtils::check_convergence_order(stepper, {10, 50});
-  TimeStepperTestUtils::check_dense_output(stepper, 3_st, {10, 30});
+  TimeStepperTestUtils::check_dense_output(stepper, 3_st, {10, 30}, 1, true);
 
   TimeStepperTestUtils::imex::check_convergence_order(stepper, {10, 50});
   TimeStepperTestUtils::imex::check_bounded_dense_output(stepper);

--- a/tests/Unit/Time/TimeSteppers/Test_Rk3Owren.cpp
+++ b/tests/Unit/Time/TimeSteppers/Test_Rk3Owren.cpp
@@ -31,7 +31,7 @@ SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.Rk3Owren", "[Unit][Time]") {
   TimeStepperTestUtils::integrate_variable_test(stepper, 3, 0, 1.0e-9);
   TimeStepperTestUtils::stability_test(stepper);
   TimeStepperTestUtils::check_convergence_order(stepper, {10, 50});
-  TimeStepperTestUtils::check_dense_output(stepper, 3_st, {10, 30});
+  TimeStepperTestUtils::check_dense_output(stepper, 3_st, {10, 30}, 1, true);
 
   TestHelpers::test_factory_creation<TimeStepper, TimeSteppers::Rk3Owren>(
       "Rk3Owren");

--- a/tests/Unit/Time/TimeSteppers/Test_Rk3Pareschi.cpp
+++ b/tests/Unit/Time/TimeSteppers/Test_Rk3Pareschi.cpp
@@ -33,7 +33,7 @@ SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.Rk3Pareschi", "[Unit][Time]") {
   TimeStepperTestUtils::integrate_variable_test(stepper, 3, 0, 1.0e-9);
   TimeStepperTestUtils::stability_test(stepper);
   TimeStepperTestUtils::check_convergence_order(stepper, {10, 50});
-  TimeStepperTestUtils::check_dense_output(stepper, 3_st, {10, 30});
+  TimeStepperTestUtils::check_dense_output(stepper, 3_st, {10, 30}, 1, true);
 
   TimeStepperTestUtils::imex::check_convergence_order(stepper, {10, 50});
   TimeStepperTestUtils::imex::check_bounded_dense_output(stepper);

--- a/tests/Unit/Time/TimeSteppers/Test_Rk4Kennedy.cpp
+++ b/tests/Unit/Time/TimeSteppers/Test_Rk4Kennedy.cpp
@@ -33,7 +33,7 @@ SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.Rk4Kennedy", "[Unit][Time]") {
   TimeStepperTestUtils::integrate_variable_test(stepper, 4, 0, 1.0e-14);
   TimeStepperTestUtils::stability_test(stepper);
   TimeStepperTestUtils::check_convergence_order(stepper, {10, 50});
-  TimeStepperTestUtils::check_dense_output(stepper, 4_st, {10, 30});
+  TimeStepperTestUtils::check_dense_output(stepper, 4_st, {10, 30}, 1, true);
 
   TimeStepperTestUtils::imex::check_convergence_order(stepper, {10, 50});
   TimeStepperTestUtils::imex::check_bounded_dense_output(stepper);

--- a/tests/Unit/Time/TimeSteppers/Test_Rk4Owren.cpp
+++ b/tests/Unit/Time/TimeSteppers/Test_Rk4Owren.cpp
@@ -31,7 +31,7 @@ SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.Rk4Owren", "[Unit][Time]") {
   TimeStepperTestUtils::integrate_variable_test(stepper, 4, 0, 1.0e-9);
   TimeStepperTestUtils::stability_test(stepper);
   TimeStepperTestUtils::check_convergence_order(stepper, {10, 50});
-  TimeStepperTestUtils::check_dense_output(stepper, 4_st, {10, 30});
+  TimeStepperTestUtils::check_dense_output(stepper, 4_st, {10, 30}, 1, true);
 
   TestHelpers::test_factory_creation<TimeStepper, TimeSteppers::Rk4Owren>(
       "Rk4Owren");

--- a/tests/Unit/Time/TimeSteppers/Test_Rk5Owren.cpp
+++ b/tests/Unit/Time/TimeSteppers/Test_Rk5Owren.cpp
@@ -31,7 +31,7 @@ SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.Rk5Owren", "[Unit][Time]") {
   TimeStepperTestUtils::integrate_variable_test(stepper, 5, 0, 1.0e-9);
   TimeStepperTestUtils::stability_test(stepper);
   TimeStepperTestUtils::check_convergence_order(stepper, {10, 50});
-  TimeStepperTestUtils::check_dense_output(stepper, 5_st, {10, 30});
+  TimeStepperTestUtils::check_dense_output(stepper, 5_st, {10, 30}, 1, true);
 
   TestHelpers::test_factory_creation<TimeStepper, TimeSteppers::Rk5Owren>(
       "Rk5Owren");

--- a/tests/Unit/Time/TimeSteppers/Test_Rk5Tsitouras.cpp
+++ b/tests/Unit/Time/TimeSteppers/Test_Rk5Tsitouras.cpp
@@ -32,7 +32,7 @@ SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.Rk5Tsitouras", "[Unit][Time]") {
   TimeStepperTestUtils::integrate_variable_test(stepper, 5, 0, 1.0e-9);
   TimeStepperTestUtils::check_convergence_order(stepper, {30, 70});
   TimeStepperTestUtils::stability_test(stepper);
-  TimeStepperTestUtils::check_dense_output(stepper, 5_st, {10, 30});
+  TimeStepperTestUtils::check_dense_output(stepper, 5_st, {10, 30}, 1, true);
 
   TestHelpers::test_factory_creation<TimeStepper, TimeSteppers::Rk5Tsitouras>(
       "Rk5Tsitouras");


### PR DESCRIPTION
Naturally avoids control-system deadlocks like AdamsBashforth.  Will extend to LTS later.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
