### PR TITLE
Add hydro coupling bookkeeping to emission function in MC

### DIFF
--- a/src/Evolution/Particles/MonteCarlo/TemplatedLocalFunctions.hpp
+++ b/src/Evolution/Particles/MonteCarlo/TemplatedLocalFunctions.hpp
@@ -24,10 +24,11 @@ struct Packet;
 
 namespace detail {
 
-void draw_single_packet(gsl::not_null<double*> time,
-                        gsl::not_null<std::array<double, 3>*> coord,
-                        gsl::not_null<std::array<double, 3>*> momentum,
-                        gsl::not_null<std::mt19937*> random_number_generator);
+void draw_single_packet(
+    gsl::not_null<double*> time,
+    gsl::not_null<std::array<double, 3>*> coord,
+    gsl::not_null<std::array<double, 3>*> momentum,
+    gsl::not_null<std::mt19937*> random_number_generator);
 }  // namespace detail
 
 /// Structure containing Monte-Carlo function templated on EnergyBins
@@ -66,12 +67,18 @@ struct TemplatedLocalFunctions {
   void emit_packets(
       gsl::not_null<std::vector<Packet>*> packets,
       gsl::not_null<std::mt19937*> random_number_generator,
+      gsl::not_null<Scalar<DataVector>*> coupling_tilde_tau,
+      gsl::not_null<tnsr::i<DataVector, 3, Frame::Inertial>*> coupling_tilde_s,
+      gsl::not_null<Scalar<DataVector>*> coupling_rho_ye,
       const double& time_start_step, const double& time_step,
       const Mesh<3>& mesh,
       const std::array<std::array<DataVector, EnergyBins>, NeutrinoSpecies>&
           emission_in_cell,
       const std::array<DataVector, NeutrinoSpecies>& single_packet_energy,
       const std::array<double, EnergyBins>& energy_at_bin_center,
+      const Scalar<DataVector>& lorentz_factor,
+      const tnsr::i<DataVector, 3, Frame::Inertial>&
+          lower_spatial_four_velocity,
       const Jacobian<DataVector, 4, Frame::Inertial, Frame::Fluid>&
           inertial_to_fluid_jacobian,
       const InverseJacobian<DataVector, 4, Frame::Inertial, Frame::Fluid>&

--- a/src/PointwiseFunctions/Hydro/Units.hpp
+++ b/src/PointwiseFunctions/Hydro/Units.hpp
@@ -5,6 +5,8 @@
 
 #include <cmath>
 
+#include "Utilities/ConstantExpressions.hpp"
+
 namespace hydro {
 /*!
  * \brief Functions, constants, and classes for converting between different
@@ -67,6 +69,8 @@ constexpr double pressure_unit =
 constexpr double atomic_mass_unit = 1.66053906660e-24;
 /// The neutron mass, given in grams, uncertainty at 5.7 x 10^-10 level
 constexpr double neutron_mass = 1.67492749804e-24;
+/// The proton mass, given in grams. Uncertainty at 2e-8 level
+constexpr double proton_mass = 1.672621898e-24;
 /// The electron-volt (eV) given in ergs, which is known exactly in SI/cgs
 constexpr double electron_volt = 1.602176634e-12;
 
@@ -144,6 +148,10 @@ constexpr double neutron_mass =
     (1.0e6 * cgs::electron_volt / square(cgs::speed_of_light));
 constexpr double atomic_mass_unit =
     cgs::atomic_mass_unit /
+    (1.0e6 * cgs::electron_volt / square(cgs::speed_of_light));
+/// The proton mass in MeV, uncertainty at 5.8eV.
+constexpr double proton_mass =
+    cgs::proton_mass /
     (1.0e6 * cgs::electron_volt / square(cgs::speed_of_light));
 
 /// The saturation number density of baryons in nuclear matter, in


### PR DESCRIPTION
## Proposed changes

This PR begins the process of keeping track of energy/momentum/lepton number exchange between neutrinos and the fluid. Here, I only consider the "emit" function, as it is already merged.
My current plan is to keep the total energy/momentum/lepton number in the various coupling_* containers, then divide by the coordinate volume at the end of a timestep to get the actual coupling terms used in the GhValenciaDivClean equations.

### Upgrade instructions

None

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.