### PR TITLE
Calculation of proper and coordinate volume needed for MC

### DIFF
--- a/src/Evolution/Particles/MonteCarlo/CMakeLists.txt
+++ b/src/Evolution/Particles/MonteCarlo/CMakeLists.txt
@@ -8,6 +8,7 @@ add_spectre_library(${LIBRARY})
 spectre_target_sources(
   ${LIBRARY}
   PRIVATE
+  CellVolume.cpp
   EvolvePackets.cpp
   InverseJacobianInertialToFluidCompute.cpp
   TemplatedLocalFunctions.cpp
@@ -19,6 +20,7 @@ spectre_target_headers(
   ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
+  CellVolume.hpp
   EmitPackets.tpp
   EvolvePackets.hpp
   EvolvePacketsInElement.tpp

--- a/src/Evolution/Particles/MonteCarlo/CellVolume.cpp
+++ b/src/Evolution/Particles/MonteCarlo/CellVolume.cpp
@@ -1,0 +1,33 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Evolution/Particles/MonteCarlo/CellVolume.hpp"
+
+namespace Particles::MonteCarlo {
+
+void cell_proper_four_volume_finite_difference(
+    const gsl::not_null<Scalar<DataVector>*> cell_proper_four_volume,
+    const Scalar<DataVector>& lapse,
+    const Scalar<DataVector>& determinant_spatial_metric,
+    const double time_step, const Mesh<3>& mesh,
+    const Scalar<DataVector>& det_jacobian_logical_to_inertial) {
+  const double cell_logical_volume =
+    8.0 / static_cast<double>(mesh.number_of_grid_points());
+  cell_proper_four_volume->get() =
+      get(lapse) * get(determinant_spatial_metric) * time_step *
+      cell_logical_volume * get(det_jacobian_logical_to_inertial);
+}
+
+void cell_inertial_coordinate_three_volume_finite_difference(
+    gsl::not_null<Scalar<DataVector>*> cell_inertial_three_volume,
+    const Mesh<3>& mesh,
+    const Scalar<DataVector>& det_jacobian_logical_to_inertial) {
+  const double cell_logical_volume =
+    8.0 / static_cast<double>(mesh.number_of_grid_points());
+  cell_inertial_three_volume->get() =
+      cell_logical_volume * get(det_jacobian_logical_to_inertial);
+}
+
+}  // namespace Particles::MonteCarlo

--- a/src/Evolution/Particles/MonteCarlo/CellVolume.hpp
+++ b/src/Evolution/Particles/MonteCarlo/CellVolume.hpp
@@ -1,0 +1,46 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "Utilities/Gsl.hpp"
+
+/// \cond
+namespace gsl {
+  template <typename T>
+  class not_null;
+}  // namespace gsl
+
+class DataVector;
+
+template<size_t Dim>
+class Mesh;
+/// \endcond
+
+namespace Particles::MonteCarlo {
+
+/// Proper 4-volume of a cell for a time step time_step.
+/// We assume that determinant_spatial_metric is given
+/// in inertial coordinates, hence the need for
+/// det_jacobian_logical_to_inertial
+void cell_proper_four_volume_finite_difference(
+  gsl::not_null<Scalar<DataVector>* > cell_proper_four_volume,
+  const Scalar<DataVector>& lapse,
+  const Scalar<DataVector>& determinant_spatial_metric,
+  double time_step,
+  const Mesh<3>& mesh,
+  const Scalar<DataVector>& det_jacobian_logical_to_inertial);
+
+/// 3-volume of a cell in inertial coordinate. Note that this is
+/// the coordinate volume, not the proper volume. This quantity
+/// is needed as a normalization factor for the terms coupling
+/// Monte-Carlo transport to the fluid evolution (as we evolved
+/// densitized fluid variables in inertial coordinates).
+void cell_inertial_coordinate_three_volume_finite_difference(
+  gsl::not_null<Scalar<DataVector>* > cell_inertial_three_volume,
+  const Mesh<3>& mesh,
+  const Scalar<DataVector>& det_jacobian_logical_to_inertial);
+
+} // namespace Particles::MonteCarlo

--- a/tests/Unit/Evolution/Particles/MonteCarlo/CMakeLists.txt
+++ b/tests/Unit/Evolution/Particles/MonteCarlo/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY "Test_MonteCarlo")
 
 set(LIBRARY_SOURCES
+  Test_CellVolume.cpp
   Test_EmitPackets.cpp
   Test_EvolvePackets.cpp
   Test_InterpolateOpacities.cpp

--- a/tests/Unit/Evolution/Particles/MonteCarlo/Test_CellVolume.cpp
+++ b/tests/Unit/Evolution/Particles/MonteCarlo/Test_CellVolume.cpp
@@ -1,0 +1,40 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Evolution/Particles/MonteCarlo/CellVolume.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+
+SPECTRE_TEST_CASE("Unit.Evolution.Particles.MonteCarloCellVolume",
+                  "[Unit][Evolution]") {
+  const Mesh<3> mesh(3, Spectral::Basis::FiniteDifference,
+                     Spectral::Quadrature::CellCentered);
+
+  const size_t dv_size = 27;
+  DataVector zero_dv(dv_size, 0.0);
+  Scalar<DataVector> lapse{DataVector(dv_size, 1.2)};
+  Scalar<DataVector> determinant_spatial_metric{DataVector(dv_size, 0.9)};
+  Scalar<DataVector> det_jacobian_logical_to_inertial{DataVector(dv_size, 1.1)};
+  const double time_step = 0.6;
+
+  Scalar<DataVector> cell_proper_four_volume{DataVector(dv_size, 0.0)};
+  Scalar<DataVector> expected_cell_proper_four_volume{
+      DataVector(dv_size, 8.0 / 27.0 * 1.2 * 0.9 * 0.6 * 1.1)};
+  Particles::MonteCarlo::cell_proper_four_volume_finite_difference(
+      &cell_proper_four_volume, lapse, determinant_spatial_metric, time_step,
+      mesh, det_jacobian_logical_to_inertial);
+
+  Scalar<DataVector> cell_inertial_three_volume{DataVector(dv_size, 0.0)};
+  Scalar<DataVector> expected_cell_inertial_three_volume{
+      DataVector(dv_size, 8.0 / 27.0 * 1.1)};
+  Particles::MonteCarlo::
+      cell_inertial_coordinate_three_volume_finite_difference(
+          &cell_inertial_three_volume, mesh, det_jacobian_logical_to_inertial);
+
+  CHECK(expected_cell_proper_four_volume == cell_proper_four_volume);
+  CHECK(expected_cell_inertial_three_volume == cell_inertial_three_volume);
+}


### PR DESCRIPTION
## Proposed changes

Add calculation of the proper 4-volume of a cell over a time step, and the coordinate spatial 3-volume of a cell in inertial coordinates. Both are needed during MC evolution (the first for emission, the second to normalize coupling terms)>

### Upgrade instructions

None

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.