### PR TITLE
CleanOutput.py: support glob patterns

### DIFF
--- a/support/Pipelines/Bbh/InitialData.yaml
+++ b/support/Pipelines/Bbh/InitialData.yaml
@@ -2,6 +2,9 @@
 # See LICENSE.txt for details.
 
 Executable: SolveXcts
+ExpectedOutput:
+  - BbhReductions.h5
+  - BbhVolume*.h5
 {% if evolve %}
 Next:
   Run: spectre.Pipelines.Bbh.Inspiral:start_inspiral

--- a/tests/InputFiles/Poisson/ProductOfSinusoids1D.yaml
+++ b/tests/InputFiles/Poisson/ProductOfSinusoids1D.yaml
@@ -8,12 +8,7 @@ Testing:
 ExpectedOutput:
   - PoissonProductOfSinusoids1DReductions.h5
   - PoissonProductOfSinusoids1DVolume0.h5
-  - SubdomainMatrix_[B0,(L1I0)].txt
-  - SubdomainMatrix_[B0,(L1I1)].txt
-  - SubdomainMatrix_[B0,(L2I0)].txt
-  - SubdomainMatrix_[B0,(L2I1)].txt
-  - SubdomainMatrix_[B0,(L2I2)].txt
-  - SubdomainMatrix_[B0,(L2I3)].txt
+  - SubdomainMatrix*.txt
 OutputFileChecks:
   - Label: Discretization error
     Subfile: ErrorNorms.dat

--- a/tests/tools/Test_CleanOutput.py
+++ b/tests/tools/Test_CleanOutput.py
@@ -27,7 +27,7 @@ class TestCleanOutput(unittest.TestCase):
         os.makedirs(self.test_dir, exist_ok=True)
         with open(self.input_file_path, "w") as open_file:
             yaml.safe_dump_all(
-                [{"ExpectedOutput": ["Reduction.h5", "Volume0.h5"]}, {}],
+                [{"ExpectedOutput": ["Reduction.h5", "Volume*.h5"]}, {}],
                 open_file,
             )
 
@@ -48,7 +48,7 @@ class TestCleanOutput(unittest.TestCase):
         )
         with open(self.reduction_file_path, "w"):
             pass
-        with self.assertRaisesRegex(MissingExpectedOutputError, "Volume0.h5"):
+        with self.assertRaisesRegex(MissingExpectedOutputError, "Volume\*.h5"):
             clean_output(
                 input_file=self.input_file_path,
                 output_dir=self.test_dir,


### PR DESCRIPTION
## Proposed changes

Makes it easier to clean up after previous runs.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
