### PR TITLE
XCTS: add Robin outer boundary conditions

### DIFF
--- a/src/Elliptic/BoundaryConditions/AnalyticSolution.hpp
+++ b/src/Elliptic/BoundaryConditions/AnalyticSolution.hpp
@@ -134,6 +134,9 @@ class AnalyticSolution<System, Dim, tmpl::list<FieldTags...>,
   template <typename Metavariables>
   void apply(const gsl::not_null<typename FieldTags::type*>... fields,
              const gsl::not_null<typename FieldTags::type*>... n_dot_fluxes,
+             const TensorMetafunctions::prepend_spatial_index<
+                 typename FieldTags::type, Dim, UpLo::Lo,
+                 Frame::Inertial>&... /*deriv_fields*/,
              const Metavariables& /*meta*/,
              const tnsr::I<DataVector, Dim>& face_inertial_coords,
              const tnsr::i<DataVector, Dim>& face_normal) const {
@@ -184,7 +187,10 @@ class AnalyticSolution<System, Dim, tmpl::list<FieldTags...>,
 
   void apply_linearized(
       const gsl::not_null<typename FieldTags::type*>... fields,
-      const gsl::not_null<typename FieldTags::type*>... n_dot_fluxes) const {
+      const gsl::not_null<typename FieldTags::type*>... n_dot_fluxes,
+      const TensorMetafunctions::prepend_spatial_index<
+          typename FieldTags::type, Dim, UpLo::Lo,
+          Frame::Inertial>&... /*deriv_fields*/) const {
     const auto impose_boundary_condition = [this](auto field_tag_v,
                                                   const auto field,
                                                   const auto n_dot_flux) {

--- a/src/Elliptic/BoundaryConditions/ApplyBoundaryCondition.hpp
+++ b/src/Elliptic/BoundaryConditions/ApplyBoundaryCondition.hpp
@@ -68,7 +68,7 @@ void apply_boundary_condition(
     const elliptic::BoundaryConditions::BoundaryCondition<Dim>&
         boundary_condition,
     const db::DataBox<DbTagsList>& box, const MapKeys& map_keys_to_direction,
-    const gsl::not_null<FieldsAndFluxes*>... fields_and_fluxes) {
+    FieldsAndFluxes&&... fields_and_fluxes) {
   using boundary_condition_classes =
       typename detail::GetBoundaryConditionClasses<
           elliptic::BoundaryConditions::BoundaryCondition<Dim>,
@@ -99,9 +99,13 @@ void apply_boundary_condition(
                                  volume_tags_transformed>(
             [&derived, &fields_and_fluxes...](const auto&... args) {
               if constexpr (Linearized) {
-                derived->apply_linearized(fields_and_fluxes..., args...);
+                derived->apply_linearized(
+                    std::forward<FieldsAndFluxes>(fields_and_fluxes)...,
+                    args...);
               } else {
-                derived->apply(fields_and_fluxes..., args...);
+                derived->apply(
+                    std::forward<FieldsAndFluxes>(fields_and_fluxes)...,
+                    args...);
               }
             },
             box, map_keys_to_direction);

--- a/src/Elliptic/BoundaryConditions/BoundaryCondition.hpp
+++ b/src/Elliptic/BoundaryConditions/BoundaryCondition.hpp
@@ -68,12 +68,11 @@ namespace BoundaryConditions {
  *   1. The dynamic fields as not-null pointers.
  *   2. The normal-dot-fluxes corresponding to the dynamic fields as not-null
  *      pointers. These have the same types as the dynamic fields.
- *   3. The types held by the argument tags.
+ *   3. The field derivatives as const-refs.
+ *   4. The types held by the argument tags.
  *
- *   For first-order systems that involve auxiliary variables, only the
- *   non-auxiliary ("primal") variables are included in the lists above. For
- *   example, boundary conditions for a first-order Poisson system might have an
- *   `apply` function signature that looks like this:
+ *   For example, boundary conditions for a first-order Poisson system might
+ *   have an `apply` function signature that looks like this:
  *
  *   \snippet Elliptic/BoundaryConditions/Test_BoundaryCondition.cpp example_poisson_fields
  *

--- a/src/Elliptic/DiscontinuousGalerkin/Actions/ApplyOperator.hpp
+++ b/src/Elliptic/DiscontinuousGalerkin/Actions/ApplyOperator.hpp
@@ -181,7 +181,7 @@ struct PrepareAndSendMortarData<
             element_id.block_id());
     const auto apply_boundary_condition =
         [&box, &boundary_conditions, &element_id](
-            const Direction<Dim>& direction, const auto... fields_and_fluxes) {
+            const Direction<Dim>& direction, auto&&... fields_and_fluxes) {
           ASSERT(
               boundary_conditions.contains(direction),
               "No boundary condition is available in block "
@@ -198,7 +198,8 @@ struct PrepareAndSendMortarData<
               dynamic_cast<const BoundaryConditionsBase&>(
                   *boundary_conditions.at(direction));
           elliptic::apply_boundary_condition<Linearized>(
-              boundary_condition, box, direction, fields_and_fluxes...);
+              boundary_condition, box, direction,
+              std::forward<decltype(fields_and_fluxes)>(fields_and_fluxes)...);
         };
 
     // Can't `db::get` the arguments for the boundary conditions within
@@ -564,7 +565,7 @@ struct ImposeInhomogeneousBoundaryConditionsOnSource<
             element_id.block_id());
     const auto apply_boundary_condition =
         [&box, &boundary_conditions, &element_id](
-            const Direction<Dim>& direction, const auto... fields_and_fluxes) {
+            const Direction<Dim>& direction, auto&&... fields_and_fluxes) {
           ASSERT(
               boundary_conditions.contains(direction),
               "No boundary condition is available in block "
@@ -581,7 +582,8 @@ struct ImposeInhomogeneousBoundaryConditionsOnSource<
               dynamic_cast<const BoundaryConditionsBase&>(
                   *boundary_conditions.at(direction));
           elliptic::apply_boundary_condition<false>(
-              boundary_condition, box, direction, fields_and_fluxes...);
+              boundary_condition, box, direction,
+              std::forward<decltype(fields_and_fluxes)>(fields_and_fluxes)...);
         };
 
     // Can't `db::get` the arguments for the boundary conditions within

--- a/src/Elliptic/Systems/Elasticity/BoundaryConditions/LaserBeam.cpp
+++ b/src/Elliptic/Systems/Elasticity/BoundaryConditions/LaserBeam.cpp
@@ -15,6 +15,7 @@ namespace Elasticity::BoundaryConditions {
 void LaserBeam::apply(
     const gsl::not_null<tnsr::I<DataVector, 3>*> /*displacement*/,
     const gsl::not_null<tnsr::I<DataVector, 3>*> n_dot_minus_stress,
+    const tnsr::iJ<DataVector, 3>& /*deriv_displacement*/,
     const tnsr::I<DataVector, 3>& x,
     const tnsr::i<DataVector, 3>& face_normal) const {
   const auto n_dot_x = get<0>(face_normal) * get<0>(x) +
@@ -31,7 +32,8 @@ void LaserBeam::apply(
 
 void LaserBeam::apply_linearized(
     const gsl::not_null<tnsr::I<DataVector, 3>*> /*displacement*/,
-    const gsl::not_null<tnsr::I<DataVector, 3>*> n_dot_minus_stress) {
+    const gsl::not_null<tnsr::I<DataVector, 3>*> n_dot_minus_stress,
+    const tnsr::iJ<DataVector, 3>& /*deriv_displacement*/) {
   get<0>(*n_dot_minus_stress) = 0.;
   get<1>(*n_dot_minus_stress) = 0.;
   get<2>(*n_dot_minus_stress) = 0.;

--- a/src/Elliptic/Systems/Elasticity/BoundaryConditions/LaserBeam.hpp
+++ b/src/Elliptic/Systems/Elasticity/BoundaryConditions/LaserBeam.hpp
@@ -102,6 +102,7 @@ class LaserBeam : public elliptic::BoundaryConditions::BoundaryCondition<3> {
 
   void apply(gsl::not_null<tnsr::I<DataVector, 3>*> displacement,
              gsl::not_null<tnsr::I<DataVector, 3>*> n_dot_minus_stress,
+             const tnsr::iJ<DataVector, 3>& deriv_displacement,
              const tnsr::I<DataVector, 3>& x,
              const tnsr::i<DataVector, 3>& face_normal) const;
 
@@ -110,7 +111,8 @@ class LaserBeam : public elliptic::BoundaryConditions::BoundaryCondition<3> {
 
   static void apply_linearized(
       gsl::not_null<tnsr::I<DataVector, 3>*> displacement,
-      gsl::not_null<tnsr::I<DataVector, 3>*> n_dot_minus_stress);
+      gsl::not_null<tnsr::I<DataVector, 3>*> n_dot_minus_stress,
+      const tnsr::iJ<DataVector, 3>& deriv_displacement);
 
   // NOLINTNEXTLINE(google-runtime-references)
   void pup(PUP::er& p) override { p | beam_width_; }

--- a/src/Elliptic/Systems/Elasticity/BoundaryConditions/Zero.cpp
+++ b/src/Elliptic/Systems/Elasticity/BoundaryConditions/Zero.cpp
@@ -28,7 +28,8 @@ std::string Zero<Dim, BoundaryConditionType>::name() {
 template <size_t Dim, elliptic::BoundaryConditionType BoundaryConditionType>
 void Zero<Dim, BoundaryConditionType>::apply(
     const gsl::not_null<tnsr::I<DataVector, Dim>*> displacement,
-    const gsl::not_null<tnsr::I<DataVector, Dim>*> n_dot_minus_stress) {
+    const gsl::not_null<tnsr::I<DataVector, Dim>*> n_dot_minus_stress,
+    const tnsr::iJ<DataVector, Dim>& /*deriv_displacement*/) {
   if constexpr (BoundaryConditionType ==
                 elliptic::BoundaryConditionType::Dirichlet) {
     (void)n_dot_minus_stress;
@@ -46,8 +47,9 @@ void Zero<Dim, BoundaryConditionType>::apply(
 template <size_t Dim, elliptic::BoundaryConditionType BoundaryConditionType>
 void Zero<Dim, BoundaryConditionType>::apply_linearized(
     const gsl::not_null<tnsr::I<DataVector, Dim>*> displacement,
-    const gsl::not_null<tnsr::I<DataVector, Dim>*> n_dot_minus_stress) {
-  apply(displacement, n_dot_minus_stress);
+    const gsl::not_null<tnsr::I<DataVector, Dim>*> n_dot_minus_stress,
+    const tnsr::iJ<DataVector, Dim>& deriv_displacement) {
+  apply(displacement, n_dot_minus_stress, deriv_displacement);
 }
 
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)

--- a/src/Elliptic/Systems/Elasticity/BoundaryConditions/Zero.hpp
+++ b/src/Elliptic/Systems/Elasticity/BoundaryConditions/Zero.hpp
@@ -86,16 +86,17 @@ class Zero : public elliptic::BoundaryConditions::BoundaryCondition<Dim> {
   using argument_tags = tmpl::list<>;
   using volume_tags = tmpl::list<>;
 
-  static void apply(
-      gsl::not_null<tnsr::I<DataVector, Dim>*> displacement,
-      gsl::not_null<tnsr::I<DataVector, Dim>*> n_dot_minus_stress);
+  static void apply(gsl::not_null<tnsr::I<DataVector, Dim>*> displacement,
+                    gsl::not_null<tnsr::I<DataVector, Dim>*> n_dot_minus_stress,
+                    const tnsr::iJ<DataVector, Dim>& deriv_displacement);
 
   using argument_tags_linearized = tmpl::list<>;
   using volume_tags_linearized = tmpl::list<>;
 
   static void apply_linearized(
       gsl::not_null<tnsr::I<DataVector, Dim>*> displacement,
-      gsl::not_null<tnsr::I<DataVector, Dim>*> n_dot_minus_stress);
+      gsl::not_null<tnsr::I<DataVector, Dim>*> n_dot_minus_stress,
+      const tnsr::iJ<DataVector, Dim>& deriv_displacement);
 };
 
 template <size_t Dim, elliptic::BoundaryConditionType BoundaryConditionType>

--- a/src/Elliptic/Systems/Poisson/BoundaryConditions/Robin.cpp
+++ b/src/Elliptic/Systems/Poisson/BoundaryConditions/Robin.cpp
@@ -30,7 +30,8 @@ Robin<Dim>::Robin(const double dirichlet_weight, const double neumann_weight,
 template <size_t Dim>
 void Robin<Dim>::apply(
     const gsl::not_null<Scalar<DataVector>*> field,
-    const gsl::not_null<Scalar<DataVector>*> n_dot_field_gradient) const {
+    const gsl::not_null<Scalar<DataVector>*> n_dot_field_gradient,
+    const tnsr::i<DataVector, Dim>& /*deriv_field*/) const {
   if (neumann_weight_ == 0.) {
     ASSERT(
         not equal_within_roundoff(dirichlet_weight_, 0.),
@@ -49,8 +50,8 @@ void Robin<Dim>::apply(
 template <size_t Dim>
 void Robin<Dim>::apply_linearized(
     const gsl::not_null<Scalar<DataVector>*> field_correction,
-    const gsl::not_null<Scalar<DataVector>*> n_dot_field_gradient_correction)
-    const {
+    const gsl::not_null<Scalar<DataVector>*> n_dot_field_gradient_correction,
+    const tnsr::i<DataVector, Dim>& /*deriv_field_correction*/) const {
   if (neumann_weight_ == 0.) {
     get(*field_correction) = 0.;
   } else {

--- a/src/Elliptic/Systems/Poisson/BoundaryConditions/Robin.hpp
+++ b/src/Elliptic/Systems/Poisson/BoundaryConditions/Robin.hpp
@@ -90,14 +90,16 @@ class Robin : public elliptic::BoundaryConditions::BoundaryCondition<Dim> {
   using volume_tags = tmpl::list<>;
 
   void apply(gsl::not_null<Scalar<DataVector>*> field,
-             gsl::not_null<Scalar<DataVector>*> n_dot_field_gradient) const;
+             gsl::not_null<Scalar<DataVector>*> n_dot_field_gradient,
+             const tnsr::i<DataVector, Dim>& deriv_field) const;
 
   using argument_tags_linearized = tmpl::list<>;
   using volume_tags_linearized = tmpl::list<>;
 
   void apply_linearized(
       gsl::not_null<Scalar<DataVector>*> field_correction,
-      gsl::not_null<Scalar<DataVector>*> n_dot_field_gradient_correction) const;
+      gsl::not_null<Scalar<DataVector>*> n_dot_field_gradient_correction,
+      const tnsr::i<DataVector, Dim>& deriv_field_correction) const;
 
   void pup(PUP::er& p) override;
 

--- a/src/Elliptic/Systems/Punctures/BoundaryConditions/Flatness.cpp
+++ b/src/Elliptic/Systems/Punctures/BoundaryConditions/Flatness.cpp
@@ -13,6 +13,7 @@ namespace Punctures::BoundaryConditions {
 void Flatness::apply(
     const gsl::not_null<Scalar<DataVector>*> field,
     const gsl::not_null<Scalar<DataVector>*> n_dot_field_gradient,
+    const tnsr::i<DataVector, 3>& /*field_gradient*/,
     const tnsr::I<DataVector, 3>& x) {
   get(*n_dot_field_gradient) = -get(*field) / get(magnitude(x));
 }
@@ -20,6 +21,7 @@ void Flatness::apply(
 void Flatness::apply_linearized(
     const gsl::not_null<Scalar<DataVector>*> field_correction,
     const gsl::not_null<Scalar<DataVector>*> n_dot_field_gradient_correction,
+    const tnsr::i<DataVector, 3>& /*field_gradient*/,
     const tnsr::I<DataVector, 3>& x) {
   get(*n_dot_field_gradient_correction) =
       -get(*field_correction) / get(magnitude(x));

--- a/src/Elliptic/Systems/Punctures/BoundaryConditions/Flatness.hpp
+++ b/src/Elliptic/Systems/Punctures/BoundaryConditions/Flatness.hpp
@@ -59,6 +59,7 @@ class Flatness : public elliptic::BoundaryConditions::BoundaryCondition<3> {
 
   static void apply(gsl::not_null<Scalar<DataVector>*> field,
                     gsl::not_null<Scalar<DataVector>*> n_dot_field_gradient,
+                    const tnsr::i<DataVector, 3>& field_gradient,
                     const tnsr::I<DataVector, 3>& x);
 
   using argument_tags_linearized =
@@ -68,6 +69,7 @@ class Flatness : public elliptic::BoundaryConditions::BoundaryCondition<3> {
   static void apply_linearized(
       gsl::not_null<Scalar<DataVector>*> field_correction,
       gsl::not_null<Scalar<DataVector>*> n_dot_field_gradient_correction,
+      const tnsr::i<DataVector, 3>& field_gradient,
       const tnsr::I<DataVector, 3>& x);
 };
 

--- a/src/Elliptic/Systems/Xcts/BoundaryConditions/ApparentHorizon.cpp
+++ b/src/Elliptic/Systems/Xcts/BoundaryConditions/ApparentHorizon.cpp
@@ -506,6 +506,9 @@ void ApparentHorizon<ConformalGeometry>::apply(
         n_dot_lapse_times_conformal_factor_gradient,
     const gsl::not_null<tnsr::I<DataVector, 3>*>
         n_dot_longitudinal_shift_excess,
+    const tnsr::i<DataVector, 3>& /*deriv_conformal_factor*/,
+    const tnsr::i<DataVector, 3>& /*deriv_lapse_times_conformal_factor*/,
+    const tnsr::iJ<DataVector, 3>& /*deriv_shift_excess*/,
     const tnsr::i<DataVector, 3>& face_normal,
     const tnsr::ij<DataVector, 3>& deriv_unnormalized_face_normal,
     const Scalar<DataVector>& face_normal_magnitude,
@@ -535,6 +538,9 @@ void ApparentHorizon<ConformalGeometry>::apply(
         n_dot_lapse_times_conformal_factor_gradient,
     const gsl::not_null<tnsr::I<DataVector, 3>*>
         n_dot_longitudinal_shift_excess,
+    const tnsr::i<DataVector, 3>& /*deriv_conformal_factor*/,
+    const tnsr::i<DataVector, 3>& /*deriv_lapse_times_conformal_factor*/,
+    const tnsr::iJ<DataVector, 3>& /*deriv_shift_excess*/,
     const tnsr::i<DataVector, 3>& face_normal,
     const tnsr::ij<DataVector, 3>& deriv_unnormalized_face_normal,
     const Scalar<DataVector>& face_normal_magnitude,
@@ -568,6 +574,10 @@ void ApparentHorizon<ConformalGeometry>::apply_linearized(
         n_dot_lapse_times_conformal_factor_gradient_correction,
     const gsl::not_null<tnsr::I<DataVector, 3>*>
         n_dot_longitudinal_shift_excess_correction,
+    const tnsr::i<DataVector, 3>& /*deriv_conformal_factor_correction*/,
+    const tnsr::i<DataVector,
+                  3>& /*deriv_lapse_times_conformal_factor_correction*/,
+    const tnsr::iJ<DataVector, 3>& /*deriv_shift_excess_correction*/,
     const tnsr::i<DataVector, 3>& face_normal,
     const tnsr::ij<DataVector, 3>& deriv_unnormalized_face_normal,
     const Scalar<DataVector>& face_normal_magnitude,
@@ -601,6 +611,10 @@ void ApparentHorizon<ConformalGeometry>::apply_linearized(
         n_dot_lapse_times_conformal_factor_gradient_correction,
     const gsl::not_null<tnsr::I<DataVector, 3>*>
         n_dot_longitudinal_shift_excess_correction,
+    const tnsr::i<DataVector, 3>& /*deriv_conformal_factor_correction*/,
+    const tnsr::i<DataVector,
+                  3>& /*deriv_lapse_times_conformal_factor_correction*/,
+    const tnsr::iJ<DataVector, 3>& /*deriv_shift_excess_correction*/,
     const tnsr::i<DataVector, 3>& face_normal,
     const tnsr::ij<DataVector, 3>& deriv_unnormalized_face_normal,
     const Scalar<DataVector>& face_normal_magnitude,

--- a/src/Elliptic/Systems/Xcts/BoundaryConditions/ApparentHorizon.hpp
+++ b/src/Elliptic/Systems/Xcts/BoundaryConditions/ApparentHorizon.hpp
@@ -238,6 +238,9 @@ class ApparentHorizon
       gsl::not_null<Scalar<DataVector>*>
           n_dot_lapse_times_conformal_factor_gradient,
       gsl::not_null<tnsr::I<DataVector, 3>*> n_dot_longitudinal_shift_excess,
+      const tnsr::i<DataVector, 3>& deriv_conformal_factor,
+      const tnsr::i<DataVector, 3>& deriv_lapse_times_conformal_factor,
+      const tnsr::iJ<DataVector, 3>& deriv_shift_excess,
       const tnsr::i<DataVector, 3>& face_normal,
       const tnsr::ij<DataVector, 3>& deriv_unnormalized_face_normal,
       const Scalar<DataVector>& face_normal_magnitude,
@@ -254,6 +257,9 @@ class ApparentHorizon
       gsl::not_null<Scalar<DataVector>*>
           n_dot_lapse_times_conformal_factor_gradient,
       gsl::not_null<tnsr::I<DataVector, 3>*> n_dot_longitudinal_shift_excess,
+      const tnsr::i<DataVector, 3>& deriv_conformal_factor,
+      const tnsr::i<DataVector, 3>& deriv_lapse_times_conformal_factor,
+      const tnsr::iJ<DataVector, 3>& deriv_shift_excess,
       const tnsr::i<DataVector, 3>& face_normal,
       const tnsr::ij<DataVector, 3>& deriv_unnormalized_face_normal,
       const Scalar<DataVector>& face_normal_magnitude,
@@ -297,6 +303,10 @@ class ApparentHorizon
           n_dot_lapse_times_conformal_factor_gradient_correction,
       gsl::not_null<tnsr::I<DataVector, 3>*>
           n_dot_longitudinal_shift_excess_correction,
+      const tnsr::i<DataVector, 3>& deriv_conformal_factor_correction,
+      const tnsr::i<DataVector, 3>&
+          deriv_lapse_times_conformal_factor_correction,
+      const tnsr::iJ<DataVector, 3>& deriv_shift_excess_correction,
       const tnsr::i<DataVector, 3>& face_normal,
       const tnsr::ij<DataVector, 3>& deriv_unnormalized_face_normal,
       const Scalar<DataVector>& face_normal_magnitude,
@@ -318,6 +328,10 @@ class ApparentHorizon
           n_dot_lapse_times_conformal_factor_gradient_correction,
       gsl::not_null<tnsr::I<DataVector, 3>*>
           n_dot_longitudinal_shift_excess_correction,
+      const tnsr::i<DataVector, 3>& deriv_conformal_factor_correction,
+      const tnsr::i<DataVector, 3>&
+          deriv_lapse_times_conformal_factor_correction,
+      const tnsr::iJ<DataVector, 3>& deriv_shift_excess_correction,
       const tnsr::i<DataVector, 3>& face_normal,
       const tnsr::ij<DataVector, 3>& deriv_unnormalized_face_normal,
       const Scalar<DataVector>& face_normal_magnitude,

--- a/src/Elliptic/Systems/Xcts/BoundaryConditions/CMakeLists.txt
+++ b/src/Elliptic/Systems/Xcts/BoundaryConditions/CMakeLists.txt
@@ -10,6 +10,7 @@ spectre_target_sources(
   PRIVATE
   ApparentHorizon.cpp
   Flatness.cpp
+  Robin.cpp
   )
 
 spectre_target_headers(
@@ -19,6 +20,7 @@ spectre_target_headers(
   ApparentHorizon.hpp
   Factory.hpp
   Flatness.hpp
+  Robin.hpp
   )
 
 target_link_libraries(

--- a/src/Elliptic/Systems/Xcts/BoundaryConditions/Factory.hpp
+++ b/src/Elliptic/Systems/Xcts/BoundaryConditions/Factory.hpp
@@ -6,6 +6,7 @@
 #include "Elliptic/BoundaryConditions/AnalyticSolution.hpp"
 #include "Elliptic/Systems/Xcts/BoundaryConditions/ApparentHorizon.hpp"
 #include "Elliptic/Systems/Xcts/BoundaryConditions/Flatness.hpp"
+#include "Elliptic/Systems/Xcts/BoundaryConditions/Robin.hpp"
 #include "Utilities/TMPL.hpp"
 
 namespace Xcts::BoundaryConditions {
@@ -13,5 +14,6 @@ template <typename System>
 using standard_boundary_conditions =
     tmpl::list<elliptic::BoundaryConditions::AnalyticSolution<System>,
                Flatness<System::enabled_equations>,
+               Robin<System::enabled_equations>,
                ApparentHorizon<System::conformal_geometry>>;
 }

--- a/src/Elliptic/Systems/Xcts/BoundaryConditions/Flatness.cpp
+++ b/src/Elliptic/Systems/Xcts/BoundaryConditions/Flatness.cpp
@@ -17,7 +17,8 @@ template <>
 void Flatness<Xcts::Equations::Hamiltonian>::apply(
     const gsl::not_null<Scalar<DataVector>*> conformal_factor_minus_one,
     const gsl::not_null<Scalar<DataVector>*>
-    /*n_dot_conformal_factor_gradient*/) {
+    /*n_dot_conformal_factor_gradient*/,
+    const tnsr::i<DataVector, 3>& /*deriv_conformal_factor*/) {
   get(*conformal_factor_minus_one) = 0.;
 }
 
@@ -29,7 +30,9 @@ void Flatness<Xcts::Equations::HamiltonianAndLapse>::apply(
     const gsl::not_null<Scalar<DataVector>*>
     /*n_dot_conformal_factor_gradient*/,
     const gsl::not_null<Scalar<DataVector>*>
-    /*n_dot_lapse_times_conformal_factor_gradient*/) {
+    /*n_dot_lapse_times_conformal_factor_gradient*/,
+    const tnsr::i<DataVector, 3>& /*deriv_conformal_factor*/,
+    const tnsr::i<DataVector, 3>& /*deriv_lapse_times_conformal_factor*/) {
   get(*conformal_factor_minus_one) = 0.;
   get(*lapse_times_conformal_factor_minus_one) = 0.;
 }
@@ -45,7 +48,10 @@ void Flatness<Xcts::Equations::HamiltonianLapseAndShift>::apply(
     const gsl::not_null<Scalar<DataVector>*>
     /*n_dot_lapse_times_conformal_factor_gradient*/,
     const gsl::not_null<tnsr::I<DataVector, 3>*>
-    /*n_dot_longitudinal_shift_excess*/) {
+    /*n_dot_longitudinal_shift_excess*/,
+    const tnsr::i<DataVector, 3>& /*deriv_conformal_factor*/,
+    const tnsr::i<DataVector, 3>& /*deriv_lapse_times_conformal_factor*/,
+    const tnsr::iJ<DataVector, 3>& /*deriv_shift_excess*/) {
   get(*conformal_factor_minus_one) = 0.;
   get(*lapse_times_conformal_factor_minus_one) = 0.;
   std::fill(shift_excess->begin(), shift_excess->end(), 0.);
@@ -55,7 +61,8 @@ template <>
 void Flatness<Xcts::Equations::Hamiltonian>::apply_linearized(
     const gsl::not_null<Scalar<DataVector>*> conformal_factor_correction,
     const gsl::not_null<Scalar<DataVector>*>
-    /*n_dot_conformal_factor_gradient_correction*/) {
+    /*n_dot_conformal_factor_gradient_correction*/,
+    const tnsr::i<DataVector, 3>& /*deriv_conformal_factor_correction*/) {
   get(*conformal_factor_correction) = 0.;
 }
 
@@ -67,7 +74,10 @@ void Flatness<Xcts::Equations::HamiltonianAndLapse>::apply_linearized(
     const gsl::not_null<Scalar<DataVector>*>
     /*n_dot_conformal_factor_gradient_correction*/,
     const gsl::not_null<Scalar<DataVector>*>
-    /*n_dot_lapse_times_conformal_factor_gradient_correction*/) {
+    /*n_dot_lapse_times_conformal_factor_gradient_correction*/,
+    const tnsr::i<DataVector, 3>& /*deriv_conformal_factor_correction*/,
+    const tnsr::i<DataVector,
+                  3>& /*deriv_lapse_times_conformal_factor_correction*/) {
   get(*conformal_factor_correction) = 0.;
   get(*lapse_times_conformal_factor_correction) = 0.;
 }
@@ -83,7 +93,11 @@ void Flatness<Xcts::Equations::HamiltonianLapseAndShift>::apply_linearized(
     const gsl::not_null<Scalar<DataVector>*>
     /*n_dot_lapse_times_conformal_factor_gradient_correction*/,
     const gsl::not_null<tnsr::I<DataVector, 3>*>
-    /*n_dot_longitudinal_shift_excess_correction*/) {
+    /*n_dot_longitudinal_shift_excess_correction*/,
+    const tnsr::i<DataVector, 3>& /*deriv_conformal_factor_correction*/,
+    const tnsr::i<DataVector,
+                  3>& /*deriv_lapse_times_conformal_factor_correction*/,
+    const tnsr::iJ<DataVector, 3>& /*deriv_shift_excess_correction*/) {
   get(*conformal_factor_correction) = 0.;
   get(*lapse_times_conformal_factor_correction) = 0.;
   std::fill(shift_excess_correction->begin(), shift_excess_correction->end(),

--- a/src/Elliptic/Systems/Xcts/BoundaryConditions/Flatness.hpp
+++ b/src/Elliptic/Systems/Xcts/BoundaryConditions/Flatness.hpp
@@ -84,14 +84,17 @@ class Flatness : public elliptic::BoundaryConditions::BoundaryCondition<3> {
 
   static void apply(
       gsl::not_null<Scalar<DataVector>*> conformal_factor_minus_one,
-      gsl::not_null<Scalar<DataVector>*> n_dot_conformal_factor_gradient);
+      gsl::not_null<Scalar<DataVector>*> n_dot_conformal_factor_gradient,
+      const tnsr::i<DataVector, 3>& deriv_conformal_factor);
 
   static void apply(
       gsl::not_null<Scalar<DataVector>*> conformal_factor_minus_one,
       gsl::not_null<Scalar<DataVector>*> lapse_times_conformal_factor_minus_one,
       gsl::not_null<Scalar<DataVector>*> n_dot_conformal_factor_gradient,
       gsl::not_null<Scalar<DataVector>*>
-          n_dot_lapse_times_conformal_factor_gradient);
+          n_dot_lapse_times_conformal_factor_gradient,
+      const tnsr::i<DataVector, 3>& deriv_conformal_factor,
+      const tnsr::i<DataVector, 3>& deriv_lapse_times_conformal_factor);
 
   static void apply(
       gsl::not_null<Scalar<DataVector>*> conformal_factor_minus_one,
@@ -100,7 +103,10 @@ class Flatness : public elliptic::BoundaryConditions::BoundaryCondition<3> {
       gsl::not_null<Scalar<DataVector>*> n_dot_conformal_factor_gradient,
       gsl::not_null<Scalar<DataVector>*>
           n_dot_lapse_times_conformal_factor_gradient,
-      gsl::not_null<tnsr::I<DataVector, 3>*> n_dot_longitudinal_shift_excess);
+      gsl::not_null<tnsr::I<DataVector, 3>*> n_dot_longitudinal_shift_excess,
+      const tnsr::i<DataVector, 3>& deriv_conformal_factor,
+      const tnsr::i<DataVector, 3>& deriv_lapse_times_conformal_factor,
+      const tnsr::iJ<DataVector, 3>& deriv_shift_excess);
 
   using argument_tags_linearized = tmpl::list<>;
   using volume_tags_linearized = tmpl::list<>;
@@ -108,7 +114,8 @@ class Flatness : public elliptic::BoundaryConditions::BoundaryCondition<3> {
   static void apply_linearized(
       gsl::not_null<Scalar<DataVector>*> conformal_factor_correction,
       gsl::not_null<Scalar<DataVector>*>
-          n_dot_conformal_factor_gradient_correction);
+          n_dot_conformal_factor_gradient_correction,
+      const tnsr::i<DataVector, 3>& deriv_conformal_factor_correction);
 
   static void apply_linearized(
       gsl::not_null<Scalar<DataVector>*> conformal_factor_correction,
@@ -117,7 +124,10 @@ class Flatness : public elliptic::BoundaryConditions::BoundaryCondition<3> {
       gsl::not_null<Scalar<DataVector>*>
           n_dot_conformal_factor_gradient_correction,
       gsl::not_null<Scalar<DataVector>*>
-          n_dot_lapse_times_conformal_factor_gradient_correction);
+          n_dot_lapse_times_conformal_factor_gradient_correction,
+      const tnsr::i<DataVector, 3>& deriv_conformal_factor_correction,
+      const tnsr::i<DataVector, 3>&
+          deriv_lapse_times_conformal_factor_correction);
 
   static void apply_linearized(
       gsl::not_null<Scalar<DataVector>*> conformal_factor_correction,
@@ -129,7 +139,11 @@ class Flatness : public elliptic::BoundaryConditions::BoundaryCondition<3> {
       gsl::not_null<Scalar<DataVector>*>
           n_dot_lapse_times_conformal_factor_gradient_correction,
       gsl::not_null<tnsr::I<DataVector, 3>*>
-          n_dot_longitudinal_shift_excess_correction);
+          n_dot_longitudinal_shift_excess_correction,
+      const tnsr::i<DataVector, 3>& deriv_conformal_factor_correction,
+      const tnsr::i<DataVector, 3>&
+          deriv_lapse_times_conformal_factor_correction,
+      const tnsr::iJ<DataVector, 3>& deriv_shift_excess_correction);
 };
 
 template <Xcts::Equations EnabledEquations>

--- a/src/Elliptic/Systems/Xcts/BoundaryConditions/Robin.cpp
+++ b/src/Elliptic/Systems/Xcts/BoundaryConditions/Robin.cpp
@@ -1,0 +1,210 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Elliptic/Systems/Xcts/BoundaryConditions/Robin.hpp"
+
+#include <algorithm>
+#include <cstddef>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
+#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace Xcts::BoundaryConditions {
+
+namespace {
+void robin_boundary_condition_scalar(
+    const gsl::not_null<Scalar<DataVector>*> n_dot_gradient,
+    const Scalar<DataVector>& scalar, const Scalar<DataVector>& r) {
+  get(*n_dot_gradient) = -get(scalar) / get(r);
+}
+
+void robin_boundary_condition_shift(
+    const gsl::not_null<tnsr::I<DataVector, 3>*> n_dot_longitudinal_shift,
+    tnsr::I<DataVector, 3> shift, const tnsr::iJ<DataVector, 3>& deriv_shift,
+    const Scalar<DataVector>& r, const tnsr::i<DataVector, 3>& face_normal) {
+  for (size_t i = 0; i < 3; ++i) {
+    shift.get(i) /= get(r);
+    for (size_t j = 0; j < 3; ++j) {
+      shift.get(i) += face_normal.get(j) * deriv_shift.get(j, i);
+    }
+  }
+  const auto n_dot_shift = dot_product(face_normal, shift);
+  for (size_t i = 0; i < 3; ++i) {
+    n_dot_longitudinal_shift->get(i) -=
+        shift.get(i) + face_normal.get(i) * get(n_dot_shift) / 3.;
+  }
+}
+}  // namespace
+
+template <Xcts::Equations EnabledEquations>
+std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
+Robin<EnabledEquations>::get_clone() const {
+  return std::make_unique<Robin>(*this);
+}
+
+template <Xcts::Equations EnabledEquations>
+std::vector<elliptic::BoundaryConditionType>
+Robin<EnabledEquations>::boundary_condition_types() const {
+  if constexpr (EnabledEquations == Xcts::Equations::Hamiltonian) {
+    return {1, elliptic::BoundaryConditionType::Neumann};
+  } else if constexpr (EnabledEquations ==
+                       Xcts::Equations::HamiltonianAndLapse) {
+    return {2, elliptic::BoundaryConditionType::Neumann};
+  } else {
+    return {5, elliptic::BoundaryConditionType::Neumann};
+  }
+}
+
+template <>
+void Robin<Xcts::Equations::Hamiltonian>::apply(
+    const gsl::not_null<Scalar<DataVector>*> conformal_factor_minus_one,
+    const gsl::not_null<Scalar<DataVector>*> n_dot_conformal_factor_gradient,
+    const tnsr::i<DataVector, 3>& /*deriv_conformal_factor*/,
+    const tnsr::I<DataVector, 3>& x,
+    const tnsr::i<DataVector, 3>& /*face_normal*/) const {
+  robin_boundary_condition_scalar(n_dot_conformal_factor_gradient,
+                                  *conformal_factor_minus_one, magnitude(x));
+}
+
+template <>
+void Robin<Xcts::Equations::HamiltonianAndLapse>::apply(
+    const gsl::not_null<Scalar<DataVector>*> conformal_factor_minus_one,
+    const gsl::not_null<Scalar<DataVector>*>
+        lapse_times_conformal_factor_minus_one,
+    const gsl::not_null<Scalar<DataVector>*> n_dot_conformal_factor_gradient,
+    const gsl::not_null<Scalar<DataVector>*>
+        n_dot_lapse_times_conformal_factor_gradient,
+    const tnsr::i<DataVector, 3>& /*deriv_conformal_factor*/,
+    const tnsr::i<DataVector, 3>& /*deriv_lapse_times_conformal_factor*/,
+    const tnsr::I<DataVector, 3>& x,
+    const tnsr::i<DataVector, 3>& /*face_normal*/) const {
+  const auto r = magnitude(x);
+  robin_boundary_condition_scalar(n_dot_conformal_factor_gradient,
+                                  *conformal_factor_minus_one, r);
+  robin_boundary_condition_scalar(n_dot_lapse_times_conformal_factor_gradient,
+                                  *lapse_times_conformal_factor_minus_one, r);
+}
+
+template <>
+void Robin<Xcts::Equations::HamiltonianLapseAndShift>::apply(
+    const gsl::not_null<Scalar<DataVector>*> conformal_factor_minus_one,
+    const gsl::not_null<Scalar<DataVector>*>
+        lapse_times_conformal_factor_minus_one,
+    const gsl::not_null<tnsr::I<DataVector, 3>*> shift_excess,
+    const gsl::not_null<Scalar<DataVector>*> n_dot_conformal_factor_gradient,
+    const gsl::not_null<Scalar<DataVector>*>
+        n_dot_lapse_times_conformal_factor_gradient,
+    const gsl::not_null<tnsr::I<DataVector, 3>*>
+        n_dot_longitudinal_shift_excess,
+    const tnsr::i<DataVector, 3>& /*deriv_conformal_factor*/,
+    const tnsr::i<DataVector, 3>& /*deriv_lapse_times_conformal_factor*/,
+    const tnsr::iJ<DataVector, 3>& deriv_shift_excess,
+    const tnsr::I<DataVector, 3>& x,
+    const tnsr::i<DataVector, 3>& face_normal) const {
+  const auto r = magnitude(x);
+  robin_boundary_condition_scalar(n_dot_conformal_factor_gradient,
+                                  *conformal_factor_minus_one, r);
+  robin_boundary_condition_scalar(n_dot_lapse_times_conformal_factor_gradient,
+                                  *lapse_times_conformal_factor_minus_one, r);
+  robin_boundary_condition_shift(n_dot_longitudinal_shift_excess, *shift_excess,
+                                 deriv_shift_excess, r, face_normal);
+}
+
+template <>
+void Robin<Xcts::Equations::Hamiltonian>::apply_linearized(
+    const gsl::not_null<Scalar<DataVector>*> conformal_factor_correction,
+    const gsl::not_null<Scalar<DataVector>*>
+        n_dot_conformal_factor_gradient_correction,
+    const tnsr::i<DataVector, 3>& /*deriv_conformal_factor_correction*/,
+    const tnsr::I<DataVector, 3>& x,
+    const tnsr::i<DataVector, 3>& /*face_normal*/) const {
+  robin_boundary_condition_scalar(n_dot_conformal_factor_gradient_correction,
+                                  *conformal_factor_correction, magnitude(x));
+}
+
+template <>
+void Robin<Xcts::Equations::HamiltonianAndLapse>::apply_linearized(
+    const gsl::not_null<Scalar<DataVector>*> conformal_factor_correction,
+    const gsl::not_null<Scalar<DataVector>*>
+        lapse_times_conformal_factor_correction,
+    const gsl::not_null<Scalar<DataVector>*>
+        n_dot_conformal_factor_gradient_correction,
+    const gsl::not_null<Scalar<DataVector>*>
+        n_dot_lapse_times_conformal_factor_gradient_correction,
+    const tnsr::i<DataVector, 3>& /*deriv_conformal_factor_correction*/,
+    const tnsr::i<DataVector,
+                  3>& /*deriv_lapse_times_conformal_factor_correction*/,
+    const tnsr::I<DataVector, 3>& x,
+    const tnsr::i<DataVector, 3>& /*face_normal*/) const {
+  const auto r = magnitude(x);
+  robin_boundary_condition_scalar(n_dot_conformal_factor_gradient_correction,
+                                  *conformal_factor_correction, r);
+  robin_boundary_condition_scalar(
+      n_dot_lapse_times_conformal_factor_gradient_correction,
+      *lapse_times_conformal_factor_correction, r);
+}
+
+template <>
+void Robin<Xcts::Equations::HamiltonianLapseAndShift>::apply_linearized(
+    const gsl::not_null<Scalar<DataVector>*> conformal_factor_correction,
+    const gsl::not_null<Scalar<DataVector>*>
+        lapse_times_conformal_factor_correction,
+    const gsl::not_null<tnsr::I<DataVector, 3>*> shift_excess_correction,
+    const gsl::not_null<Scalar<DataVector>*>
+        n_dot_conformal_factor_gradient_correction,
+    const gsl::not_null<Scalar<DataVector>*>
+        n_dot_lapse_times_conformal_factor_gradient_correction,
+    const gsl::not_null<tnsr::I<DataVector, 3>*>
+        n_dot_longitudinal_shift_excess_correction,
+    const tnsr::i<DataVector, 3>& /*deriv_conformal_factor_correction*/,
+    const tnsr::i<DataVector,
+                  3>& /*deriv_lapse_times_conformal_factor_correction*/,
+    const tnsr::iJ<DataVector, 3>& deriv_shift_excess_correction,
+    const tnsr::I<DataVector, 3>& x,
+    const tnsr::i<DataVector, 3>& face_normal) const {
+  const auto r = magnitude(x);
+  robin_boundary_condition_scalar(n_dot_conformal_factor_gradient_correction,
+                                  *conformal_factor_correction, r);
+  robin_boundary_condition_scalar(
+      n_dot_lapse_times_conformal_factor_gradient_correction,
+      *lapse_times_conformal_factor_correction, r);
+  robin_boundary_condition_shift(n_dot_longitudinal_shift_excess_correction,
+                                 *shift_excess_correction,
+                                 deriv_shift_excess_correction, r, face_normal);
+}
+
+template <Xcts::Equations EnabledEquations>
+bool operator==(const Robin<EnabledEquations>& /*lhs*/,
+                const Robin<EnabledEquations>& /*rhs*/) {
+  return true;
+}
+
+template <Xcts::Equations EnabledEquations>
+bool operator!=(const Robin<EnabledEquations>& lhs,
+                const Robin<EnabledEquations>& rhs) {
+  return not(lhs == rhs);
+}
+
+template <Xcts::Equations EnabledEquations>
+PUP::able::PUP_ID Robin<EnabledEquations>::my_PUP_ID = 0;  // NOLINT
+
+#define EQNS(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data)                          \
+  template class Robin<EQNS(data)>;                   \
+  template bool operator==(const Robin<EQNS(data)>&,  \
+                           const Robin<EQNS(data)>&); \
+  template bool operator!=(const Robin<EQNS(data)>&, const Robin<EQNS(data)>&);
+
+GENERATE_INSTANTIATIONS(INSTANTIATE,
+                        (Xcts::Equations::Hamiltonian,
+                         Xcts::Equations::HamiltonianAndLapse,
+                         Xcts::Equations::HamiltonianLapseAndShift))
+#undef INSTANTIATE
+#undef EQNS
+
+}  // namespace Xcts::BoundaryConditions

--- a/src/Elliptic/Systems/Xcts/BoundaryConditions/Robin.hpp
+++ b/src/Elliptic/Systems/Xcts/BoundaryConditions/Robin.hpp
@@ -1,0 +1,182 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <memory>
+#include <pup.h>
+#include <string>
+#include <vector>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Domain/Tags.hpp"
+#include "Domain/Tags/FaceNormal.hpp"
+#include "Elliptic/BoundaryConditions/BoundaryCondition.hpp"
+#include "Elliptic/BoundaryConditions/BoundaryConditionType.hpp"
+#include "Elliptic/Systems/Xcts/FluxesAndSources.hpp"
+#include "Options/String.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Serialization/CharmPupable.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+class DataVector;
+/// \endcond
+
+namespace Xcts::BoundaryConditions {
+
+/*!
+ * \brief Impose Robin boundary conditions at the outer boundary
+ *
+ * Impose $\partial_r(r\psi)=0$, $\partial_r(\alpha\psi)=0$, and
+ * $\partial_r(r\beta_\mathrm{excess}^j)=0$ on the boundary. These Robin
+ * boundary conditions incur an error of order $1/R^2$, where $R$ is the outer
+ * radius of the domain. This allows to place the outer boundary much closer
+ * to the center than for Dirichlet boundary conditions
+ * (Xcts::BoundaryConditions::Flatness), which incur an error of order $1/R$.
+ *
+ * The Robin boundary conditions are imposed as Neumann-type as follows:
+ *
+ * \begin{align*}
+ * (n^i \partial_i \psi)_N &= -\frac{\psi}{r}, \\
+ * (n^i \partial_i (\alpha\psi))_N &= -\frac{\alpha\psi}{r}, \\
+ * (n^i (L\beta)^{ij})_N = n^i (L\beta)^{ij} - \left[
+ *   \frac{\beta_\mathrm{excess}^j}{r}
+ *   + \frac{1}{3} n^j \frac{n^i \beta_\mathrm{excess}^i}{r}
+ *   + n^i \partial_i \beta_\mathrm{excess}^j
+ *   + \frac{1}{3} n^j n^i n_k \partial_i \beta_\mathrm{excess}^k
+ * \right]
+ * \end{align*}
+ *
+ * Here, the condition on the longitudinal shift is derived by imposing the
+ * Robin boundary condition
+ * $n^i\partial_i\beta_\mathrm{excess}^j=-\beta_\mathrm{excess}^j/r$ only on the
+ * normal component of the shift gradient. To do this we can use the projection
+ * operator $P_{ij}=\delta_{ij}-n_i n_j$ to set the shift gradient to
+ * $\partial_i\beta_\mathrm{excess}^j=P_{ik}\partial_k\beta_\mathrm{excess}^j
+ * -n_i \beta_\mathrm{excess}^j/r$ and then apply the longitudinal operator.
+ *
+ * \tparam EnabledEquations The subset of XCTS equations that are being solved
+ */
+template <Xcts::Equations EnabledEquations>
+class Robin : public elliptic::BoundaryConditions::BoundaryCondition<3> {
+ private:
+  using Base = elliptic::BoundaryConditions::BoundaryCondition<3>;
+
+ public:
+  using options = tmpl::list<>;
+  static constexpr Options::String help =
+      "Impose Robin boundary conditions at the outer boundary. "
+      "They incur an error of order 1/R^2, where R is the outer radius.";
+
+  Robin() = default;
+  Robin(const Robin&) = default;
+  Robin& operator=(const Robin&) = default;
+  Robin(Robin&&) = default;
+  Robin& operator=(Robin&&) = default;
+  ~Robin() override = default;
+
+  /// \cond
+  explicit Robin(CkMigrateMessage* m) : Base(m) {}
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(Robin);
+  /// \endcond
+
+  std::unique_ptr<domain::BoundaryConditions::BoundaryCondition> get_clone()
+      const override;
+
+  std::vector<elliptic::BoundaryConditionType> boundary_condition_types()
+      const override;
+
+  using argument_tags =
+      tmpl::list<domain::Tags::Coordinates<3, Frame::Inertial>,
+                 domain::Tags::FaceNormal<3, Frame::Inertial>>;
+  using volume_tags = tmpl::list<>;
+
+  void apply(gsl::not_null<Scalar<DataVector>*> conformal_factor_minus_one,
+             gsl::not_null<Scalar<DataVector>*> n_dot_conformal_factor_gradient,
+             const tnsr::i<DataVector, 3>& deriv_conformal_factor,
+             const tnsr::I<DataVector, 3>& x,
+             const tnsr::i<DataVector, 3>& face_normal) const;
+
+  void apply(
+      gsl::not_null<Scalar<DataVector>*> conformal_factor_minus_one,
+      gsl::not_null<Scalar<DataVector>*> lapse_times_conformal_factor_minus_one,
+      gsl::not_null<Scalar<DataVector>*> n_dot_conformal_factor_gradient,
+      gsl::not_null<Scalar<DataVector>*>
+          n_dot_lapse_times_conformal_factor_gradient,
+      const tnsr::i<DataVector, 3>& deriv_conformal_factor,
+      const tnsr::i<DataVector, 3>& deriv_lapse_times_conformal_factor,
+      const tnsr::I<DataVector, 3>& x,
+      const tnsr::i<DataVector, 3>& face_normal) const;
+
+  void apply(
+      gsl::not_null<Scalar<DataVector>*> conformal_factor_minus_one,
+      gsl::not_null<Scalar<DataVector>*> lapse_times_conformal_factor_minus_one,
+      gsl::not_null<tnsr::I<DataVector, 3>*> shift_excess,
+      gsl::not_null<Scalar<DataVector>*> n_dot_conformal_factor_gradient,
+      gsl::not_null<Scalar<DataVector>*>
+          n_dot_lapse_times_conformal_factor_gradient,
+      gsl::not_null<tnsr::I<DataVector, 3>*> n_dot_longitudinal_shift_excess,
+      const tnsr::i<DataVector, 3>& deriv_conformal_factor,
+      const tnsr::i<DataVector, 3>& deriv_lapse_times_conformal_factor,
+      const tnsr::iJ<DataVector, 3>& deriv_shift_excess,
+      const tnsr::I<DataVector, 3>& x,
+      const tnsr::i<DataVector, 3>& face_normal) const;
+
+  using argument_tags_linearized =
+      tmpl::list<domain::Tags::Coordinates<3, Frame::Inertial>,
+                 domain::Tags::FaceNormal<3, Frame::Inertial>>;
+  using volume_tags_linearized = tmpl::list<>;
+
+  void apply_linearized(
+      gsl::not_null<Scalar<DataVector>*> conformal_factor_correction,
+      gsl::not_null<Scalar<DataVector>*>
+          n_dot_conformal_factor_gradient_correction,
+      const tnsr::i<DataVector, 3>& deriv_conformal_factor_correction,
+      const tnsr::I<DataVector, 3>& x,
+      const tnsr::i<DataVector, 3>& face_normal) const;
+
+  void apply_linearized(
+      gsl::not_null<Scalar<DataVector>*> conformal_factor_correction,
+      gsl::not_null<Scalar<DataVector>*>
+          lapse_times_conformal_factor_correction,
+      gsl::not_null<Scalar<DataVector>*>
+          n_dot_conformal_factor_gradient_correction,
+      gsl::not_null<Scalar<DataVector>*>
+          n_dot_lapse_times_conformal_factor_gradient_correction,
+      const tnsr::i<DataVector, 3>& deriv_conformal_factor_correction,
+      const tnsr::i<DataVector, 3>&
+          deriv_lapse_times_conformal_factor_correction,
+      const tnsr::I<DataVector, 3>& x,
+      const tnsr::i<DataVector, 3>& face_normal) const;
+
+  void apply_linearized(
+      gsl::not_null<Scalar<DataVector>*> conformal_factor_correction,
+      gsl::not_null<Scalar<DataVector>*>
+          lapse_times_conformal_factor_correction,
+      gsl::not_null<tnsr::I<DataVector, 3>*> shift_excess_correction,
+      gsl::not_null<Scalar<DataVector>*>
+          n_dot_conformal_factor_gradient_correction,
+      gsl::not_null<Scalar<DataVector>*>
+          n_dot_lapse_times_conformal_factor_gradient_correction,
+      gsl::not_null<tnsr::I<DataVector, 3>*>
+          n_dot_longitudinal_shift_excess_correction,
+      const tnsr::i<DataVector, 3>& deriv_conformal_factor_correction,
+      const tnsr::i<DataVector, 3>&
+          deriv_lapse_times_conformal_factor_correction,
+      const tnsr::iJ<DataVector, 3>& deriv_shift_excess_correction,
+      const tnsr::I<DataVector, 3>& x,
+      const tnsr::i<DataVector, 3>& face_normal) const;
+};
+
+template <Xcts::Equations LocalEnabledEquations>
+bool operator==(const Robin<LocalEnabledEquations>& lhs,
+                const Robin<LocalEnabledEquations>& rhs);
+
+template <Xcts::Equations EnabledEquations>
+bool operator!=(const Robin<EnabledEquations>& lhs,
+                const Robin<EnabledEquations>& rhs);
+
+}  // namespace Xcts::BoundaryConditions

--- a/support/Pipelines/Bbh/InitialData.yaml
+++ b/support/Pipelines/Bbh/InitialData.yaml
@@ -90,10 +90,10 @@ DomainCreator:
       Radius: &outer_shell_inner_radius 60.
       RadialDistribution: Projective
     OuterShell:
-      Radius: &outer_radius 1e9
+      Radius: &outer_radius 1e5
       RadialDistribution: &outer_shell_distribution Inverse
       OpeningAngle: 120.0
-      BoundaryCondition: Flatness
+      BoundaryCondition: Robin
     UseEquiangularMap: True
     InitialRefinement:
       ObjectAShell:     [{{ L }}, {{ L }}, {{ L }}]
@@ -207,7 +207,7 @@ RadiallyCompressedCoordinates:
   Compression: *outer_shell_distribution
 
 EventsAndTriggers:
-  - Trigger: Always
+  - Trigger: HasConverged
     Events:
       - ObserveFields:
           SubfileName: VolumeData

--- a/tests/Unit/Elliptic/BoundaryConditions/Test_AnalyticSolution.cpp
+++ b/tests/Unit/Elliptic/BoundaryConditions/Test_AnalyticSolution.cpp
@@ -156,6 +156,8 @@ void test_analytic_solution() {
                          ::Tags::NormalDotFlux<ScalarFieldTag<1>>,
                          ::Tags::NormalDotFlux<ScalarFieldTag<2>>>>
         vars{face_num_points, std::numeric_limits<double>::max()};
+    const tnsr::i<DataVector, Dim> deriv_scalar{
+        face_num_points, std::numeric_limits<double>::signaling_NaN()};
     // Inhomogeneous boundary conditions
     elliptic::apply_boundary_condition<
         false, void, tmpl::list<AnalyticSolution<System<Dim>>>>(
@@ -163,7 +165,8 @@ void test_analytic_solution() {
         make_not_null(&get<ScalarFieldTag<1>>(vars)),
         make_not_null(&get<ScalarFieldTag<2>>(vars)),
         make_not_null(&get<::Tags::NormalDotFlux<ScalarFieldTag<1>>>(vars)),
-        make_not_null(&get<::Tags::NormalDotFlux<ScalarFieldTag<2>>>(vars)));
+        make_not_null(&get<::Tags::NormalDotFlux<ScalarFieldTag<2>>>(vars)),
+        deriv_scalar, deriv_scalar);
     // Imposed Dirichlet conditions on field 1
     const auto expected_dirichlet_field = []() -> DataVector {
       if constexpr (Dim == 1) {
@@ -204,7 +207,8 @@ void test_analytic_solution() {
         make_not_null(&get<ScalarFieldTag<1>>(vars)),
         make_not_null(&get<ScalarFieldTag<2>>(vars)),
         make_not_null(&get<::Tags::NormalDotFlux<ScalarFieldTag<1>>>(vars)),
-        make_not_null(&get<::Tags::NormalDotFlux<ScalarFieldTag<2>>>(vars)));
+        make_not_null(&get<::Tags::NormalDotFlux<ScalarFieldTag<2>>>(vars)),
+        deriv_scalar, deriv_scalar);
     // Imposed Dirichlet conditions on field 1
     CHECK_ITERABLE_APPROX(get(get<ScalarFieldTag<1>>(vars)),
                           SINGLE_ARG(DataVector{face_num_points, 0.}));

--- a/tests/Unit/Elliptic/Systems/Elasticity/BoundaryConditions/Test_Zero.cpp
+++ b/tests/Unit/Elliptic/Systems/Elasticity/BoundaryConditions/Test_Zero.cpp
@@ -62,37 +62,43 @@ SPECTRE_TEST_CASE("Unit.Elasticity.BoundaryConditions.Zero",
   const auto box = db::create<db::AddSimpleTags<>>();
   {
     INFO("Dirichlet");
-    tnsr::I<DataVector, 2> displacement{3_st,
-                                        std::numeric_limits<double>::max()};
+    tnsr::I<DataVector, 2> displacement{
+        3_st, std::numeric_limits<double>::signaling_NaN()};
     tnsr::I<DataVector, 2> n_dot_minus_stress{
-        3_st, std::numeric_limits<double>::max()};
+        3_st, std::numeric_limits<double>::signaling_NaN()};
+    tnsr::iJ<DataVector, 2> deriv_displacement{
+        3_st, std::numeric_limits<double>::signaling_NaN()};
     elliptic::apply_boundary_condition<false, void, tmpl::list<Fixed>>(
         fixed, box, Direction<2>::lower_xi(), make_not_null(&displacement),
-        make_not_null(&n_dot_minus_stress));
+        make_not_null(&n_dot_minus_stress), deriv_displacement);
     CHECK_ITERABLE_APPROX(get<0>(displacement), SINGLE_ARG(DataVector{3, 0.}));
     CHECK_ITERABLE_APPROX(get<1>(displacement), SINGLE_ARG(DataVector{3, 0.}));
   }
   {
     INFO("Linearized Dirichlet");
-    tnsr::I<DataVector, 2> displacement{3_st,
-                                        std::numeric_limits<double>::max()};
+    tnsr::I<DataVector, 2> displacement{
+        3_st, std::numeric_limits<double>::signaling_NaN()};
     tnsr::I<DataVector, 2> n_dot_minus_stress{
-        3_st, std::numeric_limits<double>::max()};
+        3_st, std::numeric_limits<double>::signaling_NaN()};
+    tnsr::iJ<DataVector, 2> deriv_displacement{
+        3_st, std::numeric_limits<double>::signaling_NaN()};
     elliptic::apply_boundary_condition<true, void, tmpl::list<Fixed>>(
         fixed, box, Direction<2>::lower_xi(), make_not_null(&displacement),
-        make_not_null(&n_dot_minus_stress));
+        make_not_null(&n_dot_minus_stress), deriv_displacement);
     CHECK_ITERABLE_APPROX(get<0>(displacement), SINGLE_ARG(DataVector{3, 0.}));
     CHECK_ITERABLE_APPROX(get<1>(displacement), SINGLE_ARG(DataVector{3, 0.}));
   }
   {
     INFO("Neumann");
-    tnsr::I<DataVector, 2> displacement{3_st,
-                                        std::numeric_limits<double>::max()};
+    tnsr::I<DataVector, 2> displacement{
+        3_st, std::numeric_limits<double>::signaling_NaN()};
     tnsr::I<DataVector, 2> n_dot_minus_stress{
-        3_st, std::numeric_limits<double>::max()};
+        3_st, std::numeric_limits<double>::signaling_NaN()};
+    tnsr::iJ<DataVector, 2> deriv_displacement{
+        3_st, std::numeric_limits<double>::signaling_NaN()};
     elliptic::apply_boundary_condition<false, void, tmpl::list<Free>>(
         free, box, Direction<2>::lower_xi(), make_not_null(&displacement),
-        make_not_null(&n_dot_minus_stress));
+        make_not_null(&n_dot_minus_stress), deriv_displacement);
     CHECK_ITERABLE_APPROX(get<0>(n_dot_minus_stress),
                           SINGLE_ARG(DataVector{3, 0.}));
     CHECK_ITERABLE_APPROX(get<1>(n_dot_minus_stress),
@@ -100,13 +106,15 @@ SPECTRE_TEST_CASE("Unit.Elasticity.BoundaryConditions.Zero",
   }
   {
     INFO("Linearized Neumann");
-    tnsr::I<DataVector, 2> displacement{3_st,
-                                        std::numeric_limits<double>::max()};
+    tnsr::I<DataVector, 2> displacement{
+        3_st, std::numeric_limits<double>::signaling_NaN()};
     tnsr::I<DataVector, 2> n_dot_minus_stress{
-        3_st, std::numeric_limits<double>::max()};
+        3_st, std::numeric_limits<double>::signaling_NaN()};
+    tnsr::iJ<DataVector, 2> deriv_displacement{
+        3_st, std::numeric_limits<double>::signaling_NaN()};
     elliptic::apply_boundary_condition<true, void, tmpl::list<Free>>(
         free, box, Direction<2>::lower_xi(), make_not_null(&displacement),
-        make_not_null(&n_dot_minus_stress));
+        make_not_null(&n_dot_minus_stress), deriv_displacement);
     CHECK_ITERABLE_APPROX(get<0>(n_dot_minus_stress),
                           SINGLE_ARG(DataVector{3, 0.}));
     CHECK_ITERABLE_APPROX(get<1>(n_dot_minus_stress),

--- a/tests/Unit/Elliptic/Systems/Poisson/BoundaryConditions/Test_Robin.cpp
+++ b/tests/Unit/Elliptic/Systems/Poisson/BoundaryConditions/Test_Robin.cpp
@@ -29,14 +29,17 @@ template <bool Linearized>
 void apply_dirichlet_boundary_condition(
     const gsl::not_null<Scalar<DataVector>*> field,
     const double dirichlet_weight, const double constant,
-    const Scalar<DataVector>& /*used_for_size*/) {
+    const Scalar<DataVector>& used_for_size) {
   const Robin<1> boundary_condition{dirichlet_weight, 0., constant};
   const auto box = db::create<db::AddSimpleTags<>>();
   auto n_dot_field_gradient = make_with_value<Scalar<DataVector>>(
       *field, std::numeric_limits<double>::signaling_NaN());
+  const tnsr::i<DataVector, 1> field_gradient{
+      used_for_size.begin()->size(),
+      std::numeric_limits<double>::signaling_NaN()};
   elliptic::apply_boundary_condition<Linearized, void, tmpl::list<Robin<1>>>(
       boundary_condition, box, Direction<1>::lower_xi(), field,
-      make_not_null(&n_dot_field_gradient));
+      make_not_null(&n_dot_field_gradient), field_gradient);
 }
 template <bool Linearized>
 void apply_neumann_boundary_condition(
@@ -45,9 +48,11 @@ void apply_neumann_boundary_condition(
     const double neumann_weight, const double constant) {
   const Robin<1> boundary_condition{dirichlet_weight, neumann_weight, constant};
   const auto box = db::create<db::AddSimpleTags<>>();
+  const tnsr::i<DataVector, 1> field_gradient{
+      field.begin()->size(), std::numeric_limits<double>::signaling_NaN()};
   elliptic::apply_boundary_condition<Linearized, void, tmpl::list<Robin<1>>>(
       boundary_condition, box, Direction<1>::lower_xi(), make_not_null(&field),
-      n_dot_field_gradient);
+      n_dot_field_gradient, field_gradient);
 }
 }  // namespace
 

--- a/tests/Unit/Elliptic/Systems/Punctures/BoundaryConditions/Test_Flatness.cpp
+++ b/tests/Unit/Elliptic/Systems/Punctures/BoundaryConditions/Test_Flatness.cpp
@@ -37,10 +37,12 @@ void apply_boundary_condition(
       domain::Tags::Faces<3, domain::Tags::Coordinates<3, Frame::Inertial>>>>(
       DirectionMap<3, tnsr::I<DataVector, 3>>{
           {Direction<3>::upper_xi(), std::move(x)}});
+  const tnsr::i<DataVector, 3> field_gradient{
+      field.begin()->size(), std::numeric_limits<double>::signaling_NaN()};
   // grad(u) will be set by the boundary condition
   elliptic::apply_boundary_condition<Linearized, void, tmpl::list<Flatness>>(
       boundary_condition, box, Direction<3>::upper_xi(), make_not_null(&field),
-      n_dot_field_gradient);
+      n_dot_field_gradient, field_gradient);
 }
 }  // namespace
 

--- a/tests/Unit/Elliptic/Systems/Xcts/BoundaryConditions/CMakeLists.txt
+++ b/tests/Unit/Elliptic/Systems/Xcts/BoundaryConditions/CMakeLists.txt
@@ -6,6 +6,7 @@ set(LIBRARY "Test_XctsBoundaryConditions")
 set(LIBRARY_SOURCES
   Test_ApparentHorizon.cpp
   Test_Flatness.cpp
+  Test_Robin.cpp
   )
 
 add_test_library(${LIBRARY} "${LIBRARY_SOURCES}")

--- a/tests/Unit/Elliptic/Systems/Xcts/BoundaryConditions/Robin.py
+++ b/tests/Unit/Elliptic/Systems/Xcts/BoundaryConditions/Robin.py
@@ -1,0 +1,26 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+from numpy import abs, sqrt
+from PointwiseFunctions.Xcts.LongitudinalOperator import (
+    longitudinal_operator_flat_cartesian,
+)
+
+
+def robin_boundary_condition_scalar(field, x):
+    r = np.linalg.norm(x)
+    return -field / r
+
+
+def robin_boundary_condition_shift(shift, deriv_shift, x, face_normal):
+    proj = np.eye(3) - np.outer(face_normal, face_normal)
+    r = np.linalg.norm(x)
+    deriv_shift = (
+        np.einsum("ik,kj->ij", proj, deriv_shift)
+        - np.outer(face_normal, shift) / r
+    )
+    strain = (deriv_shift + deriv_shift.T) / 2.0
+    return np.einsum(
+        "i,ij", face_normal, longitudinal_operator_flat_cartesian(strain)
+    )

--- a/tests/Unit/Elliptic/Systems/Xcts/BoundaryConditions/Test_Flatness.cpp
+++ b/tests/Unit/Elliptic/Systems/Xcts/BoundaryConditions/Test_Flatness.cpp
@@ -34,16 +34,21 @@ void test_flatness(const Flatness<EnabledEquations>& boundary_condition) {
       num_points, std::numeric_limits<double>::signaling_NaN()};
   Scalar<DataVector> n_dot_conformal_factor_gradient{
       num_points, std::numeric_limits<double>::signaling_NaN()};
+  tnsr::i<DataVector, 3> conformal_factor_gradient{
+      num_points, std::numeric_limits<double>::signaling_NaN()};
   if constexpr (EnabledEquations == Xcts::Equations::Hamiltonian) {
     elliptic::apply_boundary_condition<Linearized, void,
                                        tmpl::list<Flatness<EnabledEquations>>>(
         boundary_condition, box, Direction<3>::lower_xi(),
         make_not_null(&conformal_factor_minus_one),
-        make_not_null(&n_dot_conformal_factor_gradient));
+        make_not_null(&n_dot_conformal_factor_gradient),
+        conformal_factor_gradient);
   } else {
     Scalar<DataVector> lapse_times_conformal_factor_minus_one{
         num_points, std::numeric_limits<double>::signaling_NaN()};
     Scalar<DataVector> n_dot_lapse_times_conformal_factor_gradient{
+        num_points, std::numeric_limits<double>::signaling_NaN()};
+    tnsr::i<DataVector, 3> lapse_times_conformal_factor_gradient{
         num_points, std::numeric_limits<double>::signaling_NaN()};
     if constexpr (EnabledEquations == Xcts::Equations::HamiltonianAndLapse) {
       elliptic::apply_boundary_condition<
@@ -52,11 +57,14 @@ void test_flatness(const Flatness<EnabledEquations>& boundary_condition) {
           make_not_null(&conformal_factor_minus_one),
           make_not_null(&lapse_times_conformal_factor_minus_one),
           make_not_null(&n_dot_conformal_factor_gradient),
-          make_not_null(&n_dot_lapse_times_conformal_factor_gradient));
+          make_not_null(&n_dot_lapse_times_conformal_factor_gradient),
+          conformal_factor_gradient, lapse_times_conformal_factor_gradient);
     } else {
       tnsr::I<DataVector, 3> shift_excess{
           num_points, std::numeric_limits<double>::signaling_NaN()};
       tnsr::I<DataVector, 3> n_dot_longitudinal_shift_excess{
+          num_points, std::numeric_limits<double>::signaling_NaN()};
+      tnsr::iJ<DataVector, 3> deriv_shift_excess{
           num_points, std::numeric_limits<double>::signaling_NaN()};
       elliptic::apply_boundary_condition<
           Linearized, void, tmpl::list<Flatness<EnabledEquations>>>(
@@ -66,7 +74,9 @@ void test_flatness(const Flatness<EnabledEquations>& boundary_condition) {
           make_not_null(&shift_excess),
           make_not_null(&n_dot_conformal_factor_gradient),
           make_not_null(&n_dot_lapse_times_conformal_factor_gradient),
-          make_not_null(&n_dot_longitudinal_shift_excess));
+          make_not_null(&n_dot_longitudinal_shift_excess),
+          conformal_factor_gradient, lapse_times_conformal_factor_gradient,
+          deriv_shift_excess);
       CHECK(get<0>(shift_excess) == DataVector(num_points, 0.));
       CHECK(get<1>(shift_excess) == DataVector(num_points, 0.));
       CHECK(get<2>(shift_excess) == DataVector(num_points, 0.));

--- a/tests/Unit/Elliptic/Systems/Xcts/BoundaryConditions/Test_Robin.cpp
+++ b/tests/Unit/Elliptic/Systems/Xcts/BoundaryConditions/Test_Robin.cpp
@@ -1,0 +1,195 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <limits>
+#include <string>
+#include <utility>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Tags.hpp"
+#include "Domain/Tags/FaceNormal.hpp"
+#include "Elliptic/BoundaryConditions/ApplyBoundaryCondition.hpp"
+#include "Elliptic/BoundaryConditions/BoundaryCondition.hpp"
+#include "Elliptic/BoundaryConditions/BoundaryConditionType.hpp"
+#include "Elliptic/Systems/Xcts/BoundaryConditions/Robin.hpp"
+#include "Elliptic/Systems/Xcts/FluxesAndSources.hpp"
+#include "Framework/CheckWithRandomValues.hpp"
+#include "Framework/Pypp.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/NormalDotFlux.hpp"
+#include "PointwiseFunctions/Xcts/LongitudinalOperator.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace Xcts::BoundaryConditions {
+
+namespace {
+
+const std::string py_module{"Elliptic.Systems.Xcts.BoundaryConditions.Robin"};
+
+tnsr::i<DataVector, 3> make_spherical_face_normal_flat_cartesian(
+    tnsr::I<DataVector, 3> x, const std::array<double, 3>& center) {
+  for (size_t d = 0; d < 3; ++d) {
+    x.get(d) -= gsl::at(center, d);
+  }
+  Scalar<DataVector> euclidean_radius = magnitude(x);
+  tnsr::i<DataVector, 3> face_normal{x.begin()->size()};
+  get<0>(face_normal) = -get<0>(x) / get(euclidean_radius);
+  get<1>(face_normal) = -get<1>(x) / get(euclidean_radius);
+  get<2>(face_normal) = -get<2>(x) / get(euclidean_radius);
+  return face_normal;
+}
+
+template <Xcts::Equations EnabledEquations, bool Linearized>
+void test_robin(const Robin<EnabledEquations>& boundary_condition) {
+  MAKE_GENERATOR(gen);
+  std::uniform_real_distribution<> dist(-1., 1.);
+  const size_t num_points = 3;
+  const auto direction = Direction<3>::upper_zeta();
+  const std::array<double, 3> center{{0., 0., 0.}};
+  const auto x = make_with_random_values<tnsr::I<DataVector, 3>>(
+      make_not_null(&gen), make_not_null(&dist), num_points);
+  const auto face_normal = make_spherical_face_normal_flat_cartesian(x, center);
+  const auto box = db::create<db::AddSimpleTags<
+      domain::Tags::Faces<3, domain::Tags::Coordinates<3, Frame::Inertial>>,
+      domain::Tags::Faces<3, domain::Tags::FaceNormal<3, Frame::Inertial>>>>(
+      DirectionMap<3, tnsr::I<DataVector, 3>>{{direction, x}},
+      DirectionMap<3, tnsr::i<DataVector, 3>>{{direction, face_normal}});
+  auto conformal_factor_minus_one = make_with_random_values<Scalar<DataVector>>(
+      make_not_null(&gen), make_not_null(&dist), num_points);
+  Scalar<DataVector> n_dot_conformal_factor_gradient{
+      num_points, std::numeric_limits<double>::signaling_NaN()};
+  tnsr::i<DataVector, 3> deriv_conformal_factor{
+      num_points, std::numeric_limits<double>::signaling_NaN()};
+  if constexpr (EnabledEquations == Xcts::Equations::Hamiltonian) {
+    elliptic::apply_boundary_condition<Linearized, void,
+                                       tmpl::list<Robin<EnabledEquations>>>(
+        boundary_condition, box, direction,
+        make_not_null(&conformal_factor_minus_one),
+        make_not_null(&n_dot_conformal_factor_gradient),
+        deriv_conformal_factor);
+  } else {
+    auto lapse_times_conformal_factor_minus_one =
+        make_with_random_values<Scalar<DataVector>>(
+            make_not_null(&gen), make_not_null(&dist), num_points);
+    Scalar<DataVector> n_dot_lapse_times_conformal_factor_gradient{
+        num_points, std::numeric_limits<double>::signaling_NaN()};
+    tnsr::i<DataVector, 3> deriv_lapse_times_conformal_factor{
+        num_points, std::numeric_limits<double>::signaling_NaN()};
+    if constexpr (EnabledEquations == Xcts::Equations::HamiltonianAndLapse) {
+      elliptic::apply_boundary_condition<Linearized, void,
+                                         tmpl::list<Robin<EnabledEquations>>>(
+          boundary_condition, box, direction,
+          make_not_null(&conformal_factor_minus_one),
+          make_not_null(&lapse_times_conformal_factor_minus_one),
+          make_not_null(&n_dot_conformal_factor_gradient),
+          make_not_null(&n_dot_lapse_times_conformal_factor_gradient),
+          deriv_conformal_factor, deriv_lapse_times_conformal_factor);
+    } else {
+      auto shift_excess = make_with_random_values<tnsr::I<DataVector, 3>>(
+          make_not_null(&gen), make_not_null(&dist), num_points);
+      auto deriv_shift_excess =
+          make_with_random_values<tnsr::iJ<DataVector, 3>>(
+              make_not_null(&gen), make_not_null(&dist), num_points);
+      tnsr::II<DataVector, 3> longitudinal_shift_excess{
+          num_points, std::numeric_limits<double>::signaling_NaN()};
+      Xcts::longitudinal_operator_flat_cartesian(
+          make_not_null(&longitudinal_shift_excess), deriv_shift_excess);
+      tnsr::I<DataVector, 3> n_dot_longitudinal_shift_excess{
+          num_points, std::numeric_limits<double>::signaling_NaN()};
+      normal_dot_flux(make_not_null(&n_dot_longitudinal_shift_excess),
+                      face_normal, longitudinal_shift_excess);
+      elliptic::apply_boundary_condition<Linearized, void,
+                                         tmpl::list<Robin<EnabledEquations>>>(
+          boundary_condition, box, direction,
+          make_not_null(&conformal_factor_minus_one),
+          make_not_null(&lapse_times_conformal_factor_minus_one),
+          make_not_null(&shift_excess),
+          make_not_null(&n_dot_conformal_factor_gradient),
+          make_not_null(&n_dot_lapse_times_conformal_factor_gradient),
+          make_not_null(&n_dot_longitudinal_shift_excess),
+          deriv_conformal_factor, deriv_lapse_times_conformal_factor,
+          deriv_shift_excess);
+      const auto expected_n_dot_longitudinal_shift_excess =
+          pypp::call<tnsr::I<DataVector, 3>>(
+              py_module, "robin_boundary_condition_shift", shift_excess,
+              deriv_shift_excess, x, face_normal);
+      CHECK_ITERABLE_APPROX(get<0>(n_dot_longitudinal_shift_excess),
+                            get<0>(expected_n_dot_longitudinal_shift_excess));
+      CHECK_ITERABLE_APPROX(get<1>(n_dot_longitudinal_shift_excess),
+                            get<1>(expected_n_dot_longitudinal_shift_excess));
+      CHECK_ITERABLE_APPROX(get<2>(n_dot_longitudinal_shift_excess),
+                            get<2>(expected_n_dot_longitudinal_shift_excess));
+    }
+    const auto expected_n_dot_lapse_times_conformal_factor_gradient =
+        pypp::call<Scalar<DataVector>>(
+            py_module, "robin_boundary_condition_scalar",
+            lapse_times_conformal_factor_minus_one, x);
+    CHECK_ITERABLE_APPROX(
+        get(n_dot_lapse_times_conformal_factor_gradient),
+        get(expected_n_dot_lapse_times_conformal_factor_gradient));
+  }
+  const auto expected_n_dot_conformal_factor_gradient =
+      pypp::call<Scalar<DataVector>>(py_module,
+                                     "robin_boundary_condition_scalar",
+                                     conformal_factor_minus_one, x);
+  CHECK_ITERABLE_APPROX(get(n_dot_conformal_factor_gradient),
+                        get(expected_n_dot_conformal_factor_gradient));
+}
+
+template <Xcts::Equations EnabledEquations>
+void test_suite() {
+  // Test factory-creation
+  const auto created = TestHelpers::test_factory_creation<
+      elliptic::BoundaryConditions::BoundaryCondition<3>,
+      Robin<EnabledEquations>>("Robin");
+  REQUIRE(dynamic_cast<const Robin<EnabledEquations>*>(created.get()) !=
+          nullptr);
+  const auto& boundary_condition =
+      dynamic_cast<const Robin<EnabledEquations>&>(*created);
+  {
+    INFO("Semantics");
+    test_serialization(boundary_condition);
+    test_copy_semantics(boundary_condition);
+    auto move_boundary_condition = boundary_condition;
+    test_move_semantics(std::move(move_boundary_condition), boundary_condition);
+  }
+  {
+    INFO("Properties");
+    if constexpr (EnabledEquations == Xcts::Equations::Hamiltonian) {
+      CHECK(boundary_condition.boundary_condition_types() ==
+            std::vector<elliptic::BoundaryConditionType>{
+                1, elliptic::BoundaryConditionType::Neumann});
+    } else if constexpr (EnabledEquations ==
+                         Xcts::Equations::HamiltonianAndLapse) {
+      CHECK(boundary_condition.boundary_condition_types() ==
+            std::vector<elliptic::BoundaryConditionType>{
+                2, elliptic::BoundaryConditionType::Neumann});
+    } else if constexpr (EnabledEquations ==
+                         Xcts::Equations::HamiltonianLapseAndShift) {
+      CHECK(boundary_condition.boundary_condition_types() ==
+            std::vector<elliptic::BoundaryConditionType>{
+                5, elliptic::BoundaryConditionType::Neumann});
+    }
+  }
+  test_robin<EnabledEquations, false>(boundary_condition);
+  test_robin<EnabledEquations, true>(boundary_condition);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Xcts.BoundaryConditions.Robin", "[Unit][Elliptic]") {
+  pypp::SetupLocalPythonEnvironment local_python_env("");
+  test_suite<Xcts::Equations::Hamiltonian>();
+  test_suite<Xcts::Equations::HamiltonianAndLapse>();
+  test_suite<Xcts::Equations::HamiltonianLapseAndShift>();
+}
+
+}  // namespace Xcts::BoundaryConditions


### PR DESCRIPTION
## Proposed changes

These allow to place the outer boundary at a much smaller outer radius R, since the error falls of as 1/R^2 rather than 1/R.

Here's a plot showing the faster convergence for BBH initial data:

![daacdea2-275d-4b7b-95bc-47ecf770e045](https://github.com/sxs-collaboration/spectre/assets/746230/533e295a-a570-4a23-b087-13d78976b5fc)


### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
