### PR TITLE
XCTS: output spatial Christoffels

### DIFF
--- a/src/Elliptic/Executables/Xcts/SolveXcts.hpp
+++ b/src/Elliptic/Executables/Xcts/SolveXcts.hpp
@@ -72,6 +72,8 @@ struct Metavariables {
                  gr::Tags::HamiltonianConstraint<DataVector>,
                  gr::Tags::MomentumConstraint<DataVector, 3>,
                  gr::Tags::SpatialMetric<DataVector, 3>,
+                 gr::Tags::InverseSpatialMetric<DataVector, 3>,
+                 gr::Tags::SpatialChristoffelSecondKind<DataVector, 3>,
                  gr::Tags::Lapse<DataVector>, gr::Tags::Shift<DataVector, 3>,
                  gr::Tags::ExtrinsicCurvature<DataVector, 3>>>;
   using hydro_quantities_compute = Xcts::Tags::HydroQuantitiesCompute<

--- a/src/PointwiseFunctions/Xcts/SpacetimeQuantities.hpp
+++ b/src/PointwiseFunctions/Xcts/SpacetimeQuantities.hpp
@@ -53,6 +53,7 @@ using SpacetimeQuantities = CachedTempBuffer<
     gr::Tags::SpatialMetric<DataVector, 3>,
     gr::Tags::InverseSpatialMetric<DataVector, 3>, gr::Tags::Lapse<DataVector>,
     gr::Tags::Shift<DataVector, 3>, gr::Tags::ExtrinsicCurvature<DataVector, 3>,
+    gr::Tags::SpatialChristoffelSecondKind<DataVector, 3>,
     // Constraints
     gr::Tags::HamiltonianConstraint<DataVector>,
     gr::Tags::MomentumConstraint<DataVector, 3>>;
@@ -80,6 +81,10 @@ struct SpacetimeQuantitiesComputer {
       gsl::not_null<Cache*> cache,
       ::Tags::deriv<Tags::ConformalFactor<DataVector>, tmpl::size_t<3>,
                     Frame::Inertial> /*meta*/) const;
+  void operator()(
+      gsl::not_null<tnsr::Ijj<DataVector, 3>*> spatial_christoffel_second_kind,
+      gsl::not_null<Cache*> cache,
+      gr::Tags::SpatialChristoffelSecondKind<DataVector, 3> /*meta*/) const;
   void operator()(
       gsl::not_null<Scalar<DataVector>*>
           conformal_laplacian_of_conformal_factor,

--- a/support/Pipelines/Bbh/InitialData.yaml
+++ b/support/Pipelines/Bbh/InitialData.yaml
@@ -207,7 +207,7 @@ RadiallyCompressedCoordinates:
   Compression: *outer_shell_distribution
 
 EventsAndTriggers:
-  - Trigger: Always
+  - Trigger: HasConverged
     Events:
       - ObserveFields:
           SubfileName: VolumeData
@@ -217,6 +217,8 @@ EventsAndTriggers:
             - Shift
             - ShiftExcess
             - SpatialMetric
+            - InverseSpatialMetric
+            - SpatialChristoffelSecondKind
             - ExtrinsicCurvature
             - RadiallyCompressedCoordinates
           InterpolateToMesh: None

--- a/tests/Unit/PointwiseFunctions/Xcts/SpacetimeQuantities.py
+++ b/tests/Unit/PointwiseFunctions/Xcts/SpacetimeQuantities.py
@@ -13,6 +13,29 @@ def inv_spatial_metric(conformal_factor, inv_conformal_metric):
     return conformal_factor ** (-4) * inv_conformal_metric
 
 
+def spatial_christoffel_second_kind(
+    conformal_factor,
+    deriv_conformal_factor,
+    conformal_metric,
+    inv_conformal_metric,
+    conformal_christoffel_second_kind,
+):
+    # Eq. (3.7) in Baumgarte/Shapiro
+    krond = np.eye(3)
+    return conformal_christoffel_second_kind + 2.0 * (
+        np.einsum("ij,k->ijk", krond, deriv_conformal_factor / conformal_factor)
+        + np.einsum(
+            "ik,j->ijk", krond, deriv_conformal_factor / conformal_factor
+        )
+        - np.einsum(
+            "jk,il,l->ijk",
+            conformal_metric,
+            inv_conformal_metric,
+            deriv_conformal_factor / conformal_factor,
+        )
+    )
+
+
 def lapse(conformal_factor, lapse_times_conformal_factor):
     return lapse_times_conformal_factor / conformal_factor
 

--- a/tests/Unit/PointwiseFunctions/Xcts/Test_SpacetimeQuantities.cpp
+++ b/tests/Unit/PointwiseFunctions/Xcts/Test_SpacetimeQuantities.cpp
@@ -126,6 +126,13 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.Xcts.SpacetimeQuantities",
   check_with_python(get<gr::Tags::InverseSpatialMetric<DataVector, 3>>(vars),
                     "inv_spatial_metric", conformal_factor,
                     inv_conformal_metric);
+  check_with_python(
+      get<gr::Tags::SpatialChristoffelSecondKind<DataVector, 3>>(vars),
+      "spatial_christoffel_second_kind", conformal_factor,
+      get<::Tags::deriv<Tags::ConformalFactor<DataVector>, tmpl::size_t<3>,
+                        Frame::Inertial>>(vars),
+      conformal_metric, inv_conformal_metric,
+      conformal_christoffel_second_kind);
   check_with_python(get<gr::Tags::Lapse<DataVector>>(vars), "lapse",
                     conformal_factor, lapse_times_conformal_factor);
   check_with_python(get<gr::Tags::Shift<DataVector, 3>>(vars), "shift",


### PR DESCRIPTION
## Proposed changes

Useful for horizon finding on the initial data slice. With this data available in the output data we can run the horizon finder over the data in post-processing, then output the Ylm coefficients of the horizon and use them to initialize the inspiral domain.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
