### PR TITLE
Bind horizon finder in Python

### DIFF
--- a/src/IO/Exporter/Python/__init__.py
+++ b/src/IO/Exporter/Python/__init__.py
@@ -1,4 +1,49 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
+from typing import Sequence, Type
+
 from ._Pybindings import *
+
+
+def interpolate_tensors_to_points(
+    *args,
+    tensor_names: Sequence[str],
+    tensor_types: Sequence[Type],
+    **kwargs,
+):
+    """Wrapper around 'interpolate_to_points' for tensors.
+
+    Interpolates volume data to points by calling 'interpolate_to_points'.
+    However, instead of passing a list of tensor components
+    (like 'SpatialMetric_xx') you can pass a list of tensor names (like
+    'SpatialMetric') and their corresponding types (like
+    'tnsr.ii[DataVector, 3]') and this function will assemble the tensors
+    and return them as a list.
+
+    Note: It would be nice to move this function into C++, but that's not
+    trivial because the tensor types are not known at compile time. This can be
+    revisited when we have Python support for Variables.
+    """
+    from spectre.DataStructures import DataVector
+
+    tensors = {
+        tensor_name: tensor_type()
+        for tensor_name, tensor_type in zip(tensor_names, tensor_types)
+    }
+    tensor_components = []
+    for name, tensor in tensors.items():
+        tensor_components += [
+            name + tensor.component_suffix(i) for i in range(tensor.size)
+        ]
+    data = interpolate_to_points(
+        *args,
+        **kwargs,
+        tensor_components=tensor_components,
+    )
+    j = 0
+    for tensor in tensors.values():
+        for i in range(tensor.size):
+            tensor[i] = DataVector(data[j])
+            j += 1
+    return tensors.values()

--- a/src/IO/H5/Python/File.cpp
+++ b/src/IO/H5/Python/File.cpp
@@ -79,10 +79,27 @@ void bind_h5file_impl(py::module& m) {  // NOLINT
             py::return_value_policy::reference, py::arg("path"),
             py::arg("legend"), py::arg("version"))
         .def(
+            "try_insert_dat",
+            [](H5File& f, const std::string& path,
+               const std::vector<std::string>& legend,
+               const uint32_t version) -> h5::Dat& {
+              return f.template try_insert<h5::Dat>(path, legend, version);
+            },
+            py::return_value_policy::reference, py::arg("path"),
+            py::arg("legend"), py::arg("version"))
+        .def(
             "insert_vol",
             [](H5File& f, const std::string& path,
                const uint32_t version) -> h5::VolumeData& {
               return f.template insert<h5::VolumeData>(path, version);
+            },
+            py::return_value_policy::reference, py::arg("path"),
+            py::arg("version"))
+        .def(
+            "try_insert_vol",
+            [](H5File& f, const std::string& path,
+               const uint32_t version) -> h5::VolumeData& {
+              return f.template try_insert<h5::VolumeData>(path, version);
             },
             py::return_value_policy::reference, py::arg("path"),
             py::arg("version"));

--- a/src/NumericalAlgorithms/SphericalHarmonics/CMakeLists.txt
+++ b/src/NumericalAlgorithms/SphericalHarmonics/CMakeLists.txt
@@ -51,3 +51,4 @@ target_link_libraries(
   )
 
 add_subdirectory(IO)
+add_subdirectory(Python)

--- a/src/NumericalAlgorithms/SphericalHarmonics/Python/Bindings.cpp
+++ b/src/NumericalAlgorithms/SphericalHarmonics/Python/Bindings.cpp
@@ -1,0 +1,18 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include <pybind11/pybind11.h>
+
+#include "NumericalAlgorithms/SphericalHarmonics/Python/Strahlkorper.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/Python/StrahlkorperFunctions.hpp"
+#include "Utilities/ErrorHandling/SegfaultHandler.hpp"
+
+namespace py = pybind11;
+
+PYBIND11_MODULE(_Pybindings, m) {  // NOLINT
+  enable_segfault_handler();
+  py::module_::import("spectre.DataStructures");
+  py::module_::import("spectre.DataStructures.Tensor");
+  ylm::py_bindings::bind_strahlkorper(m);
+  ylm::py_bindings::bind_strahlkorper_functions(m);
+}

--- a/src/NumericalAlgorithms/SphericalHarmonics/Python/CMakeLists.txt
+++ b/src/NumericalAlgorithms/SphericalHarmonics/Python/CMakeLists.txt
@@ -1,0 +1,37 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBRARY "PySphericalHarmonics")
+
+spectre_python_add_module(
+  SphericalHarmonics
+  LIBRARY_NAME ${LIBRARY}
+  SOURCES
+  Bindings.cpp
+  Strahlkorper.cpp
+  StrahlkorperFunctions.cpp
+  PYTHON_FILES
+  __init__.py
+)
+
+spectre_python_headers(
+  ${LIBRARY}
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  Strahlkorper.hpp
+  StrahlkorperFunctions.hpp
+  )
+
+spectre_python_link_libraries(
+  ${LIBRARY}
+  PRIVATE
+  DataStructures
+  SphericalHarmonics
+  pybind11::module
+)
+
+spectre_python_add_dependencies(
+  ${LIBRARY}
+  PyDataStructures
+  PyTensor
+  )

--- a/src/NumericalAlgorithms/SphericalHarmonics/Python/CMakeLists.txt
+++ b/src/NumericalAlgorithms/SphericalHarmonics/Python/CMakeLists.txt
@@ -27,6 +27,7 @@ spectre_python_link_libraries(
   PRIVATE
   DataStructures
   SphericalHarmonics
+  SphericalHarmonicsIO
   pybind11::module
 )
 

--- a/src/NumericalAlgorithms/SphericalHarmonics/Python/Strahlkorper.cpp
+++ b/src/NumericalAlgorithms/SphericalHarmonics/Python/Strahlkorper.cpp
@@ -5,12 +5,15 @@
 
 #include <array>
 #include <cstddef>
+#include <pybind11/operators.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/ModalVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/IO/FillYlmLegendAndData.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/IO/ReadSurfaceYlm.hpp"
 #include "NumericalAlgorithms/SphericalHarmonics/Strahlkorper.hpp"
 
 namespace py = pybind11;
@@ -57,5 +60,25 @@ void bind_strahlkorper(pybind11::module& m) {  // NOLINT
       .def(py::self == py::self)
       // NOLINTNEXTLINE(misc-redundant-expression)
       .def(py::self != py::self);
+  m.def(
+      "ylm_legend_and_data",
+      [](const ylm::Strahlkorper<Frame::Inertial>& strahlkorper,
+         const double time, const size_t max_l)
+          -> std::pair<std::vector<std::string>, std::vector<double>> {
+        std::vector<std::string> legend{};
+        std::vector<double> data{};
+        ylm::fill_ylm_legend_and_data(make_not_null(&legend),
+                                      make_not_null(&data), strahlkorper, time,
+                                      max_l);
+        return std::make_pair(legend, data);
+      },
+      py::arg("strahlkorper"), py::arg("time"), py::arg("max_l"));
+  m.def("read_surface_ylm", &ylm::read_surface_ylm<Frame::Inertial>,
+        py::arg("file_name"), py::arg("surface_subfile_name"),
+        py::arg("requested_number_of_times_from_end"));
+  m.def("read_surface_ylm_single_time",
+        &ylm::read_surface_ylm_single_time<Frame::Inertial>,
+        py::arg("file_name"), py::arg("surface_subfile_name"), py::arg("time"),
+        py::arg("relative_epsilon"));
 }
 }  // namespace ylm::py_bindings

--- a/src/NumericalAlgorithms/SphericalHarmonics/Python/Strahlkorper.cpp
+++ b/src/NumericalAlgorithms/SphericalHarmonics/Python/Strahlkorper.cpp
@@ -1,0 +1,61 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "NumericalAlgorithms/SphericalHarmonics/Python/Strahlkorper.hpp"
+
+#include <array>
+#include <cstddef>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/ModalVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/Strahlkorper.hpp"
+
+namespace py = pybind11;
+
+namespace ylm::py_bindings {
+void bind_strahlkorper(pybind11::module& m) {  // NOLINT
+  py::class_<ylm::Strahlkorper<Frame::Inertial>>(m, "Strahlkorper")
+      .def(py::init<size_t, size_t, double, std::array<double, 3>>(),
+           py::arg("l_max"), py::arg("m_max"), py::arg("radius"),
+           py::arg("center"))
+      .def(py::init<size_t, size_t, const DataVector&, std::array<double, 3>>(),
+           py::arg("l_max"), py::arg("m_max"),
+           py::arg("radius_at_collocation_points"), py::arg("center"))
+      .def(
+          py::init<size_t, size_t, const ylm::Strahlkorper<Frame::Inertial>&>(),
+          py::arg("l_max"), py::arg("m_max"), py::arg("another_strahlkorper"))
+      .def(
+          py::init<size_t, size_t, const ModalVector&, std::array<double, 3>>(),
+          py::arg("l_max"), py::arg("m_max"), py::arg("spectral_coefficients"),
+          py::arg("center"))
+      .def_property_readonly("l_max",
+                             &ylm::Strahlkorper<Frame::Inertial>::l_max)
+      .def_property_readonly("m_max",
+                             &ylm::Strahlkorper<Frame::Inertial>::m_max)
+      .def_property_readonly(
+          "physical_extents",
+          [](const ylm::Strahlkorper<Frame::Inertial>& strahlkorper) {
+            return strahlkorper.ylm_spherepack().physical_extents();
+          })
+      .def_property_readonly(
+          "expansion_center",
+          &ylm::Strahlkorper<Frame::Inertial>::expansion_center)
+      .def_property_readonly(
+          "physical_center",
+          &ylm::Strahlkorper<Frame::Inertial>::physical_center)
+      .def_property_readonly(
+          "average_radius", &ylm::Strahlkorper<Frame::Inertial>::average_radius)
+      .def("radius", &ylm::Strahlkorper<Frame::Inertial>::radius,
+           py::arg("theta"), py::arg("phi"))
+      .def("point_is_contained",
+           &ylm::Strahlkorper<Frame::Inertial>::point_is_contained,
+           py::arg("x"))
+      // NOLINTNEXTLINE(misc-redundant-expression)
+      .def(py::self == py::self)
+      // NOLINTNEXTLINE(misc-redundant-expression)
+      .def(py::self != py::self);
+}
+}  // namespace ylm::py_bindings

--- a/src/NumericalAlgorithms/SphericalHarmonics/Python/Strahlkorper.hpp
+++ b/src/NumericalAlgorithms/SphericalHarmonics/Python/Strahlkorper.hpp
@@ -1,0 +1,11 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <pybind11/pybind11.h>
+
+namespace ylm::py_bindings {
+// NOLINTNEXTLINE(google-runtime-references)
+void bind_strahlkorper(pybind11::module& m);
+}  // namespace ylm::py_bindings

--- a/src/NumericalAlgorithms/SphericalHarmonics/Python/StrahlkorperFunctions.cpp
+++ b/src/NumericalAlgorithms/SphericalHarmonics/Python/StrahlkorperFunctions.cpp
@@ -1,0 +1,21 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "NumericalAlgorithms/SphericalHarmonics/Python/StrahlkorperFunctions.hpp"
+
+#include <pybind11/pybind11.h>
+
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/Strahlkorper.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/StrahlkorperFunctions.hpp"
+
+namespace py = pybind11;
+
+namespace ylm::py_bindings {
+void bind_strahlkorper_functions(pybind11::module& m) {  // NOLINT
+  m.def("cartesian_coords",
+        py::overload_cast<const ylm::Strahlkorper<Frame::Inertial>&>(
+            &ylm::cartesian_coords<Frame::Inertial>),
+        py::arg("strahlkorper"));
+}
+}  // namespace ylm::py_bindings

--- a/src/NumericalAlgorithms/SphericalHarmonics/Python/StrahlkorperFunctions.hpp
+++ b/src/NumericalAlgorithms/SphericalHarmonics/Python/StrahlkorperFunctions.hpp
@@ -1,0 +1,11 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <pybind11/pybind11.h>
+
+namespace ylm::py_bindings {
+// NOLINTNEXTLINE(google-runtime-references)
+void bind_strahlkorper_functions(pybind11::module& m);
+}  // namespace ylm::py_bindings

--- a/src/NumericalAlgorithms/SphericalHarmonics/Python/__init__.py
+++ b/src/NumericalAlgorithms/SphericalHarmonics/Python/__init__.py
@@ -1,0 +1,4 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+from ._Pybindings import *

--- a/src/NumericalAlgorithms/SphericalHarmonics/StrahlkorperFunctions.cpp
+++ b/src/NumericalAlgorithms/SphericalHarmonics/StrahlkorperFunctions.cpp
@@ -252,6 +252,15 @@ void cartesian_coords(const gsl::not_null<tnsr::I<DataVector, 3, Fr>*> coords,
 }
 
 template <typename Fr>
+tnsr::I<DataVector, 3, Fr> cartesian_coords(
+    const Strahlkorper<Fr>& strahlkorper) {
+  const auto radius = ylm::radius(strahlkorper);
+  const auto theta_phi = ylm::theta_phi(strahlkorper);
+  const auto r_hat = ylm::rhat(theta_phi);
+  return cartesian_coords(strahlkorper, radius, r_hat);
+}
+
+template <typename Fr>
 tnsr::i<DataVector, 3, Fr> cartesian_derivs_of_scalar(
     const Scalar<DataVector>& scalar, const Strahlkorper<Fr>& strahlkorper,
     const Scalar<DataVector>& radius_of_strahlkorper,
@@ -545,6 +554,8 @@ void time_deriv_of_strahlkorper(
       const Strahlkorper<FRAME(data)>& strahlkorper,                          \
       const Scalar<DataVector>& radius,                                       \
       const tnsr::i<DataVector, 3, FRAME(data)>& r_hat);                      \
+  template tnsr::I<DataVector, 3, FRAME(data)> ylm::cartesian_coords(         \
+      const Strahlkorper<FRAME(data)>& strahlkorper);                         \
   template tnsr::i<DataVector, 3, FRAME(data)>                                \
   ylm::cartesian_derivs_of_scalar(                                            \
       const Scalar<DataVector>& scalar,                                       \

--- a/src/NumericalAlgorithms/SphericalHarmonics/StrahlkorperFunctions.hpp
+++ b/src/NumericalAlgorithms/SphericalHarmonics/StrahlkorperFunctions.hpp
@@ -159,6 +159,16 @@ void cartesian_coords(const gsl::not_null<tnsr::I<DataVector, 3, Fr>*> coords,
                       const Strahlkorper<Fr>& strahlkorper,
                       const Scalar<DataVector>& radius,
                       const tnsr::i<DataVector, 3, Fr>& r_hat);
+
+/*!
+ * This overload computes `radius`, `theta_phi`, and `r_hat` internally.
+ * Use the other overloads if you already have these quantities.
+ *
+ * \param strahlkorper The Strahlkorper surface.
+ */
+template <typename Fr>
+tnsr::I<DataVector, 3, Fr> cartesian_coords(
+    const Strahlkorper<Fr>& strahlkorper);
 /// @}
 
 /// @{

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/CMakeLists.txt
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/CMakeLists.txt
@@ -50,4 +50,5 @@ target_link_libraries(
   ParallelInterpolation
   )
 
-  add_subdirectory(Callbacks)
+add_subdirectory(Callbacks)
+add_subdirectory(Python)

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/Python/Bindings.cpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/Python/Bindings.cpp
@@ -1,0 +1,59 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/Strahlkorper.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/FastFlow.hpp"
+#include "Utilities/ErrorHandling/SegfaultHandler.hpp"
+
+namespace py = pybind11;
+
+PYBIND11_MODULE(_Pybindings, m) {  // NOLINT
+  enable_segfault_handler();
+  py::module_::import("spectre.SphericalHarmonics");
+  py::enum_<FastFlow::FlowType>(m, "FlowType")
+      .value("Jacobi", FastFlow::FlowType::Jacobi)
+      .value("Curvature", FastFlow::FlowType::Curvature)
+      .value("Fast", FastFlow::FlowType::Fast);
+  py::enum_<FastFlow::Status>(m, "Status")
+      .value("SuccessfulIteration", FastFlow::Status::SuccessfulIteration)
+      .value("AbsTol", FastFlow::Status::AbsTol)
+      .value("TruncationTol", FastFlow::Status::TruncationTol)
+      .value("MaxIts", FastFlow::Status::MaxIts)
+      .value("NegativeRadius", FastFlow::Status::NegativeRadius)
+      .value("DivergenceError", FastFlow::Status::DivergenceError)
+      .value("InterpolationFailure", FastFlow::Status::InterpolationFailure);
+  py::class_<FastFlow::IterInfo>(m, "IterInfo")
+      .def_readonly("iteration", &FastFlow::IterInfo::iteration)
+      .def_readonly("r_min", &FastFlow::IterInfo::r_min)
+      .def_readonly("r_max", &FastFlow::IterInfo::r_max)
+      .def_readonly("min_residual", &FastFlow::IterInfo::min_residual)
+      .def_readonly("max_residual", &FastFlow::IterInfo::max_residual)
+      .def_readonly("residual_ylm", &FastFlow::IterInfo::residual_ylm)
+      .def_readonly("residual_mesh", &FastFlow::IterInfo::residual_mesh);
+  py::class_<FastFlow>(m, "FastFlow")
+      .def(py::init<FastFlow::FlowType, double, double, double, double, double,
+                    size_t, size_t>(),
+           py::arg("flow_type"), py::arg("alpha"), py::arg("beta"),
+           py::arg("abs_tol"), py::arg("truncation_tol"),
+           py::arg("divergence_tol"), py::arg("divergence_iter"),
+           py::arg("max_its"))
+      .def(
+          "iterate_horizon_finder",
+          [](FastFlow& fast_flow,
+             ylm::Strahlkorper<Frame::Inertial>& current_strahlkorper,
+             const tnsr::II<DataVector, 3>& upper_spatial_metric,
+             const tnsr::ii<DataVector, 3>& extrinsic_curvature,
+             const tnsr::Ijj<DataVector, 3>& christoffel_2nd_kind) {
+            return fast_flow.iterate_horizon_finder<Frame::Inertial>(
+                make_not_null(&current_strahlkorper), upper_spatial_metric,
+                extrinsic_curvature, christoffel_2nd_kind);
+          },
+          py::arg("current_strahlkorper"), py::arg("upper_spatial_metric"),
+          py::arg("extrinsic_curvature"), py::arg("christoffel_2nd_kind"))
+      .def("current_l_mesh", &FastFlow::current_l_mesh<Frame::Inertial>)
+      .def("reset_for_next_find", &FastFlow::reset_for_next_find);
+}

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/Python/CMakeLists.txt
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/Python/CMakeLists.txt
@@ -1,0 +1,27 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBRARY "PyApparentHorizonFinder")
+
+spectre_python_add_module(
+  ApparentHorizonFinder
+  LIBRARY_NAME ${LIBRARY}
+  SOURCES
+  Bindings.cpp
+  PYTHON_FILES
+  __init__.py
+)
+
+spectre_python_link_libraries(
+  ${LIBRARY}
+  PRIVATE
+  DataStructures
+  ApparentHorizonFinder
+  SphericalHarmonics
+  pybind11::module
+)
+
+spectre_python_add_dependencies(
+  ${LIBRARY}
+  PySphericalHarmonics
+)

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/Python/__init__.py
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/Python/__init__.py
@@ -1,0 +1,4 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+from ._Pybindings import *

--- a/src/Visualization/Python/OpenVolfiles.py
+++ b/src/Visualization/Python/OpenVolfiles.py
@@ -65,7 +65,9 @@ def parse_points(ctx, param, values):
     return np.array(points)
 
 
-def open_volfiles_command(obs_id_required=False, multiple_vars=False):
+def open_volfiles_command(
+    obs_id_required=False, vars_required=True, multiple_vars=False
+):
     """CLI options for accessing volume data files
 
     Use this decorator to add options for accessing volume data to a CLI
@@ -208,7 +210,7 @@ def open_volfiles_command(obs_id_required=False, multiple_vars=False):
                     obs_id or volfile.list_observation_ids()[0]
                 )
                 break
-            if list_vars or not vars_patterns:
+            if list_vars or (vars_required and not vars_patterns):
                 import rich.columns
 
                 rich.print(rich.columns.Columns(all_vars))
@@ -216,7 +218,7 @@ def open_volfiles_command(obs_id_required=False, multiple_vars=False):
             # Expand globs in vars
             vars = []
             if not multiple_vars:
-                vars_patterns = [vars_patterns]
+                vars_patterns = [vars_patterns] if vars_patterns else []
             for var_pattern in vars_patterns:
                 matched_vars = fnmatch.filter(all_vars, var_pattern)
                 if not matched_vars:
@@ -236,7 +238,9 @@ def open_volfiles_command(obs_id_required=False, multiple_vars=False):
                 obs_id=obs_id,
                 obs_time=obs_time,
                 **(
-                    dict(vars=vars) if multiple_vars else dict(var_name=vars[0])
+                    dict(vars=vars)
+                    if multiple_vars
+                    else dict(var_name=vars[0] if vars else None)
                 ),
                 **kwargs,
             )

--- a/support/Pipelines/Bbh/CMakeLists.txt
+++ b/support/Pipelines/Bbh/CMakeLists.txt
@@ -6,6 +6,7 @@ spectre_python_add_module(
   MODULE_PATH Pipelines
   PYTHON_FILES
   __init__.py
+  FindHorizon.py
   InitialData.py
   InitialData.yaml
   Inspiral.py

--- a/support/Pipelines/Bbh/FindHorizon.py
+++ b/support/Pipelines/Bbh/FindHorizon.py
@@ -1,0 +1,244 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import glob
+import logging
+from pathlib import Path
+from typing import Optional, Sequence, Type, Union
+
+import click
+
+import spectre.IO.H5 as spectre_h5
+from spectre.ApparentHorizonFinder import FastFlow, FlowType, Status
+from spectre.DataStructures import DataVector
+from spectre.DataStructures.Tensor import tnsr
+from spectre.IO.Exporter import interpolate_tensors_to_points
+from spectre.Spectral import Basis, Quadrature
+from spectre.SphericalHarmonics import (
+    Strahlkorper,
+    cartesian_coords,
+    ylm_legend_and_data,
+)
+from spectre.Visualization.OpenVolfiles import open_volfiles_command
+from spectre.Visualization.ReadH5 import list_observations
+
+logger = logging.getLogger(__name__)
+
+
+def _strahlkorper_vol_data(strahlkorper):
+    """Volume data representation of a Strahlkorper, can be written to H5."""
+    coords = cartesian_coords(strahlkorper)
+    return [
+        spectre_h5.ElementVolumeData(
+            element_name="Horizon",
+            components=[
+                spectre_h5.TensorComponent(
+                    "InertialCoordinates_" + "xyz"[d], coords[d]
+                )
+                for d in range(3)
+            ],
+            extents=strahlkorper.physical_extents,
+            basis=2 * [Basis.SphericalHarmonic],
+            quadrature=[
+                Quadrature.Gauss,
+                Quadrature.Equiangular,
+            ],
+        )
+    ]
+
+
+def find_horizon(
+    h5_files: Union[str, Sequence[str]],
+    subfile_name: str,
+    obs_id: int,
+    obs_time: float,
+    initial_guess: Strahlkorper,
+    fast_flow: Optional[FastFlow] = None,
+    output: Optional[str] = None,
+    output_coeffs_subfile: Optional[str] = None,
+    output_coords_subfile: Optional[str] = None,
+    output_l_max: Optional[int] = None,
+    tensor_names: Optional[Sequence[str]] = None,
+):
+    """Find an apparent horizon in volume data.
+
+    The volume data must contain the inverse spatial metric, extrinsic
+    curvature, and spatial Christoffel symbols. The data is assumed to be in the
+    "inertial" frame.
+
+    Arguments:
+      h5_files: List of H5 files containing volume data or glob pattern.
+      subfile_name: Name of the volume data subfile in the 'h5_files'.
+      obs_id: Observation ID in the volume data.
+      obs_time: Time of the observation.
+      initial_guess: Initial guess for the horizon. Specify a
+        'spectre.SphericalHarmonics.Strahlkorper'.
+      fast_flow: Optional. FastFlow object that controls the horizon finder.
+        If not specified, a FastFlow object with default parameters is used.
+      output: Optional. H5 output file where the horizon Ylm coefficients will
+        be written. Can be a new or existing file. Requires either
+        'output_coeffs_subfile' or 'output_coords_subfile' is also specified,
+        or both.
+      output_coeffs_subfile: Optional. Name of the subfile in the H5 output file
+        where the horizon Ylm coefficients will be written.
+        These can be used to reconstruct the horizon, e.g. to initialize
+        excisions in domains.
+      output_coords_subfile: Optional. Name of the subfile in the H5 output file
+        where the horizon coordinates will be written.
+        These can be used for visualization.
+      output_l_max: Optional. Maximum l-mode for the horizon Ylm coefficients
+        written to the output file. Defaults to the l_max of the initial guess.
+        Only used if 'output_coeffs_subfile' is specified.
+      tensor_names: Optional. List of tensor names in the volume data that
+        represent the inverse spatial metric, extrinsic curvature, and spatial
+        Christoffel symbols, in this order. Defaults to ["InverseSpatialMetric",
+        "ExtrinsicCurvature", "SpatialChristoffelSecondKind"].
+
+    Returns: The Strahlkorper representing the horizon.
+    """
+    if not tensor_names:
+        tensor_names = [
+            "InverseSpatialMetric",
+            "ExtrinsicCurvature",
+            "SpatialChristoffelSecondKind",
+        ]
+    if fast_flow is None:
+        fast_flow = FastFlow(
+            FlowType.Fast,
+            alpha=1.0,
+            beta=0.5,
+            abs_tol=1e-12,
+            truncation_tol=0.01,
+            divergence_tol=1.2,
+            divergence_iter=5,
+            max_its=100,
+        )
+    strahlkorper = initial_guess
+    while True:
+        l_mesh = fast_flow.current_l_mesh(strahlkorper)
+        prolonged_strahlkorper = Strahlkorper(l_mesh, l_mesh, strahlkorper)
+        (
+            inv_spatial_metric,
+            extrinsic_curvature,
+            spatial_christoffel_second_kind,
+        ) = interpolate_tensors_to_points(
+            h5_files,
+            subfile_name,
+            observation_id=obs_id,
+            target_points=cartesian_coords(prolonged_strahlkorper),
+            tensor_names=tensor_names,
+            tensor_types=[
+                tnsr.II[DataVector, 3],
+                tnsr.ii[DataVector, 3],
+                tnsr.Ijj[DataVector, 3],
+            ],
+        )
+        status, iter_info = fast_flow.iterate_horizon_finder(
+            strahlkorper,
+            upper_spatial_metric=inv_spatial_metric,
+            extrinsic_curvature=extrinsic_curvature,
+            christoffel_2nd_kind=spatial_christoffel_second_kind,
+        )
+        logger.debug(
+            f"Horizon finder iteration {iter_info.iteration}: {status}."
+            f" {iter_info.r_min:.3f} <= r <= {iter_info.r_max:.3f},"
+            f" {iter_info.min_residual:.2e} <= residual <="
+            f" {iter_info.max_residual:.2e}"
+        )
+        if status == Status.SuccessfulIteration:
+            continue
+        elif int(status) > 0:
+            logger.info(
+                f"Found horizon around {strahlkorper.expansion_center} with"
+                f" {iter_info.r_min:.3f} <= r <= {iter_info.r_max:.3f}."
+            )
+            break
+        else:
+            raise RuntimeError(f"Horizon finder failed with status {status}.")
+    # Write the horizon to a file and return it
+    if output:
+        assert output_coeffs_subfile or output_coords_subfile, (
+            "Specify either 'output_coeffs_subfile' or 'output_coords_subfile'"
+            " or both."
+        )
+        if output_coeffs_subfile:
+            legend, ylm_data = ylm_legend_and_data(
+                strahlkorper, obs_time, output_l_max or strahlkorper.l_max
+            )
+            with spectre_h5.H5File(output, "a") as output_file:
+                datfile = output_file.try_insert_dat(
+                    output_coeffs_subfile, legend, 0
+                )
+                datfile.append(ylm_data)
+        if output_coords_subfile:
+            vol_data = _strahlkorper_vol_data(strahlkorper)
+            with spectre_h5.H5File(output, "a") as output_file:
+                volfile = output_file.try_insert_vol(output_coords_subfile, 0)
+                volfile.write_volume_data(obs_id, obs_time, vol_data)
+    return strahlkorper
+
+
+@click.command(name="find-horizon")
+@open_volfiles_command(
+    obs_id_required=True, multiple_vars=True, vars_required=False
+)
+@click.option(
+    "--l-max",
+    "-l",
+    type=int,
+    required=True,
+    help="Max l-mode for the horizon search.",
+)
+@click.option(
+    "--initial-radius",
+    "-r",
+    type=float,
+    required=True,
+    help="Initial coordinate radius of the horizon.",
+)
+@click.option(
+    "--center",
+    "-C",
+    nargs=3,
+    type=float,
+    required=True,
+    help="Coordinate center of the horizon.",
+)
+@click.option(
+    "--output",
+    "-o",
+    type=click.Path(writable=True),
+    help=(
+        "H5 output file where the horizon Ylm coefficients will be written. Can"
+        " be a new or existing file."
+    ),
+)
+@click.option(
+    "--output-coeffs-subfile",
+    help=(
+        "Name of the subfile in the H5 output file where the horizon Ylm"
+        " coefficients will be written. These can be used to reconstruct the"
+        " horizon, e.g. to initialize excisions in domains."
+    ),
+)
+@click.option(
+    "--output-coords-subfile",
+    help=(
+        "Name of the subfile in the H5 output file where the horizon"
+        " coordinates will be written. These can be used for visualization."
+    ),
+)
+def find_horizon_command(l_max, initial_radius, center, vars, **kwargs):
+    """Find an apparent horizon in volume data."""
+    initial_guess = Strahlkorper(
+        l_max=l_max, m_max=l_max, radius=initial_radius, center=center
+    )
+    find_horizon(
+        initial_guess=initial_guess,
+        tensor_names=vars,
+        **kwargs,
+    )
+
+
+if __name__ == "__main__":
+    find_horizon_command(help_option_names=["-h", "--help"])

--- a/support/Pipelines/Bbh/__init__.py
+++ b/support/Pipelines/Bbh/__init__.py
@@ -3,6 +3,7 @@
 
 import click
 
+from .FindHorizon import find_horizon_command
 from .InitialData import generate_id_command
 from .Inspiral import start_inspiral_command
 from .Ringdown import start_ringdown_command
@@ -15,6 +16,7 @@ def bbh_pipeline():
 
 
 bbh_pipeline.add_command(generate_id_command)
+bbh_pipeline.add_command(find_horizon_command)
 bbh_pipeline.add_command(start_inspiral_command)
 bbh_pipeline.add_command(start_ringdown_command)
 

--- a/tests/Unit/NumericalAlgorithms/SphericalHarmonics/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/SphericalHarmonics/CMakeLists.txt
@@ -27,4 +27,5 @@ target_link_libraries(
   Utilities
   )
 
-  add_subdirectory(IO)
+add_subdirectory(IO)
+add_subdirectory(Python)

--- a/tests/Unit/NumericalAlgorithms/SphericalHarmonics/Python/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/SphericalHarmonics/Python/CMakeLists.txt
@@ -1,0 +1,8 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+spectre_add_python_bindings_test(
+  "Unit.Ylm.Python"
+  Test_Strahlkorper.py
+  "Unit;Python"
+  PySphericalHarmonics)

--- a/tests/Unit/NumericalAlgorithms/SphericalHarmonics/Python/Test_Strahlkorper.py
+++ b/tests/Unit/NumericalAlgorithms/SphericalHarmonics/Python/Test_Strahlkorper.py
@@ -1,15 +1,37 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
+import os
+import shutil
 import unittest
 
 import numpy as np
 import numpy.testing as npt
 
-from spectre.SphericalHarmonics import Strahlkorper, cartesian_coords
+import spectre.Informer as spectre_informer
+import spectre.IO.H5 as spectre_h5
+from spectre.SphericalHarmonics import (
+    Strahlkorper,
+    cartesian_coords,
+    read_surface_ylm,
+    read_surface_ylm_single_time,
+    ylm_legend_and_data,
+)
 
 
 class TestStrahlkorper(unittest.TestCase):
+    def setUp(self):
+        self.test_dir = os.path.join(
+            spectre_informer.unit_test_build_path(),
+            "NumericalAlgorithms/Strahlkorper/Python",
+        )
+        self.filename = os.path.join(self.test_dir, "Strahlkorper.h5")
+        shutil.rmtree(self.test_dir, ignore_errors=True)
+        os.makedirs(self.test_dir, exist_ok=True)
+
+    def tearDown(self):
+        shutil.rmtree(self.test_dir)
+
     def test_strahlkorper(self):
         strahlkorper = Strahlkorper(
             l_max=12, m_max=12, radius=1.0, center=[0.0, 0.0, 0.0]
@@ -25,6 +47,38 @@ class TestStrahlkorper(unittest.TestCase):
         x = np.array(cartesian_coords(strahlkorper))
         r = np.linalg.norm(x, axis=0)
         npt.assert_allclose(r, 1.0)
+
+        legend, ylm_data = ylm_legend_and_data(strahlkorper, 1.0, 12)
+        self.assertEqual(len(legend), 174)
+        self.assertEqual(
+            legend[:7],
+            [
+                "Time",
+                "InertialExpansionCenter_x",
+                "InertialExpansionCenter_y",
+                "InertialExpansionCenter_z",
+                "Lmax",
+                "coef(0,0)",
+                "coef(1,-1)",
+            ],
+        )
+        self.assertEqual(ylm_data[:5], [1.0, 0.0, 0.0, 0.0, 12.0])
+
+        with spectre_h5.H5File(self.filename, "w") as h5file:
+            datfile = h5file.insert_dat(
+                "/Strahlkorper", legend=legend, version=0
+            )
+            datfile.append(ylm_data)
+
+        self.assertEqual(
+            read_surface_ylm(self.filename, "Strahlkorper", 1)[0], strahlkorper
+        )
+        self.assertEqual(
+            read_surface_ylm_single_time(
+                self.filename, "Strahlkorper", 1.0, 0.0
+            ),
+            strahlkorper,
+        )
 
 
 if __name__ == "__main__":

--- a/tests/Unit/NumericalAlgorithms/SphericalHarmonics/Python/Test_Strahlkorper.py
+++ b/tests/Unit/NumericalAlgorithms/SphericalHarmonics/Python/Test_Strahlkorper.py
@@ -1,0 +1,31 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import unittest
+
+import numpy as np
+import numpy.testing as npt
+
+from spectre.SphericalHarmonics import Strahlkorper, cartesian_coords
+
+
+class TestStrahlkorper(unittest.TestCase):
+    def test_strahlkorper(self):
+        strahlkorper = Strahlkorper(
+            l_max=12, m_max=12, radius=1.0, center=[0.0, 0.0, 0.0]
+        )
+        self.assertEqual(strahlkorper.l_max, 12)
+        self.assertEqual(strahlkorper.m_max, 12)
+        self.assertEqual(strahlkorper.physical_extents, [13, 25])
+        self.assertEqual(strahlkorper.expansion_center, [0.0, 0.0, 0.0])
+        self.assertEqual(strahlkorper.physical_center, [0.0, 0.0, 0.0])
+        self.assertAlmostEqual(strahlkorper.average_radius, 1.0)
+        self.assertAlmostEqual(strahlkorper.radius(0.0, 0.0), 1.0)
+        self.assertTrue(strahlkorper.point_is_contained([0.5, 0.0, 0.0]))
+        x = np.array(cartesian_coords(strahlkorper))
+        r = np.linalg.norm(x, axis=0)
+        npt.assert_allclose(r, 1.0)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/Unit/NumericalAlgorithms/SphericalHarmonics/Test_StrahlkorperFunctions.cpp
+++ b/tests/Unit/NumericalAlgorithms/SphericalHarmonics/Test_StrahlkorperFunctions.cpp
@@ -273,6 +273,8 @@ void test_cartesian_coords() {
                         ylm::cartesian_coords<Frame::Inertial>(
                             strahlkorper, ylm::radius(strahlkorper),
                             ylm::rhat(ylm::theta_phi(strahlkorper))));
+  CHECK_ITERABLE_APPROX(expected_cartesian_coords,
+                        ylm::cartesian_coords<Frame::Inertial>(strahlkorper));
 }
 
 void test_normals() {

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/CMakeLists.txt
@@ -33,3 +33,5 @@ target_link_libraries(
   Time
   Utilities
   )
+
+add_subdirectory(Python)

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Python/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Python/CMakeLists.txt
@@ -1,0 +1,8 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+spectre_add_python_bindings_test(
+  "Unit.ApparentHorizonFinder.Python"
+  Test_FastFlow.py
+  "Unit;Python"
+  PyApparentHorizonFinder)

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Python/Test_FastFlow.py
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Python/Test_FastFlow.py
@@ -1,0 +1,27 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import unittest
+
+from spectre.ApparentHorizonFinder import FastFlow, FlowType
+
+
+class TestFastFlow(unittest.TestCase):
+    def test_fast_flow(self):
+        fast_flow = FastFlow(
+            FlowType.Fast,
+            alpha=1.0,
+            beta=0.5,
+            abs_tol=1e-12,
+            truncation_tol=0.01,
+            divergence_tol=1.2,
+            divergence_iter=5,
+            max_its=100,
+        )
+        # Can't test any iterations until we bind a Schwarzschild or Kerr
+        # solution in Python, or have numeric data with a horizon stored
+        # somewhere.
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/support/Pipelines/Bbh/CMakeLists.txt
+++ b/tests/support/Pipelines/Bbh/CMakeLists.txt
@@ -7,6 +7,17 @@ spectre_add_python_bindings_test(
   "Python"
   None)
 
+# Disable if compiler is GCC because for some reason it doesn't trap the
+# exception thrown by the test. Can be re-enabled once the test can find a
+# horizon in some data, so the exception trapping is not needed anymore.
+if (NOT CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+  spectre_add_python_bindings_test(
+    "support.Pipelines.Bbh.FindHorizon"
+    Test_FindHorizon.py
+    "Python"
+    None)
+endif()
+
 spectre_add_python_bindings_test(
   "support.Pipelines.Bbh.Inspiral"
   Test_Inspiral.py

--- a/tests/support/Pipelines/Bbh/Test_FindHorizon.py
+++ b/tests/support/Pipelines/Bbh/Test_FindHorizon.py
@@ -1,0 +1,61 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import logging
+import os
+import unittest
+
+from click.testing import CliRunner
+
+from spectre.Informer import unit_test_src_path
+from spectre.Pipelines.Bbh.FindHorizon import find_horizon_command
+
+
+class TestFindHorizon(unittest.TestCase):
+    def setUp(self):
+        self.h5_filename = os.path.join(
+            unit_test_src_path(), "Visualization/Python", "VolTestData0.h5"
+        )
+        self.output_filename = os.path.join(
+            unit_test_src_path(), "Visualization/Python", "Horizons.h5"
+        )
+
+    def test_cli(self):
+        # Can't test more than that this code runs until it errors until we have
+        # a way to generate data with an apparent horizon.
+        runner = CliRunner()
+        result = runner.invoke(
+            find_horizon_command,
+            [
+                self.h5_filename,
+                "-d",
+                "element_data",
+                "--step",
+                "0",
+                "--l-max",
+                "12",
+                "--initial-radius",
+                "0.5",
+                "--center",
+                "1.0",
+                "1.0",
+                "1.0",
+                "-o",
+                self.output_filename,
+                "--output-coeffs-subfile",
+                "HorizonCoeffs",
+                "--output-coords-subfile",
+                "HorizonCoords",
+            ],
+            catch_exceptions=True,
+        )
+        self.assertEqual(result.exit_code, 1)
+        self.assertIn(
+            "Failed to open dataset 'InverseSpatialMetric_xx'",
+            str(result.exception),
+        )
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.DEBUG)
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Proposed changes

This will allow finding horizons in output data in Python. For context, we can use this to find horizons on the initial data slice, write out the Ylm coefficients, and use them to initialize the inspiral domain.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
