### PR TITLE
Add functionality to Ylm IO

### DIFF
--- a/src/Domain/Creators/Sphere.cpp
+++ b/src/Domain/Creators/Sphere.cpp
@@ -159,10 +159,9 @@ Sphere::Sphere(
       tnsr::I<double, 3, Frame::Grid>{std::array{0.0, 0.0, 0.0}};
 
   // Determine number of blocks
-  num_blocks_per_shell_ =
-      which_wedges_ == ShellWedges::All
-          ? 6
-          : which_wedges_ == ShellWedges::FourOnEquator ? 4 : 1;
+  num_blocks_per_shell_ = which_wedges_ == ShellWedges::All             ? 6
+                          : which_wedges_ == ShellWedges::FourOnEquator ? 4
+                                                                        : 1;
   num_blocks_ = num_blocks_per_shell_ * num_shells_ + (fill_interior_ ? 1 : 0);
 
   // Create block names and groups
@@ -310,7 +309,8 @@ Domain<3> Sphere::create_domain() const {
           inner_radius_, outer_radius_,
           fill_interior_ ? std::get<InnerCube>(interior_).sphericity : 1.0, 1.0,
           use_equiangular_map_, false, radial_partitioning_,
-          radial_distribution_, which_wedges_), compression);
+          radial_distribution_, which_wedges_),
+      compression);
 
   std::unordered_map<std::string, ExcisionSphere<3>> excision_spheres{};
 

--- a/src/Domain/Creators/SphereTimeDependentMaps.hpp
+++ b/src/Domain/Creators/SphereTimeDependentMaps.hpp
@@ -169,8 +169,7 @@ struct TimeDependentMapOptions {
     using options = tmpl::list<InitialValues, DecayTimescaleRotation>;
 
     std::array<std::array<double, 4>, 3> initial_values{};
-    double decay_timescale{
-        std::numeric_limits<double>::signaling_NaN()};
+    double decay_timescale{std::numeric_limits<double>::signaling_NaN()};
   };
 
   struct ExpansionMapOptions {

--- a/src/NumericalAlgorithms/SphericalHarmonics/IO/CMakeLists.txt
+++ b/src/NumericalAlgorithms/SphericalHarmonics/IO/CMakeLists.txt
@@ -8,6 +8,7 @@ add_spectre_library(${LIBRARY})
 spectre_target_sources(
   ${LIBRARY}
   PRIVATE
+  FillYlmLegendAndData.cpp
   ReadSurfaceYlm.cpp
   )
 
@@ -15,6 +16,7 @@ spectre_target_headers(
   ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
+  FillYlmLegendAndData.hpp
   ReadSurfaceYlm.hpp
   )
 
@@ -24,7 +26,7 @@ target_link_libraries(
   DataStructures
   ErrorHandling
   H5
-  Utilities
   PUBLIC
   SphericalHarmonics
+  Utilities
   )

--- a/src/NumericalAlgorithms/SphericalHarmonics/IO/FillYlmLegendAndData.cpp
+++ b/src/NumericalAlgorithms/SphericalHarmonics/IO/FillYlmLegendAndData.cpp
@@ -1,7 +1,7 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
-#include "ParallelAlgorithms/Interpolation/Callbacks/ObserveSurfaceData.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/IO/FillYlmLegendAndData.hpp"
 
 #include <array>
 #include <cstddef>
@@ -19,7 +19,7 @@
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeString.hpp"
 
-namespace intrp::callbacks::detail {
+namespace ylm {
 template <typename Frame>
 void fill_ylm_legend_and_data(
     const gsl::not_null<std::vector<std::string>*> legend,
@@ -75,12 +75,12 @@ void fill_ylm_legend_and_data(
     }
   }
 }
-}  // namespace intrp::callbacks::detail
+}  // namespace ylm
 
 #define FRAMETYPE(instantiation_data) BOOST_PP_TUPLE_ELEM(0, instantiation_data)
 
 #define INSTANTIATE(_, instantiation_data)                                  \
-  template void intrp::callbacks::detail::fill_ylm_legend_and_data(         \
+  template void ylm::fill_ylm_legend_and_data(                              \
       gsl::not_null<std::vector<std::string>*> legend,                      \
       gsl::not_null<std::vector<double>*> data,                             \
       const ylm::Strahlkorper<FRAMETYPE(instantiation_data)>& strahlkorper, \

--- a/src/NumericalAlgorithms/SphericalHarmonics/IO/FillYlmLegendAndData.hpp
+++ b/src/NumericalAlgorithms/SphericalHarmonics/IO/FillYlmLegendAndData.hpp
@@ -1,0 +1,29 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <string>
+#include <vector>
+
+#include "NumericalAlgorithms/SphericalHarmonics/Strahlkorper.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace ylm {
+/*!
+ * \brief Fills the legend and row of spherical harmonic data to write to disk
+ *
+ * The number of coefficients to write is based on `max_l`, the maximum value
+ * that the input `strahlkorper` could possibly have. When
+ * `strahlkorper.l_max() < max_l`, coefficients with \f$l\f$ higher than
+ * `strahlkorper.l_max()` will simply be zero. Assuming the same `max_l` is
+ * always used for a given surface, we will always write the same number of
+ * columns for each row, as `max_l` sets the number of columns to write
+ */
+template <typename Frame>
+void fill_ylm_legend_and_data(gsl::not_null<std::vector<std::string>*> legend,
+                              gsl::not_null<std::vector<double>*> data,
+                              const ylm::Strahlkorper<Frame>& strahlkorper,
+                              double time, size_t max_l);
+}  // namespace ylm

--- a/src/NumericalAlgorithms/SphericalHarmonics/IO/ReadSurfaceYlm.hpp
+++ b/src/NumericalAlgorithms/SphericalHarmonics/IO/ReadSurfaceYlm.hpp
@@ -30,4 +30,29 @@ template <typename Frame>
 std::vector<ylm::Strahlkorper<Frame>> read_surface_ylm(
     const std::string& file_name, const std::string& surface_subfile_name,
     size_t requested_number_of_times_from_end);
+
+/*!
+ * \brief Similar to `ylm::read_surface_ylm`, this reads in spherical harmonic
+ * data for a surface and constructs a `ylm::Strahlkorper`. However, this
+ * function only does it at a specific time and returns a single
+ * `ylm::Strahlkorper`.
+ *
+ * \note If two times are found within \p epsilon of the \p time, then an error
+ * will occur. Similarly, if no \p time is found within the \p epsilon, then an
+ * error will occur as well.
+ *
+ * \param file_name name of the H5 file containing the surface's spherical
+ * harmonic data
+ * \param surface_subfile_name name of the subfile (with no leading slash nor
+ * the `.dat` extension) within `file_name` that contains the surface's
+ * spherical harmonic data to read in
+ * \param time Time to read the coefficients at.
+ * \param relative_epsilon How much error is allowed when looking for a specific
+ * time. This is useful so users don't have to know the specific time to machine
+ * precision.
+ */
+template <typename Frame>
+ylm::Strahlkorper<Frame> read_surface_ylm_single_time(
+    const std::string& file_name, const std::string& surface_subfile_name,
+    double time, double relative_epsilon);
 }  // namespace ylm

--- a/src/ParallelAlgorithms/Interpolation/CMakeLists.txt
+++ b/src/ParallelAlgorithms/Interpolation/CMakeLists.txt
@@ -43,6 +43,7 @@ target_link_libraries(
   Serialization
   Spectral
   SphericalHarmonics
+  SphericalHarmonicsIO
   Utilities
   INTERFACE
   Actions

--- a/src/ParallelAlgorithms/Interpolation/Callbacks/CMakeLists.txt
+++ b/src/ParallelAlgorithms/Interpolation/Callbacks/CMakeLists.txt
@@ -1,12 +1,6 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-spectre_target_sources(
-  ${LIBRARY}
-  PRIVATE
-  ObserveSurfaceData.cpp
-  )
-
 spectre_target_headers(
   ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src

--- a/src/ParallelAlgorithms/Interpolation/Callbacks/ObserveSurfaceData.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Callbacks/ObserveSurfaceData.hpp
@@ -17,6 +17,7 @@
 #include "IO/Observer/VolumeActions.hpp"
 #include "NumericalAlgorithms/Spectral/Basis.hpp"
 #include "NumericalAlgorithms/Spectral/Quadrature.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/IO/FillYlmLegendAndData.hpp"
 #include "NumericalAlgorithms/SphericalHarmonics/Spherepack.hpp"
 #include "NumericalAlgorithms/SphericalHarmonics/Strahlkorper.hpp"
 #include "NumericalAlgorithms/SphericalHarmonics/Tags.hpp"
@@ -34,22 +35,6 @@
 
 namespace intrp {
 namespace callbacks {
-namespace detail {
-// Fills the legend and row of spherical harmonic data to write to disk
-//
-// The number of coefficients to write is based on `max_l`, the maximum value
-// that the input `strahlkorper` could possibly have. When
-// `strahlkorper.l_max() < max_l`, coefficients with \f$l\f$ higher than
-// `strahlkorper.l_max()` will simply be zero. Assuming the same `max_l` is
-// always used for a given surface, we will always write the same number of
-// columns for each row, as `max_l` sets the number of columns to write
-template <typename Frame>
-void fill_ylm_legend_and_data(gsl::not_null<std::vector<std::string>*> legend,
-                              gsl::not_null<std::vector<double>*> data,
-                              const ylm::Strahlkorper<Frame>& strahlkorper,
-                              double time, size_t max_l);
-}  // namespace detail
-
 /// \brief post_interpolation_callback that outputs 2D "volume" data on a
 /// surface and the surface's spherical harmonic data
 ///
@@ -173,9 +158,9 @@ struct ObserveSurfaceData
     // coefficients regardless of the current value of l_max and (b) write a
     // constant number of columns for each row of data regardless of the current
     // l_max.
-    detail::fill_ylm_legend_and_data(make_not_null(&ylm_legend),
-                                     make_not_null(&ylm_data), strahlkorper,
-                                     time, strahlkorper.l_max());
+    ylm::fill_ylm_legend_and_data(make_not_null(&ylm_legend),
+                                  make_not_null(&ylm_data), strahlkorper, time,
+                                  strahlkorper.l_max());
 
     const std::string ylm_subfile_name{std::string{"/"} + surface_name +
                                        "_Ylm"};

--- a/tests/Unit/NumericalAlgorithms/SphericalHarmonics/IO/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/SphericalHarmonics/IO/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY "Test_SphericalHarmonicsIO")
 
 set(LIBRARY_SOURCES
+  Test_FillYlmLegendAndData.cpp
   Test_ReadSurfaceYlm.cpp
   )
 

--- a/tests/Unit/NumericalAlgorithms/SphericalHarmonics/IO/Test_FillYlmLegendAndData.cpp
+++ b/tests/Unit/NumericalAlgorithms/SphericalHarmonics/IO/Test_FillYlmLegendAndData.cpp
@@ -1,0 +1,99 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <limits>
+#include <random>
+#include <string>
+#include <vector>
+
+#include "DataStructures/DataVector.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/IO/FillYlmLegendAndData.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/Spherepack.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/SpherepackIterator.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/Strahlkorper.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace {
+template <typename Generator>
+void test(const gsl::not_null<Generator*> generator) {
+  std::vector<std::string> legend{};
+  std::vector<double> data{};
+  const size_t strahlkorper_l_max = 6;
+  const size_t larger_l_max = strahlkorper_l_max + 2;
+  const double time = 6.7;
+
+  std::uniform_real_distribution<double> dist{0.1, 2.0};
+
+  const size_t radii_size =
+      ylm::Spherepack::physical_size(strahlkorper_l_max, strahlkorper_l_max);
+  auto radii = make_with_random_values<DataVector>(
+      generator, make_not_null(&dist),
+      ModalVector{radii_size, std::numeric_limits<double>::signaling_NaN()});
+
+  ylm::Strahlkorper<Frame::Inertial> strahlkorper{
+      strahlkorper_l_max, strahlkorper_l_max, radii, std::array{0.9, 0.8, 0.7}};
+  ylm::SpherepackIterator iter{strahlkorper_l_max, strahlkorper_l_max};
+  std::vector<double> expected_coefs{};
+  for (size_t l = 0; l <= strahlkorper_l_max; l++) {
+    for (int m = -static_cast<int>(l); m <= static_cast<int>(l); m++) {
+      expected_coefs.emplace_back(
+          strahlkorper.coefficients()[iter.set(l, m)()]);
+    }
+  }
+
+  // Where max_l is the same as strahlkorper.l_max()
+  {
+    ylm::fill_ylm_legend_and_data(make_not_null(&legend), make_not_null(&data),
+                                  strahlkorper, time, strahlkorper_l_max);
+
+    // +5 for time, l_max, and 3 components of the center
+    const size_t expected_size = expected_coefs.size() + 5;
+    CHECK(legend.size() == expected_size);
+    CHECK(data.size() == expected_size);
+    CHECK(data[0] == time);
+    for (size_t i = 0; i < 3; i++) {
+      CHECK(data[i + 1] == gsl::at(strahlkorper.expansion_center(), i));
+    }
+    CHECK(data[4] == strahlkorper_l_max);
+    for (size_t i = 5; i < expected_size; i++) {
+      CHECK(data[i] == expected_coefs[i - 5]);
+    }
+  }
+
+  legend.clear();
+  data.clear();
+  iter.reset();
+
+  // Where max_l is larger than strahlkorper.l_max()
+  {
+    std::vector<std::string> compare_legend{};
+    std::vector<double> compare_data{};
+    ylm::fill_ylm_legend_and_data(make_not_null(&legend), make_not_null(&data),
+                                  strahlkorper, time, larger_l_max);
+    ylm::fill_ylm_legend_and_data(make_not_null(&compare_legend),
+                                  make_not_null(&compare_data),
+                                  ylm::Strahlkorper<Frame::Inertial>{
+                                      larger_l_max, larger_l_max, strahlkorper},
+                                  time, larger_l_max);
+    CHECK(compare_legend == legend);
+    // This is the only thing that should be different so we just check this
+    // specifically first, then overwrite it and check the rest of the vector
+    CHECK(data[4] == static_cast<double>(strahlkorper_l_max));
+    CHECK(compare_data[4] == static_cast<double>(larger_l_max));
+    data[4] = static_cast<double>(larger_l_max);
+    CHECK(compare_data == data);
+  }
+}
+}  // namespace
+
+SPECTRE_TEST_CASE(
+    "Unit.NumericalAlgorithms.SphericalHarmonics.IO.FillYlmLegendAndData",
+    "[Domain][Unit]") {
+  MAKE_GENERATOR(generator);
+  test(make_not_null(&generator));
+}

--- a/tests/Unit/NumericalAlgorithms/SphericalHarmonics/IO/Test_ReadSurfaceYlm.cpp
+++ b/tests/Unit/NumericalAlgorithms/SphericalHarmonics/IO/Test_ReadSurfaceYlm.cpp
@@ -17,6 +17,7 @@
 #include "IO/H5/AccessType.hpp"
 #include "IO/H5/Dat.hpp"
 #include "IO/H5/File.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/IO/FillYlmLegendAndData.hpp"
 #include "NumericalAlgorithms/SphericalHarmonics/IO/ReadSurfaceYlm.hpp"
 #include "NumericalAlgorithms/SphericalHarmonics/Strahlkorper.hpp"
 #include "ParallelAlgorithms/Interpolation/Callbacks/ObserveSurfaceData.hpp"
@@ -64,7 +65,7 @@ void write_test_strahlkorpers(
   std::vector<std::vector<double>> data(NumTimes);
   for (size_t i = 0; i < NumTimes; i++) {
     legend.resize(0);  // clear and reuse for next row of data
-    intrp::callbacks::detail::fill_ylm_legend_and_data(
+    ylm::fill_ylm_legend_and_data(
         make_not_null(&legend), make_not_null(&(data[i])),
         gsl::at(strahlkorpers, i), gsl::at(times, i), max_l);
   }

--- a/tests/Unit/ParallelAlgorithms/Interpolation/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/CMakeLists.txt
@@ -56,5 +56,6 @@ target_link_libraries(
   RelativisticEulerSolutions
   Spectral
   SphericalHarmonics
+  SphericalHarmonicsIO
   Utilities
   )

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_ObserveTimeSeriesAndSurfaceData.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_ObserveTimeSeriesAndSurfaceData.cpp
@@ -45,6 +45,7 @@
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "NumericalAlgorithms/Spectral/Quadrature.hpp"
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/IO/FillYlmLegendAndData.hpp"
 #include "NumericalAlgorithms/SphericalHarmonics/Spherepack.hpp"
 #include "NumericalAlgorithms/SphericalHarmonics/SpherepackIterator.hpp"
 #include "NumericalAlgorithms/SphericalHarmonics/Strahlkorper.hpp"
@@ -258,9 +259,9 @@ void check_ylm_data_with_greater_max_l() {
   std::vector<std::string> ylm_written_legend;
   std::vector<double> ylm_written_data;
 
-  intrp::callbacks::detail::fill_ylm_legend_and_data(
-      make_not_null(&ylm_written_legend), make_not_null(&ylm_written_data),
-      strahlkorper, time, max_l);
+  ylm::fill_ylm_legend_and_data(make_not_null(&ylm_written_legend),
+                                make_not_null(&ylm_written_data), strahlkorper,
+                                time, max_l);
 
   CHECK(ylm_written_legend.size() == expected_num_columns);
   CHECK(ylm_written_data.size() == expected_num_columns);


### PR DESCRIPTION
## Proposed changes

This is the first of 3 PRs to allow reading horizon coefficients from a file into the shape map coefficients in a domain creator. This PR just factors out a function into a more accessible part of the code and adds the ability to read Ylm coefs at a specific time from a file.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
