### PR TITLE
Factor out Shape options from BCO and Sphere domain

### DIFF
--- a/src/Domain/Creators/CMakeLists.txt
+++ b/src/Domain/Creators/CMakeLists.txt
@@ -24,6 +24,7 @@ spectre_target_sources(
   RotatedBricks.cpp
   RotatedIntervals.cpp
   RotatedRectangles.cpp
+  ShapeMapOptions.cpp
   Sphere.cpp
   SphereTimeDependentMaps.cpp
   )
@@ -55,6 +56,7 @@ spectre_target_headers(
   RotatedBricks.hpp
   RotatedIntervals.hpp
   RotatedRectangles.hpp
+  ShapeMapOptions.hpp
   Sphere.hpp
   SphereTimeDependentMaps.hpp
   )

--- a/src/Domain/Creators/ShapeMapOptions.cpp
+++ b/src/Domain/Creators/ShapeMapOptions.cpp
@@ -1,0 +1,84 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Domain/Creators/ShapeMapOptions.hpp"
+
+#include <array>
+#include <string>
+#include <utility>
+#include <variant>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/Structure/ObjectLabel.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/Spherepack.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrHorizon.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/StdArrayHelpers.hpp"
+
+namespace domain::creators::time_dependent_options {
+template <bool IncludeTransitionEndsAtCube, domain::ObjectLabel Object>
+std::pair<std::array<DataVector, 3>, std::array<DataVector, 4>>
+initial_shape_and_size_funcs(
+    const ShapeMapOptions<IncludeTransitionEndsAtCube, Object>& shape_options,
+    const double inner_radius) {
+  const DataVector shape_zeros{
+      ylm::Spherepack::spectral_size(shape_options.l_max, shape_options.l_max),
+      0.0};
+
+  std::array<DataVector, 3> shape_funcs =
+      make_array<3, DataVector>(shape_zeros);
+  std::array<DataVector, 4> size_funcs =
+      make_array<4, DataVector>(DataVector{1, 0.0});
+
+  if (shape_options.initial_values.has_value()) {
+    if (std::holds_alternative<KerrSchildFromBoyerLindquist>(
+            shape_options.initial_values.value())) {
+      const ylm::Spherepack ylm{shape_options.l_max, shape_options.l_max};
+      const auto& mass_and_spin = std::get<KerrSchildFromBoyerLindquist>(
+          shape_options.initial_values.value());
+      const DataVector radial_distortion =
+          inner_radius -
+          get(gr::Solutions::kerr_schild_radius_from_boyer_lindquist(
+              inner_radius, ylm.theta_phi_points(), mass_and_spin.mass,
+              mass_and_spin.spin));
+      shape_funcs[0] = ylm.phys_to_spec(radial_distortion);
+      // Transform from SPHEREPACK to actual Ylm for size func
+      size_funcs[0][0] = shape_funcs[0][0] * sqrt(0.5 * M_PI);
+      // Set l=0 for shape map to 0 because size is going to be used
+      shape_funcs[0][0] = 0.0;
+    }
+  }
+
+  // If any size options were specified, those override the values from the
+  // shape coefs
+  if (shape_options.initial_size_values.has_value()) {
+    for (size_t i = 0; i < 3; i++) {
+      gsl::at(size_funcs, i)[0] =
+          gsl::at(shape_options.initial_size_values.value(), i);
+    }
+  }
+
+  return std::make_pair(std::move(shape_funcs), std::move(size_funcs));
+}
+
+#define INCLUDETRANSITION(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define OBJECT(data) BOOST_PP_TUPLE_ELEM(1, data)
+
+#define INSTANTIATE(_, data)                                               \
+  template class ShapeMapOptions<INCLUDETRANSITION(data), OBJECT(data)>;   \
+  template std::pair<std::array<DataVector, 3>, std::array<DataVector, 4>> \
+  initial_shape_and_size_funcs<INCLUDETRANSITION(data), OBJECT(data)>(     \
+      const ShapeMapOptions<INCLUDETRANSITION(data), OBJECT(data)>&        \
+          shape_options,                                                   \
+      double inner_radius);
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (true, false),
+                        (domain::ObjectLabel::A, domain::ObjectLabel::B,
+                         domain::ObjectLabel::None))
+
+#undef INCLUDETRANSITION
+#undef OBJECT
+#undef INSTANTIATE
+
+}  // namespace domain::creators::time_dependent_options

--- a/src/Domain/Creators/ShapeMapOptions.hpp
+++ b/src/Domain/Creators/ShapeMapOptions.hpp
@@ -1,0 +1,122 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <limits>
+#include <optional>
+#include <string>
+#include <variant>
+
+#include "DataStructures/DataVector.hpp"
+#include "Domain/Structure/ObjectLabel.hpp"
+#include "Options/Auto.hpp"
+#include "Options/String.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace domain::creators::time_dependent_options {
+/*!
+ * \brief Mass and spin necessary for calculating the \f$ Y_{lm} \f$
+ * coefficients of a Kerr horizon of certain Boyer-Lindquist radius for the
+ * shape map of the Sphere domain creator.
+ */
+struct KerrSchildFromBoyerLindquist {
+  /// \brief The mass of the Kerr black hole.
+  struct Mass {
+    using type = double;
+    static constexpr Options::String help = {"The mass of the Kerr BH."};
+  };
+  /// \brief The dimensionless spin of the Kerr black hole.
+  struct Spin {
+    using type = std::array<double, 3>;
+    static constexpr Options::String help = {
+        "The dim'less spin of the Kerr BH."};
+  };
+
+  using options = tmpl::list<Mass, Spin>;
+
+  static constexpr Options::String help = {
+      "Conform to an ellipsoid of constant Boyer-Lindquist radius in "
+      "Kerr-Schild coordinates. This Boyer-Lindquist radius is chosen as the "
+      "value of the 'InnerRadius'. To conform to the outer Kerr horizon, "
+      "choose an 'InnerRadius' of r_+ = M + sqrt(M^2-a^2)."};
+
+  double mass{std::numeric_limits<double>::signaling_NaN()};
+  std::array<double, 3> spin{std::numeric_limits<double>::signaling_NaN(),
+                             std::numeric_limits<double>::signaling_NaN(),
+                             std::numeric_limits<double>::signaling_NaN()};
+};
+
+/// Label for shape map options
+struct Spherical {};
+
+/*!
+ * \brief Class to be used as an option for initializing shape map coefficients.
+ *
+ * \tparam IncludeTransitionEndsAtCube This is mainly added for the
+ * `domain::creators::BinaryCompactObject` domain.
+ * \tparam Object Which object that this shape map represents. Use
+ * `domain::ObjectLabel::None` if there is only a single object in your
+ * simulation.
+ */
+template <bool IncludeTransitionEndsAtCube, domain::ObjectLabel Object>
+struct ShapeMapOptions {
+  using type = Options::Auto<ShapeMapOptions, Options::AutoLabel::None>;
+  static std::string name() { return "ShapeMap" + get_output(Object); }
+  static constexpr Options::String help = {
+      "Options for a time-dependent distortion (shape) map about the "
+      "specified object. Specify 'None' to not use this map."};
+
+  struct LMax {
+    using type = size_t;
+    static constexpr Options::String help = {
+        "LMax used for the number of spherical harmonic coefficients of the "
+        "distortion map."};
+  };
+
+  struct InitialValues {
+    using type =
+        Options::Auto<std::variant<KerrSchildFromBoyerLindquist>, Spherical>;
+    static constexpr Options::String help = {
+        "Initial Ylm coefficients for the shape map. Specify 'Spherical' for "
+        "all coefficients to be initialized to zero."};
+  };
+
+  struct SizeInitialValues {
+    using type = Options::Auto<std::array<double, 3>>;
+    static constexpr Options::String help = {
+        "Initial value and two derivatives of the 00 coefficient. Specify "
+        "'Auto' to use the 00 coefficient specified in the 'InitialValues' "
+        "option."};
+  };
+
+  struct TransitionEndsAtCube {
+    using type = bool;
+    static constexpr Options::String help = {
+        "If 'true', the shape map transition function will be 0 at the cubical "
+        "boundary around the object. If 'false' the transition function will "
+        "be 0 at the outer radius of the inner sphere around the object"};
+  };
+
+  using common_options = tmpl::list<LMax, InitialValues, SizeInitialValues>;
+
+  using options =
+      tmpl::conditional_t<IncludeTransitionEndsAtCube,
+                          tmpl::push_back<common_options, TransitionEndsAtCube>,
+                          common_options>;
+
+  size_t l_max{};
+  std::optional<std::variant<KerrSchildFromBoyerLindquist>> initial_values{};
+  std::optional<std::array<double, 3>> initial_size_values{};
+  bool transition_ends_at_cube{false};
+};
+
+template <bool IncludeTransitionEndsAtCube, domain::ObjectLabel Object>
+std::pair<std::array<DataVector, 3>, std::array<DataVector, 4>>
+initial_shape_and_size_funcs(
+    const ShapeMapOptions<IncludeTransitionEndsAtCube, Object>& shape_options,
+    double inner_radius);
+}  // namespace domain::creators::time_dependent_options

--- a/src/Domain/Creators/Sphere.cpp
+++ b/src/Domain/Creators/Sphere.cpp
@@ -390,9 +390,11 @@ Domain<3> Sphere::create_domain() const {
       // First shell gets the distorted maps.
       // Last shell gets the transition region for the rotation, expansion and
       // translation maps
+      const bool include_distorted_frame =
+          hard_coded_options.using_distorted_frame();
       for (size_t block_id = 0; block_id < num_blocks_; block_id++) {
         const bool include_distorted_map_in_first_shell =
-            block_id < num_blocks_per_shell_;
+            include_distorted_frame and block_id < num_blocks_per_shell_;
         // False if block_id is in the last shell
         const bool use_rigid =
             block_id + num_blocks_per_shell_ + (fill_interior_ ? 1 : 0) <

--- a/tests/Unit/Domain/Creators/CMakeLists.txt
+++ b/tests/Unit/Domain/Creators/CMakeLists.txt
@@ -23,6 +23,7 @@ set(LIBRARY_SOURCES
   Test_RotatedBricks.cpp
   Test_RotatedIntervals.cpp
   Test_RotatedRectangles.cpp
+  Test_ShapeMapOptions.cpp
   Test_Sphere.cpp
   Test_SphereTimeDependentMaps.cpp
   )

--- a/tests/Unit/Domain/Creators/Test_BinaryCompactObject.cpp
+++ b/tests/Unit/Domain/Creators/Test_BinaryCompactObject.cpp
@@ -27,6 +27,7 @@
 #include "Domain/Creators/BinaryCompactObject.hpp"
 #include "Domain/Creators/DomainCreator.hpp"
 #include "Domain/Creators/OptionTags.hpp"
+#include "Domain/Creators/ShapeMapOptions.hpp"
 #include "Domain/Domain.hpp"
 #include "Domain/FunctionsOfTime/FixedSpeedCubic.hpp"
 #include "Domain/FunctionsOfTime/PiecewisePolynomial.hpp"
@@ -790,13 +791,13 @@ void test_kerr_horizon_conforming() {
           std::nullopt,
           std::nullopt,
           {{32_st,
-            domain::creators::sphere::KerrSchildFromBoyerLindquist{mass_A,
-                                                                   spin_A},
-            {{0., 0., 0.}}}},
+            domain::creators::time_dependent_options::
+                KerrSchildFromBoyerLindquist{mass_A, spin_A},
+            std::nullopt}},
           {{32_st,
-            domain::creators::sphere::KerrSchildFromBoyerLindquist{mass_B,
-                                                                   spin_B},
-            {{0., 0., 0.}}}}}};
+            domain::creators::time_dependent_options::
+                KerrSchildFromBoyerLindquist{mass_B, spin_B},
+            std::nullopt}}}};
   const auto domain = domain_creator.create_domain();
   const auto functions_of_time = domain_creator.functions_of_time();
   // Set up coordinates on an ellipsoid of constant Boyer-Lindquist radius

--- a/tests/Unit/Domain/Creators/Test_CylindricalBinaryCompactObject.cpp
+++ b/tests/Unit/Domain/Creators/Test_CylindricalBinaryCompactObject.cpp
@@ -404,13 +404,13 @@ TimeDepOptions construct_time_dependent_options() {
       TimeDepOptions::ShapeMapOptions<domain::ObjectLabel::A>{
           8_st,
           std::nullopt,
-          {initial_size_A_coefs[0][0], initial_size_A_coefs[1][0],
-           initial_size_A_coefs[1][0]}},
+          {{initial_size_A_coefs[0][0], initial_size_A_coefs[1][0],
+            initial_size_A_coefs[1][0]}}},
       TimeDepOptions::ShapeMapOptions<domain::ObjectLabel::B>{
           8_st,
           std::nullopt,
-          {initial_size_B_coefs[0][0], initial_size_B_coefs[1][0],
-           initial_size_B_coefs[1][0]}}};
+          {{initial_size_B_coefs[0][0], initial_size_B_coefs[1][0],
+            initial_size_B_coefs[1][0]}}}};
 }
 
 void test_parse_errors() {

--- a/tests/Unit/Domain/Creators/Test_ShapeMapOptions.cpp
+++ b/tests/Unit/Domain/Creators/Test_ShapeMapOptions.cpp
@@ -1,0 +1,123 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <string>
+
+#include "Domain/Creators/ShapeMapOptions.hpp"
+#include "Domain/Structure/ObjectLabel.hpp"
+#include "Framework/TestCreation.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/Spherepack.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace {
+void test_kerr_schild_boyer_lindquist() {
+  const auto kerr_schild_boyer_lindquist = TestHelpers::test_creation<
+      domain::creators::time_dependent_options::KerrSchildFromBoyerLindquist>(
+      "Mass: 1.7\n"
+      "Spin: [0.45, 0.12, 0.34]");
+  CHECK(kerr_schild_boyer_lindquist.mass == 1.7);
+  CHECK(kerr_schild_boyer_lindquist.spin == std::array{0.45, 0.12, 0.34});
+}
+
+void test_shape_map_options() {
+  {
+    constexpr bool include_transition_ends_at_cube = false;
+    constexpr domain::ObjectLabel object_label = domain::ObjectLabel::A;
+    CAPTURE(include_transition_ends_at_cube);
+    CAPTURE(object_label);
+    const auto shape_map_options = TestHelpers::test_creation<
+        domain::creators::time_dependent_options::ShapeMapOptions<
+            include_transition_ends_at_cube, object_label>>(
+        "LMax: 8\n"
+        "InitialValues: Spherical\n"
+        "SizeInitialValues: [0.5, 1.0, 2.4]");
+    CHECK(shape_map_options.name() == "ShapeMapA");
+    CHECK(shape_map_options.l_max == 8);
+    CHECK_FALSE(shape_map_options.initial_values.has_value());
+    CHECK(shape_map_options.initial_size_values.has_value());
+    CHECK(shape_map_options.initial_size_values.value() ==
+          std::array{0.5, 1.0, 2.4});
+    CHECK_FALSE(shape_map_options.transition_ends_at_cube);
+  }
+  {
+    constexpr bool include_transition_ends_at_cube = true;
+    constexpr domain::ObjectLabel object_label = domain::ObjectLabel::B;
+    CAPTURE(include_transition_ends_at_cube);
+    CAPTURE(object_label);
+    const auto shape_map_options = TestHelpers::test_creation<
+        domain::creators::time_dependent_options::ShapeMapOptions<
+            include_transition_ends_at_cube, object_label>>(
+        "LMax: 8\n"
+        "InitialValues:\n"
+        "  Mass: 1.7\n"
+        "  Spin: [0.45, 0.12, 0.34]\n"
+        "SizeInitialValues: Auto\n"
+        "TransitionEndsAtCube: True");
+    CHECK(shape_map_options.name() == "ShapeMapB");
+    CHECK(shape_map_options.l_max == 8);
+    CHECK(shape_map_options.initial_values.has_value());
+    CHECK(std::holds_alternative<domain::creators::time_dependent_options::
+                                     KerrSchildFromBoyerLindquist>(
+        shape_map_options.initial_values.value()));
+    CHECK_FALSE(shape_map_options.initial_size_values.has_value());
+    CHECK(shape_map_options.transition_ends_at_cube);
+  }
+}
+
+void test_funcs() {
+  const double inner_radius = 0.5;
+  const size_t l_max = 8;
+  // We choose a Schwarzschild BH so all coefs are zero and it's easy to check
+  {
+    const auto shape_map_options = TestHelpers::test_creation<
+        domain::creators::time_dependent_options::ShapeMapOptions<
+            false, domain::ObjectLabel::None>>(
+        "LMax: 8\n"
+        "InitialValues:\n"
+        "  Mass: 1.0\n"
+        "  Spin: [0.0, 0.0, 0.0]\n"
+        "SizeInitialValues: [0.5, 1.0, 2.4]");
+
+    const auto [shape_funcs, size_funcs] =
+        domain::creators::time_dependent_options::initial_shape_and_size_funcs(
+            shape_map_options, inner_radius);
+
+    for (size_t i = 0; i < shape_funcs.size(); i++) {
+      CHECK(gsl::at(shape_funcs, i) ==
+            DataVector{ylm::Spherepack::spectral_size(l_max, l_max), 0.0});
+    }
+    CHECK(size_funcs == std::array{DataVector{0.5}, DataVector{1.0},
+                                   DataVector{2.4}, DataVector{0.0}});
+  }
+  {
+    const auto shape_map_options = TestHelpers::test_creation<
+        domain::creators::time_dependent_options::ShapeMapOptions<
+            false, domain::ObjectLabel::None>>(
+        "LMax: 8\n"
+        "InitialValues:\n"
+        "  Mass: 1.0\n"
+        "  Spin: [0.0, 0.0, 0.0]\n"
+        "SizeInitialValues: Auto");
+
+    const auto [shape_funcs, size_funcs] =
+        domain::creators::time_dependent_options::initial_shape_and_size_funcs(
+            shape_map_options, inner_radius);
+
+    for (size_t i = 0; i < shape_funcs.size(); i++) {
+      CHECK(gsl::at(shape_funcs, i) ==
+            DataVector{ylm::Spherepack::spectral_size(l_max, l_max), 0.0});
+    }
+    CHECK(size_funcs == std::array{DataVector{0.0}, DataVector{0.0},
+                                   DataVector{0.0}, DataVector{0.0}});
+  }
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Domain.Creators.ShapeMapOptions", "[Domain][Unit]") {
+  test_kerr_schild_boyer_lindquist();
+  test_shape_map_options();
+  test_funcs();
+}

--- a/tests/Unit/Domain/Creators/Test_Sphere.cpp
+++ b/tests/Unit/Domain/Creators/Test_Sphere.cpp
@@ -33,6 +33,7 @@
 #include "Domain/CoordinateMaps/Wedge.hpp"
 #include "Domain/Creators/DomainCreator.hpp"
 #include "Domain/Creators/OptionTags.hpp"
+#include "Domain/Creators/ShapeMapOptions.hpp"
 #include "Domain/Creators/Sphere.hpp"
 #include "Domain/Creators/TimeDependence/None.hpp"
 #include "Domain/Creators/TimeDependence/RegisterDerivedWithCharm.hpp"
@@ -142,6 +143,7 @@ std::string option_string(
                               "    ShapeMap:\n"
                               "      LMax: 10\n"
                               "      InitialValues: Spherical\n"
+                              "      SizeInitialValues: Auto\n"
                               "    RotationMap: None\n"
                               "    ExpansionMap: None\n"
                               "    TranslationMap:\n"
@@ -762,8 +764,8 @@ void test_kerr_horizon_conforming(const bool use_time_dependence) {
   } else {
     time_dependent_options = domain::creators::sphere::TimeDependentMapOptions{
         0.,
-        {32_st,
-         domain::creators::sphere::KerrSchildFromBoyerLindquist{mass, spin}},
+        {{32_st, domain::creators::time_dependent_options::
+                     KerrSchildFromBoyerLindquist{mass, spin}}},
         std::nullopt,
         std::nullopt,
         std::nullopt};

--- a/tests/Unit/Domain/Test_Domain.cpp
+++ b/tests/Unit/Domain/Test_Domain.cpp
@@ -666,9 +666,9 @@ Domain<3> create_serialized_domain() {
           {{1.0, -4.6148457646200002e-05}}, -1.0e-6, 50.},
       TimeDepOps::RotationMapOptions{{0.0, 0.0, 1.5264577062000000e-02}},
       TimeDepOps::ShapeMapOptions<domain::ObjectLabel::A>{
-          8, std::nullopt, {0., 0., 0.}},
+          8, std::nullopt, {{0., 0., 0.}}},
       TimeDepOps::ShapeMapOptions<domain::ObjectLabel::B>{
-          8, std::nullopt, {0., 0., 0.}}};
+          8, std::nullopt, {{0., 0., 0.}}}};
 
   const std::optional<std::array<double, 2>> inner_outer_radii_A =
       std::array{object_A.inner_radius, object_A.outer_radius};


### PR DESCRIPTION
## Proposed changes

This is the second of 3 PRs to allow reading horizon coefficients from a file into the shape map coefficients in a domain creator. This PR factors out the shape map options from the BCO and Sphere domains into a common place since they are shared. In doing so, this also adds the capability of specifying if you want a shape map at runtime in the Sphere domain.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
When using the hardcoded time dependent maps in the Sphere domain, you must now also specify `SizeInitialValues:` in the shape map options:
```yaml
ShapeMap:
  LMax: 10
  InitialValues: Spherical
  SizeInitialValues: Auto  # <-- This is new
```
These are either `Auto` or an array of length 3 for the value and it's two time derivatives
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

~Depends on and includes #5921.~

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
