### PR TITLE
Add ability to read horizon coefs from file into shape map

### DIFF
--- a/src/Domain/CoordinateMaps/TimeDependent/Shape.hpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/Shape.hpp
@@ -86,6 +86,18 @@ namespace domain::CoordinateMaps::TimeDependent {
  * FunctionOfTime representation we are using, because the resulting expressions
  * are much shorter.
  *
+ * \parblock
+ *
+ * \note Also note that the FunctionOfTime coefficients $\lambda_{lm}(t)$ are
+ * stored as *negative* of the coefficients you'd retrieve from a
+ * `Strahlkorper`. This is because you would typically represent the expansion
+ * of a strahlkorper as $S(r) = +\sum S_{lm} Y_{lm}$. However, in equation
+ * $\ref{eq:map_form_2}$ there is a minus sign on the $\sum \lambda_{lm}
+ * Y_{lm}$, not a plus sign. Therefore, $\lambda_{lm}(t)$ picks up an extra
+ * factor of $-1$. This is purely a choice of convention.
+ *
+ * \endparblock
+ *
  * An additional dimensionless domain-dependent transition function
  * \f$f(r, \theta, \phi)\f$ ensures that the distortion falls off correctly to
  * zero at a certain boundary (must be a block boundary). The function \f$f(r,
@@ -110,19 +122,19 @@ namespace domain::CoordinateMaps::TimeDependent {
  * The shape map maps the unmapped
  * coordinates \f$\xi^i\f$ to coordinates \f$x^i\f$:
  *
- * \f{equation}{
+ * \f{equation}{\label{eq:map_form_1}
  * x^i = \xi^i - (\xi^i - x_c^i) \frac{f(r, \theta, \phi)}{r} \sum_{lm}
  * \lambda_{lm}(t)Y_{lm}(\theta, \phi).
  * \f}
  *
  * Or written another way
  *
- * \f{equation}{\label{eq:map_center_plus_distortion}
+ * \f{equation}{\label{eq:map_form_2}
  * x^i = x_c^i + (\xi^i - x_c^i) \left(1 - \frac{f(r, \theta, \phi)}{r}
  * \sum_{lm} \lambda_{lm}(t)Y_{lm}(\theta, \phi)\right).
  * \f}
  *
- * The form in Eq. \f$\ref{eq:map_center_plus_distortion}\f$ makes two things
+ * The form in Eq. \f$\ref{eq:map_form_2}\f$ makes two things
  * clearer
  *
  * 1. This shape map is just a radial distortion about \f$x_c^i\f$

--- a/src/Domain/Creators/CMakeLists.txt
+++ b/src/Domain/Creators/CMakeLists.txt
@@ -72,6 +72,8 @@ target_link_libraries(
   DomainBoundaryConditions
   DomainTimeDependence
   GeneralRelativitySolutions
+  SphericalHarmonics
+  SphericalHarmonicsIO
   INTERFACE
   ErrorHandling
   Options

--- a/src/Domain/Creators/ShapeMapOptions.hpp
+++ b/src/Domain/Creators/ShapeMapOptions.hpp
@@ -12,7 +12,10 @@
 
 #include "DataStructures/DataVector.hpp"
 #include "Domain/Structure/ObjectLabel.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/IO/ReadSurfaceYlm.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/Strahlkorper.hpp"
 #include "Options/Auto.hpp"
+#include "Options/Context.hpp"
 #include "Options/String.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
@@ -53,6 +56,63 @@ struct KerrSchildFromBoyerLindquist {
 /// Label for shape map options
 struct Spherical {};
 
+struct YlmsFromFile {
+  struct H5Filename {
+    using type = std::string;
+    static constexpr Options::String help =
+        "Path to the data file containing the ylm coefficients and their "
+        "derivatives.";
+  };
+
+  struct SubfileNames {
+    using type = std::vector<std::string>;
+    static constexpr Options::String help =
+        "Subfile names for the different order derivatives of the ylm "
+        "coefficients. You must specify the subfile name for the ylm "
+        "coefficients themselves, and can optionally specify the subfile name "
+        "for the first and second time derivatives as well, in that order. If "
+        "you don't specify a derivative subfile, those coefficients will be "
+        "defaulted to zero.";
+    static size_t lower_bound_on_size() { return 1; }
+    static size_t upper_bound_on_size() { return 3; }
+  };
+
+  struct MatchTime {
+    using type = double;
+    static constexpr Options::String help =
+        "Time in the H5File to get the coefficients at. Will likely be the "
+        "same as the initial time";
+  };
+
+  struct MatchTimeEpsilon {
+    using type = Options::Auto<double>;
+    static constexpr Options::String help =
+        "Look for times in the H5File within this epsilon of the match time. "
+        "This is to avoid having to know the exact time to all digits. Default "
+        "is 1e-12.";
+  };
+
+  struct SetL1CoefsToZero {
+    using type = bool;
+    static constexpr Options::String help =
+        "Whether to set the L=1 coefs to zero or not. This may be desirable "
+        "because L=1 is degenerate with a translation of the BH.";
+  };
+
+  using options = tmpl::list<H5Filename, SubfileNames, MatchTime,
+                             MatchTimeEpsilon, SetL1CoefsToZero>;
+
+  static constexpr Options::String help = {
+      "Read the Y_lm coefficients of a Strahlkorper from file and use those to "
+      "initialize the coefficients of a shape map."};
+
+  std::string h5_filename{};
+  std::vector<std::string> subfile_names{};
+  double match_time{};
+  std::optional<double> match_time_epsilon{};
+  bool set_l1_coefs_to_zero{};
+};
+
 /*!
  * \brief Class to be used as an option for initializing shape map coefficients.
  *
@@ -79,7 +139,8 @@ struct ShapeMapOptions {
 
   struct InitialValues {
     using type =
-        Options::Auto<std::variant<KerrSchildFromBoyerLindquist>, Spherical>;
+        Options::Auto<std::variant<KerrSchildFromBoyerLindquist, YlmsFromFile>,
+                      Spherical>;
     static constexpr Options::String help = {
         "Initial Ylm coefficients for the shape map. Specify 'Spherical' for "
         "all coefficients to be initialized to zero."};
@@ -109,7 +170,8 @@ struct ShapeMapOptions {
                           common_options>;
 
   size_t l_max{};
-  std::optional<std::variant<KerrSchildFromBoyerLindquist>> initial_values{};
+  std::optional<std::variant<KerrSchildFromBoyerLindquist, YlmsFromFile>>
+      initial_values{};
   std::optional<std::array<double, 3>> initial_size_values{};
   bool transition_ends_at_cube{false};
 };

--- a/tests/Unit/Domain/Creators/CMakeLists.txt
+++ b/tests/Unit/Domain/Creators/CMakeLists.txt
@@ -38,4 +38,7 @@ target_link_libraries(
   DomainBoundaryConditionsHelpers
   DomainCreators
   DomainHelpers
+  H5
+  SphericalHarmonics
+  SphericalHarmonicsIO
   )

--- a/tests/Unit/Domain/Creators/Test_ShapeMapOptions.cpp
+++ b/tests/Unit/Domain/Creators/Test_ShapeMapOptions.cpp
@@ -4,12 +4,23 @@
 #include "Framework/TestingFramework.hpp"
 
 #include <array>
+#include <random>
 #include <string>
+#include <vector>
 
 #include "Domain/Creators/ShapeMapOptions.hpp"
 #include "Domain/Structure/ObjectLabel.hpp"
 #include "Framework/TestCreation.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "IO/H5/AccessType.hpp"
+#include "IO/H5/Dat.hpp"
+#include "IO/H5/File.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/IO/FillYlmLegendAndData.hpp"
 #include "NumericalAlgorithms/SphericalHarmonics/Spherepack.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/SpherepackIterator.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/Strahlkorper.hpp"
+#include "Utilities/FileSystem.hpp"
 #include "Utilities/Gsl.hpp"
 
 namespace {
@@ -20,6 +31,25 @@ void test_kerr_schild_boyer_lindquist() {
       "Spin: [0.45, 0.12, 0.34]");
   CHECK(kerr_schild_boyer_lindquist.mass == 1.7);
   CHECK(kerr_schild_boyer_lindquist.spin == std::array{0.45, 0.12, 0.34});
+}
+
+void test_ylms_from_file() {
+  const auto ylms_from_file = TestHelpers::test_creation<
+      domain::creators::time_dependent_options::YlmsFromFile>(
+      "H5Filename: TotalEclipseOfTheHeart.h5\n"
+      "SubfileNames:\n"
+      "  - Ylm_coefs\n"
+      "  - dt_Ylm_coefs\n"
+      "MatchTime: 1.7\n"
+      "MatchTimeEpsilon: 1.0e-14\n"
+      "SetL1CoefsToZero: False");
+  CHECK(ylms_from_file.h5_filename == "TotalEclipseOfTheHeart.h5");
+  CHECK(ylms_from_file.subfile_names ==
+        std::vector<std::string>{"Ylm_coefs", "dt_Ylm_coefs"});
+  CHECK(ylms_from_file.match_time == 1.7);
+  CHECK(ylms_from_file.match_time_epsilon.has_value());
+  CHECK(ylms_from_file.match_time_epsilon.value() == 1.0e-14);
+  CHECK_FALSE(ylms_from_file.set_l1_coefs_to_zero);
 }
 
 void test_shape_map_options() {
@@ -65,9 +95,36 @@ void test_shape_map_options() {
     CHECK_FALSE(shape_map_options.initial_size_values.has_value());
     CHECK(shape_map_options.transition_ends_at_cube);
   }
+  {
+    constexpr bool include_transition_ends_at_cube = false;
+    constexpr domain::ObjectLabel object_label = domain::ObjectLabel::None;
+    CAPTURE(include_transition_ends_at_cube);
+    CAPTURE(object_label);
+    const auto shape_map_options = TestHelpers::test_creation<
+        domain::creators::time_dependent_options::ShapeMapOptions<
+            include_transition_ends_at_cube, object_label>>(
+        "LMax: 8\n"
+        "InitialValues:\n"
+        "  H5Filename: TotalEclipseOfTheHeart.h5\n"
+        "  SubfileNames:\n"
+        "    - Ylm_coefs\n"
+        "  MatchTime: 1.7\n"
+        "  MatchTimeEpsilon: Auto\n"
+        "  SetL1CoefsToZero: True\n"
+        "SizeInitialValues: Auto");
+    CHECK(shape_map_options.name() == "ShapeMap");
+    CHECK(shape_map_options.l_max == 8);
+    CHECK(shape_map_options.initial_values.has_value());
+    CHECK(std::holds_alternative<
+          domain::creators::time_dependent_options::YlmsFromFile>(
+        shape_map_options.initial_values.value()));
+    CHECK_FALSE(shape_map_options.initial_size_values.has_value());
+    CHECK_FALSE(shape_map_options.transition_ends_at_cube);
+  }
 }
 
-void test_funcs() {
+template <typename Generator>
+void test_funcs(const gsl::not_null<Generator*> generator) {
   const double inner_radius = 0.5;
   const size_t l_max = 8;
   // We choose a Schwarzschild BH so all coefs are zero and it's easy to check
@@ -113,11 +170,138 @@ void test_funcs() {
     CHECK(size_funcs == std::array{DataVector{0.0}, DataVector{0.0},
                                    DataVector{0.0}, DataVector{0.0}});
   }
+  {
+    const std::string test_filename{"TotalEclipseOfTheHeart.h5"};
+    if (file_system::check_if_file_exists(test_filename)) {
+      file_system::rm(test_filename, true);
+    }
+    const std::vector<std::string> subfile_names{"Ylm_coefs", "dt_Ylm_coefs"};
+    const double time = 1.7;
+    // Purposefully larger than the LMax in the options so that the
+    // Strahlkorpers will be restricted
+    const size_t file_l_max = 10;
+    std::uniform_real_distribution<double> distribution(0.1, 2.0);
+    using Frame = ::Frame::Distorted;
+    std::array<ylm::Strahlkorper<Frame>, 3> strahlkorpers{};
+    std::vector<std::string> legend{};
+    std::vector<double> data{};
+
+    // Scoped to close h5 file
+    {
+      h5::H5File<h5::AccessType::ReadWrite> test_file(test_filename, true);
+      for (size_t i = 0; i < 3; i++) {
+        legend.clear();
+        data.clear();
+        const auto radius = make_with_random_values<DataVector>(
+            generator, distribution,
+            DataVector(ylm::Spherepack::physical_size(file_l_max, file_l_max),
+                       std::numeric_limits<double>::signaling_NaN()));
+        if (i < 2) {
+          gsl::at(strahlkorpers, i) = ylm::Strahlkorper<Frame>(
+              file_l_max, file_l_max, radius, std::array{0.0, 0.0, 0.0});
+        } else {
+          gsl::at(strahlkorpers, i) = ylm::Strahlkorper<Frame>(
+              file_l_max, inner_radius, std::array{0.0, 0.0, 0.0});
+          continue;
+        }
+
+        ylm::fill_ylm_legend_and_data(
+            make_not_null(&legend), make_not_null(&(data)),
+            gsl::at(strahlkorpers, i), time, file_l_max);
+
+        auto& file = test_file.insert<h5::Dat>("/" + subfile_names[i], legend);
+        file.append(data);
+        test_file.close_current_object();
+      }
+    }
+
+    {
+      const auto shape_map_options = TestHelpers::test_creation<
+          domain::creators::time_dependent_options::ShapeMapOptions<
+              false, domain::ObjectLabel::None>>(
+          "LMax: 8\n"
+          "InitialValues:\n"
+          "  H5Filename: TotalEclipseOfTheHeart.h5\n"
+          "  SubfileNames:\n"
+          "    - Ylm_coefs\n"
+          "    - dt_Ylm_coefs\n"
+          "  MatchTime: 1.7\n"
+          "  MatchTimeEpsilon: Auto\n"
+          "  SetL1CoefsToZero: True\n"
+          "SizeInitialValues: [1.1, 2.2, 3.3]");
+
+      const auto [shape_funcs, size_funcs] =
+          domain::creators::time_dependent_options::
+              initial_shape_and_size_funcs(shape_map_options, inner_radius);
+
+      ylm::SpherepackIterator iter{l_max, l_max};
+      ylm::SpherepackIterator file_iter{file_l_max, file_l_max};
+      for (size_t i = 0; i < shape_funcs.size(); i++) {
+        const size_t expected_size =
+            ylm::Spherepack::spectral_size(l_max, l_max);
+        // Make sure they were restricted properly
+        CHECK(gsl::at(shape_funcs, i).size() == expected_size);
+
+        // Loop pointwise so we only check the coefficients that matter
+        for (size_t l = 0; l <= l_max; l++) {
+          for (int m = -static_cast<int>(l); m <= static_cast<int>(l); m++) {
+            CAPTURE(l);
+            CAPTURE(m);
+            const double expected_value =
+                l < 2 ? 0.0
+                      : -1.0 * gsl::at(strahlkorpers, i)
+                                   .coefficients()[file_iter.set(l, m)()];
+            CHECK(gsl::at(shape_funcs, i)[iter.set(l, m)()] == expected_value);
+          }
+        }
+      }
+      CHECK(size_funcs == std::array{DataVector{1.1}, DataVector{2.2},
+                                     DataVector{3.3}, DataVector{0.0}});
+    }
+
+    // Already checked that shape funcs are correct. Here just check that size
+    // funcs were automatically set to correct values
+    {
+      const auto shape_map_options = TestHelpers::test_creation<
+          domain::creators::time_dependent_options::ShapeMapOptions<
+              false, domain::ObjectLabel::None>>(
+          "LMax: 8\n"
+          "InitialValues:\n"
+          "  H5Filename: TotalEclipseOfTheHeart.h5\n"
+          "  SubfileNames:\n"
+          "    - Ylm_coefs\n"
+          "    - dt_Ylm_coefs\n"
+          "  MatchTime: 1.7\n"
+          "  MatchTimeEpsilon: Auto\n"
+          "  SetL1CoefsToZero: True\n"
+          "SizeInitialValues: Auto");
+
+      const auto [shape_funcs, size_funcs] =
+          domain::creators::time_dependent_options::
+              initial_shape_and_size_funcs(shape_map_options, inner_radius);
+
+      for (size_t i = 0; i < shape_funcs.size(); i++) {
+        CHECK(gsl::at(shape_funcs, i)[0] == 0.0);
+      }
+      CHECK(size_funcs ==
+            std::array{DataVector{-1.0 * strahlkorpers[0].coefficients()[0] *
+                                  sqrt(0.5 * M_PI)},
+                       DataVector{-1.0 * strahlkorpers[1].coefficients()[0] *
+                                  sqrt(0.5 * M_PI)},
+                       DataVector{0.0}, DataVector{0.0}});
+    }
+
+    if (file_system::check_if_file_exists(test_filename)) {
+      file_system::rm(test_filename, true);
+    }
+  }
 }
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Domain.Creators.ShapeMapOptions", "[Domain][Unit]") {
+  MAKE_GENERATOR(generator);
   test_kerr_schild_boyer_lindquist();
+  test_ylms_from_file();
   test_shape_map_options();
-  test_funcs();
+  test_funcs(make_not_null(&generator));
 }


### PR DESCRIPTION
## Proposed changes

This is the third and final of 3 PRs to allow reading horizon coefficients from a file into the shape map coefficients in a domain creator.

Fixes #5541
Fixes #5669
Fixes #4598 

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
Specify reading in the shape coefficients from a file like so
```yaml
ShapeMap:
  LMax: 8
  SizeInitialValues: Auto
  InitialValues:
    H5Filename: NameOfFile.h5
    SubfileNames:
      - NameOfCoefSubfile
      - NameOfdtCoefSubfile
      - NameOfd2tCoefSubfile
    MatchTime: 49.8
    MatchTimeEpsilon: 1e-10 # <-- Use 'Auto' for a default of 1e-12
    SetL2CoefsToZero: True
```
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

~Depends on and includes #5921 and #5922.~

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
