### PR TITLE
Normalize subfile path in H5 lib

### DIFF
--- a/src/IO/Exporter/Exporter.cpp
+++ b/src/IO/Exporter/Exporter.cpp
@@ -151,7 +151,7 @@ template <size_t Dim>
 std::vector<std::vector<double>> interpolate_to_points(
     const std::variant<std::vector<std::string>, std::string>&
         volume_files_or_glob,
-    std::string subfile_name,
+    const std::string& subfile_name,
     const std::variant<ObservationId, ObservationStep>& observation,
     const std::vector<std::string>& tensor_components,
     const std::array<std::vector<double>, Dim>& target_points,
@@ -171,15 +171,6 @@ std::vector<std::vector<double>> interpolate_to_points(
                  volume_files_or_glob);
   if (filenames.empty()) {
     ERROR_NO_TRACE("No volume files found. Specify at least one volume file.");
-  }
-
-  // Normalize subfile name
-  if (subfile_name.size() > 4 &&
-      subfile_name.substr(subfile_name.size() - 4) == ".vol") {
-    subfile_name = subfile_name.substr(0, subfile_name.size() - 4);
-  }
-  if (subfile_name.front() != '/') {
-    subfile_name = '/' + subfile_name;
   }
 
   // Retrieve info from the first volume file
@@ -278,7 +269,7 @@ std::vector<std::vector<double>> interpolate_to_points(
   template std::vector<std::vector<double>> interpolate_to_points<DIM(data)>( \
       const std::variant<std::vector<std::string>, std::string>&              \
           volume_files_or_glob,                                               \
-      std::string subfile_name,                                               \
+      const std::string& subfile_name,                                        \
       const std::variant<ObservationId, ObservationStep>& observation,        \
       const std::vector<std::string>& tensor_components,                      \
       const std::array<std::vector<double>, DIM(data)>& target_points,        \

--- a/src/IO/Exporter/Exporter.hpp
+++ b/src/IO/Exporter/Exporter.hpp
@@ -58,7 +58,7 @@ template <size_t Dim>
 std::vector<std::vector<double>> interpolate_to_points(
     const std::variant<std::vector<std::string>, std::string>&
         volume_files_or_glob,
-    std::string subfile_name,
+    const std::string& subfile_name,
     const std::variant<ObservationId, ObservationStep>& observation,
     const std::vector<std::string>& tensor_components,
     const std::array<std::vector<double>, Dim>& target_points,

--- a/src/IO/H5/File.hpp
+++ b/src/IO/H5/File.hpp
@@ -209,7 +209,7 @@ class H5File {
 
   template <typename ObjectType>
   std::tuple<bool, detail::OpenGroup, std::string> check_if_object_exists(
-      const std::string& path) const;
+      std::string path) const;
 
   std::string file_name_;
   // NOLINTNEXTLINE(spectre-mutable)
@@ -392,7 +392,16 @@ const ObjectType& H5File<Access_t>::convert_to_derived(
 template <AccessType Access_t>
 template <typename ObjectType>
 std::tuple<bool, detail::OpenGroup, std::string>
-H5File<Access_t>::check_if_object_exists(const std::string& path) const {
+H5File<Access_t>::check_if_object_exists(std::string path) const {
+  // Normalize path to have a leading slash and the correct extension
+  if (path.front() != '/') {
+    path = '/' + path;
+  }
+  const size_t extension_length = ObjectType::extension().size();
+  if (path.size() > extension_length and
+      path.substr(path.size() - extension_length) == ObjectType::extension()) {
+    path = path.substr(0, path.size() - extension_length);
+  }
   std::string name_only = "/";
   if (path != "/") {
     name_only = file_system::get_file_name(path);

--- a/src/IO/H5/Python/CombineH5.py
+++ b/src/IO/H5/Python/CombineH5.py
@@ -78,11 +78,6 @@ def combine_h5_vol_command(h5files, subfile_name, output, check_src):
         rich.print(rich.columns.Columns(spectre_file.all_vol_files()))
         return
 
-    if not subfile_name.startswith("/"):
-        subfile_name = "/" + subfile_name
-    if subfile_name.endswith(".vol"):
-        subfile_name = subfile_name[:-4]
-
     if not output.endswith(".h5"):
         output += ".h5"
 

--- a/src/IO/H5/Python/ExtendConnectivityData.py
+++ b/src/IO/H5/Python/ExtendConnectivityData.py
@@ -40,11 +40,6 @@ def extend_connectivity_data_command(filename, subfile_name):
     files, the combine-h5 executable must be run first. The extend-connectivity
     command can then be run on the newly generated HDF5 file.
     """
-    # Ensure that the format of the subfile is correct
-    if subfile_name.endswith(".vol"):
-        subfile_name = subfile_name[:-4]
-    if subfile_name[0] != "/":
-        subfile_name = "/" + subfile_name
     # Read the h5 file and extract the volume file from it
     h5_file = spectre_h5.H5File(filename, "r+")
     vol_file = h5_file.get_vol(subfile_name)

--- a/src/Visualization/Python/OpenVolfiles.py
+++ b/src/Visualization/Python/OpenVolfiles.py
@@ -168,12 +168,6 @@ def open_volfiles_command(obs_id_required=False, multiple_vars=False):
                     rich.print(rich.columns.Columns(available_subfiles))
                     return
 
-            # Normalize subfile name
-            if subfile_name.endswith(".vol"):
-                subfile_name = subfile_name[:-4]
-            if not subfile_name.startswith("/"):
-                subfile_name = "/" + subfile_name
-
             # Print available observations/times and exit
             if list_times:
                 import rich.columns

--- a/src/Visualization/Python/Render1D.py
+++ b/src/Visualization/Python/Render1D.py
@@ -310,11 +310,6 @@ def render_1d_command(
         rich.print(rich.columns.Columns(open_h5_files[0].all_vol_files()))
         return
 
-    if subfile_name.endswith(".vol"):
-        subfile_name = subfile_name[:-4]
-    if not subfile_name.startswith("/"):
-        subfile_name = "/" + subfile_name
-
     volfiles = [h5file.get_vol(subfile_name) for h5file in open_h5_files]
     dim = volfiles[0].get_dimension()
     assert (

--- a/src/Visualization/Python/TransformVolumeData.py
+++ b/src/Visualization/Python/TransformVolumeData.py
@@ -800,11 +800,6 @@ def transform_volume_data_command(
             rich.print(rich.columns.Columns())
             return
 
-    if subfile_name.endswith(".vol"):
-        subfile_name = subfile_name[:-4]
-    if not subfile_name.startswith("/"):
-        subfile_name = "/" + subfile_name
-
     volfiles = [h5file.get_vol(subfile_name) for h5file in open_h5_files]
 
     # Load kernels

--- a/tests/Unit/IO/H5/Test_Dat.cpp
+++ b/tests/Unit/IO/H5/Test_Dat.cpp
@@ -321,7 +321,9 @@ void test_dat_read() {
     error_file.append(std::vector<double>{0.33, 0.66, 0.77, 0.90});
   }
   h5::H5File<h5::AccessType::ReadOnly> my_file(h5_file_name);
-  const auto& error_file = my_file.get<h5::Dat>("/L2_errors");
+  // No leading slash should also find the subfile, and a ".dat" extension as
+  // well
+  const auto& error_file = my_file.get<h5::Dat>("L2_errors.dat");
   CHECK(error_file.subfile_path() == "/L2_errors");
 
   // Check version info is correctly retrieved from Dat file

--- a/tests/Unit/IO/H5/Test_VolumeData.cpp
+++ b/tests/Unit/IO/H5/Test_VolumeData.cpp
@@ -264,9 +264,10 @@ void test() {
     my_file.close_current_object();
   }
   // Open the read volume file and check that the observation id and values are
-  // correct.
+  // correct. No leading slash should also find the subfile, and a ".vol"
+  // extension as well.
   const auto& volume_file =
-      my_file.get<h5::VolumeData>("/element_data", version_number);
+      my_file.get<h5::VolumeData>("element_data.vol", version_number);
   CHECK(volume_file.subfile_path() == "/element_data");
   const auto read_observation_ids = volume_file.list_observation_ids();
   // The observation IDs should be sorted by their observation value


### PR DESCRIPTION
This has bothered me for a long time. A leading slash and _no_ extension for subfile names was required before, and failing to do this lead to rather useless error messages. Now, the leading slash and the extension are handled within the H5 lib, so it should be much easier to use.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
