### PR TITLE
BBH ID: compute initial orbital params from PN

### DIFF
--- a/cmake/SetupSpec.cmake
+++ b/cmake/SetupSpec.cmake
@@ -3,9 +3,15 @@
 
 find_package(SpEC)
 
-if (SpEC_FOUND)
-  file(APPEND
-    "${CMAKE_BINARY_DIR}/BuildInfo.txt"
-    "SpEC exporter: ${SPEC_EXPORTER_ROOT}\n"
-    )
+if (NOT SpEC_FOUND)
+  return()
 endif()
+
+# Make SpEC scripts available in Python. These can be used until we have ported
+# them to SpECTRE.
+set(PYTHONPATH "${SPEC_ROOT}/Support/Python:${PYTHONPATH}")
+
+file(APPEND
+  "${CMAKE_BINARY_DIR}/BuildInfo.txt"
+  "SpEC exporter: ${SPEC_EXPORTER_ROOT}\n"
+  )

--- a/support/Pipelines/EccentricityControl/CMakeLists.txt
+++ b/support/Pipelines/EccentricityControl/CMakeLists.txt
@@ -1,0 +1,10 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+spectre_python_add_module(
+  EccentricityControl
+  MODULE_PATH Pipelines
+  PYTHON_FILES
+  __init__.py
+  InitialOrbitalParameters.py
+)

--- a/support/Pipelines/EccentricityControl/InitialOrbitalParameters.py
+++ b/support/Pipelines/EccentricityControl/InitialOrbitalParameters.py
@@ -1,0 +1,194 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import logging
+from typing import Optional, Sequence, Tuple
+
+import numpy as np
+from scipy.optimize import minimize
+
+logger = logging.getLogger(__name__)
+
+
+def initial_orbital_parameters(
+    mass_ratio: float,
+    dimensionless_spin_a: Sequence[float],
+    dimensionless_spin_b: Sequence[float],
+    eccentricity: Optional[float] = None,
+    mean_anomaly_fraction: Optional[float] = None,
+    separation: Optional[float] = None,
+    orbital_angular_velocity: Optional[float] = None,
+    radial_expansion_velocity: Optional[float] = None,
+    num_orbits: Optional[float] = None,
+    time_to_merger: Optional[float] = None,
+) -> Tuple[float, float, float]:
+    """Estimate initial orbital parameters from a Post-Newtonian approximation.
+
+    Given the target eccentricity and one other orbital parameter, this function
+    estimates the initial separation 'D', orbital angular velocity 'Omega_0',
+    and radial expansion velocity 'adot_0' of a binary system in general
+    relativity from a Post-Newtonian (PN) approximation.
+    The result can be used to start an eccentricity control procedure to tune
+    the initial orbital parameters further.
+
+    Currently only zero eccentricity (circular orbits) are supported, and the
+    implementation uses functions from SpEC's ZeroEccParamsFromPN.py. This
+    should be generalized.
+
+    Arguments:
+      mass_ratio: Defined as q = M_A / M_B >= 1.
+      dimensionless_spin_a: Dimensionless spin of the larger black hole, chi_A.
+      dimensionless_spin_b: Dimensionless spin of the smaller black hole, chi_B.
+      eccentricity: Eccentricity of the orbit. Specify together with _one_ of
+        the other orbital parameters. Currently only an eccentricity of 0 is
+        supported (circular orbit).
+      mean_anomaly_fraction: Mean anomaly of the orbit divided by 2 pi, so it is
+        a number between 0 and 1. The value 0 corresponds to the pericenter of
+        the orbit (closest approach), the value 0.5 corresponds to the apocenter
+        of the orbit (farthest distance), and the value 1 corresponds to the
+        pericenter again. Currently this is unused because only an eccentricity
+        of 0 is supported.
+      separation: Coordinate separation D of the black holes.
+      orbital_angular_velocity: Omega_0.
+      radial_expansion_velocity: adot_0.
+      num_orbits: Number of orbits until merger.
+      time_to_merger: Time to merger.
+
+    Returns: Tuple of the initial separation 'D_0', orbital angular velocity
+      'Omega_0', and radial expansion velocity 'adot_0'.
+    """
+    dimensionless_spin_a = np.asarray(dimensionless_spin_a)
+    dimensionless_spin_b = np.asarray(dimensionless_spin_b)
+    if eccentricity is not None and eccentricity != 0.0:
+        assert mean_anomaly_fraction is not None, (
+            "If you specify a nonzero 'eccentricity' you must also specify a"
+            " 'mean_anomaly_fraction'."
+        )
+    if eccentricity is None:
+        assert (
+            separation is not None
+            and orbital_angular_velocity is not None
+            and radial_expansion_velocity is not None
+        ), (
+            "Specify all orbital parameters 'separation',"
+            " 'orbital_angular_velocity', and 'radial_expansion_velocity', or"
+            " specify an 'eccentricity' plus one orbital parameter."
+        )
+        return separation, orbital_angular_velocity, radial_expansion_velocity
+
+    # The functions from SpEC currently work only for zero eccentricity. We will
+    # need to generalize this for eccentric orbits.
+    assert eccentricity == 0.0, (
+        "Initial orbital parameters can currently only be computed for zero"
+        " eccentricity."
+    )
+    assert radial_expansion_velocity is None, (
+        "Can't use the 'radial_expansion_velocity' to compute orbital"
+        " parameters. Remove it and choose another orbital parameter."
+    )
+    assert (
+        (separation is not None)
+        ^ (orbital_angular_velocity is not None)
+        ^ (num_orbits is not None)
+        ^ (time_to_merger is not None)
+    ), (
+        "Specify an 'eccentricity' plus _one_ of the following orbital"
+        " parameters: 'separation', 'orbital_angular_velocity', 'num_orbits',"
+        " 'time_to_merger'."
+    )
+
+    # Import functions from SpEC until we have ported them over. These functions
+    # call old Fortran code (LSODA) through scipy.integrate.odeint, which leads
+    # to lots of noise in stdout. When porting these functions, we should
+    # modernize them to use scipy.integrate.solve_ivp.
+    try:
+        from ZeroEccParamsFromPN import nOrbitsAndTotalTime, omegaAndAdot
+    except ImportError:
+        raise ImportError(
+            "Importing from SpEC failed. Make sure you have pointed "
+            "'-D SPEC_ROOT' to a SpEC installation when configuring the build "
+            "with CMake."
+        )
+
+    # Find an omega0 that gives the right number of orbits or time to merger
+    if num_orbits is not None or time_to_merger is not None:
+        opt_result = minimize(
+            lambda x: (
+                abs(
+                    nOrbitsAndTotalTime(
+                        q=mass_ratio,
+                        chiA0=dimensionless_spin_a,
+                        chiB0=dimensionless_spin_b,
+                        omega0=x[0],
+                    )[0 if num_orbits is not None else 1]
+                    - (num_orbits if num_orbits is not None else time_to_merger)
+                )
+            ),
+            x0=[0.01],
+            method="Nelder-Mead",
+        )
+        if not opt_result.success:
+            raise ValueError(
+                "Failed to find an orbital angular velocity that gives the"
+                " desired number of orbits or time to merger. Error:"
+                f" {opt_result.message}"
+            )
+        orbital_angular_velocity = opt_result.x[0]
+        logger.debug(
+            f"Found orbital angular velocity: {orbital_angular_velocity}"
+        )
+
+    # Find the separation that gives the desired orbital angular velocity
+    if orbital_angular_velocity is not None:
+        opt_result = minimize(
+            lambda x: abs(
+                omegaAndAdot(
+                    r=x[0],
+                    q=mass_ratio,
+                    chiA=dimensionless_spin_a,
+                    chiB=dimensionless_spin_b,
+                    rPrime0=1.0,  # Choice also made in SpEC
+                )[0]
+                - orbital_angular_velocity
+            ),
+            x0=[10.0],
+            method="Nelder-Mead",
+        )
+        if not opt_result.success:
+            raise ValueError(
+                "Failed to find a separation that gives the desired orbital"
+                f" angular velocity. Error: {opt_result.message}"
+            )
+        separation = opt_result.x[0]
+        logger.debug(f"Found initial separation: {separation}")
+
+    # Find the radial expansion velocity
+    new_orbital_angular_velocity, radial_expansion_velocity = omegaAndAdot(
+        r=separation,
+        q=mass_ratio,
+        chiA=dimensionless_spin_a,
+        chiB=dimensionless_spin_b,
+        rPrime0=1.0,  # Choice also made in SpEC
+    )
+    if orbital_angular_velocity is None:
+        orbital_angular_velocity = new_orbital_angular_velocity
+    else:
+        assert np.isclose(
+            new_orbital_angular_velocity, orbital_angular_velocity, rtol=1e-4
+        ), (
+            "Orbital angular velocity is inconsistent with separation."
+            " Maybe the rootfind failed to reach sufficient accuracy."
+        )
+
+    # Estimate number of orbits and time to merger
+    num_orbits, time_to_merger = nOrbitsAndTotalTime(
+        q=mass_ratio,
+        chiA0=dimensionless_spin_a,
+        chiB0=dimensionless_spin_b,
+        omega0=orbital_angular_velocity,
+    )
+    logger.info(
+        "Selected approximately circular orbit. Number of orbits:"
+        f" {num_orbits:g}. Time to merger: {time_to_merger:g} M."
+    )
+    return separation, orbital_angular_velocity, radial_expansion_velocity

--- a/support/Pipelines/EccentricityControl/__init__.py
+++ b/support/Pipelines/EccentricityControl/__init__.py
@@ -1,5 +1,2 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
-
-add_subdirectory(Bbh)
-add_subdirectory(EccentricityControl)

--- a/support/Python/Schedule.py
+++ b/support/Python/Schedule.py
@@ -382,7 +382,7 @@ def schedule(
             executable = metadata["Executable"]
         except (KeyError, TypeError) as err:
             raise ValueError(
-                "Specify an 'executable' ('--executable' / '-e') "
+                "Specify an 'executable' ('--executable' / '-E') "
                 "or list one in the input file metadata "
                 "as 'Executable:'."
             ) from err
@@ -767,7 +767,7 @@ def scheduler_options(f):
 
     @click.option(
         "--executable",
-        "-e",
+        "-E",
         show_default="executable listed in input file",
         help=(
             "The executable to run. Can be a path, or just the name of the"

--- a/tests/support/Pipelines/Bbh/Test_InitialData.py
+++ b/tests/support/Pipelines/Bbh/Test_InitialData.py
@@ -96,7 +96,7 @@ class TestInitialData(unittest.TestCase):
             "1",
             "--polynomial-order",
             "5",
-            "-e",
+            "-E",
             str(self.bin_dir / "SolveXcts"),
         ]
         # Not using `CliRunner.invoke()` because it runs in an isolated

--- a/tests/support/Pipelines/Bbh/Test_Inspiral.py
+++ b/tests/support/Pipelines/Bbh/Test_Inspiral.py
@@ -73,7 +73,7 @@ class TestInspiral(unittest.TestCase):
             "1",
             "--polynomial-order",
             "5",
-            "-e",
+            "-E",
             str(self.bin_dir / "EvolveGhBinaryBlackHole"),
         ]
         # Not using `CliRunner.invoke()` because it runs in an isolated

--- a/tests/support/Pipelines/Bbh/Test_Ringdown.py
+++ b/tests/support/Pipelines/Bbh/Test_Ringdown.py
@@ -85,7 +85,7 @@ class TestInitialData(unittest.TestCase):
                     "-O",
                     str(self.test_dir / "Ringdown"),
                     "--no-submit",
-                    "-e",
+                    "-E",
                     str(self.bin_dir / "EvolveGhSingleBlackHole"),
                 ]
             )

--- a/tests/support/Pipelines/CMakeLists.txt
+++ b/tests/support/Pipelines/CMakeLists.txt
@@ -2,3 +2,4 @@
 # See LICENSE.txt for details.
 
 add_subdirectory(Bbh)
+add_subdirectory(EccentricityControl)

--- a/tests/support/Pipelines/EccentricityControl/CMakeLists.txt
+++ b/tests/support/Pipelines/EccentricityControl/CMakeLists.txt
@@ -1,0 +1,16 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+if (SpEC_FOUND)
+  spectre_add_python_bindings_test(
+    "support.Pipelines.EccentricityControl.InitialOrbitalParameters"
+    Test_InitialOrbitalParameters.py
+    "Python"
+    None)
+
+  if (BUILD_PYTHON_BINDINGS)
+    set_tests_properties(
+      "support.Pipelines.EccentricityControl.InitialOrbitalParameters"
+      PROPERTIES TIMEOUT 60)
+  endif()
+endif()

--- a/tests/support/Pipelines/EccentricityControl/Test_InitialOrbitalParameters.py
+++ b/tests/support/Pipelines/EccentricityControl/Test_InitialOrbitalParameters.py
@@ -1,0 +1,82 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import logging
+import unittest
+
+import numpy.testing as npt
+
+from spectre.Pipelines.EccentricityControl.InitialOrbitalParameters import (
+    initial_orbital_parameters,
+)
+
+
+class TestInitialOrbitalParameters(unittest.TestCase):
+    def test_initial_orbital_parameters(self):
+        # Expected results are computed from SpEC's ZeroEccParamsFromPN.py
+        npt.assert_allclose(
+            initial_orbital_parameters(
+                mass_ratio=1.0,
+                dimensionless_spin_a=[0.0, 0.0, 0.0],
+                dimensionless_spin_b=[0.0, 0.0, 0.0],
+                separation=20.0,
+                orbital_angular_velocity=0.01,
+                radial_expansion_velocity=-1.0e-5,
+            ),
+            [20.0, 0.01, -1.0e-5],
+        )
+        npt.assert_allclose(
+            initial_orbital_parameters(
+                mass_ratio=1.0,
+                dimensionless_spin_a=[0.0, 0.0, 0.0],
+                dimensionless_spin_b=[0.0, 0.0, 0.0],
+                eccentricity=0.0,
+                separation=16.0,
+            ),
+            [16.0, 0.014474280975952748, -4.117670632867514e-05],
+        )
+        npt.assert_allclose(
+            initial_orbital_parameters(
+                mass_ratio=1.0,
+                dimensionless_spin_a=[0.0, 0.0, 0.0],
+                dimensionless_spin_b=[0.0, 0.0, 0.0],
+                eccentricity=0.0,
+                orbital_angular_velocity=0.015,
+            ),
+            [15.6060791015625, 0.015, -4.541705362753467e-05],
+        )
+        npt.assert_allclose(
+            initial_orbital_parameters(
+                mass_ratio=1.0,
+                dimensionless_spin_a=[0.0, 0.0, 0.0],
+                dimensionless_spin_b=[0.0, 0.0, 0.0],
+                eccentricity=0.0,
+                orbital_angular_velocity=0.015,
+            ),
+            [15.6060791015625, 0.015, -4.541705362753467e-05],
+        )
+        npt.assert_allclose(
+            initial_orbital_parameters(
+                mass_ratio=1.0,
+                dimensionless_spin_a=[0.0, 0.0, 0.0],
+                dimensionless_spin_b=[0.0, 0.0, 0.0],
+                eccentricity=0.0,
+                num_orbits=20,
+            ),
+            [16.0421142578125, 0.014419921875000002, -4.0753460821644916e-05],
+        )
+        npt.assert_allclose(
+            initial_orbital_parameters(
+                mass_ratio=1.0,
+                dimensionless_spin_a=[0.0, 0.0, 0.0],
+                dimensionless_spin_b=[0.0, 0.0, 0.0],
+                eccentricity=0.0,
+                time_to_merger=6000,
+            ),
+            [16.1357421875, 0.01430025219917298, -3.9831982447244026e-05],
+        )
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.DEBUG)
+    unittest.main(verbosity=2)

--- a/tests/support/Python/Test_Schedule.py
+++ b/tests/support/Python/Test_Schedule.py
@@ -297,7 +297,7 @@ NUM_NODES=1
             schedule_command,
             [
                 str(self.input_file_template),
-                "-e",
+                "-E",
                 str(self.executable),
                 "-o",
                 str(self.test_dir / "Run"),
@@ -312,7 +312,7 @@ NUM_NODES=1
             schedule_command,
             [
                 str(self.input_file_template),
-                "-e",
+                "-E",
                 str(self.executable),
                 "-O",
                 str(self.test_dir / "Segments"),

--- a/tests/tools/Test_ValidateInputFile.py
+++ b/tests/tools/Test_ValidateInputFile.py
@@ -50,13 +50,13 @@ class TestValidateInputFile(unittest.TestCase):
         runner = CliRunner()
         result = runner.invoke(
             validate_input_file_command,
-            [str(self.valid_input_file_path), "-e", str(self.executable)],
+            [str(self.valid_input_file_path), "-E", str(self.executable)],
         )
         self.assertEqual(result.exit_code, 0)
         with self.assertRaisesRegex(InvalidInputFileError, "LowerBound"):
             result = runner.invoke(
                 validate_input_file_command,
-                [str(self.invalid_input_file_path), "-e", str(self.executable)],
+                [str(self.invalid_input_file_path), "-E", str(self.executable)],
                 catch_exceptions=False,
             )
             self.assertEqual(result.exit_code, 1)

--- a/tools/ValidateInputFile.py
+++ b/tools/ValidateInputFile.py
@@ -158,7 +158,7 @@ def validate_input_file(
 )
 @click.option(
     "--executable",
-    "-e",
+    "-E",
     help=(
         "Name or path of the executable. "
         "If unspecified, the 'Executable:' in the input file "


### PR DESCRIPTION
## Proposed changes

Port parts of SpEC's ZeroEccParamsFromPN.py to set initial orbital parameters for circular orbits. Two functions from SpEC are just imported, and should be modernized later. This allows to generate near-circular ID like this:

```
spectre bbh generate-id -o ./test -q 1 --chi-A 0 0 0 --chi-B 0 0 0 --eccentricity 0 --num-orbits 20
```

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
