### PR TITLE
Remove TOV sanity check for RHS evaluation

### DIFF
--- a/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/Tov.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/Tov.cpp
@@ -105,16 +105,6 @@ void lindblom_rhs(
       d_log_conformal_factor = -0.25 * d_mass_over_radius;
     }
   } else {
-    // This statement is triggered by one of the test examples,
-    // Test_Tov.cpp: void {anonymous}::test_rueter()
-    // Test_Tov.cpp: void {anonymous}::test_baumgarte_shapiro()
-    // not sure what to do about that
-    if constexpr (CoordSystem == TovCoordinates::Schwarzschild) {
-      ASSERT(mass_over_radius < .5,
-             "Compactness of Star is greater than BH"
-             "limit in TOV solver, currently, " +
-                 std::to_string(mass_over_radius));
-    }
     const double one_minus_two_m_over_r = 1.0 - 2.0 * mass_over_radius;
     const double denominator =
         4.0 * M_PI * radius_squared * pressure + mass_over_radius;


### PR DESCRIPTION
## Proposed changes

This check is triggered in otherwise very well behaved solutions (I.e. solutions where we know the  solution from e.g. an external source, and can reproduce the right answer, and the right answer has very simple behavior).  I think this can be chalked up to the integrator potentially evaluating the RHS with too large a step size (the problem only occurs at very high densities); in this case the place the RHS is evaluated may not satisfy the sanity condition.  This shouldn't be an actual problem, as the integrator should just take a smaller step size.  

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
