### PR TITLE
Parallelize block_logical_coords with OpenMP if enabled

### DIFF
--- a/cmake/AddInputFileTests.cmake
+++ b/cmake/AddInputFileTests.cmake
@@ -27,11 +27,11 @@ else()
 endif()
 
 # Environment variables for test
-set(_TEST_ENV_VARS "")
+set(_INPUT_FILE_TEST_ENV_VARS "")
 # - Disable ASAN's leak sanitizer because Charm++ has false positives
-list(APPEND _TEST_ENV_VARS "ASAN_OPTIONS=detect_leaks=0")
+list(APPEND _INPUT_FILE_TEST_ENV_VARS "ASAN_OPTIONS=detect_leaks=0")
 # - Set PYTHONPATH to find Python modules
-list(APPEND _TEST_ENV_VARS "PYTHONPATH=${PYTHONPATH}")
+list(APPEND _INPUT_FILE_TEST_ENV_VARS "PYTHONPATH=${PYTHONPATH}")
 
 function(add_single_input_file_test INPUT_FILE EXECUTABLE COMMAND_LINE_ARGS
                                     CHECK_TYPE TIMEOUT EXPECTED_EXIT_CODE)
@@ -105,7 +105,7 @@ function(add_single_input_file_test INPUT_FILE EXECUTABLE COMMAND_LINE_ARGS
     PROPERTIES
     TIMEOUT ${TIMEOUT}
     LABELS "${TAGS}"
-    ENVIRONMENT "${_TEST_ENV_VARS}")
+    ENVIRONMENT "${_INPUT_FILE_TEST_ENV_VARS}")
 endfunction()
 
 # Searches the directory INPUT_FILE_DIR for .yaml files and adds a test for each

--- a/cmake/SpectreAddCatchTests.cmake
+++ b/cmake/SpectreAddCatchTests.cmake
@@ -42,11 +42,11 @@ add_custom_target(unit-tests)
 spectre_define_test_timeout_factor_option(UNIT "unit")
 
 # Environment variables for test
-set(_TEST_ENV_VARS "")
+set(_CATCH_TEST_ENV_VARS "")
 # - Disable ASAN's leak sanitizer because Charm++ has false positives
-list(APPEND _TEST_ENV_VARS "ASAN_OPTIONS=detect_leaks=0")
+list(APPEND _CATCH_TEST_ENV_VARS "ASAN_OPTIONS=detect_leaks=0")
 # - Set PYTHONPATH to find Python modules
-list(APPEND _TEST_ENV_VARS "PYTHONPATH=${PYTHONPATH}")
+list(APPEND _CATCH_TEST_ENV_VARS "PYTHONPATH=${PYTHONPATH}")
 
 # Main function - the only one designed to be called from outside this module.
 function(spectre_add_catch_tests TEST_TARGET)
@@ -225,7 +225,7 @@ function(spectre_parse_file SOURCE_FILE TEST_TARGET)
         TIMEOUT ${TIMEOUT}
         PASS_REGULAR_EXPRESSION "${OUTPUT_REGEX}"
         LABELS "${TAGS}"
-        ENVIRONMENT "${_TEST_ENV_VARS}")
+        ENVIRONMENT "${_CATCH_TEST_ENV_VARS}")
       set(FAILURE_TESTS "\"~${CTEST_NAME}\";${FAILURE_TESTS}")
     else ()
       set_tests_properties(
@@ -233,7 +233,7 @@ function(spectre_parse_file SOURCE_FILE TEST_TARGET)
         FAIL_REGULAR_EXPRESSION "No tests ran"
         TIMEOUT ${TIMEOUT}
         LABELS "${TAGS}"
-        ENVIRONMENT "${_TEST_ENV_VARS}")
+        ENVIRONMENT "${_CATCH_TEST_ENV_VARS}")
     endif ()
   endforeach ()
   set_property(GLOBAL PROPERTY SPECTRE_FAILURE_TESTS ${FAILURE_TESTS})

--- a/cmake/SpectreSetupPythonPackage.cmake
+++ b/cmake/SpectreSetupPythonPackage.cmake
@@ -317,11 +317,11 @@ function(SPECTRE_ADD_PYTHON_TEST TEST_NAME FILE TAGS
 
   spectre_test_timeout(TIMEOUT PYTHON 2)
 
-  set(_TEST_ENV_VARS "PYTHONPATH=${PYTHONPATH}")
+  set(_PY_TEST_ENV_VARS "PYTHONPATH=${PYTHONPATH}")
   if(BUILD_PYTHON_BINDINGS AND
       "${JEMALLOC_LIB_TYPE}" STREQUAL SHARED)
     list(APPEND
-      _TEST_ENV_VARS
+      _PY_TEST_ENV_VARS
       "LD_PRELOAD=${JEMALLOC_LIBRARIES}"
       )
   endif()
@@ -334,7 +334,7 @@ function(SPECTRE_ADD_PYTHON_TEST TEST_NAME FILE TAGS
     FAIL_REGULAR_EXPRESSION "Ran 0 test"
     TIMEOUT ${TIMEOUT}
     LABELS "${TAGS};Python"
-    ENVIRONMENT "${_TEST_ENV_VARS}"
+    ENVIRONMENT "${_PY_TEST_ENV_VARS}"
     )
   # check if this is a unit test, and if so add it to the dependencies
   foreach(LABEL ${TAGS})

--- a/src/Domain/BlockLogicalCoordinates.cpp
+++ b/src/Domain/BlockLogicalCoordinates.cpp
@@ -11,26 +11,17 @@
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Domain/Block.hpp"
 #include "Domain/Domain.hpp"  // IWYU pragma: keep
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
 #include "Domain/Structure/BlockId.hpp"
 #include "Utilities/EqualWithinRoundoff.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 
-namespace {
-// Define this alias so we don't need to keep typing this monster.
-template <size_t Dim>
-using block_logical_coord_holder =
-    std::optional<IdPair<domain::BlockId,
-                         tnsr::I<double, Dim, typename ::Frame::BlockLogical>>>;
-using functions_of_time_type = std::unordered_map<
-    std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>;
-}  // namespace
-
 template <size_t Dim, typename Frame>
 std::optional<tnsr::I<double, Dim, ::Frame::BlockLogical>>
 block_logical_coordinates_single_point(
     const tnsr::I<double, Dim, Frame>& input_point, const Block<Dim>& block,
-    const double time, const functions_of_time_type& functions_of_time) {
+    const double time, const domain::FunctionsOfTimeMap& functions_of_time) {
   std::optional<tnsr::I<double, Dim, ::Frame::BlockLogical>> logical_point{};
   if (block.is_time_dependent()) {
     if constexpr (std::is_same_v<Frame, ::Frame::Inertial>) {
@@ -143,11 +134,11 @@ block_logical_coordinates_single_point(
 }
 
 template <size_t Dim, typename Frame>
-std::vector<block_logical_coord_holder<Dim>> block_logical_coordinates(
+std::vector<BlockLogicalCoords<Dim>> block_logical_coordinates(
     const Domain<Dim>& domain, const tnsr::I<DataVector, Dim, Frame>& x,
-    const double time, const functions_of_time_type& functions_of_time) {
+    const double time, const domain::FunctionsOfTimeMap& functions_of_time) {
   const size_t num_pts = get<0>(x).size();
-  std::vector<block_logical_coord_holder<Dim>> block_coord_holders(num_pts);
+  std::vector<BlockLogicalCoords<Dim>> block_coord_holders(num_pts);
   for (size_t s = 0; s < num_pts; ++s) {
     tnsr::I<double, Dim, Frame> x_frame(0.0);
     for (size_t d = 0; d < Dim; ++d) {
@@ -183,12 +174,12 @@ std::vector<block_logical_coord_holder<Dim>> block_logical_coordinates(
   block_logical_coordinates_single_point(                                      \
       const tnsr::I<double, DIM(data), FRAME(data)>& input_point,              \
       const Block<DIM(data)>& block, const double time,                        \
-      const functions_of_time_type& functions_of_time);                        \
-  template std::vector<block_logical_coord_holder<DIM(data)>>                  \
+      const domain::FunctionsOfTimeMap& functions_of_time);                    \
+  template std::vector<BlockLogicalCoords<DIM(data)>>                          \
   block_logical_coordinates(                                                   \
       const Domain<DIM(data)>& domain,                                         \
       const tnsr::I<DataVector, DIM(data), FRAME(data)>& x, const double time, \
-      const functions_of_time_type& functions_of_time);
+      const domain::FunctionsOfTimeMap& functions_of_time);
 
 GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3),
                         (::Frame::Grid, ::Frame::Distorted, ::Frame::Inertial))

--- a/src/Domain/BlockLogicalCoordinates.hpp
+++ b/src/Domain/BlockLogicalCoordinates.hpp
@@ -23,6 +23,10 @@ template <size_t VolumeDim>
 class Block;
 /// \endcond
 
+template <size_t Dim>
+using BlockLogicalCoords = std::optional<
+    IdPair<domain::BlockId, tnsr::I<double, Dim, Frame::BlockLogical>>>;
+
 /// @{
 /// \ingroup ComputationalDomainGroup
 ///
@@ -62,22 +66,13 @@ template <size_t Dim, typename Frame>
 auto block_logical_coordinates(
     const Domain<Dim>& domain, const tnsr::I<DataVector, Dim, Frame>& x,
     double time = std::numeric_limits<double>::signaling_NaN(),
-    const std::unordered_map<
-        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
-        functions_of_time = std::unordered_map<
-            std::string,
-            std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>{})
-    -> std::vector<std::optional<
-        IdPair<domain::BlockId, tnsr::I<double, Dim, ::Frame::BlockLogical>>>>;
+    const domain::FunctionsOfTimeMap& functions_of_time = {})
+    -> std::vector<BlockLogicalCoords<Dim>>;
 
 template <size_t Dim, typename Frame>
 std::optional<tnsr::I<double, Dim, ::Frame::BlockLogical>>
 block_logical_coordinates_single_point(
     const tnsr::I<double, Dim, Frame>& input_point, const Block<Dim>& block,
     double time = std::numeric_limits<double>::signaling_NaN(),
-    const std::unordered_map<
-        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
-        functions_of_time = std::unordered_map<
-            std::string,
-            std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>{});
+    const domain::FunctionsOfTimeMap& functions_of_time = {});
 /// @}

--- a/src/Domain/ElementLogicalCoordinates.cpp
+++ b/src/Domain/ElementLogicalCoordinates.cpp
@@ -12,6 +12,7 @@
 #include "DataStructures/IdPair.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"  // IWYU pragma: keep
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Domain/BlockLogicalCoordinates.hpp"
 #include "Domain/Structure/BlockId.hpp"    // IWYU pragma: keep
 #include "Domain/Structure/ElementId.hpp"  // IWYU pragma: keep
 #include "Domain/Structure/Side.hpp"
@@ -40,12 +41,6 @@ element_logical_coordinates(
 }
 
 namespace {
-// Define this alias so we don't need to keep typing this monster.
-template <size_t Dim>
-using block_logical_coord_holder =
-    std::optional<IdPair<domain::BlockId,
-                         tnsr::I<double, Dim, typename ::Frame::BlockLogical>>>;
-
 // The segments bounds are binary fractions (i.e. the numerator is an
 // integer and the denominator is a power of 2) so these floating point
 // comparisons should be safe from roundoff problems
@@ -66,7 +61,7 @@ template <size_t Dim>
 std::unordered_map<ElementId<Dim>, ElementLogicalCoordHolder<Dim>>
 element_logical_coordinates(
     const std::vector<ElementId<Dim>>& element_ids,
-    const std::vector<block_logical_coord_holder<Dim>>& block_coord_holders) {
+    const std::vector<BlockLogicalCoords<Dim>>& block_coord_holders) {
   // Temporarily put results here in data structures that allow
   // push_back, because we don't know the sizes of the output
   // DataVectors ahead of time.
@@ -151,8 +146,7 @@ element_logical_coordinates(
                               ElementLogicalCoordHolder<DIM(data)>>           \
   element_logical_coordinates(                                                \
       const std::vector<ElementId<DIM(data)>>& element_ids,                   \
-      const std::vector<block_logical_coord_holder<DIM(data)>>&               \
-          block_coord_holders);
+      const std::vector<BlockLogicalCoords<DIM(data)>>& block_coord_holders);
 
 GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
 

--- a/src/Domain/ElementLogicalCoordinates.hpp
+++ b/src/Domain/ElementLogicalCoordinates.hpp
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Domain/BlockLogicalCoordinates.hpp"
 
 /// \cond
 namespace domain {
@@ -128,7 +129,5 @@ struct ElementLogicalCoordHolder {
 template <size_t Dim>
 auto element_logical_coordinates(
     const std::vector<ElementId<Dim>>& element_ids,
-    const std::vector<std::optional<IdPair<
-        domain::BlockId, tnsr::I<double, Dim, typename Frame::BlockLogical>>>>&
-        block_coord_holders)
+    const std::vector<BlockLogicalCoords<Dim>>& block_coord_holders)
     -> std::unordered_map<ElementId<Dim>, ElementLogicalCoordHolder<Dim>>;

--- a/src/Domain/Python/ElementLogicalCoordinates.cpp
+++ b/src/Domain/Python/ElementLogicalCoordinates.cpp
@@ -42,11 +42,8 @@ void bind_element_logical_coordinates_impl(py::module& m) {  // NOLINT
                     &ElementLogicalCoordHolder<Dim>::element_logical_coords)
       .def_readonly("offsets", &ElementLogicalCoordHolder<Dim>::offsets);
   m.def("element_logical_coordinates",
-        py::overload_cast<
-            const std::vector<ElementId<Dim>>&,
-            const std::vector<std::optional<
-                IdPair<domain::BlockId,
-                       tnsr::I<double, Dim, typename Frame::BlockLogical>>>>&>(
+        py::overload_cast<const std::vector<ElementId<Dim>>&,
+                          const std::vector<BlockLogicalCoords<Dim>>&>(
             &element_logical_coordinates<Dim>),
         py::arg("element_ids"), py::arg("block_coord_holders"));
 }

--- a/src/IO/Exporter/Exporter.cpp
+++ b/src/IO/Exporter/Exporter.cpp
@@ -39,9 +39,7 @@ void interpolate_to_points(
     const gsl::not_null<std::vector<bool>*> filled_data,
     const std::string& filename, const std::string& subfile_name,
     const size_t obs_id, const std::vector<std::string>& tensor_components,
-    const std::vector<std::optional<
-        IdPair<domain::BlockId, tnsr::I<double, Dim, Frame::BlockLogical>>>>&
-        block_logical_coords) {
+    const std::vector<BlockLogicalCoords<Dim>>& block_logical_coords) {
   std::vector<std::string> grid_names;
   std::vector<std::vector<size_t>> all_extents;
   std::vector<std::vector<Spectral::Basis>> all_bases;

--- a/src/ParallelAlgorithms/Interpolation/Actions/InterpolationTargetVarsFromElement.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Actions/InterpolationTargetVarsFromElement.hpp
@@ -9,6 +9,7 @@
 
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/Variables.hpp"
+#include "Domain/BlockLogicalCoordinates.hpp"
 #include "ParallelAlgorithms/Actions/FunctionsOfTimeAreReady.hpp"
 #include "ParallelAlgorithms/Interpolation/InterpolationTargetDetail.hpp"
 #include "ParallelAlgorithms/Interpolation/Tags.hpp"
@@ -78,9 +79,7 @@ struct InterpolationTargetVarsFromElement {
       const std::vector<Variables<
           typename InterpolationTargetTag::vars_to_interpolate_to_target>>&
           vars_src,
-      const std::vector<std::optional<
-          IdPair<domain::BlockId, tnsr::I<double, Metavariables::volume_dim,
-                                          typename ::Frame::BlockLogical>>>>&
+      const std::vector<BlockLogicalCoords<Metavariables::volume_dim>>&
           block_logical_coords,
       const std::vector<std::vector<size_t>>& global_offsets,
       const TemporalId& temporal_id,

--- a/src/ParallelAlgorithms/Interpolation/Actions/InterpolatorReceivePoints.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Actions/InterpolatorReceivePoints.hpp
@@ -10,6 +10,7 @@
 
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Domain/BlockLogicalCoordinates.hpp"
 #include "ParallelAlgorithms/Interpolation/Actions/TryToInterpolate.hpp"
 #include "ParallelAlgorithms/Interpolation/InterpolatedVars.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"
@@ -78,10 +79,7 @@ struct ReceivePoints {
       db::DataBox<DbTags>& box, Parallel::GlobalCache<Metavariables>& cache,
       const ArrayIndex& /*array_index*/,
       const typename InterpolationTargetTag::temporal_id::type& temporal_id,
-      std::vector<std::optional<
-          IdPair<domain::BlockId,
-                 tnsr::I<double, VolumeDim, typename ::Frame::BlockLogical>>>>&&
-          block_logical_coords,
+      std::vector<BlockLogicalCoords<VolumeDim>>&& block_logical_coords,
       const size_t iteration = 0_st) {
     db::mutate<intrp::Tags::InterpolatedVarsHolders<Metavariables>>(
         [&temporal_id, &block_logical_coords, &iteration](

--- a/src/ParallelAlgorithms/Interpolation/Events/InterpolateWithoutInterpComponent.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Events/InterpolateWithoutInterpComponent.hpp
@@ -14,8 +14,8 @@
 
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataVector.hpp"
-#include "DataStructures/IdPair.hpp"
 #include "DataStructures/Index.hpp"
+#include "Domain/BlockLogicalCoordinates.hpp"
 #include "Domain/Creators/Tags/Domain.hpp"
 #include "Domain/Domain.hpp"
 #include "Domain/ElementLogicalCoordinates.hpp"
@@ -137,9 +137,7 @@ class InterpolateWithoutInterpComponent<VolumeDim, InterpolationTargetTag,
       const ObservationValue& /*observation_value*/) const {
     const tnsr::I<DataVector, VolumeDim, frame>& all_target_points =
         get<Vars::PointInfoTag<InterpolationTargetTag, VolumeDim>>(point_infos);
-    std::vector<std::optional<IdPair<
-        domain::BlockId, tnsr::I<double, VolumeDim, ::Frame::BlockLogical>>>>
-        block_logical_coords{};
+    std::vector<BlockLogicalCoords<VolumeDim>> block_logical_coords{};
 
     // The sphere target is special because we have a better idea of where the
     // points will be.

--- a/src/ParallelAlgorithms/Interpolation/InterpolatedVars.hpp
+++ b/src/ParallelAlgorithms/Interpolation/InterpolatedVars.hpp
@@ -13,6 +13,7 @@
 #include "DataStructures/IdPair.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "DataStructures/Variables.hpp"
+#include "Domain/BlockLogicalCoordinates.hpp"
 #include "Domain/Structure/BlockId.hpp"
 #include "Domain/Structure/ElementId.hpp"
 
@@ -41,10 +42,7 @@ struct Info {
   /// `block_coord_holders` even after all `Element`s have sent their
   /// data (this is because this `Info` lives only on a single core,
   /// and this core will have access only to the local `Element`s).
-  std::vector<std::optional<
-      IdPair<domain::BlockId,
-             tnsr::I<double, VolumeDim, typename ::Frame::BlockLogical>>>>
-      block_coord_holders;
+  std::vector<BlockLogicalCoords<VolumeDim>> block_coord_holders;
   /// If a target needs to send points in a specific order, it should also send
   /// along which iteration the `block_coord_holders` are for. That way they can
   /// be properly ordered in the Interpolator.

--- a/src/ParallelAlgorithms/Interpolation/InterpolationTargetDetail.hpp
+++ b/src/ParallelAlgorithms/Interpolation/InterpolationTargetDetail.hpp
@@ -11,7 +11,6 @@
 #include <vector>
 
 #include "DataStructures/DataBox/DataBox.hpp"
-#include "DataStructures/IdPair.hpp"
 #include "DataStructures/LinkedMessageId.hpp"
 #include "DataStructures/Tensor/Metafunctions.hpp"
 #include "DataStructures/VariablesTag.hpp"
@@ -614,10 +613,7 @@ template <typename InterpolationTargetTag, typename DbTags, size_t VolumeDim,
 void set_up_interpolation(
     const gsl::not_null<db::DataBox<DbTags>*> box,
     const TemporalId& temporal_id,
-    const std::vector<std::optional<
-        IdPair<domain::BlockId,
-               tnsr::I<double, VolumeDim, typename ::Frame::BlockLogical>>>>&
-        block_logical_coords) {
+    const std::vector<BlockLogicalCoords<VolumeDim>>& block_logical_coords) {
   db::mutate<Tags::IndicesOfFilledInterpPoints<TemporalId>,
              Tags::IndicesOfInvalidInterpPoints<TemporalId>,
              Tags::InterpolatedVars<InterpolationTargetTag, TemporalId>>(

--- a/src/Visualization/Python/PlotSlice.py
+++ b/src/Visualization/Python/PlotSlice.py
@@ -60,7 +60,9 @@ def points_on_slice(
     u *= slice_extent[1]
     lower_left = slice_origin - 0.5 * (u + v)
     xx, yy = np.meshgrid(
-        np.linspace(0, 1, num_points[0]), np.linspace(0, 1, num_points[1])
+        np.linspace(0, 1, num_points[0]),
+        np.linspace(0, 1, num_points[1]),
+        indexing="ij",
     )
     return (
         lower_left[:, np.newaxis, np.newaxis]

--- a/tests/Unit/Domain/Test_BlockAndElementLogicalCoordinates.cpp
+++ b/tests/Unit/Domain/Test_BlockAndElementLogicalCoordinates.cpp
@@ -716,9 +716,7 @@ void test_element_ids_are_uniquely_determined() {
   const size_t n_zeta_segments = two_to_the(zeta_level);
   const size_t n_pts = (2 * n_xi_segments + 1) * (2 * n_eta_segments + 1) *
                        (2 * n_zeta_segments + 1);
-  std::vector<std::optional<IdPair<
-      domain::BlockId, tnsr::I<double, 3, typename Frame::BlockLogical>>>>
-      block_logical_points{n_pts, std::nullopt};
+  std::vector<BlockLogicalCoords<3>> block_logical_points{n_pts, std::nullopt};
   const double xi_stride = 1.0 / n_xi_segments;
   const double eta_stride = 1.0 / n_eta_segments;
   const double zeta_stride = 1.0 / n_zeta_segments;

--- a/tests/Unit/Helpers/ParallelAlgorithms/Interpolation/InterpolateOnElementTestHelpers.hpp
+++ b/tests/Unit/Helpers/ParallelAlgorithms/Interpolation/InterpolateOnElementTestHelpers.hpp
@@ -126,9 +126,7 @@ struct MockInterpolationTargetVarsFromElement {
       const std::vector<Variables<
           typename InterpolationTargetTag::vars_to_interpolate_to_target>>&
           vars_src,
-      const std::vector<std::optional<
-          IdPair<domain::BlockId, tnsr::I<double, Metavariables::volume_dim,
-                                          typename ::Frame::BlockLogical>>>>&
+      const std::vector<BlockLogicalCoords<Metavariables::volume_dim>>&
           block_logical_coords,
       const std::vector<std::vector<size_t>>& global_offsets,
       const TemporalId& /*temporal_id*/) {

--- a/tests/Unit/Helpers/ParallelAlgorithms/Interpolation/InterpolationTargetTestHelpers.hpp
+++ b/tests/Unit/Helpers/ParallelAlgorithms/Interpolation/InterpolationTargetTestHelpers.hpp
@@ -12,6 +12,7 @@
 
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/BlockLogicalCoordinates.hpp"
 #include "Domain/Creators/Tags/Domain.hpp"
 #include "Framework/ActionTesting.hpp"
 #include "Parallel/ParallelComponentHelpers.hpp"
@@ -103,10 +104,7 @@ struct MockReceivePoints {
       const ArrayIndex& /*array_index*/,
       const typename Metavariables::InterpolationTargetA::temporal_id::type&
           temporal_id,
-      std::vector<std::optional<
-          IdPair<domain::BlockId,
-                 tnsr::I<double, VolumeDim, typename Frame::BlockLogical>>>>&&
-          block_coord_holders,
+      std::vector<BlockLogicalCoords<VolumeDim>>&& block_coord_holders,
       const size_t iteration = 0_st) {
     db::mutate<intrp::Tags::InterpolatedVarsHolders<Metavariables>>(
         [&temporal_id, &block_coord_holders, &iteration](

--- a/tests/Unit/IO/Exporter/Test_Exporter.cpp
+++ b/tests/Unit/IO/Exporter/Test_Exporter.cpp
@@ -7,6 +7,9 @@
 #include <cstddef>
 #include <string>
 #include <vector>
+#ifdef _OPENMP
+#include <omp.h>
+#endif  // _OPENMP
 
 #include "DataStructures/DataVector.hpp"
 #include "Domain/Creators/Rectangle.hpp"
@@ -22,6 +25,10 @@
 namespace spectre::Exporter {
 
 SPECTRE_TEST_CASE("Unit.IO.Exporter", "[Unit]") {
+#ifdef _OPENMP
+  // Disable OpenMP multithreading since multiple unit tests may run in parallel
+  omp_set_num_threads(1);
+#endif
   {
     INFO("Bundled volume data files");
     const auto interpolated_data = interpolate_to_points<3>(

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolationTargetVarsFromElement.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolationTargetVarsFromElement.cpp
@@ -12,6 +12,7 @@
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataBox/Tag.hpp"
 #include "DataStructures/DataVector.hpp"
+#include "Domain/BlockLogicalCoordinates.hpp"
 #include "Domain/Creators/RegisterDerivedWithCharm.hpp"
 #include "Domain/Creators/Sphere.hpp"
 #include "Domain/Creators/Tags/Domain.hpp"
@@ -300,9 +301,7 @@ void test() {
   auto& target_box =
       ActionTesting::get_databox<target_component>(make_not_null(&runner), 0);
 
-  using BlockLogicalCoordType = std::vector<std::optional<
-      IdPair<domain::BlockId, tnsr::I<double, 3, ::Frame::BlockLogical>>>>;
-  BlockLogicalCoordType block_logical_coords{};
+  std::vector<BlockLogicalCoords<3>> block_logical_coords{};
   if constexpr (UseTimeDepMaps) {
     block_logical_coords =
         intrp::InterpolationTarget_detail::block_logical_coords<


### PR DESCRIPTION
## Proposed changes

The majority of time spent in interpolation and loading numeric initial data is spent in `block_logical_coordinates`, mapping
all grid points through the domain. It's very easily parallelized though (literally 1 line of OpenMP for perfect strong scaling).

OpenMP is disabled in our charm++ execs unless explicitly requested, so this doesn't have an effect there. It currently only applies to pybindings and the exporter lib. However, we are loading numeric initial data on a nodegroup, so we may even want to enable the OpenMP parallelization there. I haven't tested it yet though.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
