### PR TITLE
Write data synchronously in CCE for monotomic times in output

### DIFF
--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_ScriObserveInterpolated.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_ScriObserveInterpolated.cpp
@@ -145,7 +145,7 @@ struct mock_characteristic_evolution {
                                            cce_boundary_component>>>,
               Actions::ScriObserveInterpolated<
                   mock_observer<Metavariables>,
-                  typename Metavariables::cce_boundary_component>,
+                  typename Metavariables::cce_boundary_component, false>,
               ::Actions::AdvanceTime>>>;
 };
 


### PR DESCRIPTION
## Proposed changes

Use a local synchronous action instead of a threaded action. We still have the option to use a threaded action, you just have to specify a template bool.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
