### PR TITLE
Automate choice of some params in BBH pipeline

### DIFF
--- a/src/Domain/Creators/ShapeMapOptions.cpp
+++ b/src/Domain/Creators/ShapeMapOptions.cpp
@@ -67,7 +67,7 @@ initial_shape_and_size_funcs(
         const ylm::Strahlkorper<Frame::Distorted> file_strahlkorper =
             ylm::read_surface_ylm_single_time<Frame::Distorted>(
                 h5_filename, gsl::at(subfile_names, i), match_time,
-                match_time_epsilon);
+                match_time_epsilon, files.check_frame);
         const ylm::Strahlkorper<Frame::Distorted> this_strahlkorper{
             shape_options.l_max, 1.0, std::array{0.0, 0.0, 0.0}};
 

--- a/src/Domain/Creators/ShapeMapOptions.hpp
+++ b/src/Domain/Creators/ShapeMapOptions.hpp
@@ -99,8 +99,15 @@ struct YlmsFromFile {
         "because L=1 is degenerate with a translation of the BH.";
   };
 
+  struct CheckFrame {
+    using type = bool;
+    static constexpr Options::String help =
+        "Whether to check if the frame of the Strahlkorper in the file matches "
+        "the Distorted frame.";
+  };
+
   using options = tmpl::list<H5Filename, SubfileNames, MatchTime,
-                             MatchTimeEpsilon, SetL1CoefsToZero>;
+                             MatchTimeEpsilon, SetL1CoefsToZero, CheckFrame>;
 
   static constexpr Options::String help = {
       "Read the Y_lm coefficients of a Strahlkorper from file and use those to "
@@ -111,6 +118,7 @@ struct YlmsFromFile {
   double match_time{};
   std::optional<double> match_time_epsilon{};
   bool set_l1_coefs_to_zero{};
+  bool check_frame{true};
 };
 
 /*!

--- a/src/NumericalAlgorithms/SphericalHarmonics/IO/ReadSurfaceYlm.hpp
+++ b/src/NumericalAlgorithms/SphericalHarmonics/IO/ReadSurfaceYlm.hpp
@@ -50,9 +50,10 @@ std::vector<ylm::Strahlkorper<Frame>> read_surface_ylm(
  * \param relative_epsilon How much error is allowed when looking for a specific
  * time. This is useful so users don't have to know the specific time to machine
  * precision.
+ * \param check_frame Whether to check the frame in the subfile or not.
  */
 template <typename Frame>
 ylm::Strahlkorper<Frame> read_surface_ylm_single_time(
     const std::string& file_name, const std::string& surface_subfile_name,
-    double time, double relative_epsilon);
+    double time, double relative_epsilon, bool check_frame = true);
 }  // namespace ylm

--- a/src/NumericalAlgorithms/SphericalHarmonics/Python/Strahlkorper.cpp
+++ b/src/NumericalAlgorithms/SphericalHarmonics/Python/Strahlkorper.cpp
@@ -78,6 +78,6 @@ void bind_strahlkorper(pybind11::module& m) {  // NOLINT
   m.def("read_surface_ylm_single_time",
         &ylm::read_surface_ylm_single_time<Frame::Inertial>,
         py::arg("file_name"), py::arg("surface_subfile_name"), py::arg("time"),
-        py::arg("relative_epsilon"));
+        py::arg("relative_epsilon"), py::arg("check_frame"));
 }
 }  // namespace ylm::py_bindings

--- a/support/Pipelines/Bbh/Inspiral.py
+++ b/support/Pipelines/Bbh/Inspiral.py
@@ -57,6 +57,24 @@ def _control_system_params(
     }
 
 
+def _constraint_damping_params(
+    mass_left: float,
+    mass_right: float,
+    initial_separation: float,
+) -> dict:
+    total_mass = mass_left + mass_right
+    return {
+        "Gamma0Constant": 0.001 / total_mass,
+        "Gamma0LeftAmplitude": 4.0 / mass_left,
+        "Gamma0LeftWidth": 7.0 * mass_left,
+        "Gamma0RightAmplitude": 4.0 / mass_right,
+        "Gamma0RightWidth": 7.0 * mass_right,
+        "Gamma0OriginAmplitude": 0.075 / total_mass,
+        "Gamma0OriginWidth": 2.5 * initial_separation,
+        "Gamma1Width": 10.0 * initial_separation,
+    }
+
+
 def inspiral_parameters(
     id_input_file: dict,
     id_run_dir: Union[str, Path],
@@ -79,6 +97,10 @@ def inspiral_parameters(
 
     # ID parameters
     horizons_filename = Path(id_run_dir) / "Horizons.h5"
+    initial_separation = (
+        id_domain_creator["ObjectA"]["XCoord"]
+        - id_domain_creator["ObjectB"]["XCoord"]
+    )
     with spectre_h5.H5File(
         str(horizons_filename.resolve()), "r"
     ) as horizons_file:
@@ -118,6 +140,15 @@ def inspiral_parameters(
         "L": refinement_level,
         "P": polynomial_order,
     }
+
+    # Constraint damping parameters
+    params.update(
+        _constraint_damping_params(
+            mass_left=mass_left,
+            mass_right=mass_right,
+            initial_separation=initial_separation,
+        )
+    )
 
     # Control system
     params.update(
@@ -175,6 +206,7 @@ def inspiral_parameters_spec(
     mass_right = id_params["ID_MA"]
     spin_magnitude_left = id_params["ID_chiBMagnitude"]
     spin_magnitude_right = id_params["ID_chiAMagnitude"]
+    initial_separation = id_params["ID_d"]
 
     params = {
         # Initial data files
@@ -192,6 +224,15 @@ def inspiral_parameters_spec(
         "L": refinement_level,
         "P": polynomial_order,
     }
+
+    # Constraint damping parameters
+    params.update(
+        _constraint_damping_params(
+            mass_left=mass_left,
+            mass_right=mass_right,
+            initial_separation=initial_separation,
+        )
+    )
 
     # Control system
     params.update(

--- a/support/Pipelines/Bbh/Inspiral.py
+++ b/support/Pipelines/Bbh/Inspiral.py
@@ -122,6 +122,16 @@ def inspiral_parameters(
     # if total_mass != 1.0:
     #     raise ValueError(f"Total mass must 1.0, not {total_mass}.")
 
+    # The excision surface in the ID grid is distorted to one of constant
+    # Boyer-Lindquist radius, meaning that it looks like a Kerr BH. It is not
+    # distorted to match the shape of the AH. However, in the Ev grid, we *do*
+    # want the excision to match the AH shape so that the control system has an
+    # easier time adjusting. Therefore, in order to ensure that the Ev grid lies
+    # entirely inside the ID grid regardless of the excision shapes, we make the
+    # Ev excision radius a tad larger than the ID excision radius to account for
+    # these different excision shapes. This factor was found empirically.
+    excision_factor = 1.02
+
     params = {
         # Initial data files
         "IdFileGlob": str(
@@ -129,13 +139,20 @@ def inspiral_parameters(
             / (id_input_file["Observers"]["VolumeFileName"] + "*.h5")
         ),
         # Domain geometry
-        "ExcisionRadiusA": id_domain_creator["ObjectA"]["InnerRadius"],
-        "ExcisionRadiusB": id_domain_creator["ObjectB"]["InnerRadius"],
+        "ExcisionRadiusA": (
+            excision_factor * id_domain_creator["ObjectA"]["InnerRadius"]
+        ),
+        "ExcisionRadiusB": (
+            excision_factor * id_domain_creator["ObjectB"]["InnerRadius"]
+        ),
         "XCoordA": id_domain_creator["ObjectA"]["XCoord"],
         "XCoordB": id_domain_creator["ObjectB"]["XCoord"],
         # Initial functions of time
         "InitialAngularVelocity": id_binary["AngularVelocity"],
         "RadialExpansionVelocity": float(id_binary["Expansion"]),
+        "HorizonsFile": str(horizons_filename.resolve()),
+        "AhASubfileName": "AhA/Coefficients",
+        "AhBSubfileName": "AhB/Coefficients",
         # Resolution
         "L": refinement_level,
         "P": polynomial_order,

--- a/support/Pipelines/Bbh/Inspiral.yaml
+++ b/support/Pipelines/Bbh/Inspiral.yaml
@@ -393,100 +393,108 @@ ControlSystems:
   Verbosity: Silent
   Expansion:
     IsActive: true
-    Averager:
-      AverageTimescaleFraction: 0.25
+    Averager: &KinematicAverager
+      AverageTimescaleFraction: &AvgTimescaleFrac 0.25
       Average0thDeriv: false
-    Controller:
+    Controller: &KinematicController
       # Changed UpdateFraction from 0.03 to 0.3 to increase run speed
       UpdateFraction: 0.3
-    TimescaleTuner:
-      InitialTimescales: [0.2]
-      MinTimescale: 1.0e-2
-      MaxTimescale: 10.0
-      IncreaseThreshold: 2.5e-4
-      DecreaseThreshold: 1.0e-3
-      IncreaseFactor: 1.01
-      DecreaseFactor: 0.98
+    TimescaleTuner: &KinematicTuner
+      InitialTimescales: {{ KinematicTimescale }}
+      MinTimescale: &MinTimescale 1.0e-2
+      MaxTimescale: &MaxTimescale {{ MaxDampingTimescale }}
+      IncreaseThreshold: &IncreaseThreshold {{ IncreaseThreshold }}
+      DecreaseThreshold: &DecreaseThreshold {{ DecreaseThreshold }}
+      IncreaseFactor: &IncreaseFactor 1.01
+      DecreaseFactor: &DecreaseFactor 0.98
     ControlError:
   Rotation:
     IsActive: true
-    Averager:
-      AverageTimescaleFraction: 0.25
-      Average0thDeriv: false
-    Controller:
-      # Changed UpdateFraction from 0.03 to 0.3 to increase run speed
-      UpdateFraction: 0.3
-    TimescaleTuner:
-      InitialTimescales: [0.2, 0.2, 0.2]
-      MinTimescale: 1.0e-2
-      MaxTimescale: 10.0
-      IncreaseThreshold: 2.5e-4
-      DecreaseThreshold: 1.0e-3
-      IncreaseFactor: 1.01
-      DecreaseFactor: 0.98
+    Averager: *KinematicAverager
+    Controller: *KinematicController
+    TimescaleTuner: *KinematicTuner
     ControlError:
   Translation:
     IsActive: false
-    Averager:
-      AverageTimescaleFraction: 0.25
-      Average0thDeriv: false
-    Controller:
-      # Changed UpdateFraction from 0.03 to 0.3 to increase run speed
-      UpdateFraction: 0.3
-    TimescaleTuner:
-      InitialTimescales: [0.2, 0.2, 0.2]
-      MinTimescale: 1.0e-2
-      MaxTimescale: 20.0
-      IncreaseThreshold: 2.5e-4
-      DecreaseThreshold: 1.0e-3
-      IncreaseFactor: 1.01
-      DecreaseFactor: 0.98
+    Averager: *KinematicAverager
+    Controller: *KinematicController
+    TimescaleTuner: *KinematicTuner
     ControlError:
-  ShapeA: &ShapeControl
+  ShapeA:
     IsActive: true
-    Averager:
-      AverageTimescaleFraction: 0.25
-      Average0thDeriv: false
-    Controller:
-      # Changed UpdateFraction from 0.03 to 0.3 to increase run speed
-      UpdateFraction: 0.3
-    TimescaleTuner:
-      InitialTimescales: 2.0
-      MinTimescale: 1.0e-2
-      MaxTimescale: 10.0
-      IncreaseThreshold: 2.5e-4
-      DecreaseThreshold: 1.0e-3
-      IncreaseFactor: 1.01
-      DecreaseFactor: 0.98
-    ControlError:
-  ShapeB: *ShapeControl
-  SizeA: &SizeControl
-    IsActive: true
-    Averager:
-      AverageTimescaleFraction: 0.25
+    Averager: &SizeShapeAverager
+      AverageTimescaleFraction: *AvgTimescaleFrac
       Average0thDeriv: true
-    Controller:
+    Controller: *KinematicController
+    TimescaleTuner:
+      InitialTimescales: {{ ShapeATimescale }}
+      MinTimescale: *MinTimescale
+      MaxTimescale: *MaxTimescale
+      IncreaseThreshold: *IncreaseThreshold
+      DecreaseThreshold: *DecreaseThreshold
+      IncreaseFactor: *IncreaseFactor
+      DecreaseFactor: *DecreaseFactor
+    ControlError:
+  ShapeB:
+    IsActive: true
+    Averager: *SizeShapeAverager
+    Controller: *KinematicController
+    TimescaleTuner:
+      InitialTimescales: {{ ShapeBTimescale }}
+      MinTimescale: *MinTimescale
+      MaxTimescale: *MaxTimescale
+      IncreaseThreshold: *IncreaseThreshold
+      DecreaseThreshold: *DecreaseThreshold
+      IncreaseFactor: *IncreaseFactor
+      DecreaseFactor: *DecreaseFactor
+    ControlError:
+  SizeA:
+    IsActive: true
+    Averager: *SizeShapeAverager
+    Controller: &SizeController
       UpdateFraction: 0.2
     TimescaleTuner:
-      InitialTimescales: 0.02
-      MinTimescale: 1.0e-4
-      MaxTimescale: 20.0
-      IncreaseThreshold: 2.5e-4
-      IncreaseFactor: 1.01
+      InitialTimescales: &SizeATimescale {{ SizeATimescale }}
+      MinTimescale: &SizeMinTimescale 1.0e-4
+      MaxTimescale: {{ SizeAMaxTimescale }}
+      IncreaseThreshold: &SizeIncreaseThreshold {{ SizeIncreaseThreshold }}
+      IncreaseFactor: *IncreaseFactor
     ControlError:
       MaxNumTimesForZeroCrossingPredictor: 4
       SmoothAvgTimescaleFraction: 0.25
       DeltaRDriftOutwardOptions: None
       InitialState: Initial
       SmootherTuner:
-        InitialTimescales: [0.2]
-        MinTimescale: 1.0e-4
-        MaxTimescale: 20.0
-        IncreaseThreshold: 2.5e-4
-        DecreaseThreshold: 1.0e-3
-        IncreaseFactor: 1.01
-        DecreaseFactor: 0.9
-  SizeB: *SizeControl
+        InitialTimescales: *SizeATimescale
+        MinTimescale: *MinTimescale
+        MaxTimescale: *MaxTimescale
+        IncreaseThreshold: *IncreaseThreshold
+        DecreaseThreshold: *DecreaseThreshold
+        IncreaseFactor: *IncreaseFactor
+        DecreaseFactor: *DecreaseFactor
+  SizeB:
+    IsActive: true
+    Averager: *SizeShapeAverager
+    Controller: *SizeController
+    TimescaleTuner:
+      InitialTimescales: &SizeBTimescale {{ SizeBTimescale }}
+      MinTimescale: *SizeMinTimescale
+      MaxTimescale: {{ SizeBMaxTimescale }}
+      IncreaseThreshold: *SizeIncreaseThreshold
+      IncreaseFactor: *IncreaseFactor
+    ControlError:
+      MaxNumTimesForZeroCrossingPredictor: 4
+      SmoothAvgTimescaleFraction: 0.25
+      DeltaRDriftOutwardOptions: None
+      InitialState: Initial
+      SmootherTuner:
+        InitialTimescales: *SizeBTimescale
+        MinTimescale: *MinTimescale
+        MaxTimescale: *MaxTimescale
+        IncreaseThreshold: *IncreaseThreshold
+        DecreaseThreshold: *DecreaseThreshold
+        IncreaseFactor: *IncreaseFactor
+        DecreaseFactor: *DecreaseFactor
 
 ResourceInfo:
   AvoidGlobalProc0: false

--- a/support/Pipelines/Bbh/Inspiral.yaml
+++ b/support/Pipelines/Bbh/Inspiral.yaml
@@ -155,42 +155,28 @@ EvolutionSystem:
         SpatialDecayWidth: 17.0152695482514 # From SpEC run: 100.0/sqrt(34.54)
         Amplitudes: [1.0, 0.0, 1.0]         # From SpEC run: damped harmonic
         Exponents: [2, 2, 2]                # From SpEC run
-    DampingFunctionGamma0:
+    DampingFunctionGamma0: &ConstraintDampingTripleGaussian
       TimeDependentTripleGaussian:
-        Constant: 0.001             # 0.001 / (m_A + m_B)
+        Constant: {{ Gamma0Constant }}
         Gaussian1:
-          Amplitude: 8.0             # 4.0 / m_A
-          Width: 3.5                 # 7.0 * m_A
-          Center: [*XCoordA, 0.0, 0.0] # [x_A, 0, 0]
+          Amplitude: {{ Gamma0LeftAmplitude }}
+          Width: {{ Gamma0LeftWidth }}
+          Center: [*XCoordA, 0.0, 0.0]
         Gaussian2:
-          Amplitude: 8.0             # 4.0 / m_B
-          Width: 3.5                 # 7.0 * m_B
-          Center: [*XCoordB, 0.0, 0.0]  # [x_B, 0, 0]
+          Amplitude: {{ Gamma0RightAmplitude }}
+          Width:  {{ Gamma0RightWidth }}
+          Center: [*XCoordB, 0.0, 0.0]
         Gaussian3:
-          Amplitude: 0.075            # 0.075 / (m_A + m_B)
-          Width: 38.415              # 2.5 * (x_B - x_A)
+          Amplitude: {{ Gamma0OriginAmplitude }}
+          Width: {{ Gamma0OriginWidth }}
           Center: [0.0, 0.0, 0.0]
     DampingFunctionGamma1:
       GaussianPlusConstant:
         Constant: -0.999
         Amplitude: 0.999
-        Width: 153.66                # 10.0 * (x_B - x_A)
+        Width: {{ Gamma1Width }}
         Center: [0.0, 0.0, 0.0]
-    DampingFunctionGamma2:
-      TimeDependentTripleGaussian:
-        Constant: 0.001              # 0.001 / (m_A + m_B)
-        Gaussian1:
-          Amplitude: 8.0             # 4.0 / m_A
-          Width: 3.5                 # 7.0 * m_A
-          Center: [*XCoordA, 0.0, 0.0] # [x_A, 0, 0]
-        Gaussian2:
-          Amplitude: 8.0             # 4.0 / m_B
-          Width: 3.5                 # 7.0 * m_B
-          Center: [*XCoordB, 0.0, 0.0]  # [x_B, 0, 0]
-        Gaussian3:
-          Amplitude: 0.075            # 0.075 / (m_A + m_B)
-          Width: 38.415              # 2.5 * (x_B - x_A)
-          Center: [0.0, 0.0, 0.0]
+    DampingFunctionGamma2: *ConstraintDampingTripleGaussian
 
 # Half power was determined to filter only the last term up to N = 19
 # since we support up to 20 gridpoints.

--- a/support/Pipelines/Bbh/Inspiral.yaml
+++ b/support/Pipelines/Bbh/Inspiral.yaml
@@ -95,7 +95,7 @@ DomainCreator:
       Envelope:       [{{ P + 3 }}, {{ P + 3 }}, {{ P + 5 }}]
       OuterShell:     [{{ P + 2 }}, {{ P + 2 }}, {{ P + 4 }}]
     TimeDependentMaps:
-      InitialTime: 0.0
+      InitialTime: &InitialTime 0.0
       ExpansionMap:
         InitialValues: [1.0, {{ RadialExpansionVelocity }}]
         AsymptoticVelocityOuterBoundary: -1.0e-6
@@ -106,17 +106,37 @@ DomainCreator:
         InitialValues: [[0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]]
       ShapeMapA:
         LMax: &LMax 10
+{% if SpecDataDirectory is defined %}
         InitialValues: Spherical
+{% else %}
+        InitialValues:
+          H5Filename: &HorizonsFile "{{ HorizonsFile }}"
+          SubfileNames: ["{{ AhASubfileName }}"]
+          MatchTime: *InitialTime
+          MatchTimeEpsilon: Auto
+          SetL1CoefsToZero: True
+          CheckFrame: False
+{% endif %}
         SizeInitialValues: [0.0, 0.0, 0.0]
         TransitionEndsAtCube: true
       ShapeMapB:
         LMax: *LMax
+{% if SpecDataDirectory is defined %}
         InitialValues: Spherical
+{% else %}
+        InitialValues:
+          H5Filename: *HorizonsFile
+          SubfileNames: ["{{ AhBSubfileName }}"]
+          MatchTime: *InitialTime
+          MatchTimeEpsilon: Auto
+          SetL1CoefsToZero: True
+          CheckFrame: False
+{% endif %}
         SizeInitialValues: [0.0, 0.0, 0.0]
         TransitionEndsAtCube: true
 
 Evolution:
-  InitialTime: 0.0
+  InitialTime: *InitialTime
   InitialTimeStep: 0.0002
   # This is the smallest interval we'd need to observe time step/constraints. If
   # you need it smaller you can edit it, but make sure to change the slab

--- a/support/Python/Schedule.py
+++ b/support/Python/Schedule.py
@@ -12,8 +12,10 @@ from typing import Optional, Sequence, Union
 import click
 import jinja2
 import jinja2.meta
+import numpy as np
 import yaml
 from rich.pretty import pretty_repr
+from yaml.representer import SafeRepresenter
 
 from spectre.support.DirectoryStructure import (
     Checkpoint,
@@ -650,6 +652,9 @@ def schedule(
         with open(run_dir / context_file_name, "w") as open_context_file:
             yaml_dumper = yaml.SafeDumper
             yaml_dumper.add_multi_representer(Path, _path_representer)
+            yaml_dumper.add_multi_representer(
+                np.float64, SafeRepresenter.represent_float
+            )
             yaml.dump(context, open_context_file, Dumper=yaml_dumper)
 
     # Submit

--- a/tests/Unit/Domain/Creators/Test_ShapeMapOptions.cpp
+++ b/tests/Unit/Domain/Creators/Test_ShapeMapOptions.cpp
@@ -42,6 +42,7 @@ void test_ylms_from_file() {
       "  - dt_Ylm_coefs\n"
       "MatchTime: 1.7\n"
       "MatchTimeEpsilon: 1.0e-14\n"
+      "CheckFrame: True\n"
       "SetL1CoefsToZero: False");
   CHECK(ylms_from_file.h5_filename == "TotalEclipseOfTheHeart.h5");
   CHECK(ylms_from_file.subfile_names ==
@@ -111,6 +112,7 @@ void test_shape_map_options() {
         "  MatchTime: 1.7\n"
         "  MatchTimeEpsilon: Auto\n"
         "  SetL1CoefsToZero: True\n"
+        "  CheckFrame: True\n"
         "SizeInitialValues: Auto");
     CHECK(shape_map_options.name() == "ShapeMap");
     CHECK(shape_map_options.l_max == 8);
@@ -181,7 +183,7 @@ void test_funcs(const gsl::not_null<Generator*> generator) {
     // Strahlkorpers will be restricted
     const size_t file_l_max = 10;
     std::uniform_real_distribution<double> distribution(0.1, 2.0);
-    using Frame = ::Frame::Distorted;
+    using Frame = ::Frame::Inertial;
     std::array<ylm::Strahlkorper<Frame>, 3> strahlkorpers{};
     std::vector<std::string> legend{};
     std::vector<double> data{};
@@ -228,6 +230,7 @@ void test_funcs(const gsl::not_null<Generator*> generator) {
           "  MatchTime: 1.7\n"
           "  MatchTimeEpsilon: Auto\n"
           "  SetL1CoefsToZero: True\n"
+          "  CheckFrame: False\n"
           "SizeInitialValues: [1.1, 2.2, 3.3]");
 
       const auto [shape_funcs, size_funcs] =
@@ -274,6 +277,7 @@ void test_funcs(const gsl::not_null<Generator*> generator) {
           "  MatchTime: 1.7\n"
           "  MatchTimeEpsilon: Auto\n"
           "  SetL1CoefsToZero: True\n"
+          "  CheckFrame: False\n"
           "SizeInitialValues: Auto");
 
       const auto [shape_funcs, size_funcs] =

--- a/tests/Unit/NumericalAlgorithms/SphericalHarmonics/IO/Test_ReadSurfaceYlm.cpp
+++ b/tests/Unit/NumericalAlgorithms/SphericalHarmonics/IO/Test_ReadSurfaceYlm.cpp
@@ -327,6 +327,16 @@ void test_single_time(const std::string& test_filename) {
     CHECK(expected_strahlkorpers[2] == read_in_strahlkorper);
   }
 
+  {
+    const ylm::Strahlkorper<Frame::Grid> read_in_strahlkorper =
+        ylm::read_surface_ylm_single_time<Frame::Grid>(
+            test_filename, subfile_name, 0.2, 1e-2, false);
+
+    // Just check the coefficients since == won't work with different frames
+    CHECK(expected_strahlkorpers[2].coefficients() ==
+          read_in_strahlkorper.coefficients());
+  }
+
   CHECK_THROWS_WITH(
       ylm::read_surface_ylm_single_time<frame>(test_filename, subfile_name, 0.3,
                                                1e-12),

--- a/tests/Unit/NumericalAlgorithms/SphericalHarmonics/Python/Test_Strahlkorper.py
+++ b/tests/Unit/NumericalAlgorithms/SphericalHarmonics/Python/Test_Strahlkorper.py
@@ -75,7 +75,7 @@ class TestStrahlkorper(unittest.TestCase):
         )
         self.assertEqual(
             read_surface_ylm_single_time(
-                self.filename, "Strahlkorper", 1.0, 0.0
+                self.filename, "Strahlkorper", 1.0, 0.0, True
             ),
             strahlkorper,
         )

--- a/tests/support/Pipelines/Bbh/Test_Inspiral.py
+++ b/tests/support/Pipelines/Bbh/Test_Inspiral.py
@@ -87,6 +87,15 @@ class TestInspiral(unittest.TestCase):
         self.assertEqual(params["IncreaseThreshold"], 2.5e-5)
         self.assertEqual(params["SizeAMaxTimescale"], 20)
         self.assertEqual(params["SizeBMaxTimescale"], 20)
+        # Constraint damping
+        self.assertEqual(params["Gamma0Constant"], 5e-4)
+        self.assertEqual(params["Gamma0LeftAmplitude"], 4.0)
+        self.assertEqual(params["Gamma0LeftWidth"], 7.0)
+        self.assertEqual(params["Gamma0RightAmplitude"], 4.0)
+        self.assertEqual(params["Gamma0RightWidth"], 7.0)
+        self.assertEqual(params["Gamma0OriginAmplitude"], 3.75e-2)
+        self.assertEqual(params["Gamma0OriginWidth"], 50.0)
+        self.assertEqual(params["Gamma1Width"], 200.0)
 
     def test_cli(self):
         common_args = [

--- a/tests/support/Pipelines/Bbh/Test_Inspiral.py
+++ b/tests/support/Pipelines/Bbh/Test_Inspiral.py
@@ -73,6 +73,11 @@ class TestInspiral(unittest.TestCase):
         self.assertEqual(params["XCoordB"], -12.0)
         self.assertEqual(params["InitialAngularVelocity"], 0.01)
         self.assertEqual(params["RadialExpansionVelocity"], -1.0e-5)
+        self.assertEqual(
+            params["HorizonsFile"], str(self.horizons_filename.resolve())
+        )
+        self.assertEqual(params["AhASubfileName"], "AhA/Coefficients")
+        self.assertEqual(params["AhBSubfileName"], "AhB/Coefficients")
         self.assertEqual(params["L"], 1)
         self.assertEqual(params["P"], 5)
         # Control system

--- a/tests/support/Pipelines/Bbh/Test_Ringdown.py
+++ b/tests/support/Pipelines/Bbh/Test_Ringdown.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import yaml
 from click.testing import CliRunner
 
+import spectre.IO.H5 as spectre_h5
 from spectre.Informer import unit_test_build_path
 from spectre.Pipelines.Bbh.InitialData import generate_id
 from spectre.Pipelines.Bbh.Inspiral import start_inspiral
@@ -41,6 +42,15 @@ class TestInitialData(unittest.TestCase):
             executable=str(self.bin_dir / "SolveXcts"),
         )
         self.id_dir = self.test_dir / "ID"
+        self.horizons_filename = self.id_dir / "Horizons.h5"
+        with spectre_h5.H5File(
+            str(self.horizons_filename.resolve()), "a"
+        ) as horizons_file:
+            legend = ["Time", "ChristodoulouMass", "DimensionlessSpinMagnitude"]
+            for subfile_name in ["AhA", "AhB"]:
+                horizons_file.close_current_object()
+                dat_file = horizons_file.try_insert_dat(subfile_name, legend, 0)
+                dat_file.append([[0.0, 1.0, 0.3]])
         start_inspiral(
             id_input_file_path=self.test_dir / "ID" / "InitialData.yaml",
             refinement_level=1,


### PR DESCRIPTION
## Proposed changes

Some of the initial parameters in our input file depend on the parameters used in the ID solve, and it'd be very tedious to try and update these manually in our pipeline. This PR adds logic to determine some constraint damping parameters and control system parameters automatically based on the masses, mass ratio, spins, and separation of the binary. These formulas were taken from `DoMultipleRuns.input` in SpEC.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

This PR should be merged after #5953 

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
