### PR TITLE
Unconstrain numpy version

### DIFF
--- a/support/Python/requirements.txt
+++ b/support/Python/requirements.txt
@@ -21,9 +21,7 @@ h5py >= 3.5.0
 humanize
 # Jinja2: To work with placeholders in input files and submit scripts
 Jinja2
-# - We constrain the Numpy version because v1.22+ segfaults in Pypp tests, see
-#   issue: https://github.com/sxs-collaboration/spectre/issues/3844
-numpy < 1.22.0
+numpy
 matplotlib
 # Pandas: To work with columns of data. Need a sufficiently recent version
 # to do some fancy indexing in Status CLI

--- a/tests/Unit/Framework/Tests/Test_Pypp.cpp
+++ b/tests/Unit/Framework/Tests/Test_Pypp.cpp
@@ -653,8 +653,10 @@ void test_custom_conversion() {
 SPECTRE_TEST_CASE("Unit.Pypp", "[Pypp][Unit]") {
   pypp::SetupLocalPythonEnvironment local_python_env{"Framework/Tests/"};
   {
-    INFO("Testing scipy support");
-    CHECK((pypp::call<size_t>("scipy", "ndim", tnsr::abcc<double, 3>{})) == 4);
+    INFO("Testing numpy and scipy support");
+    CHECK((pypp::call<size_t>("numpy", "ndim", tnsr::abcc<double, 3>{})) == 4);
+    CHECK((pypp::call<double>("scipy.linalg", "det", tnsr::ii<double, 3>{})) ==
+          0.);
   }
 
   test_none();


### PR DESCRIPTION
## Proposed changes

Looks like the segfault we got in #3844 was fixed in newer versions of numpy. Closes #3844.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
