### PR TITLE
Add Cce H5 file type

### DIFF
--- a/src/IO/H5/CMakeLists.txt
+++ b/src/IO/H5/CMakeLists.txt
@@ -9,6 +9,7 @@ spectre_target_sources(
   ${LIBRARY}
   PRIVATE
   AccessType.cpp
+  Cce.cpp
   CheckH5PropertiesMatch.cpp
   CombineH5.cpp
   Dat.cpp
@@ -31,6 +32,7 @@ spectre_target_headers(
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   AccessType.hpp
+  Cce.hpp
   CheckH5.hpp
   CheckH5PropertiesMatch.hpp
   CombineH5.hpp

--- a/src/IO/H5/Cce.cpp
+++ b/src/IO/H5/Cce.cpp
@@ -1,0 +1,264 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "IO/H5/Cce.hpp"
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <hdf5.h>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include "DataStructures/Matrix.hpp"
+#include "IO/H5/AccessType.hpp"
+#include "IO/H5/CheckH5.hpp"
+#include "IO/H5/Header.hpp"
+#include "IO/H5/Helpers.hpp"
+#include "IO/H5/OpenGroup.hpp"
+#include "IO/H5/Version.hpp"
+#include "IO/H5/Wrappers.hpp"
+#include "Utilities/Algorithm.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/MakeString.hpp"
+#include "Utilities/StdHelpers.hpp"
+
+namespace h5 {
+Cce::Cce(const bool exists, detail::OpenGroup&& group, const hid_t /*location*/,
+         const std::string& name, const size_t l_max, const uint32_t version)
+    : group_(std::move(group)),
+      name_(extension() == name.substr(name.size() > extension().size()
+                                           ? name.size() - extension().size()
+                                           : 0)
+                ? name
+                : name + extension()),
+      path_(group_.group_path_with_trailing_slash() + name),
+      version_(version),
+      l_max_(l_max),
+      legend_([this]() {
+        std::vector<std::string> legend;
+        legend.reserve(2 * square(l_max_ + 1) + 1);
+        legend.emplace_back("time");
+        for (int i = 0; i <= static_cast<int>(l_max_); ++i) {
+          for (int j = -i; j <= i; ++j) {
+            legend.push_back(MakeString{} << "Real Y_" << i << "," << j);
+            legend.push_back(MakeString{} << "Imag Y_" << i << "," << j);
+          }
+        }
+        return legend;
+      }()),
+      cce_group_(group_.id(), name_, h5::AccessType::ReadWrite) {
+  for (const std::string& bondi_var : bondi_variables_) {
+    // We will set the id below
+    bondi_datasets_[bondi_var] = DataSet{-1, {0, legend_.size()}};
+  }
+
+  if (exists) {
+    {
+      // We treat this as an internal version for now. We'll need to deal with
+      // proper versioning later.
+
+      // Check if the version exists before calling the open_version.
+      const htri_t version_exists = H5Aexists(cce_group_.id(), "version.ver");
+      if (version_exists != 0) {
+        const Version open_version(true, detail::OpenGroup{}, cce_group_.id(),
+                                   "version");
+        version_ = open_version.get_version();
+      }
+    }
+    {
+      const htri_t header_exists = H5Aexists(cce_group_.id(), "header.hdr");
+      if (header_exists != 0) {
+        const Header header(true, detail::OpenGroup{}, cce_group_.id(),
+                            "header");
+        header_ = header.get_header();
+      }
+    }
+
+    for (const std::string& bondi_var : bondi_variables_) {
+      DataSet& dataset = bondi_datasets_.at(bondi_var);
+      dataset.id =
+          H5Dopen2(cce_group_.id(), bondi_var.c_str(), h5::h5p_default());
+      CHECK_H5(dataset.id, "Failed to open dataset");
+
+      hid_t space_id = H5Dget_space(dataset.id);
+      std::array<hsize_t, 2> max_dims{};
+      if (2 != H5Sget_simple_extent_dims(space_id, dataset.size.data(),
+                                         max_dims.data())) {
+        ERROR("Invalid number of dimensions in cce file " << bondi_var
+                                                          << " on disk.");
+      }
+      CHECK_H5(H5Sclose(space_id), "Failed to close dataspace");
+
+      if (legend_ != read_rank1_attribute<std::string>(dataset.id, "Legend"s)) {
+        ERROR("l_max from cce file " << bondi_var
+                                     << " does not match l_max in constructor");
+      }
+    }
+  } else {  // file does not exist
+    {
+      Version open_version(false, detail::OpenGroup{}, cce_group_.id(),
+                           "version", version_);
+    }
+    {
+      Header header(false, detail::OpenGroup{}, cce_group_.id(), "header");
+      header_ = header.get_header();
+    }
+    // So this file is compatible with the sxs/scri python packages offered by
+    // the SXS collaboration
+    write_to_attribute(cce_group_.id(), sxs_format_str_, sxs_version_str_);
+
+    for (const std::string& bondi_var : bondi_variables_) {
+      DataSet& dataset = bondi_datasets_.at(bondi_var);
+      dataset.id = h5::detail::create_extensible_dataset(
+          cce_group_.id(), bondi_var, dataset.size,
+          std::array<hsize_t, 2>{{4, legend_.size()}},
+          {{h5s_unlimited(), legend_.size()}});
+      CHECK_H5(dataset.id, "Failed to create dataset");
+
+      write_to_attribute(dataset.id, "Legend"s, legend_);
+      // So this dataset is compatible with the sxs/scri python packages offered
+      // by the SXS collaboration
+      write_to_attribute(dataset.id, sxs_format_str_, sxs_version_str_);
+    }
+  }
+}
+
+Cce::~Cce() {
+#if defined(__GNUC__) and not defined(__clang__)
+// The pragma here is used to suppress the warning that the compile time branch
+// of `ERROR` will always call `terminate()` because it throws an error.
+// Throwing that error is a code path that will never actually be entered at
+// runtime, so we suppress the warning here.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wterminate"
+#endif
+  // We don't use structured bindings because there was a bug that was fixed in
+  // C++20 about capturing structured bindings in a lambda (the lambda is in the
+  // internals of CHECK_H5), so older compilers that we support may not have
+  // fixed this bug.
+  for (const auto& name_and_dataset : bondi_datasets_) {
+    const auto& name = name_and_dataset.first;
+    const auto& dataset = name_and_dataset.second;
+    CHECK_H5(H5Dclose(dataset.id), "Failed to close dataset " << name);
+  }
+#if defined(__GNUC__) and not defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+}
+
+void Cce::append(
+    const std::unordered_map<std::string, std::vector<double>>& data) {
+  for (const std::string& bondi_var : bondi_variables_) {
+    if (not data.contains(bondi_var)) {
+      ERROR("Passed in data does not contain the bondi variable " << bondi_var);
+    }
+    DataSet& dataset = bondi_datasets_.at(bondi_var);
+
+    const std::vector<double>& vec_data = data.at(bondi_var);
+    if (vec_data.size() != dataset.size[1]) {
+      ERROR("Cannot add columns to Cce files. Current number of columns is "
+            << dataset.size[1] << " but received " << vec_data.size()
+            << " entries.");
+    }
+
+    dataset.size =
+        h5::append_to_dataset(dataset.id, bondi_var, vec_data, 1, dataset.size);
+  }
+}
+
+std::unordered_map<std::string, Matrix> Cce::get_data() const {
+  std::unordered_map<std::string, Matrix> result{};
+
+  for (const std::string& bondi_var : bondi_variables_) {
+    const DataSet& dataset = bondi_datasets_.at(bondi_var);
+    result[bondi_var] = h5::retrieve_dataset(dataset.id, dataset.size);
+  }
+
+  return result;
+}
+
+Matrix Cce::get_data(const std::string& bondi_variable_name) const {
+  check_bondi_variable(bondi_variable_name);
+
+  const DataSet& dataset = bondi_datasets_.at(bondi_variable_name);
+  return h5::retrieve_dataset(dataset.id, dataset.size);
+}
+
+std::unordered_map<std::string, Matrix> Cce::get_data_subset(
+    const std::vector<size_t>& these_ell, const size_t first_row,
+    const size_t num_rows) const {
+  std::unordered_map<std::string, Matrix> result{};
+
+  for (const std::string& bondi_var : bondi_variables_) {
+    result[bondi_var] =
+        get_data_subset(bondi_var, these_ell, first_row, num_rows);
+  }
+
+  return result;
+}
+
+Matrix Cce::get_data_subset(const std::string& bondi_variable_name,
+                            const std::vector<size_t>& these_ell,
+                            const size_t first_row,
+                            const size_t num_rows) const {
+  check_bondi_variable(bondi_variable_name);
+
+  if (alg::any_of(these_ell,
+                  [this](const size_t ell) { return ell > l_max_; })) {
+    ERROR("One (or more) of the requested ells "
+          << these_ell << " is larger than the l_max " << l_max_);
+  }
+
+  if (these_ell.empty()) {
+    return {num_rows, 0, 0.0};
+  }
+
+  // Always grab the time
+  std::vector<size_t> these_columns{0};
+
+  // For a given ell, we nedd the first column index and the last column index.
+  // For a given ell, the total number of coefs is given by
+  // f(l) = 2 * (l + 1)^2 (first factor of 2 comes from having both real and
+  // imag components). Therefore, the first column index is just f(ell - 1) + 1,
+  // and the last column index is just f(ell). The +1 is because we have a
+  // time column
+  for (size_t ell : these_ell) {
+    if (ell == 0_st) {
+      these_columns.emplace_back(1);
+      these_columns.emplace_back(2);
+    } else {
+      const size_t first_col = 2 * square(ell) + 1;
+      const size_t last_col = 2 * square(ell + 1);
+      for (size_t col = first_col; col <= last_col; col++) {
+        these_columns.emplace_back(col);
+      }
+    }
+  }
+
+  if (num_rows == 0) {
+    return {0, these_columns.size(), 0.0};
+  }
+
+  const DataSet& dataset = bondi_datasets_.at(bondi_variable_name);
+  return h5::retrieve_dataset_subset(dataset.id, these_columns, first_row,
+                                     num_rows, dataset.size);
+}
+
+void Cce::check_bondi_variable(const std::string& bondi_variable_name) const {
+  if (not bondi_variables_.contains(bondi_variable_name)) {
+    ERROR("Requested bondi variable " << bondi_variable_name
+                                      << " not available");
+  }
+}
+
+const std::array<hsize_t, 2>& Cce::get_dimensions(
+    const std::string& bondi_variable_name) const {
+  check_bondi_variable(bondi_variable_name);
+
+  return bondi_datasets_.at(bondi_variable_name).size;
+}
+}  // namespace h5

--- a/src/IO/H5/Cce.hpp
+++ b/src/IO/H5/Cce.hpp
@@ -1,0 +1,186 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+/// \file
+/// Defines class h5::Cce
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <hdf5.h>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include "IO/H5/Object.hpp"
+#include "IO/H5/OpenGroup.hpp"
+
+/// \cond
+class Matrix;
+/// \endcond
+
+namespace h5 {
+/*!
+ * \ingroup HDF5Group
+ * \brief Represents Cauchy-Characteristic Extraction (CCE) bondi variables
+ * inside of an HDF5 file.
+ *
+ * Within a Cce object, there are several datasets that correspond to the
+ * `Cce::scri_plus_interpolation_set` bondi variables at future null infinity
+ * represented as complex spherical harmonic coefficients. The names of these
+ * bondi variables are
+ *
+ * - `EthInertialRetardedTime`
+ * - `News`
+ * - `Psi0`
+ * - `Psi1`
+ * - `Psi2`
+ * - `Psi3`
+ * - `Psi4`
+ * - `Strain`
+ *
+ * Each dataset has a couple H5 attributes:
+ *
+ * - `Legend` which is determined by the `l_max` massed to the constructor.
+ * - `sxs_format` which is a string. The value is "SpECTRE_CCE_v1"
+ *
+ * The Cce object itself also has the `sxs_format` attribute with the same
+ * value, along with a `version` and `header` attribute.
+ *
+ * The columns of data are stored in each dataset in the following order:
+ *
+ * - `time`
+ * - `Real Y_0,0`
+ * - `Imag Y_0,0`
+ * - `Real Y_1,-1`
+ * - `Imag Y_1,-1`
+ * - `Real Y_1,0`
+ * - `Imag Y_1,0`
+ * - `Real Y_1,1`
+ * - `Imag Y_1,1`
+ * - ...
+ *
+ * and so on until you reach the coefficients for `l_max`.
+ *
+ * \note This class does not do any caching of data so all data is written as
+ * soon as append() is called.
+ */
+class Cce : public h5::Object {
+  struct DataSet {
+    hid_t id;
+    std::array<hsize_t, 2> size;
+  };
+
+ public:
+  /// \cond HIDDEN_SYMBOLS
+  static std::string extension() { return ".cce"; }
+
+  Cce(bool exists, detail::OpenGroup&& group, hid_t location,
+      const std::string& name, size_t l_max, uint32_t version = 1);
+
+  Cce(const Cce& /*rhs*/) = delete;
+  Cce& operator=(const Cce& /*rhs*/) = delete;
+  Cce(Cce&& /*rhs*/) = delete;             // NOLINT
+  Cce& operator=(Cce&& /*rhs*/) = delete;  // NOLINT
+
+  ~Cce() override;
+  /// \endcond HIDDEN_SYMBOLS
+
+  /*!
+   * \brief For each bondi variable name, appends the \p data to the dataset in
+   * the H5 file.
+   *
+   * \details The `data.at(name).size()` must be the same as the number of
+   * columns already in the dataset. Also, all bondi variable names listed in
+   * the constructor of `h5::Cce` must be present in the \p data.
+   */
+  void append(const std::unordered_map<std::string, std::vector<double>>& data);
+
+  /// @{
+  /*!
+   * \brief Return all currently stored data in the `h5::Cce` file in the form
+   * of a `Matrix` for each bondi variable
+   */
+  std::unordered_map<std::string, Matrix> get_data() const;
+
+  Matrix get_data(const std::string& bondi_variable_name) const;
+  /// @}
+
+  /// @{
+  /*!
+   * \brief Get only some values of $\ell$ over a range of rows
+   *
+   * \details The `time` column is always returned. The coefficients will be
+   * returned in the order that you requested them in. No sorting is done
+   * internally. All requested \p these_ell must be less that or equal to the \p
+   * l_max that this file was constructed with. Also both the first and last row
+   * requested must be less than or equal to the total number of rows.
+   */
+  std::unordered_map<std::string, Matrix> get_data_subset(
+      const std::vector<size_t>& these_ell, size_t first_row = 0,
+      size_t num_rows = 1) const;
+
+  Matrix get_data_subset(const std::string& bondi_variable_name,
+                         const std::vector<size_t>& these_ell,
+                         size_t first_row = 0, size_t num_rows = 1) const;
+  /// @}
+
+  /*!
+   * \brief Return the legend. All bondi variables have the same legend.
+   */
+  const std::vector<std::string> get_legend() const { return legend_; }
+
+  /*!
+   * \brief Return the number of rows (first index) and columns (second index)
+   * of the \p bondi_variable_name dataset. All bondi variables will have the
+   * same dimensions.
+   */
+  const std::array<hsize_t, 2>& get_dimensions(
+      const std::string& bondi_variable_name) const;
+
+  /*!
+   * \brief The header of the Cce file
+   */
+  const std::string& get_header() const { return header_; }
+
+  /*!
+   * \brief The user-specified version number of the Cce file
+   *
+   * \note h5::Version returns a uint32_t, so we return one here too for the
+   * version
+   */
+  uint32_t get_version() const { return version_; }
+
+  /*!
+   * \brief Path to this Cce file.
+   */
+  const std::string& subfile_path() const override { return path_; }
+
+ private:
+  void check_bondi_variable(const std::string& bondi_variable_name) const;
+  /// \cond HIDDEN_SYMBOLS
+  detail::OpenGroup group_;
+  std::string name_;
+  std::string path_;
+  uint32_t version_;
+  size_t l_max_;
+  std::vector<std::string> legend_{};
+  detail::OpenGroup cce_group_{};
+  std::string header_;
+  std::unordered_map<std::string, DataSet> bondi_datasets_;
+  std::unordered_set<std::string> bondi_variables_{"EthInertialRetardedTime",
+                                                   "News",
+                                                   "Psi0",
+                                                   "Psi1",
+                                                   "Psi2",
+                                                   "Psi3",
+                                                   "Psi4",
+                                                   "Strain"};
+  std::string sxs_format_str_{"sxs_format"};
+  std::string sxs_version_str_{"SpECTRE_CCE_v1"};
+  /// \endcond HIDDEN_SYMBOLS
+};
+}  // namespace h5

--- a/src/IO/H5/Dat.cpp
+++ b/src/IO/H5/Dat.cpp
@@ -20,23 +20,6 @@
 #include "Utilities/Gsl.hpp"
 #include "Utilities/StdHelpers.hpp"
 
-// IWYU pragma: no_include "DataStructures/Index.hpp"
-
-namespace {
-// Given a vector of contiguous data and an array giving the dimensions of the
-// matrix returns a `vector<vector<T>>` representing the matrix.
-Matrix vector_to_matrix(const std::vector<double>& raw_data,
-                        const std::array<hsize_t, 2>& size) {
-  Matrix temp(size[0], size[1]);
-  for (size_t i = 0; i < size[0]; ++i) {
-    for (size_t j = 0; j < size[1]; ++j) {
-      temp(i, j) = raw_data[j + i * size[1]];
-    }
-  }
-  return temp;
-}
-}  // namespace
-
 namespace h5 {
 Dat::Dat(const bool exists, detail::OpenGroup&& group, const hid_t location,
          const std::string& name, std::vector<std::string> legend,
@@ -117,57 +100,13 @@ Dat::~Dat() {
 #endif
 }
 
-void Dat::append_impl(const hsize_t number_of_rows,
-                      const std::vector<double>& data) {
-  {
-    std::array<hsize_t, 2> read_size{};
-    std::array<hsize_t, 2> read_max_size{};
-    const hid_t dataspace_id = H5Dget_space(dataset_id_);
-    CHECK_H5(dataspace_id, "Failed to get dataspace for appending");
-    if (2 != H5Sget_simple_extent_dims(dataspace_id, read_size.data(),
-                                       read_max_size.data())) {
-      ERROR("Incorrect rank of file on disk");  // LCOV_EXCL_LINE
-    }
-    CHECK_H5(H5Sclose(dataspace_id), "Failed to close dataspace");
-    if (read_size != size_) {
-      using ::operator<<;
-      ERROR("Mismatch in the size of the read dataset. Read "
-            << read_size << " but have stored " << size_
-            << ". This means that another thread or process is writing data at "
-               "the same time it is being written by this process.");
-    }
-  }
-
-  std::array<hsize_t, 2> new_size{{size_[0] + number_of_rows, size_[1]}};
-  CHECK_H5(H5Dset_extent(dataset_id_, new_size.data()),
-           "Failed to append to the file '" << name_ << "'");
-  const hid_t dataspace_id = H5Dget_space(dataset_id_);
-  CHECK_H5(dataspace_id, "Failed to get dataspace for appending");
-  CHECK_H5(H5Sselect_all(dataspace_id),
-           "Failed to select dataspace for appending");
-  CHECK_H5(H5Sselect_hyperslab(dataspace_id, H5S_SELECT_NOTB,
-                               std::array<hsize_t, 2>{{0, 0}}.data(), nullptr,
-                               size_.data(), nullptr),
-           "Failed to select the new dataspace subset where the appended "
-           "data would have been written.");
-  const std::array<hsize_t, 2> added_size{{number_of_rows, size_[1]}};
-  const hid_t memspace_id =
-      H5Screate_simple(2, added_size.data(), added_size.data());
-  CHECK_H5(memspace_id, "Failed to create new simple memspace while appending");
-  CHECK_H5(H5Dwrite(dataset_id_, h5_type<double>(), memspace_id, dataspace_id,
-                    h5::h5p_default(), data.data()),
-           "Failed to append to dataset while writing");
-  CHECK_H5(H5Sclose(memspace_id), "Failed to close memspace after appending");
-  CHECK_H5(H5Sclose(dataspace_id), "Failed to close dataspace after appending");
-  size_ = new_size;
-}
-
 void Dat::append(const std::vector<double>& data) {
   if (data.size() != size_[1]) {
     ERROR("Cannot add columns to Dat files. Current number of columns is "
           << size_[1] << " but received " << data.size() << " entries.");
   }
-  append_impl(1, data);
+
+  size_ = h5::append_to_dataset(dataset_id_, name_, data, 1, size_);
 }
 
 void Dat::append(const std::vector<std::vector<double>>& data) {
@@ -193,7 +132,9 @@ void Dat::append(const std::vector<std::vector<double>>& data) {
         }
         return result;
       }(data);
-  append_impl(data.size(), contiguous_data);
+
+  size_ = h5::append_to_dataset(dataset_id_, name_, contiguous_data,
+                                data.size(), size_);
 }
 
 void Dat::append(const Matrix& data) {
@@ -214,96 +155,19 @@ void Dat::append(const Matrix& data) {
     }
     return result;
   }(data);
-  append_impl(data.rows(), contiguous_data);
+
+  size_ = h5::append_to_dataset(dataset_id_, name_, contiguous_data,
+                                data.rows(), size_);
 }
 
 Matrix Dat::get_data() const {
-  const hid_t dataspace_id = H5Dget_space(dataset_id_);
-  CHECK_H5(dataspace_id, "Failed to get dataspace");
-
-  std::array<hsize_t, 2> size{};
-  std::array<hsize_t, 2> max_size{};
-  if (2 !=
-      H5Sget_simple_extent_dims(dataspace_id, size.data(), max_size.data())) {
-    ERROR("Incorrect dimension in get_data()");  // LCOV_EXCL_LINE
-  }
-  CHECK_H5(H5Sclose(dataspace_id), "Failed to close dataspace");
-
-  if (size != size_) {
-    using ::operator<<;
-    ERROR("Mismatch in the size of the read dataset. Read "
-          << size << " but have stored " << size_
-          << ". This means that another thread or process is writing data at "
-             "the same time it is being read.");
-  }
-
-  std::vector<double> temp(size[0] * size[1]);
-  if (0 != size[0] * size[1]) {
-    CHECK_H5(H5Dread(dataset_id_, h5_type<double>(), h5::h5s_all(),
-                     h5::h5s_all(), h5::h5p_default(), temp.data()),
-             "Failed to read data");
-  }
-  return vector_to_matrix(temp, size);
+  return h5::retrieve_dataset(dataset_id_, size_);
 }
 
 Matrix Dat::get_data_subset(const std::vector<size_t>& these_columns,
                             const size_t first_row,
                             const size_t num_rows) const {
-  Expects(first_row + num_rows <= size_[0]);
-  Expects(std::all_of(these_columns.begin(),
-                      these_columns.end(), [size = size_](const auto& column) {
-                        return column < size[1];
-                      }));
-
-  const auto num_cols = these_columns.size();
-  if (0 == num_cols * num_rows) {
-    return Matrix(num_rows, num_cols, 0.0);
-  }
-
-  const hid_t dataspace_id = H5Dget_space(dataset_id_);
-  CHECK_H5(dataspace_id, "Failed to get dataspace");
-  std::array<hsize_t, 2> size{};
-  std::array<hsize_t, 2> max_size{};
-  if (2 !=
-      H5Sget_simple_extent_dims(dataspace_id, size.data(), max_size.data())) {
-    ERROR("Incorrect dimension in get_data()");  // LCOV_EXCL_LINE
-  }
-  if (size != size_) {
-    using ::operator<<;
-    CHECK_H5(H5Sclose(dataspace_id), "Failed to close dataspace");
-    ERROR("Mismatch in the size of the read dataset. Read "
-          << size << " but have stored " << size_
-          << ". This means that another thread or process is writing data at "
-             "the same time it is being read.");
-  }
-
-  CHECK_H5(H5Sselect_none(dataspace_id),
-           "Failed to select none of the dataspace");
-  for (auto& column : these_columns) {
-    const std::array<hsize_t, 2> start{
-        {first_row, static_cast<hsize_t>(column)}};
-    // offset between blocks (have only one anyway)
-    const std::array<hsize_t, 2> stride{{1, 1}};
-    const std::array<hsize_t, 2> count{{1, 1}};
-    const std::array<hsize_t, 2> block{{num_rows, 1}};
-
-    CHECK_H5(H5Sselect_hyperslab(dataspace_id, H5S_SELECT_OR, start.data(),
-                                 stride.data(), count.data(), block.data()),
-             "Failed to select column " << column);
-  }
-
-  std::vector<double> raw_data(num_rows * num_cols);
-  const std::array<hsize_t, 2> memspace_size{{num_rows, num_cols}};
-  const hid_t memspace_id =
-      H5Screate_simple(2, memspace_size.data(), memspace_size.data());
-  CHECK_H5(memspace_id, "Failed to create memory space");
-  CHECK_H5(H5Dread(dataset_id_, h5_type<double>(), memspace_id, dataspace_id,
-                   h5::h5p_default(), raw_data.data()),
-           "Failed to read data subset");
-
-  CHECK_H5(H5Sclose(memspace_id), "Failed to close memory space");
-  CHECK_H5(H5Sclose(dataspace_id), "Failed to close dataspace");
-  return vector_to_matrix(raw_data,
-                          std::array<hsize_t, 2>{{num_rows, num_cols}});
+  return retrieve_dataset_subset(dataset_id_, these_columns, first_row,
+                                 num_rows, size_);
 }
 }  // namespace h5

--- a/src/IO/H5/Dat.hpp
+++ b/src/IO/H5/Dat.hpp
@@ -121,8 +121,6 @@ class Dat : public h5::Object {
   const std::string& subfile_path() const override { return path_; }
 
  private:
-  void append_impl(hsize_t number_of_rows, const std::vector<double>& data);
-
   /// \cond HIDDEN_SYMBOLS
   detail::OpenGroup group_;
   std::string name_;

--- a/src/IO/H5/Helpers.hpp
+++ b/src/IO/H5/Helpers.hpp
@@ -16,6 +16,7 @@
 
 /// \cond
 class DataVector;
+class Matrix;
 /// \endcond
 
 namespace h5 {
@@ -118,6 +119,29 @@ void write_connectivity(hid_t group_id, const std::vector<int>& connectivity);
  * \brief Delete the connectivity from the group in the H5 file
  */
 void delete_connectivity(hid_t group_id);
+
+/*!
+ * \ingroup HDF5Group
+ * \brief Append rows to an existing dataset
+ *
+ * \return std::array<hsize_t, 2> New size of the data in the file
+ */
+std::array<hsize_t, 2> append_to_dataset(
+    hid_t file_id, const std::string& name, const std::vector<double>& data,
+    hsize_t number_of_rows, const std::array<hsize_t, 2>& current_file_size);
+
+/// @{
+/*!
+ * \ingroup HDF5Group
+ * \brief Convert the data in a dataset to a Matrix
+ */
+Matrix retrieve_dataset(hid_t file_id, const std::array<hsize_t, 2>& file_size);
+
+Matrix retrieve_dataset_subset(hid_t file_id,
+                               const std::vector<size_t>& these_columns,
+                               size_t first_row, size_t num_rows,
+                               const std::array<hsize_t, 2>& file_size);
+/// @}
 
 /*!
  * \ingroup HDF5Group

--- a/src/IO/H5/Python/Bindings.cpp
+++ b/src/IO/H5/Python/Bindings.cpp
@@ -3,6 +3,7 @@
 
 #include <pybind11/pybind11.h>
 
+#include "IO/H5/Python/Cce.hpp"
 #include "IO/H5/Python/CombineH5.hpp"
 #include "IO/H5/Python/Dat.hpp"
 #include "IO/H5/Python/File.hpp"
@@ -18,6 +19,7 @@ PYBIND11_MODULE(_Pybindings, m) {  // NOLINT
   py::module_::import("spectre.Spectral");
   py_bindings::bind_h5file(m);
   py_bindings::bind_h5dat(m);
+  py_bindings::bind_h5cce(m);
   py_bindings::bind_h5vol(m);
   py_bindings::bind_tensordata(m);
   py_bindings::bind_h5combine(m);

--- a/src/IO/H5/Python/CMakeLists.txt
+++ b/src/IO/H5/Python/CMakeLists.txt
@@ -8,6 +8,7 @@ spectre_python_add_module(
   LIBRARY_NAME ${LIBRARY}
   SOURCES
   Bindings.cpp
+  Cce.cpp
   CombineH5.cpp
   Dat.cpp
   File.cpp
@@ -29,6 +30,7 @@ spectre_python_headers(
   ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
+  Cce.hpp
   CombineH5.hpp
   Dat.hpp
   File.hpp

--- a/src/IO/H5/Python/Cce.cpp
+++ b/src/IO/H5/Python/Cce.cpp
@@ -1,0 +1,42 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "IO/H5/Python/Cce.hpp"
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "DataStructures/Matrix.hpp"
+#include "IO/H5/Cce.hpp"
+
+namespace py = pybind11;
+
+namespace py_bindings {
+void bind_h5cce(py::module& m) {
+  // Wrapper for basic H5Cce operations
+  py::class_<h5::Cce>(m, "H5Cce")
+      .def("append", &h5::Cce::append, py::arg("data"))
+      .def("get_legend", &h5::Cce::get_legend)
+      .def("get_data", py::overload_cast<>(&h5::Cce::get_data, py::const_))
+      .def(
+          "get_data",
+          py::overload_cast<const std::string&>(&h5::Cce::get_data, py::const_),
+          py::arg("bondi_variable_name"))
+      .def("get_data_subset",
+           py::overload_cast<const std::vector<size_t>&, size_t, size_t>(
+               &h5::Cce::get_data_subset, py::const_),
+           py::arg("ell"), py::arg("first_row") = 0, py::arg("num_rows") = 1)
+      .def("get_data_subset",
+           py::overload_cast<const std::string&, const std::vector<size_t>&,
+                             size_t, size_t>(&h5::Cce::get_data_subset,
+                                             py::const_),
+           py::arg("bondi_variable_name"), py::arg("ell"),
+           py::arg("first_row") = 0, py::arg("num_rows") = 1)
+      .def("get_dimensions", &h5::Cce::get_dimensions)
+      .def("get_header", &h5::Cce::get_header)
+      .def("get_version", &h5::Cce::get_version);
+}
+}  // namespace py_bindings

--- a/src/IO/H5/Python/Cce.hpp
+++ b/src/IO/H5/Python/Cce.hpp
@@ -1,0 +1,11 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <pybind11/pybind11.h>
+
+namespace py_bindings {
+// NOLINTNEXTLINE(google-runtime-references)
+void bind_h5cce(pybind11::module& m);
+}  // namespace py_bindings

--- a/src/IO/H5/Python/File.cpp
+++ b/src/IO/H5/Python/File.cpp
@@ -9,6 +9,7 @@
 #include <string>
 #include <vector>
 
+#include "IO/H5/Cce.hpp"
 #include "IO/H5/Dat.hpp"
 #include "IO/H5/File.hpp"
 #include "IO/H5/VolumeData.hpp"
@@ -37,6 +38,14 @@ void bind_h5file_impl(py::module& m) {  // NOLINT
                 return f.template get<h5::Dat>(path);
               },
               py::return_value_policy::reference, py::arg("path"))
+          .def(
+              "get_cce",
+              [](const H5File& f, const std::string& path,
+                 const size_t l_max) -> const h5::Cce& {
+                return f.template get<h5::Cce>(path, l_max);
+              },
+              py::return_value_policy::reference, py::arg("path"),
+              py::arg("l_max"))
           .def("close_current_object", &H5File::close_current_object)
           .def("close", &H5File::close)
           .def("all_files",
@@ -46,6 +55,10 @@ void bind_h5file_impl(py::module& m) {  // NOLINT
           .def("all_dat_files",
                [](const H5File& f) -> const std::vector<std::string> {
                  return f.template all_files<h5::Dat>("/");
+               })
+          .def("all_cce_files",
+               [](const H5File& f) -> const std::vector<std::string> {
+                 return f.template all_files<h5::Cce>("/");
                })
           .def("all_vol_files",
                [](const H5File& f) -> const std::vector<std::string> {
@@ -61,11 +74,10 @@ void bind_h5file_impl(py::module& m) {  // NOLINT
               py::return_value_policy::reference, py::arg("path"))
           .def("input_source", &H5File::input_source)
           .def("__enter__", [](H5File& file) -> H5File& { return file; })
-          .def("__exit__", [](H5File& f, const py::object& /* exception_type */,
-                              const py::object& /* val */,
-                              const py::object& /* traceback */) {
-            f.close();
-          });
+          .def("__exit__",
+               [](H5File& f, const py::object& /* exception_type */,
+                  const py::object& /* val */,
+                  const py::object& /* traceback */) { f.close(); });
 
   if constexpr (Access_t == h5::AccessType::ReadWrite) {
     bind_h5_file
@@ -87,6 +99,22 @@ void bind_h5file_impl(py::module& m) {  // NOLINT
             },
             py::return_value_policy::reference, py::arg("path"),
             py::arg("legend"), py::arg("version"))
+        .def(
+            "insert_cce",
+            [](H5File& f, const std::string& path, const size_t l_max,
+               const uint32_t version) -> h5::Cce& {
+              return f.template insert<h5::Cce>(path, l_max, version);
+            },
+            py::return_value_policy::reference, py::arg("path"),
+            py::arg("l_max"), py::arg("version"))
+        .def(
+            "try_insert_cce",
+            [](H5File& f, const std::string& path, const size_t l_max,
+               const uint32_t version) -> h5::Cce& {
+              return f.template try_insert<h5::Cce>(path, l_max, version);
+            },
+            py::return_value_policy::reference, py::arg("path"),
+            py::arg("l_max"), py::arg("version"))
         .def(
             "insert_vol",
             [](H5File& f, const std::string& path,

--- a/tests/Unit/IO/H5/CMakeLists.txt
+++ b/tests/Unit/IO/H5/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY "Test_H5")
 
 set(LIBRARY_SOURCES
+  Test_Cce.cpp
   Test_CheckH5PropertiesMatch.cpp
   Test_Dat.cpp
   Test_EosTable.cpp

--- a/tests/Unit/IO/H5/Test_Cce.cpp
+++ b/tests/Unit/IO/H5/Test_Cce.cpp
@@ -1,0 +1,576 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <hdf5.h>
+#include <memory>
+#include <random>
+#include <regex>
+#include <sstream>
+#include <string>
+#include <typeinfo>
+#include <utility>
+#include <vector>
+
+#include "DataStructures/BoostMultiArray.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Matrix.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "IO/Connectivity.hpp"
+#include "IO/H5/AccessType.hpp"
+#include "IO/H5/Cce.hpp"
+#include "IO/H5/CheckH5.hpp"
+#include "IO/H5/Dat.hpp"
+#include "IO/H5/File.hpp"
+#include "IO/H5/Header.hpp"
+#include "IO/H5/Helpers.hpp"
+#include "IO/H5/OpenGroup.hpp"
+#include "IO/H5/SourceArchive.hpp"
+#include "IO/H5/Version.hpp"
+#include "IO/H5/Wrappers.hpp"
+#include "Informer/InfoFromBuild.hpp"
+#include "Utilities/Algorithm.hpp"
+#include "Utilities/FileSystem.hpp"
+#include "Utilities/Formaline.hpp"
+#include "Utilities/GetOutput.hpp"
+#include "Utilities/MakeString.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+void test_errors() {
+  std::string file_name{"./Unit.IO.H5.FileErrorObjectAlreadyExists.h5"};
+  CHECK_THROWS_WITH(
+      ([&file_name]() {
+        const uint32_t version_number = 4;
+        if (file_system::check_if_file_exists(file_name)) {
+          file_system::rm(file_name, true);
+        }
+        const size_t l_max = 4;
+        h5::H5File<h5::AccessType::ReadWrite> my_file(file_name);
+        {
+          auto& cce_file =
+              my_file.insert<h5::Cce>("/Bondi", l_max, version_number);
+          (void)cce_file;
+          my_file.close_current_object();
+        }
+        { my_file.insert<h5::Cce>("/Bondi//", l_max, version_number); }
+      }()),
+      Catch::Matchers::ContainsSubstring(
+          "Cannot insert an Object that already exists. Failed to "
+          "add Object named: /Bondi"));
+  if (file_system::check_if_file_exists(file_name)) {
+    file_system::rm(file_name, true);
+  }
+
+  file_name = "./Unit.IO.H5.FileErrorObjectAlreadyOpenGet.h5";
+  CHECK_THROWS_WITH(
+      [&file_name]() {
+        if (file_system::check_if_file_exists(file_name)) {
+          file_system::rm(file_name, true);
+        };
+        const size_t l_max = 4;
+        h5::H5File<h5::AccessType::ReadWrite> my_file(file_name);
+        auto& cce_file = my_file.insert<h5::Cce>("/DummyPath", l_max);
+        auto& get_cce_file = my_file.get<h5::Cce>("/DummyPath", l_max);
+        (void)cce_file;
+        (void)get_cce_file;
+      }(),
+      Catch::Matchers::ContainsSubstring(
+          "Object /DummyPath already open. Cannot open object /DummyPath."));
+  if (file_system::check_if_file_exists(file_name)) {
+    file_system::rm(file_name, true);
+  }
+
+  file_name = "./Unit.IO.H5.FileErrorObjectAlreadyOpenInsert.h5";
+  CHECK_THROWS_WITH(
+      [&file_name]() {
+        if (file_system::check_if_file_exists(file_name)) {
+          file_system::rm(file_name, true);
+        };
+        const size_t l_max = 4;
+        h5::H5File<h5::AccessType::ReadWrite> my_file(file_name);
+        auto& cce_file = my_file.insert<h5::Cce>("/DummyPath", l_max);
+        auto& cce_file2 = my_file.insert<h5::Cce>("/DummyPath2", l_max);
+        (void)cce_file;
+        (void)cce_file2;
+      }(),
+      Catch::Matchers::ContainsSubstring(
+          "Object /DummyPath already open. Cannot insert object "
+          "/DummyPath2."));
+  if (file_system::check_if_file_exists(file_name)) {
+    file_system::rm(file_name, true);
+  }
+
+  file_name = "./Unit.IO.H5.FileErrorObjectAlreadyOpenTryInsert.h5";
+  CHECK_THROWS_WITH(
+      [&file_name]() {
+        if (file_system::check_if_file_exists(file_name)) {
+          file_system::rm(file_name, true);
+        };
+        const size_t l_max = 4;
+        h5::H5File<h5::AccessType::ReadWrite> my_file(file_name);
+        auto& cce_file = my_file.insert<h5::Cce>("/DummyPath", l_max);
+        auto& cce_file2 = my_file.try_insert<h5::Cce>("/DummyPath2", l_max);
+        (void)cce_file;
+        (void)cce_file2;
+      }(),
+      Catch::Matchers::ContainsSubstring(
+          "Object /DummyPath already open. Cannot try to insert "
+          "object /DummyPath2."));
+  if (file_system::check_if_file_exists(file_name)) {
+    file_system::rm(file_name, true);
+  }
+
+  file_name = "./Unit.IO.H5.FileErrorObjectAlreadyOpen.h5";
+  CHECK_THROWS_WITH(
+      [&file_name]() {
+        if (file_system::check_if_file_exists(file_name)) {
+          file_system::rm(file_name, true);
+        };
+        const size_t l_max = 4;
+        h5::H5File<h5::AccessType::ReadWrite> my_file(file_name);
+        {
+          auto& cce_file = my_file.insert<h5::Cce>("/DummyPath", l_max);
+          my_file.close_current_object();
+          (void)cce_file;
+          auto& cce_file2 = my_file.insert<h5::Cce>("/Dummy/Path2", l_max);
+          my_file.close_current_object();
+          (void)cce_file2;
+        }
+        auto& cce_file2 = my_file.get<h5::Cce>("/Dummy/Path2", l_max);
+        auto& cce_file = my_file.get<h5::Cce>("/DummyPath", l_max);
+        (void)cce_file;
+        (void)cce_file2;
+      }(),
+      Catch::Matchers::ContainsSubstring(
+          "Object /Dummy/Path2 already open. Cannot open object /DummyPath."));
+  if (file_system::check_if_file_exists(file_name)) {
+    file_system::rm(file_name, true);
+  }
+
+  file_name = "./Unit.IO.H5.LegendsDontMatch.h5";
+  CHECK_THROWS_WITH(
+      [&file_name]() {
+        if (file_system::check_if_file_exists(file_name)) {
+          file_system::rm(file_name, true);
+        };
+        const size_t l_max = 4;
+        h5::H5File<h5::AccessType::ReadWrite> my_file(file_name);
+        {
+          auto& cce_file = my_file.insert<h5::Cce>("/DummyPath", l_max);
+          my_file.close_current_object();
+          (void)cce_file;
+          auto& cce_file2 = my_file.get<h5::Cce>("/DummyPath", l_max + 1);
+          (void)cce_file2;
+        }
+      }(),
+      Catch::Matchers::ContainsSubstring("l_max from cce file") and
+          Catch::Matchers::ContainsSubstring(
+              "does not match l_max in constructor"));
+  if (file_system::check_if_file_exists(file_name)) {
+    file_system::rm(file_name, true);
+  }
+
+  file_name = "./Unit.IO.H5.NoBondiVariable.h5";
+  CHECK_THROWS_WITH(
+      ([&file_name]() {
+        if (file_system::check_if_file_exists(file_name)) {
+          file_system::rm(file_name, true);
+        };
+        // Easy to make data
+        const size_t l_max = 0;
+        h5::H5File<h5::AccessType::ReadWrite> my_file(file_name);
+        {
+          auto& cce_file = my_file.insert<h5::Cce>("/Bondi", l_max);
+          std::unordered_map<std::string, std::vector<double>> data{};
+          data["News"] = std::vector<double>(3, 0.0);
+          cce_file.append(data);
+        }
+      }()),
+      Catch::Matchers::ContainsSubstring(
+          "Passed in data does not contain the bondi variable"));
+  if (file_system::check_if_file_exists(file_name)) {
+    file_system::rm(file_name, true);
+  }
+
+  file_name = "./Unit.IO.H5.IncorrectDataSize.h5";
+  CHECK_THROWS_WITH(
+      ([&file_name]() {
+        if (file_system::check_if_file_exists(file_name)) {
+          file_system::rm(file_name, true);
+        };
+        // Easy to make data
+        const size_t l_max = 0;
+        h5::H5File<h5::AccessType::ReadWrite> my_file(file_name);
+        {
+          auto& cce_file = my_file.insert<h5::Cce>("/Bondi", l_max);
+          std::unordered_map<std::string, std::vector<double>> data{};
+          // Incorrect vector length. Need all the vars or else we'll hit the
+          // previous error
+          data["EthInertialRetardedTime"] = std::vector<double>(10, 0.0);
+          data["News"] = std::vector<double>(10, 0.0);
+          data["Psi0"] = std::vector<double>(10, 0.0);
+          data["Psi1"] = std::vector<double>(10, 0.0);
+          data["Psi2"] = std::vector<double>(10, 0.0);
+          data["Psi3"] = std::vector<double>(10, 0.0);
+          data["Psi4"] = std::vector<double>(10, 0.0);
+          data["Strain"] = std::vector<double>(10, 0.0);
+          cce_file.append(data);
+        }
+      }()),
+      Catch::Matchers::ContainsSubstring(
+          "Cannot add columns to Cce files. Current number of columns is 3 but "
+          "received 10 entries"));
+  if (file_system::check_if_file_exists(file_name)) {
+    file_system::rm(file_name, true);
+  }
+
+  file_name = "./Unit.IO.H5.LTooLarge.h5";
+  CHECK_THROWS_WITH(
+      ([&file_name]() {
+        if (file_system::check_if_file_exists(file_name)) {
+          file_system::rm(file_name, true);
+        };
+        // Easy to make data
+        const size_t l_max = 0;
+        h5::H5File<h5::AccessType::ReadWrite> my_file(file_name);
+        {
+          auto& cce_file = my_file.insert<h5::Cce>("/Bondi", l_max);
+          std::unordered_map<std::string, std::vector<double>> data{};
+          data["EthInertialRetardedTime"] = std::vector<double>(3, 0.0);
+          data["News"] = std::vector<double>(3, 0.0);
+          data["Psi0"] = std::vector<double>(3, 0.0);
+          data["Psi1"] = std::vector<double>(3, 0.0);
+          data["Psi2"] = std::vector<double>(3, 0.0);
+          data["Psi3"] = std::vector<double>(3, 0.0);
+          data["Psi4"] = std::vector<double>(3, 0.0);
+          data["Strain"] = std::vector<double>(3, 0.0);
+          cce_file.append(data);
+          const auto subset = cce_file.get_data_subset("Psi0", {2}, 0);
+          (void)subset;
+        }
+      }()),
+      Catch::Matchers::ContainsSubstring("One (or more) of the requested ells "
+                                         "(2) is larger than the l_max 0"));
+  if (file_system::check_if_file_exists(file_name)) {
+    file_system::rm(file_name, true);
+  }
+
+  file_name = "./Unit.IO.H5.IncorrectBondiVarDim.h5";
+  CHECK_THROWS_WITH(
+      [&file_name]() {
+        if (file_system::check_if_file_exists(file_name)) {
+          file_system::rm(file_name, true);
+        };
+        // Easy to make data
+        const size_t l_max = 0;
+        h5::H5File<h5::AccessType::ReadWrite> my_file(file_name);
+        {
+          auto& cce_file = my_file.insert<h5::Cce>("/Bondi", l_max);
+          const auto size = cce_file.get_dimensions("NonExistentBondiVar");
+          (void)size;
+        }
+      }(),
+      Catch::Matchers::ContainsSubstring(
+          "Requested bondi variable NonExistentBondiVar not available"));
+  if (file_system::check_if_file_exists(file_name)) {
+    file_system::rm(file_name, true);
+  }
+}
+
+void check_written_data(
+    const h5::Cce& cce_file,
+    const std::unordered_map<std::string, std::vector<std::vector<double>>>
+        expected_data,
+    const std::unordered_set<std::string>& bondi_variables,
+    const std::vector<std::string>& legend, const size_t version_number) {
+  // Check version info is correctly retrieved from Cce file
+  CHECK(cce_file.get_version() == version_number);
+
+  // Check getting the header from Cce file
+  std::stringstream ss;
+  ss << "# ";
+  auto build_info = info_from_build();
+  ss << std::regex_replace(build_info, std::regex{"\n"}, "\n# ");
+  const auto& header = cce_file.get_header();
+  CHECK(header.starts_with("#\n# File created on "));
+  CHECK(header.ends_with(ss.str()));
+
+  CHECK(cce_file.get_legend() == legend);
+
+  // Check data is retrieved correctly from Cce file
+  std::array<hsize_t, 2> size_of_data{{4, legend.size()}};
+  for (const std::string& bondi_var : bondi_variables) {
+    CHECK(cce_file.get_dimensions(bondi_var) == size_of_data);
+  }
+
+  const std::unordered_map<std::string, Matrix> data_in_cce_file =
+      [&expected_data, &legend, &bondi_variables]() {
+        std::unordered_map<std::string, Matrix> result{};
+        for (const std::string& bondi_var : bondi_variables) {
+          Matrix matrix_result(4, legend.size());
+          for (size_t row = 0; row < matrix_result.rows(); row++) {
+            for (size_t col = 0; col < legend.size(); col++) {
+              matrix_result(row, col) = expected_data.at(bondi_var)[row][col];
+            }
+          }
+
+          result[bondi_var] = std::move(matrix_result);
+        }
+        return result;
+      }();
+
+  CHECK(cce_file.get_data() == data_in_cce_file);
+  for (const std::string& bondi_var : bondi_variables) {
+    CHECK(cce_file.get_data(bondi_var) == data_in_cce_file.at(bondi_var));
+  }
+
+  // Just ell = 2
+  {
+    const std::unordered_map<std::string, Matrix> expected_subset =
+        [&expected_data, &bondi_variables]() {
+          std::unordered_map<std::string, Matrix> result{};
+          for (const std::string& bondi_var : bondi_variables) {
+            Matrix matrix_result(2, 11);
+            size_t row = 1;
+            for (size_t row_idx = 0; row_idx < 2; row_idx++, row++) {
+              // time
+              matrix_result(row_idx, 0) = expected_data.at(bondi_var)[row][0];
+              size_t col = 9;
+              for (size_t col_idx = 1; col_idx < 11; col_idx++, col++) {
+                matrix_result(row_idx, col_idx) =
+                    expected_data.at(bondi_var)[row][col];
+              }
+            }
+
+            result[bondi_var] = std::move(matrix_result);
+          }
+
+          return result;
+        }();
+
+    const auto subset = cce_file.get_data_subset({2}, 1, 2);
+    CHECK(subset == expected_subset);
+    for (const std::string& bondi_var : bondi_variables) {
+      CHECK(cce_file.get_data_subset(bondi_var, {2}, 1, 2) ==
+            expected_subset.at(bondi_var));
+    }
+  }
+  // ell = 1,3
+  {
+    const std::unordered_map<std::string, Matrix> expected_subset =
+        [&expected_data, &bondi_variables]() {
+          std::unordered_map<std::string, Matrix> result{};
+          for (const std::string& bondi_var : bondi_variables) {
+            Matrix matrix_result(3, 21);
+            size_t row = 1;
+            for (size_t row_idx = 0; row_idx < 3; row_idx++, row++) {
+              // time
+              matrix_result(row_idx, 0) = expected_data.at(bondi_var)[row][0];
+              // ell = 1
+              size_t col = 3;
+              for (size_t col_idx = 1; col_idx < 7; col_idx++, col++) {
+                matrix_result(row_idx, col_idx) =
+                    expected_data.at(bondi_var)[row][col];
+              }
+              // ell = 3
+              col = 19;
+              for (size_t col_idx = 7; col_idx < 21; col_idx++, col++) {
+                matrix_result(row_idx, col_idx) =
+                    expected_data.at(bondi_var)[row][col];
+              }
+            }
+
+            result[bondi_var] = std::move(matrix_result);
+          }
+
+          return result;
+        }();
+
+    const auto subset = cce_file.get_data_subset({1, 3}, 1, 3);
+    CHECK(subset == expected_subset);
+    for (const std::string& bondi_var : bondi_variables) {
+      CHECK(cce_file.get_data_subset(bondi_var, {1, 3}, 1, 3) ==
+            expected_subset.at(bondi_var));
+    }
+  }
+  // ell = 0,2
+  {
+    const std::unordered_map<std::string, Matrix> expected_subset =
+        [&expected_data, &bondi_variables]() {
+          std::unordered_map<std::string, Matrix> result{};
+          for (const std::string& bondi_var : bondi_variables) {
+            Matrix matrix_result(2, 13);
+            size_t row = 0;
+            for (size_t row_idx = 0; row_idx < 2; row_idx++, row++) {
+              // time
+              matrix_result(row_idx, 0) = expected_data.at(bondi_var)[row][0];
+              // ell = 0
+              size_t col = 1;
+              for (size_t col_idx = 1; col_idx < 3; col_idx++, col++) {
+                matrix_result(row_idx, col_idx) =
+                    expected_data.at(bondi_var)[row][col];
+              }
+
+              // ell = 2
+              col = 9;
+              for (size_t col_idx = 3; col_idx < 13; col_idx++, col++) {
+                matrix_result(row_idx, col_idx) =
+                    expected_data.at(bondi_var)[row][col];
+              }
+            }
+
+            result[bondi_var] = std::move(matrix_result);
+          }
+
+          return result;
+        }();
+
+    const auto subset = cce_file.get_data_subset({0, 2}, 0, 2);
+    CHECK(subset == expected_subset);
+    for (const std::string& bondi_var : bondi_variables) {
+      CHECK(cce_file.get_data_subset(bondi_var, {0, 2}, 0, 2) ==
+            expected_subset.at(bondi_var));
+    }
+  }
+  // No ell
+  {
+    const auto subset = cce_file.get_data_subset({}, 0, 2);
+    const Matrix answer(2, 0, 0.0);
+    const std::unordered_map<std::string, Matrix> expected_subset =
+        [&answer, &bondi_variables]() {
+          std::unordered_map<std::string, Matrix> result{};
+          for (const std::string& bondi_var : bondi_variables) {
+            result[bondi_var] = answer;
+          }
+          return result;
+        }();
+    CHECK(subset == expected_subset);
+    for (const std::string& bondi_var : bondi_variables) {
+      CHECK(cce_file.get_data_subset(bondi_var, {}, 0, 2) == answer);
+    }
+  }
+  // No rows
+  {
+    const auto subset = cce_file.get_data_subset({0, 3}, 0, 0);
+    const Matrix answer(0, 17, 0.0);
+    const std::unordered_map<std::string, Matrix> expected_subset =
+        [&answer, &bondi_variables]() {
+          std::unordered_map<std::string, Matrix> result{};
+          for (const std::string& bondi_var : bondi_variables) {
+            result[bondi_var] = answer;
+          }
+          return result;
+        }();
+    CHECK(subset == expected_subset);
+    for (const std::string& bondi_var : bondi_variables) {
+      CHECK(cce_file.get_data_subset(bondi_var, {0, 3}, 0, 0) == answer);
+    }
+  }
+}
+
+template <typename Generator>
+void test_core_functionality(const gsl::not_null<Generator*> generator) {
+  const std::unordered_set<std::string> bondi_variables{
+      "EthInertialRetardedTime",
+      "News",
+      "Psi0",
+      "Psi1",
+      "Psi2",
+      "Psi3",
+      "Psi4",
+      "Strain"};
+
+  const std::string h5_file_name("Unit.IO.H5.Cce.h5");
+  const uint32_t version_number = 4;
+  if (file_system::check_if_file_exists(h5_file_name)) {
+    file_system::rm(h5_file_name, true);
+  }
+  const size_t l_max = 4;
+  std::vector<std::string> legend{
+      "time",        "Real Y_0,0",  "Imag Y_0,0",  "Real Y_1,-1", "Imag Y_1,-1",
+      "Real Y_1,0",  "Imag Y_1,0",  "Real Y_1,1",  "Imag Y_1,1",  "Real Y_2,-2",
+      "Imag Y_2,-2", "Real Y_2,-1", "Imag Y_2,-1", "Real Y_2,0",  "Imag Y_2,0",
+      "Real Y_2,1",  "Imag Y_2,1",  "Real Y_2,2",  "Imag Y_2,2",  "Real Y_3,-3",
+      "Imag Y_3,-3", "Real Y_3,-2", "Imag Y_3,-2", "Real Y_3,-1", "Imag Y_3,-1",
+      "Real Y_3,0",  "Imag Y_3,0",  "Real Y_3,1",  "Imag Y_3,1",  "Real Y_3,2",
+      "Imag Y_3,2",  "Real Y_3,3",  "Imag Y_3,3",  "Real Y_4,-4", "Imag Y_4,-4",
+      "Real Y_4,-3", "Imag Y_4,-3", "Real Y_4,-2", "Imag Y_4,-2", "Real Y_4,-1",
+      "Imag Y_4,-1", "Real Y_4,0",  "Imag Y_4,0",  "Real Y_4,1",  "Imag Y_4,1",
+      "Real Y_4,2",  "Imag Y_4,2",  "Real Y_4,3",  "Imag Y_4,3",  "Real Y_4,4",
+      "Imag Y_4,4"};
+
+  const auto create_data =
+      [&legend, &generator](const size_t row) -> std::vector<double> {
+    std::uniform_real_distribution<double> dist{static_cast<double>(row),
+                                                static_cast<double>(row + 1)};
+    std::vector<double> result(legend.size());
+    result[0] = static_cast<double>(row);
+    for (size_t i = 1; i < legend.size(); i++) {
+      result[i] = dist(*generator);
+    }
+    return result;
+  };
+
+  std::unordered_map<std::string, std::vector<std::vector<double>>>
+      expected_data{};
+  {
+    h5::H5File<h5::AccessType::ReadWrite> my_file(h5_file_name);
+    my_file.insert<h5::Cce>("/Bondi", l_max, version_number);
+    my_file.close_current_object();
+
+    // Check that the Cce file is found to be a subgroup of the file.
+    const auto groups_in_file = my_file.groups();
+    CHECK(alg::find(groups_in_file, std::string{"Bondi.cce"}) !=
+          groups_in_file.end());
+
+    auto& cce_file = my_file.get<h5::Cce>("/Bondi", l_max, version_number);
+
+    CHECK(legend == cce_file.get_legend());
+
+    std::unordered_map<std::string, std::vector<double>> tmp_data{};
+    for (const std::string& bondi_var : bondi_variables) {
+      expected_data[bondi_var] = std::vector<std::vector<double>>(4);
+      tmp_data[bondi_var];
+    }
+
+    for (size_t i = 0; i < 4; i++) {
+      for (const std::string& bondi_var : bondi_variables) {
+        tmp_data.at(bondi_var) = create_data(i);
+        expected_data.at(bondi_var)[i] = tmp_data.at(bondi_var);
+      }
+      cce_file.append(tmp_data);
+    }
+
+    // Test with ReadWrite access
+    check_written_data(cce_file, expected_data, bondi_variables, legend,
+                       version_number);
+  }
+
+  // Test with ReadOnly access
+  {
+    h5::H5File<h5::AccessType::ReadOnly> my_file(h5_file_name);
+    const auto& cce_file =
+        my_file.get<h5::Cce>("Bondi.cce", l_max, version_number);
+
+    check_written_data(cce_file, expected_data, bondi_variables, legend,
+                       version_number);
+  }
+
+  if (file_system::check_if_file_exists(h5_file_name)) {
+    file_system::rm(h5_file_name, true);
+  }
+}
+}  // namespace
+
+// [[TimeOut, 10]]
+SPECTRE_TEST_CASE("Unit.IO.H5.Cce", "[Unit][IO][H5]") {
+  MAKE_GENERATOR(generator);
+  test_errors();
+  test_core_functionality(make_not_null(&generator));
+}

--- a/tests/Unit/IO/H5/Test_H5.py
+++ b/tests/Unit/IO/H5/Test_H5.py
@@ -20,6 +20,25 @@ class TestIOH5File(unittest.TestCase):
         self.data_1_array = np.array(self.data_1)
         self.data_2 = [3.0, 10.3]
         self.data_2_array = np.array(self.data_2)
+        self.l_max = 2
+        self.bondi_variables = [
+            "EthInertialRetardedTime",
+            "News",
+            "Psi0",
+            "Psi1",
+            "Psi2",
+            "Psi3",
+            "Psi4",
+            "Strain",
+        ]
+        self.cce_data_1 = {
+            name: np.array([i] * 19)
+            for i, name in enumerate(self.bondi_variables)
+        }
+        self.cce_data_2 = {
+            name: np.array([i + 1] * 19)
+            for i, name in enumerate(self.bondi_variables)
+        }
         if os.path.isfile(self.file_name):
             os.remove(self.file_name)
 
@@ -40,8 +59,14 @@ class TestIOH5File(unittest.TestCase):
             )
             self.assertEqual(datfile.get_version(), 0)
 
+    # Test whether a cce file can be added correctly
+    def test_insert_cce(self):
+        with spectre_h5.H5File(file_name=self.file_name, mode="a") as h5file:
+            ccefile = h5file.insert_cce(path="/cce_data", l_max=2, version=0)
+            self.assertEqual(ccefile.get_version(), 0)
+
     # Test whether data can be added to the dat file correctly
-    def test_append(self):
+    def test_append_dat(self):
         with spectre_h5.H5File(file_name=self.file_name, mode="a") as h5file:
             datfile = h5file.insert_dat(
                 path="/element_data", legend=["Time", "Value"], version=0
@@ -50,8 +75,24 @@ class TestIOH5File(unittest.TestCase):
             outdata_array = np.asarray(datfile.get_data())
             npt.assert_array_equal(outdata_array[0], self.data_1_array)
 
+    # Test whether data can be added to the cce file correctly
+    def test_append_cce(self):
+        with spectre_h5.H5File(file_name=self.file_name, mode="a") as h5file:
+            ccefile = h5file.insert_cce(
+                path="/cce_data", l_max=self.l_max, version=0
+            )
+            ccefile.append(self.cce_data_1)
+            outdata_dict = ccefile.get_data()
+            for name in self.bondi_variables:
+                self.assertIn(name, outdata_dict)
+                npt.assert_array_equal(
+                    np.asarray(outdata_dict[name])[0], self.cce_data_1[name]
+                )
+                outdata = np.asarray(ccefile.get_data(name))[0]
+                npt.assert_array_equal(outdata, self.cce_data_1[name])
+
     # More complicated test case for getting data subsets and dimensions
-    def test_get_data_subset(self):
+    def test_get_data_subset_dat(self):
         with spectre_h5.H5File(file_name=self.file_name, mode="a") as h5file:
             datfile = h5file.insert_dat(
                 path="/element_data", legend=["Time", "Value"], version=0
@@ -66,6 +107,31 @@ class TestIOH5File(unittest.TestCase):
             )
             self.assertEqual(datfile.get_dimensions()[0], 2)
 
+    # More complicated test case for getting cce subsets and dimensions
+    def test_get_data_subset_cce(self):
+        with spectre_h5.H5File(file_name=self.file_name, mode="a") as h5file:
+            ccefile = h5file.insert_cce(
+                path="/cce_data", l_max=self.l_max, version=0
+            )
+            ccefile.append(self.cce_data_1)
+            ccefile.append(self.cce_data_2)
+            outdata_dict = ccefile.get_data_subset(
+                ell=[0, 1], first_row=0, num_rows=2
+            )
+            for name in self.bondi_variables:
+                self.assertIn(name, outdata_dict)
+                expected = np.array(
+                    [self.cce_data_1[name][:9], self.cce_data_2[name][:9]],
+                )
+                npt.assert_array_equal(outdata_dict[name], expected)
+                outdata = np.asarray(
+                    ccefile.get_data_subset(
+                        name, ell=[0, 1], first_row=0, num_rows=2
+                    )
+                )
+                npt.assert_array_equal(outdata, expected)
+                self.assertEqual(ccefile.get_dimensions(name)[0], 2)
+
     # Getting Attributes
     def test_get_legend(self):
         with spectre_h5.H5File(file_name=self.file_name, mode="a") as h5file:
@@ -74,6 +140,35 @@ class TestIOH5File(unittest.TestCase):
             )
             self.assertEqual(datfile.get_legend(), ["Time", "Value"])
             self.assertEqual(datfile.get_version(), 0)
+            h5file.close_current_object()
+            ccefile = h5file.insert_cce(
+                path="/cce_data", l_max=self.l_max, version=0
+            )
+            self.assertEqual(
+                ccefile.get_legend(),
+                [
+                    "time",
+                    "Real Y_0,0",
+                    "Imag Y_0,0",
+                    "Real Y_1,-1",
+                    "Imag Y_1,-1",
+                    "Real Y_1,0",
+                    "Imag Y_1,0",
+                    "Real Y_1,1",
+                    "Imag Y_1,1",
+                    "Real Y_2,-2",
+                    "Imag Y_2,-2",
+                    "Real Y_2,-1",
+                    "Imag Y_2,-1",
+                    "Real Y_2,0",
+                    "Imag Y_2,0",
+                    "Real Y_2,1",
+                    "Imag Y_2,1",
+                    "Real Y_2,2",
+                    "Imag Y_2,2",
+                ],
+            )
+            self.assertEqual(ccefile.get_version(), 0)
 
     # The header is not universal, just checking the part that is predictable
     def test_get_header(self):
@@ -82,6 +177,11 @@ class TestIOH5File(unittest.TestCase):
                 path="/element_data", legend=["Time", "Value"], version=0
             )
             self.assertEqual(datfile.get_header()[0:16], "#\n# File created")
+            h5file.close_current_object()
+            ccefile = h5file.insert_cce(
+                path="/cce_data", l_max=self.l_max, version=0
+            )
+            self.assertEqual(ccefile.get_header()[0:16], "#\n# File created")
 
     def test_all_files(self):
         with spectre_h5.H5File(file_name=self.file_name, mode="a") as h5file:
@@ -94,6 +194,8 @@ class TestIOH5File(unittest.TestCase):
             legend = ["Fake"]
             h5file.insert_dat(path="/root_dat", legend=legend, version=0)
             h5file.close_current_object()
+            h5file.insert_cce(path="/root_cce", l_max=self.l_max, version=0)
+            h5file.close_current_object()
             h5file.insert_dat(
                 path="/group0/sub_dat_1", legend=legend, version=0
             )
@@ -102,11 +204,22 @@ class TestIOH5File(unittest.TestCase):
                 path="/group0/sub_dat_2", legend=legend, version=0
             )
             h5file.close_current_object()
+            h5file.insert_cce(
+                path="/group0/sub_cce_1", l_max=self.l_max, version=0
+            )
+            h5file.close_current_object()
+            h5file.insert_cce(
+                path="/group0/sub_cce_2", l_max=self.l_max, version=0
+            )
+            h5file.close_current_object()
 
             expected_all_files = [
+                "/group0/sub_cce_1.cce",
+                "/group0/sub_cce_2.cce",
                 "/group0/sub_dat_1.dat",
                 "/group0/sub_dat_2.dat",
                 "/group0/sub_vol.vol",
+                "/root_cce.cce",
                 "/root_dat.dat",
                 "/root_vol_1.vol",
                 "/root_vol_2.vol",
@@ -117,6 +230,11 @@ class TestIOH5File(unittest.TestCase):
                 "/group0/sub_dat_2.dat",
                 "/root_dat.dat",
             ]
+            expected_cce_files = [
+                "/group0/sub_cce_1.cce",
+                "/group0/sub_cce_2.cce",
+                "/root_cce.cce",
+            ]
             expected_vol_files = [
                 "/group0/sub_vol.vol",
                 "/root_vol_1.vol",
@@ -125,10 +243,12 @@ class TestIOH5File(unittest.TestCase):
 
             all_files = h5file.all_files()
             dat_files = h5file.all_dat_files()
+            cce_files = h5file.all_cce_files()
             vol_files = h5file.all_vol_files()
 
             self.assertEqual(all_files, expected_all_files)
             self.assertEqual(dat_files, expected_dat_files)
+            self.assertEqual(cce_files, expected_cce_files)
             self.assertEqual(vol_files, expected_vol_files)
 
     def test_groups(self):
@@ -145,7 +265,16 @@ class TestIOH5File(unittest.TestCase):
                 path="/element_size", legend=["Time", "Size"], version=0
             )
             h5file.close_current_object()
+            h5file.insert_cce(path="/cce_1", l_max=self.l_max, version=0)
+            h5file.close_current_object()
+            h5file.insert_cce(path="/cce_2", l_max=self.l_max, version=0)
+            h5file.close_current_object()
+            h5file.insert_cce(path="/cce_3", l_max=self.l_max, version=0)
+            h5file.close_current_object()
             groups_spec = [
+                "cce_1.cce",
+                "cce_2.cce",
+                "cce_3.cce",
                 "element_data.dat",
                 "element_position.dat",
                 "element_size.dat",
@@ -181,6 +310,23 @@ class TestIOH5File(unittest.TestCase):
                 "Cannot open the object '/element_dat.vol' because it",
             ):
                 h5file.get_vol("/element_dat")
+
+            h5file.close_current_object()
+            h5file.insert_cce(path="/cce_data", l_max=self.l_max, version=0)
+
+            # insert existing cce file
+            with self.assertRaisesRegex(
+                RuntimeError, "/cce_data already open. Cannot insert object"
+            ):
+                h5file.insert_cce(path="/cce_data", l_max=self.l_max, version=0)
+            h5file.close_current_object()
+
+            # grab non-existing cce file
+            with self.assertRaisesRegex(
+                RuntimeError,
+                "Cannot open the object '/cce.cce' because it",
+            ):
+                h5file.get_cce("/cce", self.l_max)
 
             h5file.close_current_object()
             h5file.insert_vol(path="/volume_data", version=0)


### PR DESCRIPTION
## Proposed changes

This new H5 file type will help streamline the usage of waveform output from the CCE executable within the [sxs](https://github.com/sxs-collaboration/sxs) and [scri](https://github.com/moble/scri) python packages.

These new Cce subfile is basically just a group that holds datasets for the bondi variables. The group and the datasets have attributes that the python packages will look for.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
