### PR TITLE
Static libsz and libaec, switch to HDF5::HDF5 in cmake, rename ENABLE_SPECTRE_DEBUG to SPECTRE_DEBUG in cmake, fix incorrect CCE assert

### DIFF
--- a/cmake/SetupCxxFlags.cmake
+++ b/cmake/SetupCxxFlags.cmake
@@ -5,14 +5,14 @@ option(DEBUG_SYMBOLS "Add -g to CMAKE_CXX_FLAGS if ON, -g0 if OFF." ON)
 
 option(OVERRIDE_ARCH "The architecture to use. Default is native." OFF)
 
-option(ENABLE_SPECTRE_DEBUG "Enable ASSERTs and other SPECTRE_DEBUG options"
+option(SPECTRE_DEBUG "Enable ASSERTs and other SPECTRE_DEBUG options"
   OFF)
 
 if (CMAKE_BUILD_TYPE STREQUAL "Debug")
-  set(ENABLE_SPECTRE_DEBUG ON)
+  set(SPECTRE_DEBUG ON)
 endif()
 
-if(${ENABLE_SPECTRE_DEBUG})
+if(${SPECTRE_DEBUG})
   set_property(TARGET SpectreFlags
     APPEND PROPERTY INTERFACE_COMPILE_DEFINITIONS SPECTRE_DEBUG)
 endif()

--- a/cmake/SetupHdf5.cmake
+++ b/cmake/SetupHdf5.cmake
@@ -119,7 +119,7 @@ endif()
 
 set_property(
   GLOBAL APPEND PROPERTY SPECTRE_THIRD_PARTY_LIBS
-  hdf5::hdf5
+  HDF5::HDF5
   )
 
 file(APPEND

--- a/cmake/SetupPch.cmake
+++ b/cmake/SetupPch.cmake
@@ -47,7 +47,7 @@ target_link_libraries(
   Brigand
   Charmxx::charmxx
   Charmxx::pup
-  hdf5::hdf5
+  HDF5::HDF5
   SpectreFlags
   )
 

--- a/docs/DevGuide/BuildSystem.md
+++ b/docs/DevGuide/BuildSystem.md
@@ -249,7 +249,7 @@ cmake -D FLAG1=OPT1 ... -D FLAGN=OPTN <SPECTRE_ROOT>
 - ENABLE_PROFILING
   - Enables various options to make profiling SpECTRE easier
     (default is `OFF`)
-- ENABLE_SPECTRE_DEBUG
+- SPECTRE_DEBUG
   - Defines `SPECTRE_DEBUG` macro to enable `ASSERT`s and other debug
     checks so they can be used in Release builds. That is, you get sanity checks
     and compiler optimizations. You cannot disable the checks in Debug builds,

--- a/src/Evolution/Systems/Cce/WorldtubeBufferUpdater.cpp
+++ b/src/Evolution/Systems/Cce/WorldtubeBufferUpdater.cpp
@@ -39,9 +39,11 @@ std::pair<size_t, size_t> create_span_for_time_value(
       lower_bound < upper_bound,
       "The supplied `lower_bound` is greater than `upper_bound`, which is not "
       "permitted");
-  ASSERT(2 * interpolator_length + pad < upper_bound,
+  ASSERT(2 * interpolator_length + pad <= upper_bound,
          "The combined `interpolator_length` and `pad` is too large for the "
-         "supplied `upper_bound`");
+         "supplied `upper_bound`.\nupper_bound="
+             << upper_bound << "\npad=" << pad
+             << "\ninterpolator_length=" << interpolator_length);
 
   size_t range_start = lower_bound;
   size_t range_end = upper_bound;

--- a/src/IO/H5/CMakeLists.txt
+++ b/src/IO/H5/CMakeLists.txt
@@ -59,7 +59,7 @@ target_link_libraries(
   DataStructures
   DomainStructure
   ErrorHandling
-  hdf5::hdf5
+  HDF5::HDF5
   Serialization
   Spectral
   Utilities

--- a/src/Utilities/CMakeLists.txt
+++ b/src/Utilities/CMakeLists.txt
@@ -101,7 +101,7 @@ target_link_libraries(
 # As of Sep 1, 2023 libxsmm has an issue with lldb on ARM Macs (detecting
 # the CPU architecture raises SIGILL signals when loading the libxsmm dynamic
 # library). Just not linking libxsmm in Debug mode works around that.
-if (NOT ENABLE_SPECTRE_DEBUG
+if (NOT SPECTRE_DEBUG
     OR NOT (APPLE AND CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "arm64"))
   target_link_libraries(
     ${LIBRARY}


### PR DESCRIPTION
## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
