### PR TITLE
Upgrade to Apple Silicon on CI, simplify Apple Silicon installation instructions

### DIFF
--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -598,7 +598,7 @@ jobs:
         run: |
           apt-get install -y libopenmpi-dev
           cd /work/charm_7_0_0 && ./build charm++ mpi-linux-x86_64-smp clang \
-          -j4 -g0 -O1 --build-shared --with-production
+          -j ${NUMBER_OF_CORES} -g0 -O1 --build-shared --with-production
 
       # Assign a unique cache key for every run.
       # - We will save the cache using this unique key, but only on the develop
@@ -874,17 +874,27 @@ ${{ matrix.build_type }}-pch-${{ matrix.use_pch || 'ON' }}"
   # Build all test executables and run unit tests on macOS
   unit_tests_macos:
     name: Unit tests on macOS
-    runs-on: macos-13
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # The number of cores is given at:
+          # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
+          - arch: x86
+            macos-version: 13  # Intel
+            NUM_CORES: 4
+          - arch: arm64
+            macos-version: 14  # Apple Silicon
+            NUM_CORES: 3
+    runs-on: macos-${{ matrix.macos-version }}
     env:
       # We install some low-level dependencies with Homebrew. They get picked up
       # by `spack external find`.
       SPECTRE_BREW_DEPS: >-  # Line breaks are spaces, no trailing newline
-        autoconf automake catch2 ccache cmake pkg-config boost
+        autoconf automake boost catch2 ccache cmake gsl hdf5 openblas yaml-cpp
       # We install these packages with Spack and cache them. The full specs are
-      # listed in support/DevEnvironments/spack.yaml. This list is only needed
-      # to create the cache.
-      SPECTRE_SPACK_DEPS: >-
-        blaze charmpp gsl hdf5 libxsmm openblas yaml-cpp
+      # listed below. This list is only needed to create the cache.
+      SPECTRE_SPACK_DEPS: blaze charmpp libxsmm
       CCACHE_DIR: $HOME/ccache
       CCACHE_TEMPDIR: $HOME/ccache-tmp
       CCACHE_MAXSIZE: "2G"
@@ -893,6 +903,7 @@ ${{ matrix.build_type }}-pch-${{ matrix.use_pch || 'ON' }}"
       CCACHE_COMPILERCHECK: content
       SPACK_SKIP_MODULES: true
       SPACK_COLOR: always
+      NUM_CORES: ${{ matrix.NUM_CORES }}
     steps:
       - name: Record start time
         id: start
@@ -902,7 +913,7 @@ ${{ matrix.build_type }}-pch-${{ matrix.use_pch || 'ON' }}"
         uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: '3.12'
       - name: Install Homebrew dependencies
         run: |
           brew install $SPECTRE_BREW_DEPS
@@ -911,17 +922,22 @@ ${{ matrix.build_type }}-pch-${{ matrix.use_pch || 'ON' }}"
       - name: Restore dependency cache
         uses: actions/cache/restore@v4
         id: restore-dependencies
+        env:
+          CACHE_KEY_PREFIX: "dependencies-macos-${{ matrix.macos-version }}"
         with:
           path: ~/dependencies
-          key: "dependencies-macos-${{ github.run_id }}"
+          key: "${{ env.CACHE_KEY_PREFIX }}-${{ github.run_id }}"
           restore-keys: |
-            dependencies-macos-
+            ${{ env.CACHE_KEY_PREFIX }}-
       - name: Install Spack
+        # Pin a specific version of Spack to avoid breaking CI builds when
+        # Spack changes.
         run: |
           cd $HOME
-          git clone -c feature.manyFiles=true --depth=1 \
-            --branch releases/v0.18 --single-branch \
+          git clone -c feature.manyFiles=true \
             https://github.com/spack/spack.git
+          cd spack
+          git checkout 7d1de58378fa210b7db887964fcc17187a504ad8
       - name: Configure Spack
         # - To avoid re-building packages that are already installed by Homebrew
         #   we let Spack find them.
@@ -930,7 +946,7 @@ ${{ matrix.build_type }}-pch-${{ matrix.use_pch || 'ON' }}"
           source $HOME/spack/share/spack/setup-env.sh
           spack debug report
           spack compiler find && spack compiler list
-          spack external find && spack external find perl python
+          spack external find
           spack config get packages
           spack mirror add dependencies file://$HOME/dependencies/spack
       # Install the remaining dependencies from source with Spack. We install
@@ -939,9 +955,12 @@ ${{ matrix.build_type }}-pch-${{ matrix.use_pch || 'ON' }}"
       - name: Install Spack dependencies
         run: |
           source $HOME/spack/share/spack/setup-env.sh
-          spack env create spectre support/DevEnvironments/spack.yaml
+          spack env create spectre
           spack env activate spectre
-          spack remove catch2 doxygen jemalloc boost
+          spack add blaze@3.8.2 ~blas ~lapack smp=none
+          spack add charmpp@7.0.0 +shared backend=multicore build-target=charm++
+          # Use main branch until spack has 2.0 release
+          spack add libxsmm@main
           spack concretize --reuse
           spack install --no-check-signature
           spack find -v
@@ -979,11 +998,13 @@ ${{ matrix.build_type }}-pch-${{ matrix.use_pch || 'ON' }}"
       - name: Restore ccache
         uses: actions/cache/restore@v4
         id: restore-ccache
+        env:
+          CACHE_KEY_PREFIX: "ccache-macos-${{ matrix.macos-version }}"
         with:
           path: ~/ccache
-          key: "ccache-macos-${{ github.run_id }}"
+          key: "${{ env.CACHE_KEY_PREFIX }}-${{ github.run_id }}"
           restore-keys: |
-            ccache-macos-
+            ${{ env.CACHE_KEY_PREFIX }}-
       - name: Configure ccache
         run: |
           ccache -pz
@@ -1008,11 +1029,12 @@ ${{ matrix.build_type }}-pch-${{ matrix.use_pch || 'ON' }}"
             -D CMAKE_CXX_COMPILER=clang++ \
             -D CMAKE_Fortran_COMPILER=gfortran-14 \
             -D CMAKE_CXX_FLAGS="-Werror" \
-            -D OVERRIDE_ARCH=x86-64 \
             -D BUILD_SHARED_LIBS=ON \
             -D BUILD_PYTHON_BINDINGS=ON \
             -D MEMORY_ALLOCATOR=SYSTEM \
             -D CHARM_ROOT=$(spack location --install-dir charmpp) \
+            -D BLAS_ROOT=$(brew --prefix openblas) \
+            -D LAPACK_ROOT=$(brew --prefix openblas) \
             -D CMAKE_BUILD_TYPE=Debug \
             -D DEBUG_SYMBOLS=OFF \
             -D UNIT_TESTS_IN_TEST_EXECUTABLES=OFF \
@@ -1020,17 +1042,15 @@ ${{ matrix.build_type }}-pch-${{ matrix.use_pch || 'ON' }}"
             -D STUB_LIBRARY_OBJECT_FILES=ON \
             -D USE_PCH=ON \
             -D USE_CCACHE=ON \
-            -D SPECTRE_TEST_TIMEOUT_FACTOR=5 \
+            -D SPECTRE_TEST_TIMEOUT_FACTOR=10 \
             -D CMAKE_INSTALL_PREFIX=../install \
             -D BUILD_DOCS=OFF \
             -D USE_XSIMD=OFF \
             $GITHUB_WORKSPACE
       - name: Build unit tests
         working-directory: build
-        # Build on 4 threads because GitHub's macOS VMs have 4 cores:
-        # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
         run: |
-          make -j4 unit-tests
+          make -j${NUM_CORES} unit-tests
       - name: Build executables
         working-directory: build
         run: |
@@ -1058,7 +1078,7 @@ ${{ matrix.build_type }}-pch-${{ matrix.use_pch || 'ON' }}"
       - name: Run unit tests
         working-directory: build
         run: |
-          ctest -j4 --repeat after-timeout:3 --output-on-failure
+          ctest -j${NUM_CORES} --repeat after-timeout:3 --output-on-failure
       - name: Install
         working-directory: build
         run: |

--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -884,8 +884,7 @@ ${{ matrix.build_type }}-pch-${{ matrix.use_pch || 'ON' }}"
       # listed in support/DevEnvironments/spack.yaml. This list is only needed
       # to create the cache.
       SPECTRE_SPACK_DEPS: >-
-        blaze brigand charmpp gsl hdf5 libsharp libxsmm openblas
-        yaml-cpp
+        blaze charmpp gsl hdf5 libxsmm openblas yaml-cpp
       CCACHE_DIR: $HOME/ccache
       CCACHE_TEMPDIR: $HOME/ccache-tmp
       CCACHE_MAXSIZE: "2G"

--- a/docs/Installation/BuildSystem.md
+++ b/docs/Installation/BuildSystem.md
@@ -470,13 +470,10 @@ dev_guide_creating_executables "how to create executables".
 ## Adding External Dependencies {#adding_external_dependencies}
 
 To add an external dependency, first add a `SetupDEPENDENCY.cmake`
-file to the `cmake` directory. You should model this after the
-existing one for `Brigand` if you're adding a header-only
-library and `yaml-cpp` if the library is not header-only. If CMake
+file to the `cmake` directory. If CMake
 does not already support `find_package` for the library you're adding
-you can write your own. These should be modeled after `FindBrigand`
-for header-only libraries, and `FindYAMLCPP` for compiled
-libraries. The `SetupDEPENDENCY.cmake` file must then be included in
+you can write your own `FindDEPENDENCY.cmake` file.
+The `SetupDEPENDENCY.cmake` file must then be included in
 the root `spectre/CMakeLists.txt`. Be sure to test both that setting
 `LIBRARY_ROOT` works correctly for your library, and also that if the
 library is required that CMake fails gracefully if the library is not

--- a/docs/Installation/Installation.md
+++ b/docs/Installation/Installation.md
@@ -144,7 +144,7 @@ The following dependencies will be fetched automatically if you set
 
 #### Bundled:
 * [Brigand](https://github.com/edouarda/brigand)
-* [libsharp](https://github.com/Libsharp/libsharp)
+* [libsharp](https://github.com/Libsharp/libsharp) \cite Libsharp
 
 ## Clone the SpECTRE repository
 
@@ -350,11 +350,6 @@ with a plain `spack install` if you prefer.
   [LMod](https://github.com/TACC/Lmod). See the [Spack documentation on
   modules](https://spack.readthedocs.io/en/latest/module_file_support.html) for
   details.
-- On macOS:
-  - Brigand has an issue with AppleClang 13 when compiling tests (see
-    https://github.com/edouarda/brigand/issues/274). Since it is header-only,
-    you can simply clone the [Brigand repository](https://github.com/edouarda/brigand)
-    instead of installing it with Spack.
 
 ## Building Charm++ {#building-charm}
 

--- a/src/Utilities/CMakeLists.txt
+++ b/src/Utilities/CMakeLists.txt
@@ -104,8 +104,7 @@ target_link_libraries(
 # As of Sep 1, 2023 libxsmm has an issue with lldb on ARM Macs (detecting
 # the CPU architecture raises SIGILL signals when loading the libxsmm dynamic
 # library). Just not linking libxsmm in Debug mode works around that.
-if (NOT SPECTRE_DEBUG
-    OR NOT (APPLE AND CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "arm64"))
+if (NOT (SPECTRE_DEBUG AND APPLE))
   target_link_libraries(
     ${LIBRARY}
     PUBLIC

--- a/support/DevEnvironments/spack.yaml
+++ b/support/DevEnvironments/spack.yaml
@@ -44,7 +44,6 @@ spack:
   specs:
   - blaze@3.8
   - 'boost@1.60:+math+program_options'
-  - brigand@master
   - 'catch2@3.4.0:3'
   # Charm++:
   # - The 'multicore' backend runs with shared memory on a single node. On
@@ -55,7 +54,6 @@ spack:
   - gsl
   - hdf5 -mpi
   - jemalloc
-  - libsharp -mpi -openmp
   - 'libxsmm@1.16.1:'
   - openblas
   - 'python@3.8:'

--- a/support/DevEnvironments/spack.yaml
+++ b/support/DevEnvironments/spack.yaml
@@ -42,7 +42,7 @@
 
 spack:
   specs:
-  - blaze@3.8
+  - 'blaze@3.8:3.8'
   - 'boost@1.60:+math+program_options'
   - 'catch2@3.4.0:3'
   # Charm++:
@@ -57,7 +57,7 @@ spack:
   - 'libxsmm@1.16.1:'
   - openblas
   - 'python@3.8:'
-  - yaml-cpp@0.6.3
+  - 'yaml-cpp@0.6.3:'
   concretizer:
     unify: true
   view: true

--- a/tests/Unit/Evolution/DgSubcell/Test_Reconstruction.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Test_Reconstruction.cpp
@@ -252,7 +252,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.Subcell.Fd.Reconstruction",
 
     test_reconstruct_fd<6, 3, Spectral::Basis::Legendre,
                         Spectral::Quadrature::GaussLobatto>(
-        {1.0e-14, 1.0e-14, 3.0e-6, 3.0e-7, 3.0e-8}, reconstruction_method);
+        {1.0e-14, 1.0e-12, 3.0e-6, 3.0e-7, 3.0e-8}, reconstruction_method);
     test_reconstruct_fd<6, 3, Spectral::Basis::Legendre,
                         Spectral::Quadrature::Gauss>(
         {1.0e-14, 1.0e-14, 1.0e-6, 3.0e-7, 3.0e-8}, reconstruction_method);

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/Test_PartialDerivatives.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/Test_PartialDerivatives.cpp
@@ -214,7 +214,7 @@ void test_partial_derivative_per_tensor(
         const auto single_du =
             partial_derivative(get<var_tag>(u), mesh, inverse_jacobian);
 
-        Approx local_approx = Approx::custom().epsilon(1e-11).scale(1.0);
+        Approx local_approx = Approx::custom().epsilon(1e-10).scale(1.0);
         CHECK_ITERABLE_CUSTOM_APPROX(single_du, get<gradient_tag>(du),
                                      local_approx);
 
@@ -377,7 +377,7 @@ void test_partial_derivatives_1d(const Mesh<1>& mesh) {
   Variables<
       db::wrap_tags_in<Tags::deriv, GradientTags, tmpl::size_t<1>, Frame::Grid>>
       expected_du(number_of_grid_points);
-  Approx local_approx = Approx::custom().epsilon(1e-11).scale(1.0);
+  Approx local_approx = Approx::custom().epsilon(1e-10).scale(1.0);
   for (size_t a = 0; a < mesh.extents(0); ++a) {
     CAPTURE(a);
     tmpl::for_each<VariableTags>([&a, &x, &u](auto tag) {
@@ -477,7 +477,7 @@ void test_partial_derivatives_3d(const Mesh<3>& mesh) {
   Variables<
       db::wrap_tags_in<Tags::deriv, GradientTags, tmpl::size_t<3>, Frame::Grid>>
       expected_du(number_of_grid_points);
-  Approx local_approx = Approx::custom().epsilon(1e-10).scale(1.0);
+  Approx local_approx = Approx::custom().epsilon(1e-9).scale(1.0);
   for (size_t a = 0; a < mesh.extents(0) / 2; ++a) {
     for (size_t b = 0; b < mesh.extents(1) / 2; ++b) {
       for (size_t c = 0; c < mesh.extents(2) / 2; ++c) {


### PR DESCRIPTION
## Proposed changes

Upgrade the macOS CI test to run on Apple Silicon. Also simplify Apple Silicon installation instructions a bit.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
