### PR TITLE
Fix beginners guide docker instruction

### DIFF
--- a/docs/Tutorials/BeginnersTutorial.md
+++ b/docs/Tutorials/BeginnersTutorial.md
@@ -42,8 +42,8 @@ in VSCode as well.
 For both a terminal and VSCode, create the container in a terminal and start it.
 
 ```
-docker create --rm --name spectre_demo -p 11111:11111 \
-    -i -t sxscollaboration/spectre:demo /bin/bash
+docker create --entrypoint "/bin/bash" --rm --name spectre_demo -p 11111:11111 \
+    -i -t sxscollaboration/spectre:demo
 ```
 ```
 docker start spectre_demo
@@ -52,6 +52,11 @@ docker start spectre_demo
 We connect port `11111` on your local machine to port `11111` of the container
 so we can use Paraview. The `--rm` will delete the container when you stop it.
 This won't put you into the container, only start it in the background.
+
+\note The `--entrypoint "/bin/bash"` is important because the default entrypoint
+of the container is the SpECTRE CLI. You can try out the default entrypoint by
+running `docker run sxscollaboration/spectre:demo -h` and it'll print the help
+string for the CLI. See the [Python documentation](py/cli.html) for more.
 
 You can also run a [Jupyter](https://jupyter.org/index.html) server for
 accessing the Python bindings (see \ref spectre_using_python) or running Jupyter


### PR DESCRIPTION
Since we changed the demo container so that the entry point is the
CLI, this broke the instructions on the tutorial page. Adding
`--entrypoint "/bin/bash"` fixes this.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
