### PR TITLE
BBH Inspiral.yaml: trigger checkpoint and AH observations more often

### DIFF
--- a/support/Pipelines/Bbh/InitialData.yaml
+++ b/support/Pipelines/Bbh/InitialData.yaml
@@ -12,8 +12,6 @@ Next:
     id_input_file_path: __file__
     id_run_dir: ./
     pipeline_dir: {{ pipeline_dir }}
-    refinement_level: {{ L }}
-    polynomial_order: {{ P }}
     continue_with_ringdown: True
     scheduler: {{ scheduler | default("None") }}
     copy_executable: {{ copy_executable | default("None") }}

--- a/support/Pipelines/Bbh/Inspiral.py
+++ b/support/Pipelines/Bbh/Inspiral.py
@@ -187,7 +187,7 @@ def start_inspiral(
     "-L",
     type=int,
     help="h-refinement level.",
-    default=0,
+    default=1,
     show_default=True,
 )
 @click.option(
@@ -195,7 +195,7 @@ def start_inspiral(
     "-P",
     type=int,
     help="p-refinement level.",
-    default=5,
+    default=9,
     show_default=True,
 )
 @click.option(

--- a/support/Pipelines/Bbh/Inspiral.yaml
+++ b/support/Pipelines/Bbh/Inspiral.yaml
@@ -216,8 +216,9 @@ PhaseChangeAndTriggers:
   - Trigger:
       Slabs:
         EvenlySpaced:
-          # Current implementation checks wallclock at these global syncs
-          Interval: 100
+          # Trigger checkpoint often enough so it triggers within the last 30
+          # minutes of the run
+          Interval: 20
           Offset: 0
     PhaseChanges:
       - CheckpointAndExitAfterWallclock:
@@ -270,12 +271,22 @@ EventsAndTriggers:
             - PointwiseL2Norm(ThreeIndexConstraint)
             - PointwiseL2Norm(FourIndexConstraint)
           InterpolateToMesh: None
-          CoordinatesFloatingPointType: Double
-          FloatingPointTypes: [Double]
-      - ObservationAhA
-      - ObservationAhB
+          # Save disk space by saving single precision data. This is enough
+          # for visualization.
+          CoordinatesFloatingPointType: Float
+          FloatingPointTypes: [Float]
       - ObservationExcisionBoundaryA
       - ObservationExcisionBoundaryB
+  - Trigger:
+      Slabs:
+        EvenlySpaced:
+          # Trigger apparent horizon observations often enough so they find the
+          # next horizon based on the previous initial guess.
+          Interval: 10
+          Offset: 0
+    Events:
+      - ObservationAhA
+      - ObservationAhB
   - Trigger:
       SeparationLessThan:
         Value: 2.5

--- a/tests/support/Pipelines/Bbh/Test_InitialData.py
+++ b/tests/support/Pipelines/Bbh/Test_InitialData.py
@@ -138,8 +138,6 @@ class TestInitialData(unittest.TestCase):
                     "id_input_file_path": "__file__",
                     "id_run_dir": "./",
                     "pipeline_dir": str(self.test_dir.resolve() / "Pipeline"),
-                    "refinement_level": 1,
-                    "polynomial_order": 5,
                     "continue_with_ringdown": True,
                     "scheduler": "None",
                     "copy_executable": "None",


### PR DESCRIPTION
The BBH runs so slowly right now that it may not trigger a checkpoint in the last 30 minutes of the run. Increasing the trigger frequency. Also trigger AH observations more often so they actually find AHs.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
