### PR TITLE
Reenable FPEs and similar in non-charm tests

### DIFF
--- a/tests/Unit/TestMain.cpp
+++ b/tests/Unit/TestMain.cpp
@@ -9,7 +9,13 @@
 #include <memory>
 
 #include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "Informer/InfoFromBuild.hpp"
+#include "Parallel/InitializationFunctions.hpp"
+#include "Parallel/Printf/Printf.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
+#include "Utilities/ErrorHandling/SegfaultHandler.hpp"
+#include "Utilities/MemoryHelpers.hpp"
 
 class TestRunListener : public Catch::EventListenerBase {
  public:
@@ -28,6 +34,11 @@ extern "C" void CkRegisterMainModule(void) {}
 #pragma GCC diagnostic pop
 
 int main(int argc, char* argv[]) {
+  setup_error_handling();
+  setup_memory_allocation_failure_reporting();
+  Parallel::printf("%s", info_from_build().c_str());
+  enable_floating_point_exceptions();
+  enable_segfault_handler();
   Catch::StringMaker<double>::precision =
       std::numeric_limits<double>::max_digits10;
   Catch::StringMaker<float>::precision =


### PR DESCRIPTION
Lost when RunTests was split up.

This causes several tests to fail.  I will be opening an issue shortly to organize getting them fixed.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
