### PR TITLE
Write an H5::Cce file from the *CharacteristicExtract execs

### DIFF
--- a/docs/Tutorials/CCE.md
+++ b/docs/Tutorials/CCE.md
@@ -87,11 +87,28 @@ CCE using external data are:
 Once you have the reduction data output file from a successful CCE run, you can
 confirm the integrity of the h5 file and its contents by running
 ```
-h5ls -r CharacteristicExtractReduction.h5/Cce.dir
+h5ls -r CharacteristicExtractReduction.h5
 ```
 
 For the reduction file produced by a successful run, the output of the `h5ls`
 should resemble
+
+```
+/SpectreR0100.cce                 Group
+/SpectreR0100.cce/EthInertialRetardedTime Dataset {26451/Inf, 163}
+/SpectreR0100.cce/News            Dataset {26451/Inf, 163}
+/SpectreR0100.cce/Psi0            Dataset {26451/Inf, 163}
+/SpectreR0100.cce/Psi1            Dataset {26451/Inf, 163}
+/SpectreR0100.cce/Psi2            Dataset {26451/Inf, 163}
+/SpectreR0100.cce/Psi3            Dataset {26451/Inf, 163}
+/SpectreR0100.cce/Psi4            Dataset {26451/Inf, 163}
+/SpectreR0100.cce/Strain          Dataset {26451/Inf, 163}
+/src.tar.gz              Dataset {7757329}
+```
+
+\note Prior to
+[this Pull Request](https://github.com/sxs-collaboration/spectre/pull/5985), the
+output of `h5ls` looked like this
 ```
 /                        Group
 /Cce                     Group
@@ -103,17 +120,17 @@ should resemble
 /Cce/Psi3.dat                 Dataset {3995/Inf, 163}
 /Cce/Psi4.dat                 Dataset {3995/Inf, 163}
 /Cce/Strain.dat               Dataset {3995/Inf, 163}
-src.tar.gz               Dataset {3750199}
+/src.tar.gz               Dataset {3750199}
 ```
 
-The `Strain.dat` represents the asymptotic transverse-traceless contribution
+The `Strain` represents the asymptotic transverse-traceless contribution
 to the metric scaled by the Bondi radius (to give the asymptotically leading
-part), the `News.dat` represents the first derivative of the strain, and each
+part), the `News` represents the first derivative of the strain, and each
 of the `Psi...` datasets represent the Weyl scalars, each scaled by the
 appropriate factor of the Bondi-Sachs radius to retrieve the asymptotically
 leading contribution.
 
-The `EthInertialRetardedTime.dat` is a diagnostic dataset that represents the
+The `EthInertialRetardedTime` is a diagnostic dataset that represents the
 angular derivative of the inertial retarded time, which determines the
 coordinate transformation that is performed at scri+.
 
@@ -135,7 +152,7 @@ def spectre_imag_mode_index(l, m):
 
 def get_modes_from_block_output(filename, dataset, modes=[[2, 2], [3, 3]]):
     with h5.File(filename, "r") as h5_file:
-        timeseries_data = (h5_file[dataset + ".dat"][()][:, [0] + list(
+        timeseries_data = (h5_file[dataset][()][:, [0] + list(
             np.array([[
                 spectre_real_mode_index(x[0], x[1]),
                 spectre_imag_mode_index(x[0], x[1])
@@ -160,7 +177,7 @@ for i in range(len(plot_quantities)):
     ax = plt.subplot(len(plot_quantities), 1, i + 1)
     timeseries = np.transpose(
         get_modes_from_block_output(
-            filename, f"/Cce/{plot_quantities[i]}", mode_set
+            filename, f"/SpectreR0100.cce/{plot_quantities[i]}", mode_set
         )
     )
     for j in range(len(mode_set)):

--- a/src/Evolution/Systems/Cce/Actions/BoundaryComputeAndSendToEvolution.hpp
+++ b/src/Evolution/Systems/Cce/Actions/BoundaryComputeAndSendToEvolution.hpp
@@ -380,7 +380,7 @@ struct SendToEvolution<GhWorldtubeBoundary<Metavariables>, EvolutionComponent> {
                                      spacetime_metric, extraction_radius,
                                      l_max);
         },
-        make_not_null(&box), db::get<InitializationTags::ExtractionRadius>(box),
+        make_not_null(&box), db::get<Tags::ExtractionRadius>(box),
         db::get<Tags::LMax>(box));
     Parallel::receive_data<Cce::ReceiveTags::BoundaryData<
         typename Metavariables::cce_boundary_communication_tags>>(

--- a/src/Evolution/Systems/Cce/Actions/CMakeLists.txt
+++ b/src/Evolution/Systems/Cce/Actions/CMakeLists.txt
@@ -32,4 +32,5 @@ spectre_target_headers(
   SendGhVarsToCce.hpp
   TimeManagement.hpp
   UpdateGauge.hpp
+  WriteScriBondiQuantities.hpp
   )

--- a/src/Evolution/Systems/Cce/Actions/InitializeWorldtubeBoundary.hpp
+++ b/src/Evolution/Systems/Cce/Actions/InitializeWorldtubeBoundary.hpp
@@ -107,7 +107,7 @@ struct InitializeWorldtubeBoundary;
  * \details Uses:
  * - simple tags from options
  * `Cce::Tags::H5WorldtubeBoundaryDataManager`,
- * - const global cache tag `Cce::Tags::LMax`.
+ * - const global cache tag `Cce::Tags::LMax`, `Tags::ExtractionRadiusFromH5`.
  *
  * Databox changes:
  * - Adds:
@@ -130,7 +130,8 @@ struct InitializeWorldtubeBoundary<H5WorldtubeBoundary<Metavariables>>
   using base_type::apply;
   using typename base_type::simple_tags;
   using const_global_cache_tags =
-      tmpl::list<Tags::LMax, Tags::EndTimeFromFile, Tags::StartTimeFromFile>;
+      tmpl::list<Tags::LMax, Tags::ExtractionRadiusFromH5,
+                 Tags::EndTimeFromFile, Tags::StartTimeFromFile>;
   using typename base_type::simple_tags_from_options;
 };
 
@@ -142,7 +143,7 @@ struct InitializeWorldtubeBoundary<H5WorldtubeBoundary<Metavariables>>
  * - simple tags from options
  * `Cce::Tags::H5WorldtubeBoundaryDataManager`,
  * `Cce::Tags::KleinGordonH5WorldtubeBoundaryDataManager`.
- * - const global cache tag `Cce::Tags::LMax`.
+ * - const global cache tag `Cce::Tags::LMax`, `Tags::ExtractionRadiusFromH5`.
  *
  * Databox changes:
  * - Adds:
@@ -175,7 +176,8 @@ struct InitializeWorldtubeBoundary<
   using base_type::apply;
   using typename base_type::simple_tags;
   using const_global_cache_tags =
-      tmpl::list<Tags::LMax, Tags::EndTimeFromFile, Tags::StartTimeFromFile>;
+      tmpl::list<Tags::LMax, Tags::ExtractionRadiusFromH5,
+                 Tags::EndTimeFromFile, Tags::StartTimeFromFile>;
   using typename base_type::simple_tags_from_options;
 };
 
@@ -186,7 +188,7 @@ struct InitializeWorldtubeBoundary<
  * \details Uses:
  * - simple tags from options
  * `Cce::Tags::GhWorldtubeBoundaryDataManager`, `Tags::GhInterfaceManager`
- * - const global cache tags `Tags::LMax`, `Tags::ExtractionRadius`.
+ * - const global cache tags `Tags::LMax`, `Tags::ExtractionRadiusSimple`.
  *
  * Databox changes:
  * - Adds:
@@ -210,8 +212,8 @@ struct InitializeWorldtubeBoundary<GhWorldtubeBoundary<Metavariables>>
   using typename base_type::simple_tags;
 
   using const_global_cache_tags =
-      tmpl::list<Tags::LMax, InitializationTags::ExtractionRadius,
-                 Tags::NoEndTime, Tags::SpecifiedStartTime>;
+      tmpl::list<Tags::LMax, Tags::ExtractionRadiusSimple, Tags::NoEndTime,
+                 Tags::SpecifiedStartTime>;
   using typename base_type::simple_tags_from_options;
 };
 
@@ -223,7 +225,7 @@ struct InitializeWorldtubeBoundary<GhWorldtubeBoundary<Metavariables>>
  * - simple tags from options
  * `Cce::Tags::AnalyticBoundaryDataManager`,
  * - const global cache tags `Tags::LMax`,
- * `Tags::ExtractionRadius`.
+ * `Tags::ExtractionRadiusSimple`.
  *
  * Databox changes:
  * - Adds:
@@ -254,7 +256,8 @@ struct InitializeWorldtubeBoundary<AnalyticWorldtubeBoundary<Metavariables>>
   using typename base_type::simple_tags;
   using compute_tags = time_stepper_ref_tags<TimeStepperType>;
   using const_global_cache_tags =
-      tmpl::list<Tags::LMax, Tags::SpecifiedEndTime, Tags::SpecifiedStartTime>;
+      tmpl::list<Tags::LMax, Tags::ExtractionRadiusSimple,
+                 Tags::SpecifiedEndTime, Tags::SpecifiedStartTime>;
   using typename base_type::simple_tags_from_options;
 };
 }  // namespace Actions

--- a/src/Evolution/Systems/Cce/Actions/WriteScriBondiQuantities.hpp
+++ b/src/Evolution/Systems/Cce/Actions/WriteScriBondiQuantities.hpp
@@ -1,0 +1,97 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "IO/H5/AccessType.hpp"
+#include "IO/H5/Cce.hpp"
+#include "IO/H5/File.hpp"
+#include "IO/Observer/Helpers.hpp"
+#include "IO/Observer/Tags.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "Parallel/NodeLock.hpp"
+#include "Utilities/Algorithm.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace Cce::Actions {
+/*!
+ * \brief Write a single row of data into an `h5::Cce` subfile within an H5
+ * file.
+ *
+ * \details This action can be called as either a threaded action or a local
+ * synchronous action. In both cases, invoke this action on the
+ * `observers::ObserverWriter` component on node 0. You must pass the following
+ * arguments when invoking this action
+ *
+ * - `subfile_name`: the name of the `h5::Cce` subfile in the HDF5 file.
+ * - `l_max`: the number of spherical harmonics of the data
+ * - `data`: a `std::unordered_map<std::string, std::vector<double>>` where the
+ *   keys are the names of all the bondi quantities to write and the data are
+ *   the spherical harmonic coefficients. See `h5::Cce` for exactly what names
+ *   need to be used and the layout of the data.
+ *
+ * \note If you want to write data into an `h5::Dat` file, use
+ * `observers::ThreadedActions::WriteReductionDataRow`.
+ */
+struct WriteScriBondiQuantities {
+  /// \brief The apply call for the threaded action
+  template <typename ParallelComponent, typename DbTagsList,
+            typename Metavariables, typename ArrayIndex>
+  static void apply(db::DataBox<DbTagsList>& box,
+                    Parallel::GlobalCache<Metavariables>& cache,
+                    const ArrayIndex& /*array_index*/,
+                    const gsl::not_null<Parallel::NodeLock*> node_lock,
+                    const std::string& subfile_name, const size_t l_max,
+                    std::unordered_map<std::string, std::vector<double>> data) {
+    apply<ParallelComponent>(box, node_lock, cache, subfile_name, l_max,
+                             std::move(data));
+  }
+
+  // The local synchronous action
+  using return_type = void;
+
+  /// \brief The apply call for the local synchronous action
+  template <typename ParallelComponent, typename DbTagList,
+            typename Metavariables>
+  static return_type apply(
+      db::DataBox<DbTagList>& box,
+      const gsl::not_null<Parallel::NodeLock*> /*node_lock*/,
+      Parallel::GlobalCache<Metavariables>& cache,
+      const std::string& subfile_name, const size_t l_max,
+      std::unordered_map<std::string, std::vector<double>> data) {
+    auto& reduction_file_lock =
+        db::get_mutable_reference<observers::Tags::H5FileLock>(
+            make_not_null(&box));
+    const std::lock_guard hold_lock(reduction_file_lock);
+
+    // Make sure all data is the proper size
+    ASSERT(
+        alg::all_of(data,
+                    [&l_max](const auto& name_and_data) {
+                      return name_and_data.second.size() ==
+                             2 * square(l_max + 1) + 1;
+                    }),
+        "Some data sent to WriteScriBondiQuantities is not of the proper size "
+            << 2 * square(l_max + 1) + 1);
+
+    const std::string input_source = observers::input_source_from_cache(cache);
+    const std::string& reduction_file_prefix =
+        Parallel::get<observers::Tags::ReductionFileName>(cache);
+    h5::H5File<h5::AccessType::ReadWrite> h5file(reduction_file_prefix + ".h5",
+                                                 true, input_source);
+    constexpr size_t version_number = 0;
+    auto& cce_file =
+        h5file.try_insert<h5::Cce>(subfile_name, l_max, version_number);
+    cce_file.append(data);
+  }
+};
+}  // namespace Cce::Actions

--- a/src/Evolution/Systems/Cce/CMakeLists.txt
+++ b/src/Evolution/Systems/Cce/CMakeLists.txt
@@ -11,6 +11,7 @@ spectre_target_sources(
   AnalyticBoundaryDataManager.cpp
   BoundaryData.cpp
   Equations.cpp
+  ExtractionRadius.cpp
   GaugeTransformBoundaryData.cpp
   KleinGordonSource.cpp
   LinearOperators.cpp
@@ -32,6 +33,7 @@ spectre_target_headers(
   BoundaryData.hpp
   BoundaryDataTags.hpp
   Equations.hpp
+  ExtractionRadius.hpp
   GaugeTransformBoundaryData.hpp
   IntegrandInputSteps.hpp
   KleinGordonSystem.hpp

--- a/src/Evolution/Systems/Cce/ExtractionRadius.cpp
+++ b/src/Evolution/Systems/Cce/ExtractionRadius.cpp
@@ -1,0 +1,39 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/Cce/ExtractionRadius.hpp"
+
+#include <optional>
+#include <stdexcept>
+#include <string>
+
+#include "Utilities/ErrorHandling/Error.hpp"
+
+namespace Cce {
+std::string get_text_radius(const std::string& cce_data_filename) {
+  const size_t r_pos = cce_data_filename.find_last_of('R');
+  const size_t dot_pos = cce_data_filename.find_last_of('.');
+  return cce_data_filename.substr(r_pos + 1, dot_pos - r_pos - 1);
+}
+
+std::optional<double> get_extraction_radius(
+    const std::string& cce_data_filename,
+    const std::optional<double>& extraction_radius, const bool error) {
+  const std::string text_radius = get_text_radius(cce_data_filename);
+  std::optional<double> result{};
+  try {
+    result = extraction_radius.has_value() ? extraction_radius.value()
+                                           : std::stod(text_radius);
+  } catch (const std::invalid_argument&) {
+    if (error) {
+      ERROR(
+          "The CCE filename must encode the extraction radius as an integer "
+          "between the last instance of 'R' and the last instance of '.' "
+          "(SpEC CCE filename format). Provided filename: "
+          << cce_data_filename);
+    }
+  }
+
+  return result;
+}
+}  // namespace Cce

--- a/src/Evolution/Systems/Cce/ExtractionRadius.hpp
+++ b/src/Evolution/Systems/Cce/ExtractionRadius.hpp
@@ -1,0 +1,24 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <optional>
+#include <string>
+
+namespace Cce {
+/// @{
+/*!
+ * \brief Retrieves the extraction radius from the specified file name.
+ *
+ * \details We assume that the filename has the extraction radius encoded as an
+ * integer between the last occurrence of 'R' and the last occurrence of '.'.
+ * This is the format provided by SpEC.
+ */
+std::string get_text_radius(const std::string& cce_data_filename);
+
+std::optional<double> get_extraction_radius(
+    const std::string& cce_data_filename,
+    const std::optional<double>& extraction_radius, bool error = true);
+/// @}
+}  // namespace Cce

--- a/src/Evolution/Systems/Cce/OptionTags.hpp
+++ b/src/Evolution/Systems/Cce/OptionTags.hpp
@@ -10,6 +10,7 @@
 #include "DataStructures/DataBox/Tag.hpp"
 #include "Evolution/Systems/Cce/AnalyticBoundaryDataManager.hpp"
 #include "Evolution/Systems/Cce/AnalyticSolutions/WorldtubeData.hpp"
+#include "Evolution/Systems/Cce/ExtractionRadius.hpp"
 #include "Evolution/Systems/Cce/Initialize/InitializeJ.hpp"
 #include "Evolution/Systems/Cce/InterfaceManagers/GhInterfaceManager.hpp"
 #include "Evolution/Systems/Cce/InterfaceManagers/GhLocalTimeStepping.hpp"
@@ -237,16 +238,6 @@ struct ScriInterpolationOrder : db::SimpleTag {
   }
 };
 
-struct ExtractionRadius : db::SimpleTag {
-  using type = double;
-  using option_tags = tmpl::list<OptionTags::ExtractionRadius>;
-
-  static constexpr bool pass_metavariables = false;
-  static double create_from_options(const double extraction_radius) {
-    return extraction_radius;
-  }
-};
-
 struct ScriOutputDensity : db::SimpleTag {
   using type = size_t;
   using option_tags = tmpl::list<OptionTags::ScriOutputDensity>;
@@ -259,6 +250,35 @@ struct ScriOutputDensity : db::SimpleTag {
 }  // namespace InitializationTags
 
 namespace Tags {
+struct ExtractionRadius : db::BaseTag {};
+
+struct ExtractionRadiusSimple : ExtractionRadius, db::SimpleTag {
+  static std::string name() { return "ExtractionRadius"; }
+  using type = double;
+  using option_tags = tmpl::list<OptionTags::ExtractionRadius>;
+
+  static constexpr bool pass_metavariables = false;
+  static double create_from_options(const double extraction_radius) {
+    return extraction_radius;
+  }
+};
+
+struct ExtractionRadiusFromH5 : ExtractionRadius, db::SimpleTag {
+  static std::string name() { return "ExtractionRadius"; }
+  using type = double;
+  using option_tags = tmpl::list<OptionTags::BoundaryDataFilename,
+                                 OptionTags::StandaloneExtractionRadius>;
+
+  static constexpr bool pass_metavariables = false;
+  static double create_from_options(
+      const std::string& filename,
+      const std::optional<double>& extraction_radius) {
+    const std::optional<double> radius =
+        Cce::get_extraction_radius(filename, extraction_radius);
+    return radius.value();
+  }
+};
+
 struct FilePrefix : db::SimpleTag {
   using type = std::string;
   using option_tags = tmpl::list<OptionTags::BondiSachsOutputFilePrefix>;

--- a/src/Evolution/Systems/Cce/WorldtubeBufferUpdater.hpp
+++ b/src/Evolution/Systems/Cce/WorldtubeBufferUpdater.hpp
@@ -82,12 +82,6 @@ std::pair<size_t, size_t> create_span_for_time_value(
     double time, size_t pad, size_t interpolator_length, size_t lower_bound,
     size_t upper_bound, const DataVector& time_buffer);
 
-// retrieves the extraction radius from the specified file.
-// We assume that the filename has the extraction radius encoded as an
-// integer between the last occurrence of 'R' and the last occurrence of
-// '.'. This is the format provided by SpEC.
-std::string get_text_radius(const std::string& cce_data_filename);
-
 // retrieves time stamps and lmax the from the specified file.
 void set_time_buffer_and_lmax(gsl::not_null<DataVector*> time_buffer,
                               size_t& l_max, const h5::Dat& data);

--- a/tests/InputFiles/Cce/AnalyticTestBouncingBlackHole.yaml
+++ b/tests/InputFiles/Cce/AnalyticTestBouncingBlackHole.yaml
@@ -10,7 +10,7 @@ ExpectedOutput:
   - CharacteristicExtractReduction.h5
 OutputFileChecks:
   - Label: "check_news"
-    Subfile: "/Cce/News.dat"
+    Subfile: "/SpectreR0030.cce/News"
     FileGlob: "CharacteristicExtractReduction.h5"
     ExpectedDataSubfile: "/Cce/News_expected.dat"
     AbsoluteTolerance: 5e-5

--- a/tests/InputFiles/Cce/AnalyticTestGaugeWave.yaml
+++ b/tests/InputFiles/Cce/AnalyticTestGaugeWave.yaml
@@ -10,7 +10,7 @@ ExpectedOutput:
   - CharacteristicExtractReduction.h5
 OutputFileChecks:
   - Label: "check_news"
-    Subfile: "/Cce/News.dat"
+    Subfile: "/SpectreR0040.cce/News"
     FileGlob: "CharacteristicExtractReduction.h5"
     ExpectedDataSubfile: "/Cce/News_expected.dat"
     AbsoluteTolerance: 5e-10

--- a/tests/InputFiles/Cce/AnalyticTestLinearizedBondiSachs.yaml
+++ b/tests/InputFiles/Cce/AnalyticTestLinearizedBondiSachs.yaml
@@ -10,7 +10,7 @@ ExpectedOutput:
   - CharacteristicExtractReduction.h5
 OutputFileChecks:
   - Label: "check_news"
-    Subfile: "/Cce/News.dat"
+    Subfile: "/SpectreR0040.cce/News"
     FileGlob: "CharacteristicExtractReduction.h5"
     ExpectedDataSubfile: "/Cce/News_expected.dat"
     AbsoluteTolerance: 1e-2

--- a/tests/InputFiles/Cce/AnalyticTestRotatingSchwarzschild.yaml
+++ b/tests/InputFiles/Cce/AnalyticTestRotatingSchwarzschild.yaml
@@ -10,7 +10,7 @@ ExpectedOutput:
   - CharacteristicExtractReduction.h5
 OutputFileChecks:
   - Label: "check_news"
-    Subfile: "/Cce/News.dat"
+    Subfile: "/SpectreR0020.cce/News"
     FileGlob: "CharacteristicExtractReduction.h5"
     ExpectedDataSubfile: "/Cce/News_expected.dat"
     AbsoluteTolerance: 1e-11

--- a/tests/InputFiles/Cce/AnalyticTestTeukolskyWave.yaml
+++ b/tests/InputFiles/Cce/AnalyticTestTeukolskyWave.yaml
@@ -10,7 +10,7 @@ ExpectedOutput:
   - CharacteristicExtractReduction.h5
 OutputFileChecks:
   - Label: "check_news"
-    Subfile: "/Cce/News.dat"
+    Subfile: "/SpectreR0040.cce/News"
     FileGlob: "CharacteristicExtractReduction.h5"
     ExpectedDataSubfile: "/Cce/News_expected.dat"
     AbsoluteTolerance: 5e-10

--- a/tests/Unit/Evolution/Systems/Cce/Actions/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/CMakeLists.txt
@@ -26,6 +26,7 @@ set(LIBRARY_SOURCES
   Test_ScriObserveInterpolated.cpp
   Test_TimeManagement.cpp
   Test_UpdateGauge.cpp
+  Test_WriteScriBondiQuantities.cpp
   )
 
 add_test_library(${LIBRARY} "${LIBRARY_SOURCES}")
@@ -36,7 +37,9 @@ target_link_libraries(
   Cce
   CceHelpers
   GeneralRelativitySolutions
+  H5
   Interpolation
   InterpolationHelpers
+  Observer
   SpinWeightedSphericalHarmonics
   )

--- a/tests/Unit/Evolution/Systems/Cce/Actions/ScriObserveInterpolated.py
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/ScriObserveInterpolated.py
@@ -15,6 +15,7 @@ def compute_News(
     _4,
     _5,
     _6,
+    _7,
 ):
     return news_coefficient * (
         1.0 + linear_coefficient * time + quadratic_coefficient * time**2
@@ -32,6 +33,7 @@ def compute_EthInertialRetardedTime(
     _5,
     _6,
     eth_u_coefficient,
+    _7,
 ):
     return eth_u_coefficient * (
         1.0 + linear_coefficient * time + quadratic_coefficient * time**2
@@ -49,6 +51,7 @@ def compute_Du_TimeIntegral_ScriPlus_Psi4(
     _5,
     psi4_coefficient,
     _6,
+    _7,
 ):
     return psi4_coefficient * (
         linear_coefficient + 2.0 * quadratic_coefficient * time
@@ -66,6 +69,7 @@ def compute_ScriPlus_Psi3(
     _4,
     psi4_coefficient,
     eth_u_coefficient,
+    _5,
 ):
     time_factor = (
         1.0 + linear_coefficient * time + quadratic_coefficient * time**2
@@ -89,6 +93,7 @@ def compute_ScriPlus_Psi2(
     _3,
     psi4_coefficient,
     eth_u_coefficient,
+    _4,
 ):
     time_factor = (
         1.0 + linear_coefficient * time + quadratic_coefficient * time**2
@@ -113,6 +118,7 @@ def compute_ScriPlus_Psi1(
     _2,
     psi4_coefficient,
     eth_u_coefficient,
+    _3,
 ):
     time_factor = (
         1.0 + linear_coefficient * time + quadratic_coefficient * time**2
@@ -143,6 +149,7 @@ def compute_ScriPlus_Psi0(
     psi0_coefficient,
     psi4_coefficient,
     eth_u_coefficient,
+    _2,
 ):
     time_factor = (
         1.0 + linear_coefficient * time + quadratic_coefficient * time**2
@@ -161,4 +168,22 @@ def compute_ScriPlus_Psi0(
         + 0.75 * psi2 * eth_u**2
         + 0.5 * psi3 * eth_u**3
         + 0.0625 * psi4 * eth_u**4
+    )
+
+
+def compute_ScriPlus_Strain(
+    linear_coefficient,
+    quadratic_coefficient,
+    time,
+    _1,
+    _2,
+    _3,
+    _4,
+    _5,
+    _6,
+    _7,
+    strain_coefficient,
+):
+    return strain_coefficient * (
+        1.0 + linear_coefficient * time + quadratic_coefficient * time**2
     )

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_AnalyticBoundaryCommunication.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_AnalyticBoundaryCommunication.cpp
@@ -186,7 +186,8 @@ SPECTRE_TEST_CASE(
   ActionTesting::MockRuntimeSystem<test_metavariables> runner{
       tuples::tagged_tuple_from_typelist<
           Parallel::get_const_global_cache_tags<test_metavariables>>{
-          l_max, end_time, start_time, number_of_radial_points}};
+          l_max, extraction_radius, end_time, start_time,
+          number_of_radial_points}};
 
   const AnalyticBoundaryDataManager analytic_manager{
       l_max, extraction_radius,

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_H5BoundaryCommunication.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_H5BoundaryCommunication.cpp
@@ -183,8 +183,8 @@ struct test_metavariables {
                  Cce::Tags::TimeIntegral<Cce::Tags::ScriPlus<Cce::Tags::Psi4>>,
                  Cce::Tags::ScriPlusFactor<Cce::Tags::Psi4>>;
   using ccm_psi0 = tmpl::list<
-        Cce::Tags::BoundaryValue<Cce::Tags::Psi0Match>,
-        Cce::Tags::BoundaryValue<Cce::Tags::Dlambda<Cce::Tags::Psi0Match>>>;
+      Cce::Tags::BoundaryValue<Cce::Tags::Psi0Match>,
+      Cce::Tags::BoundaryValue<Cce::Tags::Dlambda<Cce::Tags::Psi0Match>>>;
 
   using component_list =
       tmpl::list<mock_h5_worldtube_boundary<test_metavariables>,
@@ -231,7 +231,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.Actions.H5BoundaryCommunication",
   const double target_step_size = 0.01 * value_dist(gen);
   const double end_time = std::numeric_limits<double>::quiet_NaN();
   ActionTesting::MockRuntimeSystem<test_metavariables> runner{
-      {l_max,
+      {l_max, extraction_radius,
        Tags::EndTimeFromFile::create_from_options(end_time, filename, false),
        start_time, number_of_radial_points}};
 

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_InitializeKleinGordonWorldtubeBoundary.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_InitializeKleinGordonWorldtubeBoundary.cpp
@@ -78,7 +78,7 @@ void test_klein_gordon_h5_initialization(const gsl::not_null<Generator*> gen) {
   ActionTesting::MockRuntimeSystem<KleinGordonH5Metavariables> runner{
       tuples::tagged_tuple_from_typelist<
           Parallel::get_const_global_cache_tags<KleinGordonH5Metavariables>>{
-          l_max, end_time, start_time}};
+          l_max, extraction_radius, end_time, start_time}};
   ActionTesting::set_phase(make_not_null(&runner),
                            Parallel::Phase::Initialization);
   ActionTesting::emplace_component<component>(

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_InitializeWorldtubeBoundary.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_InitializeWorldtubeBoundary.cpp
@@ -92,10 +92,11 @@ void test_h5_initialization(const gsl::not_null<Generator*> gen) {
   const size_t l_max = 8;
   const size_t end_time = 100.0;
   const size_t start_time = 0.0;
+  const double extraction_radius = 100.0;
   ActionTesting::MockRuntimeSystem<H5Metavariables> runner{
       tuples::tagged_tuple_from_typelist<
           Parallel::get_const_global_cache_tags<H5Metavariables>>{
-          l_max, end_time, start_time}};
+          l_max, extraction_radius, end_time, start_time}};
 
   const size_t buffer_size = 8;
   const std::string filename = "InitializeWorldtubeBoundaryTest_CceR0100.h5";
@@ -111,7 +112,6 @@ void test_h5_initialization(const gsl::not_null<Generator*> gen) {
       {value_dist(*gen), value_dist(*gen), value_dist(*gen)}};
   gr::Solutions::KerrSchild solution{mass, spin, center};
 
-  const double extraction_radius = 100.0;
   const double frequency = 0.1 * value_dist(*gen);
   const double amplitude = 0.1 * value_dist(*gen);
   const double target_time = 50.0 * value_dist(*gen);
@@ -197,14 +197,15 @@ template <typename SolutionType>
 void test_analytic_initialization() {
   using component = mock_analytic_worldtube_boundary<AnalyticMetavariables>;
   const size_t l_max = 8;
+  const double extraction_radius = 20.0;
   register_classes_with_charm<TimeSteppers::Rk3HesthavenSsp>();
   ActionTesting::MockRuntimeSystem<AnalyticMetavariables> runner{
-      {l_max, 100.0, 0.0}};
+      {l_max, extraction_radius, 100.0, 0.0}};
 
   runner.set_phase(Parallel::Phase::Initialization);
   ActionTesting::emplace_component<component>(
       &runner, 0,
-      AnalyticBoundaryDataManager{12_st, 20.0,
+      AnalyticBoundaryDataManager{12_st, extraction_radius,
                                   std::make_unique<SolutionType>()},
       static_cast<std::unique_ptr<TimeStepper>>(
           std::make_unique<::TimeSteppers::Rk3HesthavenSsp>()));

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_KleinGordonH5BoundaryCommunication.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_KleinGordonH5BoundaryCommunication.cpp
@@ -209,7 +209,7 @@ void test_klein_gordon_h5_boundary_communication(
 
   // tests start here
   ActionTesting::MockRuntimeSystem<test_metavariables> runner{
-      {l_max,
+      {l_max, extraction_radius,
        Tags::EndTimeFromFile::create_from_options(end_time, filename, false),
        start_time, number_of_radial_points}};
 

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_RequestBoundaryData.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_RequestBoundaryData.cpp
@@ -198,7 +198,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.Actions.RequestBoundaryData",
   const double end_time = start_time + 10 * target_step_size;
   const size_t buffer_size = 5;
   ActionTesting::MockRuntimeSystem<test_metavariables> runner{
-      {l_max,
+      {l_max, extraction_radius,
        Tags::EndTimeFromFile::create_from_options(end_time, filename, false),
        start_time, number_of_radial_points}};
 

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_RequestKleinGordonBoundaryData.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_RequestKleinGordonBoundaryData.cpp
@@ -177,7 +177,7 @@ void test_klein_gordon_boundary_data(const gsl::not_null<Generator*> gen) {
 
   // tests start here
   ActionTesting::MockRuntimeSystem<test_metavariables> runner{
-      {l_max,
+      {l_max, extraction_radius,
        Tags::EndTimeFromFile::create_from_options(end_time, filename, false),
        start_time, number_of_radial_points}};
 

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_WriteScriBondiQuantities.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_WriteScriBondiQuantities.cpp
@@ -1,0 +1,144 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "DataStructures/Matrix.hpp"
+#include "Domain/Domain.hpp"
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "Evolution/Systems/Cce/Actions/WriteScriBondiQuantities.hpp"
+#include "Framework/ActionTesting.hpp"
+#include "Helpers/IO/Observers/ObserverHelpers.hpp"
+#include "IO/H5/AccessType.hpp"
+#include "IO/H5/Cce.hpp"
+#include "IO/H5/File.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "Parallel/Invoke.hpp"
+#include "Parallel/NodeLock.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/FileSystem.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace helpers = TestObservers_detail;
+
+namespace {
+using registration_list = tmpl::list<>;
+
+using metavariables = helpers::Metavariables<registration_list>;
+using obs_component = helpers::observer_component<metavariables>;
+using obs_writer = helpers::observer_writer_component<metavariables>;
+using element_comp =
+    helpers::element_component<metavariables, registration_list>;
+
+void test() {
+  const std::string output_file_prefix = "WriteScriBondiQuantities";
+  const std::string output_file = output_file_prefix + ".h5";
+  if (file_system::check_if_file_exists(output_file)) {
+    file_system::rm(output_file, true);
+  }
+  ActionTesting::MockRuntimeSystem<metavariables> runner{
+      {Domain<3>{},
+       std::unordered_map<
+           std::string,
+           std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>{},
+       output_file_prefix, ""}};
+  ActionTesting::emplace_nodegroup_component<obs_writer>(&runner);
+  for (size_t i = 0; i < 2; ++i) {
+    ActionTesting::next_action<obs_writer>(make_not_null(&runner), 0);
+  }
+
+  ActionTesting::set_phase(make_not_null(&runner), Parallel::Phase::Testing);
+
+  auto& cache = ActionTesting::cache<obs_writer>(runner, 0);
+  auto& obs_writer_proxy = Parallel::get_parallel_component<obs_writer>(cache);
+
+  const size_t l_max = 12;
+  const size_t num_points = 2 * square(l_max + 1) + 1;
+
+  // We don't actually care here about what data was written, just that it *was*
+  // written
+  std::unordered_set<std::string> bondi_variables{"EthInertialRetardedTime",
+                                                  "News",
+                                                  "Psi0",
+                                                  "Psi1",
+                                                  "Psi2",
+                                                  "Psi3",
+                                                  "Psi4",
+                                                  "Strain"};
+  std::unordered_map<std::string, std::vector<double>> fake_data{};
+  for (const std::string& bondi_var : bondi_variables) {
+    fake_data[bondi_var] = std::vector<double>(num_points, 0.0);
+  }
+
+  // First test the threaded action
+  Parallel::threaded_action<Cce::Actions::WriteScriBondiQuantities>(
+      obs_writer_proxy[0], "/TestBondiThreaded", l_max, fake_data);
+
+  CHECK(ActionTesting::number_of_queued_threaded_actions<obs_writer>(runner,
+                                                                     0) == 1);
+  ActionTesting::invoke_queued_threaded_action<obs_writer>(
+      make_not_null(&runner), 0);
+
+  {
+    h5::H5File<h5::AccessType::ReadOnly> h5_file{output_file};
+    const auto groups = h5_file.groups();
+    REQUIRE(alg::found(groups, "TestBondiThreaded.cce"));
+    const auto& cce_file = h5_file.get<h5::Cce>("TestBondiThreaded", l_max, 0);
+    const std::unordered_map<std::string, Matrix> data_matrix =
+        cce_file.get_data();
+    for (const std::string& bondi_var : bondi_variables) {
+      REQUIRE(data_matrix.contains(bondi_var));
+      CHECK(data_matrix.at(bondi_var).rows() == 1);
+      CHECK(data_matrix.at(bondi_var).columns() == num_points);
+    }
+  }
+
+  // Now test the local synchronous action. However, the action testing
+  // framework can't handle local synchronous actions so we just call the apply
+  // function itself.
+  auto& box = ActionTesting::get_databox<obs_writer>(make_not_null(&runner), 0);
+  Parallel::NodeLock lock{};
+
+  Cce::Actions::WriteScriBondiQuantities::apply<void>(
+      box, make_not_null(&lock), cache, "/TestBondiSync", l_max, fake_data);
+
+  {
+    h5::H5File<h5::AccessType::ReadOnly> h5_file{output_file};
+    const auto groups = h5_file.groups();
+    REQUIRE(alg::found(groups, "TestBondiSync.cce"));
+    const auto& cce_file = h5_file.get<h5::Cce>("TestBondiSync", l_max, 0);
+    const std::unordered_map<std::string, Matrix> data_matrix =
+        cce_file.get_data();
+    for (const std::string& bondi_var : bondi_variables) {
+      REQUIRE(data_matrix.contains(bondi_var));
+      CHECK(data_matrix.at(bondi_var).rows() == 1);
+      CHECK(data_matrix.at(bondi_var).columns() == num_points);
+    }
+  }
+
+#ifdef SPECTRE_DEBUG
+  CHECK_THROWS_WITH(Cce::Actions::WriteScriBondiQuantities::apply<void>(
+                        box, make_not_null(&lock), cache, "/TestBondiFail",
+                        l_max + 1, fake_data),
+                    Catch::Matchers::ContainsSubstring(
+                        "Some data sent to WriteScriBondiQuantities is "
+                        "not of the proper size 393"));
+#endif
+
+  if (file_system::check_if_file_exists(output_file)) {
+    file_system::rm(output_file, true);
+  }
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.Actions.WriteScriBondiQuantities",
+                  "[Unit][Cce]") {
+  test();
+}

--- a/tests/Unit/Evolution/Systems/Cce/Test_OptionTags.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_OptionTags.cpp
@@ -43,8 +43,6 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.OptionTags", "[Unit][Cce]") {
   TestHelpers::db::test_simple_tag<
       Cce::InitializationTags::ScriInterpolationOrder>(
       "ScriInterpolationOrder");
-  TestHelpers::db::test_simple_tag<Cce::InitializationTags::ExtractionRadius>(
-      "ExtractionRadius");
   TestHelpers::db::test_simple_tag<Cce::InitializationTags::ScriOutputDensity>(
       "ScriOutputDensity");
   TestHelpers::db::test_simple_tag<Cce::Tags::H5WorldtubeBoundaryDataManager>(
@@ -52,6 +50,12 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.OptionTags", "[Unit][Cce]") {
   TestHelpers::db::test_simple_tag<
       Cce::Tags::KleinGordonH5WorldtubeBoundaryDataManager>(
       "KleinGordonH5WorldtubeBoundaryDataManager");
+  TestHelpers::db::test_base_tag<Cce::Tags::ExtractionRadius>(
+      "ExtractionRadius");
+  TestHelpers::db::test_simple_tag<Cce::Tags::ExtractionRadiusSimple>(
+      "ExtractionRadius");
+  TestHelpers::db::test_simple_tag<Cce::Tags::ExtractionRadiusFromH5>(
+      "ExtractionRadius");
   TestHelpers::db::test_simple_tag<Cce::Tags::FilePrefix>("FilePrefix");
   TestHelpers::db::test_simple_tag<Cce::Tags::LMax>("LMax");
   TestHelpers::db::test_simple_tag<Cce::Tags::NumberOfRadialPoints>(


### PR DESCRIPTION
## Proposed changes

Instead of writing a bunch of `.dat` files in the H5 file for each Bondi quantity at future null infinity, `CharacteristicExtract` and `KleinGordonCharacteristicExtract` now output an `H5::Cce` subfile. See #5963 for more details about the subfile.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
The output from CCE in the reductions file should only be a `Cce.cce` subfile. It won't have a bunch of `.dat` files anymore.
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
