### PR TITLE
Decrease sizes of Time and TimeStepId

### DIFF
--- a/src/Time/Time.cpp
+++ b/src/Time/Time.cpp
@@ -5,10 +5,13 @@
 
 #include <boost/functional/hash.hpp>
 #include <cmath>
+#include <cstddef>
+#include <functional>
 #include <ostream>
 #include <pup.h>
 #include <utility>
 
+#include "Time/Slab.hpp"
 #include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
 

--- a/src/Time/Time.cpp
+++ b/src/Time/Time.cpp
@@ -10,6 +10,7 @@
 #include <utility>
 
 #include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
 
 // Time implementations
 
@@ -71,7 +72,12 @@ bool Time::is_at_slab_boundary() const {
 void Time::pup(PUP::er& p) {
   p | slab_;
   p | fraction_;
-  p | value_;
+  if (p.isUnpacking()) {
+    // If the serialized object was uninitialized, this calculation
+    // can be garbage.
+    const ScopedFpeState disable_fpes(false);
+    compute_value();
+  }
 }
 
 bool Time::StructuralCompare::operator()(const Time& a, const Time& b) const {

--- a/src/Time/TimeStepId.cpp
+++ b/src/Time/TimeStepId.cpp
@@ -4,6 +4,9 @@
 #include "Time/TimeStepId.hpp"
 
 #include <boost/functional/hash.hpp>
+#include <cstddef>
+#include <cstdint>
+#include <functional>
 #include <limits>
 #include <ostream>
 #include <pup.h>
@@ -63,7 +66,7 @@ bool TimeStepId::is_at_slab_boundary() const {
 TimeStepId TimeStepId::next_step(const TimeDelta& step_size) const {
   ASSERT(substep_ == 0 or step_size == this->step_size(),
          "Step size inconsistent: " << this->step_size() << " " << step_size);
-  return TimeStepId(time_runs_forward(), slab_number_, step_time_ + step_size);
+  return {time_runs_forward(), slab_number_, step_time_ + step_size};
 }
 
 TimeStepId TimeStepId::next_substep(const TimeDelta& step_size,

--- a/src/Time/TimeStepId.hpp
+++ b/src/Time/TimeStepId.hpp
@@ -35,7 +35,7 @@ class TimeStepId {
   TimeStepId(bool time_runs_forward, int64_t slab_number, const Time& step_time,
              uint64_t substep, const TimeDelta& step_size, double substep_time);
 
-  bool time_runs_forward() const { return time_runs_forward_; }
+  bool time_runs_forward() const;
   int64_t slab_number() const { return slab_number_; }
   /// Time at the start of the current step
   const Time& step_time() const { return step_time_; }
@@ -62,7 +62,6 @@ class TimeStepId {
  private:
   void canonicalize();
 
-  bool time_runs_forward_{false};
   int64_t slab_number_{std::numeric_limits<int64_t>::lowest()};
   Time step_time_{};
   uint64_t substep_{0};

--- a/src/Time/TimeStepId.hpp
+++ b/src/Time/TimeStepId.hpp
@@ -64,7 +64,7 @@ class TimeStepId {
 
   int64_t slab_number_{std::numeric_limits<int64_t>::lowest()};
   Time step_time_{};
-  uint64_t substep_{0};
+  uint8_t substep_{0};
   Rational step_size_{};
   double substep_time_{};
 };

--- a/src/Time/TimeStepId.hpp
+++ b/src/Time/TimeStepId.hpp
@@ -13,6 +13,7 @@
 #include <limits>
 
 #include "Time/Time.hpp"
+#include "Utilities/Rational.hpp"
 
 namespace PUP {
 class er;
@@ -41,7 +42,7 @@ class TimeStepId {
   uint64_t substep() const { return substep_; }
   /// Current step size.  Only available when the substep is nonzero,
   /// because on the full step the state is valid for any step size.
-  const TimeDelta& step_size() const;
+  TimeDelta step_size() const;
   /// Time of the current substep
   double substep_time() const { return substep_time_; }
 
@@ -65,7 +66,7 @@ class TimeStepId {
   int64_t slab_number_{std::numeric_limits<int64_t>::lowest()};
   Time step_time_{};
   uint64_t substep_{0};
-  TimeDelta step_size_{};
+  Rational step_size_{};
   double substep_time_{};
 };
 

--- a/tests/Unit/Time/Test_Time.cpp
+++ b/tests/Unit/Time/Test_Time.cpp
@@ -11,7 +11,6 @@
 #include "Framework/TestHelpers.hpp"
 #include "Time/Slab.hpp"
 #include "Time/Time.hpp"
-#include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/GetOutput.hpp"
 
 namespace {
@@ -98,7 +97,7 @@ void test_time() {
            Time(slab.retreat(), rational_t(2, 3)));
 
   // Hashing
-  std::hash<Time> h;
+  const std::hash<Time> h{};
   CHECK(h(Slab(0, 1).start()) == h(Slab(0, 2).start()));
   CHECK(h(Slab(0, 1).start()) != h(Slab(0, 1).end()));
   CHECK(h(Slab(0, 1).start()) == h(Slab(-2, 0).end()));
@@ -113,7 +112,7 @@ void test_time() {
   CHECK(get_output(Time(slab, rational_t(3, 5))) == slab_str + ":3/5");
 
   const auto check_structural_compare = [](const Time& a, const Time& b) {
-    Time::StructuralCompare sc;
+    const Time::StructuralCompare sc{};
     CHECK_FALSE(sc(a, a));
     CHECK_FALSE(sc(b, b));
     CHECK(sc(a, b) != sc(b, a));
@@ -279,7 +278,7 @@ void test_time_delta() {
         Time(slab.retreat(), rational_t(2, 3)));
 
   // Hashing
-  std::hash<TimeDelta> h;
+  const std::hash<TimeDelta> h{};
   CHECK(h(Slab(0.0, 1.0).duration()) != h(Slab(0.0, 2.0).duration()));
   CHECK(h(Slab(0.0, 1.0).duration()) != h(Slab(0.0, 1.0).duration() / 2));
 

--- a/tests/Unit/Time/Test_Time.cpp
+++ b/tests/Unit/Time/Test_Time.cpp
@@ -128,6 +128,9 @@ void test_time() {
   {
     const Time time = slab.start() + slab.duration() * 3 / 5;
     test_serialization(time);
+    CHECK(serialize_and_deserialize(time).value() == time.value());
+    // Check that this doesn't crash.
+    serialize_and_deserialize(Time{});
   }
 }
 
@@ -290,6 +293,9 @@ void test_time_delta() {
   {
     const TimeDelta dt = slab.duration() * 3 / 5;
     test_serialization(dt);
+    CHECK(serialize_and_deserialize(dt).value() == dt.value());
+    // Check that this doesn't crash.
+    serialize_and_deserialize(TimeDelta{});
   }
 }
 

--- a/tests/Unit/Time/Test_TimeStepId.cpp
+++ b/tests/Unit/Time/Test_TimeStepId.cpp
@@ -5,7 +5,6 @@
 
 #include <cstdint>
 #include <functional>
-#include <string>
 
 #include "Framework/TestHelpers.hpp"
 #include "Time/Slab.hpp"


### PR DESCRIPTION
Primarily aiming to decrease checkpoint sizes.

This is the easy optimizations.  Some harder ones that were discussed that I didn't do here are
* Specialize to power-of-two slab fractions instead of generic rationals.  This requires fixing any places that are still using more general slab fractions, and requires deciding how to deal with `TimeDelta` objects with fraction greater than one, which can show up as intermediates, particularly in tests.
* Use some bits from the `TimeStepId` slab number to store the substep.  This complicates things more than any of the changes in this PR, particularly because it involves bit-manipulating signed integers.
* Removing the `Time::value_` field and computing it when needed.  This might have performance implications as I frequently code assuming `Time::value()` is free.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
