### PR TITLE
Add limit to time step of packet in high opacity region

### DIFF
--- a/src/Evolution/Particles/MonteCarlo/EvolvePacketsInElement.tpp
+++ b/src/Evolution/Particles/MonteCarlo/EvolvePacketsInElement.tpp
@@ -89,6 +89,7 @@ void TemplatedLocalFunctions<EnergyBins, NeutrinoSpecies>::evolve_packets(
     const gsl::not_null<Scalar<DataVector>*> coupling_rho_ye,
     const double final_time, const Mesh<3>& mesh,
     const tnsr::I<DataVector, 3, Frame::ElementLogical>& mesh_coordinates,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& inertial_coordinates,
     const std::array<std::array<DataVector, EnergyBins>, NeutrinoSpecies>&
         absorption_opacity_table,
     const std::array<std::array<DataVector, EnergyBins>, NeutrinoSpecies>&
@@ -128,15 +129,20 @@ void TemplatedLocalFunctions<EnergyBins, NeutrinoSpecies>::evolve_packets(
       &prefactor_diffusion_time_step, lorentz_factor,
       lower_spatial_four_velocity, lapse, shift, spatial_metric);
 
-  // Mesh information. Currently assumes uniform grid without map
+  // Mesh information.
   const Index<3>& extents = mesh.extents();
   const std::array<double, 3> bottom_coord_mesh{mesh_coordinates.get(0)[0],
                                                 mesh_coordinates.get(1)[0],
                                                 mesh_coordinates.get(2)[0]};
+  const std::array<size_t, 3> step{1, extents[0], extents[0] * extents[1]};
   const std::array<double, 3> dx_mesh{
-      mesh_coordinates.get(0)[1] - bottom_coord_mesh[0],
-      mesh_coordinates.get(1)[extents[0]] - bottom_coord_mesh[1],
-      mesh_coordinates.get(2)[extents[0] * extents[1]] - bottom_coord_mesh[2]};
+      mesh_coordinates.get(0)[step[0]] - bottom_coord_mesh[0],
+      mesh_coordinates.get(1)[step[1]] - bottom_coord_mesh[1],
+      mesh_coordinates.get(2)[step[2]] - bottom_coord_mesh[2]};
+  const std::array<double, 3> dx_inertial{
+      inertial_coordinates.get(0)[step[0]] - inertial_coordinates.get(0)[0],
+      inertial_coordinates.get(1)[step[1]] - inertial_coordinates.get(1)[0],
+      inertial_coordinates.get(2)[step[2]] - inertial_coordinates.get(2)[0]};
 
   // Temporary variables keeping track of opacities and times to next events
   double fluid_frame_energy = -1.0;
@@ -156,19 +162,36 @@ void TemplatedLocalFunctions<EnergyBins, NeutrinoSpecies>::evolve_packets(
     initial_time = packet.time;
     dt_end_step = final_time - initial_time;
 
+    // Get quantities that we do NOT update if the packet
+    // changes cell.
+    size_t idx = packet.index_of_closest_grid_point;
+    const double& lapse_packet = get(lapse)[idx];
+    const double& lorentz_factor_packet = get(lorentz_factor)[idx];
+    const std::array<double, 3> lower_spatial_four_velocity_packet = {
+        lower_spatial_four_velocity.get(0)[idx],
+        lower_spatial_four_velocity.get(1)[idx],
+        lower_spatial_four_velocity.get(2)[idx]};
+
+    // Estimate light-crossing time in the cell.
+    double min_crossing_time =
+        dx_inertial[0] /
+        (fabs(shift.get(0)[idx]) +
+         sqrt(inv_spatial_metric.get(0, 0)[idx]) * get(lapse)[idx]);
+    for (size_t d = 1; d < 3; d++) {
+      const double dim_crossing_time =
+          dx_inertial[d] /
+          (fabs(shift.get(d)[idx]) +
+           sqrt(inv_spatial_metric.get(d, d)[idx]) * get(lapse)[idx]);
+      min_crossing_time = std::min(min_crossing_time, dim_crossing_time);
+    }
+
     // We evolve until at least 95 percent of the desired step.
     // We don't require the full step because diffusion in the fluid
     // frame leads to unpredictable time steps in the inertial frame,
     // and we want to avoid taking a lot of potentially small steps
     // when reaching the end of the desired step.
     while (dt_end_step > 0.05 * (final_time - initial_time)) {
-      const size_t& idx = packet.index_of_closest_grid_point;
-      const double& lapse_packet = get(lapse)[idx];
-      const double& lorentz_factor_packet = get(lorentz_factor)[idx];
-      const std::array<double, 3> lower_spatial_four_velocity_packet = {
-          lower_spatial_four_velocity.get(0)[idx],
-          lower_spatial_four_velocity.get(1)[idx],
-          lower_spatial_four_velocity.get(2)[idx]};
+      idx = packet.index_of_closest_grid_point;
       // Get fluid frame energy of neutrinos in packet, then retrieve
       // opacities
       packet.renormalize_momentum(inv_spatial_metric, lapse);
@@ -180,10 +203,58 @@ void TemplatedLocalFunctions<EnergyBins, NeutrinoSpecies>::evolve_packets(
           packet.species, idx, absorption_opacity_table,
           scattering_opacity_table, energy_at_bin_center);
 
+      // Find maximum total opacity in current cell and
+      // neighbors, to limit time step in high opacity regions
+      // Need to properly deal with ghost zones.
+      double max_opacity = absorption_opacity + scattering_opacity;
+      for (size_t d = 0; d < 3; d++) {
+        double ka_neighbor = 0.0;
+        double ks_neighbor = 0.0;
+        if (idx >= step[d]) {
+          this->interpolate_opacities_at_fluid_energy(
+              &ka_neighbor, &ks_neighbor, fluid_frame_energy, packet.species,
+              idx - step[d], absorption_opacity_table, scattering_opacity_table,
+              energy_at_bin_center);
+          max_opacity = std::max(max_opacity, ka_neighbor + ks_neighbor);
+        }
+        if (idx < mesh.number_of_grid_points() - step[d]) {
+          this->interpolate_opacities_at_fluid_energy(
+              &ka_neighbor, &ks_neighbor, fluid_frame_energy, packet.species,
+              idx + step[d], absorption_opacity_table, scattering_opacity_table,
+              energy_at_bin_center);
+          max_opacity = std::max(max_opacity, ka_neighbor + ks_neighbor);
+        }
+      }
+      // Minimum fraction of light crossing time used for time step.
+      // This is a compromise between taking very small steps in high
+      // opacity regions close to cell boundaries, and minimizing
+      // computational costs.
+      const double fmin = std::max(
+          0.03, 0.1 / (max_opacity * min_crossing_time + opacity_floor));
+      // Shortest distance to a grid boundary, in units of the grid spacing.
+      double frac_min_grid = 1.0;
+      {
+        std::array<size_t, 3> closest_point_index_3d{0, 0, 0};
+        for (size_t d = 0; d < 3; d++) {
+          gsl::at(closest_point_index_3d, d) = std::floor(
+              (packet.coordinates[d] - gsl::at(bottom_coord_mesh, d)) /
+                  gsl::at(dx_mesh, d) +
+              0.5);
+          double frac_grid =
+              (packet.coordinates[d] - gsl::at(bottom_coord_mesh, d) -
+               gsl::at(closest_point_index_3d, d) * gsl::at(dx_mesh, d)) /
+                  gsl::at(dx_mesh, d) +
+              0.5;
+          frac_min_grid = std::min(frac_min_grid, frac_grid + fmin);
+          frac_min_grid = std::min(frac_min_grid, 1.0 - frac_grid + fmin);
+        }
+      }
+
       // Determine time to next events
       // TO DO: Implement cell check with ghost zone methods
       dt_min = dt_end_step;
-      dt_cell_check = 10.0 * dt_end_step;
+      // Limit time step close to cell boundary in high-opacity regions
+      dt_cell_check = frac_min_grid * min_crossing_time;
       dt_min = std::min(dt_cell_check, dt_min);
       // Time step to next absorption is
       // -ln(r)/K_a*p^t/nu
@@ -258,9 +329,9 @@ void TemplatedLocalFunctions<EnergyBins, NeutrinoSpecies>::evolve_packets(
               lorentz_factor, lower_spatial_four_velocity, lapse, shift,
               d_lapse, d_shift, d_inv_spatial_metric, spatial_metric,
               inv_spatial_metric, mesh_velocity,
-              inverse_jacobian_logical_to_inertial,
-              inertial_to_fluid_jacobian, inertial_to_fluid_inverse_jacobian,
-              prefactor_diffusion_time_step, prefactor_diffusion_four_velocity,
+              inverse_jacobian_logical_to_inertial, inertial_to_fluid_jacobian,
+              inertial_to_fluid_inverse_jacobian, prefactor_diffusion_time_step,
+              prefactor_diffusion_four_velocity,
               prefactor_diffusion_time_vector);
         } else {
           // Low optical depth; perform scatterings one by one.
@@ -304,7 +375,24 @@ void TemplatedLocalFunctions<EnergyBins, NeutrinoSpecies>::evolve_packets(
         }
       }
       // TO DO: Deal with update to opacities to neighboring
-      // points when we can handle ghost zones.
+      // points when we can handle ghost zones. At this point
+      // updating the index in the packet forces the use of
+      // the new index when getting metric quantities, which
+      // would required ghost zone data for the metric.
+      // Overall, we have to review how we access fluid/metric
+      // data and add to the coupling terms when we implement
+      // ghost zones.
+      std::array<size_t, 3> closest_point_index_3d{0, 0, 0};
+      for (size_t d = 0; d < 3; d++) {
+        gsl::at(closest_point_index_3d, d) =
+            std::floor((packet.coordinates[d] - gsl::at(bottom_coord_mesh, d)) /
+                           gsl::at(dx_mesh, d) +
+                       0.5);
+      }
+      packet.index_of_closest_grid_point =
+          closest_point_index_3d[0] +
+          extents[0] * (closest_point_index_3d[1] +
+                        extents[1] * closest_point_index_3d[2]);
 
       // Update time to end of step
       dt_end_step = final_time - packet.time;

--- a/src/Evolution/Particles/MonteCarlo/TakeTimeStep.tpp
+++ b/src/Evolution/Particles/MonteCarlo/TakeTimeStep.tpp
@@ -44,6 +44,7 @@ void TemplatedLocalFunctions<EnergyBins, NeutrinoSpecies>::
 
         const Mesh<3>& mesh,
         const tnsr::I<DataVector, 3, Frame::ElementLogical>& mesh_coordinates,
+        const tnsr::I<DataVector, 3, Frame::Inertial>& inertial_coordinates,
         const std::optional<tnsr::I<DataVector, 3, Frame::Inertial>>&
             mesh_velocity,
         const InverseJacobian<DataVector, 3, Frame::ElementLogical,
@@ -115,7 +116,7 @@ void TemplatedLocalFunctions<EnergyBins, NeutrinoSpecies>::
   evolve_packets(
       packets, random_number_generator,
       &coupling_tilde_tau, &coupling_tilde_s, &coupling_rho_ye,
-      target_end_time, mesh, mesh_coordinates,
+      target_end_time, mesh, mesh_coordinates, inertial_coordinates,
       absorption_opacity, scattering_opacity, energy_at_bin_center,
       lorentz_factor, lower_spatial_four_velocity, lapse, shift, d_lapse,
       d_shift, d_inv_spatial_metric, spatial_metric, inv_spatial_metric,

--- a/src/Evolution/Particles/MonteCarlo/TemplatedLocalFunctions.hpp
+++ b/src/Evolution/Particles/MonteCarlo/TemplatedLocalFunctions.hpp
@@ -78,6 +78,7 @@ struct TemplatedLocalFunctions {
       const tnsr::II<DataVector, 3, Frame::Inertial>& inv_spatial_metric,
       const Scalar<DataVector>& determinant_spatial_metric, const Mesh<3>& mesh,
       const tnsr::I<DataVector, 3, Frame::ElementLogical>& mesh_coordinates,
+      const tnsr::I<DataVector, 3, Frame::Inertial>& inertial_coordinates,
       const std::optional<tnsr::I<DataVector, 3, Frame::Inertial>>&
           mesh_velocity,
       const InverseJacobian<DataVector, 3, Frame::ElementLogical,
@@ -156,11 +157,11 @@ struct TemplatedLocalFunctions {
       gsl::not_null<std::vector<Packet>*> packets,
       gsl::not_null<std::mt19937*> random_number_generator,
       gsl::not_null<Scalar<DataVector>*> coupling_tilde_tau,
-      gsl::not_null<tnsr::i<DataVector, 3, Frame::Inertial>*>
-        coupling_tilde_s,
-      gsl::not_null<Scalar<DataVector>*> coupling_rho_ye,
-      double final_time, const Mesh<3>& mesh,
+      gsl::not_null<tnsr::i<DataVector, 3, Frame::Inertial>*> coupling_tilde_s,
+      gsl::not_null<Scalar<DataVector>*> coupling_rho_ye, double final_time,
+      const Mesh<3>& mesh,
       const tnsr::I<DataVector, 3, Frame::ElementLogical>& mesh_coordinates,
+      const tnsr::I<DataVector, 3, Frame::Inertial>& inertial_coordinates,
       const std::array<std::array<DataVector, EnergyBins>, NeutrinoSpecies>&
           absorption_opacity_table,
       const std::array<std::array<DataVector, EnergyBins>, NeutrinoSpecies>&

--- a/tests/Unit/Evolution/Particles/MonteCarlo/Test_TakeTimeStep.cpp
+++ b/tests/Unit/Evolution/Particles/MonteCarlo/Test_TakeTimeStep.cpp
@@ -88,6 +88,14 @@ void test_flat_space_time_step() {
       DataVector{-0.5, -0.5, 0.5, 0.5, -0.5, -0.5, 0.5, 0.5};
   mesh_coordinates.get(2) =
       DataVector{-0.5, -0.5, -0.5, -0.5, 0.5, 0.5, 0.5, 0.5};
+  tnsr::I<DataVector, 3, Frame::Inertial> inertial_coordinates =
+      make_with_value<tnsr::I<DataVector, 3, Frame::Inertial>>(lapse, 0.0);
+  inertial_coordinates.get(0) =
+      DataVector{-0.5, 0.5, -0.5, 0.5, -0.5, 0.5, -0.5, 0.5};
+  inertial_coordinates.get(1) =
+      DataVector{-0.5, -0.5, 0.5, 0.5, -0.5, -0.5, 0.5, 0.5};
+  inertial_coordinates.get(2) =
+      DataVector{-0.5, -0.5, -0.5, -0.5, 0.5, 0.5, 0.5, 0.5};
 
   Particles::MonteCarlo::Packet packet(1, 1.0, 0, 0.0, -1.0, -1.0, -1.0, 1.0,
                                        1.0, 0.0, 0.0);
@@ -146,7 +154,8 @@ void test_flat_space_time_step() {
       interaction_table, electron_fraction, baryon_density, temperature,
       lorentz_factor, lower_spatial_four_velocity, lapse, shift, d_lapse,
       d_shift, d_inv_spatial_metric, spatial_metric, inv_spatial_metric,
-      determinant_spatial_metric, mesh, mesh_coordinates, mesh_velocity,
+      determinant_spatial_metric, mesh, mesh_coordinates, inertial_coordinates,
+      mesh_velocity,
       inverse_jacobian_logical_to_inertial, det_jacobian_logical_to_inertial,
       jacobian_inertial_to_fluid, inverse_jacobian_inertial_to_fluid);
 


### PR DESCRIPTION
## Proposed changes

Implement limit to the time step that a packet can take if close to a cell boundary in a high opacity region (to deal more accurately with regions where only packets very close to a cell boundary can escape that cell).
This improves the accuracy of e.g. the optically thick sphere test for large optical depths.

### Upgrade instructions

None

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.