### PR TITLE
Register initial magnetic field in EvolveGhValenciaDivClean with Charm.

### DIFF
--- a/src/Elliptic/Executables/Xcts/SolveXcts.hpp
+++ b/src/Elliptic/Executables/Xcts/SolveXcts.hpp
@@ -143,7 +143,11 @@ struct Metavariables {
                 PhaseControl::VisitAndReturn<
                     Parallel::Phase::EvaluateAmrCriteria>,
                 PhaseControl::VisitAndReturn<Parallel::Phase::AdjustDomain>,
-                PhaseControl::VisitAndReturn<Parallel::Phase::CheckDomain>>>>;
+                PhaseControl::VisitAndReturn<Parallel::Phase::CheckDomain>>>,
+        tmpl::pair<
+            grmhd::AnalyticData::InitialMagneticFields::InitialMagneticField,
+            grmhd::AnalyticData::InitialMagneticFields::
+                initial_magnetic_fields>>;
   };
 
   // Collect all reduction tags for observers

--- a/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
+++ b/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
@@ -174,6 +174,7 @@
 #include "PointwiseFunctions/AnalyticData/GhGrMhd/Factory.hpp"
 #include "PointwiseFunctions/AnalyticData/GrMhd/BlastWave.hpp"
 #include "PointwiseFunctions/AnalyticData/GrMhd/BondiHoyleAccretion.hpp"
+#include "PointwiseFunctions/AnalyticData/GrMhd/InitialMagneticFields/Factory.hpp"
 #include "PointwiseFunctions/AnalyticData/GrMhd/MagneticFieldLoop.hpp"
 #include "PointwiseFunctions/AnalyticData/GrMhd/MagneticRotor.hpp"
 #include "PointwiseFunctions/AnalyticData/GrMhd/MagnetizedFmDisk.hpp"
@@ -614,6 +615,10 @@ struct GhValenciaDivCleanTemplateBase<
         tmpl::pair<
             grmhd::GhValenciaDivClean::BoundaryConditions::BoundaryCondition,
             boundary_conditions>,
+        tmpl::pair<
+            grmhd::AnalyticData::InitialMagneticFields::InitialMagneticField,
+            grmhd::AnalyticData::InitialMagneticFields::
+                initial_magnetic_fields>,
         tmpl::pair<gh::gauges::GaugeCondition, gh::gauges::all_gauges>,
         tmpl::pair<evolution::initial_data::InitialData, initial_data_list>,
         // Restrict to monotonic time steppers in LTS to avoid control

--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
@@ -349,6 +349,10 @@ struct EvolutionMetavars<tmpl::list<InterpolationTargetTags...>,
             grmhd::ValenciaDivClean::BoundaryConditions::BoundaryCondition,
             grmhd::ValenciaDivClean::BoundaryConditions::
                 standard_boundary_conditions>,
+        tmpl::pair<
+            grmhd::AnalyticData::InitialMagneticFields::InitialMagneticField,
+            grmhd::AnalyticData::InitialMagneticFields::
+                initial_magnetic_fields>,
         tmpl::pair<LtsTimeStepper, TimeSteppers::lts_time_steppers>,
         tmpl::pair<PhaseChange, PhaseControl::factory_creatable_classes>,
         tmpl::pair<StepChooser<StepChooserUse::LtsStep>,

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/InitialMagneticFields/Factory.hpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/InitialMagneticFields/Factory.hpp
@@ -6,3 +6,10 @@
 #include "PointwiseFunctions/AnalyticData/GrMhd/InitialMagneticFields/InitialMagneticField.hpp"
 #include "PointwiseFunctions/AnalyticData/GrMhd/InitialMagneticFields/Poloidal.hpp"
 #include "PointwiseFunctions/AnalyticData/GrMhd/InitialMagneticFields/Toroidal.hpp"
+
+namespace grmhd::AnalyticData::InitialMagneticFields {
+
+/// Typelist of available InitialMagneticFields
+using initial_magnetic_fields = tmpl::list<Poloidal, Toroidal>;
+
+}  // namespace grmhd::AnalyticData::InitialMagneticFields

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/InitialMagneticFields/InitialMagneticField.hpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/InitialMagneticFields/InitialMagneticField.hpp
@@ -12,10 +12,6 @@
 
 /// \cond
 class DataVector;
-namespace grmhd::AnalyticData::InitialMagneticFields {
-class Poloidal;
-class Toroidal;
-}  // namespace grmhd::AnalyticData::InitialMagneticFields
 
 namespace gsl {
 template <typename T>
@@ -68,8 +64,6 @@ class InitialMagneticField : public PUP::able {
   InitialMagneticField() = default;
 
  public:
-  using creatable_classes = tmpl::list<Poloidal, Toroidal>;
-
   ~InitialMagneticField() override = default;
 
   virtual auto get_clone() const -> std::unique_ptr<InitialMagneticField> = 0;

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryConditions/Test_DirichletAnalytic.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryConditions/Test_DirichletAnalytic.cpp
@@ -38,7 +38,10 @@ struct Metavariables {
             tmpl::list<grmhd::ValenciaDivClean::BoundaryConditions::
                            DirichletAnalytic>>,
         tmpl::pair<evolution::initial_data::InitialData,
-                   grmhd::ValenciaDivClean::InitialData::initial_data_list>>;
+                   grmhd::ValenciaDivClean::InitialData::initial_data_list>,
+        tmpl::pair<
+            grmhd::AnalyticData::InitialMagneticFields::InitialMagneticField,
+            tmpl::list<grmhd::AnalyticData::InitialMagneticFields::Poloidal>>>;
   };
 };
 }  // namespace

--- a/tests/Unit/PointwiseFunctions/AnalyticData/GrMhd/InitialMagneticFields/Test_Poloidal.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/GrMhd/InitialMagneticFields/Test_Poloidal.cpp
@@ -44,7 +44,7 @@ struct PoloidalProxy : Poloidal {
 SPECTRE_TEST_CASE(
     "Unit.PointwiseFunctions.AnalyticData.GrMhd.InitialMagneticFields.Poloidal",
     "[Unit][PointwiseFunctions]") {
-  register_derived_classes_with_charm<InitialMagneticField>();
+  register_classes_with_charm<Poloidal>();
   // test creation
   const auto factory_solution = serialize_and_deserialize(
       TestHelpers::test_factory_creation<InitialMagneticField, Poloidal>(
@@ -70,7 +70,6 @@ SPECTRE_TEST_CASE(
   }
 
   // test derived
-  register_classes_with_charm<Poloidal>();
   const std::unique_ptr<InitialMagneticField> base_ptr =
       std::make_unique<Poloidal>();
   const std::unique_ptr<InitialMagneticField> deserialized_base_ptr =

--- a/tests/Unit/PointwiseFunctions/AnalyticData/GrMhd/InitialMagneticFields/Test_Toroidal.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/GrMhd/InitialMagneticFields/Test_Toroidal.cpp
@@ -44,7 +44,7 @@ struct ToroidalProxy : Toroidal {
 SPECTRE_TEST_CASE(
     "Unit.PointwiseFunctions.AnalyticData.GrMhd.InitialMagneticFields.Toroidal",
     "[Unit][PointwiseFunctions]") {
-  register_derived_classes_with_charm<InitialMagneticField>();
+  register_classes_with_charm<Toroidal>();
   // test creation
   const auto factory_solution = serialize_and_deserialize(
       TestHelpers::test_factory_creation<InitialMagneticField, Toroidal>(
@@ -70,7 +70,6 @@ SPECTRE_TEST_CASE(
   }
 
   // test derived
-  register_classes_with_charm<Toroidal>();
   const std::unique_ptr<InitialMagneticField> base_ptr =
       std::make_unique<Toroidal>();
   const std::unique_ptr<InitialMagneticField> deserialized_base_ptr =


### PR DESCRIPTION
## Proposed changes

<!--
At a high level, describe what this PR does.
-->

Registers `InitialMagneticField` with Charm in EvolveGhValenciaDivClean. Necessary for evolving a magnetized TOV star with GH.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [x] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [x] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [x] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
