### PR TITLE
Expand list of TciStatus

### DIFF
--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TciOnFdGrid.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TciOnFdGrid.cpp
@@ -79,19 +79,23 @@ std::tuple<int, evolution::dg::subcell::RdmpTciData> TciOnFdGrid::apply(
       evolution::dg::subcell::fd::ReconstructionMethod::DimByDim);
 
   if (min(get(dg_tilde_d)) <
-          tci_options.minimum_rest_mass_density_times_lorentz_factor or
-      min(get(dg_tilde_ye)) <
-          tci_options.minimum_rest_mass_density_times_lorentz_factor *
-              tci_options.minimum_ye or
-      min(get(dg_tilde_tau)) < tci_options.minimum_tilde_tau) {
+          tci_options.minimum_rest_mass_density_times_lorentz_factor) {
     return {+1, rdmp_tci_data};
+  }
+  if (min(get(dg_tilde_ye)) <
+          tci_options.minimum_rest_mass_density_times_lorentz_factor *
+              tci_options.minimum_ye) {
+    return {+2, rdmp_tci_data};
+  }
+  if (min(get(dg_tilde_tau)) < tci_options.minimum_tilde_tau) {
+    return {+3, rdmp_tci_data};
   }
 
   const bool in_atmosphere =
       max(get(subcell_rest_mass_density)) < tci_options.atmosphere_density;
 
   if (not(in_atmosphere) and vars_needed_fixing) {
-    return {+2, rdmp_tci_data};
+    return {+4, rdmp_tci_data};
   }
 
   if (not in_atmosphere) {
@@ -105,17 +109,17 @@ std::tuple<int, evolution::dg::subcell::RdmpTciData> TciOnFdGrid::apply(
     if (evolution::dg::subcell::persson_tci(
             dg_tilde_d, dg_mesh, persson_exponent,
             subcell_options.persson_num_highest_modes())) {
-      return {+3, rdmp_tci_data};
+      return {+5, rdmp_tci_data};
     }
     if (evolution::dg::subcell::persson_tci(
             dg_tilde_ye, dg_mesh, persson_exponent,
             subcell_options.persson_num_highest_modes())) {
-      return {+4, rdmp_tci_data};
+      return {+6, rdmp_tci_data};
     }
     if (evolution::dg::subcell::persson_tci(
             dg_pressure, dg_mesh, persson_exponent,
             subcell_options.persson_num_highest_modes())) {
-      return {+5, rdmp_tci_data};
+      return {+7, rdmp_tci_data};
     }
   }
 
@@ -148,7 +152,7 @@ std::tuple<int, evolution::dg::subcell::RdmpTciData> TciOnFdGrid::apply(
           past_rdmp_tci_data.max_variables_values,
           past_rdmp_tci_data.min_variables_values,
           subcell_options.rdmp_delta0(), subcell_options.rdmp_epsilon())) {
-    return {+5 + rdmp_tci_status, rdmp_tci_data};
+    return {+7 + rdmp_tci_status, rdmp_tci_data};
   }
 
   if (tci_options.magnetic_field_cutoff.has_value() and
@@ -156,7 +160,7 @@ std::tuple<int, evolution::dg::subcell::RdmpTciData> TciOnFdGrid::apply(
        evolution::dg::subcell::persson_tci(
            dg_mag_tilde_b, dg_mesh, persson_exponent,
            subcell_options.persson_num_highest_modes()))) {
-    return {+10, rdmp_tci_data};
+    return {+12, rdmp_tci_data};
   }
 
   return {0, rdmp_tci_data};

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TciOnFdGrid.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TciOnFdGrid.hpp
@@ -40,54 +40,60 @@ namespace grmhd::ValenciaDivClean::subcell {
  * <tr><th> Description <th> TCI status
  *
  * <tr><td> if `min(tilde_d)` is less than
- *  `tci_options.minimum_rest_mass_density_times_lorentz_factor`, or if
- *  `min(tilde_ye)` is less than
- *  `tci_options.minimum_rest_mass_density_times_lorentz_factor` times
- *  `tci_options.minimum_ye`, or if `min(tilde_tau)` is less than
- *  `tci_options.minimum_tilde_tau`, then the we remain on FD.
+ *  `tci_options.minimum_rest_mass_density_times_lorentz_factor`, then we
+ *  remain on FD.
  * <td> `+1`
+ *
+ * <tr><td> if `min(tilde_ye)` is less than
+ *  `tci_options.minimum_rest_mass_density_times_lorentz_factor` times
+ *  `tci_options.minimum_ye`, then we remain on FD.
+ * <td> `+2`
+ *
+ * <tr><td> if `min(tilde_tau)` is less than
+ *  `tci_options.minimum_tilde_tau`, then we remain on FD.
+ * <td> `+3`
  *
  * <tr><td> if `grmhd::ValenciaDivClean::Tags::VariablesNeededFixing` is `true`
  *  and the maximum of rest mass density on FD grid is greater than
  * `tci_options.atmosphere_density`, then we remain on FD.
- * <td> `+2`
+ * <td> `+4`
  *
  * <tr><td> apply the Persson TCI to \f$\tilde{D}\f$, \f$\tilde{Y}_e\f$, and
  * pressure if the maximum of rest mass density on FD grid is greater than
  * `tci_options.atmosphere_density`.
- * <td> `+3`
+ * <td> `+5`
  *
  * <tr><td> apply the Persson TCI to \f$\tilde{Y}_e\f$ if the maximum of rest
  * mass density on FD grid is greater than `tci_options.atmosphere_density`.
- * <td> `+4`
+ * <td> `+6`
  *
  * <tr><td> apply the Persson TCI to pressure if the maximum of rest mass
  * density on FD grid is greater than `tci_options.atmosphere_density`. <td>
- * `+5`
+ * `+7`
  *
  * <tr><td> apply the RDMP TCI to `TildeD`
- * <td> `+6`
- *
- * <tr><td> apply the RDMP TCI to `TildeYe`
- * <td> `+7`
- *
- * <tr><td> apply the RDMP TCI to `TildeTau`
  * <td> `+8`
  *
- * <tr><td> apply the RDMP TCI to `TildeB`
+ * <tr><td> apply the RDMP TCI to `TildeYe`
  * <td> `+9`
+ *
+ * <tr><td> apply the RDMP TCI to `TildeTau`
+ * <td> `+10`
+ *
+ * <tr><td> apply the RDMP TCI to `TildeB`
+ * <td> `+11`
  *
  * <tr><td> apply the Persson TCI to the magnitude of \f$\tilde{B}^{n+1}\f$ if
  * its magnitude is greater than `tci_options.magnetic_field_cutoff`.
- * <td> `+10`
+ * <td> `+12`
  *
  * </table>
  *
  * The second column of the table above denotes the value of an integer stored
  * as the first element of the returned `std::tuple`, which indicates the
- * particular kind of check that failed. For example, if the fifth check
+ * particular kind of check that failed. For example, if the tenth check
  * (RDMP TCI to TildeTau) fails and cell is marked as troubled, an integer with
- * value `+5` is stored in the first slot of the returned tuple. Note that this
+ * value `+10` is stored in the first slot of the returned tuple. Note that this
  * integer is marking only the _first_ check to fail, since checks are done in a
  * particular sequence as listed above. If all checks are passed and cell is not
  * troubled, it is returned with the value `0`.

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_TciOnFdGrid.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_TciOnFdGrid.cpp
@@ -248,15 +248,15 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.ValenciaDivClean.Subcell.TciOnFdGrid",
   test(TestThis::AllGood, 0);
   test(TestThis::Atmosphere, 0);
   test(TestThis::NegativeTildeD, 1);
-  test(TestThis::NegativeTildeYe, 1);
-  test(TestThis::NegativeTildeTau, 1);
-  test(TestThis::NeededFixing, 2);
-  test(TestThis::PerssonTildeD, 3);
-  test(TestThis::PerssonTildeYe, 4);
-  test(TestThis::PerssonPressure, 5);
-  test(TestThis::RdmpTildeD, 6);
-  test(TestThis::RdmpTildeYe, 7);
-  test(TestThis::RdmpTildeTau, 8);
-  test(TestThis::RdmpMagnitudeTildeB, 9);
-  test(TestThis::PerssonTildeB, 10);
+  test(TestThis::NegativeTildeYe, 2);
+  test(TestThis::NegativeTildeTau, 3);
+  test(TestThis::NeededFixing, 4);
+  test(TestThis::PerssonTildeD, 5);
+  test(TestThis::PerssonTildeYe, 6);
+  test(TestThis::PerssonPressure, 7);
+  test(TestThis::RdmpTildeD, 8);
+  test(TestThis::RdmpTildeYe, 9);
+  test(TestThis::RdmpTildeTau, 10);
+  test(TestThis::RdmpMagnitudeTildeB, 11);
+  test(TestThis::PerssonTildeB, 12);
 }


### PR DESCRIPTION
## Proposed changes

<!--
At a high level, describe what this PR does.
-->

Expands the list of the number of `TciStatus` options for greater precision in debugging TCI problems. In this case, takes the three options that formerly resulted in `TciStatus = +1` and separated them into separate statuses.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [x] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [x] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [x] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
