### PR TITLE
Add Fraction of Orbit Trigger

### DIFF
--- a/src/Domain/FunctionsOfTime/QuaternionFunctionOfTime.cpp
+++ b/src/Domain/FunctionsOfTime/QuaternionFunctionOfTime.cpp
@@ -387,6 +387,26 @@ QuaternionFunctionOfTime<MaxDeriv>::quat_func_and_3_derivs(
 }
 
 template <size_t MaxDeriv>
+double QuaternionFunctionOfTime<MaxDeriv>::full_angle(const double t) const {
+  double angle = 0.0;
+  auto it = stored_quaternions_and_times_.begin();
+  if (it == stored_quaternions_and_times_.end()) {
+    return angle;
+  }
+  angle += std::abs(
+    2.0 * (acos(quat_func(t)[0][0]) - acos(it->data.R_component_1())));
+  auto it_2 = stored_quaternions_and_times_.begin();
+  it_2++;
+  while (it_2 != stored_quaternions_and_times_.end()) {
+    angle += std::abs(2.0 * (acos(it->data.R_component_1()) -
+                             acos(it_2->data.R_component_1())));
+    it++;
+    it_2++;
+  }
+  return angle;
+}
+
+template <size_t MaxDeriv>
 bool operator==(const QuaternionFunctionOfTime<MaxDeriv>& lhs,
                 const QuaternionFunctionOfTime<MaxDeriv>& rhs) {
   return lhs.stored_quaternions_and_times_ ==

--- a/src/Domain/FunctionsOfTime/QuaternionFunctionOfTime.hpp
+++ b/src/Domain/FunctionsOfTime/QuaternionFunctionOfTime.hpp
@@ -26,7 +26,7 @@ namespace domain::FunctionsOfTime {
  *
  * \details This FunctionOfTime stores quaternions that will be used in the
  * time-dependent rotation map as well as the orbital angular velocity that
- * will be controlled by the rotation control sytem. To get the quaternion, an
+ * will be controlled by the rotation control system. To get the quaternion, an
  * ODE is solved of the form \f$ \dot{q} = \frac{1}{2} q \times \omega \f$
  * where \f$ \omega \f$ is the orbital angular velocity which is stored
  * internally as the derivative of an angle `PiecewisePolynomial`, and
@@ -162,6 +162,10 @@ class QuaternionFunctionOfTime : public FunctionOfTime {
   std::vector<DataVector> angle_func_and_all_derivs(const double t) const {
     return angle_f_of_t_.func_and_all_derivs(t);
   }
+
+  /// Returns the full angle the quaternion has rotated through at an arbitrary
+  /// time `t`.
+  double full_angle(const double t) const;
 
  private:
   template <size_t LocalMaxDeriv>

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
@@ -59,6 +59,7 @@
 #include "Evolution/Systems/GeneralizedHarmonic/System.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
 #include "Evolution/Tags/Filter.hpp"
+#include "Evolution/Triggers/FractionOfOrbit.hpp"
 #include "Evolution/Triggers/SeparationLessThan.hpp"
 #include "Evolution/TypeTraits.hpp"
 #include "IO/Importers/Actions/RegisterWithElementDataReader.hpp"
@@ -476,6 +477,7 @@ struct EvolutionMetavars {
         tmpl::pair<DenseTrigger,
                    tmpl::flatten<tmpl::list<
                        control_system::control_system_triggers<control_systems>,
+                       DenseTriggers::FractionOfOrbit,
                        DenseTriggers::standard_dense_triggers>>>,
         tmpl::pair<
             DomainCreator<volume_dim>,
@@ -528,7 +530,8 @@ struct EvolutionMetavars {
         tmpl::pair<
             Trigger,
             tmpl::append<Triggers::logical_triggers, Triggers::time_triggers,
-                         tmpl::list<Triggers::SeparationLessThan<false>>>>>;
+                         tmpl::list<Triggers::SeparationLessThan<false>>,
+                         tmpl::list<Triggers::FractionOfOrbit>>>>;
   };
 
   // A tmpl::list of tags to be added to the GlobalCache by the

--- a/src/Evolution/Triggers/CMakeLists.txt
+++ b/src/Evolution/Triggers/CMakeLists.txt
@@ -8,6 +8,7 @@ add_spectre_library(${LIBRARY})
 spectre_target_sources(
   ${LIBRARY}
   PRIVATE
+  FractionOfOrbit.cpp
   SeparationLessThan.cpp
   )
 
@@ -15,6 +16,7 @@ spectre_target_headers(
   ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
+  FractionOfOrbit.hpp
   SeparationLessThan.hpp
   )
 

--- a/src/Evolution/Triggers/FractionOfOrbit.cpp
+++ b/src/Evolution/Triggers/FractionOfOrbit.cpp
@@ -1,0 +1,57 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Triggers/FractionOfOrbit.hpp"
+#include <iostream>
+
+#include <cmath>
+#include <cstddef>
+#include <memory>
+#include <pup.h>
+#include <string>
+#include <unordered_map>
+
+namespace DenseTriggers {
+FractionOfOrbit::FractionOfOrbit(const double fraction,
+                                 const double initial_time)
+    : fraction_of_orbit_(fraction), last_trigger_time_(initial_time) {}
+
+void FractionOfOrbit::pup(PUP::er& p) {
+  DenseTrigger::pup(p);
+  p | fraction_of_orbit_;
+  p | last_trigger_time_;
+}
+
+std::optional<bool> FractionOfOrbit::is_triggered_impl(
+    const double time,
+    const std::unordered_map<
+        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+        functions_of_time) {
+  for (auto i = functions_of_time.begin(); i != functions_of_time.end(); i++) {
+    const auto* const rot_f_of_t = dynamic_cast<
+        const domain::FunctionsOfTime::QuaternionFunctionOfTime<3>*>(
+        (i->second.get()));
+    if (rot_f_of_t != nullptr) {
+      if (last_trigger_time_ > time) {
+        return false;
+      }
+      const double orbits_since_last_trigger =
+          abs((rot_f_of_t->full_angle(time) -
+               rot_f_of_t->full_angle(last_trigger_time_))) /
+          (2.0 * M_PI);
+      if (orbits_since_last_trigger >= fraction_of_orbit_) {
+        last_trigger_time_ = time;
+        std::cout << "time when triggered: " << time;
+        return true;
+      } else {
+        return false;
+      }
+    }
+  }
+  ERROR(
+      "FractionOfOrbit trigger can only be used when the rotation map is "
+      "active");
+}
+
+PUP::able::PUP_ID FractionOfOrbit::my_PUP_ID = 0;  // NOLINT
+}  // namespace DenseTriggers

--- a/src/Evolution/Triggers/FractionOfOrbit.hpp
+++ b/src/Evolution/Triggers/FractionOfOrbit.hpp
@@ -1,0 +1,163 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <iostream>
+#include <memory>
+#include <pup.h>
+#include <string>
+
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "Domain/FunctionsOfTime/QuaternionFunctionOfTime.hpp"
+#include "Options/Auto.hpp"
+#include "Options/String.hpp"
+#include "Parallel/AlgorithmExecution.hpp"
+#include "Parallel/ArrayComponentId.hpp"
+#include "Parallel/Callback.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "ParallelAlgorithms/EventsAndDenseTriggers/DenseTrigger.hpp"
+#include "Utilities/Serialization/CharmPupable.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace domain::Tags {
+template <size_t VolumeDim>
+struct Domain;
+struct FunctionsOfTime;
+}  // namespace domain::Tags
+namespace Tags {
+struct Time;
+}  // namespace Tags
+
+namespace DenseTriggers {
+class FractionOfOrbit : public DenseTrigger {
+ public:
+  /// \cond
+  FractionOfOrbit() = default;
+  explicit FractionOfOrbit(CkMigrateMessage* const msg) : DenseTrigger(msg) {}
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(FractionOfOrbit);  // NOLINT
+  /// \endcond
+
+  struct Value {
+    using type = double;
+    static constexpr Options::String help = {
+        "Fraction of an orbit completed between triggers."};
+  };
+
+  struct InitialTime {
+    using type = double;
+    static constexpr Options::String help = {
+        "The initial time of the functions of time"};
+  };
+
+  using options = tmpl::list<Value, InitialTime>;
+  static constexpr Options::String help{
+      "Trigger at a fraction of an orbit since last trigger."};
+
+  explicit FractionOfOrbit(double fraction_of_orbit, double initial_time);
+
+  using is_triggered_return_tags = tmpl::list<>;
+  using is_triggered_argument_tags =
+      tmpl::list<Tags::Time, domain::Tags::FunctionsOfTime>;
+
+  template <typename Metavariables, typename ArrayIndex, typename Component>
+  std::optional<bool> is_triggered(
+      Parallel::GlobalCache<Metavariables>& /*cache*/,
+      const ArrayIndex& /*array_index*/, const Component* /*component*/,
+      const double time,
+      const std::unordered_map<
+          std::string,
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+          functions_of_time) {
+    return is_triggered_impl(time, functions_of_time);
+  }
+
+  using next_check_time_return_tags = tmpl::list<>;
+  using next_check_time_argument_tags =
+      tmpl::list<Tags::Time, domain::Tags::FunctionsOfTime>;
+
+  template <typename Metavariables, typename ArrayIndex,
+            typename ParallelComponent>
+  std::optional<double> next_check_time(
+      Parallel::GlobalCache<Metavariables>& cache,
+      const ArrayIndex& array_index, const ParallelComponent* const /*meta*/,
+      const double time,
+      const std::unordered_map<
+          std::string,
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+          functions_of_time) {
+    for (auto i = functions_of_time.begin(); i != functions_of_time.end();
+         i++) {
+      const auto* const rot_f_of_t = dynamic_cast<
+          const domain::FunctionsOfTime::QuaternionFunctionOfTime<3>*>(
+          (i->second.get()));
+      if (rot_f_of_t != nullptr) {
+        const auto& this_proxy =
+            ::Parallel::get_parallel_component<ParallelComponent>(
+                cache)[array_index];
+        bool ready = rot_f_of_t->time_bounds()[1] > time;
+        // Calculate group_expiration
+        // Parallel::mutable_cache_item_is_ready<domain::Tags::FunctionsOfTime>(
+        //     cache,
+        //     Parallel::make_array_component_id<ParallelComponent>
+        // (array_index),
+        //     [&](const auto& functions_of_time) {
+        //       return ready ? std::unique_ptr<Parallel::Callback>{}
+        //                    : std::unique_ptr<Parallel::Callback>(
+        //                          new Parallel::PerformAlgorithmCallback(
+        //                              this_proxy));
+        //     });
+        if (not ready) {
+          return std::nullopt;
+        }
+        if (last_trigger_time_ > time) {
+          return last_trigger_time_;
+        }
+        const double expiration_time = rot_f_of_t->expiration_after(time);
+        const double sin_func_in_quat =
+            sin(acos(rot_f_of_t->quat_func_and_deriv(time)[0][0]));
+        if (sin_func_in_quat == 0) {
+          return expiration_time;
+        }
+        const double omega =
+            abs(2.0 * rot_f_of_t->quat_func_and_deriv(time)[1][0] /
+                sin_func_in_quat);
+        const double angle_left_to_orbit =
+            2 * M_PI * fraction_of_orbit_ -
+            abs(rot_f_of_t->full_angle(time) -
+                rot_f_of_t->full_angle(last_trigger_time_));
+        const double next_time = time + (angle_left_to_orbit / omega);
+        if (next_time < time) {
+          std::cout << "Is this the problem?";
+          return expiration_time;
+        }
+        std::cout << "expiration time: " << expiration_time;
+        std::cout << "next time: " << next_time;
+        if (expiration_time < next_time) {
+          return expiration_time;
+        } else {
+          return next_time;
+        }
+      }
+    }
+    ERROR(
+        "FractionOfOrbit trigger can only be used when the rotation map is "
+        "active");
+  }
+
+  // NOLINENEXTLINE(google-runtime-references)
+  void pup(PUP::er& p) override;
+
+ private:
+  std::optional<bool> is_triggered_impl(
+      const double time,
+      const std::unordered_map<
+          std::string,
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+          functions_of_time);
+
+  double fraction_of_orbit_{};
+  double last_trigger_time_{};
+};
+}  // namespace DenseTriggers

--- a/tests/Unit/Evolution/Triggers/CMakeLists.txt
+++ b/tests/Unit/Evolution/Triggers/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY "Test_EvolutionTriggers")
 
 set(LIBRARY_SOURCES
+  Test_FractionOfOrbit.cpp
   Test_SeparationLessThan.cpp
   )
 

--- a/tests/Unit/Evolution/Triggers/Test_FractionOfOrbit.cpp
+++ b/tests/Unit/Evolution/Triggers/Test_FractionOfOrbit.cpp
@@ -1,0 +1,86 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cmath>
+
+#include "Domain/CoordinateMaps/TimeDependent/Rotation.hpp"
+#include "Domain/Domain.hpp"
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "Domain/FunctionsOfTime/QuaternionFunctionOfTime.hpp"
+#include "Evolution/Triggers/FractionOfOrbit.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Options/Protocols/FactoryCreation.hpp"
+#include "ParallelAlgorithms/EventsAndTriggers/Trigger.hpp"
+
+namespace {
+struct Metavariables {
+  using component_list = tmpl::list<>;
+  struct factory_creation
+      : tt::ConformsTo<Options::protocols::FactoryCreation> {
+    using factory_classes = tmpl::map<
+        tmpl::pair<Trigger, tmpl::list<DenseTriggers::FractionOfOrbit>>>;
+  };
+};
+
+using RotationMap = domain::CoordinateMaps::TimeDependent::Rotation<3>;
+
+void test() {
+  const std::string f_of_t_name = "Rotation";
+  std::unordered_map<std::string,
+                     std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
+      functions_of_time{};
+  DataVector axis{{0.0, 0.0, 1.0}};
+  std::array<DataVector, 4> init_func = {axis, axis * M_PI / 10, axis * 0.0,
+                                         axis * 0.0};
+  const std::array<DataVector, 1> init_quat{DataVector{
+      {cos(0.5), axis[0] * sin(0.5), axis[1] * sin(0.5), axis[2] * sin(0.5)}}};
+  domain::FunctionsOfTime::QuaternionFunctionOfTime<3> quat_f_of_t{
+      0.0, init_quat, init_func, 20.0};
+  functions_of_time[f_of_t_name] =
+      std::make_unique<domain::FunctionsOfTime::QuaternionFunctionOfTime<3>>(
+          quat_f_of_t);
+  double fraction_of_orbit = 0.25;
+  DenseTriggers::FractionOfOrbit trigger{fraction_of_orbit};
+  int time = 0;
+  while (time <= 20) {
+    bool is_triggered = trigger(time, functions_of_time);
+    bool expected_is_triggered = time % 5 == 0;
+    CHECK(is_triggered == expected_is_triggered);
+    time += 1;
+  }
+
+  TestHelpers::test_creation<std::unique_ptr<Trigger>, Metavariables>(
+      "FractionOfOrbit:\n"
+      "  Value: 0.25");
+}
+
+void test_errors() {
+  const std::string f_of_t_name = "NeonPegasus";
+  std::unordered_map<std::string,
+                     std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
+      functions_of_time{};
+  DataVector axis{{0.0, 0.0, 1.0}};
+  std::array<DataVector, 3> init_func = {axis, axis, axis};
+  const std::array<DataVector, 1> init_quat{
+      DataVector{{0.0, axis[0], axis[1], axis[2]}}};
+  functions_of_time[f_of_t_name] =
+      std::make_unique<domain::FunctionsOfTime::QuaternionFunctionOfTime<2>>(
+          0.0, init_quat, init_func, 20.0);
+
+  DenseTriggers::FractionOfOrbit trigger{0.1};
+
+  CHECK_THROWS_WITH(trigger(0.0, functions_of_time),
+                    Catch::Matchers::ContainsSubstring(
+                        "FractionOfOrbit trigger can only be used when the "
+                        "rotation map is active"));
+}
+
+SPECTRE_TEST_CASE("Unit.Evolution.Triggers.FractionOfOrbit",
+                  "[Unit][Evolution]") {
+  test();
+  test_errors();
+}
+}  // namespace


### PR DESCRIPTION
## Proposed changes

Adds a trigger to do something the user specifies after a certain number of orbits. Addresses #5938 

If you want to try either of these triggers out for something like eccentricity control or Observations after a certain fraction of an orbit, add this to the EventsAndDenseTriggers sections in your yaml.
```
  - Trigger:
      FractionOfOrbit:
        Value: 0.25
    Events:
      - ObservationAhA
      - ObservationAhB
```
** Notes ** 
This isn't fully fleshed out yet. This will calculate the full angle your quaternion has rotated through, but there's something messed up in the logic of when the next check time should be. This causes an issue where the trigger never actually triggers. I didn't have the time to debug it, but that's the state it's currently in. The tests also need a bit of an update.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
