### PR TITLE
Add perturbation option to MagnetizedTovStar

### DIFF
--- a/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/TovStar.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/TovStar.hpp
@@ -215,7 +215,7 @@ struct TovVariables {
   void operator()(gsl::not_null<Scalar<DataType>*> lorentz_factor,
                   gsl::not_null<Cache*> cache,
                   hydro::Tags::LorentzFactor<DataType> /*meta*/) const;
-  void operator()(gsl::not_null<tnsr::I<DataType, 3>*> spatial_velocity,
+  virtual void operator()(gsl::not_null<tnsr::I<DataType, 3>*> spatial_velocity,
                   gsl::not_null<Cache*> cache,
                   hydro::Tags::SpatialVelocity<DataType, 3> /*meta*/) const;
   virtual void operator()(

--- a/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/BoundaryConditions/Test_DirichletAnalytic.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/BoundaryConditions/Test_DirichletAnalytic.cpp
@@ -362,7 +362,8 @@ SPECTRE_TEST_CASE(
             "              CutoffPressure: 0.04\n"
             "              VectorPotentialAmplitude: 2500\n"
             "              Center: [0.0, 0.0, 0.0]\n"
-            "              MaxDistanceFromCenter: 100.0\n")
+            "              MaxDistanceFromCenter: 100.0\n"
+            "        Perturbation: 0.0\n")
             ->get_clone();
 
     const gh::Solutions::WrappedGr<grmhd::AnalyticData::MagnetizedTovStar>
@@ -376,7 +377,7 @@ SPECTRE_TEST_CASE(
                                     InitialMagneticField>>(
                 std::make_unique<
                     grmhd::AnalyticData::InitialMagneticFields::Poloidal>(
-                    2, 0.04, 2500.0, std::array{0.0, 0.0, 0.0}, 100.0))};
+                    2, 0.04, 2500.0, std::array{0.0, 0.0, 0.0}, 100.0)), 0.0};
     const auto serialized_and_deserialized_condition =
         serialize_and_deserialize(
             *dynamic_cast<grmhd::GhValenciaDivClean::BoundaryConditions::

--- a/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/BoundaryConditions/Test_DirichletFreeOutflow.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/BoundaryConditions/Test_DirichletFreeOutflow.cpp
@@ -562,7 +562,8 @@ SPECTRE_TEST_CASE(
             "              CutoffPressure: 0.04\n"
             "              VectorPotentialAmplitude: 2500\n"
             "              Center: [0.0, 0.0, 0.0]\n"
-            "              MaxDistanceFromCenter: 100.0\n")
+            "              MaxDistanceFromCenter: 100.0\n"
+            "        Perturbation: 0.0\n")
             ->get_clone();
     const gh::Solutions::WrappedGr<grmhd::AnalyticData::MagnetizedTovStar>
         analytic_solution_or_data{
@@ -575,7 +576,7 @@ SPECTRE_TEST_CASE(
                                     InitialMagneticField>>(
                 std::make_unique<
                     grmhd::AnalyticData::InitialMagneticFields::Poloidal>(
-                    2, 0.04, 2500.0, std::array{0.0, 0.0, 0.0}, 100.0))};
+                    2, 0.04, 2500.0, std::array{0.0, 0.0, 0.0}, 100.0)), 0.0};
     const auto serialized_and_deserialized_condition =
         serialize_and_deserialize(
             *dynamic_cast<grmhd::GhValenciaDivClean::BoundaryConditions::

--- a/tests/Unit/PointwiseFunctions/AnalyticData/GrMhd/Test_MagnetizedTovStar.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/GrMhd/Test_MagnetizedTovStar.cpp
@@ -44,26 +44,27 @@ void test_equality() {
       1.28e-3,
       std::make_unique<EquationsOfState::PolytropicFluid<true>>(100.0, 2.0),
       TovCoordinates::Schwarzschild,
-      {}};
+      {},
+      0.0};
   const auto mag_tov = serialize_and_deserialize(mag_tov_original);
   CHECK(
       mag_tov ==
       MagnetizedTovStar(
           1.28e-3,
           std::make_unique<EquationsOfState::PolytropicFluid<true>>(100.0, 2.0),
-          TovCoordinates::Schwarzschild, {}));
+          TovCoordinates::Schwarzschild, {}, 0.0));
   CHECK(
       mag_tov !=
       MagnetizedTovStar(
           2.28e-3,
           std::make_unique<EquationsOfState::PolytropicFluid<true>>(100.0, 2.0),
-          TovCoordinates::Schwarzschild, {}));
+          TovCoordinates::Schwarzschild, {}, 0.0));
   CHECK(
       mag_tov !=
       MagnetizedTovStar(
           1.28e-3,
           std::make_unique<EquationsOfState::PolytropicFluid<true>>(100.0, 2.0),
-          TovCoordinates::Isotropic, {}));
+          TovCoordinates::Isotropic, {}, 0.0));
   CHECK(
       mag_tov !=
       MagnetizedTovStar(
@@ -75,7 +76,7 @@ void test_equality() {
                                   InitialMagneticField>>(
               std::make_unique<
                   grmhd::AnalyticData::InitialMagneticFields::Poloidal>(
-                  2, 0.04, 2500.0, std::array{0.0, 0.0, 0.0}, 100.0))));
+                  2, 0.04, 2500.0, std::array{0.0, 0.0, 0.0}, 100.0)), 0.0));
   CHECK(
       MagnetizedTovStar(
           1.28e-3,
@@ -86,7 +87,7 @@ void test_equality() {
                                   InitialMagneticField>>(
               std::make_unique<
                   grmhd::AnalyticData::InitialMagneticFields::Poloidal>(
-                  2, 0.04, 2500.0, std::array{0.0, 0.0, 0.0}, 100.0))) ==
+                  2, 0.04, 2500.0, std::array{0.0, 0.0, 0.0}, 100.0)), 0.0) ==
       MagnetizedTovStar(
           1.28e-3,
           std::make_unique<EquationsOfState::PolytropicFluid<true>>(100.0, 2.0),
@@ -96,7 +97,7 @@ void test_equality() {
                                   InitialMagneticField>>(
               std::make_unique<
                   grmhd::AnalyticData::InitialMagneticFields::Poloidal>(
-                  2, 0.04, 2500.0, std::array{0.0, 0.0, 0.0}, 100.0))));
+                  2, 0.04, 2500.0, std::array{0.0, 0.0, 0.0}, 100.0)), 0.0));
   CHECK(
       MagnetizedTovStar(
           1.28e-3,
@@ -107,7 +108,7 @@ void test_equality() {
                                   InitialMagneticField>>(
               std::make_unique<
                   grmhd::AnalyticData::InitialMagneticFields::Toroidal>(
-                  2, 0.04, 2500.0, std::array{0.0, 0.0, 0.0}, 100.0))) !=
+                  2, 0.04, 2500.0, std::array{0.0, 0.0, 0.0}, 100.0)), 0.0) !=
       MagnetizedTovStar(
           1.28e-3,
           std::make_unique<EquationsOfState::PolytropicFluid<true>>(100.0, 2.0),
@@ -117,7 +118,7 @@ void test_equality() {
                                   InitialMagneticField>>(
               std::make_unique<
                   grmhd::AnalyticData::InitialMagneticFields::Poloidal>(
-                  2, 0.04, 2500.0, std::array{0.0, 0.0, 0.0}, 100.0))));
+                  2, 0.04, 2500.0, std::array{0.0, 0.0, 0.0}, 100.0)), 0.0));
   CHECK(
       MagnetizedTovStar(
           1.28e-3,
@@ -128,7 +129,7 @@ void test_equality() {
                                   InitialMagneticField>>(
               std::make_unique<
                   grmhd::AnalyticData::InitialMagneticFields::Poloidal>(
-                  2, 0.04, 2500.0, std::array{0.0, 0.0, 0.0}, 100.0))) !=
+                  2, 0.04, 2500.0, std::array{0.0, 0.0, 0.0}, 100.0)), 0.0) !=
       MagnetizedTovStar(
           1.28e-3,
           std::make_unique<EquationsOfState::PolytropicFluid<true>>(100.0, 2.0),
@@ -141,7 +142,7 @@ void test_equality() {
                   2, 0.04, 2500.0, std::array{0.0, 0.0, 0.0}, 100.0),
               std::make_unique<
                   grmhd::AnalyticData::InitialMagneticFields::Toroidal>(
-                  2, 0.04, 2500.0, std::array{0.0, 0.0, 0.0}, 100.0))));
+                  2, 0.04, 2500.0, std::array{0.0, 0.0, 0.0}, 100.0)), 0.0));
   // Check order of magnetic fields doesn't matter.
   const MagnetizedTovStar toroidal_plus_poloidal(
       1.28e-3,
@@ -154,7 +155,7 @@ void test_equality() {
               2, 1.0e-6, 2500.0, std::array{0.0, 0.0, 0.0}, 100.0),
           std::make_unique<
               grmhd::AnalyticData::InitialMagneticFields::Poloidal>(
-              2, 1.0e-6, 2500.0, std::array{0.0, 0.0, 0.0}, 100.0)));
+              2, 1.0e-6, 2500.0, std::array{0.0, 0.0, 0.0}, 100.0)), 0.0);
   const MagnetizedTovStar poloidal_plus_toroidal(
       1.28e-3,
       std::make_unique<EquationsOfState::PolytropicFluid<true>>(100.0, 2.0),
@@ -166,7 +167,7 @@ void test_equality() {
               2, 1.0e-6, 2500.0, std::array{0.0, 0.0, 0.0}, 100.0),
           std::make_unique<
               grmhd::AnalyticData::InitialMagneticFields::Toroidal>(
-              2, 1.0e-6, 2500.0, std::array{0.0, 0.0, 0.0}, 100.0)));
+              2, 1.0e-6, 2500.0, std::array{0.0, 0.0, 0.0}, 100.0)), 0.0);
   const DataVector coord{2.0};
   const tnsr::I<DataVector, 3, Frame::Inertial> coords{{coord, coord, coord}};
   CHECK_ITERABLE_APPROX(
@@ -204,7 +205,8 @@ void test_magnetized_tov_star(const TovCoordinates coord_system) {
           "        VectorPotentialAmplitude: 2500\n"
           "        CutoffPressure: 6.5536e-06\n"  // 0.04 * 100 * (1.28e-3)**2
           "        Center: [0.0, 0.0, 0.0]\n"
-          "        MaxDistanceFromCenter: 100.0\n")
+          "        MaxDistanceFromCenter: 100.0\n"
+          "  Perturbation: 0.0\n")
           ->get_clone();
   const auto deserialized_option_solution =
       serialize_and_deserialize(option_solution);


### PR DESCRIPTION
## Proposed changes

Adds a `Perturbation` input option to `MagnetizedTovStar` for the size of an initial radially symmetric perturbation applied to `spatial_velocity` in the interior star region. This is potentially useful for convergence testing/measuring oscillation modes in a high resolution run.

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

I could use feedback over what tests would be useful to add and whether there's a better formulation to use. 
