### PR TITLE
Add python bindings for ModalVector

### DIFF
--- a/src/DataStructures/Python/Bindings.cpp
+++ b/src/DataStructures/Python/Bindings.cpp
@@ -5,10 +5,12 @@
 
 #include "DataStructures/Python/DataVector.hpp"
 #include "DataStructures/Python/Matrix.hpp"
+#include "DataStructures/Python/ModalVector.hpp"
 #include "Utilities/ErrorHandling/SegfaultHandler.hpp"
 
 PYBIND11_MODULE(_Pybindings, m) {  // NOLINT
   enable_segfault_handler();
   py_bindings::bind_datavector(m);
   py_bindings::bind_matrix(m);
+  py_bindings::bind_modalvector(m);
 }

--- a/src/DataStructures/Python/CMakeLists.txt
+++ b/src/DataStructures/Python/CMakeLists.txt
@@ -10,6 +10,7 @@ spectre_python_add_module(
   Bindings.cpp
   DataVector.cpp
   Matrix.cpp
+  ModalVector.cpp
   PYTHON_FILES
   __init__.py
   )
@@ -20,6 +21,7 @@ spectre_python_headers(
   HEADERS
   DataVector.hpp
   Matrix.hpp
+  ModalVector.hpp
   )
 
 spectre_python_link_libraries(

--- a/src/DataStructures/Python/ModalVector.cpp
+++ b/src/DataStructures/Python/ModalVector.cpp
@@ -1,0 +1,144 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "DataStructures/Python/ModalVector.hpp"
+
+#include <memory>
+#include <pybind11/numpy.h>
+#include <pybind11/operators.h>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <sstream>
+#include <string>
+#include <utility>
+
+#include "DataStructures/ModalVector.hpp"
+#include "PythonBindings/BoundChecks.hpp"
+#include "Utilities/GetOutput.hpp"
+
+namespace py = pybind11;
+
+namespace py_bindings {
+void bind_modalvector(py::module& m) {
+  // Wrapper for basic ModalVector operations
+  py::class_<ModalVector>(m, "ModalVector", py::buffer_protocol())
+      .def(py::init<size_t>(), py::arg("size"))
+      .def(py::init<size_t, double>(), py::arg("size"), py::arg("fill"))
+      .def(py::init([](const std::vector<double>& values) {
+             ModalVector result{values.size()};
+             std::copy(values.begin(), values.end(), result.begin());
+             return result;
+           }),
+           py::arg("values"))
+      .def(py::init([](const py::buffer& buffer, const bool copy) {
+             py::buffer_info info = buffer.request();
+             // Sanity-check the buffer
+             if (info.format != py::format_descriptor<double>::format()) {
+               throw std::runtime_error(
+                   "Incompatible format: expected a double array.");
+             }
+             if (info.ndim != 1) {
+               throw std::runtime_error("Incompatible dimension.");
+             }
+             const auto size = static_cast<size_t>(info.shape[0]);
+             auto data = static_cast<double*>(info.ptr);
+             if (copy) {
+               ModalVector result{size};
+               std::copy_n(data, result.size(), result.begin());
+               return result;
+             } else {
+               // Create a non-owning ModalVector from the buffer
+               return ModalVector{data, size};
+             }
+           }),
+           py::arg("buffer"), py::arg("copy") = true)
+      // Expose the data as a Python buffer so it can be cast into Numpy arrays
+      .def_buffer([](ModalVector& data_vector) {
+        return py::buffer_info(data_vector.data(),
+                               // Size of one scalar
+                               sizeof(double),
+                               py::format_descriptor<double>::format(),
+                               // Number of dimensions
+                               1,
+                               // Size of the buffer
+                               {data_vector.size()},
+                               // Stride for each index (in bytes)
+                               {sizeof(double)});
+      })
+      .def(
+          "__iter__",
+          [](const ModalVector& t) {
+            return py::make_iterator(t.begin(), t.end());
+          },
+          // Keep object alive while iterator exists
+          py::keep_alive<0, 1>())
+      // __len__ is for being able to write len(my_data_vector) in python
+      .def("__len__", [](const ModalVector& t) { return t.size(); })
+      // __getitem__ and __setitem__ are the subscript operators (operator[]).
+      // To define (and overload) operator() use __call__
+      .def(
+          "__getitem__",
+          +[](const ModalVector& t, const size_t i) {
+            bounds_check(t, i);
+            return t[i];
+          })
+      .def(
+          "__setitem__",
+          +[](ModalVector& t, const size_t i, const double v) {
+            bounds_check(t, i);
+            t[i] = v;
+          })
+      // Need __str__ for converting to string/printing
+      .def(
+          "__str__", +[](const ModalVector& t) { return get_output(t); })
+      // repr allows you to output the object in an interactive python terminal
+      // using obj to get the "string REPResenting the object".
+      .def(
+          "__repr__", +[](const ModalVector& t) { return get_output(t); })
+      .def(py::self += py::self)
+      // Need to do math explicitly converting to ModalVector because we don't
+      // want to represent all the possible expression template types
+      .def(
+          "abs", +[](const ModalVector& t) { return ModalVector{abs(t)}; })
+      .def(
+          "__mul__",
+          +[](const ModalVector& self, const double other) {
+            return ModalVector{self * other};
+          })
+      .def(
+          "__rmul__",
+          +[](const ModalVector& self, const double other) {
+            return ModalVector{other * self};
+          })
+      .def(
+          "__div__",
+          +[](const ModalVector& self, const double other) {
+            return ModalVector{self / other};
+          })
+      .def(
+          "__truediv__",
+          +[](const ModalVector& self, const double other) {
+            return ModalVector{self / other};
+          })
+
+      // ModalVector-ModalVector math
+      .def(
+          "__add__",
+          +[](const ModalVector& self, const ModalVector& other) {
+            return ModalVector{self + other};
+          })
+      .def(
+          "__sub__",
+          +[](const ModalVector& self, const ModalVector& other) {
+            return ModalVector{self - other};
+          })
+
+      // NOLINTNEXTLINE(misc-redundant-expression)
+      .def(py::self == py::self)
+      // NOLINTNEXTLINE(misc-redundant-expression)
+      .def(py::self != py::self)
+      .def(
+          "__neg__", +[](const ModalVector& t) { return ModalVector{-t}; });
+  py::implicitly_convertible<py::array, ModalVector>();
+}
+}  // namespace py_bindings

--- a/src/DataStructures/Python/ModalVector.hpp
+++ b/src/DataStructures/Python/ModalVector.hpp
@@ -1,0 +1,11 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <pybind11/pybind11.h>
+
+namespace py_bindings {
+// NOLINTNEXTLINE(google-runtime-references)
+void bind_modalvector(pybind11::module& m);
+}  // namespace py_bindings

--- a/tests/Unit/DataStructures/CMakeLists.txt
+++ b/tests/Unit/DataStructures/CMakeLists.txt
@@ -73,3 +73,8 @@ spectre_add_python_bindings_test(
   Test_Matrix.py
   "Unit;DataStructures;Python"
   PyDataStructures)
+spectre_add_python_bindings_test(
+  "Unit.DataStructures.Python.ModalVector"
+  Test_ModalVector.py
+  "Unit;DataStructures;Python"
+  PyDataStructures)

--- a/tests/Unit/DataStructures/Test_ModalVector.py
+++ b/tests/Unit/DataStructures/Test_ModalVector.py
@@ -1,0 +1,113 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import math
+import unittest
+
+import numpy as np
+import numpy.testing as npt
+
+from spectre.DataStructures import ModalVector
+
+
+class TestModalVector(unittest.TestCase):
+    def test_len(self):
+        a = ModalVector(5, 6.7)
+        self.assertEqual(len(a), 5)
+
+    def test_math_double(self):
+        b = ModalVector([7.2, -3.9])
+
+        self.assertEqual((2.0 * b)[0], 14.4)
+        self.assertEqual((2.0 * b)[1], -7.8)
+        self.assertEqual((b * 2.0)[0], 14.4)
+        self.assertEqual((b * 2.0)[1], -7.8)
+
+        self.assertEqual((b / 2.0)[0], 3.6)
+        self.assertEqual((b / 2.0)[1], -1.95)
+
+    def test_math_modalvector(self):
+        a = ModalVector(5, 6.7)
+        b = ModalVector(5, 8.7)
+        self.assertEqual(a + b, ModalVector(5, 6.7 + 8.7))
+        self.assertEqual(a - b, ModalVector(5, 6.7 - 8.7))
+
+        c = ModalVector([1.5, 2.5])
+        d = ModalVector([3.0, 7.5])
+        self.assertEqual((c + d)[0], 4.5)
+        self.assertEqual((c + d)[1], 10.0)
+        self.assertEqual((c - d)[0], -1.5)
+        self.assertEqual((c - d)[1], -5.0)
+
+    def test_negate(self):
+        a = ModalVector(5, 6.7)
+        self.assertEqual(-a, ModalVector(5, -6.7))
+        b = ModalVector([1.5, 3.7])
+        self.assertEqual((-b)[0], -1.5)
+        self.assertEqual((-b)[1], -3.7)
+
+    def test_bounds_check(self):
+        a = ModalVector(5, 6.7)
+        self.assertRaises(RuntimeError, lambda: a[5])
+
+        def assignment_test():
+            a[5] = 8
+
+        self.assertRaises(RuntimeError, assignment_test)
+
+    def test_output(self):
+        a = ModalVector(5, 6.7)
+        self.assertEqual(str(a), "(6.7,6.7,6.7,6.7,6.7)")
+        b = ModalVector([3.8, 7.2])
+        self.assertEqual(str(b), "(3.8,7.2)")
+
+    def test_abs(self):
+        a = ModalVector(5, -6.0)
+        self.assertEqual(a.abs(), ModalVector(5, 6.0))
+        b = ModalVector([1.0, -2.0])
+        self.assertEqual(b.abs()[0], 1.0)
+        self.assertEqual(b.abs()[1], 2.0)
+
+    def test_numpy_compatibility(self):
+        b = np.array([1.0, 2.0, 3.0])
+        c = ModalVector([1.0, 2.0, 3.0])
+        self.assertTrue(((b + c) == np.array([2.0, 4.0, 6.0])).all())
+        x = np.linspace(0, 2 * np.pi, 10)
+        npt.assert_allclose(ModalVector(x).abs(), np.abs(x))
+        # Convert a ModalVector to a Numpy array
+        c_array_copy = np.array(c)
+        npt.assert_equal(c_array_copy, b)
+        # Changing the copy shouldn't change the ModalVector
+        c_array_copy[2] = 4.0
+        npt.assert_equal(c, b)
+        c_array_reference = np.array(c, copy=False)
+        npt.assert_equal(c_array_reference, b)
+        # Changing the reference should change the ModalVector as well
+        c_array_reference[2] = 4.0
+        self.assertEqual(c[2], 4.0)
+        # Convert a Numpy array to a ModalVector
+        b_dv_copy = ModalVector(b)
+        self.assertEqual(b_dv_copy, ModalVector([1.0, 2.0, 3.0]))
+        b_dv_copy[2] = 4.0
+        self.assertEqual(b[2], 3.0)
+        b_dv_reference = ModalVector(b, copy=False)
+        b_dv_reference[2] = 4.0
+        self.assertEqual(b[2], 4.0)
+
+    def test_iterator(self):
+        a = ModalVector([1.0, 2.0, 3.0, 4.0, 5.0])
+        for i, val in enumerate(a):
+            self.assertEqual(val, a[i])
+
+    def test_size_constructor(self):
+        a = ModalVector(3)
+        self.assertEqual(len(a), 3)
+
+    def test_list_constructor(self):
+        a = ModalVector([1.0, 2.0, 3.0, 4.0, 5.0])
+        self.assertEqual(len(a), 5)
+        self.assertEqual(a[3], 4.0)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Proposed changes

Add python bindings to ModalVector, which will be needed for the merger->ringdown transition for BBH evolutions.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
