### PR TITLE
Split time-stepper-history cleaning from update

### DIFF
--- a/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
+++ b/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
@@ -236,7 +236,7 @@ struct EvolutionMetavars {
               Actions::RecordTimeStepperData<system>,
               evolution::Actions::RunEventsAndDenseTriggers<tmpl::list<>>,
               Actions::UpdateU<system>>>,
-      Actions::CleanHistory<system>,
+      Actions::CleanHistory<system, local_time_stepping>,
       Limiters::Actions::SendData<EvolutionMetavars>,
       Limiters::Actions::Limit<EvolutionMetavars>>>;
 
@@ -255,7 +255,7 @@ struct EvolutionMetavars {
               Actions::UpdateU<system>>>,
       evolution::dg::subcell::Actions::TciAndRollback<
           Burgers::subcell::TciOnDgGrid>,
-      Actions::CleanHistory<system>,
+      Actions::CleanHistory<system, local_time_stepping>,
       Actions::Goto<evolution::dg::subcell::Actions::Labels::EndOfSolvers>,
       Actions::Label<evolution::dg::subcell::Actions::Labels::BeginSubcell>,
       evolution::dg::subcell::Actions::SendDataForReconstruction<
@@ -268,7 +268,7 @@ struct EvolutionMetavars {
       Actions::RecordTimeStepperData<system>,
       evolution::Actions::RunEventsAndDenseTriggers<tmpl::list<>>,
       Actions::UpdateU<system>,
-      Actions::CleanHistory<system>,
+      Actions::CleanHistory<system, local_time_stepping>,
       evolution::dg::subcell::Actions::TciAndSwitchToDg<
           Burgers::subcell::TciOnFdGrid>,
       Actions::Label<evolution::dg::subcell::Actions::Labels::EndOfSolvers>>>;

--- a/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
+++ b/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
@@ -88,6 +88,7 @@
 #include "PointwiseFunctions/AnalyticSolutions/Burgers/Step.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
 #include "Time/Actions/AdvanceTime.hpp"
+#include "Time/Actions/CleanHistory.hpp"
 #include "Time/Actions/RecordTimeStepperData.hpp"
 #include "Time/Actions/SelfStartActions.hpp"
 #include "Time/Actions/UpdateU.hpp"
@@ -235,6 +236,7 @@ struct EvolutionMetavars {
               Actions::RecordTimeStepperData<system>,
               evolution::Actions::RunEventsAndDenseTriggers<tmpl::list<>>,
               Actions::UpdateU<system>>>,
+      Actions::CleanHistory<system>,
       Limiters::Actions::SendData<EvolutionMetavars>,
       Limiters::Actions::Limit<EvolutionMetavars>>>;
 
@@ -253,6 +255,7 @@ struct EvolutionMetavars {
               Actions::UpdateU<system>>>,
       evolution::dg::subcell::Actions::TciAndRollback<
           Burgers::subcell::TciOnDgGrid>,
+      Actions::CleanHistory<system>,
       Actions::Goto<evolution::dg::subcell::Actions::Labels::EndOfSolvers>,
       Actions::Label<evolution::dg::subcell::Actions::Labels::BeginSubcell>,
       evolution::dg::subcell::Actions::SendDataForReconstruction<
@@ -265,6 +268,7 @@ struct EvolutionMetavars {
       Actions::RecordTimeStepperData<system>,
       evolution::Actions::RunEventsAndDenseTriggers<tmpl::list<>>,
       Actions::UpdateU<system>,
+      Actions::CleanHistory<system>,
       evolution::dg::subcell::Actions::TciAndSwitchToDg<
           Burgers::subcell::TciOnFdGrid>,
       Actions::Label<evolution::dg::subcell::Actions::Labels::EndOfSolvers>>>;

--- a/src/Evolution/Executables/CurvedScalarWave/EvolveCurvedScalarWave.hpp
+++ b/src/Evolution/Executables/CurvedScalarWave/EvolveCurvedScalarWave.hpp
@@ -89,6 +89,7 @@
 #include "PointwiseFunctions/MathFunctions/Factory.hpp"
 #include "PointwiseFunctions/MathFunctions/MathFunction.hpp"
 #include "Time/Actions/AdvanceTime.hpp"
+#include "Time/Actions/CleanHistory.hpp"
 #include "Time/Actions/RecordTimeStepperData.hpp"
 #include "Time/Actions/SelfStartActions.hpp"
 #include "Time/Actions/UpdateU.hpp"
@@ -251,6 +252,7 @@ struct EvolutionMetavars {
               Actions::RecordTimeStepperData<system>,
               evolution::Actions::RunEventsAndDenseTriggers<tmpl::list<>>,
               Actions::UpdateU<system>>>,
+      Actions::CleanHistory<system>,
       tmpl::conditional_t<
           use_filtering,
           dg::Actions::Filter<Filters::Exponential<0>,

--- a/src/Evolution/Executables/CurvedScalarWave/EvolveCurvedScalarWave.hpp
+++ b/src/Evolution/Executables/CurvedScalarWave/EvolveCurvedScalarWave.hpp
@@ -252,7 +252,7 @@ struct EvolutionMetavars {
               Actions::RecordTimeStepperData<system>,
               evolution::Actions::RunEventsAndDenseTriggers<tmpl::list<>>,
               Actions::UpdateU<system>>>,
-      Actions::CleanHistory<system>,
+      Actions::CleanHistory<system, local_time_stepping>,
       tmpl::conditional_t<
           use_filtering,
           dg::Actions::Filter<Filters::Exponential<0>,

--- a/src/Evolution/Executables/CurvedScalarWave/EvolveWorldtubeCurvedScalarWave.hpp
+++ b/src/Evolution/Executables/CurvedScalarWave/EvolveWorldtubeCurvedScalarWave.hpp
@@ -255,7 +255,7 @@ struct EvolutionMetavars {
       Actions::RecordTimeStepperData<system>,
       evolution::Actions::RunEventsAndDenseTriggers<tmpl::list<>>,
       Actions::UpdateU<system>,
-      Actions::CleanHistory<system>,
+      Actions::CleanHistory<system, local_time_stepping>,
       tmpl::conditional_t<
           use_filtering,
           dg::Actions::Filter<

--- a/src/Evolution/Executables/CurvedScalarWave/EvolveWorldtubeCurvedScalarWave.hpp
+++ b/src/Evolution/Executables/CurvedScalarWave/EvolveWorldtubeCurvedScalarWave.hpp
@@ -102,6 +102,7 @@
 #include "PointwiseFunctions/MathFunctions/Factory.hpp"
 #include "PointwiseFunctions/MathFunctions/MathFunction.hpp"
 #include "Time/Actions/AdvanceTime.hpp"
+#include "Time/Actions/CleanHistory.hpp"
 #include "Time/Actions/RecordTimeStepperData.hpp"
 #include "Time/Actions/SelfStartActions.hpp"
 #include "Time/Actions/UpdateU.hpp"
@@ -254,6 +255,7 @@ struct EvolutionMetavars {
       Actions::RecordTimeStepperData<system>,
       evolution::Actions::RunEventsAndDenseTriggers<tmpl::list<>>,
       Actions::UpdateU<system>,
+      Actions::CleanHistory<system>,
       tmpl::conditional_t<
           use_filtering,
           dg::Actions::Filter<

--- a/src/Evolution/Executables/ForceFree/EvolveForceFree.hpp
+++ b/src/Evolution/Executables/ForceFree/EvolveForceFree.hpp
@@ -74,6 +74,7 @@
 #include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
 #include "PointwiseFunctions/InitialDataUtilities/InitialData.hpp"
 #include "Time/Actions/AdvanceTime.hpp"
+#include "Time/Actions/CleanHistory.hpp"
 #include "Time/Actions/RecordTimeStepperData.hpp"
 #include "Time/Actions/SelfStartActions.hpp"
 #include "Time/Actions/UpdateU.hpp"
@@ -195,6 +196,7 @@ struct EvolutionMetavars {
               Actions::RecordTimeStepperData<system>,
               evolution::Actions::RunEventsAndDenseTriggers<tmpl::list<>>,
               Actions::UpdateU<system>>>,
+      Actions::CleanHistory<system>,
       Limiters::Actions::SendData<EvolutionMetavars>,
       Limiters::Actions::Limit<EvolutionMetavars>,
 

--- a/src/Evolution/Executables/ForceFree/EvolveForceFree.hpp
+++ b/src/Evolution/Executables/ForceFree/EvolveForceFree.hpp
@@ -196,7 +196,7 @@ struct EvolutionMetavars {
               Actions::RecordTimeStepperData<system>,
               evolution::Actions::RunEventsAndDenseTriggers<tmpl::list<>>,
               Actions::UpdateU<system>>>,
-      Actions::CleanHistory<system>,
+      Actions::CleanHistory<system, local_time_stepping>,
       Limiters::Actions::SendData<EvolutionMetavars>,
       Limiters::Actions::Limit<EvolutionMetavars>,
 

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
@@ -156,6 +156,7 @@
 #include "PointwiseFunctions/GeneralRelativity/WeylTypeD1.hpp"
 #include "PointwiseFunctions/InitialDataUtilities/InitialData.hpp"
 #include "Time/Actions/AdvanceTime.hpp"
+#include "Time/Actions/CleanHistory.hpp"
 #include "Time/Actions/RecordTimeStepperData.hpp"
 #include "Time/Actions/SelfStartActions.hpp"
 #include "Time/Actions/UpdateU.hpp"
@@ -549,6 +550,7 @@ struct EvolutionMetavars {
                   ::domain::CheckFunctionsOfTimeAreReadyPostprocessor>>,
               control_system::Actions::LimitTimeStep<control_systems>,
               Actions::UpdateU<system>>>,
+      Actions::CleanHistory<system>,
       dg::Actions::Filter<
           Filters::Exponential<0>,
           tmpl::list<gr::Tags::SpacetimeMetric<DataVector, volume_dim>,

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
@@ -550,7 +550,7 @@ struct EvolutionMetavars {
                   ::domain::CheckFunctionsOfTimeAreReadyPostprocessor>>,
               control_system::Actions::LimitTimeStep<control_systems>,
               Actions::UpdateU<system>>>,
-      Actions::CleanHistory<system>,
+      Actions::CleanHistory<system, local_time_stepping>,
       dg::Actions::Filter<
           Filters::Exponential<0>,
           tmpl::list<gr::Tags::SpacetimeMetric<DataVector, volume_dim>,

--- a/src/Evolution/Executables/GeneralizedHarmonic/GeneralizedHarmonicBase.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/GeneralizedHarmonicBase.hpp
@@ -126,6 +126,7 @@
 #include "PointwiseFunctions/MathFunctions/Factory.hpp"
 #include "PointwiseFunctions/MathFunctions/MathFunction.hpp"
 #include "Time/Actions/AdvanceTime.hpp"
+#include "Time/Actions/CleanHistory.hpp"
 #include "Time/Actions/RecordTimeStepperData.hpp"
 #include "Time/Actions/SelfStartActions.hpp"
 #include "Time/Actions/UpdateU.hpp"
@@ -389,6 +390,7 @@ struct GeneralizedHarmonicTemplateBase {
               evolution::Actions::RunEventsAndDenseTriggers<tmpl::list<>>,
               control_system::Actions::LimitTimeStep<ControlSystems>,
               Actions::UpdateU<system>>>,
+      Actions::CleanHistory<system>,
       dg::Actions::Filter<
           Filters::Exponential<0>,
           tmpl::list<gr::Tags::SpacetimeMetric<DataVector, volume_dim>,

--- a/src/Evolution/Executables/GeneralizedHarmonic/GeneralizedHarmonicBase.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/GeneralizedHarmonicBase.hpp
@@ -390,7 +390,7 @@ struct GeneralizedHarmonicTemplateBase {
               evolution::Actions::RunEventsAndDenseTriggers<tmpl::list<>>,
               control_system::Actions::LimitTimeStep<ControlSystems>,
               Actions::UpdateU<system>>>,
-      Actions::CleanHistory<system>,
+      Actions::CleanHistory<system, local_time_stepping>,
       dg::Actions::Filter<
           Filters::Exponential<0>,
           tmpl::list<gr::Tags::SpacetimeMetric<DataVector, volume_dim>,

--- a/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
+++ b/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
@@ -214,6 +214,7 @@
 #include "PointwiseFunctions/Hydro/TransportVelocity.hpp"
 #include "PointwiseFunctions/InitialDataUtilities/Tags/InitialData.hpp"
 #include "Time/Actions/AdvanceTime.hpp"
+#include "Time/Actions/CleanHistory.hpp"
 #include "Time/Actions/RecordTimeStepperData.hpp"
 #include "Time/Actions/SelfStartActions.hpp"
 #include "Time/Actions/SelfStartActions.hpp"  // IWYU pragma: keep
@@ -711,6 +712,7 @@ struct GhValenciaDivCleanTemplateBase<
                   system, volume_dim, false>,
               Actions::RecordTimeStepperData<system>,
               Actions::UpdateU<system>>>,
+      Actions::CleanHistory<system>,
       Limiters::Actions::SendData<derived_metavars>,
       Limiters::Actions::Limit<derived_metavars>,
       VariableFixing::Actions::FixVariables<
@@ -740,6 +742,7 @@ struct GhValenciaDivCleanTemplateBase<
       evolution::dg::subcell::Actions::TciAndRollback<
           grmhd::GhValenciaDivClean::subcell::TciOnDgGrid<
               tmpl::front<ordered_list_of_primitive_recovery_schemes>>>,
+      Actions::CleanHistory<system>,
       VariableFixing::Actions::FixVariables<
           VariableFixing::FixToAtmosphere<volume_dim>>,
       VariableFixing::Actions::FixVariables<VariableFixing::LimitLorentzFactor>,
@@ -764,6 +767,7 @@ struct GhValenciaDivCleanTemplateBase<
           events_and_dense_triggers_subcell_postprocessors>,
       control_system::Actions::LimitTimeStep<control_systems>,
       Actions::UpdateU<system>,
+      Actions::CleanHistory<system>,
       Actions::MutateApply<
           grmhd::GhValenciaDivClean::subcell::FixConservativesAndComputePrims<
               ordered_list_of_primitive_recovery_schemes>>,

--- a/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
+++ b/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
@@ -712,7 +712,7 @@ struct GhValenciaDivCleanTemplateBase<
                   system, volume_dim, false>,
               Actions::RecordTimeStepperData<system>,
               Actions::UpdateU<system>>>,
-      Actions::CleanHistory<system>,
+      Actions::CleanHistory<system, local_time_stepping>,
       Limiters::Actions::SendData<derived_metavars>,
       Limiters::Actions::Limit<derived_metavars>,
       VariableFixing::Actions::FixVariables<
@@ -742,7 +742,7 @@ struct GhValenciaDivCleanTemplateBase<
       evolution::dg::subcell::Actions::TciAndRollback<
           grmhd::GhValenciaDivClean::subcell::TciOnDgGrid<
               tmpl::front<ordered_list_of_primitive_recovery_schemes>>>,
-      Actions::CleanHistory<system>,
+      Actions::CleanHistory<system, local_time_stepping>,
       VariableFixing::Actions::FixVariables<
           VariableFixing::FixToAtmosphere<volume_dim>>,
       VariableFixing::Actions::FixVariables<VariableFixing::LimitLorentzFactor>,
@@ -767,7 +767,7 @@ struct GhValenciaDivCleanTemplateBase<
           events_and_dense_triggers_subcell_postprocessors>,
       control_system::Actions::LimitTimeStep<control_systems>,
       Actions::UpdateU<system>,
-      Actions::CleanHistory<system>,
+      Actions::CleanHistory<system, local_time_stepping>,
       Actions::MutateApply<
           grmhd::GhValenciaDivClean::subcell::FixConservativesAndComputePrims<
               ordered_list_of_primitive_recovery_schemes>>,

--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
@@ -426,7 +426,7 @@ struct EvolutionMetavars<tmpl::list<InterpolationTargetTags...>,
                   tmpl::list<system::primitive_from_conservative<
                       ordered_list_of_primitive_recovery_schemes>>>,
               Actions::UpdateU<system>>>,
-      Actions::CleanHistory<system>,
+      Actions::CleanHistory<system, local_time_stepping>,
       Limiters::Actions::SendData<EvolutionMetavars>,
       Limiters::Actions::Limit<EvolutionMetavars>,
       VariableFixing::Actions::FixVariables<grmhd::ValenciaDivClean::Flattener<
@@ -456,7 +456,7 @@ struct EvolutionMetavars<tmpl::list<InterpolationTargetTags...>,
       evolution::dg::subcell::Actions::TciAndRollback<
           grmhd::ValenciaDivClean::subcell::TciOnDgGrid<
               tmpl::front<ordered_list_of_primitive_recovery_schemes>>>,
-      Actions::CleanHistory<system>,
+      Actions::CleanHistory<system, local_time_stepping>,
       parameterized_deleptonization,
       VariableFixing::Actions::FixVariables<
           VariableFixing::FixToAtmosphere<volume_dim>>,
@@ -487,7 +487,7 @@ struct EvolutionMetavars<tmpl::list<InterpolationTargetTags...>,
       evolution::Actions::RunEventsAndDenseTriggers<
           events_and_dense_triggers_subcell_postprocessors>,
       Actions::UpdateU<system>,
-      Actions::CleanHistory<system>,
+      Actions::CleanHistory<system, local_time_stepping>,
       Actions::MutateApply<
           grmhd::ValenciaDivClean::subcell::FixConservativesAndComputePrims<
               ordered_list_of_primitive_recovery_schemes>>,

--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
@@ -167,6 +167,7 @@
 #include "PointwiseFunctions/Hydro/Tags.hpp"
 #include "PointwiseFunctions/Hydro/TransportVelocity.hpp"
 #include "Time/Actions/AdvanceTime.hpp"
+#include "Time/Actions/CleanHistory.hpp"
 #include "Time/Actions/RecordTimeStepperData.hpp"
 #include "Time/Actions/SelfStartActions.hpp"  // IWYU pragma: keep
 #include "Time/Actions/UpdateU.hpp"
@@ -425,6 +426,7 @@ struct EvolutionMetavars<tmpl::list<InterpolationTargetTags...>,
                   tmpl::list<system::primitive_from_conservative<
                       ordered_list_of_primitive_recovery_schemes>>>,
               Actions::UpdateU<system>>>,
+      Actions::CleanHistory<system>,
       Limiters::Actions::SendData<EvolutionMetavars>,
       Limiters::Actions::Limit<EvolutionMetavars>,
       VariableFixing::Actions::FixVariables<grmhd::ValenciaDivClean::Flattener<
@@ -454,6 +456,7 @@ struct EvolutionMetavars<tmpl::list<InterpolationTargetTags...>,
       evolution::dg::subcell::Actions::TciAndRollback<
           grmhd::ValenciaDivClean::subcell::TciOnDgGrid<
               tmpl::front<ordered_list_of_primitive_recovery_schemes>>>,
+      Actions::CleanHistory<system>,
       parameterized_deleptonization,
       VariableFixing::Actions::FixVariables<
           VariableFixing::FixToAtmosphere<volume_dim>>,
@@ -484,6 +487,7 @@ struct EvolutionMetavars<tmpl::list<InterpolationTargetTags...>,
       evolution::Actions::RunEventsAndDenseTriggers<
           events_and_dense_triggers_subcell_postprocessors>,
       Actions::UpdateU<system>,
+      Actions::CleanHistory<system>,
       Actions::MutateApply<
           grmhd::ValenciaDivClean::subcell::FixConservativesAndComputePrims<
               ordered_list_of_primitive_recovery_schemes>>,

--- a/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
+++ b/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
@@ -99,6 +99,7 @@
 #include "PointwiseFunctions/Hydro/EquationsOfState/RegisterDerivedWithCharm.hpp"
 #include "PointwiseFunctions/Hydro/Tags.hpp"
 #include "Time/Actions/AdvanceTime.hpp"
+#include "Time/Actions/CleanHistory.hpp"
 #include "Time/Actions/RecordTimeStepperData.hpp"
 #include "Time/Actions/SelfStartActions.hpp"
 #include "Time/Actions/UpdateU.hpp"
@@ -296,6 +297,7 @@ struct EvolutionMetavars {
               evolution::Actions::RunEventsAndDenseTriggers<
                   tmpl::list<typename system::primitive_from_conservative>>,
               Actions::UpdateU<system>>>,
+      Actions::CleanHistory<system>,
       Limiters::Actions::SendData<EvolutionMetavars>,
       Limiters::Actions::Limit<EvolutionMetavars>,
       // Conservative `UpdatePrimitives` expects system to possess
@@ -339,6 +341,7 @@ struct EvolutionMetavars {
       // Note: The primitive variables are computed as part of the TCI.
       evolution::dg::subcell::Actions::TciAndRollback<
           NewtonianEuler::subcell::TciOnDgGrid<volume_dim>>,
+      Actions::CleanHistory<system>,
       Actions::Goto<evolution::dg::subcell::Actions::Labels::EndOfSolvers>,
 
       Actions::Label<evolution::dg::subcell::Actions::Labels::BeginSubcell>,
@@ -354,6 +357,7 @@ struct EvolutionMetavars {
       evolution::dg::subcell::fd::Actions::TakeTimeStep<
           NewtonianEuler::subcell::TimeDerivative<volume_dim>>,
       Actions::RecordTimeStepperData<system>, Actions::UpdateU<system>,
+      Actions::CleanHistory<system>,
       Actions::MutateApply<typename system::primitive_from_conservative>,
       evolution::dg::subcell::Actions::TciAndSwitchToDg<
           NewtonianEuler::subcell::TciOnFdGrid<volume_dim>>,

--- a/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
+++ b/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
@@ -297,7 +297,7 @@ struct EvolutionMetavars {
               evolution::Actions::RunEventsAndDenseTriggers<
                   tmpl::list<typename system::primitive_from_conservative>>,
               Actions::UpdateU<system>>>,
-      Actions::CleanHistory<system>,
+      Actions::CleanHistory<system, local_time_stepping>,
       Limiters::Actions::SendData<EvolutionMetavars>,
       Limiters::Actions::Limit<EvolutionMetavars>,
       // Conservative `UpdatePrimitives` expects system to possess
@@ -341,7 +341,7 @@ struct EvolutionMetavars {
       // Note: The primitive variables are computed as part of the TCI.
       evolution::dg::subcell::Actions::TciAndRollback<
           NewtonianEuler::subcell::TciOnDgGrid<volume_dim>>,
-      Actions::CleanHistory<system>,
+      Actions::CleanHistory<system, local_time_stepping>,
       Actions::Goto<evolution::dg::subcell::Actions::Labels::EndOfSolvers>,
 
       Actions::Label<evolution::dg::subcell::Actions::Labels::BeginSubcell>,
@@ -357,7 +357,7 @@ struct EvolutionMetavars {
       evolution::dg::subcell::fd::Actions::TakeTimeStep<
           NewtonianEuler::subcell::TimeDerivative<volume_dim>>,
       Actions::RecordTimeStepperData<system>, Actions::UpdateU<system>,
-      Actions::CleanHistory<system>,
+      Actions::CleanHistory<system, local_time_stepping>,
       Actions::MutateApply<typename system::primitive_from_conservative>,
       evolution::dg::subcell::Actions::TciAndSwitchToDg<
           NewtonianEuler::subcell::TciOnFdGrid<volume_dim>>,

--- a/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveM1Grey.hpp
+++ b/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveM1Grey.hpp
@@ -69,6 +69,7 @@
 #include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
 #include "PointwiseFunctions/Hydro/Tags.hpp"
 #include "Time/Actions/AdvanceTime.hpp"
+#include "Time/Actions/CleanHistory.hpp"
 #include "Time/Actions/RecordTimeStepperData.hpp"
 #include "Time/Actions/SelfStartActions.hpp"  // IWYU pragma: keep
 #include "Time/Actions/UpdateU.hpp"
@@ -200,6 +201,7 @@ struct EvolutionMetavars {
               Actions::RecordTimeStepperData<system>,
               evolution::Actions::RunEventsAndDenseTriggers<tmpl::list<>>,
               Actions::UpdateU<system>>>,
+      Actions::CleanHistory<system>,
       Limiters::Actions::SendData<EvolutionMetavars>,
       Limiters::Actions::Limit<EvolutionMetavars>,
       Actions::MutateApply<typename RadiationTransport::M1Grey::

--- a/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveM1Grey.hpp
+++ b/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveM1Grey.hpp
@@ -201,7 +201,7 @@ struct EvolutionMetavars {
               Actions::RecordTimeStepperData<system>,
               evolution::Actions::RunEventsAndDenseTriggers<tmpl::list<>>,
               Actions::UpdateU<system>>>,
-      Actions::CleanHistory<system>,
+      Actions::CleanHistory<system, local_time_stepping>,
       Limiters::Actions::SendData<EvolutionMetavars>,
       Limiters::Actions::Limit<EvolutionMetavars>,
       Actions::MutateApply<typename RadiationTransport::M1Grey::

--- a/src/Evolution/Executables/RelativisticEuler/Valencia/EvolveValencia.hpp
+++ b/src/Evolution/Executables/RelativisticEuler/Valencia/EvolveValencia.hpp
@@ -74,6 +74,7 @@
 #include "PointwiseFunctions/Hydro/SoundSpeedSquared.hpp"
 #include "PointwiseFunctions/Hydro/Tags.hpp"
 #include "Time/Actions/AdvanceTime.hpp"
+#include "Time/Actions/CleanHistory.hpp"
 #include "Time/Actions/RecordTimeStepperData.hpp"
 #include "Time/Actions/SelfStartActions.hpp"
 #include "Time/Actions/UpdateU.hpp"
@@ -217,6 +218,7 @@ struct EvolutionMetavars {
                   tmpl::list<AlwaysReadyPostprocessor<
                       typename system::primitive_from_conservative>>>,
               Actions::UpdateU<system>>>,
+      Actions::CleanHistory<system>,
       Limiters::Actions::SendData<EvolutionMetavars>,
       Limiters::Actions::Limit<EvolutionMetavars>,
       VariableFixing::Actions::FixVariables<

--- a/src/Evolution/Executables/RelativisticEuler/Valencia/EvolveValencia.hpp
+++ b/src/Evolution/Executables/RelativisticEuler/Valencia/EvolveValencia.hpp
@@ -218,7 +218,7 @@ struct EvolutionMetavars {
                   tmpl::list<AlwaysReadyPostprocessor<
                       typename system::primitive_from_conservative>>>,
               Actions::UpdateU<system>>>,
-      Actions::CleanHistory<system>,
+      Actions::CleanHistory<system, local_time_stepping>,
       Limiters::Actions::SendData<EvolutionMetavars>,
       Limiters::Actions::Limit<EvolutionMetavars>,
       VariableFixing::Actions::FixVariables<

--- a/src/Evolution/Executables/ScalarAdvection/EvolveScalarAdvection.hpp
+++ b/src/Evolution/Executables/ScalarAdvection/EvolveScalarAdvection.hpp
@@ -255,7 +255,7 @@ struct EvolutionMetavars {
               Actions::RecordTimeStepperData<system>,
               evolution::Actions::RunEventsAndDenseTriggers<tmpl::list<>>,
               Actions::UpdateU<system>>>,
-      Actions::CleanHistory<system>,
+      Actions::CleanHistory<system, local_time_stepping>,
       Limiters::Actions::SendData<EvolutionMetavars>,
       Limiters::Actions::Limit<EvolutionMetavars>>>;
 
@@ -275,7 +275,7 @@ struct EvolutionMetavars {
               Actions::UpdateU<system>>>,
       evolution::dg::subcell::Actions::TciAndRollback<
           ScalarAdvection::subcell::TciOnDgGrid<Dim>>,
-      Actions::CleanHistory<system>,
+      Actions::CleanHistory<system, local_time_stepping>,
       Actions::Goto<evolution::dg::subcell::Actions::Labels::EndOfSolvers>,
       Actions::Label<evolution::dg::subcell::Actions::Labels::BeginSubcell>,
       evolution::dg::subcell::Actions::SendDataForReconstruction<
@@ -287,7 +287,7 @@ struct EvolutionMetavars {
       evolution::dg::subcell::fd::Actions::TakeTimeStep<
           ScalarAdvection::subcell::TimeDerivative<volume_dim>>,
       Actions::RecordTimeStepperData<system>, Actions::UpdateU<system>,
-      Actions::CleanHistory<system>,
+      Actions::CleanHistory<system, local_time_stepping>,
       evolution::dg::subcell::Actions::TciAndSwitchToDg<
           ScalarAdvection::subcell::TciOnFdGrid<volume_dim>>,
       Actions::Label<evolution::dg::subcell::Actions::Labels::EndOfSolvers>>>;

--- a/src/Evolution/Executables/ScalarAdvection/EvolveScalarAdvection.hpp
+++ b/src/Evolution/Executables/ScalarAdvection/EvolveScalarAdvection.hpp
@@ -89,6 +89,7 @@
 #include "PointwiseFunctions/AnalyticSolutions/ScalarAdvection/Sinusoid.hpp"  // IWYU pragma: keep
 #include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
 #include "Time/Actions/AdvanceTime.hpp"            // IWYU pragma: keep
+#include "Time/Actions/CleanHistory.hpp"
 #include "Time/Actions/RecordTimeStepperData.hpp"  // IWYU pragma: keep
 #include "Time/Actions/SelfStartActions.hpp"       // IWYU pragma: keep
 #include "Time/Actions/UpdateU.hpp"                // IWYU pragma: keep
@@ -254,6 +255,7 @@ struct EvolutionMetavars {
               Actions::RecordTimeStepperData<system>,
               evolution::Actions::RunEventsAndDenseTriggers<tmpl::list<>>,
               Actions::UpdateU<system>>>,
+      Actions::CleanHistory<system>,
       Limiters::Actions::SendData<EvolutionMetavars>,
       Limiters::Actions::Limit<EvolutionMetavars>>>;
 
@@ -273,6 +275,7 @@ struct EvolutionMetavars {
               Actions::UpdateU<system>>>,
       evolution::dg::subcell::Actions::TciAndRollback<
           ScalarAdvection::subcell::TciOnDgGrid<Dim>>,
+      Actions::CleanHistory<system>,
       Actions::Goto<evolution::dg::subcell::Actions::Labels::EndOfSolvers>,
       Actions::Label<evolution::dg::subcell::Actions::Labels::BeginSubcell>,
       evolution::dg::subcell::Actions::SendDataForReconstruction<
@@ -284,6 +287,7 @@ struct EvolutionMetavars {
       evolution::dg::subcell::fd::Actions::TakeTimeStep<
           ScalarAdvection::subcell::TimeDerivative<volume_dim>>,
       Actions::RecordTimeStepperData<system>, Actions::UpdateU<system>,
+      Actions::CleanHistory<system>,
       evolution::dg::subcell::Actions::TciAndSwitchToDg<
           ScalarAdvection::subcell::TciOnFdGrid<volume_dim>>,
       Actions::Label<evolution::dg::subcell::Actions::Labels::EndOfSolvers>>>;

--- a/src/Evolution/Executables/ScalarTensor/ScalarTensorBase.hpp
+++ b/src/Evolution/Executables/ScalarTensor/ScalarTensorBase.hpp
@@ -126,6 +126,7 @@
 #include "PointwiseFunctions/InitialDataUtilities/Tags/InitialData.hpp"
 #include "PointwiseFunctions/ScalarTensor/ScalarCharge.hpp"
 #include "Time/Actions/AdvanceTime.hpp"
+#include "Time/Actions/CleanHistory.hpp"
 #include "Time/Actions/RecordTimeStepperData.hpp"
 #include "Time/Actions/SelfStartActions.hpp"
 #include "Time/Actions/UpdateU.hpp"
@@ -441,6 +442,7 @@ struct ScalarTensorTemplateBase {
               evolution::Actions::RunEventsAndDenseTriggers<tmpl::list<>>,
               control_system::Actions::LimitTimeStep<ControlSystems>,
               Actions::UpdateU<system>>>,
+      Actions::CleanHistory<system>,
       // We allow for separate filtering of the system variables
       dg::Actions::Filter<Filters::Exponential<0>,
                           system::gh_system::variables_tag::tags_list>,

--- a/src/Evolution/Executables/ScalarTensor/ScalarTensorBase.hpp
+++ b/src/Evolution/Executables/ScalarTensor/ScalarTensorBase.hpp
@@ -442,7 +442,7 @@ struct ScalarTensorTemplateBase {
               evolution::Actions::RunEventsAndDenseTriggers<tmpl::list<>>,
               control_system::Actions::LimitTimeStep<ControlSystems>,
               Actions::UpdateU<system>>>,
-      Actions::CleanHistory<system>,
+      Actions::CleanHistory<system, local_time_stepping>,
       // We allow for separate filtering of the system variables
       dg::Actions::Filter<Filters::Exponential<0>,
                           system::gh_system::variables_tag::tags_list>,

--- a/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
+++ b/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
@@ -87,6 +87,7 @@
 #include "PointwiseFunctions/MathFunctions/Factory.hpp"
 #include "PointwiseFunctions/MathFunctions/MathFunction.hpp"
 #include "Time/Actions/AdvanceTime.hpp"
+#include "Time/Actions/CleanHistory.hpp"
 #include "Time/Actions/RecordTimeStepperData.hpp"
 #include "Time/Actions/SelfStartActions.hpp"
 #include "Time/Actions/UpdateU.hpp"
@@ -238,6 +239,7 @@ struct EvolutionMetavars {
               Actions::RecordTimeStepperData<system>,
               evolution::Actions::RunEventsAndDenseTriggers<tmpl::list<>>,
               Actions::UpdateU<system>>>,
+      Actions::CleanHistory<system>,
       tmpl::conditional_t<
           use_filtering,
           dg::Actions::Filter<

--- a/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
+++ b/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
@@ -239,7 +239,7 @@ struct EvolutionMetavars {
               Actions::RecordTimeStepperData<system>,
               evolution::Actions::RunEventsAndDenseTriggers<tmpl::list<>>,
               Actions::UpdateU<system>>>,
-      Actions::CleanHistory<system>,
+      Actions::CleanHistory<system, local_time_stepping>,
       tmpl::conditional_t<
           use_filtering,
           dg::Actions::Filter<

--- a/src/Evolution/Imex/SolveImplicitSector.hpp
+++ b/src/Evolution/Imex/SolveImplicitSector.hpp
@@ -90,32 +90,31 @@ struct SolveImplicitSector {
 
   static void apply_impl(
       gsl::not_null<SystemVariables*> system_variables,
-      gsl::not_null<TimeSteppers::History<SectorVariables>*> implicit_history,
       gsl::not_null<Scalar<DataVector>*> solve_failures,
       const ImexTimeStepper& time_stepper, const TimeDelta& time_step,
+      const TimeSteppers::History<SectorVariables>& implicit_history,
       Mode implicit_solve_mode, double implicit_solve_tolerance,
       const EvolutionDataTuple& joined_evolution_data);
 
  public:
-  using return_tags = tmpl::list<SystemVariablesTag,
-                                 imex::Tags::ImplicitHistory<ImplicitSector>,
-                                 Tags::SolveFailures<ImplicitSector>>;
+  using return_tags =
+      tmpl::list<SystemVariablesTag, Tags::SolveFailures<ImplicitSector>>;
   using argument_tags = tmpl::append<
       tmpl::list<::Tags::TimeStepper<ImexTimeStepper>, ::Tags::TimeStep,
-                 Tags::Mode, Tags::SolveTolerance>,
+                 imex::Tags::ImplicitHistory<ImplicitSector>, Tags::Mode,
+                 Tags::SolveTolerance>,
       tmpl::join<evolution_data_tags>>;
 
   template <typename... ForwardArgs>
-  static void apply(const gsl::not_null<SystemVariables*> system_variables,
-                    const gsl::not_null<TimeSteppers::History<SectorVariables>*>
-                        implicit_history,
-                    const gsl::not_null<Scalar<DataVector>*> solve_failures,
-                    const ImexTimeStepper& time_stepper,
-                    const TimeDelta& time_step, const Mode implicit_solve_mode,
-                    const double implicit_solve_tolerance,
-                    const ForwardArgs&... forward_args) {
-    apply_impl(system_variables, implicit_history, solve_failures, time_stepper,
-               time_step, implicit_solve_mode, implicit_solve_tolerance,
+  static void apply(
+      const gsl::not_null<SystemVariables*> system_variables,
+      const gsl::not_null<Scalar<DataVector>*> solve_failures,
+      const ImexTimeStepper& time_stepper, const TimeDelta& time_step,
+      const TimeSteppers::History<SectorVariables>& implicit_history,
+      const Mode implicit_solve_mode, const double implicit_solve_tolerance,
+      const ForwardArgs&... forward_args) {
+    apply_impl(system_variables, solve_failures, time_stepper, time_step,
+               implicit_history, implicit_solve_mode, implicit_solve_tolerance,
                std::forward_as_tuple(forward_args...));
   }
 };

--- a/src/Evolution/Imex/SolveImplicitSector.tpp
+++ b/src/Evolution/Imex/SolveImplicitSector.tpp
@@ -56,9 +56,8 @@ class ImplicitEquation {
   template <typename ImplicitSector, typename SystemVariables>
   ImplicitEquation(
       const gsl::not_null<SystemVariables*> system_variables,
-      const gsl::not_null<TimeSteppers::History<SectorVariables>*>
-          implicit_history,
       const ImexTimeStepper& time_stepper, const TimeDelta& time_step,
+      const TimeSteppers::History<SectorVariables>& implicit_history,
       const ForwardTuple<typename ImplicitSector::initial_guess::argument_tags>&
           initial_guess_arguments,
       tmpl::type_<ImplicitSector> /*meta*/)
@@ -408,10 +407,9 @@ class ImplicitSolver {
 template <typename SystemVariablesTag, typename ImplicitSector>
 void SolveImplicitSector<SystemVariablesTag, ImplicitSector>::apply_impl(
     const gsl::not_null<SystemVariables*> system_variables,
-    const gsl::not_null<TimeSteppers::History<SectorVariables>*>
-        implicit_history,
     const gsl::not_null<Scalar<DataVector>*> solve_failures,
     const ImexTimeStepper& time_stepper, const TimeDelta& time_step,
+    const TimeSteppers::History<SectorVariables>& implicit_history,
     const Mode implicit_solve_mode, const double implicit_solve_tolerance,
     const EvolutionDataTuple& joined_evolution_data) {
   get(*solve_failures) = 0.0;
@@ -422,7 +420,7 @@ void SolveImplicitSector<SystemVariablesTag, ImplicitSector>::apply_impl(
   const auto& initial_guess_arguments = std::get<0>(evolution_data);
 
   const solve_implicit_sector_detail::ImplicitEquation<SectorVariables>
-      equation(system_variables, implicit_history, time_stepper, time_step,
+      equation(system_variables, time_stepper, time_step, implicit_history,
                initial_guess_arguments, tmpl::type_<ImplicitSector>{});
   if (not equation.solve_needed()) {
     return;

--- a/src/Evolution/Systems/Cce/Components/CharacteristicEvolution.hpp
+++ b/src/Evolution/Systems/Cce/Components/CharacteristicEvolution.hpp
@@ -196,7 +196,7 @@ struct CharacteristicEvolution {
                                  tmpl::bind<CalculateScriPlusValue, tmpl::_1>>>,
       ::Actions::RecordTimeStepperData<cce_system>,
       ::Actions::UpdateU<cce_system>,
-      ::Actions::CleanHistory<cce_system>>;
+      ::Actions::CleanHistory<cce_system, false>>;
 
   using extract_action_list = tmpl::list<
       Actions::RequestBoundaryData<
@@ -225,7 +225,7 @@ struct CharacteristicEvolution {
       ::Actions::RecordTimeStepperData<cce_system>,
       ::Actions::UpdateU<cce_system>,
       ::Actions::ChangeStepSize<typename Metavariables::cce_step_choosers>,
-      ::Actions::CleanHistory<cce_system>,
+      ::Actions::CleanHistory<cce_system, false>,
       // We cannot know our next step for certain until after we've performed
       // step size selection, as we may need to reject a step.
       Actions::RequestNextBoundaryData<

--- a/src/Evolution/Systems/Cce/Components/CharacteristicEvolution.hpp
+++ b/src/Evolution/Systems/Cce/Components/CharacteristicEvolution.hpp
@@ -36,6 +36,7 @@
 #include "ParallelAlgorithms/Actions/TerminatePhase.hpp"
 #include "Time/Actions/AdvanceTime.hpp"
 #include "Time/Actions/ChangeStepSize.hpp"
+#include "Time/Actions/CleanHistory.hpp"
 #include "Time/Actions/RecordTimeStepperData.hpp"
 #include "Time/Actions/SelfStartActions.hpp"
 #include "Time/Actions/UpdateU.hpp"
@@ -194,7 +195,8 @@ struct CharacteristicEvolution {
                       tmpl::bind<::Actions::MutateApply,
                                  tmpl::bind<CalculateScriPlusValue, tmpl::_1>>>,
       ::Actions::RecordTimeStepperData<cce_system>,
-      ::Actions::UpdateU<cce_system>>;
+      ::Actions::UpdateU<cce_system>,
+      ::Actions::CleanHistory<cce_system>>;
 
   using extract_action_list = tmpl::list<
       Actions::RequestBoundaryData<
@@ -223,13 +225,14 @@ struct CharacteristicEvolution {
       ::Actions::RecordTimeStepperData<cce_system>,
       ::Actions::UpdateU<cce_system>,
       ::Actions::ChangeStepSize<typename Metavariables::cce_step_choosers>,
+      ::Actions::CleanHistory<cce_system>,
       // We cannot know our next step for certain until after we've performed
       // step size selection, as we may need to reject a step.
       Actions::RequestNextBoundaryData<
           typename Metavariables::cce_boundary_component,
           CharacteristicEvolution<Metavariables>>,
-      ::Actions::AdvanceTime, Actions::ExitIfEndTimeReached,
-      ::Actions::Goto<CceEvolutionLabelTag>>;
+      ::Actions::AdvanceTime,
+      Actions::ExitIfEndTimeReached, ::Actions::Goto<CceEvolutionLabelTag>>;
 
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<Parallel::Phase::Initialization,

--- a/src/Evolution/Systems/Cce/Components/KleinGordonCharacteristicEvolution.hpp
+++ b/src/Evolution/Systems/Cce/Components/KleinGordonCharacteristicEvolution.hpp
@@ -155,7 +155,7 @@ struct KleinGordonCharacteristicEvolution
       ::Actions::RecordTimeStepperData<cce_system>,
       ::Actions::UpdateU<cce_system>,
       ::Actions::ChangeStepSize<typename Metavariables::cce_step_choosers>,
-      ::Actions::CleanHistory<cce_system>,
+      ::Actions::CleanHistory<cce_system, false>,
       // We cannot know our next step for certain until after we've performed
       // step size selection, as we may need to reject a step.
       Actions::RequestNextBoundaryData<

--- a/src/Evolution/Systems/Cce/Components/KleinGordonCharacteristicEvolution.hpp
+++ b/src/Evolution/Systems/Cce/Components/KleinGordonCharacteristicEvolution.hpp
@@ -14,6 +14,7 @@
 #include "Parallel/GlobalCache.hpp"
 #include "Parallel/Local.hpp"
 #include "Parallel/Phase.hpp"
+#include "Time/Actions/CleanHistory.hpp"
 #include "Time/Actions/SelfStartActions.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -154,13 +155,14 @@ struct KleinGordonCharacteristicEvolution
       ::Actions::RecordTimeStepperData<cce_system>,
       ::Actions::UpdateU<cce_system>,
       ::Actions::ChangeStepSize<typename Metavariables::cce_step_choosers>,
+      ::Actions::CleanHistory<cce_system>,
       // We cannot know our next step for certain until after we've performed
       // step size selection, as we may need to reject a step.
       Actions::RequestNextBoundaryData<
           typename Metavariables::cce_boundary_component,
           KleinGordonCharacteristicEvolution<Metavariables>>,
-      ::Actions::AdvanceTime, Actions::ExitIfEndTimeReached,
-      ::Actions::Goto<CceEvolutionLabelTag>>;
+      ::Actions::AdvanceTime,
+      Actions::ExitIfEndTimeReached, ::Actions::Goto<CceEvolutionLabelTag>>;
 
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<Parallel::Phase::Initialization,

--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonChare.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonChare.hpp
@@ -28,6 +28,7 @@
 #include "ParallelAlgorithms/Actions/MutateApply.hpp"
 #include "ParallelAlgorithms/Actions/TerminatePhase.hpp"
 #include "Time/Actions/AdvanceTime.hpp"
+#include "Time/Actions/CleanHistory.hpp"
 #include "Time/Actions/RecordTimeStepperData.hpp"
 #include "Time/Actions/SelfStartActions.hpp"
 #include "Time/Actions/UpdateU.hpp"
@@ -90,6 +91,7 @@ struct WorldtubeSingleton {
                  ::Actions::MutateApply<UpdateAcceleration>,
                  ::Actions::RecordTimeStepperData<worldtube_system>,
                  ::Actions::UpdateU<worldtube_system>,
+                 ::Actions::CleanHistory<worldtube_system>,
                  Actions::SendToElements<Metavariables>>;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<Parallel::Phase::Initialization,

--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonChare.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonChare.hpp
@@ -91,7 +91,7 @@ struct WorldtubeSingleton {
                  ::Actions::MutateApply<UpdateAcceleration>,
                  ::Actions::RecordTimeStepperData<worldtube_system>,
                  ::Actions::UpdateU<worldtube_system>,
-                 ::Actions::CleanHistory<worldtube_system>,
+                 ::Actions::CleanHistory<worldtube_system, false>,
                  Actions::SendToElements<Metavariables>>;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<Parallel::Phase::Initialization,

--- a/src/Time/Actions/CMakeLists.txt
+++ b/src/Time/Actions/CMakeLists.txt
@@ -7,6 +7,7 @@ spectre_target_headers(
   HEADERS
   AdvanceTime.hpp
   ChangeStepSize.hpp
+  CleanHistory.hpp
   RecordTimeStepperData.hpp
   SelfStartActions.hpp
   UpdateU.hpp

--- a/src/Time/Actions/CleanHistory.hpp
+++ b/src/Time/Actions/CleanHistory.hpp
@@ -1,0 +1,74 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <optional>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "Parallel/AlgorithmExecution.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TypeTraits/IsA.hpp"
+
+/// \cond
+class TimeStepper;
+namespace Parallel {
+template <typename Metavariables>
+class GlobalCache;
+}  // namespace Parallel
+namespace Tags {
+template <typename StepperInterface>
+struct TimeStepper;
+template <typename Tag>
+struct HistoryEvolvedVariables;
+}  // namespace Tags
+namespace tuples {
+template <class... Tags>
+class TaggedTuple;
+}  // namespace tuples
+/// \endcond
+
+namespace Actions {
+/// \ingroup ActionsGroup
+/// \ingroup TimeGroup
+/// \brief Clean time stepper history after a substep
+///
+/// Uses:
+/// - DataBox:
+///   - Tags::TimeStepper<TimeStepper>
+///
+/// DataBox changes:
+/// - Adds: nothing
+/// - Removes: nothing
+/// - Modifies:
+///   - Tags::HistoryEvolvedVariables<variables_tag>
+template <typename System>
+struct CleanHistory {
+  template <typename DbTags, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent>
+  static Parallel::iterable_action_return_t apply(
+      db::DataBox<DbTags>& box, tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+      const Parallel::GlobalCache<Metavariables>& /*cache*/,
+      const ArrayIndex& /*array_index*/, ActionList /*meta*/,
+      const ParallelComponent* const /*meta*/) {  // NOLINT const
+    const auto& time_stepper = db::get<Tags::TimeStepper<TimeStepper>>(box);
+
+    using variables_tags = tmpl::conditional_t<
+        tt::is_a_v<tmpl::list, typename System::variables_tag>,
+        typename System::variables_tag,
+        tmpl::list<typename System::variables_tag>>;
+    using history_tags =
+        tmpl::transform<variables_tags,
+                        tmpl::bind<Tags::HistoryEvolvedVariables, tmpl::_1>>;
+    db::mutate_apply<history_tags, tmpl::list<>>(
+        [&time_stepper](const auto... histories) {
+          expand_pack((time_stepper.clean_history(histories), 0)...);
+        },
+        make_not_null(&box));
+
+    return {Parallel::AlgorithmExecution::Continue, std::nullopt};
+  }
+};
+}  // namespace Actions

--- a/src/Time/Actions/CleanHistory.hpp
+++ b/src/Time/Actions/CleanHistory.hpp
@@ -8,6 +8,7 @@
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "Parallel/AlgorithmExecution.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TypeTraits/IsA.hpp"
 
@@ -23,6 +24,13 @@ struct TimeStepper;
 template <typename Tag>
 struct HistoryEvolvedVariables;
 }  // namespace Tags
+namespace imex::Tags {
+template <typename ImplicitSector>
+struct ImplicitHistory;
+}  // namespace imex::Tags
+namespace imex::protocols {
+struct ImexSystem;
+}  // namespace imex::protocols
 namespace tuples {
 template <class... Tags>
 class TaggedTuple;
@@ -43,6 +51,7 @@ namespace Actions {
 /// - Removes: nothing
 /// - Modifies:
 ///   - Tags::HistoryEvolvedVariables<variables_tag>
+///   - imex::Tags::ImplicitHistory<sector> for each IMEX sector
 template <typename System>
 struct CleanHistory {
   template <typename DbTags, typename... InboxTags, typename Metavariables,
@@ -67,6 +76,22 @@ struct CleanHistory {
           expand_pack((time_stepper.clean_history(histories), 0)...);
         },
         make_not_null(&box));
+
+    // This action can't depend on Evolution, but most of the time
+    // stepping structures are in Evolution, so everything past here
+    // has to only depend on Evolution classes through the DataBox
+    // type.
+
+    if constexpr (tt::conforms_to_v<System, imex::protocols::ImexSystem>) {
+      using implicit_history_tags =
+          tmpl::transform<typename System::implicit_sectors,
+                          tmpl::bind<imex::Tags::ImplicitHistory, tmpl::_1>>;
+      db::mutate_apply<implicit_history_tags, tmpl::list<>>(
+          [&time_stepper](const auto... histories) {
+            expand_pack((time_stepper.clean_history(histories), 0)...);
+          },
+          make_not_null(&box));
+    }
 
     return {Parallel::AlgorithmExecution::Continue, std::nullopt};
   }

--- a/src/Time/Actions/SelfStartActions.hpp
+++ b/src/Time/Actions/SelfStartActions.hpp
@@ -370,18 +370,6 @@ struct CheckForOrderIncrease {
                      "integration order.");
               mutable_history->integration_order(
                   mutable_history->integration_order() + 1);
-              // The time steppers do cleanup internally when taking a
-              // step, but since we are resetting to the start instead
-              // of taking a step we have to do it here.  If we
-              // skipped this the extra value would harmlessly fall
-              // off the end after a few steps, but that would
-              // unnecessarily increase the size of the data held by
-              // the History object.  A different way to handle this
-              // would be to call shrink_to_fit() on the history a few
-              // steps after the start of the evolution.
-              for (const auto& record : *mutable_history) {
-                mutable_history->discard_value(record.time_step_id);
-              }
             },
             make_not_null(&box));
       });

--- a/src/Time/Actions/UpdateU.hpp
+++ b/src/Time/Actions/UpdateU.hpp
@@ -13,6 +13,7 @@
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataBox/Prefixes.hpp"
 #include "Parallel/AlgorithmExecution.hpp"
+#include "Time/SelfStart.hpp"
 #include "Time/Tags/HistoryEvolvedVariables.hpp"
 #include "Time/Tags/StepperErrors.hpp"
 #include "Time/Time.hpp"
@@ -31,6 +32,7 @@ class GlobalCache;
 namespace Tags {
 struct IsUsingTimeSteppingErrorControl;
 struct TimeStep;
+struct TimeStepId;
 template <typename StepperInterface>
 struct TimeStepper;
 }  // namespace Tags
@@ -49,15 +51,15 @@ void update_one_variables(const gsl::not_null<db::DataBox<DbTags>*> box) {
   if (is_using_error_control) {
     using error_tag = ::Tags::StepperErrors<VariablesTag>;
     if constexpr (tmpl::list_contains_v<DbTags, error_tag>) {
-      db::mutate<VariablesTag, error_tag, history_tag>(
+      db::mutate<VariablesTag, error_tag>(
           [](const gsl::not_null<typename VariablesTag::type*> vars,
              const gsl::not_null<typename error_tag::type*> errors,
-             const gsl::not_null<typename history_tag::type*> history,
+             const typename history_tag::type& history,
              const ::TimeDelta& time_step, const TimeStepper& time_stepper) {
             using std::swap;
             bool new_entry = false;
             const auto current_step_time =
-                history->back().time_step_id.step_time();
+                history.back().time_step_id.step_time();
             if (not errors->back().has_value() or
                 errors->back()->step_time != current_step_time) {
               swap((*errors)[0], (*errors)[1]);
@@ -82,7 +84,7 @@ void update_one_variables(const gsl::not_null<db::DataBox<DbTags>*> box) {
               swap((*errors)[0], (*errors)[1]);
             }
           },
-          box, db::get<Tags::TimeStep>(*box),
+          box, db::get<history_tag>(*box), db::get<Tags::TimeStep>(*box),
           db::get<Tags::TimeStepper<TimeStepper>>(*box));
     } else {
       ERROR(
@@ -90,13 +92,13 @@ void update_one_variables(const gsl::not_null<db::DataBox<DbTags>*> box) {
           "`::Tags::StepperErrors<VariablesTag>` is not present in the box.");
     }
   } else {
-    db::mutate<VariablesTag, history_tag>(
+    db::mutate<VariablesTag>(
         [](const gsl::not_null<typename VariablesTag::type*> vars,
-           const gsl::not_null<typename history_tag::type*> history,
+           const typename history_tag::type& history,
            const ::TimeDelta& time_step, const TimeStepper& time_stepper) {
           time_stepper.update_u(vars, history, time_step);
         },
-        box, db::get<Tags::TimeStep>(*box),
+        box, db::get<history_tag>(*box), db::get<Tags::TimeStep>(*box),
         db::get<Tags::TimeStepper<TimeStepper>>(*box));
   }
 }
@@ -110,6 +112,11 @@ void update_one_variables(const gsl::not_null<db::DataBox<DbTags>*> box) {
 /// the middle of another action.
 template <typename System, typename DbTags>
 void update_u(const gsl::not_null<db::DataBox<DbTags>*> box) {
+  if (::SelfStart::step_unused(db::get<Tags::TimeStepId>(*box),
+                               db::get<Tags::Next<Tags::TimeStepId>>(*box))) {
+    return;
+  }
+
   if constexpr (tt::is_a_v<tmpl::list, typename System::variables_tag>) {
     // The system has multiple evolved variables, probably because
     // there is a mixture of real and complex values or similar.  Step
@@ -143,7 +150,6 @@ namespace Actions {
 /// - Removes: nothing
 /// - Modifies:
 ///   - variables_tag
-///   - Tags::HistoryEvolvedVariables<variables_tag>
 template <typename System>
 struct UpdateU {
   template <typename DbTags, typename... InboxTags, typename Metavariables,

--- a/src/Time/SelfStart.cpp
+++ b/src/Time/SelfStart.cpp
@@ -9,4 +9,9 @@ namespace SelfStart {
 bool is_self_starting(const TimeStepId& time_id) {
   return time_id.slab_number() < 0;
 }
+
+bool step_unused(const TimeStepId& time_id, const TimeStepId& next_time_id) {
+  return time_id.slab_number() < 0 and
+         time_id.slab_number() != next_time_id.slab_number();
+}
 }  // namespace SelfStart

--- a/src/Time/SelfStart.hpp
+++ b/src/Time/SelfStart.hpp
@@ -12,4 +12,8 @@ namespace SelfStart {
 /// negative if and only if self-start is in progress. If self start is
 /// modified to alter that behavior, this utility must also be modified.
 bool is_self_starting(const TimeStepId& time_id);
+
+/// Returns whether the result of the step from \p time_id to \p
+/// next_time_id is unused because of a self-start reset.
+bool step_unused(const TimeStepId& time_id, const TimeStepId& next_time_id);
 }  // namespace SelfStart

--- a/src/Time/TimeSteppers/AdamsBashforth.hpp
+++ b/src/Time/TimeSteppers/AdamsBashforth.hpp
@@ -286,10 +286,15 @@ class AdamsBashforth : public LtsTimeStepper {
   template <typename T>
   void add_boundary_delta_impl(
       gsl::not_null<T*> result,
-      const TimeSteppers::MutableBoundaryHistoryTimes& local_times,
-      const TimeSteppers::MutableBoundaryHistoryTimes& remote_times,
+      const TimeSteppers::ConstBoundaryHistoryTimes& local_times,
+      const TimeSteppers::ConstBoundaryHistoryTimes& remote_times,
       const TimeSteppers::BoundaryHistoryEvaluator<T>& coupling,
       const TimeDelta& time_step) const;
+
+  void clean_boundary_history_impl(
+      const TimeSteppers::MutableBoundaryHistoryTimes& local_times,
+      const TimeSteppers::MutableBoundaryHistoryTimes& remote_times)
+      const override;
 
   template <typename T>
   void boundary_dense_output_impl(

--- a/src/Time/TimeSteppers/AdamsBashforth.hpp
+++ b/src/Time/TimeSteppers/AdamsBashforth.hpp
@@ -258,14 +258,16 @@ class AdamsBashforth : public LtsTimeStepper {
   // constant-time-step case, while the latter are necessary for dense
   // output.
   template <typename T>
-  void update_u_impl(gsl::not_null<T*> u,
-                     const MutableUntypedHistory<T>& history,
+  void update_u_impl(gsl::not_null<T*> u, const ConstUntypedHistory<T>& history,
                      const TimeDelta& time_step) const;
 
   template <typename T>
   bool update_u_impl(gsl::not_null<T*> u, gsl::not_null<T*> u_error,
-                     const MutableUntypedHistory<T>& history,
+                     const ConstUntypedHistory<T>& history,
                      const TimeDelta& time_step) const;
+
+  template <typename T>
+  void clean_history_impl(const MutableUntypedHistory<T>& history) const;
 
   template <typename T>
   bool dense_update_u_impl(gsl::not_null<T*> u,

--- a/src/Time/TimeSteppers/AdamsMoultonPc.hpp
+++ b/src/Time/TimeSteppers/AdamsMoultonPc.hpp
@@ -139,14 +139,16 @@ class AdamsMoultonPc : public TimeStepper {
 
  private:
   template <typename T>
-  void update_u_impl(gsl::not_null<T*> u,
-                     const MutableUntypedHistory<T>& history,
+  void update_u_impl(gsl::not_null<T*> u, const ConstUntypedHistory<T>& history,
                      const TimeDelta& time_step) const;
 
   template <typename T>
   bool update_u_impl(gsl::not_null<T*> u, gsl::not_null<T*> u_error,
-                     const MutableUntypedHistory<T>& history,
+                     const ConstUntypedHistory<T>& history,
                      const TimeDelta& time_step) const;
+
+  template <typename T>
+  void clean_history_impl(const MutableUntypedHistory<T>& history) const;
 
   template <typename T>
   bool dense_update_u_impl(gsl::not_null<T*> u,

--- a/src/Time/TimeSteppers/ImexRungeKutta.hpp
+++ b/src/Time/TimeSteppers/ImexRungeKutta.hpp
@@ -14,8 +14,6 @@ class TimeDelta;
 namespace TimeSteppers {
 template <typename T>
 class ConstUntypedHistory;
-template <typename T>
-class MutableUntypedHistory;
 }  // namespace TimeSteppers
 /// \endcond
 
@@ -63,11 +61,11 @@ class ImexRungeKutta : public virtual RungeKutta,
  private:
   template <typename T>
   void add_inhomogeneous_implicit_terms_impl(
-      gsl::not_null<T*> u, const MutableUntypedHistory<T>& implicit_history,
+      gsl::not_null<T*> u, const ConstUntypedHistory<T>& implicit_history,
       const TimeDelta& time_step) const;
 
   template <typename T>
-  double implicit_weight_impl(const MutableUntypedHistory<T>& implicit_history,
+  double implicit_weight_impl(const ConstUntypedHistory<T>& implicit_history,
                               const TimeDelta& time_step) const;
 
   IMEX_TIME_STEPPER_DECLARE_OVERLOADS

--- a/src/Time/TimeSteppers/Rk3HesthavenSsp.hpp
+++ b/src/Time/TimeSteppers/Rk3HesthavenSsp.hpp
@@ -75,14 +75,16 @@ class Rk3HesthavenSsp : public TimeStepper {
 
  private:
   template <typename T>
-  void update_u_impl(gsl::not_null<T*> u,
-                     const MutableUntypedHistory<T>& history,
+  void update_u_impl(gsl::not_null<T*> u, const ConstUntypedHistory<T>& history,
                      const TimeDelta& time_step) const;
 
   template <typename T>
   bool update_u_impl(gsl::not_null<T*> u, gsl::not_null<T*> u_error,
-                     const MutableUntypedHistory<T>& history,
+                     const ConstUntypedHistory<T>& history,
                      const TimeDelta& time_step) const;
+
+  template <typename T>
+  void clean_history_impl(const MutableUntypedHistory<T>& history) const;
 
   template <typename T>
   bool dense_update_u_impl(gsl::not_null<T*> u,

--- a/src/Time/TimeSteppers/RungeKutta.hpp
+++ b/src/Time/TimeSteppers/RungeKutta.hpp
@@ -96,14 +96,16 @@ class RungeKutta : public virtual TimeStepper {
 
  private:
   template <typename T>
-  void update_u_impl(gsl::not_null<T*> u,
-                     const MutableUntypedHistory<T>& history,
+  void update_u_impl(gsl::not_null<T*> u, const ConstUntypedHistory<T>& history,
                      const TimeDelta& time_step) const;
 
   template <typename T>
   bool update_u_impl(gsl::not_null<T*> u, gsl::not_null<T*> u_error,
-                     const MutableUntypedHistory<T>& history,
+                     const ConstUntypedHistory<T>& history,
                      const TimeDelta& time_step) const;
+
+  template <typename T>
+  void clean_history_impl(const MutableUntypedHistory<T>& history) const;
 
   template <typename T>
   bool dense_update_u_impl(gsl::not_null<T*> u,

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Actions/Test_ApplyBoundaryCorrections.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Actions/Test_ApplyBoundaryCorrections.cpp
@@ -931,8 +931,7 @@ void test_impl(const Spectral::Quadrature quadrature,
               ? mesh.slice_away(direction.dimension()).number_of_grid_points()
               : mesh.number_of_grid_points(),
           0.0};
-      time_stepper.add_boundary_delta(&lifted_volume_data,
-                                      make_not_null(&mortar_data_hist),
+      time_stepper.add_boundary_delta(&lifted_volume_data, mortar_data_hist,
                                       time_step, compute_correction_coupling);
       if (quadrature == Spectral::Quadrature::GaussLobatto) {
         // Add the flux contribution to the volume data

--- a/tests/Unit/Helpers/Time/TimeSteppers/ImexHelpers.cpp
+++ b/tests/Unit/Helpers/Time/TimeSteppers/ImexHelpers.cpp
@@ -52,7 +52,8 @@ void check_convergence_order(const ImexTimeStepper& stepper,
       implicit_history.insert(time_step_id,
                               TimeSteppers::History<double>::no_value,
                               implicit_rhs(y, time_step_id.substep_time()));
-      stepper.update_u(make_not_null(&y), make_not_null(&history), step_size);
+      stepper.update_u(make_not_null(&y), history, step_size);
+      stepper.clean_history(make_not_null(&history));
       // This system is simple enough that we can do the implicit
       // solve analytically.
 

--- a/tests/Unit/Helpers/Time/TimeSteppers/LtsHelpers.cpp
+++ b/tests/Unit/Helpers/Time/TimeSteppers/LtsHelpers.cpp
@@ -83,8 +83,8 @@ void test_equal_rate(const LtsTimeStepper& stepper, const size_t order,
 
       stepper.update_u(make_not_null(&y), volume_history, step_size);
       stepper.clean_history(make_not_null(&volume_history));
-      stepper.add_boundary_delta(&y, make_not_null(&boundary_history),
-                                 step_size, coupling);
+      stepper.add_boundary_delta(&y, boundary_history, step_size, coupling);
+      stepper.clean_boundary_history(make_not_null(&boundary_history));
       time_id = stepper.next_time_id(time_id, step_size);
     }
     CHECK(y == approx(analytic(time_id.substep_time())));
@@ -160,8 +160,8 @@ void test_dense_output(const LtsTimeStepper& stepper) {
       stepper.boundary_dense_output(&dense_result, history, next_check.value(),
                                     coupling);
       double delta = 0.0;
-      stepper.add_boundary_delta(&delta, make_not_null(&history),
-                                 next_check - t, coupling);
+      stepper.add_boundary_delta(&delta, history, next_check - t, coupling);
+      stepper.clean_boundary_history(make_not_null(&history));
       CHECK(dense_result == approx(delta));
       if (next_check.is_at_slab_boundary()) {
         break;

--- a/tests/Unit/Helpers/Time/TimeSteppers/LtsHelpers.cpp
+++ b/tests/Unit/Helpers/Time/TimeSteppers/LtsHelpers.cpp
@@ -81,8 +81,8 @@ void test_equal_rate(const LtsTimeStepper& stepper, const size_t order,
       boundary_history.remote().insert(time_id, order,
                                        driver(time_id.substep_time()));
 
-      stepper.update_u(make_not_null(&y), make_not_null(&volume_history),
-                       step_size);
+      stepper.update_u(make_not_null(&y), volume_history, step_size);
+      stepper.clean_history(make_not_null(&volume_history));
       stepper.add_boundary_delta(&y, make_not_null(&boundary_history),
                                  step_size, coupling);
       time_id = stepper.next_time_id(time_id, step_size);

--- a/tests/Unit/Helpers/Time/TimeSteppers/TimeStepperTestUtils.cpp
+++ b/tests/Unit/Helpers/Time/TimeSteppers/TimeStepperTestUtils.cpp
@@ -41,7 +41,8 @@ void take_step(
     history->insert(time_id, *y, rhs(*y, time_id.substep_time()));
     // There is no std::numeric_limits<complex>
     *y = std::numeric_limits<double>::signaling_NaN();
-    stepper.update_u(y, history, step_size);
+    stepper.update_u(y, *history, step_size);
+    stepper.clean_history(history);
     time_id = stepper.next_time_id(time_id, step_size);
   }
   CHECK(time_id.substep() == 0);
@@ -61,7 +62,8 @@ void take_step_and_check_error(
     CHECK(time_id.substep() == substep);
     history->insert(time_id, *y, rhs(*y, time_id.substep_time()));
     *y = std::numeric_limits<double>::signaling_NaN();
-    bool error_updated = stepper.update_u(y, y_error, history, step_size);
+    bool error_updated = stepper.update_u(y, y_error, *history, step_size);
+    stepper.clean_history(history);
     CAPTURE(substep);
     REQUIRE((substep == stepper.number_of_substeps_for_error() - 1) ==
             error_updated);
@@ -371,11 +373,12 @@ void check_dense_output(
         y = std::numeric_limits<double>::signaling_NaN();
         if (use_error_methods) {
           double error = 0.0;
-          stepper.update_u(make_not_null(&y), make_not_null(&error),
-                           make_not_null(&history), step);
+          stepper.update_u(make_not_null(&y), make_not_null(&error), history,
+                           step);
         } else {
-          stepper.update_u(make_not_null(&y), make_not_null(&history), step);
+          stepper.update_u(make_not_null(&y), history, step);
         }
+        stepper.clean_history(make_not_null(&history));
         time_id = use_error_methods
                       ? stepper.next_time_id_for_error(time_id, step)
                       : stepper.next_time_id(time_id, step);
@@ -445,9 +448,9 @@ void check_strong_stability_preservation(const TimeStepper& stepper,
   ASSERT(stepper.number_of_past_steps() == 0,
          "Unimplemented for multistep methods");
 
-  const auto impl = [&step_size](const size_t order,
-                                 const uint64_t number_of_substeps_to_test,
-                                 const auto update_u, const auto next_time_id) {
+  const auto impl = [&](const size_t order,
+                        const uint64_t number_of_substeps_to_test,
+                        const auto update_u, const auto next_time_id) {
     const Slab slab(0.0, step_size);
     const auto time_step = slab.duration();
 
@@ -470,10 +473,11 @@ void check_strong_stability_preservation(const TimeStepper& stepper,
           derivative_history.insert(time_step_id, 0.0, 0.0);
         }
         double u = std::numeric_limits<double>::signaling_NaN();
-        update_u(make_not_null(&u), make_not_null(&value_history), time_step);
+        update_u(make_not_null(&u), value_history, time_step);
+        stepper.clean_history(make_not_null(&value_history));
         const double value_dependence = u;
-        update_u(make_not_null(&u), make_not_null(&derivative_history),
-                 time_step);
+        update_u(make_not_null(&u), derivative_history, time_step);
+        stepper.clean_history(make_not_null(&derivative_history));
         const double derivative_dependence = u;
         CHECK(value_dependence >= 0.0);
         CHECK(derivative_dependence >= 0.0);
@@ -488,7 +492,7 @@ void check_strong_stability_preservation(const TimeStepper& stepper,
     impl(
         stepper.order(), stepper.number_of_substeps(),
         [&](const gsl::not_null<double*> u,
-            const gsl::not_null<TimeSteppers::History<double>*> history,
+            const TimeSteppers::History<double>& history,
             const TimeDelta& time_step) {
           stepper.update_u(u, history, time_step);
         },
@@ -501,7 +505,7 @@ void check_strong_stability_preservation(const TimeStepper& stepper,
     impl(
         stepper.order(), stepper.number_of_substeps_for_error(),
         [&](const gsl::not_null<double*> u,
-            const gsl::not_null<TimeSteppers::History<double>*> history,
+            const TimeSteppers::History<double>& history,
             const TimeDelta& time_step) {
           double error;
           stepper.update_u(u, make_not_null(&error), history, time_step);

--- a/tests/Unit/Helpers/Time/TimeSteppers/TimeStepperTestUtils.hpp
+++ b/tests/Unit/Helpers/Time/TimeSteppers/TimeStepperTestUtils.hpp
@@ -92,7 +92,7 @@ void check_convergence_order(const TimeStepper& stepper,
                              bool output = false);
 
 void check_dense_output(
-    const TimeStepper& stepper, size_t history_integration_order,
+    const TimeStepper& stepper,
     const std::pair<int32_t, int32_t>& convergence_step_range, int32_t stride,
     bool check_backward_continuity);
 

--- a/tests/Unit/Time/Actions/CMakeLists.txt
+++ b/tests/Unit/Time/Actions/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY_SOURCES
   ${LIBRARY_SOURCES}
   Actions/Test_AdvanceTime.cpp
   Actions/Test_ChangeStepSize.cpp
+  Actions/Test_CleanHistory.cpp
   Actions/Test_RecordTimeStepperData.cpp
   Actions/Test_SelfStartActions.cpp
   Actions/Test_UpdateU.cpp

--- a/tests/Unit/Time/Actions/Test_CleanHistory.cpp
+++ b/tests/Unit/Time/Actions/Test_CleanHistory.cpp
@@ -1,0 +1,108 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <memory>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/Tag.hpp"
+#include "Framework/ActionTesting.hpp"
+#include "Parallel/Phase.hpp"
+#include "Parallel/PhaseDependentActionList.hpp"
+#include "Time/Actions/CleanHistory.hpp"
+#include "Time/History.hpp"
+#include "Time/Slab.hpp"
+#include "Time/Tags/HistoryEvolvedVariables.hpp"
+#include "Time/Tags/TimeStepper.hpp"
+#include "Time/TimeStepId.hpp"
+#include "Time/TimeSteppers/AdamsBashforth.hpp"
+#include "Time/TimeSteppers/TimeStepper.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Serialization/RegisterDerivedClassesWithCharm.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace PUP {
+struct er;
+}  // namespace PUP
+
+namespace {
+struct Var : db::SimpleTag {
+  using type = double;
+};
+
+struct AlternativeVar : db::SimpleTag {
+  using type = double;
+};
+
+struct SingleVariableSystem {
+  using variables_tag = Var;
+};
+
+struct TwoVariableSystem {
+  using variables_tag = tmpl::list<Var, AlternativeVar>;
+};
+
+template <typename Metavariables>
+struct Component {
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = int;
+  using const_global_cache_tags = tmpl::list<>;
+  using simple_tags = tmpl::list<Tags::ConcreteTimeStepper<TimeStepper>,
+                                 Tags::HistoryEvolvedVariables<Var>,
+                                 Tags::HistoryEvolvedVariables<AlternativeVar>>;
+  using compute_tags = time_stepper_ref_tags<TimeStepper>;
+
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<Parallel::Phase::Initialization,
+                             tmpl::list<ActionTesting::InitializeDataBox<
+                                 simple_tags, compute_tags>>>,
+      Parallel::PhaseActions<Parallel::Phase::Testing,
+                             tmpl::list<Actions::CleanHistory<
+                                 typename metavariables::system_for_test>>>>;
+};
+
+template <typename System>
+struct Metavariables {
+  using system_for_test = System;
+  using component_list = tmpl::list<Component<Metavariables>>;
+
+  void pup(PUP::er& /*p*/) {}
+};
+
+template <bool TwoVars>
+void test_action() {
+  using system =
+      tmpl::conditional_t<TwoVars, TwoVariableSystem, SingleVariableSystem>;
+  using metavariables = Metavariables<system>;
+  using component = Component<metavariables>;
+
+  const Slab slab(1., 3.);
+  TimeSteppers::History<double> history{2};
+  history.insert(TimeStepId(true, 0, slab.start()), 0.0, 0.0);
+  history.insert(TimeStepId(true, 0, slab.end()), 0.0, 0.0);
+
+  using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<metavariables>;
+  MockRuntimeSystem runner{{}};
+  ActionTesting::emplace_component_and_initialize<component>(
+      &runner, 0,
+      {std::make_unique<TimeSteppers::AdamsBashforth>(2), history, history});
+
+  ActionTesting::set_phase(make_not_null(&runner), Parallel::Phase::Testing);
+
+  ActionTesting::next_action<component>(make_not_null(&runner), 0);
+
+  const auto& box = ActionTesting::get_databox<component>(runner, 0);
+  CHECK(db::get<Tags::HistoryEvolvedVariables<Var>>(box).size() == 1);
+  CHECK(db::get<Tags::HistoryEvolvedVariables<AlternativeVar>>(box).size() ==
+        (TwoVars ? 1 : 2));
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Time.Actions.CleanHistory", "[Unit][Time][Actions]") {
+  register_classes_with_charm<TimeSteppers::AdamsBashforth>();
+
+  test_action<false>();
+  test_action<true>();
+}

--- a/tests/Unit/Time/Actions/Test_SelfStartActions.cpp
+++ b/tests/Unit/Time/Actions/Test_SelfStartActions.cpp
@@ -165,7 +165,7 @@ struct Component {
       tmpl::list<ComputeTimeDerivative,
                  Actions::RecordTimeStepperData<typename metavariables::system>,
                  Actions::UpdateU<typename metavariables::system>,
-                 Actions::CleanHistory<typename metavariables::system>,
+                 Actions::CleanHistory<typename metavariables::system, false>,
                  tmpl::conditional_t<has_primitives, Actions::UpdatePrimitives,
                                      tmpl::list<>>>;
   using action_list = tmpl::flatten<

--- a/tests/Unit/Time/Actions/Test_SelfStartActions.cpp
+++ b/tests/Unit/Time/Actions/Test_SelfStartActions.cpp
@@ -25,6 +25,7 @@
 #include "Parallel/AlgorithmExecution.hpp"
 #include "Parallel/Phase.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"  // IWYU pragma: keep
+#include "Time/Actions/CleanHistory.hpp"
 #include "Time/Actions/RecordTimeStepperData.hpp"  // IWYU pragma: keep
 #include "Time/Actions/SelfStartActions.hpp"
 #include "Time/Actions/UpdateU.hpp"  // IWYU pragma: keep
@@ -164,6 +165,7 @@ struct Component {
       tmpl::list<ComputeTimeDerivative,
                  Actions::RecordTimeStepperData<typename metavariables::system>,
                  Actions::UpdateU<typename metavariables::system>,
+                 Actions::CleanHistory<typename metavariables::system>,
                  tmpl::conditional_t<has_primitives, Actions::UpdatePrimitives,
                                      tmpl::list<>>>;
   using action_list = tmpl::flatten<

--- a/tests/Unit/Time/CMakeLists.txt
+++ b/tests/Unit/Time/CMakeLists.txt
@@ -32,8 +32,10 @@ target_link_libraries(
   ${LIBRARY}
   PRIVATE
   CoordinateMaps
+  DataStructures
   Domain
   DomainStructure
+  Imex
   Time
   TimeStepperHelpers
   Utilities

--- a/tests/Unit/Time/CMakeLists.txt
+++ b/tests/Unit/Time/CMakeLists.txt
@@ -35,6 +35,7 @@ target_link_libraries(
   DataStructures
   Domain
   DomainStructure
+  Evolution
   Imex
   Time
   TimeStepperHelpers

--- a/tests/Unit/Time/Test_SelfStart.cpp
+++ b/tests/Unit/Time/Test_SelfStart.cpp
@@ -4,6 +4,7 @@
 #include "Framework/TestingFramework.hpp"
 
 #include "Time/SelfStart.hpp"
+#include "Time/Slab.hpp"
 #include "Time/Time.hpp"
 #include "Time/TimeStepId.hpp"
 
@@ -16,4 +17,15 @@ SPECTRE_TEST_CASE("Unit.Time.SelfStart", "[Unit][Time][Actions]") {
       TimeStepId{true, 0, Time{{0.0, 1.0}, {1, 5}}}));
   CHECK_FALSE(SelfStart::is_self_starting(
       TimeStepId{true, 5, Time{{0.5, 0.6}, {4, 9}}}));
+
+  CHECK_FALSE(
+      SelfStart::step_unused(TimeStepId{true, 0, Time{{0.0, 1.0}, 0}},
+                             TimeStepId{true, 0, Time{{0.0, 1.0}, {1, 2}}}));
+  CHECK_FALSE(SelfStart::step_unused(TimeStepId{true, 0, Time{{0.0, 1.0}, 0}},
+                                     TimeStepId{true, 1, Time{{1.0, 2.0}, 0}}));
+  CHECK_FALSE(
+      SelfStart::step_unused(TimeStepId{true, -1, Time{{0.0, 1.0}, 0}},
+                             TimeStepId{true, -1, Time{{0.0, 1.0}, {1, 2}}}));
+  CHECK(SelfStart::step_unused(TimeStepId{true, -1, Time{{0.0, 1.0}, 0}},
+                               TimeStepId{true, 0, Time{{0.0, 1.0}, 0}}));
 }

--- a/tests/Unit/Time/Test_TakeStep.cpp
+++ b/tests/Unit/Time/Test_TakeStep.cpp
@@ -204,11 +204,15 @@ void test_lts() {
 
   // advance time
   db::mutate<Tags::TimeStepId, Tags::Next<Tags::TimeStepId>, Tags::TimeStep,
-             Tags::Next<Tags::TimeStep>>(
+             Tags::Next<Tags::TimeStep>,
+             Tags::HistoryEvolvedVariables<EvolvedVariable>>(
       [](const gsl::not_null<TimeStepId*> time_id,
          const gsl::not_null<TimeStepId*> next_time_id,
          const gsl::not_null<TimeDelta*> local_time_step,
          const gsl::not_null<TimeDelta*> next_time_step,
+         const gsl::not_null<
+             Tags::HistoryEvolvedVariables<EvolvedVariable>::type*>
+             local_history,
          const LtsTimeStepper& time_stepper) {
         *time_id = *next_time_id;
         *local_time_step =
@@ -218,6 +222,7 @@ void test_lts() {
             time_stepper.next_time_id(*next_time_id, *local_time_step);
         *next_time_step =
             local_time_step->with_slab(next_time_id->step_time().slab());
+        time_stepper.clean_history(local_history);
       },
       make_not_null(&box), db::get<Tags::TimeStepper<LtsTimeStepper>>(box));
 

--- a/tests/Unit/Time/TimeSteppers/Test_AdamsBashforth.cpp
+++ b/tests/Unit/Time/TimeSteppers/Test_AdamsBashforth.cpp
@@ -263,8 +263,8 @@ void do_lts_test(const std::array<TimeDelta, 2>& dt) {
 
     ASSERT(not simulation_less(next_check, t), "Screwed up arithmetic");
     if (t == next_check) {
-      ab4.add_boundary_delta(&y, make_not_null(&history), dt[0],
-                             quartic_coupling);
+      ab4.add_boundary_delta(&y, history, dt[0], quartic_coupling);
+      ab4.clean_boundary_history(make_not_null(&history));
       CHECK(y() == approx(quartic_answer(t.value())));
       if (t.is_at_slab_boundary()) {
         break;
@@ -328,8 +328,8 @@ void check_lts_vts() {
     gsl::at(next, side) += this_dt;
 
     if (*std::min_element(next.cbegin(), next.cend()) == next_check) {
-      ab4.add_boundary_delta(&y, make_not_null(&history), next_check - t,
-                             quartic_coupling);
+      ab4.add_boundary_delta(&y, history, next_check - t, quartic_coupling);
+      ab4.clean_boundary_history(make_not_null(&history));
       CHECK(y() == approx(quartic_answer(next_check.value())));
       if (next_check.is_at_slab_boundary()) {
         break;
@@ -454,7 +454,7 @@ SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.AdamsBashforth.Boundary.Reversal",
   add_history(TimeStepId(true, 1, slab.start() + slab.duration() / 3));
   double y = f(1. / 3.);
   ab3.add_boundary_delta(
-      &y, make_not_null(&history), slab.duration() / 3,
+      &y, history, slab.duration() / 3,
       [](const double local, const double /*remote*/) { return local; });
   CHECK(y == approx(f(2. / 3.)));
 }

--- a/tests/Unit/Time/TimeSteppers/Test_AdamsBashforth.cpp
+++ b/tests/Unit/Time/TimeSteppers/Test_AdamsBashforth.cpp
@@ -54,11 +54,7 @@ SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.AdamsBashforth", "[Unit][Time]") {
           1.0e-4);
     }
     TimeStepperTestUtils::check_convergence_order(stepper, {10, 30});
-    for(size_t history_order = 1; history_order <= order; ++history_order){
-      CAPTURE(history_order);
-      TimeStepperTestUtils::check_dense_output(stepper, history_order,
-                                               {10, 30}, 1, true);
-    }
+    TimeStepperTestUtils::check_dense_output(stepper, {10, 30}, 1, true);
 
     CHECK(stepper.order() == order);
     CHECK(stepper.error_estimate_order() == order - 1);

--- a/tests/Unit/Time/TimeSteppers/Test_AdamsBashforth.cpp
+++ b/tests/Unit/Time/TimeSteppers/Test_AdamsBashforth.cpp
@@ -429,7 +429,7 @@ SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.AdamsBashforth.Reversal",
   add_history(0, slab.start() + slab.duration() * 3 / 4);
   add_history(1, slab.start() + slab.duration() / 3);
   double y = f(1. / 3.);
-  ab3.update_u(make_not_null(&y), make_not_null(&history), slab.duration() / 3);
+  ab3.update_u(make_not_null(&y), history, slab.duration() / 3);
   CHECK(y == approx(f(2. / 3.)));
 }
 

--- a/tests/Unit/Time/TimeSteppers/Test_AdamsMoultonPc.cpp
+++ b/tests/Unit/Time/TimeSteppers/Test_AdamsMoultonPc.cpp
@@ -55,19 +55,16 @@ void test_am() {
                                                     start_points, epsilon);
     }
     TimeStepperTestUtils::check_convergence_order(stepper, {10, 30});
-    for (size_t history_order = 2; history_order <= order; ++history_order) {
-      CAPTURE(history_order);
+    {
       std::pair<int32_t, int32_t> convergence_step_range{10, 30};
       int32_t stride = 1;
       if (Monotonic) {
         // Monotonic dense output is much noisier.
-        convergence_step_range.second =
-            110 - 10 * static_cast<int32_t>(history_order);
-        stride = 3 - static_cast<int32_t>(history_order) / 3;
+        convergence_step_range.second = 110 - 10 * static_cast<int32_t>(order);
+        stride = 3 - static_cast<int32_t>(order) / 3;
       }
-      TimeStepperTestUtils::check_dense_output(stepper, history_order,
-                                               convergence_step_range, stride,
-                                               not Monotonic);
+      TimeStepperTestUtils::check_dense_output(stepper, convergence_step_range,
+                                               stride, not Monotonic);
     }
   }
 

--- a/tests/Unit/Time/TimeSteppers/Test_ClassicalRungeKutta4.cpp
+++ b/tests/Unit/Time/TimeSteppers/Test_ClassicalRungeKutta4.cpp
@@ -33,7 +33,7 @@ SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.ClassicalRungeKutta4",
   TimeStepperTestUtils::integrate_variable_test(stepper, 4, 0, 1.0e-9);
   TimeStepperTestUtils::check_convergence_order(stepper, {10, 50});
   TimeStepperTestUtils::stability_test(stepper);
-  TimeStepperTestUtils::check_dense_output(stepper, 4_st, {10, 30}, 1, true);
+  TimeStepperTestUtils::check_dense_output(stepper, {10, 30}, 1, true);
 
   TestHelpers::test_factory_creation<TimeStepper,
                                      TimeSteppers::ClassicalRungeKutta4>(

--- a/tests/Unit/Time/TimeSteppers/Test_DormandPrince5.cpp
+++ b/tests/Unit/Time/TimeSteppers/Test_DormandPrince5.cpp
@@ -32,7 +32,7 @@ SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.DormandPrince5", "[Unit][Time]") {
   TimeStepperTestUtils::integrate_variable_test(stepper, 5, 0, 1.0e-9);
   TimeStepperTestUtils::check_convergence_order(stepper, {10, 50});
   TimeStepperTestUtils::stability_test(stepper);
-  TimeStepperTestUtils::check_dense_output(stepper, 5_st, {10, 30}, 1, true);
+  TimeStepperTestUtils::check_dense_output(stepper, {10, 30}, 1, true);
 
   TestHelpers::test_factory_creation<TimeStepper, TimeSteppers::DormandPrince5>(
       "DormandPrince5");

--- a/tests/Unit/Time/TimeSteppers/Test_Heun2.cpp
+++ b/tests/Unit/Time/TimeSteppers/Test_Heun2.cpp
@@ -33,7 +33,7 @@ SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.Heun2", "[Unit][Time]") {
   TimeStepperTestUtils::integrate_variable_test(stepper, 2, 0, 1.0e-6);
   TimeStepperTestUtils::stability_test(stepper);
   TimeStepperTestUtils::check_convergence_order(stepper, {10, 50});
-  TimeStepperTestUtils::check_dense_output(stepper, 2_st, {10, 100}, 1, true);
+  TimeStepperTestUtils::check_dense_output(stepper, {10, 100}, 1, true);
 
   TimeStepperTestUtils::imex::check_convergence_order(stepper, {10, 50});
   TimeStepperTestUtils::imex::check_bounded_dense_output(stepper);

--- a/tests/Unit/Time/TimeSteppers/Test_Rk3HesthavenSsp.cpp
+++ b/tests/Unit/Time/TimeSteppers/Test_Rk3HesthavenSsp.cpp
@@ -31,7 +31,7 @@ SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.Rk3HesthavenSsp", "[Unit][Time]") {
   TimeStepperTestUtils::integrate_variable_test(stepper, 3, 0, 1e-9);
   TimeStepperTestUtils::stability_test(stepper);
   TimeStepperTestUtils::check_convergence_order(stepper, {10, 50});
-  TimeStepperTestUtils::check_dense_output(stepper, 3_st, {10, 30}, 1, true);
+  TimeStepperTestUtils::check_dense_output(stepper, {10, 30}, 1, true);
 
   TimeStepperTestUtils::check_strong_stability_preservation(stepper, 1.0);
 

--- a/tests/Unit/Time/TimeSteppers/Test_Rk3Kennedy.cpp
+++ b/tests/Unit/Time/TimeSteppers/Test_Rk3Kennedy.cpp
@@ -33,7 +33,7 @@ SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.Rk3Kennedy", "[Unit][Time]") {
   TimeStepperTestUtils::integrate_variable_test(stepper, 3, 0, 1.0e-9);
   TimeStepperTestUtils::stability_test(stepper);
   TimeStepperTestUtils::check_convergence_order(stepper, {10, 50});
-  TimeStepperTestUtils::check_dense_output(stepper, 3_st, {10, 30}, 1, true);
+  TimeStepperTestUtils::check_dense_output(stepper, {10, 30}, 1, true);
 
   TimeStepperTestUtils::imex::check_convergence_order(stepper, {10, 50});
   TimeStepperTestUtils::imex::check_bounded_dense_output(stepper);

--- a/tests/Unit/Time/TimeSteppers/Test_Rk3Owren.cpp
+++ b/tests/Unit/Time/TimeSteppers/Test_Rk3Owren.cpp
@@ -31,7 +31,7 @@ SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.Rk3Owren", "[Unit][Time]") {
   TimeStepperTestUtils::integrate_variable_test(stepper, 3, 0, 1.0e-9);
   TimeStepperTestUtils::stability_test(stepper);
   TimeStepperTestUtils::check_convergence_order(stepper, {10, 50});
-  TimeStepperTestUtils::check_dense_output(stepper, 3_st, {10, 30}, 1, true);
+  TimeStepperTestUtils::check_dense_output(stepper, {10, 30}, 1, true);
 
   TestHelpers::test_factory_creation<TimeStepper, TimeSteppers::Rk3Owren>(
       "Rk3Owren");

--- a/tests/Unit/Time/TimeSteppers/Test_Rk3Pareschi.cpp
+++ b/tests/Unit/Time/TimeSteppers/Test_Rk3Pareschi.cpp
@@ -33,7 +33,7 @@ SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.Rk3Pareschi", "[Unit][Time]") {
   TimeStepperTestUtils::integrate_variable_test(stepper, 3, 0, 1.0e-9);
   TimeStepperTestUtils::stability_test(stepper);
   TimeStepperTestUtils::check_convergence_order(stepper, {10, 50});
-  TimeStepperTestUtils::check_dense_output(stepper, 3_st, {10, 30}, 1, true);
+  TimeStepperTestUtils::check_dense_output(stepper, {10, 30}, 1, true);
 
   TimeStepperTestUtils::imex::check_convergence_order(stepper, {10, 50});
   TimeStepperTestUtils::imex::check_bounded_dense_output(stepper);

--- a/tests/Unit/Time/TimeSteppers/Test_Rk4Kennedy.cpp
+++ b/tests/Unit/Time/TimeSteppers/Test_Rk4Kennedy.cpp
@@ -33,7 +33,7 @@ SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.Rk4Kennedy", "[Unit][Time]") {
   TimeStepperTestUtils::integrate_variable_test(stepper, 4, 0, 1.0e-14);
   TimeStepperTestUtils::stability_test(stepper);
   TimeStepperTestUtils::check_convergence_order(stepper, {10, 50});
-  TimeStepperTestUtils::check_dense_output(stepper, 4_st, {10, 30}, 1, true);
+  TimeStepperTestUtils::check_dense_output(stepper, {10, 30}, 1, true);
 
   TimeStepperTestUtils::imex::check_convergence_order(stepper, {10, 50});
   TimeStepperTestUtils::imex::check_bounded_dense_output(stepper);

--- a/tests/Unit/Time/TimeSteppers/Test_Rk4Owren.cpp
+++ b/tests/Unit/Time/TimeSteppers/Test_Rk4Owren.cpp
@@ -31,7 +31,7 @@ SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.Rk4Owren", "[Unit][Time]") {
   TimeStepperTestUtils::integrate_variable_test(stepper, 4, 0, 1.0e-9);
   TimeStepperTestUtils::stability_test(stepper);
   TimeStepperTestUtils::check_convergence_order(stepper, {10, 50});
-  TimeStepperTestUtils::check_dense_output(stepper, 4_st, {10, 30}, 1, true);
+  TimeStepperTestUtils::check_dense_output(stepper, {10, 30}, 1, true);
 
   TestHelpers::test_factory_creation<TimeStepper, TimeSteppers::Rk4Owren>(
       "Rk4Owren");

--- a/tests/Unit/Time/TimeSteppers/Test_Rk5Owren.cpp
+++ b/tests/Unit/Time/TimeSteppers/Test_Rk5Owren.cpp
@@ -31,7 +31,7 @@ SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.Rk5Owren", "[Unit][Time]") {
   TimeStepperTestUtils::integrate_variable_test(stepper, 5, 0, 1.0e-9);
   TimeStepperTestUtils::stability_test(stepper);
   TimeStepperTestUtils::check_convergence_order(stepper, {10, 50});
-  TimeStepperTestUtils::check_dense_output(stepper, 5_st, {10, 30}, 1, true);
+  TimeStepperTestUtils::check_dense_output(stepper, {10, 30}, 1, true);
 
   TestHelpers::test_factory_creation<TimeStepper, TimeSteppers::Rk5Owren>(
       "Rk5Owren");

--- a/tests/Unit/Time/TimeSteppers/Test_Rk5Tsitouras.cpp
+++ b/tests/Unit/Time/TimeSteppers/Test_Rk5Tsitouras.cpp
@@ -32,7 +32,7 @@ SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.Rk5Tsitouras", "[Unit][Time]") {
   TimeStepperTestUtils::integrate_variable_test(stepper, 5, 0, 1.0e-9);
   TimeStepperTestUtils::check_convergence_order(stepper, {30, 70});
   TimeStepperTestUtils::stability_test(stepper);
-  TimeStepperTestUtils::check_dense_output(stepper, 5_st, {10, 30}, 1, true);
+  TimeStepperTestUtils::check_dense_output(stepper, {10, 30}, 1, true);
 
   TestHelpers::test_factory_creation<TimeStepper, TimeSteppers::Rk5Tsitouras>(
       "Rk5Tsitouras");


### PR DESCRIPTION
Reduces the amount of data we need to store in checkpoints, mostly in LTS.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
Evolution executables now need to include the `Actions::CleanHistory` action after each variable update.  See the modifications to the executables in this PR for suggested exact changes.
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
