### PR TITLE
Status CLI: remove some backwards compatibility

### DIFF
--- a/tools/Status/Status.py
+++ b/tools/Status/Status.py
@@ -114,8 +114,6 @@ def get_input_file(comment: Optional[str], work_dir: str) -> Optional[str]:
             )
     # Fallback: Get the input file from the scheduler context file if present
     context_file = Path(work_dir) / "SchedulerContext.yaml"
-    if not context_file.exists():  # Default name of the file changed in #5547
-        context_file = Path(work_dir) / "SubmitContext.yaml"
     try:
         with open(context_file, "r") as open_context_file:
             input_file = yaml.safe_load(open_context_file)["input_file"]


### PR DESCRIPTION
This line raised permission errors if the directory isn't readable. We don't need this backwards compatibility anymore (it's been 8 months), so just delete it.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
