### PR TITLE
Add max/min overloads for two doubles

### DIFF
--- a/src/Utilities/ContainerHelpers.hpp
+++ b/src/Utilities/ContainerHelpers.hpp
@@ -123,6 +123,16 @@ SPECTRE_ALWAYS_INLINE decltype(auto) get_size(
 
 /// Fall-back that allows using `min(x)` where `x` can be a vector or a double
 SPECTRE_ALWAYS_INLINE double min(const double val) { return val; }
+/// Fall-back that allows using `min(x, y)` where `x` or `y` could be a vector
+/// or a double
+SPECTRE_ALWAYS_INLINE double min(const double x, const double y) {
+  return std::min(x, y);
+}
 
 /// Fall-back that allows using `max(x)` where `x` can be a vector or a double
 SPECTRE_ALWAYS_INLINE double max(const double val) { return val; }
+/// Fall-back that allows using `max(x, y)` where `x` or `y` could be a vector
+/// or a double
+SPECTRE_ALWAYS_INLINE double max(const double x, const double y) {
+  return std::max(x, y);
+}

--- a/tests/Unit/Utilities/Test_ContainerHelpers.cpp
+++ b/tests/Unit/Utilities/Test_ContainerHelpers.cpp
@@ -121,4 +121,6 @@ SPECTRE_TEST_CASE("Unit.Utilities.ContainerHelpers", "[Unit][Utilities]") {
   }
   CHECK(min(constant_spectre_vector) == min(2.0));
   CHECK(max(constant_spectre_vector) == max(2.0));
+  CHECK(max(2.0, 1.0) == 2.0);
+  CHECK(min(2.0, 1.0) == 1.0);
 }


### PR DESCRIPTION
## Proposed changes

There is currently an implementation of `max()` with a single `double` argument, so that `max(x)` has the desired behavior whether `x` is a `DataVector` or `double`.  This PR makes an additional implementation `max(x, y)` for `x, y` doubles.  This behavior is consistent with the `DataVector` behavior which is already inherited from `blaze` in which `max(x, y)` with `x` a `DataVector`, and `y` a `double` returns a `DataVector` of element-wise maxima.  Additionally implemented: same thing but with `max` -> `min`.  
 
### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

This is necessary for an additional PR I'll be making soon but I'm trying to reduce that PR's size