### PR TITLE
BBH pipeline: load subcommands lazily

### DIFF
--- a/support/Pipelines/Bbh/__init__.py
+++ b/support/Pipelines/Bbh/__init__.py
@@ -3,22 +3,48 @@
 
 import click
 
-from .FindHorizon import find_horizon_command
-from .InitialData import generate_id_command
-from .Inspiral import start_inspiral_command
-from .Ringdown import start_ringdown_command
+
+# Load subcommands lazily, i.e., only import the module when the subcommand is
+# invoked. This is important so the CLI responds quickly.
+class Bbh(click.MultiCommand):
+    def list_commands(self, ctx):
+        return [
+            "find-horizon",
+            "generate-id",
+            "start-inspiral",
+            "start-ringdown",
+        ]
+
+    def get_command(self, ctx, name):
+        if name == "find-horizon":
+            from .FindHorizon import find_horizon_command
+
+            return find_horizon_command
+        if name == "generate-id":
+            from .InitialData import generate_id_command
+
+            return generate_id_command
+        elif name == "start-inspiral":
+            from .Inspiral import start_inspiral_command
+
+            return start_inspiral_command
+        elif name == "start-ringdown":
+            from .Ringdown import start_ringdown_command
+
+            return start_ringdown_command
+
+        available_commands = " " + "\n ".join(self.list_commands(ctx))
+        raise click.UsageError(
+            f"The command '{name}' is not implemented. "
+            f"Available commands are:\n{available_commands}"
+        )
 
 
-@click.group(name="bbh")
+@click.group(name="bbh", cls=Bbh)
 def bbh_pipeline():
     """Pipeline for binary black hole simulations."""
     pass
 
-
-bbh_pipeline.add_command(generate_id_command)
-bbh_pipeline.add_command(find_horizon_command)
-bbh_pipeline.add_command(start_inspiral_command)
-bbh_pipeline.add_command(start_ringdown_command)
 
 if __name__ == "__main__":
     bbh_pipeline(help_option_names=["-h", "--help"])


### PR DESCRIPTION
Only import the module when the subcommand is
invoked. This is important so the CLI responds quickly.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
