### PR TITLE
Support SpEC initial data in BBH pipeline

### DIFF
--- a/support/Pipelines/Bbh/Inspiral.yaml
+++ b/support/Pipelines/Bbh/Inspiral.yaml
@@ -23,6 +23,10 @@ Parallelization:
   ElementDistribution: NumGridPointsAndGridSpacing
 
 InitialData:
+{% if SpecDataDirectory is defined %}
+  SpecInitialData:
+    DataDirectory: "{{ SpecDataDirectory }}"
+{% else %}
   NumericInitialData:
     FileGlob: "{{ IdFileGlob }}"
     Subgroup: "VolumeData"
@@ -35,6 +39,7 @@ InitialData:
       Shift: ShiftExcess
       SpatialMetric: SpatialMetric
       ExtrinsicCurvature: ExtrinsicCurvature
+{% endif %}
 
 DomainCreator:
   BinaryCompactObject:


### PR DESCRIPTION
## Proposed changes

Allows to start a BBH evolution from SpEC initial data like this:

```
spectre bbh start-inspiral ID_Params.perl -O Ev
```

Closes #6020.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
