### PR TITLE
Fix linker errors when building with shared libs on macOS Apple Silicon

### DIFF
--- a/src/Elliptic/DiscontinuousGalerkin/Initialization.cpp
+++ b/src/Elliptic/DiscontinuousGalerkin/Initialization.cpp
@@ -245,6 +245,22 @@ void mortar_jacobian(
       const std::optional<tnsr::II<DataVector, DIM(data)>>&                    \
           inv_metric_on_mortar,                                                \
       const ElementMap<DIM(data), Frame::Inertial>& element_map,               \
+      const domain::FunctionsOfTimeMap& functions_of_time);                    \
+  template void detail::initialize_coords_and_jacobians(                       \
+      gsl::not_null<tnsr::I<DataVector, DIM(data), Frame::ElementLogical>*>    \
+          logical_coords,                                                      \
+      gsl::not_null<tnsr::I<DataVector, DIM(data), Frame::Inertial>*>          \
+          inertial_coords,                                                     \
+      gsl::not_null<InverseJacobian<DataVector, DIM(data),                     \
+                                    Frame::ElementLogical, Frame::Inertial>*>  \
+          inv_jacobian,                                                        \
+      gsl::not_null<Scalar<DataVector>*> det_inv_jacobian,                     \
+      gsl::not_null<Scalar<DataVector>*> det_jacobian,                         \
+      gsl::not_null<InverseJacobian<DataVector, DIM(data),                     \
+                                    Frame::ElementLogical, Frame::Inertial>*>  \
+          det_times_inv_jacobian,                                              \
+      const Mesh<DIM(data)>& mesh,                                             \
+      const ElementMap<DIM(data), Frame::Inertial>& element_map,               \
       const domain::FunctionsOfTimeMap& functions_of_time);
 
 GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))

--- a/src/Evolution/Systems/CurvedScalarWave/VolumeTermsInstantiation.cpp
+++ b/src/Evolution/Systems/CurvedScalarWave/VolumeTermsInstantiation.cpp
@@ -6,13 +6,14 @@
 #include "Evolution/DiscontinuousGalerkin/Actions/VolumeTermsImpl.tpp"
 #include "Evolution/Systems/CurvedScalarWave/System.hpp"
 #include "Evolution/Systems/CurvedScalarWave/TimeDerivative.hpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.tpp"
 #include "Utilities/GenerateInstantiations.hpp"
 
-namespace evolution::dg::Actions::detail {
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 
 #define INSTANTIATION(r, data)                                                \
-  template void volume_terms<::CurvedScalarWave::TimeDerivative<DIM(data)>>(  \
+  template void evolution::dg::Actions::detail::volume_terms<                 \
+      ::CurvedScalarWave::TimeDerivative<DIM(data)>>(                         \
       const gsl::not_null<Variables<db::wrap_tags_in<                         \
           ::Tags::dt, typename ::CurvedScalarWave::System<DIM(                \
                           data)>::variables_tag::tags_list>>*>                \
@@ -60,10 +61,11 @@ namespace evolution::dg::Actions::detail {
       const tnsr::I<DataVector, DIM(data), Frame::Inertial>&                  \
           trace_spatial_christoffel,                                          \
       const Scalar<DataVector>& trace_extrinsic_curvature,                    \
-      const Scalar<DataVector>& gamma1, const Scalar<DataVector>& gamma2);
+      const Scalar<DataVector>& gamma1, const Scalar<DataVector>& gamma2);    \
+  INSTANTIATE_PARTIAL_DERIVATIVES_WITH_SYSTEM(                                \
+      CurvedScalarWave::System<DIM(data)>, DIM(data), Frame::Inertial)
 
 GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
 
 #undef INSTANTIATION
 #undef DIM
-}  // namespace evolution::dg::Actions::detail

--- a/src/Evolution/Systems/GeneralizedHarmonic/VolumeTermsInstantiation.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/VolumeTermsInstantiation.cpp
@@ -8,13 +8,14 @@
 #include "Evolution/DiscontinuousGalerkin/Actions/VolumeTermsImpl.tpp"
 #include "Evolution/Systems/GeneralizedHarmonic/System.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/TimeDerivative.hpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.tpp"
 #include "Utilities/GenerateInstantiations.hpp"
 
-namespace evolution::dg::Actions::detail {
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 
 #define INSTANTIATION(r, data)                                                 \
-  template void volume_terms<::gh::TimeDerivative<DIM(data)>>(                 \
+  template void evolution::dg::Actions::detail::volume_terms<                  \
+      ::gh::TimeDerivative<DIM(data)>>(                                        \
       const gsl::not_null<Variables<db::wrap_tags_in<                          \
           ::Tags::dt,                                                          \
           typename ::gh::System<DIM(data)>::variables_tag::tags_list>>*>       \
@@ -59,10 +60,11 @@ namespace evolution::dg::Actions::detail {
       const InverseJacobian<DataVector, DIM(data), Frame::ElementLogical,      \
                             Frame::Inertial>& inverse_jacobian,                \
       const std::optional<tnsr::I<DataVector, DIM(data), Frame::Inertial>>&    \
-          mesh_velocity_from_time_deriv_args);
+          mesh_velocity_from_time_deriv_args);                                 \
+  INSTANTIATE_PARTIAL_DERIVATIVES_WITH_SYSTEM(gh::System<DIM(data)>,           \
+                                              DIM(data), Frame::Inertial)
 
 GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
 
 #undef INSTANTIATION
 #undef DIM
-}  // namespace evolution::dg::Actions::detail

--- a/src/Evolution/Systems/ScalarTensor/VolumeTermsInstantiation.cpp
+++ b/src/Evolution/Systems/ScalarTensor/VolumeTermsInstantiation.cpp
@@ -8,9 +8,10 @@
 #include "Evolution/DiscontinuousGalerkin/Actions/VolumeTermsImpl.tpp"
 #include "Evolution/Systems/ScalarTensor/System.hpp"
 #include "Evolution/Systems/ScalarTensor/TimeDerivative.hpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.tpp"
 
-namespace evolution::dg::Actions::detail {
-template void volume_terms<::ScalarTensor::TimeDerivative>(
+template void
+evolution::dg::Actions::detail::volume_terms<::ScalarTensor::TimeDerivative>(
     const gsl::not_null<Variables<db::wrap_tags_in<
         ::Tags::dt,
         typename ::ScalarTensor::System::variables_tag::tags_list>>*>
@@ -70,4 +71,6 @@ template void volume_terms<::ScalarTensor::TimeDerivative>(
     const Scalar<DataVector>& gamma2_scalar,
     // Scalar Tensor extra argument tags
     const Scalar<DataVector>& scalar_source);
-}  // namespace evolution::dg::Actions::detail
+
+INSTANTIATE_PARTIAL_DERIVATIVES_WITH_SYSTEM(ScalarTensor::System, 3,
+                                            Frame::Inertial)

--- a/src/Evolution/Systems/ScalarWave/VolumeTermsInstantiation.cpp
+++ b/src/Evolution/Systems/ScalarWave/VolumeTermsInstantiation.cpp
@@ -6,13 +6,14 @@
 #include "Evolution/DiscontinuousGalerkin/Actions/VolumeTermsImpl.tpp"
 #include "Evolution/Systems/ScalarWave/System.hpp"
 #include "Evolution/Systems/ScalarWave/TimeDerivative.hpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.tpp"
 #include "Utilities/GenerateInstantiations.hpp"
 
-namespace evolution::dg::Actions::detail {
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 
 #define INSTANTIATION(r, data)                                                \
-  template void volume_terms<::ScalarWave::TimeDerivative<DIM(data)>>(        \
+  template void evolution::dg::Actions::detail::volume_terms<                 \
+      ::ScalarWave::TimeDerivative<DIM(data)>>(                               \
       const gsl::not_null<Variables<db::wrap_tags_in<                         \
           ::Tags::dt, typename ::ScalarWave::System<DIM(                      \
                           data)>::variables_tag::tags_list>>*>                \
@@ -51,10 +52,11 @@ namespace evolution::dg::Actions::detail {
       const std::optional<Scalar<DataVector>>& div_mesh_velocity,             \
       const Scalar<DataVector>& pi,                                           \
       const tnsr::i<DataVector, DIM(data), Frame::Inertial>& phi,             \
-      const Scalar<DataVector>& gamma2);
+      const Scalar<DataVector>& gamma2);                                      \
+  INSTANTIATE_PARTIAL_DERIVATIVES_WITH_SYSTEM(ScalarWave::System<DIM(data)>,  \
+                                              DIM(data), Frame::Inertial)
 
 GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
 
 #undef INSTANTIATION
 #undef DIM
-}  // namespace evolution::dg::Actions::detail

--- a/src/NumericalAlgorithms/LinearOperators/PartialDerivatives.tpp
+++ b/src/NumericalAlgorithms/LinearOperators/PartialDerivatives.tpp
@@ -371,3 +371,34 @@ struct LogicalImpl<3, VariableTags, DerivativeTags> {
   }
 };
 }  // namespace partial_derivatives_detail
+
+// Macro to explicitly instantiate partial_derivatives()
+// for a given system of equations
+#define INSTANTIATE_PARTIAL_DERIVATIVES_WITH_SYSTEM(SYSTEM, DIM,             \
+                                                    DERIVATIVE_FRAME)        \
+  template void partial_derivatives(                                         \
+      gsl::not_null<Variables<                                               \
+          db::wrap_tags_in<Tags::deriv, typename SYSTEM::gradient_variables, \
+                           tmpl::size_t<DIM>, DERIVATIVE_FRAME>>*>           \
+          du,                                                                \
+      const std::array<Variables<typename SYSTEM::gradient_variables>, DIM>& \
+          logical_partial_derivatives_of_u,                                  \
+      const InverseJacobian<DataVector, DIM, Frame::ElementLogical,          \
+                            DERIVATIVE_FRAME>& inverse_jacobian);            \
+  template void partial_derivatives(                                         \
+      gsl::not_null<Variables<                                               \
+          db::wrap_tags_in<Tags::deriv, typename SYSTEM::gradient_variables, \
+                           tmpl::size_t<DIM>, DERIVATIVE_FRAME>>*>           \
+          du,                                                                \
+      const Variables<typename SYSTEM::gradient_variables>& u,               \
+      const Mesh<DIM>& mesh,                                                 \
+      const InverseJacobian<DataVector, DIM, Frame::ElementLogical,          \
+                            DERIVATIVE_FRAME>& inverse_jacobian);            \
+  template Variables<                                                        \
+      db::wrap_tags_in<Tags::deriv, typename SYSTEM::gradient_variables,     \
+                       tmpl::size_t<DIM>, DERIVATIVE_FRAME>>                 \
+  partial_derivatives<typename SYSTEM::gradient_variables>(                  \
+      const Variables<typename SYSTEM::gradient_variables>& u,               \
+      const Mesh<DIM>& mesh,                                                 \
+      const InverseJacobian<DataVector, DIM, Frame::ElementLogical,          \
+                            DERIVATIVE_FRAME>& inverse_jacobian);


### PR DESCRIPTION
## Proposed changes

I have succeeded in building spectre, with all tests passing, on macOS using shared libraries. (Previously, we required macOS Apple Silicon users to build with static libraries.) But to make this work, I had to fix some linker errors that appeared:

* I added an explicit instantiation for `detail::initialize_coords_and_jacobians()` in `src/Elliptic/DiscontinuousGalerkin/Initialization.cpp`. Otherwise, I get an undefined symbol linker error when trying to build this file.
* I added includes for PartialDerivatives.hpp and PartialDerivatives.tpp to a bunch of our executables, since when building them I was getting linker errors about partial_derivatives being undefined symbols.

A followup PR will update the macOS apple silicon docs.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
