### PR TITLE
Update how often constraints are observed in BBH inspiral pipeline

### DIFF
--- a/support/Pipelines/Bbh/Inspiral.yaml
+++ b/support/Pipelines/Bbh/Inspiral.yaml
@@ -108,7 +108,10 @@ DomainCreator:
 Evolution:
   InitialTime: 0.0
   InitialTimeStep: 0.0002
-  InitialSlabSize: 0.25
+  # This is the smallest interval we'd need to observe time step/constraints. If
+  # you need it smaller you can edit it, but make sure to change the slab
+  # intervals in the EventsAndTriggers
+  InitialSlabSize: 0.5
   StepChoosers:
     - Increase:
         Factor: 2
@@ -250,9 +253,32 @@ EventsAndTriggers:
           - Name: PointwiseL2Norm(FourIndexConstraint)
             NormType: L2Norm
             Components: Sum
+  - Trigger:
+      Slabs:
+        # Trigger apparent horizon observations often enough so they find the
+        # next horizon based on the previous initial guess.
+        EvenlySpaced:
+          Interval: 20
+          Offset: 0
+    Events:
+      # Observe constraint energy while we need it for ErrorIfDataTooBig so we
+      # only compute it once
+      - ObserveNorms:
+          SubfileName: Norms
+          TensorsToObserve:
           - Name: ConstraintEnergy
             NormType: L2Norm
             Components: Sum
+      - ErrorIfDataTooBig:
+          Threshold: 10
+          VariablesToCheck: [ConstraintEnergy]
+      - ErrorIfDataTooBig:
+          Threshold: 100
+          VariablesToCheck: [SpacetimeMetric]
+      - ObservationAhA
+      - ObservationAhB
+      - ObservationExcisionBoundaryA
+      - ObservationExcisionBoundaryB
   - Trigger:
       Slabs:
         EvenlySpaced:
@@ -275,24 +301,6 @@ EventsAndTriggers:
           # for visualization.
           CoordinatesFloatingPointType: Float
           FloatingPointTypes: [Float]
-      - ObservationExcisionBoundaryA
-      - ObservationExcisionBoundaryB
-  - Trigger:
-      Slabs:
-        EvenlySpaced:
-          # Trigger apparent horizon observations often enough so they find the
-          # next horizon based on the previous initial guess.
-          Interval: 10
-          Offset: 0
-    Events:
-      - ErrorIfDataTooBig:
-          Threshold: 10
-          VariablesToCheck: [ConstraintEnergy]
-      - ErrorIfDataTooBig:
-          Threshold: 100
-          VariablesToCheck: [SpacetimeMetric]
-      - ObservationAhA
-      - ObservationAhB
   - Trigger:
       SeparationLessThan:
         Value: 2.5

--- a/tests/tools/Test_Status.py
+++ b/tests/tools/Test_Status.py
@@ -85,9 +85,14 @@ class TestExecutableStatus(unittest.TestCase):
             open_h5_file.close_current_object()
             # Constraints
             constraints_subfile = open_h5_file.insert_dat(
-                "/Norms", legend=["L2Norm(ConstraintEnergy)"], version=0
+                "/Norms",
+                legend=[
+                    "L2Norm(ConstraintEnergy)",
+                    "L2Norm(PointwiseL2Norm(ThreeIndexConstraint))",
+                ],
+                version=0,
             )
-            constraints_subfile.append([1.0e-3])
+            constraints_subfile.append([1.0e-3, 1.0e-4])
             open_h5_file.close_current_object()
             # Elliptic solver residuals
             residuals_subfile = open_h5_file.insert_dat(
@@ -125,7 +130,7 @@ class TestExecutableStatus(unittest.TestCase):
         self.assertEqual(status["Speed"], 2640.0)
         self.assertEqual(status["Orbits"], 0.5)
         self.assertEqual(status["Separation"], 2.0)
-        self.assertEqual(status["Constraint Energy"], 1.0e-3)
+        self.assertEqual(status["3-Index Constraint"], 1.0e-4)
 
     def test_evolve_single_bh_status(self):
         executable_status = match_executable_status("EvolveGhSingleBlackHole")

--- a/tools/Status/ExecutableStatus/EvolveGhBinaryBlackHole.py
+++ b/tools/Status/ExecutableStatus/EvolveGhBinaryBlackHole.py
@@ -21,7 +21,7 @@ class EvolveGhBinaryBlackHole(EvolutionStatus):
         "Speed": "M/h",
         "Orbits": None,
         "Separation": "M",
-        "Constraint Energy": None,
+        "3-Index Constraint": None,
     }
 
     def status(self, input_file, work_dir):
@@ -77,12 +77,12 @@ class EvolveGhBinaryBlackHole(EvolutionStatus):
                 norms = to_dataframe(
                     open_reductions_file["Norms.dat"], slice=np.s_[-1:]
                 )
-                result["Constraint Energy"] = norms.iloc[-1][
-                    "L2Norm(ConstraintEnergy)"
+                result["3-Index Constraint"] = norms.iloc[-1][
+                    "L2Norm(PointwiseL2Norm(ThreeIndexConstraint))"
                 ]
             except:
                 logger.debug(
-                    "Unable to extract constraint energy.", exc_info=True
+                    "Unable to extract three index constraint.", exc_info=True
                 )
         return result
 
@@ -91,6 +91,6 @@ class EvolveGhBinaryBlackHole(EvolutionStatus):
             return f"{value:g}"
         elif field == "Orbits":
             return f"{value:g}"
-        elif field == "Constraint Energy":
+        elif field == "3-Index Constraint":
             return f"{value:.2e}"
         return super().format(field, value)


### PR DESCRIPTION
## Proposed changes

This is currently only done for inspiral because I honestly don't know how often we'll want it done for ringdown and there's so many other changes that have to happen for the ringdown yaml that it didn't seem necessary to incorrectly guess here.

Also changed the BBH status in the CLI to print the 3-index constraint instead of the constraint energy because we observe the 3-index more often now and a "status" seemed like it should be updated pretty often to give an accurate snapshot of the simulation.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
