### PR TITLE
Compress ElementId more

### DIFF
--- a/src/Domain/Structure/ElementId.cpp
+++ b/src/Domain/Structure/ElementId.cpp
@@ -33,11 +33,11 @@ static_assert(std::is_standard_layout_v<ElementId<2>> and
 static_assert(std::is_standard_layout_v<ElementId<3>> and
               std::is_trivial_v<ElementId<3>>);
 
-static_assert(sizeof(ElementId<1>) == 3 * sizeof(int),
+static_assert(sizeof(ElementId<1>) == 2 * sizeof(int),
               "Wrong size for ElementId<1>");
-static_assert(sizeof(ElementId<2>) == 3 * sizeof(int),
+static_assert(sizeof(ElementId<2>) == 2 * sizeof(int),
               "Wrong size for ElementId<2>");
-static_assert(sizeof(ElementId<3>) == 3 * sizeof(int),
+static_assert(sizeof(ElementId<3>) == 2 * sizeof(int),
               "Wrong size for ElementId<3>");
 
 template <size_t VolumeDim>
@@ -50,8 +50,7 @@ ElementId<VolumeDim>::ElementId(const size_t block_id, const size_t grid_index)
       index_eta_{0},
       refinement_level_eta_{0},
       index_zeta_{0},
-      refinement_level_zeta_{0},
-      empty_{0} {
+      refinement_level_zeta_{0} {
   ASSERT(block_id < two_to_the(block_id_bits),
          "Block id out of bounds: " << block_id << "\nMaximum value is: "
                                     << two_to_the(block_id_bits) - 1);
@@ -73,7 +72,6 @@ ElementId<VolumeDim>::ElementId(const size_t block_id,
   ASSERT(grid_index < two_to_the(grid_index_bits),
          "Grid index out of bounds: " << grid_index << "\nMaximum value is: "
                                       << two_to_the(grid_index_bits) - 1);
-  empty_ = 0;
   index_xi_ = segment_ids[0].index();
   refinement_level_xi_ = segment_ids[0].refinement_level();
   if constexpr (VolumeDim > 1) {
@@ -104,8 +102,7 @@ ElementId<VolumeDim>::ElementId(const Direction<VolumeDim>& direction,
       index_eta_{element_id.index_eta_},
       refinement_level_eta_{element_id.refinement_level_eta_},
       index_zeta_{element_id.index_zeta_},
-      refinement_level_zeta_{element_id.refinement_level_zeta_},
-      empty_{0} {}
+      refinement_level_zeta_{element_id.refinement_level_zeta_} {}
 
 template <size_t VolumeDim>
 ElementId<VolumeDim>::ElementId(const std::string& grid_name)
@@ -156,7 +153,6 @@ ElementId<VolumeDim>::ElementId(const std::string& grid_name)
   } else {
     grid_index_ = 0;
   }
-  empty_ = 0;
   ASSERT(block_id_ < two_to_the(block_id_bits),
          "Block id out of bounds: " << block_id_ << "\nMaximum value is: "
                                     << two_to_the(block_id_bits) - 1);

--- a/src/Domain/Structure/ElementId.hpp
+++ b/src/Domain/Structure/ElementId.hpp
@@ -93,7 +93,7 @@ class alignas(int[3]) ElementId { // NOLINT(modernize-avoid-c-arrays)
             size_t grid_index = 0);
 
   /// Create an ElementId from its string representation (see `operator<<`).
-  ElementId(const std::string& grid_name);
+  explicit ElementId(const std::string& grid_name);
 
   ElementId<VolumeDim> id_of_child(size_t dim, Side side) const;
 

--- a/src/Domain/Structure/ElementId.hpp
+++ b/src/Domain/Structure/ElementId.hpp
@@ -50,7 +50,7 @@ class er;
  * constraints.
  */
 template <size_t VolumeDim>
-class ElementId {
+class alignas(int[3]) ElementId { // NOLINT(modernize-avoid-c-arrays)
  public:
   // We restrict the ElementId size to 64 bits for easy hashing into
   // size_t. This still allows us to have over 17 trillion elements, which is
@@ -68,12 +68,9 @@ class ElementId {
       static_cast<uint64_t>(block_id_bits + grid_index_bits);
   static constexpr uint64_t direction_mask = static_cast<uint64_t>(0b1111)
                                              << direction_shift;
-  // We need some padding to ensure bit fields align with type boundaries,
-  // otherwise the size of `ElementId` is too large.
-  static constexpr size_t padding = 32;
   static_assert(block_id_bits + 3 * (refinement_bits + max_refinement_level) +
-                        grid_index_bits + direction_bits + padding ==
-                    3 * 8 * sizeof(int),
+                        grid_index_bits + direction_bits ==
+                    static_cast<size_t>(2 * 8) * sizeof(int),
                 "Bit representation requires padding or is too large");
   static_assert(two_to_the(refinement_bits) >= max_refinement_level,
                 "Not enough bits to represent all refinement levels");
@@ -138,7 +135,6 @@ class ElementId {
   uint8_t refinement_level_eta_ : refinement_bits;  // third 16 bits
   uint16_t index_zeta_ : max_refinement_level;
   uint8_t refinement_level_zeta_ : refinement_bits;  // fourth 16 bits
-  uint32_t empty_ : padding;                         // last 32 bits
 };
 
 /// \cond

--- a/tests/Unit/Domain/Structure/Test_ElementId.cpp
+++ b/tests/Unit/Domain/Structure/Test_ElementId.cpp
@@ -20,6 +20,7 @@
 #include "Utilities/GetOutput.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeArray.hpp"
+#include "Utilities/Serialization/Serialize.hpp"
 #include "Utilities/StdHelpers.hpp"  // IWYU pragma: keep
 
 namespace {
@@ -365,6 +366,7 @@ void test_serialization() {
   };
 
   const ElementId<volume_dim> unused_id(0);
+  CHECK(size_of_object_in_bytes(unused_id) == 8);
   for (size_t i = 0; i < 100; ++i) {
     ElementId<volume_dim> element_id{dist_block_id(gen), random_segment_ids(),
                                      dist_grid_index(gen)};


### PR DESCRIPTION
## Proposed changes

I hadn't realized you could have IDs smaller than 96 bits with Charm++. I thought it always had to be exactly 96 bits. This saves us another 4 bytes in the ElementId of unused space.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
