### PR TITLE
Add support for Charm 7.0.1, switch container to it, and add Charm++ license+copyright

### DIFF
--- a/.github/workflows/BuildDockerContainer.yaml
+++ b/.github/workflows/BuildDockerContainer.yaml
@@ -60,6 +60,7 @@ jobs:
           platforms: >
             ${{ inputs.build_arm && 'linux/amd64,linux/arm64'
             || 'linux/amd64' }}
+          build-args: PARALLEL_MAKE_ARG=-j4
       - name: Build CI container
         uses: docker/build-push-action@v5
         with:
@@ -70,6 +71,7 @@ jobs:
           tags: ${{ inputs.image_name }}:ci
           # No ARM container for CI because GitHub doesn't host ARM runners yet
           platforms: linux/amd64
+          build-args: PARALLEL_MAKE_ARG=-j4
 
   run_tests:
     name: Test

--- a/.github/workflows/DemoContainer.yaml
+++ b/.github/workflows/DemoContainer.yaml
@@ -60,6 +60,7 @@ jobs:
           platforms: >
             ${{ inputs.build_arm && 'linux/amd64,linux/arm64'
             || 'linux/amd64' }}
+          build-args: PARALLEL_MAKE_ARG=-j4
       - name: Build and push demo container
         uses: docker/build-push-action@v3
         with:
@@ -71,4 +72,4 @@ jobs:
           platforms: >
             ${{ inputs.build_arm && 'linux/amd64,linux/arm64'
             || 'linux/amd64' }}
-
+          build-args: PARALLEL_MAKE_ARG=-j4

--- a/cmake/SetupCharm.cmake
+++ b/cmake/SetupCharm.cmake
@@ -38,8 +38,8 @@ find_package(Charm ${SPECTRE_REQUIRED_CHARM_VERSION} REQUIRED
   EveryLB
   ${SCOTCHLB_COMPONENT}
   )
-if(CHARM_VERSION VERSION_GREATER 7.0.0)
-  message(WARNING "Builds with Charm++ versions greater than 7.0.0 are \
+if(CHARM_VERSION VERSION_GREATER 7.0.1)
+  message(WARNING "Builds with Charm++ versions greater than 7.0.1 are \
 considered experimental. Please file any issues you encounter.")
 endif()
 

--- a/cmake/SetupLicenseInfo.cmake
+++ b/cmake/SetupLicenseInfo.cmake
@@ -6,6 +6,7 @@ set(_LIST_OF_3PLS
   Boost
   Brigand
   Catch2
+  Charm
   Gsl
   Hdf5
   Jemalloc

--- a/containers/Dockerfile.buildenv
+++ b/containers/Dockerfile.buildenv
@@ -134,7 +134,7 @@ FROM --platform=$BUILDPLATFORM ubuntu:22.04 AS xbuild
 WORKDIR /root
 COPY --from=xx / /
 ARG TARGETPLATFORM
-ARG PARALLEL_MAKE_ARG=-j2
+ARG PARALLEL_MAKE_ARG=-j4
 # Install build dependencies for the host system
 RUN apt-get update -y \
     && apt-get install -y cmake clang lld wget
@@ -183,7 +183,7 @@ ENV TEX_ARCH=aarch64
 FROM base-${TARGETARCH} AS dev
 ARG TARGETARCH
 
-ARG PARALLEL_MAKE_ARG=-j2
+ARG PARALLEL_MAKE_ARG=-j4
 ARG DEBIAN_FRONTEND=noninteractive
 
 # We install dependencies not available through apt manually rather than using
@@ -337,7 +337,7 @@ ARG TARGETARCH
 
 # When building this image individually, the PARALLEL_MAKE_ARG from above is not
 # remembered (and it doesn't hurt to redefine the env variable).
-ARG PARALLEL_MAKE_ARG=-j2
+ARG PARALLEL_MAKE_ARG=-j4
 
 # Install OpenMPI
 RUN apt-get install -y libopenmpi-dev
@@ -402,7 +402,7 @@ CMD ["--help"]
 FROM deploy AS demo
 ARG BUILDARCH
 ARG TARGETARCH
-ARG PARALLEL_MAKE_ARG=-j2
+ARG PARALLEL_MAKE_ARG=-j4
 
 # vim and emacs for editing files
 # Also ffmpeg for making movies with paraview output pngs

--- a/containers/Dockerfile.buildenv
+++ b/containers/Dockerfile.buildenv
@@ -196,10 +196,6 @@ RUN wget https://bitbucket.org/blaze-lib/blaze/downloads/blaze-3.8.tar.gz -O bla
     && mv blaze-* blaze \
     && mv blaze/blaze /usr/local/include \
     && rm -rf blaze*
-# - Brigand
-RUN git clone https://github.com/edouarda/brigand.git \
-    && mv brigand/include/brigand /usr/local/include \
-    && rm -rf brigand
 # - Catch2
 RUN wget https://github.com/catchorg/Catch2/archive/refs/tags/v3.4.0.tar.gz -O catch.tar.gz \
     && tar -xzf catch.tar.gz && rm catch.tar.gz \
@@ -220,21 +216,6 @@ RUN git clone https://github.com/ianlancetaylor/libbacktrace \
     && ./configure --prefix=/usr/local \
     && make $PARALLEL_MAKE_ARG install \
     && cd .. && rm -rf libbacktrace
-# - Libsharp
-RUN wget https://github.com/Libsharp/libsharp/archive/v1.0.0.tar.gz -O libsharp.tar.gz \
-    && tar -xzf libsharp.tar.gz \
-    && mv libsharp-* libsharp_build \
-    && cd libsharp_build \
-    && { if [ "$TARGETARCH" != "arm64" ]; \
-        then sed -i 's/march=native/march=x86-64/' configure.ac; fi } \
-    && autoconf \
-    && ./configure --prefix=/usr/local --enable-pic --disable-openmp \
-    && make $PARALLEL_MAKE_ARG \
-    && mv auto/bin/* /usr/local/bin \
-    && mv auto/include/* /usr/local/include \
-    && mv auto/lib/* /usr/local/lib \
-    && cd ../ \
-    && rm -r libsharp*
 # - LibXSMM
 RUN if [ "$TARGETARCH" = "arm64" ] ; then \
         git clone --single-branch --branch main --depth 1 \

--- a/containers/Dockerfile.buildenv
+++ b/containers/Dockerfile.buildenv
@@ -281,10 +281,10 @@ WORKDIR /work
 # easier for people, and build with O2 to reduce build size.
 RUN wget https://raw.githubusercontent.com/sxs-collaboration/spectre/develop/support/Charm/v7.0.0.patch
 
-RUN git clone --single-branch --branch v7.0.0 --depth 1 \
+RUN git clone --single-branch --branch v7.0.1 --depth 1 \
         https://github.com/UIUC-PPL/charm charm_7_0_0 \
     && cd /work/charm_7_0_0 \
-    && git checkout v7.0.0 \
+    && git checkout v7.0.1 \
     && git apply /work/v7.0.0.patch \
     && ./build LIBS multicore-linux-${CHARM_ARCH} gcc \
         ${PARALLEL_MAKE_ARG} -g -O2 --build-shared --with-production \

--- a/external/Licenses/CharmCopyright.txt
+++ b/external/Licenses/CharmCopyright.txt
@@ -1,0 +1,2 @@
+Copyright (C) 1990-present University of Illinois, Charmworks, Inc.
+https://github.com/charmplusplus/charm/

--- a/external/Licenses/CharmLicense.txt
+++ b/external/Licenses/CharmLicense.txt
@@ -1,0 +1,217 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+--- LLVM Exceptions to the Apache 2.0 License ----
+
+As an exception, if, as a result of your compiling your source code, portions
+of this Software are embedded into an Object form of such source code, you
+may redistribute such embedded portions in such Object form without complying
+with the conditions of Sections 4(a), 4(b) and 4(d) of the License.
+
+In addition, if you combine or link compiled forms of this Software with
+software that is licensed under the GPLv2 ("Combined Software") and if a
+court of competent jurisdiction determines that the patent provision (Section
+3), the indemnity provision (Section 9) or other Section of the License
+conflicts with the conditions of the GPLv2, you may retroactively and
+prospectively choose to deem waived or otherwise exclude such Section(s) of
+the License, but only in their entirety and only with respect to the Combined
+Software.

--- a/support/Charm/v7.0.1.patch
+++ b/support/Charm/v7.0.1.patch
@@ -1,0 +1,101 @@
+diff --git a/cmake/detect-features-cxx.cmake b/cmake/detect-features-cxx.cmake
+index d3aa6ab94..830da9cf1 100644
+--- a/cmake/detect-features-cxx.cmake
++++ b/cmake/detect-features-cxx.cmake
+@@ -38,12 +38,12 @@ endif()
+ 
+ # Needed so that tlsglobals works correctly with --build-shared
+ # See https://github.com/UIUC-PPL/charm/issues/3168 for details.
+-check_cxx_compiler_flag("-ftls-model=initial-exec" CMK_COMPILER_KNOWS_FTLS_MODEL)
+-if(CMK_COMPILER_KNOWS_FTLS_MODEL)
+-  set(OPTS_CC "${OPTS_CC} -ftls-model=initial-exec")
+-  set(OPTS_CXX "${OPTS_CXX} -ftls-model=initial-exec")
+-  set(OPTS_LD "${OPTS_LD} -ftls-model=initial-exec")
+-endif()
++# check_cxx_compiler_flag("-ftls-model=initial-exec" CMK_COMPILER_KNOWS_FTLS_MODEL)
++# if(CMK_COMPILER_KNOWS_FTLS_MODEL)
++#   set(OPTS_CC "${OPTS_CC} -ftls-model=initial-exec")
++#   set(OPTS_CXX "${OPTS_CXX} -ftls-model=initial-exec")
++#   set(OPTS_LD "${OPTS_LD} -ftls-model=initial-exec")
++# endif()
+ 
+ # Allow seeing own symbols dynamically, needed for programmatic backtraces
+ check_cxx_compiler_flag("-rdynamic" CMK_COMPILER_KNOWS_RDYNAMIC)
+diff --git a/src/scripts/configure.ac b/src/scripts/configure.ac
+index f6c0f311b..41a7c9f46 100644
+--- a/src/scripts/configure.ac
++++ b/src/scripts/configure.ac
+@@ -820,15 +820,15 @@ then
+ fi
+ 
+ # Needed so that tlsglobals works correctly with --build-shared
+-# See https://github.com/UIUC-PPL/charm/issues/3168 for details.
+-test_cxx "whether C++ compiler accepts -ftls-model=initial-exec" "yes" "no" "-ftls-model=initial-exec"
+-if test $strictpass -eq 1
+-then
+-    add_flag 'CMK_COMPILER_KNOWS_FTLS_MODEL="1"' "tlsglobals"
+-    OPTS_CC="$OPTS_CC -ftls-model=initial-exec"
+-    OPTS_CXX="$OPTS_CXX -ftls-model=initial-exec"
+-    OPTS_LD="$OPTS_LD -ftls-model=initial-exec"
+-fi
++# # See https://github.com/UIUC-PPL/charm/issues/3168 for details.
++# test_cxx "whether C++ compiler accepts -ftls-model=initial-exec" "yes" "no" "-ftls-model=initial-exec"
++# if test $strictpass -eq 1
++# then
++#     add_flag 'CMK_COMPILER_KNOWS_FTLS_MODEL="1"' "tlsglobals"
++#     OPTS_CC="$OPTS_CC -ftls-model=initial-exec"
++#     OPTS_CXX="$OPTS_CXX -ftls-model=initial-exec"
++#     OPTS_LD="$OPTS_LD -ftls-model=initial-exec"
++# fi
+ 
+ # Test for a flag important for shared linking
+ test_cxx "whether C++ compiler accepts -fvisibility=hidden" "yes" "no" "-fvisibility=hidden"
+diff --git a/src/util/ckhashtable.h b/src/util/ckhashtable.h
+index 3f2c895aa..6b19c4641 100644
+--- a/src/util/ckhashtable.h
++++ b/src/util/ckhashtable.h
+@@ -437,9 +437,9 @@ as a fast key like this:
+ template <class T> class CkHashtableAdaptorT {
+ 	T val;
+ public:
+-	CkHashtableAdaptorT<T>(const T &v):val(v) {}
++	CkHashtableAdaptorT(const T &v):val(v) {}
+ 	/**added to allow pup to do Key k while unPacking*/
+-	CkHashtableAdaptorT<T>(){}
++	CkHashtableAdaptorT(){}
+ 	operator T & () {return val;}
+ 	operator const T & () const {return val;}
+ 	inline CkHashCode hash(void) const 
+diff --git a/src/util/pup_util.C b/src/util/pup_util.C
+index 82206c118..22ad68fd9 100644
+--- a/src/util/pup_util.C
++++ b/src/util/pup_util.C
+@@ -580,12 +580,16 @@ static PUP_registry *PUP_getRegistry(void) {
+ 	return reg;
+ }
+ 
+-const PUP_regEntry *PUP_getRegEntry(const PUP::able::PUP_ID &id)
++const PUP_regEntry *PUP_getRegEntry(const PUP::able::PUP_ID &id,
++                                    const char *const name_hint = NULL)
+ {
+ 	const PUP_regEntry *cur=(const PUP_regEntry *)(
+ 		PUP_getRegistry()->CkHashtable::get((const void *)&id) );
+-	if (cur==NULL)
+-		CmiAbort("Unrecognized PUP::able::PUP_ID. is there an unregistered module?");
++	if (cur==NULL){
++          if (name_hint != NULL)
++            CmiAbort("Unrecognized PUP::able::PUP_ID for %s", name_hint);
++          CmiAbort("Unrecognized PUP::able::PUP_ID. is there an unregistered module?");
++        }
+ 	return cur;
+ }
+ 
+@@ -623,7 +627,7 @@ void PUP::er::object(able** a)
+ 		} else {
+ 			const PUP::able::PUP_ID &id=(*a)->get_PUP_ID();
+ 			id.pup(*this);
+-			r=PUP_getRegEntry(id);
++			r=PUP_getRegEntry(id, typeid(**a).name());
+ 		}
+ 	}
+ 	syncComment(PUP::sync_begin_object,r->name);

--- a/tools/CharmModulePatches/src/Evolution/DiscontinuousGalerkin/Messages/BoundaryMessage_v7.0.1.decl.h.patch
+++ b/tools/CharmModulePatches/src/Evolution/DiscontinuousGalerkin/Messages/BoundaryMessage_v7.0.1.decl.h.patch
@@ -1,0 +1,13 @@
+diff --git a/src/Evolution/DiscontinuousGalerkin/Messages/BoundaryMessage.decl.h b/src/Evolution/DiscontinuousGalerkin/Messages/BoundaryMessage.decl.h
+index 7444066..317d095 100644
+--- a/src/Evolution/DiscontinuousGalerkin/Messages/BoundaryMessage.decl.h
++++ b/src/Evolution/DiscontinuousGalerkin/Messages/BoundaryMessage.decl.h
+@@ -38,7 +38,7 @@ template <size_t Dim> class CMessage_BoundaryMessage:public CkMessage{
+     void operator delete(void*p, size_t){dealloc(p);}
+     static void* alloc(int,size_t, int*, int, GroupDepNum);
+     static void dealloc(void *p);
+-    CMessage_BoundaryMessage <Dim> ();
++    CMessage_BoundaryMessage ();
+     static void *pack(BoundaryMessage <Dim>  *p);
+     static BoundaryMessage <Dim> * unpack(void* p);
+     void *operator new(size_t, const int);

--- a/tools/CharmModulePatches/src/Parallel/Algorithms/AlgorithmArray_v7.0.1.decl.h.patch
+++ b/tools/CharmModulePatches/src/Parallel/Algorithms/AlgorithmArray_v7.0.1.decl.h.patch
@@ -1,0 +1,13 @@
+diff --git a/src/Parallel/Algorithms/AlgorithmArray.decl.h b/build_main/src/Parallel/Algorithms/AlgorithmArray.decl.h
+index 7bc3d5c52..f10f24c9a 100644
+--- a/src/Parallel/Algorithms/AlgorithmArray.decl.h
++++ b/src/Parallel/Algorithms/AlgorithmArray.decl.h
+@@ -498,7 +498,7 @@ template <class ParallelComponent, class SpectreArrayIndex>  class CProxyElement
+ 
+ /* DECLS: void receive_data(const typename ReceiveTag::temporal_id &impl_noname_7, const ReceiveData_t &impl_noname_8, bool enable_if_disabled);
+  */
+-    template <class ReceiveTag, class ReceiveData_t, typename Fwd1 = typename ReceiveTag::temporal_id, typename Fwd2 = ReceiveData_t>
++    template <typename ReceiveTag, typename Fwd2, typename Fwd1 = typename ReceiveTag::temporal_id>
+     void receive_data(Fwd1 &&impl_noname_7, Fwd2 &&impl_noname_8, bool enable_if_disabled = false, const CkEntryOptions *impl_e_opts=NULL) ;
+ 
+ /* DECLS: void set_terminate(const bool &impl_noname_9);

--- a/tools/CharmModulePatches/src/Parallel/Algorithms/AlgorithmArray_v7.0.1.def.h.patch
+++ b/tools/CharmModulePatches/src/Parallel/Algorithms/AlgorithmArray_v7.0.1.def.h.patch
@@ -1,0 +1,43 @@
+diff --git a/src/Parallel/Algorithms/AlgorithmArray.def.h b/src/Parallel/Algorithms/AlgorithmArray.def.h
+index 79de7a10b..ac9571c89 100644
+--- a/src/Parallel/Algorithms/AlgorithmArray.def.h
++++ b/src/Parallel/Algorithms/AlgorithmArray.def.h
+@@ -555,16 +555,17 @@ void CProxyElement_AlgorithmArray <ParallelComponent, SpectreArrayIndex> ::recei
+ /* DEFS: void receive_data(const typename ReceiveTag::temporal_id &impl_noname_7, const ReceiveData_t &impl_noname_8, bool enable_if_disabled);
+  */
+ template <class ParallelComponent, class SpectreArrayIndex> 
+-template <class ReceiveTag, class ReceiveData_t, typename Fwd1, typename Fwd2>
++template <typename ReceiveTag, typename Fwd2, typename Fwd1>
+ void CProxyElement_AlgorithmArray <ParallelComponent, SpectreArrayIndex> ::receive_data(Fwd1 &&impl_noname_7, Fwd2 &&impl_noname_8, bool enable_if_disabled, const CkEntryOptions *impl_e_opts) 
+ {
++  using ReceiveData_t = Fwd2;
+   ckCheck();
+   AlgorithmArray <ParallelComponent, SpectreArrayIndex>  *obj = ckLocal();
+-  if (obj) {
++  if (obj != nullptr and not Parallel::detail::max_inline_entry_methods_reached()) {
+   envelope env;
+   env.setMsgtype(ForArrayEltMsg);
+   env.setTotalsize(0);
+-  _TRACE_CREATION_DETAILED(&env, CkIndex_AlgorithmArray <ParallelComponent, SpectreArrayIndex> ::template idx_receive_data_marshall10<ReceiveTag, ReceiveData_t>());
++  _TRACE_CREATION_DETAILED(&env, (CkIndex_AlgorithmArray <ParallelComponent, SpectreArrayIndex> ::template idx_receive_data_marshall10<ReceiveTag, ReceiveData_t>()));
+   _TRACE_CREATION_DONE(1);
+   _TRACE_BEGIN_EXECUTE_DETAILED(CpvAccess(curPeEvent),ForArrayEltMsg,(CkIndex_AlgorithmArray <ParallelComponent, SpectreArrayIndex> ::template idx_receive_data_marshall10<ReceiveTag, ReceiveData_t>()),CkMyPe(), 0, ((CkArrayIndex&)ckGetIndex()).getProjectionID(), obj);
+ #if CMK_LBDB_ON
+@@ -669,7 +670,7 @@ bool CProxyElement_AlgorithmArray <ParallelComponent, SpectreArrayIndex> ::invok
+   envelope env;
+   env.setMsgtype(ForArrayEltMsg);
+   env.setTotalsize(0);
+-  _TRACE_CREATION_DETAILED(&env, CkIndex_AlgorithmArray <ParallelComponent, SpectreArrayIndex> ::template idx_invoke_iterable_action_void<ThisAction, PhaseIndex, DataBoxIndex>());
++  _TRACE_CREATION_DETAILED(&env, (CkIndex_AlgorithmArray <ParallelComponent, SpectreArrayIndex> ::template idx_invoke_iterable_action_void<ThisAction, PhaseIndex, DataBoxIndex>()));
+   _TRACE_CREATION_DONE(1);
+   _TRACE_BEGIN_EXECUTE_DETAILED(CpvAccess(curPeEvent),ForArrayEltMsg,(CkIndex_AlgorithmArray <ParallelComponent, SpectreArrayIndex> ::template idx_invoke_iterable_action_void<ThisAction, PhaseIndex, DataBoxIndex>()),CkMyPe(), 0, ((CkArrayIndex&)ckGetIndex()).getProjectionID(), obj);
+ #if CMK_LBDB_ON
+@@ -1399,7 +1400,7 @@ template <class ParallelComponent, class SpectreArrayIndex>
+ template <class ReceiveTag, class MessageType>
+ int CkIndex_AlgorithmArray <ParallelComponent, SpectreArrayIndex> ::reg_receive_data_MessageType() {
+   int epidx = CkRegisterEp<ReceiveTag, MessageType>("receive_data(MessageType* impl_msg)",
+-      reinterpret_cast<CkCallFnPtr>(_call_receive_data_MessageType<ReceiveTag, MessageType>), CMessage_MessageType::__idx, __idx, 0);
++      reinterpret_cast<CkCallFnPtr>(_call_receive_data_MessageType<ReceiveTag, MessageType>), MessageType::base::__idx, __idx, 0);
+   CkRegisterMessagePupFn(epidx, (CkMessagePupFn)MessageType::ckDebugPup);
+   return epidx;
+ }

--- a/tools/CharmModulePatches/src/Parallel/Algorithms/AlgorithmSingleton_v7.0.1.def.h.patch
+++ b/tools/CharmModulePatches/src/Parallel/Algorithms/AlgorithmSingleton_v7.0.1.def.h.patch
@@ -1,0 +1,18 @@
+diff --git a/src/Parallel/Algorithms/AlgorithmSingleton.def.h b/build_main/src/Parallel/Algorithms/AlgorithmSingleton.def.h
+index 136029936..4e3875fbf 100644
+--- a/src/Parallel/Algorithms/AlgorithmSingleton.def.h
++++ b/src/Parallel/Algorithms/AlgorithmSingleton.def.h
+@@ -474,11 +474,11 @@ void CProxyElement_AlgorithmSingleton <ParallelComponent, SpectreArrayIndex> ::receive
+ {
+   ckCheck();
+   AlgorithmSingleton <ParallelComponent, SpectreArrayIndex>  *obj = ckLocal();
+-  if (obj) {
++  if (obj != nullptr and not Parallel::detail::max_inline_entry_methods_reached()) {
+   envelope env;
+   env.setMsgtype(ForArrayEltMsg);
+   env.setTotalsize(0);
+-  _TRACE_CREATION_DETAILED(&env, CkIndex_AlgorithmSingleton <ParallelComponent, SpectreArrayIndex> ::template idx_receive_data_marshall8<ReceiveTag, ReceiveData_t>());
++  _TRACE_CREATION_DETAILED(&env, (CkIndex_AlgorithmSingleton <ParallelComponent, SpectreArrayIndex> ::template idx_receive_data_marshall8<ReceiveTag, ReceiveData_t>()));
+   _TRACE_CREATION_DONE(1);
+   _TRACE_BEGIN_EXECUTE_DETAILED(CpvAccess(curPeEvent),ForArrayEltMsg,(CkIndex_AlgorithmSingleton <ParallelComponent, SpectreArrayIndex> ::template idx_receive_data_marshall8<ReceiveTag, ReceiveData_t>()),CkMyPe(), 0, ((CkArrayIndex&)ckGetIndex()).getProjectionID(), obj);
+ #if CMK_LBDB_ON

--- a/tools/CharmModulePatches/src/Parallel/Algorithms/BoundaryMessage_v7.0.1.decl.h.patch
+++ b/tools/CharmModulePatches/src/Parallel/Algorithms/BoundaryMessage_v7.0.1.decl.h.patch
@@ -1,0 +1,13 @@
+diff --git a/BoundaryMessage2.decl.h b/BoundaryMessage.decl.h
+index 7444066..317d095 100644
+--- a/BoundaryMessage2.decl.h
++++ b/BoundaryMessage.decl.h
+@@ -38,7 +38,7 @@ template <size_t Dim> class CMessage_BoundaryMessage:public CkMessage{
+     void operator delete(void*p, size_t){dealloc(p);}
+     static void* alloc(int,size_t, int*, int, GroupDepNum);
+     static void dealloc(void *p);
+-    CMessage_BoundaryMessage <Dim> ();
++    CMessage_BoundaryMessage ();
+     static void *pack(BoundaryMessage <Dim>  *p);
+     static BoundaryMessage <Dim> * unpack(void* p);
+     void *operator new(size_t, const int);


### PR DESCRIPTION
## Proposed changes

- This maintains support for 7.0.0 since 7.0.1 is only a license change with no code changes. There's no reason to update the version on any clusters, etc. since the license is only relevant for distributing compiled executables and libraries. @kidder is working on Charm 8.0.0 support, which also has the new license, and we can delay updating Charm++ everywhere until that's released.
- I have not yet pushed the container but tested it on my fork.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
