### PR TITLE
Add BnsInitialData System

### DIFF
--- a/src/Elliptic/Systems/BnsInitialData/BnsInitialData.hpp
+++ b/src/Elliptic/Systems/BnsInitialData/BnsInitialData.hpp
@@ -1,0 +1,23 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+/// \file
+/// Documents the `IrrotationalBns` namespace
+
+#pragma once
+
+/*!
+ * \ingroup EllipticSystemsGroup
+ * \brief Items related to solving for irrotational Binary Neutron Star initial
+ * data.
+ *
+ * We solve the equations for the relativistic quasi-equilibrium configuration
+ * associated with an object in a quasi-circular orbit around a binary
+ * companion.  We assume the compact object is nonspinning, which allows the
+ * solution to be written in terms of a "velocity potential", which is a
+ * function \f$\Phi\f$ such that \f$D_i \Phi = \rho h u_i\f$, with \f$ \rho,
+ * h\f$ the rest mass density and specific enthalpy respectively, and \f$u_i \f$
+ * the spatial part of the four velocity
+ *
+ */
+namespace BnsInitialData {}

--- a/src/Elliptic/Systems/BnsInitialData/BoundaryConditions/CMakeLists.txt
+++ b/src/Elliptic/Systems/BnsInitialData/BoundaryConditions/CMakeLists.txt
@@ -1,0 +1,30 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBRARY IrrotationalBnsBoundaryConditions)
+
+add_spectre_library(${LIBRARY})
+
+spectre_target_sources(
+  ${LIBRARY}
+  PRIVATE
+  StarSurface.cpp
+  )
+
+spectre_target_headers(
+  ${LIBRARY}
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  Factory.hpp
+  StarSurface.hpp
+  )
+
+target_link_libraries(
+  ${LIBRARY}
+  PUBLIC
+  DataStructures
+  Elliptic
+  Options
+  Parallel
+  Utilities
+  )

--- a/src/Elliptic/Systems/BnsInitialData/BoundaryConditions/Factory.hpp
+++ b/src/Elliptic/Systems/BnsInitialData/BoundaryConditions/Factory.hpp
@@ -1,0 +1,16 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "Elliptic/BoundaryConditions/AnalyticSolution.hpp"
+#include "Elliptic/Systems/BnsInitialData/BoundaryConditions/StarSurface.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace BnsInitialData::BoundaryConditions {
+
+template <typename System>
+using standard_boundary_conditions =
+    tmpl::list<elliptic::BoundaryConditions::AnalyticSolution<System>,
+               StarSurface>;
+}  // namespace BnsInitialData::BoundaryConditions

--- a/src/Elliptic/Systems/BnsInitialData/BoundaryConditions/StarSurface.cpp
+++ b/src/Elliptic/Systems/BnsInitialData/BoundaryConditions/StarSurface.cpp
@@ -1,0 +1,52 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Elliptic/Systems/BnsInitialData/BoundaryConditions/StarSurface.hpp"
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Options/ParseError.hpp"
+#include "Utilities/EqualWithinRoundoff.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+namespace BnsInitialData::BoundaryConditions {
+
+StarSurface::StarSurface(const Options::Context& /*context*/) {}
+
+void StarSurface::apply(
+    gsl::not_null<Scalar<DataVector>*> /*velocity_potential*/,
+    gsl::not_null<Scalar<DataVector>*> n_dot_flux_for_potential,
+    const tnsr::i<DataVector, 3>& /*deriv_velocity_potential*/,
+    const Scalar<DataVector>& lapse,
+    const tnsr::I<DataVector, 3>& rotational_shift,
+    const double euler_enthalpy_constant,
+    const tnsr::i<DataVector, 3>& normal) {
+  tenex::evaluate<>(n_dot_flux_for_potential,
+                    euler_enthalpy_constant / square(lapse()) *
+                        rotational_shift(ti::I) * normal(ti::i));
+}
+// The term on the RHS is constant w.r.t. the variables, so the linearized form
+// of the RHS is zero.
+void StarSurface::apply_linearized(
+    gsl::not_null<Scalar<DataVector>*> velocity_potential_correction,
+    gsl::not_null<Scalar<DataVector>*> n_dot_flux_for_potential_correction,
+    const tnsr::i<DataVector, 3>& /*deriv_velocity_potential*/) {
+  set_number_of_grid_points(n_dot_flux_for_potential_correction,
+                            *velocity_potential_correction);
+  get(*n_dot_flux_for_potential_correction) = 0.0;
+}
+
+void StarSurface::pup(PUP::er& /*p*/) {}
+
+bool operator==(const StarSurface& /*lhs*/, const StarSurface& /*rhs*/) {
+  return true;
+}
+
+bool operator!=(const StarSurface& lhs, const StarSurface& rhs) {
+  return not(lhs == rhs);
+}
+
+PUP::able::PUP_ID StarSurface::my_PUP_ID = 0;  // NOLINT
+
+}  // namespace BnsInitialData::BoundaryConditions

--- a/src/Elliptic/Systems/BnsInitialData/BoundaryConditions/StarSurface.hpp
+++ b/src/Elliptic/Systems/BnsInitialData/BoundaryConditions/StarSurface.hpp
@@ -1,0 +1,105 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <pup.h>
+#include <string>
+#include <vector>
+
+#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Domain/Tags.hpp"
+#include "Domain/Tags/FaceNormal.hpp"
+#include "Elliptic/BoundaryConditions/BoundaryCondition.hpp"
+#include "Elliptic/BoundaryConditions/BoundaryConditionType.hpp"
+#include "Elliptic/Systems//BnsInitialData/Tags.hpp"
+#include "Options/Context.hpp"
+#include "Options/String.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Serialization/CharmPupable.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+class DataVector;
+/// \endcond
+
+namespace BnsInitialData ::BoundaryConditions {
+
+/*!
+ * Impose StarSurface boundary conditions:
+ * \f[
+ *   n_i F^i = \frac{C}{\alpha^2} B^i n_i.
+ * \f]
+ * The boundary condition results from requiring the conservation
+ * equations be regular at the surface of the neutron star.  See
+ * \cite BaumgarteShapiro 15.79.
+ */
+class StarSurface : public elliptic::BoundaryConditions::BoundaryCondition<3> {
+ private:
+  using Base = elliptic::BoundaryConditions::BoundaryCondition<3>;
+
+ public:
+  static constexpr Options::String help =
+      "StarSurface boundary conditions  n_i F^i = C/square(alpha) B^i n_i .";
+
+  using options = tmpl::list<>;
+
+  StarSurface() = default;
+  StarSurface(const StarSurface&) = default;
+  StarSurface& operator=(const StarSurface&) = default;
+  StarSurface(StarSurface&&) = default;
+  StarSurface& operator=(StarSurface&&) = default;
+  ~StarSurface() override = default;
+
+  /// \cond
+  explicit StarSurface(CkMigrateMessage* m) : Base(m) {}
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(StarSurface);
+  /// \endcond
+
+  std::unique_ptr<domain::BoundaryConditions::BoundaryCondition> get_clone()
+      const override {
+    return std::make_unique<StarSurface>(*this);
+  }
+
+  explicit StarSurface(const Options::Context& context);
+
+  std::vector<elliptic::BoundaryConditionType> boundary_condition_types()
+      const override {
+    return {elliptic::BoundaryConditionType::Neumann};
+  }
+
+  using argument_tags =
+      tmpl::list<gr::Tags::Lapse<DataVector>,
+                 BnsInitialData::Tags::RotationalShift<DataVector>,
+                 BnsInitialData::Tags::EulerEnthalpyConstant,
+                 domain::Tags::FaceNormal<3>>;
+  using volume_tags = tmpl::list<BnsInitialData::Tags::EulerEnthalpyConstant>;
+
+  static void apply(gsl::not_null<Scalar<DataVector>*> velocity_potential,
+                    gsl::not_null<Scalar<DataVector>*> n_dot_flux_for_potential,
+                    const tnsr::i<DataVector, 3>& deriv_velocity_potential,
+                    const Scalar<DataVector>& lapse,
+                    const tnsr::I<DataVector, 3>& rotational_shift,
+                    double euler_enthalpy_constant,
+                    const tnsr::i<DataVector, 3>& normal);
+
+  using argument_tags_linearized = tmpl::list<>;
+  using volume_tags_linearized = tmpl::list<>;
+
+  static void apply_linearized(
+      gsl::not_null<Scalar<DataVector>*> velocity_potential_correction,
+      gsl::not_null<Scalar<DataVector>*> n_dot_flux_for_potential_correction,
+      const tnsr::i<DataVector, 3>& deriv_velocity_potential);
+
+  void pup(PUP::er& p) override;
+};
+
+bool operator==(const StarSurface& lhs, const StarSurface& rhs);
+
+bool operator!=(const StarSurface& lhs, const StarSurface& rhs);
+
+}  // namespace BnsInitialData::BoundaryConditions

--- a/src/Elliptic/Systems/BnsInitialData/CMakeLists.txt
+++ b/src/Elliptic/Systems/BnsInitialData/CMakeLists.txt
@@ -1,0 +1,36 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBRARY BnsInitialData)
+
+add_spectre_library(${LIBRARY})
+
+spectre_target_sources(
+  ${LIBRARY}
+  PRIVATE
+  Equations.cpp
+  )
+
+spectre_target_headers(
+  ${LIBRARY}
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  Equations.hpp
+  FirstOrderSystem.hpp
+  BnsInitialData.hpp
+  Tags.hpp
+  )
+
+target_link_libraries(
+  ${LIBRARY}
+  PUBLIC
+  DataStructures
+  ErrorHandling
+  GeneralRelativity
+  Hydro
+  Utilities
+  INTERFACE
+  LinearOperators
+  )
+
+add_subdirectory(BoundaryConditions)

--- a/src/Elliptic/Systems/BnsInitialData/Equations.cpp
+++ b/src/Elliptic/Systems/BnsInitialData/Equations.cpp
@@ -1,0 +1,92 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Elliptic/Systems/BnsInitialData/Equations.hpp"
+
+#include <cstddef>
+
+#include "DataStructures/DataBox/PrefixHelpers.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Index.hpp"
+#include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
+#include "DataStructures/Tensor/Identity.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Elliptic/Systems/Poisson/Equations.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/MakeWithValue.hpp"
+
+namespace BnsInitialData {
+
+void potential_fluxes(
+    const gsl::not_null<tnsr::I<DataVector, 3>*> flux_for_potential,
+    const tnsr::II<DataVector, 3>& rotational_shift_stress,
+    const tnsr::II<DataVector, 3>& inverse_spatial_metric,
+    const tnsr::i<DataVector, 3>& velocity_potential_gradient) {
+  ::tenex::evaluate<ti::I>(flux_for_potential,
+                           (inverse_spatial_metric(ti::I, ti::J) -
+                            rotational_shift_stress(ti::I, ti::J)) *
+                               velocity_potential_gradient(ti::j));
+}
+
+void fluxes_on_face(
+    gsl::not_null<tnsr::I<DataVector, 3>*> face_flux_for_potential,
+    const tnsr::i<DataVector, 3>& face_normal,
+    const tnsr::I<DataVector, 3>& face_normal_vector,
+    const tnsr::II<DataVector, 3>& rotational_shift_stress,
+    const Scalar<DataVector>& velocity_potential) {
+  // potential optimization : precompute the product of the `face_normal`
+  // and the `rotational_shift_stress`
+  ::tenex::evaluate<ti::I>(
+      face_flux_for_potential,
+      velocity_potential() *
+          (face_normal_vector(ti::I) -
+           rotational_shift_stress(ti::I, ti::J) * face_normal(ti::j)));
+}
+
+void add_potential_sources(
+    const gsl::not_null<Scalar<DataVector>*> source_for_potential,
+    const tnsr::i<DataVector, 3>&
+        log_deriv_lapse_times_density_over_specific_enthalpy,
+    const tnsr::i<DataVector, 3>& christoffel_contracted,
+    const tnsr::I<DataVector, 3>& flux_for_potential) {
+  ::tenex::update(
+      source_for_potential,
+      (*source_for_potential)() -
+          flux_for_potential(ti::I) *
+              (log_deriv_lapse_times_density_over_specific_enthalpy(ti::i) +
+               christoffel_contracted(ti::i)));
+}
+
+void Fluxes::apply(
+    const gsl::not_null<tnsr::I<DataVector, 3>*> flux_for_potential,
+    const tnsr::II<DataVector, 3>& inverse_spatial_metric,
+    const tnsr::II<DataVector, 3>& rotational_shift_stress,
+    const Scalar<DataVector>& /*velocity_potential*/,
+    const tnsr::i<DataVector, 3>& velocity_potential_gradient) {
+  potential_fluxes(flux_for_potential, rotational_shift_stress,
+                   inverse_spatial_metric, velocity_potential_gradient);
+}
+
+void Fluxes::apply(const gsl::not_null<tnsr::I<DataVector, 3>*> flux_on_face,
+                   const tnsr::II<DataVector, 3>& /*inverse_spatial_metric*/,
+                   const tnsr::II<DataVector, 3>& rotational_shift_stress,
+                   const tnsr::i<DataVector, 3>& face_normal,
+                   const tnsr::I<DataVector, 3>& face_normal_vector,
+                   const Scalar<DataVector>& velocity_potential) {
+  fluxes_on_face(flux_on_face, face_normal, face_normal_vector,
+                 rotational_shift_stress, velocity_potential);
+}
+
+void Sources::apply(
+    const gsl::not_null<Scalar<DataVector>*> equation_for_potential,
+    const tnsr::i<DataVector, 3>&
+        log_deriv_lapse_times_density_over_specific_enthalpy,
+    const tnsr::i<DataVector, 3>& christoffel_contracted,
+    const Scalar<DataVector>& /*velocity_potential*/,
+    const tnsr::I<DataVector, 3>& flux_for_potential) {
+  add_potential_sources(equation_for_potential,
+                        log_deriv_lapse_times_density_over_specific_enthalpy,
+                        christoffel_contracted, flux_for_potential);
+}
+
+}  // namespace BnsInitialData

--- a/src/Elliptic/Systems/BnsInitialData/Equations.hpp
+++ b/src/Elliptic/Systems/BnsInitialData/Equations.hpp
@@ -1,0 +1,111 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Elliptic/Systems/BnsInitialData/Tags.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeWithValue.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+class DataVector;
+namespace PUP {
+class er;
+}  // namespace PUP
+namespace BnsInitialData {
+struct Fluxes;
+struct Sources;
+}  // namespace BnsInitialData
+/// \endcond
+
+namespace BnsInitialData {
+
+/*!
+ * \brief Compute the fluxes
+ * \f[ F^i = \gamma^{ij} n_j \Phi  - n_j \Phi
+ * \frac{B^iB^j}{\alpha^2}  \f] where \f$ n_j\f$ is the
+ * `face_normal`.
+ *
+ * The `face_normal_vector` is \f$ \gamma^{ij} n_j\f$.
+ */
+void fluxes_on_face(
+    gsl::not_null<tnsr::I<DataVector, 3>*> face_flux_for_potential,
+    const tnsr::i<DataVector, 3>& face_normal,
+    const tnsr::I<DataVector, 3>& face_normal_vector,
+    const tnsr::II<DataVector, 3>& rotational_shift_stress,
+    const Scalar<DataVector>& velocity_potential);
+
+/*!
+ * \brief Compute the generic fluxes \f$ F^i = D^i \Phi - B^jD_j\Phi /\alpha^2
+ * B^i \f$ for the Irrotational BNS equation for the velocity potential.
+ */
+void potential_fluxes(
+    gsl::not_null<tnsr::I<DataVector, 3>*> flux_for_potential,
+    const tnsr::II<DataVector, 3>& rotational_shift_stress,
+    const tnsr::II<DataVector, 3>& inverse_spatial_metric,
+    const tnsr::i<DataVector, 3>& velocity_potential_gradient);
+
+/*!
+ * \brief Add the sources \f$S=-\Gamma^i_{ij}F^j - \D_j \left(\alpha \rho /
+ * h\right)  F^j\f$ for the curved-space Irrotational BNS equation on a spatial
+ * metric \f$\gamma_{ij}\f$.
+ *
+ * These sources arise from the non-principal part of the Laplacian on a
+ * non-Euclidean background.
+ */
+void add_potential_sources(
+    gsl::not_null<Scalar<DataVector>*> source_for_potential,
+    const tnsr::i<DataVector, 3>&
+        log_deriv_lapse_times_density_over_specific_enthalpy,
+    const tnsr::i<DataVector, 3>& christoffel_contracted,
+    const tnsr::I<DataVector, 3>& flux_for_potential);
+
+/*!
+ * \brief Compute the fluxes \f$F^i\f$ for the curved-space Irrotatational BNS
+ * equations on a spatial metric \f$\gamma_{ij}\f$.
+ *
+ * \see IrrotationalBns::FirstOrderSystem
+ */
+struct Fluxes {
+  using argument_tags =
+      tmpl::list<gr::Tags::InverseSpatialMetric<DataVector, 3>,
+                 Tags::RotationalShiftStress<DataVector>>;
+  using volume_tags = tmpl::list<>;
+  using const_global_cache_tags = tmpl::list<>;
+  static void apply(gsl::not_null<tnsr::I<DataVector, 3>*> flux_for_potential,
+                    const tnsr::II<DataVector, 3>& inverse_spatial_metric,
+                    const tnsr::II<DataVector, 3>& rotational_shift_stress,
+                    const Scalar<DataVector>& velocity_potential,
+                    const tnsr::i<DataVector, 3>& velocity_potential_gradient);
+  static void apply(gsl::not_null<tnsr::I<DataVector, 3>*> flux_on_face,
+                    const tnsr::II<DataVector, 3>& inverse_spatial_metric,
+                    const tnsr::II<DataVector, 3>& rotational_shift_stress,
+                    const tnsr::i<DataVector, 3>& face_normal,
+                    const tnsr::I<DataVector, 3>& face_normal_vector,
+                    const Scalar<DataVector>& velocity_potential);
+};
+
+/*!
+ * \brief Add the sources \f$S_A\f$ for the curved-space Irrotatioanl BNS
+ * equation on a spatial metric \f$\gamma_{ij}\f$.
+ *
+ * \see IrrotationalBns::FirstOrderSystem
+ */
+struct Sources {
+  using argument_tags = tmpl::list<
+      Tags::DerivLogLapseTimesDensityOverSpecificEnthalpy<DataVector>,
+      gr::Tags::SpatialChristoffelSecondKindContracted<DataVector, 3>>;
+  static void apply(gsl::not_null<Scalar<DataVector>*> equation_for_potential,
+                    const tnsr::i<DataVector, 3>&
+                        log_deriv_lapse_times_density_over_specific_enthalpy,
+                    const tnsr::i<DataVector, 3>& christoffel_contracted,
+                    const Scalar<DataVector>& velocity_potential,
+                    const tnsr::I<DataVector, 3>& flux_for_potential);
+};
+
+}  // namespace BnsInitialData

--- a/src/Elliptic/Systems/BnsInitialData/FirstOrderSystem.hpp
+++ b/src/Elliptic/Systems/BnsInitialData/FirstOrderSystem.hpp
@@ -1,0 +1,98 @@
+
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/DataBox/PrefixHelpers.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "Elliptic/BoundaryConditions/BoundaryCondition.hpp"
+#include "Elliptic/Protocols/FirstOrderSystem.hpp"
+#include "Elliptic/Systems/BnsInitialData/Equations.hpp"
+#include "Elliptic/Systems/BnsInitialData/Tags.hpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
+#include "PointwiseFunctions/GeneralRelativity/TagsDeclarations.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace BnsInitialData {
+
+/*!
+ * \brief The Irrotational Bns equations From Baumgarte and Shapiro Chapter 15
+ *  formulated as a set of coupled first-order PDEs.
+ *
+ * \details This system formulates the Irrotational Bns Hydrostatic Equilibrium
+ * equations for the velocity potential \f$\Phi\f$. For a background matter
+ * distribution (given by the specific enthalpy h) and a background metric
+ * \f$\gamma_{ij}\f$. The velocity potential is defined by \f$D_i \Phi = h
+ * u_i\f$ with \f$u_i\f$ (the spatial part of) the four velocity and where
+ * \f$\Gamma^i_{jk}=\frac{1}{2}\gamma^{il}\left(\partial_j\gamma_{kl}
+ * +\partial_k\gamma_{jl}-\partial_l\gamma_{jk}\right)\f$ are the Christoffel
+ * symbols of the second kind of the background (spatial) metric
+ * \f$\gamma_{ij}\f$. The
+ * background metric \f$\gamma_{ij}\f$ and the Christoffel symbols derived from
+ * it are assumed to be independent of the variables \f$\Phi\f$ and \f$u_i\f$,
+ * i.e.
+ * constant throughout an iterative elliptic solve.  Additionally a background
+ * lapse (\f$\alpha\f$) and
+ * shift (\f$\beta\f$) must be provided.  Finally, a ``rotational killing
+ * vector" \f$k^i\f$ (with magnitude
+ * proportional to the angular velocity of the orbital motion) is provided.  The
+ * rotational shift is defined as \f$B^i = \beta^i + k^i\f$ which is
+ * heuristically the background
+ * motion of the spacetime.
+ *
+ * The system can be formulated in terms of these fluxes and sources (see
+ * `elliptic::protocols::FirstOrderSystem`):
+ *
+ *
+ * \f{align*}
+ * -\partial_i F^i + S = f
+ * \f}
+ *
+ * \f{align*}
+ * F^i &=  D_i \phi - \frac{B^j D_j \phi}{\alpha^2}B^i  \\
+ * S &= -F^iD_i \left( \ln \frac{\alpha \rho}{h}\right) -\Gamma^i_{ij}F^j \\
+ * f &= -D_i \left(\frac{C B^i}{\alpha^2}\right) -
+ * \frac{C}{\alpha^2}B^iD_i\left(
+ * \ln \frac{\alpha \rho}{h}\right)\\
+ * \f}
+ */
+struct FirstOrderSystem
+    : tt::ConformsTo<elliptic::protocols::FirstOrderSystem> {
+ private:
+  using velocity_potential = Tags::VelocityPotential<DataVector>;
+
+ public:
+  static constexpr size_t volume_dim = 3;
+
+  using primal_fields = tmpl::list<velocity_potential>;
+
+  // We just use the standard `Flux` prefix because the fluxes don't have
+  // symmetries and we don't need to give them a particular meaning.
+  using primal_fluxes = tmpl::list<
+      ::Tags::Flux<velocity_potential, tmpl::size_t<3>, Frame::Inertial>>;
+
+  using background_fields = tmpl::list<
+      gr::Tags::InverseSpatialMetric<DataVector, 3>,
+      gr::Tags::SpatialChristoffelSecondKindContracted<DataVector, 3>,
+      gr::Tags::Lapse<DataVector>,
+      ::Tags::deriv<gr::Tags::Lapse<DataVector>,
+                    tmpl::integral_constant<size_t, 3>, Frame::Inertial>,
+      gr::Tags::Shift<DataVector, 3>,
+      ::Tags::deriv<gr::Tags::Shift<DataVector, 3>,
+                    tmpl::integral_constant<size_t, 3>, Frame::Inertial>,
+      Tags::RotationalShift<DataVector>,
+      Tags::DerivLogLapseTimesDensityOverSpecificEnthalpy<DataVector>,
+      Tags::RotationalShiftStress<DataVector>>;
+  using inv_metric_tag = gr::Tags::InverseSpatialMetric<DataVector, 3>;
+
+  using fluxes_computer = Fluxes;
+  using sources_computer = Sources;
+
+  using boundary_conditions_base =
+      elliptic::BoundaryConditions::BoundaryCondition<3>;
+};
+}  // namespace BnsInitialData

--- a/src/Elliptic/Systems/BnsInitialData/Tags.hpp
+++ b/src/Elliptic/Systems/BnsInitialData/Tags.hpp
@@ -1,0 +1,70 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <string>
+
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+
+/// \cond
+class DataVector;
+/// \endcond
+
+/*!
+ * \ingroup EllipticSystemsGroup
+ * \brief Items related to solving for irrotational bns initial data
+ */
+namespace BnsInitialData::Tags {
+
+/*!
+ * \brief The shift plus a spatial vector \f$ k^i\f$
+ * \f$B^i = \beta^i + k^i\f$
+ */
+template <typename DataType>
+struct RotationalShift : db::SimpleTag {
+  using type = tnsr::I<DataType, 3>;
+};
+/*!
+ * \brief The stress-energy corresponding to the rotation shift
+ *
+ *
+ * \f[\Sigma^i_j = \frac{1}{2}\frac{B^iB_j}{\alpha^2}\f]
+ */
+template <typename DataType>
+struct RotationalShiftStress : db::SimpleTag {
+  using type = tnsr::II<DataType, 3>;
+};
+/*!
+ * \brief  The derivative  \f$D_i \ln (\alpha \rho/h)\f$
+ */
+template <typename DataType>
+struct DerivLogLapseTimesDensityOverSpecificEnthalpy : db::SimpleTag {
+  using type = tnsr::i<DataType, 3>;
+};
+
+/*!
+ * \brief The velocity potential for the fluid flow \f$\Phi\f$, i.e. the
+ * curl-free part of the fluid is given by \f$\nabla_a \Phi = h u_a\f$
+ */
+template <typename DataType>
+struct VelocityPotential : db::SimpleTag {
+  using type = Scalar<DataType>;
+};
+
+template <typename DataType>
+struct SpatialRotationalKillingVector : db::SimpleTag {
+  using type = tnsr::I<DataType, 3>;
+};
+
+template <typename DataType>
+struct DerivSpatialRotationalKillingVector : db::SimpleTag {
+  using type = tnsr::iJ<DataType, 3>;
+};
+
+struct EulerEnthalpyConstant : db::SimpleTag {
+  using type = double;
+};
+
+}  // namespace BnsInitialData::Tags

--- a/src/Elliptic/Systems/CMakeLists.txt
+++ b/src/Elliptic/Systems/CMakeLists.txt
@@ -19,6 +19,8 @@ target_link_libraries(
   )
 
 add_subdirectory(Elasticity)
+add_subdirectory(BnsInitialData)
 add_subdirectory(Poisson)
 add_subdirectory(Punctures)
 add_subdirectory(Xcts)
+

--- a/tests/Unit/Elliptic/Systems/BnsInitialData/BoundaryConditions/CMakeLists.txt
+++ b/tests/Unit/Elliptic/Systems/BnsInitialData/BoundaryConditions/CMakeLists.txt
@@ -1,0 +1,20 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBRARY "Test_BnsInitialDataBoundaryConditions")
+
+set(LIBRARY_SOURCES
+  Test_StarSurface.cpp
+  )
+
+add_test_library(${LIBRARY} "${LIBRARY_SOURCES}")
+
+target_link_libraries(
+  ${LIBRARY}
+  PRIVATE
+  DataStructures
+  DomainStructure
+  Elliptic
+  IrrotationalBnsBoundaryConditions
+  Utilities
+  )

--- a/tests/Unit/Elliptic/Systems/BnsInitialData/BoundaryConditions/StarSurface.py
+++ b/tests/Unit/Elliptic/Systems/BnsInitialData/BoundaryConditions/StarSurface.py
@@ -1,0 +1,23 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+
+
+def star_surface_normal_dot_flux(
+    velocity_potential,
+    velocity_potential_gradient,
+    lapse,
+    rotational_shift,
+    euler_enthalpy_constnant,
+    normal,
+):
+    return (
+        euler_enthalpy_constnant
+        / lapse**2
+        * np.einsum("i,i", rotational_shift, normal)
+    )
+
+
+def star_surface_normal_dot_flux_linearized(field_correction):
+    return 0.0

--- a/tests/Unit/Elliptic/Systems/BnsInitialData/BoundaryConditions/Test_StarSurface.cpp
+++ b/tests/Unit/Elliptic/Systems/BnsInitialData/BoundaryConditions/Test_StarSurface.cpp
@@ -1,0 +1,168 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Elliptic/BoundaryConditions/ApplyBoundaryCondition.hpp"
+#include "Elliptic/BoundaryConditions/BoundaryCondition.hpp"
+#include "Elliptic/BoundaryConditions/BoundaryConditionType.hpp"
+#include "Elliptic/Systems/BnsInitialData/BoundaryConditions/StarSurface.hpp"
+#include "Framework/CheckWithRandomValues.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/NormalDotFlux.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace BnsInitialData::BoundaryConditions {
+
+namespace {
+// the velocity potential does not matter
+template <bool Linearized>
+void apply_star_surface_boundary_condition_specific(
+    const gsl::not_null<Scalar<DataVector>*> n_dot_auxilliary_velocity,
+    Scalar<DataVector> velocity_potential = Scalar<DataVector>{
+        DataVector{1.0, 2.0, 3.0}}) {
+  const StarSurface boundary_condition{{}};
+  const tnsr::i<DataVector, 3> velocity_potential_gradient{
+      {DataVector{1.0, 1.0, 1.0}, DataVector{0.0, 0.0, 0.0},
+       DataVector{0.0, 0.0, 0.0}}};
+  const Scalar<DataVector> lapse{DataVector{1.0, 1.5, 1.2}};
+  const tnsr::I<DataVector, 3> rotational_shift{{DataVector{1.0, 1.0, 1.0},
+                                                 DataVector{0.0, 0.0, 0.0},
+                                                 DataVector{0.0, 0.0, 0.0}}};
+  const auto x = tnsr::I<DataVector, 3>{{DataVector{1.0, 1.0, 1.0},
+                                         DataVector{0.0, 0.0, 0.0},
+                                         DataVector{0.0, 0.0, 0.0}}};
+
+  const auto direction = Direction<3>::lower_xi();
+  const tnsr::i<DataVector, 3> normal{{DataVector{1.0, 0.0, 0.0},
+                                       DataVector{0.0, 1.0, 0.0},
+                                       DataVector{0.0, 0.0, 1.0}}};
+  const double euler_enthalpy_constant = 1.0;
+  const auto box = db::create<db::AddSimpleTags<
+      domain::Tags::Faces<3, domain::Tags::Coordinates<3, Frame::Inertial>>,
+      domain::Tags::Faces<3, domain::Tags::FaceNormal<3>>,
+      domain::Tags::Faces<3, gr::Tags::Lapse<DataVector>>,
+      domain::Tags::Faces<3, BnsInitialData::Tags::RotationalShift<DataVector>>,
+      BnsInitialData::Tags::EulerEnthalpyConstant>>(
+      DirectionMap<3, tnsr::I<DataVector, 3>>{{direction, x}},
+      DirectionMap<3, tnsr::i<DataVector, 3>>{{direction, normal}},
+      DirectionMap<3, Scalar<DataVector>>{{direction, lapse}},
+      DirectionMap<3, tnsr::I<DataVector, 3>>{{direction, rotational_shift}},
+      euler_enthalpy_constant);
+  elliptic::apply_boundary_condition<Linearized, void, tmpl::list<StarSurface>>(
+      boundary_condition, box, Direction<3>::lower_xi(),
+      make_not_null(&velocity_potential), n_dot_auxilliary_velocity,
+      velocity_potential_gradient);
+}
+
+void apply_star_surface_boundary_condition_generic(
+    const gsl::not_null<Scalar<DataVector>*> n_dot_auxilliary_velocity,
+    Scalar<DataVector> velocity_potential,
+    const tnsr::i<DataVector, 3>& velocity_potential_gradient,
+    const Scalar<DataVector>& lapse,
+    const tnsr::I<DataVector, 3>& rotational_shift,
+    const double euler_enthalpy_constant,
+    const tnsr::i<DataVector, 3>& normal) {
+  const StarSurface boundary_condition{{}};
+
+  const auto x = tnsr::I<DataVector, 3>{{DataVector{1.0, 1.0, 1.0},
+                                         DataVector{0.0, 0.0, 0.0},
+                                         DataVector{0.0, 0.0, 0.0}}};
+
+  const auto direction = Direction<3>::lower_xi();
+
+  const auto box = db::create<db::AddSimpleTags<
+      domain::Tags::Faces<3, domain::Tags::Coordinates<3, Frame::Inertial>>,
+      domain::Tags::Faces<3, domain::Tags::FaceNormal<3>>,
+      domain::Tags::Faces<3, gr::Tags::Lapse<DataVector>>,
+      domain::Tags::Faces<3, BnsInitialData::Tags::RotationalShift<DataVector>>,
+      BnsInitialData::Tags::EulerEnthalpyConstant>>(
+      DirectionMap<3, tnsr::I<DataVector, 3>>{{direction, x}},
+      DirectionMap<3, tnsr::i<DataVector, 3>>{{direction, normal}},
+      DirectionMap<3, Scalar<DataVector>>{{direction, lapse}},
+      DirectionMap<3, tnsr::I<DataVector, 3>>{{direction, rotational_shift}},
+      euler_enthalpy_constant);
+  elliptic::apply_boundary_condition<false, void, tmpl::list<StarSurface>>(
+      boundary_condition, box, Direction<3>::lower_xi(),
+      make_not_null(&velocity_potential), n_dot_auxilliary_velocity,
+      velocity_potential_gradient);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.BnsInitialData.BoundaryConditions.StarSurface",
+                  "[Unit][Elliptic]") {
+  // Test factory-creation
+  const auto created = TestHelpers::test_factory_creation<
+      elliptic::BoundaryConditions::BoundaryCondition<3>, StarSurface>(
+      "StarSurface:");
+  REQUIRE(dynamic_cast<const StarSurface*>(created.get()) != nullptr);
+  const auto& boundary_condition = dynamic_cast<const StarSurface&>(*created);
+  {
+    {
+      INFO("Semantics");
+      test_serialization(boundary_condition);
+      test_copy_semantics(boundary_condition);
+      auto move_boundary_condition = boundary_condition;
+      test_move_semantics(std::move(move_boundary_condition),
+                          boundary_condition);
+    }
+    {
+      Scalar<DataVector> n_dot_auxilliary_velocity{};
+      Scalar<DataVector> n_dot_auxilliary_velocity_for_linearized{};
+      {
+        apply_star_surface_boundary_condition_specific<true>(
+            make_not_null(&n_dot_auxilliary_velocity_for_linearized));
+        CHECK(get(n_dot_auxilliary_velocity_for_linearized) ==
+              DataVector{3, 0.0});
+      }
+      {
+        Scalar<DataVector> velocity_potential{DataVector{1.0, 2.0, 3.0}};
+        const tnsr::i<DataVector, 3> velocity_potential_gradient{
+            {DataVector{1.0, 1.0, 1.0}, DataVector{0.0, 0.0, 0.0},
+             DataVector{0.0, 0.0, 0.0}}};
+        const Scalar<DataVector> lapse{DataVector{1.0, 1.5, 1.2}};
+        const tnsr::I<DataVector, 3> rotational_shift{
+            {DataVector{1.0, 1.0, 1.0}, DataVector{0.0, 0.0, 0.0},
+             DataVector{0.0, 0.0, 0.0}}};
+        const tnsr::i<DataVector, 3> normal{{DataVector{1.0, 0.0, 0.0},
+                                             DataVector{0.0, 1.0, 0.0},
+                                             DataVector{0.0, 0.0, 1.0}}};
+        const double euler_enthalpy_constant = 1.0;
+        apply_star_surface_boundary_condition_specific<false>(
+            make_not_null(&n_dot_auxilliary_velocity));
+        CHECK(get(n_dot_auxilliary_velocity) ==
+              euler_enthalpy_constant / square(get(lapse)) *
+                  (rotational_shift.get(0) * normal.get(0) +
+                   rotational_shift.get(1) * normal.get(1) +
+                   rotational_shift.get(2) * normal.get(2)));
+      }
+    }
+    {
+      // Compare to python implementation
+      pypp::SetupLocalPythonEnvironment local_python_env(
+          "Elliptic/Systems/BnsInitialData/BoundaryConditions/");
+      pypp::check_with_random_values<6>(
+          &apply_star_surface_boundary_condition_generic, "StarSurface",
+          {"star_surface_normal_dot_flux"},
+          {{{0.0, 1.0},
+            {0.0, 1.0},
+            {.9, 1.1},
+            {-0.5, 0.5},
+            {0.0, 0.1},
+            {0.0, 1.5}}},
+          DataVector{3});
+    }
+  }
+}
+}  // namespace BnsInitialData::BoundaryConditions

--- a/tests/Unit/Elliptic/Systems/BnsInitialData/CMakeLists.txt
+++ b/tests/Unit/Elliptic/Systems/BnsInitialData/CMakeLists.txt
@@ -1,0 +1,23 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBRARY "Test_BnsInitialData")
+
+set(LIBRARY_SOURCES
+  Test_Equations.cpp
+  Test_Tags.cpp
+  )
+
+add_test_library(${LIBRARY} "${LIBRARY_SOURCES}")
+
+target_link_libraries(
+  ${LIBRARY}
+  PRIVATE
+  DataStructures
+  DataStructuresHelpers
+  EllipticTestHelpers
+  BnsInitialData
+  Utilities
+  )
+
+add_subdirectory(BoundaryConditions)

--- a/tests/Unit/Elliptic/Systems/BnsInitialData/Equations.py
+++ b/tests/Unit/Elliptic/Systems/BnsInitialData/Equations.py
@@ -1,0 +1,33 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+
+
+def potential_fluxes(
+    rotational_shift_stress, inv_spatial_metric, auxiliary_velocity
+):
+    return np.einsum(
+        "ij,j", inv_spatial_metric - rotational_shift_stress, auxiliary_velocity
+    )
+
+
+def fluxes_on_face(
+    face_normal, face_normal_vector, rotational_shift_stress, velocity_potential
+):
+    return velocity_potential * (
+        face_normal_vector
+        - np.einsum("ij,j", rotational_shift_stress, face_normal)
+    )
+
+
+def add_potential_sources(
+    log_deriv_lapse_over_specific_enthalpy,
+    christoffel_contracted,
+    flux_for_potential,
+):
+    return -np.einsum(
+        "i,i",
+        christoffel_contracted + log_deriv_lapse_over_specific_enthalpy,
+        flux_for_potential,
+    )

--- a/tests/Unit/Elliptic/Systems/BnsInitialData/Test_Equations.cpp
+++ b/tests/Unit/Elliptic/Systems/BnsInitialData/Test_Equations.cpp
@@ -1,0 +1,53 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <string>
+
+#include "DataStructures/DataVector.hpp"
+#include "Elliptic/Protocols/FirstOrderSystem.hpp"
+#include "Elliptic/Systems/BnsInitialData/Equations.hpp"
+#include "Elliptic/Systems/BnsInitialData/FirstOrderSystem.hpp"
+#include "Framework/CheckWithRandomValues.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "Helpers/Domain/CoordinateMaps/TestMapHelpers.hpp"
+#include "Helpers/Elliptic/FirstOrderSystem.hpp"
+#include "Utilities/MakeString.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
+
+namespace helpers = TestHelpers::elliptic;
+
+namespace {
+void test_equations(const DataVector& used_for_size) {
+  pypp::check_with_random_values<1>(&BnsInitialData::potential_fluxes,
+                                    "Equations", {"potential_fluxes"},
+                                    {{{0., 1.}}}, used_for_size);
+  pypp::check_with_random_values<1>(&BnsInitialData::fluxes_on_face,
+                                    "Equations", {"fluxes_on_face"},
+                                    {{{0., 1.}}}, used_for_size);
+  pypp::check_with_random_values<1>(
+      &BnsInitialData::add_potential_sources, "Equations",
+      {"add_potential_sources"}, {{{0., 1.}}}, used_for_size, 1.e-12, {}, 0.);
+}
+
+void test_computers(const DataVector& used_for_size) {
+  using system = BnsInitialData::FirstOrderSystem;
+  static_assert(
+      tt::assert_conforms_to_v<system, elliptic::protocols::FirstOrderSystem>);
+  helpers::test_first_order_fluxes_computer<system>(used_for_size);
+  helpers::test_first_order_sources_computer<system>(used_for_size);
+}
+
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Elliptic.Systems.BnsInitialData", "[Unit][Elliptic]") {
+  pypp::SetupLocalPythonEnvironment local_python_env{
+      "Elliptic/Systems/BnsInitialData"};
+
+  DataVector used_for_size{5};
+  test_equations(used_for_size);
+  test_computers(used_for_size);
+}

--- a/tests/Unit/Elliptic/Systems/BnsInitialData/Test_Tags.cpp
+++ b/tests/Unit/Elliptic/Systems/BnsInitialData/Test_Tags.cpp
@@ -1,0 +1,34 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <string>
+
+#include "Elliptic/Systems/BnsInitialData/Tags.hpp"
+#include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
+
+SPECTRE_TEST_CASE("Unit.Elliptic.Systems.BnsInitialData.Tags",
+                  "[Unit][Elliptic]") {
+  TestHelpers::db::test_simple_tag<
+      BnsInitialData::Tags::VelocityPotential<DataVector>>(
+      std::string{"VelocityPotential"});
+  TestHelpers::db::test_simple_tag<
+      BnsInitialData::Tags::RotationalShift<DataVector>>(
+      std::string{"RotationalShift"});
+  TestHelpers::db::test_simple_tag<
+      BnsInitialData::Tags::RotationalShiftStress<DataVector>>(
+      std::string{"RotationalShiftStress"});
+  TestHelpers::db::test_simple_tag<
+      BnsInitialData::Tags::DerivLogLapseTimesDensityOverSpecificEnthalpy<
+          DataVector>>(
+      std::string{"DerivLogLapseTimesDensityOverSpecificEnthalpy"});
+  TestHelpers::db::test_simple_tag<
+      BnsInitialData::Tags::SpatialRotationalKillingVector<DataVector>>(
+      std::string{"SpatialRotationalKillingVector"});
+  TestHelpers::db::test_simple_tag<
+      BnsInitialData::Tags::DerivSpatialRotationalKillingVector<DataVector>>(
+      std::string{"DerivSpatialRotationalKillingVector"});
+  TestHelpers::db::test_simple_tag<BnsInitialData::Tags::EulerEnthalpyConstant>(
+      std::string{"EulerEnthalpyConstant"});
+}

--- a/tests/Unit/Elliptic/Systems/CMakeLists.txt
+++ b/tests/Unit/Elliptic/Systems/CMakeLists.txt
@@ -16,6 +16,8 @@ target_link_libraries(
   )
 
 add_subdirectory(Elasticity)
+add_subdirectory(BnsInitialData)
 add_subdirectory(Poisson)
 add_subdirectory(Punctures)
 add_subdirectory(Xcts)
+


### PR DESCRIPTION
## Proposed changes

This PR adds the system for generating BNS Irrotational Initial data.  To do this, an elliptic system is introduced to solve for the velocity potential using the framework of Baumgarte + Shapiro Ch. 15.  The background consists of a matter profile which is not yet implemented (as it is contained in the initial data).
### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
