### PR TITLE
AMR: do not enforce 2:1 balance in normal direction

### DIFF
--- a/src/Domain/Amr/UpdateAmrDecision.hpp
+++ b/src/Domain/Amr/UpdateAmrDecision.hpp
@@ -34,6 +34,8 @@ namespace amr {
 /// following changes are made to the current flags of the element:
 /// - If the neighbor wants to be two or more refinement levels higher than
 ///   the element, the flag is updated to bring the element to within one level
+///   (unless this occurs in the direction to the neighbor and
+///   `enforce_two_to_one_balance_in_normal_direction` is set to false).
 /// - If the element wants to join, and the neighbor is a potential sibling but
 ///   wants to be at a different refinement level in any dimension, the flag is
 ///   updated to not do h-refinement.
@@ -49,5 +51,6 @@ template <size_t VolumeDim>
 bool update_amr_decision(
     gsl::not_null<std::array<Flag, VolumeDim>*> my_current_amr_flags,
     const Element<VolumeDim>& element, const ElementId<VolumeDim>& neighbor_id,
-    const std::array<Flag, VolumeDim>& neighbor_amr_flags);
+    const std::array<Flag, VolumeDim>& neighbor_amr_flags,
+    bool enforce_two_to_one_balance_in_normal_direction);
 }  // namespace amr

--- a/src/ParallelAlgorithms/Amr/Actions/EvaluateRefinementCriteria.hpp
+++ b/src/ParallelAlgorithms/Amr/Actions/EvaluateRefinementCriteria.hpp
@@ -25,6 +25,7 @@
 #include "ParallelAlgorithms/Amr/Criteria/Criterion.hpp"
 #include "ParallelAlgorithms/Amr/Criteria/Tags/Criteria.hpp"
 #include "ParallelAlgorithms/Amr/Policies/EnforcePolicies.hpp"
+#include "ParallelAlgorithms/Amr/Policies/Policies.hpp"
 #include "ParallelAlgorithms/Amr/Policies/Tags.hpp"
 #include "ParallelAlgorithms/Amr/Projectors/Mesh.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"
@@ -103,8 +104,9 @@ struct EvaluateRefinementCriteria {
       }
     }
 
-    amr::enforce_policies(make_not_null(&overall_decision),
-                          db::get<amr::Tags::Policies>(box), element_id,
+    const auto& policies = db::get<amr::Tags::Policies>(box);
+    amr::enforce_policies(make_not_null(&overall_decision), policies,
+                          element_id,
                           get<::domain::Tags::Mesh<volume_dim>>(box));
 
     // An element cannot join if it is splitting in another dimension.
@@ -123,8 +125,10 @@ struct EvaluateRefinementCriteria {
     if (not my_neighbors_amr_info.empty()) {
       for (const auto& [neighbor_id, neighbor_amr_info] :
            my_neighbors_amr_info) {
-        amr::update_amr_decision(make_not_null(&overall_decision), my_element,
-                                 neighbor_id, neighbor_amr_info.flags);
+        amr::update_amr_decision(
+            make_not_null(&overall_decision), my_element, neighbor_id,
+            neighbor_amr_info.flags,
+            policies.enforce_two_to_one_balance_in_normal_direction());
       }
     }
 

--- a/src/ParallelAlgorithms/Amr/Actions/UpdateAmrDecision.hpp
+++ b/src/ParallelAlgorithms/Amr/Actions/UpdateAmrDecision.hpp
@@ -19,6 +19,8 @@
 #include "Domain/Tags.hpp"
 #include "Parallel/GlobalCache.hpp"
 #include "Parallel/Invoke.hpp"
+#include "ParallelAlgorithms/Amr/Policies/Policies.hpp"
+#include "ParallelAlgorithms/Amr/Policies/Tags.hpp"
 #include "ParallelAlgorithms/Amr/Projectors/Mesh.hpp"
 #include "Utilities/Algorithm.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"
@@ -93,9 +95,11 @@ struct UpdateAmrDecision {
     const auto& element = get<::domain::Tags::Element<volume_dim>>(box);
     const auto my_initial_new_mesh = my_amr_info.new_mesh;
 
-    const bool my_amr_decision_changed =
-        amr::update_amr_decision(make_not_null(&my_amr_flags), element,
-                                 neighbor_id, neighbor_amr_info.flags);
+    const bool my_amr_decision_changed = amr::update_amr_decision(
+        make_not_null(&my_amr_flags), element, neighbor_id,
+        neighbor_amr_info.flags,
+        get<amr::Tags::Policies>(box)
+            .enforce_two_to_one_balance_in_normal_direction());
 
     auto& my_new_mesh = my_amr_info.new_mesh;
     my_new_mesh =

--- a/src/ParallelAlgorithms/Amr/Policies/Policies.cpp
+++ b/src/ParallelAlgorithms/Amr/Policies/Policies.cpp
@@ -6,16 +6,23 @@
 #include <pup.h>
 
 namespace amr {
-Policies::Policies(const amr::Isotropy isotropy, const amr::Limits& limits)
-    : isotropy_(isotropy), limits_(limits) {}
+Policies::Policies(const amr::Isotropy isotropy, const amr::Limits& limits,
+                   const bool enforce_two_to_one_balance_in_normal_direction)
+    : isotropy_(isotropy),
+      limits_(limits),
+      enforce_two_to_one_balance_in_normal_direction_(
+          enforce_two_to_one_balance_in_normal_direction) {}
 
 void Policies::pup(PUP::er& p) {
   p | isotropy_;
   p | limits_;
+  p | enforce_two_to_one_balance_in_normal_direction_;
 }
 
 bool operator==(const Policies& lhs, const Policies& rhs) {
-  return lhs.isotropy() == rhs.isotropy() and lhs.limits() == rhs.limits();
+  return lhs.isotropy() == rhs.isotropy() and lhs.limits() == rhs.limits() and
+         lhs.enforce_two_to_one_balance_in_normal_direction() ==
+             rhs.enforce_two_to_one_balance_in_normal_direction();
 }
 
 bool operator!=(const Policies& lhs, const Policies& rhs) {

--- a/src/ParallelAlgorithms/Amr/Policies/Policies.hpp
+++ b/src/ParallelAlgorithms/Amr/Policies/Policies.hpp
@@ -34,24 +34,40 @@ class Policies {
         "refinement."};
   };
 
-  using options = tmpl::list<Isotropy, Limits>;
+  /// Whether or not to enforce 2:1 balance in the direction normal to element
+  /// faces
+  struct EnforceTwoToOneBalanceInNormalDirection {
+    using type = bool;
+    static constexpr Options::String help = {
+        "Whether or not to enforce 2:1 balance in the direction normal to "
+        "element faces."};
+  };
+
+  using options =
+      tmpl::list<Isotropy, Limits, EnforceTwoToOneBalanceInNormalDirection>;
 
   static constexpr Options::String help = {
       "Policies controlling adaptive mesh refinement."};
 
   Policies() = default;
 
-  Policies(amr::Isotropy isotropy, const amr::Limits& limits);
+  Policies(amr::Isotropy isotropy, const amr::Limits& limits,
+           bool enforce_two_to_one_balance_in_normal_direction);
 
   amr::Isotropy isotropy() const { return isotropy_; }
 
   amr::Limits limits() const { return limits_; }
+
+  bool enforce_two_to_one_balance_in_normal_direction() const {
+    return enforce_two_to_one_balance_in_normal_direction_;
+  }
 
   void pup(PUP::er& p);
 
  private:
   amr::Isotropy isotropy_{amr::Isotropy::Anisotropic};
   amr::Limits limits_{};
+  bool enforce_two_to_one_balance_in_normal_direction_{true};
 };
 
 bool operator==(const Policies& lhs, const Policies& rhs);

--- a/support/Pipelines/Bbh/InitialData.yaml
+++ b/support/Pipelines/Bbh/InitialData.yaml
@@ -133,6 +133,7 @@ Amr:
   Verbosity: Verbose
   Criteria: []
   Policies:
+    EnforceTwoToOneBalanceInNormalDirection: true
     Isotropy: Anisotropic
     Limits:
       NumGridPoints: Auto

--- a/support/Pipelines/Bbh/Inspiral.yaml
+++ b/support/Pipelines/Bbh/Inspiral.yaml
@@ -214,6 +214,7 @@ Cce:
 Amr:
   Criteria:
   Policies:
+    EnforceTwoToOneBalanceInNormalDirection: true
     Isotropy: Anisotropic
     Limits:
       RefinementLevel: Auto

--- a/support/Pipelines/Bbh/Ringdown.yaml
+++ b/support/Pipelines/Bbh/Ringdown.yaml
@@ -101,6 +101,7 @@ Observers:
 Amr:
   Criteria:
   Policies:
+    EnforceTwoToOneBalanceInNormalDirection: true
     Isotropy: Anisotropic
     Limits:
       RefinementLevel: Auto

--- a/tests/InputFiles/Elasticity/BentBeam.yaml
+++ b/tests/InputFiles/Elasticity/BentBeam.yaml
@@ -109,6 +109,7 @@ Amr:
   Verbosity: Quiet
   Criteria: []
   Policies:
+    EnforceTwoToOneBalanceInNormalDirection: true
     Isotropy: Anisotropic
     Limits:
       NumGridPoints: Auto

--- a/tests/InputFiles/Elasticity/HalfSpaceMirror.yaml
+++ b/tests/InputFiles/Elasticity/HalfSpaceMirror.yaml
@@ -147,6 +147,7 @@ Amr:
   Verbosity: Quiet
   Criteria: []
   Policies:
+    EnforceTwoToOneBalanceInNormalDirection: true
     Isotropy: Anisotropic
     Limits:
       NumGridPoints: Auto

--- a/tests/InputFiles/Elasticity/SingleCoatingMirror.yaml
+++ b/tests/InputFiles/Elasticity/SingleCoatingMirror.yaml
@@ -164,6 +164,7 @@ Amr:
   Verbosity: Quiet
   Criteria: []
   Policies:
+    EnforceTwoToOneBalanceInNormalDirection: true
     Isotropy: Anisotropic
     Limits:
       NumGridPoints: Auto

--- a/tests/InputFiles/ExampleExecutables/RandomAmr1D.yaml
+++ b/tests/InputFiles/ExampleExecutables/RandomAmr1D.yaml
@@ -23,6 +23,7 @@ Amr:
           Join: 1
           DoNothing: 1
   Policies:
+    EnforceTwoToOneBalanceInNormalDirection: true
     Isotropy: Anisotropic
     Limits:
       RefinementLevel: [0, 8]

--- a/tests/InputFiles/ExportCoordinates/Input1D.yaml
+++ b/tests/InputFiles/ExportCoordinates/Input1D.yaml
@@ -22,6 +22,7 @@ Amr:
           Join: 1
           DoNothing: 1
   Policies:
+    EnforceTwoToOneBalanceInNormalDirection: true
     Isotropy: Anisotropic
     Limits:
       RefinementLevel: [0, 4]

--- a/tests/InputFiles/ExportCoordinates/Input2D.yaml
+++ b/tests/InputFiles/ExportCoordinates/Input2D.yaml
@@ -17,6 +17,7 @@ Parallelization:
 Amr:
   Criteria:
   Policies:
+    EnforceTwoToOneBalanceInNormalDirection: true
     Isotropy: Anisotropic
     Limits:
       RefinementLevel: Auto

--- a/tests/InputFiles/ExportCoordinates/Input3D.yaml
+++ b/tests/InputFiles/ExportCoordinates/Input3D.yaml
@@ -17,6 +17,7 @@ Parallelization:
 Amr:
   Criteria:
   Policies:
+    EnforceTwoToOneBalanceInNormalDirection: true
     Isotropy: Anisotropic
     Limits:
       RefinementLevel: Auto

--- a/tests/InputFiles/ExportCoordinates/InputTimeDependent3D.yaml
+++ b/tests/InputFiles/ExportCoordinates/InputTimeDependent3D.yaml
@@ -18,6 +18,7 @@ Parallelization:
 Amr:
   Criteria:
   Policies:
+    EnforceTwoToOneBalanceInNormalDirection: true
     Isotropy: Anisotropic
     Limits:
       RefinementLevel: Auto

--- a/tests/InputFiles/GeneralizedHarmonic/CylindricalBinaryBlackHole.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/CylindricalBinaryBlackHole.yaml
@@ -131,6 +131,7 @@ EvolutionSystem:
 Amr:
   Criteria:
   Policies:
+    EnforceTwoToOneBalanceInNormalDirection: true
     Isotropy: Anisotropic
     Limits:
       RefinementLevel: Auto

--- a/tests/InputFiles/GeneralizedHarmonic/GaugeWave1D.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/GaugeWave1D.yaml
@@ -28,6 +28,7 @@ Evolution:
 Amr:
   Criteria:
   Policies:
+    EnforceTwoToOneBalanceInNormalDirection: true
     Isotropy: Anisotropic
     Limits:
       RefinementLevel: Auto

--- a/tests/InputFiles/GeneralizedHarmonic/GaugeWave3D.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/GaugeWave3D.yaml
@@ -29,6 +29,7 @@ Evolution:
 Amr:
   Criteria:
   Policies:
+    EnforceTwoToOneBalanceInNormalDirection: true
     Isotropy: Anisotropic
     Limits:
       RefinementLevel: Auto

--- a/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
@@ -35,6 +35,7 @@ Evolution:
 Amr:
   Criteria:
   Policies:
+    EnforceTwoToOneBalanceInNormalDirection: true
     Isotropy: Anisotropic
     Limits:
       RefinementLevel: Auto

--- a/tests/InputFiles/Poisson/Lorentzian.yaml
+++ b/tests/InputFiles/Poisson/Lorentzian.yaml
@@ -54,6 +54,7 @@ Amr:
   Criteria:
     - IncreaseResolution
   Policies:
+    EnforceTwoToOneBalanceInNormalDirection: true
     Isotropy: Anisotropic
     Limits:
       NumGridPoints: Auto

--- a/tests/InputFiles/Poisson/ProductOfSinusoids1D.yaml
+++ b/tests/InputFiles/Poisson/ProductOfSinusoids1D.yaml
@@ -92,6 +92,7 @@ Amr:
         TargetNumberOfGridPoints: [5]
         OscillationAtTarget: [DoNothing]
   Policies:
+    EnforceTwoToOneBalanceInNormalDirection: true
     Isotropy: Anisotropic
     Limits:
       NumGridPoints: Auto

--- a/tests/InputFiles/Poisson/ProductOfSinusoids2D.yaml
+++ b/tests/InputFiles/Poisson/ProductOfSinusoids2D.yaml
@@ -112,6 +112,7 @@ Amr:
   Verbosity: Quiet
   Criteria: []
   Policies:
+    EnforceTwoToOneBalanceInNormalDirection: true
     Isotropy: Anisotropic
     Limits:
       NumGridPoints: Auto

--- a/tests/InputFiles/Poisson/ProductOfSinusoids3D.yaml
+++ b/tests/InputFiles/Poisson/ProductOfSinusoids3D.yaml
@@ -121,6 +121,7 @@ Amr:
   Verbosity: Quiet
   Criteria: []
   Policies:
+    EnforceTwoToOneBalanceInNormalDirection: true
     Isotropy: Anisotropic
     Limits:
       NumGridPoints: Auto

--- a/tests/InputFiles/Punctures/MultiplePunctures.yaml
+++ b/tests/InputFiles/Punctures/MultiplePunctures.yaml
@@ -78,6 +78,7 @@ Amr:
     - RefineAtPunctures
     - IncreaseResolution
   Policies:
+    EnforceTwoToOneBalanceInNormalDirection: true
     Isotropy: Anisotropic
     Limits:
       NumGridPoints: Auto

--- a/tests/InputFiles/ScalarWave/PlaneWave1D.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave1D.yaml
@@ -32,6 +32,7 @@ Amr:
         AbsoluteTarget: 1.e-6
         RelativeTarget: 1.0
   Policies:
+    EnforceTwoToOneBalanceInNormalDirection: true
     Isotropy: Anisotropic
     Limits:
       RefinementLevel: Auto

--- a/tests/InputFiles/ScalarWave/PlaneWave1DEventsAndTriggersExample.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave1DEventsAndTriggersExample.yaml
@@ -34,6 +34,7 @@ Amr:
         AbsoluteTarget: 1.e-6
         RelativeTarget: 1.0
   Policies:
+    EnforceTwoToOneBalanceInNormalDirection: true
     Isotropy: Anisotropic
     Limits:
       RefinementLevel: Auto

--- a/tests/InputFiles/ScalarWave/PlaneWave1DObserveExample.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave1DObserveExample.yaml
@@ -35,6 +35,7 @@ Amr:
         AbsoluteTarget: 1.e-6
         RelativeTarget: 1.0
   Policies:
+    EnforceTwoToOneBalanceInNormalDirection: true
     Isotropy: Anisotropic
     Limits:
       RefinementLevel: Auto

--- a/tests/InputFiles/ScalarWave/PlaneWave2D.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave2D.yaml
@@ -29,6 +29,7 @@ InitialData:
 Amr:
   Criteria:
   Policies:
+    EnforceTwoToOneBalanceInNormalDirection: true
     Isotropy: Anisotropic
     Limits:
       RefinementLevel: Auto

--- a/tests/InputFiles/ScalarWave/PlaneWave3D.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave3D.yaml
@@ -27,6 +27,7 @@ InitialData:
 Amr:
   Criteria:
   Policies:
+    EnforceTwoToOneBalanceInNormalDirection: true
     Isotropy: Anisotropic
     Limits:
       RefinementLevel: Auto

--- a/tests/InputFiles/Xcts/BinaryBlackHole.yaml
+++ b/tests/InputFiles/Xcts/BinaryBlackHole.yaml
@@ -155,6 +155,7 @@ Amr:
   Verbosity: Verbose
   Criteria: []
   Policies:
+    EnforceTwoToOneBalanceInNormalDirection: true
     Isotropy: Anisotropic
     Limits:
       NumGridPoints: Auto

--- a/tests/InputFiles/Xcts/HeadOnBns.yaml
+++ b/tests/InputFiles/Xcts/HeadOnBns.yaml
@@ -224,6 +224,7 @@ Amr:
   Verbosity: Quiet
   Criteria: []
   Policies:
+    EnforceTwoToOneBalanceInNormalDirection: true
     Isotropy: Anisotropic
     Limits:
       NumGridPoints: Auto

--- a/tests/InputFiles/Xcts/KerrSchild.yaml
+++ b/tests/InputFiles/Xcts/KerrSchild.yaml
@@ -117,6 +117,7 @@ Amr:
   Criteria:
     - IncreaseResolution
   Policies:
+    EnforceTwoToOneBalanceInNormalDirection: true
     Isotropy: Anisotropic
     Limits:
       NumGridPoints: Auto

--- a/tests/InputFiles/Xcts/TovStar.yaml
+++ b/tests/InputFiles/Xcts/TovStar.yaml
@@ -162,6 +162,7 @@ Amr:
   Verbosity: Quiet
   Criteria: []
   Policies:
+    EnforceTwoToOneBalanceInNormalDirection: true
     Isotropy: Anisotropic
     Limits:
       NumGridPoints: Auto

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/SubdomainOperator/Test_SubdomainOperator.cpp
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/SubdomainOperator/Test_SubdomainOperator.cpp
@@ -596,7 +596,7 @@ void test_subdomain_operator(
         std::make_unique<RandomBackground<Dim>>(), overlap,
         ::Verbosity::Verbose, penalty_parameter, use_massive_dg_operator,
         quadrature, ::dg::Formulation::StrongInertial, std::move(amr_criteria),
-        ::amr::Policies{::amr::Isotropy::Anisotropic, ::amr::Limits{}},
+        ::amr::Policies{::amr::Isotropy::Anisotropic, ::amr::Limits{}, true},
         ::Verbosity::Debug}};
 
     // Initialize all elements, generating random subdomain data

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_DgOperator.cpp
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_DgOperator.cpp
@@ -333,7 +333,7 @@ void test_dg_operator(
       std::move(boundary_conditions), penalty_parameter,
       use_massive_dg_operator, quadrature, ::dg::Formulation::StrongInertial,
       analytic_solution, std::move(amr_criteria),
-      ::amr::Policies{::amr::Isotropy::Anisotropic, ::amr::Limits{}},
+      ::amr::Policies{::amr::Isotropy::Anisotropic, ::amr::Limits{}, true},
       ::Verbosity::Debug}};
 
   // DataBox shortcuts

--- a/tests/Unit/ParallelAlgorithms/Amr/Actions/Test_EvaluateRefinementCriteria.cpp
+++ b/tests/Unit/ParallelAlgorithms/Amr/Actions/Test_EvaluateRefinementCriteria.cpp
@@ -120,7 +120,7 @@ void evaluate_criteria(std::vector<std::unique_ptr<amr::Criterion>> criteria,
 
   ActionTesting::MockRuntimeSystem<Metavariables<1>> runner{
       {std::move(criteria),
-       amr::Policies{amr::Isotropy::Anisotropic, amr::Limits{}}}};
+       amr::Policies{amr::Isotropy::Anisotropic, amr::Limits{}, true}}};
 
   const Element<1> self(self_id, {{{Direction<1>::lower_xi(), {{lo_id}, {}}},
                                    {Direction<1>::upper_xi(), {{up_id}, {}}}}});
@@ -259,7 +259,7 @@ void check_split_while_join_is_avoided() {
   // action should change the flags to (DoNothing, Split)
   ActionTesting::MockRuntimeSystem<Metavariables<2>> runner{
       {std::move(criteria),
-       amr::Policies{amr::Isotropy::Anisotropic, amr::Limits{}}}};
+       amr::Policies{amr::Isotropy::Anisotropic, amr::Limits{}, true}}};
 
   const Element<2> self(self_id, {});
   ActionTesting::emplace_component_and_initialize<my_component>(

--- a/tests/Unit/ParallelAlgorithms/Amr/Actions/Test_UpdateAmrDecision.cpp
+++ b/tests/Unit/ParallelAlgorithms/Amr/Actions/Test_UpdateAmrDecision.cpp
@@ -24,6 +24,10 @@
 #include "Parallel/Phase.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
 #include "ParallelAlgorithms/Amr/Actions/UpdateAmrDecision.hpp"
+#include "ParallelAlgorithms/Amr/Policies/Isotropy.hpp"
+#include "ParallelAlgorithms/Amr/Policies/Limits.hpp"
+#include "ParallelAlgorithms/Amr/Policies/Policies.hpp"
+#include "ParallelAlgorithms/Amr/Policies/Tags.hpp"
 #include "Utilities/StdHelpers.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
@@ -36,7 +40,7 @@ struct Component {
   static constexpr size_t volume_dim = Metavariables::volume_dim;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = ElementId<volume_dim>;
-  using const_global_cache_tags = tmpl::list<>;
+  using const_global_cache_tags = tmpl::list<amr::Tags::Policies>;
   using simple_tags =
       tmpl::list<domain::Tags::Mesh<volume_dim>,
                  domain::Tags::Element<volume_dim>, amr::Tags::Info<volume_dim>,
@@ -89,7 +93,8 @@ void test() {
 
   std::unordered_map<ElementId<1>, amr::Info<1>> initial_neighbor_info{};
 
-  ActionTesting::MockRuntimeSystem<Metavariables> runner{{}};
+  ActionTesting::MockRuntimeSystem<Metavariables> runner{
+      {amr::Policies{amr::Isotropy::Anisotropic, amr::Limits{}, true}}};
 
   const Element<1> self(self_id,
                         {{{Direction<1>::lower_xi(), {{sibling_id}, {}}},

--- a/tests/Unit/ParallelAlgorithms/Amr/Policies/Test_EnforcePolicies.cpp
+++ b/tests/Unit/ParallelAlgorithms/Amr/Policies/Test_EnforcePolicies.cpp
@@ -37,8 +37,8 @@ void test_1d() {
   const auto join = std::array{amr::Flag::Join};
   const auto all_flags = std::vector{split, increase, stay, decrease, join};
 
-  amr::Policies isotropic{amr::Isotropy::Isotropic, amr::Limits{}};
-  amr::Policies anisotropic{amr::Isotropy::Anisotropic, amr::Limits{}};
+  amr::Policies isotropic{amr::Isotropy::Isotropic, amr::Limits{}, true};
+  amr::Policies anisotropic{amr::Isotropy::Anisotropic, amr::Limits{}, true};
   const auto policies = std::array{anisotropic, isotropic};
   const ElementId<1> element_id{0, {{{1, 0}}}};
   const Mesh<1> mesh{3, Spectral::Basis::Legendre, Spectral::Quadrature::Gauss};
@@ -48,7 +48,8 @@ void test_1d() {
     }
   }
 
-  amr::Policies policy{amr::Isotropy::Anisotropic, amr::Limits{0, 5, 1, 12}};
+  amr::Policies policy{amr::Isotropy::Anisotropic, amr::Limits{0, 5, 1, 12},
+                       true};
   test_decision(join, policy, ElementId<1>{0}, mesh, stay);
   test_decision(split, policy, ElementId<1>{0, {{{5, 2}}}}, mesh, stay);
   test_decision(
@@ -116,8 +117,8 @@ void test_2d() {
       split_join,        increase_join,  stay_join,         decrease_join,
       join_join};
 
-  amr::Policies isotropic{amr::Isotropy::Isotropic, amr::Limits{}};
-  amr::Policies anisotropic{amr::Isotropy::Anisotropic, amr::Limits{}};
+  amr::Policies isotropic{amr::Isotropy::Isotropic, amr::Limits{}, true};
+  amr::Policies anisotropic{amr::Isotropy::Anisotropic, amr::Limits{}, true};
 
   const ElementId<2> element_id{0, {{{1, 0}, {1, 0}}}};
   const Mesh<2> mesh{3, Spectral::Basis::Legendre, Spectral::Quadrature::Gauss};
@@ -152,8 +153,8 @@ void test_3d() {
       std::array{amr::Flag::DoNothing, amr::Flag::Split, amr::Flag::Split};
   const auto split_split_split =
       std::array{amr::Flag::Split, amr::Flag::Split, amr::Flag::Split};
-  amr::Policies isotropic{amr::Isotropy::Isotropic, amr::Limits{}};
-  amr::Policies anisotropic{amr::Isotropy::Anisotropic, amr::Limits{}};
+  amr::Policies isotropic{amr::Isotropy::Isotropic, amr::Limits{}, true};
+  amr::Policies anisotropic{amr::Isotropy::Anisotropic, amr::Limits{}, true};
   const ElementId<3> element_id{0, {{{1, 0}, {1, 0}, {1, 0}}}};
   const Mesh<3> mesh{3, Spectral::Basis::Legendre, Spectral::Quadrature::Gauss};
   test_decision(stay_split_split, anisotropic, element_id, mesh,


### PR DESCRIPTION
## Proposed changes

Remove requirement that h-refinement must have 2:1 balance in the direction normal to faces.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
In input files that use AMR, you will need to add `EnforceTwoToOneBalanceInNormalDirection: true` to the list of Policies
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
