### PR TITLE
Simplify MortarData

### DIFF
--- a/src/Evolution/Deadlock/PrintDgElementArray.hpp
+++ b/src/Evolution/Deadlock/PrintDgElementArray.hpp
@@ -111,15 +111,6 @@ struct PrintElementInfo {
           ss << "   Key: " << key << ", history:\n";
           history.template print<false>(ss, 4_st);
         }
-      } else {
-        const auto& mortar_data =
-            db::get<evolution::dg::Tags::MortarData<3>>(box);
-        ss << "  MortarData:\n";
-
-        for (const auto& [key, single_mortar_data] : mortar_data) {
-          ss << "   Key: " << key << ", mortar data:\n";
-          ss << single_mortar_data.pretty_print_current_buffer_no_data(4_st);
-        }
       }
     } else {
       ss << "\n";

--- a/src/Evolution/DgSubcell/Actions/ReconstructionCommunication.hpp
+++ b/src/Evolution/DgSubcell/Actions/ReconstructionCommunication.hpp
@@ -378,11 +378,11 @@ struct ReceiveDataForReconstruction {
             }
             if (received_mortar_data.second.boundary_correction_data
                     .has_value()) {
-              mortar_data->at(mortar_id).insert_neighbor_mortar_data(
-                  current_time_step_id,
+              mortar_data->at(mortar_id).time_step_id() = current_time_step_id;
+              mortar_data->at(mortar_id).neighbor_mortar_data() = std::pair{
                   received_mortar_data.second.interface_mesh,
                   std::move(
-                      *received_mortar_data.second.boundary_correction_data));
+                      *received_mortar_data.second.boundary_correction_data)};
             }
             // Set new neighbor mesh
             neighbor_mesh->insert_or_assign(

--- a/src/Evolution/DgSubcell/Actions/ReconstructionCommunication.hpp
+++ b/src/Evolution/DgSubcell/Actions/ReconstructionCommunication.hpp
@@ -342,7 +342,7 @@ struct ReceiveDataForReconstruction {
                evolution::dg::Tags::MortarNextTemporalId<Dim>,
                domain::Tags::NeighborMesh<Dim>,
                evolution::dg::subcell::Tags::NeighborTciDecisions<Dim>>(
-        [&current_time_step_id, &element,
+        [&element,
          ghost_zone_size =
              db::get<evolution::dg::subcell::Tags::Reconstructor>(box)
                  .ghost_zone_size(),
@@ -378,7 +378,6 @@ struct ReceiveDataForReconstruction {
             }
             if (received_mortar_data.second.boundary_correction_data
                     .has_value()) {
-              mortar_data->at(mortar_id).time_step_id() = current_time_step_id;
               mortar_data->at(mortar_id).neighbor_mortar_data() = std::pair{
                   received_mortar_data.second.interface_mesh,
                   std::move(

--- a/src/Evolution/DiscontinuousGalerkin/Actions/ApplyBoundaryCorrections.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Actions/ApplyBoundaryCorrections.hpp
@@ -320,13 +320,6 @@ bool receive_boundary_data_global_time_stepping(
         for (auto& received_mortar_data :
              received_temporal_id_and_data.second) {
           const auto& mortar_id = received_mortar_data.first;
-          ASSERT(received_temporal_id_and_data.first ==
-                     mortar_data->at(mortar_id).time_step_id(),
-                 "Expected to receive mortar data on mortar "
-                     << mortar_id << " at time "
-                     << mortar_next_time_step_id->at(mortar_id)
-                     << " but actually received at time "
-                     << received_temporal_id_and_data.first);
           neighbor_mesh->insert_or_assign(
               mortar_id,
               received_mortar_data.second.volume_mesh_ghost_cell_data);
@@ -342,8 +335,6 @@ bool receive_boundary_data_global_time_stepping(
                      << received_temporal_id_and_data.first);
           if (received_mortar_data.second.boundary_correction_data
                   .has_value()) {
-            mortar_data->at(mortar_id).time_step_id() =
-                received_temporal_id_and_data.first;
             mortar_data->at(mortar_id).neighbor_mortar_data() =
                 std::pair{received_mortar_data.second.interface_mesh,
                           std::move(received_mortar_data.second
@@ -470,7 +461,6 @@ bool receive_boundary_data_local_time_stepping(
             neighbor_mesh->insert_or_assign(
                 mortar_id,
                 received_mortar_data->second.volume_mesh_ghost_cell_data);
-            neighbor_mortar_data.time_step_id() = mortar_next_time_step_id;
             neighbor_mortar_data.neighbor_mortar_data() =
                 std::pair{received_mortar_data->second.interface_mesh,
                           std::move(received_mortar_data->second

--- a/src/Evolution/DiscontinuousGalerkin/Actions/ApplyBoundaryCorrections.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Actions/ApplyBoundaryCorrections.hpp
@@ -958,10 +958,6 @@ struct ApplyBoundaryCorrections {
                                       : volume_dt_correction;
               lifted_data = compute_correction_coupling(
                   mortar_id_and_data.second, mortar_id_and_data.second);
-              // Remove data since it's tagged with the time. In the future we
-              // _might_ be able to reuse allocations, but this optimization
-              // should only be done after profiling.
-              mortar_id_and_data.second.extract();
 
               if (using_gauss_lobatto_points) {
                 // Add the flux contribution to the volume data

--- a/src/Evolution/DiscontinuousGalerkin/Actions/ApplyBoundaryCorrections.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Actions/ApplyBoundaryCorrections.hpp
@@ -342,11 +342,12 @@ bool receive_boundary_data_global_time_stepping(
                      << received_temporal_id_and_data.first);
           if (received_mortar_data.second.boundary_correction_data
                   .has_value()) {
-            mortar_data->at(mortar_id).insert_neighbor_mortar_data(
-                received_temporal_id_and_data.first,
-                received_mortar_data.second.interface_mesh,
-                std::move(received_mortar_data.second.boundary_correction_data
-                              .value()));
+            mortar_data->at(mortar_id).time_step_id() =
+                received_temporal_id_and_data.first;
+            mortar_data->at(mortar_id).neighbor_mortar_data() =
+                std::pair{received_mortar_data.second.interface_mesh,
+                          std::move(received_mortar_data.second
+                                        .boundary_correction_data.value())};
           }
         }
       },
@@ -469,11 +470,11 @@ bool receive_boundary_data_local_time_stepping(
             neighbor_mesh->insert_or_assign(
                 mortar_id,
                 received_mortar_data->second.volume_mesh_ghost_cell_data);
-            neighbor_mortar_data.insert_neighbor_mortar_data(
-                mortar_next_time_step_id,
-                received_mortar_data->second.interface_mesh,
-                std::move(received_mortar_data->second.boundary_correction_data
-                              .value()));
+            neighbor_mortar_data.time_step_id() = mortar_next_time_step_id;
+            neighbor_mortar_data.neighbor_mortar_data() =
+                std::pair{received_mortar_data->second.interface_mesh,
+                          std::move(received_mortar_data->second
+                                        .boundary_correction_data.value())};
             // We don't yet communicate the integration order, because
             // we don't have any variable-order methods.  The
             // fixed-order methods ignore the field.

--- a/src/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivative.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivative.hpp
@@ -691,12 +691,6 @@ void ComputeTimeDerivative<Dim, EvolutionSystem, DgStepChoosers,
       const DirectionalId<Dim> mortar_id{direction, neighbor};
 
       std::pair<Mesh<Dim - 1>, DataVector> neighbor_boundary_data_on_mortar{};
-      ASSERT(time_step_id == all_mortar_data.at(mortar_id).time_step_id(),
-             "The current time step id of the volume is "
-                 << time_step_id
-                 << "but the time step id on the mortar with mortar id "
-                 << mortar_id << " is "
-                 << all_mortar_data.at(mortar_id).time_step_id());
 
       if (LIKELY(orientation.is_aligned())) {
         neighbor_boundary_data_on_mortar =

--- a/src/Evolution/DiscontinuousGalerkin/Initialization/Mortars.cpp
+++ b/src/Evolution/DiscontinuousGalerkin/Initialization/Mortars.cpp
@@ -51,7 +51,7 @@ mortars_apply_impl(const std::vector<std::array<size_t, Dim>>& initial_extents,
     normal_covector_quantities[direction] = std::nullopt;
     for (const auto& neighbor : neighbors) {
       const DirectionalId<Dim> mortar_id{direction, neighbor};
-      mortar_data.emplace(mortar_id, MortarData<Dim>{1});
+      mortar_data.emplace(mortar_id, MortarData<Dim>{});
       mortar_meshes.emplace(
           mortar_id,
           ::dg::mortar_mesh(volume_mesh.slice_away(direction.dimension()),

--- a/src/Evolution/DiscontinuousGalerkin/Initialization/Mortars.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Initialization/Mortars.hpp
@@ -214,7 +214,7 @@ struct ProjectMortars : tt::ConformsTo<amr::protocols::Projector> {
       (*normal_covector_and_magnitude)[direction] = std::nullopt;
       for (const auto& neighbor : neighbors) {
         const DirectionalId<dim> mortar_id{direction, neighbor};
-        mortar_data->emplace(mortar_id, MortarData<dim>{1});
+        mortar_data->emplace(mortar_id, MortarData<dim>{});
         const auto new_neighbor_mesh = neighbors.orientation().inverse_map()(
             neighbor_info.at(neighbor).new_mesh);
         mortar_mesh->emplace(

--- a/src/Evolution/DiscontinuousGalerkin/MortarData.cpp
+++ b/src/Evolution/DiscontinuousGalerkin/MortarData.cpp
@@ -15,7 +15,6 @@
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
-#include "Time/TimeStepId.hpp"
 #include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Serialization/PupStlCpp17.hpp"
@@ -166,7 +165,6 @@ void MortarData<Dim>::get_local_face_normal_magnitude(
 
 template <size_t Dim>
 void MortarData<Dim>::pup(PUP::er& p) {
-  p | time_step_id_;
   p | local_mortar_data_;
   p | neighbor_mortar_data_;
   p | local_geometric_quantities_;
@@ -175,20 +173,8 @@ void MortarData<Dim>::pup(PUP::er& p) {
 }
 
 template <size_t Dim>
-std::string MortarData<Dim>::pretty_print_current_buffer_no_data(
-    size_t padding_size) const {
-  std::stringstream ss{};
-  ss << std::scientific << std::setprecision(16);
-  const std::string pad(padding_size, ' ');
-  ss << pad << "Current buffer: " << 0_st << ", time = " << time_step_id_
-     << "\n";
-  return ss.str();
-}
-
-template <size_t Dim>
 bool operator==(const MortarData<Dim>& lhs, const MortarData<Dim>& rhs) {
-  return lhs.time_step_id() == rhs.time_step_id() and
-         lhs.local_mortar_data() == rhs.local_mortar_data() and
+  return lhs.local_mortar_data() == rhs.local_mortar_data() and
          lhs.neighbor_mortar_data() == rhs.neighbor_mortar_data() and
          lhs.local_geometric_quantities_ == rhs.local_geometric_quantities_ and
          lhs.using_volume_and_face_jacobians_ ==
@@ -204,7 +190,6 @@ bool operator!=(const MortarData<Dim>& lhs, const MortarData<Dim>& rhs) {
 
 template <size_t Dim>
 std::ostream& operator<<(std::ostream& os, const MortarData<Dim>& mortar_data) {
-  os << "TimeStepId: " << mortar_data.time_step_id() << "\n";
   os << "LocalMortarData: " << mortar_data.local_mortar_data() << "\n";
   os << "NeighborMortarData: " << mortar_data.neighbor_mortar_data() << "\n";
   return os;

--- a/src/Evolution/DiscontinuousGalerkin/MortarData.cpp
+++ b/src/Evolution/DiscontinuousGalerkin/MortarData.cpp
@@ -22,32 +22,22 @@
 
 namespace evolution::dg {
 template <size_t Dim>
-MortarData<Dim>::MortarData(const size_t number_of_buffers)
-    : number_of_buffers_(number_of_buffers) {
-  time_step_id_.resize(number_of_buffers_);
-  local_mortar_data_.resize(number_of_buffers_);
-  neighbor_mortar_data_.resize(number_of_buffers_);
-  mortar_index_ = 0;
-}
-
-template <size_t Dim>
 void MortarData<Dim>::insert_local_mortar_data(
     TimeStepId time_step_id, Mesh<Dim - 1> local_interface_mesh,
     // NOLINTNEXTLINE(performance-unnecessary-value-param)
     DataVector local_mortar_vars) {
   // clang-tidy can't figure out that `vars` is moved below
-  ASSERT(not local_mortar_data_[mortar_index_].has_value(),
-         "Already received local data at " << time_step_id
-                                           << " with interface mesh "
-                                           << local_interface_mesh);
-  ASSERT(not neighbor_mortar_data_[mortar_index_].has_value() or
-             time_step_id == time_step_id_[mortar_index_],
+  ASSERT(not local_mortar_data_.has_value(), "Already received local data at "
+                                                 << time_step_id
+                                                 << " with interface mesh "
+                                                 << local_interface_mesh);
+  ASSERT(not neighbor_mortar_data_.has_value() or time_step_id == time_step_id_,
          "Received local data at " << time_step_id
                                    << ", but already have neighbor data at "
-                                   << time_step_id_[mortar_index_]);
+                                   << time_step_id_);
   // NOLINTNEXTLINE(performance-move-const-arg)
-  time_step_id_[mortar_index_] = std::move(time_step_id);
-  local_mortar_data_[mortar_index_] =
+  time_step_id_ = std::move(time_step_id);
+  local_mortar_data_ =
       std::pair{std::move(local_interface_mesh), std::move(local_mortar_vars)};
 }
 
@@ -57,19 +47,18 @@ void MortarData<Dim>::insert_neighbor_mortar_data(
     // NOLINTNEXTLINE(performance-unnecessary-value-param)
     DataVector neighbor_mortar_vars) {
   // clang-tidy can't figure out that `vars` is moved below
-  ASSERT(not neighbor_mortar_data_[mortar_index_].has_value(),
+  ASSERT(not neighbor_mortar_data_.has_value(),
          "Already received neighbor data at " << time_step_id
                                               << " with interface mesh "
                                               << neighbor_interface_mesh);
-  ASSERT(not local_mortar_data_[mortar_index_].has_value() or
-             time_step_id == time_step_id_[mortar_index_],
+  ASSERT(not local_mortar_data_.has_value() or time_step_id == time_step_id_,
          "Received neighbor data at " << time_step_id
                                       << ", but already have local data at "
-                                      << time_step_id_[mortar_index_]);
+                                      << time_step_id_);
   // NOLINTNEXTLINE(performance-move-const-arg)
-  time_step_id_[mortar_index_] = std::move(time_step_id);
-  neighbor_mortar_data_[mortar_index_] = std::pair{
-      std::move(neighbor_interface_mesh), std::move(neighbor_mortar_vars)};
+  time_step_id_ = std::move(time_step_id);
+  neighbor_mortar_data_ = std::pair{std::move(neighbor_interface_mesh),
+                                    std::move(neighbor_mortar_vars)};
 }
 
 template <size_t Dim>
@@ -77,7 +66,7 @@ void MortarData<Dim>::insert_local_geometric_quantities(
     const Scalar<DataVector>& local_volume_det_inv_jacobian,
     const Scalar<DataVector>& local_face_det_jacobian,
     const Scalar<DataVector>& local_face_normal_magnitude) {
-  ASSERT(local_mortar_data_[mortar_index_].has_value(),
+  ASSERT(local_mortar_data_.has_value(),
          "Must set local mortar data before setting the geometric quantities.");
   ASSERT(local_face_det_jacobian[0].size() ==
              local_face_normal_magnitude[0].size(),
@@ -121,7 +110,7 @@ void MortarData<Dim>::insert_local_geometric_quantities(
 template <size_t Dim>
 void MortarData<Dim>::insert_local_face_normal_magnitude(
     const Scalar<DataVector>& local_face_normal_magnitude) {
-  ASSERT(local_mortar_data_[mortar_index_].has_value(),
+  ASSERT(local_mortar_data_.has_value(),
          "Must set local mortar data before setting the local face normal.");
   ASSERT(not using_volume_and_face_jacobians_,
          "The face normal magnitude cannot be inserted if the face normal, "
@@ -140,7 +129,7 @@ template <size_t Dim>
 void MortarData<Dim>::get_local_volume_det_inv_jacobian(
     const gsl::not_null<Scalar<DataVector>*> local_volume_det_inv_jacobian)
     const {
-  ASSERT(local_mortar_data_[mortar_index_].has_value(),
+  ASSERT(local_mortar_data_.has_value(),
          "Must set local mortar data before getting the local volume inverse "
          "Jacobian determinant.");
   ASSERT(
@@ -168,7 +157,7 @@ void MortarData<Dim>::get_local_volume_det_inv_jacobian(
 template <size_t Dim>
 void MortarData<Dim>::get_local_face_det_jacobian(
     const gsl::not_null<Scalar<DataVector>*> local_face_det_jacobian) const {
-  ASSERT(local_mortar_data_[mortar_index_].has_value(),
+  ASSERT(local_mortar_data_.has_value(),
          "Must set local mortar data before getting the local face Jacobian "
          "determinant.");
   ASSERT(local_geometric_quantities_.size() >
@@ -197,7 +186,7 @@ template <size_t Dim>
 void MortarData<Dim>::get_local_face_normal_magnitude(
     const gsl::not_null<Scalar<DataVector>*> local_face_normal_magnitude)
     const {
-  ASSERT(local_mortar_data_[mortar_index_].has_value(),
+  ASSERT(local_mortar_data_.has_value(),
          "Must set local mortar data before getting the local face normal "
          "magnitude.");
   const size_t num_face_points =
@@ -219,42 +208,21 @@ template <size_t Dim>
 std::pair<std::pair<Mesh<Dim - 1>, DataVector>,
           std::pair<Mesh<Dim - 1>, DataVector>>
 MortarData<Dim>::extract() {
-  ASSERT(
-      local_mortar_data_[mortar_index_].has_value() and
-          neighbor_mortar_data_[mortar_index_].has_value(),
-      "Tried to extract boundary data, but do not have "
-          << (local_mortar_data_[mortar_index_].has_value()
-                  ? "neighbor"
-                  : neighbor_mortar_data_[mortar_index_].has_value() ? "local"
-                                                                     : "any")
-          << " data.");
-  auto result = std::pair{std::move(*local_mortar_data_[mortar_index_]),
-                          std::move(*neighbor_mortar_data_[mortar_index_])};
-  local_mortar_data_[mortar_index_].reset();
-  neighbor_mortar_data_[mortar_index_].reset();
+  ASSERT(local_mortar_data_.has_value() and neighbor_mortar_data_.has_value(),
+         "Tried to extract boundary data, but do not have "
+             << (local_mortar_data_.has_value()      ? "neighbor"
+                 : neighbor_mortar_data_.has_value() ? "local"
+                                                     : "any")
+             << " data.");
+  auto result = std::pair{std::move(*local_mortar_data_),
+                          std::move(*neighbor_mortar_data_)};
+  local_mortar_data_.reset();
+  neighbor_mortar_data_.reset();
   return result;
 }
 
 template <size_t Dim>
-void MortarData<Dim>::next_buffer() {
-  mortar_index_ =
-      mortar_index_ + 1 == number_of_buffers_ ? 0 : mortar_index_ + 1;
-}
-
-template <size_t Dim>
-size_t MortarData<Dim>::current_buffer_index() const {
-  return mortar_index_;
-}
-
-template <size_t Dim>
-size_t MortarData<Dim>::total_number_of_buffers() const {
-  return number_of_buffers_;
-}
-
-template <size_t Dim>
 void MortarData<Dim>::pup(PUP::er& p) {
-  p | number_of_buffers_;
-  p | mortar_index_;
   p | time_step_id_;
   p | local_mortar_data_;
   p | neighbor_mortar_data_;
@@ -269,16 +237,14 @@ std::string MortarData<Dim>::pretty_print_current_buffer_no_data(
   std::stringstream ss{};
   ss << std::scientific << std::setprecision(16);
   const std::string pad(padding_size, ' ');
-  ss << pad << "Current buffer: " << mortar_index_
-     << ", time = " << time_step_id_[mortar_index_] << "\n";
+  ss << pad << "Current buffer: " << 0_st << ", time = " << time_step_id_
+     << "\n";
   return ss.str();
 }
 
 template <size_t Dim>
 bool operator==(const MortarData<Dim>& lhs, const MortarData<Dim>& rhs) {
-  return lhs.number_of_buffers_ == rhs.number_of_buffers_ and
-         lhs.mortar_index_ == rhs.mortar_index_ and
-         lhs.time_step_id() == rhs.time_step_id() and
+  return lhs.time_step_id() == rhs.time_step_id() and
          lhs.local_mortar_data() == rhs.local_mortar_data() and
          lhs.neighbor_mortar_data() == rhs.neighbor_mortar_data() and
          lhs.local_geometric_quantities_ == rhs.local_geometric_quantities_ and

--- a/src/Evolution/DiscontinuousGalerkin/MortarData.cpp
+++ b/src/Evolution/DiscontinuousGalerkin/MortarData.cpp
@@ -165,23 +165,6 @@ void MortarData<Dim>::get_local_face_normal_magnitude(
 }
 
 template <size_t Dim>
-std::pair<std::pair<Mesh<Dim - 1>, DataVector>,
-          std::pair<Mesh<Dim - 1>, DataVector>>
-MortarData<Dim>::extract() {
-  ASSERT(local_mortar_data_.has_value() and neighbor_mortar_data_.has_value(),
-         "Tried to extract boundary data, but do not have "
-             << (local_mortar_data_.has_value()      ? "neighbor"
-                 : neighbor_mortar_data_.has_value() ? "local"
-                                                     : "any")
-             << " data.");
-  auto result = std::pair{std::move(*local_mortar_data_),
-                          std::move(*neighbor_mortar_data_)};
-  local_mortar_data_.reset();
-  neighbor_mortar_data_.reset();
-  return result;
-}
-
-template <size_t Dim>
 void MortarData<Dim>::pup(PUP::er& p) {
   p | time_step_id_;
   p | local_mortar_data_;

--- a/src/Evolution/DiscontinuousGalerkin/MortarData.cpp
+++ b/src/Evolution/DiscontinuousGalerkin/MortarData.cpp
@@ -22,46 +22,6 @@
 
 namespace evolution::dg {
 template <size_t Dim>
-void MortarData<Dim>::insert_local_mortar_data(
-    TimeStepId time_step_id, Mesh<Dim - 1> local_interface_mesh,
-    // NOLINTNEXTLINE(performance-unnecessary-value-param)
-    DataVector local_mortar_vars) {
-  // clang-tidy can't figure out that `vars` is moved below
-  ASSERT(not local_mortar_data_.has_value(), "Already received local data at "
-                                                 << time_step_id
-                                                 << " with interface mesh "
-                                                 << local_interface_mesh);
-  ASSERT(not neighbor_mortar_data_.has_value() or time_step_id == time_step_id_,
-         "Received local data at " << time_step_id
-                                   << ", but already have neighbor data at "
-                                   << time_step_id_);
-  // NOLINTNEXTLINE(performance-move-const-arg)
-  time_step_id_ = std::move(time_step_id);
-  local_mortar_data_ =
-      std::pair{std::move(local_interface_mesh), std::move(local_mortar_vars)};
-}
-
-template <size_t Dim>
-void MortarData<Dim>::insert_neighbor_mortar_data(
-    TimeStepId time_step_id, Mesh<Dim - 1> neighbor_interface_mesh,
-    // NOLINTNEXTLINE(performance-unnecessary-value-param)
-    DataVector neighbor_mortar_vars) {
-  // clang-tidy can't figure out that `vars` is moved below
-  ASSERT(not neighbor_mortar_data_.has_value(),
-         "Already received neighbor data at " << time_step_id
-                                              << " with interface mesh "
-                                              << neighbor_interface_mesh);
-  ASSERT(not local_mortar_data_.has_value() or time_step_id == time_step_id_,
-         "Received neighbor data at " << time_step_id
-                                      << ", but already have local data at "
-                                      << time_step_id_);
-  // NOLINTNEXTLINE(performance-move-const-arg)
-  time_step_id_ = std::move(time_step_id);
-  neighbor_mortar_data_ = std::pair{std::move(neighbor_interface_mesh),
-                                    std::move(neighbor_mortar_vars)};
-}
-
-template <size_t Dim>
 void MortarData<Dim>::insert_local_geometric_quantities(
     const Scalar<DataVector>& local_volume_det_inv_jacobian,
     const Scalar<DataVector>& local_face_det_jacobian,

--- a/src/Evolution/DiscontinuousGalerkin/MortarData.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/MortarData.hpp
@@ -13,7 +13,6 @@
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
-#include "Time/TimeStepId.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/Serialization/PupStlCpp17.hpp"
 
@@ -113,10 +112,6 @@ class MortarData {
   void get_local_face_normal_magnitude(
       gsl::not_null<Scalar<DataVector>*> local_face_normal_magnitude) const;
 
-  const TimeStepId& time_step_id() const { return time_step_id_; }
-
-  TimeStepId& time_step_id() { return time_step_id_; }
-
   auto local_mortar_data() const
       -> const std::optional<std::pair<Mesh<Dim - 1>, DataVector>>& {
     return local_mortar_data_;
@@ -140,15 +135,12 @@ class MortarData {
   // NOLINTNEXTLINE(google-runtime-references)
   void pup(PUP::er& p);
 
-  std::string pretty_print_current_buffer_no_data(size_t padding_size) const;
-
  private:
   template <size_t LocalDim>
   // NOLINTNEXTLINE
   friend bool operator==(const MortarData<LocalDim>& lhs,
                          const MortarData<LocalDim>& rhs);
 
-  TimeStepId time_step_id_{};
   MortarType local_mortar_data_{};
   MortarType neighbor_mortar_data_{};
   DataVector local_geometric_quantities_{};

--- a/src/Evolution/DiscontinuousGalerkin/MortarData.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/MortarData.hpp
@@ -47,8 +47,6 @@ class MortarData {
   using MortarType = std::optional<std::pair<Mesh<Dim - 1>, DataVector>>;
 
  public:
-  MortarData(size_t number_of_buffers = 1);
-
   /*!
    * \brief Insert data onto the mortar.
    *
@@ -148,40 +146,28 @@ class MortarData {
   auto extract() -> std::pair<std::pair<Mesh<Dim - 1>, DataVector>,
                               std::pair<Mesh<Dim - 1>, DataVector>>;
 
-  /// Move to the next internal mortar buffer
-  void next_buffer();
+  const TimeStepId& time_step_id() const { return time_step_id_; }
 
-  /// Return the current internal mortar index
-  size_t current_buffer_index() const;
-
-  /// Return the total number of buffers that this MortarData was constructed
-  /// with
-  size_t total_number_of_buffers() const;
-
-  const TimeStepId& time_step_id() const {
-    return time_step_id_[mortar_index_];
-  }
-
-  TimeStepId& time_step_id() { return time_step_id_[mortar_index_]; }
+  TimeStepId& time_step_id() { return time_step_id_; }
 
   auto local_mortar_data() const
       -> const std::optional<std::pair<Mesh<Dim - 1>, DataVector>>& {
-    return local_mortar_data_[mortar_index_];
+    return local_mortar_data_;
   }
 
   auto neighbor_mortar_data() const
       -> const std::optional<std::pair<Mesh<Dim - 1>, DataVector>>& {
-    return neighbor_mortar_data_[mortar_index_];
+    return neighbor_mortar_data_;
   }
 
   auto local_mortar_data()
       -> std::optional<std::pair<Mesh<Dim - 1>, DataVector>>& {
-    return local_mortar_data_[mortar_index_];
+    return local_mortar_data_;
   }
 
   auto neighbor_mortar_data()
       -> std::optional<std::pair<Mesh<Dim - 1>, DataVector>>& {
-    return neighbor_mortar_data_[mortar_index_];
+    return neighbor_mortar_data_;
   }
 
   // NOLINTNEXTLINE(google-runtime-references)
@@ -195,11 +181,9 @@ class MortarData {
   friend bool operator==(const MortarData<LocalDim>& lhs,
                          const MortarData<LocalDim>& rhs);
 
-  size_t number_of_buffers_{1};
-  std::vector<TimeStepId> time_step_id_{};
-  std::vector<MortarType> local_mortar_data_{};
-  std::vector<MortarType> neighbor_mortar_data_{};
-  size_t mortar_index_{0};
+  TimeStepId time_step_id_{};
+  MortarType local_mortar_data_{};
+  MortarType neighbor_mortar_data_{};
   DataVector local_geometric_quantities_{};
   bool using_volume_and_face_jacobians_{false};
   bool using_only_face_normal_magnitude_{false};

--- a/src/Evolution/DiscontinuousGalerkin/MortarData.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/MortarData.hpp
@@ -113,13 +113,6 @@ class MortarData {
   void get_local_face_normal_magnitude(
       gsl::not_null<Scalar<DataVector>*> local_face_normal_magnitude) const;
 
-  /// Return the inserted data and reset the state to empty.
-  ///
-  /// The first element is the local data while the second element is the
-  /// neighbor data.
-  auto extract() -> std::pair<std::pair<Mesh<Dim - 1>, DataVector>,
-                              std::pair<Mesh<Dim - 1>, DataVector>>;
-
   const TimeStepId& time_step_id() const { return time_step_id_; }
 
   TimeStepId& time_step_id() { return time_step_id_; }

--- a/src/Evolution/DiscontinuousGalerkin/MortarData.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/MortarData.hpp
@@ -48,32 +48,6 @@ class MortarData {
 
  public:
   /*!
-   * \brief Insert data onto the mortar.
-   *
-   * Exactly one local and neighbor insert call must be made between calls to
-   * `extract()`.
-   *
-   * The insert functions require that:
-   * - the data is inserted only once
-   * - the `TimeStepId` of the local and neighbor data are the same (this is
-   *   only checked if the local/neighbor data was already inserted)
-   *
-   * \note it is not required that the number of grid points between the local
-   * and neighbor data be the same since one may be using FD/FV instead of DG
-   * and this switch is done locally in space and time in such a way that
-   * neighboring elements have no a priori knowledge about what well be
-   * received.
-   */
-  /// @{
-  void insert_local_mortar_data(TimeStepId time_step_id,
-                                Mesh<Dim - 1> local_interface_mesh,
-                                DataVector local_mortar_vars);
-  void insert_neighbor_mortar_data(TimeStepId time_step_id,
-                                   Mesh<Dim - 1> neighbor_interface_mesh,
-                                   DataVector neighbor_mortar_vars);
-  /// @}
-
-  /*!
    * \brief Insert the magnitude of the local face normal, the determinant
    * of the volume inverse Jacobian, and the determinant of the face Jacobian.
    * Used for local time stepping with Gauss points.

--- a/tests/Unit/Evolution/DgSubcell/Actions/Test_TakeTimeStep.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Actions/Test_TakeTimeStep.cpp
@@ -148,9 +148,10 @@ void test() {
   // cleared.
   DirectionalIdMap<Dim, evolution::dg::MortarData<Dim>> mortar_data{};
   evolution::dg::MortarData<Dim> lower_xi_data{};
-  lower_xi_data.insert_local_mortar_data(
-      TimeStepId{true, 1, Time{Slab{1.2, 7.8}, {1, 10}}},
-      subcell_mesh.slice_away(0), DataVector{1.1, 2.43, 7.8});
+  lower_xi_data.time_step_id() =
+      TimeStepId{true, 1, Time{Slab{1.2, 7.8}, {1, 10}}};
+  lower_xi_data.local_mortar_data() =
+      std::pair{subcell_mesh.slice_away(0), DataVector{1.1, 2.43, 7.8}};
   const DirectionalId<Dim> lower_id{Direction<Dim>::lower_xi(),
                                     ElementId<Dim>{1}};
   mortar_data[lower_id] = lower_xi_data;

--- a/tests/Unit/Evolution/DgSubcell/Actions/Test_TakeTimeStep.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Actions/Test_TakeTimeStep.cpp
@@ -148,8 +148,6 @@ void test() {
   // cleared.
   DirectionalIdMap<Dim, evolution::dg::MortarData<Dim>> mortar_data{};
   evolution::dg::MortarData<Dim> lower_xi_data{};
-  lower_xi_data.time_step_id() =
-      TimeStepId{true, 1, Time{Slab{1.2, 7.8}, {1, 10}}};
   lower_xi_data.local_mortar_data() =
       std::pair{subcell_mesh.slice_away(0), DataVector{1.1, 2.43, 7.8}};
   const DirectionalId<Dim> lower_id{Direction<Dim>::lower_xi(),

--- a/tests/Unit/Evolution/DgSubcell/Test_CorrectPackagedData.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Test_CorrectPackagedData.cpp
@@ -117,10 +117,8 @@ void test() {
     }();
 
     // Insert neighbor DG data.
-    upper_mortar_data.time_step_id() = time_step_id;
     upper_mortar_data.neighbor_mortar_data() =
         std::pair{dg_face_mesh, upper_neighbor_data};
-    lower_mortar_data.time_step_id() = time_step_id;
     lower_mortar_data.neighbor_mortar_data() =
         std::pair{dg_face_mesh, lower_neighbor_data};
 
@@ -225,10 +223,8 @@ void test() {
       DataVector lower_local_data{dg_number_of_independent_components *
                                   dg_face_mesh.number_of_grid_points()};
       std::iota(lower_local_data.begin(), lower_local_data.end(), 1.0e7);
-      upper_mortar_data.time_step_id() = time_step_id;
       upper_mortar_data.local_mortar_data() =
           std::pair{dg_face_mesh, upper_local_data};
-      lower_mortar_data.time_step_id() = time_step_id;
       lower_mortar_data.local_mortar_data() =
           std::pair{dg_face_mesh, lower_local_data};
 

--- a/tests/Unit/Evolution/DgSubcell/Test_CorrectPackagedData.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Test_CorrectPackagedData.cpp
@@ -117,10 +117,12 @@ void test() {
     }();
 
     // Insert neighbor DG data.
-    upper_mortar_data.insert_neighbor_mortar_data(time_step_id, dg_face_mesh,
-                                                  upper_neighbor_data);
-    lower_mortar_data.insert_neighbor_mortar_data(time_step_id, dg_face_mesh,
-                                                  lower_neighbor_data);
+    upper_mortar_data.time_step_id() = time_step_id;
+    upper_mortar_data.neighbor_mortar_data() =
+        std::pair{dg_face_mesh, upper_neighbor_data};
+    lower_mortar_data.time_step_id() = time_step_id;
+    lower_mortar_data.neighbor_mortar_data() =
+        std::pair{dg_face_mesh, lower_neighbor_data};
 
     const Mesh<Dim - 1> subcell_face_mesh =
         volume_subcell_mesh.slice_away(direction_to_check);
@@ -223,10 +225,12 @@ void test() {
       DataVector lower_local_data{dg_number_of_independent_components *
                                   dg_face_mesh.number_of_grid_points()};
       std::iota(lower_local_data.begin(), lower_local_data.end(), 1.0e7);
-      upper_mortar_data.insert_local_mortar_data(time_step_id, dg_face_mesh,
-                                                 upper_local_data);
-      lower_mortar_data.insert_local_mortar_data(time_step_id, dg_face_mesh,
-                                                 lower_local_data);
+      upper_mortar_data.time_step_id() = time_step_id;
+      upper_mortar_data.local_mortar_data() =
+          std::pair{dg_face_mesh, upper_local_data};
+      lower_mortar_data.time_step_id() = time_step_id;
+      lower_mortar_data.local_mortar_data() =
+          std::pair{dg_face_mesh, lower_local_data};
 
       evolution::dg::subcell::correct_package_data<true>(
           make_not_null(&lower_packaged_data),

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Actions/Test_ApplyBoundaryCorrections.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Actions/Test_ApplyBoundaryCorrections.cpp
@@ -974,16 +974,6 @@ void test_impl(const Spectral::Quadrature quadrature,
           get_tag<variables_tag>(runner, self_id));
   }
 
-  for (const auto& mortar_data :
-       get_tag<::evolution::dg::Tags::MortarData<Dim>>(runner, self_id)) {
-    // The MortarData currently requires there to be no data already inserted.
-    // In theory we could re-use the allocation, but that is a future
-    // optimization. For now, we require that there is nothing in the MortarData
-    // after `ApplyBoundaryCorrections` was called.
-    CHECK_FALSE(mortar_data.second.local_mortar_data().has_value());
-    CHECK_FALSE(mortar_data.second.neighbor_mortar_data().has_value());
-  }
-
   // Check neighbor meshes
   size_t total_neighbors = 0;
   const auto& neighbor_meshes =

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Actions/Test_ApplyBoundaryCorrections.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Actions/Test_ApplyBoundaryCorrections.cpp
@@ -231,13 +231,12 @@ struct SetLocalMortarData {
                       100 * count + 1000);
 
         db::mutate<evolution::dg::Tags::MortarData<Metavariables::volume_dim>>(
-            [&face_mesh, &mortar_id, &time_step_id,
+            [&face_mesh, &mortar_id,
              &type_erased_boundary_data_on_mortar](const auto mortar_data_ptr) {
               // when using local time stepping, we reset the local mortar data
               // at the end of the SetLocalMortarData action since the
               // ComputeTimeDerivative action would've moved the data into the
               // boundary history.
-              mortar_data_ptr->at(mortar_id).time_step_id() = time_step_id;
               mortar_data_ptr->at(mortar_id).local_mortar_data() = std::pair{
                   face_mesh, std::move(type_erased_boundary_data_on_mortar)};
             },
@@ -267,7 +266,6 @@ struct SetLocalMortarData {
           count++;
           evolution::dg::MortarData<Metavariables::volume_dim>
               past_mortar_data{};
-          past_mortar_data.time_step_id() = past_time_step_id;
           past_mortar_data.local_mortar_data() = std::pair{
               face_mesh, std::move(type_erased_boundary_data_on_mortar)};
           Scalar<DataVector> local_face_normal_magnitude{
@@ -693,7 +691,6 @@ void test_impl(const Spectral::Quadrature quadrature,
       if (UseLocalTimeStepping) {
         if (neighbor_time_step_id < local_next_time_step_id) {
           evolution::dg::MortarData<Dim> nhbr_mortar_data{};
-          nhbr_mortar_data.time_step_id() = neighbor_time_step_id;
           nhbr_mortar_data.neighbor_mortar_data() =
               std::pair{face_mesh, flux_data};
           mortar_data_history.at(mortar_id).remote().insert(
@@ -701,7 +698,6 @@ void test_impl(const Spectral::Quadrature quadrature,
               std::move(nhbr_mortar_data));
         }
       } else {
-        all_mortar_data.at(mortar_id).time_step_id() = neighbor_time_step_id;
         all_mortar_data.at(mortar_id).neighbor_mortar_data() =
             std::pair{face_mesh, flux_data};
       }

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Actions/Test_ApplyBoundaryCorrections.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Actions/Test_ApplyBoundaryCorrections.cpp
@@ -237,9 +237,9 @@ struct SetLocalMortarData {
               // at the end of the SetLocalMortarData action since the
               // ComputeTimeDerivative action would've moved the data into the
               // boundary history.
-              mortar_data_ptr->at(mortar_id).insert_local_mortar_data(
-                  time_step_id, face_mesh,
-                  std::move(type_erased_boundary_data_on_mortar));
+              mortar_data_ptr->at(mortar_id).time_step_id() = time_step_id;
+              mortar_data_ptr->at(mortar_id).local_mortar_data() = std::pair{
+                  face_mesh, std::move(type_erased_boundary_data_on_mortar)};
             },
             make_not_null(&box));
         ++count;
@@ -267,9 +267,9 @@ struct SetLocalMortarData {
           count++;
           evolution::dg::MortarData<Metavariables::volume_dim>
               past_mortar_data{};
-          past_mortar_data.insert_local_mortar_data(
-              past_time_step_id, face_mesh,
-              std::move(type_erased_boundary_data_on_mortar));
+          past_mortar_data.time_step_id() = past_time_step_id;
+          past_mortar_data.local_mortar_data() = std::pair{
+              face_mesh, std::move(type_erased_boundary_data_on_mortar)};
           Scalar<DataVector> local_face_normal_magnitude{
               face_mesh.number_of_grid_points()};
           alg::iota(get(local_face_normal_magnitude),
@@ -693,15 +693,17 @@ void test_impl(const Spectral::Quadrature quadrature,
       if (UseLocalTimeStepping) {
         if (neighbor_time_step_id < local_next_time_step_id) {
           evolution::dg::MortarData<Dim> nhbr_mortar_data{};
-          nhbr_mortar_data.insert_neighbor_mortar_data(neighbor_time_step_id,
-                                                       face_mesh, flux_data);
+          nhbr_mortar_data.time_step_id() = neighbor_time_step_id;
+          nhbr_mortar_data.neighbor_mortar_data() =
+              std::pair{face_mesh, flux_data};
           mortar_data_history.at(mortar_id).remote().insert(
               neighbor_time_step_id, integration_order,
               std::move(nhbr_mortar_data));
         }
       } else {
-        all_mortar_data.at(mortar_id).insert_neighbor_mortar_data(
-            neighbor_time_step_id, face_mesh, flux_data);
+        all_mortar_data.at(mortar_id).time_step_id() = neighbor_time_step_id;
+        all_mortar_data.at(mortar_id).neighbor_mortar_data() =
+            std::pair{face_mesh, flux_data};
       }
       ++count;
     };

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Initialization/Test_Mortars.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Initialization/Test_Mortars.cpp
@@ -502,7 +502,7 @@ void test_p_refine_gts() {
     expected_normal_covector_and_magnitude[direction] = std::nullopt;
     for (const auto& neighbor : neighbors) {
       const DirectionalId<Dim> mortar_id{direction, neighbor};
-      expected_mortar_data.emplace(mortar_id, MortarData<Dim>{1});
+      expected_mortar_data.emplace(mortar_id, MortarData<Dim>{});
       expected_mortar_mesh.emplace(
           mortar_id,
           ::dg::mortar_mesh(new_mesh.slice_away(direction.dimension()),

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Test_MortarData.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Test_MortarData.cpp
@@ -100,10 +100,8 @@ void test_global_time_stepping_usage() {
   std::uniform_real_distribution<double> dist(-1.0, 2.3);
   MAKE_GENERATOR(gen);
   constexpr size_t number_of_components = 1 + Dim;
-  const size_t number_of_buffers = 2;
 
-  MortarData<Dim> mortar_data{number_of_buffers};
-  CHECK(mortar_data.total_number_of_buffers() == number_of_buffers);
+  MortarData<Dim> mortar_data{};
   const TimeStepId time_step_id{true, 3, Time{Slab{0.2, 7.1}, {2, 51}}};
 
   const Mesh<Dim - 1> mortar_mesh{4, Spectral::Basis::Legendre,
@@ -146,9 +144,7 @@ void test_global_time_stepping_usage() {
   CHECK(mortar_data.pretty_print_current_buffer_no_data(1_st) ==
         expected_pretty_output);
 
-  CHECK(mortar_data.current_buffer_index() == 0);
-  mortar_data.next_buffer();
-  CHECK(mortar_data.current_buffer_index() == 1);
+  mortar_data = MortarData<Dim>{};
 
   // Then assign things with the local_mortar_data() non-const reference
   // functions
@@ -157,18 +153,12 @@ void test_global_time_stepping_usage() {
                         std::optional{neighbor_data}, expected_output);
 
   expected_pretty_output = MakeString{}
-                           << "  Current buffer: 1, time = " << std::scientific
+                           << "  Current buffer: 0, time = " << std::scientific
                            << std::setprecision(16) << time_step_id << "\n";
   CHECK(mortar_data.pretty_print_current_buffer_no_data(2_st) ==
         expected_pretty_output);
 
   check_serialization(make_not_null(&mortar_data));
-
-  const auto second_index_mortar_data = mortar_data.extract();
-  mortar_data.next_buffer();
-  const auto first_index_mortar_data = mortar_data.extract();
-
-  CHECK(second_index_mortar_data == first_index_mortar_data);
 }
 
 template <size_t Dim>
@@ -178,10 +168,8 @@ void test_local_time_stepping_usage(const bool use_gauss_points) {
   std::uniform_real_distribution<double> dist(-1.0, 2.3);
   MAKE_GENERATOR(gen);
   constexpr size_t number_of_components = 1 + Dim;
-  const size_t number_of_buffers = 1;
 
-  MortarData<Dim> mortar_data{1};
-  CHECK(mortar_data.total_number_of_buffers() == number_of_buffers);
+  MortarData<Dim> mortar_data{};
   const TimeStepId time_step_id{true, 3, Time{Slab{0.2, 7.1}, {2, 51}}};
 
   const Mesh<Dim - 1> mortar_mesh{4, Spectral::Basis::Legendre,
@@ -204,9 +192,7 @@ void test_local_time_stepping_usage(const bool use_gauss_points) {
                      std::optional{local_data}, local_mesh, std::nullopt,
                      expected_output);
 
-  CHECK(mortar_data.current_buffer_index() == 0);
-  mortar_data.next_buffer();
-  CHECK(mortar_data.current_buffer_index() == 0);
+  mortar_data = MortarData<Dim>{};
 
   assign_with_reference(make_not_null(&mortar_data), time_step_id, local_mesh,
                         std::optional{local_data}, local_mesh, std::nullopt,

--- a/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/Test_TimeDerivative.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/Test_TimeDerivative.cpp
@@ -583,7 +583,6 @@ double test(const size_t num_dg_pts, std::optional<double> expansion_velocity,
 
     auto& the_mortar_data = mortar_data[DirectionalId<3>{
         direction, *element.neighbors().at(direction).begin()}];
-    the_mortar_data.time_step_id() = TimeStepId{true, 0, Time{slab, {0, 1}}};
     if (local_data) {
       the_mortar_data.local_mortar_data() =
           std::pair{interface_mesh, std::move(interface_data)};

--- a/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/Test_TimeDerivative.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/Test_TimeDerivative.cpp
@@ -581,17 +581,15 @@ double test(const size_t num_dg_pts, std::optional<double> expansion_velocity,
                         static_cast<std::ptrdiff_t>(dg_packaged_data.size())),
               interface_data.begin());
 
+    auto& the_mortar_data = mortar_data[DirectionalId<3>{
+        direction, *element.neighbors().at(direction).begin()}];
+    the_mortar_data.time_step_id() = TimeStepId{true, 0, Time{slab, {0, 1}}};
     if (local_data) {
-      mortar_data[DirectionalId<3>{direction,
-                                   *element.neighbors().at(direction).begin()}]
-          .insert_local_mortar_data(TimeStepId{true, 0, Time{slab, {0, 1}}},
-                                    interface_mesh, std::move(interface_data));
+      the_mortar_data.local_mortar_data() =
+          std::pair{interface_mesh, std::move(interface_data)};
     } else {
-      mortar_data[DirectionalId<3>{direction,
-                                   *element.neighbors().at(direction).begin()}]
-          .insert_neighbor_mortar_data(TimeStepId{true, 0, Time{slab, {0, 1}}},
-                                       interface_mesh,
-                                       std::move(interface_data));
+      the_mortar_data.neighbor_mortar_data() =
+          std::pair{interface_mesh, std::move(interface_data)};
     }
   };
   insert_dg_data(Direction<3>::lower_zeta(), true);


### PR DESCRIPTION
## Proposed changes

Minor cleanup of MortarData to make it easier to add an AMR projector.
- remove unused internal buffers
- remove stored TimeStepId; GTS only used them for an ASSERT, LTS already stores a TimeStepId in its BoundaryHistory
- remove insert and extract functions as they are redundant with the accessor functions

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
