### PR TITLE
Fix notification for new contributors

### DIFF
--- a/.github/workflows/NewContributors.yaml
+++ b/.github/workflows/NewContributors.yaml
@@ -5,7 +5,7 @@
 name: New contributors
 
 on:
-  pull_request:
+  pull_request_target:
     branches: [develop]
     types: [closed]
 


### PR DESCRIPTION
This automation hasn't ever really worked because of security restrictions by GitHub. But this change should fix it, see here: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
