### PR TITLE
BBH pipeline: fix default resolution parameters

### DIFF
--- a/support/Pipelines/Bbh/InitialData.py
+++ b/support/Pipelines/Bbh/InitialData.py
@@ -109,8 +109,8 @@ def generate_id(
     orbital_angular_velocity: float,
     radial_expansion_velocity: float,
     # Resolution
-    refinement_level: int,
-    polynomial_order: int,
+    refinement_level: int = 1,
+    polynomial_order: int = 6,
     # Scheduling options
     id_input_file_template: Union[str, Path] = ID_INPUT_FILE_TEMPLATE,
     evolve: bool = False,
@@ -289,7 +289,7 @@ def generate_id(
     "-L",
     type=click.IntRange(0, None),
     help="h-refinement level.",
-    default=0,
+    default=1,
     show_default=True,
 )
 @click.option(
@@ -297,7 +297,7 @@ def generate_id(
     "-P",
     type=click.IntRange(1, None),
     help="p-refinement level.",
-    default=5,
+    default=6,
     show_default=True,
 )
 # Scheduling options

--- a/support/Pipelines/Bbh/Inspiral.py
+++ b/support/Pipelines/Bbh/Inspiral.py
@@ -114,8 +114,8 @@ def inspiral_parameters_spec(
 
 def start_inspiral(
     id_input_file_path: Union[str, Path],
-    refinement_level: int,
-    polynomial_order: int,
+    refinement_level: int = 1,
+    polynomial_order: int = 9,
     id_run_dir: Optional[Union[str, Path]] = None,
     inspiral_input_file_template: Union[
         str, Path


### PR DESCRIPTION
These arguments have defaults in the CLI, so add them also to the standalone function. This fixes a bug when running `generate-id --evolve`.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
