### PR TITLE
Fix test failure Worldtube.Tags

### DIFF
--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/Test_Tags.cpp
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/Test_Tags.cpp
@@ -415,7 +415,7 @@ void test_background_quantities_compute() {
   MAKE_GENERATOR(gen);
 
   // the velocity has to be less than c or the dilation factor is undefined
-  std::uniform_real_distribution<> pos_dist(1., 10.);
+  std::uniform_real_distribution<> pos_dist(2., 10.);
   std::uniform_real_distribution<> vel_dist(-0.2, 0.2);
 
   const auto random_position = make_with_random_values<tnsr::I<double, Dim>>(


### PR DESCRIPTION
The normalization of the four-velocity failed inside the horizon. This should fix it.

fixes #6070 