### PR TITLE
BBH pipeline: find horizons in initial data, write masses & spins to file

### DIFF
--- a/src/NumericalAlgorithms/SphericalHarmonics/Python/Strahlkorper.cpp
+++ b/src/NumericalAlgorithms/SphericalHarmonics/Python/Strahlkorper.cpp
@@ -21,9 +21,8 @@ namespace py = pybind11;
 namespace ylm::py_bindings {
 void bind_strahlkorper(pybind11::module& m) {  // NOLINT
   py::class_<ylm::Strahlkorper<Frame::Inertial>>(m, "Strahlkorper")
-      .def(py::init<size_t, size_t, double, std::array<double, 3>>(),
-           py::arg("l_max"), py::arg("m_max"), py::arg("radius"),
-           py::arg("center"))
+      .def(py::init<size_t, double, std::array<double, 3>>(), py::arg("l_max"),
+           py::arg("radius"), py::arg("center"))
       .def(py::init<size_t, size_t, const DataVector&, std::array<double, 3>>(),
            py::arg("l_max"), py::arg("m_max"),
            py::arg("radius_at_collocation_points"), py::arg("center"))

--- a/support/Pipelines/Bbh/CMakeLists.txt
+++ b/support/Pipelines/Bbh/CMakeLists.txt
@@ -11,6 +11,7 @@ spectre_python_add_module(
   InitialData.yaml
   Inspiral.py
   Inspiral.yaml
+  PostprocessId.py
   Ringdown.py
   Ringdown.yaml
 )

--- a/support/Pipelines/Bbh/FindHorizon.py
+++ b/support/Pipelines/Bbh/FindHorizon.py
@@ -272,7 +272,7 @@ def find_horizon(
 def find_horizon_command(l_max, initial_radius, center, vars, **kwargs):
     """Find an apparent horizon in volume data."""
     initial_guess = Strahlkorper(
-        l_max=l_max, m_max=l_max, radius=initial_radius, center=center
+        l_max=l_max, radius=initial_radius, center=center
     )
     horizon, quantities = find_horizon(
         initial_guess=initial_guess,

--- a/support/Pipelines/Bbh/FindHorizon.py
+++ b/support/Pipelines/Bbh/FindHorizon.py
@@ -70,6 +70,11 @@ def _horizon_reduction_data(quantities):
     return legend, reduction_data
 
 
+def vec_to_string(vec):
+    """Convert a vector to a (readable) string."""
+    return f"[{', '.join(f'{v:g}' for v in vec)}]"
+
+
 def find_horizon(
     h5_files: Union[str, Sequence[str]],
     subfile_name: str,
@@ -177,7 +182,7 @@ def find_horizon(
         )
         logger.debug(
             f"Horizon finder iteration {iter_info.iteration}: {status}."
-            f" {iter_info.r_min:.3f} <= r <= {iter_info.r_max:.3f},"
+            f" {iter_info.r_min:g} <= r <= {iter_info.r_max:g},"
             f" {iter_info.min_residual:.2e} <= residual <="
             f" {iter_info.max_residual:.2e}"
         )
@@ -185,8 +190,9 @@ def find_horizon(
             continue
         elif int(status) > 0:
             logger.info(
-                f"Found horizon around {strahlkorper.expansion_center} with"
-                f" {iter_info.r_min:.3f} <= r <= {iter_info.r_max:.3f}."
+                "Found horizon around"
+                f" {vec_to_string(strahlkorper.expansion_center)} with"
+                f" {iter_info.r_min:g} <= r <= {iter_info.r_max:g}."
             )
             break
         else:
@@ -350,7 +356,7 @@ def find_horizon_command(l_max, initial_radius, center, vars, **kwargs):
             (
                 f"{value:g}"
                 if isinstance(value, float)
-                else "[" + ", ".join(f"{v:g}" for v in value) + "]"
+                else vec_to_string(value)
             ),
         )
     rich.print(table)

--- a/support/Pipelines/Bbh/InitialData.yaml
+++ b/support/Pipelines/Bbh/InitialData.yaml
@@ -5,19 +5,17 @@ Executable: SolveXcts
 ExpectedOutput:
   - BbhReductions.h5
   - BbhVolume*.h5
-{% if evolve %}
 Next:
-  Run: spectre.Pipelines.Bbh.Inspiral:start_inspiral
+  Run: spectre.Pipelines.Bbh.PostprocessId:postprocess_id
   With:
     id_input_file_path: __file__
     id_run_dir: ./
-    pipeline_dir: {{ pipeline_dir }}
-    continue_with_ringdown: True
+    pipeline_dir: {{ pipeline_dir | default("None") }}
+    evolve: {{ evolve }}
     scheduler: {{ scheduler | default("None") }}
     copy_executable: {{ copy_executable | default("None") }}
     submit_script_template: {{ submit_script_template | default("None") }}
     submit: True
-{% endif %}
 
 ---
 

--- a/support/Pipelines/Bbh/PostprocessId.py
+++ b/support/Pipelines/Bbh/PostprocessId.py
@@ -1,0 +1,179 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import glob
+import logging
+from pathlib import Path
+from typing import Optional, Union
+
+import click
+import yaml
+
+from spectre.Pipelines.Bbh.FindHorizon import find_horizon, vec_to_string
+from spectre.SphericalHarmonics import Strahlkorper
+from spectre.support.Schedule import schedule, scheduler_options
+from spectre.Visualization.OpenVolfiles import open_volfiles
+from spectre.Visualization.ReadH5 import select_observation
+from spectre.Visualization.ReadInputFile import find_event
+
+logger = logging.getLogger(__name__)
+
+
+def postprocess_id(
+    id_input_file_path: Union[str, Path],
+    id_run_dir: Optional[Union[str, Path]] = None,
+    horizon_l_max: int = 12,
+    horizons_file: Optional[Union[str, Path]] = None,
+    evolve: bool = False,
+    pipeline_dir: Optional[Union[str, Path]] = None,
+    **scheduler_kwargs,
+):
+    """Postprocess initial data after generation.
+
+    This function is called automatically after the initial data has been
+    generated (see the 'Next' section in the 'InitialData.yaml' input file), or
+    manually by pointing the ID_INPUT_FILE_PATH to the input file of the initial
+    data run. Also specify 'id_run_dir' if the initial data was run in a
+    different directory than where the input file is.
+
+    This function does the following:
+
+    - Find apparent horizons in the data to determine quantities like the masses
+      and spins of the black holes. These quantities are stored in the given
+      'horizons_file' in subfiles 'Ah{A,B}.dat'. In addition, the horizon
+      surface coordinates and coefficients are written to the 'horizons_file' in
+      subfiles 'Ah{A,B}/Coordinates' and 'Ah{A,B}/Coefficients'.
+
+    - Start the inspiral if 'evolve' is set to True.
+
+    Arguments:
+      id_input_file_path: Path to the input file of the initial data run.
+      id_run_dir: Directory of the initial data run. Paths in the input file are
+        relative to this directory. If not provided, the directory of the input
+        file is used.
+      horizon_l_max: Maximum l-mode for the horizon search.
+      horizons_file: Path to the file where the horizon data is written to.
+        Default is 'Horizons.h5' in the 'id_run_dir'.
+      evolve: Evolve the initial data after postprocessing (default: False).
+      pipeline_dir: Directory where steps in the pipeline are created.
+        Required if 'evolve' is set to True.
+    """
+    # Read input file
+    with open(id_input_file_path, "r") as open_input_file:
+        _, id_input_file = yaml.safe_load_all(open_input_file)
+    x_B, x_A = id_input_file["Background"]["Binary"]["XCoords"]
+    id_domain = id_input_file["DomainCreator"]["BinaryCompactObject"]
+    excision_radius_A = id_domain[f"ObjectA"]["InnerRadius"]
+    excision_radius_B = id_domain[f"ObjectB"]["InnerRadius"]
+    volfile_name = id_input_file["Observers"]["VolumeFileName"]
+    id_subfile_name = find_event("ObserveFields", id_input_file)["SubfileName"]
+
+    # Find latest observation in output data
+    if id_run_dir is None:
+        id_run_dir = Path(id_input_file_path).resolve().parent
+    id_volfiles = glob.glob(str(Path(id_run_dir) / (volfile_name + "*.h5")))
+    obs_id, _ = select_observation(
+        open_volfiles(id_volfiles, id_subfile_name), step=-1
+    )
+
+    # Find horizons and write to the output file
+    if not horizons_file:
+        horizons_file = Path(id_run_dir) / "Horizons.h5"
+    for object_label, xcoord, excision_radius in zip(
+        ["AhA", "AhB"], [x_A, x_B], [excision_radius_A, excision_radius_B]
+    ):
+        _, horizon_quantities = find_horizon(
+            id_volfiles,
+            subfile_name=id_subfile_name,
+            obs_id=obs_id,
+            obs_time=0.0,
+            initial_guess=Strahlkorper(
+                l_max=horizon_l_max,
+                radius=excision_radius * 1.5,
+                center=[xcoord, 0.0, 0.0],
+            ),
+            output_surfaces_file=horizons_file,
+            output_coeffs_subfile=f"{object_label}/Coefficients",
+            output_coords_subfile=f"{object_label}/Coordinates",
+            output_reductions_file=horizons_file,
+            output_quantities_subfile=object_label,
+        )
+        logger.info(
+            f"{object_label} has mass"
+            f" {horizon_quantities['ChristodoulouMass']:g} and spin"
+            f" {vec_to_string(horizon_quantities['DimensionlessSpinVector'])}."
+        )
+    logger.info(f"Horizons found and written to {horizons_file}.")
+
+    # Start the inspiral from the ID if requested
+    if evolve:
+        from spectre.Pipelines.Bbh.Inspiral import start_inspiral
+
+        start_inspiral(
+            id_input_file_path,
+            id_run_dir=id_run_dir,
+            continue_with_ringdown=True,
+            pipeline_dir=pipeline_dir,
+            **scheduler_kwargs,
+        )
+
+
+@click.command(name="postprocess-id", help=postprocess_id.__doc__)
+@click.argument(
+    "id_input_file_path",
+    type=click.Path(
+        exists=True,
+        file_okay=True,
+        dir_okay=False,
+        readable=True,
+        path_type=Path,
+    ),
+)
+@click.option(
+    "-i",
+    "--id-run-dir",
+    type=click.Path(
+        exists=True,
+        file_okay=False,
+        dir_okay=True,
+        readable=True,
+        path_type=Path,
+    ),
+    help=(
+        "Directory of the initial data run. Paths in the input file are"
+        " relative to this directory."
+    ),
+    show_default="directory of the ID_INPUT_FILE_PATH",
+)
+@click.option(
+    "--evolve",
+    is_flag=True,
+    help="Evolve the initial data after postprocessing.",
+)
+@click.option(
+    "--pipeline-dir",
+    "-d",
+    type=click.Path(writable=True, path_type=Path),
+    help="Directory where steps in the pipeline are created.",
+)
+@click.option(
+    "--horizon-l-max",
+    type=click.IntRange(0, None),
+    help="Maximum l-mode for the horizon search.",
+    default=12,
+    show_default=True,
+)
+@click.option(
+    "--horizons-file",
+    type=click.Path(writable=True, path_type=Path),
+    help="Path to the file where the horizon data is written to.",
+    show_default="Horizons.h5 in the ID_RUN_DIR",
+)
+@scheduler_options
+def postprocess_id_command(**kwargs):
+    _rich_traceback_guard = True  # Hide traceback until here
+    postprocess_id(**kwargs)
+
+
+if __name__ == "__main__":
+    postprocess_id_command(help_option_names=["-h", "--help"])

--- a/support/Pipelines/Bbh/__init__.py
+++ b/support/Pipelines/Bbh/__init__.py
@@ -13,6 +13,7 @@ class Bbh(click.MultiCommand):
         return [
             "find-horizon",
             "generate-id",
+            "postprocess-id",
             "start-inspiral",
             "start-ringdown",
         ]
@@ -26,6 +27,10 @@ class Bbh(click.MultiCommand):
             from .InitialData import generate_id_command
 
             return generate_id_command
+        if name == "postprocess-id":
+            from .PostprocessId import postprocess_id_command
+
+            return postprocess_id_command
         elif name == "start-inspiral":
             from .Inspiral import start_inspiral_command
 

--- a/tests/Unit/NumericalAlgorithms/SphericalHarmonics/Python/Test_Strahlkorper.py
+++ b/tests/Unit/NumericalAlgorithms/SphericalHarmonics/Python/Test_Strahlkorper.py
@@ -34,7 +34,7 @@ class TestStrahlkorper(unittest.TestCase):
 
     def test_strahlkorper(self):
         strahlkorper = Strahlkorper(
-            l_max=12, m_max=12, radius=1.0, center=[0.0, 0.0, 0.0]
+            l_max=12, radius=1.0, center=[0.0, 0.0, 0.0]
         )
         self.assertEqual(strahlkorper.l_max, 12)
         self.assertEqual(strahlkorper.m_max, 12)

--- a/tests/support/Pipelines/Bbh/Test_FindHorizon.py
+++ b/tests/support/Pipelines/Bbh/Test_FindHorizon.py
@@ -119,7 +119,7 @@ class TestFindHorizon(unittest.TestCase):
             obs_id=0,
             obs_time=0.0,
             initial_guess=Strahlkorper(
-                l_max=12, m_max=12, radius=2.5, center=[0.0, 0.0, 0.0]
+                l_max=12, radius=2.5, center=[0.0, 0.0, 0.0]
             ),
         )
         # Horizon should be a sphere of coordinate radius 2.0

--- a/tests/support/Pipelines/Bbh/Test_FindHorizon.py
+++ b/tests/support/Pipelines/Bbh/Test_FindHorizon.py
@@ -52,7 +52,12 @@ class TestFindHorizon(unittest.TestCase):
             unit_test_build_path(), "Pipelines/Bbh/FindHorizon"
         )
         self.h5_filename = os.path.join(self.test_dir, "TestData.h5")
-        self.output_filename = os.path.join(self.test_dir, "Horizons.h5")
+        self.output_surfaces_filename = os.path.join(
+            self.test_dir, "Surfaces.h5"
+        )
+        self.output_reductions_filename = os.path.join(
+            self.test_dir, "Reductions.h5"
+        )
         shutil.rmtree(self.test_dir, ignore_errors=True)
         os.makedirs(self.test_dir, exist_ok=True)
 
@@ -150,17 +155,22 @@ class TestFindHorizon(unittest.TestCase):
                 "0.0",
                 "0.0",
                 "0.0",
-                "-o",
-                self.output_filename,
+                "--output-surfaces-file",
+                self.output_surfaces_filename,
                 "--output-coeffs-subfile",
                 "HorizonCoeffs",
                 "--output-coords-subfile",
                 "HorizonCoords",
+                "--output-reductions-file",
+                self.output_reductions_filename,
+                "--output-quantities-subfile",
+                "HorizonQuantities",
             ],
             catch_exceptions=True,
         )
         self.assertEqual(result.exit_code, 0, result.output)
-        self.assertTrue(os.path.exists(self.output_filename))
+        self.assertTrue(os.path.exists(self.output_surfaces_filename))
+        self.assertTrue(os.path.exists(self.output_reductions_filename))
 
 
 if __name__ == "__main__":

--- a/tests/support/Pipelines/Bbh/Test_InitialData.py
+++ b/tests/support/Pipelines/Bbh/Test_InitialData.py
@@ -133,12 +133,12 @@ class TestInitialData(unittest.TestCase):
         self.assertEqual(
             metadata["Next"],
             {
-                "Run": "spectre.Pipelines.Bbh.Inspiral:start_inspiral",
+                "Run": "spectre.Pipelines.Bbh.PostprocessId:postprocess_id",
                 "With": {
                     "id_input_file_path": "__file__",
                     "id_run_dir": "./",
                     "pipeline_dir": str(self.test_dir.resolve() / "Pipeline"),
-                    "continue_with_ringdown": True,
+                    "evolve": True,
                     "scheduler": "None",
                     "copy_executable": "None",
                     "submit_script_template": "None",

--- a/tests/support/Pipelines/Bbh/Test_PostprocessId.py
+++ b/tests/support/Pipelines/Bbh/Test_PostprocessId.py
@@ -1,0 +1,60 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import logging
+import shutil
+import unittest
+from pathlib import Path
+
+import numpy.testing as npt
+import yaml
+from click.testing import CliRunner
+
+from spectre.Informer import unit_test_build_path
+from spectre.Pipelines.Bbh.InitialData import generate_id
+from spectre.Pipelines.Bbh.PostprocessId import postprocess_id_command
+
+
+class TestPostprocessId(unittest.TestCase):
+    def setUp(self):
+        self.test_dir = Path(
+            unit_test_build_path(), "support/Pipelines/Bbh/PostprocessId"
+        )
+        shutil.rmtree(self.test_dir, ignore_errors=True)
+        self.test_dir.mkdir(parents=True, exist_ok=True)
+        self.bin_dir = Path(unit_test_build_path(), "../../bin").resolve()
+        generate_id(
+            mass_ratio=1.5,
+            dimensionless_spin_a=[0.0, 0.0, 0.0],
+            dimensionless_spin_b=[0.0, 0.0, 0.0],
+            separation=20.0,
+            orbital_angular_velocity=0.01,
+            radial_expansion_velocity=-1.0e-5,
+            refinement_level=1,
+            polynomial_order=5,
+            run_dir=self.test_dir / "ID",
+            scheduler=None,
+            submit=False,
+            executable=str(self.bin_dir / "SolveXcts"),
+        )
+        self.id_dir = self.test_dir / "ID"
+
+    def tearDown(self):
+        shutil.rmtree(self.test_dir, ignore_errors=True)
+
+    def test_cli(self):
+        # Not using `CliRunner.invoke()` because it runs in an isolated
+        # environment and doesn't work with MPI in the container.
+        # Can only test that the command runs until this error until we have
+        # some BBH initial data to postprocess.
+        with self.assertRaisesRegex(ValueError, "Number of observations"):
+            postprocess_id_command(
+                [
+                    str(self.id_dir / "InitialData.yaml"),
+                ]
+            )
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.DEBUG)
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Proposed changes

Automatically runs the horizon finder over initial data and writes horizon quantities to the reductions file. This makes important quantities like horizon masses and spins available to later steps in the pipeline.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
