### PR TITLE
Bump pybind11 version, include in Py dependencies, support pathlib.Path

### DIFF
--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -564,7 +564,6 @@ jobs:
       - name: Install Python dependencies
         if: matrix.PYTHON_VERSION
         run: |
-          python3 -m pip install pybind11~=2.6.1
           python3 -m pip install -r support/Python/requirements.txt \
             -r support/Python/dev_requirements.txt
           python3 -m pip list -v
@@ -879,7 +878,7 @@ ${{ matrix.build_type }}-pch-${{ matrix.use_pch || 'ON' }}"
       # to create the cache.
       SPECTRE_SPACK_DEPS: >-
         blaze brigand charmpp gsl hdf5 libsharp libxsmm openblas
-        py-pybind11 yaml-cpp
+        yaml-cpp
       CCACHE_DIR: $HOME/ccache
       CCACHE_TEMPDIR: $HOME/ccache-tmp
       CCACHE_MAXSIZE: "2G"

--- a/cmake/SetupPybind11.cmake
+++ b/cmake/SetupPybind11.cmake
@@ -22,6 +22,7 @@ if(BUILD_PYTHON_BINDINGS)
   find_package(pybind11 2.7.0 REQUIRED
     HINTS
     ${PYBIND11_CMAKEDIR}
+    ${SPECTRE_PYTHON_SITE_PACKAGES}
     ${Python_SITEARCH}
     ${Python_SITELIB}
     ${Python_STDARCH}

--- a/cmake/SetupPybind11.cmake
+++ b/cmake/SetupPybind11.cmake
@@ -19,7 +19,7 @@ if(BUILD_PYTHON_BINDINGS)
       "determined CMake dir: ${PYBIND11_CMAKEDIR}")
   endif()
 
-  find_package(pybind11 2.6.0 REQUIRED
+  find_package(pybind11 2.7.0 REQUIRED
     HINTS
     ${PYBIND11_CMAKEDIR}
     ${Python_SITEARCH}

--- a/containers/Dockerfile.buildenv
+++ b/containers/Dockerfile.buildenv
@@ -218,12 +218,10 @@ RUN apt-get update -y \
     && make altinstall && cd ../ \
     && rm -rf ./Python-3.10.1.tgz ./Python-3.10.1 \
     && python3.10 -m pip install --upgrade pip \
-    && pip3.10 --no-cache-dir install pybind11~=2.6.1 \
     && pip3.10 --no-cache-dir install --only-binary=h5py -r requirements.txt \
     -r dev_requirements.txt; \
     else \
     apt-get install -y python3-pip python-is-python3 pkg-config \
-    && pip3 --no-cache-dir install pybind11~=2.6.1 \
     && pip3 --no-cache-dir install --only-binary=h5py -r requirements.txt \
     -r dev_requirements.txt; \
     fi \

--- a/docs/Installation/Installation.md
+++ b/docs/Installation/Installation.md
@@ -96,8 +96,9 @@ apt), or AppleClang 13.0.0 or later
   </details>
 
 #### Optional:
+
 * [Pybind11](https://pybind11.readthedocs.io) 2.6.0 or later for SpECTRE Python
-  bindings \cite Pybind11
+  bindings. Included in `support/Python/requirements.txt`.  \cite Pybind11
 * [Doxygen](https://www.doxygen.nl/index.html) 1.9.1 to 1.9.6 — to
   generate documentation
 * Python dev dependencies listed in `support/Python/dev_requirements.txt`

--- a/docs/Installation/Installation.md
+++ b/docs/Installation/Installation.md
@@ -97,7 +97,7 @@ apt), or AppleClang 13.0.0 or later
 
 #### Optional:
 
-* [Pybind11](https://pybind11.readthedocs.io) 2.6.0 or later for SpECTRE Python
+* [Pybind11](https://pybind11.readthedocs.io) 2.7.0 or later for SpECTRE Python
   bindings. Included in `support/Python/requirements.txt`.  \cite Pybind11
 * [Doxygen](https://www.doxygen.nl/index.html) 1.9.1 to 1.9.6 — to
   generate documentation

--- a/docs/Installation/InstallationOnAppleSilicon.md
+++ b/docs/Installation/InstallationOnAppleSilicon.md
@@ -72,7 +72,7 @@ run the following to install a fortran compiler and other dependencies:
 ```
 brew install gcc
 brew install boost gsl cmake doxygen catch2 openblas
-brew install ccache autoconf automake jemalloc hdf5 pybind11 yaml-cpp
+brew install ccache autoconf automake jemalloc hdf5 yaml-cpp
 ```
 
 ### 4. Install remaining dependencies

--- a/src/IO/H5/Python/File.cpp
+++ b/src/IO/H5/Python/File.cpp
@@ -6,6 +6,7 @@
 #include <boost/algorithm/string/join.hpp>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
+#include <pybind11/stl/filesystem.h>
 #include <string>
 #include <vector>
 
@@ -141,13 +142,13 @@ void bind_h5file(py::module& m) {
 
   m.def(
       "H5File",
-      [](const std::string& file_name, const std::string& mode) {
+      [](const std::filesystem::path& file_name, const std::string& mode) {
         if (mode == "r") {
           return py::cast(
-              h5::H5File<h5::AccessType::ReadOnly>{file_name, false});
+              h5::H5File<h5::AccessType::ReadOnly>{file_name.string(), false});
         }
         return py::cast(h5::H5File<h5::AccessType::ReadWrite>{
-            file_name, (mode == "a" or mode == "r+")});
+            file_name.string(), (mode == "a" or mode == "r+")});
       },
       py::arg("file_name"), py::arg("mode") = "r",
       "Open an H5File object\n\nfile_name: the name of the H5File to "

--- a/support/DevEnvironments/spack.yaml
+++ b/support/DevEnvironments/spack.yaml
@@ -59,7 +59,6 @@ spack:
   - 'libxsmm@1.16.1:'
   - openblas
   - 'python@3.8:'
-  - 'py-pybind11@2.6:'
   - yaml-cpp@0.6.3
   concretizer:
     unify: true

--- a/support/Environments/setup/anvil_gcc.sh
+++ b/support/Environments/setup/anvil_gcc.sh
@@ -227,7 +227,6 @@ cat >$dep_dir/modules/spectre_python <<EOF
 setenv VIRTUAL_ENV $dep_dir/py_env
 prepend-path PATH ${VIRTUAL_ENV}/bin
 EOF
-pip install pybind11~=2.6.1
 HDF5_DIR=$HDF5_HOME pip install --no-binary=h5py \
   -r $SPECTRE_HOME/support/Python/requirements.txt
 

--- a/support/Environments/setup/expanse_gcc.sh
+++ b/support/Environments/setup/expanse_gcc.sh
@@ -271,7 +271,6 @@ cat >$dep_dir/modules/spectre_python <<EOF
 setenv VIRTUAL_ENV $dep_dir/py_env
 prepend-path PATH ${VIRTUAL_ENV}/bin
 EOF
-pip install pybind11~=2.6.1
 HDF5_DIR=$HDF5HOME pip install --no-binary=h5py \
   -r $SPECTRE_HOME/support/Python/requirements.txt
 

--- a/support/Environments/setup/frontera_gcc.sh
+++ b/support/Environments/setup/frontera_gcc.sh
@@ -206,7 +206,6 @@ cat >$dep_dir/modules/spectre_python <<EOF
 setenv VIRTUAL_ENV $dep_dir/py_env
 prepend-path PATH ${VIRTUAL_ENV}/bin
 EOF
-pip install pybind11~=2.6.1
 HDF5_DIR=$TACC_HDF5_DIR pip install --no-binary=h5py \
   -r $SPECTRE_HOME/support/Python/requirements.txt
 

--- a/support/Python/requirements.txt
+++ b/support/Python/requirements.txt
@@ -27,7 +27,7 @@ matplotlib <= 3.8.4
 # Pandas: To work with columns of data. Need a sufficiently recent version
 # to do some fancy indexing in Status CLI
 pandas >= 1.5
-pybind11 >= 2.6.1
+pybind11 >= 2.7.0
 pyyaml
 # Rich: to format CLI output and tracebacks
 rich >= 12.0.0

--- a/support/Python/requirements.txt
+++ b/support/Python/requirements.txt
@@ -27,6 +27,7 @@ matplotlib <= 3.8.4
 # Pandas: To work with columns of data. Need a sufficiently recent version
 # to do some fancy indexing in Status CLI
 pandas >= 1.5
+pybind11 >= 2.6.1
 pyyaml
 # Rich: to format CLI output and tracebacks
 rich >= 12.0.0

--- a/tests/Unit/IO/H5/Test_H5.py
+++ b/tests/Unit/IO/H5/Test_H5.py
@@ -3,6 +3,7 @@
 
 import os
 import unittest
+from pathlib import Path
 
 import h5py
 import numpy as np
@@ -49,6 +50,11 @@ class TestIOH5File(unittest.TestCase):
     # Test whether an H5 file is created correctly,
     def test_name(self):
         with spectre_h5.H5File(file_name=self.file_name, mode="a") as h5file:
+            self.assertEqual(self.file_name, h5file.name())
+        # Also test with pathlib.Path
+        with spectre_h5.H5File(
+            file_name=Path(self.file_name), mode="a"
+        ) as h5file:
             self.assertEqual(self.file_name, h5file.name())
 
     # Test whether a dat file can be added correctly


### PR DESCRIPTION
## Proposed changes

Mostly to support Python's `pathlib.Path` in bindings. Also these commits make CI testing on Apple Silicon easier.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
Pybind11 version 2.7+ is required now. To upgrade, run `pip install -r support/Python/requirements.txt` in your Python environment.
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
