### PR TITLE
Add TaggedVariant, parsable similarly to a factory

### DIFF
--- a/src/DataStructures/CMakeLists.txt
+++ b/src/DataStructures/CMakeLists.txt
@@ -62,6 +62,7 @@ spectre_target_headers(
   StaticVector.hpp
   StripeIterator.hpp
   TaggedContainers.hpp
+  TaggedVariant.hpp
   Tags.hpp
   TempBuffer.hpp
   Transpose.hpp

--- a/src/DataStructures/TaggedVariant.hpp
+++ b/src/DataStructures/TaggedVariant.hpp
@@ -1,0 +1,448 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <functional>
+#include <type_traits>
+#include <utility>
+#include <variant>
+
+#include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Requires.hpp"
+#include "Utilities/Serialization/PupStlCpp17.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+namespace PUP {
+class er;
+}  // namespace PUP
+/// \endcond
+
+/// \ingroup DataStructuresGroup
+///
+/// TaggedVariant and related functionality.
+namespace variants {
+namespace TaggedVariant_detail {
+template <typename R, typename Variant, typename Tag, typename Visitor>
+struct VisitAlternative;
+}  // namespace TaggedVariant_detail
+
+/// \cond
+template <typename... Tags>
+class TaggedVariant;
+template <typename... Tags>
+constexpr bool operator==(const TaggedVariant<Tags...>& a,
+                          const TaggedVariant<Tags...>& b);
+template <typename... Tags>
+constexpr bool operator<(const TaggedVariant<Tags...>& a,
+                         const TaggedVariant<Tags...>& b);
+/// \endcond
+
+/// \ingroup DataStructuresGroup
+///
+/// A class similar to `std::variant`, but indexed by tag structs.
+///
+/// \see variants::get, variants::get_if, variants::holds_alternative,
+/// variants::visit
+template <typename... Tags>
+class TaggedVariant {
+ private:
+  static_assert(sizeof...(Tags) > 0);
+  static_assert(
+      std::is_same_v<tmpl::remove_duplicates<TaggedVariant>, TaggedVariant>,
+      "TaggedVariant cannot have duplicate tags.");
+
+  template <typename Tag>
+  static constexpr size_t data_index =
+      tmpl::index_of<TaggedVariant, Tag>::value;
+
+ public:
+  /// A default constructed instance has the first tag active.
+  TaggedVariant() = default;
+  TaggedVariant(const TaggedVariant&) = default;
+  TaggedVariant(TaggedVariant&&) = default;
+  TaggedVariant& operator=(const TaggedVariant&) = default;
+  TaggedVariant& operator=(TaggedVariant&&) = default;
+  ~TaggedVariant() = default;
+
+  /// Construct with \p Tag active, using \p args to construct the
+  /// contained object.
+  ///
+  /// \snippet DataStructures/Test_TaggedVariant.cpp construct in_place_type
+  template <
+      typename Tag, typename... Args,
+      Requires<(... or std::is_same_v<Tag, Tags>) and
+               std::is_constructible_v<typename Tag::type, Args...>> = nullptr>
+  constexpr explicit TaggedVariant(std::in_place_type_t<Tag> /*meta*/,
+                                   Args&&... args)
+      : data_(std::in_place_index<data_index<Tag>>,
+              std::forward<Args>(args)...) {}
+
+  /// Construct the contained object from \p args.  Only available if
+  /// the TaggedVariant only has one tag.
+  ///
+  /// \snippet DataStructures/Test_TaggedVariant.cpp construct single
+  template <typename... Args,
+            Requires<sizeof...(Tags) == 1 and
+                     std::is_constructible_v<
+                         typename tmpl::front<TaggedVariant>::type, Args...>> =
+                nullptr>
+  constexpr explicit TaggedVariant(Args&&... args)
+      : TaggedVariant(std::in_place_type<tmpl::front<TaggedVariant>>,
+                      std::forward<Args>(args)...) {}
+
+  /// A TaggedVariant can be implicitly move-converted to another
+  /// variant with a superset of the tags.
+  ///
+  /// \snippet DataStructures/Test_TaggedVariant.cpp convert
+  /// @{
+  template <typename... OtherTags,
+            Requires<tmpl::size<tmpl::list_difference<
+                         TaggedVariant<OtherTags...>, TaggedVariant>>::value ==
+                     0> = nullptr>
+  // NOLINTNEXTLINE(google-explicit-constructor)
+  constexpr TaggedVariant(TaggedVariant<OtherTags...>&& other);
+
+  template <typename... OtherTags,
+            Requires<tmpl::size<tmpl::list_difference<
+                         TaggedVariant<OtherTags...>, TaggedVariant>>::value ==
+                     0> = nullptr>
+  constexpr TaggedVariant& operator=(TaggedVariant<OtherTags...>&& other);
+  /// @}
+
+  /// The index into the `Tags...` of the active object.
+  constexpr size_t index() const { return data_.index(); }
+
+  /// See `std::variant::valueless_by_exception`.
+  constexpr bool valueless_by_exception() const {
+    return data_.valueless_by_exception();
+  }
+
+  /// Destroys the contained object and actives \p Tag, constructing a
+  /// new value from \p args.
+  ///
+  /// \snippet DataStructures/Test_TaggedVariant.cpp emplace
+  template <
+      typename Tag, typename... Args,
+      Requires<(... or std::is_same_v<Tag, Tags>) and
+               std::is_constructible_v<typename Tag::type, Args...>> = nullptr>
+  constexpr typename Tag::type& emplace(Args&&... args) {
+    return data_.template emplace<data_index<Tag>>(std::forward<Args>(args)...);
+  }
+
+  constexpr void swap(TaggedVariant& other) noexcept(noexcept(
+      (... and (std::is_nothrow_move_constructible_v<typename Tags::type> and
+                std::is_nothrow_swappable_v<typename Tags::type>)))) {
+    data_.swap(other.data_);
+  }
+
+  void pup(PUP::er& p) { p | data_; }
+
+ private:
+  template <typename R, typename Variant, typename Tag, typename Visitor>
+  friend struct TaggedVariant_detail::VisitAlternative;
+
+  template <typename Tag, typename... Tags2>
+  friend constexpr typename Tag::type& get(TaggedVariant<Tags2...>& variant);
+  template <typename Tag, typename... Tags2>
+  friend constexpr const typename Tag::type& get(
+      const TaggedVariant<Tags2...>& variant);
+  template <typename Tag, typename... Tags2>
+  friend constexpr typename Tag::type&& get(TaggedVariant<Tags2...>&& variant);
+  template <typename Tag, typename... Tags2>
+  friend constexpr const typename Tag::type&& get(
+      const TaggedVariant<Tags2...>&& variant);
+
+  friend constexpr bool operator== <Tags...>(const TaggedVariant<Tags...>& a,
+                                             const TaggedVariant<Tags...>& b);
+  friend constexpr bool operator< <Tags...>(const TaggedVariant<Tags...>& a,
+                                            const TaggedVariant<Tags...>& b);
+
+  friend struct std::hash<TaggedVariant>;
+
+  std::variant<typename Tags::type...> data_;
+};
+
+namespace TaggedVariant_detail {
+template <typename... Tags>
+constexpr bool is_variant_or_derived(const TaggedVariant<Tags...>* /*meta*/) {
+  return true;
+}
+// NOLINTNEXTLINE(cert-dcl50-cpp) - variadic function
+constexpr bool is_variant_or_derived(...) { return false; }
+
+template <typename Tag, typename Value>
+constexpr std::pair<tmpl::type_<Tag>, Value&&> make_visitor_pair(
+    Value&& value) {
+  return {tmpl::type_<Tag>{}, std::forward<Value>(value)};
+}
+
+struct DeduceReturn;
+
+template <typename R, typename Variant, typename Tag, typename Visitor>
+struct VisitAlternative {
+  static constexpr R apply(Variant&& variant, const Visitor& visitor) {
+    return std::forward<Visitor>(visitor)(make_visitor_pair<Tag>(
+        get<std::decay_t<Variant>::template data_index<Tag>>(
+            std::forward<Variant>(variant).data_)));
+  }
+};
+
+template <typename Variant, typename Tag, typename Visitor>
+struct VisitAlternative<void, Variant, Tag, Visitor> {
+  static constexpr void apply(Variant&& variant, const Visitor& visitor) {
+    std::forward<Visitor>(visitor)(make_visitor_pair<Tag>(
+        get<std::decay_t<Variant>::template data_index<Tag>>(
+            std::forward<Variant>(variant).data_)));
+  }
+};
+
+template <typename Variant, typename Tag, typename Visitor>
+struct VisitAlternative<DeduceReturn, Variant, Tag, Visitor> {
+  static constexpr decltype(auto) apply(Variant&& variant,
+                                        const Visitor& visitor) {
+    return std::forward<Visitor>(visitor)(make_visitor_pair<Tag>(
+        get<std::decay_t<Variant>::template data_index<Tag>>(
+            std::forward<Variant>(variant).data_)));
+  }
+};
+
+template <typename... Tags>
+constexpr TaggedVariant<Tags...>& as_variant(TaggedVariant<Tags...>& variant) {
+  return variant;
+}
+template <typename... Tags>
+constexpr const TaggedVariant<Tags...>& as_variant(
+    const TaggedVariant<Tags...>& variant) {
+  return variant;
+}
+template <typename... Tags>
+constexpr TaggedVariant<Tags...>&& as_variant(
+    TaggedVariant<Tags...>&& variant) {
+  return std::move(variant);
+}
+template <typename... Tags>
+constexpr const TaggedVariant<Tags...>&& as_variant(
+    const TaggedVariant<Tags...>&& variant) {
+  return std::move(variant);
+}
+
+template <typename R, typename Visitor, typename... Variants>
+constexpr decltype(auto) visit_impl(Visitor&& visitor) {
+  return std::forward<Visitor>(visitor)();
+}
+
+template <typename R, typename Variant, typename Visitor,
+          typename DecayedVariant = std::decay_t<Variant>>
+struct VisitJumpTable;
+
+template <typename R, typename Variant, typename Visitor, typename... Tags>
+struct VisitJumpTable<R, Variant, Visitor, TaggedVariant<Tags...>> {
+  static constexpr std::array value{
+      VisitAlternative<R, Variant, Tags, Visitor>::apply...};
+};
+
+template <typename R, typename Visitor, typename FirstVariant,
+          typename... Variants>
+constexpr decltype(auto) visit_impl(Visitor&& visitor,
+                                    FirstVariant&& first_variant,
+                                    Variants&&... variants) {
+  const auto recurse = [&]<typename Arg>(Arg&& first_arg) {
+    return visit_impl<R>(
+        [&]<typename... Rest>(Rest&&... rest) {
+          return std::forward<Visitor>(visitor)(std::forward<Arg>(first_arg),
+                                                std::forward<Rest>(rest)...);
+        },
+        std::forward<Variants>(variants)...);
+  };
+  if (UNLIKELY(first_variant.valueless_by_exception())) {
+    throw std::bad_variant_access{};
+  }
+  return gsl::at(VisitJumpTable<R, FirstVariant, decltype(recurse)>::value,
+                 first_variant.index())(
+      std::forward<FirstVariant>(first_variant), recurse);
+}
+}  // namespace TaggedVariant_detail
+
+/// Call \p visitor with the contents of one or more variants.
+///
+/// Calls \p visitor with the contents of each variant as arguments,
+/// passed as `std::pair<tmpl::type_<Tag>, typename Tag::type ref>`,
+/// where `Tag` is the active tag of the variant and `ref` is a
+/// reference qualifier matching that of the passed variant.
+///
+/// If the template parameter \p R is supplied, the result is
+/// implicitly converted to that type (which may be `void`).
+/// Otherwise it is deduced from the return type of \p visitor, which
+/// must be the same for all tags in the variant.
+///
+/// \warning Unlike `visit` for `std::variant`, the types of the
+/// visitor arguments do not allow for implicit conversions between
+/// reference types.  If the visitor expects, for example,
+/// `std::pair<tmpl::type_<Tag>, const typename Tag::type&>`, the caller must
+/// ensure that the passed variant is a const lvalue.
+///
+/// \snippet DataStructures/Test_TaggedVariant.cpp visit
+/// @{
+template <typename Visitor, typename... Variants,
+          Requires<(... and TaggedVariant_detail::is_variant_or_derived(
+                                std::add_pointer_t<std::remove_reference_t<
+                                    Variants>>{}))> = nullptr>
+constexpr decltype(auto) visit(Visitor&& visitor, Variants&&... variants) {
+  return TaggedVariant_detail::visit_impl<TaggedVariant_detail::DeduceReturn>(
+      visitor,
+      TaggedVariant_detail::as_variant(std::forward<Variants>(variants))...);
+}
+
+template <typename R, typename Visitor, typename... Variants,
+          Requires<(... and TaggedVariant_detail::is_variant_or_derived(
+                                std::add_pointer_t<std::remove_reference_t<
+                                    Variants>>{}))> = nullptr>
+constexpr R visit(Visitor&& visitor, Variants&&... variants) {
+  return TaggedVariant_detail::visit_impl<R>(
+      visitor,
+      TaggedVariant_detail::as_variant(std::forward<Variants>(variants))...);
+}
+/// @}
+
+/// Check whether \p Tag is active.
+template <typename Tag, typename... Tags>
+constexpr bool holds_alternative(const TaggedVariant<Tags...>& variant) {
+  return variant.index() == tmpl::index_of<TaggedVariant<Tags...>, Tag>::value;
+}
+
+/// Access the contained object.  Throws `std::bad_variant_access` if
+/// \p Tag is not active.
+/// @{
+template <typename Tag, typename... Tags>
+constexpr typename Tag::type& get(TaggedVariant<Tags...>& variant) {
+  return get<TaggedVariant<Tags...>::template data_index<Tag>>(variant.data_);
+}
+template <typename Tag, typename... Tags>
+constexpr const typename Tag::type& get(const TaggedVariant<Tags...>& variant) {
+  return get<TaggedVariant<Tags...>::template data_index<Tag>>(variant.data_);
+}
+template <typename Tag, typename... Tags>
+constexpr typename Tag::type&& get(TaggedVariant<Tags...>&& variant) {
+  return get<TaggedVariant<Tags...>::template data_index<Tag>>(
+      std::move(variant.data_));
+}
+template <typename Tag, typename... Tags>
+constexpr const typename Tag::type&& get(
+    const TaggedVariant<Tags...>&& variant) {
+  return get<TaggedVariant<Tags...>::template data_index<Tag>>(
+      std::move(variant.data_));
+}
+/// @}
+
+/// Returns a pointer to the contained object if \p variant is a
+/// non-null pointer and \p Tag is active.  Otherwise, returns
+/// `nullptr`.
+/// @{
+template <typename Tag, typename... Tags>
+constexpr const typename Tag::type* get_if(
+    const TaggedVariant<Tags...>* variant) {
+  if (variant != nullptr and holds_alternative<Tag>(*variant)) {
+    return &get<Tag>(*variant);
+  } else {
+    return nullptr;
+  }
+}
+template <typename Tag, typename... Tags>
+constexpr typename Tag::type* get_if(TaggedVariant<Tags...>* variant) {
+  if (variant != nullptr and holds_alternative<Tag>(*variant)) {
+    return &get<Tag>(*variant);
+  } else {
+    return nullptr;
+  }
+}
+/// @}
+
+template <typename... Tags>
+constexpr bool operator==(const TaggedVariant<Tags...>& a,
+                          const TaggedVariant<Tags...>& b) {
+  return a.data_ == b.data_;
+}
+template <typename... Tags>
+constexpr bool operator!=(const TaggedVariant<Tags...>& a,
+                          const TaggedVariant<Tags...>& b) {
+  return not(a == b);
+}
+template <typename... Tags>
+constexpr bool operator<(const TaggedVariant<Tags...>& a,
+                         const TaggedVariant<Tags...>& b) {
+  return a.data_ < b.data_;
+}
+template <typename... Tags>
+constexpr bool operator>(const TaggedVariant<Tags...>& a,
+                         const TaggedVariant<Tags...>& b) {
+  return b < a;
+}
+template <typename... Tags>
+constexpr bool operator<=(const TaggedVariant<Tags...>& a,
+                          const TaggedVariant<Tags...>& b) {
+  return not(b < a);
+}
+template <typename... Tags>
+constexpr bool operator>=(const TaggedVariant<Tags...>& a,
+                          const TaggedVariant<Tags...>& b) {
+  return not(a < b);
+}
+
+template <
+    typename... Tags,
+    Requires<(... and (std::is_move_constructible_v<typename Tags::type> and
+                       std::is_swappable_v<typename Tags::type>))> = nullptr>
+constexpr void swap(TaggedVariant<Tags...>& a,
+                    TaggedVariant<Tags...>& b) noexcept(noexcept(a.swap(b))) {
+  a.swap(b);
+}
+
+template <typename... Tags>
+template <
+    typename... OtherTags,
+    Requires<tmpl::size<tmpl::list_difference<TaggedVariant<OtherTags...>,
+                                              TaggedVariant<Tags...>>>::value ==
+             0>>
+constexpr TaggedVariant<Tags...>::TaggedVariant(
+    TaggedVariant<OtherTags...>&& other)
+    : TaggedVariant(visit(
+          []<typename Tag>(
+              std::pair<tmpl::type_<Tag>, typename Tag::type&&> entry) {
+            return TaggedVariant(std::in_place_type<Tag>,
+                                 std::move(entry.second));
+          },
+          std::move(other))) {}
+
+template <typename... Tags>
+template <
+    typename... OtherTags,
+    Requires<tmpl::size<tmpl::list_difference<TaggedVariant<OtherTags...>,
+                                              TaggedVariant<Tags...>>>::value ==
+             0>>
+constexpr TaggedVariant<Tags...>& TaggedVariant<Tags...>::operator=(
+    TaggedVariant<OtherTags...>&& other) {
+  visit(
+      [&]<typename Tag>(
+          std::pair<tmpl::type_<Tag>, typename Tag::type&&> entry) {
+        emplace<Tag>(std::move(entry.second));
+      },
+      std::move(other));
+  return *this;
+}
+}  // namespace variants
+
+namespace std {
+template <typename... Tags>
+// https://github.com/llvm/llvm-project/issues/45454
+// NOLINTNEXTLINE(cert-dcl58-cpp)
+struct hash<::variants::TaggedVariant<Tags...>> {
+  size_t operator()(const ::variants::TaggedVariant<Tags...>& variant) const {
+    return std::hash<decltype(variant.data_)>{}(variant.data_);
+  }
+};
+}  // namespace std

--- a/src/DataStructures/TaggedVariant.hpp
+++ b/src/DataStructures/TaggedVariant.hpp
@@ -10,6 +10,7 @@
 #include <utility>
 #include <variant>
 
+#include "Options/String.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/Requires.hpp"
@@ -17,6 +18,10 @@
 #include "Utilities/TMPL.hpp"
 
 /// \cond
+namespace Options {
+template <typename... AlternativeLists>
+struct Alternatives;
+}  // namespace Options
 namespace PUP {
 class er;
 }  // namespace PUP
@@ -141,6 +146,15 @@ class TaggedVariant {
   }
 
   void pup(PUP::er& p) { p | data_; }
+
+  /// A TaggedVariant over option tags can be parsed as any of them.
+  /// @{
+  static constexpr Options::String help = "One of multiple options";
+  using options = tmpl::list<Options::Alternatives<tmpl::list<Tags>...>>;
+  template <typename Tag>
+  explicit TaggedVariant(tmpl::list<Tag> /*meta*/, typename Tag::type value)
+      : TaggedVariant(std::in_place_type<Tag>, std::move(value)) {}
+  /// @}
 
  private:
   template <typename R, typename Variant, typename Tag, typename Visitor>

--- a/tests/Unit/DataStructures/CMakeLists.txt
+++ b/tests/Unit/DataStructures/CMakeLists.txt
@@ -38,6 +38,7 @@ set(LIBRARY_SOURCES
   Test_StaticDeque.cpp
   Test_StripeIterator.cpp
   Test_TaggedContainers.cpp
+  Test_TaggedVariant.cpp
   Test_Tags.cpp
   Test_TempBuffer.cpp
   Test_Transpose.cpp

--- a/tests/Unit/DataStructures/Test_TaggedVariant.cpp
+++ b/tests/Unit/DataStructures/Test_TaggedVariant.cpp
@@ -1,0 +1,500 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <functional>
+#include <memory>
+#include <type_traits>
+#include <utility>
+#include <variant>
+
+#include "DataStructures/TaggedVariant.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Utilities/TMPL.hpp"
+
+#if (not defined(__clang__) and __GNUC__ < 12) or \
+    (defined(__clang__) and __clang__ < 15)
+#define LIMITED_CONSTEXPR
+#endif
+
+namespace {
+namespace Tags {
+struct Int {
+  using type = int;
+};
+
+template <typename T>
+struct Templated {
+  using type = T;
+};
+
+struct MoveOnly {
+  using type = std::unique_ptr<int>;
+};
+}  // namespace Tags
+
+constexpr variants::TaggedVariant<Tags::Int> simple_variant(
+    std::in_place_type<Tags::Int>, 4);
+static_assert(simple_variant.index() == 0);
+static_assert(not simple_variant.valueless_by_exception());
+static_assert(holds_alternative<Tags::Int>(simple_variant));
+static_assert(get<Tags::Int>(simple_variant) == 4);
+
+// [construct single]
+constexpr variants::TaggedVariant<Tags::Int> simple_variant2(4);
+// [construct single]
+static_assert(simple_variant2.index() == 0);
+static_assert(not simple_variant2.valueless_by_exception());
+static_assert(holds_alternative<Tags::Int>(simple_variant2));
+static_assert(get<Tags::Int>(simple_variant2) == 4);
+static_assert(simple_variant == simple_variant2);
+
+static_assert(visit([](const std::pair<tmpl::type_<Tags::Int>, const int&>&
+                           entry) { return entry.second; },
+                    simple_variant) == 4);
+
+// [construct in_place_type]
+constexpr variants::TaggedVariant<Tags::Int, Tags::Templated<double>>
+    int_variant(std::in_place_type<Tags::Int>, 1);
+// [construct in_place_type]
+static_assert(int_variant.index() == 0);
+static_assert(not int_variant.valueless_by_exception());
+static_assert(holds_alternative<Tags::Int>(int_variant));
+static_assert(not holds_alternative<Tags::Templated<double>>(int_variant));
+static_assert(get<Tags::Int>(int_variant) == 1);
+static_assert(visit(
+    [](const auto& entry) {
+      return std::is_same_v<typename std::decay_t<decltype(entry)>::first_type,
+                            tmpl::type_<Tags::Int>> and
+             entry.second == 1;
+    },
+    int_variant));
+
+constexpr variants::TaggedVariant<Tags::Int, Tags::Templated<double>>
+    double_variant(std::in_place_type<Tags::Templated<double>>, 4.56);
+static_assert(double_variant.index() == 1);
+static_assert(not double_variant.valueless_by_exception());
+static_assert(holds_alternative<Tags::Templated<double>>(double_variant));
+static_assert(not holds_alternative<Tags::Int>(double_variant));
+static_assert(get<Tags::Templated<double>>(double_variant) == 4.56);
+static_assert(visit(
+    [](const auto& entry) {
+      return std::is_same_v<typename std::decay_t<decltype(entry)>::first_type,
+                            tmpl::type_<Tags::Templated<double>>> and
+             entry.second == 4.56;
+    },
+    double_variant));
+
+static_assert(visit(
+    [](const auto& entry1, const auto& entry2) {
+      return std::is_same_v<typename std::decay_t<decltype(entry1)>::first_type,
+                            tmpl::type_<Tags::Int>> and
+             std::is_same_v<typename std::decay_t<decltype(entry2)>::first_type,
+                            tmpl::type_<Tags::Templated<double>>> and
+             entry1.second == 1 and entry2.second == 4.56;
+    },
+    int_variant, double_variant));
+
+constexpr variants::TaggedVariant<Tags::Int, Tags::Templated<double>>
+    double_variant2(std::in_place_type<Tags::Templated<double>>, -1.23);
+
+// NOLINTBEGIN(misc-redundant-expression)
+static_assert(int_variant == int_variant);
+static_assert(not(int_variant != int_variant));
+static_assert(not(int_variant < int_variant));
+static_assert(not(int_variant > int_variant));
+static_assert(int_variant <= int_variant);
+static_assert(int_variant >= int_variant);
+// NOLINTEND(misc-redundant-expression)
+
+static_assert(not(int_variant == double_variant));
+static_assert(int_variant != double_variant);
+static_assert(int_variant < double_variant);
+static_assert(not(int_variant > double_variant));
+static_assert(int_variant <= double_variant);
+static_assert(not(int_variant >= double_variant));
+
+static_assert(not(int_variant == double_variant2));
+static_assert(int_variant != double_variant2);
+static_assert(int_variant < double_variant2);
+static_assert(not(int_variant > double_variant2));
+static_assert(int_variant <= double_variant2);
+static_assert(not(int_variant >= double_variant2));
+
+static_assert(not(double_variant == double_variant2));
+static_assert(double_variant != double_variant2);
+static_assert(not(double_variant < double_variant2));
+static_assert(double_variant > double_variant2);
+static_assert(not(double_variant <= double_variant2));
+static_assert(double_variant >= double_variant2);
+
+constexpr variants::TaggedVariant<Tags::Int, Tags::Templated<double>>
+    default_variant{};
+static_assert(holds_alternative<Tags::Int>(default_variant));
+
+constexpr variants::TaggedVariant<Tags::Int, Tags::Templated<double>>
+    converted_variant = variants::TaggedVariant<Tags::Templated<double>>(4.56);
+static_assert(converted_variant == double_variant);
+static_assert([]() {
+  variants::TaggedVariant<Tags::Int, Tags::Templated<double>> variant(
+      std::in_place_type<Tags::Templated<double>>, 4.56);
+  const variants::TaggedVariant<Tags::Int, Tags::Templated<double>>
+      assigned_variant = std::move(variant);
+  return converted_variant == assigned_variant;
+}());
+static_assert([]() {
+  variants::TaggedVariant<Tags::Templated<double>> variant(4.56);
+  const variants::TaggedVariant<Tags::Int, Tags::Templated<double>>
+      converted_variant2 = std::move(variant);
+  return converted_variant == converted_variant2;
+}());
+
+static_assert([]() {
+  // [convert]
+  variants::TaggedVariant<Tags::Int, Tags::Templated<double>> input(
+      std::in_place_type<Tags::Int>, 4);
+  variants::TaggedVariant<Tags::Templated<double>, Tags::Templated<int>,
+                          Tags::Int>
+      complex_converted(std::move(input));
+  return get<Tags::Int>(complex_converted) == 4;
+  // [convert]
+}());
+
+static_assert([]() {
+  variants::TaggedVariant<Tags::Int, Tags::Templated<double>> variant(
+      std::in_place_type<Tags::Templated<double>>, 1.23);
+  decltype(auto) lvalue_mut = get<Tags::Templated<double>>(variant);
+  decltype(auto) lvalue_const =
+      get<Tags::Templated<double>>(std::as_const(variant));
+  decltype(auto) rvalue_mut = get<Tags::Templated<double>>(std::move(variant));
+  decltype(auto) rvalue_const =
+  // NOLINTNEXTLINE(performance-move-const-arg)
+      get<Tags::Templated<double>>(std::move(std::as_const(variant)));
+  decltype(auto) if_mut = get_if<Tags::Templated<double>>(&variant);
+  decltype(auto) if_const =
+      get_if<Tags::Templated<double>>(&std::as_const(variant));
+
+  static_assert(std::is_same_v<decltype(lvalue_mut), double&>);
+  static_assert(std::is_same_v<decltype(lvalue_const), const double&>);
+  static_assert(std::is_same_v<decltype(rvalue_mut), double&&>);
+  static_assert(std::is_same_v<decltype(rvalue_const), const double&&>);
+  static_assert(std::is_same_v<decltype(if_mut), double*>);
+  static_assert(std::is_same_v<decltype(if_const), const double*>);
+
+  variants::TaggedVariant<Tags::Int, Tags::Templated<double>>* const null_mut =
+      nullptr;
+  const variants::TaggedVariant<Tags::Int, Tags::Templated<double>>* const
+      null_const = nullptr;
+
+  return lvalue_mut == 1.23 and &lvalue_mut == &lvalue_const and
+         &lvalue_mut == &rvalue_mut and &lvalue_mut == &rvalue_const and
+         &lvalue_mut == if_mut and &lvalue_mut == if_const and
+         get_if<Tags::Int>(&variant) == nullptr and
+         get_if<Tags::Int>(&std::as_const(variant)) == nullptr and
+         get_if<Tags::Int>(null_mut) == nullptr and
+         get_if<Tags::Int>(null_const) == nullptr;
+}());
+
+constexpr bool test_emplace() {
+  // [emplace]
+  variants::TaggedVariant<Tags::Int, Tags::Templated<double>> variant{};
+  decltype(auto) emplace_result =
+      variant.emplace<Tags::Templated<double>>(1.23);
+  // [emplace]
+  static_assert(std::is_same_v<decltype(emplace_result), double&>);
+  return variant.index() == 1 and emplace_result == 1.23 and
+         &emplace_result == &get<Tags::Templated<double>>(variant);
+}
+#ifndef LIMITED_CONSTEXPR
+// Tested at runtime below
+static_assert(test_emplace());
+#endif
+
+static_assert([]() {
+  variants::TaggedVariant<Tags::Int> v{};
+  visit(
+      []<typename Entry>(const Entry& /*entry*/) {
+        static_assert(
+            std::is_same_v<Entry, std::pair<tmpl::type_<Tags::Int>, int&>>);
+      },
+      v);
+  return true;
+}());
+static_assert([]() {
+  const variants::TaggedVariant<Tags::Int> v{};
+  visit(
+      []<typename Entry>(const Entry& /*entry*/) {
+        static_assert(
+            std::is_same_v<Entry,
+                           std::pair<tmpl::type_<Tags::Int>, const int&>>);
+      },
+      v);
+  return true;
+}());
+static_assert([]() {
+  variants::TaggedVariant<Tags::Int> v{};
+  visit(
+      []<typename Entry>(const Entry& /*entry*/) {
+        static_assert(
+            std::is_same_v<Entry, std::pair<tmpl::type_<Tags::Int>, int&&>>);
+      },
+      std::move(v));
+  return true;
+}());
+static_assert([]() {
+  const variants::TaggedVariant<Tags::Int> v{};
+  visit(
+      []<typename Entry>(const Entry& /*entry*/) {
+        static_assert(
+            std::is_same_v<Entry,
+                           std::pair<tmpl::type_<Tags::Int>, const int&&>>);
+      },
+      std::move(v));  // NOLINT(performance-move-const-arg)
+  return true;
+}());
+
+static_assert([]() {
+  variants::TaggedVariant<Tags::Int> v1{};
+  variants::TaggedVariant<Tags::Templated<double>> v2{};
+  visit(
+      []<typename Entry1, typename Entry2>(const Entry1& /*entry1*/,
+                                           const Entry2& /*entry2*/) {
+        static_assert(
+            std::is_same_v<Entry1, std::pair<tmpl::type_<Tags::Int>, int&>>);
+        static_assert(
+            std::is_same_v<
+                Entry2,
+                std::pair<tmpl::type_<Tags::Templated<double>>, double&&>>);
+      },
+      v1, std::move(v2));
+  return true;
+}());
+
+static_assert(
+    visit<double>([](const auto& entry) { return entry.second; },
+                  variants::TaggedVariant<Tags::Int, Tags::Templated<double>>(
+                      std::in_place_type<Tags::Templated<double>>, 1.23)) ==
+    1.23);
+// Check this compiles
+static_assert(
+    (visit<void>([](const auto& entry) { return entry.second; },
+                 variants::TaggedVariant<Tags::Int, Tags::Templated<double>>(
+                     std::in_place_type<Tags::Templated<double>>, 1.23)),
+     true));
+
+static_assert(variants::visit([]() { return true; }));
+static_assert(variants::visit<bool>([]() { return true; }));
+
+struct DerivedFromVariant : variants::TaggedVariant<Tags::Int> {};
+static_assert(variants::visit([](const auto& /*unused*/) { return true; },
+                              DerivedFromVariant{}));
+
+constexpr bool test_swap() {
+  variants::TaggedVariant<Tags::Int, Tags::Templated<double>> v1(
+      std::in_place_type<Tags::Int>, 5);
+  variants::TaggedVariant<Tags::Int, Tags::Templated<double>> v2(
+      std::in_place_type<Tags::Templated<double>>, 1.23);
+  v1.swap(v2);
+  if (get<Tags::Templated<double>>(v1) != 1.23 or get<Tags::Int>(v2) != 5) {
+    return false;
+  }
+  using std::swap;
+  swap(v1, v2);
+  return get<Tags::Int>(v1) == 5 and get<Tags::Templated<double>>(v2) == 1.23;
+}
+#ifndef LIMITED_CONSTEXPR
+// Tested at runtime below
+static_assert(test_swap());
+#endif
+
+struct ValuelessCausingType {
+  ValuelessCausingType() = default;
+  [[noreturn]] ValuelessCausingType(const ValuelessCausingType& /*other*/) {
+    throw 0;
+  }
+  ValuelessCausingType& operator=(const ValuelessCausingType&) = delete;
+  ~ValuelessCausingType() = default;
+};
+
+bool operator==(const ValuelessCausingType& /*a*/,
+                const ValuelessCausingType& /*b*/) {
+  return true;
+}
+bool operator<(const ValuelessCausingType& /*a*/,
+               const ValuelessCausingType& /*b*/) {
+  return false;
+}
+
+struct ValuelessCausingTag {
+  using type = ValuelessCausingType;
+};
+
+SPECTRE_TEST_CASE("Unit.DataStructures.TaggedVariant",
+                  "[DataStructures][Unit]") {
+  // Test stuff that can't be done in constexpr
+
+  // errors
+  {
+    const variants::TaggedVariant<Tags::Int, Tags::Templated<double>> variant(
+        std::in_place_type<Tags::Int>, 3);
+    CHECK_THROWS_AS(get<Tags::Templated<double>>(variant),
+                    std::bad_variant_access);
+  }
+
+  // Repeated type
+  {
+    const variants::TaggedVariant<Tags::Int, Tags::Templated<int>>
+        repeated_int_variant(std::in_place_type<Tags::Templated<int>>, 4);
+    CHECK(repeated_int_variant.index() == 1);
+    CHECK(not repeated_int_variant.valueless_by_exception());
+    CHECK(holds_alternative<Tags::Templated<int>>(repeated_int_variant));
+    CHECK(not holds_alternative<Tags::Int>(repeated_int_variant));
+    CHECK(get<Tags::Templated<int>>(repeated_int_variant) == 4);
+    CHECK_THROWS_AS(get<Tags::Int>(repeated_int_variant),
+                    std::bad_variant_access);
+  }
+
+  // move-only types (easier at runtime)
+  {
+    using Variant = variants::TaggedVariant<Tags::Int, Tags::MoveOnly>;
+    const Variant v1(std::in_place_type<Tags::MoveOnly>,
+                     std::make_unique<int>(1));
+    CHECK(*get<Tags::MoveOnly>(v1) == 1);
+    Variant v2(
+        variants::TaggedVariant<Tags::MoveOnly>(std::make_unique<int>(2)));
+    CHECK(*get<Tags::MoveOnly>(v2) == 2);
+    Variant v3{};
+    v3 = variants::TaggedVariant<Tags::MoveOnly>(std::make_unique<int>(3));
+    CHECK(*get<Tags::MoveOnly>(v3) == 3);
+    Variant v4(std::move(v3));
+    CHECK(*get<Tags::MoveOnly>(v4) == 3);
+    Variant v5{};
+    v5 = std::move(v4);
+    CHECK(*get<Tags::MoveOnly>(v5) == 3);
+    Variant v6{};
+    v6.emplace<Tags::MoveOnly>(std::make_unique<int>(6));
+    CHECK(*get<Tags::MoveOnly>(v6) == 6);
+
+    visit(
+        []<typename Tag>(const std::pair<tmpl::type_<Tag>,
+                                         const typename Tag::type&>& entry) {
+          CHECK(std::is_same_v<Tag, Tags::MoveOnly>);
+          if constexpr (std::is_same_v<Tag, Tags::MoveOnly>) {
+            CHECK(*entry.second == 1);
+          }
+        },
+        v1);
+    visit(
+        []<typename Tag>(
+            const std::pair<tmpl::type_<Tag>, typename Tag::type&&>& entry) {
+          CHECK(std::is_same_v<Tag, Tags::MoveOnly>);
+          if constexpr (std::is_same_v<Tag, Tags::MoveOnly>) {
+            CHECK(*entry.second == 6);
+          }
+        },
+        std::move(v6));
+  }
+
+  // valueless_by_exception
+  {
+    variants::TaggedVariant<Tags::Int, ValuelessCausingTag> valueless_variant{};
+    CHECK_THROWS_AS(
+        (valueless_variant =
+             variants::TaggedVariant<Tags::Int, ValuelessCausingTag>(
+                 std::in_place_type<ValuelessCausingTag>)),
+        int);
+    CHECK(valueless_variant.valueless_by_exception());
+    CHECK(valueless_variant.index() == std::variant_npos);
+    CHECK(not holds_alternative<Tags::Int>(valueless_variant));
+    CHECK(not holds_alternative<ValuelessCausingTag>(valueless_variant));
+    CHECK_THROWS_AS(get<Tags::Int>(valueless_variant), std::bad_variant_access);
+    CHECK_THROWS_AS(visit([](const auto& /*unused*/) {}, valueless_variant),
+                    std::bad_variant_access);
+
+    variants::TaggedVariant<Tags::Int, ValuelessCausingTag> good_variant(
+        std::in_place_type<Tags::Int>, 5);
+
+    CHECK(valueless_variant == valueless_variant);
+    CHECK_FALSE(valueless_variant != valueless_variant);
+    CHECK_FALSE(valueless_variant < valueless_variant);
+    CHECK_FALSE(valueless_variant > valueless_variant);
+    CHECK(valueless_variant <= valueless_variant);
+    CHECK(valueless_variant >= valueless_variant);
+
+    CHECK_FALSE(good_variant == valueless_variant);
+    CHECK(good_variant != valueless_variant);
+    CHECK_FALSE(good_variant < valueless_variant);
+    CHECK(good_variant > valueless_variant);
+    CHECK_FALSE(good_variant <= valueless_variant);
+    CHECK(good_variant >= valueless_variant);
+
+    CHECK_FALSE(valueless_variant == good_variant);
+    CHECK(valueless_variant != good_variant);
+    CHECK(valueless_variant < good_variant);
+    CHECK_FALSE(valueless_variant > good_variant);
+    CHECK(valueless_variant <= good_variant);
+    CHECK_FALSE(valueless_variant >= good_variant);
+  }
+
+  // hashing
+  {
+    using Variant = variants::TaggedVariant<Tags::Int, Tags::Templated<double>>;
+    const Variant v1(std::in_place_type<Tags::Int>, 1);
+    const Variant v2(std::in_place_type<Tags::Templated<double>>, 2.0);
+    const std::hash<Variant> h{};
+    CHECK(h(v1) != h(v2));
+  }
+
+  // visit example
+  {
+    // clang-tidy is complaining about a move in a loop.  Presumably
+    // the "do while (false)" in the CHECK macro.
+    // NOLINTBEGIN(bugprone-use-after-move)
+    // [visit]
+    const variants::TaggedVariant<Tags::Int, Tags::Templated<double>>
+        visit_example(std::in_place_type<Tags::Int>, 5);
+    CHECK(visit(
+              []<typename Tag>(
+                  const std::pair<tmpl::type_<Tag>, const typename Tag::type&>&
+                      entry) {
+                if constexpr (std::is_same_v<Tag, Tags::Int>) {
+                  // Deduced return types must match for all tags if
+                  // no template argument is given to visit.
+                  return static_cast<double>(entry.second + 1);
+                } else {
+                  static_assert(std::is_same_v<Tag, Tags::Templated<double>>);
+                  return entry.second;
+                }
+              },
+              visit_example) == 6.0);
+    variants::TaggedVariant<Tags::Int, Tags::Templated<double>> visit_example2(
+        std::in_place_type<Tags::Templated<double>>, 1.23);
+    CHECK(visit<double>(
+              []<typename Tag>(const std::pair<tmpl::type_<Tag>,
+                                               typename Tag::type&&>& entry) {
+                if constexpr (std::is_same_v<Tag, Tags::Int>) {
+                  // Implicitly converted to double because of
+                  // template argument of visit.
+                  return entry.second + 1;
+                } else {
+                  static_assert(std::is_same_v<Tag, Tags::Templated<double>>);
+                  return entry.second;
+                }
+              },
+              std::move(visit_example2)) == 1.23);
+    // [visit]
+    // NOLINTEND(bugprone-use-after-move)
+  }
+
+  test_serialization(
+      variants::TaggedVariant<Tags::Int, Tags::Templated<double>>(
+          std::in_place_type<Tags::Templated<double>>, 1.23));
+
+#ifdef LIMITED_CONSTEXPR
+  // Tested in static_asserts for other compilers.
+  CHECK(test_emplace());
+  CHECK(test_swap());
+#endif
+}
+}  // namespace


### PR DESCRIPTION
I have mixed feelings on the `visit` interface.  The version here follows `std::visit` and allows multiple TaggedVariants to be passed to a single call, but this makes reporting the tag awkward and, in particular, prevents implicit conversions between reference types in the visitor arguments.  An alternative would be to restrict to the (I assume vastly most common) case of a single TaggedVariant and pass the tag and value as separate arguments, which would fix all the conversion trouble.  Opinions are welcome.

Ping @knelli2 

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
