### PR TITLE
Add stub M1 initial guess

### DIFF
--- a/src/Evolution/Systems/RadiationTransport/M1Grey/CMakeLists.txt
+++ b/src/Evolution/Systems/RadiationTransport/M1Grey/CMakeLists.txt
@@ -48,3 +48,4 @@ target_link_libraries(
 
 add_subdirectory(BoundaryConditions)
 add_subdirectory(BoundaryCorrections)
+add_subdirectory(Imex)

--- a/src/Evolution/Systems/RadiationTransport/M1Grey/Imex/CMakeLists.txt
+++ b/src/Evolution/Systems/RadiationTransport/M1Grey/Imex/CMakeLists.txt
@@ -1,0 +1,15 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+spectre_target_sources(
+  ${LIBRARY}
+  PRIVATE
+  )
+
+spectre_target_headers(
+  ${LIBRARY}
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  InitialGuess.hpp
+  InitialGuess.tpp
+  )

--- a/src/Evolution/Systems/RadiationTransport/M1Grey/Imex/InitialGuess.hpp
+++ b/src/Evolution/Systems/RadiationTransport/M1Grey/Imex/InitialGuess.hpp
@@ -1,0 +1,58 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <vector>
+
+#include "DataStructures/Tags/TempTensor.hpp"
+#include "Evolution/Imex/GuessResult.hpp"
+#include "Evolution/Systems/RadiationTransport/M1Grey/Tags.hpp"
+#include "PointwiseFunctions/GeneralRelativity/TagsDeclarations.hpp"
+#include "Utilities/Gsl.hpp"
+
+/// \cond
+class DataVector;
+template <typename>
+class Variables;
+namespace gsl {
+template <typename T>
+class not_null;
+}  // namespace gsl
+/// \endcond
+
+namespace M1Grey::Imex {
+
+template <typename NeutrinoSpeciesList>
+struct InitialGuess;
+
+template <typename... NeutrinoSpecies>
+struct InitialGuess<tmpl::list<NeutrinoSpecies...>> {
+  using return_tags =
+      tmpl::list<RadiationTransport::M1Grey::Tags::TildeE<Frame::Inertial,
+                                                          NeutrinoSpecies>...,
+                 RadiationTransport::M1Grey::Tags::TildeS<Frame::Inertial,
+                                                          NeutrinoSpecies>...>;
+  using argument_tags = tmpl::list<
+      RadiationTransport::M1Grey::Tags::TildeJ<NeutrinoSpecies>...,
+      RadiationTransport::M1Grey::Tags::TildeHSpatial<Frame::Inertial,
+                                                      NeutrinoSpecies>...,
+      gr::Tags::Lapse<DataVector>, gr::Tags::SpatialMetric<DataVector, 3>>;
+
+  // This is a stub implementation for initial guesses for the M1 system, should
+  // a more accurate guess in the future be needed. Currently, the M1 system
+  // just uses the explicit solution as an initial guess.
+  template <typename return_tags>
+  static std::vector<imex::GuessResult> apply(
+      [[maybe_unused]] gsl::not_null<Scalar<DataVector>*> tilde_e,
+      [[maybe_unused]] gsl::not_null<tnsr::i<DataVector, 3>*> tilde_s,
+      [[maybe_unused]] const Scalar<DataVector>& tilde_j,
+      [[maybe_unused]] const tnsr::i<DataVector, 3>& tilde_h_spatial,
+      [[maybe_unused]] const Scalar<DataVector>& lapse,
+      [[maybe_unused]] const tnsr::ii<DataVector, 3, Frame::Inertial>&
+          spatial_metric,
+      [[maybe_unused]] const Variables<return_tags>& inhomogeneous_terms,
+      [[maybe_unused]] double implicit_weight);
+};
+
+}  // namespace M1Grey::Imex

--- a/src/Evolution/Systems/RadiationTransport/M1Grey/Imex/InitialGuess.tpp
+++ b/src/Evolution/Systems/RadiationTransport/M1Grey/Imex/InitialGuess.tpp
@@ -1,0 +1,53 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+#pragma once
+
+#include "Evolution/Systems/RadiationTransport/M1Grey/Imex/InitialGuess.hpp"
+
+#include <vector>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tags/TempTensor.hpp"
+#include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Evolution/Imex/GuessResult.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace M1Grey::Imex {
+
+template <typename inhomogeneous_types>
+static std::vector<imex::GuessResult> apply(
+    [[maybe_unused]] gsl::not_null<Scalar<DataVector>*> tilde_e,
+    [[maybe_unused]] gsl::not_null<tnsr::i<DataVector, 3>*> tilde_s,
+    [[maybe_unused]] const Scalar<DataVector>& tilde_j,
+    [[maybe_unused]] const tnsr::i<DataVector, 3>& tilde_h_spatial,
+    [[maybe_unused]] const Scalar<DataVector>& lapse,
+    [[maybe_unused]] const tnsr::ii<DataVector, 3, Frame::Inertial>&
+        spatial_metric,
+    [[maybe_unused]] const Variables<inhomogeneous_types>& inhomogeneous_terms,
+    [[maybe_unused]] const double implicit_weight) {
+  //  Note the empty return guesses the explicit result
+  return {};
+}
+
+using NeutrinoSpecies = neutrinos::ElectronNeutrinos<1>;
+
+using tilde_e_tag =
+    RadiationTransport::M1Grey::Tags::TildeE<Frame::Inertial, NeutrinoSpecies>;
+using tilde_s_tag =
+    RadiationTransport::M1Grey::Tags::TildeS<Frame::Inertial, NeutrinoSpecies>;
+using return_tags = tmpl::list<tilde_e_tag, tilde_s_tag>;
+
+// explicit instantiation
+template std::vector<imex::GuessResult> apply<return_tags>(
+    gsl::not_null<Scalar<DataVector>*> tilde_e,
+    gsl::not_null<tnsr::i<DataVector, 3>*> tilde_s,
+    const Scalar<DataVector>& tilde_j,
+    const tnsr::i<DataVector, 3>& tilde_h_spatial,
+    const Scalar<DataVector>& lapse,
+    const tnsr::ii<DataVector, 3, Frame::Inertial>& spatial_metric,
+    const Variables<return_tags>& inhomogeneous_terms, double implicit_weight);
+
+}  // namespace M1Grey::Imex

--- a/tests/Unit/Evolution/Systems/RadiationTransport/M1Grey/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/RadiationTransport/M1Grey/CMakeLists.txt
@@ -9,6 +9,7 @@ set(LIBRARY_SOURCES
   BoundaryCorrections/Test_Rusanov.cpp
   Test_Actions.cpp
   Test_Fluxes.cpp
+  Test_InitialGuess.cpp
   Test_M1Closure.cpp
   Test_M1HydroCoupling.cpp
   Test_Sources.cpp

--- a/tests/Unit/Evolution/Systems/RadiationTransport/M1Grey/Test_InitialGuess.cpp
+++ b/tests/Unit/Evolution/Systems/RadiationTransport/M1Grey/Test_InitialGuess.cpp
@@ -1,0 +1,60 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tags/TempTensor.hpp"
+#include "Evolution/Systems/RadiationTransport/M1Grey/Imex/InitialGuess.tpp"
+#include "Evolution/Systems/RadiationTransport/M1Grey/Tags.hpp"
+#include "Evolution/Systems/RadiationTransport/Tags.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Framework/TestingFramework.hpp"
+#include "Utilities/Gsl.hpp"
+
+using NeutrinoSpecies = neutrinos::ElectronNeutrinos<1>;
+
+using tilde_e_tag =
+    RadiationTransport::M1Grey::Tags::TildeE<Frame::Inertial, NeutrinoSpecies>;
+using tilde_s_tag =
+    RadiationTransport::M1Grey::Tags::TildeS<Frame::Inertial, NeutrinoSpecies>;
+using return_tags = tmpl::list<tilde_e_tag, tilde_s_tag>;
+
+SPECTRE_TEST_CASE("Evolution.Systems.RadiationTransport.M1Grey.InitialGuess",
+                  "[Unit][M1Grey]") {
+  // initialize
+  const size_t num_points = 3;
+  Scalar<DataVector> tilde_e_old{num_points, 6.1};
+
+  tnsr::i<DataVector, 3> tilde_s_old;
+  get<0>(tilde_s_old) = DataVector(num_points, 0.0);
+  get<1>(tilde_s_old) = DataVector(num_points, 1.1);
+  get<2>(tilde_s_old) = DataVector(num_points, 2.2);
+
+  // old values to compare against
+  Scalar<DataVector> tilde_e_base = tilde_e_old;
+  tnsr::i<DataVector, 3> tilde_s_base = tilde_s_old;
+  Scalar<DataVector>* tilde_e = &tilde_e_base;
+  tnsr::i<DataVector, 3>* tilde_s = &tilde_s_base;
+
+  // arguments for calculation
+  const Scalar<DataVector> tilde_j(num_points, 0.0);
+  const tnsr::i<DataVector, 3> tilde_h_spatial(num_points, 2.1);
+  const Scalar<DataVector> lapse(num_points, 0.8);
+  tnsr::ii<DataVector, 3, Frame::Inertial> spatial_metric;
+
+  get<0, 0>(spatial_metric) = DataVector(num_points, 1.0);
+  get<1, 1>(spatial_metric) = DataVector(num_points, 1.0);
+  get<2, 2>(spatial_metric) = DataVector(num_points, 1.0);
+
+  Variables<return_tags> inhomogeneous_terms;
+  const double implicit_weight = 1.0;
+
+  auto null_result = M1Grey::Imex::apply<return_tags>(
+      tilde_e, tilde_s, tilde_j, tilde_h_spatial, lapse, spatial_metric,
+      inhomogeneous_terms, implicit_weight);
+
+  // tilde_e and tilde_s should remain unchanged
+  CHECK(*tilde_e == tilde_e_old);
+  CHECK(*tilde_s == tilde_s_old);
+  // nothing should be returned
+  CHECK(null_result.empty());
+}


### PR DESCRIPTION
## Proposed changes

<!--
At a high level, describe what this PR does.
-->

Adds framework to modify the initial guess for the implicit step of the M1 system.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

Currently, only the explicit solution is used for the initial guess.  This file is unused for now.
