### PR TITLE
Fix BuildDockerContainer workflow

### DIFF
--- a/.github/workflows/BuildDockerContainer.yaml
+++ b/.github/workflows/BuildDockerContainer.yaml
@@ -27,6 +27,20 @@ jobs:
     # deployment. On forks where you set your own secrets for authentication
     # with DockerHub you can choose not to protect this environment.
     environment: deploy-containers
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+          # Development container for building and testing
+          - ubuntu_version: "22.04"
+            platforms: >
+              ${{ inputs.build_arm && 'linux/amd64,linux/arm64'
+              || 'linux/amd64' }}
+            tag: "dev"
+          # Container for deploying static execs
+          - ubuntu_version: "18.04"
+            platforms: "linux/amd64"
+            tag: "dev1804"
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -56,53 +70,11 @@ jobs:
           context: .
           file: "./containers/Dockerfile.buildenv"
           target: dev
-          tags: ${{ inputs.image_name }}:dev
-          platforms: >
-            ${{ inputs.build_arm && 'linux/amd64,linux/arm64'
-            || 'linux/amd64' }}
-          build-args: PARALLEL_MAKE_ARG=-j4
-      - name: Build CI container
-        uses: docker/build-push-action@v5
-        with:
-          push: true
-          context: .
-          file: "./containers/Dockerfile.buildenv"
-          target: ci
-          tags: ${{ inputs.image_name }}:ci
-          # No ARM container for CI because GitHub doesn't host ARM runners yet
-          platforms: linux/amd64
-          build-args: PARALLEL_MAKE_ARG=-j4
-
-  build_1804_container:
-    # Note: this container is used for deploying static execs
-    name: Build and deploy Ubuntu 18.04 container
-    runs-on: ubuntu-latest
-    # This environment can be protected to require manual approval before
-    # deployment. On forks where you set your own secrets for authentication
-    # with DockerHub you can choose not to protect this environment.
-    environment: deploy-containers
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      - name: Login to DockerHub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Build dev container for Ubuntu 18.04
-        uses: docker/build-push-action@v5
-        with:
-          push: true
-          context: .
-          file: "./containers/Dockerfile.buildenv"
-          target: dev
-          tags: ${{ inputs.image_name }}:dev1804
-          platforms: linux/amd64
+          tags: ${{ inputs.image_name }}:${{ matrix.tag }}
+          platforms: ${{ matrix.platforms }}
           build-args: |
             PARALLEL_MAKE_ARG=-j4
-            UBUNTU_VERSION=18.04
+            UBUNTU_VERSION=${{ matrix.ubuntu_version}}
 
   run_tests:
     name: Test
@@ -110,4 +82,4 @@ jobs:
     needs: build_container
     secrets: inherit
     with:
-      container: ${{ inputs.image_name }}:ci
+      container: ${{ inputs.image_name }}:dev

--- a/containers/Dockerfile.buildenv
+++ b/containers/Dockerfile.buildenv
@@ -427,14 +427,16 @@ RUN apt-get update -y \
 # Install bibtex for Doxygen bibliography management
 # We first install the TeXLive infrastructure according to the configuration in
 # support/TeXLive/texlive.profile and then use it to install the bibtex package.
-RUN mkdir /work/texlive && cd /work/texlive \
+RUN if [ ${UBUNTU_VERSION} = 22.04 ]; then \
+    mkdir /work/texlive && cd /work/texlive \
     && wget http://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz \
     && tar -xzf install-tl-unx.tar.gz \
     && rm install-tl-unx.tar.gz \
     && wget https://raw.githubusercontent.com/sxs-collaboration/spectre/develop/support/TeXLive/texlive.profile \
     && install-tl-*/install-tl -profile=texlive.profile \
     && rm -r install-tl-* texlive.profile install-tl.log \
-    && /work/texlive/bin/${TEX_ARCH}-linux/tlmgr install bibtex
+    && /work/texlive/bin/${TEX_ARCH}-linux/tlmgr install bibtex \
+    ; fi
 ENV PATH="${PATH}:/work/texlive/bin/${TEX_ARCH}-linux"
 
 # Remove the apt-get cache in order to reduce image size


### PR DESCRIPTION
This failed to build the CI container because we deleted it. Only build dev and dev1804 now, and combine the jobs into a matrix.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
