### PR TITLE
Add is_equilibrium and is_barotropic tests to EOSes

### DIFF
--- a/src/PointwiseFunctions/Hydro/EquationsOfState/Barotropic3D.hpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/Barotropic3D.hpp
@@ -15,6 +15,7 @@
 #include <memory>
 #include <pup.h>
 
+#include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Options/String.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
@@ -99,7 +100,7 @@ class Barotropic3D : public EquationOfState<ColdEquilEos::is_relativistic, 3> {
    */
   Scalar<double> equilibrium_electron_fraction_from_density_temperature(
       const Scalar<double>& rest_mass_density,
-      const Scalar<double>& temperature) const {
+      const Scalar<double>& temperature) const override {
     return underlying_eos_
         .equilibrium_electron_fraction_from_density_temperature(
             rest_mass_density, temperature);
@@ -107,7 +108,7 @@ class Barotropic3D : public EquationOfState<ColdEquilEos::is_relativistic, 3> {
 
   Scalar<DataVector> equilibrium_electron_fraction_from_density_temperature(
       const Scalar<DataVector>& rest_mass_density,
-      const Scalar<DataVector>& temperature) const {
+      const Scalar<DataVector>& temperature) const override {
     return underlying_eos_
         .equilibrium_electron_fraction_from_density_temperature(
             rest_mass_density, temperature);

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/Barotropic3D.hpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/Barotropic3D.hpp
@@ -86,6 +86,9 @@ class Barotropic3D : public EquationOfState<ColdEquilEos::is_relativistic, 3> {
   /// \brief Returns `true` if the EOS is barotropic
   bool is_barotropic() const override { return true; }
 
+  /// \brief Returns `true` if the EOS is in beta-equilibrium
+  bool is_equilibrium() const override { return false; }
+
   bool operator==(const Barotropic3D<ColdEquilEos>& rhs) const;
 
   bool operator!=(const Barotropic3D<ColdEquilEos>& rhs) const;

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp
@@ -371,6 +371,11 @@ class EquationOfState<IsRelativistic, 2> : public PUP::able {
   /// \brief Returns `true` if the EOS is barotropic
   virtual bool is_barotropic() const = 0;
 
+  /// \brief Returns `true` if the EOS is in beta-equilibrium
+  virtual bool is_equilibrium() const {
+    return true;
+  }
+
   /// @{
   /*!
    * Computes the electron fraction in beta-equilibrium \f$Y_e^{\rm eq}\f$ from
@@ -570,6 +575,9 @@ class EquationOfState<IsRelativistic, 3> : public PUP::able {
 
   /// \brief Returns `true` if the EOS is barotropic
   virtual bool is_barotropic() const = 0;
+
+  /// \brief Returns `true` if the EOS is in beta-equilibrium
+  virtual bool is_equilibrium() const = 0;
 
   /// @{
   /*!

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp
@@ -581,6 +581,21 @@ class EquationOfState<IsRelativistic, 3> : public PUP::able {
 
   /// @{
   /*!
+   * Computes the electron fraction in beta-equilibrium \f$Y_e^{\rm eq}\f$ from
+   * the rest mass density \f$\rho\f$ and the temperature \f$T\f$.
+   */
+  virtual Scalar<double> equilibrium_electron_fraction_from_density_temperature(
+      const Scalar<double>& /*rest_mass_density*/,
+      const Scalar<double>& /*temperature*/) const = 0;
+
+  virtual Scalar<DataVector>
+  equilibrium_electron_fraction_from_density_temperature(
+      const Scalar<DataVector>& /*rest_mass_density*/,
+      const Scalar<DataVector>& /*temperature*/) const = 0;
+  /// @}
+
+  /// @{
+  /*!
    * Computes the pressure \f$p\f$ from the rest mass density \f$\rho\f$, the
    * specific internal energy \f$\epsilon\f$ and electron fraction \f$Y_e\f$.
    */

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/Equilibrium3D.hpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/Equilibrium3D.hpp
@@ -15,6 +15,7 @@
 #include <memory>
 #include <pup.h>
 
+#include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Options/String.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
@@ -98,7 +99,7 @@ class Equilibrium3D : public EquationOfState<EquilEos::is_relativistic, 3> {
    */
   Scalar<double> equilibrium_electron_fraction_from_density_temperature(
       const Scalar<double>& rest_mass_density,
-      const Scalar<double>& temperature) const {
+      const Scalar<double>& temperature) const override{
     return underlying_eos_
         .equilibrium_electron_fraction_from_density_temperature(
             rest_mass_density, temperature);
@@ -106,7 +107,7 @@ class Equilibrium3D : public EquationOfState<EquilEos::is_relativistic, 3> {
 
   Scalar<DataVector> equilibrium_electron_fraction_from_density_temperature(
       const Scalar<DataVector>& rest_mass_density,
-      const Scalar<DataVector>& temperature) const {
+      const Scalar<DataVector>& temperature) const override {
     return underlying_eos_
         .equilibrium_electron_fraction_from_density_temperature(
             rest_mass_density, temperature);

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/Equilibrium3D.hpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/Equilibrium3D.hpp
@@ -85,6 +85,9 @@ class Equilibrium3D : public EquationOfState<EquilEos::is_relativistic, 3> {
   /// \brief Returns `true` if the EOS is barotropic
   bool is_barotropic() const override { return false; }
 
+  /// \brief Returns `true` if the EOS is in beta-equilibrium
+  bool is_equilibrium() const override { return true; }
+
   bool operator==(const Equilibrium3D<EquilEos>& rhs) const;
 
   bool operator!=(const Equilibrium3D<EquilEos>& rhs) const;

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/Tabulated3d.cpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/Tabulated3d.cpp
@@ -660,3 +660,12 @@ Tabulated3D<IsRelativistic>::Tabulated3D(const std::string& filename,
 
 template class EquationsOfState::Tabulated3D<true>;
 template class EquationsOfState::Tabulated3D<false>;
+
+template Scalar<double> EquationsOfState::Tabulated3D<true>::
+    equilibrium_electron_fraction_from_density_temperature_impl(
+        Tensor<double, brigand::list<>, brigand::list<>> const&,
+        Tensor<double, brigand::list<>, brigand::list<>> const&) const;
+template Scalar<DataVector> EquationsOfState::Tabulated3D<true>::
+    equilibrium_electron_fraction_from_density_temperature_impl(
+        Tensor<DataVector, brigand::list<>, brigand::list<>> const&,
+        Tensor<DataVector, brigand::list<>, brigand::list<>> const&) const;

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/Tabulated3d.hpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/Tabulated3d.hpp
@@ -13,6 +13,7 @@
 #include <limits>
 #include <pup.h>
 
+#include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "IO/H5/EosTable.hpp"
 #include "IO/H5/File.hpp"
@@ -129,7 +130,7 @@ class Tabulated3D : public EquationOfState<IsRelativistic, 3> {
   /// \brief Returns `true` if the EOS is barotropic
   bool is_barotropic() const override { return false; }
 
-  /// \breif Returns `true` if the EOS is in beta-equilibrium
+  /// \brief Returns `true` if the EOS is in beta-equilibrium
   bool is_equilibrium() const override { return false; }
 
   bool operator==(const Tabulated3D<IsRelativistic>& rhs) const;
@@ -148,14 +149,14 @@ class Tabulated3D : public EquationOfState<IsRelativistic, 3> {
    */
   Scalar<double> equilibrium_electron_fraction_from_density_temperature(
       const Scalar<double>& rest_mass_density,
-      const Scalar<double>& temperature) const {
+      const Scalar<double>& temperature) const override {
     return equilibrium_electron_fraction_from_density_temperature_impl<double>(
         rest_mass_density, temperature);
   }
 
   Scalar<DataVector> equilibrium_electron_fraction_from_density_temperature(
       const Scalar<DataVector>& rest_mass_density,
-      const Scalar<DataVector>& temperature) const {
+      const Scalar<DataVector>& temperature) const override {
     return equilibrium_electron_fraction_from_density_temperature_impl<
         DataVector>(rest_mass_density, temperature);
   }

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/Tabulated3d.hpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/Tabulated3d.hpp
@@ -129,6 +129,9 @@ class Tabulated3D : public EquationOfState<IsRelativistic, 3> {
   /// \brief Returns `true` if the EOS is barotropic
   bool is_barotropic() const override { return false; }
 
+  /// \breif Returns `true` if the EOS is in beta-equilibrium
+  bool is_equilibrium() const override { return false; }
+
   bool operator==(const Tabulated3D<IsRelativistic>& rhs) const;
 
   bool operator!=(const Tabulated3D<IsRelativistic>& rhs) const;

--- a/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_Barotropic2D.cpp
+++ b/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_Barotropic2D.cpp
@@ -30,6 +30,8 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.EquationsOfState.Barotropic2D",
   CHECK(eos.electron_fraction_upper_bound() == 1.0);
   CHECK(eos.temperature_lower_bound() == 0.0);
   CHECK(eos.temperature_upper_bound() == std::numeric_limits<double>::max());
+  CHECK(eos.is_barotropic());
+  CHECK(eos.is_equilibrium());
   {
     // DataVector functions
     const Scalar<DataVector> rest_mass_density{

--- a/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_Barotropic3D.cpp
+++ b/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_Barotropic3D.cpp
@@ -31,6 +31,8 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.EquationsOfState.Barotropic3D",
   CHECK(eos.electron_fraction_upper_bound() == 1.0);
   CHECK(eos.temperature_lower_bound() == 0.0);
   CHECK(eos.temperature_upper_bound() == std::numeric_limits<double>::max());
+  CHECK(eos.is_barotropic());
+  CHECK(not eos.is_equilibrium());
   {
     // DataVector functions
     const Scalar<DataVector> rest_mass_density{

--- a/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_DarkEnergyFluid.cpp
+++ b/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_DarkEnergyFluid.cpp
@@ -29,6 +29,7 @@ void check_bounds() {
   CHECK(max_double == eos.specific_internal_energy_upper_bound(1.0));
   CHECK(eos.baryon_mass() ==
         approx(hydro::units::geometric::default_baryon_mass));
+  CHECK(not eos.is_barotropic());
 }
 }  // namespace
 

--- a/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_Enthalpy.cpp
+++ b/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_Enthalpy.cpp
@@ -91,6 +91,7 @@ void check_exact() {
     CHECK(*eos.promote_to_2d_eos() == Barotropic2D<Enthalpy<Spectral>>(eos));
     CHECK(eos.baryon_mass() ==
           approx(hydro::units::geometric::default_baryon_mass));
+    CHECK(eos.is_barotropic());
   }
   // Test DataVector functions
   {

--- a/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_Equilibrium3D.cpp
+++ b/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_Equilibrium3D.cpp
@@ -42,6 +42,8 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.EquationsOfState.Equilibrium3D",
   CHECK(eos.electron_fraction_upper_bound() == 1.0);
   CHECK(eos.specific_enthalpy_lower_bound() ==
         underlying_eos.specific_enthalpy_lower_bound());
+  CHECK(not eos.is_barotropic());
+  CHECK(eos.is_equilibrium());
 
   {
     const double rest_mass_density = 1e-3;

--- a/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_HybridEos.cpp
+++ b/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_HybridEos.cpp
@@ -92,6 +92,7 @@ void check_exact_polytrope() {
   const auto p_kappa_over_rho_sq =
       eos.kappa_times_p_over_rho_squared_from_density_and_energy(rho, eps);
   CHECK(get(p_kappa_over_rho_sq) == 4.25);
+  CHECK(not eos.is_barotropic());
 }
 
 template <bool IsRelativistic>

--- a/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_IdealFluid.cpp
+++ b/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_IdealFluid.cpp
@@ -81,6 +81,8 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.EquationsOfState.IdealFluid",
   CHECK(eos != other_type_eos);
   CHECK(*eos.promote_to_3d_eos() ==
         EoS::Equilibrium3D<EoS::IdealFluid<true>>(eos));
+  CHECK(not eos.is_barotropic());
+  CHECK(not other_eos.is_barotropic());
 
   TestHelpers::EquationsOfState::check(EoS::IdealFluid<true>{5.0 / 3.0},
                                        "IdealFluid", "ideal_fluid", d_for_size,

--- a/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_PiecewisePolytropicFluid.cpp
+++ b/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_PiecewisePolytropicFluid.cpp
@@ -355,6 +355,8 @@ SPECTRE_TEST_CASE(
   const double poly_exponent_lo = 1.5;
   const double poly_constant_lo = 10.0;
   const double poly_exponent_hi = 2.0;
+  //Check if barotropic
+  CHECK(eos.is_barotropic());
 
   // Relativistic checks
   TestHelpers::EquationsOfState::check(

--- a/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_PolytropicFluid.cpp
+++ b/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_PolytropicFluid.cpp
@@ -83,6 +83,7 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.EquationsOfState.PolytropicFluid",
         EoS::Barotropic3D<EoS::PolytropicFluid<true>>(eos));
   CHECK(*eos.promote_to_2d_eos() ==
         EoS::Barotropic2D<EoS::PolytropicFluid<true>>(eos));
+  CHECK(eos.is_barotropic());
   const double d_for_size = std::numeric_limits<double>::signaling_NaN();
   const DataVector dv_for_size(5);
   TestHelpers::EquationsOfState::check(EoS::PolytropicFluid<true>{100.0, 2.0},

--- a/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_SpectralEoS.cpp
+++ b/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_SpectralEoS.cpp
@@ -46,6 +46,7 @@ void check_exact() {
         EquationsOfState::Barotropic3D<EquationsOfState::Spectral>(eos));
   CHECK(*eos.promote_to_2d_eos() ==
         EquationsOfState::Barotropic2D<EquationsOfState::Spectral>(eos));
+  CHECK(eos.is_barotropic());
   // Test DataVector functions
   {
     const Scalar<DataVector> rho{DataVector{

--- a/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_Tabulated3D.cpp
+++ b/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_Tabulated3D.cpp
@@ -194,6 +194,8 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.EquationsOfState.Tabulated3D",
             get(eos.sound_speed_squared_from_density_and_temperature(
                 state[1], state[0], state[2])) <
         1.e-12);
+  CHECK(not eos.is_barotropic());
+  CHECK(not eos.is_equilibrium());
 
   const auto eps_interp =
       eos.specific_internal_energy_from_density_and_temperature(


### PR DESCRIPTION
## Proposed changes

<!--
Add is_equilibrium to 2D and 3D and the tests for is_barotropic to EOSes
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
