### PR TITLE
Optionally specify path to Horizons.h5 in Inspiral CLI

### DIFF
--- a/tests/support/Pipelines/Bbh/Test_Inspiral.py
+++ b/tests/support/Pipelines/Bbh/Test_Inspiral.py
@@ -41,7 +41,8 @@ class TestInspiral(unittest.TestCase):
             executable=str(self.bin_dir / "SolveXcts"),
         )
         self.id_dir = self.test_dir / "ID"
-        self.horizons_filename = self.id_dir / "Horizons.h5"
+        # Purposefully not in the ID directory
+        self.horizons_filename = self.test_dir / "Horizons.h5"
         with spectre_h5.H5File(
             str(self.horizons_filename.resolve()), "a"
         ) as horizons_file:
@@ -60,6 +61,7 @@ class TestInspiral(unittest.TestCase):
         params = inspiral_parameters(
             id_input_file=id_input_file,
             id_run_dir=self.id_dir,
+            id_horizons_path=self.horizons_filename,
             refinement_level=1,
             polynomial_order=5,
         )
@@ -109,6 +111,8 @@ class TestInspiral(unittest.TestCase):
             "1",
             "--polynomial-order",
             "5",
+            "--id-horizons-path",
+            str(self.horizons_filename),
             "-E",
             str(self.bin_dir / "EvolveGhBinaryBlackHole"),
         ]


### PR DESCRIPTION
## Proposed changes

I realized I didn't add backwards compatibility support in #5957 for if the `Horizons.h5` file didn't exist. This PR now allows you to specify the path to the `Horizons.h5` file. If the file doesn't exist, the user is told to run `postprocess-id` on the ID to generate this file.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
