### PR TITLE
Add several common time dependent options

### DIFF
--- a/src/Domain/Creators/TimeDependentOptions/CMakeLists.txt
+++ b/src/Domain/Creators/TimeDependentOptions/CMakeLists.txt
@@ -8,6 +8,7 @@ spectre_target_sources(
   FromVolumeFile.cpp
   ShapeMap.cpp
   Sphere.cpp
+  TranslationMap.cpp
 )
 
 spectre_target_headers(
@@ -18,4 +19,5 @@ spectre_target_headers(
   FromVolumeFile.hpp
   ShapeMap.hpp
   Sphere.hpp
+  TranslationMap.hpp
   )

--- a/src/Domain/Creators/TimeDependentOptions/CMakeLists.txt
+++ b/src/Domain/Creators/TimeDependentOptions/CMakeLists.txt
@@ -7,6 +7,7 @@ spectre_target_sources(
   BinaryCompactObject.cpp
   ExpansionMap.cpp
   FromVolumeFile.cpp
+  RotationMap.cpp
   ShapeMap.cpp
   Sphere.cpp
   TranslationMap.cpp
@@ -19,6 +20,7 @@ spectre_target_headers(
   BinaryCompactObject.hpp
   ExpansionMap.hpp
   FromVolumeFile.hpp
+  RotationMap.hpp
   ShapeMap.hpp
   Sphere.hpp
   TranslationMap.hpp

--- a/src/Domain/Creators/TimeDependentOptions/CMakeLists.txt
+++ b/src/Domain/Creators/TimeDependentOptions/CMakeLists.txt
@@ -5,6 +5,7 @@ spectre_target_sources(
   ${LIBRARY}
   PRIVATE
   BinaryCompactObject.cpp
+  ExpansionMap.cpp
   FromVolumeFile.cpp
   ShapeMap.cpp
   Sphere.cpp
@@ -16,6 +17,7 @@ spectre_target_headers(
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   BinaryCompactObject.hpp
+  ExpansionMap.hpp
   FromVolumeFile.hpp
   ShapeMap.hpp
   Sphere.hpp

--- a/src/Domain/Creators/TimeDependentOptions/ExpansionMap.cpp
+++ b/src/Domain/Creators/TimeDependentOptions/ExpansionMap.cpp
@@ -1,0 +1,90 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Domain/Creators/TimeDependentOptions/ExpansionMap.hpp"
+
+#include <array>
+#include <string>
+#include <variant>
+
+#include "DataStructures/DataVector.hpp"
+#include "Domain/Creators/TimeDependentOptions/FromVolumeFile.hpp"
+#include "Options/Context.hpp"
+#include "Options/ParseError.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace domain::creators::time_dependent_options {
+ExpansionMapOptions::ExpansionMapOptions(
+    const std::variant<std::array<double, 3>, FromVolumeFile<names::Expansion>>&
+        expansion_values,
+    const std::variant<std::array<double, 3>, FromVolumeFile<names::Expansion>>&
+        expansion_outer_boundary_values,
+    std::optional<double> decay_timescale_outer_boundary_in,
+    std::optional<double> decay_timescale_in,
+    std::optional<double> asymptotic_velocity_outer_boundary_in,
+    const Options::Context& context)
+    : decay_timescale(std::move(decay_timescale_in)) {
+  const auto set_values =
+      [&, this](const gsl::not_null<std::array<DataVector, 3>*> to_set,
+                const auto& input_values, const bool is_outer_boundary) {
+        if (std::holds_alternative<std::array<double, 3>>(input_values)) {
+          asymptotic_velocity_outer_boundary =
+              asymptotic_velocity_outer_boundary_in;
+          if (decay_timescale.has_value() ==
+              asymptotic_velocity_outer_boundary.has_value()) {
+            PARSE_ERROR(
+                context,
+                "When specifying the ExpansionMap initial outer boundary "
+                "values directly, you must specify one of DecayTimescale or "
+                "AsymptoticVelocityOuterBoundary, but not both.");
+          }
+          auto& values = std::get<std::array<double, 3>>(input_values);
+          for (size_t i = 0; i < to_set->size(); i++) {
+            gsl::at(*to_set, i) = DataVector{1, gsl::at(values, i)};
+          }
+
+          if (is_outer_boundary) {
+            if (not decay_timescale_outer_boundary_in.has_value()) {
+              PARSE_ERROR(context,
+                          "When specifying the ExpansionMap initial outer "
+                          "boundary values directly, you must also specify a "
+                          "'DecayTimescaleOuterBoundary'.");
+            }
+
+            decay_timescale_outer_boundary =
+                decay_timescale_outer_boundary_in.value();
+          }
+
+        } else if (std::holds_alternative<FromVolumeFile<names::Expansion>>(
+                       input_values)) {
+          if (decay_timescale.has_value()) {
+            PARSE_ERROR(
+                context,
+                "When specifying the initial values from a volume file, "
+                "the decay timescale must be 'Auto'.");
+          }
+          auto& values_from_file =
+              std::get<FromVolumeFile<names::Expansion>>(input_values);
+          *to_set = is_outer_boundary
+                        ? values_from_file.expansion_values_outer_boundary
+                        : values_from_file.expansion_values;
+
+          if (is_outer_boundary) {
+            decay_timescale_outer_boundary =
+                decay_timescale_outer_boundary_in.value_or(
+                    values_from_file.decay_timescale_outer_boundary);
+            asymptotic_velocity_outer_boundary =
+                asymptotic_velocity_outer_boundary_in.value_or(
+                    values_from_file.velocity_outer_boundary);
+          }
+        }
+      };
+
+  // Expansion values
+  set_values(make_not_null(&initial_values), expansion_values, false);
+  // Outer boundary
+  set_values(make_not_null(&initial_values_outer_boundary),
+             expansion_outer_boundary_values, true);
+}
+}  // namespace domain::creators::time_dependent_options

--- a/src/Domain/Creators/TimeDependentOptions/ExpansionMap.hpp
+++ b/src/Domain/Creators/TimeDependentOptions/ExpansionMap.hpp
@@ -1,0 +1,108 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <optional>
+#include <string>
+#include <variant>
+
+#include "DataStructures/DataVector.hpp"
+#include "Domain/Creators/TimeDependentOptions/FromVolumeFile.hpp"
+#include "Options/Auto.hpp"
+#include "Options/Context.hpp"
+#include "Options/String.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace domain::creators::time_dependent_options {
+/*!
+ * \brief Class to be used as an option for initializing expansion map
+ * coefficients.
+ */
+struct ExpansionMapOptions {
+  using type = Options::Auto<ExpansionMapOptions, Options::AutoLabel::None>;
+  static std::string name() { return "ExpansionMap"; }
+  static constexpr Options::String help = {
+      "Options for a time-dependent expansion of the coordinates. Specify "
+      "'None' to not use this map."};
+
+  struct InitialValues {
+    using type =
+        std::variant<std::array<double, 3>, FromVolumeFile<names::Expansion>>;
+    static constexpr Options::String help = {
+        "Initial values for the expansion map, its velocity and "
+        "acceleration."};
+  };
+
+  struct InitialValuesOuterBoundary {
+    using type =
+        std::variant<std::array<double, 3>, FromVolumeFile<names::Expansion>>;
+    static constexpr Options::String help = {
+        "Initial values for the expansion map, its velocity and "
+        "acceleration at the outer boundary. Unless you are starting from a "
+        "checkpoint or continuing an evolution, this option should likely be "
+        "[1.0, 0.0, 0.0] at the start of an evolution"};
+  };
+
+  struct DecayTimescaleOuterBoundary {
+    using type = Options::Auto<double>;
+    static constexpr Options::String help = {
+        "A timescale for how fast the outer boundary expansion approaches its "
+        "asymptotic value. Can optionally specify 'Auto' when reading the "
+        "initial values 'FromVolumeFile' to use the decay timescale from the "
+        "function of time in the volume file. Cannot specify 'Auto' when "
+        "initial values are specified directly."};
+  };
+
+  struct DecayTimescale {
+    using type = Options::Auto<double>;
+    static constexpr Options::String help = {
+        "If specified, a SettleToConstant function of time will be used for "
+        "the expansion map and this number will determine the timescale that "
+        "the expansion approaches its asymptotic value. If 'Auto' is "
+        "specified, a PiecewisePolynomial function of time will be used for "
+        "the expansion map. Note that if you are reading the initial values "
+        "from a volume file, you must specify 'Auto' for this option."};
+  };
+
+  struct AsymptoticVelocityOuterBoundary {
+    using type = Options::Auto<double>;
+    static constexpr Options::String help = {
+        "There are two choices for this option. If a value is specified, a "
+        "FixedSpeedCubic function of time will be used for the expansion map "
+        "at the outer boundary and this number will determine its velocity. If "
+        "'Auto' is specified, the behavior will depend on what is chosen for "
+        "'InitialValuesOuterBoundary'. If values are specified for "
+        "'InitialValuesOuterBoundary', then 'Auto' here means a "
+        "SettleToConstant function of time will be used for the expansion map "
+        "at the outer boundary. If 'FromVolumeFile' is specified for "
+        "'InitialValuesOuterBoundary', then a FixedSpeedCubic function of time "
+        "will be used and the velocity from the function of "
+        "time in the volume file will be used."};
+  };
+
+  using options = tmpl::list<InitialValues, InitialValuesOuterBoundary,
+                             DecayTimescaleOuterBoundary, DecayTimescale,
+                             AsymptoticVelocityOuterBoundary>;
+
+  ExpansionMapOptions() = default;
+  ExpansionMapOptions(
+      const std::variant<std::array<double, 3>,
+                         FromVolumeFile<names::Expansion>>& expansion_values,
+      const std::variant<std::array<double, 3>,
+                         FromVolumeFile<names::Expansion>>&
+          expansion_outer_boundary_values,
+      std::optional<double> decay_timescale_outer_boundary_in,
+      std::optional<double> decay_timescale_in,
+      std::optional<double> asymptotic_velocity_outer_boundary_in,
+      const Options::Context& context = {});
+
+  std::array<DataVector, 3> initial_values{};
+  std::array<DataVector, 3> initial_values_outer_boundary{};
+  double decay_timescale_outer_boundary{};
+  std::optional<double> decay_timescale{};
+  std::optional<double> asymptotic_velocity_outer_boundary{};
+};
+}  // namespace domain::creators::time_dependent_options

--- a/src/Domain/Creators/TimeDependentOptions/FromVolumeFile.cpp
+++ b/src/Domain/Creators/TimeDependentOptions/FromVolumeFile.cpp
@@ -12,6 +12,7 @@
 #include <vector>
 
 #include "DataStructures/DataVector.hpp"
+#include "Domain/FunctionsOfTime/FixedSpeedCubic.hpp"
 #include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
 #include "Domain/FunctionsOfTime/QuaternionFunctionOfTime.hpp"
 #include "Domain/FunctionsOfTime/QuaternionHelpers.hpp"
@@ -110,6 +111,20 @@ FromVolumeFile<names::Expansion>::FromVolumeFile(
   expansion_values = exp_function_of_time->func_and_2_derivs(time);
   expansion_values_outer_boundary =
       exp_outer_boundary_function_of_time->func_and_2_derivs(time);
+
+  const auto* fixed_speed_cubic =
+      dynamic_cast<domain::FunctionsOfTime::FixedSpeedCubic*>(
+          exp_outer_boundary_function_of_time.get());
+
+  if (fixed_speed_cubic == nullptr) {
+    PARSE_ERROR(
+        context,
+        "When reading the Expansion map parameters from a volume file, the "
+        "ExpansionOuterBoundary function of time must be a FixedSpeedCubic.");
+  }
+
+  velocity_outer_boundary = fixed_speed_cubic->velocity();
+  decay_timescale_outer_boundary = fixed_speed_cubic->decay_timescale();
 }
 
 FromVolumeFile<names::Rotation>::FromVolumeFile(

--- a/src/Domain/Creators/TimeDependentOptions/FromVolumeFile.hpp
+++ b/src/Domain/Creators/TimeDependentOptions/FromVolumeFile.hpp
@@ -94,6 +94,8 @@ struct FromVolumeFile<names::Expansion> : public detail::FromVolumeFileBase {
 
   std::array<DataVector, 3> expansion_values{};
   std::array<DataVector, 3> expansion_values_outer_boundary{};
+  double velocity_outer_boundary{};
+  double decay_timescale_outer_boundary{};
 };
 
 template <>

--- a/src/Domain/Creators/TimeDependentOptions/RotationMap.cpp
+++ b/src/Domain/Creators/TimeDependentOptions/RotationMap.cpp
@@ -1,0 +1,105 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Domain/Creators/TimeDependentOptions/RotationMap.hpp"
+
+#include <array>
+#include <optional>
+#include <string>
+#include <utility>
+#include <variant>
+
+#include "DataStructures/DataVector.hpp"
+#include "Domain/Creators/TimeDependentOptions/FromVolumeFile.hpp"
+#include "Options/Context.hpp"
+#include "Options/ParseError.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/MakeArray.hpp"
+
+namespace domain::creators::time_dependent_options {
+template <size_t NumDerivs>
+RotationMapOptions<NumDerivs>::RotationMapOptions(
+    std::variant<std::vector<std::array<double, 4>>,
+                 FromVolumeFile<names::Rotation>>
+        initial_quaternions,
+    std::optional<std::vector<std::array<double, 3>>> initial_angles,
+    std::optional<double> decay_timescale_in, const Options::Context& context)
+    : decay_timescale(decay_timescale_in) {
+  quaternions = make_array<NumDerivs + 1, DataVector>(DataVector{4, 0.0});
+  angles = make_array<NumDerivs + 1, DataVector>(DataVector{3, 0.0});
+
+  if (std::holds_alternative<std::vector<std::array<double, 4>>>(
+          initial_quaternions)) {
+    auto& values =
+        std::get<std::vector<std::array<double, 4>>>(initial_quaternions);
+    if (values.empty() or values.size() > quaternions.size()) {
+      PARSE_ERROR(
+          context,
+          "Must specify at least the value of the quaternion, and optionally "
+          "up to "
+              << NumDerivs << " time derivatives.");
+    }
+    for (size_t i = 0; i < values.size(); i++) {
+      gsl::at(quaternions, i) =
+          DataVector{values[i][0], values[i][1], values[i][2], values[i][3]};
+    }
+
+    if (initial_angles.has_value()) {
+      auto& angle_values = initial_angles.value();
+      if (angle_values.empty() or angle_values.size() > angles.size()) {
+        PARSE_ERROR(
+            context,
+            "When specifying the angle, you must specify at least the value, "
+            "and optionally up to "
+                << NumDerivs << " time derivatives.");
+      }
+      for (size_t i = 0; i < angle_values.size(); i++) {
+        gsl::at(angles, i) = DataVector{angle_values[i][0], angle_values[i][1],
+                                        angle_values[i][2]};
+      }
+    }
+  } else if (std::holds_alternative<FromVolumeFile<names::Rotation>>(
+                 initial_quaternions)) {
+    if (decay_timescale.has_value()) {
+      PARSE_ERROR(context,
+                  "When specifying the initial quaternions from a volume file, "
+                  "the decay timescale must be 'Auto'.");
+    }
+    auto& values_from_file =
+        std::get<FromVolumeFile<names::Rotation>>(initial_quaternions);
+
+    for (size_t i = 0; i < values_from_file.quaternions.size(); i++) {
+      gsl::at(quaternions, i) = gsl::at(values_from_file.quaternions, i);
+      gsl::at(angles, i) = gsl::at(values_from_file.angle_values, i);
+    }
+
+    if (initial_angles.has_value()) {
+      // Reset angle func so derivs that weren't specified are zero
+      angles = make_array<NumDerivs + 1, DataVector>(DataVector{3, 0.0});
+      auto& angle_values = initial_angles.value();
+      if (angle_values.empty() or angle_values.size() > angles.size()) {
+        PARSE_ERROR(
+            context,
+            "When specifying the angle, you must specify at least the value, "
+            "and optionally up to "
+                << NumDerivs << " time derivatives.");
+      }
+      for (size_t i = 0; i < angle_values.size(); i++) {
+        gsl::at(angles, i) = DataVector{angle_values[i][0], angle_values[i][1],
+                                        angle_values[i][2]};
+      }
+    }
+  }
+}
+
+#define NUMDERIVS(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data) \
+  template struct RotationMapOptions<NUMDERIVS(data)>;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (2, 3))
+
+#undef INSTANTIATE
+#undef NUMDERIVS
+}  // namespace domain::creators::time_dependent_options

--- a/src/Domain/Creators/TimeDependentOptions/RotationMap.hpp
+++ b/src/Domain/Creators/TimeDependentOptions/RotationMap.hpp
@@ -1,0 +1,82 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <optional>
+#include <string>
+#include <utility>
+#include <variant>
+#include <vector>
+
+#include "DataStructures/DataVector.hpp"
+#include "Domain/Creators/TimeDependentOptions/FromVolumeFile.hpp"
+#include "Options/Auto.hpp"
+#include "Options/Context.hpp"
+#include "Options/String.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace domain::creators::time_dependent_options {
+/*!
+ * \brief Class to be used as an option for initializing rotation map
+ * coefficients.
+ */
+template <size_t NumDerivs>
+struct RotationMapOptions {
+  using type = Options::Auto<RotationMapOptions, Options::AutoLabel::None>;
+  static std::string name() { return "RotationMap"; }
+  static constexpr Options::String help = {
+      "Options for a time-dependent rotation of the coordinates. Specify "
+      "'None' to not use this map."};
+
+  struct InitialQuaternions {
+    using type = std::variant<std::vector<std::array<double, 4>>,
+                              FromVolumeFile<names::Rotation>>;
+    static constexpr Options::String help = {
+        "Initial values for the quaternion of the rotation map. You can "
+        "optionally specify its first two time derivatives. If time "
+        "derivatives aren't specified, zero will be used."};
+  };
+
+  struct InitialAngles {
+    using type = Options::Auto<std::vector<std::array<double, 3>>>;
+    static constexpr Options::String help = {
+        "Initial values for the angle of the rotation map. If 'Auto' is "
+        "specified, the behavior will depend on the 'InitialQuaternions' "
+        "option. If you are reading the quaternion from a volume file, 'Auto' "
+        "will use the angle values from the volume file. If you are simply "
+        "specifying the quaternion and (optionally) its time derivatives, then "
+        "'Auto' here will set the angle and its time derivatives to zero. If "
+        "values are specified for the angle and its time derivatives, then "
+        "those will override anything computed from the 'InitialQuaternions' "
+        "option."};
+  };
+
+  struct DecayTimescale {
+    using type = Options::Auto<double>;
+    static constexpr Options::String help = {
+        "The timescale for how fast the rotation approaches its asymptotic "
+        "value. If this is specified, a SettleToConstant function of time will "
+        "be used. If 'Auto' is specified, a PiecewisePolynomial function of "
+        "time will be used. Note that if you are reading the initial "
+        "quaternions from a volume file, then this option must be 'Auto'"};
+  };
+
+  using options = tmpl::list<InitialQuaternions, InitialAngles, DecayTimescale>;
+
+  RotationMapOptions() = default;
+  RotationMapOptions(
+      std::variant<std::vector<std::array<double, 4>>,
+                   FromVolumeFile<names::Rotation>>
+          initial_quaternions,
+      std::optional<std::vector<std::array<double, 3>>> initial_angles,
+      std::optional<double> decay_timescale_in,
+      const Options::Context& context = {});
+
+  std::array<DataVector, NumDerivs + 1> quaternions{};
+  std::array<DataVector, NumDerivs + 1> angles{};
+  std::optional<double> decay_timescale{};
+};
+}  // namespace domain::creators::time_dependent_options

--- a/src/Domain/Creators/TimeDependentOptions/TranslationMap.cpp
+++ b/src/Domain/Creators/TimeDependentOptions/TranslationMap.cpp
@@ -1,0 +1,46 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Domain/Creators/TimeDependentOptions/TranslationMap.hpp"
+
+#include <array>
+#include <string>
+#include <variant>
+
+#include "DataStructures/DataVector.hpp"
+#include "Domain/Creators/TimeDependentOptions/FromVolumeFile.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+
+namespace domain::creators::time_dependent_options {
+template <size_t Dim>
+TranslationMapOptions<Dim>::TranslationMapOptions(
+    std::variant<std::array<std::array<double, Dim>, 3>,
+                 FromVolumeFile<names::Translation>>
+        values_from_options) {
+  if (std::holds_alternative<std::array<std::array<double, Dim>, 3>>(
+          values_from_options)) {
+    auto& values =
+        std::get<std::array<std::array<double, Dim>, 3>>(values_from_options);
+    for (size_t i = 0; i < initial_values.size(); i++) {
+      gsl::at(initial_values, i) = DataVector{Dim, 0.0};
+      for (size_t j = 0; j < Dim; j++) {
+        gsl::at(initial_values, i)[j] = gsl::at(gsl::at(values, i), j);
+      }
+    }
+  } else if (std::holds_alternative<FromVolumeFile<names::Translation>>(
+                 values_from_options)) {
+    auto& values_from_file =
+        std::get<FromVolumeFile<names::Translation>>(values_from_options);
+    initial_values = values_from_file.values;
+  }
+}
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data) template class TranslationMapOptions<DIM(data)>;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
+
+#undef INSTANTIATE
+#undef DIM
+}  // namespace domain::creators::time_dependent_options

--- a/src/Domain/Creators/TimeDependentOptions/TranslationMap.hpp
+++ b/src/Domain/Creators/TimeDependentOptions/TranslationMap.hpp
@@ -1,0 +1,50 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <optional>
+#include <string>
+#include <variant>
+
+#include "DataStructures/DataVector.hpp"
+#include "Domain/Creators/TimeDependentOptions/FromVolumeFile.hpp"
+#include "Options/Auto.hpp"
+#include "Options/Context.hpp"
+#include "Options/String.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace domain::creators::time_dependent_options {
+/*!
+ * \brief Class to be used as an option for initializing translation map
+ * coefficients.
+ */
+template <size_t Dim>
+struct TranslationMapOptions {
+  using type = Options::Auto<TranslationMapOptions, Options::AutoLabel::None>;
+  static std::string name() { return "TranslationMap"; }
+  static constexpr Options::String help = {
+      "Options for a time-dependent translation of the coordinates. Specify "
+      "'None' to not use this map."};
+
+  struct InitialValues {
+    using type = std::variant<std::array<std::array<double, Dim>, 3>,
+                              FromVolumeFile<names::Translation>>;
+    static constexpr Options::String help = {
+        "Initial values for the translation map, its velocity and "
+        "acceleration."};
+  };
+
+  using options = tmpl::list<InitialValues>;
+
+  TranslationMapOptions() = default;
+  // NOLINTNEXTLINE(google-explicit-constructor)
+  TranslationMapOptions(std::variant<std::array<std::array<double, Dim>, 3>,
+                                     FromVolumeFile<names::Translation>>
+                            values_from_options);
+
+  std::array<DataVector, 3> initial_values{};
+};
+}  // namespace domain::creators::time_dependent_options

--- a/src/Domain/FunctionsOfTime/FixedSpeedCubic.hpp
+++ b/src/Domain/FunctionsOfTime/FixedSpeedCubic.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <array>
+#include <cmath>
 #include <cstddef>
 #include <limits>
 #include <memory>
@@ -73,6 +74,13 @@ class FixedSpeedCubic : public FunctionOfTime {
   double expiration_after(const double /*time*/) const override {
     return std::numeric_limits<double>::infinity();
   }
+
+  /// Returns the velocity that the function approaches
+  double velocity() const { return velocity_; }
+
+  /// Returns the timescale at which the function approaches a constant
+  /// velocity.
+  double decay_timescale() const { return sqrt(squared_decay_timescale_); }
 
   // NOLINTNEXTLINE(google-runtime-references)
   void pup(PUP::er& p) override;

--- a/tests/Unit/Domain/Creators/TimeDependentOptions/CMakeLists.txt
+++ b/tests/Unit/Domain/Creators/TimeDependentOptions/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY_SOURCES
   ${LIBRARY_SOURCES}
   TimeDependentOptions/Test_BinaryCompactObject.cpp
+  TimeDependentOptions/Test_ExpansionMap.cpp
   TimeDependentOptions/Test_FromVolumeFile.cpp
   TimeDependentOptions/Test_ShapeMap.cpp
   TimeDependentOptions/Test_Sphere.cpp

--- a/tests/Unit/Domain/Creators/TimeDependentOptions/CMakeLists.txt
+++ b/tests/Unit/Domain/Creators/TimeDependentOptions/CMakeLists.txt
@@ -6,6 +6,7 @@ set(LIBRARY_SOURCES
   TimeDependentOptions/Test_BinaryCompactObject.cpp
   TimeDependentOptions/Test_ExpansionMap.cpp
   TimeDependentOptions/Test_FromVolumeFile.cpp
+  TimeDependentOptions/Test_RotationMap.cpp
   TimeDependentOptions/Test_ShapeMap.cpp
   TimeDependentOptions/Test_Sphere.cpp
   TimeDependentOptions/Test_TranslationMap.cpp

--- a/tests/Unit/Domain/Creators/TimeDependentOptions/CMakeLists.txt
+++ b/tests/Unit/Domain/Creators/TimeDependentOptions/CMakeLists.txt
@@ -7,4 +7,5 @@ set(LIBRARY_SOURCES
   TimeDependentOptions/Test_FromVolumeFile.cpp
   TimeDependentOptions/Test_ShapeMap.cpp
   TimeDependentOptions/Test_Sphere.cpp
+  TimeDependentOptions/Test_TranslationMap.cpp
   PARENT_SCOPE)

--- a/tests/Unit/Domain/Creators/TimeDependentOptions/Test_ExpansionMap.cpp
+++ b/tests/Unit/Domain/Creators/TimeDependentOptions/Test_ExpansionMap.cpp
@@ -1,0 +1,204 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <sstream>
+#include <string>
+#include <variant>
+
+#include "DataStructures/DataVector.hpp"
+#include "Domain/Creators/TimeDependentOptions/ExpansionMap.hpp"
+#include "Domain/Creators/TimeDependentOptions/FromVolumeFile.hpp"
+#include "Domain/FunctionsOfTime/FixedSpeedCubic.hpp"
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "Domain/FunctionsOfTime/PiecewisePolynomial.hpp"
+#include "Domain/FunctionsOfTime/RegisterDerivedWithCharm.hpp"
+#include "Framework/TestCreation.hpp"
+#include "IO/H5/AccessType.hpp"
+#include "IO/H5/File.hpp"
+#include "IO/H5/TensorData.hpp"
+#include "IO/H5/VolumeData.hpp"
+#include "NumericalAlgorithms/Spectral/Basis.hpp"
+#include "NumericalAlgorithms/Spectral/Quadrature.hpp"
+#include "Utilities/FileSystem.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeArray.hpp"
+#include "Utilities/Serialization/Serialize.hpp"
+
+namespace {
+void test_expansion_map_options() {
+  {
+    const auto expansion_map_options = TestHelpers::test_creation<
+        domain::creators::time_dependent_options::ExpansionMapOptions>(
+        "InitialValues: [1.0, 2.0, 3.0]\n"
+        "InitialValuesOuterBoundary: [4.0, 5.0, 6.0]\n"
+        "DecayTimescaleOuterBoundary: 50\n"
+        "DecayTimescale: Auto\n"
+        "AsymptoticVelocityOuterBoundary: -1e-5");
+
+    CHECK(expansion_map_options.name() == "ExpansionMap");
+    CHECK(expansion_map_options.initial_values ==
+          std::array{DataVector{1.0}, DataVector{2.0}, DataVector{3.0}});
+    CHECK(expansion_map_options.initial_values_outer_boundary ==
+          std::array{DataVector{4.0}, DataVector{5.0}, DataVector{6.0}});
+    CHECK(expansion_map_options.decay_timescale_outer_boundary == 50.0);
+    CHECK_FALSE(expansion_map_options.decay_timescale.has_value());
+    CHECK(expansion_map_options.asymptotic_velocity_outer_boundary.has_value());
+    CHECK(expansion_map_options.asymptotic_velocity_outer_boundary.value() ==
+          -1e-5);
+  }
+  {
+    const auto expansion_map_options = TestHelpers::test_creation<
+        domain::creators::time_dependent_options::ExpansionMapOptions>(
+        "InitialValues: [1.0, 2.0, 3.0]\n"
+        "InitialValuesOuterBoundary: [4.0, 5.0, 6.0]\n"
+        "DecayTimescaleOuterBoundary: 50\n"
+        "DecayTimescale: 40\n"
+        "AsymptoticVelocityOuterBoundary: Auto");
+
+    CHECK(expansion_map_options.name() == "ExpansionMap");
+    CHECK(expansion_map_options.initial_values ==
+          std::array{DataVector{1.0}, DataVector{2.0}, DataVector{3.0}});
+    CHECK(expansion_map_options.initial_values_outer_boundary ==
+          std::array{DataVector{4.0}, DataVector{5.0}, DataVector{6.0}});
+    CHECK(expansion_map_options.decay_timescale_outer_boundary == 50.0);
+    CHECK(expansion_map_options.decay_timescale.has_value());
+    CHECK(expansion_map_options.decay_timescale.value() == 40.0);
+    CHECK_FALSE(
+        expansion_map_options.asymptotic_velocity_outer_boundary.has_value());
+  }
+
+  CHECK_THROWS_WITH(
+      (TestHelpers::test_creation<
+          domain::creators::time_dependent_options::ExpansionMapOptions>(
+          "InitialValues: [1.0, 2.0, 3.0]\n"
+          "InitialValuesOuterBoundary: [4.0, 5.0, 6.0]\n"
+          "DecayTimescaleOuterBoundary: 50\n"
+          "DecayTimescale: Auto\n"
+          "AsymptoticVelocityOuterBoundary: Auto")),
+      Catch::Matchers::ContainsSubstring(
+          "must specify one of DecayTimescale or "
+          "AsymptoticVelocityOuterBoundary, but not both."));
+  CHECK_THROWS_WITH(
+      (TestHelpers::test_creation<
+          domain::creators::time_dependent_options::ExpansionMapOptions>(
+          "InitialValues: [1.0, 2.0, 3.0]\n"
+          "InitialValuesOuterBoundary: [4.0, 5.0, 6.0]\n"
+          "DecayTimescaleOuterBoundary: 50\n"
+          "DecayTimescale: 40\n"
+          "AsymptoticVelocityOuterBoundary: -1e-5")),
+      Catch::Matchers::ContainsSubstring(
+          "must specify one of DecayTimescale or "
+          "AsymptoticVelocityOuterBoundary, but not both."));
+  CHECK_THROWS_WITH(
+      (TestHelpers::test_creation<
+          domain::creators::time_dependent_options::ExpansionMapOptions>(
+          "InitialValues: [1.0, 2.0, 3.0]\n"
+          "InitialValuesOuterBoundary: [4.0, 5.0, 6.0]\n"
+          "DecayTimescaleOuterBoundary: Auto\n"
+          "DecayTimescale: 40\n"
+          "AsymptoticVelocityOuterBoundary: Auto")),
+      Catch::Matchers::ContainsSubstring(
+          "When specifying the ExpansionMap initial outer "
+          "boundary values directly, you must also specify a "
+          "'DecayTimescaleOuterBoundary'."));
+
+  {
+    std::unordered_map<std::string,
+                       std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
+        functions_of_time{};
+    functions_of_time["Expansion"] =
+        std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<2>>(
+            0.0, std::array{DataVector{1.0}, DataVector{2.0}, DataVector{3.0}},
+            100.0);
+    functions_of_time["ExpansionOuterBoundary"] =
+        std::make_unique<domain::FunctionsOfTime::FixedSpeedCubic>(0.0, 0.0,
+                                                                   -1e-5, 50.0);
+    const std::string filename{"Commencement.h5"};
+    const std::string subfile_name{"VolumeData"};
+    if (file_system::check_if_file_exists(filename)) {
+      file_system::rm(filename, true);
+    }
+
+    {
+      h5::H5File<h5::AccessType::ReadWrite> h5_file{filename};
+      auto& vol_file = h5_file.insert<h5::VolumeData>(subfile_name);
+
+      // We don't care about the volume data here, just the functions of time
+      vol_file.write_volume_data(
+          0, 0.0,
+          {ElementVolumeData{
+              "blah",
+              {TensorComponent{"RandomTensor", DataVector{3, 0.0}}},
+              {3},
+              {Spectral::Basis::Legendre},
+              {Spectral::Quadrature::GaussLobatto}}},
+          std::nullopt, serialize(functions_of_time));
+    }
+
+    {
+      const auto expansion_map_options = TestHelpers::test_creation<
+          domain::creators::time_dependent_options::ExpansionMapOptions>(
+          "DecayTimescaleOuterBoundary: 60\n"
+          "DecayTimescale: Auto\n"
+          "AsymptoticVelocityOuterBoundary: -2e-5\n"
+          "InitialValues:\n"
+          "  H5Filename: " +
+          filename + "\n  SubfileName: " + subfile_name +
+          "\n  Time: 0.0\n"
+          "InitialValuesOuterBoundary:\n"
+          "  H5Filename: " +
+          filename + "\n  SubfileName: " + subfile_name + "\n  Time: 0.0");
+      CHECK(expansion_map_options.name() == "ExpansionMap");
+      CHECK(expansion_map_options.initial_values ==
+            std::array{DataVector{1.0}, DataVector{2.0}, DataVector{3.0}});
+      CHECK(expansion_map_options.initial_values_outer_boundary ==
+            std::array{DataVector{0.0}, DataVector{0.0}, DataVector{0.0}});
+      CHECK(expansion_map_options.decay_timescale_outer_boundary == 60.0);
+      CHECK_FALSE(expansion_map_options.decay_timescale.has_value());
+      CHECK(
+          expansion_map_options.asymptotic_velocity_outer_boundary.has_value());
+      CHECK(expansion_map_options.asymptotic_velocity_outer_boundary.value() ==
+            -2e-5);
+    }
+    {
+      const auto expansion_map_options = TestHelpers::test_creation<
+          domain::creators::time_dependent_options::ExpansionMapOptions>(
+          "DecayTimescaleOuterBoundary: Auto\n"
+          "DecayTimescale: Auto\n"
+          "AsymptoticVelocityOuterBoundary: Auto\n"
+          "InitialValues:\n"
+          "  H5Filename: " +
+          filename + "\n  SubfileName: " + subfile_name +
+          "\n  Time: 0.0\n"
+          "InitialValuesOuterBoundary:\n"
+          "  H5Filename: " +
+          filename + "\n  SubfileName: " + subfile_name + "\n  Time: 0.0");
+      CHECK(expansion_map_options.name() == "ExpansionMap");
+      CHECK(expansion_map_options.initial_values ==
+            std::array{DataVector{1.0}, DataVector{2.0}, DataVector{3.0}});
+      CHECK(expansion_map_options.initial_values_outer_boundary ==
+            std::array{DataVector{0.0}, DataVector{0.0}, DataVector{0.0}});
+      CHECK(expansion_map_options.decay_timescale_outer_boundary == 50.0);
+      CHECK_FALSE(expansion_map_options.decay_timescale.has_value());
+      CHECK(
+          expansion_map_options.asymptotic_velocity_outer_boundary.has_value());
+      CHECK(expansion_map_options.asymptotic_velocity_outer_boundary.value() ==
+            -1e-5);
+    }
+
+    if (file_system::check_if_file_exists(filename)) {
+      file_system::rm(filename, true);
+    }
+  }
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Domain.Creators.TimeDependentOptions.ExpansionMap",
+                  "[Domain][Unit]") {
+  domain::FunctionsOfTime::register_derived_with_charm();
+  test_expansion_map_options();
+}

--- a/tests/Unit/Domain/Creators/TimeDependentOptions/Test_FromVolumeFile.cpp
+++ b/tests/Unit/Domain/Creators/TimeDependentOptions/Test_FromVolumeFile.cpp
@@ -135,6 +135,8 @@ void test<domain::creators::time_dependent_options::names::Expansion>() {
   CHECK(from_volume_file.expansion_values == expected_values);
   CHECK_ITERABLE_APPROX(from_volume_file.expansion_values_outer_boundary,
                         expected_values_outer_boundary);
+  CHECK(from_volume_file.velocity_outer_boundary == velocity);
+  CHECK(from_volume_file.decay_timescale_outer_boundary == decay_timescale);
 
   if (file_system::check_if_file_exists(filename)) {
     file_system::rm(filename, true);

--- a/tests/Unit/Domain/Creators/TimeDependentOptions/Test_RotationMap.cpp
+++ b/tests/Unit/Domain/Creators/TimeDependentOptions/Test_RotationMap.cpp
@@ -1,0 +1,173 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Domain/FunctionsOfTime/QuaternionFunctionOfTime.hpp"
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <sstream>
+#include <string>
+#include <variant>
+
+#include "DataStructures/DataVector.hpp"
+#include "Domain/Creators/TimeDependentOptions/FromVolumeFile.hpp"
+#include "Domain/Creators/TimeDependentOptions/RotationMap.hpp"
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "Domain/FunctionsOfTime/PiecewisePolynomial.hpp"
+#include "Domain/FunctionsOfTime/RegisterDerivedWithCharm.hpp"
+#include "Framework/TestCreation.hpp"
+#include "IO/H5/AccessType.hpp"
+#include "IO/H5/File.hpp"
+#include "IO/H5/TensorData.hpp"
+#include "IO/H5/VolumeData.hpp"
+#include "NumericalAlgorithms/Spectral/Basis.hpp"
+#include "NumericalAlgorithms/Spectral/Quadrature.hpp"
+#include "Utilities/FileSystem.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeArray.hpp"
+#include "Utilities/Serialization/Serialize.hpp"
+
+namespace {
+template <size_t Dim>
+std::string make_array_str(const double value) {
+  std::stringstream ss{};
+  ss << "[" << value;
+  if constexpr (Dim > 1) {
+    ss << ", " << value;
+    if constexpr (Dim > 2) {
+      ss << ", " << value;
+    }
+  }
+  ss << "]";
+
+  return ss.str();
+}
+
+void test_rotation_map_options() {
+  {
+    const auto rotation_map_options = TestHelpers::test_creation<
+        domain::creators::time_dependent_options::RotationMapOptions<2>>(
+        "InitialQuaternions: [[1.0, 0.0, 0.0, 0.0]]\n"
+        "InitialAngles: Auto\n"
+        "DecayTimescale: Auto\n");
+    CHECK(rotation_map_options.name() == "RotationMap");
+    std::array<DataVector, 3> expected_quat_func =
+        make_array<3>(DataVector{4, 0.0});
+    expected_quat_func[0][0] = 1.0;
+    const std::array<DataVector, 3> expected_angle_func =
+        make_array<3>(DataVector{3, 0.0});
+    CHECK(expected_quat_func == rotation_map_options.quaternions);
+    CHECK(expected_angle_func == rotation_map_options.angles);
+    CHECK_FALSE(rotation_map_options.decay_timescale.has_value());
+  }
+  {
+    const auto rotation_map_options = TestHelpers::test_creation<
+        domain::creators::time_dependent_options::RotationMapOptions<3>>(
+        "InitialQuaternions: [[1.0, 0.0, 0.0, 0.0]]\n"
+        "InitialAngles: [[0.1, 0.2, 0.3], [1.1, 1.2, 1.3]]\n"
+        "DecayTimescale: 50.0\n");
+    CHECK(rotation_map_options.name() == "RotationMap");
+    std::array<DataVector, 4> expected_quat_func =
+        make_array<4>(DataVector{4, 0.0});
+    expected_quat_func[0][0] = 1.0;
+    const std::array<DataVector, 4> expected_angle_func{
+        DataVector{0.1, 0.2, 0.3}, DataVector{1.1, 1.2, 1.3},
+        DataVector{3, 0.0}, DataVector{3, 0.0}};
+    CHECK(expected_quat_func == rotation_map_options.quaternions);
+    CHECK(expected_angle_func == rotation_map_options.angles);
+    CHECK(rotation_map_options.decay_timescale.has_value());
+    CHECK(rotation_map_options.decay_timescale.value() == 50.0);
+  }
+
+  std::unordered_map<std::string,
+                     std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
+      functions_of_time{};
+  functions_of_time["Rotation"] =
+      std::make_unique<domain::FunctionsOfTime::QuaternionFunctionOfTime<3>>(
+          0.0, std::array{DataVector{1.0, 0.0, 0.0, 0.0}},
+          std::array{DataVector{3, 0.1}, DataVector{3, 0.2}, DataVector{3, 0.3},
+                     DataVector{3, 0.4}},
+          100.0);
+  const std::string filename{"GoatCheese.h5"};
+  const std::string subfile_name{"VolumeData"};
+  if (file_system::check_if_file_exists(filename)) {
+    file_system::rm(filename, true);
+  }
+  {
+    h5::H5File<h5::AccessType::ReadWrite> h5_file{filename};
+    auto& vol_file = h5_file.insert<h5::VolumeData>(subfile_name);
+
+    // We don't care about the volume data here, just the functions of time
+    vol_file.write_volume_data(
+        0, 0.0,
+        {ElementVolumeData{
+            "blah",
+            {TensorComponent{"RandomTensor", DataVector{3, 0.0}}},
+            {3},
+            {Spectral::Basis::Legendre},
+            {Spectral::Quadrature::GaussLobatto}}},
+        std::nullopt, serialize(functions_of_time));
+  }
+
+  {
+    const auto rotation_map_options = TestHelpers::test_creation<
+        domain::creators::time_dependent_options::RotationMapOptions<2>>(
+        "InitialQuaternions:\n"
+        "  H5Filename: " +
+        filename + "\n  SubfileName: " + subfile_name +
+        "\n  Time: 0.0\n"
+        "InitialAngles: Auto\n"
+        "DecayTimescale: Auto\n");
+    CHECK(rotation_map_options.name() == "RotationMap");
+    // q
+    // dtq = 0.5 * q * omega
+    // d2tq = 0.5 * (dtq * omega + q * dtomega)
+    std::array<DataVector, 3> expected_quaternion{
+        DataVector{1.0, 0.0, 0.0, 0.0}, DataVector{0.0, 0.1, 0.1, 0.1},
+        DataVector{-0.03, 0.15, 0.15, 0.15}};
+    std::array<DataVector, 3> expected_angle{
+        DataVector{3, 0.1}, DataVector{3, 0.2}, DataVector{3, 0.3}};
+
+    CHECK_ITERABLE_APPROX(expected_quaternion,
+                          rotation_map_options.quaternions);
+    CHECK(expected_angle == rotation_map_options.angles);
+    CHECK_FALSE(rotation_map_options.decay_timescale.has_value());
+  }
+  {
+    const auto rotation_map_options = TestHelpers::test_creation<
+        domain::creators::time_dependent_options::RotationMapOptions<3>>(
+        "InitialQuaternions:\n"
+        "  H5Filename: " +
+        filename + "\n  SubfileName: " + subfile_name +
+        "\n  Time: 0.0\n"
+        "InitialAngles: [[0.11, 0.22, 0.33]]\n"
+        "DecayTimescale: Auto\n");
+    CHECK(rotation_map_options.name() == "RotationMap");
+    // q
+    // dtq = 0.5 * q * omega
+    // d2tq = 0.5 * (dtq * omega + q * dtomega)
+    std::array<DataVector, 4> expected_quaternion{
+        DataVector{1.0, 0.0, 0.0, 0.0}, DataVector{0.0, 0.1, 0.1, 0.1},
+        DataVector{-0.03, 0.15, 0.15, 0.15}, DataVector{4, 0.0}};
+    std::array<DataVector, 4> expected_angle{
+        DataVector{0.11, 0.22, 0.33}, DataVector{3, 0.0}, DataVector{3, 0.0},
+        DataVector{3, 0.0}};
+
+    CHECK_ITERABLE_APPROX(expected_quaternion,
+                          rotation_map_options.quaternions);
+    CHECK(expected_angle == rotation_map_options.angles);
+    CHECK_FALSE(rotation_map_options.decay_timescale.has_value());
+  }
+
+  if (file_system::check_if_file_exists(filename)) {
+    file_system::rm(filename, true);
+  }
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Domain.Creators.TimeDependentOptions.RotationMap",
+                  "[Domain][Unit]") {
+  domain::FunctionsOfTime::register_derived_with_charm();
+  test_rotation_map_options();
+}

--- a/tests/Unit/Domain/Creators/TimeDependentOptions/Test_TranslationMap.cpp
+++ b/tests/Unit/Domain/Creators/TimeDependentOptions/Test_TranslationMap.cpp
@@ -1,0 +1,113 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <sstream>
+#include <string>
+#include <variant>
+
+#include "DataStructures/DataVector.hpp"
+#include "Domain/Creators/TimeDependentOptions/FromVolumeFile.hpp"
+#include "Domain/Creators/TimeDependentOptions/TranslationMap.hpp"
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "Domain/FunctionsOfTime/PiecewisePolynomial.hpp"
+#include "Domain/FunctionsOfTime/RegisterDerivedWithCharm.hpp"
+#include "Framework/TestCreation.hpp"
+#include "IO/H5/AccessType.hpp"
+#include "IO/H5/File.hpp"
+#include "IO/H5/TensorData.hpp"
+#include "IO/H5/VolumeData.hpp"
+#include "NumericalAlgorithms/Spectral/Basis.hpp"
+#include "NumericalAlgorithms/Spectral/Quadrature.hpp"
+#include "Utilities/FileSystem.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeArray.hpp"
+#include "Utilities/Serialization/Serialize.hpp"
+
+namespace {
+template <size_t Dim>
+std::string make_array_str(const double value) {
+  std::stringstream ss{};
+  ss << "[" << value;
+  if constexpr (Dim > 1) {
+    ss << ", " << value;
+    if constexpr (Dim > 2) {
+      ss << ", " << value;
+    }
+  }
+  ss << "]";
+
+  return ss.str();
+}
+
+template <size_t Dim>
+void test_translation_map_options() {
+  {
+    const auto translation_map_options = TestHelpers::test_creation<
+        domain::creators::time_dependent_options::TranslationMapOptions<Dim>>(
+        "InitialValues: [" + make_array_str<Dim>(1.0) + "," +
+        make_array_str<Dim>(2.0) + "," + make_array_str<Dim>(3.0) + "]");
+    CHECK(translation_map_options.name() == "TranslationMap");
+    CHECK(translation_map_options.initial_values ==
+          std::array{DataVector{Dim, 1.0}, DataVector{Dim, 2.0},
+                     DataVector{Dim, 3.0}});
+  }
+  {
+    std::unordered_map<std::string,
+                       std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
+        functions_of_time{};
+    functions_of_time["Translation"] =
+        std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<2>>(
+            0.0,
+            std::array{DataVector{Dim, 1.0}, DataVector{Dim, 2.0},
+                       DataVector{Dim, 3.0}},
+            100.0);
+    const std::string filename{"NewFinalActualFinal2Final.h5"};
+    const std::string subfile_name{"VolumeData"};
+    if (file_system::check_if_file_exists(filename)) {
+      file_system::rm(filename, true);
+    }
+
+    {
+      h5::H5File<h5::AccessType::ReadWrite> h5_file{filename};
+      auto& vol_file = h5_file.insert<h5::VolumeData>(subfile_name);
+
+      // We don't care about the volume data here, just the functions of time
+      vol_file.write_volume_data(
+          0, 0.0,
+          {ElementVolumeData{
+              "blah",
+              {TensorComponent{"RandomTensor", DataVector{3, 0.0}}},
+              {3},
+              {Spectral::Basis::Legendre},
+              {Spectral::Quadrature::GaussLobatto}}},
+          std::nullopt, serialize(functions_of_time));
+    }
+
+    const auto translation_map_options = TestHelpers::test_creation<
+        domain::creators::time_dependent_options::TranslationMapOptions<Dim>>(
+        "InitialValues:\n"
+        "  H5Filename: " +
+        filename + "\n  SubfileName: " + subfile_name + "\n  Time: 0.0");
+    CHECK(translation_map_options.name() == "TranslationMap");
+    CHECK(translation_map_options.initial_values ==
+          std::array{DataVector{Dim, 1.0}, DataVector{Dim, 2.0},
+                     DataVector{Dim, 3.0}});
+
+    if (file_system::check_if_file_exists(filename)) {
+      file_system::rm(filename, true);
+    }
+  }
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Domain.Creators.TimeDependentOptions.TranslationMap",
+                  "[Domain][Unit]") {
+  domain::FunctionsOfTime::register_derived_with_charm();
+  test_translation_map_options<1>();
+  test_translation_map_options<2>();
+  test_translation_map_options<3>();
+}

--- a/tests/Unit/Domain/FunctionsOfTime/Test_FixedSpeedCubic.cpp
+++ b/tests/Unit/Domain/FunctionsOfTime/Test_FixedSpeedCubic.cpp
@@ -63,10 +63,18 @@ void test(
   CHECK(f_of_t->expiration_after(check_time) ==
         std::numeric_limits<double>::infinity());
 
-  INFO("Test stream operator.");
-  CHECK(
-      get_output(*dynamic_cast<const domain::FunctionsOfTime::FixedSpeedCubic*>(
-          f_of_t.get())) == "FixedSpeedCubic(t=10, f=1, v=0.4, tau^2=25)");
+  const auto* fixed_speed_cubic =
+      dynamic_cast<const domain::FunctionsOfTime::FixedSpeedCubic*>(
+          f_of_t.get());
+
+  CHECK(fixed_speed_cubic->velocity() == velocity);
+  CHECK(fixed_speed_cubic->decay_timescale() == decay_timescale);
+
+  {
+    INFO("Test stream operator.");
+    CHECK(get_output(*fixed_speed_cubic) ==
+          "FixedSpeedCubic(t=10, f=1, v=0.4, tau^2=25)");
+  }
 }
 
 void test_function(const double initial_function_value,


### PR DESCRIPTION
## Proposed changes

Second PR in the series to revamp the time dependent options of the Sphere and BCO domain creators.

This PR adds common options for the
- Rotation map
- Expansion map
- Translation map

These common options were designed so that different function of time types (`PiecewisePolynomial` or `SettleToConst`) could be chosen at runtime.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

~Depends on and includes #6109~

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
