### PR TITLE
Add YlmsFromSpEC to shape time dependent options

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -55,6 +55,8 @@ Checks: '*,
 -llvm-qualified-auto,
 # We are not developing LLVM libc,
 -llvmlibc-*,
+# Triggers when 'l' is used because it's "too similar" to 'I'
+-misc-confusable-identifiers,
 # thinks constexpr variables in header files cause ODR violations,
 -misc-definitions-in-headers,
 # false positives,

--- a/src/Domain/Creators/TimeDependentOptions/ShapeMap.cpp
+++ b/src/Domain/Creators/TimeDependentOptions/ShapeMap.cpp
@@ -17,6 +17,7 @@
 #include "DataStructures/ModalVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/Structure/ObjectLabel.hpp"
+#include "FromVolumeFile.hpp"
 #include "NumericalAlgorithms/SphericalHarmonics/Spherepack.hpp"
 #include "NumericalAlgorithms/SphericalHarmonics/SpherepackIterator.hpp"
 #include "NumericalAlgorithms/SphericalHarmonics/Strahlkorper.hpp"
@@ -226,6 +227,14 @@ initial_shape_and_size_funcs(
           shape_funcs[0][iter.set(1_st, m)()] = 0.0;
         }
       }
+    } else if (std::holds_alternative<FromVolumeFile<names::ShapeSize<Object>>>(
+                   shape_options.initial_values.value())) {
+      const auto& volume_file_options =
+          std::get<FromVolumeFile<names::ShapeSize<Object>>>(
+              shape_options.initial_values.value());
+
+      shape_funcs = volume_file_options.shape_values;
+      size_funcs = volume_file_options.size_values;
     }
   }
 

--- a/src/Domain/Creators/TimeDependentOptions/ShapeMap.cpp
+++ b/src/Domain/Creators/TimeDependentOptions/ShapeMap.cpp
@@ -4,17 +4,24 @@
 #include "Domain/Creators/TimeDependentOptions/ShapeMap.hpp"
 
 #include <array>
+#include <cmath>
+#include <fstream>
+#include <istream>
+#include <limits>
+#include <sstream>
 #include <string>
 #include <utility>
 #include <variant>
 
 #include "DataStructures/DataVector.hpp"
+#include "DataStructures/ModalVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/Structure/ObjectLabel.hpp"
 #include "NumericalAlgorithms/SphericalHarmonics/Spherepack.hpp"
 #include "NumericalAlgorithms/SphericalHarmonics/SpherepackIterator.hpp"
 #include "NumericalAlgorithms/SphericalHarmonics/Strahlkorper.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrHorizon.hpp"
+#include "Utilities/EqualWithinRoundoff.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/StdArrayHelpers.hpp"
 
@@ -36,6 +43,16 @@ YlmsFromFile::YlmsFromFile(std::string h5_filename_in,
       match_time_epsilon(match_time_epsilon_in),
       set_l1_coefs_to_zero(set_l1_coefs_to_zero_in),
       check_frame(check_frame_in) {}
+
+YlmsFromSpEC::YlmsFromSpEC() = default;
+YlmsFromSpEC::YlmsFromSpEC(std::string dat_filename_in,
+                           const double match_time_in,
+                           const std::optional<double> match_time_epsilon_in,
+                           bool set_l1_coefs_to_zero_in)
+    : dat_filename(std::move(dat_filename_in)),
+      match_time(match_time_in),
+      match_time_epsilon(match_time_epsilon_in),
+      set_l1_coefs_to_zero(set_l1_coefs_to_zero_in) {}
 
 template <bool IncludeTransitionEndsAtCube, domain::ObjectLabel Object>
 std::pair<std::array<DataVector, 3>, std::array<DataVector, 4>>
@@ -65,7 +82,7 @@ initial_shape_and_size_funcs(
       shape_funcs[0] = ylm.phys_to_spec(radial_distortion);
       // Transform from SPHEREPACK to actual Ylm for size func
       size_funcs[0][0] = shape_funcs[0][0] * sqrt(0.5 * M_PI);
-      // Set l=0 for shape map to 0 because size is going to be used
+      // Set l=0 for shape map to 0 because size control will adjust l=0
       shape_funcs[0][0] = 0.0;
     } else if (std::holds_alternative<YlmsFromFile>(
                    shape_options.initial_values.value())) {
@@ -98,12 +115,115 @@ initial_shape_and_size_funcs(
         // Transform from SPHEREPACK to actual Ylm for size func
         gsl::at(size_funcs, i)[0] =
             gsl::at(shape_funcs, i)[0] * sqrt(0.5 * M_PI);
-        // Set l=0 for shape map to 0 because size is going to be used
+        // Set l=0 for shape map to 0 because size control will adjust l=0
         gsl::at(shape_funcs, i)[0] = 0.0;
         if (set_l1_coefs_to_zero) {
           for (int m = -1; m <= 1; m++) {
             gsl::at(shape_funcs, i)[iter.set(1_st, m)()] = 0.0;
           }
+        }
+      }
+    } else if (std::holds_alternative<YlmsFromSpEC>(
+                   shape_options.initial_values.value())) {
+      const auto& spec_option =
+          std::get<YlmsFromSpEC>(shape_options.initial_values.value());
+      const std::string& dat_filename = spec_option.dat_filename;
+      const double match_time = spec_option.match_time;
+      const double match_time_epsilon =
+          spec_option.match_time_epsilon.value_or(1e-12);
+      const bool set_l1_coefs_to_zero = spec_option.set_l1_coefs_to_zero;
+
+      std::ifstream dat_file(dat_filename);
+      if (not dat_file.is_open()) {
+        ERROR("Unable to open SpEC dat file " << dat_filename);
+      }
+      std::string line{};
+      size_t total_col = 0;
+      std::optional<size_t> l_max{};
+      std::array<double, 3> center{};
+      ModalVector coefficients{};
+      // This will be actually set below
+      ylm::SpherepackIterator file_iter{2, 2};
+
+      // We have to parse the dat file manually
+      while (std::getline(dat_file, line)) {
+        // Avoid comment lines. The SpEC file puts the legend in comments at the
+        // top of the file, so we count how many columns the dat file has based
+        // on the number of comment lines that are the legend (ends in ')')
+        if (line.starts_with("#")) {
+          if (line.starts_with("# [") and line.ends_with(")")) {
+            ++total_col;
+          }
+          continue;
+        }
+
+        std::stringstream ss(line);
+
+        double time = 0.0;
+        ss >> time;
+
+        // Set scale to current time plus 1 just in case time = 0
+        if (not equal_within_roundoff(time, match_time, match_time_epsilon,
+                                      time + 1.0)) {
+          continue;
+        }
+
+        if (l_max.has_value()) {
+          ERROR("Found more than one time in the SpEC dat file "
+                << dat_filename << " that is within a relative epsilon of "
+                << match_time_epsilon << " of the time requested " << time);
+        }
+
+        // Casting to an integer floors a double, so we add 0.5 before we take
+        // the sqrt to avoid any rounding issues
+        const auto l_max_plus_one =
+            static_cast<size_t>(sqrt(static_cast<double>(total_col) + 0.5));
+        if (l_max_plus_one == 0) {
+          ERROR(
+              "Invalid l_max from SpEC dat file. l_max + 1 was computed to be "
+              "0");
+        }
+        l_max = l_max_plus_one - 1;
+
+        ss >> center[0];
+        ss >> center[1];
+        ss >> center[2];
+
+        coefficients.destructive_resize(
+            ylm::Spherepack::spectral_size(l_max.value(), l_max.value()));
+
+        file_iter = ylm::SpherepackIterator{l_max.value(), l_max.value()};
+
+        for (int l = 0; l <= static_cast<int>(l_max.value()); l++) {
+          for (int m = -l; m <= l; m++) {
+            ss >> coefficients[file_iter.set(static_cast<size_t>(l), m)()];
+          }
+        }
+      }
+
+      if (not l_max.has_value()) {
+        ERROR_NO_TRACE("Unable to find requested time "
+                       << time << " within an epsilon of " << match_time_epsilon
+                       << " in SpEC dat file " << dat_filename);
+      }
+
+      const ylm::Strahlkorper<Frame::Inertial> file_strahlkorper{
+          l_max.value(), l_max.value(), coefficients, center};
+      const ylm::Strahlkorper<Frame::Inertial> this_strahlkorper{
+          shape_options.l_max, 1.0, std::array{0.0, 0.0, 0.0}};
+      ylm::SpherepackIterator iter{shape_options.l_max, shape_options.l_max};
+
+      shape_funcs[0] =
+          -1.0 * file_strahlkorper.ylm_spherepack().prolong_or_restrict(
+                     file_strahlkorper.coefficients(),
+                     this_strahlkorper.ylm_spherepack());
+      // Transform from SPHEREPACK to actual Ylm for size func
+      size_funcs[0][0] = shape_funcs[0][0] * sqrt(0.5 * M_PI);
+      // Set l=0 for shape map to 0 because size control will adjust l=0
+      shape_funcs[0][0] = 0.0;
+      if (set_l1_coefs_to_zero) {
+        for (int m = -1; m <= 1; m++) {
+          shape_funcs[0][iter.set(1_st, m)()] = 0.0;
         }
       }
     }

--- a/src/Domain/Creators/TimeDependentOptions/ShapeMap.hpp
+++ b/src/Domain/Creators/TimeDependentOptions/ShapeMap.hpp
@@ -11,6 +11,7 @@
 #include <variant>
 
 #include "DataStructures/DataVector.hpp"
+#include "Domain/Creators/TimeDependentOptions/FromVolumeFile.hpp"
 #include "Domain/Structure/ObjectLabel.hpp"
 #include "NumericalAlgorithms/SphericalHarmonics/IO/ReadSurfaceYlm.hpp"
 #include "NumericalAlgorithms/SphericalHarmonics/Strahlkorper.hpp"
@@ -203,7 +204,8 @@ struct ShapeMapOptions {
 
   struct InitialValues {
     using type = Options::Auto<
-        std::variant<KerrSchildFromBoyerLindquist, YlmsFromFile, YlmsFromSpEC>,
+        std::variant<KerrSchildFromBoyerLindquist, YlmsFromFile, YlmsFromSpEC,
+                     FromVolumeFile<names::ShapeSize<Object>>>,
         Spherical>;
     static constexpr Options::String help = {
         "Initial Ylm coefficients for the shape map. Specify 'Spherical' for "
@@ -233,13 +235,15 @@ struct ShapeMapOptions {
                           tmpl::push_back<common_options, TransitionEndsAtCube>,
                           common_options>;
   ShapeMapOptions() = default;
-  ShapeMapOptions(size_t l_max_in,
-                  std::optional<std::variant<KerrSchildFromBoyerLindquist,
-                                             YlmsFromFile, YlmsFromSpEC>>
-                      initial_values_in,
-                  std::optional<std::array<double, 3>> initial_size_values_in =
-                      std::nullopt,
-                  bool transition_ends_at_cube_in = false)
+  ShapeMapOptions(
+      size_t l_max_in,
+      std::optional<
+          std::variant<KerrSchildFromBoyerLindquist, YlmsFromFile, YlmsFromSpEC,
+                       FromVolumeFile<names::ShapeSize<Object>>>>
+          initial_values_in,
+      std::optional<std::array<double, 3>> initial_size_values_in =
+          std::nullopt,
+      bool transition_ends_at_cube_in = false)
       : l_max(l_max_in),
         initial_values(std::move(initial_values_in)),
         initial_size_values(initial_size_values_in),
@@ -247,7 +251,8 @@ struct ShapeMapOptions {
 
   size_t l_max{};
   std::optional<
-      std::variant<KerrSchildFromBoyerLindquist, YlmsFromFile, YlmsFromSpEC>>
+      std::variant<KerrSchildFromBoyerLindquist, YlmsFromFile, YlmsFromSpEC,
+                   FromVolumeFile<names::ShapeSize<Object>>>>
       initial_values{};
   std::optional<std::array<double, 3>> initial_size_values{};
   bool transition_ends_at_cube{false};

--- a/src/Domain/Creators/TimeDependentOptions/ShapeMap.hpp
+++ b/src/Domain/Creators/TimeDependentOptions/ShapeMap.hpp
@@ -129,6 +129,54 @@ struct YlmsFromFile {
   bool check_frame{true};
 };
 
+struct YlmsFromSpEC {
+  struct DatFilename {
+    using type = std::string;
+    static constexpr Options::String help =
+        "Name of the SpEC dat file holding the coefficients. Note that this "
+        "isn't a Dat file within an H5 file. This must be an actual '.dat' "
+        "file on disk.";
+  };
+
+  struct MatchTime {
+    using type = double;
+    static constexpr Options::String help =
+        "Time in the H5File to get the coefficients at. Will likely be the "
+        "same as the initial time";
+  };
+
+  struct MatchTimeEpsilon {
+    using type = Options::Auto<double>;
+    static constexpr Options::String help =
+        "Look for times in the H5File within this epsilon of the match time. "
+        "This is to avoid having to know the exact time to all digits. Default "
+        "is 1e-12.";
+  };
+
+  struct SetL1CoefsToZero {
+    using type = bool;
+    static constexpr Options::String help =
+        "Whether to set the L=1 coefs to zero or not. This may be desirable "
+        "because L=1 is degenerate with a translation of the BH.";
+  };
+
+  using options =
+      tmpl::list<DatFilename, MatchTime, MatchTimeEpsilon, SetL1CoefsToZero>;
+
+  static constexpr Options::String help = {
+      "Read the Y_lm coefficients of a Strahlkorper from file and use those to "
+      "initialize the coefficients of a shape map."};
+  YlmsFromSpEC();
+  YlmsFromSpEC(std::string dat_filename_in, double match_time_in,
+               std::optional<double> match_time_epsilon_in,
+               bool set_l1_coefs_to_zero_in);
+
+  std::string dat_filename{};
+  double match_time{};
+  std::optional<double> match_time_epsilon{};
+  bool set_l1_coefs_to_zero{};
+};
+
 /*!
  * \brief Class to be used as an option for initializing shape map coefficients.
  *
@@ -154,9 +202,9 @@ struct ShapeMapOptions {
   };
 
   struct InitialValues {
-    using type =
-        Options::Auto<std::variant<KerrSchildFromBoyerLindquist, YlmsFromFile>,
-                      Spherical>;
+    using type = Options::Auto<
+        std::variant<KerrSchildFromBoyerLindquist, YlmsFromFile, YlmsFromSpEC>,
+        Spherical>;
     static constexpr Options::String help = {
         "Initial Ylm coefficients for the shape map. Specify 'Spherical' for "
         "all coefficients to be initialized to zero."};
@@ -185,20 +233,21 @@ struct ShapeMapOptions {
                           tmpl::push_back<common_options, TransitionEndsAtCube>,
                           common_options>;
   ShapeMapOptions() = default;
-  ShapeMapOptions(
-      size_t l_max_in,
-      std::optional<std::variant<KerrSchildFromBoyerLindquist, YlmsFromFile>>
-          initial_values_in,
-      std::optional<std::array<double, 3>> initial_size_values_in =
-          std::nullopt,
-      bool transition_ends_at_cube_in = false)
+  ShapeMapOptions(size_t l_max_in,
+                  std::optional<std::variant<KerrSchildFromBoyerLindquist,
+                                             YlmsFromFile, YlmsFromSpEC>>
+                      initial_values_in,
+                  std::optional<std::array<double, 3>> initial_size_values_in =
+                      std::nullopt,
+                  bool transition_ends_at_cube_in = false)
       : l_max(l_max_in),
         initial_values(std::move(initial_values_in)),
         initial_size_values(initial_size_values_in),
         transition_ends_at_cube(transition_ends_at_cube_in) {}
 
   size_t l_max{};
-  std::optional<std::variant<KerrSchildFromBoyerLindquist, YlmsFromFile>>
+  std::optional<
+      std::variant<KerrSchildFromBoyerLindquist, YlmsFromFile, YlmsFromSpEC>>
       initial_values{};
   std::optional<std::array<double, 3>> initial_size_values{};
   bool transition_ends_at_cube{false};

--- a/tests/Unit/Domain/Creators/TimeDependentOptions/Test_ShapeMap.cpp
+++ b/tests/Unit/Domain/Creators/TimeDependentOptions/Test_ShapeMap.cpp
@@ -1,9 +1,14 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
+#include "DataStructures/DataVector.hpp"
 #include "Framework/TestingFramework.hpp"
 
 #include <array>
+#include <catch2/matchers/catch_matchers_string.hpp>
+#include <fstream>
+#include <iomanip>
+#include <ios>
 #include <random>
 #include <string>
 #include <vector>
@@ -119,6 +124,30 @@ void test_shape_map_options() {
     CHECK(shape_map_options.initial_values.has_value());
     CHECK(std::holds_alternative<
           domain::creators::time_dependent_options::YlmsFromFile>(
+        shape_map_options.initial_values.value()));
+    CHECK_FALSE(shape_map_options.initial_size_values.has_value());
+    CHECK_FALSE(shape_map_options.transition_ends_at_cube);
+  }
+  {
+    constexpr bool include_transition_ends_at_cube = false;
+    constexpr domain::ObjectLabel object_label = domain::ObjectLabel::None;
+    CAPTURE(include_transition_ends_at_cube);
+    CAPTURE(object_label);
+    const auto shape_map_options = TestHelpers::test_creation<
+        domain::creators::time_dependent_options::ShapeMapOptions<
+            include_transition_ends_at_cube, object_label>>(
+        "LMax: 8\n"
+        "InitialValues:\n"
+        "  DatFilename: PartialEclipseOfTheHeart.dat\n"
+        "  MatchTime: 1.7\n"
+        "  MatchTimeEpsilon: Auto\n"
+        "  SetL1CoefsToZero: True\n"
+        "SizeInitialValues: Auto");
+    CHECK(shape_map_options.name() == "ShapeMap");
+    CHECK(shape_map_options.l_max == 8);
+    CHECK(shape_map_options.initial_values.has_value());
+    CHECK(std::holds_alternative<
+          domain::creators::time_dependent_options::YlmsFromSpEC>(
         shape_map_options.initial_values.value()));
     CHECK_FALSE(shape_map_options.initial_size_values.has_value());
     CHECK_FALSE(shape_map_options.transition_ends_at_cube);
@@ -293,6 +322,138 @@ void test_funcs(const gsl::not_null<Generator*> generator) {
                        DataVector{-1.0 * strahlkorpers[1].coefficients()[0] *
                                   sqrt(0.5 * M_PI)},
                        DataVector{0.0}, DataVector{0.0}});
+    }
+
+    if (file_system::check_if_file_exists(test_filename)) {
+      file_system::rm(test_filename, true);
+    }
+  }
+  {
+    const std::string test_filename{"PartialEclipseOfTheHeart.dat"};
+    if (file_system::check_if_file_exists(test_filename)) {
+      file_system::rm(test_filename, true);
+    }
+    const double time = 1.7;
+    // Purposefully larger than the LMax in the options so that the
+    // Strahlkorpers will be restricted
+    const size_t file_l_max = 10;
+    const std::uniform_real_distribution<double> distribution(0.1, 2.0);
+    using Frame = ::Frame::Inertial;
+    ylm::Strahlkorper<Frame> strahlkorper{};
+    std::vector<std::string> legend{};
+    std::vector<double> data{};
+
+    // Scoped to close dat file
+    {
+      std::fstream test_file{};
+      test_file.open(test_filename, std::ios_base::out);
+      test_file << std::scientific << std::setprecision(16);
+      legend.clear();
+      data.clear();
+      const auto radius = make_with_random_values<DataVector>(
+          generator, distribution,
+          ylm::Spherepack::physical_size(file_l_max, file_l_max));
+      strahlkorper = ylm::Strahlkorper<Frame>(file_l_max, file_l_max, radius,
+                                              std::array{0.0, 0.0, 0.0});
+
+      ylm::fill_ylm_legend_and_data(make_not_null(&legend),
+                                    make_not_null(&(data)), strahlkorper, time,
+                                    file_l_max);
+
+      test_file << "# This is a random comment\n";
+      // These columns won't be exactly what is in the SpEC dat file, but they
+      // will be close enough. Also SpEC starts columns numbers from 1
+      size_t col_num = 1;
+      for (const std::string& col : legend) {
+        // SpEC doesn't write Lmax
+        if (col == "Lmax") {
+          continue;
+        }
+
+        test_file << "# [" << col_num << "] = " << col << "\n";
+        col_num++;
+      }
+      test_file << "# Another random comment to show\n";
+
+      // Write three rows of same data
+      for (size_t i = 0; i < 3; i++) {
+        // Time and center
+        test_file << time + static_cast<double>(i) << " " << 0.0 << " " << 0.0
+                  << " " << 0.0;
+        // Skip writing time, center, and Lmax
+        for (size_t j = 5; j < data.size(); j++) {
+          test_file << " " << data[j];
+        }
+        test_file << "\n";
+      }
+    }
+
+    {
+      const auto shape_map_options = TestHelpers::test_creation<
+          domain::creators::time_dependent_options::ShapeMapOptions<
+              false, domain::ObjectLabel::None>>(
+          "LMax: 8\n"
+          "InitialValues:\n"
+          "  DatFilename: PartialEclipseOfTheHeart.dat\n"
+          "  MatchTime: 2.7\n"
+          "  MatchTimeEpsilon: Auto\n"
+          "  SetL1CoefsToZero: True\n"
+          "SizeInitialValues: Auto");
+
+      const auto [shape_funcs, size_funcs] =
+          domain::creators::time_dependent_options::
+              initial_shape_and_size_funcs(shape_map_options, inner_radius);
+
+      ylm::SpherepackIterator iter{l_max, l_max};
+      ylm::SpherepackIterator file_iter{file_l_max, file_l_max};
+      for (size_t i = 0; i < shape_funcs.size(); i++) {
+        const size_t expected_size =
+            ylm::Spherepack::spectral_size(l_max, l_max);
+        // Make sure they were restricted properly
+        CHECK(gsl::at(shape_funcs, i).size() == expected_size);
+
+        if (i > 0) {
+          CHECK(gsl::at(shape_funcs, i) == DataVector{expected_size, 0.0});
+          continue;
+        }
+
+        // Loop pointwise so we only check the coefficients that matter
+        for (size_t l = 0; l <= l_max; l++) {
+          for (int m = -static_cast<int>(l); m <= static_cast<int>(l); m++) {
+            CAPTURE(l);
+            CAPTURE(m);
+            const double expected_value =
+                l < 2
+                    ? 0.0
+                    : -1.0 * strahlkorper.coefficients()[file_iter.set(l, m)()];
+            CHECK(gsl::at(shape_funcs, i)[iter.set(l, m)()] == expected_value);
+          }
+        }
+      }
+      CHECK(size_funcs ==
+            std::array{DataVector{-1.0 * strahlkorper.coefficients()[0] *
+                                  sqrt(0.5 * M_PI)},
+                       DataVector{0.0}, DataVector{0.0}, DataVector{0.0}});
+    }
+
+    {
+      const auto shape_map_options = TestHelpers::test_creation<
+          domain::creators::time_dependent_options::ShapeMapOptions<
+              false, domain::ObjectLabel::None>>(
+          "LMax: 8\n"
+          "InitialValues:\n"
+          "  DatFilename: PartialEclipseOfTheHeart.dat\n"
+          "  MatchTime: 10000.0\n"
+          "  MatchTimeEpsilon: Auto\n"
+          "  SetL1CoefsToZero: True\n"
+          "SizeInitialValues: Auto");
+      CHECK_THROWS_WITH(
+          (domain::creators::time_dependent_options::
+               initial_shape_and_size_funcs(shape_map_options, inner_radius)),
+          Catch::Matchers::ContainsSubstring(
+              "Unable to find requested time 1") and
+              Catch::Matchers::ContainsSubstring(
+                  "in SpEC dat file PartialEclipseOfTheHeart.dat"));
     }
 
     if (file_system::check_if_file_exists(test_filename)) {


### PR DESCRIPTION
## Proposed changes

This is tangentially related to the PRs revamping the time dependent options for the Sphere and BCO domain creators.

This adds the ability to read the shape coefficients from a SpEC ID horizons dat file (not a dat file within an H5 file, but an actual dat file). If we are starting from SpEC ID (which we can do), then this is an important feature to have.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

~Depends on and includes #6109.~

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
