### PR TITLE
Use new common time dependent options in Sphere and BCO domains

### DIFF
--- a/src/Domain/Creators/TimeDependentOptions/BinaryCompactObject.hpp
+++ b/src/Domain/Creators/TimeDependentOptions/BinaryCompactObject.hpp
@@ -17,8 +17,10 @@
 #include "Domain/CoordinateMaps/TimeDependent/Rotation.hpp"
 #include "Domain/CoordinateMaps/TimeDependent/Shape.hpp"
 #include "Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/ShapeMapTransitionFunction.hpp"
+#include "Domain/Creators/TimeDependentOptions/ExpansionMap.hpp"
+#include "Domain/Creators/TimeDependentOptions/RotationMap.hpp"
 #include "Domain/Creators/TimeDependentOptions/ShapeMap.hpp"
-#include "Domain/Creators/TimeDependentOptions/Sphere.hpp"
+#include "Domain/Creators/TimeDependentOptions/TranslationMap.hpp"
 #include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
 #include "Domain/Structure/ObjectLabel.hpp"
 #include "Options/Auto.hpp"
@@ -146,105 +148,30 @@ struct TimeDependentMapOptions {
   /// The outer boundary radius of the map is always set to
   /// the outer boundary of the Domain, so there is no option
   /// here to set the outer boundary radius.
-  struct ExpansionMapOptions {
-    using type = Options::Auto<ExpansionMapOptions, Options::AutoLabel::None>;
-    static std::string name() { return "ExpansionMap"; }
-    static constexpr Options::String help = {
-        "Options for the expansion map. Specify 'None' to not use this map."};
-    struct InitialValues {
-      using type = std::array<double, 2>;
-      static constexpr Options::String help = {
-          "Initial value and deriv of expansion."};
-    };
-    struct AsymptoticVelocityOuterBoundary {
-      using type = double;
-      static constexpr Options::String help = {
-          "The asymptotic velocity of the outer boundary."};
-    };
-    struct DecayTimescaleOuterBoundaryVelocity {
-      using type = double;
-      static constexpr Options::String help = {
-          "The timescale for how fast the outer boundary velocity approaches "
-          "its asymptotic value."};
-    };
-    using options = tmpl::list<InitialValues, AsymptoticVelocityOuterBoundary,
-                               DecayTimescaleOuterBoundaryVelocity>;
-    ExpansionMapOptions() = default;
-    ExpansionMapOptions(std::array<double, 2> initial_values_in,
-                        double outer_boundary_velocity_in,
-                        double outer_boundary_decay_time_in)
-        : initial_values(initial_values_in),
-          outer_boundary_velocity(outer_boundary_velocity_in),
-          outer_boundary_decay_time(outer_boundary_decay_time_in) {}
+  using ExpansionMapOptions =
+      domain::creators::time_dependent_options::ExpansionMapOptions<false>;
+  using ExpansionMapOptionType = typename ExpansionMapOptions::type::value_type;
 
-    std::array<double, 2> initial_values{
-        std::numeric_limits<double>::signaling_NaN(),
-        std::numeric_limits<double>::signaling_NaN()};
-    double outer_boundary_velocity{
-        std::numeric_limits<double>::signaling_NaN()};
-    double outer_boundary_decay_time{
-        std::numeric_limits<double>::signaling_NaN()};
-  };
-
-  struct RotationMapOptions {
-    using type = Options::Auto<RotationMapOptions, Options::AutoLabel::None>;
-    static std::string name() { return "RotationMap"; }
-    static constexpr Options::String help = {
-        "Options for a time-dependent rotation map about an arbitrary axis. "
-        "Specify 'None' to not use this map."};
-
-    struct InitialAngularVelocity {
-      using type = std::array<double, 3>;
-      static constexpr Options::String help = {"The initial angular velocity."};
-    };
-
-    using options = tmpl::list<InitialAngularVelocity>;
-
-    RotationMapOptions() = default;
-    explicit RotationMapOptions(
-        std::array<double, 3> initial_angular_velocity_in)
-        : initial_angular_velocity(initial_angular_velocity_in) {}
-
-    std::array<double, 3> initial_angular_velocity{};
-  };
+  /// \brief Options for the rotation map
+  using RotationMapOptions =
+      domain::creators::time_dependent_options::RotationMapOptions<false>;
+  using RotationMapOptionType = typename RotationMapOptions::type::value_type;
 
   /// \brief Options for the Translation Map, the outer radius is always set to
   /// the outer boundary of the Domain, so there's no option needed for outer
   /// boundary.
-  struct TranslationMapOptions {
-    using type = Options::Auto<TranslationMapOptions, Options::AutoLabel::None>;
-    static std::string name() { return "TranslationMap"; }
-    static constexpr Options::String help = {
-        "Options for a time-dependent translation map. Specify 'None' to not "
-        "use this map."};
+  using TranslationMapOptions =
+      domain::creators::time_dependent_options::TranslationMapOptions<3>;
+  using TranslationMapOptionType =
+      typename TranslationMapOptions::type::value_type;
 
-    struct InitialValues {
-      using type = std::array<std::array<double, 3>, 3>;
-      static constexpr Options::String help = {
-          "Initial position, velocity and acceleration."};
-    };
-
-    using options = tmpl::list<InitialValues>;
-    TranslationMapOptions() = default;
-    explicit TranslationMapOptions(
-        std::array<std::array<double, 3>, 3> initial_values_in)
-        : initial_values(initial_values_in) {}
-
-    std::array<std::array<double, 3>, 3> initial_values{};
-  };
-
-  // We use a type alias here instead of defining the ShapeMapOptions struct
-  // because there appears to be a bug in clang-10. If the definition of
-  // ShapeMapOptions is here inside TimeDependentMapOptions, on clang-10 there
-  // is a linking error that there is an undefined reference to
-  // Options::Option::parse_as<TimeDependentMapOptions<A>> (and B). This doesn't
-  // show up for GCC. If we put the definition of ShapeMapOptions outside of
-  // TimeDependentMapOptions and just use a type alias here, the linking error
-  // goes away.
+  /// \brief Options for the shape map
   template <domain::ObjectLabel Object>
   using ShapeMapOptions =
       domain::creators::time_dependent_options::ShapeMapOptions<
           not IsCylindrical, Object>;
+  template <domain::ObjectLabel Object>
+  using ShapeMapOptionType = typename ShapeMapOptions<Object>::type::value_type;
 
   using options =
       tmpl::list<InitialTime, ExpansionMapOptions, RotationMapOptions,
@@ -257,12 +184,11 @@ struct TimeDependentMapOptions {
   TimeDependentMapOptions() = default;
 
   TimeDependentMapOptions(
-      double initial_time,
-      std::optional<ExpansionMapOptions> expansion_map_options,
-      std::optional<RotationMapOptions> rotation_map_options,
-      std::optional<TranslationMapOptions> translation_map_options,
-      std::optional<ShapeMapOptions<domain::ObjectLabel::A>> shape_options_A,
-      std::optional<ShapeMapOptions<domain::ObjectLabel::B>> shape_options_B,
+      double initial_time, ExpansionMapOptionType expansion_map_options,
+      RotationMapOptionType rotation_map_options,
+      TranslationMapOptionType translation_map_options,
+      ShapeMapOptionType<domain::ObjectLabel::A> shape_options_A,
+      ShapeMapOptionType<domain::ObjectLabel::B> shape_options_B,
       const Options::Context& context = {});
 
   /*!
@@ -407,11 +333,11 @@ struct TimeDependentMapOptions {
   static size_t get_index(domain::ObjectLabel object);
 
   double initial_time_{std::numeric_limits<double>::signaling_NaN()};
-  std::optional<ExpansionMapOptions> expansion_map_options_{};
-  std::optional<RotationMapOptions> rotation_map_options_{};
-  std::optional<TranslationMapOptions> translation_map_options_{};
-  std::optional<ShapeMapOptions<domain::ObjectLabel::A>> shape_options_A_{};
-  std::optional<ShapeMapOptions<domain::ObjectLabel::B>> shape_options_B_{};
+  ExpansionMapOptionType expansion_map_options_;
+  RotationMapOptionType rotation_map_options_;
+  TranslationMapOptionType translation_map_options_;
+  ShapeMapOptionType<domain::ObjectLabel::A> shape_options_A_{};
+  ShapeMapOptionType<domain::ObjectLabel::B> shape_options_B_{};
   std::array<std::optional<double>, 2> deformed_radii_{};
 
   // Maps

--- a/src/Domain/Creators/TimeDependentOptions/ExpansionMap.cpp
+++ b/src/Domain/Creators/TimeDependentOptions/ExpansionMap.cpp
@@ -4,87 +4,171 @@
 #include "Domain/Creators/TimeDependentOptions/ExpansionMap.hpp"
 
 #include <array>
+#include <memory>
 #include <string>
 #include <variant>
 
 #include "DataStructures/DataVector.hpp"
 #include "Domain/Creators/TimeDependentOptions/FromVolumeFile.hpp"
+#include "Domain/FunctionsOfTime/FixedSpeedCubic.hpp"
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "Domain/FunctionsOfTime/PiecewisePolynomial.hpp"
+#include "Domain/FunctionsOfTime/SettleToConstant.hpp"
 #include "Options/Context.hpp"
 #include "Options/ParseError.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/MakeArray.hpp"
 
 namespace domain::creators::time_dependent_options {
-ExpansionMapOptions::ExpansionMapOptions(
-    const std::variant<std::array<double, 3>, FromVolumeFile<names::Expansion>>&
-        expansion_values,
-    const std::variant<std::array<double, 3>, FromVolumeFile<names::Expansion>>&
-        expansion_outer_boundary_values,
-    std::optional<double> decay_timescale_outer_boundary_in,
-    std::optional<double> decay_timescale_in,
-    std::optional<double> asymptotic_velocity_outer_boundary_in,
-    const Options::Context& context)
-    : decay_timescale(std::move(decay_timescale_in)) {
-  const auto set_values =
-      [&, this](const gsl::not_null<std::array<DataVector, 3>*> to_set,
-                const auto& input_values, const bool is_outer_boundary) {
-        if (std::holds_alternative<std::array<double, 3>>(input_values)) {
-          asymptotic_velocity_outer_boundary =
-              asymptotic_velocity_outer_boundary_in;
-          if (decay_timescale.has_value() ==
-              asymptotic_velocity_outer_boundary.has_value()) {
-            PARSE_ERROR(
-                context,
-                "When specifying the ExpansionMap initial outer boundary "
-                "values directly, you must specify one of DecayTimescale or "
-                "AsymptoticVelocityOuterBoundary, but not both.");
-          }
-          auto& values = std::get<std::array<double, 3>>(input_values);
-          for (size_t i = 0; i < to_set->size(); i++) {
-            gsl::at(*to_set, i) = DataVector{1, gsl::at(values, i)};
-          }
-
-          if (is_outer_boundary) {
-            if (not decay_timescale_outer_boundary_in.has_value()) {
-              PARSE_ERROR(context,
-                          "When specifying the ExpansionMap initial outer "
-                          "boundary values directly, you must also specify a "
-                          "'DecayTimescaleOuterBoundary'.");
-            }
-
-            decay_timescale_outer_boundary =
-                decay_timescale_outer_boundary_in.value();
-          }
-
-        } else if (std::holds_alternative<FromVolumeFile<names::Expansion>>(
-                       input_values)) {
-          if (decay_timescale.has_value()) {
-            PARSE_ERROR(
-                context,
-                "When specifying the initial values from a volume file, "
-                "the decay timescale must be 'Auto'.");
-          }
-          auto& values_from_file =
-              std::get<FromVolumeFile<names::Expansion>>(input_values);
-          *to_set = is_outer_boundary
-                        ? values_from_file.expansion_values_outer_boundary
-                        : values_from_file.expansion_values;
-
-          if (is_outer_boundary) {
-            decay_timescale_outer_boundary =
-                decay_timescale_outer_boundary_in.value_or(
-                    values_from_file.decay_timescale_outer_boundary);
-            asymptotic_velocity_outer_boundary =
-                asymptotic_velocity_outer_boundary_in.value_or(
-                    values_from_file.velocity_outer_boundary);
-          }
-        }
-      };
-
-  // Expansion values
-  set_values(make_not_null(&initial_values), expansion_values, false);
-  // Outer boundary
-  set_values(make_not_null(&initial_values_outer_boundary),
-             expansion_outer_boundary_values, true);
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsuggest-attribute=noreturn"
+#endif  // defined(__GNUC__) && !defined(__clang__)
+template <bool AllowSettleFoTs>
+ExpansionMapOptions<AllowSettleFoTs>::ExpansionMapOptions(
+    const std::array<double, 3>& initial_values_in,
+    double decay_timescale_outer_boundary_in,
+    const std::array<double, 3>& initial_values_outer_boundary_in,
+    double decay_timescale_in, const Options::Context& context)
+    : decay_timescale_outer_boundary(decay_timescale_outer_boundary_in),
+      decay_timescale(decay_timescale_in) {
+  if constexpr (AllowSettleFoTs) {
+    initial_values = std::array{DataVector{initial_values_in[0]},
+                                DataVector{initial_values_in[1]},
+                                DataVector{initial_values_in[2]}};
+    initial_values_outer_boundary =
+        std::array{DataVector{initial_values_outer_boundary_in[0]},
+                   DataVector{initial_values_outer_boundary_in[1]},
+                   DataVector{initial_values_outer_boundary_in[2]}};
+  } else {
+    PARSE_ERROR(context,
+                "This class does not allow SettleToConst functions of time, "
+                "but the constructor for allowing SettleToConst functions of "
+                "time was used. Please use the other constructor.");
+  }
 }
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif  // defined(__GNUC__) && !defined(__clang__)
+
+template <bool AllowSettleFoTs>
+ExpansionMapOptions<AllowSettleFoTs>::ExpansionMapOptions(
+    const std::array<double, 3>& initial_values_in,
+    double decay_timescale_outer_boundary_in,
+    double asymptotic_velocity_outer_boundary_in,
+    const Options::Context& /*context*/)
+    : decay_timescale_outer_boundary(decay_timescale_outer_boundary_in),
+      asymptotic_velocity_outer_boundary(
+          asymptotic_velocity_outer_boundary_in) {
+  initial_values = std::array{DataVector{initial_values_in[0]},
+                              DataVector{initial_values_in[1]},
+                              DataVector{initial_values_in[2]}};
+  initial_values_outer_boundary =
+      std::array{DataVector{1.0}, DataVector{0.0}, DataVector{0.0}};
+}
+
+template <bool AllowSettleFoTs>
+FunctionsOfTimeMap get_expansion(
+    const std::variant<ExpansionMapOptions<AllowSettleFoTs>, FromVolumeFile>&
+        expansion_map_options,
+    const double initial_time, const double expiration_time) {
+  const std::string name{"Expansion"};
+  const std::string name_outer_boundary{"ExpansionOuterBoundary"};
+  FunctionsOfTimeMap result{};
+
+  if (std::holds_alternative<FromVolumeFile>(expansion_map_options)) {
+    const auto& from_vol_file = std::get<FromVolumeFile>(expansion_map_options);
+    const auto volume_fot = from_vol_file.retrieve_function_of_time(
+        {name, name_outer_boundary}, initial_time);
+
+    // Expansion must be either a PiecewisePolynomial or a SettleToConstant
+    const auto* pp_volume_fot =
+        dynamic_cast<domain::FunctionsOfTime::PiecewisePolynomial<2>*>(
+            volume_fot.at(name).get());
+    const auto* settle_volume_fot =
+        dynamic_cast<domain::FunctionsOfTime::SettleToConstant*>(
+            volume_fot.at(name).get());
+
+    if (UNLIKELY(pp_volume_fot == nullptr and settle_volume_fot == nullptr)) {
+      ERROR_NO_TRACE(
+          "Expansion function of time read from volume data is not a "
+          "PiecewisePolynomial<2> or a SettleToConstant. Cannot use it to "
+          "initialize the expansion map.");
+    }
+
+    result[name] =
+        volume_fot.at(name)->create_at_time(initial_time, expiration_time);
+
+    // Outer boundary must be either a FixedSpeedCubic or a SettleToConstant
+    const auto* outer_boundary_cubic_volume_fot =
+        dynamic_cast<domain::FunctionsOfTime::FixedSpeedCubic*>(
+            volume_fot.at(name_outer_boundary).get());
+    const auto* outer_boundary_settle_volume_fot =
+        dynamic_cast<domain::FunctionsOfTime::SettleToConstant*>(
+            volume_fot.at(name_outer_boundary).get());
+
+    if (UNLIKELY(outer_boundary_cubic_volume_fot == nullptr and
+                 outer_boundary_settle_volume_fot == nullptr)) {
+      ERROR_NO_TRACE(
+          "ExpansionOuterBoundary function of time read from volume data is "
+          "not a FixedSpeedCubic or a SettleToConstant. Cannot use it to "
+          "initialize the expansion map.");
+    }
+
+    ASSERT(outer_boundary_cubic_volume_fot != nullptr or AllowSettleFoTs,
+           "ExpansionOuterBoundary function of time in the volume file is a "
+           "SettleToConstant, but SettleToConstant functions of time aren't "
+           "allowed.");
+
+    result[name_outer_boundary] =
+        volume_fot.at(name_outer_boundary)->get_clone();
+  } else if (std::holds_alternative<ExpansionMapOptions<AllowSettleFoTs>>(
+                 expansion_map_options)) {
+    const auto& hard_coded_options =
+        std::get<ExpansionMapOptions<AllowSettleFoTs>>(expansion_map_options);
+
+    if (hard_coded_options.asymptotic_velocity_outer_boundary.has_value()) {
+      result[name] =
+          std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<2>>(
+              initial_time, hard_coded_options.initial_values, expiration_time);
+      result[name_outer_boundary] =
+          std::make_unique<domain::FunctionsOfTime::FixedSpeedCubic>(
+              hard_coded_options.initial_values_outer_boundary[0][0],
+              initial_time,
+              hard_coded_options.asymptotic_velocity_outer_boundary.value(),
+              hard_coded_options.decay_timescale_outer_boundary);
+    } else {
+      ASSERT(hard_coded_options.decay_timescale.has_value(),
+             "To construct an ExpansionMap SettleToConstant function of time, "
+             "a decay timescale must be supplied.");
+      result[name] =
+          std::make_unique<domain::FunctionsOfTime::SettleToConstant>(
+              hard_coded_options.initial_values, initial_time,
+              hard_coded_options.decay_timescale.value());
+      result[name_outer_boundary] =
+          std::make_unique<domain::FunctionsOfTime::SettleToConstant>(
+              hard_coded_options.initial_values_outer_boundary, initial_time,
+              hard_coded_options.decay_timescale_outer_boundary);
+    }
+  } else {
+    ERROR("Unknown ExpansionMap.");
+  }
+
+  return result;
+}
+
+#define ALLOWSETTLE(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data)                                     \
+  template struct ExpansionMapOptions<ALLOWSETTLE(data)>;        \
+  template FunctionsOfTimeMap get_expansion(                     \
+      const std::variant<ExpansionMapOptions<ALLOWSETTLE(data)>, \
+                         FromVolumeFile>& expansion_map_options, \
+      double initial_time, double expiration_time);
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (true, false))
+
+#undef INSTANTIATE
+#undef ALLOWSETTLE
 }  // namespace domain::creators::time_dependent_options

--- a/src/Domain/Creators/TimeDependentOptions/ExpansionMap.hpp
+++ b/src/Domain/Creators/TimeDependentOptions/ExpansionMap.hpp
@@ -5,104 +5,113 @@
 
 #include <array>
 #include <cstddef>
+#include <memory>
 #include <optional>
 #include <string>
 #include <variant>
 
 #include "DataStructures/DataVector.hpp"
 #include "Domain/Creators/TimeDependentOptions/FromVolumeFile.hpp"
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
 #include "Options/Auto.hpp"
 #include "Options/Context.hpp"
+#include "Options/Options.hpp"
 #include "Options/String.hpp"
 #include "Utilities/TMPL.hpp"
 
 namespace domain::creators::time_dependent_options {
 /*!
- * \brief Class to be used as an option for initializing expansion map
- * coefficients.
+ * \brief Class that holds hard coded expansion map options from the input file.
+ *
+ * \details This class can also be used as an option tag with the \p type type
+ * alias, `name()` function, and \p help string.
  */
+template <bool AllowSettleFoTs>
 struct ExpansionMapOptions {
-  using type = Options::Auto<ExpansionMapOptions, Options::AutoLabel::None>;
+  using type = Options::Auto<
+      std::variant<ExpansionMapOptions<AllowSettleFoTs>, FromVolumeFile>,
+      Options::AutoLabel::None>;
   static std::string name() { return "ExpansionMap"; }
   static constexpr Options::String help = {
       "Options for a time-dependent expansion of the coordinates. Specify "
       "'None' to not use this map."};
 
   struct InitialValues {
-    using type =
-        std::variant<std::array<double, 3>, FromVolumeFile<names::Expansion>>;
-    static constexpr Options::String help = {
-        "Initial values for the expansion map, its velocity and "
-        "acceleration."};
+    using type = std::array<double, 3>;
+    static constexpr Options::String help =
+        "Initial values for the expansion map, its velocity and acceleration.";
   };
 
   struct InitialValuesOuterBoundary {
-    using type =
-        std::variant<std::array<double, 3>, FromVolumeFile<names::Expansion>>;
+    using type = std::array<double, 3>;
     static constexpr Options::String help = {
-        "Initial values for the expansion map, its velocity and "
-        "acceleration at the outer boundary. Unless you are starting from a "
-        "checkpoint or continuing an evolution, this option should likely be "
-        "[1.0, 0.0, 0.0] at the start of an evolution"};
+        "Initial values for the expansion map, its velocity and acceleration "
+        "at the outer boundary."};
   };
 
   struct DecayTimescaleOuterBoundary {
-    using type = Options::Auto<double>;
+    using type = double;
     static constexpr Options::String help = {
         "A timescale for how fast the outer boundary expansion approaches its "
-        "asymptotic value. Can optionally specify 'Auto' when reading the "
-        "initial values 'FromVolumeFile' to use the decay timescale from the "
-        "function of time in the volume file. Cannot specify 'Auto' when "
-        "initial values are specified directly."};
+        "asymptotic value."};
   };
 
   struct DecayTimescale {
-    using type = Options::Auto<double>;
+    using type = double;
     static constexpr Options::String help = {
-        "If specified, a SettleToConstant function of time will be used for "
-        "the expansion map and this number will determine the timescale that "
-        "the expansion approaches its asymptotic value. If 'Auto' is "
-        "specified, a PiecewisePolynomial function of time will be used for "
-        "the expansion map. Note that if you are reading the initial values "
-        "from a volume file, you must specify 'Auto' for this option."};
+        "A timescale for how fast the expansion approaches its asymptotic "
+        "value with a SettleToConstant function of time."};
   };
 
   struct AsymptoticVelocityOuterBoundary {
-    using type = Options::Auto<double>;
+    using type = double;
     static constexpr Options::String help = {
-        "There are two choices for this option. If a value is specified, a "
-        "FixedSpeedCubic function of time will be used for the expansion map "
-        "at the outer boundary and this number will determine its velocity. If "
-        "'Auto' is specified, the behavior will depend on what is chosen for "
-        "'InitialValuesOuterBoundary'. If values are specified for "
-        "'InitialValuesOuterBoundary', then 'Auto' here means a "
-        "SettleToConstant function of time will be used for the expansion map "
-        "at the outer boundary. If 'FromVolumeFile' is specified for "
-        "'InitialValuesOuterBoundary', then a FixedSpeedCubic function of time "
-        "will be used and the velocity from the function of "
-        "time in the volume file will be used."};
+        "The constant velocity of the outer boundary expansion."};
   };
 
-  using options = tmpl::list<InitialValues, InitialValuesOuterBoundary,
-                             DecayTimescaleOuterBoundary, DecayTimescale,
-                             AsymptoticVelocityOuterBoundary>;
+  using common_options = tmpl::list<InitialValues, DecayTimescaleOuterBoundary>;
+  using settle_options =
+      tmpl::push_back<common_options, InitialValuesOuterBoundary,
+                      DecayTimescale>;
+  using non_settle_options =
+      tmpl::push_back<common_options, AsymptoticVelocityOuterBoundary>;
+
+  using options = tmpl::conditional_t<
+      AllowSettleFoTs,
+      tmpl::list<Options::Alternatives<settle_options, non_settle_options>>,
+      non_settle_options>;
 
   ExpansionMapOptions() = default;
+  // Constructor for SettleToConstant functions of time
   ExpansionMapOptions(
-      const std::variant<std::array<double, 3>,
-                         FromVolumeFile<names::Expansion>>& expansion_values,
-      const std::variant<std::array<double, 3>,
-                         FromVolumeFile<names::Expansion>>&
-          expansion_outer_boundary_values,
-      std::optional<double> decay_timescale_outer_boundary_in,
-      std::optional<double> decay_timescale_in,
-      std::optional<double> asymptotic_velocity_outer_boundary_in,
-      const Options::Context& context = {});
+      const std::array<double, 3>& initial_values_in,
+      double decay_timescale_outer_boundary_in,
+      const std::array<double, 3>& initial_values_outer_boundary_in,
+      double decay_timescale_in, const Options::Context& context = {});
+  // Constructor for non SettleToConstant functions of time
+  ExpansionMapOptions(const std::array<double, 3>& initial_values_in,
+                      double decay_timescale_outer_boundary_in,
+                      double asymptotic_velocity_outer_boundary_in,
+                      const Options::Context& context = {});
 
   std::array<DataVector, 3> initial_values{};
   std::array<DataVector, 3> initial_values_outer_boundary{};
   double decay_timescale_outer_boundary{};
-  std::optional<double> decay_timescale{};
-  std::optional<double> asymptotic_velocity_outer_boundary{};
+  std::optional<double> decay_timescale;
+  std::optional<double> asymptotic_velocity_outer_boundary;
 };
+
+/*!
+ * \brief Helper functions that take the variant of the expansion map options,
+ * and return the fully constructed expansion functions of time.
+ *
+ * \details Even if the functions of time are read from a file, they will have a
+ * new \p initial_time and \p expiration_time (no expiration time for the outer
+ * boundary function of time though).
+ */
+template <bool AllowSettleFoTs>
+FunctionsOfTimeMap get_expansion(
+    const std::variant<ExpansionMapOptions<AllowSettleFoTs>, FromVolumeFile>&
+        expansion_map_options,
+    double initial_time, double expiration_time);
 }  // namespace domain::creators::time_dependent_options

--- a/src/Domain/Creators/TimeDependentOptions/FromVolumeFile.cpp
+++ b/src/Domain/Creators/TimeDependentOptions/FromVolumeFile.cpp
@@ -7,6 +7,7 @@
 #include <boost/math/quaternion.hpp>
 #include <cstddef>
 #include <memory>
+#include <optional>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -23,36 +24,34 @@
 #include "Options/Context.hpp"
 #include "Options/ParseError.hpp"
 #include "Utilities/Algorithm.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/PrettyType.hpp"
 #include "Utilities/Serialization/Serialize.hpp"
 
 namespace domain::creators::time_dependent_options {
-
 namespace {
 // Returns a clone of the FoT requested
 std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime> get_function_of_time(
     const std::string& function_of_time_name, const std::string& h5_filename,
-    const std::string& subfile_name, const double time,
-    const Options::Context& context) {
+    const std::string& subfile_name, const std::optional<double>& time) {
   const h5::H5File<h5::AccessType::ReadOnly> h5_file{h5_filename};
   const auto& vol_file = h5_file.get<h5::VolumeData>(subfile_name);
 
   const std::vector<size_t> obs_ids = vol_file.list_observation_ids();
   if (obs_ids.empty()) {
-    PARSE_ERROR(context, function_of_time_name
-                             << ": There are no observation IDs in the subfile "
-                             << subfile_name << " of H5 file " << h5_filename);
+    ERROR_NO_TRACE(function_of_time_name
+                   << ": There are no observation IDs in the subfile "
+                   << subfile_name << " of H5 file " << h5_filename);
   }
   // Take last observation ID so we have all possible times available
   std::optional<std::vector<char>> serialized_functions_of_time =
       vol_file.get_functions_of_time(obs_ids[obs_ids.size() - 1]);
 
   if (not serialized_functions_of_time.has_value()) {
-    PARSE_ERROR(context,
-                function_of_time_name
-                    << ": There are no functions of time in the subfile "
-                    << subfile_name << " of the H5 file " << h5_filename
-                    << ". Choose a different subfile or H5 file.");
+    ERROR_NO_TRACE(function_of_time_name
+                   << ": There are no functions of time in the subfile "
+                   << subfile_name << " of the H5 file " << h5_filename
+                   << ". Choose a different subfile or H5 file.");
   }
 
   const auto functions_of_time = deserialize<std::unordered_map<
@@ -60,167 +59,42 @@ std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime> get_function_of_time(
       serialized_functions_of_time->data());
 
   if (not functions_of_time.contains(function_of_time_name)) {
-    PARSE_ERROR(context, "No function of time named "
-                             << function_of_time_name << " in the subfile "
-                             << subfile_name << " of the H5 file "
-                             << h5_filename);
+    ERROR_NO_TRACE("No function of time named "
+                   << function_of_time_name << " in the subfile "
+                   << subfile_name << " of the H5 file " << h5_filename);
   }
 
   const auto& function_of_time = functions_of_time.at(function_of_time_name);
   const std::array<double, 2> time_bounds = function_of_time->time_bounds();
 
-  if (time < time_bounds[0] or time > time_bounds[1]) {
+  if (time.has_value() and
+      (time.value() < time_bounds[0] or time.value() > time_bounds[1])) {
     using ::operator<<;
-    PARSE_ERROR(context, function_of_time_name
-                             << ": The requested time " << time
-                             << " is out of the range of the function of time "
-                             << time_bounds << " from the subfile "
-                             << subfile_name << " of the H5 file "
-                             << h5_filename);
+    ERROR_NO_TRACE(function_of_time_name
+                   << ": The requested time " << time
+                   << " is out of the range of the function of time "
+                   << time_bounds << " from the subfile " << subfile_name
+                   << " of the H5 file " << h5_filename);
   }
 
   return function_of_time->get_clone();
 }
 }  // namespace
 
-template <typename FoTName>
-FromVolumeFile<FoTName>::FromVolumeFile(const std::string& h5_filename,
-                                        const std::string& subfile_name,
-                                        const double time,
-                                        const Options::Context& context) {
-  const std::string function_of_time_name = pretty_type::name<FoTName>();
+FromVolumeFile::FromVolumeFile(std::string h5_filename,
+                               std::string subfile_name)
+    : h5_filename_(std::move(h5_filename)),
+      subfile_name_(std::move(subfile_name)) {}
 
-  const auto function_of_time = get_function_of_time(
-      function_of_time_name, h5_filename, subfile_name, time, context);
-
-  values = function_of_time->func_and_2_derivs(time);
-}
-
-FromVolumeFile<names::Expansion>::FromVolumeFile(
-    const std::string& h5_filename, const std::string& subfile_name,
-    const double time, const Options::Context& context) {
-  const std::string expansion_function_of_time_name{"Expansion"};
-
-  const auto exp_function_of_time =
-      get_function_of_time(expansion_function_of_time_name, h5_filename,
-                           subfile_name, time, context);
-  const auto exp_outer_boundary_function_of_time =
-      get_function_of_time(expansion_function_of_time_name + "OuterBoundary",
-                           h5_filename, subfile_name, time, context);
-
-  expansion_values = exp_function_of_time->func_and_2_derivs(time);
-  expansion_values_outer_boundary =
-      exp_outer_boundary_function_of_time->func_and_2_derivs(time);
-
-  const auto* fixed_speed_cubic =
-      dynamic_cast<domain::FunctionsOfTime::FixedSpeedCubic*>(
-          exp_outer_boundary_function_of_time.get());
-
-  if (fixed_speed_cubic == nullptr) {
-    PARSE_ERROR(
-        context,
-        "When reading the Expansion map parameters from a volume file, the "
-        "ExpansionOuterBoundary function of time must be a FixedSpeedCubic.");
+FunctionsOfTimeMap FromVolumeFile::retrieve_function_of_time(
+    const std::unordered_set<std::string>& function_of_time_names,
+    const std::optional<double>& time) const {
+  FunctionsOfTimeMap result{};
+  for (const std::string& name : function_of_time_names) {
+    result[name] =
+        get_function_of_time(name, h5_filename_, subfile_name_, time);
   }
 
-  velocity_outer_boundary = fixed_speed_cubic->velocity();
-  decay_timescale_outer_boundary = fixed_speed_cubic->decay_timescale();
+  return result;
 }
-
-FromVolumeFile<names::Rotation>::FromVolumeFile(
-    const std::string& h5_filename, const std::string& subfile_name,
-    const double time, const Options::Context& context) {
-  const std::string function_of_time_name{"Rotation"};
-
-  const auto function_of_time = get_function_of_time(
-      function_of_time_name, h5_filename, subfile_name, time, context);
-
-  bool is_quat_fot = false;
-  const auto set_values = [this, &function_of_time, &time, &is_quat_fot,
-                           &context]<size_t N>() {
-    const auto* const quat_function_of_time =
-        dynamic_cast<domain::FunctionsOfTime::QuaternionFunctionOfTime<N>*>(
-            function_of_time.get());
-
-    if (quat_function_of_time != nullptr) {
-      quaternions = quat_function_of_time->quat_func_and_2_derivs(time);
-      auto all_angle_values =
-          quat_function_of_time->angle_func_and_all_derivs(time);
-      if (all_angle_values.size() > angle_values.size()) {
-        PARSE_ERROR(context,
-                    "FromVolumeFile bad size of angle values (needed at most "
-                        << angle_values.size() << ", got "
-                        << all_angle_values.size() << ")");
-      }
-      angle_values = make_array<4>(DataVector{3, 0.0});
-      for (size_t i = 0; i < all_angle_values.size(); i++) {
-        gsl::at(angle_values, i) = std::move(all_angle_values[i]);
-      }
-      is_quat_fot = true;
-    }
-  };
-
-  set_values.operator()<2>();
-  set_values.operator()<3>();
-
-  // The FoT isn't a QuaternionFunctionOfTime so we must compute the angle
-  // derivatives ourselves
-  if (not is_quat_fot) {
-    quaternions = function_of_time->func_and_2_derivs(time);
-    std::array<boost::math::quaternion<double>, 3> quats;
-    for (size_t i = 0; i < quaternions.size(); i++) {
-      gsl::at(quats, i) = datavector_to_quaternion(gsl::at(quaternions, i));
-    }
-
-    angle_values = make_array<4>(DataVector{4, 0.0});
-    // We can't compute the angle so set it to zero
-    // We'd need more quaternion derivatives to compute the higher angle
-    // derivatives.
-    // dtq = 0.5 * q * w   =>   w = 2.0 * conj(q) * dtq
-    // d2tq = 0.5 * (dtq * w  + q * dtw)
-    //    =>   dtw = conj(q) * (2.0 * d2tq - dtq * w)
-    angle_values[1] = quaternion_to_datavector(2.0 * conj(quats[0]) * quats[1]);
-    angle_values[2] = quaternion_to_datavector(
-        conj(quats[0]) * (2.0 * quats[2] - quats[1] * datavector_to_quaternion(
-                                                          angle_values[0])));
-    // The above DataVectors have size 4, so we need to make them have size 3.
-    for (size_t i = 0; i < angle_values.size(); i++) {
-      gsl::at(angle_values, i) =
-          DataVector{gsl::at(angle_values, i)[1], gsl::at(angle_values, i)[2],
-                     gsl::at(angle_values, i)[3]};
-    }
-  }
-}
-
-template <ObjectLabel Object>
-FromVolumeFile<names::ShapeSize<Object>>::FromVolumeFile(
-    const std::string& h5_filename, const std::string& subfile_name,
-    const double time, const Options::Context& context) {
-  const std::string object = domain::name(Object);
-  const std::string shape_function_of_time_name{"Shape" + object};
-  const std::string size_function_of_time_name{"Size" + object};
-
-  const auto shape_function_of_time = get_function_of_time(
-      shape_function_of_time_name, h5_filename, subfile_name, time, context);
-  const auto size_function_of_time = get_function_of_time(
-      size_function_of_time_name, h5_filename, subfile_name, time, context);
-
-  shape_values = shape_function_of_time->func_and_2_derivs(time);
-  auto all_size_values = size_function_of_time->func_and_all_derivs(time);
-  if (all_size_values.size() > size_values.size()) {
-    PARSE_ERROR(context,
-                "FromVolumeFile bad size of Size values (needed at most "
-                    << size_values.size() << ", got " << all_size_values.size()
-                    << ")");
-  }
-  size_values = make_array<4>(DataVector{0.0});
-  for (size_t i = 0; i < all_size_values.size(); i++) {
-    gsl::at(size_values, i) = std::move(all_size_values[i]);
-  }
-}
-
-template struct FromVolumeFile<names::Translation>;
-template struct FromVolumeFile<names::ShapeSize<ObjectLabel::A>>;
-template struct FromVolumeFile<names::ShapeSize<ObjectLabel::B>>;
-template struct FromVolumeFile<names::ShapeSize<ObjectLabel::None>>;
 }  // namespace domain::creators::time_dependent_options

--- a/src/Domain/Creators/TimeDependentOptions/FromVolumeFile.hpp
+++ b/src/Domain/Creators/TimeDependentOptions/FromVolumeFile.hpp
@@ -4,9 +4,12 @@
 #pragma once
 
 #include <array>
+#include <memory>
+#include <optional>
 #include <string>
 
 #include "DataStructures/DataVector.hpp"
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
 #include "Domain/Structure/ObjectLabel.hpp"
 #include "Options/Auto.hpp"
 #include "Options/Context.hpp"
@@ -14,20 +17,15 @@
 #include "Utilities/TMPL.hpp"
 
 namespace domain::creators::time_dependent_options {
+/// @{
 /*!
- * \brief Structs meant to be used as template parameters for the
- * `domain::creators::time_dependent_options::FromVolumeFile` classes.
+ * \brief Read in FunctionOfTime coefficients from an H5 file and volume
+ * subfile.
+ *
+ * \details The H5 file will only be accessed in the `retrieve_function_of_time`
+ * function.
  */
-namespace names {
-struct Translation {};
-struct Rotation {};
-struct Expansion {};
-template <domain::ObjectLabel Object>
-struct ShapeSize {};
-}  // namespace names
-
-namespace detail {
-struct FromVolumeFileBase {
+struct FromVolumeFile {
   struct H5Filename {
     using type = std::string;
     static constexpr Options::String help{
@@ -41,84 +39,28 @@ struct FromVolumeFileBase {
         "subfile."};
   };
 
-  struct Time {
-    using type = double;
-    static constexpr Options::String help =
-        "Time in the H5File to get the coefficients at. Will likely be the "
-        "same as the initial time";
-  };
-
-  using options = tmpl::list<H5Filename, SubfileName, Time>;
+  using options = tmpl::list<H5Filename, SubfileName>;
   static constexpr Options::String help =
       "Read function of time coefficients from a volume subfile of an H5 file.";
 
-  FromVolumeFileBase() = default;
-};
-}  // namespace detail
-
-/// @{
-/*!
- * \brief Read in FunctionOfTime coefficients from an H5 file and volume
- * subfile.
- *
- * \details To use, template the class on one of the structs in
- * `domain::creators::time_dependent_options::names`. The general struct will
- * have one member, `values` that will hold the function of time and its first
- * two derivatives.
- *
- * There are specializations for
- *
- * - `domain::creators::time_dependent_options::names::Rotation` because of
- * quaternions
- * - `domain::creators::time_dependent_options::name::Expansion` because it also
- * has outer boundary values (a second function of time)
- * - `domain::creators::time_dependent_options::names::ShapeSize` because it
- * handles both the Shape and Size function of time.
- */
-template <typename FoTName>
-struct FromVolumeFile : public detail::FromVolumeFileBase {
   FromVolumeFile() = default;
-  FromVolumeFile(const std::string& h5_filename,
-                 const std::string& subfile_name, double time,
-                 const Options::Context& context = {});
+  FromVolumeFile(std::string h5_filename, std::string subfile_name);
 
-  std::array<DataVector, 3> values{};
-};
+  /*!
+   * \brief Searches the last observation in the volume subfile and returns
+   * clones of all functions of time in \p function_of_time_names.
+   *
+   * \details If a value for \p time is specified, will ensure that \p time is
+   * within the `domain::FunctionsOfTime::FunctionOfTime::time_bounds()` of each
+   * function of time.
+   */
+  FunctionsOfTimeMap retrieve_function_of_time(
+      const std::unordered_set<std::string>& function_of_time_names,
+      const std::optional<double>& time) const;
 
-template <>
-struct FromVolumeFile<names::Expansion> : public detail::FromVolumeFileBase {
-  FromVolumeFile() = default;
-  FromVolumeFile(const std::string& h5_filename,
-                 const std::string& subfile_name, double time,
-                 const Options::Context& context = {});
-
-  std::array<DataVector, 3> expansion_values{};
-  std::array<DataVector, 3> expansion_values_outer_boundary{};
-  double velocity_outer_boundary{};
-  double decay_timescale_outer_boundary{};
-};
-
-template <>
-struct FromVolumeFile<names::Rotation> : public detail::FromVolumeFileBase {
-  FromVolumeFile() = default;
-  FromVolumeFile(const std::string& h5_filename,
-                 const std::string& subfile_name, double time,
-                 const Options::Context& context = {});
-
-  std::array<DataVector, 3> quaternions{};
-  std::array<DataVector, 4> angle_values{};
-};
-
-template <ObjectLabel Object>
-struct FromVolumeFile<names::ShapeSize<Object>>
-    : public detail::FromVolumeFileBase {
-  FromVolumeFile() = default;
-  FromVolumeFile(const std::string& h5_filename,
-                 const std::string& subfile_name, double time,
-                 const Options::Context& context = {});
-
-  std::array<DataVector, 3> shape_values{};
-  std::array<DataVector, 4> size_values{};
+ private:
+  std::string h5_filename_;
+  std::string subfile_name_;
 };
 /// @}
 }  // namespace domain::creators::time_dependent_options

--- a/src/Domain/Creators/TimeDependentOptions/RotationMap.hpp
+++ b/src/Domain/Creators/TimeDependentOptions/RotationMap.hpp
@@ -15,68 +15,83 @@
 #include "Domain/Creators/TimeDependentOptions/FromVolumeFile.hpp"
 #include "Options/Auto.hpp"
 #include "Options/Context.hpp"
+#include "Options/Options.hpp"
 #include "Options/String.hpp"
 #include "Utilities/TMPL.hpp"
 
 namespace domain::creators::time_dependent_options {
 /*!
- * \brief Class to be used as an option for initializing rotation map
- * coefficients.
+ * \brief Class that holds hard coded rotation map options from the input file.
+ *
+ * \details This class can also be used as an option tag with the \p type type
+ * alias, `name()` function, and \p help string.
  */
-template <size_t NumDerivs>
+template <bool AllowSettleFoTs>
 struct RotationMapOptions {
-  using type = Options::Auto<RotationMapOptions, Options::AutoLabel::None>;
+  using type = Options::Auto<
+      std::variant<RotationMapOptions<AllowSettleFoTs>, FromVolumeFile>,
+      Options::AutoLabel::None>;
   static std::string name() { return "RotationMap"; }
   static constexpr Options::String help = {
       "Options for a time-dependent rotation of the coordinates. Specify "
       "'None' to not use this map."};
 
   struct InitialQuaternions {
-    using type = std::variant<std::vector<std::array<double, 4>>,
-                              FromVolumeFile<names::Rotation>>;
+    using type = std::vector<std::array<double, 4>>;
     static constexpr Options::String help = {
         "Initial values for the quaternion of the rotation map. You can "
         "optionally specify its first two time derivatives. If time "
         "derivatives aren't specified, zero will be used."};
   };
 
-  struct InitialAngles {
-    using type = Options::Auto<std::vector<std::array<double, 3>>>;
-    static constexpr Options::String help = {
-        "Initial values for the angle of the rotation map. If 'Auto' is "
-        "specified, the behavior will depend on the 'InitialQuaternions' "
-        "option. If you are reading the quaternion from a volume file, 'Auto' "
-        "will use the angle values from the volume file. If you are simply "
-        "specifying the quaternion and (optionally) its time derivatives, then "
-        "'Auto' here will set the angle and its time derivatives to zero. If "
-        "values are specified for the angle and its time derivatives, then "
-        "those will override anything computed from the 'InitialQuaternions' "
-        "option."};
+  struct InitialAngularVelocity {
+    using type = std::array<double, 3>;
+    static constexpr Options::String help = {"The initial angular velocity."};
   };
 
   struct DecayTimescale {
-    using type = Options::Auto<double>;
+    using type = double;
     static constexpr Options::String help = {
         "The timescale for how fast the rotation approaches its asymptotic "
-        "value. If this is specified, a SettleToConstant function of time will "
-        "be used. If 'Auto' is specified, a PiecewisePolynomial function of "
-        "time will be used. Note that if you are reading the initial "
-        "quaternions from a volume file, then this option must be 'Auto'"};
+        "value with a SettleToConstant function of time."};
   };
 
-  using options = tmpl::list<InitialQuaternions, InitialAngles, DecayTimescale>;
+  using non_settle_options = tmpl::list<InitialAngularVelocity>;
+  using settle_options = tmpl::list<InitialQuaternions, DecayTimescale>;
+
+  using options = tmpl::conditional_t<
+      AllowSettleFoTs,
+      tmpl::list<Options::Alternatives<non_settle_options, settle_options>>,
+      non_settle_options>;
 
   RotationMapOptions() = default;
+  // Constructor for non SettleToConstant functions of time
+  // NOLINTNEXTLINE(google-explicit-constructor)
+  RotationMapOptions(const std::array<double, 3>& initial_angular_velocity,
+                     const Options::Context& context = {});
+  // Constructor for SettleToConst functions of time
   RotationMapOptions(
-      std::variant<std::vector<std::array<double, 4>>,
-                   FromVolumeFile<names::Rotation>>
-          initial_quaternions,
-      std::optional<std::vector<std::array<double, 3>>> initial_angles,
-      std::optional<double> decay_timescale_in,
-      const Options::Context& context = {});
+      const std::vector<std::array<double, 4>>& initial_quaternions,
+      double decay_timescale_in, const Options::Context& context = {});
 
-  std::array<DataVector, NumDerivs + 1> quaternions{};
-  std::array<DataVector, NumDerivs + 1> angles{};
-  std::optional<double> decay_timescale{};
+  std::array<DataVector, 3> quaternions{};
+  std::array<DataVector, 4> angles{};
+  std::optional<double> decay_timescale;
+
+ private:
+  void initialize_angles_and_quats();
 };
+
+/*!
+ * \brief Helper function that takes the variant of the rotation map options,
+ * and returns the fully constructed rotation function of time.
+ *
+ * \details Even if the function of time is read from a file, it will have a
+ * new \p initial_time and \p expiration_time.
+ */
+template <bool AllowSettleFoTs>
+std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime> get_rotation(
+    const std::variant<RotationMapOptions<AllowSettleFoTs>, FromVolumeFile>&
+        rotation_map_options,
+    double initial_time, double expiration_time);
 }  // namespace domain::creators::time_dependent_options

--- a/src/Domain/Creators/TimeDependentOptions/ShapeMap.cpp
+++ b/src/Domain/Creators/TimeDependentOptions/ShapeMap.cpp
@@ -8,6 +8,7 @@
 #include <fstream>
 #include <istream>
 #include <limits>
+#include <memory>
 #include <sstream>
 #include <string>
 #include <utility>
@@ -16,6 +17,8 @@
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/ModalVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "Domain/FunctionsOfTime/PiecewisePolynomial.hpp"
 #include "Domain/Structure/ObjectLabel.hpp"
 #include "FromVolumeFile.hpp"
 #include "NumericalAlgorithms/SphericalHarmonics/Spherepack.hpp"
@@ -55,26 +58,109 @@ YlmsFromSpEC::YlmsFromSpEC(std::string dat_filename_in,
       match_time_epsilon(match_time_epsilon_in),
       set_l1_coefs_to_zero(set_l1_coefs_to_zero_in) {}
 
+template <ObjectLabel Object>
+FromVolumeFileShapeSize<Object>::FromVolumeFileShapeSize(
+    const bool transition_ends_at_cube_in, std::string h5_filename,
+    std::string subfile_name)
+    : FromVolumeFile(std::move(h5_filename), std::move(subfile_name)),
+      transition_ends_at_cube(transition_ends_at_cube_in) {
+  const auto shape_fot_map =
+      retrieve_function_of_time({"Shape" + name(Object)}, std::nullopt);
+  const auto& shape_fot = shape_fot_map.at("Shape" + name(Object));
+
+  const double initial_time = shape_fot->time_bounds()[0];
+  const auto function = shape_fot->func(initial_time);
+
+  // num_components = 2 * (l_max + 1)**2 if l_max == m_max which it is for the
+  // shape map. This is why we can divide by 2 and take the sqrt without
+  // worrying about odd numbers or non-perfect squares
+  l_max = -1 + sqrt(function[0].size() / 2);
+}
+
 template <bool IncludeTransitionEndsAtCube, domain::ObjectLabel Object>
-std::pair<std::array<DataVector, 3>, std::array<DataVector, 4>>
-initial_shape_and_size_funcs(
-    const ShapeMapOptions<IncludeTransitionEndsAtCube, Object>& shape_options,
-    const double deformed_radius) {
-  const DataVector shape_zeros{
-      ylm::Spherepack::spectral_size(shape_options.l_max, shape_options.l_max),
-      0.0};
+size_t l_max_from_shape_options(
+    const std::variant<ShapeMapOptions<IncludeTransitionEndsAtCube, Object>,
+                       FromVolumeFileShapeSize<Object>>& shape_map_options) {
+  return std::visit([](auto variant) { return variant.l_max; },
+                    shape_map_options);
+}
+
+template <bool IncludeTransitionEndsAtCube, domain::ObjectLabel Object>
+bool transition_ends_at_cube_from_shape_options(
+    const std::variant<ShapeMapOptions<IncludeTransitionEndsAtCube, Object>,
+                       FromVolumeFileShapeSize<Object>>& shape_map_options) {
+  return std::visit(
+      [](auto variant) { return variant.transition_ends_at_cube; },
+      shape_map_options);
+}
+
+template <bool IncludeTransitionEndsAtCube, domain::ObjectLabel Object>
+FunctionsOfTimeMap get_shape_and_size(
+    const std::variant<ShapeMapOptions<IncludeTransitionEndsAtCube, Object>,
+                       FromVolumeFileShapeSize<Object>>& shape_map_options,
+    const double initial_time, const double shape_expiration_time,
+    const double size_expiration_time, const double deformed_radius) {
+  const size_t l_max = l_max_from_shape_options(shape_map_options);
+  const DataVector shape_zeros{ylm::Spherepack::spectral_size(l_max, l_max),
+                               0.0};
+  const std::string shape_name = "Shape" + name(Object);
+  const std::string size_name = "Size" + name(Object);
+
+  FunctionsOfTimeMap result{};
+
+  if (std::holds_alternative<FromVolumeFileShapeSize<Object>>(
+          shape_map_options)) {
+    const auto& from_vol_file =
+        std::get<FromVolumeFileShapeSize<Object>>(shape_map_options);
+    const auto volume_fots = from_vol_file.retrieve_function_of_time(
+        {shape_name, size_name}, initial_time);
+
+    const auto check_fot = [&]<size_t MaxDeriv>(const std::string& name) {
+      // It must be a PiecewisePolynomial
+      if (UNLIKELY(dynamic_cast<
+                       domain::FunctionsOfTime::PiecewisePolynomial<MaxDeriv>*>(
+                       volume_fots.at(name).get()) == nullptr)) {
+        ERROR_NO_TRACE(name << " function of time read from volume data is not "
+                               "a PiecewisePolynomial<"
+                            << MaxDeriv << ">. Cannot use it to initialize the "
+                            << name << " map.");
+      }
+    };
+
+    check_fot.template operator()<2>(shape_name);
+    check_fot.template operator()<3>(size_name);
+
+    result[shape_name] =
+        volume_fots.at(shape_name)
+            ->create_at_time(initial_time, shape_expiration_time);
+    result[size_name] = volume_fots.at(size_name)->create_at_time(
+        initial_time, size_expiration_time);
+
+    return result;
+  }
+
+  if (not std::holds_alternative<
+          ShapeMapOptions<IncludeTransitionEndsAtCube, Object>>(
+          shape_map_options)) {
+    ERROR("Unknown ShapeMap.");
+  }
+
+  const auto& hard_coded_options =
+      std::get<ShapeMapOptions<IncludeTransitionEndsAtCube, Object>>(
+          shape_map_options);
 
   std::array<DataVector, 3> shape_funcs =
       make_array<3, DataVector>(shape_zeros);
   std::array<DataVector, 4> size_funcs =
       make_array<4, DataVector>(DataVector{1, 0.0});
 
-  if (shape_options.initial_values.has_value()) {
+  if (hard_coded_options.initial_values.has_value()) {
     if (std::holds_alternative<KerrSchildFromBoyerLindquist>(
-            shape_options.initial_values.value())) {
-      const ylm::Spherepack ylm{shape_options.l_max, shape_options.l_max};
+            hard_coded_options.initial_values.value())) {
+      const ylm::Spherepack ylm{hard_coded_options.l_max,
+                                hard_coded_options.l_max};
       const auto& mass_and_spin = std::get<KerrSchildFromBoyerLindquist>(
-          shape_options.initial_values.value());
+          hard_coded_options.initial_values.value());
       const DataVector radial_distortion =
           deformed_radius -
           get(gr::Solutions::kerr_schild_radius_from_boyer_lindquist(
@@ -86,16 +172,15 @@ initial_shape_and_size_funcs(
       // Set l=0 for shape map to 0 because size control will adjust l=0
       shape_funcs[0][0] = 0.0;
     } else if (std::holds_alternative<YlmsFromFile>(
-                   shape_options.initial_values.value())) {
+                   hard_coded_options.initial_values.value())) {
       const auto& files =
-          std::get<YlmsFromFile>(shape_options.initial_values.value());
+          std::get<YlmsFromFile>(hard_coded_options.initial_values.value());
       const std::string& h5_filename = files.h5_filename;
       const std::vector<std::string>& subfile_names = files.subfile_names;
       const double match_time = files.match_time;
       const double match_time_epsilon =
           files.match_time_epsilon.value_or(1e-12);
       const bool set_l1_coefs_to_zero = files.set_l1_coefs_to_zero;
-      const size_t l_max = shape_options.l_max;
       ylm::SpherepackIterator iter{l_max, l_max};
 
       for (size_t i = 0; i < subfile_names.size(); i++) {
@@ -105,7 +190,7 @@ initial_shape_and_size_funcs(
                 h5_filename, gsl::at(subfile_names, i), match_time,
                 match_time_epsilon, files.check_frame);
         const ylm::Strahlkorper<Frame::Distorted> this_strahlkorper{
-            shape_options.l_max, 1.0, std::array{0.0, 0.0, 0.0}};
+            hard_coded_options.l_max, 1.0, std::array{0.0, 0.0, 0.0}};
 
         // The coefficients in the shape map are stored as the negative
         // coefficients of the strahlkorper, so we need to multiply by -1 here.
@@ -129,9 +214,9 @@ initial_shape_and_size_funcs(
         }
       }
     } else if (std::holds_alternative<YlmsFromSpEC>(
-                   shape_options.initial_values.value())) {
+                   hard_coded_options.initial_values.value())) {
       const auto& spec_option =
-          std::get<YlmsFromSpEC>(shape_options.initial_values.value());
+          std::get<YlmsFromSpEC>(hard_coded_options.initial_values.value());
       const std::string& dat_filename = spec_option.dat_filename;
       const double match_time = spec_option.match_time;
       const double match_time_epsilon =
@@ -144,7 +229,7 @@ initial_shape_and_size_funcs(
       }
       std::string line{};
       size_t total_col = 0;
-      std::optional<size_t> l_max{};
+      std::optional<size_t> file_l_max{};
       std::array<double, 3> center{};
       ModalVector coefficients{};
       // This will be actually set below
@@ -173,7 +258,7 @@ initial_shape_and_size_funcs(
           continue;
         }
 
-        if (l_max.has_value()) {
+        if (file_l_max.has_value()) {
           ERROR("Found more than one time in the SpEC dat file "
                 << dat_filename << " that is within a relative epsilon of "
                 << match_time_epsilon << " of the time requested " << time);
@@ -181,42 +266,43 @@ initial_shape_and_size_funcs(
 
         // Casting to an integer floors a double, so we add 0.5 before we take
         // the sqrt to avoid any rounding issues
-        const auto l_max_plus_one =
+        const auto file_l_max_plus_one =
             static_cast<size_t>(sqrt(static_cast<double>(total_col) + 0.5));
-        if (l_max_plus_one == 0) {
+        if (file_l_max_plus_one == 0) {
           ERROR(
               "Invalid l_max from SpEC dat file. l_max + 1 was computed to be "
               "0");
         }
-        l_max = l_max_plus_one - 1;
+        file_l_max = file_l_max_plus_one - 1;
 
         ss >> center[0];
         ss >> center[1];
         ss >> center[2];
 
-        coefficients.destructive_resize(
-            ylm::Spherepack::spectral_size(l_max.value(), l_max.value()));
+        coefficients.destructive_resize(ylm::Spherepack::spectral_size(
+            file_l_max.value(), file_l_max.value()));
 
-        file_iter = ylm::SpherepackIterator{l_max.value(), l_max.value()};
+        file_iter =
+            ylm::SpherepackIterator{file_l_max.value(), file_l_max.value()};
 
-        for (int l = 0; l <= static_cast<int>(l_max.value()); l++) {
+        for (int l = 0; l <= static_cast<int>(file_l_max.value()); l++) {
           for (int m = -l; m <= l; m++) {
             ss >> coefficients[file_iter.set(static_cast<size_t>(l), m)()];
           }
         }
       }
 
-      if (not l_max.has_value()) {
+      if (not file_l_max.has_value()) {
         ERROR_NO_TRACE("Unable to find requested time "
                        << time << " within an epsilon of " << match_time_epsilon
                        << " in SpEC dat file " << dat_filename);
       }
 
       const ylm::Strahlkorper<Frame::Inertial> file_strahlkorper{
-          l_max.value(), l_max.value(), coefficients, center};
+          file_l_max.value(), file_l_max.value(), coefficients, center};
       const ylm::Strahlkorper<Frame::Inertial> this_strahlkorper{
-          shape_options.l_max, 1.0, std::array{0.0, 0.0, 0.0}};
-      ylm::SpherepackIterator iter{shape_options.l_max, shape_options.l_max};
+          l_max, 1.0, std::array{0.0, 0.0, 0.0}};
+      ylm::SpherepackIterator iter{l_max, l_max};
 
       shape_funcs[0] =
           -1.0 * file_strahlkorper.ylm_spherepack().prolong_or_restrict(
@@ -231,46 +317,61 @@ initial_shape_and_size_funcs(
           shape_funcs[0][iter.set(1_st, m)()] = 0.0;
         }
       }
-    } else if (std::holds_alternative<FromVolumeFile<names::ShapeSize<Object>>>(
-                   shape_options.initial_values.value())) {
-      const auto& volume_file_options =
-          std::get<FromVolumeFile<names::ShapeSize<Object>>>(
-              shape_options.initial_values.value());
-
-      shape_funcs = volume_file_options.shape_values;
-      size_funcs = volume_file_options.size_values;
     }
   }
 
   // If any size options were specified, those override the values from the
   // shape coefs
-  if (shape_options.initial_size_values.has_value()) {
+  if (hard_coded_options.initial_size_values.has_value()) {
     for (size_t i = 0; i < 3; i++) {
       gsl::at(size_funcs, i)[0] =
-          gsl::at(shape_options.initial_size_values.value(), i);
+          gsl::at(hard_coded_options.initial_size_values.value(), i);
     }
   }
 
-  return std::make_pair(std::move(shape_funcs), std::move(size_funcs));
+  result[shape_name] =
+      std::make_unique<FunctionsOfTime::PiecewisePolynomial<2>>(
+          initial_time, std::move(shape_funcs), shape_expiration_time);
+  result[size_name] = std::make_unique<FunctionsOfTime::PiecewisePolynomial<3>>(
+      initial_time, std::move(size_funcs), size_expiration_time);
+
+  return result;
 }
 
-#define INCLUDETRANSITION(data) BOOST_PP_TUPLE_ELEM(0, data)
-#define OBJECT(data) BOOST_PP_TUPLE_ELEM(1, data)
+#define OBJECT(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define INCLUDETRANSITION(data) BOOST_PP_TUPLE_ELEM(1, data)
 
-#define INSTANTIATE(_, data)                                               \
-  template class ShapeMapOptions<INCLUDETRANSITION(data), OBJECT(data)>;   \
-  template std::pair<std::array<DataVector, 3>, std::array<DataVector, 4>> \
-  initial_shape_and_size_funcs<INCLUDETRANSITION(data), OBJECT(data)>(     \
-      const ShapeMapOptions<INCLUDETRANSITION(data), OBJECT(data)>&        \
-          shape_options,                                                   \
-      double deformed_radius);
+#define INSTANTIATE(_, data)                                          \
+  template size_t l_max_from_shape_options(                           \
+      const std::variant<                                             \
+          ShapeMapOptions<INCLUDETRANSITION(data), OBJECT(data)>,     \
+          FromVolumeFileShapeSize<OBJECT(data)>>& shape_map_options); \
+  template bool transition_ends_at_cube_from_shape_options(           \
+      const std::variant<                                             \
+          ShapeMapOptions<INCLUDETRANSITION(data), OBJECT(data)>,     \
+          FromVolumeFileShapeSize<OBJECT(data)>>& shape_map_options); \
+  template FunctionsOfTimeMap get_shape_and_size(                     \
+      const std::variant<                                             \
+          ShapeMapOptions<INCLUDETRANSITION(data), OBJECT(data)>,     \
+          FromVolumeFileShapeSize<OBJECT(data)>>& shape_map_options,  \
+      double initial_time, double shape_expiration_time,              \
+      double size_expiration_time, double deformed_radius);
 
-GENERATE_INSTANTIATIONS(INSTANTIATE, (true, false),
+GENERATE_INSTANTIATIONS(INSTANTIATE,
+                        (domain::ObjectLabel::A, domain::ObjectLabel::B,
+                         domain::ObjectLabel::None),
+                        (true, false))
+
+#undef INCLUDETRANSITION
+#undef INSTANTIATE
+
+#define INSTANTIATE(_, data) \
+  template class FromVolumeFileShapeSize<OBJECT(data)>;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE,
                         (domain::ObjectLabel::A, domain::ObjectLabel::B,
                          domain::ObjectLabel::None))
 
-#undef INCLUDETRANSITION
 #undef OBJECT
 #undef INSTANTIATE
-
 }  // namespace domain::creators::time_dependent_options

--- a/src/Domain/Creators/TimeDependentOptions/Sphere.hpp
+++ b/src/Domain/Creators/TimeDependentOptions/Sphere.hpp
@@ -16,7 +16,10 @@
 #include "Domain/CoordinateMaps/TimeDependent/RotScaleTrans.hpp"
 #include "Domain/CoordinateMaps/TimeDependent/Shape.hpp"
 #include "Domain/CoordinateMaps/TimeDependent/Translation.hpp"
+#include "Domain/Creators/TimeDependentOptions/ExpansionMap.hpp"
+#include "Domain/Creators/TimeDependentOptions/RotationMap.hpp"
 #include "Domain/Creators/TimeDependentOptions/ShapeMap.hpp"
+#include "Domain/Creators/TimeDependentOptions/TranslationMap.hpp"
 #include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
 #include "Domain/Structure/ObjectLabel.hpp"
 #include "Options/Auto.hpp"
@@ -81,113 +84,18 @@ struct TimeDependentMapOptions {
 
   using ShapeMapOptions =
       time_dependent_options::ShapeMapOptions<false, domain::ObjectLabel::None>;
+  using ShapeMapOptionType = typename ShapeMapOptions::type::value_type;
 
-  struct RotationMapOptions {
-    using type = Options::Auto<RotationMapOptions, Options::AutoLabel::None>;
-    static std::string name() { return "RotationMap"; }
-    static constexpr Options::String help = {
-        "Options for a time-dependent rotation map about an arbitrary axis. "
-        "Specify 'None' to not use this map."};
+  using RotationMapOptions = time_dependent_options::RotationMapOptions<true>;
+  using RotationMapOptionType = typename RotationMapOptions::type::value_type;
 
-    struct InitialValues {
-      using type = std::array<std::array<double, 4>, 3>;
-      static constexpr Options::String help = {
-          "The initial values for the quaternion function and its first two "
-          "derivatives."};
-    };
+  using ExpansionMapOptions = time_dependent_options::ExpansionMapOptions<true>;
+  using ExpansionMapOptionType = typename ExpansionMapOptions::type::value_type;
 
-    struct DecayTimescaleRotation {
-      using type = double;
-      static constexpr Options::String help = {
-          "The timescale for how fast the rotation approaches its asymptotic "
-          "value."};
-    };
-
-    using options = tmpl::list<InitialValues, DecayTimescaleRotation>;
-    RotationMapOptions();
-    RotationMapOptions(std::array<std::array<double, 4>, 3> initial_values_in,
-                       double decay_timescale_in);
-
-    std::array<std::array<double, 4>, 3> initial_values{};
-    double decay_timescale{std::numeric_limits<double>::signaling_NaN()};
-  };
-
-  struct ExpansionMapOptions {
-    using type = Options::Auto<ExpansionMapOptions, Options::AutoLabel::None>;
-    static std::string name() { return "ExpansionMap"; }
-    static constexpr Options::String help = {
-        "Options for the expansion map. Specify 'None' to not use this map."};
-
-    struct InitialValues {
-      using type = std::array<double, 3>;
-      static constexpr Options::String help = {
-          "Initial value and first two derivatives of expansion."};
-    };
-
-    struct DecayTimescaleExpansion {
-      using type = double;
-      static constexpr Options::String help = {
-          "The timescale for how fast the expansion approaches "
-          "its asymptotic value."};
-    };
-
-    struct InitialValuesOuterBoundary {
-      using type = std::array<double, 3>;
-      static constexpr Options::String help = {
-          "Initial value and first two derivatives of expansion outside the "
-          "transition region."};
-    };
-
-    struct DecayTimescaleExpansionOuterBoundary {
-      using type = double;
-      static constexpr Options::String help = {
-          "The timescale for how fast the expansion approaches "
-          "its asymptotic value outside the transition region."};
-    };
-
-    using options = tmpl::list<InitialValues, DecayTimescaleExpansion,
-                               InitialValuesOuterBoundary,
-                               DecayTimescaleExpansionOuterBoundary>;
-    ExpansionMapOptions();
-    ExpansionMapOptions(std::array<double, 3> initial_values_in,
-                        double decay_timescale_in,
-                        std::array<double, 3> initial_values_outer_boundary_in,
-                        double decay_timescale_outer_boundary_in);
-
-    std::array<double, 3> initial_values{
-        std::numeric_limits<double>::signaling_NaN(),
-        std::numeric_limits<double>::signaling_NaN(),
-        std::numeric_limits<double>::signaling_NaN()};
-    double decay_timescale{std::numeric_limits<double>::signaling_NaN()};
-    std::array<double, 3> initial_values_outer_boundary{
-        std::numeric_limits<double>::signaling_NaN(),
-        std::numeric_limits<double>::signaling_NaN(),
-        std::numeric_limits<double>::signaling_NaN()};
-    double decay_timescale_outer_boundary{
-        std::numeric_limits<double>::signaling_NaN()};
-  };
-
-  struct TranslationMapOptions {
-    using type = Options::Auto<TranslationMapOptions, Options::AutoLabel::None>;
-    static std::string name() { return "TranslationMap"; }
-    static constexpr Options::String help = {
-        "Options for a time-dependent translation map in that keeps the "
-        "outer boundary fixed. Specify 'None' to not use this map."};
-
-    struct InitialValues {
-      using type = std::array<std::array<double, 3>, 3>;
-      static constexpr Options::String help = {
-          "Initial values for the translation map, its velocity and "
-          "acceleration."};
-    };
-
-    using options = tmpl::list<InitialValues>;
-    TranslationMapOptions();
-    explicit TranslationMapOptions(
-        std::array<std::array<double, 3>, 3> initial_values_in);
-
-    std::array<std::array<double, 3>, 3> initial_values{};
-  };
+  using TranslationMapOptions =
+      time_dependent_options::TranslationMapOptions<3>;
+  using TranslationMapOptionType =
+      typename TranslationMapOptions::type::value_type;
 
   struct TransitionRotScaleTrans {
     using type = bool;
@@ -205,12 +113,12 @@ struct TimeDependentMapOptions {
 
   TimeDependentMapOptions() = default;
 
-  TimeDependentMapOptions(
-      double initial_time, std::optional<ShapeMapOptions> shape_map_options,
-      std::optional<RotationMapOptions> rotation_map_options,
-      std::optional<ExpansionMapOptions> expansion_map_options,
-      std::optional<TranslationMapOptions> translation_map_options,
-      bool transition_rot_scale_trans);
+  TimeDependentMapOptions(double initial_time,
+                          ShapeMapOptionType shape_map_options,
+                          RotationMapOptionType rotation_map_options,
+                          ExpansionMapOptionType expansion_map_options,
+                          TranslationMapOptionType translation_map_options,
+                          bool transition_rot_scale_trans);
 
   /*!
    * \brief Create the function of time map using the options that were
@@ -299,10 +207,10 @@ struct TimeDependentMapOptions {
   RotScaleTransMap inner_rot_scale_trans_map_{};
   RotScaleTransMap transition_rot_scale_trans_map_{};
 
-  std::optional<ShapeMapOptions> shape_map_options_{};
-  std::optional<RotationMapOptions> rotation_map_options_{};
-  std::optional<ExpansionMapOptions> expansion_map_options_{};
-  std::optional<TranslationMapOptions> translation_map_options_{};
+  ShapeMapOptionType shape_map_options_;
+  RotationMapOptionType rotation_map_options_;
+  ExpansionMapOptionType expansion_map_options_;
+  TranslationMapOptionType translation_map_options_;
   bool transition_rot_scale_trans_{false};
 };
 }  // namespace domain::creators::sphere

--- a/src/Domain/Creators/TimeDependentOptions/TranslationMap.cpp
+++ b/src/Domain/Creators/TimeDependentOptions/TranslationMap.cpp
@@ -9,35 +9,75 @@
 
 #include "DataStructures/DataVector.hpp"
 #include "Domain/Creators/TimeDependentOptions/FromVolumeFile.hpp"
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "Domain/FunctionsOfTime/PiecewisePolynomial.hpp"
+#include "Options/Context.hpp"
+#include "Options/ParseError.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 
 namespace domain::creators::time_dependent_options {
 template <size_t Dim>
 TranslationMapOptions<Dim>::TranslationMapOptions(
-    std::variant<std::array<std::array<double, Dim>, 3>,
-                 FromVolumeFile<names::Translation>>
-        values_from_options) {
-  if (std::holds_alternative<std::array<std::array<double, Dim>, 3>>(
-          values_from_options)) {
-    auto& values =
-        std::get<std::array<std::array<double, Dim>, 3>>(values_from_options);
-    for (size_t i = 0; i < initial_values.size(); i++) {
-      gsl::at(initial_values, i) = DataVector{Dim, 0.0};
-      for (size_t j = 0; j < Dim; j++) {
-        gsl::at(initial_values, i)[j] = gsl::at(gsl::at(values, i), j);
-      }
-    }
-  } else if (std::holds_alternative<FromVolumeFile<names::Translation>>(
-                 values_from_options)) {
-    auto& values_from_file =
-        std::get<FromVolumeFile<names::Translation>>(values_from_options);
-    initial_values = values_from_file.values;
+    const std::array<std::array<double, Dim>, 3>& initial_values_in,
+    const Options::Context& context) {
+  if (initial_values_in.empty() or initial_values_in.size() > 3) {
+    PARSE_ERROR(
+        context,
+        "Must specify at least the value of the translation, and optionally "
+        "up to 2 time derivatives.");
   }
+
+  for (size_t i = 0; i < initial_values_in.size(); i++) {
+    gsl::at(initial_values, i) = DataVector{gsl::at(initial_values_in, i)};
+  }
+}
+
+template <size_t Dim>
+std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime> get_translation(
+    const std::variant<TranslationMapOptions<Dim>, FromVolumeFile>&
+        translation_map_options,
+    const double initial_time, const double expiration_time) {
+  const std::string name = "Translation";
+  std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime> result{};
+
+  if (std::holds_alternative<FromVolumeFile>(translation_map_options)) {
+    const auto& from_vol_file =
+        std::get<FromVolumeFile>(translation_map_options);
+    const auto volume_fot =
+        from_vol_file.retrieve_function_of_time({name}, initial_time);
+
+    // It must be a PiecewisePolynomial
+    if (UNLIKELY(dynamic_cast<domain::FunctionsOfTime::PiecewisePolynomial<2>*>(
+                     volume_fot.at(name).get()) == nullptr)) {
+      ERROR_NO_TRACE(
+          "Translation function of time read from volume data is not a "
+          "PiecewisePolynomial<2>. Cannot use it to initialize the translation "
+          "map.");
+    }
+
+    result = volume_fot.at(name)->create_at_time(initial_time, expiration_time);
+  } else if (std::holds_alternative<TranslationMapOptions<Dim>>(
+                 translation_map_options)) {
+    const auto& hard_coded_options =
+        std::get<TranslationMapOptions<Dim>>(translation_map_options);
+
+    result = std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<2>>(
+        initial_time, hard_coded_options.initial_values, expiration_time);
+  } else {
+    ERROR("Unknown TranslationMap.");
+  }
+
+  return result;
 }
 
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 
-#define INSTANTIATE(_, data) template class TranslationMapOptions<DIM(data)>;
+#define INSTANTIATE(_, data)                                                   \
+  template class TranslationMapOptions<DIM(data)>;                             \
+  template std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>            \
+  get_translation(const std::variant<TranslationMapOptions<DIM(data)>,         \
+                                     FromVolumeFile>& translation_map_options, \
+                  double initial_time, double expiration_time);
 
 GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
 

--- a/src/Domain/Creators/TimeDependentOptions/TranslationMap.hpp
+++ b/src/Domain/Creators/TimeDependentOptions/TranslationMap.hpp
@@ -18,33 +18,51 @@
 
 namespace domain::creators::time_dependent_options {
 /*!
- * \brief Class to be used as an option for initializing translation map
- * coefficients.
+ * \brief Class that holds hard coded translation map options from the input
+ * file.
+ *
+ * \details This class can also be used as an option tag with the \p type type
+ * alias, `name()` function, and \p help string.
  */
 template <size_t Dim>
 struct TranslationMapOptions {
-  using type = Options::Auto<TranslationMapOptions, Options::AutoLabel::None>;
+  using type =
+      Options::Auto<std::variant<TranslationMapOptions<Dim>, FromVolumeFile>,
+                    Options::AutoLabel::None>;
   static std::string name() { return "TranslationMap"; }
   static constexpr Options::String help = {
       "Options for a time-dependent translation of the coordinates. Specify "
       "'None' to not use this map."};
 
   struct InitialValues {
-    using type = std::variant<std::array<std::array<double, Dim>, 3>,
-                              FromVolumeFile<names::Translation>>;
+    using type = std::array<std::array<double, Dim>, 3>;
     static constexpr Options::String help = {
-        "Initial values for the translation map, its velocity and "
-        "acceleration."};
+        "Initial values for the translation map. You can optionally specify "
+        "its first two time derivatives. If time derivatives aren't specified, "
+        "zero will be used."};
   };
 
   using options = tmpl::list<InitialValues>;
 
   TranslationMapOptions() = default;
   // NOLINTNEXTLINE(google-explicit-constructor)
-  TranslationMapOptions(std::variant<std::array<std::array<double, Dim>, 3>,
-                                     FromVolumeFile<names::Translation>>
-                            values_from_options);
+  TranslationMapOptions(
+      const std::array<std::array<double, Dim>, 3>& initial_values_in,
+      const Options::Context& context = {});
 
   std::array<DataVector, 3> initial_values{};
 };
+
+/*!
+ * \brief Helper function that takes the variant of the translation map options,
+ * and returns the fully constructed translation function of time.
+ *
+ * \details Even if the function of time is read from a file, it will have a
+ * new \p initial_time and \p expiration_time.
+ */
+template <size_t Dim>
+std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime> get_translation(
+    const std::variant<TranslationMapOptions<Dim>, FromVolumeFile>&
+        translation_map_options,
+    double initial_time, double expiration_time);
 }  // namespace domain::creators::time_dependent_options

--- a/src/Domain/FunctionsOfTime/FunctionOfTime.hpp
+++ b/src/Domain/FunctionsOfTime/FunctionOfTime.hpp
@@ -49,6 +49,18 @@ class FunctionOfTime : public PUP::able {
 
   virtual auto get_clone() const -> std::unique_ptr<FunctionOfTime> = 0;
 
+  /// Create a FunctionOfTime at time \p t as if one had created a new
+  /// FunctionOfTime with \p t as its initial time, except the initial values of
+  /// new FunctionOfTime are the exact values of the old FunctionOfTime at time
+  /// \p t, and the new expriation is \p expiration_time.
+  ///
+  /// \details This defaults to just `get_clone()` since some functions can't be
+  /// updated/don't expire.
+  virtual std::unique_ptr<FunctionOfTime> create_at_time(
+      const double /*t*/, const double /*expiration_time*/) const {
+    return get_clone();
+  }
+
   /// Returns the domain of validity of the function.
   /// For FunctionsOfTime that allow a small amount of time extrapolation,
   /// `time_bounds` tells you the bounds including the allowed extrapolation

--- a/src/Domain/FunctionsOfTime/IntegratedFunctionOfTime.cpp
+++ b/src/Domain/FunctionsOfTime/IntegratedFunctionOfTime.cpp
@@ -55,6 +55,13 @@ std::unique_ptr<FunctionOfTime> IntegratedFunctionOfTime::get_clone() const {
   return std::make_unique<IntegratedFunctionOfTime>(*this);
 }
 
+std::unique_ptr<FunctionOfTime> IntegratedFunctionOfTime::create_at_time(
+    const double t, const double expiration_time) const {
+  const auto initial_func_and_deriv = deriv_info_at_update_times_(t);
+  return std::make_unique<IntegratedFunctionOfTime>(
+      t, initial_func_and_deriv.data, expiration_time, rotation_);
+}
+
 template <size_t MaxDerivReturned>
 std::array<DataVector, MaxDerivReturned + 1>
 IntegratedFunctionOfTime::func_and_derivs(const double t) const {

--- a/src/Domain/FunctionsOfTime/IntegratedFunctionOfTime.hpp
+++ b/src/Domain/FunctionsOfTime/IntegratedFunctionOfTime.hpp
@@ -50,6 +50,9 @@ class IntegratedFunctionOfTime : public FunctionOfTime {
 
   auto get_clone() const -> std::unique_ptr<FunctionOfTime> override;
 
+  std::unique_ptr<FunctionOfTime> create_at_time(
+      double t, double expiration_time) const override;
+
   std::array<DataVector, 1> func(double t) const override;
   std::array<DataVector, 2> func_and_deriv(double t) const override;
   [[noreturn]] std::array<DataVector, 3> func_and_2_derivs(

--- a/src/Domain/FunctionsOfTime/PiecewisePolynomial.cpp
+++ b/src/Domain/FunctionsOfTime/PiecewisePolynomial.cpp
@@ -70,6 +70,13 @@ std::unique_ptr<FunctionOfTime> PiecewisePolynomial<MaxDeriv>::get_clone()
 }
 
 template <size_t MaxDeriv>
+std::unique_ptr<FunctionOfTime> PiecewisePolynomial<MaxDeriv>::create_at_time(
+    const double t, const double expiration_time) const {
+  return std::make_unique<PiecewisePolynomial>(t, func_and_derivs(t),
+                                               expiration_time);
+}
+
+template <size_t MaxDeriv>
 template <size_t MaxDerivReturned>
 std::array<DataVector, MaxDerivReturned + 1>
 PiecewisePolynomial<MaxDeriv>::func_and_derivs(const double t) const {

--- a/src/Domain/FunctionsOfTime/PiecewisePolynomial.hpp
+++ b/src/Domain/FunctionsOfTime/PiecewisePolynomial.hpp
@@ -44,6 +44,9 @@ class PiecewisePolynomial : public FunctionOfTime {
 
   auto get_clone() const -> std::unique_ptr<FunctionOfTime> override;
 
+  std::unique_ptr<FunctionOfTime> create_at_time(
+      double t, double expiration_time) const override;
+
   // clang-tidy: google-runtime-references
   // clang-tidy: cppcoreguidelines-owning-memory,-warnings-as-errors
   WRAPPED_PUPable_decl_template(PiecewisePolynomial<MaxDeriv>);  // NOLINT
@@ -70,6 +73,12 @@ class PiecewisePolynomial : public FunctionOfTime {
   /// Return the function and all derivs up to and including the `MaxDeriv` at
   /// an arbitrary time `t`.
   std::vector<DataVector> func_and_all_derivs(double t) const override;
+
+  /// Returns the function and `MaxDerivReturned` derivatives at
+  /// an arbitrary time `t`.
+  /// The function has multiple components.
+  template <size_t MaxDerivReturned = MaxDeriv>
+  std::array<DataVector, MaxDerivReturned + 1> func_and_derivs(double t) const;
 
   /// Updates the `MaxDeriv`th derivative of the function at the given time.
   /// `updated_max_deriv` is a vector of the `MaxDeriv`ths for each component.
@@ -102,12 +111,6 @@ class PiecewisePolynomial : public FunctionOfTime {
       const PiecewisePolynomial<LocalMaxDeriv>& piecewise_polynomial);
 
   void unpack_old_version(PUP::er& p, size_t version);
-
-  /// Returns the function and `MaxDerivReturned` derivatives at
-  /// an arbitrary time `t`.
-  /// The function has multiple components.
-  template <size_t MaxDerivReturned = MaxDeriv>
-  std::array<DataVector, MaxDerivReturned + 1> func_and_derivs(double t) const;
 
   void store_entry(double time_of_update,
                    std::array<DataVector, MaxDeriv + 1> func_and_derivs,

--- a/src/Domain/FunctionsOfTime/QuaternionFunctionOfTime.cpp
+++ b/src/Domain/FunctionsOfTime/QuaternionFunctionOfTime.cpp
@@ -32,6 +32,7 @@
 #include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/MakeArray.hpp"
 #include "Utilities/Serialization/PupBoost.hpp"
 #include "Utilities/StdHelpers.hpp"
 
@@ -77,6 +78,14 @@ template <size_t MaxDeriv>
 std::unique_ptr<FunctionOfTime> QuaternionFunctionOfTime<MaxDeriv>::get_clone()
     const {
   return std::make_unique<QuaternionFunctionOfTime>(*this);
+}
+
+template <size_t MaxDeriv>
+std::unique_ptr<FunctionOfTime>
+QuaternionFunctionOfTime<MaxDeriv>::create_at_time(
+    const double t, const double expiration_time) const {
+  return std::make_unique<QuaternionFunctionOfTime>(
+      t, func(t), angle_f_of_t_.func_and_derivs(t), expiration_time);
 }
 
 template <size_t MaxDeriv>

--- a/src/Domain/FunctionsOfTime/QuaternionFunctionOfTime.hpp
+++ b/src/Domain/FunctionsOfTime/QuaternionFunctionOfTime.hpp
@@ -42,6 +42,12 @@ namespace domain::FunctionsOfTime {
  * around the internal `PiecewisePolynomial::update` function with the addition
  * that it then updates the stored quaternions as well.
  *
+ * \note The initial rotation angles passed to the angle PiecewisePolynomial
+ * don't matter as we never actually use the angles themselves. We only use
+ * their derivatives (angular velocity) to determine map parameters. In theory
+ * we could determine each initial angle from the input axis-angle
+ * representation, but we don't need to.
+ *
  * The angle PiecewisePolynomial is accessible through the `angle_func`,
  * `angle_func_and_deriv`, and `angle_func_and_2_derivs` functions which
  * correspond to the function calls of a normal PiecewisePolynomial except

--- a/src/Domain/FunctionsOfTime/QuaternionFunctionOfTime.hpp
+++ b/src/Domain/FunctionsOfTime/QuaternionFunctionOfTime.hpp
@@ -79,6 +79,9 @@ class QuaternionFunctionOfTime : public FunctionOfTime {
 
   auto get_clone() const -> std::unique_ptr<FunctionOfTime> override;
 
+  std::unique_ptr<FunctionOfTime> create_at_time(
+      double t, double expiration_time) const override;
+
   // clang-tidy: google-runtime-references
   // clang-tidy: cppcoreguidelines-owning-memory,-warnings-as-errors
   WRAPPED_PUPable_decl_template(QuaternionFunctionOfTime<MaxDeriv>);  // NOLINT

--- a/src/Evolution/Ringdown/StrahlkorperCoefsInRingdownDistortedFrame.cpp
+++ b/src/Evolution/Ringdown/StrahlkorperCoefsInRingdownDistortedFrame.cpp
@@ -10,6 +10,8 @@
 #include "DataStructures/Matrix.hpp"
 #include "Domain/CoordinateMaps/Distribution.hpp"
 #include "Domain/Creators/Sphere.hpp"
+#include "Domain/Creators/TimeDependentOptions/ExpansionMap.hpp"
+#include "Domain/Creators/TimeDependentOptions/RotationMap.hpp"
 #include "Domain/Creators/TimeDependentOptions/Sphere.hpp"
 #include "Domain/StrahlkorperTransformations.hpp"
 #include "IO/H5/Dat.hpp"
@@ -26,7 +28,7 @@ std::vector<DataVector> strahlkorper_coefs_in_ringdown_distorted_frame(
     const double settling_timescale,
     const std::array<double, 3>& exp_func_and_2_derivs,
     const std::array<double, 3>& exp_outer_bdry_func_and_2_derivs,
-    const std::array<std::array<double, 4>, 3>& rot_func_and_2_derivs) {
+    const std::vector<std::array<double, 4>>& rot_func_and_2_derivs) {
   // Read the AhC coefficients from the H5 file
   const std::vector<ylm::Strahlkorper<Frame::Inertial>>& ahc_inertial_h5 =
       ylm::read_surface_ylm<Frame::Inertial>(
@@ -47,11 +49,11 @@ std::vector<DataVector> strahlkorper_coefs_in_ringdown_distorted_frame(
   // Create a time-dependent domain; only the the time-dependent map options
   // matter; the domain is just a spherical shell with inner and outer
   // radii chosen so any conceivable common horizon will fit between them.
-  const domain::creators::sphere::TimeDependentMapOptions::ExpansionMapOptions
+  const domain::creators::time_dependent_options::ExpansionMapOptions<true>
       expansion_map_options{exp_func_and_2_derivs, settling_timescale,
                             exp_outer_bdry_func_and_2_derivs,
                             settling_timescale};
-  const domain::creators::sphere::TimeDependentMapOptions::RotationMapOptions
+  const domain::creators::time_dependent_options::RotationMapOptions<true>
       rotation_map_options{rot_func_and_2_derivs, settling_timescale};
   const domain::creators::sphere::TimeDependentMapOptions
       time_dependent_map_options{match_time,           std::nullopt,

--- a/src/Evolution/Ringdown/StrahlkorperCoefsInRingdownDistortedFrame.hpp
+++ b/src/Evolution/Ringdown/StrahlkorperCoefsInRingdownDistortedFrame.hpp
@@ -39,5 +39,5 @@ std::vector<DataVector> strahlkorper_coefs_in_ringdown_distorted_frame(
     double settling_timescale,
     const std::array<double, 3>& exp_func_and_2_derivs,
     const std::array<double, 3>& exp_outer_bdry_func_and_2_derivs,
-    const std::array<std::array<double, 4>, 3>& rot_func_and_2_derivs);
+    const std::vector<std::array<double, 4>>& rot_func_and_2_derivs);
 }  // namespace evolution::Ringdown

--- a/support/Pipelines/Bbh/Inspiral.yaml
+++ b/support/Pipelines/Bbh/Inspiral.yaml
@@ -118,9 +118,9 @@ DomainCreator:
     TimeDependentMaps:
       InitialTime: &InitialTime 0.0
       ExpansionMap:
-        InitialValues: [1.0, {{ RadialExpansionVelocity }}]
+        InitialValues: [1.0, {{ RadialExpansionVelocity }}, 0.0]
         AsymptoticVelocityOuterBoundary: -1.0e-6
-        DecayTimescaleOuterBoundaryVelocity: 50.0
+        DecayTimescaleOuterBoundary: 50.0
       RotationMap:
         InitialAngularVelocity: [0.0, 0.0, {{ InitialAngularVelocity }}]
       TranslationMap:

--- a/support/Pipelines/Bbh/Ringdown.yaml
+++ b/support/Pipelines/Bbh/Ringdown.yaml
@@ -65,13 +65,13 @@ DomainCreator:
         # and has not been tested for other configurations.
         SizeInitialValues: [0.0, -1.0, 0.0]
       RotationMap:
-        InitialValues:
+        InitialQuaternions:
           - [{{ Rotation0 }}, {{ Rotation1 }}, {{ Rotation2 }}, {{ Rotation3 }}]
           - [{{ dtRotation0 }}, {{ dtRotation1 }}, {{ dtRotation2 }},
              {{ dtRotation3 }}]
           - [{{ dt2Rotation0 }}, {{ dt2Rotation1 }}, {{ dt2Rotation2}},
              {{ dt2Rotation3 }}]
-        DecayTimescaleRotation: 1.0
+        DecayTimescale: 1.0
       ExpansionMap:
         # During the ringdown, only the outer boundary's expansion map is
         # applied.
@@ -79,8 +79,8 @@ DomainCreator:
         InitialValuesOuterBoundary: [{{ ExpansionOuterBdry }},
                                      {{ dtExpansionOuterBdry }},
                                      {{ dt2ExpansionOuterBdry }}]
-        DecayTimescaleExpansion: 1.0
-        DecayTimescaleExpansionOuterBoundary: 1.0
+        DecayTimescale: 1.0
+        DecayTimescaleOuterBoundary: 1.0
       TranslationMap:
         InitialValues: [[0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]]
       TransitionRotScaleTrans: True

--- a/tests/InputFiles/CurvedScalarWave/WorldtubeKerrSchild.yaml
+++ b/tests/InputFiles/CurvedScalarWave/WorldtubeKerrSchild.yaml
@@ -72,9 +72,9 @@ DomainCreator:
     TimeDependentMaps:
       InitialTime: 0.
       ExpansionMap:
-        InitialValues: [1., 0.]
+        InitialValues: [1., 0., 0.]
         AsymptoticVelocityOuterBoundary: 0.
-        DecayTimescaleOuterBoundaryVelocity: 1.
+        DecayTimescaleOuterBoundary: 1.
       RotationMap:
         InitialAngularVelocity: [0., 0., 0.08944271909999159]
       TranslationMap:

--- a/tests/InputFiles/ExportCoordinates/InputTimeDependent3D.yaml
+++ b/tests/InputFiles/ExportCoordinates/InputTimeDependent3D.yaml
@@ -69,9 +69,9 @@ DomainCreator:
     TimeDependentMaps:
       InitialTime: 0.0
       ExpansionMap:
-        InitialValues: [1.0, -4.6148457646200002e-05]
+        InitialValues: [1.0, -4.6148457646200002e-05, 0.0]
         AsymptoticVelocityOuterBoundary: -1.0e-6
-        DecayTimescaleOuterBoundaryVelocity: 50.0
+        DecayTimescaleOuterBoundary: 50.0
       RotationMap:
         InitialAngularVelocity: [0.0, 0.0, 1.5264577062000000e-02]
       TranslationMap:

--- a/tests/InputFiles/GeneralizedHarmonic/CylindricalBinaryBlackHole.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/CylindricalBinaryBlackHole.yaml
@@ -58,9 +58,9 @@ DomainCreator:
     TimeDependentMaps:
       InitialTime: 0.0
       ExpansionMap:
-        InitialValues: [1.0, -4.6148457646200002e-05]
+        InitialValues: [1.0, -4.6148457646200002e-05, 0.0]
         AsymptoticVelocityOuterBoundary: -1.0e-6
-        DecayTimescaleOuterBoundaryVelocity: 50.0
+        DecayTimescaleOuterBoundary: 50.0
       RotationMap:
         InitialAngularVelocity: [0.0, 0.0, 1.5264577062000000e-02]
       TranslationMap:

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/BinaryNeutronStar.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/BinaryNeutronStar.yaml
@@ -64,9 +64,9 @@ DomainCreator:
     TimeDependentMaps:
       InitialTime: 0.0
       ExpansionMap:
-        InitialValues: [1.0, 0.0]
+        InitialValues: [1.0, 0.0, 0.0]
         AsymptoticVelocityOuterBoundary: -1.0e-6
-        DecayTimescaleOuterBoundaryVelocity: 50.0
+        DecayTimescaleOuterBoundary: 50.0
       RotationMap:
         InitialAngularVelocity: [0.0, 0.0, 0.00826225]
       TranslationMap:

--- a/tests/Unit/ControlSystem/Test_Measurements.cpp
+++ b/tests/Unit/ControlSystem/Test_Measurements.cpp
@@ -18,6 +18,7 @@
 #include "Domain/Creators/Tags/Domain.hpp"
 #include "Domain/Creators/Tags/FunctionsOfTime.hpp"
 #include "Domain/Creators/TimeDependentOptions/BinaryCompactObject.hpp"
+#include "Domain/Creators/TimeDependentOptions/RotationMap.hpp"
 #include "Domain/FunctionsOfTime/RegisterDerivedWithCharm.hpp"
 #include "Domain/Structure/ObjectLabel.hpp"
 #include "Framework/ActionTesting.hpp"
@@ -323,7 +324,7 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.FindTwoCenters",
   const domain::creators::bco::TimeDependentMapOptions<false> time_dep_opts{
       0.0,
       std::nullopt,
-      domain::creators::bco::TimeDependentMapOptions<false>::RotationMapOptions{
+      domain::creators::time_dependent_options::RotationMapOptions<false>{
           std::array{0.0, 0.0, 0.1}},
       std::nullopt,
       std::nullopt,

--- a/tests/Unit/Domain/Creators/Test_BinaryCompactObject.cpp
+++ b/tests/Unit/Domain/Creators/Test_BinaryCompactObject.cpp
@@ -33,6 +33,7 @@
 #include "Domain/FunctionsOfTime/PiecewisePolynomial.hpp"
 #include "Domain/FunctionsOfTime/QuaternionFunctionOfTime.hpp"
 #include "Domain/Structure/BlockNeighbor.hpp"
+#include "Domain/Structure/ObjectLabel.hpp"
 #include "Framework/TestCreation.hpp"
 #include "Helpers/DataStructures/MakeWithRandomValues.hpp"
 #include "Helpers/Domain/BoundaryConditions/BoundaryCondition.hpp"
@@ -404,9 +405,9 @@ std::string create_option_string(
           ? "  TimeDependentMaps:\n"
             "    InitialTime: 1.0\n"
             "    ExpansionMap: \n"
-            "      InitialValues: [1.0, -0.1]\n"
+            "      InitialValues: [1.0, -0.1, 0.0]\n"
             "      AsymptoticVelocityOuterBoundary: -0.1\n"
-            "      DecayTimescaleOuterBoundaryVelocity: 5.0\n"
+            "      DecayTimescaleOuterBoundary: 5.0\n"
             "    RotationMap:\n"
             "      InitialAngularVelocity: [0.0, 0.0, -0.2]\n"
             "    TranslationMap:\n"
@@ -839,6 +840,10 @@ void test_parse_errors() {
   // test_connectivity function.
 }
 
+template <domain::ObjectLabel Object>
+using HardcodedShape =
+    domain::creators::time_dependent_options::ShapeMapOptions<true, Object>;
+
 void test_kerr_horizon_conforming() {
   INFO(
       "Check that inner radius is deformed to constant Boyer-Lindquist radius");
@@ -868,18 +873,13 @@ void test_kerr_horizon_conforming() {
       Distribution::Inverse,
       120.,
       domain::creators::bco::TimeDependentMapOptions<false>{
-          0.,
-          std::nullopt,
-          std::nullopt,
-          std::nullopt,
-          {{32_st,
-            domain::creators::time_dependent_options::
-                KerrSchildFromBoyerLindquist{mass_A, spin_A},
-            std::nullopt}},
-          {{32_st,
-            domain::creators::time_dependent_options::
-                KerrSchildFromBoyerLindquist{mass_B, spin_B},
-            std::nullopt}}}};
+          0., std::nullopt, std::nullopt, std::nullopt,
+          HardcodedShape<domain::ObjectLabel::A>{
+              32_st, domain::creators::time_dependent_options::
+                         KerrSchildFromBoyerLindquist{mass_A, spin_A}},
+          HardcodedShape<domain::ObjectLabel::B>{
+              32_st, domain::creators::time_dependent_options::
+                         KerrSchildFromBoyerLindquist{mass_B, spin_B}}}};
   const auto domain = domain_creator.create_domain();
   const auto functions_of_time = domain_creator.functions_of_time();
   // Set up coordinates on an ellipsoid of constant Boyer-Lindquist radius

--- a/tests/Unit/Domain/Creators/Test_CylindricalBinaryCompactObject.cpp
+++ b/tests/Unit/Domain/Creators/Test_CylindricalBinaryCompactObject.cpp
@@ -27,12 +27,15 @@
 #include "Domain/Creators/DomainCreator.hpp"
 #include "Domain/Creators/OptionTags.hpp"
 #include "Domain/Creators/TimeDependentOptions/BinaryCompactObject.hpp"
+#include "Domain/Creators/TimeDependentOptions/RotationMap.hpp"
+#include "Domain/Creators/TimeDependentOptions/ShapeMap.hpp"
 #include "Domain/Domain.hpp"
 #include "Domain/ExcisionSphere.hpp"
 #include "Domain/FunctionsOfTime/FixedSpeedCubic.hpp"
 #include "Domain/FunctionsOfTime/PiecewisePolynomial.hpp"
 #include "Domain/FunctionsOfTime/QuaternionFunctionOfTime.hpp"
 #include "Domain/Structure/BlockNeighbor.hpp"
+#include "Domain/Structure/ObjectLabel.hpp"
 #include "Framework/TestCreation.hpp"
 #include "Helpers/Domain/BoundaryConditions/BoundaryCondition.hpp"
 #include "Helpers/Domain/Creators/TestHelpers.hpp"
@@ -400,16 +403,18 @@ TimeDepOptions construct_time_dependent_options() {
   return TimeDepOptions{
       expected_time,
       std::nullopt,
-      TimeDepOptions::RotationMapOptions{{initial_angular_velocity[0],
-                                          initial_angular_velocity[1],
-                                          initial_angular_velocity[2]}},
+      domain::creators::time_dependent_options::RotationMapOptions<false>{
+          std::array{initial_angular_velocity[0], initial_angular_velocity[1],
+                     initial_angular_velocity[2]}},
       std::nullopt,
-      TimeDepOptions::ShapeMapOptions<domain::ObjectLabel::A>{
+      domain::creators::time_dependent_options::ShapeMapOptions<
+          false, domain::ObjectLabel::A>{
           8_st,
           std::nullopt,
           {{initial_size_A_coefs[0][0], initial_size_A_coefs[1][0],
             initial_size_A_coefs[1][0]}}},
-      TimeDepOptions::ShapeMapOptions<domain::ObjectLabel::B>{
+      domain::creators::time_dependent_options::ShapeMapOptions<
+          false, domain::ObjectLabel::B>{
           8_st,
           std::nullopt,
           {{initial_size_B_coefs[0][0], initial_size_B_coefs[1][0],
@@ -477,7 +482,8 @@ void test_parse_errors() {
           25.0, false, 1_st, 3_st,
           TimeDepOptions{
               0.0, std::nullopt,
-              TimeDepOptions::RotationMapOptions{std::array{0.0, 0.0, 0.0}},
+              domain::creators::time_dependent_options::RotationMapOptions<
+                  false>{std::array{0.0, 0.0, 0.0}},
               std::nullopt, std::nullopt, std::nullopt},
           create_inner_boundary_condition(), create_outer_boundary_condition(),
           Options::Context{false, {}, 1, 1}),

--- a/tests/Unit/Domain/Creators/Test_Sphere.cpp
+++ b/tests/Unit/Domain/Creators/Test_Sphere.cpp
@@ -38,12 +38,14 @@
 #include "Domain/Creators/TimeDependence/RegisterDerivedWithCharm.hpp"
 #include "Domain/Creators/TimeDependence/UniformTranslation.hpp"
 #include "Domain/Creators/TimeDependentOptions/ShapeMap.hpp"
+#include "Domain/Creators/TimeDependentOptions/TranslationMap.hpp"
 #include "Domain/Domain.hpp"
 #include "Domain/ElementMap.hpp"
 #include "Domain/FunctionsOfTime/PiecewisePolynomial.hpp"
 #include "Domain/Structure/BlockNeighbor.hpp"
 #include "Domain/Structure/Direction.hpp"
 #include "Domain/Structure/DirectionMap.hpp"
+#include "Domain/Structure/ObjectLabel.hpp"
 #include "Domain/Structure/OrientationMap.hpp"
 #include "Framework/TestCreation.hpp"
 #include "Framework/TestHelpers.hpp"
@@ -595,16 +597,18 @@ void test_sphere(const gsl::not_null<Generator*> gen) {
 
     if (time_dependent) {
       if (use_hard_coded_time_dep_options) {
+        using namespace domain::creators::time_dependent_options;  // NOLINT
         translation_velocity = std::array<double, 3>{{0.001, -0.003, 0.005}};
-        time_dependent_options = creators::sphere::TimeDependentMapOptions(
+        time_dependent_options = creators::sphere::TimeDependentMapOptions{
             1.0,
-            creators::sphere::TimeDependentMapOptions::ShapeMapOptions{
-                l_max, std::nullopt},
-            std::nullopt, std::nullopt,
-            creators::sphere::TimeDependentMapOptions::TranslationMapOptions{
-                {std::array<double, 3>{0.0, 0.0, 0.0}, translation_velocity,
-                 std::array<double, 3>{0.0, 0.0, 0.0}}},
-            false);
+            ShapeMapOptions<false, domain::ObjectLabel::None>{l_max,
+                                                              std::nullopt},
+            std::nullopt,
+            std::nullopt,
+            TranslationMapOptions<3>{std::array{
+                std::array<double, 3>{0.0, 0.0, 0.0}, translation_velocity,
+                std::array<double, 3>{0.0, 0.0, 0.0}}},
+            false};
       } else {
         time_dependent_options = std::make_unique<
             domain::creators::time_dependence::UniformTranslation<3, 0>>(
@@ -717,8 +721,10 @@ void test_shape_distortion() {
       time_dependent_options =
           domain::creators::sphere::TimeDependentMapOptions{
               time,
-              {{l_max, domain::creators::time_dependent_options::
-                           KerrSchildFromBoyerLindquist{mass, spin}}},
+              domain::creators::time_dependent_options::ShapeMapOptions<
+                  false, domain::ObjectLabel::None>{
+                  l_max, domain::creators::time_dependent_options::
+                             KerrSchildFromBoyerLindquist{mass, spin}},
               std::nullopt,
               std::nullopt,
               std::nullopt,
@@ -750,16 +756,18 @@ void test_shape_distortion() {
 
     time_dependent_options = domain::creators::sphere::TimeDependentMapOptions{
         time,
-        {{l_max,
-          domain::creators::time_dependent_options::YlmsFromFile{
-              h5_filename, std::vector{subfile_name}, time, std::nullopt,
-              false},
-          // Constructing a strahlkorper from collocation radii will not exactly
-          // match the collocation points (see Strahlkorper constructor docs).
-          // For this reason, the 00 coef we calculate is not exact. This is why
-          // we just hard code the proper value here. If you change l_max, this
-          // value must also change.
-          std::array{-4.6442771561420703730e-01, 0.0, 0.0}}},
+        domain::creators::time_dependent_options::ShapeMapOptions<
+            false, domain::ObjectLabel::None>{
+            l_max,
+            domain::creators::time_dependent_options::YlmsFromFile{
+                h5_filename, std::vector{subfile_name}, time, std::nullopt,
+                false},
+            // Constructing a strahlkorper from collocation radii will not
+            // exactly match the collocation points (see Strahlkorper
+            // constructor docs). For this reason, the 00 coef we calculate is
+            // not exact. This is why we just hard code the proper value here.
+            // If you change l_max, this value must also change.
+            std::array{-4.6442771561420703730e-01, 0.0, 0.0}},
         std::nullopt,
         std::nullopt,
         std::nullopt,

--- a/tests/Unit/Domain/Creators/TimeDependentOptions/Test_FromVolumeFile.cpp
+++ b/tests/Unit/Domain/Creators/TimeDependentOptions/Test_FromVolumeFile.cpp
@@ -1,8 +1,6 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
-#include "DataStructures/DataVector.hpp"
-#include "Domain/Structure/ObjectLabel.hpp"
 #include "Framework/TestingFramework.hpp"
 
 #include <catch2/matchers/catch_matchers.hpp>
@@ -11,13 +9,16 @@
 #include <string>
 #include <unordered_map>
 
+#include "DataStructures/DataVector.hpp"
 #include "Domain/Creators/TimeDependentOptions/FromVolumeFile.hpp"
 #include "Domain/FunctionsOfTime/FixedSpeedCubic.hpp"
 #include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
 #include "Domain/FunctionsOfTime/PiecewisePolynomial.hpp"
 #include "Domain/FunctionsOfTime/QuaternionFunctionOfTime.hpp"
 #include "Domain/FunctionsOfTime/RegisterDerivedWithCharm.hpp"
+#include "Domain/Structure/ObjectLabel.hpp"
 #include "Framework/TestCreation.hpp"
+#include "Helpers/Domain/Creators/TimeDependent/TestHelpers.hpp"
 #include "IO/H5/AccessType.hpp"
 #include "IO/H5/File.hpp"
 #include "IO/H5/TensorData.hpp"
@@ -30,35 +31,12 @@
 #include "Utilities/Serialization/Serialize.hpp"
 
 namespace {
-void write_volume_data(
-    const std::string& filename, const std::string& subfile_name,
-    const std::unordered_map<
-        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
-        functions_of_time = {}) {
-  h5::H5File<h5::AccessType::ReadWrite> h5_file{filename, true};
-  auto& vol_file = h5_file.insert<h5::VolumeData>(subfile_name);
-
-  // We don't care about the volume data here, just the functions of time
-  vol_file.write_volume_data(
-      0, 0.0,
-      {ElementVolumeData{"blah",
-                         {TensorComponent{"RandomTensor", DataVector{3, 0.0}}},
-                         {3},
-                         {Spectral::Basis::Legendre},
-                         {Spectral::Quadrature::GaussLobatto}}},
-      std::nullopt,
-      functions_of_time.empty() ? std::nullopt
-                                : std::optional{serialize(functions_of_time)});
-}
-
-template <typename FoTName>
-void test() {
+void test(const std::string& function_of_time_name) {
   const std::string filename{"HorseRadish.h5"};
   if (file_system::check_if_file_exists(filename)) {
     file_system::rm(filename, true);
   }
   const std::string subfile_name{"VolumeData"};
-  const std::string function_of_time_name = pretty_type::name<FoTName>();
 
   std::unordered_map<std::string,
                      std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
@@ -70,212 +48,25 @@ void test() {
                      DataVector{3, 0.0}},
           100.0);
 
-  write_volume_data(filename, subfile_name, functions_of_time);
+  TestHelpers::domain::creators::write_volume_data(filename, subfile_name,
+                                                   functions_of_time);
 
   const double time = 50.0;
 
   const auto from_volume_file = TestHelpers::test_creation<
-      domain::creators::time_dependent_options::FromVolumeFile<FoTName>>(
-      "H5Filename: " + filename + "\nSubfileName: " + subfile_name +
-      "\nTime: 50.0\n");
+      domain::creators::time_dependent_options::FromVolumeFile>(
+      "H5Filename: " + filename + "\nSubfileName: " + subfile_name);
+
+  const domain::FunctionsOfTimeMap fot_from_file =
+      from_volume_file.retrieve_function_of_time({function_of_time_name}, time);
 
   std::array<DataVector, 3> expected_values{
       DataVector{3, 1.0 * time}, DataVector{3, 1.0}, DataVector{3, 0.0}};
 
-  CHECK(from_volume_file.values == expected_values);
-
-  if (file_system::check_if_file_exists(filename)) {
-    file_system::rm(filename, true);
-  }
-}
-
-template <>
-void test<domain::creators::time_dependent_options::names::Expansion>() {
-  const std::string filename{"SpicyHorseRadish.h5"};
-  if (file_system::check_if_file_exists(filename)) {
-    file_system::rm(filename, true);
-  }
-  const std::string subfile_name{"VolumeData"};
-  const std::string function_of_time_name{"Expansion"};
-
-  std::unordered_map<std::string,
-                     std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
-      functions_of_time{};
-  functions_of_time[function_of_time_name] =
-      std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<2>>(
-          0.0,
-          std::array{DataVector{1, 0.0}, DataVector{1, 1.0},
-                     DataVector{1, 0.0}},
-          100.0);
-  const double velocity = -1e-5;
-  const double decay_timescale = 50.0;
-  functions_of_time[function_of_time_name + "OuterBoundary"] =
-      std::make_unique<domain::FunctionsOfTime::FixedSpeedCubic>(
-          1.0, 0.0, velocity, decay_timescale);
-
-  write_volume_data(filename, subfile_name, functions_of_time);
-
-  // Makes things easier
-  const double time = decay_timescale;
-
-  const auto from_volume_file = TestHelpers::test_creation<
-      domain::creators::time_dependent_options::FromVolumeFile<
-          domain::creators::time_dependent_options::names::Expansion>>(
-      "H5Filename: " + filename + "\nSubfileName: " + subfile_name +
-      "\nTime: 50.0\n");
-
-  std::array<DataVector, 3> expected_values{DataVector{1.0 * time},
-                                            DataVector{1.0}, DataVector{0.0}};
-  // Comes from the FixedSpeedCubic formula
-  std::array<DataVector, 3> expected_values_outer_boundary{
-      DataVector{1.0 + velocity * cube(time) /
-                           (square(decay_timescale) + square(time))},
-      DataVector{velocity}, DataVector{0.01 * velocity}};
-
-  CHECK(from_volume_file.expansion_values == expected_values);
-  CHECK_ITERABLE_APPROX(from_volume_file.expansion_values_outer_boundary,
-                        expected_values_outer_boundary);
-  CHECK(from_volume_file.velocity_outer_boundary == velocity);
-  CHECK(from_volume_file.decay_timescale_outer_boundary == decay_timescale);
-
-  if (file_system::check_if_file_exists(filename)) {
-    file_system::rm(filename, true);
-  }
-}
-
-template <>
-void test<domain::creators::time_dependent_options::names::Rotation>() {
-  const std::string filename{"ExtraSpicyHorseRadish.h5"};
-  if (file_system::check_if_file_exists(filename)) {
-    file_system::rm(filename, true);
-  }
-  const std::string subfile_name{"VolumeData"};
-  const std::string function_of_time_name{"Rotation"};
-
-  std::unordered_map<std::string,
-                     std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
-      functions_of_time{};
-  functions_of_time[function_of_time_name] =
-      std::make_unique<domain::FunctionsOfTime::QuaternionFunctionOfTime<3>>(
-          0.0, std::array{DataVector{1.0, 0.0, 0.0, 0.0}},
-          std::array{DataVector{3, 2.0}, DataVector{3, 1.0}, DataVector{3, 0.0},
-                     DataVector{3, 0.0}},
-          100.0);
-
-  write_volume_data(filename, subfile_name, functions_of_time);
-
-  {
-    INFO("Is a QuaternionFunctionOfTime");
-    // Going at t=0 is easier for checking quaternions
-    const auto from_volume_file = TestHelpers::test_creation<
-        domain::creators::time_dependent_options::FromVolumeFile<
-            domain::creators::time_dependent_options::names::Rotation>>(
-        "H5Filename: " + filename + "\nSubfileName: " + subfile_name +
-        "\nTime: 0.0\n");
-
-    // q
-    // dtq = 0.5 * q * omega
-    // d2tq = 0.5 * (dtq * omega + q * dtomega)
-    std::array<DataVector, 3> expected_quaternion{
-        DataVector{1.0, 0.0, 0.0, 0.0}, DataVector{0.0, 0.5, 0.5, 0.5},
-        DataVector{-0.75, 0.0, 0.0, 0.0}};
-    std::array<DataVector, 4> expected_angle{
-        DataVector{3, 2.0}, DataVector{3, 1.0}, DataVector{3, 0.0},
-        DataVector{3, 0.0}};
-
-    CHECK(from_volume_file.quaternions == expected_quaternion);
-    CHECK(from_volume_file.angle_values == expected_angle);
-  }
-
-  if (file_system::check_if_file_exists(filename)) {
-    file_system::rm(filename, true);
-  }
-
-  // Write new function of time
-  {
-    auto quat_and_derivs =
-        functions_of_time.at(function_of_time_name)->func_and_2_derivs(0.0);
-    functions_of_time.clear();
-    functions_of_time[function_of_time_name] =
-        std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<2>>(
-            0.0, std::move(quat_and_derivs), 100.0);
-    write_volume_data(filename, subfile_name, functions_of_time);
-  }
-
-  {
-    INFO("Is not a QuaternionFunctionOfTime");
-    // Going at t=0 is easier for checking quaternions
-    const auto from_volume_file = TestHelpers::test_creation<
-        domain::creators::time_dependent_options::FromVolumeFile<
-            domain::creators::time_dependent_options::names::Rotation>>(
-        "H5Filename: " + filename + "\nSubfileName: " + subfile_name +
-        "\nTime: 0.0\n");
-
-    // q
-    // dtq = 0.5 * q * omega
-    // d2tq = 0.5 * (dtq * omega + q * dtomega)
-    std::array<DataVector, 3> expected_quaternion{
-        DataVector{1.0, 0.0, 0.0, 0.0}, DataVector{0.0, 0.5, 0.5, 0.5},
-        DataVector{-0.75, 0.0, 0.0, 0.0}};
-    std::array<DataVector, 4> expected_angle{
-        DataVector{3, 0.0}, DataVector{3, 1.0}, DataVector{3, 0.0},
-        DataVector{3, 0.0}};
-
-    CHECK(from_volume_file.quaternions == expected_quaternion);
-    CHECK(from_volume_file.angle_values == expected_angle);
-  }
-
-  if (file_system::check_if_file_exists(filename)) {
-    file_system::rm(filename, true);
-  }
-}
-
-template <>
-void test<domain::creators::time_dependent_options::names::ShapeSize<
-    domain::ObjectLabel::B>>() {
-  const std::string filename{"BlandHorseRadish.h5"};
-  if (file_system::check_if_file_exists(filename)) {
-    file_system::rm(filename, true);
-  }
-  const std::string subfile_name{"VolumeData"};
-  const std::string shape_name{"ShapeB"};
-  const std::string size_name{"SizeB"};
-
-  std::unordered_map<std::string,
-                     std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
-      functions_of_time{};
-  // For reading these in, we don't care how many components of the DataVector
-  // there are. Normally there'd be a lot more.
-  functions_of_time[shape_name] =
-      std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<2>>(
-          0.0,
-          std::array{DataVector{1, 0.0}, DataVector{1, 0.0},
-                     DataVector{1, 2.0}},
-          100.0);
-  functions_of_time[size_name] =
-      std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<3>>(
-          0.0,
-          std::array{DataVector{1, 0.1}, DataVector{1, 0.0}, DataVector{1, 0.3},
-                     DataVector{1, 0.0}},
-          100.0);
-
-  write_volume_data(filename, subfile_name, functions_of_time);
-
-  const auto from_volume_file = TestHelpers::test_creation<
-      domain::creators::time_dependent_options::FromVolumeFile<
-          domain::creators::time_dependent_options::names::ShapeSize<
-              domain::ObjectLabel::B>>>("H5Filename: " + filename +
-                                        "\nSubfileName: " + subfile_name +
-                                        "\nTime: 50.0\n");
-
-  std::array<DataVector, 3> expected_shape_values{
-      DataVector{2500.0}, DataVector{100.0}, DataVector{2.0}};
-  std::array<DataVector, 4> expected_size_values{
-      DataVector{0.1 + 0.5 * 2500.0 * 0.3}, DataVector{50.0 * 0.3},
-      DataVector{0.3}, DataVector{0.0}};
-
-  CHECK(from_volume_file.shape_values == expected_shape_values);
-  CHECK_ITERABLE_APPROX(from_volume_file.size_values, expected_size_values);
+  CHECK(dynamic_cast<domain::FunctionsOfTime::PiecewisePolynomial<2>&>(
+            *fot_from_file.at(function_of_time_name)) ==
+        dynamic_cast<domain::FunctionsOfTime::PiecewisePolynomial<2>&>(
+            *functions_of_time.at(function_of_time_name)));
 
   if (file_system::check_if_file_exists(filename)) {
     file_system::rm(filename, true);
@@ -295,24 +86,31 @@ void test_errors() {
   }
 
   using FromVolumeFile =
-      domain::creators::time_dependent_options::FromVolumeFile<
-          domain::creators::time_dependent_options::names::Expansion>;
+      domain::creators::time_dependent_options::FromVolumeFile;
+
+  auto from_volume_file = TestHelpers::test_creation<FromVolumeFile>(
+      "H5Filename: " + filename + "\nSubfileName: " + subfile_name);
 
   CHECK_THROWS_WITH(
-      (FromVolumeFile{filename, subfile_name, 0.0}),
+      (from_volume_file.retrieve_function_of_time({"Expansion"}, 0.0)),
       Catch::Matchers::ContainsSubstring(
           "Expansion: There are no observation IDs in the subfile "));
 
   // Need new subfile to write to
   subfile_name += "0";
-  write_volume_data(filename, subfile_name);
+  TestHelpers::domain::creators::write_volume_data(filename, subfile_name);
+
+  from_volume_file = TestHelpers::test_creation<FromVolumeFile>(
+      "H5Filename: " + filename + "\nSubfileName: " + subfile_name);
 
   CHECK_THROWS_WITH(
-      (FromVolumeFile{filename, subfile_name, 0.0}),
+      (from_volume_file.retrieve_function_of_time({"Expansion"}, 0.0)),
       Catch::Matchers::ContainsSubstring(
           "Expansion: There are no functions of time in the subfile "));
 
   subfile_name += "0";
+  from_volume_file = TestHelpers::test_creation<FromVolumeFile>(
+      "H5Filename: " + filename + "\nSubfileName: " + subfile_name);
   std::unordered_map<std::string,
                      std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
       functions_of_time{};
@@ -323,13 +121,17 @@ void test_errors() {
                      DataVector{3, 0.0}},
           100.0);
 
-  write_volume_data(filename, subfile_name, functions_of_time);
+  TestHelpers::domain::creators::write_volume_data(filename, subfile_name,
+                                                   functions_of_time);
 
-  CHECK_THROWS_WITH((FromVolumeFile{filename, subfile_name, 0.1}),
-                    Catch::Matchers::ContainsSubstring(
-                        "No function of time named Expansion in the subfile "));
+  CHECK_THROWS_WITH(
+      (from_volume_file.retrieve_function_of_time({"Expansion"}, 0.0)),
+      Catch::Matchers::ContainsSubstring(
+          "No function of time named Expansion in the subfile "));
 
   subfile_name += "0";
+  from_volume_file = TestHelpers::test_creation<FromVolumeFile>(
+      "H5Filename: " + filename + "\nSubfileName: " + subfile_name);
   functions_of_time.clear();
   functions_of_time["Expansion"] =
       std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<2>>(
@@ -338,13 +140,19 @@ void test_errors() {
                      DataVector{3, 0.0}},
           1.0);
 
-  write_volume_data(filename, subfile_name, functions_of_time);
+  TestHelpers::domain::creators::write_volume_data(filename, subfile_name,
+                                                   functions_of_time);
 
   CHECK_THROWS_WITH(
-      (FromVolumeFile{filename, subfile_name, 10.0}),
+      (from_volume_file.retrieve_function_of_time({"Expansion"}, 10.0)),
       Catch::Matchers::ContainsSubstring("Expansion: The requested time") and
           Catch::Matchers::ContainsSubstring(
               "is out of the range of the function of time"));
+
+  // Check that this is ok to call
+  const auto function_of_time =
+      from_volume_file.retrieve_function_of_time({"Expansion"}, std::nullopt);
+  (void)function_of_time;
 
   if (file_system::check_if_file_exists(filename)) {
     file_system::rm(filename, true);
@@ -354,11 +162,7 @@ void test_errors() {
 SPECTRE_TEST_CASE("Unit.Domain.Creators.TimeDependentOptions.FromVolumeFile",
                   "[Unit][Domain]") {
   domain::FunctionsOfTime::register_derived_with_charm();
-  test<domain::creators::time_dependent_options::names::Translation>();
-  test<domain::creators::time_dependent_options::names::Expansion>();
-  test<domain::creators::time_dependent_options::names::Rotation>();
-  test<domain::creators::time_dependent_options::names::ShapeSize<
-      domain::ObjectLabel::B>>();
+  test("Translation");
   test_errors();
 }
 }  // namespace

--- a/tests/Unit/Domain/FunctionsOfTime/Test_FixedSpeedCubic.cpp
+++ b/tests/Unit/Domain/FunctionsOfTime/Test_FixedSpeedCubic.cpp
@@ -75,6 +75,11 @@ void test(
     CHECK(get_output(*fixed_speed_cubic) ==
           "FixedSpeedCubic(t=10, f=1, v=0.4, tau^2=25)");
   }
+
+  CHECK(dynamic_cast<const domain::FunctionsOfTime::FixedSpeedCubic&>(
+            *f_of_t->get_clone()) ==
+        dynamic_cast<const domain::FunctionsOfTime::FixedSpeedCubic&>(
+            *f_of_t->create_at_time(0.0, 0.0)));
 }
 
 void test_function(const double initial_function_value,

--- a/tests/Unit/Domain/FunctionsOfTime/Test_IntegratedFunctionOfTime.cpp
+++ b/tests/Unit/Domain/FunctionsOfTime/Test_IntegratedFunctionOfTime.cpp
@@ -59,6 +59,20 @@ void test(const gsl::not_null<FunctionsOfTime::FunctionOfTime*> f_of_t,
     CHECK(f_of_t->expiration_after(t) == approx(t + 0.5 * dt));
     CHECK(*f_of_t_derived != f_of_t_derived_copy);
   }
+
+  const size_t index = positions.size() - 8;
+  const auto new_time = static_cast<double>(index) * dt;
+  const auto new_expiration = new_time + dt;
+  const auto copy_at_time = f_of_t->create_at_time(new_time, new_expiration);
+
+  CAPTURE(rotation);
+  const double check_time = new_time;
+  CHECK_ITERABLE_APPROX(copy_at_time->func(check_time),
+                        f_of_t_derived->func(check_time));
+  CHECK_ITERABLE_APPROX(copy_at_time->func_and_deriv(check_time),
+                        f_of_t_derived->func_and_deriv(check_time));
+  const auto t_bounds = copy_at_time->time_bounds();
+  CHECK(t_bounds == std::array{new_time, new_expiration});
 }
 
 void test_out_of_order_update() {

--- a/tests/Unit/Domain/FunctionsOfTime/Test_SettleToConstant.cpp
+++ b/tests/Unit/Domain/FunctionsOfTime/Test_SettleToConstant.cpp
@@ -50,6 +50,11 @@ void test(
   CHECK(t_bounds[1] == std::numeric_limits<double>::infinity());
   CHECK(f_of_t->expiration_after(match_time) ==
         std::numeric_limits<double>::infinity());
+
+  CHECK(dynamic_cast<const domain::FunctionsOfTime::SettleToConstant&>(
+            *f_of_t->get_clone()) ==
+        dynamic_cast<const domain::FunctionsOfTime::SettleToConstant&>(
+            *f_of_t->create_at_time(0.0, 0.0)));
 }
 }  // namespace
 

--- a/tests/Unit/Domain/FunctionsOfTime/Test_SettleToConstantQuaternion.cpp
+++ b/tests/Unit/Domain/FunctionsOfTime/Test_SettleToConstantQuaternion.cpp
@@ -57,6 +57,12 @@ void test(
   CHECK(t_bounds[1] == std::numeric_limits<double>::infinity());
   CHECK(f_of_t->expiration_after(match_time) ==
         std::numeric_limits<double>::infinity());
+
+  CHECK(
+      dynamic_cast<const domain::FunctionsOfTime::SettleToConstantQuaternion&>(
+          *f_of_t->get_clone()) ==
+      dynamic_cast<const domain::FunctionsOfTime::SettleToConstantQuaternion&>(
+          *f_of_t->create_at_time(0.0, 0.0)));
 }
 }  // namespace
 

--- a/tests/Unit/Evolution/Ringdown/Test_StrahlkorperCoefsInRingdownDistortedFrame.cpp
+++ b/tests/Unit/Evolution/Ringdown/Test_StrahlkorperCoefsInRingdownDistortedFrame.cpp
@@ -15,8 +15,12 @@
 #include "DataStructures/DataVector.hpp"
 #include "Domain/CoordinateMaps/Distribution.hpp"
 #include "Domain/Creators/Sphere.hpp"
+#include "Domain/Creators/TimeDependentOptions/ExpansionMap.hpp"
+#include "Domain/Creators/TimeDependentOptions/RotationMap.hpp"
+#include "Domain/Creators/TimeDependentOptions/ShapeMap.hpp"
 #include "Domain/Creators/TimeDependentOptions/Sphere.hpp"
 #include "Domain/StrahlkorperTransformations.hpp"
+#include "Domain/Structure/ObjectLabel.hpp"
 #include "Evolution/Ringdown/StrahlkorperCoefsInRingdownDistortedFrame.hpp"
 #include "Framework/TestHelpers.hpp"
 #include "Helpers/DataStructures/MakeWithRandomValues.hpp"
@@ -86,7 +90,7 @@ SPECTRE_TEST_CASE(
   for (size_t i = 0; i < 4; ++i) {
     gsl::at(initial_unit_quaternion, i) /= initial_unit_quaternion_magnitude;
   }
-  const std::array<std::array<double, 4>, 3> rot_func_and_2_derivs{
+  const std::vector<std::array<double, 4>> rot_func_and_2_derivs{
       initial_unit_quaternion,
       make_with_random_values<std::array<double, 4>>(make_not_null(&generator),
                                                      make_not_null(&fot_dist)),
@@ -96,13 +100,14 @@ SPECTRE_TEST_CASE(
   std::uniform_real_distribution<double> settling_dist{0.5, 1.5};
   const double settling_timescale{settling_dist(generator)};
 
-  const domain::creators::sphere::TimeDependentMapOptions::ShapeMapOptions
+  const domain::creators::time_dependent_options::ShapeMapOptions<
+      false, domain::ObjectLabel::None>
       shape_map_options{l_max, std::nullopt};
-  const domain::creators::sphere::TimeDependentMapOptions::ExpansionMapOptions
+  const domain::creators::time_dependent_options::ExpansionMapOptions<true>
       expansion_map_options{exp_func_and_2_derivs, settling_timescale,
                             exp_outer_bdry_func_and_2_derivs,
                             settling_timescale};
-  const domain::creators::sphere::TimeDependentMapOptions::RotationMapOptions
+  const domain::creators::time_dependent_options::RotationMapOptions<true>
       rotation_map_options{rot_func_and_2_derivs, settling_timescale};
   const domain::creators::sphere::TimeDependentMapOptions
       time_dependent_map_options{match_time,           shape_map_options,

--- a/tests/Unit/Evolution/Systems/Cce/Test_OptionTags.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_OptionTags.cpp
@@ -108,13 +108,13 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.OptionTags", "[Unit][Cce]") {
             "100.0") == 100.0);
 
   CHECK(TestHelpers::test_option_tag<Cce::OptionTags::EndTime>("4.0") ==
-        Options::Auto<double>{4.0});
+        std::optional<double>{4.0});
   CHECK(TestHelpers::test_option_tag<Cce::OptionTags::EndTime>("Auto") ==
-        Options::Auto<double>{});
+        std::optional<double>{});
   CHECK(TestHelpers::test_option_tag<Cce::OptionTags::StartTime>("2.0") ==
-        Options::Auto<double>{2.0});
+        std::optional<double>{2.0});
   CHECK(TestHelpers::test_option_tag<Cce::OptionTags::StartTime>("Auto") ==
-        Options::Auto<double>{});
+        std::optional<double>{});
   CHECK(TestHelpers::test_option_tag<Cce::OptionTags::BoundaryDataFilename>(
             "OptionTagsCceR0100.h5") == "OptionTagsCceR0100.h5");
   CHECK(TestHelpers::test_option_tag<

--- a/tests/Unit/Framework/TestCreation.hpp
+++ b/tests/Unit/Framework/TestCreation.hpp
@@ -8,6 +8,7 @@
 #include <string>
 #include <type_traits>
 
+#include "Options/Auto.hpp"
 #include "Options/Options.hpp"
 #include "Options/ParseOptions.hpp"
 #include "Options/Protocols/FactoryCreation.hpp"
@@ -51,6 +52,23 @@ struct AddGroups<Tag, std::void_t<typename Tag::group>> {
         AddGroups<void>::template apply<Tag>(construction_string));
   }
 };
+
+template <typename OptionTag, bool IsAuto>
+struct option_return;
+
+template <typename OptionTag>
+struct option_return<OptionTag, true> {
+  using type = typename OptionTag::type::value_type;
+};
+
+template <typename OptionTag>
+struct option_return<OptionTag, false> {
+  using type = typename OptionTag::type;
+};
+
+template <typename OptionTag>
+using option_return_t = typename option_return<
+    OptionTag, tt::is_a_v<Options::Auto, typename OptionTag::type>>::type;
 
 template <typename BaseClass, typename DerivedClass>
 struct SingleFactoryMetavariables {
@@ -106,7 +124,7 @@ T test_creation(const std::string& construction_string) {
 ///
 /// \see TestHelpers::test_creation()
 template <typename OptionTag, typename Metavariables = NoSuchType>
-typename OptionTag::type test_option_tag(
+TestCreation_detail::option_return_t<OptionTag> test_option_tag(
     const std::string& construction_string) {
   Options::Parser<tmpl::list<OptionTag>> options("");
   options.parse(

--- a/tests/Unit/Helpers/Domain/CMakeLists.txt
+++ b/tests/Unit/Helpers/Domain/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY "DomainHelpers")
 
 set(LIBRARY_SOURCES
   DomainTestHelpers.cpp
+  Creators/TimeDependent/TestHelpers.cpp
   )
 
 add_spectre_library(${LIBRARY} ${SPECTRE_TEST_LIBS_TYPE} ${LIBRARY_SOURCES})

--- a/tests/Unit/Helpers/Domain/Creators/TimeDependent/TestHelpers.cpp
+++ b/tests/Unit/Helpers/Domain/Creators/TimeDependent/TestHelpers.cpp
@@ -1,0 +1,45 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Helpers/Domain/Creators/TimeDependent/TestHelpers.hpp"
+
+#include <memory>
+#include <optional>
+#include <pup.h>
+#include <pup_stl.h>
+#include <string>
+#include <unordered_map>
+
+#include "DataStructures/DataVector.hpp"
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "IO/H5/AccessType.hpp"
+#include "IO/H5/File.hpp"
+#include "IO/H5/TensorData.hpp"
+#include "IO/H5/VolumeData.hpp"
+#include "NumericalAlgorithms/Spectral/Basis.hpp"
+#include "NumericalAlgorithms/Spectral/Quadrature.hpp"
+#include "Utilities/Serialization/Serialize.hpp"
+
+namespace TestHelpers::domain::creators {
+void write_volume_data(
+    const std::string& filename, const std::string& subfile_name,
+    const std::unordered_map<
+        std::string,
+        std::unique_ptr<::domain::FunctionsOfTime::FunctionOfTime>>&
+        functions_of_time) {
+  h5::H5File<h5::AccessType::ReadWrite> h5_file{filename, true};
+  auto& vol_file = h5_file.insert<h5::VolumeData>(subfile_name);
+
+  // We don't care about the volume data here, just the functions of time
+  vol_file.write_volume_data(
+      0, 0.0,
+      {ElementVolumeData{"blah",
+                         {TensorComponent{"RandomTensor", DataVector{3, 0.0}}},
+                         {3},
+                         {Spectral::Basis::Legendre},
+                         {Spectral::Quadrature::GaussLobatto}}},
+      std::nullopt,
+      functions_of_time.empty() ? std::nullopt
+                                : std::optional{serialize(functions_of_time)});
+}
+}  // namespace TestHelpers::domain::creators

--- a/tests/Unit/Helpers/Domain/Creators/TimeDependent/TestHelpers.hpp
+++ b/tests/Unit/Helpers/Domain/Creators/TimeDependent/TestHelpers.hpp
@@ -1,0 +1,19 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <memory>
+#include <string>
+#include <unordered_map>
+
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+
+namespace TestHelpers::domain::creators {
+void write_volume_data(
+    const std::string& filename, const std::string& subfile_name,
+    const std::unordered_map<
+        std::string,
+        std::unique_ptr<::domain::FunctionsOfTime::FunctionOfTime>>&
+        functions_of_time = {});
+}  // namespace TestHelpers::domain::creators

--- a/tests/Unit/Helpers/Evolution/Systems/CurvedScalarWave/Worldtube/TestHelpers.cpp
+++ b/tests/Unit/Helpers/Evolution/Systems/CurvedScalarWave/Worldtube/TestHelpers.cpp
@@ -65,11 +65,11 @@ std::unique_ptr<DomainCreator<3>> worldtube_binary_compact_object(
       "  TimeDependentMaps:\n"
       "    InitialTime: 0.0\n"
       "    ExpansionMap: \n"
-      "      InitialValues: [1.0, 0.0]\n"
+      "      InitialValues: [1.0, 0.0, 0.0]\n"
       "      AsymptoticVelocityOuterBoundary: 0.0\n"
-      "      DecayTimescaleOuterBoundaryVelocity: 1.0\n"
+      "      DecayTimescaleOuterBoundary: 1.0\n"
       "    RotationMap:\n"
-      "      InitialAngularVelocity: [0.0, 0.0," +
+      "      InitialAngularVelocity: [0.0, 0.0, " +
       angular_velocity_stream.str() +
       "]\n"
       "    TranslationMap: None\n"

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_ComputeDestVars.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_ComputeDestVars.cpp
@@ -11,10 +11,12 @@
 #include "DataStructures/Variables.hpp"
 #include "Domain/Creators/Sphere.hpp"
 #include "Domain/Creators/Tags/FunctionsOfTime.hpp"
+#include "Domain/Creators/TimeDependentOptions/ShapeMap.hpp"
 #include "Domain/Creators/TimeDependentOptions/Sphere.hpp"
 #include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
 #include "Domain/FunctionsOfTime/RegisterDerivedWithCharm.hpp"
 #include "Domain/Structure/ElementId.hpp"
+#include "Domain/Structure/ObjectLabel.hpp"
 #include "Framework/ActionTesting.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "Parallel/GlobalCache.hpp"
@@ -108,9 +110,13 @@ void test() {
   domain::FunctionsOfTime::register_derived_with_charm();
 
   using TDMO = domain::creators::sphere::TimeDependentMapOptions;
-  TDMO time_dep_opts{0.0,          TDMO::ShapeMapOptions{2, std::nullopt},
-                     std::nullopt, std::nullopt,
-                     std::nullopt, true};
+  TDMO time_dep_opts{0.0,
+                     domain::creators::time_dependent_options::ShapeMapOptions<
+                         false, domain::ObjectLabel::None>{2, std::nullopt},
+                     std::nullopt,
+                     std::nullopt,
+                     std::nullopt,
+                     true};
 
   const auto domain_creator = domain::creators::Sphere(
       0.9, 4.9, domain::creators::Sphere::Excision{}, 1_st, 7_st, false, {},


### PR DESCRIPTION
## Proposed changes

Final PR in the series that revamps the time dependent options for the Sphere and BCO domains.

This actually adds all the new common options to the domain creators.

Fixes #5584.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
The options for the Expansion and Rotation map in the BinaryCompactObject and Sphere domains have changed slightly. In the BinaryCompactObject, they are now
```yaml
    TimeDependentMaps:
      ...
      ExpansionMap:
        InitialValues: [1.0, -4.6148457646200002e-05, 0.0] # <-- Must specify all derivs
        AsymptoticVelocityOuterBoundary: -1.0e-6 # <-- Same as before
        DecayTimescaleOuterBoundary: 50.0 # <-- Different name, same value as before
```

In the Sphere domain, you can optionally specify the same options as the BinaryCompactObject like above to use functions of time that expire. Additionally, you can specify options to use SettleToConstant functions of time in the Sphere domain with the options below
```yaml
    TimeDependentMaps:
      ...
      ExpansionMap:
        InitialValues: [1.0, -4.6148457646200002e-05, 0.0] # <-- Must specify all derivs
        InitialValuesOuterBoundary: [1.0, 0.0, 0.0] # <-- Must specify all derivs
        DecayTimescale: 52.0 # <-- Different name
        DecayTimescaleOuterBoundary: 50.0 # <-- Different name
      RotationMap:
        InitialQuaternions: [[1.0, 0.0, 0.0, 0.0]] # <-- Need quat. Can optionally specify derivs
        DecayTimescale: 50 # <-- Different name
```

Additionally, for any of the time dependent map options, you can choose the function of time from a volume H5 file by specifying the following options (not just for Expansion, but for Rotation and Translation as well and shape is slightly different)

```yaml
    TimeDependentMaps:
      ...
      ExpansionMap:
        H5Filename: BbhVolume0.h5
        SubfileName: VolumeData
      ShapeMapA:
        H5Filename: BbhVolume0.h5
        SubfileName: VolumeData
        TransitionEndsAtCube: true
```


<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

~Depends on and includes #6109, #6113, and #6114.~

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
