### PR TITLE
Fix mistake in ScalarTensor stress energy tensor

### DIFF
--- a/src/Evolution/Systems/ScalarTensor/StressEnergy.cpp
+++ b/src/Evolution/Systems/ScalarTensor/StressEnergy.cpp
@@ -27,14 +27,29 @@ void trace_reversed_stress_energy(
     const gsl::not_null<tnsr::aa<DataVector, 3_st>*> stress_energy,
     const Scalar<DataVector>& pi_scalar,
     const tnsr::i<DataVector, 3_st>& phi_scalar,
-    const Scalar<DataVector>& lapse) {
+    const Scalar<DataVector>& lapse, const tnsr::I<DataVector, 3_st>& shift) {
+  // 00-component
   get<0, 0>(*stress_energy) = square(get(lapse) * get(pi_scalar));
+
   for (size_t i = 0; i < 3; ++i) {
+    // 00-component
+    get<0, 0>(*stress_energy) +=
+        -2.0 * get(lapse) * get(pi_scalar) * shift.get(i) * phi_scalar.get(i);
+    // 0i-component
     stress_energy->get(0, i + 1) =
         -get(lapse) * get(pi_scalar) * phi_scalar.get(i);
-  }
-  for (size_t i = 0; i < 3; ++i) {
+
+    for (size_t j = 0; j < 3; ++j) {
+      // 00-component
+      get<0, 0>(*stress_energy) +=
+          shift.get(i) * shift.get(j) * phi_scalar.get(i) * phi_scalar.get(j);
+      // 0i-component
+      stress_energy->get(0, i + 1) +=
+          shift.get(j) * phi_scalar.get(j) * phi_scalar.get(i);
+    }
+
     for (size_t j = i; j < 3; ++j) {
+      // ij-component
       stress_energy->get(i + 1, j + 1) = phi_scalar.get(i) * phi_scalar.get(j);
     }
   }

--- a/src/Evolution/Systems/ScalarTensor/StressEnergy.hpp
+++ b/src/Evolution/Systems/ScalarTensor/StressEnergy.hpp
@@ -63,10 +63,10 @@ void add_stress_energy_term_to_dt_pi(
  *
  * In terms of the evolved variables of the scalar,
  * \f{align*}{
-    T^{(\Psi), \text{TR}}_{00} &= \alpha^2 \Pi^2 ~, \\
-    T^{(\Psi), \text{TR}}_{j 0} &= T^{(\Psi), \text{TR}}_{0j}
-                                 = - \alpha \Pi \Phi_j ~, \\
-    T^{(\Psi), \text{TR}}_{ij} &= \Phi_i \Phi_j ~,
+    T_{00} &= \alpha^2 \Pi^{2} - 2 \alpha \Pi \beta^{i} \Phi_{i}
+     + \beta^{i} \beta^{j} \Phi_{i} \Phi{j}~,                     \\
+    T_{0k} &= - \alpha \Pi \Phi_{k} + \beta^{i} \Phi_{i} \Phi_{k}~,          \\
+    T_{ij} &= \Phi_{i} \Phi{j}~.
  * \f}
  *
  * where \f$\alpha\f$ is the lapse.
@@ -77,12 +77,13 @@ void add_stress_energy_term_to_dt_pi(
  * \param pi_scalar Scalar evolution variable $\Pi$.
  * \param phi_scalar Scalar evolution variable $\Phi_i$.
  * \param lapse Lapse $\alpha$.
+ * \param shift Shift $\beta^{i}$.
  */
 void trace_reversed_stress_energy(
     gsl::not_null<tnsr::aa<DataVector, 3_st>*> stress_energy,
     const Scalar<DataVector>& pi_scalar,
     const tnsr::i<DataVector, 3_st>& phi_scalar,
-    const Scalar<DataVector>& lapse);
+    const Scalar<DataVector>& lapse, const tnsr::I<DataVector, 3_st>& shift);
 
 namespace Tags {
 
@@ -97,12 +98,14 @@ struct TraceReversedStressEnergyCompute
   static constexpr size_t Dim = 3;
   using argument_tags =
       tmpl::list<CurvedScalarWave::Tags::Pi, CurvedScalarWave::Tags::Phi<Dim>,
-                 gr::Tags::Lapse<DataVector>>;
+                 gr::Tags::Lapse<DataVector>,
+                 gr::Tags::Shift<DataVector, 3, Frame::Inertial>>;
   using return_type = tnsr::aa<DataVector, Dim, Frame::Inertial>;
   static constexpr void (*function)(
       const gsl::not_null<tnsr::aa<DataVector, Dim>*> result,
       const Scalar<DataVector>&, const tnsr::i<DataVector, Dim>&,
-      const Scalar<DataVector>&) = &trace_reversed_stress_energy;
+      const Scalar<DataVector>&,
+      const tnsr::I<DataVector, Dim>&) = &trace_reversed_stress_energy;
   using base = TraceReversedStressEnergy<DataVector, Dim, Frame::Inertial>;
 };
 }  // namespace Tags

--- a/src/Evolution/Systems/ScalarTensor/TimeDerivative.cpp
+++ b/src/Evolution/Systems/ScalarTensor/TimeDerivative.cpp
@@ -157,7 +157,7 @@ void TimeDerivative::apply(
 
   // Compute the (trace-reversed) stress energy tensor here
   trace_reversed_stress_energy(stress_energy, pi_scalar, phi_scalar,
-                               lapse_scalar);
+                               lapse_scalar, shift_scalar);
 
   add_stress_energy_term_to_dt_pi(dt_pi, *stress_energy, lapse_scalar);
 

--- a/tests/Unit/Evolution/Systems/ScalarTensor/StressEnergy.py
+++ b/tests/Unit/Evolution/Systems/ScalarTensor/StressEnergy.py
@@ -4,19 +4,28 @@
 import numpy as np
 
 
-def trace_reversed_stress_energy(pi_scalar, phi_scalar, lapse):
+def trace_reversed_stress_energy(pi_scalar, phi_scalar, lapse, shift):
     # Define the different components
-    tt_component = lapse * lapse * pi_scalar * pi_scalar
-    tj_component = -lapse * pi_scalar * phi_scalar
-    ij_component = np.outer(phi_scalar, phi_scalar)
+    rho = pi_scalar * pi_scalar
+    j_vec = -pi_scalar * phi_scalar
+    S = np.outer(phi_scalar, phi_scalar)
 
     # Construct the trace-reversed stress energy tensor
     stress_energy = np.zeros((4, 4))
 
-    stress_energy[0, 0] = tt_component
-    stress_energy[0, 1:] = tj_component
-    stress_energy[1:, 0] = stress_energy[0, 1:]
-    stress_energy[1:, 1:] = ij_component
+    # 00-component
+    stress_energy[0, 0] = (
+        np.power(lapse, 2) * rho
+        + 2.0 * lapse * np.dot(shift, j_vec)
+        + shift @ S @ shift
+    )
+
+    # 0i-component
+    stress_energy[0, 1:] = lapse * j_vec + shift @ S
+    stress_energy[1:, 0] = np.transpose(stress_energy[0, 1:])
+
+    # ij-component
+    stress_energy[1:, 1:] = S
 
     return stress_energy
 

--- a/tests/Unit/Evolution/Systems/ScalarTensor/Test_TimeDerivative.cpp
+++ b/tests/Unit/Evolution/Systems/ScalarTensor/Test_TimeDerivative.cpp
@@ -253,7 +253,9 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.ScalarTensor.TimeDerivative",
               DataVector, 3, ::Frame::Inertial>>(expected_temp_variables)),
       tuples::get<CurvedScalarWave::Tags::Pi>(arg_variables),
       tuples::get<CurvedScalarWave::Tags::Phi<3>>(arg_variables),
-      tuples::get<gr::Tags::Lapse<DataVector>>(arg_variables));
+      tuples::get<gr::Tags::Lapse<DataVector>>(arg_variables),
+      tuples::get<gr::Tags::Shift<DataVector, 3, ::Frame::Inertial>>(
+          arg_variables));
 
   // When we have backreaction we also need to compute and apply the correction
   // to dt pi for the expected variables


### PR DESCRIPTION
## Proposed changes

Fix a mistake in the formula for the stress energy tensor for the ScalarTensor system. (Unused so far to my knowledge.)

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
