### PR TITLE
Support complex numbers in serial linear solvers, add BLAS zdot

### DIFF
--- a/src/DataStructures/DynamicMatrix.cpp
+++ b/src/DataStructures/DynamicMatrix.cpp
@@ -3,7 +3,10 @@
 
 #include "DataStructures/DynamicMatrix.hpp"
 
+#include <complex>
+
 #include "Options/ParseOptions.hpp"
+#include "Options/StdComplex.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 
 namespace DynamicMatrix_detail {
@@ -20,7 +23,7 @@ std::vector<std::vector<Type>> parse_to_vectors(
   template std::vector<std::vector<TYPE(data)>> parse_to_vectors( \
       const Options::Option& options);
 
-GENERATE_INSTANTIATIONS(INSTANTIATE, (double))
+GENERATE_INSTANTIATIONS(INSTANTIATE, (double, std::complex<double>))
 
 #undef INSTANTIATE
 #undef TYPE

--- a/src/DataStructures/DynamicVector.cpp
+++ b/src/DataStructures/DynamicVector.cpp
@@ -3,8 +3,11 @@
 
 #include "DataStructures/DynamicVector.hpp"
 
+#include <complex>
+
 #include "Options/Options.hpp"
 #include "Options/ParseOptions.hpp"
+#include "Options/StdComplex.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 
 namespace DynamicVector_detail {
@@ -20,7 +23,7 @@ std::vector<T> parse_to_vector(const Options::Option& options) {
   template std::vector<TYPE(data)> parse_to_vector( \
       const Options::Option& options);
 
-GENERATE_INSTANTIATIONS(INSTANTIATE, (double))
+GENERATE_INSTANTIATIONS(INSTANTIATE, (double, std::complex<double>))
 
 #undef INSTANTIATE
 #undef TYPE

--- a/src/Elliptic/SubdomainPreconditioners/MinusLaplacian.hpp
+++ b/src/Elliptic/SubdomainPreconditioners/MinusLaplacian.hpp
@@ -55,7 +55,7 @@ template <size_t Dim, typename OptionsGroup,
               ::LinearSolver::Serial::Registrars::Gmres<
                   ::LinearSolver::Schwarz::ElementCenteredSubdomainData<
                       Dim, tmpl::list<Poisson::Tags::Field>>>,
-              ::LinearSolver::Serial::Registrars::ExplicitInverse>>>
+              ::LinearSolver::Serial::Registrars::ExplicitInverse<double>>>>
 struct MinusLaplacian {
   template <typename LinearSolverRegistrars>
   using f = subdomain_preconditioners::MinusLaplacian<Dim, OptionsGroup, Solver,
@@ -97,7 +97,7 @@ template <size_t Dim, typename OptionsGroup,
               ::LinearSolver::Serial::Registrars::Gmres<
                   ::LinearSolver::Schwarz::ElementCenteredSubdomainData<
                       Dim, tmpl::list<Poisson::Tags::Field>>>,
-              ::LinearSolver::Serial::Registrars::ExplicitInverse>>,
+              ::LinearSolver::Serial::Registrars::ExplicitInverse<double>>>,
           typename LinearSolverRegistrars =
               tmpl::list<Registrars::MinusLaplacian<Dim, OptionsGroup, Solver>>>
 class MinusLaplacian

--- a/src/Elliptic/SubdomainPreconditioners/RegisterDerived.cpp
+++ b/src/Elliptic/SubdomainPreconditioners/RegisterDerived.cpp
@@ -14,11 +14,12 @@
 namespace {
 template <size_t Dim>
 void register_derived_with_charm_impl() {
-  register_derived_classes_with_charm<LinearSolver::Serial::LinearSolver<
-      tmpl::list<::LinearSolver::Serial::Registrars::Gmres<
-                     ::LinearSolver::Schwarz::ElementCenteredSubdomainData<
-                         Dim, tmpl::list<Poisson::Tags::Field>>>,
-                 ::LinearSolver::Serial::Registrars::ExplicitInverse>>>();
+  register_derived_classes_with_charm<
+      LinearSolver::Serial::LinearSolver<tmpl::list<
+          ::LinearSolver::Serial::Registrars::Gmres<
+              ::LinearSolver::Schwarz::ElementCenteredSubdomainData<
+                  Dim, tmpl::list<Poisson::Tags::Field>>>,
+          ::LinearSolver::Serial::Registrars::ExplicitInverse<double>>>>();
 }
 }  // namespace
 

--- a/src/NumericalAlgorithms/LinearSolver/BuildMatrix.hpp
+++ b/src/NumericalAlgorithms/LinearSolver/BuildMatrix.hpp
@@ -56,7 +56,7 @@ void build_matrix(const gsl::not_null<MatrixType*> matrix,
   // Re-using the iterators for all operator invocations
   auto result_iterator_begin = result_buffer->begin();
   auto result_iterator_end = result_buffer->end();
-  for (double& unit_vector_data : *operand_buffer) {
+  for (auto& unit_vector_data : *operand_buffer) {
     // Set a 1 at the unit vector location i
     unit_vector_data = 1.;
     // Invoke the operator on the unit vector

--- a/src/ParallelAlgorithms/Events/ObserveNorms.cpp
+++ b/src/ParallelAlgorithms/Events/ObserveNorms.cpp
@@ -118,8 +118,10 @@ split_complex_vector_of_data(
     const std::pair<std::vector<std::string>, std::vector<ComplexDataVector>>&
         names_and_components) {
   const auto& [names, components] = names_and_components;
-  std::vector<std::string> result_names{2 * names.size()};
-  std::vector<DataVector> result_components{2 * names.size()};
+  std::vector<std::string> result_names{};
+  std::vector<DataVector> result_components{};
+  result_names.reserve(2 * names.size());
+  result_components.reserve(2 * names.size());
   for (size_t i = 0; i < names.size(); ++i) {
     result_names.emplace_back("Re(" + names[i] + ")");
     result_components.emplace_back(real(components[i]));

--- a/src/ParallelAlgorithms/LinearSolver/AsynchronousSolvers/ElementActions.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/AsynchronousSolvers/ElementActions.hpp
@@ -294,8 +294,7 @@ struct PrepareSolve {
           observers::get_section_observation_key<ArraySectionIdTag>(box);
       if (section_observation_key.has_value()) {
         const auto& residual = get<residual_tag>(box);
-        const double residual_magnitude_square =
-            inner_product(residual, residual);
+        const double residual_magnitude_square = magnitude_square(residual);
         contribute_to_residual_observation<OptionsGroup, ParallelComponent>(
             iteration_id, residual_magnitude_square, cache, array_index,
             *section_observation_key);
@@ -386,8 +385,7 @@ struct CompleteStep {
       const size_t completed_iterations =
           get<Convergence::Tags::IterationId<OptionsGroup>>(box);
       const auto& residual = get<residual_tag>(box);
-      const double residual_magnitude_square =
-          inner_product(residual, residual);
+      const double residual_magnitude_square = magnitude_square(residual);
       contribute_to_residual_observation<OptionsGroup, ParallelComponent>(
           completed_iterations, residual_magnitude_square, cache, array_index,
           *section_observation_key);

--- a/src/ParallelAlgorithms/LinearSolver/ConjugateGradient/ElementActions.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/ConjugateGradient/ElementActions.hpp
@@ -85,7 +85,7 @@ struct PrepareSolve {
         InitializeResidual<FieldsTag, OptionsGroup, ParallelComponent>>(
         Parallel::ReductionData<
             Parallel::ReductionDatum<double, funcl::Plus<>>>{
-            inner_product(residual, residual)},
+            magnitude_square(residual)},
         Parallel::get_parallel_component<ParallelComponent>(cache)[array_index],
         Parallel::get_parallel_component<
             ResidualMonitor<Metavariables, FieldsTag, OptionsGroup>>(cache));
@@ -212,8 +212,7 @@ struct UpdateFieldValues {
 
     // Compute new residual norm in a second global reduction
     const auto& residual = get<residual_tag>(box);
-    const double local_residual_magnitude_square =
-        inner_product(residual, residual);
+    const double local_residual_magnitude_square = magnitude_square(residual);
 
     Parallel::contribute_to_reduction<
         UpdateResidual<FieldsTag, OptionsGroup, ParallelComponent>>(

--- a/src/ParallelAlgorithms/LinearSolver/Gmres/ElementActions.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Gmres/ElementActions.hpp
@@ -116,7 +116,7 @@ struct PrepareSolve {
         FieldsTag, OptionsGroup, ParallelComponent>>(
         Parallel::ReductionData<
             Parallel::ReductionDatum<double, funcl::Plus<>, funcl::Sqrt<>>>{
-            inner_product(get<operand_tag>(box), get<operand_tag>(box))},
+            magnitude_square(get<operand_tag>(box))},
         Parallel::get_parallel_component<ParallelComponent>(cache)[array_index],
         Parallel::get_parallel_component<
             ResidualMonitor<Metavariables, FieldsTag, OptionsGroup>>(cache),

--- a/src/ParallelAlgorithms/LinearSolver/Gmres/Tags/InboxTags.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Gmres/Tags/InboxTags.hpp
@@ -22,19 +22,20 @@ struct InitialOrthogonalization
       std::map<temporal_id, std::tuple<double, Convergence::HasConverged>>;
 };
 
-template <typename OptionsGroup>
-struct Orthogonalization
-    : Parallel::InboxInserters::Value<Orthogonalization<OptionsGroup>> {
+template <typename OptionsGroup, typename ValueType>
+struct Orthogonalization : Parallel::InboxInserters::Value<
+                               Orthogonalization<OptionsGroup, ValueType>> {
   using temporal_id = size_t;
-  using type = std::map<temporal_id, double>;
+  using type = std::map<temporal_id, ValueType>;
 };
 
-template <typename OptionsGroup>
+template <typename OptionsGroup, typename ValueType>
 struct FinalOrthogonalization
-    : Parallel::InboxInserters::Value<FinalOrthogonalization<OptionsGroup>> {
+    : Parallel::InboxInserters::Value<
+          FinalOrthogonalization<OptionsGroup, ValueType>> {
   using temporal_id = size_t;
   using type =
-      std::map<temporal_id, std::tuple<double, blaze::DynamicVector<double>,
+      std::map<temporal_id, std::tuple<double, blaze::DynamicVector<ValueType>,
                                        Convergence::HasConverged>>;
 };
 

--- a/src/ParallelAlgorithms/LinearSolver/Schwarz/ElementActions.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Schwarz/ElementActions.hpp
@@ -188,7 +188,8 @@ template <typename FieldsTag, typename SubdomainOperator,
                                           FieldsTag>::tags_list>>
 using subdomain_solver = LinearSolver::Serial::LinearSolver<tmpl::append<
     tmpl::list<::LinearSolver::Serial::Registrars::Gmres<SubdomainData>,
-               ::LinearSolver::Serial::Registrars::ExplicitInverse>,
+               ::LinearSolver::Serial::Registrars::ExplicitInverse<
+                   typename SubdomainData::value_type>>,
     SubdomainPreconditioners>>;
 
 template <typename FieldsTag, typename OptionsGroup, typename SubdomainOperator,

--- a/src/ParallelAlgorithms/LinearSolver/Schwarz/ElementCenteredSubdomainData.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Schwarz/ElementCenteredSubdomainData.hpp
@@ -63,6 +63,7 @@ struct ElementCenteredSubdomainData {
   using iterator = ElementCenteredSubdomainDataIterator<false, Dim, TagsList>;
   using const_iterator =
       ElementCenteredSubdomainDataIterator<true, Dim, TagsList>;
+  using value_type = typename ElementData::value_type;
 
   ElementCenteredSubdomainData() = default;
   ElementCenteredSubdomainData(const ElementCenteredSubdomainData&) = default;

--- a/src/ParallelAlgorithms/LinearSolver/Tags.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Tags.hpp
@@ -17,6 +17,7 @@
 #include "DataStructures/DataBox/TagName.hpp"
 #include "DataStructures/DynamicMatrix.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/TypeTraits/GetFundamentalType.hpp"
 
 /*!
  * \ingroup LinearSolverGroup
@@ -137,11 +138,12 @@ struct Orthogonalization : db::PrefixTag, db::SimpleTag {
  */
 template <typename Tag>
 struct OrthogonalizationHistory : db::PrefixTag, db::SimpleTag {
+  using ValueType = tt::get_complex_or_fundamental_type_t<typename Tag::type>;
   static std::string name() {
     // Add "Linear" prefix to abbreviate the namespace for uniqueness
     return "LinearOrthogonalizationHistory(" + db::tag_name<Tag>() + ")";
   }
-  using type = blaze::DynamicMatrix<double>;
+  using type = blaze::DynamicMatrix<ValueType>;
   using tag = Tag;
 };
 

--- a/src/ParallelAlgorithms/NonlinearSolver/NewtonRaphson/ElementActions.hpp
+++ b/src/ParallelAlgorithms/NonlinearSolver/NewtonRaphson/ElementActions.hpp
@@ -200,7 +200,7 @@ struct SendInitialResidualMagnitude {
     // Perform a global reduction to compute the initial residual magnitude
     const auto& residual = db::get<nonlinear_residual_tag>(box);
     const double local_residual_magnitude_square =
-        LinearSolver::inner_product(residual, residual);
+        LinearSolver::magnitude_square(residual);
     ResidualReductionData reduction_data{0, 0, local_residual_magnitude_square,
                                          1.};
     auto& section = Parallel::get_section<ParallelComponent, ArraySectionIdTag>(
@@ -458,7 +458,7 @@ struct ContributeToResidualMagnitudeReduction {
       const ParallelComponent* const /*meta*/) {
     const auto& residual = db::get<nonlinear_residual_tag>(box);
     const double local_residual_magnitude_square =
-        LinearSolver::inner_product(residual, residual);
+        LinearSolver::magnitude_square(residual);
     ResidualReductionData reduction_data{
         db::get<Convergence::Tags::IterationId<OptionsGroup>>(box),
         db::get<NonlinearSolver::Tags::Globalization<

--- a/src/Utilities/Blas.hpp
+++ b/src/Utilities/Blas.hpp
@@ -9,9 +9,12 @@
 
 #pragma once
 
+#include <complex>
+
 #ifndef SPECTRE_DEBUG
 #include <libxsmm.h>
 #endif  // ifndef SPECTRE_DEBUG
+#include <gsl/gsl_cblas.h>
 
 #include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/Gsl.hpp"
@@ -47,6 +50,7 @@ void dgemv_(const char& TRANS, const int& M, const int& N, const double& ALPHA,
  */
 void disable_openblas_multithreading();
 
+/// @{
 /*!
  * \ingroup UtilitiesGroup
  * The dot product of two vectors.
@@ -68,6 +72,36 @@ inline double ddot_(const size_t& N, const double* X, const size_t& INCX,
                             gsl::narrow_cast<int>(INCX), Y,
                             gsl::narrow_cast<int>(INCY));
 }
+/// The unconjugated complex dot product $x \cdot y$. See `zdotc_` for the
+/// conjugated complex dot product, which is the standard dot product on the
+/// vector space of complex numbers.
+inline std::complex<double> zdotu_(const size_t& N,
+                                   const std::complex<double>* X,
+                                   const size_t& INCX,
+                                   const std::complex<double>* Y,
+                                   const size_t& INCY) {
+  // The complex result of the BLAS zdot* functions is sometimes returned by
+  // value and sometimes returned by reference, depending on the Fortran
+  // compiler settings. By using the cblas interface we ensure a consistent
+  // behavior.
+  std::complex<double> result;
+  cblas_zdotu_sub(gsl::narrow_cast<int>(N), X, gsl::narrow_cast<int>(INCX), Y,
+                  gsl::narrow_cast<int>(INCY), &result);
+  return result;
+}
+/// The conjugated complex dot product $\bar{x} \cdot y$. This is the standard
+/// dot product on the vector space of complex numbers.
+inline std::complex<double> zdotc_(const size_t& N,
+                                   const std::complex<double>* X,
+                                   const size_t& INCX,
+                                   const std::complex<double>* Y,
+                                   const size_t& INCY) {
+  std::complex<double> result;
+  cblas_zdotc_sub(gsl::narrow_cast<int>(N), X, gsl::narrow_cast<int>(INCX), Y,
+                  gsl::narrow_cast<int>(INCY), &result);
+  return result;
+}
+/// @}
 
 /// @{
 /*!

--- a/src/Utilities/TypeTraits/GetFundamentalType.hpp
+++ b/src/Utilities/TypeTraits/GetFundamentalType.hpp
@@ -3,11 +3,13 @@
 
 #pragma once
 
+#include <complex>
 #include <type_traits>
 
 #include "Utilities/NoSuchType.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TypeTraits/CreateHasTypeAlias.hpp"
+#include "Utilities/TypeTraits/IsComplexOfFundamental.hpp"
 
 namespace tt {
 namespace detail {
@@ -52,4 +54,34 @@ struct get_fundamental_type<T, Requires<detail::has_value_type_v<T> and
 template <typename T>
 using get_fundamental_type_t = typename get_fundamental_type<T>::type;
 /// @}
+
+template <typename T, typename = std::nullptr_t>
+struct get_complex_or_fundamental_type {
+  using type =
+      std::conditional_t<tt::is_complex_or_fundamental_v<T>, T, NoSuchType>;
+};
+
+/// \cond
+// Specialization for Blaze expressions
+template <typename T>
+struct get_complex_or_fundamental_type<T,
+                                       Requires<detail::has_ElementType_v<T>>> {
+  using type =
+      typename get_complex_or_fundamental_type<typename T::ElementType>::type;
+};
+// Specialization for containers
+template <typename T>
+struct get_complex_or_fundamental_type<
+    T, Requires<detail::has_value_type_v<T> and
+                not detail::has_ElementType_v<T> and
+                not tt::is_complex_or_fundamental_v<T>>> {
+  using type =
+      typename get_complex_or_fundamental_type<typename T::value_type>::type;
+};
+/// \endcond
+
+template <typename T>
+using get_complex_or_fundamental_type_t =
+    typename get_complex_or_fundamental_type<T>::type;
+
 }  // namespace tt

--- a/tests/Unit/DataStructures/Test_BlazeInteroperability.cpp
+++ b/tests/Unit/DataStructures/Test_BlazeInteroperability.cpp
@@ -55,6 +55,28 @@ SPECTRE_TEST_CASE("Unit.DataStructures.BlazeInteroperability",
     CHECK(v.size() == 3);
   }
   {
+    INFO("Complex DynamicVector");
+    using namespace std::complex_literals;
+    test_serialization(blaze::DynamicVector<std::complex<double>>{
+        0. + 1.i, 1. + 2.i, 0. - 1.i, 2. + 3.i});
+    CHECK(make_with_value<blaze::DynamicVector<std::complex<double>>>(
+              blaze::DynamicVector<std::complex<double>>(3), 1.) ==
+          blaze::DynamicVector<std::complex<double>>(3, 1.));
+    CHECK(
+        TestHelpers::test_creation<blaze::DynamicVector<std::complex<double>>>(
+            "[[0., 1.], [1., 2.], [0., -1.], [2., 3.]]") ==
+        blaze::DynamicVector<std::complex<double>>{0. + 1.i, 1. + 2.i, 0. - 1.i,
+                                                   2. + 3.i});
+
+    blaze::DynamicVector<std::complex<double>> v{0. + 1.i, 1. + 2.i, 0. - 1.i,
+                                                 2. + 3.i};
+    set_number_of_grid_points(make_not_null(&v), 4_st);
+    CHECK(v == blaze::DynamicVector<std::complex<double>>{0. + 1.i, 1. + 2.i,
+                                                          0. - 1.i, 2. + 3.i});
+    set_number_of_grid_points(make_not_null(&v), 3_st);
+    CHECK(v.size() == 3);
+  }
+  {
     INFO("CompressedVector");
     test_serialization(blaze::CompressedVector<double>{0., 1., 0., 2.});
     CHECK(serialize_and_deserialize(
@@ -106,6 +128,34 @@ SPECTRE_TEST_CASE("Unit.DataStructures.BlazeInteroperability",
                                                             {3., 0., 4.}};
     write_csv(ss, matrix);
     CHECK(ss.str() == "0,1,2\n3,0,4\n");
+  }
+  {
+    INFO("Complex DynamicMatrix");
+    using namespace std::complex_literals;
+    test_serialization(
+        blaze::DynamicMatrix<std::complex<double>, blaze::columnMajor>{
+            {0. + 1.i, 1. + 3.i, 2. + 2.i}, {3. + 4.i, 0. - 1.i, 4. + 5.i}});
+    test_serialization(
+        blaze::DynamicMatrix<std::complex<double>, blaze::rowMajor>{
+            {0. + 1.i, 1. + 3.i, 2. + 2.i}, {3. + 4.i, 0. - 1.i, 4. + 5.i}});
+    CHECK(TestHelpers::test_creation<
+              blaze::DynamicMatrix<std::complex<double>, blaze::columnMajor>>(
+              "[[[0., 1.], [1., 3.], [2., 2.]], [[3., 4.], [0., -1.], [4., "
+              "5.]]]") ==
+          blaze::DynamicMatrix<std::complex<double>, blaze::columnMajor>{
+              {0. + 1.i, 1. + 3.i, 2. + 2.i}, {3. + 4.i, 0. - 1.i, 4. + 5.i}});
+    CHECK(TestHelpers::test_creation<
+              blaze::DynamicMatrix<std::complex<double>, blaze::rowMajor>>(
+              "[[[0., 1.], [1., 3.], [2., 2]], [[3., 4.], [0., -1.], [4., "
+              "5.]]]") ==
+          blaze::DynamicMatrix<std::complex<double>, blaze::rowMajor>{
+              {0. + 1.i, 1. + 3.i, 2. + 2.i}, {3. + 4.i, 0. - 1.i, 4. + 5.i}});
+    // Test `write_csv`
+    std::stringstream ss{};
+    blaze::DynamicMatrix<std::complex<double>, blaze::columnMajor> matrix{
+        {{0. + 1.i, 1. + 3.i, 2. + 2.i}, {3. + 4.i, 0. - 1.i, 4. + 5.i}}};
+    write_csv(ss, matrix);
+    CHECK(ss.str() == "(0,1),(1,3),(2,2)\n(3,4),(0,-1),(4,5)\n");
   }
   {
     INFO("CompressedMatrix");

--- a/tests/Unit/Elliptic/SubdomainPreconditioners/Test_MinusLaplacian.cpp
+++ b/tests/Unit/Elliptic/SubdomainPreconditioners/Test_MinusLaplacian.cpp
@@ -433,11 +433,10 @@ SPECTRE_TEST_CASE("Unit.Elliptic.SubdomainPreconditioners.MinusLaplacian",
     const auto& minus_laplacian =
         dynamic_cast<const MinusLaplacian<Dim, OptionsGroup>&>(*cloned);
     const auto& solver = minus_laplacian.solver();
-    REQUIRE(
-        dynamic_cast<
-            const LinearSolver::Serial::ExplicitInverse<typename MinusLaplacian<
-                Dim, OptionsGroup>::solver_type::registrars>*>(&solver) !=
-        nullptr);
+    REQUIRE(dynamic_cast<const LinearSolver::Serial::ExplicitInverse<
+                double, typename MinusLaplacian<
+                            Dim, OptionsGroup>::solver_type::registrars>*>(
+                &solver) != nullptr);
   }
   {
     INFO("Resetting");

--- a/tests/Unit/NumericalAlgorithms/LinearSolver/Test_BuildMatrix.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearSolver/Test_BuildMatrix.cpp
@@ -42,7 +42,7 @@ SPECTRE_TEST_CASE("Unit.LinearSolver.Serial.BuildMatrix",
   {
     INFO("Build a simple dense matrix");
     const blaze::DynamicMatrix<double> matrix{{4., 1.}, {3., 1.}};
-    const helpers::ApplyMatrix linear_operator{matrix};
+    const helpers::ApplyMatrix<double> linear_operator{matrix};
     blaze::DynamicMatrix<double> matrix_representation(2, 2);
     blaze::DynamicVector<double> operand_buffer(2, 0.);
     blaze::DynamicVector<double> result_buffer(2, 0.);

--- a/tests/Unit/NumericalAlgorithms/LinearSolver/Test_BuildMatrix.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearSolver/Test_BuildMatrix.cpp
@@ -53,6 +53,21 @@ SPECTRE_TEST_CASE("Unit.LinearSolver.Serial.BuildMatrix",
     CHECK(linear_operator.invocations == 2);
   }
   {
+    INFO("Build a complex dense matrix");
+    const blaze::DynamicMatrix<std::complex<double>> matrix{
+        {std::complex(4., 2.), std::complex(1., -1.)},
+        {std::complex(3., 0.), std::complex(1., 3.)}};
+    const helpers::ApplyMatrix<std::complex<double>> linear_operator{matrix};
+    blaze::DynamicMatrix<std::complex<double>> matrix_representation(2, 2);
+    blaze::DynamicVector<std::complex<double>> operand_buffer(2, 0.);
+    blaze::DynamicVector<std::complex<double>> result_buffer(2, 0.);
+    build_matrix(make_not_null(&matrix_representation),
+                 make_not_null(&operand_buffer), make_not_null(&result_buffer),
+                 linear_operator);
+    CHECK_ITERABLE_APPROX(matrix_representation, matrix);
+    CHECK(linear_operator.invocations == 2);
+  }
+  {
     INFO("Build a simple sparse matrix");
     const blaze::StaticMatrix<double, 2, 2> matrix{{4., 0.}, {3., 0.}};
     size_t operator_invocations = 0;

--- a/tests/Unit/NumericalAlgorithms/LinearSolver/Test_ExplicitInverse.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearSolver/Test_ExplicitInverse.cpp
@@ -38,7 +38,7 @@ SPECTRE_TEST_CASE("Unit.LinearSolver.Serial.ExplicitInverse",
   {
     INFO("Solve a simple matrix");
     const blaze::DynamicMatrix<double> matrix{{4., 1.}, {3., 1.}};
-    const helpers::ApplyMatrix linear_operator{matrix};
+    const helpers::ApplyMatrix<double> linear_operator{matrix};
     const blaze::DynamicVector<double> source{1., 2.};
     const blaze::DynamicVector<double> expected_solution{-1., 5.};
     blaze::DynamicVector<double> solution(2);
@@ -59,7 +59,7 @@ SPECTRE_TEST_CASE("Unit.LinearSolver.Serial.ExplicitInverse",
       // Solving a different operator after resetting should work
       resetting_solver.reset();
       const blaze::DynamicMatrix<double> matrix2{{4., 1.}, {1., 3.}};
-      const helpers::ApplyMatrix linear_operator2{matrix2};
+      const helpers::ApplyMatrix<double> linear_operator2{matrix2};
       const blaze::DynamicVector<double> expected_solution2{0.0909090909090909,
                                                             0.6363636363636364};
       resetting_solver.solve(make_not_null(&solution), linear_operator2,

--- a/tests/Unit/NumericalAlgorithms/LinearSolver/Test_InnerProduct.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearSolver/Test_InnerProduct.cpp
@@ -5,33 +5,53 @@
 
 #include <blaze/math/DynamicVector.h>
 
+#include "DataStructures/ComplexDataVector.hpp"
 #include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Variables.hpp"
 #include "NumericalAlgorithms/LinearSolver/InnerProduct.hpp"
 #include "Utilities/TMPL.hpp"
 
-class DataVector;
-
 namespace {
 
+template <typename DataType>
 struct ScalarFieldTag : db::SimpleTag {
-  using type = Scalar<DataVector>;
+  using type = Scalar<DataType>;
 };
 
+template <typename DataType>
 struct AnotherScalarFieldTag : db::SimpleTag {
-  using type = Scalar<DataVector>;
+  using type = Scalar<DataType>;
 };
 
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.LinearSolver.InnerProduct",
                   "[Unit][NumericalAlgorithms][LinearSolver]") {
-  const blaze::DynamicVector<double> lhs{1., 0., 2.};
-  const blaze::DynamicVector<double> rhs{1.5, 1., 3.};
-  CHECK(LinearSolver::inner_product(lhs, rhs) == dot(lhs, rhs));
-
-  const Variables<tmpl::list<ScalarFieldTag>> vars{3, 1.};
-  const Variables<tmpl::list<AnotherScalarFieldTag>> other_vars{3, 2.};
-  CHECK(LinearSolver::inner_product(vars, other_vars) == 6.);
+  {
+    INFO("Blaze vector");
+    const blaze::DynamicVector<double> lhs{1., 0., 2.};
+    const blaze::DynamicVector<double> rhs{1.5, 1., 3.};
+    CHECK(LinearSolver::inner_product(lhs, rhs) == dot(lhs, rhs));
+    CHECK(LinearSolver::magnitude_square(lhs) == 5.);
+  }
+  {
+    INFO("Variables");
+    const Variables<tmpl::list<ScalarFieldTag<DataVector>>> vars{3, 1.};
+    const Variables<tmpl::list<AnotherScalarFieldTag<DataVector>>> other_vars{
+        3, 2.};
+    CHECK(LinearSolver::inner_product(vars, other_vars) == 6.);
+    CHECK(LinearSolver::magnitude_square(vars) == 3.);
+  }
+  {
+    INFO("Complex Variables");
+    const Variables<tmpl::list<ScalarFieldTag<ComplexDataVector>>> vars{
+        3, std::complex<double>(1., 2.)};
+    const Variables<tmpl::list<AnotherScalarFieldTag<ComplexDataVector>>>
+        other_vars{3, std::complex<double>(2., 3.)};
+    CHECK(LinearSolver::inner_product(vars, other_vars) ==
+          std::complex<double>(24., -3.));
+    CHECK(LinearSolver::magnitude_square(vars) == 15.);
+  }
 }

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/ConjugateGradient/Test_ConjugateGradientAlgorithm.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/ConjugateGradient/Test_ConjugateGradientAlgorithm.cpp
@@ -25,9 +25,8 @@ struct Metavariables {
   static constexpr const char* const help{
       "Test the conjugate gradient linear solver algorithm"};
 
-  using linear_solver =
-      LinearSolver::cg::ConjugateGradient<Metavariables, helpers::fields_tag,
-                                          SerialCg>;
+  using linear_solver = LinearSolver::cg::ConjugateGradient<
+      Metavariables, helpers::fields_tag<double>, SerialCg>;
   using preconditioner = void;
 
   using component_list = helpers::component_list<Metavariables>;

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/CMakeLists.txt
@@ -29,6 +29,13 @@ target_link_libraries(
   PRIVATE
   "${INTEGRATION_TEST_LINK_LIBRARIES}")
 add_standalone_test(
+  "Integration.LinearSolver.ComplexGmresAlgorithm"
+  INPUT_FILE "Test_ComplexGmresAlgorithm.yaml")
+target_link_libraries(
+  "Test_ComplexGmresAlgorithm"
+  PRIVATE
+  "${INTEGRATION_TEST_LINK_LIBRARIES}")
+add_standalone_test(
   "Integration.LinearSolver.GmresPreconditionedAlgorithm"
   INPUT_FILE "Test_GmresPreconditionedAlgorithm.yaml")
 target_link_libraries(

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/Test_ComplexGmresAlgorithm.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/Test_ComplexGmresAlgorithm.cpp
@@ -6,7 +6,6 @@
 #include "Helpers/ParallelAlgorithms/LinearSolver/LinearSolverAlgorithmTestHelpers.hpp"
 #include "Parallel/CharmMain.tpp"
 #include "ParallelAlgorithms/LinearSolver/Gmres/Gmres.hpp"
-#include "ParallelAlgorithms/LinearSolver/Richardson/Richardson.hpp"
 #include "Utilities/TMPL.hpp"
 
 namespace PUP {
@@ -22,20 +21,15 @@ struct SerialGmres {
       "Options for the iterative linear solver";
 };
 
-struct Preconditioner {
-  static constexpr Options::String help = "Options for the preconditioner";
-};
-
 struct Metavariables {
   static constexpr const char* const help{
-      "Test the preconditioned GMRES linear solver algorithm"};
+      "Test the GMRES linear solver algorithm"};
 
   using linear_solver =
-      LinearSolver::gmres::Gmres<Metavariables, helpers::fields_tag<double>,
-                                 SerialGmres, true>;
-  using preconditioner = LinearSolver::Richardson::Richardson<
-      typename linear_solver::operand_tag, Preconditioner,
-      typename linear_solver::preconditioner_source_tag>;
+      LinearSolver::gmres::Gmres<Metavariables,
+                                 helpers::fields_tag<std::complex<double>>,
+                                 SerialGmres, false>;
+  using preconditioner = void;
 
   using component_list = helpers::component_list<Metavariables>;
   using observed_reduction_data_tags =

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/Test_ComplexGmresAlgorithm.yaml
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/Test_ComplexGmresAlgorithm.yaml
@@ -1,0 +1,29 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+---
+---
+
+LinearOperator:
+  - [[1, 2], [2, -1]]
+  - [[3, 4], [4, 1]]
+Source: [[1, 1], [2, -3]]
+InitialGuess: [[0, 0], [0, 0]]
+ExpectedResult: [[0.45, -1.4], [-1.2, 0.15]]
+
+Observers:
+  VolumeFileName: "Test_ComplexGmresAlgorithm_Volume"
+  ReductionFileName: "Test_ComplexGmresAlgorithm_Reductions"
+
+SerialGmres:
+  ConvergenceCriteria:
+    MaxIterations: 2
+    AbsoluteResidual: 1e-14
+    RelativeResidual: 0
+  Verbosity: Verbose
+
+ConvergenceReason: AbsoluteResidual
+
+ResourceInfo:
+  AvoidGlobalProc0: false
+  Singletons: Auto

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/Test_ElementActions.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/Test_ElementActions.cpp
@@ -206,9 +206,9 @@ void test_element_actions() {
         REQUIRE_FALSE(ActionTesting::next_action_if_ready<element_array>(
             make_not_null(&runner), 0));
         auto& inbox = ActionTesting::get_inbox_tag<
-            element_array, LinearSolver::gmres::detail::Tags::
-                               FinalOrthogonalization<DummyOptionsGroup>>(
-            make_not_null(&runner), 0);
+            element_array,
+            LinearSolver::gmres::detail::Tags::FinalOrthogonalization<
+                DummyOptionsGroup, double>>(make_not_null(&runner), 0);
         const double normalization = 4.;
         const blaze::DynamicVector<double> minres{2., 4.};
         CAPTURE(has_converged);

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/Test_GmresAlgorithm.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/Test_GmresAlgorithm.cpp
@@ -26,7 +26,7 @@ struct Metavariables {
       "Test the GMRES linear solver algorithm"};
 
   using linear_solver =
-      LinearSolver::gmres::Gmres<Metavariables, helpers::fields_tag,
+      LinearSolver::gmres::Gmres<Metavariables, helpers::fields_tag<double>,
                                  SerialGmres, false>;
   using preconditioner = void;
 

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/Test_ResidualMonitorActions.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/Test_ResidualMonitorActions.cpp
@@ -79,12 +79,13 @@ struct MockElementArray {
   using array_index = int;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<Parallel::Phase::Initialization, tmpl::list<>>>;
-  using inbox_tags = tmpl::list<
-      LinearSolver::gmres::detail::Tags::InitialOrthogonalization<
-          TestLinearSolver>,
-      LinearSolver::gmres::detail::Tags::Orthogonalization<TestLinearSolver>,
-      LinearSolver::gmres::detail::Tags::FinalOrthogonalization<
-          TestLinearSolver>>;
+  using inbox_tags =
+      tmpl::list<LinearSolver::gmres::detail::Tags::InitialOrthogonalization<
+                     TestLinearSolver>,
+                 LinearSolver::gmres::detail::Tags::Orthogonalization<
+                     TestLinearSolver, double>,
+                 LinearSolver::gmres::detail::Tags::FinalOrthogonalization<
+                     TestLinearSolver, double>>;
 };
 
 struct Metavariables {
@@ -206,7 +207,7 @@ SPECTRE_TEST_CASE(
     // Test element state
     CHECK(get_element_inbox_tag(
               LinearSolver::gmres::detail::Tags::Orthogonalization<
-                  TestLinearSolver>{})
+                  TestLinearSolver, double>{})
               .at(1) == 2.);
   }
 
@@ -239,7 +240,7 @@ SPECTRE_TEST_CASE(
     const auto& element_inbox =
         get_element_inbox_tag(
             LinearSolver::gmres::detail::Tags::FinalOrthogonalization<
-                TestLinearSolver>{})
+                TestLinearSolver, double>{})
             .at(1);
     // beta = [2., 0.]
     // minres = inv(qr_R(H)) * trans(qr_Q(H)) * beta = [0.4615384615384615]
@@ -286,7 +287,7 @@ SPECTRE_TEST_CASE(
     const auto& element_inbox =
         get_element_inbox_tag(
             LinearSolver::gmres::detail::Tags::FinalOrthogonalization<
-                TestLinearSolver>{})
+                TestLinearSolver, double>{})
             .at(1);
     // beta = [2., 0.]
     // minres = inv(qr_R(H)) * trans(qr_Q(H)) * beta = [2.]
@@ -335,7 +336,7 @@ SPECTRE_TEST_CASE(
     const auto& element_inbox =
         get_element_inbox_tag(
             LinearSolver::gmres::detail::Tags::FinalOrthogonalization<
-                TestLinearSolver>{})
+                TestLinearSolver, double>{})
             .at(2);
     // beta = [1., 0., 0.]
     // minres = inv(qr_R(H)) * trans(qr_Q(H)) * beta = [0.13178295, 0.03100775]
@@ -373,7 +374,7 @@ SPECTRE_TEST_CASE(
     const auto& element_inbox =
         get_element_inbox_tag(
             LinearSolver::gmres::detail::Tags::FinalOrthogonalization<
-                TestLinearSolver>{})
+                TestLinearSolver, double>{})
             .at(1);
     // beta = [2., 0.]
     // minres = inv(qr_R(H)) * trans(qr_Q(H)) * beta = [0.6]
@@ -411,7 +412,7 @@ SPECTRE_TEST_CASE(
     const auto& element_inbox =
         get_element_inbox_tag(
             LinearSolver::gmres::detail::Tags::FinalOrthogonalization<
-                TestLinearSolver>{})
+                TestLinearSolver, double>{})
             .at(1);
     const auto& minres = get<1>(element_inbox);
     CHECK(minres.size() == 1);

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Richardson/Test_RichardsonAlgorithm.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Richardson/Test_RichardsonAlgorithm.cpp
@@ -26,7 +26,7 @@ struct Metavariables {
       "Test the Richardson linear solver algorithm"};
 
   using linear_solver =
-      LinearSolver::Richardson::Richardson<helpers::fields_tag,
+      LinearSolver::Richardson::Richardson<helpers::fields_tag<double>,
                                            SerialRichardson>;
   using preconditioner = void;
 

--- a/tests/Unit/Utilities/TypeTraits/Test_GetFundamentalType.cpp
+++ b/tests/Unit/Utilities/TypeTraits/Test_GetFundamentalType.cpp
@@ -15,9 +15,23 @@ static_assert(
     "Failed testing get_fundamental_type");
 static_assert(
     std::is_same_v<
-        typename tt::get_fundamental_type_t<std::vector<std::complex<int>>>,
-        int>,
+        typename tt::get_fundamental_type_t<std::vector<std::complex<double>>>,
+        double>,
     "Failed testing get_fundamental_type");
 static_assert(std::is_same_v<typename tt::get_fundamental_type_t<int>, int>,
               "Failed testing get_fundamental_type");
 // [get_fundamental_type]
+
+static_assert(
+    std::is_same_v<
+        typename tt::get_complex_or_fundamental_type_t<std::array<double, 2>>,
+        double>);
+static_assert(std::is_same_v<typename tt::get_complex_or_fundamental_type_t<
+                                 std::vector<std::complex<double>>>,
+                             std::complex<double>>);
+static_assert(
+    std::is_same_v<typename tt::get_complex_or_fundamental_type_t<int>, int>);
+static_assert(
+    std::is_same_v<
+        typename tt::get_complex_or_fundamental_type_t<std::complex<double>>,
+        std::complex<double>>);


### PR DESCRIPTION
## Proposed changes

Adds complex numbers support to the serial linear solvers, which are used as preconditioners in the parallel linear solvers. Most notably, extends the GMRES algorithm to complex arithmetics, which involves the inner product on the vector space of complex numbers.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
