### PR TITLE
Control BBH masses and spins in initial data

### DIFF
--- a/support/Pipelines/Bbh/CMakeLists.txt
+++ b/support/Pipelines/Bbh/CMakeLists.txt
@@ -6,6 +6,7 @@ spectre_python_add_module(
   MODULE_PATH Pipelines
   PYTHON_FILES
   __init__.py
+  ControlId.py
   FindHorizon.py
   InitialData.py
   InitialData.yaml

--- a/support/Pipelines/Bbh/ControlId.py
+++ b/support/Pipelines/Bbh/ControlId.py
@@ -1,0 +1,190 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import logging
+from pathlib import Path
+from typing import Optional, Union
+
+import h5py
+import numpy as np
+import yaml
+
+import spectre.IO.H5 as spectre_h5
+from spectre.Pipelines.Bbh.InitialData import generate_id
+from spectre.Visualization.ReadH5 import to_dataframe
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_RESIDUAL_TOLERANCE = 1.0e-6
+DEFAULT_MAX_ITERATIONS = 30
+
+
+def control_id(
+    id_input_file_path: Union[str, Path],
+    id_run_dir: Optional[Union[str, Path]] = None,
+    residual_tolerance: float = DEFAULT_RESIDUAL_TOLERANCE,
+    max_iterations: int = DEFAULT_MAX_ITERATIONS,
+):
+    """Control BBH physical parameters.
+
+    This function is called after initial data has been generated and horizons
+    have been found in 'PostprocessId.py'. It uses an iterative scheme to drive
+    the black hole physical parameters (masses and spins) closer to the desired
+    values.
+
+    For each iteration, this function does the following:
+
+    - Determine new guesses for ID input parameters.
+
+    - Generate initial data using these guesses.
+
+    - Find horizons in the generated initial data.
+
+    - Measure the difference between the horizon quantities and the desired
+      values.
+
+    Arguments:
+      id_input_file_path: Path to the input file of the first initial data run.
+      id_run_dir: Directory of the first initial data run. If not provided, the
+        directory of the input file is used.
+      residual_tolerance: Residual tolerance used for termination condition.
+        (Default: 1.e-6)
+      max_iterations: Maximum of iterations allowed. Note: each iteration is
+        very expensive as it needs to solve an entire initial data problem.
+        (Default: 30)
+    """
+
+    # Read input file
+    if id_run_dir is None:
+        id_run_dir = Path(id_input_file_path).resolve().parent
+    with open(id_input_file_path, "r") as open_input_file:
+        _, id_input_file = yaml.safe_load_all(open_input_file)
+    binary_data = id_input_file["Background"]["Binary"]
+    M_target_A = binary_data["ObjectRight"]["KerrSchild"]["Mass"]
+    M_target_B = binary_data["ObjectLeft"]["KerrSchild"]["Mass"]
+    chi_target_A = binary_data["ObjectRight"]["KerrSchild"]["Spin"]
+    chi_target_B = binary_data["ObjectLeft"]["KerrSchild"]["Spin"]
+    x_B, x_A = binary_data["XCoords"]
+    separation = x_A - x_B
+    orbital_angular_velocity = binary_data["AngularVelocity"]
+    radial_expansion_velocity = binary_data["Expansion"]
+
+    # File to write control diagnostic data
+    data_file = open(f"{id_run_dir}/ControlParamsData.txt", "w")
+
+    iteration = 0
+    control_run_dir = id_run_dir
+
+    # Function to be minimized
+    def Residual(
+        M_Kerr_A: float,
+        M_Kerr_B: float,
+        chi_Kerr_A_x: float,
+        chi_Kerr_A_y: float,
+        chi_Kerr_A_z: float,
+        chi_Kerr_B_x: float,
+        chi_Kerr_B_y: float,
+        chi_Kerr_B_z: float,
+    ):
+        nonlocal iteration
+        nonlocal control_run_dir
+
+        if iteration > 0:
+            logger.info(
+                "\n"
+                "=========================================="
+                f" Control of BBH Parameters ({iteration}) "
+                "=========================================="
+            )
+            control_run_dir = f"{id_run_dir}/ControlParams{iteration:02}"
+
+            # Run ID and find horizons
+            generate_id(
+                mass_a=M_Kerr_A,
+                mass_b=M_Kerr_B,
+                dimensionless_spin_a=[chi_Kerr_A_x, chi_Kerr_A_y, chi_Kerr_A_z],
+                dimensionless_spin_b=[chi_Kerr_B_x, chi_Kerr_B_y, chi_Kerr_B_z],
+                separation=separation,
+                orbital_angular_velocity=orbital_angular_velocity,
+                radial_expansion_velocity=radial_expansion_velocity,
+                run_dir=control_run_dir,
+                control=False,
+                evolve=False,
+                scheduler=None,
+            )
+
+        # Get black hole physical parameters
+        with spectre_h5.H5File(
+            f"{control_run_dir}/Horizons.h5", "r"
+        ) as horizons_file:
+            AhA_quantities = to_dataframe(
+                horizons_file.get_dat("AhA.dat")
+            ).iloc[-1]
+
+            M_A = AhA_quantities["ChristodoulouMass"]
+            chi_A_x = AhA_quantities["DimensionlessSpinVector_x"]
+            chi_A_y = AhA_quantities["DimensionlessSpinVector_y"]
+            chi_A_z = AhA_quantities["DimensionlessSpinVector_z"]
+
+            horizons_file.close_current_object()
+            AhB_quantities = to_dataframe(
+                horizons_file.get_dat("AhB.dat")
+            ).iloc[-1]
+
+            M_B = AhB_quantities["ChristodoulouMass"]
+            chi_B_x = AhB_quantities["DimensionlessSpinVector_x"]
+            chi_B_y = AhB_quantities["DimensionlessSpinVector_y"]
+            chi_B_z = AhB_quantities["DimensionlessSpinVector_z"]
+
+        residual = np.array(
+            [
+                M_A - M_target_A,
+                M_B - M_target_B,
+                chi_A_x - chi_target_A[0],
+                chi_A_y - chi_target_A[1],
+                chi_A_z - chi_target_A[2],
+                chi_B_x - chi_target_B[0],
+                chi_B_y - chi_target_B[1],
+                chi_B_z - chi_target_B[2],
+            ]
+        )
+        logger.info(f"Control Residual = {np.max(np.abs(residual)):e}")
+
+        data_file.write(
+            f" {iteration},"
+            f" {M_A}, {M_B},"
+            f" {chi_A_x}, {chi_A_y}, {chi_A_z},"
+            f" {chi_B_x}, {chi_B_y}, {chi_B_z},"
+            f" {residual[0]}, {residual[1]},"
+            f" {residual[2]}, {residual[3]}, {residual[4]},"
+            f" {residual[5]}, {residual[6]}, {residual[7]}"
+            " \n"
+        )
+        data_file.flush()
+
+        return residual
+
+    # Initial guess
+    u = np.array([M_target_A, M_target_B, *chi_target_A, *chi_target_B])
+
+    # Initial residual
+    F = Residual(*u)
+
+    # Initial Jacobian (identity matrix)
+    J = np.identity(len(u))
+
+    while iteration < max_iterations and np.max(np.abs(F)) > residual_tolerance:
+        iteration += 1
+
+        # Update the free parameters using a quasi-Newton-Raphson method
+        Delta_u = -np.dot(np.linalg.inv(J), F)
+        u += Delta_u
+
+        F = Residual(*u)
+
+        # Update the Jacobian using Broyden's method
+        J += np.outer(F, Delta_u) / np.dot(Delta_u, Delta_u)
+
+    data_file.close()
+
+    return control_run_dir

--- a/support/Pipelines/Bbh/InitialData.yaml
+++ b/support/Pipelines/Bbh/InitialData.yaml
@@ -11,6 +11,7 @@ Next:
     id_input_file_path: __file__
     id_run_dir: ./
     pipeline_dir: {{ pipeline_dir | default("None") }}
+    control: {{ control }}
     evolve: {{ evolve }}
     scheduler: {{ scheduler | default("None") }}
     copy_executable: {{ copy_executable | default("None") }}

--- a/support/Pipelines/Bbh/PostprocessId.py
+++ b/support/Pipelines/Bbh/PostprocessId.py
@@ -9,6 +9,11 @@ from typing import Optional, Union
 import click
 import yaml
 
+from spectre.Pipelines.Bbh.ControlId import (
+    DEFAULT_MAX_ITERATIONS,
+    DEFAULT_RESIDUAL_TOLERANCE,
+    control_id,
+)
 from spectre.Pipelines.Bbh.FindHorizon import find_horizon, vec_to_string
 from spectre.SphericalHarmonics import Strahlkorper
 from spectre.support.Schedule import schedule, scheduler_options
@@ -24,6 +29,9 @@ def postprocess_id(
     id_run_dir: Optional[Union[str, Path]] = None,
     horizon_l_max: int = 12,
     horizons_file: Optional[Union[str, Path]] = None,
+    control: bool = True,
+    control_residual_tolerance: float = DEFAULT_RESIDUAL_TOLERANCE,
+    control_max_iterations: int = DEFAULT_MAX_ITERATIONS,
     evolve: bool = False,
     pipeline_dir: Optional[Union[str, Path]] = None,
     **scheduler_kwargs,
@@ -44,6 +52,10 @@ def postprocess_id(
       surface coordinates and coefficients are written to the 'horizons_file' in
       subfiles 'Ah{A,B}/Coordinates' and 'Ah{A,B}/Coefficients'.
 
+    - If 'control' is set to True, run a control loop such that masses and
+      spins of the horizons match the input parameters. See ControlId.py for
+      details.
+
     - Start the inspiral if 'evolve' is set to True.
 
     Arguments:
@@ -54,6 +66,9 @@ def postprocess_id(
       horizon_l_max: Maximum l-mode for the horizon search.
       horizons_file: Path to the file where the horizon data is written to.
         Default is 'Horizons.h5' in the 'id_run_dir'.
+      control: Control BBH physical parameters (default: False).
+      control_residual_tolerance: Residual tolerance used for control.
+      control_max_iterations: Maximum of iterations allowed for control.
       evolve: Evolve the initial data after postprocessing (default: False).
       pipeline_dir: Directory where steps in the pipeline are created.
         Required if 'evolve' is set to True.
@@ -105,6 +120,16 @@ def postprocess_id(
         )
     logger.info(f"Horizons found and written to {horizons_file}.")
 
+    if control:
+        last_control_run_dir = control_id(
+            id_input_file_path,
+            id_run_dir=id_run_dir,
+            residual_tolerance=control_residual_tolerance,
+            max_iterations=control_max_iterations,
+        )
+        id_run_dir = last_control_run_dir
+        id_input_file_path = f"{last_control_run_dir}/InitialData.yaml"
+
     # Start the inspiral from the ID if requested
     if evolve:
         from spectre.Pipelines.Bbh.Inspiral import start_inspiral
@@ -144,6 +169,12 @@ def postprocess_id(
         " relative to this directory."
     ),
     show_default="directory of the ID_INPUT_FILE_PATH",
+)
+@click.option(
+    "--control",
+    default=True,
+    show_default=True,
+    help="Control BBH physical parameters during postprocessing.",
 )
 @click.option(
     "--evolve",

--- a/tests/support/Pipelines/Bbh/Test_InitialData.py
+++ b/tests/support/Pipelines/Bbh/Test_InitialData.py
@@ -28,7 +28,8 @@ class TestInitialData(unittest.TestCase):
 
     def test_generate_id(self):
         params = id_parameters(
-            mass_ratio=1.5,
+            mass_a=0.6,
+            mass_b=0.4,
             dimensionless_spin_a=[0.1, 0.2, 0.3],
             dimensionless_spin_b=[0.4, 0.5, 0.6],
             separation=20.0,
@@ -98,6 +99,7 @@ class TestInitialData(unittest.TestCase):
             "5",
             "-E",
             str(self.bin_dir / "SolveXcts"),
+            "--no-schedule",
         ]
         # Not using `CliRunner.invoke()` because it runs in an isolated
         # environment and doesn't work with MPI in the container.
@@ -138,6 +140,7 @@ class TestInitialData(unittest.TestCase):
                     "id_input_file_path": "__file__",
                     "id_run_dir": "./",
                     "pipeline_dir": str(self.test_dir.resolve() / "Pipeline"),
+                    "control": True,
                     "evolve": True,
                     "scheduler": "None",
                     "copy_executable": "None",

--- a/tests/support/Pipelines/Bbh/Test_Inspiral.py
+++ b/tests/support/Pipelines/Bbh/Test_Inspiral.py
@@ -27,7 +27,8 @@ class TestInspiral(unittest.TestCase):
         self.test_dir.mkdir(parents=True, exist_ok=True)
         self.bin_dir = Path(unit_test_build_path(), "../../bin").resolve()
         generate_id(
-            mass_ratio=1.5,
+            mass_a=0.6,
+            mass_b=0.4,
             dimensionless_spin_a=[0.0, 0.0, 0.0],
             dimensionless_spin_b=[0.0, 0.0, 0.0],
             separation=20.0,
@@ -115,6 +116,9 @@ class TestInspiral(unittest.TestCase):
             str(self.horizons_filename),
             "-E",
             str(self.bin_dir / "EvolveGhBinaryBlackHole"),
+            "--no-schedule",
+            "--num-nodes",
+            "1",
         ]
         # Not using `CliRunner.invoke()` because it runs in an isolated
         # environment and doesn't work with MPI in the container.

--- a/tests/support/Pipelines/Bbh/Test_PostprocessId.py
+++ b/tests/support/Pipelines/Bbh/Test_PostprocessId.py
@@ -24,7 +24,8 @@ class TestPostprocessId(unittest.TestCase):
         self.test_dir.mkdir(parents=True, exist_ok=True)
         self.bin_dir = Path(unit_test_build_path(), "../../bin").resolve()
         generate_id(
-            mass_ratio=1.5,
+            mass_a=0.6,
+            mass_b=0.4,
             dimensionless_spin_a=[0.0, 0.0, 0.0],
             dimensionless_spin_b=[0.0, 0.0, 0.0],
             separation=20.0,

--- a/tests/support/Pipelines/Bbh/Test_Ringdown.py
+++ b/tests/support/Pipelines/Bbh/Test_Ringdown.py
@@ -28,7 +28,8 @@ class TestInitialData(unittest.TestCase):
         self.test_dir.mkdir(parents=True, exist_ok=True)
         self.bin_dir = Path(unit_test_build_path(), "../../bin").resolve()
         generate_id(
-            mass_ratio=1.5,
+            mass_a=0.6,
+            mass_b=0.4,
             dimensionless_spin_a=[0.0, 0.0, 0.0],
             dimensionless_spin_b=[0.0, 0.0, 0.0],
             separation=20.0,


### PR DESCRIPTION
## Proposed changes
<!--
At a high level, describe what this PR does.
-->
I've implemented a Newton-Raphson iterative scheme with Broyden's method that controls the BBH masses and spins during the Initial Data. This follows a similar approach to what is described in section 2.3 of [arXiv:1506.01689](https://arxiv.org/abs/1506.01689), except that here we control the Kerr masses and spins instead of the excision radii and horizon frequencies.
### Upgrade instructions
<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
If calling `generate_id` or `id_parameters` from `InitialData.py`, you now need to specify the masses `mass_a` and `mass_b` separately instead of the previous `mass_ratio`. Note that `generate_id_command` still takes in `mass_ratio` as an argument.
<!-- UPGRADE INSTRUCTIONS -->
### Code review checklist
- [x] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [x] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
### Further comments
<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->