### PR TITLE
Fix Test_DgSubcell for GCC 13.2

### DIFF
--- a/tests/Unit/Evolution/DgSubcell/Test_BackgroundGrVars.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Test_BackgroundGrVars.cpp
@@ -249,6 +249,9 @@ void test(const gsl::not_null<std::mt19937*> gen, const bool did_rollback) {
   auto box = [&block, &brick, &dg_gr_vars, &element, &element_id,
               &grid_to_inertial_map, &initial_time, &solution,
               &subcell_initial_inertial_coords, &subcell_mesh]() {
+    // Bug in GCC 13.2 where having this class created in-place below causes an
+    // internal compiler error
+    typename subcell_face_gr_variables_tag::type face_gr_vars{};
     // Since we want to test that the BackgroundGrVars action properly
     // initializes (allocate + assign) the background GR variables on
     // cell-centered and face-centered coordinates, use an empty subcell GR
@@ -276,8 +279,7 @@ void test(const gsl::not_null<std::mt19937*> gen, const bool did_rollback) {
           std::move(grid_to_inertial_map),
           clone_unique_ptrs(brick.functions_of_time()), subcell_mesh,
           subcell_initial_inertial_coords, dg_gr_vars,
-          typename inactive_gr_variables_tag::type{},
-          typename subcell_face_gr_variables_tag::type{}, false,
+          typename inactive_gr_variables_tag::type{}, face_gr_vars, false,
           solution.get_clone());
     } else {
       return db::create<db::AddSimpleTags<
@@ -301,8 +303,8 @@ void test(const gsl::not_null<std::mt19937*> gen, const bool did_rollback) {
           std::move(grid_to_inertial_map),
           clone_unique_ptrs(brick.functions_of_time()), subcell_mesh,
           subcell_initial_inertial_coords, dg_gr_vars,
-          typename inactive_gr_variables_tag::type{},
-          typename subcell_face_gr_variables_tag::type{}, false, solution);
+          typename inactive_gr_variables_tag::type{}, face_gr_vars, false,
+          solution);
     }
   }();
 


### PR DESCRIPTION
There was an internal compiler error.

## Proposed changes

Ran into this on Caltech HPC when building tests.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
