### PR TITLE
Add constraint preserving boundary condition product for ScalarTensor

### DIFF
--- a/src/Evolution/Systems/ScalarTensor/BoundaryConditions/CMakeLists.txt
+++ b/src/Evolution/Systems/ScalarTensor/BoundaryConditions/CMakeLists.txt
@@ -5,6 +5,7 @@ spectre_target_sources(
   ${LIBRARY}
   PRIVATE
   BoundaryCondition.cpp
+  ConstraintPreserving.cpp
   )
 
 spectre_target_headers(
@@ -12,6 +13,7 @@ spectre_target_headers(
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   BoundaryCondition.hpp
+  ConstraintPreserving.hpp
   Factory.hpp
   ProductOfConditions.hpp
   )

--- a/src/Evolution/Systems/ScalarTensor/BoundaryConditions/ConstraintPreserving.cpp
+++ b/src/Evolution/Systems/ScalarTensor/BoundaryConditions/ConstraintPreserving.cpp
@@ -1,0 +1,209 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/ScalarTensor/BoundaryConditions/ConstraintPreserving.hpp"
+
+#include <cstddef>
+#include <memory>
+#include <pup.h>
+
+namespace ScalarTensor::BoundaryConditions {
+ConstraintPreserving::ConstraintPreserving(
+    gh::BoundaryConditions::detail::ConstraintPreservingBjorhusType type)
+    : constraint_preserving_(type) {}
+
+// LCOV_EXCL_START
+ConstraintPreserving::ConstraintPreserving(CkMigrateMessage* const msg)
+    : BoundaryCondition(msg) {}
+// LCOV_EXCL_STOP
+
+std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
+ConstraintPreserving::get_clone() const {
+  return std::make_unique<ConstraintPreserving>(*this);
+}
+
+void ConstraintPreserving::pup(PUP::er& p) {
+  BoundaryCondition::pup(p);
+  p | constraint_preserving_;
+  p | csw_constraint_preserving_;
+}
+
+std::optional<std::string> ConstraintPreserving::dg_ghost(
+    const gsl::not_null<tnsr::aa<DataVector, 3, Frame::Inertial>*>
+        spacetime_metric,
+    const gsl::not_null<tnsr::aa<DataVector, 3, Frame::Inertial>*> pi,
+    const gsl::not_null<tnsr::iaa<DataVector, 3, Frame::Inertial>*> phi,
+
+    const gsl::not_null<Scalar<DataVector>*> psi_scalar,
+    const gsl::not_null<Scalar<DataVector>*> pi_scalar,
+    const gsl::not_null<tnsr::i<DataVector, 3, Frame::Inertial>*> phi_scalar,
+
+    // c.f. dg_package_data_temporary_tags from the combined Upwind correction
+    const gsl::not_null<Scalar<DataVector>*> gamma1,
+    const gsl::not_null<Scalar<DataVector>*> gamma2,
+    const gsl::not_null<Scalar<DataVector>*> lapse,
+    const gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> shift,
+    const gsl::not_null<Scalar<DataVector>*> gamma1_scalar,
+    const gsl::not_null<Scalar<DataVector>*> gamma2_scalar,
+
+    const gsl::not_null<tnsr::II<DataVector, 3, Frame::Inertial>*>
+        inv_spatial_metric,
+
+    const std::optional<tnsr::I<DataVector, 3, Frame::Inertial>>&
+    /*face_mesh_velocity*/,
+    const tnsr::i<DataVector, 3, Frame::Inertial>& /*normal_covector*/,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& /*normal_vector*/,
+
+    const tnsr::aa<DataVector, 3, Frame::Inertial>& interior_spacetime_metric,
+    const tnsr::aa<DataVector, 3, Frame::Inertial>& interior_pi,
+    const tnsr::iaa<DataVector, 3, Frame::Inertial>& interior_phi,
+
+    const Scalar<DataVector>& psi_scalar_interior,
+    const Scalar<DataVector>& pi_scalar_interior,
+    const tnsr::i<DataVector, 3>& phi_scalar_interior,
+
+    const tnsr::I<DataVector, 3, Frame::Inertial>& /*coords*/,
+    const Scalar<DataVector>& interior_gamma1,
+    const Scalar<DataVector>& interior_gamma2,
+    const Scalar<DataVector>& interior_lapse,
+    const tnsr::I<DataVector, 3>& interior_shift,
+    const tnsr::II<DataVector, 3>& interior_inv_spatial_metric,
+    const tnsr::AA<DataVector, 3,
+                   Frame::Inertial>& /*inverse_spacetime_metric*/,
+    const tnsr::A<DataVector, 3, Frame::Inertial>&
+    /*spacetime_unit_normal_vector*/,
+    const tnsr::iaa<DataVector, 3, Frame::Inertial>& /*three_index_constraint*/,
+    const tnsr::a<DataVector, 3, Frame::Inertial>& /*gauge_source*/,
+    const tnsr::ab<DataVector, 3, Frame::Inertial>&
+    /*spacetime_deriv_gauge_source*/,
+    const Scalar<DataVector>& interior_gamma1_scalar,
+    const Scalar<DataVector>& interior_gamma2_scalar,
+
+    // c.f. dg_interior_dt_vars_tags
+    const tnsr::aa<DataVector, 3, Frame::Inertial>&
+    /*logical_dt_spacetime_metric*/,
+    const tnsr::aa<DataVector, 3, Frame::Inertial>& /*logical_dt_pi*/,
+    const tnsr::iaa<DataVector, 3, Frame::Inertial>& /*logical_dt_phi*/,
+
+    const Scalar<DataVector>& /*logical_dt_psi_scalar*/,
+    const Scalar<DataVector>& /*logical_dt_pi_scalar*/,
+    const tnsr::i<DataVector, 3>& /*logical_dt_phi_scalar*/,
+
+    // c.f. dg_interior_deriv_vars_tags
+    const tnsr::iaa<DataVector, 3, Frame::Inertial>& /*d_spacetime_metric*/,
+    const tnsr::iaa<DataVector, 3, Frame::Inertial>& /*d_pi*/,
+    const tnsr::ijaa<DataVector, 3, Frame::Inertial>& /*d_phi*/,
+
+    const tnsr::i<DataVector, 3, Frame::Inertial>& /*d_psi_scalar*/,
+    const tnsr::i<DataVector, 3, Frame::Inertial>& /*d_pi_scalar*/,
+    const tnsr::ij<DataVector, 3, Frame::Inertial>& /*d_phi_scalar*/) {
+  // GH
+  *gamma1 = interior_gamma1;
+  *gamma2 = interior_gamma2;
+  *spacetime_metric = interior_spacetime_metric;
+  *pi = interior_pi;
+  *phi = interior_phi;
+  *lapse = interior_lapse;
+  *shift = interior_shift;
+  *inv_spatial_metric = interior_inv_spatial_metric;
+
+  // Scalar
+  *psi_scalar = psi_scalar_interior;
+  *pi_scalar = pi_scalar_interior;
+  *phi_scalar = phi_scalar_interior;
+  *gamma1_scalar = interior_gamma1_scalar;
+  *gamma2_scalar = interior_gamma2_scalar;
+
+  return {};
+}
+
+std::optional<std::string> ConstraintPreserving::dg_time_derivative(
+    const gsl::not_null<tnsr::aa<DataVector, 3, Frame::Inertial>*>
+        dt_spacetime_metric_correction,
+    const gsl::not_null<tnsr::aa<DataVector, 3, Frame::Inertial>*>
+        dt_pi_correction,
+    const gsl::not_null<tnsr::iaa<DataVector, 3, Frame::Inertial>*>
+        dt_phi_correction,
+
+    const gsl::not_null<Scalar<DataVector>*> dt_psi_scalar_correction,
+    const gsl::not_null<Scalar<DataVector>*> dt_pi_scalar_correction,
+    const gsl::not_null<tnsr::i<DataVector, 3, Frame::Inertial>*>
+        dt_phi_scalar_correction,
+
+    const std::optional<tnsr::I<DataVector, 3, Frame::Inertial>>&
+        face_mesh_velocity,
+    const tnsr::i<DataVector, 3, Frame::Inertial>& normal_covector,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& normal_vector,
+    // c.f. dg_interior_evolved_variables_tags
+    const tnsr::aa<DataVector, 3, Frame::Inertial>& spacetime_metric,
+    const tnsr::aa<DataVector, 3, Frame::Inertial>& pi,
+    const tnsr::iaa<DataVector, 3, Frame::Inertial>& phi,
+
+    const Scalar<DataVector>& psi_scalar,
+    const Scalar<DataVector>& /*pi_scalar*/,
+    const tnsr::i<DataVector, 3, Frame::Inertial>& phi_scalar,
+
+    // c.f. dg_interior_temporary_tags
+    const tnsr::I<DataVector, 3, Frame::Inertial>& coords,
+    const Scalar<DataVector>& gamma1, const Scalar<DataVector>& gamma2,
+    const Scalar<DataVector>& lapse,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& shift,
+    const tnsr::II<DataVector, 3>& /*interior_inv_spatial_metric*/,
+    const tnsr::AA<DataVector, 3, Frame::Inertial>& inverse_spacetime_metric,
+    const tnsr::A<DataVector, 3, Frame::Inertial>& spacetime_unit_normal_vector,
+    const tnsr::iaa<DataVector, 3, Frame::Inertial>& three_index_constraint,
+    const tnsr::a<DataVector, 3, Frame::Inertial>& gauge_source,
+    const tnsr::ab<DataVector, 3, Frame::Inertial>&
+        spacetime_deriv_gauge_source,
+    const Scalar<DataVector>& gamma1_scalar,
+    const Scalar<DataVector>& gamma2_scalar,
+
+    // c.f. dg_interior_dt_vars_tags
+    const tnsr::aa<DataVector, 3, Frame::Inertial>& logical_dt_spacetime_metric,
+    const tnsr::aa<DataVector, 3, Frame::Inertial>& logical_dt_pi,
+    const tnsr::iaa<DataVector, 3, Frame::Inertial>& logical_dt_phi,
+
+    const Scalar<DataVector>& logical_dt_psi_scalar,
+    const Scalar<DataVector>& logical_dt_pi_scalar,
+    const tnsr::i<DataVector, 3>& logical_dt_phi_scalar,
+
+    // c.f. dg_interior_deriv_vars_tags
+    const tnsr::iaa<DataVector, 3, Frame::Inertial>& d_spacetime_metric,
+    const tnsr::iaa<DataVector, 3, Frame::Inertial>& d_pi,
+    const tnsr::ijaa<DataVector, 3, Frame::Inertial>& d_phi,
+
+    const tnsr::i<DataVector, 3, Frame::Inertial>& d_psi_scalar,
+    const tnsr::i<DataVector, 3, Frame::Inertial>& d_pi_scalar,
+    const tnsr::ij<DataVector, 3, Frame::Inertial>& d_phi_scalar) const {
+  // GH ConstraintPreserving
+  auto gh_string = constraint_preserving_.dg_time_derivative(
+      dt_spacetime_metric_correction, dt_pi_correction, dt_phi_correction,
+      face_mesh_velocity, normal_covector, normal_vector, spacetime_metric, pi,
+      phi, coords, gamma1, gamma2, lapse, shift, inverse_spacetime_metric,
+      spacetime_unit_normal_vector, three_index_constraint, gauge_source,
+      spacetime_deriv_gauge_source, logical_dt_spacetime_metric, logical_dt_pi,
+      logical_dt_phi, d_spacetime_metric, d_pi, d_phi);
+
+  // Scalar ConstraintPreservingSphericalRadiation boundary conditions
+  auto scalar_string = csw_constraint_preserving_.dg_time_derivative(
+      dt_psi_scalar_correction, dt_pi_scalar_correction,
+      dt_phi_scalar_correction, face_mesh_velocity, normal_covector,
+      normal_vector, psi_scalar, phi_scalar, coords, gamma1_scalar,
+      gamma2_scalar, lapse, shift, logical_dt_psi_scalar, logical_dt_pi_scalar,
+      logical_dt_phi_scalar, d_psi_scalar, d_pi_scalar, d_phi_scalar);
+
+  if (not gh_string.has_value() and not scalar_string.has_value()) {
+    return {};
+  }
+  if (not gh_string.has_value()) {
+    return scalar_string;
+  }
+  if (not scalar_string.has_value()) {
+    return gh_string;
+  }
+  return gh_string.value() + ";" + scalar_string.value();
+}
+
+// NOLINTNEXTLINE
+PUP::able::PUP_ID ConstraintPreserving::my_PUP_ID = 0;
+}  // namespace ScalarTensor::BoundaryConditions

--- a/src/Evolution/Systems/ScalarTensor/BoundaryConditions/ConstraintPreserving.hpp
+++ b/src/Evolution/Systems/ScalarTensor/BoundaryConditions/ConstraintPreserving.hpp
@@ -1,0 +1,254 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <memory>
+#include <optional>
+#include <pup.h>
+#include <string>
+
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/CoordinateMaps/Tags.hpp"
+#include "Domain/ElementMap.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Tags.hpp"
+#include "Evolution/BoundaryConditions/Type.hpp"
+#include "Evolution/Systems/CurvedScalarWave/BoundaryConditions/ConstraintPreservingSphericalRadiation.hpp"
+#include "Evolution/Systems/CurvedScalarWave/Tags.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Bjorhus.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/Tags.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
+#include "Evolution/Systems/ScalarTensor/BoundaryConditions/BoundaryCondition.hpp"
+#include "Evolution/Systems/ScalarTensor/Tags.hpp"
+#include "Options/String.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Serialization/CharmPupable.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace ScalarTensor::BoundaryConditions {
+/*!
+ * \brief Sets constraint-preserving boundary conditions on the variables of the
+ * ScalarTensor system.
+ * \details The constraint-preserving boundary conditions on the scalar
+ * variables are approximate as they assume a fixed spacetime geometry.
+ * Likewise, the constraint-preserving boundary conditions on the metric
+ * variables assume that there is no back-reaction of the scalar stress energy
+ * tensor on the metric.
+ *
+ */
+class ConstraintPreserving final : public BoundaryCondition {
+ public:
+  using options = tmpl::push_back<
+      typename gh::BoundaryConditions::ConstraintPreservingBjorhus<3>::options>;
+
+  static constexpr Options::String help{
+      "Constraint-preserving boundary conditions are applied for the "
+      "Generalized Harmonic variables and spherical radiation constraint-"
+      "preserving boundary conditions are applied for the scalar variables."};
+
+  ConstraintPreserving() = default;
+  explicit ConstraintPreserving(
+      gh::BoundaryConditions::detail::ConstraintPreservingBjorhusType type);
+
+  ConstraintPreserving(ConstraintPreserving&&) = default;
+  ConstraintPreserving& operator=(ConstraintPreserving&&) = default;
+  ConstraintPreserving(const ConstraintPreserving&) = default;
+  ConstraintPreserving& operator=(const ConstraintPreserving&) = default;
+  ~ConstraintPreserving() override = default;
+
+  explicit ConstraintPreserving(CkMigrateMessage* msg);
+
+  WRAPPED_PUPable_decl_base_template(
+      domain::BoundaryConditions::BoundaryCondition, ConstraintPreserving);
+
+  auto get_clone() const -> std::unique_ptr<
+      domain::BoundaryConditions::BoundaryCondition> override;
+
+  static constexpr evolution::BoundaryConditions::Type bc_type =
+      evolution::BoundaryConditions::Type::GhostAndTimeDerivative;
+
+  void pup(PUP::er& p) override;
+
+  using dg_interior_evolved_variables_tags =
+      tmpl::list<gr::Tags::SpacetimeMetric<DataVector, 3>,
+                 gh::Tags::Pi<DataVector, 3>, gh::Tags::Phi<DataVector, 3>,
+                 CurvedScalarWave::Tags::Psi, CurvedScalarWave::Tags::Pi,
+                 CurvedScalarWave::Tags::Phi<3>>;
+  using dg_interior_temporary_tags =
+      tmpl::list<domain::Tags::Coordinates<3, Frame::Inertial>,
+                 ::gh::ConstraintDamping::Tags::ConstraintGamma1,
+                 ::gh::ConstraintDamping::Tags::ConstraintGamma2,
+                 gr::Tags::Lapse<DataVector>, gr::Tags::Shift<DataVector, 3>,
+                 gr::Tags::InverseSpatialMetric<DataVector, 3>,
+                 gr::Tags::InverseSpacetimeMetric<DataVector, 3>,
+                 gr::Tags::SpacetimeNormalVector<DataVector, 3>,
+                 gh::Tags::ThreeIndexConstraint<DataVector, 3>,
+                 gh::Tags::GaugeH<DataVector, 3>,
+                 gh::Tags::SpacetimeDerivGaugeH<DataVector, 3>,
+                 CurvedScalarWave::Tags::ConstraintGamma1,
+                 CurvedScalarWave::Tags::ConstraintGamma2>;
+  using dg_interior_primitive_variables_tags = tmpl::list<>;
+  using dg_gridless_tags = tmpl::list<>;
+
+  static std::optional<std::string> dg_ghost(
+      gsl::not_null<tnsr::aa<DataVector, 3, Frame::Inertial>*> spacetime_metric,
+      gsl::not_null<tnsr::aa<DataVector, 3, Frame::Inertial>*> pi,
+      gsl::not_null<tnsr::iaa<DataVector, 3, Frame::Inertial>*> phi,
+
+      gsl::not_null<Scalar<DataVector>*> psi_scalar,
+      gsl::not_null<Scalar<DataVector>*> pi_scalar,
+      gsl::not_null<tnsr::i<DataVector, 3, Frame::Inertial>*> phi_scalar,
+
+      // c.f. dg_package_data_temporary_tags from the combined Upwind correction
+      gsl::not_null<Scalar<DataVector>*> gamma1,
+      gsl::not_null<Scalar<DataVector>*> gamma2,
+      gsl::not_null<Scalar<DataVector>*> lapse,
+      gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> shift,
+      gsl::not_null<Scalar<DataVector>*> gamma1_scalar,
+      gsl::not_null<Scalar<DataVector>*> gamma2_scalar,
+
+      gsl::not_null<tnsr::II<DataVector, 3, Frame::Inertial>*>
+          inv_spatial_metric,
+
+      const std::optional<tnsr::I<DataVector, 3, Frame::Inertial>>&
+          face_mesh_velocity,
+      const tnsr::i<DataVector, 3, Frame::Inertial>& normal_covector,
+      const tnsr::I<DataVector, 3, Frame::Inertial>& normal_vector,
+
+      const tnsr::aa<DataVector, 3, Frame::Inertial>& interior_spacetime_metric,
+      const tnsr::aa<DataVector, 3, Frame::Inertial>& interior_pi,
+      const tnsr::iaa<DataVector, 3, Frame::Inertial>& interior_phi,
+
+      const Scalar<DataVector>& psi_scalar_interior,
+      const Scalar<DataVector>& pi_scalar_interior,
+      const tnsr::i<DataVector, 3>& phi_scalar_interior,
+
+      const tnsr::I<DataVector, 3, Frame::Inertial>& /*coords*/,
+      const Scalar<DataVector>& interior_gamma1,
+      const Scalar<DataVector>& interior_gamma2,
+      const Scalar<DataVector>& interior_lapse,
+      const tnsr::I<DataVector, 3>& interior_shift,
+      const tnsr::II<DataVector, 3>& interior_inv_spatial_metric,
+      const tnsr::AA<DataVector, 3,
+                     Frame::Inertial>& /*inverse_spacetime_metric*/,
+      const tnsr::A<DataVector, 3, Frame::Inertial>&
+      /*spacetime_unit_normal_vector*/,
+      const tnsr::iaa<DataVector, 3,
+                      Frame::Inertial>& /*three_index_constraint*/,
+      const tnsr::a<DataVector, 3, Frame::Inertial>& /*gauge_source*/,
+      const tnsr::ab<DataVector, 3, Frame::Inertial>&
+      /*spacetime_deriv_gauge_source*/,
+      const Scalar<DataVector>& interior_gamma1_scalar,
+      const Scalar<DataVector>& interior_gamma2_scalar,
+
+      // c.f. dg_interior_dt_vars_tags
+      const tnsr::aa<DataVector, 3, Frame::Inertial>&
+      /*logical_dt_spacetime_metric*/,
+      const tnsr::aa<DataVector, 3, Frame::Inertial>& /*logical_dt_pi*/,
+      const tnsr::iaa<DataVector, 3, Frame::Inertial>& /*logical_dt_phi*/,
+
+      const Scalar<DataVector>& /* logical_dt_psi_scalar*/,
+      const Scalar<DataVector>& /*logical_dt_pi_scalar*/,
+      const tnsr::i<DataVector, 3>& /*logical_dt_phi_scalar*/,
+
+      // c.f. dg_interior_deriv_vars_tags
+      const tnsr::iaa<DataVector, 3, Frame::Inertial>& /*d_spacetime_metric*/,
+      const tnsr::iaa<DataVector, 3, Frame::Inertial>& /*d_pi*/,
+      const tnsr::ijaa<DataVector, 3, Frame::Inertial>& /*d_phi*/,
+
+      const tnsr::i<DataVector, 3, Frame::Inertial>& /*d_psi_scalar*/,
+      const tnsr::i<DataVector, 3, Frame::Inertial>& /*d_pi_scalar*/,
+      const tnsr::ij<DataVector, 3, Frame::Inertial>& /*d_phi_scalar*/);
+
+  using dg_interior_dt_vars_tags =
+      tmpl::list<::Tags::dt<gr::Tags::SpacetimeMetric<DataVector, 3>>,
+                 ::Tags::dt<gh::Tags::Pi<DataVector, 3>>,
+                 ::Tags::dt<gh::Tags::Phi<DataVector, 3>>,
+                 ::Tags::dt<CurvedScalarWave::Tags::Psi>,
+                 ::Tags::dt<CurvedScalarWave::Tags::Pi>,
+                 ::Tags::dt<CurvedScalarWave::Tags::Phi<3>>>;
+  using dg_interior_deriv_vars_tags =
+      tmpl::list<::Tags::deriv<gr::Tags::SpacetimeMetric<DataVector, 3>,
+                               tmpl::size_t<3>, Frame::Inertial>,
+                 ::Tags::deriv<gh::Tags::Pi<DataVector, 3>, tmpl::size_t<3>,
+                               Frame::Inertial>,
+                 ::Tags::deriv<gh::Tags::Phi<DataVector, 3>, tmpl::size_t<3>,
+                               Frame::Inertial>,
+                 ::Tags::deriv<CurvedScalarWave::Tags::Psi, tmpl::size_t<3>,
+                               Frame::Inertial>,
+                 ::Tags::deriv<CurvedScalarWave::Tags::Pi, tmpl::size_t<3>,
+                               Frame::Inertial>,
+                 ::Tags::deriv<CurvedScalarWave::Tags::Phi<3>, tmpl::size_t<3>,
+                               Frame::Inertial>>;
+
+  std::optional<std::string> dg_time_derivative(
+      gsl::not_null<tnsr::aa<DataVector, 3, Frame::Inertial>*>
+          dt_spacetime_metric_correction,
+      gsl::not_null<tnsr::aa<DataVector, 3, Frame::Inertial>*> dt_pi_correction,
+      gsl::not_null<tnsr::iaa<DataVector, 3, Frame::Inertial>*>
+          dt_phi_correction,
+
+      gsl::not_null<Scalar<DataVector>*> dt_psi_scalar_correction,
+      gsl::not_null<Scalar<DataVector>*> dt_pi_scalar_correction,
+      gsl::not_null<tnsr::i<DataVector, 3, Frame::Inertial>*>
+          dt_phi_scalar_correction,
+
+      const std::optional<tnsr::I<DataVector, 3, Frame::Inertial>>&
+          face_mesh_velocity,
+      const tnsr::i<DataVector, 3, Frame::Inertial>& normal_covector,
+      const tnsr::I<DataVector, 3, Frame::Inertial>& normal_vector,
+      // c.f. dg_interior_evolved_variables_tags
+      const tnsr::aa<DataVector, 3, Frame::Inertial>& spacetime_metric,
+      const tnsr::aa<DataVector, 3, Frame::Inertial>& pi,
+      const tnsr::iaa<DataVector, 3, Frame::Inertial>& phi,
+
+      const Scalar<DataVector>& psi_scalar, const Scalar<DataVector>& pi_scalar,
+      const tnsr::i<DataVector, 3, Frame::Inertial>& phi_scalar,
+
+      // c.f. dg_interior_temporary_tags
+      const tnsr::I<DataVector, 3, Frame::Inertial>& coords,
+      const Scalar<DataVector>& gamma1, const Scalar<DataVector>& gamma2,
+      const Scalar<DataVector>& lapse,
+      const tnsr::I<DataVector, 3, Frame::Inertial>& shift,
+      const tnsr::II<DataVector, 3>& /*interior_inv_spatial_metric*/,
+      const tnsr::AA<DataVector, 3, Frame::Inertial>& inverse_spacetime_metric,
+      const tnsr::A<DataVector, 3, Frame::Inertial>&
+          spacetime_unit_normal_vector,
+      const tnsr::iaa<DataVector, 3, Frame::Inertial>& three_index_constraint,
+      const tnsr::a<DataVector, 3, Frame::Inertial>& gauge_source,
+      const tnsr::ab<DataVector, 3, Frame::Inertial>&
+          spacetime_deriv_gauge_source,
+      const Scalar<DataVector>& gamma1_scalar,
+      const Scalar<DataVector>& gamma2_scalar,
+
+      // c.f. dg_interior_dt_vars_tags
+      const tnsr::aa<DataVector, 3, Frame::Inertial>&
+          logical_dt_spacetime_metric,
+      const tnsr::aa<DataVector, 3, Frame::Inertial>& logical_dt_pi,
+      const tnsr::iaa<DataVector, 3, Frame::Inertial>& logical_dt_phi,
+
+      const Scalar<DataVector>& logical_dt_psi_scalar,
+      const Scalar<DataVector>& logical_dt_pi_scalar,
+      const tnsr::i<DataVector, 3>& logical_dt_phi_scalar,
+
+      // c.f. dg_interior_deriv_vars_tags
+      const tnsr::iaa<DataVector, 3, Frame::Inertial>& d_spacetime_metric,
+      const tnsr::iaa<DataVector, 3, Frame::Inertial>& d_pi,
+      const tnsr::ijaa<DataVector, 3, Frame::Inertial>& d_phi,
+
+      const tnsr::i<DataVector, 3, Frame::Inertial>& d_psi_scalar,
+      const tnsr::i<DataVector, 3, Frame::Inertial>& d_pi_scalar,
+      const tnsr::ij<DataVector, 3, Frame::Inertial>& d_phi_scalar) const;
+
+ private:
+  gh::BoundaryConditions::ConstraintPreservingBjorhus<3>
+      constraint_preserving_{};
+  CurvedScalarWave::BoundaryConditions::ConstraintPreservingSphericalRadiation<
+      3>
+      csw_constraint_preserving_{};
+};
+}  // namespace ScalarTensor::BoundaryConditions

--- a/src/Evolution/Systems/ScalarTensor/BoundaryConditions/Factory.hpp
+++ b/src/Evolution/Systems/ScalarTensor/BoundaryConditions/Factory.hpp
@@ -12,6 +12,7 @@
 #include "Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/DirichletAnalytic.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Factory.hpp"
 #include "Evolution/Systems/ScalarTensor/BoundaryConditions/BoundaryCondition.hpp"
+#include "Evolution/Systems/ScalarTensor/BoundaryConditions/ConstraintPreserving.hpp"
 #include "Evolution/Systems/ScalarTensor/BoundaryConditions/ProductOfConditions.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -51,10 +52,11 @@ using subset_standard_boundary_conditions_gh =
 using subset_standard_boundary_conditions_scalar = tmpl::list<
     CurvedScalarWave::BoundaryConditions::AnalyticConstant<3>,
     CurvedScalarWave::BoundaryConditions::DemandOutgoingCharSpeeds<3>>;
-using standard_boundary_conditions =
-    tmpl::push_back<typename detail::AllProductConditions<
-                        subset_standard_boundary_conditions_gh,
-                        subset_standard_boundary_conditions_scalar>::type,
-                    domain::BoundaryConditions::Periodic<BoundaryCondition>>;
+using standard_boundary_conditions = tmpl::append<
+    detail::AllProductConditions<
+        subset_standard_boundary_conditions_gh,
+        subset_standard_boundary_conditions_scalar>::type,
+    tmpl::list<ScalarTensor::BoundaryConditions::ConstraintPreserving,
+               domain::BoundaryConditions::Periodic<BoundaryCondition>>>;
 
 }  // namespace ScalarTensor::BoundaryConditions

--- a/tests/Unit/Evolution/Systems/ScalarTensor/BoundaryConditions/Test_ConstraintPreserving.cpp
+++ b/tests/Unit/Evolution/Systems/ScalarTensor/BoundaryConditions/Test_ConstraintPreserving.cpp
@@ -1,0 +1,404 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <memory>
+#include <random>
+#include <tuple>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Evolution/Systems/CurvedScalarWave/BoundaryConditions/ConstraintPreservingSphericalRadiation.hpp"
+#include "Evolution/Systems/CurvedScalarWave/Tags.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Bjorhus.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Factory.hpp"
+#include "Evolution/Systems/ScalarTensor/BoundaryConditions/BoundaryCondition.hpp"
+#include "Evolution/Systems/ScalarTensor/BoundaryConditions/ConstraintPreserving.hpp"
+#include "Evolution/Systems/ScalarTensor/BoundaryCorrections/ProductOfCorrections.hpp"
+#include "Evolution/Systems/ScalarTensor/System.hpp"
+#include "Evolution/Systems/ScalarTensor/Tags.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "Helpers/Evolution/DiscontinuousGalerkin/BoundaryConditions.hpp"
+#include "Helpers/PointwiseFunctions/GeneralRelativity/TestHelpers.hpp"
+#include "Options/Protocols/FactoryCreation.hpp"
+#include "PointwiseFunctions/AnalyticData/ScalarTensor/KerrSphericalHarmonic.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/AnalyticSolution.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/WrappedGr.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
+#include "PointwiseFunctions/GeneralRelativity/SpacetimeNormalOneForm.hpp"
+#include "PointwiseFunctions/GeneralRelativity/SpacetimeNormalVector.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Serialization/RegisterDerivedClassesWithCharm.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace {
+
+struct Metavariables {
+  struct factory_creation
+      : tt::ConformsTo<Options::protocols::FactoryCreation> {
+    using factory_classes = tmpl::map<tmpl::pair<
+        ScalarTensor::BoundaryConditions::BoundaryCondition,
+        tmpl::list<ScalarTensor::BoundaryConditions::ConstraintPreserving>>>;
+  };
+};
+
+template <typename U>
+void test_dg(const gsl::not_null<std::mt19937*> generator,
+             const U& boundary_condition) {
+  const size_t num_points = 5;
+
+  std::uniform_real_distribution<> dist(0.1, 1.0);
+
+  const gh::Solutions::WrappedGr<
+      ScalarTensor::AnalyticData::KerrSphericalHarmonic>
+      analytic_data{1.0,    std::array<double, 3>{{0.0, 0.0, 0.0}},
+                    1.0e-5, 30.0,
+                    5.0,    std::pair<size_t, int>{0, 0}};
+
+  const auto interior_gamma1 = make_with_random_values<Scalar<DataVector>>(
+      generator, make_not_null(&dist), num_points);
+  const auto interior_gamma2 = make_with_random_values<Scalar<DataVector>>(
+      generator, make_not_null(&dist), num_points);
+
+  const auto interior_gamma1_scalar =
+      make_with_random_values<Scalar<DataVector>>(
+          generator, make_not_null(&dist), num_points);
+  const auto interior_gamma2_scalar =
+      make_with_random_values<Scalar<DataVector>>(
+          generator, make_not_null(&dist), num_points);
+
+  const auto coords =
+      make_with_random_values<tnsr::I<DataVector, 3, Frame::Inertial>>(
+          generator, make_not_null(&dist), num_points);
+
+  using Vars = Variables<tmpl::append<
+      ScalarTensor::System::variables_tag::tags_list,
+      db::wrap_tags_in<::Tags::Flux, ScalarTensor::System::flux_variables,
+                       tmpl::size_t<3_st>, Frame::Inertial>,
+      tmpl::list<gh::ConstraintDamping::Tags::ConstraintGamma1,
+                 gh::ConstraintDamping::Tags::ConstraintGamma2,
+                 gr::Tags::Lapse<DataVector>, gr::Tags::Shift<DataVector, 3>,
+                 gr::Tags::InverseSpatialMetric<DataVector, 3>,
+                 CurvedScalarWave::Tags::ConstraintGamma1,
+                 CurvedScalarWave::Tags::ConstraintGamma2>>>;
+  using PrimVars = Variables<tmpl::list<>>;
+
+  Vars vars{num_points};
+  Vars expected_vars;
+  PrimVars prim_vars;
+
+  std::tie(expected_vars, prim_vars) = [&analytic_data, &coords,
+                                        &interior_gamma1, &interior_gamma2,
+                                        &interior_gamma1_scalar,
+                                        &interior_gamma2_scalar]() {
+    Vars expected{num_points};
+    auto& [spacetime_metric, pi, phi, psi_scalar, pi_scalar, phi_scalar, gamma1,
+           gamma2, lapse, shift, inverse_spatial_metric, gamma1_scalar,
+           gamma2_scalar] = expected;
+
+    gamma1 = interior_gamma1;
+    gamma2 = interior_gamma2;
+
+    gamma1_scalar = interior_gamma1_scalar;
+    gamma2_scalar = interior_gamma2_scalar;
+
+    PrimVars local_prim_vars{num_points};
+
+    using tags =
+        tmpl::list<gr::Tags::SpatialMetric<DataVector, 3>,
+                   gr::Tags::InverseSpatialMetric<DataVector, 3>,
+                   gr::Tags::SqrtDetSpatialMetric<DataVector>,
+                   gr::Tags::Lapse<DataVector>, gr::Tags::Shift<DataVector, 3>,
+                   gr::Tags::SpacetimeMetric<DataVector, 3>,
+                   ::gh::Tags::Pi<DataVector, 3>,
+                   ::gh::Tags::Phi<DataVector, 3>, CurvedScalarWave::Tags::Psi,
+                   CurvedScalarWave::Tags::Pi, CurvedScalarWave::Tags::Phi<3>>;
+
+    tuples::tagged_tuple_from_typelist<tags> analytic_vars{};
+
+    analytic_vars = analytic_data.variables(coords, tags{});
+
+    spacetime_metric =
+        get<gr::Tags::SpacetimeMetric<DataVector, 3>>(analytic_vars);
+    pi = get<::gh::Tags::Pi<DataVector, 3>>(analytic_vars);
+    phi = get<::gh::Tags::Phi<DataVector, 3>>(analytic_vars);
+
+    psi_scalar = get<CurvedScalarWave::Tags::Psi>(analytic_vars);
+    pi_scalar = get<CurvedScalarWave::Tags::Pi>(analytic_vars);
+    phi_scalar = get<CurvedScalarWave::Tags::Phi<3>>(analytic_vars);
+
+    lapse = get<gr::Tags::Lapse<DataVector>>(analytic_vars);
+    shift = get<gr::Tags::Shift<DataVector, 3>>(analytic_vars);
+    inverse_spatial_metric =
+        get<gr::Tags::InverseSpatialMetric<DataVector, 3>>(analytic_vars);
+
+    return std::tuple(expected, local_prim_vars);
+  }();
+
+  // Pick random direction normal covector, then normalize and compute normal
+  // vector.
+  tnsr::i<DataVector, 3> normal_covector{num_points};
+  get<0>(normal_covector) = 0.5;
+  get<1>(normal_covector) = 0.0;
+  get<2>(normal_covector) = 0.5;
+  const auto magnitude_normal = magnitude(
+      normal_covector,
+      get<gr::Tags::InverseSpatialMetric<DataVector, 3>>(expected_vars));
+  for (size_t i = 0; i < 3; ++i) {
+    normal_covector.get(i) /= get(magnitude_normal);
+  }
+  const auto normal_vector =
+      tenex::evaluate<ti::I>(normal_covector(ti::j) *
+                             get<gr::Tags::InverseSpatialMetric<DataVector, 3>>(
+                                 expected_vars)(ti::I, ti::J));
+
+  auto& [spacetime_metric, pi, phi, psi_scalar, pi_scalar, phi_scalar, gamma1,
+         gamma2, lapse, shift, inverse_spatial_metric, gamma1_scalar,
+         gamma2_scalar] = vars;
+
+  CHECK(
+      not boundary_condition
+              .dg_ghost(
+                  make_not_null(&spacetime_metric), make_not_null(&pi),
+                  make_not_null(&phi),
+
+                  make_not_null(&psi_scalar), make_not_null(&pi_scalar),
+                  make_not_null(&phi_scalar),
+
+                  make_not_null(&gamma1), make_not_null(&gamma2),
+                  make_not_null(&lapse), make_not_null(&shift),
+
+                  make_not_null(&gamma1_scalar), make_not_null(&gamma2_scalar),
+
+                  make_not_null(&inverse_spatial_metric), {}, normal_covector,
+                  normal_vector,
+
+                  get<gr::Tags::SpacetimeMetric<DataVector, 3>>(expected_vars),
+                  get<gh::Tags::Pi<DataVector, 3>>(expected_vars),
+                  get<gh::Tags::Phi<DataVector, 3>>(expected_vars),
+
+                  get<CurvedScalarWave::Tags::Psi>(expected_vars),
+                  get<CurvedScalarWave::Tags::Pi>(expected_vars),
+                  get<CurvedScalarWave::Tags::Phi<3>>(expected_vars),
+
+                  coords, interior_gamma1, interior_gamma2,
+                  get<gr::Tags::Lapse<DataVector>>(expected_vars),
+                  get<gr::Tags::Shift<DataVector, 3>>(expected_vars),
+                  get<gr::Tags::InverseSpatialMetric<DataVector, 3>>(
+                      expected_vars),
+
+                  {}, {}, {}, {}, {},
+
+                  interior_gamma1_scalar, interior_gamma2_scalar,
+
+                  {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {})
+              .has_value());
+
+  const auto inverse_spacetime_metric =
+      determinant_and_inverse(spacetime_metric).second;
+  const auto spacetime_normal_vector = gr::spacetime_normal_vector(
+      get<gr::Tags::Lapse<DataVector>>(expected_vars),
+      get<gr::Tags::Shift<DataVector, 3>>(expected_vars));
+  const auto gauge_source = make_with_random_values<tnsr::a<DataVector, 3>>(
+      generator, make_not_null(&dist), num_points);
+  const auto spacetime_deriv_gauge_source =
+      make_with_random_values<tnsr::ab<DataVector, 3>>(
+          generator, make_not_null(&dist), num_points);
+  const auto d_spacetime_metric =
+      make_with_random_values<tnsr::iaa<DataVector, 3>>(
+          generator, make_not_null(&dist), num_points);
+  const auto d_pi = make_with_random_values<tnsr::iaa<DataVector, 3>>(
+      generator, make_not_null(&dist), num_points);
+  const auto d_phi = make_with_random_values<tnsr::ijaa<DataVector, 3>>(
+      generator, make_not_null(&dist), num_points);
+
+  const auto d_psi_scalar = make_with_random_values<tnsr::i<DataVector, 3>>(
+      generator, make_not_null(&dist), num_points);
+  const auto d_pi_scalar = make_with_random_values<tnsr::i<DataVector, 3>>(
+      generator, make_not_null(&dist), num_points);
+  const auto d_phi_scalar = make_with_random_values<tnsr::ij<DataVector, 3>>(
+      generator, make_not_null(&dist), num_points);
+
+  const auto three_index_constraint =
+      make_with_random_values<tnsr::iaa<DataVector, 3>>(
+          generator, make_not_null(&dist), num_points);
+  const auto logical_dt_spacetime_metric =
+      make_with_random_values<tnsr::aa<DataVector, 3>>(
+          generator, make_not_null(&dist), num_points);
+  const auto logical_dt_pi = make_with_random_values<tnsr::aa<DataVector, 3>>(
+      generator, make_not_null(&dist), num_points);
+  const auto logical_dt_phi = make_with_random_values<tnsr::iaa<DataVector, 3>>(
+      generator, make_not_null(&dist), num_points);
+
+  const auto logical_dt_psi_scalar =
+      make_with_random_values<Scalar<DataVector>>(
+          generator, make_not_null(&dist), num_points);
+  const auto logical_dt_pi_scalar = make_with_random_values<Scalar<DataVector>>(
+      generator, make_not_null(&dist), num_points);
+  const auto logical_dt_phi_scalar =
+      make_with_random_values<tnsr::i<DataVector, 3>>(
+          generator, make_not_null(&dist), num_points);
+
+  using DtVars = Variables<db::wrap_tags_in<
+      ::Tags::dt, ScalarTensor::System::variables_tag::tags_list>>;
+  DtVars dt_vars{num_points};
+
+  // Test CurvedScalarWave constraint-preserving BC
+  CHECK(
+      not boundary_condition
+              .dg_time_derivative(
+                  make_not_null(
+                      &get<
+                          ::Tags::dt<gr::Tags::SpacetimeMetric<DataVector, 3>>>(
+                          dt_vars)),
+                  make_not_null(
+                      &get<::Tags::dt<gh::Tags::Pi<DataVector, 3>>>(dt_vars)),
+                  make_not_null(
+                      &get<::Tags::dt<gh::Tags::Phi<DataVector, 3>>>(dt_vars)),
+
+                  make_not_null(
+                      &get<::Tags::dt<CurvedScalarWave::Tags::Psi>>(dt_vars)),
+                  make_not_null(
+                      &get<::Tags::dt<CurvedScalarWave::Tags::Pi>>(dt_vars)),
+                  make_not_null(
+                      &get<::Tags::dt<CurvedScalarWave::Tags::Phi<3>>>(
+                          dt_vars)),
+
+                  {}, normal_covector, normal_vector,
+
+                  get<gr::Tags::SpacetimeMetric<DataVector, 3>>(expected_vars),
+                  get<gh::Tags::Pi<DataVector, 3>>(expected_vars),
+                  get<gh::Tags::Phi<DataVector, 3>>(expected_vars),
+
+                  get<CurvedScalarWave::Tags::Psi>(expected_vars),
+                  get<CurvedScalarWave::Tags::Pi>(expected_vars),
+                  get<CurvedScalarWave::Tags::Phi<3>>(expected_vars),
+
+                  coords, interior_gamma1, interior_gamma2,
+                  get<gr::Tags::Lapse<DataVector>>(expected_vars),
+                  get<gr::Tags::Shift<DataVector, 3>>(expected_vars),
+                  get<gr::Tags::InverseSpatialMetric<DataVector, 3>>(
+                      expected_vars),
+                  inverse_spacetime_metric, spacetime_normal_vector,
+                  three_index_constraint, gauge_source,
+                  spacetime_deriv_gauge_source,
+
+                  interior_gamma1_scalar, interior_gamma2_scalar,
+
+                  logical_dt_spacetime_metric, logical_dt_pi, logical_dt_phi,
+
+                  logical_dt_psi_scalar, logical_dt_pi_scalar,
+                  logical_dt_phi_scalar,
+
+                  d_spacetime_metric, d_pi, d_phi,
+
+                  d_psi_scalar, d_pi_scalar, d_phi_scalar)
+              .has_value());
+
+  CurvedScalarWave::BoundaryConditions::ConstraintPreservingSphericalRadiation<
+      3>
+      csw_constraint_preserving{};
+
+  DtVars expected_dt_vars{num_points, 0.0};
+
+  CHECK(not csw_constraint_preserving
+                .dg_time_derivative(
+
+                    make_not_null(&get<::Tags::dt<CurvedScalarWave::Tags::Psi>>(
+                        expected_dt_vars)),
+                    make_not_null(&get<::Tags::dt<CurvedScalarWave::Tags::Pi>>(
+                        expected_dt_vars)),
+                    make_not_null(
+                        &get<::Tags::dt<CurvedScalarWave::Tags::Phi<3>>>(
+                            expected_dt_vars)),
+
+                    {}, normal_covector, normal_vector,
+
+                    get<CurvedScalarWave::Tags::Psi>(expected_vars),
+                    get<CurvedScalarWave::Tags::Phi<3>>(expected_vars),
+
+                    coords, interior_gamma1_scalar, interior_gamma2_scalar,
+
+                    get<gr::Tags::Lapse<DataVector>>(expected_vars),
+                    get<gr::Tags::Shift<DataVector, 3>>(expected_vars),
+
+                    logical_dt_psi_scalar, logical_dt_pi_scalar,
+                    logical_dt_phi_scalar, d_psi_scalar, d_pi_scalar,
+                    d_phi_scalar)
+                .has_value());
+
+  tmpl::for_each<typename Vars::tags_list>([&expected_vars, &vars](auto tag_v) {
+    using tag = tmpl::type_from<decltype(tag_v)>;
+    CAPTURE(db::tag_name<tag>());
+    CHECK(get<tag>(vars) == get<tag>(expected_vars));
+  });
+
+  // Test Generalized Harmonic constraint-preserving BC
+  gh::BoundaryConditions::ConstraintPreservingBjorhus<3> gh_cp{
+      gh::BoundaryConditions::detail::ConstraintPreservingBjorhusType::
+          ConstraintPreservingPhysical};
+  CHECK(
+      not gh_cp
+              .dg_time_derivative(
+                  make_not_null(
+                      &get<
+                          ::Tags::dt<gr::Tags::SpacetimeMetric<DataVector, 3>>>(
+                          expected_dt_vars)),
+                  make_not_null(&get<::Tags::dt<gh::Tags::Pi<DataVector, 3>>>(
+                      expected_dt_vars)),
+                  make_not_null(&get<::Tags::dt<gh::Tags::Phi<DataVector, 3>>>(
+                      expected_dt_vars)),
+
+                  {}, normal_covector, normal_vector,
+
+                  get<gr::Tags::SpacetimeMetric<DataVector, 3>>(expected_vars),
+                  get<gh::Tags::Pi<DataVector, 3>>(expected_vars),
+                  get<gh::Tags::Phi<DataVector, 3>>(expected_vars),
+
+                  coords, interior_gamma1, interior_gamma2,
+                  get<gr::Tags::Lapse<DataVector>>(expected_vars),
+                  get<gr::Tags::Shift<DataVector, 3>>(expected_vars),
+                  inverse_spacetime_metric, spacetime_normal_vector,
+                  three_index_constraint, gauge_source,
+                  spacetime_deriv_gauge_source, logical_dt_spacetime_metric,
+                  logical_dt_pi, logical_dt_phi, d_spacetime_metric, d_pi,
+                  d_phi)
+              .has_value());
+  tmpl::for_each<typename DtVars::tags_list>(
+      [&dt_vars, &expected_dt_vars](auto tag_v) {
+        using tag = tmpl::type_from<decltype(tag_v)>;
+        CAPTURE(db::tag_name<tag>());
+        CHECK(get<tag>(dt_vars) == get<tag>(expected_dt_vars));
+      });
+}
+
+}  // namespace
+
+SPECTRE_TEST_CASE(
+  "Unit.ScalarTensor.BoundaryConditions.ConstraintPreserving",
+  "[Unit][Evolution]") {
+  MAKE_GENERATOR(gen);
+  register_factory_classes_with_charm<Metavariables>();
+
+  const auto product_boundary_condition =
+      TestHelpers::test_creation<
+          std::unique_ptr<ScalarTensor::BoundaryConditions::BoundaryCondition>,
+          Metavariables>(
+          "ConstraintPreserving:\n"
+          "  Type: ConstraintPreservingPhysical\n")
+          ->get_clone();
+
+  const auto serialized_and_deserialized_condition = serialize_and_deserialize(
+      *dynamic_cast<ScalarTensor::BoundaryConditions::ConstraintPreserving*>(
+          product_boundary_condition.get()));
+
+  test_dg(make_not_null(&gen), serialized_and_deserialized_condition);
+}

--- a/tests/Unit/Evolution/Systems/ScalarTensor/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/ScalarTensor/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY "Test_ScalarTensor")
 
 set(LIBRARY_SOURCES
+  BoundaryConditions/Test_ConstraintPreserving.cpp
   BoundaryConditions/Test_ProductOfConditions.cpp
   BoundaryCorrections/Test_ProductOfCorrections.cpp
   Test_Characteristics.cpp


### PR DESCRIPTION
## Proposed changes

We write a boundary condition for the ScalarTensor system that combines the Bjorhus BCs for the metric sector and the constraint-preserving BC of CurvedScalarWave. 

This is not a true constraint-preserving boundary condition since the gh BCs assume no backreaction of the scalar, and conversely, the constraint-preserving boundary conditions of the scalar assume a fixed spacetime geometry. I find that this approximation behaves well during evolution.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
