### PR TITLE
Stop storing volume time-stepper errors

### DIFF
--- a/src/Time/CMakeLists.txt
+++ b/src/Time/CMakeLists.txt
@@ -14,6 +14,7 @@ spectre_target_sources(
   History.cpp
   SelfStart.cpp
   Slab.cpp
+  StepperErrorEstimate.cpp
   StepperErrorTolerances.cpp
   Time.cpp
   TimeSequence.cpp

--- a/src/Time/CMakeLists.txt
+++ b/src/Time/CMakeLists.txt
@@ -14,6 +14,7 @@ spectre_target_sources(
   History.cpp
   SelfStart.cpp
   Slab.cpp
+  StepperErrorTolerances.cpp
   Time.cpp
   TimeSequence.cpp
   TimeStepId.cpp
@@ -33,6 +34,7 @@ spectre_target_headers(
   SelfStart.hpp
   Slab.hpp
   StepperErrorEstimate.hpp
+  StepperErrorTolerances.hpp
   TakeStep.hpp
   Time.hpp
   TimeSequence.hpp

--- a/src/Time/CMakeLists.txt
+++ b/src/Time/CMakeLists.txt
@@ -31,6 +31,7 @@ spectre_target_headers(
   ChooseLtsStepSize.hpp
   EvolutionOrdering.hpp
   History.hpp
+  LargestStepperError.hpp
   SelfStart.hpp
   Slab.hpp
   StepperErrorEstimate.hpp

--- a/src/Time/CMakeLists.txt
+++ b/src/Time/CMakeLists.txt
@@ -12,6 +12,7 @@ spectre_target_sources(
   ApproximateTime.cpp
   ChooseLtsStepSize.cpp
   History.cpp
+  LargestStepperError.cpp
   SelfStart.cpp
   Slab.cpp
   StepperErrorEstimate.cpp

--- a/src/Time/LargestStepperError.cpp
+++ b/src/Time/LargestStepperError.cpp
@@ -1,0 +1,56 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Time/LargestStepperError.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <complex>
+
+#include "DataStructures/ComplexDataVector.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "Time/StepperErrorTolerances.hpp"
+
+double largest_stepper_error(const double values, const double errors,
+                             const StepperErrorTolerances& tolerances) {
+  return std::abs(errors) /
+         (tolerances.absolute +
+          tolerances.relative * std::max(abs(values), abs(values + errors)));
+}
+
+double largest_stepper_error(const std::complex<double>& values,
+                             const std::complex<double>& errors,
+                             const StepperErrorTolerances& tolerances) {
+  return std::abs(errors) /
+         (tolerances.absolute +
+          tolerances.relative * std::max(abs(values), abs(values + errors)));
+}
+
+double largest_stepper_error(const DataVector& values, const DataVector& errors,
+                             const StepperErrorTolerances& tolerances) {
+  double result = 0.0;
+  for (auto val_it = values.begin(), err_it = errors.begin();
+       val_it != values.end(); ++val_it, ++err_it) {
+    const double recursive_call_result =
+        largest_stepper_error(*val_it, *err_it, tolerances);
+    if (recursive_call_result > result) {
+      result = recursive_call_result;
+    }
+  }
+  return result;
+}
+
+double largest_stepper_error(const ComplexDataVector& values,
+                             const ComplexDataVector& errors,
+                             const StepperErrorTolerances& tolerances) {
+  double result = 0.0;
+  for (auto val_it = values.begin(), err_it = errors.begin();
+       val_it != values.end(); ++val_it, ++err_it) {
+    const double recursive_call_result =
+        largest_stepper_error(*val_it, *err_it, tolerances);
+    if (recursive_call_result > result) {
+      result = recursive_call_result;
+    }
+  }
+  return result;
+}

--- a/src/Time/LargestStepperError.hpp
+++ b/src/Time/LargestStepperError.hpp
@@ -1,0 +1,75 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <algorithm>
+#include <cmath>
+#include <type_traits>
+
+#include "DataStructures/SpinWeighted.hpp"
+#include "Time/StepperErrorTolerances.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TypeTraits/IsA.hpp"
+#include "Utilities/TypeTraits/IsComplexOfFundamental.hpp"
+#include "Utilities/TypeTraits/IsIterable.hpp"
+
+/// \cond
+template <typename TagsList>
+class Variables;
+/// \endcond
+
+/*!
+ * \ingroup TimeGroup
+ * \brief Calculate the pointwise worst error.
+ *
+ * \details For a `double`, or `std::complex<double>`, calculates
+ *
+ * \f{equation}
+ *   \frac{e}{a + r \max(|v|, |v + e|)}
+ * \f}
+ *
+ * where $v$ is \p values, $e$ is \p errors, and $a$ and $r$ are the
+ * tolerances from \p tolerances.
+ *
+ * For iterable or `Variables` types, takes the largest value over all
+ * the points.
+ *
+ * For `SpinWeighted` types, returns the result for the contained values.
+ */
+template <typename EvolvedType, typename ErrorType>
+double largest_stepper_error(const EvolvedType& values, const ErrorType& errors,
+                             const StepperErrorTolerances& tolerances) {
+  if constexpr (std::is_fundamental_v<std::remove_cv_t<EvolvedType>> or
+                tt::is_complex_of_fundamental_v<
+                    std::remove_cv_t<EvolvedType>>) {
+    return std::abs(errors) /
+           (tolerances.absolute +
+            tolerances.relative * std::max(abs(values), abs(values + errors)));
+  } else if constexpr (tt::is_iterable_v<std::remove_cv_t<EvolvedType>>) {
+    double result = 0.0;
+    double recursive_call_result;
+    for (auto val_it = values.begin(), err_it = errors.begin();
+         val_it != values.end(); ++val_it, ++err_it) {
+      recursive_call_result =
+          largest_stepper_error(*val_it, *err_it, tolerances);
+      if (recursive_call_result > result) {
+        result = recursive_call_result;
+      }
+    }
+    return result;
+  } else if constexpr (tt::is_a_v<Variables, std::remove_cv_t<EvolvedType>>) {
+    double result = 0.0;
+    tmpl::for_each<typename EvolvedType::tags_list>(
+        [&]<typename Tag>(tmpl::type_<Tag> /*meta*/) {
+          const double recursive_call_result = largest_stepper_error(
+              get<Tag>(values), get<Tag>(errors), tolerances);
+          if (recursive_call_result > result) {
+            result = recursive_call_result;
+          }
+        });
+    return result;
+  } else if constexpr (is_any_spin_weighted_v<std::remove_cv_t<EvolvedType>>) {
+    return largest_stepper_error(values.data(), errors.data(), tolerances);
+  }
+}

--- a/src/Time/StepperErrorEstimate.cpp
+++ b/src/Time/StepperErrorEstimate.cpp
@@ -1,0 +1,13 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Time/StepperErrorEstimate.hpp"
+
+#include <pup.h>
+
+void StepperErrorEstimate::pup(PUP::er& p) {
+  p | step_time;
+  p | step_size;
+  p | order;
+  p | error;
+}

--- a/src/Time/StepperErrorEstimate.hpp
+++ b/src/Time/StepperErrorEstimate.hpp
@@ -4,13 +4,17 @@
 #pragma once
 
 #include <cstddef>
-#include <pup.h>
 
 #include "Time/Time.hpp"
 
+/// \cond
+namespace PUP {
+class er;
+}  // namespace PUP
+/// \endcond
+
 /// \ingroup TimeGroup
 /// Estimate of the TimeStepper truncation error.
-template <typename T>
 struct StepperErrorEstimate {
   /// Start of the step the estimate is for.
   Time step_time{};
@@ -19,17 +23,8 @@ struct StepperErrorEstimate {
   /// Order of accuracy of the estimate.  The estimated error should
   /// scale approximately as $(\Delta t)^{\text{order} + 1}$.
   size_t order{};
-  /// Error estimate, with the same structure as the evolved
-  /// variables.
-  T error{};
+  /// Error estimate.
+  double error{};
 
   void pup(PUP::er& p);
 };
-
-template <typename T>
-void StepperErrorEstimate<T>::pup(PUP::er& p) {
-  p | step_time;
-  p | step_size;
-  p | order;
-  p | error;
-}

--- a/src/Time/StepperErrorTolerances.cpp
+++ b/src/Time/StepperErrorTolerances.cpp
@@ -1,0 +1,21 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Time/StepperErrorTolerances.hpp"
+
+#include <pup.h>
+
+void StepperErrorTolerances::pup(PUP::er& p) {
+  p | absolute;
+  p | relative;
+}
+
+bool operator==(const StepperErrorTolerances& a,
+                const StepperErrorTolerances& b) {
+  return a.absolute == b.absolute and a.relative == b.relative;
+}
+
+bool operator!=(const StepperErrorTolerances& a,
+                const StepperErrorTolerances& b) {
+  return not(a == b);
+}

--- a/src/Time/StepperErrorTolerances.hpp
+++ b/src/Time/StepperErrorTolerances.hpp
@@ -1,0 +1,26 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <limits>
+
+/// \cond
+namespace PUP {
+class er;
+}  // namespace PUP
+/// \endcond
+
+/// \ingroup TimeGroup
+/// Tolerances used for time step error control
+struct StepperErrorTolerances {
+  double absolute = std::numeric_limits<double>::signaling_NaN();
+  double relative = std::numeric_limits<double>::signaling_NaN();
+
+  void pup(PUP::er& p);
+};
+
+bool operator==(const StepperErrorTolerances& a,
+                const StepperErrorTolerances& b);
+bool operator!=(const StepperErrorTolerances& a,
+                const StepperErrorTolerances& b);

--- a/src/Time/Tags/CMakeLists.txt
+++ b/src/Time/Tags/CMakeLists.txt
@@ -9,6 +9,7 @@ spectre_target_headers(
   HistoryEvolvedVariables.hpp
   IsUsingTimeSteppingErrorControl.hpp
   StepChoosers.hpp
+  StepperErrorTolerances.hpp
   StepperErrors.hpp
   Time.hpp
   TimeAndPrevious.hpp

--- a/src/Time/Tags/StepperErrorTolerances.hpp
+++ b/src/Time/Tags/StepperErrorTolerances.hpp
@@ -1,0 +1,25 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <optional>
+#include <string>
+
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/DataBox/TagName.hpp"
+#include "Time/StepperErrorTolerances.hpp"
+
+namespace Tags {
+/// \ingroup DataBoxTagsGroup
+/// \ingroup TimeGroup
+/// \brief Tag for the stepper error tolerances.
+template <typename Tag>
+struct StepperErrorTolerances : db::PrefixTag, db::SimpleTag {
+  static std::string name() {
+    return "StepperErrorTolerances(" + db::tag_name<Tag>() + ")";
+  }
+  using type = std::optional<::StepperErrorTolerances>;
+  using tag = Tag;
+};
+}  // namespace Tags

--- a/src/Time/Tags/StepperErrors.hpp
+++ b/src/Time/Tags/StepperErrors.hpp
@@ -20,8 +20,7 @@ struct StepperErrors : db::PrefixTag, db::SimpleTag {
   static std::string name() {
     return "StepperErrors(" + db::tag_name<Tag>() + ")";
   }
-  using type =
-      std::array<std::optional<StepperErrorEstimate<typename Tag::type>>, 2>;
+  using type = std::array<std::optional<StepperErrorEstimate>, 2>;
   using tag = Tag;
 };
 }  // namespace Tags

--- a/src/Time/TimeSteppers/AdamsBashforth.cpp
+++ b/src/Time/TimeSteppers/AdamsBashforth.cpp
@@ -63,8 +63,6 @@ AdamsBashforth::AdamsBashforth(const size_t order) : order_(order) {
 
 size_t AdamsBashforth::order() const { return order_; }
 
-size_t AdamsBashforth::error_estimate_order() const { return order_ - 1; }
-
 uint64_t AdamsBashforth::number_of_substeps() const { return 1; }
 
 uint64_t AdamsBashforth::number_of_substeps_for_error() const { return 1; }

--- a/src/Time/TimeSteppers/AdamsBashforth.cpp
+++ b/src/Time/TimeSteppers/AdamsBashforth.cpp
@@ -124,7 +124,7 @@ void AdamsBashforth::update_u_impl(const gsl::not_null<T*> u,
          << " step.  Have " << history.size() << " times, need "
          << history.integration_order());
   *u = *history.back().value;
-  update_u_common(u, history, time_step, history.integration_order());
+  update_u_common(u, history, time_step);
 }
 
 template <typename T>
@@ -137,12 +137,8 @@ bool AdamsBashforth::update_u_impl(const gsl::not_null<T*> u,
          << " step.  Have " << history.size() << " times, need "
          << history.integration_order());
   *u = *history.back().value;
-  update_u_common(u, history, time_step, history.integration_order());
-  // the error estimate is only useful once the history has enough elements to
-  // do more than one order of step
-  *u_error = *history.back().value;
-  update_u_common(u_error, history, time_step, history.integration_order() - 1);
-  *u_error = *u - *u_error;
+  update_u_common(u, history, time_step);
+  step_error(u_error, history, time_step);
   return true;
 }
 
@@ -163,18 +159,18 @@ bool AdamsBashforth::dense_update_u_impl(const gsl::not_null<T*> u,
                                          const double time) const {
   const ApproximateTimeDelta time_step{
       time - history.back().time_step_id.step_time().value()};
-  update_u_common(u, history, time_step, history.integration_order());
+  update_u_common(u, history, time_step);
   return true;
 }
 
 template <typename T, typename Delta>
 void AdamsBashforth::update_u_common(const gsl::not_null<T*> u,
                                      const ConstUntypedHistory<T>& history,
-                                     const Delta& time_step,
-                                     const size_t order) const {
+                                     const Delta& time_step) const {
   ASSERT(
       history.size() > 0,
       "Cannot meaningfully update the evolved variables with an empty history");
+  const auto order = history.integration_order();
   ASSERT(order <= order_,
          "Requested integration order higher than integrator order");
 
@@ -192,6 +188,47 @@ void AdamsBashforth::update_u_common(const gsl::not_null<T*> u,
        history_entry != history.end();
        ++history_entry, ++coefficient) {
     *u += *coefficient * history_entry->derivative;
+  }
+}
+
+template <typename T>
+void AdamsBashforth::step_error(const gsl::not_null<T*> u_error,
+                                const ConstUntypedHistory<T>& history,
+                                const TimeDelta& time_step) const {
+  ASSERT(
+      history.size() > 0,
+      "Cannot meaningfully update the evolved variables with an empty history");
+  const auto order = history.integration_order();
+  ASSERT(order <= order_,
+         "Requested integration order higher than integrator order");
+
+  const auto history_start =
+      history.end() -
+      static_cast<typename ConstUntypedHistory<T>::difference_type>(order);
+  auto coefficients = adams_coefficients::coefficients(
+      history_time_iterator(history_start),
+      history_time_iterator(history.end()),
+      history.back().time_step_id.step_time(),
+      history.back().time_step_id.step_time() + time_step);
+  const auto lower_order_coefficients = adams_coefficients::coefficients(
+      history_time_iterator(history_start + 1),
+      history_time_iterator(history.end()),
+      history.back().time_step_id.step_time(),
+      history.back().time_step_id.step_time() + time_step);
+  for (size_t i = 0; i < lower_order_coefficients.size(); ++i) {
+    coefficients[i + 1] -= lower_order_coefficients[i];
+  }
+
+  auto coefficient = coefficients.begin();
+  auto history_entry = history_start;
+  *u_error = *coefficient * history_entry->derivative;
+  for (;;) {
+    ++history_entry;
+    ++coefficient;
+    if (history_entry == history.end()) {
+      return;
+    }
+    *u_error += *coefficient * history_entry->derivative;
   }
 }
 

--- a/src/Time/TimeSteppers/AdamsBashforth.hpp
+++ b/src/Time/TimeSteppers/AdamsBashforth.hpp
@@ -5,14 +5,17 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <optional>
 
 #include "Options/String.hpp"
+#include "Time/StepperErrorEstimate.hpp"
 #include "Time/TimeStepId.hpp"
 #include "Time/TimeSteppers/LtsTimeStepper.hpp"
 #include "Utilities/Serialization/CharmPupable.hpp"
 #include "Utilities/TMPL.hpp"
 
 /// \cond
+struct StepperErrorTolerances;
 class TimeDelta;
 namespace PUP {
 class er;
@@ -262,9 +265,10 @@ class AdamsBashforth : public LtsTimeStepper {
                      const TimeDelta& time_step) const;
 
   template <typename T>
-  bool update_u_impl(gsl::not_null<T*> u, gsl::not_null<T*> u_error,
-                     const ConstUntypedHistory<T>& history,
-                     const TimeDelta& time_step) const;
+  std::optional<StepperErrorEstimate> update_u_impl(
+      gsl::not_null<T*> u, const ConstUntypedHistory<T>& history,
+      const TimeDelta& time_step,
+      const std::optional<StepperErrorTolerances>& tolerances) const;
 
   template <typename T>
   void clean_history_impl(const MutableUntypedHistory<T>& history) const;

--- a/src/Time/TimeSteppers/AdamsBashforth.hpp
+++ b/src/Time/TimeSteppers/AdamsBashforth.hpp
@@ -277,7 +277,12 @@ class AdamsBashforth : public LtsTimeStepper {
   template <typename T, typename Delta>
   void update_u_common(gsl::not_null<T*> u,
                        const ConstUntypedHistory<T>& history,
-                       const Delta& time_step, size_t order) const;
+                       const Delta& time_step) const;
+
+  template <typename T>
+  void step_error(gsl::not_null<T*> u_error,
+                  const ConstUntypedHistory<T>& history,
+                  const TimeDelta& time_step) const;
 
   template <typename T>
   bool can_change_step_size_impl(const TimeStepId& time_id,

--- a/src/Time/TimeSteppers/AdamsBashforth.hpp
+++ b/src/Time/TimeSteppers/AdamsBashforth.hpp
@@ -218,8 +218,6 @@ class AdamsBashforth : public LtsTimeStepper {
 
   size_t order() const override;
 
-  size_t error_estimate_order() const override;
-
   uint64_t number_of_substeps() const override;
 
   uint64_t number_of_substeps_for_error() const override;

--- a/src/Time/TimeSteppers/AdamsMoultonPc.cpp
+++ b/src/Time/TimeSteppers/AdamsMoultonPc.cpp
@@ -31,8 +31,8 @@ namespace {
 template <typename T, typename TimeType>
 void update_u_common(const gsl::not_null<T*> u,
                      const ConstUntypedHistory<T>& history,
-                     const TimeType& step_end, const size_t method_order,
-                     const bool corrector) {
+                     const TimeType& step_end, const bool corrector) {
+  const auto method_order = history.integration_order();
   ASSERT(history.size() >= method_order - 1, "Insufficient history");
   // Pass in whether to run the predictor or corrector even though we
   // can compute it as a sanity check.
@@ -65,6 +65,45 @@ void update_u_common(const gsl::not_null<T*> u,
   }
   if (corrector) {
     *u += coefficients.back() * history.substeps().front().derivative;
+  }
+}
+
+template <typename T>
+void step_error(const gsl::not_null<T*> u_error,
+                const ConstUntypedHistory<T>& history, const Time& step_end) {
+  const auto method_order = history.integration_order();
+  ASSERT(history.size() >= method_order - 1, "Insufficient history");
+  ASSERT(not history.substeps().empty(),
+         "step_error called without substep data.");
+  ASSERT(not history.at_step_start(), "Unexpected new data");
+
+  const auto used_history_begin =
+      history.end() -
+      static_cast<typename ConstUntypedHistory<T>::difference_type>(
+          method_order - 1);
+  adams_coefficients::OrderVector<Time> control_times{};
+  std::transform(used_history_begin, history.end(),
+                 std::back_inserter(control_times),
+                 [](const auto& r) { return r.time_step_id.step_time(); });
+  control_times.push_back(history.back().time_step_id.step_time() +
+                          history.substeps().front().time_step_id.step_size());
+  auto coefficients = adams_coefficients::coefficients(
+      control_times.begin(), control_times.end(),
+      history.back().time_step_id.step_time(), step_end);
+  control_times.erase(control_times.begin());
+  const auto lower_order_coefficients = adams_coefficients::coefficients(
+      control_times.begin(), control_times.end(),
+      history.back().time_step_id.step_time(), step_end);
+  for (size_t i = 0; i < lower_order_coefficients.size(); ++i) {
+    coefficients[i + 1] -= lower_order_coefficients[i];
+  }
+
+  *u_error = coefficients.back() * history.substeps().front().derivative;
+  auto coefficient = coefficients.begin();
+  for (auto history_entry = used_history_begin;
+       history_entry != history.end();
+       ++history_entry, ++coefficient) {
+    *u_error += *coefficient * history_entry->derivative;
   }
 }
 }  // namespace
@@ -203,8 +242,7 @@ void AdamsMoultonPc<Monotonic>::update_u_impl(
     const TimeDelta& time_step) const {
   const Time next_time = history.back().time_step_id.step_time() + time_step;
   *u = *history.back().value;
-  update_u_common(u, history, next_time, history.integration_order(),
-                  not history.at_step_start());
+  update_u_common(u, history, next_time, not history.at_step_start());
 }
 
 template <bool Monotonic>
@@ -215,15 +253,11 @@ bool AdamsMoultonPc<Monotonic>::update_u_impl(
   const bool predictor = history.at_step_start();
   const Time next_time = history.back().time_step_id.step_time() + time_step;
   *u = *history.back().value;
-  update_u_common(u, history, next_time, history.integration_order(),
-                  not predictor);
+  update_u_common(u, history, next_time, not predictor);
   if (predictor) {
     return false;
   }
-  *u_error = *history.back().value;
-  update_u_common(u_error, history, next_time, history.integration_order() - 1,
-                  true);
-  *u_error = *u - *u_error;
+  step_error(u_error, history, next_time);
   return true;
 }
 
@@ -257,15 +291,13 @@ bool AdamsMoultonPc<Monotonic>::dense_update_u_impl(
     if (not history.at_step_start()) {
       return false;
     }
-    update_u_common(u, history, ApproximateTime{time},
-                    history.integration_order(), false);
+    update_u_common(u, history, ApproximateTime{time}, false);
     return true;
   } else {
     if (history.at_step_start()) {
       return false;
     }
-    update_u_common(u, history, ApproximateTime{time},
-                    history.integration_order(), true);
+    update_u_common(u, history, ApproximateTime{time}, true);
     return true;
   }
 }

--- a/src/Time/TimeSteppers/AdamsMoultonPc.cpp
+++ b/src/Time/TimeSteppers/AdamsMoultonPc.cpp
@@ -124,11 +124,6 @@ size_t AdamsMoultonPc<Monotonic>::order() const {
 }
 
 template <bool Monotonic>
-size_t AdamsMoultonPc<Monotonic>::error_estimate_order() const {
-  return order_ - 1;
-}
-
-template <bool Monotonic>
 uint64_t AdamsMoultonPc<Monotonic>::number_of_substeps() const {
   return 2;
 }

--- a/src/Time/TimeSteppers/AdamsMoultonPc.hpp
+++ b/src/Time/TimeSteppers/AdamsMoultonPc.hpp
@@ -123,8 +123,6 @@ class AdamsMoultonPc : public LtsTimeStepper {
 
   size_t order() const override;
 
-  size_t error_estimate_order() const override;
-
   uint64_t number_of_substeps() const override;
 
   uint64_t number_of_substeps_for_error() const override;

--- a/src/Time/TimeSteppers/AdamsMoultonPc.hpp
+++ b/src/Time/TimeSteppers/AdamsMoultonPc.hpp
@@ -5,16 +5,19 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <optional>
 #include <pup.h>
 #include <string>
 
 #include "Options/String.hpp"
+#include "Time/StepperErrorEstimate.hpp"
 #include "Time/TimeSteppers/LtsTimeStepper.hpp"
 #include "Time/TimeSteppers/TimeStepper.hpp"
 #include "Utilities/Serialization/CharmPupable.hpp"
 #include "Utilities/TMPL.hpp"
 
 /// \cond
+struct StepperErrorTolerances;
 class TimeDelta;
 class TimeStepId;
 namespace PUP {
@@ -158,9 +161,10 @@ class AdamsMoultonPc : public LtsTimeStepper {
                      const TimeDelta& time_step) const;
 
   template <typename T>
-  bool update_u_impl(gsl::not_null<T*> u, gsl::not_null<T*> u_error,
-                     const ConstUntypedHistory<T>& history,
-                     const TimeDelta& time_step) const;
+  std::optional<StepperErrorEstimate> update_u_impl(
+      gsl::not_null<T*> u, const ConstUntypedHistory<T>& history,
+      const TimeDelta& time_step,
+      const std::optional<StepperErrorTolerances>& tolerances) const;
 
   template <typename T>
   void clean_history_impl(const MutableUntypedHistory<T>& history) const;

--- a/src/Time/TimeSteppers/ClassicalRungeKutta4.cpp
+++ b/src/Time/TimeSteppers/ClassicalRungeKutta4.cpp
@@ -9,8 +9,6 @@ namespace TimeSteppers {
 
 size_t ClassicalRungeKutta4::order() const { return 4; }
 
-size_t ClassicalRungeKutta4::error_estimate_order() const { return 3; }
-
 // The growth function for RK4 is (e.g. page 60 of
 // http://www.staff.science.uu.nl/~frank011/Classes/numwisk/ch10.pdf
 //

--- a/src/Time/TimeSteppers/ClassicalRungeKutta4.hpp
+++ b/src/Time/TimeSteppers/ClassicalRungeKutta4.hpp
@@ -61,8 +61,6 @@ class ClassicalRungeKutta4 : public RungeKutta {
 
   size_t order() const override;
 
-  size_t error_estimate_order() const override;
-
   double stable_step() const override;
 
   WRAPPED_PUPable_decl_template(ClassicalRungeKutta4);  // NOLINT

--- a/src/Time/TimeSteppers/DormandPrince5.cpp
+++ b/src/Time/TimeSteppers/DormandPrince5.cpp
@@ -7,8 +7,6 @@ namespace TimeSteppers {
 
 size_t DormandPrince5::order() const { return 5; }
 
-size_t DormandPrince5::error_estimate_order() const { return 4; }
-
 // The growth function for DP5 is
 //
 //   g = mu^6 / 600 + \sum_{n=0}^5 mu^n / n!,

--- a/src/Time/TimeSteppers/DormandPrince5.hpp
+++ b/src/Time/TimeSteppers/DormandPrince5.hpp
@@ -55,8 +55,6 @@ class DormandPrince5 : public RungeKutta {
 
   size_t order() const override;
 
-  size_t error_estimate_order() const override;
-
   double stable_step() const override;
 
   WRAPPED_PUPable_decl_template(DormandPrince5);  // NOLINT

--- a/src/Time/TimeSteppers/Heun2.cpp
+++ b/src/Time/TimeSteppers/Heun2.cpp
@@ -7,8 +7,6 @@ namespace TimeSteppers {
 
 size_t Heun2::order() const { return 2; }
 
-size_t Heun2::error_estimate_order() const { return 1; }
-
 // The stability polynomial is
 //
 //   p(z) = \sum_{n=0}^{stages-1} alpha_n z^n / n!,

--- a/src/Time/TimeSteppers/Heun2.hpp
+++ b/src/Time/TimeSteppers/Heun2.hpp
@@ -53,8 +53,6 @@ class Heun2 : public ImexRungeKutta {
 
   size_t order() const override;
 
-  size_t error_estimate_order() const override;
-
   double stable_step() const override;
 
   size_t imex_order() const override;

--- a/src/Time/TimeSteppers/Rk3HesthavenSsp.cpp
+++ b/src/Time/TimeSteppers/Rk3HesthavenSsp.cpp
@@ -20,8 +20,6 @@ namespace TimeSteppers {
 
 size_t Rk3HesthavenSsp::order() const { return 3; }
 
-size_t Rk3HesthavenSsp::error_estimate_order() const { return 2; }
-
 double Rk3HesthavenSsp::stable_step() const {
   // This is the condition for  y' = -k y  to go to zero.
   return 0.5 * (1. + cbrt(4. + sqrt(17.)) - 1. / cbrt(4. + sqrt(17.)));
@@ -100,8 +98,7 @@ std::optional<StepperErrorEstimate> Rk3HesthavenSsp::update_u_impl(
          0.5 * *history.substeps()[0].value -
          0.5 * time_step.value() * history.substeps()[0].derivative;
     error.emplace(StepperErrorEstimate{
-        history.back().time_step_id.step_time(), time_step,
-        error_estimate_order(),
+        history.back().time_step_id.step_time(), time_step, 2,
         largest_stepper_error(*history.back().value, *u, *tolerances)});
   }
 

--- a/src/Time/TimeSteppers/Rk3HesthavenSsp.cpp
+++ b/src/Time/TimeSteppers/Rk3HesthavenSsp.cpp
@@ -93,8 +93,12 @@ bool Rk3HesthavenSsp::update_u_impl(const gsl::not_null<T*> u,
     return false;
   }
 
-  *u_error = *u - 0.5 * (*history.back().value + *history.substeps()[0].value +
-                         time_step.value() * history.substeps()[0].derivative);
+  *u_error =
+      -(1.0 / 6.0) * *history.back().value +
+      (2.0 / 3.0) * *history.substeps()[1].value +
+      (2.0 / 3.0) * time_step.value() * history.substeps()[1].derivative -
+      0.5 * *history.substeps()[0].value -
+      0.5 * time_step.value() * history.substeps()[0].derivative;
 
   return true;
 }

--- a/src/Time/TimeSteppers/Rk3HesthavenSsp.hpp
+++ b/src/Time/TimeSteppers/Rk3HesthavenSsp.hpp
@@ -58,8 +58,6 @@ class Rk3HesthavenSsp : public TimeStepper {
 
   size_t order() const override;
 
-  size_t error_estimate_order() const override;
-
   double stable_step() const override;
 
   bool monotonic() const override;

--- a/src/Time/TimeSteppers/Rk3HesthavenSsp.hpp
+++ b/src/Time/TimeSteppers/Rk3HesthavenSsp.hpp
@@ -5,8 +5,10 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <optional>
 
 #include "Options/String.hpp"
+#include "Time/StepperErrorEstimate.hpp"
 #include "Time/TimeStepId.hpp"
 #include "Time/TimeSteppers/TimeStepper.hpp"
 #include "Utilities/Gsl.hpp"
@@ -14,6 +16,7 @@
 #include "Utilities/TMPL.hpp"
 
 /// \cond
+struct StepperErrorTolerances;
 class TimeDelta;
 namespace TimeSteppers {
 template <typename T>
@@ -79,9 +82,10 @@ class Rk3HesthavenSsp : public TimeStepper {
                      const TimeDelta& time_step) const;
 
   template <typename T>
-  bool update_u_impl(gsl::not_null<T*> u, gsl::not_null<T*> u_error,
-                     const ConstUntypedHistory<T>& history,
-                     const TimeDelta& time_step) const;
+  std::optional<StepperErrorEstimate> update_u_impl(
+      gsl::not_null<T*> u, const ConstUntypedHistory<T>& history,
+      const TimeDelta& time_step,
+      const std::optional<StepperErrorTolerances>& tolerances) const;
 
   template <typename T>
   void clean_history_impl(const MutableUntypedHistory<T>& history) const;

--- a/src/Time/TimeSteppers/Rk3Kennedy.cpp
+++ b/src/Time/TimeSteppers/Rk3Kennedy.cpp
@@ -7,8 +7,6 @@ namespace TimeSteppers {
 
 size_t Rk3Kennedy::order() const { return 3; }
 
-size_t Rk3Kennedy::error_estimate_order() const { return 2; }
-
 double Rk3Kennedy::stable_step() const { return 1.832102281377816; }
 
 size_t Rk3Kennedy::imex_order() const { return 3; }

--- a/src/Time/TimeSteppers/Rk3Kennedy.hpp
+++ b/src/Time/TimeSteppers/Rk3Kennedy.hpp
@@ -36,8 +36,6 @@ class Rk3Kennedy : public ImexRungeKutta {
 
   size_t order() const override;
 
-  size_t error_estimate_order() const override;
-
   double stable_step() const override;
 
   size_t imex_order() const override;

--- a/src/Time/TimeSteppers/Rk3Owren.cpp
+++ b/src/Time/TimeSteppers/Rk3Owren.cpp
@@ -7,8 +7,6 @@ namespace TimeSteppers {
 
 size_t Rk3Owren::order() const { return 3; }
 
-size_t Rk3Owren::error_estimate_order() const { return 2; }
-
 // The stability polynomial is
 //
 //   p(z) = \sum_{n=0}^{stages-1} alpha_n z^n / n!,

--- a/src/Time/TimeSteppers/Rk3Owren.hpp
+++ b/src/Time/TimeSteppers/Rk3Owren.hpp
@@ -51,8 +51,6 @@ class Rk3Owren : public RungeKutta {
 
   size_t order() const override;
 
-  size_t error_estimate_order() const override;
-
   double stable_step() const override;
 
   WRAPPED_PUPable_decl_template(Rk3Owren);  // NOLINT

--- a/src/Time/TimeSteppers/Rk3Pareschi.cpp
+++ b/src/Time/TimeSteppers/Rk3Pareschi.cpp
@@ -7,8 +7,6 @@ namespace TimeSteppers {
 
 size_t Rk3Pareschi::order() const { return 3; }
 
-size_t Rk3Pareschi::error_estimate_order() const { return 2; }
-
 double Rk3Pareschi::stable_step() const { return 1.25637; }
 
 size_t Rk3Pareschi::imex_order() const { return 3; }

--- a/src/Time/TimeSteppers/Rk3Pareschi.hpp
+++ b/src/Time/TimeSteppers/Rk3Pareschi.hpp
@@ -49,8 +49,6 @@ class Rk3Pareschi : public ImexRungeKutta {
 
   size_t order() const override;
 
-  size_t error_estimate_order() const override;
-
   double stable_step() const override;
 
   size_t imex_order() const override;

--- a/src/Time/TimeSteppers/Rk4Kennedy.cpp
+++ b/src/Time/TimeSteppers/Rk4Kennedy.cpp
@@ -7,8 +7,6 @@ namespace TimeSteppers {
 
 size_t Rk4Kennedy::order() const { return 4; }
 
-size_t Rk4Kennedy::error_estimate_order() const { return 3; }
-
 double Rk4Kennedy::stable_step() const { return 2.1172491998184686; }
 
 size_t Rk4Kennedy::imex_order() const { return 4; }

--- a/src/Time/TimeSteppers/Rk4Kennedy.hpp
+++ b/src/Time/TimeSteppers/Rk4Kennedy.hpp
@@ -36,8 +36,6 @@ class Rk4Kennedy : public ImexRungeKutta {
 
   size_t order() const override;
 
-  size_t error_estimate_order() const override;
-
   double stable_step() const override;
 
   size_t imex_order() const override;

--- a/src/Time/TimeSteppers/Rk4Owren.cpp
+++ b/src/Time/TimeSteppers/Rk4Owren.cpp
@@ -8,8 +8,6 @@ Rk4Owren::Rk4Owren(CkMigrateMessage* /*msg*/) {}
 
 size_t Rk4Owren::order() const { return 4; }
 
-size_t Rk4Owren::error_estimate_order() const { return 3; }
-
 // The stability polynomial is
 //
 //   p(z) = \sum_{n=0}^{stages-1} alpha_n z^n / n!,

--- a/src/Time/TimeSteppers/Rk4Owren.hpp
+++ b/src/Time/TimeSteppers/Rk4Owren.hpp
@@ -51,8 +51,6 @@ class Rk4Owren : public RungeKutta {
 
   size_t order() const override;
 
-  size_t error_estimate_order() const override;
-
   double stable_step() const override;
 
   WRAPPED_PUPable_decl_template(Rk4Owren);  // NOLINT

--- a/src/Time/TimeSteppers/Rk5Owren.cpp
+++ b/src/Time/TimeSteppers/Rk5Owren.cpp
@@ -8,8 +8,6 @@ Rk5Owren::Rk5Owren(CkMigrateMessage* /*msg*/) {}
 
 size_t Rk5Owren::order() const { return 5; }
 
-size_t Rk5Owren::error_estimate_order() const { return 4; }
-
 // The stability polynomial is
 //
 //   p(z) = \sum_{n=0}^{stages-1} alpha_n z^n / n!,

--- a/src/Time/TimeSteppers/Rk5Owren.hpp
+++ b/src/Time/TimeSteppers/Rk5Owren.hpp
@@ -51,8 +51,6 @@ class Rk5Owren : public RungeKutta {
 
   size_t order() const override;
 
-  size_t error_estimate_order() const override;
-
   double stable_step() const override;
 
   WRAPPED_PUPable_decl_template(Rk5Owren);  // NOLINT

--- a/src/Time/TimeSteppers/Rk5Tsitouras.cpp
+++ b/src/Time/TimeSteppers/Rk5Tsitouras.cpp
@@ -8,8 +8,6 @@ Rk5Tsitouras::Rk5Tsitouras(CkMigrateMessage* /*msg*/) {}
 
 size_t Rk5Tsitouras::order() const { return 5; }
 
-size_t Rk5Tsitouras::error_estimate_order() const { return 4; }
-
 double Rk5Tsitouras::stable_step() const { return 1.7534234969024887; }
 
 const RungeKutta::ButcherTableau& Rk5Tsitouras::butcher_tableau() const {

--- a/src/Time/TimeSteppers/Rk5Tsitouras.hpp
+++ b/src/Time/TimeSteppers/Rk5Tsitouras.hpp
@@ -35,8 +35,6 @@ class Rk5Tsitouras : public RungeKutta {
 
   size_t order() const override;
 
-  size_t error_estimate_order() const override;
-
   double stable_step() const override;
 
   WRAPPED_PUPable_decl_template(Rk5Tsitouras);  // NOLINT

--- a/src/Time/TimeSteppers/RungeKutta.cpp
+++ b/src/Time/TimeSteppers/RungeKutta.cpp
@@ -151,8 +151,7 @@ std::optional<StepperErrorEstimate> RungeKutta::update_u_impl(
     const double dt = time_step.value();
     step_error(u, history, dt, tableau);
     error.emplace(StepperErrorEstimate{
-        history.back().time_step_id.step_time(), time_step,
-        error_estimate_order(),
+        history.back().time_step_id.step_time(), time_step, order() - 1,
         largest_stepper_error(*history.back().value, *u, *tolerances)});
   }
 

--- a/src/Time/TimeSteppers/RungeKutta.hpp
+++ b/src/Time/TimeSteppers/RungeKutta.hpp
@@ -31,10 +31,10 @@ namespace TimeSteppers {
  *
  * Implements most of the virtual methods of TimeStepper for a generic
  * Runge-Kutta method.  From the TimeStepper interface, derived
- * classes need only implement `order`, `error_estimate_order`, and
- * `stable_step`, and should not include the `TIME_STEPPER_*` macros.
- * All other methods are implemented in terms of a Butcher tableau
- * returned by the `butcher_tableau` function.
+ * classes need only implement `order` and `stable_step`, and should
+ * not include the `TIME_STEPPER_*` macros.  All other methods are
+ * implemented in terms of a Butcher tableau returned by the
+ * `butcher_tableau` function.
  */
 class RungeKutta : public virtual TimeStepper {
  public:
@@ -61,7 +61,8 @@ class RungeKutta : public virtual TimeStepper {
     std::vector<double> result_coefficients;
     /*!
      * The coefficients for an error estimate.  Often called
-     * \f$b^*\f$ or \f$\hat{b}\f$ in the literature.
+     * \f$b^*\f$ or \f$\hat{b}\f$ in the literature.  This is assumed
+     * to be one order less accurate than the main method.
      */
     std::vector<double> error_coefficients;
     /*!

--- a/src/Time/TimeSteppers/RungeKutta.hpp
+++ b/src/Time/TimeSteppers/RungeKutta.hpp
@@ -5,13 +5,16 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <optional>
 #include <vector>
 
+#include "Time/StepperErrorEstimate.hpp"
 #include "Time/TimeStepId.hpp"
 #include "Time/TimeSteppers/TimeStepper.hpp"
 #include "Utilities/Gsl.hpp"
 
 /// \cond
+struct StepperErrorTolerances;
 class TimeDelta;
 namespace TimeSteppers {
 template <typename T>
@@ -100,9 +103,10 @@ class RungeKutta : public virtual TimeStepper {
                      const TimeDelta& time_step) const;
 
   template <typename T>
-  bool update_u_impl(gsl::not_null<T*> u, gsl::not_null<T*> u_error,
-                     const ConstUntypedHistory<T>& history,
-                     const TimeDelta& time_step) const;
+  std::optional<StepperErrorEstimate> update_u_impl(
+      gsl::not_null<T*> u, const ConstUntypedHistory<T>& history,
+      const TimeDelta& time_step,
+      const std::optional<StepperErrorTolerances>& tolerances) const;
 
   template <typename T>
   void clean_history_impl(const MutableUntypedHistory<T>& history) const;

--- a/src/Time/TimeSteppers/TimeStepper.hpp
+++ b/src/Time/TimeSteppers/TimeStepper.hpp
@@ -183,9 +183,6 @@ class TimeStepper : public PUP::able {
   /// The convergence order of the stepper
   virtual size_t order() const = 0;
 
-  /// The convergence order of the stepper error measure
-  virtual size_t error_estimate_order() const = 0;
-
   /// Number of substeps in this TimeStepper
   virtual uint64_t number_of_substeps() const = 0;
 

--- a/tests/Unit/Helpers/Time/TimeSteppers/RungeKutta.cpp
+++ b/tests/Unit/Helpers/Time/TimeSteppers/RungeKutta.cpp
@@ -44,8 +44,7 @@ void check_quadrature_order(const std::vector<double>& substep_times,
 }  // namespace
 
 void check_tableau(const TimeSteppers::RungeKutta::ButcherTableau& tableau,
-                   const size_t expected_order,
-                   const size_t expected_error_order) {
+                   const size_t expected_order) {
   INFO("check_tableau");
   const auto& substep_times = tableau.substep_times;
   const auto& substep_coefficients = tableau.substep_coefficients;
@@ -97,12 +96,11 @@ void check_tableau(const TimeSteppers::RungeKutta::ButcherTableau& tableau,
   check_quadrature_order(substep_times, result_coefficients, 1.0,
                          expected_order);
   check_quadrature_order(substep_times, error_coefficients, 1.0,
-                         expected_error_order);
+                         expected_order - 1);
 }
 
 void check_tableau(const TimeSteppers::RungeKutta& stepper) {
-  check_tableau(stepper.butcher_tableau(), stepper.order(),
-                stepper.error_estimate_order());
+  check_tableau(stepper.butcher_tableau(), stepper.order());
 }
 
 void check_implicit_tableau(

--- a/tests/Unit/Helpers/Time/TimeSteppers/RungeKutta.hpp
+++ b/tests/Unit/Helpers/Time/TimeSteppers/RungeKutta.hpp
@@ -11,7 +11,7 @@
 namespace TestHelpers::RungeKutta {
 /// Sanity-check a Butcher tableau
 void check_tableau(const TimeSteppers::RungeKutta::ButcherTableau& tableau,
-                   size_t expected_order, size_t expected_error_order);
+                   size_t expected_order);
 /// Convenience wrapper for the previous function
 void check_tableau(const TimeSteppers::RungeKutta& stepper);
 

--- a/tests/Unit/Time/CMakeLists.txt
+++ b/tests/Unit/Time/CMakeLists.txt
@@ -10,6 +10,7 @@ set(LIBRARY_SOURCES
   Test_ChooseLtsStepSize.cpp
   Test_EvolutionOrdering.cpp
   Test_History.cpp
+  Test_LargestStepperError.cpp
   Test_SelfStart.cpp
   Test_Slab.cpp
   Test_StepperErrorTolerances.cpp

--- a/tests/Unit/Time/CMakeLists.txt
+++ b/tests/Unit/Time/CMakeLists.txt
@@ -12,6 +12,7 @@ set(LIBRARY_SOURCES
   Test_History.cpp
   Test_SelfStart.cpp
   Test_Slab.cpp
+  Test_StepperErrorTolerances.cpp
   Test_TakeStep.cpp
   Test_Time.cpp
   Test_TimeSequence.cpp

--- a/tests/Unit/Time/StepChoosers/Test_ErrorControl.cpp
+++ b/tests/Unit/Time/StepChoosers/Test_ErrorControl.cpp
@@ -3,47 +3,49 @@
 
 #include "Framework/TestingFramework.hpp"
 
+#include <array>
+#include <cmath>
 #include <cstddef>
 #include <limits>
 #include <memory>
+#include <optional>
 #include <string>
 #include <utility>
+#include <vector>
 
 #include "DataStructures/DataBox/DataBox.hpp"
-#include "DataStructures/DataBox/PrefixHelpers.hpp"
-#include "DataStructures/DataBox/Prefixes.hpp"
-#include "DataStructures/DataVector.hpp"
-#include "DataStructures/Tensor/Tensor.hpp"
-#include "DataStructures/Variables.hpp"
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
 #include "DataStructures/VariablesTag.hpp"
-#include "Domain/Tags.hpp"
 #include "Framework/TestCreation.hpp"
 #include "Framework/TestHelpers.hpp"
 #include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
-#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
 #include "Options/Protocols/FactoryCreation.hpp"
+#include "Parallel/Tags/Metavariables.hpp"
 #include "ParallelAlgorithms/EventsAndTriggers/Completion.hpp"
 #include "ParallelAlgorithms/EventsAndTriggers/Event.hpp"
 #include "ParallelAlgorithms/EventsAndTriggers/LogicalTriggers.hpp"
 #include "ParallelAlgorithms/EventsAndTriggers/Tags.hpp"
 #include "ParallelAlgorithms/EventsAndTriggers/Trigger.hpp"
 #include "Time/ChangeSlabSize/Event.hpp"
-#include "Time/History.hpp"
+#include "Time/Slab.hpp"
 #include "Time/StepChoosers/Constant.hpp"
 #include "Time/StepChoosers/ErrorControl.hpp"
 #include "Time/StepChoosers/Increase.hpp"
-#include "Time/StepChoosers/PreventRapidIncrease.hpp"
 #include "Time/StepChoosers/StepChooser.hpp"
-#include "Time/Tags/HistoryEvolvedVariables.hpp"
+#include "Time/StepperErrorEstimate.hpp"
+#include "Time/StepperErrorTolerances.hpp"
 #include "Time/Tags/IsUsingTimeSteppingErrorControl.hpp"
 #include "Time/Tags/StepChoosers.hpp"
 #include "Time/Tags/StepperErrorTolerances.hpp"
 #include "Time/Tags/StepperErrors.hpp"
-#include "Time/TimeStepId.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/Literals.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/Serialization/RegisterDerivedClassesWithCharm.hpp"
 #include "Utilities/TMPL.hpp"
+
+class DataVector;
 
 namespace {
 struct EvolvedVar1 : db::SimpleTag {
@@ -73,8 +75,7 @@ template <bool WithErrorControl, bool WithAltErrorControl = false>
 struct Metavariables {
   template <typename Use>
   using step_choosers_without_error_control =
-      tmpl::list<StepChoosers::Increase<Use>, StepChoosers::Constant<Use>,
-                 StepChoosers::PreventRapidIncrease<Use>>;
+      tmpl::list<StepChoosers::Increase<Use>, StepChoosers::Constant<Use>>;
   template <typename Use>
   using step_choosers = tmpl::append<
       step_choosers_without_error_control<Use>,
@@ -106,33 +107,24 @@ struct Metavariables {
 using LtsErrorControl =
     StepChoosers::ErrorControl<StepChooserUse::LtsStep, EvolvedVariablesTag>;
 
-template <typename EvolvedTags>
 std::pair<double, bool> get_suggestion(
     const LtsErrorControl& error_control,
-    const Variables<EvolvedTags>& step_values,
-    const std::optional<StepperErrorEstimate<Variables<EvolvedTags>>>& error,
-    const std::optional<StepperErrorEstimate<Variables<EvolvedTags>>>&
-        previous_error,
-    const double previous_step, const size_t stepper_order) {
-  TimeSteppers::History<Variables<EvolvedTags>> history{stepper_order};
-  history.insert(TimeStepId{true, 0, {{0.0, 1.0}, {0, 1}}}, step_values,
-                 0.1 * step_values);
-  history.discard_value(TimeStepId{true, 0, {{0.0, 1.0}, {0, 1}}});
+    const std::optional<StepperErrorEstimate>& error,
+    const std::optional<StepperErrorEstimate>& previous_error,
+    const double previous_step) {
   auto box = db::create<
       db::AddSimpleTags<Parallel::Tags::MetavariablesImpl<Metavariables<true>>,
-                        Tags::HistoryEvolvedVariables<EvolvedVariablesTag>,
                         Tags::StepperErrors<EvolvedVariablesTag>>>(
-      Metavariables<true>{}, history, std::array{previous_error, error});
+      Metavariables<true>{}, std::array{previous_error, error});
 
   const std::unique_ptr<StepChooser<StepChooserUse::LtsStep>>
       error_control_base = std::make_unique<LtsErrorControl>(error_control);
 
   const std::pair<double, bool> result =
-      error_control(history, std::array{previous_error, error}, previous_step);
+      error_control(std::array{previous_error, error}, previous_step);
   CHECK(error_control_base->desired_step(previous_step, box) == result);
   CHECK(serialize_and_deserialize(error_control)(
-            history, std::array{previous_error, error}, previous_step) ==
-        result);
+            std::array{previous_error, error}, previous_step) == result);
   CHECK(serialize_and_deserialize(error_control_base)
             ->desired_step(previous_step, box) == result);
   return result;
@@ -142,121 +134,64 @@ std::pair<double, bool> get_suggestion(
 SPECTRE_TEST_CASE("Unit.Time.StepChoosers.ErrorControl", "[Unit][Time]") {
   register_factory_classes_with_charm<Metavariables<true>>();
 
-  MAKE_GENERATOR(generator);
-  std::uniform_real_distribution<> step_dist{1.0, 2.0};
-  Variables<tmpl::list<EvolvedVar1, EvolvedVar2>> step_values{5};
-  fill_with_random_values(make_not_null(&step_values),
-                          make_not_null(&generator), make_not_null(&step_dist));
-  const DataVector flattened_step_values{step_values.data(), 15};
-  std::uniform_real_distribution<> error_dist{1.0e-4, 2.0e-4};
-  Variables<tmpl::list<EvolvedVar1, EvolvedVar2>> step_error_data{5};
-  fill_with_random_values(make_not_null(&step_error_data),
-                          make_not_null(&generator),
-                          make_not_null(&error_dist));
-  const DataVector flattened_step_errors{step_error_data.data(), 15};
   const std::vector<size_t> stepper_orders{2_st, 5_st};
   for (const bool time_runs_forward : {true, false}) {
     for (size_t stepper_order : stepper_orders) {
       CAPTURE(stepper_order);
-      const auto step_errors = [&](const double error_time,
-                                   const double error_multiplier = 1.0,
+      const auto step_errors = [&](const double error_time, const double error,
                                    const double step_size = 1.0) {
         const auto error_slab = time_runs_forward
                                     ? Slab(error_time, error_time + step_size)
                                     : Slab(error_time - step_size, error_time);
-        return StepperErrorEstimate<decltype(step_error_data)>{
+        return StepperErrorEstimate{
             time_runs_forward ? error_slab.start() : error_slab.end(),
             (time_runs_forward ? 1 : -1) * error_slab.duration(),
-            stepper_order - 1, step_error_data * error_multiplier};
+            stepper_order - 1, error};
       };
 
       {
         INFO("No data available");
         const LtsErrorControl error_control{5.0e-4, 0.0, 2.0, 0.5, 0.95};
-        const auto result = get_suggestion(error_control, step_values, {}, {},
-                                           1.0, stepper_order);
+        const auto result = get_suggestion(error_control, {}, {}, 1.0);
         CHECK(result.first == std::numeric_limits<double>::infinity());
         CHECK(result.second);
       }
       {
-        INFO("Test error control step fixed by absolute tolerance");
-        const LtsErrorControl error_control{5.0e-4, 0.0, 2.0, 0.5, 0.95};
+        INFO("Test successful step");
+        const LtsErrorControl error_control{5.0e-4, 1.0e-3, 2.0, 0.5, 0.95};
+        CHECK(error_control.tolerances() ==
+              StepperErrorTolerances{.absolute = 5.0e-4, .relative = 1.0e-3});
         const auto first_result =
-            get_suggestion(error_control, step_values, {step_errors(0.0)}, {},
-                           1.0, stepper_order);
-        // manually calculated in the special case in question: only absolute
-        // errors constrained
-        const double expected_linf_error = max(flattened_step_errors) / 5.0e-4;
+            get_suggestion(error_control, {step_errors(0.0, 0.3)}, {}, 1.0);
         CHECK(approx(first_result.first) ==
-              0.95 / pow(expected_linf_error, 1.0 / stepper_order));
+              0.95 / pow(0.3, 1.0 / stepper_order));
         CHECK(first_result.second);
         const auto second_result = get_suggestion(
-            error_control, step_values,
-            {step_errors(0.0, 1.2, first_result.first)}, {step_errors(-1.0)},
-            first_result.first, stepper_order);
+            error_control, {step_errors(0.0, 0.31, first_result.first)},
+            {step_errors(-1.0, 0.3)}, first_result.first);
         CHECK(approx(second_result.first) ==
               0.95 * first_result.first /
-                  (pow(expected_linf_error, 0.3 / stepper_order) *
-                   pow(1.2, 0.7 / stepper_order)));
+                  (pow(0.3, -0.4 / stepper_order) *
+                   pow(0.31, 0.7 / stepper_order)));
         CHECK(second_result.second);
         // Check that the suggested step size is smaller if the error in
         // increasing faster.
         const auto adjusted_second_result = get_suggestion(
-            error_control, step_values,
-            {step_errors(0.0, 1.2, first_result.first)},
-            {step_errors(-1.0, 0.5)}, first_result.first, stepper_order);
+            error_control, {step_errors(0.0, 0.31, first_result.first)},
+            {step_errors(-1.0, 0.1)}, first_result.first);
         CHECK(adjusted_second_result.first < second_result.first);
-      }
-      {
-        INFO("Test error control step fixed by relative tolerance");
-        const LtsErrorControl error_control{0.0, 3.0e-4, 2.0, 0.5, 0.95};
-        const auto first_result =
-            get_suggestion(error_control, step_values, {step_errors(0.0)}, {},
-                           1.0, stepper_order);
-        // manually calculated in the special case in question: only relative
-        // errors constrained
-        const double expected_linf_error =
-            max(flattened_step_errors /
-                (flattened_step_values + flattened_step_errors)) /
-            3.0e-4;
-        CHECK(approx(first_result.first) ==
-              0.95 / pow(expected_linf_error, 1.0 / stepper_order));
-        CHECK(first_result.second);
-        const auto second_result = get_suggestion(
-            error_control, step_values,
-            {step_errors(0.0, 1.2, first_result.first)}, {step_errors(-1.0)},
-            first_result.first, stepper_order);
-        const double new_expected_linf_error =
-            max(1.2 * flattened_step_errors /
-                (flattened_step_values + 1.2 * flattened_step_errors)) /
-            3.0e-4;
-        CHECK(approx(second_result.first) ==
-              0.95 * first_result.first *
-                  pow(pow(new_expected_linf_error, 1.0 / stepper_order), -0.7) *
-                  pow(pow(expected_linf_error, 1.0 / stepper_order), 0.4));
-        CHECK(second_result.second);
       }
       {
         INFO("Test error control step failure");
         const LtsErrorControl error_control{4.0e-5, 4.0e-5, 2.0, 0.5, 0.95};
         const auto result_start =
-            get_suggestion(error_control, step_values, {step_errors(0.0)}, {},
-                           1.0, stepper_order);
+            get_suggestion(error_control, {step_errors(0.0, 1.2)}, {}, 1.0);
         const auto result_end =
-            get_suggestion(error_control, step_values, {step_errors(-1.0)}, {},
-                           1.0, stepper_order);
-        const auto result_end2 =
-            get_suggestion(error_control, step_values, {step_errors(-1.0)}, {},
-                           result_end.first, stepper_order);
-        // manually calculated in the special case in question: only absolute
-        // errors constrained
-        const double expected_linf_error =
-            max(flattened_step_errors /
-                (flattened_step_values + flattened_step_errors + 1.0)) /
-            4.0e-5;
+            get_suggestion(error_control, {step_errors(-1.0, 1.2)}, {}, 1.0);
+        const auto result_end2 = get_suggestion(
+            error_control, {step_errors(-1.0, 1.2)}, {}, result_end.first);
         CHECK(approx(result_start.first) ==
-              std::max(0.95 / pow(expected_linf_error, 1.0 / stepper_order),
-                       0.5));
+              0.95 / pow(1.2, 1.0 / stepper_order));
         CHECK(result_end.first == result_start.first);
         CHECK(result_end2.first == result_start.first);
         CHECK_FALSE(result_start.second);
@@ -267,18 +202,14 @@ SPECTRE_TEST_CASE("Unit.Time.StepChoosers.ErrorControl", "[Unit][Time]") {
         INFO("Test error control clamped minimum");
         const LtsErrorControl error_control{4.0e-5, 4.0e-5, 2.0, 0.9, 0.95};
         const auto first_result =
-            get_suggestion(error_control, step_values, {step_errors(0.0)}, {},
-                           1.0, stepper_order);
-        // manually calculated in the special case in question: only absolute
-        // errors constrained
+            get_suggestion(error_control, {step_errors(0.0, 10.0)}, {}, 1.0);
         CHECK(first_result.first == 0.9);
       }
       {
-        INFO("Test error control clamped minimum");
+        INFO("Test error control clamped maximum");
         const LtsErrorControl error_control{1.0e-1, 1.0e-1, 2.0, 0.5, 0.95};
         const auto first_result =
-            get_suggestion(error_control, step_values, {step_errors(0.0)}, {},
-                           1.0, stepper_order);
+            get_suggestion(error_control, {step_errors(0.0, 0.01)}, {}, 1.0);
         CHECK(first_result == std::make_pair(2.0, true));
       }
     }
@@ -352,7 +283,6 @@ SPECTRE_TEST_CASE("Unit.Time.StepChoosers.ErrorControl", "[Unit][Time]") {
           *choosers =
               TestHelpers::test_creation<typename Tags::StepChoosers::type,
                                          Metavariables<true, true>>(
-                  "- PreventRapidIncrease:\n"
                   "- Increase:\n"
                   "    Factor: 2\n"
                   "- Constant: 0.5");

--- a/tests/Unit/Time/Tags/CMakeLists.txt
+++ b/tests/Unit/Time/Tags/CMakeLists.txt
@@ -7,6 +7,7 @@ set(LIBRARY_SOURCES
   Tags/Test_HistoryEvolvedVariables.cpp
   Tags/Test_IsUsingTimeSteppingErrorControl.cpp
   Tags/Test_StepChoosers.cpp
+  Tags/Test_StepperErrorTolerances.cpp
   Tags/Test_StepperErrors.cpp
   Tags/Test_Time.cpp
   Tags/Test_TimeAndPrevious.cpp

--- a/tests/Unit/Time/Tags/Test_StepperErrorTolerances.cpp
+++ b/tests/Unit/Time/Tags/Test_StepperErrorTolerances.cpp
@@ -1,0 +1,18 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <string>
+
+#include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
+#include "Time/Tags/StepperErrorTolerances.hpp"
+
+namespace {
+struct Vars {};
+
+SPECTRE_TEST_CASE("Unit.Time.Tags.StepperErrorTolerances", "[Unit][Time]") {
+  TestHelpers::db::test_simple_tag<Tags::StepperErrorTolerances<Vars>>(
+      "StepperErrorTolerances(Vars)");
+}
+}  // namespace

--- a/tests/Unit/Time/Test_LargestStepperError.cpp
+++ b/tests/Unit/Time/Test_LargestStepperError.cpp
@@ -5,13 +5,10 @@
 
 #include <complex>
 
+#include "DataStructures/ComplexDataVector.hpp"
 #include "DataStructures/DataVector.hpp"
-#include "DataStructures/SpinWeighted.hpp"
-#include "DataStructures/Variables.hpp"
-#include "Helpers/DataStructures/TestTags.hpp"
 #include "Time/LargestStepperError.hpp"
 #include "Time/StepperErrorTolerances.hpp"
-#include "Utilities/TMPL.hpp"
 
 SPECTRE_TEST_CASE("Unit.Time.LargestStepperError", "[Unit][Time]") {
   CHECK(largest_stepper_error(20.0, 10.0, {.absolute = 2.0, .relative = 0.0}) ==
@@ -41,23 +38,15 @@ SPECTRE_TEST_CASE("Unit.Time.LargestStepperError", "[Unit][Time]") {
   }
 
   {
-    using Vars = Variables<
-        tmpl::list<TestHelpers::Tags::Scalar<>, TestHelpers::Tags::Vector<>>>;
-    Vars values(5, 0.0);
-    get<1>(get<TestHelpers::Tags::Vector<>>(values))[1] = 3.0;
-    Vars errors(5, 0.0);
-    get<1>(get<TestHelpers::Tags::Vector<>>(errors))[1] = 6.0;
-    const StepperErrorTolerances tolerances{.absolute = 2.0, .relative = 5.0};
-    CHECK(largest_stepper_error(values, errors, tolerances) ==
-          largest_stepper_error(3.0, 6.0, tolerances));
-  }
-
-  {
-    using Weighted = SpinWeighted<std::complex<double>, 2>;
-    const std::complex<double> value(3.0, 5.0);
-    const std::complex<double> error(2.0, 1.0);
-    const StepperErrorTolerances tolerances{.absolute = 2.0, .relative = 5.0};
-    CHECK(largest_stepper_error(Weighted(value), Weighted(error), tolerances) ==
-          largest_stepper_error(value, error, tolerances));
+    const ComplexDataVector values{std::complex<double>{10.0, 3.0},
+                                   std::complex<double>{0.0, 0.0}};
+    const ComplexDataVector errors{std::complex<double>{5.0, 1.0},
+                                   std::complex<double>{1.0, 3.0}};
+    const StepperErrorTolerances mostly_abs{.absolute = 2.0, .relative = 0.1};
+    const StepperErrorTolerances mostly_rel{.absolute = 0.1, .relative = 2.0};
+    CHECK(largest_stepper_error(values, errors, mostly_abs) ==
+          largest_stepper_error(values[0], errors[0], mostly_abs));
+    CHECK(largest_stepper_error(values, errors, mostly_rel) ==
+          largest_stepper_error(values[1], errors[1], mostly_rel));
   }
 }

--- a/tests/Unit/Time/Test_LargestStepperError.cpp
+++ b/tests/Unit/Time/Test_LargestStepperError.cpp
@@ -1,0 +1,63 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <complex>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/SpinWeighted.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Helpers/DataStructures/TestTags.hpp"
+#include "Time/LargestStepperError.hpp"
+#include "Time/StepperErrorTolerances.hpp"
+#include "Utilities/TMPL.hpp"
+
+SPECTRE_TEST_CASE("Unit.Time.LargestStepperError", "[Unit][Time]") {
+  CHECK(largest_stepper_error(20.0, 10.0, {.absolute = 2.0, .relative = 0.0}) ==
+        5.0);
+  CHECK(largest_stepper_error(20.0, 10.0, {.absolute = 0.0, .relative = 2.0}) ==
+        1.0 / 6.0);
+  CHECK(largest_stepper_error(0.0, 10.0, {.absolute = 0.0, .relative = 2.0}) ==
+        0.5);
+
+  CHECK(largest_stepper_error(20.0, 10.0, {.absolute = 2.0, .relative = 3.0}) ==
+        10.0 / (2.0 + 3.0 * 30.0));
+
+  CHECK(largest_stepper_error(std::complex<double>(12.0, 5.0),
+                              std::complex<double>(-3.0, -4.0),
+                              {.absolute = 2.0, .relative = 3.0}) ==
+        approx(5.0 / (2.0 + 3.0 * 13.0)));
+
+  {
+    const DataVector values{10.0, 0.0};
+    const DataVector errors{5.0, 2.0};
+    const StepperErrorTolerances mostly_abs{.absolute = 2.0, .relative = 0.1};
+    const StepperErrorTolerances mostly_rel{.absolute = 0.1, .relative = 2.0};
+    CHECK(largest_stepper_error(values, errors, mostly_abs) ==
+          largest_stepper_error(10.0, 5.0, mostly_abs));
+    CHECK(largest_stepper_error(values, errors, mostly_rel) ==
+          largest_stepper_error(0.0, 2.0, mostly_rel));
+  }
+
+  {
+    using Vars = Variables<
+        tmpl::list<TestHelpers::Tags::Scalar<>, TestHelpers::Tags::Vector<>>>;
+    Vars values(5, 0.0);
+    get<1>(get<TestHelpers::Tags::Vector<>>(values))[1] = 3.0;
+    Vars errors(5, 0.0);
+    get<1>(get<TestHelpers::Tags::Vector<>>(errors))[1] = 6.0;
+    const StepperErrorTolerances tolerances{.absolute = 2.0, .relative = 5.0};
+    CHECK(largest_stepper_error(values, errors, tolerances) ==
+          largest_stepper_error(3.0, 6.0, tolerances));
+  }
+
+  {
+    using Weighted = SpinWeighted<std::complex<double>, 2>;
+    const std::complex<double> value(3.0, 5.0);
+    const std::complex<double> error(2.0, 1.0);
+    const StepperErrorTolerances tolerances{.absolute = 2.0, .relative = 5.0};
+    CHECK(largest_stepper_error(Weighted(value), Weighted(error), tolerances) ==
+          largest_stepper_error(value, error, tolerances));
+  }
+}

--- a/tests/Unit/Time/Test_StepperErrorTolerances.cpp
+++ b/tests/Unit/Time/Test_StepperErrorTolerances.cpp
@@ -1,0 +1,20 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include "Framework/TestHelpers.hpp"
+#include "Time/StepperErrorTolerances.hpp"
+
+SPECTRE_TEST_CASE("Unit.Time.StepperErrorTolerances", "[Unit][Time]") {
+  const StepperErrorTolerances tols1{.absolute = 0.1, .relative = 0.3};
+  const StepperErrorTolerances tols2{.absolute = 0.1, .relative = 0.5};
+  const StepperErrorTolerances tols3{.absolute = 0.5, .relative = 0.3};
+  CHECK(tols1 == tols1);
+  CHECK_FALSE(tols1 != tols1);
+  CHECK(tols1 != tols2);
+  CHECK_FALSE(tols1 == tols2);
+  CHECK(tols1 != tols3);
+  CHECK_FALSE(tols1 == tols3);
+  test_serialization(tols1);
+}

--- a/tests/Unit/Time/Test_TakeStep.cpp
+++ b/tests/Unit/Time/Test_TakeStep.cpp
@@ -23,10 +23,12 @@
 #include "Time/StepChoosers/Cfl.hpp"
 #include "Time/StepChoosers/Increase.hpp"
 #include "Time/StepChoosers/StepChooser.hpp"
+#include "Time/StepperErrorTolerances.hpp"
 #include "Time/Tags/AdaptiveSteppingDiagnostics.hpp"
 #include "Time/Tags/HistoryEvolvedVariables.hpp"
 #include "Time/Tags/IsUsingTimeSteppingErrorControl.hpp"
 #include "Time/Tags/StepChoosers.hpp"
+#include "Time/Tags/StepperErrorTolerances.hpp"
 #include "Time/Tags/StepperErrors.hpp"
 #include "Time/Tags/TimeStep.hpp"
 #include "Time/Tags/TimeStepId.hpp"
@@ -107,14 +109,15 @@ void test_gts() {
                         EvolvedVariable, Tags::dt<EvolvedVariable>,
                         Tags::HistoryEvolvedVariables<EvolvedVariable>,
                         Tags::ConcreteTimeStepper<TimeStepper>,
-                        ::Tags::IsUsingTimeSteppingErrorControl>,
+                        ::Tags::IsUsingTimeSteppingErrorControl,
+                        ::Tags::StepperErrorTolerances<EvolvedVariable>>,
       time_stepper_ref_tags<TimeStepper>>(
       Metavariables{}, TimeStepId{true, 0_st, slab.start()},
       TimeStepId{true, 0_st, Time{slab, {1, 4}}}, time_step, time_step,
       initial_values, DataVector{5, 0.0}, std::move(history),
       static_cast<std::unique_ptr<TimeStepper>>(
           std::make_unique<TimeSteppers::AdamsBashforth>(5)),
-      false);
+      false, std::optional<StepperErrorTolerances>{});
   // update the rhs
   db::mutate<Tags::dt<EvolvedVariable>>(update_rhs, make_not_null(&box),
                                         db::get<EvolvedVariable>(box));
@@ -172,6 +175,7 @@ void test_lts() {
           Tags::ConcreteTimeStepper<LtsTimeStepper>, Tags::StepChoosers,
           domain::Tags::MinimumGridSpacing<1, Frame::Inertial>,
           ::Tags::IsUsingTimeSteppingErrorControl,
+          ::Tags::StepperErrorTolerances<EvolvedVariable>,
           Tags::AdaptiveSteppingDiagnostics>,
       tmpl::push_back<time_stepper_ref_tags<LtsTimeStepper>,
                       typename Metavariables::system::
@@ -184,6 +188,7 @@ void test_lts() {
           std::make_unique<TimeSteppers::AdamsBashforth>(5)),
       std::move(step_choosers),
       1.0 / TimeSteppers::AdamsBashforth{5}.stable_step(), false,
+      std::optional<StepperErrorTolerances>{},
       AdaptiveSteppingDiagnostics{1, 2, 3, 4, 5});
 
   // update the rhs

--- a/tests/Unit/Time/TimeSteppers/Test_AdamsBashforth.cpp
+++ b/tests/Unit/Time/TimeSteppers/Test_AdamsBashforth.cpp
@@ -51,7 +51,6 @@ SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.AdamsBashforth", "[Unit][Time]") {
     TimeStepperTestUtils::check_dense_output(stepper, {10, 30}, 1, true);
 
     CHECK(stepper.order() == order);
-    CHECK(stepper.error_estimate_order() == order - 1);
 
     TimeStepperTestUtils::stability_test(stepper);
   }

--- a/tests/Unit/Time/TimeSteppers/Test_AdamsMoultonPc.cpp
+++ b/tests/Unit/Time/TimeSteppers/Test_AdamsMoultonPc.cpp
@@ -31,7 +31,6 @@ void test_am() {
     CAPTURE(order);
     const TimeSteppers::AdamsMoultonPc<Monotonic> stepper(order);
     CHECK(stepper.order() == order);
-    CHECK(stepper.error_estimate_order() == order - 1);
     CHECK(stepper.number_of_past_steps() == order - 2);
     CHECK(stepper.number_of_substeps() == 2);
     CHECK(stepper.number_of_substeps_for_error() == 2);

--- a/tests/Unit/Time/TimeSteppers/Test_ClassicalRungeKutta4.cpp
+++ b/tests/Unit/Time/TimeSteppers/Test_ClassicalRungeKutta4.cpp
@@ -16,7 +16,6 @@ SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.ClassicalRungeKutta4",
   const TimeSteppers::ClassicalRungeKutta4 stepper{};
 
   CHECK(stepper.order() == 4);
-  CHECK(stepper.error_estimate_order() == 3);
   CHECK(stepper.number_of_substeps() == 4);
   CHECK(stepper.number_of_substeps_for_error() == 5);
   TestHelpers::RungeKutta::check_tableau(stepper);

--- a/tests/Unit/Time/TimeSteppers/Test_DormandPrince5.cpp
+++ b/tests/Unit/Time/TimeSteppers/Test_DormandPrince5.cpp
@@ -15,7 +15,6 @@ SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.DormandPrince5", "[Unit][Time]") {
   const TimeSteppers::DormandPrince5 stepper{};
 
   CHECK(stepper.order() == 5);
-  CHECK(stepper.error_estimate_order() == 4);
   CHECK(stepper.number_of_substeps() == 6);
   CHECK(stepper.number_of_substeps_for_error() == 7);
   TestHelpers::RungeKutta::check_tableau(stepper);

--- a/tests/Unit/Time/TimeSteppers/Test_Heun2.cpp
+++ b/tests/Unit/Time/TimeSteppers/Test_Heun2.cpp
@@ -15,7 +15,6 @@ SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.Heun2", "[Unit][Time]") {
   const TimeSteppers::Heun2 stepper{};
 
   CHECK(stepper.order() == 2);
-  CHECK(stepper.error_estimate_order() == 1);
   CHECK(stepper.number_of_substeps() == 2);
   CHECK(stepper.number_of_substeps_for_error() == 2);
   TestHelpers::RungeKutta::check_tableau(stepper);

--- a/tests/Unit/Time/TimeSteppers/Test_Rk3HesthavenSsp.cpp
+++ b/tests/Unit/Time/TimeSteppers/Test_Rk3HesthavenSsp.cpp
@@ -15,7 +15,6 @@ SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.Rk3HesthavenSsp", "[Unit][Time]") {
   const TimeSteppers::Rk3HesthavenSsp stepper{};
 
   CHECK(stepper.order() == 3);
-  CHECK(stepper.error_estimate_order() == 2);
   CHECK(stepper.number_of_substeps() == 3);
   CHECK(stepper.number_of_substeps_for_error() == 3);
 

--- a/tests/Unit/Time/TimeSteppers/Test_Rk3Kennedy.cpp
+++ b/tests/Unit/Time/TimeSteppers/Test_Rk3Kennedy.cpp
@@ -15,7 +15,6 @@ SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.Rk3Kennedy", "[Unit][Time]") {
   const TimeSteppers::Rk3Kennedy stepper{};
 
   CHECK(stepper.order() == 3);
-  CHECK(stepper.error_estimate_order() == 2);
   CHECK(stepper.number_of_substeps() == 4);
   CHECK(stepper.number_of_substeps_for_error() == 4);
   TestHelpers::RungeKutta::check_tableau(stepper);

--- a/tests/Unit/Time/TimeSteppers/Test_Rk3Owren.cpp
+++ b/tests/Unit/Time/TimeSteppers/Test_Rk3Owren.cpp
@@ -14,7 +14,6 @@ SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.Rk3Owren", "[Unit][Time]") {
   const TimeSteppers::Rk3Owren stepper{};
 
   CHECK(stepper.order() == 3);
-  CHECK(stepper.error_estimate_order() == 2);
   CHECK(stepper.number_of_substeps() == 3);
   CHECK(stepper.number_of_substeps_for_error() == 3);
   TestHelpers::RungeKutta::check_tableau(stepper);

--- a/tests/Unit/Time/TimeSteppers/Test_Rk3Pareschi.cpp
+++ b/tests/Unit/Time/TimeSteppers/Test_Rk3Pareschi.cpp
@@ -15,7 +15,6 @@ SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.Rk3Pareschi", "[Unit][Time]") {
   const TimeSteppers::Rk3Pareschi stepper{};
 
   CHECK(stepper.order() == 3);
-  CHECK(stepper.error_estimate_order() == 2);
   CHECK(stepper.number_of_substeps() == 5);
   CHECK(stepper.number_of_substeps_for_error() == 5);
   TestHelpers::RungeKutta::check_tableau(stepper);

--- a/tests/Unit/Time/TimeSteppers/Test_Rk4Kennedy.cpp
+++ b/tests/Unit/Time/TimeSteppers/Test_Rk4Kennedy.cpp
@@ -15,7 +15,6 @@ SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.Rk4Kennedy", "[Unit][Time]") {
   const TimeSteppers::Rk4Kennedy stepper{};
 
   CHECK(stepper.order() == 4);
-  CHECK(stepper.error_estimate_order() == 3);
   CHECK(stepper.number_of_substeps() == 6);
   CHECK(stepper.number_of_substeps_for_error() == 6);
   TestHelpers::RungeKutta::check_tableau(stepper);

--- a/tests/Unit/Time/TimeSteppers/Test_Rk4Owren.cpp
+++ b/tests/Unit/Time/TimeSteppers/Test_Rk4Owren.cpp
@@ -14,7 +14,6 @@ SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.Rk4Owren", "[Unit][Time]") {
   const TimeSteppers::Rk4Owren stepper{};
 
   CHECK(stepper.order() == 4);
-  CHECK(stepper.error_estimate_order() == 3);
   CHECK(stepper.number_of_substeps() == 5);
   CHECK(stepper.number_of_substeps_for_error() == 5);
   TestHelpers::RungeKutta::check_tableau(stepper);

--- a/tests/Unit/Time/TimeSteppers/Test_Rk5Owren.cpp
+++ b/tests/Unit/Time/TimeSteppers/Test_Rk5Owren.cpp
@@ -14,7 +14,6 @@ SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.Rk5Owren", "[Unit][Time]") {
   const TimeSteppers::Rk5Owren stepper{};
 
   CHECK(stepper.order() == 5);
-  CHECK(stepper.error_estimate_order() == 4);
   CHECK(stepper.number_of_substeps() == 7);
   CHECK(stepper.number_of_substeps_for_error() == 7);
   TestHelpers::RungeKutta::check_tableau(stepper);

--- a/tests/Unit/Time/TimeSteppers/Test_Rk5Tsitouras.cpp
+++ b/tests/Unit/Time/TimeSteppers/Test_Rk5Tsitouras.cpp
@@ -15,7 +15,6 @@ SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.Rk5Tsitouras", "[Unit][Time]") {
   const TimeSteppers::Rk5Tsitouras stepper{};
 
   CHECK(stepper.order() == 5);
-  CHECK(stepper.error_estimate_order() == 4);
   CHECK(stepper.number_of_substeps() == 6);
   CHECK(stepper.number_of_substeps_for_error() == 7);
   TestHelpers::RungeKutta::check_tableau(stepper);


### PR DESCRIPTION
## Proposed changes

Instead, calculate the error norm we use immediately and store that (a double).

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
