### PR TITLE
Add Gaussian plus constant constraint gamma for ScalarTensor

### DIFF
--- a/src/Evolution/Executables/ScalarTensor/EvolveScalarTensorSingleBlackHole.cpp
+++ b/src/Evolution/Executables/ScalarTensor/EvolveScalarTensorSingleBlackHole.cpp
@@ -10,6 +10,7 @@
 #include "Domain/FunctionsOfTime/RegisterDerivedWithCharm.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/RegisterDerivedWithCharm.hpp"
 #include "Evolution/Systems/ScalarTensor/BoundaryCorrections/RegisterDerived.hpp"
+#include "Evolution/Systems/ScalarTensor/ConstraintDamping/RegisterDerivedWithCharm.hpp"
 #include "Parallel/CharmMain.tpp"
 #include "Utilities/Serialization/RegisterDerivedClassesWithCharm.hpp"
 
@@ -21,6 +22,7 @@ extern "C" void CkRegisterMainModule() {
        &domain::FunctionsOfTime::register_derived_with_charm,
        &ScalarTensor::BoundaryCorrections::register_derived_with_charm,
        &gh::ConstraintDamping::register_derived_with_charm,
+       &ScalarTensor::ConstraintDamping::register_derived_with_charm,
        &register_factory_classes_with_charm<EvolutionMetavars>},
       {});
 }

--- a/src/Evolution/Executables/ScalarTensor/ScalarTensorBase.hpp
+++ b/src/Evolution/Executables/ScalarTensor/ScalarTensorBase.hpp
@@ -46,6 +46,7 @@
 #include "Evolution/Systems/ScalarTensor/BoundaryConditions/Factory.hpp"
 #include "Evolution/Systems/ScalarTensor/BoundaryCorrections/Factory.hpp"
 #include "Evolution/Systems/ScalarTensor/Constraints.hpp"
+#include "Evolution/Systems/ScalarTensor/ConstraintDamping/Tags.hpp"
 #include "Evolution/Systems/ScalarTensor/Initialize.hpp"
 #include "Evolution/Systems/ScalarTensor/Sources/ScalarSource.hpp"
 #include "Evolution/Systems/ScalarTensor/StressEnergy.hpp"
@@ -397,24 +398,25 @@ struct ScalarTensorTemplateBase {
               volume_dim>>,
       Actions::MutateApply<gh::gauges::SetPiAndPhiFromConstraints<
           gh::ScalarTensor::AnalyticData::all_analytic_data, volume_dim>>,
-      Initialization::Actions::AddSimpleTags<
-          CurvedScalarWave::Initialization::InitializeConstraintDampingGammas<
-              volume_dim>>,
       Parallel::Actions::TerminatePhase>;
 
   // A tmpl::list of tags to be added to the GlobalCache by the
   // metavariables
-  using const_global_cache_tags =
-      tmpl::list<gh::gauges::Tags::GaugeCondition,
-                 evolution::initial_data::Tags::InitialData,
-                 gh::ConstraintDamping::Tags::DampingFunctionGamma0<
-                     volume_dim, Frame::Grid>,
-                 gh::ConstraintDamping::Tags::DampingFunctionGamma1<
-                     volume_dim, Frame::Grid>,
-                 gh::ConstraintDamping::Tags::DampingFunctionGamma2<
-                     volume_dim, Frame::Grid>,
-                 // Source parameters
-                 ScalarTensor::Tags::ScalarMass>;
+  using const_global_cache_tags = tmpl::list<
+      gh::gauges::Tags::GaugeCondition,
+      evolution::initial_data::Tags::InitialData,
+      gh::ConstraintDamping::Tags::DampingFunctionGamma0<volume_dim,
+                                                         Frame::Grid>,
+      gh::ConstraintDamping::Tags::DampingFunctionGamma1<volume_dim,
+                                                         Frame::Grid>,
+      gh::ConstraintDamping::Tags::DampingFunctionGamma2<volume_dim,
+                                                         Frame::Grid>,
+      ScalarTensor::ConstraintDamping::Tags::DampingFunctionGamma1<volume_dim,
+                                                                   Frame::Grid>,
+      ScalarTensor::ConstraintDamping::Tags::DampingFunctionGamma2<volume_dim,
+                                                                   Frame::Grid>,
+      // Source parameters
+      ScalarTensor::Tags::ScalarMass>;
 
   using dg_registration_list =
       tmpl::list<observers::Actions::RegisterEventsWithObservers>;

--- a/src/Evolution/Systems/ScalarTensor/CMakeLists.txt
+++ b/src/Evolution/Systems/ScalarTensor/CMakeLists.txt
@@ -45,4 +45,5 @@ target_link_libraries(
 
 add_subdirectory(BoundaryConditions)
 add_subdirectory(BoundaryCorrections)
+add_subdirectory(ConstraintDamping)
 add_subdirectory(Sources)

--- a/src/Evolution/Systems/ScalarTensor/ConstraintDamping/CMakeLists.txt
+++ b/src/Evolution/Systems/ScalarTensor/ConstraintDamping/CMakeLists.txt
@@ -1,0 +1,20 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+spectre_target_sources(
+  ${LIBRARY}
+  PRIVATE
+  GaussianPlusConstant.cpp
+  RegisterDerivedWithCharm.cpp
+)
+
+spectre_target_headers(
+  ${LIBRARY}
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  ConstraintGammas.hpp
+  DampingFunction.hpp
+  GaussianPlusConstant.hpp
+  RegisterDerivedWithCharm.hpp
+  Tags.hpp
+)

--- a/src/Evolution/Systems/ScalarTensor/ConstraintDamping/CMakeLists.txt
+++ b/src/Evolution/Systems/ScalarTensor/ConstraintDamping/CMakeLists.txt
@@ -6,6 +6,7 @@ spectre_target_sources(
   PRIVATE
   GaussianPlusConstant.cpp
   RegisterDerivedWithCharm.cpp
+  TimeDependentTripleGaussian.cpp
 )
 
 spectre_target_headers(

--- a/src/Evolution/Systems/ScalarTensor/ConstraintDamping/ConstraintGammas.hpp
+++ b/src/Evolution/Systems/ScalarTensor/ConstraintDamping/ConstraintGammas.hpp
@@ -1,0 +1,98 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/FunctionsOfTime/Tags.hpp"
+#include "Evolution/Systems/ScalarTensor/ConstraintDamping/Tags.hpp"
+#include "Evolution/Systems/ScalarTensor/Tags.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Utilities/ContainerHelpers.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+// IWYU pragma: no_forward_declare Tags::deriv
+
+/// \cond
+namespace Tags {
+struct Time;
+}  // namespace Tags
+namespace domain::Tags {
+template <size_t Dim, typename Frame>
+struct Coordinates;
+}  // namespace domain::Tags
+class DataVector;
+template <typename X, typename Symm, typename IndexList>
+class Tensor;
+/// \endcond
+
+namespace ScalarTensor::ConstraintDamping::Tags {
+/*!
+ * \brief Computes the constraint damping parameter \f$\gamma_1\f$ from the
+ * coordinates and a DampingFunction.
+ *
+ * \details Can be retrieved using
+ * `gh::ConstraintDamping::Tags::ConstraintGamma1`.
+ */
+template <size_t SpatialDim, typename Frame>
+struct ConstraintGamma1Compute : ::CurvedScalarWave::Tags::ConstraintGamma1,
+                                 db::ComputeTag {
+  using argument_tags =
+      tmpl::list<DampingFunctionGamma1<SpatialDim, Frame>,
+                 domain::Tags::Coordinates<SpatialDim, Frame>, ::Tags::Time,
+                 ::domain::Tags::FunctionsOfTime>;
+  using return_type = Scalar<DataVector>;
+
+  static constexpr void function(
+      gsl::not_null<Scalar<DataVector>*> gamma1,
+      const ::ScalarTensor::ConstraintDamping::DampingFunction<
+          SpatialDim, Frame>& damping_function,
+      const tnsr::I<DataVector, SpatialDim, Frame>& coords, const double time,
+      const std::unordered_map<
+          std::string,
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+          functions_of_time) {
+    damping_function(gamma1, coords, time, functions_of_time);
+  }
+
+  using base = ::CurvedScalarWave::Tags::ConstraintGamma1;
+};
+
+/*!
+ * \brief Computes the constraint damping parameter \f$\gamma_2\f$ from the
+ * coordinates and a DampingFunction.
+ *
+ * \details Can be retrieved using
+ * `gh::ConstraintDamping::Tags::ConstraintGamma2`.
+ */
+template <size_t SpatialDim, typename Frame>
+struct ConstraintGamma2Compute : ::CurvedScalarWave::Tags::ConstraintGamma2,
+                                 db::ComputeTag {
+  using argument_tags =
+      tmpl::list<DampingFunctionGamma2<SpatialDim, Frame>,
+                 domain::Tags::Coordinates<SpatialDim, Frame>, ::Tags::Time,
+                 ::domain::Tags::FunctionsOfTime>;
+  using return_type = Scalar<DataVector>;
+
+  static constexpr void function(
+      gsl::not_null<Scalar<DataVector>*> gamma,
+      const ::ScalarTensor::ConstraintDamping::DampingFunction<
+          SpatialDim, Frame>& damping_function,
+      const tnsr::I<DataVector, SpatialDim, Frame>& coords, const double time,
+      const std::unordered_map<
+          std::string,
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+          functions_of_time) {
+    damping_function(gamma, coords, time, functions_of_time);
+  }
+
+  using base = ::CurvedScalarWave::Tags::ConstraintGamma2;
+};
+}  // namespace ScalarTensor::ConstraintDamping::Tags

--- a/src/Evolution/Systems/ScalarTensor/ConstraintDamping/DampingFunction.hpp
+++ b/src/Evolution/Systems/ScalarTensor/ConstraintDamping/DampingFunction.hpp
@@ -1,0 +1,83 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <memory>
+#include <string>
+#include <type_traits>
+#include <unordered_map>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Serialization/CharmPupable.hpp"
+
+/// \cond
+class DataVector;
+namespace domain::FunctionsOfTime {
+class FunctionOfTime;
+}  // namespace domain::FunctionsOfTime
+/// \endcond
+
+/// Holds classes implementing DampingFunction (functions \f$R^n \to R\f$).
+namespace ScalarTensor::ConstraintDamping {
+/// \cond
+template <size_t VolumeDim, typename Fr>
+class GaussianPlusConstant;
+/// \endcond
+
+/*!
+ * \brief Base class defining interface for constraint damping functions.
+ *
+ * Encodes a function \f$R^n \to R\f$ where n is `VolumeDim` that represents
+ * a generalized-harmonic constraint-damping parameter (i.e., Gamma0,
+ * Gamma1, or Gamma2).
+ */
+template <size_t VolumeDim, typename Fr>
+class DampingFunction : public PUP::able {
+ public:
+  using creatable_classes = tmpl::conditional_t<
+      (VolumeDim == 3 and std::is_same<Fr, Frame::Grid>::value),
+      tmpl::list<
+          ScalarTensor::ConstraintDamping::GaussianPlusConstant<VolumeDim, Fr>>,
+      tmpl::list<ScalarTensor::ConstraintDamping::GaussianPlusConstant<
+          VolumeDim, Fr>>>;
+  constexpr static size_t volume_dim = VolumeDim;
+  using frame = Fr;
+
+  WRAPPED_PUPable_abstract(DampingFunction);  // NOLINT
+
+  DampingFunction() = default;
+  DampingFunction(const DampingFunction& /*rhs*/) = default;
+  DampingFunction& operator=(const DampingFunction& /*rhs*/) = default;
+  DampingFunction(DampingFunction&& /*rhs*/) = default;
+  DampingFunction& operator=(DampingFunction&& /*rhs*/) = default;
+  ~DampingFunction() override = default;
+
+  explicit DampingFunction(CkMigrateMessage* msg) : PUP::able(msg) {}
+
+  /// @{
+  /// Returns the value of the function at the coordinate 'x'.
+  virtual void operator()(
+      gsl::not_null<Scalar<double>*> value_at_x,
+      const tnsr::I<double, VolumeDim, Fr>& x, double time,
+      const std::unordered_map<
+          std::string,
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+          functions_of_time) const = 0;
+  virtual void operator()(
+      gsl::not_null<Scalar<DataVector>*> value_at_x,
+      const tnsr::I<DataVector, VolumeDim, Fr>& x, double time,
+      const std::unordered_map<
+          std::string,
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+          functions_of_time) const = 0;
+  /// @}
+
+  virtual auto get_clone() const
+      -> std::unique_ptr<DampingFunction<VolumeDim, Fr>> = 0;
+};
+}  // namespace ScalarTensor::ConstraintDamping
+
+#include "Evolution/Systems/ScalarTensor/ConstraintDamping/GaussianPlusConstant.hpp"

--- a/src/Evolution/Systems/ScalarTensor/ConstraintDamping/DampingFunction.hpp
+++ b/src/Evolution/Systems/ScalarTensor/ConstraintDamping/DampingFunction.hpp
@@ -25,6 +25,7 @@ namespace ScalarTensor::ConstraintDamping {
 /// \cond
 template <size_t VolumeDim, typename Fr>
 class GaussianPlusConstant;
+class TimeDependentTripleGaussian;
 /// \endcond
 
 /*!
@@ -40,7 +41,8 @@ class DampingFunction : public PUP::able {
   using creatable_classes = tmpl::conditional_t<
       (VolumeDim == 3 and std::is_same<Fr, Frame::Grid>::value),
       tmpl::list<
-          ScalarTensor::ConstraintDamping::GaussianPlusConstant<VolumeDim, Fr>>,
+          ScalarTensor::ConstraintDamping::GaussianPlusConstant<VolumeDim, Fr>,
+          ScalarTensor::ConstraintDamping::TimeDependentTripleGaussian>,
       tmpl::list<ScalarTensor::ConstraintDamping::GaussianPlusConstant<
           VolumeDim, Fr>>>;
   constexpr static size_t volume_dim = VolumeDim;
@@ -81,3 +83,4 @@ class DampingFunction : public PUP::able {
 }  // namespace ScalarTensor::ConstraintDamping
 
 #include "Evolution/Systems/ScalarTensor/ConstraintDamping/GaussianPlusConstant.hpp"
+#include "Evolution/Systems/ScalarTensor/ConstraintDamping/TimeDependentTripleGaussian.hpp"

--- a/src/Evolution/Systems/ScalarTensor/ConstraintDamping/GaussianPlusConstant.cpp
+++ b/src/Evolution/Systems/ScalarTensor/ConstraintDamping/GaussianPlusConstant.cpp
@@ -1,0 +1,131 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/ScalarTensor/ConstraintDamping/GaussianPlusConstant.hpp"
+
+#include <cmath>
+#include <cstddef>
+#include <memory>
+#include <pup.h>
+#include <pup_stl.h>
+#include <string>
+#include <unordered_map>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/SetNumberOfGridPoints.hpp"
+
+namespace domain::FunctionsOfTime {
+class FunctionOfTime;
+}  // namespace domain::FunctionsOfTime
+
+namespace ScalarTensor::ConstraintDamping {
+template <size_t VolumeDim, typename Fr>
+GaussianPlusConstant<VolumeDim, Fr>::GaussianPlusConstant(CkMigrateMessage* msg)
+    : DampingFunction<VolumeDim, Fr>(msg) {}
+
+template <size_t VolumeDim, typename Fr>
+GaussianPlusConstant<VolumeDim, Fr>::GaussianPlusConstant(
+    const double constant, const double amplitude, const double width,
+    const std::array<double, VolumeDim>& center)
+    : constant_(constant),
+      amplitude_(amplitude),
+      inverse_width_(1.0 / width),
+      center_(center) {}
+
+template <size_t VolumeDim, typename Fr>
+template <typename T>
+void GaussianPlusConstant<VolumeDim, Fr>::apply_call_operator(
+    const gsl::not_null<Scalar<T>*> value_at_x,
+    const tnsr::I<T, VolumeDim, Fr>& x) const {
+  tnsr::I<T, VolumeDim, Fr> centered_coords{x};
+  for (size_t i = 0; i < VolumeDim; ++i) {
+    centered_coords.get(i) -= gsl::at(center_, i);
+  }
+  dot_product(value_at_x, centered_coords, centered_coords);
+  get(*value_at_x) =
+      constant_ + amplitude_ * exp(-get(*value_at_x) * square(inverse_width_));
+}
+
+template <size_t VolumeDim, typename Fr>
+void GaussianPlusConstant<VolumeDim, Fr>::operator()(
+    const gsl::not_null<Scalar<double>*> value_at_x,
+    const tnsr::I<double, VolumeDim, Fr>& x, const double /*time*/,
+    const std::unordered_map<
+        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+    /*functions_of_time*/) const {
+  apply_call_operator(value_at_x, x);
+}
+template <size_t VolumeDim, typename Fr>
+void GaussianPlusConstant<VolumeDim, Fr>::operator()(
+    const gsl::not_null<Scalar<DataVector>*> value_at_x,
+    const tnsr::I<DataVector, VolumeDim, Fr>& x, const double /*time*/,
+    const std::unordered_map<
+        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+    /*functions_of_time*/) const {
+  set_number_of_grid_points(value_at_x, x);
+  apply_call_operator(value_at_x, x);
+}
+
+template <size_t VolumeDim, typename Fr>
+void GaussianPlusConstant<VolumeDim, Fr>::pup(PUP::er& p) {
+  DampingFunction<VolumeDim, Fr>::pup(p);
+  p | constant_;
+  p | amplitude_;
+  p | inverse_width_;
+  p | center_;
+}
+
+template <size_t VolumeDim, typename Fr>
+auto GaussianPlusConstant<VolumeDim, Fr>::get_clone() const
+    -> std::unique_ptr<DampingFunction<VolumeDim, Fr>> {
+  return std::make_unique<GaussianPlusConstant<VolumeDim, Fr>>(*this);
+}
+}  // namespace ScalarTensor::ConstraintDamping
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define FRAME(data) BOOST_PP_TUPLE_ELEM(1, data)
+#define INSTANTIATE(_, data)                                                 \
+  template ScalarTensor::ConstraintDamping::GaussianPlusConstant<            \
+      DIM(data), FRAME(data)>::GaussianPlusConstant(CkMigrateMessage* msg);  \
+  template ScalarTensor::ConstraintDamping::                                 \
+      GaussianPlusConstant<DIM(data), FRAME(data)>::GaussianPlusConstant(    \
+          const double constant, const double amplitude, const double width, \
+          const std::array<double, DIM(data)>& center);                      \
+  template void ScalarTensor::ConstraintDamping::GaussianPlusConstant<       \
+      DIM(data), FRAME(data)>::pup(PUP::er& p);                              \
+  template auto ScalarTensor::ConstraintDamping::GaussianPlusConstant<       \
+      DIM(data), FRAME(data)>::get_clone()                                   \
+      const->std::unique_ptr<DampingFunction<DIM(data), FRAME(data)>>;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (Frame::Grid, Frame::Inertial))
+#undef DIM
+#undef FRAME
+#undef INSTANTIATE
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define FRAME(data) BOOST_PP_TUPLE_ELEM(1, data)
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(2, data)
+
+#define INSTANTIATE(_, data)                                               \
+  template void ScalarTensor::ConstraintDamping::                          \
+      GaussianPlusConstant<DIM(data), FRAME(data)>::operator()(            \
+          const gsl::not_null<Scalar<DTYPE(data)>*> value_at_x,            \
+          const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& x,           \
+          const double /*time*/,                                           \
+          const std::unordered_map<                                        \
+              std::string,                                                 \
+              std::unique_ptr<domain::FunctionsOfTime::                    \
+                                  FunctionOfTime>>& /*functions_of_time*/) \
+          const;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (Frame::Grid, Frame::Inertial),
+                        (double, DataVector))
+#undef FRAME
+#undef DIM
+#undef DTYPE
+#undef INSTANTIATE

--- a/src/Evolution/Systems/ScalarTensor/ConstraintDamping/GaussianPlusConstant.hpp
+++ b/src/Evolution/Systems/ScalarTensor/ConstraintDamping/GaussianPlusConstant.hpp
@@ -1,0 +1,136 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <limits>
+#include <memory>
+#include <string>
+#include <unordered_map>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Evolution/Systems/ScalarTensor/ConstraintDamping/DampingFunction.hpp"
+#include "Options/String.hpp"
+#include "Utilities/Serialization/CharmPupable.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+class DataVector;
+namespace PUP {
+class er;
+}  // namespace PUP
+namespace domain::FunctionsOfTime {
+class FunctionOfTime;
+}  // namespace domain::FunctionsOfTime
+/// \endcond
+
+namespace ScalarTensor::ConstraintDamping {
+/*!
+ * \brief A Gaussian plus a constant: \f$f = C + A
+ * \exp\left(-\frac{(x-x_0)^2}{w^2}\right)\f$
+ *
+ * \details Input file options are: `Constant` \f$C\f$, `Amplitude` \f$A\f$,
+ * `Width` \f$w\f$, and `Center`\f$x_0\f$. The function takes input coordinates
+ * of type `tnsr::I<T, VolumeDim, Fr>`, where `T` is e.g. `double` or
+ * `DataVector`, `Fr` is a frame (e.g. `Frame::Inertial`), and `VolumeDim` is
+ * the dimension of the spatial volume.
+ */
+template <size_t VolumeDim, typename Fr>
+class GaussianPlusConstant : public DampingFunction<VolumeDim, Fr> {
+ public:
+  struct Constant {
+    using type = double;
+    static constexpr Options::String help = {"The constant."};
+  };
+
+  struct Amplitude {
+    using type = double;
+    static constexpr Options::String help = {"The amplitude of the Gaussian."};
+  };
+
+  struct Width {
+    using type = double;
+    static constexpr Options::String help = {"The width of the Gaussian."};
+    static type lower_bound() { return 0.; }
+  };
+
+  struct Center {
+    using type = std::array<double, VolumeDim>;
+    static constexpr Options::String help = {"The center of the Gaussian."};
+  };
+  using options = tmpl::list<Constant, Amplitude, Width, Center>;
+
+  static constexpr Options::String help = {
+      "Computes a Gaussian plus a constant about an arbitrary coordinate "
+      "center with given width and amplitude"};
+
+  /// \cond
+  WRAPPED_PUPable_decl_base_template(SINGLE_ARG(DampingFunction<VolumeDim, Fr>),
+                                     GaussianPlusConstant);  // NOLINT
+
+  explicit GaussianPlusConstant(CkMigrateMessage* msg);
+  /// \endcond
+
+  GaussianPlusConstant(double constant, double amplitude, double width,
+                       const std::array<double, VolumeDim>& center);
+
+  GaussianPlusConstant() = default;
+  ~GaussianPlusConstant() override = default;
+  GaussianPlusConstant(const GaussianPlusConstant& /*rhs*/) = default;
+  GaussianPlusConstant& operator=(const GaussianPlusConstant& /*rhs*/) =
+      default;
+  GaussianPlusConstant(GaussianPlusConstant&& /*rhs*/) = default;
+  GaussianPlusConstant& operator=(GaussianPlusConstant&& /*rhs*/) = default;
+
+  void operator()(gsl::not_null<Scalar<double>*> value_at_x,
+                  const tnsr::I<double, VolumeDim, Fr>& x, double time,
+                  const std::unordered_map<
+                      std::string,
+                      std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+                      functions_of_time) const override;
+  void operator()(gsl::not_null<Scalar<DataVector>*> value_at_x,
+                  const tnsr::I<DataVector, VolumeDim, Fr>& x, double time,
+                  const std::unordered_map<
+                      std::string,
+                      std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+                      functions_of_time) const override;
+
+  auto get_clone() const
+      -> std::unique_ptr<DampingFunction<VolumeDim, Fr>> override;
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& p) override;
+
+ private:
+  friend bool operator==(const GaussianPlusConstant& lhs,
+                         const GaussianPlusConstant& rhs) {
+    return lhs.constant_ == rhs.constant_ and
+           lhs.amplitude_ == rhs.amplitude_ and
+           lhs.inverse_width_ == rhs.inverse_width_ and
+           lhs.center_ == rhs.center_;
+  }
+
+  double constant_ = std::numeric_limits<double>::signaling_NaN();
+  double amplitude_ = std::numeric_limits<double>::signaling_NaN();
+  double inverse_width_ = std::numeric_limits<double>::signaling_NaN();
+  std::array<double, VolumeDim> center_{};
+
+  template <typename T>
+  void apply_call_operator(gsl::not_null<Scalar<T>*> value_at_x,
+                           const tnsr::I<T, VolumeDim, Fr>& x) const;
+};
+
+template <size_t VolumeDim, typename Fr>
+bool operator!=(const GaussianPlusConstant<VolumeDim, Fr>& lhs,
+                const GaussianPlusConstant<VolumeDim, Fr>& rhs) {
+  return not(lhs == rhs);
+}
+}  // namespace ScalarTensor::ConstraintDamping
+
+/// \cond
+template <size_t VolumeDim, typename Fr>
+PUP::able::PUP_ID ScalarTensor::ConstraintDamping::GaussianPlusConstant<
+    VolumeDim, Fr>::my_PUP_ID = 0;  // NOLINT
+/// \endcond

--- a/src/Evolution/Systems/ScalarTensor/ConstraintDamping/RegisterDerivedWithCharm.cpp
+++ b/src/Evolution/Systems/ScalarTensor/ConstraintDamping/RegisterDerivedWithCharm.cpp
@@ -1,0 +1,32 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/ScalarTensor/ConstraintDamping/RegisterDerivedWithCharm.hpp"
+
+#include <cstddef>
+
+#include "Evolution/Systems/ScalarTensor/ConstraintDamping/DampingFunction.hpp"
+#include "Utilities/Serialization/RegisterDerivedClassesWithCharm.hpp"
+
+namespace Frame {
+struct Grid;
+struct Inertial;
+}  // namespace Frame
+
+namespace ScalarTensor::ConstraintDamping {
+namespace {
+template <size_t Dim, typename Fr>
+void register_damping_functions_with_charm() {
+  register_derived_classes_with_charm<DampingFunction<Dim, Fr>>();
+}
+}  // namespace
+
+void register_derived_with_charm() {
+  register_damping_functions_with_charm<1, Frame::Grid>();
+  register_damping_functions_with_charm<2, Frame::Grid>();
+  register_damping_functions_with_charm<3, Frame::Grid>();
+  register_damping_functions_with_charm<1, Frame::Inertial>();
+  register_damping_functions_with_charm<2, Frame::Inertial>();
+  register_damping_functions_with_charm<3, Frame::Inertial>();
+}
+}  // namespace ScalarTensor::ConstraintDamping

--- a/src/Evolution/Systems/ScalarTensor/ConstraintDamping/RegisterDerivedWithCharm.hpp
+++ b/src/Evolution/Systems/ScalarTensor/ConstraintDamping/RegisterDerivedWithCharm.hpp
@@ -1,0 +1,8 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+namespace ScalarTensor::ConstraintDamping {
+void register_derived_with_charm();
+}  // namespace ScalarTensor::ConstraintDamping

--- a/src/Evolution/Systems/ScalarTensor/ConstraintDamping/Tags.hpp
+++ b/src/Evolution/Systems/ScalarTensor/ConstraintDamping/Tags.hpp
@@ -1,0 +1,79 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <memory>
+
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "Evolution/Systems/ScalarTensor/ConstraintDamping/DampingFunction.hpp"
+#include "Options/String.hpp"
+
+/// \cond
+namespace ScalarTensor::OptionTags {
+struct Group;
+}  // namespace ScalarTensor::OptionTags
+/// \endcond
+
+namespace ScalarTensor::ConstraintDamping {
+namespace OptionTags {
+
+template <size_t VolumeDim, typename Fr>
+struct DampingFunctionGamma1 {
+  using type = std::unique_ptr<
+      ::ScalarTensor::ConstraintDamping::DampingFunction<VolumeDim, Fr>>;
+  static constexpr Options::String help{
+      "DampingFunction for damping parameter gamma1"};
+  using group = ScalarTensor::OptionTags::Group;
+};
+
+template <size_t VolumeDim, typename Fr>
+struct DampingFunctionGamma2 {
+  using type = std::unique_ptr<
+      ::ScalarTensor::ConstraintDamping::DampingFunction<VolumeDim, Fr>>;
+  static constexpr Options::String help{
+      "DampingFunction for damping parameter gamma2"};
+  using group = ScalarTensor::OptionTags::Group;
+};
+}  // namespace OptionTags
+
+namespace Tags {
+
+/*!
+ * \brief A DampingFunction to compute the constraint damping parameter
+ * \f$\gamma_0\f$.
+ */
+template <size_t VolumeDim, typename Fr>
+struct DampingFunctionGamma1 : db::SimpleTag {
+  using DampingFunctionType =
+      ::ScalarTensor::ConstraintDamping::DampingFunction<VolumeDim, Fr>;
+  using type = std::unique_ptr<DampingFunctionType>;
+  using option_tags = tmpl::list<::ScalarTensor::ConstraintDamping::OptionTags::
+                                     DampingFunctionGamma1<VolumeDim, Fr>>;
+
+  static constexpr bool pass_metavariables = false;
+  static type create_from_options(const type& damping_function) {
+    return damping_function->get_clone();
+  }
+};
+
+/*!
+ * \brief A DampingFunction to compute the constraint damping parameter
+ * \f$\gamma_0\f$.
+ */
+template <size_t VolumeDim, typename Fr>
+struct DampingFunctionGamma2 : db::SimpleTag {
+  using DampingFunctionType =
+      ::ScalarTensor::ConstraintDamping::DampingFunction<VolumeDim, Fr>;
+  using type = std::unique_ptr<DampingFunctionType>;
+  using option_tags = tmpl::list<::ScalarTensor::ConstraintDamping::OptionTags::
+                                     DampingFunctionGamma2<VolumeDim, Fr>>;
+
+  static constexpr bool pass_metavariables = false;
+  static type create_from_options(const type& damping_function) {
+    return damping_function->get_clone();
+  }
+};
+}  // namespace Tags
+}  // namespace ScalarTensor::ConstraintDamping

--- a/src/Evolution/Systems/ScalarTensor/ConstraintDamping/TimeDependentTripleGaussian.cpp
+++ b/src/Evolution/Systems/ScalarTensor/ConstraintDamping/TimeDependentTripleGaussian.cpp
@@ -1,0 +1,212 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/ScalarTensor/ConstraintDamping/TimeDependentTripleGaussian.hpp"
+
+#include <array>
+#include <cmath>
+#include <cstddef>
+#include <memory>
+#include <pup.h>
+#include <pup_stl.h>
+#include <string>
+#include <unordered_map>
+#include <utility>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "Options/ParseError.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Serialization/PupStlCpp17.hpp"
+#include "Utilities/SetNumberOfGridPoints.hpp"
+
+namespace ScalarTensor::ConstraintDamping {
+TimeDependentTripleGaussian::TimeDependentTripleGaussian(CkMigrateMessage* msg)
+    : DampingFunction<3, Frame::Grid>(msg) {}
+
+TimeDependentTripleGaussian::TimeDependentTripleGaussian(
+    const double constant, const double amplitude_1, const double width_1,
+    const std::optional<std::array<double, 3>>& center_1,
+    const double amplitude_2, const double width_2,
+    const std::optional<std::array<double, 3>>& center_2,
+    const double amplitude_3, const double width_3,
+    const std::array<double, 3>& center_3, const std::string& movement_method,
+    const Options::Context& context)
+    : constant_(constant),
+      amplitude_1_(amplitude_1),
+      inverse_width_1_(1.0 / width_1),
+      center_1_(center_1),
+      amplitude_2_(amplitude_2),
+      inverse_width_2_(1.0 / width_2),
+      center_2_(center_2),
+      amplitude_3_(amplitude_3),
+      inverse_width_3_(1.0 / width_3),
+      center_3_(center_3),
+      movement_method_(movement_method == "ExpansionFactor"
+                           ? MovementMethods::ExpansionFactor
+                           : MovementMethods::ObjectCenters) {
+  if (movement_method != "ExpansionFactor" and
+      movement_method != "ObjectCenters") {
+    PARSE_ERROR(
+        context,
+        "The movement method must be either 'ExpansionFactor' (for BBH "
+        "simulations) or 'ObjectCenters' (for BNS simulations) but got '"
+            << movement_method << "'");
+  }
+  if (movement_method == "ObjectCenters") {
+    if (center_1_.has_value()) {
+      PARSE_ERROR(context,
+                  "You cannot set the Center of Gaussian1 when using the "
+                  "ObjectCenters movement method. The center is determine from "
+                  "the ObjectCenters function of time.");
+    }
+    if (center_2_.has_value()) {
+      PARSE_ERROR(context,
+                  "You cannot set the Center of Gaussian2 when using the "
+                  "ObjectCenters movement method. The center is determine from "
+                  "the ObjectCenters function of time.");
+    }
+  } else {
+    if (not center_1_.has_value()) {
+      PARSE_ERROR(context,
+                  "You must set the Center of Gaussian1 when using the "
+                  "ExpansionFactor movement method.");
+    }
+    if (not center_2_.has_value()) {
+      PARSE_ERROR(context,
+                  "You must set the Center of Gaussian1 when using the "
+                  "ExpansionFactor movement method.");
+    }
+  }
+}
+
+template <typename T>
+void TimeDependentTripleGaussian::apply_call_operator(
+    const gsl::not_null<Scalar<T>*> value_at_x,
+    const tnsr::I<T, 3, Frame::Grid>& x, const double time,
+    const std::unordered_map<
+        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+        functions_of_time) const {
+  // Start by setting the result to the constant
+  get(*value_at_x) = constant_;
+
+  // Loop over the three Gaussians, adding each to the result
+  auto centered_coords = make_with_value<tnsr::I<T, 3, Frame::Grid>>(
+      get<0>(x), std::numeric_limits<double>::signaling_NaN());
+
+  const auto add_gauss_to_value_at_x =
+      [&centered_coords, &x, &functions_of_time, time, this, &value_at_x](
+          const double amplitude, const double inverse_width,
+          const std::array<double, 3>& center) {
+        for (size_t i = 0; i < 3; ++i) {
+          centered_coords.get(i) = x.get(i) - gsl::at(center, i);
+        }
+        if (this->movement_method_ == MovementMethods::ExpansionFactor) {
+          ASSERT(functions_of_time.at(function_of_time_for_scaling_)
+                         ->func(time)[0]
+                         .size() == 1,
+                 "FunctionOfTimeForScaling in TimeDependentTripleGaussian must "
+                 "be a scalar FunctionOfTime, not "
+                     << functions_of_time.at(function_of_time_for_scaling_)
+                            ->func(time)[0]
+                            .size());
+          const double expansion_factor_value =
+              functions_of_time.at(function_of_time_for_scaling_)
+                  ->func(time)[0][0];
+          get(*value_at_x) +=
+              amplitude *
+              exp(-get(dot_product(centered_coords, centered_coords)) *
+                  square(inverse_width * expansion_factor_value));
+        } else {
+          get(*value_at_x) +=
+              amplitude *
+              exp(-get(dot_product(centered_coords, centered_coords)) *
+                  square(inverse_width));
+        }
+      };
+  if (this->movement_method_ == MovementMethods::ExpansionFactor) {
+    add_gauss_to_value_at_x(amplitude_1_, inverse_width_1_, center_1_.value());
+    add_gauss_to_value_at_x(amplitude_2_, inverse_width_2_, center_2_.value());
+  } else {
+    const DataVector centers =
+        functions_of_time.at(function_of_time_for_centers_)->func(time)[0];
+    ASSERT(centers.size() == 6,
+           "FunctionOfTimeForCenters in TimeDependentTripleGaussian must have "
+           "6 components, not "
+               << functions_of_time.at(function_of_time_for_centers_)
+                      ->func(time)[0]
+                      .size());
+    const std::array center_1{centers[0], centers[1], centers[2]};
+    const std::array center_2{centers[3], centers[4], centers[5]};
+    add_gauss_to_value_at_x(amplitude_1_, inverse_width_1_, center_1);
+    add_gauss_to_value_at_x(amplitude_2_, inverse_width_2_, center_2);
+  }
+  // Gaussian 3 should be the one centered at the origin in a binary simulation.
+  add_gauss_to_value_at_x(amplitude_3_, inverse_width_3_, center_3_);
+}  // namespace ScalarTensor::ConstraintDamping
+
+void TimeDependentTripleGaussian::operator()(
+    const gsl::not_null<Scalar<double>*> value_at_x,
+    const tnsr::I<double, 3, Frame::Grid>& x, const double time,
+    const std::unordered_map<
+        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+        functions_of_time) const {
+  apply_call_operator(value_at_x, x, time, functions_of_time);
+}
+void TimeDependentTripleGaussian::operator()(
+    const gsl::not_null<Scalar<DataVector>*> value_at_x,
+    const tnsr::I<DataVector, 3, Frame::Grid>& x, const double time,
+    const std::unordered_map<
+        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+        functions_of_time) const {
+  set_number_of_grid_points(value_at_x, x);
+  apply_call_operator(value_at_x, x, time, functions_of_time);
+}
+
+void TimeDependentTripleGaussian::pup(PUP::er& p) {
+  DampingFunction<3, Frame::Grid>::pup(p);
+  p | constant_;
+  p | amplitude_1_;
+  p | inverse_width_1_;
+  p | center_1_;
+  p | amplitude_2_;
+  p | inverse_width_2_;
+  p | center_2_;
+  p | amplitude_3_;
+  p | inverse_width_3_;
+  p | center_3_;
+  p | movement_method_;
+}
+
+auto TimeDependentTripleGaussian::get_clone() const
+    -> std::unique_ptr<DampingFunction<3, Frame::Grid>> {
+  return std::make_unique<TimeDependentTripleGaussian>(*this);
+}
+
+bool operator==(const TimeDependentTripleGaussian& lhs,
+                const TimeDependentTripleGaussian& rhs) {
+  return lhs.constant_ == rhs.constant_ and
+         lhs.amplitude_1_ == rhs.amplitude_1_ and
+         lhs.inverse_width_1_ == rhs.inverse_width_1_ and
+         lhs.center_1_ == rhs.center_1_ and
+         lhs.amplitude_2_ == rhs.amplitude_2_ and
+         lhs.inverse_width_2_ == rhs.inverse_width_2_ and
+         lhs.center_2_ == rhs.center_2_ and
+         lhs.amplitude_3_ == rhs.amplitude_3_ and
+         lhs.inverse_width_3_ == rhs.inverse_width_3_ and
+         lhs.center_3_ == rhs.center_3_ and
+         lhs.movement_method_ == rhs.movement_method_;
+}
+
+bool operator!=(const TimeDependentTripleGaussian& lhs,
+                const TimeDependentTripleGaussian& rhs) {
+  return not(lhs == rhs);
+}
+}  // namespace ScalarTensor::ConstraintDamping
+PUP::able::PUP_ID
+    ScalarTensor::ConstraintDamping::TimeDependentTripleGaussian::my_PUP_ID =
+        0;  // NOLINT

--- a/src/Evolution/Systems/ScalarTensor/ConstraintDamping/TimeDependentTripleGaussian.hpp
+++ b/src/Evolution/Systems/ScalarTensor/ConstraintDamping/TimeDependentTripleGaussian.hpp
@@ -1,0 +1,197 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <limits>
+#include <memory>
+#include <string>
+#include <unordered_map>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Evolution/Systems/ScalarTensor/ConstraintDamping/DampingFunction.hpp"
+#include "Options/Auto.hpp"
+#include "Options/String.hpp"
+#include "Utilities/Serialization/CharmPupable.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+class DataVector;
+namespace PUP {
+class er;
+}  // namespace PUP
+namespace domain::FunctionsOfTime {
+class FunctionOfTime;
+}  // namespace domain::FunctionsOfTime
+/// \endcond
+
+namespace ScalarTensor::ConstraintDamping {
+/*!
+ * \brief A sum of three Gaussians plus a constant, where the Gaussian widths
+ * are scaled by a domain::FunctionsOfTime::FunctionOfTime.
+ *
+ * \details The function \f$f\f$ is given by
+ * \f{align}{
+ * f = C + \sum_{\alpha=1}^3
+ * A_\alpha \exp\left(-\frac{(x-(x_0)_\alpha)^2}{w_\alpha^2(t)}\right).
+ * \f}
+ * Input file options are: `Constant` \f$C\f$, `Amplitude[1-3]`
+ * \f$A_\alpha\f$, `Width[1-3]` \f$w_\alpha\f$, and `Center[1-3]
+ * `\f$(x_0)_\alpha\f$. The function takes input
+ * coordinates \f$x\f$ of type `tnsr::I<T, 3, Frame::Grid>`, where `T` is e.g.
+ * `double` or `DataVector`; note that this DampingFunction is only defined
+ * for three spatial dimensions and for the grid frame. The Gaussian widths
+ * \f$w_\alpha\f$ are scaled by the inverse of the value of a scalar
+ * domain::FunctionsOfTime::FunctionOfTime \f$f(t)\f$: \f$w_\alpha(t) = w_\alpha
+ * / f(t)\f$.
+ *
+ * You can choose one of two methods for tracking the object
+ * centers. `ExpansionFactor` should be used for BBH simulations where the
+ * expansion control system is used to track the objects. `ObjectCenters`
+ * sholud be used for BNS simulations where the coordinate centers of the two
+ * stars is tracked separately and there is no expansion control system.
+ */
+class TimeDependentTripleGaussian : public DampingFunction<3, Frame::Grid> {
+ private:
+  enum class MovementMethods { ExpansionFactor, ObjectCenters };
+
+ public:
+  template <size_t GaussianNumber>
+  struct Gaussian {
+    static constexpr Options::String help = {
+        "Parameters for one of the Gaussians."};
+    static std::string name() {
+      return "Gaussian" + std::to_string(GaussianNumber);
+    };
+  };
+  struct Constant {
+    using type = double;
+    static constexpr Options::String help = {"The constant."};
+  };
+
+  template <typename Group>
+  struct Amplitude {
+    using group = Group;
+    using type = double;
+    static constexpr Options::String help = {"The amplitude of the Gaussian."};
+  };
+
+  template <typename Group>
+  struct Width {
+    using group = Group;
+    using type = double;
+    static constexpr Options::String help = {
+        "The unscaled width of the Gaussian."};
+    static type lower_bound() { return 0.; }
+  };
+
+  template <typename Group>
+  struct Center {
+    using group = Group;
+    using type = tmpl::conditional_t<std::is_same_v<Group, Gaussian<3>>,
+                                     std::array<double, 3>,
+                                     Options::Auto<std::array<double, 3>>>;
+    static constexpr Options::String help = {"The center of the Gaussian."};
+  };
+
+  /// \brief How to track the movement of the compact objects.
+  ///
+  /// - `ExpansionFactor` for BBH simulations.
+  /// - `ObjectCenters` for BNS simulations.
+  struct MovementMethod {
+    using type = std::string;
+    static constexpr Options::String help = {
+        "How to track the movement of the compact objects.\n\n"
+        "- `ExpansionFactor` for BBH simulations.\n"
+        "- `ObjectCenters` for BNS simulations."};
+  };
+
+  using options =
+      tmpl::list<Constant, Amplitude<Gaussian<1>>, Width<Gaussian<1>>,
+                 Center<Gaussian<1>>, Amplitude<Gaussian<2>>,
+                 Width<Gaussian<2>>, Center<Gaussian<2>>,
+                 Amplitude<Gaussian<3>>, Width<Gaussian<3>>,
+                 Center<Gaussian<3>>, MovementMethod>;
+
+  static constexpr Options::String help = {
+      "Computes a sum of a constant and 3 Gaussians (each with its own "
+      "amplitude, width, and coordinate center), with the Gaussian widths "
+      "scaled by the inverse of a FunctionOfTime."};
+
+  /// \cond
+  WRAPPED_PUPable_decl_base_template(
+      SINGLE_ARG(DampingFunction<3, Frame::Grid>),
+      TimeDependentTripleGaussian);  // NOLINT
+  /// \endcond
+
+  explicit TimeDependentTripleGaussian(CkMigrateMessage* msg);
+
+  TimeDependentTripleGaussian(
+      double constant, double amplitude_1, double width_1,
+      const std::optional<std::array<double, 3>>& center_1, double amplitude_2,
+      double width_2, const std::optional<std::array<double, 3>>& center_2,
+      double amplitude_3, double width_3, const std::array<double, 3>& center_3,
+      const std::string& movement_method, const Options::Context& context = {});
+
+  TimeDependentTripleGaussian() = default;
+  ~TimeDependentTripleGaussian() override = default;
+  TimeDependentTripleGaussian(const TimeDependentTripleGaussian& /*rhs*/) =
+      default;
+  TimeDependentTripleGaussian& operator=(
+      const TimeDependentTripleGaussian& /*rhs*/) = default;
+  TimeDependentTripleGaussian(TimeDependentTripleGaussian&& /*rhs*/) = default;
+  TimeDependentTripleGaussian& operator=(
+      TimeDependentTripleGaussian&& /*rhs*/) = default;
+
+  void operator()(gsl::not_null<Scalar<double>*> value_at_x,
+                  const tnsr::I<double, 3, Frame::Grid>& x, double time,
+                  const std::unordered_map<
+                      std::string,
+                      std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+                      functions_of_time) const override;
+  void operator()(gsl::not_null<Scalar<DataVector>*> value_at_x,
+                  const tnsr::I<DataVector, 3, Frame::Grid>& x, double time,
+                  const std::unordered_map<
+                      std::string,
+                      std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+                      functions_of_time) const override;
+
+  auto get_clone() const
+      -> std::unique_ptr<DampingFunction<3, Frame::Grid>> override;
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& p) override;
+
+ private:
+  friend bool operator==(const TimeDependentTripleGaussian& lhs,
+                         const TimeDependentTripleGaussian& rhs);
+
+  double constant_ = std::numeric_limits<double>::signaling_NaN();
+  double amplitude_1_ = std::numeric_limits<double>::signaling_NaN();
+  double inverse_width_1_ = std::numeric_limits<double>::signaling_NaN();
+  std::optional<std::array<double, 3>> center_1_{};
+  double amplitude_2_ = std::numeric_limits<double>::signaling_NaN();
+  double inverse_width_2_ = std::numeric_limits<double>::signaling_NaN();
+  std::optional<std::array<double, 3>> center_2_{};
+  double amplitude_3_ = std::numeric_limits<double>::signaling_NaN();
+  double inverse_width_3_ = std::numeric_limits<double>::signaling_NaN();
+  std::array<double, 3> center_3_{};
+  MovementMethods movement_method_{MovementMethods::ExpansionFactor};
+  inline static const std::string function_of_time_for_scaling_{"Expansion"};
+  inline static const std::string function_of_time_for_centers_{"GridCenters"};
+
+  template <typename T>
+  void apply_call_operator(
+      gsl::not_null<Scalar<T>*> value_at_x, const tnsr::I<T, 3, Frame::Grid>& x,
+      double time,
+      const std::unordered_map<
+          std::string,
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+          functions_of_time) const;
+};
+
+bool operator!=(const TimeDependentTripleGaussian& lhs,
+                const TimeDependentTripleGaussian& rhs);
+}  // namespace ScalarTensor::ConstraintDamping

--- a/src/Evolution/Systems/ScalarTensor/Initialize.hpp
+++ b/src/Evolution/Systems/ScalarTensor/Initialize.hpp
@@ -11,6 +11,8 @@
 #include "Evolution/Systems/GeneralizedHarmonic/Constraints.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/System.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
+#include "Evolution/Systems/ScalarTensor/ConstraintDamping/ConstraintGammas.hpp"
+#include "Evolution/Systems/ScalarTensor/ConstraintDamping/Tags.hpp"
 #include "Evolution/Systems/ScalarTensor/Sources/ScalarSource.hpp"
 #include "Evolution/Systems/ScalarTensor/Tags.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Christoffel.hpp"
@@ -68,6 +70,11 @@ using scalar_tensor_3plus1_compute_tags = tmpl::list<
     gh::ConstraintDamping::Tags::ConstraintGamma0Compute<Dim, Frame::Grid>,
     gh::ConstraintDamping::Tags::ConstraintGamma1Compute<Dim, Frame::Grid>,
     gh::ConstraintDamping::Tags::ConstraintGamma2Compute<Dim, Frame::Grid>,
+
+    ScalarTensor::ConstraintDamping::Tags::ConstraintGamma1Compute<Dim,
+                                                                   Frame::Grid>,
+    ScalarTensor::ConstraintDamping::Tags::ConstraintGamma2Compute<Dim,
+                                                                   Frame::Grid>,
 
     ScalarTensor::Tags::ScalarSourceCompute>;
 

--- a/src/Evolution/Systems/ScalarTensor/Tags.hpp
+++ b/src/Evolution/Systems/ScalarTensor/Tags.hpp
@@ -11,6 +11,7 @@
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Evolution/Systems/CurvedScalarWave/Constraints.hpp"
 #include "Evolution/Systems/CurvedScalarWave/Tags.hpp"
+#include "Evolution/Tags.hpp"
 #include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
 #include "Options/String.hpp"
 #include "Utilities/TMPL.hpp"
@@ -151,5 +152,18 @@ struct CswTwoIndexConstraintCompute
 };
 
 }  // namespace Tags
+
+namespace OptionTags {
+/*!
+ * \ingroup OptionGroupsGroup
+ * Groups option tags related to the ScalarTensor evolution system.
+ */
+struct Group {
+  static std::string name() { return "ScalarTensor"; }
+  static constexpr Options::String help{
+      "Options for the ScalarTensor evolution system"};
+  using group = evolution::OptionTags::SystemGroup;
+};
+}  // namespace OptionTags
 
 }  // namespace ScalarTensor

--- a/tests/InputFiles/ScalarTensor/KerrSchildSphericalHarmonic.yaml
+++ b/tests/InputFiles/ScalarTensor/KerrSchildSphericalHarmonic.yaml
@@ -100,6 +100,19 @@ EvolutionSystem:
         Amplitude: 1.0
         Width: 11.313708499
         Center: [0.0, 0.0, 0.0]
+  ScalarTensor:
+    DampingFunctionGamma1:
+      GaussianPlusConstant:
+        Constant: 0.0
+        Amplitude: 0.0
+        Width: 11.313708499
+        Center: [0.0, 0.0, 0.0]
+    DampingFunctionGamma2:
+      GaussianPlusConstant:
+        Constant: 0.001
+        Amplitude: 1.0
+        Width: 11.313708499
+        Center: [0.0, 0.0, 0.0]
 
 Filtering:
   ExpFilter0:

--- a/tests/Unit/Evolution/Systems/ScalarTensor/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/ScalarTensor/CMakeLists.txt
@@ -6,6 +6,7 @@ set(LIBRARY "Test_ScalarTensor")
 set(LIBRARY_SOURCES
   BoundaryConditions/Test_ConstraintPreserving.cpp
   BoundaryConditions/Test_DemandOutgoingCharSpeeds.cpp
+  ConstraintDamping/Test_GaussianPlusConstant.cpp
   Test_Characteristics.cpp
   Test_Constraints.cpp
   Test_Sources.cpp

--- a/tests/Unit/Evolution/Systems/ScalarTensor/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/ScalarTensor/CMakeLists.txt
@@ -7,6 +7,7 @@ set(LIBRARY_SOURCES
   BoundaryConditions/Test_ConstraintPreserving.cpp
   BoundaryConditions/Test_DemandOutgoingCharSpeeds.cpp
   ConstraintDamping/Test_GaussianPlusConstant.cpp
+  ConstraintDamping/Test_TimeDependentTripleGaussian.cpp
   Test_Characteristics.cpp
   Test_Constraints.cpp
   Test_Sources.cpp

--- a/tests/Unit/Evolution/Systems/ScalarTensor/ConstraintDamping/Test_GaussianPlusConstant.cpp
+++ b/tests/Unit/Evolution/Systems/ScalarTensor/ConstraintDamping/Test_GaussianPlusConstant.cpp
@@ -1,0 +1,57 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <limits>
+#include <random>
+
+#include "DataStructures/DataVector.hpp"
+#include "Evolution/Systems/ScalarTensor/ConstraintDamping/DampingFunction.hpp"
+#include "Evolution/Systems/ScalarTensor/ConstraintDamping/GaussianPlusConstant.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Serialization/RegisterDerivedClassesWithCharm.hpp"
+
+SPECTRE_TEST_CASE(
+    "Unit.Evolution.Systems.ScalarTensor.ConstraintDamp.GaussPlusConst",
+    "[PointwiseFunctions][Unit]") {
+  const DataVector dv{5};
+
+  TestHelpers::test_creation<std::unique_ptr<
+      ScalarTensor::ConstraintDamping::DampingFunction<1, Frame::Inertial>>>(
+      "GaussianPlusConstant:\n"
+      "  Constant: 4.0\n"
+      "  Amplitude: 3.0\n"
+      "  Width: 2.0\n"
+      "  Center: [-9.0]");
+
+  const double constant_3d{5.0};
+  const double amplitude_3d{4.0};
+  const double width_3d{1.5};
+  const std::array<double, 3> center_3d{{1.1, -2.2, 3.3}};
+  const ScalarTensor::ConstraintDamping::GaussianPlusConstant<3,
+                                                              Frame::Inertial>
+      gauss_plus_const_3d{constant_3d, amplitude_3d, width_3d, center_3d};
+  const auto created_gauss_plus_const =
+      TestHelpers::test_creation<ScalarTensor::ConstraintDamping::
+                                     GaussianPlusConstant<3, Frame::Inertial>>(
+          "Constant: 5.0\n"
+          "Amplitude: 4.0\n"
+          "Width: 1.5\n"
+          "Center: [1.1, -2.2, 3.3]");
+  CHECK(created_gauss_plus_const == gauss_plus_const_3d);
+  const auto created_gauss_gh_damping_function =
+      TestHelpers::test_creation<std::unique_ptr<
+        ScalarTensor::ConstraintDamping::DampingFunction<3, Frame::Inertial>>>(
+          "GaussianPlusConstant:\n"
+          "  Constant: 5.0\n"
+          "  Amplitude: 4.0\n"
+          "  Width: 1.5\n"
+          "  Center: [1.1, -2.2, 3.3]");
+
+  test_serialization(gauss_plus_const_3d);
+}

--- a/tests/Unit/Evolution/Systems/ScalarTensor/ConstraintDamping/Test_TimeDependentTripleGaussian.cpp
+++ b/tests/Unit/Evolution/Systems/ScalarTensor/ConstraintDamping/Test_TimeDependentTripleGaussian.cpp
@@ -1,0 +1,330 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <limits>
+#include <memory>
+#include <pup.h>
+#include <random>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "Domain/FunctionsOfTime/PiecewisePolynomial.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/DampingFunction.hpp"
+#include "Evolution/Systems/ScalarTensor/ConstraintDamping/DampingFunction.hpp"
+#include "Evolution/Systems/ScalarTensor/ConstraintDamping/TimeDependentTripleGaussian.hpp"
+#include "Framework/CheckWithRandomValues.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "Helpers/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/TestHelpers.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Literals.hpp"
+#include "Utilities/MakeWithValue.hpp"
+#include "Utilities/Overloader.hpp"
+#include "Utilities/Serialization/PupStlCpp11.hpp"
+#include "Utilities/Serialization/RegisterDerivedClassesWithCharm.hpp"
+
+namespace TestHelpers::ScalarTensor::ConstraintDamping {
+namespace detail {
+template <size_t VolumeDim, typename Fr, class... MemberArgs, class T>
+void check_impl(
+    const std::unique_ptr<::ScalarTensor::ConstraintDamping::DampingFunction<
+        VolumeDim, Fr>>& in_gh_damping_function,
+    const std::string& python_function_prefix, const T& used_for_size,
+    const std::array<std::pair<double, double>, 1> random_value_bounds,
+    const std::vector<std::string>& function_of_time_names,
+    const MemberArgs&... member_args) {
+  using GhDampingFunc =
+      ::ScalarTensor::ConstraintDamping::DampingFunction<VolumeDim, Fr>;
+
+  const auto member_args_tuple = std::make_tuple(member_args...);
+  const auto helper = [&python_function_prefix, &random_value_bounds,
+                       &member_args_tuple, &function_of_time_names,
+                       &used_for_size](const std::unique_ptr<GhDampingFunc>&
+                                           gh_damping_function) {
+    INFO("Testing call operator...");
+    // Make a lambda that calls the damping function's call operator
+    // with a hard-coded FunctionsOfTime, since check_with_random_values
+    // cannot convert a FunctionsOfTime into a python type.
+    // The FunctionsOfTime contains a single FunctionOfTime
+    // \f$f(t) = a_0 + a_1 (t-t_0) + a_2 (t-t_0)^2 + a_3 (t-t_0)^3\f$, where
+    // \f$a_0 = 1.0\f$, \f$a_1 = 0.2\f$, \f$a_2 = 0.03,\f$,
+    // \f$a_3 = 0.004\f$, and \f$t_0\f$ is the smallest possible value
+    // of the randomly selected time.
+    //
+    // The corresponding python function should use
+    // the same hard-coded coefficients to evaluate \f$f(t)\f$ as well
+    // as the same value of \f$t_0\f$.
+    // However, here the PiecewisePolynomial must be initialized not
+    // with the polynomial coefficients but with the values of \f$f(t)\f$
+    // and its derivatives evaluated at \f$t=t_0\f$: these are,
+    // respectively, \f$a_0,a_1,2 a_2,6 a_3\f$.
+    //
+    // Finally, note that the FunctionOfTime never expires.
+    const auto damping_function_call_operator_helper =
+        [&gh_damping_function, &random_value_bounds, &function_of_time_names](
+            const tnsr::I<T, VolumeDim, Fr>& coordinates, const double time) {
+          std::unordered_map<
+              std::string,
+              std::unique_ptr<::domain::FunctionsOfTime::FunctionOfTime>>
+              functions_of_time{};
+          for (const auto& function_of_time_name : function_of_time_names) {
+            if (function_of_time_name == "GridCenters") {
+              functions_of_time[function_of_time_name] = std::make_unique<
+                  ::domain::FunctionsOfTime::PiecewisePolynomial<3>>(
+                  std::min(gsl::at(random_value_bounds, 0).first,
+                           gsl::at(random_value_bounds, 0).second),
+                  std::array<DataVector, 4>{
+                      {{16.0, 0.0, 0.0, -16.0, 0.0, 0.0},
+                       {-0.001, 0.0, 0.0, 0.002, 0.0, 0.0},
+                       {0.0, 0.0, 0.0, 0.0, 0.0, 0.0},
+                       {0.0, 0.0, 0.0, 0.0, 0.0, 0.0}}},
+                  std::numeric_limits<double>::max());
+            } else {
+              // The randomly selected time will be between the
+              // random_value_bounds, so set the earliest time of the
+              // function_of_times to the lower bound in
+              // random_value_bounds.
+              functions_of_time[function_of_time_name] = std::make_unique<
+                  ::domain::FunctionsOfTime::PiecewisePolynomial<3>>(
+                  std::min(gsl::at(random_value_bounds, 0).first,
+                           gsl::at(random_value_bounds, 0).second),
+                  std::array<DataVector, 4>{{{1.0}, {0.2}, {0.06}, {0.024}}},
+                  std::numeric_limits<double>::max());
+            }
+          }
+          // Default-construct the scalar, to test that the damping
+          // function's call operator correctly resizes it
+          // (in the case T is a DataVector)
+          // with set_number_of_grid_points()
+          Scalar<T> value_at_coordinates{};
+          gh_damping_function->operator()(make_not_null(&value_at_coordinates),
+                                          coordinates, time, functions_of_time);
+          return value_at_coordinates;
+        };
+
+    pypp::check_with_random_values<1>(
+        &decltype(damping_function_call_operator_helper)::operator(),
+        damping_function_call_operator_helper, "TestFunctions",
+        python_function_prefix + "_call_operator", random_value_bounds,
+        member_args_tuple, used_for_size);
+    INFO("Done testing call operator...");
+    INFO("Done\n\n");
+  };
+
+  helper(in_gh_damping_function);
+  helper(serialize_and_deserialize(in_gh_damping_function));
+}
+}  // namespace detail
+
+// \ingroup TestingFrameworkGroup
+// \brief Test a DampingFunction by comparing to python functions
+
+// The python functions must be added to TestFunctions.py in
+// tests/Unit/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/Python.
+// Each python function for a corresponding DampingFunction should begin
+// with a prefix `python_function_prefix`. The prefix for each class of
+// DampingFunction is arbitrary, but should generally be descriptive (e.g.
+// 'gaussian_plus_constant') of the DampingFunction.
+
+// The input parameter `function_of_time_name` is the name of the FunctionOfTime
+// that will be included in the FunctionsOfTime passed to the DampingFunction's
+// call operator. For time-dependent DampingFunctions, this parameter must be
+// consistent with the FunctionOfTime name that the call operator of
+// `in_gh_damping_function` expects. For time-independent DampingFunctions,
+// `function_of_time_name` will be ignored.
+
+// If a DampingFunction class has member variables set by its constructor, then
+// these member variables must be passed in as the last arguments to the `check`
+// function`. Each python function must take these same arguments as the
+// trailing arguments.
+template <class DampingFunctionType, class T, class... MemberArgs>
+void check(std::unique_ptr<DampingFunctionType> in_gh_damping_function,
+           const std::string& python_function_prefix, const T& used_for_size,
+           const std::array<std::pair<double, double>, 1>& random_value_bounds,
+           const std::vector<std::string>& function_of_time_names,
+           const MemberArgs&... member_args) {
+  detail::check_impl(
+      std::unique_ptr<::ScalarTensor::ConstraintDamping::DampingFunction<
+          DampingFunctionType::volume_dim,
+          typename DampingFunctionType::frame>>(
+          std::move(in_gh_damping_function)),
+      python_function_prefix, used_for_size, random_value_bounds,
+      function_of_time_names, member_args...);
+}
+
+template <class DampingFunctionType, class T, class... MemberArgs>
+void check(DampingFunctionType in_gh_damping_function,
+           const std::string& python_function_prefix, const T& used_for_size,
+           const std::array<std::pair<double, double>, 1>& random_value_bounds,
+           const std::vector<std::string>& function_of_time_names,
+           const MemberArgs&... member_args) {
+  detail::check_impl(
+      std::unique_ptr<::ScalarTensor::ConstraintDamping::DampingFunction<
+          DampingFunctionType::volume_dim,
+          typename DampingFunctionType::frame>>(
+          std::make_unique<DampingFunctionType>(
+              std::move(in_gh_damping_function))),
+      python_function_prefix, used_for_size, random_value_bounds,
+      function_of_time_names, member_args...);
+}
+
+}  // namespace TestHelpers::ScalarTensor::ConstraintDamping
+
+namespace {
+template <typename DataType>
+void test_triple_gaussian_random(const DataType& used_for_size) {
+  register_derived_classes_with_charm<
+      ScalarTensor::ConstraintDamping::TimeDependentTripleGaussian>();
+
+  // Generate the amplitude and width
+  MAKE_GENERATOR(gen);
+  std::uniform_real_distribution<> real_dis(-1.0, 1.0);
+  std::uniform_real_distribution<> positive_dis(0.0, 1.0);
+
+  const double constant = real_dis(gen);
+
+  const double amplitude_1{positive_dis(gen)};
+  const double amplitude_2{positive_dis(gen)};
+  const double amplitude_3{positive_dis(gen)};
+
+  const double width_1{positive_dis(gen) + 0.5};
+  const double width_2{positive_dis(gen) + 0.5};
+  const double width_3{positive_dis(gen) + 0.5};
+
+  // Generate the center
+  std::array<double, 3> center_1{};
+  std::array<double, 3> center_2{};
+  std::array<double, 3> center_3{};
+  for (size_t i = 0; i < 3; ++i) {
+    gsl::at(center_1, i) = real_dis(gen);
+    gsl::at(center_2, i) = real_dis(gen);
+    gsl::at(center_3, i) = real_dis(gen);
+  }
+
+  // Name of FunctionOfTime to read. This must match up with the hard coded name
+  // in the TimeDependentTripleGaussian
+  const std::string function_of_time_for_scaling{"Expansion"s};
+
+  const ScalarTensor::ConstraintDamping::TimeDependentTripleGaussian
+      triple_gauss{constant,    amplitude_1, width_1,          center_1,
+                   amplitude_2, width_2,     center_2,         amplitude_3,
+                   width_3,     center_3,    "ExpansionFactor"};
+
+  TestHelpers::ScalarTensor::ConstraintDamping::check(
+      std::move(triple_gauss), "time_dependent_triple_gaussian", used_for_size,
+      {{{-1.0, 1.0}}}, {function_of_time_for_scaling}, constant, amplitude_1,
+      width_1, center_1, amplitude_2, width_2, center_2, amplitude_3, width_3,
+      center_3);
+
+  const std::unique_ptr<
+      ScalarTensor::ConstraintDamping::TimeDependentTripleGaussian>
+      triple_gauss_unique_ptr = std::make_unique<
+          ScalarTensor::ConstraintDamping::TimeDependentTripleGaussian>(
+          constant, amplitude_1, width_1, center_1, amplitude_2, width_2,
+          center_2, amplitude_3, width_3, center_3, "ExpansionFactor");
+
+  TestHelpers::ScalarTensor::ConstraintDamping::check(
+      triple_gauss_unique_ptr->get_clone(), "time_dependent_triple_gaussian",
+      used_for_size, {{{-1.0, 1.0}}}, {function_of_time_for_scaling}, constant,
+      amplitude_1, width_1, center_1, amplitude_2, width_2, center_2,
+      amplitude_3, width_3, center_3);
+
+  const std::unique_ptr<
+      ScalarTensor::ConstraintDamping::TimeDependentTripleGaussian>
+      triple_gauss_object_centers_unique_ptr = std::make_unique<
+          ScalarTensor::ConstraintDamping::TimeDependentTripleGaussian>(
+          constant, amplitude_1, width_1, std::nullopt, amplitude_2, width_2,
+          std::nullopt, amplitude_3, width_3, center_3, "ObjectCenters");
+
+  REQUIRE(
+      dynamic_cast<
+          const ScalarTensor::ConstraintDamping::TimeDependentTripleGaussian&>(
+          *triple_gauss_object_centers_unique_ptr->get_clone()) ==
+      *triple_gauss_object_centers_unique_ptr);
+  TestHelpers::ScalarTensor::ConstraintDamping::check(
+      triple_gauss_object_centers_unique_ptr->get_clone(),
+      "time_dependent_triple_gaussian_object_centers", used_for_size,
+      {{{-1.0, 1.0}}}, {"GridCenters"}, constant, amplitude_1, width_1,
+      center_1, amplitude_2, width_2, center_2, amplitude_3, width_3, center_3);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE(
+    "Unit.Evolution.Systems.ScalarTensor.ConstraintDamp.TimeDep3Gauss",
+    "[PointwiseFunctions][Unit]") {
+  const DataVector dv{5};
+
+  pypp::SetupLocalPythonEnvironment{
+      "Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/Python"};
+
+  test_triple_gaussian_random<DataVector>(dv);
+  test_triple_gaussian_random<double>(
+      std::numeric_limits<double>::signaling_NaN());
+
+  const double constant_3d{5.0};
+  const double amplitude_1_3d{4.0};
+  const double width_1_3d{1.5};
+  const std::array<double, 3> center_1_3d{{1.1, -2.2, 3.3}};
+  const double amplitude_2_3d{3.0};
+  const double width_2_3d{2.0};
+  const std::array<double, 3> center_2_3d{{4.4, -5.5, 6.6}};
+  const double amplitude_3_3d{5.0};
+  const double width_3_3d{1.0};
+  const std::array<double, 3> center_3_3d{{7.7, -8.8, 9.9}};
+
+  const ScalarTensor::ConstraintDamping::TimeDependentTripleGaussian
+      triple_gauss_3d{constant_3d, amplitude_1_3d,   width_1_3d,
+                      center_1_3d, amplitude_2_3d,   width_2_3d,
+                      center_2_3d, amplitude_3_3d,   width_3_3d,
+                      center_3_3d, "ExpansionFactor"};
+  const auto created_triple_gauss = TestHelpers::test_creation<
+      ScalarTensor::ConstraintDamping::TimeDependentTripleGaussian>(
+      "Constant: 5.0\n"
+      "Gaussian1:\n"
+      "  Amplitude: 4.0\n"
+      "  Width: 1.5\n"
+      "  Center: [1.1, -2.2, 3.3]\n"
+      "Gaussian2:\n"
+      "  Amplitude: 3.0\n"
+      "  Width: 2.0\n"
+      "  Center: [4.4, -5.5, 6.6]\n"
+      "Gaussian3:\n"
+      "  Amplitude: 5.0\n"
+      "  Width: 1.0\n"
+      "  Center: [7.7, -8.8, 9.9]\n"
+      "MovementMethod: ExpansionFactor\n");
+  CHECK(created_triple_gauss == triple_gauss_3d);
+  CHECK_FALSE(created_triple_gauss != triple_gauss_3d);
+  const auto created_triple_gauss_gh_damping_function =
+      TestHelpers::test_creation<std::unique_ptr<
+          ScalarTensor::ConstraintDamping::DampingFunction<3, Frame::Grid>>>(
+          "TimeDependentTripleGaussian:\n"
+          "  Constant: 5.0\n"
+          "  Gaussian1:\n"
+          "    Amplitude: 4.0\n"
+          "    Width: 1.5\n"
+          "    Center: [1.1, -2.2, 3.3]\n"
+          "  Gaussian2:\n"
+          "    Amplitude: 3.0\n"
+          "    Width: 2.0\n"
+          "    Center: [4.4, -5.5, 6.6]\n"
+          "  Gaussian3:\n"
+          "    Amplitude: 5.0\n"
+          "    Width: 1.0\n"
+          "    Center: [7.7, -8.8, 9.9]\n"
+          "  MovementMethod: ExpansionFactor\n");
+
+  test_serialization(triple_gauss_3d);
+}


### PR DESCRIPTION
## Proposed changes

I want add the Gaussian plus constant for the constraint gammas of the CurvedScalarWave system.

(Is there a way the to avoid so much duplicate code? Some member functions of the gh classes are private so I think I cannot wrap them.)

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
