### PR TITLE
Enable ParaView on CaltechHPC

### DIFF
--- a/support/Environments/caltech_hpc_gcc.sh
+++ b/support/Environments/caltech_hpc_gcc.sh
@@ -13,12 +13,12 @@ spectre_setup_modules() {
 
 spectre_load_modules() {
     module use /central/groups/sxs/modules/
-    module load libraries/spectre-deps/skylake-2024-04
+    module load libraries/spectre-deps/skylake-2024-06
 }
 
 spectre_unload_modules() {
     module use /central/groups/sxs/modules/
-    module unload libraries/spectre-deps/skylake-2024-04
+    module unload libraries/spectre-deps/skylake-2024-06
 }
 
 spectre_run_cmake() {
@@ -40,8 +40,6 @@ spectre_run_cmake() {
     #   of nodes on CaltechHPC. All dependencies were also compiled for skylake.
     #   This means we should be able to run on all types of nodes available on
     #   the cluster.
-    # - We temporarily turn off ParaView until a compatible version is
-    #   installed.
     cmake -D CMAKE_C_COMPILER=gcc \
           -D CMAKE_CXX_COMPILER=g++ \
           -D CMAKE_Fortran_COMPILER=gfortran \
@@ -54,7 +52,7 @@ spectre_run_cmake() {
           -D BUILD_PYTHON_BINDINGS=ON \
           -D MACHINE=CaltechHpc \
           -D OVERRIDE_ARCH=skylake \
-          -D ENABLE_PARAVIEW=OFF \
+          -D ENABLE_PARAVIEW=ON \
           "$@" \
           $SPECTRE_HOME
 }


### PR DESCRIPTION
This new environment is the same as before, except switched to Python 3.10 and added a ParaView module. Enables 3D rendering scripts.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
