### PR TITLE
Add stress-energy tensor to FConstraint in ScalarTensor

### DIFF
--- a/src/Evolution/Executables/ScalarTensor/ScalarTensorBase.hpp
+++ b/src/Evolution/Executables/ScalarTensor/ScalarTensorBase.hpp
@@ -47,6 +47,7 @@
 #include "Evolution/Systems/ScalarTensor/BoundaryConditions/ProductOfConditions.hpp"
 #include "Evolution/Systems/ScalarTensor/BoundaryCorrections/Factory.hpp"
 #include "Evolution/Systems/ScalarTensor/BoundaryCorrections/ProductOfCorrections.hpp"
+#include "Evolution/Systems/ScalarTensor/Constraints.hpp"
 #include "Evolution/Systems/ScalarTensor/Initialize.hpp"
 #include "Evolution/Systems/ScalarTensor/Sources/ScalarSource.hpp"
 #include "Evolution/Systems/ScalarTensor/StressEnergy.hpp"
@@ -267,7 +268,7 @@ struct ObserverTags {
       // The 4-index constraint is only implemented in 3d
       tmpl::list<
           gh::Tags::FourIndexConstraintCompute<volume_dim, Frame::Inertial>,
-          gh::Tags::FConstraintCompute<volume_dim, Frame::Inertial>,
+          ScalarTensor::Tags::FConstraintCompute<volume_dim, Frame::Inertial>,
           ::Tags::PointwiseL2NormCompute<
               gh::Tags::FConstraint<DataVector, volume_dim>>,
           ::Tags::PointwiseL2NormCompute<

--- a/src/Evolution/Systems/ScalarTensor/CMakeLists.txt
+++ b/src/Evolution/Systems/ScalarTensor/CMakeLists.txt
@@ -18,6 +18,7 @@ spectre_target_headers(
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   Characteristics.hpp
+  Constraints.hpp
   Initialize.hpp
   StressEnergy.hpp
   System.hpp

--- a/src/Evolution/Systems/ScalarTensor/Constraints.hpp
+++ b/src/Evolution/Systems/ScalarTensor/Constraints.hpp
@@ -1,0 +1,70 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/Tags.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Constraints.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
+#include "Evolution/Systems/ScalarTensor/Tags.hpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace ScalarTensor::Tags {
+/*!
+ * \brief Compute item to get the F-constraint for the generalized harmonic
+ * evolution system with an scalar field stress-energy source.
+ *
+ * \details See `gh::f_constraint()`. Can be retrieved using
+ * `gh::Tags::FConstraint`.
+ */
+template <size_t SpatialDim, typename Frame>
+struct FConstraintCompute
+    : gh::Tags::FConstraint<DataVector, SpatialDim, Frame>,
+      db::ComputeTag {
+  using argument_tags = tmpl::list<
+      gh::Tags::GaugeH<DataVector, SpatialDim, Frame>,
+      gh::Tags::SpacetimeDerivGaugeH<DataVector, SpatialDim, Frame>,
+      gr::Tags::SpacetimeNormalOneForm<DataVector, SpatialDim, Frame>,
+      gr::Tags::SpacetimeNormalVector<DataVector, SpatialDim, Frame>,
+      gr::Tags::InverseSpatialMetric<DataVector, SpatialDim, Frame>,
+      gr::Tags::InverseSpacetimeMetric<DataVector, SpatialDim, Frame>,
+      gh::Tags::Pi<DataVector, SpatialDim, Frame>,
+      gh::Tags::Phi<DataVector, SpatialDim, Frame>,
+      ::Tags::deriv<gh::Tags::Pi<DataVector, SpatialDim, Frame>,
+                    tmpl::size_t<SpatialDim>, Frame>,
+      ::Tags::deriv<gh::Tags::Phi<DataVector, SpatialDim, Frame>,
+                    tmpl::size_t<SpatialDim>, Frame>,
+      ::gh::ConstraintDamping::Tags::ConstraintGamma2,
+      gh::Tags::ThreeIndexConstraint<DataVector, SpatialDim, Frame>,
+      Tags::TraceReversedStressEnergy<DataVector, SpatialDim, Frame>>;
+
+  using return_type = tnsr::a<DataVector, SpatialDim, Frame>;
+
+  static constexpr auto function = static_cast<void (*)(
+      gsl::not_null<tnsr::a<DataVector, SpatialDim, Frame>*>,
+      const tnsr::a<DataVector, SpatialDim, Frame>&,
+      const tnsr::ab<DataVector, SpatialDim, Frame>&,
+      const tnsr::a<DataVector, SpatialDim, Frame>&,
+      const tnsr::A<DataVector, SpatialDim, Frame>&,
+      const tnsr::II<DataVector, SpatialDim, Frame>&,
+      const tnsr::AA<DataVector, SpatialDim, Frame>&,
+      const tnsr::aa<DataVector, SpatialDim, Frame>&,
+      const tnsr::iaa<DataVector, SpatialDim, Frame>&,
+      const tnsr::iaa<DataVector, SpatialDim, Frame>&,
+      const tnsr::ijaa<DataVector, SpatialDim, Frame>&,
+      const Scalar<DataVector>&,
+      const tnsr::iaa<DataVector, SpatialDim, Frame>&,
+      const tnsr::aa<DataVector, SpatialDim, Frame>&)>(
+      &gh::f_constraint<DataVector, SpatialDim, Frame>);
+
+  using base = gh::Tags::FConstraint<DataVector, SpatialDim, Frame>;
+};
+}  // namespace ScalarTensor::Tags

--- a/tests/Unit/Evolution/Systems/ScalarTensor/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/ScalarTensor/CMakeLists.txt
@@ -8,6 +8,7 @@ set(LIBRARY_SOURCES
   BoundaryConditions/Test_ProductOfConditions.cpp
   BoundaryCorrections/Test_ProductOfCorrections.cpp
   Test_Characteristics.cpp
+  Test_Constraints.cpp
   Test_Sources.cpp
   Test_StressEnergy.cpp
   Test_Tags.cpp

--- a/tests/Unit/Evolution/Systems/ScalarTensor/Test_Constraints.cpp
+++ b/tests/Unit/Evolution/Systems/ScalarTensor/Test_Constraints.cpp
@@ -1,0 +1,14 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include "Evolution/Systems/ScalarTensor/Constraints.hpp"
+#include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
+
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.ScalarTensor.Constraints",
+                  "[Unit][Evolution]") {
+  TestHelpers::db::test_compute_tag<
+      ScalarTensor::Tags::FConstraintCompute<3, Frame::Inertial>>(
+      "FConstraint");
+}


### PR DESCRIPTION
## Proposed changes

Properly compute the FConstaint by adding the stress energy tensor as in the grmhd system.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
