### PR TITLE
Compute total ADM linear momentum integrands.

### DIFF
--- a/src/PointwiseFunctions/Xcts/AdmLinearMomentum.cpp
+++ b/src/PointwiseFunctions/Xcts/AdmLinearMomentum.cpp
@@ -1,0 +1,82 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "PointwiseFunctions/Xcts/AdmLinearMomentum.hpp"
+
+#include <cmath>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Slice.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/IndexToSliceAt.hpp"
+#include "NumericalAlgorithms/LinearOperators/Divergence.hpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace Xcts {
+
+void adm_linear_momentum_surface_integrand(
+    gsl::not_null<tnsr::II<DataVector, 3>*> result,
+    const Scalar<DataVector>& conformal_factor,
+    const tnsr::II<DataVector, 3>& inv_spatial_metric,
+    const tnsr::II<DataVector, 3>& inv_extrinsic_curvature,
+    const Scalar<DataVector>& trace_extrinsic_curvature) {
+  tenex::evaluate<ti::I, ti::J>(
+      result,
+      1. / (8. * M_PI) * pow<10>(conformal_factor()) *
+          (inv_extrinsic_curvature(ti::I, ti::J) -
+           trace_extrinsic_curvature() * inv_spatial_metric(ti::I, ti::J)));
+}
+
+tnsr::II<DataVector, 3> adm_linear_momentum_surface_integrand(
+    const Scalar<DataVector>& conformal_factor,
+    const tnsr::II<DataVector, 3>& inv_spatial_metric,
+    const tnsr::II<DataVector, 3>& inv_extrinsic_curvature,
+    const Scalar<DataVector>& trace_extrinsic_curvature) {
+  tnsr::II<DataVector, 3> result;
+  adm_linear_momentum_surface_integrand(
+      make_not_null(&result), conformal_factor, inv_spatial_metric,
+      inv_extrinsic_curvature, trace_extrinsic_curvature);
+  return result;
+}
+
+void adm_linear_momentum_volume_integrand(
+    gsl::not_null<tnsr::I<DataVector, 3>*> result,
+    const tnsr::II<DataVector, 3>& surface_integrand,
+    const Scalar<DataVector>& conformal_factor,
+    const tnsr::i<DataVector, 3>& conformal_factor_deriv,
+    const tnsr::ii<DataVector, 3>& conformal_metric,
+    const tnsr::II<DataVector, 3>& inv_conformal_metric,
+    const tnsr::Ijj<DataVector, 3>& conformal_christoffel_second_kind,
+    const tnsr::i<DataVector, 3>& conformal_christoffel_contracted) {
+  tenex::evaluate<ti::I>(
+      result,
+      -(conformal_christoffel_second_kind(ti::I, ti::j, ti::k) *
+            surface_integrand(ti::J, ti::K) +
+        conformal_christoffel_contracted(ti::k) *
+            surface_integrand(ti::I, ti::K) -
+        2. * conformal_metric(ti::j, ti::k) * surface_integrand(ti::J, ti::K) *
+            inv_conformal_metric(ti::I, ti::L) * conformal_factor_deriv(ti::l) /
+            conformal_factor()));
+}
+
+tnsr::I<DataVector, 3> adm_linear_momentum_volume_integrand(
+    const tnsr::II<DataVector, 3>& surface_integrand,
+    const Scalar<DataVector>& conformal_factor,
+    const tnsr::i<DataVector, 3>& conformal_factor_deriv,
+    const tnsr::ii<DataVector, 3>& conformal_metric,
+    const tnsr::II<DataVector, 3>& inv_conformal_metric,
+    const tnsr::Ijj<DataVector, 3>& conformal_christoffel_second_kind,
+    const tnsr::i<DataVector, 3>& conformal_christoffel_contracted) {
+  tnsr::I<DataVector, 3> result;
+  adm_linear_momentum_volume_integrand(
+      make_not_null(&result), surface_integrand, conformal_factor,
+      conformal_factor_deriv, conformal_metric, inv_conformal_metric,
+      conformal_christoffel_second_kind, conformal_christoffel_contracted);
+  return result;
+}
+
+}  // namespace Xcts

--- a/src/PointwiseFunctions/Xcts/AdmLinearMomentum.hpp
+++ b/src/PointwiseFunctions/Xcts/AdmLinearMomentum.hpp
@@ -1,0 +1,103 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Slice.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/IndexToSliceAt.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "Utilities/Gsl.hpp"
+
+#include <cmath>
+
+#include "NumericalAlgorithms/LinearOperators/Divergence.hpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
+
+namespace Xcts {
+
+/// @{
+/*!
+ * \brief Surface integrand for ADM linear momentum calculation defined as (see
+ * Eq. 20 in \cite Ossokine2015yla):
+ *
+ * \begin{equation}
+ *   \frac{1}{8\pi} \psi^{10} (K^{ij} - K \gamma^{ij})
+ * \end{equation}
+ *
+ * \param result output buffer for the surface integrand
+ * \param conformal_factor the conformal factor $\psi$
+ * \param inv_spatial_metric the inverse spatial metric $\gamma^{ij}$
+ * \param inv_extrinsic_curvature the inverse extrinsic curvature $K^{ij}$
+ * \param trace_extrinsic_curvature the trace of the extrinsic curvature $K$
+ */
+void adm_linear_momentum_surface_integrand(
+    gsl::not_null<tnsr::II<DataVector, 3>*> result,
+    const Scalar<DataVector>& conformal_factor,
+    const tnsr::II<DataVector, 3>& inv_spatial_metric,
+    const tnsr::II<DataVector, 3>& inv_extrinsic_curvature,
+    const Scalar<DataVector>& trace_extrinsic_curvature);
+
+/// Return-by-value overload
+tnsr::II<DataVector, 3> adm_linear_momentum_surface_integrand(
+    const Scalar<DataVector>& conformal_factor,
+    const tnsr::II<DataVector, 3>& inv_spatial_metric,
+    const tnsr::II<DataVector, 3>& inv_extrinsic_curvature,
+    const Scalar<DataVector>& trace_extrinsic_curvature);
+/// @}
+
+/// @{
+/*!
+ * \brief Volume integrand for ADM linear momentum calculation defined as (see
+ * Eq. 20 in \cite Ossokine2015yla):
+ *
+ * \begin{equation}
+ *   - \frac{1}{8\pi} (
+ *       \bar\Gamma^i_{jk} P^{jk}
+ *       + \bar\Gamma^j_{jk} P^{jk}
+ *       - 2 \bar\gamma_{jk} P^{jk} \bar\gamma^{il} \partial_l(\ln\psi)
+ *   ),
+ * \end{equation}
+ *
+ * where $\frac{1}{8\pi} P^{jk}$ is the result from
+ * `adm_linear_momentum_surface_integrand`.
+ *
+ * Note that we are including the negative sign in the integrand.
+ *
+ * \param result output buffer for the surface integrand
+ * \param surface_integrand the result of
+ * `adm_linear_momentum_surface_integrand`
+ * \param conformal_factor the conformal factor $\psi$
+ * \param conformal_factor_deriv the derivative of the conformal factor
+ * $\partial_i\psi$
+ * \param conformal_metric the conformal metric $\bar\gamma_{ij}$
+ * \param inv_conformal_metric the inverse conformal metric $\bar\gamma^{ij}$
+ * \param conformal_christoffel_second_kind the conformal christoffel symbol
+ * $\bar\Gamma^i_{jk}$
+ * \param conformal_christoffel_contracted the contracted conformal christoffel
+ * symbol $\bar\Gamma_i$
+ */
+void adm_linear_momentum_volume_integrand(
+    gsl::not_null<tnsr::I<DataVector, 3>*> result,
+    const tnsr::II<DataVector, 3>& surface_integrand,
+    const Scalar<DataVector>& conformal_factor,
+    const tnsr::i<DataVector, 3>& conformal_factor_deriv,
+    const tnsr::ii<DataVector, 3>& conformal_metric,
+    const tnsr::II<DataVector, 3>& inv_conformal_metric,
+    const tnsr::Ijj<DataVector, 3>& conformal_christoffel_second_kind,
+    const tnsr::i<DataVector, 3>& conformal_christoffel_contracted);
+
+/// Return-by-value overload
+tnsr::I<DataVector, 3> adm_linear_momentum_volume_integrand(
+    const tnsr::II<DataVector, 3>& surface_integrand,
+    const Scalar<DataVector>& conformal_factor,
+    const tnsr::i<DataVector, 3>& conformal_factor_deriv,
+    const tnsr::ii<DataVector, 3>& conformal_metric,
+    const tnsr::II<DataVector, 3>& inv_conformal_metric,
+    const tnsr::Ijj<DataVector, 3>& conformal_christoffel_second_kind,
+    const tnsr::i<DataVector, 3>& conformal_christoffel_contracted);
+/// @}
+
+}  // namespace Xcts

--- a/src/PointwiseFunctions/Xcts/CMakeLists.txt
+++ b/src/PointwiseFunctions/Xcts/CMakeLists.txt
@@ -8,6 +8,7 @@ add_spectre_library(${LIBRARY})
 spectre_target_sources(
   ${LIBRARY}
   PRIVATE
+  AdmLinearMomentum.cpp
   ExtrinsicCurvature.cpp
   LongitudinalOperator.cpp
   SpacetimeQuantities.cpp
@@ -17,6 +18,7 @@ spectre_target_headers(
   ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
+  AdmLinearMomentum.hpp
   ExtrinsicCurvature.hpp
   LongitudinalOperator.hpp
   SpacetimeQuantities.hpp

--- a/tests/Unit/PointwiseFunctions/Xcts/AdmLinearMomentum.py
+++ b/tests/Unit/PointwiseFunctions/Xcts/AdmLinearMomentum.py
@@ -1,0 +1,53 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+
+
+def adm_linear_momentum_surface_integrand(
+    conformal_factor,
+    inv_spatial_metric,
+    inv_extrinsic_curvature,
+    trace_extrinsic_curvature,
+):
+    return (
+        1.0
+        / (8.0 * np.pi)
+        * conformal_factor**10
+        * (
+            inv_extrinsic_curvature
+            - trace_extrinsic_curvature * inv_spatial_metric
+        )
+    )
+
+
+def adm_linear_momentum_volume_integrand(
+    surface_integrand,
+    conformal_factor,
+    conformal_factor_deriv,
+    conformal_metric,
+    inv_conformal_metric,
+    conformal_christoffel_second_kind,
+    conformal_christoffel_contracted,
+):
+    first_term = np.einsum(
+        "ijk,jk->i",
+        conformal_christoffel_second_kind,
+        surface_integrand,
+    )
+
+    second_term = np.einsum(
+        "k,ik->i",
+        conformal_christoffel_contracted,
+        surface_integrand,
+    )
+
+    third_term = 2.0 * np.einsum(
+        "jk,jk,il,l->i",
+        conformal_metric,
+        surface_integrand,
+        inv_conformal_metric,
+        conformal_factor_deriv / conformal_factor,
+    )
+
+    return -(first_term + second_term - third_term)

--- a/tests/Unit/PointwiseFunctions/Xcts/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/Xcts/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY Test_XctsPointwiseFunctions)
 
 set(LIBRARY_SOURCES
+  Test_AdmLinearMomentum.cpp
   Test_ExtrinsicCurvature.cpp
   Test_LongitudinalOperator.cpp
   Test_SpacetimeQuantities.cpp
@@ -14,10 +15,17 @@ add_test_library(${LIBRARY} "${LIBRARY_SOURCES}")
 target_link_libraries(
   ${LIBRARY}
   PRIVATE
+  CoordinateMaps
   DataStructures
+  Domain
+  DomainCreators
+  DomainStructure
+  GeneralRelativitySolutions
+  LinearOperators
   ElasticityPointwiseFunctions
   GeneralRelativityHelpers
   Spectral
   Utilities
   XctsPointwiseFunctions
+  XctsSolutions
   )

--- a/tests/Unit/PointwiseFunctions/Xcts/Test_AdmLinearMomentum.cpp
+++ b/tests/Unit/PointwiseFunctions/Xcts/Test_AdmLinearMomentum.cpp
@@ -1,0 +1,221 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/Determinant.hpp"
+#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
+#include "DataStructures/Tensor/Slice.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/AreaElement.hpp"
+#include "Domain/CoordinateMaps/Composition.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
+#include "Domain/CoordinateMaps/KerrHorizonConforming.hpp"
+#include "Domain/CoordinateMaps/Wedge.hpp"
+#include "Domain/CreateInitialElement.hpp"
+#include "Domain/Creators/Sphere.hpp"
+#include "Domain/ElementMap.hpp"
+#include "Domain/ElementToBlockLogicalMap.hpp"
+#include "Domain/FaceNormal.hpp"
+#include "Domain/InterfaceLogicalCoordinates.hpp"
+#include "Domain/Structure/IndexToSliceAt.hpp"
+#include "Domain/Structure/InitialElementIds.hpp"
+#include "Framework/CheckWithRandomValues.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "NumericalAlgorithms/LinearOperators/DefiniteIntegral.hpp"
+#include "NumericalAlgorithms/LinearOperators/Divergence.hpp"
+#include "NumericalAlgorithms/Spectral/LogicalCoordinates.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/HarmonicSchwarzschild.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrHorizon.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/Xcts/Schwarzschild.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/Xcts/WrappedGr.hpp"
+#include "PointwiseFunctions/Xcts/AdmLinearMomentum.hpp"
+
+namespace {
+
+using KerrSchild = Xcts::Solutions::WrappedGr<gr::Solutions::KerrSchild>;
+
+void test_linear_momentum_surface_integral(const double distance,
+                                           const size_t refinement_level,
+                                           const size_t polynomial_order) {
+  // Define black hole parameters
+  const double mass = 1;
+  const double boost_speed = 0.5;
+  const double lorentz_factor = 1. / sqrt(1. - square(boost_speed));
+
+  // Get Kerr-Schild solution
+  const std::array<double, 3> dimensionless_spin{{0., 0., 0.}};
+  const std::array<double, 3> boost_velocity{{0., 0., boost_speed}};
+  const KerrSchild solution{mass, dimensionless_spin,
+                            /* center */ {{0., 0., 0.}}, boost_velocity};
+
+  // Set up domain
+  const double horizon_kerrschild_radius =
+      mass * (1. + sqrt(1. - dot(dimensionless_spin, dimensionless_spin)));
+  domain::creators::Sphere shell{
+      /* inner_radius */ horizon_kerrschild_radius,
+      /* outer_radius */ distance,
+      /* interior */ domain::creators::Sphere::Excision{},
+      refinement_level,
+      polynomial_order + 1,
+      true,
+      {},
+      {},
+      domain::CoordinateMaps::Distribution::Logarithmic};
+  const auto shell_domain = shell.create_domain();
+  const auto& blocks = shell_domain.blocks();
+  const auto& initial_ref_levels = shell.initial_refinement_levels();
+  const auto element_ids = initial_element_ids(initial_ref_levels);
+  const Mesh<2> face_mesh{polynomial_order + 1, Spectral::Basis::Legendre,
+                          Spectral::Quadrature::GaussLobatto};
+
+  // Initialize surface integral
+  tnsr::I<double, 3> surface_integral;
+  for (int I = 0; I < 3; I++) {
+    surface_integral.get(I) = 0.;
+  }
+
+  // Compute integrals by summing over each element
+  for (const auto& element_id : element_ids) {
+    // Skip elements not at the outer boundary
+    const size_t radial_dimension = 2;
+    const auto radial_segment_id = element_id.segment_id(radial_dimension);
+    if (radial_segment_id.index() !=
+        two_to_the(radial_segment_id.refinement_level()) - 1) {
+      continue;
+    }
+
+    // Get element information
+    const auto& current_block = blocks.at(element_id.block_id());
+    const auto current_element = domain::Initialization::create_initial_element(
+        element_id, current_block, initial_ref_levels);
+    const ElementMap<3, Frame::Inertial> logical_to_inertial_map(
+        element_id, current_block.stationary_map().get_clone());
+
+    // Loop over external boundaries
+    for (auto boundary_direction : current_element.external_boundaries()) {
+      // Skip interfaces not at the outer boundary
+      if (boundary_direction != Direction<3>::upper_zeta()) {
+        continue;
+      }
+
+      // Get coordinates
+      const auto logical_coords =
+          interface_logical_coordinates(face_mesh, boundary_direction);
+      const auto inertial_coords = logical_to_inertial_map(logical_coords);
+
+      // Get required fields
+      const auto background_fields = solution.variables(
+          inertial_coords,
+          tmpl::list<
+              Xcts::Tags::ConformalFactor<DataVector>,
+              gr::Tags::SpatialMetric<DataVector, 3, Frame::Inertial>,
+              gr::Tags::InverseSpatialMetric<DataVector, 3, Frame::Inertial>,
+              gr::Tags::ExtrinsicCurvature<DataVector, 3, Frame::Inertial>,
+              gr::Tags::TraceExtrinsicCurvature<DataVector>>{});
+      const auto& conformal_factor =
+          get<Xcts::Tags::ConformalFactor<DataVector>>(background_fields);
+      const auto& spatial_metric =
+          get<gr::Tags::SpatialMetric<DataVector, 3, Frame::Inertial>>(
+              background_fields);
+      const auto& inv_spatial_metric =
+          get<gr::Tags::InverseSpatialMetric<DataVector, 3, Frame::Inertial>>(
+              background_fields);
+      const auto& extrinsic_curvature =
+          get<gr::Tags::ExtrinsicCurvature<DataVector, 3, Frame::Inertial>>(
+              background_fields);
+      const auto& trace_extrinsic_curvature =
+          get<gr::Tags::TraceExtrinsicCurvature<DataVector>>(background_fields);
+
+      // Compute the inverse extrinsic curvature
+      tnsr::II<DataVector, 3> inv_extrinsic_curvature;
+      tenex::evaluate<ti::I, ti::J>(make_not_null(&inv_extrinsic_curvature),
+                                    inv_spatial_metric(ti::I, ti::K) *
+                                        inv_spatial_metric(ti::J, ti::L) *
+                                        extrinsic_curvature(ti::k, ti::l));
+
+      // Compute curved area element
+      const auto inv_jacobian =
+          logical_to_inertial_map.inv_jacobian(logical_coords);
+      const auto sqrt_det_spatial_metric =
+          Scalar<DataVector>(sqrt(get(determinant(spatial_metric))));
+      const auto curved_area_element =
+          area_element(inv_jacobian, boundary_direction, inv_spatial_metric,
+                       sqrt_det_spatial_metric);
+
+      // Compute face normal
+      auto face_normal = unnormalized_face_normal(
+          face_mesh, logical_to_inertial_map, boundary_direction);
+      const auto face_normal_magnitude =
+          magnitude(face_normal, inv_spatial_metric);
+      for (size_t d = 0; d < 3; ++d) {
+        face_normal.get(d) /= get(face_normal_magnitude);
+      }
+
+      // Compute surface integrand
+      const auto surface_integrand =
+          Xcts::adm_linear_momentum_surface_integrand(
+              conformal_factor, inv_spatial_metric, inv_extrinsic_curvature,
+              trace_extrinsic_curvature);
+      const auto contracted_integrand = tenex::evaluate<ti::I>(
+          surface_integrand(ti::I, ti::J) * face_normal(ti::j));
+
+      // Compute contribution to surface integral
+      for (int I = 0; I < 3; I++) {
+        surface_integral.get(I) += definite_integral(
+            contracted_integrand.get(I) * get(curved_area_element), face_mesh);
+      }
+    }
+  }
+
+  // Check result
+  auto custom_approx = Approx::custom().epsilon(10. / distance).scale(1.0);
+  CHECK(surface_integral.get(0) == custom_approx(0.));
+  CHECK(surface_integral.get(1) == custom_approx(0.));
+  CHECK(surface_integral.get(2) ==
+        custom_approx(lorentz_factor * mass * boost_speed));
+}
+
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.PointwiseFunctions.Xcts.AdmLinearMomentum",
+                  "[Unit][PointwiseFunctions]") {
+  pypp::SetupLocalPythonEnvironment
+  local_python_env{"PointwiseFunctions/Xcts"}; const DataVector
+  used_for_size{5};
+
+  pypp::check_with_random_values<1>(
+      static_cast<void (*)(
+          gsl::not_null<tnsr::II<DataVector, 3>*>, const Scalar<DataVector>&,
+          const tnsr::II<DataVector, 3>&, const tnsr::II<DataVector, 3>&,
+          const Scalar<DataVector>&)>(
+          &Xcts::adm_linear_momentum_surface_integrand),
+      "AdmLinearMomentum", {"adm_linear_momentum_surface_integrand"},
+      {{{-1., 1.}}}, used_for_size);
+
+  pypp::check_with_random_values<1>(
+      static_cast<void (*)(
+          gsl::not_null<tnsr::I<DataVector, 3>*>,
+          const tnsr::II<DataVector, 3>&, const Scalar<DataVector>&,
+          const tnsr::i<DataVector, 3>&, const tnsr::ii<DataVector, 3>&,
+          const tnsr::II<DataVector, 3>&, const tnsr::Ijj<DataVector, 3>&,
+          const tnsr::i<DataVector, 3>&)>(
+          &Xcts::adm_linear_momentum_volume_integrand),
+      "AdmLinearMomentum", {"adm_linear_momentum_volume_integrand"},
+      {{{-1, 1.}}}, used_for_size);
+
+  const size_t P = 6;
+  const size_t L = 1;
+  for (double distance : std::array<double, 3>{{1.e3, 1.e5, 1.e10}}) {
+    test_linear_momentum_surface_integral(distance, L, P);
+  }
+}


### PR DESCRIPTION
## Proposed changes

<!--
At a high level, describe what this PR does.
-->

Add pointwise functions for the integrands needed to compute the total ADM linear momentum. The formulas were taken from section 2.4 of [arXiv:1506.01689](https://arxiv.org/abs/1506.01689).

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
