### PR TITLE
Enable nodegroups with LTS and compute correct hash for boundary data

### DIFF
--- a/src/Evolution/DiscontinuousGalerkin/Actions/ApplyBoundaryCorrections.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Actions/ApplyBoundaryCorrections.hpp
@@ -491,7 +491,6 @@ bool receive_boundary_data_local_time_stepping(
                     evolution::dg::AtomicInboxBoundaryData<Dim>,
                     typename evolution::dg::Tags::
                         BoundaryCorrectionAndGhostCellsInbox<Dim>::type>) {
-    ERROR("LTS does not yet work with nodegroups");
     // We only decrease the counter if we are done with the current time
     // and we only decrease it by the number of neighbors at the current
     // time.

--- a/src/Evolution/DiscontinuousGalerkin/InboxTags.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/InboxTags.hpp
@@ -142,7 +142,7 @@ struct BoundaryCorrectionAndGhostCellsInbox {
     const DirectionalId<Dim>& neighbor_id = data.first;
     // Note: This assumes the neighbor_id is oriented into our (the element
     // whose inbox this is) frame.
-    const size_t neighbor_index = hash_value(neighbor_id);
+    const size_t neighbor_index = inbox->index(neighbor_id);
     if (UNLIKELY(not gsl::at(inbox->boundary_data_in_directions, neighbor_index)
                          .try_emplace(time_step_id, std::move(data.second),
                                       std::move(data.first)))) {

--- a/tests/Unit/Helpers/Domain/Structure/NeighborHelpers.hpp
+++ b/tests/Unit/Helpers/Domain/Structure/NeighborHelpers.hpp
@@ -67,11 +67,14 @@ std::vector<SegmentId> valid_neighbor_segments(const SegmentId& segment_id);
 std::vector<SegmentId> valid_neighbor_segments(const SegmentId& segment_id,
                                                const FaceType face_type);
 
-/// Valid Neighbors for an Element with `element_id` in the given `direction`
-/// with the given `face_type`
+/// \brief All valid neighbor configurations for an Element with `element_id` in
+/// the given `direction` with the given `face_type`
 ///
 /// \details FaceType needs to be passed in only if the Element abuts a Block
-/// boundary in the given `direction`
+/// boundary in the given `direction`3
+///
+/// The `generator` is used to assign a random orientation if the neighbor is
+/// in a different block, i.e. `face_type == FaceType::Block`.
 template <size_t Dim>
 std::vector<Neighbors<Dim>> valid_neighbors(
     gsl::not_null<std::mt19937*> generator, const ElementId<Dim>& element_id,


### PR DESCRIPTION
## Proposed changes

This plus 3 more PRs allow for LTS with SW3D and non-uniform h- & p-refinement.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
