### PR TITLE
Add option for higher dimension EOSes to Spec initial data

### DIFF
--- a/src/PointwiseFunctions/AnalyticData/GrMhd/SpecInitialData.hpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/SpecInitialData.hpp
@@ -61,6 +61,10 @@ class SpecInitialData : public evolution::initial_data::InitialData,
                  gr::Tags::Lapse<DataType>, gr::Tags::Shift<DataType, 3>>,
       hydro::grmhd_tags<DataType>>;
 
+  static std::string name() {
+    return "SpecInitialData" + std::tostring(ThermodynamicDim) + "dEos";
+  }
+
   struct DataDirectory {
     using type = std::string;
     static constexpr Options::String help = {

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/BinaryNeutronStar.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/BinaryNeutronStar.yaml
@@ -415,7 +415,7 @@ ControlSystems:
     ControlError:
 
 InitialData:
-  # SpecInitialData:
+  # SpecInitialData3dEos:
   #   DataDirectory: "/path/to/EvID"
   #   EquationOfState: *eos
   #   DensityCutoff: *AtmosphereDensityCutoff


### PR DESCRIPTION
## Proposed changes

<!--
Add option to 'SpecInitalData' setting in 'InitialData' for higher dimensional EOS
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
