### PR TITLE
Make MortarData a simple struct

### DIFF
--- a/src/Evolution/DgSubcell/Actions/ReconstructionCommunication.hpp
+++ b/src/Evolution/DgSubcell/Actions/ReconstructionCommunication.hpp
@@ -379,10 +379,10 @@ struct ReceiveDataForReconstruction {
             }
             if (received_mortar_data.second.boundary_correction_data
                     .has_value()) {
-              mortar_data->at(mortar_id).neighbor().mortar_data() = std::pair{
-                  received_mortar_data.second.interface_mesh,
-                  std::move(
-                      *received_mortar_data.second.boundary_correction_data)};
+              mortar_data->at(mortar_id).neighbor().face_mesh =
+                  received_mortar_data.second.interface_mesh;
+              mortar_data->at(mortar_id).neighbor().mortar_data = std::move(
+                  *received_mortar_data.second.boundary_correction_data);
             }
             // Set new neighbor mesh
             neighbor_mesh->insert_or_assign(

--- a/src/Evolution/DgSubcell/Actions/ReconstructionCommunication.hpp
+++ b/src/Evolution/DgSubcell/Actions/ReconstructionCommunication.hpp
@@ -379,10 +379,10 @@ struct ReceiveDataForReconstruction {
             }
             if (received_mortar_data.second.boundary_correction_data
                     .has_value()) {
-              mortar_data->at(mortar_id).neighbor().neighbor_mortar_data() =
-                  std::pair{received_mortar_data.second.interface_mesh,
-                            std::move(*received_mortar_data.second
-                                           .boundary_correction_data)};
+              mortar_data->at(mortar_id).neighbor().mortar_data() = std::pair{
+                  received_mortar_data.second.interface_mesh,
+                  std::move(
+                      *received_mortar_data.second.boundary_correction_data)};
             }
             // Set new neighbor mesh
             neighbor_mesh->insert_or_assign(

--- a/src/Evolution/DgSubcell/Actions/ReconstructionCommunication.hpp
+++ b/src/Evolution/DgSubcell/Actions/ReconstructionCommunication.hpp
@@ -48,6 +48,7 @@
 #include "Evolution/DiscontinuousGalerkin/BoundaryData.hpp"
 #include "Evolution/DiscontinuousGalerkin/InboxTags.hpp"
 #include "Evolution/DiscontinuousGalerkin/MortarData.hpp"
+#include "Evolution/DiscontinuousGalerkin/MortarDataHolder.hpp"
 #include "Evolution/DiscontinuousGalerkin/MortarTags.hpp"
 #include "NumericalAlgorithms/Interpolation/IrregularInterpolant.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
@@ -351,7 +352,7 @@ struct ReceiveDataForReconstruction {
                 ghost_data_ptr,
             const gsl::not_null<RdmpTciData*> rdmp_tci_data_ptr,
             const gsl::not_null<
-                DirectionalIdMap<Dim, evolution::dg::MortarData<Dim>>*>
+                DirectionalIdMap<Dim, evolution::dg::MortarDataHolder<Dim>>*>
                 mortar_data,
             const gsl::not_null<DirectionalIdMap<Dim, TimeStepId>*>
                 mortar_next_time_step_id,
@@ -378,10 +379,10 @@ struct ReceiveDataForReconstruction {
             }
             if (received_mortar_data.second.boundary_correction_data
                     .has_value()) {
-              mortar_data->at(mortar_id).neighbor_mortar_data() = std::pair{
-                  received_mortar_data.second.interface_mesh,
-                  std::move(
-                      *received_mortar_data.second.boundary_correction_data)};
+              mortar_data->at(mortar_id).neighbor().neighbor_mortar_data() =
+                  std::pair{received_mortar_data.second.interface_mesh,
+                            std::move(*received_mortar_data.second
+                                           .boundary_correction_data)};
             }
             // Set new neighbor mesh
             neighbor_mesh->insert_or_assign(

--- a/src/Evolution/DgSubcell/Actions/TakeTimeStep.hpp
+++ b/src/Evolution/DgSubcell/Actions/TakeTimeStep.hpp
@@ -18,6 +18,7 @@
 #include "Evolution/DgSubcell/Tags/Coordinates.hpp"
 #include "Evolution/DgSubcell/Tags/Jacobians.hpp"
 #include "Evolution/DiscontinuousGalerkin/MortarData.hpp"
+#include "Evolution/DiscontinuousGalerkin/MortarDataHolder.hpp"
 #include "Evolution/DiscontinuousGalerkin/MortarTags.hpp"
 #include "Parallel/AlgorithmExecution.hpp"
 #include "Utilities/ErrorHandling/Assert.hpp"
@@ -72,7 +73,7 @@ struct TakeTimeStep {
     db::mutate<evolution::dg::Tags::MortarData<Dim>>(
         [](const auto mortar_data_ptr) {
           for (auto& data : *mortar_data_ptr) {
-            data.second = evolution::dg::MortarData<Dim>{};
+            data.second = evolution::dg::MortarDataHolder<Dim>{};
           }
         },
         make_not_null(&box));

--- a/src/Evolution/DgSubcell/CorrectPackagedData.hpp
+++ b/src/Evolution/DgSubcell/CorrectPackagedData.hpp
@@ -19,6 +19,7 @@
 #include "Domain/Structure/ElementId.hpp"
 #include "Evolution/DgSubcell/Projection.hpp"
 #include "Evolution/DiscontinuousGalerkin/MortarData.hpp"
+#include "Evolution/DiscontinuousGalerkin/MortarDataHolder.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/Gsl.hpp"
@@ -76,7 +77,8 @@ void correct_package_data(
     const gsl::not_null<Variables<DgPackageFieldTags>*> upper_packaged_data,
     const size_t logical_dimension_to_operate_in, const Element<Dim>& element,
     const Mesh<Dim>& subcell_volume_mesh,
-    const DirectionalIdMap<Dim, evolution::dg::MortarData<Dim>>& mortar_data,
+    const DirectionalIdMap<Dim, evolution::dg::MortarDataHolder<Dim>>&
+        mortar_data,
     const size_t variables_to_offset_in_dg_grid) {
   const Direction<Dim> upper_direction{logical_dimension_to_operate_in,
                                        Side::Upper};
@@ -158,37 +160,56 @@ void correct_package_data(
   // Project DG data to the subcells
   if (auto neighbor_mortar_data_it = mortar_data.find(upper_mortar_id);
       has_upper_neighbor and neighbor_mortar_data_it != mortar_data.end()) {
-    if (neighbor_mortar_data_it->second.neighbor_mortar_data().has_value()) {
+    if (neighbor_mortar_data_it->second.neighbor()
+            .neighbor_mortar_data()
+            .has_value()) {
       project_dg_data_to_subcells(
           upper_packaged_data,
           subcell_extents_with_faces[logical_dimension_to_operate_in] - 1,
-          neighbor_mortar_data_it->second.neighbor_mortar_data()->first,
-          neighbor_mortar_data_it->second.neighbor_mortar_data()->second);
+          neighbor_mortar_data_it->second.neighbor()
+              .neighbor_mortar_data()
+              ->first,
+          neighbor_mortar_data_it->second.neighbor()
+              .neighbor_mortar_data()
+              ->second);
     }
     if constexpr (OverwriteInternalMortarData) {
-      if (neighbor_mortar_data_it->second.local_mortar_data().has_value()) {
+      if (neighbor_mortar_data_it->second.local()
+              .local_mortar_data()
+              .has_value()) {
         project_dg_data_to_subcells(
             lower_packaged_data,
             subcell_extents_with_faces[logical_dimension_to_operate_in] - 1,
-            neighbor_mortar_data_it->second.local_mortar_data()->first,
-            neighbor_mortar_data_it->second.local_mortar_data()->second);
+            neighbor_mortar_data_it->second.local().local_mortar_data()->first,
+            neighbor_mortar_data_it->second.local()
+                .local_mortar_data()
+                ->second);
       }
     }
   }
   if (auto neighbor_mortar_data_it = mortar_data.find(lower_mortar_id);
       has_lower_neighbor and neighbor_mortar_data_it != mortar_data.end()) {
-    if (neighbor_mortar_data_it->second.neighbor_mortar_data().has_value()) {
-      project_dg_data_to_subcells(
-          lower_packaged_data, 0,
-          neighbor_mortar_data_it->second.neighbor_mortar_data()->first,
-          neighbor_mortar_data_it->second.neighbor_mortar_data()->second);
+    if (neighbor_mortar_data_it->second.neighbor()
+            .neighbor_mortar_data()
+            .has_value()) {
+      project_dg_data_to_subcells(lower_packaged_data, 0,
+                                  neighbor_mortar_data_it->second.neighbor()
+                                      .neighbor_mortar_data()
+                                      ->first,
+                                  neighbor_mortar_data_it->second.neighbor()
+                                      .neighbor_mortar_data()
+                                      ->second);
     }
     if constexpr (OverwriteInternalMortarData) {
-      if (neighbor_mortar_data_it->second.local_mortar_data().has_value()) {
+      if (neighbor_mortar_data_it->second.local()
+              .local_mortar_data()
+              .has_value()) {
         project_dg_data_to_subcells(
             upper_packaged_data, 0,
-            neighbor_mortar_data_it->second.local_mortar_data()->first,
-            neighbor_mortar_data_it->second.local_mortar_data()->second);
+            neighbor_mortar_data_it->second.local().local_mortar_data()->first,
+            neighbor_mortar_data_it->second.local()
+                .local_mortar_data()
+                ->second);
       }
     }
   }

--- a/src/Evolution/DgSubcell/CorrectPackagedData.hpp
+++ b/src/Evolution/DgSubcell/CorrectPackagedData.hpp
@@ -160,56 +160,37 @@ void correct_package_data(
   // Project DG data to the subcells
   if (auto neighbor_mortar_data_it = mortar_data.find(upper_mortar_id);
       has_upper_neighbor and neighbor_mortar_data_it != mortar_data.end()) {
-    if (neighbor_mortar_data_it->second.neighbor()
-            .neighbor_mortar_data()
-            .has_value()) {
+    if (neighbor_mortar_data_it->second.neighbor().mortar_data().has_value()) {
       project_dg_data_to_subcells(
           upper_packaged_data,
           subcell_extents_with_faces[logical_dimension_to_operate_in] - 1,
-          neighbor_mortar_data_it->second.neighbor()
-              .neighbor_mortar_data()
-              ->first,
-          neighbor_mortar_data_it->second.neighbor()
-              .neighbor_mortar_data()
-              ->second);
+          neighbor_mortar_data_it->second.neighbor().mortar_data()->first,
+          neighbor_mortar_data_it->second.neighbor().mortar_data()->second);
     }
     if constexpr (OverwriteInternalMortarData) {
-      if (neighbor_mortar_data_it->second.local()
-              .local_mortar_data()
-              .has_value()) {
+      if (neighbor_mortar_data_it->second.local().mortar_data().has_value()) {
         project_dg_data_to_subcells(
             lower_packaged_data,
             subcell_extents_with_faces[logical_dimension_to_operate_in] - 1,
-            neighbor_mortar_data_it->second.local().local_mortar_data()->first,
-            neighbor_mortar_data_it->second.local()
-                .local_mortar_data()
-                ->second);
+            neighbor_mortar_data_it->second.local().mortar_data()->first,
+            neighbor_mortar_data_it->second.local().mortar_data()->second);
       }
     }
   }
   if (auto neighbor_mortar_data_it = mortar_data.find(lower_mortar_id);
       has_lower_neighbor and neighbor_mortar_data_it != mortar_data.end()) {
-    if (neighbor_mortar_data_it->second.neighbor()
-            .neighbor_mortar_data()
-            .has_value()) {
-      project_dg_data_to_subcells(lower_packaged_data, 0,
-                                  neighbor_mortar_data_it->second.neighbor()
-                                      .neighbor_mortar_data()
-                                      ->first,
-                                  neighbor_mortar_data_it->second.neighbor()
-                                      .neighbor_mortar_data()
-                                      ->second);
+    if (neighbor_mortar_data_it->second.neighbor().mortar_data().has_value()) {
+      project_dg_data_to_subcells(
+          lower_packaged_data, 0,
+          neighbor_mortar_data_it->second.neighbor().mortar_data()->first,
+          neighbor_mortar_data_it->second.neighbor().mortar_data()->second);
     }
     if constexpr (OverwriteInternalMortarData) {
-      if (neighbor_mortar_data_it->second.local()
-              .local_mortar_data()
-              .has_value()) {
+      if (neighbor_mortar_data_it->second.local().mortar_data().has_value()) {
         project_dg_data_to_subcells(
             upper_packaged_data, 0,
-            neighbor_mortar_data_it->second.local().local_mortar_data()->first,
-            neighbor_mortar_data_it->second.local()
-                .local_mortar_data()
-                ->second);
+            neighbor_mortar_data_it->second.local().mortar_data()->first,
+            neighbor_mortar_data_it->second.local().mortar_data()->second);
       }
     }
   }

--- a/src/Evolution/DgSubcell/CorrectPackagedData.hpp
+++ b/src/Evolution/DgSubcell/CorrectPackagedData.hpp
@@ -160,37 +160,37 @@ void correct_package_data(
   // Project DG data to the subcells
   if (auto neighbor_mortar_data_it = mortar_data.find(upper_mortar_id);
       has_upper_neighbor and neighbor_mortar_data_it != mortar_data.end()) {
-    if (neighbor_mortar_data_it->second.neighbor().mortar_data().has_value()) {
+    if (neighbor_mortar_data_it->second.neighbor().mortar_data.has_value()) {
       project_dg_data_to_subcells(
           upper_packaged_data,
           subcell_extents_with_faces[logical_dimension_to_operate_in] - 1,
-          neighbor_mortar_data_it->second.neighbor().mortar_data()->first,
-          neighbor_mortar_data_it->second.neighbor().mortar_data()->second);
+          neighbor_mortar_data_it->second.neighbor().face_mesh.value(),
+          neighbor_mortar_data_it->second.neighbor().mortar_data.value());
     }
     if constexpr (OverwriteInternalMortarData) {
-      if (neighbor_mortar_data_it->second.local().mortar_data().has_value()) {
+      if (neighbor_mortar_data_it->second.local().mortar_data.has_value()) {
         project_dg_data_to_subcells(
             lower_packaged_data,
             subcell_extents_with_faces[logical_dimension_to_operate_in] - 1,
-            neighbor_mortar_data_it->second.local().mortar_data()->first,
-            neighbor_mortar_data_it->second.local().mortar_data()->second);
+            neighbor_mortar_data_it->second.local().face_mesh.value(),
+            neighbor_mortar_data_it->second.local().mortar_data.value());
       }
     }
   }
   if (auto neighbor_mortar_data_it = mortar_data.find(lower_mortar_id);
       has_lower_neighbor and neighbor_mortar_data_it != mortar_data.end()) {
-    if (neighbor_mortar_data_it->second.neighbor().mortar_data().has_value()) {
+    if (neighbor_mortar_data_it->second.neighbor().mortar_data.has_value()) {
       project_dg_data_to_subcells(
           lower_packaged_data, 0,
-          neighbor_mortar_data_it->second.neighbor().mortar_data()->first,
-          neighbor_mortar_data_it->second.neighbor().mortar_data()->second);
+          neighbor_mortar_data_it->second.neighbor().face_mesh.value(),
+          neighbor_mortar_data_it->second.neighbor().mortar_data.value());
     }
     if constexpr (OverwriteInternalMortarData) {
-      if (neighbor_mortar_data_it->second.local().mortar_data().has_value()) {
+      if (neighbor_mortar_data_it->second.local().mortar_data.has_value()) {
         project_dg_data_to_subcells(
             upper_packaged_data, 0,
-            neighbor_mortar_data_it->second.local().mortar_data()->first,
-            neighbor_mortar_data_it->second.local().mortar_data()->second);
+            neighbor_mortar_data_it->second.local().face_mesh.value(),
+            neighbor_mortar_data_it->second.local().mortar_data.value());
       }
     }
   }

--- a/src/Evolution/DgSubcell/GhostData.hpp
+++ b/src/Evolution/DgSubcell/GhostData.hpp
@@ -17,7 +17,7 @@ namespace evolution::dg::subcell {
  * This class holds both the local ghost data on the local subcell mesh for a
  * given direction, as well as the neighbor's ghost data (on the neighbor's
  * mesh) in that same direction. This class is similar to
- * `evolution::dg::MortarData` in the sense that it holds both local and
+ * `evolution::dg::MortarDataHolder` in the sense that it holds both local and
  * neighbor data in a direction. However, it differs because the local ghost
  * data is not used in our own calculation when reconstructing the solution at
  * the face between the elements. This is because we already have our own data

--- a/src/Evolution/DiscontinuousGalerkin/Actions/ApplyBoundaryCorrections.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Actions/ApplyBoundaryCorrections.hpp
@@ -336,10 +336,10 @@ bool receive_boundary_data_global_time_stepping(
                      << received_temporal_id_and_data.first);
           if (received_mortar_data.second.boundary_correction_data
                   .has_value()) {
-            mortar_data->at(mortar_id).neighbor().mortar_data() =
-                std::pair{received_mortar_data.second.interface_mesh,
-                          std::move(received_mortar_data.second
-                                        .boundary_correction_data.value())};
+            mortar_data->at(mortar_id).neighbor().face_mesh =
+                received_mortar_data.second.interface_mesh;
+            mortar_data->at(mortar_id).neighbor().mortar_data = std::move(
+                received_mortar_data.second.boundary_correction_data.value());
           }
         }
       },
@@ -462,10 +462,10 @@ bool receive_boundary_data_local_time_stepping(
             neighbor_mesh->insert_or_assign(
                 mortar_id,
                 received_mortar_data->second.volume_mesh_ghost_cell_data);
-            neighbor_mortar_data.mortar_data() =
-                std::pair{received_mortar_data->second.interface_mesh,
-                          std::move(received_mortar_data->second
-                                        .boundary_correction_data.value())};
+            neighbor_mortar_data.face_mesh =
+                received_mortar_data->second.interface_mesh;
+            neighbor_mortar_data.mortar_data = std::move(
+                received_mortar_data->second.boundary_correction_data.value());
             // We don't yet communicate the integration order, because
             // we don't have any variable-order methods.  The
             // fixed-order methods ignore the field.
@@ -764,27 +764,24 @@ struct ApplyBoundaryCorrections {
                 // and local time stepping we could first perform the integral
                 // on the boundaries, and then lift to the volume. This is
                 // left as a future optimization.
-                local_mortar_data.get_local_volume_det_inv_jacobian(
-                    make_not_null(&volume_det_inv_jacobian));
+                volume_det_inv_jacobian =
+                    local_mortar_data.volume_det_inv_jacobian.value();
                 get(volume_det_jacobian) = 1.0 / get(volume_det_inv_jacobian);
               }
               const auto& mortar_mesh = mortar_meshes.at(mortar_id);
 
               // Extract local and neighbor data, copy into Variables because
               // we store them in a std::vector for type erasure.
-              const std::pair<Mesh<volume_dim - 1>, DataVector>&
-                  local_mesh_and_data = *local_mortar_data.mortar_data();
-              const std::pair<Mesh<volume_dim - 1>, DataVector>&
-                  neighbor_mesh_and_data = *neighbor_mortar_data.mortar_data();
+              const DataVector& local_data = *local_mortar_data.mortar_data;
+              const DataVector& neighbor_data =
+                  *neighbor_mortar_data.mortar_data;
               local_data_on_mortar.set_data_ref(
                   // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
-                  const_cast<double*>(std::get<1>(local_mesh_and_data).data()),
-                  std::get<1>(local_mesh_and_data).size());
+                  const_cast<double*>(local_data.data()), local_data.size());
               neighbor_data_on_mortar.set_data_ref(
                   // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
-                  const_cast<double*>(
-                      std::get<1>(neighbor_mesh_and_data).data()),
-                  std::get<1>(neighbor_mesh_and_data).size());
+                  const_cast<double*>(neighbor_data.data()),
+                  neighbor_data.size());
 
               // The boundary computations and lifting can be further
               // optimized by in the h-refinement case having only one
@@ -827,8 +824,9 @@ struct ApplyBoundaryCorrections {
               Scalar<DataVector> magnitude_of_face_normal{};
               if constexpr (local_time_stepping) {
                 (void)face_normal_covector_and_magnitude;
-                local_mortar_data.get_local_face_normal_magnitude(
-                    &magnitude_of_face_normal);
+                get(magnitude_of_face_normal)
+                    .set_data_ref(make_not_null(&const_cast<DataVector&>(
+                        get(local_mortar_data.face_normal_magnitude.value()))));
               } else {
                 ASSERT(
                     face_normal_covector_and_magnitude.count(direction) == 1 and
@@ -869,8 +867,9 @@ struct ApplyBoundaryCorrections {
                          "For local time stepping the volume determinant of "
                          "the inverse Jacobian has not been set.");
 
-                  local_mortar_data.get_local_face_det_jacobian(
-                      make_not_null(&face_det_jacobian));
+                  get(face_det_jacobian)
+                      .set_data_ref(make_not_null(&const_cast<DataVector&>(
+                          get(local_mortar_data.face_det_jacobian.value()))));
                 } else {
                   // Project the determinant of the Jacobian to the face. This
                   // could be optimized by caching in the time-independent case.

--- a/src/Evolution/DiscontinuousGalerkin/Actions/ApplyBoundaryCorrections.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Actions/ApplyBoundaryCorrections.hpp
@@ -336,7 +336,7 @@ bool receive_boundary_data_global_time_stepping(
                      << received_temporal_id_and_data.first);
           if (received_mortar_data.second.boundary_correction_data
                   .has_value()) {
-            mortar_data->at(mortar_id).neighbor().neighbor_mortar_data() =
+            mortar_data->at(mortar_id).neighbor().mortar_data() =
                 std::pair{received_mortar_data.second.interface_mesh,
                           std::move(received_mortar_data.second
                                         .boundary_correction_data.value())};
@@ -462,7 +462,7 @@ bool receive_boundary_data_local_time_stepping(
             neighbor_mesh->insert_or_assign(
                 mortar_id,
                 received_mortar_data->second.volume_mesh_ghost_cell_data);
-            neighbor_mortar_data.neighbor_mortar_data() =
+            neighbor_mortar_data.mortar_data() =
                 std::pair{received_mortar_data->second.interface_mesh,
                           std::move(received_mortar_data->second
                                         .boundary_correction_data.value())};
@@ -773,10 +773,9 @@ struct ApplyBoundaryCorrections {
               // Extract local and neighbor data, copy into Variables because
               // we store them in a std::vector for type erasure.
               const std::pair<Mesh<volume_dim - 1>, DataVector>&
-                  local_mesh_and_data = *local_mortar_data.local_mortar_data();
+                  local_mesh_and_data = *local_mortar_data.mortar_data();
               const std::pair<Mesh<volume_dim - 1>, DataVector>&
-                  neighbor_mesh_and_data =
-                      *neighbor_mortar_data.neighbor_mortar_data();
+                  neighbor_mesh_and_data = *neighbor_mortar_data.mortar_data();
               local_data_on_mortar.set_data_ref(
                   // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
                   const_cast<double*>(std::get<1>(local_mesh_and_data).data()),

--- a/src/Evolution/DiscontinuousGalerkin/Actions/ApplyBoundaryCorrections.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Actions/ApplyBoundaryCorrections.hpp
@@ -30,6 +30,7 @@
 #include "Evolution/DiscontinuousGalerkin/BoundaryData.hpp"
 #include "Evolution/DiscontinuousGalerkin/InboxTags.hpp"
 #include "Evolution/DiscontinuousGalerkin/MortarData.hpp"
+#include "Evolution/DiscontinuousGalerkin/MortarDataHolder.hpp"
 #include "Evolution/DiscontinuousGalerkin/MortarTags.hpp"
 #include "Evolution/DiscontinuousGalerkin/NormalVectorTags.hpp"
 #include "Evolution/DiscontinuousGalerkin/UsingSubcell.hpp"
@@ -310,7 +311,7 @@ bool receive_boundary_data_global_time_stepping(
              domain::Tags::NeighborMesh<volume_dim>>(
       [&received_temporal_id_and_data](
           const gsl::not_null<DirectionalIdMap<
-              volume_dim, evolution::dg::MortarData<volume_dim>>*>
+              volume_dim, evolution::dg::MortarDataHolder<volume_dim>>*>
               mortar_data,
           const gsl::not_null<DirectionalIdMap<volume_dim, TimeStepId>*>
               mortar_next_time_step_id,
@@ -335,7 +336,7 @@ bool receive_boundary_data_global_time_stepping(
                      << received_temporal_id_and_data.first);
           if (received_mortar_data.second.boundary_correction_data
                   .has_value()) {
-            mortar_data->at(mortar_id).neighbor_mortar_data() =
+            mortar_data->at(mortar_id).neighbor().neighbor_mortar_data() =
                 std::pair{received_mortar_data.second.interface_mesh,
                           std::move(received_mortar_data.second
                                         .boundary_correction_data.value())};
@@ -947,7 +948,8 @@ struct ApplyBoundaryCorrections {
                                       ? dt_boundary_correction_on_mortar
                                       : volume_dt_correction;
               lifted_data = compute_correction_coupling(
-                  mortar_id_and_data.second, mortar_id_and_data.second);
+                  mortar_id_and_data.second.local(),
+                  mortar_id_and_data.second.neighbor());
 
               if (using_gauss_lobatto_points) {
                 // Add the flux contribution to the volume data

--- a/src/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivative.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivative.hpp
@@ -695,13 +695,13 @@ void ComputeTimeDerivative<Dim, EvolutionSystem, DgStepChoosers,
 
       if (LIKELY(orientation.is_aligned())) {
         neighbor_boundary_data_on_mortar =
-            *all_mortar_data.at(mortar_id).local().local_mortar_data();
+            *all_mortar_data.at(mortar_id).local().mortar_data();
       } else {
         const auto& slice_extents = mortar_meshes.at(mortar_id).extents();
         neighbor_boundary_data_on_mortar.first =
-            all_mortar_data.at(mortar_id).local().local_mortar_data()->first;
+            all_mortar_data.at(mortar_id).local().mortar_data()->first;
         neighbor_boundary_data_on_mortar.second = orient_variables_on_slice(
-            all_mortar_data.at(mortar_id).local().local_mortar_data()->second,
+            all_mortar_data.at(mortar_id).local().mortar_data()->second,
             slice_extents, direction.dimension(), orientation);
       }
 

--- a/src/Evolution/DiscontinuousGalerkin/Actions/InternalMortarDataImpl.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Actions/InternalMortarDataImpl.hpp
@@ -252,7 +252,7 @@ void internal_mortar_data_impl(
       } else {
         // Can use the local_mortar_data
         auto& local_mortar_data_opt =
-            mortar_data_ptr->at(mortar_id).local().local_mortar_data();
+            mortar_data_ptr->at(mortar_id).local().mortar_data();
         // If this isn't the first time, set the face mesh
         if (LIKELY(local_mortar_data_opt.has_value())) {
           local_mortar_data_opt->first = face_mesh;
@@ -297,7 +297,7 @@ void internal_mortar_data_impl(
 
       if (Spectral::needs_projection(face_mesh, mortar_mesh, mortar_size)) {
         auto& local_mortar_data_opt =
-            mortar_data_ptr->at(mortar_id).local().local_mortar_data();
+            mortar_data_ptr->at(mortar_id).local().mortar_data();
 
         // If this isn't the first time, set the face mesh
         if (LIKELY(local_mortar_data_opt.has_value())) {

--- a/src/Evolution/DiscontinuousGalerkin/Actions/InternalMortarDataImpl.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Actions/InternalMortarDataImpl.hpp
@@ -251,19 +251,15 @@ void internal_mortar_data_impl(
                                    total_face_size);
       } else {
         // Can use the local_mortar_data
-        auto& local_mortar_data_opt =
-            mortar_data_ptr->at(mortar_id).local().mortar_data();
-        // If this isn't the first time, set the face mesh
-        if (LIKELY(local_mortar_data_opt.has_value())) {
-          local_mortar_data_opt->first = face_mesh;
-        } else {
-          // Otherwise we need to initialize the pair. If we don't do this, then
-          // the DataVector will be non-owning which we don't want
-          local_mortar_data_opt =
-              std::optional{std::pair{face_mesh, DataVector{}}};
+        auto& local_mortar = mortar_data_ptr->at(mortar_id).local();
+        local_mortar.face_mesh = face_mesh;
+        // If this is the first time, initialize the data. If we don't do this,
+        // then the DataVector will be non-owning which we don't want
+        if (UNLIKELY(not local_mortar.mortar_data.has_value())) {
+          local_mortar.mortar_data = DataVector{};
         }
 
-        DataVector& local_mortar_data = local_mortar_data_opt->second;
+        DataVector& local_mortar_data = local_mortar.mortar_data.value();
 
         // Do a destructive resize to account for potential p-refinement
         local_mortar_data.destructive_resize(total_face_size);
@@ -296,20 +292,15 @@ void internal_mortar_data_impl(
       const auto& mortar_size = mortar_sizes.at(mortar_id);
 
       if (Spectral::needs_projection(face_mesh, mortar_mesh, mortar_size)) {
-        auto& local_mortar_data_opt =
-            mortar_data_ptr->at(mortar_id).local().mortar_data();
-
-        // If this isn't the first time, set the face mesh
-        if (LIKELY(local_mortar_data_opt.has_value())) {
-          local_mortar_data_opt->first = face_mesh;
-        } else {
-          // If we don't do this, then the DataVector will be non-owning which
-          // we don't want
-          local_mortar_data_opt =
-              std::optional{std::pair{face_mesh, DataVector{}}};
+        auto& local_mortar = mortar_data_ptr->at(mortar_id).local();
+        local_mortar.face_mesh = face_mesh;
+        // If this is the first time, initialize the data. If we don't do this,
+        // then the DataVector will be non-owning which we don't want
+        if (UNLIKELY(not local_mortar.mortar_data.has_value())) {
+          local_mortar.mortar_data = DataVector{};
         }
 
-        DataVector& local_mortar_data = local_mortar_data_opt->second;
+        DataVector& local_mortar_data = local_mortar.mortar_data.value();
 
         // Do a destructive resize to account for potential p-refinement
         local_mortar_data.destructive_resize(

--- a/src/Evolution/DiscontinuousGalerkin/Actions/InternalMortarDataImpl.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Actions/InternalMortarDataImpl.hpp
@@ -50,7 +50,8 @@ void internal_mortar_data_impl(
                               evolution::dg::Tags::MagnitudeOfNormal,
                               evolution::dg::Tags::NormalCovector<Dim>>>>>*>
         normal_covector_and_magnitude_ptr,
-    const gsl::not_null<DirectionalIdMap<Dim, evolution::dg::MortarData<Dim>>*>
+    const gsl::not_null<
+        DirectionalIdMap<Dim, evolution::dg::MortarDataHolder<Dim>>*>
         mortar_data_ptr,
     const gsl::not_null<gsl::span<double>*> face_temporaries,
     const gsl::not_null<gsl::span<double>*> packaged_data_buffer,
@@ -251,7 +252,7 @@ void internal_mortar_data_impl(
       } else {
         // Can use the local_mortar_data
         auto& local_mortar_data_opt =
-            mortar_data_ptr->at(mortar_id).local_mortar_data();
+            mortar_data_ptr->at(mortar_id).local().local_mortar_data();
         // If this isn't the first time, set the face mesh
         if (LIKELY(local_mortar_data_opt.has_value())) {
           local_mortar_data_opt->first = face_mesh;
@@ -296,7 +297,7 @@ void internal_mortar_data_impl(
 
       if (Spectral::needs_projection(face_mesh, mortar_mesh, mortar_size)) {
         auto& local_mortar_data_opt =
-            mortar_data_ptr->at(mortar_id).local_mortar_data();
+            mortar_data_ptr->at(mortar_id).local().local_mortar_data();
 
         // If this isn't the first time, set the face mesh
         if (LIKELY(local_mortar_data_opt.has_value())) {

--- a/src/Evolution/DiscontinuousGalerkin/CMakeLists.txt
+++ b/src/Evolution/DiscontinuousGalerkin/CMakeLists.txt
@@ -11,6 +11,7 @@ spectre_target_headers(
   DgElementArray.hpp
   InboxTags.hpp
   MortarData.hpp
+  MortarDataHolder.hpp
   MortarTags.hpp
   NormalVectorTags.hpp
   UsingSubcell.hpp
@@ -22,6 +23,7 @@ spectre_target_sources(
   AtomicInboxBoundaryData.cpp
   BoundaryData.cpp
   MortarData.cpp
+  MortarDataHolder.cpp
   )
 
 add_subdirectory(Actions)

--- a/src/Evolution/DiscontinuousGalerkin/Initialization/Mortars.cpp
+++ b/src/Evolution/DiscontinuousGalerkin/Initialization/Mortars.cpp
@@ -27,7 +27,7 @@ using MortarMap = DirectionalIdMap<Dim, MappedType>;
 }  // namespace
 
 template <size_t Dim>
-std::tuple<DirectionalIdMap<Dim, evolution::dg::MortarData<Dim>>,
+std::tuple<DirectionalIdMap<Dim, evolution::dg::MortarDataHolder<Dim>>,
            DirectionalIdMap<Dim, Mesh<Dim - 1>>,
            DirectionalIdMap<Dim, std::array<Spectral::MortarSize, Dim - 1>>,
            DirectionalIdMap<Dim, TimeStepId>,
@@ -39,7 +39,7 @@ mortars_apply_impl(const std::vector<std::array<size_t, Dim>>& initial_extents,
                    const Element<Dim>& element,
                    const TimeStepId& next_temporal_id,
                    const Mesh<Dim>& volume_mesh) {
-  MortarMap<evolution::dg::MortarData<Dim>, Dim> mortar_data{};
+  MortarMap<evolution::dg::MortarDataHolder<Dim>, Dim> mortar_data{};
   MortarMap<Mesh<Dim - 1>, Dim> mortar_meshes{};
   MortarMap<std::array<Spectral::MortarSize, Dim - 1>, Dim> mortar_sizes{};
   MortarMap<TimeStepId, Dim> mortar_next_temporal_ids{};
@@ -51,7 +51,7 @@ mortars_apply_impl(const std::vector<std::array<size_t, Dim>>& initial_extents,
     normal_covector_quantities[direction] = std::nullopt;
     for (const auto& neighbor : neighbors) {
       const DirectionalId<Dim> mortar_id{direction, neighbor};
-      mortar_data.emplace(mortar_id, MortarData<Dim>{});
+      mortar_data.emplace(mortar_id, MortarDataHolder<Dim>{});
       mortar_meshes.emplace(
           mortar_id,
           ::dg::mortar_mesh(volume_mesh.slice_away(direction.dimension()),
@@ -81,21 +81,21 @@ mortars_apply_impl(const std::vector<std::array<size_t, Dim>>& initial_extents,
 
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 
-#define INSTANTIATION(r, data)                                               \
-  template std::tuple<                                                       \
-      DirectionalIdMap<DIM(data), evolution::dg::MortarData<DIM(data)>>,     \
-      DirectionalIdMap<DIM(data), Mesh<DIM(data) - 1>>,                      \
-      DirectionalIdMap<DIM(data),                                            \
-                       std::array<Spectral::MortarSize, DIM(data) - 1>>,     \
-      DirectionalIdMap<DIM(data), TimeStepId>,                               \
-      DirectionMap<DIM(data),                                                \
-                   std::optional<Variables<tmpl::list<                       \
-                       evolution::dg::Tags::MagnitudeOfNormal,               \
-                       evolution::dg::Tags::NormalCovector<DIM(data)>>>>>>   \
-  mortars_apply_impl(                                                        \
-      const std::vector<std::array<size_t, DIM(data)>>& initial_extents,     \
-      const Spectral::Quadrature quadrature,                                 \
-      const Element<DIM(data)>& element, const TimeStepId& next_temporal_id, \
+#define INSTANTIATION(r, data)                                                 \
+  template std::tuple<                                                         \
+      DirectionalIdMap<DIM(data), evolution::dg::MortarDataHolder<DIM(data)>>, \
+      DirectionalIdMap<DIM(data), Mesh<DIM(data) - 1>>,                        \
+      DirectionalIdMap<DIM(data),                                              \
+                       std::array<Spectral::MortarSize, DIM(data) - 1>>,       \
+      DirectionalIdMap<DIM(data), TimeStepId>,                                 \
+      DirectionMap<DIM(data),                                                  \
+                   std::optional<Variables<tmpl::list<                         \
+                       evolution::dg::Tags::MagnitudeOfNormal,                 \
+                       evolution::dg::Tags::NormalCovector<DIM(data)>>>>>>     \
+  mortars_apply_impl(                                                          \
+      const std::vector<std::array<size_t, DIM(data)>>& initial_extents,       \
+      const Spectral::Quadrature quadrature,                                   \
+      const Element<DIM(data)>& element, const TimeStepId& next_temporal_id,   \
       const Mesh<DIM(data)>& volume_mesh);
 
 GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))

--- a/src/Evolution/DiscontinuousGalerkin/Initialization/Mortars.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Initialization/Mortars.hpp
@@ -33,6 +33,7 @@
 #include "Parallel/AlgorithmExecution.hpp"
 #include "ParallelAlgorithms/Amr/Protocols/Projector.hpp"
 #include "ParallelAlgorithms/Initialization/MutateAssign.hpp"
+#include "Time/BoundaryHistory.hpp"
 #include "Time/TimeStepId.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"

--- a/src/Evolution/DiscontinuousGalerkin/Initialization/Mortars.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Initialization/Mortars.hpp
@@ -26,6 +26,7 @@
 #include "Evolution/DiscontinuousGalerkin/InboxTags.hpp"
 #include "Evolution/DiscontinuousGalerkin/Initialization/QuadratureTag.hpp"
 #include "Evolution/DiscontinuousGalerkin/MortarData.hpp"
+#include "Evolution/DiscontinuousGalerkin/MortarDataHolder.hpp"
 #include "Evolution/DiscontinuousGalerkin/MortarTags.hpp"
 #include "Evolution/DiscontinuousGalerkin/NormalVectorTags.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/MortarHelpers.hpp"
@@ -60,7 +61,7 @@ class TaggedTuple;
 namespace evolution::dg::Initialization {
 namespace detail {
 template <size_t Dim>
-std::tuple<DirectionalIdMap<Dim, evolution::dg::MortarData<Dim>>,
+std::tuple<DirectionalIdMap<Dim, evolution::dg::MortarDataHolder<Dim>>,
            DirectionalIdMap<Dim, Mesh<Dim - 1>>,
            DirectionalIdMap<Dim, std::array<Spectral::MortarSize, Dim - 1>>,
            DirectionalIdMap<Dim, TimeStepId>,
@@ -184,7 +185,8 @@ struct ProjectMortars : tt::ConformsTo<amr::protocols::Projector> {
                  amr::Tags::NeighborInfo<dim>>;
 
   static void apply(
-      const gsl::not_null<::dg::MortarMap<dim, evolution::dg::MortarData<dim>>*>
+      const gsl::not_null<
+          ::dg::MortarMap<dim, evolution::dg::MortarDataHolder<dim>>*>
           mortar_data,
       const gsl::not_null<::dg::MortarMap<dim, Mesh<dim - 1>>*> mortar_mesh,
       const gsl::not_null<
@@ -215,7 +217,7 @@ struct ProjectMortars : tt::ConformsTo<amr::protocols::Projector> {
       (*normal_covector_and_magnitude)[direction] = std::nullopt;
       for (const auto& neighbor : neighbors) {
         const DirectionalId<dim> mortar_id{direction, neighbor};
-        mortar_data->emplace(mortar_id, MortarData<dim>{});
+        mortar_data->emplace(mortar_id, MortarDataHolder<dim>{});
         const auto new_neighbor_mesh = neighbors.orientation().inverse_map()(
             neighbor_info.at(neighbor).new_mesh);
         mortar_mesh->emplace(
@@ -236,7 +238,8 @@ struct ProjectMortars : tt::ConformsTo<amr::protocols::Projector> {
 
   template <typename... Tags>
   static void apply(
-      const gsl::not_null<::dg::MortarMap<dim, evolution::dg::MortarData<dim>>*>
+      const gsl::not_null<
+          ::dg::MortarMap<dim, evolution::dg::MortarDataHolder<dim>>*>
       /*mortar_data*/,
       const gsl::not_null<::dg::MortarMap<dim, Mesh<dim - 1>>*> /*mortar_mesh*/,
       const gsl::not_null<
@@ -260,7 +263,8 @@ struct ProjectMortars : tt::ConformsTo<amr::protocols::Projector> {
 
   template <typename... Tags>
   static void apply(
-      const gsl::not_null<::dg::MortarMap<dim, evolution::dg::MortarData<dim>>*>
+      const gsl::not_null<
+          ::dg::MortarMap<dim, evolution::dg::MortarDataHolder<dim>>*>
       /*mortar_data*/,
       const gsl::not_null<::dg::MortarMap<dim, Mesh<dim - 1>>*> /*mortar_mesh*/,
       const gsl::not_null<

--- a/src/Evolution/DiscontinuousGalerkin/MortarData.cpp
+++ b/src/Evolution/DiscontinuousGalerkin/MortarData.cpp
@@ -21,164 +21,21 @@
 
 namespace evolution::dg {
 template <size_t Dim>
-void MortarData<Dim>::insert_local_geometric_quantities(
-    const Scalar<DataVector>& local_volume_det_inv_jacobian,
-    const Scalar<DataVector>& local_face_det_jacobian,
-    const Scalar<DataVector>& local_face_normal_magnitude) {
-  ASSERT(mortar_data_.has_value(),
-         "Must set mortar data before setting the geometric quantities.");
-  ASSERT(local_face_det_jacobian[0].size() ==
-             local_face_normal_magnitude[0].size(),
-         "The determinant of the local face Jacobian has "
-             << local_face_det_jacobian[0].size()
-             << " grid points, and the magnitude of the local face normal has "
-             << local_face_normal_magnitude[0].size()
-             << " but they must be the same");
-  ASSERT(local_face_det_jacobian[0].size() ==
-             std::get<0>(*mortar_data()).number_of_grid_points(),
-         "The number of grid points ("
-             << std::get<0>(*mortar_data()).number_of_grid_points()
-             << ") on the local face must match the number of grid points "
-                "passed in for the face Jacobian determinant and normal vector "
-                "magnitude ("
-             << local_face_det_jacobian[0].size() << ")");
-  ASSERT(not using_only_face_normal_magnitude_,
-         "The face normal, volume inverse Jacobian determinant, and face "
-         "Jacobian determinant cannot be inserted because the only the face "
-         "normal is being used.");
-  using_volume_and_face_jacobians_ = true;
-  const size_t required_storage_size = local_volume_det_inv_jacobian[0].size() +
-                                       2 * local_face_det_jacobian[0].size();
-  local_geometric_quantities_.destructive_resize(required_storage_size);
-
-  std::copy(local_volume_det_inv_jacobian[0].begin(),
-            local_volume_det_inv_jacobian[0].end(),
-            local_geometric_quantities_.begin());
-  std::copy(
-      local_face_det_jacobian[0].begin(), local_face_det_jacobian[0].end(),
-      local_geometric_quantities_.begin() +
-          static_cast<std::ptrdiff_t>(local_volume_det_inv_jacobian[0].size()));
-  std::copy(
-      local_face_normal_magnitude[0].begin(),
-      local_face_normal_magnitude[0].end(),
-      local_geometric_quantities_.begin() +
-          static_cast<std::ptrdiff_t>(local_volume_det_inv_jacobian[0].size() +
-                                      local_face_det_jacobian[0].size()));
-}
-
-template <size_t Dim>
-void MortarData<Dim>::insert_local_face_normal_magnitude(
-    const Scalar<DataVector>& local_face_normal_magnitude) {
-  ASSERT(mortar_data_.has_value(),
-         "Must set mortar data before setting the local face normal.");
-  ASSERT(not using_volume_and_face_jacobians_,
-         "The face normal magnitude cannot be inserted if the face normal, "
-         "volume inverse Jacobian determinant, and face Jacobian determinant "
-         "are being used.");
-  using_only_face_normal_magnitude_ = true;
-  const size_t required_storage_size = local_face_normal_magnitude[0].size();
-  local_geometric_quantities_.destructive_resize(required_storage_size);
-
-  std::copy(local_face_normal_magnitude[0].begin(),
-            local_face_normal_magnitude[0].end(),
-            local_geometric_quantities_.begin());
-}
-
-template <size_t Dim>
-void MortarData<Dim>::get_local_volume_det_inv_jacobian(
-    const gsl::not_null<Scalar<DataVector>*> local_volume_det_inv_jacobian)
-    const {
-  ASSERT(mortar_data_.has_value(),
-         "Must set mortar data before getting the local volume inverse "
-         "Jacobian determinant.");
-  ASSERT(
-      local_geometric_quantities_.size() >
-          2 * std::get<0>(*mortar_data()).number_of_grid_points(),
-      "Cannot retrieve the volume inverse Jacobian determinant because it was "
-      "not inserted.");
-  ASSERT(
-      using_volume_and_face_jacobians_,
-      "Cannot retrieve the volume inverse Jacobian determinant because it was "
-      "not inserted.");
-  ASSERT(not using_only_face_normal_magnitude_,
-         "Inconsistent internal state: we are apparently using both the volume "
-         "and face Jacobians, as well as only the face normal.");
-  const size_t num_face_points =
-      std::get<0>(*mortar_data()).number_of_grid_points();
-  const size_t num_volume_points =
-      local_geometric_quantities_.size() - 2 * num_face_points;
-  get(*local_volume_det_inv_jacobian)
-      .set_data_ref(const_cast<double*>(  // NOLINT
-                        local_geometric_quantities_.data()),
-                    num_volume_points);
-}
-
-template <size_t Dim>
-void MortarData<Dim>::get_local_face_det_jacobian(
-    const gsl::not_null<Scalar<DataVector>*> local_face_det_jacobian) const {
-  ASSERT(mortar_data_.has_value(),
-         "Must set mortar data before getting the local face Jacobian "
-         "determinant.");
-  ASSERT(local_geometric_quantities_.size() >
-             2 * std::get<0>(*mortar_data()).number_of_grid_points(),
-         "Cannot retrieve the face Jacobian determinant because it was not "
-         "inserted.");
-  ASSERT(using_volume_and_face_jacobians_,
-         "Cannot retrieve the face Jacobian determinant because it was not "
-         "inserted.");
-  ASSERT(not using_only_face_normal_magnitude_,
-         "Inconsistent internal state: we are apparently using both the volume "
-         "and face Jacobians, as well as only the face normal.");
-  const size_t num_face_points =
-      std::get<0>(*mortar_data()).number_of_grid_points();
-  const size_t offset =
-      local_geometric_quantities_.size() - 2 * num_face_points;
-  get(*local_face_det_jacobian)
-      .set_data_ref(
-          // NOLINTNEXTLINE
-          const_cast<double*>(  // NOLINTNEXTLINE
-              local_geometric_quantities_.data() + offset),
-          num_face_points);
-}
-
-template <size_t Dim>
-void MortarData<Dim>::get_local_face_normal_magnitude(
-    const gsl::not_null<Scalar<DataVector>*> local_face_normal_magnitude)
-    const {
-  ASSERT(mortar_data_.has_value(),
-         "Must set local mortar data before getting the local face normal "
-         "magnitude.");
-  const size_t num_face_points =
-      std::get<0>(*mortar_data()).number_of_grid_points();
-  ASSERT(local_geometric_quantities_.size() == num_face_points or
-             local_geometric_quantities_.size() > 2 * num_face_points,
-         "Cannot retrieve the face normal magnitude because it was not "
-         "inserted.");
-  const size_t offset = local_geometric_quantities_.size() - num_face_points;
-  get(*local_face_normal_magnitude)
-      .set_data_ref(
-          // NOLINTNEXTLINE
-          const_cast<double*>(  // NOLINTNEXTLINE
-              local_geometric_quantities_.data() + offset),
-          num_face_points);
-}
-
-template <size_t Dim>
 void MortarData<Dim>::pup(PUP::er& p) {
-  p | mortar_data_;
-  p | local_geometric_quantities_;
-  p | using_volume_and_face_jacobians_;
-  p | using_only_face_normal_magnitude_;
+  p | mortar_data;
+  p | face_normal_magnitude;
+  p | face_det_jacobian;
+  p | volume_det_inv_jacobian;
+  p | face_mesh;
 }
 
 template <size_t Dim>
 bool operator==(const MortarData<Dim>& lhs, const MortarData<Dim>& rhs) {
-  return lhs.mortar_data() == rhs.mortar_data() and
-         lhs.local_geometric_quantities_ == rhs.local_geometric_quantities_ and
-         lhs.using_volume_and_face_jacobians_ ==
-             rhs.using_volume_and_face_jacobians_ and
-         lhs.using_only_face_normal_magnitude_ ==
-             rhs.using_only_face_normal_magnitude_;
+  return lhs.mortar_data == rhs.mortar_data and
+         lhs.face_normal_magnitude == rhs.face_normal_magnitude and
+         lhs.face_det_jacobian == rhs.face_det_jacobian and
+         lhs.volume_det_inv_jacobian == rhs.volume_det_inv_jacobian and
+         lhs.face_mesh == rhs.face_mesh;
 }
 
 template <size_t Dim>
@@ -188,7 +45,11 @@ bool operator!=(const MortarData<Dim>& lhs, const MortarData<Dim>& rhs) {
 
 template <size_t Dim>
 std::ostream& operator<<(std::ostream& os, const MortarData<Dim>& mortar_data) {
-  os << "MortarData: " << mortar_data.mortar_data() << "\n";
+  os << "Mortar data: " << mortar_data.mortar_data << "\n";
+  os << "Face normal magnitude: " << mortar_data.face_normal_magnitude << "\n";
+  os << "Face det(J): " << mortar_data.face_det_jacobian << "\n";
+  os << "Face mesh: " << mortar_data.face_mesh << "\n";
+  os << "Volume det(invJ): " << mortar_data.volume_det_inv_jacobian << "\n";
   return os;
 }
 

--- a/src/Evolution/DiscontinuousGalerkin/MortarData.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/MortarData.hpp
@@ -21,14 +21,15 @@ namespace evolution::dg {
  * \brief Data on the mortar used to compute the boundary correction for the
  * DG scheme.
  *
- * The class holds the local data that has been projected to the mortar as well
- * as the neighbor data that has been projected to the mortar. The local and
- * neighbor data is later used to compute the same unique boundary correction on
- * the mortar for both elements. That is, the final boundary correction
+ * The class holds the data that has been projected to one side of the mortar.
+ * It is meant to be used in a container (either MortarDataHolder or
+ * TimeSteppers::BoundaryHistory) that holds MortarData on each side of the
+ * mortar. The data is later used to compute the same unique boundary correction
+ * on the mortar for both elements. That is, the final boundary correction
  * computation is done twice: once on each element touching the mortar. However,
  * the computation is done in such a way that the results agree.
  *
- * In addition to the (type-erased) fields on both sides of the mortar, the face
+ * In addition to the (type-erased) fields on the mortar, the face
  * (not mortar!) mesh of the neighbor is stored. The mesh will be necessary
  * when hybridizing DG with finite difference or finite volume schemes
  * (DG-subcell).
@@ -112,25 +113,17 @@ class MortarData {
   void get_local_face_normal_magnitude(
       gsl::not_null<Scalar<DataVector>*> local_face_normal_magnitude) const;
 
-  auto local_mortar_data() const
+  /// @{
+  /// Data on the mortar
+  auto mortar_data() const
       -> const std::optional<std::pair<Mesh<Dim - 1>, DataVector>>& {
-    return local_mortar_data_;
+    return mortar_data_;
   }
 
-  auto neighbor_mortar_data() const
-      -> const std::optional<std::pair<Mesh<Dim - 1>, DataVector>>& {
-    return neighbor_mortar_data_;
+  auto mortar_data() -> std::optional<std::pair<Mesh<Dim - 1>, DataVector>>& {
+    return mortar_data_;
   }
-
-  auto local_mortar_data()
-      -> std::optional<std::pair<Mesh<Dim - 1>, DataVector>>& {
-    return local_mortar_data_;
-  }
-
-  auto neighbor_mortar_data()
-      -> std::optional<std::pair<Mesh<Dim - 1>, DataVector>>& {
-    return neighbor_mortar_data_;
-  }
+  /// @}
 
   // NOLINTNEXTLINE(google-runtime-references)
   void pup(PUP::er& p);
@@ -141,8 +134,7 @@ class MortarData {
   friend bool operator==(const MortarData<LocalDim>& lhs,
                          const MortarData<LocalDim>& rhs);
 
-  MortarType local_mortar_data_{};
-  MortarType neighbor_mortar_data_{};
+  MortarType mortar_data_{};
   DataVector local_geometric_quantities_{};
   bool using_volume_and_face_jacobians_{false};
   bool using_only_face_normal_magnitude_{false};

--- a/src/Evolution/DiscontinuousGalerkin/MortarData.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/MortarData.hpp
@@ -11,7 +11,7 @@
 #include <utility>
 
 #include "DataStructures/DataVector.hpp"
-#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/Serialization/PupStlCpp17.hpp"
@@ -29,116 +29,47 @@ namespace evolution::dg {
  * computation is done twice: once on each element touching the mortar. However,
  * the computation is done in such a way that the results agree.
  *
- * In addition to the (type-erased) fields on the mortar, the face
- * (not mortar!) mesh of the neighbor is stored. The mesh will be necessary
- * when hybridizing DG with finite difference or finite volume schemes
- * (DG-subcell).
+ * For local time stepping, the magnitude of the face normal is stored.
  *
- * If the element and its neighbor have unaligned logical coordinate systems
- * then the data is stored in the local logical coordinate's orientation
- * (\f$\xi\f$ varies fastest). This means the action sending the data is
- * responsible for reorienting the data on the mortar so it matches the
- * neighbor's orientation.
+ * The magnitude of the face normal is given by:
  *
- * \tparam Dim the volume dimension of the mesh
+ * \f{align*}{
+ *  \sqrt{
+ *   \frac{\partial\xi}{\partial x^i} \gamma^{ij}
+ *   \frac{\partial\xi}{\partial x^j}}
+ * \f}
+ *
+ * for a face in the \f$\xi\f$-direction, with inverse spatial metric
+ * \f$\gamma^{ij}\f$.
+ *
+ * In addition, for local time stepping with Gauss points, the determinants of
+ * the volume inverse Jacobian and the face Jacobian are stored.
+ *
+ * In addition to the (type-erased) fields on the mortar, the face mesh is
+ * stored
+ *
+ * If the element and its neighbor have unaligned logical coordinate
+ * systems then the data and meshes are stored in the local logical
+ * coordinate's orientation (\f$\xi\f$ varies fastest). This means the
+ * action sending the data is responsible for reorienting the data on
+ * the mortar so it matches the neighbor's orientation.
+ *
+ * \tparam Dim the volume dimension
  */
 template <size_t Dim>
-class MortarData {
-  using MortarType = std::optional<std::pair<Mesh<Dim - 1>, DataVector>>;
-
- public:
-  /*!
-   * \brief Insert the magnitude of the local face normal, the determinant
-   * of the volume inverse Jacobian, and the determinant of the face Jacobian.
-   * Used for local time stepping with Gauss points.
-   *
-   * The magnitude of the face normal is given by:
-   *
-   * \f{align*}{
-   *  \sqrt{
-   *   \frac{\partial\xi}{\partial x^i} \gamma^{ij}
-   *   \frac{\partial\xi}{\partial x^j}}
-   * \f}
-   *
-   * for a face in the \f$\xi\f$-direction, with inverse spatial metric
-   * \f$\gamma^{ij}\f$.
-   */
-  void insert_local_geometric_quantities(
-      const Scalar<DataVector>& local_volume_det_inv_jacobian,
-      const Scalar<DataVector>& local_face_det_jacobian,
-      const Scalar<DataVector>& local_face_normal_magnitude);
-
-  /*!
-   * \brief Insert the magnitude of the local face normal. Used for local time
-   * stepping with Gauss-Lobatto points.
-   *
-   * The magnitude of the face normal is given by:
-   *
-   * \f{align*}{
-   *  \sqrt{
-   *   \frac{\partial\xi}{\partial x^i} \gamma^{ij}
-   *   \frac{\partial\xi}{\partial x^j}}
-   * \f}
-   *
-   * for a face in the \f$\xi\f$-direction, with inverse spatial metric
-   * \f$\gamma^{ij}\f$.
-   */
-  void insert_local_face_normal_magnitude(
-      const Scalar<DataVector>& local_face_normal_magnitude);
-
-  /*!
-   * \brief Sets the `local_volume_det_inv_jacobian` by setting the DataVector
-   * to point into the `MortarData`'s internal storage.
-   *
-   * \warning The result should never be changed.
-   */
-  void get_local_volume_det_inv_jacobian(
-      gsl::not_null<Scalar<DataVector>*> local_volume_det_inv_jacobian) const;
-
-  /*!
-   * \brief Sets the `local_face_det_jacobian` by setting the DataVector to
-   * point into the `MortarData`'s internal storage.
-   *
-   * \warning The result should never be changed.
-   */
-  void get_local_face_det_jacobian(
-      gsl::not_null<Scalar<DataVector>*> local_face_det_jacobian) const;
-
-  /*!
-   * \brief Sets the `local_face_normal_magnitude` by setting the DataVector to
-   * point into the `MortarData`'s internal storage.
-   *
-   * \warning The result should never be changed.
-   */
-  void get_local_face_normal_magnitude(
-      gsl::not_null<Scalar<DataVector>*> local_face_normal_magnitude) const;
-
-  /// @{
-  /// Data on the mortar
-  auto mortar_data() const
-      -> const std::optional<std::pair<Mesh<Dim - 1>, DataVector>>& {
-    return mortar_data_;
-  }
-
-  auto mortar_data() -> std::optional<std::pair<Mesh<Dim - 1>, DataVector>>& {
-    return mortar_data_;
-  }
-  /// @}
+struct MortarData {
+  std::optional<DataVector> mortar_data{std::nullopt};
+  std::optional<Scalar<DataVector>> face_normal_magnitude{std::nullopt};
+  std::optional<Scalar<DataVector>> face_det_jacobian{std::nullopt};
+  std::optional<Scalar<DataVector>> volume_det_inv_jacobian{std::nullopt};
+  std::optional<Mesh<Dim - 1>> face_mesh{std::nullopt};
 
   // NOLINTNEXTLINE(google-runtime-references)
   void pup(PUP::er& p);
-
- private:
-  template <size_t LocalDim>
-  // NOLINTNEXTLINE
-  friend bool operator==(const MortarData<LocalDim>& lhs,
-                         const MortarData<LocalDim>& rhs);
-
-  MortarType mortar_data_{};
-  DataVector local_geometric_quantities_{};
-  bool using_volume_and_face_jacobians_{false};
-  bool using_only_face_normal_magnitude_{false};
 };
+
+template <size_t Dim>
+bool operator==(const MortarData<Dim>& lhs, const MortarData<Dim>& rhs);
 
 template <size_t Dim>
 bool operator!=(const MortarData<Dim>& lhs, const MortarData<Dim>& rhs);

--- a/src/Evolution/DiscontinuousGalerkin/MortarDataHolder.cpp
+++ b/src/Evolution/DiscontinuousGalerkin/MortarDataHolder.cpp
@@ -1,0 +1,25 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/DiscontinuousGalerkin/MortarDataHolder.hpp"
+
+#include <pup.h>
+
+#include "Utilities/GenerateInstantiations.hpp"
+
+namespace evolution::dg {
+template <size_t Dim>
+void MortarDataHolder<Dim>::pup(PUP::er& p) {
+  p | local_data_;
+  p | neighbor_data_;
+}
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATION(r, data) template class MortarDataHolder<DIM(data)>;
+
+GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
+
+#undef INSTANTIATION
+#undef DIM
+}  // namespace evolution::dg

--- a/src/Evolution/DiscontinuousGalerkin/MortarDataHolder.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/MortarDataHolder.hpp
@@ -1,0 +1,39 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "Evolution/DiscontinuousGalerkin/MortarData.hpp"
+
+/// \cond
+namespace PUP {
+class er;
+}  // namespace PUP
+/// \endcond
+
+namespace evolution::dg {
+/// \brief Data on each side of the mortar used to compute the boundary
+/// correction for the DG scheme using global time stepping.
+template <size_t Dim>
+class MortarDataHolder {
+ public:
+  /// Access the data on the local side.
+  /// @{
+  const MortarData<Dim>& local() const { return local_data_; }
+  MortarData<Dim>& local() { return local_data_; }
+  /// @}
+
+  /// Access the data on the neighbor side.
+  /// @{
+  const MortarData<Dim>& neighbor() const { return neighbor_data_; }
+  MortarData<Dim>& neighbor() { return neighbor_data_; }
+  /// @}
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& p);
+
+ private:
+  MortarData<Dim> local_data_;
+  MortarData<Dim> neighbor_data_;
+};
+}  // namespace evolution::dg

--- a/src/Evolution/DiscontinuousGalerkin/MortarTags.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/MortarTags.hpp
@@ -18,6 +18,8 @@ template <size_t Dim>
 class BoundaryMessage;
 template <size_t Dim>
 class MortarData;
+template <size_t Dim>
+class MortarDataHolder;
 }  // namespace evolution::dg
 namespace Spectral {
 enum class ChildSize : uint8_t;
@@ -37,7 +39,7 @@ namespace evolution::dg::Tags {
 /// The `Dim` is the volume dimension, not the face dimension.
 template <size_t Dim>
 struct MortarData : db::SimpleTag {
-  using type = DirectionalIdMap<Dim, evolution::dg::MortarData<Dim>>;
+  using type = DirectionalIdMap<Dim, evolution::dg::MortarDataHolder<Dim>>;
 };
 
 /// History of the data on mortars, indexed by (Direction, ElementId) pairs, and

--- a/src/Evolution/DiscontinuousGalerkin/MortarTags.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/MortarTags.hpp
@@ -3,22 +3,32 @@
 
 #pragma once
 
-#include <array>
 #include <cstddef>
 #include <memory>
-#include <utility>
 
 #include "DataStructures/DataBox/Tag.hpp"
-#include "Domain/Structure/Direction.hpp"
-#include "Domain/Structure/DirectionalId.hpp"
-#include "Domain/Structure/DirectionalIdMap.hpp"
-#include "Domain/Structure/ElementId.hpp"
-#include "Evolution/DiscontinuousGalerkin/Messages/BoundaryMessage.hpp"
-#include "Evolution/DiscontinuousGalerkin/MortarData.hpp"
-#include "NumericalAlgorithms/Spectral/Mesh.hpp"
-#include "NumericalAlgorithms/Spectral/Projection.hpp"  // for MortarSize
-#include "Time/BoundaryHistory.hpp"
-#include "Time/TimeStepId.hpp"
+
+/// \cond
+template <size_t Dim, typename T>
+class DirectionalIdMap;
+template <size_t Dim>
+class Mesh;
+namespace evolution::dg {
+template <size_t Dim>
+class BoundaryMessage;
+template <size_t Dim>
+class MortarData;
+}  // namespace evolution::dg
+namespace Spectral {
+enum class ChildSize : uint8_t;
+using MortarSize = ChildSize;
+}  // namespace Spectral
+class TimeStepId;
+namespace TimeSteppers {
+template <typename LocalData, typename RemoteData, typename CouplingResult>
+class BoundaryHistory;
+}  // namespace TimeSteppers
+/// \endcond
 
 /// %Tags used for DG evolution scheme.
 namespace evolution::dg::Tags {

--- a/tests/Unit/Evolution/DgSubcell/Actions/Test_ReconstructionCommunication.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Actions/Test_ReconstructionCommunication.cpp
@@ -42,6 +42,7 @@
 #include "Evolution/DgSubcell/Tags/TciGridHistory.hpp"
 #include "Evolution/DgSubcell/Tags/TciStatus.hpp"
 #include "Evolution/DiscontinuousGalerkin/BoundaryData.hpp"
+#include "Evolution/DiscontinuousGalerkin/MortarDataHolder.hpp"
 #include "Framework/ActionTesting.hpp"
 #include "NumericalAlgorithms/Spectral/LogicalCoordinates.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"

--- a/tests/Unit/Evolution/DgSubcell/Actions/Test_TakeTimeStep.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Actions/Test_TakeTimeStep.cpp
@@ -148,7 +148,7 @@ void test() {
   // cleared.
   DirectionalIdMap<Dim, evolution::dg::MortarDataHolder<Dim>> mortar_data{};
   evolution::dg::MortarDataHolder<Dim> lower_xi_data{};
-  lower_xi_data.local().local_mortar_data() =
+  lower_xi_data.local().mortar_data() =
       std::pair{subcell_mesh.slice_away(0), DataVector{1.1, 2.43, 7.8}};
   const DirectionalId<Dim> lower_id{Direction<Dim>::lower_xi(),
                                     ElementId<Dim>{1}};
@@ -165,7 +165,7 @@ void test() {
             runner, 0)
             .at(lower_id)
             .local()
-            .local_mortar_data()
+            .mortar_data()
             .has_value());
 
   // Invoke the TakeTimeStep action on the runner
@@ -175,7 +175,7 @@ void test() {
                   comp, evolution::dg::Tags::MortarData<Dim>>(runner, 0)
                   .at(lower_id)
                   .local()
-                  .local_mortar_data()
+                  .mortar_data()
                   .has_value());
   CHECK(metavars::time_derivative_invoked);
 }

--- a/tests/Unit/Evolution/DgSubcell/Actions/Test_TakeTimeStep.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Actions/Test_TakeTimeStep.cpp
@@ -148,8 +148,8 @@ void test() {
   // cleared.
   DirectionalIdMap<Dim, evolution::dg::MortarDataHolder<Dim>> mortar_data{};
   evolution::dg::MortarDataHolder<Dim> lower_xi_data{};
-  lower_xi_data.local().mortar_data() =
-      std::pair{subcell_mesh.slice_away(0), DataVector{1.1, 2.43, 7.8}};
+  lower_xi_data.local().face_mesh = subcell_mesh.slice_away(0);
+  lower_xi_data.local().mortar_data = DataVector{1.1, 2.43, 7.8};
   const DirectionalId<Dim> lower_id{Direction<Dim>::lower_xi(),
                                     ElementId<Dim>{1}};
   mortar_data[lower_id] = lower_xi_data;
@@ -165,8 +165,7 @@ void test() {
             runner, 0)
             .at(lower_id)
             .local()
-            .mortar_data()
-            .has_value());
+            .mortar_data.has_value());
 
   // Invoke the TakeTimeStep action on the runner
   ActionTesting::next_action<comp>(make_not_null(&runner), 0);
@@ -175,8 +174,7 @@ void test() {
                   comp, evolution::dg::Tags::MortarData<Dim>>(runner, 0)
                   .at(lower_id)
                   .local()
-                  .mortar_data()
-                  .has_value());
+                  .mortar_data.has_value());
   CHECK(metavars::time_derivative_invoked);
 }
 

--- a/tests/Unit/Evolution/DgSubcell/Actions/Test_TakeTimeStep.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Actions/Test_TakeTimeStep.cpp
@@ -146,9 +146,9 @@ void test() {
                                Spectral::Quadrature::CellCentered};
   // Set up nonsense mortar data since we only need to check that it got
   // cleared.
-  DirectionalIdMap<Dim, evolution::dg::MortarData<Dim>> mortar_data{};
-  evolution::dg::MortarData<Dim> lower_xi_data{};
-  lower_xi_data.local_mortar_data() =
+  DirectionalIdMap<Dim, evolution::dg::MortarDataHolder<Dim>> mortar_data{};
+  evolution::dg::MortarDataHolder<Dim> lower_xi_data{};
+  lower_xi_data.local().local_mortar_data() =
       std::pair{subcell_mesh.slice_away(0), DataVector{1.1, 2.43, 7.8}};
   const DirectionalId<Dim> lower_id{Direction<Dim>::lower_xi(),
                                     ElementId<Dim>{1}};
@@ -164,6 +164,7 @@ void test() {
                                        evolution::dg::Tags::MortarData<Dim>>(
             runner, 0)
             .at(lower_id)
+            .local()
             .local_mortar_data()
             .has_value());
 
@@ -173,6 +174,7 @@ void test() {
   CHECK_FALSE(ActionTesting::get_databox_tag<
                   comp, evolution::dg::Tags::MortarData<Dim>>(runner, 0)
                   .at(lower_id)
+                  .local()
                   .local_mortar_data()
                   .has_value());
   CHECK(metavars::time_derivative_invoked);

--- a/tests/Unit/Evolution/DgSubcell/Test_CorrectPackagedData.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Test_CorrectPackagedData.cpp
@@ -22,6 +22,7 @@
 #include "Evolution/DgSubcell/Mesh.hpp"
 #include "Evolution/DgSubcell/Projection.hpp"
 #include "Evolution/DiscontinuousGalerkin/MortarData.hpp"
+#include "Evolution/DiscontinuousGalerkin/MortarDataHolder.hpp"
 #include "NumericalAlgorithms/Spectral/Basis.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "NumericalAlgorithms/Spectral/Quadrature.hpp"
@@ -83,16 +84,16 @@ void test() {
     const SubcellFaceVars interior_lower_packaged_data = lower_packaged_data;
     const SubcellFaceVars interior_upper_packaged_data = upper_packaged_data;
 
-    DirectionalIdMap<Dim, evolution::dg::MortarData<Dim>> mortar_data{};
+    DirectionalIdMap<Dim, evolution::dg::MortarDataHolder<Dim>> mortar_data{};
     const Direction<Dim> upper{direction_to_check, Side::Upper};
     const Direction<Dim> lower{direction_to_check, Side::Lower};
     const DirectionalId<Dim> upper_neighbor{
         upper, *element.neighbors().at(upper).begin()};
     const DirectionalId<Dim> lower_neighbor{
         lower, *element.neighbors().at(lower).begin()};
-    evolution::dg::MortarData<Dim>& upper_mortar_data =
+    evolution::dg::MortarDataHolder<Dim>& upper_mortar_data =
         mortar_data[upper_neighbor] = {};
-    evolution::dg::MortarData<Dim>& lower_mortar_data =
+    evolution::dg::MortarDataHolder<Dim>& lower_mortar_data =
         mortar_data[lower_neighbor] = {};
 
     const Mesh<Dim - 1> dg_face_mesh =
@@ -117,9 +118,9 @@ void test() {
     }();
 
     // Insert neighbor DG data.
-    upper_mortar_data.neighbor_mortar_data() =
+    upper_mortar_data.neighbor().neighbor_mortar_data() =
         std::pair{dg_face_mesh, upper_neighbor_data};
-    lower_mortar_data.neighbor_mortar_data() =
+    lower_mortar_data.neighbor().neighbor_mortar_data() =
         std::pair{dg_face_mesh, lower_neighbor_data};
 
     const Mesh<Dim - 1> subcell_face_mesh =
@@ -223,9 +224,9 @@ void test() {
       DataVector lower_local_data{dg_number_of_independent_components *
                                   dg_face_mesh.number_of_grid_points()};
       std::iota(lower_local_data.begin(), lower_local_data.end(), 1.0e7);
-      upper_mortar_data.local_mortar_data() =
+      upper_mortar_data.local().local_mortar_data() =
           std::pair{dg_face_mesh, upper_local_data};
-      lower_mortar_data.local_mortar_data() =
+      lower_mortar_data.local().local_mortar_data() =
           std::pair{dg_face_mesh, lower_local_data};
 
       evolution::dg::subcell::correct_package_data<true>(

--- a/tests/Unit/Evolution/DgSubcell/Test_CorrectPackagedData.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Test_CorrectPackagedData.cpp
@@ -118,10 +118,10 @@ void test() {
     }();
 
     // Insert neighbor DG data.
-    upper_mortar_data.neighbor().mortar_data() =
-        std::pair{dg_face_mesh, upper_neighbor_data};
-    lower_mortar_data.neighbor().mortar_data() =
-        std::pair{dg_face_mesh, lower_neighbor_data};
+    upper_mortar_data.neighbor().face_mesh = dg_face_mesh;
+    upper_mortar_data.neighbor().mortar_data = upper_neighbor_data;
+    lower_mortar_data.neighbor().face_mesh = dg_face_mesh;
+    lower_mortar_data.neighbor().mortar_data = lower_neighbor_data;
 
     const Mesh<Dim - 1> subcell_face_mesh =
         volume_subcell_mesh.slice_away(direction_to_check);
@@ -224,10 +224,10 @@ void test() {
       DataVector lower_local_data{dg_number_of_independent_components *
                                   dg_face_mesh.number_of_grid_points()};
       std::iota(lower_local_data.begin(), lower_local_data.end(), 1.0e7);
-      upper_mortar_data.local().mortar_data() =
-          std::pair{dg_face_mesh, upper_local_data};
-      lower_mortar_data.local().mortar_data() =
-          std::pair{dg_face_mesh, lower_local_data};
+      upper_mortar_data.local().face_mesh = dg_face_mesh;
+      upper_mortar_data.local().mortar_data = upper_local_data;
+      lower_mortar_data.local().face_mesh = dg_face_mesh;
+      lower_mortar_data.local().mortar_data = lower_local_data;
 
       evolution::dg::subcell::correct_package_data<true>(
           make_not_null(&lower_packaged_data),

--- a/tests/Unit/Evolution/DgSubcell/Test_CorrectPackagedData.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Test_CorrectPackagedData.cpp
@@ -118,9 +118,9 @@ void test() {
     }();
 
     // Insert neighbor DG data.
-    upper_mortar_data.neighbor().neighbor_mortar_data() =
+    upper_mortar_data.neighbor().mortar_data() =
         std::pair{dg_face_mesh, upper_neighbor_data};
-    lower_mortar_data.neighbor().neighbor_mortar_data() =
+    lower_mortar_data.neighbor().mortar_data() =
         std::pair{dg_face_mesh, lower_neighbor_data};
 
     const Mesh<Dim - 1> subcell_face_mesh =
@@ -224,9 +224,9 @@ void test() {
       DataVector lower_local_data{dg_number_of_independent_components *
                                   dg_face_mesh.number_of_grid_points()};
       std::iota(lower_local_data.begin(), lower_local_data.end(), 1.0e7);
-      upper_mortar_data.local().local_mortar_data() =
+      upper_mortar_data.local().mortar_data() =
           std::pair{dg_face_mesh, upper_local_data};
-      lower_mortar_data.local().local_mortar_data() =
+      lower_mortar_data.local().mortar_data() =
           std::pair{dg_face_mesh, lower_local_data};
 
       evolution::dg::subcell::correct_package_data<true>(

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Actions/Test_ApplyBoundaryCorrections.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Actions/Test_ApplyBoundaryCorrections.cpp
@@ -237,8 +237,9 @@ struct SetLocalMortarData {
               // at the end of the SetLocalMortarData action since the
               // ComputeTimeDerivative action would've moved the data into the
               // boundary history.
-              mortar_data_ptr->at(mortar_id).local_mortar_data() = std::pair{
-                  face_mesh, std::move(type_erased_boundary_data_on_mortar)};
+              mortar_data_ptr->at(mortar_id).local().local_mortar_data() =
+                  std::pair{face_mesh,
+                            std::move(type_erased_boundary_data_on_mortar)};
             },
             make_not_null(&box));
         ++count;
@@ -317,7 +318,7 @@ struct SetLocalMortarData {
 
                 // Now add the current data into the history.
                 evolution::dg::MortarData<Metavariables::volume_dim>&
-                    local_mortar_data = mortar_data_ptr->at(mortar_id);
+                    local_mortar_data = mortar_data_ptr->at(mortar_id).local();
 
                 const Scalar<DataVector>& face_normal_magnitude =
                     get<evolution::dg::Tags::MagnitudeOfNormal>(
@@ -698,7 +699,7 @@ void test_impl(const Spectral::Quadrature quadrature,
               std::move(nhbr_mortar_data));
         }
       } else {
-        all_mortar_data.at(mortar_id).neighbor_mortar_data() =
+        all_mortar_data.at(mortar_id).neighbor().neighbor_mortar_data() =
             std::pair{face_mesh, flux_data};
       }
       ++count;
@@ -957,7 +958,7 @@ void test_impl(const Spectral::Quadrature quadrature,
         continue;
       }
       mortar_id_ptr = &mortar_id;
-      compute_correction_coupling(mortar_data, mortar_data);
+      compute_correction_coupling(mortar_data.local(), mortar_data.neighbor());
     }
     tmpl::for_each<dt_variables_tags>(
         [&expected_dt_variables_volume, &runner, &self_id](auto tag_v) {

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Actions/Test_ApplyBoundaryCorrections.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Actions/Test_ApplyBoundaryCorrections.cpp
@@ -237,9 +237,8 @@ struct SetLocalMortarData {
               // at the end of the SetLocalMortarData action since the
               // ComputeTimeDerivative action would've moved the data into the
               // boundary history.
-              mortar_data_ptr->at(mortar_id).local().local_mortar_data() =
-                  std::pair{face_mesh,
-                            std::move(type_erased_boundary_data_on_mortar)};
+              mortar_data_ptr->at(mortar_id).local().mortar_data() = std::pair{
+                  face_mesh, std::move(type_erased_boundary_data_on_mortar)};
             },
             make_not_null(&box));
         ++count;
@@ -267,7 +266,7 @@ struct SetLocalMortarData {
           count++;
           evolution::dg::MortarData<Metavariables::volume_dim>
               past_mortar_data{};
-          past_mortar_data.local_mortar_data() = std::pair{
+          past_mortar_data.mortar_data() = std::pair{
               face_mesh, std::move(type_erased_boundary_data_on_mortar)};
           Scalar<DataVector> local_face_normal_magnitude{
               face_mesh.number_of_grid_points()};
@@ -692,14 +691,13 @@ void test_impl(const Spectral::Quadrature quadrature,
       if (UseLocalTimeStepping) {
         if (neighbor_time_step_id < local_next_time_step_id) {
           evolution::dg::MortarData<Dim> nhbr_mortar_data{};
-          nhbr_mortar_data.neighbor_mortar_data() =
-              std::pair{face_mesh, flux_data};
+          nhbr_mortar_data.mortar_data() = std::pair{face_mesh, flux_data};
           mortar_data_history.at(mortar_id).remote().insert(
               neighbor_time_step_id, integration_order,
               std::move(nhbr_mortar_data));
         }
       } else {
-        all_mortar_data.at(mortar_id).neighbor().neighbor_mortar_data() =
+        all_mortar_data.at(mortar_id).neighbor().mortar_data() =
             std::pair{face_mesh, flux_data};
       }
       ++count;
@@ -799,9 +797,9 @@ void test_impl(const Spectral::Quadrature quadrature,
     Variables<mortar_tags_list> neighbor_data_on_mortar{
         mortar_mesh.number_of_grid_points()};
     const std::pair<Mesh<Dim - 1>, DataVector>& local_mesh_and_data =
-        *local_mortar_data.local_mortar_data();
+        *local_mortar_data.mortar_data();
     const std::pair<Mesh<Dim - 1>, DataVector>& neighbor_mesh_and_data =
-        *neighbor_mortar_data.neighbor_mortar_data();
+        *neighbor_mortar_data.mortar_data();
     std::copy(std::get<1>(local_mesh_and_data).begin(),
               std::get<1>(local_mesh_and_data).end(),
               local_data_on_mortar.data());

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Initialization/Test_Mortars.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Initialization/Test_Mortars.cpp
@@ -353,7 +353,7 @@ struct Test<3, LocalTimeStepping> {
 
 template <size_t Dim, bool UsingLts>
 void test_p_refine(
-    ::dg::MortarMap<Dim, evolution::dg::MortarData<Dim>>& mortar_data,
+    ::dg::MortarMap<Dim, evolution::dg::MortarDataHolder<Dim>>& mortar_data,
     ::dg::MortarMap<Dim, Mesh<Dim - 1>>& mortar_mesh,
     ::dg::MortarMap<Dim, std::array<Spectral::MortarSize, Dim - 1>>&
         mortar_size,
@@ -367,7 +367,7 @@ void test_p_refine(
     const Element<Dim>& old_element, Element<Dim>& new_element,
     std::unordered_map<ElementId<Dim>, amr::Info<Dim>>& neighbor_info,
     const ::dg::MortarMap<
-        Dim, evolution::dg::MortarData<Dim>>& /*expected_mortar_data*/,
+        Dim, evolution::dg::MortarDataHolder<Dim>>& /*expected_mortar_data*/,
     const ::dg::MortarMap<Dim, Mesh<Dim - 1>>& expected_mortar_mesh,
     const ::dg::MortarMap<Dim, std::array<Spectral::MortarSize, Dim - 1>>&
         expected_mortar_size,
@@ -467,7 +467,7 @@ void test_p_refine_gts() {
 
   // These quantities are re-allocated after projection, so we can
   // just set them to empty maps...
-  ::dg::MortarMap<Dim, evolution::dg::MortarData<Dim>> mortar_data{};
+  ::dg::MortarMap<Dim, evolution::dg::MortarDataHolder<Dim>> mortar_data{};
   ::dg::MortarMap<Dim, Mesh<Dim - 1>> mortar_mesh{};
   ::dg::MortarMap<Dim, std::array<Spectral::MortarSize, Dim - 1>> mortar_size{};
   DirectionMap<Dim, std::optional<Variables<
@@ -488,7 +488,8 @@ void test_p_refine_gts() {
     }
   }
 
-  ::dg::MortarMap<Dim, evolution::dg::MortarData<Dim>> expected_mortar_data{};
+  ::dg::MortarMap<Dim, evolution::dg::MortarDataHolder<Dim>>
+      expected_mortar_data{};
   ::dg::MortarMap<Dim, Mesh<Dim - 1>> expected_mortar_mesh{};
   ::dg::MortarMap<Dim, std::array<Spectral::MortarSize, Dim - 1>>
       expected_mortar_size{};
@@ -502,7 +503,7 @@ void test_p_refine_gts() {
     expected_normal_covector_and_magnitude[direction] = std::nullopt;
     for (const auto& neighbor : neighbors) {
       const DirectionalId<Dim> mortar_id{direction, neighbor};
-      expected_mortar_data.emplace(mortar_id, MortarData<Dim>{});
+      expected_mortar_data.emplace(mortar_id, MortarDataHolder<Dim>{});
       expected_mortar_mesh.emplace(
           mortar_id,
           ::dg::mortar_mesh(new_mesh.slice_away(direction.dimension()),

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Test_MortarData.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Test_MortarData.cpp
@@ -28,23 +28,12 @@ namespace evolution::dg {
 namespace {
 template <size_t Dim>
 void assign_with_reference(const gsl::not_null<MortarData<Dim>*> mortar_data,
-                           Mesh<Dim - 1> local_mesh,
-                           std::optional<DataVector> local_data,
-                           Mesh<Dim - 1> neighbor_mesh,
-                           std::optional<DataVector> neighbor_data,
+                           Mesh<Dim - 1> mesh, std::optional<DataVector> data,
                            const std::string& expected_output) {
-  if (local_data.has_value()) {
-    mortar_data->local_mortar_data() = std::pair{local_mesh, *local_data};
+  if (data.has_value()) {
+    mortar_data->mortar_data() = std::pair{mesh, *data};
 
-    CHECK(mortar_data->local_mortar_data().has_value());
-    CHECK_FALSE(mortar_data->neighbor_mortar_data().has_value());
-  }
-
-  if (neighbor_data.has_value()) {
-    mortar_data->neighbor_mortar_data() =
-        std::pair{neighbor_mesh, *neighbor_data};
-    CHECK(mortar_data->local_mortar_data().has_value());
-    CHECK(mortar_data->neighbor_mortar_data().has_value());
+    CHECK(mortar_data->mortar_data().has_value());
   }
 
   CHECK(get_output(*mortar_data) == expected_output);
@@ -54,18 +43,12 @@ template <size_t Dim>
 void check_serialization(const gsl::not_null<MortarData<Dim>*> mortar_data) {
   const auto deserialized_mortar_data = serialize_and_deserialize(*mortar_data);
 
-  CHECK(*mortar_data->local_mortar_data() ==
-        *deserialized_mortar_data.local_mortar_data());
-  CHECK(*mortar_data->neighbor_mortar_data() ==
-        *deserialized_mortar_data.neighbor_mortar_data());
+  CHECK(*mortar_data->mortar_data() == *deserialized_mortar_data.mortar_data());
 
   CHECK(*mortar_data == deserialized_mortar_data);
   CHECK_FALSE(*mortar_data != deserialized_mortar_data);
 
-  CHECK(*mortar_data->local_mortar_data() ==
-        *deserialized_mortar_data.local_mortar_data());
-  CHECK(*mortar_data->neighbor_mortar_data() ==
-        *deserialized_mortar_data.neighbor_mortar_data());
+  CHECK(*mortar_data->mortar_data() == *deserialized_mortar_data.mortar_data());
 }
 
 template <size_t Dim>
@@ -74,7 +57,7 @@ void test_global_time_stepping_usage() {
   MAKE_GENERATOR(gen);
   constexpr size_t number_of_components = 1 + Dim;
 
-  MortarData<Dim> mortar_data{};
+  MortarData<Dim> local_mortar_data{};
 
   const Mesh<Dim - 1> mortar_mesh{4, Spectral::Basis::Legendre,
                                   Spectral::Quadrature::Gauss};
@@ -86,27 +69,34 @@ void test_global_time_stepping_usage() {
   fill_with_random_values(make_not_null(&local_data), make_not_null(&gen),
                           make_not_null(&dist));
 
+  MortarData<Dim> neighbor_mortar_data{};
+
   const Mesh<Dim - 1> neighbor_mesh{3, Spectral::Basis::Legendre,
                                     Spectral::Quadrature::Gauss};
   DataVector neighbor_data{
       mortar_mesh.number_of_grid_points() * number_of_components, 0.0};
-  fill_with_random_values(make_not_null(&local_data), make_not_null(&gen),
+  fill_with_random_values(make_not_null(&neighbor_data), make_not_null(&gen),
                           make_not_null(&dist));
 
-  std::string expected_output = MakeString{}
-                                << "LocalMortarData: (" << local_mesh << ", "
-                                << local_data << ")\n"
-                                << "NeighborMortarData: (" << neighbor_mesh
-                                << ", " << neighbor_data << ")\n";
+  std::string local_expected_output = MakeString{} << "MortarData: ("
+                                                   << local_mesh << ", "
+                                                   << local_data << ")\n";
 
-  CHECK_FALSE(mortar_data.local_mortar_data().has_value());
-  CHECK_FALSE(mortar_data.neighbor_mortar_data().has_value());
+  std::string neighbor_expected_output = MakeString{} << "MortarData: ("
+                                                      << neighbor_mesh << ", "
+                                                      << neighbor_data << ")\n";
 
-  assign_with_reference(make_not_null(&mortar_data), local_mesh,
-                        std::optional{local_data}, neighbor_mesh,
-                        std::optional{neighbor_data}, expected_output);
+  CHECK_FALSE(local_mortar_data.mortar_data().has_value());
+  CHECK_FALSE(neighbor_mortar_data.mortar_data().has_value());
 
-  check_serialization(make_not_null(&mortar_data));
+  assign_with_reference(make_not_null(&local_mortar_data), local_mesh,
+                        std::optional{local_data}, local_expected_output);
+
+  assign_with_reference(make_not_null(&neighbor_mortar_data), neighbor_mesh,
+                        std::optional{neighbor_data}, neighbor_expected_output);
+
+  check_serialization(make_not_null(&local_mortar_data));
+  check_serialization(make_not_null(&neighbor_mortar_data));
 }
 
 template <size_t Dim>
@@ -128,14 +118,11 @@ void test_local_time_stepping_usage(const bool use_gauss_points) {
   fill_with_random_values(make_not_null(&local_data), make_not_null(&gen),
                           make_not_null(&dist));
 
-  std::string expected_output = MakeString{} << "LocalMortarData: ("
-                                             << local_mesh << ", " << local_data
-                                             << ")\n"
-                                             << "NeighborMortarData: --\n";
+  std::string expected_output = MakeString{} << "MortarData: (" << local_mesh
+                                             << ", " << local_data << ")\n";
 
   assign_with_reference(make_not_null(&mortar_data), local_mesh,
-                        std::optional{local_data}, local_mesh, std::nullopt,
-                        expected_output);
+                        std::optional{local_data}, expected_output);
 
   const auto local_volume_det_inv_jacobian =
       make_with_random_values<Scalar<DataVector>>(
@@ -186,9 +173,7 @@ void test_local_time_stepping_usage(const bool use_gauss_points) {
   // insert neighbor data here
   const auto deserialized_mortar_data = serialize_and_deserialize(mortar_data);
 
-  CHECK(*mortar_data.local_mortar_data() ==
-        *deserialized_mortar_data.local_mortar_data());
-  CHECK_FALSE(deserialized_mortar_data.neighbor_mortar_data().has_value());
+  CHECK(*mortar_data.mortar_data() == *deserialized_mortar_data.mortar_data());
   check_geometric_quantities(deserialized_mortar_data);
 
   CHECK(mortar_data == deserialized_mortar_data);

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Test_MortarData.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Test_MortarData.cpp
@@ -28,12 +28,13 @@ namespace evolution::dg {
 namespace {
 template <size_t Dim>
 void assign_with_reference(const gsl::not_null<MortarData<Dim>*> mortar_data,
-                           Mesh<Dim - 1> mesh, std::optional<DataVector> data,
+                           const Mesh<Dim - 1>& face_mesh,
+                           const std::optional<DataVector>& data,
                            const std::string& expected_output) {
   if (data.has_value()) {
-    mortar_data->mortar_data() = std::pair{mesh, *data};
-
-    CHECK(mortar_data->mortar_data().has_value());
+    mortar_data->face_mesh = face_mesh;
+    mortar_data->mortar_data = *data;
+    CHECK(mortar_data->mortar_data.has_value());
   }
 
   CHECK(get_output(*mortar_data) == expected_output);
@@ -43,12 +44,12 @@ template <size_t Dim>
 void check_serialization(const gsl::not_null<MortarData<Dim>*> mortar_data) {
   const auto deserialized_mortar_data = serialize_and_deserialize(*mortar_data);
 
-  CHECK(*mortar_data->mortar_data() == *deserialized_mortar_data.mortar_data());
+  CHECK(*mortar_data->mortar_data == *deserialized_mortar_data.mortar_data);
 
   CHECK(*mortar_data == deserialized_mortar_data);
   CHECK_FALSE(*mortar_data != deserialized_mortar_data);
 
-  CHECK(*mortar_data->mortar_data() == *deserialized_mortar_data.mortar_data());
+  CHECK(*mortar_data->mortar_data == *deserialized_mortar_data.mortar_data);
 }
 
 template <size_t Dim>
@@ -78,22 +79,30 @@ void test_global_time_stepping_usage() {
   fill_with_random_values(make_not_null(&neighbor_data), make_not_null(&gen),
                           make_not_null(&dist));
 
-  std::string local_expected_output = MakeString{} << "MortarData: ("
-                                                   << local_mesh << ", "
-                                                   << local_data << ")\n";
+  std::string local_expected_output = MakeString{}
+                                      << "Mortar data: " << local_data << "\n"
+                                      << "Face normal magnitude: --\n"
+                                      << "Face det(J): --\n"
+                                      << "Face mesh: " << local_mesh << "\n"
+                                      << "Volume det(invJ): --\n";
 
-  std::string neighbor_expected_output = MakeString{} << "MortarData: ("
-                                                      << neighbor_mesh << ", "
-                                                      << neighbor_data << ")\n";
+  std::string neighbor_expected_output =
+      MakeString{} << "Mortar data: " << neighbor_data << "\n"
+                   << "Face normal magnitude: --\n"
+                   << "Face det(J): --\n"
+                   << "Face mesh: " << neighbor_mesh << "\n"
+                   << "Volume det(invJ): --\n";
 
-  CHECK_FALSE(local_mortar_data.mortar_data().has_value());
-  CHECK_FALSE(neighbor_mortar_data.mortar_data().has_value());
+  CHECK_FALSE(local_mortar_data.mortar_data.has_value());
+  CHECK_FALSE(neighbor_mortar_data.mortar_data.has_value());
 
-  assign_with_reference(make_not_null(&local_mortar_data), local_mesh,
-                        std::optional{local_data}, local_expected_output);
+  assign_with_reference(make_not_null(&local_mortar_data),
+                        local_mesh, std::optional{local_data},
+                        local_expected_output);
 
-  assign_with_reference(make_not_null(&neighbor_mortar_data), neighbor_mesh,
-                        std::optional{neighbor_data}, neighbor_expected_output);
+  assign_with_reference(make_not_null(&neighbor_mortar_data),
+                        neighbor_mesh, std::optional{neighbor_data},
+                        neighbor_expected_output);
 
   check_serialization(make_not_null(&local_mortar_data));
   check_serialization(make_not_null(&neighbor_mortar_data));
@@ -118,8 +127,12 @@ void test_local_time_stepping_usage(const bool use_gauss_points) {
   fill_with_random_values(make_not_null(&local_data), make_not_null(&gen),
                           make_not_null(&dist));
 
-  std::string expected_output = MakeString{} << "MortarData: (" << local_mesh
-                                             << ", " << local_data << ")\n";
+  std::string expected_output = MakeString{}
+                                << "Mortar data: " << local_data << "\n"
+                                << "Face normal magnitude: --\n"
+                                << "Face det(J): --\n"
+                                << "Face mesh: " << local_mesh << "\n"
+                                << "Volume det(invJ): --\n";
 
   assign_with_reference(make_not_null(&mortar_data), local_mesh,
                         std::optional{local_data}, expected_output);
@@ -137,12 +150,10 @@ void test_local_time_stepping_usage(const bool use_gauss_points) {
           make_not_null(&gen), make_not_null(&dist),
           mortar_mesh.number_of_grid_points());
 
+  mortar_data.face_normal_magnitude = local_face_normal_magnitude;
   if (use_gauss_points) {
-    mortar_data.insert_local_geometric_quantities(local_volume_det_inv_jacobian,
-                                                  local_face_det_jacobian,
-                                                  local_face_normal_magnitude);
-  } else {
-    mortar_data.insert_local_face_normal_magnitude(local_face_normal_magnitude);
+    mortar_data.volume_det_inv_jacobian = local_volume_det_inv_jacobian;
+    mortar_data.face_det_jacobian = local_face_det_jacobian;
   }
 
   const auto check_geometric_quantities = [&local_face_det_jacobian,
@@ -151,20 +162,12 @@ void test_local_time_stepping_usage(const bool use_gauss_points) {
                                            use_gauss_points](
                                               const auto& mortar_data_local) {
     if (use_gauss_points) {
-      Scalar<DataVector> retrieved_local_face_det_jacobian{};
-      Scalar<DataVector> retrieved_local_volume_det_inv_jacobian{};
-      mortar_data_local.get_local_face_det_jacobian(
-          &retrieved_local_face_det_jacobian);
-      mortar_data_local.get_local_volume_det_inv_jacobian(
-          &retrieved_local_volume_det_inv_jacobian);
-      CHECK(retrieved_local_face_det_jacobian == local_face_det_jacobian);
-      CHECK(retrieved_local_volume_det_inv_jacobian ==
+      CHECK(mortar_data_local.face_det_jacobian == local_face_det_jacobian);
+      CHECK(mortar_data_local.volume_det_inv_jacobian ==
             local_volume_det_inv_jacobian);
     }
-    Scalar<DataVector> retrieved_local_face_normal_magnitude{};
-    mortar_data_local.get_local_face_normal_magnitude(
-        &retrieved_local_face_normal_magnitude);
-    CHECK(retrieved_local_face_normal_magnitude == local_face_normal_magnitude);
+    CHECK(mortar_data_local.face_normal_magnitude ==
+          local_face_normal_magnitude);
   };
 
   check_geometric_quantities(mortar_data);
@@ -173,7 +176,7 @@ void test_local_time_stepping_usage(const bool use_gauss_points) {
   // insert neighbor data here
   const auto deserialized_mortar_data = serialize_and_deserialize(mortar_data);
 
-  CHECK(*mortar_data.mortar_data() == *deserialized_mortar_data.mortar_data());
+  CHECK(*mortar_data.mortar_data == *deserialized_mortar_data.mortar_data);
   check_geometric_quantities(deserialized_mortar_data);
 
   CHECK(mortar_data == deserialized_mortar_data);

--- a/tests/Unit/Evolution/Systems/Burgers/Subcell/Test_TimeDerivative.cpp
+++ b/tests/Unit/Evolution/Systems/Burgers/Subcell/Test_TimeDerivative.cpp
@@ -31,6 +31,7 @@
 #include "Evolution/DgSubcell/Tags/GhostDataForReconstruction.hpp"
 #include "Evolution/DgSubcell/Tags/Jacobians.hpp"
 #include "Evolution/DgSubcell/Tags/Mesh.hpp"
+#include "Evolution/DiscontinuousGalerkin/MortarDataHolder.hpp"
 #include "Evolution/DiscontinuousGalerkin/NormalVectorTags.hpp"
 #include "Evolution/Systems/Burgers/BoundaryConditions/BoundaryCondition.hpp"
 #include "Evolution/Systems/Burgers/BoundaryConditions/Factory.hpp"

--- a/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/Test_TimeDerivative.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/Test_TimeDerivative.cpp
@@ -584,10 +584,10 @@ double test(const size_t num_dg_pts, std::optional<double> expansion_velocity,
     auto& the_mortar_data = mortar_data[DirectionalId<3>{
         direction, *element.neighbors().at(direction).begin()}];
     if (local_data) {
-      the_mortar_data.local().local_mortar_data() =
+      the_mortar_data.local().mortar_data() =
           std::pair{interface_mesh, std::move(interface_data)};
     } else {
-      the_mortar_data.neighbor().neighbor_mortar_data() =
+      the_mortar_data.neighbor().mortar_data() =
           std::pair{interface_mesh, std::move(interface_data)};
     }
   };

--- a/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/Test_TimeDerivative.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/Test_TimeDerivative.cpp
@@ -584,10 +584,10 @@ double test(const size_t num_dg_pts, std::optional<double> expansion_velocity,
     auto& the_mortar_data = mortar_data[DirectionalId<3>{
         direction, *element.neighbors().at(direction).begin()}];
     if (local_data) {
-      the_mortar_data.local_mortar_data() =
+      the_mortar_data.local().local_mortar_data() =
           std::pair{interface_mesh, std::move(interface_data)};
     } else {
-      the_mortar_data.neighbor_mortar_data() =
+      the_mortar_data.neighbor().neighbor_mortar_data() =
           std::pair{interface_mesh, std::move(interface_data)};
     }
   };

--- a/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/Test_TimeDerivative.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/Test_TimeDerivative.cpp
@@ -584,11 +584,11 @@ double test(const size_t num_dg_pts, std::optional<double> expansion_velocity,
     auto& the_mortar_data = mortar_data[DirectionalId<3>{
         direction, *element.neighbors().at(direction).begin()}];
     if (local_data) {
-      the_mortar_data.local().mortar_data() =
-          std::pair{interface_mesh, std::move(interface_data)};
+      the_mortar_data.local().face_mesh = interface_mesh;
+      the_mortar_data.local().mortar_data = std::move(interface_data);
     } else {
-      the_mortar_data.neighbor().mortar_data() =
-          std::pair{interface_mesh, std::move(interface_data)};
+      the_mortar_data.neighbor().face_mesh = interface_mesh;
+      the_mortar_data.neighbor().mortar_data = std::move(interface_data);
     }
   };
   insert_dg_data(Direction<3>::lower_zeta(), true);

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_NeighborPackagedData.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_NeighborPackagedData.cpp
@@ -38,6 +38,7 @@
 #include "Evolution/DgSubcell/Tags/SubcellOptions.hpp"
 #include "Evolution/DiscontinuousGalerkin/Actions/NormalCovectorAndMagnitude.hpp"
 #include "Evolution/DiscontinuousGalerkin/MortarData.hpp"
+#include "Evolution/DiscontinuousGalerkin/MortarDataHolder.hpp"
 #include "Evolution/DiscontinuousGalerkin/MortarTags.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryCorrections/BoundaryCorrection.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryCorrections/Factory.hpp"

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_NeighborPackagedData.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_NeighborPackagedData.cpp
@@ -37,6 +37,7 @@
 #include "Evolution/DgSubcell/Tags/OnSubcellFaces.hpp"
 #include "Evolution/DgSubcell/Tags/SubcellOptions.hpp"
 #include "Evolution/DiscontinuousGalerkin/Actions/NormalCovectorAndMagnitude.hpp"
+#include "Evolution/DiscontinuousGalerkin/MortarData.hpp"
 #include "Evolution/DiscontinuousGalerkin/MortarTags.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryCorrections/BoundaryCorrection.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryCorrections/Factory.hpp"

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/Subcell/Test_NeighborPackagedData.cpp
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/Subcell/Test_NeighborPackagedData.cpp
@@ -43,6 +43,7 @@
 #include "Evolution/DgSubcell/Tags/Mesh.hpp"
 #include "Evolution/DgSubcell/Tags/SubcellOptions.hpp"
 #include "Evolution/DiscontinuousGalerkin/Actions/NormalCovectorAndMagnitude.hpp"
+#include "Evolution/DiscontinuousGalerkin/MortarData.hpp"
 #include "Evolution/DiscontinuousGalerkin/MortarTags.hpp"
 #include "Evolution/Systems/NewtonianEuler/BoundaryCorrections/BoundaryCorrection.hpp"
 #include "Evolution/Systems/NewtonianEuler/BoundaryCorrections/Factory.hpp"

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/Subcell/Test_NeighborPackagedData.cpp
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/Subcell/Test_NeighborPackagedData.cpp
@@ -44,6 +44,7 @@
 #include "Evolution/DgSubcell/Tags/SubcellOptions.hpp"
 #include "Evolution/DiscontinuousGalerkin/Actions/NormalCovectorAndMagnitude.hpp"
 #include "Evolution/DiscontinuousGalerkin/MortarData.hpp"
+#include "Evolution/DiscontinuousGalerkin/MortarDataHolder.hpp"
 #include "Evolution/DiscontinuousGalerkin/MortarTags.hpp"
 #include "Evolution/Systems/NewtonianEuler/BoundaryCorrections/BoundaryCorrection.hpp"
 #include "Evolution/Systems/NewtonianEuler/BoundaryCorrections/Factory.hpp"

--- a/tests/Unit/Evolution/Systems/ScalarAdvection/Subcell/Test_TimeDerivative.cpp
+++ b/tests/Unit/Evolution/Systems/ScalarAdvection/Subcell/Test_TimeDerivative.cpp
@@ -28,6 +28,7 @@
 #include "Evolution/DgSubcell/Tags/Inactive.hpp"
 #include "Evolution/DgSubcell/Tags/Mesh.hpp"
 #include "Evolution/DgSubcell/Tags/OnSubcellFaces.hpp"
+#include "Evolution/DiscontinuousGalerkin/MortarDataHolder.hpp"
 #include "Evolution/Initialization/Tags.hpp"
 #include "Evolution/Systems/ScalarAdvection/BoundaryCorrections/BoundaryCorrection.hpp"
 #include "Evolution/Systems/ScalarAdvection/BoundaryCorrections/Factory.hpp"

--- a/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivativeImpl.tpp
+++ b/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivativeImpl.tpp
@@ -1800,7 +1800,7 @@ void test_impl(const Spectral::Quadrature quadrature,
                                   &det_inv_jacobian, &get_tag, &mesh,
                                   &quadrature](const auto& mortar_data,
                                                const auto& mortar_id) {
-    CHECK_ITERABLE_APPROX(mortar_data.local_mortar_data()->second,
+    CHECK_ITERABLE_APPROX(mortar_data.mortar_data()->second,
                           compute_expected_mortar_data(mortar_id.direction(),
                                                        mortar_id.id(), true));
 
@@ -1861,7 +1861,7 @@ void test_impl(const Spectral::Quadrature quadrature,
         get_tag(::evolution::dg::Tags::MortarData<Dim>{})
             .at(mortar_id_east)
             .local()
-            .local_mortar_data()
+            .mortar_data()
             ->second,
         compute_expected_mortar_data(mortar_id_east.direction(),
                                      mortar_id_east.id(), true));
@@ -1928,7 +1928,7 @@ void test_impl(const Spectral::Quadrature quadrature,
       CHECK_ITERABLE_APPROX(get_tag(::evolution::dg::Tags::MortarData<Dim>{})
                                 .at(mortar_id_south)
                                 .local()
-                                .local_mortar_data()
+                                .mortar_data()
                                 ->second,
                             compute_expected_mortar_data(
                                 Direction<Dim>::lower_eta(), south_id, true));
@@ -1953,9 +1953,8 @@ void test_impl(const Spectral::Quadrature quadrature,
          get_tag(::evolution::dg::Tags::MortarData<Dim>{})) {
       // When doing local time stepping the MortarData should've been moved into
       // the MortarDataHistory.
-      CHECK_FALSE(mortar_data.second.local().local_mortar_data().has_value());
-      CHECK_FALSE(
-          mortar_data.second.neighbor().neighbor_mortar_data().has_value());
+      CHECK_FALSE(mortar_data.second.local().mortar_data().has_value());
+      CHECK_FALSE(mortar_data.second.neighbor().mortar_data().has_value());
     }
   }
 }

--- a/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivativeImpl.tpp
+++ b/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivativeImpl.tpp
@@ -1800,25 +1800,24 @@ void test_impl(const Spectral::Quadrature quadrature,
                                   &det_inv_jacobian, &get_tag, &mesh,
                                   &quadrature](const auto& mortar_data,
                                                const auto& mortar_id) {
-    CHECK_ITERABLE_APPROX(mortar_data.mortar_data()->second,
+    CHECK_ITERABLE_APPROX(mortar_data.mortar_data.value(),
                           compute_expected_mortar_data(mortar_id.direction(),
                                                        mortar_id.id(), true));
 
     // Check face normal and/or Jacobians
     const bool using_gauss_points = quadrature == Spectral::Quadrature::Gauss;
-
-    Scalar<DataVector> local_face_normal_magnitude{};
-    mortar_data.get_local_face_normal_magnitude(
-        make_not_null(&local_face_normal_magnitude));
+    REQUIRE(mortar_data.face_normal_magnitude.has_value());
+    const Scalar<DataVector>& local_face_normal_magnitude =
+        mortar_data.face_normal_magnitude.value();
     CHECK(local_face_normal_magnitude ==
           get<::evolution::dg::Tags::MagnitudeOfNormal>(
               *get_tag(::evolution::dg::Tags::NormalCovectorAndMagnitude<Dim>{})
                    .at(mortar_id.direction())));
 
     if (using_gauss_points) {
-      Scalar<DataVector> local_volume_det_inv_jacobian{};
-      mortar_data.get_local_volume_det_inv_jacobian(
-          make_not_null(&local_volume_det_inv_jacobian));
+      REQUIRE(mortar_data.volume_det_inv_jacobian.has_value());
+      const Scalar<DataVector>& local_volume_det_inv_jacobian =
+          mortar_data.volume_det_inv_jacobian.value();
       CHECK(local_volume_det_inv_jacobian == det_inv_jacobian);
 
       // We use IrregularGridInterpolant to avoid reusing/copying the
@@ -1836,9 +1835,9 @@ void test_impl(const Spectral::Quadrature quadrature,
           get<::Tags::TempScalar<0>>(
               interpolator.interpolate(volume_det_jacobian));
 
-      Scalar<DataVector> local_face_det_jacobian{};
-      mortar_data.get_local_face_det_jacobian(
-          make_not_null(&local_face_det_jacobian));
+      REQUIRE(mortar_data.face_det_jacobian.has_value());
+      const Scalar<DataVector>& local_face_det_jacobian =
+          mortar_data.face_det_jacobian.value();
       CHECK_ITERABLE_APPROX(local_face_det_jacobian,
                             expected_local_face_det_jacobian);
     }
@@ -1861,8 +1860,7 @@ void test_impl(const Spectral::Quadrature quadrature,
         get_tag(::evolution::dg::Tags::MortarData<Dim>{})
             .at(mortar_id_east)
             .local()
-            .mortar_data()
-            ->second,
+            .mortar_data.value(),
         compute_expected_mortar_data(mortar_id_east.direction(),
                                      mortar_id_east.id(), true));
   }
@@ -1928,8 +1926,7 @@ void test_impl(const Spectral::Quadrature quadrature,
       CHECK_ITERABLE_APPROX(get_tag(::evolution::dg::Tags::MortarData<Dim>{})
                                 .at(mortar_id_south)
                                 .local()
-                                .mortar_data()
-                                ->second,
+                                .mortar_data.value(),
                             compute_expected_mortar_data(
                                 Direction<Dim>::lower_eta(), south_id, true));
     }
@@ -1953,8 +1950,8 @@ void test_impl(const Spectral::Quadrature quadrature,
          get_tag(::evolution::dg::Tags::MortarData<Dim>{})) {
       // When doing local time stepping the MortarData should've been moved into
       // the MortarDataHistory.
-      CHECK_FALSE(mortar_data.second.local().mortar_data().has_value());
-      CHECK_FALSE(mortar_data.second.neighbor().mortar_data().has_value());
+      CHECK_FALSE(mortar_data.second.local().mortar_data.has_value());
+      CHECK_FALSE(mortar_data.second.neighbor().mortar_data.has_value());
     }
   }
 }

--- a/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivativeImpl.tpp
+++ b/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivativeImpl.tpp
@@ -43,6 +43,7 @@
 #include "Evolution/DiscontinuousGalerkin/Initialization/Mortars.hpp"
 #include "Evolution/DiscontinuousGalerkin/Initialization/QuadratureTag.hpp"
 #include "Evolution/DiscontinuousGalerkin/MortarData.hpp"
+#include "Evolution/DiscontinuousGalerkin/MortarDataHolder.hpp"
 #include "Evolution/DiscontinuousGalerkin/MortarTags.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/ProjectToBoundary.hpp"
 #include "Evolution/PassVariables.hpp"
@@ -1859,6 +1860,7 @@ void test_impl(const Spectral::Quadrature quadrature,
     CHECK_ITERABLE_APPROX(
         get_tag(::evolution::dg::Tags::MortarData<Dim>{})
             .at(mortar_id_east)
+            .local()
             .local_mortar_data()
             ->second,
         compute_expected_mortar_data(mortar_id_east.direction(),
@@ -1925,6 +1927,7 @@ void test_impl(const Spectral::Quadrature quadrature,
     } else {
       CHECK_ITERABLE_APPROX(get_tag(::evolution::dg::Tags::MortarData<Dim>{})
                                 .at(mortar_id_south)
+                                .local()
                                 .local_mortar_data()
                                 ->second,
                             compute_expected_mortar_data(
@@ -1950,8 +1953,9 @@ void test_impl(const Spectral::Quadrature quadrature,
          get_tag(::evolution::dg::Tags::MortarData<Dim>{})) {
       // When doing local time stepping the MortarData should've been moved into
       // the MortarDataHistory.
-      CHECK_FALSE(mortar_data.second.local_mortar_data().has_value());
-      CHECK_FALSE(mortar_data.second.neighbor_mortar_data().has_value());
+      CHECK_FALSE(mortar_data.second.local().local_mortar_data().has_value());
+      CHECK_FALSE(
+          mortar_data.second.neighbor().neighbor_mortar_data().has_value());
     }
   }
 }

--- a/tests/Unit/Time/Actions/Test_CleanHistory.cpp
+++ b/tests/Unit/Time/Actions/Test_CleanHistory.cpp
@@ -15,6 +15,7 @@
 #include "DataStructures/VariablesTag.hpp"
 #include "Domain/Structure/Direction.hpp"
 #include "Domain/Structure/DirectionalId.hpp"
+#include "Domain/Structure/DirectionalIdMap.hpp"
 #include "Domain/Structure/ElementId.hpp"
 #include "Domain/Structure/Side.hpp"
 #include "Evolution/DiscontinuousGalerkin/MortarData.hpp"


### PR DESCRIPTION
## Proposed changes

- Introduce class MortarDataHolder that holds two MortarData to make GTS and LTS code more similar. (For LTS BoundaryHistory already holds MortarData on each side of the mortar.)
- Change MortarData to hold data on only one side of the mortar.  
- Turn MortarData into a simple struct in order to make it easier to use with AMR

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
