### PR TITLE
Observe ADM linear momentum in SolveXcts executable.

### DIFF
--- a/src/Elliptic/Executables/Xcts/CMakeLists.txt
+++ b/src/Elliptic/Executables/Xcts/CMakeLists.txt
@@ -45,5 +45,6 @@ target_link_libraries(
   Xcts
   XctsAnalyticData
   XctsBoundaryConditions
+  XctsEvents
   XctsSolutions
   )

--- a/src/Elliptic/Executables/Xcts/SolveXcts.hpp
+++ b/src/Elliptic/Executables/Xcts/SolveXcts.hpp
@@ -15,6 +15,7 @@
 #include "Elliptic/DiscontinuousGalerkin/DgElementArray.hpp"
 #include "Elliptic/Executables/Solver.hpp"
 #include "Elliptic/Systems/Xcts/BoundaryConditions/Factory.hpp"
+#include "Elliptic/Systems/Xcts/Events/ObserveAdmIntegrals.hpp"
 #include "Elliptic/Systems/Xcts/FirstOrderSystem.hpp"
 #include "Elliptic/Systems/Xcts/HydroQuantities.hpp"
 #include "Elliptic/Triggers/Factory.hpp"
@@ -131,7 +132,7 @@ struct Metavariables {
                        volume_dim, typename system::primal_fields>>,
         tmpl::pair<Event,
                    tmpl::flatten<tmpl::list<
-                       Events::Completion,
+                       Events::Completion, Events::ObserveAdmIntegrals,
                        dg::Events::field_observations<
                            volume_dim, observe_fields, observer_compute_tags,
                            LinearSolver::multigrid::Tags::IsFinestGrid>>>>,

--- a/src/Elliptic/Systems/Xcts/Events/CMakeLists.txt
+++ b/src/Elliptic/Systems/Xcts/Events/CMakeLists.txt
@@ -1,45 +1,32 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-set(LIBRARY Xcts)
+set(LIBRARY XctsEvents)
 
 add_spectre_library(${LIBRARY})
 
 spectre_target_sources(
   ${LIBRARY}
   PRIVATE
-  Equations.cpp
-  FluxesAndSources.cpp
+  ObserveAdmIntegrals.cpp
   )
 
 spectre_target_headers(
   ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
-  Equations.hpp
-  FirstOrderSystem.hpp
-  FluxesAndSources.hpp
-  Geometry.hpp
-  HydroQuantities.hpp
-  Tags.hpp
-  Xcts.hpp
+  ObserveAdmIntegrals.hpp
   )
 
 target_link_libraries(
   ${LIBRARY}
   PUBLIC
   DataStructures
-  GeneralRelativity
-  Hydro
-  Utilities
-  PRIVATE
-  Elasticity
-  ErrorHandling
-  LinearOperators
-  Poisson
+  Domain
+  Elliptic
+  Xcts
+  Options
+  Serialization
   Utilities
   XctsPointwiseFunctions
   )
-
-add_subdirectory(BoundaryConditions)
-add_subdirectory(Events)

--- a/src/Elliptic/Systems/Xcts/Events/ObserveAdmIntegrals.cpp
+++ b/src/Elliptic/Systems/Xcts/Events/ObserveAdmIntegrals.cpp
@@ -1,0 +1,110 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Elliptic/Systems/Xcts/Events/ObserveAdmIntegrals.hpp"
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/AreaElement.hpp"
+#include "Domain/Tags.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/ProjectToBoundary.hpp"
+#include "NumericalAlgorithms/LinearOperators/DefiniteIntegral.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "PointwiseFunctions/Xcts/AdmLinearMomentum.hpp"
+
+namespace Events {
+
+void local_adm_integrals(
+    gsl::not_null<tnsr::I<double, 3>*> result,
+    const Scalar<DataVector>& conformal_factor,
+    const tnsr::ii<DataVector, 3>& spatial_metric,
+    const tnsr::II<DataVector, 3>& inv_spatial_metric,
+    const tnsr::ii<DataVector, 3>& extrinsic_curvature,
+    const Scalar<DataVector>& trace_extrinsic_curvature,
+    const InverseJacobian<DataVector, 3, Frame::ElementLogical,
+                          Frame::Inertial>& inv_jacobian,
+    const Mesh<3>& mesh, const Element<3>& element,
+    const DirectionMap<3, tnsr::i<DataVector, 3>>& conformal_face_normals) {
+  // Initialize integral to 0
+  for (int I = 0; I < 3; I++) {
+    result->get(I) = 0;
+  }
+
+  // Skip elements not at the outer boundary
+  const size_t radial_dimension = 2;
+  const auto radial_segment_id = element.id().segment_id(radial_dimension);
+  if (radial_segment_id.index() !=
+      two_to_the(radial_segment_id.refinement_level()) - 1) {
+    return;
+  }
+
+  // Loop over external boundaries
+  for (const auto boundary_direction : element.external_boundaries()) {
+    // Skip interfaces not at the outer boundary
+    if (boundary_direction != Direction<3>::upper_zeta()) {
+      continue;
+    }
+
+    // Project fields to the boundary
+    const auto face_conformal_factor = dg::project_tensor_to_boundary(
+        conformal_factor, mesh, boundary_direction);
+    const auto face_spatial_metric = dg::project_tensor_to_boundary(
+        spatial_metric, mesh, boundary_direction);
+    const auto face_inv_spatial_metric = dg::project_tensor_to_boundary(
+        inv_spatial_metric, mesh, boundary_direction);
+    const auto face_extrinsic_curvature = dg::project_tensor_to_boundary(
+        extrinsic_curvature, mesh, boundary_direction);
+    const auto face_trace_extrinsic_curvature = dg::project_tensor_to_boundary(
+        trace_extrinsic_curvature, mesh, boundary_direction);
+    // This projection could be avoided by using
+    // domain::Tags::DetSurfaceJacobian from the DataBox, which is computed
+    // directly on the face (not projected). That would be better on Gauss
+    // meshes that have no grid point at the boundary. The DetSurfaceJacobian
+    // could then be multiplied by the (conformal) metric determinant to form
+    // the area element. Note that the DetSurfaceJacobian is computed using the
+    // conformal metric.
+    const auto face_inv_jacobian =
+        dg::project_tensor_to_boundary(inv_jacobian, mesh, boundary_direction);
+
+    // Compute the inverse extrinsic curvature
+    tnsr::II<DataVector, 3> face_inv_extrinsic_curvature;
+    tenex::evaluate<ti::I, ti::J>(make_not_null(&face_inv_extrinsic_curvature),
+                                  face_inv_spatial_metric(ti::I, ti::K) *
+                                      face_inv_spatial_metric(ti::J, ti::L) *
+                                      face_extrinsic_curvature(ti::k, ti::l));
+
+    // Compute curved area element
+    const auto face_sqrt_det_spatial_metric =
+        Scalar<DataVector>(sqrt(get(determinant(face_spatial_metric))));
+    const auto curved_area_element =
+        area_element(face_inv_jacobian, boundary_direction,
+                     face_inv_spatial_metric, face_sqrt_det_spatial_metric);
+
+    // Get face mesh and face normal from data box
+    const auto& face_mesh = mesh.slice_away(boundary_direction.dimension());
+    // Note that this face normal is related to the conformal metric. To get
+    // the non-conformal face normal, we multiply by the square of the
+    // conformal factor in the computation of 'contracted_integrand'.
+    const auto& face_normal_conformal =
+        conformal_face_normals.at(boundary_direction);
+
+    // Compute surface integrand
+    const auto surface_integrand = Xcts::adm_linear_momentum_surface_integrand(
+        face_conformal_factor, face_inv_spatial_metric,
+        face_inv_extrinsic_curvature, face_trace_extrinsic_curvature);
+    const auto contracted_integrand = tenex::evaluate<ti::I>(
+        surface_integrand(ti::I, ti::J) * square(face_conformal_factor()) *
+        face_normal_conformal(ti::j));
+
+    // Take integral
+    for (int I = 0; I < 3; I++) {
+      result->get(I) += definite_integral(
+          contracted_integrand.get(I) * get(curved_area_element), face_mesh);
+    }
+  }
+}
+
+PUP::able::PUP_ID ObserveAdmIntegrals::my_PUP_ID = 0;  // NOLINT
+
+}  // namespace Events

--- a/src/Elliptic/Systems/Xcts/Events/ObserveAdmIntegrals.hpp
+++ b/src/Elliptic/Systems/Xcts/Events/ObserveAdmIntegrals.hpp
@@ -1,0 +1,197 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <optional>
+#include <pup.h>
+#include <string>
+#include <vector>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Domain/Tags.hpp"
+#include "Domain/Tags/FaceNormal.hpp"
+#include "Domain/Tags/Faces.hpp"
+#include "Elliptic/Systems/Xcts/Tags.hpp"
+#include "IO/Observer/GetSectionObservationKey.hpp"
+#include "IO/Observer/ObservationId.hpp"
+#include "IO/Observer/ObserverComponent.hpp"
+#include "IO/Observer/ReductionActions.hpp"
+#include "IO/Observer/TypeOfObservation.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "Options/String.hpp"
+#include "Parallel/ArrayIndex.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "Parallel/Reduction.hpp"
+#include "Parallel/TypeTraits.hpp"
+#include "ParallelAlgorithms/Events/Tags.hpp"
+#include "ParallelAlgorithms/EventsAndTriggers/Event.hpp"
+#include "Utilities/Serialization/CharmPupable.hpp"
+
+namespace Events {
+
+/// @{
+/*!
+ * \brief Computes the ADM integrals locally (within one element).
+ *
+ * To get the total ADM integrals, the results need to be summed over in a
+ * reduction.
+ *
+ * See `Xcts::adm_linear_momentum_surface_integrand` for details on the formula
+ * for each integrand.
+ */
+void local_adm_integrals(
+    gsl::not_null<tnsr::I<double, 3>*> result,
+    const Scalar<DataVector>& conformal_factor,
+    const tnsr::ii<DataVector, 3>& spatial_metric,
+    const tnsr::II<DataVector, 3>& inv_spatial_metric,
+    const tnsr::ii<DataVector, 3>& extrinsic_curvature,
+    const Scalar<DataVector>& trace_extrinsic_curvature,
+    const InverseJacobian<DataVector, 3, Frame::ElementLogical,
+                          Frame::Inertial>& inv_jacobian,
+    const Mesh<3>& mesh, const Element<3>& element,
+    const DirectionMap<3, tnsr::i<DataVector, 3>>& conformal_face_normals);
+/// @}
+
+/// @{
+/*!
+ * \brief Observe ADM integrals after the XCTS solve.
+ *
+ * The surface integrals are taken over the outer boundary, which is defined as
+ * the domain boundary in the upper logical zeta direction.
+ *
+ * Writes reduction quantities:
+ * - `Linear momentum`
+ */
+class ObserveAdmIntegrals : public Event {
+ private:
+  using ReductionData = Parallel::ReductionData<
+      // ADM Linear Momentum (x-component)
+      Parallel::ReductionDatum<double, funcl::Plus<>>,
+      // ADM Linear Momentum (y-component)
+      Parallel::ReductionDatum<double, funcl::Plus<>>,
+      // ADM Linear Momentum (z-component)
+      Parallel::ReductionDatum<double, funcl::Plus<>>>;
+
+ public:
+  /// \cond
+  explicit ObserveAdmIntegrals(CkMigrateMessage* msg) : Event(msg) {}
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(ObserveAdmIntegrals);  // NOLINT
+  /// \endcond
+
+  using options = tmpl::list<>;
+  static constexpr Options::String help =
+      "Observe ADM integrals after the XCTS solve.\n"
+      "\n"
+      "Writes reduction quantities:\n"
+      "- Linear momentum";
+
+  ObserveAdmIntegrals() = default;
+
+  using observed_reduction_data_tags =
+      observers::make_reduction_data_tags<tmpl::list<ReductionData>>;
+
+  using compute_tags_for_observation_box = tmpl::list<>;
+
+  using return_tags = tmpl::list<>;
+
+  using argument_tags = tmpl::list<
+      Xcts::Tags::ConformalFactor<DataVector>,
+      gr::Tags::SpatialMetric<DataVector, 3, Frame::Inertial>,
+      gr::Tags::InverseSpatialMetric<DataVector, 3, Frame::Inertial>,
+      gr::Tags::ExtrinsicCurvature<DataVector, 3, Frame::Inertial>,
+      gr::Tags::TraceExtrinsicCurvature<DataVector>,
+      domain::Tags::InverseJacobian<3, Frame::ElementLogical, Frame::Inertial>,
+      domain::Tags::Mesh<3>, domain::Tags::Element<3>,
+      domain::Tags::Faces<3, domain::Tags::FaceNormal<3>>>;
+
+  template <typename Metavariables, typename ArrayIndex,
+            typename ParallelComponent>
+  void operator()(
+      const Scalar<DataVector>& conformal_factor,
+      const tnsr::ii<DataVector, 3>& spatial_metric,
+      const tnsr::II<DataVector, 3>& inv_spatial_metric,
+      const tnsr::ii<DataVector, 3>& extrinsic_curvature,
+      const Scalar<DataVector>& trace_extrinsic_curvature,
+      const InverseJacobian<DataVector, 3, Frame::ElementLogical,
+                            Frame::Inertial>& inv_jacobian,
+      const Mesh<3>& mesh, const Element<3>& element,
+      const DirectionMap<3, tnsr::i<DataVector, 3>>& conformal_face_normals,
+      Parallel::GlobalCache<Metavariables>& cache,
+      const ArrayIndex& array_index, const ParallelComponent* const /*meta*/,
+      const ObservationValue& observation_value) const {
+    tnsr::I<double, 3> linear_momentum;
+    local_adm_integrals(make_not_null(&linear_momentum), conformal_factor,
+                        spatial_metric, inv_spatial_metric, extrinsic_curvature,
+                        trace_extrinsic_curvature, inv_jacobian, mesh, element,
+                        conformal_face_normals);
+
+    // Save components of linear momentum as reduction data
+    ReductionData reduction_data{get<0>(linear_momentum),
+                                 get<1>(linear_momentum),
+                                 get<2>(linear_momentum)};
+    std::vector<std::string> legend{
+        "AdmLinearMomentum_x", "AdmLinearMomentum_y", "AdmLinearMomentum_z"};
+
+    // Get information required for reduction
+    auto& local_observer = *Parallel::local_branch(
+        Parallel::get_parallel_component<
+            tmpl::conditional_t<Parallel::is_nodegroup_v<ParallelComponent>,
+                                observers::ObserverWriter<Metavariables>,
+                                observers::Observer<Metavariables>>>(cache));
+    observers::ObservationId observation_id{observation_value.value,
+                                            subfile_path_ + ".dat"};
+    Parallel::ArrayComponentId array_component_id{
+        std::add_pointer_t<ParallelComponent>{nullptr},
+        Parallel::ArrayIndex<ElementId<3>>(array_index)};
+
+    // Send reduction action
+    if constexpr (Parallel::is_nodegroup_v<ParallelComponent>) {
+      Parallel::threaded_action<
+          observers::ThreadedActions::CollectReductionDataOnNode>(
+          local_observer, std::move(observation_id),
+          std::move(array_component_id), subfile_path_, std::move(legend),
+          std::move(reduction_data));
+    } else {
+      Parallel::simple_action<observers::Actions::ContributeReductionData>(
+          local_observer, std::move(observation_id),
+          std::move(array_component_id), subfile_path_, std::move(legend),
+          std::move(reduction_data));
+    }
+  }
+
+  using observation_registration_tags = tmpl::list<>;
+
+  std::optional<
+      std::pair<observers::TypeOfObservation, observers::ObservationKey>>
+  get_observation_type_and_key_for_registration() const {
+    return {{observers::TypeOfObservation::Reduction,
+             observers::ObservationKey(subfile_path_ + ".dat")}};
+  }
+
+  using is_ready_argument_tags = tmpl::list<>;
+
+  template <typename Metavariables, typename ArrayIndex, typename Component>
+  bool is_ready(Parallel::GlobalCache<Metavariables>& /*cache*/,
+                const ArrayIndex& /*array_index*/,
+                const Component* const /*meta*/) const {
+    return true;
+  }
+
+  bool needs_evolved_variables() const override { return false; }
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& p) override {
+    Event::pup(p);
+    p | subfile_path_;
+  }
+
+ private:
+  std::string subfile_path_ = "/AdmIntegrals";
+};
+/// @}
+
+}  // namespace Events

--- a/support/Pipelines/Bbh/InitialData.yaml
+++ b/support/Pipelines/Bbh/InitialData.yaml
@@ -228,6 +228,7 @@ EventsAndTriggers:
           InterpolateToMesh: None
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double]
+      - ObserveAdmIntegrals
 
 RandomizeInitialGuess: None
 

--- a/tests/Unit/Elliptic/Systems/Xcts/CMakeLists.txt
+++ b/tests/Unit/Elliptic/Systems/Xcts/CMakeLists.txt
@@ -29,3 +29,4 @@ target_link_libraries(
   )
 
 add_subdirectory(BoundaryConditions)
+add_subdirectory(Events)

--- a/tests/Unit/Elliptic/Systems/Xcts/Events/CMakeLists.txt
+++ b/tests/Unit/Elliptic/Systems/Xcts/Events/CMakeLists.txt
@@ -1,0 +1,24 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBRARY "Test_XctsEvents")
+
+set(LIBRARY_SOURCES
+  Test_ObserveAdmIntegrals.cpp
+  )
+
+add_test_library(${LIBRARY} "${LIBRARY_SOURCES}")
+
+target_link_libraries(
+  ${LIBRARY}
+  PRIVATE
+  CoordinateMaps
+  DataStructures
+  Domain
+  DomainStructure
+  Elliptic
+  GeneralRelativitySolutions
+  LinearOperators
+  XctsEvents
+  XctsSolutions
+  )

--- a/tests/Unit/Elliptic/Systems/Xcts/Events/Test_ObserveAdmIntegrals.cpp
+++ b/tests/Unit/Elliptic/Systems/Xcts/Events/Test_ObserveAdmIntegrals.cpp
@@ -1,0 +1,163 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/Determinant.hpp"
+#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
+#include "DataStructures/Tensor/Slice.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/AreaElement.hpp"
+#include "Domain/CoordinateMaps/Composition.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
+#include "Domain/CoordinateMaps/Wedge.hpp"
+#include "Domain/CreateInitialElement.hpp"
+#include "Domain/Creators/Sphere.hpp"
+#include "Domain/ElementMap.hpp"
+#include "Domain/ElementToBlockLogicalMap.hpp"
+#include "Domain/FaceNormal.hpp"
+#include "Domain/InterfaceLogicalCoordinates.hpp"
+#include "Domain/Structure/IndexToSliceAt.hpp"
+#include "Domain/Structure/InitialElementIds.hpp"
+#include "Elliptic/Systems/Xcts/Events/ObserveAdmIntegrals.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/ProjectToBoundary.hpp"
+#include "NumericalAlgorithms/LinearOperators/DefiniteIntegral.hpp"
+#include "NumericalAlgorithms/Spectral/LogicalCoordinates.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrHorizon.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/Xcts/WrappedGr.hpp"
+
+namespace {
+
+using KerrSchild = Xcts::Solutions::WrappedGr<gr::Solutions::KerrSchild>;
+
+void test_local_adm_integrals(const double distance,
+                                  const size_t refinement_level,
+                                  const size_t polynomial_order) {
+  // Define black hole parameters
+  const double mass = 1;
+  const double boost_speed = 0.5;
+  const double lorentz_factor = 1. / sqrt(1. - square(boost_speed));
+
+  // Get Kerr-Schild solution
+  const std::array<double, 3> dimensionless_spin{{0., 0., 0.}};
+  const std::array<double, 3> center{{0., 0., 0.}};
+  const std::array<double, 3> boost_velocity{{0., 0., boost_speed}};
+  const KerrSchild solution{mass, dimensionless_spin, center, boost_velocity};
+
+  // Set up domain
+  const double horizon_kerrschild_radius =
+      mass * (1. + sqrt(1. - dot(dimensionless_spin, dimensionless_spin)));
+  domain::creators::Sphere shell{
+      /* inner_radius */ horizon_kerrschild_radius,
+      /* outer_radius */ distance,
+      /* interior */ domain::creators::Sphere::Excision{},
+      refinement_level,
+      polynomial_order + 1,
+      true,
+      {},
+      {},
+      domain::CoordinateMaps::Distribution::Logarithmic};
+  const auto shell_domain = shell.create_domain();
+  const auto& blocks = shell_domain.blocks();
+  const auto& initial_ref_levels = shell.initial_refinement_levels();
+  const auto element_ids = initial_element_ids(initial_ref_levels);
+  const Mesh<3> mesh{polynomial_order + 1, Spectral::Basis::Legendre,
+                     Spectral::Quadrature::GaussLobatto};
+  const Mesh<2> face_mesh{polynomial_order + 1, Spectral::Basis::Legendre,
+                          Spectral::Quadrature::GaussLobatto};
+
+  // Initialize "reduced" integral
+  tnsr::I<double, 3> reduced_integral;
+  for (int I = 0; I < 3; I++) {
+    reduced_integral.get(I) = 0.;
+  }
+
+  // Compute integral by summing over each element
+  for (const auto& element_id : element_ids) {
+    // Get element information
+    const auto& current_block = blocks.at(element_id.block_id());
+    const auto current_element = domain::Initialization::create_initial_element(
+        element_id, current_block, initial_ref_levels);
+    const ElementMap<3, Frame::Inertial> logical_to_inertial_map(
+        element_id, current_block.stationary_map().get_clone());
+
+    // Get coordinates
+    const auto logical_coords = logical_coordinates(mesh);
+    const auto inertial_coords = logical_to_inertial_map(logical_coords);
+    const auto inv_jacobian =
+        logical_to_inertial_map.inv_jacobian(logical_coords);
+
+    // Get required fields
+    const auto background_fields = solution.variables(
+        inertial_coords,
+        tmpl::list<
+            Xcts::Tags::ConformalFactor<DataVector>,
+            gr::Tags::SpatialMetric<DataVector, 3, Frame::Inertial>,
+            gr::Tags::InverseSpatialMetric<DataVector, 3, Frame::Inertial>,
+            Xcts::Tags::InverseConformalMetric<DataVector, 3, Frame::Inertial>,
+            gr::Tags::ExtrinsicCurvature<DataVector, 3, Frame::Inertial>,
+            gr::Tags::TraceExtrinsicCurvature<DataVector>>{});
+    const auto& conformal_factor =
+        get<Xcts::Tags::ConformalFactor<DataVector>>(background_fields);
+    const auto& spatial_metric =
+        get<gr::Tags::SpatialMetric<DataVector, 3, Frame::Inertial>>(
+            background_fields);
+    const auto& inv_spatial_metric =
+        get<gr::Tags::InverseSpatialMetric<DataVector, 3, Frame::Inertial>>(
+            background_fields);
+    const auto& inv_conformal_metric =
+        get<Xcts::Tags::InverseConformalMetric<DataVector, 3, Frame::Inertial>>(
+            background_fields);
+    const auto& extrinsic_curvature =
+        get<gr::Tags::ExtrinsicCurvature<DataVector, 3, Frame::Inertial>>(
+            background_fields);
+    const auto& trace_extrinsic_curvature =
+        get<gr::Tags::TraceExtrinsicCurvature<DataVector>>(background_fields);
+
+    // Compute face normal (related to the conformal metric)
+    auto direction = Direction<3>::upper_zeta();
+    auto face_normal =
+        unnormalized_face_normal(face_mesh, logical_to_inertial_map, direction);
+    const auto& face_inv_conformal_metric =
+        dg::project_tensor_to_boundary(inv_conformal_metric, mesh, direction);
+    const auto face_normal_magnitude =
+        magnitude(face_normal, face_inv_conformal_metric);
+    for (size_t d = 0; d < 3; ++d) {
+      face_normal.get(d) /= get(face_normal_magnitude);
+    }
+    DirectionMap<3, tnsr::i<DataVector, 3>> faces_map_normal(
+        {std::make_pair(direction, face_normal)});
+
+    // Compute integral
+    tnsr::I<double, 3> element_integral;
+    Events::local_adm_integrals(
+        make_not_null(&element_integral), conformal_factor, spatial_metric,
+        inv_spatial_metric, extrinsic_curvature, trace_extrinsic_curvature,
+        inv_jacobian, mesh, current_element, faces_map_normal);
+    for (int I = 0; I < 3; I++) {
+      reduced_integral.get(I) += element_integral.get(I);
+    }
+  }
+
+  // Check result
+  auto custom_approx = Approx::custom().epsilon(10. / distance).scale(1.0);
+  CHECK(reduced_integral.get(0) == custom_approx(0.));
+  CHECK(reduced_integral.get(1) == custom_approx(0.));
+  CHECK(reduced_integral.get(2) ==
+        custom_approx(lorentz_factor * mass * boost_speed));
+}
+
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Elliptic.Systems.Xcts.ObserveAdmIntegrals",
+                  "[Unit][Elliptic]") {
+  const size_t P = 6;
+  const size_t L = 1;
+  for (double distance : std::array<double, 3>{{1.e3, 1.e5, 1.e10}}) {
+    test_local_adm_integrals(distance, L, P);
+  }
+}


### PR DESCRIPTION
## Proposed changes

<!--
At a high level, describe what this PR does.
-->

Compute the total ADM linear momentum integral after an XCTS solve. This creates a new dataset `/AdmIntegrals.dat` inside `BbhReductions.h5`.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
