### PR TITLE
Allow to read in numerical initial data for CurvedScalarWave

### DIFF
--- a/src/Evolution/Systems/CurvedScalarWave/Actions/CMakeLists.txt
+++ b/src/Evolution/Systems/CurvedScalarWave/Actions/CMakeLists.txt
@@ -1,0 +1,15 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+spectre_target_sources(
+  ${LIBRARY}
+  PRIVATE
+  NumericInitialData.cpp
+  )
+
+spectre_target_headers(
+  ${LIBRARY}
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  NumericInitialData.hpp
+  )

--- a/src/Evolution/Systems/CurvedScalarWave/Actions/NumericInitialData.cpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Actions/NumericInitialData.cpp
@@ -1,0 +1,56 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/CurvedScalarWave/Actions/NumericInitialData.hpp"
+
+#include <boost/functional/hash.hpp>
+#include <optional>
+#include <string>
+#include <utility>
+#include <variant>
+
+#include "Utilities/PrettyType.hpp"
+
+namespace CurvedScalarWave {
+
+NumericInitialData::NumericInitialData(
+    std::string file_glob, std::string subfile_name,
+    std::variant<double, importers::ObservationSelector> observation_value,
+    std::optional<double> observation_value_epsilon, bool enable_interpolation,
+    ScalarVars selected_variables)
+    : importer_options_(
+          std::move(file_glob), std::move(subfile_name), observation_value,
+          observation_value_epsilon.value_or(1.0e-12), enable_interpolation),
+      selected_variables_(std::move(selected_variables)) {}
+
+NumericInitialData::NumericInitialData(CkMigrateMessage* msg)
+    : InitialData(msg) {}
+
+const importers::ImporterOptions& NumericInitialData::importer_options() const {
+  return importer_options_;
+}
+
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+PUP::able::PUP_ID NumericInitialData::my_PUP_ID = 0;
+
+size_t NumericInitialData::volume_data_id() const {
+  size_t hash = 0;
+  boost::hash_combine(hash, pretty_type::get_name<NumericInitialData>());
+  boost::hash_combine(hash,
+                      get<importers::OptionTags::FileGlob>(importer_options_));
+  boost::hash_combine(hash,
+                      get<importers::OptionTags::Subgroup>(importer_options_));
+  return hash;
+}
+
+void NumericInitialData::pup(PUP::er& p) {
+  p | importer_options_;
+  p | selected_variables_;
+}
+
+bool operator==(const NumericInitialData& lhs, const NumericInitialData& rhs) {
+  return lhs.importer_options_ == rhs.importer_options_ and
+         lhs.selected_variables_ == rhs.selected_variables_;
+}
+
+}  // namespace CurvedScalarWave

--- a/src/Evolution/Systems/CurvedScalarWave/Actions/NumericInitialData.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Actions/NumericInitialData.hpp
@@ -1,0 +1,234 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <optional>
+#include <pup.h>
+#include <string>
+#include <variant>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
+#include "DataStructures/Tensor/EagerMath/RaiseOrLowerIndex.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Domain/Tags.hpp"
+#include "Evolution/Initialization/InitialData.hpp"
+#include "Evolution/Systems/CurvedScalarWave/Tags.hpp"
+#include "IO/Importers/Actions/ReadVolumeData.hpp"
+#include "IO/Importers/ElementDataReader.hpp"
+#include "IO/Importers/Tags.hpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "Options/String.hpp"
+#include "Parallel/AlgorithmExecution.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "Parallel/Invoke.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "PointwiseFunctions/InitialDataUtilities/InitialData.hpp"
+#include "PointwiseFunctions/InitialDataUtilities/Tags/InitialData.hpp"
+#include "Utilities/CallWithDynamicType.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Serialization/CharmPupable.hpp"
+#include "Utilities/SetNumberOfGridPoints.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace CurvedScalarWave {
+
+/*!
+ * \brief Numeric initial data loaded from volume data files
+ */
+class NumericInitialData : public evolution::initial_data::InitialData {
+ public:
+  template <typename Tag>
+  struct VarName {
+    using tag = Tag;
+    static std::string name() { return db::tag_name<Tag>(); }
+    using type = std::string;
+    static constexpr Options::String help =
+        "Name of the variable in the volume data file";
+  };
+
+  // These are the scalar variables that we support loading from volume
+  // data files
+  using all_vars =
+      tmpl::list<CurvedScalarWave::Tags::Psi, CurvedScalarWave::Tags::Pi,
+                 CurvedScalarWave::Tags::Phi<3>>;
+  using optional_primitive_vars = tmpl::list<>;
+
+  struct ScalarVars : tuples::tagged_tuple_from_typelist<
+                          db::wrap_tags_in<VarName, all_vars>> {
+    static constexpr Options::String help =
+        "Scalar variables: 'Psi', 'Pi' and 'Phi'.";
+    using options = tags_list;
+    using TaggedTuple::TaggedTuple;
+  };
+
+  // Input-file options
+  struct Variables {
+    using type = ScalarVars;
+    static constexpr Options::String help =
+        "Set of initial data variables for the CurvedScalarWave system.";
+  };
+
+  using options =
+      tmpl::push_back<importers::ImporterOptions::tags_list, Variables>;
+
+  static constexpr Options::String help =
+      "Numeric initial data loaded from volume data files";
+
+  NumericInitialData() = default;
+  NumericInitialData(const NumericInitialData& rhs) = default;
+  NumericInitialData& operator=(const NumericInitialData& rhs) = default;
+  NumericInitialData(NumericInitialData&& /*rhs*/) = default;
+  NumericInitialData& operator=(NumericInitialData&& /*rhs*/) = default;
+  ~NumericInitialData() override = default;
+
+  /// \cond
+  explicit NumericInitialData(CkMigrateMessage* msg);
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(NumericInitialData);
+  /// \endcond
+
+  std::unique_ptr<evolution::initial_data::InitialData> get_clone()
+      const override {
+    return std::make_unique<NumericInitialData>(*this);
+  }
+
+  NumericInitialData(
+      std::string file_glob, std::string subfile_name,
+      std::variant<double, importers::ObservationSelector> observation_value,
+      std::optional<double> observation_value_epsilon,
+      bool enable_interpolation, ScalarVars selected_variables);
+
+  const importers::ImporterOptions& importer_options() const;
+
+  const ScalarVars& selected_variables() const { return selected_variables_; }
+
+  size_t volume_data_id() const;
+
+  template <typename... AllTags>
+  void select_for_import(
+      const gsl::not_null<tuples::TaggedTuple<AllTags...>*> fields) const {
+    // Select the subset of the available variables that we want to read from
+    // the volume data file
+    using selected_vars = std::decay_t<decltype(selected_variables_)>;
+    tmpl::for_each<typename selected_vars::tags_list>(
+        [&fields, this](const auto tag_v) {
+          using tag = typename std::decay_t<decltype(tag_v)>::type::tag;
+          get<importers::Tags::Selected<tag>>(*fields) =
+              get<VarName<tag>>(selected_variables_);
+        });
+  }
+
+  template <typename... AllTags>
+  void set_initial_data(const gsl::not_null<Scalar<DataVector>*> psi_scalar,
+                        const gsl::not_null<Scalar<DataVector>*> pi_scalar,
+                        const gsl::not_null<tnsr::i<DataVector, 3>*> phi_scalar,
+                        const gsl::not_null<tuples::TaggedTuple<AllTags...>*>
+                            numeric_data) const {
+    *psi_scalar = std::move(get<CurvedScalarWave::Tags::Psi>(*numeric_data));
+    *pi_scalar = std::move(get<CurvedScalarWave::Tags::Pi>(*numeric_data));
+    *phi_scalar = std::move(get<CurvedScalarWave::Tags::Phi<3>>(*numeric_data));
+  }
+
+  void pup(PUP::er& p) override;
+
+  friend bool operator==(const NumericInitialData& lhs,
+                         const NumericInitialData& rhs);
+
+ private:
+  importers::ImporterOptions importer_options_{};
+  ScalarVars selected_variables_{};
+};
+
+namespace Actions {
+
+/*!
+ * \brief Dispatch loading numeric initial data from files.
+ *
+ * Place this action before
+ * CurvedScalarWave::Actions::SetNumericInitialData in the action list.
+ * See importers::Actions::ReadAllVolumeDataAndDistribute for details, which is
+ * invoked by this action.
+ */
+struct ReadNumericInitialData {
+  using const_global_cache_tags =
+      tmpl::list<evolution::initial_data::Tags::InitialData>;
+
+  template <typename DbTagsList, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent>
+  static Parallel::iterable_action_return_t apply(
+      db::DataBox<DbTagsList>& box,
+      const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+      Parallel::GlobalCache<Metavariables>& cache,
+      const ArrayIndex& /*array_index*/, const ActionList /*meta*/,
+      const ParallelComponent* const /*meta*/) {
+    // Select the subset of the available variables that we want to read from
+    // the volume data file
+    const auto& initial_data = dynamic_cast<const NumericInitialData&>(
+        db::get<evolution::initial_data::Tags::InitialData>(box));
+    tuples::tagged_tuple_from_typelist<db::wrap_tags_in<
+        importers::Tags::Selected, NumericInitialData::all_vars>>
+        selected_fields{};
+    initial_data.select_for_import(make_not_null(&selected_fields));
+    auto& reader_component = Parallel::get_parallel_component<
+        importers::ElementDataReader<Metavariables>>(cache);
+    Parallel::simple_action<importers::Actions::ReadAllVolumeDataAndDistribute<
+        3, NumericInitialData::all_vars, ParallelComponent>>(
+        reader_component, initial_data.importer_options(),
+        initial_data.volume_data_id(), std::move(selected_fields));
+    return {Parallel::AlgorithmExecution::Continue, std::nullopt};
+  }
+};
+
+/*!
+ * \brief Receive numeric initial data loaded by
+ * CurvedScalarWave::Actions::ReadNumericInitialData.
+ */
+struct SetNumericInitialData {
+  static constexpr size_t Dim = 3;
+  using inbox_tags =
+      tmpl::list<importers::Tags::VolumeData<NumericInitialData::all_vars>>;
+
+  template <typename DbTagsList, typename... InboxTags, typename Metavariables,
+            typename ActionList, typename ParallelComponent>
+  static Parallel::iterable_action_return_t apply(
+      db::DataBox<DbTagsList>& box, tuples::TaggedTuple<InboxTags...>& inboxes,
+      const Parallel::GlobalCache<Metavariables>& /*cache*/,
+      const ElementId<Dim>& /*element_id*/, const ActionList /*meta*/,
+      const ParallelComponent* const /*meta*/) {
+    auto& inbox =
+        tuples::get<importers::Tags::VolumeData<NumericInitialData::all_vars>>(
+            inboxes);
+    const auto& initial_data = dynamic_cast<const NumericInitialData&>(
+        db::get<evolution::initial_data::Tags::InitialData>(box));
+    const size_t volume_data_id = initial_data.volume_data_id();
+    if (inbox.find(volume_data_id) == inbox.end()) {
+      return {Parallel::AlgorithmExecution::Retry, std::nullopt};
+    }
+    auto numeric_data = std::move(inbox.extract(volume_data_id).mapped());
+
+    db::mutate<CurvedScalarWave::Tags::Psi, CurvedScalarWave::Tags::Pi,
+               CurvedScalarWave::Tags::Phi<3>>(
+        [&initial_data, &numeric_data](
+            const gsl::not_null<Scalar<DataVector>*> psi_scalar,
+            const gsl::not_null<Scalar<DataVector>*> pi_scalar,
+            const gsl::not_null<tnsr::i<DataVector, 3>*> phi_scalar) {
+          initial_data.set_initial_data(psi_scalar, pi_scalar, phi_scalar,
+                                        make_not_null(&numeric_data));
+        },
+        make_not_null(&box));
+
+    return {Parallel::AlgorithmExecution::Continue, std::nullopt};
+  }
+};
+
+}  // namespace Actions
+
+}  // namespace CurvedScalarWave

--- a/src/Evolution/Systems/CurvedScalarWave/CMakeLists.txt
+++ b/src/Evolution/Systems/CurvedScalarWave/CMakeLists.txt
@@ -38,12 +38,15 @@ target_link_libraries(
   Domain
   ErrorHandling
   LinearOperators
+  IO
+  Importers
   Serialization
   Utilities
   INTERFACE
   GeneralRelativity
   )
 
+add_subdirectory(Actions)
 add_subdirectory(BoundaryConditions)
 add_subdirectory(BoundaryCorrections)
 add_subdirectory(Worldtube)

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Actions/Test_NumericInitialData.cpp
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Actions/Test_NumericInitialData.cpp
@@ -1,0 +1,228 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <limits>
+#include <optional>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <variant>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "DataStructures/VariablesTag.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
+#include "Domain/CoordinateMaps/Wedge.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Domain/Tags.hpp"
+#include "Evolution/Systems/CurvedScalarWave/Actions/NumericInitialData.hpp"
+#include "Framework/ActionTesting.hpp"
+#include "Framework/TestCreation.hpp"
+#include "IO/Importers/Actions/ReadVolumeData.hpp"
+#include "IO/Importers/ElementDataReader.hpp"
+#include "IO/Importers/Tags.hpp"
+#include "NumericalAlgorithms/Spectral/Basis.hpp"
+#include "NumericalAlgorithms/Spectral/LogicalCoordinates.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Quadrature.hpp"
+#include "Options/Protocols/FactoryCreation.hpp"
+#include "Parallel/Phase.hpp"
+#include "PointwiseFunctions/AnalyticData/CurvedWaveEquation/PureSphericalHarmonic.hpp"
+#include "Utilities/Serialization/RegisterDerivedClassesWithCharm.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace CurvedScalarWave::Actions {
+
+namespace {
+
+using all_scalar_vars =
+    tmpl::list<CurvedScalarWave::Tags::Psi, CurvedScalarWave::Tags::Pi,
+               CurvedScalarWave::Tags::Phi<3>>;
+
+template <typename Metavariables>
+struct MockElementArray {
+  using component_being_mocked = void;  // Not needed
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = ElementId<3>;
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<
+          Parallel::Phase::Initialization,
+          tmpl::list<ActionTesting::InitializeDataBox<tmpl::list<
+              ::Tags::Variables<all_scalar_vars>, domain::Tags::Mesh<3>,
+              domain::Tags::Coordinates<3, Frame::Inertial>,
+              domain::Tags::InverseJacobian<3, Frame::ElementLogical,
+                                            Frame::Inertial>>>>>,
+      Parallel::PhaseActions<
+          Parallel::Phase::Testing,
+          tmpl::list<CurvedScalarWave::Actions::ReadNumericInitialData,
+                     CurvedScalarWave::Actions::SetNumericInitialData>>>;
+};
+
+struct MockReadVolumeData {
+  template <typename ParallelComponent, typename DataBox,
+            typename Metavariables, typename ArrayIndex>
+  static void apply(
+      DataBox& /*box*/, Parallel::GlobalCache<Metavariables>& cache,
+      const ArrayIndex& /*array_index*/,
+      const importers::ImporterOptions& options, const size_t volume_data_id,
+      tuples::tagged_tuple_from_typelist<db::wrap_tags_in<
+          importers::Tags::Selected, NumericInitialData::all_vars>>
+          selected_fields) {
+    const auto& initial_data = dynamic_cast<const NumericInitialData&>(
+        get<evolution::initial_data::Tags::InitialData>(cache));
+    CHECK(options == initial_data.importer_options());
+    CHECK(volume_data_id == initial_data.volume_data_id());
+    CHECK(get<importers::Tags::Selected<CurvedScalarWave::Tags::Psi>>(
+              selected_fields) == "CustomPsi");
+    CHECK(get<importers::Tags::Selected<CurvedScalarWave::Tags::Pi>>(
+              selected_fields) == "CustomPi");
+    CHECK(get<importers::Tags::Selected<CurvedScalarWave::Tags::Phi<3>>>(
+              selected_fields) == "CustomPhi");
+  }
+};
+
+template <typename Metavariables>
+struct MockVolumeDataReader {
+  using component_being_mocked = importers::ElementDataReader<Metavariables>;
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockNodeGroupChare;
+  using array_index = size_t;
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<Parallel::Phase::Initialization, tmpl::list<>>>;
+  using replace_these_simple_actions =
+      tmpl::list<importers::Actions::ReadAllVolumeDataAndDistribute<
+          metavariables::volume_dim, NumericInitialData::all_vars,
+          MockElementArray<Metavariables>>>;
+  using with_these_simple_actions = tmpl::list<MockReadVolumeData>;
+};
+
+struct Metavariables {
+  static constexpr size_t volume_dim = 3;
+  using component_list = tmpl::list<MockElementArray<Metavariables>,
+                                    MockVolumeDataReader<Metavariables>>;
+
+  struct factory_creation
+      : tt::ConformsTo<Options::protocols::FactoryCreation> {
+    using factory_classes =
+        tmpl::map<tmpl::pair<evolution::initial_data::InitialData,
+                             tmpl::list<NumericInitialData>>>;
+  };
+};
+
+void test_numeric_initial_data(const NumericInitialData& initial_data,
+                               const std::string& option_string) {
+  {
+    INFO("Factory creation");
+    const auto created = TestHelpers::test_creation<
+        std::unique_ptr<evolution::initial_data::InitialData>, Metavariables>(
+        option_string);
+    CHECK(dynamic_cast<const NumericInitialData&>(*created) == initial_data);
+  }
+
+  using reader_component = MockVolumeDataReader<Metavariables>;
+  using element_array = MockElementArray<Metavariables>;
+
+  ActionTesting::MockRuntimeSystem<Metavariables> runner{
+      initial_data.get_clone()};
+
+  const double wave_radius = 2.0;
+
+  const CurvedScalarWave::AnalyticData::PureSphericalHarmonic csw_sh_wave{
+      wave_radius, 1.0, std::pair<size_t, int>{0, 0}};
+
+  // Setup mock data file reader
+  ActionTesting::emplace_nodegroup_component<reader_component>(
+      make_not_null(&runner));
+
+  // Setup element
+  const ElementId<3> element_id{0, {{{1, 0}, {1, 0}, {1, 0}}}};
+  const Mesh<3> mesh{6, Spectral::Basis::Legendre,
+                     Spectral::Quadrature::GaussLobatto};
+  const size_t num_points = mesh.number_of_grid_points();
+  const auto map =
+      domain::make_coordinate_map<Frame::ElementLogical, Frame::Inertial>(
+          domain::CoordinateMaps::Wedge<3>{
+              wave_radius / 2., wave_radius * 2., 1., 1.,
+              OrientationMap<3>::create_aligned(), true});
+  const auto logical_coords = logical_coordinates(mesh);
+  const auto coords = map(logical_coords);
+  const auto inv_jacobian = map.inv_jacobian(logical_coords);
+  ActionTesting::emplace_component_and_initialize<element_array>(
+      make_not_null(&runner), element_id,
+      {Variables<all_scalar_vars>{num_points}, mesh, coords, inv_jacobian});
+
+  const auto get_element_tag = [&runner,
+                                &element_id](auto tag_v) -> decltype(auto) {
+    using tag = std::decay_t<decltype(tag_v)>;
+    return ActionTesting::get_databox_tag<element_array, tag>(runner,
+                                                              element_id);
+  };
+
+  ActionTesting::set_phase(make_not_null(&runner), Parallel::Phase::Testing);
+
+  // ReadNumericInitialData
+  ActionTesting::next_action<element_array>(make_not_null(&runner), element_id);
+  REQUIRE_FALSE(ActionTesting::next_action_if_ready<element_array>(
+      make_not_null(&runner), element_id));
+
+  // MockReadVolumeData
+  ActionTesting::invoke_queued_simple_action<reader_component>(
+      make_not_null(&runner), 0);
+
+  // Insert Csw data into the inbox
+  auto& inbox = ActionTesting::get_inbox_tag<
+      element_array, importers::Tags::VolumeData<NumericInitialData::all_vars>,
+      Metavariables>(make_not_null(&runner),
+                     element_id)[initial_data.volume_data_id()];
+  auto csw_sh_wave_vars = csw_sh_wave.variables(coords, all_scalar_vars{});
+  get<CurvedScalarWave::Tags::Psi>(inbox) =
+      get<CurvedScalarWave::Tags::Psi>(csw_sh_wave_vars);
+  get<CurvedScalarWave::Tags::Pi>(inbox) =
+      get<CurvedScalarWave::Tags::Pi>(csw_sh_wave_vars);
+  get<CurvedScalarWave::Tags::Phi<3>>(inbox) =
+      get<CurvedScalarWave::Tags::Phi<3>>(csw_sh_wave_vars);
+
+  // SetNumericInitialData
+  ActionTesting::next_action<element_array>(make_not_null(&runner), element_id);
+
+  // Check result
+  tmpl::for_each<all_scalar_vars>([&get_element_tag,
+                                   &csw_sh_wave_vars](const auto tag_v) {
+    using tag = tmpl::type_from<std::decay_t<decltype(tag_v)>>;
+    CAPTURE(pretty_type::name<tag>());
+    CHECK_ITERABLE_APPROX(get_element_tag(tag{}), (get<tag>(csw_sh_wave_vars)));
+  });
+}
+
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.CurvedScalarWave.SetInitialData",
+                  "[Unit][Evolution]") {
+  register_factory_classes_with_charm<Metavariables>();
+  test_numeric_initial_data(
+      NumericInitialData{"TestInitialData.h5",
+                         "VolumeData",
+                         0.,
+                         {1.0e-9},
+                         false,
+                         {"CustomPsi", "CustomPi", "CustomPhi"}},
+      "NumericInitialData:\n"
+      "  FileGlob: TestInitialData.h5\n"
+      "  Subgroup: VolumeData\n"
+      "  ObservationValue: 0.\n"
+      "  ObservationValueEpsilon: 1e-9\n"
+      "  ElementsAreIdentical: False\n"
+      "  Variables:\n"
+      "    Psi: CustomPsi\n"
+      "    Pi: CustomPi\n"
+      "    Phi: CustomPhi");
+}
+
+}  // namespace CurvedScalarWave::Actions

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/CMakeLists.txt
@@ -6,6 +6,7 @@ add_subdirectory(Worldtube)
 set(LIBRARY "Test_CurvedScalarWave")
 
 set(LIBRARY_SOURCES
+  Actions/Test_NumericInitialData.cpp
   BoundaryCorrections/Test_UpwindPenalty.cpp
   BoundaryConditions/Test_AnalyticConstant.cpp
   BoundaryConditions/Test_ConstraintPreservingSphericalRadiation.cpp
@@ -34,6 +35,7 @@ target_link_libraries(
   DomainBoundaryConditions
   DomainBoundaryConditionsHelpers
   GeneralRelativityHelpers
+  Importers
   MathFunctions
   Time
   Utilities


### PR DESCRIPTION
## Proposed changes

Add actions to read in numerical initial data for the CurvedScalarWave system. These data can be obtained, for instance, from an elliptic solve of the Poisson equation.

To be combined in a future PR (#6155) with reading in numeric data for the metric variables in the ScalarTensor system.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
