### PR TITLE
Print ElementId in DataTooBig error

### DIFF
--- a/src/ParallelAlgorithms/Events/ErrorIfDataTooBig.hpp
+++ b/src/ParallelAlgorithms/Events/ErrorIfDataTooBig.hpp
@@ -20,6 +20,7 @@
 #include "DataStructures/ExtractPoint.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Domain/Tags.hpp"
 #include "Options/String.hpp"
 #include "ParallelAlgorithms/EventsAndTriggers/Event.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"
@@ -119,10 +120,12 @@ class ErrorIfDataTooBig : public Event {
           for (const auto& component : tensor) {
             for (size_t point = 0; point < component.size(); ++point) {
               if (std::abs(component[point]) > threshold_) {
-                ERROR_NO_TRACE(tag_name << " too big with value "
-                                        << extract_point(tensor, point)
-                                        << " at position "
-                                        << extract_point(coordinates, point));
+                ERROR_NO_TRACE(
+                    tag_name
+                    << " too big with value " << extract_point(tensor, point)
+                    << " at position\n"
+                    << extract_point(coordinates, point) << "\nwith ElementId: "
+                    << get<::domain::Tags::Element<Dim>>(box).id());
               }
             }
           }

--- a/tests/Unit/ParallelAlgorithms/Events/Test_ErrorIfDataTooBig.cpp
+++ b/tests/Unit/ParallelAlgorithms/Events/Test_ErrorIfDataTooBig.cpp
@@ -103,11 +103,11 @@ void run_event(
   ActionTesting::MockRuntimeSystem<Metavariables> runner{{}};
   ActionTesting::emplace_component<my_component>(&runner, 0);
 
-  auto databox = db::create<
-      db::AddSimpleTags<domain::Tags::Coordinates<2, Frame::Inertial>,
-                        TestTags::ScalarVar, TestTags::OptionalScalar>>(
-      std::move(coordinates), std::move(scalar_var),
-      std::move(optional_scalar));
+  auto databox = db::create<db::AddSimpleTags<
+      domain::Tags::Element<2>, domain::Tags::Coordinates<2, Frame::Inertial>,
+      TestTags::ScalarVar, TestTags::OptionalScalar>>(
+      Element<2>{ElementId<2>{0}, {}}, std::move(coordinates),
+      std::move(scalar_var), std::move(optional_scalar));
 
   auto obs_box = make_observation_box<tmpl::filter<
       TooBig::compute_tags_for_observation_box, db::is_compute_tag<tmpl::_1>>>(
@@ -145,8 +145,10 @@ SPECTRE_TEST_CASE("Unit.ParallelAlgorithms.Events.ErrorIfDataTooBig",
                 "  Threshold: 8.5"),
       Catch::Matchers::ContainsSubstring("ScalarVar too big") and
           Catch::Matchers::ContainsSubstring("value T()=9") and
-          Catch::Matchers::ContainsSubstring("at position T(0)=3") and
-          Catch::Matchers::ContainsSubstring("T(1)=3"));
+          Catch::Matchers::ContainsSubstring("at position") and
+          Catch::Matchers::ContainsSubstring("T(0)=3") and
+          Catch::Matchers::ContainsSubstring("T(1)=3") and
+          Catch::Matchers::ContainsSubstring("with ElementId:"));
   CHECK_THROWS_WITH(
       run_event(tnsr::I<DataVector, 2>{{{{1.0, 2.0, 3.0}, {1.0, 2.0, 3.0}}}},
                 Scalar<DataVector>{{{{1.0, 2.0, 3.0}}}},
@@ -156,8 +158,10 @@ SPECTRE_TEST_CASE("Unit.ParallelAlgorithms.Events.ErrorIfDataTooBig",
                 "  Threshold: 8.5"),
       Catch::Matchers::ContainsSubstring("OptionalScalar too big") and
           Catch::Matchers::ContainsSubstring("value T()=9") and
-          Catch::Matchers::ContainsSubstring("at position T(0)=3") and
-          Catch::Matchers::ContainsSubstring("T(1)=3"));
+          Catch::Matchers::ContainsSubstring("at position") and
+          Catch::Matchers::ContainsSubstring("T(0)=3") and
+          Catch::Matchers::ContainsSubstring("T(1)=3") and
+          Catch::Matchers::ContainsSubstring("with ElementId:"));
   CHECK_THROWS_WITH(
       run_event(tnsr::I<DataVector, 2>{{{{1.0, 2.0, 3.0}, {1.0, 2.0, 3.0}}}},
                 Scalar<DataVector>{{{{1.0, 2.0, -9.0}}}}, std::nullopt,
@@ -166,8 +170,10 @@ SPECTRE_TEST_CASE("Unit.ParallelAlgorithms.Events.ErrorIfDataTooBig",
                 "  Threshold: 8.5"),
       Catch::Matchers::ContainsSubstring("ScalarVar too big") and
           Catch::Matchers::ContainsSubstring("value T()=-9") and
-          Catch::Matchers::ContainsSubstring("at position T(0)=3") and
-          Catch::Matchers::ContainsSubstring("T(1)=3"));
+          Catch::Matchers::ContainsSubstring("at position") and
+          Catch::Matchers::ContainsSubstring("T(0)=3") and
+          Catch::Matchers::ContainsSubstring("T(1)=3") and
+          Catch::Matchers::ContainsSubstring("with ElementId:"));
   CHECK_THROWS_WITH(
       run_event(tnsr::I<DataVector, 2>{{{{1.0, 5.0, 3.0}, {1.0, 2.0, 3.0}}}},
                 Scalar<DataVector>{{{{1.0, 2.0, 3.0}}}}, std::nullopt,
@@ -178,6 +184,7 @@ SPECTRE_TEST_CASE("Unit.ParallelAlgorithms.Events.ErrorIfDataTooBig",
           Catch::Matchers::ContainsSubstring("value T(0,0)=7") and
           Catch::Matchers::ContainsSubstring("T(1,0)=8") and
           Catch::Matchers::ContainsSubstring("T(1,1)=9") and
-          Catch::Matchers::ContainsSubstring("at position T(0)=5") and
+          Catch::Matchers::ContainsSubstring("at position") and
+          Catch::Matchers::ContainsSubstring("T(0)=5") and
           Catch::Matchers::ContainsSubstring("T(1)=2"));
 }


### PR DESCRIPTION
## Proposed changes

This just makes it easier to load the problematic element from a file and look at data.

I added the newline before the coordinates because I found the message easier to read that way.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
