### PR TITLE
Maintain initial data resolution in control loop.

### DIFF
--- a/support/Pipelines/Bbh/ControlId.py
+++ b/support/Pipelines/Bbh/ControlId.py
@@ -24,6 +24,8 @@ def control_id(
     id_run_dir: Optional[Union[str, Path]] = None,
     residual_tolerance: float = DEFAULT_RESIDUAL_TOLERANCE,
     max_iterations: int = DEFAULT_MAX_ITERATIONS,
+    refinement_level: int = 1,
+    polynomial_order: int = 6,
 ):
     """Control BBH physical parameters.
 
@@ -52,6 +54,8 @@ def control_id(
       max_iterations: Maximum of iterations allowed. Note: each iteration is
         very expensive as it needs to solve an entire initial data problem.
         (Default: 30)
+      refinement_level: h-refinement used in control loop.
+      polynomial_order: p-refinement used in control loop.
     """
 
     # Read input file
@@ -111,6 +115,8 @@ def control_id(
                 control=False,
                 evolve=False,
                 scheduler=None,
+                refinement_level=refinement_level,
+                polynomial_order=polynomial_order,
             )
 
         # Get black hole physical parameters

--- a/support/Pipelines/Bbh/InitialData.yaml
+++ b/support/Pipelines/Bbh/InitialData.yaml
@@ -12,6 +12,8 @@ Next:
     id_run_dir: ./
     pipeline_dir: {{ pipeline_dir | default("None") }}
     control: {{ control }}
+    control_refinement_level: {{ L }}
+    control_polynomial_order: {{ P }}
     evolve: {{ evolve }}
     scheduler: {{ scheduler | default("None") }}
     copy_executable: {{ copy_executable | default("None") }}

--- a/support/Pipelines/Bbh/PostprocessId.py
+++ b/support/Pipelines/Bbh/PostprocessId.py
@@ -32,6 +32,8 @@ def postprocess_id(
     control: bool = True,
     control_residual_tolerance: float = DEFAULT_RESIDUAL_TOLERANCE,
     control_max_iterations: int = DEFAULT_MAX_ITERATIONS,
+    control_refinement_level: int = 1,
+    control_polynomial_order: int = 6,
     evolve: bool = False,
     pipeline_dir: Optional[Union[str, Path]] = None,
     **scheduler_kwargs,
@@ -69,6 +71,8 @@ def postprocess_id(
       control: Control BBH physical parameters (default: False).
       control_residual_tolerance: Residual tolerance used for control.
       control_max_iterations: Maximum of iterations allowed for control.
+      control_refinement_level: h-refinement used for control.
+      control_polynomial_order: p-refinement used for control.
       evolve: Evolve the initial data after postprocessing (default: False).
       pipeline_dir: Directory where steps in the pipeline are created.
         Required if 'evolve' is set to True.
@@ -126,6 +130,8 @@ def postprocess_id(
             id_run_dir=id_run_dir,
             residual_tolerance=control_residual_tolerance,
             max_iterations=control_max_iterations,
+            refinement_level=control_refinement_level,
+            polynomial_order=control_polynomial_order,
         )
         id_run_dir = last_control_run_dir
         id_input_file_path = f"{last_control_run_dir}/InitialData.yaml"

--- a/tests/support/Pipelines/Bbh/Test_InitialData.py
+++ b/tests/support/Pipelines/Bbh/Test_InitialData.py
@@ -139,6 +139,8 @@ class TestInitialData(unittest.TestCase):
                     "id_run_dir": "./",
                     "pipeline_dir": str(self.test_dir.resolve() / "Pipeline"),
                     "control": True,
+                    "control_refinement_level": 1,
+                    "control_polynomial_order": 5,
                     "evolve": True,
                     "scheduler": "None",
                     "copy_executable": "None",


### PR DESCRIPTION
## Proposed changes

<!--
At a high level, describe what this PR does.
-->

This PR ensures that the control loop uses the resolution specified in the first initial data run. Before, it was incorrectly using the default resolution (L=1, P=6).

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
