### PR TITLE
Observe GR variables in EvolveValenciaDivClean volume data

### DIFF
--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
@@ -263,6 +263,7 @@ struct EvolutionMetavars<tmpl::list<InterpolationTargetTags...>,
       tmpl::append<
           typename system::variables_tag::tags_list,
           typename system::primitive_variables_tag::tags_list,
+          typename system::flux_spacetime_variables_tag::tags_list,
           tmpl::list<
               grmhd::ValenciaDivClean::Tags::
                   ComovingMagneticFieldMagnitudeCompute,


### PR DESCRIPTION
## Proposed changes
Adds the respective GR tags to the observed tag list so that metric variables can be dumped to volume output. The metric is sometimes a useful diagnostic even though it is static.

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.