### PR TITLE
Ignore matplotlib font manager debug logging info

### DIFF
--- a/src/Visualization/Python/GenerateXdmf.py
+++ b/src/Visualization/Python/GenerateXdmf.py
@@ -21,6 +21,7 @@ import numpy as np
 import rich
 
 from spectre.support.CliExceptions import RequiredChoiceError
+from spectre.support.Logging import configure_logging
 from spectre.Visualization.ReadH5 import available_subfiles
 
 logger = logging.getLogger(__name__)
@@ -506,5 +507,5 @@ def generate_xdmf_command(**kwargs):
 
 
 if __name__ == "__main__":
-    logging.basicConfig(level=logging.INFO)
+    configure_logging(log_level=logging.INFO)
     generate_xdmf_command(help_option_names=["-h", "--help"])

--- a/src/Visualization/Python/Render1D.py
+++ b/src/Visualization/Python/Render1D.py
@@ -25,6 +25,7 @@ from spectre.Domain import (
 from spectre.IO.H5.IterElements import Element, iter_elements
 from spectre.Spectral import Basis
 from spectre.support.CliExceptions import RequiredChoiceError
+from spectre.support.Logging import configure_logging
 from spectre.Visualization.Plot import (
     apply_stylesheet_command,
     show_or_save_plot_command,
@@ -425,5 +426,5 @@ def render_1d_command(
 
 
 if __name__ == "__main__":
-    logging.basicConfig(level=logging.INFO)
+    configure_logging(log_level=logging.INFO)
     render_1d_command(help_option_names=["-h", "--help"])

--- a/support/Python/CMakeLists.txt
+++ b/support/Python/CMakeLists.txt
@@ -9,6 +9,7 @@ spectre_python_add_module(
   PYTHON_FILES
   CliExceptions.py
   DirectoryStructure.py
+  Logging.py
   Machines.py
   Resubmit.py
   RunNext.py

--- a/support/Python/Logging.py
+++ b/support/Python/Logging.py
@@ -1,0 +1,21 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import logging
+
+import rich.logging
+
+
+def configure_logging(log_level=logging.INFO):
+    """
+    Configure logging for our python scripts using the 'logging' module
+
+    This is factored out into a free function so that any time we need to add
+    module-specific logging configuration, we only have to add it to one place.
+    """
+    logging.basicConfig(
+        level=logging.INFO if log_level is None else log_level,
+        format="%(message)s",
+        datefmt="[%X]",
+        handlers=[rich.logging.RichHandler()],
+    )

--- a/support/Python/Logging.py
+++ b/support/Python/Logging.py
@@ -12,6 +12,9 @@ def configure_logging(log_level=logging.INFO):
 
     This is factored out into a free function so that any time we need to add
     module-specific logging configuration, we only have to add it to one place.
+
+    Module specific logging info:
+     - Disable 'matplotlib.font_manager' logging for 'logging.DEBUG' or higher
     """
     logging.basicConfig(
         level=logging.INFO if log_level is None else log_level,
@@ -19,3 +22,5 @@ def configure_logging(log_level=logging.INFO):
         datefmt="[%X]",
         handlers=[rich.logging.RichHandler()],
     )
+    if log_level is not None and log_level >= logging.DEBUG:
+        logging.getLogger("matplotlib.font_manager").disabled = True

--- a/support/Python/__main__.py
+++ b/support/Python/__main__.py
@@ -5,12 +5,12 @@ import logging
 import os
 
 import click
-import rich.logging
 import rich.traceback
 import yaml
 
 import spectre
 from spectre.support.CliExceptions import RequiredChoiceError
+from spectre.support.Logging import configure_logging
 from spectre.support.Machines import UnknownMachineError, this_machine
 
 logger = logging.getLogger(__name__)
@@ -267,20 +267,14 @@ def read_config_file(ctx, param, config_file):
     ),
 )
 def cli(log_level, build_dir, profile, output_profile):
-    if log_level is None:
-        log_level = logging.INFO
-    # Configure logging
-    logging.basicConfig(
-        level=log_level,
-        format="%(message)s",
-        datefmt="[%X]",
-        handlers=[rich.logging.RichHandler()],
-    )
+    configure_logging(log_level=log_level)
     # Format tracebacks with rich
     # - Suppress traceback entries from modules that we don't care about
     rich.traceback.install(
-        show_locals=log_level <= logging.DEBUG,
-        extra_lines=(3 if log_level <= logging.DEBUG else 0),
+        show_locals=log_level is None or log_level <= logging.DEBUG,
+        extra_lines=(
+            3 if log_level is None or log_level <= logging.DEBUG else 0
+        ),
         suppress=[click],
     )
     # Add the build directory to the PATH so subprocesses can find executables.

--- a/tests/Unit/Visualization/Python/Test_GenerateXdmf.py
+++ b/tests/Unit/Visualization/Python/Test_GenerateXdmf.py
@@ -13,6 +13,7 @@ import h5py
 from click.testing import CliRunner
 
 import spectre.Informer as spectre_informer
+from spectre.support.Logging import configure_logging
 from spectre.Visualization.GenerateXdmf import (
     generate_xdmf,
     generate_xdmf_command,
@@ -139,5 +140,5 @@ class TestGenerateXdmf(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    logging.basicConfig(level=logging.DEBUG)
+    configure_logging(log_level=logging.DEBUG)
     unittest.main(verbosity=2)

--- a/tests/Unit/Visualization/Python/Test_InterpolateToMesh.py
+++ b/tests/Unit/Visualization/Python/Test_InterpolateToMesh.py
@@ -14,6 +14,7 @@ from spectre import Spectral
 from spectre.DataStructures import DataVector
 from spectre.Informer import unit_test_build_path
 from spectre.IO.H5 import ElementVolumeData, TensorComponent
+from spectre.support.Logging import configure_logging
 from spectre.Visualization.InterpolateToMesh import (
     interpolate_to_mesh,
     interpolate_to_mesh_command,
@@ -408,5 +409,5 @@ class TestInterpolateToMesh(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    logging.basicConfig(level=logging.DEBUG)
+    configure_logging(log_level=logging.DEBUG)
     unittest.main(verbosity=2)

--- a/tests/Unit/Visualization/Python/Test_PlotTrajectories.py
+++ b/tests/Unit/Visualization/Python/Test_PlotTrajectories.py
@@ -12,6 +12,7 @@ from click.testing import CliRunner
 
 import spectre.IO.H5 as spectre_h5
 from spectre.Informer import unit_test_build_path, unit_test_src_path
+from spectre.support.Logging import configure_logging
 from spectre.Visualization.PlotTrajectories import plot_trajectories_command
 
 
@@ -133,5 +134,5 @@ class TestPlotTrajectories(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    logging.basicConfig(level=logging.DEBUG)
+    configure_logging(log_level=logging.DEBUG)
     unittest.main(verbosity=2)

--- a/tests/support/Pipelines/Bbh/Test_FindHorizon.py
+++ b/tests/support/Pipelines/Bbh/Test_FindHorizon.py
@@ -23,6 +23,7 @@ from spectre.PointwiseFunctions.AnalyticSolutions.GeneralRelativity import (
 from spectre.PointwiseFunctions.GeneralRelativity import ricci_tensor
 from spectre.Spectral import Basis, Mesh, Quadrature, logical_coordinates
 from spectre.SphericalHarmonics import Strahlkorper, cartesian_coords
+from spectre.support.Logging import configure_logging
 
 
 def _to_tensor_components(tensors):
@@ -174,5 +175,5 @@ class TestFindHorizon(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    logging.basicConfig(level=logging.DEBUG)
+    configure_logging(log_level=logging.DEBUG)
     unittest.main(verbosity=2)

--- a/tests/support/Pipelines/Bbh/Test_InitialData.py
+++ b/tests/support/Pipelines/Bbh/Test_InitialData.py
@@ -12,6 +12,7 @@ from click.testing import CliRunner
 
 from spectre.Informer import unit_test_build_path
 from spectre.Pipelines.Bbh.InitialData import generate_id_command, id_parameters
+from spectre.support.Logging import configure_logging
 
 
 class TestInitialData(unittest.TestCase):
@@ -150,5 +151,5 @@ class TestInitialData(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    logging.basicConfig(level=logging.DEBUG)
+    configure_logging(log_level=logging.DEBUG)
     unittest.main(verbosity=2)

--- a/tests/support/Pipelines/Bbh/Test_Inspiral.py
+++ b/tests/support/Pipelines/Bbh/Test_Inspiral.py
@@ -16,6 +16,7 @@ from spectre.Pipelines.Bbh.Inspiral import (
     inspiral_parameters,
     start_inspiral_command,
 )
+from spectre.support.Logging import configure_logging
 
 
 class TestInspiral(unittest.TestCase):
@@ -182,5 +183,5 @@ class TestInspiral(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    logging.basicConfig(level=logging.DEBUG)
+    configure_logging(log_level=logging.DEBUG)
     unittest.main(verbosity=2)

--- a/tests/support/Pipelines/Bbh/Test_PostprocessId.py
+++ b/tests/support/Pipelines/Bbh/Test_PostprocessId.py
@@ -13,6 +13,7 @@ from click.testing import CliRunner
 from spectre.Informer import unit_test_build_path
 from spectre.Pipelines.Bbh.InitialData import generate_id
 from spectre.Pipelines.Bbh.PostprocessId import postprocess_id_command
+from support.Python.Logging import configure_logging
 
 
 class TestPostprocessId(unittest.TestCase):
@@ -57,5 +58,5 @@ class TestPostprocessId(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    logging.basicConfig(level=logging.DEBUG)
+    configure_logging(log_level=logging.DEBUG)
     unittest.main(verbosity=2)

--- a/tests/support/Pipelines/Bbh/Test_Ringdown.py
+++ b/tests/support/Pipelines/Bbh/Test_Ringdown.py
@@ -17,6 +17,7 @@ from spectre.Pipelines.Bbh.Ringdown import (
     ringdown_parameters,
     start_ringdown_command,
 )
+from spectre.support.Logging import configure_logging
 
 
 class TestInitialData(unittest.TestCase):
@@ -108,5 +109,5 @@ class TestInitialData(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    logging.basicConfig(level=logging.DEBUG)
+    configure_logging(log_level=logging.DEBUG)
     unittest.main(verbosity=2)

--- a/tests/support/Pipelines/EccentricityControl/Test_EccentricityControl.py
+++ b/tests/support/Pipelines/EccentricityControl/Test_EccentricityControl.py
@@ -16,6 +16,7 @@ from spectre.Pipelines.EccentricityControl import eccentricity_control_command
 from spectre.Pipelines.EccentricityControl.EccentricityControl import (
     coordinate_separation_eccentricity_control,
 )
+from spectre.support.Logging import configure_logging
 
 
 class TestEccentricityControl(unittest.TestCase):
@@ -257,5 +258,5 @@ class TestEccentricityControl(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    logging.basicConfig(level=logging.DEBUG)
+    configure_logging(log_level=logging.DEBUG)
     unittest.main(verbosity=2)

--- a/tests/support/Pipelines/EccentricityControl/Test_InitialOrbitalParameters.py
+++ b/tests/support/Pipelines/EccentricityControl/Test_InitialOrbitalParameters.py
@@ -9,6 +9,7 @@ import numpy.testing as npt
 from spectre.Pipelines.EccentricityControl.InitialOrbitalParameters import (
     initial_orbital_parameters,
 )
+from support.Python.Logging import configure_logging
 
 
 class TestInitialOrbitalParameters(unittest.TestCase):
@@ -78,5 +79,5 @@ class TestInitialOrbitalParameters(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    logging.basicConfig(level=logging.DEBUG)
+    configure_logging(log_level=logging.DEBUG)
     unittest.main(verbosity=2)

--- a/tests/support/Python/Test_DirectoryStructure.py
+++ b/tests/support/Python/Test_DirectoryStructure.py
@@ -13,6 +13,7 @@ from spectre.support.DirectoryStructure import (
     list_checkpoints,
     list_segments,
 )
+from spectre.support.Logging import configure_logging
 
 
 class TestDirectoryStructure(unittest.TestCase):
@@ -65,5 +66,5 @@ class TestDirectoryStructure(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    logging.basicConfig(level=logging.DEBUG)
+    configure_logging(log_level=logging.DEBUG)
     unittest.main(verbosity=2)

--- a/tests/support/Python/Test_RunNext.py
+++ b/tests/support/Python/Test_RunNext.py
@@ -11,6 +11,7 @@ from click.testing import CliRunner
 
 import spectre
 from spectre.Informer import unit_test_build_path, unit_test_src_path
+from spectre.support.Logging import configure_logging
 from spectre.support.RunNext import run_next, run_next_command
 
 
@@ -60,5 +61,5 @@ class TestRunNext(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    logging.basicConfig(level=logging.DEBUG)
+    configure_logging(log_level=logging.DEBUG)
     unittest.main(verbosity=2)

--- a/tests/support/Python/Test_Schedule.py
+++ b/tests/support/Python/Test_Schedule.py
@@ -11,6 +11,7 @@ import yaml
 from click.testing import CliRunner
 
 from spectre.Informer import unit_test_build_path, unit_test_src_path
+from spectre.support.Logging import configure_logging
 from spectre.support.Resubmit import resubmit, resubmit_command
 from spectre.support.Schedule import (
     Checkpoint,
@@ -344,5 +345,5 @@ NUM_NODES=1
 
 
 if __name__ == "__main__":
-    logging.basicConfig(level=logging.DEBUG)
+    configure_logging(log_level=logging.DEBUG)
     unittest.main(verbosity=2)

--- a/tests/tools/Test_Status.py
+++ b/tests/tools/Test_Status.py
@@ -11,6 +11,7 @@ import yaml
 
 import spectre.IO.H5 as spectre_h5
 from spectre.Informer import unit_test_build_path
+from spectre.support.Logging import configure_logging
 from spectre.tools.Status.ExecutableStatus import match_executable_status
 from spectre.tools.Status.Status import get_executable_name, get_input_file
 
@@ -211,5 +212,5 @@ class TestStatus(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    logging.basicConfig(level=logging.DEBUG)
+    configure_logging(log_level=logging.DEBUG)
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Proposed changes

This causes python tests to be slow sometimes due to the sheer amount of debug info logged. Also factors python logging into a free function so we only have to edit logging things in one place in the future.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
