### PR TITLE
Fix minimial executable so it builds

### DIFF
--- a/src/Executables/Examples/ParallelTutorial/MinimalExecutable.cpp
+++ b/src/Executables/Examples/ParallelTutorial/MinimalExecutable.cpp
@@ -1,8 +1,6 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
-#include "Executables/Examples/ParallelTutorial/MinimalExecutable.hpp"
-
 #include <array>
 
 #include "Options/String.hpp"


### PR DESCRIPTION
## Proposed changes

The minimal executable didn't build because it included an hpp that doesn't exist. This fixes that.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
