### PR TITLE
Use continued fraction semiconvergent on overflow

### DIFF
--- a/tests/Unit/Utilities/Test_FractionUtilities.cpp
+++ b/tests/Unit/Utilities/Test_FractionUtilities.cpp
@@ -120,6 +120,18 @@ SPECTRE_TEST_CASE("Unit.Utilities.FractionUtilities.ContinuedFractionSummer",
     summer.insert(1);
     CHECK(summer.value() == first_value);
   }
+
+  // Check a case that returns a semiconvergent
+  {
+    ContinuedFractionSummer<Rational> summer;
+    summer.insert(0);
+    summer.insert(2);
+    summer.insert(std::numeric_limits<std::int32_t>::max() / 2 + 10);
+    // Remember that max() is odd, so this isn't 1/2.
+    CHECK(summer.value() ==
+          Rational(std::numeric_limits<std::int32_t>::max() / 2,
+                   std::numeric_limits<std::int32_t>::max()));
+  }
 }
 
 SPECTRE_TEST_CASE(


### PR DESCRIPTION
The last representable convergent may not be accurate enough.

Fixes #6179 

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
