### PR TITLE
Fix fallback bin directory in Schedule.py

### DIFF
--- a/support/Python/Schedule.py
+++ b/support/Python/Schedule.py
@@ -3,6 +3,7 @@
 
 import functools
 import logging
+import os
 import re
 import shutil
 import subprocess
@@ -41,7 +42,13 @@ def _resolve_executable(executable: Union[str, Path]) -> Path:
     Raises 'ValueError' if the executable is not found.
     """
     logger.debug(f"Resolving executable: {executable}")
-    which_exec = shutil.which(executable)
+    # This default bin dir is already added in spectre.__main__.py, but only
+    # when running the CLI. It is the bin dir of the build directory that
+    # contains this script. When running Python code outside the CLI this should
+    # also be the default bin dir.
+    default_bin_dir = Path(__file__).parent.parent.parent.parent.resolve()
+    path = os.environ["PATH"] + ":" + str(default_bin_dir)
+    which_exec = shutil.which(executable, path=path)
     if not which_exec:
         raise ValueError(
             f"Executable not found: {executable}. Make sure it is compiled. To"


### PR DESCRIPTION
The bin directory was only added in __main__.py before, which is only used when running the CLI. This makes it work in other Python scripts as well.

Marking as priority because it's needed for SXScon tutorials.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
