### PR TITLE
Pass spec pythonpath directly to spectre

### DIFF
--- a/cmake/SetupSpec.cmake
+++ b/cmake/SetupSpec.cmake
@@ -3,13 +3,15 @@
 
 find_package(SpEC)
 
+# Make SpEC scripts available in Python. These can be used until we have ported
+# them to SpECTRE.
+if (SPEC_ROOT)
+  set(PYTHONPATH "${SPEC_ROOT}/Support/Python:${PYTHONPATH}")
+endif()
+
 if (NOT SpEC_FOUND)
   return()
 endif()
-
-# Make SpEC scripts available in Python. These can be used until we have ported
-# them to SpECTRE.
-set(PYTHONPATH "${SPEC_ROOT}/Support/Python:${PYTHONPATH}")
 
 file(APPEND
   "${CMAKE_BINARY_DIR}/BuildInfo.txt"


### PR DESCRIPTION
## Proposed changes

Since the spec exporter might be a bit difficult to set up, I would like to use the spec python scripts independently of it (still useful for using the pipeline). Could we pass the path directly if it fails to find spec like this?

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
